### PR TITLE
Request for feedback: Making StormLib compile on FreeBSD

### DIFF
--- a/3rdParty/StormLib/src/FileStream.cpp
+++ b/3rdParty/StormLib/src/FileStream.cpp
@@ -70,6 +70,10 @@ static DWORD StringToInt(const char * szString)
 #define lseek64 lseek
 #endif
 
+#ifndef fstat64
+#define fstat64 fstat
+#endif
+
 //-----------------------------------------------------------------------------
 // Dummy init function
 

--- a/3rdParty/StormLib/src/FileStream.cpp
+++ b/3rdParty/StormLib/src/FileStream.cpp
@@ -78,6 +78,10 @@ static DWORD StringToInt(const char * szString)
 #define stat64 stat
 #endif
 
+#ifndef ftruncate64
+#define ftruncate64 ftruncate
+#endif
+
 //-----------------------------------------------------------------------------
 // Dummy init function
 

--- a/3rdParty/StormLib/src/FileStream.cpp
+++ b/3rdParty/StormLib/src/FileStream.cpp
@@ -66,6 +66,10 @@ static DWORD StringToInt(const char * szString)
 #define O_LARGEFILE 0
 #endif
 
+#ifndef HAVE_LSEEK64
+#define lseek64 lseek
+#endif
+
 //-----------------------------------------------------------------------------
 // Dummy init function
 

--- a/3rdParty/StormLib/src/FileStream.cpp
+++ b/3rdParty/StormLib/src/FileStream.cpp
@@ -62,6 +62,10 @@ static DWORD StringToInt(const char * szString)
     return dwValue;
 }
 
+#ifndef O_LARGEFILE
+#define O_LARGEFILE 0
+#endif
+
 //-----------------------------------------------------------------------------
 // Dummy init function
 

--- a/3rdParty/StormLib/src/FileStream.cpp
+++ b/3rdParty/StormLib/src/FileStream.cpp
@@ -74,6 +74,10 @@ static DWORD StringToInt(const char * szString)
 #define fstat64 fstat
 #endif
 
+#ifndef stat64
+#define stat64 stat
+#endif
+
 //-----------------------------------------------------------------------------
 // Dummy init function
 


### PR DESCRIPTION
DevilutionX compiles without problems on FreeBSD when the address sanitizer is disabled. The only thing that requires patches is StormLib which uses some (glibc?) internal structs. I've read on the net that they should not be used anyway - but they work on Linux and the StormLib maintainer (being a Windows user if I got it right) didn't want to change it in the past (see https://github.com/ladislav-zezula/StormLib/issues/73). The problem was eventually solved upstream by feeding additional parameters to CMake.

I think the changes that I propose here will not harm any other platform, however I cannot test things like Windows. I found the first two definitions on the net from various other projects dealing with that problem. The other three were added by me (and I had no idea what to actually check). So this pull request doesn't mean I want the code merged in this form. I'm not a C programmer and don't know if there's better ways to do it or if those lines belong somewhere else.

Steps for building on FreeBSD 12.0 i386:
`pkg install cmake gcc8 libsodium pkgconf sdl2_mixer sdl2_ttf`
Fetch and extract devilutionX source
Prepare build dir
`cmake -DCMAKE_C_COMPILER=/usr/local/bin/gcc8 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++8 -DASAN=OFF ..`
Run make

The resulting binary runs but cannot find diabdat.mpq. I don't think it is related to the changes I made (building on Linux still works and finds the MPQ).

Another question: Is it possible to use StormLib installed on the system instead of the one shipped with DevilutionX? E.g. Debian and Ubuntu have it available, Arch in the AUR and a few others feature it as well. It would be nice if this was possible as it allows packagers for other platforms (e.g. *BSD, Illumos, etc.) to patch the lib according to their needs when creating a package for it.