### PR TITLE
'attribute_id' enum cleanup

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1505,25 +1505,25 @@ void DrawChr(CelOutputBuffer out)
 
 	col = COL_WHITE;
 	sprintf(chrstr, "%i", plr[myplr]._pBaseStr);
-	if (plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_STR) == plr[myplr]._pBaseStr)
+	if (plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Strength) == plr[myplr]._pBaseStr)
 		col = COL_GOLD;
 	ADD_PlrStringXY(out, 95, 155, 126, chrstr, col);
 
 	col = COL_WHITE;
 	sprintf(chrstr, "%i", plr[myplr]._pBaseMag);
-	if (plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG) == plr[myplr]._pBaseMag)
+	if (plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Magic) == plr[myplr]._pBaseMag)
 		col = COL_GOLD;
 	ADD_PlrStringXY(out, 95, 183, 126, chrstr, col);
 
 	col = COL_WHITE;
 	sprintf(chrstr, "%i", plr[myplr]._pBaseDex);
-	if (plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX) == plr[myplr]._pBaseDex)
+	if (plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Dexterity) == plr[myplr]._pBaseDex)
 		col = COL_GOLD;
 	ADD_PlrStringXY(out, 95, 211, 126, chrstr, col);
 
 	col = COL_WHITE;
 	sprintf(chrstr, "%i", plr[myplr]._pBaseVit);
-	if (plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_VIT) == plr[myplr]._pBaseVit)
+	if (plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Vitality) == plr[myplr]._pBaseVit)
 		col = COL_GOLD;
 	ADD_PlrStringXY(out, 95, 239, 126, chrstr, col);
 
@@ -1567,14 +1567,14 @@ void DrawChr(CelOutputBuffer out)
 	if (plr[myplr]._pStatPts > 0) {
 		sprintf(chrstr, "%i", plr[myplr]._pStatPts);
 		ADD_PlrStringXY(out, 95, 266, 126, chrstr, COL_RED);
-		if (plr[myplr]._pBaseStr < plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_STR))
-			CelDrawTo(out, 137, 159, pChrButtons, chrbtn[static_cast<size_t>(attribute_id::ATTRIB_STR)] + 2, 41);
-		if (plr[myplr]._pBaseMag < plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG))
-			CelDrawTo(out, 137, 187, pChrButtons, chrbtn[static_cast<size_t>(attribute_id::ATTRIB_MAG)] + 4, 41);
-		if (plr[myplr]._pBaseDex < plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX))
-			CelDrawTo(out, 137, 216, pChrButtons, chrbtn[static_cast<size_t>(attribute_id::ATTRIB_DEX)] + 6, 41);
-		if (plr[myplr]._pBaseVit < plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_VIT))
-			CelDrawTo(out, 137, 244, pChrButtons, chrbtn[static_cast<size_t>(attribute_id::ATTRIB_VIT)] + 8, 41);
+		if (plr[myplr]._pBaseStr < plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Strength))
+			CelDrawTo(out, 137, 159, pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Strength)] + 2, 41);
+		if (plr[myplr]._pBaseMag < plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Magic))
+			CelDrawTo(out, 137, 187, pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Magic)] + 4, 41);
+		if (plr[myplr]._pBaseDex < plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Dexterity))
+			CelDrawTo(out, 137, 216, pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Dexterity)] + 6, 41);
+		if (plr[myplr]._pBaseVit < plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Vitality))
+			CelDrawTo(out, 137, 244, pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Vitality)] + 8, 41);
 	}
 
 	if (plr[myplr]._pMaxHP > plr[myplr]._pMaxHPBase)
