### PR TITLE
Fixed data type of quest _qmsg in save files.

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -739,7 +739,7 @@ static void LoadQuest(LoadHelper *file, int i)
 		file->skip(2); // Alignment
 		pQuest->_qmsg = file->nextLE<Sint32>();
 	} else {
-		pQuest->_qmsg = file->nextLE<Sint8>();
+		pQuest->_qmsg = file->nextLE<Uint8>();
 	}
 	pQuest->_qvar1 = file->nextLE<Uint8>();
 	pQuest->_qvar2 = file->nextLE<Uint8>();
@@ -1690,7 +1690,7 @@ static void SaveQuest(SaveHelper *file, int i)
 		file->skip(2); // Alignment
 		file->writeLE<Sint32>(pQuest->_qmsg);
 	} else {
-		file->writeLE<Sint8>(pQuest->_qmsg);
+		file->writeLE<Uint8>(pQuest->_qmsg);
 	}
 	file->writeLE<Uint8>(pQuest->_qvar1);
 	file->writeLE<Uint8>(pQuest->_qvar2);


### PR DESCRIPTION
This resolves #1463

FYI, the savegame attached to the issue works in the original game. This must be because the original game is reading _qmsg as a `Uint8` regardless of how DevilutionX saves it. After making this change, the same savegame works fine in DevilutionX as well.