### PR TITLE
Exposes player number from multi_send_packet

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -677,7 +677,7 @@ static bool LeftMouseCmd(bool bShift)
 			NetSendCmdLocParam1(true, pcurs == CURSOR_DISARM ? CMD_DISARMXY : CMD_OPOBJXY, cursmx, cursmy, pcursobj);
 		} else if (plr[myplr]._pwtype == WT_RANGED) {
 			if (bShift) {
-				NetSendCmdLoc(true, CMD_RATTACKXY, cursmx, cursmy);
+				NetSendCmdLoc(myplr, true, CMD_RATTACKXY, cursmx, cursmy);
 			} else if (pcursmonst != -1) {
 				if (CanTalkToMonst(pcursmonst)) {
 					NetSendCmdParam1(true, CMD_ATTACKID, pcursmonst);
@@ -693,10 +693,10 @@ static bool LeftMouseCmd(bool bShift)
 					if (CanTalkToMonst(pcursmonst)) {
 						NetSendCmdParam1(true, CMD_ATTACKID, pcursmonst);
 					} else {
-						NetSendCmdLoc(true, CMD_SATTACKXY, cursmx, cursmy);
+						NetSendCmdLoc(myplr, true, CMD_SATTACKXY, cursmx, cursmy);
 					}
 				} else {
-					NetSendCmdLoc(true, CMD_SATTACKXY, cursmx, cursmy);
+					NetSendCmdLoc(myplr, true, CMD_SATTACKXY, cursmx, cursmy);
 				}
 			} else if (pcursmonst != -1) {
 				NetSendCmdParam1(true, CMD_ATTACKID, pcursmonst);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4340,7 +4340,7 @@ void UseItem(int p, item_misc_id Mid, spell_id spl)
 			plr[p].destParam1 = cursmx;
 			plr[p].destParam2 = cursmy;
 			if (p == myplr && spl == SPL_NOVA)
-				NetSendCmdLoc(true, CMD_NOVA, cursmx, cursmy);
+				NetSendCmdLoc(myplr, true, CMD_NOVA, cursmx, cursmy);
 		}
 		break;
 	case IMISC_SCROLLT:

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -838,9 +838,9 @@ void NetSendCmd(bool bHiPri, _cmd_id bCmd)
 
 	cmd.bCmd = bCmd;
 	if (bHiPri)
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdGolem(BYTE mx, BYTE my, BYTE dir, BYTE menemy, int hp, BYTE cl)
@@ -854,10 +854,10 @@ void NetSendCmdGolem(BYTE mx, BYTE my, BYTE dir, BYTE menemy, int hp, BYTE cl)
 	cmd._menemy = menemy;
 	cmd._mhitpoints = hp;
 	cmd._currlevel = cl;
-	NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+	NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
-void NetSendCmdLoc(bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y)
+void NetSendCmdLoc(int playerId, bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y)
 {
 	ALIGN_BY_1 TCmdLoc cmd;
 
@@ -865,9 +865,9 @@ void NetSendCmdLoc(bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y)
 	cmd.x = x;
 	cmd.y = y;
 	if (bHiPri)
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(playerId, (BYTE *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendLoPri(playerId, (BYTE *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdLocParam1(bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y, WORD wParam1)
@@ -879,9 +879,9 @@ void NetSendCmdLocParam1(bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y, WORD wParam1
 	cmd.y = y;
 	cmd.wParam1 = wParam1;
 	if (bHiPri)
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdLocParam2(bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y, WORD wParam1, WORD wParam2)
@@ -894,9 +894,9 @@ void NetSendCmdLocParam2(bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y, WORD wParam1
 	cmd.wParam1 = wParam1;
 	cmd.wParam2 = wParam2;
 	if (bHiPri)
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdLocParam3(bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y, WORD wParam1, WORD wParam2, WORD wParam3)
@@ -910,9 +910,9 @@ void NetSendCmdLocParam3(bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y, WORD wParam1
 	cmd.wParam2 = wParam2;
 	cmd.wParam3 = wParam3;
 	if (bHiPri)
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdParam1(bool bHiPri, _cmd_id bCmd, WORD wParam1)
@@ -922,9 +922,9 @@ void NetSendCmdParam1(bool bHiPri, _cmd_id bCmd, WORD wParam1)
 	cmd.bCmd = bCmd;
 	cmd.wParam1 = wParam1;
 	if (bHiPri)
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdParam2(bool bHiPri, _cmd_id bCmd, WORD wParam1, WORD wParam2)
@@ -935,9 +935,9 @@ void NetSendCmdParam2(bool bHiPri, _cmd_id bCmd, WORD wParam1, WORD wParam2)
 	cmd.wParam1 = wParam1;
 	cmd.wParam2 = wParam2;
 	if (bHiPri)
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdParam3(bool bHiPri, _cmd_id bCmd, WORD wParam1, WORD wParam2, WORD wParam3)
@@ -949,9 +949,9 @@ void NetSendCmdParam3(bool bHiPri, _cmd_id bCmd, WORD wParam1, WORD wParam2, WOR
 	cmd.wParam2 = wParam2;
 	cmd.wParam3 = wParam3;
 	if (bHiPri)
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdQuest(bool bHiPri, BYTE q)
@@ -964,9 +964,9 @@ void NetSendCmdQuest(bool bHiPri, BYTE q)
 	cmd.qlog = quests[q]._qlog;
 	cmd.qvar1 = quests[q]._qvar1;
 	if (bHiPri)
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdGItem(bool bHiPri, _cmd_id bCmd, BYTE mast, BYTE pnum, BYTE ii)
@@ -1012,9 +1012,9 @@ void NetSendCmdGItem(bool bHiPri, _cmd_id bCmd, BYTE mast, BYTE pnum, BYTE ii)
 	}
 
 	if (bHiPri)
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdGItem2(bool usonly, _cmd_id bCmd, BYTE mast, BYTE pnum, TCmdGItem *p)
@@ -1028,7 +1028,7 @@ void NetSendCmdGItem2(bool usonly, _cmd_id bCmd, BYTE mast, BYTE pnum, TCmdGItem
 
 	if (!usonly) {
 		cmd.dwTime = 0;
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 		return;
 	}
 
@@ -1069,7 +1069,7 @@ void NetSendCmdExtra(TCmdGItem *p)
 	memcpy(&cmd, p, sizeof(cmd));
 	cmd.dwTime = 0;
 	cmd.bCmd = CMD_ITEMEXTRA;
-	NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+	NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y)
@@ -1110,9 +1110,9 @@ void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y)
 	}
 
 	if (bHiPri)
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdChItem(bool bHiPri, BYTE bLoc)
@@ -1128,9 +1128,9 @@ void NetSendCmdChItem(bool bHiPri, BYTE bLoc)
 	cmd.dwBuff = plr[myplr].HoldItem.dwBuff;
 
 	if (bHiPri)
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdDelItem(bool bHiPri, BYTE bLoc)
@@ -1140,9 +1140,9 @@ void NetSendCmdDelItem(bool bHiPri, BYTE bLoc)
 	cmd.bLoc = bLoc;
 	cmd.bCmd = CMD_DELPLRITEMS;
 	if (bHiPri)
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdDItem(bool bHiPri, int ii)
@@ -1183,9 +1183,9 @@ void NetSendCmdDItem(bool bHiPri, int ii)
 	}
 
 	if (bHiPri)
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
 static bool i_own_level(int nReqLevel)
@@ -1214,9 +1214,9 @@ void NetSendCmdDamage(bool bHiPri, BYTE bPlr, DWORD dwDam)
 	cmd.bPlr = bPlr;
 	cmd.dwDam = dwDam;
 	if (bHiPri)
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdMonDmg(bool bHiPri, WORD wMon, DWORD dwDam)
@@ -1227,9 +1227,9 @@ void NetSendCmdMonDmg(bool bHiPri, WORD wMon, DWORD dwDam)
 	cmd.wMon = wMon;
 	cmd.dwDam = dwDam;
 	if (bHiPri)
-		NetSendHiPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendHiPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri((BYTE *)&cmd, sizeof(cmd));
+		NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdString(int pmask, const char *pszStr)

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -427,7 +427,7 @@ void DeltaSaveLevel();
 void DeltaLoadLevel();
 void NetSendCmd(bool bHiPri, _cmd_id bCmd);
 void NetSendCmdGolem(BYTE mx, BYTE my, BYTE dir, BYTE menemy, int hp, BYTE cl);
-void NetSendCmdLoc(bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y);
+void NetSendCmdLoc(int playerId, bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y);
 void NetSendCmdLocParam1(bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y, WORD wParam1);
 void NetSendCmdLocParam2(bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y, WORD wParam1, WORD wParam2);
 void NetSendCmdLocParam3(bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y, WORD wParam1, WORD wParam2, WORD wParam3);

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -125,26 +125,26 @@ void multi_msg_add(BYTE *pbMsg, BYTE bLen)
 	}
 }
 
-static void multi_send_packet(void *packet, BYTE dwSize)
+static void multi_send_packet(int playerId, void *packet, BYTE dwSize)
 {
 	TPkt pkt;
 
 	NetRecvPlrData(&pkt);
 	pkt.hdr.wLen = dwSize + sizeof(pkt.hdr);
 	memcpy(pkt.body, packet, dwSize);
-	if (!SNetSendMessage(myplr, &pkt.hdr, pkt.hdr.wLen))
+	if (!SNetSendMessage(playerId, &pkt.hdr, pkt.hdr.wLen))
 		nthread_terminate_game("SNetSendMessage0");
 }
 
-void NetSendLoPri(BYTE *pbMsg, BYTE bLen)
+void NetSendLoPri(int playerId, BYTE *pbMsg, BYTE bLen)
 {
 	if (pbMsg && bLen) {
 		multi_copy_packet(&sgLoPriBuf, pbMsg, bLen);
-		multi_send_packet(pbMsg, bLen);
+		multi_send_packet(playerId, pbMsg, bLen);
 	}
 }
 
-void NetSendHiPri(BYTE *pbMsg, BYTE bLen)
+void NetSendHiPri(int playerId, BYTE *pbMsg, BYTE bLen)
 {
 	BYTE *hipri_body;
 	BYTE *lowpri_body;
@@ -153,7 +153,7 @@ void NetSendHiPri(BYTE *pbMsg, BYTE bLen)
 
 	if (pbMsg && bLen) {
 		multi_copy_packet(&sgHiPriBuf, pbMsg, bLen);
-		multi_send_packet(pbMsg, bLen);
+		multi_send_packet(playerId, pbMsg, bLen);
 	}
 	if (!gbShouldValidatePackage) {
 		gbShouldValidatePackage = true;
@@ -403,12 +403,12 @@ int multi_handle_delta()
 	sgbTimeout = false;
 	if (received) {
 		if (!gbShouldValidatePackage) {
-			NetSendHiPri(0, 0);
+			NetSendHiPri(myplr, 0, 0);
 			gbShouldValidatePackage = false;
 		} else {
 			gbShouldValidatePackage = false;
 			if (!multi_check_pkt_valid(&sgHiPriBuf))
-				NetSendHiPri(0, 0);
+				NetSendHiPri(myplr, 0, 0);
 		}
 	}
 	multi_mon_seeds();

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -45,8 +45,8 @@ extern BYTE gbDeltaSender;
 extern int player_state[MAX_PLRS];
 
 void multi_msg_add(BYTE *pbMsg, BYTE bLen);
-void NetSendLoPri(BYTE *pbMsg, BYTE bLen);
-void NetSendHiPri(BYTE *pbMsg, BYTE bLen);
+void NetSendLoPri(int playerId, BYTE *pbMsg, BYTE bLen);
+void NetSendHiPri(int playerId, BYTE *pbMsg, BYTE bLen);
 void multi_send_msg_packet(int pmask, BYTE *src, BYTE len);
 void multi_msg_countdown();
 void multi_player_left(int pnum, int reason);

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -30,7 +30,7 @@ void track_process()
 		Uint32 tick = SDL_GetTicks();
 		if ((int)(tick - sgdwLastWalk) >= gnTickDelay * 6) {
 			sgdwLastWalk = tick;
-			NetSendCmdLoc(true, CMD_WALKXY, cursmx, cursmy);
+			NetSendCmdLoc(myplr, true, CMD_WALKXY, cursmx, cursmy);
 			if (!sgbIsScrolling)
 				sgbIsScrolling = true;
 		}
@@ -46,7 +46,7 @@ void track_repeat_walk(bool rep)
 	if (rep) {
 		sgbIsScrolling = false;
 		sgdwLastWalk = SDL_GetTicks() - gnTickDelay;
-		NetSendCmdLoc(true, CMD_WALKXY, cursmx, cursmy);
+		NetSendCmdLoc(myplr, true, CMD_WALKXY, cursmx, cursmy);
 	} else if (sgbIsScrolling) {
 		sgbIsScrolling = false;
 	}

--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -847,7 +847,7 @@ void CheckTriggers()
 		switch (trigs[i]._tmsg) {
 		case WM_DIABNEXTLVL:
 			if (gbIsSpawn && currlevel >= 2) {
-				NetSendCmdLoc(true, CMD_WALKXY, plr[myplr]._px, plr[myplr]._py + 1);
+				NetSendCmdLoc(myplr, true, CMD_WALKXY, plr[myplr]._px, plr[myplr]._py + 1);
 				PlaySFX(PS_WARR18);
 				InitDiabloMsg(EMSG_NOT_IN_SHAREWARE);
 			} else {
@@ -903,7 +903,7 @@ void CheckTriggers()
 					}
 
 					InitDiabloMsg(abortflag);
-					NetSendCmdLoc(true, CMD_WALKXY, x, y);
+					NetSendCmdLoc(myplr, true, CMD_WALKXY, x, y);
 					return;
 				}
 			}

--- a/SourceX/controls/plrctrls.cpp
+++ b/SourceX/controls/plrctrls.cpp
@@ -800,26 +800,26 @@ bool IsPathBlocked(int x, int y, int dir)
 	return !PosOkPlayer(myplr, d1x, d1y) && !PosOkPlayer(myplr, d2x, d2y);
 }
 
-void WalkInDir(AxisDirection dir)
+void WalkInDir(int playerId, AxisDirection dir)
 {
-	const int x = plr[myplr]._pfutx;
-	const int y = plr[myplr]._pfuty;
+	const int x = plr[playerId]._pfutx;
+	const int y = plr[playerId]._pfuty;
 
 	if (dir.x == AxisDirectionX_NONE && dir.y == AxisDirectionY_NONE) {
-		if (sgbControllerActive && plr[myplr].walkpath[0] != WALK_NONE && plr[myplr].destAction == ACTION_NONE)
-			NetSendCmdLoc(true, CMD_WALKXY, x, y); // Stop walking
+		if (sgbControllerActive && plr[playerId].walkpath[0] != WALK_NONE && plr[playerId].destAction == ACTION_NONE)
+			NetSendCmdLoc(playerId, true, CMD_WALKXY, x, y); // Stop walking
 		return;
 	}
 
 	const direction pdir = kFaceDir[static_cast<std::size_t>(dir.x)][static_cast<std::size_t>(dir.y)];
 	const int dx = x + kOffsets[pdir][0];
 	const int dy = y + kOffsets[pdir][1];
-	plr[myplr]._pdir = pdir;
+	plr[playerId]._pdir = pdir;
 
-	if (PosOkPlayer(myplr, dx, dy) && IsPathBlocked(x, y, pdir))
+	if (PosOkPlayer(playerId, dx, dy) && IsPathBlocked(x, y, pdir))
 		return; // Don't start backtrack around obstacles
 
-	NetSendCmdLoc(true, CMD_WALKXY, dx, dy);
+	NetSendCmdLoc(playerId, true, CMD_WALKXY, dx, dy);
 }
 
 void QuestLogMove(AxisDirection move_dir)
@@ -869,7 +869,7 @@ void ProcessLeftStickOrDPadGameUI()
 		handler(GetLeftStickOrDpadDirection(true));
 }
 
-void Movement()
+void Movement(int playerId)
 {
 	if (InGameMenu()
 	    || IsControllerButtonPressed(ControllerButton_BUTTON_START)
@@ -882,7 +882,7 @@ void Movement()
 	}
 
 	if (GetLeftStickOrDPadGameUIHandler() == NULL) {
-		WalkInDir(move_dir);
+		WalkInDir(playerId, move_dir);
 	}
 }
 
@@ -1056,7 +1056,7 @@ void plrctrls_every_frame()
 
 void plrctrls_after_game_logic()
 {
-	Movement();
+	Movement(myplr);
 }
 
 void UseBeltItem(int type)


### PR DESCRIPTION
Exposes player number from multi_send_packet.

It also adds playerNumbers for functions:
- NetSendCmdLoc
- NetSendLoPri
- NetSendHiPri
- Movement

With this PR, is possible to move a specific player (or more than one) using the gamepad logic (after a few tweaks).

You will notice that some functions are using playerId and others are using myplr, it was done on purpose. I am trying to create a convention here, myplr is the default value for player one so if the call chain is not complete, myplr is being used. When all calls were changed to expose playerId, myplr will/should be replaced.