### PR TITLE
.travis.yml: Remove workaround (fixes macOS build)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 
 os: osx
 
-osx_image: xcode10.3
+osx_image: xcode11.3
 
 git:
   depth: false
@@ -11,9 +11,6 @@ git:
 addons:
   homebrew:
     brewfile: true
-    # TODO: Remove the `update` line once this PR has been released:
-    # https://github.com/travis-ci/packer-templates-mac/pull/13
-    update: true
 
 script:
   - cd build


### PR DESCRIPTION
Travis MacOS image has been updated but only for Xcode 11:
https://changelog.travis-ci.com/xcode-11-3-1-xcode-11-2-1-xcode-11-1-and-xcode11-images-updated-142286

Removes the workaround and updates the image version to Xcode 11