### PR TITLE
Controller improvements: START modifier and hints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,7 @@ set(devilutionx_SRCS
   SourceX/controls/controller_motion.cpp
   SourceX/controls/game_controls.cpp
   SourceX/controls/menu_controls.cpp
+  SourceX/controls/modifier_hints.cpp
   SourceX/controls/plrctrls.cpp
   SourceX/controls/touch.cpp
   SourceX/miniwin/ddraw.cpp

--- a/Packaging/OpenDingux/devilutionx-retrofw.man.txt
+++ b/Packaging/OpenDingux/devilutionx-retrofw.man.txt
@@ -12,11 +12,13 @@ Controls:
 - Y: cast spell, delete character while in main menu
 - R1: use mana potion from belt
 - L1: use health item from belt
-- Suspend: toggle automap
-- Start: game menu, skip movie
-- Select + R1: inventory
-- Select + R2: character
+- Start + Up: game menu
+- Start + Left: character info
+- Start + Right: inventory
+- Start + Down: map
 - Select + A/B/X/Y: hot spell
 - Select + D-pad: move map/cursor
-- Select + Suspend: left mouse click
-- Select + Start: right mouse click
+- Select + L1: left mouse click
+- Select + R1: right mouse click
+- Start + Select: game menu
+- Suspend: map

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1274,7 +1274,7 @@ void control_print_info_str(int y, char *str, BOOL center, int lines)
 	}
 }
 
-void PrintGameStr(int x, int y, char *str, int color)
+void PrintGameStr(int x, int y, const char *str, int color)
 {
 	BYTE c;
 	int sx, sy;

--- a/Source/control.h
+++ b/Source/control.h
@@ -85,7 +85,7 @@ BOOL control_WriteStringToBuffer(BYTE *str);
 void DrawInfoBox();
 void control_draw_info_str();
 void control_print_info_str(int y, char *str, BOOL center, int lines);
-void PrintGameStr(int x, int y, char *str, int color);
+void PrintGameStr(int x, int y, const char *str, int color);
 void DrawChr();
 #define ADD_PlrStringXY(x, y, width, pszStr, col) MY_PlrStringXY(x, y, width, pszStr, col, 1)
 void MY_PlrStringXY(int x, int y, int width, char *pszStr, char col, int base);

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -872,6 +872,9 @@ static void DrawGame(int x, int y)
 	}
 }
 