@@ -1630,22 +1630,22 @@ void CheckChrBtns()
 
 	if (!chrbtnactive && plr[myplr]._pStatPts) {
 		HeroClass pc = plr[myplr]._pClass;
-		for (auto i : enum_values<attribute_id>()) {
+		for (auto i : enum_values<CharacterAttribute>()) {
 			int max = plr[myplr].GetMaximumAttributeValue(i);
 			switch (i) {
-			case attribute_id::ATTRIB_STR:
+			case CharacterAttribute::Strength:
 				if (plr[myplr]._pBaseStr >= max)
 					continue;
 				break;
-			case attribute_id::ATTRIB_MAG:
+			case CharacterAttribute::Magic:
 				if (plr[myplr]._pBaseMag >= max)
 					continue;
 				break;
-			case attribute_id::ATTRIB_DEX:
+			case CharacterAttribute::Dexterity:
 				if (plr[myplr]._pBaseDex >= max)
 					continue;
 				break;
-			case attribute_id::ATTRIB_VIT:
+			case CharacterAttribute::Vitality:
 				if (plr[myplr]._pBaseVit >= max)
 					continue;
 				break;
@@ -1665,7 +1665,7 @@ void CheckChrBtns()
 	}
 }
 
-int CapStatPointsToAdd(int remainingStatPoints, const PlayerStruct &player, attribute_id attribute)
+int CapStatPointsToAdd(int remainingStatPoints, const PlayerStruct &player, CharacterAttribute attribute)
 {
 	int pointsToReachCap = player.GetMaximumAttributeValue(attribute) - player.GetBaseAttributeValue(attribute);
 
@@ -1675,7 +1675,7 @@ int CapStatPointsToAdd(int remainingStatPoints, const PlayerStruct &player, attr
 void ReleaseChrBtns(bool addAllStatPoints)
 {
 	chrbtnactive = false;
-	for (auto i : enum_values<attribute_id>()) {
+	for (auto i : enum_values<CharacterAttribute>()) {
 		if (!chrbtn[static_cast<size_t>(i)])
 			continue;
 
@@ -1689,19 +1689,19 @@ void ReleaseChrBtns(bool addAllStatPoints)
 			if (addAllStatPoints)
 				statPointsToAdd = CapStatPointsToAdd(player._pStatPts, player, i);
 			switch (i) {
-			case attribute_id::ATTRIB_STR:
+			case CharacterAttribute::Strength:
 				NetSendCmdParam1(true, CMD_ADDSTR, statPointsToAdd);
 				player._pStatPts -= statPointsToAdd;
 				break;
-			case attribute_id::ATTRIB_MAG:
+			case CharacterAttribute::Magic:
 				NetSendCmdParam1(true, CMD_ADDMAG, statPointsToAdd);
 				player._pStatPts -= statPointsToAdd;
 				break;
-			case attribute_id::ATTRIB_DEX:
+			case CharacterAttribute::Dexterity:
 				NetSendCmdParam1(true, CMD_ADDDEX, statPointsToAdd);
 				player._pStatPts -= statPointsToAdd;
 				break;
-			case attribute_id::ATTRIB_VIT:
+			case CharacterAttribute::Vitality:
 				NetSendCmdParam1(true, CMD_ADDVIT, statPointsToAdd);
 				player._pStatPts -= statPointsToAdd;
 				break;

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1505,25 +1505,25 @@ void DrawChr(CelOutputBuffer out)
 
 	col = COL_WHITE;
 	sprintf(chrstr, "%i", plr[myplr]._pBaseStr);
-	if (plr[myplr].GetMaximumAttributeValue(ATTRIB_STR) == plr[myplr]._pBaseStr)
+	if (plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_STR) == plr[myplr]._pBaseStr)
 		col = COL_GOLD;
 	ADD_PlrStringXY(out, 95, 155, 126, chrstr, col);
 
 	col = COL_WHITE;
 	sprintf(chrstr, "%i", plr[myplr]._pBaseMag);
-	if (plr[myplr].GetMaximumAttributeValue(ATTRIB_MAG) == plr[myplr]._pBaseMag)
+	if (plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG) == plr[myplr]._pBaseMag)
 		col = COL_GOLD;
 	ADD_PlrStringXY(out, 95, 183, 126, chrstr, col);
 
 	col = COL_WHITE;
 	sprintf(chrstr, "%i", plr[myplr]._pBaseDex);
-	if (plr[myplr].GetMaximumAttributeValue(ATTRIB_DEX) == plr[myplr]._pBaseDex)
+	if (plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX) == plr[myplr]._pBaseDex)
 		col = COL_GOLD;
 	ADD_PlrStringXY(out, 95, 211, 126, chrstr, col);
 
 	col = COL_WHITE;
 	sprintf(chrstr, "%i", plr[myplr]._pBaseVit);
-	if (plr[myplr].GetMaximumAttributeValue(ATTRIB_VIT) == plr[myplr]._pBaseVit)
+	if (plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_VIT) == plr[myplr]._pBaseVit)
 		col = COL_GOLD;
 	ADD_PlrStringXY(out, 95, 239, 126, chrstr, col);
 
@@ -1567,14 +1567,14 @@ void DrawChr(CelOutputBuffer out)
 	if (plr[myplr]._pStatPts > 0) {
 		sprintf(chrstr, "%i", plr[myplr]._pStatPts);
 		ADD_PlrStringXY(out, 95, 266, 126, chrstr, COL_RED);
-		if (plr[myplr]._pBaseStr < plr[myplr].GetMaximumAttributeValue(ATTRIB_STR))
-			CelDrawTo(out, 137, 159, pChrButtons, chrbtn[ATTRIB_STR] + 2, 41);
-		if (plr[myplr]._pBaseMag < plr[myplr].GetMaximumAttributeValue(ATTRIB_MAG))
-			CelDrawTo(out, 137, 187, pChrButtons, chrbtn[ATTRIB_MAG] + 4, 41);
-		if (plr[myplr]._pBaseDex < plr[myplr].GetMaximumAttributeValue(ATTRIB_DEX))
-			CelDrawTo(out, 137, 216, pChrButtons, chrbtn[ATTRIB_DEX] + 6, 41);
-		if (plr[myplr]._pBaseVit < plr[myplr].GetMaximumAttributeValue(ATTRIB_VIT))
-			CelDrawTo(out, 137, 244, pChrButtons, chrbtn[ATTRIB_VIT] + 8, 41);
+		if (plr[myplr]._pBaseStr < plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_STR))
+			CelDrawTo(out, 137, 159, pChrButtons, chrbtn[static_cast<size_t>(attribute_id::ATTRIB_STR)] + 2, 41);
+		if (plr[myplr]._pBaseMag < plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG))
+			CelDrawTo(out, 137, 187, pChrButtons, chrbtn[static_cast<size_t>(attribute_id::ATTRIB_MAG)] + 4, 41);
+		if (plr[myplr]._pBaseDex < plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX))
+			CelDrawTo(out, 137, 216, pChrButtons, chrbtn[static_cast<size_t>(attribute_id::ATTRIB_DEX)] + 6, 41);
+		if (plr[myplr]._pBaseVit < plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_VIT))
+			CelDrawTo(out, 137, 244, pChrButtons, chrbtn[static_cast<size_t>(attribute_id::ATTRIB_VIT)] + 8, 41);
 	}
 
 	if (plr[myplr]._pMaxHP > plr[myplr]._pMaxHPBase)
