### PR TITLE
Fixed order of evaluation in SBmpLoadImage size allocation.

### DIFF
--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -197,7 +197,9 @@ BOOL SBmpLoadImage(const char *pszFileName, SDL_Color *pPalette, BYTE *pBuffer, 
 		fileBuffer = NULL;
 	} else {
 		const auto pos = SFileGetFilePointer(hFile);
-		size = SFileSetFilePointer(hFile, 0, DVL_FILE_END) - SFileSetFilePointer(hFile, pos, DVL_FILE_BEGIN);
+		const auto end = SFileSetFilePointer(hFile, 0, DVL_FILE_END);
+		const auto begin = SFileSetFilePointer(hFile, pos, DVL_FILE_BEGIN);
+		size = end - begin;
 		fileBuffer = (BYTE *)malloc(size);
 	}
 


### PR DESCRIPTION
I encountered crashes at startup in a VS2019 release build that didn't occur in the debug build. The compiler optimizations used a different ordering for evaluation of the operands in the subtraction, causing it to seek to `DVL_FILE_END` before attempting to load the image data.