### PR TITLE
64-bit multiplayer

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -55,7 +55,7 @@ TMegaPkt *msg_get_next_packet()
 {
 	TMegaPkt *result;
 
-	sgpCurrPkt = (TMegaPkt *)DiabloAllocPtr(32008);
+	sgpCurrPkt = (TMegaPkt *)DiabloAllocPtr(TMEGAPKT_SIZE);
 	sgpCurrPkt->pNext = NULL;
 	sgpCurrPkt->dwSpaceLeft = 32000;
 

--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -9,7 +9,7 @@ static CCritSect sgMemCrit;
 DWORD gdwDeltaBytesSec;
 BOOLEAN nthread_should_run;
 DWORD gdwTurnsInTransit;
-int glpMsgTbl[MAX_PLRS];
+uintptr_t glpMsgTbl[MAX_PLRS];
 unsigned int glpNThreadId;
 char sgbSyncCountdown;
 int turn_upper_bit;

--- a/Source/nthread.h
+++ b/Source/nthread.h
@@ -7,7 +7,7 @@ extern DWORD gdwMsgLenTbl[MAX_PLRS];
 extern DWORD gdwDeltaBytesSec;
 extern BOOLEAN nthread_should_run;
 extern DWORD gdwTurnsInTransit;
-extern int glpMsgTbl[MAX_PLRS];
+extern uintptr_t glpMsgTbl[MAX_PLRS];
 extern unsigned int glpNThreadId;
 extern int turn_upper_bit;
 extern BOOLEAN sgbThreadIsRunning;

--- a/SourceX/dvlnet/frame_queue.cpp
+++ b/SourceX/dvlnet/frame_queue.cpp
@@ -48,7 +48,12 @@ bool frame_queue::packet_ready()
 		if(size() < sizeof(framesize_t))
 			return false;
 		auto szbuf = read(sizeof(framesize_t));
+#ifdef __LP64__
+		std::memcpy(&nextsize, &szbuf[0], sizeof(framesize_t));
+		nextsize >> 32;
+#else
 		std::memcpy(&nextsize, &szbuf[0], sizeof(nextsize));
+#endif
 		if(!nextsize)
 			throw frame_queue_exception();
 	}

--- a/SourceX/dvlnet/frame_queue.cpp
+++ b/SourceX/dvlnet/frame_queue.cpp
@@ -48,7 +48,10 @@ bool frame_queue::packet_ready()
 		if(size() < sizeof(framesize_t))
 			return false;
 		auto szbuf = read(sizeof(framesize_t));
-#ifdef __LP64__
+#if defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) ||	\
+	defined(__LP64__) || defined(_M_X64) || defined(_M_ARM64) ||	\
+	defined(__aarch64__) || defined(__ppc64__) ||			\
+	defined(__powerpc64__) || defined(_ARCH_PPC64)
 		std::memcpy(&nextsize, &szbuf[0], sizeof(framesize_t));
 		nextsize >> 32;
 #else

--- a/structs.h
+++ b/structs.h
@@ -955,11 +955,14 @@ typedef struct DJunk {
 } DJunk;
 #pragma pack(pop)
 
+#pragma pack(push, 1)
 typedef struct TMegaPkt {
 	struct TMegaPkt *pNext;
 	DWORD dwSpaceLeft;
 	BYTE data[32000];
 } TMegaPkt;
+#pragma pack(pop)
+#define TMEGAPKT_SIZE sizeof(TMegaPkt)
 
 typedef struct TBuffer {
 	DWORD dwNextWriteOffset;


### PR DESCRIPTION
This pull request incorporates feedback from https://github.com/diasurgical/devilutionX/issues/191 to unbreak 64-bit TCP multiplayer. I packed the TMegaPkt struct as suggested by @AJenbo. In doing so, I kept usage of ifdef(\_\_LP64__) down to only one instance with the shift, as one of my goals was to use these sparingly.

I am a bit worried about the portability of the bitshift line on PowerPC. Perhaps this is something to consider in the BigEndian branch of devilutionX?

https://stackoverflow.com/questions/7184789/does-bit-shift-depend-on-endianness

> @jww: On PowerPC the vector shifts and rotates are endian sensitive. You can have a value in a vector register and a shift will produce different results on little-endian and big-endian.