### PR TITLE
Remove blank space before ':' on monster info

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4976,7 +4976,7 @@ void PrintMonstHistory(int mt)
 {
 	int minHP, maxHP, res;
 
-	sprintf(tempstr, "Total kills : %i", monstkills[mt]);
+	sprintf(tempstr, "Total kills: %i", monstkills[mt]);
 	AddPanelString(tempstr, TRUE);
 	if (monstkills[mt] >= 30) {
 		minHP = monsterdata[mt].mMinHP;
@@ -4997,7 +4997,7 @@ void PrintMonstHistory(int mt)
 			minHP = 4 * minHP + 3;
 			maxHP = 4 * maxHP + 3;
 		}
-		sprintf(tempstr, "Hit Points : %i-%i", minHP, maxHP);
+		sprintf(tempstr, "Hit Points: %i-%i", minHP, maxHP);
 		AddPanelString(tempstr, TRUE);
 	}
 	if (monstkills[mt] >= 15) {
@@ -5011,7 +5011,7 @@ void PrintMonstHistory(int mt)
 			AddPanelString(tempstr, TRUE);
 		} else {
 			if (res & (RESIST_MAGIC | RESIST_FIRE | RESIST_LIGHTNING)) {
-				strcpy(tempstr, "Resists : ");
+				strcpy(tempstr, "Resists: ");
 				if (res & RESIST_MAGIC)
 					strcat(tempstr, "Magic ");
 				if (res & RESIST_FIRE)
@@ -5022,7 +5022,7 @@ void PrintMonstHistory(int mt)
 				AddPanelString(tempstr, TRUE);
 			}
 			if (res & (IMUNE_MAGIC | IMUNE_FIRE | IMUNE_LIGHTNING)) {
-				strcpy(tempstr, "Immune : ");
+				strcpy(tempstr, "Immune: ");
 				if (res & IMUNE_MAGIC)
 					strcat(tempstr, "Magic ");
 				if (res & IMUNE_FIRE)


### PR DESCRIPTION
This PR fixes a small formatting inconsistency between how monster data is presented compared to how item data is presented in the information panel, by removing an extra white space character before the colon `:` character on all labelled monster data.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/461579/92979887-6e274700-f46a-11ea-8bc5-c2685384ad67.png) | ![image](https://user-images.githubusercontent.com/461579/92980054-0c1b1180-f46b-11ea-9cd8-b370f892fb49.png) |
| ![image](https://user-images.githubusercontent.com/461579/92979901-7c756300-f46a-11ea-840b-a969e991bce1.png) | ![image](https://user-images.githubusercontent.com/461579/92979901-7c756300-f46a-11ea-840b-a969e991bce1.png) |

This resolves #803 