### PR TITLE
Fixed player base block is zero bug after loading a new game.  

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -452,6 +452,8 @@ void LoadPlayer(int i)
 	CopyInt(tbuff, &pPlayer->pDiabloKillLevel);
 	CopyInts(tbuff, 7, &pPlayer->dwReserved);
 
+	pPlayer->_pBaseToBlk = ToBlkTbl[pPlayer->_pClass];
+
 	// Omit pointer _pNData
 	// Omit pointer _pWData
 	// Omit pointer _pAData

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -194,6 +194,7 @@ void UnPackPlayer(PkPlayerStruct *pPack, int pnum, BOOL killok)
 	pPlayer->_pGold = SwapLE32(pPack->pGold);
 	pPlayer->_pMaxHPBase = SwapLE32(pPack->pMaxHPBase);
 	pPlayer->_pHPBase = SwapLE32(pPack->pHPBase);
+	pPlayer->_pBaseToBlk = ToBlkTbl[pPlayer->_pClass];
 	if (!killok)
 		if ((int)(pPlayer->_pHPBase & 0xFFFFFFC0) < 64)
 			pPlayer->_pHPBase = 64;


### PR DESCRIPTION
This value is not saved in single player or multiplayer, so when a character is loaded, the value is always zero.  Now when a player is loaded, it is set to the default.  See section 2.1.4 in Jarulf's Guide.