### PR TITLE
fix infinite attack loop when force attacking a non-hostile character

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2725,7 +2725,8 @@ BOOL PM_DoAttack(int pnum)
 				m = -(dMonster[dx][dy] + 1);
 			}
 			if (CanTalkToMonst(m)) {
-				plr[pnum]._pVar1 = 0;
+				StartStand(pnum, plr[pnum]._pdir);
+				ClearPlrPVars(pnum);
 				return FALSE;
 			}
 		}


### PR DESCRIPTION
Not sure if this is the right fix but fixes the problem for me. Reproduce by standing next to a non hostile character (I found the bug with Lachdanan), putting the cursor the opposite side of them then force attack. An infinite loop of attacks starts and there doesn't seem to be any way to break out of it.