### PR TITLE
Fix extern "C" and namespace hell

### DIFF
--- a/Source/all.h
+++ b/Source/all.h
@@ -18,9 +18,6 @@
 
 #include "../types.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 #include "appfat.h"
 #include "automap.h"
 #include "capture.h"
@@ -91,10 +88,5 @@ extern "C" {
 #include "trigs.h"
 #include "wave.h"
 #include "render.h" // linked last, likely .s/.asm
-#ifdef __cplusplus
-}
-#endif
-
-DEVILUTION_END_NAMESPACE
 
 #endif /* __ALL_H__ */

--- a/Source/appfat.h
+++ b/Source/appfat.h
@@ -6,6 +6,8 @@
 #ifndef __APPFAT_H__
 #define __APPFAT_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern char sz_error_buf[256];
 extern BOOL terminating;
 extern int cleanup_thread_id;
@@ -29,5 +31,7 @@ void FileErrDlg(const char *error);
 void DiskFreeDlg(char *error);
 void InsertCDDlg(const char *fileName);
 void DirErrorDlg(char *error);
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __APPFAT_H__ */

--- a/Source/appfat.h
+++ b/Source/appfat.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern char sz_error_buf[256];
 extern BOOL terminating;
 extern int cleanup_thread_id;
@@ -31,6 +35,10 @@ void FileErrDlg(const char *error);
 void DiskFreeDlg(char *error);
 void InsertCDDlg(const char *fileName);
 void DirErrorDlg(char *error);
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern WORD automaptype[512];
 extern BOOL automapflag;
 extern char AmShiftTab[31];
@@ -37,6 +41,10 @@ WORD GetAutomapType(int x, int y, BOOL view);
 void DrawAutomapText();
 void SetAutomapView(int x, int y);
 void AutomapZoomReset();
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -6,6 +6,8 @@
 #ifndef __AUTOMAP_H__
 #define __AUTOMAP_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern WORD automaptype[512];
 extern BOOL automapflag;
 extern char AmShiftTab[31];
@@ -35,5 +37,7 @@ WORD GetAutomapType(int x, int y, BOOL view);
 void DrawAutomapText();
 void SetAutomapView(int x, int y);
 void AutomapZoomReset();
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __AUTOMAP_H__ */

--- a/Source/capture.h
+++ b/Source/capture.h
@@ -8,7 +8,15 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void CaptureScreen();
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/capture.h
+++ b/Source/capture.h
@@ -6,6 +6,10 @@
 #ifndef __CAPTURE_H__
 #define __CAPTURE_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 void CaptureScreen();
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __CAPTURE_H__ */

--- a/Source/codec.h
+++ b/Source/codec.h
@@ -8,10 +8,18 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int codec_decode(BYTE *pbSrcDst, DWORD size, char *pszPassword);
 void codec_init_key(int unused, char *pszPassword);
 DWORD codec_get_encoded_len(DWORD dwSrcBytes);
 void codec_encode(BYTE *pbSrcDst, DWORD size, int size_64, char *pszPassword);
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/codec.h
+++ b/Source/codec.h
@@ -6,9 +6,13 @@
 #ifndef __CODEC_H__
 #define __CODEC_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 int codec_decode(BYTE *pbSrcDst, DWORD size, char *pszPassword);
 void codec_init_key(int unused, char *pszPassword);
 DWORD codec_get_encoded_len(DWORD dwSrcBytes);
 void codec_encode(BYTE *pbSrcDst, DWORD size, int size_64, char *pszPassword);
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __CODEC_H__ */

--- a/Source/control.h
+++ b/Source/control.h
@@ -6,6 +6,8 @@
 #ifndef __CONTROL_H__
 #define __CONTROL_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern BYTE *pDurIcons;
 extern BYTE *pChrButtons;
 extern BOOL drawhpflag;
@@ -136,5 +138,7 @@ extern char *PanBtnHotKey[8];
 extern char *PanBtnStr[8];
 extern RECT32 ChrBtnsRect[4];
 extern int SpellPages[6][7];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __CONTROL_H__ */

--- a/Source/control.h
+++ b/Source/control.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern BYTE *pDurIcons;
 extern BYTE *pChrButtons;
 extern BOOL drawhpflag;
@@ -138,6 +142,10 @@ extern char *PanBtnHotKey[8];
 extern char *PanBtnStr[8];
 extern RECT32 ChrBtnsRect[4];
 extern int SpellPages[6][7];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int cursW;
 extern int cursH;
 extern int pcursmonst;
@@ -38,6 +42,10 @@ void CheckCursMove();
 /* rdata */
 extern const int InvItemWidth[];
 extern const int InvItemHeight[];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -6,6 +6,8 @@
 #ifndef __CURSOR_H__
 #define __CURSOR_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int cursW;
 extern int cursH;
 extern int pcursmonst;
@@ -36,5 +38,7 @@ void CheckCursMove();
 /* rdata */
 extern const int InvItemWidth[];
 extern const int InvItemHeight[];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __CURSOR_H__ */

--- a/Source/dead.h
+++ b/Source/dead.h
@@ -6,6 +6,8 @@
 #ifndef __DEAD_H__
 #define __DEAD_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int spurtndx;
 extern DeadStruct dead[MAXDEAD];
 extern int stonendx;
@@ -13,5 +15,7 @@ extern int stonendx;
 void InitDead();
 void AddDead(int dx, int dy, char dv, int ddir);
 void SetDead();
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __DEAD_H__ */

--- a/Source/dead.h
+++ b/Source/dead.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int spurtndx;
 extern DeadStruct dead[MAXDEAD];
 extern int stonendx;
@@ -15,6 +19,10 @@ extern int stonendx;
 void InitDead();
 void AddDead(int dx, int dy, char dv, int ddir);
 void SetDead();
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -6,6 +6,8 @@
 #ifndef __DEBUG_H__
 #define __DEBUG_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern BYTE *pSquareCel;
 extern char dMonsDbg[NUMLEVELS][MAXDUNX][MAXDUNY];
 extern char dFlagDbg[NUMLEVELS][MAXDUNX][MAXDUNY];
@@ -26,5 +28,7 @@ void PrintDebugMonster(int m);
 void GetDebugMonster();
 void NextDebugMonster();
 #endif
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __DEBUG_H__ */

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern BYTE *pSquareCel;
 extern char dMonsDbg[NUMLEVELS][MAXDUNX][MAXDUNY];
 extern char dFlagDbg[NUMLEVELS][MAXDUNX][MAXDUNY];
@@ -27,6 +31,10 @@ void PrintDebugQuest();
 void PrintDebugMonster(int m);
 void GetDebugMonster();
 void NextDebugMonster();
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 DEVILUTION_END_NAMESPACE

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern SDL_Window *ghMainWnd;
 extern DWORD glSeedTbl[NUMLEVELS];
 extern int gnLevelTypeTbl[NUMLEVELS];
@@ -104,6 +108,10 @@ extern int framestart;
 extern BOOL FriendlyMode;
 extern char *spszMsgTbl[4];
 extern char *spszMsgHotKeyTbl[4];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -6,6 +6,8 @@
 #ifndef __DIABLO_H__
 #define __DIABLO_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern SDL_Window *ghMainWnd;
 extern DWORD glSeedTbl[NUMLEVELS];
 extern int gnLevelTypeTbl[NUMLEVELS];
@@ -102,5 +104,7 @@ extern int framestart;
 extern BOOL FriendlyMode;
 extern char *spszMsgTbl[4];
 extern char *spszMsgHotKeyTbl[4];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __DIABLO_H__ */

