### PR TITLE
Allow re-mapping keyboard keys

### DIFF
--- a/CMake/rg350_defs.cmake
+++ b/CMake/rg350_defs.cmake
@@ -27,3 +27,6 @@ set(JOY_BUTTON_TRIGGERLEFT 6)
 set(JOY_BUTTON_TRIGGERRIGHT 7)
 set(JOY_BUTTON_START 9)
 set(JOY_BUTTON_BACK 8)
+
+# Map Power button to Esc (Menu in-game / Exit in-menu).
+set(REMAP_KEYBOARD_KEYS "{SDLK_HOME,SDLK_ESCAPE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,6 +432,7 @@ foreach(
   JOY_BUTTON_TRIGGERRIGHT
   JOY_BUTTON_START
   JOY_BUTTON_BACK
+  REMAP_KEYBOARD_KEYS
 )
   if(DEFINED ${def_name})
     list(APPEND def_list ${def_name}=${${def_name}})

--- a/SourceX/controls/menu_controls.cpp
+++ b/SourceX/controls/menu_controls.cpp
@@ -1,6 +1,7 @@
 #include "controls/menu_controls.h"
 
 #include "controls/controller.h"
+#include "controls/remap_keyboard.h"
 
 namespace dvl {
 
@@ -44,7 +45,9 @@ MenuAction GetMenuAction(const SDL_Event &event)
 		sgbControllerActive = false;
 
 	if (event.type == SDL_KEYDOWN) {
-		switch (event.key.keysym.sym) {
+		auto sym = event.key.keysym.sym;
+		remap_keyboard_key(&sym);
+		switch (sym) {
 		case SDLK_UP:
 			return MenuAction::UP;
 		case SDLK_DOWN:

--- a/SourceX/controls/remap_keyboard.h
+++ b/SourceX/controls/remap_keyboard.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstddef>
+
+#include <SDL.h>
+
+#ifdef USE_SDL1
+#include "sdl2_to_1_2_backports.h"
+#endif
+
+namespace dvl {
+
+// Re-maps a keyboard key as per the REMAP_KEYBOARD_KEYS define.
+inline void remap_keyboard_key(SDL_Keycode *sym)
+{
+#ifdef REMAP_KEYBOARD_KEYS
+
+	struct Mapping {
+		SDL_Keycode from;
+		SDL_Keycode to;
+	};
+	constexpr Mapping kMappings[] = {REMAP_KEYBOARD_KEYS};
+	for (std::size_t i = 0; i < sizeof(kMappings) / sizeof(kMappings[0]); ++i) {
+		if (*sym == kMappings[i].from) {
+			*sym = kMappings[i].to;
+			return;
+		}
+	}
+#endif
+}
+
+} // namespace dvl

--- a/SourceX/miniwin/misc_msg.cpp
+++ b/SourceX/miniwin/misc_msg.cpp
@@ -8,6 +8,7 @@
 #include "controls/controller_motion.h"
 #include "controls/game_controls.h"
 #include "controls/plrctrls.h"
+#include "controls/remap_keyboard.h"
 #include "controls/touch.h"
 #include "display.h"
 #include "controls/controller.h"
@@ -82,6 +83,7 @@ static int translate_sdl_key(SDL_Keysym key)
 	// ref: https://wiki.libsdl.org/SDL_Keycode
 	// ref: https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
 	SDL_Keycode sym = key.sym;
+	remap_keyboard_key(&sym);
 	switch (sym) {
 	case SDLK_BACKSPACE:
 		return DVL_VK_BACK;


### PR DESCRIPTION
Adds a `REMAP_KEYBOARD_KEYS` CMake option and uses it to map the "Power"
button to the menu on RG350 and GKD350h.

This remapping applies wherever Game or Menu controls apply.