### PR TITLE
SDL1: Use SDL_HWSURFACE for the main surface

### DIFF
--- a/SourceX/miniwin/misc.cpp
+++ b/SourceX/miniwin/misc.cpp
@@ -179,7 +179,7 @@ HWND CreateWindowExA(
 	DvlIntSetting("grab input", &grabInput);
 
 #ifdef USE_SDL1
-	int flags = SDL_SWSURFACE | SDL_DOUBLEBUF | SDL_HWPALETTE;
+	int flags = SDL_HWSURFACE | SDL_DOUBLEBUF | SDL_HWPALETTE;
 	if (fullscreen) {
 		SDL_Log("fullscreen not yet supported with SDL1");
 	}


### PR DESCRIPTION
It works just fine on my RG300 device and is required for `SDL_DOUBLEBUF`.
https://www.libsdl.org/release/SDL-1.2.15/docs/html/sdlsetvideomode.html