@@ -1630,35 +1630,35 @@ void CheckChrBtns()
 
 	if (!chrbtnactive && plr[myplr]._pStatPts) {
 		HeroClass pc = plr[myplr]._pClass;
-		for (int i = ATTRIB_STR; i <= ATTRIB_VIT; i++) {
-			int max = plr[myplr].GetMaximumAttributeValue((attribute_id)i);
+		for (auto i : enum_values<attribute_id>()) {
+			int max = plr[myplr].GetMaximumAttributeValue(i);
 			switch (i) {
-			case ATTRIB_STR:
+			case attribute_id::ATTRIB_STR:
 				if (plr[myplr]._pBaseStr >= max)
 					continue;
 				break;
-			case ATTRIB_MAG:
+			case attribute_id::ATTRIB_MAG:
 				if (plr[myplr]._pBaseMag >= max)
 					continue;
 				break;
-			case ATTRIB_DEX:
+			case attribute_id::ATTRIB_DEX:
 				if (plr[myplr]._pBaseDex >= max)
 					continue;
 				break;
-			case ATTRIB_VIT:
+			case attribute_id::ATTRIB_VIT:
 				if (plr[myplr]._pBaseVit >= max)
 					continue;
 				break;
 			default:
 				continue;
 			}
-			x = ChrBtnsRect[i].x + ChrBtnsRect[i].w;
-			y = ChrBtnsRect[i].y + ChrBtnsRect[i].h;
-			if (MouseX >= ChrBtnsRect[i].x
+			x = ChrBtnsRect[static_cast<size_t>(i)].x + ChrBtnsRect[static_cast<size_t>(i)].w;
+			y = ChrBtnsRect[static_cast<size_t>(i)].y + ChrBtnsRect[static_cast<size_t>(i)].h;
+			if (MouseX >= ChrBtnsRect[static_cast<size_t>(i)].x
 			    && MouseX <= x
-			    && MouseY >= ChrBtnsRect[i].y
+			    && MouseY >= ChrBtnsRect[static_cast<size_t>(i)].y
 			    && MouseY <= y) {
-				chrbtn[i] = true;
+				chrbtn[static_cast<size_t>(i)] = true;
 				chrbtnactive = true;
 			}
 		}
@@ -1675,33 +1675,33 @@ int CapStatPointsToAdd(int remainingStatPoints, const PlayerStruct &player, attr
 void ReleaseChrBtns(bool addAllStatPoints)
 {
 	chrbtnactive = false;
-	for (int i = ATTRIB_STR; i <= ATTRIB_VIT; ++i) {
-		if (!chrbtn[i])
+	for (auto i : enum_values<attribute_id>()) {
+		if (!chrbtn[static_cast<size_t>(i)])
 			continue;
 
-		chrbtn[i] = false;
-		if (MouseX >= ChrBtnsRect[i].x
-			&& MouseX <= ChrBtnsRect[i].x + ChrBtnsRect[i].w
-			&& MouseY >= ChrBtnsRect[i].y
-			&& MouseY <= ChrBtnsRect[i].y + ChrBtnsRect[i].h) {
+		chrbtn[static_cast<size_t>(i)] = false;
+		if (MouseX >= ChrBtnsRect[static_cast<size_t>(i)].x
+			&& MouseX <= ChrBtnsRect[static_cast<size_t>(i)].x + ChrBtnsRect[static_cast<size_t>(i)].w
+			&& MouseY >= ChrBtnsRect[static_cast<size_t>(i)].y
+			&& MouseY <= ChrBtnsRect[static_cast<size_t>(i)].y + ChrBtnsRect[static_cast<size_t>(i)].h) {
 			PlayerStruct &player = plr[myplr];
 			int statPointsToAdd = 1;
 			if (addAllStatPoints)
-				statPointsToAdd = CapStatPointsToAdd(player._pStatPts, player, (attribute_id)i);
+				statPointsToAdd = CapStatPointsToAdd(player._pStatPts, player, i);
 			switch (i) {
-			case ATTRIB_STR:
+			case attribute_id::ATTRIB_STR:
 				NetSendCmdParam1(true, CMD_ADDSTR, statPointsToAdd);
 				player._pStatPts -= statPointsToAdd;
 				break;
-			case ATTRIB_MAG:
+			case attribute_id::ATTRIB_MAG:
 				NetSendCmdParam1(true, CMD_ADDMAG, statPointsToAdd);
 				player._pStatPts -= statPointsToAdd;
 				break;
-			case ATTRIB_DEX:
+			case attribute_id::ATTRIB_DEX:
 				NetSendCmdParam1(true, CMD_ADDDEX, statPointsToAdd);
 				player._pStatPts -= statPointsToAdd;
 				break;
-			case ATTRIB_VIT:
+			case attribute_id::ATTRIB_VIT:
 				NetSendCmdParam1(true, CMD_ADDVIT, statPointsToAdd);
 				player._pStatPts -= statPointsToAdd;
 				break;

--- a/Source/enum_traits.h
+++ b/Source/enum_traits.h
@@ -14,4 +14,45 @@ struct enum_size {
 	constexpr static const std::size_t value = static_cast<std::size_t>(T::LAST) + 1;
 };
 
+template <typename T>
+class enum_values {
+public:
+	class Iterator {
+		typename std::underlying_type<T>::type m_value;
+
+	public:
+		Iterator(typename std::underlying_type<T>::type value)
+		    : m_value(value)
+		{
+		}
+
+		const T operator*() const
+		{
+			return static_cast<T>(m_value);
+		}
+
+		void operator++()
+		{
+			m_value++;
+		}
+
+		bool operator!=(Iterator rhs) const
+		{
+			return m_value != rhs.m_value;
+		}
+	};
+};
+
+template <typename T>
+typename enum_values<T>::Iterator begin(enum_values<T>)
+{
+	return typename enum_values<T>::Iterator(static_cast<typename std::underlying_type<T>::type>(T::FIRST));
+}
+
+template <typename T>
+typename enum_values<T>::Iterator end(enum_values<T>)
+{
+	return typename enum_values<T>::Iterator(static_cast<typename std::underlying_type<T>::type>(T::LAST) + 1);
+}
+
 }

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4622,9 +4622,9 @@ static void SpawnOnePremium(int i, int plvl, int myplr)
 	bool keepgoing = false;
 	ItemStruct holditem = items[0];
 
-	int strength = std::max(plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_STR), plr[myplr]._pStrength);
-	int dexterity = std::max(plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX), plr[myplr]._pDexterity);
-	int magic = std::max(plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG), plr[myplr]._pMagic);
+	int strength = std::max(plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Strength), plr[myplr]._pStrength);
+	int dexterity = std::max(plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Dexterity), plr[myplr]._pDexterity);
+	int magic = std::max(plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Magic), plr[myplr]._pMagic);
 	strength *= 1.2;
 	dexterity *= 1.2;
 	magic *= 1.2;
@@ -4950,9 +4950,9 @@ void SpawnBoy(int lvl)
 	int count = 0;
 
 	HeroClass pc = plr[myplr]._pClass;
-	int strength = std::max(plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_STR), plr[myplr]._pStrength);
-	int dexterity = std::max(plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX), plr[myplr]._pDexterity);
-	int magic = std::max(plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG), plr[myplr]._pMagic);
+	int strength = std::max(plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Strength), plr[myplr]._pStrength);
+	int dexterity = std::max(plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Dexterity), plr[myplr]._pDexterity);
+	int magic = std::max(plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Magic), plr[myplr]._pMagic);
 	strength *= 1.2;
 	dexterity *= 1.2;
 	magic *= 1.2;
