### PR TITLE
CMake: Cleanup target platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,19 +74,15 @@ if(SWITCH)
   include(switch_defs)
 endif()
 
-if(RG350)
-  include(rg350_defs)
-endif()
-
-if (GKD350H)
-  include(gkd350h_defs)
-endif()
-
-if(RETROFW)
+set(TARGET_PLATFORM host CACHE STRING "Target platform")
+set_property(CACHE TARGET_PLATFORM PROPERTY STRINGS host retrofw rg350 gkd350h cpigamesh)
+if(TARGET_PLATFORM STREQUAL "retrofw")
   include(retrofw_defs)
-endif()
-
-if(CPIGAMESH)
+elseif(TARGET_PLATFORM STREQUAL "rg350")
+  include(rg350_defs)
+elseif(TARGET_PLATFORM STREQUAL "gkd350h")
+  include(gkd350h_defs)
+elseif(TARGET_PLATFORM STREQUAL "cpigamesh")
   include(cpigamesh_defs)
 endif()
 

--- a/Packaging/OpenDingux/build.sh
+++ b/Packaging/OpenDingux/build.sh
@@ -64,7 +64,7 @@ build() {
 	mkdir -p "$BUILD_DIR"
 	cd "$BUILD_DIR"
 	rm -f CMakeCache.txt
-	cmake .. -DBINARY_RELEASE=ON "-D${TARGET^^}=ON" \
+	cmake .. -DBINARY_RELEASE=ON "-DTARGET_PLATFORM=$TARGET" \
 		-DCMAKE_TOOLCHAIN_FILE="$BUILDROOT/output/host/usr/share/buildroot/toolchainfile.cmake"
 	make -j $(getconf _NPROCESSORS_ONLN)
 	cd -

--- a/Packaging/OpenDingux/targets.sh
+++ b/Packaging/OpenDingux/targets.sh
@@ -1,6 +1,7 @@
 declare -ra VALID_TARGETS=(
   retrofw
   rg350
+  gkd350h
 )
 
 usage_target() {

--- a/Packaging/cpi-gamesh/build.sh
+++ b/Packaging/cpi-gamesh/build.sh
@@ -51,8 +51,7 @@ build() {
 	cd ../../build
 	rm -f CMakeCache.txt
 
-	local -a defs=(-DCPIGAMESH=ON)
-	cmake .. ${defs[@]}
+	cmake .. -DTARGET_PLATFORM=cpigamesh
 	make -j $(getconf _NPROCESSORS_ONLN)
 	cd -
 }
@@ -62,20 +61,20 @@ install() {
 	cp /home/cpi/games/devilutionX/build/devilutionx /home/cpi/games/devilutionX/bin
 	git rev-parse HEAD > /home/cpi/games/devilutionX/bin/devilutionx.rev
 
-	if [ -z ${TARGET+x} ]; then 
+	if [ -z ${TARGET+x} ]; then
 		local target_dir="25_devilutionX"
-	else 
+	else
 		local target_dir=${TARGET#"/home/cpi/apps/Menu/"}
 	fi
 
 	local script_dir="/home/cpi/apps/Menu/$target_dir"
-	
+
 	local target_dir_base=`basename "$target_dir"`
 	local target_dir_dir=`dirname "$target_dir"`
 	local icon_name="${target_dir_dir}/${target_dir_base#*_}"
 
 	local icon_dir="/home/cpi/launcher/skin/default/Menu/GameShell/${icon_name}.png"
-	
+
 	echo $target_dir
 	echo $script_dir
 	echo $target_dir_base


### PR DESCRIPTION
Instead of having a bool option for each target platform,
make it a STRINGS property (basically an enum).