+// DevilutionX extension.
+extern void DrawControllerModifierHints();
+
 /**
  * @brief Start rendering of screen, town variation
  * @param StartX Center of view in dPiece coordinate
@@ -926,6 +929,7 @@ void DrawView(int StartX, int StartY)
 		gmenu_draw_pause();
 	}
 
+	DrawControllerModifierHints();
 	DrawPlrMsg();
 	gmenu_draw();
 	doom_draw();

--- a/SourceX/controls/controller_buttons.h
+++ b/SourceX/controls/controller_buttons.h
@@ -28,4 +28,12 @@ enum class ControllerButton {
 	BUTTON_DPAD_RIGHT
 };
 
+inline bool IsDPadButton(ControllerButton button)
+{
+	return button == ControllerButton::BUTTON_DPAD_UP
+	    || button == ControllerButton::BUTTON_DPAD_DOWN
+	    || button == ControllerButton::BUTTON_DPAD_LEFT
+	    || button == ControllerButton::BUTTON_DPAD_RIGHT;
+}
+
 } // namespace dvl

--- a/SourceX/controls/controller_motion.cpp
+++ b/SourceX/controls/controller_motion.cpp
@@ -3,6 +3,7 @@
 #include "controls/devices/game_controller.h"
 #include "controls/devices/joystick.h"
 #include "controls/devices/kbcontroller.h"
+#include "controls/controller.h"
 
 namespace dvl {
 
@@ -93,7 +94,32 @@ bool ProcessControllerMotion(const SDL_Event &event)
 	if (ProcessKbCtrlAxisMotion(event))
 		return true;
 #endif
-	return false;
+
+	// SELECT + D-Pad simulating mouse movement.
+	if (!IsControllerButtonPressed(ControllerButton::BUTTON_BACK)) {
+		rightStickX = 0;
+		rightStickY = 0;
+		return false;
+	}
+
+	const ControllerButtonEvent ctrl_event = ToControllerButtonEvent(event);
+	if (!IsDPadButton(ctrl_event.button))
+		return false;
+	if (IsControllerButtonPressed(ControllerButton::BUTTON_DPAD_LEFT)) {
+		rightStickX = -1;
+	} else if (IsControllerButtonPressed(ControllerButton::BUTTON_DPAD_RIGHT)) {
+		rightStickX = 1;
+	} else {
+		rightStickX = 0;
+	}
+	if (IsControllerButtonPressed(ControllerButton::BUTTON_DPAD_UP)) {
+		rightStickY = 1;
+	} else if (IsControllerButtonPressed(ControllerButton::BUTTON_DPAD_DOWN)) {
+		rightStickY = -1;
+	} else {
+		rightStickY = 0;
+	}
+	return true;
 }
 
 } // namespace dvl

--- a/SourceX/controls/devices/kbcontroller.cpp
+++ b/SourceX/controls/devices/kbcontroller.cpp
@@ -3,24 +3,10 @@
 #if HAS_KBCTRL == 1
 
 #include "controls/controller_motion.h"
-#include "sdl2_to_1_2_backports.h"
 #include "sdl_compat.h"
 #include "stubs.h"
 
 namespace dvl {
-
-namespace {
-
-bool IsModifierKey()
-{
-#ifdef KBCTRL_BUTTON_BACK
-	return SDLC_GetKeyState()[KBCTRL_BUTTON_BACK];
-#else
-	return false;
-#endif
-}
-
-} // namespace
 
 ControllerButton KbCtrlToControllerButton(const SDL_Event &event)
 {
@@ -58,14 +44,10 @@ ControllerButton KbCtrlToControllerButton(const SDL_Event &event)
 #endif
 #ifdef KBCTRL_BUTTON_LEFTSHOULDER
 		case KBCTRL_BUTTON_LEFTSHOULDER:
-			if (IsModifierKey())
-				return ControllerButton::AXIS_TRIGGERLEFT;
 			return ControllerButton::BUTTON_LEFTSHOULDER;
 #endif
 #ifdef KBCTRL_BUTTON_RIGHTSHOULDER
 		case KBCTRL_BUTTON_RIGHTSHOULDER:
-			if (IsModifierKey())
-				return ControllerButton::AXIS_TRIGGERRIGHT;
 			return ControllerButton::BUTTON_RIGHTSHOULDER;
 #endif
 #ifdef KBCTRL_BUTTON_START
@@ -78,26 +60,18 @@ ControllerButton KbCtrlToControllerButton(const SDL_Event &event)
 #endif
 #ifdef KBCTRL_BUTTON_DPAD_UP
 		case KBCTRL_BUTTON_DPAD_UP:
-			if (IsModifierKey())
-				return ControllerButton::IGNORE;
 			return ControllerButton::BUTTON_DPAD_UP;
 #endif
 #ifdef KBCTRL_BUTTON_DPAD_DOWN
 		case KBCTRL_BUTTON_DPAD_DOWN:
-			if (IsModifierKey())
-				return ControllerButton::IGNORE;
 			return ControllerButton::BUTTON_DPAD_DOWN;
 #endif
 #ifdef KBCTRL_BUTTON_DPAD_LEFT
 		case KBCTRL_BUTTON_DPAD_LEFT:
-			if (IsModifierKey())
-				return ControllerButton::IGNORE;
 			return ControllerButton::BUTTON_DPAD_LEFT;
 #endif
 #ifdef KBCTRL_BUTTON_DPAD_RIGHT
 		case KBCTRL_BUTTON_DPAD_RIGHT:
-			if (IsModifierKey())
-				return ControllerButton::IGNORE;
 			return ControllerButton::BUTTON_DPAD_RIGHT;
 #endif
 		default:
@@ -176,7 +150,9 @@ int ControllerButtonToKbCtrlKeyCode(ControllerButton button)
 	}
 }
 
-bool IsButtonPressed(ControllerButton button)
+} // namespace
+
+bool IsKbCtrlButtonPressed(ControllerButton button)
 {
 	int key_code = ControllerButtonToKbCtrlKeyCode(button);
 	if (key_code == -1)
@@ -188,42 +164,10 @@ bool IsButtonPressed(ControllerButton button)
 #endif
 }
 
-} // namespace
-
-bool IsKbCtrlButtonPressed(ControllerButton button)
-{
-	if (IsModifierKey() && (button == ControllerButton::BUTTON_DPAD_UP || button == ControllerButton::BUTTON_DPAD_DOWN || button == ControllerButton::BUTTON_DPAD_LEFT || button == ControllerButton::BUTTON_DPAD_RIGHT))
-		return false;
-	return IsButtonPressed(button);
-}
-
 bool ProcessKbCtrlAxisMotion(const SDL_Event &event)
 {
-	if (!IsModifierKey()) {
-		rightStickX = 0;
-		rightStickY = 0;
-		return false;
-	}
-	if (event.type != SDL_KEYUP && event.type != SDL_KEYDOWN)
-		return false;
-	const auto sym = event.key.keysym.sym;
-	if (sym != KBCTRL_BUTTON_DPAD_UP && sym != KBCTRL_BUTTON_DPAD_DOWN && sym != KBCTRL_BUTTON_DPAD_LEFT && sym != KBCTRL_BUTTON_DPAD_RIGHT)
-		return false;
-	if (IsButtonPressed(ControllerButton::BUTTON_DPAD_LEFT)) {
-		rightStickX = -1;
-	} else if (IsButtonPressed(ControllerButton::BUTTON_DPAD_RIGHT)) {
-		rightStickX = 1;
-	} else {
-		rightStickX = 0;
-	}
-	if (IsButtonPressed(ControllerButton::BUTTON_DPAD_UP)) {
-		rightStickY = 1;
-	} else if (IsButtonPressed(ControllerButton::BUTTON_DPAD_DOWN)) {
-		rightStickY = -1;
-	} else {
-		rightStickY = 0;
-	}
-	return true;
+	// Mapping keyboard to right stick axis not implemented.
+	return false;
 }
 
 } // namespace dvl

--- a/SourceX/controls/game_controls.cpp
+++ b/SourceX/controls/game_controls.cpp
@@ -71,13 +71,15 @@ bool GetGameAction(const SDL_Event &event, GameAction *action)
 		switch (ctrl_event.button) {
 		case ControllerButton::BUTTON_LEFTSHOULDER:
 			if (IsControllerButtonPressed(ControllerButton::BUTTON_BACK)) {
-				*action = GameActionSendMouseClick{ GameActionSendMouseClick::LEFT, ctrl_event.up };
+				if (!IsAutomapActive())
+					*action = GameActionSendMouseClick{ GameActionSendMouseClick::LEFT, ctrl_event.up };
 				return true;
 			}
 			break;
 		case ControllerButton::BUTTON_RIGHTSHOULDER:
 			if (IsControllerButtonPressed(ControllerButton::BUTTON_BACK)) {
-				*action = GameActionSendMouseClick{ GameActionSendMouseClick::RIGHT, ctrl_event.up };
+				if (!IsAutomapActive())
+					*action = GameActionSendMouseClick{ GameActionSendMouseClick::RIGHT, ctrl_event.up };
 				return true;
 			}
 			break;
@@ -99,7 +101,8 @@ bool GetGameAction(const SDL_Event &event, GameAction *action)
 			return true;
 		case ControllerButton::BUTTON_LEFTSTICK:
 			if (IsControllerButtonPressed(ControllerButton::BUTTON_BACK)) {
-				*action = GameActionSendMouseClick{ GameActionSendMouseClick::LEFT, ctrl_event.up };
+				if (!IsAutomapActive())
+					*action = GameActionSendMouseClick{ GameActionSendMouseClick::LEFT, ctrl_event.up };
 				return true;
 			}
 			break;
@@ -200,10 +203,12 @@ bool GetGameAction(const SDL_Event &event, GameAction *action)
 				// The rest of D-Pad actions are handled in charMovement() on every game_logic() call.
 				return true;
 			case ControllerButton::BUTTON_RIGHTSTICK:
-				if (IsControllerButtonPressed(ControllerButton::BUTTON_BACK))
-					*action = GameActionSendMouseClick{ GameActionSendMouseClick::RIGHT, ctrl_event.up };
-				else
-					*action = GameActionSendMouseClick{ GameActionSendMouseClick::LEFT, ctrl_event.up };
+				if (!IsAutomapActive()) {
+					if (IsControllerButtonPressed(ControllerButton::BUTTON_BACK))
+						*action = GameActionSendMouseClick{ GameActionSendMouseClick::RIGHT, ctrl_event.up };
+					else
+						*action = GameActionSendMouseClick{ GameActionSendMouseClick::LEFT, ctrl_event.up };
+				}
 				return true;
 			default:
 				break;

--- a/SourceX/controls/game_controls.h
+++ b/SourceX/controls/game_controls.h
@@ -83,4 +83,7 @@ struct MoveDirection {
 };
 MoveDirection GetMoveDirection();
 
+extern bool start_modifier_active;
+extern bool select_modifier_active;
+
 } // namespace dvl

--- a/SourceX/controls/modifier_hints.cpp
+++ b/SourceX/controls/modifier_hints.cpp
@@ -1,0 +1,132 @@
+#include "controls/modifier_hints.h"
+
+#include <cstddef>
+
+#include "devilution.h"
+#include "controls/controller.h"
+#include "controls/game_controls.h"
+
+namespace dvl {
+
+namespace {
+
+int CalculateTextWidth(const char *s)
+{
+	int l = 0;
+	while (*s) {
+		l += fontkern[fontframe[gbFontTransTbl[static_cast<unsigned char>(*s++)]]] + 1;
+	}
+	return l;
+}
+
+int SpaceWidth()
+{
+	static const int kSpaceWidth = CalculateTextWidth(" ");
+	return kSpaceWidth;
+}
+
+struct CircleMenuHint {
+	CircleMenuHint(bool is_dpad, const char *top, const char *right, const char *bottom, const char *left)
+	    : is_dpad(is_dpad)
+	    , top(top)
+	    , top_w(CalculateTextWidth(top))
+	    , right(right)
+	    , right_w(CalculateTextWidth(right))
+	    , bottom(bottom)
+	    , bottom_w(CalculateTextWidth(bottom))
+	    , left(left)
+	    , left_w(CalculateTextWidth(left))
+	    , x_mid(left_w + SpaceWidth() * 2.5)
+	{
+	}
+
+	bool is_dpad;
+
+	const char *top;
+	int top_w;
+	const char *right;
+	int right_w;
+	const char *bottom;
+	int bottom_w;
+	const char *left;
+	int left_w;
+
+	int x_mid;
+};
+
+bool IsTopActive(const CircleMenuHint &hint)
+{
+	if (hint.is_dpad)
+		return IsControllerButtonPressed(ControllerButton::BUTTON_DPAD_UP);
+	return IsControllerButtonPressed(ControllerButton::BUTTON_Y);
+}
+
+bool IsRightActive(const CircleMenuHint &hint)
+{
+	if (hint.is_dpad)
+		return IsControllerButtonPressed(ControllerButton::BUTTON_DPAD_RIGHT);
+	return IsControllerButtonPressed(ControllerButton::BUTTON_B);
+}
+
+bool IsBottomActive(const CircleMenuHint &hint)
+{
+	if (hint.is_dpad)
+		return IsControllerButtonPressed(ControllerButton::BUTTON_DPAD_DOWN);
+	return IsControllerButtonPressed(ControllerButton::BUTTON_A);
+}
+
+bool IsLeftActive(const CircleMenuHint &hint)
+{
+	if (hint.is_dpad)
+		return IsControllerButtonPressed(ControllerButton::BUTTON_DPAD_LEFT);
+	return IsControllerButtonPressed(ControllerButton::BUTTON_X);
+}
+
+text_color CircleMenuHintTextColor(bool active)
+{
+	return active ? COL_BLUE : COL_GOLD;
+}
+
+void DrawCircleMenuHint(const CircleMenuHint &hint, int x, int y)
+{
+	constexpr int kLineHeight = 25;
+	PrintGameStr(x + hint.x_mid - hint.top_w / 2, y, hint.top, CircleMenuHintTextColor(IsTopActive(hint)));
+	y += kLineHeight;
+
+	PrintGameStr(x, y, hint.left, CircleMenuHintTextColor(IsLeftActive(hint)));
+	PrintGameStr(x + hint.left_w + 5 * SpaceWidth(), y, hint.right, CircleMenuHintTextColor(IsRightActive(hint)));
+	y += kLineHeight;
+
+	PrintGameStr(x + hint.x_mid - hint.bottom_w / 2, y, hint.bottom, CircleMenuHintTextColor(IsBottomActive(hint)));
+}
+
+constexpr int kCirclesDist = 200;
+constexpr int kCirclesTop = VIEWPORT_HEIGHT / 2 + TILE_SIZE / 2;
+
+void DrawStartModifierMenu()
+{
+	if (!start_modifier_active)
+		return;
+	static const CircleMenuHint kDpad(/*is_dpad=*/true, /*top=*/"Menu", /*right=*/"Inv", /*bottom=*/"Map", /*left=*/"Char");
+	static const CircleMenuHint kButtons(/*is_dpad=*/false, /*top=*/"", /*right=*/"", /*bottom=*/"Spells", /*left=*/"Quests");
+	DrawCircleMenuHint(kDpad, SCREEN_WIDTH / 2 - kDpad.x_mid - kCirclesDist / 2, kCirclesTop);
+	DrawCircleMenuHint(kButtons, SCREEN_WIDTH / 2 - kButtons.x_mid + kCirclesDist / 2, kCirclesTop);
+}
+
+void DrawSelectModifierMenu()
+{
+	if (!select_modifier_active)
+		return;
+	static const CircleMenuHint kSpells(/*is_dpad=*/false, "F6", "F8", "F7", "F5");
+	DrawCircleMenuHint(kSpells, SCREEN_WIDTH / 2 - kSpells.x_mid + kCirclesDist / 2, kCirclesTop);
+}
+
+} // namespace
+
+void DrawControllerModifierHints()
+{
+	DrawStartModifierMenu();
+	DrawSelectModifierMenu();
+}
+
+} // namespace dvl

