### PR TITLE
Add integer scaling support. Disabled by default.

### DIFF
--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -126,6 +126,12 @@ bool SpawnWindow(const char *lpWindowName, int nWidth, int nHeight)
 			ErrSdl();
 		}
 
+		int integerScalingEnabled = 0;
+		DvlIntSetting("integer scaling", &integerScalingEnabled);
+		if (integerScalingEnabled && SDL_RenderSetIntegerScale(renderer, SDL_TRUE) < 0) {
+			ErrSdl();
+		}
+
 		if (SDL_RenderSetLogicalSize(renderer, nWidth, nHeight) <= -1) {
 			ErrSdl();
 		}


### PR DESCRIPTION
This PR introduces the option to enable integer scaling in DevilutionX. It can be enabled by setting a new `diablo.ini` flag called `integer scaling`, which can have both a `0` (disabled) and `1` (enabled) values. The default is `0` to maintain current behavior.

This results in optimal scaling of 2D assets by ensuring that every pixel is stable during scaling: each pixel will always end up being N times bigger in the scaled image, no matter its position. i.e. a single pixel in the original 640x480 frame becomes 4 pixels (2x2) on 1280x960 or 9 pixels (3x3) on 1440p.

On a normal non-integer scaling, each column and row on the screen will have to fit a wider area that is not a perfect multiple of the original image. This introduces rounding differences resulting in variable pixel widths and/or heights, which in turn dramatically degrade picture quality by adding constant shimmering, especially with scrolling images.

Here is a real example (windows screenshot over game frame, not in-game screenshot):

| integer x 2 (1080p -> 960p) | non-integer scale (fullscreen 1080p) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/461579/91783889-d60e9f80-ebd7-11ea-9055-a760f45cddde.png) | ![image](https://user-images.githubusercontent.com/461579/91783895-d9a22680-ebd7-11ea-9352-5fa09e635074.png) |

Notice how, while both images are clearly aliased (due to low resolution), the integer scaled version has all segments exactly identical, while the other image is all over the place: some 2 pixel rows, some 1 pixel rows, etc.

Enabling integer scaling manually ensures SDL will scale the image to the maximum possible multiple of 480p over your desktop resolution. This removes the need to configure the desktop resolution to an integer multiple before opening the game.

This implements #784