### PR TITLE
Fixed unforeseen definition of O_LARGEFILE=1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL FreeBSD)
   set(ASAN OFF)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DO_LARGEFILE -Dstat64=stat -Dlstat64=lstat -Dlseek64=lseek -Doff64_t=off_t -Dfstat64=fstat -Dftruncate64=ftruncate")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DO_LARGEFILE=0 -Dstat64=stat -Dlstat64=lstat -Dlseek64=lseek -Doff64_t=off_t -Dfstat64=fstat -Dftruncate64=ftruncate")
 endif()
 
 if(WIN32)


### PR DESCRIPTION
By setting -DO_LARGEFILE on the cmake command line, it is actually the same as
setting -DO_LARGEFILE=1. Since this constant is used inside code to set flags,
a file would be opened with both READ_ONLY and READ_WRITE flag set.
This of course will not be allowed by the kernel