### PR TITLE
Fix issue with NPC/Quest text scrolling

### DIFF
--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -168,7 +168,7 @@ void DrawQText()
 		}
 	}
 
-	for (currTime = SDL_GetTicks(); sgLastScroll + scrolltexty < currTime; sgLastScroll += scrolltexty) {
+	for (currTime = SDL_GetTicks(); qtextSpd + scrolltexty < currTime; qtextSpd += scrolltexty) {
 		qtexty--;
 		if (qtexty <= 209) {
 			qtexty += 38;


### PR DESCRIPTION
Scrolling texts were abruptly closing while the audio played right. This patch fixes a simple error on the scrolling loop so the correct variable is used to make the scrolling happens