### PR TITLE
Fix to network desyncs related to player movement

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -114,6 +114,33 @@ static BYTE *multi_recv_packet(TBuffer *pBuf, BYTE *body, DWORD *size)
 
 static void NetRecvPlrData(TPkt *pkt)
 {
+	/*
+	* We calculate _ptargx and _ptargy here and prepare for it to be sent to other clients.
+	* If px/py and ptarx/ptary don't match on other clients, then they'll move our
+	* local player to that location.
+	*/
+	{
+		int realTargetX = plr[myplr]._pfutx;
+		int realTargetY = plr[myplr]._pfuty;
+		for (int i = 0; i < MAX_PATH_LENGTH; i++) {
+			if (plr[myplr].walkpath[i] == WALK_NONE)
+				break;
+
+			if (plr[myplr].walkpath[i] == WALK_N || plr[myplr].walkpath[i] == WALK_NW || plr[myplr].walkpath[i] == WALK_W)
+				realTargetX--;
+			else if (plr[myplr].walkpath[i] == WALK_E || plr[myplr].walkpath[i] == WALK_SE || plr[myplr].walkpath[i] == WALK_S)
+				realTargetX++;
+
+			if (plr[myplr].walkpath[i] == WALK_N || plr[myplr].walkpath[i] == WALK_NE || plr[myplr].walkpath[i] == WALK_E)
+				realTargetY--;
+			else if (plr[myplr].walkpath[i] == WALK_S || plr[myplr].walkpath[i] == WALK_SW || plr[myplr].walkpath[i] == WALK_W)
+				realTargetY++;
+		}
+
+		plr[myplr]._ptargx = realTargetX;
+		plr[myplr]._ptargy = realTargetY;
+	}
+
 	pkt->hdr.wCheck = LOAD_BE32("\0\0ip");
 	pkt->hdr.px = plr[myplr]._px;
 	pkt->hdr.py = plr[myplr]._py;

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -114,32 +114,14 @@ static BYTE *multi_recv_packet(TBuffer *pBuf, BYTE *body, DWORD *size)
 
 static void NetRecvPlrData(TPkt *pkt)
 {
-	/*
-	* We calculate _ptargx and _ptargy here and prepare for it to be sent to other clients.
-	* If px/py and ptarx/ptary don't match on other clients, then they'll move our local player to that location.
-	*/
-	{
-		// clang-format off
-		int directionOffsetX[8] = {  0,-1, 1, 0,-1, 1, 1,-1 };
-		int directionOffsetY[8] = { -1, 0, 0, 1,-1,-1, 1, 1 };
-		// clang-format on
-		plr[myplr]._ptargx = plr[myplr]._pfutx;
-		plr[myplr]._ptargy = plr[myplr]._pfuty;
-		for (int i = 0; i < MAX_PATH_LENGTH; i++) {
-			if (plr[myplr].walkpath[i] == WALK_NONE)
-				break;
-			if (plr[myplr].walkpath[i] > 0) {
-				plr[myplr]._ptargx += directionOffsetX[plr[myplr].walkpath[i] - 1];
-				plr[myplr]._ptargy += directionOffsetY[plr[myplr].walkpath[i] - 1];
-			}
-		}
-	}
+	Sint32 targetX, targetY;
+	GetPlayerTargetPosition(myplr, &targetX, &targetY);
 
 	pkt->hdr.wCheck = LOAD_BE32("\0\0ip");
 	pkt->hdr.px = plr[myplr]._px;
 	pkt->hdr.py = plr[myplr]._py;
-	pkt->hdr.targx = plr[myplr]._ptargx;
-	pkt->hdr.targy = plr[myplr]._ptargy;
+	pkt->hdr.targx = targetX;
+	pkt->hdr.targy = targetY;
 	pkt->hdr.php = plr[myplr]._pHitPoints;
 	pkt->hdr.pmhp = plr[myplr]._pMaxHP;
 	pkt->hdr.bstr = plr[myplr]._pBaseStr;

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -128,8 +128,10 @@ static void NetRecvPlrData(TPkt *pkt)
 		for (int i = 0; i < MAX_PATH_LENGTH; i++) {
 			if (plr[myplr].walkpath[i] == WALK_NONE)
 				break;
-			plr[myplr]._ptargx += directionOffsetX[plr[myplr].walkpath[i] - 1];
-			plr[myplr]._ptargy += directionOffsetY[plr[myplr].walkpath[i] - 1];
+			if (plr[myplr].walkpath[i] > 0) {
+				plr[myplr]._ptargx += directionOffsetX[plr[myplr].walkpath[i] - 1];
+				plr[myplr]._ptargy += directionOffsetY[plr[myplr].walkpath[i] - 1];
+			}
 		}
 	}
 

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -116,29 +116,21 @@ static void NetRecvPlrData(TPkt *pkt)
 {
 	/*
 	* We calculate _ptargx and _ptargy here and prepare for it to be sent to other clients.
-	* If px/py and ptarx/ptary don't match on other clients, then they'll move our
-	* local player to that location.
+	* If px/py and ptarx/ptary don't match on other clients, then they'll move our local player to that location.
 	*/
 	{
-		int realTargetX = plr[myplr]._pfutx;
-		int realTargetY = plr[myplr]._pfuty;
+		// clang-format off
+		int directionOffsetX[8] = {  0,-1, 1, 0,-1, 1, 1,-1 };
+		int directionOffsetY[8] = { -1, 0, 0, 1,-1,-1, 1, 1 };
+		// clang-format on
+		plr[myplr]._ptargx = plr[myplr]._pfutx;
+		plr[myplr]._ptargy = plr[myplr]._pfuty;
 		for (int i = 0; i < MAX_PATH_LENGTH; i++) {
 			if (plr[myplr].walkpath[i] == WALK_NONE)
 				break;
-
-			if (plr[myplr].walkpath[i] == WALK_N || plr[myplr].walkpath[i] == WALK_NW || plr[myplr].walkpath[i] == WALK_W)
-				realTargetX--;
-			else if (plr[myplr].walkpath[i] == WALK_E || plr[myplr].walkpath[i] == WALK_SE || plr[myplr].walkpath[i] == WALK_S)
-				realTargetX++;
-
-			if (plr[myplr].walkpath[i] == WALK_N || plr[myplr].walkpath[i] == WALK_NE || plr[myplr].walkpath[i] == WALK_E)
-				realTargetY--;
-			else if (plr[myplr].walkpath[i] == WALK_S || plr[myplr].walkpath[i] == WALK_SW || plr[myplr].walkpath[i] == WALK_W)
-				realTargetY++;
+			plr[myplr]._ptargx += directionOffsetX[plr[myplr].walkpath[i] - 1];
+			plr[myplr]._ptargy += directionOffsetY[plr[myplr].walkpath[i] - 1];
 		}
-
-		plr[myplr]._ptargx = realTargetX;
-		plr[myplr]._ptargy = realTargetY;
 	}
 
 	pkt->hdr.wCheck = LOAD_BE32("\0\0ip");

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3225,36 +3225,6 @@ void CheckNewPath(int pnum)
 			if (plr[pnum]._pmode == PM_STAND) {
 				StartStand(pnum, plr[pnum]._pdir);
 				plr[pnum].destAction = ACTION_NONE;
-			} else if (pnum == myplr) {
-
-				/*
-				* This forces _ptargx and _ptargy (those indicate the end position for a player after following pathfinding)
-				* to be correct while character is moving.
-				*
-				* This fixes a desync which happens if a player queues a move while attacking. When finishing an attack,
-				* the game calls FixPlayerPosition() which resets _ptargx and _ptargy, but they shouldn't be reset if
-				* player is supposed to follow pathfinding immediately after attacking.
-				*/
-
-				int realTargetX = plr[pnum]._pfutx;
-				int realTargetY = plr[pnum]._pfuty;
-				for (i = 0; i < MAX_PATH_LENGTH; i++) {
-					if (plr[pnum].walkpath[i] == WALK_NONE)
-						break;
-
-					if (plr[pnum].walkpath[i] == WALK_N || plr[pnum].walkpath[i] == WALK_NW || plr[pnum].walkpath[i] == WALK_W)
-						realTargetX--;
-					else if (plr[pnum].walkpath[i] == WALK_E || plr[pnum].walkpath[i] == WALK_SE || plr[pnum].walkpath[i] == WALK_S)
-						realTargetX++;
-
-					if (plr[pnum].walkpath[i] == WALK_N || plr[pnum].walkpath[i] == WALK_NE || plr[pnum].walkpath[i] == WALK_E)
-						realTargetY--;
-					else if (plr[pnum].walkpath[i] == WALK_S || plr[pnum].walkpath[i] == WALK_SW || plr[pnum].walkpath[i] == WALK_W)
-						realTargetY++;
-				}
-
-				plr[pnum]._ptargx = realTargetX;
-				plr[pnum]._ptargy = realTargetY;
 			}
 		}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3225,6 +3225,36 @@ void CheckNewPath(int pnum)
 			if (plr[pnum]._pmode == PM_STAND) {
 				StartStand(pnum, plr[pnum]._pdir);
 				plr[pnum].destAction = ACTION_NONE;
+			} else if (pnum == myplr) {
+
+				/*
+				* This forces _ptargx and _ptargy (those indicate the end position for a player after following pathfinding)
+				* to be correct while character is moving.
+				*
+				* This fixes a desync which happens if a player queues a move while attacking. When finishing an attack,
+				* the game calls FixPlayerPosition() which resets _ptargx and _ptargy, but they shouldn't be reset if
+				* player is supposed to follow pathfinding immediately after attacking.
+				*/
+
+				int realTargetX = plr[pnum]._pfutx;
+				int realTargetY = plr[pnum]._pfuty;
+				for (i = 0; i < MAX_PATH_LENGTH; i++) {
+					if (plr[pnum].walkpath[i] == WALK_NONE)
+						break;
+
+					if (plr[pnum].walkpath[i] == WALK_N || plr[pnum].walkpath[i] == WALK_NW || plr[pnum].walkpath[i] == WALK_W)
+						realTargetX--;
+					else if (plr[pnum].walkpath[i] == WALK_E || plr[pnum].walkpath[i] == WALK_SE || plr[pnum].walkpath[i] == WALK_S)
+						realTargetX++;
+
+					if (plr[pnum].walkpath[i] == WALK_N || plr[pnum].walkpath[i] == WALK_NE || plr[pnum].walkpath[i] == WALK_E)
+						realTargetY--;
+					else if (plr[pnum].walkpath[i] == WALK_S || plr[pnum].walkpath[i] == WALK_SW || plr[pnum].walkpath[i] == WALK_W)
+						realTargetY++;
+				}
+
+				plr[pnum]._ptargx = realTargetX;
+				plr[pnum]._ptargy = realTargetY;
 			}
 		}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1184,8 +1184,6 @@ void FixPlayerLocation(int pnum, direction bDir)
 
 	plr[pnum]._pfutx = plr[pnum]._px;
 	plr[pnum]._pfuty = plr[pnum]._py;
