### PR TITLE
Fix Linux compiling section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ sudo dnf install cmake glibc-devel SDL2-devel SDL2_ttf-devel SDL2_mixer-devel li
 ```
 cd build
 cmake ..
-cmake --build . -j $(nproc)
+cmake --build . -- -j $(nproc)
 ```
 </details>
 


### PR DESCRIPTION
`--` is required to separate remaining options for the native tool

```bash
$ cmake --build . -j $(nproc)
Unknown argument -j
Unknown argument 8
Usage: cmake --build <dir> [options] [-- [native-options]]
Options:
  <dir>          = Project binary directory to be built.
  --target <tgt> = Build <tgt> instead of default targets.
                   May only be specified once.
  --config <cfg> = For multi-configuration tools, choose <cfg>.
  --clean-first  = Build target 'clean' first, then build.
                   (To clean only, use --target 'clean'.)
  --use-stderr   = Ignored.  Behavior is default in CMake >= 3.0.
  --             = Pass remaining options to the native tool.
```

```bash
$ cmake --build . -- -j $(nproc)
Scanning dependencies of target StormLib
...
```