### PR TITLE
Blit: Fix scaled output handling

### DIFF
--- a/SourceS/sdl2_to_1_2_backports.h
+++ b/SourceS/sdl2_to_1_2_backports.h
@@ -217,17 +217,7 @@ SDL_FreePalette(SDL_Palette *palette)
 
 inline bool SDL_HasColorKey(SDL_Surface *surface)
 {
-	return (surface->flags & (SDL_SRCCOLORKEY | SDL_RLEACCELOK)) != 0;
-}
-
-inline int SDL_GetColorKey(SDL_Surface *surface, Uint32 *colorkey)
-{
-	if (!SDL_HasColorKey(surface)) {
-		SDL_SetError("Surface doesn't have a colorkey");
-		return -1;
-	}
-	*colorkey = surface->format->colorkey;
-	return 0;
+	return (surface->flags & SDL_SRCCOLORKEY) != 0;
 }
 
 //= Pixel formats

--- a/SourceS/sdl2_to_1_2_backports.h
+++ b/SourceS/sdl2_to_1_2_backports.h
@@ -215,6 +215,21 @@ SDL_FreePalette(SDL_Palette *palette)
 	SDL_free(palette);
 }
 
+inline bool SDL_HasColorKey(SDL_Surface *surface)
+{
+	return (surface->flags & (SDL_SRCCOLORKEY | SDL_RLEACCELOK)) != 0;
+}
+
+inline int SDL_GetColorKey(SDL_Surface *surface, Uint32 *colorkey)
+{
+	if (!SDL_HasColorKey(surface)) {
+		SDL_SetError("Surface doesn't have a colorkey");
+		return -1;
+	}
+	*colorkey = surface->format->colorkey;
+	return 0;
+}
+
 //= Pixel formats
 
 #define SDL_PIXELFORMAT_INDEX8 1
