### PR TITLE
ttf_render_wrapped: std functions instead of SDL

### DIFF
--- a/SourceX/DiabloUI/ttf_render_wrapped.cpp
+++ b/SourceX/DiabloUI/ttf_render_wrapped.cpp
@@ -1,9 +1,7 @@
 #include "DiabloUI/ttf_render_wrapped.h"
 
 #include <cstddef>
-#ifdef __3DS__
-#include <string.h>
-#endif
+#include <cstring>
 
 namespace dvl {
 
@@ -43,11 +41,7 @@ SDL_Surface *RenderUTF8_Solid_Wrapped(TTF_Font *font, const char *text, SDL_Colo
 		int w, h;
 		char *spot, *tok, *next_tok, *end;
 		char delim;
-#ifdef __3DS__
-		size_t str_len = strlen(text);
-#else
-		size_t str_len = SDL_strlen(text);
-#endif
+		const std::size_t str_len = std::strlen(text);
 
 		numLines = 0;
 
@@ -57,11 +51,7 @@ SDL_Surface *RenderUTF8_Solid_Wrapped(TTF_Font *font, const char *text, SDL_Colo
 			return NULL;
 		}
 
-#ifdef __3DS__
-		memcpy(str, text, str_len + 1);
-#else
-		SDL_strlcpy(str, text, str_len + 1);
-#endif
+		std::memcpy(str, text, str_len + 1);
 		tok = str;
 		end = str + str_len;
 		do {


### PR DESCRIPTION
Some SDL ports, such as the 3DS one and the PSP one, are missing these SDL functions.