### PR TITLE
Use relative mouse position

### DIFF
--- a/SourceX/DiabloUI/diabloui.h
+++ b/SourceX/DiabloUI/diabloui.h
@@ -95,15 +95,18 @@ constexpr size_t size(T (&)[N])
 
 extern void(*gfnSoundFunction)(char *file);
 
-bool IsInsideRect(const SDL_Event *event, const SDL_Rect *rect);
+extern int MousePositionX;
+extern int MousePositionY;
+extern float MouseSensitivity;
+
 void UiFadeIn(int steps = 16);
+void UiUpdateMousePosition(SDL_Event *event);
 bool UiFocusNavigation(SDL_Event *event);
 bool UiItemMouseEvents(SDL_Event *event, UI_Item *items, int size);
 int GetAnimationFrame(int frames, int fps = 60);
 int GetCenterOffset(int w, int bw = 0);
 void DrawArt(int screenX, int screenY, Art *art, int nFrame = 0, int drawW = 0);
 void DrawLogo(int t = 0, int size = LOGO_MED);
-void DrawMouse();
 void LoadArt(char *pszFile, Art *art, int frames = 1, PALETTEENTRY *pPalette = NULL);
 void LoadBackgroundArt(char *pszFile);
 void LoadMaskedArtFont(char *pszFile, Art *art, int frames, int mask = 250);
@@ -116,6 +119,7 @@ void UiRenderItems(UI_Item *items, int size);
 void WordWrap(UI_Item *item);
 
 void DvlIntSetting(const char *valuename, int *value);
-void DvlStringSetting(const char *valuename, char *string, int len);
+void DvlFloatSetting(const char *valuename, float *value);
+void DvlStringSetting(const char *valuename, char *value, int len);
 
 }

