### PR TITLE
:recycle: Make options struct hierarchical

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -400,45 +400,45 @@ BOOL StartGame(BOOL bNewGame, BOOL bSinglePlayer)
  */
 static void SaveOptions()
 {
-	setIniInt("Audio", "Sound Volume", sgOptions.nSoundVolume);
-	setIniInt("Audio", "Music Volume", sgOptions.nMusicVolume);
-	setIniInt("Audio", "Walking Sound", sgOptions.bWalkingSound);
+	setIniInt("Audio", "Sound Volume", sgOptions.Audio.nSoundVolume);
+	setIniInt("Audio", "Music Volume", sgOptions.Audio.nMusicVolume);
+	setIniInt("Audio", "Walking Sound", sgOptions.Audio.bWalkingSound);
 
 #ifndef __vita__
-	setIniInt("Graphics", "Width", sgOptions.nWidth);
-	setIniInt("Graphics", "Height", sgOptions.nHeight);
+	setIniInt("Graphics", "Width", sgOptions.Graphics.nWidth);
+	setIniInt("Graphics", "Height", sgOptions.Graphics.nHeight);
 #endif
-	setIniInt("Graphics", "Fullscreen", sgOptions.bFullscreen);
+	setIniInt("Graphics", "Fullscreen", sgOptions.Graphics.bFullscreen);
 #ifndef __vita__
-	setIniInt("Graphics", "Upscale", sgOptions.bUpscale);
+	setIniInt("Graphics", "Upscale", sgOptions.Graphics.bUpscale);
 #endif
-	setIniInt("Graphics", "Fit to Screen", sgOptions.bFitToScreen);
-	setIniValue("Graphics", "Scaling Quality", sgOptions.szScaleQuality);
-	setIniInt("Graphics", "Integer Scaling", sgOptions.bIntegerScaling);
-	setIniInt("Graphics", "Vertical Sync", sgOptions.bVSync);
-	setIniInt("Graphics", "Blended Transparency", sgOptions.bBlendedTransparancy);
-	setIniInt("Graphics", "Gamma Correction", sgOptions.nGammaCorrection);
-	setIniInt("Graphics", "Color Cycling", sgOptions.bColorCycling);
+	setIniInt("Graphics", "Fit to Screen", sgOptions.Graphics.bFitToScreen);
+	setIniValue("Graphics", "Scaling Quality", sgOptions.Graphics.szScaleQuality);
+	setIniInt("Graphics", "Integer Scaling", sgOptions.Graphics.bIntegerScaling);
+	setIniInt("Graphics", "Vertical Sync", sgOptions.Graphics.bVSync);
+	setIniInt("Graphics", "Blended Transparency", sgOptions.Graphics.bBlendedTransparancy);
+	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
+	setIniInt("Graphics", "Color Cycling", sgOptions.Graphics.bColorCycling);
 
-	setIniInt("Game", "Speed", sgOptions.nTickRate);
-	setIniInt("Game", "Fast Walk", sgOptions.bJogInTown);
-	setIniInt("Game", "Grab Input", sgOptions.bGrabInput);
-	setIniInt("Game", "Theo Quest", sgOptions.bTheoQuest);
-	setIniInt("Game", "Cow Quest", sgOptions.bCowQuest);
-	setIniInt("Game", "Friendly Fire", sgOptions.bFriendlyFire);
-	setIniInt("Game", "Test Bard", sgOptions.bTestBard);
-	setIniInt("Game", "Test Barbarian", sgOptions.bTestBarbarian);
-	setIniInt("Game", "Experience Bar", sgOptions.bExperienceBar);
-	setIniInt("Game", "Enemy Health Bar", sgOptions.bEnemyHealthBar);
-	setIniInt("Game", "Auto Gold Pickup", sgOptions.bAutoGoldPickup);
-	setIniInt("Game", "Adria Refills Mana", sgOptions.bAdriaRefillsMana);
-	setIniInt("Game", "Auto Equip Weapons on Pickup", sgOptions.bAutoEquipWeapons);
-	setIniInt("Game", "Auto Equip Armor on Pickup", sgOptions.bAutoEquipArmor);
-	setIniInt("Game", "Auto Equip Helms on Pickup", sgOptions.bAutoEquipHelms);
-	setIniInt("Game", "Auto Equip Shields on Pickup", sgOptions.bAutoEquipShields);
-	setIniInt("Game", "Auto Equip Jewelry on Pickup", sgOptions.bAutoEquipJewelry);
+	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
+	setIniInt("Game", "Fast Walk", sgOptions.Gameplay.bJogInTown);
+	setIniInt("Game", "Grab Input", sgOptions.Gameplay.bGrabInput);
+	setIniInt("Game", "Theo Quest", sgOptions.Gameplay.bTheoQuest);
+	setIniInt("Game", "Cow Quest", sgOptions.Gameplay.bCowQuest);
+	setIniInt("Game", "Friendly Fire", sgOptions.Gameplay.bFriendlyFire);
+	setIniInt("Game", "Test Bard", sgOptions.Gameplay.bTestBard);
+	setIniInt("Game", "Test Barbarian", sgOptions.Gameplay.bTestBarbarian);
+	setIniInt("Game", "Experience Bar", sgOptions.Gameplay.bExperienceBar);
+	setIniInt("Game", "Enemy Health Bar", sgOptions.Gameplay.bEnemyHealthBar);
+	setIniInt("Game", "Auto Gold Pickup", sgOptions.Gameplay.bAutoGoldPickup);
+	setIniInt("Game", "Adria Refills Mana", sgOptions.Gameplay.bAdriaRefillsMana);
+	setIniInt("Game", "Auto Equip Weapons on Pickup", sgOptions.Gameplay.bAutoEquipWeapons);
+	setIniInt("Game", "Auto Equip Armor on Pickup", sgOptions.Gameplay.bAutoEquipArmor);
+	setIniInt("Game", "Auto Equip Helms on Pickup", sgOptions.Gameplay.bAutoEquipHelms);
+	setIniInt("Game", "Auto Equip Shields on Pickup", sgOptions.Gameplay.bAutoEquipShields);
+	setIniInt("Game", "Auto Equip Jewelry on Pickup", sgOptions.Gameplay.bAutoEquipJewelry);
 
-	setIniValue("Network", "Bind Address", sgOptions.szBindAddress);
+	setIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress);
 }
 
 /**
@@ -446,50 +446,50 @@ static void SaveOptions()
  */
 static void LoadOptions()
 {
-	sgOptions.nSoundVolume = getIniInt("Audio", "Sound Volume", VOLUME_MAX);
-	sgOptions.nMusicVolume = getIniInt("Audio", "Music Volume", VOLUME_MAX);
-	sgOptions.bWalkingSound = getIniBool("Audio", "Walking Sound", true);
+	sgOptions.Audio.nSoundVolume = getIniInt("Audio", "Sound Volume", VOLUME_MAX);
+	sgOptions.Audio.nMusicVolume = getIniInt("Audio", "Music Volume", VOLUME_MAX);
+	sgOptions.Audio.bWalkingSound = getIniBool("Audio", "Walking Sound", true);
 
 #ifndef __vita__
-	sgOptions.nWidth = getIniInt("Graphics", "Width", DEFAULT_WIDTH);
-	sgOptions.nHeight = getIniInt("Graphics", "Height", DEFAULT_HEIGHT);
+	sgOptions.Graphics.nWidth = getIniInt("Graphics", "Width", DEFAULT_WIDTH);
+	sgOptions.Graphics.nHeight = getIniInt("Graphics", "Height", DEFAULT_HEIGHT);
 #else
-	sgOptions.nWidth = DEFAULT_WIDTH;
-	sgOptions.nHeight = DEFAULT_HEIGHT;
+	sgOptions.Graphics.nWidth = DEFAULT_WIDTH;
+	sgOptions.Graphics.nHeight = DEFAULT_HEIGHT;
 #endif
-	sgOptions.bFullscreen = getIniBool("Graphics", "Fullscreen", true);
+	sgOptions.Graphics.bFullscreen = getIniBool("Graphics", "Fullscreen", true);
 #if !defined(USE_SDL1) && !defined(__vita__)
-	sgOptions.bUpscale = getIniBool("Graphics", "Upscale", true);
+	sgOptions.Graphics.bUpscale = getIniBool("Graphics", "Upscale", true);
 #else
-	sgOptions.bUpscale = false;
+	sgOptions.Graphics.bUpscale = false;
 #endif
-	sgOptions.bFitToScreen = getIniBool("Graphics", "Fit to Screen", true);
-	getIniValue("Graphics", "Scaling Quality", sgOptions.szScaleQuality, sizeof(sgOptions.szScaleQuality), "2");
-	sgOptions.bIntegerScaling = getIniBool("Graphics", "Integer Scaling", false);
-	sgOptions.bVSync = getIniBool("Graphics", "Vertical Sync", true);
-	sgOptions.bBlendedTransparancy = getIniBool("Graphics", "Blended Transparency", true);
-	sgOptions.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
-	sgOptions.bColorCycling = getIniBool("Graphics", "Color Cycling", true);
+	sgOptions.Graphics.bFitToScreen = getIniBool("Graphics", "Fit to Screen", true);
+	getIniValue("Graphics", "Scaling Quality", sgOptions.Graphics.szScaleQuality, sizeof(sgOptions.Graphics.szScaleQuality), "2");
+	sgOptions.Graphics.bIntegerScaling = getIniBool("Graphics", "Integer Scaling", false);
+	sgOptions.Graphics.bVSync = getIniBool("Graphics", "Vertical Sync", true);
+	sgOptions.Graphics.bBlendedTransparancy = getIniBool("Graphics", "Blended Transparency", true);
+	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
+	sgOptions.Graphics.bColorCycling = getIniBool("Graphics", "Color Cycling", true);
 
-	sgOptions.nTickRate = getIniInt("Game", "Speed", 20);
-	sgOptions.bJogInTown = getIniBool("Game", "Fast Walk", false);
-	sgOptions.bGrabInput = getIniBool("Game", "Grab Input", false);
-	sgOptions.bTheoQuest = getIniBool("Game", "Theo Quest", false);
-	sgOptions.bCowQuest = getIniBool("Game", "Cow Quest", false);
-	sgOptions.bFriendlyFire = getIniBool("Game", "Friendly Fire", true);
-	sgOptions.bTestBard = getIniBool("Game", "Test Bard", false);
-	sgOptions.bTestBarbarian = getIniBool("Game", "Test Barbarian", false);
-	sgOptions.bExperienceBar = getIniBool("Game", "Experience Bar", false);
-	sgOptions.bEnemyHealthBar = getIniBool("Game", "Enemy Health Bar", false);
-	sgOptions.bAutoGoldPickup = getIniBool("Game", "Auto Gold Pickup", false);
-	sgOptions.bAdriaRefillsMana = getIniBool("Game", "Adria Refills Mana", false);
-	sgOptions.bAutoEquipWeapons = getIniBool("Game", "Auto Equip Weapons on Pickup", true);
-	sgOptions.bAutoEquipArmor = getIniBool("Game", "Auto Equip Armor on Pickup", false);
-	sgOptions.bAutoEquipHelms = getIniBool("Game", "Auto Equip Helms on Pickup", false);
-	sgOptions.bAutoEquipShields = getIniBool("Game", "Auto Equip Shields on Pickup", false);
-	sgOptions.bAutoEquipJewelry = getIniBool("Game", "Auto Equip Jewelry on Pickup", false);
+	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
+	sgOptions.Gameplay.bJogInTown = getIniBool("Game", "Fast Walk", false);
+	sgOptions.Gameplay.bGrabInput = getIniBool("Game", "Grab Input", false);
+	sgOptions.Gameplay.bTheoQuest = getIniBool("Game", "Theo Quest", false);
+	sgOptions.Gameplay.bCowQuest = getIniBool("Game", "Cow Quest", false);
+	sgOptions.Gameplay.bFriendlyFire = getIniBool("Game", "Friendly Fire", true);
+	sgOptions.Gameplay.bTestBard = getIniBool("Game", "Test Bard", false);
+	sgOptions.Gameplay.bTestBarbarian = getIniBool("Game", "Test Barbarian", false);
+	sgOptions.Gameplay.bExperienceBar = getIniBool("Game", "Experience Bar", false);
+	sgOptions.Gameplay.bEnemyHealthBar = getIniBool("Game", "Enemy Health Bar", false);
+	sgOptions.Gameplay.bAutoGoldPickup = getIniBool("Game", "Auto Gold Pickup", false);
+	sgOptions.Gameplay.bAdriaRefillsMana = getIniBool("Game", "Adria Refills Mana", false);
+	sgOptions.Gameplay.bAutoEquipWeapons = getIniBool("Game", "Auto Equip Weapons on Pickup", true);
+	sgOptions.Gameplay.bAutoEquipArmor = getIniBool("Game", "Auto Equip Armor on Pickup", false);
+	sgOptions.Gameplay.bAutoEquipHelms = getIniBool("Game", "Auto Equip Helms on Pickup", false);
+	sgOptions.Gameplay.bAutoEquipShields = getIniBool("Game", "Auto Equip Shields on Pickup", false);
+	sgOptions.Gameplay.bAutoEquipJewelry = getIniBool("Game", "Auto Equip Jewelry on Pickup", false);
 
-	getIniValue("Network", "Bind Address", sgOptions.szBindAddress, sizeof(sgOptions.szBindAddress), "0.0.0.0");
+	getIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress, sizeof(sgOptions.Network.szBindAddress), "0.0.0.0");
 }
 
 static void diablo_init_screen()
