### PR TITLE
Remove atexit() calls and implement a diablo_deinit() function instea…

### DIFF
--- a/Source/appfat.cpp
+++ b/Source/appfat.cpp
@@ -27,7 +27,7 @@ void app_fatal(const char *pszFmt, ...)
 
 	va_end(va);
 
-	exit(1);
+	diablo_quit(1);
 }
 
 void MsgBox(const char *pszFmt, va_list va)

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -81,7 +81,7 @@ char *spszMsgTbl[4] = {
 char *spszMsgHotKeyTbl[4] = { "F9", "F10", "F11", "F12" };
 
 /** To know if these things have been done when we get to the diablo_deinit() function */
-BOOL was_diablo_init = false;
+BOOL was_archives_init = false;
 BOOL was_ui_init = false;
 BOOL was_snd_init = false;
 BOOL was_sfx_init = false;
@@ -276,7 +276,7 @@ void diablo_init()
 
 	SFileEnableDirectAccess(TRUE);
 	init_archives();
-	was_diablo_init = true;
+	was_archives_init = true;
 
 	UiInitialize();
 #ifdef SPAWN
@@ -320,12 +320,12 @@ void diablo_deinit()
 		sound_cleanup();
 	if (was_ui_init)
 		UiDestroy();
-	if (was_diablo_init)
+	if (was_archives_init)
 		init_cleanup();
-	if (was_dx_init)
+	if (was_window_init)
 		dx_cleanup();  // Cleanup SDL surfaces stuff, so we have to do it before SDL_Quit().
-	if (was_ttf_init)
-		DeinitTtf();	
+	if (was_fonts_init)
+		FontsCleanup();	
 	if (SDL_WasInit(SDL_INIT_EVERYTHING & ~SDL_INIT_HAPTIC))
 		SDL_Quit();
 }

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -80,6 +80,12 @@ char *spszMsgTbl[4] = {
 /** INI files variable names for quick message keys */
 char *spszMsgHotKeyTbl[4] = { "F9", "F10", "F11", "F12" };
 
+/** To know if these things have been done when we get to the diablo_deinit() function */
+BOOL was_diablo_init = false;
+BOOL was_ui_init = false;
+BOOL was_snd_init = false;
+BOOL was_sfx_init = false;
+
 void FreeGameMem()
 {
 	music_stop();
@@ -270,13 +276,13 @@ void diablo_init()
 
 	SFileEnableDirectAccess(TRUE);
 	init_archives();
-	atexit(init_cleanup);
+	was_diablo_init = true;
 
 	UiInitialize();
 #ifdef SPAWN
 	UiSetSpawned(TRUE);
 #endif
-	atexit(UiDestroy);
+	was_ui_init = true;
 
 	ReadOnlyTest();
 
@@ -285,9 +291,10 @@ void diablo_init()
 	diablo_init_screen();
 
 	snd_init(NULL);
-	atexit(sound_cleanup);
+	was_snd_init = true;
+
 	sound_init();
-	atexit(effects_cleanup_sfx);
+	was_sfx_init = true;
 }
 
 void diablo_splash()
@@ -305,12 +312,37 @@ void diablo_splash()
 	UiTitleDialog();
 }
 
+void diablo_deinit()
+{
+	if (was_sfx_init)
+		effects_cleanup_sfx();
+	if (was_snd_init)
+		sound_cleanup();
+	if (was_ui_init)
+		UiDestroy();
+	if (was_diablo_init)
+		init_cleanup();
+	if (was_dx_init)
+		dx_cleanup();  // Cleanup SDL surfaces stuff, so we have to do it before SDL_Quit().
+	if (was_ttf_init)
+		DeinitTtf();	
+	if (SDL_WasInit(SDL_INIT_EVERYTHING & ~SDL_INIT_HAPTIC))
+		SDL_Quit();
+}
+
+void diablo_quit(int exitStatus)
+{
+	diablo_deinit();
+	exit(exitStatus);
+}
+
 int DiabloMain(int argc, char **argv)
 {
 	diablo_parse_flags(argc, argv);
 	diablo_init();
 	diablo_splash();
 	mainmenu_loop();
+	diablo_deinit();
 
 	return 0;
 }
@@ -341,7 +373,7 @@ static void print_help_and_exit()
 	printf("    %-20s %-30s\n", "-t <##>", "Set current quest level");
 #endif
 	printf("\nReport bugs at https://github.com/diasurgical/devilutionX/\n");
-	exit(0);
+	diablo_quit(0);
 }
 
 void diablo_parse_flags(int argc, char **argv)
