### PR TITLE
all: remove unused storm imports

### DIFF
--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -1,5 +1,4 @@
 #include "diablo.h"
-#include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -1,5 +1,4 @@
 #include "diablo.h"
-#include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1,5 +1,4 @@
 #include "diablo.h"
-#include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1,5 +1,4 @@
 #include "diablo.h"
-#include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -1,5 +1,4 @@
 #include "diablo.h"
-#include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 


### PR DESCRIPTION
While no storm functions are called from these source files
it is determined that they included storm in the original
source files as made visible by the inclusion of infinity
in the data segments of the respective source files.

ref: diasurgical/devilution#1695.