### PR TITLE
Implement `--save-dir` CLI option (#720)

### DIFF
--- a/3rdParty/Storm/Source/storm.h
+++ b/3rdParty/Storm/Source/storm.h
@@ -5,6 +5,7 @@
 namespace dvl {
 
 extern std::string basePath;
+extern std::string prefPath;
 
 // Note to self: Linker error => forgot a return value in cpp
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -352,6 +352,7 @@ static void print_help_and_exit()
 	printf("    %-20s %-30s\n", "-h, --help", "Print this message and exit");
 	printf("    %-20s %-30s\n", "--version", "Print the version and exit");
 	printf("    %-20s %-30s\n", "--data-dir", "Specify the folder of diabdat.mpq");
+	printf("    %-20s %-30s\n", "--save-dir", "Specify the folder of save files");
 	printf("    %-20s %-30s\n", "-n", "Skip startup videos");
 	printf("    %-20s %-30s\n", "-f", "Display frames per second");
 	printf("    %-20s %-30s\n", "-x", "Run in windowed mode");
@@ -391,6 +392,15 @@ void diablo_parse_flags(int argc, char **argv)
 #else
 			if (basePath.back() != '/')
 				basePath += '/';
+#endif
+		} else if (strcasecmp("--save-dir", argv[i]) == 0) {
+			prefPath = argv[++i];
+#ifdef _WIN32
+			if (prefPath.back() != '\\')
+				prefPath += '\\';
+#else
+			if (prefPath.back() != '/')
+				prefPath += '/';
 #endif
 		} else if (strcasecmp("-n", argv[i]) == 0) {
 			showintrodebug = FALSE;

--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -18,6 +18,7 @@
 namespace dvl {
 
 std::string basePath;
+std::string prefPath;
 
 DWORD nLastError = 0;
 bool directFileAccess = false;
@@ -59,6 +60,11 @@ void GetBasePath(char *buffer, size_t size)
 
 void GetPrefPath(char *buffer, size_t size)
 {
+	if (prefPath.length()) {
+		snprintf(buffer, size, "%s", prefPath.c_str());
+		return;
+	}
+
 	char *path = SDL_GetPrefPath("diasurgical", "devilution");
 	if (path == NULL) {
 		buffer[0] = '\0';

--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -37,7 +37,6 @@ static std::string getIniPath()
 	return result;
 }
 
-static radon::File ini(getIniPath());
 static Mix_Chunk *SFileChunk;
 
 void GetBasePath(char *buffer, size_t size)
@@ -347,6 +346,8 @@ bool getIniBool(const char *sectionName, const char *keyName, bool defaultValue)
 
 bool getIniValue(const char *sectionName, const char *keyName, char *string, int stringSize, int *dataSize)
 {
+	radon::File ini(getIniPath());
+
 	radon::Section *section = ini.getSection(sectionName);
 	if (!section)
 		return false;
@@ -367,6 +368,8 @@ bool getIniValue(const char *sectionName, const char *keyName, char *string, int
 
 void setIniValue(const char *sectionName, const char *keyName, char *value, int len)
 {
+	radon::File ini(getIniPath());
+
 	radon::Section *section = ini.getSection(sectionName);
 	if (!section) {
 		ini.addSection(sectionName);

--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -37,6 +37,11 @@ static std::string getIniPath()
 	return result;
 }
 
+radon::File& getIni() {
+  static radon::File ini(getIniPath());
+  return ini;
+}
+
 static Mix_Chunk *SFileChunk;
 
 void GetBasePath(char *buffer, size_t size)
@@ -346,9 +351,7 @@ bool getIniBool(const char *sectionName, const char *keyName, bool defaultValue)
 
 bool getIniValue(const char *sectionName, const char *keyName, char *string, int stringSize, int *dataSize)
 {
-	radon::File ini(getIniPath());
-
-	radon::Section *section = ini.getSection(sectionName);
+	radon::Section *section = getIni().getSection(sectionName);
 	if (!section)
 		return false;
 
@@ -368,7 +371,7 @@ bool getIniValue(const char *sectionName, const char *keyName, char *string, int
 
 void setIniValue(const char *sectionName, const char *keyName, char *value, int len)
 {
-	radon::File ini(getIniPath());
+	radon::File& ini = getIni();
 
 	radon::Section *section = ini.getSection(sectionName);
 	if (!section) {


### PR DESCRIPTION
This implements support for `--save-dir` (as described in #720).

Unfortunately `ini` file is initialized as static variable, before we can change `prefPath`: https://github.com/diasurgical/devilutionX/blob/0fddb655e3ef855b43166e720252ba1736197ccb/SourceX/storm/storm.cpp#L39

`SourceX/storm/storm.cpp` and/or `3rdParty/radon/File` may need to be modified to workaround that (i was thinking about initializing `radon::File` only at first access to ini file, but i am not sure if that would be ok).

@AJenbo would further modifications to SourceX/storm/storm.cpp` be OK?