### PR TITLE
Dead clean up and direction enums

### DIFF
--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -13,16 +13,16 @@
 namespace devilution {
 
 DeadStruct dead[MAXDEAD];
-int stonendx;
+int8_t stonendx;
 
 void InitDead()
 {
-	int mtypes[MAXMONSTERS];
+	int8_t mtypes[MAXMONSTERS];
 
-	for (int &mtype : mtypes)
+	for (int8_t &mtype : mtypes)
 		mtype = 0;
 
-	int nd = 0;
+	int8_t nd = 0;
 
 	for (int i = 0; i < nummtypes; i++) {
 		if (mtypes[Monsters[i].mtype] == 0) {
@@ -32,9 +32,10 @@ void InitDead()
 			dead[nd]._deadWidth = Monsters[i].width;
 			dead[nd]._deadWidth2 = Monsters[i].width2;
 			dead[nd]._deadtrans = 0;
-			Monsters[i].mdeadval = nd + 1;
-			mtypes[Monsters[i].mtype] = nd + 1;
 			nd++;
+
+			Monsters[i].mdeadval = nd;
+			mtypes[Monsters[i].mtype] = nd;
 		}
 	}
 
@@ -48,12 +49,14 @@ void InitDead()
 
 	for (auto &d : dead[nd]._deadData)
 		d = misfiledata[MFILE_SHATTER1].mAnimData[0];
+
 	dead[nd]._deadFrame = 12;
 	dead[nd]._deadWidth = 128;
 	dead[nd]._deadWidth2 = 32;
 	dead[nd]._deadtrans = 0;
-	stonendx = nd + 1;
 	nd++;
+
+	stonendx = nd;
 
 	for (int i = 0; i < nummonsters; i++) {
 		int mi = monstactive[i];
@@ -64,15 +67,16 @@ void InitDead()
 			dead[nd]._deadWidth = monster[mi].MType->width;
 			dead[nd]._deadWidth2 = monster[mi].MType->width2;
 			dead[nd]._deadtrans = monster[mi]._uniqtrans + 4;
-			monster[mi]._udeadval = nd + 1;
 			nd++;
+
+			monster[mi]._udeadval = nd;
 		}
 	}
 
 	assert(nd <= MAXDEAD);
 }
 
-void AddDead(int dx, int dy, char dv, int ddir)
+void AddDead(int dx, int dy, int8_t dv, int ddir)
 {
 	dDead[dx][dy] = (dv & 0x1F) + (ddir << 5);
 }

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -76,7 +76,7 @@ void InitDead()
 	assert(nd <= MAXDEAD);
 }
 
