### PR TITLE
🐞 pfile: Fix stale tables after leaving a game

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -388,10 +388,9 @@ static void run_game_loop(interface_mode uMsg)
 	}
 
 	if (gbIsMultiplayer) {
-		pfile_write_hero();
+		pfile_write_hero(/*write_game_data=*/false, /*clear_tables=*/true);
 	}
 
-	pfile_flush_W();
 	PaletteFadeOut(8);
 	NewCursor(CURSOR_NONE);
 	ClearScreenBuffer();

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -83,9 +83,8 @@ char gszProductName[64] = "DevilutionX vUnknown";
 void init_cleanup()
 {
 	if (gbIsMultiplayer && gbRunGame) {
-		pfile_write_hero();
+		pfile_write_hero(/*write_game_data=*/false, /*clear_tables=*/true);
 	}
-	pfile_flush_W();
 
 	if (spawn_mpq) {
 		SFileCloseArchive(spawn_mpq);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1924,7 +1924,7 @@ void SaveGameData()
 
 void SaveGame() {
 	gbValidSaveFile = true;
-	pfile_write_hero(/*save_game_data=*/true);
+	pfile_write_hero(/*write_game_data=*/true);
 }
 
 void SaveLevel()

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -220,8 +220,9 @@ static void pfile_SFileCloseArchive(HANDLE *hsArchive)
 	*hsArchive = NULL;
 }
 
-PFileScopedArchiveWriter::PFileScopedArchiveWriter()
+PFileScopedArchiveWriter::PFileScopedArchiveWriter(bool clear_tables)
     : save_num_(pfile_get_save_num_from_name(plr[myplr]._pName))
+    , clear_tables_(clear_tables)
 {
 	if (!pfile_open_archive(save_num_))
 		app_fatal("Failed to open player archive for writing.");
@@ -229,12 +230,12 @@ PFileScopedArchiveWriter::PFileScopedArchiveWriter()
 
 PFileScopedArchiveWriter::~PFileScopedArchiveWriter()
 {
-	pfile_flush(!gbIsMultiplayer, save_num_);
+	pfile_flush(clear_tables_, save_num_);
 }
 
-void pfile_write_hero(bool write_game_data)
+void pfile_write_hero(bool write_game_data, bool clear_tables)
 {
-	PFileScopedArchiveWriter scoped_writer;
+	PFileScopedArchiveWriter scoped_writer(clear_tables);
 	if (write_game_data) {
 		SaveGameData();
 		pfile_rename_temp_to_perm();
@@ -276,11 +277,6 @@ bool pfile_create_player_description()
 	UiSetupPlayerInfo(gszHero, &uihero, GAME_ID);
 
 	return true;
-}
-
-void pfile_flush_W()
-{
-	pfile_flush(true, pfile_get_save_num_from_name(plr[myplr]._pName));
 }
 
 bool pfile_ui_set_hero_infos(bool (*ui_add_hero_info)(_uiheroinfo *))

--- a/Source/pfile.h
+++ b/Source/pfile.h
@@ -17,19 +17,19 @@ extern bool gbValidSaveFile;
 class PFileScopedArchiveWriter {
 public:
 	// Opens the player save file for writing
-	PFileScopedArchiveWriter();
+	PFileScopedArchiveWriter(bool clear_tables = !gbIsMultiplayer);
 
 	// Finishes writing and closes the player save file.
 	~PFileScopedArchiveWriter();
 
 private:
 	DWORD save_num_;
+	bool clear_tables_;
 };
 
 const char *pfile_get_password();
-void pfile_write_hero(bool write_game_data = false);
+void pfile_write_hero(bool write_game_data = false, bool clear_tables = !gbIsMultiplayer);
 bool pfile_create_player_description();
-void pfile_flush_W();
 bool pfile_ui_set_hero_infos(bool (*ui_add_hero_info)(_uiheroinfo *));
 bool pfile_archive_contains_game(HANDLE hsArchive, DWORD save_num);
 void pfile_ui_set_class_stats(unsigned int player_class_nr, _uidefaultstats *class_stats);


### PR DESCRIPTION
In multiplayer, the hash and block tables are kept around between the saves (presumably to improve performance).

When leaving the game, they should be cleared.

Clearing of the tables is handled by `Archive::Close` in `mpqapi.cpp`.

After #1426, which moved the archive closing inside `pfile_write_hero`, the tables were no longer cleared on `pfile_flush_W` (because the archive was already closed when it was called).

To fix the issue, this commit adds a `clear_tables` argument to `pfile_write_hero` and removes the `pfile_flush_W` function.

Bug reported and root cause found by @Eider-McDuck:

> Example to reproduce: Have 2 vanilla savegames, join a game with the first,
> then leave, then join a game with the second, then drop an item on the floor.

Initial proposed fix by @Eider-McDuck: #1555