### PR TITLE
Fixed monster to hit and unique monster to hit and ac difficulty bonus.

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -534,10 +534,10 @@ void LoadMonster(int i)
 	tbuff += 1; // Alignment
 	CopyShort(tbuff, &pMonster->mExp);
 
-	CopyChar(tbuff, &pMonster->mHit);
+	tbuff += 1; //skip mHit as it's already initialized
 	CopyChar(tbuff, &pMonster->mMinDamage);
 	CopyChar(tbuff, &pMonster->mMaxDamage);
-	CopyChar(tbuff, &pMonster->mHit2);
+	tbuff += 1; //skip mHit2 as it's already initialized
 	CopyChar(tbuff, &pMonster->mMinDamage2);
 	CopyChar(tbuff, &pMonster->mMaxDamage2);
 	CopyChar(tbuff, &pMonster->mArmorClass);
@@ -1260,10 +1260,10 @@ void SaveMonster(int i)
 	tbuff += 1; // Alignment
 	CopyShort(&pMonster->mExp, tbuff);
 
-	CopyChar(&pMonster->mHit, tbuff);
+	tbuff += 1; //don't write mHit as it's unnecessary
 	CopyChar(&pMonster->mMinDamage, tbuff);
 	CopyChar(&pMonster->mMaxDamage, tbuff);
-	CopyChar(&pMonster->mHit2, tbuff);
+	tbuff += 1; //don't write mHit2 as it's unnecessary
 	CopyChar(&pMonster->mMinDamage2, tbuff);
 	CopyChar(&pMonster->mMaxDamage2, tbuff);
 	CopyChar(&pMonster->mArmorClass, tbuff);

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -454,13 +454,11 @@ void InitMonster(int i, int rd, int mtype, int x, int y)
 		monster[i].mLevel += 15;
 		monster[i].mExp = 2 * (monster[i].mExp + 1000);
 
-		unsigned short iHit = monster[i].mHit + NIGHTMARE_TO_HIT_BONUS;
-		monster[i].mHit = iHit > MAX_TO_HIT ? MAX_TO_HIT : (unsigned char)iHit;
+		monster[i].mHit += NIGHTMARE_TO_HIT_BONUS;
 		monster[i].mMinDamage = 2 * (monster[i].mMinDamage + 2);
 		monster[i].mMaxDamage = 2 * (monster[i].mMaxDamage + 2);
 
-		iHit = monster[i].mHit2 + NIGHTMARE_TO_HIT_BONUS;
-		monster[i].mHit2 = iHit > MAX_TO_HIT ? MAX_TO_HIT : (unsigned char)iHit;
+		monster[i].mHit2 += NIGHTMARE_TO_HIT_BONUS;
 		monster[i].mMinDamage2 = 2 * (monster[i].mMinDamage2 + 2);
 		monster[i].mMaxDamage2 = 2 * (monster[i].mMaxDamage2 + 2);
 		monster[i].mArmorClass += NIGHTMARE_AC_BONUS;
@@ -472,13 +470,11 @@ void InitMonster(int i, int rd, int mtype, int x, int y)
 		monster[i].mLevel += 30;
 		monster[i].mExp = 4 * (monster[i].mExp + 1000);
 
-		unsigned short iHit = monster[i].mHit + HELL_TO_HIT_BONUS;
-		monster[i].mHit = iHit > MAX_TO_HIT ? MAX_TO_HIT : (unsigned char)iHit;
+		monster[i].mHit += HELL_TO_HIT_BONUS;
 		monster[i].mMinDamage = 4 * monster[i].mMinDamage + 6;
 		monster[i].mMaxDamage = 4 * monster[i].mMaxDamage + 6;
 
-		iHit = monster[i].mHit2 + HELL_TO_HIT_BONUS;
-		monster[i].mHit2 = iHit > MAX_TO_HIT ? MAX_TO_HIT : (unsigned char)iHit;
+		monster[i].mHit2 += HELL_TO_HIT_BONUS;
 		monster[i].mMinDamage2 = 4 * monster[i].mMinDamage2 + 6;
 		monster[i].mMaxDamage2 = 4 * monster[i].mMaxDamage2 + 6;
 		monster[i].mArmorClass += HELL_AC_BONUS;
