### PR TITLE
Bug on Windows: game crashes when the PC wakes up from sleep

### DIFF
--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -310,26 +310,10 @@ void RenderPresent()
 #ifndef USE_SDL1
 	if (renderer != nullptr) {
 		if (SDL_UpdateTexture(texture.get(), nullptr, surface->pixels, surface->pitch) <= -1) { //pitch is 2560
-			// We should supposedly handle SDL_RENDER_DEVICE_RESET, but I tried and it doesn't arrive
+			// We do handle SDL_RENDER_DEVICE_RESET, but I tried and it doesn't arrive
 			if (string_view(SDL_GetError()) == "LockRect(): INVALIDCALL") {
-				texture.reset();
-				SDL_DestroyRenderer(renderer);
-
-				renderer = SDL_CreateRenderer(ghMainWnd, -1, SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_ACCELERATED);
-				if (renderer == nullptr) {
-					ErrSdl();
-				}
-
-				texture = SDLWrap::CreateTexture(renderer, SDL_PIXELFORMAT_RGB888, SDL_TEXTUREACCESS_STREAMING, gnScreenWidth, gnScreenHeight);
-				if (texture == nullptr) {
-					ErrSdl();
-				}
-
-				if (SDL_RenderSetLogicalSize(renderer, gnScreenWidth, gnScreenHeight) <= -1) {
-					ErrSdl();
-				}
-
-				if (SDL_UpdateTexture(texture.get(), nullptr, surface->pixels, surface->pitch) <= -1) { //pitch is 2560
+				ReinitializeRenderer();
+				if (SDL_UpdateTexture(texture.get(), nullptr, surface->pixels, surface->pitch) <= -1) {
 					ErrSdl();
 				}
 			} else {

--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -310,7 +310,31 @@ void RenderPresent()
 #ifndef USE_SDL1
 	if (renderer != nullptr) {
 		if (SDL_UpdateTexture(texture.get(), nullptr, surface->pixels, surface->pitch) <= -1) { //pitch is 2560
-			ErrSdl();
+			// We should supposedly handle SDL_RENDER_DEVICE_RESET, but I tried and it doesn't arrive
+			if (string_view(SDL_GetError()) == "LockRect(): INVALIDCALL") {
+				texture.reset();
+				SDL_DestroyRenderer(renderer);
+
+				renderer = SDL_CreateRenderer(ghMainWnd, -1, SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_ACCELERATED);
+				if (renderer == nullptr) {
+					ErrSdl();
+				}
+
+				texture = SDLWrap::CreateTexture(renderer, SDL_PIXELFORMAT_RGB888, SDL_TEXTUREACCESS_STREAMING, gnScreenWidth, gnScreenHeight);
+				if (texture == nullptr) {
+					ErrSdl();
+				}
+
+				if (SDL_RenderSetLogicalSize(renderer, gnScreenWidth, gnScreenHeight) <= -1) {
+					ErrSdl();
+				}
+
+				if (SDL_UpdateTexture(texture.get(), nullptr, surface->pixels, surface->pitch) <= -1) { //pitch is 2560
+					ErrSdl();
+				}
+			} else {
+				ErrSdl();
+			}
 		}
 
 		// Clear buffer to avoid artifacts in case the window was resized

--- a/Source/miniwin/misc_msg.cpp
+++ b/Source/miniwin/misc_msg.cpp
@@ -612,6 +612,10 @@ bool FetchMessage_Real(tagMSG *lpMsg)
 		}
 
 		break;
+
+	case SDL_RENDER_DEVICE_RESET:
+		ReinitializeRenderer();
+		break;
 #endif
 	default:
 		return FalseAvail("unknown", e.type);

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -218,28 +218,7 @@ bool SpawnWindow(const char *lpWindowName)
 	refreshDelay = 1000000 / refreshRate;
 
 	if (sgOptions.Graphics.bUpscale) {
-#ifndef USE_SDL1
-		Uint32 rendererFlags = SDL_RENDERER_ACCELERATED;
-
-		if (sgOptions.Graphics.bVSync) {
-			rendererFlags |= SDL_RENDERER_PRESENTVSYNC;
-		}
-
-		renderer = SDL_CreateRenderer(ghMainWnd, -1, rendererFlags);
-		if (renderer == nullptr) {
-			ErrSdl();
-		}
-
-		texture = SDLWrap::CreateTexture(renderer, SDL_PIXELFORMAT_RGB888, SDL_TEXTUREACCESS_STREAMING, width, height);
-
-		if (sgOptions.Graphics.bIntegerScaling && SDL_RenderSetIntegerScale(renderer, SDL_TRUE) < 0) {
-			ErrSdl();
-		}
-
-		if (SDL_RenderSetLogicalSize(renderer, width, height) <= -1) {
-			ErrSdl();
-		}
-#endif
+		ReinitializeRenderer();
 	} else {
 #ifdef USE_SDL1
 		const SDL_VideoInfo &current = *SDL_GetVideoInfo();
@@ -252,6 +231,37 @@ bool SpawnWindow(const char *lpWindowName)
 	}
 
 	return ghMainWnd != nullptr;
+}
+
+void ReinitializeRenderer()
+{
+#ifndef USE_SDL1
+	Uint32 rendererFlags = SDL_RENDERER_ACCELERATED;
+
+	if (sgOptions.Graphics.bVSync) {
+		rendererFlags |= SDL_RENDERER_PRESENTVSYNC;
+	}
+
+	texture.reset();
+	if (renderer != nullptr) {
+		SDL_DestroyRenderer(renderer);
+	}
+
+	renderer = SDL_CreateRenderer(ghMainWnd, -1, rendererFlags);
+	if (renderer == nullptr) {
+		ErrSdl();
+	}
+
+	texture = SDLWrap::CreateTexture(renderer, SDL_PIXELFORMAT_RGB888, SDL_TEXTUREACCESS_STREAMING, gnScreenWidth, gnScreenHeight);
+
+	if (sgOptions.Graphics.bIntegerScaling && SDL_RenderSetIntegerScale(renderer, SDL_TRUE) < 0) {
+		ErrSdl();
+	}
+
+	if (SDL_RenderSetLogicalSize(renderer, gnScreenWidth, gnScreenHeight) <= -1) {
+		ErrSdl();
+	}
+#endif
 }
 
 SDL_Surface *GetOutputSurface()

--- a/Source/utils/display.h
+++ b/Source/utils/display.h
@@ -22,6 +22,8 @@ extern SDL_Renderer *renderer;
 extern SDLTextureUniquePtr texture;
 #endif
 
+void ReinitializeRenderer();
+
 extern SDLPaletteUniquePtr Palette;
 extern SDL_Surface *PalSurface;
 extern unsigned int pal_surface_palette_version;


### PR DESCRIPTION
If I close and reopen my laptop during the game, it crashes with

> SDL Error
> LockRect(): INVALIDCALL
> The error occurred at: ..\..\SourceX\dx.cpp line 264

I have absolutely no experience with SDL, but I've managed to put
together a workaround. Improvements are welcome.