### PR TITLE
Correct missing hellfire level mapping in leveltype

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -77,22 +77,22 @@ void InitAutomap()
 
 	switch (leveltype) {
 	case DTYPE_CATHEDRAL:
-		if (currlevel < 21)
-			pAFile = LoadFileInMem("Levels\\L1Data\\L1.AMP", &dwTiles);
-		else
-			pAFile = LoadFileInMem("NLevels\\L5Data\\L5.AMP", &dwTiles);
+		pAFile = LoadFileInMem("Levels\\L1Data\\L1.AMP", &dwTiles);
 		break;
 	case DTYPE_CATACOMBS:
 		pAFile = LoadFileInMem("Levels\\L2Data\\L2.AMP", &dwTiles);
 		break;
 	case DTYPE_CAVES:
-		if (currlevel < 17)
-			pAFile = LoadFileInMem("Levels\\L3Data\\L3.AMP", &dwTiles);
-		else
-			pAFile = LoadFileInMem("NLevels\\L6Data\\L6.AMP", &dwTiles);
+		pAFile = LoadFileInMem("Levels\\L3Data\\L3.AMP", &dwTiles);
 		break;
 	case DTYPE_HELL:
 		pAFile = LoadFileInMem("Levels\\L4Data\\L4.AMP", &dwTiles);
+		break;
+	case DTYPE_CRYPT:
+		pAFile = LoadFileInMem("NLevels\\L5Data\\L5.AMP", &dwTiles);
+		break;
+	case DTYPE_NEST:
+		pAFile = LoadFileInMem("NLevels\\L6Data\\L6.AMP", &dwTiles);
 		break;
 	default:
 		return;

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -43,7 +43,6 @@ BOOLEAN UseBarbarianTest;
 BOOLEAN UseMultiTest;
 int sgnTimeoutCurs;
 char sgbMouseDown;
-int color_cycle_timer;
 int ticks_per_sec = 20;
 WORD tick_delay = 50;
 /** Game options */
@@ -1474,17 +1473,10 @@ void LoadLvlGFX()
 		pSpecialCels = LoadFileInMem("Levels\\TownData\\TownS.CEL", NULL);
 		break;
 	case DTYPE_CATHEDRAL:
-		if (currlevel < 21) {
-			pDungeonCels = LoadFileInMem("Levels\\L1Data\\L1.CEL", NULL);
-			pMegaTiles = LoadFileInMem("Levels\\L1Data\\L1.TIL", NULL);
-			pLevelPieces = LoadFileInMem("Levels\\L1Data\\L1.MIN", NULL);
-			pSpecialCels = LoadFileInMem("Levels\\L1Data\\L1S.CEL", NULL);
-		} else {
-			pDungeonCels = LoadFileInMem("NLevels\\L5Data\\L5.CEL", NULL);
-			pMegaTiles = LoadFileInMem("NLevels\\L5Data\\L5.TIL", NULL);
-			pLevelPieces = LoadFileInMem("NLevels\\L5Data\\L5.MIN", NULL);
-			pSpecialCels = LoadFileInMem("NLevels\\L5Data\\L5S.CEL", NULL);
-		}
+		pDungeonCels = LoadFileInMem("Levels\\L1Data\\L1.CEL", NULL);
+		pMegaTiles = LoadFileInMem("Levels\\L1Data\\L1.TIL", NULL);
+		pLevelPieces = LoadFileInMem("Levels\\L1Data\\L1.MIN", NULL);
+		pSpecialCels = LoadFileInMem("Levels\\L1Data\\L1S.CEL", NULL);
 		break;
 	case DTYPE_CATACOMBS:
 		pDungeonCels = LoadFileInMem("Levels\\L2Data\\L2.CEL", NULL);
@@ -1493,15 +1485,9 @@ void LoadLvlGFX()
 		pSpecialCels = LoadFileInMem("Levels\\L2Data\\L2S.CEL", NULL);
 		break;
 	case DTYPE_CAVES:
-		if (currlevel < 17) {
-			pDungeonCels = LoadFileInMem("Levels\\L3Data\\L3.CEL", NULL);
-			pMegaTiles = LoadFileInMem("Levels\\L3Data\\L3.TIL", NULL);
-			pLevelPieces = LoadFileInMem("Levels\\L3Data\\L3.MIN", NULL);
-		} else {
-			pDungeonCels = LoadFileInMem("NLevels\\L6Data\\L6.CEL", NULL);
-			pMegaTiles = LoadFileInMem("NLevels\\L6Data\\L6.TIL", NULL);
-			pLevelPieces = LoadFileInMem("NLevels\\L6Data\\L6.MIN", NULL);
-		}
+		pDungeonCels = LoadFileInMem("Levels\\L3Data\\L3.CEL", NULL);
+		pMegaTiles = LoadFileInMem("Levels\\L3Data\\L3.TIL", NULL);
+		pLevelPieces = LoadFileInMem("Levels\\L3Data\\L3.MIN", NULL);
 		pSpecialCels = LoadFileInMem("Levels\\L1Data\\L1S.CEL", NULL);
 		break;
 	case DTYPE_HELL:
@@ -1509,6 +1495,18 @@ void LoadLvlGFX()
 		pMegaTiles = LoadFileInMem("Levels\\L4Data\\L4.TIL", NULL);
 		pLevelPieces = LoadFileInMem("Levels\\L4Data\\L4.MIN", NULL);
 		pSpecialCels = LoadFileInMem("Levels\\L2Data\\L2S.CEL", NULL);
+		break;
+	case DTYPE_NEST:
+		pDungeonCels = LoadFileInMem("NLevels\\L6Data\\L6.CEL", NULL);
+		pMegaTiles = LoadFileInMem("NLevels\\L6Data\\L6.TIL", NULL);
+		pLevelPieces = LoadFileInMem("NLevels\\L6Data\\L6.MIN", NULL);
+		pSpecialCels = LoadFileInMem("Levels\\L1Data\\L1S.CEL", NULL);
+		break;
+	case DTYPE_CRYPT:
+		pDungeonCels = LoadFileInMem("NLevels\\L5Data\\L5.CEL", NULL);
+		pMegaTiles = LoadFileInMem("NLevels\\L5Data\\L5.TIL", NULL);
+		pLevelPieces = LoadFileInMem("NLevels\\L5Data\\L5.MIN", NULL);
+		pSpecialCels = LoadFileInMem("NLevels\\L5Data\\L5S.CEL", NULL);
 		break;
 	default:
 		app_fatal("LoadLvlGFX");
@@ -1541,11 +1539,7 @@ void CreateLevel(int lvldir)
 		CreateL5Dungeon(glSeedTbl[currlevel], lvldir);
 		InitL1Triggers();
 		Freeupstairs();
-		if (currlevel < 21) {
-			LoadRndLvlPal(1);
-		} else {
-			LoadRndLvlPal(5);
-		}
+		LoadRndLvlPal(1);
 		break;
 	case DTYPE_CATACOMBS:
 		CreateL2Dungeon(glSeedTbl[currlevel], lvldir);
@@ -1557,17 +1551,25 @@ void CreateLevel(int lvldir)
 		CreateL3Dungeon(glSeedTbl[currlevel], lvldir);
 		InitL3Triggers();
 		Freeupstairs();
-		if (currlevel < 17) {
-			LoadRndLvlPal(3);
-		} else {
-			LoadRndLvlPal(6);
-		}
+		LoadRndLvlPal(3);
 		break;
 	case DTYPE_HELL:
 		CreateL4Dungeon(glSeedTbl[currlevel], lvldir);
 		InitL4Triggers();
 		Freeupstairs();
 		LoadRndLvlPal(4);
+		break;
+	case DTYPE_NEST:
+		CreateL3Dungeon(glSeedTbl[currlevel], lvldir);
+		InitL3Triggers();
+		Freeupstairs();
+		LoadRndLvlPal(6);
+		break;
+	case DTYPE_CRYPT:
+		CreateL5Dungeon(glSeedTbl[currlevel], lvldir);
+		InitL1Triggers();
+		Freeupstairs();
+		LoadRndLvlPal(5);
 		break;
 	default:
 		app_fatal("CreateLevel");
@@ -1921,14 +1923,14 @@ void diablo_color_cyc_logic()
 	if (!palette_get_color_cycling())
 		return;
 
-	if (leveltype == DTYPE_HELL) {
-		lighting_color_cycling();
-	} else if (currlevel >= 21) {
-		palette_update_crypt();
-	} else if (currlevel >= 17) {
-		palette_update_hive();
-	} else if (leveltype == DTYPE_CAVES) {
+	if (leveltype == DTYPE_CAVES) {
 		palette_update_caves();
+	} else if (leveltype == DTYPE_HELL) {
+		lighting_color_cycling();
+	} else if (leveltype == DTYPE_NEST) {
+		palette_update_hive();
+	} else if (leveltype == DTYPE_CRYPT) {
+		palette_update_crypt();
 	}
 }
 

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -143,22 +143,22 @@ void FillSolidBlockTbls()
 			pSBFile = LoadFileInMem("Levels\\TownData\\Town.SOL", &dwTiles);
 		break;
 	case DTYPE_CATHEDRAL:
-		if (currlevel < 17)
-			pSBFile = LoadFileInMem("Levels\\L1Data\\L1.SOL", &dwTiles);
-		else
-			pSBFile = LoadFileInMem("NLevels\\L5Data\\L5.SOL", &dwTiles);
+		pSBFile = LoadFileInMem("Levels\\L1Data\\L1.SOL", &dwTiles);
 		break;
 	case DTYPE_CATACOMBS:
 		pSBFile = LoadFileInMem("Levels\\L2Data\\L2.SOL", &dwTiles);
 		break;
 	case DTYPE_CAVES:
-		if (currlevel < 17)
-			pSBFile = LoadFileInMem("Levels\\L3Data\\L3.SOL", &dwTiles);
-		else
-			pSBFile = LoadFileInMem("NLevels\\L6Data\\L6.SOL", &dwTiles);
+		pSBFile = LoadFileInMem("Levels\\L3Data\\L3.SOL", &dwTiles);
 		break;
 	case DTYPE_HELL:
 		pSBFile = LoadFileInMem("Levels\\L4Data\\L4.SOL", &dwTiles);
+		break;
+	case DTYPE_NEST:
+		pSBFile = LoadFileInMem("NLevels\\L6Data\\L6.SOL", &dwTiles);
+		break;
+	case DTYPE_CRYPT:
+		pSBFile = LoadFileInMem("NLevels\\L5Data\\L5.SOL", &dwTiles);
 		break;
 	default:
 		app_fatal("FillSolidBlockTbls");
@@ -437,7 +437,7 @@ void DRLG_CreateThemeRoom(int themeIndex)
 					dungeon[xx][yy] = 3;
 				}
 			}
