### PR TITLE
Fix CI Debian Stretch build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run: echo deb http://deb.debian.org/debian stretch-backports-sloppy main >> /etc/apt/sources.list.d/debian-backports.list
       - run: apt-get update -y
       - run: apt-get install -y g++ libsdl2-dev libsdl2-mixer-dev libsdl2-ttf-dev git
-      - run: apt-get install -y -f -t stretch-backports -t stretch-backports-sloppy cmake libsodium-dev
+      - run: apt-get install -y -t 'stretch-backports*' cmake libsodium-dev
       - run: cd build && cmake .. -DNIGHTLY_BUILD=ON
       - run: cd build && cmake --build . -j $(nproc)
       - store_artifacts: {path: ./build/devilutionx, destination: devilutionx_linux_x86_64}
@@ -34,7 +34,7 @@ jobs:
       - run: echo deb http://deb.debian.org/debian stretch-backports-sloppy main >> /etc/apt/sources.list.d/debian-backports.list
       - run: apt-get update -y
       - run: apt-get install -y g++ libsdl-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev git
-      - run: apt-get install -y -f -t stretch-backports cmake libsodium-dev
+      - run: apt-get install -y -t 'stretch-backports*' cmake libsodium-dev
       - run: cd build && cmake .. -DNIGHTLY_BUILD=ON -DUSE_SDL1=ON
       - run: cd build && cmake --build . -j $(nproc)
       - store_artifacts: {path: ./build/devilutionx, destination: devilutionx_linux_x86_64_sdl1}
@@ -48,7 +48,7 @@ jobs:
       - run: dpkg --add-architecture i386
       - run: apt-get update -y
       - run: apt-get install -y g++-multilib libsdl2-dev:i386 libsdl2-mixer-dev:i386 libsdl2-ttf-dev:i386 libsodium-dev git
-      - run: apt-get install -y -f -t stretch-backports cmake libsodium-dev:i386
+      - run: apt-get install -y -f -t 'stretch-backports*' cmake libsodium-dev:i386
       - run: cd build && cmake -DNIGHTLY_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=../CMake/32bit.cmake ..
       - run: cd build && cmake --build . -j $(nproc)
       - store_artifacts: {path: ./build/devilutionx, destination: devilutionx_linux_x86}
@@ -81,7 +81,7 @@ jobs:
       - checkout
       - run: echo deb http://deb.debian.org/debian stretch-backports main > /etc/apt/sources.list.d/debian-backports.list
       - run: echo deb http://deb.debian.org/debian stretch-backports-sloppy main >> /etc/apt/sources.list.d/debian-backports.list
-      - run: apt-get update && apt-get install -y -f -t stretch-backports cmake
+      - run: apt-get update && apt-get install -y -f -t 'stretch-backports*' cmake
       - run: dkp-pacman -Syu --noconfirm
       # Install cmake files (https://github.com/devkitPro/docker/issues/3)
       - run: dkp-pacman -S --needed --noconfirm --quiet devkitpro-pkgbuild-helpers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,10 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
+      - run: echo deb http://deb.debian.org/debian stretch-backports-sloppy main >> /etc/apt/sources.list.d/debian-backports.list
       - run: apt-get update -y
       - run: apt-get install -y g++ libsdl2-dev libsdl2-mixer-dev libsdl2-ttf-dev git
-      - run: apt-get install -y -f -t stretch-backports cmake libsodium-dev
+      - run: apt-get install -y -f -t stretch-backports -t stretch-backports-sloppy cmake libsodium-dev
       - run: cd build && cmake .. -DNIGHTLY_BUILD=ON
       - run: cd build && cmake --build . -j $(nproc)
       - store_artifacts: {path: ./build/devilutionx, destination: devilutionx_linux_x86_64}
@@ -30,6 +31,7 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
+      - run: echo deb http://deb.debian.org/debian stretch-backports-sloppy main >> /etc/apt/sources.list.d/debian-backports.list
       - run: apt-get update -y
       - run: apt-get install -y g++ libsdl-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev git
       - run: apt-get install -y -f -t stretch-backports cmake libsodium-dev
@@ -42,6 +44,7 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
+      - run: echo deb http://deb.debian.org/debian stretch-backports-sloppy main >> /etc/apt/sources.list.d/debian-backports.list
       - run: dpkg --add-architecture i386
       - run: apt-get update -y
       - run: apt-get install -y g++-multilib libsdl2-dev:i386 libsdl2-mixer-dev:i386 libsdl2-ttf-dev:i386 libsodium-dev git
@@ -77,6 +80,7 @@ jobs:
     steps:
       - checkout
       - run: echo deb http://deb.debian.org/debian stretch-backports main > /etc/apt/sources.list.d/debian-backports.list
