### PR TITLE
Corrected Markdown syntax on FAQ section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ variable (see
 # F.A.Q.
 > Wow, does this mean I can download and play Diablo for free now?
 
-No, you'll need access to the data from the original game. If you don't have an original CD then you can [buy Diablo from GoG.com](https://www.gog.com/game/diablo). Alternately you can use `spawn.mpq` from the [http://ftp.blizzard.com/pub/demos/diablosw.exe](shareware) version to play the shareware portion of the game.
+No, you'll need access to the data from the original game. If you don't have an original CD then you can [buy Diablo from GoG.com](https://www.gog.com/game/diablo). Alternately you can use `spawn.mpq` from the [shareware](http://ftp.blizzard.com/pub/demos/diablosw.exe) version to play the shareware portion of the game.
 > What game changes does DevilutionX provide
 
 DevilutionX's main focus is to make the game work on multiple platforms. An additional goal is to make the engine mod friendly. As such, there are no changes to gameplay, but we will be making some enhancments to the engine itself. For example, the engine now has upscaling, unlocked fps, controller support, and multiplayer via TCP.


### PR DESCRIPTION
The md for the ftp link was backwards! Correct markdown syntax is [text](url), but I understand why it would happen, it's like connecting USB, you never get it right the first time! 🙂