### PR TITLE
Fix maximum experience bugs, use consistent colors, and update XP bar

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1366,17 +1366,27 @@ void DrawChr(const CelOutputBuffer &out)
 	ADD_PlrStringXY(out, 168, 32, 299, ClassStrTbl[static_cast<std::size_t>(plr[myplr]._pClass)], COL_WHITE);
 
 	sprintf(chrstr, "%i", plr[myplr]._pLevel);
-	ADD_PlrStringXY(out, 66, 69, 109, chrstr, COL_WHITE);
-
-	sprintf(chrstr, "%i", plr[myplr]._pExperience);
-	ADD_PlrStringXY(out, 216, 69, 300, chrstr, COL_WHITE);
-
 	if (plr[myplr]._pLevel == MAXCHARLEVEL - 1) {
-		strcpy(chrstr, _("None"));
 		col = COL_GOLD;
 	} else {
-		sprintf(chrstr, "%i", plr[myplr]._pNextExper);
 		col = COL_WHITE;
+	}
+	ADD_PlrStringXY(out, 66, 69, 109, chrstr, col);
+
+	sprintf(chrstr, "%i", plr[myplr]._pExperience);
+	if (plr[myplr]._pExperience == ExpLvlsTbl[MAXCHARLEVEL - 1]) {
+		col = COL_GOLD;
+	} else {
+		col = COL_WHITE;
+	}
+	ADD_PlrStringXY(out, 216, 69, 300, chrstr, col);
+
+	if (plr[myplr]._pLevel == MAXCHARLEVEL - 1) {
+		col = COL_GOLD;
+		strcpy(chrstr, _("None"));
+	} else {
+		col = COL_WHITE;
+		sprintf(chrstr, "%i", plr[myplr]._pNextExper);
 	}
 	ADD_PlrStringXY(out, 216, 97, 300, chrstr, col);
 
@@ -1436,36 +1446,27 @@ void DrawChr(const CelOutputBuffer &out)
 		col = COL_WHITE;
 	else
 		col = COL_BLUE;
-	if (plr[myplr]._pMagResist < MAXRESIST) {
-		sprintf(chrstr, "%i%%", plr[myplr]._pMagResist);
-	} else {
+	if (plr[myplr]._pMagResist == MAXRESIST)
 		col = COL_GOLD;
-		sprintf(chrstr, _("MAX"));
-	}
+	sprintf(chrstr, "%i%%", plr[myplr]._pMagResist);
 	ADD_PlrStringXY(out, 257, 276, 300, chrstr, col);
 
 	if (plr[myplr]._pFireResist == 0)
 		col = COL_WHITE;
 	else
 		col = COL_BLUE;
-	if (plr[myplr]._pFireResist < MAXRESIST) {
-		sprintf(chrstr, "%i%%", plr[myplr]._pFireResist);
-	} else {
+	if (plr[myplr]._pFireResist == MAXRESIST)
 		col = COL_GOLD;
-		sprintf(chrstr, _("MAX"));
-	}
+	sprintf(chrstr, "%i%%", plr[myplr]._pFireResist);
 	ADD_PlrStringXY(out, 257, 304, 300, chrstr, col);
 
 	if (plr[myplr]._pLghtResist == 0)
 		col = COL_WHITE;
 	else
 		col = COL_BLUE;
-	if (plr[myplr]._pLghtResist < MAXRESIST) {
-		sprintf(chrstr, "%i%%", plr[myplr]._pLghtResist);
-	} else {
+	if (plr[myplr]._pLghtResist == MAXRESIST)
 		col = COL_GOLD;
-		sprintf(chrstr, _("MAX"));
-	}
+	sprintf(chrstr, "%i%%", plr[myplr]._pLghtResist);
 	ADD_PlrStringXY(out, 257, 332, 300, chrstr, col);
 
 	col = COL_WHITE;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1012,8 +1012,6 @@ void NextPlrLevel(int pnum)
 	CalcPlrInv(pnum, true);
 }
 
-#define MAXEXP 2000000000
-
 void AddPlrExperience(int pnum, int lvl, int exp)
 {
 	int powerLvlCap, expCap, newLvl, i;
@@ -1054,16 +1052,17 @@ void AddPlrExperience(int pnum, int lvl, int exp)
 	}
 
 	plr[pnum]._pExperience += exp;
