### PR TITLE
loadsave: Fix off-by-one in RemoveEmptyLevelItems

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -965,7 +965,7 @@ void RemoveEmptyInventory(int pnum)
 
 void RemoveEmptyLevelItems()
 {
-	for (int i = numitems; i >= 0; i--) {
+	for (int i = numitems; i > 0; i--) {
 		int ii = itemactive[i];
 		if (items[ii].isEmpty()) {
 			dItem[items[ii]._ix][items[ii]._iy] = 0;


### PR DESCRIPTION
Refs #1367

I'm not sure how this function works but this fixes the following ASAN error for me on VS2019:

![image](https://user-images.githubusercontent.com/216339/114118629-042c2e80-98e1-11eb-9dac-4415e7cee4bc.png)

Yes, VS finally has ASAN. A decade late but still welcome: https://devblogs.microsoft.com/cppblog/addresssanitizer-asan-for-windows-with-msvc/