### PR TITLE
fix gold spinner

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1959,9 +1959,9 @@ void DrawGoldSplit(CelOutputBuffer out, int amount)
 			BYTE c = fontframe[gbFontTransTbl[(BYTE)tempstr[i]]];
 			screen_x += fontkern[c] + 1;
 		}
-		screen_x += 452;
+		screen_x += 388;
 	} else {
-		screen_x = 450;
+		screen_x = 386;
 	}
 	CelDrawTo(out, screen_x, 140, pSPentSpn2Cels, PentSpn2Spin(), 12);
 }


### PR DESCRIPTION
It was probably caused by https://github.com/diasurgical/devilutionX/commit/70d1d633bd1745f803ffbc0a5be9e3a76479a08e
and I subtracted 64 from hardcoded numbers (that's what SCREEN_X was), now gold spinner aligns properly
Found by Nitekat
![image](https://user-images.githubusercontent.com/14297035/113494140-de201c00-94e5-11eb-9d56-eb6b91e58f69.png)
