### PR TITLE
CMake: Explicitly enable POSIX extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,11 @@ if(WIN32)
   endif()
 endif()
 
+if(NOT WIN32 AND NOT APPLE)
+  # Enable POSIX extensions such as `readlink` and `ftruncate`.
+  add_definitions(-D_POSIX_C_SOURCE=200809L)
+endif()
+
 if(HAIKU)
   target_link_libraries(devilutionx PRIVATE network)
 endif()


### PR DESCRIPTION
This is needed when compiling on non-Linux platforms, such as Amiga,
Switch, etc.