### PR TITLE
CMake: Link libzt to ${BIN_TARGET}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -894,5 +894,5 @@ endif()
 
 if(NOT NONET)
   add_subdirectory(3rdParty/libzt)
-  target_link_libraries(devilutionx PRIVATE zt-static)
+  target_link_libraries(${BIN_TARGET} PRIVATE zt-static)
 endif()


### PR DESCRIPTION
BIN_TARGET is devilutionx by default but is devilutionx.elf on Switch and 3DS