### PR TITLE
Distributed skipped frames in hit recovery animations.

### DIFF
--- a/Source/player.h
+++ b/Source/player.h
@@ -351,6 +351,7 @@ void StartPlrBlock(int pnum, direction dir);
 void FixPlrWalkTags(int pnum);
 void RemovePlrFromMap(int pnum);
 void StartPlrHit(int pnum, int dam, bool forcehit);
+void SkipPlrHFrames(int pnum);
 void StartPlayerKill(int pnum, int earflag);
 void DropHalfPlayersGold(int pnum);
 void StripTopGold(int pnum);

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -4,18 +4,21 @@
 using namespace devilution;
 
 namespace devilution {
+extern void SkipPlrHFrames(int pnum);
 extern int PM_DoGotHit(int pnum);
 }
 
 int RunBlockTest(int frames, int flags)
 {
 	int pnum = 0;
-	plr[pnum]._pAnimFrame = 1;
+	plr[pnum]._pAnimFrame = 0;
 	plr[pnum]._pHFrames = frames;
 	plr[pnum]._pVar8 = 1;
 	plr[pnum]._pIFlags = flags;
 	plr[pnum]._pmode = PM_GOTHIT;
 	plr[pnum]._pGFXLoad = -1;
+	SkipPlrHFrames(pnum);
+	plr[pnum]._pAnimFrame++;
 
 	int i = 1;
 	for (; i < 100; i++) {


### PR DESCRIPTION
Smooths hit recovery animations by distributing frame skips more evenly.

As a note for reviewers, I added a check to disable the zen combination for Hellfire. This is more consistent with the original behavior in Hellfire, but not with prior versions of devilutionX.

This logic was tested using the output from log messages, but I did not test Hellfire. Feel free to use the attached save files for testing.
[warrior.zip](https://github.com/diasurgical/devilutionX/files/6275863/warrior.zip)
[rogue.zip](https://github.com/diasurgical/devilutionX/files/6275861/rogue.zip)
[sorcerer.zip](https://github.com/diasurgical/devilutionX/files/6275862/sorcerer.zip)

This resolves #984