@@ -5071,13 +5071,13 @@ bool HealerItemOk(int i)
 
 	if (!gbIsMultiplayer) {
 		if (AllItemsList[i].iMiscId == IMISC_ELIXSTR)
-			return !gbIsHellfire || plr[myplr]._pBaseStr < plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_STR);
+			return !gbIsHellfire || plr[myplr]._pBaseStr < plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Strength);
 		if (AllItemsList[i].iMiscId == IMISC_ELIXMAG)
-			return !gbIsHellfire || plr[myplr]._pBaseMag < plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG);
+			return !gbIsHellfire || plr[myplr]._pBaseMag < plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Magic);
 		if (AllItemsList[i].iMiscId == IMISC_ELIXDEX)
-			return !gbIsHellfire || plr[myplr]._pBaseDex < plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX);
+			return !gbIsHellfire || plr[myplr]._pBaseDex < plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Dexterity);
 		if (AllItemsList[i].iMiscId == IMISC_ELIXVIT)
-			return !gbIsHellfire || plr[myplr]._pBaseVit < plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_VIT);
+			return !gbIsHellfire || plr[myplr]._pBaseVit < plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Vitality);
 	}
 
 	if (AllItemsList[i].iMiscId == IMISC_REJUV)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4622,9 +4622,9 @@ static void SpawnOnePremium(int i, int plvl, int myplr)
 	bool keepgoing = false;
 	ItemStruct holditem = items[0];
 
-	int strength = std::max(plr[myplr].GetMaximumAttributeValue(ATTRIB_STR), plr[myplr]._pStrength);
-	int dexterity = std::max(plr[myplr].GetMaximumAttributeValue(ATTRIB_DEX), plr[myplr]._pDexterity);
-	int magic = std::max(plr[myplr].GetMaximumAttributeValue(ATTRIB_MAG), plr[myplr]._pMagic);
+	int strength = std::max(plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_STR), plr[myplr]._pStrength);
+	int dexterity = std::max(plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX), plr[myplr]._pDexterity);
+	int magic = std::max(plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG), plr[myplr]._pMagic);
 	strength *= 1.2;
 	dexterity *= 1.2;
 	magic *= 1.2;
@@ -4950,9 +4950,9 @@ void SpawnBoy(int lvl)
 	int count = 0;
 
 	HeroClass pc = plr[myplr]._pClass;
-	int strength = std::max(plr[myplr].GetMaximumAttributeValue(ATTRIB_STR), plr[myplr]._pStrength);
-	int dexterity = std::max(plr[myplr].GetMaximumAttributeValue(ATTRIB_DEX), plr[myplr]._pDexterity);
-	int magic = std::max(plr[myplr].GetMaximumAttributeValue(ATTRIB_MAG), plr[myplr]._pMagic);
+	int strength = std::max(plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_STR), plr[myplr]._pStrength);
+	int dexterity = std::max(plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX), plr[myplr]._pDexterity);
+	int magic = std::max(plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG), plr[myplr]._pMagic);
 	strength *= 1.2;
 	dexterity *= 1.2;
 	magic *= 1.2;
@@ -5071,13 +5071,13 @@ bool HealerItemOk(int i)
 
 	if (!gbIsMultiplayer) {
 		if (AllItemsList[i].iMiscId == IMISC_ELIXSTR)
-			return !gbIsHellfire || plr[myplr]._pBaseStr < plr[myplr].GetMaximumAttributeValue(ATTRIB_STR);
+			return !gbIsHellfire || plr[myplr]._pBaseStr < plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_STR);
 		if (AllItemsList[i].iMiscId == IMISC_ELIXMAG)
