### PR TITLE
Expose monster type on monster info

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -437,6 +437,7 @@ static void SaveOptions()
 	setIniInt("Game", "Auto Equip Shields", sgOptions.Gameplay.bAutoEquipShields);
 	setIniInt("Game", "Auto Equip Jewelry", sgOptions.Gameplay.bAutoEquipJewelry);
 	setIniInt("Game", "Enable All Quests for Single Player", sgOptions.Gameplay.bAllQuests);
+	setIniInt("Game", "Show Monster Type", sgOptions.Gameplay.bShowMonsterType);
 
 	setIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress);
 }
@@ -491,6 +492,7 @@ static void LoadOptions()
 	sgOptions.Gameplay.bAutoEquipShields = getIniBool("Game", "Auto Equip Shields", false);
 	sgOptions.Gameplay.bAutoEquipJewelry = getIniBool("Game", "Auto Equip Jewelry", false);
 	sgOptions.Gameplay.bAllQuests = getIniBool("Game", "Enable All Quests for Single Player", false);
+	sgOptions.Gameplay.bShowMonsterType = getIniBool("Game", "Show Monster Type", false);
 
 	getIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress, sizeof(sgOptions.Network.szBindAddress), "0.0.0.0");
 }

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -98,6 +98,8 @@ typedef struct GameplayOptions {
 	bool bAutoEquipJewelry;
 	/** @brief Enable All Quests for Single Player */
 	bool bAllQuests;
+	/** @brief Indicates whether or not mosnter type (Animal, Demon, Undead) is shown along with other monster information. */
+	bool bShowMonsterType;
 } GameplayOptions;
 
 typedef struct NetworkOptions {

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -5156,11 +5156,24 @@ void M_FallenFear(int x, int y)
 	}
 }
 
