### PR TITLE
 DiabloUI: Move art and text code out of diablo.cpp 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,10 +198,12 @@ set(devilutionx_SRCS
   SourceX/dvlnet/packet.cpp
   SourceX/dvlnet/base.cpp
   SourceX/dvlnet/frame_queue.cpp
+  SourceX/DiabloUI/art_draw.cpp
   SourceX/DiabloUI/art.cpp
   SourceX/DiabloUI/credits.cpp
   SourceX/DiabloUI/diabloui.cpp
   SourceX/DiabloUI/dialogs.cpp
+  SourceX/DiabloUI/fonts.cpp
   SourceX/DiabloUI/mainmenu.cpp
   SourceX/DiabloUI/progress.cpp
   SourceX/DiabloUI/scrollbar.cpp
@@ -209,6 +211,8 @@ set(devilutionx_SRCS
   SourceX/DiabloUI/selgame.cpp
   SourceX/DiabloUI/selhero.cpp
   SourceX/DiabloUI/selyesno.cpp
+  SourceX/DiabloUI/text_draw.cpp
+  SourceX/DiabloUI/text.cpp
   SourceX/DiabloUI/title.cpp
   SourceX/main.cpp
   ./Packaging/macOS/AppIcon.icns

--- a/SourceX/.clang-format
+++ b/SourceX/.clang-format
@@ -8,4 +8,5 @@
 	UseTab: ForIndentation,
 	SortIncludes: false,
 	NamespaceIndentation: None,
+	FixNamespaceComments: true,
 }

--- a/SourceX/DiabloUI/art.cpp
+++ b/SourceX/DiabloUI/art.cpp
@@ -2,7 +2,7 @@
 
 namespace dvl {
 
-void LoadArt(char *pszFile, Art *art, int frames, PALETTEENTRY *pPalette)
+void LoadArt(const char *pszFile, Art *art, int frames, PALETTEENTRY *pPalette)
 {
 	if (art == NULL || art->surface != NULL)
 		return;
@@ -38,6 +38,16 @@ void LoadArt(char *pszFile, Art *art, int frames, PALETTEENTRY *pPalette)
 	art->surface = art_surface;
 	art->frames = frames;
 	art->frame_height = height / frames;
+}
+
+void LoadMaskedArt(const char *pszFile, Art *art, int frames, int mask)
+{
+	LoadArt(pszFile, art, frames);
+#ifdef USE_SDL1
+	SDL_SetColorKey(art->surface, SDL_SRCCOLORKEY, mask);
+#else
+	SDL_SetColorKey(art->surface, SDL_TRUE, mask);
+#endif
 }
 
 } // namespace dvl

--- a/SourceX/DiabloUI/art.h
+++ b/SourceX/DiabloUI/art.h
@@ -27,6 +27,7 @@ struct Art {
 	}
 };
 
-void LoadArt(char *pszFile, Art *art, int frames = 1, PALETTEENTRY *pPalette = NULL);
+void LoadArt(const char *pszFile, Art *art, int frames = 1, PALETTEENTRY *pPalette = NULL);
+void LoadMaskedArt(const char *pszFile, Art *art, int frames = 1, int mask = 250);
 
-}
+} // namespace dvl

