### PR TITLE
Reword potion effect descriptions for consistency

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3318,11 +3318,11 @@ void PrintItemOil(char IDidx)
 		AddPanelString(tempstr);
 		break;
 	case IMISC_FULLHEAL:
-		strcpy(tempstr, _("fully recover life"));
+		strcpy(tempstr, _("restore all life"));
 		AddPanelString(tempstr);
 		break;
 	case IMISC_HEAL:
-		strcpy(tempstr, _("recover partial life"));
+		strcpy(tempstr, _("restore some life"));
 		AddPanelString(tempstr);
 		break;
 	case IMISC_OLDHEAL:
@@ -3334,11 +3334,11 @@ void PrintItemOil(char IDidx)
 		AddPanelString(tempstr);
 		break;
 	case IMISC_MANA:
-		strcpy(tempstr, _("recover mana"));
+		strcpy(tempstr, _("restore some mana"));
 		AddPanelString(tempstr);
 		break;
 	case IMISC_FULLMANA:
-		strcpy(tempstr, _("fully recover mana"));
+		strcpy(tempstr, _("restore all mana"));
 		AddPanelString(tempstr);
 		break;
 	case IMISC_ELIXSTR:
@@ -3374,11 +3374,11 @@ void PrintItemOil(char IDidx)
 		AddPanelString(tempstr);
 		break;
 	case IMISC_REJUV:
-		strcpy(tempstr, _("recover life and mana"));
+		strcpy(tempstr, _("restore some life and mana"));
 		AddPanelString(tempstr);
 		break;
 	case IMISC_FULLREJUV:
-		strcpy(tempstr, _("fully recover life and mana"));
+		strcpy(tempstr, _("restore all life and mana"));
 		AddPanelString(tempstr);
 		break;
 	}


### PR DESCRIPTION
This PR rewrites all health/mana/rejuvenation potion effect descriptions so that the message is consistently conveyed for all potion types, using more adequate and concise terminology.

| Potion | Old Description | New Description |
| --- | --- | --- |
| Healing | "Recover partial life" | "Restore some life" |
| Full Healing | "Fully recover life" | "Restore all life" |
| Mana | "Recover mana" | "Restore some mana" |
| Full Mana | "Fully recover mana" | "Restore all mana" |
| Rejuvenation | "Recover life and mana" |  "Restore some life and mana" |
| Full Rejuvenation | "Fully recover life and mana" | "Restore all life and mana" |

This resolves #807