### PR TITLE
:sparkles: Autoequip items on purchase

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -433,11 +433,11 @@ static void SaveOptions()
 	setIniInt("Game", "Enemy Health Bar", sgOptions.Gameplay.bEnemyHealthBar);
 	setIniInt("Game", "Auto Gold Pickup", sgOptions.Gameplay.bAutoGoldPickup);
 	setIniInt("Game", "Adria Refills Mana", sgOptions.Gameplay.bAdriaRefillsMana);
-	setIniInt("Game", "Auto Equip Weapons on Pickup", sgOptions.Gameplay.bAutoEquipWeapons);
-	setIniInt("Game", "Auto Equip Armor on Pickup", sgOptions.Gameplay.bAutoEquipArmor);
-	setIniInt("Game", "Auto Equip Helms on Pickup", sgOptions.Gameplay.bAutoEquipHelms);
-	setIniInt("Game", "Auto Equip Shields on Pickup", sgOptions.Gameplay.bAutoEquipShields);
-	setIniInt("Game", "Auto Equip Jewelry on Pickup", sgOptions.Gameplay.bAutoEquipJewelry);
+	setIniInt("Game", "Auto Equip Weapons on Pickup/Purchase", sgOptions.Gameplay.bAutoEquipWeapons);
+	setIniInt("Game", "Auto Equip Armor on Pickup/Purchase", sgOptions.Gameplay.bAutoEquipArmor);
+	setIniInt("Game", "Auto Equip Helms on Pickup/Purchase", sgOptions.Gameplay.bAutoEquipHelms);
+	setIniInt("Game", "Auto Equip Shields on Pickup/Purchase", sgOptions.Gameplay.bAutoEquipShields);
+	setIniInt("Game", "Auto Equip Jewelry on Pickup/Purchase", sgOptions.Gameplay.bAutoEquipJewelry);
 
 	setIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress);
 }
@@ -485,11 +485,11 @@ static void LoadOptions()
 	sgOptions.Gameplay.bEnemyHealthBar = getIniBool("Game", "Enemy Health Bar", false);
 	sgOptions.Gameplay.bAutoGoldPickup = getIniBool("Game", "Auto Gold Pickup", false);
 	sgOptions.Gameplay.bAdriaRefillsMana = getIniBool("Game", "Adria Refills Mana", false);
-	sgOptions.Gameplay.bAutoEquipWeapons = getIniBool("Game", "Auto Equip Weapons on Pickup", true);
-	sgOptions.Gameplay.bAutoEquipArmor = getIniBool("Game", "Auto Equip Armor on Pickup", false);
-	sgOptions.Gameplay.bAutoEquipHelms = getIniBool("Game", "Auto Equip Helms on Pickup", false);
-	sgOptions.Gameplay.bAutoEquipShields = getIniBool("Game", "Auto Equip Shields on Pickup", false);
-	sgOptions.Gameplay.bAutoEquipJewelry = getIniBool("Game", "Auto Equip Jewelry on Pickup", false);
+	sgOptions.Gameplay.bAutoEquipWeapons = getIniBool("Game", "Auto Equip Weapons on Pickup/Purchase", true);
+	sgOptions.Gameplay.bAutoEquipArmor = getIniBool("Game", "Auto Equip Armor on Pickup/Purchase", false);
+	sgOptions.Gameplay.bAutoEquipHelms = getIniBool("Game", "Auto Equip Helms on Pickup/Purchase", false);
+	sgOptions.Gameplay.bAutoEquipShields = getIniBool("Game", "Auto Equip Shields on Pickup/Purchase", false);
+	sgOptions.Gameplay.bAutoEquipJewelry = getIniBool("Game", "Auto Equip Jewelry on Pickup/Purchase", false);
 
 	getIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress, sizeof(sgOptions.Network.szBindAddress), "0.0.0.0");
 }

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -35,6 +35,8 @@ void InitInv();
 void DrawInv(CelOutputBuffer out);
 
 void DrawInvBelt(CelOutputBuffer out);
+bool AutoEquipEnabled(const ItemStruct &item);
+bool AutoEquip(int playerNumber, const ItemStruct &item, bool persistItem = true);
 BOOL AutoPlace(int pnum, int ii, int sx, int sy, BOOL saveflag);
 BOOL SpecialAutoPlace(int pnum, int ii, const ItemStruct &item);
 BOOL GoldAutoPlace(int pnum);

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -363,7 +363,11 @@ void StoreAutoPlace()
 	w = icursW28;
 	h = icursH28;
 	done = FALSE;
