### PR TITLE
Tag flag enums with __attribute__((flag_enum))

### DIFF
--- a/Source/effects.h
+++ b/Source/effects.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include "../defs.h"
 #include "sound.h"
 
 namespace devilution {
@@ -1043,7 +1044,7 @@ enum _sfx_id : int16_t {
 	SFX_NONE = -1,
 };
 
-enum sfx_flag : uint8_t {
+enum DVL_FLAG_ENUM_ATTRIBUTE sfx_flag : uint8_t {
 	// clang-format off
 	sfx_STREAM   = 1 << 0,
 	sfx_MISC     = 1 << 1,

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include "../defs.h"
 #include "scrollrt.h"
 
 namespace devilution {
@@ -42,7 +43,7 @@ enum lvl_entry : uint8_t {
 	ENTRY_TWARPUP,
 };
 
-enum {
+enum DVL_FLAG_ENUM_ATTRIBUTE _dlrg_l5_dflags {
 	// clang-format off
 	DLRG_HDOOR     = 1 << 0,
 	DLRG_VDOOR     = 1 << 1,
@@ -51,7 +52,7 @@ enum {
 	// clang-format on
 };
 
-enum {
+enum DVL_FLAG_ENUM_ATTRIBUTE _dungeon_bflags {
 	// clang-format off
 	BFLAG_MISSILE     = 1 << 0,
 	BFLAG_VISIBLE     = 1 << 1,

--- a/Source/itemdat.h
+++ b/Source/itemdat.h
@@ -8,6 +8,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "../defs.h"
+
 namespace devilution {
 
 /** @todo add missing values and apply */
@@ -311,7 +313,7 @@ enum unique_base_item : int8_t {
 	UITYPE_INVALID = -1,
 };
 
-enum item_special_effect {
+enum DVL_FLAG_ENUM_ATTRIBUTE item_special_effect {
 	// clang-format off
 	ISPL_NONE           = 0,
 	ISPL_INFRAVISION    = 1 << 0,
@@ -539,7 +541,7 @@ enum goodorevil : uint8_t {
 	GOE_GOOD,
 };
 
-enum affix_item_type : uint8_t {
+enum DVL_FLAG_ENUM_ATTRIBUTE affix_item_type : uint8_t {
 	// clang-format off
 	PLT_MISC  = 1 << 0,
 	PLT_BOW   = 1 << 1,

--- a/Source/items.h
+++ b/Source/items.h
@@ -127,7 +127,7 @@ enum _unique_items : int8_t {
  combining CF_UPER15 and CF_UPER1 flags (CF_USEFUL) is used to mark potions and town portal scrolls created on the ground
  CF_TOWN is combining all store flags and indicates if item has been bought from a NPC
  */
-enum icreateinfo_flag {
+enum DVL_FLAG_ENUM_ATTRIBUTE icreateinfo_flag {
 	// clang-format off
 	CF_LEVEL        = (1 << 6) - 1,
 	CF_ONLYGOOD     = 1 << 6,

--- a/Source/monstdat.h
+++ b/Source/monstdat.h
@@ -7,6 +7,8 @@
 
 #include <stdint.h>
 
+#include "../defs.h"
+
 namespace devilution {
 
 enum _mai_id : int8_t {
@@ -59,7 +61,7 @@ enum _mc_id : uint8_t {
 	MC_ANIMAL,
 };
 
-enum monster_resistance : uint8_t {
+enum DVL_FLAG_ENUM_ATTRIBUTE monster_resistance : uint8_t {
 	// clang-format off
 	RESIST_MAGIC     = 1 << 0,
 	RESIST_FIRE      = 1 << 1,

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -7,9 +7,11 @@
 
 #include <stdint.h>
 
+#include "../defs.h"
+
 namespace devilution {
 
-enum monster_flag : uint16_t {
+enum DVL_FLAG_ENUM_ATTRIBUTE monster_flag : uint16_t {
 	// clang-format off
 	MFLAG_HIDDEN          = 1 << 0,
 	MFLAG_LOCK_ANIMATION  = 1 << 1,

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -4314,7 +4314,7 @@ void InitDungMsgs(int pnum)
 	plr[pnum].pDungMsgs2 = 0;
 }
 
-enum {
+enum DVL_FLAG_ENUM_ATTRIBUTE _dmsg_flags {
 	// clang-format off
 	DMSG_CATHEDRAL = 1 << 0,
 	DMSG_CATACOMBS = 1 << 1,

--- a/Source/player.h
+++ b/Source/player.h
@@ -63,7 +63,7 @@ enum inv_body_loc : uint8_t {
 	NUM_INVLOC,
 };
 
-enum player_graphic : uint16_t {
+enum DVL_FLAG_ENUM_ATTRIBUTE player_graphic : uint16_t {
 	// clang-format off
 	PFILE_STAND     = 1 << 0,
 	PFILE_WALK      = 1 << 1,

--- a/SourceX/DiabloUI/ui_item.h
+++ b/SourceX/DiabloUI/ui_item.h
@@ -24,7 +24,7 @@ enum UiType : uint8_t {
 	UI_EDIT,
 };
 
-enum UiFlags : uint16_t {
+enum DVL_FLAG_ENUM_ATTRIBUTE UiFlags : uint16_t {
 	// clang-format off
 	UIS_SMALL    = 1 << 0,
 	UIS_MED      = 1 << 1,

--- a/defs.h
+++ b/defs.h
@@ -210,3 +210,9 @@
 #else
 #define DVL_PRINTF_ATTRIBUTE(fmtargnum)
 #endif
+
+#if DVL_HAVE_ATTRIBUTE(flag_enum)
+#define DVL_FLAG_ENUM_ATTRIBUTE __attribute__((flag_enum))
+#else
+#define DVL_FLAG_ENUM_ATTRIBUTE
+#endif


### PR DESCRIPTION
> This attribute can be added to an enumerator to signal to the compiler that it is intended to be used as a flag type. This will cause the compiler to assume that the range of the type includes all of the values that you can get by manipulating bits of the enumerator when issuing warnings.

https://clang.llvm.org/docs/AttributeReference.html#flag-enum