### PR TITLE
Fix lazarus staff skip bug

### DIFF
--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -1383,7 +1383,7 @@ static BOOL DRLG_L4PlaceMiniSet(const BYTE *miniset, int tmin, int tmax, int cx,
 		}
 	}
 
-	if (currlevel == 15) {
+	if (currlevel == 15 && quests[Q_BETRAYER]._qactive >= QUEST_ACTIVE) { /// Lazarus staff skip bug fixed
 		quests[Q_BETRAYER]._qtx = sx + 1;
 		quests[Q_BETRAYER]._qty = sy + 1;
 	}


### PR DESCRIPTION
Sometimes on level 15 the player can teleport to lazarus' lair by walking on a "random" tile because that tile hasn't been converted to a mini tile yet. This ports the fix from the PSX version of Diablo. Since the dungeon is generated each time, it only sets the coordinates when the portal is active.

ref: https://github.com/diabpsx/skeleton/blob/master/JAP_1998_05_29/DIABPSX/SOURCE/DRLG_L4.CPP#L2683

Bug found by @NiteKat