### PR TITLE
🧹 SDL1.2: Remove unimplemented SDL_*Window backports

### DIFF
--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -82,8 +82,10 @@ static void dx_create_primary_surface()
 
 void dx_init()
 {
+#ifndef USE_SDL1
 	SDL_RaiseWindow(ghMainWnd);
 	SDL_ShowWindow(ghMainWnd);
+#endif
 
 	dx_create_primary_surface();
 	palette_init();
@@ -139,8 +141,10 @@ CelOutputBuffer GlobalBackBuffer()
 
 void dx_cleanup()
 {
+#ifndef USE_SDL1
 	if (ghMainWnd)
 		SDL_HideWindow(ghMainWnd);
+#endif
 	sgMemCrit.Enter();
 	sgdwLockCount = 0;
 	sgMemCrit.Leave();

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -224,7 +224,9 @@ void init_create_window()
 		app_fatal("Unable to create main window");
 	dx_init();
 	gbActive = true;
+#ifndef USE_SDL1
 	SDL_DisableScreenSaver();
+#endif
 }
 
 void MainWndProc(UINT Msg, WPARAM wParam, LPARAM lParam)

--- a/Source/utils/sdl2_to_1_2_backports.h
+++ b/Source/utils/sdl2_to_1_2_backports.h
@@ -114,11 +114,6 @@ inline SDL_bool SDL_PointInRect(const SDL_Point *p, const SDL_Rect *r)
 	return ((p->x >= r->x) && (p->x < (r->x + r->w)) && (p->y >= r->y) && (p->y < (r->y + r->h))) ? SDL_TRUE : SDL_FALSE;
 }
 
-inline void SDL_DisableScreenSaver()
-{
-	DUMMY();
-}
-
 //= Messagebox (simply logged to stderr for now)
 
 enum {
@@ -149,31 +144,11 @@ inline void SDL_GetWindowPosition(SDL_Window *window, int *x, int *y)
 	SDL_Log("SDL_GetWindowPosition %d %d", *x, *y);
 }
 
-inline void SDL_SetWindowPosition(SDL_Window *window, int x, int y)
-{
-	DUMMY();
-}
-
 inline void SDL_GetWindowSize(SDL_Window *window, int *w, int *h)
 {
 	*w = window->clip_rect.w;
 	*h = window->clip_rect.h;
 	SDL_Log("SDL_GetWindowSize %d %d", *w, *h);
-}
-
-inline void SDL_ShowWindow(SDL_Window *window)
-{
-	DUMMY();
-}
-
-inline void SDL_HideWindow(SDL_Window *window)
-{
-	DUMMY();
-}
-
-inline void SDL_RaiseWindow(SDL_Window *window)
-{
-	DUMMY();
 }
 
 inline void SDL_DestroyWindow(SDL_Window *window)

--- a/Source/utils/stubs.h
+++ b/Source/utils/stubs.h
@@ -16,8 +16,6 @@
 		abort();                                                          \
 	} while (0)
 
-#define DUMMY() SDL_Log("DUMMY: %s @ %s:%d", __FUNCTION__, __FILE__, __LINE__)
-
 #define ASSERT(x)                                                         \
 	if (!(x)) {                                                           \
 		SDL_Log("Assertion failed in %s:%d: %s", __FILE__, __LINE__, #x); \


### PR DESCRIPTION
Guard around SDL version at call site instead.