### PR TITLE
Remove items dropping before entering level

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1582,7 +1582,9 @@ void LoadGameLevel(BOOL firstflag, int lvldir)
 		glSeedTbl[currlevel] = setseed;
 
 	music_stop();
-	NewCursor(CURSOR_HAND);
+	if (pcurs > CURSOR_HAND && pcurs < CURSOR_FIRSTITEM) {
+		NewCursor(CURSOR_HAND);
+	}
 	SetRndSeed(glSeedTbl[currlevel]);
 	IncProgress();
 	MakeLightTable();

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1781,10 +1781,8 @@ void AutoGetItem(int pnum, int ii)
 		dropGoldValue = 0;
 	}
 
-	if (ii != MAXITEMS) {
-		if (dItem[item[ii]._ix][item[ii]._iy] == 0)
-			return;
-	}
+	if (dItem[item[ii]._ix][item[ii]._iy] == 0)
+		return;
 
 #ifdef HELLFIRE
 	if (item[ii]._iUid != 0)
@@ -2606,17 +2604,6 @@ int CalculateGold(int pnum)
 	}
 
 	return gold;
-}
-
-BOOL DropItemBeforeTrig()
-{
-	if (TryInvPut()) {
-		NetSendCmdPItem(TRUE, CMD_PUTITEM, cursmx, cursmy);
-		NewCursor(CURSOR_HAND);
-		return TRUE;
-	}
-
-	return FALSE;
 }
 
 DEVILUTION_END_NAMESPACE

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -2606,4 +2606,15 @@ int CalculateGold(int pnum)
 	return gold;
 }
 
+BOOL DropItemBeforeTrig()
+{
+	if (TryInvPut()) {
+		NetSendCmdPItem(TRUE, CMD_PUTITEM, cursmx, cursmy);
+		NewCursor(CURSOR_HAND);
+		return TRUE;
+	}
+
+	return FALSE;
+}
+
 DEVILUTION_END_NAMESPACE

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -48,6 +48,7 @@ BOOL UseStaff();
 BOOL UseInvItem(int pnum, int cii);
 void DoTelekinesis();
 int CalculateGold(int pnum);
+BOOL DropItemBeforeTrig();
 
 /* data */
 

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -48,7 +48,6 @@ BOOL UseStaff();
 BOOL UseInvItem(int pnum, int cii);
 void DoTelekinesis();
 int CalculateGold(int pnum);
-BOOL DropItemBeforeTrig();
 
 /* data */
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1935,10 +1935,6 @@ static DWORD On_WARP(TCmd *pCmd, int pnum)
 		msg_send_packet(pnum, p, sizeof(*p));
 	else {
 		StartWarpLvl(pnum, p->wParam1);
-		if (pnum == myplr && pcurs >= CURSOR_FIRSTITEM) {
-			item[MAXITEMS] = plr[myplr].HoldItem;
-			AutoGetItem(myplr, MAXITEMS);
-		}
 	}
 
 	return sizeof(*p);

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -755,7 +755,7 @@ void TalkToTowner(int p, int t)
 
 	towner[t]._tMsgSaid = FALSE;
 
-	if (pcurs >= CURSOR_FIRSTITEM && !DropItemBeforeTrig()) {
+	if (pcurs >= CURSOR_FIRSTITEM) {
 		return;
 	}
 

--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -851,14 +851,10 @@ void CheckTriggers()
 				PlaySFX(PS_WARR18);
 				InitDiabloMsg(EMSG_NOT_IN_SHAREWARE);
 			} else {
-				if (pcurs >= CURSOR_FIRSTITEM && DropItemBeforeTrig())
-					return;
 				StartNewLvl(myplr, trigs[i]._tmsg, currlevel + 1);
 			}
 			break;
 		case WM_DIABPREVLVL:
-			if (pcurs >= CURSOR_FIRSTITEM && DropItemBeforeTrig())
-				return;
 			StartNewLvl(myplr, trigs[i]._tmsg, currlevel - 1);
 			break;
 		case WM_DIABRTNLVL:


### PR DESCRIPTION
This makes the item stay put in the cursor when entering a new level/portal. It also keeps items from dropping when talking to towners. Overall the dropping items thing was pointless and hacky.