### PR TITLE
Fix OOB in DrawSpell

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -226,13 +226,13 @@ void SetSpellTrans(char t)
  */
 void DrawSpell()
 {
-	char spl, st;
-	int tlvl;
+	char st;
+	int spl, tlvl;
 
 	spl = plr[myplr]._pRSpell;
 	st = plr[myplr]._pRSplType;
-	tlvl = plr[myplr]._pISplLvlAdd + plr[myplr]._pSplLvl[spl];
 	if (st == RSPLTYPE_SPELL && spl != SPL_INVALID) {
+		tlvl = plr[myplr]._pISplLvlAdd + plr[myplr]._pSplLvl[spl];
 		if (!CheckSpell(myplr, spl, RSPLTYPE_SPELL, TRUE))
 			st = RSPLTYPE_INVALID;
 		if (tlvl <= 0)


### PR DESCRIPTION
The OOB here was in `_pSplLvl[spl]`.

The value of `SPL_INVALID` is defined as `0xFFFFFFFF`, which is `-1` if you're lucky with the `sizeof(int)`.

The fix is 2-fold:
1. Change the type of `spl` to `int` to avoid depending on `sizeof(int)`.
2. Do not access the array when `spl == SPL_INVALID`.

By the way, perhaps `SPL_INVALID` was defined as `-1` in the original game?