### PR TITLE
Do not pass GCC options to the MSVC compiler/linker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,13 +238,16 @@ if(ASAN)
   target_link_libraries(devilution PUBLIC -fsanitize=address -fsanitize-recover=address)
 endif()
 
-if(DIST)
+if(DIST AND NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_link_libraries(devilutionx PUBLIC -static-libgcc -static-libstdc++)
 endif()
 
 if(WIN32)
   target_link_libraries(devilutionx PRIVATE wsock32 ws2_32 wininet)
-  target_compile_options(devilution PUBLIC $<$<CONFIG:Debug>:-gstabs>)
+
+  if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    target_compile_options(devilution PUBLIC $<$<CONFIG:Debug>:-gstabs>)
+  endif()
 endif()
 
 if(HAIKU)
@@ -264,6 +267,9 @@ if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 
   # Warnings for devilutionX
   target_compile_options(devilutionx PRIVATE -Wall -Wextra -Wno-write-strings -Wno-multichar -Wno-unused-parameter)
+
+  target_compile_options(devilution PRIVATE -fsigned-char)
+  target_compile_options(devilutionx PRIVATE -fsigned-char)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
@@ -273,9 +279,6 @@ endif()
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   target_compile_options(devilution PRIVATE -fno-aggressive-loop-optimizations)
 endif()
-
-target_compile_options(devilution PRIVATE -fsigned-char)
-target_compile_options(devilutionx PRIVATE -fsigned-char)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # Style issues


### PR DESCRIPTION
Visual Studio builds warn about gcc options that the MSVC compiler does not understand.