### PR TITLE
Fix portals appearing on wrong levels

### DIFF
--- a/Source/portal.cpp
+++ b/Source/portal.cpp
@@ -68,7 +68,7 @@ void SyncPortals()
 			int lvl = currlevel;
 			if (setlevel)
 				lvl = setlvlnum;
-			if (portal[i].level == lvl)
+			if (portal[i].level == lvl && portal[i].setlvl == setlevel)
 				AddWarpMissile(i, portal[i].x, portal[i].y);
 		}
 	}


### PR DESCRIPTION
To reproduce before fix:
Go to leoric's tomb, cast town portal, go back to dlvl 1, you can see your portal there.
That's because leoric's setlvlnum is 1