### PR TITLE
Cleanup DiabloAllocPtr

### DIFF
--- a/3rdParty/Storm/Source/storm.h
+++ b/3rdParty/Storm/Source/storm.h
@@ -241,48 +241,6 @@ BOOL
         DWORD *pdwHeight,
         DWORD *pdwBpp);
 
-/*  SMemAlloc @ 401
- *
- *  Allocates a block of memory. This block is different
- *  from the standard malloc by including a header containing
- *  information about the block.
- *
- *  amount:       The amount of memory to allocate, in bytes.
- *  logfilename:  The name of the file or object that this call belongs to.
- *  logline:      The line in the file or one of the SLOG_ macros.
- *  defaultValue: The default value of a byte in the allocated memory.
- *
- *  Returns a pointer to the allocated memory. This pointer does NOT include
- *  the additional storm header.
- */
-void *
-    STORMAPI
-    SMemAlloc(
-        unsigned int amount,
-        const char *logfilename,
-        int logline,
-        int defaultValue);
-
-/*  SMemFree @ 403
- *
- *  Frees a block of memory that was created using SMemAlloc,
- *  includes the log file and line for debugging purposes.
- *
- *  location:     The memory location to be freed.
- *  logfilename:  The name of the file or object that this call belongs to.
- *  logline:      The line in the file or one of the SLOG_ macros.
- *  defaultValue:
- *
- *  Returns TRUE if the call was successful and FALSE otherwise.
- */
-BOOL
-    STORMAPI
-    SMemFree(
-        void *location,
-        const char *logfilename,
-        int logline,
-        char defaultValue);
-
 bool getIniBool(const char *sectionName, const char *keyName, bool defaultValue = false);
 bool getIniValue(const char *sectionName, const char *keyName, char *string, int stringSize, const char *defaultString = "");
 void setIniValue(const char *sectionName, const char *keyName, const char *value, int len = 0);

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -20,7 +20,6 @@ DEVILUTION_BEGIN_NAMESPACE
 Sint32 orgseed;
 /** Current game seed */
 Sint32 sglGameSeed;
-static CCritSect sgMemCrit;
 
 /**
  * Specifies the increment used in the Borland C/C++ pseudo-random.
@@ -657,40 +656,6 @@ Sint32 random_(BYTE idx, Sint32 v)
 	if (v < 0xFFFF)
 		return (AdvanceRndSeed() >> 16) % v;
 	return AdvanceRndSeed() % v;
-}
-
-/**
- * @brief Multithreaded safe malloc
- * @param dwBytes Byte size to allocate
- */
-BYTE *DiabloAllocPtr(DWORD dwBytes)
-{
-	BYTE *buf;
-
-	sgMemCrit.Enter();
-	buf = (BYTE *)SMemAlloc(dwBytes, __FILE__, __LINE__, 0);
-	sgMemCrit.Leave();
-
-	if (buf == NULL) {
-		const char *text = "System memory exhausted.\n"
-		                   "Make sure you have at least 64MB of free system memory before running the game";
-		ErrDlg("Out of Memory Error", text, __FILE__, __LINE__);
-	}
-
-	return buf;
-}
-
-/**
- * @brief Multithreaded safe memfree
- * @param p Memory pointer to free
- */
-void mem_free_dbg(void *p)
-{
-	if (p) {
-		sgMemCrit.Enter();
-		SMemFree(p, __FILE__, __LINE__, 0);
-		sgMemCrit.Leave();
-	}
 }
 
 /**

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdlib>
 
 #include <SDL.h>
 
@@ -25,6 +26,24 @@
 #include "../types.h"
 
 DEVILUTION_BEGIN_NAMESPACE
+
+// `malloc` that returns a user-friendly error on OOM.
+//
+// Defined as a macro so that:
+// 1. We provide the correct location for the OOM error.
+// 2. Get better attribution from memory profilers.
+#define DiabloAllocPtr(NUM_BYTES)                                                                                    \
+	[](std::size_t num_bytes) {                                                                                      \
+		BYTE *ptr = static_cast<BYTE *>(std::malloc(num_bytes));                                                     \
+		constexpr char kMesage[] = "System memory exhausted.\n"                                                      \
+		                           "Make sure you have at least 64MB of free system memory before running the game"; \
+		if (ptr == NULL)                                                                                             \
+			ErrDlg("Out of Memory Error", kMesage, __FILE__, __LINE__);                                              \
+		return ptr;                                                                                                  \
+	}(NUM_BYTES)
+
+#define mem_free_dbg(PTR) \
+	std::free(PTR)
 
 inline BYTE *CelGetFrameStart(BYTE *pCelBuff, int nCel)
 {
@@ -416,8 +435,6 @@ void SetRndSeed(Sint32 s);
 Sint32 AdvanceRndSeed();
 Sint32 GetRndSeed();
 Sint32 random_(BYTE idx, Sint32 v);
-BYTE *DiabloAllocPtr(DWORD dwBytes);
-void mem_free_dbg(void *p);
 BYTE *LoadFileInMem(const char *pszName, DWORD *pdwFileLen);
 DWORD LoadFileWithMem(const char *pszName, BYTE *p);
 void Cl2ApplyTrans(BYTE *p, BYTE *ttbl, int nCel);

--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -253,19 +253,6 @@ BOOL SBmpLoadImage(const char *pszFileName, SDL_Color *pPalette, BYTE *pBuffer, 
 	return true;
 }
 
-void *SMemAlloc(unsigned int amount, const char *logfilename, int logline, int defaultValue)
-{
-	assert(amount != -1u);
-	return malloc(amount);
-}
-
-BOOL SMemFree(void *location, const char *logfilename, int logline, char defaultValue)
-{
-	assert(location);
-	free(location);
-	return true;
-}
-
 bool getIniBool(const char *sectionName, const char *keyName, bool defaultValue)
 {
 	char string[2];


### PR DESCRIPTION
1. Removes a lock around allocation. `malloc` is required to be thread-safe in C11.

2. Defines it as a macro so that:

   1. We provide the correct location for the OOM error.
   2. We get better attribution from memory profilers.