### PR TITLE
✨ Make shift+attack consistent with attack at close range

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -443,7 +443,7 @@ void Interact()
 		NetSendCmdLocParam1(true, CMD_TALKXY, Towners[pcursmonst].position, pcursmonst);
 	} else if (pcursmonst != -1) {
 		if (Players[MyPlayerId]._pwtype != WT_RANGED || CanTalkToMonst(pcursmonst)) {
-			NetSendCmdParam1(true, CMD_ATTACKID, pcursmonst);
+			NetSendCmdParam2(true, CMD_ATTACKID, pcursmonst, false);
 		} else {
 			NetSendCmdParam1(true, CMD_RATTACKID, pcursmonst);
 		}

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -251,7 +251,7 @@ bool LeftMouseCmd(bool bShift)
 				NetSendCmdLoc(MyPlayerId, true, CMD_RATTACKXY, { cursmx, cursmy });
 			} else if (pcursmonst != -1) {
 				if (CanTalkToMonst(pcursmonst)) {
-					NetSendCmdParam1(true, CMD_ATTACKID, pcursmonst);
+					NetSendCmdParam2(true, CMD_ATTACKID, pcursmonst, false);
 				} else {
 					NetSendCmdParam1(true, CMD_RATTACKID, pcursmonst);
 				}
@@ -262,15 +262,15 @@ bool LeftMouseCmd(bool bShift)
 			if (bShift) {
 				if (pcursmonst != -1) {
 					if (CanTalkToMonst(pcursmonst)) {
-						NetSendCmdParam1(true, CMD_ATTACKID, pcursmonst);
+						NetSendCmdParam2(true, CMD_ATTACKID, pcursmonst, false);
 					} else {
-						NetSendCmdLoc(MyPlayerId, true, CMD_SATTACKXY, { cursmx, cursmy });
+						NetSendCmdParam2(true, CMD_ATTACKID, pcursmonst, true);
 					}
 				} else {
 					NetSendCmdLoc(MyPlayerId, true, CMD_SATTACKXY, { cursmx, cursmy });
 				}
 			} else if (pcursmonst != -1) {
-				NetSendCmdParam1(true, CMD_ATTACKID, pcursmonst);
+				NetSendCmdParam2(true, CMD_ATTACKID, pcursmonst, false);
 			} else if (pcursplr != -1 && !gbFriendlyMode) {
 				NetSendCmdParam1(true, CMD_ATTACKPID, pcursplr);
 			}

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1044,13 +1044,22 @@ DWORD OnOperateObjectTelekinesis(TCmd *pCmd, int pnum)
 
 DWORD OnAttackMonster(TCmd *pCmd, int pnum)
 {
-	auto *p = (TCmdParam1 *)pCmd;
+	auto *p = (TCmdParam2 *)pCmd;
+	auto monsterIndex = p->wParam1;
+	auto holdPosition = p->wParam2;
+	auto &targetMonster = Monsters[monsterIndex];
 
 	if (gbBufferMsgs != 1 && currlevel == Players[pnum].plrlevel) {
-		if (Players[pnum].position.tile.WalkingDistance(Monsters[p->wParam1].position.future) > 1)
-			MakePlrPath(pnum, Monsters[p->wParam1].position.future, false);
+		if (Players[pnum].position.tile.WalkingDistance(Monsters[p->wParam1].position.future) > 1) {
+			if (holdPosition) {
+				ClrPlrPath(Players[pnum]);
+			} else {
+				MakePlrPath(pnum, targetMonster.position.future, false);
+			}
+		}
 		Players[pnum].destAction = ACTION_ATTACKMON;
-		Players[pnum].destParam1 = p->wParam1;
+		Players[pnum].destParam1 = monsterIndex;
+		Players[pnum].destParam2 = holdPosition;
 	}
 
 	return sizeof(*p);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2960,7 +2960,9 @@ void CheckNewPath(int pnum, bool pmWillBeCalled)
 	int y = 0;
 
 	int i = -1;
-	if (player.destAction == ACTION_ATTACKMON) {
+
+	bool holdPosition = Players[pnum].destParam2;
+	if (player.destAction == ACTION_ATTACKMON && !holdPosition) {
 		i = player.destParam1;
 		MakePlrPath(pnum, Monsters[i].position.future, false);
 	}
@@ -3062,7 +3064,7 @@ void CheckNewPath(int pnum, bool pmWillBeCalled)
 		case ACTION_ATTACKMON:
 			x = abs(player.position.tile.x - Monsters[i].position.future.x);
 			y = abs(player.position.tile.y - Monsters[i].position.future.y);
-			if (x <= 1 && y <= 1) {
+			if ((x <= 1 && y <= 1) || holdPosition) {
 				d = GetDirection(player.position.future, Monsters[i].position.future);
 				if (Monsters[i].mtalkmsg != TEXT_NONE && Monsters[i].mtalkmsg != TEXT_VILE14) {
 					TalktoMonster(i);
@@ -3206,7 +3208,7 @@ void CheckNewPath(int pnum, bool pmWillBeCalled)
 			i = player.destParam1;
 			x = abs(player.position.tile.x - Monsters[i].position.future.x);
 			y = abs(player.position.tile.y - Monsters[i].position.future.y);
-			if (x <= 1 && y <= 1) {
+			if ((x <= 1 && y <= 1) || holdPosition) {
 				d = GetDirection(player.position.future, Monsters[i].position.future);
 				StartAttack(pnum, d);
 			}


### PR DESCRIPTION
This PR changes the way the game handles SHIFT+Clicking to attack when monsters are targeted. Instead of always generating a "attack tile at X/Y" command, we'll now generate a "attack monster X" when the player targets a specific monster. This improves responsiveness as the game actually keeps track of the monster being targeted, making it a bit easier and more intuitive to hit monsters.

Making it target a monster also helps with this parallel change: 
- https://github.com/diasurgical/devilutionX/pull/962