### PR TITLE
Transparency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,8 @@ add_library(devilution STATIC
   Source/town.cpp
   Source/towners.cpp
   Source/track.cpp
-  Source/trigs.cpp)
+  Source/trigs.cpp
+  Source/Misc/config.cpp)
 
 set(devilutionx_SRCS
   SourceX/dx.cpp

--- a/Source/Misc/config.cpp
+++ b/Source/Misc/config.cpp
@@ -1,0 +1,44 @@
+//Fluffy: For loading various options from the game's config file
+
+#include "..\all.h"
+#include "../../3rdParty/Storm/Source/storm.h"
+
+//TODO: We could create a struct which contains all general options which can be defined in the config file to make them tidier
+
+DEVILUTION_BEGIN_NAMESPACE
+
+static void LoadGameSetupVariableFromConfig(char *name, BOOL *variable)
+{
+	int temp = *variable;
+	if (SRegLoadValue("devilutionx", name, 0, &temp))
+		*variable = (BOOL)temp;
+	else
+		SRegSaveValue("devilutionx", name, 0, temp);
+}
+
+void LoadOptionsFromConfig()
+{
+	if (!SRegLoadValue("devilutionx", "game speed", 0, &ticks_per_sec)) {
+		SRegSaveValue("devilutionx", "game speed", 0, ticks_per_sec);
+	}
+	tick_delay_highResolution = SDL_GetPerformanceFrequency() / ticks_per_sec; //Fluffy
+
+	//Fluffy: Load speed modifiers from config, but if they don't exist, then we calculate based on the tick rate
+	if (!SRegLoadValue("devilutionx", "Game Simulation Speed Modifier", 0, &gSpeedMod)) {
+		gSpeedMod = ticks_per_sec / 20;
+	}
+	if (!SRegLoadValue("devilutionx", "Monster Speed Modifier", 0, &gMonsterSpeedMod)) {
+		gMonsterSpeedMod = ticks_per_sec / 20;
+	}
+	if (gSpeedMod < 1)
+		gSpeedMod = 1;
+	if (gMonsterSpeedMod < 1)
+		gMonsterSpeedMod = 1;
+
+	//Fluffy: Load game setup from config here when booting up singleplayer (if we fail to load it, then we save its default to the config)
+	LoadGameSetupVariableFromConfig("Fast Walking In Town", &gameSetup_fastWalkInTown);
+	LoadGameSetupVariableFromConfig("Allow Attacks In Town", &gameSetup_allowAttacksInTown);
+	LoadGameSetupVariableFromConfig("Transparency", &options_transparency);
+}
+
+DEVILUTION_END_NAMESPACE

--- a/Source/Misc/config.cpp
+++ b/Source/Misc/config.cpp
@@ -1,6 +1,6 @@
 //Fluffy: For loading various options from the game's config file
 
-#include "..\all.h"
+#include "../all.h"
 #include "../../3rdParty/Storm/Source/storm.h"
 
 //TODO: We could create a struct which contains all general options which can be defined in the config file to make them tidier

--- a/Source/Misc/config.cpp
+++ b/Source/Misc/config.cpp
@@ -21,23 +21,8 @@ void LoadOptionsFromConfig()
 	if (!SRegLoadValue("devilutionx", "game speed", 0, &ticks_per_sec)) {
 		SRegSaveValue("devilutionx", "game speed", 0, ticks_per_sec);
 	}
-	tick_delay_highResolution = SDL_GetPerformanceFrequency() / ticks_per_sec; //Fluffy
-
-	//Fluffy: Load speed modifiers from config, but if they don't exist, then we calculate based on the tick rate
-	if (!SRegLoadValue("devilutionx", "Game Simulation Speed Modifier", 0, &gSpeedMod)) {
-		gSpeedMod = ticks_per_sec / 20;
-	}
-	if (!SRegLoadValue("devilutionx", "Monster Speed Modifier", 0, &gMonsterSpeedMod)) {
-		gMonsterSpeedMod = ticks_per_sec / 20;
-	}
-	if (gSpeedMod < 1)
-		gSpeedMod = 1;
-	if (gMonsterSpeedMod < 1)
-		gMonsterSpeedMod = 1;
 
 	//Fluffy: Load game setup from config here when booting up singleplayer (if we fail to load it, then we save its default to the config)
-	LoadGameSetupVariableFromConfig("Fast Walking In Town", &gameSetup_fastWalkInTown);
-	LoadGameSetupVariableFromConfig("Allow Attacks In Town", &gameSetup_allowAttacksInTown);
 	LoadGameSetupVariableFromConfig("Transparency", &options_transparency);
 }
 

