### PR TITLE
Always use desktop fullscreen mode

### DIFF
--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -178,7 +178,7 @@ bool SpawnWindow(const char *lpWindowName)
 		DvlStringSetting("scaling quality", scaleQuality, 2);
 		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, scaleQuality);
 	} else if (fullscreen) {
-		flags |= SDL_WINDOW_FULLSCREEN;
+		flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 	}
 
 	if (grabInput) {

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -155,7 +155,7 @@ void dx_reinit()
 #else
 	Uint32 flags = 0;
 	if (!fullscreen) {
-		flags = renderer ? SDL_WINDOW_FULLSCREEN_DESKTOP : SDL_WINDOW_FULLSCREEN;
+		flags = SDL_WINDOW_FULLSCREEN_DESKTOP;
 	}
 	if (SDL_SetWindowFullscreen(ghMainWnd, flags)) {
 		ErrSdl();


### PR DESCRIPTION
Exclusive fullscreen mode is a thing of the past. Borderless windowed mode is the de-facto standard for games now because it allows quick switching between applications and doesn't mess up your screen resolution and/or sound.