### PR TITLE
OpenDingux: Use xburst arch for RetroFW builds

### DIFF
--- a/Packaging/OpenDingux/build.sh
+++ b/Packaging/OpenDingux/build.sh
@@ -54,10 +54,10 @@ prepare_buildroot() {
 		tar xf "$BUILDROOT_ARCHIVE" -C "$(dirname "$BUILDROOT_ARCHIVE")"
 		mv "${BUILDROOT_ARCHIVE%.tar.gz}" "$BUILDROOT"
 	fi
-	cp buildroot_${TARGET}_defconfig "$BUILDROOT/configs/${TARGET}_devilutionx_defconfig"
 }
 
 make_buildroot() {
+	cp buildroot_${TARGET}_defconfig "$BUILDROOT/configs/${TARGET}_devilutionx_defconfig"
 	cd "$BUILDROOT"
 	if [[ "$TARGET" != "rg350" ]]; then
 		if ! grep 'enable-static' package/libsodium/libsodium.mk > /dev/null; then

--- a/Packaging/OpenDingux/buildroot_rg350_defconfig
+++ b/Packaging/OpenDingux/buildroot_rg350_defconfig
@@ -1,5 +1,5 @@
 BR2_mipsel=y
-BR2_mips_32r2=y
+BR2_mips_xburst=y
 # BR2_MIPS_SOFT_FLOAT is not set
 BR2_OPTIMIZE_2=y
 BR2_KERNEL_HEADERS_3_12=y


### PR DESCRIPTION
It's basically the same as before but with FMA instruction disabled
(known to be buggy on some (all?) Ingenic CPUs)

This doesn't fix any crashes / have any impact as far as I can tell