### PR TITLE
Parse language metadata

### DIFF
--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -41,7 +41,7 @@ char *read_entry(FILE *fp, mo_entry *e)
 		return nullptr;
 	}
 
-	if (!(data = calloc(e->length, sizeof(char)))) {
+	if (!(data = calloc(e->length + 1, sizeof(char)))) {
 		return nullptr;
 	}
 

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -34,24 +34,48 @@ struct mo_entry {
 	uint32_t offset;
 };
 
+char *strtrim_left(char *s)
+{
+	while (*s && isblank(*s)) {
+		s++;
+	}
+	return s;
+}
+
+char *strtrim_right(char *s)
+{
+	size_t length = strlen(s);
+
+	while (length) {
+		length--;
+		if (isblank(s[length])) {
+			s[length] = '\0';
+		} else {
+			break;
+		}
+	}
+	return s;
+}
+
 void parse_metadata(char *data)
 {
 	char *key, *delim, *val;
 	char *ptr = data;
 
-	while (ptr) {
-		if (!(delim = strstr(ptr, ":"))) {
-			return;
-		}
-		key = data;
-		val = delim + 1;
+	while (ptr && (delim = strstr(ptr, ":"))) {
+		key = strtrim_left(ptr);
+		val = strtrim_left(delim + 1);
 
-		// add null termination to key and val
+		// null-terminate key
 		*delim = '\0';
-		if ((ptr = strstr(ptr, "\n"))) {
+
+		// progress to next line (if any)
+		if ((ptr = strstr(val, "\n"))) {
 			*ptr = '\0';
 			ptr++;
 		}
+
+		val = strtrim_right(val);
 		meta[key] = val;
 	}
 }

--- a/Source/utils/language.h
+++ b/Source/utils/language.h
@@ -5,4 +5,4 @@
 
 void LanguageInitialize();
 const char* LanguageTranslate(const char* key);
-
+const char* LanguageMetadata(const char *key);


### PR DESCRIPTION
This pull request adds language metadata lookup capabilities, e.g., to check which character set a translation is encoded in. There is also a fix that ensures translations are null-terminated.