### PR TITLE
Selok

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,7 @@ set(devilutionx_SRCS
   SourceX/DiabloUI/selgame.cpp
   SourceX/DiabloUI/selhero.cpp
   SourceX/DiabloUI/selyesno.cpp
+  SourceX/DiabloUI/selok.cpp
   SourceX/DiabloUI/text_draw.cpp
   SourceX/DiabloUI/text.cpp
   SourceX/DiabloUI/title.cpp

--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -36,6 +36,7 @@ Art ArtBackground;
 Art ArtCursor;
 Art ArtHero;
 bool gbSpawned;
+int heroLevel;
 
 void (*gfnSoundFunction)(char *file);
 void (*gfnListFocus)(int value);
@@ -415,6 +416,27 @@ BOOL UiValidPlayerName(char *name)
 	for (BYTE *letter = (BYTE *)name; *letter; letter++)
 		if (*letter < 0x20 || (*letter > 0x7E && *letter < 0xC0))
 			return false;
+
+	char *reserved[] = {
+		"gvdl",
+		"dvou",
+		"tiju",
+		"cjudi",
+		"bttipmf",
+		"ojhhfs",
+		"cmj{{bse",
+		"benjo",
+	};
+
+	char tmpname[PLR_NAME_LEN];
+	strcpy(tmpname, name);
+	for (size_t i = 0, n = strlen(tmpname); i < n; i++)
+		tmpname[i]++;
+
+	for (int i = 0; i < sizeof(reserved) / sizeof(*reserved); i++) {
+		if (strstr(tmpname, reserved[i]))
+			return false;
+	}
 
 	return true;
 }

--- a/SourceX/DiabloUI/diabloui.h
+++ b/SourceX/DiabloUI/diabloui.h
@@ -26,6 +26,7 @@ extern Art ArtBackground;
 extern Art ArtCursor;
 extern Art ArtHero;
 extern bool gbSpawned;
+extern int heroLevel;
 
 constexpr auto MAINMENU_BACKGROUND = UiImage(&ArtBackground, { 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT });
 constexpr auto MAINMENU_LOGO = UiImage(&ArtLogos[LOGO_MED], /*animated=*/true, /*frame=*/0, { 0, 0, 0, 0 }, UIS_CENTER);

