### PR TITLE
Fix broken KeySupport for Gameshell (and others)

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,61 +1,42 @@
 {
-  "configurations": [
-    {
-      "name": "x64-Debug",
-      "generator": "Ninja",
-      "configurationType": "Debug",
-      "buildRoot": "${workspaceRoot}\\build\\${name}",
-      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "inheritEnvironments": [ "msvc_x64" ],
-      "intelliSenseMode": "windows-msvc-x64"
-    },
-    {
-      "name": "x64-Release",
-      "generator": "Ninja",
-      "configurationType": "Release",
-      "buildRoot": "${workspaceRoot}\\build\\${name}",
-      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "-DBINARY_RELEASE=ON",
-      "inheritEnvironments": [ "msvc_x64" ],
-      "intelliSenseMode": "windows-msvc-x64"
-    },
-    {
-      "name": "x86-Debug",
-      "generator": "Ninja",
-      "configurationType": "Debug",
-      "buildRoot": "${workspaceRoot}\\build\\${name}",
-      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "inheritEnvironments": [ "msvc_x86" ],
-      "intelliSenseMode": "windows-msvc-x86"
-    },
-    {
-      "name": "x86-Release",
-      "generator": "Ninja",
-      "configurationType": "Release",
-      "buildRoot": "${workspaceRoot}\\build\\${name}",
-      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "-DBINARY_RELEASE=ON",
-      "inheritEnvironments": [ "msvc_x86" ],
-      "intelliSenseMode": "windows-msvc-x86"
-    },
-    {
-      "name": "CPI-Debug",
-      "generator": "Unix Makefiles",
-      "configurationType": "Debug",
-      "cmakeExecutable": "cmake",
-      "remoteCopySourcesExclusionList": [ ".vs", ".git", "out" ],
-      "cmakeCommandArgs": "-DTARGET_PLATFORM=cpigamesh -DVERSION_NUM=1.1.0 -DVERSION_SUFFIX=DKR_VERSION",
-      "ctestCommandArgs": "",
-      "inheritEnvironments": [ "linux_arm" ],
-      "remoteMachineName": "-1829704065;192.168.10.1 (username=cpi, port=22, authentication=Password)",
-      "remoteCMakeListsRoot": "$HOME/.vs/${projectDirName}/${workspaceHash}/src",
-      "remoteBuildRoot": "$HOME/.vs/${projectDirName}/${workspaceHash}/out/build/${name}",
-      "remoteInstallRoot": "$HOME/.vs/${projectDirName}/${workspaceHash}/out/install/${name}",
-      "remoteCopySources": true,
-      "rsyncCommandArgs": "-t --delete --delete-excluded",
-      "remoteCopyBuildOutput": false,
-      "remoteCopySourcesMethod": "rsync",
-      "addressSanitizerRuntimeFlags": "detect_leaks=0"
-    }
-  ]
+	"configurations": [
+		{
+			"name": "x64-Debug",
+			"generator": "Ninja",
+			"configurationType": "Debug",
+			"buildRoot": "${workspaceRoot}\\build\\${name}",
+			"installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+			"inheritEnvironments": [ "msvc_x64" ],
+			"intelliSenseMode": "windows-msvc-x64"
+		},
+		{
+			"name": "x64-Release",
+			"generator": "Ninja",
+			"configurationType": "Release",
+			"buildRoot": "${workspaceRoot}\\build\\${name}",
+			"installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+			"cmakeCommandArgs": "-DBINARY_RELEASE=ON",
+			"inheritEnvironments": [ "msvc_x64" ],
+			"intelliSenseMode": "windows-msvc-x64"
+		},
+		{
+			"name": "x86-Debug",
+			"generator": "Ninja",
+			"configurationType": "Debug",
+			"buildRoot": "${workspaceRoot}\\build\\${name}",
+			"installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+			"inheritEnvironments": [ "msvc_x86" ],
+			"intelliSenseMode": "windows-msvc-x86"
+		},
+		{
+			"name": "x86-Release",
+			"generator": "Ninja",
+			"configurationType": "Release",
+			"buildRoot": "${workspaceRoot}\\build\\${name}",
+			"installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+			"cmakeCommandArgs": "-DBINARY_RELEASE=ON",
+			"inheritEnvironments": [ "msvc_x86" ],
+			"intelliSenseMode": "windows-msvc-x86"
+		}
+	]
 }

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,42 +1,61 @@
 {
-	"configurations": [
-		{
-			"name": "x64-Debug",
-			"generator": "Ninja",
-			"configurationType": "Debug",
-			"buildRoot": "${workspaceRoot}\\build\\${name}",
-			"installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-			"inheritEnvironments": [ "msvc_x64" ],
-			"intelliSenseMode": "windows-msvc-x64"
-		},
-		{
-			"name": "x64-Release",
-			"generator": "Ninja",
-			"configurationType": "Release",
-			"buildRoot": "${workspaceRoot}\\build\\${name}",
-			"installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-			"cmakeCommandArgs": "-DBINARY_RELEASE=ON",
-			"inheritEnvironments": [ "msvc_x64" ],
-			"intelliSenseMode": "windows-msvc-x64"
-		},
-		{
-			"name": "x86-Debug",
-			"generator": "Ninja",
-			"configurationType": "Debug",
-			"buildRoot": "${workspaceRoot}\\build\\${name}",
-			"installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-			"inheritEnvironments": [ "msvc_x86" ],
-			"intelliSenseMode": "windows-msvc-x86"
-		},
-		{
-			"name": "x86-Release",
-			"generator": "Ninja",
-			"configurationType": "Release",
-			"buildRoot": "${workspaceRoot}\\build\\${name}",
-			"installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-			"cmakeCommandArgs": "-DBINARY_RELEASE=ON",
-			"inheritEnvironments": [ "msvc_x86" ],
-			"intelliSenseMode": "windows-msvc-x86"
-		}
-	]
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${workspaceRoot}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "inheritEnvironments": [ "msvc_x64" ],
+      "intelliSenseMode": "windows-msvc-x64"
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "buildRoot": "${workspaceRoot}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "cmakeCommandArgs": "-DBINARY_RELEASE=ON",
+      "inheritEnvironments": [ "msvc_x64" ],
+      "intelliSenseMode": "windows-msvc-x64"
+    },
+    {
+      "name": "x86-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${workspaceRoot}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "inheritEnvironments": [ "msvc_x86" ],
+      "intelliSenseMode": "windows-msvc-x86"
+    },
+    {
+      "name": "x86-Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "buildRoot": "${workspaceRoot}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "cmakeCommandArgs": "-DBINARY_RELEASE=ON",
+      "inheritEnvironments": [ "msvc_x86" ],
+      "intelliSenseMode": "windows-msvc-x86"
+    },
+    {
+      "name": "CPI-Debug",
+      "generator": "Unix Makefiles",
+      "configurationType": "Debug",
+      "cmakeExecutable": "cmake",
+      "remoteCopySourcesExclusionList": [ ".vs", ".git", "out" ],
+      "cmakeCommandArgs": "-DTARGET_PLATFORM=cpigamesh -DVERSION_NUM=1.1.0 -DVERSION_SUFFIX=DKR_VERSION",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "linux_arm" ],
+      "remoteMachineName": "-1829704065;192.168.10.1 (username=cpi, port=22, authentication=Password)",
+      "remoteCMakeListsRoot": "$HOME/.vs/${projectDirName}/${workspaceHash}/src",
+      "remoteBuildRoot": "$HOME/.vs/${projectDirName}/${workspaceHash}/out/build/${name}",
+      "remoteInstallRoot": "$HOME/.vs/${projectDirName}/${workspaceHash}/out/install/${name}",
+      "remoteCopySources": true,
+      "rsyncCommandArgs": "-t --delete --delete-excluded",
+      "remoteCopyBuildOutput": false,
+      "remoteCopySourcesMethod": "rsync",
+      "addressSanitizerRuntimeFlags": "detect_leaks=0"
+    }
+  ]
 }