--- a/SourceX/DiabloUI/art_draw.cpp
+++ b/SourceX/DiabloUI/art_draw.cpp
@@ -1,0 +1,57 @@
+#include "DiabloUI/art_draw.h"
+
+namespace dvl {
+
+extern SDL_Surface *pal_surface;
+extern unsigned int pal_surface_palette_version;
+
+void DrawArt(int screenX, int screenY, Art *art, int nFrame,
+    decltype(SDL_Rect().w) srcW, decltype(SDL_Rect().h) srcH)
+{
+	if (screenY >= SCREEN_Y + SCREEN_HEIGHT || screenX >= SCREEN_X + SCREEN_WIDTH)
+		return;
+
+	SDL_Rect src_rect = {
+		0,
+		static_cast<decltype(SDL_Rect().y)>(nFrame * art->h()),
+		static_cast<decltype(SDL_Rect().w)>(art->w()),
+		static_cast<decltype(SDL_Rect().h)>(art->h())
+	};
+	if (srcW && srcW < src_rect.w)
+		src_rect.w = srcW;
+	if (srcH && srcH < src_rect.h)
+		src_rect.h = srcH;
+	SDL_Rect dst_rect = {
+		static_cast<decltype(SDL_Rect().x)>(screenX + SCREEN_X),
+		static_cast<decltype(SDL_Rect().y)>(screenY + SCREEN_Y),
+		src_rect.w, src_rect.h
+	};
+
+	if (art->surface->format->BitsPerPixel == 8 && art->palette_version != pal_surface_palette_version) {
+#ifdef USE_SDL1
+		if (SDL_SetPalette(art->surface, SDL_LOGPAL, pal_surface->format->palette->colors, 0, 256) != 1)
+			SDL_Log(SDL_GetError());
+#else
+		if (SDL_SetSurfacePalette(art->surface, pal_surface->format->palette) <= -1)
+			SDL_Log(SDL_GetError());
+#endif
+		art->palette_version = pal_surface_palette_version;
+	}
+
+	if (SDL_BlitSurface(art->surface, &src_rect, pal_surface, &dst_rect) <= -1) {
+		SDL_Log(SDL_GetError());
+	}
+}
+
+void DrawAnimatedArt(Art *art, int screenX, int screenY) {
+	DrawArt(screenX, screenY, art, GetAnimationFrame(art->frames));
+}
+
+int GetAnimationFrame(int frames, int fps)
+{
+	int frame = (SDL_GetTicks() / fps) % frames;
+
+	return frame > frames ? 0 : frame;
+}
+
+} // namespace dvl

--- a/SourceX/DiabloUI/art_draw.h
+++ b/SourceX/DiabloUI/art_draw.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "devilution.h"
+
+#include "DiabloUI/art.h"
+
+namespace dvl {
+
+void DrawArt(int screenX, int screenY, Art *art, int nFrame = 0,
+    decltype(SDL_Rect().w) srcW = 0, decltype(SDL_Rect().h) srcH = 0);
+
+void DrawAnimatedArt(Art *art, int screenX, int screenY);
+
+int GetAnimationFrame(int frames, int fps = 60);
+
+} // namespace dvl

--- a/SourceX/DiabloUI/credits.cpp
+++ b/SourceX/DiabloUI/credits.cpp
@@ -2,6 +2,9 @@
 #include "miniwin/ddraw.h"
 
 #include "DiabloUI/diabloui.h"
+#include "DiabloUI/art.h"
+#include "DiabloUI/art_draw.h"
+#include "DiabloUI/fonts.h"
 
 #define CREDIT_LINES 13
 
