### PR TITLE
Remove checks for duplicate items

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1989,8 +1989,7 @@ void SyncGetItem(int x, int y, int idx, WORD ci, int iseed)
 				i++;
 			}
 		}
-		/// ASSERT: assert(FindGetItem(idx, ci, iseed) == -1);
-		FindGetItem(idx, ci, iseed); /* todo: replace with above */
+		assert(FindGetItem(idx, ci, iseed) == -1);
 	}
 }
 
@@ -2077,11 +2076,6 @@ int InvPutItem(int pnum, int x, int y)
 
 	if (numitems >= MAXITEMS)
 		return -1;
-
-	if (FindGetItem(plr[pnum].HoldItem.IDidx, plr[pnum].HoldItem._iCreateInfo, plr[pnum].HoldItem._iSeed) != -1) {
-		DrawInvMsg("A duplicate item has been detected.  Destroying duplicate...");
-		SyncGetItem(x, y, plr[pnum].HoldItem.IDidx, plr[pnum].HoldItem._iCreateInfo, plr[pnum].HoldItem._iSeed);
-	}
 
 	d = GetDirection(plr[pnum]._px, plr[pnum]._py, x, y);
 	xx = x - plr[pnum]._px;
@@ -2175,11 +2169,6 @@ int SyncPutItem(int pnum, int x, int y, int idx, WORD icreateinfo, int iseed, in
 
 	if (numitems >= MAXITEMS)
 		return -1;
-
-	if (FindGetItem(idx, icreateinfo, iseed) != -1) {
-		DrawInvMsg("A duplicate item has been detected from another player.");
-		SyncGetItem(x, y, idx, icreateinfo, iseed);
-	}
 
 	d = GetDirection(plr[pnum]._px, plr[pnum]._py, x, y);
 	xx = x - plr[pnum]._px;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1689,11 +1689,6 @@ void RespawnDeadItem(ItemStruct *itm, int x, int y)
 		return;
 	}
 
-	if (FindGetItem(itm->IDidx, itm->_iCreateInfo, itm->_iSeed) >= 0) {
-		DrawInvMsg("A duplicate item has been detected.  Destroying duplicate...");
-		SyncGetItem(x, y, itm->IDidx, itm->_iCreateInfo, itm->_iSeed);
-	}
-
 	ii = itemavail[0];
 	dItem[x][y] = ii + 1;
 	itemavail[0] = itemavail[MAXITEMS - numitems - 1];


### PR DESCRIPTION
- We fixed the normal way of duplicating items.
- Legit items can be seen as duplicates in some instances.
- It doesn't fix the issue since the player has to drop both for it to
trigger.