### PR TITLE
Use older devkitpro/devkita64 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
       - store_artifacts: {path: ./build/devilutionx.exe, destination: devilutionx_x86.exe}
   switch:
     docker:
-      - image: devkitpro/devkita64:latest
+      - image: devkitpro/devkita64:20200528
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
As of 20200730 the latest devkitpro/devkita64 image has been failing to start because of UID issues.
https://github.com/devkitPro/docker/issues/9