-	plr[pnum]._ptargx = plr[pnum]._px;
-	plr[pnum]._ptargy = plr[pnum]._py;
 	plr[pnum]._pxoff = 0;
 	plr[pnum]._pyoff = 0;
 	plr[pnum]._pdir = bDir;
@@ -3131,6 +3129,24 @@ bool PM_DoNewLvl(int pnum)
 	return false;
 }
 
+void GetPlayerTargetPosition(int playerNumber, Sint32 *x, Sint32 *y)
+{
+	// clang-format off
+	int directionOffsetX[8] = {  0,-1, 1, 0,-1, 1, 1,-1 };
+	int directionOffsetY[8] = { -1, 0, 0, 1,-1,-1, 1, 1 };
+	// clang-format on
+	*x = plr[playerNumber]._pfutx;
+	*y = plr[playerNumber]._pfuty;
+	for (int i = 0; i < MAX_PATH_LENGTH; i++) {
+		if (plr[playerNumber].walkpath[i] == WALK_NONE)
+			break;
+		if (plr[playerNumber].walkpath[i] > 0) {
+			*x += directionOffsetX[plr[playerNumber].walkpath[i] - 1];
+			*y += directionOffsetY[plr[playerNumber].walkpath[i] - 1];
+		}
+	}
+}
+
 void CheckNewPath(int pnum)
 {
 	int i, x, y;
@@ -3779,8 +3795,6 @@ void MakePlrPath(int pnum, int xx, int yy, bool endspace)
 		app_fatal("MakePlrPath: illegal player %d", pnum);
 	}
 
