### PR TITLE
Minor cleanup of internal error handling

### DIFF
--- a/SourceX/DiabloUI/art.cpp
+++ b/SourceX/DiabloUI/art.cpp
@@ -32,6 +32,7 @@ void LoadArt(const char *pszFile, Art *art, int frames, PALETTEENTRY *pPalette)
 	        art_surface->pitch * art_surface->format->BytesPerPixel * height, 0, 0, 0)) {
 		SDL_Log("Failed to load image");
 		SDL_FreeSurface(art_surface);
+		art->surface = nullptr;
 		return;
 	}
 
@@ -43,11 +44,13 @@ void LoadArt(const char *pszFile, Art *art, int frames, PALETTEENTRY *pPalette)
 void LoadMaskedArt(const char *pszFile, Art *art, int frames, int mask)
 {
 	LoadArt(pszFile, art, frames);
+	if (art->surface != nullptr) {
 #ifdef USE_SDL1
-	SDL_SetColorKey(art->surface, SDL_SRCCOLORKEY, mask);
+		SDL_SetColorKey(art->surface, SDL_SRCCOLORKEY, mask);
 #else
-	SDL_SetColorKey(art->surface, SDL_TRUE, mask);
+		SDL_SetColorKey(art->surface, SDL_TRUE, mask);
 #endif
+	}
 }
 
 } // namespace dvl

--- a/SourceX/DiabloUI/art.h
+++ b/SourceX/DiabloUI/art.h
@@ -12,7 +12,7 @@ struct Art {
 
 	int w() const
 	{
-		return surface->w;
+		return surface ? surface->w : 0;
 	}
 
 	int h() const

--- a/SourceX/DiabloUI/art_draw.cpp
+++ b/SourceX/DiabloUI/art_draw.cpp
@@ -8,7 +8,7 @@ extern unsigned int pal_surface_palette_version;
 void DrawArt(int screenX, int screenY, Art *art, int nFrame,
     decltype(SDL_Rect().w) srcW, decltype(SDL_Rect().h) srcH)
 {
-	if (screenY >= SCREEN_Y + SCREEN_HEIGHT || screenX >= SCREEN_X + SCREEN_WIDTH)
+	if (screenY >= SCREEN_Y + SCREEN_HEIGHT || screenX >= SCREEN_X + SCREEN_WIDTH || art->surface == nullptr)
 		return;
 
 	SDL_Rect src_rect = {

--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -12,6 +12,7 @@
 #include "DiabloUI/text_draw.h"
 #include "DiabloUI/fonts.h"
 #include "DiabloUI/button.h"
+#include "DiabloUI/dialogs.h"
 
 namespace dvl {
 
@@ -600,6 +601,9 @@ void LoadBackgroundArt(char *pszFile)
 
 	fadeValue = 0;
 	LoadArt(pszFile, &ArtBackground, 1, pPal);
+	if (ArtBackground.surface == nullptr)
+		return;
+
 	LoadPalInMem(pPal);
 	ApplyGamma(logical_palette, orig_palette, 256);
 }

--- a/SourceX/DiabloUI/dialogs.cpp
+++ b/SourceX/DiabloUI/dialogs.cpp
@@ -14,7 +14,7 @@ namespace {
 Art dialogArt;
 Art progressArt;
 char dialogText[256];
-char dialogCaption[256];
+char dialogCaption[1024];
 bool fontWasLoaded;
 bool textInputWasActive;
 
@@ -156,11 +156,16 @@ void DialogLoop(UiItem *items, std::size_t num_items, UiItem *render_behind, std
 
 } // namespace
 
-void UiErrorOkDialog(const char *text, const char *caption, UiItem *render_behind, std::size_t render_behind_size)
+void UiOkDialog(const char *text, const char *caption, bool error, UiItem *render_behind, std::size_t render_behind_size)
 {
-	Init(text, caption, /*error=*/true);
+	Init(text, caption, error);
 	DialogLoop(dialogItems, dialogItemsSize, render_behind, render_behind_size);
 	Deinit();
+}
+
+void UiErrorOkDialog(const char *text, const char *caption, UiItem *render_behind, std::size_t render_behind_size)
+{
+	UiOkDialog(text, caption, /*error=*/true, render_behind, render_behind_size);
 }
 
 void UiErrorOkDialog(const char *text, UiItem *render_behind, std::size_t render_behind_size)

--- a/SourceX/DiabloUI/dialogs.h
+++ b/SourceX/DiabloUI/dialogs.h
@@ -8,5 +8,6 @@ namespace dvl {
 
 void UiErrorOkDialog(const char *text, UiItem *renderBehind, std::size_t renderBehindSize);
 void UiErrorOkDialog(const char *text, const char *caption, UiItem *render_behind, std::size_t render_behind_size);
+void UiOkDialog(const char *text, const char *caption, bool error, UiItem *render_behind, std::size_t render_behind_size);
 
 } // namespace dvl

--- a/SourceX/DiabloUI/fonts.cpp
+++ b/SourceX/DiabloUI/fonts.cpp
@@ -50,11 +50,13 @@ void UnloadArtFonts()
 }
 
 void LoadTtfFont() {
-	if (!TTF_WasInit() && TTF_Init() == -1) {
-		printf("TTF_Init: %s\n", TTF_GetError());
-		exit(1);
+	if (!TTF_WasInit()) {
+		if (TTF_Init() == -1) {
+			printf("TTF_Init: %s\n", TTF_GetError());
+			exit(1);
+		}
+		atexit(TTF_Quit);
 	}
-	atexit(TTF_Quit);
 
 	font = TTF_OpenFont("CharisSILB.ttf", 17);
 	if (font == NULL) {
@@ -67,7 +69,7 @@ void LoadTtfFont() {
 }
 
 void UnloadTtfFont() {
-	if (font)
+	if (font && TTF_WasInit())
 		TTF_CloseFont(font);
 	font = nullptr;
 }

--- a/SourceX/DiabloUI/text_draw.cpp
+++ b/SourceX/DiabloUI/text_draw.cpp
@@ -44,6 +44,8 @@ void DrawTTF(const char *text, const SDL_Rect &rect, int flags,
 	}
 	SDL_Surface *text_surface = (*render_cache)->text;
 	SDL_Surface *shadow_surface = (*render_cache)->shadow;
+	if (text_surface == nullptr)
+		return;
 
 	SDL_Rect dest_rect = rect;
 	const int x_offset = AlignXOffset(flags, rect, text_surface->w);

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -146,7 +146,10 @@ void dx_cleanup()
 	gpBuffer = NULL;
 	sgMemCrit.Leave();
 
+	if (pal_surface == nullptr)
+		return;
 	SDL_FreeSurface(pal_surface);
+	pal_surface = nullptr;
 	SDL_FreePalette(palette);
 	SDL_FreeSurface(surface);
 	SDL_DestroyTexture(texture);


### PR DESCRIPTION
1. TTF no longer crashes on exit.
2. Art failing to load simply isn't rendered instead of crashing in random places.
3. Fixes empty line rendering in ttf_render_wrapped.cpp
4. dx_cleanup is now idempotent.