### PR TITLE
Extract valid readied spell logic

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1671,17 +1671,7 @@ void RemoveInvItem(int pnum, int iv)
 
 	CalcPlrScrolls(pnum);
 
-	if (plr[pnum]._pRSplType == RSPLTYPE_SCROLL) {
-		if (plr[pnum]._pRSpell != SPL_INVALID) {
-			if (!(
-			        plr[pnum]._pScrlSpells
-			        & (1ULL << (plr[pnum]._pRSpell - 1)))) {
-				plr[pnum]._pRSpell = SPL_INVALID;
-			}
-
-			force_redraw = 255;
-		}
-	}
+	EnsureValidReadiedSpell(plr[pnum]);
 }
 
 #ifdef HELLFIRE
@@ -1733,15 +1723,7 @@ void RemoveSpdBarItem(int pnum, int iv)
 
 	CalcPlrScrolls(pnum);
 
-	if (plr[pnum]._pRSplType == RSPLTYPE_SCROLL) {
-		if (plr[pnum]._pRSpell != SPL_INVALID) {
-			if (!(
-			        plr[pnum]._pScrlSpells
-			        & (1ULL << (plr[pnum]._pRSpell - 1)))) {
-				plr[pnum]._pRSpell = SPL_INVALID;
-			}
-		}
-	}
+	EnsureValidReadiedSpell(plr[pnum]);
 	force_redraw = 255;
 }
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1673,11 +1673,9 @@ void RemoveInvItem(int pnum, int iv)
 
 	if (plr[pnum]._pRSplType == RSPLTYPE_SCROLL) {
 		if (plr[pnum]._pRSpell != SPL_INVALID) {
-			// BUGFIX: Cast the literal `1` to `unsigned __int64` to make that bitshift 64bit
-			// this causes the last 4 skills to not reset correctly after use
 			if (!(
 			        plr[pnum]._pScrlSpells
-			        & (1 << (plr[pnum]._pRSpell - 1)))) {
+			        & (1ULL << (plr[pnum]._pRSpell - 1)))) {
 				plr[pnum]._pRSpell = SPL_INVALID;
 			}
 
@@ -1737,11 +1735,9 @@ void RemoveSpdBarItem(int pnum, int iv)
 
 	if (plr[pnum]._pRSplType == RSPLTYPE_SCROLL) {
 		if (plr[pnum]._pRSpell != SPL_INVALID) {
-			// BUGFIX: Cast the literal `1` to `unsigned __int64` to make that bitshift 64bit
-			// this causes the last 4 skills to not reset correctly after use
 			if (!(
 			        plr[pnum]._pScrlSpells
-			        & (1 << (plr[pnum]._pRSpell - 1)))) {
+			        & (1ULL << (plr[pnum]._pRSpell - 1)))) {
 				plr[pnum]._pRSpell = SPL_INVALID;
 			}
 		}

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1670,8 +1670,6 @@ void RemoveInvItem(int pnum, int iv)
 	}
 
 	CalcPlrScrolls(pnum);
-
-	EnsureValidReadiedSpell(plr[pnum]);
 }
 
 #ifdef HELLFIRE
@@ -1722,8 +1720,6 @@ void RemoveSpdBarItem(int pnum, int iv)
 	plr[pnum].SpdList[iv]._itype = ITYPE_NONE;
 
 	CalcPlrScrolls(pnum);
-
-	EnsureValidReadiedSpell(plr[pnum]);
 	force_redraw = 255;
 }
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -906,13 +906,7 @@ void CalcPlrItemVals(int p, BOOL Loadgfx)
 
 	plr[p]._pISpells = spl;
 
-	// check if the current RSplType is a valid/allowed spell
-	if (plr[p]._pRSplType == RSPLTYPE_CHARGES
-	    && !(spl & (1ULL << (plr[p]._pRSpell - 1)))) {
-		plr[p]._pRSpell = SPL_INVALID;
-		plr[p]._pRSplType = RSPLTYPE_INVALID;
-		force_redraw = 255;
-	}
+	EnsureValidReadiedSpell(plr[p]);
 
 	plr[p]._pISplLvlAdd = spllvladd;
 	plr[p]._pIEnAc = enac;
@@ -1164,13 +1158,7 @@ void CalcPlrScrolls(int p)
 				plr[p]._pScrlSpells |= 1ULL << (plr[p].SpdList[j]._iSpell - 1);
 		}
 	}
