### PR TITLE
Add fix to allow all unique items to drop

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1941,7 +1941,7 @@ int RndTypeItems(int itype, int imid)
 
 int CheckUnique(int i, int lvl, int uper, BOOL recreate)
 {
-	int j, idata, numu;
+	int j, idata, numu, rv;
 	BOOLEAN uok[128];
 
 	if (random_(28, 100) > uper)
@@ -1950,7 +1950,8 @@ int CheckUnique(int i, int lvl, int uper, BOOL recreate)
 	numu = 0;
 	memset(uok, 0, sizeof(uok));
 	for (j = 0; UniqueItemList[j].UIItemId != UITYPE_INVALID; j++) {
-		if (UniqueItemList[j].UIItemId == AllItemsList[item[i].IDidx].iItemId
+		idata = item[i].IDidx;
+		if (UniqueItemList[j].UIItemId == AllItemsList[idata].iItemId
 		    && lvl >= UniqueItemList[j].UIMinLvl
 		    && (recreate || !UniqueItemFlag[j] || gbMaxPlayers != 1)) {
 			uok[j] = TRUE;
@@ -1961,19 +1962,33 @@ int CheckUnique(int i, int lvl, int uper, BOOL recreate)
 	if (!numu)
 		return -1;
 
-	random_(29, 10);
-	idata = 0;
+#ifdef FIX_UNIQUEITEMS
+	rv = random_(29, numu);
+	int k = 0;
+	for(j = 0; j < sizeof(uok); j++) {
+		if(!uok[j]) {
+			continue;
+		}
+		if(k == rv) {
+			break;
+		}
+		k++;
+	}
+#else
+	rv = random_(29, 10);
+	j = 0;
 	while (numu > 0) {
-		if (uok[idata])
+		if (uok[j])
 			numu--;
 		if (numu > 0) {
-			idata++;
-			if (idata == 128)
-				idata = 0;
+			j++;
+			if (j == 128)
+				j = 0;
 		}
 	}
+#endif
+	return j;
 
-	return idata;
 }
 
 void GetUniqueItem(int i, int uid)

--- a/fixes.h
+++ b/fixes.h
@@ -1,0 +1,7 @@
+// uncomment to enable fixes below
+//#define OPTIONAL_FIXES
+
+#ifdef OPTIONAL_FIXES
+// allow all unique items which have multiple uniques with the same base to drop
+#define FIX_UNIQUEITEMS
+#endif

--- a/types.h
+++ b/types.h
@@ -14,6 +14,7 @@ DEVILUTION_BEGIN_NAMESPACE
 
 #include <limits.h>
 #include "defs.h"
+#include "fixes.h"
 #include "enums.h"
 #include "structs.h"
 


### PR DESCRIPTION
This adds an optional fix for the unique item generation bug, as well as a header file to toggle on/off optional fixes. I know that some people will want a pure vanilla experience, so it's disabled by default.

As an FYI, the bug involves unique items where more than one item of the same base type exists. The game will always pick the last occurring item in multi player, making it impossible to find any item but that. In single player the game records which uniques have already dropped so it is possible, but it starts from bottom to top making it extremely difficult since you would have to find 3-4+ uniques of the same base in the **_same_** game.

How this should be fixed can be argued, but interestingly there is an unused `random` call in the vanilla code. I fixed it by making the game use this call, so it picks one at random rather than the last one. Below is a screenshot of me finding both Lightforge and Constricting Ring in multiplayer:
![DIABLO_20200115_024042](https://user-images.githubusercontent.com/15209402/72401664-4385c280-3712-11ea-99af-a6709e45d939.png)
