### PR TITLE
Migrate most rendering away from gpBuffer / gpBufEnd

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1755,30 +1755,30 @@ void DrawDurIcon(CelOutputBuffer out)
 	DrawDurIcon4Item(out, &p->InvBody[INVLOC_HAND_RIGHT], x, 0);
 }
 
-void RedBack()
+void RedBack(CelOutputBuffer out)
 {
 	int idx;
 
 	idx = light4flag ? 1536 : 4608;
 
-	assert(gpBuffer);
+	assert(out.begin != NULL);
 
 	int w, h;
 	BYTE *dst, *tbl;
 
 	if (leveltype != DTYPE_HELL) {
-		dst = &gpBuffer[SCREENXY(0, 0)];
+		dst = out.at(SCREEN_X, SCREEN_Y);
 		tbl = &pLightTbl[idx];
-		for (h = gnViewportHeight; h; h--, dst += BUFFER_WIDTH - gnScreenWidth) {
+		for (h = gnViewportHeight; h; h--, dst += out.line_width - gnScreenWidth) {
 			for (w = gnScreenWidth; w; w--) {
 				*dst = tbl[*dst];
 				dst++;
 			}
 		}
 	} else {
-		dst = &gpBuffer[SCREENXY(0, 0)];
+		dst = out.at(SCREEN_X, SCREEN_Y);
 		tbl = &pLightTbl[idx];
-		for (h = gnViewportHeight; h; h--, dst += BUFFER_WIDTH - gnScreenWidth) {
+		for (h = gnViewportHeight; h; h--, dst += out.line_width - gnScreenWidth) {
 			for (w = gnScreenWidth; w; w--) {
 				if (*dst >= 32)
 					*dst = tbl[*dst];

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -620,22 +620,22 @@ static void DrawFlaskTop(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, in
  * Draws the dome of the flask that protrudes above the panel top line.
  * It draws a rectangle of fixed width 59 and height 'h' from the source buffer
  * into the target buffer.
+ * @param out The target buffer.
  * @param pCelBuff The flask cel buffer.
  * @param w Width of the cel.
  * @param nSrcOff Offset of the source buffer from where the bytes will start to be copied from.
  * @param pBuff Target buffer.
- * @param nDstOff Offset of the target buffer where the bytes will start to be copied to.
+ * @param sx Target buffer coordinate.
+ * @param sy Target buffer coordinate.
  * @param h How many lines of the source buffer that will be copied.
  */
-void DrawFlask(BYTE *pCelBuff, int w, int nSrcOff, BYTE *pBuff, int nDstOff, int h)
+static void DrawFlask(CelOutputBuffer out, BYTE *pCelBuff, int w, int nSrcOff, int x, int y, int h)
 {
 	int wdt, hgt;
-	BYTE *src, *dst;
+	BYTE *src = &pCelBuff[nSrcOff];
+	BYTE *dst = out.at(x, y);
 
-	src = &pCelBuff[nSrcOff];
-	dst = &pBuff[nDstOff];
-
-	for (hgt = h; hgt; hgt--, src += w - 59, dst += BUFFER_WIDTH - 59) {
+	for (hgt = h; hgt; hgt--, src += w - 59, dst += out.line_width - 59) {
 		for (wdt = 59; wdt; wdt--) {
 			if (*src)
 				*dst = *src;
@@ -645,11 +645,7 @@ void DrawFlask(BYTE *pCelBuff, int w, int nSrcOff, BYTE *pBuff, int nDstOff, int
 	}
 }
 
-/**
- * Draws the top dome of the life flask (that part that protrudes out of the control panel).
- * First it draws the empty flask cel and then draws the filled part on top if needed.
- */
-void DrawLifeFlask()
+void DrawLifeFlask(CelOutputBuffer out)
 {
 	double p;
 	int filled;
@@ -669,9 +665,9 @@ void DrawLifeFlask()
 		filled = 11;
 	filled += 2;
 
-	DrawFlask(pLifeBuff, 88, 88 * 3 + 13, gpBuffer, SCREENXY(PANEL_LEFT + 109, PANEL_TOP - 13), filled);
+	DrawFlask(out, pLifeBuff, 88, 88 * 3 + 13, SCREEN_X + PANEL_LEFT + 109, SCREEN_Y + PANEL_TOP - 13, filled);
 	if (filled != 13)
-		DrawFlask(pBtmBuff, PANEL_WIDTH, PANEL_WIDTH * (filled + 3) + 109, gpBuffer, SCREENXY(PANEL_LEFT + 109, PANEL_TOP - 13 + filled), 13 - filled);
+		DrawFlask(out, pBtmBuff, PANEL_WIDTH, PANEL_WIDTH * (filled + 3) + 109, SCREEN_X + PANEL_LEFT + 109, SCREEN_Y + PANEL_TOP - 13 + filled, 13 - filled);
 }
 
 void UpdateLifeFlask(CelOutputBuffer out)
@@ -696,7 +692,7 @@ void UpdateLifeFlask(CelOutputBuffer out)
 		DrawPanelBox(out, 96, 85 - filled, 88, filled, 96 + PANEL_X, PANEL_Y + 69 - filled);
 }
 
-void DrawManaFlask()
+void DrawManaFlask(CelOutputBuffer out)
 {
 	int filled = plr[myplr]._pManaPer;
 	if (filled > 80)
@@ -706,9 +702,9 @@ void DrawManaFlask()
 		filled = 11;
 	filled += 2;
 
-	DrawFlask(pManaBuff, 88, 88 * 3 + 13, gpBuffer, SCREENXY(PANEL_LEFT + 475, PANEL_TOP - 13), filled);
+	DrawFlask(out, pManaBuff, 88, 88 * 3 + 13, SCREEN_X + PANEL_LEFT + 475, SCREEN_Y + PANEL_TOP - 13, filled);
 	if (filled != 13)
-		DrawFlask(pBtmBuff, PANEL_WIDTH, PANEL_WIDTH * (filled + 3) + 475, gpBuffer, SCREENXY(PANEL_LEFT + 475, PANEL_TOP - 13 + filled), 13 - filled);
+		DrawFlask(out, pBtmBuff, PANEL_WIDTH, PANEL_WIDTH * (filled + 3) + 475, SCREEN_X + PANEL_LEFT + 475, SCREEN_Y + PANEL_TOP - 13 + filled, 13 - filled);
 }
 
 void control_update_life_mana()

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -597,30 +597,23 @@ void DrawPanelBox(CelOutputBuffer out, int x, int y, int w, int h, int sx, int s
 /**
  * Draws a section of the empty flask cel on top of the panel to create the illusion
  * of the flask getting empty. This function takes a cel and draws a
- * horizontal stripe of height (max-min) onto the back buffer.
+ * horizontal stripe of height (max-min) onto the given buffer.
+ * @param out Target buffer.
+ * @param sx Buffer coordinate
+ * @param sy Buffer coordinate
  * @param pCelBuff Buffer of the empty flask cel.
- * @param min Top of the flask cel section to draw.
- * @param max Bottom of the flask cel section to draw.
- * @param sx Back buffer coordinate
- * @param sy Back buffer coordinate
+ * @param y0 Top of the flask cel section to draw.
+ * @param y1 Bottom of the flask cel section to draw.
  */
-void SetFlaskHeight(BYTE *pCelBuff, int min, int max, int sx, int sy)
+static void DrawFlaskTop(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int y0, int y1)
 {
-	int nSrcOff, nDstOff, w;
+	const std::size_t kSrcWidth = 88;
 
-	assert(gpBuffer);
+	const BYTE *src = &pCelBuff[kSrcWidth * y0];
+	BYTE *dst = out.at(sx, sy);
 
-	nSrcOff = 88 * min;
-	nDstOff = sx + BUFFER_WIDTH * sy;
-	w = max - min;
-
-	BYTE *src, *dst;
-
-	src = &pCelBuff[nSrcOff];
-	dst = &gpBuffer[nDstOff];
-
-	for (; w; w--, src += 88, dst += BUFFER_WIDTH)
-		memcpy(dst, src, 88);
+	for (int h = y1 - y0; h != 0; --h, src += kSrcWidth, dst += out.line_width)
+		memcpy(dst, src, kSrcWidth);
 }
 
 /**
@@ -698,7 +691,7 @@ void UpdateLifeFlask(CelOutputBuffer out)
 	else if (filled < 0)
 		filled = 0;
 	if (filled != 69)
-		SetFlaskHeight(pLifeBuff, 16, 85 - filled, 96 + PANEL_X, PANEL_Y);
+		DrawFlaskTop(out, 96 + PANEL_X, PANEL_Y, pLifeBuff, 16, 85 - filled);
 	if (filled != 0)
 		DrawPanelBox(out, 96, 85 - filled, 88, filled, 96 + PANEL_X, PANEL_Y + 69 - filled);
 }
@@ -755,7 +748,7 @@ void UpdateManaFlask(CelOutputBuffer out)
 	if (filled > 69)
 		filled = 69;
 	if (filled != 69)
-		SetFlaskHeight(pManaBuff, 16, 85 - filled, PANEL_X + 464, PANEL_Y);
+		DrawFlaskTop(out, PANEL_X + 464, PANEL_Y, pManaBuff, 16, 85 - filled);
 	if (filled != 0)
 		DrawPanelBox(out, 464, 85 - filled, 88, filled, PANEL_X + 464, PANEL_Y + 69 - filled);
 

--- a/Source/control.h
+++ b/Source/control.h
@@ -65,7 +65,12 @@ void PrintChar(CelOutputBuffer out, int sx, int sy, int nCel, char col);
 void AddPanelString(const char *str, BOOL just);
 void ClearPanel();
 void DrawPanelBox(CelOutputBuffer out, int x, int y, int w, int h, int sx, int sy);
-void DrawLifeFlask();
+
+/**
+ * Draws the top dome of the life flask (that part that protrudes out of the control panel).
+ * First it draws the empty flask cel and then draws the filled part on top if needed.
+ */
+void DrawLifeFlask(CelOutputBuffer out);
 
 /**
  * Controls the drawing of the area of the life flask within the control panel.
@@ -74,7 +79,7 @@ void DrawLifeFlask();
  */
 void UpdateLifeFlask(CelOutputBuffer out);
 
-void DrawManaFlask();
+void DrawManaFlask(CelOutputBuffer out);
 void control_update_life_mana();
 
 /**

--- a/Source/control.h
+++ b/Source/control.h
@@ -119,7 +119,7 @@ void DrawLevelUpIcon(CelOutputBuffer out);
 void CheckChrBtns();
 void ReleaseChrBtns(bool addAllStatPoints);
 void DrawDurIcon(CelOutputBuffer out);
-void RedBack();
+void RedBack(CelOutputBuffer out);
 void DrawSpellBook(CelOutputBuffer out);
 void CheckSBook();
 const char *get_pieces_str(int nGold);

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -72,9 +72,12 @@ struct CelOutputBuffer {
 		return x >= 0 && y >= 0 && begin + x + line_width * y < end;
 	}
 
-	CelOutputBuffer subregion(int x0, int y0, int x1, int y1) const
+	/**
+	 * @brief Returns a buffer that starts at y0 and ends at y1.
+	 */
+	CelOutputBuffer subregionY(int y0, int y1) const
 	{
-		return CelOutputBuffer { at(x0, y0), std::min(at(x1, y1), end), line_width };
+		return CelOutputBuffer { at(0, y0), std::min(at(0, y1), end), line_width };
 	}
 #endif
 };

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -124,7 +124,7 @@ void DrawDiabloMsg(CelOutputBuffer out)
 		sy += 12;
 	}
 
-	assert(gpBuffer);
+	assert(out.begin);
 
 	DrawHalfTransparentRectTo(out, PANEL_X + 104, DIALOG_Y - 8, 432, 54);
 

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -156,14 +156,12 @@ void gmenu_set_items(TMenuItem *pItem, void (*gmFunc)(TMenuItem *))
 	gmenu_up_down(TRUE);
 }
 
-static void gmenu_clear_buffer(int x, int y, int width, int height)
+static void gmenu_clear_buffer(CelOutputBuffer out, int x, int y, int width, int height)
 {
-	BYTE *i;
-
-	i = gpBuffer + BUFFER_WIDTH * y + x;
+	BYTE *i = out.at(x, y);
 	while (height--) {
 		memset(i, 205, width);
-		i -= BUFFER_WIDTH;
+		i -= out.line_width;
 	}
 }
 
@@ -196,7 +194,7 @@ static void gmenu_draw_menu_item(CelOutputBuffer out, TMenuItem *pItem, int y)
 		if (nSteps < 2)
 			nSteps = 2;
 		pos = step * 256 / nSteps;
-		gmenu_clear_buffer(x + 2 + PANEL_LEFT, y - 12, pos + 13, 28);
+		gmenu_clear_buffer(out, x + 2 + PANEL_LEFT, y - 12, pos + 13, 28);
 		CelDrawTo(out, x + 2 + pos + PANEL_LEFT, y - 12, option_cel, 1, 27);
 	}
 	x = gnScreenWidth / 2 - w / 2 + SCREEN_X;

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -64,7 +64,7 @@ static void gmenu_print_text(CelOutputBuffer out, int x, int y, const char *pszS
 void gmenu_draw_pause(CelOutputBuffer out)
 {
 	if (currlevel != 0)
-		RedBack();
+		RedBack(out);
 	if (!sgpCurrentMenu) {
 		light_table_index = 0;
 		gmenu_print_text(out, 316 + PANEL_LEFT, 336, "Pause");

--- a/Source/help.cpp
+++ b/Source/help.cpp
@@ -486,7 +486,7 @@ void DrawHelp(CelOutputBuffer out)
 		PrintSString(out, 0, 2, TRUE, "Hellfire Help", COL_GOLD, 0);
 	else
 		PrintSString(out, 0, 2, TRUE, "Diablo Help", COL_GOLD, 0);
-	DrawSLine(5);
+	DrawSLine(out, 5);
 
 	s = &gszHelpText[0];
 	if (gbIsSpawn)

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -230,15 +230,11 @@ static void InitCutscene(unsigned int uMsg)
 	sgdwProgress = 0;
 }
 
-static void DrawProgress(int screen_x, int screen_y, int progress_id)
+static void DrawProgress(CelOutputBuffer out, int x, int y, int progress_id)
 {
-	BYTE *dst;
-	int i;
-
-	dst = &gpBuffer[screen_x + BUFFER_WIDTH * screen_y];
-	for (i = 0; i < 22; i++) {
+	BYTE *dst = out.at(x, y);
+	for (int i = 0; i < 22; ++i, dst += out.line_width) {
 		*dst = BarColor[progress_id];
-		dst += BUFFER_WIDTH;
 	}
 }
 
@@ -247,10 +243,12 @@ static void DrawCutscene()
 	DWORD i;
 
 	lock_buf(1);
-	CelDrawTo(GlobalBackBuffer(), PANEL_X, 480 + SCREEN_Y - 1 + UI_OFFSET_Y, sgpBackCel, 1, 640);
+	CelOutputBuffer out = GlobalBackBuffer();
+	CelDrawTo(out, PANEL_X, 480 + SCREEN_Y - 1 + UI_OFFSET_Y, sgpBackCel, 1, 640);
 
 	for (i = 0; i < sgdwProgress; i++) {
 		DrawProgress(
+		    out,
 		    BarPos[progress_id][0] + i + PANEL_X,
 		    BarPos[progress_id][1] + SCREEN_Y + UI_OFFSET_Y,
 		    progress_id);

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -139,18 +139,18 @@ void InitInv()
 	drawsbarflag = FALSE;
 }
 
-void InvDrawSlotBack(int X, int Y, int W, int H)
+static void InvDrawSlotBack(CelOutputBuffer out, int X, int Y, int W, int H)
 {
 	BYTE *dst;
 
-	assert(gpBuffer);
+	assert(out.begin);
 
-	dst = &gpBuffer[X + BUFFER_WIDTH * Y];
+	dst = out.at(X, Y);
 
 	int wdt, hgt;
 	BYTE pix;
 
-	for (hgt = H; hgt; hgt--, dst -= BUFFER_WIDTH + W) {
+	for (hgt = H; hgt; hgt--, dst -= out.line_width + W) {
 		for (wdt = W; wdt; wdt--) {
 			pix = *dst;
 			if (pix >= PAL16_BLUE) {
@@ -172,7 +172,7 @@ void DrawInv(CelOutputBuffer out)
 	CelDrawTo(out, RIGHT_PANEL_X, 351 + SCREEN_Y, pInvCels, 1, SPANEL_WIDTH);
 
 	if (!plr[myplr].InvBody[INVLOC_HEAD].isEmpty()) {
-		InvDrawSlotBack(RIGHT_PANEL_X + 133, 59 + SCREEN_Y, 2 * INV_SLOT_SIZE_PX, 2 * INV_SLOT_SIZE_PX);
+		InvDrawSlotBack(out, RIGHT_PANEL_X + 133, 59 + SCREEN_Y, 2 * INV_SLOT_SIZE_PX, 2 * INV_SLOT_SIZE_PX);
 
 		frame = plr[myplr].InvBody[INVLOC_HEAD]._iCurs + CURSOR_FIRSTITEM;
 		frame_width = InvItemWidth[frame];
@@ -208,7 +208,7 @@ void DrawInv(CelOutputBuffer out)
 	}
 
 	if (!plr[myplr].InvBody[INVLOC_RING_LEFT].isEmpty()) {
-		InvDrawSlotBack(RIGHT_PANEL_X + 48, 205 + SCREEN_Y, INV_SLOT_SIZE_PX, INV_SLOT_SIZE_PX);
+		InvDrawSlotBack(out, RIGHT_PANEL_X + 48, 205 + SCREEN_Y, INV_SLOT_SIZE_PX, INV_SLOT_SIZE_PX);
 
 		frame = plr[myplr].InvBody[INVLOC_RING_LEFT]._iCurs + CURSOR_FIRSTITEM;
 		frame_width = InvItemWidth[frame];
@@ -244,7 +244,7 @@ void DrawInv(CelOutputBuffer out)
 	}
 
 	if (!plr[myplr].InvBody[INVLOC_RING_RIGHT].isEmpty()) {
-		InvDrawSlotBack(RIGHT_PANEL_X + 249, 205 + SCREEN_Y, INV_SLOT_SIZE_PX, INV_SLOT_SIZE_PX);
+		InvDrawSlotBack(out, RIGHT_PANEL_X + 249, 205 + SCREEN_Y, INV_SLOT_SIZE_PX, INV_SLOT_SIZE_PX);
 
 		frame = plr[myplr].InvBody[INVLOC_RING_RIGHT]._iCurs + CURSOR_FIRSTITEM;
 		frame_width = InvItemWidth[frame];
@@ -280,7 +280,7 @@ void DrawInv(CelOutputBuffer out)
 	}
 
 	if (!plr[myplr].InvBody[INVLOC_AMULET].isEmpty()) {
-		InvDrawSlotBack(RIGHT_PANEL_X + 205, 60 + SCREEN_Y, INV_SLOT_SIZE_PX, INV_SLOT_SIZE_PX);
+		InvDrawSlotBack(out, RIGHT_PANEL_X + 205, 60 + SCREEN_Y, INV_SLOT_SIZE_PX, INV_SLOT_SIZE_PX);
 
 		frame = plr[myplr].InvBody[INVLOC_AMULET]._iCurs + CURSOR_FIRSTITEM;
 		frame_width = InvItemWidth[frame];
@@ -316,7 +316,7 @@ void DrawInv(CelOutputBuffer out)
 	}
 
 	if (!plr[myplr].InvBody[INVLOC_HAND_LEFT].isEmpty()) {
-		InvDrawSlotBack(RIGHT_PANEL_X + 17, 160 + SCREEN_Y, 2 * INV_SLOT_SIZE_PX, 3 * INV_SLOT_SIZE_PX);
+		InvDrawSlotBack(out, RIGHT_PANEL_X + 17, 160 + SCREEN_Y, 2 * INV_SLOT_SIZE_PX, 3 * INV_SLOT_SIZE_PX);
 
 		frame = plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCurs + CURSOR_FIRSTITEM;
 		frame_width = InvItemWidth[frame];
@@ -357,7 +357,7 @@ void DrawInv(CelOutputBuffer out)
 			if (plr[myplr]._pClass != PC_BARBARIAN
 			    || plr[myplr].InvBody[INVLOC_HAND_LEFT]._itype != ITYPE_SWORD
 			        && plr[myplr].InvBody[INVLOC_HAND_LEFT]._itype != ITYPE_MACE) {
-				InvDrawSlotBack(RIGHT_PANEL_X + 248, 160 + SCREEN_Y, 2 * INV_SLOT_SIZE_PX, 3 * INV_SLOT_SIZE_PX);
+				InvDrawSlotBack(out, RIGHT_PANEL_X + 248, 160 + SCREEN_Y, 2 * INV_SLOT_SIZE_PX, 3 * INV_SLOT_SIZE_PX);
 				light_table_index = 0;
 				cel_transparency_active = TRUE;
 
@@ -374,7 +374,7 @@ void DrawInv(CelOutputBuffer out)
 		}
 	}
 	if (!plr[myplr].InvBody[INVLOC_HAND_RIGHT].isEmpty()) {
-		InvDrawSlotBack(RIGHT_PANEL_X + 248, 160 + SCREEN_Y, 2 * INV_SLOT_SIZE_PX, 3 * INV_SLOT_SIZE_PX);
+		InvDrawSlotBack(out, RIGHT_PANEL_X + 248, 160 + SCREEN_Y, 2 * INV_SLOT_SIZE_PX, 3 * INV_SLOT_SIZE_PX);
 
 		frame = plr[myplr].InvBody[INVLOC_HAND_RIGHT]._iCurs + CURSOR_FIRSTITEM;
 		frame_width = InvItemWidth[frame];
@@ -413,7 +413,7 @@ void DrawInv(CelOutputBuffer out)
 	}
 
 	if (!plr[myplr].InvBody[INVLOC_CHEST].isEmpty()) {
-		InvDrawSlotBack(RIGHT_PANEL_X + 133, 160 + SCREEN_Y, 2 * INV_SLOT_SIZE_PX, 3 * INV_SLOT_SIZE_PX);
+		InvDrawSlotBack(out, RIGHT_PANEL_X + 133, 160 + SCREEN_Y, 2 * INV_SLOT_SIZE_PX, 3 * INV_SLOT_SIZE_PX);
 
 		frame = plr[myplr].InvBody[INVLOC_CHEST]._iCurs + CURSOR_FIRSTITEM;
 		frame_width = InvItemWidth[frame];
@@ -452,6 +452,7 @@ void DrawInv(CelOutputBuffer out)
 		invtest[i] = FALSE;
 		if (plr[myplr].InvGrid[i] != 0) {
 			InvDrawSlotBack(
+			    out,
 			    InvRect[i + SLOTXY_INV_FIRST].X + RIGHT_PANEL_X,
 			    InvRect[i + SLOTXY_INV_FIRST].Y + SCREEN_Y - 1,
 			    INV_SLOT_SIZE_PX,
@@ -542,7 +543,7 @@ void DrawInvBelt(CelOutputBuffer out)
 			continue;
 		}
 
-		InvDrawSlotBack(InvRect[i + SLOTXY_BELT_FIRST].X + PANEL_X, InvRect[i + SLOTXY_BELT_FIRST].Y + PANEL_Y - 1, INV_SLOT_SIZE_PX, INV_SLOT_SIZE_PX);
+		InvDrawSlotBack(out, InvRect[i + SLOTXY_BELT_FIRST].X + PANEL_X, InvRect[i + SLOTXY_BELT_FIRST].Y + PANEL_Y - 1, INV_SLOT_SIZE_PX, INV_SLOT_SIZE_PX);
 		frame = plr[myplr].SpdList[i]._iCurs + CURSOR_FIRSTITEM;
 		frame_width = InvItemWidth[frame];
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3994,18 +3994,14 @@ void PrintUString(CelOutputBuffer out, int x, int y, BOOL cjustflag, const char 
 	}
 }
 
-void DrawULine(int y)
+static void DrawULine(CelOutputBuffer out, int y)
 {
-	assert(gpBuffer);
+	assert(out.begin);
+	BYTE *src = out.at(SCREEN_X + 26 + RIGHT_PANEL - SPANEL_WIDTH, SCREEN_Y + 25);
+	BYTE *dst = out.at(26 + RIGHT_PANEL_X - SPANEL_WIDTH, SCREEN_Y + y * 12 + 38);
 
-	int i;
-	BYTE *src, *dst;
-
-	src = &gpBuffer[SCREENXY(26 + RIGHT_PANEL - SPANEL_WIDTH, 25)];
-	dst = &gpBuffer[BUFFER_WIDTH * (y * 12 + 38 + SCREEN_Y) + 26 + RIGHT_PANEL_X - SPANEL_WIDTH];
-
-	for (i = 0; i < 3; i++, src += BUFFER_WIDTH, dst += BUFFER_WIDTH)
-		memcpy(dst, src, 266); // BUGFIX: should be 267
+	for (int i = 0; i < 3; i++, src += out.line_width, dst += out.line_width)
+		memcpy(dst, src, 267); // BUGFIX: should be 267 (fixed)
 }
 
 void DrawUniqueInfo(CelOutputBuffer out)
@@ -4016,7 +4012,7 @@ void DrawUniqueInfo(CelOutputBuffer out)
 		uid = curruitem._iUid;
 		DrawUTextBack(GlobalBackBuffer());
 		PrintUString(out, 0 + RIGHT_PANEL - SPANEL_WIDTH, 2, TRUE, UniqueItemList[uid].UIName, 3);
-		DrawULine(5);
+		DrawULine(out, 5);
 		PrintItemPower(UniqueItemList[uid].UIPower1, &curruitem);
 		y = 6 - UniqueItemList[uid].UINumPL + 8;
 		PrintUString(out, 0 + RIGHT_PANEL - SPANEL_WIDTH, y, TRUE, tempstr, 0);

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -146,7 +146,7 @@ void PrintQTextChr(int sx, int sy, Uint8 *pCelBuff, int nCel)
 {
 	CelOutputBuffer buf = GlobalBackBuffer();
 	const int start_y = 49 + SCREEN_Y + UI_OFFSET_Y;
-	buf = buf.subregion(0, start_y, buf.line_width, 309 + SCREEN_Y + UI_OFFSET_Y);
+	buf = buf.subregionY(start_y, 309 + SCREEN_Y + UI_OFFSET_Y);
 	CelDrawTo(buf, sx, sy - start_y, pCelBuff, nCel, 22);
 }
 

--- a/Source/render.h
+++ b/Source/render.h
@@ -12,8 +12,21 @@ DEVILUTION_BEGIN_NAMESPACE
 extern "C" {
 #endif
 
-void RenderTile(BYTE *pBuff);
-void world_draw_black_tile(int sx, int sy);
+/**
+ * @brief Blit current world CEL to the given buffer
+ * @param out Target buffer
+ * @param x Target buffer coordinate
+ * @param y Target buffer coordinate
+ */
+void RenderTile(CelOutputBuffer out, int x, int y);
+
+/**
+ * @brief Render a black tile
+ * @param out Target buffer
+ * @param sx Target buffer coordinate
+ * @param sy Target buffer coordinate
+ */
+void world_draw_black_tile(CelOutputBuffer out, int sx, int sy);
 
 #ifdef __cplusplus
 }

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -193,7 +193,7 @@ static void scrollrt_draw_cursor_item(CelOutputBuffer out)
 	dst = sgSaveBack;
 	src = out.at(SCREEN_X + sgdwCursX, SCREEN_Y + sgdwCursY);
 
-	for (i = sgdwCursHgt; i != 0; i--, dst += sgdwCursWdt, src += BUFFER_WIDTH) {
+	for (i = sgdwCursHgt; i != 0; i--, dst += sgdwCursWdt, src += out.line_width) {
 		memcpy(dst, src, sgdwCursWdt);
 	}
 

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1214,7 +1214,7 @@ void DrawView(CelOutputBuffer out, int StartX, int StartY)
 	if (automapflag) {
 		DrawAutomap(out.subregionY(0, SCREEN_Y + gnViewportHeight));
 	}
-	DrawMonsterHealthBar();
+	DrawMonsterHealthBar(out);
 
 	if (stextflag && !qtextflag)
 		DrawSText(out);
@@ -1554,7 +1554,7 @@ void DrawAndBlit()
 		DrawTalkPan(out);
 		hgt = gnScreenHeight;
 	}
-	DrawXPBar();
+	DrawXPBar(out);
 	scrollrt_draw_cursor_item(out);
 
 	DrawFPS(out);

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1218,7 +1218,7 @@ void DrawView(CelOutputBuffer out, int StartX, int StartY)
 {
 	DrawGame(out, StartX, StartY);
 	if (automapflag) {
-		DrawAutomap(out.subregion(0, 0, out.line_width, SCREEN_Y + gnViewportHeight));
+		DrawAutomap(out.subregionY(0, SCREEN_Y + gnViewportHeight));
 	}
 	DrawMonsterHealthBar();
 

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -107,28 +107,21 @@ void ClearCursor() // CODE_FIX: this was supposed to be in cursor.cpp
 }
 
 /**
- * @brief Remove the cursor from the back buffer
+ * @brief Remove the cursor from the buffer
  */
-static void scrollrt_draw_cursor_back_buffer()
+static void scrollrt_draw_cursor_back_buffer(CelOutputBuffer out)
 {
-	int i;
-	BYTE *src, *dst;
-
 	if (sgdwCursWdt == 0) {
 		return;
 	}
 
-	assert(gpBuffer);
-	src = sgSaveBack;
-	dst = &gpBuffer[SCREENXY(sgdwCursX, sgdwCursY)];
-	i = sgdwCursHgt;
-
-	if (sgdwCursHgt != 0) {
-		while (i--) {
-			memcpy(dst, src, sgdwCursWdt);
-			src += sgdwCursWdt;
-			dst += BUFFER_WIDTH;
-		}
+	assert(out.begin);
+	BYTE *src = sgSaveBack;
+	BYTE *dst = out.at(SCREEN_X + sgdwCursX, SCREEN_Y + sgdwCursY);
+	for (int i = sgdwCursHgt; i-- > 0; ) {
+		memcpy(dst, src, sgdwCursWdt);
+		src += sgdwCursWdt;
+		dst += out.line_width;
 	}
 
 	sgdwCursXOld = sgdwCursX;
@@ -1496,7 +1489,7 @@ void scrollrt_draw_game_screen(BOOL draw_cursor)
 
 	if (draw_cursor) {
 		lock_buf(0);
-		scrollrt_draw_cursor_back_buffer();
+		scrollrt_draw_cursor_back_buffer(GlobalBackBuffer());
 		unlock_buf(0);
 	}
 	RenderPresent();
@@ -1564,7 +1557,7 @@ void DrawAndBlit()
 	DrawMain(hgt, ddsdesc, drawhpflag, drawmanaflag, drawsbarflag, drawbtnflag);
 
 	lock_buf(0);
-	scrollrt_draw_cursor_back_buffer();
+	scrollrt_draw_cursor_back_buffer(GlobalBackBuffer());
 	unlock_buf(0);
 	RenderPresent();
 

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1264,8 +1264,8 @@ void DrawView(CelOutputBuffer out, int StartX, int StartY)
 	gmenu_draw(out);
 	doom_draw(out);
 	DrawInfoBox(out);
-	DrawLifeFlask();
-	DrawManaFlask();
+	DrawLifeFlask(out);
+	DrawManaFlask(out);
 }
 
 extern SDL_Surface *pal_surface;

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1254,7 +1254,7 @@ void DrawView(CelOutputBuffer out, int StartX, int StartY)
 		DrawDiabloMsg(out);
 	}
 	if (deathflag) {
-		RedBack();
+		RedBack(out);
 	} else if (PauseMode != 0) {
 		gmenu_draw_pause(out);
 	}

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2331,33 +2331,23 @@ void PrintSString(CelOutputBuffer out, int x, int y, bool cjustflag, const char 
 	}
 }
 
-void DrawSLine(int y)
+void DrawSLine(CelOutputBuffer out, int y)
 {
-	int xy, yy, width, line, sy;
-
-	sy = y * 12;
+	const int sy = y * 12;
+	BYTE *src, *dst;
+	int width;
 	if (stextsize) {
-		xy = SCREENXY(PANEL_LEFT + 26, 25 + UI_OFFSET_Y);
-		yy = BUFFER_WIDTH * (sy + 38 + SCREEN_Y + UI_OFFSET_Y) + 26 + PANEL_X;
-		width = 586 / 4;           // BUGFIX: should be 587, not 586
-		line = BUFFER_WIDTH - 586; // BUGFIX: should be 587, not 586
+		src = out.at(SCREEN_X + PANEL_LEFT + 26, SCREEN_Y + 25 + UI_OFFSET_Y);
+		dst = out.at(26 + PANEL_X, SCREEN_Y + sy + 38 + UI_OFFSET_Y);
+		width = 587; // BUGFIX: should be 587, not 586 (fixed)
 	} else {
-		xy = SCREENXY(PANEL_LEFT + 346, 25 + UI_OFFSET_Y);
-		yy = BUFFER_WIDTH * (sy + 38 + SCREEN_Y + UI_OFFSET_Y) + 346 + PANEL_X;
-		width = 266 / 4;           // BUGFIX: should be 267, not 266
-		line = BUFFER_WIDTH - 266; // BUGFIX: should be 267, not 266
+		src = out.at(SCREEN_X + PANEL_LEFT + 346, SCREEN_Y + 25 + UI_OFFSET_Y);
+		dst = out.at(346 + PANEL_X, SCREEN_Y + sy + 38 + UI_OFFSET_Y);
+		width = 267; // BUGFIX: should be 267, not 266 (fixed)
 	}
 
-	/// ASSERT: assert(gpBuffer);
-
-	int i;
-	BYTE *src, *dst;
-
-	src = &gpBuffer[xy];
-	dst = &gpBuffer[yy];
-
-	for (i = 0; i < 3; i++, src += BUFFER_WIDTH, dst += BUFFER_WIDTH)
-		memcpy(dst, src, BUFFER_WIDTH - line);
+	for (int i = 0; i < 3; i++, src += out.line_width, dst += out.line_width)
+		memcpy(dst, src, width);
 }
 
 void DrawSTextHelp()
@@ -2515,7 +2505,7 @@ void DrawSText(CelOutputBuffer out)
 
 	for (i = 0; i < STORE_LINES; i++) {
 		if (stext[i]._sline)
-			DrawSLine(i);
+			DrawSLine(out, i);
 		if (stext[i]._sstr[0])
 			PrintSString(out, stext[i]._sx, i, stext[i]._sjust, stext[i]._sstr, stext[i]._sclr, stext[i]._sval);
 	}

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -98,7 +98,7 @@ int PentSpn2Spin();
 void SetupTownStores();
 void FreeStoreMem();
 void PrintSString(CelOutputBuffer out, int x, int y, bool cjustflag, const char *str, char col, int val);
-void DrawSLine(int y);
+void DrawSLine(CelOutputBuffer out, int y);
 void DrawSTextHelp();
 void ClearSText(int s, int e);
 void StartStore(talk_id s);

--- a/SourceX/qol.h
+++ b/SourceX/qol.h
@@ -6,10 +6,12 @@
 #ifndef __QOL_H__
 #define __QOL_H__
 
+#include "engine.h"
+
 DEVILUTION_BEGIN_NAMESPACE
 
-void DrawMonsterHealthBar();
-void DrawXPBar();
+void DrawMonsterHealthBar(CelOutputBuffer out);
+void DrawXPBar(CelOutputBuffer out);
 void AutoGoldPickup(int pnum);
 
 DEVILUTION_END_NAMESPACE

--- a/defs.h
+++ b/defs.h
@@ -156,8 +156,6 @@
 #define DIALOG_TOP		((gnScreenHeight - PANEL_HEIGHT) / 2 - 18)
 #define DIALOG_Y		(SCREEN_Y + DIALOG_TOP)
 
-#define SCREENXY(x, y) ((x) + SCREEN_X + ((y) + SCREEN_Y) * BUFFER_WIDTH)
-
 #define NIGHTMARE_TO_HIT_BONUS  85
 #define HELL_TO_HIT_BONUS      120
 


### PR DESCRIPTION
After this PR, only a few instances of `gpBuf*` remain :rocket: 

```
$ rg gpBuf              
Source/scrollrt.h
20:extern BYTE *gpBufEnd;

SourceX/dx.cpp
18:BYTE *gpBuffer;
35:/** 8-bit surface wrapper around #gpBuffer */
45:	gpBuffer = (BYTE *)pal_surface->pixels;
46:	gpBufEnd = gpBuffer;
95:	gpBuffer = (BYTE *)pal_surface->pixels;
96:	gpBufEnd = (BYTE *)pal_surface->pixels + pal_surface->pitch * pal_surface->h;
112:	if (gpBuffer == NULL)
117:		gpBufEnd = gpBuffer;
138:	gpBuffer = NULL;

Source/scrollrt.cpp
20:BYTE *gpBufEnd;

Source/dx.h
15:extern BYTE *gpBuffer;

Source/engine.h
87:	extern BYTE *gpBuffer;
88:	extern BYTE *gpBufEnd;
89:	return CelOutputBuffer { gpBuffer, gpBufEnd, BUFFER_WIDTH };
```

Next step after this PR is to change `CelOutputBuffer` to store an `SDL_Surface *`. Then we can migrate functions piecemeal.