### PR TITLE
Add a keymapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,6 +349,7 @@ set(devilutionx_SRCS
   Source/controls/modifier_hints.cpp
   Source/controls/plrctrls.cpp
   Source/controls/touch.cpp
+  Source/controls/keymapper.cpp
   Source/engine/animationinfo.cpp
   Source/qol/autopickup.cpp
   Source/qol/common.cpp

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -6,6 +6,7 @@
 #include "control.h"
 
 #include <cstddef>
+#include <array>
 
 #include "DiabloUI/diabloui.h"
 #include "automap.h"
@@ -22,6 +23,7 @@
 #include "towners.h"
 #include "trigs.h"
 #include "utils/language.h"
+#include "controls/keymapper.hpp"
 
 namespace devilution {
 namespace {
@@ -79,6 +81,8 @@ BYTE SplTransTbl[256];
 int initialDropGoldValue;
 bool panbtndown;
 bool spselflag;
+extern Keymapper keymapper;
+extern std::array<Keymapper::ActionIndex, 4> quickSpellActionIndexes;
 
 /** Map of hero class names */
 const char *const ClassStrTbl[] = {
@@ -367,6 +371,23 @@ static void DrawSpell(const CelOutputBuffer &out)
 		DrawSpellCel(out, PANEL_X + 565, PANEL_Y + 119, *pSpellCels, 27);
 }
 
+static void PrintSBookHotkey(CelOutputBuffer out, int x, int y, const std::string &text, text_color col)
+{
+	x += SPLICONLENGTH;
+	y -= SPLICONLENGTH;
+
+	int totalWidth = 0;
+
+	for (const char txtChar : text) {
+		auto c = gbFontTransTbl[static_cast<BYTE>(txtChar)];
+		c = fontframe[c];
+
+		totalWidth += fontkern[c] + 1;
+	}
+
+	PrintGameStr(out, x - totalWidth - 4, y + 17, text.c_str(), col);
+}
+
 void DrawSpellList(const CelOutputBuffer &out)
 {
 	int c;
@@ -474,8 +495,10 @@ void DrawSpellList(const CelOutputBuffer &out)
 				}
 				for (int t = 0; t < 4; t++) {
 					if (plr[myplr]._pSplHotKey[t] == pSpell && plr[myplr]._pSplTHotKey[t] == pSplType) {
-						DrawSpellCel(out, x, y, *pSpellCels, t + SPLICONLAST + 5);
-						sprintf(tempstr, _("Spell Hotkey #F%i"), t + 5);
+						auto hotkeyName = keymapper.keyNameForAction(quickSpellActionIndexes[t]);
+						PrintSBookHotkey(out, x - 1, y + 1, hotkeyName, COL_BLACK);
+						PrintSBookHotkey(out, x, y, hotkeyName, COL_WHITE);
+						sprintf(tempstr, _("Spell Hotkey %s"), hotkeyName.c_str());
 						AddPanelString(tempstr, true);
 					}
 				}

--- a/Source/controls/keymapper.cpp
+++ b/Source/controls/keymapper.cpp
@@ -1,0 +1,129 @@
+#include "keymapper.hpp"
+
+#include <cassert>
+#include <fmt/format.h>
+
+#include <SDL.h>
+
+#ifdef USE_SDL1
+#include "utils/sdl2_to_1_2_backports.h"
+#endif
+
+#include "../miniwin/miniwin.h"
+#include "utils/log.hpp"
+
+namespace devilution {
+
+Keymapper::Keymapper(SetConfigKeyFunction setKeyFunction, GetConfigKeyFunction getKeyFunction)
+    : setKeyFunction(setKeyFunction)
+    , getKeyFunction(getKeyFunction)
+{
+	// Insert all supported keys: a-z, 0-9 and F1-F12.
+	keyIDToKeyName.reserve(('Z' - 'A' + 1) + ('9' - '0' + 1) + 12);
+	for (char c = 'A'; c <= 'Z'; ++c) {
+		keyIDToKeyName.emplace(c, std::string(1, c));
+	}
+	for (char c = '0'; c <= '9'; ++c) {
+		keyIDToKeyName.emplace(c, std::string(1, c));
+	}
+	for (int i = 0; i < 12; ++i) {
+		keyIDToKeyName.emplace(DVL_VK_F1 + i, fmt::format("F{}", i + 1));
+	}
+
+	keyNameToKeyID.reserve(keyIDToKeyName.size());
+	for (const auto &kv : keyIDToKeyName) {
+		keyNameToKeyID.emplace(kv.second, kv.first);
+	}
+}
+
+Keymapper::ActionIndex Keymapper::addAction(const Action &action)
+{
+	actions.emplace_back(action);
+
+	return actions.size() - 1;
+}
+
+void Keymapper::keyPressed(int key, bool isPlayerDead) const
+{
+	auto it = keyIDToAction.find(key);
+	if (it == keyIDToAction.end())
+		return; // Ignore unmapped keys.
+
+	auto &action = it->second;
+
+	// Some actions cannot be triggered while the player is dead.
+	if (isPlayerDead && action.get().ifDead == Action::IfDead::Ignore)
+		return;
+
+	action();
+}
+
+std::string Keymapper::keyNameForAction(ActionIndex actionIndex) const
+{
+	assert(actionIndex < actions.size());
+	auto key = actions[actionIndex].key;
+	auto it = keyIDToKeyName.find(key);
+	assert(it != keyIDToKeyName.end());
+	return it->second;
+}
+
+void Keymapper::save() const
+{
+	// Use the action vector to go though the actions to keep the same order.
+	for (const auto &action : actions) {
+		if (action.key == DVL_VK_INVALID) {
+			// Just add an empty config entry if the action is unbound.
+			setKeyFunction(action.name, "");
+			continue;
+		}
+
+		auto keyNameIt = keyIDToKeyName.find(action.key);
+		if (keyNameIt == keyIDToKeyName.end()) {
+			Log("Keymapper: no name found for key '{}'", action.key);
+			continue;
+		}
+		setKeyFunction(action.name, keyNameIt->second);
+	}
+}
+
+void Keymapper::load()
+{
+	keyIDToAction.clear();
+
+	for (auto &action : actions) {
+		auto key = getActionKey(action);
+		action.key = key;
+		if (key == DVL_VK_INVALID) {
+			// Skip if the action has no key bound to it.
+			continue;
+		}
+		// Store the key in action.key and in the map so we can save() the
+		// actions while keeping the same order as they have been added.
+		keyIDToAction.emplace(key, action);
+	}
+}
+
+int Keymapper::getActionKey(const Keymapper::Action &action)
+{
+	auto key = getKeyFunction(action.name);
+	if (key.empty())
+		return action.defaultKey; // Return the default key if no key has been set.
+
+
+	auto keyIt = keyNameToKeyID.find(key);
+	if (keyIt == keyNameToKeyID.end()) {
+		// Return the default key if the key is unknown.
+		Log("Keymapper: unknown key '{}'", key);
+		return action.defaultKey;
+	}
+
+	auto it = keyIDToAction.find(keyIt->second);
+	if (it != keyIDToAction.end()) {
+		// Warn about overwriting keys.
+		Log("Keymapper: key '{}' is already bound to action '{}', overwriting", key, it->second.get().name);
+	}
+
+	return keyIt->second;
+}
+
+} // namespace devilution

--- a/Source/controls/keymapper.cpp
+++ b/Source/controls/keymapper.cpp
@@ -19,7 +19,11 @@ Keymapper::Keymapper(SetConfigKeyFunction setKeyFunction, GetConfigKeyFunction g
     , getKeyFunction(getKeyFunction)
 {
 	// Insert all supported keys: a-z, 0-9 and F1-F12.
+#ifndef __vita__
+	// HACK: Disable reserving on Vita because it triggers a linking error:
+	// "multiple definition of `ceill'".
 	keyIDToKeyName.reserve(('Z' - 'A' + 1) + ('9' - '0' + 1) + 12);
+#endif
 	for (char c = 'A'; c <= 'Z'; ++c) {
 		keyIDToKeyName.emplace(c, std::string(1, c));
 	}
@@ -30,7 +34,11 @@ Keymapper::Keymapper(SetConfigKeyFunction setKeyFunction, GetConfigKeyFunction g
 		keyIDToKeyName.emplace(DVL_VK_F1 + i, fmt::format("F{}", i + 1));
 	}
 
+#ifndef __vita__
+	// HACK: Disable reserving on Vita because it triggers a linking error:
+	// "multiple definition of `ceill'".
 	keyNameToKeyID.reserve(keyIDToKeyName.size());
+#endif
 	for (const auto &kv : keyIDToKeyName) {
 		keyNameToKeyID.emplace(kv.second, kv.first);
 	}

--- a/Source/controls/keymapper.hpp
+++ b/Source/controls/keymapper.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <functional>
+#include <vector>
+#include <unordered_map>
+
+namespace devilution {
+
+/** The Keymapper maps keys to actions. */
+class Keymapper final {
+public:
+	using SetConfigKeyFunction = std::function<void(const std::string &key, const std::string &value)>;
+	using GetConfigKeyFunction = std::function<std::string(const std::string &key)>;
+	using ActionIndex = std::size_t;
+
+	/**
+	 * Action represents an action that can be triggered using a keyboard
+	 * shortcut.
+	 */
+	class Action final {
+	public:
+		/** Can this action be triggered while the player is dead? */
+
+		enum class IfDead {
+			Allow,
+			Ignore,
+		};
+
+		Action(const std::string &name, int defaultKey, std::function<void()> action)
+		    : name(name)
+		    , defaultKey(defaultKey)
+		    , action(action)
+		    , ifDead(IfDead::Ignore)
+		{
+		}
+		Action(const std::string &name, int defaultKey, std::function<void()> action, IfDead ifDead)
+		    : name(name)
+		    , defaultKey(defaultKey)
+		    , action(action)
+		    , ifDead(ifDead)
+		{
+		}
+
+		void operator()() const
+		{
+			action();
+		}
+
+	private:
+		std::string name;
+		int defaultKey;
+		std::function<void()> action;
+		IfDead ifDead;
+		int key {};
+
+		friend class Keymapper;
+	};
+
+	/**
+	 * Keymapper, for now, uses two function pointers to interact with the
+	 * configuration.
+	 * This is mostly a workaround and should be replaced later when another INI
+	 * library will be used.
+	 */
+	Keymapper(SetConfigKeyFunction setKeyFunction, GetConfigKeyFunction getKeyFunction);
+
+	ActionIndex addAction(const Action &action);
+	void keyPressed(int key, bool isPlayerDead) const;
+	std::string keyNameForAction(ActionIndex actionIndex) const;
+	void save() const;
+	void load();
+
+private:
+	int getActionKey(const Action &action);
+
+	std::vector<Action> actions;
+	std::unordered_map<int, std::reference_wrapper<Action>> keyIDToAction;
+	std::unordered_map<int, std::string> keyIDToKeyName;
+	std::unordered_map<std::string, int> keyNameToKeyID;
+	SetConfigKeyFunction setKeyFunction;
+	GetConfigKeyFunction getKeyFunction;
+};
+
+} // namespace devilution

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2203,15 +2203,8 @@ void initKeymapActions()
 	for (int i = 0; i < 8; ++i) {
 		keymapper.addAction({
 		    std::string("BeltItem") + std::to_string(i + 1),
-
 		    '1' + i,
 		    [i] {
-#ifdef _DEBUG
-			    if (i == 7 && (debug_mode_key_inverted_v || debug_mode_key_w)) {
-				    NetSendCmd(true, CMD_CHEAT_EXPERIENCE);
-				    return;
-			    }
-#endif
 			    if (!plr[myplr].SpdList[i].isEmpty() && plr[myplr].SpdList[i]._itype != ITYPE_GOLD) {
 				    UseInvItem(myplr, INVITEM_BELT_FIRST + i);
 			    }
@@ -2235,6 +2228,18 @@ void initKeymapActions()
 	    [] { gamemenu_quit_game(false); },
 	    Keymapper::Action::IfDead::Allow,
 	});
+#ifdef _DEBUG
+	keymapper.addAction({
+	    "CheatExperience",
+	    DVL_VK_INVALID,
+	    [] {
+		    if (debug_mode_key_inverted_v || debug_mode_key_w) {
+			    NetSendCmd(true, CMD_CHEAT_EXPERIENCE);
+			    return;
+		    }
+	    },
+	});
+#endif
 }
 
 } // namespace devilution

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1001,19 +1001,21 @@ static void RightMouseDown()
 	if (!gmenu_is_active() && sgnTimeoutCurs == CURSOR_NONE && PauseMode != 2 && !plr[myplr]._pInvincible) {
 		if (DoomFlag) {
 			doom_close();
-		} else if (stextflag == STORE_NONE) {
-			if (spselflag) {
-				SetSpell();
-			} else if (MouseY >= SPANEL_HEIGHT
-			    || ((!sbookflag || MouseX <= RIGHT_PANEL)
-			        && !TryIconCurs()
-			        && (pcursinvitem == -1 || !UseInvItem(myplr, pcursinvitem)))) {
-				if (pcurs == CURSOR_HAND) {
-					if (pcursinvitem == -1 || !UseInvItem(myplr, pcursinvitem))
-						CheckPlrSpell();
-				} else if (pcurs > CURSOR_HAND && pcurs < CURSOR_FIRSTITEM) {
-					NewCursor(CURSOR_HAND);
-				}
+			return;
+		}
+		if (stextflag != STORE_NONE)
+			return;
+		if (spselflag) {
+			SetSpell();
+		} else if (MouseY >= SPANEL_HEIGHT
+		    || ((!sbookflag || MouseX <= RIGHT_PANEL)
+		        && !TryIconCurs()
+		        && (pcursinvitem == -1 || !UseInvItem(myplr, pcursinvitem)))) {
+			if (pcurs == CURSOR_HAND) {
+				if (pcursinvitem == -1 || !UseInvItem(myplr, pcursinvitem))
+					CheckPlrSpell();
+			} else if (pcurs > CURSOR_HAND && pcurs < CURSOR_FIRSTITEM) {
+				NewCursor(CURSOR_HAND);
 			}
 		}
 	}
@@ -2007,98 +2009,98 @@ void itemInfoKeyPressed()
 
 void inventoryKeyPressed()
 {
-	if (stextflag == STORE_NONE) {
-		invflag = !invflag;
-		if (!chrflag && !questlog && CanPanelsCoverView()) {
-			if (!invflag) { // We closed the invetory
-				if (MouseX < 480 && MouseY < PANEL_TOP) {
-					SetCursorPos(MouseX + 160, MouseY);
-				}
-			} else if (!sbookflag) { // We opened the invetory
-				if (MouseX > 160 && MouseY < PANEL_TOP) {
-					SetCursorPos(MouseX - 160, MouseY);
-				}
+	if (stextflag != STORE_NONE)
+		return;
+	invflag = !invflag;
+	if (!chrflag && !questlog && CanPanelsCoverView()) {
+		if (!invflag) { // We closed the invetory
+			if (MouseX < 480 && MouseY < PANEL_TOP) {
+				SetCursorPos(MouseX + 160, MouseY);
+			}
+		} else if (!sbookflag) { // We opened the invetory
+			if (MouseX > 160 && MouseY < PANEL_TOP) {
+				SetCursorPos(MouseX - 160, MouseY);
 			}
 		}
-		sbookflag = false;
 	}
+	sbookflag = false;
 }
 
 void characterSheetKeyPressed()
 {
-	if (stextflag == STORE_NONE) {
-		chrflag = !chrflag;
-		if (!invflag && !sbookflag && CanPanelsCoverView()) {
-			if (!chrflag) { // We closed the character sheet
-				if (MouseX > 160 && MouseY < PANEL_TOP) {
-					SetCursorPos(MouseX - 160, MouseY);
-				}
-			} else if (!questlog) { // We opened the character sheet
-				if (MouseX < 480 && MouseY < PANEL_TOP) {
-					SetCursorPos(MouseX + 160, MouseY);
-				}
+	if (stextflag != STORE_NONE)
+		return;
+	chrflag = !chrflag;
+	if (!invflag && !sbookflag && CanPanelsCoverView()) {
+		if (!chrflag) { // We closed the character sheet
+			if (MouseX > 160 && MouseY < PANEL_TOP) {
+				SetCursorPos(MouseX - 160, MouseY);
+			}
+		} else if (!questlog) { // We opened the character sheet
+			if (MouseX < 480 && MouseY < PANEL_TOP) {
+				SetCursorPos(MouseX + 160, MouseY);
 			}
 		}
-		questlog = false;
 	}
+	questlog = false;
 }
 
 void questLogKeyPressed()
 {
-	if (stextflag == STORE_NONE) {
-		if (!questlog) {
-			StartQuestlog();
-		} else {
-			questlog = false;
-		}
-		if (!invflag && !sbookflag && CanPanelsCoverView()) {
-			if (!questlog) { // We closed the quest log
-				if (MouseX > 160 && MouseY < PANEL_TOP) {
-					SetCursorPos(MouseX - 160, MouseY);
-				}
-			} else if (!chrflag) { // We opened the character quest log
-				if (MouseX < 480 && MouseY < PANEL_TOP) {
-					SetCursorPos(MouseX + 160, MouseY);
-				}
+	if (stextflag != STORE_NONE)
+		return;
+	if (!questlog) {
+		StartQuestlog();
+	} else {
+		questlog = false;
+	}
+	if (!invflag && !sbookflag && CanPanelsCoverView()) {
+		if (!questlog) { // We closed the quest log
+			if (MouseX > 160 && MouseY < PANEL_TOP) {
+				SetCursorPos(MouseX - 160, MouseY);
+			}
+		} else if (!chrflag) { // We opened the character quest log
+			if (MouseX < 480 && MouseY < PANEL_TOP) {
+				SetCursorPos(MouseX + 160, MouseY);
 			}
 		}
-		chrflag = false;
 	}
+	chrflag = false;
 }
 
 void displaySpellsKeyPressed()
 {
-	if (stextflag == STORE_NONE) {
-		chrflag = false;
-		questlog = false;
-		invflag = false;
-		sbookflag = false;
-		if (!spselflag) {
-			DoSpeedBook();
-		} else {
-			spselflag = false;
-		}
-		track_repeat_walk(false);
+	if (stextflag != STORE_NONE)
+		return;
+	chrflag = false;
+	questlog = false;
+	invflag = false;
+	sbookflag = false;
+	if (!spselflag) {
+		DoSpeedBook();
+	} else {
+		spselflag = false;
 	}
+	track_repeat_walk(false);
 }
 
 void spellBookKeyPressed()
 {
-	if (stextflag == STORE_NONE) {
-		sbookflag = !sbookflag;
-		if (!chrflag && !questlog && CanPanelsCoverView()) {
-			if (!sbookflag) { // We closed the invetory
-				if (MouseX < 480 && MouseY < PANEL_TOP) {
-					SetCursorPos(MouseX + 160, MouseY);
-				}
-			} else if (!invflag) { // We opened the invetory
-				if (MouseX > 160 && MouseY < PANEL_TOP) {
-					SetCursorPos(MouseX - 160, MouseY);
-				}
+	if (stextflag != STORE_NONE)
+		return;
+	sbookflag = !sbookflag;
+	if (!chrflag && !questlog && CanPanelsCoverView()) {
+		if (!sbookflag) { // We closed the invetory
+			if (MouseX < 480 && MouseY < PANEL_TOP) {
+				SetCursorPos(MouseX + 160, MouseY);
+			}
+		} else if (!invflag) { // We opened the invetory
+			if (MouseX > 160 && MouseY < PANEL_TOP) {
+				SetCursorPos(MouseX - 160, MouseY);
 			}
 		}
-		invflag = false;
 	}
+	invflag = false;
 }
 
 void initKeymapActions()

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -3,6 +3,8 @@
  *
  * Implementation of the main game initialization functions.
  */
+#include <array>
+
 #include <config.h>
 
 #include "automap.h"
@@ -52,6 +54,7 @@
 #include "utils/language.h"
 #include "utils/paths.h"
 #include "utils/language.h"
+#include "controls/keymapper.hpp"
 
 #ifndef NOSOUND
 #include "sound.h"
@@ -110,6 +113,19 @@ int color_cycle_timer;
 uint16_t gnTickDelay = 50;
 /** Game options */
 Options sgOptions;
+Keymapper keymapper {
+	// Workaround: remove once the INI library has been replaced.
+	[](const std::string &key, const std::string &value) {
+	    setIniValue("Keymapping", key.c_str(), value.c_str());
+	},
+	[](const std::string &key) -> std::string {
+	    std::array<char, 64> result;
+	    if (!getIniValue("Keymapping", key.c_str(), result.data(), result.size()))
+		    return {};
+	    return { result.data() };
+	}
+};
+std::array<Keymapper::ActionIndex, 4> quickSpellActionIndexes;
 
 /* rdata */
 
@@ -140,8 +156,8 @@ const char *const spszMsgTbl[] = {
 	N_("Here's something for you."),
 	N_("Now you DIE!")
 };
-/** INI files variable names for quick message keys */
-const char *const spszMsgHotKeyTbl[] = { "F9", "F10", "F11", "F12" };
+/** INI files variable names for quick messages */
+const char *const spszMsgNameTbl[] = { "QuickMessage1", "QuickMessage2", "QuickMessage3", "QuickMessage4" };
 
 /** To know if these things have been done when we get to the diablo_deinit() function */
 bool was_archives_init = false;
@@ -154,6 +170,8 @@ bool sbWasOptionsLoaded = false;
 // Controller support:
 extern void plrctrls_every_frame();
 extern void plrctrls_after_game_logic();
+
+void initKeymapActions();
 
 [[noreturn]] static void print_help_and_exit()
 {
@@ -526,7 +544,7 @@ static void SaveOptions()
 	setIniValue("Network", "Previous Host", sgOptions.Network.szPreviousHost);
 
 	for (size_t i = 0; i < sizeof(spszMsgTbl) / sizeof(spszMsgTbl[0]); i++)
-		setIniValue("NetMsg", spszMsgHotKeyTbl[i], sgOptions.Chat.szHotKeyMsgs[i]);
+		setIniValue("NetMsg", spszMsgNameTbl[i], sgOptions.Chat.szHotKeyMsgs[i]);
 
 	setIniValue("Controller", "Mapping", sgOptions.Controller.szMapping);
 	setIniInt("Controller", "Swap Shoulder Button Mode", sgOptions.Controller.bSwapShoulderButtonMode);
@@ -537,6 +555,8 @@ static void SaveOptions()
 #endif
 
 	setIniValue("Language", "Code", sgOptions.Language.szCode);
+
+	keymapper.save();
 
 	SaveIni();
 }
@@ -609,7 +629,7 @@ static void LoadOptions()
 	getIniValue("Network", "Previous Host", sgOptions.Network.szPreviousHost, sizeof(sgOptions.Network.szPreviousHost), "");
 
 	for (size_t i = 0; i < sizeof(spszMsgTbl) / sizeof(spszMsgTbl[0]); i++)
-		getIniValue("NetMsg", spszMsgHotKeyTbl[i], sgOptions.Chat.szHotKeyMsgs[i], MAX_SEND_STR_LEN, "");
+		getIniValue("NetMsg", spszMsgNameTbl[i], sgOptions.Chat.szHotKeyMsgs[i], MAX_SEND_STR_LEN, "");
 
 	getIniValue("Controller", "Mapping", sgOptions.Controller.szMapping, sizeof(sgOptions.Controller.szMapping), "");
 	sgOptions.Controller.bSwapShoulderButtonMode = getIniBool("Controller", "Swap Shoulder Button Mode", false);
@@ -620,6 +640,8 @@ static void LoadOptions()
 #endif
 
 	getIniValue("Language", "Code", sgOptions.Language.szCode, sizeof(sgOptions.Language.szCode), "en");
+
+	keymapper.load();
 
 	sbWasOptionsLoaded = true;
 }
@@ -753,6 +775,7 @@ int DiabloMain(int argc, char **argv)
 #endif
 
 	diablo_parse_flags(argc, argv);
+	initKeymapActions();
 	LoadOptions();
 	diablo_init();
 	diablo_splash();
@@ -1113,18 +1136,7 @@ static void PressKey(int vkey)
 		if (sgnTimeoutCurs != CURSOR_NONE) {
 			return;
 		}
-		if (vkey == DVL_VK_F9) {
-			diablo_hotkey_msg(0);
-		}
-		if (vkey == DVL_VK_F10) {
-			diablo_hotkey_msg(1);
-		}
-		if (vkey == DVL_VK_F11) {
-			diablo_hotkey_msg(2);
-		}
-		if (vkey == DVL_VK_F12) {
-			diablo_hotkey_msg(3);
-		}
+		keymapper.keyPressed(vkey, deathflag);
 		if (vkey == DVL_VK_RETURN) {
 			if ((GetAsyncKeyState(DVL_VK_MENU) & 0x8000) != 0)
 				dx_reinit();
@@ -1156,6 +1168,8 @@ static void PressKey(int vkey)
 		return;
 	}
 
+	keymapper.keyPressed(vkey, deathflag);
+
 	if (vkey == DVL_VK_RETURN) {
 		if ((GetAsyncKeyState(DVL_VK_MENU) & 0x8000) != 0) {
 			dx_reinit();
@@ -1166,91 +1180,6 @@ static void PressKey(int vkey)
 		} else {
 			control_type_message();
 		}
-	} else if (vkey == DVL_VK_F1) {
-		if (helpflag) {
-			helpflag = false;
-		} else if (stextflag != STORE_NONE) {
-			ClearPanel();
-			AddPanelString(_("No help available"), true); /// BUGFIX: message isn't displayed
-			AddPanelString(_("while in stores"), true);
-			track_repeat_walk(false);
-		} else {
-			invflag = false;
-			chrflag = false;
-			sbookflag = false;
-			spselflag = false;
-			if (qtextflag && leveltype == DTYPE_TOWN) {
-				qtextflag = false;
-				stream_stop();
-			}
-			questlog = false;
-			AutomapActive = false;
-			msgdelay = 0;
-			gamemenu_off();
-			DisplayHelp();
-			doom_close();
-		}
-	}
-#ifdef _DEBUG
-	else if (vkey == DVL_VK_F2) {
-	}
-#endif
-#ifdef _DEBUG
-	else if (vkey == DVL_VK_F3) {
-		if (pcursitem != -1) {
-			sprintf(
-			    tempstr,
-			    "IDX = %i  :  Seed = %i  :  CF = %i",
-			    items[pcursitem].IDidx,
-			    items[pcursitem]._iSeed,
-			    items[pcursitem]._iCreateInfo);
-			NetSendCmdString(1 << myplr, tempstr);
-		}
-		sprintf(tempstr, "Numitems : %i", numitems);
-		NetSendCmdString(1 << myplr, tempstr);
-	}
-#endif
-#ifdef _DEBUG
-	else if (vkey == DVL_VK_F4) {
-		PrintDebugQuest();
-	}
-#endif
-	else if (vkey == DVL_VK_F5) {
-		if (spselflag) {
-			SetSpeedSpell(0);
-			return;
-		}
-		ToggleSpell(0);
-		return;
-	} else if (vkey == DVL_VK_F6) {
-		if (spselflag) {
-			SetSpeedSpell(1);
-			return;
-		}
-		ToggleSpell(1);
-		return;
-	} else if (vkey == DVL_VK_F7) {
-		if (spselflag) {
-			SetSpeedSpell(2);
-			return;
-		}
-		ToggleSpell(2);
-		return;
-	} else if (vkey == DVL_VK_F8) {
-		if (spselflag) {
-			SetSpeedSpell(3);
-			return;
-		}
-		ToggleSpell(3);
-		return;
-	} else if (vkey == DVL_VK_F9) {
-		diablo_hotkey_msg(0);
-	} else if (vkey == DVL_VK_F10) {
-		diablo_hotkey_msg(1);
-	} else if (vkey == DVL_VK_F11) {
-		diablo_hotkey_msg(2);
-	} else if (vkey == DVL_VK_F12) {
-		diablo_hotkey_msg(3);
 	} else if (vkey == DVL_VK_UP) {
 		if (stextflag != STORE_NONE) {
 			STextUp();
@@ -1328,111 +1257,9 @@ static void PressChar(int32_t vkey)
 		return;
 	}
 
+	keymapper.keyPressed(vkey, deathflag);
+
 	switch (vkey) {
-	case 'G':
-	case 'g':
-		DecreaseGamma();
-		return;
-	case 'F':
-	case 'f':
-		IncreaseGamma();
-		return;
-	case 'I':
-	case 'i':
-		if (stextflag == STORE_NONE) {
-			invflag = !invflag;
-			if (!chrflag && !questlog && CanPanelsCoverView()) {
-				if (!invflag) { // We closed the invetory
-					if (MouseX < 480 && MouseY < PANEL_TOP) {
-						SetCursorPos(MouseX + 160, MouseY);
-					}
-				} else if (!sbookflag) { // We opened the invetory
-					if (MouseX > 160 && MouseY < PANEL_TOP) {
-						SetCursorPos(MouseX - 160, MouseY);
-					}
-				}
-			}
-			sbookflag = false;
-		}
-		return;
-	case 'C':
-	case 'c':
-		if (stextflag == STORE_NONE) {
-			chrflag = !chrflag;
-			if (!invflag && !sbookflag && CanPanelsCoverView()) {
-				if (!chrflag) { // We closed the character sheet
-					if (MouseX > 160 && MouseY < PANEL_TOP) {
-						SetCursorPos(MouseX - 160, MouseY);
-					}
-				} else if (!questlog) { // We opened the character sheet
-					if (MouseX < 480 && MouseY < PANEL_TOP) {
-						SetCursorPos(MouseX + 160, MouseY);
-					}
-				}
-			}
-			questlog = false;
-		}
-		return;
-	case 'Q':
-	case 'q':
-		if (stextflag == STORE_NONE) {
-			if (!questlog) {
-				StartQuestlog();
-			} else {
-				questlog = false;
-			}
-			if (!invflag && !sbookflag && CanPanelsCoverView()) {
-				if (!questlog) { // We closed the quest log
-					if (MouseX > 160 && MouseY < PANEL_TOP) {
-						SetCursorPos(MouseX - 160, MouseY);
-					}
-				} else if (!chrflag) { // We opened the character quest log
-					if (MouseX < 480 && MouseY < PANEL_TOP) {
-						SetCursorPos(MouseX + 160, MouseY);
-					}
-				}
-			}
-			chrflag = false;
-		}
-		return;
-	case 'Z':
-	case 'z':
-		zoomflag = !zoomflag;
-		CalcViewportGeometry();
-		return;
-	case 'S':
-	case 's':
-		if (stextflag == STORE_NONE) {
-			chrflag = false;
-			questlog = false;
-			invflag = false;
-			sbookflag = false;
-			if (!spselflag) {
-				DoSpeedBook();
-			} else {
-				spselflag = false;
-			}
-			track_repeat_walk(false);
-		}
-		return;
-	case 'B':
-	case 'b':
-		if (stextflag == STORE_NONE) {
-			sbookflag = !sbookflag;
-			if (!chrflag && !questlog && CanPanelsCoverView()) {
-				if (!sbookflag) { // We closed the invetory
-					if (MouseX < 480 && MouseY < PANEL_TOP) {
-						SetCursorPos(MouseX + 160, MouseY);
-					}
-				} else if (!invflag) { // We opened the invetory
-					if (MouseX > 160 && MouseY < PANEL_TOP) {
-						SetCursorPos(MouseX - 160, MouseY);
-					}
-				}
-			}
-			invflag = false;
-		}
-		return;
 	case '+':
 	case '=':
 		if (AutomapActive) {
@@ -1443,74 +1270,6 @@ static void PressChar(int32_t vkey)
 	case '_':
 		if (AutomapActive) {
 			AutomapZoomOut();
-		}
-		return;
-	case 'v': {
-		char pszStr[120];
-		const char *difficulties[3] = {
-			_("Normal"),
-			_("Nightmare"),
-			_("Hell"),
-		};
-		sprintf(pszStr, _("%s, mode = %s"), gszProductName, difficulties[sgGameInitInfo.nDifficulty]);
-		NetSendCmdString(1 << myplr, pszStr);
-		return;
-	}
-	case 'V':
-		NetSendCmdString(1 << myplr, gszVersionNumber);
-		return;
-	case '!':
-	case '1':
-		if (!plr[myplr].SpdList[0].isEmpty() && plr[myplr].SpdList[0]._itype != ITYPE_GOLD) {
-			UseInvItem(myplr, INVITEM_BELT_FIRST);
-		}
-		return;
-	case '@':
-	case '2':
-		if (!plr[myplr].SpdList[1].isEmpty() && plr[myplr].SpdList[1]._itype != ITYPE_GOLD) {
-			UseInvItem(myplr, INVITEM_BELT_FIRST + 1);
-		}
-		return;
-	case '#':
-	case '3':
-		if (!plr[myplr].SpdList[2].isEmpty() && plr[myplr].SpdList[2]._itype != ITYPE_GOLD) {
-			UseInvItem(myplr, INVITEM_BELT_FIRST + 2);
-		}
-		return;
-	case '$':
-	case '4':
-		if (!plr[myplr].SpdList[3].isEmpty() && plr[myplr].SpdList[3]._itype != ITYPE_GOLD) {
-			UseInvItem(myplr, INVITEM_BELT_FIRST + 3);
-		}
-		return;
-	case '%':
-	case '5':
-		if (!plr[myplr].SpdList[4].isEmpty() && plr[myplr].SpdList[4]._itype != ITYPE_GOLD) {
-			UseInvItem(myplr, INVITEM_BELT_FIRST + 4);
-		}
-		return;
-	case '^':
-	case '6':
-		if (!plr[myplr].SpdList[5].isEmpty() && plr[myplr].SpdList[5]._itype != ITYPE_GOLD) {
-			UseInvItem(myplr, INVITEM_BELT_FIRST + 5);
-		}
-		return;
-	case '&':
-	case '7':
-		if (!plr[myplr].SpdList[6].isEmpty() && plr[myplr].SpdList[6]._itype != ITYPE_GOLD) {
-			UseInvItem(myplr, INVITEM_BELT_FIRST + 6);
-		}
-		return;
-	case '*':
-	case '8':
-#ifdef _DEBUG
-		if (debug_mode_key_inverted_v || debug_mode_key_w) {
-			NetSendCmd(true, CMD_CHEAT_EXPERIENCE);
-			return;
-		}
-#endif
-		if (!plr[myplr].SpdList[7].isEmpty() && plr[myplr].SpdList[7]._itype != ITYPE_GOLD) {
-			UseInvItem(myplr, INVITEM_BELT_FIRST + 7);
 		}
 		return;
 #ifdef _DEBUG
@@ -2200,6 +1959,280 @@ void diablo_color_cyc_logic()
 	} else if (leveltype == DTYPE_CAVES) {
 		palette_update_caves();
 	}
+}
+
+void helpKeyPressed()
+{
+	if (helpflag) {
+		helpflag = false;
+	} else if (stextflag != STORE_NONE) {
+		ClearPanel();
+		AddPanelString(_("No help available"), true); /// BUGFIX: message isn't displayed
+		AddPanelString(_("while in stores"), true);
+		track_repeat_walk(false);
+	} else {
+		invflag = false;
+		chrflag = false;
+		sbookflag = false;
+		spselflag = false;
+		if (qtextflag && leveltype == DTYPE_TOWN) {
+			qtextflag = false;
+			stream_stop();
+		}
+		questlog = false;
+		AutomapActive = false;
+		msgdelay = 0;
+		gamemenu_off();
+		DisplayHelp();
+		doom_close();
+	}
+}
+
+#ifdef _DEBUG
+void itemInfoKeyPressed()
+{
+	if (pcursitem != -1) {
+		sprintf(
+		    tempstr,
+		    "IDX = %i  :  Seed = %i  :  CF = %i",
+		    items[pcursitem].IDidx,
+		    items[pcursitem]._iSeed,
+		    items[pcursitem]._iCreateInfo);
+		NetSendCmdString(1 << myplr, tempstr);
+	}
+	sprintf(tempstr, "Numitems : %i", numitems);
+	NetSendCmdString(1 << myplr, tempstr);
+}
+#endif
+
+void inventoryKeyPressed()
+{
+	if (stextflag == STORE_NONE) {
+		invflag = !invflag;
+		if (!chrflag && !questlog && CanPanelsCoverView()) {
+			if (!invflag) { // We closed the invetory
+				if (MouseX < 480 && MouseY < PANEL_TOP) {
+					SetCursorPos(MouseX + 160, MouseY);
+				}
+			} else if (!sbookflag) { // We opened the invetory
+				if (MouseX > 160 && MouseY < PANEL_TOP) {
+					SetCursorPos(MouseX - 160, MouseY);
+				}
+			}
+		}
+		sbookflag = false;
+	}
+}
+
+void characterSheetKeyPressed()
+{
+	if (stextflag == STORE_NONE) {
+		chrflag = !chrflag;
+		if (!invflag && !sbookflag && CanPanelsCoverView()) {
+			if (!chrflag) { // We closed the character sheet
+				if (MouseX > 160 && MouseY < PANEL_TOP) {
+					SetCursorPos(MouseX - 160, MouseY);
+				}
+			} else if (!questlog) { // We opened the character sheet
+				if (MouseX < 480 && MouseY < PANEL_TOP) {
+					SetCursorPos(MouseX + 160, MouseY);
+				}
+			}
+		}
+		questlog = false;
+	}
+}
+
+void questLogKeyPressed()
+{
+	if (stextflag == STORE_NONE) {
+		if (!questlog) {
+			StartQuestlog();
+		} else {
+			questlog = false;
+		}
+		if (!invflag && !sbookflag && CanPanelsCoverView()) {
+			if (!questlog) { // We closed the quest log
+				if (MouseX > 160 && MouseY < PANEL_TOP) {
+					SetCursorPos(MouseX - 160, MouseY);
+				}
+			} else if (!chrflag) { // We opened the character quest log
+				if (MouseX < 480 && MouseY < PANEL_TOP) {
+					SetCursorPos(MouseX + 160, MouseY);
+				}
+			}
+		}
+		chrflag = false;
+	}
+}
+
+void displaySpellsKeyPressed()
+{
+	if (stextflag == STORE_NONE) {
+		chrflag = false;
+		questlog = false;
+		invflag = false;
+		sbookflag = false;
+		if (!spselflag) {
+			DoSpeedBook();
+		} else {
+			spselflag = false;
+		}
+		track_repeat_walk(false);
+	}
+}
+
+void spellBookKeyPressed()
+{
+	if (stextflag == STORE_NONE) {
+		sbookflag = !sbookflag;
+		if (!chrflag && !questlog && CanPanelsCoverView()) {
+			if (!sbookflag) { // We closed the invetory
+				if (MouseX < 480 && MouseY < PANEL_TOP) {
+					SetCursorPos(MouseX + 160, MouseY);
+				}
+			} else if (!invflag) { // We opened the invetory
+				if (MouseX > 160 && MouseY < PANEL_TOP) {
+					SetCursorPos(MouseX - 160, MouseY);
+				}
+			}
+		}
+		invflag = false;
+	}
+}
+
+void initKeymapActions()
+{
+	keymapper.addAction({
+	    "Help",
+	    DVL_VK_F1,
+	    helpKeyPressed,
+	});
+#ifdef _DEBUG
+	keymapper.addAction({
+	    "ItemInfo",
+	    DVL_VK_INVALID,
+	    itemInfoKeyPressed,
+	});
+	keymapper.addAction({
+	    "QuestDebug",
+	    DVL_VK_INVALID,
+	    PrintDebugQuest,
+	});
+#endif
+	for (int i = 0; i < 4; ++i) {
+		quickSpellActionIndexes[i] = keymapper.addAction({
+		    std::string("QuickSpell") + std::to_string(i + 1),
+		    DVL_VK_F5 + i,
+		    [i]() {
+			    if (spselflag) {
+				    SetSpeedSpell(i);
+				    return;
+			    }
+			    ToggleSpell(i);
+		    },
+		});
+	}
+	for (int i = 0; i < 4; ++i) {
+		keymapper.addAction({
+		    spszMsgNameTbl[i],
+		    DVL_VK_F9 + i,
+		    [i]() { diablo_hotkey_msg(i); },
+		    Keymapper::Action::IfDead::Allow,
+		});
+	}
+	keymapper.addAction({
+	    "DecreaseGamma",
+	    'G',
+	    DecreaseGamma,
+	});
+	keymapper.addAction({
+	    "IncreaseGamma",
+	    'F',
+	    IncreaseGamma,
+	});
+	keymapper.addAction({
+	    "Inventory",
+	    'I',
+	    inventoryKeyPressed,
+	});
+	keymapper.addAction({
+	    "Character",
+	    'C',
+	    characterSheetKeyPressed,
+	});
+	keymapper.addAction({
+	    "QuestLog",
+	    'Q',
+	    questLogKeyPressed,
+	});
+	keymapper.addAction({
+	    "Zoom",
+	    'Z',
+	    [] {
+		    zoomflag = !zoomflag;
+		    CalcViewportGeometry();
+	    },
+	});
+	keymapper.addAction({
+	    "DisplaySpells",
+	    'S',
+	    displaySpellsKeyPressed,
+	});
+	keymapper.addAction({
+	    "SpellBook",
+	    'B',
+	    spellBookKeyPressed,
+	});
+	keymapper.addAction({
+	    "GameInfo",
+	    'V',
+	    [] {
+		    char pszStr[120];
+		    const char *difficulties[3] = {
+			    _("Normal"),
+			    _("Nightmare"),
+			    _("Hell"),
+		    };
+		    sprintf(pszStr, _("%s, version = %s, mode = %s"), gszProductName, gszVersionNumber, difficulties[sgGameInitInfo.nDifficulty]);
+		    NetSendCmdString(1 << myplr, pszStr);
+	    },
+	});
+	for (int i = 0; i < 8; ++i) {
+		keymapper.addAction({
+		    std::string("BeltItem") + std::to_string(i + 1),
+
+		    '1' + i,
+		    [i] {
+#ifdef _DEBUG
+			    if (i == 7 && (debug_mode_key_inverted_v || debug_mode_key_w)) {
+				    NetSendCmd(true, CMD_CHEAT_EXPERIENCE);
+				    return;
+			    }
+#endif
+			    if (!plr[myplr].SpdList[i].isEmpty() && plr[myplr].SpdList[i]._itype != ITYPE_GOLD) {
+				    UseInvItem(myplr, INVITEM_BELT_FIRST + i);
+			    }
+		    },
+		});
+	}
+	keymapper.addAction({
+	    "QuickSave",
+	    DVL_VK_F2,
+	    [] { gamemenu_save_game(false); },
+	});
+	keymapper.addAction({
+	    "QuickLoad",
+	    DVL_VK_F3,
+	    [] { gamemenu_load_game(false); },
+	    Keymapper::Action::IfDead::Allow,
+	});
+	keymapper.addAction({
+	    "QuitGame",
+	    DVL_VK_INVALID,
+	    [] { gamemenu_quit_game(false); },
+	    Keymapper::Action::IfDead::Allow,
+	});
 }
 
 } // namespace devilution

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -24,9 +24,6 @@ namespace {
 // Forward-declare menu handlers, used by the global menu structs below.
 void gamemenu_previous(bool bActivate);
 void gamemenu_new_game(bool bActivate);
-void gamemenu_quit_game(bool bActivate);
-void gamemenu_load_game(bool bActivate);
-void gamemenu_save_game(bool bActivate);
 void gamemenu_restart_town(bool bActivate);
 void gamemenu_options(bool bActivate);
 void gamemenu_music_volume(bool bActivate);
@@ -117,62 +114,6 @@ void gamemenu_new_game(bool bActivate)
 	CornerStone.activated = false;
 	gbRunGame = false;
 	gamemenu_off();
-}
-
-void gamemenu_quit_game(bool bActivate)
-{
-	gamemenu_new_game(bActivate);
-	gbRunGameResult = false;
-}
-
-void gamemenu_load_game(bool bActivate)
-{
-	WNDPROC saveProc = SetWindowProc(DisableInputWndProc);
-	gamemenu_off();
-	NewCursor(CURSOR_NONE);
-	InitDiabloMsg(EMSG_LOADING);
-	force_redraw = 255;
-	DrawAndBlit();
-	LoadGame(false);
-	ClrDiabloMsg();
-	CornerStone.activated = false;
-	PaletteFadeOut(8);
-	deathflag = false;
-	force_redraw = 255;
-	DrawAndBlit();
-	LoadPWaterPalette();
-	PaletteFadeIn(8);
-	NewCursor(CURSOR_HAND);
-	interface_msg_pump();
-	SetWindowProc(saveProc);
-}
-
-void gamemenu_save_game(bool bActivate)
-{
-	if (pcurs != CURSOR_HAND) {
-		return;
-	}
-
-	if (plr[myplr]._pmode == PM_DEATH || deathflag) {
-		gamemenu_off();
-		return;
-	}
-
-	WNDPROC saveProc = SetWindowProc(DisableInputWndProc);
-	NewCursor(CURSOR_NONE);
-	gamemenu_off();
-	InitDiabloMsg(EMSG_SAVING);
-	force_redraw = 255;
-	DrawAndBlit();
-	SaveGame();
-	ClrDiabloMsg();
-	force_redraw = 255;
-	NewCursor(CURSOR_HAND);
-	if (CornerStone.activated) {
-		items_427A72();
-	}
-	interface_msg_pump();
-	SetWindowProc(saveProc);
 }
 
 void gamemenu_restart_town(bool bActivate)
@@ -365,6 +306,62 @@ void gamemenu_speed(bool bActivate)
 }
 
 } // namespace
+
+void gamemenu_quit_game(bool bActivate)
+{
+	gamemenu_new_game(bActivate);
+	gbRunGameResult = false;
+}
+
+void gamemenu_load_game(bool bActivate)
+{
+	WNDPROC saveProc = SetWindowProc(DisableInputWndProc);
+	gamemenu_off();
+	NewCursor(CURSOR_NONE);
+	InitDiabloMsg(EMSG_LOADING);
+	force_redraw = 255;
+	DrawAndBlit();
+	LoadGame(false);
+	ClrDiabloMsg();
+	CornerStone.activated = false;
+	PaletteFadeOut(8);
+	deathflag = false;
+	force_redraw = 255;
+	DrawAndBlit();
+	LoadPWaterPalette();
+	PaletteFadeIn(8);
+	NewCursor(CURSOR_HAND);
+	interface_msg_pump();
+	SetWindowProc(saveProc);
+}
+
+void gamemenu_save_game(bool bActivate)
+{
+	if (pcurs != CURSOR_HAND) {
+		return;
+	}
+
+	if (plr[myplr]._pmode == PM_DEATH || deathflag) {
+		gamemenu_off();
+		return;
+	}
+
+	WNDPROC saveProc = SetWindowProc(DisableInputWndProc);
+	NewCursor(CURSOR_NONE);
+	gamemenu_off();
+	InitDiabloMsg(EMSG_SAVING);
+	force_redraw = 255;
+	DrawAndBlit();
+	SaveGame();
+	ClrDiabloMsg();
+	force_redraw = 255;
+	NewCursor(CURSOR_HAND);
+	if (CornerStone.activated) {
+		items_427A72();
+	}
+	interface_msg_pump();
+	SetWindowProc(saveProc);
+}
 
 void gamemenu_on()
 {

--- a/Source/gamemenu.h
+++ b/Source/gamemenu.h
@@ -10,5 +10,8 @@ namespace devilution {
 void gamemenu_on();
 void gamemenu_off();
 void gamemenu_handle_previous();
+void gamemenu_quit_game(bool bActivate);
+void gamemenu_load_game(bool bActivate);
+void gamemenu_save_game(bool bActivate);
 
 } // namespace devilution

--- a/Source/miniwin/miniwin.h
+++ b/Source/miniwin/miniwin.h
@@ -101,6 +101,7 @@ bool PostMessage(uint32_t Msg, int32_t wParam, int32_t lParam);
 // Virtual key codes.
 //
 // ref: https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+#define DVL_VK_INVALID 0     // Invalid key
 #define DVL_VK_BACK 0x08     // BACKSPACE key
 #define DVL_VK_TAB 0x09      // TAB key
 #define DVL_VK_RETURN 0x0D   // ENTER key


### PR DESCRIPTION
This adds a keymapper that allows players to change the default key used to trigger various actions. The config file now has a new section called `Controller.Keymapping` that will be automatically filled with all defined actions and their default value.

Limitations:
 * no support for having multiple keys bound to the same action (not sure if that's needed, but the original code does accept two different keys for the belt actions for instance, like '&' or '1'. '&' is on the same key as '1' on the French keyboard layout at least, and pressing this key without shift does produce '&' in most applications and not '1'. The SDL seem to have solved this though, as pressing this key on my keyboard produces '1' in the DevilutionX code. All of that to say that those alternative keys might not be useful after all.)
 * not everything has been converted to actions, notably pausing the game (because it has a few other conditions and possibly side-effects), escape, enter and moving up and down text and menus (but I don't imagine we want to accept rebinding those key anyway).

Happy to receive any comment, this can certainly be improved and I've probably missed some cases here and there. :)

Fixes #1050