### PR TITLE
Remove SFileDdaSetVolume

### DIFF
--- a/3rdParty/Storm/Source/storm.h
+++ b/3rdParty/Storm/Source/storm.h
@@ -207,8 +207,6 @@ BOOL
 BOOL STORMAPI SFileCloseArchive(HANDLE hArchive);
 BOOL STORMAPI SFileCloseFile(HANDLE hFile);
 
-BOOL STORMAPI SFileDdaSetVolume(HANDLE hFile, signed int bigvolume, signed int volume);
-
 LONG STORMAPI SFileGetFileSize(HANDLE hFile, LPDWORD lpFileSizeHigh);
 BOOL STORMAPI SFileOpenArchive(const char *szMpqName, DWORD dwPriority, DWORD dwFlags, HANDLE *phMpq);
 

--- a/SourceX/sound.cpp
+++ b/SourceX/sound.cpp
@@ -237,7 +237,7 @@ int sound_get_or_set_music_volume(int volume)
 	sgOptions.Audio.nMusicVolume = volume;
 
 	if (sghMusic)
-		SFileDdaSetVolume(sghMusic, volume, 0);
+		Mix_VolumeMusic(MIX_MAX_VOLUME - MIX_MAX_VOLUME * volume / VOLUME_MIN);
 
 	return sgOptions.Audio.nMusicVolume;
 }

--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -40,13 +40,6 @@ radon::File &getIni()
 	return ini;
 }
 
-BOOL SFileDdaSetVolume(HANDLE hFile, signed int bigvolume, signed int volume)
-{
-	Mix_VolumeMusic(MIX_MAX_VOLUME - MIX_MAX_VOLUME * bigvolume / VOLUME_MIN);
-
-	return true;
-}
-
 // Converts ASCII characters to lowercase
 // Converts slash (0x2F) / backslash (0x5C) to system file-separator
 unsigned char AsciiToLowerTable_Path[256] = {


### PR DESCRIPTION
It is only used in one place and does not actually control the volume of any specific file.