-	plr[pnum]._ptargx = xx;
-	plr[pnum]._ptargy = yy;
 	if (plr[pnum]._pfutx == xx && plr[pnum]._pfuty == yy) {
 		return;
 	}
@@ -3823,9 +3837,6 @@ void MakePlrPath(int pnum, int xx, int yy, bool endspace)
 			yy--;
 			break;
 		}
-
-		plr[pnum]._ptargx = xx;
-		plr[pnum]._ptargy = yy;
 	}
 
 	plr[pnum].walkpath[path] = WALK_NONE;

--- a/Source/player.h
+++ b/Source/player.h
@@ -160,8 +160,14 @@ struct PlayerStruct {
 	Sint32 _py;      // Tile Y-position of player
 	Sint32 _pfutx;   // Future tile X-position of player. Set at start of walking animation
 	Sint32 _pfuty;   // Future tile Y-position of player. Set at start of walking animation
-	Sint32 _ptargx;  // Target tile X-position for player movment. Set during pathfinding
-	Sint32 _ptargy;  // Target tile Y-position for player movment. Set during pathfinding
+
+	/*
+	* These values store the target position for non-local players during network play.
+	* This is needed because player positions drift over time due to desyncs, so we have
+	* clients try to pathfind non-local players to this position.
+	*/
+	Sint32 _ptargx, _ptargy;
+
 	Sint32 _pownerx; // Tile X-position of player. Set via network on player input
 	Sint32 _pownery; // Tile X-position of player. Set via network on player input
 	Sint32 _poldx;   // Most recent X-position in dPlayer.
@@ -427,6 +433,15 @@ void RemovePlrMissiles(int pnum);
 void StartNewLvl(int pnum, interface_mode fom, int lvl);
 void RestartTownLvl(int pnum);
 void StartWarpLvl(int pnum, int pidx);
+
+/*
+* @brief Returns the tile coordinates a player is moving to (if not moving, then it corresponds to current position).
+* @param playerNumber Player index
+* @param x Pointer to variable which will get updated with X tile coordinate
+* @param y Pointer to variable which will get updated with Y tile coordinate
+*/
+void GetPlayerTargetPosition(int playerNumber, Sint32 *x, Sint32 *y);
+
 void ProcessPlayers();
 void ClrPlrPath(int pnum);
 bool PosOkPlayer(int pnum, int x, int y);

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -28,7 +28,9 @@ void track_process()
 	if (plr[myplr]._pVar8 <= 6 && plr[myplr]._pmode != PM_STAND)
 		return;
 
-	if (cursmx != plr[myplr]._ptargx || cursmy != plr[myplr]._ptargy) {
+	Sint32 targetX, targetY;
+	GetPlayerTargetPosition(myplr, &targetX, &targetY);
+	if (cursmx != targetX || cursmy != targetY) {
 		Uint32 tick = SDL_GetTicks();
 		if ((int)(tick - sgdwLastWalk) >= gnTickDelay * 6) {
 			sgdwLastWalk = tick;


### PR DESCRIPTION
This fixes the first desync issue listed here: https://github.com/diasurgical/devilutionX/issues/1576

Video example of the issue: https://www.youtube.com/watch?v=wDXCDKLnpNY

The cause of the problem is the _ptarx and _ptary values (these correspond to where the player is pathfinding to) are sometimes set incorrectly. The game keeps sending these values (and player position) to other clients so they can ensure the player position is the same across all clients, but sometimes the values are set incorrectly which makes the local player tell other clients to move the player to the wrong position.

For instance, this desync is caused by the following sequence of code:

- Player is in the middle of the attack animation.
- Player clicks to move, which makes the game pathfind to a new location, and it sets _ptarx and _ptary to where the player is pathfinding to.
- Game waits for player to finish attacking before starting to move.
- Player finishes the attack animation, this calls PlayerStand() which then calls FixPlayerLocation() which resets _ptarx and _ptary to the player's current position.
- Player starts sending the new (wrong) _ptarx and _ptary to other clients, and other clients keep pathfinding the player to the wrong location.

My fix re-calculates the _ptarx and _ptary values each time the player starts walking towards a new tile when following pathfinding. Based on brief testing, this fixes the issue entirely and I haven't seen any downsides.

A better fix would probably be to prevent the game from resetting _ptarx and _ptary to the wrong value after finishing an attack.