### PR TITLE
add all.h and use in place of diablo.h

### DIFF
--- a/Source/all.h
+++ b/Source/all.h
@@ -1,0 +1,96 @@
+#ifndef __ALL_H__
+#define __ALL_H__
+
+#include <SDL.h>
+
+#ifdef USE_SDL1
+#include "sdl2_to_1_2_backports.h"
+#else
+#include "sdl2_backports.h"
+#endif
+
+#include "sdl_compat.h"
+
+#include "../types.h"
+
+//#ifdef __cplusplus
+//extern "C" {
+//#endif
+#include "appfat.h"
+#include "automap.h"
+#include "capture.h"
+#include "codec.h"
+#include "control.h"
+#include "cursor.h"
+#include "dead.h"
+#include "debug.h"
+#include "diablo.h"
+#include "doom.h"
+#include "drlg_l1.h"
+#include "drlg_l2.h"
+#include "drlg_l3.h"
+#include "drlg_l4.h"
+#include "dthread.h"
+#include "dx.h"
+#include "effects.h"
+#include "encrypt.h"
+#include "engine.h"
+#include "error.h"
+#include "gamemenu.h"
+#include "gendung.h"
+#include "gmenu.h"
+#include "help.h"
+#include "init.h"
+#include "interfac.h"
+#include "inv.h"
+#include "itemdat.h"
+#include "items.h"
+#include "lighting.h"
+#include "loadsave.h"
+#include "mainmenu.h"
+#include "minitext.h"
+#include "misdat.h"
+#include "missiles.h"
+#include "monstdat.h"
+#include "monster.h"
+#include "movie.h"
+#include "mpqapi.h"
+#include "msg.h"
+#include "multi.h"
+#include "nthread.h"
+#include "objdat.h"
+#include "objects.h"
+#include "pack.h"
+#include "palette.h"
+#include "path.h"
+#include "pfile.h"
+#include "player.h"
+#include "plrmsg.h"
+#include "portal.h"
+#include "quests.h"
+#include "restrict.h"
+#include "scrollrt.h"
+#include "setmaps.h"
+#include "sha.h"
+#include "sound.h"
+#include "spelldat.h"
+#include "spells.h"
+#include "stores.h"
+#include "sync.h"
+#include "textdat.h" // check file name
+#include "themes.h"
+#include "tmsg.h"
+#include "town.h"
+#include "towners.h"
+#include "track.h"
+#include "trigs.h"
+#include "wave.h"
+#include "render.h" // linked last, likely .s/.asm
+//#ifdef __cplusplus
+//}
+//#endif
+
+#include "miniwin/popdecl.inc"
+DEVILUTION_END_NAMESPACE
+
+#endif /* __ALL_H__ */

--- a/Source/appfat.cpp
+++ b/Source/appfat.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include <config.h>
 

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/Source/codec.cpp
+++ b/Source/codec.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include "../DiabloUI/diabloui.h"
 

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -1,94 +1,6 @@
 #ifndef __DIABLO_H__
 #define __DIABLO_H__
 