@@ -259,7 +274,8 @@ inline void SDLBackport_PixelformatToMask(int pixelformat, Uint32 *flags, Uint32
  */
 inline bool SDLBackport_PixelFormatFormatEq(const SDL_PixelFormat *a, const SDL_PixelFormat *b)
 {
-	return a->BitsPerPixel == b->BitsPerPixel && (a->palette != nullptr) == (b->palette != nullptr);
+	return a->BitsPerPixel == b->BitsPerPixel && (a->palette != nullptr) == (b->palette != nullptr)
+	    && a->Rmask == b->Rmask && a->Gmask == b->Gmask && a->Bmask == b->Bmask;
 }
 
 /**

--- a/SourceS/sdl_compat.h
+++ b/SourceS/sdl_compat.h
@@ -14,6 +14,7 @@
 #define SDLC_KEYSTATE_LEFT SDL_SCANCODE_LEFT
 #define SDLC_KEYSTATE_RIGHT SDL_SCANCODE_RIGHT
 #else
+#include "sdl2_to_1_2_backports.h"
 #define SDLC_KEYSTATE_LEFTCTRL SDLK_LCTRL
 #define SDLC_KEYSTATE_RIGHTCTRL SDLK_RCTRL
 #define SDLC_KEYSTATE_LEFTSHIFT SDLK_LSHIFT
@@ -25,6 +26,14 @@
 #define SDLC_KEYSTATE_LEFT SDLK_LEFT
 #define SDLC_KEYSTATE_RIGHT SDLK_RIGHT
 #endif
+
+inline bool SDLC_PixelFormatEq(const SDL_PixelFormat *a, const SDL_PixelFormat *b) {
+#ifndef USE_SDL1
+	return a->format == b->format;
+#else
+	return SDLBackport_PixelFormatFormatEq(a, b);
+#endif
+}
 
 inline const Uint8 *SDLC_GetKeyState()
 {

--- a/SourceS/sdl_compat.h
+++ b/SourceS/sdl_compat.h
@@ -14,7 +14,6 @@
 #define SDLC_KEYSTATE_LEFT SDL_SCANCODE_LEFT
 #define SDLC_KEYSTATE_RIGHT SDL_SCANCODE_RIGHT
 #else
-#include "sdl2_to_1_2_backports.h"
 #define SDLC_KEYSTATE_LEFTCTRL SDLK_LCTRL
 #define SDLC_KEYSTATE_RIGHTCTRL SDLK_RCTRL
 #define SDLC_KEYSTATE_LEFTSHIFT SDLK_LSHIFT
@@ -26,14 +25,6 @@
 #define SDLC_KEYSTATE_LEFT SDLK_LEFT
 #define SDLC_KEYSTATE_RIGHT SDLK_RIGHT
 #endif
-
-inline bool SDLC_PixelFormatEq(const SDL_PixelFormat *a, const SDL_PixelFormat *b) {
-#ifndef USE_SDL1
-	return a->format == b->format;
-#else
-	return SDLBackport_PixelFormatFormatEq(a, b);
-#endif
-}
 
 inline const Uint8 *SDLC_GetKeyState()
 {

--- a/SourceX/DiabloUI/art.cpp
+++ b/SourceX/DiabloUI/art.cpp
@@ -1,4 +1,5 @@
 #include "DiabloUI/art.h"
+#include "display.h"
 
 namespace dvl {
 
@@ -40,6 +41,8 @@ void LoadArt(const char *pszFile, Art *art, int frames, SDL_Color *pPalette)
 
 	art->surface = art_surface;
 	art->frame_height = height / frames;
+
+	ScaleSurfaceToOutput(&art->surface);
 }
 
 void LoadMaskedArt(const char *pszFile, Art *art, int frames, int mask)
@@ -55,6 +58,7 @@ void LoadArt(Art *art, const BYTE *artData, int w, int h, int frames)
 	art->surface = SDL_CreateRGBSurfaceWithFormatFrom(
 		const_cast<BYTE *>(artData), w, h, 8, w, SDL_PIXELFORMAT_INDEX8);
 	art->frame_height = h / frames;
+	ScaleSurfaceToOutput(&art->surface);
 }
 
 } // namespace dvl

--- a/SourceX/DiabloUI/art_draw.cpp
+++ b/SourceX/DiabloUI/art_draw.cpp
@@ -1,4 +1,5 @@
 #include "DiabloUI/art_draw.h"
+#include "display.h"
 
 namespace dvl {
 
@@ -18,11 +19,14 @@ void DrawArt(int screenX, int screenY, Art *art, int nFrame,
 		static_cast<decltype(SDL_Rect().w)>(art->w()),
 		static_cast<decltype(SDL_Rect().h)>(art->h())
 	};
+	ScaleOutputRect(&src_rect);
+
 	if (srcW && srcW < src_rect.w)
 		src_rect.w = srcW;
 	if (srcH && srcH < src_rect.h)
 		src_rect.h = srcH;
 	SDL_Rect dst_rect = { screenX, screenY, src_rect.w, src_rect.h };
+	ScaleOutputRect(&dst_rect);
 
 	if (art->surface->format->BitsPerPixel == 8 && art->palette_version != pal_surface_palette_version) {
 		if (SDLC_SetSurfaceColors(art->surface, pal_surface->format->palette) <= -1)
@@ -30,7 +34,8 @@ void DrawArt(int screenX, int screenY, Art *art, int nFrame,
 		art->palette_version = pal_surface_palette_version;
 	}
 
-	Blit(art->surface, &src_rect, &dst_rect);
+	if (SDL_BlitSurface(art->surface, &src_rect, GetOutputSurface(), &dst_rect) < 0)
+		ErrSdl();
 }
 
 void DrawAnimatedArt(Art *art, int screenX, int screenY) {

--- a/SourceX/DiabloUI/credits.cpp
+++ b/SourceX/DiabloUI/credits.cpp
@@ -95,6 +95,10 @@ CachedLine PrepareLine(std::size_t index)
 
 		if (SDL_BlitSurface(text.get(), nullptr, surface.get(), nullptr) <= -1)
 			ErrSdl();
+
+		SDL_Surface *surface_ptr = surface.release();
+		ScaleSurfaceToOutput(&surface_ptr);
+		surface.reset(surface_ptr);
 	}
 
 	return CachedLine(index, std::move(surface));
@@ -243,8 +247,12 @@ void CreditsRenderer::Render()
 		if (CREDITS_LINES[line.index][0] == '\t')
 			dest_x += 40;
 
-		SDL_Rect dest_rect = { dest_x, dest_y, line.surface.get()->w, line.surface.get()->h };
-		Blit(line.surface.get(), nullptr, &dest_rect);
+		SDL_Rect dst_rect = { dest_x, dest_y, 0, 0 };
+		ScaleOutputRect(&dst_rect);
+		dst_rect.w = line.surface.get()->w;
+		dst_rect.h = line.surface.get()->h;
+		if (SDL_BlitSurface(line.surface.get(), nullptr, GetOutputSurface(), &dst_rect) < 0)
+			ErrSdl();
 	}
 	SDL_SetClipRect(GetOutputSurface(), nullptr);
 }

--- a/SourceX/DiabloUI/credits.cpp
+++ b/SourceX/DiabloUI/credits.cpp
@@ -224,7 +224,11 @@ void CreditsRenderer::Render()
 	while (lines_.back().index + 1 != lines_end)
 		lines_.push_back(PrepareLine(lines_.back().index + 1));
 
-	SDL_SetClipRect(GetOutputSurface(), &VIEWPORT);
+	SDL_Rect viewport = VIEWPORT;
+	ScaleOutputRect(&viewport);
+	SDL_SetClipRect(GetOutputSurface(), &viewport);
+
+	// We use unscaled coordinates for calculation throughout.
 	decltype(SDL_Rect().y) dest_y = VIEWPORT.y - (offset_y - lines_begin * LINE_H);
 	for (std::size_t i = 0; i < lines_.size(); ++i, dest_y += LINE_H) {
 		auto &line = lines_[i];

--- a/SourceX/display.h
+++ b/SourceX/display.h
@@ -28,6 +28,9 @@ bool OutputRequiresScaling();
 // Scales rect if necessary.
 void ScaleOutputRect(SDL_Rect *rect);
 
+// If the output requires software scaling, replaces the given surface with a scaled one.
+void ScaleSurfaceToOutput(SDL_Surface **surface);
+
 // Convert from output coordinates to logical (resolution-independent) coordinates.
 template <
     typename T,

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -173,40 +173,59 @@ void CreatePalette()
 
 void BltFast(SDL_Rect *src_rect, SDL_Rect *dst_rect)
 {
-	if (OutputRequiresScaling()) {
-		ScaleOutputRect(dst_rect);
-		// Convert from 8-bit to 32-bit
-		SDL_Surface *tmp = SDL_ConvertSurface(pal_surface, GetOutputSurface()->format, 0);
-		if (SDL_BlitScaled(tmp, src_rect, GetOutputSurface(), dst_rect) <= -1) {
-			SDL_FreeSurface(tmp);
-			ErrSdl();
-		}
-		SDL_FreeSurface(tmp);
-	} else {
-		// Convert from 8-bit to 32-bit
-		if (SDL_BlitSurface(pal_surface, src_rect, GetOutputSurface(), dst_rect) <= -1) {
-			ErrSdl();
-		}
-	}
+	Blit(pal_surface, src_rect, dst_rect);
 }
 
 void Blit(SDL_Surface *src, SDL_Rect *src_rect, SDL_Rect *dst_rect)
 {
-	if (OutputRequiresScaling()) {
-		ScaleOutputRect(dst_rect);
-		// Convert from 8-bit to 32-bit
-		SDL_Surface *tmp = SDL_ConvertSurface(src, GetOutputSurface()->format, 0);
-		if (SDL_BlitScaled(tmp, src_rect, GetOutputSurface(), dst_rect) <= -1) {
-			SDL_FreeSurface(tmp);
+	SDL_Surface *dst = GetOutputSurface();
+	if (!OutputRequiresScaling()) {
+		if (SDL_BlitSurface(src, src_rect, dst, dst_rect) < 0)
 			ErrSdl();
-		}
-		SDL_FreeSurface(tmp);
-	} else {
-		// Convert from 8-bit to 32-bit
-		if (SDL_BlitSurface(src, src_rect, GetOutputSurface(), dst_rect) <= -1) {
-			ErrSdl();
-		}
+		return;
 	}
+
+	ScaleOutputRect(dst_rect);
+
+	// Same pixel format: We can call BlitScaled directly.
+	if (SDLC_PixelFormatEq(src->format, dst->format)) {
+		if (SDL_BlitScaled(src, src_rect, dst, dst_rect) < 0)
+			ErrSdl();
+		return;
+	}
+
+	// If the surface has a color key, we must stretch first and can then call BlitSurface.
+	if (SDL_HasColorKey(src)) {
+		SDL_Surface *stretched = SDL_CreateRGBSurface(SDL_SWSURFACE, dst_rect->w, dst_rect->h, src->format->BitsPerPixel,
+		    src->format->Rmask, src->format->Gmask, src->format->BitsPerPixel, src->format->Amask);
+		Uint32 colorkey;
+		SDL_GetColorKey(src, &colorkey);
+		SDLC_SetColorKey(stretched, colorkey);
+#ifndef USE_SDL1
+		if (SDL_ISPIXELFORMAT_INDEXED(src->format->format))
+			SDL_SetSurfacePalette(stretched, src->format->palette);
+#else
+		if (src->format->palette != nullptr)
+			SDL_SetPalette(stretched, SDL_LOGPAL, src->format->palette->colors, 0, src->format->palette->ncolors);
+#endif
+		SDL_Rect stretched_rect = { 0, 0, dst_rect->w, dst_rect->h };
+		if (SDL_SoftStretch(src, src_rect, stretched, &stretched_rect) < 0
+		    || SDL_BlitSurface(stretched, &stretched_rect, dst, dst_rect) < 0) {
+			SDL_FreeSurface(stretched);
+			ErrSdl();
+		}
+		SDL_FreeSurface(stretched);
+		return;
+	}
+
+	// A surface with a non-output pixel format but without a color key needs scaling.
+	// We can convert the format and then call BlitScaled.
+	SDL_Surface *converted = SDL_ConvertSurface(src, dst->format, 0);
+	if (SDL_BlitScaled(converted, src_rect, dst, dst_rect) < 0) {
+		SDL_FreeSurface(converted);
+		ErrSdl();
+	}
+	SDL_FreeSurface(converted);
 }
 
 /**


### PR DESCRIPTION
Fixes #594

For the menu, we scale the surface at load time and use `SDL_BlitSurface`.
For the game, we use `Blit` where we now scale before blitting if the surface has a color key.