### PR TITLE
Engine: Functions to render to any buffer

### DIFF
--- a/Source/engine.h
+++ b/Source/engine.h
@@ -13,6 +13,10 @@
 #ifndef __ENGINE_H__
 #define __ENGINE_H__
 
+#ifdef __cplusplus
+#include <algorithm>
+#endif
+
 DEVILUTION_BEGIN_NAMESPACE
 
 #ifdef __cplusplus
@@ -49,22 +53,306 @@ inline BYTE *CelGetFrameClipped(BYTE *pCelBuff, int nCel, int *nDataSize)
 	return pRLEBytes + nDataStart;
 }
 
-void CelDraw(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
-void CelBlitFrame(BYTE *pBuff, BYTE *pCelBuff, int nCel, int nWidth);
-void CelClippedDraw(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
-void CelDrawLight(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, BYTE *tbl);
-void CelClippedDrawLight(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
-void CelClippedBlitLightTrans(BYTE *pBuff, BYTE *pCelBuff, int nCel, int nWidth);
-void CelDrawLightRed(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, char light);
-void CelBlitSafe(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth);
-void CelClippedDrawSafe(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
-void CelBlitLightSafe(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth, BYTE *tbl);
-void CelDrawLightRedSafe(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, char light);
-void CelBlitWidth(BYTE *pBuff, int x, int y, int wdt, BYTE *pCelBuff, int nCel, int nWidth);
-void CelBlitOutline(BYTE col, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
-void ENG_set_pixel(int sx, int sy, BYTE col);
+struct CelOutputBuffer {
+	BYTE *begin;
+	BYTE *end;
+	int line_width;
+
+#ifdef __cplusplus
+	BYTE *at(int x, int y) const
+	{
+		return &begin[x + line_width * y];
+	}
+
+	bool in_bounds(int x, int y) const
+	{
+		return x >= 0 && y >= 0 && begin + x + line_width * y < end;
+	}
+
+	CelOutputBuffer subregion(int x0, int y0, int x1, int y1) const
+	{
+		return CelOutputBuffer { at(x0, y0), std::min(at(x1, y1), end), line_width };
+	}
+#endif
+};
+
+inline CelOutputBuffer GlobalBackBuffer()
+{
+	extern BYTE *gpBuffer;
+	extern BYTE *gpBufEnd;
+	return CelOutputBuffer { gpBuffer, gpBufEnd, BUFFER_WIDTH };
+}
+
+/**
+ * @brief Blit CEL sprite to the back buffer at the given coordinates
+ * @param out Target buffer
+ * @param sx Target buffer coordinate
+ * @param sy Target buffer coordinate
+ * @param pCelBuff Cel data
+ * @param nCel CEL frame number
+ * @param nWidth Width of sprite
+ */
+void CelDrawTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+inline void CelDraw(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth)
+{
+	CelDrawTo(GlobalBackBuffer(), sx, sy, pCelBuff, nCel, nWidth);
+}
+
+/**
+ * @briefBlit CEL sprite to the given buffer, does not perform bounds-checking.
+ * @param out Target buffer
+ * @param x Cordinate in the target buffer
+ * @param y Cordinate in the target buffer
+ * @param pCelBuff Cel data
+ * @param nCel CEL frame number
+ * @param nWidth Width of cel
+ */
+void CelDrawUnsafeTo(CelOutputBuffer out, int x, int y, BYTE *pCelBuff, int nCel, int nWidth);
+
+/**
+ * @brief Same as CelDrawTo but with the option to skip parts of the top and bottom of the sprite
+ * @param out Target buffer
+ * @param sx Target buffer coordinate
+ * @param sy Target buffer coordinate
+ * @param pCelBuff Cel data
+ * @param nCel CEL frame number
+ * @param nWidth Width of sprite
+ */
+void CelClippedDrawTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+inline void CelClippedDraw(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth)
+{
+	CelClippedDrawTo(GlobalBackBuffer(), sx, sy, pCelBuff, nCel, nWidth);
+}
+
+/**
+ * @brief Blit CEL sprite, and apply lighting, to the back buffer at the given coordinates
+ * @param out Target buffer
+ * @param sx Target buffer coordinate
+ * @param sy Target buffer coordinate
+ * @param pCelBuff Cel data
+ * @param nCel CEL frame number
+ * @param nWidth Width of sprite
+ */
+void CelDrawLightTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, BYTE *tbl);
+inline void CelDrawLight(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, BYTE *tbl)
+{
+	CelDrawLightTo(GlobalBackBuffer(), sx, sy, pCelBuff, nCel, nWidth, tbl);
+}
+
+/**
+ * @brief Same as CelDrawLightTo but with the option to skip parts of the top and bottom of the sprite
+ * @param out Target buffer
+ * @param sx Target buffer coordinate
+ * @param sy Target buffer coordinate
+ * @param pCelBuff Cel data
+ * @param nCel CEL frame number
+ * @param nWidth Width of sprite
+ */
+void CelClippedDrawLightTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+inline void CelClippedDrawLight(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth)
+{
+	return CelClippedDrawLightTo(GlobalBackBuffer(), sx, sy, pCelBuff, nCel, nWidth);
+}
+
+/**
+ * @brief Same as CelBlitLightTransSafeTo
+ * @param out Target buffer
+ * @param sx Target buffer coordinate
+ * @param sy Target buffer coordinate
+ * @param pCelBuff Cel data
+ * @param nCel CEL frame number
+ * @param nWidth Width of sprite
+ */
+void CelClippedBlitLightTransTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+inline void CelClippedBlitLightTrans(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth)
+{
+	return CelClippedBlitLightTransTo(GlobalBackBuffer(), sx, sy, pCelBuff, nCel, nWidth);
+}
+
+/**
+ * @brief Blit CEL sprite, and apply lighting, to the back buffer at the given coordinates, translated to a red hue
+ * @param out Target buffer
+ * @param sx Target buffer coordinate
+ * @param sy Target buffer coordinate
+ * @param pCelBuff Cel data
+ * @param nCel CEL frame number
+ * @param nWidth Width of sprite
+ * @param light Light shade to use
+ */
+void CelDrawLightRedTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, char light);
+inline void CelDrawLightRed(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, char light)
+{
+	return CelDrawLightRedTo(GlobalBackBuffer(), sx, sy, pCelBuff, nCel, nWidth, light);
+}
+
+/**
+ * @brief Blit CEL sprite to the given buffer, checks for drawing outside the buffer.
+ * @param out Target buffer
+ * @param sx Target buffer coordinate
+ * @param sy Target buffer coordinate
+ * @param pRLEBytes CEL pixel stream (run-length encoded)
+ * @param nDataSize Size of CEL in bytes
+ * @param nWidth Width of sprite
+ */
+void CelBlitSafeTo(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBytes, int nDataSize, int nWidth);
+inline void CelBlitSafe(int sx, int sy, BYTE *pRLEBytes, int nDataSize, int nWidth)
+{
+	return CelBlitSafeTo(GlobalBackBuffer(), sx, sy, pRLEBytes, nDataSize, nWidth);
+}
+
+/**
+ * @brief Same as CelClippedDrawTo but checks for drawing outside the buffer
+ * @param out Target buffer
+ * @param sx Target buffer coordinate
+ * @param sy Target buffer coordinate
+ * @param pCelBuff Cel data
+ * @param nCel CEL frame number
+ * @param nWidth Width of sprite
+ */
+void CelClippedDrawSafeTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+inline void CelClippedDrawSafe(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth)
+{
+	return CelClippedDrawSafeTo(GlobalBackBuffer(), sx, sy, pCelBuff, nCel, nWidth);
+}
+
+/**
+ * @brief Blit CEL sprite, and apply lighting, to the given buffer, checks for drawing outside the buffer
+ * @param out Target buffer
+ * @param sx Target buffer coordinate
+ * @param sy Target buffer coordinate
+ * @param pRLEBytes CEL pixel stream (run-length encoded)
+ * @param nDataSize Size of CEL in bytes
+ * @param nWidth Width of sprite
+ * @param tbl Palette translation table
+ */
+void CelBlitLightSafeTo(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBytes, int nDataSize, int nWidth, BYTE *tbl);
+inline void CelBlitLightSafe(int sx, int sy, BYTE *pRLEBytes, int nDataSize, int nWidth, BYTE *tbl)
+{
+	return CelBlitLightSafeTo(GlobalBackBuffer(), sx, sy, pRLEBytes, nDataSize, nWidth, tbl);
+}
+
+/**
+ * @brief Same as CelBlitLightSafeTo but with stippled transparancy applied
+ * @param out Target buffer
+ * @param sx Target buffer coordinate
+ * @param sy Target buffer coordinate
+ * @param pRLEBytes CEL pixel stream (run-length encoded)
+ * @param nDataSize Size of CEL in bytes
+ * @param nWidth Width of sprite
+ */
+void CelBlitLightTransSafeTo(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBytes, int nDataSize, int nWidth);
+inline void CelBlitLightTransSafe(int sx, int sy, BYTE *pRLEBytes, int nDataSize, int nWidth)
+{
+	return CelBlitLightTransSafeTo(GlobalBackBuffer(), sx, sy, pRLEBytes, nDataSize, nWidth);
+}
+
+/**
+ * @brief Same as CelDrawLightRedTo but checks for drawing outside the buffer
+ * @param out Target buffer
+ * @param sx Target buffer coordinate
+ * @param sy Target buffer coordinate
+ * @param pCelBuff Cel data
+ * @param nCel CEL frame number
+ * @param nWidth Width of cel
+ * @param light Light shade to use
+ */
+void CelDrawLightRedSafeTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, char light);
+inline void CelDrawLightRedSafe(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, char light)
+{
+	return CelDrawLightRedSafeTo(GlobalBackBuffer(), sx, sy, pCelBuff, nCel, nWidth, light);
+}
+
+/**
+ * @brief Blit a solid colder shape one pixel larger then the given sprite shape, to the target buffer at the given coordianates
+ * @param out Target buffer
+ * @param col Color index from current palette
+ * @param sx Target buffer coordinate
+ * @param sy Target buffer coordinate
+ * @param pCelBuff CEL buffer
+ * @param nCel CEL frame number
+ * @param nWidth Width of sprite
+ */
+void CelBlitOutlineTo(CelOutputBuffer out, BYTE col, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+inline void CelBlitOutline(BYTE col, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth)
+{
+	return CelBlitOutlineTo(GlobalBackBuffer(), col, sx, sy, pCelBuff, nCel, nWidth);
+}
+
+/**
+ * @brief Set the value of a single pixel in the back buffer, checks bounds
+ * @param out Target buffer
+ * @param sx Target buffer coordinate
+ * @param sy Target buffer coordinate
+ * @param col Color index from current palette
+ */
+void SetPixel(CelOutputBuffer out, int sx, int sy, BYTE col);
+inline void ENG_set_pixel(int sx, int sy, BYTE col)
+{
+	return SetPixel(GlobalBackBuffer(), sx, sy, col);
+}
+
+/**
+ * @brief Blit CL2 sprite, to the back buffer at the given coordianates
+ * @param sx Back buffer coordinate
+ * @param sy Back buffer coordinate
+ * @param pCelBuff CL2 buffer
+ * @param nCel CL2 frame number
+ * @param nWidth Width of sprite
+ */
+void Cl2Draw(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+
+/**
+ * @brief Blit a solid colder shape one pixel larger then the given sprite shape, to the back buffer at the given coordianates
+ * @param col Color index from current palette
+ * @param sx Back buffer coordinate
+ * @param sy Back buffer coordinate
+ * @param pCelBuff CL2 buffer
+ * @param nCel CL2 frame number
+ * @param nWidth Width of sprite
+ */
+void Cl2DrawOutline(BYTE col, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+
+/**
+ * @brief Blit CL2 sprite, and apply a given lighting, to the back buffer at the given coordianates
+ * @param sx Back buffer coordinate
+ * @param sy Back buffer coordinate
+ * @param pCelBuff CL2 buffer
+ * @param nCel CL2 frame number
+ * @param nWidth Width of sprite
+ * @param light Light shade to use
+ */
+void Cl2DrawLightTbl(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, char light);
+
+/**
+ * @brief Blit CL2 sprite, and apply lighting, to the back buffer at the given coordinates
+ * @param sx Back buffer coordinate
+ * @param sy Back buffer coordinate
+ * @param pCelBuff CL2 buffer
+ * @param nCel CL2 frame number
+ * @param nWidth Width of sprite
+ */
+void Cl2DrawLight(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+
+/**
+ * @brief Draw a line on the back buffer
+ * @param x0 Back buffer coordinate
+ * @param y0 Back buffer coordinate
+ * @param x1 Back buffer coordinate
+ * @param y1 Back buffer coordinate
+ * @param col Color index from current palette
+ */
 void DrawLine(int x0, int y0, int x1, int y1, BYTE col);
+
+/**
+ * @brief Calculate the best fit direction between two points
+ * @param x1 Tile coordinate
+ * @param y1 Tile coordinate
+ * @param x2 Tile coordinate
+ * @param y2 Tile coordinate
+ * @return A value from the direction enum
+ */
 int GetDirection(int x1, int y1, int x2, int y2);
+
 void SetRndSeed(int s);
 int AdvanceRndSeed();
 int GetRndSeed();
@@ -74,10 +362,6 @@ void mem_free_dbg(void *p);
 BYTE *LoadFileInMem(const char *pszName, DWORD *pdwFileLen);
 DWORD LoadFileWithMem(const char *pszName, BYTE *p);
 void Cl2ApplyTrans(BYTE *p, BYTE *ttbl, int nCel);
-void Cl2Draw(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
-void Cl2DrawOutline(BYTE col, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
-void Cl2DrawLightTbl(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, char light);
-void Cl2DrawLight(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
 void PlayInGameMovie(const char *pszMovie);
 
 #ifdef __cplusplus

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -365,13 +365,12 @@ void DrawInv()
 				light_table_index = 0;
 				cel_transparency_active = TRUE;
 
-				pBuff = frame_width == INV_SLOT_SIZE_PX
-				    ? &gpBuffer[SCREENXY(RIGHT_PANEL_X + 197, SCREEN_Y)]
-				    : &gpBuffer[SCREENXY(RIGHT_PANEL_X + 183, SCREEN_Y)];
+				const int dst_x = SCREEN_X + RIGHT_PANEL_X + (frame_width == INV_SLOT_SIZE_PX ? 197 : 183);
+				const int dst_y = SCREEN_Y;
 				if (frame <= 179) {
-					CelClippedBlitLightTrans(pBuff, pCursCels, frame, frame_width);
+					CelClippedBlitLightTrans(dst_x, dst_y, pCursCels, frame, frame_width);
 				} else {
-					CelClippedBlitLightTrans(pBuff, pCursCels2, frame - 179, frame_width);
+					CelClippedBlitLightTrans(dst_x, dst_y, pCursCels2, frame - 179, frame_width);
 				}
 
 				cel_transparency_active = FALSE;

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -144,17 +144,10 @@ int CalcTextSpeed(int nSFX)
  */
 void PrintQTextChr(int sx, int sy, Uint8 *pCelBuff, int nCel)
 {
-	Uint8 *pStart, *pEnd;
-
-	assert(gpBuffer);
-	pStart = gpBufStart;
-	gpBufStart = &gpBuffer[BUFFER_WIDTH * (49 + SCREEN_Y + UI_OFFSET_Y)];
-	pEnd = gpBufEnd;
-	gpBufEnd = &gpBuffer[BUFFER_WIDTH * (309 + SCREEN_Y + UI_OFFSET_Y)];
-	CelDraw(sx, sy, pCelBuff, nCel, 22);
-
-	gpBufStart = pStart;
-	gpBufEnd = pEnd;
+	CelOutputBuffer buf = GlobalBackBuffer();
+	const int start_y = 49 + SCREEN_Y + UI_OFFSET_Y;
+	buf = buf.subregion(0, start_y, buf.line_width, 309 + SCREEN_Y + UI_OFFSET_Y);
+	CelDrawTo(buf, sx, sy - start_y, pCelBuff, nCel, 22);
 }
 
 /**

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -815,7 +815,7 @@ static void scrollrt_draw_dungeon(int sx, int sy, int dx, int dy)
 				cel_transparency_active = 0; // Turn transparency off here for debugging
 			}
 #endif
-			CelClippedBlitLightTrans(&gpBuffer[dx + BUFFER_WIDTH * dy], pSpecialCels, bArch, 64);
+			CelClippedBlitLightTrans(dx, dy, pSpecialCels, bArch, 64);
 #ifdef _DEBUG
 			if (GetAsyncKeyState(DVL_VK_MENU) & 0x8000) {
 				cel_transparency_active = TransList[bMap]; // Turn transparency back to its normal state
@@ -829,7 +829,7 @@ static void scrollrt_draw_dungeon(int sx, int sy, int dx, int dy)
 		if (sx > 0 && sy > 0 && dy > TILE_HEIGHT + SCREEN_Y) {
 			bArch = dSpecial[sx - 1][sy - 1];
 			if (bArch != 0) {
-				CelBlitFrame(&gpBuffer[dx + BUFFER_WIDTH * (dy - TILE_HEIGHT)], pSpecialCels, bArch, 64);
+				CelDraw(dx, dy - TILE_HEIGHT, pSpecialCels, bArch, 64);
 			}
 		}
 	}


### PR DESCRIPTION
Refactor the rendering functions to allow rendering to any output buffer.

New functions that accept a buffer have the `To` suffix.

The functions that render to the global buffer now always accept coordinates.

/cc @viciious