-			return !gbIsHellfire || plr[myplr]._pBaseMag < plr[myplr].GetMaximumAttributeValue(ATTRIB_MAG);
+			return !gbIsHellfire || plr[myplr]._pBaseMag < plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG);
 		if (AllItemsList[i].iMiscId == IMISC_ELIXDEX)
-			return !gbIsHellfire || plr[myplr]._pBaseDex < plr[myplr].GetMaximumAttributeValue(ATTRIB_DEX);
+			return !gbIsHellfire || plr[myplr]._pBaseDex < plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX);
 		if (AllItemsList[i].iMiscId == IMISC_ELIXVIT)
-			return !gbIsHellfire || plr[myplr]._pBaseVit < plr[myplr].GetMaximumAttributeValue(ATTRIB_VIT);
+			return !gbIsHellfire || plr[myplr]._pBaseVit < plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_VIT);
 	}
 
 	if (AllItemsList[i].iMiscId == IMISC_REJUV)

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3408,17 +3408,17 @@ bool OperateShrineMysterious(int pnum)
 	ModifyPlrDex(pnum, -1);
 	ModifyPlrVit(pnum, -1);
 
-	switch (static_cast<attribute_id>(random_(0, 4))) {
-	case attribute_id::ATTRIB_STR:
+	switch (static_cast<CharacterAttribute>(random_(0, 4))) {
+	case CharacterAttribute::Strength:
 		ModifyPlrStr(pnum, 6);
 		break;
-	case attribute_id::ATTRIB_MAG:
+	case CharacterAttribute::Magic:
 		ModifyPlrMag(pnum, 6);
 		break;
-	case attribute_id::ATTRIB_DEX:
+	case CharacterAttribute::Dexterity:
 		ModifyPlrDex(pnum, 6);
 		break;
-	case attribute_id::ATTRIB_VIT:
+	case CharacterAttribute::Vitality:
 		ModifyPlrVit(pnum, 6);
 		break;
 	}

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3408,17 +3408,17 @@ bool OperateShrineMysterious(int pnum)
 	ModifyPlrDex(pnum, -1);
 	ModifyPlrVit(pnum, -1);
 
-	switch (random_(0, 4)) {
-	case ATTRIB_STR:
+	switch (static_cast<attribute_id>(random_(0, 4))) {
+	case attribute_id::ATTRIB_STR:
 		ModifyPlrStr(pnum, 6);
 		break;
-	case ATTRIB_MAG:
+	case attribute_id::ATTRIB_MAG:
 		ModifyPlrMag(pnum, 6);
 		break;
-	case ATTRIB_DEX:
+	case attribute_id::ATTRIB_DEX:
 		ModifyPlrDex(pnum, 6);
 		break;
-	case ATTRIB_VIT:
+	case attribute_id::ATTRIB_VIT:
 		ModifyPlrVit(pnum, 6);
 		break;
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -179,25 +179,25 @@ const char *const ClassPathTbl[] = {
 	"Warrior",
 };
 
-Sint32 PlayerStruct::GetBaseAttributeValue(attribute_id attribute) const
+Sint32 PlayerStruct::GetBaseAttributeValue(CharacterAttribute attribute) const
 {
 	switch (attribute) {
-	case attribute_id::ATTRIB_DEX:
+	case CharacterAttribute::Dexterity:
 		return this->_pBaseDex;
-	case attribute_id::ATTRIB_MAG:
+	case CharacterAttribute::Magic:
 		return this->_pBaseMag;
-	case attribute_id::ATTRIB_STR:
+	case CharacterAttribute::Strength:
 		return this->_pBaseStr;
-	case attribute_id::ATTRIB_VIT:
+	case CharacterAttribute::Vitality:
 		return this->_pBaseVit;
 	default:
 		app_fatal("Unsupported attribute");
 	}
 }
 
-Sint32 PlayerStruct::GetMaximumAttributeValue(attribute_id attribute) const
+Sint32 PlayerStruct::GetMaximumAttributeValue(CharacterAttribute attribute) const
 {
-	static const int MaxStats[enum_size<HeroClass>::value][enum_size<attribute_id>::value] = {
+	static const int MaxStats[enum_size<HeroClass>::value][enum_size<CharacterAttribute>::value] = {
 		// clang-format off
 		{ 250,  50,  60, 100 },
 		{  55,  70, 250,  80 },
@@ -802,13 +802,13 @@ void CreatePlayer(int pnum, HeroClass c)
 
 int CalcStatDiff(int pnum)
 {
-	return plr[pnum].GetMaximumAttributeValue(attribute_id::ATTRIB_STR)
+	return plr[pnum].GetMaximumAttributeValue(CharacterAttribute::Strength)
 	    - plr[pnum]._pBaseStr
-	    + plr[pnum].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG)
+	    + plr[pnum].GetMaximumAttributeValue(CharacterAttribute::Magic)
 	    - plr[pnum]._pBaseMag
-	    + plr[pnum].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX)
+	    + plr[pnum].GetMaximumAttributeValue(CharacterAttribute::Dexterity)
 	    - plr[pnum]._pBaseDex
-	    + plr[pnum].GetMaximumAttributeValue(attribute_id::ATTRIB_VIT)
+	    + plr[pnum].GetMaximumAttributeValue(CharacterAttribute::Vitality)
 	    - plr[pnum]._pBaseVit;
 }
 
@@ -3493,17 +3493,17 @@ void ValidatePlayer()
 	if (gt != plr[myplr]._pGold)
 		plr[myplr]._pGold = gt;
 
-	if (plr[myplr]._pBaseStr > plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_STR)) {
-		plr[myplr]._pBaseStr = plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_STR);
+	if (plr[myplr]._pBaseStr > plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Strength)) {
+		plr[myplr]._pBaseStr = plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Strength);
 	}
-	if (plr[myplr]._pBaseMag > plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG)) {
-		plr[myplr]._pBaseMag = plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG);
+	if (plr[myplr]._pBaseMag > plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Magic)) {
+		plr[myplr]._pBaseMag = plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Magic);
 	}
