### PR TITLE
Optional feature to auto-refill belt from inventory

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1295,6 +1295,14 @@ static void PressChar(WPARAM vkey)
 		}
 		return;
 #endif
+	case 'A':
+        plr[myplr].autoRefillBelt = !plr[myplr].autoRefillBelt;
+        if(plr[myplr].autoRefillBelt)
+            NetSendCmdString(1 << myplr, "Auto-refill belt activated");
+        else
+            NetSendCmdString(1 << myplr, "Auto-refill belt de-activated");
+        PlaySFX(IS_IGRAB);
+        return;
 	}
 }
 

--- a/Source/help.cpp
+++ b/Source/help.cpp
@@ -439,6 +439,10 @@ const char gszHelpText[] = {
 	"$Spell Books|"
 	"Reading more than one book increases your knowledge of that "
 	"spell, allowing you to cast the spell more effectively.|"
+	"|"
+	"$Auto-refill Belt Itmes|"
+	"Press Shift+A to toggle auto-refilling. Belt items will be refilled "
+	"as long as there is a replacement in the inventory.|"
 	"&"
 };
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -2508,6 +2508,16 @@ BOOL UseInvItem(int pnum, int cii)
 		speedlist = TRUE;
 	}
 
+	//If selected speedlist item exists in InvList, use the InvList item.
+	for (int i = 0; i < plr[pnum]._pNumInv && plr[pnum].autoRefillBelt; i++) {
+		if (plr[myplr].InvList[i]._iMiscId == Item->_iMiscId && plr[myplr].InvList[i]._iSpell ==Item->_iSpell){
+            c = i;
+            Item = &plr[pnum].InvList[c];
+            speedlist = FALSE;
+            break;
+        }
+	}
+
 	switch (Item->IDidx) {
 	case IDI_MUSHROOM:
 		sfxdelay = 10;

--- a/structs.h
+++ b/structs.h
@@ -362,6 +362,7 @@ typedef struct PlayerStruct {
 	unsigned char *_pDData;
 	unsigned char *_pBData;
 	void *pReserved;
+	BOOLEAN autoRefillBelt = false;
 } PlayerStruct;
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
Functionality to "auto-refill" the belt from inventory when using a belt item. 
The code looks for an identical potion / scroll (oil / rune / etc.) in the inventory and uses that item instead of the belt item.

The feature should be optional and is default off. I would love to use the config.ini that is planned for "All the cool QOL stuff" but for now I have added  hotkey Shift+A to switch it on and off again.

I play on a laptop without mouse, and have the strong impression this is not what the original developers had in mind. Right clicking potions in the inventory is not really a feasible option.
This feature allows to utilize more slots for scrolls without losing access to quick Life / Mana refill.

 