--- a/Source/Misc/config.cpp
+++ b/Source/Misc/config.cpp
@@ -3,8 +3,6 @@
 #include "../all.h"
 #include "../../3rdParty/Storm/Source/storm.h"
 
-//TODO: We could create a struct which contains all general options which can be defined in the config file to make them tidier
-
 DEVILUTION_BEGIN_NAMESPACE
 
 static void LoadGameSetupVariableFromConfig(char *name, BOOL *variable)

--- a/Source/Misc/config.cpp
+++ b/Source/Misc/config.cpp
@@ -1,4 +1,4 @@
-//Fluffy: For loading various options from the game's config file
+//For loading various options from the game's config file
 
 #include "../all.h"
 #include "../../3rdParty/Storm/Source/storm.h"
@@ -22,7 +22,7 @@ void LoadOptionsFromConfig()
 		SRegSaveValue("devilutionx", "game speed", 0, ticks_per_sec);
 	}
 
-	//Fluffy: Load game setup from config here when booting up singleplayer (if we fail to load it, then we save its default to the config)
+	//Load game setup from config here when booting up singleplayer (if we fail to load it, then we save its default to the config)
 	LoadGameSetupVariableFromConfig("Transparency", &options_transparency);
 }
 

--- a/Source/Misc/config.h
+++ b/Source/Misc/config.h
@@ -1,0 +1,7 @@
+#pragma once
+
+DEVILUTION_BEGIN_NAMESPACE
+
+void LoadOptionsFromConfig();
+
+DEVILUTION_END_NAMESPACE

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -56,6 +56,7 @@ char sgbMouseDown;
 int color_cycle_timer;
 int ticks_per_sec = 20;
 WORD tick_delay = 50;
+BOOL options_transparency = false; //Fluffy: If true, we apply proper transparency rather than dithering
 
 /* rdata */
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -8,7 +8,7 @@
 #include "../3rdParty/Storm/Source/storm.h"
 #include "../DiabloUI/diabloui.h"
 #include <config.h>
-#include "misc\config.h" //Fluffy: For reading options from config during startup
+#include "misc\config.h" //For reading options from config during startup
 
 DEVILUTION_BEGIN_NAMESPACE
 
@@ -56,7 +56,7 @@ char sgbMouseDown;
 int color_cycle_timer;
 int ticks_per_sec = 20;
 WORD tick_delay = 50;
-BOOL options_transparency = false; //Fluffy: If true, we apply proper transparency rather than dithering
+BOOL options_transparency = false; //If true, we apply proper transparency rather than dithering
 
 /* rdata */
 
