### PR TITLE
Fix Storm error code on Windows

### DIFF
--- a/Source/miniwin/miniwin.h
+++ b/Source/miniwin/miniwin.h
@@ -89,8 +89,6 @@ bool PostMessage(UINT Msg, WPARAM wParam, LPARAM lParam);
 #define DVL_FILE_CURRENT 1
 #define DVL_FILE_END 2
 
-#define DVL_ERROR_HANDLE_EOF 1002
-
 #define DVL_WM_QUIT 0x0012
 
 //

--- a/Source/storm/storm.h
+++ b/Source/storm/storm.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cerrno>
 #include <cstdint>
 #include <limits>
 #include <string>
@@ -287,6 +288,17 @@ void setIniFloat(const char *keyname, const char *valuename, float value);
 
 void SVidPlayBegin(const char *filename, int flags, HANDLE *video);
 void SVidPlayEnd(HANDLE video);
+
+// These error codes are used and returned by StormLib.
+// See StormLib/src/StormPort.h
+#if defined(_WIN32)
+// https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
+#define STORM_ERROR_FILE_NOT_FOUND 2
+#define STORM_ERROR_HANDLE_EOF 38
+#else // !defined(_WIN32)
+#define STORM_ERROR_FILE_NOT_FOUND ENOENT
+#define STORM_ERROR_HANDLE_EOF 1002
+#endif
 
 /*  SErrGetLastError @ 463
  *

--- a/Source/storm/storm_sdl_rw.cpp
+++ b/Source/storm/storm_sdl_rw.cpp
@@ -61,7 +61,7 @@ static int SFileRw_read(struct SDL_RWops *context, void *ptr, int size, int maxn
 	DWORD num_read = 0;
 	if (!SFileReadFile(SFileRw_GetHandle(context), ptr, maxnum * size, &num_read, NULL)) {
 		const DWORD err_code = SErrGetLastError();
-		if (err_code != DVL_ERROR_HANDLE_EOF) {
+		if (err_code != STORM_ERROR_HANDLE_EOF) {
 			SDL_Log("SFileRw_read error: %u %u ERROR CODE %u", (unsigned int)size, (unsigned int)maxnum, (unsigned int)err_code);
 		}
 	}


### PR DESCRIPTION
`DVL_ERROR_HANDLE_EOF` was defined incorrectly on Windows.

These error codes are used and returned by Storm. Moves them from `miniwin.h` to `storm.h`.