### PR TITLE
Rename "Bone Chamber" level to "Chamber of Bone"

### DIFF
--- a/Source/setmaps.cpp
+++ b/Source/setmaps.cpp
@@ -65,7 +65,7 @@ BYTE SkelChamTrans3[] = {
 char *quest_level_names[] = {
 	"",
 	"Skeleton King's Lair",
-	"Bone Chamber",
+	"Chamber of Bone",
 	"Maze",
 	"Poisoned Water Supply",
 	"Archbishop Lazarus' Lair",


### PR DESCRIPTION
This PR renames the "Chamber of Bone" level to match all other references to it in the game for consistency.

This resolves #842