### PR TITLE
CMake: libsodium FetchContent CMake 3.13 compat

### DIFF
--- a/3rdParty/libsodium/CMakeLists.txt
+++ b/3rdParty/libsodium/CMakeLists.txt
@@ -1,4 +1,6 @@
 if(NOT DEVILUTIONX_SYSTEM_LIBSODIUM)
+  include(FetchContent_MakeAvailableExcludeFromAll)
+
   set(SODIUM_MINIMAL ON)
   set(SODIUM_ENABLE_BLOCKING_RANDOM OFF)
   set(SODIUM_DISABLE_TESTS ON)
@@ -13,5 +15,5 @@ if(NOT DEVILUTIONX_SYSTEM_LIBSODIUM)
       GIT_REPOSITORY https://github.com/robinlinden/libsodium-cmake.git
       GIT_TAG a8ac4509b22b84d6c2eb7d7448f08678e4a67da6
   )
-  FetchContent_MakeAvailable(sodium)
+  FetchContent_MakeAvailableExcludeFromAll(sodium)
 endif()

--- a/CMake/FetchContent_MakeAvailableExcludeFromAll.cmake
+++ b/CMake/FetchContent_MakeAvailableExcludeFromAll.cmake
@@ -1,0 +1,14 @@
+# Like `FetchContent_MakeAvailable` but passes EXCLUDE_FROM_ALL to `add_subdirectory`.
+macro(FetchContent_MakeAvailableExcludeFromAll)
+    foreach(contentName IN ITEMS ${ARGV})
+        string(TOLOWER ${contentName} contentNameLower)
+        FetchContent_GetProperties(${contentName})
+        if(NOT ${contentNameLower}_POPULATED)
+            FetchContent_Populate(${contentName})
+            if(EXISTS ${${contentNameLower}_SOURCE_DIR}/CMakeLists.txt)
+                add_subdirectory(${${contentNameLower}_SOURCE_DIR}
+                    ${${contentNameLower}_BINARY_DIR} EXCLUDE_FROM_ALL)
+            endif()
+        endif()
+    endforeach()
+endmacro()


### PR DESCRIPTION
This commit serves 2 purposes:

1. Fixes CMake 3.13 compatibility when using
  ` -DDEVILUTIONX_SYSTEM_LIBSODIUM=OFF` (fixes #1222).

2. Ensures we do not build targets that are not depended on by us,
   by passing `EXCLUDE_FROM_ALL` to `add_subdirectory`.