### PR TITLE
[macOS] Standalone package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 
 script:
   - cd build
-  - cmake --DBINARY_RELEASE=ON ..
+  - cmake -DBINARY_RELEASE=ON ..
   - cmake --build . --target package -j $(sysctl -n hw.physicalcpu)
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 script:
   - cd build
   - cmake -DBINARY_RELEASE=ON ..
-  - cmake --build . --target package -j $(sysctl -n hw.physicalcpu)
+  - sudo cmake --build . --target package -j $(sysctl -n hw.physicalcpu)
 
 deploy:
   provider: releases

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,15 @@ if(APPLE)
 
   install (TARGETS devilutionx DESTINATION ./)
 
+  if(DIST)
+      set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR})
+      install(CODE "
+      include(BundleUtilities)
+      fixup_bundle(${CMAKE_INSTALL_PREFIX}/${MACOSX_BUNDLE_BUNDLE_NAME}.app \"\" \"\")
+      "
+      COMPONENT Runtime)
+  endif()
+
   set(MACOSX_BUNDLE_LONG_VERSION_STRING "Version ${PROJECT_VERSION}")
   set(CPACK_PACKAGE_FILE_NAME "devilutionx")
   set(CPACK_DMG_DISABLE_APPLICATIONS_SYMLINK "ON")


### PR DESCRIPTION
To solve the issue #278 this changes creates a standalone package (bundle) for macOS embedding all the dependencies inside the app.

Here is the documentation of cmake about this changes: https://cmake.org/cmake/help/v3.15/module/BundleUtilities.html

We're using the same logic of the 32-bit package of macOS, with the difference of this bundle use dylib instead of frameworks ('cause we're installing dylibs across brew).

Additionally I change the .travis.yml file for two reasons:

We're passing this cmake --DBINARY_RELEASE=ON .. to enable the release version with an extra -.
In the locally tests, the command fixup_bundle of cmake who calls to otool, needs more permissions to update the copy of libvorbis, so I added the sudo command to the build command (this is not needed for debug).