### PR TITLE
Block buying "red" consumables with full inventory

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -580,6 +580,21 @@ void DrawInvBelt()
 	}
 }
 
+/**
+ * @brief Gets the size, in inventory cells, of the given item.
+ * @param item The item whose size is to be determined.
+ * @return The size, in inventory cells, of the item.
+ */
+InvXY GetInventorySize(const ItemStruct &item)
+{
+	int itemSizeIndex = item._iCurs + CURSOR_FIRSTITEM;
+
+	return {
+		InvItemWidth[itemSizeIndex] / INV_SLOT_SIZE_PX,
+		InvItemHeight[itemSizeIndex] / INV_SLOT_SIZE_PX,
+	};
+}
+
 BOOL AutoPlace(int pnum, int ii, int sx, int sy, BOOL saveflag)
 {
 	int i, j, xx, yy;
@@ -635,7 +650,7 @@ BOOL AutoPlace(int pnum, int ii, int sx, int sy, BOOL saveflag)
 	return done;
 }
 
-BOOL SpecialAutoPlace(int pnum, int ii, int sx, int sy)
+BOOL SpecialAutoPlace(int pnum, int ii, const ItemStruct &item)
 {
 	int i, j, xx, yy;
 	BOOL done;
@@ -645,7 +660,9 @@ BOOL SpecialAutoPlace(int pnum, int ii, int sx, int sy)
 	if (yy < 0) {
 		yy = 0;
 	}
-	for (j = 0; j < sy && done; j++) {
+
+	InvXY itemSize = GetInventorySize(item); 
+	for (j = 0; j < itemSize.Y && done; j++) {
 		if (yy >= NUM_INV_GRID_ELEM) {
 			done = FALSE;
 		}
@@ -653,7 +670,7 @@ BOOL SpecialAutoPlace(int pnum, int ii, int sx, int sy)
 		if (xx < 0) {
 			xx = 0;
 		}
-		for (i = 0; i < sx && done; i++) {
+		for (i = 0; i < itemSize.X && done; i++) {
 			if (xx >= 10) {
 				done = FALSE;
 			} else {
@@ -664,7 +681,7 @@ BOOL SpecialAutoPlace(int pnum, int ii, int sx, int sy)
 		yy += 10;
 	}
 	if (!done) {
-		if (sx > 1 || sy > 1) {
+		if (itemSize.X > 1 || itemSize.Y > 1) {
 			done = FALSE;
 		} else {
 			for (i = 0; i < MAXBELTITEMS; i++) {

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -21,7 +21,7 @@ void InitInv();
 void DrawInv();
 void DrawInvBelt();
 BOOL AutoPlace(int pnum, int ii, int sx, int sy, BOOL saveflag);
-BOOL SpecialAutoPlace(int pnum, int ii, int sx, int sy);
+BOOL SpecialAutoPlace(int pnum, int ii, const ItemStruct &item);
 BOOL GoldAutoPlace(int pnum);
 void CheckInvSwap(int pnum, BYTE bLoc, int idx, WORD wCI, int seed, BOOL bId);
 void inv_update_rem_item(int pnum, BYTE iv);

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2270,7 +2270,7 @@ void S_WBuyEnter()
 			done = FALSE;
 
 			for (i = 0; i < NUM_INV_GRID_ELEM && !done; i++) {
-				done = SpecialAutoPlace(myplr, i, cursW / 28, cursH / 28);
+				done = SpecialAutoPlace(myplr, i, plr[myplr].HoldItem);
 			}
 
 			if (done)
@@ -2571,7 +2571,7 @@ void S_HBuyEnter()
 			done = FALSE;
 
 			for (i = 0; i < NUM_INV_GRID_ELEM && !done; i++) {
-				done = SpecialAutoPlace(myplr, i, cursW / 28, cursH / 28);
+				done = SpecialAutoPlace(myplr, i, plr[myplr].HoldItem);
 			}
 
 			if (done)


### PR DESCRIPTION
This fixes a problem that causes items to vanish after being bought from Adria by ensuring the inventory space verification logic uses consistent logic between checking for space before buying, and checking for space when adding the item to the player after purchase.

Right before confirming a purchase, the game performs a thorough check on the player's inventory and belt to see if there is any space left to house the item that will be bought. However, due to a poor guard in the belt verification logic, items that the player cannot currently use due to unmet requirements are still considered as valid candidates for putting the item in the belt: the store then allows the player to purchase the item, but fails when actually adding the item to the player as items with unmet requirements cannot be placed on the belt.

Pepin's store call is also modified for consistency, even though he does not sell any item with stat requirements, and thus would not be affected by the bug today.

This resolves #848