### PR TITLE
Fix SErrGet/SetLastError

### DIFF
--- a/Source/miniwin/miniwin.h
+++ b/Source/miniwin/miniwin.h
@@ -11,8 +11,6 @@
 #include <string.h>
 #include <time.h>
 
-#include "storm/storm_full.h"
-
 namespace devilution {
 
 #ifndef MAX_PATH

--- a/Source/storm/storm.cpp
+++ b/Source/storm/storm.cpp
@@ -23,9 +23,19 @@
 #include "utils/sdl_compat.h"
 #include "utils/stubs.h"
 
-namespace devilution {
+// Include Windows headers for Get/SetLastError.
+#if defined(_WIN32)
+// Suppress definitions of `min` and `max` macros by <windows.h>:
+#define NOMINMAX 1
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else // !defined(_WIN32)
+// On non-Windows, these are defined in 3rdParty/StormLib.
+extern "C" void SetLastError(std::uint32_t dwErrCode);
+extern "C" std::uint32_t GetLastError();
+#endif
 
-uint32_t nLastError = 0;
+namespace devilution {
 
 namespace {
 
@@ -801,12 +811,12 @@ void SVidPlayEnd(HANDLE video)
 
 DWORD SErrGetLastError()
 {
-	return nLastError;
+	return ::GetLastError();
 }
 
 void SErrSetLastError(DWORD dwErrCode)
 {
-	nLastError = dwErrCode;
+	::SetLastError(dwErrCode);
 }
 
 bool SFileSetBasePath(const char *path)

--- a/Source/storm/storm_full.h
+++ b/Source/storm/storm_full.h
@@ -1,9 +1,0 @@
-#pragma once
-
-#include <stdint.h>
-
-namespace devilution {
-
-extern uint32_t nLastError;
-
-} // namespace devilution


### PR DESCRIPTION
SErrGet/SetLastError were not propagating errors from 3rdParty/StormLib because StormLib uses native Windows functions on Windows and defines its own on Linux.

Also removes `storm_full.h`