### PR TITLE
Fix invalid file and line constants

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -252,7 +252,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	ghInst = hInst;
 
 	if (RestrictedTest())
-		ErrOkDlg(IDD_DIALOG10, 0, __FILE__, __LINE__);
+		ERR_OK_DLG(IDD_DIALOG10, 0);
 	if (ReadOnlyTest()) {
 		if (!GetModuleFileName(ghInst, szFileName, sizeof(szFileName)))
 			szFileName[0] = '\0';

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -252,7 +252,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	ghInst = hInst;
 
 	if (RestrictedTest())
-		ErrOkDlg(IDD_DIALOG10, 0, "C:\\Src\\Diablo\\Source\\DIABLO.CPP", 877);
+		ErrOkDlg(IDD_DIALOG10, 0, __FILE__, __LINE__);
 	if (ReadOnlyTest()) {
 		if (!GetModuleFileName(ghInst, szFileName, sizeof(szFileName)))
 			szFileName[0] = '\0';

--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -40,7 +40,7 @@ void dx_init(HWND hWnd)
 	}
 	hDDVal = dx_DirectDrawCreate(lpGUID, &lpDDInterface, NULL);
 	if (hDDVal != DD_OK) {
-		ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Src\\Diablo\\Source\\dx.cpp", 149);
+		ErrDlg(IDD_DIALOG1, hDDVal, __FILE__, __LINE__);
 	}
 
 #ifdef COLORFIX
@@ -63,7 +63,7 @@ void dx_init(HWND hWnd)
 		if (hDDVal == DDERR_EXCLUSIVEMODEALREADYSET) {
 			TriggerBreak();
 		} else if (hDDVal != DD_OK) {
-			ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Diablo\\Direct\\dx.cpp", 155);
+			ErrDlg(IDD_DIALOG1, hDDVal, __FILE__, __LINE__);
 		}
 		SetWindowPos(hWnd, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
 	} else {
@@ -75,7 +75,7 @@ void dx_init(HWND hWnd)
 		if (hDDVal == DDERR_EXCLUSIVEMODEALREADYSET) {
 			TriggerBreak();
 		} else if (hDDVal != DD_OK) {
-			ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Src\\Diablo\\Source\\dx.cpp", 170);
+			ErrDlg(IDD_DIALOG1, hDDVal, __FILE__, __LINE__);
 		}
 #ifdef __cplusplus
 		hDDVal = lpDDInterface->SetDisplayMode(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_BPP);
@@ -92,7 +92,7 @@ void dx_init(HWND hWnd)
 #endif
 		}
 		if (hDDVal != DD_OK) {
-			ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Src\\Diablo\\Source\\dx.cpp", 183);
+			ErrDlg(IDD_DIALOG1, hDDVal, __FILE__, __LINE__);
 		}
 	}
 
@@ -135,7 +135,7 @@ void dx_create_back_buffer()
 			return;
 		}
 		if (error_code != DDERR_CANTLOCKSURFACE)
-			ErrDlg(IDD_DIALOG1, error_code, "C:\\Src\\Diablo\\Source\\dx.cpp", 81);
+			ErrDlg(IDD_DIALOG1, error_code, __FILE__, __LINE__);
 	}
 
 	memset(&ddsd, 0, sizeof(ddsd));
@@ -152,14 +152,14 @@ void dx_create_back_buffer()
 	error_code = lpDDSPrimary->lpVtbl->GetPixelFormat(lpDDSPrimary, &ddsd.ddpfPixelFormat);
 #endif
 	if (error_code != DD_OK)
-		ErrDlg(IDD_DIALOG1, error_code, "C:\\Src\\Diablo\\Source\\dx.cpp", 94);
+		ErrDlg(IDD_DIALOG1, error_code, __FILE__, __LINE__);
 #ifdef __cplusplus
 	error_code = lpDDInterface->CreateSurface(&ddsd, &lpDDSBackBuf, NULL);
 #else
 	error_code = lpDDInterface->lpVtbl->CreateSurface(lpDDInterface, &ddsd, &lpDDSBackBuf, NULL);
 #endif
 	if (error_code != DD_OK)
