### PR TITLE
Fix for "Distant sound sources aren't panned correctly"

### DIFF
--- a/Source/utils/soundsample.cpp
+++ b/Source/utils/soundsample.cpp
@@ -54,7 +54,7 @@ void SoundSample::Play(int lVolume, int lPan, int channel)
 
 	Mix_Volume(channel, pow((double)10, (double)lVolume / 2000.0) * MIX_MAX_VOLUME);
 	int pan = copysign(pow((double)10, -abs(lPan) / 2000.0) * 255, (double)lPan);
-	Mix_SetPanning(channel, pan > 0 ? pan : 255, pan < 0 ? abs(pan) : 255);
+	Mix_SetPanning(channel, lPan > 0 ? pan : 255, lPan < 0 ? abs(pan) : 255);
 };
 
 /**


### PR DESCRIPTION
This fixes exclusively the panning bug, where after a certain distance is exceeded, sound samples get played without panning.
Fixes https://github.com/diasurgical/devilutionX/issues/1657