### PR TITLE
mpqapi cleanup

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,11 +1,14 @@
 {
 	BasedOnStyle: webkit,
+	AlignConsecutiveAssignments: false,
+	AlignConsecutiveDeclarations: false,
 	AlignTrailingComments: true,
 	AllowShortBlocksOnASingleLine: true,
 	AllowShortFunctionsOnASingleLine: None,
 	PointerAlignment: Right,
-	AlignConsecutiveAssignments: true,
 	TabWidth: 4,
 	UseTab: ForIndentation,
 	SortIncludes: false,
+	FixNamespaceComments: true,
+	NamespaceIndentation: None,
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,7 +325,8 @@ if(RUN_TESTS)
     SourceT/drlg_l2_test.cpp
     SourceT/drlg_l3_test.cpp
     SourceT/drlg_l4_test.cpp
-    SourceT/effects_test.cpp)
+    SourceT/effects_test.cpp
+    SourceT/file_util_test.cpp)
 endif()
 
 add_executable(${BIN_TARGET} WIN32 MACOSX_BUNDLE ${devilutionx_SRCS})

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -57,11 +57,14 @@ std::string OpenModeToString(std::ios::openmode mode)
 }
 
 // Wraps fstream with error checks and logging.
-#define FSTREAM_CHECK(fmt, ...)                                                 \
-	if (s_->fail())                                                             \
-		SDL_Log(fmt ": failed with \"%s\"", __VA_ARGS__, std::strerror(errno)); \
-	else                                                                        \
-		FSTREAM_LOG_DEBUG(fmt, __VA_ARGS__);                                    \
+#define FSTREAM_CHECK(fmt, ...)                             \
+	if (s_->fail()) {                                       \
+		const char *error_message = std::strerror(errno);   \
+		SDL_Log(fmt ": failed with \"%s\"", __VA_ARGS__,    \
+		    error_message != nullptr ? error_message : ""); \
+	} else {                                                \
+		FSTREAM_LOG_DEBUG(fmt, __VA_ARGS__);                \
+	}                                                       \
 	return !s_->fail()
 
 struct FStreamWrapper {
@@ -223,8 +226,8 @@ private:
 		fhdr.filesize = SDL_SwapLE32(static_cast<std::uint32_t>(size));
 		fhdr.version = SDL_SwapLE16(0);
 		fhdr.sectorsizeid = SDL_SwapLE16(3);
-		fhdr.hashoffset = SDL_SwapLE32(kMpqHashEntryOffset);
-		fhdr.blockoffset = SDL_SwapLE32(kMpqBlockEntryOffset);
+		fhdr.hashoffset = SDL_SwapLE32(static_cast<std::uint32_t>(kMpqHashEntryOffset));
+		fhdr.blockoffset = SDL_SwapLE32(static_cast<std::uint32_t>(kMpqBlockEntryOffset));
 		fhdr.hashcount = SDL_SwapLE32(2048);
 		fhdr.blockcount = SDL_SwapLE32(2048);
 

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -77,49 +77,49 @@ public:
 	bool seekg(std::streampos pos)
 	{
 		s_->seekg(pos);
-		FSTREAM_CHECK("seekg(%d)", pos);
+		FSTREAM_CHECK("seekg(%ju)", static_cast<std::uintmax_t>(pos));
 	}
 
 	bool seekg(std::streamoff pos, std::ios::seekdir dir)
 	{
 		s_->seekg(pos, dir);
-		FSTREAM_CHECK("seekg(%d, %s)", static_cast<int>(pos), DirToString(dir));
+		FSTREAM_CHECK("seekg(%jd, %s)", static_cast<std::intmax_t>(pos), DirToString(dir));
 	}
 
 	bool seekp(std::streampos pos)
 	{
 		s_->seekp(pos);
-		FSTREAM_CHECK("seekp(%d)", pos);
+		FSTREAM_CHECK("seekp(%ju)", static_cast<std::uintmax_t>(pos));
 	}
 
 	bool seekp(std::streamoff pos, std::ios::seekdir dir)
 	{
 		s_->seekp(pos, dir);
-		FSTREAM_CHECK("seekp(%d, %s)", static_cast<int>(pos), DirToString(dir));
+		FSTREAM_CHECK("seekp(%jd, %s)", static_cast<std::intmax_t>(pos), DirToString(dir));
 	}
 
 	bool tellg(std::streampos *result)
 	{
 		*result = s_->tellg();
-		FSTREAM_CHECK("tellg() = %d", *result);
+		FSTREAM_CHECK("tellg() = %ju", static_cast<std::uintmax_t>(*result));
 	}
 
 	bool tellp(std::streampos *result)
 	{
 		*result = s_->tellp();
-		FSTREAM_CHECK("tellp() = %d", *result);
+		FSTREAM_CHECK("tellp() = %ju", static_cast<std::uintmax_t>(*result));
 	}
 
 	bool write(const char *data, std::streamsize size)
 	{
 		s_->write(data, size);
-		FSTREAM_CHECK("write(data, %d)", size);
+		FSTREAM_CHECK("write(data, %ju)", static_cast<std::uintmax_t>(size));
 	}
 
 	bool read(char *out, std::streamsize size)
 	{
 		s_->read(out, size);
-		FSTREAM_CHECK("read(out, %d)", size);
+		FSTREAM_CHECK("read(out, %ju)", static_cast<std::uintmax_t>(size));
 	}
 
 private:
@@ -150,7 +150,7 @@ struct Archive {
 		std::ios::openmode mode = std::ios::in | std::ios::out | std::ios::binary;
 		if (exists) {
 			if (GetFileSize(name, &size)) {
-				FSTREAM_LOG_DEBUG("GetFileSize(\"%s\") = %u", name, size);
+				FSTREAM_LOG_DEBUG("GetFileSize(\"%s\") = %ju", name, size);
 			} else {
 				SDL_Log("GetFileSize(\"%s\") failed with \"%s\"", name, std::strerror(errno));
 				return false;
@@ -179,7 +179,7 @@ struct Archive {
 			result = false;
 		stream.Close();
 		if (result && size != 0) {
-			FSTREAM_LOG_DEBUG("ResizeFile(\"%s\", %d)", name.c_str(), size);
+			FSTREAM_LOG_DEBUG("ResizeFile(\"%s\", %ju)", name.c_str(), size);
 
 			// NOTE: The original code called ResizeFile even if the file wasn't modified.
 			// It does not seem necessary, we should revisit this.

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -80,7 +80,7 @@ public:
 
 	bool IsOpen() const
 	{
-		return s_ == nullptr;
+		return s_ != nullptr;
 	}
 
 	bool seekg(std::streampos pos)
@@ -89,7 +89,7 @@ public:
 		FSTREAM_CHECK("seekg(%d)", pos);
 	}
 
-	bool seekg(std::streampos pos, std::ios::seekdir dir)
+	bool seekg(std::streamoff pos, std::ios::seekdir dir)
 	{
 		s_->seekg(pos, dir);
 		FSTREAM_CHECK("seekg(%d, %s)", static_cast<int>(pos), DirToString(dir));
@@ -101,7 +101,7 @@ public:
 		FSTREAM_CHECK("seekp(%d)", pos);
 	}
 
-	bool seekp(std::streampos pos, std::ios::seekdir dir)
+	bool seekp(std::streamoff pos, std::ios::seekdir dir)
 	{
 		s_->seekp(pos, dir);
 		FSTREAM_CHECK("seekp(%d, %s)", static_cast<int>(pos), DirToString(dir));
@@ -340,7 +340,7 @@ BOOL mpqapi_write_file_contents(const char *pszName, const BYTE *pbData, DWORD d
 			if (!archive.write(reinterpret_cast<const char *>(sectoroffsettable), nNumberOfBytesToWrite))
 				goto on_error;
 		}
-		if (archive.tellp(&end_pos))
+		if (!archive.tellp(&end_pos))
 			goto on_error;
 		sectoroffsettable[j] = SwapLE32(end_pos - start_pos);
 		if (!archive.write(mpq_buf, len))

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -178,11 +178,8 @@ struct Archive {
 		if (modified && !(stream.seekp(0, std::ios::beg) && WriteHeaderAndTables()))
 			result = false;
 		stream.Close();
-		if (result && size != 0) {
+		if (modified && result && size != 0) {
 			FSTREAM_LOG_DEBUG("ResizeFile(\"%s\", %ju)", name.c_str(), size);
-
-			// NOTE: The original code called ResizeFile even if the file wasn't modified.
-			// It does not seem necessary, we should revisit this.
 			result = ResizeFile(name.c_str(), size);
 		}
 		name.clear();

--- a/Source/mpqapi.h
+++ b/Source/mpqapi.h
@@ -2,11 +2,6 @@
 #ifndef __MPQAPI_H__
 #define __MPQAPI_H__
 
-void mpqapi_store_creation_time(const char *pszArchive, DWORD dwChar);
-BOOL mpqapi_reg_load_modification_time(char *dst, int size);
-void mpqapi_xor_buf(char *pbData);
-void mpqapi_store_default_time(DWORD dwChar);
-BOOLEAN mpqapi_reg_store_modification_time(char *pbData, DWORD dwLen);
 void mpqapi_remove_hash_entry(const char *pszName);
 void mpqapi_alloc_block(int block_offset, int block_size);
 _BLOCKENTRY *mpqapi_new_block(int *block_index);
@@ -20,7 +15,6 @@ int mpqapi_find_free_block(int size, int *block_size);
 void mpqapi_rename(char *pszOld, char *pszNew);
 BOOL mpqapi_has_file(const char *pszName);
 BOOL OpenMPQ(const char *pszArchive, DWORD dwChar);
-void mpqapi_store_modified_time(const char *pszArchive, DWORD dwChar);
 BOOL mpqapi_flush_and_close(const char *pszArchive, BOOL bFree, DWORD dwChar);
 /* rdata */
 

--- a/Source/mpqapi.h
+++ b/Source/mpqapi.h
@@ -2,10 +2,6 @@
 #ifndef __MPQAPI_H__
 #define __MPQAPI_H__
 
-extern char mpq_buf[4096];
-extern BOOL save_archive_modified;
-extern BOOLEAN save_archive_open;
-
 void mpqapi_store_creation_time(const char *pszArchive, DWORD dwChar);
 BOOL mpqapi_reg_load_modification_time(char *dst, int size);
 void mpqapi_xor_buf(char *pbData);
@@ -24,15 +20,8 @@ int mpqapi_find_free_block(int size, int *block_size);
 void mpqapi_rename(char *pszOld, char *pszNew);
 BOOL mpqapi_has_file(const char *pszName);
 BOOL OpenMPQ(const char *pszArchive, DWORD dwChar);
-BOOL ParseMPQHeader(_FILEHEADER *pHdr, DWORD *pdwNextFileStart);
-void CloseMPQ(const char *pszArchive, BOOL bFree, DWORD dwChar);
 void mpqapi_store_modified_time(const char *pszArchive, DWORD dwChar);
 BOOL mpqapi_flush_and_close(const char *pszArchive, BOOL bFree, DWORD dwChar);
-BOOL WriteMPQHeader();
-BOOL mpqapi_write_block_table();
-BOOL mpqapi_write_hash_table();
-BOOL mpqapi_can_seek();
-
 /* rdata */
 
 /* data */

--- a/SourceS/file_util.h
+++ b/SourceS/file_util.h
@@ -1,6 +1,14 @@
 #pragma once
 
+#include <algorithm>
+#include <string>
 #include <cstdint>
+
+#include <SDL.h>
+
+#ifdef USE_SDL1
+#include "sdl2_to_1_2_backports.h"
+#endif
 
 #if defined(_WIN64) || defined(_WIN32)
 // Suppress definitions of `min` and `max` macros by <windows.h>:
@@ -88,17 +96,16 @@ inline bool ResizeFile(const char *path, std::uintmax_t size)
 
 inline void RemoveFile(char *lpFileName)
 {
-	char name[DVL_MAX_PATH];
-	TranslateFileName(name, sizeof(name), lpFileName);
-
-	FILE *f = fopen(name, "r+");
+	std::string name = lpFileName;
+	std::replace(name.begin(), name.end(), '\\', '/');
+	FILE *f = fopen(name.c_str(), "r+");
 	if (f) {
 		fclose(f);
-		remove(name);
+		remove(name.c_str());
 		f = NULL;
-		SDL_Log("Removed file: %s", name);
+		SDL_Log("Removed file: %s", name.c_str());
 	} else {
-		SDL_Log("Failed to remove file: %s", name);
+		SDL_Log("Failed to remove file: %s", name.c_str());
 	}
 }
 

--- a/SourceT/file_util_test.cpp
+++ b/SourceT/file_util_test.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <fstream>
+
+#include "file_util.h"
+
+namespace dvl {
+namespace {
+
+void WriteDummyFile(const char *name, std::uintmax_t size)
+{
+	std::ofstream test_file(name, std::ios::out | std::ios::trunc | std::ios::binary);
+	ASSERT_FALSE(test_file.fail());
+	const char c = '\0';
+	for (std::uintmax_t i = 0; i < size; ++i) {
+		test_file.write(&c, 1);
+		ASSERT_FALSE(test_file.fail());
+	}
+}
+
+std::string GetTmpPathName(const char *suffix = ".tmp")
+{
+	const auto *current_test = ::testing::UnitTest::GetInstance()->current_test_info();
+	std::string result = "Test_";
+	result.append(current_test->test_case_name());
+	result += '_';
+	result.append(current_test->name());
+	result.append(suffix);
+	return result;
+}
+
+TEST(FileUtil, GetFileSize)
+{
+	const std::string path = GetTmpPathName();
+	std::cout << path << std::endl;
+	WriteDummyFile(path.c_str(), 42);
+	std::uintmax_t result;
+	ASSERT_TRUE(GetFileSize(path.c_str(), &result));
+	EXPECT_EQ(result, 42);
+}
+
+TEST(FileUtil, FileExists)
+{
+	EXPECT_FALSE(FileExists("this-file-should-not-exist"));
+	const std::string path = GetTmpPathName();
+	std::cout << path << std::endl;
+	WriteDummyFile(path.c_str(), 42);
+	EXPECT_TRUE(FileExists(path.c_str()));
+}
+
+TEST(FileUtil, ResizeFile)
+{
+	const std::string path = GetTmpPathName();
+	std::cout << path << std::endl;
+	WriteDummyFile(path.c_str(), 42);
+	std::uintmax_t size;
+	ASSERT_TRUE(GetFileSize(path.c_str(), &size));
+	EXPECT_EQ(size, 42);
+	ASSERT_TRUE(ResizeFile(path.c_str(), 30));
+	ASSERT_TRUE(GetFileSize(path.c_str(), &size));
+	EXPECT_EQ(size, 30);
+}
+
+} // namespace
+} // namespace dvl


### PR DESCRIPTION
1. Do not rely on stream positions for getting the initial file size.
2. Remove most `seek` calls that were unnecessary.
3. Replace magic numbers with constants.
4. A class to manage archive lifetime and all associated data.
5. Works around save issue on Amiga

@Cowcat5150, could you please test this?