### PR TITLE
Fix conn_type enum order

### DIFF
--- a/enums.h
+++ b/enums.h
@@ -2920,11 +2920,11 @@ typedef enum dlrg_flag {
 } dlrg_flag;
 
 typedef enum conn_type {
-	SELCONN_LOOPBACK = 0,
 #ifndef NONET
 	SELCONN_TCP,
 #ifdef BUGGY
 	SELCONN_UDP,
 #endif
 #endif
+	SELCONN_LOOPBACK,
 } conn_type;


### PR DESCRIPTION
DiabloUI selconn.cp relies on the enum values to be ordered in the same
way as the UI items (e.g. for keyboard navigation).

This restores the order to what it was prior to:
https://github.com/diasurgical/devilutionX/commit/4e29a4b8aa728c1aa65b0686f82ac441d54af780