### PR TITLE
Thumb stick / DPad repeating navigation in DiabloUI, gmenu, and quest log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,7 @@ set(devilutionx_SRCS
   SourceX/controls/devices/game_controller.cpp
   SourceX/controls/devices/joystick.cpp
   SourceX/controls/devices/kbcontroller.cpp
+  SourceX/controls/axis_direction.cpp
   SourceX/controls/controller.cpp
   SourceX/controls/controller_motion.cpp
   SourceX/controls/game_controls.cpp

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -234,7 +234,7 @@ static void gmenu_draw_menu_item(CelOutputBuffer out, TMenuItem *pItem, int y)
 
 static void GameMenuMove()
 {
-	static AxisDirectionRepeater repeater(/*min_interval_ms=*/200);
+	static AxisDirectionRepeater repeater;
 	const AxisDirection move_dir = repeater.Get(GetLeftStickOrDpadDirection());
 	if (move_dir.x != AxisDirectionX_NONE)
 		gmenu_left_right(move_dir.x == AxisDirectionX_RIGHT);

--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -145,6 +145,8 @@ void UiPlaySelectSound()
 		gfnSoundFunction("sfx\\items\\titlslct.wav");
 }
 
+namespace {
+
 void UiFocus(std::size_t itemIndex)
 {
 	if (SelectedItem == itemIndex)
@@ -214,6 +216,39 @@ void selhero_CatToName(char *in_buf, char *out_buf, int cnt)
 	strncat(out_buf, output.c_str(), cnt - strlen(out_buf));
 }
 
+bool HandleMenuAction(MenuAction menu_action)
+{
+	switch (menu_action) {
+	case MenuAction_SELECT:
+		UiFocusNavigationSelect();
+		return true;
+	case MenuAction_UP:
+		UiFocusUp();
+		return true;
+	case MenuAction_DOWN:
+		UiFocusDown();
+		return true;
+	case MenuAction_PAGE_UP:
+		UiFocusPageUp();
+		return true;
+	case MenuAction_PAGE_DOWN:
+		UiFocusPageDown();
+		return true;
+	case MenuAction_DELETE:
+		UiFocusNavigationYesNo();
+		return true;
+	case MenuAction_BACK:
+		if (!gfnListEsc)
+			return false;
+		UiFocusNavigationEsc();
+		return true;
+	default:
+		return false;
+	}
+}
+
+} // namespace
+
 void UiFocusNavigation(SDL_Event *event)
 {
 	switch (event->type) {
@@ -239,33 +274,7 @@ void UiFocusNavigation(SDL_Event *event)
 		break;
 	}
 
-	switch (GetMenuAction(*event)) {
-	case MenuAction_SELECT:
-		UiFocusNavigationSelect();
-		return;
-	case MenuAction_UP:
-		UiFocusUp();
-		return;
-	case MenuAction_DOWN:
-		UiFocusDown();
-		return;
-	case MenuAction_PAGE_UP:
-		UiFocusPageUp();
-		return;
-	case MenuAction_PAGE_DOWN:
-		UiFocusPageDown();
-		return;
-	case MenuAction_DELETE:
-		UiFocusNavigationYesNo();
-		return;
-	case MenuAction_BACK:
-		if (!gfnListEsc)
-			break;
-		UiFocusNavigationEsc();
-		return;
-	default:
-		break;
-	}
+	if (HandleMenuAction(GetMenuAction(*event))) return;
 
 #ifndef USE_SDL1
 	if (event->type == SDL_MOUSEWHEEL) {
@@ -617,6 +626,7 @@ void UiPollAndRender()
 		UiFocusNavigation(&event);
 		UiHandleEvents(&event);
 	}
+	HandleMenuAction(GetMenuHeldUpDownAction());
 	UiRenderItems(gUiItems);
 	DrawMouse();
 	UiFadeIn();

--- a/SourceX/controls/axis_direction.cpp
+++ b/SourceX/controls/axis_direction.cpp
@@ -1,0 +1,55 @@
+#include "axis_direction.h"
+
+#include <SDL.h>
+
+namespace dvl {
+
+AxisDirection AxisDirectionRepeater::Get(AxisDirection axis_direction)
+{
+	const int now = SDL_GetTicks();
+	switch (axis_direction.x) {
+		case AxisDirectionX_LEFT:
+			last_right_ = 0;
+			if (now - last_left_ < min_interval_ms_) {
+				axis_direction.x = AxisDirectionX_NONE;
+			} else {
+				last_left_ = now;
+			}
+			break;
+		case AxisDirectionX_RIGHT:
+			last_left_ = 0;
+			if (now - last_right_ < min_interval_ms_) {
+				axis_direction.x = AxisDirectionX_NONE;
+			} else {
+				last_right_ = now;
+			}
+			break;
+		case AxisDirectionX_NONE:
+			last_left_ = last_right_ = 0;
+			break;
+	}
+	switch (axis_direction.y) {
+		case AxisDirectionY_UP:
+			last_down_ = 0;
+			if (now - last_up_ < min_interval_ms_) {
+				axis_direction.y = AxisDirectionY_NONE;
+			} else {
+				last_up_ = now;
+			}
+			break;
+		case AxisDirectionY_DOWN:
+			last_up_ = 0;
+			if (now - last_down_ < min_interval_ms_) {
+				axis_direction.y = AxisDirectionY_NONE;
+			} else {
+				last_down_ = now;
+			}
+			break;
+		case AxisDirectionY_NONE:
+			last_up_ = last_down_ = 0;
+			break;
+	}
+	return axis_direction;
+}
+
+} // namespace

--- a/SourceX/controls/axis_direction.h
+++ b/SourceX/controls/axis_direction.h
@@ -1,0 +1,48 @@
+#pragma once
+
+namespace dvl {
+
+enum AxisDirectionX {
+	AxisDirectionX_NONE = 0,
+	AxisDirectionX_LEFT,
+	AxisDirectionX_RIGHT
+};
+enum AxisDirectionY {
+	AxisDirectionY_NONE = 0,
+	AxisDirectionY_UP,
+	AxisDirectionY_DOWN
+};
+
+/**
+ * @brief 8-way direction of a D-Pad or a thumb stick.
+ */
+struct AxisDirection {
+	AxisDirectionX x;
+	AxisDirectionY y;
+};
+
+/**
+ * @brief Returns a non-empty AxisDirection at most once per the given time interval.
+ */
+class AxisDirectionRepeater {
+public:
+	AxisDirectionRepeater(int min_interval_ms)
+	    : last_left_(0)
+	    , last_right_(0)
+	    , last_up_(0)
+	    , last_down_(0)
+	    , min_interval_ms_(min_interval_ms)
+	{
+	}
+
+	AxisDirection Get(AxisDirection axis_direction);
+
+private:
+	int last_left_;
+	int last_right_;
+	int last_up_;
+	int last_down_;
+	int min_interval_ms_;
+};
+
+} // namespace dvl

--- a/SourceX/controls/axis_direction.h
+++ b/SourceX/controls/axis_direction.h
@@ -26,7 +26,7 @@ struct AxisDirection {
  */
 class AxisDirectionRepeater {
 public:
-	AxisDirectionRepeater(int min_interval_ms)
+	AxisDirectionRepeater(int min_interval_ms = 200)
 	    : last_left_(0)
 	    , last_right_(0)
 	    , last_up_(0)

--- a/SourceX/controls/controller.h
+++ b/SourceX/controls/controller.h
@@ -2,7 +2,7 @@
 
 #include <SDL.h>
 
-#include "controls/controller_buttons.h"
+#include "./controller_buttons.h"
 
 namespace dvl {
 

--- a/SourceX/controls/controller_buttons.h
+++ b/SourceX/controls/controller_buttons.h
@@ -1,8 +1,6 @@
 #pragma once
 // Unifies joystick, gamepad, and keyboard controller APIs.
 
-#include "all.h"
-
 namespace dvl {
 
 // NOTE: A, B, X, Y refer to physical positions on an XBox 360 controller.

--- a/SourceX/controls/controller_motion.cpp
+++ b/SourceX/controls/controller_motion.cpp
@@ -1,5 +1,7 @@
 #include "controls/controller_motion.h"
 
+#include <cmath>
+
 #include "controls/devices/game_controller.h"
 #include "controls/devices/joystick.h"
 #include "controls/devices/kbcontroller.h"
@@ -30,7 +32,7 @@ void ScaleJoystickAxes(float *x, float *y, float deadzone)
 	float analog_y = *y;
 	float dead_zone = deadzone * maximum;
 
-	float magnitude = sqrtf(analog_x * analog_x + analog_y * analog_y);
+	float magnitude = std::sqrt(analog_x * analog_x + analog_y * analog_y);
 	if (magnitude >= dead_zone) {
 		// find scaled axis values with magnitudes between zero and maximum
 		float scalingFactor = 1.0 / magnitude * (magnitude - dead_zone) / (maximum - dead_zone);
@@ -39,8 +41,8 @@ void ScaleJoystickAxes(float *x, float *y, float deadzone)
 
 		// clamp to ensure results will never exceed the max_axis value
 		float clamping_factor = 1.0f;
-		float abs_analog_x = fabs(analog_x);
-		float abs_analog_y = fabs(analog_y);
+		float abs_analog_x = std::fabs(analog_x);
+		float abs_analog_y = std::fabs(analog_y);
 		if (abs_analog_x > 1.0 || abs_analog_y > 1.0) {
 			if (abs_analog_x > abs_analog_y) {
 				clamping_factor = 1 / abs_analog_x;
@@ -142,6 +144,28 @@ bool ProcessControllerMotion(const SDL_Event &event, ControllerButtonEvent ctrl_
 		return true;
 #endif
 	return SimulateRightStickWithDpad(event, ctrl_event);
+}
+
+AxisDirection GetLeftStickOrDpadDirection(bool allow_dpad)
+{
+	const float stickX = leftStickX;
+	const float stickY = leftStickY;
+
+	AxisDirection result { AxisDirectionX_NONE, AxisDirectionY_NONE };
+
+	if (stickY >= 0.5 || (allow_dpad && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_UP))) {
+		result.y = AxisDirectionY_UP;
+	} else if (stickY <= -0.5 || (allow_dpad && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_DOWN))) {
+		result.y = AxisDirectionY_DOWN;
+	}
+
+	if (stickX <= -0.5 || (allow_dpad && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_LEFT))) {
+		result.x = AxisDirectionX_LEFT;
+	} else if (stickX >= 0.5 || (allow_dpad && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_RIGHT))) {
+		result.x = AxisDirectionX_RIGHT;
+	}
+
+	return result;
 }
 
 } // namespace dvl

--- a/SourceX/controls/controller_motion.h
+++ b/SourceX/controls/controller_motion.h
@@ -2,8 +2,10 @@
 
 // Processes and stores mouse and joystick motion.
 
-#include "all.h"
-#include "controls/controller.h"
+#include <SDL.h>
+
+#include "./axis_direction.h"
+#include "./controller.h"
 
 namespace dvl {
 
@@ -18,5 +20,8 @@ extern bool leftStickNeedsScaling, rightStickNeedsScaling;
 
 // Updates motion state for mouse and joystick sticks.
 bool ProcessControllerMotion(const SDL_Event &event, ControllerButtonEvent ctrl_event);
+
+// Returns direction of the left thumb stick or DPad (if allow_dpad = true).
+AxisDirection GetLeftStickOrDpadDirection(bool allow_dpad = true);
 
 } // namespace dvl

--- a/SourceX/controls/devices/game_controller.cpp
+++ b/SourceX/controls/devices/game_controller.cpp
@@ -8,6 +8,9 @@
 #include "controls/devices/joystick.h"
 #include "stubs.h"
 
+// Defined in SourceX/controls/plctrls.cpp
+extern "C" bool sgbControllerActive;
+
 namespace dvl {
 
 std::vector<GameController> *const GameController::controllers_ = new std::vector<GameController>;

--- a/SourceX/controls/devices/joystick.cpp
+++ b/SourceX/controls/devices/joystick.cpp
@@ -6,6 +6,9 @@
 #include "controls/controller_motion.h"
 #include "stubs.h"
 
+// Defined in SourceX/controls/plctrls.cpp
+extern "C" bool sgbControllerActive;
+
 namespace dvl {
 
 std::vector<Joystick> *const Joystick::joysticks_ = new std::vector<Joystick>;

--- a/SourceX/controls/game_controls.cpp
+++ b/SourceX/controls/game_controls.cpp
@@ -15,9 +15,9 @@ namespace dvl {
 bool start_modifier_active = false;
 bool select_modifier_active = false;
 
-// gamepad dpad acts as hotkeys without holding "start"
+/** Gamepad dpad acts as hotkeys without holding "start" */
 bool dpad_hotkeys = false;
-// shoulder gamepad buttons act as potions by default
+/** Shoulder gamepad buttons act as potions by default */
 bool switch_potions_and_clicks = false;
 
 namespace {

--- a/SourceX/controls/game_controls.cpp
+++ b/SourceX/controls/game_controls.cpp
@@ -308,6 +308,20 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrl_event, Gam
 	}
 
 
+	// DPad navigation is handled separately for these.
+	if (gmenu_is_active() || questlog)
+	{
+		switch (ctrl_event.button) {
+			case ControllerButton_BUTTON_DPAD_UP:
+			case ControllerButton_BUTTON_DPAD_DOWN:
+			case ControllerButton_BUTTON_DPAD_LEFT:
+			case ControllerButton_BUTTON_DPAD_RIGHT:
+				return true;
+			default:
+				break;
+		}
+	}
+
 	// By default, map to a keyboard key.
 	if (ctrl_event.button != ControllerButton_NONE) {
 		*action = GameActionSendKey{ translate_controller_button_to_key(ctrl_event.button),
@@ -330,26 +344,9 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrl_event, Gam
 	return false;
 }
 
-MoveDirection GetMoveDirection()
+AxisDirection GetMoveDirection()
 {
-	const float stickX = leftStickX;
-	const float stickY = leftStickY;
-
-	MoveDirection result{ MoveDirectionX_NONE, MoveDirectionY_NONE };
-
-	if (stickY >= 0.5 || (!dpad_hotkeys && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_UP))) {
-		result.y = MoveDirectionY_UP;
-	} else if (stickY <= -0.5 || (!dpad_hotkeys && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_DOWN))) {
-		result.y = MoveDirectionY_DOWN;
-	}
-
-	if (stickX <= -0.5 || (!dpad_hotkeys && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_LEFT))) {
-		result.x = MoveDirectionX_LEFT;
-	} else if (stickX >= 0.5 || (!dpad_hotkeys && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_RIGHT))) {
-		result.x = MoveDirectionX_RIGHT;
-	}
-
-	return result;
+	return GetLeftStickOrDpadDirection(/*allow_dpad=*/!dpad_hotkeys);
 }
 
 } // namespace dvl

--- a/SourceX/controls/game_controls.h
+++ b/SourceX/controls/game_controls.h
@@ -25,7 +25,7 @@ enum GameActionType {
 };
 
 struct GameActionSendKey {
-	std::uint32_t vk_code;
+	Uint32 vk_code;
 	bool up;
 };
 

--- a/SourceX/controls/game_controls.h
+++ b/SourceX/controls/game_controls.h
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "all.h"
-#include "controls/controller.h"
+#include <cstdint>
+#include <SDL.h>
+
+#include "./axis_direction.h"
+#include "./controller.h"
 
 namespace dvl {
 
@@ -22,7 +25,7 @@ enum GameActionType {
 };
 
 struct GameActionSendKey {
-	DWORD vk_code;
+	std::uint32_t vk_code;
 	bool up;
 };
 
@@ -68,21 +71,7 @@ struct GameAction {
 
 bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrl_event, GameAction *action);
 
-enum MoveDirectionX {
-	MoveDirectionX_NONE = 0,
-	MoveDirectionX_LEFT,
-	MoveDirectionX_RIGHT
-};
-enum MoveDirectionY {
-	MoveDirectionY_NONE = 0,
-	MoveDirectionY_UP,
-	MoveDirectionY_DOWN
-};
-struct MoveDirection {
-	MoveDirectionX x;
-	MoveDirectionY y;
-};
-MoveDirection GetMoveDirection();
+AxisDirection GetMoveDirection();
 
 extern bool start_modifier_active;
 extern bool select_modifier_active;

--- a/SourceX/controls/menu_controls.cpp
+++ b/SourceX/controls/menu_controls.cpp
@@ -8,11 +8,10 @@
 
 namespace dvl {
 
-static AxisDirectionRepeater menuUpDownRepeater(/*min_interval_ms=*/200);
-
 MenuAction GetMenuHeldUpDownAction()
 {
-	const AxisDirection dir = menuUpDownRepeater.Get(GetLeftStickOrDpadDirection());
+	static AxisDirectionRepeater repeater;
+	const AxisDirection dir = repeater.Get(GetLeftStickOrDpadDirection());
 	switch (dir.y) {
 	case AxisDirectionY_UP:
 		return MenuAction_UP;

--- a/SourceX/controls/menu_controls.cpp
+++ b/SourceX/controls/menu_controls.cpp
@@ -1,14 +1,37 @@
 #include "controls/menu_controls.h"
 
+#include "controls/axis_direction.h"
 #include "controls/controller.h"
+#include "controls/controller_motion.h"
 #include "controls/remap_keyboard.h"
 #include "DiabloUI/diabloui.h"
 
 namespace dvl {
 
+static AxisDirectionRepeater menuUpDownRepeater(/*min_interval_ms=*/200);
+
+MenuAction GetMenuHeldUpDownAction()
+{
+	const AxisDirection dir = menuUpDownRepeater.Get(GetLeftStickOrDpadDirection());
+	switch (dir.y) {
+	case AxisDirectionY_UP:
+		return MenuAction_UP;
+	case AxisDirectionY_DOWN:
+		return MenuAction_DOWN;
+	default:
+		return MenuAction_NONE;
+	}
+}
+
 MenuAction GetMenuAction(const SDL_Event &event)
 {
 	const ControllerButtonEvent ctrl_event = ToControllerButtonEvent(event);
+
+	if (ProcessControllerMotion(event, ctrl_event)) {
+		sgbControllerActive = true;
+		return GetMenuHeldUpDownAction();
+	}
+
 	if (ctrl_event.button != ControllerButton_NONE)
 		sgbControllerActive = true;
 
@@ -25,9 +48,8 @@ MenuAction GetMenuAction(const SDL_Event &event)
 		case ControllerButton_BUTTON_X: // Left button
 			return MenuAction_DELETE;
 		case ControllerButton_BUTTON_DPAD_UP:
-			return MenuAction_UP;
 		case ControllerButton_BUTTON_DPAD_DOWN:
-			return MenuAction_DOWN;
+			return GetMenuHeldUpDownAction();
 		case ControllerButton_BUTTON_DPAD_LEFT:
 			return MenuAction_LEFT;
 		case ControllerButton_BUTTON_DPAD_RIGHT:

--- a/SourceX/controls/menu_controls.h
+++ b/SourceX/controls/menu_controls.h
@@ -21,4 +21,7 @@ enum MenuAction {
 
 MenuAction GetMenuAction(const SDL_Event &event);
 
+// Menu action from holding the left stick or DPad.
+MenuAction GetMenuHeldUpDownAction();
+
 } // namespace dvl

--- a/SourceX/controls/menu_controls.h
+++ b/SourceX/controls/menu_controls.h
@@ -21,7 +21,7 @@ enum MenuAction {
 
 MenuAction GetMenuAction(const SDL_Event &event);
 
-// Menu action from holding the left stick or DPad.
+/** Menu action from holding the left stick or DPad. */
 MenuAction GetMenuHeldUpDownAction();
 
 } // namespace dvl

--- a/SourceX/controls/plrctrls.cpp
+++ b/SourceX/controls/plrctrls.cpp
@@ -446,7 +446,7 @@ void Interact()
 
 void AttrIncBtnSnap(AxisDirection dir)
 {
-	static AxisDirectionRepeater repeater(/*min_interval_ms=*/200);
+	static AxisDirectionRepeater repeater;
 	dir = repeater.Get(dir);
 	if (dir.y == AxisDirectionY_NONE)
 		return;
@@ -677,7 +677,7 @@ bool HSExists(int x, int y)
 
 void HotSpellMove(AxisDirection dir)
 {
-	static AxisDirectionRepeater repeater(/*min_interval_ms=*/200);
+	static AxisDirectionRepeater repeater;
 	dir = repeater.Get(dir);
 	if (dir.x == AxisDirectionX_NONE && dir.y == AxisDirectionY_NONE)
 		return;
@@ -725,7 +725,7 @@ void HotSpellMove(AxisDirection dir)
 
 void SpellBookMove(AxisDirection dir)
 {
-	static AxisDirectionRepeater repeater(/*min_interval_ms=*/200);
+	static AxisDirectionRepeater repeater;
 	dir = repeater.Get(dir);
 
 	if (dir.x == AxisDirectionX_LEFT) {
@@ -824,7 +824,7 @@ void WalkInDir(AxisDirection dir)
 
 void QuestLogMove(AxisDirection move_dir)
 {
-	static AxisDirectionRepeater repeater(/*min_interval_ms=*/200);
+	static AxisDirectionRepeater repeater;
 	move_dir = repeater.Get(move_dir);
 	if (move_dir.y == AxisDirectionY_UP)
 		QuestlogUp();


### PR DESCRIPTION
Implements thumb stick / dpad navigation and repeat-on-hold in DiabloUI, gmenu, and quest log.

1. Allows DiabloUI, gmenu, and quest log navigation with the left thumb stick.
    
2. De-duplicates repetition / throttling logic throughout.
    
3. Menus have separate repetition frequencies (inventory at 100ms, everything else at 200ms).
    
4. Movement mostly decoupled from menu navigation: the `dpad_hotkeys` setting used on the Vita no longer prevents dpad from navigating in menus.
