### PR TITLE
Prevent player from queuing up a spell which would cause mana to drop below 0

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3898,7 +3898,7 @@ void CheckPlrSpell()
 	switch (plr[myplr]._pRSplType) {
 	case RSPLTYPE_SKILL:
 	case RSPLTYPE_SPELL:
-		addflag = CheckSpell(myplr, rspell, plr[myplr]._pRSplType, false);
+		addflag = CheckSpell(myplr, rspell, plr[myplr]._pRSplType, false, true);
 		break;
 	case RSPLTYPE_SCROLL:
 		addflag = UseScroll();

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -163,7 +163,7 @@ void EnsureValidReadiedSpell(PlayerStruct &player)
 	}
 }
 
-bool CheckSpell(int id, spell_id sn, spell_type st, bool manaonly)
+bool CheckSpell(int id, spell_id sn, spell_type st, bool manaonly, bool addCostOfSpellInProgress)
 {
 	bool result;
 
@@ -180,7 +180,13 @@ bool CheckSpell(int id, spell_id sn, spell_type st, bool manaonly)
 			if (GetSpellLevel(id, sn) <= 0) {
 				result = false;
 			} else {
-				result = plr[id]._pMana >= GetManaAmount(id, sn);
+				int manaCost = GetManaAmount(id, sn);
+
+				//If player is currently casting a spell (but hasn't spent mana on it yet) then add that spell cost as well
+				if (addCostOfSpellInProgress && plr[id]._pmode == PM_SPELL && plr[id]._pVar8 <= plr[id]._pSFNum)
+					manaCost += GetManaAmount(id, plr[id]._pSpell);
+
+				result = plr[id]._pMana >= manaCost;
 			}
 		}
 	}

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -12,7 +12,7 @@ namespace devilution {
 int GetManaAmount(int id, spell_id sn);
 void UseMana(int id, spell_id sn);
 Uint64 GetSpellBitmask(int spellId);
-bool CheckSpell(int id, spell_id sn, spell_type st, bool manaonly);
+bool CheckSpell(int id, spell_id sn, spell_type st, bool manaonly, bool addCostOfSpellInProgress = false);
 void EnsureValidReadiedSpell(PlayerStruct &player);
 void CastSpell(int id, int spl, int sx, int sy, int dx, int dy, int spllvl);
 void DoResurrect(int pnum, int rid);


### PR DESCRIPTION
Did a brief test in SP and MP and this seems to work fine.

The check if the player hasn't finished casting a spell yet is very ugly, though.

This is one potential way the player could still result in negative health with this solution:
- Get hit while mana shield is active after queueing up spell (mana check only happens once)