### PR TITLE
Update Fedora's dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ sudo apt-get install cmake g++ libsdl2-mixer-dev libsdl2-ttf-dev libsodium-dev
 ```
 ### Installing dependencies on Fedora
 ```
-sudo dnf install cmake glibc-devel SDL2-devel SDL2_ttf-devel SDL2_mixer-devel libsodium-devel libasan libubsan
+sudo dnf install cmake glibc-devel SDL2-devel SDL2_ttf-devel SDL2_mixer-devel libsodium-devel libasan libubsan libstdc++-static
 ```
 ### Compiling
 ```


### PR DESCRIPTION
Without `libstdc++-static`, the compilation would yield following error:

```
ld: cannot find -lstdc++
```

Tested and verified on Fedora 33