### PR TITLE
bugfix pfile_flush_W() not clearing tables

### DIFF
--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -223,28 +223,32 @@ struct Archive {
 
 	bool Close(bool clear_tables = true)
 	{
-		if (!stream.IsOpen())
-			return true;
+		bool result = true;
+		if (stream.IsOpen()) {
 #ifdef _DEBUG
-		SDL_Log("Closing %s", name.c_str());
+			SDL_Log("Closing %s", name.c_str());
 #endif
 
-		bool result = true;
-		if (modified && !(stream.seekp(0, std::ios::beg) && WriteHeaderAndTables()))
-			result = false;
-		stream.Close();
-		if (modified && result && size != 0) {
+			if (modified && !(stream.seekp(0, std::ios::beg) && WriteHeaderAndTables()))
+				result = false;
+			stream.Close();
+			if (modified && result && size != 0) {
 #ifdef _DEBUG
-			SDL_Log("ResizeFile(\"%s\", %" PRIuMAX ")", name.c_str(), size);
+				SDL_Log("ResizeFile(\"%s\", %" PRIuMAX ")", name.c_str(), size);
 #endif
-			result = ResizeFile(name.c_str(), size);
+				result = ResizeFile(name.c_str(), size);
+			}
+			name.clear();
 		}
-		name.clear();
 		if (clear_tables) {
-			delete[] sgpHashTbl;
-			sgpHashTbl = NULL;
-			delete[] sgpBlockTbl;
-			sgpBlockTbl = NULL;
+			if(sgpHashTbl) {
+				delete[] sgpHashTbl;
+				sgpHashTbl = NULL;
+			}
+			if(sgpBlockTbl) {
+				delete[] sgpBlockTbl;
+				sgpBlockTbl = NULL;
+			}
 		}
 		return result;
 	}


### PR DESCRIPTION
With the new Archive class, pfile_flush_W() currently does nothing, since the archive is regarded as already closed. However, it should clear the hash and block tables.

pfile_flush_W() is called when leaving a game. If at that time the tables are not cleared, the next character loaded will use the same tables, resulting in crashes.

Example to reproduce: Have 2 vanilla savegames, join a game with the first, then leave, then join a game with the second, then drop an item on the floor.