### PR TITLE
SHA: Fix some implementation-defined behaviour

### DIFF
--- a/Source/sha.cpp
+++ b/Source/sha.cpp
@@ -23,7 +23,7 @@ namespace {
 ATTR_ALLOW_SHIFT_NEGATIVE_BASE
 std::uint32_t asr(std::int32_t value, std::int32_t amount)
 {
-	return !USES_ARITHMETIC_SHR(int) && value < 0 ? ~(~value >> amount) : value >> amount;
+	return !USES_ARITHMETIC_SHR(std::int32_t) && value < 0 ? ~(~value >> amount) : value >> amount;
 }
 
 /*
@@ -83,9 +83,9 @@ void SHA1Input(SHA1Context *context, const char *message_array, int len)
 
 void SHA1ProcessMessageBlock(SHA1Context *context)
 {
-	int i, temp;
-	int W[80];
-	int A, B, C, D, E;
+	DWORD i, temp;
+	DWORD W[80];
+	DWORD A, B, C, D, E;
 
 	DWORD *buf = (DWORD *)context->buffer;
 	for (i = 0; i < 16; i++)

--- a/Source/sha.cpp
+++ b/Source/sha.cpp
@@ -7,23 +7,19 @@ DEVILUTION_BEGIN_NAMESPACE
 // Diablo's "SHA1" is different from actual SHA1 in that it uses arithmetic
 // right shifts (sign bit extension).
 //
-// Here we check whether the platform does signed-bit extension.
-// If not, we fall back to a portable implementation.
-
-#define USES_ARITHMETIC_SHR(TYPE) (static_cast<TYPE>(-1) >> 1 == static_cast<TYPE>(-1))
-
-#if defined(__clang__) || defined(__GNUC__)
-#define ATTR_ALLOW_SHIFT_NEGATIVE_BASE __attribute__((no_sanitize("shift-base")))
-#else
-#define ATTR_ALLOW_SHIFT_NEGATIVE_BASE
-#endif
+// Note that:
+// 1. Tere is a C++20 proposal to make right shift always defined
+//    as an arithmetic shift with sign extension:
+//    http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0907r1.html
+// 2. Modern C++ compilers (GCC 8+, Clang 7+) compile the portable code
+//    to the same assembly as the implementation defined `value >> bits`:
+//    https://stackoverflow.com/a/53766752
 
 namespace {
 
-ATTR_ALLOW_SHIFT_NEGATIVE_BASE
 std::uint32_t asr(std::int32_t value, std::int32_t amount)
 {
-	return !USES_ARITHMETIC_SHR(std::int32_t) && value < 0 ? ~(~value >> amount) : value >> amount;
+	return value < 0 ? ~(~value >> amount) : value >> amount;
 }
 
 /*

--- a/Source/sha.h
+++ b/Source/sha.h
@@ -2,11 +2,6 @@
 #ifndef __SHA_H__
 #define __SHA_H__
 
-/*
- *  Define the SHA1 circular left shift macro
- */
-#define SHA1CircularShift(bits, word) \
-	(((word) << (bits)) | ((word) >> (32 - (bits))))
 #define SHA1HashSize 20
 
 //sha

--- a/structs.h
+++ b/structs.h
@@ -1433,8 +1433,8 @@ typedef struct PATHNODE {
 //////////////////////////////////////////////////
 
 typedef struct SHA1Context {
-	int state[5];
-	int count[2];
+	DWORD state[5];
+	DWORD count[2];
 	char buffer[64];
 } SHA1Context;
 


### PR DESCRIPTION
1. Shifting a negative integer.
2. Signed integer overflow.