### PR TITLE
Remove item persistence from 'inv.SpecialAutoPlace'

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -636,7 +636,7 @@ BOOL AutoPlace(int pnum, int ii, int sx, int sy, BOOL saveflag)
 	return done;
 }
 
-BOOL SpecialAutoPlace(int pnum, int ii, int sx, int sy, BOOL saveflag)
+BOOL SpecialAutoPlace(int pnum, int ii, int sx, int sy)
 {
 	int i, j, xx, yy;
 	BOOL done;
@@ -676,30 +676,7 @@ BOOL SpecialAutoPlace(int pnum, int ii, int sx, int sy, BOOL saveflag)
 			}
 		}
 	}
-	if (done && saveflag) {
-		plr[pnum].InvList[plr[pnum]._pNumInv] = plr[pnum].HoldItem;
-		plr[pnum]._pNumInv++;
-		yy = 10 * (ii / 10);
-		if (yy < 0) {
-			yy = 0;
-		}
-		for (j = 0; j < sy; j++) {
-			xx = ii % 10;
-			if (xx < 0) {
-				xx = 0;
-			}
-			for (i = 0; i < sx; i++) {
-				if (i != 0 || j != sy - 1) {
-					plr[pnum].InvGrid[xx + yy] = -plr[pnum]._pNumInv;
-				} else {
-					plr[pnum].InvGrid[xx + yy] = plr[pnum]._pNumInv;
-				}
-				xx++;
-			}
-			yy += 10;
-		}
-		CalcPlrScrolls(pnum);
-	}
+	
 	return done;
 }
 

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -21,7 +21,7 @@ void InitInv();
 void DrawInv();
 void DrawInvBelt();
 BOOL AutoPlace(int pnum, int ii, int sx, int sy, BOOL saveflag);
-BOOL SpecialAutoPlace(int pnum, int ii, int sx, int sy, BOOL saveflag);
+BOOL SpecialAutoPlace(int pnum, int ii, int sx, int sy);
 BOOL GoldAutoPlace(int pnum);
 int SwapItem(ItemStruct *a, ItemStruct *b);
 void CheckInvSwap(int pnum, BYTE bLoc, int idx, WORD wCI, int seed, BOOL bId);

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2289,7 +2289,7 @@ void S_WBuyEnter()
 			done = FALSE;
 
 			for (i = 0; i < NUM_INV_GRID_ELEM && !done; i++) {
-				done = SpecialAutoPlace(myplr, i, cursW / 28, cursH / 28, FALSE);
+				done = SpecialAutoPlace(myplr, i, cursW / 28, cursH / 28);
 			}
 
 			if (done)
@@ -2598,7 +2598,7 @@ void S_HBuyEnter()
 			done = FALSE;
 			i = 0;
 			for (i = 0; i < NUM_INV_GRID_ELEM && !done; i++) {
-				done = SpecialAutoPlace(myplr, i, cursW / 28, cursH / 28, FALSE);
+				done = SpecialAutoPlace(myplr, i, cursW / 28, cursH / 28);
 			}
 			if (done)
 				StartStore(STORE_CONFIRM);


### PR DESCRIPTION
The 'saveFlag' argument used for persisting the changes into the
inventory is never leveraged on this function: all existing consumers
provide 'FALSE'. It was probably a copy-paste leftover from the
standard 'AutoPlace'.