-	if (plr[p]._pRSplType == RSPLTYPE_SCROLL) {
-		if (!(plr[p]._pScrlSpells & 1ULL << (plr[p]._pRSpell - 1))) {
-			plr[p]._pRSpell = SPL_INVALID;
-			plr[p]._pRSplType = RSPLTYPE_INVALID;
-			force_redraw = 255;
-		}
-	}
+	EnsureValidReadiedSpell(plr[p]);
 }
 
 void CalcPlrStaff(int p)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -908,7 +908,7 @@ void CalcPlrItemVals(int p, BOOL Loadgfx)
 
 	// check if the current RSplType is a valid/allowed spell
 	if (plr[p]._pRSplType == RSPLTYPE_CHARGES
-	    && !(spl & ((unsigned __int64)1 << (plr[p]._pRSpell - 1)))) {
+	    && !(spl & (1ULL << (plr[p]._pRSpell - 1)))) {
 		plr[p]._pRSpell = SPL_INVALID;
 		plr[p]._pRSplType = RSPLTYPE_INVALID;
 		force_redraw = 255;
@@ -1154,18 +1154,18 @@ void CalcPlrScrolls(int p)
 	for (i = 0; i < plr[p]._pNumInv; i++) {
 		if (plr[p].InvList[i]._itype != ITYPE_NONE && (plr[p].InvList[i]._iMiscId == IMISC_SCROLL || plr[p].InvList[i]._iMiscId == IMISC_SCROLLT)) {
 			if (plr[p].InvList[i]._iStatFlag)
-				plr[p]._pScrlSpells |= (__int64)1 << (plr[p].InvList[i]._iSpell - 1);
+				plr[p]._pScrlSpells |= 1ULL << (plr[p].InvList[i]._iSpell - 1);
 		}
 	}
 
 	for (j = 0; j < MAXBELTITEMS; j++) {
 		if (plr[p].SpdList[j]._itype != ITYPE_NONE && (plr[p].SpdList[j]._iMiscId == IMISC_SCROLL || plr[p].SpdList[j]._iMiscId == IMISC_SCROLLT)) {
 			if (plr[p].SpdList[j]._iStatFlag)
-				plr[p]._pScrlSpells |= (__int64)1 << (plr[p].SpdList[j]._iSpell - 1);
+				plr[p]._pScrlSpells |= 1ULL << (plr[p].SpdList[j]._iSpell - 1);
 		}
 	}
 	if (plr[p]._pRSplType == RSPLTYPE_SCROLL) {
-		if (!(plr[p]._pScrlSpells & 1 << (plr[p]._pRSpell - 1))) {
+		if (!(plr[p]._pScrlSpells & 1ULL << (plr[p]._pRSpell - 1))) {
 			plr[p]._pRSpell = SPL_INVALID;
 			plr[p]._pRSplType = RSPLTYPE_INVALID;
 			force_redraw = 255;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3188,23 +3188,7 @@ BOOL PM_DoSpell(int pnum)
 		    plr[pnum]._pVar4);
 
 		if (!plr[pnum]._pSplFrom) {
-			if (plr[pnum]._pRSplType == RSPLTYPE_SCROLL) {
-				if (!(plr[pnum]._pScrlSpells
-				        & 1ULL << (plr[pnum]._pRSpell - 1))) {
-					plr[pnum]._pRSpell = SPL_INVALID;
-					plr[pnum]._pRSplType = RSPLTYPE_INVALID;
-					force_redraw = 255;
-				}
-			}
-
-			if (plr[pnum]._pRSplType == RSPLTYPE_CHARGES) {
-				if (!(plr[pnum]._pISpells
-				        & 1ULL << (plr[pnum]._pRSpell - 1))) {
-					plr[pnum]._pRSpell = SPL_INVALID;
-					plr[pnum]._pRSplType = RSPLTYPE_INVALID;
-					force_redraw = 255;
-				}
-			}
+			EnsureValidReadiedSpell(plr[pnum]);
 		}
 	}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3190,7 +3190,7 @@ BOOL PM_DoSpell(int pnum)
 		if (!plr[pnum]._pSplFrom) {
 			if (plr[pnum]._pRSplType == RSPLTYPE_SCROLL) {
 				if (!(plr[pnum]._pScrlSpells
-				        & (unsigned __int64)1 << (plr[pnum]._pRSpell - 1))) {
+				        & 1ULL << (plr[pnum]._pRSpell - 1))) {
 					plr[pnum]._pRSpell = SPL_INVALID;
 					plr[pnum]._pRSplType = RSPLTYPE_INVALID;
 					force_redraw = 255;
@@ -3199,7 +3199,7 @@ BOOL PM_DoSpell(int pnum)
 
 			if (plr[pnum]._pRSplType == RSPLTYPE_CHARGES) {
 				if (!(plr[pnum]._pISpells
-				        & (unsigned __int64)1 << (plr[pnum]._pRSpell - 1))) {
+				        & 1ULL << (plr[pnum]._pRSpell - 1))) {
 					plr[pnum]._pRSpell = SPL_INVALID;
 					plr[pnum]._pRSplType = RSPLTYPE_INVALID;
 					force_redraw = 255;

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -139,21 +139,15 @@ bool IsReadiedSpellValid(const PlayerStruct &player)
  */
 void ClearReadiedSpell(PlayerStruct &player)
 {
-	bool needsRedraw = false;
-
 	int &readiedSpell = player._pRSpell;
 	if (readiedSpell != SPL_INVALID) {
 		readiedSpell = SPL_INVALID;
-		needsRedraw = true;
+		force_redraw = 255;
 	}
 
 	char &readiedSpellType = player._pRSplType;
 	if (readiedSpellType != RSPLTYPE_INVALID) {
 		readiedSpellType = RSPLTYPE_INVALID;
-		needsRedraw = true;
-	}
-
-	if (needsRedraw) {
 		force_redraw = 255;
 	}
 }

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -15,6 +15,7 @@ extern "C" {
 int GetManaAmount(int id, int sn);
 void UseMana(int id, int sn);
 BOOL CheckSpell(int id, int sn, char st, BOOL manaonly);
+void EnsureValidReadiedSpell(PlayerStruct &player);
 void CastSpell(int id, int spl, int sx, int sy, int dx, int dy, int caster, int spllvl);
 void DoResurrect(int pnum, int rid);
 void DoHealOther(int pnum, int rid);


### PR DESCRIPTION
This includes a few changes related to how the player's readied spell is validated. It extracts common logic into `spells.cpp`, simplifies the logic a little bit and adds some documentation around the behavior.