### PR TITLE
GPERF: Dump heap profile of the first game iteration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -442,3 +442,6 @@ exefs/main
 ddraw_settings.ini
 Brewfile.lock.json
 .vscode/settings.json
+
+# GPerf heap profile dumps
+*.heap

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ DEBUG_OPTION(UBSAN "Enable undefined behaviour sanitizer")
 option(TSAN "Enable thread sanitizer (not compatible with ASAN=ON)" OFF)
 DEBUG_OPTION(DEBUG "Enable debug mode in engine")
 option(GPERF "Build with GPerfTools profiler" OFF)
+cmake_dependent_option(GPERF_HEAP_FIRST_GAME_ITERATION "Save heap profile of the first game iteration" OFF "GPERF" OFF)
 option(DISABLE_LTO "Disable link-time optimization (by default enabled in release mode)" OFF)
 option(PIE "Generate position-independent code" OFF)
 option(DIST "Dynamically link only glibc and SDL2" OFF)
@@ -106,6 +107,21 @@ if(NOT DISABLE_LTO)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${DevilutionX_SOURCE_DIR}/CMake")
+
+if(GPERF)
+  if(GPERF_HEAP_FIRST_GAME_ITERATION)
+    set(GPERF_HEAP_MAIN ON)
+  endif()
+
+  # Compile with information about file and line numbers for everything
+  # even in non-Debug build types.
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    add_compile_options("$<$<NOT:$<CONFIG:Debug>>:-g2>")
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # Use the more size-efficient `-gmlt` option on clang.
+    add_compile_options("$<$<NOT:$<CONFIG:Debug>>:-gmlt>")
+  endif()
+endif()
 
 if(SWITCH)
   set(ASAN OFF)
@@ -573,6 +589,8 @@ foreach(
   DISABLE_STREAMING_MUSIC
   DISABLE_STREAMING_SOUNDS
   GPERF
+  GPERF_HEAP_MAIN
+  GPERF_HEAP_FIRST_GAME_ITERATION
 )
 if(${def_name})
   list(APPEND def_list ${def_name})
@@ -710,7 +728,7 @@ if (GPERF)
   target_link_libraries(${BIN_TARGET} PRIVATE ${GPERFTOOLS_LIBRARIES})
 endif()
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND NOT HAIKU AND NOT VITA)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND NOT GPERF AND NOT HAIKU AND NOT VITA)
   target_link_libraries(${BIN_TARGET} PUBLIC "$<$<NOT:$<CONFIG:Debug>>:-static-libgcc;-static-libstdc++>")
 endif()
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -59,6 +59,9 @@
 #ifndef NOSOUND
 #include "sound.h"
 #endif
+#ifdef GPERF_HEAP_FIRST_GAME_ITERATION
+#include <gperftools/heap-profiler.h>
+#endif
 
 namespace devilution {
 
@@ -392,6 +395,9 @@ static void run_game_loop(interface_mode uMsg)
 	gbGameLoopStartup = true;
 	nthread_ignore_mutex(false);
 
+#ifdef GPERF_HEAP_FIRST_GAME_ITERATION
+	unsigned run_game_iteration = 0;
+#endif
 	while (gbRunGame) {
 		while (FetchMessage(&msg)) {
 			if (msg.message == DVL_WM_QUIT) {
@@ -415,6 +421,10 @@ static void run_game_loop(interface_mode uMsg)
 		game_loop(gbGameLoopStartup);
 		gbGameLoopStartup = false;
 		DrawAndBlit();
+#ifdef GPERF_HEAP_FIRST_GAME_ITERATION
+	if (run_game_iteration++ == 0)
+		HeapProfilerDump("first_game_iteration");
+#endif
 	}
 
 	if (gbIsMultiplayer) {

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -8,6 +8,9 @@
 #ifdef RUN_TESTS
 #include <gtest/gtest.h>
 #endif
+#ifdef GPERF_HEAP_MAIN
+#include <gperftools/heap-profiler.h>
+#endif
 
 #include "diablo.h"
 
@@ -30,6 +33,12 @@ int main(int argc, char **argv)
 #ifdef __3DS__
 	ctr_sys_init();
 #endif
-
-	return devilution::DiabloMain(argc, argv);
+#ifdef GPERF_HEAP_MAIN
+	HeapProfilerStart("main");
+#endif
+	const int result = devilution::DiabloMain(argc, argv);
+#ifdef GPERF_HEAP_MAIN
+	HeapProfilerStop();
+#endif
+	return result;
 }


### PR DESCRIPTION
If `GPERF` and `GPERF_HEAP_FIRST_GAME_ITERATION` are set,
start tracking allocation in `main` and save the heap state of the first game iteration.

Here is a part of the current heap state of the first game iteration for SDL1 and no audio that this produces:

![profile-sdl1-no-audio](https://user-images.githubusercontent.com/216339/117916230-a6737380-b2de-11eb-8a40-e172b38478b7.png)
