### PR TITLE
dx_create_back_buffer: Minor improvement for SDL2

### DIFF
--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -37,9 +37,15 @@ static void dx_create_back_buffer()
 
 	gpBuffer = (BYTE *)pal_surface->pixels;
 
-	if (SDLC_SetSurfaceColors(pal_surface, palette) <= -1) {
+#ifndef USE_SDL1
+	// In SDL2, `pal_surface` points to the global `palette`.
+	if (SDL_SetSurfacePalette(pal_surface, palette) < 0)
 		ErrSdl();
-	}
+#else
+	// In SDL1, `pal_surface` owns its palette and we must update it every
+	// time the global `palette` is changed. No need to do anything here as
+	// the global `palette` doesn't have any colors set yet.
+#endif
 
 	pal_surface_palette_version = 1;
 }


### PR DESCRIPTION
Previously, we were copying the colors onto the surface's own palette
that was then immediately replaced by `palette`.