### PR TITLE
Update music to always use WAV, instead of detecting it

### DIFF
--- a/SourceX/sound.cpp
+++ b/SourceX/sound.cpp
@@ -212,7 +212,7 @@ void music_start(int nTrack)
 			if (musicRw == NULL) {
 				SDL_Log(SDL_GetError());
 			}
-			music = Mix_LoadMUSType_RW(musicRw, MUS_NONE, 1);
+			music = Mix_LoadMUSType_RW(musicRw, MUS_WAV, 1);
 			Mix_VolumeMusic(MIX_MAX_VOLUME - MIX_MAX_VOLUME * sglMusicVolume / VOLUME_MIN);
 			Mix_PlayMusic(music, -1);
 


### PR DESCRIPTION
Is there even possibility that audio files might have different format? If not maybe it's better to assume we are always playing WAV files here.