-		ErrDlg(IDD_DIALOG1, error_code, "C:\\Src\\Diablo\\Source\\dx.cpp", 96);
+		ErrDlg(IDD_DIALOG1, error_code, __FILE__, __LINE__);
 }
 
 void dx_create_primary_surface()
@@ -177,7 +177,7 @@ void dx_create_primary_surface()
 	error_code = lpDDInterface->lpVtbl->CreateSurface(lpDDInterface, &ddsd, &lpDDSPrimary, NULL);
 #endif
 	if (error_code != DD_OK)
-		ErrDlg(IDD_DIALOG1, error_code, "C:\\Src\\Diablo\\Source\\dx.cpp", 109);
+		ErrDlg(IDD_DIALOG1, error_code, __FILE__, __LINE__);
 }
 
 HRESULT dx_DirectDrawCreate(LPGUID guid, LPDIRECTDRAW *lplpDD, LPUNKNOWN pUnkOuter)
@@ -188,13 +188,13 @@ HRESULT dx_DirectDrawCreate(LPGUID guid, LPDIRECTDRAW *lplpDD, LPUNKNOWN pUnkOut
 	if (ghDiabMod == NULL) {
 		ghDiabMod = LoadLibrary("ddraw.dll");
 		if (ghDiabMod == NULL) {
-			ErrDlg(IDD_DIALOG4, GetLastError(), "C:\\Src\\Diablo\\Source\\dx.cpp", 122);
+			ErrDlg(IDD_DIALOG4, GetLastError(), __FILE__, __LINE__);
 		}
 	}
 
 	DirectDrawCreate = (HRESULT(WINAPI *)(LPGUID, LPDIRECTDRAW *, LPUNKNOWN))GetProcAddress(ghDiabMod, "DirectDrawCreate");
 	if (DirectDrawCreate == NULL) {
-		ErrDlg(IDD_DIALOG4, GetLastError(), "C:\\Src\\Diablo\\Source\\dx.cpp", 127);
+		ErrDlg(IDD_DIALOG4, GetLastError(), __FILE__, __LINE__);
 	}
 	return DirectDrawCreate(guid, lplpDD, pUnkOuter);
 }

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -2372,7 +2372,7 @@ BYTE *DiabloAllocPtr(DWORD dwBytes)
 #endif
 
 	if (buf == NULL) {
-		ErrDlg(IDD_DIALOG2, GetLastError(), __FILE__, __LINE__);
+		ERR_DLG(IDD_DIALOG2, GetLastError());
 	}
 
 	return buf;

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -2352,7 +2352,7 @@ void engine_debug_trap(BOOL show_cursor)
 	sgMemCrit.Enter();
 	while(sgpMemBlock != NULL) {
 		pCurr = sgpMemBlock->pNext;
-		SMemFree(sgpMemBlock, "C:\\Diablo\\Direct\\ENGINE.CPP", 1970);
+		SMemFree(sgpMemBlock, __FILE__, __LINE__);
 		sgpMemBlock = pCurr;
 	}
 	sgMemCrit.Leave();
@@ -2366,13 +2366,13 @@ BYTE *DiabloAllocPtr(DWORD dwBytes)
 #ifdef __cplusplus
 	sgMemCrit.Enter();
 #endif
-	buf = (BYTE *)SMemAlloc(dwBytes, "C:\\Src\\Diablo\\Source\\ENGINE.CPP", 2236, 0);
+	buf = (BYTE *)SMemAlloc(dwBytes, __FILE__, __LINE__, 0);
 #ifdef __cplusplus
 	sgMemCrit.Leave();
 #endif
 
 	if (buf == NULL) {
-		ErrDlg(IDD_DIALOG2, GetLastError(), "C:\\Src\\Diablo\\Source\\ENGINE.CPP", 2269);
+		ErrDlg(IDD_DIALOG2, GetLastError(), __FILE__, __LINE__);
 	}
 
 	return buf;
