### PR TITLE
fix saves in x64-release

### DIFF
--- a/Source/sha.cpp
+++ b/Source/sha.cpp
@@ -17,12 +17,15 @@ namespace {
 /**
  * Diablo-"SHA1" circular left shift, portable version.
  */
-uint32_t SHA1CircularShift(uint32_t bits, uint32_t word) {
+uint32_t SHA1CircularShift(uint32_t bits, uint32_t word)
+{
 	assert(bits < 32);
 	assert(bits > 0);
 
-	if(word >> 31) {
-		return (word << bits) | (~((~word) >> (32 - bits)));
+	if (word >> 31) {
+		//moving this part to a separate volatile variable fixes saves in x64-release build in visual studio 2017
+		volatile uint32_t tmp = ((~word) >> (32 - bits));
+		return (word << bits) | (~tmp);
 	} else {
 		return (word << bits) | (word >> (32 - bits));
 	}


### PR DESCRIPTION
Fixes saves in x64-Release in visual studio 2017 (and older?) - it worked properly in vs2019, hopefully this fix makes it work in the cases where it didn't and doesn't affect when it did xD