### PR TITLE
Fix name conflict with MESA

### DIFF
--- a/Source/sha.cpp
+++ b/Source/sha.cpp
@@ -23,6 +23,17 @@ std::uint32_t SHA1CircularShift(std::uint32_t bits, std::uint32_t word) {
 	}
 }
 
+void SHA1Init(SHA1Context *context)
+{
+	context->count[0] = 0;
+	context->count[1] = 0;
+	context->state[0] = 0x67452301;
+	context->state[1] = 0xEFCDAB89;
+	context->state[2] = 0x98BADCFE;
+	context->state[3] = 0x10325476;
+	context->state[4] = 0xC3D2E1F0;
+}
+
 } // namespace
 
 SHA1Context sgSHA1[3];
@@ -138,17 +149,6 @@ void SHA1ProcessMessageBlock(SHA1Context *context)
 void SHA1Reset(int n)
 {
 	SHA1Init(&sgSHA1[n]);
-}
-
-void SHA1Init(SHA1Context *context)
-{
-	context->count[0] = 0;
-	context->count[1] = 0;
-	context->state[0] = 0x67452301;
-	context->state[1] = 0xEFCDAB89;
-	context->state[2] = 0x98BADCFE;
-	context->state[3] = 0x10325476;
-	context->state[4] = 0xC3D2E1F0;
 }
 
 DEVILUTION_END_NAMESPACE

--- a/Source/sha.h
+++ b/Source/sha.h
@@ -12,6 +12,5 @@ void SHA1Calculate(int n, const char *data, char Message_Digest[SHA1HashSize]);
 void SHA1Input(SHA1Context *context, const char *message_array, int len);
 void SHA1ProcessMessageBlock(SHA1Context *context);
 void SHA1Reset(int n);
-void SHA1Init(SHA1Context *context);
 
 #endif /* __SHA_H__ */


### PR DESCRIPTION
MESA also has a function called SHA1Init:
https://github.com/grate-driver/mesa/blob/9b2ccd6a0e98b0c70f9dae275f4a2d0b43219709/src/util/sha1/sha1.h#L29-L33

The function here is only used in internally, so we fix the conflict
by simply moving it to an anonymous namespace.

Discovered by accidentally building the Switch build with the wrong flags:
https://app.circleci.com/pipelines/github/diasurgical/devilutionX/2143/workflows/d1b58503-2357-41b1-b94f-dcf4ceee4626/jobs/9709