@@ -2384,7 +2384,7 @@ void mem_free_dbg(void *p)
 #ifdef __cplusplus
 		sgMemCrit.Enter();
 #endif
-		SMemFree(p, "C:\\Src\\Diablo\\Source\\ENGINE.CPP", 2317, 0);
+		SMemFree(p, __FILE__, __LINE__, 0);
 #ifdef __cplusplus
 		sgMemCrit.Leave();
 #endif

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1802,7 +1802,7 @@ int InvPutItem(int pnum, int x, int y)
 	}
 
 	CanPut(x, y); //if (!CanPut(x, y)) {
-	//	assertion_failed(1524, "C:\\Diablo\\Direct\\inv.cpp", "CanPut(x,y)");
+	//	assertion_failed(__LINE__, __FILE__, "CanPut(x,y)");
 	//}
 
 	ii = itemavail[0];

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -33,7 +33,7 @@ void palette_init()
 	error_code = lpDDInterface->lpVtbl->CreatePalette(lpDDInterface, DDPCAPS_ALLOW256 | DDPCAPS_8BIT, system_palette, &lpDDPalette, NULL);
 #endif
 	if (error_code)
-		ErrDlg(IDD_DIALOG8, error_code, "C:\\Src\\Diablo\\Source\\PALETTE.CPP", 143);
+		ErrDlg(IDD_DIALOG8, error_code, __FILE__, __LINE__);
 #ifdef __cplusplus
 	error_code = lpDDSPrimary->SetPalette(lpDDPalette);
 #else
@@ -41,7 +41,7 @@ void palette_init()
 #endif
 #ifndef RGBMODE
 	if (error_code)
-		ErrDlg(IDD_DIALOG8, error_code, "C:\\Src\\Diablo\\Source\\PALETTE.CPP", 146);
+		ErrDlg(IDD_DIALOG8, error_code, __FILE__, __LINE__);
 #endif
 }
 

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -33,7 +33,7 @@ void palette_init()
 	error_code = lpDDInterface->lpVtbl->CreatePalette(lpDDInterface, DDPCAPS_ALLOW256 | DDPCAPS_8BIT, system_palette, &lpDDPalette, NULL);
 #endif
 	if (error_code)
-		ErrDlg(IDD_DIALOG8, error_code, __FILE__, __LINE__);
+		ERR_DLG(IDD_DIALOG8, error_code);
 #ifdef __cplusplus
 	error_code = lpDDSPrimary->SetPalette(lpDDPalette);
 #else
@@ -41,7 +41,7 @@ void palette_init()
 #endif
 #ifndef RGBMODE
 	if (error_code)
-		ErrDlg(IDD_DIALOG8, error_code, __FILE__, __LINE__);
+		ERR_DLG(IDD_DIALOG8, error_code);
 #endif
 }
 

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -2399,7 +2399,7 @@ void DrawMain(int dwHgt, BOOL draw_desc, BOOL draw_hp, BOOL draw_mana, BOOL draw
 			return;
 		}
 		if (hDDVal != DD_OK) {
-			DDErrMsg(hDDVal, 3707, "C:\\Src\\Diablo\\Source\\SCROLLRT.CPP");
+			DDErrMsg(hDDVal, __LINE__, __FILE__);
 		}
 	}
 
@@ -2445,7 +2445,7 @@ void DrawMain(int dwHgt, BOOL draw_desc, BOOL draw_hp, BOOL draw_mana, BOOL draw
 		hDDVal = lpDDSPrimary->lpVtbl->Unlock(lpDDSPrimary, NULL);
 #endif
 		if (hDDVal != DDERR_SURFACELOST && hDDVal != DD_OK) {
-			DDErrMsg(hDDVal, 3779, "C:\\Src\\Diablo\\Source\\SCROLLRT.CPP");
+			DDErrMsg(hDDVal, __LINE__, __FILE__);
 		}
 	}
 
