### PR TITLE
:bug: Allow shift+click to equip weapons on monk

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -774,11 +774,6 @@ bool AutoEquip(int playerNumber, const ItemStruct &item, int bodyLocation, bool 
 		return false;
 	}
 
-	// Monk can use unarmed attack as an encouraged option, thus we do not automatically equip weapons on him so as to not
-	// annoy players who prefer that playstyle.
-	if (plr[playerNumber]._pClass == PC_MONK && (bodyLocation == INVLOC_HAND_LEFT || bodyLocation == INVLOC_HAND_RIGHT))
-		return false;
-
 	if (persistItem) {
 		plr[playerNumber].InvBody[bodyLocation] = item;
 
@@ -818,14 +813,17 @@ bool AutoEquip(int playerNumber, const ItemStruct &item, bool persistItem)
 }
 
 /**
- * @brief Checks whether or not auto-equipping behavior is enabled for the given item.
+ * @brief Checks whether or not auto-equipping behavior is enabled for the given player and item.
+ * @param player The player to check.
  * @param item The item to check.
- * @return 'True' if auto-equipping behavior is enabled for the item and 'False' otherwise.
+ * @return 'True' if auto-equipping behavior is enabled for the player and item and 'False' otherwise.
  */
-bool AutoEquipEnabled(const ItemStruct &item)
+bool AutoEquipEnabled(const PlayerStruct &player, const ItemStruct &item)
 {
 	if (item.isWeapon()) {
-		return sgOptions.Gameplay.bAutoEquipWeapons;
+		// Monk can use unarmed attack as an encouraged option, thus we do not automatically equip weapons on him so as to not
+		// annoy players who prefer that playstyle.
+		return player._pClass != PC_MONK && sgOptions.Gameplay.bAutoEquipWeapons;
 	}
 
 	if (item.isArmor()) {
@@ -2181,7 +2179,7 @@ void AutoGetItem(int pnum, int ii)
 			SetPlrHandGoldCurs(&item[ii]);
 		}
 	} else {
-		done = AutoEquipEnabled(plr[pnum].HoldItem) && AutoEquip(pnum, plr[pnum].HoldItem);
+		done = AutoEquipEnabled(plr[pnum], plr[pnum].HoldItem) && AutoEquip(pnum, plr[pnum].HoldItem);
 		if (!done) {
 			done = AutoPlaceItemInBelt(pnum, plr[pnum].HoldItem, true);
 		}

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -7,6 +7,7 @@
 #define __INV_H__
 
 #include "items.h"
+#include "player.h"
 
 DEVILUTION_BEGIN_NAMESPACE
 
@@ -35,7 +36,7 @@ void InitInv();
 void DrawInv(CelOutputBuffer out);
 
 void DrawInvBelt(CelOutputBuffer out);
-bool AutoEquipEnabled(const ItemStruct &item);
+bool AutoEquipEnabled(const PlayerStruct &player, const ItemStruct &item);
 bool AutoEquip(int playerNumber, const ItemStruct &item, bool persistItem = true);
 BOOL AutoPlace(int pnum, int ii, int sx, int sy, BOOL saveflag);
 BOOL SpecialAutoPlace(int pnum, int ii, const ItemStruct &item);

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -201,7 +201,7 @@ void StoreAutoPlace()
 	w = icursW28;
 	h = icursH28;
 	done = FALSE;
-	if (AutoEquipEnabled(plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem)) {
+	if (AutoEquipEnabled(plr[myplr], plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem)) {
 		done = TRUE;
 	}
 
@@ -1365,7 +1365,7 @@ void S_SBuyEnter()
 			plr[myplr].HoldItem = smithitem[idx];
 			SetCursor_(plr[myplr].HoldItem._iCurs + CURSOR_FIRSTITEM);
 			done = FALSE;
-			if (AutoEquipEnabled(plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem, false)) {
+			if (AutoEquipEnabled(plr[myplr], plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem, false)) {
 				done = TRUE;
 			}
 
@@ -1433,7 +1433,7 @@ void S_SPBuyEnter()
 			plr[myplr].HoldItem = premiumitem[idx];
 			SetCursor_(plr[myplr].HoldItem._iCurs + CURSOR_FIRSTITEM);
 			done = FALSE;
-			if (AutoEquipEnabled(plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem, false)) {
+			if (AutoEquipEnabled(plr[myplr], plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem, false)) {
 				done = TRUE;
 			}
 
@@ -1700,7 +1700,7 @@ void S_WBuyEnter()
 			plr[myplr].HoldItem = witchitem[idx];
 			SetCursor_(plr[myplr].HoldItem._iCurs + CURSOR_FIRSTITEM);
 			done = FALSE;
-			if (AutoEquipEnabled(plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem, false)) {
+			if (AutoEquipEnabled(plr[myplr], plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem, false)) {
 				done = TRUE;
 			}
 
@@ -1879,7 +1879,7 @@ void S_BBuyEnter()
 	SetCursor_(plr[myplr].HoldItem._iCurs + CURSOR_FIRSTITEM);
 
 	bool done = false;
-	if (AutoEquipEnabled(plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem, false)) {
+	if (AutoEquipEnabled(plr[myplr], plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem, false)) {
 		done = true;
 	}
 
@@ -2011,7 +2011,7 @@ void S_HBuyEnter()
 			plr[myplr].HoldItem = healitem[idx];
 			SetCursor_(plr[myplr].HoldItem._iCurs + CURSOR_FIRSTITEM);
 			done = FALSE;
-			if (AutoEquipEnabled(plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem, false)) {
+			if (AutoEquipEnabled(plr[myplr], plr[myplr].HoldItem) && AutoEquip(myplr, plr[myplr].HoldItem, false)) {
 				done = TRUE;
 			}
 


### PR DESCRIPTION
This PR fixes a bug that caused the shift+click to equip weapons to not work when playing with the Monk class, due to the way we were evaluating the monk exception for auto-equipping weapons.

The exception has been moved to a more appropriate place now, where it is checked on every auto-equip attempt but no on explicit user equip attempts.

Fixes #1330  