### PR TITLE
Bugfix: allow players of level 20 to enter nightmare game

### DIFF
--- a/SourceX/DiabloUI/selgame.cpp
+++ b/SourceX/DiabloUI/selgame.cpp
@@ -145,10 +145,11 @@ void selgame_GameSelection_Select(int value)
 	selgame_enteringGame = true;
 	selgame_selectedGame = value;
 
+	gfnHeroInfo(UpdateHeroLevel);
+
 	switch (value) {
 	case 0:
 		strcpy(title, "Create Game");
-		gfnHeroInfo(UpdateHeroLevel);
 		UiInitList(0, NUM_DIFFICULTIES - 1, selgame_Diff_Focus, selgame_Diff_Select, selgame_Diff_Esc, SELDIFF_DIALOG, size(SELDIFF_DIALOG));
 		break;
 	case 1:


### PR DESCRIPTION
Right now we update heroLevel only on "CreateGame" code. This
means you can't enter nightmare/hell game at all - unless you
do createGame first. Let's set the heroLevel global variable in both
create and join game cases.