### PR TITLE
Mark executable as DPI aware (per monitor)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,7 @@ set(devilutionx_SRCS
   SourceX/DiabloUI/title.cpp
   SourceX/DiabloUI/ttf_render_wrapped.cpp
   SourceX/main.cpp
+  SourceX/devilutionx.exe.manifest
   Packaging/macOS/AppIcon.icns
   Packaging/resources/CharisSILB.ttf
   Packaging/windows/devilutionx.rc)

--- a/SourceX/devilutionx.exe.manifest
+++ b/SourceX/devilutionx.exe.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<assembly xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+	<asmv3:application>
+		<asmv3:windowsSettings>
+			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+		</asmv3:windowsSettings>
+	</asmv3:application>
+</assembly>


### PR DESCRIPTION
This PR adds a new flag into the games `.exe`'s manifest to indicate that the application is DPI aware. The setting we are using is "Per Monitor", which causes Windows to publish full monitor pixel range to our application even if the DPI settings in Windows are not set to 100% scale, and instructs it to not perform any further scaling of it's own.

This is equivalent to setting the DPI override flag on the `exe`'s properties to `Application`:

![image](https://user-images.githubusercontent.com/461579/92186222-7bba4c80-ee2c-11ea-99dd-813243250af0.png)

This change results in correct image scaling regardless of external Windows scaling settings.

We are using the "Per Monitor v1" flag along with the `<dpiAware>` setting because they are compatible with older versions of Windows. The more modern, v2 flag and `<dpiAwareness>` setting only works with Windows 10 and doesn't provide anything in particular that would benefit us now.

Adding the custom manifest file to the list of source files in CMake causes it to automatically recognize it as a manifest file and "merges" it with the autogenerated manifest during build. One can validate the final manifest using the `mt` command:
```
mt -inputresource:"devilutionx.exe";1 -out:extracted.manifest
```

Here is how it looks in our case:
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<assembly xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" manifestVersion="1.0">
    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
        <security>
            <requestedPrivileges>
                <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
            </requestedPrivileges>
        </security>
    </trustInfo>
    <asmv3:application>
        <asmv3:windowsSettings>
            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
        </asmv3:windowsSettings>
    </asmv3:application>
</assembly>
```

More information on these settings here:
- [How to: Embed a Manifest Inside a C/C++ Application
](https://docs.microsoft.com/en-us/cpp/build/how-to-embed-a-manifest-inside-a-c-cpp-application?view=vs-2019)
- [Setting the default DPI awareness for a process](https://docs.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process#setting-default-awareness-with-the-application-manifest)
- [CMake 3.4 Release Notes - automatic manifest support](https://cmake.org/cmake/help/v3.4/release/3.4.html#other)
- [How can I embed a specific manifest file in a Windows DLL with a CMake build?](https://stackoverflow.com/a/34518526/1946412)
- [High-DPI Scaling Improvements for Desktop Applications in the Windows 10 Creators Update (1703)](https://blogs.windows.com/windowsdeveloper/2017/04/04/high-dpi-scaling-improvements-desktop-applications-windows-10-creators-update/)

This resolves #786 