### PR TITLE
Simplify SDL1/2 palette handling

### DIFF
--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -7,6 +7,8 @@
 #include "sdl2_to_1_2_backports.h"
 #endif
 
+#include "sdl_compat.h"
+
 #include "../types.h"
 
 //#ifdef __cplusplus

--- a/SourceS/sdl2_to_1_2_backports.h
+++ b/SourceS/sdl2_to_1_2_backports.h
@@ -204,28 +204,6 @@ SDL_FreePalette(SDL_Palette *palette)
 	SDL_free(palette);
 }
 
-inline int SDL_SetPaletteColors(SDL_Palette *palette, const SDL_Color *colors,
-    int firstcolor, int ncolors)
-{
-	int status = 0;
-
-	/* Verify the parameters */
-	if (!palette) {
-		return -1;
-	}
-	if (ncolors > (palette->ncolors - firstcolor)) {
-		ncolors = (palette->ncolors - firstcolor);
-		status = -1;
-	}
-
-	if (colors != (palette->colors + firstcolor)) {
-		SDL_memcpy(palette->colors + firstcolor, colors,
-		    ncolors * sizeof(*colors));
-	}
-
-	return status;
-}
-
 //= Pixel formats
 
 #define SDL_PIXELFORMAT_INDEX8 1

--- a/SourceS/sdl_compat.h
+++ b/SourceS/sdl_compat.h
@@ -1,0 +1,51 @@
+// Compatibility wrappers for SDL 1 & 2.
+#include <SDL.h>
+
+inline int SDLC_SetColorKey(SDL_Surface *surface, Uint32 key)
+{
+#ifdef USE_SDL1
+	return SDL_SetColorKey(surface, SDL_SRCCOLORKEY, key);
+#else
+	return SDL_SetColorKey(surface, SDL_TRUE, key);
+#endif
+}
+
+// Copies the colors into the surface's palette.
+inline int SDLC_SetSurfaceColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors)
+{
+#ifdef USE_SDL1
+	return SDL_SetPalette(surface, SDL_LOGPAL, colors, firstcolor, ncolors) - 1;
+#else
+	return SDL_SetPaletteColors(surface->format->palette, colors, firstcolor, ncolors);
+#endif
+}
+
+// Copies the colors into the surface's palette.
+inline int SDLC_SetSurfaceColors(SDL_Surface *surface, SDL_Palette *palette)
+{
+	return SDLC_SetSurfaceColors(surface, palette->colors, 0, palette->ncolors);
+}
+
+// Sets the palette's colors and:
+// SDL2: Points the surface's palette to the given palette if necessary.
+// SDL1: Sets the surface's colors.
+inline int SDLC_SetSurfaceAndPaletteColors(SDL_Surface *surface, SDL_Palette *palette, SDL_Color *colors, int firstcolor, int ncolors)
+{
+#ifdef USE_SDL1
+	if (ncolors > (palette->ncolors - firstcolor)) {
+		SDL_SetError("ncolors > (palette->ncolors - firstcolor)");
+		return -1;
+	}
+	if (colors != (palette->colors + firstcolor))
+		SDL_memcpy(palette->colors + firstcolor, colors, ncolors * sizeof(*colors));
+	// In SDL1, the surface always has its own distinct palette, so we need to
+	// update it as well.
+	return SDL_SetPalette(surface, SDL_LOGPAL, colors, firstcolor, ncolors) - 1;
+#else
+	if (SDL_SetPaletteColors(palette, colors, firstcolor, ncolors) < 0)
+		return -1;
+	if (surface->format->palette != palette)
+		return SDL_SetSurfacePalette(surface, palette);
+	return 0;
+#endif
+}

