### PR TITLE
adl: fix animations with delay (block animations), refactoring and unittests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,7 +404,8 @@ if(RUN_TESTS)
     test/player_test.cpp
     test/scrollrt_test.cpp
     test/stores_test.cpp
-    test/writehero_test.cpp)
+    test/writehero_test.cpp
+    test/animationinformation_test.cpp)
 endif()
 
 add_executable(${BIN_TARGET} WIN32 MACOSX_BUNDLE ${devilutionx_SRCS})

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -524,7 +524,7 @@ void FreePlayerGFX(int pnum)
 	plr[pnum]._pGFXLoad = 0;
 }
 
-void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, AnimationFlags flags /*= AnimationFlags::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/)
+void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/)
 {
 	if ((DWORD)pnum >= MAX_PLRS) {
 		app_fatal("NewPlrAnim: illegal player %d", pnum);
@@ -541,7 +541,7 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, Animat
 	plr[pnum]._pAnimRelevantAnimationFramesForDistributing = 0;
 	plr[pnum]._pAnimGameTickModifier = 0.0f;
 
-	if (numSkippedFrames != 0 || flags != AnimationFlags::None) {
+	if (numSkippedFrames != 0 || flags != AnimationDistributionFlags::None) {
 		int relevantAnimationFramesForDistributing = numFrames; // Animation Frames that will be adjusted for the skipped Frames/GameTicks
 		if (distributeFramesBeforeFrame != 0) {
 			// After an attack hits (_pAFNum or _pSFNum) it can be canceled or another attack can be queued and this means the animation is canceled.
@@ -555,7 +555,7 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, Animat
 		int relevantAnimationGameTicksForDistribution = relevantAnimationFramesForDistributing * gameTicksPerFrame; // GameTicks that will be adjusted for the skipped Frames/GameTicks
 
 		int relevantAnimationGameTicksWithSkipping = relevantAnimationGameTicksForDistribution - (numSkippedFrames * gameTicksPerFrame); // How many GameTicks will the Animation be really shown (skipped Frames and GameTicks removed)
-		if ((flags & AnimationFlags::ProcessAnimationPending) == AnimationFlags::ProcessAnimationPending) {
+		if ((flags & AnimationDistributionFlags::ProcessAnimationPending) == AnimationDistributionFlags::ProcessAnimationPending) {
 			// If ProcessAnimation will be called after NewPlrAnim (in same GameTick as NewPlrAnim), we increment the Animation-Counter.
 			// If no delay is specified, this will result in complete skipped frame (see ProcessPlayerAnimation).
 			// But if we have a delay specified, this would only result in a reduced time the first frame is shown (one skipped delay).
@@ -567,7 +567,7 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, Animat
 			plr[pnum]._pAnimGameTicksSinceSequenceStarted = -1;
 		}
 
-		if ((flags & AnimationFlags::SkipsDelayOfLastFrame) == AnimationFlags::SkipsDelayOfLastFrame) {
+		if ((flags & AnimationDistributionFlags::SkipsDelayOfLastFrame) == AnimationDistributionFlags::SkipsDelayOfLastFrame) {
 			// The logic for player/monster/... (not ProcessAnimation) only checks the frame not the delay.
 			// That means if a delay is specified, the last-frame is shown less then the other frames
 			// Example:
@@ -1521,7 +1521,7 @@ void StartWalk(int pnum, int xvel, int yvel, int xoff, int yoff, int xadd, int y
 
 	//Start walk animation
 	int numSkippedFrames = (currlevel == 0 && sgGameInitInfo.bRunInTown) ? (plr[pnum]._pWFrames / 2) : 0;
-	NewPlrAnim(pnum, plr[pnum]._pWAnim[EndDir], plr[pnum]._pWFrames, 0, plr[pnum]._pWWidth, AnimationFlags::None, numSkippedFrames);
+	NewPlrAnim(pnum, plr[pnum]._pWAnim[EndDir], plr[pnum]._pWFrames, 0, plr[pnum]._pWWidth, AnimationDistributionFlags::None, numSkippedFrames);
 
 	plr[pnum]._pdir = EndDir;
 	plr[pnum]._pVar8 = 0;
@@ -1569,7 +1569,7 @@ void StartAttack(int pnum, direction d)
 		skippedAnimationFrames += 2;
 	}
 
-	NewPlrAnim(pnum, plr[pnum]._pAAnim[d], plr[pnum]._pAFrames, 0, plr[pnum]._pAWidth, AnimationFlags::ProcessAnimationPending, skippedAnimationFrames, plr[pnum]._pAFNum);
+	NewPlrAnim(pnum, plr[pnum]._pAAnim[d], plr[pnum]._pAFrames, 0, plr[pnum]._pAWidth, AnimationDistributionFlags::ProcessAnimationPending, skippedAnimationFrames, plr[pnum]._pAFNum);
 	plr[pnum]._pmode = PM_ATTACK;
 	FixPlayerLocation(pnum, d);
 	SetPlayerOld(pnum);
@@ -1597,7 +1597,7 @@ void StartRangeAttack(int pnum, direction d, int cx, int cy)
 		}
 	}
 
-	NewPlrAnim(pnum, plr[pnum]._pAAnim[d], plr[pnum]._pAFrames, 0, plr[pnum]._pAWidth, AnimationFlags::ProcessAnimationPending, skippedAnimationFrames, plr[pnum]._pAFNum);
+	NewPlrAnim(pnum, plr[pnum]._pAAnim[d], plr[pnum]._pAFrames, 0, plr[pnum]._pAWidth, AnimationDistributionFlags::ProcessAnimationPending, skippedAnimationFrames, plr[pnum]._pAFNum);
 
 	plr[pnum]._pmode = PM_RATTACK;
 	FixPlayerLocation(pnum, d);
@@ -1628,7 +1628,7 @@ void StartPlrBlock(int pnum, direction dir)
 		skippedAnimationFrames = (plr[pnum]._pBFrames - 2); // ISPL_FASTBLOCK means we cancel the animation if frame 2 was shown
 	}
 
-	NewPlrAnim(pnum, plr[pnum]._pBAnim[dir], plr[pnum]._pBFrames, 2, plr[pnum]._pBWidth, AnimationFlags::SkipsDelayOfLastFrame, skippedAnimationFrames);
+	NewPlrAnim(pnum, plr[pnum]._pBAnim[dir], plr[pnum]._pBFrames, 2, plr[pnum]._pBWidth, AnimationDistributionFlags::SkipsDelayOfLastFrame, skippedAnimationFrames);
 
 	plr[pnum]._pmode = PM_BLOCK;
 	FixPlayerLocation(pnum, dir);
@@ -1651,19 +1651,19 @@ void StartSpell(int pnum, direction d, int cx, int cy)
 			if ((plr[pnum]._pGFXLoad & PFILE_FIRE) == 0) {
 				LoadPlrGFX(pnum, PFILE_FIRE);
 			}
-			NewPlrAnim(pnum, plr[pnum]._pFAnim[d], plr[pnum]._pSFrames, 0, plr[pnum]._pSWidth, AnimationFlags::ProcessAnimationPending);
+			NewPlrAnim(pnum, plr[pnum]._pFAnim[d], plr[pnum]._pSFrames, 0, plr[pnum]._pSWidth, AnimationDistributionFlags::ProcessAnimationPending);
 			break;
 		case STYPE_LIGHTNING:
 			if ((plr[pnum]._pGFXLoad & PFILE_LIGHTNING) == 0) {
 				LoadPlrGFX(pnum, PFILE_LIGHTNING);
 			}
-			NewPlrAnim(pnum, plr[pnum]._pLAnim[d], plr[pnum]._pSFrames, 0, plr[pnum]._pSWidth, AnimationFlags::ProcessAnimationPending);
+			NewPlrAnim(pnum, plr[pnum]._pLAnim[d], plr[pnum]._pSFrames, 0, plr[pnum]._pSWidth, AnimationDistributionFlags::ProcessAnimationPending);
 			break;
 		case STYPE_MAGIC:
 			if ((plr[pnum]._pGFXLoad & PFILE_MAGIC) == 0) {
 				LoadPlrGFX(pnum, PFILE_MAGIC);
 			}
-			NewPlrAnim(pnum, plr[pnum]._pTAnim[d], plr[pnum]._pSFrames, 0, plr[pnum]._pSWidth, AnimationFlags::ProcessAnimationPending);
+			NewPlrAnim(pnum, plr[pnum]._pTAnim[d], plr[pnum]._pSFrames, 0, plr[pnum]._pSWidth, AnimationDistributionFlags::ProcessAnimationPending);
 			break;
 		}
 	}
@@ -1775,7 +1775,7 @@ void StartPlrHit(int pnum, int dam, bool forcehit)
 		skippedAnimationFrames = 0;
 	}
 
-	NewPlrAnim(pnum, plr[pnum]._pHAnim[pd], plr[pnum]._pHFrames, 0, plr[pnum]._pHWidth, AnimationFlags::None, skippedAnimationFrames);
+	NewPlrAnim(pnum, plr[pnum]._pHAnim[pd], plr[pnum]._pHFrames, 0, plr[pnum]._pHWidth, AnimationDistributionFlags::None, skippedAnimationFrames);
 
 	plr[pnum]._pmode = PM_GOTHIT;
 	FixPlayerLocation(pnum, pd);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -555,7 +555,7 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, Animat
 		int relevantAnimationGameTicksForDistribution = relevantAnimationFramesForDistributing * gameTicksPerFrame; // GameTicks that will be adjusted for the skipped Frames/GameTicks
 
 		int relevantAnimationGameTicksWithSkipping = relevantAnimationGameTicksForDistribution - (numSkippedFrames * gameTicksPerFrame); // How many GameTicks will the Animation be really shown (skipped Frames and GameTicks removed)
-		if (flags & AnimationFlags::ProcessAnimationPending) {
+		if ((flags & AnimationFlags::ProcessAnimationPending) == AnimationFlags::ProcessAnimationPending) {
 			// If ProcessAnimation will be called after NewPlrAnim (in same GameTick as NewPlrAnim), we increment the Animation-Counter.
 			// If no delay is specified, this will result in complete skipped frame (see ProcessPlayerAnimation).
 			// But if we have a delay specified, this would only result in a reduced time the first frame is shown (one skipped delay).
@@ -567,7 +567,7 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, Animat
 			plr[pnum]._pAnimGameTicksSinceSequenceStarted = -1;
 		}
 
-		if (flags & AnimationFlags::SkipsDelayOfLastFrame) {
+		if ((flags & AnimationFlags::SkipsDelayOfLastFrame) == AnimationFlags::SkipsDelayOfLastFrame) {
 			// The logic for player/monster/... (not ProcessAnimation) only checks the frame not the delay.
 			// That means if a delay is specified, the last-frame is shown less then the other frames
 			// Example:

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -524,7 +524,7 @@ void FreePlayerGFX(int pnum)
 	plr[pnum]._pGFXLoad = 0;
 }
 
-void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/)
+void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, AnimationDistributionParams params /*= AnimationDistributionParams::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/)
 {
 	if ((DWORD)pnum >= MAX_PLRS) {
 		app_fatal("NewPlrAnim: illegal player %d", pnum);
@@ -541,7 +541,7 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, Animat
 	plr[pnum]._pAnimRelevantAnimationFramesForDistributing = 0;
 	plr[pnum]._pAnimGameTickModifier = 0.0f;
 
-	if (numSkippedFrames != 0 || flags != AnimationDistributionFlags::None) {
+	if (numSkippedFrames != 0 || params != AnimationDistributionParams::None) {
 		// Animation Frames that will be adjusted for the skipped Frames/GameTicks
 		int relevantAnimationFramesForDistributing = numFrames;
 		if (distributeFramesBeforeFrame != 0) {
@@ -561,7 +561,7 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, Animat
 		// How many GameTicks will the Animation be really shown (skipped Frames and GameTicks removed)
 		int relevantAnimationGameTicksWithSkipping = relevantAnimationGameTicksForDistribution - (numSkippedFrames * gameTicksPerFrame);
 
-		if ((flags & AnimationDistributionFlags::ProcessAnimationPending) == AnimationDistributionFlags::ProcessAnimationPending) {
+		if (params == AnimationDistributionParams::ProcessAnimationPending) {
 			// If ProcessAnimation will be called after NewPlrAnim (in same GameTick as NewPlrAnim), we increment the Animation-Counter.
 			// If no delay is specified, this will result in complete skipped frame (see ProcessPlayerAnimation).
 			// But if we have a delay specified, this would only result in a reduced time the first frame is shown (one skipped delay).
@@ -573,7 +573,7 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, Animat
 			plr[pnum]._pAnimGameTicksSinceSequenceStarted = -1;
 		}
 
-		if ((flags & AnimationDistributionFlags::SkipsDelayOfLastFrame) == AnimationDistributionFlags::SkipsDelayOfLastFrame) {
+		if (params == AnimationDistributionParams::SkipsDelayOfLastFrame) {
 			// The logic for player/monster/... (not ProcessAnimation) only checks the frame not the delay.
 			// That means if a delay is specified, the last-frame is shown less then the other frames
 			// Example:
@@ -1577,7 +1577,7 @@ void StartAttack(int pnum, direction d)
 		skippedAnimationFrames += 2;
 	}
 
-	NewPlrAnim(pnum, plr[pnum]._pAAnim[d], plr[pnum]._pAFrames, 0, plr[pnum]._pAWidth, AnimationDistributionFlags::ProcessAnimationPending, skippedAnimationFrames, plr[pnum]._pAFNum);
+	NewPlrAnim(pnum, plr[pnum]._pAAnim[d], plr[pnum]._pAFrames, 0, plr[pnum]._pAWidth, AnimationDistributionParams::ProcessAnimationPending, skippedAnimationFrames, plr[pnum]._pAFNum);
 	plr[pnum]._pmode = PM_ATTACK;
 	FixPlayerLocation(pnum, d);
 	SetPlayerOld(pnum);
@@ -1605,7 +1605,7 @@ void StartRangeAttack(int pnum, direction d, int cx, int cy)
 		}
 	}
 
-	NewPlrAnim(pnum, plr[pnum]._pAAnim[d], plr[pnum]._pAFrames, 0, plr[pnum]._pAWidth, AnimationDistributionFlags::ProcessAnimationPending, skippedAnimationFrames, plr[pnum]._pAFNum);
+	NewPlrAnim(pnum, plr[pnum]._pAAnim[d], plr[pnum]._pAFrames, 0, plr[pnum]._pAWidth, AnimationDistributionParams::ProcessAnimationPending, skippedAnimationFrames, plr[pnum]._pAFNum);
 
 	plr[pnum]._pmode = PM_RATTACK;
 	FixPlayerLocation(pnum, d);
@@ -1636,7 +1636,7 @@ void StartPlrBlock(int pnum, direction dir)
 		skippedAnimationFrames = (plr[pnum]._pBFrames - 2); // ISPL_FASTBLOCK means we cancel the animation if frame 2 was shown
 	}
 
-	NewPlrAnim(pnum, plr[pnum]._pBAnim[dir], plr[pnum]._pBFrames, 2, plr[pnum]._pBWidth, AnimationDistributionFlags::SkipsDelayOfLastFrame, skippedAnimationFrames);
+	NewPlrAnim(pnum, plr[pnum]._pBAnim[dir], plr[pnum]._pBFrames, 2, plr[pnum]._pBWidth, AnimationDistributionParams::SkipsDelayOfLastFrame, skippedAnimationFrames);
 
 	plr[pnum]._pmode = PM_BLOCK;
 	FixPlayerLocation(pnum, dir);
@@ -1659,19 +1659,19 @@ void StartSpell(int pnum, direction d, int cx, int cy)
 			if ((plr[pnum]._pGFXLoad & PFILE_FIRE) == 0) {
 				LoadPlrGFX(pnum, PFILE_FIRE);
 			}
-			NewPlrAnim(pnum, plr[pnum]._pFAnim[d], plr[pnum]._pSFrames, 0, plr[pnum]._pSWidth, AnimationDistributionFlags::ProcessAnimationPending);
+			NewPlrAnim(pnum, plr[pnum]._pFAnim[d], plr[pnum]._pSFrames, 0, plr[pnum]._pSWidth, AnimationDistributionParams::ProcessAnimationPending);
 			break;
 		case STYPE_LIGHTNING:
 			if ((plr[pnum]._pGFXLoad & PFILE_LIGHTNING) == 0) {
 				LoadPlrGFX(pnum, PFILE_LIGHTNING);
 			}
-			NewPlrAnim(pnum, plr[pnum]._pLAnim[d], plr[pnum]._pSFrames, 0, plr[pnum]._pSWidth, AnimationDistributionFlags::ProcessAnimationPending);
+			NewPlrAnim(pnum, plr[pnum]._pLAnim[d], plr[pnum]._pSFrames, 0, plr[pnum]._pSWidth, AnimationDistributionParams::ProcessAnimationPending);
 			break;
 		case STYPE_MAGIC:
 			if ((plr[pnum]._pGFXLoad & PFILE_MAGIC) == 0) {
 				LoadPlrGFX(pnum, PFILE_MAGIC);
 			}
-			NewPlrAnim(pnum, plr[pnum]._pTAnim[d], plr[pnum]._pSFrames, 0, plr[pnum]._pSWidth, AnimationDistributionFlags::ProcessAnimationPending);
+			NewPlrAnim(pnum, plr[pnum]._pTAnim[d], plr[pnum]._pSFrames, 0, plr[pnum]._pSWidth, AnimationDistributionParams::ProcessAnimationPending);
 			break;
 		}
 	}
@@ -1783,7 +1783,7 @@ void StartPlrHit(int pnum, int dam, bool forcehit)
 		skippedAnimationFrames = 0;
 	}
 
-	NewPlrAnim(pnum, plr[pnum]._pHAnim[pd], plr[pnum]._pHFrames, 0, plr[pnum]._pHWidth, AnimationDistributionFlags::None, skippedAnimationFrames);
+	NewPlrAnim(pnum, plr[pnum]._pHAnim[pd], plr[pnum]._pHFrames, 0, plr[pnum]._pHWidth, AnimationDistributionParams::None, skippedAnimationFrames);
 
 	plr[pnum]._pmode = PM_GOTHIT;
 	FixPlayerLocation(pnum, pd);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -538,21 +538,21 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, Animat
 	plr[pnum]._pAnimWidth = width;
 	plr[pnum]._pAnimWidth2 = (width - 64) / 2;
 	plr[pnum]._pAnimGameTicksSinceSequenceStarted = 0;
-	plr[pnum]._pAnimRelevantAnimationFramesForDistributen = 0;
+	plr[pnum]._pAnimRelevantAnimationFramesForDistributing = 0;
 	plr[pnum]._pAnimGameTickModifier = 0.0f;
 
 	if (numSkippedFrames != 0 || flags != AnimationFlags::None) {
-		int relevantAnimationFramesForDistribution = numFrames; // Animation Frames that will be adjusted for the skipped Frames/GameTicks
+		int relevantAnimationFramesForDistributing = numFrames; // Animation Frames that will be adjusted for the skipped Frames/GameTicks
 		if (distributeFramesBeforeFrame != 0) {
 			// After an attack hits (_pAFNum or _pSFNum) it can be canceled or another attack can be queued and this means the animation is canceled.
 			// In normal attacks frame skipping always happens before the attack actual hit.
 			// This has the advantage that the sword or bow always points to the enemy when the hit happens (_pAFNum or _pSFNum).
 			// Our distribution logic must also regard this behaviour, so we are not allowed to distribute the skipped animations after the actual hit (_pAnimStopDistributingAfterFrame).
-			relevantAnimationFramesForDistribution = distributeFramesBeforeFrame - 1;
+			relevantAnimationFramesForDistributing = distributeFramesBeforeFrame - 1;
 		}
 
 		int gameTicksPerFrame = (Delay + 1);                                                                        // How many GameTicks are needed to advance one Animation Frame
-		int relevantAnimationGameTicksForDistribution = relevantAnimationFramesForDistribution * gameTicksPerFrame; // GameTicks that will be adjusted for the skipped Frames/GameTicks
+		int relevantAnimationGameTicksForDistribution = relevantAnimationFramesForDistributing * gameTicksPerFrame; // GameTicks that will be adjusted for the skipped Frames/GameTicks
 
 		int relevantAnimationGameTicksWithSkipping = relevantAnimationGameTicksForDistribution - (numSkippedFrames * gameTicksPerFrame); // How many GameTicks will the Animation be really shown (skipped Frames and GameTicks removed)
 		if (flags & AnimationFlags::ProcessAnimationPending) {
@@ -590,7 +590,7 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, Animat
 		float gameTickModifier = (float)relevantAnimationGameTicksForDistribution / (float)relevantAnimationGameTicksWithSkipping; // if we skipped Frames we need to expand the GameTicks to make one GameTick for this Animation "faster"
 		gameTickModifier /= gameTicksPerFrame;                                                                                     // gameTickModifier specifies the Animation fraction per GameTick, so we have to remove the delay from the variable
 
-		plr[pnum]._pAnimRelevantAnimationFramesForDistributen = relevantAnimationFramesForDistribution;
+		plr[pnum]._pAnimRelevantAnimationFramesForDistributing = relevantAnimationFramesForDistributing;
 		plr[pnum]._pAnimGameTickModifier = gameTickModifier;
 	}
 }
@@ -3769,11 +3769,11 @@ int GetFrameToUseForPlayerRendering(const PlayerStruct *pPlayer)
 	// - if no frame-skipping is required and so we have exactly one Animationframe per GameTick
 	// or
 	// - if we load from a savegame where the new variables are not stored (we don't want to break savegame compatiblity because of smoother rendering of one animation)
-	int relevantAnimationFrames = pPlayer->_pAnimRelevantAnimationFramesForDistributen;
-	if (relevantAnimationFrames <= 0)
+	int relevantAnimationFramesForDistributing = pPlayer->_pAnimRelevantAnimationFramesForDistributing;
+	if (relevantAnimationFramesForDistributing <= 0)
 		return pPlayer->_pAnimFrame;
 
-	if (pPlayer->_pAnimFrame > relevantAnimationFrames)
+	if (pPlayer->_pAnimFrame > relevantAnimationFramesForDistributing)
 		return pPlayer->_pAnimFrame;
 
 	assert(pPlayer->_pAnimGameTicksSinceSequenceStarted >= 0);
@@ -3781,10 +3781,10 @@ int GetFrameToUseForPlayerRendering(const PlayerStruct *pPlayer)
 	float progressToNextGameTick = gfProgressToNextGameTick;
 	float totalGameTicksForCurrentAnimationSequence = progressToNextGameTick + (float)pPlayer->_pAnimGameTicksSinceSequenceStarted; // we don't use the processed game ticks alone but also the fragtion of the next game tick (if a rendering happens between game ticks). This helps to smooth the animations.
 	int absoluteAnimationFrame = 1 + (int)(totalGameTicksForCurrentAnimationSequence * pPlayer->_pAnimGameTickModifier);            // 1 added for rounding reasons. float to int cast always truncate.
-	if (absoluteAnimationFrame > relevantAnimationFrames) {                                                                         // this can happen if we are at the last frame and the next game tick is due (nthread_GetProgressToNextGameTick returns 1.0f)
-		if (absoluteAnimationFrame > (relevantAnimationFrames + 1))                                                                 // we should never have +2 frames even if next game tick is due
-			SDL_Log("GetFrameToUseForPlayerRendering: Calculated an invalid Animation Frame (Calculated %d MaxFrame %d)", absoluteAnimationFrame, relevantAnimationFrames);
-		return relevantAnimationFrames;
+	if (absoluteAnimationFrame > relevantAnimationFramesForDistributing) {                                                                         // this can happen if we are at the last frame and the next game tick is due (nthread_GetProgressToNextGameTick returns 1.0f)
+		if (absoluteAnimationFrame > (relevantAnimationFramesForDistributing + 1))                                                                 // we should never have +2 frames even if next game tick is due
+			SDL_Log("GetFrameToUseForPlayerRendering: Calculated an invalid Animation Frame (Calculated %d MaxFrame %d)", absoluteAnimationFrame, relevantAnimationFramesForDistributing);
+		return relevantAnimationFramesForDistributing;
 	}
 	if (absoluteAnimationFrame <= 0) {
 		SDL_Log("GetFrameToUseForPlayerRendering: Calculated an invalid Animation Frame (Calculated %d)", absoluteAnimationFrame);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -542,33 +542,35 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, Animat
 	plr[pnum]._pAnimGameTickModifier = 0.0f;
 
 	if (numSkippedFrames != 0 || flags != AnimationFlags::None) {
-		int relevantAnimationLength = numFrames;
+		int relevantAnimationFramesForDistribution = numFrames; // Animation Frames that will be adjusted for the skipped Frames/GameTicks
 		if (distributeFramesBeforeFrame != 0) {
 			// After an attack hits (_pAFNum or _pSFNum) it can be canceled or another attack can be queued and this means the animation is canceled.
 			// In normal attacks frame skipping always happens before the attack actual hit.
 			// This has the advantage that the sword or bow always points to the enemy when the hit happens (_pAFNum or _pSFNum).
 			// Our distribution logic must also regard this behaviour, so we are not allowed to distribute the skipped animations after the actual hit (_pAnimStopDistributingAfterFrame).
-			relevantAnimationLength = distributeFramesBeforeFrame - 1;
+			relevantAnimationFramesForDistribution = distributeFramesBeforeFrame - 1;
 		}
 
+		int gameTicksPerFrame = (Delay + 1);                                                                        // How many GameTicks are needed to advance one Animation Frame
+		int relevantAnimationGameTicksForDistribution = relevantAnimationFramesForDistribution * gameTicksPerFrame; // GameTicks that will be adjusted for the skipped Frames/GameTicks
+
+		int relevantAnimationGameTicksWithSkipping = relevantAnimationGameTicksForDistribution - (numSkippedFrames * gameTicksPerFrame); // How many GameTicks will the Animation be really shown (skipped Frames and GameTicks removed)
 		if (flags & AnimationFlags::ProcessAnimationPending) {
 			// If ProcessAnimation will be called after NewPlrAnim (in same GameTick as NewPlrAnim), we increment the Animation-Counter.
 			// If no delay is specified, this will result in complete skipped frame (see ProcessPlayerAnimation).
 			// But if we have a delay specified, this would only result in a reduced time the first frame is shown (one skipped delay).
 			// Because of that, we only the remove one GameTick from the time the Animation is shown
-			relevantAnimationLength -= 1;
+			relevantAnimationGameTicksWithSkipping -= 1;
 			// The Animation Distribution Logic needs to account how many GameTicks passed since the Animation started.
 			// Because ProcessAnimation will increase this later (in same GameTick as NewPlrAnim), we correct this upfront.
 			// This also means Rendering should never hapen with _pAnimGameTicksSinceSequenceStarted < 0.
 			plr[pnum]._pAnimGameTicksSinceSequenceStarted = -1;
 		}
 
-		int animationMaxGameTickets = relevantAnimationLength;
-		if (Delay > 1)
-			animationMaxGameTickets = (relevantAnimationLength * Delay);
-		float gameTickModifier = (float)animationMaxGameTickets / (float)(relevantAnimationLength - numSkippedFrames); // if we skipped Frames we need to expand the GameTicks to make one GameTick for this Animation "faster"
+		float gameTickModifier = (float)relevantAnimationGameTicksForDistribution / (float)relevantAnimationGameTicksWithSkipping; // if we skipped Frames we need to expand the GameTicks to make one GameTick for this Animation "faster"
+		gameTickModifier /= gameTicksPerFrame;                                                                                     // gameTickModifier specifies the Animation fraction per GameTick, so we have to remove the delay from the variable
 
-		plr[pnum]._pAnimRelevantAnimationFramesForDistributen = relevantAnimationLength;
+		plr[pnum]._pAnimRelevantAnimationFramesForDistributen = relevantAnimationFramesForDistribution;
 		plr[pnum]._pAnimGameTickModifier = gameTickModifier;
 	}
 }
@@ -3747,21 +3749,25 @@ int GetFrameToUseForPlayerRendering(const PlayerStruct *pPlayer)
 	// - if no frame-skipping is required and so we have exactly one Animationframe per GameTick
 	// or
 	// - if we load from a savegame where the new variables are not stored (we don't want to break savegame compatiblity because of smoother rendering of one animation)
-	int relevantAnimationLength = pPlayer->_pAnimRelevantAnimationFramesForDistributen;
-	if (relevantAnimationLength <= 0)
+	int relevantAnimationFrames = pPlayer->_pAnimRelevantAnimationFramesForDistributen;
+	if (relevantAnimationFrames <= 0)
 		return pPlayer->_pAnimFrame;
 
-	if (pPlayer->_pAnimFrame > relevantAnimationLength)
+	if (pPlayer->_pAnimFrame > relevantAnimationFrames)
 		return pPlayer->_pAnimFrame;
+
+	assert(pPlayer->_pAnimGameTicksSinceSequenceStarted >= 0);
 
 	float progressToNextGameTick = gfProgressToNextGameTick;
 	float totalGameTicksForCurrentAnimationSequence = progressToNextGameTick + (float)pPlayer->_pAnimGameTicksSinceSequenceStarted; // we don't use the processed game ticks alone but also the fragtion of the next game tick (if a rendering happens between game ticks). This helps to smooth the animations.
-
-	int absolutAnimationFrame = 1 + (int)(totalGameTicksForCurrentAnimationSequence * pPlayer->_pAnimGameTickModifier); // 1 added for rounding reasons. float to int cast always truncate.
-	if (absolutAnimationFrame > relevantAnimationLength) // this can happen if we are at the last frame and the next game tick is due (nthread_GetProgressToNextGameTick returns 1.0f)
-		return relevantAnimationLength;
+	int absolutAnimationFrame = 1 + (int)(totalGameTicksForCurrentAnimationSequence * pPlayer->_pAnimGameTickModifier);             // 1 added for rounding reasons. float to int cast always truncate.
+	if (absolutAnimationFrame > relevantAnimationFrames) {                                                                          // this can happen if we are at the last frame and the next game tick is due (nthread_GetProgressToNextGameTick returns 1.0f)
+		if (absolutAnimationFrame > (relevantAnimationFrames + 1))                                                                  // we should never have +2 frames even if next game tick is due
+			SDL_Log("GetFrameToUseForPlayerRendering: Calculated an invalid Animation Frame (Calculated %d MaxFrame %d)", absolutAnimationFrame, relevantAnimationFrames);
+		return relevantAnimationFrames;
+	}
 	if (absolutAnimationFrame <= 0) {
-		SDL_Log("GetFrameToUseForPlayerRendering: Calculated an invalid Animation Frame");
+		SDL_Log("GetFrameToUseForPlayerRendering: Calculated an invalid Animation Frame (Calculated %d)", absolutAnimationFrame);
 		return 1;
 	}
 	return absolutAnimationFrame;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3780,17 +3780,17 @@ int GetFrameToUseForPlayerRendering(const PlayerStruct *pPlayer)
 
 	float progressToNextGameTick = gfProgressToNextGameTick;
 	float totalGameTicksForCurrentAnimationSequence = progressToNextGameTick + (float)pPlayer->_pAnimGameTicksSinceSequenceStarted; // we don't use the processed game ticks alone but also the fragtion of the next game tick (if a rendering happens between game ticks). This helps to smooth the animations.
-	int absolutAnimationFrame = 1 + (int)(totalGameTicksForCurrentAnimationSequence * pPlayer->_pAnimGameTickModifier);             // 1 added for rounding reasons. float to int cast always truncate.
-	if (absolutAnimationFrame > relevantAnimationFrames) {                                                                          // this can happen if we are at the last frame and the next game tick is due (nthread_GetProgressToNextGameTick returns 1.0f)
-		if (absolutAnimationFrame > (relevantAnimationFrames + 1))                                                                  // we should never have +2 frames even if next game tick is due
-			SDL_Log("GetFrameToUseForPlayerRendering: Calculated an invalid Animation Frame (Calculated %d MaxFrame %d)", absolutAnimationFrame, relevantAnimationFrames);
+	int absoluteAnimationFrame = 1 + (int)(totalGameTicksForCurrentAnimationSequence * pPlayer->_pAnimGameTickModifier);            // 1 added for rounding reasons. float to int cast always truncate.
+	if (absoluteAnimationFrame > relevantAnimationFrames) {                                                                         // this can happen if we are at the last frame and the next game tick is due (nthread_GetProgressToNextGameTick returns 1.0f)
+		if (absoluteAnimationFrame > (relevantAnimationFrames + 1))                                                                 // we should never have +2 frames even if next game tick is due
+			SDL_Log("GetFrameToUseForPlayerRendering: Calculated an invalid Animation Frame (Calculated %d MaxFrame %d)", absoluteAnimationFrame, relevantAnimationFrames);
 		return relevantAnimationFrames;
 	}
-	if (absolutAnimationFrame <= 0) {
-		SDL_Log("GetFrameToUseForPlayerRendering: Calculated an invalid Animation Frame (Calculated %d)", absolutAnimationFrame);
+	if (absoluteAnimationFrame <= 0) {
+		SDL_Log("GetFrameToUseForPlayerRendering: Calculated an invalid Animation Frame (Calculated %d)", absoluteAnimationFrame);
 		return 1;
 	}
-	return absolutAnimationFrame;
+	return absoluteAnimationFrame;
 }
 
 void ClrPlrPath(int pnum)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -567,6 +567,26 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, Animat
 			plr[pnum]._pAnimGameTicksSinceSequenceStarted = -1;
 		}
 
+		if (flags & AnimationFlags::SkipsDelayOfLastFrame) {
+			// The logic for player/monster/... (not ProcessAnimation) only checks the frame not the delay.
+			// That means if a delay is specified, the last-frame is shown less then the other frames
+			// Example:
+			// If we have a animation with 3 frames and with a delay of 1 (gameTicksPerFrame = 2).
+			// The logic checks "if (frame == 3) { start_new_animation(); }"
+			// This will result that frame 4 is the last shown Animation Frame.
+			// GameTick		Frame		Cnt
+			// 1			1			0
+			// 2			1			1
+			// 3			2			0
+			// 3			2			1
+			// 4			3			0
+			// 5			-			-
+			// in GameTick 5 ProcessPlayer sees Frame = 3 and stops the animation.
+			// But Frame 3 is only shown 1 GameTick and all other Frames are shown 2 GameTicks.
+			// Thats why we need to remove the Delay of the last Frame from the time (GameTicks) the Animation is shown
+			relevantAnimationGameTicksWithSkipping -= Delay;
+		}
+
 		float gameTickModifier = (float)relevantAnimationGameTicksForDistribution / (float)relevantAnimationGameTicksWithSkipping; // if we skipped Frames we need to expand the GameTicks to make one GameTick for this Animation "faster"
 		gameTickModifier /= gameTicksPerFrame;                                                                                     // gameTickModifier specifies the Animation fraction per GameTick, so we have to remove the delay from the variable
 
@@ -1603,12 +1623,12 @@ void StartPlrBlock(int pnum, direction dir)
 		LoadPlrGFX(pnum, PFILE_BLOCK);
 	}
 
-	int skippedAnimationFrames = 0; // Block can start with Frame 1 if Player 2 hits Player 1. In this case Player 1 will not call again ProcessPlayerAnimation.
+	int skippedAnimationFrames = 0;
 	if ((plr[pnum]._pIFlags & ISPL_FASTBLOCK) != 0) {
-		skippedAnimationFrames = (plr[pnum]._pBFrames - 1); // ISPL_FASTBLOCK means there is only one AnimationFrame.
+		skippedAnimationFrames = (plr[pnum]._pBFrames - 2); // ISPL_FASTBLOCK means we cancel the animation if frame 2 was shown
 	}
 
-	NewPlrAnim(pnum, plr[pnum]._pBAnim[dir], plr[pnum]._pBFrames, 2, plr[pnum]._pBWidth, AnimationFlags::None, skippedAnimationFrames);
+	NewPlrAnim(pnum, plr[pnum]._pBAnim[dir], plr[pnum]._pBFrames, 2, plr[pnum]._pBWidth, AnimationFlags::SkipsDelayOfLastFrame, skippedAnimationFrames);
 
 	plr[pnum]._pmode = PM_BLOCK;
 	FixPlayerLocation(pnum, dir);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1529,8 +1529,7 @@ void StartWalk(int pnum, int xvel, int yvel, int xoff, int yoff, int xadd, int y
 	}
 
 	//Start walk animation
-	int numSkippedFrames = (currlevel == 0 && sgGameInitInfo.bRunInTown) ? (plr[pnum]._pWFrames / 2) : 0;
-	NewPlrAnim(pnum, plr[pnum]._pWAnim[EndDir], plr[pnum]._pWFrames, 0, plr[pnum]._pWWidth, AnimationDistributionFlags::None, numSkippedFrames);
+	NewPlrAnim(pnum, plr[pnum]._pWAnim[EndDir], plr[pnum]._pWFrames, 0, plr[pnum]._pWWidth);
 
 	plr[pnum]._pdir = EndDir;
 	plr[pnum]._pVar8 = 0;

--- a/Source/player.h
+++ b/Source/player.h
@@ -410,7 +410,7 @@ void FreePlayerGFX(int pnum);
 /**
  * @brief Specifies what special logics are applied for a Animation
  */
