### PR TITLE
Fix Storm local file seeking (also fixes `SBmpLoadImage`)

### DIFF
--- a/3rdParty/Storm/Source/storm.h
+++ b/3rdParty/Storm/Source/storm.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <limits>
 #include <string>
 namespace dvl {
@@ -351,6 +352,26 @@ BOOL SFileEnableDirectAccess(BOOL enable);
 
 #if defined(__GNUC__) || defined(__cplusplus)
 }
+
+// Additions to Storm API:
+
+// Sets the file's 64-bit seek position.
+inline std::uint64_t SFileSetFilePointer(HANDLE hFile, std::int64_t offset, int whence)
+{
+    int high = static_cast<std::uint64_t>(offset) >> 32;
+    int low = static_cast<int>(offset);
+    low = SFileSetFilePointer(hFile, low, &high, whence);
+    return (static_cast<std::uint64_t>(high) << 32) | low;
+}
+
+// Returns the current 64-bit file seek position.
+inline std::uint64_t SFileGetFilePointer(HANDLE hFile)
+{
+    // We use `SFileSetFilePointer` with offset 0 to get the current position
+    // because there is no `SFileGetFilePointer`.
+    return SFileSetFilePointer(hFile, 0, DVL_FILE_CURRENT);
+}
+
 #endif
 
 } // namespace dvl

--- a/3rdParty/Storm/Source/storm.h
+++ b/3rdParty/Storm/Source/storm.h
@@ -346,7 +346,7 @@ bool SNetRegisterEventHandler(event_type, SEVTHANDLER);
 BOOLEAN SNetSetBasePlayer(int);
 int SNetInitializeProvider(unsigned long, struct _SNETPROGRAMDATA *, struct _SNETPLAYERDATA *, struct _SNETUIDATA *, struct _SNETVERSIONDATA *);
 int SNetGetProviderCaps(struct _SNETCAPS *);
-int SFileSetFilePointer(HANDLE, int, HANDLE, int);
+int SFileSetFilePointer(HANDLE, int, int*, int);
 BOOL SFileEnableDirectAccess(BOOL enable);
 
 #if defined(__GNUC__) || defined(__cplusplus)

--- a/3rdParty/StormLib/src/SFileReadFile.cpp
+++ b/3rdParty/StormLib/src/SFileReadFile.cpp
@@ -711,7 +711,12 @@ bool STORMAPI SFileReadFile(HANDLE hFile, void * pvBuffer, DWORD dwToRead, LPDWO
     // If the file is local file, read the data directly from the stream
     if(hf->pStream != NULL)
     {
-        nError = ReadMpqFileLocalFile(hf, pvBuffer, hf->dwFilePos, dwToRead, &dwBytesRead);
+        ULONGLONG pos;
+        if (!FileStream_GetPos(hf->pStream, &pos)) {
+            SetLastError(ERROR_CAN_NOT_COMPLETE);
+            return false;
+        }
+        nError = ReadMpqFileLocalFile(hf, pvBuffer, pos, dwToRead, &dwBytesRead);
     }
 #ifdef FULL
     // If the file is a patch file, we have to read it special way
@@ -739,7 +744,8 @@ bool STORMAPI SFileReadFile(HANDLE hFile, void * pvBuffer, DWORD dwToRead, LPDWO
     }
 
     // Increment the file position
-    hf->dwFilePos += dwBytesRead;
+    if(hf->pStream == NULL)
+        hf->dwFilePos += dwBytesRead;
 
     // Give the caller the number of bytes read
     if(pdwRead != NULL)

--- a/SourceX/storm_sdl_rw.cpp
+++ b/SourceX/storm_sdl_rw.cpp
@@ -46,17 +46,11 @@ static int SFileRw_seek(struct SDL_RWops *context, int offset, int whence)
 	default:
 		return -1;
 	}
-	int high = static_cast<std::uint64_t>(offset) >> 32;
-	int low = static_cast<int>(offset);
-	low = SFileSetFilePointer(SFileRw_GetHandle(context), low, &high, swhence);
-	if (low == -1) {
+	const std::uint64_t pos = SFileSetFilePointer(SFileRw_GetHandle(context), offset, swhence);
+	if (pos == static_cast<std::uint64_t>(-1)) {
 		SDL_Log("SFileRw_seek error: %ud", (unsigned int)SErrGetLastError());
 	}
-#ifndef USE_SDL1
-	return (static_cast<std::uint64_t>(high) << 32) | low;
-#else
-	return low;
-#endif
+	return pos;
 }
 
 #ifndef USE_SDL1


### PR DESCRIPTION
SBmpLoadImage tried to get the size of the rest of the file incorrectly
by subtracting the current file position from the total size.

This was incorrect because file positions do not always begin at 0.

The only semi-portable way to get a size from file positions is to
subtract two file positions.