### PR TITLE
🐛 Ensure picked up items on the ground are removed

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1911,7 +1911,7 @@ void AutoGetItem(int pnum, ItemStruct *item, int ii)
 	}
 
 	if (done) {
-		CleanupItems(&plr[pnum].HoldItem, ii);
+		CleanupItems(&items[ii], ii);
 		return;
 	}
 


### PR DESCRIPTION
This PR fixes an issue introduced in commit https://github.com/diasurgical/devilutionX/commit/01606ea4df8150367d6401e49921b8d21b133eae that caused picked up items to remain visible on the group in some situations.

Relying on HoldItem is incorrect as it points to a different copy of the item than the global item array, so even if the item is assigned earlier, we cannot use that value.

This fixes #1519