### PR TITLE
Fix lifetime of 'frame' buffer in tcp server/client.

### DIFF
--- a/SourceX/dvlnet/tcp_client.cpp
+++ b/SourceX/dvlnet/tcp_client.cpp
@@ -97,10 +97,12 @@ void tcp_client::handle_send(const asio::error_code& error, size_t bytes_sent)
 
 void tcp_client::send(packet& pkt)
 {
-	auto frame = frame_queue::make_frame(pkt.data());
-	asio::async_write(sock, asio::buffer(frame),
-	                  std::bind(&tcp_client::handle_send, this,
-	                            std::placeholders::_1, std::placeholders::_2));
+	auto frame = std::make_shared<buffer_t>(frame_queue::make_frame(pkt.data()));
+	auto buf = asio::buffer(*frame);
+	asio::async_write(sock, buf, [this, frame = std::move(frame)]
+	(const asio::error_code &error, size_t bytes_sent) {
+		handle_send(error, bytes_sent);
+	});
 }
 
 }  // namespace net


### PR DESCRIPTION
Just happened to find this problem Visual Studio debug iterator checks while creating new tcp/ip game. I'm no expert on asio but what happens here is essentially:

1. `asio::buffer` is basically pointer + size, so lifetime guarantees for used buffer should be provided by the user.
2. `async_write` is asynchronous so it returns immediately and the actual work is done somewhat later.
3. If `frame` is defined locally it gets freed almost immediately and invalid to use when async work needs to be done.
4. Seems like `send` can be called before other `send` is finished its work, thus storing this buffer as class field is also unsuitable
5. Attaching buffer's lifetime to handler's seems to viable approach in such case.
6. It's not entirely obvious should it be wrapped into `std::shared_ptr` or not. But since some copies of handler may be performed it can actually save a couple of possibly large unnecessary `std::vector` copies.

I checked that server successfully starts with no iterator debug check triggerd after these changes.