### PR TITLE
Preserve cursor position on vendors

### DIFF
--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -1962,7 +1962,11 @@ void TakePlrsMoney(int cost)
 	}
 }
 
-void SmithBuyItem()
+/**
+ * @brief Purchases an item from the smith and returns the index into the vendors inventory where the item was purchased from.
+ * @return A zero-based index into the vendor's inventory where the purchased item was.
+ */
+int SmithBuyItem()
 {
 	int idx;
 
@@ -1971,6 +1975,7 @@ void SmithBuyItem()
 		plr[myplr].HoldItem._iIdentified = FALSE;
 	StoreAutoPlace();
 	idx = stextvhold + ((stextlhold - stextup) >> 2);
+	int purchasedItemIndex = idx;
 	if (idx == SMITH_ITEMS - 1) {
 		smithitem[SMITH_ITEMS - 1]._itype = ITYPE_NONE;
 	} else {
@@ -1980,6 +1985,8 @@ void SmithBuyItem()
 		smithitem[idx]._itype = ITYPE_NONE;
 	}
 	CalcPlrInv(myplr, TRUE);
+
+	return purchasedItemIndex;
 }
 
 void S_SBuyEnter()
@@ -2014,7 +2021,11 @@ void S_SBuyEnter()
 	}
 }
 
-void SmithBuyPItem()
+/**
+ * @brief Purchases a premium item from the smith and returns the index into the vendors inventory where the item was purchased from.
+ * @return A zero-based index into the vendor's inventory where the purchased item was.
+ */
+int SmithBuyPItem()
 {
 	int i, xx, idx;
 
@@ -2024,6 +2035,7 @@ void SmithBuyPItem()
 	StoreAutoPlace();
 
 	idx = stextvhold + ((stextlhold - stextup) >> 2);
+	int purchasedItemIndex = idx;
 	xx = 0;
 	for (i = 0; idx >= 0; i++) {
 		if (premiumitem[i]._itype != ITYPE_NONE) {
@@ -2039,6 +2051,8 @@ void SmithBuyPItem()
 #else
 	SpawnPremium(plr[myplr]._pLevel);
 #endif
+
+	return purchasedItemIndex;
 }
 
 void S_SPBuyEnter()
@@ -2539,7 +2553,7 @@ void S_ConfirmEnter()
 		int itemIndex = 0;
 		switch (stextshold) {
 		case STORE_SBUY:
-			SmithBuyItem();
+			itemIndex = SmithBuyItem();
 			break;
 		case STORE_SSELL:
 		case STORE_WSELL:
@@ -2565,7 +2579,7 @@ void S_ConfirmEnter()
 			StartStore(STORE_IDSHOW);
 			return;
 		case STORE_SPBUY:
-			SmithBuyPItem();
+			itemIndex = SmithBuyPItem();
 			break;
 		}
 		StartStore(stextshold);

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2387,7 +2387,12 @@ void S_WSellEnter()
 	}
 }
 
-void WitchRechargeItem()
+/**
+ * @brief Recharges an item in the player's inventory or body in the witch and returns the index into the vendors inventory where
+ * the item was recharged from.
+ * @return A zero-based index into the vendor's inventory where the recharged item was.
+ */
+int WitchRechargeItem()
 {
 	int i, idx;
 
@@ -2403,6 +2408,8 @@ void WitchRechargeItem()
 		plr[myplr].InvList[i]._iCharges = plr[myplr].InvList[i]._iMaxCharges;
 
 	CalcPlrInv(myplr, TRUE);
+
+	return idx;
 }
 
 void S_WRechargeEnter()
@@ -2587,7 +2594,7 @@ void S_ConfirmEnter()
 			itemIndex = WitchBuyItem();
 			break;
 		case STORE_WRECHARGE:
-			WitchRechargeItem();
+			itemIndex = WitchRechargeItem();
 			break;
 		case STORE_BBOY:
 			BoyBuyItem();

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -1776,9 +1776,12 @@ void STextUp()
 	}
 }
 
-void STextDown()
+void STextDown(bool playSound)
 {
-	PlaySFX(IS_TITLEMOV);
+	if (playSound) {
+		PlaySFX(IS_TITLEMOV);
+	}
+
 	if (stextsel == -1) {
 		return;
 	}
@@ -2420,7 +2423,11 @@ void BoyBuyItem()
 	CalcPlrInv(myplr, TRUE);
 }
 
-void HealerBuyItem()
+/**
+ * @brief Purchases an item from the healer and returns the index into the vendors inventory where the item was purchased from.
+ * @return A zero-based index into the vendor's inventory where the purchased item was.
+ */
+int HealerBuyItem()
 {
 	int idx;
 
@@ -2438,12 +2445,13 @@ void HealerBuyItem()
 		plr[myplr].HoldItem._iIdentified = FALSE;
 	StoreAutoPlace();
 
+	int purchasedItemIndex = idx;
 	if (gbMaxPlayers == 1) {
 		if (idx < 2)
-			return;
+			return purchasedItemIndex;
 	} else {
 		if (idx < 3)
-			return;
+			return purchasedItemIndex;
 	}
 	idx = stextvhold + ((stextlhold - stextup) >> 2);
 	if (idx == 19) {
@@ -2455,6 +2463,8 @@ void HealerBuyItem()
 		healitem[idx]._itype = ITYPE_NONE;
 	}
 	CalcPlrInv(myplr, TRUE);
+
+	return purchasedItemIndex;
 }
 
 void S_BBuyEnter()
