### PR TITLE
Set Single Player Difficulty via ini

### DIFF
--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -136,6 +136,11 @@ void mainmenu_loop()
 BOOL mainmenu_single_player()
 {
 	gbMaxPlayers = 1;
+	int value = gnDifficulty;
+	if (!SRegLoadValue(APP_NAME, "SP Difficulty", 0, &value))
+		value = 0;
+	value = SDL_max(0, SDL_min(value, 2)); // Clamp values 0-Normal, 1-Nightmare, 2-Hell
+	gnDifficulty = value;
 	return mainmenu_init_menu(SELHERO_NEW_DUNGEON);
 }
 


### PR DESCRIPTION
Adds "SP Difficulty" to ini which is used to set gnDifficulty when Single Player is selected.
Eliminates the need to do the Multiplayer New Game bug originally used before.  Multiplayer is unaffected as it will set gnDifficulty when player selects the difficulty. 
Going back and selecting a Single Player game will again read the ini and set gnDifficulty back to the ini setting.