### PR TITLE
Add a possibility to select SDL audio device other than default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,6 +493,9 @@ foreach(target devilution ${BIN_TARGET} SourceS)
       ${SDL_LIBRARY})
     target_compile_definitions(${target} PRIVATE USE_SDL1)
   else()
+    if(SDL2_mixerPC_VERSION VERSION_GREATER_EQUAL 2.0.2)
+      target_compile_definitions(${target} PRIVATE SDL2_MIXER_VERSION_AT_LEAST_2_0_2)
+    endif()
     target_link_libraries(${target} PRIVATE
       SDL2::SDL2main
       SDL2::SDL2_ttf

--- a/SourceX/sound.cpp
+++ b/SourceX/sound.cpp
@@ -6,6 +6,7 @@
 #include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include "stubs.h"
+#include "DiabloUI/diabloui.h"
 #include <SDL.h>
 #include <SDL_mixer.h>
 
@@ -165,7 +166,23 @@ void snd_init(HWND hWnd)
 	snd_get_volume("Music Volume", &sglMusicVolume);
 	gbMusicOn = sglMusicVolume > VOLUME_MIN;
 
+	int audio_device = 0;
+	DvlIntSetting("audio device", &audio_device);
+#ifdef USE_SDL1
+	if (audio_device != 0) {
+		SDL_Log("Audio device other than default not supported with USE_SDL1");
+	}
 	int result = Mix_OpenAudio(22050, AUDIO_S16LSB, 2, 1024);
+#else
+#ifdef SDL2_MIXER_VERSION_AT_LEAST_2_0_2
+	int result = Mix_OpenAudioDevice(22050, AUDIO_S16LSB, 2, 1024, SDL_GetAudioDeviceName(audio_device, 0), SDL_AUDIO_ALLOW_ANY_CHANGE);
+#else
+	if (audio_device != 0) {
+		SDL_Log("Audio device other than default not supported with SDL2_MIXER version older than 2.0.2");
+	}
+	int result = Mix_OpenAudio(22050, AUDIO_S16LSB, 2, 1024);
+#endif
+#endif
 	if (result < 0) {
 		SDL_Log(Mix_GetError());
 	}


### PR DESCRIPTION
Currently devilutionx is using SDL_OpenAudioDevice with first parameter set as NULL which makes it always default to audio device 0. Same behaviour is with Mix_OpenAudio that under the hood does the same.

This PR allows to override this setting to allow playback on other audio devices. E.g. in my use case is the HDMI output of my monitor has id=4.

(use "aplay -l" to list the audio devices in Linux)

I hope it does not break anything but I did only limited testing on Debian due to lack of time. I still think this is a useful feature to add.