### PR TITLE
Update CMakeLists.txt: FreeBSD specific POSIX extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -528,7 +528,7 @@ if(WIN32)
   endif()
 endif()
 
-if(NOT WIN32 AND NOT APPLE)
+if(NOT WIN32 AND NOT APPLE AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL FreeBSD)
   # Enable POSIX extensions such as `readlink` and `ftruncate`.
   add_definitions(-D_POSIX_C_SOURCE=200809L)
 endif()


### PR DESCRIPTION
FreeBSD specific # Enable POSIX extensions such as `readlink` and `ftruncate`.

Without it doesn't build:
https://termbin.com/duv8

Right now, this is the only patch needed to build devilutionX successfully on FBSD (rest of patches are just cmake tweaks, install paths, etc)

Thanks,

Nuno Teixeira