-	if (plr[myplr]._pBaseDex > plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX)) {
-		plr[myplr]._pBaseDex = plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX);
+	if (plr[myplr]._pBaseDex > plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Dexterity)) {
+		plr[myplr]._pBaseDex = plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Dexterity);
 	}
-	if (plr[myplr]._pBaseVit > plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_VIT)) {
-		plr[myplr]._pBaseVit = plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_VIT);
+	if (plr[myplr]._pBaseVit > plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Vitality)) {
+		plr[myplr]._pBaseVit = plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Vitality);
 	}
 
 	Uint64 msk = 0;
@@ -4052,31 +4052,31 @@ void CheckStats(int p)
 		app_fatal("CheckStats: illegal player %d", p);
 	}
 
-	for (auto i : enum_values<attribute_id>()) {
+	for (auto i : enum_values<CharacterAttribute>()) {
 		int maxStatPoint = plr[p].GetMaximumAttributeValue(i);
 		switch (i) {
-		case attribute_id::ATTRIB_STR:
+		case CharacterAttribute::Strength:
 			if (plr[p]._pBaseStr > maxStatPoint) {
 				plr[p]._pBaseStr = maxStatPoint;
 			} else if (plr[p]._pBaseStr < 0) {
 				plr[p]._pBaseStr = 0;
 			}
 			break;
-		case attribute_id::ATTRIB_MAG:
+		case CharacterAttribute::Magic:
 			if (plr[p]._pBaseMag > maxStatPoint) {
 				plr[p]._pBaseMag = maxStatPoint;
 			} else if (plr[p]._pBaseMag < 0) {
 				plr[p]._pBaseMag = 0;
 			}
 			break;
-		case attribute_id::ATTRIB_DEX:
+		case CharacterAttribute::Dexterity:
 			if (plr[p]._pBaseDex > maxStatPoint) {
 				plr[p]._pBaseDex = maxStatPoint;
 			} else if (plr[p]._pBaseDex < 0) {
 				plr[p]._pBaseDex = 0;
 			}
 			break;
-		case attribute_id::ATTRIB_VIT:
+		case CharacterAttribute::Vitality:
 			if (plr[p]._pBaseVit > maxStatPoint) {
 				plr[p]._pBaseVit = maxStatPoint;
 			} else if (plr[p]._pBaseVit < 0) {
@@ -4093,7 +4093,7 @@ void ModifyPlrStr(int p, int l)
 		app_fatal("ModifyPlrStr: illegal player %d", p);
 	}
 
-	int max = plr[p].GetMaximumAttributeValue(attribute_id::ATTRIB_STR);
+	int max = plr[p].GetMaximumAttributeValue(CharacterAttribute::Strength);
 	if (plr[p]._pBaseStr + l > max) {
 		l = max - plr[p]._pBaseStr;
 	}
@@ -4120,7 +4120,7 @@ void ModifyPlrMag(int p, int l)
 		app_fatal("ModifyPlrMag: illegal player %d", p);
 	}
 
-	int max = plr[p].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG);
+	int max = plr[p].GetMaximumAttributeValue(CharacterAttribute::Magic);
 	if (plr[p]._pBaseMag + l > max) {
 		l = max - plr[p]._pBaseMag;
 	}
@@ -4155,7 +4155,7 @@ void ModifyPlrDex(int p, int l)
 		app_fatal("ModifyPlrDex: illegal player %d", p);
 	}
 
-	int max = plr[p].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX);
+	int max = plr[p].GetMaximumAttributeValue(CharacterAttribute::Dexterity);
 	if (plr[p]._pBaseDex + l > max) {
 		l = max - plr[p]._pBaseDex;
 	}
@@ -4179,7 +4179,7 @@ void ModifyPlrVit(int p, int l)
 		app_fatal("ModifyPlrVit: illegal player %d", p);
 	}
 
-	int max = plr[p].GetMaximumAttributeValue(attribute_id::ATTRIB_VIT);
+	int max = plr[p].GetMaximumAttributeValue(CharacterAttribute::Vitality);
 	if (plr[p]._pBaseVit + l > max) {
 		l = max - plr[p]._pBaseVit;
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -197,7 +197,7 @@ Sint32 PlayerStruct::GetBaseAttributeValue(attribute_id attribute) const
 
 Sint32 PlayerStruct::GetMaximumAttributeValue(attribute_id attribute) const
 {
-	static const int MaxStats[enum_size<HeroClass>::value][4] = {
+	static const int MaxStats[enum_size<HeroClass>::value][enum_size<attribute_id>::value] = {
 		// clang-format off
 		{ 250,  50,  60, 100 },
 		{  55,  70, 250,  80 },
@@ -208,7 +208,7 @@ Sint32 PlayerStruct::GetMaximumAttributeValue(attribute_id attribute) const
 		// clang-format on
 	};
 
-	return MaxStats[static_cast<std::size_t>(_pClass)][attribute];
+	return MaxStats[static_cast<std::size_t>(_pClass)][static_cast<std::size_t>(attribute)];
 }
 
 void SetPlayerGPtrs(BYTE *pData, BYTE **pAnim)
@@ -802,13 +802,13 @@ void CreatePlayer(int pnum, HeroClass c)
 
 int CalcStatDiff(int pnum)
 {
-	return plr[pnum].GetMaximumAttributeValue(ATTRIB_STR)
+	return plr[pnum].GetMaximumAttributeValue(attribute_id::ATTRIB_STR)
 	    - plr[pnum]._pBaseStr
-	    + plr[pnum].GetMaximumAttributeValue(ATTRIB_MAG)
+	    + plr[pnum].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG)
 	    - plr[pnum]._pBaseMag
-	    + plr[pnum].GetMaximumAttributeValue(ATTRIB_DEX)
+	    + plr[pnum].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX)
 	    - plr[pnum]._pBaseDex
-	    + plr[pnum].GetMaximumAttributeValue(ATTRIB_VIT)
+	    + plr[pnum].GetMaximumAttributeValue(attribute_id::ATTRIB_VIT)
 	    - plr[pnum]._pBaseVit;
 }
 
