### PR TITLE
StormLib: Replace switch/nds/amiga hacks with a simpler one

### DIFF
--- a/CMake/ctr/n3ds_defs.cmake
+++ b/CMake/ctr/n3ds_defs.cmake
@@ -2,11 +2,6 @@
 set(NONET ON)
 set(USE_SDL1 ON)
 
-# Streaming audio is broken on the 3DS as of 25 Mar 2021:
-# https://github.com/devkitPro/SDL/issues/72
-set(DISABLE_STREAMING_MUSIC ON)
-set(DISABLE_STREAMING_SOUNDS ON)
-
 #3DS libraries
 list(APPEND CMAKE_MODULE_PATH "${DevilutionX_SOURCE_DIR}/CMake/ctr/modules")
 find_package(CITRO3D REQUIRED)

--- a/CMake/switch/switch_defs.cmake
+++ b/CMake/switch/switch_defs.cmake
@@ -1,11 +1,6 @@
 set(NONET ON)
 set(PREFILL_PLAYER_NAME ON)
 
-# Streaming audio is broken on the Switch as of 25 Mar 2021:
-# https://github.com/devkitPro/SDL/issues/72
-set(DISABLE_STREAMING_MUSIC ON)
-set(DISABLE_STREAMING_SOUNDS ON)
-
 set(JOY_BUTTON_DPAD_LEFT 16)
 set(JOY_BUTTON_DPAD_UP 17)
 set(JOY_BUTTON_DPAD_RIGHT 18)

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -54,10 +54,7 @@ HANDLE init_test_access(const std::vector<std::string> &paths, const char *mpq_n
 {
 	HANDLE archive;
 	std::string mpq_abspath;
-	DWORD mpq_flags = 0;
-#if !defined(__SWITCH__) && !defined(__AMIGA__) && !defined(__vita__)
-	mpq_flags |= MPQ_FLAG_READ_ONLY;
-#endif
+	DWORD mpq_flags = MPQ_FLAG_READ_ONLY;
 	for (int i = 0; i < paths.size(); i++) {
 		mpq_abspath = paths[i] + mpq_name;
 		if (SFileOpenArchive(mpq_abspath.c_str(), dwPriority, mpq_flags, &archive)) {


### PR DESCRIPTION
The previous hacks didn't work at all for streaming files.

This is because the previous hacks manually patched `BaseMap_Open` to
`malloc` a buffer but didn't actually read anything into the buffer, so
`BaseMap_Read` was just reading out garbage bytes.

This far simpler hack is to simply use `BaseFile` functions on
platforms that don't have mmap.