--- a/SourceX/controls/modifier_hints.cpp
+++ b/SourceX/controls/modifier_hints.cpp
@@ -40,6 +40,11 @@ struct CircleMenuHint {
 	{
 	}
 
+	int width() const
+	{
+		return 2 * x_mid;
+	}
+
 	bool is_dpad;
 
 	const char *top;
@@ -100,8 +105,8 @@ void DrawCircleMenuHint(const CircleMenuHint &hint, int x, int y)
 	PrintGameStr(x + hint.x_mid - hint.bottom_w / 2, y, hint.bottom, CircleMenuHintTextColor(IsBottomActive(hint)));
 }
 
-constexpr int kCirclesDist = 200;
-constexpr int kCirclesTop = VIEWPORT_HEIGHT / 2 + TILE_SIZE / 2;
+constexpr int kCircleMarginX = 16;
+constexpr int kCirclesTop = PANEL_TOP - 76;
 
 void DrawStartModifierMenu()
 {
@@ -109,8 +114,8 @@ void DrawStartModifierMenu()
 		return;
 	static const CircleMenuHint kDpad(/*is_dpad=*/true, /*top=*/"Menu", /*right=*/"Inv", /*bottom=*/"Map", /*left=*/"Char");
 	static const CircleMenuHint kButtons(/*is_dpad=*/false, /*top=*/"", /*right=*/"", /*bottom=*/"Spells", /*left=*/"Quests");
-	DrawCircleMenuHint(kDpad, SCREEN_WIDTH / 2 - kDpad.x_mid - kCirclesDist / 2, kCirclesTop);
-	DrawCircleMenuHint(kButtons, SCREEN_WIDTH / 2 - kButtons.x_mid + kCirclesDist / 2, kCirclesTop);
+	DrawCircleMenuHint(kDpad, kCircleMarginX, kCirclesTop);
+	DrawCircleMenuHint(kButtons, SCREEN_WIDTH - kButtons.width() - kCircleMarginX, kCirclesTop);
 }
 
 void DrawSelectModifierMenu()
