### PR TITLE
Handle scaling for SDL1

### DIFF
--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -283,8 +283,14 @@ bool UiFocusNavigation(SDL_Event *event)
 		}
 	}
 
-	if (UiItemMouseEvents(event, gUiItems, gUiItemCnt))
-		return true;
+	if (event->type == SDL_MOUSEBUTTONDOWN || event->type == SDL_MOUSEBUTTONUP) {
+		// In SDL2 mouse events already use logical coordinates.
+#ifdef USE_SDL1
+		OutputToLogical(&event->button.x, &event->button.y);
+#endif
+		if (UiItemMouseEvents(event, gUiItems, gUiItemCnt))
+			return true;
+	}
 
 	return false;
 }
@@ -782,21 +788,7 @@ void DrawMouse()
 		return;
 
 	SDL_GetMouseState(&MouseX, &MouseY);
-
-#ifndef USE_SDL1
-	if (renderer) {
-		float scaleX;
-		SDL_RenderGetScale(renderer, &scaleX, NULL);
-		MouseX /= scaleX;
-		MouseY /= scaleX;
-
-		SDL_Rect view;
-		SDL_RenderGetViewport(renderer, &view);
-		MouseX -= view.x;
-		MouseY -= view.y;
-	}
-#endif
-
+	OutputToLogical(&MouseX, &MouseY);
 	DrawArt(MouseX, MouseY, &ArtCursor);
 }
 

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -186,12 +186,21 @@ void BltFast(DWORD dwX, DWORD dwY, LPRECT lpSrcRect)
 		static_cast<decltype(SDL_Rect().y)>(dwY),
 		w, h
 	};
-
-	// Convert from 8-bit to 32-bit
-	if (SDL_BlitSurface(pal_surface, &src_rect, GetOutputSurface(), &dst_rect) <= -1) {
-		ErrSdl();
+	if (OutputRequiresScaling()) {
+		ScaleOutputRect(&dst_rect);
+		// Convert from 8-bit to 32-bit
+		SDL_Surface *tmp = SDL_ConvertSurface(pal_surface, GetOutputSurface()->format, 0);
+		if (SDL_BlitScaled(tmp, &src_rect, GetOutputSurface(), &dst_rect) <= -1) {
+			SDL_FreeSurface(tmp);
+			ErrSdl();
+		}
+		SDL_FreeSurface(tmp);
+	} else {
+		// Convert from 8-bit to 32-bit
+		if (SDL_BlitSurface(pal_surface, &src_rect, GetOutputSurface(), &dst_rect) <= -1) {
+			ErrSdl();
+		}
 	}
-
 	bufferUpdated = true;
 }
 

