### PR TITLE
Packaging files for Fedora

### DIFF
--- a/Packaging/fedora/devilutionx.desktop
+++ b/Packaging/fedora/devilutionx.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=devilutionX
+GenericName=DevilutionX
+Comment=Play Diablo I on Linux
+Exec=/var/games/devilutionx/devilutionx
+Icon=devilutionx
+Terminal=false
+Type=Application
+X-DCOP-ServiceType=Multi
+X-KDE-StartupNotify=true
+Categories=Qt;Game;RolePlaying;

--- a/Packaging/fedora/devilutionx.desktop
+++ b/Packaging/fedora/devilutionx.desktop
@@ -2,8 +2,8 @@
 Name=devilutionX
 GenericName=DevilutionX
 Comment=Play Diablo I on Linux
-Exec=/var/games/devilutionx/devilutionx
-Icon=devilutionx
+Exec=devilutionx
+Icon=/usr/share/pixmaps/devilutionx.ico
 Terminal=false
 Type=Application
 X-DCOP-ServiceType=Multi

--- a/Packaging/fedora/devilutionx.spec
+++ b/Packaging/fedora/devilutionx.spec
@@ -1,0 +1,53 @@
+%define debug_package %{nil}
+
+Name:		devilutionx
+Version:	0.3.1
+Release:	1%{?dist}
+Summary:	Diablo I engine for modern operating systems
+
+
+#Group:		
+License:	Unlicensed
+URL:		https://github.com/diasurgical/devilutionX
+Source0:	https://github.com/diasurgical/devilutionX/archive/%{version}.tar.gz
+Source1:	devilutionx.desktop
+
+BuildRequires:	cmake gcc gcc-c++ libstdc++-static glibc desktop-file-utils
+BuildRequires:  glibc-devel SDL2-devel SDL2_ttf-devel SDL2_mixer-devel libsodium-devel libasan
+Requires:	SDL2_ttf SDL2_mixer libsodium
+
+%description
+Diablo devolved - magic behind the 1996 computer game
+Note, Devilution requires an original copy of diabdat.mpq. None of the Diablo 1 game assets are provided by this package. 
+
+%prep
+%setup -q -n devilutionX-%{version}
+
+
+%build
+#%{__rm} makefile
+cmake -DBINARY_RELEASE=ON -DDEBUG=OFF
+make %{?_smp_mflags}
+
+%install
+make INSTALL_ROOT=%{buildroot}
+#according to Fedora's Games Packaging guidelines the binary should go in %{_bindir}
+#However, the problem is that the mpq files do actually not belong in this directory.
+#That's why we gonna use /var/games/%{name} for the moment, but this needs to be addressed though.
+#mkdir -p %{buildroot}%{_bindir}
+#install -m 755 devilutionx %{buildroot}%{_bindir}
+
+mkdir -p %{buildroot}/var/games/%{name}
+install -m 755 devilutionx %{buildroot}/var/games/%{name}
+desktop-file-install --remove-category="Qt" --dir=%{buildroot}%{_datadir}/applications %{SOURCE1} 
+
+
+%files
+/var/games/%{name}
+/var/games/%{name}/%{name}
+%{_datadir}/applications/%{name}.desktop
+
+
+%changelog
+* Mon Apr 15 2019 Michael Seevogel <michael (at) michaelseevogel.de> - 0.3.1-1
+- Initial release for Fedora

--- a/Packaging/fedora/devilutionx.spec
+++ b/Packaging/fedora/devilutionx.spec
@@ -5,8 +5,6 @@ Version:	0.3.1
 Release:	1%{?dist}
 Summary:	Diablo I engine for modern operating systems
 
-
-#Group:		
 License:	Unlicensed
 URL:		https://github.com/diasurgical/devilutionX
 Source0:	https://github.com/diasurgical/devilutionX/archive/%{version}.tar.gz
@@ -25,7 +23,6 @@ Note, Devilution requires an original copy of diabdat.mpq. None of the Diablo 1 
 
 
 %build
