### PR TITLE
Optionally use SDL1 instead of SDL2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,19 @@ jobs:
       - run: cd build && cmake ..
       - run: cd build && make -j$(nproc)
       - store_artifacts: {path: ./build/devilutionx, destination: devilutionx_linux_x86_64}
+  linux_x86_64_sdl1:
+    docker:
+      - image: debian:stretch-backports
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run: apt-get update -y
+      - run: apt-get install -y cmake g++ libsdl-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev
+      - run: apt-get install -y -t stretch-backports libsodium-dev
+      - run: mkdir build
+      - run: cd build && cmake .. -DUSE_SDL1=ON
+      - run: cd build && make -j$(nproc)
+      - store_artifacts: {path: ./build/devilutionx, destination: devilutionx_linux_x86_64_sdl1}
   linux_x86:
     docker:
       - image: debian:stretch-backports
@@ -58,3 +71,4 @@ workflows:
       - linux_x86_64
       - linux_x86
       - windows_x86
+      - linux_x86_64_sdl1

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,5 +7,22 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+# TODO(#262): Normalize all C++ line endings to CRLF.
+[SourceX/miniwin/ddraw.*]
+end_of_line = lf
+
+[SourceX/miniwin/misc_*]
+end_of_line = lf
+
+[SourceX/miniwin/thread.*]
+end_of_line = lf
+
+[SourceX/storm/storm_dx.cpp]
+end_of_line = lf
+
+[*.yml]
+indent_style = space
+end_of_line = lf
+
 [*.sh]
 end_of_line = lf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ option(DIST "Dynamically link only glibc and SDL2" OFF)
 option(FASTER "Enable FASTER in engine" ON)
 option(BINARY_RELEASE "Enable options for binary release" OFF)
 option(NIGHTLY_BUILD "Enable options for nightly build" OFF)
+option(USE_SDL1 "Use SDL1.2 instead of SDL2" OFF)
 
 if(BINARY_RELEASE)
   set(CMAKE_BUILD_TYPE "Release")
@@ -60,13 +61,21 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 
 find_package(Threads REQUIRED)
-find_package(SDL2 CONFIG QUIET)
-if (NOT SDL2_FOUND)
-	find_package(SDL2 REQUIRED)
-endif()
-find_package(SDL2_ttf REQUIRED)
-find_package(SDL2_mixer REQUIRED)
 find_package(sodium REQUIRED)