--- a/SourceX/miniwin/ddraw.cpp
+++ b/SourceX/miniwin/ddraw.cpp
@@ -4,7 +4,8 @@ namespace dvl {
 
 extern SDL_Surface *renderer_texture_surface; // defined in dx.cpp
 
-SDL_Surface *GetOutputSurface() {
+SDL_Surface *GetOutputSurface()
+{
 #ifdef USE_SDL1
 	return SDL_GetVideoSurface();
 #else
@@ -12,6 +13,26 @@ SDL_Surface *GetOutputSurface() {
 		return renderer_texture_surface;
 	return SDL_GetWindowSurface(window);
 #endif
+}
+
+bool OutputRequiresScaling()
+{
+#ifdef USE_SDL1
+	return SCREEN_WIDTH != GetOutputSurface()->w;
+#else // SDL2, scaling handled by renderer.
+	return false;
+#endif
+}
+
+void ScaleOutputRect(SDL_Rect *rect)
+{
+	if (!OutputRequiresScaling())
+		return;
+	const auto *surface = GetOutputSurface();
+	rect->x = rect->x * surface->w / SCREEN_WIDTH;
+	rect->y = rect->y * surface->h / SCREEN_HEIGHT;
+	rect->w = rect->w * surface->w / SCREEN_WIDTH;
+	rect->h = rect->h * surface->h / SCREEN_HEIGHT;
 }
 
 } // namespace dvl

--- a/SourceX/miniwin/ddraw.cpp
+++ b/SourceX/miniwin/ddraw.cpp
@@ -18,7 +18,7 @@ SDL_Surface *GetOutputSurface()
 bool OutputRequiresScaling()
 {
 #ifdef USE_SDL1
-	return SCREEN_WIDTH != GetOutputSurface()->w;
+	return SCREEN_WIDTH != GetOutputSurface()->w || SCREEN_HEIGHT != GetOutputSurface()->h;
 #else // SDL2, scaling handled by renderer.
 	return false;
 #endif

--- a/SourceX/miniwin/ddraw.h
+++ b/SourceX/miniwin/ddraw.h
@@ -63,15 +63,15 @@ void LogicalToOutput(T *x, T *y)
 #ifndef USE_SDL1
 	if (!renderer)
 		return;
-	float scaleX;
-	SDL_RenderGetScale(renderer, &scaleX, NULL);
-	*x /= scaleX;
-	*y /= scaleX;
-
 	SDL_Rect view;
 	SDL_RenderGetViewport(renderer, &view);
-	*x -= view.x;
-	*y -= view.y;
+	*x += view.x;
+	*y += view.y;
+
+	float scaleX;
+	SDL_RenderGetScale(renderer, &scaleX, NULL);
+	*x *= scaleX;
+	*y *= scaleX;
 #else
 	if (!OutputRequiresScaling())
 		return;

--- a/SourceX/miniwin/ddraw.h
+++ b/SourceX/miniwin/ddraw.h
@@ -1,5 +1,8 @@
+#pragma once
+
 #include "devilution.h"
 #include <SDL.h>
+#include <type_traits>
 
 namespace dvl {
 
@@ -17,5 +20,65 @@ extern bool bufferUpdated;
 // SDL2, no upscale: Window surface.
 // SDL2, upscale: Renderer texture surface.
 SDL_Surface *GetOutputSurface();
+
+// Whether the output surface requires software scaling.
+// Always returns false on SDL2.
+bool OutputRequiresScaling();
+
+// Scales rect if necessary.
+void ScaleOutputRect(SDL_Rect *rect);
+
+// Convert from output coordinates to logical (resolution-independent) coordinates.
+template <
+    typename T,
+    typename = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
+void OutputToLogical(T *x, T *y)
+{
+#ifndef USE_SDL1
+	if (!renderer)
+		return;
+	float scaleX;
+	SDL_RenderGetScale(renderer, &scaleX, NULL);
+	*x /= scaleX;
+	*y /= scaleX;
+
+	SDL_Rect view;
+	SDL_RenderGetViewport(renderer, &view);
+	*x -= view.x;
+	*y -= view.y;
+#else
+	if (!OutputRequiresScaling())
+		return;
+	const auto *surface = GetOutputSurface();
+	*x = *x * SCREEN_WIDTH / surface->w;
+	*y = *y * SCREEN_HEIGHT / surface->h;
+#endif
+}
+
+template <
+    typename T,
+    typename = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
+void LogicalToOutput(T *x, T *y)
+{
+#ifndef USE_SDL1
+	if (!renderer)
+		return;
+	float scaleX;
+	SDL_RenderGetScale(renderer, &scaleX, NULL);
+	*x /= scaleX;
+	*y /= scaleX;
+
+	SDL_Rect view;
+	SDL_RenderGetViewport(renderer, &view);
+	*x -= view.x;
+	*y -= view.y;
+#else
+	if (!OutputRequiresScaling())
+		return;
+	const auto *surface = GetOutputSurface();
+	*x = *x * surface->w / SCREEN_WIDTH;
+	*y = *y * surface->h / SCREEN_HEIGHT;
+#endif
+}
 
 } // namespace dvl

--- a/SourceX/miniwin/dsound.h
+++ b/SourceX/miniwin/dsound.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "devilution.h"
 
 #include <SDL_mixer.h>

--- a/SourceX/miniwin/misc_msg.cpp
+++ b/SourceX/miniwin/misc_msg.cpp
@@ -8,6 +8,7 @@
 #include "controls/controller_motion.h"
 #include "controls/game_controls.h"
 #include "controls/plrctrls.h"
+#include "miniwin/ddraw.h"
 
 /** @file
  * *
@@ -26,22 +27,8 @@ void SetCursorPos(int X, int Y)
 {
 	mouseWarpingX = X;
 	mouseWarpingY = Y;
-
-#ifndef USE_SDL1
-	if (renderer) {
-		SDL_Rect view;
-		SDL_RenderGetViewport(renderer, &view);
-		X += view.x;
-		Y += view.y;
-
-		float scaleX;
-		SDL_RenderGetScale(renderer, &scaleX, NULL);
-		X *= scaleX;
-		Y *= scaleX;
-	}
-#endif
-
 	mouseWarping = true;
+	LogicalToOutput(&X, &Y);
 	SDL_WarpMouseInWindow(window, X, Y);
 }
 
@@ -400,6 +387,14 @@ WINBOOL PeekMessageA(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilter
 		lpMsg->message = DVL_WM_QUIT;
 		return true;
 	}
+
+#ifdef USE_SDL1
+	if (e.type == SDL_MOUSEMOTION) {
+		OutputToLogical(&e.motion.x, &e.motion.y);
+	} else if (e.type == SDL_MOUSEBUTTONDOWN || e.type == SDL_MOUSEBUTTONUP) {
+		OutputToLogical(&e.button.x, &e.button.y);
+	}
+#endif
 
 	if (movie_playing) {
 		if (ShouldSkipMovie(e))

--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -721,6 +721,7 @@ BOOL SVidPlayContinue(void)
 		Uint32 format = SDL_GetWindowPixelFormat(window);
 		SDL_Surface *tmp = SDL_ConvertSurfaceFormat(SVidSurface, format, 0);
 #endif
+		ScaleOutputRect(&pal_surface_offset);
 		if (SDL_BlitScaled(tmp, NULL, GetOutputSurface(), &pal_surface_offset) <= -1) {
 			SDL_Log(SDL_GetError());
 			return false;


### PR DESCRIPTION
Background: Only some handheld devices support auto-scaling. E.g. the LDK has a screen with 320x480 resolution (non-square pixels!), so we need to scale in software.

If the target surface resolution is smaller than `SCREEN_*`, we need to scale manually.

Hardware auto-scaler check for jz4760 provided by @jbanes and @scooterpsu

NOTE: This doesn't implement upscaling, but rather scaling when output surface size is different from logical size. With this, implementing upscaling is trivial but perhaps unnecessary for SDL1.