### PR TITLE
Fix gold stacking when gold stack limit is modified

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1382,15 +1382,15 @@ void CheckInvPaste(int pnum, int mx, int my)
 				il--;
 				gt = plr[pnum].InvList[il]._ivalue;
 				ig = plr[pnum].HoldItem._ivalue + gt;
-				if (ig <= GOLD_MAX_LIMIT) {
+				if (ig <= MaxGold) {
 					plr[pnum].InvList[il]._ivalue = ig;
 					plr[pnum]._pGold += plr[pnum].HoldItem._ivalue;
 					SetPlrHandGoldCurs(&plr[pnum].InvList[il]);
 				} else {
-					ig = GOLD_MAX_LIMIT - gt;
+					ig = MaxGold - gt;
 					plr[pnum]._pGold += ig;
 					plr[pnum].HoldItem._ivalue -= ig;
-					plr[pnum].InvList[il]._ivalue = GOLD_MAX_LIMIT;
+					plr[pnum].InvList[il]._ivalue = MaxGold;
 					plr[pnum].InvList[il]._iCurs = ICURS_GOLD_LARGE;
 					// BUGFIX: incorrect values here are leftover from beta (fixed)
 					cn = GetGoldCursor(plr[pnum].HoldItem._ivalue);
@@ -1448,15 +1448,15 @@ void CheckInvPaste(int pnum, int mx, int my)
 			if (!plr[pnum].SpdList[ii].isEmpty()) {
 				if (plr[pnum].SpdList[ii]._itype == ITYPE_GOLD) {
 					i = plr[pnum].HoldItem._ivalue + plr[pnum].SpdList[ii]._ivalue;
-					if (i <= GOLD_MAX_LIMIT) {
+					if (i <= MaxGold) {
 						plr[pnum].SpdList[ii]._ivalue = i;
 						plr[pnum]._pGold += plr[pnum].HoldItem._ivalue;
 						SetPlrHandGoldCurs(&plr[pnum].SpdList[ii]);
 					} else {
-						i = GOLD_MAX_LIMIT - plr[pnum].SpdList[ii]._ivalue;
+						i = MaxGold - plr[pnum].SpdList[ii]._ivalue;
 						plr[pnum]._pGold += i;
 						plr[pnum].HoldItem._ivalue -= i;
-						plr[pnum].SpdList[ii]._ivalue = GOLD_MAX_LIMIT;
+						plr[pnum].SpdList[ii]._ivalue = MaxGold;
 						plr[pnum].SpdList[ii]._iCurs = ICURS_GOLD_LARGE;
 
 						// BUGFIX: incorrect values here are leftover from beta (fixed)

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -1384,8 +1384,8 @@ bool StoreGoldFit(int idx)
 	int i, sz, cost, numsqrs;
 
 	cost = storehold[idx]._iIvalue;
-	sz = cost / GOLD_MAX_LIMIT;
-	if (cost % GOLD_MAX_LIMIT != 0)
+	sz = cost / MaxGold;
+	if (cost % MaxGold != 0)
 		sz++;
 
 	SetCursor_(storehold[idx]._iCurs + CURSOR_FIRSTITEM);
@@ -1401,16 +1401,16 @@ bool StoreGoldFit(int idx)
 	}
 
 	for (i = 0; i < plr[myplr]._pNumInv; i++) {
-		if (plr[myplr].InvList[i]._itype == ITYPE_GOLD && plr[myplr].InvList[i]._ivalue != GOLD_MAX_LIMIT) {
-			if (cost + plr[myplr].InvList[i]._ivalue <= GOLD_MAX_LIMIT)
+		if (plr[myplr].InvList[i]._itype == ITYPE_GOLD && plr[myplr].InvList[i]._ivalue != MaxGold) {
+			if (cost + plr[myplr].InvList[i]._ivalue <= MaxGold)
 				cost = 0;
 			else
-				cost -= GOLD_MAX_LIMIT - plr[myplr].InvList[i]._ivalue;
+				cost -= MaxGold - plr[myplr].InvList[i]._ivalue;
 		}
 	}
 
-	sz = cost / GOLD_MAX_LIMIT;
-	if (cost % GOLD_MAX_LIMIT)
+	sz = cost / MaxGold;
+	if (cost % MaxGold)
 		sz++;
 
 	return numsqrs >= sz;
@@ -1466,22 +1466,22 @@ void StoreSellItem()
 	}
 	plr[myplr]._pGold += cost;
 	for (i = 0; i < plr[myplr]._pNumInv && cost > 0; i++) {
-		if (plr[myplr].InvList[i]._itype == ITYPE_GOLD && plr[myplr].InvList[i]._ivalue != GOLD_MAX_LIMIT) {
-			if (cost + plr[myplr].InvList[i]._ivalue <= GOLD_MAX_LIMIT) {
+		if (plr[myplr].InvList[i]._itype == ITYPE_GOLD && plr[myplr].InvList[i]._ivalue != MaxGold) {
+			if (cost + plr[myplr].InvList[i]._ivalue <= MaxGold) {
 				plr[myplr].InvList[i]._ivalue += cost;
 				SetGoldCurs(myplr, i);
 				cost = 0;
 			} else {
-				cost -= GOLD_MAX_LIMIT - plr[myplr].InvList[i]._ivalue;
-				plr[myplr].InvList[i]._ivalue = GOLD_MAX_LIMIT;
+				cost -= MaxGold - plr[myplr].InvList[i]._ivalue;
+				plr[myplr].InvList[i]._ivalue = MaxGold;
 				SetGoldCurs(myplr, i);
 			}
 		}
 	}
 	if (cost > 0) {
-		while (cost > GOLD_MAX_LIMIT) {
-			PlaceStoreGold(GOLD_MAX_LIMIT);
-			cost -= GOLD_MAX_LIMIT;
+		while (cost > MaxGold) {
+			PlaceStoreGold(MaxGold);
+			cost -= MaxGold;
 		}
 		PlaceStoreGold(cost);
 	}
@@ -2628,7 +2628,7 @@ void TakePlrsMoney(int cost)
 
 	plr[myplr]._pGold = CalculateGold(myplr) - cost;
 	for (i = 0; i < MAXBELTITEMS && cost > 0; i++) {
-		if (plr[myplr].SpdList[i]._itype == ITYPE_GOLD && plr[myplr].SpdList[i]._ivalue != GOLD_MAX_LIMIT) {
+		if (plr[myplr].SpdList[i]._itype == ITYPE_GOLD && plr[myplr].SpdList[i]._ivalue != MaxGold) {
 			if (cost < plr[myplr].SpdList[i]._ivalue) {
 				plr[myplr].SpdList[i]._ivalue -= cost;
 				SetSpdbarGoldCurs(myplr, i);
@@ -2658,7 +2658,7 @@ void TakePlrsMoney(int cost)
 	force_redraw = 255;
 	if (cost > 0) {
 		for (i = 0; i < plr[myplr]._pNumInv && cost > 0; i++) {
-			if (plr[myplr].InvList[i]._itype == ITYPE_GOLD && plr[myplr].InvList[i]._ivalue != GOLD_MAX_LIMIT) {
+			if (plr[myplr].InvList[i]._itype == ITYPE_GOLD && plr[myplr].InvList[i]._ivalue != MaxGold) {
 				if (cost < plr[myplr].InvList[i]._ivalue) {
 					plr[myplr].InvList[i]._ivalue -= cost;
 					SetGoldCurs(myplr, i);


### PR DESCRIPTION
Equipping the Auric Amulet increases the amount gold can stack in your inventory from 5k to 10k. This works when picking gold up off the ground, but not when gaining gold through sales or attempting to drag and drop to create a stack. I've fixed this here by simply ensuring that the MaxGold variable is used when checking gold stack size instead of GOLD_MAX_LIMIT.