+
+if(USE_SDL1)
+	find_package(SDL REQUIRED)
+	find_package(SDL_ttf REQUIRED)
+	find_package(SDL_mixer REQUIRED)
+	include_directories(${SDL_INCLUDE_DIR})
+else()
+	find_package(SDL2 CONFIG QUIET)
+	if (NOT SDL2_FOUND)
+		find_package(SDL2 REQUIRED)
+	endif()
+	find_package(SDL2_ttf REQUIRED)
+	find_package(SDL2_mixer REQUIRED)
+endif()
 
 add_library(smacker STATIC
   3rdParty/libsmacker/smk_bitstream.c
@@ -214,9 +223,6 @@ target_link_libraries(devilutionx PRIVATE
   StormLib
   smacker
   Radon
-  SDL2::SDL2main
-  SDL2::SDL2_ttf
-  SDL2::SDL2_mixer
   sodium)
 
 target_compile_definitions(devilution PRIVATE DEVILUTION_ENGINE)
@@ -226,6 +232,18 @@ target_compile_definitions(devilution PUBLIC
   # Skip fades and other fluff
   "$<$<BOOL:${FASTER}>:FASTER>")
 target_compile_definitions(devilutionx PRIVATE ASIO_STANDALONE)
+
+
+if(USE_SDL1)
+  target_link_libraries(devilutionx PRIVATE
+    ${SDL_LIBRARY} ${SDL_TTF_LIBRARY} ${SDL_MIXER_LIBRARY})
+  target_compile_definitions(devilutionx PRIVATE USE_SDL1)
+else()
+  target_link_libraries(devilutionx PRIVATE
+    SDL2::SDL2main
+    SDL2::SDL2_ttf
+    SDL2::SDL2_mixer)
+endif()
 
 if(ASAN)
   target_compile_options(devilution PUBLIC -fsanitize=address -fsanitize-recover=address)

--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ The default build type is `Debug`. This can be changed with `-DBINARY_RELEASE=ON
 You can also generate 32bit builds on 64bit platforms by setting `-DCMAKE_TOOLCHAIN_FILE=../CMake/32bit.cmake` (remember to use the `linux32` command if on Linux).
 ### mingw32
 Use `-DCROSS_PREFIX=/path/to/prefix` if the `i686-w64-mingw32` directory is not in `/usr`.
-
+### Use SDL v1 instead of SDL v2.
+Pass `-DUSE_SDL1=ON` to build with SDL v1 instead of v2.
+Note that some features are not yet supported in SDL v1, notably sound, upscaling, and fullscreen.
 
 # Multiplayer
  - TCP/IP only requires the host to expose port 6112

--- a/SourceS/devilution.h
+++ b/SourceS/devilution.h
@@ -1,2 +1,5 @@
 #include "diablo.h"
+#ifdef USE_SDL1
+#include "sdl2_to_1_2_backports.h"
+#endif
 #include "../3rdParty/Storm/Source/storm.h"

--- a/SourceS/sdl2_to_1_2_backports.h
+++ b/SourceS/sdl2_to_1_2_backports.h
@@ -1,0 +1,506 @@
+#pragma once
+
+#include <SDL.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "stubs.h"
+
+#define WINDOW_ICON_NAME 0
+
+//== Utility
+
+#define SDL_zero(x) SDL_memset(&(x), 0, sizeof((x)))
+#define SDL_InvalidParamError(param) SDL_SetError("Parameter '%s' is invalid", (param))
+#define SDL_Log puts
+
+//== Events handling
+
+#define SDL_Keysym SDL_keysym
+#define SDL_Keycode SDLKey
+
+#define SDLK_PRINTSCREEN SDLK_PRINT
+#define SDLK_SCROLLLOCK SDLK_SCROLLOCK
+#define SDLK_NUMLOCKCLEAR SDLK_NUMLOCK
+#define SDLK_KP_1 SDLK_KP1
+#define SDLK_KP_2 SDLK_KP2
+#define SDLK_KP_3 SDLK_KP3
+#define SDLK_KP_4 SDLK_KP4
+#define SDLK_KP_5 SDLK_KP5
+#define SDLK_KP_6 SDLK_KP6
+#define SDLK_KP_7 SDLK_KP7
+#define SDLK_KP_8 SDLK_KP8
+#define SDLK_KP_9 SDLK_KP9
+#define SDLK_KP_0 SDLK_KP0
+#define SDLK_LGUI SDLK_LSUPER
+#define SDLK_RGUI SDLK_RSUPER
+
+// Haptic events are not supported in SDL1.
+#define SDL_INIT_HAPTIC 0
+
+// For now we only process ASCII input when using SDL1.
+#define SDL_TEXTINPUTEVENT_TEXT_SIZE 2
+
+static SDL_bool SDLBackport_IsTextInputActive = SDL_FALSE;
+
+inline SDL_bool SDL_IsTextInputActive()
+{
+	return SDLBackport_IsTextInputActive;
+}
+
+inline void SDL_StartTextInput()
+{
+	SDLBackport_IsTextInputActive = SDL_TRUE;
+}
+inline void SDL_StopTextInput()
+{
+	SDLBackport_IsTextInputActive = SDL_FALSE;
+}
+
+//== Graphics helpers
+
+typedef struct SDL_Point {
+	int x;
+	int y;
+} SDL_Point;
+
+inline SDL_bool SDL_PointInRect(const SDL_Point *p, const SDL_Rect *r)
+{
+	return ((p->x >= r->x) && (p->x < (r->x + r->w)) && (p->y >= r->y) && (p->y < (r->y + r->h))) ? SDL_TRUE : SDL_FALSE;
+}
+
+//= Messagebox (simply logged to stderr for now)
+
+typedef enum {
+	SDL_MESSAGEBOX_ERROR       = 0x00000010, /**< error dialog */
+	SDL_MESSAGEBOX_WARNING     = 0x00000020, /**< warning dialog */
+	SDL_MESSAGEBOX_INFORMATION = 0x00000040  /**< informational dialog */
+} SDL_MessageBoxFlags;
+
+inline int SDL_ShowSimpleMessageBox(Uint32 flags,
+    const char *title,
+    const char *message,
+    SDL_Surface *window)
+{
+	fprintf(stderr, "MSGBOX: %s\n%s\n", title, message);
+	return 0;
+}
+
+//= Window handling
+
+#define SDL_Window SDL_Surface
+
+inline void SDL_GetWindowPosition(SDL_Window *window, int *x, int *y)
+{
+	*x = window->clip_rect.x;
+	*y = window->clip_rect.x;
+	printf("SDL_GetWindowPosition %d %d", *x, *y);
+}
+
+inline void SDL_SetWindowPosition(SDL_Window *window, int x, int y) {
+	DUMMY();
+}
+
+inline void SDL_GetWindowSize(SDL_Window *window, int *w, int *h)
+{
+	*w = window->clip_rect.w;
+	*h = window->clip_rect.h;
+	printf("SDL_GetWindowSize %d %d", *w, *h);
+}
+
+inline void SDL_ShowWindow(SDL_Window *window)
+{
+	DUMMY();
+}
+
+inline void SDL_HideWindow(SDL_Window *window)
+{
+	DUMMY();
+}
+
+inline void SDL_RaiseWindow(SDL_Window *window)
+{
+	DUMMY();
+}
+
+inline void SDL_DestroyWindow(SDL_Window *window)
+{
+	SDL_FreeSurface(window);
+}
+
+inline void
+SDL_WarpMouseInWindow(SDL_Window * window, int x, int y)
+{
+	SDL_WarpMouse(x, y);
+}
+
+
+//= Renderer stubs
+
+#define SDL_Renderer void
+
+inline void SDL_DestroyRenderer(SDL_Renderer *renderer)
+{
+	if (renderer != NULL)
+		UNIMPLEMENTED();
+}
+
+//= Texture stubs
+
+#define SDL_Texture void
+
+inline void SDL_DestroyTexture(SDL_Texture *texture)
+{
+	if (texture != NULL)
+		UNIMPLEMENTED();
+}
+
+//= Palette handling
+
+inline SDL_Palette *
+SDL_AllocPalette(int ncolors)
+{
+	SDL_Palette *palette;
+
+	/* Input validation */
+	if (ncolors < 1) {
+		SDL_InvalidParamError("ncolors");
+		return NULL;
+	}
+
+	palette = (SDL_Palette *)SDL_malloc(sizeof(*palette));
+	if (!palette) {
+		SDL_OutOfMemory();
+		return NULL;
+	}
+	palette->colors = (SDL_Color *)SDL_malloc(ncolors * sizeof(*palette->colors));
+	if (!palette->colors) {
+		SDL_free(palette);
+		return NULL;
+	}
+	palette->ncolors = ncolors;
+	SDL_memset(palette->colors, 0xFF, ncolors * sizeof(*palette->colors));
+	return palette;
+}
+
+inline void
+SDL_FreePalette(SDL_Palette *palette)
+{
+	if (!palette) {
+		SDL_InvalidParamError("palette");
+		return;
+	}
+	SDL_free(palette->colors);
+	SDL_free(palette);
+}
+
+inline int SDL_SetPaletteColors(SDL_Palette *palette, const SDL_Color *colors,
+    int firstcolor, int ncolors)
+{
+	int status = 0;
+
+	/* Verify the parameters */
+	if (!palette) {
+		return -1;
+	}
+	if (ncolors > (palette->ncolors - firstcolor)) {
+		ncolors = (palette->ncolors - firstcolor);
+		status  = -1;
+	}
+
+	if (colors != (palette->colors + firstcolor)) {
+		SDL_memcpy(palette->colors + firstcolor, colors,
+		    ncolors * sizeof(*colors));
+	}
+
+	return status;
+}
+
+//= Pixel formats
+
+#define SDL_PIXELFORMAT_RGBA8888 1
+#define SDL_PIXELFORMAT_INDEX8 2
+
+inline void SDLBackport_PixelformatToMask(int pixelformat, Uint32 *flags, Uint32 *rmask,
+    Uint32 *gmask,
+    Uint32 *bmask,
+    Uint32 *amask)
+{
+	if (pixelformat == SDL_PIXELFORMAT_RGBA8888) {
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+		*rmask = 0xff000000;
+		*gmask = 0x00ff0000;
+		*bmask = 0x0000ff00;
+		*amask = 0x000000ff;
+#else
+		*rmask = 0x000000ff;
+		*gmask = 0x0000ff00;
+		*bmask = 0x00ff0000;
+		*amask = 0xff000000;
+#endif
+	}
+}
+
+//= Surface creation
+
+inline SDL_Surface *
+SDL_CreateRGBSurfaceWithFormat(Uint32 flags, int width, int height, int depth,
+    Uint32 format)
+{
+	Uint32 rmask, gmask, bmask, amask;
+	SDLBackport_PixelformatToMask(format, &flags, &rmask, &gmask, &bmask, &amask);
+	return SDL_CreateRGBSurface(flags, width, height, depth, rmask, gmask, bmask, amask);
+}
+
+inline SDL_Surface *
+SDL_CreateRGBSurfaceWithFormatFrom(void *pixels, Uint32 flags, int width, int height, int depth,
+    Uint32 format)
+{
+	Uint32 rmask, gmask, bmask, amask;
+	SDLBackport_PixelformatToMask(format, &flags, &rmask, &gmask, &bmask, &amask);
+	return SDL_CreateRGBSurfaceFrom(pixels, flags, width, height, depth, rmask, gmask, bmask, amask);
+}
+
+//= Display handling
+
+typedef struct
+{
+	Uint32 format;    /**< pixel format */
+	int w;            /**< width, in screen coordinates */
+	int h;            /**< height, in screen coordinates */
+	int refresh_rate; /**< refresh rate (or zero for unspecified) */
+	void *driverdata; /**< driver-specific data, initialize to 0 */
+} SDL_DisplayMode;
+
+inline int SDL_GetCurrentDisplayMode(int displayIndex, SDL_DisplayMode *mode)
+{
+	if (displayIndex != 0)
+		UNIMPLEMENTED();
+
+	const SDL_VideoInfo *info = SDL_GetVideoInfo();
+	if (info == NULL)
+		return 0;
+
+	switch (info->vfmt->BitsPerPixel) {
+	case 8:
+		mode->format = SDL_PIXELFORMAT_INDEX8;
+	case 32:
+		mode->format = SDL_PIXELFORMAT_RGBA8888;
+	default:
+		mode->format = 0;
+	}
+
+	mode->w            = info->current_w;
+	mode->h            = info->current_h;
+	mode->refresh_rate = 0;
+	mode->driverdata   = NULL;
+
+	return 0;
+}
+
+//== Filesystem
+
+#if !defined(__QNXNTO__)
+inline char *
+readSymLink(const char *path)
+{
+	// From sdl2-2.0.9/src/filesystem/unix/SDL_sysfilesystem.c
+	char *retval = NULL;
+	ssize_t len  = 64;
+	ssize_t rc   = -1;
+
+	while (1) {
+		char *ptr = (char *)SDL_realloc(retval, (size_t)len);
+		if (ptr == NULL) {
+			SDL_OutOfMemory();
+			break;
+		}
+
+		retval = ptr;
+
+		rc = readlink(path, retval, len);
+		if (rc == -1) {
+			break; /* not a symlink, i/o error, etc. */
+		} else if (rc < len) {
+			retval[rc] = '\0'; /* readlink doesn't null-terminate. */
+			return retval;     /* we're good to go. */
+		}
+
+		len *= 2; /* grow buffer, try again. */
+	}
+
+	SDL_free(retval);
+	return NULL;
+}
+#endif
+
+inline char *SDL_GetBasePath()
+{
+	// From sdl2-2.0.9/src/filesystem/unix/SDL_sysfilesystem.c
+
+	char *retval = NULL;
+
+#if defined(__FREEBSD__)
+	char fullpath[PATH_MAX];
+	size_t buflen   = sizeof(fullpath);
+	const int mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+	if (sysctl(mib, SDL_arraysize(mib), fullpath, &buflen, NULL, 0) != -1) {
+		retval = SDL_strdup(fullpath);
+		if (!retval) {
+			SDL_OutOfMemory();
+			return NULL;
+		}
+	}
+#endif
+#if defined(__OPENBSD__)
+	char **retvalargs;
+	size_t len;
+	const int mib[] = { CTL_KERN, KERN_PROC_ARGS, getpid(), KERN_PROC_ARGV };
+	if (sysctl(mib, 4, NULL, &len, NULL, 0) != -1) {
+		retvalargs = SDL_malloc(len);
+		if (!retvalargs) {
+			SDL_OutOfMemory();
+			return NULL;
+		}
+		sysctl(mib, 4, retvalargs, &len, NULL, 0);
+		retval = SDL_malloc(PATH_MAX + 1);
+		if (retval)
+			realpath(retvalargs[0], retval);
+
+		SDL_free(retvalargs);
+	}
+#endif
+#if defined(__SOLARIS__)
+	const char *path = getexecname();
+	if ((path != NULL) && (path[0] == '/')) { /* must be absolute path... */
+		retval = SDL_strdup(path);
+		if (!retval) {
+			SDL_OutOfMemory();
+			return NULL;
+		}
+	}
+#endif
+
+	/* is a Linux-style /proc filesystem available? */
+	if (!retval && (access("/proc", F_OK) == 0)) {
+		/* !!! FIXME: after 2.0.6 ships, let's delete this code and just
+                      use the /proc/%llu version. There's no reason to have
+                      two copies of this plus all the #ifdefs. --ryan. */
+#if defined(__FREEBSD__)
+		retval = readSymLink("/proc/curproc/file");
+#elif defined(__NETBSD__)
+		retval = readSymLink("/proc/curproc/exe");
+#elif defined(__QNXNTO__)
+		retval = SDL_LoadFile("/proc/self/exefile", NULL);
+#else
+		retval = readSymLink("/proc/self/exe"); /* linux. */
+		if (retval == NULL) {
+			/* older kernels don't have /proc/self ... try PID version... */
+			char path[64];
+			const int rc = (int)SDL_snprintf(path, sizeof(path),
+			    "/proc/%llu/exe",
+			    (unsigned long long)getpid());
+			if ((rc > 0) && (rc < sizeof(path))) {
+				retval = readSymLink(path);
+			}
+		}
+#endif
+	}
+
+	/* If we had access to argv[0] here, we could check it for a path,
+        or troll through $PATH looking for it, too. */
+
+	if (retval != NULL) { /* chop off filename. */
+		char *ptr = SDL_strrchr(retval, '/');
+		if (ptr != NULL) {
+			*(ptr + 1) = '\0';
+		} else { /* shouldn't happen, but just in case... */
+			SDL_free(retval);
+			retval = NULL;
+		}
+	}
+
+	if (retval != NULL) {
+		/* try to shrink buffer... */
+		char *ptr = (char *)SDL_realloc(retval, strlen(retval) + 1);
+		if (ptr != NULL)
+			retval = ptr; /* oh well if it failed. */
+	}
+
+	return retval;
+}
+
+inline char *SDL_GetPrefPath(const char *org, const char *app)
+{
+	// From sdl2-2.0.9/src/filesystem/unix/SDL_sysfilesystem.c
+	/*
+     * We use XDG's base directory spec, even if you're not on Linux.
+     *  This isn't strictly correct, but the results are relatively sane
+     *  in any case.
+     *
+     * http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+     */
+	const char *envr = SDL_getenv("XDG_DATA_HOME");
+	const char *append;
+	char *retval = NULL;
+	char *ptr    = NULL;
+	size_t len   = 0;
+
+	if (!app) {
+		SDL_InvalidParamError("app");
+		return NULL;
+	}
+	if (!org) {
+		org = "";
+	}
+
+	if (!envr) {
+		/* You end up with "$HOME/.local/share/Game Name 2" */
+		envr = SDL_getenv("HOME");
+		if (!envr) {
+			/* we could take heroic measures with /etc/passwd, but oh well. */
+			SDL_SetError("neither XDG_DATA_HOME nor HOME environment is set");
+			return NULL;
+		}
+		append = "/.local/share/";
+	} else {
+		append = "/";
+	}
+
+	len = SDL_strlen(envr);
+	if (envr[len - 1] == '/')
+		append += 1;
+
+	len += SDL_strlen(append) + SDL_strlen(org) + SDL_strlen(app) + 3;
+	retval = (char *)SDL_malloc(len);
+	if (!retval) {
+		SDL_OutOfMemory();
+		return NULL;
+	}
+
+	if (*org) {
+		SDL_snprintf(retval, len, "%s%s%s/%s/", envr, append, org, app);
+	} else {
+		SDL_snprintf(retval, len, "%s%s%s/", envr, append, app);
+	}
+
+	for (ptr = retval + 1; *ptr; ptr++) {
+		if (*ptr == '/') {
+			*ptr = '\0';
+			if (mkdir(retval, 0700) != 0 && errno != EEXIST)
+				goto error;
+			*ptr = '/';
+		}
+	}
+	if (mkdir(retval, 0700) != 0 && errno != EEXIST) {
+	error:
+		SDL_SetError("Couldn't create directory '%s': '%s'", retval, strerror(errno));
+		SDL_free(retval);
+		return NULL;
+	}
+
+	return retval;
+}

--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -220,17 +220,21 @@ bool UiFocusNavigation(SDL_Event *event)
 	case SDL_KEYUP:
 	case SDL_MOUSEBUTTONUP:
 	case SDL_MOUSEMOTION:
+#ifndef USE_SDL1
 	case SDL_MOUSEWHEEL:
+#endif
 	case SDL_JOYBUTTONUP:
 	case SDL_JOYAXISMOTION:
 	case SDL_JOYBALLMOTION:
 	case SDL_JOYHATMOTION:
+#ifndef USE_SDL1
 	case SDL_FINGERUP:
 	case SDL_FINGERMOTION:
 	case SDL_CONTROLLERBUTTONUP:
 	case SDL_CONTROLLERAXISMOTION:
-	case SDL_SYSWMEVENT:
 	case SDL_WINDOWEVENT:
+#endif
+	case SDL_SYSWMEVENT:
 		mainmenu_restart_repintro();
 	}
 
@@ -267,8 +271,9 @@ bool UiFocusNavigation(SDL_Event *event)
 
 	if (SDL_IsTextInputActive()) {
 		switch (event->type) {
-		case SDL_KEYDOWN:
+		case SDL_KEYDOWN: {
 			switch (event->key.keysym.sym) {
+#ifndef USE_SDL1
 			case SDLK_v:
 				if (SDL_GetModState() & KMOD_CTRL) {
 					char *clipboard = SDL_GetClipboardText();
@@ -278,6 +283,7 @@ bool UiFocusNavigation(SDL_Event *event)
 					selhero_CatToName(clipboard, UiTextInput, UiTextInputLen);
 				}
 				return true;
+#endif
 			case SDLK_BACKSPACE:
 			case SDLK_LEFT:
 				int nameLen = strlen(UiTextInput);
@@ -286,10 +292,24 @@ bool UiFocusNavigation(SDL_Event *event)
 				}
 				return true;
 			}
+#ifdef USE_SDL1
+			if ((event->key.keysym.mod & KMOD_CTRL) == 0) {
+				Uint16 unicode = event->key.keysym.unicode;
+				if (unicode && (unicode & 0xFF80) == 0) {
+					char utf8[SDL_TEXTINPUTEVENT_TEXT_SIZE];
+					utf8[0] = (char) unicode;
+					utf8[1] = '\0';
+					selhero_CatToName(utf8, UiTextInput, UiTextInputLen);
+				}
+			}
+#endif
 			break;
+		}
+#ifndef USE_SDL1
 		case SDL_TEXTINPUT:
 			selhero_CatToName(event->text.text, UiTextInput, UiTextInputLen);
 			return true;
+#endif
 		}
 	}
 
@@ -821,7 +841,11 @@ bool UiItemMouseEvents(SDL_Event *event, UI_Item *items, int size)
 			if (items[i].caption != NULL && *items[i].caption != '\0') {
 				if (gfnListFocus != NULL && SelectedItem != items[i].value) {
 					UiFocus(items[i].value);
+#ifdef USE_SDL1
+				} else if (gfnListFocus == NULL) {
+#else
 				} else if (gfnListFocus == NULL || event->button.clicks >= 2) {
+#endif
 					SelectedItem = items[i].value;
 					UiFocusNavigationSelect();
 				}
@@ -848,6 +872,7 @@ void DrawMouse()
 {
 	SDL_GetMouseState(&MouseX, &MouseY);
 
+#ifndef USE_SDL1
 	if (renderer) {
 		float scaleX;
 		SDL_RenderGetScale(renderer, &scaleX, NULL);
@@ -859,6 +884,7 @@ void DrawMouse()
 		MouseX -= view.x;
 		MouseY -= view.y;
 	}
+#endif
 
 	DrawArt(MouseX, MouseY, &ArtCursor);
 }

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -22,6 +22,7 @@ HMODULE ghDiabMod;
 void dx_init(HWND hWnd)
 {
 	SetFocus(hWnd);
+
 	SDL_ShowWindow(window);
 
 	lpDDInterface = new StubDraw();

--- a/SourceX/miniwin/ddraw.h
+++ b/SourceX/miniwin/ddraw.h
@@ -6,6 +6,7 @@ namespace dvl {
 extern SDL_Window *window;
 extern SDL_Renderer *renderer;
 extern SDL_Texture *texture;
+
 extern SDL_Surface *surface;
 extern SDL_Palette *palette;
 extern SDL_Surface *pal_surface;

--- a/SourceX/miniwin/misc_dx.cpp
+++ b/SourceX/miniwin/misc_dx.cpp
@@ -9,6 +9,7 @@ WINBOOL SetCursorPos(int X, int Y)
 {
 	assert(window);
 
+#ifndef USE_SDL1
 	if (renderer) {
 		SDL_Rect view;
 		SDL_RenderGetViewport(renderer, &view);
@@ -20,6 +21,7 @@ WINBOOL SetCursorPos(int X, int Y)
 		X *= scaleX;
 		Y *= scaleX;
 	}
+#endif
 
 	SDL_WarpMouseInWindow(window, X, Y);
 	return true;
@@ -39,7 +41,11 @@ WINBOOL TextOutA(HDC hdc, int x, int y, LPCSTR lpString, int c)
 	DUMMY_ONCE();
 
 	assert(window);
+#ifdef USE_SDL1
+	SDL_WM_SetCaption(lpString, WINDOW_ICON_NAME);
+#else
 	SDL_SetWindowTitle(window, lpString);
+#endif
 
 	return true;
 }

--- a/SourceX/miniwin/misc_msg.cpp
+++ b/SourceX/miniwin/misc_msg.cpp
@@ -17,7 +17,7 @@ static int translate_sdl_key(SDL_Keysym key)
 {
 	// ref: https://wiki.libsdl.org/SDL_Keycode
 	// ref: https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
-	int sym = key.sym;
+	SDL_Keycode sym = key.sym;
 	switch (sym) {
 	case SDLK_BACKSPACE:
 		return DVL_VK_BACK;
@@ -145,8 +145,10 @@ static int translate_sdl_key(SDL_Keysym key)
 		return DVL_VK_DECIMAL;
 	case SDLK_MENU:
 		return DVL_VK_MENU;
+#ifndef USE_SDL1
 	case SDLK_KP_COMMA:
 		return DVL_VK_OEM_COMMA;
+#endif
 	case SDLK_LCTRL:
 		return DVL_VK_LCONTROL;
 	case SDLK_LSHIFT:
@@ -178,9 +180,7 @@ static int translate_sdl_key(SDL_Keysym key)
 
 static WPARAM keystate_for_mouse(WPARAM ret)
 {
-	const Uint8 *keystate = SDL_GetKeyboardState(NULL);
-	ret |= keystate[SDL_SCANCODE_LSHIFT] ? DVL_MK_SHIFT : 0;
-	ret |= keystate[SDL_SCANCODE_RSHIFT] ? DVL_MK_SHIFT : 0;
+	ret |= (SDL_GetModState() & KMOD_SHIFT) ? DVL_MK_SHIFT : 0;
 	// XXX: other DVL_MK_* codes not implemented
 	return ret;
 }
@@ -271,6 +271,7 @@ WINBOOL PeekMessageA(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilter
 			return false_avail();
 		}
 	} break;
+#ifndef USE_SDL1
 	case SDL_TEXTINPUT:
 	case SDL_WINDOWEVENT:
 		if (e.window.event == SDL_WINDOWEVENT_CLOSE) {
@@ -279,6 +280,7 @@ WINBOOL PeekMessageA(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilter
 			return false_avail();
 		}
 		break;
+#endif
 	default:
 		DUMMY_PRINT("unknown SDL message 0x%X", e.type);
 		return false_avail();

--- a/SourceX/miniwin/thread.cpp
+++ b/SourceX/miniwin/thread.cpp
@@ -38,7 +38,11 @@ uintptr_t DVL_beginthreadex(void *_Security, unsigned _StackSize, unsigned (*_St
 	func_translate *ft = new func_translate;
 	ft->func = _StartAddress;
 	ft->arg = _ArgList;
+#ifdef USE_SDL1
+	SDL_Thread *ret = SDL_CreateThread(thread_translate, ft);
+#else
 	SDL_Thread *ret = SDL_CreateThread(thread_translate, NULL, ft);
+#endif
 	if (ret == NULL) {
 		SDL_Log(SDL_GetError());
 	}

--- a/SourceX/sound.cpp
+++ b/SourceX/sound.cpp
@@ -410,7 +410,7 @@ void music_start(int nTrack)
 			if (musicRw == NULL) {
 				SDL_Log(SDL_GetError());
 			}
-			music = Mix_LoadMUS_RW(musicRw, 1);
+			music = Mix_LoadMUSType_RW(musicRw, MUS_NONE, 1);
 			Mix_VolumeMusic(MIX_MAX_VOLUME - MIX_MAX_VOLUME * sglMusicVolume / VOLUME_MIN);
 			Mix_PlayMusic(music, -1);
 

--- a/SourceX/storm/storm_dx.cpp
+++ b/SourceX/storm/storm_dx.cpp
@@ -18,7 +18,9 @@ BOOL SDrawUpdatePalette(unsigned int firstentry, unsigned int numentries, PALETT
 		c->r = p->peRed;
 		c->g = p->peGreen;
 		c->b = p->peBlue;
+#ifndef USE_SDL1
 		c->a = SDL_ALPHA_OPAQUE;
+#endif
 	}
 
 	assert(palette);
@@ -26,6 +28,18 @@ BOOL SDrawUpdatePalette(unsigned int firstentry, unsigned int numentries, PALETT
 		SDL_Log(SDL_GetError());
 		return false;
 	}
+
+#ifdef USE_SDL1
+	// In SDL2, the `pal_surface` owns the `pallete`, so modifying the palette
+	// directly updates the `pal_surface` palette.
+	//
+	// In SDL1, the `palette` is independent of `pal_surface`, so we need to
+	// explictly update the surface's palette here (SetPalette *copies* the palette).
+	if (SDL_SetPalette(pal_surface, SDL_LOGPAL, palette->colors, 0, palette->ncolors) != 1) {
+		SDL_Log(SDL_GetError());
+		return false;
+	}
+#endif
 
 	return true;
 }


### PR DESCRIPTION
Adds a `USE_SDL1` build option to use SDL v1 instead of v2.

This is useful for porting Diablo onto devices that don't support SDL2,
such as the RetroFW / OpenDingux devices (e.g. RG300 Retro Gaming Handheld)

Not yet supported:
* Fullscreen
* Upscaling
* Audio

Achieved by backporting some functions from SDL2 and scattering a few ifdefs.

I understand if you don't want to merge this.