-			if (leveltype == DTYPE_CAVES) {
+			if (leveltype == DTYPE_CAVES || leveltype == DTYPE_NEST) {
 				if (yy == ly || yy == hy - 1) {
 					dungeon[xx][yy] = 134;
 				} else if (xx == lx || xx == hx - 1) {
@@ -464,7 +464,7 @@ void DRLG_CreateThemeRoom(int themeIndex)
 		dungeon[lx][hy - 1] = 9;
 		dungeon[hx - 1][hy - 1] = 6;
 	}
-	if (leveltype == DTYPE_CAVES) {
+	if (leveltype == DTYPE_CAVES || leveltype == DTYPE_NEST) {
 		dungeon[lx][ly] = 150;
 		dungeon[hx - 1][ly] = 151;
 		dungeon[lx][hy - 1] = 152;
@@ -487,7 +487,7 @@ void DRLG_CreateThemeRoom(int themeIndex)
 			break;
 		}
 	}
-	if (leveltype == DTYPE_CAVES) {
+	if (leveltype == DTYPE_CAVES || leveltype == DTYPE_NEST) {
 		switch (random_(0, 2)) {
 		case 0:
 			dungeon[hx - 1][(ly + hy) / 2] = 147;
@@ -547,7 +547,7 @@ void DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int freq, int rnd
 				themeLoc[themeCount].y = j + 1;
 				themeLoc[themeCount].width = themeW;
 				themeLoc[themeCount].height = themeH;
-				if (leveltype == DTYPE_CAVES)
+				if (leveltype == DTYPE_CAVES || leveltype == DTYPE_NEST)
 					DRLG_RectTrans(2 * i + 20, 2 * j + 20, 2 * (i + themeW) + 15, 2 * (j + themeH) + 15);
 				else
 					DRLG_MRectTrans(i + 1, j + 1, i + themeW, j + themeH);

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -34,15 +34,9 @@ static void InitCutscene(unsigned int uMsg)
 			progress_id = 1;
 			break;
 		case DTYPE_CATHEDRAL:
-			if (currlevel < 17) {
-				sgpBackCel = LoadFileInMem("Gendata\\Cutl1d.CEL", NULL);
-				LoadPalette("Gendata\\Cutl1d.pal");
-				progress_id = 0;
-			} else {
-				sgpBackCel = LoadFileInMem("Nlevels\\cutl5.CEL", NULL);
-				LoadPalette("Nlevels\\cutl5.pal");
-				progress_id = 1;
-			}
+			sgpBackCel = LoadFileInMem("Gendata\\Cutl1d.CEL", NULL);
+			LoadPalette("Gendata\\Cutl1d.pal");
+			progress_id = 0;
 			break;
 		case DTYPE_CATACOMBS:
 			sgpBackCel = LoadFileInMem("Gendata\\Cut2.CEL", NULL);
@@ -50,15 +44,9 @@ static void InitCutscene(unsigned int uMsg)
 			progress_id = 2;
 			break;
 		case DTYPE_CAVES:
-			if (currlevel < 17) {
-				sgpBackCel = LoadFileInMem("Gendata\\Cut3.CEL", NULL);
-				LoadPalette("Gendata\\Cut3.pal");
-				progress_id = 1;
-			} else {
-				sgpBackCel = LoadFileInMem("Nlevels\\cutl6.CEL", NULL);
-				LoadPalette("Nlevels\\cutl6.pal");
-				progress_id = 1;
-			}
+			sgpBackCel = LoadFileInMem("Gendata\\Cut3.CEL", NULL);
+			LoadPalette("Gendata\\Cut3.pal");
+			progress_id = 1;
 			break;
 		case DTYPE_HELL:
 			if (currlevel < 15) {
@@ -71,6 +59,16 @@ static void InitCutscene(unsigned int uMsg)
 				progress_id = 1;
 			}
 			break;
+		case DTYPE_NEST:
+			sgpBackCel = LoadFileInMem("Nlevels\\cutl6.CEL", NULL);
+			LoadPalette("Nlevels\\cutl6.pal");
+			progress_id = 1;
+			break;
+		case DTYPE_CRYPT:
+			sgpBackCel = LoadFileInMem("Nlevels\\cutl5.CEL", NULL);
+			LoadPalette("Nlevels\\cutl5.pal");
+			progress_id = 1;
+			break;
 		default:
 			sgpBackCel = LoadFileInMem("Gendata\\Cutl1d.CEL", NULL);
 			LoadPalette("Gendata\\Cutl1d.pal");
@@ -79,7 +77,7 @@ static void InitCutscene(unsigned int uMsg)
 		}
 		break;
 	case WM_DIABPREVLVL:
-		if (gnLevelTypeTbl[currlevel - 1] == 0) {
+		if (gnLevelTypeTbl[currlevel - 1] == DTYPE_TOWN) {
 			sgpBackCel = LoadFileInMem("Gendata\\Cuttt.CEL", NULL);
 			LoadPalette("Gendata\\Cuttt.pal");
 			progress_id = 1;
@@ -91,15 +89,9 @@ static void InitCutscene(unsigned int uMsg)
 				progress_id = 1;
 				break;
 			case DTYPE_CATHEDRAL:
-				if (currlevel < 17) {
-					sgpBackCel = LoadFileInMem("Gendata\\Cutl1d.CEL", NULL);
-					LoadPalette("Gendata\\Cutl1d.pal");
-					progress_id = 0;
-				} else {
-					sgpBackCel = LoadFileInMem("Nlevels\\cutl5.CEL", NULL);
-					LoadPalette("Nlevels\\cutl5.pal");
-					progress_id = 1;
-				}
+				sgpBackCel = LoadFileInMem("Gendata\\Cutl1d.CEL", NULL);
+				LoadPalette("Gendata\\Cutl1d.pal");
+				progress_id = 0;
 				break;
 			case DTYPE_CATACOMBS:
 				sgpBackCel = LoadFileInMem("Gendata\\Cut2.CEL", NULL);
@@ -107,19 +99,23 @@ static void InitCutscene(unsigned int uMsg)
 				progress_id = 2;
 				break;
 			case DTYPE_CAVES:
-				if (currlevel < 17) {
-					sgpBackCel = LoadFileInMem("Gendata\\Cut3.CEL", NULL);
-					LoadPalette("Gendata\\Cut3.pal");
-					progress_id = 1;
-				} else {
-					sgpBackCel = LoadFileInMem("Nlevels\\cutl6.CEL", NULL);
-					LoadPalette("Nlevels\\cutl6.pal");
-					progress_id = 1;
-				}
+				sgpBackCel = LoadFileInMem("Gendata\\Cut3.CEL", NULL);
+				LoadPalette("Gendata\\Cut3.pal");
+				progress_id = 1;
 				break;
 			case DTYPE_HELL:
 				sgpBackCel = LoadFileInMem("Gendata\\Cut4.CEL", NULL);
 				LoadPalette("Gendata\\Cut4.pal");
+				progress_id = 1;
+				break;
+			case DTYPE_NEST:
+				sgpBackCel = LoadFileInMem("Nlevels\\cutl6.CEL", NULL);
+				LoadPalette("Nlevels\\cutl6.pal");
+				progress_id = 1;
+				break;
+			case DTYPE_CRYPT:
+				sgpBackCel = LoadFileInMem("Nlevels\\cutl5.CEL", NULL);
+				LoadPalette("Nlevels\\cutl5.pal");
 				progress_id = 1;
 				break;
 			default:
@@ -184,15 +180,9 @@ static void InitCutscene(unsigned int uMsg)
 			progress_id = 1;
 			break;
 		case DTYPE_CATHEDRAL:
-			if (plr[myplr].plrlevel < 17) {
-				sgpBackCel = LoadFileInMem("Gendata\\Cutl1d.CEL", NULL);
-				LoadPalette("Gendata\\Cutl1d.pal");
-				progress_id = 0;
-			} else {
-				sgpBackCel = LoadFileInMem("Nlevels\\Cutl5.CEL", NULL);
-				LoadPalette("Nlevels\\Cutl5.pal");
-				progress_id = 1;
-			}
+			sgpBackCel = LoadFileInMem("Gendata\\Cutl1d.CEL", NULL);
+			LoadPalette("Gendata\\Cutl1d.pal");
+			progress_id = 0;
 			break;
 		case DTYPE_CATACOMBS:
 			sgpBackCel = LoadFileInMem("Gendata\\Cut2.CEL", NULL);
@@ -200,19 +190,22 @@ static void InitCutscene(unsigned int uMsg)
 			progress_id = 2;
 			break;
 		case DTYPE_CAVES:
-			if (plr[myplr].plrlevel < 17) {
-				sgpBackCel = LoadFileInMem("Gendata\\Cut3.CEL", NULL);
-				LoadPalette("Gendata\\Cut3.pal");
-				progress_id = 1;
-			} else {
-				sgpBackCel = LoadFileInMem("Nlevels\\Cutl6.CEL", NULL);
-				LoadPalette("Nlevels\\Cutl6.pal");
-				progress_id = 1;
-			}
-			break;
+			sgpBackCel = LoadFileInMem("Gendata\\Cut3.CEL", NULL);
+			LoadPalette("Gendata\\Cut3.pal");
+			progress_id = 1;
 		case DTYPE_HELL:
 			sgpBackCel = LoadFileInMem("Gendata\\Cut4.CEL", NULL);
 			LoadPalette("Gendata\\Cut4.pal");
+			progress_id = 1;
+			break;
+		case DTYPE_NEST:
+			sgpBackCel = LoadFileInMem("Nlevels\\Cutl6.CEL", NULL);
+			LoadPalette("Nlevels\\Cutl6.pal");
+			progress_id = 1;
+			break;
+		case DTYPE_CRYPT:
+			sgpBackCel = LoadFileInMem("Nlevels\\Cutl5.CEL", NULL);
+			LoadPalette("Nlevels\\Cutl5.pal");
 			progress_id = 1;
 			break;
 		}

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -785,7 +785,8 @@ void LoadGame(BOOL firstflag)
 	setlevel = LoadBool8();
 	setlvlnum = WLoad();
 	currlevel = WLoad();
-	leveltype = WLoad();
+	tbuff += 4; // Skip leveltype
+	leveltype = gnLevelTypeTbl[currlevel];
 	_ViewX = WLoad();
 	_ViewY = WLoad();
 	invflag = LoadBool8();
@@ -797,7 +798,7 @@ void LoadGame(BOOL firstflag)
 
 	for (i = 0; i < giNumberOfLevels; i++) {
 		glSeedTbl[i] = ILoad();
-		gnLevelTypeTbl[i] = WLoad();
+		tbuff += 4; // Skip leveltype
 	}
 
 	LoadPlayer(myplr);
@@ -940,7 +941,7 @@ void LoadGame(BOOL firstflag)
 	SetCursor_(CURSOR_HAND);
 	gbProcessPlayers = TRUE;
 
-    gbIsHellfireSaveGame = gbIsHellfire;
+	gbIsHellfireSaveGame = gbIsHellfire;
 }
 
 static void BSave(char v)
@@ -1557,6 +1558,17 @@ static void SavePortal(int i)
 	CopyInt(&pPortal->setlvl, tbuff);
 }
 
+static int getHelfireLevelType(int type)
+{
+	if (type == DTYPE_CRYPT)
+		return DTYPE_CATHEDRAL;
+
+	if (type == DTYPE_NEST)
+		return DTYPE_CAVES;
+
+	return type;
+}
+
 void SaveGame()
 {
 	int i, j;
@@ -1589,7 +1601,7 @@ void SaveGame()
 	SaveBool8(setlevel);
 	WSave(setlvlnum);
 	WSave(currlevel);
-	WSave(leveltype);
+	WSave(getHelfireLevelType(leveltype));
 	WSave(ViewX);
 	WSave(ViewY);
 	SaveBool8(invflag);
@@ -1601,7 +1613,7 @@ void SaveGame()
 
 	for (i = 0; i < giNumberOfLevels; i++) {
 		ISave(glSeedTbl[i]);
-		WSave(gnLevelTypeTbl[i]);
+		WSave(getHelfireLevelType(gnLevelTypeTbl[i]));
 	}
 
 	plr[myplr].pDifficulty = gnDifficulty;

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -594,10 +594,10 @@ static int InitLevelType(int l)
 		return DTYPE_CAVES;
 	if (l >= 13 && l <= 16)
 		return DTYPE_HELL;
-	if (l >= 21 && l <= 24)
-		return DTYPE_CATHEDRAL; // Crypt
 	if (l >= 17 && l <= 20)
-		return DTYPE_CAVES; // Hive
+		return DTYPE_NEST;
+	if (l >= 21 && l <= 24)
+		return DTYPE_CRYPT;
 
 	return DTYPE_CATHEDRAL;
 }

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -274,7 +274,7 @@ bool RndLocOk(int xp, int yp)
 		return FALSE;
 	if (nSolidTable[dPiece[xp][yp]])
 		return FALSE;
-	if (leveltype != DTYPE_CATHEDRAL || dPiece[xp][yp] <= 126 || dPiece[xp][yp] >= 144)
+	if ((leveltype != DTYPE_CATHEDRAL && leveltype != DTYPE_CRYPT) || dPiece[xp][yp] <= 126 || dPiece[xp][yp] >= 144)
 		return TRUE;
 	return FALSE;
 }
@@ -1005,13 +1005,9 @@ void InitObjects()
 			if (QuestStatus(Q_LTBANNER))
 				AddObject(OBJ_SIGNCHEST, 2 * setpc_x + 26, 2 * setpc_y + 19);
 			InitRndLocBigObj(10, 15, OBJ_SARC);
-			if (currlevel >= 21)
-				add_crypt_objs(0, 0, MAXDUNX, MAXDUNY);
-			else
-				AddL1Objs(0, 0, MAXDUNX, MAXDUNY);
+			AddL1Objs(0, 0, MAXDUNX, MAXDUNY);
 			InitRndBarrels();
-		}
-		if (leveltype == DTYPE_CATACOMBS) {
+		} else if (leveltype == DTYPE_CATACOMBS) {
 			if (QuestStatus(Q_ROCK))
 				InitRndLocObj5x5(1, 1, OBJ_STAND);
 			if (QuestStatus(Q_SCHAMB))
@@ -1057,12 +1053,10 @@ void InitObjects()
 				AddObject(OBJ_PEDISTAL, 2 * setpc_x + 25, 2 * setpc_y + 32);
 			}
 			InitRndBarrels();
-		}
-		if (leveltype == DTYPE_CAVES) {
+		} else if (leveltype == DTYPE_CAVES) {
 			AddL3Objs(0, 0, MAXDUNX, MAXDUNY);
 			InitRndBarrels();
-		}
-		if (leveltype == DTYPE_HELL) {
+		} else if (leveltype == DTYPE_HELL) {
 			if (QuestStatus(Q_WARLORD)) {
 				if (plr[myplr]._pClass == PC_WARRIOR) {
 					sp_id = TEXT_BLOODWAR;
@@ -1087,13 +1081,20 @@ void InitObjects()
 				AddLazStand();
 			InitRndBarrels();
 			AddL4Goodies();
+		} else if (leveltype == DTYPE_NEST) {
+			AddL3Objs(0, 0, MAXDUNX, MAXDUNY);
+			InitRndBarrels();
+		} else if (leveltype == DTYPE_CRYPT) {
+			InitRndLocBigObj(10, 15, OBJ_SARC);
+			add_crypt_objs(0, 0, MAXDUNX, MAXDUNY);
+			InitRndBarrels();
 		}
 		InitRndLocObj(5, 10, OBJ_CHEST1);
 		InitRndLocObj(3, 6, OBJ_CHEST2);
 		InitRndLocObj(1, 5, OBJ_CHEST3);
 		if (leveltype != DTYPE_HELL)
 			AddObjTraps();
-		if (leveltype > DTYPE_CATHEDRAL)
+		else if (leveltype != DTYPE_CATHEDRAL && leveltype != DTYPE_CRYPT)
 			AddChestTraps();
 		InitObjFlag = FALSE;
 	}
@@ -2791,7 +2792,7 @@ void ObjChangeMap(int x1, int y1, int x2, int y2)
 			dungeon[i][j] = pdungeon[i][j];
 		}
 	}
