### PR TITLE
Fixing mouse lag on Linux (issue #745)

### DIFF
--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -116,7 +116,7 @@ bool SpawnWindow(const char *lpWindowName, int nWidth, int nHeight)
 #ifdef USE_SDL1
 		SDL_Log("upscaling not supported with USE_SDL1");
 #else
-		renderer = SDL_CreateRenderer(ghMainWnd, -1, SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_ACCELERATED);
+		renderer = SDL_CreateRenderer(ghMainWnd, -1, /* SDL_RENDERER_PRESENTVSYNC | */ SDL_RENDERER_ACCELERATED);
 		if (renderer == NULL) {
 			ErrSdl();
 		}


### PR DESCRIPTION
On my particular setup, I was experiencing a mouse making the game hard
to play (see issue #745 ). Desactivating vsync seemed to fix that issue - while I did not
test the change on Windows, I don't believe desactivating vsync will
make any difference.

But in the case that it does make a difference, perhaps an alternative could
be to only activate it for Linux users? Or provide some way to activate
it via the building commands?