--- a/SourceX/DiabloUI/progress.cpp
+++ b/SourceX/DiabloUI/progress.cpp
@@ -8,12 +8,29 @@
 
 namespace dvl {
 
+Art dialogArt;
+char dialogText[256];
+Art progressArt;
 Art ArtPopupSm;
 Art ArtProgBG;
 Art ProgFil;
 SDL_Surface *msgSurface;
 SDL_Surface *cancleSurface;
 int textWidth;
+bool endMenu;
+
+void DialogActionCancel()
+{
+	endMenu = true;
+}
+
+// TODO use PROGRESS_DIALOG for rendering the progressbar or delete it
+UiItem PROGRESS_DIALOG[] = {
+	UiImage(&dialogArt, { 180, 168, 280, 144 }),
+	UiText(dialogText, { 180, 177, 280, 43 }, UIS_CENTER),
+	UiImage(&progressArt, { 205, 220, 228, 38 }),
+	MakeSmlButton("Cancel", &DialogActionCancel, 330, 265),
+};
 
 void progress_Load(char *msg)
 {
@@ -82,7 +99,7 @@ BOOL UiProgressDialog(HWND window, char *msg, int enable, int (*fnfunc)(), int r
 {
 	progress_Load(msg);
 
-	bool endMenu = false;
+	endMenu = false;
 	int progress = 0;
 
 	SDL_Event event;

--- a/SourceX/DiabloUI/selok.cpp
+++ b/SourceX/DiabloUI/selok.cpp
@@ -1,0 +1,86 @@
+#include "devilution.h"
+#include "DiabloUI/diabloui.h"
+#include "DiabloUI/text.h"
+#include "DiabloUI/selok.h"
+
+namespace dvl {
+
+namespace {
+
+char dialogText[256];
+
+} // namespace
+
+int selok_endMenu;
+char selok_title[32];
+
+void selok_Free()
+{
+	ArtBackground.Unload();
+}
+
+void selok_Select(int value)
+{
+	selok_endMenu = true;
+}
+
+void selok_Esc()
+{
+	selok_endMenu = true;
+}
+
+UiListItem SELOK_DIALOG_ITEMS[] = {
+	{ "OK", 0 }
+};
+
+UiItem SELOK_DIALOG[] = {
+	MAINMENU_BACKGROUND,
+	MAINMENU_LOGO,
+	UiArtText(selok_title, { 24, 161, 590, 35 }, UIS_CENTER | UIS_BIG),
+	UiArtText(dialogText, { 140, 210, 560, 168 }, UIS_MED),
+	UiList(SELOK_DIALOG_ITEMS, 230, 390, 180, 35, UIS_CENTER | UIS_BIG | UIS_GOLD)
+};
+
+UiItem SPAWNERR_DIALOG[] = {
+	MAINMENU_BACKGROUND,
+	MAINMENU_LOGO,
+	UiArtText(dialogText, { 140, 197, 560, 168 }, UIS_MED),
+	UiList(SELOK_DIALOG_ITEMS, 230, 390, 180, 35, UIS_CENTER | UIS_BIG | UIS_GOLD)
+};
+
+void UiSelOkDialog(const char *title, const char *body, bool background)
+{
+	if (!background) {
+		LoadBackgroundArt("ui_art\\black.pcx");
+	} else {
+		if (!gbSpawned) {
+			LoadBackgroundArt("ui_art\\mainmenu.pcx");
+		} else {
+			LoadBackgroundArt("ui_art\\swmmenu.pcx");
+		}
+	}
+
+	UiItem *items = SPAWNERR_DIALOG;
+	int itemCnt = size(SPAWNERR_DIALOG);
+	if (title != nullptr) {
+		strcpy(selok_title, title);
+		items = SELOK_DIALOG;
+		itemCnt = size(SELOK_DIALOG);
+	}
+
+	strcpy(dialogText, body);
+	WordWrapArtStr(dialogText, 280);
+
+	UiInitList(0, 0, NULL, selok_Select, selok_Esc, items, itemCnt, false, NULL);
+
+	selok_endMenu = false;
+	while (!selok_endMenu) {
+		UiRenderItems(items, itemCnt);
+		UiPollAndRender();
+	}
+
+	BlackPalette();
+
+	selok_Free();
+}
+} // namespace dvl

--- a/SourceX/DiabloUI/selok.h
+++ b/SourceX/DiabloUI/selok.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "devilution.h"
+
+namespace dvl {
+void UiSelOkDialog(const char *title, const char *body, bool background);
+void selok_Free();
+void selok_Select(int value);
+void selok_Esc();
+
+}

--- a/SourceX/DiabloUI/selyesno.cpp
+++ b/SourceX/DiabloUI/selyesno.cpp
@@ -45,7 +45,7 @@ void selyesno_Esc()
 	selyesno_endMenu = true;
 }
 
-BOOL UiSelHeroDelYesNoDialog(
+void UiSelHeroDelYesNoDialog(
     BOOL (*fnremove)(_uiheroinfo *),
     _uiheroinfo *selectHero,
     bool isMultiplayer)
@@ -74,6 +74,5 @@ BOOL UiSelHeroDelYesNoDialog(
 	BlackPalette();
 
 	selyesno_Free();
-	return true;
 }
 }

--- a/SourceX/DiabloUI/selyesno.h
+++ b/SourceX/DiabloUI/selyesno.h
@@ -3,7 +3,7 @@
 #include "devilution.h"
 
 namespace dvl {
-BOOL UiSelHeroDelYesNoDialog(BOOL (*fnremove)(_uiheroinfo *), _uiheroinfo *selectHero, bool isMultiplayer);
+void UiSelHeroDelYesNoDialog(BOOL (*fnremove)(_uiheroinfo *), _uiheroinfo *selectHero, bool isMultiplayer);
 void selyesno_Free();
 void selyesno_Select(int value);
 void selyesno_Esc();

--- a/SourceX/dvlnet/abstract_net.h
+++ b/SourceX/dvlnet/abstract_net.h
@@ -13,6 +13,11 @@ namespace net {
 typedef std::vector<unsigned char> buffer_t;
 typedef unsigned long provider_t;
 class dvlnet_exception : public std::exception {
+public:
+	const char *what() const throw() override
+	{
+		return "Network error";
+	}
 };
 
 class abstract_net {

--- a/SourceX/dvlnet/frame_queue.h
+++ b/SourceX/dvlnet/frame_queue.h
@@ -8,6 +8,11 @@ namespace dvl {
 namespace net {
 
 class frame_queue_exception : public dvlnet_exception {
+public:
+	const char *what() const throw() override
+	{
+		return "Incorrect frame size";
+	}
 };
 
 typedef uint32_t framesize_t;

--- a/SourceX/dvlnet/packet.h
+++ b/SourceX/dvlnet/packet.h
@@ -35,6 +35,11 @@ static constexpr plr_t PLR_MASTER = 0xFE;
 static constexpr plr_t PLR_BROADCAST = 0xFF;
 
 class packet_exception : public dvlnet_exception {
+public:
+	const char *what() const throw() override
+	{
+		return "Incorrect package size";
+	}
 };
 
 class packet {
@@ -57,7 +62,7 @@ protected:
 
 public:
 	packet(const key_t &k)
-		: key(k) {};
+	    : key(k) {};
 
 	const buffer_t &data();
 
@@ -152,7 +157,7 @@ void packet_in::process_element(T &x)
 		throw packet_exception();
 	std::memcpy(&x, decrypted_buffer.data(), sizeof(T));
 	decrypted_buffer.erase(decrypted_buffer.begin(),
-		decrypted_buffer.begin() + sizeof(T));
+	    decrypted_buffer.begin() + sizeof(T));
 }
 
 template <>
@@ -181,7 +186,7 @@ inline void packet_out::create<PT_TURN>(plr_t s, plr_t d, turn_t u)
 
 template <>
 inline void packet_out::create<PT_JOIN_REQUEST>(plr_t s, plr_t d,
-	cookie_t c, buffer_t i)
+    cookie_t c, buffer_t i)
 {
 	if (have_encrypted || have_decrypted)
 		ABORT();
@@ -195,7 +200,7 @@ inline void packet_out::create<PT_JOIN_REQUEST>(plr_t s, plr_t d,
 
 template <>
 inline void packet_out::create<PT_JOIN_ACCEPT>(plr_t s, plr_t d, cookie_t c,
-	plr_t n, buffer_t i)
+    plr_t n, buffer_t i)
 {
 	if (have_encrypted || have_decrypted)
 		ABORT();
@@ -222,7 +227,7 @@ inline void packet_out::create<PT_CONNECT>(plr_t s, plr_t d, plr_t n)
 
 template <>
 inline void packet_out::create<PT_DISCONNECT>(plr_t s, plr_t d, plr_t n,
-	leaveinfo_t l)
+    leaveinfo_t l)
 {
 	if (have_encrypted || have_decrypted)
 		ABORT();

--- a/SourceX/dvlnet/tcp_server.cpp
+++ b/SourceX/dvlnet/tcp_server.cpp
@@ -82,6 +82,7 @@ void tcp_server::handle_recv(scc con, const asio::error_code &ec,
 				handle_recv_packet(*pkt);
 			}
 		} catch (dvlnet_exception &e) {
+			SDL_Log("Network error: %s", e.what());
 			drop_connection(con);
 			return;
 		}

--- a/SourceX/dvlnet/tcp_server.h
+++ b/SourceX/dvlnet/tcp_server.h
@@ -16,6 +16,11 @@ namespace dvl {
 namespace net {
 
 class server_exception : public dvlnet_exception {
+public:
+	const char *what() const throw() override
+	{
+		return "Invalid player ID";
+	}
 };
 
 class tcp_server {


### PR DESCRIPTION
Fixes #60

Todo: Disallow joining a Nightmare/Hell game with a low-level hero.

This isn't fully pixel-perfect since there where at least 3 different buttons and some odd vertical alignments in tow of the slides for the original, but this is acceptable in this case as it makes them more consistent and was probably just mistaken on the part of the original implementation. Also, this has a very low impact since it's only seen in case of errors. On other difference is that this will slow network as given by the implementation and not try to map them to the original error messages.