### PR TITLE
Fix shift+clicking stats behavior with capped stats

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1655,6 +1655,13 @@ void CheckChrBtns()
 	}
 }
 
+int CapStatPointsToAdd(int remainingStatPoints, const PlayerStruct &player, attribute_id attribute)
+{
+	int pointsToReachCap = player.GetMaximumAttributeValue(attribute) - player.GetBaseAttributeValue(attribute);
+
+	return std::min(remainingStatPoints, pointsToReachCap);
+}
+
 void ReleaseChrBtns(bool addAllStatPoints)
 {
 	int i;
@@ -1671,18 +1678,22 @@ void ReleaseChrBtns(bool addAllStatPoints)
 				int statPointsToAdd = addAllStatPoints ? player._pStatPts : 1;
 				switch (i) {
 				case 0:
+					statPointsToAdd = CapStatPointsToAdd(statPointsToAdd, player, attribute_id::ATTRIB_STR);
 					NetSendCmdParam1(TRUE, CMD_ADDSTR, statPointsToAdd);
 					player._pStatPts -= statPointsToAdd;
 					break;
 				case 1:
+					statPointsToAdd = CapStatPointsToAdd(statPointsToAdd, player, attribute_id::ATTRIB_MAG);
 					NetSendCmdParam1(TRUE, CMD_ADDMAG, statPointsToAdd);
 					player._pStatPts -= statPointsToAdd;
 					break;
 				case 2:
+					statPointsToAdd = CapStatPointsToAdd(statPointsToAdd, player, attribute_id::ATTRIB_DEX);
 					NetSendCmdParam1(TRUE, CMD_ADDDEX, statPointsToAdd);
 					player._pStatPts -= statPointsToAdd;
 					break;
 				case 3:
+					statPointsToAdd = CapStatPointsToAdd(statPointsToAdd, player, attribute_id::ATTRIB_VIT);
 					NetSendCmdParam1(TRUE, CMD_ADDVIT, statPointsToAdd);
 					player._pStatPts -= statPointsToAdd;
 					break;

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1667,23 +1667,24 @@ void ReleaseChrBtns(bool addAllStatPoints)
 			    && MouseX <= ChrBtnsRect[i].x + ChrBtnsRect[i].w
 			    && MouseY >= ChrBtnsRect[i].y
 			    && MouseY <= ChrBtnsRect[i].y + ChrBtnsRect[i].h) {
-				int statPointsToAdd = addAllStatPoints ? plr[myplr]._pStatPts : 1;
+				PlayerStruct &player = plr[myplr];
+				int statPointsToAdd = addAllStatPoints ? player._pStatPts : 1;
 				switch (i) {
 				case 0:
 					NetSendCmdParam1(TRUE, CMD_ADDSTR, statPointsToAdd);
-					plr[myplr]._pStatPts -= statPointsToAdd;
+					player._pStatPts -= statPointsToAdd;
 					break;
 				case 1:
 					NetSendCmdParam1(TRUE, CMD_ADDMAG, statPointsToAdd);
-					plr[myplr]._pStatPts -= statPointsToAdd;
+					player._pStatPts -= statPointsToAdd;
 					break;
 				case 2:
 					NetSendCmdParam1(TRUE, CMD_ADDDEX, statPointsToAdd);
-					plr[myplr]._pStatPts -= statPointsToAdd;
+					player._pStatPts -= statPointsToAdd;
 					break;
 				case 3:
 					NetSendCmdParam1(TRUE, CMD_ADDVIT, statPointsToAdd);
-					plr[myplr]._pStatPts -= statPointsToAdd;
+					player._pStatPts -= statPointsToAdd;
 					break;
 				}
 			}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -200,6 +200,27 @@ const char *const ClassPathTbl[] = {
 	"Warrior",
 };
 
+Sint32 PlayerStruct::GetBaseAttributeValue(attribute_id attribute) const
+{
+	switch (attribute) {
+	case attribute_id::ATTRIB_DEX:
+		return this->_pBaseDex;
+	case attribute_id::ATTRIB_MAG:
+		return this->_pBaseMag;
+	case attribute_id::ATTRIB_STR:
+		return this->_pBaseStr;
+	case attribute_id::ATTRIB_VIT:
+		return this->_pBaseVit;
+	default:
+		app_fatal("Unsupported attribute");
+	}
+}
+
+Sint32 PlayerStruct::GetMaximumAttributeValue(attribute_id attribute) const
+{
+	return MaxStats[_pClass][attribute];
+}
+
 void SetPlayerGPtrs(BYTE *pData, BYTE **pAnim)
 {
 	int i;

--- a/Source/player.h
+++ b/Source/player.h
@@ -225,6 +225,20 @@ typedef struct PlayerStruct {
 	Uint8 *_pHData;
 	Uint8 *_pDData;
 	Uint8 *_pBData;
+
+	/**
+	 * @brief Gets the base value of the player's specified attribute.
+	 * @param attribute The attribute to retrieve the base value for
+	 * @return The base value for the requested attribute.
+	*/
+	Sint32 GetBaseAttributeValue(attribute_id attribute) const;
+
+	/**
+	 * @brief Gets the maximum value of the player's specified attribute.
+	 * @param attribute The attribute to retrieve the maximum value for
+	 * @return The maximum value for the requested attribute.
+	*/
+	Sint32 GetMaximumAttributeValue(attribute_id attribute) const;
 } PlayerStruct;
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR fixes a bug that caused extra remaining stats to vanish when shift+click was used to assign all remaining stat points to a near-capped attribute.

Fixes #1342