### PR TITLE
CMake: Add GPERF option

### DIFF
--- a/CMake/FindGperftools.cmake
+++ b/CMake/FindGperftools.cmake
@@ -1,0 +1,53 @@
+# Based on https://github.com/baidu/braft/blob/e7776cd03ccc04f18d0f0911200617a89ac3cdf0/cmake/FindGperftools.cmake
+
+# Tries to find Gperftools.
+#
+# Usage of this module as follows:
+#
+#     find_package(Gperftools)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  Gperftools_ROOT_DIR  Set this variable to the root installation of
+#                       Gperftools if the module has problems finding
+#                       the proper installation path.
+#
+# Variables defined by this module:
+#
+#  GPERFTOOLS_FOUND              System has Gperftools libs/headers
+#  GPERFTOOLS_LIBRARIES          The Gperftools libraries (tcmalloc & profiler)
+#  GPERFTOOLS_INCLUDE_DIR        The location of Gperftools headers
+
+find_library(GPERFTOOLS_TCMALLOC
+  NAMES tcmalloc
+  HINTS ${Gperftools_ROOT_DIR}/lib)
+
+find_library(GPERFTOOLS_PROFILER
+  NAMES profiler
+  HINTS ${Gperftools_ROOT_DIR}/lib)
+
+find_library(GPERFTOOLS_TCMALLOC_AND_PROFILER
+  NAMES tcmalloc_and_profiler
+  HINTS ${Gperftools_ROOT_DIR}/lib)
+
+find_path(GPERFTOOLS_INCLUDE_DIR
+  NAMES gperftools/heap-profiler.h
+  HINTS ${Gperftools_ROOT_DIR}/include)
+
+set(GPERFTOOLS_LIBRARIES ${GPERFTOOLS_TCMALLOC_AND_PROFILER})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  Gperftools
+  DEFAULT_MSG
+  GPERFTOOLS_LIBRARIES
+  GPERFTOOLS_INCLUDE_DIR)
+
+mark_as_advanced(
+  Gperftools_ROOT_DIR
+  GPERFTOOLS_TCMALLOC
+  GPERFTOOLS_PROFILER
+  GPERFTOOLS_TCMALLOC_AND_PROFILER
+  GPERFTOOLS_LIBRARIES
+  GPERFTOOLS_INCLUDE_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ include(CMake/genex.cmake)
 DEBUG_OPTION(ASAN "Enable address sanitizer")
 DEBUG_OPTION(UBSAN "Enable undefined behaviour sanitizer")
 DEBUG_OPTION(DEBUG "Enable debug mode in engine")
+option(GPERF "Build with GPerfTools profiler" OFF)
 option(DISABLE_LTO "Disable link-time optimization (by default enabled in release mode)" OFF)
 option(PIE "Generate position-independent code" OFF)
 option(DIST "Dynamically link only glibc and SDL2" OFF)
@@ -422,6 +423,10 @@ if(RUN_TESTS)
   gtest_add_tests(${BIN_TARGET} "" AUTO)
 endif()
 
+if(GPERF)
+  find_package(Gperftools REQUIRED)
+endif()
+
 target_include_directories(devilution PUBLIC Source SourceS ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(${BIN_TARGET} PRIVATE
   SourceS
@@ -462,6 +467,7 @@ foreach(
   PREFILL_PLAYER_NAME
   DISABLE_STREAMING_MUSIC
   DISABLE_STREAMING_SOUNDS
+  GPERF
 )
 if(${def_name})
   list(APPEND def_list ${def_name})
@@ -600,6 +606,10 @@ foreach(target devilution ${BIN_TARGET} SourceS)
   endif()
 
   target_compile_definitions(${target} PRIVATE ${def_list})
+
+  if (GPERF)
+    target_link_libraries(${target} PRIVATE ${GPERFTOOLS_LIBRARIES})
+  endif()
 endforeach(target)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND NOT HAIKU AND NOT VITA)


### PR DESCRIPTION
This option links the tcmalloc and gperf memory profiler.

It can then be used to memory-profile individual sections of the app.

On Ubuntu, the package that provides the profiler is `libgoogle-perftools-dev`.

Here is how the profiler can be used:


```diff
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -11,6 +11,8 @@
 #include "../DiabloUI/diabloui.h"
 #include <config.h>
 
+#include <gperftools/heap-profiler.h>
+
 DEVILUTION_BEGIN_NAMESPACE
 
 SDL_Window *ghMainWnd;
@@ -300,6 +302,8 @@ static void run_game_loop(interface_mode uMsg)
 	WNDPROC saveProc;
 	MSG msg;
 
+	HeapProfilerStart("run_game_loop");
+
 	nthread_ignore_mutex(TRUE);
 	start_game(uMsg);
 	assert(ghMainWnd);
@@ -342,6 +346,9 @@ static void run_game_loop(interface_mode uMsg)
 		DrawAndBlit();
 	}
 
+	HeapProfilerDump("gbRunGame_false");
+	HeapProfilerStop();
+
 	if (gbIsMultiplayer) {
 		pfile_write_hero();
 	}
```

Then the result can be analyzed with:

```bash
$ google-pprof --web build/devilutionx run_game_loop.0001.heap
```

Example output:

![image](https://user-images.githubusercontent.com/216339/113647579-0002d580-9683-11eb-9c52-a77991a1bcf2.png)
