### PR TITLE
Save 1.3 MiB RAM in-game by freeing menu resources

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -377,6 +377,10 @@ BOOL StartGame(BOOL bNewGame, BOOL bSinglePlayer)
 			break;
 		}
 
+		// Save 1.3 MiB of RAM by freeing all main menu resources
+		// before starting the game.
+		UiDestroy();
+
 		gbSelectProvider = FALSE;
 
 		if (bNewGame || !gbValidSaveFile) {
@@ -392,6 +396,11 @@ BOOL StartGame(BOOL bNewGame, BOOL bSinglePlayer)
 		run_game_loop(uMsg);
 		NetClose();
 		pfile_create_player_description(NULL, 0);
+
+		// If the player left the game into the main menu,
+		// initialize main menu resources.
+		if (gbRunGameResult)
+			UiInitialize();
 	} while (gbRunGameResult);
 
 	SNetDestroy();


### PR DESCRIPTION
Running with a memory profiler revealed that we were keeping main menu UI resources around while the game was running:

![image](https://user-images.githubusercontent.com/216339/113650619-69391780-9688-11eb-8259-43b2ece5924a.png)


