### PR TITLE
Update SDL2 version to 2.0.14 for Windows MinGW builds. And remove note for SDL2 2.0.12 in readme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -759,7 +759,7 @@ if(CPACK)
     install(FILES "${PROJECT_SOURCE_DIR}/SDL2_ttf-2.0.15/i686-w64-mingw32/bin/libfreetype-6.dll"
       DESTINATION "."
     )
-    install(FILES "${PROJECT_SOURCE_DIR}/SDL2-2.0.9/i686-w64-mingw32/bin/SDL2.dll"
+    install(FILES "${PROJECT_SOURCE_DIR}/SDL2-2.0.14/i686-w64-mingw32/bin/SDL2.dll"
       DESTINATION "."
     )
     install(FILES "${PROJECT_SOURCE_DIR}/SDL2_mixer-2.0.4/i686-w64-mingw32/bin/SDL2_mixer.dll"
@@ -777,7 +777,7 @@ if(CPACK)
     install(FILES "${PROJECT_SOURCE_DIR}/SDL2_ttf-2.0.15/i686-w64-mingw32/bin/LICENSE.freetype.txt"
       DESTINATION "LICENSE"
     )
-    install(FILES "${PROJECT_SOURCE_DIR}/SDL2-2.0.9/README-SDL.txt"
+    install(FILES "${PROJECT_SOURCE_DIR}/SDL2-2.0.14/README-SDL.txt"
       DESTINATION "LICENSE"
     )
 
@@ -799,7 +799,7 @@ if(CPACK)
     install(FILES "${PROJECT_SOURCE_DIR}/SDL2_ttf-2.0.15/x86_64-w64-mingw32/bin/libfreetype-6.dll"
       DESTINATION "."
     )
-    install(FILES "${PROJECT_SOURCE_DIR}/SDL2-2.0.9/x86_64-w64-mingw32/bin/SDL2.dll"
+    install(FILES "${PROJECT_SOURCE_DIR}/SDL2-2.0.14/x86_64-w64-mingw32/bin/SDL2.dll"
       DESTINATION "."
     )
     install(FILES "${PROJECT_SOURCE_DIR}/SDL2_mixer-2.0.4/x86_64-w64-mingw32/bin/SDL2_mixer.dll"
@@ -817,7 +817,7 @@ if(CPACK)
     install(FILES "${PROJECT_SOURCE_DIR}/SDL2_ttf-2.0.15/x86_64-w64-mingw32/bin/LICENSE.freetype.txt"
       DESTINATION "LICENSE"
     )
-    install(FILES "${PROJECT_SOURCE_DIR}/SDL2-2.0.9/README-SDL.txt"
+    install(FILES "${PROJECT_SOURCE_DIR}/SDL2-2.0.14/README-SDL.txt"
       DESTINATION "LICENSE"
     )
 

--- a/Packaging/windows/mingw-prep.sh
+++ b/Packaging/windows/mingw-prep.sh
@@ -3,8 +3,8 @@
 # exit when any command fails
 set -euo pipefail
 
-wget https://www.libsdl.org/release/SDL2-devel-2.0.9-mingw.tar.gz
-tar -xzf SDL2-devel-2.0.9-mingw.tar.gz
+wget https://www.libsdl.org/release/SDL2-devel-2.0.14-mingw.tar.gz
+tar -xzf SDL2-devel-2.0.14-mingw.tar.gz
 wget https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.15-mingw.tar.gz
 tar -xzf SDL2_ttf-devel-2.0.15-mingw.tar.gz
 wget https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.4-mingw.tar.gz

--- a/Packaging/windows/mingw-prep64.sh
+++ b/Packaging/windows/mingw-prep64.sh
@@ -3,8 +3,8 @@
 # exit when any command fails
 set -euo pipefail
 
-wget https://www.libsdl.org/release/SDL2-devel-2.0.9-mingw.tar.gz
-tar -xzf SDL2-devel-2.0.9-mingw.tar.gz
+wget https://www.libsdl.org/release/SDL2-devel-2.0.14-mingw.tar.gz
+tar -xzf SDL2-devel-2.0.14-mingw.tar.gz
 wget https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.15-mingw.tar.gz
 tar -xzf SDL2_ttf-devel-2.0.15-mingw.tar.gz
 wget https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.4-mingw.tar.gz

--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ cmake --build . -j $(sysctl -n hw.ncpuonline)
 ### 32-bit
 
 Download and place the 32bit MinGW Development Libraries of [SDL2](https://www.libsdl.org/download-2.0.php), [SDL2_mixer](https://www.libsdl.org/projects/SDL_mixer/), [SDL2_ttf](https://www.libsdl.org/projects/SDL_ttf/) and [Libsodium](https://github.com/jedisct1/libsodium/releases) in `/usr/i686-w64-mingw32`. This can be done automatically by running `Packaging/windows/mingw-prep.sh`.
-NOTE: SDL2 2.0.12 appears to not compile correctly.
 
 ```
 sudo apt-get install cmake gcc-mingw-w64-i686 g++-mingw-w64-i686
@@ -124,7 +123,6 @@ sudo apt-get install cmake gcc-mingw-w64-i686 g++-mingw-w64-i686
 ### 64-bit
 
 Download and place the 64bit MinGW Development Libraries of [SDL2](https://www.libsdl.org/download-2.0.php), [SDL2_mixer](https://www.libsdl.org/projects/SDL_mixer/), [SDL2_ttf](https://www.libsdl.org/projects/SDL_ttf/) and [Libsodium](https://github.com/jedisct1/libsodium/releases) in `/usr/x86_64-w64-mingw32`. This can be done automatically by running `Packaging/windows/mingw-prep64.sh`.
-NOTE: SDL2 2.0.12 appears to not compile correctly.
 
 ```
 sudo apt-get install cmake gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64


### PR DESCRIPTION
This PR does two things. Brings the SDL2 version from 2.0.9 to 2.0.14 for Windows MinGW builds. Removes the note in the readme for SDL2 2.0.12 as it is no longer the latest and whatever issue there was has been fixed as it now builds successfully with 2.0.12.