### PR TITLE
Fix some write-strings warnings

### DIFF
--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -489,7 +489,7 @@ int GetCenterOffset(int w, int bw)
 	return (bw - w) / 2;
 }
 
-void LoadBackgroundArt(char *pszFile)
+void LoadBackgroundArt(const char *pszFile)
 {
 	PALETTEENTRY pPal[256];
 

--- a/SourceX/DiabloUI/diabloui.h
+++ b/SourceX/DiabloUI/diabloui.h
@@ -45,7 +45,7 @@ bool UiItemMouseEvents(SDL_Event *event, UiItem *items, std::size_t size);
 int GetCenterOffset(int w, int bw = 0);
 void LoadPalInMem(const PALETTEENTRY *pPal);
 void DrawMouse();
-void LoadBackgroundArt(char *pszFile);
+void LoadBackgroundArt(const char *pszFile);
 void SetMenu(int MenuId);
 void UiFocusNavigationSelect();
 void UiFocusNavigationEsc();

--- a/SourceX/DiabloUI/fonts.cpp
+++ b/SourceX/DiabloUI/fonts.cpp
@@ -8,7 +8,7 @@ Art ArtFonts[4][2];
 
 namespace {
 
-void LoadArtFont(char *pszFile, int size, int color)
+void LoadArtFont(const char *pszFile, int size, int color)
 {
 	LoadMaskedArt(pszFile, &ArtFonts[size][color], 256, 32);
 }

--- a/SourceX/DiabloUI/mainmenu.cpp
+++ b/SourceX/DiabloUI/mainmenu.cpp
@@ -43,10 +43,11 @@ void mainmenu_Load(char *name, void (*fnSound)(char *file))
 
 	MainMenuResult = 0;
 
-	char *pszFile = "ui_art\\mainmenu.pcx";
-	if (false) //DiabloUI_GetSpawned()
-		pszFile = "ui_art\\swmmenu.pcx";
-	LoadBackgroundArt(pszFile);
+	if (!gbSpawned) {
+		LoadBackgroundArt("ui_art\\mainmenu.pcx");
+	} else {
+		LoadBackgroundArt("ui_art\\swmmenu.pcx");
+	}
 
 	UiInitList(MAINMENU_SINGLE_PLAYER, MAINMENU_EXIT_DIABLO, NULL, UiMainMenuSelect, mainmenu_Esc, MAINMENU_DIALOG, size(MAINMENU_DIALOG), true);
 }


### PR DESCRIPTION
Declare `const char*` arguments to get proper string conversion. Some of these warnings still remain, as it involves code from Source/ directory. This is why I kept the `-Wno-write-strings`.

According to https://github.com/diasurgical/devilutionX/issues/279, those fixes should not be made outside of SourceX/. But if I have the green light, I will be happy to fix them all. =)