### PR TITLE
Add missing 1st frame for animations

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1812,7 +1812,7 @@ void SetupItem(int i)
 	item[i]._iPostDraw = FALSE;
 
 	if (!plr[myplr].pLvlLoad) {
-		item[i]._iAnimFrame = 1;
+		item[i]._iAnimFrame = 0;
 		item[i]._iAnimFlag = TRUE;
 		item[i]._iSelFlag = 0;
 	} else {
@@ -2410,7 +2410,7 @@ void RespawnItem(int i, BOOL FlipFlag)
 	item[i]._iPostDraw = FALSE;
 	item[i]._iRequest = FALSE;
 	if (FlipFlag) {
-		item[i]._iAnimFrame = 1;
+		item[i]._iAnimFrame = 0;
 		item[i]._iAnimFlag = TRUE;
 		item[i]._iSelFlag = 0;
 	} else {

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1116,7 +1116,7 @@ void NewMonsterAnim(int i, AnimStruct *anim, int md)
 	MonsterStruct *Monst = monster + i;
 	Monst->_mAnimData = anim->Data[md];
 	Monst->_mAnimLen = anim->Frames;
-	Monst->_mAnimCnt = 0;
+	Monst->_mAnimCnt = -2;
 	Monst->_mAnimFrame = 1;
 	Monst->_mAnimDelay = anim->Rate;
 	Monst->_mFlags &= ~(MFLAG_LOCK_ANIMATION | MFLAG_ALLOW_SPECIAL);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -422,7 +422,7 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width)
 	plr[pnum]._pAnimData = Peq;
 	plr[pnum]._pAnimLen = numFrames;
 	plr[pnum]._pAnimFrame = 1;
-	plr[pnum]._pAnimCnt = 0;
+	plr[pnum]._pAnimCnt = -1;
 	plr[pnum]._pAnimDelay = Delay;
 	plr[pnum]._pAnimWidth = width;
 	plr[pnum]._pAnimWidth2 = (width - 64) >> 1;


### PR DESCRIPTION
This PR makes it so that the 1st frame of animation for monsters, players and items are shown and processed properly. To achieve that effect, it relies on a minimally invasive approach by leveraging the animation delay system for players and monsters to force the first frame to remain unchanged for 1 game frame, and uses a simpler approach for items since they already have an animation flag by starting their animations on frame 0 instead of 1.

Today, the 1st frame of animation is always skipped, meaning that for any CEL animation file, only frames 2 onwards are displayed.

This change also fixes a problem related to how speed affixes affect weapons, since now the first frame will be taken into consideration for skipping logic for both melee and ranged attacks.

Feel free to use the save files provided in #839 to test this change out. For a fully smooth animation, consider applying #790 as well.

This resolves #838
This resolves #839