### PR TITLE
Fix panning

### DIFF
--- a/SourceX/miniwin/dsound.cpp
+++ b/SourceX/miniwin/dsound.cpp
@@ -74,7 +74,7 @@ HRESULT DirectSoundBuffer::Play(DWORD dwReserved1, DWORD dwPriority, DWORD dwFla
 	}
 
 	Mix_Volume(channel, volume);
-	Mix_SetPanning(channel, pan <= 0 ? 255 : abs(pan), pan >= 0 ? 255 : pan);
+	Mix_SetPanning(channel, pan > 0 ? pan : 255, pan < 0 ? abs(pan) : 255);
 
 	return DVL_DS_OK;
 };


### PR DESCRIPTION
I accidentally put the `abs()` on the wrong side in #142, so I fixed that, and rearranged the ternary expressions to (hopefully) make the intent more clear.

I also noticed that if `lPan` was 0, then `pan` would be set to 255 instead of 0. I originally added a condition for it, but after thinking for a bit... It shouldn't really matter in practice, since left/right would both end up at 255 anyway. I can add the condition back in if I'm overlooking something.