### PR TITLE
Render menu directly to the output surface

### DIFF
--- a/Source/dx.h
+++ b/Source/dx.h
@@ -15,6 +15,7 @@ void dx_reinit();
 
 void CreatePalette();
 void BltFast(SDL_Rect *src_rect, SDL_Rect *dst_rect);
+void Blit(SDL_Surface *src, SDL_Rect *src_rect, SDL_Rect *dst_rect);
 void RenderPresent();
 void PaletteGetEntries(DWORD dwNumEntries, SDL_Color *lpEntries);
 void PaletteSetEntries(DWORD dwCount, SDL_Color *lpEntries);

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -151,16 +151,6 @@ void SetFadeLevel(DWORD fadeval)
 		system_palette[i].b = (fadeval * logical_palette[i].b) >> 8;
 	}
 	palette_update();
-
-	// Workaround for flickering mouse in caves https://github.com/diasurgical/devilutionX/issues/7
-	SDL_Rect SrcRect = {
-		SCREEN_X,
-		SCREEN_Y,
-		SCREEN_WIDTH,
-		SCREEN_HEIGHT,
-	};
-	BltFast(&SrcRect, NULL);
-	RenderPresent();
 }
 
 void BlackPalette()
@@ -176,6 +166,9 @@ void PaletteFadeIn(int fr)
 	DWORD tc = SDL_GetTicks();
 	for (i = 0; i < 256; i = (SDL_GetTicks() - tc) / 2.083) { // 32 frames @ 60hz
 		SetFadeLevel(i);
+		SDL_Rect SrcRect = { SCREEN_X, SCREEN_Y, SCREEN_WIDTH, SCREEN_HEIGHT };
+		BltFast(&SrcRect, NULL);
+		RenderPresent();
 	}
 	SetFadeLevel(256);
 	memcpy(logical_palette, orig_palette, sizeof(orig_palette));
@@ -190,6 +183,9 @@ void PaletteFadeOut(int fr)
 		DWORD tc = SDL_GetTicks();
 		for (i = 256; i > 0; i = 256 - (SDL_GetTicks() - tc) / 2.083) { // 32 frames @ 60hz
 			SetFadeLevel(i);
+			SDL_Rect SrcRect = { SCREEN_X, SCREEN_Y, SCREEN_WIDTH, SCREEN_HEIGHT };
+			BltFast(&SrcRect, NULL);
+			RenderPresent();
 		}
 		SetFadeLevel(0);
 		sgbFadedIn = FALSE;