--- a/SourceX/DiabloUI/art.cpp
+++ b/SourceX/DiabloUI/art.cpp
@@ -45,13 +45,8 @@ void LoadArt(const char *pszFile, Art *art, int frames, PALETTEENTRY *pPalette)
 void LoadMaskedArt(const char *pszFile, Art *art, int frames, int mask)
 {
 	LoadArt(pszFile, art, frames);
-	if (art->surface != nullptr) {
-#ifdef USE_SDL1
-		SDL_SetColorKey(art->surface, SDL_SRCCOLORKEY, mask);
-#else
-		SDL_SetColorKey(art->surface, SDL_TRUE, mask);
-#endif
-	}
+	if (art->surface != nullptr)
+		SDLC_SetColorKey(art->surface, mask);
 }
 
 void LoadArt(Art *art, const BYTE *artData, int w, int h, int frames)

--- a/SourceX/DiabloUI/art_draw.cpp
+++ b/SourceX/DiabloUI/art_draw.cpp
@@ -28,13 +28,8 @@ void DrawArt(int screenX, int screenY, Art *art, int nFrame,
 	};
 
 	if (art->surface->format->BitsPerPixel == 8 && art->palette_version != pal_surface_palette_version) {
-#ifdef USE_SDL1
-		if (SDL_SetPalette(art->surface, SDL_LOGPAL, pal_surface->format->palette->colors, 0, 256) != 1)
+		if (SDLC_SetSurfaceColors(art->surface, pal_surface->format->palette) <= -1)
 			SDL_Log(SDL_GetError());
-#else
-		if (SDL_SetSurfacePalette(art->surface, pal_surface->format->palette) <= -1)
-			SDL_Log(SDL_GetError());
-#endif
 		art->palette_version = pal_surface_palette_version;
 	}
 

--- a/SourceX/DiabloUI/credits.cpp
+++ b/SourceX/DiabloUI/credits.cpp
@@ -72,12 +72,9 @@ CachedLine PrepareLine(std::size_t index)
 		const SDL_Color &mask_color = palette->colors[50]; // Any color different from both shadow and text
 		const SDL_Color &text_color = palette->colors[224];
 		SDL_Color colors[3] = { mask_color, text_color, shadow_color };
-		SDL_SetPaletteColors(surface->format->palette, colors, 0, 3);
-#ifdef USE_SDL1
-		SDL_SetColorKey(surface.get(), SDL_SRCCOLORKEY, 0);
-#else
-		SDL_SetColorKey(surface.get(), SDL_TRUE, 0);
-#endif
+		if (SDLC_SetSurfaceColors(surface.get(), colors, 0, 3) <= -1)
+			SDL_Log(SDL_GetError());
+		SDLC_SetColorKey(surface.get(), 0);
 
 		// Blit the shadow first:
 		SDL_Rect shadow_rect = { SHADOW_OFFSET_X, SHADOW_OFFSET_Y, 0, 0 };
@@ -86,15 +83,11 @@ CachedLine PrepareLine(std::size_t index)
 
 		// Change the text surface color and blit again:
 		SDL_Color text_colors[2] = { mask_color, text_color };
-#ifdef USE_SDL1
-		if (SDL_SetPalette(text.get(), SDL_LOGPAL, text_colors, 0, 2) != 1)
+
+		if (SDLC_SetSurfaceColors(text.get(), text_colors, 0, 2) <= -1)
 			SDL_Log(SDL_GetError());
-		SDL_SetColorKey(text.get(), SDL_SRCCOLORKEY, 0);
-#else
-		if (SDL_SetPaletteColors(text->format->palette, text_colors, 0, 2) <= -1)
-			SDL_Log(SDL_GetError());
-		SDL_SetColorKey(text.get(), SDL_TRUE, 0);
-#endif
+		SDLC_SetColorKey(text.get(), 0);
+
 		if (SDL_BlitSurface(text.get(), nullptr, surface.get(), nullptr) <= -1)
 			SDL_Log(SDL_GetError());
 	}