@@ -2529,7 +2529,7 @@ void DoBlitScreen(DWORD dwX, DWORD dwY, DWORD dwWdt, DWORD dwHgt)
 		    && hDDVal != DDERR_WASSTILLDRAWING
 		    && hDDVal != DDERR_SURFACEBUSY
 		    && hDDVal != DD_OK) {
-			DDErrMsg(hDDVal, 3596, "C:\\Src\\Diablo\\Source\\SCROLLRT.CPP");
+			DDErrMsg(hDDVal, __LINE__, __FILE__);
 		}
 	} else {
 		nSrcOff = SCREENXY(dwX, dwY);

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -2399,7 +2399,7 @@ void DrawMain(int dwHgt, BOOL draw_desc, BOOL draw_hp, BOOL draw_mana, BOOL draw
 			return;
 		}
 		if (hDDVal != DD_OK) {
-			DDErrMsg(hDDVal, __LINE__, __FILE__);
+			DD_ERR_MSG(hDDVal);
 		}
 	}
 
@@ -2445,7 +2445,7 @@ void DrawMain(int dwHgt, BOOL draw_desc, BOOL draw_hp, BOOL draw_mana, BOOL draw
 		hDDVal = lpDDSPrimary->lpVtbl->Unlock(lpDDSPrimary, NULL);
 #endif
 		if (hDDVal != DDERR_SURFACELOST && hDDVal != DD_OK) {
-			DDErrMsg(hDDVal, __LINE__, __FILE__);
+			DD_ERR_MSG(hDDVal);
 		}
 	}
 
@@ -2529,7 +2529,7 @@ void DoBlitScreen(DWORD dwX, DWORD dwY, DWORD dwWdt, DWORD dwHgt)
 		    && hDDVal != DDERR_WASSTILLDRAWING
 		    && hDDVal != DDERR_SURFACEBUSY
 		    && hDDVal != DD_OK) {
-			DDErrMsg(hDDVal, __LINE__, __FILE__);
+			DD_ERR_MSG(hDDVal);
 		}
 	} else {
 		nSrcOff = SCREENXY(dwX, dwY);

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -344,7 +344,7 @@ void InitCows()
 	int x, y, xo, yo;
 
 	//if ( pCowCels )
-	//	assertion_failed(300, "C:\\Diablo\\Direct\\towners.cpp", "! pCowCels");
+		// assertion_failed(__LINE__, __FILE__, "! pCowCels");
 	pCowCels = LoadFileInMem("Towners\\Animals\\Cow.CEL", NULL);
 	for (i = 0; i < 3; i++) {
 		x = TownCowX[i];

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -41,7 +41,7 @@ void dx_init(HWND hWnd)
 	}
 	hDDVal = dx_DirectDrawCreate(lpGUID, &lpDDInterface, NULL);
 	if (hDDVal != DVL_S_OK) {
-		ErrDlg(IDD_DIALOG1, hDDVal, __FILE__, __LINE__);
+		ERR_DLG(IDD_DIALOG1, hDDVal);
 	}
 
 #ifdef COLORFIX
@@ -64,7 +64,7 @@ void dx_init(HWND hWnd)
 		if (hDDVal == 1) {
 			TriggerBreak();
 		} else if (hDDVal != DVL_S_OK) {
-			ErrDlg(IDD_DIALOG1, hDDVal, __FILE__, __LINE__);
+			ERR_DLG(IDD_DIALOG1, hDDVal);
 		}
 		SetWindowPos(hWnd, 0, 0, 0, 0, 0, 0 | 0 | 0);
 	} else {
@@ -76,7 +76,7 @@ void dx_init(HWND hWnd)
 		if (hDDVal == 1) {
 			TriggerBreak();
 		} else if (hDDVal != DVL_S_OK) {
-			ErrDlg(IDD_DIALOG1, hDDVal, __FILE__, __LINE__);
+			ERR_DLG(IDD_DIALOG1, hDDVal);
 		}
 #ifdef __cplusplus
 		hDDVal = lpDDInterface->SetDisplayMode(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_BPP);
@@ -93,7 +93,7 @@ void dx_init(HWND hWnd)
 #endif
 		}
 		if (hDDVal != DVL_S_OK) {
-			ErrDlg(IDD_DIALOG1, hDDVal, __FILE__, __LINE__);
+			ERR_DLG(IDD_DIALOG1, hDDVal);
 		}
 	}
 
