### PR TITLE
Handle D-Pad / Left stick in UI every frame

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -91,6 +91,10 @@ BOOL was_window_init = false;
 BOOL was_ui_init = false;
 BOOL was_snd_init = false;
 
+// Controller support:
+extern void plrctrls_every_frame();
+extern void plrctrls_after_game_logic();
+
 static void print_help_and_exit()
 {
 	printInConsole("Options:\n");
@@ -322,6 +326,7 @@ static void run_game_loop(unsigned int uMsg)
 		if (!gbRunGame)
 			break;
 		if (!nthread_has_500ms_passed()) {
+			plrctrls_every_frame();
 			ProcessInput();
 			force_redraw |= 1;
 			DrawAndBlit();
@@ -1950,9 +1955,6 @@ void LoadGameLevel(BOOL firstflag, int lvldir)
 	if (!gbIsSpawn && setlevel && setlvlnum == SL_SKELKING && quests[Q_SKELKING]._qactive == QUEST_ACTIVE)
 		PlaySFX(USFX_SKING1);
 }
-
-// Controller support:
-extern void plrctrls_after_game_logic();
 
 static void game_logic()
 {

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -274,6 +274,9 @@ static bool ProcessInput()
 	if (PauseMode == 2) {
 		return false;
 	}
+
+	plrctrls_every_frame();
+
 	if (!gbIsMultiplayer && gmenu_is_active()) {
 		force_redraw |= 1;
 		return false;
@@ -326,7 +329,6 @@ static void run_game_loop(unsigned int uMsg)
 		if (!gbRunGame)
 			break;
 		if (!nthread_has_500ms_passed()) {
-			plrctrls_every_frame();
 			ProcessInput();
 			force_redraw |= 1;
 			DrawAndBlit();

--- a/SourceX/controls/game_controls.cpp
+++ b/SourceX/controls/game_controls.cpp
@@ -309,7 +309,7 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrl_event, Gam
 
 
 	// DPad navigation is handled separately for these.
-	if (gmenu_is_active() || questlog)
+	if (gmenu_is_active() || questlog || stextflag != STORE_NONE)
 	{
 		switch (ctrl_event.button) {
 			case ControllerButton_BUTTON_DPAD_UP:

--- a/SourceX/controls/plrctrls.cpp
+++ b/SourceX/controls/plrctrls.cpp
@@ -832,6 +832,16 @@ void QuestLogMove(AxisDirection move_dir)
 		QuestlogDown();
 }
 
+void StoreMove(AxisDirection move_dir)
+{
+	static AxisDirectionRepeater repeater;
+	move_dir = repeater.Get(move_dir);
+	if (move_dir.y == AxisDirectionY_UP)
+		STextUp();
+	else if (move_dir.y == AxisDirectionY_DOWN)
+		STextDown();
+}
+
 typedef void (*HandleLeftStickOrDPadFn)(dvl::AxisDirection);
 
 HandleLeftStickOrDPadFn GetLeftStickOrDPadGameUIHandler()
@@ -846,6 +856,8 @@ HandleLeftStickOrDPadFn GetLeftStickOrDPadGameUIHandler()
 		return &SpellBookMove;
 	} else if (questlog) {
 		return &QuestLogMove;
+	} else if (stextflag != STORE_NONE) {
+		return &StoreMove;
 	}
 	return NULL;
 }

--- a/SourceX/controls/plrctrls.cpp
+++ b/SourceX/controls/plrctrls.cpp
@@ -868,9 +868,6 @@ void Movement()
 		sgbControllerActive = true;
 	}
 
-	// TODO: This should be called independently of game logic / tick rate.
-	ProcessLeftStickOrDPadGameUI();
-
 	if (GetLeftStickOrDPadGameUIHandler() == NULL) {
 		WalkInDir(move_dir);
 	}
@@ -1028,6 +1025,11 @@ void plrctrls_after_check_curs_move()
 			FindTrigger();
 		}
 	}
+}
+
+void plrctrls_every_frame()
+{
+	ProcessLeftStickOrDPadGameUI();
 }
 
 void plrctrls_after_game_logic()

--- a/SourceX/controls/plrctrls.h
+++ b/SourceX/controls/plrctrls.h
@@ -10,8 +10,12 @@ typedef enum belt_item_type {
 	BLT_MANA,
 } belt_item_type;
 
+// Runs every frame.
+// Handles menu movement.
+void plrctrls_every_frame();
+
 // Run after every game logic iteration.
-// Handles player and menu movement.
+// Handles player movement.
 void plrctrls_after_game_logic();
 
 // Runs at the end of CheckCursMove()


### PR DESCRIPTION
Previously this was handled as part of `game_logic`, reducing responsiveness and making it impossible to run where `game_logic` isn't running, e.g. stores.

Bonus: Enables D-Pad / Left stick navigation in stores because the above makes it trivial