### PR TITLE
Consolidate logic for Mana Shield and player damage.

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -927,14 +927,6 @@ void CalcPlrItemVals(int p, bool Loadgfx)
 		plr[p]._pgfxnum = g;
 	}
 
-	for (i = 0; i < nummissiles; i++) {
-		mi = missileactive[i];
-		if (missile[mi]._mitype == MIS_MANASHIELD && missile[mi]._misource == p) {
-			missile[mi]._miVar1 = plr[p]._pHitPoints;
-			missile[mi]._miVar2 = plr[p]._pHPBase;
-			break;
-		}
-	}
 	if (plr[p].InvBody[INVLOC_AMULET].isEmpty() || plr[p].InvBody[INVLOC_AMULET].IDidx != IDI_AURIC) {
 		int half = MaxGold;
 		MaxGold = GOLD_MAX_LIMIT;

--- a/Source/misdat.cpp
+++ b/Source/misdat.cpp
@@ -26,7 +26,7 @@ MissileData missiledata[] = {
 	{  &AddTown,                   &MI_Town,           MIS_TOWN,          true,      1, MISR_MAGIC,     MFILE_PORTAL,    LS_SENTINEL, LS_ELEMENTL },
 	{  &AddFlash,                  &MI_Flash,          MIS_FLASH,         true,      1, MISR_MAGIC,     MFILE_BLUEXFR,   LS_NOVA,     LS_ELECIMP1 },
 	{  &AddFlash2,                 &MI_Flash2,         MIS_FLASH2,        true,      1, MISR_MAGIC,     MFILE_BLUEXBK,   SFX_NONE,    SFX_NONE    },
-	{  &AddManashield,             &MI_SetManashield,  MIS_MANASHIELD,    false,     1, MISR_MAGIC,     MFILE_MANASHLD,  LS_MSHIELD,  SFX_NONE    },
+	{  &AddManashield,             &MI_Manashield,     MIS_MANASHIELD,    false,     1, MISR_MAGIC,     MFILE_MANASHLD,  LS_MSHIELD,  SFX_NONE    },
 	{  &AddFiremove,               &MI_Firemove,       MIS_FIREMOVE,      true,      1, MISR_FIRE,      MFILE_FIREWAL,   SFX_NONE,    SFX_NONE    },
 	{  &AddChain,                  &MI_Chain,          MIS_CHAIN,         true,      1, MISR_LIGHTNING, MFILE_LGHNING,   LS_LNING1,   LS_ELECIMP1 },
 	{  NULL,                       NULL,               MIS_SENTINAL,      true,      1, MISR_LIGHTNING, MFILE_LGHNING,   SFX_NONE,    SFX_NONE    },

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -178,7 +178,7 @@ void AddDiabApoca(Sint32 mi, Sint32 sx, Sint32 sy, Sint32 dx, Sint32 dy, Sint32 
 int AddMissile(int sx, int sy, int dx, int dy, int midir, int mitype, int8_t micaster, int id, int midam, int spllvl);
 void MI_Dummy(Sint32 i);
 void MI_Golem(Sint32 i);
-void MI_SetManashield(Sint32 i);
+void MI_Manashield(Sint32 i);
 void MI_LArrow(Sint32 i);
 void MI_Arrow(Sint32 i);
 void MI_Firebolt(Sint32 i);

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -2263,8 +2263,7 @@ void M_TryH2HHit(int i, int pnum, int Hit, int MinDam, int MaxDam)
 			else
 				M_StartHit(i, pnum, mdam);
 		}
-		plr[pnum]._pHitPoints -= dam;
-		plr[pnum]._pHPBase -= dam;
+		ApplyPlrDamage(pnum, 0, 0, dam);
 	}
 	if (plr[pnum]._pIFlags & ISPL_THORNS) {
 		mdam = (random_(99, 3) + 1) << 6;
@@ -2276,12 +2275,7 @@ void M_TryH2HHit(int i, int pnum, int Hit, int MinDam, int MaxDam)
 	}
 	if (!(monster[i]._mFlags & MFLAG_NOLIFESTEAL) && monster[i].MType->mtype == MT_SKING && gbIsMultiplayer)
 		monster[i]._mhitpoints += dam;
-	if (plr[pnum]._pHitPoints > plr[pnum]._pMaxHP) {
-		plr[pnum]._pHitPoints = plr[pnum]._pMaxHP;
-		plr[pnum]._pHPBase = plr[pnum]._pMaxHPBase;
-	}
 	if (plr[pnum]._pHitPoints >> 6 <= 0) {
-		SyncPlrKill(pnum, 0);
 		if (gbIsHellfire)
 			M_StartStand(i, monster[i]._mdir);
 		return;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2066,16 +2066,7 @@ static DWORD On_PLRDAMAGE(TCmd *pCmd, int pnum)
 
 	if (p->bPlr == myplr && currlevel != 0 && gbBufferMsgs != 1) {
 		if (currlevel == plr[pnum].plrlevel && p->dwDam <= 192000 && plr[myplr]._pHitPoints >> 6 > 0) {
-			drawhpflag = true;
-			plr[myplr]._pHitPoints -= p->dwDam;
-			plr[myplr]._pHPBase -= p->dwDam;
-			if (plr[myplr]._pHitPoints > plr[myplr]._pMaxHP) {
-				plr[myplr]._pHitPoints = plr[myplr]._pMaxHP;
-				plr[myplr]._pHPBase = plr[myplr]._pMaxHPBase;
-			}
-			if (plr[myplr]._pHitPoints >> 6 <= 0) {
-				SyncPlrKill(myplr, 1);
-			}
+			ApplyPlrDamage(myplr, 0, 0, p->dwDam, 1);
 		}
 	}
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2135,11 +2135,8 @@ void Obj_BCrossDamage(int i)
 	if (plr[myplr]._px != object[i]._ox || plr[myplr]._py != object[i]._oy - 1)
 		return;
 
-	plr[myplr]._pHitPoints -= damage[leveltype - 1];
-	plr[myplr]._pHPBase -= damage[leveltype - 1];
-	if (plr[myplr]._pHitPoints >> 6 <= 0) {
-		SyncPlrKill(myplr, 0);
-	} else {
+	ApplyPlrDamage(myplr, 0, 0, damage[leveltype - 1]);
+	if (plr[myplr]._pHitPoints >> 6 > 0) {
 		if (plr[myplr]._pClass == HeroClass::Warrior) {
 			PlaySfxLoc(PS_WARR68, plr[myplr]._px, plr[myplr]._py);
 		} else if (plr[myplr]._pClass == HeroClass::Rogue) {
@@ -2154,7 +2151,6 @@ void Obj_BCrossDamage(int i)
 			PlaySfxLoc(PS_WARR68, plr[myplr]._px, plr[myplr]._py);
 		}
 	}
-	drawhpflag = true;
 }
 
 void ProcessObjects()

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2009,24 +2009,65 @@ void StripTopGold(int pnum)
 	plr[pnum].HoldItem = tmpItem;
 }
 
-void SyncPlrKill(int pnum, int earflag)
+void ApplyPlrDamage(int pnum, int dam, int minHP /*= 0*/, int frac /*= 0*/, int earflag /*= 0*/)
 {
 	int ma, i;
+	int totalDamage;
+	int minHitPoints;
 
+	totalDamage = (dam << 6) + frac;
+	if (totalDamage > 0) {
+		for (i = 0; i < nummissiles; i++) {
+			ma = missileactive[i];
+			if (missile[ma]._mitype == MIS_MANASHIELD && missile[ma]._misource == pnum && !missile[ma]._miDelFlag) {
+				if (missile[ma]._mispllvl > 0) {
+					totalDamage += totalDamage / -3;
+				}
+
+				drawmanaflag = true;
+				if (plr[pnum]._pMana >= totalDamage) {
+					plr[pnum]._pMana -= totalDamage;
+					plr[pnum]._pManaBase -= totalDamage;
+					totalDamage = 0;
+				} else {
+					totalDamage -= plr[pnum]._pMana;
+					if (missile[ma]._mispllvl > 0) {
+						totalDamage += totalDamage / 2;
+					}
+					plr[pnum]._pMana = 0;
+					plr[pnum]._pManaBase = plr[pnum]._pMaxManaBase - plr[pnum]._pMaxMana;
+				}
+
+				break;
+			}
+		}
+	}
+
+	if (totalDamage == 0)
+		return;
+
+	drawhpflag = true;
+	plr[pnum]._pHitPoints -= totalDamage;
+	plr[pnum]._pHPBase -= totalDamage;
+	if (plr[pnum]._pHitPoints > plr[pnum]._pMaxHP) {
+		plr[pnum]._pHitPoints = plr[pnum]._pMaxHP;
+		plr[pnum]._pHPBase = plr[pnum]._pMaxHPBase;
+	}
+	minHitPoints = minHP << 6;
+	if (plr[pnum]._pHitPoints < minHitPoints) {
+		plr[pnum]._pHitPoints = minHitPoints;
+		plr[pnum]._pHPBase = minHitPoints + plr[pnum]._pMaxHPBase - plr[pnum]._pMaxHP;
+	}
+	if (plr[pnum]._pHitPoints >> 6 <= 0) {
+		SyncPlrKill(pnum, earflag);
+	}
+}
+
+void SyncPlrKill(int pnum, int earflag)
+{
 	if (plr[pnum]._pHitPoints <= 0 && currlevel == 0) {
 		SetPlayerHitPoints(pnum, 64);
 		return;
-	}
-
-	for (i = 0; i < nummissiles; i++) {
-		ma = missileactive[i];
-		if (missile[ma]._mitype == MIS_MANASHIELD && missile[ma]._misource == pnum && !missile[ma]._miDelFlag) {
-			if (earflag != -1) {
-				missile[ma]._miVar8 = earflag;
-			}
-
-			return;
-		}
 	}
 
 	SetPlayerHitPoints(pnum, 0);
@@ -2519,14 +2560,7 @@ bool PlrHitMonst(int pnum, int m)
 			if (plr[pnum].pDamAcFlags & 0x04) {
 				dam2 += plr[pnum]._pIGetHit << 6;
 				if (dam2 >= 0) {
-					if (plr[pnum]._pHitPoints > dam2) {
-						plr[pnum]._pHitPoints -= dam2;
-						plr[pnum]._pHPBase -= dam2;
-					} else {
-						dam2 = (1 << 6);
-						plr[pnum]._pHPBase -= plr[pnum]._pHitPoints - dam2;
-						plr[pnum]._pHitPoints = dam2;
-					}
+					ApplyPlrDamage(pnum, 0, 1, dam2);
 				}
 				dam <<= 1;
 			}
@@ -3604,12 +3638,7 @@ void ProcessPlayers()
 
 			if (pnum == myplr) {
 				if ((plr[pnum]._pIFlags & ISPL_DRAINLIFE) && currlevel != 0) {
-					plr[pnum]._pHitPoints -= 4;
-					plr[pnum]._pHPBase -= 4;
-					if ((plr[pnum]._pHitPoints >> 6) <= 0) {
-						SyncPlrKill(pnum, 0);
-					}
-					drawhpflag = true;
+					ApplyPlrDamage(pnum, 0, 0, 4);
 				}
 				if (plr[pnum]._pIFlags & ISPL_NOMANA && plr[pnum]._pManaBase > 0) {
 					plr[pnum]._pManaBase -= plr[pnum]._pMana;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2051,8 +2051,7 @@ void ApplyPlrDamage(int pnum, int dam, int minHP /*= 0*/, int frac /*= 0*/, int 
 	}
 	int minHitPoints = minHP << 6;
 	if (plr[pnum]._pHitPoints < minHitPoints) {
-		plr[pnum]._pHitPoints = minHitPoints;
-		plr[pnum]._pHPBase = minHitPoints + plr[pnum]._pMaxHPBase - plr[pnum]._pMaxHP;
+		SetPlayerHitPoints(pnum, minHitPoints);
 	}
 	if (plr[pnum]._pHitPoints >> 6 <= 0) {
 		SyncPlrKill(pnum, earflag);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2011,14 +2011,10 @@ void StripTopGold(int pnum)
 
 void ApplyPlrDamage(int pnum, int dam, int minHP /*= 0*/, int frac /*= 0*/, int earflag /*= 0*/)
 {
-	int ma, i;
-	int totalDamage;
-	int minHitPoints;
-
-	totalDamage = (dam << 6) + frac;
+	int totalDamage = (dam << 6) + frac;
 	if (totalDamage > 0) {
-		for (i = 0; i < nummissiles; i++) {
-			ma = missileactive[i];
+		for (int i = 0; i < nummissiles; i++) {
+			int ma = missileactive[i];
 			if (missile[ma]._mitype == MIS_MANASHIELD && missile[ma]._misource == pnum && !missile[ma]._miDelFlag) {
 				if (missile[ma]._mispllvl > 0) {
 					totalDamage += totalDamage / -3;
@@ -2053,7 +2049,7 @@ void ApplyPlrDamage(int pnum, int dam, int minHP /*= 0*/, int frac /*= 0*/, int 
 		plr[pnum]._pHitPoints = plr[pnum]._pMaxHP;
 		plr[pnum]._pHPBase = plr[pnum]._pMaxHPBase;
 	}
-	minHitPoints = minHP << 6;
+	int minHitPoints = minHP << 6;
 	if (plr[pnum]._pHitPoints < minHitPoints) {
 		plr[pnum]._pHitPoints = minHitPoints;
 		plr[pnum]._pHPBase = minHitPoints + plr[pnum]._pMaxHPBase - plr[pnum]._pMaxHP;

--- a/Source/player.h
+++ b/Source/player.h
@@ -406,6 +406,7 @@ void NextPlrLevel(int pnum);
 #endif
 void AddPlrExperience(int pnum, int lvl, int exp);
 void AddPlrMonstExper(int lvl, int exp, char pmask);
+void ApplyPlrDamage(int pnum, int dam, int minHP = 0, int frac = 0, int earflag = 0);
 void InitPlayer(int pnum, bool FirstTime);
 void InitMultiView();
 bool SolidLoc(int x, int y);


### PR DESCRIPTION
This resolves #1353
This resolves #1111

Based on my testing, the hit-recovery bug does not affect PvP.

I edited a character's stats to make testing easier. Here is a save file.
[single_0.sv.zip](https://github.com/diasurgical/devilutionX/files/6301584/single_0.sv.zip)

Missles can be tested against skeleton archers on dlvl 2. Head northwest to reach the stairs.