@@ -118,7 +118,7 @@ void dx_create_back_buffer()
 	error_code = lpDDSPrimary->lpVtbl->GetCaps(lpDDSPrimary, &caps);
 #endif
 	if (error_code != DVL_S_OK)
-		DDErrMsg(error_code, __LINE__, __FILE__);
+		DD_ERR_MSG(error_code);
 
 	gbBackBuf = 1;
 	if (!gbBackBuf) {
@@ -138,7 +138,7 @@ void dx_create_back_buffer()
 			return;
 		}
 		if (error_code != 2)
-			ErrDlg(IDD_DIALOG1, error_code, __FILE__, __LINE__);
+			ERR_DLG(IDD_DIALOG1, error_code);
 	}
 
 	memset(&ddsd, 0, sizeof(ddsd));
@@ -155,14 +155,14 @@ void dx_create_back_buffer()
 	error_code = lpDDSPrimary->lpVtbl->GetPixelFormat(lpDDSPrimary, &ddsd.ddpfPixelFormat);
 #endif
 	if (error_code != DVL_S_OK)
-		ErrDlg(IDD_DIALOG1, error_code, __FILE__, __LINE__);
+		ERR_DLG(IDD_DIALOG1, error_code);
 #ifdef __cplusplus
 	error_code = lpDDInterface->CreateSurface(&ddsd, &lpDDSBackBuf, NULL);
 #else
 	error_code = lpDDInterface->lpVtbl->CreateSurface(lpDDInterface, &ddsd, &lpDDSBackBuf, NULL);
 #endif
 	if (error_code != DVL_S_OK)
-		ErrDlg(IDD_DIALOG1, error_code, __FILE__, __LINE__);
+		ERR_DLG(IDD_DIALOG1, error_code);
 }
 // 52A548: using guessed type char gbBackBuf;
 
@@ -181,7 +181,7 @@ void dx_create_primary_surface()
 	error_code = lpDDInterface->lpVtbl->CreateSurface(lpDDInterface, &ddsd, &lpDDSPrimary, NULL);
 #endif
 	if (error_code != DVL_S_OK)
-		ErrDlg(IDD_DIALOG1, error_code, __FILE__, __LINE__);
+		ERR_DLG(IDD_DIALOG1, error_code);
 }
 
 HRESULT dx_DirectDrawCreate(LPGUID guid, LPDIRECTDRAW *lplpDD, LPUNKNOWN pUnkOuter)
@@ -189,7 +189,7 @@ HRESULT dx_DirectDrawCreate(LPGUID guid, LPDIRECTDRAW *lplpDD, LPUNKNOWN pUnkOut
 	if (ghDiabMod == NULL) {
 		ghDiabMod = NULL; //ghDiabMod = LoadLibrary("ddraw.dll");
 		if (ghDiabMod == NULL) {
-			// ErrDlg(IDD_DIALOG4, GetLastError(), __FILE__, __LINE__);
+			// ERR_DLG(IDD_DIALOG4, GetLastError());
 		}
 	}
 
@@ -238,7 +238,7 @@ void lock_buf_priv()
 	error_code = lpDDSBackBuf->lpVtbl->Lock(lpDDSBackBuf, NULL, &ddsd, DDLOCK_WAIT, NULL);
 #endif
 	if (error_code != DVL_S_OK)
-		DDErrMsg(error_code, __LINE__, __FILE__);
+		DD_ERR_MSG(error_code);
 
 	gpBufEnd += (uintptr_t)ddsd.lpSurface;
 	gpBuffer = (BYTE *)ddsd.lpSurface;
@@ -275,7 +275,7 @@ void unlock_buf_priv()
 			error_code = lpDDSBackBuf->lpVtbl->Unlock(lpDDSBackBuf, NULL);
 #endif
 			if (error_code != DVL_S_OK)
-				DDErrMsg(error_code, __LINE__, __FILE__);
+				DD_ERR_MSG(error_code);
 		}
 	}
 #ifdef __cplusplus

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -41,7 +41,7 @@ void dx_init(HWND hWnd)
 	}
 	hDDVal = dx_DirectDrawCreate(lpGUID, &lpDDInterface, NULL);
 	if (hDDVal != DVL_S_OK) {
-		ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Src\\Diablo\\Source\\dx.cpp", 149);
+		ErrDlg(IDD_DIALOG1, hDDVal, __FILE__, __LINE__);
 	}
 
 #ifdef COLORFIX