-	if (leveltype == DTYPE_CATHEDRAL && currlevel < 17) {
+	if (leveltype == DTYPE_CATHEDRAL) {
 		ObjL1Special(2 * x1 + 16, 2 * y1 + 16, 2 * x2 + 17, 2 * y2 + 17);
 		AddL1Objs(2 * x1 + 16, 2 * y1 + 16, 2 * x2 + 17, 2 * y2 + 17);
 	}
@@ -2811,7 +2812,7 @@ void ObjChangeMapResync(int x1, int y1, int x2, int y2)
 			dungeon[i][j] = pdungeon[i][j];
 		}
 	}
-	if (leveltype == DTYPE_CATHEDRAL && currlevel < 17) {
+	if (leveltype == DTYPE_CATHEDRAL) {
 		ObjL1Special(2 * x1 + 16, 2 * y1 + 16, 2 * x2 + 17, 2 * y2 + 17);
 	}
 	if (leveltype == DTYPE_CATACOMBS) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1175,7 +1175,7 @@ void PlrDoTrans(int x, int y)
 {
 	int i, j;
 
-	if (leveltype != DTYPE_CATHEDRAL && leveltype != DTYPE_CATACOMBS) {
+	if (leveltype != DTYPE_CATHEDRAL && leveltype != DTYPE_CATACOMBS && leveltype != DTYPE_CRYPT) {
 		TransList[1] = TRUE;
 	} else {
 		for (i = y - 1; i <= y + 1; i++) {

--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -794,12 +794,14 @@ void CheckTrigForce()
 			trigflag = ForceTownTrig();
 			break;
 		case DTYPE_CATHEDRAL:
+		case DTYPE_CRYPT:
 			trigflag = ForceL1Trig();
 			break;
 		case DTYPE_CATACOMBS:
 			trigflag = ForceL2Trig();
 			break;
 		case DTYPE_CAVES:
+		case DTYPE_NEST:
 			trigflag = ForceL3Trig();
 			break;
 		case DTYPE_HELL:


### PR DESCRIPTION
Hellfire never added the 2 new dungeon types, instead, it makes additional checks on currlevel. This is confusing and messy, so cleaned it up.