### PR TITLE
fix first cutscene not rendered on 32bit architectures

### DIFF
--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -51,6 +51,7 @@ void init_create_window()
 	gbActive = true;
 	gpBufStart = &gpBuffer[BUFFER_WIDTH * SCREEN_Y];
 	gpBufEnd = &gpBuffer[BUFFER_WIDTH * (SCREEN_HEIGHT + SCREEN_Y)];
+	gpBufEnd -= (uintptr_t)gpBuffer;
 	SDL_DisableScreenSaver();
 }
 


### PR DESCRIPTION
The proposed fix enables the first cutscene (load/new game) to be visible.
The problem was that the lock adds `gpBuffer` to `gpBufEnd`, tirggering an overflow as in the case of my GameShell device, `gpBuffer` is somewhere north of 0xA??????. Adding `gbBuffer` in the lock function results in a value for `gbBufEnd` which is not recoverable by the following unlock call.