### PR TITLE
Fix compilation on Switch, add readme for Switch

### DIFF
--- a/SourceX/DiabloUI/selhero.cpp
+++ b/SourceX/DiabloUI/selhero.cpp
@@ -197,7 +197,7 @@ void selhero_ClassSelector_Select(int value)
 	}
 	memset(selhero_heroInfo.name, '\0', sizeof(selhero_heroInfo.name));
 #ifdef SWITCH
-	strcpy(heroInfo.name,"Switcher");
+	strcpy(selhero_heroInfo.name,"Switcher");
 #endif
 	UiInitList(0, 0, NULL, selhero_Name_Select, selhero_Name_Esc, ENTERNAME_DIALOG, size(ENTERNAME_DIALOG));
 }

--- a/makefile
+++ b/makefile
@@ -29,9 +29,114 @@ SMACKEROBJ 		= obj/smk_bitstream.o obj/smk_hufftree.o obj/smacker.o
 RADONOBJ		= obj/File.o obj/Key.o obj/Named.o obj/Section.o
 STORMLIBOBJ 	= obj/FileStream.o obj/SBaseCommon.o obj/SBaseFileTable.o obj/SBaseSubTypes.o obj/SCompression.o obj/SFileExtractFile.o obj/SFileFindFile.o obj/SFileGetFileInfo.o obj/SFileOpenArchive.o obj/SFileOpenFileEx.o obj/SFileReadFile.o
 PKWAREOBJ		= obj/explode.o obj/implode.o
-DEVILUTIONOBJ 	= obj/appfat.o obj/automap.o obj/capture.o obj/codec.o obj/control.o obj/cursor.o obj/dead.o obj/debug.o obj/diablo.o obj/doom.o obj/drlg_l1.o obj/drlg_l2.o obj/drlg_l3.o obj/drlg_l4.o obj/dthread.o obj/effects.o obj/encrypt.o obj/engine.o obj/error.o obj/fault.o obj/gamemenu.o obj/gendung.o obj/gmenu.o obj/help.o obj/init.o obj/interfac.o obj/inv.o obj/itemdat.o obj/items.o obj/lighting.o obj/loadsave.o obj/logging.o obj/mmainmenu.o obj/minitext.o obj/misdat.o obj/missiles.o obj/monstdat.o obj/monster.o obj/movie.o obj/mpqapi.o obj/msgcmd.o obj/msg.o obj/multi.o obj/nthread.o obj/objdat.o obj/objects.o obj/pack.o obj/palette.o obj/path.o obj/pfile.o obj/player.o obj/plrctrls.o obj/plrmsg.o obj/portal.o obj/spelldat.o obj/quests.o obj/render.o obj/restrict.o obj/scrollrt.o obj/setmaps.o obj/sha.o obj/spells.o obj/stores.o obj/sync.o obj/textdat.o obj/themes.o obj/tmsg.o obj/town.o obj/towners.o obj/track.o obj/trigs.o obj/wave.o
-MAINOBJ			= obj/dx.o obj/misc.o obj/misc_io.o obj/misc_msg.o obj/misc_dx.o obj/rand.o obj/thread.o obj/dsound.o obj/ddraw.o obj/sound.o obj/storm.o obj/storm_net.o obj/storm_dx.o obj/abstract_net.o obj/loopback.o obj/packet.o obj/base.o obj/frame_queue.o obj/credits.o obj/diabloui.o obj/dialogs.o obj/mainmenu.o obj/progress.o obj/selconn.o obj/selgame.o obj/selhero.o obj/title.o obj/main.o obj/touch.o
-MAINOBJ			+= obj/switch_keyboard.o
+DEVILUTIONOBJ 	= \
+	obj/appfat.o \
+	obj/automap.o \
+	obj/capture.o \
+	obj/codec.o \
+	obj/control.o \
+	obj/cursor.o \
+	obj/dead.o \
+	obj/debug.o \
+	obj/diablo.o \
+	obj/doom.o \
+	obj/drlg_l1.o \
+	obj/drlg_l2.o \
+	obj/drlg_l3.o \
+	obj/drlg_l4.o \
+	obj/dthread.o \
+	obj/effects.o \
+	obj/encrypt.o \
+	obj/engine.o \
+	obj/error.o \
+	obj/fault.o \
+	obj/gamemenu.o \
+	obj/gendung.o \
+	obj/gmenu.o \
+	obj/help.o \
+	obj/init.o \
+	obj/interfac.o \
+	obj/inv.o \
+	obj/itemdat.o \
+	obj/items.o \
+	obj/lighting.o \
+	obj/loadsave.o \
+	obj/logging.o \
+	obj/mmainmenu.o \
+	obj/minitext.o \
+	obj/misdat.o \
+	obj/missiles.o \
+	obj/monstdat.o \
+	obj/monster.o \
+	obj/movie.o \
+	obj/mpqapi.o \
+	obj/msgcmd.o \
+	obj/msg.o \
+	obj/multi.o \
+	obj/nthread.o \
+	obj/objdat.o \
+	obj/objects.o \
+	obj/pack.o \
+	obj/palette.o \
+	obj/path.o \
+	obj/pfile.o \
+	obj/player.o \
+	obj/plrctrls.o \
+	obj/plrmsg.o \
+	obj/portal.o \
+	obj/spelldat.o \
+	obj/quests.o \
+	obj/render.o \
+	obj/restrict.o \
+	obj/scrollrt.o \
+	obj/setmaps.o \
+	obj/sha.o \
+	obj/spells.o \
+	obj/stores.o \
+	obj/sync.o \
+	obj/textdat.o \
+	obj/themes.o \
+	obj/tmsg.o \
+	obj/town.o \
+	obj/towners.o \
+	obj/track.o \
+	obj/trigs.o \
+	obj/wave.o
+
+MAINOBJ = \
+	obj/dx.o \
+	obj/misc.o \
+	obj/misc_io.o \
+	obj/misc_msg.o \
+	obj/misc_dx.o \
+	obj/rand.o \
+	obj/thread.o \
+	obj/dsound.o \
+	obj/ddraw.o \
+	obj/sound.o \
+	obj/storm.o \
+	obj/storm_net.o \
+	obj/storm_dx.o \
+	obj/abstract_net.o \
+	obj/loopback.o \
+	obj/packet.o \
+	obj/base.o \
+	obj/frame_queue.o \
+	obj/credits.o \
+	obj/diabloui.o \
+	obj/dialogs.o \
+	obj/mainmenu.o \
+	obj/progress.o \
+	obj/selconn.o \
+	obj/selgame.o \
+	obj/selhero.o \
+	obj/selyesno.o \
+	obj/title.o \
+	obj/main.o \
+	obj/touch.o
+
+# touch keyboard on Switch
+MAINOBJ += obj/switch_keyboard.o
 
 .PHONY: all clean
 all: $(BINDIR)/$(OUTPUT).nro
