### PR TITLE
Make auto-equip behavior configurable

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -436,6 +436,7 @@ static void SaveOptions()
 	setIniInt("Game", "Auto Equip Armor on Pickup", sgOptions.bAutoEquipArmor);
 	setIniInt("Game", "Auto Equip Helms on Pickup", sgOptions.bAutoEquipHelms);
 	setIniInt("Game", "Auto Equip Shields on Pickup", sgOptions.bAutoEquipShields);
+	setIniInt("Game", "Auto Equip Jewelry on Pickup", sgOptions.bAutoEquipJewelry);
 
 	setIniValue("Network", "Bind Address", sgOptions.szBindAddress);
 }
@@ -486,6 +487,7 @@ static void LoadOptions()
 	sgOptions.bAutoEquipArmor = getIniBool("Game", "Auto Equip Armor on Pickup", false);
 	sgOptions.bAutoEquipHelms = getIniBool("Game", "Auto Equip Helms on Pickup", false);
 	sgOptions.bAutoEquipShields = getIniBool("Game", "Auto Equip Shields on Pickup", false);
+	sgOptions.bAutoEquipJewelry = getIniBool("Game", "Auto Equip Jewelry on Pickup", false);
 
 	getIniValue("Network", "Bind Address", sgOptions.szBindAddress, sizeof(sgOptions.szBindAddress), "0.0.0.0");
 }

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -110,6 +110,9 @@ typedef struct Options {
 	/** @brief Automatically attempt to equip shield-type items when picking them up. */
 	bool bAutoEquipShields;
 
+	/** @brief Automatically attempt to equip jewelry-type items when picking them up. */
+	bool bAutoEquipJewelry;
+
 	/** @brief Optionally bind to a specific network interface. */
 	char szBindAddress[129];
 } Options;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -824,6 +824,10 @@ bool AutoEquipEnabled(const ItemStruct &item)
 		return sgOptions.bAutoEquipShields;
 	}
 
+	if (item.isJewelry()) {
+		return sgOptions.bAutoEquipJewelry;
+	}
+
 	return true;
 }
 

--- a/Source/items.h
+++ b/Source/items.h
@@ -218,6 +218,26 @@ typedef struct ItemStruct {
 		return !this->isEmpty() && this->_itype == ITYPE_SHIELD;
 	}
 
+	/**
+	 * @brief Checks whether this item is a jewelry.
+	 * @return 'True' in case the item is a jewelry and 'False' otherwise.
+	 */
+	bool isJewelry() const
+	{
+		if (this->isEmpty()) {
+			return false;
+		}
+
+		switch (this->_itype) {
+		case ITYPE_AMULET:
+		case ITYPE_RING:
+			return true;
+
+		default:
+			return false;
+		}
+	}
+
 } ItemStruct;
 
 typedef struct ItemGetRecordStruct {


### PR DESCRIPTION
This PR introduces feature flags for controlling the auto-equip behavior implemented in #861.

Each equipment type is handled separately to allow full customization and avoiding hardcodes around weapon auto-equip.

Weapon auto-equip is set to enabled by default to mimic vanilla behavior, while other equipment types are set to disabled for an opt-in experience.

This resolves #1118