### PR TITLE
Docs: Amiga: Better "building" command [ci skip]

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -296,7 +296,7 @@ docker build -f Packaging/amiga/Dockerfile -t devilutionx-amiga .
 
 ~~~ bash
 docker run --rm -v "${PWD}:/work" devilutionx-amiga
-sudo chown "${USER}:" build-amiga/*
+sudo chown -R "${USER}:" build-amiga
 ~~~
 
 The command above builds DevilutionX in release mode.
@@ -313,8 +313,8 @@ See the `CMD` in `Packaging/amiga/Dockerfile` for reference.
 Outside of the Docker container, from the DevilutionX directory, run:
 
 ~~~ bash
+sudo chown -R "${USER}:" build-amiga
 cp Packaging/amiga/devilutionx.info Packaging/amiga/LiberationSerif-Bold.ttf build-amiga/
-sudo chown "${USER}:" build-amiga/*
 ~~~
 
 To actually start DevilutionX, increase the stack size to 50KiB in Amiga.


### PR DESCRIPTION
1. chown the whole directory including dotfile
2. Fix the "copy resources" command (must be chowned first)