### PR TITLE
Fix potential overflow in use of strcpy #906

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -589,7 +589,7 @@ void AddPanelString(const char *str, BOOL just)
 	strcpy(panelstr[pnumlines], str);
 	pstrjust[pnumlines] = just;
 
-	if (pnumlines < 4)
+	if (pnumlines < 5)
 		pnumlines++;
 }
 


### PR DESCRIPTION
Tested on Arch Linux with standard CPPFLAGS