@@ -744,15 +740,11 @@ void PlaceUniqueMonst(int uniqindex, int miniontype, int unpackfilesize)
 		Monst->mHit2 = Uniq->mUnqVar1;
 
 		if (gnDifficulty == DIFF_NIGHTMARE) {
-			unsigned short iHit = Monst->mHit + NIGHTMARE_TO_HIT_BONUS;
-			Monst->mHit = iHit > MAX_TO_HIT ? MAX_TO_HIT : iHit;
-			iHit = Monst->mHit2 + NIGHTMARE_TO_HIT_BONUS;
-			Monst->mHit2 = iHit > MAX_TO_HIT ? MAX_TO_HIT : iHit;
+			Monst->mHit += NIGHTMARE_TO_HIT_BONUS;
+			Monst->mHit2 += NIGHTMARE_TO_HIT_BONUS;
 		} else if (gnDifficulty == DIFF_HELL) {
-			unsigned short iHit = Monst->mHit + HELL_TO_HIT_BONUS;
-			Monst->mHit = iHit > MAX_TO_HIT ? MAX_TO_HIT : iHit;
-			iHit = Monst->mHit2 + HELL_TO_HIT_BONUS;
-			Monst->mHit2 = iHit > MAX_TO_HIT ? MAX_TO_HIT : iHit;
+			Monst->mHit += HELL_TO_HIT_BONUS;
+			Monst->mHit2 += HELL_TO_HIT_BONUS;
 		}
 	}
 	if (Uniq->mUnqAttr & 8) {

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -453,13 +453,17 @@ void InitMonster(int i, int rd, int mtype, int x, int y)
 		monster[i]._mhitpoints = monster[i]._mmaxhp;
 		monster[i].mLevel += 15;
 		monster[i].mExp = 2 * (monster[i].mExp + 1000);
-		monster[i].mHit += 85;
+
+		unsigned short iHit = monster[i].mHit + NIGHTMARE_TO_HIT_BONUS;
+		monster[i].mHit = iHit > MAX_TO_HIT ? MAX_TO_HIT : (unsigned char)iHit;
 		monster[i].mMinDamage = 2 * (monster[i].mMinDamage + 2);
 		monster[i].mMaxDamage = 2 * (monster[i].mMaxDamage + 2);
-		monster[i].mHit2 += 85;
+
+		iHit = monster[i].mHit2 + NIGHTMARE_TO_HIT_BONUS;
+		monster[i].mHit2 = iHit > MAX_TO_HIT ? MAX_TO_HIT : (unsigned char)iHit;
 		monster[i].mMinDamage2 = 2 * (monster[i].mMinDamage2 + 2);
 		monster[i].mMaxDamage2 = 2 * (monster[i].mMaxDamage2 + 2);
-		monster[i].mArmorClass += 50;
+		monster[i].mArmorClass += NIGHTMARE_AC_BONUS;
 	}
 
 	if (gnDifficulty == DIFF_HELL) {
@@ -467,13 +471,17 @@ void InitMonster(int i, int rd, int mtype, int x, int y)
 		monster[i]._mhitpoints = monster[i]._mmaxhp;
 		monster[i].mLevel += 30;
 		monster[i].mExp = 4 * (monster[i].mExp + 1000);
-		monster[i].mHit += 120;
+
+		unsigned short iHit = monster[i].mHit + HELL_TO_HIT_BONUS;
+		monster[i].mHit = iHit > MAX_TO_HIT ? MAX_TO_HIT : (unsigned char)iHit;
 		monster[i].mMinDamage = 4 * monster[i].mMinDamage + 6;
 		monster[i].mMaxDamage = 4 * monster[i].mMaxDamage + 6;
-		monster[i].mHit2 += 120;
+
+		iHit = monster[i].mHit2 + HELL_TO_HIT_BONUS;
+		monster[i].mHit2 = iHit > MAX_TO_HIT ? MAX_TO_HIT : (unsigned char)iHit;
 		monster[i].mMinDamage2 = 4 * monster[i].mMinDamage2 + 6;
 		monster[i].mMaxDamage2 = 4 * monster[i].mMaxDamage2 + 6;
-		monster[i].mArmorClass += 80;
+		monster[i].mArmorClass += HELL_AC_BONUS;
 		monster[i].mMagicRes = monst->MData->mMagicRes2;
 	}
 }