-void AddDead(int dx, int dy, int8_t dv, int ddir)
+void AddDead(int dx, int dy, int8_t dv, direction ddir)
 {
 	dDead[dx][dy] = (dv & 0x1F) + (ddir << 5);
 }

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -19,17 +19,16 @@ int stonendx;
 
 void InitDead()
 {
-	int i, d, nd, mi;
 	int mtypes[MAXMONSTERS];
 
-	for (i = 0; i < MAXMONSTERS; i++)
+	for (int i = 0; i < MAXMONSTERS; i++)
 		mtypes[i] = 0;
 
-	nd = 0;
+	int nd = 0;
 
-	for (i = 0; i < nummtypes; i++) {
+	for (int i = 0; i < nummtypes; i++) {
 		if (mtypes[Monsters[i].mtype] == 0) {
-			for (d = 0; d < 8; d++)
+			for (int d = 0; d < 8; d++)
 				dead[nd]._deadData[d] = Monsters[i].Anims[MA_DEATH].Data[d];
 			dead[nd]._deadFrame = Monsters[i].Anims[MA_DEATH].Frames;
 			dead[nd]._deadWidth = Monsters[i].width;
@@ -41,7 +40,7 @@ void InitDead()
 		}
 	}
 
-	for (d = 0; d < 8; d++)
+	for (int d = 0; d < 8; d++)
 		dead[nd]._deadData[d] = misfiledata[MFILE_BLODBUR].mAnimData[0];
 	dead[nd]._deadFrame = 8;
 	dead[nd]._deadWidth = 128;
@@ -49,7 +48,7 @@ void InitDead()
 	dead[nd]._deadtrans = 0;
 	nd++;
 
-	for (d = 0; d < 8; d++)
+	for (int d = 0; d < 8; d++)
 		dead[nd]._deadData[d] = misfiledata[MFILE_SHATTER1].mAnimData[0];
 	dead[nd]._deadFrame = 12;
 	dead[nd]._deadWidth = 128;
@@ -58,10 +57,10 @@ void InitDead()
 	stonendx = nd + 1;
 	nd++;
 
-	for (i = 0; i < nummonsters; i++) {
-		mi = monstactive[i];
+	for (int i = 0; i < nummonsters; i++) {
+		int mi = monstactive[i];
 		if (monster[mi]._uniqtype != 0) {
-			for (d = 0; d < 8; d++)
+			for (int d = 0; d < 8; d++)
 				dead[nd]._deadData[d] = monster[mi].MType->Anims[MA_DEATH].Data[d];
 			dead[nd]._deadFrame = monster[mi].MType->Anims[MA_DEATH].Frames;
 			dead[nd]._deadWidth = monster[mi].MType->width;
@@ -82,14 +81,11 @@ void AddDead(int dx, int dy, char dv, int ddir)
 
 void SetDead()
 {
-	int i, mi;
-	int dx, dy;
-
-	for (i = 0; i < nummonsters; i++) {
-		mi = monstactive[i];
+	for (int i = 0; i < nummonsters; i++) {
+		int mi = monstactive[i];
 		if (monster[mi]._uniqtype != 0) {
-			for (dx = 0; dx < MAXDUNX; dx++) {
-				for (dy = 0; dy < MAXDUNY; dy++) {
+			for (int dx = 0; dx < MAXDUNX; dx++) {
+				for (int dy = 0; dy < MAXDUNY; dy++) {
 					if ((dDead[dx][dy] & 0x1F) == monster[mi]._udeadval)
 						ChangeLightXY(monster[mi].mlid, dx, dy);
 				}

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -5,8 +5,6 @@
  */
 #include "dead.h"
 
-#include <SDL.h>
-
 #include "gendung.h"
 #include "lighting.h"
 #include "misdat.h"
@@ -21,8 +19,8 @@ void InitDead()
 {
 	int mtypes[MAXMONSTERS];
 
-	for (int i = 0; i < MAXMONSTERS; i++)
-		mtypes[i] = 0;
+	for (int &mtype : mtypes)
+		mtype = 0;
 
 	int nd = 0;
 
@@ -40,16 +38,16 @@ void InitDead()
 		}
 	}
 
-	for (int d = 0; d < 8; d++)
-		dead[nd]._deadData[d] = misfiledata[MFILE_BLODBUR].mAnimData[0];
+	for (auto &d : dead[nd]._deadData)
+		d = misfiledata[MFILE_BLODBUR].mAnimData[0];
 	dead[nd]._deadFrame = 8;
 	dead[nd]._deadWidth = 128;
 	dead[nd]._deadWidth2 = 32;
 	dead[nd]._deadtrans = 0;
 	nd++;
 
-	for (int d = 0; d < 8; d++)
-		dead[nd]._deadData[d] = misfiledata[MFILE_SHATTER1].mAnimData[0];
+	for (auto &d : dead[nd]._deadData)
+		d = misfiledata[MFILE_SHATTER1].mAnimData[0];
 	dead[nd]._deadFrame = 12;
 	dead[nd]._deadWidth = 128;
 	dead[nd]._deadWidth2 = 32;

--- a/Source/dead.h
+++ b/Source/dead.h
@@ -5,25 +5,27 @@
  */
 #pragma once
 
-#include <SDL.h>
+#include <stdint.h>
+
+#include "engine.h"
 
 namespace devilution {
 
 #define MAXDEAD 31
 
 struct DeadStruct {
-	Uint8 *_deadData[8];
+	uint8_t *_deadData[8];
 	int _deadFrame;
 	int _deadWidth;
 	int _deadWidth2;
-	Uint8 _deadtrans;
+	uint8_t _deadtrans;
 };
 
 extern DeadStruct dead[MAXDEAD];
-extern int stonendx;
+extern int8_t stonendx;
 
 void InitDead();
-void AddDead(int dx, int dy, char dv, int ddir);
+void AddDead(int dx, int dy, int8_t dv, int ddir);
 void SetDead();
 
 }

--- a/Source/dead.h
+++ b/Source/dead.h
@@ -25,7 +25,7 @@ extern DeadStruct dead[MAXDEAD];
 extern int8_t stonendx;
 
 void InitDead();
-void AddDead(int dx, int dy, int8_t dv, int ddir);
+void AddDead(int dx, int dy, int8_t dv, direction ddir);
 void SetDead();
 
 }

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -559,7 +559,7 @@ static void LoadMonster(LoadHelper *file, int i)
 	pMonster->_myoff = file->nextLE<Sint32>();
 	pMonster->_mxvel = file->nextLE<Sint32>();
 	pMonster->_myvel = file->nextLE<Sint32>();
-	pMonster->_mdir = file->nextLE<Sint32>();
+	pMonster->_mdir = (direction)file->nextLE<Sint32>();
 	pMonster->_menemy = file->nextLE<Sint32>();
 	pMonster->_menemyx = file->nextLE<Uint8>();
 	pMonster->_menemyy = file->nextLE<Uint8>();

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -217,7 +217,7 @@ static void LoadItemData(LoadHelper *file, ItemStruct *pItem)
 	pItem->_iSeed = file->nextLE<Sint32>();
 	pItem->_iCreateInfo = file->nextLE<Uint16>();
 	file->skip(2); // Alignment
-	pItem->_itype = (item_type)file->nextLE<Uint32>();
+	pItem->_itype = static_cast<item_type>(file->nextLE<Uint32>());
 	pItem->_ix = file->nextLE<Sint32>();
 	pItem->_iy = file->nextLE<Sint32>();
 	pItem->_iAnimFlag = file->nextBool32();
@@ -234,8 +234,8 @@ static void LoadItemData(LoadHelper *file, ItemStruct *pItem)
 	pItem->_iMagical = file->nextLE<Sint8>();
 	file->nextBytes(pItem->_iName, 64);
 	file->nextBytes(pItem->_iIName, 64);
-	pItem->_iLoc = (item_equip_type)file->nextLE<Sint8>();
-	pItem->_iClass = (item_class)file->nextLE<Uint8>();
+	pItem->_iLoc = static_cast<item_equip_type>(file->nextLE<Sint8>());
+	pItem->_iClass = static_cast<item_class>(file->nextLE<Uint8>());
 	file->skip(1); // Alignment
 	pItem->_iCurs = file->nextLE<Sint32>();
 	pItem->_ivalue = file->nextLE<Sint32>();
@@ -244,8 +244,8 @@ static void LoadItemData(LoadHelper *file, ItemStruct *pItem)
 	pItem->_iMaxDam = file->nextLE<Sint32>();
 	pItem->_iAC = file->nextLE<Sint32>();
 	pItem->_iFlags = file->nextLE<Sint32>();
-	pItem->_iMiscId = (item_misc_id)file->nextLE<Sint32>();
-	pItem->_iSpell = (spell_id)file->nextLE<Sint32>();
+	pItem->_iMiscId = static_cast<item_misc_id>(file->nextLE<Sint32>());
+	pItem->_iSpell = static_cast<spell_id>(file->nextLE<Sint32>());
 	pItem->_iCharges = file->nextLE<Sint32>();
 	pItem->_iMaxCharges = file->nextLE<Sint32>();
 	pItem->_iDurability = file->nextLE<Sint32>();
@@ -274,8 +274,8 @@ static void LoadItemData(LoadHelper *file, ItemStruct *pItem)
 	pItem->_iLMinDam = file->nextLE<Sint32>();
 	pItem->_iLMaxDam = file->nextLE<Sint32>();
 	pItem->_iPLEnAc = file->nextLE<Sint32>();
-	pItem->_iPrePower = (item_effect_type)file->nextLE<Sint8>();
-	pItem->_iSufPower = (item_effect_type)file->nextLE<Sint8>();
+	pItem->_iPrePower = static_cast<item_effect_type>(file->nextLE<Sint8>());
+	pItem->_iSufPower = static_cast<item_effect_type>(file->nextLE<Sint8>());
 	file->skip(2); // Alignment
 	pItem->_iVAdd1 = file->nextLE<Sint32>();
 	pItem->_iVMult1 = file->nextLE<Sint32>();
@@ -310,17 +310,17 @@ static void LoadPlayer(LoadHelper *file, int p)
 {
 	PlayerStruct *pPlayer = &plr[p];
 
-	pPlayer->_pmode = (PLR_MODE)file->nextLE<Sint32>();
+	pPlayer->_pmode = static_cast<PLR_MODE>(file->nextLE<Sint32>());
 
 	for (int i = 0; i < MAX_PATH_LENGTH; i++) {
 		pPlayer->walkpath[i] = file->nextLE<Sint8>();
 	}
 	pPlayer->plractive = file->nextBool8();
 	file->skip(2); // Alignment
-	pPlayer->destAction = (action_id)file->nextLE<Sint32>();
+	pPlayer->destAction = static_cast<action_id>(file->nextLE<Sint32>());
 	pPlayer->destParam1 = file->nextLE<Sint32>();
 	pPlayer->destParam2 = file->nextLE<Sint32>();
-	pPlayer->destParam3 = (direction)file->nextLE<Sint32>();
+	pPlayer->destParam3 = static_cast<direction>(file->nextLE<Sint32>());
 	pPlayer->destParam4 = file->nextLE<Sint32>();
 	pPlayer->plrlevel = file->nextLE<Sint32>();
 	pPlayer->_px = file->nextLE<Sint32>();
@@ -337,7 +337,7 @@ static void LoadPlayer(LoadHelper *file, int p)
 	pPlayer->_pyoff = file->nextLE<Sint32>();
 	pPlayer->_pxvel = file->nextLE<Sint32>();
 	pPlayer->_pyvel = file->nextLE<Sint32>();
-	pPlayer->_pdir = (direction)file->nextLE<Sint32>();
+	pPlayer->_pdir = static_cast<direction>(file->nextLE<Sint32>());
 	file->skip(4); // Unused
 	pPlayer->_pgfxnum = file->nextLE<Sint32>();
 	file->skip(4); // Skip pointer _pAnimData
@@ -351,18 +351,18 @@ static void LoadPlayer(LoadHelper *file, int p)
 	pPlayer->_plid = file->nextLE<Sint32>();
 	pPlayer->_pvid = file->nextLE<Sint32>();
 
-	pPlayer->_pSpell = (spell_id)file->nextLE<Sint32>();
-	pPlayer->_pSplType = (spell_type)file->nextLE<Sint8>();
+	pPlayer->_pSpell = static_cast<spell_id>(file->nextLE<Sint32>());
+	pPlayer->_pSplType = static_cast<spell_type>(file->nextLE<Sint8>());
 	pPlayer->_pSplFrom = file->nextLE<Sint8>();
 	file->skip(2); // Alignment
-	pPlayer->_pTSpell = (spell_id)file->nextLE<Sint32>();
-	pPlayer->_pTSplType = (spell_type)file->nextLE<Sint8>();
+	pPlayer->_pTSpell = static_cast<spell_id>(file->nextLE<Sint32>());
+	pPlayer->_pTSplType = static_cast<spell_type>(file->nextLE<Sint8>());
 	file->skip(3); // Alignment
-	pPlayer->_pRSpell = (spell_id)file->nextLE<Sint32>();
-	pPlayer->_pRSplType = (spell_type)file->nextLE<Sint8>();
+	pPlayer->_pRSpell = static_cast<spell_id>(file->nextLE<Sint32>());
+	pPlayer->_pRSplType = static_cast<spell_type>(file->nextLE<Sint8>());
 	file->skip(3); // Alignment
-	pPlayer->_pSBkSpell = (spell_id)file->nextLE<Sint32>();
-	pPlayer->_pSBkSplType = (spell_type)file->nextLE<Sint8>();
+	pPlayer->_pSBkSpell = static_cast<spell_id>(file->nextLE<Sint32>());
+	pPlayer->_pSBkSplType = static_cast<spell_type>(file->nextLE<Sint8>());
 	for (int i = 0; i < 64; i++)
 		pPlayer->_pSplLvl[i] = file->nextLE<Sint8>();
 	file->skip(7); // Alignment
@@ -372,18 +372,18 @@ static void LoadPlayer(LoadHelper *file, int p)
 	pPlayer->_pSpellFlags = file->nextLE<Uint8>();
 	file->skip(3); // Alignment
 	for (int i = 0; i < 4; i++)
-		pPlayer->_pSplHotKey[i] = (spell_id)file->nextLE<Sint32>();
+		pPlayer->_pSplHotKey[i] = static_cast<spell_id>(file->nextLE<Sint32>());
 	for (int i = 0; i < 4; i++)
-		pPlayer->_pSplTHotKey[i] = (spell_type)file->nextLE<Sint8>();
+		pPlayer->_pSplTHotKey[i] = static_cast<spell_type>(file->nextLE<Sint8>());
 
-	pPlayer->_pwtype = (player_weapon_type)file->nextLE<Sint32>();
+	pPlayer->_pwtype = static_cast<player_weapon_type>(file->nextLE<Sint32>());
 	pPlayer->_pBlockFlag = file->nextBool8();
 	pPlayer->_pInvincible = file->nextBool8();
 	pPlayer->_pLightRad = file->nextLE<Sint8>();
 	pPlayer->_pLvlChanging = file->nextBool8();
 
 	file->nextBytes(pPlayer->_pName, PLR_NAME_LEN);
-	pPlayer->_pClass = (HeroClass)file->nextLE<Sint8>();
+	pPlayer->_pClass = static_cast<HeroClass>(file->nextLE<Sint8>());
 	file->skip(3); // Alignment
 	pPlayer->_pStrength = file->nextLE<Sint32>();
 	pPlayer->_pBaseStr = file->nextLE<Sint32>();
@@ -423,7 +423,7 @@ static void LoadPlayer(LoadHelper *file, int p)
 	pPlayer->_pInfraFlag = file->nextBool32();
 	pPlayer->_pVar1 = file->nextLE<Sint32>();
 	pPlayer->_pVar2 = file->nextLE<Sint32>();
-	pPlayer->_pVar3 = (direction)file->nextLE<Sint32>();
+	pPlayer->_pVar3 = static_cast<direction>(file->nextLE<Sint32>());
 	pPlayer->_pVar4 = file->nextLE<Sint32>();
 	pPlayer->_pVar5 = file->nextLE<Sint32>();
 	pPlayer->_pVar6 = file->nextLE<Sint32>();
@@ -492,7 +492,7 @@ static void LoadPlayer(LoadHelper *file, int p)
 	pPlayer->_pIFMaxDam = file->nextLE<Sint32>();
 	pPlayer->_pILMinDam = file->nextLE<Sint32>();
 	pPlayer->_pILMaxDam = file->nextLE<Sint32>();
-	pPlayer->_pOilType = (item_misc_id)file->nextLE<Sint32>();
+	pPlayer->_pOilType = static_cast<item_misc_id>(file->nextLE<Sint32>());
 	pPlayer->pTownWarps = file->nextLE<Uint8>();
 	pPlayer->pDungMsgs = file->nextLE<Uint8>();
 	pPlayer->pLvlLoad = file->nextLE<Uint8>();
@@ -516,7 +516,7 @@ static void LoadPlayer(LoadHelper *file, int p)
 	file->skip(14); // Available bytes
 
 	pPlayer->pDiabloKillLevel = file->nextLE<Uint32>();
-	pPlayer->pDifficulty = (_difficulty)file->nextLE<Uint32>();
+	pPlayer->pDifficulty = static_cast<_difficulty>(file->nextLE<Uint32>());
 	pPlayer->pDamAcFlags = file->nextLE<Uint32>();
 	file->skip(20); // Available bytes
 	CalcPlrItemVals(p, false);
@@ -540,8 +540,8 @@ static void LoadMonster(LoadHelper *file, int i)
 	MonsterStruct *pMonster = &monster[i];
 
 	pMonster->_mMTidx = file->nextLE<Sint32>();
-	pMonster->_mmode = (MON_MODE)file->nextLE<Sint32>();
-	pMonster->_mgoal = (monster_goal)file->nextLE<Uint8>();
+	pMonster->_mmode = static_cast<MON_MODE>(file->nextLE<Sint32>());
+	pMonster->_mgoal = static_cast<monster_goal>(file->nextLE<Uint8>());
 	file->skip(3); // Alignment
 	pMonster->_mgoalvar1 = file->nextLE<Sint32>();
 	pMonster->_mgoalvar2 = file->nextLE<Sint32>();
@@ -559,7 +559,7 @@ static void LoadMonster(LoadHelper *file, int i)
 	pMonster->_myoff = file->nextLE<Sint32>();
 	pMonster->_mxvel = file->nextLE<Sint32>();
 	pMonster->_myvel = file->nextLE<Sint32>();
-	pMonster->_mdir = (direction)file->nextLE<Sint32>();
+	pMonster->_mdir = static_cast<direction>(file->nextLE<Sint32>());
 	pMonster->_menemy = file->nextLE<Sint32>();
 	pMonster->_menemyx = file->nextLE<Uint8>();
 	pMonster->_menemyy = file->nextLE<Uint8>();
@@ -583,7 +583,7 @@ static void LoadMonster(LoadHelper *file, int i)
 	pMonster->_mmaxhp = file->nextLE<Sint32>();
 	pMonster->_mhitpoints = file->nextLE<Sint32>();
 
-	pMonster->_mAi = (_mai_id)file->nextLE<Uint8>();
+	pMonster->_mAi = static_cast<_mai_id>(file->nextLE<Uint8>());
 	pMonster->_mint = file->nextLE<Uint8>();
 	file->skip(2); // Alignment
 	pMonster->_mFlags = file->nextLE<Uint32>();
@@ -692,7 +692,7 @@ static void LoadObject(LoadHelper *file, int i)
 {
 	ObjectStruct *pObject = &object[i];
 
-	pObject->_otype = (_object_id)file->nextLE<Sint32>();
+	pObject->_otype = static_cast<_object_id>(file->nextLE<Sint32>());
 	pObject->_ox = file->nextLE<Sint32>();
 	pObject->_oy = file->nextLE<Sint32>();
 	pObject->_oLight = file->nextBool32();
@@ -723,7 +723,7 @@ static void LoadObject(LoadHelper *file, int i)
 	pObject->_oVar4 = file->nextLE<Sint32>();
 	pObject->_oVar5 = file->nextLE<Sint32>();
 	pObject->_oVar6 = file->nextLE<Sint32>();
-	pObject->_oVar7 = (_speech_id)file->nextLE<Sint32>();
+	pObject->_oVar7 = static_cast<_speech_id>(file->nextLE<Sint32>());
 	pObject->_oVar8 = file->nextLE<Sint32>();
 }
 
@@ -744,11 +744,11 @@ static void LoadQuest(LoadHelper *file, int i)
 
 	pQuest->_qlevel = file->nextLE<Uint8>();
 	pQuest->_qtype = file->nextLE<Uint8>();
-	pQuest->_qactive = (quest_state)file->nextLE<Uint8>();
-	pQuest->_qlvltype = (dungeon_type)file->nextLE<Uint8>();
+	pQuest->_qactive = static_cast<quest_state>(file->nextLE<Uint8>());
+	pQuest->_qlvltype = static_cast<dungeon_type>(file->nextLE<Uint8>());
 	pQuest->_qtx = file->nextLE<Sint32>();
 	pQuest->_qty = file->nextLE<Sint32>();
-	pQuest->_qslvl = (_setlevels)file->nextLE<Uint8>();
+	pQuest->_qslvl = static_cast<_setlevels>(file->nextLE<Uint8>());
 	pQuest->_qidx = file->nextLE<Uint8>();
 	if (gbIsHellfireSaveGame) {
 		file->skip(2); // Alignment
@@ -766,7 +766,7 @@ static void LoadQuest(LoadHelper *file, int i)
 	ReturnLvlX = file->nextBE<Sint32>();
 	ReturnLvlY = file->nextBE<Sint32>();
 	ReturnLvl = file->nextBE<Sint32>();
-	ReturnLvlT = (dungeon_type)file->nextBE<Sint32>();
+	ReturnLvlT = static_cast<dungeon_type>(file->nextBE<Sint32>());
 	DoomQuestState = file->nextBE<Sint32>();
 }
 
@@ -795,7 +795,7 @@ static void LoadPortal(LoadHelper *file, int i)
 	pPortal->x = file->nextLE<Sint32>();
 	pPortal->y = file->nextLE<Sint32>();
 	pPortal->level = file->nextLE<Sint32>();
-	pPortal->ltype = (dungeon_type)file->nextLE<Sint32>();
+	pPortal->ltype = static_cast<dungeon_type>(file->nextLE<Sint32>());
 	pPortal->setlvl = file->nextBool32();
 }
 
@@ -913,13 +913,13 @@ void LoadHotkeys()
 	const size_t nHotkeySpells = sizeof(plr[myplr]._pSplTHotKey) / sizeof(plr[myplr]._pSplTHotKey[0]);
 
 	for (size_t i = 0; i < nHotkeyTypes; i++) {
-		plr[myplr]._pSplHotKey[i] = (spell_id)file.nextLE<Sint32>();
+		plr[myplr]._pSplHotKey[i] = static_cast<spell_id>(file.nextLE<Sint32>());
 	}
 	for (size_t i = 0; i < nHotkeySpells; i++) {
-		plr[myplr]._pSplTHotKey[i] = (spell_type)file.nextLE<Sint8>();
+		plr[myplr]._pSplTHotKey[i] = static_cast<spell_type>(file.nextLE<Sint8>());
 	}
-	plr[myplr]._pRSpell = (spell_id)file.nextLE<Sint32>();
-	plr[myplr]._pRSplType = (spell_type)file.nextLE<Sint8>();
+	plr[myplr]._pRSpell = static_cast<spell_id>(file.nextLE<Sint32>());
+	plr[myplr]._pRSplType = static_cast<spell_type>(file.nextLE<Sint8>());
 }
 
 void SaveHotkeys()
@@ -1017,9 +1017,9 @@ void LoadGame(bool firstflag)
 	}
 
 	setlevel = file.nextBool8();
-	setlvlnum = (_setlevels)file.nextBE<Uint32>();
+	setlvlnum = static_cast<_setlevels>(file.nextBE<Uint32>());
 	currlevel = file.nextBE<Uint32>();
-	leveltype = (dungeon_type)file.nextBE<Uint32>();
+	leveltype = static_cast<dungeon_type>(file.nextBE<Uint32>());
 	if (!setlevel)
 		leveltype = gnLevelTypeTbl[currlevel];
 	int _ViewX = file.nextBE<Sint32>();

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -299,39 +299,39 @@ int GetSpellLevel(int id, spell_id sn)
  * @param y2 the y coordinate of p2
  * @return the direction of the p1->p2 vector
 */
-int GetDirection8(int x1, int y1, int x2, int y2)
+direction GetDirection8(int x1, int y1, int x2, int y2)
 {
-	int mx, my, md;
+	direction md = DIR_S;
 
-	mx = x2 - x1;
-	my = y2 - y1;
+	int mx = x2 - x1;
+	int my = y2 - y1;
 	if (mx >= 0) {
 		if (my >= 0) {
 			if (5 * mx <= (my << 1)) // mx/my <= 0.4, approximation of tan(22.5)
-				return 1;            // DIR_SW
-			md = 0;                  // DIR_S
+				return DIR_SW;
+			md = DIR_S;
 		} else {
 			my = -my;
 			if (5 * mx <= (my << 1))
-				return 5; // DIR_NE
-			md = 6;       // DIR_E
+				return DIR_NE;
+			md = DIR_E;
 		}
 		if (5 * my <= (mx << 1)) // my/mx <= 0.4
-			md = 7;              // DIR_SE
+			md = DIR_SE;
 	} else {
 		mx = -mx;
 		if (my >= 0) {
 			if (5 * mx <= (my << 1))
-				return 1; // DIR_SW
-			md = 2;       // DIR_W
+				return DIR_SW;
+			md = DIR_W;
 		} else {
 			my = -my;
 			if (5 * mx <= (my << 1))
-				return 5; // DIR_NE
-			md = 4;       // DIR_N
+				return DIR_NE;
+			md = DIR_N;
 		}
 		if (5 * my <= (mx << 1))
-			md = 3; // DIR_NW
+			md = DIR_NW;
 	}
 	return md;
 }
@@ -3441,12 +3441,10 @@ int AddMissile(int sx, int sy, int dx, int dy, int midir, int mitype, int8_t mic
 
 int Sentfire(int i, int sx, int sy)
 {
-	int ex, dir;
-
-	ex = 0;
+	int ex = 0;
 	if (LineClear(missile[i]._mix, missile[i]._miy, sx, sy)) {
 		if (dMonster[sx][sy] > 0 && monster[dMonster[sx][sy] - 1]._mhitpoints >> 6 > 0 && dMonster[sx][sy] - 1 > MAX_PLRS - 1) {
-			dir = GetDirection(missile[i]._mix, missile[i]._miy, sx, sy);
+			direction dir = GetDirection(missile[i]._mix, missile[i]._miy, sx, sy);
 			missile[i]._miVar3 = missileavail[0];
 			AddMissile(missile[i]._mix, missile[i]._miy, sx, sy, dir, MIS_FIREBOLT, TARGET_MONSTERS, missile[i]._misource, missile[i]._midam, GetSpellLevel(missile[i]._misource, SPL_FIREBOLT));
 			ex = -1;
@@ -3664,7 +3662,7 @@ void MI_Firebolt(Sint32 i)
 				AddMissile(missile[i]._mix, missile[i]._miy, i, 0, missile[i]._mimfnum, MIS_MISEXP3, missile[i]._micaster, missile[i]._misource, 0, 0);
 				break;
 			case MIS_BONESPIRIT:
-				SetMissDir(i, 8);
+				SetMissDir(i, DIR_OMNI);
 				missile[i]._mirange = 7;
 				missile[i]._miDelFlag = false;
 				PutMissile(i);
@@ -3891,8 +3889,9 @@ void MI_HorkSpawn(Sint32 i)
 					dp = dPiece[tx][ty];
 					if (!nSolidTable[dp] && dMonster[tx][ty] == 0 && dPlayer[tx][ty] == 0 && dObject[tx][ty] == 0) {
 						j = 6;
-						int mon = AddMonster(tx, ty, missile[i]._miVar1, 1, true);
-						M_StartStand(mon, missile[i]._miVar1);
+						direction md = (direction)missile[i]._miVar1;
+						int mon = AddMonster(tx, ty, md, 1, true);
+						M_StartStand(mon, md);
 						break;
 					}
 				}
@@ -3909,7 +3908,8 @@ void MI_HorkSpawn(Sint32 i)
 
 void MI_Rune(Sint32 i)
 {
-	int mid, pid, dir, mx, my;
+	int mid, pid, mx, my;
+	direction dir;
 
 	mx = missile[i]._mix;
 	my = missile[i]._miy;
@@ -3971,9 +3971,7 @@ void MI_Immolation(Sint32 i)
 		int v = 2 * missile[i]._miVar6;
 		missile[i]._miVar6 = v;
 		missile[i]._miVar7 = v;
-		missile[i]._mimfnum--;
-		if (missile[i]._mimfnum < 0)
-			missile[i]._mimfnum = 7;
+		missile[i]._mimfnum = left[missile[i]._mimfnum];
 	} else {
 		missile[i]._miVar7--;
 	}
@@ -4345,7 +4343,7 @@ void MI_FireNova(Sint32 i)
 	int dam = missile[i]._midam;
 	int sx = missile[i]._mix;
 	int sy = missile[i]._miy;
-	int dir = 0;
+	direction dir = DIR_S;
 	mienemy_type en = TARGET_PLAYERS;
 	if (id != -1) {
 		dir = plr[id]._pdir;
@@ -4376,7 +4374,7 @@ void MI_SpecArrow(Sint32 i)
 	int dy = missile[i]._miVar2;
 	int spllvl = missile[i]._miVar3;
 	int mitype = 0;
-	int dir = 0;
+	direction dir = DIR_S;
 	mienemy_type micaster = TARGET_PLAYERS;
 	if (src != -1) {
 		dir = plr[src]._pdir;
@@ -4816,12 +4814,12 @@ void MI_Guardian(Sint32 i)
 
 void MI_Chain(Sint32 i)
 {
-	int sx, sy, id, l, n, m, k, rad, tx, ty, dir;
+	int sx, sy, id, l, n, m, k, rad, tx, ty;
 
 	id = missile[i]._misource;
 	sx = missile[i]._mix;
 	sy = missile[i]._miy;
-	dir = GetDirection(sx, sy, missile[i]._miVar1, missile[i]._miVar2);
+	direction dir = GetDirection(sx, sy, missile[i]._miVar1, missile[i]._miVar2);
 	AddMissile(sx, sy, missile[i]._miVar1, missile[i]._miVar2, dir, MIS_LIGHTCTRL, TARGET_MONSTERS, id, 1, missile[i]._mispllvl);
 	rad = missile[i]._mispllvl + 3;
 	if (rad > 19)
@@ -5216,7 +5214,7 @@ void MI_Nova(Sint32 i)
 	int dam = missile[i]._midam;
 	int sx = missile[i]._mix;
 	int sy = missile[i]._miy;
-	int dir = 0;
+	direction dir = DIR_S;
 	mienemy_type en = TARGET_PLAYERS;
 	if (id != -1) {
 		dir = plr[id]._pdir;
@@ -5424,7 +5422,7 @@ void MI_Hbolt(Sint32 i)
 
 void MI_Element(Sint32 i)
 {
-	int mid, sd, dam, cx, cy, px, py, id;
+	int mid, dam, cx, cy, px, py, id;
 
 	missile[i]._mirange--;
 	dam = missile[i]._midam;
@@ -5471,11 +5469,11 @@ void MI_Element(Sint32 i)
 			missile[i]._mirange = 255;
 			mid = FindClosest(cx, cy, 19);
 			if (mid > 0) {
-				sd = GetDirection8(cx, cy, monster[mid]._mx, monster[mid]._my);
+				direction sd = GetDirection8(cx, cy, monster[mid]._mx, monster[mid]._my);
 				SetMissDir(i, sd);
 				GetMissileVel(i, cx, cy, monster[mid]._mx, monster[mid]._my, 16);
 			} else {
-				sd = plr[id]._pdir;
+				direction sd = plr[id]._pdir;
 				SetMissDir(i, sd);
 				GetMissileVel(i, cx, cy, cx + XDirAdd[sd], cy + YDirAdd[sd], 16);
 			}
@@ -5496,13 +5494,13 @@ void MI_Element(Sint32 i)
 
 void MI_Bonespirit(Sint32 i)
 {
-	int id, mid, sd, dam;
+	int id, mid, dam;
 	int cx, cy;
 
 	missile[i]._mirange--;
 	dam = missile[i]._midam;
 	id = missile[i]._misource;
-	if (missile[i]._mimfnum == 8) {
+	if (missile[i]._mimfnum == DIR_OMNI) {
 		ChangeLight(missile[i]._mlid, missile[i]._mix, missile[i]._miy, missile[i]._miAnimFrame);
 		if (missile[i]._mirange == 0) {
 			missile[i]._miDelFlag = true;
@@ -5527,7 +5525,7 @@ void MI_Bonespirit(Sint32 i)
 				SetMissDir(i, GetDirection8(cx, cy, monster[mid]._mx, monster[mid]._my));
 				GetMissileVel(i, cx, cy, monster[mid]._mx, monster[mid]._my, 16);
 			} else {
-				sd = plr[id]._pdir;
+				direction sd = plr[id]._pdir;
 				SetMissDir(i, sd);
 				GetMissileVel(i, cx, cy, cx + XDirAdd[sd], cy + YDirAdd[sd], 16);
 			}
@@ -5538,7 +5536,7 @@ void MI_Bonespirit(Sint32 i)
 			ChangeLight(missile[i]._mlid, cx, cy, 8);
 		}
 		if (missile[i]._mirange == 0) {
-			SetMissDir(i, 8);
+			SetMissDir(i, DIR_OMNI);
 			missile[i]._mirange = 7;
 		}
 		PutMissile(i);

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include "miniwin/miniwin.h"
+#include "engine.h"
 #include "misdat.h"
 #include "spelldat.h"
 
@@ -77,7 +78,7 @@ extern bool MissilePreFlag;
 
 void GetDamageAmt(int i, int *mind, int *maxd);
 int GetSpellLevel(int id, spell_id sn);
-int GetDirection8(int x1, int y1, int x2, int y2);
+direction GetDirection8(int x1, int y1, int x2, int y2);
 int GetDirection16(int x1, int y1, int x2, int y2);
 void DeleteMissile(int mi, int i);
 bool MonsterTrapHit(int m, int mindam, int maxdam, int dist, int t, bool shift);

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3,6 +3,8 @@
  *
  * Implementation of monster functionality, AI, actions, spawning, loading, etc.
  */
+#include "monster.h"
+
 #include <algorithm>
 #include <limits.h>
 
@@ -20,7 +22,6 @@
 #include "missiles.h"
 #include "movie.h"
 #include "options.h"
-#include "sound.h"
 #include "storm/storm.h"
 #include "themes.h"
 #include "towners.h"
@@ -85,11 +86,11 @@ int MWVel[24][3] = {
 /** Maps from monster action to monster animation letter. */
 char animletter[7] = "nwahds";
 /** Maps from direction to a left turn from the direction. */
-int left[8] = { 7, 0, 1, 2, 3, 4, 5, 6 };
+direction left[8] = { DIR_SE, DIR_S, DIR_SW, DIR_W, DIR_NW, DIR_N, DIR_NE, DIR_E };
 /** Maps from direction to a right turn from the direction. */
-int right[8] = { 1, 2, 3, 4, 5, 6, 7, 0 };
+direction right[8] = { DIR_SW, DIR_W, DIR_NW, DIR_N, DIR_NE, DIR_E, DIR_SE, DIR_S };
 /** Maps from direction to the opposite direction. */
-int opposite[8] = { 4, 5, 6, 7, 0, 1, 2, 3 };
+direction opposite[8] = { DIR_N, DIR_NE, DIR_E, DIR_SE, DIR_S, DIR_SW, DIR_W, DIR_NW };
 /** Maps from direction to delta X-offset. */
 int offset_x[8] = { 1, 0, -1, -1, -1, 0, 1, 1 };
 /** Maps from direction to delta Y-offset. */
@@ -471,7 +472,7 @@ void ClearMVars(int i)
 	monster[i]._mVar8 = 0;
 }
 
-void InitMonster(int i, int rd, int mtype, int x, int y)
+void InitMonster(int i, direction rd, int mtype, int x, int y)
 {
 	CMonster *monst = &Monsters[mtype];
 
@@ -598,7 +599,7 @@ void ClrAllMonsters()
 		Monst->_mfuty = 0;
 		Monst->_moldx = 0;
 		Monst->_moldy = 0;
-		Monst->_mdir = random_(89, 8);
+		Monst->_mdir = (direction)random_(89, 8);
 		Monst->_mxvel = 0;
 		Monst->_myvel = 0;
 		Monst->_mAnimData = NULL;
@@ -657,8 +658,6 @@ void monster_some_crypt()
 
 void PlaceMonster(int i, int mtype, int x, int y)
 {
-	int rd;
-
 	if (Monsters[mtype].mtype == MT_NAKRUL) {
 		for (int j = 0; j < nummonsters; j++) {
 			if (monster[j]._mMTidx == mtype) {
@@ -671,7 +670,7 @@ void PlaceMonster(int i, int mtype, int x, int y)
 	}
 	dMonster[x][y] = i + 1;
 
-	rd = random_(90, 8);
+	direction rd = (direction)random_(90, 8);
 	InitMonster(i, rd, mtype, x, y);
 }
 
@@ -1131,10 +1130,10 @@ void InitMonsters()
 		CheckDungeonClear();
 #endif
 	if (!setlevel) {
-		AddMonster(1, 0, 0, 0, false);
-		AddMonster(1, 0, 0, 0, false);
-		AddMonster(1, 0, 0, 0, false);
-		AddMonster(1, 0, 0, 0, false);
+		AddMonster(1, 0, DIR_S, 0, false);
+		AddMonster(1, 0, DIR_S, 0, false);
+		AddMonster(1, 0, DIR_S, 0, false);
+		AddMonster(1, 0, DIR_S, 0, false);
 	}
 
 	if (!gbIsSpawn && !setlevel && currlevel == 16)
@@ -1198,10 +1197,10 @@ void SetMapMonsters(BYTE *pMap, int startx, int starty)
 	int mtype;
 
 	AddMonsterType(MT_GOLEM, PLACE_SPECIAL);
-	AddMonster(1, 0, 0, 0, false);
-	AddMonster(1, 0, 0, 0, false);
-	AddMonster(1, 0, 0, 0, false);
-	AddMonster(1, 0, 0, 0, false);
+	AddMonster(1, 0, DIR_S, 0, false);
+	AddMonster(1, 0, DIR_S, 0, false);
+	AddMonster(1, 0, DIR_S, 0, false);
+	AddMonster(1, 0, DIR_S, 0, false);
 	if (setlevel && setlvlnum == SL_VILEBETRAYER) {
 		AddMonsterType(UniqMonst[UMT_LAZURUS].mtype, PLACE_UNIQUE);
 		AddMonsterType(UniqMonst[UMT_RED_VEX].mtype, PLACE_UNIQUE);
@@ -1239,7 +1238,7 @@ void DeleteMonster(int i)
 	monstactive[i] = temp;
 }
 
-int AddMonster(int x, int y, int dir, int mtype, bool InMap)
+int AddMonster(int x, int y, direction dir, int mtype, bool InMap)
 {
 	if (nummonsters < MAXMONSTERS) {
 		int i = monstactive[nummonsters++];
@@ -1254,12 +1253,12 @@ int AddMonster(int x, int y, int dir, int mtype, bool InMap)
 
 void monster_43C785(int i)
 {
-	int x, y, d, j, oi, dir, mx, my;
+	int x, y, d, j, oi, mx, my;
 
 	if (monster[i].MType) {
 		mx = monster[i]._mx;
 		my = monster[i]._my;
-		dir = monster[i]._mdir;
+		direction dir = monster[i]._mdir;
 		for (d = 0; d < 8; d++) {
 			x = mx + offset_x[d];
 			y = my + offset_y[d];
@@ -1284,7 +1283,7 @@ void monster_43C785(int i)
 	}
 }
 
-void NewMonsterAnim(int i, AnimStruct *anim, int md)
+void NewMonsterAnim(int i, AnimStruct *anim, direction md)
 {
 	MonsterStruct *Monst = &monster[i];
 	Monst->_mAnimData = anim->Data[md];
@@ -1389,12 +1388,12 @@ void M_Enemy(int i)
 	}
 }
 
-int M_GetDir(int i)
+direction M_GetDir(int i)
 {
 	return GetDirection(monster[i]._mx, monster[i]._my, monster[i]._menemyx, monster[i]._menemyy);
 }
 
-void M_StartStand(int i, int md)
+void M_StartStand(int i, direction md)
 {
 	ClearMVars(i);
 	if (monster[i].MType->mtype == MT_GOLEM)
@@ -1426,7 +1425,7 @@ void M_StartDelay(int i, int len)
 	}
 }
 
-void M_StartSpStand(int i, int md)
+void M_StartSpStand(int i, direction md)
 {
 	NewMonsterAnim(i, &monster[i].MType->Anims[MA_SPECIAL], md);
 	monster[i]._mmode = MM_SPSTAND;
@@ -1439,7 +1438,7 @@ void M_StartSpStand(int i, int md)
 	monster[i]._mdir = md;
 }
 
-void M_StartWalk(int i, int xvel, int yvel, int xadd, int yadd, int EndDir)
+void M_StartWalk(int i, int xvel, int yvel, int xadd, int yadd, direction EndDir)
 {
 	int fx = xadd + monster[i]._mx;
 	int fy = yadd + monster[i]._my;
@@ -1462,7 +1461,7 @@ void M_StartWalk(int i, int xvel, int yvel, int xadd, int yadd, int EndDir)
 	monster[i]._mVar8 = 0;
 }
 
-void M_StartWalk2(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int yadd, int EndDir)
+void M_StartWalk2(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int yadd, direction EndDir)
 {
 	int fx = xadd + monster[i]._mx;
 	int fy = yadd + monster[i]._my;
@@ -1492,7 +1491,7 @@ void M_StartWalk2(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int y
 	monster[i]._mVar8 = 0;
 }
 
-void M_StartWalk3(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int yadd, int mapx, int mapy, int EndDir)
+void M_StartWalk3(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int yadd, int mapx, int mapy, direction EndDir)
 {
 	int fx = xadd + monster[i]._mx;
 	int fy = yadd + monster[i]._my;
@@ -1528,7 +1527,7 @@ void M_StartWalk3(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int y
 
 void M_StartAttack(int i)
 {
-	int md = M_GetDir(i);
+	direction md = M_GetDir(i);
 	NewMonsterAnim(i, &monster[i].MType->Anims[MA_ATTACK], md);
 	monster[i]._mmode = MM_ATTACK;
 	monster[i]._mxoff = 0;
@@ -1542,7 +1541,7 @@ void M_StartAttack(int i)
 
 void M_StartRAttack(int i, int missile_type, int dam)
 {
-	int md = M_GetDir(i);
+	direction md = M_GetDir(i);
 	NewMonsterAnim(i, &monster[i].MType->Anims[MA_ATTACK], md);
 	monster[i]._mmode = MM_RATTACK;
 	monster[i]._mVar1 = missile_type;
@@ -1558,7 +1557,7 @@ void M_StartRAttack(int i, int missile_type, int dam)
 
 void M_StartRSpAttack(int i, int missile_type, int dam)
 {
-	int md = M_GetDir(i);
+	direction md = M_GetDir(i);
 	NewMonsterAnim(i, &monster[i].MType->Anims[MA_SPECIAL], md);
 	monster[i]._mmode = MM_RSPATTACK;
 	monster[i]._mVar1 = missile_type;
@@ -1575,7 +1574,7 @@ void M_StartRSpAttack(int i, int missile_type, int dam)
 
 void M_StartSpAttack(int i)
 {
-	int md = M_GetDir(i);
+	direction md = M_GetDir(i);
 	NewMonsterAnim(i, &monster[i].MType->Anims[MA_SPECIAL], md);
 	monster[i]._mmode = MM_SATTACK;
 	monster[i]._mxoff = 0;
@@ -1625,7 +1624,7 @@ void M_ClearSquares(int i)
 
 void M_GetKnockback(int i)
 {
-	int d = (monster[i]._mdir - 4) & 7;
+	direction d = opposite[monster[i]._mdir];
 	if (DirOK(i, d)) {
 		M_ClearSquares(i);
 		monster[i]._moldx += offset_x[d];
@@ -1777,7 +1776,7 @@ void M2MStartHit(int mid, int i, int dam)
 
 	if ((monster[mid].MType->mtype >= MT_SNEAK && monster[mid].MType->mtype <= MT_ILLWEAV) || dam >> 6 >= monster[mid].mLevel + 3) {
 		if (i >= 0)
-			monster[mid]._mdir = (monster[i]._mdir - 4) & 7;
+			monster[mid]._mdir = opposite[monster[i]._mdir];
 
 		if (monster[mid].MType->mtype == MT_BLINK) {
 			M_Teleport(mid);
@@ -1808,7 +1807,6 @@ void M2MStartHit(int mid, int i, int dam)
 
 void MonstStartKill(int i, int pnum, bool sendmsg)
 {
-	int md;
 	MonsterStruct *Monst;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
@@ -1829,10 +1827,7 @@ void MonstStartKill(int i, int pnum, bool sendmsg)
 	else
 		PlayEffect(i, 2);
 
-	if (pnum >= 0)
-		md = M_GetDir(i);
-	else
-		md = Monst->_mdir;
+	direction md = pnum >= 0 ? M_GetDir(i) : Monst->_mdir;
 	Monst->_mdir = md;
 	NewMonsterAnim(i, &Monst->MType->Anims[MA_DEATH], md);
 	Monst->_mmode = MM_DEATH;
@@ -1854,8 +1849,6 @@ void MonstStartKill(int i, int pnum, bool sendmsg)
 
 void M2MStartKill(int i, int mid)
 {
-	int md;
-
 	assurance((DWORD)i < MAXMONSTERS, i);
 	assurance((DWORD)mid < MAXMONSTERS, mid);
 	assurance(monster[mid].MType != NULL, mid); /// BUGFIX: should check `mid` (fixed)
@@ -1880,9 +1873,9 @@ void M2MStartKill(int i, int mid)
 	else
 		PlayEffect(mid, 2);
 
-	md = (monster[i]._mdir - 4) & 7;
+	direction md = opposite[monster[i]._mdir];
 	if (monster[mid].MType->mtype == MT_GOLEM)
-		md = 0;
+		md = DIR_S;
 
 	monster[mid]._mdir = md;
 	NewMonsterAnim(mid, &monster[mid].MType->Anims[MA_DEATH], md);
@@ -1944,7 +1937,7 @@ void M_SyncStartKill(int i, int x, int y, int pnum)
 	}
 }
 
-void M_StartFadein(int i, int md, bool backwards)
+void M_StartFadein(int i, direction md, bool backwards)
 {
 	assurance((DWORD)i < MAXMONSTERS, i);
 	assurance(monster[i].MType != NULL, i);
@@ -1965,7 +1958,7 @@ void M_StartFadein(int i, int md, bool backwards)
 	}
 }
 
-void M_StartFadeout(int i, int md, bool backwards)
+void M_StartFadeout(int i, direction md, bool backwards)
 {
 	assurance((DWORD)i < MAXMONSTERS, i);
 	assurance(monster[i].MType != NULL, i);
@@ -2143,7 +2136,7 @@ void M_TryH2HHit(int i, int pnum, int Hit, int MinDam, int MaxDam)
 	int blk, blkper;
 	int dam, mdam;
 	int newx, newy;
-	int j, misnum, ms_num, cur_ms_num, new_hp, dir, ac;
+	int j, misnum, ms_num, cur_ms_num, new_hp, ac;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
 	assurance(monster[i].MType != NULL, i);
@@ -2798,13 +2791,11 @@ bool M_DoStone(int i)
 	return false;
 }
 
-void M_WalkDir(int i, int md)
+void M_WalkDir(int i, direction md)
 {
-	int mwi;
-
 	assurance((DWORD)i < MAXMONSTERS, i);
 
-	mwi = monster[i].MType->Anims[MA_WALK].Frames - 1;
+	int mwi = monster[i].MType->Anims[MA_WALK].Frames - 1;
 	switch (md) {
 	case DIR_N:
 		M_StartWalk(i, 0, -MWVel[mwi][1], -1, -1, DIR_N);
@@ -2891,13 +2882,10 @@ void GroupUnity(int i)
 	}
 }
 
-bool M_CallWalk(int i, int md)
+bool M_CallWalk(int i, direction md)
 {
-	int mdtemp;
-	bool ok;
-
-	mdtemp = md;
-	ok = DirOK(i, md);
+	direction mdtemp = md;
+	bool ok = DirOK(i, md);
 	if (random_(101, 2) != 0)
 		ok = ok || (md = left[mdtemp], DirOK(i, md)) || (md = right[mdtemp], DirOK(i, md));
 	else
@@ -2921,7 +2909,7 @@ bool M_PathWalk(int i)
 	bool (*Check)(int, int, int);
 
 	/** Maps from walking path step to facing direction. */
-	const Sint8 plr2monst[9] = { 0, 5, 3, 7, 1, 4, 6, 0, 2 };
+	const direction plr2monst[9] = { DIR_S, DIR_NE, DIR_NW, DIR_SE, DIR_SW, DIR_N, DIR_E, DIR_S, DIR_W };
 
 	commitment((DWORD)i < MAXMONSTERS, i);
 
@@ -2937,13 +2925,10 @@ bool M_PathWalk(int i)
 	return false;
 }
 
-bool M_CallWalk2(int i, int md)
+bool M_CallWalk2(int i, direction md)
 {
-	bool ok;
-	int mdtemp;
-
-	mdtemp = md;
-	ok = DirOK(i, md);          // Can we continue in the same direction
+	direction mdtemp = md;
+	bool ok = DirOK(i, md);     // Can we continue in the same direction
 	if (random_(101, 2) != 0) { // Randomly go left or right
 		ok = ok || (mdtemp = left[md], DirOK(i, left[md])) || (mdtemp = right[md], DirOK(i, right[md]));
 	} else {
@@ -2956,27 +2941,24 @@ bool M_CallWalk2(int i, int md)
 	return ok;
 }
 
-bool M_DumbWalk(int i, int md)
+bool M_DumbWalk(int i, direction md)
 {
-	bool ok;
-	ok = DirOK(i, md);
+	bool ok = DirOK(i, md);
 	if (ok)
 		M_WalkDir(i, md);
 
 	return ok;
 }
 
-bool M_RoundWalk(int i, int md, Sint32 *dir)
+bool M_RoundWalk(int i, direction md, Sint32 *dir)
 {
-	int mdtemp;
-	bool ok;
 	if (*dir)
 		md = left[left[md]];
 	else
 		md = right[right[md]];
 
-	mdtemp = md;
-	ok = DirOK(i, md);
+	direction mdtemp = md;
+	bool ok = DirOK(i, md);
 	if (!ok) {
 		if (*dir) {
 			md = right[mdtemp];
@@ -2998,7 +2980,7 @@ bool M_RoundWalk(int i, int md, Sint32 *dir)
 void MAI_Zombie(int i)
 {
 	MonsterStruct *Monst;
-	int mx, my, md;
+	int mx, my;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
 
@@ -3014,17 +2996,16 @@ void MAI_Zombie(int i)
 	}
 
 	if (random_(103, 100) < 2 * Monst->_mint + 10) {
-		md = std::max(abs(mx - Monst->_menemyx), abs(my - Monst->_menemyy));
-		if (md >= 2) {
-			if (md >= 2 * Monst->_mint + 4) {
-				md = Monst->_mdir;
+		int dist = std::max(abs(mx - Monst->_menemyx), abs(my - Monst->_menemyy));
+		if (dist >= 2) {
+			if (dist >= 2 * Monst->_mint + 4) {
+				direction md = Monst->_mdir;
 				if (random_(104, 100) < 2 * Monst->_mint + 20) {
-					md = random_(104, 8);
+					md = (direction)random_(104, 8);
 				}
 				M_DumbWalk(i, md);
 			} else {
-				md = M_GetDir(i);
-				M_CallWalk(i, md);
+				M_CallWalk(i, M_GetDir(i));
 			}
 		} else {
 			M_StartAttack(i);
@@ -3038,7 +3019,7 @@ void MAI_Zombie(int i)
 void MAI_SkelSd(int i)
 {
 	MonsterStruct *Monst;
-	int mx, my, x, y, md;
+	int mx, my, x, y;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
 
@@ -3051,7 +3032,7 @@ void MAI_SkelSd(int i)
 	my = Monst->_my;
 	x = mx - Monst->_menemyx;
 	y = my - Monst->_menemyy;
-	md = GetDirection(mx, my, Monst->_lastx, Monst->_lasty);
+	direction md = GetDirection(mx, my, Monst->_lastx, Monst->_lasty);
 	Monst->_mdir = md;
 	if (abs(x) >= 2 || abs(y) >= 2) {
 		if (Monst->_mVar1 == MM_DELAY || (random_(106, 100) >= 35 - 4 * Monst->_mint)) {
@@ -3116,9 +3097,8 @@ bool MAI_Path(int i)
 void MAI_Snake(int i)
 {
 	MonsterStruct *Monst;
-	int fx, fy, mx, my, md;
+	int fx, fy, mx, my;
 	int pnum;
-	int tmp;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
 	char pattern[6] = { 1, 1, 0, -1, -1, 0 };
@@ -3130,7 +3110,7 @@ void MAI_Snake(int i)
 	fy = Monst->_menemyy;
 	mx = Monst->_mx - fx;
 	my = Monst->_my - fy;
-	md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
+	direction md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
 	Monst->_mdir = md;
 	if (abs(mx) >= 2 || abs(my) >= 2) {
 		if (abs(mx) < 3 && abs(my) < 3 && LineClearF1(PosOkMonst, i, Monst->_mx, Monst->_my, fx, fy) && Monst->_mVar1 != MM_CHARGE) {
@@ -3140,44 +3120,28 @@ void MAI_Snake(int i)
 				Monst->_mmode = MM_CHARGE;
 			}
 		} else if (Monst->_mVar1 == MM_DELAY || random_(106, 100) >= 35 - 2 * Monst->_mint) {
-			if (md + pattern[Monst->_mgoalvar1] < 0) {
-				tmp = md + pattern[Monst->_mgoalvar1] + 8;
-			} else {
-				tmp = md + pattern[Monst->_mgoalvar1] - 8;
-				if (md + pattern[Monst->_mgoalvar1] < 8)
-					tmp = md + pattern[Monst->_mgoalvar1];
-			}
+			if (pattern[Monst->_mgoalvar1] == -1)
+				md = left[md];
+			else if (pattern[Monst->_mgoalvar1] == 1)
+				md = right[md];
+
 			Monst->_mgoalvar1++;
 			if (Monst->_mgoalvar1 > 5)
 				Monst->_mgoalvar1 = 0;
-			if (tmp - Monst->_mgoalvar2 < 0) {
-				md = tmp - Monst->_mgoalvar2 + 8;
-			} else if (tmp - Monst->_mgoalvar2 >= 8) {
-				md = tmp - Monst->_mgoalvar2 - 8;
-			} else
-				md = tmp - Monst->_mgoalvar2;
-			if (md > 0) {
-				if (md < 4) {
-					if (Monst->_mgoalvar2 + 1 < 0) {
-						md = Monst->_mgoalvar2 + 9;
-					} else if (Monst->_mgoalvar2 + 1 >= 8) {
-						md = Monst->_mgoalvar2 - 7;
-					} else
-						md = Monst->_mgoalvar2 + 1;
-					Monst->_mgoalvar2 = md;
-				} else if (md == 4) {
-					Monst->_mgoalvar2 = tmp;
-				} else {
-					if (Monst->_mgoalvar2 - 1 < 0) {
-						md = Monst->_mgoalvar2 + 7;
-					} else if (Monst->_mgoalvar2 - 1 >= 8) {
-						md = Monst->_mgoalvar2 - 9;
-					} else
-						md = Monst->_mgoalvar2 - 1;
-					Monst->_mgoalvar2 = md;
-				}
+
+			if (md != Monst->_mgoalvar2) {
+				int drift = md - Monst->_mgoalvar2;
+				if (drift < 0)
+					drift += 8;
+
+				if (drift < 4)
+					md = right[Monst->_mgoalvar2];
+				else if (drift > 4)
+					md = left[Monst->_mgoalvar2];
+				Monst->_mgoalvar2 = md;
 			}
-			if (!M_DumbWalk(i, Monst->_mgoalvar2))
+
+			if (!M_DumbWalk(i, md))
 				M_CallWalk2(i, Monst->_mdir);
 		} else {
 			M_StartDelay(i, 15 - Monst->_mint + random_(106, 10));
@@ -3197,7 +3161,7 @@ void MAI_Snake(int i)
 void MAI_Bat(int i)
 {
 	MonsterStruct *Monst;
-	int md, v, pnum;
+	int v, pnum;
 	int fx, fy, xd, yd;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
@@ -3210,7 +3174,7 @@ void MAI_Bat(int i)
 
 	xd = Monst->_mx - Monst->_menemyx;
 	yd = Monst->_my - Monst->_menemyy;
-	md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
+	direction md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
 	Monst->_mdir = md;
 	v = random_(107, 100);
 	if (Monst->_mgoal == MGOAL_RETREAT) {
@@ -3260,7 +3224,7 @@ void MAI_Bat(int i)
 void MAI_SkelBow(int i)
 {
 	MonsterStruct *Monst;
-	int mx, my, md, v;
+	int mx, my, v;
 	bool walking;
 
 	walking = false;
@@ -3274,7 +3238,7 @@ void MAI_SkelBow(int i)
 	mx = Monst->_mx - Monst->_menemyx;
 	my = Monst->_my - Monst->_menemyy;
 
-	md = M_GetDir(i);
+	direction md = M_GetDir(i);
 	Monst->_mdir = md;
 	v = random_(110, 100);
 
@@ -3303,7 +3267,7 @@ void MAI_SkelBow(int i)
 void MAI_Fat(int i)
 {
 	MonsterStruct *Monst;
-	int mx, my, md, v;
+	int mx, my, v;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
 
@@ -3314,7 +3278,7 @@ void MAI_Fat(int i)
 
 	mx = Monst->_mx - Monst->_menemyx;
 	my = Monst->_my - Monst->_menemyy;
-	md = M_GetDir(i);
+	direction md = M_GetDir(i);
 	Monst->_mdir = md;
 	v = random_(111, 100);
 	if (abs(mx) >= 2 || abs(my) >= 2) {
@@ -3337,7 +3301,7 @@ void MAI_Fat(int i)
 void MAI_Sneak(int i)
 {
 	MonsterStruct *Monst;
-	int mx, my, md;
+	int mx, my;
 	int dist, v;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
@@ -3350,7 +3314,7 @@ void MAI_Sneak(int i)
 			mx -= Monst->_menemyx;
 			my -= Monst->_menemyy;
 
-			md = M_GetDir(i);
+			direction md = M_GetDir(i);
 			dist = 5 - Monst->_mint;
 			if (Monst->_mVar1 == MM_GOTHIT) {
 				Monst->_mgoal = MGOAL_RETREAT;
@@ -3402,7 +3366,7 @@ void MAI_Sneak(int i)
 void MAI_Fireman(int i)
 {
 	int xd, yd;
-	int md, pnum;
+	int pnum;
 	int fx, fy;
 	MonsterStruct *Monst;
 
@@ -3418,7 +3382,7 @@ void MAI_Fireman(int i)
 	xd = monster[i]._mx - fx;
 	yd = monster[i]._my - fy;
 
-	md = M_GetDir(i);
+	direction md = M_GetDir(i);
 	if (Monst->_mgoal == MGOAL_NORMAL) {
 		if (LineClear(Monst->_mx, Monst->_my, fx, fy)
 		    && AddMissile(Monst->_mx, Monst->_my, fx, fy, md, MIS_FIREMAN, pnum, i, 0, 0) != -1) {
@@ -3529,7 +3493,7 @@ void MAI_Fallen(int i)
 void MAI_Cleaver(int i)
 {
 	MonsterStruct *Monst;
-	int x, y, mx, my, md;
+	int x, y, mx, my;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
 
@@ -3543,7 +3507,7 @@ void MAI_Cleaver(int i)
 	x = mx - Monst->_menemyx;
 	y = my - Monst->_menemyy;
 
-	md = GetDirection(mx, my, Monst->_lastx, Monst->_lasty);
+	direction md = GetDirection(mx, my, Monst->_lastx, Monst->_lasty);
 	Monst->_mdir = md;
 
 	if (abs(x) >= 2 || abs(y) >= 2)
@@ -3559,7 +3523,7 @@ void MAI_Round(int i, bool special)
 {
 	MonsterStruct *Monst;
 	int fx, fy;
-	int mx, my, md;
+	int mx, my;
 	int dist, v;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
@@ -3569,7 +3533,7 @@ void MAI_Round(int i, bool special)
 		fx = Monst->_menemyx;
 		mx = Monst->_mx - fx;
 		my = Monst->_my - fy;
-		md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
+		direction md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
 		if (Monst->_msquelch < UCHAR_MAX)
 			MonstCheckDoors(i);
 		v = random_(114, 100);
@@ -3620,7 +3584,6 @@ void MAI_GoatMc(int i)
 
 void MAI_Ranged(int i, int missile_type, bool special)
 {
-	int md;
 	int fx, fy, mx, my;
 	MonsterStruct *Monst;
 
@@ -3636,7 +3599,7 @@ void MAI_Ranged(int i, int missile_type, bool special)
 		fy = Monst->_menemyy;
 		mx = Monst->_mx - fx;
 		my = Monst->_my - fy;
-		md = M_GetDir(i);
+		direction md = M_GetDir(i);
 		if (Monst->_msquelch < UCHAR_MAX)
 			MonstCheckDoors(i);
 		Monst->_mdir = md;
@@ -3659,7 +3622,7 @@ void MAI_Ranged(int i, int missile_type, bool special)
 	} else if (Monst->_msquelch != 0) {
 		fx = Monst->_lastx;
 		fy = Monst->_lasty;
-		md = GetDirection(Monst->_mx, Monst->_my, fx, fy);
+		direction md = GetDirection(Monst->_mx, Monst->_my, fx, fy);
 		M_CallWalk(i, md);
 	}
 }
@@ -3810,14 +3773,14 @@ void MAI_Scav(int i)
 void MAI_Garg(int i)
 {
 	MonsterStruct *Monst;
-	int mx, my, dx, dy, md;
+	int mx, my, dx, dy;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
 
 	Monst = &monster[i];
 	dx = Monst->_mx - Monst->_lastx;
 	dy = Monst->_my - Monst->_lasty;
-	md = M_GetDir(i);
+	direction md = M_GetDir(i);
 	if (Monst->_msquelch != 0 && Monst->_mFlags & MFLAG_ALLOW_SPECIAL) {
 		M_Enemy(i);
 		mx = Monst->_mx - Monst->_menemyx;
@@ -3851,7 +3814,7 @@ void MAI_RoundRanged(int i, int missile_type, bool checkdoors, int dam, int less
 	MonsterStruct *Monst;
 	int mx, my;
 	int fx, fy;
-	int md, dist, v;
+	int dist, v;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
 	Monst = &monster[i];
@@ -3860,7 +3823,7 @@ void MAI_RoundRanged(int i, int missile_type, bool checkdoors, int dam, int less
 		fy = Monst->_menemyy;
 		mx = Monst->_mx - fx;
 		my = Monst->_my - fy;
-		md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
+		direction md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
 		if (checkdoors && Monst->_msquelch < UCHAR_MAX)
 			MonstCheckDoors(i);
 		v = random_(121, 10000);
@@ -3935,7 +3898,7 @@ void MAI_RR2(int i, int mistype, int dam)
 {
 	MonsterStruct *Monst;
 	int mx, my, fx, fy;
-	int dist, v, md;
+	int dist, v;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
 
@@ -3952,7 +3915,7 @@ void MAI_RR2(int i, int mistype, int dam)
 		fy = Monst->_menemyy;
 		mx = Monst->_mx - fx;
 		my = Monst->_my - fy;
-		md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
+		direction md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
 		if (Monst->_msquelch < UCHAR_MAX)
 			MonstCheckDoors(i);
 		v = random_(121, 100);
@@ -4009,7 +3972,7 @@ void MAI_Mega(int i)
 void MAI_Golum(int i)
 {
 	int mx, my, _mex, _mey;
-	int md, j, k, _menemy;
+	int j, k, _menemy;
 	MonsterStruct *Monst;
 	bool have_enemy, ok;
 
@@ -4041,7 +4004,7 @@ void MAI_Golum(int i)
 	my = monster[i]._my;
 	_mex = mx - monster[_menemy]._mfutx;
 	_mey = my - monster[_menemy]._mfuty;
-	md = GetDirection(mx, my, monster[_menemy]._mx, monster[_menemy]._my);
+	direction md = GetDirection(mx, my, monster[_menemy]._mx, monster[_menemy]._my);
 	monster[i]._mdir = md;
 	if (abs(_mex) < 2 && abs(_mey) < 2 && have_enemy) {
 		_menemy = monster[i]._menemy;
@@ -4074,9 +4037,9 @@ void MAI_Golum(int i)
 	if (ok)
 		return;
 
-	md = (md - 1) & 7;
+	md = left[md];
 	for (j = 0; j < 8 && !ok; j++) {
-		md = (md + 1) & 7;
+        md = right[md];
 		ok = DirOK(i, md);
 	}
 	if (ok)
@@ -4087,7 +4050,7 @@ void MAI_SkelKing(int i)
 {
 	MonsterStruct *Monst;
 	int mx, my, fx, fy, nx, ny;
-	int dist, v, md;
+	int dist, v;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
 	Monst = &monster[i];
@@ -4096,7 +4059,7 @@ void MAI_SkelKing(int i)
 		fy = Monst->_menemyy;
 		mx = Monst->_mx - fx;
 		my = Monst->_my - fy;
-		md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
+		direction md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
 		if (Monst->_msquelch < UCHAR_MAX)
 			MonstCheckDoors(i);
 		v = random_(126, 100);
@@ -4150,7 +4113,7 @@ void MAI_Rhino(int i)
 {
 	MonsterStruct *Monst;
 	int mx, my, fx, fy;
-	int v, dist, md;
+	int v, dist;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
 	Monst = &monster[i];
@@ -4159,7 +4122,7 @@ void MAI_Rhino(int i)
 		fy = Monst->_menemyy;
 		mx = Monst->_mx - fx;
 		my = Monst->_my - fy;
-		md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
+		direction md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
 		if (Monst->_msquelch < UCHAR_MAX)
 			MonstCheckDoors(i);
 		v = random_(131, 100);
@@ -4214,7 +4177,7 @@ void MAI_Rhino(int i)
 void MAI_HorkDemon(int i)
 {
 	MonsterStruct *Monst;
-	int fx, fy, mx, my, md, v, dist;
+	int fx, fy, mx, my, v, dist;
 
 	if ((DWORD)i >= MAXMONSTERS) {
 		return;
@@ -4229,7 +4192,7 @@ void MAI_HorkDemon(int i)
 	fy = Monst->_menemyy;
 	mx = Monst->_mx - fx;
 	my = Monst->_my - fy;
-	md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
+	direction md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
 
 	if (Monst->_msquelch < 255) {
 		MonstCheckDoors(i);
@@ -4285,7 +4248,7 @@ void MAI_HorkDemon(int i)
 void MAI_Counselor(int i)
 {
 	int mx, my, fx, fy;
-	int dist, md, v;
+	int dist, v;
 	MonsterStruct *Monst;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
@@ -4296,7 +4259,7 @@ void MAI_Counselor(int i)
 		fy = Monst->_menemyy;
 		mx = Monst->_mx - fx;
 		my = Monst->_my - fy;
-		md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
+		direction md = GetDirection(Monst->_mx, Monst->_my, Monst->_lastx, Monst->_lasty);
 		if (Monst->_msquelch < UCHAR_MAX)
 			MonstCheckDoors(i);
 		v = random_(121, 100);
@@ -4353,7 +4316,7 @@ void MAI_Counselor(int i)
 
 void MAI_Garbud(int i)
 {
-	int _mx, _my, md;
+	int _mx, _my;
 	MonsterStruct *Monst;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
@@ -4365,7 +4328,7 @@ void MAI_Garbud(int i)
 
 	_mx = Monst->_mx;
 	_my = Monst->_my;
-	md = M_GetDir(i);
+	direction md = M_GetDir(i);
 
 	if (Monst->mtalkmsg >= TEXT_GARBUD1
 	    && Monst->mtalkmsg <= TEXT_GARBUD3
@@ -4406,7 +4369,7 @@ void MAI_Garbud(int i)
 
 void MAI_Zhar(int i)
 {
-	int mx, my, md;
+	int mx, my;
 	MonsterStruct *Monst;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
@@ -4418,7 +4381,7 @@ void MAI_Zhar(int i)
 
 	mx = Monst->_mx;
 	my = Monst->_my;
-	md = M_GetDir(i);
+	direction md = M_GetDir(i);
 	if (Monst->mtalkmsg == TEXT_ZHAR1 && !(dFlags[mx][my] & BFLAG_VISIBLE) && Monst->_mgoal == MGOAL_TALKING) {
 		Monst->mtalkmsg = TEXT_ZHAR2;
 		Monst->_mgoal = MGOAL_INQUIRING;
@@ -4445,7 +4408,7 @@ void MAI_Zhar(int i)
 
 void MAI_SnotSpil(int i)
 {
-	int mx, my, md;
+	int mx, my;
 	MonsterStruct *Monst;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
@@ -4457,7 +4420,7 @@ void MAI_SnotSpil(int i)
 
 	mx = Monst->_mx;
 	my = Monst->_my;
-	md = M_GetDir(i);
+	direction md = M_GetDir(i);
 
 	if (Monst->mtalkmsg == TEXT_BANNER10 && !(dFlags[mx][my] & BFLAG_VISIBLE) && Monst->_mgoal == MGOAL_TALKING) {
 		Monst->mtalkmsg = TEXT_BANNER11;
@@ -4494,7 +4457,7 @@ void MAI_SnotSpil(int i)
 
 void MAI_Lazurus(int i)
 {
-	int mx, my, md;
+	int mx, my;
 	MonsterStruct *Monst;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
@@ -4506,7 +4469,7 @@ void MAI_Lazurus(int i)
 
 	mx = Monst->_mx;
 	my = Monst->_my;
-	md = M_GetDir(i);
+	direction md = M_GetDir(i);
 	if (dFlags[mx][my] & BFLAG_VISIBLE) {
 		if (!gbIsMultiplayer) {
 			if (Monst->mtalkmsg == TEXT_VILE13 && Monst->_mgoal == MGOAL_INQUIRING && plr[myplr]._px == 35 && plr[myplr]._py == 46) {
@@ -4549,7 +4512,6 @@ void MAI_Lazurus(int i)
 void MAI_Lazhelp(int i)
 {
 	int _mx, _my;
-	volatile int md; // BUGFIX: very questionable volatile
 	MonsterStruct *Monst;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
@@ -4559,7 +4521,7 @@ void MAI_Lazhelp(int i)
 	Monst = &monster[i];
 	_mx = Monst->_mx;
 	_my = Monst->_my;
-	md = M_GetDir(i);
+	direction md = M_GetDir(i);
 
 	if (dFlags[_mx][_my] & BFLAG_VISIBLE) {
 		if (!gbIsMultiplayer) {
@@ -4581,7 +4543,7 @@ void MAI_Lazhelp(int i)
 
 void MAI_Lachdanan(int i)
 {
-	int _mx, _my, md;
+	int _mx, _my;
 	MonsterStruct *Monst;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
@@ -4593,7 +4555,7 @@ void MAI_Lachdanan(int i)
 
 	_mx = Monst->_mx;
 	_my = Monst->_my;
-	md = M_GetDir(i);
+	direction md = M_GetDir(i);
 
 	if (Monst->mtalkmsg == TEXT_VEIL9 && !(dFlags[_mx][_my] & BFLAG_VISIBLE) && monster[i]._mgoal == MGOAL_TALKING) {
 		Monst->mtalkmsg = TEXT_VEIL10;
@@ -4619,7 +4581,7 @@ void MAI_Lachdanan(int i)
 void MAI_Warlord(int i)
 {
 	MonsterStruct *Monst;
-	int mx, my, md;
+	int mx, my;
 
 	assurance((DWORD)i < MAXMONSTERS, i);
 
@@ -4630,7 +4592,7 @@ void MAI_Warlord(int i)
 
 	mx = Monst->_mx;
 	my = Monst->_my;
-	md = M_GetDir(i);
+	direction md = M_GetDir(i);
 	if (dFlags[mx][my] & BFLAG_VISIBLE) {
 		if (Monst->mtalkmsg == TEXT_WARLRD9 && Monst->_mgoal == MGOAL_INQUIRING)
 			Monst->_mmode = MM_TALK;
@@ -4843,7 +4805,7 @@ void FreeMonsters()
 	FreeMissiles2();
 }
 
-bool DirOK(int i, int mdir)
+bool DirOK(int i, direction mdir)
 {
 	int fx, fy;
 	int x, y;
@@ -5319,7 +5281,7 @@ void MissToMonst(int i, int x, int y)
 	oldx = Miss->_mix;
 	oldy = Miss->_miy;
 	dMonster[x][y] = m + 1;
-	Monst->_mdir = Miss->_mimfnum;
+	Monst->_mdir = (direction)Miss->_mimfnum;
 	Monst->_mx = x;
 	Monst->_my = y;
 	M_StartStand(m, Monst->_mdir);
@@ -5490,7 +5452,7 @@ bool IsGoat(int mt)
 	    || (mt >= MT_NGOATBW && mt <= MT_GGOATBW);
 }
 
-int M_SpawnSkel(int x, int y, int dir)
+int M_SpawnSkel(int x, int y, direction dir)
 {
 	int i, j, skeltypes, skel;
 
@@ -5517,7 +5479,7 @@ int M_SpawnSkel(int x, int y, int dir)
 	return -1;
 }
 
-void ActivateSpawn(int i, int x, int y, int dir)
+void ActivateSpawn(int i, int x, int y, direction dir)
 {
 	dMonster[x][y] = i + 1;
 	monster[i]._mx = x;
@@ -5531,7 +5493,7 @@ void ActivateSpawn(int i, int x, int y, int dir)
 
 bool SpawnSkeleton(int ii, int x, int y)
 {
-	int dx, dy, xx, yy, dir, j, k, rs;
+	int dx, dy, xx, yy, j, k, rs;
 	bool savail;
 	int monstok[3][3];
 
@@ -5539,7 +5501,7 @@ bool SpawnSkeleton(int ii, int x, int y)
 		return false;
 
 	if (PosOkMonst(-1, x, y)) {
-		dir = GetDirection(x, y, x, y);
+		direction dir = GetDirection(x, y, x, y);
 		ActivateSpawn(ii, x, y, dir);
 		return true;
 	}
@@ -5578,7 +5540,7 @@ bool SpawnSkeleton(int ii, int x, int y)
 
 	dx = x - 1 + xx;
 	dy = y - 1 + yy;
-	dir = GetDirection(dx, dy, x, y);
+	direction dir = GetDirection(dx, dy, x, y);
 	ActivateSpawn(ii, dx, dy, dir);
 
 	return true;
@@ -5602,9 +5564,9 @@ int PreSpawnSkeleton()
 			if (IsSkel(Monsters[i].mtype))
 				j++;
 		}
-		skel = AddMonster(0, 0, 0, i - 1, false);
+		skel = AddMonster(0, 0, DIR_S, i - 1, false);
 		if (skel != -1)
-			M_StartStand(skel, 0);
+			M_StartStand(skel, DIR_S);
 
 		return skel;
 	}
@@ -5658,7 +5620,7 @@ void SpawnGolum(int i, int x, int y, int mi)
 	monster[i].mMinDamage = 2 * (missile[mi]._mispllvl + 4);
 	monster[i].mMaxDamage = 2 * (missile[mi]._mispllvl + 8);
 	monster[i]._mFlags |= MFLAG_GOLEM;
-	M_StartSpStand(i, 0);
+	M_StartSpStand(i, DIR_S);
 	M_Enemy(i);
 	if (i == myplr) {
 		NetSendCmdGolem(

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include "engine.h"
 #include "miniwin/miniwin.h"
 #include "monstdat.h"
 #include "sound.h"
@@ -158,7 +159,7 @@ struct MonsterStruct { // note: missing field _mAFNum
 	/** Pixel Y-velocity while walking. Applied to _myoff */
 	Sint32 _myvel;
 	/** Direction faced by monster (direction enum) */
-	Sint32 _mdir;
+	direction _mdir;
 	/** The current target of the mosnter. An index in to either the plr or monster array based on the _meflag value. */
 	Sint32 _menemy;
 	/** X-coordinate of enemy (usually correspond's to the enemy's futx value) */
@@ -231,17 +232,17 @@ extern int nummtypes;
 void InitLevelMonsters();
 void GetLevelMTypes();
 void InitMonsterGFX(int monst);
-void InitMonster(int i, int rd, int mtype, int x, int y);
+void InitMonster(int i, direction rd, int mtype, int x, int y);
 void ClrAllMonsters();
 void monster_some_crypt();
 void PlaceGroup(int mtype, int num, int leaderf, int leader);
 void InitMonsters();
 void SetMapMonsters(BYTE *pMap, int startx, int starty);
 void DeleteMonster(int i);
-int AddMonster(int x, int y, int dir, int mtype, bool InMap);
+int AddMonster(int x, int y, direction dir, int mtype, bool InMap);
 void monster_43C785(int i);
 bool M_Talker(int i);
-void M_StartStand(int i, int md);
+void M_StartStand(int i, direction md);
 void M_ClearSquares(int i);
 void M_GetKnockback(int i);
 void M_StartHit(int i, int pnum, int dam);
@@ -251,7 +252,7 @@ void M_Teleport(int i);
 void M_UpdateLeader(int i);
 void DoEnding();
 void PrepDoEnding();
-void M_WalkDir(int i, int md);
+void M_WalkDir(int i, direction md);
 void MAI_Zombie(int i);
 void MAI_SkelSd(int i);
 void MAI_Snake(int i);
@@ -298,7 +299,7 @@ void MAI_Warlord(int i);
 void DeleteMonsterList();
 void ProcessMonsters();
 void FreeMonsters();
-bool DirOK(int i, int mdir);
+bool DirOK(int i, direction mdir);
 bool PosOkMissile(int x, int y);
 bool CheckNoSolid(int x, int y);
 bool LineClearF(bool (*Clear)(int, int), int x1, int y1, int x2, int y2);
@@ -315,7 +316,7 @@ bool PosOkMonst2(int i, int x, int y);
 bool PosOkMonst3(int i, int x, int y);
 bool IsSkel(int mt);
 bool IsGoat(int mt);
-int M_SpawnSkel(int x, int y, int dir);
+int M_SpawnSkel(int x, int y, direction dir);
 bool SpawnSkeleton(int ii, int x, int y);
 int PreSpawnSkeleton();
 void TalktoMonster(int i);
@@ -327,7 +328,9 @@ void decode_enemy(int m, int enemy);
 
 /* data */
 
-extern int opposite[8];
+extern direction left[8];
+extern direction right[8];
+extern direction opposite[8];
 extern int offset_x[8];
 extern int offset_y[8];
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -863,7 +863,7 @@ void NetSendCmd(bool bHiPri, _cmd_id bCmd)
 		NetSendLoPri(myplr, (BYTE *)&cmd, sizeof(cmd));
 }
 
-void NetSendCmdGolem(BYTE mx, BYTE my, BYTE dir, BYTE menemy, int hp, BYTE cl)
+void NetSendCmdGolem(BYTE mx, BYTE my, direction dir, BYTE menemy, int hp, BYTE cl)
 {
 	TCmdGolem cmd;
 

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -188,7 +188,7 @@ struct TCmdGolem {
 	_cmd_id bCmd;
 	Uint8 _mx;
 	Uint8 _my;
-	Uint8 _mdir;
+	direction _mdir;
 	Sint8 _menemy;
 	Sint32 _mhitpoints;
 	Uint8 _currlevel;
@@ -362,7 +362,7 @@ struct TPkt {
 struct DMonsterStr {
 	Uint8 _mx;
 	Uint8 _my;
-	Uint8 _mdir;
+	direction _mdir;
 	Uint8 _menemy;
 	Uint8 _mactive;
 	Sint32 _mhitpoints;
@@ -433,7 +433,7 @@ void DeltaAddItem(int ii);
 void DeltaSaveLevel();
 void DeltaLoadLevel();
 void NetSendCmd(bool bHiPri, _cmd_id bCmd);
-void NetSendCmdGolem(BYTE mx, BYTE my, BYTE dir, BYTE menemy, int hp, BYTE cl);
+void NetSendCmdGolem(BYTE mx, BYTE my, direction dir, BYTE menemy, int hp, BYTE cl);
 void NetSendCmdLoc(int playerId, bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y);
 void NetSendCmdLocParam1(bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y, WORD wParam1);
 void NetSendCmdLocParam2(bool bHiPri, _cmd_id bCmd, BYTE x, BYTE y, WORD wParam1, WORD wParam2);

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2067,7 +2067,7 @@ void Obj_FlameTrap(int i)
 
 void Obj_Trap(int i)
 {
-	int oti, dir;
+	int oti;
 	bool otrig;
 	int sx, sy, dx, dy, x, y;
 
@@ -2111,7 +2111,7 @@ void Obj_Trap(int i)
 				}
 			}
 			if (!deltaload) {
-				dir = GetDirection(sx, sy, dx, dy);
+				direction dir = GetDirection(sx, sy, dx, dy);
 				AddMissile(sx, sy, dx, dy, dir, object[i]._oVar3, TARGET_PLAYERS, -1, 0, 0);
 				PlaySfxLoc(IS_TRAP, object[oti]._ox, object[oti]._oy);
 			}
@@ -3093,7 +3093,7 @@ void OperateSChambBk(int pnum, int i)
 
 void OperateChest(int pnum, int i, bool sendmsg)
 {
-	int j, mdir, mtype;
+	int j, mtype;
 
 	if (object[i]._oSelFlag != 0) {
 		if (!deltaload)
@@ -3115,7 +3115,7 @@ void OperateChest(int pnum, int i, bool sendmsg)
 				}
 			}
 			if (object[i]._oTrapFlag && object[i]._otype >= OBJ_TCHEST1 && object[i]._otype <= OBJ_TCHEST3) {
-				mdir = GetDirection(object[i]._ox, object[i]._oy, plr[pnum]._px, plr[pnum]._py);
+				direction mdir = GetDirection(object[i]._ox, object[i]._oy, plr[pnum]._px, plr[pnum]._py);
 				switch (object[i]._oVar4) {
 				case 0:
 					mtype = MIS_ARROW;

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -771,7 +771,7 @@ static void scrollrt_draw_dungeon(CelOutputBuffer out, int sx, int sy, int dx, i
 	if (light_table_index < lightmax && bDead != 0) {
 		do {
 			DeadStruct *pDeadGuy = &dead[(bDead & 0x1F) - 1];
-			char dd = (bDead >> 5) & 7;
+			direction dd = (direction)((bDead >> 5) & 7);
 			int px = dx - pDeadGuy->_deadWidth2;
 			BYTE *pCelBuff = pDeadGuy->_deadData[dd];
 			assert(pCelBuff != NULL);

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -190,7 +190,7 @@ bool CheckSpell(int id, spell_id sn, spell_type st, bool manaonly)
 
 void CastSpell(int id, int spl, int sx, int sy, int dx, int dy, int spllvl)
 {
-	int dir = plr[id]._pdir;
+	direction dir = plr[id]._pdir;
 	if (spl == SPL_FIREWALL || spl == SPL_LIGHTWALL) {
 		dir = plr[id]._pVar3;
 	}

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -203,7 +203,7 @@ Uint32 sync_all_monsters(const Uint8 *pbBuf, Uint32 dwMaxLen)
 
 static void sync_monster(int pnum, const TSyncMonster *p)
 {
-	int ndx, md, mdx, mdy;
+	int ndx, mdx, mdy;
 	Uint32 delta;
 
 	ndx = p->_mndx;
@@ -231,7 +231,7 @@ static void sync_monster(int pnum, const TSyncMonster *p)
 	mdy = abs(monster[ndx]._my - p->_my);
 	if (mdx <= 2 && mdy <= 2) {
 		if (monster[ndx]._mmode < MM_WALK || monster[ndx]._mmode > MM_WALK3) {
-			md = GetDirection(monster[ndx]._mx, monster[ndx]._my, p->_mx, p->_my);
+			direction md = GetDirection(monster[ndx]._mx, monster[ndx]._my, p->_mx, p->_my);
 			if (DirOK(ndx, md)) {
 				M_ClearSquares(ndx);
 				dMonster[monster[ndx]._mx][monster[ndx]._my] = ndx + 1;
@@ -245,7 +245,7 @@ static void sync_monster(int pnum, const TSyncMonster *p)
 		monster[ndx]._mx = p->_mx;
 		monster[ndx]._my = p->_my;
 		decode_enemy(ndx, p->_menemy);
-		md = GetDirection(p->_mx, p->_my, monster[ndx]._menemyx, monster[ndx]._menemyy);
+		direction md = GetDirection(p->_mx, p->_my, monster[ndx]._menemyx, monster[ndx]._menemyy);
 		M_StartStand(ndx, md);
 		monster[ndx]._msquelch = UCHAR_MAX;
 	}

--- a/Source/themes.cpp
+++ b/Source/themes.cpp
@@ -517,7 +517,7 @@ void PlaceThemeMonsts(int t, int f)
 		for (xp = 0; xp < MAXDUNX; xp++) {
 			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]] && dItem[xp][yp] == 0 && dObject[xp][yp] == 0) {
 				if (random_(0, f) == 0) {
-					AddMonster(xp, yp, random_(0, 8), mtype, true);
+					AddMonster(xp, yp, (direction)random_(0, 8), mtype, true);
 				}
 			}
 		}


### PR DESCRIPTION
This was originally just supposed to be going over and applying clang-tidy rules, but as soon as I tried satisfying clang-tidy's complaints about type conversion it ballooned into a big side project of applying the `direction` enum to everything.