### PR TITLE
Modernize deprecated headers

### DIFF
--- a/Source/DiabloUI/diabloui.h
+++ b/Source/DiabloUI/diabloui.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <array>
 #include <cstddef>
 #include <SDL.h>

--- a/Source/DiabloUI/fonts.h
+++ b/Source/DiabloUI/fonts.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <SDL_ttf.h>
-#include <stdint.h>
+#include <cstdint>
 
 #include "DiabloUI/art.h"
 

--- a/Source/DiabloUI/scrollbar.h
+++ b/Source/DiabloUI/scrollbar.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "DiabloUI/art.h"
 #include "DiabloUI/ui_item.h"

--- a/Source/DiabloUI/ttf_render_wrapped.h
+++ b/Source/DiabloUI/ttf_render_wrapped.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <SDL_ttf.h>
-#include <stdint.h>
+#include <cstdint>
 
 namespace devilution {
 

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "engine.h"
 #include "gendung.h"

--- a/Source/control.h
+++ b/Source/control.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "engine.h"
 #include "spelldat.h"

--- a/Source/controls/axis_direction.h
+++ b/Source/controls/axis_direction.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace devilution {
 

--- a/Source/controls/controller_buttons.h
+++ b/Source/controls/controller_buttons.h
@@ -1,7 +1,7 @@
 #pragma once
 // Unifies joystick, gamepad, and keyboard controller APIs.
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace devilution {
 

--- a/Source/controls/game_controls.h
+++ b/Source/controls/game_controls.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <stdint.h>
 #include <cstdint>
 #include <SDL.h>
 

--- a/Source/controls/menu_controls.h
+++ b/Source/controls/menu_controls.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <SDL.h>
-#include <stdint.h>
+#include <cstdint>
 
 namespace devilution {
 

--- a/Source/controls/plrctrls.h
+++ b/Source/controls/plrctrls.h
@@ -1,7 +1,7 @@
 #pragma once
 // Controller actions implementation
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace devilution {
 

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "miniwin/miniwin.h"
 

--- a/Source/dead.h
+++ b/Source/dead.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "engine.h"
 

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #ifdef _DEBUG
 #include "monstdat.h"

--- a/Source/dvlnet/packet.h
+++ b/Source/dvlnet/packet.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <memory>
 #include <array>

--- a/Source/effects.h
+++ b/Source/effects.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "sound.h"
 

--- a/Source/encrypt.h
+++ b/Source/encrypt.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "miniwin/miniwin.h"
 

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -16,7 +16,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <SDL.h>
-#include <stdint.h>
+#include <cstdint>
 
 #ifdef USE_SDL1
 #include "utils/sdl2_to_1_2_backports.h"

--- a/Source/error.h
+++ b/Source/error.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "engine.h"
 

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "engine.h"
 #include "scrollrt.h"

--- a/Source/gmenu.h
+++ b/Source/gmenu.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "engine.h"
 

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -4,7 +4,7 @@
  * Implementation of load screens.
  */
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "control.h"
 #include "DiabloUI/art_draw.h"

--- a/Source/interfac.h
+++ b/Source/interfac.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "utils/ui_fwd.h"
 

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "items.h"
 #include "palette.h"

--- a/Source/itemdat.h
+++ b/Source/itemdat.h
@@ -5,8 +5,8 @@
  */
 #pragma once
 
-#include <stdbool.h>
-#include <stdint.h>
+
+#include <cstdint>
 
 #include "objdat.h"
 #include "spelldat.h"

--- a/Source/items.h
+++ b/Source/items.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "engine.h"
 #include "itemdat.h"

--- a/Source/miniwin/miniwin.h
+++ b/Source/miniwin/miniwin.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
-#include <ctype.h>
-#include <math.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 
 namespace devilution {
 

--- a/Source/misdat.h
+++ b/Source/misdat.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "effects.h"
 

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "miniwin/miniwin.h"
 #include "engine.h"

--- a/Source/monstdat.h
+++ b/Source/monstdat.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace devilution {
 

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "engine.h"
 #include "miniwin/miniwin.h"

--- a/Source/mpqapi.h
+++ b/Source/mpqapi.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "miniwin/miniwin.h"
 

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "quests.h"
 #include "objects.h"

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "msg.h"
 

--- a/Source/objdat.h
+++ b/Source/objdat.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "gendung.h"
 

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "objdat.h"
 #include "textdat.h"

--- a/Source/options.h
+++ b/Source/options.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "pack.h"
 

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "player.h"
 #include "inv.h"

--- a/Source/platform/ctr/keyboard.cpp
+++ b/Source/platform/ctr/keyboard.cpp
@@ -1,5 +1,5 @@
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 
 #include "platform/ctr/keyboard.h"
 

--- a/Source/platform/ctr/system.cpp
+++ b/Source/platform/ctr/system.cpp
@@ -1,5 +1,5 @@
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 #include <3ds.h>
 #include "platform/ctr/system.h"
 

--- a/Source/platform/switch/keyboard.cpp
+++ b/Source/platform/switch/keyboard.cpp
@@ -1,6 +1,4 @@
-#include <string.h>
-#include <stdbool.h>
-
+#include <cstring>
 #include <switch.h>
 #include <SDL.h>
 #include "platform/switch/keyboard.h"

--- a/Source/platform/switch/network.cpp
+++ b/Source/platform/switch/network.cpp
@@ -1,4 +1,4 @@
-#include <stdlib.h>
+#include <cstdlib>
 #include <unistd.h>
 #include <switch.h>
 #include "platform/switch/network.h"

--- a/Source/platform/vita/keyboard.cpp
+++ b/Source/platform/vita/keyboard.cpp
@@ -1,5 +1,4 @@
-#include <string.h>
-#include <stdbool.h>
+#include <cstring>
 
 #include <SDL.h>
 #include <psp2/types.h>

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -4,7 +4,7 @@
  * Implementation of player functionality, leveling, actions, creation, loading, etc.
  */
 #include <algorithm>
-#include <stdint.h>
+#include <cstdint>
 
 #include "control.h"
 #include "cursor.h"

--- a/Source/player.h
+++ b/Source/player.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "diablo.h"
 #include "engine.h"

--- a/Source/plrmsg.h
+++ b/Source/plrmsg.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include "SDL.h"
-#include <stdint.h>
+#include <cstdint>
 
 #include "engine.h"
 

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "engine.h"
 #include "gendung.h"

--- a/Source/scrollrt.h
+++ b/Source/scrollrt.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "engine.h"
 #include "miniwin/miniwin.h"

--- a/Source/sha.h
+++ b/Source/sha.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace devilution {
 

--- a/Source/sound.h
+++ b/Source/sound.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "miniwin/miniwin.h"
 #include "utils/soundsample.h"

--- a/Source/spelldat.h
+++ b/Source/spelldat.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "effects.h"
 

--- a/Source/storm/storm.h
+++ b/Source/storm/storm.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <limits>
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 
 #include "appfat.h"
 #include "multi.h"

--- a/Source/sync.h
+++ b/Source/sync.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "miniwin/miniwin.h"
 

--- a/Source/themes.h
+++ b/Source/themes.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "gendung.h"
 #include "objdat.h"

--- a/Source/tmsg.h
+++ b/Source/tmsg.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "miniwin/miniwin.h"
 

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "items.h"
 #include "player.h"

--- a/Source/utils/sdl2_to_1_2_backports.h
+++ b/Source/utils/sdl2_to_1_2_backports.h
@@ -2,11 +2,11 @@
 
 #include <SDL.h>
 #include <unistd.h>
-#include <errno.h>
-#include <stdio.h>
+#include <cerrno>
+#include <cstdio>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <math.h>
+#include <cmath>
 #include <cstddef>
 
 #include "utils/console.h"

--- a/Source/utils/stubs.h
+++ b/Source/utils/stubs.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
 
 #define UNIMPLEMENTED()                                                         \
 	do {                                                                        \

--- a/test/pack_test.cpp
+++ b/test/pack_test.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 
 #include "pack.h"
 

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -2,7 +2,7 @@
 #include <fstream>
 #include <gtest/gtest.h>
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 
 #include "loadsave.h"
 #include "pack.h"


### PR DESCRIPTION
Mostly [clang-tidy](https://clang.llvm.org/extra/clang-tidy/checks/modernize-deprecated-headers.html#modernize-deprecated-headers) but also a few manual fixes (including a duplicate inclusion).