### PR TITLE
Fix OOB in missiles.cpp

### DIFF
--- a/Source/misdat.cpp
+++ b/Source/misdat.cpp
@@ -129,4 +129,6 @@ MisFileData misfiledata[] = {
 	// clang-format on
 };
 
+size_t misfilelength = sizeof(misfiledata);
+
 DEVILUTION_END_NAMESPACE

--- a/Source/misdat.cpp
+++ b/Source/misdat.cpp
@@ -129,6 +129,6 @@ MisFileData misfiledata[] = {
 	// clang-format on
 };
 
-size_t misfilelength = sizeof(misfiledata);
+size_t misfilelength = sizeof(misfiledata) / sizeof(misfiledata[0]);
 
 DEVILUTION_END_NAMESPACE

--- a/Source/misdat.h
+++ b/Source/misdat.h
@@ -4,5 +4,6 @@
 
 extern MissileData missiledata[];
 extern MisFileData misfiledata[];
+extern size_t misfilelength;
 
 #endif /* __MISDAT_H__ */

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1067,6 +1067,10 @@ void SetMissAnim(int mi, int animtype)
 {
 	int dir = missile[mi]._mimfnum;
 
+    if (animtype == MFILE_NONE) {
+        animtype = misfilelength - 1;
+    }
+
 	missile[mi]._miAnimType = animtype;
 	missile[mi]._miAnimFlags = misfiledata[animtype].mFlags;
 	missile[mi]._miAnimData = misfiledata[animtype].mAnimData[dir];
@@ -2469,7 +2473,7 @@ int AddMissile(int sx, int sy, int dx, int dy, int midir, int mitype, char micas
 	missile[mi]._mispllvl = spllvl;
 	missile[mi]._mimfnum = midir;
 
-	if (missile[mi]._miAnimType == 255 || misfiledata[missile[mi]._miAnimType].mAnimFAmt < 8)
+	if (missile[mi]._miAnimType == MFILE_NONE || misfiledata[missile[mi]._miAnimType].mAnimFAmt < 8)
 		SetMissDir(mi, 0);
 	else
 		SetMissDir(mi, midir);


### PR DESCRIPTION
`MFILE_NONE` does not correspond to the last item of `misfiledata` array and is actually greater than the length of that array causing out-of-bounds crash on iOS (reproduced when applying rogue's Disarm Trap skill).