### PR TITLE
SDL1: Remove SDL_DOUBLEBUF

### DIFF
--- a/SourceX/miniwin/misc.cpp
+++ b/SourceX/miniwin/misc.cpp
@@ -136,7 +136,7 @@ bool SpawnWindow(LPCSTR lpWindowName, int nWidth, int nHeight)
 	DvlIntSetting("grab input", &grabInput);
 
 #ifdef USE_SDL1
-	int flags = SDL_SWSURFACE | SDL_DOUBLEBUF | SDL_HWPALETTE;
+	int flags = SDL_SWSURFACE | SDL_HWPALETTE;
 	if (fullscreen)
 		flags |= SDL_FULLSCREEN;
 	SDL_WM_SetCaption(lpWindowName, WINDOW_ICON_NAME);


### PR DESCRIPTION
Turns out this causes flickering when consuming a potion in the belt on RG300.
Since it also doesn't work on Amiga, just remove it for now.