### PR TITLE
Adds cmake to Brewfile-32bit.rb as a dependency

### DIFF
--- a/Brewfile-32bit.rb
+++ b/Brewfile-32bit.rb
@@ -1,3 +1,4 @@
 brew "automake"
-brew "autoconf" 
+brew "autoconf"
 brew "libtool"
+brew "cmake"


### PR DESCRIPTION
Fixes #143 
`cmake` is missing as a dependency in the 32-bit Brewfile.  This PR adds `cmake` to the 32-bit Brewfile.
