### PR TITLE
Fix UB: load/store of misaligned render.cpp:130

### DIFF
--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -126,9 +126,10 @@ inline static void RenderLine(BYTE **dst, BYTE **src, int n, BYTE *tbl, DWORD ma
 			for (i = n & 3; i != 0; i--, (*src)++, (*dst)++) {
 				(*dst)[0] = (*src)[0];
 			}
-			for (i = n >> 2; i != 0; i--, (*src) += 4, (*dst) += 4) {
-				((DWORD *)(*dst))[0] = ((DWORD *)(*src))[0];
-			}
+			n = (n >> 2) << 2;
+			memcpy(*dst, *src, n);
+			(*src) += n;
+			(*dst) += n;
 		} else {
 			for (i = 0; i < n; i++, (*src)++, (*dst)++) {
 				(*dst)[0] = tbl[(*src)[0]];


### PR DESCRIPTION
> Source/render.cpp:130:47: runtime error: load of misaligned address 0x7fea0df260da for type 'DWORD', which requires 4 byte alignment
> Source/render.cpp:130:26: runtime error: store to misaligned address 0x7fea5796ff62 for type 'DWORD', which requires 4 byte alignment