--- a/SourceX/DiabloUI/art_draw.cpp
+++ b/SourceX/DiabloUI/art_draw.cpp
@@ -9,7 +9,7 @@ void DrawArt(int screenX, int screenY, Art *art, int nFrame,
     decltype(SDL_Rect().w) srcW, decltype(SDL_Rect().h) srcH)
 {
 	screenX += PANEL_LEFT;
-	if (screenY >= SCREEN_Y + SCREEN_HEIGHT || screenX >= SCREEN_X + SCREEN_WIDTH || art->surface == nullptr)
+	if (screenY >= SCREEN_HEIGHT || screenX >= SCREEN_WIDTH || art->surface == nullptr)
 		return;
 
 	SDL_Rect src_rect = {
@@ -22,11 +22,7 @@ void DrawArt(int screenX, int screenY, Art *art, int nFrame,
 		src_rect.w = srcW;
 	if (srcH && srcH < src_rect.h)
 		src_rect.h = srcH;
-	SDL_Rect dst_rect = {
-		static_cast<decltype(SDL_Rect().x)>(screenX + SCREEN_X),
-		static_cast<decltype(SDL_Rect().y)>(screenY + SCREEN_Y),
-		src_rect.w, src_rect.h
-	};
+	SDL_Rect dst_rect = { screenX, screenY, src_rect.w, src_rect.h };
 
 	if (art->surface->format->BitsPerPixel == 8 && art->palette_version != pal_surface_palette_version) {
 		if (SDLC_SetSurfaceColors(art->surface, pal_surface->format->palette) <= -1)
@@ -34,9 +30,7 @@ void DrawArt(int screenX, int screenY, Art *art, int nFrame,
 		art->palette_version = pal_surface_palette_version;
 	}
 
-	if (SDL_BlitSurface(art->surface, &src_rect, pal_surface, &dst_rect) <= -1) {
-		ErrSdl();
-	}
+	Blit(art->surface, &src_rect, &dst_rect);
 }
 
 void DrawAnimatedArt(Art *art, int screenX, int screenY) {

--- a/SourceX/DiabloUI/credits.cpp
+++ b/SourceX/DiabloUI/credits.cpp
@@ -16,7 +16,7 @@ namespace dvl {
 
 namespace {
 
-const SDL_Rect VIEWPORT = { SCREEN_X, SCREEN_Y + 114, SCREEN_WIDTH, 251 };
+const SDL_Rect VIEWPORT = { 0, 114, SCREEN_WIDTH, 251 };
 constexpr int SHADOW_OFFSET_X = 2;
 constexpr int SHADOW_OFFSET_Y = 2;
 constexpr int LINE_H = 22;
@@ -194,7 +194,7 @@ private:
 
 void CreditsRenderer::Render()
 {
-	const int offset_y = -(VIEWPORT.y - LINE_H) + (SDL_GetTicks() - ticks_begin_) / 40;
+	const int offset_y = -VIEWPORT.h + (SDL_GetTicks() - ticks_begin_) / 40;
 	if (offset_y == prev_offset_y_)
 		return;
 	prev_offset_y_ = offset_y;
@@ -219,7 +219,7 @@ void CreditsRenderer::Render()
 	while (lines_.back().index + 1 != lines_end)
 		lines_.push_back(PrepareLine(lines_.back().index + 1));
 
-	SDL_SetClipRect(pal_surface, &VIEWPORT);
+	SDL_SetClipRect(GetOutputSurface(), &VIEWPORT);
 	decltype(SDL_Rect().y) dest_y = VIEWPORT.y - (offset_y - lines_begin * LINE_H);
 	for (std::size_t i = 0; i < lines_.size(); ++i, dest_y += LINE_H) {
 		auto &line = lines_[i];
@@ -234,11 +234,10 @@ void CreditsRenderer::Render()
 		if (CREDITS_LINES[line.index][0] == '\t')
 			dest_x += 40;
 
-		SDL_Rect dest_rect = { dest_x, dest_y, 0, 0 };
-		if (SDL_BlitSurface(line.surface.get(), nullptr, pal_surface, &dest_rect) <= -1)
-			ErrSdl();
+		SDL_Rect dest_rect = { dest_x, dest_y, line.surface.get()->w, line.surface.get()->h };
+		Blit(line.surface.get(), nullptr, &dest_rect);
 	}
-	SDL_SetClipRect(pal_surface, nullptr);
+	SDL_SetClipRect(GetOutputSurface(), nullptr);
 }
 
 } // namespace

--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -51,6 +51,7 @@ int UiTextInputLen;
 
 namespace {
 
+DWORD fadeTc;
 int fadeValue = 0;
 int SelectedItem = 0;
 
@@ -564,6 +565,7 @@ void LoadBackgroundArt(const char *pszFile)
 {
 	SDL_Color pPal[256];
 
+	fadeTc = 0;
 	fadeValue = 0;
 	LoadArt(pszFile, &ArtBackground, 1, pPal);
 	if (ArtBackground.surface == nullptr)
@@ -575,18 +577,18 @@ void LoadBackgroundArt(const char *pszFile)
 
 void UiFadeIn()
 {
-	static DWORD tc;
-	if (fadeValue == 0 && tc == 0)
-		tc = SDL_GetTicks();
 	if (fadeValue < 256) {
-		fadeValue = (SDL_GetTicks() - tc) / 2.083; // 32 frames @ 60hz
+		if (fadeValue == 0 && fadeTc == 0)
+			fadeTc = SDL_GetTicks();
+		fadeValue = (SDL_GetTicks() - fadeTc) / 2.083; // 32 frames @ 60hz
 		if (fadeValue > 256) {
 			fadeValue = 256;
-			tc = 0;
+			fadeTc = 0;
 		}
+		SetFadeLevel(fadeValue);
 	}
 
-	SetFadeLevel(fadeValue);
+	RenderPresent();
 }
 
 void DrawSelector(const SDL_Rect &rect)

--- a/SourceX/DiabloUI/progress.cpp
+++ b/SourceX/DiabloUI/progress.cpp
@@ -80,24 +80,22 @@ void progress_Render(BYTE progress)
 
 	if (msgSurface) {
 		SDL_Rect dsc_rect = {
-			static_cast<decltype(SDL_Rect().x)>(SCREEN_X + x + 50),
-			static_cast<decltype(SDL_Rect().y)>(SCREEN_Y + y + 8),
-			SCREEN_WIDTH, SCREEN_HEIGHT
+			static_cast<decltype(SDL_Rect().x)>(x + 50),
+			static_cast<decltype(SDL_Rect().y)>(y + 8),
+			msgSurface->w,
+			msgSurface->h
 		};
-		if (SDL_BlitSurface(msgSurface, NULL, pal_surface, &dsc_rect) <= -1) {
-			ErrSdl();
-		}
-		dsc_rect.x = SCREEN_X + GetCenterOffset(textWidth) - 1;
-		dsc_rect.y = SCREEN_Y + y + 99 + 4;
-		if (SDL_BlitSurface(cancleSurface, NULL, pal_surface, &dsc_rect) <= -1) {
-			ErrSdl();
-		}
+		Blit(msgSurface, NULL, &dsc_rect);
+		dsc_rect.x = GetCenterOffset(textWidth) - 1;
+		dsc_rect.y = y + 99 + 4;
+		Blit(cancleSurface, NULL, &dsc_rect);
 	}
 }
 
 BOOL UiProgressDialog(HWND window, char *msg, int enable, int (*fnfunc)(), int rate)
 {
 	progress_Load(msg);
+	SetFadeLevel(256);
 
 	endMenu = false;
 	int progress = 0;
@@ -107,7 +105,7 @@ BOOL UiProgressDialog(HWND window, char *msg, int enable, int (*fnfunc)(), int r
 		progress = fnfunc();
 		progress_Render(progress);
 		DrawMouse();
-		SetFadeLevel(256);
+		RenderPresent();
 
 		while (SDL_PollEvent(&event)) {
 			switch (event.type) {

--- a/SourceX/DiabloUI/text_draw.cpp
+++ b/SourceX/DiabloUI/text_draw.cpp
@@ -53,18 +53,14 @@ void DrawTTF(const char *text, const SDL_Rect &rectIn, int flags,
 		return;
 
 	SDL_Rect dest_rect = rect;
-	const int x_offset = AlignXOffset(flags, rect, text_surface->w);
-	const int y_offset = (flags & UIS_VCENTER) ? (rect.h - text_surface->h) / 2 : 0;
-	dest_rect.x += static_cast<decltype(SDL_Rect().x)>(SCREEN_X + x_offset);
-	dest_rect.y += static_cast<decltype(SDL_Rect().y)>(SCREEN_Y + y_offset);
+	dest_rect.x += AlignXOffset(flags, rect, text_surface->w);
+	dest_rect.y += (flags & UIS_VCENTER) ? (rect.h - text_surface->h) / 2 : 0;
 
 	SDL_Rect shadow_rect = dest_rect;
 	++shadow_rect.x;
 	++shadow_rect.y;
-	if (SDL_BlitSurface(shadow_surface, nullptr, pal_surface, &shadow_rect) <= -1)
-		ErrSdl();
-	if (SDL_BlitSurface(text_surface, nullptr, pal_surface, &dest_rect) <= -1)
-		ErrSdl();
+	Blit(shadow_surface, nullptr, &shadow_rect);
+	Blit(text_surface, nullptr, &dest_rect);
 }
 
 void DrawArtStr(const char *text, const SDL_Rect &rect, int flags, bool drawTextCursor)

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -190,6 +190,25 @@ void BltFast(SDL_Rect *src_rect, SDL_Rect *dst_rect)
 	}
 }
 
+void Blit(SDL_Surface *src, SDL_Rect *src_rect, SDL_Rect *dst_rect)
+{
+	if (OutputRequiresScaling()) {
+		ScaleOutputRect(dst_rect);
+		// Convert from 8-bit to 32-bit
+		SDL_Surface *tmp = SDL_ConvertSurface(src, GetOutputSurface()->format, 0);
+		if (SDL_BlitScaled(tmp, src_rect, GetOutputSurface(), dst_rect) <= -1) {
+			SDL_FreeSurface(tmp);
+			ErrSdl();
+		}
+		SDL_FreeSurface(tmp);
+	} else {
+		// Convert from 8-bit to 32-bit
+		if (SDL_BlitSurface(src, src_rect, GetOutputSurface(), dst_rect) <= -1) {
+			ErrSdl();
+		}
+	}
+}
+
 /**
  * @brief Limit FPS to avoid high CPU load, use when v-sync isn't available
  */


### PR DESCRIPTION
This removes the use of the backbuffer (pal_surface) during the menu.

Fixes fades not reset when switching to a new menu before fade had
ended.
Fixes incorrect start position for credits.

Note: We can probably improve performance in a later PR by converting the surfaces at load time, possibly even scaling them as well.