### PR TITLE
CMake: An option to build libsodium from source

### DIFF
--- a/3rdParty/libsodium/CMakeLists.txt
+++ b/3rdParty/libsodium/CMakeLists.txt
@@ -1,0 +1,17 @@
+if(NOT DEVILUTIONX_SYSTEM_LIBSODIUM)
+  set(SODIUM_MINIMAL ON)
+  set(SODIUM_ENABLE_BLOCKING_RANDOM OFF)
+  set(SODIUM_DISABLE_TESTS ON)
+
+  if(DEVILUTIONX_STATIC_LIBSODIUM)
+    set(BUILD_SHARED_LIBS OFF)
+  else()
+    set(BUILD_SHARED_LIBS ON)
+  endif()
+  include(FetchContent)
+  FetchContent_Declare(sodium
+      GIT_REPOSITORY https://github.com/robinlinden/libsodium-cmake.git
+      GIT_TAG a8ac4509b22b84d6c2eb7d7448f08678e4a67da6
+  )
+  FetchContent_MakeAvailable(sodium)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.13) # CMP0083 NEW
 
+include(CMakeDependentOption)
 include(CMake/out_of_tree.cmake)
 include(CMake/genex.cmake)
 
@@ -31,6 +32,10 @@ if(NIGHTLY_BUILD OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
   set(DIST ON)
   set(CPACK ON)
 endif()
+
+option(DEVILUTIONX_SYSTEM_LIBSODIUM "Use system-provided libsodium" ON)
+cmake_dependent_option(DEVILUTIONX_STATIC_LIBSODIUM "Link static libsodium" OFF
+                       "DIST OR NOT DEVILUTIONX_SYSTEM_LIBSODIUM" ON)
 
 if(NOT VERSION_NUM)
   include(CMake/git.cmake)
@@ -131,10 +136,6 @@ if(N3DS)
   include(n3ds_defs)
 endif()
 
-if(DIST)
-  set(sodium_USE_STATIC_LIBS ON)
-endif()
-
 if(PIE)
   set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 endif()
@@ -150,7 +151,12 @@ if(NOT N3DS)
 endif()
 
 if(NOT NONET)
-  find_package(sodium REQUIRED)
+  if(DEVILUTIONX_SYSTEM_LIBSODIUM)
+    set(sodium_USE_STATIC_LIBS ${DEVILUTIONX_STATIC_LIBSODIUM})
+    find_package(sodium REQUIRED)
+  else()
+    add_subdirectory(3rdParty/libsodium)
+  endif()
 endif()
 
 if(USE_SDL1)


### PR DESCRIPTION
Adds an option to build libsodium from source instead of using the system-provided one.

This is useful on systems that do not provide libsodium, or for testing changes to libsodium along with devilutionx (by specifying `-DFETCHCONTENT_SOURCE_DIR_LIBSODIUM`).

This also allows us to configure sodium to our liking when building it from source, such as `SODIUM_MINIMAL`, which reduces the x64 release binary size from 4.3 MiB to 4.1 MiB.