### PR TITLE
fix cave stairs

### DIFF
--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -565,9 +565,13 @@ bool ForceL3Trig()
 				sprintf(infostr, "Up to level %i", currlevel - 1);
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABPREVLVL) {
-						cursmx = trigs[j]._tx;
-						cursmy = trigs[j]._ty;
-						return true;
+						dx = abs(trigs[j]._tx - cursmx);
+						dy = abs(trigs[j]._ty - cursmy);
+						if (dx < 4 && dy < 4) {
+							cursmx = trigs[j]._tx;
+							cursmy = trigs[j]._ty;
+							return true;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes https://github.com/diasurgical/devilutionX/issues/1582
dPiece 182 was the cause of that problem.
It occurs both in warp to town and level up and only warp to town was checking distance.

```cpp
/** Specifies the dungeon piece IDs which constitute stairways leading up from the caves. */
int L3UpList[] = { 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, -1 };
```
Whenever you put the mouse over dPiece 182 in stairs to town, the code matches that dPiece with "level up" trigger and replaces cursmx/cursmy without any check - that's why teleporting/clicking actually targetted the stairs up

While this could be applied to all entrances, I've only used it for caves one because that's the only one people reported problems with. And at the moment I'm not confident enough this wouldn't change the behavior of hell stairs which are 3x2 (I needed a 5 radius check for drawing all hell stairs tiles on automap ...)