--- a/SourceX/DiabloUI/progress.cpp
+++ b/SourceX/DiabloUI/progress.cpp
@@ -86,7 +86,7 @@ BOOL UiProgressDialog(HWND window, char *msg, int enable, int (*fnfunc)(), int r
 	while (!endMenu && progress < 100) {
 		progress = fnfunc();
 		progress_Render(progress);
-		DrawMouse();
+		DrawArt(MousePositionX, MousePositionY, &ArtCursor);
 		SetFadeLevel(256);
 
 		while (SDL_PollEvent(&event)) {

--- a/SourceX/DiabloUI/title.cpp
+++ b/SourceX/DiabloUI/title.cpp
@@ -37,13 +37,7 @@ BOOL UiTitleDialog(int a1)
 
 		while (SDL_PollEvent(&event)) {
 			switch (event.type) {
-			case SDL_KEYDOWN: /* To match the original uncomment this
-				if (event.key.keysym.sym == SDLK_UP
-				    || event.key.keysym.sym == SDLK_UP
-				    || event.key.keysym.sym == SDLK_LEFT
-				    || event.key.keysym.sym == SDLK_RIGHT) {
-					break;
-				}*/
+			case SDL_KEYDOWN:
 			case SDL_MOUSEBUTTONDOWN:
 				endMenu = true;
 				break;

--- a/SourceX/miniwin/misc.cpp
+++ b/SourceX/miniwin/misc.cpp
@@ -347,6 +347,9 @@ HWND CreateWindowExA(
 	DvlIntSetting("grab input", &grabInput);
 	if (grabInput) {
 		flags |= SDL_WINDOW_INPUT_GRABBED;
+		if (SDL_SetRelativeMouseMode(SDL_TRUE) <= -1) {
+			SDL_Log(SDL_GetError());
+		}
 	}
 
 	window = SDL_CreateWindow(lpWindowName, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, nWidth, nHeight, flags);

--- a/SourceX/miniwin/misc_dx.cpp
+++ b/SourceX/miniwin/misc_dx.cpp
@@ -15,10 +15,10 @@ WINBOOL SetCursorPos(int X, int Y)
 		X += view.x;
 		Y += view.y;
 
-		float scaleX;
-		SDL_RenderGetScale(renderer, &scaleX, NULL);
-		X *= scaleX;
-		Y *= scaleX;
+		float scale;
+		SDL_RenderGetScale(renderer, &scale, NULL);
+		X *= scale;
+		Y *= scale;
 	}
 
 	SDL_WarpMouseInWindow(window, X, Y);

--- a/SourceX/miniwin/misc_msg.cpp
+++ b/SourceX/miniwin/misc_msg.cpp
@@ -1,8 +1,11 @@
-#include <deque>
 #include <SDL.h>
+#include <deque>
 
 #include "devilution.h"
+#include "miniwin/ddraw.h"
 #include "stubs.h"
+
+#include "DiabloUI/diabloui.h"
 
 /** @file
  * *
@@ -150,20 +153,31 @@ WINBOOL PeekMessageA(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilter
 		lpMsg->lParam = e.key.keysym.mod << 16;
 	} break;
 	case SDL_MOUSEMOTION:
+		UiUpdateMousePosition(&e);
+
 		lpMsg->message = DVL_WM_MOUSEMOVE;
-		lpMsg->lParam = (e.motion.y << 16) | (e.motion.x & 0xFFFF);
+		if (MousePositionX > 0)
+			lpMsg->lParam |= MousePositionX & 0xFFFF;
+		if (MousePositionY > 0)
+			lpMsg->lParam |= MousePositionY << 16;
 		lpMsg->wParam = keystate_for_mouse(0);
 		break;
 	case SDL_MOUSEBUTTONDOWN: {
 		int button = e.button.button;
 		if (button == SDL_BUTTON_LEFT) {
 			lpMsg->message = DVL_WM_LBUTTONDOWN;
-			lpMsg->lParam = (e.button.y << 16) | (e.button.x & 0xFFFF);
-			lpMsg->wParam = keystate_for_mouse(DVL_MK_LBUTTON);
+			if (MousePositionX > 0)
+				lpMsg->lParam |= MousePositionX & 0xFFFF;
+			if (MousePositionY > 0)
+				lpMsg->lParam |= MousePositionY << 16;
+				lpMsg->wParam = keystate_for_mouse(DVL_MK_LBUTTON);
 		} else if (button == SDL_BUTTON_RIGHT) {
 			lpMsg->message = DVL_WM_RBUTTONDOWN;
-			lpMsg->lParam = (e.button.y << 16) | (e.button.x & 0xFFFF);
-			lpMsg->wParam = keystate_for_mouse(DVL_MK_RBUTTON);
+			if (MousePositionX > 0)
+				lpMsg->lParam |= MousePositionX & 0xFFFF;
+			if (MousePositionY > 0)
+				lpMsg->lParam |= MousePositionY << 16;
+				lpMsg->wParam = keystate_for_mouse(DVL_MK_RBUTTON);
 		} else {
 			return false_avail();
 		}
@@ -172,12 +186,18 @@ WINBOOL PeekMessageA(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilter
 		int button = e.button.button;
 		if (button == SDL_BUTTON_LEFT) {
 			lpMsg->message = DVL_WM_LBUTTONUP;
-			lpMsg->lParam = (e.button.y << 16) | (e.button.x & 0xFFFF);
+			if (MousePositionX > 0)
+				lpMsg->lParam |= MousePositionX & 0xFFFF;
+			if (MousePositionY > 0)
+				lpMsg->lParam |= MousePositionY << 16;
 			lpMsg->wParam = keystate_for_mouse(0);
 		} else if (button == SDL_BUTTON_RIGHT) {
 			lpMsg->message = DVL_WM_RBUTTONUP;
-			lpMsg->lParam = (e.button.y << 16) | (e.button.x & 0xFFFF);
-			lpMsg->wParam = keystate_for_mouse(0);
+			if (MousePositionX > 0)
+				lpMsg->lParam |= MousePositionX & 0xFFFF;
+			if (MousePositionY > 0)
+				lpMsg->lParam |= MousePositionY << 16;
+				lpMsg->wParam = keystate_for_mouse(0);
 		} else {
 			return false_avail();
 		}


### PR DESCRIPTION
This fixes #91

When mouse is grabbed:
- Relative mouse position is used.
- Mouse speed is consistent at all scales.
- A new ini settings has been added for mouse sensitivity.

When mouse is not grabbed:
- The the mouse pointer no longer wrapps when moved out of the screen.
- Ingame the mouse will always appear inside of the window, this is a
limitation of the engine.