### PR TITLE
Fix for small AC malus of less than 1 resulting in a bonus of 1 AC

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -16,6 +16,7 @@
 #include "options.h"
 #include "stores.h"
 #include "utils/language.h"
+#include "utils/math.h"
 
 namespace devilution {
 
@@ -600,7 +601,7 @@ void CalcPlrItemVals(int p, bool Loadgfx)
 					tmpac *= itm->_iPLAC;
 					tmpac /= 100;
 					if (tmpac == 0)
-						tmpac = 1;
+						tmpac = math::Sign(itm->_iPLAC);
 					bac += tmpac;
 				}
 				iflgs |= itm->_iFlags;

--- a/Source/utils/math.h
+++ b/Source/utils/math.h
@@ -1,0 +1,24 @@
+/**
+* @file math.h
+*
+* Math utility functions
+*/
+#pragma once
+
+namespace devilution {
+namespace math {
+
+/**
+ * @brief Compute sign of t
+ * @tparam T Any arithmetic type
+ * @param t Value to compute sign of
+ * @return -1 if t < 0, 1 if t > 0, 0 if t == 0
+*/
+template<typename T>
+int Sign(T t)
+{
+	return (t > T(0)) - (t < T(0));
+}
+
+} // namespace math
+} // namespace devilution


### PR DESCRIPTION
This one is described in Jarulf's guide, page 24 bottom: 

> There is a minimum increase of 1 in AC. That is, even if the percentage will give an increase to AC less than one, it will be increased by at least one. Due to a bug, any decrease in AC less than 1 will be transformed into a positive increase by 1.

The code just checked if (due to rounding) the AC bonus would be == 0, and if it was, it would increase it to 1. This change makes sure that a negative bonus results in -1 for that case.

It also adds a math::Sign helper for calculating the signum of a value, without branching.