### PR TITLE
fix level transitions making cursor items disappear

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -4504,6 +4504,8 @@ void MI_Town(int i)
 		if (plr[p].plractive && currlevel == plr[p].plrlevel && !plr[p]._pLvlChanging && plr[p]._pmode == PM_STAND && plr[p]._px == missile[i]._mix && plr[p]._py == missile[i]._miy) {
 			ClrPlrPath(p);
 			if (p == myplr) {
+				if (!DropItemBeforeTrig())
+					break;
 				NetSendCmdParam1(TRUE, CMD_WARP, missile[i]._misource);
 				plr[p]._pmode = PM_NEWLVL;
 			}

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1935,10 +1935,6 @@ static DWORD On_WARP(TCmd *pCmd, int pnum)
 		msg_send_packet(pnum, p, sizeof(*p));
 	else {
 		StartWarpLvl(pnum, p->wParam1);
-		if (pnum == myplr && pcurs >= CURSOR_FIRSTITEM) {
-			item[MAXITEMS] = plr[myplr].HoldItem;
-			AutoGetItem(myplr, MAXITEMS);
-		}
 	}
 
 	return sizeof(*p);

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -241,6 +241,8 @@ void CheckQuests()
 			    && quests[i]._qactive != QUEST_NOTAVAIL
 			    && plr[myplr]._px == quests[i]._qtx
 			    && plr[myplr]._py == quests[i]._qty) {
+				if (pcurs >= CURSOR_FIRSTITEM && !DropItemBeforeTrig())
+					continue;
 				if (quests[i]._qlvltype != DTYPE_NONE) {
 					setlvltype = quests[i]._qlvltype;
 				}

--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -844,6 +844,9 @@ void CheckTriggers()
 			continue;
 		}
 
+		if (pcurs >= CURSOR_FIRSTITEM && !DropItemBeforeTrig())
+			return;
+
 		switch (trigs[i]._tmsg) {
 		case WM_DIABNEXTLVL:
 			if (gbIsSpawn && currlevel >= 2) {
@@ -851,14 +854,10 @@ void CheckTriggers()
 				PlaySFX(PS_WARR18);
 				InitDiabloMsg(EMSG_NOT_IN_SHAREWARE);
 			} else {
-				if (pcurs >= CURSOR_FIRSTITEM && DropItemBeforeTrig())
-					return;
 				StartNewLvl(myplr, trigs[i]._tmsg, currlevel + 1);
 			}
 			break;
 		case WM_DIABPREVLVL:
-			if (pcurs >= CURSOR_FIRSTITEM && DropItemBeforeTrig())
-				return;
 			StartNewLvl(myplr, trigs[i]._tmsg, currlevel - 1);
 			break;
 		case WM_DIABRTNLVL:


### PR DESCRIPTION
In vanilla they attempted to deal with cursor items disappearing during level transitions but pretty much failed.
There's a `DropItemBeforeTrig` function but they did a wrong check for return value and only used it for next/previous level transitions.
Town portals attempted to put cursor item back to inventory, but if it wasn't possible (you rearranged items in inventory in such a way the cursor item doesn't fit anymore), the cursor item would simply be gone.
Fast entrances in town simply destroyed cursor items.

```cpp
		if (pnum == myplr && pcurs >= CURSOR_FIRSTITEM) {
			item[MAXITEMS] = plr[myplr].HoldItem;
			AutoGetItem(myplr, MAXITEMS);
		}
```
I'm removing this original code from portals, as our antidupe fix broke AutoGetItem in this case anyway
```cpp
	if (pcurs != CURSOR_HAND) {
		return;
	}
```

+ I think dropping an item on the ground is a better solution as it will only fail when there are more than 127 items on the ground.

