### PR TITLE
update damage after leveling up

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -929,7 +929,7 @@ void NextPlrLevel(int pnum)
 
 	if (sgbControllerActive)
 		FocusOnCharInfo();
-	CalcPlrInv(pnum, TRUE);
+		CalcPlrInv(pnum, TRUE);
 }
 
 void AddPlrExperience(int pnum, int lvl, int exp)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -929,6 +929,7 @@ void NextPlrLevel(int pnum)
 
 	if (sgbControllerActive)
 		FocusOnCharInfo();
+	CalcPlrInv(pnum, TRUE);
 }
 
 void AddPlrExperience(int pnum, int lvl, int exp)


### PR DESCRIPTION
This fixes a vanilla bug where you level up but your damage only gets updated after you spend a stat point or equip/unequip any item - leveling up itself didn't call updating damage despite being one of the factors in the damage formula
How to reproduce:
Level up from 3 to 4 with rogue, unequip an item, notice dmg +1 jump.

With this fix it will update automatically