+      - run: echo deb http://deb.debian.org/debian stretch-backports-sloppy main >> /etc/apt/sources.list.d/debian-backports.list
       - run: apt-get update && apt-get install -y -f -t stretch-backports cmake
       - run: dkp-pacman -Syu --noconfirm
       # Install cmake files (https://github.com/devkitPro/docker/issues/3)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
       - checkout
       - run: echo deb http://deb.debian.org/debian stretch-backports main > /etc/apt/sources.list.d/debian-backports.list
       - run: echo deb http://deb.debian.org/debian stretch-backports-sloppy main >> /etc/apt/sources.list.d/debian-backports.list
-      - run: apt-get update && apt-get install -y -f -t 'stretch-backports*' cmake
+      - run: apt-get update && apt-get install -y -t 'stretch-backports*' cmake
       - run: dkp-pacman -Syu --noconfirm
       # Install cmake files (https://github.com/devkitPro/docker/issues/3)
       - run: dkp-pacman -S --needed --noconfirm --quiet devkitpro-pkgbuild-helpers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run: apt-get update -y
       - run: apt-get install -y g++ libsdl2-dev libsdl2-mixer-dev libsdl2-ttf-dev git
-      - run: apt-get install -y -t stretch-backports cmake libsodium-dev
+      - run: apt-get install -y -f -t stretch-backports cmake libsodium-dev
       - run: cd build && cmake .. -DNIGHTLY_BUILD=ON
       - run: cd build && cmake --build . -j $(nproc)
       - store_artifacts: {path: ./build/devilutionx, destination: devilutionx_linux_x86_64}
@@ -32,7 +32,7 @@ jobs:
       - checkout
       - run: apt-get update -y
       - run: apt-get install -y g++ libsdl-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev git
-      - run: apt-get install -y -t stretch-backports cmake libsodium-dev
+      - run: apt-get install -y -f -t stretch-backports cmake libsodium-dev
       - run: cd build && cmake .. -DNIGHTLY_BUILD=ON -DUSE_SDL1=ON
       - run: cd build && cmake --build . -j $(nproc)
       - store_artifacts: {path: ./build/devilutionx, destination: devilutionx_linux_x86_64_sdl1}
@@ -45,7 +45,7 @@ jobs:
       - run: dpkg --add-architecture i386
       - run: apt-get update -y
       - run: apt-get install -y g++-multilib libsdl2-dev:i386 libsdl2-mixer-dev:i386 libsdl2-ttf-dev:i386 libsodium-dev git
-      - run: apt-get install -y -t stretch-backports cmake libsodium-dev:i386
+      - run: apt-get install -y -f -t stretch-backports cmake libsodium-dev:i386
       - run: cd build && cmake -DNIGHTLY_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=../CMake/32bit.cmake ..
       - run: cd build && cmake --build . -j $(nproc)
       - store_artifacts: {path: ./build/devilutionx, destination: devilutionx_linux_x86}
@@ -77,7 +77,7 @@ jobs:
     steps:
       - checkout
       - run: echo deb http://deb.debian.org/debian stretch-backports main > /etc/apt/sources.list.d/debian-backports.list
-      - run: apt-get update && apt-get install -y -t stretch-backports cmake
+      - run: apt-get update && apt-get install -y -f -t stretch-backports cmake
       - run: dkp-pacman -Syu --noconfirm
       # Install cmake files (https://github.com/devkitPro/docker/issues/3)
       - run: dkp-pacman -S --needed --noconfirm --quiet devkitpro-pkgbuild-helpers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - run: dpkg --add-architecture i386
       - run: apt-get update -y
       - run: apt-get install -y g++-multilib libsdl2-dev:i386 libsdl2-mixer-dev:i386 libsdl2-ttf-dev:i386 libsodium-dev git
-      - run: apt-get install -y -f -t 'stretch-backports*' cmake libsodium-dev:i386
+      - run: apt-get install -y -t 'stretch-backports*' cmake libsodium-dev:i386
       - run: cd build && cmake -DNIGHTLY_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=../CMake/32bit.cmake ..
       - run: cd build && cmake --build . -j $(nproc)
       - store_artifacts: {path: ./build/devilutionx, destination: devilutionx_linux_x86}


### PR DESCRIPTION
The `cmake` package in `debian-stretch` has recently been updated: https://packages.debian.org/stretch-backports/cmake

This new version of `cmake` depends on a version of `libarchive13` that is only available in `stretch-backports-sloppy`.

To allow `libarchive13` to be installed from `stretch-backports-sloppy` I've added the `debian-stretch-sloppy` "suite" and changed `-t stretch-backports` to `-t 'stretch-backports*'`.

When merging this please squash the commits ("Squash and merge" in GitHub) and copy subject and description from the PR.