### PR TITLE
Replace Radon with toml11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - checkout
       - run: echo deb http://deb.debian.org/debian stretch-backports main > /etc/apt/sources.list.d/debian-backports.list
       - run: echo deb http://deb.debian.org/debian stretch-backports-sloppy main >> /etc/apt/sources.list.d/debian-backports.list
-      - run: apt-get update && apt-get install -y -t 'stretch-backports*' cmake
+      - run: apt-get update && apt-get install -y -t 'stretch-backports*' cmake patch
       - run: dkp-pacman -Syu --noconfirm
       # Install cmake files (https://github.com/devkitPro/docker/issues/3)
       - run: dkp-pacman -S --needed --noconfirm --quiet devkitpro-pkgbuild-helpers
@@ -127,7 +127,7 @@ jobs:
       - checkout
       - run: echo deb http://deb.debian.org/debian stretch-backports main > /etc/apt/sources.list.d/debian-backports.list
       - run: echo deb http://deb.debian.org/debian stretch-backports-sloppy main >> /etc/apt/sources.list.d/debian-backports.list
-      - run: apt-get update && apt-get install -y -t 'stretch-backports*' cmake unzip
+      - run: apt-get update && apt-get install -y -t 'stretch-backports*' cmake unzip patch
       - run: dkp-pacman -Syu --noconfirm
       - run: dkp-pacman -S --needed --noconfirm --quiet devkitpro-pkgbuild-helpers
       - run: wget https://github.com/Steveice10/bannertool/releases/download/1.1.0/bannertool.zip
@@ -155,7 +155,7 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run: apk --no-cache add git cmake ninja
+      - run: apk --no-cache add git cmake ninja patch
       - run: cmake -S. -Bbuild -GNinja -DCMAKE_TOOLCHAIN_FILE=${VITASDK}/share/vita.toolchain.cmake -DNIGHTLY_BUILD=ON
       - run: cmake --build build -j 2
       - store_artifacts: {path: ./build/devilutionx.vpk, destination: devilutionx.vpk}

--- a/3rdParty/toml11/0001-Allow-semicolon-comments.patch
+++ b/3rdParty/toml11/0001-Allow-semicolon-comments.patch
@@ -1,0 +1,27 @@
+From e80d508fcc2c02b3b686396fa95d841c86494f84 Mon Sep 17 00:00:00 2001
+From: Gleb Mazovetskiy <glex.spb@gmail.com>
+Date: Mon, 22 Mar 2021 00:45:09 +0000
+Subject: [PATCH] Allow semicolon comments
+
+---
+ toml/lexer.hpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/toml/lexer.hpp b/toml/lexer.hpp
+index 2eea996..2608af6 100644
+--- a/toml/lexer.hpp
++++ b/toml/lexer.hpp
+@@ -226,7 +226,9 @@ using lex_string = either<lex_ml_basic_string,   lex_basic_string,
+ 
+ // ===========================================================================
+ 
+-using lex_comment_start_symbol = character<'#'>;
++// DevilutionX patch: Also allow `;` as a comment symbol because the original
++// Diablo config file uses it.
++using lex_comment_start_symbol = either<character<'#'>, character<';'>>;
+ using lex_non_eol = either<character<'\t'>, exclude<in_range<0x00, 0x19>>>;
+ using lex_comment = sequence<lex_comment_start_symbol,
+                              repeat<lex_non_eol, unlimited>>;
+-- 
+2.27.0
+

