### PR TITLE
Can build hellfire on OpenDingux by using `./build.sh rg350-hellfire`

### DIFF
--- a/Packaging/OpenDingux/build.sh
+++ b/Packaging/OpenDingux/build.sh
@@ -17,7 +17,14 @@ if ! check_target "$@"; then
   exit 64
 fi
 
-declare -r TARGET="$1"
+declare -r TARGET=$(echo "$1" | cut -d "-" -f 1)
+
+if [[ $(echo "$1" | cut -d "-" -f 2) == hellfire ]]; then
+	declare -r HELLFIRE=ON
+else
+	declare -r HELLFIRE=OFF
+fi
+
 declare -r BUILD_DIR="build-${TARGET}"
 declare -rA BUILDROOT_REPOS=(
 	[retrofw]=https://github.com/retrofw/buildroot.git
@@ -64,7 +71,7 @@ build() {
 	mkdir -p "$BUILD_DIR"
 	cd "$BUILD_DIR"
 	rm -f CMakeCache.txt
-	cmake .. -DBINARY_RELEASE=ON "-DTARGET_PLATFORM=$TARGET" \
+	cmake .. -DBINARY_RELEASE=ON "-DHELLFIRE=$HELLFIRE" "-DTARGET_PLATFORM=$TARGET" \
 		-DCMAKE_TOOLCHAIN_FILE="$BUILDROOT/output/host/usr/share/buildroot/toolchainfile.cmake"
 	make -j $(getconf _NPROCESSORS_ONLN)
 	cd -

--- a/Packaging/OpenDingux/package-opk.sh
+++ b/Packaging/OpenDingux/package-opk.sh
@@ -11,15 +11,22 @@ package_opk() {
 	set -x
 	rm -rf "$tmp"
 	mkdir -p "$tmp"
-	cp "Packaging/OpenDingux/${TARGET}.desktop" "${tmp}/default.${ext}.desktop"
-	cp "Packaging/OpenDingux/${TARGET}-hellfire.desktop" "${tmp}/hellfire.${ext}.desktop"
+
+	if [[ $HELLFIRE == ON ]]; then
+		cp "Packaging/OpenDingux/${TARGET}-hellfire.desktop" "${tmp}/default.${ext}.desktop"
+		SUFFIX="-hellfire"
+	else
+		cp "Packaging/OpenDingux/${TARGET}.desktop" "${tmp}/default.${ext}.desktop"
+		SUFFIX=""
+	fi
+
 	cp "Packaging/OpenDingux/${TARGET}-manual.txt" "${tmp}/readme.${ext}.txt"
 	mksquashfs "${BUILD_DIR}/devilutionx" \
-		"${tmp}/default.${ext}.desktop" "${tmp}/hellfire.${ext}.desktop" \
+		"${tmp}/default.${ext}.desktop" \
 		"${tmp}/readme.${ext}.txt" Packaging/resources/icon_32.png \
 		Packaging/resources/hellfire_32.png Packaging/resources/CharisSILB.ttf \
 		Packaging/resources/devilutionx.mpq \
-		"${BUILD_DIR}/devilutionx-${TARGET}.opk" \
+		"${BUILD_DIR}/devilutionx-${TARGET}${SUFFIX}.opk" \
 		-all-root -no-xattrs -noappend -no-exports -no-progress
 }
 

--- a/Packaging/OpenDingux/targets.sh
+++ b/Packaging/OpenDingux/targets.sh
@@ -1,7 +1,10 @@
 declare -ra VALID_TARGETS=(
   retrofw
+  retrofw-hellfire
   rg350
+  rg350-hellfire
   gkd350h
+  gkd350h-hellfire
 )
 
 usage_target() {


### PR DESCRIPTION
This is a really small PR to the OpenDingux build script. I just added `*-hellfire` platforms that set the `-DHELLFIRE` cmake property.

So you can build hellfire on the rg350 like this: `./build.sh rg350-hellfire`

I was going to try to make it a flag (`./build.sh rg350 --helfire`), but I wasn't sure the best way to do that with bash. I usually make all my scripts in python.

It outputs an OPK with `-hellfire` in the name.

Let me know if there's a better way to do this.

Thanks.

----

I built and tested this on an RG350M, and it worked perfectly as far as I can tell.