### PR TITLE
make repair costs consistent

### DIFF
--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -741,7 +741,7 @@ static void AddStoreHoldRepair(ItemStruct *itm, int i)
 	storehold[storenumh] = *itm;
 	if (item->_iMagical != ITEM_QUALITY_NORMAL && item->_iIdentified)
 		item->_ivalue = 30 * item->_iIvalue / 100;
-	v = item->_ivalue * (100 * (item->_iMaxDur - item->_iDurability) / item->_iMaxDur) / 100;
+	v = item->_ivalue * (100 * (1) / item->_iMaxDur) / 100;
 	if (!v) {
 		if (item->_iMagical != ITEM_QUALITY_NORMAL && item->_iIdentified)
 			return;
@@ -749,6 +749,7 @@ static void AddStoreHoldRepair(ItemStruct *itm, int i)
 	}
 	if (v > 1)
 		v >>= 1;
+	v *= item->_iMaxDur - item->_iDurability;
 	item->_iIvalue = v;
 	item->_ivalue = v;
 	storehidx[storenumh] = i;
@@ -1006,7 +1007,8 @@ void AddStoreHoldRecharge(ItemStruct itm, int i)
 {
 	storehold[storenumh] = itm;
 	storehold[storenumh]._ivalue += spelldata[itm._iSpell].sStaffCost;
-	storehold[storenumh]._ivalue = storehold[storenumh]._ivalue * (100 * (storehold[storenumh]._iMaxCharges - storehold[storenumh]._iCharges) / storehold[storenumh]._iMaxCharges) / 100 >> 1;
+	storehold[storenumh]._ivalue = storehold[storenumh]._ivalue * (100 * (1) / storehold[storenumh]._iMaxCharges) / 100 >> 1;
+	storehold[storenumh]._ivalue *= storehold[storenumh]._iMaxCharges - storehold[storenumh]._iCharges;
 	storehold[storenumh]._iIvalue = storehold[storenumh]._ivalue;
 	storehidx[storenumh] = i;
 	storenumh++;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14297035/107151467-04509200-6963-11eb-9b0d-4a07c9c9fa77.png)
```cpp
886 gold to repair 16 dura = 55.37 gold per dura - cost increase - 62 (!)
824 gold to repair 15 dura = 54.93 gold per dura - cost increase - 53
771 gold to repair 14 dura = 55.07 gold per dura - cost increase - 53
718 gold to repair 13 dura = 55.23 gold per dura - cost increase - 54
664 gold to repair 12 dura = 55.33 gold per dura - cost increase - 62 (!)
602 gold to repair 11 dura = 54.72 gold per dura - cost increase - 53
549 gold to repair 10 dura = 54.90 gold per dura - cost increase - 53
496 gold to repair 9  dura = 55.11 gold per dura - cost increase - 53
443 gold to repair 8  dura = 55.37 gold per dura - cost increase - 62 (!)
381 gold to repair 7  dura = 54.42 gold per dura - cost increase - 53
328 gold to repair 6  dura = 54.66 gold per dura - cost increase - 54
274 gold to repair 5  dura = 54.80 gold per dura - cost increase - 53
221 gold to repair 4  dura = 55.25 gold per dura - cost increase - 62 (!)
159 gold to repair 3  dura = 53.00 gold per dura - cost increase - 53
106 gold to repair 2  dura = 53.00 gold per dura - cost increase - 53
53  gold to repair 1  dura = 53.00 gold per dura - cost increase - 53
```

Here's a sample of how inconsistent the original formula is. What I'm doing is making the total repair cost be
`the cost to repair 1 charge/durability * number of durability/charges missing.`

This has a side effect of limiting minimal repair/recharge cost per 1 durability/charge to 1. I  don't think you could get a recharge cost that low, but some super crappy white items had cost lower than 1 per dura to repair them (Cap etc.) But the overall difference is probably below 10 gold, so I don't think it matters in general.