### PR TITLE
Respect sfx_STREAM in PlaySFX

### DIFF
--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -1093,7 +1093,7 @@ static void stream_play(TSFX *pSFX, int lVolume, int lPan)
 		if (lVolume > VOLUME_MAX)
 			lVolume = VOLUME_MAX;
 		if (pSFX->pSnd == NULL)
-			pSFX->pSnd = sound_file_load(pSFX->pszName);
+			pSFX->pSnd = sound_file_load(pSFX->pszName, /*stream=*/true);
 		pSFX->pSnd->DSB->Play(lVolume, lPan, 0);
 		sgpStreamSFX = pSFX;
 	}

--- a/Source/sound.h
+++ b/Source/sound.h
@@ -17,7 +17,7 @@ void snd_update(BOOL bStopAll);
 void snd_stop_snd(TSnd *pSnd);
 BOOL snd_playing(TSnd *pSnd);
 void snd_play_snd(TSnd *pSnd, int lVolume, int lPan);
-TSnd *sound_file_load(const char *path);
+TSnd *sound_file_load(const char *path, bool stream = false);
 void sound_file_cleanup(TSnd *sound_file);
 void snd_init();
 void sound_cleanup();

--- a/SourceS/miniwin/misc.h
+++ b/SourceS/miniwin/misc.h
@@ -66,6 +66,8 @@ bool PostMessage(UINT Msg, WPARAM wParam, LPARAM lParam);
 #define DVL_FILE_CURRENT 1
 #define DVL_FILE_END 2
 
+#define DVL_ERROR_HANDLE_EOF 1002
+
 #define DVL_WM_QUIT 0x0012
 
 //

--- a/SourceS/soundsample.h
+++ b/SourceS/soundsample.h
@@ -3,17 +3,18 @@
 
 namespace dvl {
 
-typedef struct SoundSample final {
+class SoundSample final {
 public:
 	void Release();
 	bool IsPlaying();
 	void Play(int lVolume, int lPan, int channel = -1);
 	void Stop();
+	int SetChunkStream(HANDLE stormHandle);
 	int SetChunk(BYTE *fileData, DWORD dwBytes);
 	int GetLength();
 
 private:
 	Mix_Chunk *chunk;
-} SoundSample;
+};
 
 } // namespace dvl

--- a/SourceX/soundsample.cpp
+++ b/SourceX/soundsample.cpp
@@ -2,6 +2,8 @@
 #include "stubs.h"
 #include <SDL.h>
 
+#include "storm_sdl_rw.h"
+
 namespace dvl {
 
 ///// SoundSample /////
@@ -9,6 +11,7 @@ namespace dvl {
 void SoundSample::Release()
 {
 	Mix_FreeChunk(chunk);
+	chunk = NULL;
 };
 
 /**
@@ -65,6 +68,16 @@ void SoundSample::Stop()
 		Mix_HaltChannel(i);
 	}
 };
+
+int SoundSample::SetChunkStream(HANDLE stormHandle)
+{
+	chunk = Mix_LoadWAV_RW(SFileRw_FromStormHandle(stormHandle), /*freesrc=*/1);
+	if (chunk == NULL) {
+		SDL_Log("Mix_LoadWAV_RW: %s", Mix_GetError());
+		return -1;
+	}
+	return 0;
+}
 
 /**
  * @brief This can load WAVE, AIFF, RIFF, OGG, and VOC formats

--- a/structs.h
+++ b/structs.h
@@ -23,6 +23,7 @@ typedef struct TextDataStruct {
 
 typedef struct TSnd {
 	const char *sound_path;
+	HANDLE file_handle; // for streamed audio
 	SoundSample *DSB;
 	int start_tc;
 } TSnd;


### PR DESCRIPTION
Changes audio playback of sounds with the `sfx_STREAM` flag, such as towner lines, to stream.