@@ -351,7 +383,7 @@ void diablo_parse_flags(int argc, char **argv)
 			print_help_and_exit();
 		} else if (strcasecmp("--version", argv[i]) == 0) {
 			printf("%s v%s\n", PROJECT_NAME, PROJECT_VERSION);
-			exit(0);
+			diablo_quit(0);
 		} else if (strcasecmp("--data-dir", argv[i]) == 0) {
 			basePath = argv[++i];
 #ifdef _WIN32

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -26,6 +26,9 @@ extern int DebugMonsters[10];
 extern BOOLEAN cineflag;
 extern int force_redraw;
 extern BOOL visiondebug;
+/* These are defined in fonts.h */ 
+extern BOOL was_ttf_init;
+extern void DeinitTtf();
 /** unused */
 extern BOOL scrollflag;
 extern BOOL light4flag;
@@ -48,6 +51,7 @@ int DiabloMain(int argc, char **argv);
 void diablo_parse_flags(int argc, char **argv);
 void diablo_init_screen();
 void diablo_reload_process(HINSTANCE hInstance);
+void diablo_quit(int exitStatus);
 BOOL PressEscKey();
 LRESULT DisableInputWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 LRESULT GM_Game(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -27,8 +27,8 @@ extern BOOLEAN cineflag;
 extern int force_redraw;
 extern BOOL visiondebug;
 /* These are defined in fonts.h */ 
-extern BOOL was_ttf_init;
-extern void DeinitTtf();
+extern BOOL was_fonts_init;
+extern void FontsCleanup();
 /** unused */
 extern BOOL scrollflag;
 extern BOOL light4flag;

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -52,7 +52,7 @@ void init_create_window()
 	if (!SpawnWindow(PROJECT_NAME, SCREEN_WIDTH, SCREEN_HEIGHT))
 		app_fatal("Unable to create main window");
 	dx_init(NULL);
-	was_dx_init = true;
+	was_window_init = true;
 	gbActive = true;
 	gpBufStart = &gpBuffer[BUFFER_WIDTH * SCREEN_Y];
 	gpBufEnd = (BYTE *)(BUFFER_WIDTH * (SCREEN_HEIGHT + SCREEN_Y));

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -52,7 +52,7 @@ void init_create_window()
 	if (!SpawnWindow(PROJECT_NAME, SCREEN_WIDTH, SCREEN_HEIGHT))
 		app_fatal("Unable to create main window");
 	dx_init(NULL);
-	atexit(dx_cleanup);
+	was_dx_init = true;
 	gbActive = true;
 	gpBufStart = &gpBuffer[BUFFER_WIDTH * SCREEN_Y];
 	gpBufEnd = (BYTE *)(BUFFER_WIDTH * (SCREEN_HEIGHT + SCREEN_Y));
@@ -132,7 +132,7 @@ LRESULT MainWndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 	case WM_QUERYNEWPALETTE:
 		return 1;
 	case WM_QUERYENDSESSION:
-		exit(0);
+		diablo_quit(0);
 	}
 
 	return 0;

--- a/Source/init.h
+++ b/Source/init.h
@@ -27,8 +27,7 @@ LRESULT MainWndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
 void init_activate_window(HWND hWnd, BOOL bActive);
 WNDPROC SetWindowProc(WNDPROC NewProc);
 
-extern BOOL was_dx_init;     // defined in dx.cpp
-extern BOOL was_diablo_init; // defined in diablo.cpp
+extern BOOL was_window_init;   /** defined in dx.cpp */
 
 /* rdata */
 

--- a/Source/init.h
+++ b/Source/init.h
@@ -27,6 +27,9 @@ LRESULT MainWndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
 void init_activate_window(HWND hWnd, BOOL bActive);
 WNDPROC SetWindowProc(WNDPROC NewProc);
 
+extern BOOL was_dx_init;     // defined in dx.cpp
+extern BOOL was_diablo_init; // defined in diablo.cpp
+
 /* rdata */
 
 /* data */

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -36,7 +36,7 @@ void play_movie(char *pszMovie, BOOL user_can_close)
 				break;
 			case WM_QUIT:
 				SVidPlayEnd(video_stream);
-				exit(0);
+				diablo_quit(0);
 				break;
 			}
 		}

--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -328,7 +328,7 @@ void UiHandleEvents(SDL_Event *event)
 	}
 
 	if (event->type == SDL_QUIT)
