### PR TITLE
false_avail: Remove `__vita__` workaround

### DIFF
--- a/SourceX/miniwin/misc_msg.cpp
+++ b/SourceX/miniwin/misc_msg.cpp
@@ -262,10 +262,7 @@ WPARAM keystate_for_mouse(WPARAM ret)
 
 bool false_avail(const char *name, int value)
 {
-#ifndef __vita__
-	// Logging on Vita is slow due slow IO, so disable spamming unhandled events to log
 	SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "Unhandled SDL event: %s %d", name, value);
-#endif
 	return true;
 }
 


### PR DESCRIPTION
No longer necessary as of [`dae4cc8` (#1484)](https://github.com/diasurgical/devilutionX/pull/1484/commits/dae4cc8c50a41f173f1432b5f81a0023fa23d45b)

The default minimum priority log level in release builds is INFO

/cc @isage 