### PR TITLE
fix Clang build

### DIFF
--- a/SourceS/miniwin.h
+++ b/SourceS/miniwin.h
@@ -14,7 +14,8 @@
 #include <string.h>
 #include <time.h>
 // For _rotr()
-#if !defined(_MSC_VER) && defined(DEVILUTION_ENGINE)
+// _rotl and _rotr are predeclared in Clang.
+#if !defined(_MSC_VER) && !defined(__clang__) && defined(DEVILUTION_ENGINE)
 #if defined(__x86_64__) || defined(__i386__)
 #include <x86intrin.h>
 #else


### PR DESCRIPTION
The following build error was observed when compiling with Clang:

	In file included from Source/appfat.cpp:1:
	In file included from ./Source/diablo.h:5:
	In file included from ./Source/../types.h:52:
	In file included from ./SourceS/miniwin.h:19:
	In file included from /usr/lib/clang/8.0.1/include/x86intrin.h:29:
	In file included from /usr/lib/clang/8.0.1/include/immintrin.h:28:
	/usr/lib/clang/8.0.1/include/mmintrin.h:81:40: error: cannot initialize a parameter of type
			'__attribute__((__vector_size__(2 * sizeof(int)))) int' (vector of 2 'int' values) with an rvalue of type
			'__v2si' (aka 'int')
		 return __builtin_ia32_vec_ext_v2si((__v2si)__m, 0);
														^~~~~~~~~~~
Clang version:

	$ clang -v
	clang version 8.0.1 (tags/RELEASE_801/final)

First I tried to replace the x86intrin.h include with:

	static inline unsigned int _rotl(unsigned int value, int shift)
	{
		return (value << shift) | (value >> (32 - shift));
	}
	static inline unsigned int _rotr(unsigned int value, int shift)
	{
		return (value >> shift) | (value << (32 - shift));
	}

But that resulted in an error stating that _rotl and _rotr were
predeclared in Clang:

	./SourceS/miniwin.h:20:28: error: definition of builtin function '_rotl'
	static inline unsigned int _rotl(unsigned int value, int shift)

Thus, we simply declare but don't define these functions when
using Clang.