### PR TITLE
Fix multiple voices playing simultaneously

### DIFF
--- a/SourceX/miniwin/dsound.cpp
+++ b/SourceX/miniwin/dsound.cpp
@@ -48,7 +48,14 @@ ULONG DirectSoundBuffer::Release()
  */
 HRESULT DirectSoundBuffer::GetStatus(LPDWORD pdwStatus)
 {
-	return DVL_DSERR_INVALIDPARAM;
+	for (int i = 1; i < Mix_AllocateChannels(-1); i++) {
+		if (Mix_GetChunk(i) == chunk && Mix_Playing(i)) {
+			*pdwStatus = DVL_DSBSTATUS_PLAYING;
+			break;
+		}
+	}
+
+	return DVL_DS_OK;
 };
 
 HRESULT DirectSoundBuffer::Lock(DWORD dwOffset, DWORD dwBytes, LPVOID *ppvAudioPtr1, LPDWORD pdwAudioBytes1,

--- a/SourceX/sound.cpp
+++ b/SourceX/sound.cpp
@@ -99,12 +99,12 @@ void snd_play_snd(TSnd *pSnd, int lVolume, int lPan)
 		return;
 	}
 
-	if (snd_playing(pSnd)) {
-		DSB = sound_dup_channel(pSnd->DSB);
-		if (DSB == NULL) {
-			return;
-		}
-	}
+	// if (snd_playing(pSnd)) {
+	// 	DSB = sound_dup_channel(pSnd->DSB);
+	// 	if (DSB == NULL) {
+	// 		return;
+	// 	}
+	// }
 
 	lVolume += sglSoundVolume;
 	if (lVolume < VOLUME_MIN) {


### PR DESCRIPTION
Fixes #252. I had to comment out a section in `SourceX/sound.cpp`, since `DuplicateSoundBuffer()` is unimplemented. If there's a better way, please let me know.