### PR TITLE
Add option to compile shareware version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 
 option(ASAN "Enable address sanitizer" ON)
 option(DEBUG "Enable debug mode in engine" ON)
+option(SPAWN "Build the shareware version" OFF)
 option(DIST "Dynamically link only glibc and SDL2" OFF)
 option(FASTER "Enable FASTER in engine" ON)
 option(BINARY_RELEASE "Enable options for binary release" OFF)
@@ -263,6 +264,10 @@ foreach(target devilution devilutionx)
 
   if(NONET)
     target_compile_definitions(${target} PRIVATE NONET)
+  endif()
+
+  if(SPAWN)
+    target_compile_definitions(${target} PRIVATE SPAWN)
   endif()
 
   if(ASAN)

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ make -j$(nproc)
 ### General
 The default build type is `Debug`. This can be changed with `-DBINARY_RELEASE=ON`. Independently of this, the debug mode of the Diablo engine is always enabled by default. It can be disabled with `-DDEBUG=OFF`. Finally, in debug builds the address sanitizer is enabled by default. This can be disabled with `-DASAN=OFF`.
 You can also generate 32bit builds on 64bit platforms by setting `-DCMAKE_TOOLCHAIN_FILE=../CMake/32bit.cmake` (remember to use the `linux32` command if on Linux).
-Network support can be deiabled using `-DNONET=ON`, this also removes the need for the ASIO and Sodium dependencies.
+Network support can be disabled using `-DNONET=ON`, this also removes the need for the ASIO and Sodium dependencies.
 You can compile the shareware version with `-DSPAWN=ON` this will allow you to try the game using spawn.mpq from the original shareware which can still be [downloaded](http://ftp.blizzard.com/pub/demos/diablosw.exe) for free.
 
 ### mingw32

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ make -j$(nproc)
 ### General
 The default build type is `Debug`. This can be changed with `-DBINARY_RELEASE=ON`. Independently of this, the debug mode of the Diablo engine is always enabled by default. It can be disabled with `-DDEBUG=OFF`. Finally, in debug builds the address sanitizer is enabled by default. This can be disabled with `-DASAN=OFF`.
 You can also generate 32bit builds on 64bit platforms by setting `-DCMAKE_TOOLCHAIN_FILE=../CMake/32bit.cmake` (remember to use the `linux32` command if on Linux).
-Network support can be deiabled using `-DNONET`, this also removes the need for the ASIO and Sodium dependencies
+Network support can be deiabled using `-DNONET=ON`, this also removes the need for the ASIO and Sodium dependencies.
+You can compile the shareware version with `-DSPAWN=ON` this will allow you to try the game using spawn.mpq from the original shareware which can still be [downloaded](http://ftp.blizzard.com/pub/demos/diablosw.exe) for free.
 
 ### mingw32
 Use `-DCROSS_PREFIX=/path/to/prefix` if the `i686-w64-mingw32` directory is not in `/usr`.

--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -1943,6 +1943,6 @@ void DRLG_L4Pass3()
 		yy += 2;
 	}
 }
+#endif
 
 DEVILUTION_END_NAMESPACE
-#endif

--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -19,6 +19,7 @@ Art ArtFocus[3];
 Art ArtBackground;
 Art ArtCursor;
 Art ArtHero;
+bool gbSpawned;
 
 void (*gfnSoundFunction)(char *file);
 void (*gfnListFocus)(int value);

--- a/SourceX/DiabloUI/diabloui.h
+++ b/SourceX/DiabloUI/diabloui.h
@@ -42,6 +42,7 @@ extern Art ArtFocus[3];
 extern Art ArtBackground;
 extern Art ArtCursor;
 extern Art ArtHero;
+extern bool gbSpawned;
 
 typedef enum TXT_JUST {
 	JustLeft = 0,

--- a/SourceX/DiabloUI/title.cpp
+++ b/SourceX/DiabloUI/title.cpp
@@ -57,4 +57,9 @@ BOOL UiTitleDialog(int a1)
 	return true;
 }
 
+void UiSetSpawned(BOOL bSpawned)
+{
+	gbSpawned = bSpawned;
+}
+
 }

--- a/SourceX/sound.cpp
+++ b/SourceX/sound.cpp
@@ -24,9 +24,11 @@ int sgnMusicTrack = 6;
 char *sgszMusicTracks[NUM_MUSIC] = {
 	"Music\\DTowne.wav",
 	"Music\\DLvlA.wav",
+#ifndef SPAWN
 	"Music\\DLvlB.wav",
 	"Music\\DLvlC.wav",
 	"Music\\DLvlD.wav",
+#endif
 	"Music\\Dintro.wav"
 };
 


### PR DESCRIPTION
This also fixes a couple of issues caused by bad merges
None of the UI parts are implemented, so you can crash the game by trying to create a rouge or sorcerer.