-	if (w == 1 && h == 1) {
+	if (AutoEquipEnabled(plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem)) {
+		done = TRUE;
+	}
+
+	if (w == 1 && h == 1 && !done) {
 		idx = plr[myplr].HoldItem.IDidx;
 		if (plr[myplr].HoldItem._iStatFlag && AllItemsList[idx].iUsable) {
 			for (i = 0; i < MAXBELTITEMS && !done; i++) {
@@ -386,7 +390,7 @@ void StoreAutoPlace()
 			done = AutoPlace(myplr, i, w, h, TRUE);
 		}
 	}
-	if (w == 1 && h == 2) {
+	if (w == 1 && h == 2 && !done) {
 		for (i = 29; i >= 20 && !done; i--) {
 			done = AutoPlace(myplr, i, w, h, TRUE);
 		}
@@ -397,12 +401,12 @@ void StoreAutoPlace()
 			done = AutoPlace(myplr, i, w, h, TRUE);
 		}
 	}
-	if (w == 1 && h == 3) {
+	if (w == 1 && h == 3 && !done) {
 		for (i = 0; i < 20 && !done; i++) {
 			done = AutoPlace(myplr, i, w, h, TRUE);
 		}
 	}
-	if (w == 2 && h == 2) {
+	if (w == 2 && h == 2 && !done) {
 		for (i = 0; i < 10 && !done; i++) {
 			done = AutoPlace(myplr, AP2x2Tbl[i], w, h, TRUE);
 		}
@@ -416,7 +420,7 @@ void StoreAutoPlace()
 			done = AutoPlace(myplr, i, w, h, TRUE);
 		}
 	}
-	if (w == 2 && h == 3) {
+	if (w == 2 && h == 3 && !done) {
 		for (i = 0; i < 9 && !done; i++) {
 			done = AutoPlace(myplr, i, w, h, TRUE);
 		}
@@ -1957,6 +1961,9 @@ void S_SBuyEnter()
 			plr[myplr].HoldItem = smithitem[idx];
 			SetCursor_(plr[myplr].HoldItem._iCurs + CURSOR_FIRSTITEM);
 			done = FALSE;
+			if (AutoEquipEnabled(plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem, false)) {
+				done = TRUE;
+			}
 
 			for (i = 0; i < NUM_INV_GRID_ELEM && !done; i++) {
 				done = AutoPlace(myplr, i, cursW / 28, cursH / 28, FALSE);
@@ -2022,6 +2029,10 @@ void S_SPBuyEnter()
 			plr[myplr].HoldItem = premiumitem[idx];
 			SetCursor_(plr[myplr].HoldItem._iCurs + CURSOR_FIRSTITEM);
 			done = FALSE;
+			if (AutoEquipEnabled(plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem, false)) {
+				done = TRUE;
+			}
+
 			for (i = 0; i < NUM_INV_GRID_ELEM && !done; i++) {
 				done = AutoPlace(myplr, i, cursW / 28, cursH / 28, FALSE);
 			}
@@ -2281,6 +2292,9 @@ void S_WBuyEnter()
 			plr[myplr].HoldItem = witchitem[idx];
 			SetCursor_(plr[myplr].HoldItem._iCurs + CURSOR_FIRSTITEM);
 			done = FALSE;
+			if (AutoEquipEnabled(plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem, false)) {
+				done = TRUE;
+			}
 
 			for (i = 0; i < NUM_INV_GRID_ELEM && !done; i++) {
 				done = SpecialAutoPlace(myplr, i, plr[myplr].HoldItem);
@@ -2456,6 +2470,10 @@ void S_BBuyEnter()
 	SetCursor_(plr[myplr].HoldItem._iCurs + CURSOR_FIRSTITEM);
 
 	bool done = false;
+	if (AutoEquipEnabled(plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem, false)) {
+		done = true;
+	}
+
 	for (int i = 0; i < NUM_INV_GRID_ELEM && !done; i++) {
 		done = AutoPlace(myplr, i, cursW / 28, cursH / 28, false);
 	}
@@ -2582,6 +2600,9 @@ void S_HBuyEnter()
 			plr[myplr].HoldItem = healitem[idx];
 			SetCursor_(plr[myplr].HoldItem._iCurs + CURSOR_FIRSTITEM);
 			done = FALSE;
+			if (AutoEquipEnabled(plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem, false)) {
+				done = TRUE;
+			}
 
 			for (i = 0; i < NUM_INV_GRID_ELEM && !done; i++) {
 				done = SpecialAutoPlace(myplr, i, plr[myplr].HoldItem);


### PR DESCRIPTION
This PR introduces auto-equip functionality for purchased items. 

If auto-equip is enabled for the corresponding item type, the item is checked against the player's current body slots: if the item can be equipped, the purchase is made and the item is equipped automatically.

Note that this means one can now puchase items even with a full inventory, provided he has the corresponding empty slot in the body for the item to be equipped.