### PR TITLE
Use an enum for connection type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,7 +353,7 @@ if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_compile_options(devilution PRIVATE -fpermissive -w)
 
   # Warnings for devilutionX
-  target_compile_options(devilutionx PRIVATE -Wall -Wextra -Wno-write-strings -Wno-multichar -Wno-unused-parameter -Wno-missing-field-initializers -Wno-format-security)
+  target_compile_options(devilutionx PRIVATE -Wall -Wextra -Wno-write-strings -Wno-unused-parameter -Wno-missing-field-initializers -Wno-format-security)
 
   # For ARM and other default unsigned char platforms
   target_compile_options(devilution PRIVATE -fsigned-char)

--- a/SourceX/DiabloUI/selconn.cpp
+++ b/SourceX/DiabloUI/selconn.cpp
@@ -16,21 +16,11 @@ _SNETPLAYERDATA *selconn_UserInfo;
 _SNETUIDATA *selconn_UiInfo;
 _SNETVERSIONDATA *selconn_FileInfo;
 
-DWORD provider;
+int provider;
 
 UiArtText SELCONNECT_DIALOG_DESCRIPTION(selconn_Description, { 35, 275, 205, 66 });
 
-// Should be in the same order than SELCONN_DIALOG_ITEM
-enum {
-#ifndef NONET
-	SELCONN_TCP,
-#ifdef BUGGY
-	SELCONN_UDP,
-#endif
-#endif
-	SELCONN_LOOPBACK,
-};
-
+// Should be in the same order than conn_type (See enums.h)
 UiListItem SELCONN_DIALOG_ITEMS[] = {
 #ifndef NONET
 	{ "Client-Server (TCP)", SELCONN_TCP },
@@ -102,21 +92,7 @@ void selconn_Focus(int value)
 
 void selconn_Select(int value)
 {
-	switch (value) {
-#ifndef NONET
-	case SELCONN_TCP:
-		provider = 'TCPN';
-		break;
-#ifdef BUGGY
-	case SELCONN_UDP:
-		provider = 'UDPN';
-		break;
-#endif
-#endif
-	case SELCONN_LOOPBACK:
-		provider = 'SCBL';
-		break;
-	}
+	provider = value;
 
 	selconn_Free();
 	selconn_EndMenu = SNetInitializeProvider(provider, selconn_ClientInfo, selconn_UserInfo, selconn_UiInfo, selconn_FileInfo);

--- a/SourceX/DiabloUI/selgame.cpp
+++ b/SourceX/DiabloUI/selgame.cpp
@@ -19,7 +19,7 @@ int *gdwPlayerId;
 int gbDifficulty;
 
 static _SNETPROGRAMDATA *m_client_info;
-extern DWORD provider;
+extern int provider;
 
 constexpr UiArtTextButton SELGAME_OK = UiArtTextButton("OK", &UiFocusNavigationSelect, { 299, 427, 140, 35 }, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD);
 constexpr UiArtTextButton SELGAME_CANCEL = UiArtTextButton("CANCEL", &UiFocusNavigationEsc, { 449, 427, 140, 35 }, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD);
@@ -96,7 +96,7 @@ void selgame_GameSelection_Init()
 	selgame_enteringGame = false;
 	selgame_selectedGame = 0;
 
-	if (provider == 'SCBL') {
+	if (provider == SELCONN_LOOPBACK) {
 		selgame_enteringGame = true;
 		selgame_GameSelection_Select(0);
 		return;
@@ -164,7 +164,7 @@ void selgame_Diff_Select(int value)
 {
 	gbDifficulty = value;
 
-	if (provider == 'SCBL') {
+	if (provider == SELCONN_LOOPBACK) {
 		selgame_Password_Select(0);
 		return;
 	}
@@ -174,7 +174,7 @@ void selgame_Diff_Select(int value)
 
 void selgame_Diff_Esc()
 {
-	if (provider == 'SCBL') {
+	if (provider == SELCONN_LOOPBACK) {
 		selgame_GameSelection_Esc();
 		return;
 	}

--- a/SourceX/dvlnet/abstract_net.cpp
+++ b/SourceX/dvlnet/abstract_net.cpp
@@ -19,13 +19,16 @@ std::unique_ptr<abstract_net> abstract_net::make_net(provider_t provider)
 #ifdef NONET
 	return std::unique_ptr<abstract_net>(new loopback);
 #else
-	if (provider == 'TCPN') {
+	switch (provider) {
+	case SELCONN_TCP:
 		return std::unique_ptr<abstract_net>(new tcp_client);
-	} else if (provider == 'UDPN') {
+#ifdef BUGGY
+	case SELCONN_UDP:
 		return std::unique_ptr<abstract_net>(new udp_p2p);
-	} else if (provider == 'SCBL' || provider == 0) {
+#endif
+	case SELCONN_LOOPBACK:
 		return std::unique_ptr<abstract_net>(new loopback);
-	} else {
+	default:
 		ABORT();
 	}
 #endif

--- a/enums.h
+++ b/enums.h
@@ -2917,3 +2917,13 @@ typedef enum dlrg_flag {
 	DLRG_CHAMBER   = 0x40,
 	DLRG_PROTECTED = 0x80,
 } dlrg_flag;
+
+typedef enum conn_type {
+#ifndef NONET
+	SELCONN_TCP,
+#ifdef BUGGY
+	SELCONN_UDP,
+#endif
+#endif
+	SELCONN_LOOPBACK,
+} conn_type;


### PR DESCRIPTION
This fixes some "multi-character character constant" warnings. See https://github.com/diasurgical/devilutionX/issues/279. I tried to comply with existing naming and coding style, but feedback is always welcome. =)

Tested on Fedora 30 x86_64:
- Single player game is OK
- Multiplayer game with TCP is OK

This contribution is sponsored by my company, [Genymobile](https://github.com/Genymobile), for #hacktoberfest.
