### PR TITLE
Fix majority of the Clang warnings

### DIFF
--- a/3rdParty/Radon/Radon/include/Key.hpp
+++ b/3rdParty/Radon/Radon/include/Key.hpp
@@ -17,13 +17,13 @@ namespace radon
 
 		Key(const std::string & name, const std::string & value);
 
-		Key(const std::string & name, const float & value);
+		Key(const std::string & name, float value);
 
 		std::string getStringValue();
 
 		float getFloatValue();
 
-		void setValue(float & value);
+		void setValue(float value);
 
 		void setValue(std::string & value);
 

--- a/3rdParty/Radon/Radon/source/Key.cpp
+++ b/3rdParty/Radon/Radon/source/Key.cpp
@@ -25,7 +25,7 @@ namespace radon
 	}
 
 
-	Key::Key(const std::string & name, const float & value)
+	Key::Key(const std::string & name, float value)
 		: Named(name), value(Float2String(value))
 	{
 	}
@@ -43,7 +43,7 @@ namespace radon
 	}
 
 
-	void Key::setValue(float & value)
+	void Key::setValue(float value)
 	{
 		this->value = Float2String(value);
 	}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -635,9 +635,6 @@ if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   genex_for_option(DEBUG)
   target_compile_options(devilution PUBLIC $<${DEBUG_GENEX}:-fno-omit-frame-pointer>)
 
-  # Warnings for devilution
-  target_compile_options(devilution PRIVATE -Wno-int-to-pointer-cast)
-
   # Warnings for devilutionX
   target_compile_options(${BIN_TARGET} PRIVATE -Wall -Wextra -Wno-unused-parameter -Wno-format-security)
 
@@ -648,15 +645,6 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_compile_options(devilution PRIVATE "/W0")
-endif()
-
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  # Style issues
-  target_compile_options(${BIN_TARGET} PRIVATE -Wno-parentheses -Wno-logical-op-parentheses -Wno-bitwise-op-parentheses)
-  # Silence warnings about __int64 alignment hack not always being applicable
-  target_compile_options(${BIN_TARGET} PRIVATE -Wno-ignored-attributes)
-  # Silence appfat.cpp warnings
-  set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-narrowing")
 endif()
 
 if(APPLE)

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -351,6 +351,7 @@ void DrawAutomapPlr(CelOutputBuffer out, int pnum)
 		DrawLineTo(out, x + AmLine16, y + AmLine8, x + AmLine8, y + AmLine8, playerColor);
 		break;
 	case DIR_S:
+	case DIR_OMNI:
 		DrawLineTo(out, x, y, x, y + AmLine16, playerColor);
 		DrawLineTo(out, x, y + AmLine16, x + AmLine4, y + AmLine8, playerColor);
 		DrawLineTo(out, x, y + AmLine16, x - AmLine4, y + AmLine8, playerColor);

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -367,6 +367,8 @@ void DrawSpellList(CelOutputBuffer out)
 			mask = plr[myplr]._pISpells;
 			c = SPLICONLAST + 2;
 			break;
+		case RSPLTYPE_INVALID:
+			break;
 		}
 		Sint32 j = SPL_FIREBOLT;
 		for (spl = 1; j < MAX_SPELLS; spl <<= 1, j++) {
@@ -440,6 +442,8 @@ void DrawSpellList(CelOutputBuffer out)
 						sprintf(tempstr, "%i Charges", plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges);
 					AddPanelString(tempstr, TRUE);
 					break;
+				case RSPLTYPE_INVALID:
+					break;
 				}
 				for (t = 0; t < 4; t++) {
 					if (plr[myplr]._pSplHotKey[t] == pSpell && plr[myplr]._pSplTHotKey[t] == pSplType) {
@@ -510,6 +514,8 @@ void ToggleSpell(int slot)
 	case RSPLTYPE_CHARGES:
 		spells = plr[myplr]._pISpells;
 		break;
+	case RSPLTYPE_INVALID:
+		return;
 	}
 
 	if (spells & GetSpellBitmask(plr[myplr]._pSplHotKey[slot])) {
@@ -1067,6 +1073,8 @@ void CheckPanelInfo()
 				else
 					sprintf(tempstr, "%i Charges", plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges);
 				AddPanelString(tempstr, TRUE);
+				break;
+			case RSPLTYPE_INVALID:
 				break;
 			}
 		}
