### PR TITLE
Quest bug fixes including Valor [proper]

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1496,6 +1496,7 @@ void AddPedistal(int i)
 	object[i]._oVar2 = setpc_y;
 	object[i]._oVar3 = setpc_x + setpc_w;
 	object[i]._oVar4 = setpc_y + setpc_h;
+	object[i]._oVar6 = 0;
 }
 
 void AddStoryBook(int i)
@@ -2943,6 +2944,9 @@ void OperateBookLever(int pnum, int i)
 
 	x = 2 * setpc_x + 16;
 	y = 2 * setpc_y + 16;
+	if (numitems >= MAXITEMS) {
+		return;
+	}
 	if (object[i]._oSelFlag != 0 && !qtextflag) {
 		if (object[i]._otype == OBJ_BLINDBOOK && quests[Q_BLIND]._qvar1 == 0) {
 			quests[Q_BLIND]._qactive = QUEST_ACTIVE;
@@ -2953,8 +2957,6 @@ void OperateBookLever(int pnum, int i)
 			quests[Q_BLOOD]._qactive = QUEST_ACTIVE;
 			quests[Q_BLOOD]._qlog = TRUE;
 			quests[Q_BLOOD]._qvar1 = 1;
-			SpawnQuestItem(IDI_BLDSTONE, 2 * setpc_x + 19, 2 * setpc_y + 26, 0, 1);
-			SpawnQuestItem(IDI_BLDSTONE, 2 * setpc_x + 31, 2 * setpc_y + 26, 0, 1);
 			SpawnQuestItem(IDI_BLDSTONE, 2 * setpc_x + 25, 2 * setpc_y + 33, 0, 1);
 		}
 		object[i]._otype = object[i]._otype;
@@ -3075,6 +3077,10 @@ void OperateMushPatch(int pnum, int i)
 {
 	int x, y;
 
+	if (numitems >= MAXITEMS) {
+		return;
+	}
+
 	if (quests[Q_MUSHROOM]._qactive != QUEST_ACTIVE || quests[Q_MUSHROOM]._qvar1 < QS_TOMEGIVEN) {
 		if (!deltaload && pnum == myplr) {
 			if (plr[myplr]._pClass == PC_WARRIOR) {
@@ -3109,6 +3115,10 @@ void OperateMushPatch(int pnum, int i)
 void OperateInnSignChest(int pnum, int i)
 {
 	int x, y;
+
+	if (numitems >= MAXITEMS) {
+		return;
+	}
 
 	if (quests[Q_LTBANNER]._qvar1 != 2) {
 		if (!deltaload && pnum == myplr) {
@@ -3254,21 +3264,25 @@ void OperatePedistal(int pnum, int i)
 	BYTE *mem;
 	int iv;
 
-	if (object[i]._oVar6 != 3) {
-		if (PlrHasItem(pnum, IDI_BLDSTONE, &iv) != NULL) {
-			RemoveInvItem(pnum, iv);
-			object[i]._oAnimFrame++;
-			object[i]._oVar6++;
-		}
+	if (numitems >= MAXITEMS) {
+		return;
+	}
+
+	if (object[i]._oVar6 != 3 && PlrHasItem(pnum, IDI_BLDSTONE, &iv) != NULL) {
+		RemoveInvItem(pnum, iv);
+		object[i]._oAnimFrame++;
+		object[i]._oVar6++;
 		if (object[i]._oVar6 == 1) {
 			if (!deltaload)
 				PlaySfxLoc(LS_PUDDLE, object[i]._ox, object[i]._oy);
 			ObjChangeMap(setpc_x, setpc_y + 3, setpc_x + 2, setpc_y + 7);
+			SpawnQuestItem(IDI_BLDSTONE, 2 * setpc_x + 19, 2 * setpc_y + 26, 0, 1);
 		}
 		if (object[i]._oVar6 == 2) {
 			if (!deltaload)
 				PlaySfxLoc(LS_PUDDLE, object[i]._ox, object[i]._oy);
 			ObjChangeMap(setpc_x + 6, setpc_y + 3, setpc_x + setpc_w, setpc_y + 7);
+			SpawnQuestItem(IDI_BLDSTONE, 2 * setpc_x + 31, 2 * setpc_y + 26, 0, 1);
 		}
 		if (object[i]._oVar6 == 3) {
 			if (!deltaload)
@@ -4412,6 +4426,10 @@ void OperateStoryBook(int pnum, int i)
 void OperateLazStand(int pnum, int i)
 {
 	int xx, yy;
+
+	if (numitems >= MAXITEMS) {
+		return;
+	}
 
 	if (object[i]._oSelFlag != 0 && !deltaload && !qtextflag && pnum == myplr) {
 		object[i]._oAnimFrame++;


### PR DESCRIPTION
Three new fixes here. First and foremost, I'd like to credit @qndel for finding the Valor bug. It took awhile to finally track down the actual cause.

#### Arkaine's Valor quest could sometimes be partially/fully completed

This is caused by the fact the number of stones in the pedestal are stored in `_oVar6`. This variable is never initialized and only used by books and pedestals. Let's say you read a book on level 4 and it sets Var6 to 3, now this book is in object slot `50`. You go down to level 5 and the pedestal also happens to spawn in slot 50. This means it will think there are 3 stones despite the fact there are none.

#### Blood Stones spawn all at once

Now they only spawn one at a time, which prevents people from being able to telekinesis them (sorry speedrunners!). This also as a side effect fixes the accidental deletion if you drop one.

#### Quest items don't spawn when 127 items are on floor

If you try to click on the mushroom patch for example, it will "use it" but not spawn anything, breaking the quest. Now these objects will not function until a slot is available.

All 3 of these bugs were fixed on the PSX port, and I took the same approach code-wise.

![Capture](https://user-images.githubusercontent.com/65138215/107172666-8a80ce80-698b-11eb-85b1-ff96f2913536.PNG)
