### PR TITLE
Add std::unique_ptr specializations for SDL types

### DIFF
--- a/SourceX/DiabloUI/art.h
+++ b/SourceX/DiabloUI/art.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "all.h"
+#include "../sdl_ptrs.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 namespace devilution {
 
 struct Art {
-	SDL_Surface *surface;
+	SDLSurfaceUniquePtr surface;
 	int frames;
 	int logical_width;
 	int frame_height;
@@ -32,8 +34,7 @@ struct Art {
 
 	void Unload()
 	{
-		SDL_FreeSurface(surface);
-		surface = NULL;
+		surface = nullptr;
 	}
 };
 

--- a/SourceX/DiabloUI/art_draw.cpp
+++ b/SourceX/DiabloUI/art_draw.cpp
@@ -26,12 +26,12 @@ void DrawArt(Sint16 screenX, Sint16 screenY, Art *art, int nFrame, Uint16 srcW, 
 	ScaleOutputRect(&dst_rect);
 
 	if (art->surface->format->BitsPerPixel == 8 && art->palette_version != pal_surface_palette_version) {
-		if (SDLC_SetSurfaceColors(art->surface, pal_surface->format->palette) <= -1)
+		if (SDLC_SetSurfaceColors(art->surface.get(), pal_surface->format->palette) <= -1)
 			ErrSdl();
 		art->palette_version = pal_surface_palette_version;
 	}
 
-	if (SDL_BlitSurface(art->surface, &src_rect, DiabloUiSurface(), &dst_rect) < 0)
+	if (SDL_BlitSurface(art->surface.get(), &src_rect, DiabloUiSurface(), &dst_rect) < 0)
 		ErrSdl();
 }
 
@@ -57,12 +57,12 @@ void DrawArt(CelOutputBuffer out, Sint16 screenX, Sint16 screenY, Art *art, int 
 	dst_rect.h = src_rect.h;
 
 	if (art->surface->format->BitsPerPixel == 8 && art->palette_version != pal_surface_palette_version) {
-		if (SDLC_SetSurfaceColors(art->surface, out.surface->format->palette) <= -1)
+		if (SDLC_SetSurfaceColors(art->surface.get(), out.surface->format->palette) <= -1)
 			ErrSdl();
 		art->palette_version = pal_surface_palette_version;
 	}
 
-	if (SDL_BlitSurface(art->surface, &src_rect, out.surface, &dst_rect) < 0)
+	if (SDL_BlitSurface(art->surface.get(), &src_rect, out.surface, &dst_rect) < 0)
 		ErrSdl();
 }
 

--- a/SourceX/DiabloUI/credits.cpp
+++ b/SourceX/DiabloUI/credits.cpp
@@ -5,6 +5,7 @@
 #include "controls/menu_controls.h"
 #include "all.h"
 #include "display.h"
+#include "sdl_ptrs.h"
 
 #include "DiabloUI/diabloui.h"
 #include "DiabloUI/credits_lines.h"
@@ -35,19 +36,18 @@ struct CachedLine {
 	CachedLine()
 	{
 		m_index = 0;
-		m_surface = NULL;
 		palette_version = pal_surface_palette_version;
 	}
 
-	CachedLine(std::size_t index, SDL_Surface *surface)
+	CachedLine(std::size_t index, SDLSurfaceUniquePtr surface)
 	{
 		m_index = index;
-		m_surface = surface;
+		m_surface = std::move(surface);
 		palette_version = pal_surface_palette_version;
 	}
 
 	std::size_t m_index;
-	SDL_Surface *m_surface;
+	SDLSurfaceUniquePtr m_surface;
 	unsigned int palette_version;
 };
 
@@ -68,40 +68,37 @@ CachedLine PrepareLine(std::size_t index)
 		++contents;
 
 	const SDL_Color shadow_color = { 0, 0, 0, 0 };
-	SDL_Surface *text = RenderText(contents, shadow_color);
+	SDLSurfaceUniquePtr text { RenderText(contents, shadow_color) };
 
 	// Precompose shadow and text:
-	SDL_Surface *surface = NULL;
-	if (text != NULL) {
+	SDLSurfaceUniquePtr surface;
+	if (text != nullptr) {
 		// Set up the target surface to have 3 colors: mask, text, and shadow.
-		surface = SDL_CreateRGBSurfaceWithFormat(0, text->w + SHADOW_OFFSET_X, text->h + SHADOW_OFFSET_Y, 8, SDL_PIXELFORMAT_INDEX8);
+		surface = SDLSurfaceUniquePtr { SDL_CreateRGBSurfaceWithFormat(0, text->w + SHADOW_OFFSET_X, text->h + SHADOW_OFFSET_Y, 8, SDL_PIXELFORMAT_INDEX8) };
 		const SDL_Color mask_color = { 0, 255, 0, 0 }; // Any color different from both shadow and text
 		const SDL_Color &text_color = palette->colors[224];
 		SDL_Color colors[3] = { mask_color, text_color, shadow_color };
-		if (SDLC_SetSurfaceColors(surface, colors, 0, 3) <= -1)
+		if (SDLC_SetSurfaceColors(surface.get(), colors, 0, 3) <= -1)
 			SDL_Log(SDL_GetError());
-		SDLC_SetColorKey(surface, 0);
+		SDLC_SetColorKey(surface.get(), 0);
 
 		// Blit the shadow first:
 		SDL_Rect shadow_rect = { SHADOW_OFFSET_X, SHADOW_OFFSET_Y, 0, 0 };
-		if (SDL_BlitSurface(text, NULL, surface, &shadow_rect) <= -1)
+		if (SDL_BlitSurface(text.get(), NULL, surface.get(), &shadow_rect) <= -1)
 			ErrSdl();
 
 		// Change the text surface color and blit again:
 		SDL_Color text_colors[2] = { mask_color, text_color };
-		if (SDLC_SetSurfaceColors(text, text_colors, 0, 2) <= -1)
+		if (SDLC_SetSurfaceColors(text.get(), text_colors, 0, 2) <= -1)
 			ErrSdl();
-		SDLC_SetColorKey(text, 0);
+		SDLC_SetColorKey(text.get(), 0);
 
-		if (SDL_BlitSurface(text, NULL, surface, NULL) <= -1)
+		if (SDL_BlitSurface(text.get(), NULL, surface.get(), NULL) <= -1)
 			ErrSdl();
 
-		SDL_Surface *surface_ptr = surface;
-		ScaleSurfaceToOutput(&surface_ptr);
-		surface = surface_ptr;
+		surface = ScaleSurfaceToOutput(std::move(surface));
 	}
-	SDL_FreeSurface(text);
-	return CachedLine(index, surface);
+	return CachedLine(index, std::move(surface));
 }
 
 class CreditsRenderer {
@@ -120,11 +117,7 @@ public:
 		ArtBackgroundWidescreen.Unload();
 		ArtBackground.Unload();
 		UnloadTtfFont();
-
-		for (size_t x = 0; x < lines_.size(); x++) {
-			if (lines_[x].m_surface)
-				SDL_FreeSurface(lines_[x].m_surface);
-		}
+		lines_.clear();
 	}
 
 	void Render();
@@ -176,12 +169,11 @@ void CreditsRenderer::Render()
 	Sint16 dest_y = UI_OFFSET_Y + VIEWPORT.y - (offset_y - lines_begin * LINE_H);
 	for (std::size_t i = lines_begin; i < lines_end; ++i, dest_y += LINE_H) {
 		CachedLine &line = lines_[i];
-		if (line.m_surface == NULL)
+		if (line.m_surface == nullptr)
 			continue;
 
 		// Still fading in: the cached line was drawn with a different fade level.
 		if (line.palette_version != pal_surface_palette_version) {
-			SDL_FreeSurface(line.m_surface);
 			line = PrepareLine(line.m_index);
 		}
 
@@ -194,7 +186,7 @@ void CreditsRenderer::Render()
 		ScaleOutputRect(&dst_rect);
 		dst_rect.w = line.m_surface->w;
 		dst_rect.h = line.m_surface->h;
-		if (SDL_BlitSurface(line.m_surface, NULL, DiabloUiSurface(), &dst_rect) < 0)
+		if (SDL_BlitSurface(line.m_surface.get(), NULL, DiabloUiSurface(), &dst_rect) < 0)
 			ErrSdl();
 	}
 	SDL_SetClipRect(DiabloUiSurface(), NULL);

--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -14,6 +14,7 @@
 #include "DiabloUI/scrollbar.h"
 #include "DiabloUI/text_draw.h"
 #include "display.h"
+#include "sdl_ptrs.h"
 #include "stubs.h"
 #include "utf8.h"
 
@@ -454,24 +455,22 @@ void LoadHeros()
 		}
 		SDL_Rect src_rect = makeRect(0, offset, ArtHero.w(), portraitHeight);
 		SDL_Rect dst_rect = makeRect(0, i * portraitHeight, ArtHero.w(), portraitHeight);