--- a/Source/doom.h
+++ b/Source/doom.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int doom_quest_time;
 extern int doom_stars_drawn;
 extern BYTE *pDoomCel;
@@ -25,6 +29,10 @@ void doom_load_graphics();
 void doom_init();
 void doom_close();
 void doom_draw();
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/doom.h
+++ b/Source/doom.h
@@ -6,6 +6,8 @@
 #ifndef __DOOM_H__
 #define __DOOM_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int doom_quest_time;
 extern int doom_stars_drawn;
 extern BYTE *pDoomCel;
@@ -23,5 +25,7 @@ void doom_load_graphics();
 void doom_init();
 void doom_close();
 void doom_draw();
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __DOOM_H__ */

--- a/Source/drlg_l1.h
+++ b/Source/drlg_l1.h
@@ -6,6 +6,8 @@
 #ifndef __DRLG_L1_H__
 #define __DRLG_L1_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern BYTE L5dungeon[80][80];
 extern BYTE L5dflags[DMAXX][DMAXY];
 extern BOOL L5setloadflag;
@@ -37,5 +39,7 @@ extern const BYTE PWATERIN[];
 
 /* data */
 extern BYTE L5ConvTbl[16];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __DRLG_L1_H__ */

--- a/Source/drlg_l1.h
+++ b/Source/drlg_l1.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern BYTE L5dungeon[80][80];
 extern BYTE L5dflags[DMAXX][DMAXY];
 extern BOOL L5setloadflag;
@@ -39,6 +43,10 @@ extern const BYTE PWATERIN[];
 
 /* data */
 extern BYTE L5ConvTbl[16];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/drlg_l2.h
+++ b/Source/drlg_l2.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int nSx1;
 extern int nSy1;
 extern int nSx2;
@@ -146,6 +150,10 @@ extern BYTE CTRDOOR6[];
 extern BYTE CTRDOOR7[];
 extern BYTE CTRDOOR8[];
 extern int Patterns[100][10];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/drlg_l2.h
+++ b/Source/drlg_l2.h
@@ -6,6 +6,8 @@
 #ifndef __DRLG_L2_H__
 #define __DRLG_L2_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int nSx1;
 extern int nSy1;
 extern int nSx2;
@@ -144,5 +146,7 @@ extern BYTE CTRDOOR6[];
 extern BYTE CTRDOOR7[];
 extern BYTE CTRDOOR8[];
 extern int Patterns[100][10];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __DRLG_L2_H__ */

--- a/Source/drlg_l3.h
+++ b/Source/drlg_l3.h
@@ -6,6 +6,8 @@
 #ifndef __DRLG_L3_H__
 #define __DRLG_L3_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern BOOLEAN lavapool;
 extern int abyssx;
 extern int lockoutcnt;
@@ -60,5 +62,7 @@ extern const BYTE L3XTRA3[4];
 extern const BYTE L3XTRA4[4];
 extern const BYTE L3XTRA5[4];
 extern const BYTE L3ANVIL[244];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __DRLG_L3_H__ */

--- a/Source/drlg_l3.h
+++ b/Source/drlg_l3.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern BOOLEAN lavapool;
 extern int abyssx;
 extern int lockoutcnt;
@@ -62,6 +66,10 @@ extern const BYTE L3XTRA3[4];
 extern const BYTE L3XTRA4[4];
 extern const BYTE L3XTRA5[4];
 extern const BYTE L3ANVIL[244];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/drlg_l4.h
+++ b/Source/drlg_l4.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int diabquad1x;
 extern int diabquad1y;
 extern int diabquad2x;
@@ -47,6 +51,10 @@ extern const BYTE L4DSTAIRS[52];
 extern const BYTE L4PENTA[52];
 extern const BYTE L4PENTA2[52];
 extern const BYTE L4BTYPES[140];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/drlg_l4.h
+++ b/Source/drlg_l4.h
@@ -6,6 +6,8 @@
 #ifndef __DRLG_L4_H__
 #define __DRLG_L4_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int diabquad1x;
 extern int diabquad1y;
 extern int diabquad2x;
@@ -45,5 +47,7 @@ extern const BYTE L4DSTAIRS[52];
 extern const BYTE L4PENTA[52];
 extern const BYTE L4PENTA2[52];
 extern const BYTE L4BTYPES[140];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __DRLG_L4_H__ */

--- a/Source/dthread.h
+++ b/Source/dthread.h
@@ -6,6 +6,8 @@
 #ifndef __DTHREAD_H__
 #define __DTHREAD_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern SDL_threadID glpDThreadId;
 extern BOOLEAN dthread_running;
 
@@ -16,5 +18,6 @@ unsigned int dthread_handler(void *data);
 void dthread_cleanup();
 
 /* data */
+DEVILUTION_END_NAMESPACE
 
 #endif /* __DTHREAD_H__ */

--- a/Source/dthread.h
+++ b/Source/dthread.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern SDL_threadID glpDThreadId;
 extern BOOLEAN dthread_running;
 
@@ -18,6 +22,10 @@ unsigned int dthread_handler(void *data);
 void dthread_cleanup();
 
 /* data */
+#ifdef __cplusplus
+}
+#endif
+
 DEVILUTION_END_NAMESPACE
 
 #endif /* __DTHREAD_H__ */

--- a/Source/dx.h
+++ b/Source/dx.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern BYTE *gpBuffer;
 extern char gbBackBuf;
 extern char gbEmulate;
@@ -27,6 +31,10 @@ void PaletteGetEntries(DWORD dwNumEntries, SDL_Color *lpEntries);
 void PaletteSetEntries(DWORD dwCount, SDL_Color *lpEntries);
 
 /* data */
+#ifdef __cplusplus
+}
+#endif
+
 DEVILUTION_END_NAMESPACE
 
 #endif /* __DX_H__ */

--- a/Source/dx.h
+++ b/Source/dx.h
@@ -6,6 +6,8 @@
 #ifndef __DX_H__
 #define __DX_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern BYTE *gpBuffer;
 extern char gbBackBuf;
 extern char gbEmulate;
@@ -25,5 +27,6 @@ void PaletteGetEntries(DWORD dwNumEntries, SDL_Color *lpEntries);
 void PaletteSetEntries(DWORD dwCount, SDL_Color *lpEntries);
 
 /* data */
+DEVILUTION_END_NAMESPACE
 
 #endif /* __DX_H__ */

--- a/Source/effects.h
+++ b/Source/effects.h
@@ -6,6 +6,8 @@
 #ifndef __EFFECTS_H__
 #define __EFFECTS_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int sfxdelay;
 extern int sfxdnum;
 extern HANDLE sghStream;
@@ -37,5 +39,6 @@ void effects_play_sound(char *snd_file);
 extern const char MonstSndChar[];
 
 /* data */
+DEVILUTION_END_NAMESPACE
 
 #endif /* __EFFECTS_H__ */

--- a/Source/effects.h
+++ b/Source/effects.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int sfxdelay;
 extern int sfxdnum;
 extern HANDLE sghStream;
@@ -39,6 +43,10 @@ void effects_play_sound(char *snd_file);
 extern const char MonstSndChar[];
 
 /* data */
+#ifdef __cplusplus
+}
+#endif
+
 DEVILUTION_END_NAMESPACE
 
 #endif /* __EFFECTS_H__ */

--- a/Source/encrypt.h
+++ b/Source/encrypt.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern DWORD hashtable[5][256];
 
 void Decrypt(DWORD *castBlock, DWORD size, DWORD key);
