### PR TITLE
GetSFXLength: Respect streaming flag

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -332,7 +332,7 @@ void UiFocusNavigation(SDL_Event *event)
 					char utf8[SDL_TEXTINPUTEVENT_TEXT_SIZE];
 					utf8[0] = (char)unicode;
 					utf8[1] = '\0';
-					selhero_CatToName(utf8, UiTextInput, UiTextInputLen);
+					SelheroCatToName(utf8, UiTextInput, UiTextInputLen);
 				}
 			}
 #endif

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -295,7 +295,7 @@ void SelheroClassSelectorSelect(int value)
 	}
 	memset(selhero_heroInfo.name, '\0', sizeof(selhero_heroInfo.name));
 #if defined __3DS__
-	ctr_vkbdInput("Enter Hero name..", selhero_GenerateName(selhero_heroInfo.heroclass), selhero_heroInfo.name);
+	ctr_vkbdInput("Enter Hero name..", SelheroGenerateName(selhero_heroInfo.heroclass), selhero_heroInfo.name);
 #endif
 	if (ShouldPrefillHeroName())
 		strncpy(selhero_heroInfo.name, SelheroGenerateName(selhero_heroInfo.heroclass), sizeof(selhero_heroInfo.name) - 1);

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -10,6 +10,13 @@
 #include "sound.h"
 
 namespace devilution {
+namespace {
+#ifndef DISABLE_STREAMING_SOUNDS
+constexpr bool AllowStreaming = true;
+#else
+constexpr bool AllowStreaming = false;
+#endif
+} // namespace
 
 int sfxdelay;
 _sfx_id sfxdnum = SFX_NONE;
@@ -1085,12 +1092,6 @@ void stream_stop()
 
 static void stream_play(TSFX *pSFX, int lVolume, int lPan)
 {
-#ifndef DISABLE_STREAMING_SOUNDS
-	constexpr bool kAllowStreaming = true;
-#else
-	constexpr bool kAllowStreaming = false;
-#endif
-
 	assert(pSFX);
 	assert(pSFX->bFlags & sfx_STREAM);
 	stream_stop();
@@ -1099,7 +1100,7 @@ static void stream_play(TSFX *pSFX, int lVolume, int lPan)
 		if (lVolume > VOLUME_MAX)
 			lVolume = VOLUME_MAX;
 		if (pSFX->pSnd == nullptr)
-			pSFX->pSnd = sound_file_load(pSFX->pszName, kAllowStreaming);
+			pSFX->pSnd = sound_file_load(pSFX->pszName, AllowStreaming);
 		pSFX->pSnd->DSB->Play(lVolume, lPan, 0);
 		sgpStreamSFX = pSFX;
 	}
@@ -1414,7 +1415,8 @@ void effects_play_sound(const char *snd_file)
 int GetSFXLength(int nSFX)
 {
 	if (sgSFX[nSFX].pSnd == nullptr)
-		sgSFX[nSFX].pSnd = sound_file_load(sgSFX[nSFX].pszName);
+		sgSFX[nSFX].pSnd = sound_file_load(sgSFX[nSFX].pszName,
+		    /*stream=*/AllowStreaming && (sgSFX[nSFX].bFlags & sfx_STREAM) != 0);
 	return sgSFX[nSFX].pSnd->DSB->GetLength();
 }
 


### PR DESCRIPTION
We've discovered that `Mix_LoadWAV_RW` actually loads the whole file in memory so this does not fix the streaming but is good to fix anyway