### PR TITLE
Fixing explosive barrels prespawning skeletons

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1100,7 +1100,7 @@ void AddBarrel(int i, int t)
 {
 	object[i]._oVar1 = 0;
 	object[i]._oRndSeed = GetRndSeed();
-	object[i]._oVar2 = random_(149, 10);
+	object[i]._oVar2 = (t == OBJ_BARRELEX) ? 0 : random_(149, 10);
 	object[i]._oVar3 = random_(149, 3);
 
 	if (object[i]._oVar2 >= 8)


### PR DESCRIPTION
The AddBarrel function was not checking the type of the barrel when
generating the oVar2. This led to skeletons being pre-spawned in
explosive barrels; except that explosive barrels do not trigger the
spawn, resulting in unreachable monsters sitting at (0, 0) even after a
full clear.

While this does not affect functionality of regular Diablo gameplay, it
potentially affects modders who would like to use the nummonsters
global variable to check for full clears.