@@ -3493,17 +3493,17 @@ void ValidatePlayer()
 	if (gt != plr[myplr]._pGold)
 		plr[myplr]._pGold = gt;
 
-	if (plr[myplr]._pBaseStr > plr[myplr].GetMaximumAttributeValue(ATTRIB_STR)) {
-		plr[myplr]._pBaseStr = plr[myplr].GetMaximumAttributeValue(ATTRIB_STR);
+	if (plr[myplr]._pBaseStr > plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_STR)) {
+		plr[myplr]._pBaseStr = plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_STR);
 	}
-	if (plr[myplr]._pBaseMag > plr[myplr].GetMaximumAttributeValue(ATTRIB_MAG)) {
-		plr[myplr]._pBaseMag = plr[myplr].GetMaximumAttributeValue(ATTRIB_MAG);
+	if (plr[myplr]._pBaseMag > plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG)) {
+		plr[myplr]._pBaseMag = plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG);
 	}
-	if (plr[myplr]._pBaseDex > plr[myplr].GetMaximumAttributeValue(ATTRIB_DEX)) {
-		plr[myplr]._pBaseDex = plr[myplr].GetMaximumAttributeValue(ATTRIB_DEX);
+	if (plr[myplr]._pBaseDex > plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX)) {
+		plr[myplr]._pBaseDex = plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX);
 	}
-	if (plr[myplr]._pBaseVit > plr[myplr].GetMaximumAttributeValue(ATTRIB_VIT)) {
-		plr[myplr]._pBaseVit = plr[myplr].GetMaximumAttributeValue(ATTRIB_VIT);
+	if (plr[myplr]._pBaseVit > plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_VIT)) {
+		plr[myplr]._pBaseVit = plr[myplr].GetMaximumAttributeValue(attribute_id::ATTRIB_VIT);
 	}
 
 	Uint64 msk = 0;
@@ -4052,31 +4052,31 @@ void CheckStats(int p)
 		app_fatal("CheckStats: illegal player %d", p);
 	}
 
-	for (int i = ATTRIB_STR; i <= ATTRIB_VIT; i++) {
-		int maxStatPoint = plr[p].GetMaximumAttributeValue((attribute_id)i);
+	for (auto i : enum_values<attribute_id>()) {
+		int maxStatPoint = plr[p].GetMaximumAttributeValue(i);
 		switch (i) {
-		case ATTRIB_STR:
+		case attribute_id::ATTRIB_STR:
 			if (plr[p]._pBaseStr > maxStatPoint) {
 				plr[p]._pBaseStr = maxStatPoint;
 			} else if (plr[p]._pBaseStr < 0) {
 				plr[p]._pBaseStr = 0;
 			}
 			break;
-		case ATTRIB_MAG:
+		case attribute_id::ATTRIB_MAG:
 			if (plr[p]._pBaseMag > maxStatPoint) {
 				plr[p]._pBaseMag = maxStatPoint;
 			} else if (plr[p]._pBaseMag < 0) {
 				plr[p]._pBaseMag = 0;
 			}
 			break;
-		case ATTRIB_DEX:
+		case attribute_id::ATTRIB_DEX:
 			if (plr[p]._pBaseDex > maxStatPoint) {
 				plr[p]._pBaseDex = maxStatPoint;
 			} else if (plr[p]._pBaseDex < 0) {
 				plr[p]._pBaseDex = 0;
 			}
 			break;
-		case ATTRIB_VIT:
+		case attribute_id::ATTRIB_VIT:
 			if (plr[p]._pBaseVit > maxStatPoint) {
 				plr[p]._pBaseVit = maxStatPoint;
 			} else if (plr[p]._pBaseVit < 0) {
@@ -4093,7 +4093,7 @@ void ModifyPlrStr(int p, int l)
 		app_fatal("ModifyPlrStr: illegal player %d", p);
 	}
 
-	int max = plr[p].GetMaximumAttributeValue(ATTRIB_STR);
+	int max = plr[p].GetMaximumAttributeValue(attribute_id::ATTRIB_STR);
 	if (plr[p]._pBaseStr + l > max) {
 		l = max - plr[p]._pBaseStr;
 	}
@@ -4120,7 +4120,7 @@ void ModifyPlrMag(int p, int l)
 		app_fatal("ModifyPlrMag: illegal player %d", p);
 	}
 
-	int max = plr[p].GetMaximumAttributeValue(ATTRIB_MAG);
+	int max = plr[p].GetMaximumAttributeValue(attribute_id::ATTRIB_MAG);
 	if (plr[p]._pBaseMag + l > max) {
 		l = max - plr[p]._pBaseMag;
 	}
@@ -4155,7 +4155,7 @@ void ModifyPlrDex(int p, int l)
 		app_fatal("ModifyPlrDex: illegal player %d", p);
 	}
 
-	int max = plr[p].GetMaximumAttributeValue(ATTRIB_DEX);
+	int max = plr[p].GetMaximumAttributeValue(attribute_id::ATTRIB_DEX);
 	if (plr[p]._pBaseDex + l > max) {
 		l = max - plr[p]._pBaseDex;
 	}
@@ -4179,7 +4179,7 @@ void ModifyPlrVit(int p, int l)
 		app_fatal("ModifyPlrVit: illegal player %d", p);
 	}
 
