### PR TITLE
Fix more compilation warnings

### DIFF
--- a/SourceS/sdl2_to_1_2_backports.h
+++ b/SourceS/sdl2_to_1_2_backports.h
@@ -603,25 +603,34 @@ SDL_UpperBlitScaled(SDL_Surface *src, SDL_Rect *srcrect,
 	dst_y0 += dst->clip_rect.y;
 	dst_y1 += dst->clip_rect.y;
 
-	final_src.x = (int)SDL_floor(src_x0 + 0.5);
-	final_src.y = (int)SDL_floor(src_y0 + 0.5);
-	final_src.w = (int)SDL_floor(src_x1 + 1 + 0.5) - (int)SDL_floor(src_x0 + 0.5);
-	final_src.h = (int)SDL_floor(src_y1 + 1 + 0.5) - (int)SDL_floor(src_y0 + 0.5);
+	final_src.x = (Sint16)SDL_floor(src_x0 + 0.5);
+	final_src.y = (Sint16)SDL_floor(src_y0 + 0.5);
+	src_w = (int)SDL_floor(src_x1 + 1 + 0.5) - (int)SDL_floor(src_x0 + 0.5);
+	src_h = (int)SDL_floor(src_y1 + 1 + 0.5) - (int)SDL_floor(src_y0 + 0.5);
+	if (src_w < 0)
+		src_w = 0;
+	if (src_h < 0)
+		src_h = 0;
 
-	final_dst.x = (int)SDL_floor(dst_x0 + 0.5);
-	final_dst.y = (int)SDL_floor(dst_y0 + 0.5);
-	final_dst.w = (int)SDL_floor(dst_x1 - dst_x0 + 1.5);
-	final_dst.h = (int)SDL_floor(dst_y1 - dst_y0 + 1.5);
+	final_src.w = static_cast<Uint16>(src_w);
+	final_src.h = static_cast<Uint16>(src_h);
 
-	if (final_dst.w < 0)
-		final_dst.w = 0;
-	if (final_dst.h < 0)
-		final_dst.h = 0;
+	final_dst.x = (Sint16)SDL_floor(dst_x0 + 0.5);
+	final_dst.y = (Sint16)SDL_floor(dst_y0 + 0.5);
+	dst_w = (int)SDL_floor(dst_x1 - dst_x0 + 1.5);
+	dst_h = (int)SDL_floor(dst_y1 - dst_y0 + 1.5);
+	if (dst_w < 0)
+		dst_w = 0;
+	if (dst_h < 0)
+		dst_h = 0;
+
+	final_dst.w = static_cast<Uint16>(dst_w);
+	final_dst.h = static_cast<Uint16>(dst_h);
 
 	if (dstrect)
 		*dstrect = final_dst;
 
-	if (final_dst.w == 0 || final_dst.h == 0 || final_src.w <= 0 || final_src.h <= 0) {
+	if (final_dst.w == 0 || final_dst.h == 0 || final_src.w == 0 || final_src.h == 0) {
 		/* No-op. */
 		return 0;
 	}
@@ -774,7 +783,7 @@ inline char *SDL_GetBasePath()
 			const int rc = (int)SDL_snprintf(path, sizeof(path),
 			    "/proc/%llu/exe",
 			    (unsigned long long)getpid());
-			if ((rc > 0) && (rc < sizeof(path))) {
+			if ((rc > 0) && (static_cast<std::size_t>(rc) < sizeof(path))) {
 				retval = readSymLink(path);
 			}
 		}

--- a/SourceX/DiabloUI/credits.cpp
+++ b/SourceX/DiabloUI/credits.cpp
@@ -513,7 +513,7 @@ void credts_Render()
 
 			int offset = 0;
 			int x = 31;
-			int y = (i * lineHeight) - ybase - lineHeight;
+			const int y = (i * lineHeight) - ybase - lineHeight;
 			if (*the_long_credits[creditLine + i] == '	') {
 				offset = 1;
 				x += 40;
@@ -522,16 +522,29 @@ void credts_Render()
 			text_surface = TTF_RenderUTF8_Solid(font, the_long_credits[creditLine + i] + offset, color);
 			shadow_surface = TTF_RenderUTF8_Solid(font, the_long_credits[creditLine + i] + offset, black_color);
 			if (text_surface && shadow_surface) {
-				SDL_Rect src_rect = { 0, -y, text_surface->w, 251 };
+				SDL_Rect src_rect = {
+					0,
+					static_cast<decltype(SDL_Rect().y)>(-y),
+					static_cast<decltype(SDL_Rect().w)>(text_surface->w),
+					251
+				};
 
 				// draw text shadow.
-				SDL_Rect dsc_rect2 = { 64 + x + 2, SCREEN_Y + 114 + 2, src_rect.w, src_rect.h };
+				SDL_Rect dsc_rect2 = {
+					static_cast<decltype(SDL_Rect().x)>(SCREEN_X + x + 2),
+					SCREEN_Y + 114 + 2,
+					src_rect.w, src_rect.h
+				};
 				if (SDL_BlitSurface(shadow_surface, &src_rect, pal_surface, &dsc_rect2) <= -1) {
 					SDL_Log(SDL_GetError());
 				}
 
 				// draw text.
-				SDL_Rect dsc_rect = { 64 + x, SCREEN_Y + 114, src_rect.w, src_rect.h };
+				SDL_Rect dsc_rect = {
+					static_cast<decltype(SDL_Rect().x)>(SCREEN_X + x),
+					SCREEN_Y + 114,
+					src_rect.w, src_rect.h
+				};
 				if (SDL_BlitSurface(text_surface, &src_rect, pal_surface, &dsc_rect) <= -1) {
 					SDL_Log(SDL_GetError());
 				}

--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -266,6 +266,8 @@ bool UiFocusNavigation(SDL_Event *event)
 		case SDLK_DELETE:
 			UiFocusNavigationYesNo();
 			return true;
+		default:
+			break;
 		}
 	}
 
@@ -285,12 +287,15 @@ bool UiFocusNavigation(SDL_Event *event)
 				return true;
 #endif
 			case SDLK_BACKSPACE:
-			case SDLK_LEFT:
+			case SDLK_LEFT: {
 				int nameLen = strlen(UiTextInput);
 				if (nameLen > 0) {
 					UiTextInput[nameLen - 1] = '\0';
 				}
 				return true;
+			}
+			default:
+				break;
 			}
 #ifdef USE_SDL1
 			if ((event->key.keysym.mod & KMOD_CTRL) == 0) {
@@ -310,6 +315,8 @@ bool UiFocusNavigation(SDL_Event *event)
 			selhero_CatToName(event->text.text, UiTextInput, UiTextInputLen);
 			return true;
 #endif
+		default:
+			break;
 		}
 	}
 

