### PR TITLE
Fix keyboard not working for non-Switch in menu

### DIFF
--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -92,6 +92,7 @@ void UiInitList(int min, int max, void (*fnFocus)(int value), void (*fnSelect)(i
 	textInputActive = false;
 	for (int i = 0; i < itemCnt; i++) {
 		if (items[i].type == UI_EDIT) {
+			textInputActive = true;
 #ifdef __SWITCH__
 			switch_start_text_input(items[i - 1].art_text.text, items[i].edit.value, /*multiline=*/0);
 #else


### PR DESCRIPTION
Fixes #869

This was missed when backporting Switch Keyboard fix in
3ef2228d859ef26c0b4a9f14ae8b0c97516e2260