### PR TITLE
storm_sdl_rw: Zero rwops after allocating

### DIFF
--- a/SourceX/storm_sdl_rw.cpp
+++ b/SourceX/storm_sdl_rw.cpp
@@ -1,5 +1,7 @@
 #include "storm_sdl_rw.h"
 
+#include <cstring>
+
 #include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include "../Source/engine.h"
@@ -75,6 +77,7 @@ static int SFileRw_close(struct SDL_RWops *context)
 SDL_RWops *SFileRw_FromStormHandle(HANDLE handle)
 {
 	SDL_RWops *result = (SDL_RWops *)DiabloAllocPtr(sizeof(SDL_RWops));
+	std::memset(result, 0, sizeof(*result));
 
 #ifndef USE_SDL1
 	result->size = &SFileRw_size;


### PR DESCRIPTION
Should really be using `calloc` but there is too many layers to these allocation wrappers.

This shouldn't make any difference but is good practice, e.g. if a field is added in a future version of SDL