### PR TITLE
DiabloUI: Render to DiabloUiSurface()

### DIFF
--- a/SourceX/DiabloUI/art_draw.cpp
+++ b/SourceX/DiabloUI/art_draw.cpp
@@ -1,10 +1,9 @@
 #include "DiabloUI/art_draw.h"
+
+#include "DiabloUI/diabloui.h"
 #include "display.h"
 
 namespace dvl {
-
-extern SDL_Surface *pal_surface;
-extern unsigned int pal_surface_palette_version;
 
 void DrawArt(Sint16 screenX, Sint16 screenY, Art *art, int nFrame, Uint16 srcW, Uint16 srcH)
 {
@@ -32,7 +31,7 @@ void DrawArt(Sint16 screenX, Sint16 screenY, Art *art, int nFrame, Uint16 srcW, 
 		art->palette_version = pal_surface_palette_version;
 	}
 
-	if (SDL_BlitSurface(art->surface, &src_rect, GetOutputSurface(), &dst_rect) < 0)
+	if (SDL_BlitSurface(art->surface, &src_rect, DiabloUiSurface(), &dst_rect) < 0)
 		ErrSdl();
 }
 

--- a/SourceX/DiabloUI/credits.cpp
+++ b/SourceX/DiabloUI/credits.cpp
@@ -148,7 +148,7 @@ void CreditsRenderer::Render()
 		return;
 	prev_offset_y_ = offset_y;
 
-	SDL_FillRect(GetOutputSurface(), NULL, 0x000000);
+	SDL_FillRect(DiabloUiSurface(), NULL, 0x000000);
 	DrawArt(PANEL_LEFT - 320, UI_OFFSET_Y, &ArtBackgroundWidescreen);
 	DrawArt(PANEL_LEFT, UI_OFFSET_Y, &ArtBackground);
 	if (font == NULL)
@@ -170,7 +170,7 @@ void CreditsRenderer::Render()
 	viewport.x += PANEL_LEFT;
 	viewport.y += UI_OFFSET_Y;
 	ScaleOutputRect(&viewport);
-	SDL_SetClipRect(GetOutputSurface(), &viewport);
+	SDL_SetClipRect(DiabloUiSurface(), &viewport);
 
 	// We use unscaled coordinates for calculation throughout.
 	Sint16 dest_y = UI_OFFSET_Y + VIEWPORT.y - (offset_y - lines_begin * LINE_H);
@@ -194,10 +194,10 @@ void CreditsRenderer::Render()
 		ScaleOutputRect(&dst_rect);
 		dst_rect.w = line.m_surface->w;
 		dst_rect.h = line.m_surface->h;
-		if (SDL_BlitSurface(line.m_surface, NULL, GetOutputSurface(), &dst_rect) < 0)
+		if (SDL_BlitSurface(line.m_surface, NULL, DiabloUiSurface(), &dst_rect) < 0)
 			ErrSdl();
 	}
-	SDL_SetClipRect(GetOutputSurface(), NULL);
+	SDL_SetClipRect(DiabloUiSurface(), NULL);
 }
 
 BOOL TextDialog()

--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -610,7 +610,7 @@ void LoadBackgroundArt(const char *pszFile, int frames)
 	fadeTc = 0;
 	fadeValue = 0;
 	BlackPalette();
-	SDL_FillRect(GetOutputSurface(), NULL, 0x000000);
+	SDL_FillRect(DiabloUiSurface(), NULL, 0x000000);
 	RenderPresent();
 }
 
@@ -643,7 +643,6 @@ void UiFadeIn()
 		}
 		SetFadeLevel(fadeValue);
 	}
-
 	RenderPresent();
 }
 
@@ -666,7 +665,7 @@ void DrawSelector(const SDL_Rect &rect)
 void UiClearScreen()
 {
 	if (gnScreenWidth > 640) // Background size
-		SDL_FillRect(GetOutputSurface(), NULL, 0x000000);
+		SDL_FillRect(DiabloUiSurface(), NULL, 0x000000);
 }
 
 void UiPollAndRender()

--- a/SourceX/DiabloUI/diabloui.h
+++ b/SourceX/DiabloUI/diabloui.h
@@ -5,6 +5,7 @@
 
 #include "DiabloUI/art.h"
 #include "DiabloUI/ui_item.h"
+#include "display.h"
 
 namespace dvl {
 
@@ -33,6 +34,11 @@ extern bool gbSpawned;
 
 extern void (*gfnSoundFunction)(const char *file);
 extern BOOL (*gfnHeroInfo)(BOOL (*fninfofunc)(_uiheroinfo *));
+
+inline SDL_Surface *DiabloUiSurface()
+{
+	return GetOutputSurface();
+}
 
 void UiFadeIn();
 void UiHandleEvents(SDL_Event *event);

--- a/SourceX/DiabloUI/dialogs.cpp
+++ b/SourceX/DiabloUI/dialogs.cpp
@@ -242,7 +242,7 @@ void DialogLoop(std::vector<UiItemBase *> items, std::vector<UiItemBase *> rende
 		}
 
 		if (renderBehind.size() == 0) {
-			SDL_FillRect(GetOutputSurface(), NULL, 0);
+			SDL_FillRect(DiabloUiSurface(), NULL, 0);
 		} else {
 			UiRenderItems(renderBehind);
 		}

--- a/SourceX/DiabloUI/progress.cpp
+++ b/SourceX/DiabloUI/progress.cpp
@@ -61,7 +61,7 @@ void progress_Free()
 
 void progress_Render(BYTE progress)
 {
-	SDL_FillRect(GetOutputSurface(), NULL, 0x000000);
+	SDL_FillRect(DiabloUiSurface(), NULL, 0x000000);
 	DrawArt(0, 0, &ArtBackground);
 
 	Sint16 x = GetCenterOffset(280);

--- a/SourceX/DiabloUI/text_draw.cpp
+++ b/SourceX/DiabloUI/text_draw.cpp
@@ -1,6 +1,7 @@
 #include "DiabloUI/text_draw.h"
 
 #include "DiabloUI/art_draw.h"
+#include "DiabloUI/diabloui.h"
 #include "DiabloUI/fonts.h"
 #include "DiabloUI/text.h"
 #include "DiabloUI/ui_item.h"
@@ -61,9 +62,9 @@ void DrawTTF(const char *text, const SDL_Rect &rectIn, int flags,
 	SDL_Rect shadow_rect = dest_rect;
 	++shadow_rect.x;
 	++shadow_rect.y;
-	if (SDL_BlitSurface(shadow_surface, NULL, GetOutputSurface(), &shadow_rect) < 0)
+	if (SDL_BlitSurface(shadow_surface, NULL, DiabloUiSurface(), &shadow_rect) < 0)
 		ErrSdl();
-	if (SDL_BlitSurface(text_surface, NULL, GetOutputSurface(), &dest_rect) < 0)
+	if (SDL_BlitSurface(text_surface, NULL, DiabloUiSurface(), &dest_rect) < 0)
 		ErrSdl();
 }
 


### PR DESCRIPTION
Use that instead of using `GetOutputSurface()` directly.

For the rg99 port, we'll want to render this to the `pal_surface`
instead of output surface directly.

Might also be useful for 3ds, perhaps to render to the bottom screen.