-		SDL_BlitSurface(ArtHero.surface, &src_rect, heros, &dst_rect);
+		SDL_BlitSurface(ArtHero.surface.get(), &src_rect, heros, &dst_rect);
 	}
 
-	Art ArtPortrait;
 	for (int i = 0; i <= NUM_CLASSES; i++) {
+		Art portrait;
 		char portraitPath[18];
 		sprintf(portraitPath, "ui_art\\hero%i.pcx", i);
-		LoadArt(portraitPath, &ArtPortrait);
-		if (ArtPortrait.surface == nullptr)
+		LoadArt(portraitPath, &portrait);
+		if (portrait.surface == nullptr)
 			continue;
 
-		SDL_Rect dst_rect = makeRect(0, i * portraitHeight, ArtPortrait.w(), portraitHeight);
-		SDL_BlitSurface(ArtPortrait.surface, nullptr, heros, &dst_rect);
-		ArtPortrait.Unload();
+		SDL_Rect dst_rect = makeRect(0, i * portraitHeight, portrait.w(), portraitHeight);
+		SDL_BlitSurface(portrait.surface.get(), nullptr, heros, &dst_rect);
 	}
 
-	ArtHero.Unload();
-	ArtHero.surface = heros;
+	ArtHero.surface = SDLSurfaceUniquePtr { heros };
 	ArtHero.frame_height = portraitHeight;
 	ArtHero.frames = NUM_CLASSES;
 }

