### PR TITLE
Copy devilutionx.mpq to the build directory when performing CMake. #1472

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,8 +399,9 @@ endif()
 
 add_executable(${BIN_TARGET} WIN32 MACOSX_BUNDLE ${devilutionx_SRCS})
 
-# Copy the font to the build directory to it works from the build directory
+# Copy the font and devilutionx.mpq to the build directory to it works from the build directory
 file(COPY "Packaging/resources/CharisSILB.ttf" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+file(COPY "Packaging/resources/devilutionx.mpq" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 
 # Use file GENERATE instead of configure_file because configure_file
 # does not support generator expressions.


### PR DESCRIPTION
As per (non) issue #1472  - devilutionx.mpq was not automatically copied across when performing 'cmake ..' in the build folder.

This just adds the copy of devilutionx.mpq when performing a cmake.
