### PR TITLE
`RenderLine()` function fix for issue #941

### DIFF
--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -179,7 +179,8 @@ inline static void RenderLine(BYTE **dst, BYTE **src, int n, BYTE *tbl, DWORD ma
 		// So we can limit it by ANDing the mask with another mask that only keeps
 		// iterations that are lower than n. We can now avoid testing if i < n
 		// at every loop iteration.
-		mask &= ((((DWORD)1) << n) - 1) << ((sizeof(DWORD) * CHAR_BIT) - n);
+		assert(n != 0 && n <= sizeof(DWORD) * CHAR_BIT);
+		k &= DWORD(-1) << ((sizeof(DWORD) * CHAR_BIT) - n);
 
 		if (light_table_index == lightmax) {
 			foreach_set_bit(mask, [=] (int i) { (*dst)[i] = 0; });

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -188,7 +188,7 @@ inline static void RenderLine(BYTE **dst, BYTE **src, int n, BYTE *tbl, DWORD ma
 		// iterations that are lower than n. We can now avoid testing if i < n
 		// at every loop iteration.
 		assert(n != 0 && n <= sizeof(DWORD) * CHAR_BIT);
-		k &= DWORD(-1) << ((sizeof(DWORD) * CHAR_BIT) - n);
+		mask &= DWORD(-1) << ((sizeof(DWORD) * CHAR_BIT) - n);
 
 		if (light_table_index == lightmax) {
 			foreach_set_bit(mask, [=] (int i) { (*dst)[i] = 0; });

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -134,14 +134,22 @@ static DWORD LeftFoliageMask[TILE_HEIGHT] = {
 };
 
 inline static int count_leading_zeros(DWORD mask) {
-	// Note: This assumes that the argument is not zero,
+	// Note: This function assumes that the argument is not zero,
 	// which means there is at least one bit set.
+	static_assert(
+		sizeof(DWORD) == sizeof(uint32_t),
+		"count_leading_zeros: DWORD must be 32bits");
 #if defined(__GNUC__) || defined(__clang__)
 	return __builtin_clz(mask);
 #else
-	int i;
-	for (i = 0; (mask & 0x80000000) == 0; i++, mask <<= 1);
-	return i;
+	// Count the number of leading zeros using binary search.
+	int n = 0;
+	if ((mask & 0xFFFF0000) == 0) n += 16, mask <<= 16;
+	if ((mask & 0xFF000000) == 0) n +=  8, mask <<=  8;
+	if ((mask & 0xF0000000) == 0) n +=  4, mask <<=  4;
+	if ((mask & 0xC0000000) == 0) n +=  2, mask <<=  2;
+	if ((mask & 0x80000000) == 0) n +=  1;
+	return n;
 #endif
 }
 


### PR DESCRIPTION
This should fix issue #941, and introduce compile-time and runtime checks for corner cases. The fallback for `count_leading_zeros` when the compiler is not gcc or clang has also been improved using binary search.