@@ -18,6 +22,10 @@ int PkwareCompress(BYTE *srcData, int size);
 unsigned int PkwareBufferRead(char *buf, unsigned int *size, void *param);
 void PkwareBufferWrite(char *buf, unsigned int *size, void *param);
 void PkwareDecompress(BYTE *pbInBuff, int recv_size, int dwMaxBytes);
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/encrypt.h
+++ b/Source/encrypt.h
@@ -6,6 +6,8 @@
 #ifndef __ENCRYPT_H__
 #define __ENCRYPT_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern DWORD hashtable[5][256];
 
 void Decrypt(DWORD *castBlock, DWORD size, DWORD key);
@@ -16,5 +18,7 @@ int PkwareCompress(BYTE *srcData, int size);
 unsigned int PkwareBufferRead(char *buf, unsigned int *size, void *param);
 void PkwareBufferWrite(char *buf, unsigned int *size, void *param);
 void PkwareDecompress(BYTE *pbInBuff, int recv_size, int dwMaxBytes);
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __ENCRYPT_H__ */

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -15,6 +15,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //offset 0
 //pCelBuff->pFrameTable[0]
 
@@ -99,6 +103,10 @@ void PlayInGameMovie(char *pszMovie);
 
 extern const int RndInc;
 extern const int RndMult;
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -13,6 +13,8 @@
 #ifndef __ENGINE_H__
 #define __ENGINE_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 //offset 0
 //pCelBuff->pFrameTable[0]
 
@@ -97,5 +99,7 @@ void PlayInGameMovie(char *pszMovie);
 
 extern const int RndInc;
 extern const int RndMult;
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __ENGINE_H__ */

--- a/Source/error.h
+++ b/Source/error.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern char msgtable[MAX_SEND_STR_LEN];
 extern DWORD msgdelay;
 extern char msgflag;
@@ -19,6 +23,10 @@ void DrawDiabloMsg();
 
 /* data */
 extern char *MsgStrings[];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/error.h
+++ b/Source/error.h
@@ -6,6 +6,8 @@
 #ifndef __ERROR_H__
 #define __ERROR_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern char msgtable[MAX_SEND_STR_LEN];
 extern DWORD msgdelay;
 extern char msgflag;
@@ -17,5 +19,7 @@ void DrawDiabloMsg();
 
 /* data */
 extern char *MsgStrings[];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __ERROR_H__ */

--- a/Source/gamemenu.h
+++ b/Source/gamemenu.h
@@ -6,6 +6,8 @@
 #ifndef __GAMEMENU_H__
 #define __GAMEMENU_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 void gamemenu_on();
 void gamemenu_update_single(TMenuItem *pMenuItems);
 void gamemenu_update_multi(TMenuItem *pMenuItems);
@@ -34,5 +36,7 @@ void gamemenu_color_cycling(BOOL bActivate);
 extern char *music_toggle_names[];
 extern char *sound_toggle_names[];
 extern char *color_cycling_toggle_names[];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __GAMEMENU_H__ */

--- a/Source/gamemenu.h
+++ b/Source/gamemenu.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void gamemenu_on();
 void gamemenu_update_single(TMenuItem *pMenuItems);
 void gamemenu_update_multi(TMenuItem *pMenuItems);
@@ -36,6 +40,10 @@ void gamemenu_color_cycling(BOOL bActivate);
 extern char *music_toggle_names[];
 extern char *sound_toggle_names[];
 extern char *color_cycling_toggle_names[];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -6,6 +6,8 @@
 #ifndef __GENDUNG_H__
 #define __GENDUNG_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern BYTE dungeon[DMAXX][DMAXY];
 extern BYTE pdungeon[DMAXX][DMAXY];
 extern char dflags[DMAXX][DMAXY];
@@ -88,5 +90,7 @@ void DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int freq, int rnd
 void DRLG_HoldThemeRooms();
 BOOL SkipThemeRoom(int x, int y);
 void InitLevels();
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __GENDUNG_H__ */

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern BYTE dungeon[DMAXX][DMAXY];
 extern BYTE pdungeon[DMAXX][DMAXY];
 extern char dflags[DMAXX][DMAXY];
@@ -90,6 +94,10 @@ void DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int freq, int rnd
 void DRLG_HoldThemeRooms();
 BOOL SkipThemeRoom(int x, int y);
 void InitLevels();
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/gmenu.h
+++ b/Source/gmenu.h
@@ -6,6 +6,8 @@
 #ifndef __GMENU_H__
 #define __GMENU_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern BYTE *optbar_cel;
 extern BOOLEAN mouseNavigation;
 extern BYTE *PentSpin_cel;
@@ -42,5 +44,7 @@ void gmenu_slider_steps(TMenuItem *pItem, int dwTicks);
 
 extern const BYTE lfontframe[];
 extern const BYTE lfontkern[];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __GMENU_H__ */

--- a/Source/gmenu.h
+++ b/Source/gmenu.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern BYTE *optbar_cel;
 extern BOOLEAN mouseNavigation;
 extern BYTE *PentSpin_cel;
@@ -44,6 +48,10 @@ void gmenu_slider_steps(TMenuItem *pItem, int dwTicks);
 
 extern const BYTE lfontframe[];
 extern const BYTE lfontkern[];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/help.h
+++ b/Source/help.h
@@ -6,6 +6,8 @@
 #ifndef __HELP_H__
 #define __HELP_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int help_select_line;
 extern int dword_634494;
 extern BOOL helpflag;
@@ -21,5 +23,7 @@ void HelpScrollDown();
 
 /* rdata */
 extern const char gszHelpText[];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __HELP_H__ */

--- a/Source/help.h
+++ b/Source/help.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int help_select_line;
 extern int dword_634494;
 extern BOOL helpflag;
@@ -23,6 +27,10 @@ void HelpScrollDown();
 
 /* rdata */
 extern const char gszHelpText[];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/init.h
+++ b/Source/init.h
@@ -6,6 +6,8 @@
 #ifndef __INIT_H__
 #define __INIT_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern _SNETVERSIONDATA fileinfo;
 extern int gbActive;
 extern char diablo_exe_path[MAX_PATH];
@@ -35,5 +37,7 @@ extern BOOL was_window_init;   /** defined in dx.cpp */
 
 extern char gszVersionNumber[MAX_PATH];
 extern char gszProductName[MAX_PATH];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __INIT_H__ */

--- a/Source/init.h
+++ b/Source/init.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern _SNETVERSIONDATA fileinfo;
 extern int gbActive;
 extern char diablo_exe_path[MAX_PATH];
@@ -37,6 +41,10 @@ extern BOOL was_window_init;   /** defined in dx.cpp */
 
 extern char gszVersionNumber[MAX_PATH];
 extern char gszProductName[MAX_PATH];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/interfac.h
+++ b/Source/interfac.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int progress_id;
 
 void interface_msg_pump();
@@ -22,6 +26,10 @@ void InitCutscene(unsigned int uMsg);
 
 extern const BYTE BarColor[3];
 extern const int BarPos[3][2];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/interfac.h
+++ b/Source/interfac.h
@@ -6,6 +6,8 @@
 #ifndef __INTERFAC_H__
 #define __INTERFAC_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int progress_id;
 
 void interface_msg_pump();
@@ -20,5 +22,7 @@ void InitCutscene(unsigned int uMsg);
 
 extern const BYTE BarColor[3];
 extern const int BarPos[3][2];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __INTERFAC_H__ */

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern BOOL invflag;
 extern BOOL drawsbarflag;
 extern const InvXY InvRect[73];
