### PR TITLE
dvlnet: More C++11 compatibility

### DIFF
--- a/SourceX/dvlnet/tcp_client.cpp
+++ b/SourceX/dvlnet/tcp_client.cpp
@@ -99,10 +99,11 @@ void tcp_client::handle_send(const asio::error_code &error, size_t bytes_sent)
 
 void tcp_client::send(packet &pkt)
 {
-	auto frame = std::make_shared<buffer_t>(frame_queue::make_frame(pkt.data()));
+	const auto *frame = new buffer_t(frame_queue::make_frame(pkt.data()));
 	auto buf = asio::buffer(*frame);
-	asio::async_write(sock, buf, [this, frame = std::move(frame)](const asio::error_code &error, size_t bytes_sent) {
+	asio::async_write(sock, buf, [this, frame](const asio::error_code &error, size_t bytes_sent) {
 		handle_send(error, bytes_sent);
+		delete frame;
 	});
 }
 

--- a/SourceX/dvlnet/tcp_server.cpp
+++ b/SourceX/dvlnet/tcp_server.cpp
@@ -136,11 +136,12 @@ void tcp_server::send_packet(packet &pkt)
 
 void tcp_server::start_send(scc con, packet &pkt)
 {
-	auto frame = std::make_shared<buffer_t>(frame_queue::make_frame(pkt.data()));
+	const auto *frame = new buffer_t(frame_queue::make_frame(pkt.data()));
 	auto buf = asio::buffer(*frame);
 	asio::async_write(con->socket, buf,
-		[this, con, frame = std::move(frame)](const asio::error_code &ec, size_t bytes_sent) {
+		[this, con, frame](const asio::error_code &ec, size_t bytes_sent) {
 			handle_send(con, ec, bytes_sent);
+			delete frame;
 		});
 }
 


### PR DESCRIPTION
Fixes the following warnings:

```
SourceX/dvlnet/tcp_client.cpp:104:38:
  warning: lambda capture initializers only available with -std=c++14 or -std=gnu++14
SourceX/dvlnet/tcp_server.cpp:142:15:
  warning: lambda capture initializers only available with -std=c++14 or -std=gnu++14
```