### PR TITLE
Fix hero order

### DIFF
--- a/SourceX/DiabloUI/selhero.cpp
+++ b/SourceX/DiabloUI/selhero.cpp
@@ -309,6 +309,7 @@ BOOL UiSelHeroDialog(
 
 		selhero_SaveCount = 0;
 		fninfo(SelHero_GetHeroInfo);
+		std::reverse(selhero_heros, selhero_heros + selhero_SaveCount);
 
 		if (selhero_SaveCount) {
 			selhero_List_Init();


### PR DESCRIPTION
Fixes #311. Feels kind of hacky, I just prepend to `selhero_heros[]` using `memmove()`. As always, I'm open to suggestions if there's a better solution.