@@ -64,7 +64,7 @@ void dx_init(HWND hWnd)
 		if (hDDVal == 1) {
 			TriggerBreak();
 		} else if (hDDVal != DVL_S_OK) {
-			ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Diablo\\Direct\\dx.cpp", 155);
+			ErrDlg(IDD_DIALOG1, hDDVal, __FILE__, __LINE__);
 		}
 		SetWindowPos(hWnd, 0, 0, 0, 0, 0, 0 | 0 | 0);
 	} else {
@@ -76,7 +76,7 @@ void dx_init(HWND hWnd)
 		if (hDDVal == 1) {
 			TriggerBreak();
 		} else if (hDDVal != DVL_S_OK) {
-			ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Src\\Diablo\\Source\\dx.cpp", 170);
+			ErrDlg(IDD_DIALOG1, hDDVal, __FILE__, __LINE__);
 		}
 #ifdef __cplusplus
 		hDDVal = lpDDInterface->SetDisplayMode(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_BPP);
@@ -93,7 +93,7 @@ void dx_init(HWND hWnd)
 #endif
 		}
 		if (hDDVal != DVL_S_OK) {
-			ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Src\\Diablo\\Source\\dx.cpp", 183);
+			ErrDlg(IDD_DIALOG1, hDDVal, __FILE__, __LINE__);
 		}
 	}
 
@@ -118,7 +118,7 @@ void dx_create_back_buffer()
 	error_code = lpDDSPrimary->lpVtbl->GetCaps(lpDDSPrimary, &caps);
 #endif
 	if (error_code != DVL_S_OK)
-		DDErrMsg(error_code, 59, "C:\\Src\\Diablo\\Source\\dx.cpp");
+		DDErrMsg(error_code, __LINE__, __FILE__);
 
 	gbBackBuf = 1;
 	if (!gbBackBuf) {
@@ -138,7 +138,7 @@ void dx_create_back_buffer()
 			return;
 		}
 		if (error_code != 2)
-			ErrDlg(IDD_DIALOG1, error_code, "C:\\Src\\Diablo\\Source\\dx.cpp", 81);
+			ErrDlg(IDD_DIALOG1, error_code, __FILE__, __LINE__);
 	}
 
 	memset(&ddsd, 0, sizeof(ddsd));
@@ -155,14 +155,14 @@ void dx_create_back_buffer()
 	error_code = lpDDSPrimary->lpVtbl->GetPixelFormat(lpDDSPrimary, &ddsd.ddpfPixelFormat);
 #endif
 	if (error_code != DVL_S_OK)
-		ErrDlg(IDD_DIALOG1, error_code, "C:\\Src\\Diablo\\Source\\dx.cpp", 94);
+		ErrDlg(IDD_DIALOG1, error_code, __FILE__, __LINE__);
 #ifdef __cplusplus
 	error_code = lpDDInterface->CreateSurface(&ddsd, &lpDDSBackBuf, NULL);
 #else
 	error_code = lpDDInterface->lpVtbl->CreateSurface(lpDDInterface, &ddsd, &lpDDSBackBuf, NULL);
 #endif
 	if (error_code != DVL_S_OK)
