### PR TITLE
RG350 buildroot: Only build dependencies

### DIFF
--- a/Packaging/OpenDingux/build.sh
+++ b/Packaging/OpenDingux/build.sh
@@ -60,11 +60,7 @@ make_buildroot() {
 	cp buildroot_${TARGET}_defconfig "$BUILDROOT/configs/${TARGET}_devilutionx_defconfig"
 	cd "$BUILDROOT"
 	make ${TARGET}_devilutionx_defconfig
-	if [[ "$TARGET" == "rg350" ]]; then
-		BR2_JLEVEL=0 make
-	else
-		BR2_JLEVEL=0 make toolchain libzip sdl sdl_mixer sdl_ttf
-	fi
+	BR2_JLEVEL=0 make toolchain libzip sdl sdl_mixer sdl_ttf
 	cd -
 }
 


### PR DESCRIPTION
Previously, there was an issue with the RG350 buildroot that necessitated building the entire thing.
That issue has been fixed and we can now build only the minimal set of dependencies (same as we do for RetroFW).