### PR TITLE
Add item sounds to auto-equip

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -403,6 +403,7 @@ static void SaveOptions()
 	setIniInt("Audio", "Sound Volume", sgOptions.Audio.nSoundVolume);
 	setIniInt("Audio", "Music Volume", sgOptions.Audio.nMusicVolume);
 	setIniInt("Audio", "Walking Sound", sgOptions.Audio.bWalkingSound);
+	setIniInt("Audio", "Auto Equip Sound", sgOptions.Audio.bAutoEquipSound);
 
 #ifndef __vita__
 	setIniInt("Graphics", "Width", sgOptions.Graphics.nWidth);
@@ -449,6 +450,7 @@ static void LoadOptions()
 	sgOptions.Audio.nSoundVolume = getIniInt("Audio", "Sound Volume", VOLUME_MAX);
 	sgOptions.Audio.nMusicVolume = getIniInt("Audio", "Music Volume", VOLUME_MAX);
 	sgOptions.Audio.bWalkingSound = getIniBool("Audio", "Walking Sound", true);
+	sgOptions.Audio.bAutoEquipSound = getIniBool("Audio", "Auto Equip Sound", false);
 
 #ifndef __vita__
 	sgOptions.Graphics.nWidth = getIniInt("Graphics", "Width", DEFAULT_WIDTH);

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -28,6 +28,9 @@ typedef struct AudioOptions {
 
 	/** @brief Player emits sound when walking. */
 	bool bWalkingSound;
+
+	/** @brief Automatically equipping items on pickup emits the equipment sound. */
+	bool bAutoEquipSound;
 } AudioOptions;
 
 typedef struct GraphicsOptions {

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -773,6 +773,10 @@ bool AutoEquip(int playerNumber, const ItemStruct &item, int bodyLocation)
 
 	plr[playerNumber].InvBody[bodyLocation] = item;
 
+	if (playerNumber == myplr) {
+		PlaySFX(ItemInvSnds[ItemCAnimTbl[item._iCurs]]);
+	}
+
 	NetSendCmdChItem(FALSE, bodyLocation);
 	CalcPlrInv(playerNumber, TRUE);
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -773,7 +773,7 @@ bool AutoEquip(int playerNumber, const ItemStruct &item, int bodyLocation)
 
 	plr[playerNumber].InvBody[bodyLocation] = item;
 
-	if (playerNumber == myplr) {
+	if (sgOptions.Audio.bAutoEquipSound && playerNumber == myplr) {
 		PlaySFX(ItemInvSnds[ItemCAnimTbl[item._iCurs]]);
 	}
 


### PR DESCRIPTION
Adds item equip sound to when the item is automatically equipped on pickup. Sound is disabled by default and can be turned on via ini toggle.