### PR TITLE
Monsterhp

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -471,12 +471,10 @@ void InitMonster(int i, int rd, int mtype, int x, int y)
 	monster[i]._mAnimFrame = random_(88, monster[i]._mAnimLen - 1) + 1;
 
 	monster[i].mLevel = monst->MData->mLevel;
-	if (monst->mtype == MT_DIABLO) {
-		monster[i]._mmaxhp = (random_(88, 1) + (gbIsHellfire ? 3333 : 1666)) << 6;
-		if (!gbIsHellfire)
-			monster[i].mLevel -= 15;
-	} else {
-		monster[i]._mmaxhp = (monst->mMinHP + random_(88, monst->mMaxHP - monst->mMinHP + 1)) << 6;
+	monster[i]._mmaxhp = (monst->mMinHP + random_(88, monst->mMaxHP - monst->mMinHP + 1)) << 6;
+	if (monst->mtype == MT_DIABLO && !gbIsHellfire) {
+		monster[i]._mmaxhp /= 2;
+		monster[i].mLevel -= 15;
 	}
 
 	if (!gbIsMultiplayer) {

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -109,8 +109,8 @@ struct CMonster {
 	TSnd *Snds[4][2];
 	Sint32 width;
 	Sint32 width2;
-	Uint8 mMinHP;
-	Uint8 mMaxHP;
+	uint16_t mMinHP;
+	uint16_t mMaxHP;
 	bool has_special;
 	Uint8 mAFNum;
 	Sint8 mdeadval;


### PR DESCRIPTION
Some hellfire monsters did not have the correct HP, this also allows us to remove an old vanilla hack for applying Diablos correct HP.