-		ErrDlg(IDD_DIALOG1, error_code, "C:\\Src\\Diablo\\Source\\dx.cpp", 96);
+		ErrDlg(IDD_DIALOG1, error_code, __FILE__, __LINE__);
 }
 // 52A548: using guessed type char gbBackBuf;
 
@@ -181,7 +181,7 @@ void dx_create_primary_surface()
 	error_code = lpDDInterface->lpVtbl->CreateSurface(lpDDInterface, &ddsd, &lpDDSPrimary, NULL);
 #endif
 	if (error_code != DVL_S_OK)
-		ErrDlg(IDD_DIALOG1, error_code, "C:\\Src\\Diablo\\Source\\dx.cpp", 109);
+		ErrDlg(IDD_DIALOG1, error_code, __FILE__, __LINE__);
 }
 
 HRESULT dx_DirectDrawCreate(LPGUID guid, LPDIRECTDRAW *lplpDD, LPUNKNOWN pUnkOuter)
@@ -189,7 +189,7 @@ HRESULT dx_DirectDrawCreate(LPGUID guid, LPDIRECTDRAW *lplpDD, LPUNKNOWN pUnkOut
 	if (ghDiabMod == NULL) {
 		ghDiabMod = NULL; //ghDiabMod = LoadLibrary("ddraw.dll");
 		if (ghDiabMod == NULL) {
-			//ErrDlg(IDD_DIALOG4, GetLastError(), "C:\\Src\\Diablo\\Source\\dx.cpp", 122);
+			// ErrDlg(IDD_DIALOG4, GetLastError(), __FILE__, __LINE__);
 		}
 	}
 
@@ -238,7 +238,7 @@ void lock_buf_priv()
 	error_code = lpDDSBackBuf->lpVtbl->Lock(lpDDSBackBuf, NULL, &ddsd, DDLOCK_WAIT, NULL);
 #endif
 	if (error_code != DVL_S_OK)
-		DDErrMsg(error_code, 235, "C:\\Src\\Diablo\\Source\\dx.cpp");
+		DDErrMsg(error_code, __LINE__, __FILE__);
 
 	gpBufEnd += (uintptr_t)ddsd.lpSurface;
 	gpBuffer = (BYTE *)ddsd.lpSurface;
@@ -275,7 +275,7 @@ void unlock_buf_priv()
 			error_code = lpDDSBackBuf->lpVtbl->Unlock(lpDDSBackBuf, NULL);
 #endif
 			if (error_code != DVL_S_OK)
-				DDErrMsg(error_code, 273, "C:\\Src\\Diablo\\Source\\dx.cpp");
+				DDErrMsg(error_code, __LINE__, __FILE__);
 		}
 	}
 #ifdef __cplusplus

--- a/SourceX/sound.cpp
+++ b/SourceX/sound.cpp
@@ -142,7 +142,7 @@ void snd_play_snd(TSnd *pSnd, int lVolume, int lPan)
 
 	if (error_code != DVL_DSERR_BUFFERLOST) {
 		if (error_code != DVL_DS_OK) {
-			DSErrMsg(error_code, 261, "C:\\Src\\Diablo\\Source\\SOUND.CPP");
+			DSErrMsg(error_code, __LINE__, __FILE__);
 		}
 	} else if (sound_file_reload(pSnd, DSB)) {
 #ifdef __cplusplus
@@ -248,7 +248,7 @@ TSnd *sound_file_load(char *path)
 	error_code = pSnd->DSB->lpVtbl->Lock(pSnd->DSB, 0, pSnd->chunk.dwSize, &buf1, &size1, &buf2, &size2, 0);
 #endif
 	if (error_code != DVL_DS_OK)
-		DSErrMsg(error_code, 318, "C:\\Src\\Diablo\\Source\\SOUND.CPP");
+		DSErrMsg(error_code, __LINE__, __FILE__);
 
 	memcpy(buf1, wave_file + pSnd->chunk.dwOffset, size1);
 
@@ -258,7 +258,7 @@ TSnd *sound_file_load(char *path)
 	error_code = pSnd->DSB->lpVtbl->Unlock(pSnd->DSB, buf1, size1, buf2, size2);
 #endif
 	if (error_code != DVL_DS_OK)
-		DSErrMsg(error_code, 325, "C:\\Src\\Diablo\\Source\\SOUND.CPP");
+		DSErrMsg(error_code, __LINE__, __FILE__);
 
 	mem_free_dbg((void *)wave_file);
 	WCloseFile(file);
@@ -288,7 +288,7 @@ void sound_CreateSoundBuffer(TSnd *sound_file)
 	error_code = sglpDS->lpVtbl->CreateSoundBuffer(sglpDS, &DSB, &sound_file->DSB, NULL);
 #endif
 	if (error_code != DVL_ERROR_SUCCESS)
-		DSErrMsg(error_code, 282, "C:\\Src\\Diablo\\Source\\SOUND.CPP");
+		DSErrMsg(error_code, __LINE__, __FILE__);
 }
 
 void sound_file_cleanup(TSnd *sound_file)
