### PR TITLE
mainmenu: Focus on the exit item before exiting

### DIFF
--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -49,11 +49,12 @@ bool UiItemsWraps;
 char *UiTextInput;
 int UiTextInputLen;
 
+int SelectedItem = 0;
+
 namespace {
 
 DWORD fadeTc;
 int fadeValue = 0;
-int SelectedItem = 0;
 
 struct {
 	bool upArrowPressed = false;

--- a/SourceX/DiabloUI/diabloui.h
+++ b/SourceX/DiabloUI/diabloui.h
@@ -8,6 +8,8 @@
 
 namespace dvl {
 
+extern int SelectedItem;
+
 typedef enum _artFocus {
 	FOCUS_SMALL,
 	FOCUS_MED,

--- a/SourceX/DiabloUI/mainmenu.cpp
+++ b/SourceX/DiabloUI/mainmenu.cpp
@@ -29,7 +29,11 @@ void UiMainMenuSelect(int value)
 
 void mainmenu_Esc()
 {
-	UiMainMenuSelect(MAINMENU_EXIT_DIABLO);
+	if (SelectedItem == MAINMENU_EXIT_DIABLO) {
+		UiMainMenuSelect(MAINMENU_EXIT_DIABLO);
+	} else {
+		SelectedItem = MAINMENU_EXIT_DIABLO;
+	}
 }
 
 void mainmenu_restart_repintro()


### PR DESCRIPTION
This affects both the B button and the Esc key
Fixes #603