@@ -295,6 +400,8 @@ obj/selgame.o: $(GLOBALDEPS) SourceX/DiabloUI/selgame.cpp
 	$(CXX) -c SourceX/DiabloUI/selgame.cpp -o obj/selgame.o $(CXXFLAGS)
 obj/selhero.o: $(GLOBALDEPS) SourceX/DiabloUI/selhero.cpp
 	$(CXX) -c SourceX/DiabloUI/selhero.cpp -o obj/selhero.o $(CXXFLAGS)
+obj/selyesno.o: $(GLOBALDEPS) SourceX/DiabloUI/selyesno.cpp
+	$(CXX) -c SourceX/DiabloUI/selyesno.cpp -o obj/selyesno.o $(CXXFLAGS)
 obj/title.o: $(GLOBALDEPS) SourceX/DiabloUI/title.cpp
 	$(CXX) -c SourceX/DiabloUI/title.cpp -o obj/title.o $(CXXFLAGS)
 obj/main.o: $(GLOBALDEPS) SourceX/main.cpp

--- a/switch/readme-switch.md
+++ b/switch/readme-switch.md
@@ -1,0 +1,81 @@
+# Nintendo Switch Port of DevilutionX (Diablo)
+
+### How To Play:
+- Extract contents of diablo-nx.zip release into `/switch/diablo-nx`
+- Copy `DIABDAT.MPQ` from original Diablo game disc or GOG version into `/switch/diablo-nx`
+- Launch `diablo-nx.nro` (do not use album to launch, see the note below)
+- *Note:* Hold R on any installed game and launch it. Do not use album to launch. If you use album, the homebrew only has very little memory available, and the touch keyboard doesn't work. This is true for all homebrew, not just Diablo-NX.
+- Enjoy :)
+
+### Joycon Controls
+
+- Left analog : move hero
+- Right analog : simulate mouse
+- B : attack nearby enemies, talk to towns people and merchants, pickup & drop items in inventory, OK in main menu
+- Y : pickup gold, potions & equipment from ground, open chests and doors that are nearby, use item when in inventory (useful to read books etc.)
+- X : cast spell, go to previous screen when talking to people and in shops
+- A : Select spell, cancel while in main menu
+- R : inventory
+- L : character
+- ZR : drink mana potion
+- ZL : drink health potion
+- Left analog click : quest log
+- Right analog click : left mouse click
+- Minus : automap
+- Plus : game Menu, skip intro
+
+### Touch Controls
+
+- Single finger drag : move the mouse pointer (pointer jumps to finger)
+- Single short tap : left mouse click
+- Single short tap while holding a second finger down : right mouse click
+- Dual finger drag : drag'n'drop (left mouse button is held down)
+- Three finger drag : drag'n'drop (right mouse button is held down)
+
+### Compiling On Linux
+
+- ```install devkitproA64, libzip, libpng, libjpeg, switch-freetype, switch-mesa, switch-glad, switch-glm, switch-sdl2, switch-sdl2_ttf, switch-sdl2_mixer, switch-libvorbis, switch-libmikmod```
+
+- ```make```
+
+### Compiling On Windows
+
+- Install [devkitpro](https://sourceforge.net/projects/devkitpro/)
+- Open ```Start Button > DevKitPro > MSys2```
+- Type in ```pacman -S switch-freetype switch-mesa switch-glad switch-glm switch-sdl2 switch-sdl2_ttf switch-sdl2_mixer switch-libvorbis switch-libmikmod```
+- Type in ```make```
+
+### Compiling On MacOS
+
+- Install [devkitpro](https://devkitpro.org/wiki/Getting_Started#macOS)
+- Open Terminal
+- Type in ```dkp-pacman -S switch-freetype switch-mesa switch-glad switch-glm switch-sdl2 switch-sdl2_ttf switch-sdl2_mixer switch-libvorbis switch-libmikmod```
+- Type in ```make```
+
+- .nro lives in release. Test with an emulator (RyuJinx) or real hardware.
+
+### Credits
+
+- Initial Switch Port by MVG in 2019
+- Control improvements and bug fixes by [rsn8887](https://github.com/rsn8887) in 2019
+- Controller code by [Jacob Fliss](https://github.com/erfg12)
+- RetroArch team for the Switch mman.h file
+- AJenbo for upstreaming Switch code and many code fixes
+- [sanctuary](https://github.com/sanctuary) - extensively documenting Diablo's game engine
+- [BWAPI Team](https://github.com/bwapi) - providing library API to work with Storm
+- [Ladislav Zezula](https://github.com/ladislav-zezula) - reversing PKWARE library, further documenting Storm
+- [fearedbliss](https://github.com/fearedbliss) - being awe-inspiring
+- Climax Studios & Sony - secretly helping with their undercover QA :P
+- Blizzard North - wait, this was a typo!
+- Depression - reason to waste four months of my life doing this ;)
+
+And a special thanks to all the support and people who work on Devilution to make it possible! <3
+
+# Legal
+Devilution is released to the Public Domain. The documentation and function provided by Devilution may only be utilized with assets provided by ownership of Diablo.
+
+Battle.net(R) - Copyright (C) 1996 Blizzard Entertainment, Inc. All rights reserved. Battle.net and Blizzard Entertainment are trademarks or registered trademarks of Blizzard Entertainment, Inc. in the U.S. and/or other countries.
+
+Diablo(R) - Copyright (C) 1996 Blizzard Entertainment, Inc. All rights reserved. Diablo and Blizzard Entertainment are trademarks or registered trademarks of Blizzard Entertainment, Inc. in the U.S. and/or other countries.
+
+Devilution and any of its' maintainers are in no way associated with or endorsed by Blizzard Entertainment(R).


### PR DESCRIPTION
This PR
- fixes compilation on Switch (recently broke because selyesno.o was missing)
- adds a readme-switch document (can always be edited later)