@@ -118,7 +123,7 @@ void DrawSelectModifierMenu()
 	if (!select_modifier_active)
 		return;
 	static const CircleMenuHint kSpells(/*is_dpad=*/false, "F6", "F8", "F7", "F5");
-	DrawCircleMenuHint(kSpells, SCREEN_WIDTH / 2 - kSpells.x_mid + kCirclesDist / 2, kCirclesTop);
+	DrawCircleMenuHint(kSpells, SCREEN_WIDTH - kSpells.width() - kCircleMarginX, kCirclesTop);
 }
 
 } // namespace

--- a/SourceX/controls/modifier_hints.h
+++ b/SourceX/controls/modifier_hints.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace dvl {
+
+void DrawControllerModifierHints();
+
+} // namespace dvl

--- a/SourceX/controls/plrctrls.cpp
+++ b/SourceX/controls/plrctrls.cpp
@@ -872,6 +872,10 @@ struct RightStickAccumulator {
 
 } // namespace
 
+bool IsAutomapActive() {
+	return automapflag && currlevel != DTYPE_TOWN;
+}
+
 void HandleRightStickMotion()
 {
 	static RightStickAccumulator acc;
@@ -881,7 +885,7 @@ void HandleRightStickMotion()
 		return;
 	}
 
-	if (automapflag && currlevel != DTYPE_TOWN) { // move map
+	if (IsAutomapActive()) { // move map
 		int dx = 0, dy = 0;
 		acc.pool(&dx, &dy, 32);
 		AutoMapXOfs += dy + dx;

--- a/SourceX/controls/plrctrls.cpp
+++ b/SourceX/controls/plrctrls.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <list>
 
+#include "controls/controller.h"
 #include "controls/controller_motion.h"
 #include "controls/game_controls.h"
 
@@ -822,7 +823,9 @@ void WalkInDir(MoveDirection dir)
 
 void Movement()
 {
-	if (InGameMenu() || questlog)
+	if (InGameMenu() || questlog
+	    || IsControllerButtonPressed(ControllerButton::BUTTON_START)
+	    || IsControllerButtonPressed(ControllerButton::BUTTON_BACK))
 		return;
 
 	MoveDirection move_dir = GetMoveDirection();

--- a/SourceX/controls/plrctrls.h
+++ b/SourceX/controls/plrctrls.h
@@ -24,6 +24,9 @@ void HandleRightStickMotion();
 // Whether we're in a dialog menu that the game handles natively with keyboard controls.
 bool InGameMenu();
 
+// Whether the automap is being displayed.
+bool IsAutomapActive();
+
 void UseBeltItem(int type);
 
 // Talk to towners, click on inv items, attack, etc.


### PR DESCRIPTION
1. Makes START a modifier key.
2. Main modifier actions are now displayed as hints while the modifier is pressed.
3. Mouse simulation now available on all controllers:
   SELECT + D-Pad to move mouse
   SELECT + Left/Right should button to click
   
 START +    | Action
 ---------- | ------
 SELECT     | Menu
 UP         | Menu
 DOWN       | Map
 LEFT       | Character info
 RIGHT      | Inventory
 B (Bottom) | Spell book
 Y (Left)   | Quest log

This makes all actions available on controllers without sticks and ZL/ZR.

![devilutionx-controls-corners](https://user-images.githubusercontent.com/216339/71780014-0c4a3f80-2fb5-11ea-9376-89950f0eb77f.png)

Alternative hint positioning:

![devilutionx-start](https://user-images.githubusercontent.com/216339/71779802-b0ca8280-2fb1-11ea-802c-51729d036908.png)

[devilutionx-retrofw.ipk.zip](https://github.com/diasurgical/devilutionX/files/4023364/devilutionx-retrofw.ipk.zip)
