### PR TITLE
fancy stairs2

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -13,6 +13,7 @@
 #include "setmaps.h"
 #include "utils/ui_fwd.h"
 #include "trigs.h"
+#include "options.h"
 
 namespace devilution {
 
@@ -115,24 +116,26 @@ void DrawAutomapTile(CelOutputBuffer out, Sint32 sx, Sint32 sy, Uint16 automap_t
 		DrawLineTo(out, sx - AmLine16, sy - AmLine8, sx + AmLine16, sy + AmLine8, COLOR_BRIGHT);
 		DrawLineTo(out, sx - AmLine16 - AmLine8, sy - AmLine4, sx + AmLine8, sy + AmLine8 + AmLine4, COLOR_BRIGHT);
 		DrawLineTo(out, sx - AmLine32, sy, sx, sy + AmLine16, COLOR_BRIGHT);
-		int radius = 2;
-		if (leveltype == DTYPE_HELL)
-			radius = 5; //hell stairs are bigger, detect all segments
-		for (int j = 0; j < numtrigs; j++) {
-			if (abs(trigs[j]._tx - ((dunx << 1) + 16)) <= radius && abs(trigs[j]._ty - ((duny << 1) + 16)) <= radius) {
-				switch (trigs[j]._tmsg) {
-				case WM_DIABTWARPUP:
-					DrawEntranceWarp(out, sx, sy);
-					break;
-				case WM_DIABNEXTLVL:
-					DrawEntranceNext(out, sx, sy);
-					break;
-				case WM_DIABPREVLVL:
-					DrawEntrancePrev(out, sx, sy);
-					break;
-				default:
-					SDL_Log("UNKNOWN STAIRS: %d", trigs[j]._tmsg);
-					break;
+		if(sgOptions.Gameplay.bRecolorStairs){
+			int radius = 2;
+			if (leveltype == DTYPE_HELL)
+				radius = 5; //hell stairs are bigger, detect all segments
+			for (int j = 0; j < numtrigs; j++) {
+				if (abs(trigs[j]._tx - ((dunx << 1) + 16)) <= radius && abs(trigs[j]._ty - ((duny << 1) + 16)) <= radius) {
+					switch (trigs[j]._tmsg) {
+					case WM_DIABTWARPUP:
+						DrawEntranceWarp(out, sx, sy);
+						break;
+					case WM_DIABNEXTLVL:
+						DrawEntranceNext(out, sx, sy);
+						break;
+					case WM_DIABPREVLVL:
+						DrawEntrancePrev(out, sx, sy);
+						break;
+					default:
+						SDL_Log("UNKNOWN STAIRS: %d", trigs[j]._tmsg);
+						break;
+					}
 				}
 			}
 		}

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -117,7 +117,7 @@ void DrawAutomapTile(CelOutputBuffer out, Sint32 sx, Sint32 sy, Uint16 automap_t
 		DrawLineTo(out, sx - AmLine32, sy, sx, sy + AmLine16, COLOR_BRIGHT);
 		int radius = 2;
 		if (leveltype == DTYPE_HELL)
-			radius = 4; //hell stairs are bigger, detect all segments
+			radius = 5; //hell stairs are bigger, detect all segments
 		for (int j = 0; j < numtrigs; j++) {
 			if (abs(trigs[j]._tx - ((dunx << 1) + 16)) <= radius && abs(trigs[j]._ty - ((duny << 1) + 16)) <= radius) {
 				switch (trigs[j]._tmsg) {

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -501,6 +501,7 @@ static void SaveOptions()
 	setIniInt("Game", "Auto Equip Jewelry", sgOptions.Gameplay.bAutoEquipJewelry);
 	setIniInt("Game", "Randomize Quests", sgOptions.Gameplay.bRandomizeQuests);
 	setIniInt("Game", "Show Monster Type", sgOptions.Gameplay.bShowMonsterType);
+	setIniInt("Game", "Recolor Stairs On Automap", sgOptions.Gameplay.bRecolorStairs);
 
 	setIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress);
 	setIniInt("Network", "Port", sgOptions.Network.nPort);
@@ -575,6 +576,7 @@ static void LoadOptions()
 	sgOptions.Gameplay.bAutoEquipJewelry = getIniBool("Game", "Auto Equip Jewelry", false);
 	sgOptions.Gameplay.bRandomizeQuests = getIniBool("Game", "Randomize Quests", true);
 	sgOptions.Gameplay.bShowMonsterType = getIniBool("Game", "Show Monster Type", false);
+	sgOptions.Gameplay.bRecolorStairs = getIniBool("Game", "Recolor Stairs On Automap", false);
 
 	getIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress, sizeof(sgOptions.Network.szBindAddress), "0.0.0.0");
 	sgOptions.Network.nPort = getIniInt("Network", "Port", 6112);

--- a/Source/options.h
+++ b/Source/options.h
@@ -93,6 +93,8 @@ struct GameplayOptions {
 	bool bRandomizeQuests;
 	/** @brief Indicates whether or not monster type (Animal, Demon, Undead) is shown along with other monster information. */
 	bool bShowMonsterType;
+	/** @brief Recolors stairs on automap based on their type - down = red, up = blue, town entrance = white. */
+	bool bRecolorStairs;
 };
 
 struct ControllerOptions {


### PR DESCRIPTION
Much cleaner implementation than the previous attempt + at the moment I think recoloring is the only sane way as stairs are built from varying number of segments (1x1 for church/catas, hell = 3x2, caves stairs up = 1x2) so patterns look weird, same with attempting to display some symbol next to it

![image](https://user-images.githubusercontent.com/14297035/115098636-60223300-9f31-11eb-9594-31861a1cb76c.png)
![image](https://user-images.githubusercontent.com/14297035/115098646-6ca68b80-9f31-11eb-9c10-9b0a37cc0273.png)
![image](https://user-images.githubusercontent.com/14297035/115098800-55b46900-9f32-11eb-9afc-55bfa058a5a1.png)


Current color code: 
red = stairs down
blue = stairs up
white = warp to town
standard color = quest stairs (chamber of bone only?)