@@ -2526,6 +2536,7 @@ void StoryIdItem()
 void S_ConfirmEnter()
 {
 	if (stextsel == 18) {
+		int itemIndex = 0;
 		switch (stextshold) {
 		case STORE_SBUY:
 			SmithBuyItem();
@@ -2547,7 +2558,7 @@ void S_ConfirmEnter()
 			BoyBuyItem();
 			break;
 		case STORE_HBUY:
-			HealerBuyItem();
+			itemIndex = HealerBuyItem();
 			break;
 		case STORE_SIDENTIFY:
 			StoryIdItem();
@@ -2558,6 +2569,9 @@ void S_ConfirmEnter()
 			break;
 		}
 		StartStore(stextshold);
+		for (int i = 0; i < itemIndex; i++) {
+			STextDown(false);
+		}
 	} else {
 		StartStore(stextshold);
 		stextsel = stextlhold;

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2285,11 +2285,16 @@ void S_WitchEnter()
 	}
 }
 
-void WitchBuyItem()
+/**
+ * @brief Purchases an item from the witch and returns the index into the vendors inventory where the item was purchased from.
+ * @return A zero-based index into the vendor's inventory where the purchased item was.
+ */
+int WitchBuyItem()
 {
 	int idx;
 
 	idx = stextvhold + ((stextlhold - stextup) >> 2);
+	int purchasedItemIndex = idx;
 
 	if (idx < 3)
 		plr[myplr].HoldItem._iSeed = GetRndSeed();
@@ -2309,6 +2314,8 @@ void WitchBuyItem()
 	}
 
 	CalcPlrInv(myplr, TRUE);
+
+	return purchasedItemIndex;
 }
 
 void S_WBuyEnter()
@@ -2563,7 +2570,7 @@ void S_ConfirmEnter()
 			SmithRepairItem();
 			break;
 		case STORE_WBUY:
-			WitchBuyItem();
+			itemIndex = WitchBuyItem();
 			break;
 		case STORE_WRECHARGE:
 			WitchRechargeItem();

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2222,7 +2222,12 @@ void S_SSellEnter()
 	}
 }
 
-void SmithRepairItem()
+/**
+ * @brief Repairs an item in the player's inventory or body in the smith and returns the index into the vendors inventory where
+ * the item was repaired from.
+ * @return A zero-based index into the vendor's inventory where the repaired item was.
+ */
+int SmithRepairItem()
 {
 	int i, idx;
 
@@ -2244,6 +2249,8 @@ void SmithRepairItem()
 	} else {
 		plr[myplr].InvList[i]._iDurability = plr[myplr].InvList[i]._iMaxDur;
 	}
+
+	return idx;
 }
 
 void S_SRepairEnter()
@@ -2574,7 +2581,7 @@ void S_ConfirmEnter()
 			itemIndex = StoreSellItem();
 			break;
 		case STORE_SREPAIR:
-			SmithRepairItem();
+			itemIndex = SmithRepairItem();
 			break;
 		case STORE_WBUY:
 			itemIndex = WitchBuyItem();

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2153,11 +2153,16 @@ void PlaceStoreGold(int v)
 	}
 }
 
-void StoreSellItem()
+/**
+ * @brief Sells an item from the player's inventory or belt and returns the index into the vendors inventory where the item was sold from.
+ * @return A zero-based index into the vendor's inventory where the sold item was.
+ */
+int StoreSellItem()
 {
 	int i, idx, cost;
 
 	idx = stextvhold + ((stextlhold - stextup) >> 2);
+	int soldItemIndex = idx;
 	if (storehidx[idx] >= 0)
 		RemoveInvItem(myplr, storehidx[idx]);
 	else
@@ -2192,6 +2197,8 @@ void StoreSellItem()
 		}
 		PlaceStoreGold(cost);
 	}
+
+	return soldItemIndex;
 }
 
 void S_SSellEnter()
@@ -2564,7 +2571,7 @@ void S_ConfirmEnter()
 			break;
 		case STORE_SSELL:
 		case STORE_WSELL:
-			StoreSellItem();
+			itemIndex = StoreSellItem();
 			break;
 		case STORE_SREPAIR:
 			SmithRepairItem();

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -44,7 +44,7 @@ void StartStore(char s);
 void DrawSText();
 void STextESC();
 void STextUp();
-void STextDown();
+void STextDown(bool playSound = true);
 void STextPrior();
 void STextNext();
 void SetGoldCurs(int pnum, int i);


### PR DESCRIPTION
This PR adds a new behavior to all vendors so that the cursor position is preserved when interacting with them.

This affects the following actions:
- Buying items (Adria, Pepin and Griswold. Wirt is not affected since he only sells 1 item)
- Selling items (Adria and Griswold)
- Repairing items
- Recharging items

The implementation was done in a noninvasive manner, by manually scrolling the vendor sections back to the previously interacted with item index. This is a less than ideal solution but I feel other approaches would require significant refactoring at this point, as the vendor logic is extremely convoluted.

This should dramatically improve the user experience when purchasing and selling items from my experience.

Resolves #937