@@ -734,9 +742,27 @@ void PlaceUniqueMonst(int uniqindex, int miniontype, int unpackfilesize)
 	if (Uniq->mUnqAttr & 4) {
 		Monst->mHit = Uniq->mUnqVar1;
 		Monst->mHit2 = Uniq->mUnqVar1;
+
+		if (gnDifficulty == DIFF_NIGHTMARE) {
+			unsigned short iHit = Monst->mHit + NIGHTMARE_TO_HIT_BONUS;
+			Monst->mHit = iHit > MAX_TO_HIT ? MAX_TO_HIT : iHit;
+			iHit = Monst->mHit2 + NIGHTMARE_TO_HIT_BONUS;
+			Monst->mHit2 = iHit > MAX_TO_HIT ? MAX_TO_HIT : iHit;
+		} else if (gnDifficulty == DIFF_HELL) {
+			unsigned short iHit = Monst->mHit + HELL_TO_HIT_BONUS;
+			Monst->mHit = iHit > MAX_TO_HIT ? MAX_TO_HIT : iHit;
+			iHit = Monst->mHit2 + HELL_TO_HIT_BONUS;
+			Monst->mHit2 = iHit > MAX_TO_HIT ? MAX_TO_HIT : iHit;
+		}
 	}
 	if (Uniq->mUnqAttr & 8) {
 		Monst->mArmorClass = Uniq->mUnqVar1;
+
+		if (gnDifficulty == DIFF_NIGHTMARE) {
+			Monst->mArmorClass += NIGHTMARE_AC_BONUS;
+		} else if (gnDifficulty == DIFF_HELL) {
+			Monst->mArmorClass += HELL_AC_BONUS;
+		}
 	}
 
 	nummonsters++;

--- a/defs.h
+++ b/defs.h
@@ -149,6 +149,13 @@
 
 #define SCREENXY(x, y)	((x) + SCREEN_X + ((y) + SCREEN_Y) * BUFFER_WIDTH)
 
+#define NIGHTMARE_TO_HIT_BONUS  85
+#define HELL_TO_HIT_BONUS      120
+#define MAX_TO_HIT             255
+
+#define NIGHTMARE_AC_BONUS 50
+#define HELL_AC_BONUS      80
+
 #define MemFreeDbg(p)	\
 {						\
 	void *p__p;			\

--- a/defs.h
+++ b/defs.h
@@ -151,7 +151,6 @@
 
 #define NIGHTMARE_TO_HIT_BONUS  85
 #define HELL_TO_HIT_BONUS      120
-#define MAX_TO_HIT             255
 
 #define NIGHTMARE_AC_BONUS 50
 #define HELL_AC_BONUS      80

--- a/structs.h
+++ b/structs.h
@@ -494,11 +494,11 @@ typedef struct MonsterData {
 	char mAi;
 	int mFlags;
 	unsigned char mInt;
-	unsigned char mHit; // BUGFIX: Some monsters overflow this value on high difficulty
+	unsigned short mHit;
 	unsigned char mAFNum;
 	unsigned char mMinDamage;
 	unsigned char mMaxDamage;
-	unsigned char mHit2; // BUGFIX: Some monsters overflow this value on high difficulty
+	unsigned short mHit2;
 	unsigned char mAFNum2;
 	unsigned char mMinDamage2;
 	unsigned char mMaxDamage2;
@@ -588,10 +588,10 @@ typedef struct MonsterStruct { // note: missing field _mAFNum
 	char mWhoHit;
 	char mLevel;
 	unsigned short mExp;
-	unsigned char mHit;
+	unsigned short mHit;
 	unsigned char mMinDamage;
 	unsigned char mMaxDamage;
-	unsigned char mHit2;
+	unsigned short mHit2;
 	unsigned char mMinDamage2;
 	unsigned char mMaxDamage2;
 	unsigned char mArmorClass;


### PR DESCRIPTION
The fix for monster to hit is likely temporary.  To hit is stored as an unsigned char when it should be an unsigned short, but this cannot be changed as it will break single player save file compatibility.  So I simply check to see if the bonus would overflow, and if it does, set it to 255 instead.  There's only a few monsters this affects, but Diablo is one of them so it's a rather important fix.  A better solution would be to apply the full bonus, so perhaps it can be properly implemented with the new json save files.

The second fix simply applies to hit and ac difficulty bonuses to unique monsters that have a special to hit or ac.