--- a/SourceX/DiabloUI/text_draw.cpp
+++ b/SourceX/DiabloUI/text_draw.cpp
@@ -42,15 +42,14 @@ void DrawTTF(const char *text, const SDL_Rect &rectIn, int flags,
 	if (font == NULL || text == NULL || *text == '\0')
 		return;
 	if (*render_cache == NULL) {
-		*render_cache = new TtfSurfaceCache();
 		const auto x_align = XAlignmentFromFlags(flags);
-		(*render_cache)->text = RenderUTF8_Solid_Wrapped(font, text, text_color, rect.w, x_align);
-		ScaleSurfaceToOutput(&(*render_cache)->text);
-		(*render_cache)->shadow = RenderUTF8_Solid_Wrapped(font, text, shadow_color, rect.w, x_align);
-		ScaleSurfaceToOutput(&(*render_cache)->shadow);
+		*render_cache = new TtfSurfaceCache {
+			/*.text=*/ScaleSurfaceToOutput(SDLSurfaceUniquePtr { RenderUTF8_Solid_Wrapped(font, text, text_color, rect.w, x_align) }),
+			/*.shadow=*/ScaleSurfaceToOutput(SDLSurfaceUniquePtr { RenderUTF8_Solid_Wrapped(font, text, shadow_color, rect.w, x_align) }),
+		};
 	}
-	SDL_Surface *text_surface = (*render_cache)->text;
-	SDL_Surface *shadow_surface = (*render_cache)->shadow;
+	SDL_Surface *text_surface = (*render_cache)->text.get();
+	SDL_Surface *shadow_surface = (*render_cache)->shadow.get();
 	if (text_surface == NULL)
 		return;
 

--- a/SourceX/DiabloUI/text_draw.h
+++ b/SourceX/DiabloUI/text_draw.h
@@ -1,25 +1,14 @@
 #pragma once
 
-#include "all.h"
+#include <SDL.h>
+
+#include "sdl_ptrs.h"
 
 namespace devilution {
 
 struct TtfSurfaceCache {
-
-	TtfSurfaceCache()
-	{
-		text = NULL;
-		shadow = NULL;
-	}
-
-	~TtfSurfaceCache()
-	{
-		mem_free_dbg(text);
-		mem_free_dbg(shadow);
-	}
-
-	SDL_Surface *text;
-	SDL_Surface *shadow;
+	SDLSurfaceUniquePtr text;
+	SDLSurfaceUniquePtr shadow;
 };
 
 void DrawTTF(const char *text, const SDL_Rect &rect, int flags,

--- a/SourceX/controls/devices/game_controller.cpp
+++ b/SourceX/controls/devices/game_controller.cpp
@@ -7,6 +7,7 @@
 #include "controls/controller_motion.h"
 #include "controls/devices/joystick.h"
 #include "stubs.h"
+#include "sdl_ptrs.h"
 
 // Defined in SourceX/controls/plctrls.cpp
 extern "C" bool sgbControllerActive;
@@ -166,9 +167,8 @@ void GameController::Add(int joystick_index)
 	controllers_->push_back(result);
 
 	const SDL_JoystickGUID guid = SDL_JoystickGetGUID(sdl_joystick);
-	char *mapping = SDL_GameControllerMappingForGUID(guid);
-	SDL_Log("Opened game controller with mapping:\n%s", mapping);
-	SDL_free(mapping);
+	SDLUniquePtr<char> mapping{SDL_GameControllerMappingForGUID(guid)};
+	SDL_Log("Opened game controller with mapping:\n%s", mapping.get());
 }
 
 void GameController::Remove(SDL_JoystickID instance_id)

--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -301,6 +301,17 @@ SDL_Surface *CreateScaledSurface(SDL_Surface *src)
 } // namespace
 #endif // USE_SDL1
 
+SDLSurfaceUniquePtr ScaleSurfaceToOutput(SDLSurfaceUniquePtr surface)
+{
+#ifdef USE_SDL1
+	SDL_Surface *ptr = surface.release();
+	ScaleSurfaceToOutput(&ptr);
+	return SDLSurfaceUniquePtr{ptr};
+#else
+	return surface;
+#endif
+}
+
 void ScaleSurfaceToOutput(SDL_Surface **surface)
 {
 #ifdef USE_SDL1

--- a/SourceX/display.cpp
+++ b/SourceX/display.cpp
@@ -304,23 +304,10 @@ SDL_Surface *CreateScaledSurface(SDL_Surface *src)
 SDLSurfaceUniquePtr ScaleSurfaceToOutput(SDLSurfaceUniquePtr surface)
 {
 #ifdef USE_SDL1
-	SDL_Surface *ptr = surface.release();
-	ScaleSurfaceToOutput(&ptr);
-	return SDLSurfaceUniquePtr{ptr};
-#else
+	if (OutputRequiresScaling())
+		return SDLSurfaceUniquePtr { CreateScaledSurface(surface.get()) };
+#endif
 	return surface;
-#endif
-}
-
-void ScaleSurfaceToOutput(SDL_Surface **surface)
-{
-#ifdef USE_SDL1
-	if (!OutputRequiresScaling())
-		return;
-	SDL_Surface *stretched = CreateScaledSurface(*surface);
-	SDL_FreeSurface((*surface));
-	*surface = stretched;
-#endif
 }
 
 } // namespace devilution

--- a/SourceX/display.h
+++ b/SourceX/display.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 
 #include "all.h"
+#include "sdl_ptrs.h"
+
 #include <SDL.h>
 #include <type_traits>
 
@@ -38,6 +40,10 @@ bool OutputRequiresScaling();
 void ScaleOutputRect(SDL_Rect *rect);
 
 // If the output requires software scaling, replaces the given surface with a scaled one.
+SDLSurfaceUniquePtr ScaleSurfaceToOutput(SDLSurfaceUniquePtr surface);
+
+// Prefer the SDLSurfaceUniquePtr version.
+// FIXME: Delete this version.
 void ScaleSurfaceToOutput(SDL_Surface **surface);
 
 // Convert from output coordinates to logical (resolution-independent) coordinates.

--- a/SourceX/display.h
+++ b/SourceX/display.h
@@ -42,10 +42,6 @@ void ScaleOutputRect(SDL_Rect *rect);
 // If the output requires software scaling, replaces the given surface with a scaled one.
 SDLSurfaceUniquePtr ScaleSurfaceToOutput(SDLSurfaceUniquePtr surface);
 
-// Prefer the SDLSurfaceUniquePtr version.
-// FIXME: Delete this version.
-void ScaleSurfaceToOutput(SDL_Surface **surface);
-
 // Convert from output coordinates to logical (resolution-independent) coordinates.
 template <
     typename T,

--- a/SourceX/sdl_ptrs.h
+++ b/SourceX/sdl_ptrs.h
@@ -1,0 +1,45 @@
+#pragma once
+/**
+ * @brief std::unique_ptr specializations for SDL types.
+ */
+
+#include <memory>
+#include <type_traits>
+
+#include <SDL.h>
+
+namespace devilution {
+
+/**
+ * @brief Deletes the SDL surface using `SDL_FreeSurface`.
+ */
+struct SDLSurfaceDeleter {
+	void operator()(SDL_Surface *surface) const
+	{
+		SDL_FreeSurface(surface);
+	}
+};
+
+using SDLSurfaceUniquePtr = std::unique_ptr<SDL_Surface, SDLSurfaceDeleter>;
+
+/**
+ * @brief Deletes the object using `SDL_free`.
+ */
+template <typename T>
+struct SDLFreeDeleter {
+	static_assert(!std::is_same<T, SDL_Surface>::value,
+	    "SDL_Surface should use SDLSurfaceUniquePtr instead.");
+
+	void operator()(T *obj) const
+	{
+		SDL_free(obj);
+	}
+};
+
+/**
+ * @brief A unique pointer to T that is deleted with SDL_free.
+ */
+template <typename T>
+using SDLUniquePtr = std::unique_ptr<T, SDLFreeDeleter<T>>;
+
+} // namespace devilution


### PR DESCRIPTION
Adds `SDLSurfaceUniquePtr` that simplifies handling of SDL surfaces (so we don't have to free them manually).

Migrates a few places to this new type as an example.