@@ -56,6 +60,10 @@ BOOL DropItemBeforeTrig();
 /* data */
 
 extern int AP2x2Tbl[10];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -6,6 +6,8 @@
 #ifndef __INV_H__
 #define __INV_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern BOOL invflag;
 extern BOOL drawsbarflag;
 extern const InvXY InvRect[73];
@@ -54,5 +56,7 @@ BOOL DropItemBeforeTrig();
 /* data */
 
 extern int AP2x2Tbl[10];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __INV_H__ */

--- a/Source/itemdat.h
+++ b/Source/itemdat.h
@@ -8,10 +8,18 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern ItemDataStruct AllItemsList[];
 extern const PLStruct PL_Prefix[];
 extern const PLStruct PL_Suffix[];
 extern const UItemStruct UniqueItemList[];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/itemdat.h
+++ b/Source/itemdat.h
@@ -6,9 +6,13 @@
 #ifndef __ITEMDAT_H__
 #define __ITEMDAT_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern ItemDataStruct AllItemsList[];
 extern const PLStruct PL_Prefix[];
 extern const PLStruct PL_Suffix[];
 extern const UItemStruct UniqueItemList[];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __ITEMDAT_H__ */

--- a/Source/items.h
+++ b/Source/items.h
@@ -6,6 +6,8 @@
 #ifndef __ITEMS_H__
 #define __ITEMS_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int itemactive[MAXITEMS];
 extern BOOL uitemflag;
 extern int itemavail[MAXITEMS];
@@ -139,5 +141,7 @@ extern int ItemDropSnds[];
 extern int ItemInvSnds[];
 extern int idoppely;
 extern int premiumlvladd[6];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __ITEMS_H__ */

--- a/Source/items.h
+++ b/Source/items.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int itemactive[MAXITEMS];
 extern BOOL uitemflag;
 extern int itemavail[MAXITEMS];
@@ -141,6 +145,10 @@ extern int ItemDropSnds[];
 extern int ItemInvSnds[];
 extern int idoppely;
 extern int premiumlvladd[6];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern LightListStruct VisionList[MAXVISION];
 extern BYTE lightactive[MAXLIGHTS];
 extern LightListStruct LightList[MAXLIGHTS];
@@ -57,6 +61,10 @@ extern char *pCrawlTable[19];
 extern BYTE vCrawlTable[23][30];
 extern BYTE byte_49463C[18][18];
 extern BYTE RadiusAdj[23];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -6,6 +6,8 @@
 #ifndef __LIGHTING_H__
 #define __LIGHTING_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern LightListStruct VisionList[MAXVISION];
 extern BYTE lightactive[MAXLIGHTS];
 extern LightListStruct LightList[MAXLIGHTS];
@@ -55,5 +57,7 @@ extern char *pCrawlTable[19];
 extern BYTE vCrawlTable[23][30];
 extern BYTE byte_49463C[18][18];
 extern BYTE RadiusAdj[23];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __LIGHTING_H__ */

--- a/Source/loadsave.h
+++ b/Source/loadsave.h
@@ -6,6 +6,8 @@
 #ifndef __LOADSAVE_H__
 #define __LOADSAVE_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern BYTE *tbuff;
 
 void LoadGame(BOOL firstflag);
@@ -44,5 +46,7 @@ void SaveVision(int i);
 void SavePortal(int i);
 void SaveLevel();
 void LoadLevel();
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __LOADSAVE_H__ */

--- a/Source/loadsave.h
+++ b/Source/loadsave.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern BYTE *tbuff;
 
 void LoadGame(BOOL firstflag);
@@ -46,6 +50,10 @@ void SaveVision(int i);
 void SavePortal(int i);
 void SaveLevel();
 void LoadLevel();
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/mainmenu.h
+++ b/Source/mainmenu.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern char gszHero[16];
 
 void mainmenu_refresh_music();
@@ -32,6 +36,10 @@ void mainmenu_play_intro();
 /* data */
 
 extern int menu_music_track_id;
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/mainmenu.h
+++ b/Source/mainmenu.h
@@ -6,6 +6,8 @@
 #ifndef __MAINMENU_H__
 #define __MAINMENU_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern char gszHero[16];
 
 void mainmenu_refresh_music();
@@ -30,5 +32,7 @@ void mainmenu_play_intro();
 /* data */
 
 extern int menu_music_track_id;
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __MAINMENU_H__ */

--- a/Source/minitext.h
+++ b/Source/minitext.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int qtexty;
 extern char *qtextptr;
 extern BOOLEAN qtextflag;
@@ -29,6 +33,10 @@ extern const BYTE mfontkern[56];
 /* data */
 
 extern int qscroll_spd_tbl[9];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/minitext.h
+++ b/Source/minitext.h
@@ -6,6 +6,8 @@
 #ifndef __MINITEXT_H__
 #define __MINITEXT_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int qtexty;
 extern char *qtextptr;
 extern BOOLEAN qtextflag;
@@ -27,5 +29,7 @@ extern const BYTE mfontkern[56];
 /* data */
 
 extern int qscroll_spd_tbl[9];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __MINITEXT_H__ */

--- a/Source/misdat.h
+++ b/Source/misdat.h
@@ -8,8 +8,16 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern MissileData missiledata[];
 extern MisFileData misfiledata[];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/misdat.h
+++ b/Source/misdat.h
@@ -6,7 +6,11 @@
 #ifndef __MISDAT_H__
 #define __MISDAT_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern MissileData missiledata[];
 extern MisFileData misfiledata[];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __MISDAT_H__ */

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int missileactive[MAXMISSILES];
 extern int missileavail[MAXMISSILES];
 extern MissileStruct missile[MAXMISSILES];
@@ -156,6 +160,10 @@ void ClearMissileSpot(int mi);
 
 extern int XDirAdd[8];
 extern int YDirAdd[8];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -6,6 +6,8 @@
 #ifndef __MISSILES_H__
 #define __MISSILES_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int missileactive[MAXMISSILES];
 extern int missileavail[MAXMISSILES];
 extern MissileStruct missile[MAXMISSILES];
@@ -154,5 +156,7 @@ void ClearMissileSpot(int mi);
 
 extern int XDirAdd[8];
 extern int YDirAdd[8];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __MISSILES_H__ */

--- a/Source/monstdat.h
+++ b/Source/monstdat.h
@@ -6,9 +6,13 @@
 #ifndef __MONSTDAT_H__
 #define __MONSTDAT_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern MonsterData monsterdata[];
 extern BYTE MonstConvTbl[];
 extern BYTE MonstAvailTbl[];
 extern UniqMonstStruct UniqMonst[];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __MONSTDAT_H__ */

--- a/Source/monstdat.h
+++ b/Source/monstdat.h
@@ -8,10 +8,18 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern MonsterData monsterdata[];
 extern BYTE MonstConvTbl[];
 extern BYTE MonstAvailTbl[];
 extern UniqMonstStruct UniqMonst[];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -6,6 +6,8 @@
 #ifndef __MONSTER_H__
 #define __MONSTER_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int MissileFileFlag;
 extern int monstkills[MAXMONSTERS];
 extern int monstactive[MAXMONSTERS];
@@ -188,5 +190,7 @@ extern int rnd60[4];
 //
 
 extern void (*AiProc[])(int i);
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __MONSTER_H__ */

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int MissileFileFlag;
 extern int monstkills[MAXMONSTERS];
 extern int monstactive[MAXMONSTERS];
@@ -190,6 +194,10 @@ extern int rnd60[4];
 //
 
 extern void (*AiProc[])(int i);
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/movie.h
+++ b/Source/movie.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern BYTE movie_playing;
 extern BOOL loop_movie;
 
