### PR TITLE
Fix SDL_PrefPath on SDL1 for non-Amiga

### DIFF
--- a/SourceS/sdl2_to_1_2_backports.h
+++ b/SourceS/sdl2_to_1_2_backports.h
@@ -881,7 +881,12 @@ inline char *SDL_GetPrefPath(const char *org, const char *app)
 		return NULL;
 	}
 
-	SDL_snprintf(retval, len, "%s/", retval);
+	// Append trailing /
+	size_t final_len = SDL_strlen(retval);
+	if (final_len + 1 < len) {
+		retval[final_len++] = '/';
+		retval[final_len] = '\0';
+	}
 
 	return retval;
 }


### PR DESCRIPTION
snprintf was used incorrectly - its arguments cannot overlap