-#%{__rm} makefile
 cmake -DBINARY_RELEASE=ON -DDEBUG=OFF
 make %{?_smp_mflags}
 

--- a/Packaging/fedora/devilutionx.spec
+++ b/Packaging/fedora/devilutionx.spec
@@ -2,7 +2,7 @@
 
 Name:		devilutionx
 Version:	0.3.1
-Release:	1%{?dist}
+Release:	2%{?dist}
 Summary:	Diablo I engine for modern operating systems
 
 License:	Unlicensed
@@ -15,12 +15,11 @@ BuildRequires:  glibc-devel SDL2-devel SDL2_ttf-devel SDL2_mixer-devel libsodium
 Requires:	SDL2_ttf SDL2_mixer libsodium
 
 %description
-Diablo devolved - magic behind the 1996 computer game
-Note, Devilution requires an original copy of diabdat.mpq. None of the Diablo 1 game assets are provided by this package. 
+Diablo I devolved - magic behind the 1996 computer game
+Note: Devilution requires an original copy of diabdat.mpq. None of the Diablo 1 game assets are provided by this package! 
 
 %prep
 %setup -q -n devilutionX-%{version}
-
 
 %build
 cmake -DBINARY_RELEASE=ON -DDEBUG=OFF
@@ -28,23 +27,43 @@ make %{?_smp_mflags}
 
 %install
 make INSTALL_ROOT=%{buildroot}
-#according to Fedora's Games Packaging guidelines the binary should go in %{_bindir}
-#However, the problem is that the mpq files do actually not belong in this directory.
-#That's why we gonna use /var/games/%{name} for the moment, but this needs to be addressed though.
-#mkdir -p %{buildroot}%{_bindir}
-#install -m 755 devilutionx %{buildroot}%{_bindir}
-
-mkdir -p %{buildroot}/var/games/%{name}
-install -m 755 devilutionx %{buildroot}/var/games/%{name}
+mkdir -p %{buildroot}%{_bindir}
+mkdir -p %{buildroot}%{_datadir}/pixmaps
+install -m 755 devilutionx %{buildroot}%{_bindir}%{name}
+install -p -D -m644 Diablo.ico %{buildroot}%{_datadir}/pixmaps/%{name}.ico
 desktop-file-install --remove-category="Qt" --dir=%{buildroot}%{_datadir}/applications %{SOURCE1} 
 
-
 %files
-/var/games/%{name}
-/var/games/%{name}/%{name}
+%{_bindir}%{name}
 %{_datadir}/applications/%{name}.desktop
+%{_datadir}/pixmaps/%{name}.ico
+
+%post
+# print info
+cat <<BANNER
+-------------------------------------------------------------------------
+
+Thank you for trying devilutionx!
+
+Please make sure that you have the game assets (specifically diabdat.mpq)
+of Diablo I at hand!
+
+The game assets need to be in ~/.local/share/diasurgical/devilution.
+This directory should be created automatically on launch by the binary.
+
+However, you can do this step manually by executing:
+
+	mkdir -p ~/.local/share/diasurgical/devilution
+
+------------------------------------------------------------------------
+BANNER
+
 
 
 %changelog
+* Tue Apr 16 2019 Michael Seevogel <michael (at) michaelseevogel.de> - 0.3.1-2
+- Updated packaging files
+- added icon to desktop file
+
 * Mon Apr 15 2019 Michael Seevogel <michael (at) michaelseevogel.de> - 0.3.1-1
 - Initial release for Fedora


### PR DESCRIPTION
This commit provides the necessary files to build DevilutionX for Fedora (and compatible).

I suppose that package maintainers (generally speaking) know how to build for different archs, but if necessary I can also add a note on how to build for 32bit target.

Also it would be nice if we could have a command line switch with which we could specify in which directory the data assets are located.

Like:
`./devilutionx --datadir=/usr/share/devilutionx`