### PR TITLE
[bugfix] Quest items from previous games breaking dungeon

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1567,7 +1567,7 @@ void CheckBookLevel(int pnum)
 
 void CheckQuestItem(int pnum)
 {
-	if (plr[pnum].HoldItem.IDidx == IDI_OPTAMULET)
+	if (plr[pnum].HoldItem.IDidx == IDI_OPTAMULET && quests[Q_BLIND]._qactive == QUEST_ACTIVE)
 		quests[Q_BLIND]._qactive = QUEST_DONE;
 	if (plr[pnum].HoldItem.IDidx == IDI_MUSHROOM && quests[Q_MUSHROOM]._qactive == QUEST_ACTIVE && quests[Q_MUSHROOM]._qvar1 == QS_MUSHSPAWNED) {
 		sfxdelay = 10;
@@ -1586,7 +1586,7 @@ void CheckQuestItem(int pnum)
 		}
 		quests[Q_MUSHROOM]._qvar1 = QS_MUSHPICKED;
 	}
-	if (plr[pnum].HoldItem.IDidx == IDI_ANVIL) {
+	if (plr[pnum].HoldItem.IDidx == IDI_ANVIL && quests[Q_ANVIL]._qactive != QUEST_NOTAVAIL) {
 		if (quests[Q_ANVIL]._qactive == QUEST_INIT) {
 			quests[Q_ANVIL]._qactive = QUEST_ACTIVE;
 			quests[Q_ANVIL]._qvar1 = 1;
@@ -1608,7 +1608,7 @@ void CheckQuestItem(int pnum)
 			}
 		}
 	}
-	if (plr[pnum].HoldItem.IDidx == IDI_GLDNELIX) {
+	if (plr[pnum].HoldItem.IDidx == IDI_GLDNELIX && quests[Q_VEIL]._qactive != QUEST_NOTAVAIL) {
 		sfxdelay = 30;
 		if (plr[myplr]._pClass == PC_WARRIOR) {
 			sfxdnum = PS_WARR88;
@@ -1624,7 +1624,7 @@ void CheckQuestItem(int pnum)
 			sfxdnum = PS_WARR88;
 		}
 	}
-	if (plr[pnum].HoldItem.IDidx == IDI_ROCK) {
+	if (plr[pnum].HoldItem.IDidx == IDI_ROCK && quests[Q_ROCK]._qactive != QUEST_NOTAVAIL) {
 		if (quests[Q_ROCK]._qactive == QUEST_INIT) {
 			quests[Q_ROCK]._qactive = QUEST_ACTIVE;
 			quests[Q_ROCK]._qvar1 = 1;
@@ -1646,7 +1646,7 @@ void CheckQuestItem(int pnum)
 			}
 		}
 	}
-	if (plr[pnum].HoldItem.IDidx == IDI_ARMOFVAL) {
+	if (plr[pnum].HoldItem.IDidx == IDI_ARMOFVAL && quests[Q_BLOOD]._qactive == QUEST_ACTIVE) {
 		quests[Q_BLOOD]._qactive = QUEST_DONE;
 		sfxdelay = 20;
 		if (plr[myplr]._pClass == PC_WARRIOR) {

--- a/enums.h
+++ b/enums.h
@@ -3052,10 +3052,10 @@ typedef enum quest_id {
 } quest_id;
 
 typedef enum quest_state {
-	QUEST_NOTAVAIL = 0,
-	QUEST_INIT     = 1,
-	QUEST_ACTIVE   = 2,
-	QUEST_DONE     = 3
+	QUEST_NOTAVAIL = 0, // quest did not spawn this game
+	QUEST_INIT     = 1, // quest has spawned, waiting to trigger
+	QUEST_ACTIVE   = 2, // quest is currently in progress
+	QUEST_DONE     = 3  // quest log closed and finished
 } quest_state;
 
 typedef enum quest_gametype {


### PR DESCRIPTION
If you held quest items over from a previous game, such as Arkaine's Valor, then bring them to a new game where that quest didn't spawn, it can erroneously set the quest status from not available to completed. If you spawn the dungeon, go to a different level, pick the item up, then come back, the dungeon will be messed up as it will spawn the quest set pieces.

As a good side effect "May the spirit of Arkaine protect me" will only play once now and then the quest finishes so never again. Whew, thank god ^^

Can't remember who found this bug, @Nitekat ?