### PR TITLE
Completely replace gpBuffer with CelOutputBuffer

### DIFF
--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -116,10 +116,10 @@ static bool CapturePix(CelOutputBuffer buf, WORD width, WORD height, std::ofstre
 	BYTE *pBuffer, *pBufferEnd;
 
 	pBuffer = (BYTE *)DiabloAllocPtr(2 * width);
-	BYTE *pixels = buf.begin;
+	BYTE *pixels = buf.begin();
 	while (height--) {
 		pBufferEnd = CaptureEnc(pixels, pBuffer, width);
-		pixels += buf.line_width;
+		pixels += buf.pitch();
 		writeSize = pBufferEnd - pBuffer;
 		out->write(reinterpret_cast<const char *>(pBuffer), writeSize);
 		if (out->fail())

--- a/Source/dx.h
+++ b/Source/dx.h
@@ -12,7 +12,7 @@ DEVILUTION_BEGIN_NAMESPACE
 extern "C" {
 #endif
 
-extern BYTE *gpBuffer;
+CelOutputBuffer GlobalBackBuffer();
 
 void dx_init();
 void lock_buf(BYTE idx);

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -37,8 +37,6 @@ void CelDrawTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, in
 	BYTE *pRLEBytes;
 
 	assert(pCelBuff != NULL);
-	assert(out.begin != NULL);
-
 	pRLEBytes = CelGetFrame(pCelBuff, nCel, &nDataSize);
 	CelBlitSafeTo(out, sx, sy, pRLEBytes, nDataSize, nWidth);
 }
@@ -48,7 +46,6 @@ void CelClippedDrawTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int n
 	BYTE *pRLEBytes;
 	int nDataSize;
 
-	assert(out.begin != NULL);
 	assert(pCelBuff != NULL);
 
 	pRLEBytes = CelGetFrameClipped(pCelBuff, nCel, &nDataSize);
@@ -61,7 +58,6 @@ void CelDrawLightTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCe
 	int nDataSize;
 	BYTE *pRLEBytes;
 
-	assert(out.begin != NULL);
 	assert(pCelBuff != NULL);
 
 	pRLEBytes = CelGetFrame(pCelBuff, nCel, &nDataSize);
@@ -77,7 +73,6 @@ void CelClippedDrawLightTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, 
 	int nDataSize;
 	BYTE *pRLEBytes;
 
-	assert(out.begin != NULL);
 	assert(pCelBuff != NULL);
 
 	pRLEBytes = CelGetFrameClipped(pCelBuff, nCel, &nDataSize);
@@ -93,7 +88,6 @@ void CelDrawLightRedTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int 
 	int nDataSize, w, idx;
 	BYTE *pRLEBytes, *dst, *tbl;
 
-	assert(out.begin != NULL);
 	assert(pCelBuff != NULL);
 
 	pRLEBytes = CelGetFrameClipped(pCelBuff, nCel, &nDataSize);
@@ -111,7 +105,7 @@ void CelDrawLightRedTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int 
 	tbl = &pLightTbl[idx];
 	end = &pRLEBytes[nDataSize];
 
-	for (; pRLEBytes != end; dst -= out.line_width + nWidth) {
+	for (; pRLEBytes != end; dst -= out.pitch() + nWidth) {
 		for (w = nWidth; w;) {
 			width = *pRLEBytes++;
 			if (!(width & 0x80)) {
@@ -137,19 +131,18 @@ void CelBlitSafeTo(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBytes, int nDa
 	BYTE width;
 	BYTE *src, *dst;
 
-	assert(out.begin != NULL);
 	assert(pRLEBytes != NULL);
 
 	src = pRLEBytes;
 	dst = out.at(sx, sy);
 	w = nWidth;
 
-	for (; src != &pRLEBytes[nDataSize]; dst -= out.line_width + w) {
+	for (; src != &pRLEBytes[nDataSize]; dst -= out.pitch() + w) {
 		for (i = w; i;) {
 			width = *src++;
 			if (!(width & 0x80)) {
 				i -= width;
-				if (dst < out.end && dst > out.begin) {
+				if (dst < out.end() && dst > out.begin()) {
 					memcpy(dst, src, width);
 				}
 				src += width;
@@ -168,7 +161,6 @@ void CelClippedDrawSafeTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, i
 	BYTE *pRLEBytes;
 	int nDataSize;
 
-	assert(out.begin != NULL);
 	assert(pCelBuff != NULL);
 
 	pRLEBytes = CelGetFrameClipped(pCelBuff, nCel, &nDataSize);
@@ -181,7 +173,6 @@ void CelBlitLightSafeTo(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBytes, in
 	BYTE width;
 	BYTE *src, *dst;
 
-	assert(out.begin != NULL);
 	assert(pRLEBytes != NULL);
 
 	src = pRLEBytes;
@@ -190,12 +181,12 @@ void CelBlitLightSafeTo(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBytes, in
 		tbl = &pLightTbl[light_table_index * 256];
 	w = nWidth;
 
-	for (; src != &pRLEBytes[nDataSize]; dst -= out.line_width + w) {
+	for (; src != &pRLEBytes[nDataSize]; dst -= out.pitch() + w) {
 		for (i = w; i;) {
 			width = *src++;
 			if (!(width & 0x80)) {
 				i -= width;
-				if (dst < out.end && dst > out.begin) {
+				if (dst < out.end() && dst > out.begin()) {
 					if (width & 1) {
 						dst[0] = tbl[src[0]];
 						src++;
@@ -237,8 +228,6 @@ void CelBlitLightTransSafeTo(CelOutputBuffer out, int sx, int sy, BYTE *pRLEByte
 	BYTE *tbl;
 
 	assert(pRLEBytes != NULL);
-	assert(out.begin != NULL);
-
 	int i;
 	BYTE width;
 	BYTE *src, *dst;
@@ -249,12 +238,12 @@ void CelBlitLightTransSafeTo(CelOutputBuffer out, int sx, int sy, BYTE *pRLEByte
 	w = nWidth;
 	shift = (BYTE)(size_t)dst & 1;
 
-	for (; src != &pRLEBytes[nDataSize]; dst -= out.line_width + w, shift = (shift + 1) & 1) {
+	for (; src != &pRLEBytes[nDataSize]; dst -= out.pitch() + w, shift = (shift + 1) & 1) {
 		for (i = w; i;) {
 			width = *src++;
 			if (!(width & 0x80)) {
 				i -= width;
-				if (dst < out.end && dst > out.begin) {
+				if (dst < out.end() && dst > out.begin()) {
 					if (((BYTE)(size_t)dst & 1) == shift) {
 						if (!(width & 1)) {
 							goto L_ODD;
@@ -326,7 +315,6 @@ static void CelBlitLightBlendedSafeTo(CelOutputBuffer out, int sx, int sy, BYTE 
 	BYTE width;
 	BYTE *src, *dst;
 
-	assert(out.begin != NULL);
 	assert(pRLEBytes != NULL);
 
 	src = pRLEBytes;
@@ -335,12 +323,12 @@ static void CelBlitLightBlendedSafeTo(CelOutputBuffer out, int sx, int sy, BYTE 
 		tbl = &pLightTbl[light_table_index * 256];
 	w = nWidth;
 
-	for (; src != &pRLEBytes[nDataSize]; dst -= out.line_width + w) {
+	for (; src != &pRLEBytes[nDataSize]; dst -= out.pitch() + w) {
 		for (i = w; i;) {
 			width = *src++;
 			if (!(width & 0x80)) {
 				i -= width;
-				if (dst < out.end && dst > out.begin) {
+				if (dst < out.end() && dst > out.begin()) {
 					if (width & 1) {
 						dst[0] = paletteTransparencyLookup[dst[0]][tbl[src[0]]];
 						src++;
@@ -400,7 +388,6 @@ void CelDrawLightRedSafeTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, 
 	int nDataSize, w, idx;
 	BYTE *pRLEBytes, *dst, *tbl;
 
-	assert(out.begin != NULL);
 	assert(pCelBuff != NULL);
 
 	pRLEBytes = CelGetFrameClipped(pCelBuff, nCel, &nDataSize);
@@ -419,12 +406,12 @@ void CelDrawLightRedSafeTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, 
 
 	end = &pRLEBytes[nDataSize];
 
-	for (; pRLEBytes != end; dst -= out.line_width + nWidth) {
+	for (; pRLEBytes != end; dst -= out.pitch() + nWidth) {
 		for (w = nWidth; w;) {
 			width = *pRLEBytes++;
 			if (!(width & 0x80)) {
 				w -= width;
-				if (dst < out.end && dst > out.begin) {
+				if (dst < out.end() && dst > out.begin()) {
 					while (width) {
 						*dst = tbl[*pRLEBytes];
 						pRLEBytes++;
@@ -449,8 +436,6 @@ void CelDrawUnsafeTo(CelOutputBuffer out, int x, int y, BYTE *pCelBuff, int nCel
 	BYTE *pRLEBytes, *dst, *end;
 
 	assert(pCelBuff != NULL);
-	assert(out.begin != NULL);
-
 	int i, nDataSize;
 	BYTE width;
 
@@ -458,7 +443,7 @@ void CelDrawUnsafeTo(CelOutputBuffer out, int x, int y, BYTE *pCelBuff, int nCel
 	end = &pRLEBytes[nDataSize];
 	dst = out.at(x, y);
 
-	for (; pRLEBytes != end; dst -= out.line_width + nWidth) {
+	for (; pRLEBytes != end; dst -= out.pitch() + nWidth) {
 		for (i = nWidth; i;) {
 			width = *pRLEBytes++;
 			if (!(width & 0x80)) {
@@ -482,22 +467,20 @@ void CelBlitOutlineTo(CelOutputBuffer out, BYTE col, int sx, int sy, BYTE *pCelB
 	BYTE width;
 
 	assert(pCelBuff != NULL);
-	assert(out.begin != NULL);
-
 	src = CelGetFrameClipped(pCelBuff, nCel, &nDataSize);
 	end = &src[nDataSize];
 	dst = out.at(sx, sy);
 
-	for (; src != end; dst -= out.line_width + nWidth) {
+	for (; src != end; dst -= out.pitch() + nWidth) {
 		for (w = nWidth; w;) {
 			width = *src++;
 			if (!(width & 0x80)) {
 				w -= width;
-				if (dst < out.end && dst > out.begin) {
-					if (dst >= out.end - out.line_width) {
+				if (dst < out.end() && dst > out.begin()) {
+					if (dst >= out.end() - out.pitch()) {
 						while (width) {
 							if (*src++) {
-								dst[-out.line_width] = col;
+								dst[-out.pitch()] = col;
 								dst[-1] = col;
 								dst[1] = col;
 							}
@@ -507,10 +490,10 @@ void CelBlitOutlineTo(CelOutputBuffer out, BYTE col, int sx, int sy, BYTE *pCelB
 					} else {
 						while (width) {
 							if (*src++) {
-								dst[-out.line_width] = col;
+								dst[-out.pitch()] = col;
 								dst[-1] = col;
 								dst[1] = col;
-								dst[out.line_width] = col;
+								dst[out.pitch()] = col;
 							}
 							dst++;
 							width--;
@@ -531,7 +514,6 @@ void CelBlitOutlineTo(CelOutputBuffer out, BYTE col, int sx, int sy, BYTE *pCelB
 
 void SetPixel(CelOutputBuffer out, int sx, int sy, BYTE col)
 {
-	assert(out.begin != NULL);
 	if (!out.in_bounds(sx, sy))
 		return;
 	*out.at(sx, sy) = col;
@@ -563,7 +545,7 @@ static void DrawHalfTransparentBlendedRectTo(CelOutputBuffer out, int sx, int sy
 			*pix = paletteTransparencyLookup[0][*pix];
 			pix++;
 		}
-		pix += out.line_width - width;
+		pix += out.pitch() - width;
 	}
 }
 
@@ -576,7 +558,7 @@ static void DrawHalfTransparentStippledRectTo(CelOutputBuffer out, int sx, int s
 				*pix = 0;
 			pix++;
 		}
-		pix += out.line_width - width;
+		pix += out.pitch() - width;
 	}
 }
 
@@ -837,7 +819,7 @@ static void Cl2BlitSafe(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBytes, in
 				width -= 65;
 				nDataSize--;
 				fill = *src++;
-				if (dst < out.end && dst > out.begin) {
+				if (dst < out.end() && dst > out.begin()) {
 					w -= width;
 					while (width) {
 						*dst = fill;
@@ -846,13 +828,13 @@ static void Cl2BlitSafe(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBytes, in
 					}
 					if (!w) {
 						w = nWidth;
-						dst -= out.line_width + w;
+						dst -= out.pitch() + w;
 					}
 					continue;
 				}
 			} else {
 				nDataSize -= width;
-				if (dst < out.end && dst > out.begin) {
+				if (dst < out.end() && dst > out.begin()) {
 					w -= width;
 					while (width) {
 						*dst = *src;
@@ -862,7 +844,7 @@ static void Cl2BlitSafe(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBytes, in
 					}
 					if (!w) {
 						w = nWidth;
-						dst -= out.line_width + w;
+						dst -= out.pitch() + w;
 					}
 					continue;
 				} else {
@@ -882,7 +864,7 @@ static void Cl2BlitSafe(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBytes, in
 			}
 			if (!w) {
 				w = nWidth;
-				dst -= out.line_width + w;
+				dst -= out.pitch() + w;
 			}
 		}
 	}
@@ -916,40 +898,40 @@ static void Cl2BlitOutlineSafe(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBy
 			if (width > 65) {
 				width -= 65;
 				nDataSize--;
-				if (*src++ && dst < out.end && dst > out.begin) {
+				if (*src++ && dst < out.end() && dst > out.begin()) {
 					w -= width;
 					dst[-1] = col;
 					dst[width] = col;
 					while (width) {
-						dst[-out.line_width] = col;
-						dst[out.line_width] = col;
+						dst[-out.pitch()] = col;
+						dst[out.pitch()] = col;
 						dst++;
 						width--;
 					}
 					if (!w) {
 						w = nWidth;
-						dst -= out.line_width + w;
+						dst -= out.pitch() + w;
 					}
 					continue;
 				}
 			} else {
 				nDataSize -= width;
-				if (dst < out.end && dst > out.begin) {
+				if (dst < out.end() && dst > out.begin()) {
 					w -= width;
 					while (width) {
 						if (*src++) {
 							dst[-1] = col;
 							dst[1] = col;
-							dst[-out.line_width] = col;
-							// BUGFIX: only set `if (dst+out.line_width < out.end)`
-							dst[out.line_width] = col;
+							dst[-out.pitch()] = col;
+							// BUGFIX: only set `if (dst+out.pitch() < out.end())`
+							dst[out.pitch()] = col;
 						}
 						dst++;
 						width--;
 					}
 					if (!w) {
 						w = nWidth;
-						dst -= out.line_width + w;
+						dst -= out.pitch() + w;
 					}
 					continue;
 				} else {
@@ -969,7 +951,7 @@ static void Cl2BlitOutlineSafe(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBy
 			}
 			if (!w) {
 				w = nWidth;
-				dst -= out.line_width + w;
+				dst -= out.pitch() + w;
 			}
 		}
 	}
@@ -1006,7 +988,7 @@ static void Cl2BlitLightSafe(CelOutputBuffer out, int sx, int sy, BYTE *pRLEByte
 				width -= 65;
 				nDataSize--;
 				fill = pTable[*src++];
-				if (dst < out.end && dst > out.begin) {
+				if (dst < out.end() && dst > out.begin()) {
 					w -= width;
 					while (width) {
 						*dst = fill;
@@ -1015,13 +997,13 @@ static void Cl2BlitLightSafe(CelOutputBuffer out, int sx, int sy, BYTE *pRLEByte
 					}
 					if (w == 0) {
 						w = spriteWidth;
-						dst -= out.line_width + w;
+						dst -= out.pitch() + w;
 					}
 					continue;
 				}
 			} else {
 				nDataSize -= width;
-				if (dst < out.end && dst > out.begin) {
+				if (dst < out.end() && dst > out.begin()) {
 					w -= width;
 					while (width) {
 						*dst = pTable[*src];
@@ -1031,7 +1013,7 @@ static void Cl2BlitLightSafe(CelOutputBuffer out, int sx, int sy, BYTE *pRLEByte
 					}
 					if (w == 0) {
 						w = spriteWidth;
-						dst -= out.line_width + w;
+						dst -= out.pitch() + w;
 					}
 					continue;
 				} else {
@@ -1051,7 +1033,7 @@ static void Cl2BlitLightSafe(CelOutputBuffer out, int sx, int sy, BYTE *pRLEByte
 			}
 			if (w == 0) {
 				w = spriteWidth;
-				dst -= out.line_width + w;
+				dst -= out.pitch() + w;
 			}
 		}
 	}
@@ -1062,7 +1044,6 @@ void Cl2Draw(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, int 
 	BYTE *pRLEBytes;
 	int nDataSize;
 
-	assert(out.begin != NULL);
 	assert(pCelBuff != NULL);
 	assert(nCel > 0);
 
@@ -1076,13 +1057,12 @@ void Cl2DrawOutline(CelOutputBuffer out, BYTE col, int sx, int sy, BYTE *pCelBuf
 	int nDataSize;
 	BYTE *pRLEBytes;
 
-	assert(out.begin != NULL);
 	assert(pCelBuff != NULL);
 	assert(nCel > 0);
 
 	pRLEBytes = CelGetFrameClipped(pCelBuff, nCel, &nDataSize);
 
-	out.end -= out.line_width;
+	out = out.subregionY(0, out.h() - 1);
 	Cl2BlitOutlineSafe(out, sx, sy, pRLEBytes, nDataSize, nWidth, col);
 }
 
@@ -1091,7 +1071,6 @@ void Cl2DrawLightTbl(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nC
 	int nDataSize, idx;
 	BYTE *pRLEBytes;
 
-	assert(out.begin != NULL);
 	assert(pCelBuff != NULL);
 	assert(nCel > 0);
 
@@ -1111,7 +1090,6 @@ void Cl2DrawLight(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel,
 	int nDataSize;
 	BYTE *pRLEBytes;
 
-	assert(out.begin != NULL);
 	assert(pCelBuff != NULL);
 	assert(nCel > 0);
 

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -124,8 +124,6 @@ void DrawDiabloMsg(CelOutputBuffer out)
 		sy += 12;
 	}
 
-	assert(out.begin);
-
 	DrawHalfTransparentRectTo(out, PANEL_X + 104, DIALOG_Y - 8, 432, 54);
 
 	strcpy(tempstr, MsgStrings[msgflag]);

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -161,7 +161,7 @@ static void gmenu_clear_buffer(CelOutputBuffer out, int x, int y, int width, int
 	BYTE *i = out.at(x, y);
 	while (height--) {
 		memset(i, 205, width);
-		i -= out.line_width;
+		i -= out.pitch();
 	}
 }
 

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -233,7 +233,7 @@ static void InitCutscene(unsigned int uMsg)
 static void DrawProgress(CelOutputBuffer out, int x, int y, int progress_id)
 {
 	BYTE *dst = out.at(x, y);
-	for (int i = 0; i < 22; ++i, dst += out.line_width) {
+	for (int i = 0; i < 22; ++i, dst += out.pitch()) {
 		*dst = BarColor[progress_id];
 	}
 }

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -143,14 +143,12 @@ static void InvDrawSlotBack(CelOutputBuffer out, int X, int Y, int W, int H)
 {
 	BYTE *dst;
 
-	assert(out.begin);
-
 	dst = out.at(X, Y);
 
 	int wdt, hgt;
 	BYTE pix;
 
-	for (hgt = H; hgt; hgt--, dst -= out.line_width + W) {
+	for (hgt = H; hgt; hgt--, dst -= out.pitch() + W) {
 		for (wdt = W; wdt; wdt--) {
 			pix = *dst;
 			if (pix >= PAL16_BLUE) {

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3996,11 +3996,10 @@ void PrintUString(CelOutputBuffer out, int x, int y, BOOL cjustflag, const char 
 
 static void DrawULine(CelOutputBuffer out, int y)
 {
-	assert(out.begin);
 	BYTE *src = out.at(SCREEN_X + 26 + RIGHT_PANEL - SPANEL_WIDTH, SCREEN_Y + 25);
 	BYTE *dst = out.at(26 + RIGHT_PANEL_X - SPANEL_WIDTH, SCREEN_Y + y * 12 + 38);
 
-	for (int i = 0; i < 3; i++, src += out.line_width, dst += out.line_width)
+	for (int i = 0; i < 3; i++, src += out.pitch(), dst += out.pitch())
 		memcpy(dst, src, 267); // BUGFIX: should be 267 (fixed)
 }
 

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -146,7 +146,7 @@ void PrintQTextChr(int sx, int sy, Uint8 *pCelBuff, int nCel)
 {
 	CelOutputBuffer buf = GlobalBackBuffer();
 	const int start_y = 49 + SCREEN_Y + UI_OFFSET_Y;
-	buf = buf.subregionY(start_y, 309 + SCREEN_Y + UI_OFFSET_Y);
+	buf = buf.subregionY(start_y, 260);
 	CelDrawTo(buf, sx, sy - start_y, pCelBuff, nCel, 22);
 }
 

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -376,7 +376,7 @@ inline static void RenderLine(CelOutputBuffer out, int &x, int y, BYTE **src, in
 {
 	BYTE *dst = out.at(x, y);
 #ifdef NO_OVERDRAW
-	if (y < SCREEN_Y || dst > out.end) {
+	if (y < SCREEN_Y || dst > out.end()) {
 		goto skip;
 	}
 #endif
@@ -579,13 +579,13 @@ void world_draw_black_tile(CelOutputBuffer out, int sx, int sy)
 		return;
 
 	BYTE *dst = out.at(sx + TILE_WIDTH / 2 - 2, sy);
-	for (i = TILE_HEIGHT - 2, j = 1; i >= 0; i -= 2, j++, dst -= out.line_width + 2) {
-		if (dst < out.end)
+	for (i = TILE_HEIGHT - 2, j = 1; i >= 0; i -= 2, j++, dst -= out.pitch() + 2) {
+		if (dst < out.end())
 			memset(dst, 0, 4 * j);
 	}
 	dst += 4;
-	for (i = 2, j = TILE_HEIGHT / 2 - 1; i != TILE_HEIGHT; i += 2, j--, dst -= out.line_width - 2) {
-		if (dst < out.end)
+	for (i = 2, j = TILE_HEIGHT / 2 - 1; i != TILE_HEIGHT; i += 2, j--, dst -= out.pitch() - 2) {
+		if (dst < out.end())
 			memset(dst, 0, 4 * j);
 	}
 }

--- a/Source/scrollrt.h
+++ b/Source/scrollrt.h
@@ -17,7 +17,6 @@ extern bool sgbControllerActive;
 extern bool IsMovingMouseCursorWithController();
 
 extern int light_table_index;
-extern BYTE *gpBufEnd;
 extern DWORD level_cel_block;
 extern char arch_draw_type;
 extern int cel_transparency_active;

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2346,7 +2346,7 @@ void DrawSLine(CelOutputBuffer out, int y)
 		width = 267; // BUGFIX: should be 267, not 266 (fixed)
 	}
 
-	for (int i = 0; i < 3; i++, src += out.line_width, dst += out.line_width)
+	for (int i = 0; i < 3; i++, src += out.pitch(), dst += out.pitch())
 		memcpy(dst, src, width);
 }
 

--- a/SourceX/qol.cpp
+++ b/SourceX/qol.cpp
@@ -28,7 +28,7 @@ void FastDrawVertLine(CelOutputBuffer out, int x, int y, int height, BYTE col)
 	BYTE *p = out.at(SCREEN_X + x, SCREEN_Y + y);
 	for (int j = 0; j < height; j++) {
 		*p = col;
-		p += out.line_width;
+		p += out.pitch();
 	}
 }
 

--- a/defs.h
+++ b/defs.h
@@ -200,3 +200,15 @@
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
 #endif
+
+#ifdef __has_attribute
+#define DVL_HAVE_ATTRIBUTE(x) __has_attribute(x)
+#else
+#define DVL_HAVE_ATTRIBUTE(x) 0
+#endif
+
+#if DVL_HAVE_ATTRIBUTE(always_inline) ||  (defined(__GNUC__) && !defined(__clang__))
+#define DVL_ATTRIBUTE_ALWAYS_INLINE __attribute__((always_inline))
+#else
+#define DVL_ATTRIBUTE_ALWAYS_INLINE
+#endif


### PR DESCRIPTION
`CelOutputBuffer` now contains an `SDL_Surface` and an `SDL_Rect`.

We now have access to SDL surface manipulation functions.

`gpBuffer` and `gpBufEnd` are completely gone 🧹