### PR TITLE
add an ini option to configure gamepad deadzone

### DIFF
--- a/3rdParty/Storm/Source/storm.h
+++ b/3rdParty/Storm/Source/storm.h
@@ -262,11 +262,13 @@ BOOL
         DWORD *pdwBpp);
 
 bool getIniBool(const char *sectionName, const char *keyName, bool defaultValue = false);
+float getIniFloat(const char *sectionName, const char *keyName, float defaultValue);
 bool getIniValue(const char *sectionName, const char *keyName, char *string, int stringSize, const char *defaultString = "");
 void setIniValue(const char *sectionName, const char *keyName, const char *value, int len = 0);
 void SaveIni();
 int getIniInt(const char *keyname, const char *valuename, int defaultValue);
 void setIniInt(const char *keyname, const char *valuename, int value);
+void setIniFloat(const char *keyname, const char *valuename, float value);
 
 void SVidPlayBegin(const char *filename, int a2, int a3, int a4, int a5, int flags, HANDLE *video);
 void SVidPlayEnd(HANDLE video);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -468,6 +468,7 @@ static void SaveOptions()
 	setIniValue("Controller", "Mapping", sgOptions.Controller.szMapping);
 	setIniInt("Controller", "Swap Shoulder Button Mode", sgOptions.Controller.bSwapShoulderButtonMode);
 	setIniInt("Controller", "Dpad Hotkeys", sgOptions.Controller.bDpadHotkeys);
+	setIniFloat("Controller", "deadzone", sgOptions.Controller.fDeadzone);
 #ifdef __vita__
 	setIniInt("Controller", "Enable Rear Touchpad", sgOptions.Controller.bRearTouch);
 #endif
@@ -541,6 +542,7 @@ static void LoadOptions()
 	getIniValue("Controller", "Mapping", sgOptions.Controller.szMapping, sizeof(sgOptions.Controller.szMapping), "");
 	sgOptions.Controller.bSwapShoulderButtonMode = getIniBool("Controller", "Swap Shoulder Button Mode", false);
 	sgOptions.Controller.bDpadHotkeys = getIniBool("Controller", "Dpad Hotkeys", false);
+	sgOptions.Controller.fDeadzone = getIniFloat("Controller", "deadzone", 0.07);
 #ifdef __vita__
 	sgOptions.Controller.bRearTouch = getIniBool("Controller", "Enable Rear Touchpad", true);
 #endif

--- a/Source/options.h
+++ b/Source/options.h
@@ -100,6 +100,8 @@ struct ControllerOptions {
 	bool bDpadHotkeys;
 	/** @brief Shoulder gamepad shoulder buttons act as potions by default */
 	bool bSwapShoulderButtonMode;
+    /** @brief Configure gamepad joysticks deadzone */
+	float fDeadzone;
 #ifdef __vita__
 	/** @brief Enable input via rear touchpad */
 	bool bRearTouch;

--- a/SourceX/controls/controller_motion.cpp
+++ b/SourceX/controls/controller_motion.cpp
@@ -105,8 +105,8 @@ namespace {
 
 void ScaleJoysticks()
 {
-	const float rightDeadzone = 0.07;
-	const float leftDeadzone = 0.07;
+	const float rightDeadzone = sgOptions.Controller.fDeadzone;
+	const float leftDeadzone = sgOptions.Controller.fDeadzone;
 
 	if (leftStickNeedsScaling) {
 		leftStickX = leftStickXUnscaled;

--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -263,6 +263,19 @@ bool getIniBool(const char *sectionName, const char *keyName, bool defaultValue)
 	return strtol(string, NULL, 10) != 0;
 }
 
+float getIniFloat(const char *sectionName, const char *keyName, float defaultValue)
+{
+    radon::Section *section = getIni().getSection(sectionName);
+    if (!section)
+        return defaultValue;
+
+    radon::Key *key = section->getKey(keyName);
+    if (!key)
+        return defaultValue;
+
+    return key->getFloatValue();
+}
+
 bool getIniValue(const char *sectionName, const char *keyName, char *string, int stringSize, const char *defaultString)
 {
 	strncpy(string, defaultString, stringSize);
@@ -322,6 +335,13 @@ void setIniInt(const char *keyname, const char *valuename, int value)
 {
 	char str[10];
 	sprintf(str, "%d", value);
+	setIniValue(keyname, valuename, str);
+}
+
+void setIniFloat(const char *keyname, const char *valuename, float value)
+{
+	char str[10];
+	sprintf(str, "%.2f", value);
 	setIniValue(keyname, valuename, str);
 }
 


### PR DESCRIPTION
This adds an ini option under Controller.deadzone, read as a float.

I had some drift on my Xbox gamepads that made the use of the emulate pointer feature on the gamepad very inpractical.
So I figured, why not make this a user configurable value?

My C++ is very rusty so I'm very eager to hear your reviews.

Here are some things I am unsure about:

- Saving the deadzone in the ini file: I opted for 2 point float precision for this. This can be changed easily if you think it is necessary.
- Default deadzone value of 0.07 is untouched but this seems very low and it is likely that other xbox gamepad users are affected. Maybe we should consider making this a bit bigger, e.g: 0.15
- Maybe we should consider splitting joysticks left and right deadzones instead of having a single value?