### PR TITLE
🧹 DiabloUI: Clean up text render cache

### DIFF
--- a/Source/DiabloUI/button.cpp
+++ b/Source/DiabloUI/button.cpp
@@ -30,7 +30,7 @@ void RenderButton(UiButton *button)
 	SDL_Color color1 = { 243, 243, 243, 0 };
 	SDL_Color color2 = { 0, 0, 0, 0 };
 	DrawTTF(button->m_text, text_rect, UIS_CENTER,
-	    color1, color2, &button->m_render_cache);
+	    color1, color2, button->m_render_cache);
 }
 
 bool HandleMouseEventButton(const SDL_Event &event, UiButton *button)

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -706,7 +706,7 @@ void Render(UiText *ui_text)
 	    ui_text->m_iFlags,
 	    ui_text->m_color,
 	    ui_text->m_shadow_color,
-	    &ui_text->m_render_cache);
+	    ui_text->m_render_cache);
 }
 
 void Render(const UiArtText *ui_art_text)

--- a/Source/DiabloUI/text_draw.cpp
+++ b/Source/DiabloUI/text_draw.cpp
@@ -36,20 +36,20 @@ int AlignXOffset(int flags, const SDL_Rect &dest, int w)
 
 void DrawTTF(const char *text, const SDL_Rect &rectIn, int flags,
     const SDL_Color &text_color, const SDL_Color &shadow_color,
-    TtfSurfaceCache **render_cache)
+    TtfSurfaceCache &render_cache)
 {
 	SDL_Rect rect(rectIn);
 	if (font == NULL || text == NULL || *text == '\0')
 		return;
-	if (*render_cache == NULL) {
-		const auto x_align = XAlignmentFromFlags(flags);
-		*render_cache = new TtfSurfaceCache {
-			/*.text=*/ScaleSurfaceToOutput(SDLSurfaceUniquePtr { RenderUTF8_Solid_Wrapped(font, text, text_color, rect.w, x_align) }),
-			/*.shadow=*/ScaleSurfaceToOutput(SDLSurfaceUniquePtr { RenderUTF8_Solid_Wrapped(font, text, shadow_color, rect.w, x_align) }),
-		};
-	}
-	SDL_Surface *text_surface = (*render_cache)->text.get();
-	SDL_Surface *shadow_surface = (*render_cache)->shadow.get();
+
+	const auto x_align = XAlignmentFromFlags(flags);
+	if (render_cache.text == nullptr)
+		render_cache.text = ScaleSurfaceToOutput(SDLSurfaceUniquePtr { RenderUTF8_Solid_Wrapped(font, text, text_color, rect.w, x_align) });
+	if (render_cache.shadow == nullptr)
+		render_cache.shadow = ScaleSurfaceToOutput(SDLSurfaceUniquePtr { RenderUTF8_Solid_Wrapped(font, text, shadow_color, rect.w, x_align) });
+
+	SDL_Surface *text_surface = render_cache.text.get();
+	SDL_Surface *shadow_surface = render_cache.shadow.get();
 	if (text_surface == NULL)
 		return;
 

--- a/Source/DiabloUI/text_draw.h
+++ b/Source/DiabloUI/text_draw.h
@@ -13,7 +13,7 @@ struct TtfSurfaceCache {
 
 void DrawTTF(const char *text, const SDL_Rect &rect, int flags,
     const SDL_Color &text_color, const SDL_Color &shadow_color,
-    TtfSurfaceCache **surface_cache);
+    TtfSurfaceCache &render_cache);
 
 void DrawArtStr(const char *text, const SDL_Rect &rect, int flags, bool drawTextCursor = false);
 

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -210,7 +210,6 @@ public:
 		m_shadow_color = color2;
 
 		m_text = text;
-		m_render_cache = NULL;
 	}
 
 	UiText(const char *text, SDL_Rect rect, int flags = 0)
@@ -225,7 +224,6 @@ public:
 		m_shadow_color = color2;
 
 		m_text = text;
-		m_render_cache = NULL;
 	}
 
 	//private:
@@ -234,13 +232,7 @@ public:
 	const char *m_text;
 
 	// State:
-	TtfSurfaceCache *m_render_cache;
-
-	virtual void FreeCache()
-	{
-		delete m_render_cache;
-		m_render_cache = NULL;
-	}
+	TtfSurfaceCache m_render_cache;
 };
 
 //=============================================================================
@@ -257,7 +249,6 @@ public:
 		m_text = text;
 		m_action = action;
 		m_pressed = false;
-		m_render_cache = NULL;
 	}
 
 	enum FrameKey : uint8_t {
@@ -274,13 +265,7 @@ public:
 
 	// State
 	bool m_pressed;
-	TtfSurfaceCache *m_render_cache;
-
-	virtual void FreeCache()
-	{
-		delete m_render_cache;
-		m_render_cache = NULL;
-	}
+	TtfSurfaceCache m_render_cache;
 };
 
 //=============================================================================


### PR DESCRIPTION
Cleans up the handling of text render cache for `UiText` and `UiButton`.
This also happens to fix a memory leak (`FreeCache` was never called).