### PR TITLE
experimental scale2x hack

### DIFF
--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -172,7 +172,7 @@ void PaletteFadeIn(int fr)
 	for (i = 0; i < 256; i = (SDL_GetTicks() - tc) / 2.083) { // 32 frames @ 60hz
 		SetFadeLevel(i);
 		SDL_Rect SrcRect = { SCREEN_X, SCREEN_Y, SCREEN_WIDTH, SCREEN_HEIGHT };
-		BltFast(&SrcRect, NULL);
+		//BltFast(&SrcRect, NULL); // avoid scaling issue when using scale2x
 		RenderPresent();
 	}
 	SetFadeLevel(256);
@@ -189,7 +189,7 @@ void PaletteFadeOut(int fr)
 		for (i = 256; i > 0; i = 256 - (SDL_GetTicks() - tc) / 2.083) { // 32 frames @ 60hz
 			SetFadeLevel(i);
 			SDL_Rect SrcRect = { SCREEN_X, SCREEN_Y, SCREEN_WIDTH, SCREEN_HEIGHT };
-			BltFast(&SrcRect, NULL);
+			//BltFast(&SrcRect, NULL); // avoid scaling issue when using scale2x
 			RenderPresent();
 		}
 		SetFadeLevel(0);

--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -126,7 +126,7 @@ bool SpawnWindow(const char *lpWindowName, int nWidth, int nHeight)
 			ErrSdl();
 		}
 
-		if (SDL_RenderSetLogicalSize(renderer, 1280/*nWidth*/, 960/*nHeight*/) <= -1) {
+		if (SDL_RenderSetLogicalSize(renderer, 1280/*nWidth*/, 960/*nHeight*/) <= -1) { //inceased size for scale2x
 			ErrSdl();
 		}
 #endif

--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -121,12 +121,12 @@ bool SpawnWindow(const char *lpWindowName, int nWidth, int nHeight)
 			ErrSdl();
 		}
 
-		texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB888, SDL_TEXTUREACCESS_STREAMING, nWidth, nHeight);
+		texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB888, SDL_TEXTUREACCESS_STREAMING, 1280/*nWidth*/, 960/*nHeight*/); //inceased size for scale2x
 		if (texture == NULL) {
 			ErrSdl();
 		}
 
-		if (SDL_RenderSetLogicalSize(renderer, nWidth, nHeight) <= -1) {
+		if (SDL_RenderSetLogicalSize(renderer, 1280/*nWidth*/, 960/*nHeight*/) <= -1) {
 			ErrSdl();
 		}
 #endif

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -28,7 +28,7 @@ unsigned int pal_surface_palette_version = 0;
 
 /** 24-bit renderer texture surface */
 SDL_Surface *renderer_texture_surface = nullptr;
-
+SDL_Surface *scale2x_renderer_texture_surface = nullptr; // surface for scale2x
 /** 8-bit surface wrapper around #gpBuffer */
 SDL_Surface *pal_surface;
 
@@ -66,7 +66,8 @@ static void dx_create_primary_surface()
 		Uint32 format;
 		if (SDL_QueryTexture(texture, &format, nullptr, nullptr, nullptr) < 0)
 			ErrSdl();
-		renderer_texture_surface = SDL_CreateRGBSurfaceWithFormat(0, width, height, SDL_BITSPERPIXEL(format), format);
+		renderer_texture_surface = SDL_CreateRGBSurfaceWithFormat(0, 1280/*width*/, 960/*height*/, SDL_BITSPERPIXEL(format), format); // increase buffer size by 2x
+		scale2x_renderer_texture_surface = SDL_CreateRGBSurfaceWithFormat(0, 1280/*width*/, 960/*height*/, SDL_BITSPERPIXEL(format), format); // create surface for scale2x
 	}
 #endif
 	if (GetOutputSurface() == nullptr) {
@@ -143,6 +144,7 @@ void dx_cleanup()
 	pal_surface = nullptr;
 	SDL_FreePalette(palette);
 	SDL_FreeSurface(renderer_texture_surface);
+	SDL_FreeSurface(scale2x_renderer_texture_surface); //destroy surface for scale2x
 	SDL_DestroyTexture(texture);
 	SDL_DestroyRenderer(renderer);
 	SDL_DestroyWindow(ghMainWnd);

--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -786,11 +786,11 @@ void SVidPlayEnd(HANDLE video)
 #ifndef USE_SDL1
 	if (renderer) {
 		SDL_DestroyTexture(texture);
-		texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB888, SDL_TEXTUREACCESS_STREAMING, SCREEN_WIDTH, SCREEN_HEIGHT);
+		texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB888, SDL_TEXTUREACCESS_STREAMING, 1280/*SCREEN_WIDTH*/, 960/*SCREEN_HEIGHT*/); //increased size for scale2x
 		if (texture == NULL) {
 			ErrSdl();
 		}
-		if (renderer && SDL_RenderSetLogicalSize(renderer, SCREEN_WIDTH, SCREEN_HEIGHT) <= -1) {
+		if (renderer && SDL_RenderSetLogicalSize(renderer, 1280/*SCREEN_WIDTH*/, 960/*SCREEN_HEIGHT*/) <= -1) { //increased size for scale2x
 			ErrSdl();
 		}
 	}


### PR DESCRIPTION
Be careful. It is a quick hack and can cause crashes.
It crashes e.g. when upscale = 0 in diablo.ini.
This hack is just an example for visual improvement.
The main menu is not scaled.
Further improvements are welcome.