@@ -15,6 +19,10 @@ void play_movie(char *pszMovie, BOOL user_can_close);
 LRESULT MovieWndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
 
 /* rdata */
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/movie.h
+++ b/Source/movie.h
@@ -6,6 +6,8 @@
 #ifndef __MOVIE_H__
 #define __MOVIE_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern BYTE movie_playing;
 extern BOOL loop_movie;
 
@@ -13,5 +15,7 @@ void play_movie(char *pszMovie, BOOL user_can_close);
 LRESULT MovieWndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
 
 /* rdata */
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __MOVIE_H__ */

--- a/Source/mpqapi.h
+++ b/Source/mpqapi.h
@@ -7,6 +7,9 @@
 #define __MPQAPI_H__
 
 #include <stdint.h>
+
+DEVILUTION_BEGIN_NAMESPACE
+
 extern BYTE mpq_buf[4096];
 extern BOOL save_archive_modified;
 extern BOOLEAN save_archive_open;
@@ -28,5 +31,6 @@ BOOL mpqapi_flush_and_close(const char *pszArchive, BOOL bFree, DWORD dwChar);
 /* rdata */
 
 /* data */
+DEVILUTION_END_NAMESPACE
 
 #endif /* __MPQAPI_H__ */

--- a/Source/mpqapi.h
+++ b/Source/mpqapi.h
@@ -10,6 +10,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern BYTE mpq_buf[4096];
 extern BOOL save_archive_modified;
 extern BOOLEAN save_archive_open;
@@ -31,6 +35,10 @@ BOOL mpqapi_flush_and_close(const char *pszArchive, BOOL bFree, DWORD dwChar);
 /* rdata */
 
 /* data */
+#ifdef __cplusplus
+}
+#endif
+
 DEVILUTION_END_NAMESPACE
 
 #endif /* __MPQAPI_H__ */

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern BOOL deltaload;
 extern BYTE gbBufferMsgs;
 extern int dwRecCount;
@@ -147,6 +151,10 @@ DWORD On_DEBUG(TCmd *pCmd, int pnum);
 DWORD On_NOVA(TCmd *pCmd, int pnum);
 DWORD On_SETSHIELD(TCmd *pCmd, int pnum);
 DWORD On_REMSHIELD(TCmd *pCmd, int pnum);
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -6,6 +6,8 @@
 #ifndef __MSG_H__
 #define __MSG_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern BOOL deltaload;
 extern BYTE gbBufferMsgs;
 extern int dwRecCount;
@@ -145,5 +147,7 @@ DWORD On_DEBUG(TCmd *pCmd, int pnum);
 DWORD On_NOVA(TCmd *pCmd, int pnum);
 DWORD On_SETSHIELD(TCmd *pCmd, int pnum);
 DWORD On_REMSHIELD(TCmd *pCmd, int pnum);
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __MSG_H__ */

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern BOOLEAN gbSomebodyWonGameKludge;
 extern char szPlayerDescript[128];
 extern WORD sgwPackPlrOffsetTbl[MAX_PLRS];
@@ -61,6 +65,10 @@ void recv_plrinfo(int pnum, TCmdPlrInfoHdr *p, BOOL recv);
 /* rdata */
 
 extern const int event_types[3];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -6,6 +6,8 @@
 #ifndef __MULTI_H__
 #define __MULTI_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern BOOLEAN gbSomebodyWonGameKludge;
 extern char szPlayerDescript[128];
 extern WORD sgwPackPlrOffsetTbl[MAX_PLRS];
@@ -59,5 +61,7 @@ void recv_plrinfo(int pnum, TCmdPlrInfoHdr *p, BOOL recv);
 /* rdata */
 
 extern const int event_types[3];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __MULTI_H__ */

--- a/Source/nthread.h
+++ b/Source/nthread.h
@@ -6,6 +6,8 @@
 #ifndef __NTHREAD_H__
 #define __NTHREAD_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern BYTE sgbNetUpdateRate;
 extern DWORD gdwMsgLenTbl[MAX_PLRS];
 extern DWORD gdwDeltaBytesSec;
@@ -30,5 +32,6 @@ void nthread_ignore_mutex(BOOL bStart);
 BOOL nthread_has_500ms_passed(BOOL unused);
 
 /* rdata */
+DEVILUTION_END_NAMESPACE
 
 #endif /* __NTHREAD_H__ */

--- a/Source/nthread.h
+++ b/Source/nthread.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern BYTE sgbNetUpdateRate;
 extern DWORD gdwMsgLenTbl[MAX_PLRS];
 extern DWORD gdwDeltaBytesSec;
@@ -32,6 +36,10 @@ void nthread_ignore_mutex(BOOL bStart);
 BOOL nthread_has_500ms_passed(BOOL unused);
 
 /* rdata */
+#ifdef __cplusplus
+}
+#endif
+
 DEVILUTION_END_NAMESPACE
 
 #endif /* __NTHREAD_H__ */

--- a/Source/objdat.h
+++ b/Source/objdat.h
@@ -2,8 +2,12 @@
 #ifndef __OBJDAT_H__
 #define __OBJDAT_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int ObjTypeConv[];
 extern ObjDataStruct AllObjects[99];
 extern char *ObjMasterLoadList[56];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __OBJDAT_H__ */

--- a/Source/objdat.h
+++ b/Source/objdat.h
@@ -4,9 +4,17 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int ObjTypeConv[];
 extern ObjDataStruct AllObjects[99];
 extern char *ObjMasterLoadList[56];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -2,6 +2,8 @@
 #ifndef __OBJECTS_H__
 #define __OBJECTS_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int trapid;
 extern int trapdir;
 extern BYTE *pObjCels[40];
@@ -162,5 +164,7 @@ extern char shrinemax[NUM_SHRINETYPE];
 extern BYTE shrineavail[NUM_SHRINETYPE];
 extern char *StoryBookName[9];
 extern int StoryText[3][3];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __OBJECTS_H__ */

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -4,6 +4,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int trapid;
 extern int trapdir;
 extern BYTE *pObjCels[40];
@@ -164,6 +168,10 @@ extern char shrinemax[NUM_SHRINETYPE];
 extern BYTE shrineavail[NUM_SHRINETYPE];
 extern char *StoryBookName[9];
 extern int StoryText[3][3];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -4,11 +4,19 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void PackPlayer(PkPlayerStruct *pPack, int pnum, BOOL manashield);
 void VerifyGoldSeeds(PlayerStruct *pPlayer);
 void UnPackPlayer(PkPlayerStruct *pPack, int pnum, BOOL killok);
 
 /* rdata */
+#ifdef __cplusplus
+}
+#endif
+
 DEVILUTION_END_NAMESPACE
 
 #endif /* __PACK_H__ */

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -2,10 +2,13 @@
 #ifndef __PACK_H__
 #define __PACK_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 void PackPlayer(PkPlayerStruct *pPack, int pnum, BOOL manashield);
 void VerifyGoldSeeds(PlayerStruct *pPlayer);
 void UnPackPlayer(PkPlayerStruct *pPack, int pnum, BOOL killok);
 
 /* rdata */
+DEVILUTION_END_NAMESPACE
 
 #endif /* __PACK_H__ */

--- a/Source/palette.h
+++ b/Source/palette.h
@@ -2,6 +2,8 @@
 #ifndef __PALETTE_H__
 #define __PALETTE_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern SDL_Color logical_palette[256];
 extern SDL_Color system_palette[256];
 extern SDL_Color orig_palette[256];
