### PR TITLE
Self-saving/self-loading options mechanism

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,7 @@ add_library(devilution STATIC
   Source/nthread.cpp
   Source/objdat.cpp
   Source/objects.cpp
+  Source/options.cpp
   Source/pack.cpp
   Source/palette.cpp
   Source/path.cpp

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -407,7 +407,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
-	setIniInt("Game", "Theo Quest", sgOptions.Gameplay.bTheoQuest);
 	setIniInt("Game", "Cow Quest", sgOptions.Gameplay.bCowQuest);
 	setIniInt("Game", "Friendly Fire", sgOptions.Gameplay.bFriendlyFire);
 	setIniInt("Game", "Test Bard", sgOptions.Gameplay.bTestBard);
@@ -448,7 +447,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
-	sgOptions.Gameplay.bTheoQuest = getIniBool("Game", "Theo Quest", false);
 	sgOptions.Gameplay.bCowQuest = getIniBool("Game", "Cow Quest", false);
 	sgOptions.Gameplay.bFriendlyFire = getIniBool("Game", "Friendly Fire", true);
 	sgOptions.Gameplay.bTestBard = getIniBool("Game", "Test Bard", false);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -407,7 +407,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
-	setIniInt("Game", "Cow Quest", sgOptions.Gameplay.bCowQuest);
 	setIniInt("Game", "Friendly Fire", sgOptions.Gameplay.bFriendlyFire);
 	setIniInt("Game", "Test Bard", sgOptions.Gameplay.bTestBard);
 	setIniInt("Game", "Test Barbarian", sgOptions.Gameplay.bTestBarbarian);
@@ -447,7 +446,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
-	sgOptions.Gameplay.bCowQuest = getIniBool("Game", "Cow Quest", false);
 	sgOptions.Gameplay.bFriendlyFire = getIniBool("Game", "Friendly Fire", true);
 	sgOptions.Gameplay.bTestBard = getIniBool("Game", "Test Bard", false);
 	sgOptions.Gameplay.bTestBarbarian = getIniBool("Game", "Test Barbarian", false);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -403,7 +403,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Width", sgOptions.Graphics.nWidth);
 	setIniInt("Graphics", "Height", sgOptions.Graphics.nHeight);
 #endif
-	setIniInt("Graphics", "Fullscreen", sgOptions.Graphics.bFullscreen);
 #ifndef __vita__
 	setIniInt("Graphics", "Upscale", sgOptions.Graphics.bUpscale);
 #endif
@@ -456,7 +455,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nWidth = DEFAULT_WIDTH;
 	sgOptions.Graphics.nHeight = DEFAULT_HEIGHT;
 #endif
-	sgOptions.Graphics.bFullscreen = getIniBool("Graphics", "Fullscreen", true);
 #if !defined(USE_SDL1) && !defined(__vita__)
 	sgOptions.Graphics.bUpscale = getIniBool("Graphics", "Upscale", true);
 #else

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -407,7 +407,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
-	setIniInt("Game", "Adria Refills Mana", sgOptions.Gameplay.bAdriaRefillsMana);
 	setIniInt("Game", "Auto Equip Weapons", sgOptions.Gameplay.bAutoEquipWeapons);
 	setIniInt("Game", "Auto Equip Armor", sgOptions.Gameplay.bAutoEquipArmor);
 	setIniInt("Game", "Auto Equip Helms", sgOptions.Gameplay.bAutoEquipHelms);
@@ -440,7 +439,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
-	sgOptions.Gameplay.bAdriaRefillsMana = getIniBool("Game", "Adria Refills Mana", false);
 	sgOptions.Gameplay.bAutoEquipWeapons = getIniBool("Game", "Auto Equip Weapons", true);
 	sgOptions.Gameplay.bAutoEquipArmor = getIniBool("Game", "Auto Equip Armor", false);
 	sgOptions.Gameplay.bAutoEquipHelms = getIniBool("Game", "Auto Equip Helms", false);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -407,7 +407,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
-	setIniInt("Game", "Friendly Fire", sgOptions.Gameplay.bFriendlyFire);
 	setIniInt("Game", "Test Bard", sgOptions.Gameplay.bTestBard);
 	setIniInt("Game", "Test Barbarian", sgOptions.Gameplay.bTestBarbarian);
 	setIniInt("Game", "Experience Bar", sgOptions.Gameplay.bExperienceBar);
@@ -446,7 +445,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
-	sgOptions.Gameplay.bFriendlyFire = getIniBool("Game", "Friendly Fire", true);
 	sgOptions.Gameplay.bTestBard = getIniBool("Game", "Test Bard", false);
 	sgOptions.Gameplay.bTestBarbarian = getIniBool("Game", "Test Barbarian", false);
 	sgOptions.Gameplay.bExperienceBar = getIniBool("Game", "Experience Bar", false);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -6,6 +6,7 @@
 #include "all.h"
 #include "paths.h"
 #include "console.h"
+#include "options.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include "../DiabloUI/diabloui.h"
 #include <config.h>

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -407,7 +407,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
-	setIniInt("Game", "Experience Bar", sgOptions.Gameplay.bExperienceBar);
 	setIniInt("Game", "Enemy Health Bar", sgOptions.Gameplay.bEnemyHealthBar);
 	setIniInt("Game", "Auto Gold Pickup", sgOptions.Gameplay.bAutoGoldPickup);
 	setIniInt("Game", "Adria Refills Mana", sgOptions.Gameplay.bAdriaRefillsMana);
@@ -443,7 +442,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
-	sgOptions.Gameplay.bExperienceBar = getIniBool("Game", "Experience Bar", false);
 	sgOptions.Gameplay.bEnemyHealthBar = getIniBool("Game", "Enemy Health Bar", false);
 	sgOptions.Gameplay.bAutoGoldPickup = getIniBool("Game", "Auto Gold Pickup", false);
 	sgOptions.Gameplay.bAdriaRefillsMana = getIniBool("Game", "Adria Refills Mana", false);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -398,7 +398,6 @@ static void SaveOptions()
 {
 	setIniInt("Audio", "Sound Volume", sgOptions.Audio.nSoundVolume);
 	setIniInt("Audio", "Music Volume", sgOptions.Audio.nMusicVolume);
-	setIniInt("Audio", "Auto Equip Sound", sgOptions.Audio.bAutoEquipSound);
 
 #ifndef __vita__
 	setIniInt("Graphics", "Width", sgOptions.Graphics.nWidth);
@@ -449,7 +448,6 @@ static void LoadOptions()
 {
 	sgOptions.Audio.nSoundVolume = getIniInt("Audio", "Sound Volume", VOLUME_MAX);
 	sgOptions.Audio.nMusicVolume = getIniInt("Audio", "Music Volume", VOLUME_MAX);
-	sgOptions.Audio.bAutoEquipSound = getIniBool("Audio", "Auto Equip Sound", false);
 
 #ifndef __vita__
 	sgOptions.Graphics.nWidth = getIniInt("Graphics", "Width", DEFAULT_WIDTH);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -404,7 +404,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Height", sgOptions.Graphics.nHeight);
 #endif
 	setIniValue("Graphics", "Scaling Quality", sgOptions.Graphics.szScaleQuality);
-	setIniInt("Graphics", "Integer Scaling", sgOptions.Graphics.bIntegerScaling);
 	setIniInt("Graphics", "Vertical Sync", sgOptions.Graphics.bVSync);
 	setIniInt("Graphics", "Blended Transparency", sgOptions.Graphics.bBlendedTransparancy);
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
@@ -452,7 +451,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nHeight = DEFAULT_HEIGHT;
 #endif
 	getIniValue("Graphics", "Scaling Quality", sgOptions.Graphics.szScaleQuality, sizeof(sgOptions.Graphics.szScaleQuality), "2");
-	sgOptions.Graphics.bIntegerScaling = getIniBool("Graphics", "Integer Scaling", false);
 	sgOptions.Graphics.bVSync = getIniBool("Graphics", "Vertical Sync", true);
 	sgOptions.Graphics.bBlendedTransparancy = getIniBool("Graphics", "Blended Transparency", true);
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -405,7 +405,6 @@ static void SaveOptions()
 #endif
 	setIniValue("Graphics", "Scaling Quality", sgOptions.Graphics.szScaleQuality);
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
-	setIniInt("Graphics", "Color Cycling", sgOptions.Graphics.bColorCycling);
 	setIniInt("Graphics", "FPS Limiter", sgOptions.Graphics.bFPSLimit);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
@@ -450,7 +449,6 @@ static void LoadOptions()
 #endif
 	getIniValue("Graphics", "Scaling Quality", sgOptions.Graphics.szScaleQuality, sizeof(sgOptions.Graphics.szScaleQuality), "2");
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
-	sgOptions.Graphics.bColorCycling = getIniBool("Graphics", "Color Cycling", true);
 	sgOptions.Graphics.bFPSLimit = getIniBool("Graphics", "FPS Limiter", true);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
@@ -2017,7 +2015,7 @@ void game_loop(BOOL bStartup)
 
 void diablo_color_cyc_logic()
 {
-	if (!sgOptions.Graphics.bColorCycling)
+	if (!*sgOptions.Graphics.bColorCycling)
 		return;
 
 	if (leveltype == DTYPE_HELL) {

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -407,7 +407,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
-	setIniInt("Game", "Fast Walk", sgOptions.Gameplay.bJogInTown);
 	setIniInt("Game", "Grab Input", sgOptions.Gameplay.bGrabInput);
 	setIniInt("Game", "Theo Quest", sgOptions.Gameplay.bTheoQuest);
 	setIniInt("Game", "Cow Quest", sgOptions.Gameplay.bCowQuest);
@@ -450,7 +449,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
-	sgOptions.Gameplay.bJogInTown = getIniBool("Game", "Fast Walk", false);
 	sgOptions.Gameplay.bGrabInput = getIniBool("Game", "Grab Input", false);
 	sgOptions.Gameplay.bTheoQuest = getIniBool("Game", "Theo Quest", false);
 	sgOptions.Gameplay.bCowQuest = getIniBool("Game", "Cow Quest", false);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -405,7 +405,6 @@ static void SaveOptions()
 #endif
 	setIniValue("Graphics", "Scaling Quality", sgOptions.Graphics.szScaleQuality);
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
-	setIniInt("Graphics", "FPS Limiter", sgOptions.Graphics.bFPSLimit);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
 	setIniInt("Game", "Fast Walk", sgOptions.Gameplay.bJogInTown);
@@ -449,7 +448,6 @@ static void LoadOptions()
 #endif
 	getIniValue("Graphics", "Scaling Quality", sgOptions.Graphics.szScaleQuality, sizeof(sgOptions.Graphics.szScaleQuality), "2");
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
-	sgOptions.Graphics.bFPSLimit = getIniBool("Graphics", "FPS Limiter", true);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
 	sgOptions.Gameplay.bJogInTown = getIniBool("Game", "Fast Walk", false);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -407,7 +407,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
-	setIniInt("Game", "Test Bard", sgOptions.Gameplay.bTestBard);
 	setIniInt("Game", "Test Barbarian", sgOptions.Gameplay.bTestBarbarian);
 	setIniInt("Game", "Experience Bar", sgOptions.Gameplay.bExperienceBar);
 	setIniInt("Game", "Enemy Health Bar", sgOptions.Gameplay.bEnemyHealthBar);
@@ -445,7 +444,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
-	sgOptions.Gameplay.bTestBard = getIniBool("Game", "Test Bard", false);
 	sgOptions.Gameplay.bTestBarbarian = getIniBool("Game", "Test Barbarian", false);
 	sgOptions.Gameplay.bExperienceBar = getIniBool("Game", "Experience Bar", false);
 	sgOptions.Gameplay.bEnemyHealthBar = getIniBool("Game", "Enemy Health Bar", false);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -407,7 +407,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
-	setIniInt("Game", "Grab Input", sgOptions.Gameplay.bGrabInput);
 	setIniInt("Game", "Theo Quest", sgOptions.Gameplay.bTheoQuest);
 	setIniInt("Game", "Cow Quest", sgOptions.Gameplay.bCowQuest);
 	setIniInt("Game", "Friendly Fire", sgOptions.Gameplay.bFriendlyFire);
@@ -449,7 +448,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
-	sgOptions.Gameplay.bGrabInput = getIniBool("Game", "Grab Input", false);
 	sgOptions.Gameplay.bTheoQuest = getIniBool("Game", "Theo Quest", false);
 	sgOptions.Gameplay.bCowQuest = getIniBool("Game", "Cow Quest", false);
 	sgOptions.Gameplay.bFriendlyFire = getIniBool("Game", "Friendly Fire", true);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -398,7 +398,6 @@ static void SaveOptions()
 {
 	setIniInt("Audio", "Sound Volume", sgOptions.Audio.nSoundVolume);
 	setIniInt("Audio", "Music Volume", sgOptions.Audio.nMusicVolume);
-	setIniInt("Audio", "Walking Sound", sgOptions.Audio.bWalkingSound);
 	setIniInt("Audio", "Auto Equip Sound", sgOptions.Audio.bAutoEquipSound);
 
 #ifndef __vita__
@@ -440,6 +439,7 @@ static void SaveOptions()
 
 	setIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress);
 	setIniInt("Network", "Port", sgOptions.Network.nPort);
+	sgOptions.Save();
 }
 
 /**
@@ -449,7 +449,6 @@ static void LoadOptions()
 {
 	sgOptions.Audio.nSoundVolume = getIniInt("Audio", "Sound Volume", VOLUME_MAX);
 	sgOptions.Audio.nMusicVolume = getIniInt("Audio", "Music Volume", VOLUME_MAX);
-	sgOptions.Audio.bWalkingSound = getIniBool("Audio", "Walking Sound", true);
 	sgOptions.Audio.bAutoEquipSound = getIniBool("Audio", "Auto Equip Sound", false);
 
 #ifndef __vita__
@@ -496,6 +495,7 @@ static void LoadOptions()
 
 	getIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress, sizeof(sgOptions.Network.szBindAddress), "0.0.0.0");
 	sgOptions.Network.nPort = getIniInt("Network", "Port", 6112);
+	sgOptions.Load();
 }
 
 static void diablo_init_screen()

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -404,7 +404,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Height", sgOptions.Graphics.nHeight);
 #endif
 	setIniValue("Graphics", "Scaling Quality", sgOptions.Graphics.szScaleQuality);
-	setIniInt("Graphics", "Blended Transparency", sgOptions.Graphics.bBlendedTransparancy);
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 	setIniInt("Graphics", "Color Cycling", sgOptions.Graphics.bColorCycling);
 	setIniInt("Graphics", "FPS Limiter", sgOptions.Graphics.bFPSLimit);
@@ -450,7 +449,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nHeight = DEFAULT_HEIGHT;
 #endif
 	getIniValue("Graphics", "Scaling Quality", sgOptions.Graphics.szScaleQuality, sizeof(sgOptions.Graphics.szScaleQuality), "2");
-	sgOptions.Graphics.bBlendedTransparancy = getIniBool("Graphics", "Blended Transparency", true);
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 	sgOptions.Graphics.bColorCycling = getIniBool("Graphics", "Color Cycling", true);
 	sgOptions.Graphics.bFPSLimit = getIniBool("Graphics", "FPS Limiter", true);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -404,7 +404,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Height", sgOptions.Graphics.nHeight);
 #endif
 	setIniValue("Graphics", "Scaling Quality", sgOptions.Graphics.szScaleQuality);
-	setIniInt("Graphics", "Vertical Sync", sgOptions.Graphics.bVSync);
 	setIniInt("Graphics", "Blended Transparency", sgOptions.Graphics.bBlendedTransparancy);
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 	setIniInt("Graphics", "Color Cycling", sgOptions.Graphics.bColorCycling);
@@ -451,7 +450,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nHeight = DEFAULT_HEIGHT;
 #endif
 	getIniValue("Graphics", "Scaling Quality", sgOptions.Graphics.szScaleQuality, sizeof(sgOptions.Graphics.szScaleQuality), "2");
-	sgOptions.Graphics.bVSync = getIniBool("Graphics", "Vertical Sync", true);
 	sgOptions.Graphics.bBlendedTransparancy = getIniBool("Graphics", "Blended Transparency", true);
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 	sgOptions.Graphics.bColorCycling = getIniBool("Graphics", "Color Cycling", true);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -403,9 +403,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Width", sgOptions.Graphics.nWidth);
 	setIniInt("Graphics", "Height", sgOptions.Graphics.nHeight);
 #endif
-#ifndef __vita__
-	setIniInt("Graphics", "Upscale", sgOptions.Graphics.bUpscale);
-#endif
 	setIniInt("Graphics", "Fit to Screen", sgOptions.Graphics.bFitToScreen);
 	setIniValue("Graphics", "Scaling Quality", sgOptions.Graphics.szScaleQuality);
 	setIniInt("Graphics", "Integer Scaling", sgOptions.Graphics.bIntegerScaling);
@@ -454,11 +451,6 @@ static void LoadOptions()
 #else
 	sgOptions.Graphics.nWidth = DEFAULT_WIDTH;
 	sgOptions.Graphics.nHeight = DEFAULT_HEIGHT;
-#endif
-#if !defined(USE_SDL1) && !defined(__vita__)
-	sgOptions.Graphics.bUpscale = getIniBool("Graphics", "Upscale", true);
-#else
-	sgOptions.Graphics.bUpscale = false;
 #endif
 	sgOptions.Graphics.bFitToScreen = getIniBool("Graphics", "Fit to Screen", true);
 	getIniValue("Graphics", "Scaling Quality", sgOptions.Graphics.szScaleQuality, sizeof(sgOptions.Graphics.szScaleQuality), "2");

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -403,7 +403,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Width", sgOptions.Graphics.nWidth);
 	setIniInt("Graphics", "Height", sgOptions.Graphics.nHeight);
 #endif
-	setIniInt("Graphics", "Fit to Screen", sgOptions.Graphics.bFitToScreen);
 	setIniValue("Graphics", "Scaling Quality", sgOptions.Graphics.szScaleQuality);
 	setIniInt("Graphics", "Integer Scaling", sgOptions.Graphics.bIntegerScaling);
 	setIniInt("Graphics", "Vertical Sync", sgOptions.Graphics.bVSync);
@@ -452,7 +451,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nWidth = DEFAULT_WIDTH;
 	sgOptions.Graphics.nHeight = DEFAULT_HEIGHT;
 #endif
-	sgOptions.Graphics.bFitToScreen = getIniBool("Graphics", "Fit to Screen", true);
 	getIniValue("Graphics", "Scaling Quality", sgOptions.Graphics.szScaleQuality, sizeof(sgOptions.Graphics.szScaleQuality), "2");
 	sgOptions.Graphics.bIntegerScaling = getIniBool("Graphics", "Integer Scaling", false);
 	sgOptions.Graphics.bVSync = getIniBool("Graphics", "Vertical Sync", true);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -407,11 +407,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
-	setIniInt("Game", "Auto Equip Weapons", sgOptions.Gameplay.bAutoEquipWeapons);
-	setIniInt("Game", "Auto Equip Armor", sgOptions.Gameplay.bAutoEquipArmor);
-	setIniInt("Game", "Auto Equip Helms", sgOptions.Gameplay.bAutoEquipHelms);
-	setIniInt("Game", "Auto Equip Shields", sgOptions.Gameplay.bAutoEquipShields);
-	setIniInt("Game", "Auto Equip Jewelry", sgOptions.Gameplay.bAutoEquipJewelry);
 	setIniInt("Game", "Randomize Quests", sgOptions.Gameplay.bRandomizeQuests);
 	setIniInt("Game", "Show Monster Type", sgOptions.Gameplay.bShowMonsterType);
 
@@ -439,11 +434,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
-	sgOptions.Gameplay.bAutoEquipWeapons = getIniBool("Game", "Auto Equip Weapons", true);
-	sgOptions.Gameplay.bAutoEquipArmor = getIniBool("Game", "Auto Equip Armor", false);
-	sgOptions.Gameplay.bAutoEquipHelms = getIniBool("Game", "Auto Equip Helms", false);
-	sgOptions.Gameplay.bAutoEquipShields = getIniBool("Game", "Auto Equip Shields", false);
-	sgOptions.Gameplay.bAutoEquipJewelry = getIniBool("Game", "Auto Equip Jewelry", false);
 	sgOptions.Gameplay.bRandomizeQuests = getIniBool("Game", "Randomize Quests", true);
 	sgOptions.Gameplay.bShowMonsterType = getIniBool("Game", "Show Monster Type", false);
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -407,7 +407,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
-	setIniInt("Game", "Test Barbarian", sgOptions.Gameplay.bTestBarbarian);
 	setIniInt("Game", "Experience Bar", sgOptions.Gameplay.bExperienceBar);
 	setIniInt("Game", "Enemy Health Bar", sgOptions.Gameplay.bEnemyHealthBar);
 	setIniInt("Game", "Auto Gold Pickup", sgOptions.Gameplay.bAutoGoldPickup);
@@ -444,7 +443,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
-	sgOptions.Gameplay.bTestBarbarian = getIniBool("Game", "Test Barbarian", false);
 	sgOptions.Gameplay.bExperienceBar = getIniBool("Game", "Experience Bar", false);
 	sgOptions.Gameplay.bEnemyHealthBar = getIniBool("Game", "Enemy Health Bar", false);
 	sgOptions.Gameplay.bAutoGoldPickup = getIniBool("Game", "Auto Gold Pickup", false);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -407,7 +407,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
-	setIniInt("Game", "Enemy Health Bar", sgOptions.Gameplay.bEnemyHealthBar);
 	setIniInt("Game", "Auto Gold Pickup", sgOptions.Gameplay.bAutoGoldPickup);
 	setIniInt("Game", "Adria Refills Mana", sgOptions.Gameplay.bAdriaRefillsMana);
 	setIniInt("Game", "Auto Equip Weapons", sgOptions.Gameplay.bAutoEquipWeapons);
@@ -442,7 +441,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
-	sgOptions.Gameplay.bEnemyHealthBar = getIniBool("Game", "Enemy Health Bar", false);
 	sgOptions.Gameplay.bAutoGoldPickup = getIniBool("Game", "Auto Gold Pickup", false);
 	sgOptions.Gameplay.bAdriaRefillsMana = getIniBool("Game", "Adria Refills Mana", false);
 	sgOptions.Gameplay.bAutoEquipWeapons = getIniBool("Game", "Auto Equip Weapons", true);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -407,7 +407,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
-	setIniInt("Game", "Randomize Quests", sgOptions.Gameplay.bRandomizeQuests);
 	setIniInt("Game", "Show Monster Type", sgOptions.Gameplay.bShowMonsterType);
 
 	setIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress);
@@ -434,7 +433,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
-	sgOptions.Gameplay.bRandomizeQuests = getIniBool("Game", "Randomize Quests", true);
 	sgOptions.Gameplay.bShowMonsterType = getIniBool("Game", "Show Monster Type", false);
 
 	getIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress, sizeof(sgOptions.Network.szBindAddress), "0.0.0.0");

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -407,7 +407,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
-	setIniInt("Game", "Show Monster Type", sgOptions.Gameplay.bShowMonsterType);
 
 	setIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress);
 	setIniInt("Network", "Port", sgOptions.Network.nPort);
@@ -433,7 +432,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
-	sgOptions.Gameplay.bShowMonsterType = getIniBool("Game", "Show Monster Type", false);
 
 	getIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress, sizeof(sgOptions.Network.szBindAddress), "0.0.0.0");
 	sgOptions.Network.nPort = getIniInt("Network", "Port", 6112);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -407,7 +407,6 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
-	setIniInt("Game", "Auto Gold Pickup", sgOptions.Gameplay.bAutoGoldPickup);
 	setIniInt("Game", "Adria Refills Mana", sgOptions.Gameplay.bAdriaRefillsMana);
 	setIniInt("Game", "Auto Equip Weapons", sgOptions.Gameplay.bAutoEquipWeapons);
 	setIniInt("Game", "Auto Equip Armor", sgOptions.Gameplay.bAutoEquipArmor);
@@ -441,7 +440,6 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
-	sgOptions.Gameplay.bAutoGoldPickup = getIniBool("Game", "Auto Gold Pickup", false);
 	sgOptions.Gameplay.bAdriaRefillsMana = getIniBool("Game", "Adria Refills Mana", false);
 	sgOptions.Gameplay.bAutoEquipWeapons = getIniBool("Game", "Auto Equip Weapons", true);
 	sgOptions.Gameplay.bAutoEquipArmor = getIniBool("Game", "Auto Equip Armor", false);

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -23,99 +23,6 @@ extern "C" {
 #define DEFAULT_HEIGHT 480
 #endif
 
-typedef struct AudioOptions {
-	/** @brief Movie and SFX volume. */
-	Sint32 nSoundVolume;
-	/** @brief Music volume. */
-	Sint32 nMusicVolume;
-	/** @brief Player emits sound when walking. */
-	bool bWalkingSound;
-	/** @brief Automatically equipping items on pickup emits the equipment sound. */
-	bool bAutoEquipSound;
-} AudioOptions;
-
-typedef struct GraphicsOptions {
-	/** @brief Render width. */
-	Sint32 nWidth;
-	/** @brief Render height. */
-	Sint32 nHeight;
-	/** @brief Run in fullscreen or windowed mode. */
-	bool bFullscreen;
-	/** @brief Scale the image after rendering. */
-	bool bUpscale;
-	/** @brief Expand the aspect ratio to match the screen. */
-	bool bFitToScreen;
-	/** @brief See SDL_HINT_RENDER_SCALE_QUALITY. */
-	char szScaleQuality[2];
-	/** @brief Only scale by values divisible by the width and height. */
-	bool bIntegerScaling;
-	/** @brief Enable vsync on the output. */
-	bool bVSync;
-	/** @brief Use blended transparency rather than stippled. */
-	bool bBlendedTransparancy;
-	/** @brief Gamma correction level. */
-	Sint32 nGammaCorrection;
-	/** @brief Enable color cycling animations. */
-	bool bColorCycling;
-	/** @brief Enable FPS Limit. */
-	bool bFPSLimit;
-} GraphicsOptions;
-
-typedef struct GameplayOptions {
-	/** @brief Game play ticks per secound. */
-	Sint32 nTickRate;
-	/** @brief Enable double walk speed when in town. */
-	bool bJogInTown;
-	/** @brief Do not let the mouse leave the application window. */
-	bool bGrabInput;
-	/** @brief Enable the Theo quest. */
-	bool bTheoQuest;
-	/** @brief Enable the cow quest. */
-	bool bCowQuest;
-	/** @brief Will players still damage other players in non-PvP mode. */
-	bool bFriendlyFire;
-	/** @brief Enable the bard hero class. */
-	bool bTestBard;
-	/** @brief Enable the babarian hero class. */
-	bool bTestBarbarian;
-	/** @brief Show the current level progress. */
-	bool bExperienceBar;
-	/** @brief Show enemy health at the top of the screen. */
-	bool bEnemyHealthBar;
-	/** @brief Automatically pick up goald when walking on to it. */
-	bool bAutoGoldPickup;
-	/** @brief Recover mana when talking to Adria. */
-	bool bAdriaRefillsMana;
-	/** @brief Automatically attempt to equip weapon-type items when picking them up. */
-	bool bAutoEquipWeapons;
-	/** @brief Automatically attempt to equip armor-type items when picking them up. */
-	bool bAutoEquipArmor;
-	/** @brief Automatically attempt to equip helm-type items when picking them up. */
-	bool bAutoEquipHelms;
-	/** @brief Automatically attempt to equip shield-type items when picking them up. */
-	bool bAutoEquipShields;
-	/** @brief Automatically attempt to equip jewelry-type items when picking them up. */
-	bool bAutoEquipJewelry;
-	/** @brief Only enable 2/3 quests in each game sessoin */
-	bool bRandomizeQuests;
-	/** @brief Indicates whether or not mosnter type (Animal, Demon, Undead) is shown along with other monster information. */
-	bool bShowMonsterType;
-} GameplayOptions;
-
-typedef struct NetworkOptions {
-	/** @brief Optionally bind to a specific network interface. */
-	char szBindAddress[129];
-	/** @brief What network port to use. */
-	Uint16 nPort;
-} NetworkOptions;
-
-typedef struct Options {
-	AudioOptions Audio;
-	GameplayOptions Gameplay;
-	GraphicsOptions Graphics;
-	NetworkOptions Network;
-} Options;
-
 extern SDL_Window *ghMainWnd;
 extern DWORD glSeedTbl[NUMLEVELS];
 extern int gnLevelTypeTbl[NUMLEVELS];
@@ -141,7 +48,6 @@ extern bool gbBarbarian;
 extern char sgbMouseDown;
 extern int gnTickRate;
 extern WORD gnTickDelay;
-extern Options sgOptions;
 
 void FreeGameMem();
 BOOL StartGame(BOOL bNewGame, BOOL bSinglePlayer);

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -374,7 +374,7 @@ void CelClippedBlitLightTransTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelB
 	pRLEBytes = CelGetFrameClipped(pCelBuff, nCel, &nDataSize);
 
 	if (cel_transparency_active) {
-		if (sgOptions.Graphics.bBlendedTransparancy)
+		if (*sgOptions.Graphics.bBlendedTransparancy)
 			CelBlitLightBlendedSafeTo(out, sx, sy, pRLEBytes, nDataSize, nWidth, NULL);
 		else
 			CelBlitLightTransSafeTo(out, sx, sy, pRLEBytes, nDataSize, nWidth);
@@ -565,7 +565,7 @@ static void DrawHalfTransparentStippledRectTo(CelOutputBuffer out, int sx, int s
 
 void DrawHalfTransparentRectTo(CelOutputBuffer out, int sx, int sy, int width, int height)
 {
-	if (sgOptions.Graphics.bBlendedTransparancy) {
+	if (*sgOptions.Graphics.bBlendedTransparancy) {
 		DrawHalfTransparentBlendedRectTo(out, sx, sy, width, height);
 	} else {
 		DrawHalfTransparentStippledRectTo(out, sx, sy, width, height);

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -11,6 +11,7 @@
  * - Video playback
  */
 #include "all.h"
+#include "options.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -255,7 +255,7 @@ static void gamemenu_get_speed()
 
 static void gamemenu_get_color_cycling()
 {
-	sgOptionsMenu[3].pszStr = color_cycling_toggle_names[sgOptions.Graphics.bColorCycling ? 1 : 0];
+	sgOptionsMenu[3].pszStr = color_cycling_toggle_names[*sgOptions.Graphics.bColorCycling ? 1 : 0];
 }
 
 static int gamemenu_slider_gamma()
@@ -393,8 +393,8 @@ void gamemenu_speed(BOOL bActivate)
 
 void gamemenu_color_cycling(BOOL bActivate)
 {
-	sgOptions.Graphics.bColorCycling = !sgOptions.Graphics.bColorCycling;
-	sgOptionsMenu[3].pszStr = color_cycling_toggle_names[sgOptions.Graphics.bColorCycling ? 1 : 0];
+	sgOptions.Graphics.bColorCycling = !*sgOptions.Graphics.bColorCycling;
+	sgOptionsMenu[3].pszStr = color_cycling_toggle_names[*sgOptions.Graphics.bColorCycling ? 1 : 0];
 }
 
 DEVILUTION_END_NAMESPACE

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -221,8 +221,8 @@ static void gamemenu_get_sound()
 static void gamemenu_jogging()
 {
 	gmenu_slider_steps(&sgOptionsMenu[3], 2);
-	gmenu_slider_set(&sgOptionsMenu[3], 0, 1, sgOptions.Gameplay.bJogInTown);
-	sgOptionsMenu[3].pszStr = jogging_toggle_names[!sgOptions.Gameplay.bJogInTown ? 1 : 0];
+	gmenu_slider_set(&sgOptionsMenu[3], 0, 1, *sgOptions.Gameplay.bJogInTown);
+	sgOptionsMenu[3].pszStr = jogging_toggle_names[!*sgOptions.Gameplay.bJogInTown ? 1 : 0];
 }
 
 static void gamemenu_get_gamma()
@@ -351,8 +351,8 @@ void gamemenu_sound_volume(BOOL bActivate)
 void gamemenu_loadjog(BOOL bActivate)
 {
 	if (!gbIsMultiplayer) {
-		sgOptions.Gameplay.bJogInTown = !sgOptions.Gameplay.bJogInTown;
-		gbJogInTown = sgOptions.Gameplay.bJogInTown;
+		sgOptions.Gameplay.bJogInTown = !*sgOptions.Gameplay.bJogInTown;
+		gbJogInTown = *sgOptions.Gameplay.bJogInTown;
 		PlaySFX(IS_TITLEMOV);
 		gamemenu_jogging();
 	}

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -5,6 +5,7 @@
  * Implementation of the in-game menu functions.
  */
 #include "all.h"
+#include "options.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -4,6 +4,7 @@
  * Implementation of general dungeon generation code.
  */
 #include "all.h"
+#include "options.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -4,6 +4,7 @@
  * Implementation of player inventory.
  */
 #include "all.h"
+#include "options.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -823,23 +823,23 @@ bool AutoEquip(int playerNumber, const ItemStruct &item, bool persistItem)
 bool AutoEquipEnabled(const ItemStruct &item)
 {
 	if (item.isWeapon()) {
-		return sgOptions.Gameplay.bAutoEquipWeapons;
+		return *sgOptions.Gameplay.bAutoEquipWeapons;
 	}
 
 	if (item.isArmor()) {
-		return sgOptions.Gameplay.bAutoEquipArmor;
+		return *sgOptions.Gameplay.bAutoEquipArmor;
 	}
 
 	if (item.isHelm()) {
-		return sgOptions.Gameplay.bAutoEquipHelms;
+		return *sgOptions.Gameplay.bAutoEquipHelms;
 	}
 
 	if (item.isShield()) {
-		return sgOptions.Gameplay.bAutoEquipShields;
+		return *sgOptions.Gameplay.bAutoEquipShields;
 	}
 
 	if (item.isJewelry()) {
-		return sgOptions.Gameplay.bAutoEquipJewelry;
+		return *sgOptions.Gameplay.bAutoEquipJewelry;
 	}
 
 	return true;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -780,7 +780,7 @@ bool AutoEquip(int playerNumber, const ItemStruct &item, int bodyLocation, bool 
 	if (persistItem) {
 		plr[playerNumber].InvBody[bodyLocation] = item;
 
-		if (sgOptions.Audio.bAutoEquipSound && playerNumber == myplr) {
+		if (*sgOptions.Audio.bAutoEquipSound && playerNumber == myplr) {
 			PlaySFX(ItemInvSnds[ItemCAnimTbl[item._iCurs]]);
 		}
 

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -56,7 +56,7 @@ static BOOL mainmenu_single_player()
 
 	gbJogInTown = *sgOptions.Gameplay.bJogInTown;
 	gnTickRate = sgOptions.Gameplay.nTickRate;
-	gbTheoQuest = sgOptions.Gameplay.bTheoQuest;
+	gbTheoQuest = *sgOptions.Gameplay.bTheoQuest;
 	gbCowQuest = sgOptions.Gameplay.bCowQuest;
 
 	return mainmenu_init_menu(SELHERO_NEW_DUNGEON);

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -4,6 +4,7 @@
  * Implementation of functions for interacting with the main menu.
  */
 #include "all.h"
+#include "options.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include "../DiabloUI/diabloui.h"
 

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -54,7 +54,7 @@ static BOOL mainmenu_single_player()
 {
 	gbIsMultiplayer = false;
 
-	gbJogInTown = sgOptions.Gameplay.bJogInTown;
+	gbJogInTown = *sgOptions.Gameplay.bJogInTown;
 	gnTickRate = sgOptions.Gameplay.nTickRate;
 	gbTheoQuest = sgOptions.Gameplay.bTheoQuest;
 	gbCowQuest = sgOptions.Gameplay.bCowQuest;

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -57,7 +57,7 @@ static BOOL mainmenu_single_player()
 	gbJogInTown = *sgOptions.Gameplay.bJogInTown;
 	gnTickRate = sgOptions.Gameplay.nTickRate;
 	gbTheoQuest = *sgOptions.Gameplay.bTheoQuest;
-	gbCowQuest = sgOptions.Gameplay.bCowQuest;
+	gbCowQuest = *sgOptions.Gameplay.bCowQuest;
 
 	return mainmenu_init_menu(SELHERO_NEW_DUNGEON);
 }

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -5181,7 +5181,7 @@ void PrintMonstHistory(int mt)
 {
 	int minHP, maxHP, res;
 
-	if (sgOptions.Gameplay.bShowMonsterType) {
+	if (*sgOptions.Gameplay.bShowMonsterType) {
 		sprintf(tempstr, "Type: %s  Kills: %i", GetMonsterTypeText(monsterdata[mt]), monstkills[mt]);
 	} else {
 		sprintf(tempstr, "Total kills: %i", monstkills[mt]);
@@ -5261,7 +5261,7 @@ void PrintUniqueHistory()
 {
 	int res;
 
-	if (sgOptions.Gameplay.bShowMonsterType) {
+	if (*sgOptions.Gameplay.bShowMonsterType) {
 		sprintf(tempstr, "Type: %s", GetMonsterTypeText(*monster[pcursmonst].MData));
 		AddPanelString(tempstr, TRUE);
 	}

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 
 #include "all.h"
+#include "options.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -745,7 +745,7 @@ BOOL NetInit(BOOL bSinglePlayer, BOOL *pfExitProgram)
 		sgGameInitInfo.nDifficulty = gnDifficulty;
 		sgGameInitInfo.nTickRate = sgOptions.Gameplay.nTickRate;
 		sgGameInitInfo.bJogInTown = *sgOptions.Gameplay.bJogInTown;
-		sgGameInitInfo.bTheoQuest = sgOptions.Gameplay.bTheoQuest;
+		sgGameInitInfo.bTheoQuest = *sgOptions.Gameplay.bTheoQuest;
 		sgGameInitInfo.bCowQuest = sgOptions.Gameplay.bCowQuest;
 		sgGameInitInfo.bFriendlyFire = sgOptions.Gameplay.bFriendlyFire;
 		memset(&ProgramData, 0, sizeof(ProgramData));

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -746,7 +746,7 @@ BOOL NetInit(BOOL bSinglePlayer, BOOL *pfExitProgram)
 		sgGameInitInfo.nTickRate = sgOptions.Gameplay.nTickRate;
 		sgGameInitInfo.bJogInTown = *sgOptions.Gameplay.bJogInTown;
 		sgGameInitInfo.bTheoQuest = *sgOptions.Gameplay.bTheoQuest;
-		sgGameInitInfo.bCowQuest = sgOptions.Gameplay.bCowQuest;
+		sgGameInitInfo.bCowQuest = *sgOptions.Gameplay.bCowQuest;
 		sgGameInitInfo.bFriendlyFire = sgOptions.Gameplay.bFriendlyFire;
 		memset(&ProgramData, 0, sizeof(ProgramData));
 		ProgramData.size = sizeof(ProgramData);

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -747,7 +747,7 @@ BOOL NetInit(BOOL bSinglePlayer, BOOL *pfExitProgram)
 		sgGameInitInfo.bJogInTown = *sgOptions.Gameplay.bJogInTown;
 		sgGameInitInfo.bTheoQuest = *sgOptions.Gameplay.bTheoQuest;
 		sgGameInitInfo.bCowQuest = *sgOptions.Gameplay.bCowQuest;
-		sgGameInitInfo.bFriendlyFire = sgOptions.Gameplay.bFriendlyFire;
+		sgGameInitInfo.bFriendlyFire = *sgOptions.Gameplay.bFriendlyFire;
 		memset(&ProgramData, 0, sizeof(ProgramData));
 		ProgramData.size = sizeof(ProgramData);
 		ProgramData.maxplayers = MAX_PLRS;

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -744,7 +744,7 @@ BOOL NetInit(BOOL bSinglePlayer, BOOL *pfExitProgram)
 		sgGameInitInfo.versionPatch = PROJECT_VERSION_PATCH;
 		sgGameInitInfo.nDifficulty = gnDifficulty;
 		sgGameInitInfo.nTickRate = sgOptions.Gameplay.nTickRate;
-		sgGameInitInfo.bJogInTown = sgOptions.Gameplay.bJogInTown;
+		sgGameInitInfo.bJogInTown = *sgOptions.Gameplay.bJogInTown;
 		sgGameInitInfo.bTheoQuest = sgOptions.Gameplay.bTheoQuest;
 		sgGameInitInfo.bCowQuest = sgOptions.Gameplay.bCowQuest;
 		sgGameInitInfo.bFriendlyFire = sgOptions.Gameplay.bFriendlyFire;

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -4,6 +4,7 @@
  * Implementation of functions for keeping multiplaye games in sync.
  */
 #include "all.h"
+#include "options.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include "../DiabloUI/diabloui.h"
 #include <config.h>

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -77,6 +77,7 @@ GraphicsOptions::GraphicsOptions()
 	AddOption(bVSync);
 	AddOption(bBlendedTransparancy);
 	AddOption(bColorCycling);
+	AddOption(bFPSLimit);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -86,6 +86,7 @@ GameplayOptions::GameplayOptions()
 	AddOption(bJogInTown);
 	AddOption(bGrabInput);
 	AddOption(bTheoQuest);
+	AddOption(bCowQuest);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -63,10 +63,17 @@ AudioOptions::AudioOptions()
 	AddOption(bAutoEquipSound);
 }
 
+GraphicsOptions::GraphicsOptions()
+    : OptionGroup("Graphics")
+{
+	AddOption(bFullscreen);
+}
+
 Options::Options()
     : OptionGroup("")
 {
 	AddOptionGroup(Audio);
+	AddOptionGroup(Graphics);
 }
 
 }

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -56,4 +56,16 @@ void OptionGroup::AddOptionGroup(std::reference_wrapper<OptionGroup> optionGroup
 	m_optionGroups.push_back(optionGroup);
 }
 
+AudioOptions::AudioOptions()
+    : OptionGroup("Audio")
+{
+	AddOption(bWalkingSound);
+}
+
+Options::Options()
+    : OptionGroup("")
+{
+	AddOptionGroup(Audio);
+}
+
 }

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -71,6 +71,8 @@ GraphicsOptions::GraphicsOptions()
 #ifndef __vita__
 	AddOption(bUpscale);
 #endif
+
+	AddOption(bFitToScreen);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -60,6 +60,7 @@ AudioOptions::AudioOptions()
     : OptionGroup("Audio")
 {
 	AddOption(bWalkingSound);
+	AddOption(bAutoEquipSound);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -88,6 +88,7 @@ GameplayOptions::GameplayOptions()
 	AddOption(bTheoQuest);
 	AddOption(bCowQuest);
 	AddOption(bFriendlyFire);
+	AddOption(bTestBard);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -100,6 +100,7 @@ GameplayOptions::GameplayOptions()
 	AddOption(bAutoEquipShields);
 	AddOption(bAutoEquipJewelry);
 	AddOption(bRandomizeQuests);
+	AddOption(bShowMonsterType);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -84,6 +84,7 @@ GameplayOptions::GameplayOptions()
     : OptionGroup("Game")
 {
 	AddOption(bJogInTown);
+	AddOption(bGrabInput);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -89,6 +89,7 @@ GameplayOptions::GameplayOptions()
 	AddOption(bCowQuest);
 	AddOption(bFriendlyFire);
 	AddOption(bTestBard);
+	AddOption(bTestBarbarian);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -73,6 +73,7 @@ GraphicsOptions::GraphicsOptions()
 #endif
 
 	AddOption(bFitToScreen);
+	AddOption(bIntegerScaling);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -91,6 +91,7 @@ GameplayOptions::GameplayOptions()
 	AddOption(bTestBard);
 	AddOption(bTestBarbarian);
 	AddOption(bExperienceBar);
+	AddOption(bEnemyHealthBar);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -85,6 +85,7 @@ GameplayOptions::GameplayOptions()
 {
 	AddOption(bJogInTown);
 	AddOption(bGrabInput);
+	AddOption(bTheoQuest);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -76,6 +76,7 @@ GraphicsOptions::GraphicsOptions()
 	AddOption(bIntegerScaling);
 	AddOption(bVSync);
 	AddOption(bBlendedTransparancy);
+	AddOption(bColorCycling);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1,0 +1,59 @@
+#include "options.h"
+
+namespace dvl {
+
+void BooleanOption::Load(const std::string& sectionName)
+{
+	m_value = getIniBool(sectionName.c_str(), this->m_displayName.c_str(), this->m_defaultValue);
+}
+
+void BooleanOption::Save(const std::string& sectionName)
+{
+	setIniInt(sectionName.c_str(), this->m_displayName.c_str(), this->m_value);
+}
+
+BooleanOption& BooleanOption::operator = (bool value)
+{
+	m_value = value;
+
+	return *this;
+}
+
+OptionGroup::OptionGroup(const std::string& sectionName)
+    : m_sectionName(sectionName)
+{
+}
+
+void OptionGroup::Load()
+{
+	for (OptionBase& option : m_options) {
+		option.Load(m_sectionName);
+	}
+
+	for (OptionGroup& optionGroup : m_optionGroups) {
+		optionGroup.Load();
+	}
+}
+
+void OptionGroup::Save()
+{
+	for (OptionBase& option : m_options) {
+		option.Save(m_sectionName);
+	}
+
+	for (OptionGroup& optionGroup : m_optionGroups) {
+		optionGroup.Save();
+	}
+}
+
+void OptionGroup::AddOption(std::reference_wrapper<OptionBase> option)
+{
+	m_options.push_back(option);
+}
+
+void OptionGroup::AddOptionGroup(std::reference_wrapper<OptionGroup> optionGroup)
+{
+	m_optionGroups.push_back(optionGroup);
+}
+
+}

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -67,6 +67,10 @@ GraphicsOptions::GraphicsOptions()
     : OptionGroup("Graphics")
 {
 	AddOption(bFullscreen);
+
+#ifndef __vita__
+	AddOption(bUpscale);
+#endif
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -99,6 +99,7 @@ GameplayOptions::GameplayOptions()
 	AddOption(bAutoEquipHelms);
 	AddOption(bAutoEquipShields);
 	AddOption(bAutoEquipJewelry);
+	AddOption(bRandomizeQuests);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -90,6 +90,7 @@ GameplayOptions::GameplayOptions()
 	AddOption(bFriendlyFire);
 	AddOption(bTestBard);
 	AddOption(bTestBarbarian);
+	AddOption(bExperienceBar);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -92,6 +92,7 @@ GameplayOptions::GameplayOptions()
 	AddOption(bTestBarbarian);
 	AddOption(bExperienceBar);
 	AddOption(bEnemyHealthBar);
+	AddOption(bAutoGoldPickup);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -74,6 +74,7 @@ GraphicsOptions::GraphicsOptions()
 
 	AddOption(bFitToScreen);
 	AddOption(bIntegerScaling);
+	AddOption(bVSync);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -87,6 +87,7 @@ GameplayOptions::GameplayOptions()
 	AddOption(bGrabInput);
 	AddOption(bTheoQuest);
 	AddOption(bCowQuest);
+	AddOption(bFriendlyFire);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -93,6 +93,7 @@ GameplayOptions::GameplayOptions()
 	AddOption(bExperienceBar);
 	AddOption(bEnemyHealthBar);
 	AddOption(bAutoGoldPickup);
+	AddOption(bAdriaRefillsMana);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -75,6 +75,7 @@ GraphicsOptions::GraphicsOptions()
 	AddOption(bFitToScreen);
 	AddOption(bIntegerScaling);
 	AddOption(bVSync);
+	AddOption(bBlendedTransparancy);
 }
 
 Options::Options()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -80,11 +80,18 @@ GraphicsOptions::GraphicsOptions()
 	AddOption(bFPSLimit);
 }
 
+GameplayOptions::GameplayOptions()
+    : OptionGroup("Game")
+{
+	AddOption(bJogInTown);
+}
+
 Options::Options()
     : OptionGroup("")
 {
 	AddOptionGroup(Audio);
 	AddOptionGroup(Graphics);
+	AddOptionGroup(Gameplay);
 }
 
 }

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -94,6 +94,11 @@ GameplayOptions::GameplayOptions()
 	AddOption(bEnemyHealthBar);
 	AddOption(bAutoGoldPickup);
 	AddOption(bAdriaRefillsMana);
+	AddOption(bAutoEquipWeapons);
+	AddOption(bAutoEquipArmor);
+	AddOption(bAutoEquipHelms);
+	AddOption(bAutoEquipShields);
+	AddOption(bAutoEquipJewelry);
 }
 
 Options::Options()

--- a/Source/options.h
+++ b/Source/options.h
@@ -140,7 +140,15 @@ public:
 	/** @brief Run in fullscreen or windowed mode. */
 	BooleanOption bFullscreen = { "Fullscreen", true };
 	/** @brief Scale the image after rendering. */
-	bool bUpscale;
+	BooleanOption bUpscale =
+	{
+		"Upscale",
+#if !defined(USE_SDL1) && !defined(__vita__)
+		true
+#else
+		false
+#endif
+	};
 	/** @brief Expand the aspect ratio to match the screen. */
 	bool bFitToScreen;
 	/** @brief See SDL_HINT_RENDER_SCALE_QUALITY. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -2,7 +2,8 @@
 
 DEVILUTION_BEGIN_NAMESPACE
 
-typedef struct AudioOptions {
+class AudioOptions final {
+public:
 	/** @brief Movie and SFX volume. */
 	Sint32 nSoundVolume;
 	/** @brief Music volume. */
@@ -11,9 +12,10 @@ typedef struct AudioOptions {
 	bool bWalkingSound;
 	/** @brief Automatically equipping items on pickup emits the equipment sound. */
 	bool bAutoEquipSound;
-} AudioOptions;
+};
 
-typedef struct GraphicsOptions {
+class GraphicsOptions final {
+public:
 	/** @brief Render width. */
 	Sint32 nWidth;
 	/** @brief Render height. */
@@ -38,9 +40,10 @@ typedef struct GraphicsOptions {
 	bool bColorCycling;
 	/** @brief Enable FPS Limit. */
 	bool bFPSLimit;
-} GraphicsOptions;
+};
 
-typedef struct GameplayOptions {
+class GameplayOptions final {
+public:
 	/** @brief Game play ticks per secound. */
 	Sint32 nTickRate;
 	/** @brief Enable double walk speed when in town. */
@@ -79,21 +82,23 @@ typedef struct GameplayOptions {
 	bool bRandomizeQuests;
 	/** @brief Indicates whether or not mosnter type (Animal, Demon, Undead) is shown along with other monster information. */
 	bool bShowMonsterType;
-} GameplayOptions;
+};
 
-typedef struct NetworkOptions {
+class NetworkOptions final {
+public:
 	/** @brief Optionally bind to a specific network interface. */
 	char szBindAddress[129];
 	/** @brief What network port to use. */
 	Uint16 nPort;
-} NetworkOptions;
+};
 
-typedef struct Options {
+class Options final {
+public:
 	AudioOptions Audio;
 	GameplayOptions Gameplay;
 	GraphicsOptions Graphics;
 	NetworkOptions Network;
-} Options;
+};
 
 extern Options sgOptions;
 

--- a/Source/options.h
+++ b/Source/options.h
@@ -180,7 +180,7 @@ public:
 	/** @brief Enable the Theo quest. */
 	BooleanOption bTheoQuest = { "Theo Quest", false };
 	/** @brief Enable the cow quest. */
-	bool bCowQuest;
+	BooleanOption bCowQuest = { "Cow Quest", false };
 	/** @brief Will players still damage other players in non-PvP mode. */
 	bool bFriendlyFire;
 	/** @brief Enable the bard hero class. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -162,7 +162,7 @@ public:
 	/** @brief Gamma correction level. */
 	Sint32 nGammaCorrection;
 	/** @brief Enable color cycling animations. */
-	bool bColorCycling;
+	BooleanOption bColorCycling = { "Color Cycling", true };
 	/** @brief Enable FPS Limit. */
 	bool bFPSLimit;
 };

--- a/Source/options.h
+++ b/Source/options.h
@@ -158,7 +158,7 @@ public:
 	/** @brief Enable vsync on the output. */
 	BooleanOption bVSync = { "Vertical Sync", true };
 	/** @brief Use blended transparency rather than stippled. */
-	bool bBlendedTransparancy;
+	BooleanOption bBlendedTransparancy = { "Blended Transparency", true };
 	/** @brief Gamma correction level. */
 	Sint32 nGammaCorrection;
 	/** @brief Enable color cycling animations. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -126,7 +126,7 @@ public:
 	/** @brief Player emits sound when walking. */
 	BooleanOption bWalkingSound = { "Walking Sound", true };
 	/** @brief Automatically equipping items on pickup emits the equipment sound. */
-	bool bAutoEquipSound;
+	BooleanOption bAutoEquipSound = { "Auto Equip Sound", false };
 };
 
 class GraphicsOptions final {

--- a/Source/options.h
+++ b/Source/options.h
@@ -167,12 +167,14 @@ public:
 	BooleanOption bFPSLimit = { "FPS Limiter", true };
 };
 
-class GameplayOptions final {
+class GameplayOptions final : public OptionGroup {
 public:
+	GameplayOptions();
+
 	/** @brief Game play ticks per secound. */
 	Sint32 nTickRate;
 	/** @brief Enable double walk speed when in town. */
-	bool bJogInTown;
+	BooleanOption bJogInTown = { "Fast Walk", false };
 	/** @brief Do not let the mouse leave the application window. */
 	bool bGrabInput;
 	/** @brief Enable the Theo quest. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -1,6 +1,119 @@
 #pragma once
 
+#include <memory>
+#include <string>
+#include <vector>
+#include "all.h"
+#include "SDL_stdinc.h"
+#include "../3rdParty/Storm/Source/storm.h"
+
 DEVILUTION_BEGIN_NAMESPACE
+
+/**
+ * @brief Base non-templated class for all options. Provides saving and loading functionality and a way to group every
+ * type of option together.
+*/
+class OptionBase {
+private:
+	/**
+	 * @brief Loads data from the ini into this instance.
+	 * @param sectionName The name of the section that contains the data for this option.
+	*/
+	virtual void Load(const std::string& sectionName) = 0;
+
+	/**
+	 * @brief Saves the data contained in this instance to the appropriate section in the ini.
+	 * @param sectionName The name of the section where the data from this instance will be saved to.
+	*/
+	virtual void Save(const std::string& sectionName) = 0;
+
+	friend class OptionGroup;
+};
+
+/**
+ * @brief Base templated class for all options. Stores information about a given option, including its current value,
+ * default value and the name of the key inside the ini file that corresponds to it.
+ * @tparam T The underlying type of the setting.
+*/
+template <typename T>
+class Option : public OptionBase {
+public:
+	/**
+	 * @brief Initializes a new instance of the Option<T> with the specified display name and default value.
+	 * @param displayName The name to use when saving and loading the option to ini.
+	 * @param defaultValue The default value to use when the option does not yet exist.
+	*/
+	Option(const std::string& displayName, const T& defaultValue)
+	    : m_value(0)
+	    , m_displayName(displayName)
+	    , m_defaultValue(defaultValue)
+	{
+	}
+
+	/**
+	 * @brief Extracts the underlying value from this option instance.
+	 * @return The underlying value of the option.
+	*/
+	const T& operator*() const
+	{
+		return m_value;
+	}
+
+protected:
+	T m_value;
+	std::string m_displayName;
+	T m_defaultValue;
+};
+
+/**
+ * @brief A class that models a boolean option.
+*/
+class BooleanOption final : public Option<bool> {
+	using Option<bool>::Option;
+
+public:
+	/**
+	 * @brief Sets the underlying value of this option instance.
+	 * @param value The new value to be set as the current value of this option.
+	 * @return This instance with the new value set.
+	*/
+	BooleanOption& operator=(bool value);
+
+private:
+	void Load(const std::string &sectionName);
+	void Save(const std::string &sectionName);
+};
+
+/**
+ * @brief A class that models a group of options persisted in an ini section.
+*/
+class OptionGroup {
+public:
+	/**
+	 * @brief Initializes a new instance of the option group with the specified section name.
+	 * @param sectionName The name of the ini section used to read and write values.
+	*/
+	OptionGroup(const std::string& sectionName);
+
+	/**
+	 * @brief Loads the data from the ini file into this option group.
+	*/
+	void Load();
+
+	/**
+	 * @brief Saves the data stored in this option group to the ini file.
+	*/
+	void Save();
+
+protected:
+	void AddOption(std::reference_wrapper<OptionBase>);
+	void AddOptionGroup(std::reference_wrapper<OptionGroup>);
+
+private:
+	std::vector<std::reference_wrapper<OptionBase>> m_options;
+	std::vector<std::reference_wrapper<OptionGroup>> m_optionGroups;
+	std::string m_sectionName;
+};
 
 class AudioOptions final {
 public:

--- a/Source/options.h
+++ b/Source/options.h
@@ -208,7 +208,7 @@ public:
 	/** @brief Only enable 2/3 quests in each game sessoin */
 	BooleanOption bRandomizeQuests = { "Randomize Quests", true };
 	/** @brief Indicates whether or not mosnter type (Animal, Demon, Undead) is shown along with other monster information. */
-	bool bShowMonsterType;
+	BooleanOption bShowMonsterType = { "Show Monster Type", false };
 };
 
 class NetworkOptions final {

--- a/Source/options.h
+++ b/Source/options.h
@@ -194,7 +194,7 @@ public:
 	/** @brief Automatically pick up goald when walking on to it. */
 	BooleanOption bAutoGoldPickup = { "Auto Gold Pickup", false };
 	/** @brief Recover mana when talking to Adria. */
-	bool bAdriaRefillsMana;
+	BooleanOption bAdriaRefillsMana = { "Adria Refills Mana", false };
 	/** @brief Automatically attempt to equip weapon-type items when picking them up. */
 	bool bAutoEquipWeapons;
 	/** @brief Automatically attempt to equip armor-type items when picking them up. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -192,7 +192,7 @@ public:
 	/** @brief Show enemy health at the top of the screen. */
 	BooleanOption bEnemyHealthBar = { "Enemy Health Bar", false };
 	/** @brief Automatically pick up goald when walking on to it. */
-	bool bAutoGoldPickup;
+	BooleanOption bAutoGoldPickup = { "Auto Gold Pickup", false };
 	/** @brief Recover mana when talking to Adria. */
 	bool bAdriaRefillsMana;
 	/** @brief Automatically attempt to equip weapon-type items when picking them up. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -150,7 +150,7 @@ public:
 #endif
 	};
 	/** @brief Expand the aspect ratio to match the screen. */
-	bool bFitToScreen;
+	BooleanOption bFitToScreen = { "Fit to Screen", true };
 	/** @brief See SDL_HINT_RENDER_SCALE_QUALITY. */
 	char szScaleQuality[2];
 	/** @brief Only scale by values divisible by the width and height. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -184,7 +184,7 @@ public:
 	/** @brief Will players still damage other players in non-PvP mode. */
 	BooleanOption bFriendlyFire = { "Friendly Fire", true };
 	/** @brief Enable the bard hero class. */
-	bool bTestBard;
+	BooleanOption bTestBard = { "Test Bard", false };
 	/** @brief Enable the babarian hero class. */
 	bool bTestBarbarian;
 	/** @brief Show the current level progress. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -190,7 +190,7 @@ public:
 	/** @brief Show the current level progress. */
 	BooleanOption bExperienceBar = { "Experience Bar", false };
 	/** @brief Show enemy health at the top of the screen. */
-	bool bEnemyHealthBar;
+	BooleanOption bEnemyHealthBar = { "Enemy Health Bar", false };
 	/** @brief Automatically pick up goald when walking on to it. */
 	bool bAutoGoldPickup;
 	/** @brief Recover mana when talking to Adria. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -164,7 +164,7 @@ public:
 	/** @brief Enable color cycling animations. */
 	BooleanOption bColorCycling = { "Color Cycling", true };
 	/** @brief Enable FPS Limit. */
-	bool bFPSLimit;
+	BooleanOption bFPSLimit = { "FPS Limiter", true };
 };
 
 class GameplayOptions final {

--- a/Source/options.h
+++ b/Source/options.h
@@ -182,7 +182,7 @@ public:
 	/** @brief Enable the cow quest. */
 	BooleanOption bCowQuest = { "Cow Quest", false };
 	/** @brief Will players still damage other players in non-PvP mode. */
-	bool bFriendlyFire;
+	BooleanOption bFriendlyFire = { "Friendly Fire", true };
 	/** @brief Enable the bard hero class. */
 	bool bTestBard;
 	/** @brief Enable the babarian hero class. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -115,14 +115,16 @@ private:
 	std::string m_sectionName;
 };
 
-class AudioOptions final {
+class AudioOptions final : public OptionGroup {
 public:
+	AudioOptions();
+
 	/** @brief Movie and SFX volume. */
 	Sint32 nSoundVolume;
 	/** @brief Music volume. */
 	Sint32 nMusicVolume;
 	/** @brief Player emits sound when walking. */
-	bool bWalkingSound;
+	BooleanOption bWalkingSound = { "Walking Sound", true };
 	/** @brief Automatically equipping items on pickup emits the equipment sound. */
 	bool bAutoEquipSound;
 };
@@ -205,8 +207,10 @@ public:
 	Uint16 nPort;
 };
 
-class Options final {
+class Options final : public OptionGroup {
 public:
+	Options();
+
 	AudioOptions Audio;
 	GameplayOptions Gameplay;
 	GraphicsOptions Graphics;

--- a/Source/options.h
+++ b/Source/options.h
@@ -196,15 +196,15 @@ public:
 	/** @brief Recover mana when talking to Adria. */
 	BooleanOption bAdriaRefillsMana = { "Adria Refills Mana", false };
 	/** @brief Automatically attempt to equip weapon-type items when picking them up. */
-	bool bAutoEquipWeapons;
+	BooleanOption bAutoEquipWeapons = { "Auto Equip Weapons", true };
 	/** @brief Automatically attempt to equip armor-type items when picking them up. */
-	bool bAutoEquipArmor;
+	BooleanOption bAutoEquipArmor = { "Auto Equip Armor", false };
 	/** @brief Automatically attempt to equip helm-type items when picking them up. */
-	bool bAutoEquipHelms;
+	BooleanOption bAutoEquipHelms = { "Auto Equip Helms", false };
 	/** @brief Automatically attempt to equip shield-type items when picking them up. */
-	bool bAutoEquipShields;
+	BooleanOption bAutoEquipShields = { "Auto Equip Shields", false };
 	/** @brief Automatically attempt to equip jewelry-type items when picking them up. */
-	bool bAutoEquipJewelry;
+	BooleanOption bAutoEquipJewelry = { "Auto Equip Jewelry", false };
 	/** @brief Only enable 2/3 quests in each game sessoin */
 	bool bRandomizeQuests;
 	/** @brief Indicates whether or not mosnter type (Animal, Demon, Undead) is shown along with other monster information. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -154,7 +154,7 @@ public:
 	/** @brief See SDL_HINT_RENDER_SCALE_QUALITY. */
 	char szScaleQuality[2];
 	/** @brief Only scale by values divisible by the width and height. */
-	bool bIntegerScaling;
+	BooleanOption bIntegerScaling = { "Integer Scaling", false };
 	/** @brief Enable vsync on the output. */
 	bool bVSync;
 	/** @brief Use blended transparency rather than stippled. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -186,7 +186,7 @@ public:
 	/** @brief Enable the bard hero class. */
 	BooleanOption bTestBard = { "Test Bard", false };
 	/** @brief Enable the babarian hero class. */
-	bool bTestBarbarian;
+	BooleanOption bTestBarbarian = { "Test Barbarian", false };
 	/** @brief Show the current level progress. */
 	bool bExperienceBar;
 	/** @brief Show enemy health at the top of the screen. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -1,0 +1,100 @@
+#pragma once
+
+DEVILUTION_BEGIN_NAMESPACE
+
+typedef struct AudioOptions {
+	/** @brief Movie and SFX volume. */
+	Sint32 nSoundVolume;
+	/** @brief Music volume. */
+	Sint32 nMusicVolume;
+	/** @brief Player emits sound when walking. */
+	bool bWalkingSound;
+	/** @brief Automatically equipping items on pickup emits the equipment sound. */
+	bool bAutoEquipSound;
+} AudioOptions;
+
+typedef struct GraphicsOptions {
+	/** @brief Render width. */
+	Sint32 nWidth;
+	/** @brief Render height. */
+	Sint32 nHeight;
+	/** @brief Run in fullscreen or windowed mode. */
+	bool bFullscreen;
+	/** @brief Scale the image after rendering. */
+	bool bUpscale;
+	/** @brief Expand the aspect ratio to match the screen. */
+	bool bFitToScreen;
+	/** @brief See SDL_HINT_RENDER_SCALE_QUALITY. */
+	char szScaleQuality[2];
+	/** @brief Only scale by values divisible by the width and height. */
+	bool bIntegerScaling;
+	/** @brief Enable vsync on the output. */
+	bool bVSync;
+	/** @brief Use blended transparency rather than stippled. */
+	bool bBlendedTransparancy;
+	/** @brief Gamma correction level. */
+	Sint32 nGammaCorrection;
+	/** @brief Enable color cycling animations. */
+	bool bColorCycling;
+	/** @brief Enable FPS Limit. */
+	bool bFPSLimit;
+} GraphicsOptions;
+
+typedef struct GameplayOptions {
+	/** @brief Game play ticks per secound. */
+	Sint32 nTickRate;
+	/** @brief Enable double walk speed when in town. */
+	bool bJogInTown;
+	/** @brief Do not let the mouse leave the application window. */
+	bool bGrabInput;
+	/** @brief Enable the Theo quest. */
+	bool bTheoQuest;
+	/** @brief Enable the cow quest. */
+	bool bCowQuest;
+	/** @brief Will players still damage other players in non-PvP mode. */
+	bool bFriendlyFire;
+	/** @brief Enable the bard hero class. */
+	bool bTestBard;
+	/** @brief Enable the babarian hero class. */
+	bool bTestBarbarian;
+	/** @brief Show the current level progress. */
+	bool bExperienceBar;
+	/** @brief Show enemy health at the top of the screen. */
+	bool bEnemyHealthBar;
+	/** @brief Automatically pick up goald when walking on to it. */
+	bool bAutoGoldPickup;
+	/** @brief Recover mana when talking to Adria. */
+	bool bAdriaRefillsMana;
+	/** @brief Automatically attempt to equip weapon-type items when picking them up. */
+	bool bAutoEquipWeapons;
+	/** @brief Automatically attempt to equip armor-type items when picking them up. */
+	bool bAutoEquipArmor;
+	/** @brief Automatically attempt to equip helm-type items when picking them up. */
+	bool bAutoEquipHelms;
+	/** @brief Automatically attempt to equip shield-type items when picking them up. */
+	bool bAutoEquipShields;
+	/** @brief Automatically attempt to equip jewelry-type items when picking them up. */
+	bool bAutoEquipJewelry;
+	/** @brief Only enable 2/3 quests in each game sessoin */
+	bool bRandomizeQuests;
+	/** @brief Indicates whether or not mosnter type (Animal, Demon, Undead) is shown along with other monster information. */
+	bool bShowMonsterType;
+} GameplayOptions;
+
+typedef struct NetworkOptions {
+	/** @brief Optionally bind to a specific network interface. */
+	char szBindAddress[129];
+	/** @brief What network port to use. */
+	Uint16 nPort;
+} NetworkOptions;
+
+typedef struct Options {
+	AudioOptions Audio;
+	GameplayOptions Gameplay;
+	GraphicsOptions Graphics;
+	NetworkOptions Network;
+} Options;
+
+extern Options sgOptions;
+
+DEVILUTION_END_NAMESPACE

--- a/Source/options.h
+++ b/Source/options.h
@@ -176,7 +176,7 @@ public:
 	/** @brief Enable double walk speed when in town. */
 	BooleanOption bJogInTown = { "Fast Walk", false };
 	/** @brief Do not let the mouse leave the application window. */
-	bool bGrabInput;
+	BooleanOption bGrabInput = { "Grab Input", false };
 	/** @brief Enable the Theo quest. */
 	bool bTheoQuest;
 	/** @brief Enable the cow quest. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -206,7 +206,7 @@ public:
 	/** @brief Automatically attempt to equip jewelry-type items when picking them up. */
 	BooleanOption bAutoEquipJewelry = { "Auto Equip Jewelry", false };
 	/** @brief Only enable 2/3 quests in each game sessoin */
-	bool bRandomizeQuests;
+	BooleanOption bRandomizeQuests = { "Randomize Quests", true };
 	/** @brief Indicates whether or not mosnter type (Animal, Demon, Undead) is shown along with other monster information. */
 	bool bShowMonsterType;
 };

--- a/Source/options.h
+++ b/Source/options.h
@@ -129,14 +129,16 @@ public:
 	BooleanOption bAutoEquipSound = { "Auto Equip Sound", false };
 };
 
-class GraphicsOptions final {
+class GraphicsOptions final : public OptionGroup {
 public:
+	GraphicsOptions();
+
 	/** @brief Render width. */
 	Sint32 nWidth;
 	/** @brief Render height. */
 	Sint32 nHeight;
 	/** @brief Run in fullscreen or windowed mode. */
-	bool bFullscreen;
+	BooleanOption bFullscreen = { "Fullscreen", true };
 	/** @brief Scale the image after rendering. */
 	bool bUpscale;
 	/** @brief Expand the aspect ratio to match the screen. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -188,7 +188,7 @@ public:
 	/** @brief Enable the babarian hero class. */
 	BooleanOption bTestBarbarian = { "Test Barbarian", false };
 	/** @brief Show the current level progress. */
-	bool bExperienceBar;
+	BooleanOption bExperienceBar = { "Experience Bar", false };
 	/** @brief Show enemy health at the top of the screen. */
 	bool bEnemyHealthBar;
 	/** @brief Automatically pick up goald when walking on to it. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -156,7 +156,7 @@ public:
 	/** @brief Only scale by values divisible by the width and height. */
 	BooleanOption bIntegerScaling = { "Integer Scaling", false };
 	/** @brief Enable vsync on the output. */
-	bool bVSync;
+	BooleanOption bVSync = { "Vertical Sync", true };
 	/** @brief Use blended transparency rather than stippled. */
 	bool bBlendedTransparancy;
 	/** @brief Gamma correction level. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -178,7 +178,7 @@ public:
 	/** @brief Do not let the mouse leave the application window. */
 	BooleanOption bGrabInput = { "Grab Input", false };
 	/** @brief Enable the Theo quest. */
-	bool bTheoQuest;
+	BooleanOption bTheoQuest = { "Theo Quest", false };
 	/** @brief Enable the cow quest. */
 	bool bCowQuest;
 	/** @brief Will players still damage other players in non-PvP mode. */

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -136,7 +136,7 @@ void LoadPalette(const char *pszFileName)
 #endif
 	}
 
-	if (sgOptions.Graphics.bBlendedTransparancy) {
+	if (*sgOptions.Graphics.bBlendedTransparancy) {
 		if (leveltype == DTYPE_CAVES || leveltype == DTYPE_CRYPT) {
 			GenerateBlendedLookupTable(orig_palette, 1, 31);
 		} else if (leveltype == DTYPE_NEST) {
@@ -270,7 +270,7 @@ static void CycleColors(int from, int to)
 	}
 	system_palette[to] = col;
 
-	if (!sgOptions.Graphics.bBlendedTransparancy)
+	if (!*sgOptions.Graphics.bBlendedTransparancy)
 		return;
 
 	for (int i = 0; i < 256; i++) {
@@ -302,7 +302,7 @@ static void CycleColorsReverse(int from, int to)
 	}
 	system_palette[from] = col;
 
-	if (!sgOptions.Graphics.bBlendedTransparancy)
+	if (!*sgOptions.Graphics.bBlendedTransparancy)
 		return;
 
 	for (int i = 0; i < 256; i++) {

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -4,6 +4,7 @@
  * Implementation of functions for handling the engines color palette.
  */
 #include "all.h"
+#include "options.h"
 #include "../SourceX/display.h"
 #include "../3rdParty/Storm/Source/storm.h"
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2134,7 +2134,7 @@ bool PM_DoWalk(int pnum, int variant)
 	}
 
 	//Play walking sound effect on certain animation frames
-	if (sgOptions.Audio.bWalkingSound) {
+	if (*sgOptions.Audio.bWalkingSound) {
 		if (plr[pnum]._pAnimFrame == 3
 		    || (plr[pnum]._pWFrames == 8 && plr[pnum]._pAnimFrame == 7)
 		    || (plr[pnum]._pWFrames != 8 && plr[pnum]._pAnimFrame == 4)) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 
 #include "all.h"
+#include "options.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -4,6 +4,7 @@
  * Implementation of functionality for handling quests.
  */
 #include "all.h"
+#include "options.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -146,7 +146,7 @@ void InitQuests()
 		quests[z]._qmsg = questlist[z]._qdmsg;
 	}
 
-	if (!gbIsMultiplayer && sgOptions.Gameplay.bRandomizeQuests) {
+	if (!gbIsMultiplayer && *sgOptions.Gameplay.bRandomizeQuests) {
 		SetRndSeed(glSeedTbl[15]);
 		if (random_(0, 2) != 0)
 			quests[Q_PWATER]._qactive = QUEST_NOTAVAIL;

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -4,6 +4,7 @@
  * Implementation of functionality for rendering the level tiles.
  */
 #include "all.h"
+#include "options.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -395,7 +395,7 @@ inline void DoRenderLine(BYTE *dst, BYTE *src, int n, BYTE *tbl, DWORD mask)
 		assert(n != 0 && n <= sizeof(DWORD) * CHAR_BIT);
 		mask &= DWORD(-1) << ((sizeof(DWORD) * CHAR_BIT) - n);
 
-		if (sgOptions.Graphics.bBlendedTransparancy) {    // Blended transparancy
+		if (*sgOptions.Graphics.bBlendedTransparancy) {    // Blended transparancy
 			if (light_table_index == lightmax) { // Complete darkness
 				for (int i = 0; i < n; i++, mask <<= 1) {
 					if (mask & 0x80000000)
@@ -473,7 +473,7 @@ void RenderTile(CelOutputBuffer out, int x, int y)
 
 	if (cel_transparency_active) {
 		if (arch_draw_type == 0) {
-			if (sgOptions.Graphics.bBlendedTransparancy) // Use a fully transparent mask
+			if (*sgOptions.Graphics.bBlendedTransparancy) // Use a fully transparent mask
 				mask = &WallMask_FullyTrasparent[TILE_HEIGHT - 1];
 			else
 				mask = &WallMask[TILE_HEIGHT - 1];
@@ -481,7 +481,7 @@ void RenderTile(CelOutputBuffer out, int x, int y)
 		if (arch_draw_type == 1 && tile != RT_LTRIANGLE) {
 			c = block_lvid[level_piece_id];
 			if (c == 1 || c == 3) {
-				if (sgOptions.Graphics.bBlendedTransparancy) // Use a fully transparent mask
+				if (*sgOptions.Graphics.bBlendedTransparancy) // Use a fully transparent mask
 					mask = &LeftMask_Transparent[TILE_HEIGHT - 1];
 				else
 					mask = &LeftMask[TILE_HEIGHT - 1];
@@ -490,7 +490,7 @@ void RenderTile(CelOutputBuffer out, int x, int y)
 		if (arch_draw_type == 2 && tile != RT_RTRIANGLE) {
 			c = block_lvid[level_piece_id];
 			if (c == 2 || c == 3) {
-				if (sgOptions.Graphics.bBlendedTransparancy) // Use a fully transparent mask
+				if (*sgOptions.Graphics.bBlendedTransparancy) // Use a fully transparent mask
 					mask = &RightMask_Transparent[TILE_HEIGHT - 1];
 				else
 					mask = &RightMask[TILE_HEIGHT - 1];

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -4,6 +4,7 @@
  * Implementation of functionality for stores and towner dialogs.
  */
 #include "all.h"
+#include "options.h"
 #include <algorithm>
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -628,7 +628,7 @@ void S_StartSRepair()
 
 void FillManaPlayer()
 {
-	if (!sgOptions.Gameplay.bAdriaRefillsMana)
+	if (!*sgOptions.Gameplay.bAdriaRefillsMana)
 		return;
 	if (plr[myplr]._pMana != plr[myplr]._pMaxMana) {
 		PlaySFX(IS_CAST8);

--- a/SourceX/DiabloUI/selgame.cpp
+++ b/SourceX/DiabloUI/selgame.cpp
@@ -447,7 +447,7 @@ void selgame_Password_Select(int value)
 	data->nTickRate = nTickRate;
 	data->bJogInTown = *sgOptions.Gameplay.bJogInTown;
 	data->bTheoQuest = *sgOptions.Gameplay.bTheoQuest;
-	data->bCowQuest = sgOptions.Gameplay.bCowQuest;
+	data->bCowQuest = *sgOptions.Gameplay.bCowQuest;
 
 	if (SNetCreateGame(NULL, selgame_Password, NULL, 0, (char *)data, sizeof(GameData), MAX_PLRS, NULL, NULL, gdwPlayerId)) {
 		UiInitList_clear();

--- a/SourceX/DiabloUI/selgame.cpp
+++ b/SourceX/DiabloUI/selgame.cpp
@@ -445,7 +445,7 @@ void selgame_Password_Select(int value)
 	GameData *data = m_client_info->initdata;
 	data->nDifficulty = nDifficulty;
 	data->nTickRate = nTickRate;
-	data->bJogInTown = sgOptions.Gameplay.bJogInTown;
+	data->bJogInTown = *sgOptions.Gameplay.bJogInTown;
 	data->bTheoQuest = sgOptions.Gameplay.bTheoQuest;
 	data->bCowQuest = sgOptions.Gameplay.bCowQuest;
 

--- a/SourceX/DiabloUI/selgame.cpp
+++ b/SourceX/DiabloUI/selgame.cpp
@@ -7,6 +7,7 @@
 #include "DiabloUI/dialogs.h"
 #include "DiabloUI/selok.h"
 #include "DiabloUI/selhero.h"
+#include "options.h"
 
 namespace dvl {
 

--- a/SourceX/DiabloUI/selgame.cpp
+++ b/SourceX/DiabloUI/selgame.cpp
@@ -446,7 +446,7 @@ void selgame_Password_Select(int value)
 	data->nDifficulty = nDifficulty;
 	data->nTickRate = nTickRate;
 	data->bJogInTown = *sgOptions.Gameplay.bJogInTown;
-	data->bTheoQuest = sgOptions.Gameplay.bTheoQuest;
+	data->bTheoQuest = *sgOptions.Gameplay.bTheoQuest;
 	data->bCowQuest = sgOptions.Gameplay.bCowQuest;
 
 	if (SNetCreateGame(NULL, selgame_Password, NULL, 0, (char *)data, sizeof(GameData), MAX_PLRS, NULL, NULL, gdwPlayerId)) {

--- a/SourceX/DiabloUI/selhero.cpp
+++ b/SourceX/DiabloUI/selhero.cpp
@@ -279,7 +279,7 @@ void selhero_List_Select(int value)
 		if (gbBard || *sgOptions.Gameplay.bTestBard) {
 			vecSelHeroDlgItems.push_back(new UiListItem("Bard", PC_BARD));
 		}
-		if (gbBarbarian || sgOptions.Gameplay.bTestBarbarian) {
+		if (gbBarbarian || *sgOptions.Gameplay.bTestBarbarian) {
 			vecSelHeroDlgItems.push_back(new UiListItem("Barbarian", PC_BARBARIAN));
 		}
 		if (vecSelHeroDlgItems.size() > 4)

--- a/SourceX/DiabloUI/selhero.cpp
+++ b/SourceX/DiabloUI/selhero.cpp
@@ -12,6 +12,7 @@
 #include "DiabloUI/selyesno.h"
 #include "DiabloUI/selok.h"
 #include "DiabloUI/selgame.h"
+#include "options.h"
 
 #ifdef __3DS__
 #include "../platform/ctr/keyboard.h"

--- a/SourceX/DiabloUI/selhero.cpp
+++ b/SourceX/DiabloUI/selhero.cpp
@@ -276,7 +276,7 @@ void selhero_List_Select(int value)
 		if (gbIsHellfire) {
 			vecSelHeroDlgItems.push_back(new UiListItem("Monk", PC_MONK));
 		}
-		if (gbBard || sgOptions.Gameplay.bTestBard) {
+		if (gbBard || *sgOptions.Gameplay.bTestBard) {
 			vecSelHeroDlgItems.push_back(new UiListItem("Bard", PC_BARD));
 		}
 		if (gbBarbarian || sgOptions.Gameplay.bTestBarbarian) {

--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -89,7 +89,7 @@ void CalculatePreferdWindowSize(int &width, int &height)
 		ErrSdl();
 	}
 
-	if (!sgOptions.Graphics.bIntegerScaling) {
+	if (!*sgOptions.Graphics.bIntegerScaling) {
 		float wFactor = (float)mode.w / width;
 		float hFactor = (float)mode.h / height;
 
@@ -225,7 +225,7 @@ bool SpawnWindow(const char *lpWindowName)
 			ErrSdl();
 		}
 
-		if (sgOptions.Graphics.bIntegerScaling && SDL_RenderSetIntegerScale(renderer, SDL_TRUE) < 0) {
+		if (*sgOptions.Graphics.bIntegerScaling && SDL_RenderSetIntegerScale(renderer, SDL_TRUE) < 0) {
 			ErrSdl();
 		}
 

--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -4,6 +4,7 @@
 #include "controls/controller.h"
 #include "controls/devices/game_controller.h"
 #include "controls/devices/joystick.h"
+#include "options.h"
 
 #ifdef __vita__
 #include <psp2/power.h>

--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -211,7 +211,7 @@ bool SpawnWindow(const char *lpWindowName)
 #ifndef USE_SDL1
 		Uint32 rendererFlags = SDL_RENDERER_ACCELERATED;
 
-		if (sgOptions.Graphics.bVSync) {
+		if (*sgOptions.Graphics.bVSync) {
 			rendererFlags |= SDL_RENDERER_PRESENTVSYNC;
 		}
 

--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -171,7 +171,7 @@ bool SpawnWindow(const char *lpWindowName)
 #ifdef USE_SDL1
 	SDL_WM_SetCaption(lpWindowName, WINDOW_ICON_NAME);
 	SetVideoModeToPrimary(!gbForceWindowed && *sgOptions.Graphics.bFullscreen, width, height);
-	if (sgOptions.Gameplay.bGrabInput)
+	if (*sgOptions.Gameplay.bGrabInput)
 		SDL_WM_GrabInput(SDL_GRAB_ON);
 	atexit(SDL_VideoQuit); // Without this video mode is not restored after fullscreen.
 #else
@@ -187,7 +187,7 @@ bool SpawnWindow(const char *lpWindowName)
 		flags |= SDL_WINDOW_FULLSCREEN;
 	}
 
-	if (sgOptions.Gameplay.bGrabInput) {
+	if (*sgOptions.Gameplay.bGrabInput) {
 		flags |= SDL_WINDOW_INPUT_GRABBED;
 	}
 

--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -163,7 +163,7 @@ bool SpawnWindow(const char *lpWindowName)
 	int width = sgOptions.Graphics.nWidth;
 	int height = sgOptions.Graphics.nHeight;
 
-	if (sgOptions.Graphics.bUpscale && sgOptions.Graphics.bFitToScreen) {
+	if (*sgOptions.Graphics.bUpscale && sgOptions.Graphics.bFitToScreen) {
 		CalculatePreferdWindowSize(width, height);
 	}
 	AdjustToScreenGeometry(width, height);
@@ -176,7 +176,7 @@ bool SpawnWindow(const char *lpWindowName)
 	atexit(SDL_VideoQuit); // Without this video mode is not restored after fullscreen.
 #else
 	int flags = 0;
-	if (sgOptions.Graphics.bUpscale) {
+	if (*sgOptions.Graphics.bUpscale) {
 		if (!gbForceWindowed && *sgOptions.Graphics.bFullscreen) {
 			flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 		}
@@ -207,7 +207,7 @@ bool SpawnWindow(const char *lpWindowName)
 #endif
 	refreshDelay = 1000000 / refreshRate;
 
-	if (sgOptions.Graphics.bUpscale) {
+	if (*sgOptions.Graphics.bUpscale) {
 #ifndef USE_SDL1
 		Uint32 rendererFlags = SDL_RENDERER_ACCELERATED;
 

--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -170,20 +170,20 @@ bool SpawnWindow(const char *lpWindowName)
 
 #ifdef USE_SDL1
 	SDL_WM_SetCaption(lpWindowName, WINDOW_ICON_NAME);
-	SetVideoModeToPrimary(!gbForceWindowed && sgOptions.Graphics.bFullscreen, width, height);
+	SetVideoModeToPrimary(!gbForceWindowed && *sgOptions.Graphics.bFullscreen, width, height);
 	if (sgOptions.Gameplay.bGrabInput)
 		SDL_WM_GrabInput(SDL_GRAB_ON);
 	atexit(SDL_VideoQuit); // Without this video mode is not restored after fullscreen.
 #else
 	int flags = 0;
 	if (sgOptions.Graphics.bUpscale) {
-		if (!gbForceWindowed && sgOptions.Graphics.bFullscreen) {
+		if (!gbForceWindowed && *sgOptions.Graphics.bFullscreen) {
 			flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 		}
 		flags |= SDL_WINDOW_RESIZABLE;
 
 		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, sgOptions.Graphics.szScaleQuality);
-	} else if (!gbForceWindowed && sgOptions.Graphics.bFullscreen) {
+	} else if (!gbForceWindowed && *sgOptions.Graphics.bFullscreen) {
 		flags |= SDL_WINDOW_FULLSCREEN;
 	}
 

--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -163,7 +163,7 @@ bool SpawnWindow(const char *lpWindowName)
 	int width = sgOptions.Graphics.nWidth;
 	int height = sgOptions.Graphics.nHeight;
 
-	if (*sgOptions.Graphics.bUpscale && sgOptions.Graphics.bFitToScreen) {
+	if (*sgOptions.Graphics.bUpscale && *sgOptions.Graphics.bFitToScreen) {
 		CalculatePreferdWindowSize(width, height);
 	}
 	AdjustToScreenGeometry(width, height);

--- a/SourceX/dvlnet/tcp_client.cpp
+++ b/SourceX/dvlnet/tcp_client.cpp
@@ -1,4 +1,5 @@
 #include "dvlnet/tcp_client.h"
+#include "options.h"
 
 #include <functional>
 #include <exception>

--- a/SourceX/dvlnet/udp_p2p.cpp
+++ b/SourceX/dvlnet/udp_p2p.cpp
@@ -1,4 +1,5 @@
 #include "dvlnet/udp_p2p.h"
+#include "options.h"
 
 #include <SDL.h>
 

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -295,7 +295,7 @@ void RenderPresent()
 		}
 		SDL_RenderPresent(renderer);
 
-		if (!sgOptions.Graphics.bVSync) {
+		if (!*sgOptions.Graphics.bVSync) {
 			LimitFrameRate();
 		}
 	} else {

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -250,7 +250,7 @@ void Blit(SDL_Surface *src, SDL_Rect *src_rect, SDL_Rect *dst_rect)
  */
 void LimitFrameRate()
 {
-	if (!sgOptions.Graphics.bFPSLimit)
+	if (!*sgOptions.Graphics.bFPSLimit)
 		return;
 	static uint32_t frameDeadline;
 	uint32_t tc = SDL_GetTicks() * 1000;

--- a/SourceX/dx.cpp
+++ b/SourceX/dx.cpp
@@ -6,6 +6,7 @@
 #include "all.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include "display.h"
+#include "options.h"
 #include <SDL.h>
 
 #ifdef __3DS__

--- a/SourceX/qol.cpp
+++ b/SourceX/qol.cpp
@@ -92,7 +92,7 @@ void DrawMonsterHealthBar(CelOutputBuffer out)
 
 	FillRect(out, xPos, yPos, (width * currentLife) / maxLife, height, filledColor);
 
-	if (sgOptions.Gameplay.bShowMonsterType) {
+	if (*sgOptions.Gameplay.bShowMonsterType) {
 		for (int j = 0; j < borderSize; j++) {
 			FastDrawHorizLine(out, xPos - xOffset - corners, yPos - borderSize - yOffset + j, (xOffset + corners) * 2 + width, borderColor);
 			FastDrawHorizLine(out, xPos - xOffset, yPos + height + yOffset + j, width + corners + xOffset * 2, borderColor);

--- a/SourceX/qol.cpp
+++ b/SourceX/qol.cpp
@@ -143,7 +143,7 @@ void DrawMonsterHealthBar(CelOutputBuffer out)
 
 void DrawXPBar(CelOutputBuffer out)
 {
-	if (!sgOptions.Gameplay.bExperienceBar)
+	if (!*sgOptions.Gameplay.bExperienceBar)
 		return;
 
 	int barWidth = 306;

--- a/SourceX/qol.cpp
+++ b/SourceX/qol.cpp
@@ -49,7 +49,7 @@ void FillSquare(CelOutputBuffer out, int x, int y, int size, BYTE col)
 
 void DrawMonsterHealthBar(CelOutputBuffer out)
 {
-	if (!sgOptions.Gameplay.bEnemyHealthBar)
+	if (!*sgOptions.Gameplay.bEnemyHealthBar)
 		return;
 	if (currlevel == 0)
 		return;

--- a/SourceX/qol.cpp
+++ b/SourceX/qol.cpp
@@ -4,6 +4,7 @@
  * Quality of life features
  */
 #include "all.h"
+#include "options.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
 DEVILUTION_BEGIN_NAMESPACE

--- a/SourceX/qol.cpp
+++ b/SourceX/qol.cpp
@@ -194,7 +194,7 @@ bool HasRoomForGold()
 
 void AutoGoldPickup(int pnum)
 {
-	if (!sgOptions.Gameplay.bAutoGoldPickup)
+	if (!*sgOptions.Gameplay.bAutoGoldPickup)
 		return;
 	if (pnum != myplr)
 		return;

--- a/SourceX/sound.cpp
+++ b/SourceX/sound.cpp
@@ -4,6 +4,7 @@
  * Implementation of functions setting up the audio pipeline.
  */
 #include "all.h"
+#include "options.h"
 #include "../3rdParty/Storm/Source/storm.h"
 #include "stubs.h"
 #include "storm_sdl_rw.h"

--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -2,6 +2,7 @@
 #include <string>
 
 #include "all.h"
+#include "options.h"
 #include "paths.h"
 #include "../3rdParty/Storm/Source/storm.h"
 

--- a/SourceX/storm/storm_net.cpp
+++ b/SourceX/storm/storm_net.cpp
@@ -1,6 +1,7 @@
 #include <memory>
 
 #include "all.h"
+#include "options.h"
 #include "stubs.h"
 #include "dvlnet/abstract_net.h"
 


### PR DESCRIPTION
This PR introduces new Options infrastruture to better centralize management of all settings in the game, by creating a hierarchy of classes that can save and load from the ini by themselves.

This makes it easier to add/remove/update flags as their definition is centralized in only one place, avoiding code duplication and mistakes.

For this iteration, we only replace boolean flags with the new system. Other types of flags will come later (each setting is mostly independent of each other).