### PR TITLE
Handle DragonFly BSD in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ elseif(TARGET_PLATFORM STREQUAL "cpigamesh")
   include(cpigamesh_defs)
 endif()
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL FreeBSD OR ${CMAKE_SYSTEM_NAME} STREQUAL OpenBSD)
+if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD|OpenBSD|DragonFly")
   set(ASAN OFF)
   set(UBSAN OFF)
   add_definitions(-D_BSD_SOURCE)


### PR DESCRIPTION
Using Ravenports, devilutionX has been available on DragonFly BSD, too, for a while now. This proposed change would allow us to drop one local compatibility patch.