### PR TITLE
:rotating_light: Fix remaning clang warnings

### DIFF
--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -185,13 +185,13 @@ void CheckRportal()
 	for (i = 0; i < nummissiles; i++) {
 		mx = missileactive[i];
 		if (missile[mx]._mitype == MIS_RPORTAL) {
-			if (cursmx == missile[mx]._mix - 1 && cursmy == missile[mx]._miy
-			    || cursmx == missile[mx]._mix && cursmy == missile[mx]._miy - 1
-			    || cursmx == missile[mx]._mix - 1 && cursmy == missile[mx]._miy - 1
-			    || cursmx == missile[mx]._mix - 2 && cursmy == missile[mx]._miy - 1
-			    || cursmx == missile[mx]._mix - 2 && cursmy == missile[mx]._miy - 2
-			    || cursmx == missile[mx]._mix - 1 && cursmy == missile[mx]._miy - 2
-			    || cursmx == missile[mx]._mix && cursmy == missile[mx]._miy) {
+			if ((cursmx == missile[mx]._mix - 1 && cursmy == missile[mx]._miy)
+			    || (cursmx == missile[mx]._mix && cursmy == missile[mx]._miy - 1)
+			    || (cursmx == missile[mx]._mix - 1 && cursmy == missile[mx]._miy - 1)
+			    || (cursmx == missile[mx]._mix - 2 && cursmy == missile[mx]._miy - 1)
+			    || (cursmx == missile[mx]._mix - 2 && cursmy == missile[mx]._miy - 2)
+			    || (cursmx == missile[mx]._mix - 1 && cursmy == missile[mx]._miy - 2)
+			    || (cursmx == missile[mx]._mix && cursmy == missile[mx]._miy)) {
 				trigflag = true;
 				ClearPanel();
 				strcpy(infostr, "Portal to");
@@ -309,7 +309,7 @@ void CheckCursMove()
 		my = MAXDUNY - 1;
 	}
 
-	flipflag = flipy && flipx || (flipy || flipx) && px < TILE_WIDTH / 2;
+	flipflag = (flipy && flipx) || ((flipy || flipx) && px < TILE_WIDTH / 2);
 
 	pcurstemp = pcursmonst;
 	pcursmonst = -1;

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -867,9 +867,9 @@ static void RightMouseDown()
 			if (spselflag) {
 				SetSpell();
 			} else if (MouseY >= SPANEL_HEIGHT
-			    || (!sbookflag || MouseX <= RIGHT_PANEL)
+			    || ((!sbookflag || MouseX <= RIGHT_PANEL)
 			        && !TryIconCurs()
-			        && (pcursinvitem == -1 || !UseInvItem(myplr, pcursinvitem))) {
+			        && (pcursinvitem == -1 || !UseInvItem(myplr, pcursinvitem)))) {
 				if (pcurs == CURSOR_HAND) {
 					if (pcursinvitem == -1 || !UseInvItem(myplr, pcursinvitem))
 						CheckPlrSpell();

--- a/Source/drlg_l3.cpp
+++ b/Source/drlg_l3.cpp
@@ -1272,7 +1272,7 @@ static void DRLG_L3River()
 					river[0][riveramt] = rx;
 					river[1][riveramt] = ry;
 					riveramt++;
-					if (dir == 0 && pdir == 2 || dir == 3 && pdir == 1) {
+					if ((dir == 0 && pdir == 2) || (dir == 3 && pdir == 1)) {
 						if (riveramt > 2) {
 							river[2][riveramt - 2] = 22;
 						}
@@ -1282,7 +1282,7 @@ static void DRLG_L3River()
 							nodir2 = 2;
 						}
 					}
-					if (dir == 0 && pdir == 3 || dir == 2 && pdir == 1) {
+					if ((dir == 0 && pdir == 3) || (dir == 2 && pdir == 1)) {
 						if (riveramt > 2) {
 							river[2][riveramt - 2] = 21;
 						}
@@ -1292,7 +1292,7 @@ static void DRLG_L3River()
 							nodir2 = 3;
 						}
 					}
-					if (dir == 1 && pdir == 2 || dir == 3 && pdir == 0) {
+					if ((dir == 1 && pdir == 2) || (dir == 3 && pdir == 0)) {
 						if (riveramt > 2) {
 							river[2][riveramt - 2] = 20;
 						}
@@ -1302,7 +1302,7 @@ static void DRLG_L3River()
 							nodir2 = 2;
 						}
 					}
-					if (dir == 1 && pdir == 3 || dir == 2 && pdir == 0) {
+					if ((dir == 1 && pdir == 3) || (dir == 2 && pdir == 0)) {
 						if (riveramt > 2) {
 							river[2][riveramt - 2] = 19;
 						}

--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -1217,7 +1217,7 @@ static void L4firstRoom()
 		l4holdx = x;
 		l4holdy = y;
 	}
-	if (QuestStatus(Q_WARLORD) || currlevel == quests[Q_BETRAYER]._qlevel && gbIsMultiplayer) {
+	if (QuestStatus(Q_WARLORD) || (currlevel == quests[Q_BETRAYER]._qlevel && gbIsMultiplayer)) {
 		SP4x1 = x + 1;
 		SP4y1 = y + 1;
 		SP4x2 = SP4x1 + w;
@@ -1611,7 +1611,7 @@ static void DRLG_L4(lvl_entry entry)
 		if (currlevel == 16) {
 			L4SaveQuads();
 		}
-		if (QuestStatus(Q_WARLORD) || currlevel == quests[Q_BETRAYER]._qlevel && gbIsMultiplayer) {
+		if (QuestStatus(Q_WARLORD) || (currlevel == quests[Q_BETRAYER]._qlevel && gbIsMultiplayer)) {
 			for (spi = SP4x1; spi < SP4x2; spi++) {
 				for (spj = SP4y1; spj < SP4y2; spj++) {
 					dflags[spi][spj] = 1;

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -119,6 +119,8 @@ void mainmenu_loop()
 			app_fatal("Unable to display mainmenu");
 
 		switch (menu) {
+		case MAINMENU_NONE:
+			break;
 		case MAINMENU_SINGLE_PLAYER:
 			if (!mainmenu_single_player())
 				done = true;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -547,9 +547,9 @@ bool MonsterTrapHit(int m, int mindam, int maxdam, int dist, int t, bool shift)
 
 	missile_resistance mir = missiledata[t].mResist;
 	mor = monster[m].mMagicRes;
-	if (mor & IMMUNE_MAGIC && mir == MISR_MAGIC
-	    || mor & IMMUNE_FIRE && mir == MISR_FIRE
-	    || mor & IMMUNE_LIGHTNING && mir == MISR_LIGHTNING) {
+	if ((mor & IMMUNE_MAGIC && mir == MISR_MAGIC)
+	    || (mor & IMMUNE_FIRE && mir == MISR_FIRE)
+	    || (mor & IMMUNE_LIGHTNING && mir == MISR_LIGHTNING)) {
 		return false;
 	}
 
@@ -617,7 +617,7 @@ bool MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, int t, bool 
 	resist = false;
 	if (monster[m].mtalkmsg
 	    || monster[m]._mhitpoints >> 6 <= 0
-	    || t == MIS_HBOLT && monster[m].MType->mtype != MT_DIABLO && monster[m].MData->mMonstClass != MC_UNDEAD) {
+	    || (t == MIS_HBOLT && monster[m].MType->mtype != MT_DIABLO && monster[m].MData->mMonstClass != MC_UNDEAD)) {
 		return false;
 	}
 	if (monster[m].MType->mtype == MT_ILLWEAV && monster[m]._mgoal == MGOAL_RETREAT)
@@ -628,15 +628,15 @@ bool MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, int t, bool 
 	mor = monster[m].mMagicRes;
 	missile_resistance mir = missiledata[t].mResist;
 
-	if (mor & IMMUNE_MAGIC && mir == MISR_MAGIC
-	    || mor & IMMUNE_FIRE && mir == MISR_FIRE
-	    || mor & IMMUNE_LIGHTNING && mir == MISR_LIGHTNING
-	    || (mor & IMMUNE_ACID) && mir == MISR_ACID)
+	if ((mor & IMMUNE_MAGIC && mir == MISR_MAGIC)
+	    || (mor & IMMUNE_FIRE && mir == MISR_FIRE)
+	    || (mor & IMMUNE_LIGHTNING && mir == MISR_LIGHTNING)
+	    || (mor & IMMUNE_ACID && mir == MISR_ACID))
 		return false;
 
-	if (mor & RESIST_MAGIC && mir == MISR_MAGIC
-	    || mor & RESIST_FIRE && mir == MISR_FIRE
-	    || mor & RESIST_LIGHTNING && mir == MISR_LIGHTNING)
+	if ((mor & RESIST_MAGIC && mir == MISR_MAGIC)
+	    || (mor & RESIST_FIRE && mir == MISR_FIRE)
+	    || (mor & RESIST_LIGHTNING && mir == MISR_LIGHTNING))
 		resist = true;
 
 	if (gbIsHellfire && t == MIS_HBOLT && (monster[m].MType->mtype == MT_DIABLO || monster[m].MType->mtype == MT_BONEDEMN))
@@ -1514,7 +1514,7 @@ void AddBerserk(Sint32 mi, Sint32 sx, Sint32 sy, Sint32 dx, Sint32 dy, Sint32 mi
 						if (monster[dm]._uniqtype == 0 && monster[dm]._mAi != AI_DIABLO) {
 							if (monster[dm]._mmode != MM_FADEIN && monster[dm]._mmode != MM_FADEOUT) {
 								if (!(monster[dm].mMagicRes & IMMUNE_MAGIC)) {
-									if ((!(monster[dm].mMagicRes & RESIST_MAGIC) || (monster[dm].mMagicRes & RESIST_MAGIC) == 1 && !random_(99, 2)) && monster[dm]._mmode != MM_CHARGE) {
+									if ((!(monster[dm].mMagicRes & RESIST_MAGIC) || ((monster[dm].mMagicRes & RESIST_MAGIC) == 1 && !random_(99, 2))) && monster[dm]._mmode != MM_CHARGE) {
 										j = 6;
 										double slvl = (double)GetSpellLevel(id, SPL_BERSERK);
 										monster[dm]._mFlags |= MFLAG_BERSERK | MFLAG_GOLEM;
@@ -2379,11 +2379,8 @@ void AddLightning(Sint32 mi, Sint32 sx, Sint32 sy, Sint32 dx, Sint32 dy, Sint32 
 
 void AddMisexp(Sint32 mi, Sint32 sx, Sint32 sy, Sint32 dx, Sint32 dy, Sint32 midir, Sint8 mienemy, Sint32 id, Sint32 dam)
 {
-	CMonster *mon;
-
 	if (mienemy && id > 0) {
-		mon = monster[id].MType;
-		switch (mon->mtype) {
+		switch (monster[id].MType->mtype) {
 		case MT_SUCCUBUS:
 			SetMissAnim(mi, MFILE_FLAREEXP);
 			break;
@@ -2395,6 +2392,8 @@ void AddMisexp(Sint32 mi, Sint32 sx, Sint32 sy, Sint32 dx, Sint32 dy, Sint32 mid
 			break;
 		case MT_SOLBRNR:
 			SetMissAnim(mi, MFILE_SCBSEXPC);
+			break;
+		default:
 			break;
 		}
 	}
@@ -2758,7 +2757,7 @@ void AddAcid(Sint32 mi, Sint32 sx, Sint32 sy, Sint32 dx, Sint32 dy, Sint32 midir
 {
 	GetMissileVel(mi, sx, sy, dx, dy, 16);
 	SetMissDir(mi, GetDirection16(sx, sy, dx, dy));
-	if (!gbIsHellfire && missile[mi]._mixvel & 0xFFFF0000 || missile[mi]._miyvel & 0xFFFF0000)
+	if ((!gbIsHellfire && missile[mi]._mixvel & 0xFFFF0000) || missile[mi]._miyvel & 0xFFFF0000)
 		missile[mi]._mirange = 5 * (monster[id]._mint + 4);
 	else
 		missile[mi]._mirange = 1;
@@ -3842,13 +3841,13 @@ void MI_Fireball(Sint32 i)
 				missile[i]._miyoff -= 32;
 			}
 			if (missile[i]._miyvel > 0
-			    && (TransList[dTransVal[mx + 1][my]] && nSolidTable[dPiece[mx + 1][my]]
-			        || TransList[dTransVal[mx - 1][my]] && nSolidTable[dPiece[mx - 1][my]])) {
+			    && ((TransList[dTransVal[mx + 1][my]] && nSolidTable[dPiece[mx + 1][my]])
+			        || (TransList[dTransVal[mx - 1][my]] && nSolidTable[dPiece[mx - 1][my]]))) {
 				missile[i]._miyoff -= 32;
 			}
 			if (missile[i]._mixvel > 0
-			    && (TransList[dTransVal[mx][my + 1]] && nSolidTable[dPiece[mx][my + 1]]
-			        || TransList[dTransVal[mx][my - 1]] && nSolidTable[dPiece[mx][my - 1]])) {
+			    && ((TransList[dTransVal[mx][my + 1]] && nSolidTable[dPiece[mx][my + 1]])
+			        || (TransList[dTransVal[mx][my - 1]] && nSolidTable[dPiece[mx][my - 1]]))) {
 				missile[i]._mixoff -= 32;
 			}
 			missile[i]._mimfnum = 0;
@@ -4052,13 +4051,13 @@ void MI_Immolation(Sint32 i)
 				missile[i]._miyoff -= 32;
 			}
 			if (missile[i]._miyvel > 0
-			    && (TransList[dTransVal[mx + 1][my]] && nSolidTable[dPiece[mx + 1][my]]
-			        || TransList[dTransVal[mx - 1][my]] && nSolidTable[dPiece[mx - 1][my]])) {
+			    && ((TransList[dTransVal[mx + 1][my]] && nSolidTable[dPiece[mx + 1][my]])
+			        || (TransList[dTransVal[mx - 1][my]] && nSolidTable[dPiece[mx - 1][my]]))) {
 				missile[i]._miyoff -= 32;
 			}
 			if (missile[i]._mixvel > 0
-			    && (TransList[dTransVal[mx][my + 1]] && nSolidTable[dPiece[mx][my + 1]]
-			        || TransList[dTransVal[mx][my - 1]] && nSolidTable[dPiece[mx][my - 1]])) {
+			    && ((TransList[dTransVal[mx][my + 1]] && nSolidTable[dPiece[mx][my + 1]])
+			        || (TransList[dTransVal[mx][my - 1]] && nSolidTable[dPiece[mx][my - 1]]))) {
 				missile[i]._mixoff -= 32;
 			}
 			missile[i]._mimfnum = 0;
@@ -4741,7 +4740,7 @@ void MI_Guardian(Sint32 i)
 	if (missile[i]._miVar2 > 0) {
 		missile[i]._miVar2--;
 	}
-	if (missile[i]._mirange == missile[i]._miVar1 || missile[i]._mimfnum == MFILE_GUARD && missile[i]._miVar2 == 0) {
+	if (missile[i]._mirange == missile[i]._miVar1 || (missile[i]._mimfnum == MFILE_GUARD && missile[i]._miVar2 == 0)) {
 		SetMissDir(i, 1);
 	}
 
@@ -5052,7 +5051,7 @@ void MI_Fireman(Sint32 i)
 		cx = monster[enemy]._mx;
 		cy = monster[enemy]._my;
 	}
-	if ((bx != ax || by != ay) && (missile[i]._miVar1 & 1 && (abs(ax - cx) >= 4 || abs(ay - cy) >= 4) || missile[i]._miVar2 > 1) && PosOkMonst(missile[i]._misource, ax, ay)) {
+	if ((bx != ax || by != ay) && ((missile[i]._miVar1 & 1 && (abs(ax - cx) >= 4 || abs(ay - cy) >= 4)) || missile[i]._miVar2 > 1) && PosOkMonst(missile[i]._misource, ax, ay)) {
 		MissToMonst(i, ax, ay);
 		missile[i]._miDelFlag = true;
 	} else if (!(monster[src]._mFlags & MFLAG_TARGETS_MONSTER)) {
@@ -5060,7 +5059,7 @@ void MI_Fireman(Sint32 i)
 	} else {
 		j = dMonster[bx][by];
 	}
-	if (!PosOkMissile(bx, by) || j > 0 && !(missile[i]._miVar1 & 1)) {
+	if (!PosOkMissile(bx, by) || (j > 0 && !(missile[i]._miVar1 & 1))) {
 		missile[i]._mixvel *= -1;
 		missile[i]._miyvel *= -1;
 		missile[i]._mimfnum = opposite[missile[i]._mimfnum];

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -817,6 +817,8 @@ void DeltaLoadLevel()
 			case CMD_BREAKOBJ:
 				SyncBreakObj(-1, i);
 				break;
+			default:
+				break;
 			}
 		}
 
@@ -2676,6 +2678,8 @@ DWORD ParseCmd(int pnum, TCmd *pCmd)
 		return On_OPENHIVE(pCmd, pnum);
 	case CMD_OPENCRYPT:
 		return On_OPENCRYPT(pCmd, pnum);
+	default:
+		break;
 	}
 
 	if (pCmd->bCmd < CMD_DLEVEL_0 || pCmd->bCmd > CMD_DLEVEL_END) {

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -726,6 +726,8 @@ void AddChestTraps()
 					case OBJ_CHEST3:
 						object[oi]._otype = OBJ_TCHEST3;
 						break;
+					default:
+						break;
 					}
 					object[oi]._oTrapFlag = true;
 					if (leveltype == DTYPE_CATACOMBS) {
@@ -1857,6 +1859,8 @@ void AddObject(_object_id ot, int ox, int oy)
 	case OBJ_TNUDEM2:
 		AddTorturedBody(oi);
 		break;
+	default:
+		break;
 	}
 	object[oi]._oAnimWidth2 = (object[oi]._oAnimWidth - 64) >> 1;
 	nobjects++;
@@ -2071,6 +2075,8 @@ void Obj_Trap(int i)
 			if (object[oti]._oSelFlag == 0)
 				otrig = true;
 			break;
+		default:
+			break;
 		}
 		if (otrig) {
 			object[i]._oVar4 = 1;
@@ -2193,6 +2199,8 @@ void ProcessObjects()
 		case OBJ_TBCROSS:
 			Obj_Light(oi, 10);
 			Obj_BCrossDamage(oi);
+			break;
+		default:
 			break;
 		}
 		if (object[oi]._oAnimFlag == 0)
@@ -4419,6 +4427,8 @@ bool OperateFountains(int pnum, int i)
 		if (pnum == myplr)
 			NetSendCmdParam1(false, CMD_OPERATEOBJ, i);
 		break;
+	default:
+		break;
 	}
 	force_redraw = 255;
 	return applied;
@@ -4618,6 +4628,8 @@ void OperateObject(int pnum, int i, bool TeleFlag)
 	case OBJ_SIGNCHEST:
 		OperateInnSignChest(pnum, i);
 		break;
+	default:
+		break;
 	}
 }
 
@@ -4767,6 +4779,8 @@ void SyncOpObject(int pnum, int cmd, int i)
 	case OBJ_SIGNCHEST:
 		OperateInnSignChest(pnum, i);
 		break;
+	default:
+		break;
 	}
 }
 
@@ -4899,6 +4913,8 @@ void BreakObject(int pnum, int oi)
 	case OBJ_BARREL:
 	case OBJ_BARRELEX:
 		BreakBarrel(pnum, oi, objdam, false, true);
+		break;
+	default:
 		break;
 	}
 }
@@ -5097,6 +5113,8 @@ void SyncObjectAnim(int o)
 	case OBJ_PEDISTAL:
 		SyncPedistal(o);
 		break;
+	default:
+		break;
 	}
 }
 
@@ -5237,6 +5255,8 @@ void GetObjectStr(int i)
 		break;
 	case OBJ_SLAINHERO:
 		strcpy(infostr, "Slain Hero");
+		break;
+	default:
 		break;
 	}
 	if (plr[myplr]._pClass == PC_ROGUE) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -588,6 +588,8 @@ void SetPlrAnims(int pnum)
 			plr[pnum]._pAFrames = 13;
 			plr[pnum]._pAFNum = 8;
 			break;
+		default:
+			break;
 		}
 	} else if (pc == PC_BARD) {
 		if (gn == ANIM_ID_AXE) {

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1175,6 +1175,8 @@ static void DrawGame(CelOutputBuffer full_out, int x, int y)
 		columns++;
 		rows++;
 		break;
+	case SDIR_NONE:
+		break;
 	}
 
 	scrollrt_drawFloor(out, x, y, sx, sy, rows, columns);

--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -216,11 +216,13 @@ void selhero_CatToName(char *in_buf, char *out_buf, int cnt)
 	strncat(out_buf, output.c_str(), cnt - strlen(out_buf));
 }
 
+#ifdef __vita__
 void selhero_SetName(char *in_buf, char *out_buf, int cnt)
 {
 	std::string output = utf8_to_latin1(in_buf);
 	strncpy(out_buf, output.c_str(), cnt);
 }
+#endif
 
 bool HandleMenuAction(MenuAction menu_action)
 {


### PR DESCRIPTION
Should try and tackle more the warnings that we silence, or enable more compiler checks next?