### PR TITLE
make killing golem cost no mana

### DIFF
--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -57,7 +57,10 @@ int GetManaAmount(int id, spell_id sn)
 	if (spelldata[sn].sMinMana > ma >> 6) {
 		ma = spelldata[sn].sMinMana << 6;
 	}
-
+	if (sn == SPL_GOLEM) { // make unsummoning golem cost 0 mana
+		if ((monster[myplr]._mx != 1 || monster[myplr]._my != 0))
+			ma = 0;
+	}
 	return ma;
 }
 


### PR DESCRIPTION
Casting golem while there's an active one kills the old one and costs mana. This makes no sense. This change makes the spell only take mana if you summon the golem, killing it is free (Why would you want to kill it? 🤕 + it still requires having enough mana to cast the spell)