### PR TITLE
Remove globals/pointers from paths.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -700,6 +700,7 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_compile_options(${BIN_TARGET} PRIVATE "/W0")
+  target_compile_options(${BIN_TARGET} PRIVATE "/Zc:__cplusplus")
 endif()
 
 if(APPLE)

--- a/Source/DiabloUI/fonts.cpp
+++ b/Source/DiabloUI/fonts.cpp
@@ -66,10 +66,10 @@ void LoadTtfFont()
 		was_fonts_init = true;
 	}
 
-	std::string ttfFontPath = GetTtfPath() + GetTtfName();
+	std::string ttfFontPath = paths::TtfPath() + paths::TtfName();
 #ifdef __linux__
 	if (!FileExists(ttfFontPath.c_str())) {
-		ttfFontPath = "/usr/share/fonts/truetype/" + GetTtfName();
+		ttfFontPath = "/usr/share/fonts/truetype/" + paths::TtfName();
 	}
 #endif
 	font = TTF_OpenFont(ttfFontPath.c_str(), 17);

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -137,7 +137,7 @@ static std::ofstream *CaptureFile(std::string *dstPath)
 	char filename[sizeof("screen00.PCX") / sizeof(char)];
 	for (int i = 0; i <= 99; ++i) {
 		snprintf(filename, sizeof(filename) / sizeof(char), "screen%02d.PCX", i);
-		*dstPath = GetPrefPath() + filename;
+		*dstPath = paths::PrefPath() + filename;
 		if (!FileExists(dstPath->c_str())) {
 			return new std::ofstream(*dstPath, std::ios::binary | std::ios::trunc);
 		}

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -185,17 +185,17 @@ static void diablo_parse_flags(int argc, char **argv)
 			printInConsole("%s v%s\n", PROJECT_NAME, PROJECT_VERSION);
 			diablo_quit(0);
 		} else if (strcasecmp("--data-dir", argv[i]) == 0) {
-			SetBasePath(argv[++i]);
+			paths::SetBasePath(argv[++i]);
 		} else if (strcasecmp("--save-dir", argv[i]) == 0) {
-			SetPrefPath(argv[++i]);
+			paths::SetPrefPath(argv[++i]);
 		} else if (strcasecmp("--config-dir", argv[i]) == 0) {
-			SetConfigPath(argv[++i]);
+			paths::SetConfigPath(argv[++i]);
 		} else if (strcasecmp("--lang-dir", argv[i]) == 0) {
-			SetLangPath(argv[++i]);
+			paths::SetLangPath(argv[++i]);
 		} else if (strcasecmp("--ttf-dir", argv[i]) == 0) {
-			SetTtfPath(argv[++i]);
+			paths::SetTtfPath(argv[++i]);
 		} else if (strcasecmp("--ttf-name", argv[i]) == 0) {
-			SetTtfName(argv[++i]);
+			paths::SetTtfName(argv[++i]);
 		} else if (strcasecmp("-n", argv[i]) == 0) {
 			gbShowIntro = false;
 		} else if (strcasecmp("-f", argv[i]) == 0) {

--- a/Source/dvlnet/zerotier_native.cpp
+++ b/Source/dvlnet/zerotier_native.cpp
@@ -63,7 +63,7 @@ void zerotier_network_start()
 {
 	if (zt_started)
 		return;
-	zts_start(GetPrefPath().c_str(), (void (*)(void *))Callback, 0);
+	zts_start(paths::PrefPath().c_str(), (void (*)(void *))Callback, 0);
 	std::atexit(zerotier_network_stop);
 }
 

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -151,8 +151,8 @@ void init_archives()
 
 	std::vector<std::string> paths;
 	paths.reserve(5);
-	paths.push_back(GetBasePath());
-	paths.push_back(GetPrefPath());
+	paths.push_back(paths::BasePath());
+	paths.push_back(paths::PrefPath());
 	if (paths[0] == paths[1])
 		paths.pop_back();
 

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -28,7 +28,7 @@ namespace {
 
 std::string GetSavePath(DWORD save_num)
 {
-	std::string path = GetPrefPath();
+	std::string path = paths::PrefPath();
 	const char *ext = ".sv";
 	if (gbIsHellfire)
 		ext = ".hsv";

--- a/Source/restrict.cpp
+++ b/Source/restrict.cpp
@@ -15,10 +15,10 @@ namespace devilution {
  */
 void ReadOnlyTest()
 {
-	const std::string path = GetPrefPath() + "Diablo1ReadOnlyTest.foo";
+	const std::string path = paths::PrefPath() + "Diablo1ReadOnlyTest.foo";
 	FILE *f = fopen(path.c_str(), "wt");
 	if (f == nullptr) {
-		DirErrorDlg(GetPrefPath().c_str());
+		DirErrorDlg(paths::PrefPath().c_str());
 	}
 
 	fclose(f);

--- a/Source/storm/storm.cpp
+++ b/Source/storm/storm.cpp
@@ -37,7 +37,7 @@ std::string *SBasePath = nullptr;
 
 radon::File &getIni()
 {
-	static radon::File ini(GetConfigPath() + "diablo.ini");
+	static radon::File ini(paths::ConfigPath() + "diablo.ini");
 	return ini;
 }
 

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -70,9 +70,9 @@ void LanguageInitialize()
 	mo_head head;
 	FILE *fp;
 
-	auto path = GetLangPath() + "./" + sgOptions.Language.szCode + ".gmo";
+	auto path = paths::LangPath() + "./" + sgOptions.Language.szCode + ".gmo";
 	if (!(fp = fopen(path.c_str(), "rb"))) {
-		path = GetLangPath() + "./" + sgOptions.Language.szCode + ".mo";
+		path = paths::LangPath() + "./" + sgOptions.Language.szCode + ".mo";
 		if (!(fp = fopen(path.c_str(), "rb"))) {
 			perror(path.c_str());
 			return;

--- a/Source/utils/paths.cpp
+++ b/Source/utils/paths.cpp
@@ -23,29 +23,31 @@
 
 namespace devilution {
 
+namespace paths {
+
 namespace {
 
-std::string *basePath = nullptr;
-std::string *prefPath = nullptr;
-std::string *configPath = nullptr;
-std::string *langPath = nullptr;
-std::string *ttfPath = nullptr;
-std::string *ttfName = nullptr;
+std::optional<std::string> basePath;
+std::optional<std::string> prefPath;
+std::optional<std::string> configPath;
+std::optional<std::string> langPath;
+std::optional<std::string> ttfPath;
+std::optional<std::string> ttfName;
 
-void AddTrailingSlash(std::string *path)
+void AddTrailingSlash(std::string &path)
 {
 #ifdef _WIN32
-	if (!path->empty() && path->back() != '\\')
-		*path += '\\';
+	if (!path.empty() && path.back() != '\\')
+		path += '\\';
 #else
-	if (!path->empty() && path->back() != '/')
-		*path += '/';
+	if (!path.empty() && path.back() != '/')
+		path += '/';
 #endif
 }
 
-std::string *FromSDL(char *s)
+std::string FromSDL(char *s)
 {
-	auto *result = new std::string(s != nullptr ? s : "");
+	std::string result = (s != nullptr ? s : "");
 	if (s != nullptr) {
 		SDL_free(s);
 	} else {
@@ -57,98 +59,88 @@ std::string *FromSDL(char *s)
 
 } // namespace
 
-const std::string &GetBasePath()
+const std::string &BasePath()
 {
+	if (!basePath) {
 #ifdef __vita__
-	if (basePath == NULL)
-		basePath = new std::string(GetPrefPath());
+		basePath = PrefPath();
 #else
-	if (basePath == nullptr)
 		basePath = FromSDL(SDL_GetBasePath());
 #endif
+	}
 	return *basePath;
 }
 
-const std::string &GetPrefPath()
+const std::string &PrefPath()
 {
-	if (prefPath == nullptr)
+	if (!prefPath)
 		prefPath = FromSDL(SDL_GetPrefPath("diasurgical", "devilution"));
 	return *prefPath;
 }
 
-const std::string &GetConfigPath()
+const std::string &ConfigPath()
 {
-	if (configPath == nullptr)
+	if (!configPath)
 		configPath = FromSDL(SDL_GetPrefPath("diasurgical", "devilution"));
 	return *configPath;
 }
 
-const std::string &GetTtfPath()
+const std::string &LangPath()
 {
-	if (ttfPath == nullptr)
-		ttfPath = new std::string(TTF_FONT_DIR);
-	return *ttfPath;
-}
-
-const std::string &GetLangPath()
-{
-	if (langPath == NULL)
-		langPath = new std::string(MO_LANG_DIR);
+	if (!langPath)
+		langPath = MO_LANG_DIR;
 	return *langPath;
 }
 
-const std::string &GetTtfName()
+const std::string &TtfPath()
 {
-	if (ttfName == nullptr)
-		ttfName = new std::string(TTF_FONT_NAME);
+	if (!ttfPath)
+		ttfPath = TTF_FONT_DIR;
+	return *ttfPath;
+}
+
+const std::string &TtfName()
+{
+	if (!ttfName)
+		ttfName = TTF_FONT_NAME;
 	return *ttfName;
 }
 
-void SetBasePath(const char *path)
+void SetBasePath(const std::string &path)
 {
-	if (basePath == nullptr)
-		basePath = new std::string;
-	*basePath = path;
-	AddTrailingSlash(basePath);
+	basePath = path;
+	AddTrailingSlash(*basePath);
 }
 
-void SetPrefPath(const char *path)
+void SetPrefPath(const std::string &path)
 {
-	if (prefPath == nullptr)
-		prefPath = new std::string;
-	*prefPath = path;
-	AddTrailingSlash(prefPath);
+	prefPath = path;
+	AddTrailingSlash(*prefPath);
 }
 
-void SetConfigPath(const char *path)
+void SetConfigPath(const std::string &path)
 {
-	if (configPath == nullptr)
-		configPath = new std::string;
-	*configPath = path;
-	AddTrailingSlash(configPath);
+	configPath = path;
+	AddTrailingSlash(*configPath);
 }
 
-void SetLangPath(const char *path)
+void SetLangPath(const std::string &path)
 {
-	if (langPath == NULL)
-		langPath = new std::string;
-	*langPath = path;
-	AddTrailingSlash(langPath);
+	langPath = path;
+	AddTrailingSlash(*langPath);
 }
 
-void SetTtfPath(const char *path)
+void SetTtfPath(const std::string &path)
 {
-	if (ttfPath == nullptr)
-		ttfPath = new std::string;
-	*ttfPath = path;
-	AddTrailingSlash(ttfPath);
+	ttfPath = path;
+	AddTrailingSlash(*ttfPath);
 }
 
-void SetTtfName(const char *path)
+void SetTtfName(const std::string &name)
 {
-	if (ttfName == nullptr)
-		ttfName = new std::string;
-	*ttfName = path;
+	ttfName = name;
 }
+
+} // namespace paths
 
 } // namespace devilution

--- a/Source/utils/paths.cpp
+++ b/Source/utils/paths.cpp
@@ -1,7 +1,9 @@
 #include "utils/paths.h"
-#include "utils/log.hpp"
 
 #include <SDL.h>
+
+#include "utils/stdcompat/optional.hpp"
+#include "utils/log.hpp"
 
 #ifdef USE_SDL1
 #include "utils/sdl2_to_1_2_backports.h"

--- a/Source/utils/paths.h
+++ b/Source/utils/paths.h
@@ -4,18 +4,22 @@
 
 namespace devilution {
 
-const std::string &GetBasePath();
-const std::string &GetPrefPath();
-const std::string &GetConfigPath();
-const std::string &GetLangPath();
-const std::string &GetTtfPath();
-const std::string &GetTtfName();
-  
-void SetBasePath(const char *path);
-void SetPrefPath(const char *path);
-void SetConfigPath(const char *path);
-void SetLangPath(const char *path);
-void SetTtfPath(const char *path);
-void SetTtfName(const char *path);
+namespace paths {
+
+const std::string &BasePath();
+const std::string &PrefPath();
+const std::string &ConfigPath();
+const std::string &LangPath();
+const std::string &TtfPath();
+const std::string &TtfName();
+
+void SetBasePath(const std::string &path);
+void SetPrefPath(const std::string &path);
+void SetConfigPath(const std::string &path);
+void SetLangPath(const std::string &path);
+void SetTtfPath(const std::string &path);
+void SetTtfName(const std::string &name);
+
+} // namespace paths
 
 } // namespace devilution

--- a/Source/utils/stdcompat/optional.hpp
+++ b/Source/utils/stdcompat/optional.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#ifdef __has_include
+#if defined(__cplusplus) && __cplusplus >= 201606L && __has_include(<optional>)
+#include <optional> // IWYU pragma: export
+#elif __has_include(<experimental/optional>)
+#include <experimental/optional> // IWYU pragma: export
+#define optional experimental::optional
+#else
+#error "Missing support for <optional> or <experimental/optional>"
+#endif
+#else
+#error "__has_include unavailable"
+#endif

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -362,7 +362,7 @@ static void AssertPlayer(PlayerStruct *pPlayer)
 
 TEST(Writehero, pfile_write_hero)
 {
-	SetPrefPath(".");
+	paths::SetPrefPath(".");
 	std::remove("multi_0.sv");
 
 	gbVanilla = true;


### PR DESCRIPTION
This removes globals and pointers from `paths.h`. It introduces a static class to do so.

Multiple options/alternatives here:
- skip the static, use an instantiable class and pass it around (my preferred option, as we will certainly use more and more classes this will allow us to see what class depends on what; plus the singleton pattern is usually not seen as a good practice) -- the issue here is that some static functions need those paths, so implementing this would imply removing their static status (which would probably be a good thing, but is a bit more involved so I'd rather hear your opinions on that).
- only use static variables and static functions (not a fan, as it's not much better than using globals)
- use `Get` instead of `Instance` to access the instance, shorter but less explicit