### PR TITLE
Bugfix: auricGold shouldn\'t determine MaxGold.

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -20,7 +20,7 @@ BOOL itemhold[3][3];
 CornerStoneStruct CornerStone;
 BYTE *itemanims[ITEMTYPES];
 BOOL UniqueItemFlag[128];
-int auricGold = 10000;
+int auricGold = (GOLD_MAX_LIMIT * 2);
 int numitems;
 int gnNumGetRecords;
 
@@ -1073,7 +1073,7 @@ void CalcPlrItemVals(int p, BOOL Loadgfx)
 	}
 	if (plr[p].InvBody[INVLOC_AMULET].isEmpty() || plr[p].InvBody[INVLOC_AMULET].IDidx != IDI_AURIC) {
 		int half = MaxGold;
-		MaxGold = auricGold / 2;
+		MaxGold = GOLD_MAX_LIMIT;
 
 		if (half != MaxGold)
 			StripTopGold(p);


### PR DESCRIPTION
To make my life a bit easier, I privately changed *GOLD_MAX_LIMIT* to 50000.
This yielded the unexpected result that when picking up gold, the stacks were still capped at 5000 gold, and I needed to merge stacks manually.

items.cpp first sets *MaxGold* to *GOLD_MAX_LIMIT* in line 55, but this gets overridden by *auricGold / 2* in line 1076.
This patch fixes this unintended behavior without impacting the original gameplay.