@@ -475,11 +478,13 @@ char *the_long_credits[] = {
 void credts_Load()
 {
 	LoadBackgroundArt("ui_art\\credits.pcx");
+	LoadTtfFont();
 }
 
 void credts_Free()
 {
 	ArtBackground.Unload();
+	UnloadTtfFont();
 }
 
 void credts_Render()

--- a/SourceX/DiabloUI/diabloui.h
+++ b/SourceX/DiabloUI/diabloui.h
@@ -2,10 +2,9 @@
 
 #include <cstddef>
 #include <SDL.h>
-#include <SDL_ttf.h>
 
-#include "art.h"
-#include "ui_item.h"
+#include "DiabloUI/art.h"
+#include "DiabloUI/ui_item.h"
 
 namespace dvl {
 
@@ -21,34 +20,12 @@ typedef enum _artLogo {
 	LOGO_BIG,
 } _artLogo;
 
-typedef enum _artFontTables {
-	AFT_SMALL,
-	AFT_MED,
-	AFT_BIG,
-	AFT_HUGE,
-} _artFontTables;
-
-typedef enum _artFontColors {
-	AFC_SILVER,
-	AFC_GOLD,
-} _artFontColors;
-
-extern TTF_Font *font;
-
-extern BYTE *FontTables[4];
-extern Art ArtFonts[4][2];
 extern Art ArtLogos[3];
 extern Art ArtFocus[3];
 extern Art ArtBackground;
 extern Art ArtCursor;
 extern Art ArtHero;
 extern bool gbSpawned;
-
-typedef enum TXT_JUST {
-	JustLeft = 0,
-	JustCentre = 1,
-	JustRight = 2,
-} TXT_JUST;
 
 template <class T, size_t N>
 constexpr size_t size(T (&)[N])
@@ -62,13 +39,10 @@ bool IsInsideRect(const SDL_Event &event, const SDL_Rect &rect);
 void UiFadeIn(int steps = 16);
 bool UiFocusNavigation(SDL_Event *event);
 bool UiItemMouseEvents(SDL_Event *event, UiItem *items, int size);
-int GetAnimationFrame(int frames, int fps = 60);
 int GetCenterOffset(int w, int bw = 0);
-void DrawArt(int screenX, int screenY, Art *art, int nFrame = 0, decltype(SDL_Rect().w) srcW = 0, decltype(SDL_Rect().h) srcH = 0);
 void DrawLogo(int t = 0, int size = LOGO_MED);
 void DrawMouse();
 void LoadBackgroundArt(char *pszFile);
-void LoadMaskedArtFont(char *pszFile, Art *art, int frames, int mask = 250);
 void SetMenu(int MenuId);
 void UiFocusNavigationSelect();
 void UiFocusNavigationEsc();
@@ -77,10 +51,9 @@ void UiInitList(int min, int max, void (*fnFocus)(int value), void (*fnSelect)(i
 void UiInitScrollBar(UiScrollBar *ui_sb, std::size_t viewport_size, const std::size_t *current_offset);
 void UiRender();
 void UiRenderItems(UiItem *items, int size);
-void WordWrap(UiText *item);
 
 void DvlIntSetting(const char *valuename, int *value);
 void DvlStringSetting(const char *valuename, char *string, int len);
 
 void mainmenu_restart_repintro();
-}
+} // namespace dvl

--- a/SourceX/DiabloUI/fonts.cpp
+++ b/SourceX/DiabloUI/fonts.cpp
@@ -1,0 +1,75 @@
+#include "DiabloUI/fonts.h"
+
+namespace dvl {
+
+TTF_Font *font = nullptr;
+BYTE *FontTables[4];
+Art ArtFonts[4][2];
+
+namespace {
+
+void LoadArtFont(char *pszFile, int size, int color)
+{
+	LoadMaskedArt(pszFile, &ArtFonts[size][color], 256, 32);
+}
+
+} // namespace
+
+void LoadArtFonts()
+{
+	FontTables[AFT_SMALL] = LoadFileInMem("ui_art\\font16.bin", 0);
+	FontTables[AFT_MED] = LoadFileInMem("ui_art\\font24.bin", 0);
+	FontTables[AFT_BIG] = LoadFileInMem("ui_art\\font30.bin", 0);
+	FontTables[AFT_HUGE] = LoadFileInMem("ui_art\\font42.bin", 0);
+	LoadArtFont("ui_art\\font16s.pcx", AFT_SMALL, AFC_SILVER);
+	LoadArtFont("ui_art\\font16g.pcx", AFT_SMALL, AFC_GOLD);
+	LoadArtFont("ui_art\\font24s.pcx", AFT_MED, AFC_SILVER);
+	LoadArtFont("ui_art\\font24g.pcx", AFT_MED, AFC_GOLD);
+	LoadArtFont("ui_art\\font30s.pcx", AFT_BIG, AFC_SILVER);
+	LoadArtFont("ui_art\\font30g.pcx", AFT_BIG, AFC_GOLD);
+	LoadArtFont("ui_art\\font42g.pcx", AFT_HUGE, AFC_GOLD);
+}
+
+void UnloadArtFonts()
+{
+	ArtFonts[AFT_SMALL][AFC_SILVER].Unload();
+	ArtFonts[AFT_SMALL][AFC_GOLD].Unload();
+	ArtFonts[AFT_MED][AFC_SILVER].Unload();
+	ArtFonts[AFT_MED][AFC_GOLD].Unload();
+	ArtFonts[AFT_BIG][AFC_SILVER].Unload();
+	ArtFonts[AFT_BIG][AFC_GOLD].Unload();
+	ArtFonts[AFT_HUGE][AFC_GOLD].Unload();
+	mem_free_dbg(FontTables[AFT_SMALL]);
+	FontTables[AFT_SMALL] = nullptr;
+	mem_free_dbg(FontTables[AFT_MED]);
+	FontTables[AFT_MED] = nullptr;
+	mem_free_dbg(FontTables[AFT_BIG]);
+	FontTables[AFT_BIG] = nullptr;
+	mem_free_dbg(FontTables[AFT_HUGE]);
+	FontTables[AFT_HUGE] = nullptr;
+}
+
+void LoadTtfFont() {
+	if (!TTF_WasInit() && TTF_Init() == -1) {
+		printf("TTF_Init: %s\n", TTF_GetError());
+		exit(1);
+	}
+	atexit(TTF_Quit);
+
+	font = TTF_OpenFont("CharisSILB.ttf", 17);
+	if (font == NULL) {
+		printf("TTF_OpenFont: %s\n", TTF_GetError());
+		return;
+	}
+
+	TTF_SetFontKerning(font, false);
+	TTF_SetFontHinting(font, TTF_HINTING_MONO);
+}
+
+void UnloadTtfFont() {
+	if (font)
+		TTF_CloseFont(font);
+	font = nullptr;
+}
+
+} // namespace dvl

--- a/SourceX/DiabloUI/fonts.h
+++ b/SourceX/DiabloUI/fonts.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "devilution.h"
+
+#include <SDL_ttf.h>
+
+#include "DiabloUI/art.h"
+
+namespace dvl {
+
+enum _artFontTables {
+	AFT_SMALL,
+	AFT_MED,
+	AFT_BIG,
+	AFT_HUGE,
+};
+
+enum _artFontColors {
+	AFC_SILVER,
+	AFC_GOLD,
+};
+
+extern TTF_Font *font;
+extern BYTE *FontTables[4];
+extern Art ArtFonts[4][2];
+
+void LoadArtFonts();
+void UnloadArtFonts();
+
+void LoadTtfFont();
+void UnloadTtfFont();
+
+} // namespace dvl

--- a/SourceX/DiabloUI/progress.cpp
+++ b/SourceX/DiabloUI/progress.cpp
@@ -2,6 +2,8 @@
 #include "miniwin/ddraw.h"
 
 #include "DiabloUI/diabloui.h"
+#include "DiabloUI/art_draw.h"
+#include "DiabloUI/fonts.h"
 
 namespace dvl {
 
@@ -20,6 +22,7 @@ void progress_Load(char *msg)
 	LoadArt("ui_art\\prog_bg.pcx", &ArtProgBG);
 	LoadArt("ui_art\\prog_fil.pcx", &ProgFil);
 	LoadArt("ui_art\\but_sml.pcx", &ButImage, 15);
+	LoadTtfFont();
 
 	if (font != NULL) {
 		SDL_Color color = { 243, 243, 243, 0 };
@@ -41,6 +44,7 @@ void progress_Free()
 	msgSurface = NULL;
 	SDL_FreeSurface(cancleSurface);
 	cancleSurface = NULL;
+	UnloadTtfFont();
 }
 
 void progress_Render(BYTE progress)

--- a/SourceX/DiabloUI/selconn.cpp
+++ b/SourceX/DiabloUI/selconn.cpp
@@ -2,6 +2,7 @@
 
 #include "devilution.h"
 #include "DiabloUI/diabloui.h"
+#include "DiabloUI/text.h"
 
 namespace dvl {
 
@@ -78,7 +79,7 @@ void selconn_Focus(int value)
 	}
 
 	sprintf(selconn_MaxPlayers, "Players Supported: %d", players);
-	WordWrap(&SELCONNECT_DIALOG_DESCRIPTION);
+	WordWrap(selconn_Description, SELCONNECT_DIALOG_DESCRIPTION.rect.w);
 }
 
 void selconn_Select(int value)

--- a/SourceX/DiabloUI/selgame.cpp
+++ b/SourceX/DiabloUI/selgame.cpp
@@ -2,6 +2,7 @@
 
 #include "devilution.h"
 #include "DiabloUI/diabloui.h"
+#include "DiabloUI/text.h"
 
 namespace dvl {
 
@@ -110,7 +111,7 @@ void selgame_GameSelection_Focus(int value)
 		strcpy(selgame_Description, "Enter an IP and join a game already in progress at that address.");
 		break;
 	}
-	WordWrap(&SELGAME_DESCRIPTION);
+	WordWrap(selgame_Description, SELGAME_DESCRIPTION.rect.w);
 }
 
 void selgame_GameSelection_Select(int value)
@@ -151,7 +152,7 @@ void selgame_Diff_Focus(int value)
 		strcpy(selgame_Description, "Hell Difficulty\nThe most powerful of the underworld's creatures lurk at the gateway into Hell. Only the most experienced characters should venture in this realm.");
 		break;
 	}