--- a/SourceX/DiabloUI/progress.cpp
+++ b/SourceX/DiabloUI/progress.cpp
@@ -58,11 +58,14 @@ void progress_Render(BYTE progress)
 	DrawArt(GetCenterOffset(110), y + 99, &ButImage, 2, 110);
 
 	if (msgSurface) {
-		SDL_Rect dsc_rect = { 64 + x + 50, SCREEN_Y + y + 8, SCREEN_WIDTH, SCREEN_HEIGHT };
+		SDL_Rect dsc_rect = {
+			static_cast<decltype(SDL_Rect().x)>(SCREEN_X + x + 50),
+			static_cast<decltype(SDL_Rect().y)>(SCREEN_Y + y + 8),
+			SCREEN_WIDTH, SCREEN_HEIGHT };
 		if (SDL_BlitSurface(msgSurface, NULL, pal_surface, &dsc_rect) <= -1) {
 			SDL_Log(SDL_GetError());
 		}
-		dsc_rect.x = 64 + GetCenterOffset(textWidth) - 1;
+		dsc_rect.x = SCREEN_X + GetCenterOffset(textWidth) - 1;
 		dsc_rect.y = SCREEN_Y + y + 99 + 4;
 		if (SDL_BlitSurface(cancleSurface, NULL, pal_surface, &dsc_rect) <= -1) {
 			SDL_Log(SDL_GetError());

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -192,11 +192,18 @@ HRESULT CreatePalette()
 
 HRESULT BltFast(DWORD dwX, DWORD dwY, LPRECT lpSrcRect)
 {
-	int w = lpSrcRect->right - lpSrcRect->left + 1;
-	int h = lpSrcRect->bottom - lpSrcRect->top + 1;
-
-	SDL_Rect src_rect = { lpSrcRect->left, lpSrcRect->top, w, h };
-	SDL_Rect dst_rect = { (int)dwX, (int)dwY, w, h };
+	auto w = static_cast<decltype(SDL_Rect().w)>(lpSrcRect->right - lpSrcRect->left + 1);
+	auto h = static_cast<decltype(SDL_Rect().h)>(lpSrcRect->bottom - lpSrcRect->top + 1);
+	SDL_Rect src_rect = {
+		static_cast<decltype(SDL_Rect().x)>(lpSrcRect->left),
+		static_cast<decltype(SDL_Rect().y)>(lpSrcRect->top),
+		w, h
+	};
+	SDL_Rect dst_rect = {
+		static_cast<decltype(SDL_Rect().x)>(dwX),
+		static_cast<decltype(SDL_Rect().y)>(dwY),
+		w, h
+	};
 
 	// Convert from 8-bit to 32-bit
 	if (SDL_BlitSurface(pal_surface, &src_rect, surface, &dst_rect) <= -1) {

--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -21,10 +21,10 @@ bool directFileAccess = false;
 
 static std::string getIniPath()
 {
-	char path[DVL_MAX_PATH], file_path[DVL_MAX_PATH];
+	char path[DVL_MAX_PATH], file_path[DVL_MAX_PATH + 10];
 
 	GetPrefPath(path, DVL_MAX_PATH);
-	snprintf(file_path, DVL_MAX_PATH, "%sdiablo.ini", path);
+	snprintf(file_path, DVL_MAX_PATH + 10, "%sdiablo.ini", path);
 
 	return file_path;
 }
@@ -487,7 +487,7 @@ private:
 	{
 		AudioQueueItem *item;
 		while ((item = Next()) != NULL) {
-			if (out_len <= item->len) {
+			if (static_cast<unsigned long>(out_len) <= item->len) {
 				SDL_MixAudio(out, item->pos, out_len, SDL_MIX_MAXVOLUME);
 				item->pos += out_len;
 				item->len -= out_len;
@@ -721,10 +721,15 @@ BOOL SVidPlayContinue(void)
 		} else {
 			factor = wFactor;
 		}
-		int scaledW = SVidWidth * factor;
-		int scaledH = SVidHeight * factor;
+		const int scaledW = SVidWidth * factor;
+		const int scaledH = SVidHeight * factor;
 
-		SDL_Rect pal_surface_offset = { (SCREEN_WIDTH - scaledW) / 2, (SCREEN_HEIGHT - scaledH) / 2, scaledW, scaledH };
+		SDL_Rect pal_surface_offset = {
+			static_cast<decltype(SDL_Rect().x)>((SCREEN_WIDTH - scaledW) / 2),
+			static_cast<decltype(SDL_Rect().y)>((SCREEN_HEIGHT - scaledH) / 2),
+			static_cast<decltype(SDL_Rect().w)>(scaledW),
+			static_cast<decltype(SDL_Rect().h)>(scaledH)
+		};
 #ifdef USE_SDL1
 		SDL_Surface *tmp = SDL_ConvertSurface(SVidSurface, window->format, 0);
 		// NOTE: Consider resolution switching instead if video doesn't play

--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -21,12 +21,11 @@ bool directFileAccess = false;
 
 static std::string getIniPath()
 {
-	char path[DVL_MAX_PATH], file_path[DVL_MAX_PATH + 10];
-
+	char path[DVL_MAX_PATH];
 	GetPrefPath(path, DVL_MAX_PATH);
-	snprintf(file_path, DVL_MAX_PATH + 10, "%sdiablo.ini", path);
-
-	return file_path;
+	std::string result = path;
+	result.append("diablo.ini");
+	return result;
 }
 
 static radon::File ini(getIniPath());


### PR DESCRIPTION
```
SourceX/storm/storm.cpp:27:10: note: ‘snprintf’ output between 11 and 270 bytes into a destination of size 260
  snprintf(file_path, DVL_MAX_PATH, "%sdiablo.ini", path);
```

SDL1 warnings:

```
devilutionX/SourceX/dx.cpp:199:24: warning: narrowing conversion of ‘(int)dwX’ from ‘int’ to ‘Sint16’ {aka ‘short int’} inside { } [-Wnarrowing]
  SDL_Rect dst_rect = { (int)dwX, (int)dwY, w, h };

SourceS/sdl2_to_1_2_backports.h:616:18: warning: comparison is always false due to limited range of data type [-Wtype-limits]
  if (final_dst.w < 0)

SourceS/sdl2_to_1_2_backports.h:777:24: warning: comparison of integer expressions of different signedness: ‘const int’ and ‘long unsigned int’ [-Wsign-compare]
    if ((rc > 0) && (rc < sizeof(path))) {
                     ~~~^~~~~~~~~~~~~~

SourceX/storm/storm.cpp:479:16: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
    if (out_len <= item->len) {

SourceX/storm/storm.cpp:716:60: warning: narrowing conversion of ‘((640 - scaledW) / 2)’ from ‘int’ to ‘Sint16’ {aka ‘short int’} inside { } [-Wnarrowing]
   SDL_Rect pal_surface_offset = { (SCREEN_WIDTH - scaledW) / 2, (SCREEN_HEIGHT - scaledH) / 2, scaledW, scaledH };

DiabloUI/credits.cpp:525:30: warning: narrowing conversion of ‘- y’ from ‘int’ to ‘Sint16’ {aka ‘short int’} inside { } [-Wnarrowing]
     SDL_Rect src_rect = { 0, -y, text_surface->w, 251 };
```