-	int max = plr[p].GetMaximumAttributeValue(ATTRIB_VIT);
+	int max = plr[p].GetMaximumAttributeValue(attribute_id::ATTRIB_VIT);
 	if (plr[p]._pBaseVit + l > max) {
 		l = max - plr[p]._pBaseVit;
 	}

--- a/Source/player.h
+++ b/Source/player.h
@@ -41,14 +41,14 @@ enum class HeroClass : uint8_t {
 	LAST = Barbarian
 };
 
-enum class attribute_id : uint8_t {
-	ATTRIB_STR,
-	ATTRIB_MAG,
-	ATTRIB_DEX,
-	ATTRIB_VIT,
+enum class CharacterAttribute : uint8_t {
+	Strength,
+	Magic,
+	Dexterity,
+	Vitality,
 
-	FIRST = ATTRIB_STR,
-	LAST = ATTRIB_VIT
+	FIRST = Strength,
+	LAST = Vitality
 };
 
 // Logical equipment locations
@@ -318,14 +318,14 @@ struct PlayerStruct {
 	 * @param attribute The attribute to retrieve the base value for
 	 * @return The base value for the requested attribute.
 	*/
-	Sint32 GetBaseAttributeValue(attribute_id attribute) const;
+	Sint32 GetBaseAttributeValue(CharacterAttribute attribute) const;
 
 	/**
 	 * @brief Gets the maximum value of the player's specified attribute.
 	 * @param attribute The attribute to retrieve the maximum value for
 	 * @return The maximum value for the requested attribute.
 	*/
-	Sint32 GetMaximumAttributeValue(attribute_id attribute) const;
+	Sint32 GetMaximumAttributeValue(CharacterAttribute attribute) const;
 };
 
 extern int myplr;

--- a/Source/player.h
+++ b/Source/player.h
@@ -41,11 +41,14 @@ enum class HeroClass : uint8_t {
 	LAST = Barbarian
 };
 
-enum attribute_id : uint8_t {
+enum class attribute_id : uint8_t {
 	ATTRIB_STR,
 	ATTRIB_MAG,
 	ATTRIB_DEX,
 	ATTRIB_VIT,
+
+	FIRST = ATTRIB_STR,
+	LAST = ATTRIB_VIT
 };
 
 // Logical equipment locations

--- a/SourceX/miniwin/misc_msg.cpp
+++ b/SourceX/miniwin/misc_msg.cpp
@@ -48,27 +48,27 @@ void FocusOnCharInfo()
 
 	// Find the first incrementable stat.
 	int stat = -1;
-	for (int i = ATTRIB_VIT; i >= ATTRIB_STR; i--) {
-		int max = plr[myplr].GetMaximumAttributeValue((attribute_id)i);
+	for (auto i : enum_values<attribute_id>()) {
+		int max = plr[myplr].GetMaximumAttributeValue(i);
 		switch (i) {
-		case ATTRIB_STR:
+		case attribute_id::ATTRIB_STR:
 			if (plr[myplr]._pBaseStr >= max)
 				continue;
 			break;
-		case ATTRIB_MAG:
+		case attribute_id::ATTRIB_MAG:
 			if (plr[myplr]._pBaseMag >= max)
 				continue;
 			break;
-		case ATTRIB_DEX:
+		case attribute_id::ATTRIB_DEX:
 			if (plr[myplr]._pBaseDex >= max)
 				continue;
 			break;
-		case ATTRIB_VIT:
+		case attribute_id::ATTRIB_VIT:
 			if (plr[myplr]._pBaseVit >= max)
 				continue;
 			break;
 		}
-		stat = i;
+		stat = static_cast<int>(i);
 	}
 	if (stat == -1)
 		return;

--- a/SourceX/miniwin/misc_msg.cpp
+++ b/SourceX/miniwin/misc_msg.cpp
@@ -48,22 +48,22 @@ void FocusOnCharInfo()
 
 	// Find the first incrementable stat.
 	int stat = -1;
-	for (auto i : enum_values<attribute_id>()) {
+	for (auto i : enum_values<CharacterAttribute>()) {
 		int max = plr[myplr].GetMaximumAttributeValue(i);
 		switch (i) {
-		case attribute_id::ATTRIB_STR:
+		case CharacterAttribute::Strength:
 			if (plr[myplr]._pBaseStr >= max)
 				continue;
 			break;
-		case attribute_id::ATTRIB_MAG:
+		case CharacterAttribute::Magic:
 			if (plr[myplr]._pBaseMag >= max)
 				continue;
 			break;
-		case attribute_id::ATTRIB_DEX:
+		case CharacterAttribute::Dexterity:
 			if (plr[myplr]._pBaseDex >= max)
 				continue;
 			break;
-		case attribute_id::ATTRIB_VIT:
+		case CharacterAttribute::Vitality:
 			if (plr[myplr]._pBaseVit >= max)
 				continue;
 			break;


### PR DESCRIPTION
This PR converts the `attribute_id` enum to a scoped enumeration and renames both the enum itself as well as its members.

Adjustments are made to ensure every place accessing the enum for indexing into arrays, converting into other values and iterating over all the attributes are handled appropriately.