### PR TITLE
Prevent double free of sound chunk in storm

### DIFF
--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -42,7 +42,7 @@ radon::File& getIni() {
   return ini;
 }
 
-static Mix_Chunk *SFileChunk;
+static Mix_Chunk *SFileChunk = NULL;
 
 void GetBasePath(char *buffer, size_t size)
 {
@@ -102,6 +102,9 @@ BOOL SFileDdaBeginEx(HANDLE hFile, DWORD flags, DWORD mask, unsigned __int32 lDi
 		SDL_Log(SDL_GetError());
 		return false;
 	}
+	if (SFileChunk) {
+		SFileFreeChunk();
+	}
 	SFileChunk = Mix_LoadWAV_RW(rw, 1);
 	free(SFXbuffer);
 
@@ -115,13 +118,18 @@ BOOL SFileDdaBeginEx(HANDLE hFile, DWORD flags, DWORD mask, unsigned __int32 lDi
 
 void SFileFreeChunk()
 {
-	if(SFileChunk)
+	if (SFileChunk) {
 		Mix_FreeChunk(SFileChunk);
+		SFileChunk = NULL;
+	}
 }
 
 BOOL SFileDdaDestroy()
 {
-	Mix_FreeChunk(SFileChunk);
+	if (SFileChunk) {
+		Mix_FreeChunk(SFileChunk);
+		SFileChunk = NULL;
+	}
 
 	return true;
 }

--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -103,6 +103,7 @@ BOOL SFileDdaBeginEx(HANDLE hFile, DWORD flags, DWORD mask, unsigned __int32 lDi
 		return false;
 	}
 	if (SFileChunk) {
+		SFileDdaEnd(hFile);
 		SFileFreeChunk();
 	}
 	SFileChunk = Mix_LoadWAV_RW(rw, 1);


### PR DESCRIPTION
This does not check why `SFileFreeChunk` and/or `SFileDdaDestroy` were called for the same chunk of data. It simply makes sure that once the chunk is freed it's set to `NULL`, so next call will not trigger `Mix_FreeChunk` and error.

This fixes cleanup crash i could reproduce every time by simply starting/loading game, gossiping with NPC/Townsfolk and quitting game (as described at https://github.com/diasurgical/devilutionX/issues/717#issuecomment-634628920).

This may fix both #717 and #725.