+const char* GetMonsterTypeText(const MonsterData& monsterData) {
+	switch (monsterData.mMonstClass) {
+	case MC_ANIMAL:
+		return "Animal";
+
+	case MC_DEMON:
+		return "Demon";
+
+	case MC_UNDEAD:
+		return "Undead";
+	}
+}
+
 void PrintMonstHistory(int mt)
 {
 	int minHP, maxHP, res;
 
-	sprintf(tempstr, "Total kills: %i", monstkills[mt]);
+	sprintf(tempstr, "Type: %s  Kills: %i", GetMonsterTypeText(monsterdata[mt]), monstkills[mt]);
 	AddPanelString(tempstr, TRUE);
 	if (monstkills[mt] >= 30) {
 		minHP = monsterdata[mt].mMinHP;
@@ -5235,6 +5248,8 @@ void PrintUniqueHistory()
 {
 	int res;
 
+	sprintf(tempstr, "Type: %s", GetMonsterTypeText(*monster[pcursmonst].MData));
+	AddPanelString(tempstr, TRUE);
 	res = monster[pcursmonst].mMagicRes & (RESIST_MAGIC | RESIST_FIRE | RESIST_LIGHTNING | IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING);
 	if (!res) {
 		strcpy(tempstr, "No resistances");

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -5173,7 +5173,12 @@ void PrintMonstHistory(int mt)
 {
 	int minHP, maxHP, res;
 
-	sprintf(tempstr, "Type: %s  Kills: %i", GetMonsterTypeText(monsterdata[mt]), monstkills[mt]);
+	if (sgOptions.Gameplay.bShowMonsterType) {
+		sprintf(tempstr, "Type: %s  Kills: %i", GetMonsterTypeText(monsterdata[mt]), monstkills[mt]);
+	} else {
+		sprintf(tempstr, "Total kills: %i", monstkills[mt]);
+	}
+
 	AddPanelString(tempstr, TRUE);
 	if (monstkills[mt] >= 30) {
 		minHP = monsterdata[mt].mMinHP;
@@ -5248,8 +5253,11 @@ void PrintUniqueHistory()
 {
 	int res;
 
-	sprintf(tempstr, "Type: %s", GetMonsterTypeText(*monster[pcursmonst].MData));
-	AddPanelString(tempstr, TRUE);
+	if (sgOptions.Gameplay.bShowMonsterType) {
+		sprintf(tempstr, "Type: %s", GetMonsterTypeText(*monster[pcursmonst].MData));
+		AddPanelString(tempstr, TRUE);
+	}
+
 	res = monster[pcursmonst].mMagicRes & (RESIST_MAGIC | RESIST_FIRE | RESIST_LIGHTNING | IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING);
 	if (!res) {
 		strcpy(tempstr, "No resistances");

--- a/SourceX/qol.cpp
+++ b/SourceX/qol.cpp
@@ -90,14 +90,18 @@ void DrawMonsterHealthBar(CelOutputBuffer out)
 		borderSize <<= 1;
 
 	FillRect(out, xPos, yPos, (width * currentLife) / maxLife, height, filledColor);
-	for (int j = 0; j < borderSize; j++) {
-		FastDrawHorizLine(out, xPos - xOffset - corners, yPos - borderSize - yOffset + j, (xOffset + corners) * 2 + width, borderColor);
-		FastDrawHorizLine(out, xPos - xOffset, yPos + height + yOffset + j, width + corners + xOffset * 2, borderColor);
+
+	if (sgOptions.Gameplay.bShowMonsterType) {
+		for (int j = 0; j < borderSize; j++) {
+			FastDrawHorizLine(out, xPos - xOffset - corners, yPos - borderSize - yOffset + j, (xOffset + corners) * 2 + width, borderColor);
+			FastDrawHorizLine(out, xPos - xOffset, yPos + height + yOffset + j, width + corners + xOffset * 2, borderColor);
+		}
+		for (int j = -yOffset; j < yOffset + height + corners; ++j) {
+			FastDrawHorizLine(out, xPos - xOffset - borderSize, yPos + j, borderSize, borderColor);
+			FastDrawHorizLine(out, xPos + xOffset + width, yPos + j, borderSize, borderColor);
+		}
 	}
-	for (int j = -yOffset; j < yOffset + height + corners; ++j) {
-		FastDrawHorizLine(out, xPos - xOffset - borderSize, yPos + j, borderSize, borderColor);
-		FastDrawHorizLine(out, xPos + xOffset + width, yPos + j, borderSize, borderColor);
-	}
+
 	for (int k = 0; k < resSize; ++k) {
 		if (mres & immunes[k]) {
 			drawImmu = true;


### PR DESCRIPTION
This PR introduces one extra information when displaying monster details in the bottom info panel: the monster type.

| | Disabled | Enabled |
| --- | --- | --- |
| Normal (on-screen bar) | ![image](https://user-images.githubusercontent.com/461579/111918457-e72fd880-8a63-11eb-9852-ed205a6ba9cb.png) | ![image](https://user-images.githubusercontent.com/461579/111918492-0fb7d280-8a64-11eb-8c4b-59b819afc810.png) |
| Normal (info panel) | ![image](https://user-images.githubusercontent.com/461579/92981945-7edbbb00-f472-11ea-96a0-70bad26de376.png) | ![image](https://user-images.githubusercontent.com/461579/92981165-1808d280-f46f-11ea-8ab8-057af2f7e595.png) | ![image](https://user-images.githubusercontent.com/461579/111918457-e72fd880-8a63-11eb-9852-ed205a6ba9cb.png) |
| Unique (on-screen bar) | ![image](https://user-images.githubusercontent.com/461579/111918472-f9aa1200-8a63-11eb-9683-019e2ce00480.png) | ![image](https://user-images.githubusercontent.com/461579/111918507-23633900-8a64-11eb-8bb1-439eb10865ba.png) |
| Unique | ![image](https://user-images.githubusercontent.com/461579/92981626-09231f80-f471-11ea-9552-eb0718ce4c59.png)  | ![image](https://user-images.githubusercontent.com/461579/92981782-c6ae1280-f471-11ea-8244-077faff8430b.png)|

The information is added to the second info line to preserve space and for line limit considerations.

A new feature toggle was added to control this behavior, `Show monster type information`, disabled by default.

This resolves #805