@@ -500,7 +500,7 @@ void diablo_quit(int exitStatus)
 int DiabloMain(int argc, char **argv)
 {
 	diablo_parse_flags(argc, argv);
-	LoadOptionsFromConfig(); //Fluffy: Read options from config here
+	LoadOptionsFromConfig(); //Read options from config here
 	diablo_init();
 	diablo_splash();
 	mainmenu_loop();

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -8,6 +8,7 @@
 #include "../3rdParty/Storm/Source/storm.h"
 #include "../DiabloUI/diabloui.h"
 #include <config.h>
+#include "misc\config.h" //Fluffy: For reading options from config during startup
 
 DEVILUTION_BEGIN_NAMESPACE
 
@@ -498,6 +499,7 @@ void diablo_quit(int exitStatus)
 int DiabloMain(int argc, char **argv)
 {
 	diablo_parse_flags(argc, argv);
+	LoadOptionsFromConfig(); //Fluffy: Read options from config here
 	diablo_init();
 	diablo_splash();
 	mainmenu_loop();

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -8,7 +8,8 @@
 #include "../3rdParty/Storm/Source/storm.h"
 #include "../DiabloUI/diabloui.h"
 #include <config.h>
-#include "misc\config.h" //For reading options from config during startup
+#include "misc/config.h" //For reading options from config during startup
+
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -46,6 +46,7 @@ extern BOOLEAN UseMultiTest;
 extern char sgbMouseDown;
 extern int ticks_per_sec;
 extern WORD tick_delay;
+extern BOOL options_transparency;
 
 void FreeGameMem();
 BOOL StartGame(BOOL bNewGame, BOOL bSinglePlayer);

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -329,7 +329,7 @@ void CelBlitLightSafe(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidt
 	}
 }
 
-//Fluffy: Same as CelBlitLightSafe but with proper transparency (not dithered)
+//Same as CelBlitLightSafe but with proper transparency (not dithered)
 void CelBlitLightSafe_RealTransparency(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth, BYTE *tbl)
 {
 	int i, w;
@@ -494,7 +494,7 @@ void CelClippedBlitLightTrans(BYTE *pBuff, BYTE *pCelBuff, int nCel, int nWidth)
 
 	if (cel_transparency_active) {
 		if (options_transparency)
-			CelBlitLightSafe_RealTransparency(pBuff, pRLEBytes, nDataSize, nWidth, NULL); //Fluffy: Variant of below which renders proper transparency
+			CelBlitLightSafe_RealTransparency(pBuff, pRLEBytes, nDataSize, nWidth, NULL); //Variant of below which renders proper transparency
 		else
 			CelBlitLightTransSafe(pBuff, pRLEBytes, nDataSize, nWidth);
 	}

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -59,6 +59,7 @@ void CelDrawLightRed(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, char 
 void CelBlitSafe(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth);
 void CelClippedDrawSafe(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
 void CelBlitLightSafe(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth, BYTE *tbl);
+void CelBlitLightSafe_RealTransparency(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth, BYTE *tbl);
 void CelBlitLightTransSafe(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth);
 void CelDrawLightRedSafe(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, char light);
 void CelBlitWidth(BYTE *pBuff, int x, int y, int wdt, BYTE *pCelBuff, int nCel, int nWidth);

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -61,10 +61,6 @@ static BOOL mainmenu_single_player()
 
 	gbMaxPlayers = 1;
 
-	if (!SRegLoadValue("devilutionx", "game speed", 0, &ticks_per_sec)) {
-		SRegSaveValue("devilutionx", "game speed", 0, ticks_per_sec);
-	}
-
 	LoadOptionsFromConfig(); //Fluffy: In case we are changing from multiplayer to singleplayer, we re-read various options from config here
 
 	return mainmenu_init_menu(SELHERO_NEW_DUNGEON);

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -65,6 +65,8 @@ static BOOL mainmenu_single_player()
 		SRegSaveValue("devilutionx", "game speed", 0, ticks_per_sec);
 	}
 
+	LoadOptionsFromConfig(); //Fluffy: In case we are changing from multiplayer to singleplayer, we re-read various options from config here
+
 	return mainmenu_init_menu(SELHERO_NEW_DUNGEON);
 }
 

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -6,6 +6,7 @@
 #include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include "../DiabloUI/diabloui.h"
+#include "misc\config.h" //Fluffy: For re-reading options from config
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -6,7 +6,7 @@
 #include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include "../DiabloUI/diabloui.h"
-#include "misc\config.h" //Fluffy: For re-reading options from config
+#include "misc\config.h" //For re-reading options from config
 
 DEVILUTION_BEGIN_NAMESPACE
 
@@ -61,7 +61,7 @@ static BOOL mainmenu_single_player()
 
 	gbMaxPlayers = 1;
 
-	LoadOptionsFromConfig(); //Fluffy: In case we are changing from multiplayer to singleplayer, we re-read various options from config here
+	LoadOptionsFromConfig(); //In case we are changing from multiplayer to singleplayer, we re-read various options from config here
 
 	return mainmenu_init_menu(SELHERO_NEW_DUNGEON);
 }

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -6,7 +6,7 @@
 #include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include "../DiabloUI/diabloui.h"
-#include "misc\config.h" //For re-reading options from config
+#include "misc/config.h" //For re-reading options from config
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -107,7 +107,7 @@ void LoadPalette(const char *pszFileName)
 	* We save this info in a lookup table we use during rendering for whenever we want this kind of transparency.
 	* 
 	*/
-	if (options_transparency == 1) {
+	if (options_transparency == true) {
 		for (int i = 0; i < 256; i++) {
 			for (int j = 0; j < 256; j++) {
 				if (i == j) { //No need to calculate transparency between 2 identical colours

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -107,30 +107,35 @@ void LoadPalette(const char *pszFileName)
 	* We save this info in a lookup table we use during rendering for whenever we want this kind of transparency.
 	* 
 	*/
-	for (int i = 0; i < 256; i++) {
-		for (int j = 0; j < 256; j++) {
-			if (i == j) {
-				palette_transparency_lookup[i][j] = j;
-				continue;
-			}
-
-			Uint8 r = ((int)orig_palette[i].r + (int)orig_palette[j].r) / 2;
-			Uint8 g = ((int)orig_palette[i].g + (int)orig_palette[j].g) / 2;
-			Uint8 b = ((int)orig_palette[i].b + (int)orig_palette[j].b) / 2;
-			BYTE best;
-			int bestDiff = 255 * 3;
-			for (int k = 0; k < 256; k++) {
-				int diffr = orig_palette[k].r - r;
-				int diffg = orig_palette[k].g - g;
-				int diffb = orig_palette[k].b - b;
-				int diff = diffr * diffr + diffg * diffg + diffb * diffb;
-
-				if (k == 0 || bestDiff > diff) {
-					best = k;
-					bestDiff = diff;
+	if (options_transparency == 1) {
+		for (int i = 0; i < 256; i++) {
+			for (int j = 0; j < 256; j++) {
+				if (i == j) { //No need to calculate transparency between 2 identical colours
+					palette_transparency_lookup[i][j] = j;
+					continue;
+				} else if (i > j) { //Since there's a lot of redundancy ([i][j] will always have the same value as [j][i]), we skip calculating combinations which have already been calculated
+					palette_transparency_lookup[i][j] = palette_transparency_lookup[j][i];
+					continue;
 				}
+
+				Uint8 r = ((int)orig_palette[i].r + (int)orig_palette[j].r) / 2;
+				Uint8 g = ((int)orig_palette[i].g + (int)orig_palette[j].g) / 2;
+				Uint8 b = ((int)orig_palette[i].b + (int)orig_palette[j].b) / 2;
+				BYTE best;
+				int bestDiff = 255 * 3;
+				for (int k = 0; k < 256; k++) {
+					int diffr = orig_palette[k].r - r;
+					int diffg = orig_palette[k].g - g;
+					int diffb = orig_palette[k].b - b;
+					int diff = diffr * diffr + diffg * diffg + diffb * diffb;
+
+					if (k == 0 || bestDiff > diff) {
+						best = k;
+						bestDiff = diff;
+					}
+				}
+				palette_transparency_lookup[i][j] = best;
 			}
-			palette_transparency_lookup[i][j] = best;
 		}
 	}
 }

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -120,10 +120,11 @@ void LoadPalette(const char *pszFileName)
 			BYTE best;
 			int bestDiff = 255 * 3;
 			for (int k = 0; k < 256; k++) {
-				int diff = 0;
-				diff += r > orig_palette[k].r ? r - orig_palette[k].r : orig_palette[k].r - r;
-				diff += g > orig_palette[k].g ? g - orig_palette[k].g : orig_palette[k].g - g;
-				diff += b > orig_palette[k].b ? b - orig_palette[k].b : orig_palette[k].b - b;
+				int diffr = orig_palette[k].r - r;
+				int diffg = orig_palette[k].g - g;
+				int diffb = orig_palette[k].b - b;
+				int diff = diffr * diffr + diffg * diffg + diffb * diffb;
+
 				if (k == 0 || bestDiff > diff) {
 					best = k;
 					bestDiff = diff;

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -12,7 +12,7 @@ DEVILUTION_BEGIN_NAMESPACE
 SDL_Color logical_palette[256];
 SDL_Color system_palette[256];
 SDL_Color orig_palette[256];
-BYTE palette_transparency_lookup[256][256]; //Fluffy
+BYTE palette_transparency_lookup[256][256]; //Lookup table for transparency
 
 /* data */
 
@@ -101,7 +101,7 @@ void LoadPalette(const char *pszFileName)
 #endif
 	}
 
-	/* Fluffy: Generate lookup table for transparency
+	/* Generate lookup table for transparency
 	*
 	* Explanation for how this works: To mimic 50% transparency we figure out what colours in the existing palette are the best match for the combination of any 2 colours.
 	* We save this info in a lookup table we use during rendering for whenever we want this kind of transparency.

--- a/Source/palette.h
+++ b/Source/palette.h
@@ -15,6 +15,7 @@ extern "C" {
 extern SDL_Color logical_palette[256];
 extern SDL_Color system_palette[256];
 extern SDL_Color orig_palette[256];
+extern BYTE palette_transparency_lookup[256][256];
 
 void palette_update();
 void SaveGamma();

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -18,6 +18,65 @@ enum {
 	RT_RTRAPEZOID
 };
 
+/** Fluffy: Fully transparent variant of WallMask. */
+static DWORD WallMask_FullyTrasparent[TILE_HEIGHT] = {
+	0x00000000, 0x00000000,
+	0x00000000, 0x00000000,
+	0x00000000, 0x00000000,
+	0x00000000, 0x00000000,
+	0x00000000, 0x00000000,
+	0x00000000, 0x00000000,
+	0x00000000, 0x00000000,
+	0x00000000, 0x00000000,
+	0x00000000, 0x00000000,
+	0x00000000, 0x00000000,
+	0x00000000, 0x00000000,
+	0x00000000, 0x00000000,
+	0x00000000, 0x00000000,
+	0x00000000, 0x00000000,
+	0x00000000, 0x00000000,
+	0x00000000, 0x00000000
+};
+
+/** Fluffy: Transparent variant of RightMask. */
+static DWORD RightMask_Transparent[TILE_HEIGHT] = {
+	0xE0000000, 0xF0000000,
+	0xFE000000, 0xFF000000,
+	0xFFE00000, 0xFFF00000,
+	0xFFFE0000, 0xFFFF0000,
+	0xFFFFE000, 0xFFFFF000,
+	0xFFFFFE00, 0xFFFFFF00,
+	0xFFFFFFE0, 0xFFFFFFF0,
+	0xFFFFFFFE, 0xFFFFFFFF,
+	0xFFFFFFFF, 0xFFFFFFFF,
+	0xFFFFFFFF, 0xFFFFFFFF,
+	0xFFFFFFFF, 0xFFFFFFFF,
+	0xFFFFFFFF, 0xFFFFFFFF,
+	0xFFFFFFFF, 0xFFFFFFFF,
+	0xFFFFFFFF, 0xFFFFFFFF,
+	0xFFFFFFFF, 0xFFFFFFFF,
+	0xFFFFFFFF, 0xFFFFFFFF
+};
+/** Fluffy: Transparent variant of LeftMask. */
+static DWORD LeftMask_Transparent[TILE_HEIGHT] = {
+	0x00000003, 0x0000000F,
+	0x0000003F, 0x000000FF,
+	0x000003FF, 0x00000FFF,
+	0x00003FFF, 0x0000FFFF,
+	0x0003FFFF, 0x000FFFFF,
+	0x003FFFFF, 0x00FFFFFF,
+	0x03FFFFFF, 0x0FFFFFFF,
+	0x3FFFFFFF, 0xFFFFFFFF,
+	0xFFFFFFFF, 0xFFFFFFFF,
+	0xFFFFFFFF, 0xFFFFFFFF,
+	0xFFFFFFFF, 0xFFFFFFFF,
+	0xFFFFFFFF, 0xFFFFFFFF,
+	0xFFFFFFFF, 0xFFFFFFFF,
+	0xFFFFFFFF, 0xFFFFFFFF,
+	0xFFFFFFFF, 0xFFFFFFFF,
+	0xFFFFFFFF, 0xFFFFFFFF
+};
+
 /** Specifies the draw masks used to render transparency of the right side of tiles. */
 static DWORD RightMask[TILE_HEIGHT] = {
 	0xEAAAAAAA, 0xF5555555,
@@ -232,22 +291,32 @@ void RenderTile(BYTE *pBuff)
 	tile = (level_cel_block & 0x7000) >> 12;
 	tbl = &pLightTbl[256 * light_table_index];
 
+	//The mask defines what parts of the tile is opaque
 	mask = &SolidMask[TILE_HEIGHT - 1];
 
 	if (cel_transparency_active) {
 		if (arch_draw_type == 0) {
-			mask = &WallMask[TILE_HEIGHT - 1];
+			if (options_transparency == 1) //Fluffy
+				mask = &WallMask_FullyTrasparent[TILE_HEIGHT - 1];
+			else
+				mask = &WallMask[TILE_HEIGHT - 1];
 		}
 		if (arch_draw_type == 1 && tile != RT_LTRIANGLE) {
 			c = block_lvid[level_piece_id];
 			if (c == 1 || c == 3) {
-				mask = &LeftMask[TILE_HEIGHT - 1];
+				if (options_transparency == 1) //Fluffy
+					mask = &LeftMask_Transparent[TILE_HEIGHT - 1];
+				else
+					mask = &LeftMask[TILE_HEIGHT - 1];
 			}
 		}
 		if (arch_draw_type == 2 && tile != RT_RTRIANGLE) {
 			c = block_lvid[level_piece_id];
 			if (c == 2 || c == 3) {
-				mask = &RightMask[TILE_HEIGHT - 1];
+				if (options_transparency == 1) //Fluffy
+					mask = &RightMask_Transparent[TILE_HEIGHT - 1];
+				else
+					mask = &RightMask[TILE_HEIGHT - 1];
 			}
 		}
 	} else if (arch_draw_type && cel_foliage_active) {
@@ -379,7 +448,9 @@ void trans_rect(int sx, int sy, int width, int height)
 	BYTE *pix = &gpBuffer[SCREENXY(sx, sy)];
 	for (row = 0; row < height; row++) {
 		for (col = 0; col < width; col++) {
-			if ((row & 1 && col & 1) || (!(row & 1) && !(col & 1)))
+			if (options_transparency == 1) //Fluffy
+				*pix = palette_transparency_lookup[0][*pix];
+			else if ((row & 1 && col & 1) || (!(row & 1) && !(col & 1)))
 				*pix = 0;
 			pix++;
 		}

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -200,13 +200,13 @@ inline static void RenderLine(BYTE **dst, BYTE **src, int n, BYTE *tbl, DWORD ma
 		if (light_table_index == lightmax) {
 			foreach_set_bit(mask, [=](int i) { (*dst)[i] = 0; });
 		} else if (light_table_index == 0) {
-			foreach_set_bit(mask, [=](int i) { (*dst)[i] = (*src)[i]; });
-		} else {
-			foreach_set_bit(mask, [=](int i) { (*dst)[i] = tbl[(*src)[i]]; });
-		}
-	}
+			for (i = 0; i < n; i++, (*src)++, (*dst)++, mask <<= 1) {
+				if (mask & 0x80000000) {
+					(*dst)[0] = (*src)[0];
+				}
+			}
 
-skip:
+			}
 	(*src) += n;
 	(*dst) += n;
 }

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -18,7 +18,7 @@ enum {
 	RT_RTRAPEZOID
 };
 
-/** Fluffy: Fully transparent variant of WallMask. */
+/** Fully transparent variant of WallMask. */
 static DWORD WallMask_FullyTrasparent[TILE_HEIGHT] = {
 	0x00000000, 0x00000000,
 	0x00000000, 0x00000000,
@@ -38,7 +38,7 @@ static DWORD WallMask_FullyTrasparent[TILE_HEIGHT] = {
 	0x00000000, 0x00000000
 };
 
-/** Fluffy: Transparent variant of RightMask. */
+/** Transparent variant of RightMask. */
 static DWORD RightMask_Transparent[TILE_HEIGHT] = {
 	0xE0000000, 0xF0000000,
 	0xFE000000, 0xFF000000,
@@ -57,7 +57,7 @@ static DWORD RightMask_Transparent[TILE_HEIGHT] = {
 	0xFFFFFFFF, 0xFFFFFFFF,
 	0xFFFFFFFF, 0xFFFFFFFF
 };
-/** Fluffy: Transparent variant of LeftMask. */
+/** Transparent variant of LeftMask. */
 static DWORD LeftMask_Transparent[TILE_HEIGHT] = {
 	0x00000003, 0x0000000F,
 	0x0000003F, 0x000000FF,
@@ -256,7 +256,7 @@ inline static void RenderLine(BYTE **dst, BYTE **src, int n, BYTE *tbl, DWORD ma
 		assert(n != 0 && n <= sizeof(DWORD) * CHAR_BIT);
 		mask &= DWORD(-1) << ((sizeof(DWORD) * CHAR_BIT) - n);
 
-		if (options_transparency) { //Fluffy: Render transparent pixels in the mask with actual transparent, and the rest as opaque pixels
+		if (options_transparency) { //Render transparent pixels in the mask with actual transparent, and the rest as opaque pixels
 			if (light_table_index == lightmax) { //Complete darkness
 				for (int i = 0; i < n; i++, mask <<= 1) {
 					if (mask & 0x80000000)
@@ -321,7 +321,7 @@ void RenderTile(BYTE *pBuff)
 
 	if (cel_transparency_active) {
 		if (arch_draw_type == 0) {
-			if (options_transparency == true) //Fluffy: Use a fully transparent mask
+			if (options_transparency == true) //Use a fully transparent mask
 				mask = &WallMask_FullyTrasparent[TILE_HEIGHT - 1];
 			else
 				mask = &WallMask[TILE_HEIGHT - 1];
@@ -329,7 +329,7 @@ void RenderTile(BYTE *pBuff)
 		if (arch_draw_type == 1 && tile != RT_LTRIANGLE) {
 			c = block_lvid[level_piece_id];
 			if (c == 1 || c == 3) {
-				if (options_transparency == true) //Fluffy: Use a fully transparent mask
+				if (options_transparency == true) //Use a fully transparent mask
 					mask = &LeftMask_Transparent[TILE_HEIGHT - 1];
 				else
 					mask = &LeftMask[TILE_HEIGHT - 1];
@@ -338,7 +338,7 @@ void RenderTile(BYTE *pBuff)
 		if (arch_draw_type == 2 && tile != RT_RTRIANGLE) {
 			c = block_lvid[level_piece_id];
 			if (c == 2 || c == 3) {
-				if (options_transparency == true) //Fluffy: Use a fully transparent mask
+				if (options_transparency == true) //Use a fully transparent mask
 					mask = &RightMask_Transparent[TILE_HEIGHT - 1];
 				else
 					mask = &RightMask[TILE_HEIGHT - 1];
@@ -473,9 +473,9 @@ void trans_rect(int sx, int sy, int width, int height)
 	BYTE *pix = &gpBuffer[SCREENXY(sx, sy)];
 	for (row = 0; row < height; row++) {
 		for (col = 0; col < width; col++) {
-			if (options_transparency == 1) //Fluffy
+			if (options_transparency == 1) //Transparency
 				*pix = palette_transparency_lookup[0][*pix];
-			else if ((row & 1 && col & 1) || (!(row & 1) && !(col & 1)))
+			else if ((row & 1 && col & 1) || (!(row & 1) && !(col & 1))) //Dithering
 				*pix = 0;
 			pix++;
 		}

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -783,7 +783,17 @@ static void scrollrt_draw_dungeon(int sx, int sy, int dx, int dy)
 		bArch = dSpecial[sx][sy];
 		if (bArch != 0) {
 			cel_transparency_active = TransList[bMap];
+#ifdef _DEBUG
+			if (GetAsyncKeyState(DVL_VK_MENU) & 0x8000) {
+				cel_transparency_active = 0; //Fluffy: Turn transparency off here for debugging
+			}
+#endif
 			CelClippedBlitLightTrans(&gpBuffer[dx + BUFFER_WIDTH * dy], pSpecialCels, bArch, 64);
+#ifdef _DEBUG
+			if (GetAsyncKeyState(DVL_VK_MENU) & 0x8000) {
+				cel_transparency_active = TransList[bMap]; //Fluffy: Turn transparency back to its normal state
+			}
+#endif
 		}
 	} else {
 		// Tree leaves should always cover player when entering or leaving the tile,

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -785,13 +785,13 @@ static void scrollrt_draw_dungeon(int sx, int sy, int dx, int dy)
 			cel_transparency_active = TransList[bMap];
 #ifdef _DEBUG
 			if (GetAsyncKeyState(DVL_VK_MENU) & 0x8000) {
-				cel_transparency_active = 0; //Fluffy: Turn transparency off here for debugging
+				cel_transparency_active = 0; //Turn transparency off here for debugging
 			}
 #endif
 			CelClippedBlitLightTrans(&gpBuffer[dx + BUFFER_WIDTH * dy], pSpecialCels, bArch, 64);
 #ifdef _DEBUG
 			if (GetAsyncKeyState(DVL_VK_MENU) & 0x8000) {
-				cel_transparency_active = TransList[bMap]; //Fluffy: Turn transparency back to its normal state
+				cel_transparency_active = TransList[bMap]; //Turn transparency back to its normal state
 			}
 #endif
 		}


### PR DESCRIPTION
Adds a toggle ("Transparency = 1" in config) to replace the dithering-based transparency with proper transparency (this is accomplished by creating a lookup table listing what colours in the palette are the closest approximation of every set of 2 colours blended).

Screenshots of transparency:
https://cdn.discordapp.com/attachments/518562502250856489/802176578104066078/devilutionx_2021-01-22_14-59-56-125.png
https://cdn.discordapp.com/attachments/518562502250856489/802193938667929650/devilutionx_2021-01-22_16-11-38-472.png

I need feedback on these things:
- I have a tendency to add "//Fluffy: I did thing!" as a way to track what changes I've done when I program. Not sure if those should be kept.
- I added config.cpp which I'm thinking could be a nice place to add future config toggles. Not sure if this should be kept either.
- The new code in RenderLine() can probably be cleaned up, but I'm not sure how.
- I replaced Griswold with a cow. I feel it only makes sense now as we have support for proper transparency.
- ... Okay, fine I didn't replace Griswold with a cow. It was tempting, though.