### PR TITLE
stop shrines and black deaths from ruining characters

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -2216,30 +2216,8 @@ void M_TryH2HHit(int i, int pnum, int Hit, int MinDam, int MaxDam)
 		return;
 	}
 	if (monster[i].MType->mtype == MT_YZOMBIE && pnum == myplr) {
-		cur_ms_num = -1;
-		for (j = 0; j < nummissiles; j++) {
-			misnum = missileactive[j];
-			if (missile[misnum]._mitype != MIS_MANASHIELD)
-				continue;
-			if (missile[misnum]._misource == pnum)
-				cur_ms_num = misnum;
-		}
-		if (plr[pnum]._pMaxHP > 64) {
-			if (plr[pnum]._pMaxHPBase > 64) {
-				plr[pnum]._pMaxHP -= 64;
-				if (plr[pnum]._pHitPoints > plr[pnum]._pMaxHP) {
-					plr[pnum]._pHitPoints = plr[pnum]._pMaxHP;
-					if (cur_ms_num >= 0)
-						missile[cur_ms_num]._miVar1 = plr[pnum]._pHitPoints;
-				}
-				plr[pnum]._pMaxHPBase -= 64;
-				if (plr[pnum]._pHPBase > plr[pnum]._pMaxHPBase) {
-					plr[pnum]._pHPBase = plr[pnum]._pMaxHPBase;
-					if (cur_ms_num >= 0)
-						missile[cur_ms_num]._miVar2 = plr[pnum]._pHPBase;
-				}
-			}
-		}
+		if (plr[myplr].GetBaseAttributeValue(CharacterAttribute::Vitality) > 0)
+			ModifyPlrVit(myplr, -1);
 	}
 	dam = (MinDam << 6) + GenerateRnd((MaxDam - MinDam + 1) << 6);
 	dam += (plr[pnum]._pIGetHit << 6);

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3725,21 +3725,9 @@ bool OperateShrineFascinating(int pnum)
 	if (plr[pnum]._pSplLvl[SPL_FIREBOLT] < MAX_SPELL_LEVEL)
 		plr[pnum]._pSplLvl[SPL_FIREBOLT]++;
 
-	DWORD t = plr[pnum]._pMaxManaBase / 10;
-	int v1 = plr[pnum]._pMana - plr[pnum]._pManaBase;
-	int v2 = plr[pnum]._pMaxMana - plr[pnum]._pMaxManaBase;
-	plr[pnum]._pManaBase -= t;
-	plr[pnum]._pMana -= t;
-	plr[pnum]._pMaxMana -= t;
-	plr[pnum]._pMaxManaBase -= t;
-	if (plr[pnum]._pMana >> 6 <= 0) {
-		plr[pnum]._pMana = v1;
-		plr[pnum]._pManaBase = 0;
-	}
-	if (plr[pnum]._pMaxMana >> 6 <= 0) {
-		plr[pnum]._pMaxMana = v2;
-		plr[pnum]._pMaxManaBase = 0;
-	}
+	int magicLoss = plr[pnum].GetBaseAttributeValue(CharacterAttribute::Magic) / 10;
+	if (magicLoss > 0)
+		ModifyPlrMag(pnum, -magicLoss);
 
 	InitDiabloMsg(EMSG_SHRINE_FASCINATING);
 
@@ -3903,21 +3891,10 @@ bool OperateShrineSacred(int pnum)
 	if (plr[pnum]._pSplLvl[SPL_CBOLT] < MAX_SPELL_LEVEL)
 		plr[pnum]._pSplLvl[SPL_CBOLT]++;
 
-	DWORD t = plr[pnum]._pMaxManaBase / 10;
-	int v1 = plr[pnum]._pMana - plr[pnum]._pManaBase;
-	int v2 = plr[pnum]._pMaxMana - plr[pnum]._pMaxManaBase;
-	plr[pnum]._pManaBase -= t;
-	plr[pnum]._pMana -= t;
-	plr[pnum]._pMaxMana -= t;
-	plr[pnum]._pMaxManaBase -= t;
-	if (plr[pnum]._pMana >> 6 <= 0) {
-		plr[pnum]._pMana = v1;
-		plr[pnum]._pManaBase = 0;
-	}
-	if (plr[pnum]._pMaxMana >> 6 <= 0) {
-		plr[pnum]._pMaxMana = v2;
-		plr[pnum]._pMaxManaBase = 0;
-	}
+	int magicLoss = plr[pnum].GetBaseAttributeValue(CharacterAttribute::Magic) / 10;
+	if (magicLoss > 0)
+		ModifyPlrMag(pnum, -magicLoss);
+
 
 	InitDiabloMsg(EMSG_SHRINE_SACRED);
 
@@ -4051,21 +4028,9 @@ bool OperateShrineOrnate(int pnum)
 	if (plr[pnum]._pSplLvl[SPL_HBOLT] < MAX_SPELL_LEVEL)
 		plr[pnum]._pSplLvl[SPL_HBOLT]++;
 
-	DWORD t = plr[pnum]._pMaxManaBase / 10;
-	int v1 = plr[pnum]._pMana - plr[pnum]._pManaBase;
-	int v2 = plr[pnum]._pMaxMana - plr[pnum]._pMaxManaBase;
-	plr[pnum]._pManaBase -= t;
-	plr[pnum]._pMana -= t;
-	plr[pnum]._pMaxMana -= t;
-	plr[pnum]._pMaxManaBase -= t;
-	if (plr[pnum]._pMana >> 6 <= 0) {
-		plr[pnum]._pMana = v1;
-		plr[pnum]._pManaBase = 0;
-	}
-	if (plr[pnum]._pMaxMana >> 6 <= 0) {
-		plr[pnum]._pMaxMana = v2;
-		plr[pnum]._pMaxManaBase = 0;
-	}
+	int magicLoss = plr[pnum].GetBaseAttributeValue(CharacterAttribute::Magic) / 10;
+	if (magicLoss > 0)
+		ModifyPlrMag(pnum, -magicLoss);
 
 	InitDiabloMsg(EMSG_SHRINE_ORNATE);
 


### PR DESCRIPTION
While they'd fit the game if it was meant to be played in a single playthrough or hardcore, it clashes horribly with multiplayer/multiple difficulties, which were added later - they offer replayability, yet crap like black death / shrines which ruin the replayability still exists (keep clicking random shrines and your character will end up being unable to use any spell! yay!)

This PR makes the punishment even a bit harder for some classes (if they gain more than 1 hp per vit) but in a way that doesn't ruin characters.
Each black death hit removes 1 vitality and Ornate/Sacred/Fascinating shrines remove 10% of your magic.

Keep in mind that it was usually new players that were victims of black deaths/shrines just because they didn't know about them.
Nothing better than learning your character got ruined without even knowing huh?
Old players would never use such a shrine / get hit by black death, which is yet another design flaw in my opinion.
These -10% max mana shrines effectively make goat shrines and cauldrons useless, because who's going to take a gamble?
"Oh boy, a random shrine, only 5% chance to get my character permanently ruined but I might gain some gold or a potion!" 🤪 