-enum AnimationFlags : uint8_t {
+enum AnimationDistributionFlags : uint8_t {
 	None = 0,
 	/*
 	* @brief ProcessAnimation will be called after NewPlrAnim (in same GameTick as NewPlrAnim)
@@ -434,7 +434,7 @@ enum AnimationFlags : uint8_t {
  * @param numSkippedFrames Number of Frames that will be skipped (for example with modifier "faster attack")
  * @param distributeFramesBeforeFrame Distribute the numSkippedFrames only before this frame
  */
-void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, AnimationFlags flags = AnimationFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
+void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
 void SetPlrAnims(int pnum);
 void ProcessPlayerAnimation(int pnum);
 /**

--- a/Source/player.h
+++ b/Source/player.h
@@ -178,9 +178,9 @@ struct PlayerStruct {
 	int _pAnimFrame; // Current frame of animation.
 	int _pAnimWidth;
 	int _pAnimWidth2;
-	int _pAnimNumSkippedFrames;              // Number of Frames that will be skipped (for example with modifier "faster attack")
-	int _pAnimGameTicksSinceSequenceStarted; // Number of GameTicks after the current animation sequence started
-	int _pAnimStopDistributingAfterFrame;    // Distribute the NumSkippedFrames only before this frame
+	float _pAnimGameTickModifier;                    // specifies how many animations-fractions are displayed between two gameticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
+	int _pAnimGameTicksSinceSequenceStarted;         // Number of GameTicks after the current animation sequence started
+	int _pAnimRelevantAnimationFramesForDistributen; // Animation Frames that will be adjusted for the skipped Frames/GameTicks
 	int _plid;
 	int _pvid;
 	spell_id _pSpell;

--- a/Source/player.h
+++ b/Source/player.h
@@ -397,6 +397,15 @@ void LoadPlrGFX(int pnum, player_graphic gfxflag);
 void InitPlayerGFX(int pnum);
 void InitPlrGFXMem(int pnum);
 void FreePlayerGFX(int pnum);
+
+/**
+ * @brief Specifies what special logics are applied for a Animation
+ */
+enum AnimationFlags : uint8_t {
+	None = 0,
+	ProcessAnimationPending = 1 << 0, // ProcessAnimation will be called after NewPlrAnim (in same GameTick as NewPlrAnim)
+};
+
 /**
  * @brief Sets the new Player Animation with all relevant information for rendering
 
@@ -405,11 +414,11 @@ void FreePlayerGFX(int pnum);
  * @param numFrames Number of Frames in Animation
  * @param Delay Delay after each Animation sequence
  * @param width Width of sprite
+ * @param flags Specifies what special logics are applied to this Animation
  * @param numSkippedFrames Number of Frames that will be skipped (for example with modifier "faster attack")
- * @param processAnimationPending true if first ProcessAnimation will be called in same gametick after NewPlrAnim
- * @param stopDistributingAfterFrame Distribute the NumSkippedFrames only before this frame
+ * @param distributeFramesBeforeFrame Distribute the numSkippedFrames only before this frame
  */
-void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, int numSkippedFrames = 0, bool processAnimationPending = false, int stopDistributingAfterFrame = 0);
+void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, AnimationFlags flags = AnimationFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
 void SetPlrAnims(int pnum);
 void ProcessPlayerAnimation(int pnum);
 /**

--- a/Source/player.h
+++ b/Source/player.h
@@ -404,6 +404,7 @@ void FreePlayerGFX(int pnum);
 enum AnimationFlags : uint8_t {
 	None = 0,
 	ProcessAnimationPending = 1 << 0, // ProcessAnimation will be called after NewPlrAnim (in same GameTick as NewPlrAnim)
+	SkipsDelayOfLastFrame = 1 << 1,   // Delay of last Frame is ignored (for example, because only Frame and not delay is checked in game_logic)
 };
 
 /**

--- a/Source/player.h
+++ b/Source/player.h
@@ -178,9 +178,18 @@ struct PlayerStruct {
 	int _pAnimFrame; // Current frame of animation.
 	int _pAnimWidth;
 	int _pAnimWidth2;
-	float _pAnimGameTickModifier;                    // specifies how many animations-fractions are displayed between two gameticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
-	int _pAnimGameTicksSinceSequenceStarted;         // Number of GameTicks after the current animation sequence started
-	int _pAnimRelevantAnimationFramesForDistributen; // Animation Frames that will be adjusted for the skipped Frames/GameTicks
+	/*
+	* @brief Specifies how many animations-fractions are displayed between two gameticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
+	*/
+	float _pAnimGameTickModifier;
+	/*
+	* @brief Number of GameTicks after the current animation sequence started
+	*/
+	int _pAnimGameTicksSinceSequenceStarted;
+	/*
+	* @brief Animation Frames that will be adjusted for the skipped Frames/GameTicks
+	*/
+	int _pAnimRelevantAnimationFramesForDistributen;
 	int _plid;
 	int _pvid;
 	spell_id _pSpell;
@@ -403,8 +412,14 @@ void FreePlayerGFX(int pnum);
  */
 enum AnimationFlags : uint8_t {
 	None = 0,
-	ProcessAnimationPending = 1 << 0, // ProcessAnimation will be called after NewPlrAnim (in same GameTick as NewPlrAnim)
-	SkipsDelayOfLastFrame = 1 << 1,   // Delay of last Frame is ignored (for example, because only Frame and not delay is checked in game_logic)
+	/*
+	* @brief ProcessAnimation will be called after NewPlrAnim (in same GameTick as NewPlrAnim)
+	*/
+	ProcessAnimationPending = 1 << 0,
+	/*
+	* @brief Delay of last Frame is ignored (for example, because only Frame and not delay is checked in game_logic)
+	*/
+	SkipsDelayOfLastFrame = 1 << 1,
 };
 
 /**

--- a/Source/player.h
+++ b/Source/player.h
@@ -189,7 +189,7 @@ struct PlayerStruct {
 	/*
 	* @brief Animation Frames that will be adjusted for the skipped Frames/GameTicks
 	*/
-	int _pAnimRelevantAnimationFramesForDistributen;
+	int _pAnimRelevantAnimationFramesForDistributing;
 	int _plid;
 	int _pvid;
 	spell_id _pSpell;

--- a/Source/player.h
+++ b/Source/player.h
@@ -410,16 +410,16 @@ void FreePlayerGFX(int pnum);
 /**
  * @brief Specifies what special logics are applied for a Animation
  */
-enum AnimationDistributionFlags : uint8_t {
+enum class AnimationDistributionParams : uint8_t {
 	None = 0,
 	/*
 	* @brief ProcessAnimation will be called after NewPlrAnim (in same GameTick as NewPlrAnim)
 	*/
-	ProcessAnimationPending = 1 << 0,
+	ProcessAnimationPending,
 	/*
 	* @brief Delay of last Frame is ignored (for example, because only Frame and not delay is checked in game_logic)
 	*/
-	SkipsDelayOfLastFrame = 1 << 1,
+	SkipsDelayOfLastFrame,
 };
 
 /**
@@ -430,11 +430,11 @@ enum AnimationDistributionFlags : uint8_t {
  * @param numFrames Number of Frames in Animation
  * @param Delay Delay after each Animation sequence
  * @param width Width of sprite
- * @param flags Specifies what special logics are applied to this Animation
+ * @param params Specifies what special logics are applied to this Animation
  * @param numSkippedFrames Number of Frames that will be skipped (for example with modifier "faster attack")
  * @param distributeFramesBeforeFrame Distribute the numSkippedFrames only before this frame
  */
-void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
+void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, AnimationDistributionParams params = AnimationDistributionParams::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
 void SetPlrAnims(int pnum);
 void ProcessPlayerAnimation(int pnum);
 /**

--- a/test/animationinformation_test.cpp
+++ b/test/animationinformation_test.cpp
@@ -50,11 +50,11 @@ struct RenderingData : TestData {
 * Rendering can happen more often then GameTicks and at any time between two GameTicks.
 * The Animation Distribution Logic must adjust to the Rendering that happens at any give point in time.
 */
-void RunAnimationTest(int numFrames, int delay, AnimationDistributionFlags flags, int numSkippedFrames, int distributeFramesBeforeFrame, const std::vector<TestData *> &vecTestData)
+void RunAnimationTest(int numFrames, int delay, AnimationDistributionParams params, int numSkippedFrames, int distributeFramesBeforeFrame, const std::vector<TestData *> &vecTestData)
 {
 	const int pnum = 0;
 	PlayerStruct *pPlayer = &plr[pnum];
-	NewPlrAnim(pnum, nullptr, numFrames, delay, 128, flags, numSkippedFrames, distributeFramesBeforeFrame);
+	NewPlrAnim(pnum, nullptr, numFrames, delay, 128, params, numSkippedFrames, distributeFramesBeforeFrame);
 
 	int currentGameTick = 0;
 	for (TestData *x : vecTestData) {
@@ -86,7 +86,7 @@ void RunAnimationTest(int numFrames, int delay, AnimationDistributionFlags flags
 
 TEST(AnimationInformation, AttackSwordWarrior) // ProcessAnimationPending should be considered by distribution logic
 {
-	RunAnimationTest(16, 0, AnimationDistributionFlags::ProcessAnimationPending, 0, 9,
+	RunAnimationTest(16, 0, AnimationDistributionParams::ProcessAnimationPending, 0, 9,
 	    {
 	        // ProcessPlayer directly after StartAttack (in same GameTick). So we don't see any rendering before.
 	        new GameTickData(2, 0),
@@ -148,7 +148,7 @@ TEST(AnimationInformation, AttackSwordWarrior) // ProcessAnimationPending should
 
 TEST(AnimationInformation, AttackSwordWarriorWithFastestAttack) // Skipped frames and ProcessAnimationPending should be considered by distribution logic
 {
-	RunAnimationTest(16, 0, AnimationDistributionFlags::ProcessAnimationPending, 2, 9,
+	RunAnimationTest(16, 0, AnimationDistributionParams::ProcessAnimationPending, 2, 9,
 	    {
 	        // ProcessPlayer directly after StartAttack (in same GameTick). So we don't see any rendering before.
 	        new GameTickData(2, 0),
@@ -200,7 +200,7 @@ TEST(AnimationInformation, AttackSwordWarriorWithFastestAttack) // Skipped frame
 
 TEST(AnimationInformation, BlockingWarriorNormal) // Ignored delay for last Frame should be considered by distribution logic
 {
-	RunAnimationTest(2, 2, AnimationDistributionFlags::SkipsDelayOfLastFrame, 0, 0,
+	RunAnimationTest(2, 2, AnimationDistributionParams::SkipsDelayOfLastFrame, 0, 0,
 	    {
 	        new RenderingData(0.0f, 1),
 	        new RenderingData(0.3f, 1),
@@ -227,7 +227,7 @@ TEST(AnimationInformation, BlockingWarriorNormal) // Ignored delay for last Fram
 
 TEST(AnimationInformation, BlockingSorcererWithFastBlock) // Skipped frames and ignored delay for last Frame should be considered by distribution logic
 {
-	RunAnimationTest(6, 2, AnimationDistributionFlags::SkipsDelayOfLastFrame, 4, 0,
+	RunAnimationTest(6, 2, AnimationDistributionParams::SkipsDelayOfLastFrame, 4, 0,
 	    {
 	        new RenderingData(0.0f, 1),
 	        new RenderingData(0.3f, 1),
@@ -254,7 +254,7 @@ TEST(AnimationInformation, BlockingSorcererWithFastBlock) // Skipped frames and 
 
 TEST(AnimationInformation, HitRecoverySorcererZenMode) // Skipped frames and ignored delay for last Frame should be considered by distribution logic
 {
-	RunAnimationTest(8, 0, AnimationDistributionFlags::None, 4, 0,
+	RunAnimationTest(8, 0, AnimationDistributionParams::None, 4, 0,
 	    {
 	        new RenderingData(0.0f, 1),
 	        new RenderingData(0.3f, 1),
@@ -280,7 +280,7 @@ TEST(AnimationInformation, HitRecoverySorcererZenMode) // Skipped frames and ign
 }
 TEST(AnimationInformation, Stand) // Distribution Logic shouldn't change anything here
 {
-	RunAnimationTest(10, 3, AnimationDistributionFlags::None, 0, 0,
+	RunAnimationTest(10, 3, AnimationDistributionParams::None, 0, 0,
 	    {
 	        new RenderingData(0.1f, 1),
 	        new GameTickData(1, 1),

--- a/test/animationinformation_test.cpp
+++ b/test/animationinformation_test.cpp
@@ -88,7 +88,8 @@ TEST(AnimationInformation, AttackSwordWarrior) // ProcessAnimationPending should
 {
 	RunAnimationTest(16, 0, AnimationDistributionFlags::ProcessAnimationPending, 0, 9,
 	    {
-	        new GameTickData(2, 0), // ProcessPlayer directly after StartAttack (in same GameTick). So we don't see any rendering before.
+	        // ProcessPlayer directly after StartAttack (in same GameTick). So we don't see any rendering before.
+	        new GameTickData(2, 0),
 	        new RenderingData(0.0f, 1),
 	        new RenderingData(0.3f, 1),
 	        new RenderingData(0.6f, 1),
@@ -124,7 +125,8 @@ TEST(AnimationInformation, AttackSwordWarrior) // ProcessAnimationPending should
 	        new RenderingData(0.6f, 8),
 	        new RenderingData(0.8f, 8),
 
-	        new GameTickData(9, 0), // After this GameTick, the Animation Distribution Logic is disabled
+			// After this GameTick, the Animation Distribution Logic is disabled
+	        new GameTickData(9, 0),
 	        new RenderingData(0.1f, 9),
 	        new GameTickData(10, 0),
 	        new RenderingData(0.4f, 10),
@@ -148,7 +150,8 @@ TEST(AnimationInformation, AttackSwordWarriorWithFastestAttack) // Skipped frame
 {
 	RunAnimationTest(16, 0, AnimationDistributionFlags::ProcessAnimationPending, 2, 9,
 	    {
-	        new GameTickData(2, 0), // ProcessPlayer directly after StartAttack (in same GameTick). So we don't see any rendering before.
+	        // ProcessPlayer directly after StartAttack (in same GameTick). So we don't see any rendering before.
+	        new GameTickData(2, 0),
 	        new RenderingData(0.0f, 1),
 	        new RenderingData(0.3f, 1),
 	        new RenderingData(0.6f, 1),
@@ -174,7 +177,8 @@ TEST(AnimationInformation, AttackSwordWarriorWithFastestAttack) // Skipped frame
 	        new RenderingData(0.6f, 8),
 	        new RenderingData(0.8f, 8),
 
-	        new GameTickData(9, 0), // After this GameTick, the Animation Distribution Logic is disabled
+			// After this GameTick, the Animation Distribution Logic is disabled
+	        new GameTickData(9, 0),
 	        new RenderingData(0.1f, 9),
 	        new GameTickData(10, 0),
 	        new RenderingData(0.4f, 10),
@@ -367,7 +371,8 @@ TEST(AnimationInformation, Stand) // Distribution Logic shouldn't change anythin
 	        new GameTickData(10, 3),
 	        new RenderingData(0.6f, 10),
 
-	        new GameTickData(1, 0), // Animation starts again
+			// Animation starts again
+	        new GameTickData(1, 0),
 	        new RenderingData(0.1f, 1),
 	        new GameTickData(1, 1),
 	        new RenderingData(0.6f, 1),

--- a/test/animationinformation_test.cpp
+++ b/test/animationinformation_test.cpp
@@ -32,7 +32,9 @@ struct GameTickData : TestData {
  * This happens directly after the game_logic (_fProgressToNextGameTick = 0) or if no GameTick is due between two GameTicks (_fProgressToNextGameTick != 0).
  */
 struct RenderingData : TestData {
-
+	/*
+	* @brief the progress as a fraction (0.0f to 1.0f) in time to the next game tick
+	*/
 	float _fProgressToNextGameTick;
 	int _ExpectedRenderingFrame;
 	RenderingData(float fProgressToNextGameTick, int expectedRenderingFrame)
@@ -42,6 +44,12 @@ struct RenderingData : TestData {
 	}
 };
 
+/*
+* @brief
+* This UnitTest tries to simulate the GameLoop (GameTickData) and the Rendering that can happen (RenderingData).
+* Rendering can happen more often then GameTicks and at any time between two GameTicks.
+* The Animation Distribution Logic must adjust to the Rendering that happens at any give point in time.
+*/
 void RunAnimationTest(int numFrames, int delay, AnimationFlags flags, int numSkippedFrames, int distributeFramesBeforeFrame, const std::vector<TestData *> &vecTestData)
 {
 	const int pnum = 0;

--- a/test/animationinformation_test.cpp
+++ b/test/animationinformation_test.cpp
@@ -1,0 +1,371 @@
+#include <gtest/gtest.h>
+
+#include "nthread.h"
+#include "player.h"
+
+using namespace devilution;
+
+/**
+ * @brief Represents a Action in the game_logic or rendering.
+ */
+struct TestData {
+	virtual ~TestData() = default;
+};
+
+/**
+ * @brief Represents a GameTick, this includes skipping of Frames (for example because of Fastest Attack Modifier) and ProcessAnimation (which also updates Animation Frame/Count).
+ */
+struct GameTickData : TestData {
+	int _ExpectedAnimationFrame;
+	int _ExpectedAnimationCnt;
+	int _FramesToSkip;
+	GameTickData(int expectedAnimationFrame, int expectedAnimationCnt, int framesToSkip = 0)
+	{
+		_ExpectedAnimationFrame = expectedAnimationFrame;
+		_ExpectedAnimationCnt = expectedAnimationCnt;
+		_FramesToSkip = framesToSkip;
+	}
+};
+
+/**
+ * @brief Represents a rendering/drawing Action.
+ * This happens directly after the game_logic (_fProgressToNextGameTick = 0) or if no GameTick is due between two GameTicks (_fProgressToNextGameTick != 0).
+ */
+struct RenderingData : TestData {
+
+	float _fProgressToNextGameTick;
+	int _ExpectedRenderingFrame;
+	RenderingData(float fProgressToNextGameTick, int expectedRenderingFrame)
+	{
+		this->_fProgressToNextGameTick = fProgressToNextGameTick;
+		this->_ExpectedRenderingFrame = expectedRenderingFrame;
+	}
+};
+
+void RunAnimationTest(int numFrames, int delay, AnimationFlags flags, int numSkippedFrames, int distributeFramesBeforeFrame, const std::vector<TestData *> &vecTestData)
+{
+	const int pnum = 0;
+	PlayerStruct *pPlayer = &plr[pnum];
+	NewPlrAnim(pnum, nullptr, numFrames, delay, 128, flags, numSkippedFrames, distributeFramesBeforeFrame);
+
+	int currentGameTick = 0;
+	for (TestData *x : vecTestData) {
+		auto gameTickData = dynamic_cast<GameTickData *>(x);
+		if (gameTickData != nullptr) {
+			currentGameTick += 1;
+			if (gameTickData->_FramesToSkip != 0)
+				pPlayer->_pAnimFrame += gameTickData->_FramesToSkip;
+			ProcessPlayerAnimation(pnum);
+			EXPECT_EQ(pPlayer->_pAnimFrame, gameTickData->_ExpectedAnimationFrame);
+			EXPECT_EQ(pPlayer->_pAnimCnt, gameTickData->_ExpectedAnimationCnt);
+		}
+
+		auto renderingData = dynamic_cast<RenderingData *>(x);
+		if (renderingData != nullptr) {
+			gfProgressToNextGameTick = renderingData->_fProgressToNextGameTick;
+			EXPECT_EQ(GetFrameToUseForPlayerRendering(pPlayer), renderingData->_ExpectedRenderingFrame)
+			    << std::fixed << std::setprecision(2)
+			    << "ProgressToNextGameTick: " << renderingData->_fProgressToNextGameTick
+			    << " AnimFrame: " << pPlayer->_pAnimFrame
+			    << " AnimCnt: " << pPlayer->_pAnimCnt
+			    << " GameTick: " << currentGameTick;
+		}
+	}
+	for (TestData *x : vecTestData) {
+		delete x;
+	}
+}
+
+TEST(AnimationInformation, AttackSwordWarrior) // ProcessAnimationPending should be considered by distribution logic
+{
+	RunAnimationTest(16, 0, AnimationFlags::ProcessAnimationPending, 0, 9,
+	    {
+	        new GameTickData(2, 0), // ProcessPlayer directly after StartAttack (in same GameTick). So we don't see any rendering before.
+	        new RenderingData(0.0f, 1),
+	        new RenderingData(0.3f, 1),
+	        new RenderingData(0.6f, 1),
+	        new RenderingData(0.8f, 1),
+	        new GameTickData(3, 0),
+	        new RenderingData(0.0f, 2),
+	        new RenderingData(0.3f, 2),
+	        new RenderingData(0.6f, 2),
+	        new RenderingData(0.8f, 3),
+	        new GameTickData(4, 0),
+	        new RenderingData(0.0f, 3),
+	        new RenderingData(0.3f, 3),
+	        new RenderingData(0.6f, 3),
+	        new RenderingData(0.8f, 4),
+	        new GameTickData(5, 0),
+	        new RenderingData(0.0f, 4),
+	        new RenderingData(0.3f, 4),
+	        new RenderingData(0.6f, 5),
+	        new RenderingData(0.8f, 5),
+	        new GameTickData(6, 0),
+	        new RenderingData(0.0f, 5),
+	        new RenderingData(0.3f, 5),
+	        new RenderingData(0.6f, 6),
+	        new RenderingData(0.8f, 6),
+	        new GameTickData(7, 0),
+	        new RenderingData(0.0f, 6),
+	        new RenderingData(0.3f, 7),
+	        new RenderingData(0.6f, 7),
+	        new RenderingData(0.8f, 7),
+	        new GameTickData(8, 0),
+	        new RenderingData(0.0f, 7),
+	        new RenderingData(0.3f, 8),
+	        new RenderingData(0.6f, 8),
+	        new RenderingData(0.8f, 8),
+
+	        new GameTickData(9, 0), // After this GameTick, the Animation Distribution Logic is disabled
+	        new RenderingData(0.1f, 9),
+	        new GameTickData(10, 0),
+	        new RenderingData(0.4f, 10),
+	        new GameTickData(11, 0),
+	        new RenderingData(0.4f, 11),
+	        new GameTickData(12, 0),
+	        new RenderingData(0.3f, 12),
+	        new GameTickData(13, 0),
+	        new RenderingData(0.0f, 13),
+	        new GameTickData(14, 0),
+	        new RenderingData(0.6f, 14),
+	        new GameTickData(15, 0),
+	        new RenderingData(0.6f, 15),
+	        new GameTickData(16, 0),
+	        new RenderingData(0.6f, 16),
+	        // Animation stopped cause PM_DoAttack would stop the Animation "if (plr[pnum]._pAnimFrame == plr[pnum]._pAFrames) {"
+	    });
+}
+
+TEST(AnimationInformation, AttackSwordWarriorWithFastestAttack) // Skipped frames and ProcessAnimationPending should be considered by distribution logic
+{
+	RunAnimationTest(16, 0, AnimationFlags::ProcessAnimationPending, 2, 9,
+	    {
+	        new GameTickData(2, 0), // ProcessPlayer directly after StartAttack (in same GameTick). So we don't see any rendering before.
+	        new RenderingData(0.0f, 1),
+	        new RenderingData(0.3f, 1),
+	        new RenderingData(0.6f, 1),
+	        new RenderingData(0.8f, 2),
+	        new GameTickData(3, 0),
+	        new RenderingData(0.0f, 2),
+	        new RenderingData(0.3f, 3),
+	        new RenderingData(0.6f, 3),
+	        new RenderingData(0.8f, 3),
+	        new GameTickData(4, 0),
+	        new RenderingData(0.0f, 4),
+	        new RenderingData(0.3f, 4),
+	        new RenderingData(0.6f, 5),
+	        new RenderingData(0.8f, 5),
+	        new GameTickData(7, 0, 2),
+	        new RenderingData(0.0f, 5),
+	        new RenderingData(0.3f, 6),
+	        new RenderingData(0.6f, 6),
+	        new RenderingData(0.8f, 7),
+	        new GameTickData(8, 0),
+	        new RenderingData(0.0f, 7),
+	        new RenderingData(0.3f, 7),
+	        new RenderingData(0.6f, 8),
+	        new RenderingData(0.8f, 8),
+
+	        new GameTickData(9, 0), // After this GameTick, the Animation Distribution Logic is disabled
+	        new RenderingData(0.1f, 9),
+	        new GameTickData(10, 0),
+	        new RenderingData(0.4f, 10),
+	        new GameTickData(11, 0),
+	        new RenderingData(0.4f, 11),
+	        new GameTickData(12, 0),
+	        new RenderingData(0.3f, 12),
+	        new GameTickData(13, 0),
+	        new RenderingData(0.0f, 13),
+	        new GameTickData(14, 0),
+	        new RenderingData(0.6f, 14),
+	        new GameTickData(15, 0),
+	        new RenderingData(0.6f, 15),
+	        new GameTickData(16, 0),
+	        new RenderingData(0.6f, 16),
+	        // Animation stopped cause PM_DoAttack would stop the Animation "if (plr[pnum]._pAnimFrame == plr[pnum]._pAFrames) {"
+	    });
+}
+
+TEST(AnimationInformation, BlockingWarriorNormal) // Ignored delay for last Frame should be considered by distribution logic
+{
+	RunAnimationTest(2, 2, AnimationFlags::SkipsDelayOfLastFrame, 0, 0,
+	    {
+	        new RenderingData(0.0f, 1),
+	        new RenderingData(0.3f, 1),
+	        new RenderingData(0.6f, 1),
+	        new RenderingData(0.8f, 1),
+	        new GameTickData(1, 1),
+	        new RenderingData(0.0f, 1),
+	        new RenderingData(0.3f, 1),
+	        new RenderingData(0.6f, 1),
+	        new RenderingData(0.8f, 1),
+	        new GameTickData(1, 2),
+	        new RenderingData(0.0f, 2),
+	        new RenderingData(0.3f, 2),
+	        new RenderingData(0.6f, 2),
+	        new RenderingData(0.8f, 2),
+	        new GameTickData(2, 0),
+	        new RenderingData(0.0f, 2),
+	        new RenderingData(0.3f, 2),
+	        new RenderingData(0.6f, 2),
+	        new RenderingData(0.8f, 2),
+	        // Animation stopped cause PM_DoBlock would stop the Animation "if (plr[pnum]._pAnimFrame >= plr[pnum]._pBFrames) {"
+	    });
+}
+
+TEST(AnimationInformation, BlockingSorcererWithFastBlock) // Skipped frames and ignored delay for last Frame should be considered by distribution logic
+{
+	RunAnimationTest(6, 2, AnimationFlags::SkipsDelayOfLastFrame, 4, 0,
+	    {
+	        new RenderingData(0.0f, 1),
+	        new RenderingData(0.3f, 1),
+	        new RenderingData(0.6f, 1),
+	        new RenderingData(0.8f, 2),
+	        new GameTickData(1, 1),
+	        new RenderingData(0.0f, 2),
+	        new RenderingData(0.3f, 2),
+	        new RenderingData(0.6f, 3),
+	        new RenderingData(0.8f, 3),
+	        new GameTickData(1, 2),
+	        new RenderingData(0.0f, 4),
+	        new RenderingData(0.3f, 4),
+	        new RenderingData(0.6f, 4),
+	        new RenderingData(0.8f, 5),
+	        new GameTickData(2, 0),
+	        new RenderingData(0.0f, 5),
+	        new RenderingData(0.3f, 5),
+	        new RenderingData(0.6f, 6),
+	        new RenderingData(0.8f, 6),
+	        // Animation stopped cause PM_DoBlock would stop the Animation "if (plr[pnum]._pAnimFrame >= plr[pnum]._pBFrames) {"
+	    });
+}
+
+TEST(AnimationInformation, HitRecoverySorcererZenMode) // Skipped frames and ignored delay for last Frame should be considered by distribution logic
+{
+	RunAnimationTest(8, 0, AnimationFlags::None, 4, 0,
+	    {
+	        new RenderingData(0.0f, 1),
+	        new RenderingData(0.3f, 1),
+	        new RenderingData(0.6f, 2),
+	        new RenderingData(0.8f, 2),
+	        new GameTickData(3, 0, 1),
+	        new RenderingData(0.0f, 3),
+	        new RenderingData(0.3f, 3),
+	        new RenderingData(0.6f, 4),
+	        new RenderingData(0.8f, 4),
+	        new GameTickData(7, 0, 3),
+	        new RenderingData(0.0f, 5),
+	        new RenderingData(0.3f, 5),
+	        new RenderingData(0.6f, 6),
+	        new RenderingData(0.8f, 6),
+	        new GameTickData(8, 0),
+	        new RenderingData(0.0f, 7),
+	        new RenderingData(0.3f, 7),
+	        new RenderingData(0.6f, 8),
+	        new RenderingData(0.8f, 8),
+	        // Animation stopped cause PM_DoGotHit would stop the Animation "if (plr[pnum]._pAnimFrame >= plr[pnum]._pHFrames) {"
+	    });
+}
+TEST(AnimationInformation, Stand) // Distribution Logic shouldn't change anything here
+{
+	RunAnimationTest(10, 3, AnimationFlags::None, 0, 0,
+	    {
+	        new RenderingData(0.1f, 1),
+	        new GameTickData(1, 1),
+	        new RenderingData(0.6f, 1),
+	        new GameTickData(1, 2),
+	        new RenderingData(0.6f, 1),
+	        new GameTickData(1, 3),
+	        new RenderingData(0.6f, 1),
+
+	        new GameTickData(2, 0),
+	        new RenderingData(0.6f, 2),
+	        new GameTickData(2, 1),
+	        new RenderingData(0.6f, 2),
+	        new GameTickData(2, 2),
+	        new RenderingData(0.6f, 2),
+	        new GameTickData(2, 3),
+	        new RenderingData(0.6f, 2),
+
+	        new GameTickData(3, 0),
+	        new RenderingData(0.6f, 3),
+	        new GameTickData(3, 1),
+	        new RenderingData(0.6f, 3),
+	        new GameTickData(3, 2),
+	        new RenderingData(0.6f, 3),
+	        new GameTickData(3, 3),
+	        new RenderingData(0.6f, 3),
+
+	        new GameTickData(4, 0),
+	        new RenderingData(0.6f, 4),
+	        new GameTickData(4, 1),
+	        new RenderingData(0.6f, 4),
+	        new GameTickData(4, 2),
+	        new RenderingData(0.6f, 4),
+	        new GameTickData(4, 3),
+	        new RenderingData(0.6f, 4),
+
+	        new GameTickData(5, 0),
+	        new RenderingData(0.6f, 5),
+	        new GameTickData(5, 1),
+	        new RenderingData(0.6f, 5),
+	        new GameTickData(5, 2),
+	        new RenderingData(0.6f, 5),
+	        new GameTickData(5, 3),
+	        new RenderingData(0.6f, 5),
+
+	        new GameTickData(6, 0),
+	        new RenderingData(0.6f, 6),
+	        new GameTickData(6, 1),
+	        new RenderingData(0.6f, 6),
+	        new GameTickData(6, 2),
+	        new RenderingData(0.6f, 6),
+	        new GameTickData(6, 3),
+	        new RenderingData(0.6f, 6),
+
+	        new GameTickData(7, 0),
+	        new RenderingData(0.6f, 7),
+	        new GameTickData(7, 1),
+	        new RenderingData(0.6f, 7),
+	        new GameTickData(7, 2),
+	        new RenderingData(0.6f, 7),
+	        new GameTickData(7, 3),
+	        new RenderingData(0.6f, 7),
+
+	        new GameTickData(8, 0),
+	        new RenderingData(0.6f, 8),
+	        new GameTickData(8, 1),
+	        new RenderingData(0.6f, 8),
+	        new GameTickData(8, 2),
+	        new RenderingData(0.6f, 8),
+	        new GameTickData(8, 3),
+	        new RenderingData(0.6f, 8),
+
+	        new GameTickData(9, 0),
+	        new RenderingData(0.6f, 9),
+	        new GameTickData(9, 1),
+	        new RenderingData(0.6f, 9),
+	        new GameTickData(9, 2),
+	        new RenderingData(0.6f, 9),
+	        new GameTickData(9, 3),
+	        new RenderingData(0.6f, 9),
+
+	        new GameTickData(10, 0),
+	        new RenderingData(0.6f, 10),
+	        new GameTickData(10, 1),
+	        new RenderingData(0.6f, 10),
+	        new GameTickData(10, 2),
+	        new RenderingData(0.6f, 10),
+	        new GameTickData(10, 3),
+	        new RenderingData(0.6f, 10),
+
+	        new GameTickData(1, 0), // Animation starts again
+	        new RenderingData(0.1f, 1),
+	        new GameTickData(1, 1),
+	        new RenderingData(0.6f, 1),
+	        new GameTickData(1, 2),
+	        new RenderingData(0.6f, 1),
+	        new GameTickData(1, 3),
+	        new RenderingData(0.6f, 1),
+	    });
+}

--- a/test/animationinformation_test.cpp
+++ b/test/animationinformation_test.cpp
@@ -50,7 +50,7 @@ struct RenderingData : TestData {
 * Rendering can happen more often then GameTicks and at any time between two GameTicks.
 * The Animation Distribution Logic must adjust to the Rendering that happens at any give point in time.
 */
-void RunAnimationTest(int numFrames, int delay, AnimationFlags flags, int numSkippedFrames, int distributeFramesBeforeFrame, const std::vector<TestData *> &vecTestData)
+void RunAnimationTest(int numFrames, int delay, AnimationDistributionFlags flags, int numSkippedFrames, int distributeFramesBeforeFrame, const std::vector<TestData *> &vecTestData)
 {
 	const int pnum = 0;
 	PlayerStruct *pPlayer = &plr[pnum];
@@ -86,7 +86,7 @@ void RunAnimationTest(int numFrames, int delay, AnimationFlags flags, int numSki
 
 TEST(AnimationInformation, AttackSwordWarrior) // ProcessAnimationPending should be considered by distribution logic
 {
-	RunAnimationTest(16, 0, AnimationFlags::ProcessAnimationPending, 0, 9,
+	RunAnimationTest(16, 0, AnimationDistributionFlags::ProcessAnimationPending, 0, 9,
 	    {
 	        new GameTickData(2, 0), // ProcessPlayer directly after StartAttack (in same GameTick). So we don't see any rendering before.
 	        new RenderingData(0.0f, 1),
@@ -146,7 +146,7 @@ TEST(AnimationInformation, AttackSwordWarrior) // ProcessAnimationPending should
 
 TEST(AnimationInformation, AttackSwordWarriorWithFastestAttack) // Skipped frames and ProcessAnimationPending should be considered by distribution logic
 {
-	RunAnimationTest(16, 0, AnimationFlags::ProcessAnimationPending, 2, 9,
+	RunAnimationTest(16, 0, AnimationDistributionFlags::ProcessAnimationPending, 2, 9,
 	    {
 	        new GameTickData(2, 0), // ProcessPlayer directly after StartAttack (in same GameTick). So we don't see any rendering before.
 	        new RenderingData(0.0f, 1),
@@ -196,7 +196,7 @@ TEST(AnimationInformation, AttackSwordWarriorWithFastestAttack) // Skipped frame
 
 TEST(AnimationInformation, BlockingWarriorNormal) // Ignored delay for last Frame should be considered by distribution logic
 {
-	RunAnimationTest(2, 2, AnimationFlags::SkipsDelayOfLastFrame, 0, 0,
+	RunAnimationTest(2, 2, AnimationDistributionFlags::SkipsDelayOfLastFrame, 0, 0,
 	    {
 	        new RenderingData(0.0f, 1),
 	        new RenderingData(0.3f, 1),
@@ -223,7 +223,7 @@ TEST(AnimationInformation, BlockingWarriorNormal) // Ignored delay for last Fram
 
 TEST(AnimationInformation, BlockingSorcererWithFastBlock) // Skipped frames and ignored delay for last Frame should be considered by distribution logic
 {
-	RunAnimationTest(6, 2, AnimationFlags::SkipsDelayOfLastFrame, 4, 0,
+	RunAnimationTest(6, 2, AnimationDistributionFlags::SkipsDelayOfLastFrame, 4, 0,
 	    {
 	        new RenderingData(0.0f, 1),
 	        new RenderingData(0.3f, 1),
@@ -250,7 +250,7 @@ TEST(AnimationInformation, BlockingSorcererWithFastBlock) // Skipped frames and 
 
 TEST(AnimationInformation, HitRecoverySorcererZenMode) // Skipped frames and ignored delay for last Frame should be considered by distribution logic
 {
-	RunAnimationTest(8, 0, AnimationFlags::None, 4, 0,
+	RunAnimationTest(8, 0, AnimationDistributionFlags::None, 4, 0,
 	    {
 	        new RenderingData(0.0f, 1),
 	        new RenderingData(0.3f, 1),
@@ -276,7 +276,7 @@ TEST(AnimationInformation, HitRecoverySorcererZenMode) // Skipped frames and ign
 }
 TEST(AnimationInformation, Stand) // Distribution Logic shouldn't change anything here
 {
-	RunAnimationTest(10, 3, AnimationFlags::None, 0, 0,
+	RunAnimationTest(10, 3, AnimationDistributionFlags::None, 0, 0,
 	    {
 	        new RenderingData(0.1f, 1),
 	        new GameTickData(1, 1),


### PR DESCRIPTION
This is the successor of #1468

Content:

- Adds correct logic, if delay is specified (fixes fast blocking bug)
- Small refactoring of Calculation, so that the calculation is only done when `NewPlrAnim` is called and not needed every time we render. This also reduces the number of variables we need in `PlayerStruct`.
- Extra comments that explain the logic further
- UnitTests for the Animation Distribution Logic

Notes:

- I wasn't sure if the new flags enum "AnimationFlags" should be `enum class` or normal `enum`.
- If #1507 is commited first, I will add __attribute__((flag_enum)) to the new enum.
- I named the test `AnimationInformation` cause this would be the name of the class when I refactor the logic out of player.h/cpp. if you have a better name, I will change. Other names I had in mind ("AnimationDistribution", "AnimationLogic", "Animation").

Please guide me if something is wrong. Thanks 😊 