### PR TITLE
Softcode VSYNC setting. Enabled by default.

### DIFF
--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -116,7 +116,15 @@ bool SpawnWindow(const char *lpWindowName, int nWidth, int nHeight)
 #ifdef USE_SDL1
 		SDL_Log("upscaling not supported with USE_SDL1");
 #else
-		renderer = SDL_CreateRenderer(ghMainWnd, -1, SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_ACCELERATED);
+		Uint32 rendererFlags = SDL_RENDERER_ACCELERATED;
+
+		int vsyncEnabled = 1;
+		DvlIntSetting("vsync", &vsyncEnabled);
+		if (vsyncEnabled) {
+			rendererFlags |= SDL_RENDERER_PRESENTVSYNC;
+		}
+
+		renderer = SDL_CreateRenderer(ghMainWnd, -1, rendererFlags);
 		if (renderer == NULL) {
 			ErrSdl();
 		}

--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -118,7 +118,7 @@ bool SpawnWindow(const char *lpWindowName, int nWidth, int nHeight)
 #else
 		Uint32 rendererFlags = SDL_RENDERER_ACCELERATED;
 
-		int vsyncEnabled = 1;
+		vsyncEnabled = 1;
 		DvlIntSetting("vsync", &vsyncEnabled);
 		if (vsyncEnabled) {
 			rendererFlags |= SDL_RENDERER_PRESENTVSYNC;

--- a/SourceX/display.h
+++ b/SourceX/display.h
@@ -8,6 +8,7 @@
 
 namespace dvl {
 
+extern int vsyncEnabled;
 extern int refreshDelay; // Screen refresh rate in nanoseconds
 extern SDL_Window *window;
 extern SDL_Renderer *renderer;

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -17,6 +17,7 @@ int locktbl[256];
 #endif
 static CCritSect sgMemCrit;
 
+int vsyncEnabled;
 int refreshDelay;
 SDL_Renderer *renderer;
 SDL_Texture *texture;
@@ -280,6 +281,10 @@ void RenderPresent()
 			ErrSdl();
 		}
 		SDL_RenderPresent(renderer);
+
+		if (!vsyncEnabled) {
+			LimitFrameRate();
+		}
 	} else {
 		if (SDL_UpdateWindowSurface(ghMainWnd) <= -1) {
 			ErrSdl();


### PR DESCRIPTION
This PR softcodes the 'VSYNC' option when creating the SDL renderer, allowing one to change the vsync setting through standard `diablo.ini` configuration.

The new setting is called `vsync` and can have values `0` (disabled) or `1` (enabled). As with other settings, if the flag is not found, it will be defaulted (to `1` in this case to retain old behavior) and saved back to configuration.

This resolves #782 .