### PR TITLE
Fix for a rare legacy bug causing network desync

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1113,7 +1113,6 @@ void CheckInvPaste(int pnum, int mx, int my)
 		cn = SwapItem(&plr[pnum].InvBody[INVLOC_HAND_RIGHT], &plr[pnum].HoldItem);
 		break;
 	case ILOC_TWOHAND:
-		NetSendCmdDelItem(false, INVLOC_HAND_RIGHT);
 		if (!plr[pnum].InvBody[INVLOC_HAND_LEFT].isEmpty() && !plr[pnum].InvBody[INVLOC_HAND_RIGHT].isEmpty()) {
 			tempitem = plr[pnum].HoldItem;
 			if (plr[pnum].InvBody[INVLOC_HAND_RIGHT]._itype == ITYPE_SHIELD)
@@ -1138,6 +1137,8 @@ void CheckInvPaste(int pnum, int mx, int my)
 			else
 				plr[pnum].InvBody[INVLOC_HAND_LEFT]._itype = ITYPE_NONE;
 		}
+
+		NetSendCmdDelItem(false, INVLOC_HAND_RIGHT);
 
 		if (!plr[pnum].InvBody[INVLOC_HAND_LEFT].isEmpty() || !plr[pnum].InvBody[INVLOC_HAND_RIGHT].isEmpty()) {
 			NetSendCmdChItem(false, INVLOC_HAND_LEFT);


### PR DESCRIPTION
If a player tries to swap sword+shield with a two-handed weapon without sufficient inventory space it leads to a network desync (what's in the right hand gets de-equipped on other clients, but not for local client).

Video example: https://www.youtube.com/watch?v=2GtUv-m8FoI

The cause was the game always sending a network packet for de-equipping the right-hand item before even checking if the local player has space to do the weapon swap.

(Uh, never mind the shield position looking weird. That's an unrelated issue caused by another commit.)