-#include <SDL.h>
-
-#ifdef USE_SDL1
-#include "sdl2_to_1_2_backports.h"
-#else
-#include "sdl2_backports.h"
-#endif
-
-#include "sdl_compat.h"
-
-#include "../types.h"
-
-//#ifdef __cplusplus
-//extern "C" {
-//#endif
-#include "appfat.h"
-#include "automap.h"
-#include "capture.h"
-#include "codec.h"
-#include "control.h"
-#include "cursor.h"
-#include "dead.h"
-#include "debug.h"
-#include "doom.h"
-#include "drlg_l1.h"
-#include "drlg_l2.h"
-#include "drlg_l3.h"
-#include "drlg_l4.h"
-#include "dthread.h"
-#include "dx.h"
-#include "effects.h"
-#include "encrypt.h"
-#include "engine.h"
-#include "error.h"
-#include "gamemenu.h"
-#include "gendung.h"
-#include "gmenu.h"
-#include "help.h"
-#include "init.h"
-#include "interfac.h"
-#include "inv.h"
-#include "itemdat.h"
-#include "items.h"
-#include "lighting.h"
-#include "loadsave.h"
-#include "mainmenu.h"
-#include "minitext.h"
-#include "misdat.h"
-#include "missiles.h"
-#include "monstdat.h"
-#include "monster.h"
-#include "movie.h"
-#include "mpqapi.h"
-#include "msg.h"
-#include "multi.h"
-#include "nthread.h"
-#include "objdat.h"
-#include "objects.h"
-#include "pack.h"
-#include "palette.h"
-#include "path.h"
-#include "pfile.h"
-#include "player.h"
-#include "plrmsg.h"
-#include "portal.h"
-#include "quests.h"
-#include "restrict.h"
-#include "scrollrt.h"
-#include "setmaps.h"
-#include "sha.h"
-#include "sound.h"
-#include "spelldat.h"
-#include "spells.h"
-#include "stores.h"
-#include "sync.h"
-#include "textdat.h" // check file name
-#include "themes.h"
-#include "tmsg.h"
-#include "town.h"
-#include "towners.h"
-#include "track.h"
-#include "trigs.h"
-#include "wave.h"
-#include "render.h" // linked last, likely .s/.asm
-//#ifdef __cplusplus
-//}
-//#endif
-
 extern HWND ghMainWnd;
 extern int glMid1Seed[NUMLEVELS];
 extern int glMid2Seed[NUMLEVELS];
@@ -179,8 +91,5 @@ extern int framestart;
 extern BOOL FriendlyMode;
 extern char *spszMsgTbl[4];
 extern char *spszMsgHotKeyTbl[4];
-
-#include "miniwin/popdecl.inc"
-DEVILUTION_END_NAMESPACE
 
 #endif /* __DIABLO_H__ */

--- a/Source/doom.cpp
+++ b/Source/doom.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/drlg_l2.cpp
+++ b/Source/drlg_l2.cpp
@@ -2,7 +2,7 @@
 
 #include <algorithm>
 
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/drlg_l3.cpp
+++ b/Source/drlg_l3.cpp
@@ -2,7 +2,7 @@
 
 #include <algorithm>
 
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include <SDL_mixer.h>
 

--- a/Source/encrypt.cpp
+++ b/Source/encrypt.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/PKWare/pkware.h"
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/help.cpp
+++ b/Source/help.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 #include "../3rdParty/Storm/Source/storm.h"
 #include "../DiabloUI/diabloui.h"

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/itemdat.cpp
+++ b/Source/itemdat.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include "../DiabloUI/diabloui.h"
 

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/misdat.cpp
+++ b/Source/misdat.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/monstdat.cpp
+++ b/Source/monstdat.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include "../DiabloUI/diabloui.h"
 

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include "../DiabloUI/diabloui.h"
 

--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/Source/objdat.cpp
+++ b/Source/objdat.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/Source/path.cpp
+++ b/Source/path.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include "../DiabloUI/diabloui.h"
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/portal.cpp
+++ b/Source/portal.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/restrict.cpp
+++ b/Source/restrict.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/setmaps.cpp
+++ b/Source/setmaps.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/sha.cpp
+++ b/Source/sha.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 #include <cstdint>
 

--- a/Source/spelldat.cpp
+++ b/Source/spelldat.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/textdat.cpp
+++ b/Source/textdat.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/themes.cpp
+++ b/Source/themes.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/tmsg.cpp
+++ b/Source/tmsg.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/wave.cpp
+++ b/Source/wave.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/SourceS/devilution.h
+++ b/SourceS/devilution.h
@@ -1,2 +1,2 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -1,4 +1,4 @@
-#include "diablo.h"
+#include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include "miniwin/ddraw.h"
 #include "miniwin/com_macro.h"


### PR DESCRIPTION
Now diablo.h is treated in the same way as all other header files
of Source, as it only contains the declarations of global variables
and functions of diablo.cpp.