@@ -2033,7 +2033,7 @@ void game_loop(BOOL bStartup)
 
 void diablo_color_cyc_logic()
 {
-	if (!sgOptions.bColorCycling)
+	if (!sgOptions.Graphics.bColorCycling)
 		return;
 
 	if (leveltype == DTYPE_HELL) {

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -19,7 +19,7 @@ extern "C" {
 #define DEFAULT_HEIGHT 480
 #endif
 
-typedef struct Options {
+typedef struct AudioOptions {
 	/** @brief Movie and SFX volume. */
 	Sint32 nSoundVolume;
 
@@ -28,7 +28,9 @@ typedef struct Options {
 
 	/** @brief Player emits sound when walking. */
 	bool bWalkingSound;
+} AudioOptions;
 
+typedef struct GraphicsOptions {
 	/** @brief Render width. */
 	Sint32 nWidth;
 
@@ -61,7 +63,9 @@ typedef struct Options {
 
 	/** @brief Enable color cycling animations. */
 	bool bColorCycling;
+} GraphicsOptions;
 
+typedef struct GameplayOptions {
 	/** @brief Game play ticks per secound. */
 	Sint32 nTickRate;
 
@@ -112,9 +116,18 @@ typedef struct Options {
 
 	/** @brief Automatically attempt to equip jewelry-type items when picking them up. */
 	bool bAutoEquipJewelry;
+} GameplayOptions;
 
+typedef struct NetworkOptions {
 	/** @brief Optionally bind to a specific network interface. */
 	char szBindAddress[129];
+} NetworkOptions;
+
+typedef struct Options {
+	AudioOptions Audio;
+	GameplayOptions Gameplay;
+	GraphicsOptions Graphics;
+	NetworkOptions Network;
 } Options;
 
 extern SDL_Window *ghMainWnd;

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -385,7 +385,7 @@ void CelClippedBlitLightTransTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelB
 	pRLEBytes = CelGetFrameClipped(pCelBuff, nCel, &nDataSize);
 
 	if (cel_transparency_active) {
-		if (sgOptions.bBlendedTransparancy)
+		if (sgOptions.Graphics.bBlendedTransparancy)
 			CelBlitLightBlendedSafeTo(out, sx, sy, pRLEBytes, nDataSize, nWidth, NULL);
 		else
 			CelBlitLightTransSafeTo(out, sx, sy, pRLEBytes, nDataSize, nWidth);
@@ -582,7 +582,7 @@ static void DrawHalfTransparentStippledRectTo(CelOutputBuffer out, int sx, int s
 
 void DrawHalfTransparentRectTo(CelOutputBuffer out, int sx, int sy, int width, int height)
 {
-	if (sgOptions.bBlendedTransparancy) {
+	if (sgOptions.Graphics.bBlendedTransparancy) {
 		DrawHalfTransparentBlendedRectTo(out, sx, sy, width, height);
 	} else {
 		DrawHalfTransparentStippledRectTo(out, sx, sy, width, height);

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -220,8 +220,8 @@ static void gamemenu_get_sound()
 static void gamemenu_jogging()
 {
 	gmenu_slider_steps(&sgOptionsMenu[3], 2);
-	gmenu_slider_set(&sgOptionsMenu[3], 0, 1, sgOptions.bJogInTown);
-	sgOptionsMenu[3].pszStr = jogging_toggle_names[!sgOptions.bJogInTown ? 1 : 0];
+	gmenu_slider_set(&sgOptionsMenu[3], 0, 1, sgOptions.Gameplay.bJogInTown);
+	sgOptionsMenu[3].pszStr = jogging_toggle_names[!sgOptions.Gameplay.bJogInTown ? 1 : 0];
 }
 
 static void gamemenu_get_gamma()
@@ -254,7 +254,7 @@ static void gamemenu_get_speed()
 
 static void gamemenu_get_color_cycling()
 {
-	sgOptionsMenu[3].pszStr = color_cycling_toggle_names[sgOptions.bColorCycling ? 1 : 0];
+	sgOptionsMenu[3].pszStr = color_cycling_toggle_names[sgOptions.Graphics.bColorCycling ? 1 : 0];
 }
 
 static int gamemenu_slider_gamma()
@@ -350,8 +350,8 @@ void gamemenu_sound_volume(BOOL bActivate)
 void gamemenu_loadjog(BOOL bActivate)
 {
 	if (!gbIsMultiplayer) {
-		sgOptions.bJogInTown = !sgOptions.bJogInTown;
-		gbJogInTown = sgOptions.bJogInTown;
+		sgOptions.Gameplay.bJogInTown = !sgOptions.Gameplay.bJogInTown;
+		gbJogInTown = sgOptions.Gameplay.bJogInTown;
 		PlaySFX(IS_TITLEMOV);
 		gamemenu_jogging();
 	}
@@ -386,14 +386,14 @@ void gamemenu_speed(BOOL bActivate)
 		gnTickRate = gmenu_slider_get(&sgOptionsMenu[3], 20, 50);
 	}
 
-	sgOptions.nTickRate = gnTickRate;
+	sgOptions.Gameplay.nTickRate = gnTickRate;
 	gnTickDelay = 1000 / gnTickRate;
 }
 
 void gamemenu_color_cycling(BOOL bActivate)
 {
-	sgOptions.bColorCycling = !sgOptions.bColorCycling;
-	sgOptionsMenu[3].pszStr = color_cycling_toggle_names[sgOptions.bColorCycling ? 1 : 0];
+	sgOptions.Graphics.bColorCycling = !sgOptions.Graphics.bColorCycling;
+	sgOptionsMenu[3].pszStr = color_cycling_toggle_names[sgOptions.Graphics.bColorCycling ? 1 : 0];
 }
 
 DEVILUTION_END_NAMESPACE

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -809,23 +809,23 @@ bool AutoEquip(int playerNumber, const ItemStruct &item)
 bool AutoEquipEnabled(const ItemStruct &item)
 {
 	if (item.isWeapon()) {
-		return sgOptions.bAutoEquipWeapons;
+		return sgOptions.Gameplay.bAutoEquipWeapons;
 	}
 
 	if (item.isArmor()) {
-		return sgOptions.bAutoEquipArmor;
+		return sgOptions.Gameplay.bAutoEquipArmor;
 	}
 
 	if (item.isHelm()) {
-		return sgOptions.bAutoEquipHelms;
+		return sgOptions.Gameplay.bAutoEquipHelms;
 	}
 
 	if (item.isShield()) {
-		return sgOptions.bAutoEquipShields;
+		return sgOptions.Gameplay.bAutoEquipShields;
 	}
 
 	if (item.isJewelry()) {
-		return sgOptions.bAutoEquipJewelry;
+		return sgOptions.Gameplay.bAutoEquipJewelry;
 	}
 
 	return true;

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -53,10 +53,10 @@ static BOOL mainmenu_single_player()
 {
 	gbIsMultiplayer = false;
 
-	gbJogInTown = sgOptions.bJogInTown;
-	gnTickRate = sgOptions.nTickRate;
-	gbTheoQuest = sgOptions.bTheoQuest;
-	gbCowQuest = sgOptions.bCowQuest;
+	gbJogInTown = sgOptions.Gameplay.bJogInTown;
+	gnTickRate = sgOptions.Gameplay.nTickRate;
+	gbTheoQuest = sgOptions.Gameplay.bTheoQuest;
+	gbCowQuest = sgOptions.Gameplay.bCowQuest;
 
 	return mainmenu_init_menu(SELHERO_NEW_DUNGEON);
 }

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -743,11 +743,11 @@ BOOL NetInit(BOOL bSinglePlayer, BOOL *pfExitProgram)
 		sgGameInitInfo.versionMinor = PROJECT_VERSION_MINOR;
 		sgGameInitInfo.versionPatch = PROJECT_VERSION_PATCH;
 		sgGameInitInfo.nDifficulty = gnDifficulty;
-		sgGameInitInfo.nTickRate = sgOptions.nTickRate;
-		sgGameInitInfo.bJogInTown = sgOptions.bJogInTown;
-		sgGameInitInfo.bTheoQuest = sgOptions.bTheoQuest;
-		sgGameInitInfo.bCowQuest = sgOptions.bCowQuest;
-		sgGameInitInfo.bFriendlyFire = sgOptions.bFriendlyFire;
+		sgGameInitInfo.nTickRate = sgOptions.Gameplay.nTickRate;
+		sgGameInitInfo.bJogInTown = sgOptions.Gameplay.bJogInTown;
+		sgGameInitInfo.bTheoQuest = sgOptions.Gameplay.bTheoQuest;
+		sgGameInitInfo.bCowQuest = sgOptions.Gameplay.bCowQuest;
+		sgGameInitInfo.bFriendlyFire = sgOptions.Gameplay.bFriendlyFire;
 		memset(&ProgramData, 0, sizeof(ProgramData));
 		ProgramData.size = sizeof(ProgramData);
 		ProgramData.maxplayers = MAX_PLRS;

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -33,7 +33,7 @@ void ApplyGamma(SDL_Color *dst, const SDL_Color *src, int n)
 	int i;
 	double g;
 
-	g = sgOptions.nGammaCorrection / 100.0;
+	g = sgOptions.Graphics.nGammaCorrection / 100.0;
 
 	for (i = 0; i < n; i++) {
 		dst[i].r = pow(src[i].r / 256.0, g) * 256.0;
@@ -45,14 +45,14 @@ void ApplyGamma(SDL_Color *dst, const SDL_Color *src, int n)
 
 static void LoadGamma()
 {
-	int gamma_value = sgOptions.nGammaCorrection;
+	int gamma_value = sgOptions.Graphics.nGammaCorrection;
 
 	if (gamma_value < 30) {
 		gamma_value = 30;
 	} else if (gamma_value > 100) {
 		gamma_value = 100;
 	}
-	sgOptions.nGammaCorrection = gamma_value - gamma_value % 5;
+	sgOptions.Graphics.nGammaCorrection = gamma_value - gamma_value % 5;
 }
 
 void palette_init()
@@ -135,7 +135,7 @@ void LoadPalette(const char *pszFileName)
 #endif
 	}
 
-	if (sgOptions.bBlendedTransparancy) {
+	if (sgOptions.Graphics.bBlendedTransparancy) {
 		if (leveltype == DTYPE_CAVES || leveltype == DTYPE_CRYPT) {
 			GenerateBlendedLookupTable(orig_palette, 1, 31);
 		} else if (leveltype == DTYPE_NEST) {
@@ -175,10 +175,10 @@ void ResetPal()
 
 void IncreaseGamma()
 {
-	if (sgOptions.nGammaCorrection < 100) {
-		sgOptions.nGammaCorrection += 5;
-		if (sgOptions.nGammaCorrection > 100)
-			sgOptions.nGammaCorrection = 100;
+	if (sgOptions.Graphics.nGammaCorrection < 100) {
+		sgOptions.Graphics.nGammaCorrection += 5;
+		if (sgOptions.Graphics.nGammaCorrection > 100)
+			sgOptions.Graphics.nGammaCorrection = 100;
 		ApplyGamma(system_palette, logical_palette, 256);
 		palette_update();
 	}
@@ -186,10 +186,10 @@ void IncreaseGamma()
 
 void DecreaseGamma()
 {
-	if (sgOptions.nGammaCorrection > 30) {
-		sgOptions.nGammaCorrection -= 5;
-		if (sgOptions.nGammaCorrection < 30)
-			sgOptions.nGammaCorrection = 30;
+	if (sgOptions.Graphics.nGammaCorrection > 30) {
+		sgOptions.Graphics.nGammaCorrection -= 5;
+		if (sgOptions.Graphics.nGammaCorrection < 30)
+			sgOptions.Graphics.nGammaCorrection = 30;
 		ApplyGamma(system_palette, logical_palette, 256);
 		palette_update();
 	}
@@ -198,11 +198,11 @@ void DecreaseGamma()
 int UpdateGamma(int gamma)
 {
 	if (gamma) {
-		sgOptions.nGammaCorrection = 130 - gamma;
+		sgOptions.Graphics.nGammaCorrection = 130 - gamma;
 		ApplyGamma(system_palette, logical_palette, 256);
 		palette_update();
 	}
-	return 130 - sgOptions.nGammaCorrection;
+	return 130 - sgOptions.Graphics.nGammaCorrection;
 }
 
 void SetFadeLevel(DWORD fadeval)
@@ -269,7 +269,7 @@ static void CycleColors(int from, int to)
 	}
 	system_palette[to] = col;
 
-	if (!sgOptions.bBlendedTransparancy)
+	if (!sgOptions.Graphics.bBlendedTransparancy)
 		return;
 
 	for (int i = 0; i < 256; i++) {
@@ -301,7 +301,7 @@ static void CycleColorsReverse(int from, int to)
 	}
 	system_palette[from] = col;
 
-	if (!sgOptions.bBlendedTransparancy)
+	if (!sgOptions.Graphics.bBlendedTransparancy)
 		return;
 
 	for (int i = 0; i < 256; i++) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2154,7 +2154,7 @@ bool PM_DoWalk(int pnum, int variant)
 	}
 
 	//Play walking sound effect on certain animation frames
-	if (sgOptions.bWalkingSound) {
+	if (sgOptions.Audio.bWalkingSound) {
 		if (plr[pnum]._pAnimFrame == 3
 		    || (plr[pnum]._pWFrames == 8 && plr[pnum]._pAnimFrame == 7)
 		    || (plr[pnum]._pWFrames != 8 && plr[pnum]._pAnimFrame == 4)) {

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -398,7 +398,7 @@ inline static void RenderLine(BYTE **dst, BYTE **src, int n, BYTE *tbl, DWORD ma
 		assert(n != 0 && n <= sizeof(DWORD) * CHAR_BIT);
 		mask &= DWORD(-1) << ((sizeof(DWORD) * CHAR_BIT) - n);
 
-		if (sgOptions.bBlendedTransparancy) {    // Blended transparancy
+		if (sgOptions.Graphics.bBlendedTransparancy) {    // Blended transparancy
 			if (light_table_index == lightmax) { // Complete darkness
 				for (int i = 0; i < n; i++, mask <<= 1) {
 					if (mask & 0x80000000)
@@ -464,7 +464,7 @@ RenderTile(BYTE *pBuff)
 
 	if (cel_transparency_active) {
 		if (arch_draw_type == 0) {
-			if (sgOptions.bBlendedTransparancy) // Use a fully transparent mask
+			if (sgOptions.Graphics.bBlendedTransparancy) // Use a fully transparent mask
 				mask = &WallMask_FullyTrasparent[TILE_HEIGHT - 1];
 			else
 				mask = &WallMask[TILE_HEIGHT - 1];
@@ -472,7 +472,7 @@ RenderTile(BYTE *pBuff)
 		if (arch_draw_type == 1 && tile != RT_LTRIANGLE) {
 			c = block_lvid[level_piece_id];
 			if (c == 1 || c == 3) {
-				if (sgOptions.bBlendedTransparancy) // Use a fully transparent mask
+				if (sgOptions.Graphics.bBlendedTransparancy) // Use a fully transparent mask
 					mask = &LeftMask_Transparent[TILE_HEIGHT - 1];
 				else
 					mask = &LeftMask[TILE_HEIGHT - 1];
@@ -481,7 +481,7 @@ RenderTile(BYTE *pBuff)
 		if (arch_draw_type == 2 && tile != RT_RTRIANGLE) {
 			c = block_lvid[level_piece_id];
 			if (c == 2 || c == 3) {
-				if (sgOptions.bBlendedTransparancy) // Use a fully transparent mask
+				if (sgOptions.Graphics.bBlendedTransparancy) // Use a fully transparent mask
 					mask = &RightMask_Transparent[TILE_HEIGHT - 1];
 				else
 					mask = &RightMask[TILE_HEIGHT - 1];

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -813,7 +813,7 @@ void S_StartSRepair()
 
 static void FillManaPlayer()
 {
-	if (!sgOptions.bAdriaRefillsMana)
+	if (!sgOptions.Gameplay.bAdriaRefillsMana)
 		return;
 	if (plr[myplr]._pMana != plr[myplr]._pMaxMana) {
 		PlaySFX(IS_CAST8);

--- a/SourceX/DiabloUI/selgame.cpp
+++ b/SourceX/DiabloUI/selgame.cpp
@@ -430,9 +430,9 @@ void selgame_Password_Select(int value)
 	GameData *data = m_client_info->initdata;
 	data->nDifficulty = nDifficulty;
 	data->nTickRate = nTickRate;
-	data->bJogInTown = sgOptions.bJogInTown;
-	data->bTheoQuest = sgOptions.bTheoQuest;
-	data->bCowQuest = sgOptions.bCowQuest;
+	data->bJogInTown = sgOptions.Gameplay.bJogInTown;
+	data->bTheoQuest = sgOptions.Gameplay.bTheoQuest;
+	data->bCowQuest = sgOptions.Gameplay.bCowQuest;
 
 	if (SNetCreateGame(NULL, selgame_Password, NULL, 0, (char *)data, sizeof(GameData), MAX_PLRS, NULL, NULL, gdwPlayerId)) {
 		UiInitList_clear();

--- a/SourceX/DiabloUI/selhero.cpp
+++ b/SourceX/DiabloUI/selhero.cpp
@@ -274,10 +274,10 @@ void selhero_List_Select(int value)
 		if (gbIsHellfire) {
 			vecSelHeroDlgItems.push_back(new UiListItem("Monk", PC_MONK));
 		}
-		if (gbBard || sgOptions.bTestBard) {
+		if (gbBard || sgOptions.Gameplay.bTestBard) {
 			vecSelHeroDlgItems.push_back(new UiListItem("Bard", PC_BARD));
 		}
-		if (gbBarbarian || sgOptions.bTestBarbarian) {
+		if (gbBarbarian || sgOptions.Gameplay.bTestBarbarian) {
 			vecSelHeroDlgItems.push_back(new UiListItem("Barbarian", PC_BARBARIAN));
 		}
 		if (vecSelHeroDlgItems.size() > 4)

--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -88,7 +88,7 @@ void CalculatePreferdWindowSize(int &width, int &height)
 		ErrSdl();
 	}
 
-	if (!sgOptions.bIntegerScaling) {
+	if (!sgOptions.Graphics.bIntegerScaling) {
 		float wFactor = (float)mode.w / width;
 		float hFactor = (float)mode.h / height;
 
@@ -156,34 +156,34 @@ bool SpawnWindow(const char *lpWindowName)
 #endif
 #endif
 
-	int width = sgOptions.nWidth;
-	int height = sgOptions.nHeight;
+	int width = sgOptions.Graphics.nWidth;
+	int height = sgOptions.Graphics.nHeight;
 
-	if (sgOptions.bUpscale && sgOptions.bFitToScreen) {
+	if (sgOptions.Graphics.bUpscale && sgOptions.Graphics.bFitToScreen) {
 		CalculatePreferdWindowSize(width, height);
 	}
 	AdjustToScreenGeometry(width, height);
 
 #ifdef USE_SDL1
 	SDL_WM_SetCaption(lpWindowName, WINDOW_ICON_NAME);
-	SetVideoModeToPrimary(!gbForceWindowed && sgOptions.bFullscreen, width, height);
-	if (sgOptions.bGrabInput)
+	SetVideoModeToPrimary(!gbForceWindowed && sgOptions.Graphics.bFullscreen, width, height);
+	if (sgOptions.Gameplay.bGrabInput)
 		SDL_WM_GrabInput(SDL_GRAB_ON);
 	atexit(SDL_VideoQuit); // Without this video mode is not restored after fullscreen.
 #else
 	int flags = 0;
-	if (sgOptions.bUpscale) {
-		if (!gbForceWindowed && sgOptions.bFullscreen) {
+	if (sgOptions.Graphics.bUpscale) {
+		if (!gbForceWindowed && sgOptions.Graphics.bFullscreen) {
 			flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 		}
 		flags |= SDL_WINDOW_RESIZABLE;
 
-		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, sgOptions.szScaleQuality);
-	} else if (!gbForceWindowed && sgOptions.bFullscreen) {
+		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, sgOptions.Graphics.szScaleQuality);
+	} else if (!gbForceWindowed && sgOptions.Graphics.bFullscreen) {
 		flags |= SDL_WINDOW_FULLSCREEN;
 	}
 
-	if (sgOptions.bGrabInput) {
+	if (sgOptions.Gameplay.bGrabInput) {
 		flags |= SDL_WINDOW_INPUT_GRABBED;
 	}
 
@@ -203,11 +203,11 @@ bool SpawnWindow(const char *lpWindowName)
 #endif
 	refreshDelay = 1000000 / refreshRate;
 
-	if (sgOptions.bUpscale) {
+	if (sgOptions.Graphics.bUpscale) {
 #ifndef USE_SDL1
 		Uint32 rendererFlags = SDL_RENDERER_ACCELERATED;
 
-		if (sgOptions.bVSync) {
+		if (sgOptions.Graphics.bVSync) {
 			rendererFlags |= SDL_RENDERER_PRESENTVSYNC;
 		}
 
@@ -221,7 +221,7 @@ bool SpawnWindow(const char *lpWindowName)
 			ErrSdl();
 		}
 
-		if (sgOptions.bIntegerScaling && SDL_RenderSetIntegerScale(renderer, SDL_TRUE) < 0) {
+		if (sgOptions.Graphics.bIntegerScaling && SDL_RenderSetIntegerScale(renderer, SDL_TRUE) < 0) {
 			ErrSdl();
 		}
 

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -289,7 +289,7 @@ void RenderPresent()
 		}
 		SDL_RenderPresent(renderer);
 
-		if (!sgOptions.bVSync) {
+		if (!sgOptions.Graphics.bVSync) {
 			LimitFrameRate();
 		}
 	} else {

--- a/SourceX/qol.cpp
+++ b/SourceX/qol.cpp
@@ -45,7 +45,7 @@ inline void FillSquare(int x, int y, int size, BYTE col)
 
 void DrawMonsterHealthBar()
 {
-	if (!sgOptions.bEnemyHealthBar)
+	if (!sgOptions.Gameplay.bEnemyHealthBar)
 		return;
 	if (currlevel == 0)
 		return;
@@ -136,7 +136,7 @@ void DrawMonsterHealthBar()
 
 void DrawXPBar()
 {
-	if (!sgOptions.bExperienceBar)
+	if (!sgOptions.Gameplay.bExperienceBar)
 		return;
 
 	int barWidth = 306;
@@ -176,7 +176,7 @@ void DrawXPBar()
 
 void AutoGoldPickup(int pnum)
 {
-	if (!sgOptions.bAutoGoldPickup)
+	if (!sgOptions.Gameplay.bAutoGoldPickup)
 		return;
 	if (pnum != myplr)
 		return;

--- a/SourceX/sound.cpp
+++ b/SourceX/sound.cpp
@@ -86,7 +86,7 @@ void snd_play_snd(TSnd *pSnd, int lVolume, int lPan)
 		return;
 	}
 
-	lVolume = CapVolume(lVolume + sgOptions.nSoundVolume);
+	lVolume = CapVolume(lVolume + sgOptions.Audio.nSoundVolume);
 	DSB->Play(lVolume, lPan);
 	pSnd->start_tc = tc;
 }
@@ -136,12 +136,12 @@ void sound_file_cleanup(TSnd *sound_file)
 
 void snd_init()
 {
-	sgOptions.nSoundVolume = CapVolume(sgOptions.nSoundVolume);
-	gbSoundOn = sgOptions.nSoundVolume > VOLUME_MIN;
+	sgOptions.Audio.nSoundVolume = CapVolume(sgOptions.Audio.nSoundVolume);
+	gbSoundOn = sgOptions.Audio.nSoundVolume > VOLUME_MIN;
 	sgbSaveSoundOn = gbSoundOn;
 
-	sgOptions.nMusicVolume = CapVolume(sgOptions.nMusicVolume);
-	gbMusicOn = sgOptions.nMusicVolume > VOLUME_MIN;
+	sgOptions.Audio.nMusicVolume = CapVolume(sgOptions.Audio.nMusicVolume);
+	gbMusicOn = sgOptions.Audio.nMusicVolume > VOLUME_MIN;
 
 	int result = Mix_OpenAudio(22050, AUDIO_S16LSB, 2, 1024);
 	if (result < 0) {
@@ -192,7 +192,7 @@ void music_start(int nTrack)
 				ErrSdl();
 			}
 			music = Mix_LoadMUSType_RW(musicRw, MUS_NONE, 1);
-			Mix_VolumeMusic(MIX_MAX_VOLUME - MIX_MAX_VOLUME * sgOptions.nMusicVolume / VOLUME_MIN);
+			Mix_VolumeMusic(MIX_MAX_VOLUME - MIX_MAX_VOLUME * sgOptions.Audio.nMusicVolume / VOLUME_MIN);
 			Mix_PlayMusic(music, -1);
 
 			sgnMusicTrack = nTrack;
@@ -212,24 +212,24 @@ void sound_disable_music(BOOL disable)
 int sound_get_or_set_music_volume(int volume)
 {
 	if (volume == 1)
-		return sgOptions.nMusicVolume;
+		return sgOptions.Audio.nMusicVolume;
 
-	sgOptions.nMusicVolume = volume;
+	sgOptions.Audio.nMusicVolume = volume;
 
 	if (sghMusic)
 		SFileDdaSetVolume(sghMusic, volume, 0);
 
-	return sgOptions.nMusicVolume;
+	return sgOptions.Audio.nMusicVolume;
 }
 
 int sound_get_or_set_sound_volume(int volume)
 {
 	if (volume == 1)
-		return sgOptions.nSoundVolume;
+		return sgOptions.Audio.nSoundVolume;
 
-	sgOptions.nSoundVolume = volume;
+	sgOptions.Audio.nSoundVolume = volume;
 
-	return sgOptions.nSoundVolume;
+	return sgOptions.Audio.nSoundVolume;
 }
 
 } // namespace dvl

--- a/SourceX/storm/storm_net.cpp
+++ b/SourceX/storm/storm_net.cpp
@@ -114,10 +114,10 @@ BOOL SNetCreateGame(const char *pszGameName, const char *pszGamePassword, const 
 	net::buffer_t game_init_info(GameTemplateData, GameTemplateData + GameTemplateSize);
 	dvlnet_inst->setup_gameinfo(std::move(game_init_info));
 
-	strncpy(gpszGameName, sgOptions.szBindAddress, sizeof(gpszGameName) - 1);
+	strncpy(gpszGameName, sgOptions.Network.szBindAddress, sizeof(gpszGameName) - 1);
 	if (pszGamePassword)
 		strncpy(gpszGamePassword, pszGamePassword, sizeof(gpszGamePassword) - 1);
-	*playerID = dvlnet_inst->create(sgOptions.szBindAddress, pszGamePassword);
+	*playerID = dvlnet_inst->create(sgOptions.Network.szBindAddress, pszGamePassword);
 	return *playerID != -1;
 }
 


### PR DESCRIPTION
This PR splits up the `Options` model into several smaller models, one for each configurable section, mimicking the structure of the ini file sections.

This makes each model a bit more manageable in code and improves readability.