@@ -366,7 +366,7 @@ void sound_create_primary_buffer(HANDLE music_track)
 		error_code = sglpDS->lpVtbl->CreateSoundBuffer(sglpDS, &dsbuf, &sglpDSB, NULL);
 #endif
 		if (error_code != DVL_DS_OK)
-			DSErrMsg(error_code, 375, "C:\\Src\\Diablo\\Source\\SOUND.CPP");
+			DSErrMsg(error_code, __LINE__, __FILE__);
 	}
 
 	if (sglpDSB) {
@@ -379,7 +379,7 @@ void sound_create_primary_buffer(HANDLE music_track)
 		error_code = sglpDS->lpVtbl->GetCaps(sglpDS, &dsbcaps);
 #endif
 		if (error_code != DVL_DS_OK)
-			DSErrMsg(error_code, 383, "C:\\Src\\Diablo\\Source\\SOUND.CPP");
+			DSErrMsg(error_code, __LINE__, __FILE__);
 
 		if (!music_track || !LoadWaveFormat(music_track, &format)) {
 			memset(&format, 0, sizeof(WAVEFORMATEX));

--- a/defs.h
+++ b/defs.h
@@ -159,9 +159,6 @@
 #define DS_ERR_MSG(errorCode) \
 	DSErrMsg((errorCode), __LINE, __FILE)
 
-#define ASSERT_FAIL(failMsg) \
-	assert_fail(__LINE__, __FILE__, (failMsg))
-
 #ifndef INVALID_FILE_ATTRIBUTES
 #define INVALID_FILE_ATTRIBUTES ((DWORD)-1)
 #endif

--- a/defs.h
+++ b/defs.h
@@ -147,6 +147,21 @@
 #define assert(exp) (void)( (exp) || (assert_fail(__LINE__, __FILE__, #exp), 0) )
 #endif
 
+#define ERR_OK_DLG(templateId, errorCode) \
+	ErrOkDlg((templateId), (errorCode), __FILE__, __LINE__)
+
+#define ERR_DLG(templateId, errorCode) \
+	ErrDlg((templateId), (errorCode), __FILE__, __LINE__)
+
+#define DD_ERR_MSG(errorCode) \
+	DDErrMsg((errorCode), __LINE__, __FILE__)
+
+#define DS_ERR_MSG(errorCode) \
+	DSErrMsg((errorCode), __LINE, __FILE)
+
+#define ASSERT_FAIL(failMsg) \
+	assert_fail(__LINE__, __FILE__, (failMsg))
+
 #ifndef INVALID_FILE_ATTRIBUTES
 #define INVALID_FILE_ATTRIBUTES ((DWORD)-1)
 #endif


### PR DESCRIPTION
Fixing call sites which were lying about both the current file and line number. The line number specifically was annoying since it is not immediately obvious what it is when skimming function calls. 