### PR TITLE
Controller: Fix L2/R2 handling

### DIFF
--- a/SourceX/controls/controller.h
+++ b/SourceX/controls/controller.h
@@ -9,6 +9,8 @@ struct ControllerButtonEvent {
 	bool up;
 };
 
+// NOTE: Not idempotent because of how it handles axis triggers.
+// Must be called exactly once per SDL input event.
 ControllerButtonEvent ToControllerButtonEvent(const SDL_Event &event);
 
 bool IsControllerButtonPressed(ControllerButton button);

--- a/SourceX/controls/controller_motion.cpp
+++ b/SourceX/controls/controller_motion.cpp
@@ -56,10 +56,9 @@ void ScaleJoystickAxes(float *x, float *y, float deadzone)
 }
 
 // SELECT + D-Pad to simulate right stick movement.
-bool SimulateRightStickWithDpad(const SDL_Event &event)
+bool SimulateRightStickWithDpad(const SDL_Event &event, ControllerButtonEvent ctrl_event)
 {
 	static bool simulating = false;
-	const ControllerButtonEvent ctrl_event = ToControllerButtonEvent(event);
 	if (ctrl_event.button == ControllerButton_BUTTON_BACK) {
 		if (ctrl_event.up && simulating) {
 			rightStickX = rightStickY = 0;
@@ -121,7 +120,7 @@ void ScaleJoysticks()
 } // namespace
 
 // Updates motion state for mouse and joystick sticks.
-bool ProcessControllerMotion(const SDL_Event &event)
+bool ProcessControllerMotion(const SDL_Event &event, ControllerButtonEvent ctrl_event)
 {
 #ifndef USE_SDL1
 	if (ProcessGameControllerAxisMotion(event)) {
@@ -137,7 +136,7 @@ bool ProcessControllerMotion(const SDL_Event &event)
 	if (ProcessKbCtrlAxisMotion(event))
 		return true;
 #endif
-	return SimulateRightStickWithDpad(event);
+	return SimulateRightStickWithDpad(event, ctrl_event);
 }
 
 } // namespace dvl

--- a/SourceX/controls/controller_motion.h
+++ b/SourceX/controls/controller_motion.h
@@ -3,6 +3,7 @@
 // Processes and stores mouse and joystick motion.
 
 #include "all.h"
+#include "controls/controller.h"
 
 namespace dvl {
 
@@ -16,6 +17,6 @@ extern float leftStickX, leftStickY, rightStickX, rightStickY;
 extern bool leftStickNeedsScaling, rightStickNeedsScaling;
 
 // Updates motion state for mouse and joystick sticks.
-bool ProcessControllerMotion(const SDL_Event &event);
+bool ProcessControllerMotion(const SDL_Event &event, ControllerButtonEvent ctrl_event);
 
 } // namespace dvl

--- a/SourceX/controls/game_controls.cpp
+++ b/SourceX/controls/game_controls.cpp
@@ -88,9 +88,8 @@ bool HandleStartAndSelect(const ControllerButtonEvent &ctrl_event, GameAction *a
 
 } // namespace
 
-bool GetGameAction(const SDL_Event &event, GameAction *action)
+bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrl_event, GameAction *action)
 {
-	const ControllerButtonEvent ctrl_event = ToControllerButtonEvent(event);
 	const bool in_game_menu = InGameMenu();
 
 	if (HandleStartAndSelect(ctrl_event, action))

--- a/SourceX/controls/game_controls.h
+++ b/SourceX/controls/game_controls.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "all.h"
+#include "controls/controller.h"
 
 namespace dvl {
 
@@ -65,7 +66,7 @@ struct GameAction {
 	};
 };
 
-bool GetGameAction(const SDL_Event &event, GameAction *action);
+bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrl_event, GameAction *action);
 
 enum MoveDirectionX {
 	MoveDirectionX_NONE = 0,

--- a/SourceX/miniwin/misc_msg.cpp
+++ b/SourceX/miniwin/misc_msg.cpp
@@ -337,10 +337,12 @@ bool PeekMessage(LPMSG lpMsg)
 		return true;
 	}
 
-	if (ProcessControllerMotion(e)) return true;
+	const ControllerButtonEvent ctrl_event = ToControllerButtonEvent(e);
+	if (ProcessControllerMotion(e, ctrl_event))
+		return true;
 
 	GameAction action;
-	if (GetGameAction(e, &action)) {
+	if (GetGameAction(e, ctrl_event, &action)) {
 		if (action.type != GameActionType_NONE) {
 			sgbControllerActive = true;
 


### PR DESCRIPTION
Broken in https://github.com/diasurgical/devilutionX/commit/01401a16c70213db7a9a84196dee354a2ebc11a3

`ToControllerButtonEvent` must only be called once per SDL event because of how it handles L2/R2