### PR TITLE
Remove "AnimWidth2" expect for missiles

### DIFF
--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -30,7 +30,6 @@ void InitDead()
 				dead[nd]._deadData[d] = Monsters[i].Anims[MA_DEATH].Data[d];
 			dead[nd]._deadFrame = Monsters[i].Anims[MA_DEATH].Frames;
 			dead[nd]._deadWidth = Monsters[i].width;
-			dead[nd]._deadWidth2 = CalculateWidth2(Monsters[i].width);
 			dead[nd]._deadtrans = 0;
 			nd++;
 
@@ -43,7 +42,6 @@ void InitDead()
 		d = misfiledata[MFILE_BLODBUR].mAnimData[0];
 	dead[nd]._deadFrame = 8;
 	dead[nd]._deadWidth = 128;
-	dead[nd]._deadWidth2 = 32;
 	dead[nd]._deadtrans = 0;
 	nd++;
 
@@ -52,7 +50,6 @@ void InitDead()
 
 	dead[nd]._deadFrame = 12;
 	dead[nd]._deadWidth = 128;
-	dead[nd]._deadWidth2 = 32;
 	dead[nd]._deadtrans = 0;
 	nd++;
 
@@ -65,7 +62,6 @@ void InitDead()
 				dead[nd]._deadData[d] = monster[mi].MType->Anims[MA_DEATH].Data[d];
 			dead[nd]._deadFrame = monster[mi].MType->Anims[MA_DEATH].Frames;
 			dead[nd]._deadWidth = monster[mi].MType->width;
-			dead[nd]._deadWidth2 = CalculateWidth2(monster[mi].MType->width);
 			dead[nd]._deadtrans = monster[mi]._uniqtrans + 4;
 			nd++;
 

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -30,7 +30,7 @@ void InitDead()
 				dead[nd]._deadData[d] = Monsters[i].Anims[MA_DEATH].Data[d];
 			dead[nd]._deadFrame = Monsters[i].Anims[MA_DEATH].Frames;
 			dead[nd]._deadWidth = Monsters[i].width;
-			dead[nd]._deadWidth2 = Monsters[i].width2;
+			dead[nd]._deadWidth2 = CalculateWidth2(Monsters[i].width);
 			dead[nd]._deadtrans = 0;
 			nd++;
 
@@ -65,7 +65,7 @@ void InitDead()
 				dead[nd]._deadData[d] = monster[mi].MType->Anims[MA_DEATH].Data[d];
 			dead[nd]._deadFrame = monster[mi].MType->Anims[MA_DEATH].Frames;
 			dead[nd]._deadWidth = monster[mi].MType->width;
-			dead[nd]._deadWidth2 = monster[mi].MType->width2;
+			dead[nd]._deadWidth2 = CalculateWidth2(monster[mi].MType->width);
 			dead[nd]._deadtrans = monster[mi]._uniqtrans + 4;
 			nd++;
 

--- a/Source/dead.h
+++ b/Source/dead.h
@@ -17,7 +17,6 @@ struct DeadStruct {
 	uint8_t *_deadData[8];
 	int _deadFrame;
 	int _deadWidth;
-	int _deadWidth2;
 	uint8_t _deadtrans;
 };
 

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -579,6 +579,11 @@ direction GetDirection(Point start, Point destination)
 	return md;
 }
 
+int CalculateWidth2(int width)
+{
+	return (width - 64) / 2;
+}
+
 /**
  * @brief Set the RNG seed
  * @param s RNG seed

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -482,6 +482,13 @@ void DrawHalfTransparentRectTo(const CelOutputBuffer &out, int sx, int sy, int w
  */
 direction GetDirection(Point start, Point destination);
 
+/**
+ * @brief Calculate Width2 from the orginal Width
+ * Width2 is needed for savegame compatiblity and to render animations centered
+ * @return Returns Width2
+ */
+int CalculateWidth2(int width);
+
 void SetRndSeed(int32_t s);
 int32_t AdvanceRndSeed();
 int32_t GetRndSeed();

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2256,7 +2256,6 @@ void SetupItem(int i)
 	items[i]._iAnimData = itemanims[it];
 	items[i]._iAnimLen = ItemAnimLs[it];
 	items[i]._iAnimWidth = 96;
