### PR TITLE
Fix typos as suggested by a grammar tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <img width="838" src="https://user-images.githubusercontent.com/204594/113578478-26912400-9623-11eb-9ff6-9bd9717462b6.png">
 </p>
 
-<sub>*(The health-bar, and XP-bar are off by default, but can be enabled in the [ini-file](https://github.com/diasurgical/devilutionX/wiki/DevilutionX-diablo.ini-configuration-guide). Widescreen and transparency can also be disabled if preferred)*</sub>
+<sub>*(The health-bar and XP-bar are off by default, but can be enabled in the [ini-file](https://github.com/diasurgical/devilutionX/wiki/DevilutionX-diablo.ini-configuration-guide). Widescreen and transparency can also be disabled if preferred)*</sub>
 
 # What is DevilutionX
 
@@ -43,7 +43,7 @@ We are always looking for more people to help with [coding](docs/CONTRIBUTING.md
 
 # Mods
 
-We hope to provide a good starting point for mods, in addition to the full Devilution source code we also provide modding tools. Also checkout the list of known [mods based on DevilutionX](https://github.com/diasurgical/devilutionX/wiki/Mods-and-related-projects).
+We hope to provide a good starting point for mods, in addition to the full Devilution source code we also provide modding tools. Also, check out the list of known [mods based on DevilutionX](https://github.com/diasurgical/devilutionX/wiki/Mods-and-related-projects).
 
 # Building from Source
 
@@ -54,13 +54,13 @@ Want to compile the program by yourself? Great! Simply follow the [build instruc
 - The original Devilution project [Devilution](https://github.com/diasurgical/devilution#credits)
 - [Everyone](https://github.com/diasurgical/devilutionX/graphs/contributors) who worked on Devilution/DevilutionX
 - [Nikolay Popov](https://www.instagram.com/nikolaypopovz/) who provided new backgrounds and icons
-- And a thanks to all who support the project, report bugs and help spread the word ❤️
+- And thanks to all who support the project, report bugs, and help spread the word ❤️
 
 # Legal
 
-DevilutionX is released to the Public Domain. The documentation and functionality provided by DevilutionX may only be utilized with assets provided by ownership of Diablo.
+DevilutionX is released to the Public Domain. The documentation and functionality provided by DevilutionX may only be utilized with assets provided by the ownership of Diablo.
 
-The source code in this repository is for non-commerical use only. If you use the source code you may not charge others for access to it or any derivative work thereof.
+The source code in this repository is for non-commercial use only. If you use the source code you may not charge others for access to it or any derivative work thereof.
 
 Diablo® - Copyright © 1996 Blizzard Entertainment, Inc. All rights reserved. Diablo and Blizzard Entertainment are trademarks or registered trademarks of Blizzard Entertainment, Inc. in the U.S. and/or other countries.
 


### PR DESCRIPTION
Sanity checked and applied the suggestions by the grammar checking tool Grammarly.

I really wanted to change "U.S." into "USA" or "United States of America" for greater clarity of my own accord, but I presume that the specific wording and spelling used is the original from the Diablo box or website or something.