### PR TITLE
InitPlrGfx: Only alloc enough for the class

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1778,11 +1778,6 @@ void LoadGameLevel(BOOL firstflag, int lvldir)
 		InitInv();
 		InitItemGFX();
 		InitQuestText();
-
-		int players = gbIsMultiplayer ? MAX_PLRS : 1;
-		for (i = 0; i < players; i++)
-			InitPlrGFXMem(i);
-
 		InitStores();
 		InitAutomapOnce();
 		InitHelp();

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2208,6 +2208,7 @@ static DWORD On_PLAYER_JOINLEVEL(TCmd *pCmd, int pnum)
 	else {
 		plr[pnum]._pLvlChanging = FALSE;
 		if (plr[pnum]._pName[0] != 0 && !plr[pnum].plractive) {
+			InitPlrGFXMem(pnum);
 			plr[pnum].plractive = TRUE;
 			gbActivePlayers++;
 			EventPlrMsg("Player '%s' (level %d) just joined the game", plr[pnum]._pName, plr[pnum]._pLevel);

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -267,6 +267,7 @@ static void multi_player_left_msg(int pnum, int left)
 		}
 		plr[pnum].plractive = FALSE;
 		plr[pnum]._pName[0] = '\0';
+		FreePlayerGFX(pnum);
 		gbActivePlayers--;
 	}
 }
@@ -777,8 +778,11 @@ BOOL NetInit(BOOL bSinglePlayer, BOOL *pfExitProgram)
 		nthread_send_and_recv_turn(0, 0);
 		SetupLocalCoords();
 		multi_send_pinfo(-2, CMD_SEND_PLRINFO);
+
+		InitPlrGFXMem(myplr);
 		plr[myplr].plractive = TRUE;
 		gbActivePlayers = 1;
+
 		if (sgbPlayerTurnBitTbl[myplr] == FALSE || msg_wait_resync())
 			break;
 		NetClose();
@@ -884,13 +888,13 @@ void recv_plrinfo(int pnum, TCmdPlrInfoHdr *p, BOOL recv)
 
 	sgwPackPlrOffsetTbl[pnum] = 0;
 	multi_player_left_msg(pnum, 0);
-	plr[pnum]._pGFXLoad = 0;
 	UnPackPlayer(&netplr[pnum], pnum, TRUE);
 
 	if (!recv) {
 		return;
 	}
 
+	InitPlrGFXMem(pnum);
 	plr[pnum].plractive = TRUE;
 	gbActivePlayers++;
 

--- a/Source/player.h
+++ b/Source/player.h
@@ -215,7 +215,6 @@ typedef struct PlayerStruct {
 	Uint32 pDiabloKillLevel;
 	Uint32 pDifficulty;
 	Uint32 pDamAcFlags;
-	bool bGfxMemAllocated;
 	Uint8 *_pNData;
 	Uint8 *_pWData;
 	Uint8 *_pAData;


### PR DESCRIPTION
Previously, the allocation size was the maximum size over all the classes.

RAM usage per player:

* Before: 2.2 MiB (any class)
* After:
  * Warrior: 2.0 MiB
  * Rogue: 1.5 MiB
  * Sorcerer: 1.6 MiB
  * Monk: 1.7 MiB

We now also only allocate memory in multi-player as needed.

This means the game will only use as much RAM for player graphics as there are players currently in the game. Also the RAM used for each player is lower because it now takes class into account.

Follow-up to #1393