### PR TITLE
Resolve CreatePalette name conflict

### DIFF
--- a/Source/dx.h
+++ b/Source/dx.h
@@ -13,7 +13,7 @@ void unlock_buf(BYTE idx);
 void dx_cleanup();
 void dx_reinit();
 
-void CreatePalette();
+void InitPalette();
 void BltFast(SDL_Rect *src_rect, SDL_Rect *dst_rect);
 void Blit(SDL_Surface *src, SDL_Rect *src_rect, SDL_Rect *dst_rect);
 void RenderPresent();

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -70,7 +70,7 @@ void palette_init()
 {
 	LoadGamma();
 	memcpy(system_palette, orig_palette, sizeof(orig_palette));
-	CreatePalette();
+	InitPalette();
 }
 
 void LoadPalette(char *pszFileName)

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -164,7 +164,7 @@ void dx_reinit()
 	force_redraw = 255;
 }
 
-void CreatePalette()
+void InitPalette()
 {
 	palette = SDL_AllocPalette(256);
 	if (palette == NULL) {


### PR DESCRIPTION
Use CreatePalette_ in a similar fashion as we did with random_ and
SetCursor_ to avoid conflicts

Fixes #641.