### PR TITLE
Fix init_test_access MPQ flag

### DIFF
--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -57,7 +57,7 @@ HANDLE init_test_access(const std::vector<std::string> &paths, const char *mpq_n
 	std::string mpq_abspath;
 	for (const auto &path : paths) {
 		mpq_abspath = path + mpq_name;
-		if (SFileOpenArchive(mpq_abspath.c_str(), 0, MPQ_FLAG_READ_ONLY, &archive)) {
+		if (SFileOpenArchive(mpq_abspath.c_str(), 0, MPQ_OPEN_READ_ONLY, &archive)) {
 			SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION, "  Found: %s in %s", mpq_name, path.c_str());
 			SFileSetBasePath(path.c_str());
 			return archive;

--- a/Source/storm/storm.h
+++ b/Source/storm/storm.h
@@ -225,7 +225,7 @@ bool SNetSendMessage(int playerID, void *data, unsigned int databytes);
 #define SNPLAYER_ALL    -1
 #define SNPLAYER_OTHERS -2
 
-#define MPQ_FLAG_READ_ONLY 1
+#define MPQ_OPEN_READ_ONLY 0x00000100
 #define SFILE_OPEN_FROM_MPQ 0
 #define SFILE_OPEN_LOCAL_FILE 0xFFFFFFFF
 


### PR DESCRIPTION
`MPQ_FLAG_READ_ONLY` -> `MPQ_OPEN_READ_ONLY`.

The former is a flag that is set on an MPQ that was open in read-only
mode. To request opening in read-only mode, `MPQ_OPEN_READ_ONLY` should
be used instead.