### PR TITLE
Add key to stop walking and cancel pending actions

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2240,6 +2240,11 @@ void initKeymapActions()
 	    },
 	});
 #endif
+	keymapper.addAction({
+		"StopHero",
+		DVL_VK_INVALID,
+		[] { plr[myplr].Stop(); },
+	});
 }
 
 } // namespace devilution

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4078,7 +4078,7 @@ void UseItem(int p, item_misc_id Mid, spell_id spl)
 			if (p == myplr)
 				NewCursor(CURSOR_TELEPORT);
 		} else {
-			ClrPlrPath(p);
+			ClrPlrPath(&plr[p]);
 			plr[p]._pSpell = spl;
 			plr[p]._pSplType = RSPLTYPE_INVALID;
 			plr[p]._pSplFrom = 3;
@@ -4096,7 +4096,7 @@ void UseItem(int p, item_misc_id Mid, spell_id spl)
 			if (p == myplr)
 				NewCursor(CURSOR_TELEPORT);
 		} else {
-			ClrPlrPath(p);
+			ClrPlrPath(&plr[p]);
 			plr[p]._pSpell = spl;
 			plr[p]._pSplType = RSPLTYPE_INVALID;
 			plr[p]._pSplFrom = 3;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -4220,7 +4220,7 @@ void MI_Town(int i)
 
 	for (p = 0; p < MAX_PLRS; p++) {
 		if (plr[p].plractive && currlevel == plr[p].plrlevel && !plr[p]._pLvlChanging && plr[p]._pmode == PM_STAND && plr[p].position.tile == missile[i].position.tile) {
-			ClrPlrPath(p);
+			ClrPlrPath(&plr[p]);
 			if (p == myplr) {
 				NetSendCmdParam1(true, CMD_WARP, missile[i]._misource);
 				plr[p]._pmode = PM_NEWLVL;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1317,7 +1317,7 @@ static DWORD On_WALKXY(TCmd *pCmd, int pnum)
 	auto *p = (TCmdLoc *)pCmd;
 
 	if (gbBufferMsgs != 1 && currlevel == plr[pnum].plrlevel) {
-		ClrPlrPath(pnum);
+		ClrPlrPath(&plr[pnum]);
 		MakePlrPath(pnum, p->x, p->y, true);
 		plr[pnum].destAction = ACTION_NONE;
 	}
@@ -1616,7 +1616,7 @@ static DWORD On_SATTACKXY(TCmd *pCmd, int pnum)
 	auto *p = (TCmdLoc *)pCmd;
 
 	if (gbBufferMsgs != 1 && currlevel == plr[pnum].plrlevel) {
-		ClrPlrPath(pnum);
+		ClrPlrPath(&plr[pnum]);
 		plr[pnum].destAction = ACTION_ATTACK;
 		plr[pnum].destParam1 = p->x;
 		plr[pnum].destParam2 = p->y;
@@ -1630,7 +1630,7 @@ static DWORD On_RATTACKXY(TCmd *pCmd, int pnum)
 	auto *p = (TCmdLoc *)pCmd;
 
 	if (gbBufferMsgs != 1 && currlevel == plr[pnum].plrlevel) {
-		ClrPlrPath(pnum);
+		ClrPlrPath(&plr[pnum]);
 		plr[pnum].destAction = ACTION_RATTACK;
 		plr[pnum].destParam1 = p->x;
 		plr[pnum].destParam2 = p->y;
@@ -1646,7 +1646,7 @@ static DWORD On_SPELLXYD(TCmd *pCmd, int pnum)
 	if (gbBufferMsgs != 1 && currlevel == plr[pnum].plrlevel) {
 		auto spell = static_cast<spell_id>(p->wParam1);
 		if (currlevel != 0 || spelldata[spell].sTownSpell) {
-			ClrPlrPath(pnum);
+			ClrPlrPath(&plr[pnum]);
 			plr[pnum].destAction = ACTION_SPELLWALL;
 			plr[pnum].destParam1 = p->x;
 			plr[pnum].destParam2 = p->y;
@@ -1669,7 +1669,7 @@ static DWORD On_SPELLXY(TCmd *pCmd, int pnum)
 	if (gbBufferMsgs != 1 && currlevel == plr[pnum].plrlevel) {
 		auto spell = static_cast<spell_id>(p->wParam1);
 		if (currlevel != 0 || spelldata[spell].sTownSpell) {
-			ClrPlrPath(pnum);
+			ClrPlrPath(&plr[pnum]);
 			plr[pnum].destAction = ACTION_SPELL;
 			plr[pnum].destParam1 = p->x;
 			plr[pnum].destParam2 = p->y;
@@ -1691,7 +1691,7 @@ static DWORD On_TSPELLXY(TCmd *pCmd, int pnum)
 	if (gbBufferMsgs != 1 && currlevel == plr[pnum].plrlevel) {
 		auto spell = static_cast<spell_id>(p->wParam1);
 		if (currlevel != 0 || spelldata[spell].sTownSpell) {
-			ClrPlrPath(pnum);
+			ClrPlrPath(&plr[pnum]);
 			plr[pnum].destAction = ACTION_SPELL;
 			plr[pnum].destParam1 = p->x;
 			plr[pnum].destParam2 = p->y;
@@ -1784,7 +1784,7 @@ static DWORD On_RATTACKID(TCmd *pCmd, int pnum)
 	auto *p = (TCmdParam1 *)pCmd;
 
 	if (gbBufferMsgs != 1 && currlevel == plr[pnum].plrlevel) {
-		ClrPlrPath(pnum);
+		ClrPlrPath(&plr[pnum]);
 		plr[pnum].destAction = ACTION_RATTACKMON;
 		plr[pnum].destParam1 = p->wParam1;
 	}
@@ -1797,7 +1797,7 @@ static DWORD On_RATTACKPID(TCmd *pCmd, int pnum)
 	auto *p = (TCmdParam1 *)pCmd;
 
 	if (gbBufferMsgs != 1 && currlevel == plr[pnum].plrlevel) {
-		ClrPlrPath(pnum);
+		ClrPlrPath(&plr[pnum]);
 		plr[pnum].destAction = ACTION_RATTACKPLR;
 		plr[pnum].destParam1 = p->wParam1;
 	}
@@ -1812,7 +1812,7 @@ static DWORD On_SPELLID(TCmd *pCmd, int pnum)
 	if (gbBufferMsgs != 1 && currlevel == plr[pnum].plrlevel) {
 		auto spell = static_cast<spell_id>(p->wParam2);
 		if (currlevel != 0 || spelldata[spell].sTownSpell) {
-			ClrPlrPath(pnum);
+			ClrPlrPath(&plr[pnum]);
 			plr[pnum].destAction = ACTION_SPELLMON;
 			plr[pnum].destParam1 = p->wParam1;
 			plr[pnum].destParam2 = p->wParam3;
@@ -1833,7 +1833,7 @@ static DWORD On_SPELLPID(TCmd *pCmd, int pnum)
 	if (gbBufferMsgs != 1 && currlevel == plr[pnum].plrlevel) {
 		auto spell = static_cast<spell_id>(p->wParam2);
 		if (currlevel != 0 || spelldata[spell].sTownSpell) {
-			ClrPlrPath(pnum);
+			ClrPlrPath(&plr[pnum]);
 			plr[pnum].destAction = ACTION_SPELLPLR;
 			plr[pnum].destParam1 = p->wParam1;
 			plr[pnum].destParam2 = p->wParam3;
@@ -1854,7 +1854,7 @@ static DWORD On_TSPELLID(TCmd *pCmd, int pnum)
 	if (gbBufferMsgs != 1 && currlevel == plr[pnum].plrlevel) {
 		auto spell = static_cast<spell_id>(p->wParam2);
 		if (currlevel != 0 || spelldata[spell].sTownSpell) {
-			ClrPlrPath(pnum);
+			ClrPlrPath(&plr[pnum]);
 			plr[pnum].destAction = ACTION_SPELLMON;
 			plr[pnum].destParam1 = p->wParam1;
 			plr[pnum].destParam2 = p->wParam3;
@@ -1875,7 +1875,7 @@ static DWORD On_TSPELLPID(TCmd *pCmd, int pnum)
 	if (gbBufferMsgs != 1 && currlevel == plr[pnum].plrlevel) {
 		auto spell = static_cast<spell_id>(p->wParam2);
 		if (currlevel != 0 || spelldata[spell].sTownSpell) {
-			ClrPlrPath(pnum);
+			ClrPlrPath(&plr[pnum]);
 			plr[pnum].destAction = ACTION_SPELLPLR;
 			plr[pnum].destParam1 = p->wParam1;
 			plr[pnum].destParam2 = p->wParam3;
@@ -2430,7 +2430,7 @@ static DWORD On_NOVA(TCmd *pCmd, int pnum)
 	auto *p = (TCmdLoc *)pCmd;
 
 	if (gbBufferMsgs != 1 && currlevel == plr[pnum].plrlevel && pnum != myplr) {
-		ClrPlrPath(pnum);
+		ClrPlrPath(&plr[pnum]);
 		plr[pnum]._pSpell = SPL_NOVA;
 		plr[pnum]._pSplType = RSPLTYPE_INVALID;
 		plr[pnum]._pSplFrom = 3;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1956,7 +1956,7 @@ void Obj_Circle(int i)
 			AddMissile(plr[myplr].position.tile.x, plr[myplr].position.tile.y, 35, 46, plr[myplr]._pdir, MIS_RNDTELEPORT, TARGET_MONSTERS, myplr, 0, 0);
 			track_repeat_walk(false);
 			sgbMouseDown = CLICK_NONE;
-			ClrPlrPath(myplr);
+			ClrPlrPath(&plr[myplr]);
 			StartStand(myplr, DIR_S);
 		}
 	} else {

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -216,7 +216,7 @@ void UnPackPlayer(PkPlayerStruct *pPack, int pnum, bool netSync)
 	pPlayer->position.tile = { pPack->px, pPack->py };
 	pPlayer->position.future = { pPack->px, pPack->py };
 	pPlayer->plrlevel = pPack->plrlevel;
-	ClrPlrPath(pnum);
+	ClrPlrPath(pPlayer);
 	pPlayer->destAction = ACTION_NONE;
 	strcpy(pPlayer->_pName, pPack->pName);
 	pPlayer->_pClass = (HeroClass)pPack->pClass;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -285,6 +285,12 @@ void PlayerStruct::PlaySpeach(int speachId, int delay) const
 	sfxdnum = herosounds[static_cast<size_t>(_pClass)][speachId - 1];
 }
 
+void PlayerStruct::Stop()
+{
+	ClrPlrPath(this);
+	destAction = ACTION_NONE;
+}
+
 void SetPlayerGPtrs(BYTE *pData, BYTE **pAnim)
 {
 	int i;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2106,7 +2106,7 @@ void InitLevelChange(int pnum)
 		plr[pnum]._pLvlVisited[plr[pnum].plrlevel] = true;
 	}
 
-	ClrPlrPath(pnum);
+	ClrPlrPath(&plr[pnum]);
 	plr[pnum].destAction = ACTION_NONE;
 	plr[pnum]._pLvlChanging = true;
 
@@ -3167,7 +3167,7 @@ void CheckNewPath(int pnum)
 					}
 
 					if (x < 2 && y < 2) {
-						ClrPlrPath(pnum);
+						ClrPlrPath(&plr[pnum]);
 						if (monster[i].mtalkmsg && monster[i].mtalkmsg != TEXT_VILE14) {
 							TalktoMonster(i);
 						} else {
@@ -3651,13 +3651,9 @@ void ProcessPlayers()
 	}
 }
 
-void ClrPlrPath(int pnum)
+void ClrPlrPath(PlayerStruct *player)
 {
-	if ((DWORD)pnum >= MAX_PLRS) {
-		app_fatal("ClrPlrPath: illegal player %d", pnum);
-	}
-
-	memset(plr[pnum].walkpath, WALK_NONE, sizeof(plr[pnum].walkpath));
+	memset(player->walkpath, WALK_NONE, sizeof(player->walkpath));
 }
 
 bool PosOkPlayer(int pnum, int x, int y)

--- a/Source/player.h
+++ b/Source/player.h
@@ -373,6 +373,13 @@ struct PlayerStruct {
 	 * @brief Play a player speach file, with out random variants.
 	 */
 	void PlaySpecificSpeach(int speachId) const;
+
+	/**
+	 * @brief Attempts to stop the player from performing any queued up action. If the player is currently walking, his walking will
+	 * stop as soon as he reaches the next tile. If any action was queued with the previous command (like targeting a monster,
+	 * opening a chest, picking an item up, etc) this action will also be cancelled.
+	 */
+	void Stop();
 };
 
 extern int myplr;

--- a/Source/player.h
+++ b/Source/player.h
@@ -428,7 +428,7 @@ void StartNewLvl(int pnum, interface_mode fom, int lvl);
 void RestartTownLvl(int pnum);
 void StartWarpLvl(int pnum, int pidx);
 void ProcessPlayers();
-void ClrPlrPath(int pnum);
+void ClrPlrPath(PlayerStruct *player);
 bool PosOkPlayer(int pnum, int x, int y);
 void MakePlrPath(int pnum, int xx, int yy, bool endspace);
 void CheckPlrSpell();

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -279,7 +279,7 @@ void DoResurrect(int pnum, int rid)
 			drawmanaflag = true;
 		}
 
-		ClrPlrPath(rid);
+		ClrPlrPath(&plr[rid]);
 		plr[rid].destAction = ACTION_NONE;
 		plr[rid]._pInvincible = false;
 		PlacePlayer(rid);


### PR DESCRIPTION
This PR introduces a new action that the player can now perform by pressing an assigned key (not set by default):
- Stops any walking after the current tile
- Cancels any queued up/buffered action, like attacking, talking, interacting with objects, etc

This allows for more fine grained control of the character without having to resort to things like attacking in-place or casting a skill to stop the current action/stop walking.