### PR TITLE
Single-player: Use loopback instead of TCP

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -784,7 +784,7 @@ BOOL multi_init_single(_SNETPROGRAMDATA *client_info, _SNETPLAYERDATA *user_info
 {
 	int unused;
 
-	if (!SNetInitializeProvider(0, client_info, user_info, ui_info, &fileinfo)) {
+	if (!SNetInitializeProvider(SELCONN_LOOPBACK, client_info, user_info, ui_info, &fileinfo)) {
 		SErrGetLastError();
 		return FALSE;
 	}

--- a/enums.h
+++ b/enums.h
@@ -2920,11 +2920,11 @@ typedef enum dlrg_flag {
 } dlrg_flag;
 
 typedef enum conn_type {
+	SELCONN_LOOPBACK = 0,
 #ifndef NONET
 	SELCONN_TCP,
 #ifdef BUGGY
 	SELCONN_UDP,
 #endif
 #endif
-	SELCONN_LOOPBACK,
 } conn_type;


### PR DESCRIPTION
Previously, single-player games initialized a TCP connection!
Changes this to loopback.

Refs #555