### PR TITLE
Fix entering player's name with SDL 1.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,11 @@ set(devilutionx_SRCS
   Packaging/resources/CharisSILB.ttf
   Packaging/windows/devilutionx.rc)
 
+if(USE_SDL1)
+  list(APPEND devilutionx_SRCS
+    SourceS/sdl2_to_1_2_backports.cpp)
+endif()
+
 if(NOT NONET)
   list(APPEND devilutionx_SRCS
     SourceX/dvlnet/tcp_client.cpp

--- a/SourceS/sdl2_to_1_2_backports.cpp
+++ b/SourceS/sdl2_to_1_2_backports.cpp
@@ -1,0 +1,3 @@
+#include "sdl2_to_1_2_backports.h"
+
+SDL_bool SDLBackport_IsTextInputActive = SDL_FALSE;

--- a/SourceS/sdl2_to_1_2_backports.h
+++ b/SourceS/sdl2_to_1_2_backports.h
@@ -59,7 +59,7 @@ inline void SDL_Log(const char *fmt, ...)
 	puts("");
 }
 
-static SDL_bool SDLBackport_IsTextInputActive = SDL_FALSE;
+extern SDL_bool SDLBackport_IsTextInputActive;
 
 inline SDL_bool SDL_IsTextInputActive()
 {


### PR DESCRIPTION
The static bool means there's one copy of the variable per compilation
unit using the header. So changing its value in one compilation unit
doesn't affect the other compilation units. This is clearly not what is
wanted here.

Fixing this requires adding a CPP in SourceS. This is the first one
there, I hope it's not an issue. The sdl2_to_1_2_backports should only
be used with SDL1 so I only include it in the list of sources for SDL1
builds. I'm not familiar with cmake so I hope I don't do anything stupid
there!