### PR TITLE
Default to 60hz if the driver doesn't return a usable value

### DIFF
--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -99,13 +99,15 @@ bool SpawnWindow(const char *lpWindowName, int nWidth, int nHeight)
 		ErrSdl();
 	}
 
-#ifdef USE_SDL1
-	refreshDelay = 1000000 / 60; // 60hz
-#else
+	int refreshRate = 60;
+#ifndef USE_SDL1
 	SDL_DisplayMode mode;
 	SDL_GetDisplayMode(0, 0, &mode);
-	refreshDelay = 1000000 / mode.refresh_rate;
+	if (mode.refresh_rate != 0) {
+		refreshRate = mode.refresh_rate;
+	}
 #endif
+	refreshDelay = 1000000 / refreshRate;
 
 	if (upscale) {
 #ifdef USE_SDL1


### PR DESCRIPTION
This fixes #644