### PR TITLE
Removal of redundant updating of gameplay variables

### DIFF
--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -53,12 +53,6 @@ static BOOL mainmenu_init_menu(int type)
 static BOOL mainmenu_single_player()
 {
 	gbIsMultiplayer = false;
-
-	gbRunInTown = sgOptions.Gameplay.bRunInTown;
-	gnTickRate = sgOptions.Gameplay.nTickRate;
-	gbTheoQuest = sgOptions.Gameplay.bTheoQuest;
-	gbCowQuest = sgOptions.Gameplay.bCowQuest;
-
 	return mainmenu_init_menu(SELHERO_NEW_DUNGEON);
 }
 


### PR DESCRIPTION
When you click on singleplayer in the main menu, this function gets called: `mainmenu_single_player()`

That loads several gameplay variables from the config.

However, as you progress through the character selection menus and before going ingame, this function gets called: `NetInit()`

That loads the same gameplay variables from the config, which makes the actions in `mainmenu_single_player()` unnecessary. I should note that the `NetInit()` function gets called in both singleplayer and multiplayer modes (when I first saw its name, I was thinking it was run only in network mode).

In order to remove redundant code (and to make it less confusing as to when important variables are actually initialized), I think it would be a good change to remove these lines from `mainmenu_single_player()`