### PR TITLE
Add --allquests debug switch for Singleplayer

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -11,7 +11,7 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
-BOOL allquests;
+bool allquests;
 SDL_Window *ghMainWnd;
 DWORD glSeedTbl[NUMLEVELS];
 int gnLevelTypeTbl[NUMLEVELS];
@@ -220,7 +220,7 @@ static void diablo_parse_flags(int argc, char **argv)
 		} else if (strcasecmp("-w", argv[i]) == 0) {
 			debug_mode_key_w = TRUE;
 		} else if (strcasecmp("--allquests", argv[i]) == 0) {
-			allquests = 1;
+			allquests = true;
 #endif
 		} else {
 			printf("unrecognized option '%s'\n", argv[i]);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -11,7 +11,7 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
-int allquests;
+BOOL allquests;
 SDL_Window *ghMainWnd;
 DWORD glSeedTbl[NUMLEVELS];
 int gnLevelTypeTbl[NUMLEVELS];

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -11,6 +11,7 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
+int allquests;
 SDL_Window *ghMainWnd;
 DWORD glSeedTbl[NUMLEVELS];
 int gnLevelTypeTbl[NUMLEVELS];
@@ -138,6 +139,7 @@ static void print_help_and_exit()
 	printf("    %-20s %-30s\n", "-q <#>", "Force a certain quest");
 	printf("    %-20s %-30s\n", "-r <##########>", "Set map seed");
 	printf("    %-20s %-30s\n", "-t <##>", "Set current quest level");
+	printf("    %-20s %-30s\n", "--allquests", "Force all quests to generate in a singleplayer game");
 #endif
 	printf("\nReport bugs at https://github.com/diasurgical/devilutionX/\n");
 	diablo_quit(0);
@@ -217,6 +219,8 @@ static void diablo_parse_flags(int argc, char **argv)
 			visiondebug = TRUE;
 		} else if (strcasecmp("-w", argv[i]) == 0) {
 			debug_mode_key_w = TRUE;
+		} else if (strcasecmp("--allquests", argv[i]) == 0) {
+			allquests = 1;
 #endif
 		} else {
 			printf("unrecognized option '%s'\n", argv[i]);

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -144,7 +144,7 @@ void InitQuests()
 		quests[z]._qmsg = questlist[z]._qdmsg;
 	}
 
-	if (gbMaxPlayers == 1, allquests == 0) {
+	if (gbMaxPlayers == 1 && allquests == 0) {
 		SetRndSeed(glSeedTbl[15]);
 		if (random_(0, 2) != 0)
 			quests[Q_PWATER]._qactive = QUEST_NOTAVAIL;

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -144,7 +144,7 @@ void InitQuests()
 		quests[z]._qmsg = questlist[z]._qdmsg;
 	}
 
-	if (gbMaxPlayers == 1 && allquests == 0) {
+	if (gbMaxPlayers == 1 && !allquests) {
 		SetRndSeed(glSeedTbl[15]);
 		if (random_(0, 2) != 0)
 			quests[Q_PWATER]._qactive = QUEST_NOTAVAIL;

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -144,7 +144,7 @@ void InitQuests()
 		quests[z]._qmsg = questlist[z]._qdmsg;
 	}
 
-	if (gbMaxPlayers == 1) {
+	if (gbMaxPlayers == 1, allquests == 0) {
 		SetRndSeed(glSeedTbl[15]);
 		if (random_(0, 2) != 0)
 			quests[Q_PWATER]._qactive = QUEST_NOTAVAIL;

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -12,7 +12,7 @@ DEVILUTION_BEGIN_NAMESPACE
 extern "C" {
 #endif
 
-extern BOOL allquests;
+extern bool allquests;
 extern BOOL questlog;
 extern BYTE *pQLogCel;
 extern QuestStruct quests[MAXQUESTS];

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -12,6 +12,7 @@ DEVILUTION_BEGIN_NAMESPACE
 extern "C" {
 #endif
 
+extern int allquests;
 extern BOOL questlog;
 extern BYTE *pQLogCel;
 extern QuestStruct quests[MAXQUESTS];

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -12,7 +12,7 @@ DEVILUTION_BEGIN_NAMESPACE
 extern "C" {
 #endif
 
-extern int allquests;
+extern BOOL allquests;
 extern BOOL questlog;
 extern BYTE *pQLogCel;
 extern QuestStruct quests[MAXQUESTS];


### PR DESCRIPTION
This would add a switch --allquests which would enable all the quests to spawn in Singleplayer. Multiplayer would be unaffected.