### PR TITLE
Cancel targeted attack on dead monster

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1758,6 +1758,13 @@ void MonstStartKill(int i, int pnum, bool sendmsg)
 	M_FallenFear(monst->position.tile);
 	if ((monst->MType->mtype >= MT_NACID && monst->MType->mtype <= MT_XACID) || monst->MType->mtype == MT_SPIDLORD)
 		AddMissile(monst->position.tile, { 0, 0 }, 0, MIS_ACIDPUD, TARGET_PLAYERS, i, monst->_mint + 1, 0);
+
+	if (pnum >= 0 && pnum < MAX_PLRS) {
+		PlayerStruct &player = Players[pnum];
+		if ((player.destAction == ACTION_ATTACKMON || player.destAction == ACTION_RATTACKMON || player.destAction == ACTION_SPELLMON) && player.destParam1 == i) {
+			player.destAction = ACTION_NONE;
+		}
+	}
 }
 
 void M2MStartKill(int i, int mid)


### PR DESCRIPTION
This PR introduces an optimization to improve the overall gameplay experience and responsiveness of characters while attacking. When a monster dies, any player that was currently targeting it for an attack as his next action will have that action cancelled.

This effectively prevents wasted shots when continuously attacking an enemy: the slower the action, the more pronounced this effect becomes.

Here is a comparison of how this works in practice:

| Standard | Attack cancel |
| --- | --- |
| ![Standard](https://user-images.githubusercontent.com/461579/103449513-e61eb480-4c87-11eb-9ebd-c5faa2ae6c46.gif) | ![BufferCancel](https://user-images.githubusercontent.com/461579/103449515-eae36880-4c87-11eb-9355-9b89b89cff3a.gif) |

Notice how in the standard version, each monster takes 2 hits: one to die, and another missed one after death. On the buffer cancelled version, the second hit does not occur since it is cancelled right on the frame where the monster dies, so it is easier to retarget to other monsters even while clicking constantly.

Clicking constantly on the standard version is guaranteed to always land at least 2 hits: the current action, and a buffered one.