### PR TITLE
Fix some compiler warnings

### DIFF
--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -603,7 +603,7 @@ void DrawArt(int screenX, int screenY, Art *art, int nFrame, DWORD drawW)
 		return;
 
 	SDL_Rect src_rect = { 0, nFrame * art->h(), art->w(), art->h() };
-	if (drawW && drawW < src_rect.w)
+	if (drawW && static_cast<int>(drawW) < src_rect.w)
 		src_rect.w = drawW;
 	SDL_Rect dst_rect = { screenX + SCREEN_X, screenY + SCREEN_Y, src_rect.w, src_rect.h };
 

--- a/SourceX/dvlnet/frame_queue.cpp
+++ b/SourceX/dvlnet/frame_queue.cpp
@@ -62,7 +62,7 @@ buffer_t frame_queue::read_packet()
 {
 	if(!nextsize || (size() < nextsize))
 		throw frame_queue_exception();
-	auto ret = std::move(read(nextsize));
+	auto ret = read(nextsize);
 	nextsize = 0;
 	return ret;
 }

--- a/SourceX/dvlnet/udp_p2p.h
+++ b/SourceX/dvlnet/udp_p2p.h
@@ -24,8 +24,6 @@ private:
 	typedef asio::ip::udp::endpoint endpoint;
 	static const endpoint none;
 
-	unsigned short udpport_self = 0;
-
 	static constexpr unsigned short default_port = 6112;
 	static constexpr unsigned short try_ports = 512;
 	static constexpr int ACTIVE = 60;

--- a/SourceX/miniwin/misc_msg.cpp
+++ b/SourceX/miniwin/misc_msg.cpp
@@ -187,7 +187,7 @@ static WPARAM keystate_for_mouse(WPARAM ret)
 
 static WINBOOL false_avail()
 {
-	DUMMY_PRINT("return false although event available", 1);
+	DUMMY_PRINT("return %s although event available", "false");
 	return false;
 }
 

--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -163,7 +163,7 @@ BOOL SFileOpenFile(const char *filename, HANDLE *phFile)
 	if (directFileAccess) {
 		char directPath[DVL_MAX_PATH] = "\0";
 		for (size_t i = 0; i < strlen(filename); i++) {
-			directPath[i] = AsciiToLowerTable_Path[filename[i]];
+			directPath[i] = AsciiToLowerTable_Path[static_cast<unsigned char>(filename[i])];
 		}
 		result = SFileOpenFileEx((HANDLE)0, directPath, 0xFFFFFFFF, phFile);
 	}


### PR DESCRIPTION
```
SourceX/miniwin/misc_msg.cpp:190:55: warning: data argument not used by format string [-Wformat-extra-args]
        DUMMY_PRINT("return false although event available", 1);

SourceX/dvlnet/frame_queue.cpp:65:13: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
        auto ret = std::move(read(nextsize));

SourceX/DiabloUI/diabloui.cpp:606:21: warning: comparison of integers of different signs: 'dvl::DWORD' (aka 'unsigned int') and 'int' [-Wsign-compare]
        if (drawW && drawW < src_rect.w)

SourceX/dvlnet/udp_p2p.h:27:17: warning: private field 'udpport_self' is not used [-Wunused-private-field]
        unsigned short udpport_self = 0;
```