### PR TITLE
bugfix idle animation after equipping/unequipping

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1075,7 +1075,7 @@ void CalcPlrItemVals(int p, bool Loadgfx)
 		d = plr[p]._pdir;
 
 		assert(plr[p]._pNAnim[d]);
-		NewPlrAnim(p, plr[p]._pNAnim[d], plr[p]._pNFrames, 0, plr[p]._pNWidth);
+		NewPlrAnim(p, plr[p]._pNAnim[d], plr[p]._pNFrames, 3, plr[p]._pNWidth);
 	} else {
 		plr[p]._pgfxnum = g;
 	}


### PR DESCRIPTION
Fixes #1545

Introduced with #1468
Some [careless mistake](https://github.com/obligaron/devilutionX/commit/c7b9ffec1f1ddd95d92fc1bc0bac8258bf7ebfe4#diff-be3ecbe1ead4062ccd317dfeb0428b38adf3d54377059e602229c75bfc052da8R1078) from replacing redundant sourcecode with a function call (passed wrong delay).

Now I hope the character can relax and is less nervous if a weapon is swapped 😄 