### PR TITLE
CMake: Fix sodium static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 
 option(DEVILUTIONX_SYSTEM_LIBSODIUM "Use system-provided libsodium" ON)
 cmake_dependent_option(DEVILUTIONX_STATIC_LIBSODIUM "Link static libsodium" OFF
-                       "DIST OR NOT DEVILUTIONX_SYSTEM_LIBSODIUM" ON)
+                       "DEVILUTIONX_SYSTEM_LIBSODIUM AND NOT DIST" ON)
 
 if(NOT VERSION_NUM)
   include(CMake/git.cmake)


### PR DESCRIPTION
The 4th argument to `cmake_dependent_option` is when to enable the option, not when to disable it like I'd thought.
https://cmake.org/cmake/help/latest/module/CMakeDependentOption.html