-	if ((DWORD)plr[pnum]._pExperience > MAXEXP) {
-		plr[pnum]._pExperience = MAXEXP;
+	if ((DWORD)plr[pnum]._pExperience > ExpLvlsTbl[MAXCHARLEVEL - 1]) {
+		plr[pnum]._pExperience = ExpLvlsTbl[MAXCHARLEVEL - 1];
 	}
 
 	if (sgOptions.Gameplay.bExperienceBar) {
 		force_redraw = 255;
 	}
 
-	if (plr[pnum]._pExperience >= ExpLvlsTbl[49]) {
-		plr[pnum]._pLevel = 50;
+	if (plr[pnum]._pExperience >= ExpLvlsTbl[MAXCHARLEVEL - 2]) {
+		plr[pnum]._pLevel = MAXCHARLEVEL - 1;
+		plr[pnum]._pNextExper = ExpLvlsTbl[MAXCHARLEVEL - 1];
 		return;
 	}
 

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -76,12 +76,7 @@ void DrawXPBar(const CelOutputBuffer &out)
 
 	const int charLevel = player._pLevel;
 
-	if (charLevel == MAXCHARLEVEL - 1) {
-		// Draw a nice golden bar for max level characters.
-		DrawBar(out, xPos, yPos, BAR_WIDTH, GOLD_GRADIENT);
-
-		return;
-	}
+	const ColorGradient& gradient = (charLevel == MAXCHARLEVEL - 1) ? GOLD_GRADIENT : SILVER_GRADIENT;
 
 	const int prevXp = ExpLvlsTbl[charLevel - 1];
 	if (player._pExperience < prevXp)
@@ -95,13 +90,13 @@ void DrawXPBar(const CelOutputBuffer &out)
 	uint64_t onePx = prevXpDelta / BAR_WIDTH + 1;
 	uint64_t lastFullPx = fullBar * prevXpDelta / BAR_WIDTH;
 
-	const uint64_t fade = (prevXpDelta_1 - lastFullPx) * (SILVER_GRADIENT.size() - 1) / onePx;
+	const uint64_t fade = (prevXpDelta_1 - lastFullPx) * (gradient.size() - 1) / onePx;
 
 	// Draw beginning of bar full brightness
-	DrawBar(out, xPos, yPos, fullBar, SILVER_GRADIENT);
+	DrawBar(out, xPos, yPos, fullBar, gradient);
 
 	// End pixels appear gradually
-	DrawEndCap(out, xPos + fullBar, yPos, fade, SILVER_GRADIENT);
+	DrawEndCap(out, xPos + fullBar, yPos, fade, gradient);
 }
 
 bool CheckXPBarInfo()
@@ -119,34 +114,22 @@ bool CheckXPBarInfo()
 
 	const int charLevel = player._pLevel;
 
-	sprintf(tempstr, _("Level %d"), charLevel);
-	AddPanelString(tempstr, true);
-
-	if (charLevel == MAXCHARLEVEL - 1) {
-		// Show a maximum level indicator for max level players.
-		infoclr = COL_GOLD;
-
-		sprintf(tempstr, _("Experience: "));
-		PrintWithSeparator(tempstr + SDL_arraysize("Experience: ") - 1, ExpLvlsTbl[charLevel - 1]);
-		AddPanelString(tempstr, true);
-
-		AddPanelString(_("Maximum Level"), true);
-
-		return true;
-	}
-
 	infoclr = COL_WHITE;
 
+	sprintf(tempstr, _("Level %d"), charLevel);
+	AddPanelString(tempstr, true);
 	sprintf(tempstr, _("Experience: "));
 	PrintWithSeparator(tempstr + SDL_arraysize("Experience: ") - 1, player._pExperience);
 	AddPanelString(tempstr, true);
 
-	sprintf(tempstr, _("Next Level: "));
-	PrintWithSeparator(tempstr + SDL_arraysize("Next Level: ") - 1, ExpLvlsTbl[charLevel]);
-	AddPanelString(tempstr, true);
-
-	sprintf(PrintWithSeparator(tempstr, ExpLvlsTbl[charLevel] - player._pExperience), _(" to Level %d"), charLevel + 1);
-	AddPanelString(tempstr, true);
+	if (charLevel != (MAXCHARLEVEL - 1)) {
+		auto difference = ExpLvlsTbl[charLevel] - player._pExperience;
+		sprintf(tempstr, _("Next level: "));
+		PrintWithSeparator(tempstr + SDL_arraysize("Next level: ") - 1, ExpLvlsTbl[charLevel]);
+		AddPanelString(tempstr, true);
+		sprintf(PrintWithSeparator(tempstr, difference), _(" to level %d"), charLevel + 1);
+		AddPanelString(tempstr, true);
+	}
 
 	return true;
 }


### PR DESCRIPTION
The XP bar has a bug that always shows 1,310,707,109 exp even when the actual exp are higher. Exp can actually go to 1,583,495,809 (while staying on character level 50).

A related bug existed in vanilla diablo that if you have 1,583,495,809 exp, if you kill a monster and get more exp, it will be displayed in the character screen for a millisecond before going back to 1,583,495,809. This is fixed as well.

Moreover, gold color in the character screen seems to be intended to mean that the golden value cannot go higher. It therefore makes sense to have level 50 and max exp golden, but not the string "none" which is not actually a maximal value. For consistency I replaced "MAX" with "75%" (in gold) for the resistances as well.

My suggestion for the XP bar is to turn the bar golden on level 50 as before, but then still count up exp points up to the maximum (in gold). The two screenshots illustrate this.
![low](https://user-images.githubusercontent.com/63780318/115391666-3d14af00-a1cf-11eb-96eb-db8132262a71.jpg)
![high](https://user-images.githubusercontent.com/63780318/115391687-4140cc80-a1cf-11eb-893a-6adcbbbdb395.jpg)