@@ -31,5 +33,7 @@ BOOL palette_set_color_cycling(BOOL enabled);
 
 extern int gamma_correction;
 extern BOOL color_cycling_enabled;
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __PALETTE_H__ */

--- a/Source/palette.h
+++ b/Source/palette.h
@@ -4,6 +4,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern SDL_Color logical_palette[256];
 extern SDL_Color system_palette[256];
 extern SDL_Color orig_palette[256];
@@ -33,6 +37,10 @@ BOOL palette_set_color_cycling(BOOL enabled);
 
 extern int gamma_correction;
 extern BOOL color_cycling_enabled;
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/path.h
+++ b/Source/path.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern PATHNODE path_nodes[MAXPATHNODES];
 extern int gdwCurPathStep;
 extern int gdwCurNodes;
@@ -39,6 +43,10 @@ extern const char pathydir[8];
 
 /* data */
 extern char path_directions[9];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/path.h
+++ b/Source/path.h
@@ -6,6 +6,8 @@
 #ifndef __PATH_H__
 #define __PATH_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern PATHNODE path_nodes[MAXPATHNODES];
 extern int gdwCurPathStep;
 extern int gdwCurNodes;
@@ -37,5 +39,7 @@ extern const char pathydir[8];
 
 /* data */
 extern char path_directions[9];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __PATH_H__ */

--- a/Source/pfile.h
+++ b/Source/pfile.h
@@ -2,6 +2,8 @@
 #ifndef __PFILE_H__
 #define __PFILE_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern BOOL gbValidSaveFile;
 
 void pfile_init_save_directory();
@@ -42,5 +44,6 @@ BYTE *pfile_read(const char *pszName, DWORD *pdwLen);
 void pfile_update(BOOL force_save);
 
 /* rdata */
+DEVILUTION_END_NAMESPACE
 
 #endif /* __PFILE_H__ */

--- a/Source/pfile.h
+++ b/Source/pfile.h
@@ -4,6 +4,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern BOOL gbValidSaveFile;
 
 void pfile_init_save_directory();
@@ -44,6 +48,10 @@ BYTE *pfile_read(const char *pszName, DWORD *pdwLen);
 void pfile_update(BOOL force_save);
 
 /* rdata */
+#ifdef __cplusplus
+}
+#endif
+
 DEVILUTION_END_NAMESPACE
 
 #endif /* __PFILE_H__ */

--- a/Source/player.h
+++ b/Source/player.h
@@ -2,6 +2,8 @@
 #ifndef __PLAYER_H__
 #define __PLAYER_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int plr_lframe_size;
 extern int plr_wframe_size;
 extern BYTE plr_gfx_flag;
@@ -134,5 +136,7 @@ extern int MaxStats[3][4];
 extern int ExpLvlsTbl[MAXCHARLEVEL];
 extern char *ClassStrTbl[];
 extern BYTE fix[9];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __PLAYER_H__ */

--- a/Source/player.h
+++ b/Source/player.h
@@ -4,6 +4,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int plr_lframe_size;
 extern int plr_wframe_size;
 extern BYTE plr_gfx_flag;
@@ -136,6 +140,10 @@ extern int MaxStats[3][4];
 extern int ExpLvlsTbl[MAXCHARLEVEL];
 extern char *ClassStrTbl[];
 extern BYTE fix[9];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/plrmsg.h
+++ b/Source/plrmsg.h
@@ -2,6 +2,8 @@
 #ifndef __PLRMSG_H__
 #define __PLRMSG_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern _plrmsg plr_msgs[PMSG_COUNT];
 
 void plrmsg_delay(BOOL delay);
@@ -16,5 +18,7 @@ void PrintPlrMsg(DWORD x, DWORD y, DWORD width, const char *str, BYTE col);
 /* rdata */
 
 extern const char text_color_from_player_num[MAX_PLRS + 1];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __PLRMSG_H__ */

--- a/Source/plrmsg.h
+++ b/Source/plrmsg.h
@@ -4,6 +4,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern _plrmsg plr_msgs[PMSG_COUNT];
 
 void plrmsg_delay(BOOL delay);
@@ -18,6 +22,10 @@ void PrintPlrMsg(DWORD x, DWORD y, DWORD width, const char *str, BYTE col);
 /* rdata */
 
 extern const char text_color_from_player_num[MAX_PLRS + 1];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/portal.h
+++ b/Source/portal.h
@@ -4,6 +4,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern PortalStruct portal[MAXPORTAL];
 extern int portalindex;
 
@@ -24,6 +28,10 @@ BOOL PosOkPortal(int lvl, int x, int y);
 /* rdata */
 extern int WarpDropX[MAXPORTAL];
 extern int WarpDropY[MAXPORTAL];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/portal.h
+++ b/Source/portal.h
@@ -2,6 +2,8 @@
 #ifndef __PORTAL_H__
 #define __PORTAL_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern PortalStruct portal[MAXPORTAL];
 extern int portalindex;
 
@@ -22,5 +24,7 @@ BOOL PosOkPortal(int lvl, int x, int y);
 /* rdata */
 extern int WarpDropX[MAXPORTAL];
 extern int WarpDropY[MAXPORTAL];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __PORTAL_H__ */

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -4,6 +4,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int qtopline;
 extern BOOL questlog;
 extern BYTE *pQLogCel;
@@ -53,6 +57,10 @@ extern int QuestGroup1[3];
 extern int QuestGroup2[3];
 extern int QuestGroup3[3];
 extern int QuestGroup4[2];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -2,6 +2,8 @@
 #ifndef __QUESTS_H__
 #define __QUESTS_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int qtopline;
 extern BOOL questlog;
 extern BYTE *pQLogCel;
@@ -51,5 +53,7 @@ extern int QuestGroup1[3];
 extern int QuestGroup2[3];
 extern int QuestGroup3[3];
 extern int QuestGroup4[2];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __QUESTS_H__ */

--- a/Source/render.h
+++ b/Source/render.h
@@ -1,8 +1,12 @@
 #ifndef __RENDER_H__
 #define __RENDER_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 void RenderTile(BYTE *pBuff);
 void world_draw_black_tile(int sx, int sy);
 void trans_rect(int sx, int sy, int width, int height);
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __RENDER_H__ */

--- a/Source/render.h
+++ b/Source/render.h
@@ -3,9 +3,17 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void RenderTile(BYTE *pBuff);
 void world_draw_black_tile(int sx, int sy);
 void trans_rect(int sx, int sy, int width, int height);
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/restrict.h
+++ b/Source/restrict.h
@@ -2,6 +2,10 @@
 #ifndef __RESTRICT_H__
 #define __RESTRICT_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 void ReadOnlyTest();
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __RESTRICT_H__ */

--- a/Source/restrict.h
+++ b/Source/restrict.h
@@ -4,7 +4,15 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void ReadOnlyTest();
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/scrollrt.h
+++ b/Source/scrollrt.h
@@ -2,6 +2,8 @@
 #ifndef __SCROLLRT_H__
 #define __SCROLLRT_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern bool sgbControllerActive;
 extern int light_table_index;
 extern BYTE *gpBufStart;
@@ -32,5 +34,7 @@ void DrawAndBlit();
 /** used in 1.00 debug */
 extern char *szMonModeAssert[18];
 extern char *szPlrModeAssert[12];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __SCROLLRT_H__ */

--- a/Source/scrollrt.h
+++ b/Source/scrollrt.h
@@ -4,6 +4,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern bool sgbControllerActive;
 extern int light_table_index;
 extern BYTE *gpBufStart;
@@ -34,6 +38,10 @@ void DrawAndBlit();
 /** used in 1.00 debug */
 extern char *szMonModeAssert[18];
 extern char *szPlrModeAssert[12];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/setmaps.h
