### PR TITLE
Fix drive-letter relative path log path

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -47,8 +47,10 @@ void __cdecl dumphist(const char *pszFmt, ...)
 
 	va_start(va, pszFmt);
 
-	if (sgpHistFile == NULL) {
-		sgpHistFile = fopen("dumphist.txt", "wb");
+	char dumpHistPath[MAX_PATH] = {};
+	if (sgpHistFile == NULL && GetWindowsDirectory(dumpHistPath, sizeof(dumpHistPath))) {
+		strcat(dumpHistPath, "\\dumphist.txt");
+		sgpHistFile = fopen(dumpHistPath, "wb");
 		if (sgpHistFile == NULL) {
 			return;
 		}

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -48,7 +48,7 @@ void __cdecl dumphist(const char *pszFmt, ...)
 	va_start(va, pszFmt);
 
 	if (sgpHistFile == NULL) {
-		sgpHistFile = fopen("c:\\dumphist.txt", "wb");
+		sgpHistFile = fopen("dumphist.txt", "wb");
 		if (sgpHistFile == NULL) {
 			return;
 		}


### PR DESCRIPTION
Makes no sense on non-Windows OSes. Fixes #208 