### PR TITLE
Modified UiInitList declaration to allow selection wrapping

### DIFF
--- a/SourceX/DiabloUI/diabloui.h
+++ b/SourceX/DiabloUI/diabloui.h
@@ -54,7 +54,7 @@ void SetMenu(int MenuId);
 void UiFocusNavigationSelect();
 void UiFocusNavigationEsc();
 void UiFocusNavigationYesNo();
-void UiInitList(int min, int max, void (*fnFocus)(int value), void (*fnSelect)(int value), void (*fnEsc)(), UiItem *items, int size, bool wraps = false, bool (*fnYesNo)() = NULL);
+void UiInitList(int min, int max, void (*fnFocus)(int value), void (*fnSelect)(int value), void (*fnEsc)(), UiItem *items, int size, bool wraps = true, bool (*fnYesNo)() = NULL);
 void UiInitScrollBar(UiScrollBar *ui_sb, std::size_t viewport_size, const std::size_t *current_offset);
 void UiClearScreen();
 void UiPollAndRender();


### PR DESCRIPTION
This is my first pull request so I apologize if anything is done incorrectly.

This will fix Issue #661 regarding the lack of selection wrapping when using the arrow keys to select the difficulty for multiplayer sessions. Rather than allow wrapping only when choosing difficulty, I modified the default parameter in the declaration for UiInitList so the behavior would be more consistent across applicable menus. However, this does not work in the 'Select Hero' menu because its behavior is handled separately.

Thank you.