--- a/SourceX/controls/controller.cpp
+++ b/SourceX/controls/controller.cpp
@@ -26,7 +26,7 @@ ControllerButtonEvent ToControllerButtonEvent(const SDL_Event &event)
 	result.button = KbCtrlToControllerButton(event);
 	if (result.button != ControllerButton_NONE)
 		return result;
-#endifs
+#endif
 #ifndef USE_SDL1
 	GameController *const controller = GameController::Get(event);
 	if (controller != NULL) {

--- a/SourceX/controls/controller.cpp
+++ b/SourceX/controls/controller.cpp
@@ -22,7 +22,11 @@ ControllerButtonEvent ToControllerButtonEvent(const SDL_Event &event)
 	default:
 		break;
 	}
-
+#if HAS_KBCTRL == 1
+	result.button = KbCtrlToControllerButton(event);
+	if (result.button != ControllerButton_NONE)
+		return result;
+#endifs
 #ifndef USE_SDL1
 	GameController *const controller = GameController::Get(event);
 	if (controller != NULL) {

--- a/SourceX/controls/controller.cpp
+++ b/SourceX/controls/controller.cpp
@@ -22,7 +22,11 @@ ControllerButtonEvent ToControllerButtonEvent(const SDL_Event &event)
 	default:
 		break;
 	}
-
+#if HAS_KBCTRL == 1
+	result.button = KbCtrlToControllerButton(event);
+	if (result.button != ControllerButton_NONE)
+		return result;
+#endif
 #ifndef USE_SDL1
 	GameController *const controller = GameController::Get(event);
 	if (controller != NULL) {

--- a/SourceX/controls/controller.cpp
+++ b/SourceX/controls/controller.cpp
@@ -22,11 +22,7 @@ ControllerButtonEvent ToControllerButtonEvent(const SDL_Event &event)
 	default:
 		break;
 	}
-#if HAS_KBCTRL == 1
-	result.button = KbCtrlToControllerButton(event);
-	if (result.button != ControllerButton_NONE)
-		return result;
-#endif
+
 #ifndef USE_SDL1
 	GameController *const controller = GameController::Get(event);
 	if (controller != NULL) {


### PR DESCRIPTION
Hi all,
I noticed that a recent change to controller.cpp broke the Gameshell support as `ToControllerButtonEvent` no longer reacts to key presses in the menu and later. With this commit, it is fixed.
Looking at the history, this change might have been forgotten when df56d6a03bdf1f148beafa8cbc8612eac4f6c34b was done.
Hope this fixes the issue also for other devices which need the `HAS_KBCTRL == 1` define.
Happy coding!