-	items[i]._iAnimWidth2 = 16;
 	items[i]._iIdentified = false;
 	items[i]._iPostDraw = false;
 
@@ -2967,7 +2966,6 @@ void RespawnItem(ItemStruct *item, bool FlipFlag)
 	item->_iAnimData = itemanims[it];
 	item->_iAnimLen = ItemAnimLs[it];
 	item->_iAnimWidth = 96;
-	item->_iAnimWidth2 = 16;
 	item->_iPostDraw = false;
 	item->_iRequest = false;
 	if (FlipFlag) {

--- a/Source/items.h
+++ b/Source/items.h
@@ -172,7 +172,6 @@ struct ItemStruct {
 	uint8_t _iAnimLen;   // Number of frames in current animation
 	uint8_t _iAnimFrame; // Current frame of animation.
 	int _iAnimWidth;
-	int _iAnimWidth2; // width 2?
 	bool _iDelFlag;   // set when item is flagged for deletion, deprecated in 1.02
 	uint8_t _iSelFlag;
 	bool _iPostDraw;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -704,7 +704,8 @@ static void LoadObject(LoadHelper *file, int i)
 	pObject->_oAnimLen = file->nextLE<int32_t>();
 	pObject->_oAnimFrame = file->nextLE<int32_t>();
 	pObject->_oAnimWidth = file->nextLE<int32_t>();
-	pObject->_oAnimWidth2 = file->nextLE<int32_t>();
+	// Skip _oAnimWidth2
+	file->skip(4);
 	pObject->_oDelFlag = file->nextBool32();
 	pObject->_oBreak = file->nextLE<int8_t>();
 	file->skip(3); // Alignment
@@ -1664,7 +1665,8 @@ static void SaveObject(SaveHelper *file, int i)
 	file->writeLE<int32_t>(pObject->_oAnimLen);
 	file->writeLE<int32_t>(pObject->_oAnimFrame);
 	file->writeLE<int32_t>(pObject->_oAnimWidth);
-	file->writeLE<int32_t>(pObject->_oAnimWidth2);
+	file->writeLE<int32_t>(pObject->_oAnimWidth);
+	// Write _oAnimWidth2 for vanilla compatibility
 	file->writeLE<uint32_t>(pObject->_oDelFlag);
 	file->writeLE<int8_t>(pObject->_oBreak);
 	file->skip(3); // Alignment

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -226,7 +226,8 @@ static void LoadItemData(LoadHelper *file, ItemStruct *pItem)
 	pItem->_iAnimLen = file->nextLE<int32_t>();
 	pItem->_iAnimFrame = file->nextLE<int32_t>();
 	pItem->_iAnimWidth = file->nextLE<int32_t>();
-	pItem->_iAnimWidth2 = file->nextLE<int32_t>();
+	// Skip _iAnimWidth2
+	file->skip(4);
 	file->skip(4); // Unused since 1.02
 	pItem->_iSelFlag = file->nextLE<uint8_t>();
 	file->skip(3); // Alignment
@@ -1213,7 +1214,8 @@ static void SaveItem(SaveHelper *file, ItemStruct *pItem)
 	file->writeLE<int32_t>(pItem->_iAnimLen);
 	file->writeLE<int32_t>(pItem->_iAnimFrame);
 	file->writeLE<int32_t>(pItem->_iAnimWidth);
-	file->writeLE<int32_t>(pItem->_iAnimWidth2);
+	// write _iAnimWidth2 for vanilla compatibility
+	file->writeLE<int32_t>(CalculateWidth2(pItem->_iAnimWidth));
 	file->skip(4); // Unused since 1.02
 	file->writeLE<uint8_t>(pItem->_iSelFlag);
 	file->skip(3); // Alignment

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -346,7 +346,8 @@ static void LoadPlayer(LoadHelper *file, int p)
 	pPlayer->_pAnimLen = file->nextLE<int32_t>();
 	pPlayer->_pAnimFrame = file->nextLE<int32_t>();
 	pPlayer->_pAnimWidth = file->nextLE<int32_t>();
-	pPlayer->_pAnimWidth2 = file->nextLE<int32_t>();
+	// Skip _pAnimWidth2
+	file->skip(4);
 	file->skip(4); // Skip _peflag
 	pPlayer->_plid = file->nextLE<int32_t>();
 	pPlayer->_pvid = file->nextLE<int32_t>();
@@ -1327,7 +1328,8 @@ static void SavePlayer(SaveHelper *file, int p)
 	file->writeLE<int32_t>(pPlayer->_pAnimLen);
 	file->writeLE<int32_t>(pPlayer->_pAnimFrame);
 	file->writeLE<int32_t>(pPlayer->_pAnimWidth);
-	file->writeLE<int32_t>(pPlayer->_pAnimWidth2);
+	// write _pAnimWidth2 for vanilla compatibility
+	file->writeLE<int32_t>(CalculateWidth2(pPlayer->_pAnimWidth));
 	file->skip(4); // Skip _peflag
 	file->writeLE<int32_t>(pPlayer->_plid);
 	file->writeLE<int32_t>(pPlayer->_pvid);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2513,7 +2513,7 @@ void AddRhino(int mi, int sx, int sy, int dx, int dy, int midir, int8_t mienemy,
 	missile[mi]._miAnimDelay = anim->Rate;
 	missile[mi]._miAnimLen = anim->Frames;
 	missile[mi]._miAnimWidth = monster[id].MType->width;
-	missile[mi]._miAnimWidth2 = monster[id].MType->width2;
+	missile[mi]._miAnimWidth2 = CalculateWidth2(monster[id].MType->width);
 	missile[mi]._miAnimAdd = 1;
 	if (monster[id].MType->mtype >= MT_NSNAKE && monster[id].MType->mtype <= MT_GSNAKE)
 		missile[mi]._miAnimFrame = 7;
@@ -2541,7 +2541,7 @@ void AddFireman(int mi, int sx, int sy, int dx, int dy, int midir, int8_t mienem
 	missile[mi]._miAnimDelay = anim->Rate;
 	missile[mi]._miAnimLen = anim->Frames;
 	missile[mi]._miAnimWidth = monster[id].MType->width;
-	missile[mi]._miAnimWidth2 = monster[id].MType->width2;
+	missile[mi]._miAnimWidth2 = CalculateWidth2(monster[id].MType->width);
 	missile[mi]._miAnimAdd = 1;
 	missile[mi]._miVar1 = 0;
 	missile[mi]._miVar2 = 0;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -369,7 +369,6 @@ void InitMonsterGFX(int monst)
 	}
 
 	Monsters[monst].width = monsterdata[mtype].width;
-	Monsters[monst].width2 = (monsterdata[mtype].width - 64) / 2;
 	Monsters[monst].mMinHP = monsterdata[mtype].mMinHP;
 	Monsters[monst].mMaxHP = monsterdata[mtype].mMaxHP;
 	if (!gbIsHellfire && mtype == MT_DIABLO) {

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -118,7 +118,6 @@ struct CMonster {
 	AnimStruct Anims[6];
 	TSnd *Snds[4][2];
 	int width;
-	int width2;
 	uint16_t mMinHP;
 	uint16_t mMaxHP;
 	bool has_special;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1683,7 +1683,6 @@ void objects_44D8C5(_object_id ot, int v2, int ox, int oy)
 	dObject[ox][oy] = oi + 1;
 	SetupObject(oi, ox, oy, ot);
 	objects_44DA68(oi, v2);
-	object[oi]._oAnimWidth2 = (object[oi]._oAnimWidth - 64) / 2;
 	nobjects++;
 }
 
@@ -1903,7 +1902,6 @@ void AddObject(_object_id ot, int ox, int oy)
 	default:
 		break;
 	}
-	object[oi]._oAnimWidth2 = (object[oi]._oAnimWidth - 64) / 2;
 	nobjects++;
 }
 

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -26,7 +26,6 @@ struct ObjectStruct {
 	int _oAnimLen;   // Number of frames in current animation
 	int _oAnimFrame; // Current frame of animation.
 	int _oAnimWidth;
-	int _oAnimWidth2;
 	bool _oDelFlag;
 	int8_t _oBreak;
 	bool _oSolidFlag;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -558,7 +558,6 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, Animat
 	plr[pnum]._pAnimCnt = 0;
 	plr[pnum]._pAnimDelay = Delay;
 	plr[pnum]._pAnimWidth = width;
-	plr[pnum]._pAnimWidth2 = (width - 64) / 2;
 	plr[pnum]._pAnimGameTicksSinceSequenceStarted = 0;
 	plr[pnum]._pAnimRelevantAnimationFramesForDistributing = 0;
 	plr[pnum]._pAnimGameTickModifier = 0.0f;

--- a/Source/player.h
+++ b/Source/player.h
@@ -166,7 +166,6 @@ struct PlayerStruct {
 	int _pAnimLen;   // Number of frames in current animation
 	int _pAnimFrame; // Current frame of animation.
 	int _pAnimWidth;
-	int _pAnimWidth2;
 	/*
 	* @brief Specifies how many animations-fractions are displayed between two gameticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
 	*/

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -768,7 +768,7 @@ static void scrollrt_draw_dungeon(const CelOutputBuffer &out, int sx, int sy, in
 		do {
 			DeadStruct *pDeadGuy = &dead[(bDead & 0x1F) - 1];
 			auto dd = static_cast<direction>((bDead >> 5) & 7);
-			int px = dx - pDeadGuy->_deadWidth2;
+			int px = dx - CalculateWidth2(pDeadGuy->_deadWidth);
 			BYTE *pCelBuff = pDeadGuy->_deadData[dd];
 			assert(pCelBuff != nullptr);
 			if (pCelBuff == nullptr)

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -514,7 +514,7 @@ static void DrawObject(const CelOutputBuffer &out, int x, int y, int ox, int oy,
 		bv = dObject[x][y] - 1;
 		if (object[bv]._oPreFlag != pre)
 			return;
-		sx = ox - object[bv]._oAnimWidth2;
+		sx = ox - CalculateWidth2(object[bv]._oAnimWidth);
 		sy = oy;
 	} else {
 		bv = -(dObject[x][y] + 1);
@@ -522,7 +522,7 @@ static void DrawObject(const CelOutputBuffer &out, int x, int y, int ox, int oy,
 			return;
 		int xx = object[bv].position.x - x;
 		int yy = object[bv].position.y - y;
-		sx = (xx * TILE_WIDTH / 2) + ox - object[bv]._oAnimWidth2 - (yy * TILE_WIDTH / 2);
+		sx = (xx * TILE_WIDTH / 2) + ox - CalculateWidth2(object[bv]._oAnimWidth) - (yy * TILE_WIDTH / 2);
 		sy = oy + (yy * TILE_HEIGHT / 2) + (xx * TILE_HEIGHT / 2);
 	}
 

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -640,7 +640,7 @@ static void DrawItem(const CelOutputBuffer &out, int x, int y, int sx, int sy, b
 		return;
 	}
 
-	int px = sx - pItem->_iAnimWidth2;
+	int px = sx - CalculateWidth2(pItem->_iAnimWidth);
 	if (bItem - 1 == pcursitem || AutoMapShowItems) {
 		CelBlitOutlineTo(out, GetOutlineColor(*pItem, false), px, sy, pCelBuff, nCel, pItem->_iAnimWidth);
 	}

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -378,7 +378,7 @@ static void DrawManaShield(const CelOutputBuffer &out, int pnum, int x, int y, b
 	if (!plr[pnum].pManaShield)
 		return;
 
-	x += plr[pnum]._pAnimWidth2 - misfiledata[MFILE_MANASHLD].mAnimWidth2[0];
+	x += CalculateWidth2(plr[pnum]._pAnimWidth) - misfiledata[MFILE_MANASHLD].mAnimWidth2[0];
 
 	int width = misfiledata[MFILE_MANASHLD].mAnimWidth[0];
 	BYTE *pCelBuff = misfiledata[MFILE_MANASHLD].mAnimData[0];
@@ -487,7 +487,7 @@ void DrawDeadPlayer(const CelOutputBuffer &out, int x, int y, int sx, int sy)
 		p = &plr[i];
 		if (p->plractive && p->_pHitPoints == 0 && p->plrlevel == (BYTE)currlevel && p->position.tile.x == x && p->position.tile.y == y) {
 			dFlags[x][y] |= BFLAG_DEAD_PLAYER;
-			px = sx + p->position.offset.x - p->_pAnimWidth2;
+			px = sx + p->position.offset.x - CalculateWidth2(p->_pAnimWidth);
 			py = sy + p->position.offset.y;
 			DrawPlayer(out, i, x, y, px, py);
 		}
@@ -719,7 +719,7 @@ static void DrawPlayerHelper(const CelOutputBuffer &out, int x, int y, int sx, i
 	}
 
 	PlayerStruct *pPlayer = &plr[p];
-	int px = sx + pPlayer->position.offset.x - pPlayer->_pAnimWidth2;
+	int px = sx + pPlayer->position.offset.x - CalculateWidth2(pPlayer->_pAnimWidth);
 	int py = sy + pPlayer->position.offset.y;
 
 	DrawPlayer(out, p, x, y, px, py);

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -692,7 +692,7 @@ static void DrawMonsterHelper(const CelOutputBuffer &out, int x, int y, int oy, 
 		return;
 	}
 
-	px = sx + pMonster->position.offset.x - pMonster->MType->width2;
+	px = sx + pMonster->position.offset.x - CalculateWidth2(pMonster->MType->width);
 	py = sy + pMonster->position.offset.y;
 	if (mi == pcursmonst) {
 		Cl2DrawOutline(out, 233, px, py, pMonster->_mAnimData, pMonster->_mAnimFrame, pMonster->MType->width);

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -665,7 +665,7 @@ static void DrawMonsterHelper(const CelOutputBuffer &out, int x, int y, int oy, 
 	mi = mi > 0 ? mi - 1 : -(mi + 1);
 
 	if (leveltype == DTYPE_TOWN) {
-		px = sx - towners[mi]._tAnimWidth2;
+		px = sx - CalculateWidth2(towners[mi]._tAnimWidth);
 		if (mi == pcursmonst) {
 			CelBlitOutlineTo(out, 166, px, sy, towners[mi]._tAnimData, towners[mi]._tAnimFrame, towners[mi]._tAnimWidth);
 		}

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -205,7 +205,6 @@ void InitTownerInfo(int i, int w, bool sel, _talker_id t, int x, int y, int ao)
 	memset(&towners[i], 0, sizeof(TownerStruct));
 	towners[i]._tSelFlag = sel;
 	towners[i]._tAnimWidth = w;
-	towners[i]._tAnimWidth2 = (w - 64) / 2;
 	towners[i]._tMsgSaid = false;
 	towners[i]._ttype = t;
 	towners[i].position = { x, y };

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -46,7 +46,6 @@ struct TownerStruct {
 	/** Tile position of NPC */
 	Point position;
 	int16_t _tAnimWidth;
-	int16_t _tAnimWidth2;
 	int16_t _tAnimDelay; // Tick length of each frame in the current animation
 	int16_t _tAnimCnt;   // Increases by one each game tick, counting how close we are to _pAnimDelay
 	uint8_t _tAnimLen;   // Number of frames in current animation

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -297,7 +297,6 @@ static void AssertPlayer(PlayerStruct *pPlayer)
 	ASSERT_EQ(pPlayer->_pAnimLen, 20);
 	ASSERT_EQ(pPlayer->_pAnimFrame, 1);
 	ASSERT_EQ(pPlayer->_pAnimWidth, 96);
-	ASSERT_EQ(pPlayer->_pAnimWidth2, 16);
 	ASSERT_EQ(pPlayer->_pSpell, -1);
 	ASSERT_EQ(pPlayer->_pSplType, 4);
 	ASSERT_EQ(pPlayer->_pSplFrom, 0);


### PR DESCRIPTION
I looked in generalization the animation distribution logic and I asked myself "what is Width2 and should I care?".
Mostly the answer is we shouldn't care.
AnimWidth2 seems to be only needed for rendering and can be calculated only there, so the GameLogic don't need to care about.
This reduces complexity and memory size.

But there is a exception to this rule.
it's not possible for missiles, cause in hellfire there are some missiles that have not the normal offset (for example MFILE_REFLECT, MFILE_ARCHLICH or MFILE_BONEDEMON).
But I didn't looked into this in detail.

I submitted this as draft to discuss if we should take this, even if missiles are handled differently.