### PR TITLE
Do not limit clipboard paste to 31 characters.

### DIFF
--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -174,7 +174,6 @@ void UiFocusPageDown()
 void selhero_CatToName(char *in_buf, char *out_buf, int cnt)
 {
 	std::string output = utf8_to_latin1(in_buf);
-	output.resize(SDL_TEXTINPUTEVENT_TEXT_SIZE - 1);
 	strncat(out_buf, output.c_str(), cnt - strlen(out_buf));
 }
 


### PR DESCRIPTION
Previously the clipboard contents were limited to
SDL_TEXTINPUTEVENT_TEXT_SIZE-1 (31 characters).

This is not necessary since the contents of the clipboard are written
directly to the UI element's buffer.

This is especially useful when pasting IPv6 addresses.