### PR TITLE
Renderer texture: use RGB888 instead of RGBA8888

### DIFF
--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -72,8 +72,10 @@ void dx_create_primary_surface()
 		if (SDL_GetRendererOutputSize(renderer, &width, &height) <= -1) {
 			SDL_Log(SDL_GetError());
 		}
-		// TODO Get format from render/window
-		surface = SDL_CreateRGBSurfaceWithFormat(0, width, height, 32, SDL_PIXELFORMAT_RGBA8888);
+		Uint32 format;
+		if (SDL_QueryTexture(texture, &format, nullptr, nullptr, nullptr) < 0)
+			SDL_Log(SDL_GetError());
+		surface = SDL_CreateRGBSurfaceWithFormat(0, width, height, SDL_BITSPERPIXEL(format), format);
 	} else {
 		surface = SDL_GetWindowSurface(window);
 	}

--- a/SourceX/miniwin/misc.cpp
+++ b/SourceX/miniwin/misc.cpp
@@ -198,7 +198,7 @@ bool SpawnWindow(LPCSTR lpWindowName, int nWidth, int nHeight)
 			SDL_Log(SDL_GetError());
 		}
 
-		texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, nWidth, nHeight);
+		texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB888, SDL_TEXTUREACCESS_STREAMING, nWidth, nHeight);
 		if (texture == NULL) {
 			SDL_Log(SDL_GetError());
 		}

--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -596,7 +596,7 @@ BOOL SVidPlayBegin(char *filename, int a2, int a3, int a4, int a5, int flags, HA
 #ifndef USE_SDL1
 	if (renderer) {
 		SDL_DestroyTexture(texture);
-		texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, SVidWidth, SVidHeight);
+		texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB888, SDL_TEXTUREACCESS_STREAMING, SVidWidth, SVidHeight);
 		if (texture == NULL) {
 			SDL_Log(SDL_GetError());
 		}
@@ -794,7 +794,7 @@ BOOL SVidPlayEnd(HANDLE video)
 #ifndef USE_SDL1
 	if (renderer) {
 		SDL_DestroyTexture(texture);
-		texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, SCREEN_WIDTH, SCREEN_HEIGHT);
+		texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB888, SDL_TEXTUREACCESS_STREAMING, SCREEN_WIDTH, SCREEN_HEIGHT);
 		if (texture == NULL) {
 			SDL_Log(SDL_GetError());
 		}


### PR DESCRIPTION
Massively improves renderer performance.

While benchmarking the credits with scaling on, I realized there was a problem in how we set up the renderer.

It used an RGBA texture internally, causing blits to be *very* slow (RGBA blitting in software is terrible, as it has to blend instead of copy).

This simple change makes rendering ~3-5x faster. Should hopefully fix all performance / energy consumption issues on slower devices.

@AJenbo @vanfanel