### PR TITLE
Durability icon gradually changing from gold to red

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1739,10 +1739,16 @@ static int DrawDurIcon4Item(CelOutputBuffer out, ItemStruct* pItem, int x, int c
 	}
 
 	//Draw icon
-	if (amount)
-		CelDrawTo_CropY(out, x, y, pDurIcons, c + 8, height, 0, amount); //Gold icon
-	if (amount != height)
-		CelDrawTo_CropY(out, x, y, pDurIcons, c, 32, amount, height); //Red icon
+	if (amount) {
+		CelOutputBuffer buf = GlobalBackBuffer();
+		buf = buf.subregionY(y - amount, amount);
+		CelDrawTo(buf, x, amount, pDurIcons, c + 8, 32); //Gold icon
+	}
+	if (amount != height) {
+		CelOutputBuffer buf = GlobalBackBuffer();
+		buf = buf.subregionY(y - height, height - amount);
+		CelDrawTo(buf, x, height, pDurIcons, c, 32); //Red icon
+	}
 
 	return x - 32 - 8;
 }

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1692,13 +1692,14 @@ void ReleaseChrBtns(bool addAllStatPoints)
 	}
 }
 
-#define DURABILITY_RED 2
-#define DURABILITY_GOLD 5
 static int DrawDurIcon4Item(CelOutputBuffer out, ItemStruct* pItem, int x, int c)
 {
+	const int durabilityThresholdGold = 5;
+	const int durabilityThresholdRed = 2;
+
 	if (pItem->isEmpty())
 		return x;
-	if (pItem->_iDurability > DURABILITY_GOLD)
+	if (pItem->_iDurability > durabilityThresholdGold)
 		return x;
 	if (c == 0) {
 		switch (pItem->_itype) {
@@ -1728,14 +1729,14 @@ static int DrawDurIcon4Item(CelOutputBuffer out, ItemStruct* pItem, int x, int c
 	//Calculate how much of the icon should be gold and red
 	int height = 32;
 	int amount;
-	if (pItem->_iDurability <= DURABILITY_RED)
+	if (pItem->_iDurability <= durabilityThresholdRed)
 		amount = 0;
 	else {
 		if (!sgOptions.Graphics.bDurabilityIconGradual)
 			amount = height;
 		else {
-			int cur = pItem->_iDurability - DURABILITY_RED;
-			amount = (height * cur) / (DURABILITY_GOLD - DURABILITY_RED);
+			int cur = pItem->_iDurability - durabilityThresholdRed;
+			amount = (height * cur) / (durabilityThresholdGold - durabilityThresholdRed);
 		}
 	}
 

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1738,28 +1738,12 @@ static int DrawDurIcon4Item(CelOutputBuffer out, ItemStruct* pItem, int x, int c
 		amount = (height * cur) / max;
 	}
 
-	if (options_hwRendering) { //Fluffy: Render via SDL rendering
-		int renderX = x - BORDER_LEFT;
-		int renderY = y - (height - 1) - BORDER_TOP;
-		c -= 1;
-		if (amount)
-			Render_Texture_Crop(renderX, renderY + (height - amount), TEXTURE_DURABILITYWARNING, -1, height - amount, -1, -1, c + 8); //Gold icon
-		amount = height - amount;
-		if (amount)
-			Render_Texture_Crop(renderX, renderY, TEXTURE_DURABILITYWARNING, -1, -1, -1, amount, c); //Red icon
-		//TODO: This is more indirectly related, but we should make it so that when equipment is fully destroyed, we should show some kind of icon then as well (we could add a new variable to the player struct which defines if a slot is empty due to item destruction or not, and if true, show a durability icon for that slot)
-	} else {
-		if (amount)
-			CelDraw_CropY(x, y, pDurIcons, c + 8, height, 0, amount); //Gold icon
-		if (amount != height)
-			CelDraw_CropY(x, y, pDurIcons, c, 32, amount, height); //Red icon
-	}
-	if (pItem->_iDurability > 2)
-		c += 8;
-	CelDrawTo(out, x, -17 + PANEL_Y, pDurIcons, c, 32);
-		Render_Texture_FromBottom(x - BORDER_LEFT, -17 + PANEL_TOP, TEXTURE_DURABILITYWARNING, c - 1);
-	else
-		CelDraw(x, -17 + PANEL_Y, pDurIcons, c, 32);
+	//Draw icon
+	if (amount)
+		CelDrawTo_CropY(out, x, y, pDurIcons, c + 8, height, 0, amount); //Gold icon
+	if (amount != height)
+		CelDrawTo_CropY(out, x, y, pDurIcons, c, 32, amount, height); //Red icon
+
 	return x - 32 - 8;
 }
 

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1726,13 +1726,12 @@ static int DrawDurIcon4Item(CelOutputBuffer out, ItemStruct* pItem, int x, int c
 
 	//Calculate how much of the icon should be gold and red
 	int height = 32;
-	int max = (pItem->_iMaxDur > DURABILITY_GOLD ? DURABILITY_GOLD : pItem->_iMaxDur) - DURABILITY_RED;
 	int amount;
-	if (pItem->_iDurability <= DURABILITY_RED || max <= 0)
+	if (pItem->_iDurability <= DURABILITY_RED)
 		amount = 0;
 	else {
 		int cur = pItem->_iDurability - DURABILITY_RED;
-		amount = (height * cur) / max;
+		amount = (height * cur) / (DURABILITY_GOLD - DURABILITY_RED);
 	}
 
 	//Draw icon

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -4,6 +4,7 @@
  * Implementation of the character and main control panels
  */
 #include "all.h"
+#include "options.h"
 
 #include <cstddef>
 
@@ -1730,8 +1731,12 @@ static int DrawDurIcon4Item(CelOutputBuffer out, ItemStruct* pItem, int x, int c
 	if (pItem->_iDurability <= DURABILITY_RED)
 		amount = 0;
 	else {
-		int cur = pItem->_iDurability - DURABILITY_RED;
-		amount = (height * cur) / (DURABILITY_GOLD - DURABILITY_RED);
+		if (!sgOptions.Graphics.bDurabilityIconGradual)
+			amount = height;
+		else {
+			int cur = pItem->_iDurability - DURABILITY_RED;
+			amount = (height * cur) / (DURABILITY_GOLD - DURABILITY_RED);
+		}
 	}
 
 	//Draw icon

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1724,35 +1724,30 @@ static int DrawDurIcon4Item(CelOutputBuffer out, ItemStruct* pItem, int x, int c
 		}
 	}
 
-	int y = -17 + PANEL_Y;
-
-	//Calculate how much of the icon should be gold and red
-	int height = 32;
-	int amount;
-	if (pItem->_iDurability <= durabilityThresholdRed)
-		amount = 0;
-	else {
-		if (!sgOptions.Graphics.bDurabilityIconGradual)
-			amount = height;
+	// Calculate how much of the icon should be gold and red
+	int height = 32; // Height of durability icon CEL
+	int partition = 0;
+	if (pItem->_iDurability > durabilityThresholdRed) { 
+		if (!sgOptions.Graphics.bGradualDurabilityWarning)
+			partition = height;
 		else {
-			int cur = pItem->_iDurability - durabilityThresholdRed;
-			amount = (height * cur) / (durabilityThresholdGold - durabilityThresholdRed);
+			int current = pItem->_iDurability - durabilityThresholdRed;
+			partition = (height * current) / (durabilityThresholdGold - durabilityThresholdRed);
 		}
 	}
 
-	//Draw icon
-	if (amount) {
-		CelOutputBuffer buf = GlobalBackBuffer();
-		buf = buf.subregionY(y - amount, amount);
-		CelDrawTo(buf, x, amount, pDurIcons, c + 8, 32); //Gold icon
+	// Draw icon
+	int y = -17 + PANEL_Y;
+	if (partition > 0) {
+		CelOutputBuffer stenciledBuffer = out.subregionY(y - partition, partition);
+		CelDrawTo(stenciledBuffer, x, partition, pDurIcons, c + 8, 32); // Gold icon
 	}
-	if (amount != height) {
-		CelOutputBuffer buf = GlobalBackBuffer();
-		buf = buf.subregionY(y - height, height - amount);
-		CelDrawTo(buf, x, height, pDurIcons, c, 32); //Red icon
+	if (partition != height) {
+		CelOutputBuffer stenciledBuffer = out.subregionY(y - height, height - partition);
+		CelDrawTo(stenciledBuffer, x, height, pDurIcons, c, 32); // Red icon
 	}
 
-	return x - 32 - 8;
+	return x - 32 - 8; // Add in spacing for the next durability icon
 }
 
 void DrawDurIcon(CelOutputBuffer out)

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1722,9 +1722,6 @@ static int DrawDurIcon4Item(CelOutputBuffer out, ItemStruct* pItem, int x, int c
 		}
 	}
 
-	if (pItem->_iDurability > DURABILITY_RED && pItem->_iDurability == pItem->_iMaxDur) //Avoid showing durability icon if it's equal to a low max (and above "red" durability value)
-		return x;
-
 	int y = -17 + PANEL_Y;
 
 	//Calculate how much of the icon should be gold and red

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -427,7 +427,7 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 	setIniInt("Graphics", "Color Cycling", sgOptions.Graphics.bColorCycling);
 	setIniInt("Graphics", "FPS Limiter", sgOptions.Graphics.bFPSLimit);
-	setIniInt("Graphics", "Gradual Durability Warning", sgOptions.Graphics.bDurabilityIconGradual);
+	setIniInt("Graphics", "Gradual Durability Warning", sgOptions.Graphics.bGradualDurabilityWarning);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
 	setIniInt("Game", "Fast Walk", sgOptions.Gameplay.bJogInTown);
@@ -501,7 +501,7 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 	sgOptions.Graphics.bColorCycling = getIniBool("Graphics", "Color Cycling", true);
 	sgOptions.Graphics.bFPSLimit = getIniBool("Graphics", "FPS Limiter", true);
-	sgOptions.Graphics.bDurabilityIconGradual = getIniBool("Graphics", "Gradual Durability Warning", true);
+	sgOptions.Graphics.bGradualDurabilityWarning = getIniBool("Graphics", "Gradual Durability Warning", true);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
 	sgOptions.Gameplay.bJogInTown = getIniBool("Game", "Fast Walk", false);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -427,6 +427,7 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 	setIniInt("Graphics", "Color Cycling", sgOptions.Graphics.bColorCycling);
 	setIniInt("Graphics", "FPS Limiter", sgOptions.Graphics.bFPSLimit);
+	setIniInt("Graphics", "Gradual Durability Warning", sgOptions.Graphics.bDurabilityIconGradual);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
 	setIniInt("Game", "Fast Walk", sgOptions.Gameplay.bJogInTown);
@@ -500,6 +501,7 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 	sgOptions.Graphics.bColorCycling = getIniBool("Graphics", "Color Cycling", true);
 	sgOptions.Graphics.bFPSLimit = getIniBool("Graphics", "FPS Limiter", true);
+	sgOptions.Graphics.bDurabilityIconGradual = getIniBool("Graphics", "Gradual Durability Warning", true);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
 	sgOptions.Gameplay.bJogInTown = getIniBool("Game", "Fast Walk", false);

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -42,7 +42,7 @@ void CelDrawTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, in
 	CelBlitSafeTo(out, sx, sy, pRLEBytes, nDataSize, nWidth);
 }
 
-void CelClippedDrawTo(CelOutputBuffer out, int sx, int sy, BYTE* pCelBuff, int nCel, int nWidth)
+void CelClippedDrawTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth)
 {
 	BYTE *pRLEBytes;
 	int nDataSize;

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -42,16 +42,6 @@ void CelDrawTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, in
 	CelBlitSafeTo(out, sx, sy, pRLEBytes, nDataSize, nWidth);
 }
 
-void CelDrawTo_CropY(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int startX, int endY)
-{
-	int nDataSize;
-	BYTE *pRLEBytes;
-
-	assert(pCelBuff != NULL);
-	pRLEBytes = CelGetFrame(pCelBuff, nCel, &nDataSize);
-	CelBlitSafeTo_CropY(out, sx, sy, pRLEBytes, nDataSize, nWidth, startX, endY);
-}
-
 void CelClippedDrawTo(CelOutputBuffer out, int sx, int sy, BYTE* pCelBuff, int nCel, int nWidth)
 {
 	BYTE *pRLEBytes;
@@ -154,40 +144,6 @@ void CelBlitSafeTo(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBytes, int nDa
 			if (!(width & 0x80)) {
 				i -= width;
 				if (dst < out.end() && dst > out.begin()) {
-					memcpy(dst, src, width);
-				}
-				src += width;
-				dst += width;
-			} else {
-				width = -(char)width;
-				dst += width;
-				i -= width;
-			}
-		}
-	}
-}
-
-void CelBlitSafeTo_CropY(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBytes, int nDataSize, int nWidth, int startY, int endY)
-{
-	int i, w;
-	BYTE width;
-	BYTE *src, *dst;
-
-	assert(pRLEBytes != NULL);
-
-	src = pRLEBytes;
-	dst = out.at(sx, sy);
-	w = nWidth;
-	int curY = 0;
-
-	for (; src != &pRLEBytes[nDataSize]; dst -= out.pitch() + w, curY++) {
-		if (curY > endY)
-			return;
-		for (i = w; i;) {
-			width = *src++;
-			if (!(width & 0x80)) {
-				i -= width;
-				if (curY >= startY && dst < out.end() && dst > out.begin()) {
 					memcpy(dst, src, width);
 				}
 				src += width;

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -171,19 +171,6 @@ struct CelOutputBuffer {
 void CelDrawTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
 
 /**
- * @brief Blit vertically-cropped CEL sprite to the back buffer at the given coordinates
- * @param out Target buffer
- * @param sx Target buffer coordinate
- * @param sy Target buffer coordinate
- * @param pCelBuff Cel data
- * @param nCel CEL frame number
- * @param nWidth Width of sprite
- * @param startY At what Y coordinate to start drawing sprite (note: 0 is equal to bottom of image data)
- * @param endY Final Y coordinate to draw
- */
-void CelDrawTo_CropY(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int startX, int endY);
-
-/**
  * @briefBlit CEL sprite to the given buffer, does not perform bounds-checking.
  * @param out Target buffer
  * @param x Cordinate in the target buffer
@@ -260,19 +247,6 @@ void CelDrawLightRedTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int 
  * @param nWidth Width of sprite
  */
 void CelBlitSafeTo(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBytes, int nDataSize, int nWidth);
-
-/**
- * @brief Blit vertically-cropped CEL sprite to the given buffer, checks for drawing outside the buffer
- * @param out Target buffer
- * @param sx Target buffer coordinate
- * @param sy Target buffer coordinate
- * @param pRLEBytes CEL pixel stream (run-length encoded)
- * @param nDataSize Size of CEL in bytes
- * @param nWidth Width of sprite
- * @param startY At what Y coordinate to start drawing sprite (note: 0 is equal to bottom of image data)
- * @param endY Final Y coordinate to draw
- */
-void CelBlitSafeTo_CropY(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBytes, int nDataSize, int nWidth, int startY, int endY);
 
 /**
  * @brief Same as CelClippedDrawTo but checks for drawing outside the buffer

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -171,6 +171,19 @@ struct CelOutputBuffer {
 void CelDrawTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
 
 /**
+ * @brief Blit vertically-cropped CEL sprite to the back buffer at the given coordinates
+ * @param out Target buffer
+ * @param sx Target buffer coordinate
+ * @param sy Target buffer coordinate
+ * @param pCelBuff Cel data
+ * @param nCel CEL frame number
+ * @param nWidth Width of sprite
+ * @param startY At what Y coordinate to start drawing sprite (note: 0 is equal to bottom of image data)
+ * @param endY Final Y coordinate to draw
+ */
+void CelDrawTo_CropY(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int startX, int endY);
+
+/**
  * @briefBlit CEL sprite to the given buffer, does not perform bounds-checking.
  * @param out Target buffer
  * @param x Cordinate in the target buffer
@@ -247,6 +260,19 @@ void CelDrawLightRedTo(CelOutputBuffer out, int sx, int sy, BYTE *pCelBuff, int 
  * @param nWidth Width of sprite
  */
 void CelBlitSafeTo(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBytes, int nDataSize, int nWidth);
+
+/**
+ * @brief Blit vertically-cropped CEL sprite to the given buffer, checks for drawing outside the buffer
+ * @param out Target buffer
+ * @param sx Target buffer coordinate
+ * @param sy Target buffer coordinate
+ * @param pRLEBytes CEL pixel stream (run-length encoded)
+ * @param nDataSize Size of CEL in bytes
+ * @param nWidth Width of sprite
+ * @param startY At what Y coordinate to start drawing sprite (note: 0 is equal to bottom of image data)
+ * @param endY Final Y coordinate to draw
+ */
+void CelBlitSafeTo_CropY(CelOutputBuffer out, int sx, int sy, BYTE *pRLEBytes, int nDataSize, int nWidth, int startY, int endY);
 
 /**
  * @brief Same as CelClippedDrawTo but checks for drawing outside the buffer

--- a/Source/options.h
+++ b/Source/options.h
@@ -50,6 +50,8 @@ struct GraphicsOptions {
 	bool bColorCycling;
 	/** @brief Enable FPS Limit. */
 	bool bFPSLimit;
+	/** @brief If true, makes durability icon on the HUD gradually turn from gold to red. */
+	bool bDurabilityIconGradual;
 };
 
 struct GameplayOptions {

--- a/Source/options.h
+++ b/Source/options.h
@@ -51,7 +51,7 @@ struct GraphicsOptions {
 	/** @brief Enable FPS Limit. */
 	bool bFPSLimit;
 	/** @brief If true, makes durability icon on the HUD gradually turn from gold to red. */
-	bool bDurabilityIconGradual;
+	bool bGradualDurabilityWarning;
 };
 
 struct GameplayOptions {


### PR DESCRIPTION
By default, the durability icon is gold at values 5-3 and red at 2-1. This makes it so it gradually goes from gold to red between 5 and 2.

Visual example:
![devilutionx 2021-03-29 22-10-15-034](https://user-images.githubusercontent.com/14843529/112900223-77fd5880-90e3-11eb-91ac-3101d90dbad2.png)
![devilutionx 2021-03-29 22-12-06-272](https://user-images.githubusercontent.com/14843529/112900229-7a5fb280-90e3-11eb-8f0e-8be16f83c453.png)

It also makes it so the durability icon is not shown if the item is fully repaired and has a low max of 5 to 3 (I can remove this change if that's not wanted).

This was supposed to be one single commit, but I forgot I'm really bad at using git. This could be squashed into one commit.