+++ b/Source/setmaps.h
@@ -4,6 +4,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int ObjIndex(int x, int y);
 void AddSKingObjs();
 void AddSChamObjs();
@@ -20,6 +24,10 @@ extern BYTE SkelChamTrans1[20];
 extern BYTE SkelChamTrans2[8];
 extern BYTE SkelChamTrans3[36];
 extern char *quest_level_names[];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/setmaps.h
+++ b/Source/setmaps.h
@@ -2,6 +2,8 @@
 #ifndef __SETMAPS_H__
 #define __SETMAPS_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 int ObjIndex(int x, int y);
 void AddSKingObjs();
 void AddSChamObjs();
@@ -18,5 +20,7 @@ extern BYTE SkelChamTrans1[20];
 extern BYTE SkelChamTrans2[8];
 extern BYTE SkelChamTrans3[36];
 extern char *quest_level_names[];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __SETMAPS_H__ */

--- a/Source/sha.h
+++ b/Source/sha.h
@@ -4,6 +4,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define SHA1HashSize 20
 
 //sha
@@ -15,6 +19,10 @@ void SHA1Input(SHA1Context *context, const char *message_array, int len);
 void SHA1ProcessMessageBlock(SHA1Context *context);
 void SHA1Reset(int n);
 void SHA1Init(SHA1Context *context);
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/sha.h
+++ b/Source/sha.h
@@ -2,6 +2,8 @@
 #ifndef __SHA_H__
 #define __SHA_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 #define SHA1HashSize 20
 
 //sha
@@ -13,5 +15,7 @@ void SHA1Input(SHA1Context *context, const char *message_array, int len);
 void SHA1ProcessMessageBlock(SHA1Context *context);
 void SHA1Reset(int n);
 void SHA1Init(SHA1Context *context);
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __SHA_H__ */

--- a/Source/sound.h
+++ b/Source/sound.h
@@ -4,6 +4,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern SoundSample *DSBs[8];
 extern BOOLEAN gbSndInited;
 extern HMODULE hDsound_dll;
@@ -36,6 +40,10 @@ extern BOOLEAN gbMusicOn;
 extern BOOLEAN gbSoundOn;
 extern BOOLEAN gbDupSounds;
 extern char unk_volume[4][2];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/sound.h
+++ b/Source/sound.h
@@ -2,6 +2,8 @@
 #ifndef __SOUND_H__
 #define __SOUND_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern SoundSample *DSBs[8];
 extern BOOLEAN gbSndInited;
 extern HMODULE hDsound_dll;
@@ -34,5 +36,7 @@ extern BOOLEAN gbMusicOn;
 extern BOOLEAN gbSoundOn;
 extern BOOLEAN gbDupSounds;
 extern char unk_volume[4][2];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __SOUND_H__ */

--- a/Source/spelldat.h
+++ b/Source/spelldat.h
@@ -2,6 +2,10 @@
 #ifndef __SPELLDAT_H__
 #define __SPELLDAT_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern SpellData spelldata[];
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __SPELLDAT_H__ */

--- a/Source/spelldat.h
+++ b/Source/spelldat.h
@@ -4,7 +4,15 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern SpellData spelldata[];
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -2,11 +2,15 @@
 #ifndef __SPELLS_H__
 #define __SPELLS_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 int GetManaAmount(int id, int sn);
 void UseMana(int id, int sn);
 BOOL CheckSpell(int id, int sn, char st, BOOL manaonly);
 void CastSpell(int id, int spl, int sx, int sy, int dx, int dy, int caster, int spllvl);
 void DoResurrect(int pnum, int rid);
 void DoHealOther(int pnum, int rid);
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __SPELLS_H__ */

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -4,12 +4,20 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int GetManaAmount(int id, int sn);
 void UseMana(int id, int sn);
 BOOL CheckSpell(int id, int sn, char st, BOOL manaonly);
 void CastSpell(int id, int spl, int sx, int sy, int dx, int dy, int caster, int spllvl);
 void DoResurrect(int pnum, int rid);
 void DoHealOther(int pnum, int rid);
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -2,6 +2,8 @@
 #ifndef __STORES_H__
 #define __STORES_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int stextup;
 extern int storenumh;
 extern int stextlhold;
@@ -136,5 +138,6 @@ void ReleaseStoreBtn();
 /* rdata */
 
 extern char *talkname[9];
+DEVILUTION_END_NAMESPACE
 
 #endif /* __STORES_H__ */

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -4,6 +4,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int stextup;
 extern int storenumh;
 extern int stextlhold;
@@ -138,6 +142,10 @@ void ReleaseStoreBtn();
 /* rdata */
 
 extern char *talkname[9];
+#ifdef __cplusplus
+}
+#endif
+
 DEVILUTION_END_NAMESPACE
 
 #endif /* __STORES_H__ */

--- a/Source/sync.h
+++ b/Source/sync.h
@@ -4,6 +4,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern WORD sync_word_6AA708[MAXMONSTERS];
 extern int sgnMonsters;
 extern WORD sgwLRU[MAXMONSTERS];
@@ -18,6 +22,10 @@ void SyncPlrInv(TSyncHeader *pHdr);
 DWORD sync_update(int pnum, const BYTE *pbBuf);
 void sync_monster(int pnum, const TSyncMonster *p);
 void sync_init();
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/sync.h
+++ b/Source/sync.h
@@ -2,6 +2,8 @@
 #ifndef __SYNC_H__
 #define __SYNC_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern WORD sync_word_6AA708[MAXMONSTERS];
 extern int sgnMonsters;
 extern WORD sgwLRU[MAXMONSTERS];
@@ -16,5 +18,7 @@ void SyncPlrInv(TSyncHeader *pHdr);
 DWORD sync_update(int pnum, const BYTE *pbBuf);
 void sync_monster(int pnum, const TSyncMonster *p);
 void sync_init();
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __SYNC_H__ */

--- a/Source/textdat.h
+++ b/Source/textdat.h
@@ -2,7 +2,10 @@
 #ifndef __TEXTDAT_H__
 #define __TEXTDAT_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern const TextDataStruct alltext[];
 extern const DWORD gdwAllTextEntries;
 
+DEVILUTION_END_NAMESPACE
 #endif /* __TEXTDAT_H__ */

--- a/Source/textdat.h
+++ b/Source/textdat.h
@@ -4,8 +4,17 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern const TextDataStruct alltext[];
 extern const DWORD gdwAllTextEntries;
 
+#ifdef __cplusplus
+}
+#endif
+
 DEVILUTION_END_NAMESPACE
+
 #endif /* __TEXTDAT_H__ */

--- a/Source/themes.h
+++ b/Source/themes.h
@@ -8,6 +8,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int numthemes;
 extern BOOL armorFlag;
 extern BOOL ThemeGoodIn[4];
@@ -65,5 +69,10 @@ extern int trm5y[25];
 extern int trm3x[9];
 extern int trm3y[9];
 
+#ifdef __cplusplus
+}
+#endif
+
 DEVILUTION_END_NAMESPACE
+
 #endif /* __THEMES_H__ */

--- a/Source/themes.h
+++ b/Source/themes.h
@@ -6,6 +6,8 @@
 #ifndef __THEMES_H__
 #define __THEMES_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern int numthemes;
 extern BOOL armorFlag;
 extern BOOL ThemeGoodIn[4];
@@ -63,4 +65,5 @@ extern int trm5y[25];
 extern int trm3x[9];
 extern int trm3y[9];
 
