### PR TITLE
[SWITCH] Fix touch and remove unneeded ifdefs

### DIFF
--- a/SourceX/controls/touch.cpp
+++ b/SourceX/controls/touch.cpp
@@ -1,7 +1,13 @@
 #ifndef USE_SDL1
 #include "miniwin/ddraw.h"
 #include "touch.h"
+#include "../../defs.h"
 #include <math.h>
+
+static int visible_width;
+static int visible_height;
+static int x_borderwidth;
+static int y_borderwidth;
 
 template <typename T>
 inline T clip(T v, T amin, T amax)
@@ -71,6 +77,13 @@ static void init_touch(void)
 			simulated_click_start_time[port][i] = 0;
 		}
 	}
+
+	SDL_DisplayMode current;
+	SDL_GetCurrentDisplayMode(0, &current);
+	visible_height = current.h;
+	visible_width = (current.h * SCREEN_WIDTH) / SCREEN_HEIGHT;
+	x_borderwidth = (current.w - visible_width) / 2;
+	y_borderwidth = (current.h - visible_height) / 2;
 }
 
 static void preprocess_events(SDL_Event *event)
@@ -115,8 +128,8 @@ static void preprocess_finger_down(SDL_Event *event)
 	int y = mouse_y;
 
 	if (direct_touch) {
-		x = event->tfinger.x;
-		y = event->tfinger.y;
+		x = event->tfinger.x * visible_width + x_borderwidth;
+		y = event->tfinger.y * visible_height + y_borderwidth;
 		dvl::OutputToLogical(&x, &y);
 	}
 
@@ -197,8 +210,8 @@ static void preprocess_finger_up(SDL_Event *event)
 				// need to raise the button later
 				simulated_click_start_time[port][0] = event->tfinger.timestamp;
 				if (direct_touch) {
-					x = event->tfinger.x;
-					y = event->tfinger.y;
+					x = event->tfinger.x * visible_width + x_borderwidth;
+					y = event->tfinger.y * visible_height + y_borderwidth;
 					dvl::OutputToLogical(&x, &y);
 				}
 			}
@@ -243,8 +256,8 @@ static void preprocess_finger_motion(SDL_Event *event)
 		int yrel = 0;
 
 		if (direct_touch) {
-			x = event->tfinger.x;
-			y = event->tfinger.y;
+			x = event->tfinger.x * visible_width + x_borderwidth;
+			y = event->tfinger.y * visible_height + y_borderwidth;
 			dvl::OutputToLogical(&x, &y);
 		} else {
 			// for relative mode, use the pointer speed setting

--- a/SourceX/miniwin/misc.cpp
+++ b/SourceX/miniwin/misc.cpp
@@ -167,11 +167,7 @@ bool SpawnWindow(LPCSTR lpWindowName, int nWidth, int nHeight)
 		flags |= SDL_WINDOW_INPUT_GRABBED;
 	}
 
-#ifndef __SWITCH__
 	window = SDL_CreateWindow(lpWindowName, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, nWidth, nHeight, flags);
-#else
-	window = SDL_CreateWindow(lpWindowName, 0, 0, 1920, 1080, 0);
-#endif
 #endif
 	if (window == NULL) {
 		ErrSdl();
@@ -181,11 +177,7 @@ bool SpawnWindow(LPCSTR lpWindowName, int nWidth, int nHeight)
 #ifdef USE_SDL1
 		SDL_Log("upscaling not supported with USE_SDL1");
 #else
-#ifndef __SWITCH__
 		renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_ACCELERATED);
-#else
-		renderer = SDL_CreateRenderer(window, 0, SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_ACCELERATED);
-#endif
 		if (renderer == NULL) {
 			ErrSdl();
 		}


### PR DESCRIPTION
The "clean-up" commit broke touch on Switch. I managed to get it back. Maybe by looking at my changes you can figure out the actual system-independent logic to use. It is certainly above my head. One thing to note is that touch coords go from 0 to 1 and represent the touch surface (not the SDL Viewport). So if the touch coordinate is 0 it means the touch happened on the far left of the touchscreen, regardless what is displayed there. In case of this game, there is a black border there, because game is displayed as 4:3 centered on a 16:9 touchscreen

I removed two ifdefs regarding window and renderer that were indeed unnecesary.