@@ -1678,26 +1686,25 @@ static int DrawDurIcon4Item(CelOutputBuffer out, ItemStruct *pItem, int x, int c
 	if (pItem->_iDurability > 5)
 		return x;
 	if (c == 0) {
-		if (pItem->_iClass == ICLASS_WEAPON) {
-			switch (pItem->_itype) {
-			case ITYPE_SWORD:
-				c = 2;
-				break;
-			case ITYPE_AXE:
-				c = 6;
-				break;
-			case ITYPE_BOW:
-				c = 7;
-				break;
-			case ITYPE_MACE:
-				c = 5;
-				break;
-			case ITYPE_STAFF:
-				c = 8;
-				break;
-			}
-		} else {
+		switch (pItem->_itype) {
+		case ITYPE_SWORD:
+			c = 2;
+			break;
+		case ITYPE_AXE:
+			c = 6;
+			break;
+		case ITYPE_BOW:
+			c = 7;
+			break;
+		case ITYPE_MACE:
+			c = 5;
+			break;
+		case ITYPE_STAFF:
+			c = 8;
+			break;
+		default:
 			c = 1;
+			break;
 		}
 	}
 	if (pItem->_iDurability > 2)

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -338,7 +338,7 @@ static void DrawSpell(CelOutputBuffer out)
 void DrawSpellList(CelOutputBuffer out)
 {
 	int x, y, c, s, t, v, lx, ly, trans;
-	unsigned __int64 mask, spl;
+	Uint64 mask, spl;
 
 	pSpell = SPL_INVALID;
 	infostr[0] = '\0';
@@ -491,7 +491,7 @@ void SetSpeedSpell(int slot)
 
 void ToggleSpell(int slot)
 {
-	unsigned __int64 spells;
+	Uint64 spells;
 
 	if (plr[myplr]._pSplHotKey[slot] == -1) {
 		return;
@@ -512,7 +512,7 @@ void ToggleSpell(int slot)
 		break;
 	}
 
-	if (spells & SPELLBIT(plr[myplr]._pSplHotKey[slot])) {
+	if (spells & GetSpellBitmask(plr[myplr]._pSplHotKey[slot])) {
 		plr[myplr]._pRSpell = plr[myplr]._pSplHotKey[slot];
 		plr[myplr]._pRSplType = plr[myplr]._pSplTHotKey[slot];
 		force_redraw = 255;
@@ -855,7 +855,6 @@ void DrawCtrlBtns(CelOutputBuffer out)
  */
 void DoSpeedBook()
 {
-	unsigned __int64 spell, spells;
 	int xo, yo, X, Y, i, j;
 
 	spselflag = TRUE;
@@ -866,6 +865,7 @@ void DoSpeedBook()
 
 	if (plr[myplr]._pRSpell != SPL_INVALID) {
 		for (i = 0; i < 4; i++) {
+			Uint64 spells;
 			switch (i) {
 			case RSPLTYPE_SKILL:
 				spells = plr[myplr]._pAblSpells;
@@ -880,7 +880,7 @@ void DoSpeedBook()
 				spells = plr[myplr]._pISpells;
 				break;
 			}
-			spell = (__int64)1;
+			Uint64 spell = 1;
 			for (j = 1; j < MAX_SPELLS; j++) {
 				if (spell & spells) {
 					if (j == plr[myplr]._pRSpell && i == plr[myplr]._pRSplType) {
@@ -893,7 +893,7 @@ void DoSpeedBook()
 						yo -= SPLICONLENGTH;
 					}
 				}
-				spell <<= (__int64)1;
+				spell <<= 1ULL;
 			}
 			if (spells && xo != PANEL_X + 12 + SPLICONLENGTH * SPLROWICONLS)
 				xo -= SPLICONLENGTH;
@@ -1800,10 +1800,10 @@ char GetSBookTrans(int ii, BOOL townok)
 	if ((plr[myplr]._pClass == PC_MONK) && (ii == SPL_SEARCH))
 		return RSPLTYPE_SKILL;
 	st = RSPLTYPE_SPELL;
-	if (plr[myplr]._pISpells & SPELLBIT(ii)) {
+	if (plr[myplr]._pISpells & GetSpellBitmask(ii)) {
 		st = RSPLTYPE_CHARGES;
 	}
-	if (plr[myplr]._pAblSpells & SPELLBIT(ii)) {
+	if (plr[myplr]._pAblSpells & GetSpellBitmask(ii)) {
 		st = RSPLTYPE_SKILL;
 	}
 	if (st == RSPLTYPE_SPELL) {
@@ -1825,7 +1825,6 @@ void DrawSpellBook(CelOutputBuffer out)
 {
 	int i, sn, mana, lvl, yp, min, max;
 	char st;
-	unsigned __int64 spl;
 
 	CelDrawTo(out, RIGHT_PANEL_X, 351, pSpellBkCel, 1, SPANEL_WIDTH);
 	if (gbIsHellfire && sbooktab < 5) {
@@ -1838,12 +1837,12 @@ void DrawSpellBook(CelOutputBuffer out)
 		}
 		CelDrawTo(out, sx, 348, pSBkBtnCel, sbooktab + 1, 76);
 	}
-	spl = plr[myplr]._pMemSpells | plr[myplr]._pISpells | plr[myplr]._pAblSpells;
+	Uint64 spl = plr[myplr]._pMemSpells | plr[myplr]._pISpells | plr[myplr]._pAblSpells;
 
 	yp = 55;
 	for (i = 1; i < 8; i++) {
 		sn = SpellPages[sbooktab][i - 1];
-		if (sn != -1 && spl & SPELLBIT(sn)) {
+		if (sn != -1 && spl & GetSpellBitmask(sn)) {
 			st = GetSBookTrans(sn, TRUE);
 			SetSpellTrans(st);
 			DrawSpellCel(out, RIGHT_PANEL_X + 11, yp, pSBkIconCels, SpellITbl[sn], 37);
@@ -1893,12 +1892,12 @@ void CheckSBook()
 	if (MouseX >= RIGHT_PANEL + 11 && MouseX < RIGHT_PANEL + 48 && MouseY >= 18 && MouseY < 314) {
 		spell_id sn = SpellPages[sbooktab][(MouseY - 18) / 43];
 		Uint64 spl = plr[myplr]._pMemSpells | plr[myplr]._pISpells | plr[myplr]._pAblSpells;
-		if (sn != SPL_INVALID && spl & SPELLBIT(sn)) {
+		if (sn != SPL_INVALID && spl & GetSpellBitmask(sn)) {
 			spell_type st = RSPLTYPE_SPELL;
-			if (plr[myplr]._pISpells & SPELLBIT(sn)) {
+			if (plr[myplr]._pISpells & GetSpellBitmask(sn)) {
 				st = RSPLTYPE_CHARGES;
 			}
-			if (plr[myplr]._pAblSpells & SPELLBIT(sn)) {
+			if (plr[myplr]._pAblSpells & GetSpellBitmask(sn)) {
 				st = RSPLTYPE_SKILL;
 			}
 			plr[myplr]._pRSpell = sn;

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -481,10 +481,8 @@ void SetSpell()
 
 void SetSpeedSpell(int slot)
 {
-	int i;
-
 	if (pSpell != SPL_INVALID) {
-		for (i = 0; i < 4; ++i) {
+		for (int i = 0; i < 4; ++i) {
 			if (plr[myplr]._pSplHotKey[i] == pSpell && plr[myplr]._pSplTHotKey[i] == pSplType)
 				plr[myplr]._pSplHotKey[i] = SPL_INVALID;
 		}

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -497,7 +497,7 @@ void ToggleSpell(int slot)
 {
 	Uint64 spells;
 
-	if (plr[myplr]._pSplHotKey[slot] == -1) {
+	if (plr[myplr]._pSplHotKey[slot] == SPL_INVALID) {
 		return;
 	}
 
@@ -990,7 +990,7 @@ void DoAutoMap()
  */
 void CheckPanelInfo()
 {
-	int i, c, v, s, xend, yend;
+	int i, c, s, xend, yend;
 
 	panelflag = FALSE;
 	ClearPanel();
@@ -1022,7 +1022,7 @@ void CheckPanelInfo()
 		pinfoflag = TRUE;
 		strcpy(tempstr, "Hotkey: 's'");
 		AddPanelString(tempstr, TRUE);
-		v = plr[myplr]._pRSpell;
+		spell_id v = plr[myplr]._pRSpell;
 		if (v != SPL_INVALID) {
 			switch (plr[myplr]._pRSplType) {
 			case RSPLTYPE_SKILL:

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -91,7 +91,7 @@ void MaxSpellsCheat()
 
 	for (i = 1; i < maxSpells; i++) {
 		if (GetSpellBookLevel(i) != -1) {
-			plr[myplr]._pMemSpells |= SPELLBIT(i);
+			plr[myplr]._pMemSpells |= GetSpellBitmask(i);
 			plr[myplr]._pSplLvl[i] = 10;
 		}
 	}
@@ -99,7 +99,7 @@ void MaxSpellsCheat()
 
 void SetSpellLevelCheat(char spl, int spllvl)
 {
-	plr[myplr]._pMemSpells |= SPELLBIT(spl);
+	plr[myplr]._pMemSpells |= GetSpellBitmask(spl);
 	plr[myplr]._pSplLvl[spl] = spllvl;
 }
 

--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -1352,19 +1352,17 @@ static BOOL L5checkRoom(int x, int y, int width, int height)
 
 static void L5roomGen(int x, int y, int w, int h, int dir)
 {
-	int num, dirProb;
 	BOOL ran, ran2;
 	int width, height, rx, ry, ry2;
 	int cw, ch, cx1, cy1, cx2;
 
-	dirProb = random_(0, 4);
+	int dirProb = random_(0, 4);
+	int num = 0;
 
-	switch (dir == 1 ? dirProb != 0 : dirProb == 0) {
-	case FALSE:
-		num = 0;
+	if ((dir == 1 && dirProb == 0) || (dir != 1 && dirProb != 0)) {
 		do {
-			cw = (random_(0, 5) + 2) & 0xFFFFFFFE;
-			ch = (random_(0, 5) + 2) & 0xFFFFFFFE;
+			cw = (random_(0, 5) + 2) & ~1;
+			ch = (random_(0, 5) + 2) & ~1;
 			cy1 = h / 2 + y - ch / 2;
 			cx1 = x - cw;
 			ran = L5checkRoom(cx1 - 1, cy1 - 1, ch + 2, cw + 1); /// BUGFIX: swap args 3 and 4 ("ch+2" and "cw+1")
@@ -1381,30 +1379,28 @@ static void L5roomGen(int x, int y, int w, int h, int dir)
 			L5roomGen(cx1, cy1, cw, ch, 1);
 		if (ran2 == TRUE)
 			L5roomGen(cx2, cy1, cw, ch, 1);
-		break;
-	case TRUE:
-		num = 0;
-		do {
-			width = (random_(0, 5) + 2) & 0xFFFFFFFE;
-			height = (random_(0, 5) + 2) & 0xFFFFFFFE;
-			rx = w / 2 + x - width / 2;
-			ry = y - height;
-			ran = L5checkRoom(rx - 1, ry - 1, width + 2, height + 1);
-			num++;
-		} while (ran == FALSE && num < 20);
-
-		if (ran == TRUE)
-			L5drawRoom(rx, ry, width, height);
-		ry2 = y + h;
-		ran2 = L5checkRoom(rx - 1, ry2, width + 2, height + 1);
-		if (ran2 == TRUE)
-			L5drawRoom(rx, ry2, width, height);
-		if (ran == TRUE)
-			L5roomGen(rx, ry, width, height, 0);
-		if (ran2 == TRUE)
-			L5roomGen(rx, ry2, width, height, 0);
-		break;
+		return;
 	}
+
+	do {
+		width = (random_(0, 5) + 2) & ~1;
+		height = (random_(0, 5) + 2) & ~1;
+		rx = w / 2 + x - width / 2;
+		ry = y - height;
+		ran = L5checkRoom(rx - 1, ry - 1, width + 2, height + 1);
+		num++;
+	} while (ran == FALSE && num < 20);
+
+	if (ran == TRUE)
+		L5drawRoom(rx, ry, width, height);
+	ry2 = y + h;
+	ran2 = L5checkRoom(rx - 1, ry2, width + 2, height + 1);
+	if (ran2 == TRUE)
+		L5drawRoom(rx, ry2, width, height);
+	if (ran == TRUE)
+		L5roomGen(rx, ry, width, height, 0);
+	if (ran2 == TRUE)
+		L5roomGen(rx, ry2, width, height, 0);
 }
 
 static void L5firstRoom()

--- a/Source/drlg_l3.cpp
+++ b/Source/drlg_l3.cpp
@@ -1602,6 +1602,8 @@ static void DRLG_L3PoolFix()
 				    && dungeon[dunx + 1][duny] >= 25 && dungeon[dunx + 1][duny] <= 41
 				    && dungeon[dunx + 1][duny + 1] >= 25 && dungeon[dunx + 1][duny + 1] <= 41) {
 					dungeon[dunx][duny] = 33;
+				} else if (dungeon[dunx + 1][duny] == 35 || dungeon[dunx + 1][duny] == 37) {
+					dungeon[dunx][duny] = 33;
 				}
 			}
 		}

--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -1122,16 +1122,14 @@ static BOOL L4checkRoom(int x, int y, int width, int height)
 
 static void L4roomGen(int x, int y, int w, int h, int dir)
 {
-	int num;
 	BOOL ran, ran2;
 	int width, height, rx, ry, ry2;
 	int cw, ch, cx1, cy1, cx2;
 
 	int dirProb = random_(0, 4);
+	int num = 0;
 
-	switch (dir == 1 ? dirProb != 0 : dirProb == 0) {
-	case FALSE:
-		num = 0;
+	if ((dir == 1 && dirProb == 0) || (dir != 1 && dirProb != 0)) {
 		do {
 			cw = (random_(0, 5) + 2) & ~1;
 			ch = (random_(0, 5) + 2) & ~1;
@@ -1151,30 +1149,28 @@ static void L4roomGen(int x, int y, int w, int h, int dir)
 			L4roomGen(cx1, cy1, cw, ch, 1);
 		if (ran2 == TRUE)
 			L4roomGen(cx2, cy1, cw, ch, 1);
-		break;
-	case TRUE:
-		num = 0;
-		do {
-			width = (random_(0, 5) + 2) & ~1;
-			height = (random_(0, 5) + 2) & ~1;
-			rx = w / 2 + x - width / 2;
-			ry = y - height;
-			ran = L4checkRoom(rx - 1, ry - 1, width + 2, height + 1);
-			num++;
-		} while (ran == FALSE && num < 20);
-
-		if (ran == TRUE)
-			L4drawRoom(rx, ry, width, height);
-		ry2 = y + h;
-		ran2 = L4checkRoom(rx - 1, ry2, width + 2, height + 1);
-		if (ran2 == TRUE)
-			L4drawRoom(rx, ry2, width, height);
-		if (ran == TRUE)
-			L4roomGen(rx, ry, width, height, 0);
-		if (ran2 == TRUE)
-			L4roomGen(rx, ry2, width, height, 0);
-		break;
+		return;
 	}
+
+	do {
+		width = (random_(0, 5) + 2) & ~1;
+		height = (random_(0, 5) + 2) & ~1;
+		rx = w / 2 + x - width / 2;
+		ry = y - height;
+		ran = L4checkRoom(rx - 1, ry - 1, width + 2, height + 1);
+		num++;
+	} while (ran == FALSE && num < 20);
+
+	if (ran == TRUE)
+		L4drawRoom(rx, ry, width, height);
+	ry2 = y + h;
+	ran2 = L4checkRoom(rx - 1, ry2, width + 2, height + 1);
+	if (ran2 == TRUE)
+		L4drawRoom(rx, ry2, width, height);
+	if (ran == TRUE)
+		L4roomGen(rx, ry, width, height, 0);
+	if (ran2 == TRUE)
+		L4roomGen(rx, ry2, width, height, 0);
 }
 
 static void L4firstRoom()
@@ -1406,7 +1402,7 @@ static BOOL DRLG_L4PlaceMiniSet(const BYTE *miniset, int tmin, int tmax, int cx,
 
 #if defined(__3DS__)
 #pragma GCC push_options
-#pragma GCC optimize ("O0")
+#pragma GCC optimize("O0")
 #endif
 
 static void DRLG_L4FTVR(int i, int j, int x, int y, int d)

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -660,9 +660,8 @@ bool AutoPlaceItemInBelt(int playerNumber, const ItemStruct &item, bool persistI
  */
 bool CanEquip(const ItemStruct &item)
 {
-	return
-		item.isEquipment() &&
-		item._iStatFlag;
+	return item.isEquipment()
+	    && item._iStatFlag;
 }
 
 /**
@@ -702,23 +701,20 @@ bool CanWield(int playerNumber, const ItemStruct &item)
 	// Bard can dual wield swords and maces, so we allow equiping one-handed weapons in her free slot as long as her occupied
 	// slot is another one-handed weapon.
 	if (player._pClass == PC_BARD) {
-		bool occupiedHandIsOneHandedSwordOrMace =
-			occupiedHand._iLoc == ILOC_ONEHAND &&
-			(occupiedHand._itype == ITYPE_SWORD || occupiedHand._itype == ITYPE_MACE);
+		bool occupiedHandIsOneHandedSwordOrMace = occupiedHand._iLoc == ILOC_ONEHAND
+		    && (occupiedHand._itype == ITYPE_SWORD || occupiedHand._itype == ITYPE_MACE);
 
-		bool weaponToEquipIsOneHandedSwordOrMace =
-			item._iLoc == ILOC_ONEHAND &&
-			(item._itype == ITYPE_SWORD || item._itype == ITYPE_MACE);
+		bool weaponToEquipIsOneHandedSwordOrMace = item._iLoc == ILOC_ONEHAND
+		    && (item._itype == ITYPE_SWORD || item._itype == ITYPE_MACE);
 
 		if (occupiedHandIsOneHandedSwordOrMace && weaponToEquipIsOneHandedSwordOrMace) {
 			return true;
 		}
 	}
 
-	return
-		item._iLoc == ILOC_ONEHAND &&
-		occupiedHand._iLoc == ILOC_ONEHAND &&
-		item._iClass != occupiedHand._iClass;
+	return item._iLoc == ILOC_ONEHAND
+	    && occupiedHand._iLoc == ILOC_ONEHAND
+	    && item._iClass != occupiedHand._iClass;
 }
 
 /**
@@ -1776,12 +1772,10 @@ void CheckInvCut(int pnum, int mx, int my, bool automaticMove)
 						case PC_BARBARIAN:
 							PlaySFX(PS_WARR15, false);
 							break;
-
 						case PC_ROGUE:
 						case PC_BARD:
 							PlaySFX(PS_ROGUE15, false);
 							break;
-
 						case PC_SORCERER:
 							PlaySFX(PS_MAGE15, false);
 							break;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1785,9 +1785,10 @@ void CheckInvCut(int pnum, int mx, int my, bool automaticMove)
 						case PC_SORCERER:
 							PlaySFX(PS_MAGE15, false);
 							break;
-
 						case PC_MONK:
 							PlaySFX(PS_MONK15, false);
+							break;
+						case NUM_CLASSES:
 							break;
 						}
 					} else {
@@ -1796,18 +1797,17 @@ void CheckInvCut(int pnum, int mx, int my, bool automaticMove)
 						case PC_BARBARIAN:
 							PlaySFX(PS_WARR37, false);
 							break;
-
 						case PC_ROGUE:
 						case PC_BARD:
 							PlaySFX(PS_ROGUE37, false);
 							break;
-
 						case PC_SORCERER:
 							PlaySFX(PS_MAGE37, false);
 							break;
-
 						case PC_MONK:
 							PlaySFX(PS_MONK37, false);
+							break;
+						case NUM_CLASSES:
 							break;
 						}
 					}

--- a/Source/itemdat.h
+++ b/Source/itemdat.h
@@ -182,7 +182,6 @@ typedef enum item_type {
 	ITYPE_GOLD,
 	ITYPE_RING,
 	ITYPE_AMULET,
-	ITYPE_FOOD, /* used in demo */
 	ITYPE_NONE = -1,
 } item_type;
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2535,8 +2535,6 @@ int RndUItem(int m)
 			okflag = FALSE;
 		if (AllItemsList[i].itype == ITYPE_GOLD)
 			okflag = FALSE;
-		if (AllItemsList[i].itype == ITYPE_FOOD)
-			okflag = FALSE;
 		if (AllItemsList[i].iMiscId == IMISC_BOOK)
 			okflag = TRUE;
 		if (AllItemsList[i].iSpell == SPL_RESURRECT && !gbIsMultiplayer)
@@ -4443,8 +4441,6 @@ BOOL SmithItemOk(int i)
 		rv = FALSE;
 	if (AllItemsList[i].itype == ITYPE_GOLD)
 		rv = FALSE;
-	if (AllItemsList[i].itype == ITYPE_FOOD)
-		rv = FALSE;
 	if (AllItemsList[i].itype == ITYPE_STAFF && (!gbIsHellfire || AllItemsList[i].iSpell))
 		rv = FALSE;
 	if (AllItemsList[i].itype == ITYPE_RING)
@@ -4557,8 +4553,6 @@ BOOL PremiumItemOk(int i)
 	if (AllItemsList[i].itype == ITYPE_MISC)
 		rv = FALSE;
 	if (AllItemsList[i].itype == ITYPE_GOLD)
-		rv = FALSE;
-	if (AllItemsList[i].itype == ITYPE_FOOD)
 		rv = FALSE;
 	if (!gbIsHellfire && AllItemsList[i].itype == ITYPE_STAFF)
 		rv = FALSE;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4602,28 +4602,22 @@ int RndPremiumItem(int minlvl, int maxlvl)
 
 static void SpawnOnePremium(int i, int plvl, int myplr)
 {
-	int itype;
-	ItemStruct holditem;
-
-	holditem = item[0];
-
 	int ivalue;
-	int count = 0;
+	ItemStruct holditem = item[0];
 
 	int strength = get_max_strength(plr[myplr]._pClass);
-	int dexterity = get_max_dexterity(plr[myplr]._pClass);
-	int magic = get_max_magic(plr[myplr]._pClass);
-
 	if (strength < plr[myplr]._pStrength) {
 		strength = plr[myplr]._pStrength;
 	}
 	strength *= 1.2;
 
+	int dexterity = get_max_dexterity(plr[myplr]._pClass);
 	if (dexterity < plr[myplr]._pDexterity) {
 		dexterity = plr[myplr]._pDexterity;
 	}
 	dexterity *= 1.2;
 
+	int magic = get_max_magic(plr[myplr]._pClass);
 	if (magic < plr[myplr]._pMagic) {
 		magic = plr[myplr]._pMagic;
 	}
@@ -4634,11 +4628,13 @@ static void SpawnOnePremium(int i, int plvl, int myplr)
 	if (plvl < 1)
 		plvl = 1;
 
+	int count = 0;
+
 	do {
 		memset(&item[0], 0, sizeof(*item));
 		item[0]._iSeed = AdvanceRndSeed();
 		SetRndSeed(item[0]._iSeed);
-		itype = RndPremiumItem(plvl >> 2, plvl) - 1;
+		int itype = RndPremiumItem(plvl >> 2, plvl) - 1;
 		GetItemAttrs(0, itype, plvl);
 		GetItemBonus(0, itype, plvl >> 1, plvl, TRUE, !gbIsHellfire);
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1451,6 +1451,8 @@ void CreatePlrItems(int p)
 		SetPlrHandItem(&plr[p].SpdList[1], IDI_HEAL);
 		GetPlrHandSeed(&plr[p].SpdList[1]);
 		break;
+	case NUM_CLASSES:
+		break;
 	}
 
 	SetPlrHandItem(&plr[p].HoldItem, IDI_GOLD);
@@ -2405,39 +2407,41 @@ void GetItemPower(int i, int minlvl, int maxlvl, int flgs, BOOL onlygood)
 
 void GetItemBonus(int i, int idata, int minlvl, int maxlvl, BOOL onlygood, BOOLEAN allowspells)
 {
-	if (item[i]._iClass != ICLASS_GOLD) {
-		if (minlvl > 25)
-			minlvl = 25;
+	if (minlvl > 25)
+		minlvl = 25;
 
-		switch (item[i]._itype) {
-		case ITYPE_SWORD:
-		case ITYPE_AXE:
-		case ITYPE_MACE:
-			GetItemPower(i, minlvl, maxlvl, PLT_WEAP, onlygood);
-			break;
-		case ITYPE_BOW:
-			GetItemPower(i, minlvl, maxlvl, PLT_BOW, onlygood);
-			break;
-		case ITYPE_SHIELD:
-			GetItemPower(i, minlvl, maxlvl, PLT_SHLD, onlygood);
-			break;
-		case ITYPE_LARMOR:
-		case ITYPE_HELM:
-		case ITYPE_MARMOR:
-		case ITYPE_HARMOR:
-			GetItemPower(i, minlvl, maxlvl, PLT_ARMO, onlygood);
-			break;
-		case ITYPE_STAFF:
-			if (allowspells)
-				GetStaffSpell(i, maxlvl, onlygood);
-			else
-				GetItemPower(i, minlvl, maxlvl, PLT_STAFF, onlygood);
-			break;
-		case ITYPE_RING:
-		case ITYPE_AMULET:
-			GetItemPower(i, minlvl, maxlvl, PLT_MISC, onlygood);
-			break;
-		}
+	switch (item[i]._itype) {
+	case ITYPE_SWORD:
+	case ITYPE_AXE:
+	case ITYPE_MACE:
+		GetItemPower(i, minlvl, maxlvl, PLT_WEAP, onlygood);
+		break;
+	case ITYPE_BOW:
+		GetItemPower(i, minlvl, maxlvl, PLT_BOW, onlygood);
+		break;
+	case ITYPE_SHIELD:
+		GetItemPower(i, minlvl, maxlvl, PLT_SHLD, onlygood);
+		break;
+	case ITYPE_LARMOR:
+	case ITYPE_HELM:
+	case ITYPE_MARMOR:
+	case ITYPE_HARMOR:
+		GetItemPower(i, minlvl, maxlvl, PLT_ARMO, onlygood);
+		break;
+	case ITYPE_STAFF:
+		if (allowspells)
+			GetStaffSpell(i, maxlvl, onlygood);
+		else
+			GetItemPower(i, minlvl, maxlvl, PLT_STAFF, onlygood);
+		break;
+	case ITYPE_RING:
+	case ITYPE_AMULET:
+		GetItemPower(i, minlvl, maxlvl, PLT_MISC, onlygood);
+		break;
+	case ITYPE_NONE:
+	case ITYPE_MISC:
+	case ITYPE_GOLD:
+		break;
 	}
 }
 
@@ -3417,6 +3421,8 @@ static BOOL OilItem(ItemStruct *x, PlayerStruct *p)
 			return FALSE;
 		}
 		break;
+	default:
+		break;
 	}
 
 	switch (p->_pOilType) {
@@ -3497,6 +3503,8 @@ static BOOL OilItem(ItemStruct *x, PlayerStruct *p)
 			x->_iAC += random_(68, 3) + 3;
 		}
 		break;
+	default:
+		return FALSE;
 	}
 	return TRUE;
 }
@@ -5035,6 +5043,8 @@ void SpawnBoy(int lvl)
 				case PC_BARBARIAN:
 					if (itemType == ITYPE_BOW || itemType == ITYPE_STAFF)
 						ivalue = INT_MAX;
+					break;
+				case NUM_CLASSES:
 					break;
 				}
 			}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -689,7 +689,7 @@ void CalcPlrItemVals(int p, BOOL Loadgfx)
 	int dadd = 0; // added dexterity
 	int vadd = 0; // added vitality
 
-	unsigned __int64 spl = 0; // bitarray for all enabled/active spells
+	Uint64 spl = 0; // bitarray for all enabled/active spells
 
 	int fr = 0; // fire resistance
 	int lr = 0; // lightning resistance
@@ -720,7 +720,7 @@ void CalcPlrItemVals(int p, BOOL Loadgfx)
 			tac += itm->_iAC;
 
 			if (itm->_iSpell != SPL_NULL) {
-				spl |= SPELLBIT(itm->_iSpell);
+				spl |= GetSpellBitmask(itm->_iSpell);
 			}
 
 			if (itm->_iMagical == ITEM_QUALITY_NORMAL || itm->_iIdentified) {
@@ -1093,14 +1093,14 @@ void CalcPlrScrolls(int p)
 	for (i = 0; i < plr[p]._pNumInv; i++) {
 		if (!plr[p].InvList[i].isEmpty() && (plr[p].InvList[i]._iMiscId == IMISC_SCROLL || plr[p].InvList[i]._iMiscId == IMISC_SCROLLT)) {
 			if (plr[p].InvList[i]._iStatFlag)
-				plr[p]._pScrlSpells |= SPELLBIT(plr[p].InvList[i]._iSpell);
+				plr[p]._pScrlSpells |= GetSpellBitmask(plr[p].InvList[i]._iSpell);
 		}
 	}
 
 	for (j = 0; j < MAXBELTITEMS; j++) {
 		if (!plr[p].SpdList[j].isEmpty() && (plr[p].SpdList[j]._iMiscId == IMISC_SCROLL || plr[p].SpdList[j]._iMiscId == IMISC_SCROLLT)) {
 			if (plr[p].SpdList[j]._iStatFlag)
-				plr[p]._pScrlSpells |= SPELLBIT(plr[p].SpdList[j]._iSpell);
+				plr[p]._pScrlSpells |= GetSpellBitmask(plr[p].SpdList[j]._iSpell);
 		}
 	}
 	EnsureValidReadiedSpell(plr[p]);
@@ -1112,7 +1112,7 @@ void CalcPlrStaff(int p)
 	if (!plr[p].InvBody[INVLOC_HAND_LEFT].isEmpty()
 	    && plr[p].InvBody[INVLOC_HAND_LEFT]._iStatFlag
 	    && plr[p].InvBody[INVLOC_HAND_LEFT]._iCharges > 0) {
-		plr[p]._pISpells |= SPELLBIT(plr[p].InvBody[INVLOC_HAND_LEFT]._iSpell);
+		plr[p]._pISpells |= GetSpellBitmask(plr[p].InvBody[INVLOC_HAND_LEFT]._iSpell);
 	}
 }
 
@@ -4338,7 +4338,7 @@ void UseItem(int p, item_misc_id Mid, spell_id spl)
 		}
 		break;
 	case IMISC_BOOK:
-		plr[p]._pMemSpells |= SPELLBIT(spl);
+		plr[p]._pMemSpells |= GetSpellBitmask(spl);
 		if (plr[p]._pSplLvl[spl] < MAX_SPELL_LEVEL)
 			plr[p]._pSplLvl[spl]++;
 		if (!(plr[p]._pIFlags & ISPL_NOMANA)) {

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -4262,43 +4262,34 @@ void MI_Search(Sint32 i)
 
 void MI_LightningWallC(Sint32 i)
 {
-	int src, lvl, dmg, tx, ty, dp;
-
 	missile[i]._mirange--;
-	src = missile[i]._misource;
-	if (src > 0)
-		lvl = plr[src]._pLevel;
-	else
-		lvl = 0;
-	dmg = 16 * (random_(53, 10) + random_(53, 10) + lvl + 2);
+	int id = missile[i]._misource;
+	int lvl = 0;
+	if (id > 0)
+		lvl = plr[id]._pLevel;
+	int dmg = 16 * (random_(53, 10) + random_(53, 10) + lvl + 2);
 	if (missile[i]._mirange == 0) {
 		missile[i]._miDelFlag = TRUE;
 	} else {
-		dp = dPiece[missile[i]._miVar1][missile[i]._miVar2];
-		if (dp || 1) {
-			tx = missile[i]._miVar1 + XDirAdd[missile[i]._miVar3];
-			ty = missile[i]._miVar2 + YDirAdd[missile[i]._miVar3];
-			if (!nMissileTable[dp] && !missile[i]._miVar8 && tx > 0 && tx < MAXDUNX && ty > 0 && ty < MAXDUNY) {
-				AddMissile(missile[i]._miVar1, missile[i]._miVar2, missile[i]._miVar1, missile[i]._miVar2, plr[src]._pdir, MIS_LIGHTWALL, TARGET_BOTH, src, dmg, missile[i]._mispllvl);
-				missile[i]._miVar1 = tx;
-				missile[i]._miVar2 = ty;
-			} else {
-				missile[i]._miVar8 = 1;
-			}
+		int dp = dPiece[missile[i]._miVar1][missile[i]._miVar2];
+		assert(dp <= MAXTILES && dp >= 0);
+		int tx = missile[i]._miVar1 + XDirAdd[missile[i]._miVar3];
+		int ty = missile[i]._miVar2 + YDirAdd[missile[i]._miVar3];
+		if (!nMissileTable[dp] && missile[i]._miVar8 == 0 && tx > 0 && tx < MAXDUNX && ty > 0 && ty < MAXDUNY) {
+			AddMissile(missile[i]._miVar1, missile[i]._miVar2, missile[i]._miVar1, missile[i]._miVar2, plr[id]._pdir, MIS_LIGHTWALL, TARGET_BOTH, id, dmg, missile[i]._mispllvl);
+			missile[i]._miVar1 = tx;
+			missile[i]._miVar2 = ty;
 		} else {
 			missile[i]._miVar8 = 1;
 		}
 		dp = dPiece[missile[i]._miVar5][missile[i]._miVar6];
-		if (dp || 1) {
-			tx = missile[i]._miVar5 + XDirAdd[missile[i]._miVar4];
-			ty = missile[i]._miVar6 + YDirAdd[missile[i]._miVar4];
-			if (!nMissileTable[dp] && !missile[i]._miVar7 && tx > 0 && tx < MAXDUNX && ty > 0 && ty < MAXDUNY) {
-				AddMissile(missile[i]._miVar5, missile[i]._miVar6, missile[i]._miVar5, missile[i]._miVar6, plr[src]._pdir, MIS_LIGHTWALL, TARGET_BOTH, src, dmg, missile[i]._mispllvl);
-				missile[i]._miVar5 = tx;
-				missile[i]._miVar6 = ty;
-			} else {
-				missile[i]._miVar7 = 1;
-			}
+		assert(dp <= MAXTILES && dp >= 0);
+		tx = missile[i]._miVar5 + XDirAdd[missile[i]._miVar4];
+		ty = missile[i]._miVar6 + YDirAdd[missile[i]._miVar4];
+		if (!nMissileTable[dp] && missile[i]._miVar7 == 0 && tx > 0 && tx < MAXDUNX && ty > 0 && ty < MAXDUNY) {
+			AddMissile(missile[i]._miVar5, missile[i]._miVar6, missile[i]._miVar5, missile[i]._miVar6, plr[id]._pdir, MIS_LIGHTWALL, TARGET_BOTH, id, dmg, missile[i]._mispllvl);
+			missile[i]._miVar5 = tx;
+			missile[i]._miVar6 = ty;
 		} else {
 			missile[i]._miVar7 = 1;
 		}
@@ -5059,17 +5050,15 @@ void MI_Fireman(Sint32 i)
 
 void MI_FirewallC(Sint32 i)
 {
-	int tx, ty, id, dp;
-
 	missile[i]._mirange--;
-	id = missile[i]._misource;
+	int id = missile[i]._misource;
 	if (missile[i]._mirange == 0) {
 		missile[i]._miDelFlag = TRUE;
 	} else {
-		dp = dPiece[missile[i]._miVar1][missile[i]._miVar2];
+		int dp = dPiece[missile[i]._miVar1][missile[i]._miVar2];
 		assert(dp <= MAXTILES && dp >= 0);
-		tx = missile[i]._miVar1 + XDirAdd[missile[i]._miVar3];
-		ty = missile[i]._miVar2 + YDirAdd[missile[i]._miVar3];
+		int tx = missile[i]._miVar1 + XDirAdd[missile[i]._miVar3];
+		int ty = missile[i]._miVar2 + YDirAdd[missile[i]._miVar3];
 		if (!nMissileTable[dp] && missile[i]._miVar8 == 0 && tx > 0 && tx < MAXDUNX && ty > 0 && ty < MAXDUNY) {
 			AddMissile(missile[i]._miVar1, missile[i]._miVar2, missile[i]._miVar1, missile[i]._miVar2, plr[id]._pdir, MIS_FIREWALL, TARGET_BOTH, id, 0, missile[i]._mispllvl);
 			missile[i]._miVar1 = tx;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1191,7 +1191,6 @@ void SetMapMonsters(BYTE *pMap, int startx, int starty)
 	}
 	lm = (WORD *)pMap;
 	rw = SDL_SwapLE16(*lm++);
-	lm;
 	rh = SDL_SwapLE16(*lm++);
 	lm += rw * rh;
 	rw = rw << 1;

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -433,7 +433,7 @@ static void multi_process_tmsgs()
 	int cnt;
 	TPkt pkt;
 
-	while (cnt = tmsg_get((BYTE *)&pkt, 512)) {
+	while ((cnt = tmsg_get((BYTE *)&pkt, 512)) != 0) {
 		multi_handle_all_packets(myplr, (BYTE *)&pkt, cnt);
 	}
 }

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2900,7 +2900,7 @@ void OperateBook(int pnum, int i)
 		return;
 
 	if (setlvlnum == SL_BONECHAMB) {
-		plr[pnum]._pMemSpells |= SPELLBIT(SPL_GUARDIAN);
+		plr[pnum]._pMemSpells |= GetSpellBitmask(SPL_GUARDIAN);
 		if (plr[pnum]._pSplLvl[SPL_GUARDIAN] < MAX_SPELL_LEVEL)
 			plr[pnum]._pSplLvl[SPL_GUARDIAN]++;
 		quests[Q_SCHAMB]._qactive = QUEST_DONE;
@@ -3338,7 +3338,6 @@ void OperateShrine(int pnum, int i, int sType)
 	DWORD lv, t;
 	int xx, yy;
 	int v1, v2, v3, v4;
-	unsigned __int64 spell, spells;
 
 	if (dropGoldFlag) {
 		dropGoldFlag = FALSE;
@@ -3566,9 +3565,9 @@ void OperateShrine(int pnum, int i, int sType)
 		if (pnum != myplr)
 			return;
 		cnt = 0;
-		spell = 1;
+		Uint64 spell = 1;
 		int maxSpells = gbIsHellfire ? MAX_SPELLS : 37;
-		spells = plr[pnum]._pMemSpells;
+		Uint64 spells = plr[pnum]._pMemSpells;
 		for (j = 0; j < maxSpells; j++) {
 			if (spell & spells)
 				cnt++;
@@ -3585,7 +3584,7 @@ void OperateShrine(int pnum, int i, int sType)
 			}
 			do {
 				r = random_(0, maxSpells);
-			} while (!(plr[pnum]._pMemSpells & SPELLBIT(r + 1)));
+			} while (!(plr[pnum]._pMemSpells & GetSpellBitmask(r + 1)));
 			if (plr[pnum]._pSplLvl[r + 1] >= 2)
 				plr[pnum]._pSplLvl[r + 1] -= 2;
 			else
@@ -3617,7 +3616,7 @@ void OperateShrine(int pnum, int i, int sType)
 			return;
 		if (pnum != myplr)
 			return;
-		plr[pnum]._pMemSpells |= SPELLBIT(SPL_FIREBOLT);
+		plr[pnum]._pMemSpells |= GetSpellBitmask(SPL_FIREBOLT);
 		if (plr[pnum]._pSplLvl[SPL_FIREBOLT] < MAX_SPELL_LEVEL)
 			plr[pnum]._pSplLvl[SPL_FIREBOLT]++;
 		if (plr[pnum]._pSplLvl[SPL_FIREBOLT] < MAX_SPELL_LEVEL)
@@ -3750,7 +3749,7 @@ void OperateShrine(int pnum, int i, int sType)
 	case SHRINE_SACRED:
 		if (deltaload || pnum != myplr)
 			return;
-		plr[pnum]._pMemSpells |= SPELLBIT(SPL_CBOLT);
+		plr[pnum]._pMemSpells |= GetSpellBitmask(SPL_CBOLT);
 		if (plr[pnum]._pSplLvl[SPL_CBOLT] < MAX_SPELL_LEVEL)
 			plr[pnum]._pSplLvl[SPL_CBOLT]++;
 		if (plr[pnum]._pSplLvl[SPL_CBOLT] < MAX_SPELL_LEVEL)
@@ -3853,7 +3852,7 @@ void OperateShrine(int pnum, int i, int sType)
 			return;
 		if (pnum != myplr)
 			return;
-		plr[pnum]._pMemSpells |= SPELLBIT(SPL_HBOLT);
+		plr[pnum]._pMemSpells |= GetSpellBitmask(SPL_HBOLT);
 		if (plr[pnum]._pSplLvl[SPL_HBOLT] < MAX_SPELL_LEVEL)
 			plr[pnum]._pSplLvl[SPL_HBOLT]++;
 		if (plr[pnum]._pSplLvl[SPL_HBOLT] < MAX_SPELL_LEVEL)
@@ -3978,10 +3977,10 @@ void OperateShrine(int pnum, int i, int sType)
 			return;
 		InitDiabloMsg(EMSG_SHRINE_GLOWING);
 		int playerXP = plr[myplr]._pExperience;
-		int xpLoss, magicGain;
+		Sint32 xpLoss, magicGain;
 		if (playerXP > 5000) {
 			magicGain = 5;
-			xpLoss = (signed __int64)((double)playerXP * 0.95);
+			xpLoss = ((double)playerXP * 0.95);
 		} else {
 			magicGain = playerXP / 1000;
 			xpLoss = 0;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3478,6 +3478,8 @@ void OperateShrine(int pnum, int i, int sType)
 			case ITYPE_HARMOR:
 				plr[pnum].InvList[j]._iAC += 2;
 				break;
+			default:
+				break;
 			}
 		}
 		InitDiabloMsg(EMSG_SHRINE_GLOOMY);
@@ -3954,6 +3956,8 @@ void OperateShrine(int pnum, int i, int sType)
 		case PC_BARD:
 			ModifyPlrDex(myplr, 1);
 			ModifyPlrMag(myplr, 1);
+			break;
+		case NUM_CLASSES:
 			break;
 		}
 		CheckStats(pnum);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2453,10 +2453,11 @@ BOOL PlrHitMonst(int pnum, int m)
 				dam += dam >> 1;
 			}
 			break;
-		}
-
-		if (plr[pnum]._pIFlags & ISPL_3XDAMVDEM && monster[m].MData->mMonstClass == MC_DEMON) {
-			dam *= 3;
+		case MC_DEMON:
+			if (plr[pnum]._pIFlags & ISPL_3XDAMVDEM) {
+				dam *= 3;
+			}
+			break;
 		}
 
 		if (plr[pnum].pDamAcFlags & 0x01 && random_(6, 100) < 5) {
@@ -3301,6 +3302,8 @@ void CheckNewPath(int pnum)
 				TalkToTowner(pnum, plr[pnum].destParam1);
 			}
 			break;
+		default:
+			break;
 		}
 
 		FixPlayerLocation(pnum, plr[pnum]._pdir);
@@ -3489,7 +3492,6 @@ static void CheckCheatStats(int pnum)
 void ProcessPlayers()
 {
 	int pnum;
-	BOOL tplayer;
 
 	if ((DWORD)myplr >= MAX_PLRS) {
 		app_fatal("ProcessPlayers: illegal player %d", myplr);
@@ -3547,7 +3549,7 @@ void ProcessPlayers()
 				}
 			}
 
-			tplayer = FALSE;
+			bool tplayer = false;
 			do {
 				switch (plr[pnum]._pmode) {
 				case PM_STAND:
@@ -3578,6 +3580,9 @@ void ProcessPlayers()
 					break;
 				case PM_NEWLVL:
 					tplayer = PM_DoNewLvl(pnum);
+					break;
+				case PM_QUIT:
+					tplayer = false;
 					break;
 				}
 				CheckNewPath(pnum);
@@ -3789,6 +3794,8 @@ void CheckPlrSpell()
 	case RSPLTYPE_CHARGES:
 		addflag = UseStaff();
 		break;
+	case RSPLTYPE_INVALID:
+		return;
 	}
 
 	if (addflag) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3491,8 +3491,6 @@ static void CheckCheatStats(int pnum)
 
 void ProcessPlayers()
 {
-	int pnum;
-
 	if ((DWORD)myplr >= MAX_PLRS) {
 		app_fatal("ProcessPlayers: illegal player %d", myplr);
 	}
@@ -3525,7 +3523,7 @@ void ProcessPlayers()
 
 	ValidatePlayer();
 
-	for (pnum = 0; pnum < MAX_PLRS; pnum++) {
+	for (int pnum = 0; pnum < MAX_PLRS; pnum++) {
 		if (plr[pnum].plractive && currlevel == plr[pnum].plrlevel && (pnum == myplr || !plr[pnum]._pLvlChanging)) {
 			CheckCheatStats(pnum);
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -749,21 +749,21 @@ void CreatePlayer(int pnum, plr_class c)
 	plr[pnum]._pInfraFlag = FALSE;
 
 	if (c == PC_WARRIOR) {
-		plr[pnum]._pAblSpells = SPELLBIT(SPL_REPAIR);
+		plr[pnum]._pAblSpells = GetSpellBitmask(SPL_REPAIR);
 	} else if (c == PC_ROGUE) {
-		plr[pnum]._pAblSpells = SPELLBIT(SPL_DISARM);
+		plr[pnum]._pAblSpells = GetSpellBitmask(SPL_DISARM);
 	} else if (c == PC_SORCERER) {
-		plr[pnum]._pAblSpells = SPELLBIT(SPL_RECHARGE);
+		plr[pnum]._pAblSpells = GetSpellBitmask(SPL_RECHARGE);
 	} else if (c == PC_MONK) {
-		plr[pnum]._pAblSpells = SPELLBIT(SPL_SEARCH);
+		plr[pnum]._pAblSpells = GetSpellBitmask(SPL_SEARCH);
 	} else if (c == PC_BARD) {
-		plr[pnum]._pAblSpells = SPELLBIT(SPL_IDENTIFY);
+		plr[pnum]._pAblSpells = GetSpellBitmask(SPL_IDENTIFY);
 	} else if (c == PC_BARBARIAN) {
-		plr[pnum]._pAblSpells = SPELLBIT(SPL_BLODBOIL);
+		plr[pnum]._pAblSpells = GetSpellBitmask(SPL_BLODBOIL);
 	}
 
 	if (c == PC_SORCERER) {
-		plr[pnum]._pMemSpells = SPELLBIT(SPL_FIREBOLT);
+		plr[pnum]._pMemSpells = GetSpellBitmask(SPL_FIREBOLT);
 	} else {
 		plr[pnum]._pMemSpells = 0;
 	}
@@ -1055,17 +1055,17 @@ void InitPlayer(int pnum, BOOL FirstTime)
 	}
 
 	if (plr[pnum]._pClass == PC_WARRIOR) {
-		plr[pnum]._pAblSpells = SPELLBIT(SPL_REPAIR);
+		plr[pnum]._pAblSpells = GetSpellBitmask(SPL_REPAIR);
 	} else if (plr[pnum]._pClass == PC_ROGUE) {
-		plr[pnum]._pAblSpells = SPELLBIT(SPL_DISARM);
+		plr[pnum]._pAblSpells = GetSpellBitmask(SPL_DISARM);
 	} else if (plr[pnum]._pClass == PC_SORCERER) {
-		plr[pnum]._pAblSpells = SPELLBIT(SPL_RECHARGE);
+		plr[pnum]._pAblSpells = GetSpellBitmask(SPL_RECHARGE);
 	} else if (plr[pnum]._pClass == PC_MONK) {
-		plr[pnum]._pAblSpells = SPELLBIT(SPL_SEARCH);
+		plr[pnum]._pAblSpells = GetSpellBitmask(SPL_SEARCH);
 	} else if (plr[pnum]._pClass == PC_BARD) {
-		plr[pnum]._pAblSpells = SPELLBIT(SPL_IDENTIFY);
+		plr[pnum]._pAblSpells = GetSpellBitmask(SPL_IDENTIFY);
 	} else if (plr[pnum]._pClass == PC_BARBARIAN) {
-		plr[pnum]._pAblSpells = SPELLBIT(SPL_BLODBOIL);
+		plr[pnum]._pAblSpells = GetSpellBitmask(SPL_BLODBOIL);
 	}
 
 #ifdef _DEBUG
@@ -3410,10 +3410,7 @@ BOOL PlrDeathModeOK(int p)
 
 void ValidatePlayer()
 {
-	__int64 msk;
 	int gt, i, b;
-
-	msk = 0;
 
 	if ((DWORD)myplr >= MAX_PLRS) {
 		app_fatal("ValidatePlayer: illegal player %d", myplr);
@@ -3450,9 +3447,10 @@ void ValidatePlayer()
 		plr[myplr]._pBaseVit = MaxStats[pc][ATTRIB_VIT];
 	}
 
+	Uint64 msk = 0;
 	for (b = 1; b < MAX_SPELLS; b++) {
 		if (GetSpellBookLevel(b) != -1) {
-			msk |= SPELLBIT(b);
+			msk |= GetSpellBitmask(b);
 			if (plr[myplr]._pSplLvl[b] > MAX_SPELL_LEVEL)
 				plr[myplr]._pSplLvl[b] = MAX_SPELL_LEVEL;
 		}

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -61,8 +61,8 @@ void SendPlrMsg(int pnum, const char *pszStr)
 	plr_msg_slot = (plr_msg_slot + 1) & (PMSG_COUNT - 1);
 	pMsg->player = pnum;
 	pMsg->time = SDL_GetTicks();
-	strlen(plr[pnum]._pName); /* these are used in debug */
-	strlen(pszStr);
+	assert(strlen(plr[pnum]._pName) < PLR_NAME_LEN);
+	assert(strlen(pszStr) < MAX_SEND_STR_LEN);
 	sprintf(pMsg->str, "%s (lvl %d): %s", plr[pnum]._pName, plr[pnum]._pLevel, pszStr);
 }
 

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -95,7 +95,7 @@ void UseMana(int id, int sn)
  * @param spellId The id of the spell to get a bitmask for.
  * @return A 64bit bitmask representation for the specified spell.
  */
-unsigned long long GetSpellBitmask(int spellId)
+Uint64 GetSpellBitmask(int spellId)
 {
 	return 1ULL << (spellId - 1);
 }

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -14,6 +14,7 @@ extern "C" {
 
 int GetManaAmount(int id, int sn);
 void UseMana(int id, int sn);
+Uint64 GetSpellBitmask(int spellId);
 BOOL CheckSpell(int id, int sn, char st, BOOL manaonly);
 void EnsureValidReadiedSpell(PlayerStruct &player);
 void CastSpell(int id, int spl, int sx, int sy, int dx, int dy, int spllvl);

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -434,8 +434,6 @@ BOOL SmithSellOk(int i)
 		return FALSE;
 	if (pI->_itype == ITYPE_GOLD)
 		return FALSE;
-	if (pI->_itype == ITYPE_FOOD)
-		return FALSE;
 	if (pI->_itype == ITYPE_STAFF && (!gbIsHellfire || pI->_iSpell != SPL_NULL))
 		return FALSE;
 	if (pI->_iClass == ICLASS_QUEST)
@@ -563,8 +561,6 @@ BOOL SmithRepairOk(int i)
 	if (plr[myplr].InvList[i]._itype == ITYPE_MISC)
 		return FALSE;
 	if (plr[myplr].InvList[i]._itype == ITYPE_GOLD)
-		return FALSE;
-	if (plr[myplr].InvList[i]._itype == ITYPE_FOOD)
 		return FALSE;
 	if (plr[myplr].InvList[i]._iDurability == plr[myplr].InvList[i]._iMaxDur)
 		return FALSE;

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -1960,6 +1960,8 @@ void S_ConfirmEnter()
 		case STORE_SPBUY:
 			SmithBuyPItem();
 			break;
+		default:
+			break;
 		}
 	}
 
@@ -2454,6 +2456,8 @@ void StartStore(talk_id s)
 	case STORE_BARMAID:
 		S_StartBarMaid();
 		break;
+	case STORE_NONE:
+		break;
 	}
 
 	stextsel = -1;
@@ -2496,6 +2500,8 @@ void DrawSText(CelOutputBuffer out)
 			break;
 		case STORE_SPBUY:
 			S_ScrollSPBuy(stextsval);
+			break;
+		default:
 			break;
 		}
 	}
@@ -2579,6 +2585,8 @@ void STextESC()
 			StartStore(stextshold);
 			stextsel = stextlhold;
 			stextsval = stextvhold;
+			break;
+		case STORE_NONE:
 			break;
 		}
 	}
@@ -2771,79 +2779,83 @@ void STextEnter()
 		qtextflag = FALSE;
 		if (leveltype == DTYPE_TOWN)
 			stream_stop();
-	} else {
-		PlaySFX(IS_TITLSLCT);
-		switch (stextflag) {
-		case STORE_SMITH:
-			S_SmithEnter();
-			break;
-		case STORE_SPBUY:
-			S_SPBuyEnter();
-			break;
-		case STORE_SBUY:
-			S_SBuyEnter();
-			break;
-		case STORE_SSELL:
-			S_SSellEnter();
-			break;
-		case STORE_SREPAIR:
-			S_SRepairEnter();
-			break;
-		case STORE_WITCH:
-			S_WitchEnter();
-			break;
-		case STORE_WBUY:
-			S_WBuyEnter();
-			break;
-		case STORE_WSELL:
-			S_WSellEnter();
-			break;
-		case STORE_WRECHARGE:
-			S_WRechargeEnter();
-			break;
-		case STORE_NOMONEY:
-		case STORE_NOROOM:
-			StartStore(stextshold);
-			stextsel = stextlhold;
-			stextsval = stextvhold;
-			break;
-		case STORE_CONFIRM:
-			S_ConfirmEnter();
-			break;
-		case STORE_BOY:
-			S_BoyEnter();
-			break;
-		case STORE_BBOY:
-			S_BBuyEnter();
-			break;
-		case STORE_HEALER:
-			S_HealerEnter();
-			break;
-		case STORE_STORY:
-			S_StoryEnter();
-			break;
-		case STORE_HBUY:
-			S_HBuyEnter();
-			break;
-		case STORE_SIDENTIFY:
-			S_SIDEnter();
-			break;
-		case STORE_GOSSIP:
-			S_TalkEnter();
-			break;
-		case STORE_IDSHOW:
-			StartStore(STORE_SIDENTIFY);
-			break;
-		case STORE_DRUNK:
-			S_DrunkEnter();
-			break;
-		case STORE_TAVERN:
-			S_TavernEnter();
-			break;
-		case STORE_BARMAID:
-			S_BarmaidEnter();
-			break;
-		}
+
+		return;
+	}
+
+	PlaySFX(IS_TITLSLCT);
+	switch (stextflag) {
+	case STORE_SMITH:
+		S_SmithEnter();
+		break;
+	case STORE_SPBUY:
+		S_SPBuyEnter();
+		break;
+	case STORE_SBUY:
+		S_SBuyEnter();
+		break;
+	case STORE_SSELL:
+		S_SSellEnter();
+		break;
+	case STORE_SREPAIR:
+		S_SRepairEnter();
+		break;
+	case STORE_WITCH:
+		S_WitchEnter();
+		break;
+	case STORE_WBUY:
+		S_WBuyEnter();
+		break;
+	case STORE_WSELL:
+		S_WSellEnter();
+		break;
+	case STORE_WRECHARGE:
+		S_WRechargeEnter();
+		break;
+	case STORE_NOMONEY:
+	case STORE_NOROOM:
+		StartStore(stextshold);
+		stextsel = stextlhold;
+		stextsval = stextvhold;
+		break;
+	case STORE_CONFIRM:
+		S_ConfirmEnter();
+		break;
+	case STORE_BOY:
+		S_BoyEnter();
+		break;
+	case STORE_BBOY:
+		S_BBuyEnter();
+		break;
+	case STORE_HEALER:
+		S_HealerEnter();
+		break;
+	case STORE_STORY:
+		S_StoryEnter();
+		break;
+	case STORE_HBUY:
+		S_HBuyEnter();
+		break;
+	case STORE_SIDENTIFY:
+		S_SIDEnter();
+		break;
+	case STORE_GOSSIP:
+		S_TalkEnter();
+		break;
+	case STORE_IDSHOW:
+		StartStore(STORE_SIDENTIFY);
+		break;
+	case STORE_DRUNK:
+		S_DrunkEnter();
+		break;
+	case STORE_TAVERN:
+		S_TavernEnter();
+		break;
+	case STORE_BARMAID:
+		S_BarmaidEnter();
+		break;
+	case STORE_NONE:
+		break;
 	}
 }
 

--- a/SourceS/miniwin.h
+++ b/SourceS/miniwin.h
@@ -14,13 +14,6 @@
 #include <string.h>
 #include <time.h>
 
-#ifndef _WIN32
-#define __int8 char
-#define __int16 short
-#define __int32 int
-#define __int64 long long __attribute__((aligned(8)))
-#endif
-
 #include "miniwin/misc.h"
 #include "storm_full.h"
 

--- a/SourceT/writehero_test.cpp
+++ b/SourceT/writehero_test.cpp
@@ -174,8 +174,8 @@ static void PackPlayerTest(PkPlayerStruct *pPack)
 	for (auto i = 0; i < MAXBELTITEMS; i++)
 		PackItemFullRejuv(pPack->SpdList+i, i);
 	for (auto i = 1; i < 37; i++) {
-		if(spelldat_vanilla[i] != -1) {
-			pPack->pMemSpells |= (__int64)1 << (i-1);
+		if (spelldat_vanilla[i] != -1) {
+			pPack->pMemSpells |= 1ULL << (i - 1);
 			pPack->pSplLvl[i] = 15;
 		}
 	}

--- a/SourceT/writehero_test.cpp
+++ b/SourceT/writehero_test.cpp
@@ -8,15 +8,17 @@
 
 using namespace dvl;
 
-int spelldat_vanilla[] = {0, 1, 1, 4, 5, -1, 3, 3, 6, -1, 7, 6, 8, 9,
-                          8, 9, -1, -1, -1, -1, 3, 11, -1, 14, -1, -1,
-                          -1, -1, -1, 8, 1, 1, -1, 2, 1, 14, 9};
+int spelldat_vanilla[] = {
+	0, 1, 1, 4, 5, -1, 3, 3, 6, -1, 7, 6, 8, 9,
+	8, 9, -1, -1, -1, -1, 3, 11, -1, 14, -1, -1,
+	-1, -1, -1, 8, 1, 1, -1, 2, 1, 14, 9
+};
 
 static void PackItemUnique(PkItemStruct *id, int idx)
 {
 	id->idx = idx;
 	id->iCreateInfo = 0x2DE;
-	id->bId = 1+2*ITEM_QUALITY_UNIQUE;
+	id->bId = 1 + 2 * ITEM_QUALITY_UNIQUE;
 	id->bDur = 40;
 	id->bMDur = 40;
 	id->bCh = 0;
@@ -28,7 +30,7 @@ static void PackItemStaff(PkItemStruct *id)
 {
 	id->idx = 150;
 	id->iCreateInfo = 0x2010;
-	id->bId = 1+2*ITEM_QUALITY_MAGIC;
+	id->bId = 1 + 2 * ITEM_QUALITY_MAGIC;
 	id->bDur = 75;
 	id->bMDur = 75;
 	id->bCh = 12;
@@ -40,7 +42,7 @@ static void PackItemBow(PkItemStruct *id)
 {
 	id->idx = 145;
 	id->iCreateInfo = 0x0814;
-	id->bId = 1+2*ITEM_QUALITY_MAGIC;
+	id->bId = 1 + 2 * ITEM_QUALITY_MAGIC;
 	id->bDur = 60;
 	id->bMDur = 60;
 	id->bCh = 0;
@@ -52,7 +54,7 @@ static void PackItemSword(PkItemStruct *id)
 {
 	id->idx = 122;
 	id->iCreateInfo = 0x081E;
-	id->bId = 1+2*ITEM_QUALITY_MAGIC;
+	id->bId = 1 + 2 * ITEM_QUALITY_MAGIC;
 	id->bDur = 60;
 	id->bMDur = 60;
 	id->bCh = 0;
@@ -64,7 +66,7 @@ static void PackItemRing1(PkItemStruct *id)
 {
 	id->idx = 153;
 	id->iCreateInfo = 0xDE;
-	id->bId = 1+2*ITEM_QUALITY_MAGIC;
+	id->bId = 1 + 2 * ITEM_QUALITY_MAGIC;
 	id->bDur = 0;
 	id->bMDur = 0;
 	id->bCh = 0;
@@ -76,7 +78,7 @@ static void PackItemRing2(PkItemStruct *id)
 {
 	id->idx = 153;
 	id->iCreateInfo = 0xDE;
-	id->bId = 1+2*ITEM_QUALITY_MAGIC;
+	id->bId = 1 + 2 * ITEM_QUALITY_MAGIC;
 	id->bDur = 0;
 	id->bMDur = 0;
 	id->bCh = 0;
@@ -88,7 +90,7 @@ static void PackItemAmulet(PkItemStruct *id)
 {
 	id->idx = 155;
 	id->iCreateInfo = 0xDE;
-	id->bId = 1+2*ITEM_QUALITY_MAGIC;
+	id->bId = 1 + 2 * ITEM_QUALITY_MAGIC;
 	id->bDur = 0;
 	id->bMDur = 0;
 	id->bCh = 0;
@@ -100,7 +102,7 @@ static void PackItemArmor(PkItemStruct *id)
 {
 	id->idx = 70;
 	id->iCreateInfo = 0xDE;
-	id->bId = 1+2*ITEM_QUALITY_MAGIC;
+	id->bId = 1 + 2 * ITEM_QUALITY_MAGIC;
 	id->bDur = 90;
 	id->bMDur = 90;
 	id->bCh = 0;
@@ -110,41 +112,41 @@ static void PackItemArmor(PkItemStruct *id)
 
 static void PackItemFullRejuv(PkItemStruct *id, int i)
 {
-	const Uint32 seeds[] = {0x7C253335, 0x3EEFBFF8, 0x76AFB1A9, 0x38EB45FE, 0x1154E197, 0x5964B644, 0x76B58BEB, 0x002A6E5A};
+	const Uint32 seeds[] = { 0x7C253335, 0x3EEFBFF8, 0x76AFB1A9, 0x38EB45FE, 0x1154E197, 0x5964B644, 0x76B58BEB, 0x002A6E5A };
 	id->idx = ItemMiscIdIdx(IMISC_FULLREJUV);
 	id->iSeed = seeds[i];
 	id->iCreateInfo = 0;
-	id->bId = 2*ITEM_QUALITY_NORMAL;
+	id->bId = 2 * ITEM_QUALITY_NORMAL;
 	id->bDur = 0;
 	id->bMDur = 0;
 	id->bCh = 0;
 	id->bMCh = 0;
 }
 
-static int PrepareInvSlot(PkPlayerStruct *pPack, int pos, int size, int start=0)
+static int PrepareInvSlot(PkPlayerStruct *pPack, int pos, int size, int start = 0)
 {
 	static char ret = 0;
-	if(start)
+	if (start)
 		ret = 0;
 	++ret;
-	if(size == 0) {
+	if (size == 0) {
 		pPack->InvGrid[pos] = ret;
-	} else if(size == 1) {
+	} else if (size == 1) {
 		pPack->InvGrid[pos] = ret;
-		pPack->InvGrid[pos-10] = -ret;
-		pPack->InvGrid[pos-20] = -ret;
-	} else if(size == 2) {
+		pPack->InvGrid[pos - 10] = -ret;
+		pPack->InvGrid[pos - 20] = -ret;
+	} else if (size == 2) {
 		pPack->InvGrid[pos] = ret;
-		pPack->InvGrid[pos+1] = -ret;
-		pPack->InvGrid[pos-10] = -ret;
-		pPack->InvGrid[pos-10+1] = -ret;
-		pPack->InvGrid[pos-20] = -ret;
-		pPack->InvGrid[pos-20+1] = -ret;
-	} else if(size == 3) {
+		pPack->InvGrid[pos + 1] = -ret;
+		pPack->InvGrid[pos - 10] = -ret;
+		pPack->InvGrid[pos - 10 + 1] = -ret;
+		pPack->InvGrid[pos - 20] = -ret;
+		pPack->InvGrid[pos - 20 + 1] = -ret;
+	} else if (size == 3) {
 		pPack->InvGrid[pos] = ret;
-		pPack->InvGrid[pos+1] = -ret;
-		pPack->InvGrid[pos-10] = -ret;
-		pPack->InvGrid[pos-10+1] = -ret;
+		pPack->InvGrid[pos + 1] = -ret;
+		pPack->InvGrid[pos - 10] = -ret;
+		pPack->InvGrid[pos - 10 + 1] = -ret;
 	} else {
 		abort();
 	}
@@ -172,7 +174,7 @@ static void PackPlayerTest(PkPlayerStruct *pPack)
 	for (auto i = 0; i < 7; i++)
 		pPack->InvBody[i].idx = -1;
 	for (auto i = 0; i < MAXBELTITEMS; i++)
-		PackItemFullRejuv(pPack->SpdList+i, i);
+		PackItemFullRejuv(pPack->SpdList + i, i);
 	for (auto i = 1; i < 37; i++) {
 		if (spelldat_vanilla[i] != -1) {
 			pPack->pMemSpells |= 1ULL << (i - 1);
@@ -187,25 +189,26 @@ static void PackPlayerTest(PkPlayerStruct *pPack)
 	pPack->pBaseMag = 15 + 55;
 	pPack->pBaseDex = 30 + 220;
 	pPack->pBaseVit = 20 + 60;
-	pPack->pHPBase = ((20+10)<<6)+((20+10)<<5) + 48*128 + (60<<6);
+	pPack->pHPBase = ((20 + 10) << 6) + ((20 + 10) << 5) + 48 * 128 + (60 << 6);
 	pPack->pMaxHPBase = pPack->pHPBase;
-	pPack->pManaBase = (15<<6)+(15<<5) + 48*128 + (55<<6);
+	pPack->pManaBase = (15 << 6) + (15 << 5) + 48 * 128 + (55 << 6);
 	pPack->pMaxManaBase = pPack->pManaBase;
 
-	PackItemUnique(pPack->InvBody+INVLOC_HEAD, 52);
-	PackItemRing1(pPack->InvBody+INVLOC_RING_LEFT);
-	PackItemRing2(pPack->InvBody+INVLOC_RING_RIGHT);
-	PackItemAmulet(pPack->InvBody+INVLOC_AMULET);
-	PackItemArmor(pPack->InvBody+INVLOC_CHEST);
-	PackItemBow(pPack->InvBody+INVLOC_HAND_LEFT);
+	PackItemUnique(pPack->InvBody + INVLOC_HEAD, 52);
+	PackItemRing1(pPack->InvBody + INVLOC_RING_LEFT);
+	PackItemRing2(pPack->InvBody + INVLOC_RING_RIGHT);
+	PackItemAmulet(pPack->InvBody + INVLOC_AMULET);
+	PackItemArmor(pPack->InvBody + INVLOC_CHEST);
+	PackItemBow(pPack->InvBody + INVLOC_HAND_LEFT);
 
-	PackItemStaff(pPack->InvList+PrepareInvSlot(pPack, 28, 2, 1));
-	PackItemSword(pPack->InvList+PrepareInvSlot(pPack, 20, 1));
+	PackItemStaff(pPack->InvList + PrepareInvSlot(pPack, 28, 2, 1));
+	PackItemSword(pPack->InvList + PrepareInvSlot(pPack, 20, 1));
 
 	pPack->_pNumInv = 2;
 }
 
-TEST(Writehero, pfile_write_hero) {
+TEST(Writehero, pfile_write_hero)
+{
 	SetPrefPath(".");
 	std::remove("multi_0.sv");
 
@@ -215,7 +218,7 @@ TEST(Writehero, pfile_write_hero) {
 	gbIsHellfireSaveGame = false;
 
 	myplr = 0;
-	_uiheroinfo info{};
+	_uiheroinfo info {};
 	strcpy(info.name, "TestPlayer");
 	info.heroclass = PC_ROGUE;
 	pfile_ui_save_create(&info);
@@ -228,5 +231,5 @@ TEST(Writehero, pfile_write_hero) {
 	std::vector<unsigned char> s(picosha2::k_digest_size);
 	picosha2::hash256(f, s.begin(), s.end());
 	EXPECT_EQ(picosha2::bytes_to_hex_string(s.begin(), s.end()),
-	          "08e9807d1281e4273268f4e265757b4429cfec7c3e8b6deb89dfa109d6797b1c");
+	    "08e9807d1281e4273268f4e265757b4429cfec7c3e8b6deb89dfa109d6797b1c");
 }

--- a/SourceX/qol.cpp
+++ b/SourceX/qol.cpp
@@ -157,14 +157,14 @@ void DrawXPBar(CelOutputBuffer out)
 	if (charLevel == MAXCHARLEVEL - 1)
 		return;
 
-	int curXp = ExpLvlsTbl[charLevel];
 	int prevXp = ExpLvlsTbl[charLevel - 1];
-	int prevXpDelta = curXp - prevXp;
-	int prevXpDelta_1 = plr[myplr]._pExperience - prevXp;
 	if (plr[myplr]._pExperience < prevXp)
 		return;
 
-	int visibleBar = barWidth * (unsigned __int64)prevXpDelta_1 / prevXpDelta;
+	Uint64 prevXpDelta_1 = plr[myplr]._pExperience - prevXp;
+	int prevXpDelta = ExpLvlsTbl[charLevel] - prevXp;
+	int visibleBar = barWidth * prevXpDelta_1 / prevXpDelta;
+
 	FillRect(out, xPos, yPos, barWidth, barHeight, emptyBarColor);
 	FillRect(out, xPos, yPos + (space ? 1 : 0), visibleBar, barHeight - (space ? 2 : 0), barColor);
 	FastDrawHorizLine(out, xPos - 1, yPos - 1, barWidth + 2, frameColor);

--- a/defs.h
+++ b/defs.h
@@ -21,7 +21,6 @@
 #define MAX_LVLMTYPES			24
 #define MAX_SPELLS				52
 #define MAX_SPELL_LEVEL			15
-#define SPELLBIT(s) ((__int64)1 << (s - 1))
 
 #define MAX_CHUNKS				(MAX_LVLS + 5)
 


### PR DESCRIPTION
Fixes https://github.com/diasurgical/devilutionX/issues/1201 (except for 4 warnings about switches not covering all enum values). Sorry that this is all in one chunk, but if you ignore whitespace changes (can be done in github) then it's only 150 lines changed in total.