### PR TITLE
Use the dungeon_type enum where possible

### DIFF
--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -967,7 +967,7 @@ void InitLevels()
 {
 	if (!leveldebug) {
 		currlevel = 0;
-		leveltype = 0;
+		leveltype = DTYPE_TOWN;
 		setlevel = 0;
 	}
 }

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -60,7 +60,7 @@ void LoadGame(BOOL firstflag)
 	for (i = 0; i < MAXMONSTERS; i++)
 		monstkills[i] = ILoad();
 
-	if (leveltype) {
+	if (leveltype != DTYPE_TOWN) {
 		for (i = 0; i < MAXMONSTERS; i++)
 			monstactive[i] = WLoad();
 		for (i = 0; i < nummonsters; i++)
@@ -120,7 +120,7 @@ void LoadGame(BOOL firstflag)
 			dItem[i][j] = BLoad();
 	}
 
-	if (leveltype) {
+	if (leveltype != DTYPE_TOWN) {
 		for (j = 0; j < MAXDUNY; j++) {
 			for (i = 0; i < MAXDUNX; i++)
 				dMonster[i][j] = WLoad();
@@ -163,7 +163,7 @@ void LoadGame(BOOL firstflag)
 	AutomapZoomReset();
 	ResyncQuests();
 
-	if (leveltype)
+	if (leveltype != DTYPE_TOWN)
 		ProcessLightList();
 
 	RedoPlayerVision();
@@ -311,7 +311,7 @@ void SaveGame()
 	for (i = 0; i < MAXMONSTERS; i++)
 		ISave(monstkills[i]);
 
-	if (leveltype) {
+	if (leveltype != DTYPE_TOWN) {
 		for (i = 0; i < MAXMONSTERS; i++)
 			WSave(monstactive[i]);
 		for (i = 0; i < nummonsters; i++)
@@ -369,7 +369,7 @@ void SaveGame()
 			BSave(dItem[i][j]);
 	}
 
-	if (leveltype) {
+	if (leveltype != DTYPE_TOWN) {
 		for (j = 0; j < MAXDUNY; j++) {
 			for (i = 0; i < MAXDUNX; i++)
 				WSave(dMonster[i][j]);
@@ -525,7 +525,7 @@ void SaveLevel()
 	SaveBuff = DiabloAllocPtr(dwLen);
 	tbuff = SaveBuff;
 
-	if (leveltype) {
+	if (leveltype != DTYPE_TOWN) {
 		for (j = 0; j < MAXDUNY; j++) {
 			for (i = 0; i < MAXDUNX; i++)
 				BSave(dDead[i][j]);
@@ -536,7 +536,7 @@ void SaveLevel()
 	WSave(numitems);
 	WSave(nobjects);
 
-	if (leveltype) {
+	if (leveltype != DTYPE_TOWN) {
 		for (i = 0; i < MAXMONSTERS; i++)
 			WSave(monstactive[i]);
 		for (i = 0; i < nummonsters; i++)
@@ -565,7 +565,7 @@ void SaveLevel()
 			BSave(dItem[i][j]);
 	}
 
-	if (leveltype) {
+	if (leveltype != DTYPE_TOWN) {
 		for (j = 0; j < MAXDUNY; j++) {
 			for (i = 0; i < MAXDUNX; i++)
 				WSave(dMonster[i][j]);
@@ -614,7 +614,7 @@ void LoadLevel()
 	LoadBuff = pfile_read(szName, &dwLen);
 	tbuff = LoadBuff;
 
-	if (leveltype) {
+	if (leveltype != DTYPE_TOWN) {
 		for (j = 0; j < MAXDUNY; j++) {
 			for (i = 0; i < MAXDUNX; i++)
 				dDead[i][j] = BLoad();
@@ -626,7 +626,7 @@ void LoadLevel()
 	numitems = WLoad();
 	nobjects = WLoad();
 
-	if (leveltype) {
+	if (leveltype != DTYPE_TOWN) {
 		for (i = 0; i < MAXMONSTERS; i++)
 			monstactive[i] = WLoad();
 		for (i = 0; i < nummonsters; i++)
@@ -657,7 +657,7 @@ void LoadLevel()
 			dItem[i][j] = BLoad();
 	}
 
-	if (leveltype) {
+	if (leveltype != DTYPE_TOWN) {
 		for (j = 0; j < MAXDUNY; j++) {
 			for (i = 0; i < MAXDUNX; i++)
 				dMonster[i][j] = WLoad();

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -780,7 +780,7 @@ void SetupLocalCoords()
 
 	if (!leveldebug || gbMaxPlayers > 1) {
 		currlevel = 0;
-		leveltype = 0;
+		leveltype = DTYPE_TOWN;
 		setlevel = 0;
 	}
 	x = 75;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -136,7 +136,7 @@ BOOL RndLocOk(int xp, int yp)
 		return FALSE;
 	if (nSolidTable[dPiece[xp][yp]])
 		return FALSE;
-	if (leveltype != 1 || dPiece[xp][yp] <= 126 || dPiece[xp][yp] >= 144)
+	if (leveltype != DTYPE_CATHEDRAL || dPiece[xp][yp] <= 126 || dPiece[xp][yp] >= 144)
 		return TRUE;
 	return FALSE;
 }
@@ -831,7 +831,7 @@ void InitObjects()
 		InitRndLocObj(5, 10, 5);
 		InitRndLocObj(3, 6, 6);
 		InitRndLocObj(1, 5, 7);
-		if (leveltype != 4)
+		if (leveltype != DTYPE_HELL)
 			AddObjTraps();
 		if (leveltype > 1u)
 			AddChestTraps();

--- a/Source/portal.cpp
+++ b/Source/portal.cpp
@@ -126,7 +126,7 @@ void GetPortalLevel()
 		setlevel = 0;
 		currlevel = 0;
 		plr[myplr].plrlevel = 0;
-		leveltype = 0;
+		leveltype = DTYPE_TOWN;
 	} else {
 		if (portal[portalindex].setlvl) {
 			setlevel = 1;

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -545,25 +545,25 @@ void SetReturnLvlPos()
 	case SL_SKELKING:
 		ReturnLvlX = quests[QTYPE_KING]._qtx + 1;
 		ReturnLvlY = quests[QTYPE_KING]._qty;
-		ReturnLvlT = 1;
+		ReturnLvlT = DTYPE_CATHEDRAL;
 		ReturnLvl = quests[QTYPE_KING]._qlevel;
 		break;
 	case SL_BONECHAMB:
 		ReturnLvlX = quests[QTYPE_BONE]._qtx + 1;
 		ReturnLvlY = quests[QTYPE_BONE]._qty;
-		ReturnLvlT = 2;
+		ReturnLvlT = DTYPE_CATACOMBS;
 		ReturnLvl = quests[QTYPE_BONE]._qlevel;
 		break;
 	case SL_POISONWATER:
 		ReturnLvlX = quests[QTYPE_PW]._qtx;
 		ReturnLvlY = quests[QTYPE_PW]._qty + 1;
-		ReturnLvlT = 1;
+		ReturnLvlT = DTYPE_CATHEDRAL;
 		ReturnLvl = quests[QTYPE_PW]._qlevel;
 		break;
 	case SL_VILEBETRAYER:
 		ReturnLvlX = quests[QTYPE_VB]._qtx + 1;
 		ReturnLvlY = quests[QTYPE_VB]._qty - 1;
-		ReturnLvlT = 4;
+		ReturnLvlT = DTYPE_HELL;
 		ReturnLvl = quests[QTYPE_VB]._qlevel;
 		break;
 	}

--- a/Source/themes.cpp
+++ b/Source/themes.cpp
@@ -146,7 +146,7 @@ BOOL TFit_SkelRoom(int t)
 {
 	int i;
 
-	if (leveltype != 1 && leveltype != 2) {
+	if (leveltype != DTYPE_CATHEDRAL && leveltype != DTYPE_CATACOMBS) {
 		return FALSE;
 	}
 
@@ -425,7 +425,7 @@ void InitThemes()
 			}
 		}
 	}
-	if (leveltype == 2 || leveltype == 3 || leveltype == 4) {
+	if (leveltype == DTYPE_CATACOMBS || leveltype == DTYPE_CAVES || leveltype == DTYPE_HELL) {
 		for (i = 0; i < themeCount; i++)
 			themes[i].ttype = THEME_NONE;
 		if (QuestStatus(QTYPE_ZHAR)) {


### PR DESCRIPTION
This replaces some numbers with `dungeon_type` enum values.