### PR TITLE
Update AppVeyor CI to VS 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ make -j$(nproc)
 <details><summary>Windows via Visual Studio</summary>
 
 ### Installing dependencies
+
+Visual Studio 2019 or newer is required.
+
 Make sure to install the `C++ CMake tools for Windows` component for Visual Studio.
 
 * **Using vcpkg (recommended)**

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,14 +3,14 @@ version: 1.0.{build}
 pull_requests:
   do_not_increment_build_number: true
 clone_depth: 1
-image: Visual Studio 2017
+image: Visual Studio 2019
 cache: c:\tools\vcpkg\installed\
 
 install:
   - vcpkg install sdl2:x64-windows sdl2-mixer:x64-windows sdl2-ttf:x64-windows libsodium:x64-windows
 
 before_build:
-  - cmake -G "Visual Studio 15 2017" -A x64 -DNIGHTLY_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake .
+  - cmake -G "Visual Studio 16 2019" -A x64 -DNIGHTLY_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake .
 
 build:
   project: $(APPVEYOR_BUILD_FOLDER)\$(APPVEYOR_PROJECT_NAME).sln


### PR DESCRIPTION
VS 2019 should fix %ju/d printf format specifier support which we use in mpqapi logging