### PR TITLE
Fix volume scaling

### DIFF
--- a/SourceX/miniwin/dsound.cpp
+++ b/SourceX/miniwin/dsound.cpp
@@ -74,8 +74,7 @@ HRESULT DirectSoundBuffer::Play(DWORD dwReserved1, DWORD dwPriority, DWORD dwFla
 	}
 
 	Mix_Volume(channel, volume);
-	int panned = 255 - 255 * abs(pan) / 10000;
-	Mix_SetPanning(channel, pan <= 0 ? 255 : panned, pan >= 0 ? 255 : panned);
+	Mix_SetPanning(channel, pan <= 0 ? 255 : abs(pan), pan >= 0 ? 255 : pan);
 
 	return DVL_DS_OK;
 };
@@ -87,14 +86,15 @@ HRESULT DirectSoundBuffer::SetFormat(LPCWAVEFORMATEX pcfxFormat)
 
 HRESULT DirectSoundBuffer::SetVolume(LONG lVolume)
 {
-	volume = MIX_MAX_VOLUME - MIX_MAX_VOLUME * lVolume / VOLUME_MIN;
+	volume = pow(10, lVolume / 2000.0) * MIX_MAX_VOLUME;
 
 	return DVL_DS_OK;
 };
 
 HRESULT DirectSoundBuffer::SetPan(LONG lPan)
 {
-	pan = lPan;
+	pan = copysign(pow(10, -abs(lPan) / 2000.0) * 255, lPan);
+
 	return DVL_DS_OK;
 };
 


### PR DESCRIPTION
Fixes #59.

The original DirectSound [volume](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/mt708939(v%3Dvs.85)) and [panning](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/mt708938(v=vs.85)) methods both take decibel-based values, in hundredths of a dB (-10000 to 0), but SDL_mixer's methods expect linear values (0 to 128 for [volume](https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer_27.html), 255 for [panning](https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer_80.html)).

Since ["a change in amplitude by a factor of 10 corresponds to a 20 dB change in level"](https://en.wikipedia.org/wiki/Decibel), the conversion can be done like so: `SDLMixerVolume = 10^(DirectSoundVolume / (20 * 100)) * 128`; same goes for the panning, just `* 255` instead.

With these changes, it definitely sounds much closer to the original Diablo binary, but I still don't know if it's 100% correct (or if that's even possible).