### PR TITLE
Save 1.5 MiB RAM in-game by freeing more DiabloUI art

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -377,7 +377,7 @@ BOOL StartGame(BOOL bNewGame, BOOL bSinglePlayer)
 			break;
 		}
 
-		// Save 1.3 MiB of RAM by freeing all main menu resources
+		// Save 2.8 MiB of RAM by freeing all main menu resources
 		// before starting the game.
 		UiDestroy();
 

--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -1,23 +1,21 @@
-#include "all.h"
-#include "display.h"
-#include "stubs.h"
-#include "utf8.h"
-#include <string>
+#include "DiabloUI/diabloui.h"
+
 #include <algorithm>
+#include <string>
 
 #include "../3rdParty/Storm/Source/storm.h"
 
+#include "controls/controller.h"
 #include "controls/menu_controls.h"
-
-#include "DiabloUI/scrollbar.h"
-#include "DiabloUI/diabloui.h"
-
 #include "DiabloUI/art_draw.h"
-#include "DiabloUI/text_draw.h"
-#include "DiabloUI/fonts.h"
 #include "DiabloUI/button.h"
 #include "DiabloUI/dialogs.h"
-#include "controls/controller.h"
+#include "DiabloUI/fonts.h"
+#include "DiabloUI/scrollbar.h"
+#include "DiabloUI/text_draw.h"
+#include "display.h"
+#include "stubs.h"
+#include "utf8.h"
 
 #ifdef __SWITCH__
 // for virtual keyboard on Switch
@@ -30,8 +28,8 @@ std::size_t SelectedItemMax;
 std::size_t ListViewportSize = 1;
 const std::size_t *ListOffset = NULL;
 
-Art ArtLogos[3];
-Art ArtFocus[3];
+std::array<Art, 3> ArtLogos;
+std::array<Art, 3> ArtFocus;
 Art ArtBackgroundWidescreen;
 Art ArtBackground;
 Art ArtCursor;
@@ -68,13 +66,6 @@ struct scrollBarState {
 } scrollBarState;
 
 } // namespace
-
-void UiDestroy()
-{
-	ArtHero.Unload();
-	UnloadTtfFont();
-	UnloadArtFonts();
-}
 
 void UiInitList(int count, void (*fnFocus)(int value), void (*fnSelect)(int value), void (*fnEsc)(), std::vector<UiItemBase *> items, bool itemsWraps, bool (*fnYesNo)())
 {
@@ -422,6 +413,8 @@ void UiFocusNavigationYesNo()
 		UiPlaySelectSound();
 }
 
+namespace {
+
 bool IsInsideRect(const SDL_Event &event, const SDL_Rect &rect)
 {
 	const SDL_Point point = { event.button.x, event.button.y };
@@ -489,6 +482,18 @@ void LoadUiGFX()
 	LoadHeros();
 }
 
+void UnloadUiGFX()
+{
+	ArtHero.Unload();
+	ArtCursor.Unload();
+	for (auto &art : ArtFocus)
+		art.Unload();
+	for (auto &art : ArtLogos)
+		art.Unload();
+}
+
+} // namespace
+
 void UiInitialize()
 {
 	LoadUiGFX();
@@ -498,6 +503,13 @@ void UiInitialize()
 			ErrSdl();
 		}
 	}
+}
+
+void UiDestroy()
+{
+	UnloadTtfFont();
+	UnloadArtFonts();
+	UnloadUiGFX();
 }
 
 char connect_plrinfostr[128];

--- a/SourceX/DiabloUI/diabloui.h
+++ b/SourceX/DiabloUI/diabloui.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <SDL.h>
 
@@ -24,8 +25,8 @@ typedef enum _artLogo {
 	LOGO_BIG,
 } _artLogo;
 
-extern Art ArtLogos[3];
-extern Art ArtFocus[3];
+extern std::array<Art, 3> ArtLogos;
+extern std::array<Art, 3> ArtFocus;
 extern Art ArtBackground;
 extern Art ArtBackgroundWidescreen;
 extern Art ArtCursor;


### PR DESCRIPTION
Heap state of an SDL1 build with no audio

Before:

![profile-sdl1-no-audio](https://user-images.githubusercontent.com/216339/113714663-8b5e8400-96e0-11eb-80a5-4de70f0f85aa.png)

After:

![profile-sdl1-no-audio-fixed](https://user-images.githubusercontent.com/216339/113714672-8d284780-96e0-11eb-968c-bf18c3ad538d.png)

