### PR TITLE
correct 64-bit spell-check in one place

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1302,20 +1302,6 @@ void RemoveInvItem(int pnum, int iv)
 	}
 
 	CalcPlrScrolls(pnum);
-
-	if (plr[pnum]._pRSplType == RSPLTYPE_SCROLL) {
-		if (plr[pnum]._pRSpell != SPL_INVALID) {
-			// BUGFIX: Cast the literal `1` to `unsigned __int64` to make that bitshift 64bit
-			// this causes the last 4 skills to not reset correctly after use
-			if (!(
-			        plr[pnum]._pScrlSpells
-			        & (1 << (plr[pnum]._pRSpell - 1)))) {
-				plr[pnum]._pRSpell = SPL_INVALID;
-			}
-
-			force_redraw = 255;
-		}
-	}
 }
 
 void RemoveSpdBarItem(int pnum, int iv)
@@ -1324,17 +1310,6 @@ void RemoveSpdBarItem(int pnum, int iv)
 
 	CalcPlrScrolls(pnum);
 
-	if (plr[pnum]._pRSplType == RSPLTYPE_SCROLL) {
-		if (plr[pnum]._pRSpell != SPL_INVALID) {
-			// BUGFIX: Cast the literal `1` to `unsigned __int64` to make that bitshift 64bit
-			// this causes the last 4 skills to not reset correctly after use
-			if (!(
-			        plr[pnum]._pScrlSpells
-			        & (1 << (plr[pnum]._pRSpell - 1)))) {
-				plr[pnum]._pRSpell = SPL_INVALID;
-			}
-		}
-	}
 	force_redraw = 255;
 }
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -625,12 +625,13 @@ void CalcPlrScrolls(int p)
 				plr[p]._pScrlSpells |= (__int64)1 << (plr[p].SpdList[j]._iSpell - 1);
 		}
 	}
-	if (plr[p]._pRSplType == RSPLTYPE_SCROLL) {
-		if (!(plr[p]._pScrlSpells & 1 << (plr[p]._pRSpell - 1))) {
-			plr[p]._pRSpell = SPL_INVALID;
-			plr[p]._pRSplType = RSPLTYPE_INVALID;
-			force_redraw = 255;
-		}
+
+	// check if the current RSplType is a valid/allowed spell
+	if (plr[p]._pRSplType == RSPLTYPE_SCROLL
+		&& !(plr[p]._pScrlSpells & ((unsigned __int64)1 << (plr[p]._pRSpell - 1)))) {
+		plr[p]._pRSpell = SPL_INVALID;
+		plr[p]._pRSplType = RSPLTYPE_INVALID;
+		force_redraw = 255;
 	}
 }
 


### PR DESCRIPTION
Spell availability check is done in CalcPlrScrolls, which makes the ones after item-removal unnecessary.
The check in CalcPlrScrolls is fixed to work with 64bit values.