### PR TITLE
Fix MonstStruct load/save

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -548,6 +548,7 @@ void LoadMonster(int i)
 	CopyChar(tbuff, &pMonster->packsize);
 	CopyChar(tbuff, &pMonster->mlid);
 
+	tbuff += sizeof(DWORD) * 3; // Skip 3 pointers
 	SyncMonsterAnim(i);
 }
 
@@ -1243,6 +1244,8 @@ void SaveMonster(int i)
 	CopyChar(&pMonster->leaderflag, tbuff);
 	CopyChar(&pMonster->packsize, tbuff);
 	CopyChar(&pMonster->mlid, tbuff);
+	
+	tbuff += sizeof(DWORD) * 3; // Skip 3 pointers
 }
 
 void SaveMissile(int i)


### PR DESCRIPTION
LoadMonster and SaveMonster were not skipping some pointers at the end of the struct. I'm not even sure why it works as well as it does - without the fix, I'm still able to load and save monsters correctly, but it looks like other people had situations where this problem comes to light.