### PR TITLE
[controlls] Prioritize spell targets

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2049,8 +2049,11 @@ void AddHealOther(int mi, int sx, int sy, int dx, int dy, int midir, char mienem
 {
 	missile[mi]._miDelFlag = TRUE;
 	UseMana(id, SPL_HEALOTHER);
-	if (id == myplr)
+	if (id == myplr) {
 		SetCursor_(CURSOR_HEALOTHER);
+		if (sgbControllerActive)
+			TryIconCurs();
+	}
 }
 
 void AddElement(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, int id, int dam)
@@ -2206,8 +2209,15 @@ void AddDisarm(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, 
 {
 	missile[mi]._miDelFlag = TRUE;
 	UseMana(id, SPL_DISARM);
-	if (id == myplr)
+	if (id == myplr) {
 		SetCursor_(CURSOR_DISARM);
+		if (sgbControllerActive) {
+			if (pcursobj != -1)
+				NetSendCmdLocParam1(true, CMD_DISARMXY, cursmx, cursmy, pcursobj);
+			else
+				SetCursor_(CURSOR_HAND);
+		}
+	}
 }
 
 void AddApoca(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, int id, int dam)
@@ -2336,8 +2346,11 @@ void AddHbolt(int mi, int sx, int sy, int dx, int dy, int midir, char micaster, 
 void AddResurrect(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, int id, int dam)
 {
 	UseMana(id, SPL_RESURRECT);
-	if (id == myplr)
+	if (id == myplr) {
 		SetCursor_(CURSOR_RESURRECT);
+		if (sgbControllerActive)
+			TryIconCurs();
+	}
 	missile[mi]._miDelFlag = TRUE;
 }
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3687,6 +3687,7 @@ void CheckPlrSpell()
 		return;
 	}
 
+	if (!sgbControllerActive) {
 	if (pcurs != CURSOR_HAND
 	    || (MouseY >= PANEL_TOP && MouseX >= PANEL_LEFT && MouseX <= RIGHT_PANEL) // inside main panel
 	    || ((chrflag || questlog) && MouseX < SPANEL_WIDTH && MouseY < SPANEL_HEIGHT) // inside left panel
@@ -3697,6 +3698,7 @@ void CheckPlrSpell()
 	        && rspell != SPL_INFRA
 	        && rspell != SPL_RECHARGE) {
 		return;
+	}
 	}
 
 	addflag = FALSE;

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -106,7 +106,7 @@ static void scrollrt_draw_cursor_item()
 		return;
 	}
 
-	if (sgbControllerActive && !invflag && (!chrflag || plr[myplr]._pStatPts <= 0)) {
+	if (sgbControllerActive && pcurs != CURSOR_TELEPORT && !invflag && (!chrflag || plr[myplr]._pStatPts <= 0)) {
 		return;
 	}
 

--- a/SourceX/controls/game_controls.cpp
+++ b/SourceX/controls/game_controls.cpp
@@ -66,9 +66,7 @@ bool GetGameAction(const SDL_Event &event, GameAction *action)
 	case ControllerButton::BUTTON_Y: // Top button
 		if (InGameMenu())
 			break; // Map to keyboard key
-		if (invflag)
-			*action = GameActionSendMouseClick { GameActionSendMouseClick::RIGHT, ctrl_event.up };
-		else if (!ctrl_event.up)
+		if (!ctrl_event.up)
 			*action = GameAction(GameActionType::SECONDARY_ACTION);
 		return true;
 	case ControllerButton::BUTTON_X: // Left button

--- a/SourceX/controls/plrctrls.cpp
+++ b/SourceX/controls/plrctrls.cpp
@@ -108,6 +108,8 @@ void FindItemOrObject()
 
 	for (int xx = -1; xx < 2; xx++) {
 		for (int yy = -1; yy < 2; yy++) {
+			if (xx == 0 && yy == 0)
+				continue; // Ignore doorway so we don't get stuck behind barrels
 			if (dObject[mx + xx][my + yy] == 0)
 				continue;
 			int o = dObject[mx + xx][my + yy] > 0 ? dObject[mx + xx][my + yy] - 1 : -(dObject[mx + xx][my + yy] + 1);

--- a/SourceX/controls/plrctrls.h
+++ b/SourceX/controls/plrctrls.h
@@ -31,6 +31,7 @@ void PerformPrimaryAction();
 
 // Open chests, doors, pickup items.
 void PerformSecondaryAction();
+void PerformSpellAction();
 
 typedef struct coords {
 	int x;

--- a/SourceX/miniwin/misc_msg.cpp
+++ b/SourceX/miniwin/misc_msg.cpp
@@ -405,14 +405,7 @@ WINBOOL PeekMessageA(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilter
 			PerformSecondaryAction();
 			break;
 		case GameActionType::CAST_SPELL:
-			if (pcurs >= CURSOR_FIRSTITEM && invflag)
-				// Drop item so that it does not get destroyed.
-				DropItemBeforeTrig();
-			if (!invflag && !talkflag)
-				// Cast the spell.
-				RightMouseDown();
-			// Close active menu if any / stop walking.
-			PressEscKey();
+			PerformSpellAction();
 			break;
 		case GameActionType::TOGGLE_QUICK_SPELL_MENU:
 			lpMsg->message = DVL_WM_KEYDOWN;


### PR DESCRIPTION
Spells will now target either the appropriate highlighted actor or the
current direction.

Wish list:
- Teleport only lets you jump to the other side of a 1 unit thick wall and only if standing next to it.
- <s>Trap Disarm, Heal Other, Resurrect and Telekinesis should trigger instantly, and do not fire if no target.</s>
- Telekinesis only looks for the item next to you.

This solves multiple point on https://github.com/diasurgical/devilutionX/issues/418