-	WordWrap(&SELGAME_DESCRIPTION);
+	WordWrap(selgame_Description, SELGAME_DESCRIPTION.rect.w);
 }
 
 void selgame_Diff_Select(int value)

--- a/SourceX/DiabloUI/selyesno.cpp
+++ b/SourceX/DiabloUI/selyesno.cpp
@@ -1,7 +1,8 @@
 #include "selyesno.h"
 
-#include "DiabloUI/diabloui.h"
 #include "devilution.h"
+#include "DiabloUI/diabloui.h"
+#include "DiabloUI/text.h"
 
 namespace dvl {
 
@@ -59,7 +60,7 @@ BOOL UiSelHeroDelYesNoDialog(
 	}
 
 	sprintf(selyesno_confirmationMessage, "Are you sure you want to delete the character \"%s\"?", selyesno_heroInfo.name);
-	WordWrap(SELYESNO_DIALOG_CONFIRMATION_MESSAGE);
+	WordWrap(selyesno_confirmationMessage, SELYESNO_DIALOG_CONFIRMATION_MESSAGE->rect.w);
 
 	UiInitList(0, 1, NULL, selyesno_Select, selyesno_Esc, SELYESNO_DIALOG, size(SELYESNO_DIALOG), true, NULL);
 

--- a/SourceX/DiabloUI/text.cpp
+++ b/SourceX/DiabloUI/text.cpp
@@ -1,0 +1,60 @@
+#include "DiabloUI/text.h"
+
+namespace dvl {
+
+std::size_t GetStrWidth(const char *str, std::size_t size)
+{
+	int strWidth = 0;
+
+	for (size_t i = 0, n = strlen(str); i < n; i++) {
+		BYTE w = FontTables[size][*(BYTE *)&str[i] + 2];
+		if (w)
+			strWidth += w;
+		else
+			strWidth += FontTables[size][0];
+	}
+
+	return strWidth;
+}
+
+void WordWrap(char *text, std::size_t width)
+{
+	const std::size_t len = strlen(text);
+	std::size_t lineStart = 0;
+	for (std::size_t i = 0; i <= len; i++) {
+		if (text[i] == '\n') {
+			lineStart = i + 1;
+			continue;
+		} else if (text[i] != ' ' && i != len) {
+			continue;
+		}
+
+		if (i != len)
+			text[i] = '\0';
+		if (GetStrWidth(&text[lineStart], AFT_SMALL) <= width) {
+			if (i != len)
+				text[i] = ' ';
+			continue;
+		}
+
+		std::size_t j;
+		for (j = i; j >= lineStart; j--) {
+			if (text[j] == ' ') {
+				break; // Scan for previous space
+			}
+		}
+
+		if (j == lineStart) { // Single word longer then width
+			if (i == len)
+				break;
+			j = i;
+		}
+
+		if (i != len)
+			text[i] = ' ';
+		text[j] = '\n';
+		lineStart = j + 1;
+	}
+}
+
+} // namespace dvl

--- a/SourceX/DiabloUI/text.h
+++ b/SourceX/DiabloUI/text.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstddef>
+
+#include "DiabloUI/fonts.h"
+
+namespace dvl {
+
+enum TXT_JUST {
+	JustLeft = 0,
+	JustCentre = 1,
+	JustRight = 2,
+};
+
+std::size_t GetStrWidth(const char *str, std::size_t size);
+void WordWrap(char *text, std::size_t width);
+
+} // namespace dvl

--- a/SourceX/DiabloUI/text_draw.cpp
+++ b/SourceX/DiabloUI/text_draw.cpp
@@ -1,0 +1,64 @@
+#include "DiabloUI/art_draw.h"
+#include "DiabloUI/fonts.h"
+#include "DiabloUI/text.h"
+#include "DiabloUI/ui_item.h"
+
+namespace dvl {
+
+namespace {
+
+int AlignedTextOffsetX(const char *text, std::size_t rect_w, TXT_JUST align, _artFontTables size)
+{
+	switch (align) {
+	case JustCentre:
+		return (rect_w - GetStrWidth(text, size)) / 2;
+	case JustRight:
+		return rect_w - GetStrWidth(text, size);
+	default:
+		return 0;
+	}
+}
+
+} // namespace
+
+void DrawArtStr(const char *text, const SDL_Rect &rect, int flags, bool drawTextCursor = false)
+{
+	_artFontTables size = AFT_SMALL;
+	_artFontColors color = flags & UIS_GOLD ? AFC_GOLD : AFC_SILVER;
+	TXT_JUST align = JustLeft;
+
+	if (flags & UIS_MED)
+		size = AFT_MED;
+	else if (flags & UIS_BIG)
+		size = AFT_BIG;
+	else if (flags & UIS_HUGE)
+		size = AFT_HUGE;
+
+	if (flags & UIS_CENTER)
+		align = JustCentre;
+	else if (flags & UIS_RIGHT)
+		align = JustRight;
+
+	int x = rect.x + AlignedTextOffsetX(text, rect.w, align, size);
+
+	int sx = x;
+	int sy = rect.y;
+	if (flags & UIS_VCENTER)
+		sy += (rect.h - ArtFonts[size][color].h()) / 2;
+
+	for (size_t i = 0, n = strlen(text); i < n; i++) {
+		if (text[i] == '\n') {
+			sx = x;
+			sy += ArtFonts[size][color].h();
+			continue;
+		}
+		BYTE w = FontTables[size][*(BYTE *)&text[i] + 2] ? FontTables[size][*(BYTE *)&text[i] + 2] : FontTables[size][0];
+		DrawArt(sx, sy, &ArtFonts[size][color], *(BYTE *)&text[i], w);
+		sx += w;
+	}
+	if (drawTextCursor && GetAnimationFrame(2, 500)) {
+		DrawArt(sx, sy, &ArtFonts[size][color], '|');
+	}
+}
+
+} // namespace dvl

--- a/SourceX/DiabloUI/text_draw.h
+++ b/SourceX/DiabloUI/text_draw.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "devilution.h"
+
+namespace dvl {
+
+void DrawArtStr(const char *text, const SDL_Rect &rect, int flags, bool drawTextCursor = false);
+
+} // namespace dvl

--- a/SourceX/DiabloUI/title.cpp
+++ b/SourceX/DiabloUI/title.cpp
@@ -6,7 +6,7 @@ namespace dvl {
 void title_Load()
 {
 	LoadBackgroundArt("ui_art\\title.pcx");
-	LoadMaskedArtFont("ui_art\\logo.pcx", &ArtLogos[LOGO_BIG], 15);
+	LoadMaskedArt("ui_art\\logo.pcx", &ArtLogos[LOGO_BIG], 15);
 }
 
 void title_Free()


### PR DESCRIPTION
Start moving stuff out of the diabloui.cpp file.

This is a commit on top of scrollbar (#307).