--- a/3rdParty/toml11/0002-Allow-whitespace-in-simple-keys.patch
+++ b/3rdParty/toml11/0002-Allow-whitespace-in-simple-keys.patch
@@ -1,0 +1,26 @@
+From 6bd3a11a21f3ae46b974a7a185f1747c986591e4 Mon Sep 17 00:00:00 2001
+From: Gleb Mazovetskiy <glex.spb@gmail.com>
+Date: Mon, 22 Mar 2021 19:20:21 +0000
+Subject: [PATCH] Allow whitespace in simple keys
+
+---
+ toml/lexer.hpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/toml/lexer.hpp b/toml/lexer.hpp
+index 2eea996..b8eb286 100644
+--- a/toml/lexer.hpp
++++ b/toml/lexer.hpp
+@@ -234,7 +234,8 @@ using lex_comment = sequence<lex_comment_start_symbol,
+ using lex_dot_sep = sequence<maybe<lex_ws>, character<'.'>, maybe<lex_ws>>;
+ 
+ using lex_unquoted_key = repeat<either<lex_alpha, lex_digit,
+-                                       character<'-'>, character<'_'>>,
++                                       character<'-'>, character<'_'>,
++                                       character<' '>>,
+                                 at_least<1>>;
+ using lex_quoted_key = either<lex_basic_string, lex_literal_string>;
+ using lex_simple_key = either<lex_unquoted_key, lex_quoted_key>;
+-- 
+2.27.0
+

--- a/3rdParty/toml11/CMakeLists.txt
+++ b/3rdParty/toml11/CMakeLists.txt
@@ -1,0 +1,9 @@
+include(FetchContent_MakeAvailableExcludeFromAll)
+
+include(FetchContent)
+FetchContent_Declare(toml11
+    URL https://github.com/ToruNiina/toml11/archive/7782258e68a66a34531942ec89020d174a122787.zip
+    URL_HASH MD5=428df6845c7c084d9c5257a39844e6b7
+    PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_LIST_DIR}/0001-Allow-semicolon-comments.patch
+)
+FetchContent_MakeAvailableExcludeFromAll(toml11)

--- a/3rdParty/toml11/CMakeLists.txt
+++ b/3rdParty/toml11/CMakeLists.txt
@@ -4,6 +4,8 @@ include(FetchContent)
 FetchContent_Declare(toml11
     URL https://github.com/ToruNiina/toml11/archive/7782258e68a66a34531942ec89020d174a122787.zip
     URL_HASH MD5=428df6845c7c084d9c5257a39844e6b7
-    PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_LIST_DIR}/0001-Allow-semicolon-comments.patch
+    PATCH_COMMAND
+      COMMAND patch -p1 < ${CMAKE_CURRENT_LIST_DIR}/0001-Allow-semicolon-comments.patch
+      COMMAND patch -p1 < ${CMAKE_CURRENT_LIST_DIR}/0002-Allow-whitespace-in-simple-keys.patch
 )
 FetchContent_MakeAvailableExcludeFromAll(toml11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,7 +456,7 @@ target_link_libraries(${BIN_TARGET} PRIVATE
   PKWare
   StormLib
   smacker
-  Radon)
+  toml11::toml11)
 
 if(NOT NONET)
   target_link_libraries(${BIN_TARGET} PRIVATE sodium)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ if(NIGHTLY_BUILD OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
   set(CPACK ON)
 endif()
 
+option(DEVILUTIONX_SYSTEM_TOML11 "Use system-provided toml11" OFF)
+
 option(DEVILUTIONX_SYSTEM_LIBSODIUM "Use system-provided libsodium" ON)
 cmake_dependent_option(DEVILUTIONX_STATIC_LIBSODIUM "Link static libsodium" OFF
                        "DEVILUTIONX_SYSTEM_LIBSODIUM AND NOT DIST" ON)
@@ -149,6 +151,12 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 if(NOT N3DS)
   find_package(Threads REQUIRED)
+endif()
+
+if(DEVILUTIONX_SYSTEM_TOML11)
+  find_package(toml11 REQUIRED)
+else()
+  add_subdirectory(3rdParty/toml11)
 endif()
 
 if(NOT NONET)


### PR DESCRIPTION
This replaces Radon with toml11.

We patch toml11 to:

1. Allow `;` as a comment character (in addition to `#`).
2. Allow spaces in keys.


Currently failing because the IP address keys are unquoted:

```console
$ build/devilutionx
terminate called after throwing an instance of 'toml::syntax_error'
  what():  [error] toml::parse_table: invalid line format
 --> /home/gleb/.local/share/diasurgical/devilution/diablo.ini
   |
 8 | Entry1=0.0.0.0
   |           ^--- expected newline, but got '.'.
```

See #1239. /cc @julealgon