--- a/SourceX/DiabloUI/ttf_render_wrapped.cpp
+++ b/SourceX/DiabloUI/ttf_render_wrapped.cpp
@@ -130,11 +130,7 @@ SDL_Surface *RenderUTF8_Solid_Wrapped(TTF_Font *font, const char *text, SDL_Colo
 	palette->colors[1].r = fg.r;
 	palette->colors[1].g = fg.g;
 	palette->colors[1].b = fg.b;
-#ifdef USE_SDL1
-	SDL_SetColorKey(textbuf, SDL_SRCCOLORKEY, 0);
-#else
-	SDL_SetColorKey(textbuf, SDL_TRUE, 0);
-#endif
+	SDLC_SetColorKey(textbuf, 0);
 
 	// Reduced space between lines to roughly match Diablo.
 	const int lineskip = 0.7 * TTF_FontLineSkip(font);

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -50,11 +50,7 @@ void dx_create_back_buffer()
 
 	gpBuffer = (BYTE *)pal_surface->pixels;
 
-#ifdef USE_SDL1
-	if (SDL_SetPalette(pal_surface, SDL_LOGPAL, palette->colors, 0, palette->ncolors) != 1) {
-#else
-	if (SDL_SetSurfacePalette(pal_surface, palette) <= -1) {
-#endif
+	if (SDLC_SetSurfaceColors(pal_surface, palette) <= -1) {
 		SDL_Log(SDL_GetError());
 		UiErrorOkDialog("SDL Error", SDL_GetError());
 	}

--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -623,11 +623,7 @@ BOOL SVidPlayBegin(char *filename, int a2, int a3, int a4, int a5, int flags, HA
 	if (SVidPalette == NULL) {
 		SDL_Log(SDL_GetError());
 	}
-#ifdef USE_SDL1
-	if (SDL_SetPalette(SVidSurface, SDL_LOGPAL, SVidPalette->colors, 0, SVidPalette->ncolors) != 1) {
-#else
-	if (SDL_SetSurfacePalette(SVidSurface, SVidPalette) <= -1) {
-#endif
+	if (SDLC_SetSurfaceColors(SVidSurface, SVidPalette) <= -1) {
 		SDL_Log(SDL_GetError());
 		if (HaveAudio())
 			SVidRestartMixer();
@@ -675,17 +671,10 @@ BOOL SVidPlayContinue(void)
 		}
 		memcpy(logical_palette, orig_palette, 1024);
 
-		if (SDL_SetPaletteColors(SVidPalette, colors, 0, 256) <= -1) {
+		if (SDLC_SetSurfaceAndPaletteColors(SVidSurface, SVidPalette, colors, 0, 256) <= -1) {
 			SDL_Log(SDL_GetError());
 			return false;
 		}
-
-#ifdef USE_SDL1
-		if (SDL_SetPalette(SVidSurface, SDL_LOGPAL, SVidPalette->colors, 0, SVidPalette->ncolors) != 1) {
-			SDL_Log(SDL_GetError());
-			return false;
-		}
-#endif
 	}
 
 	if (SDL_GetTicks() * 1000 >= SVidFrameEnd) {

--- a/SourceX/storm/storm_dx.cpp
+++ b/SourceX/storm/storm_dx.cpp
@@ -24,22 +24,10 @@ BOOL SDrawUpdatePalette(unsigned int firstentry, unsigned int numentries, PALETT
 	}
 
 	assert(palette);
-	if (SDL_SetPaletteColors(palette, colors, firstentry, numentries) <= -1) {
+	if (SDLC_SetSurfaceAndPaletteColors(pal_surface, palette, colors, firstentry, numentries) <= -1) {
 		SDL_Log(SDL_GetError());
 		return false;
 	}
-
-#ifdef USE_SDL1
-	// In SDL2, the `pal_surface` owns the `pallete`, so modifying the palette
-	// directly updates the `pal_surface` palette.
-	//
-	// In SDL1, the `palette` is independent of `pal_surface`, so we need to
-	// explictly update the surface's palette here (SetPalette *copies* the palette).
-	if (SDL_SetPalette(pal_surface, SDL_LOGPAL, palette->colors, 0, palette->ncolors) != 1) {
-		SDL_Log(SDL_GetError());
-		return false;
-	}
-#endif
 	++pal_surface_palette_version;
 
 	return true;


### PR DESCRIPTION
SDL 1 and 2 handle surface palettes very differently.
This adds a few compatibility functions that do the right thing
depending on the SDL version.

This lets us remove many instances of `#ifdef USE_SDL1`