+DEVILUTION_END_NAMESPACE
 #endif /* __THEMES_H__ */

--- a/Source/tmsg.h
+++ b/Source/tmsg.h
@@ -2,9 +2,12 @@
 #ifndef __TMSG_H__
 #define __TMSG_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 int tmsg_get(BYTE *pbMsg, DWORD dwMaxLen);
 void tmsg_add(BYTE *pbMsg, BYTE bLen);
 void tmsg_start();
 void tmsg_cleanup();
 
+DEVILUTION_END_NAMESPACE
 #endif /* __TMSG_H__ */

--- a/Source/tmsg.h
+++ b/Source/tmsg.h
@@ -4,10 +4,19 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int tmsg_get(BYTE *pbMsg, DWORD dwMaxLen);
 void tmsg_add(BYTE *pbMsg, BYTE bLen);
 void tmsg_start();
 void tmsg_cleanup();
 
+#ifdef __cplusplus
+}
+#endif
+
 DEVILUTION_END_NAMESPACE
+
 #endif /* __TMSG_H__ */

--- a/Source/town.h
+++ b/Source/town.h
@@ -4,11 +4,20 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void SetTownMicros();
 void T_FillSector(BYTE *P3Tiles, BYTE *pSector, int xi, int yi, int w, int h);
 void T_FillTile(BYTE *P3Tiles, int xx, int yy, int t);
 void T_Pass3();
 void CreateTown(int entry);
 
+#ifdef __cplusplus
+}
+#endif
+
 DEVILUTION_END_NAMESPACE
+
 #endif /* __TOWN_H__ */

--- a/Source/town.h
+++ b/Source/town.h
@@ -2,10 +2,13 @@
 #ifndef __TOWN_H__
 #define __TOWN_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 void SetTownMicros();
 void T_FillSector(BYTE *P3Tiles, BYTE *pSector, int xi, int yi, int w, int h);
 void T_FillTile(BYTE *P3Tiles, int xx, int yy, int t);
 void T_Pass3();
 void CreateTown(int entry);
 
+DEVILUTION_END_NAMESPACE
 #endif /* __TOWN_H__ */

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -2,6 +2,8 @@
 #ifndef __TOWNERS_H__
 #define __TOWNERS_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern TownerStruct towner[16];
 
 int GetActiveTowner(int t);
@@ -41,5 +43,6 @@ void CowSFX(int pnum);
 /* data */
 
 extern QuestTalkData Qtalklist[];
+DEVILUTION_END_NAMESPACE
 
 #endif /* __TOWNERS_H__ */

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -4,6 +4,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern TownerStruct towner[16];
 
 int GetActiveTowner(int t);
@@ -43,6 +47,10 @@ void CowSFX(int pnum);
 /* data */
 
 extern QuestTalkData Qtalklist[];
+#ifdef __cplusplus
+}
+#endif
+
 DEVILUTION_END_NAMESPACE
 
 #endif /* __TOWNERS_H__ */

--- a/Source/track.h
+++ b/Source/track.h
@@ -4,9 +4,17 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void track_process();
 void track_repeat_walk(BOOL rep);
 BOOL track_isscrolling();
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/Source/track.h
+++ b/Source/track.h
@@ -2,8 +2,12 @@
 #ifndef __TRACK_H__
 #define __TRACK_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 void track_process();
 void track_repeat_walk(BOOL rep);
 BOOL track_isscrolling();
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __TRACK_H__ */

--- a/Source/trigs.h
+++ b/Source/trigs.h
@@ -2,6 +2,8 @@
 #ifndef __TRIGS_H__
 #define __TRIGS_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 extern BOOL townwarps[3];
 extern BOOL trigflag;
 extern int numtrigs;
@@ -47,4 +49,5 @@ extern int L4DownList[6];
 extern int L4TWarpUpList[4];
 extern int L4PentaList[33];
 
+DEVILUTION_END_NAMESPACE
 #endif /* __TRIGS_H__ */

--- a/Source/trigs.h
+++ b/Source/trigs.h
@@ -4,6 +4,10 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern BOOL townwarps[3];
 extern BOOL trigflag;
 extern int numtrigs;
@@ -49,5 +53,10 @@ extern int L4DownList[6];
 extern int L4TWarpUpList[4];
 extern int L4PentaList[33];
 
+#ifdef __cplusplus
+}
+#endif
+
 DEVILUTION_END_NAMESPACE
+
 #endif /* __TRIGS_H__ */

--- a/Source/wave.h
+++ b/Source/wave.h
@@ -2,11 +2,15 @@
 #ifndef __WAVE_H__
 #define __WAVE_H__
 
+DEVILUTION_BEGIN_NAMESPACE
+
 void WCloseFile(HANDLE file);
 LONG WGetFileSize(HANDLE hsFile, DWORD *lpFileSizeHigh, const char *FileName);
 void WGetFileArchive(HANDLE hsFile, DWORD *retry, const char *FileName);
 BOOL WOpenFile(const char *FileName, HANDLE *phsFile, BOOL mayNotExist);
 void WReadFile(HANDLE hsFile, LPVOID buf, DWORD to_read, const char *FileName);
 int WSetFilePointer(HANDLE file1, int offset, HANDLE file2, int whence);
+
+DEVILUTION_END_NAMESPACE
 
 #endif /* __WAVE_H__ */

--- a/Source/wave.h
+++ b/Source/wave.h
@@ -4,12 +4,20 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void WCloseFile(HANDLE file);
 LONG WGetFileSize(HANDLE hsFile, DWORD *lpFileSizeHigh, const char *FileName);
 void WGetFileArchive(HANDLE hsFile, DWORD *retry, const char *FileName);
 BOOL WOpenFile(const char *FileName, HANDLE *phsFile, BOOL mayNotExist);
 void WReadFile(HANDLE hsFile, LPVOID buf, DWORD to_read, const char *FileName);
 int WSetFilePointer(HANDLE file1, int offset, HANDLE file2, int whence);
+
+#ifdef __cplusplus
+}
+#endif
 
 DEVILUTION_END_NAMESPACE
 

--- a/enums.h
+++ b/enums.h
@@ -4,6 +4,8 @@
  * Various global enumerators.
  */
 
+DEVILUTION_BEGIN_NAMESPACE
+
 typedef enum item_quality {
 	ITEM_QUALITY_NORMAL = 0,
 	ITEM_QUALITY_MAGIC  = 1,
@@ -2940,3 +2942,5 @@ typedef enum conn_type {
 #endif
 	SELCONN_LOOPBACK,
 } conn_type;
+
+DEVILUTION_END_NAMESPACE

--- a/structs.h
+++ b/structs.h
@@ -4,6 +4,8 @@
  * Various global structures.
  */
 
+DEVILUTION_BEGIN_NAMESPACE
+
 //////////////////////////////////////////////////
 // control
 //////////////////////////////////////////////////
@@ -1585,3 +1587,5 @@ typedef struct TDataInfo {
 	DWORD destOffset;
 	DWORD size;
 } TDataInfo;
+
+DEVILUTION_END_NAMESPACE

--- a/types.h
+++ b/types.h
@@ -14,8 +14,6 @@
 #include "thread.h"
 #include "ui_fwd.h"
 
-DEVILUTION_BEGIN_NAMESPACE
-
 #include <limits.h>
 #include "defs.h"
 #include "enums.h"


### PR DESCRIPTION
The usage of namespace dvl and extern "C" as a global modifier in all.h is a show stopper to use any standard header or external dependencies in a graceful manner.

As the extern "C" is required by other projects, the strategy was to manually move the namespace delimiters and extern "C" in every file instead of having a global slap.