-		exit(0);
+		diablo_quit(0);
 
 #ifndef USE_SDL1
 	if (event->type == SDL_JOYDEVICEADDED || event->type == SDL_JOYDEVICEREMOVED) {

--- a/SourceX/DiabloUI/fonts.cpp
+++ b/SourceX/DiabloUI/fonts.cpp
@@ -5,6 +5,8 @@ namespace dvl {
 TTF_Font *font = nullptr;
 BYTE *FontTables[4];
 Art ArtFonts[4][2];
+/* This is so we know ttf has been init when we get to the diablo_deinit() function */
+BOOL was_ttf_init = false;
 
 namespace {
 
@@ -53,9 +55,9 @@ void LoadTtfFont() {
 	if (!TTF_WasInit()) {
 		if (TTF_Init() == -1) {
 			SDL_Log("TTF_Init: %s", TTF_GetError());
-			exit(1);
+			diablo_quit(1);
 		}
-		atexit(TTF_Quit);
+		was_ttf_init = true;
 	}
 
 	font = TTF_OpenFont(TTF_FONT_PATH, 17);
@@ -72,6 +74,10 @@ void UnloadTtfFont() {
 	if (font && TTF_WasInit())
 		TTF_CloseFont(font);
 	font = nullptr;
+}
+
+void DeinitTtf() {
+	TTF_Quit();	
 }
 
 } // namespace dvl

--- a/SourceX/DiabloUI/fonts.cpp
+++ b/SourceX/DiabloUI/fonts.cpp
@@ -5,8 +5,8 @@ namespace dvl {
 TTF_Font *font = nullptr;
 BYTE *FontTables[4];
 Art ArtFonts[4][2];
-/* This is so we know ttf has been init when we get to the diablo_deinit() function */
-BOOL was_ttf_init = false;
+/** This is so we know ttf has been init when we get to the diablo_deinit() function */
+BOOL was_fonts_init = false;
 
 namespace {
 
@@ -57,7 +57,7 @@ void LoadTtfFont() {
 			SDL_Log("TTF_Init: %s", TTF_GetError());
 			diablo_quit(1);
 		}
-		was_ttf_init = true;
+		was_fonts_init = true;
 	}
 
 	font = TTF_OpenFont(TTF_FONT_PATH, 17);
@@ -76,7 +76,7 @@ void UnloadTtfFont() {
 	font = nullptr;
 }
 
-void DeinitTtf() {
+void FontsCleanup() {
 	TTF_Quit();	
 }
 

--- a/SourceX/DiabloUI/fonts.h
+++ b/SourceX/DiabloUI/fonts.h
@@ -33,6 +33,6 @@ void UnloadArtFonts();
 
 void LoadTtfFont();
 void UnloadTtfFont();
-void DeinitTtf();
+void FontsCleanup();
 
 } // namespace dvl

--- a/SourceX/DiabloUI/fonts.h
+++ b/SourceX/DiabloUI/fonts.h
@@ -33,5 +33,6 @@ void UnloadArtFonts();
 
 void LoadTtfFont();
 void UnloadTtfFont();
+void DeinitTtf();
 
 } // namespace dvl

--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -19,6 +19,8 @@
 
 namespace dvl {
 
+extern BOOL was_dx_init; // defined in dx.cpp
+
 extern SDL_Surface *renderer_texture_surface; // defined in dx.cpp
 
 #ifdef USE_SDL1
@@ -50,8 +52,6 @@ bool SpawnWindow(const char *lpWindowName, int nWidth, int nHeight)
 	if (SDL_Init(SDL_INIT_EVERYTHING & ~SDL_INIT_HAPTIC) <= -1) {
 		ErrSdl();
 	}
-
-	atexit(SDL_Quit);
 
 #ifdef USE_SDL1
 	SDL_EnableUNICODE(1);

--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -19,9 +19,9 @@
 
 namespace dvl {
 
-extern BOOL was_dx_init; // defined in dx.cpp
+extern BOOL was_window_init; /** defined in dx.cpp */
 
-extern SDL_Surface *renderer_texture_surface; // defined in dx.cpp
+extern SDL_Surface *renderer_texture_surface; /** defined in dx.cpp */
 
 #ifdef USE_SDL1
 void SetVideoMode(int width, int height, int bpp, std::uint32_t flags) {

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -32,6 +32,9 @@ SDL_Surface *renderer_texture_surface = nullptr;
 /** 8-bit surface wrapper around #gpBuffer */
 SDL_Surface *pal_surface;
 
+/** To know if surfaces have been initialized or not */
+BOOL was_dx_init = false;
+
 static void dx_create_back_buffer()
 {
 	pal_surface = SDL_CreateRGBSurfaceWithFormat(0, BUFFER_WIDTH, BUFFER_HEIGHT, 8, SDL_PIXELFORMAT_INDEX8);

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -33,7 +33,7 @@ SDL_Surface *renderer_texture_surface = nullptr;
 SDL_Surface *pal_surface;
 
 /** To know if surfaces have been initialized or not */
-BOOL was_dx_init = false;
+BOOL was_window_init = false;
 
 static void dx_create_back_buffer()
 {


### PR DESCRIPTION
…d that cleans up every subsystem if it has been init before.

Fixes https://github.com/diasurgical/devilutionX/issues/689 and possibly other atexit-related problems.