### PR TITLE
Alternative: Distributed skipped frames in hit recovery animations.

### DIFF
--- a/Source/player.h
+++ b/Source/player.h
@@ -351,6 +351,7 @@ void StartPlrBlock(int pnum, direction dir);
 void FixPlrWalkTags(int pnum);
 void RemovePlrFromMap(int pnum);
 void StartPlrHit(int pnum, int dam, bool forcehit);
+void SkipPlrHFrames(int pnum);
 void StartPlayerKill(int pnum, int earflag);
 void DropHalfPlayersGold(int pnum);
 void StripTopGold(int pnum);

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -4,18 +4,21 @@
 using namespace devilution;
 
 namespace devilution {
+extern void SkipPlrHFrames(int pnum);
 extern int PM_DoGotHit(int pnum);
 }
 
 int RunBlockTest(int frames, int flags)
 {
 	int pnum = 0;
-	plr[pnum]._pAnimFrame = 1;
+	plr[pnum]._pAnimFrame = 0;
 	plr[pnum]._pHFrames = frames;
 	plr[pnum]._pVar8 = 1;
 	plr[pnum]._pIFlags = flags;
 	plr[pnum]._pmode = PM_GOTHIT;
 	plr[pnum]._pGFXLoad = -1;
+	SkipPlrHFrames(pnum);
+	plr[pnum]._pAnimFrame++;
 
 	int i = 1;
 	for (; i < 100; i++) {


### PR DESCRIPTION
Smooths hit recovery animations by distributing frame skips more evenly.

This is just an experiment to develop a more generic algorithm as an alternative to #1412. This has the advantage of providing a good distribution of frames for any number of animation frames and frames skipped, which makes it more immediately applicable to mod extensions like adding an improved hit-recovery suffix or a new character animation with 5 or 9 hit-recovery frames. This has the disadvantage of being entirely based on raw computation, and therefore it's more difficult to manually adjust exactly which frames get skipped.

Here is the distribution of frames for each of the existing classes using this logic, based on my testing.

```
Warrior  Normal  : 1, 2, 3, 4, 5, 6
Warrior  bal     : 1, 2, 3, -, 5, 6
Warrior  sta     : 1, -, 3, 4, -, 6
Warrior  har     : 1, -, 3, -, 5, -
Warrior  bal+sta : 1, -, 3, 4, -, 6
Warrior  bal+har : 1, -, 3, -, 5, -
Warrior  sta+har : 1, -, 3, -, 5, -
Warrior  zen     : -, 2, -, -, 5, -

Rogue    Normal  : 1, 2, 3, 4, 5, 6, 7
Rogue    bal     : 1, 2, 3, -, 5, 6, 7
Rogue    sta     : 1, -, 3, 4, 5, -, 7
Rogue    har     : 1, -, 3, -, 5, -, 7
Rogue    bal+sta : 1, -, 3, 4, 5, -, 7
Rogue    bal+har : 1, -, 3, -, 5, -, 7
Rogue    sta+har : 1, -, 3, -, 5, -, 7
Rogue    zen     : -, 2, -, 4, -, 6, -

Sorceror Normal  : 1, 2, 3, 4, 5, 6, 7, 8
Sorceror bal     : 1, 2, 3, 4, -, 6, 7, 8
Sorceror sta     : 1, 2, -, 4, 5, 6, -, 8
Sorceror har     : 1, -, 3, 4, -, 6, -, 8
Sorceror bal+sta : 1, 2, -, 4, 5, 6, -, 8
Sorceror bal+har : 1, -, 3, 4, -, 6, -, 8
Sorceror sta+har : 1, -, 3, 4, -, 6, -, 8
Sorceror zen     : 1, -, 3, -, 5, -, 7, -
```

This resolves #984