### PR TITLE
DiabloUI: Consider ListOffset for focus selector

### DIFF
--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -85,6 +85,7 @@ void UiInitList(int count, void (*fnFocus)(int value), void (*fnSelect)(int valu
 	gfnListYesNo = fnYesNo;
 	gUiItems = items;
 	UiItemsWraps = itemsWraps;
+	ListOffset = NULL;
 	if (fnFocus)
 		fnFocus(0);
 
@@ -662,7 +663,7 @@ void Render(const UiList *ui_list)
 	for (std::size_t i = 0; i < ui_list->m_vecItems.size(); ++i) {
 		SDL_Rect rect = ui_list->itemRect(i);
 		const UiListItem *item = ui_list->GetItem(i);
-		if (i == SelectedItem)
+		if (i + (ListOffset == NULL ? 0 : *ListOffset) == SelectedItem)
 			DrawSelector(rect);
 		DrawArtStr(item->m_text, rect, ui_list->m_iFlags);
 	}


### PR DESCRIPTION
The original version of UI List accepted a contiguous min/max range of item (enum) values, so `SelectedItem` could be compared to `m_value`.

With the recent changes, `SelectedItem` now refers to an index in the array.

This means the function that draws the list must now know about the potential existence of the scrollbar and consider its `ListOffset` into account.

Fixes #1006