### PR TITLE
Refactor Animation Informations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,6 +343,7 @@ set(devilutionx_SRCS
   Source/controls/modifier_hints.cpp
   Source/controls/plrctrls.cpp
   Source/controls/touch.cpp
+  Source/engine/animationinfo.cpp
   Source/qol/autopickup.cpp
   Source/qol/common.cpp
   Source/qol/monhealthbar.cpp
@@ -453,7 +454,7 @@ if(RUN_TESTS)
     test/scrollrt_test.cpp
     test/stores_test.cpp
     test/writehero_test.cpp
-    test/animationinformation_test.cpp)
+    test/animationinfo_test.cpp)
 endif()
 
 add_executable(${BIN_TARGET} WIN32 MACOSX_BUNDLE ${devilutionx_SRCS})

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -5,7 +5,47 @@
  */
 
 #include "animationinfo.h"
+#include "appfat.h"
+#include "nthread.h"
+#include "utils/log.hpp"
 
 namespace devilution {
+
+int AnimationInfo::GetFrameToUseForRendering()
+{
+	// Normal logic is used,
+	// - if no frame-skipping is required and so we have exactly one Animationframe per GameTick
+	// or
+	// - if we load from a savegame where the new variables are not stored (we don't want to break savegame compatiblity because of smoother rendering of one animation)
+	int relevantAnimationFramesForDistributing = RelevantFramesForDistributing;
+	if (relevantAnimationFramesForDistributing <= 0)
+		return CurrentFrame;
+
+	if (CurrentFrame > relevantAnimationFramesForDistributing)
+		return CurrentFrame;
+
+	assert(GameTicksSinceSequenceStarted >= 0);
+
+	float progressToNextGameTick = gfProgressToNextGameTick;
+
+	// we don't use the processed game ticks alone but also the fragtion of the next game tick (if a rendering happens between game ticks). This helps to smooth the animations.
+	float totalGameTicksForCurrentAnimationSequence = progressToNextGameTick + (float)GameTicksSinceSequenceStarted;
+
+	// 1 added for rounding reasons. float to int cast always truncate.
+	int absoluteAnimationFrame = 1 + (int)(totalGameTicksForCurrentAnimationSequence * GameTickModifier);
+	if (absoluteAnimationFrame > relevantAnimationFramesForDistributing) {
+		// this can happen if we are at the last frame and the next game tick is due (nthread_GetProgressToNextGameTick returns 1.0f)
+		if (absoluteAnimationFrame > (relevantAnimationFramesForDistributing + 1)) {
+			// we should never have +2 frames even if next game tick is due
+			Log("GetFrameToUseForRendering: Calculated an invalid Animation Frame (Calculated {} MaxFrame {})", absoluteAnimationFrame, relevantAnimationFramesForDistributing);
+		}
+		return relevantAnimationFramesForDistributing;
+	}
+	if (absoluteAnimationFrame <= 0) {
+		Log("GetFrameToUseForRendering: Calculated an invalid Animation Frame (Calculated {})", absoluteAnimationFrame);
+		return 1;
+	}
+	return absoluteAnimationFrame;
+}
 
 } // namespace devilution

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -81,7 +81,7 @@ void AnimationInfo::SetNewAnimation(uint8_t *pData, int numberOfFrames, int dela
 
 		if (params == AnimationDistributionParams::ProcessAnimationPending) {
 			// If ProcessAnimation will be called after SetNewAnimation (in same GameTick as NewPlrAnim), we increment the Animation-Counter.
-			// If no delay is specified, this will result in complete skipped frame (see ProcessPlayerAnimation).
+			// If no delay is specified, this will result in complete skipped frame (see ProcessAnimation).
 			// But if we have a delay specified, this would only result in a reduced time the first frame is shown (one skipped delay).
 			// Because of that, we only the remove one GameTick from the time the Animation is shown
 			relevantAnimationGameTicksWithSkipping -= 1;
@@ -119,6 +119,20 @@ void AnimationInfo::SetNewAnimation(uint8_t *pData, int numberOfFrames, int dela
 
 		RelevantFramesForDistributing = relevantAnimationFramesForDistributing;
 		GameTickModifier = gameTickModifier;
+	}
+}
+
+void AnimationInfo::ProcessAnimation()
+{
+	DelayCounter++;
+	GameTicksSinceSequenceStarted++;
+	if (DelayCounter > DelayLen) {
+		DelayCounter = 0;
+		CurrentFrame++;
+		if (CurrentFrame > NumberOfFrames) {
+			CurrentFrame = 1;
+			GameTicksSinceSequenceStarted = 0;
+		}
 	}
 }
 

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -1,0 +1,11 @@
+/**
+ * @file animationinfo.cpp
+ *
+ * Contains the core animation information and related logic
+ */
+
+#include "animationinfo.h"
+
+namespace devilution {
+
+} // namespace devilution

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -48,4 +48,78 @@ int AnimationInfo::GetFrameToUseForRendering()
 	return absoluteAnimationFrame;
 }
 
+void AnimationInfo::SetNewAnimation(uint8_t *pData, int numberOfFrames, int delayLen, AnimationDistributionParams params /*= AnimationDistributionParams::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/)
+{
+	this->pData = pData;
+	NumberOfFrames = numberOfFrames;
+	CurrentFrame = 1;
+	DelayCounter = 0;
+	DelayLen = delayLen;
+	GameTicksSinceSequenceStarted = 0;
+	RelevantFramesForDistributing = 0;
+	GameTickModifier = 0.0f;
+
+	if (numSkippedFrames != 0 || params != AnimationDistributionParams::None) {
+		// Animation Frames that will be adjusted for the skipped Frames/GameTicks
+		int relevantAnimationFramesForDistributing = numberOfFrames;
+		if (distributeFramesBeforeFrame != 0) {
+			// After an attack hits (_pAFNum or _pSFNum) it can be canceled or another attack can be queued and this means the animation is canceled.
+			// In normal attacks frame skipping always happens before the attack actual hit.
+			// This has the advantage that the sword or bow always points to the enemy when the hit happens (_pAFNum or _pSFNum).
+			// Our distribution logic must also regard this behaviour, so we are not allowed to distribute the skipped animations after the actual hit (_pAnimStopDistributingAfterFrame).
+			relevantAnimationFramesForDistributing = distributeFramesBeforeFrame - 1;
+		}
+
+		// How many GameTicks are needed to advance one Animation Frame
+		int gameTicksPerFrame = (delayLen + 1);
+
+		// GameTicks that will be adjusted for the skipped Frames/GameTicks
+		int relevantAnimationGameTicksForDistribution = relevantAnimationFramesForDistributing * gameTicksPerFrame;
+
+		// How many GameTicks will the Animation be really shown (skipped Frames and GameTicks removed)
+		int relevantAnimationGameTicksWithSkipping = relevantAnimationGameTicksForDistribution - (numSkippedFrames * gameTicksPerFrame);
+
+		if (params == AnimationDistributionParams::ProcessAnimationPending) {
+			// If ProcessAnimation will be called after SetNewAnimation (in same GameTick as NewPlrAnim), we increment the Animation-Counter.
+			// If no delay is specified, this will result in complete skipped frame (see ProcessPlayerAnimation).
+			// But if we have a delay specified, this would only result in a reduced time the first frame is shown (one skipped delay).
+			// Because of that, we only the remove one GameTick from the time the Animation is shown
+			relevantAnimationGameTicksWithSkipping -= 1;
+			// The Animation Distribution Logic needs to account how many GameTicks passed since the Animation started.
+			// Because ProcessAnimation will increase this later (in same GameTick as SetNewAnimation), we correct this upfront.
+			// This also means Rendering should never hapen with GameTicksSinceSequenceStarted < 0.
+			GameTicksSinceSequenceStarted = -1;
+		}
+
+		if (params == AnimationDistributionParams::SkipsDelayOfLastFrame) {
+			// The logic for player/monster/... (not ProcessAnimation) only checks the frame not the delay.
+			// That means if a delay is specified, the last-frame is shown less then the other frames
+			// Example:
+			// If we have a animation with 3 frames and with a delay of 1 (gameTicksPerFrame = 2).
+			// The logic checks "if (frame == 3) { start_new_animation(); }"
+			// This will result that frame 4 is the last shown Animation Frame.
+			// GameTick		Frame		Cnt
+			// 1			1			0
+			// 2			1			1
+			// 3			2			0
+			// 3			2			1
+			// 4			3			0
+			// 5			-			-
+			// in GameTick 5 ProcessPlayer sees Frame = 3 and stops the animation.
+			// But Frame 3 is only shown 1 GameTick and all other Frames are shown 2 GameTicks.
+			// Thats why we need to remove the Delay of the last Frame from the time (GameTicks) the Animation is shown
+			relevantAnimationGameTicksWithSkipping -= delayLen;
+		}
+
+		// if we skipped Frames we need to expand the GameTicks to make one GameTick for this Animation "faster"
+		float gameTickModifier = (float)relevantAnimationGameTicksForDistribution / (float)relevantAnimationGameTicksWithSkipping;
+
+		// gameTickModifier specifies the Animation fraction per GameTick, so we have to remove the delay from the variable
+		gameTickModifier /= gameTicksPerFrame;
+
+		RelevantFramesForDistributing = relevantAnimationFramesForDistributing;
+		GameTickModifier = gameTickModifier;
+	}
+}
+
 } // namespace devilution

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -11,35 +11,32 @@
 
 namespace devilution {
 
-int AnimationInfo::GetFrameToUseForRendering()
+int AnimationInfo::GetFrameToUseForRendering() const
 {
 	// Normal logic is used,
 	// - if no frame-skipping is required and so we have exactly one Animationframe per GameTick
 	// or
 	// - if we load from a savegame where the new variables are not stored (we don't want to break savegame compatiblity because of smoother rendering of one animation)
-	int relevantAnimationFramesForDistributing = RelevantFramesForDistributing;
-	if (relevantAnimationFramesForDistributing <= 0)
+	if (RelevantFramesForDistributing <= 0)
 		return CurrentFrame;
 
-	if (CurrentFrame > relevantAnimationFramesForDistributing)
+	if (CurrentFrame > RelevantFramesForDistributing)
 		return CurrentFrame;
 
 	assert(GameTicksSinceSequenceStarted >= 0);
 
-	float progressToNextGameTick = gfProgressToNextGameTick;
-
 	// we don't use the processed game ticks alone but also the fragtion of the next game tick (if a rendering happens between game ticks). This helps to smooth the animations.
-	float totalGameTicksForCurrentAnimationSequence = progressToNextGameTick + (float)GameTicksSinceSequenceStarted;
+	float totalGameTicksForCurrentAnimationSequence = gfProgressToNextGameTick + (float)GameTicksSinceSequenceStarted;
 
 	// 1 added for rounding reasons. float to int cast always truncate.
 	int absoluteAnimationFrame = 1 + (int)(totalGameTicksForCurrentAnimationSequence * GameTickModifier);
-	if (absoluteAnimationFrame > relevantAnimationFramesForDistributing) {
+	if (absoluteAnimationFrame > RelevantFramesForDistributing) {
 		// this can happen if we are at the last frame and the next game tick is due (nthread_GetProgressToNextGameTick returns 1.0f)
-		if (absoluteAnimationFrame > (relevantAnimationFramesForDistributing + 1)) {
+		if (absoluteAnimationFrame > (RelevantFramesForDistributing + 1)) {
 			// we should never have +2 frames even if next game tick is due
-			Log("GetFrameToUseForRendering: Calculated an invalid Animation Frame (Calculated {} MaxFrame {})", absoluteAnimationFrame, relevantAnimationFramesForDistributing);
+			Log("GetFrameToUseForRendering: Calculated an invalid Animation Frame (Calculated {} MaxFrame {})", absoluteAnimationFrame, RelevantFramesForDistributing);
 		}
-		return relevantAnimationFramesForDistributing;
+		return RelevantFramesForDistributing;
 	}
 	if (absoluteAnimationFrame <= 0) {
 		Log("GetFrameToUseForRendering: Calculated an invalid Animation Frame (Calculated {})", absoluteAnimationFrame);

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -68,6 +68,12 @@ public:
 	void SetNewAnimation(uint8_t *pData, int numberOfFrames, int delayLen, AnimationDistributionParams params = AnimationDistributionParams::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
 
 	/*
+	* @brief Process the Animation for a GameTick (for example advances the frame)
+	*/
+	void ProcessAnimation();
+
+private:
+	/*
 	* @brief Specifies how many animations-fractions are displayed between two gameticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
 	*/
 	float GameTickModifier;

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -54,7 +54,7 @@ public:
 	 * @brief Calculates the Frame to use for the Animation rendering
 	 * @return The Frame to use for rendering
 	 */
-	int GetFrameToUseForRendering();
+	int GetFrameToUseForRendering() const;
 
 	/**
 	 * @brief Sets the new Animation with all relevant information for rendering

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -15,7 +15,7 @@ namespace devilution {
 enum class AnimationDistributionParams : uint8_t {
 	None,
 	/*
-	* @brief ProcessAnimation will be called after SetNewAnimation (in same GameTick as NewPlrAnim)
+	* @brief ProcessAnimation will be called after SetNewAnimation (in same game tick as NewPlrAnim)
 	*/
 	ProcessAnimationPending,
 	/*
@@ -68,21 +68,21 @@ public:
 	void SetNewAnimation(uint8_t *pData, int numberOfFrames, int delayLen, AnimationDistributionParams params = AnimationDistributionParams::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
 
 	/*
-	* @brief Process the Animation for a GameTick (for example advances the frame)
+	* @brief Process the Animation for a game tick (for example advances the frame)
 	*/
 	void ProcessAnimation();
 
 private:
 	/*
-	* @brief Specifies how many animations-fractions are displayed between two gameticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
+	* @brief Specifies how many animations-fractions are displayed between two game ticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
 	*/
-	float GameTickModifier;
+	float TickModifier;
 	/*
-	* @brief Number of GameTicks after the current animation sequence started
+	* @brief Number of game ticks after the current animation sequence started
 	*/
-	int GameTicksSinceSequenceStarted;
+	int TicksSinceSequenceStarted;
 	/*
-	* @brief Animation Frames that will be adjusted for the skipped Frames/GameTicks
+	* @brief Animation Frames that will be adjusted for the skipped Frames/game ticks
 	*/
 	int RelevantFramesForDistributing;
 };

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -34,6 +34,13 @@ public:
 	* @brief Current frame of animation
 	*/
 	int CurrentFrame;
+
+	/**
+	 * @brief Calculates the Frame to use for the Animation rendering
+	 * @return The Frame to use for rendering
+	 */
+	int GetFrameToUseForRendering();
+
 	/*
 	* @brief Specifies how many animations-fractions are displayed between two gameticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
 	*/

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -9,6 +9,21 @@
 
 namespace devilution {
 
+/**
+ * @brief Specifies what special logics are applied for a Animation
+ */
+enum class AnimationDistributionParams : uint8_t {
+	None,
+	/*
+	* @brief ProcessAnimation will be called after SetNewAnimation (in same GameTick as NewPlrAnim)
+	*/
+	ProcessAnimationPending,
+	/*
+	* @brief Delay of last Frame is ignored (for example, because only Frame and not delay is checked in game_logic)
+	*/
+	SkipsDelayOfLastFrame,
+};
+
 /*
 * @brief Contains the core animation information and related logic
 */
@@ -29,7 +44,7 @@ public:
 	/*
 	* @brief Number of frames in current animation
 	*/
-	int FrameLen;
+	int NumberOfFrames;
 	/*
 	* @brief Current frame of animation
 	*/
@@ -40,6 +55,17 @@ public:
 	 * @return The Frame to use for rendering
 	 */
 	int GetFrameToUseForRendering();
+
+	/**
+	 * @brief Sets the new Animation with all relevant information for rendering
+	 * @param pData Pointer to Animation Data
+	 * @param numberOfFrames Number of Frames in Animation
+	 * @param delayLen Delay after each Animation sequence
+	 * @param params Specifies what special logics are applied to this Animation
+	 * @param numSkippedFrames Number of Frames that will be skipped (for example with modifier "faster attack")
+	 * @param distributeFramesBeforeFrame Distribute the numSkippedFrames only before this frame
+	 */
+	void SetNewAnimation(uint8_t *pData, int numberOfFrames, int delayLen, AnimationDistributionParams params = AnimationDistributionParams::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
 
 	/*
 	* @brief Specifies how many animations-fractions are displayed between two gameticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -17,35 +17,35 @@ public:
 	/*
 	* @brief Pointer to Animation Data
 	*/
-	uint8_t *_pAnimData;
+	uint8_t *pData;
 	/*
 	* @brief Additional delay of each animation in the current animation
 	*/
-	int _pAnimDelay;
+	int DelayLen;
 	/*
-	* @brief Increases by one each game tick, counting how close we are to _pAnimDelay
+	* @brief Increases by one each game tick, counting how close we are to DelayLen
 	*/
-	int _pAnimCnt;
+	int DelayCounter;
 	/*
 	* @brief Number of frames in current animation
 	*/
-	int _pAnimLen;
+	int FrameLen;
 	/*
 	* @brief Current frame of animation
 	*/
-	int _pAnimFrame;
+	int CurrentFrame;
 	/*
 	* @brief Specifies how many animations-fractions are displayed between two gameticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
 	*/
-	float _pAnimGameTickModifier;
+	float GameTickModifier;
 	/*
 	* @brief Number of GameTicks after the current animation sequence started
 	*/
-	int _pAnimGameTicksSinceSequenceStarted;
+	int GameTicksSinceSequenceStarted;
 	/*
 	* @brief Animation Frames that will be adjusted for the skipped Frames/GameTicks
 	*/
-	int _pAnimRelevantAnimationFramesForDistributing;
+	int RelevantFramesForDistributing;
 };
 
 } // namespace devilution

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -1,0 +1,51 @@
+/**
+ * @file animationinfo.h
+ *
+ * Contains the core animation information and related logic
+ */
+#pragma once
+
+#include <stdint.h>
+
+namespace devilution {
+
+/*
+* @brief Contains the core animation information and related logic
+*/
+class AnimationInfo {
+public:
+	/*
+	* @brief Pointer to Animation Data
+	*/
+	uint8_t *_pAnimData;
+	/*
+	* @brief Additional delay of each animation in the current animation
+	*/
+	int _pAnimDelay;
+	/*
+	* @brief Increases by one each game tick, counting how close we are to _pAnimDelay
+	*/
+	int _pAnimCnt;
+	/*
+	* @brief Number of frames in current animation
+	*/
+	int _pAnimLen;
+	/*
+	* @brief Current frame of animation
+	*/
+	int _pAnimFrame;
+	/*
+	* @brief Specifies how many animations-fractions are displayed between two gameticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
+	*/
+	float _pAnimGameTickModifier;
+	/*
+	* @brief Number of GameTicks after the current animation sequence started
+	*/
+	int _pAnimGameTicksSinceSequenceStarted;
+	/*
+	* @brief Animation Frames that will be adjusted for the skipped Frames/GameTicks
+	*/
+	int _pAnimRelevantAnimationFramesForDistributing;
+};
+
+} // namespace devilution

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -345,7 +345,7 @@ static void LoadPlayer(LoadHelper *file, int p)
 	file->skip(4); // Skip pointer pData
 	pPlayer->AnimInfo.DelayLen = file->nextLE<int32_t>();
 	pPlayer->AnimInfo.DelayCounter = file->nextLE<int32_t>();
-	pPlayer->AnimInfo.FrameLen = file->nextLE<int32_t>();
+	pPlayer->AnimInfo.NumberOfFrames = file->nextLE<int32_t>();
 	pPlayer->AnimInfo.CurrentFrame = file->nextLE<int32_t>();
 	pPlayer->_pAnimWidth = file->nextLE<int32_t>();
 	// Skip _pAnimWidth2
@@ -1329,7 +1329,7 @@ static void SavePlayer(SaveHelper *file, int p)
 	file->skip(4); // Skip pointer _pAnimData
 	file->writeLE<int32_t>(pPlayer->AnimInfo.DelayLen);
 	file->writeLE<int32_t>(pPlayer->AnimInfo.DelayCounter);
-	file->writeLE<int32_t>(pPlayer->AnimInfo.FrameLen);
+	file->writeLE<int32_t>(pPlayer->AnimInfo.NumberOfFrames);
 	file->writeLE<int32_t>(pPlayer->AnimInfo.CurrentFrame);
 	file->writeLE<int32_t>(pPlayer->_pAnimWidth);
 	// write _pAnimWidth2 for vanilla compatibility

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -342,11 +342,11 @@ static void LoadPlayer(LoadHelper *file, int p)
 	pPlayer->_pdir = static_cast<direction>(file->nextLE<int32_t>());
 	file->skip(4); // Unused
 	pPlayer->_pgfxnum = file->nextLE<int32_t>();
-	file->skip(4); // Skip pointer _pAnimData
-	pPlayer->AnimInfo._pAnimDelay = file->nextLE<int32_t>();
-	pPlayer->AnimInfo._pAnimCnt = file->nextLE<int32_t>();
-	pPlayer->AnimInfo._pAnimLen = file->nextLE<int32_t>();
-	pPlayer->AnimInfo._pAnimFrame = file->nextLE<int32_t>();
+	file->skip(4); // Skip pointer pData
+	pPlayer->AnimInfo.DelayLen = file->nextLE<int32_t>();
+	pPlayer->AnimInfo.DelayCounter = file->nextLE<int32_t>();
+	pPlayer->AnimInfo.FrameLen = file->nextLE<int32_t>();
+	pPlayer->AnimInfo.CurrentFrame = file->nextLE<int32_t>();
 	pPlayer->_pAnimWidth = file->nextLE<int32_t>();
 	// Skip _pAnimWidth2
 	file->skip(4);
@@ -1327,10 +1327,10 @@ static void SavePlayer(SaveHelper *file, int p)
 	file->skip(4); // Unused
 	file->writeLE<int32_t>(pPlayer->_pgfxnum);
 	file->skip(4); // Skip pointer _pAnimData
-	file->writeLE<int32_t>(pPlayer->AnimInfo._pAnimDelay);
-	file->writeLE<int32_t>(pPlayer->AnimInfo._pAnimCnt);
-	file->writeLE<int32_t>(pPlayer->AnimInfo._pAnimLen);
-	file->writeLE<int32_t>(pPlayer->AnimInfo._pAnimFrame);
+	file->writeLE<int32_t>(pPlayer->AnimInfo.DelayLen);
+	file->writeLE<int32_t>(pPlayer->AnimInfo.DelayCounter);
+	file->writeLE<int32_t>(pPlayer->AnimInfo.FrameLen);
+	file->writeLE<int32_t>(pPlayer->AnimInfo.CurrentFrame);
 	file->writeLE<int32_t>(pPlayer->_pAnimWidth);
 	// write _pAnimWidth2 for vanilla compatibility
 	file->writeLE<int32_t>(CalculateWidth2(pPlayer->_pAnimWidth));

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -343,10 +343,10 @@ static void LoadPlayer(LoadHelper *file, int p)
 	file->skip(4); // Unused
 	pPlayer->_pgfxnum = file->nextLE<int32_t>();
 	file->skip(4); // Skip pointer _pAnimData
-	pPlayer->_pAnimDelay = file->nextLE<int32_t>();
-	pPlayer->_pAnimCnt = file->nextLE<int32_t>();
-	pPlayer->_pAnimLen = file->nextLE<int32_t>();
-	pPlayer->_pAnimFrame = file->nextLE<int32_t>();
+	pPlayer->AnimInfo._pAnimDelay = file->nextLE<int32_t>();
+	pPlayer->AnimInfo._pAnimCnt = file->nextLE<int32_t>();
+	pPlayer->AnimInfo._pAnimLen = file->nextLE<int32_t>();
+	pPlayer->AnimInfo._pAnimFrame = file->nextLE<int32_t>();
 	pPlayer->_pAnimWidth = file->nextLE<int32_t>();
 	// Skip _pAnimWidth2
 	file->skip(4);
@@ -1327,10 +1327,10 @@ static void SavePlayer(SaveHelper *file, int p)
 	file->skip(4); // Unused
 	file->writeLE<int32_t>(pPlayer->_pgfxnum);
 	file->skip(4); // Skip pointer _pAnimData
-	file->writeLE<int32_t>(pPlayer->_pAnimDelay);
-	file->writeLE<int32_t>(pPlayer->_pAnimCnt);
-	file->writeLE<int32_t>(pPlayer->_pAnimLen);
-	file->writeLE<int32_t>(pPlayer->_pAnimFrame);
+	file->writeLE<int32_t>(pPlayer->AnimInfo._pAnimDelay);
+	file->writeLE<int32_t>(pPlayer->AnimInfo._pAnimCnt);
+	file->writeLE<int32_t>(pPlayer->AnimInfo._pAnimLen);
+	file->writeLE<int32_t>(pPlayer->AnimInfo._pAnimFrame);
 	file->writeLE<int32_t>(pPlayer->_pAnimWidth);
 	// write _pAnimWidth2 for vanilla compatibility
 	file->writeLE<int32_t>(CalculateWidth2(pPlayer->_pAnimWidth));

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2235,8 +2235,8 @@ static DWORD On_PLAYER_JOINLEVEL(TCmd *pCmd, int pnum)
 					LoadPlrGFX(pnum, PFILE_DEATH);
 					plr[pnum]._pmode = PM_DEATH;
 					NewPlrAnim(pnum, plr[pnum]._pDAnim[DIR_S], plr[pnum]._pDFrames, 1, plr[pnum]._pDWidth);
-					plr[pnum].AnimInfo._pAnimFrame = plr[pnum].AnimInfo._pAnimLen - 1;
-					plr[pnum].actionFrame = plr[pnum].AnimInfo._pAnimLen * 2;
+					plr[pnum].AnimInfo.CurrentFrame = plr[pnum].AnimInfo.FrameLen - 1;
+					plr[pnum].actionFrame = plr[pnum].AnimInfo.FrameLen * 2;
 					dFlags[plr[pnum].position.tile.x][plr[pnum].position.tile.y] |= BFLAG_DEAD_PLAYER;
 				}
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2235,8 +2235,8 @@ static DWORD On_PLAYER_JOINLEVEL(TCmd *pCmd, int pnum)
 					LoadPlrGFX(pnum, PFILE_DEATH);
 					plr[pnum]._pmode = PM_DEATH;
 					NewPlrAnim(pnum, plr[pnum]._pDAnim[DIR_S], plr[pnum]._pDFrames, 1, plr[pnum]._pDWidth);
-					plr[pnum]._pAnimFrame = plr[pnum]._pAnimLen - 1;
-					plr[pnum].actionFrame = plr[pnum]._pAnimLen * 2;
+					plr[pnum].AnimInfo._pAnimFrame = plr[pnum].AnimInfo._pAnimLen - 1;
+					plr[pnum].actionFrame = plr[pnum].AnimInfo._pAnimLen * 2;
 					dFlags[plr[pnum].position.tile.x][plr[pnum].position.tile.y] |= BFLAG_DEAD_PLAYER;
 				}
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2235,8 +2235,8 @@ static DWORD On_PLAYER_JOINLEVEL(TCmd *pCmd, int pnum)
 					LoadPlrGFX(pnum, PFILE_DEATH);
 					plr[pnum]._pmode = PM_DEATH;
 					NewPlrAnim(pnum, plr[pnum]._pDAnim[DIR_S], plr[pnum]._pDFrames, 1, plr[pnum]._pDWidth);
-					plr[pnum].AnimInfo.CurrentFrame = plr[pnum].AnimInfo.FrameLen - 1;
-					plr[pnum].actionFrame = plr[pnum].AnimInfo.FrameLen * 2;
+					plr[pnum].AnimInfo.CurrentFrame = plr[pnum].AnimInfo.NumberOfFrames - 1;
+					plr[pnum].actionFrame = plr[pnum].AnimInfo.NumberOfFrames * 2;
 					dFlags[plr[pnum].position.tile.x][plr[pnum].position.tile.y] |= BFLAG_DEAD_PLAYER;
 				}
 

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -880,8 +880,8 @@ void recv_plrinfo(int pnum, TCmdPlrInfoHdr *p, bool recv)
 			LoadPlrGFX(pnum, PFILE_DEATH);
 			plr[pnum]._pmode = PM_DEATH;
 			NewPlrAnim(pnum, plr[pnum]._pDAnim[DIR_S], plr[pnum]._pDFrames, 1, plr[pnum]._pDWidth);
-			plr[pnum].AnimInfo._pAnimFrame = plr[pnum].AnimInfo._pAnimLen - 1;
-			plr[pnum].actionFrame = 2 * plr[pnum].AnimInfo._pAnimLen;
+			plr[pnum].AnimInfo.CurrentFrame = plr[pnum].AnimInfo.FrameLen - 1;
+			plr[pnum].actionFrame = 2 * plr[pnum].AnimInfo.FrameLen;
 			dFlags[plr[pnum].position.tile.x][plr[pnum].position.tile.y] |= BFLAG_DEAD_PLAYER;
 		}
 	}

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -880,8 +880,8 @@ void recv_plrinfo(int pnum, TCmdPlrInfoHdr *p, bool recv)
 			LoadPlrGFX(pnum, PFILE_DEATH);
 			plr[pnum]._pmode = PM_DEATH;
 			NewPlrAnim(pnum, plr[pnum]._pDAnim[DIR_S], plr[pnum]._pDFrames, 1, plr[pnum]._pDWidth);
-			plr[pnum].AnimInfo.CurrentFrame = plr[pnum].AnimInfo.FrameLen - 1;
-			plr[pnum].actionFrame = 2 * plr[pnum].AnimInfo.FrameLen;
+			plr[pnum].AnimInfo.CurrentFrame = plr[pnum].AnimInfo.NumberOfFrames - 1;
+			plr[pnum].actionFrame = 2 * plr[pnum].AnimInfo.NumberOfFrames;
 			dFlags[plr[pnum].position.tile.x][plr[pnum].position.tile.y] |= BFLAG_DEAD_PLAYER;
 		}
 	}

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -880,8 +880,8 @@ void recv_plrinfo(int pnum, TCmdPlrInfoHdr *p, bool recv)
 			LoadPlrGFX(pnum, PFILE_DEATH);
 			plr[pnum]._pmode = PM_DEATH;
 			NewPlrAnim(pnum, plr[pnum]._pDAnim[DIR_S], plr[pnum]._pDFrames, 1, plr[pnum]._pDWidth);
-			plr[pnum]._pAnimFrame = plr[pnum]._pAnimLen - 1;
-			plr[pnum].actionFrame = 2 * plr[pnum]._pAnimLen;
+			plr[pnum].AnimInfo._pAnimFrame = plr[pnum].AnimInfo._pAnimLen - 1;
+			plr[pnum].actionFrame = 2 * plr[pnum].AnimInfo._pAnimLen;
 			dFlags[plr[pnum].position.tile.x][plr[pnum].position.tile.y] |= BFLAG_DEAD_PLAYER;
 		}
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3637,21 +3637,7 @@ void ProcessPlayers()
 				CheckNewPath(pnum);
 			} while (tplayer);
 
-			ProcessPlayerAnimation(pnum);
-		}
-	}
-}
-
-void ProcessPlayerAnimation(int pnum)
-{
-	plr[pnum].AnimInfo.DelayCounter++;
-	plr[pnum].AnimInfo.GameTicksSinceSequenceStarted++;
-	if (plr[pnum].AnimInfo.DelayCounter > plr[pnum].AnimInfo.DelayLen) {
-		plr[pnum].AnimInfo.DelayCounter = 0;
-		plr[pnum].AnimInfo.CurrentFrame++;
-		if (plr[pnum].AnimInfo.CurrentFrame > plr[pnum].AnimInfo.FrameLen) {
-			plr[pnum].AnimInfo.CurrentFrame = 1;
-			plr[pnum].AnimInfo.GameTicksSinceSequenceStarted = 0;
+			plr[pnum].AnimInfo.ProcessAnimation();
 		}
 	}
 }

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -544,15 +544,15 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, Animat
 		app_fatal("NewPlrAnim: illegal player %d", pnum);
 	}
 
-	plr[pnum]._pAnimData = Peq;
-	plr[pnum]._pAnimLen = numFrames;
-	plr[pnum]._pAnimFrame = 1;
-	plr[pnum]._pAnimCnt = 0;
-	plr[pnum]._pAnimDelay = Delay;
+	plr[pnum].AnimInfo._pAnimData = Peq;
+	plr[pnum].AnimInfo._pAnimLen = numFrames;
+	plr[pnum].AnimInfo._pAnimFrame = 1;
+	plr[pnum].AnimInfo._pAnimCnt = 0;
+	plr[pnum].AnimInfo._pAnimDelay = Delay;
 	plr[pnum]._pAnimWidth = width;
-	plr[pnum]._pAnimGameTicksSinceSequenceStarted = 0;
-	plr[pnum]._pAnimRelevantAnimationFramesForDistributing = 0;
-	plr[pnum]._pAnimGameTickModifier = 0.0f;
+	plr[pnum].AnimInfo._pAnimGameTicksSinceSequenceStarted = 0;
+	plr[pnum].AnimInfo._pAnimRelevantAnimationFramesForDistributing = 0;
+	plr[pnum].AnimInfo._pAnimGameTickModifier = 0.0f;
 
 	if (numSkippedFrames != 0 || params != AnimationDistributionParams::None) {
 		// Animation Frames that will be adjusted for the skipped Frames/GameTicks
@@ -583,7 +583,7 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, Animat
 			// The Animation Distribution Logic needs to account how many GameTicks passed since the Animation started.
 			// Because ProcessAnimation will increase this later (in same GameTick as NewPlrAnim), we correct this upfront.
 			// This also means Rendering should never hapen with _pAnimGameTicksSinceSequenceStarted < 0.
-			plr[pnum]._pAnimGameTicksSinceSequenceStarted = -1;
+			plr[pnum].AnimInfo._pAnimGameTicksSinceSequenceStarted = -1;
 		}
 
 		if (params == AnimationDistributionParams::SkipsDelayOfLastFrame) {
@@ -612,8 +612,8 @@ void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, Animat
 		// gameTickModifier specifies the Animation fraction per GameTick, so we have to remove the delay from the variable
 		gameTickModifier /= gameTicksPerFrame;
 
-		plr[pnum]._pAnimRelevantAnimationFramesForDistributing = relevantAnimationFramesForDistributing;
-		plr[pnum]._pAnimGameTickModifier = gameTickModifier;
+		plr[pnum].AnimInfo._pAnimRelevantAnimationFramesForDistributing = relevantAnimationFramesForDistributing;
+		plr[pnum].AnimInfo._pAnimGameTickModifier = gameTickModifier;
 	}
 }
 
@@ -1135,13 +1135,13 @@ void InitPlayer(int pnum, bool FirstTime)
 		if (plr[pnum]._pHitPoints >> 6 > 0) {
 			plr[pnum]._pmode = PM_STAND;
 			NewPlrAnim(pnum, plr[pnum]._pNAnim[DIR_S], plr[pnum]._pNFrames, 3, plr[pnum]._pNWidth);
-			plr[pnum]._pAnimFrame = GenerateRnd(plr[pnum]._pNFrames - 1) + 1;
-			plr[pnum]._pAnimCnt = GenerateRnd(3);
+			plr[pnum].AnimInfo._pAnimFrame = GenerateRnd(plr[pnum]._pNFrames - 1) + 1;
+			plr[pnum].AnimInfo._pAnimCnt = GenerateRnd(3);
 		} else {
 			plr[pnum]._pmode = PM_DEATH;
 			NewPlrAnim(pnum, plr[pnum]._pDAnim[DIR_S], plr[pnum]._pDFrames, 1, plr[pnum]._pDWidth);
-			plr[pnum]._pAnimFrame = plr[pnum]._pAnimLen - 1;
-			plr[pnum].actionFrame = 2 * plr[pnum]._pAnimLen;
+			plr[pnum].AnimInfo._pAnimFrame = plr[pnum].AnimInfo._pAnimLen - 1;
+			plr[pnum].actionFrame = 2 * plr[pnum].AnimInfo._pAnimLen;
 		}
 
 		plr[pnum]._pdir = DIR_S;
@@ -2275,21 +2275,21 @@ bool PM_DoWalk(int pnum, int variant)
 
 	//Play walking sound effect on certain animation frames
 	if (sgOptions.Audio.bWalkingSound) {
-		if (plr[pnum]._pAnimFrame == 3
-		    || (plr[pnum]._pWFrames == 8 && plr[pnum]._pAnimFrame == 7)
-		    || (plr[pnum]._pWFrames != 8 && plr[pnum]._pAnimFrame == 4)) {
+		if (plr[pnum].AnimInfo._pAnimFrame == 3
+		    || (plr[pnum]._pWFrames == 8 && plr[pnum].AnimInfo._pAnimFrame == 7)
+		    || (plr[pnum]._pWFrames != 8 && plr[pnum].AnimInfo._pAnimFrame == 4)) {
 			PlaySfxLoc(PS_WALK1, plr[pnum].position.tile.x, plr[pnum].position.tile.y);
 		}
 	}
 
 	//"Jog" in town which works by doubling movement speed and skipping every other animation frame
 	if (currlevel == 0 && sgGameInitInfo.bRunInTown) {
-		if (plr[pnum]._pAnimFrame % 2 == 0) {
-			plr[pnum]._pAnimFrame++;
+		if (plr[pnum].AnimInfo._pAnimFrame % 2 == 0) {
+			plr[pnum].AnimInfo._pAnimFrame++;
 			plr[pnum].actionFrame++;
 		}
-		if (plr[pnum]._pAnimFrame >= plr[pnum]._pWFrames) {
-			plr[pnum]._pAnimFrame = 0;
+		if (plr[pnum].AnimInfo._pAnimFrame >= plr[pnum]._pWFrames) {
+			plr[pnum].AnimInfo._pAnimFrame = 0;
 		}
 	}
 
@@ -2799,24 +2799,24 @@ bool PM_DoAttack(int pnum)
 		app_fatal("PM_DoAttack: illegal player %d", pnum);
 	}
 
-	frame = plr[pnum]._pAnimFrame;
+	frame = plr[pnum].AnimInfo._pAnimFrame;
 	if (plr[pnum]._pIFlags & ISPL_QUICKATTACK && frame == 1) {
-		plr[pnum]._pAnimFrame++;
+		plr[pnum].AnimInfo._pAnimFrame++;
 	}
 	if (plr[pnum]._pIFlags & ISPL_FASTATTACK && (frame == 1 || frame == 3)) {
-		plr[pnum]._pAnimFrame++;
+		plr[pnum].AnimInfo._pAnimFrame++;
 	}
 	if (plr[pnum]._pIFlags & ISPL_FASTERATTACK && (frame == 1 || frame == 3 || frame == 5)) {
-		plr[pnum]._pAnimFrame++;
+		plr[pnum].AnimInfo._pAnimFrame++;
 	}
 	if (plr[pnum]._pIFlags & ISPL_FASTESTATTACK && (frame == 1 || frame == 4)) {
-		plr[pnum]._pAnimFrame += 2;
+		plr[pnum].AnimInfo._pAnimFrame += 2;
 	}
-	if (plr[pnum]._pAnimFrame == plr[pnum]._pAFNum - 1) {
+	if (plr[pnum].AnimInfo._pAnimFrame == plr[pnum]._pAFNum - 1) {
 		PlaySfxLoc(PS_SWING, plr[pnum].position.tile.x, plr[pnum].position.tile.y);
 	}
 
-	if (plr[pnum]._pAnimFrame == plr[pnum]._pAFNum) {
+	if (plr[pnum].AnimInfo._pAnimFrame == plr[pnum]._pAFNum) {
 		dx = plr[pnum].position.tile.x + offset_x[plr[pnum]._pdir];
 		dy = plr[pnum].position.tile.y + offset_y[plr[pnum]._pdir];
 
@@ -2893,7 +2893,7 @@ bool PM_DoAttack(int pnum)
 		}
 	}
 
-	if (plr[pnum]._pAnimFrame == plr[pnum]._pAFrames) {
+	if (plr[pnum].AnimInfo._pAnimFrame == plr[pnum]._pAFrames) {
 		StartStand(pnum, plr[pnum]._pdir);
 		ClearPlrPVars(pnum);
 		return true;
@@ -2910,20 +2910,20 @@ bool PM_DoRangeAttack(int pnum)
 	}
 
 	if (!gbIsHellfire) {
-		origFrame = plr[pnum]._pAnimFrame;
+		origFrame = plr[pnum].AnimInfo._pAnimFrame;
 		if (plr[pnum]._pIFlags & ISPL_QUICKATTACK && origFrame == 1) {
-			plr[pnum]._pAnimFrame++;
+			plr[pnum].AnimInfo._pAnimFrame++;
 		}
 		if (plr[pnum]._pIFlags & ISPL_FASTATTACK && (origFrame == 1 || origFrame == 3)) {
-			plr[pnum]._pAnimFrame++;
+			plr[pnum].AnimInfo._pAnimFrame++;
 		}
 	}
 
 	int arrows = 0;
-	if (plr[pnum]._pAnimFrame == plr[pnum]._pAFNum) {
+	if (plr[pnum].AnimInfo._pAnimFrame == plr[pnum]._pAFNum) {
 		arrows = 1;
 	}
-	if ((plr[pnum]._pIFlags & ISPL_MULT_ARROWS) != 0 && plr[pnum]._pAnimFrame == plr[pnum]._pAFNum + 2) {
+	if ((plr[pnum]._pIFlags & ISPL_MULT_ARROWS) != 0 && plr[pnum].AnimInfo._pAnimFrame == plr[pnum]._pAFNum + 2) {
 		arrows = 2;
 	}
 
@@ -2976,7 +2976,7 @@ bool PM_DoRangeAttack(int pnum)
 		}
 	}
 
-	if (plr[pnum]._pAnimFrame >= plr[pnum]._pAFrames) {
+	if (plr[pnum].AnimInfo._pAnimFrame >= plr[pnum]._pAFrames) {
 		StartStand(pnum, plr[pnum]._pdir);
 		ClearPlrPVars(pnum);
 		return true;
@@ -3025,11 +3025,11 @@ bool PM_DoBlock(int pnum)
 		app_fatal("PM_DoBlock: illegal player %d", pnum);
 	}
 
-	if (plr[pnum]._pIFlags & ISPL_FASTBLOCK && plr[pnum]._pAnimFrame != 1) {
-		plr[pnum]._pAnimFrame = plr[pnum]._pBFrames;
+	if (plr[pnum]._pIFlags & ISPL_FASTBLOCK && plr[pnum].AnimInfo._pAnimFrame != 1) {
+		plr[pnum].AnimInfo._pAnimFrame = plr[pnum]._pBFrames;
 	}
 
-	if (plr[pnum]._pAnimFrame >= plr[pnum]._pBFrames) {
+	if (plr[pnum].AnimInfo._pAnimFrame >= plr[pnum]._pBFrames) {
 		StartStand(pnum, plr[pnum]._pdir);
 		ClearPlrPVars(pnum);
 
@@ -3121,7 +3121,7 @@ bool PM_DoSpell(int pnum)
 			ClearPlrPVars(pnum);
 			return true;
 		}
-	} else if (plr[pnum]._pAnimFrame == plr[pnum]._pSFrames) {
+	} else if (plr[pnum].AnimInfo._pAnimFrame == plr[pnum]._pSFrames) {
 		StartStand(pnum, plr[pnum]._pdir);
 		ClearPlrPVars(pnum);
 		return true;
@@ -3138,18 +3138,18 @@ bool PM_DoGotHit(int pnum)
 		app_fatal("PM_DoGotHit: illegal player %d", pnum);
 	}
 
-	frame = plr[pnum]._pAnimFrame;
+	frame = plr[pnum].AnimInfo._pAnimFrame;
 	if (plr[pnum]._pIFlags & ISPL_FASTRECOVER && frame == 3) {
-		plr[pnum]._pAnimFrame++;
+		plr[pnum].AnimInfo._pAnimFrame++;
 	}
 	if (plr[pnum]._pIFlags & ISPL_FASTERRECOVER && (frame == 3 || frame == 5)) {
-		plr[pnum]._pAnimFrame++;
+		plr[pnum].AnimInfo._pAnimFrame++;
 	}
 	if (plr[pnum]._pIFlags & ISPL_FASTESTRECOVER && (frame == 1 || frame == 3 || frame == 5)) {
-		plr[pnum]._pAnimFrame++;
+		plr[pnum].AnimInfo._pAnimFrame++;
 	}
 
-	if (plr[pnum]._pAnimFrame >= plr[pnum]._pHFrames) {
+	if (plr[pnum].AnimInfo._pAnimFrame >= plr[pnum]._pHFrames) {
 		StartStand(pnum, plr[pnum]._pdir);
 		ClearPlrPVars(pnum);
 		if (GenerateRnd(4) != 0) {
@@ -3179,8 +3179,8 @@ bool PM_DoDeath(int pnum)
 			}
 		}
 
-		plr[pnum]._pAnimDelay = 10000;
-		plr[pnum]._pAnimFrame = plr[pnum]._pAnimLen;
+		plr[pnum].AnimInfo._pAnimDelay = 10000;
+		plr[pnum].AnimInfo._pAnimFrame = plr[pnum].AnimInfo._pAnimLen;
 		dFlags[plr[pnum].position.tile.x][plr[pnum].position.tile.y] |= BFLAG_DEAD_PLAYER;
 	}
 
@@ -3437,7 +3437,7 @@ void CheckNewPath(int pnum)
 		return;
 	}
 
-	if (plr[pnum]._pmode == PM_ATTACK && plr[pnum]._pAnimFrame > plr[myplr]._pAFNum) {
+	if (plr[pnum]._pmode == PM_ATTACK && plr[pnum].AnimInfo._pAnimFrame > plr[myplr]._pAFNum) {
 		if (plr[pnum].destAction == ACTION_ATTACK) {
 			d = GetDirection(plr[pnum].position.future, { plr[pnum].destParam1, plr[pnum].destParam2 });
 			StartAttack(pnum, d);
@@ -3476,7 +3476,7 @@ void CheckNewPath(int pnum)
 		}
 	}
 
-	if (plr[pnum]._pmode == PM_RATTACK && plr[pnum]._pAnimFrame > plr[myplr]._pAFNum) {
+	if (plr[pnum]._pmode == PM_RATTACK && plr[pnum].AnimInfo._pAnimFrame > plr[myplr]._pAFNum) {
 		if (plr[pnum].destAction == ACTION_RATTACK) {
 			d = GetDirection(plr[pnum].position.tile, { plr[pnum].destParam1, plr[pnum].destParam2 });
 			StartRangeAttack(pnum, d, plr[pnum].destParam1, plr[pnum].destParam2);
@@ -3494,7 +3494,7 @@ void CheckNewPath(int pnum)
 		}
 	}
 
-	if (plr[pnum]._pmode == PM_SPELL && plr[pnum]._pAnimFrame > plr[pnum]._pSFNum) {
+	if (plr[pnum]._pmode == PM_SPELL && plr[pnum].AnimInfo._pAnimFrame > plr[pnum]._pSFNum) {
 		if (plr[pnum].destAction == ACTION_SPELL) {
 			d = GetDirection(plr[pnum].position.tile, { plr[pnum].destParam1, plr[pnum].destParam2 });
 			StartSpell(pnum, d, plr[pnum].destParam1, plr[pnum].destParam2);
@@ -3714,14 +3714,14 @@ void ProcessPlayers()
 
 void ProcessPlayerAnimation(int pnum)
 {
-	plr[pnum]._pAnimCnt++;
-	plr[pnum]._pAnimGameTicksSinceSequenceStarted++;
-	if (plr[pnum]._pAnimCnt > plr[pnum]._pAnimDelay) {
-		plr[pnum]._pAnimCnt = 0;
-		plr[pnum]._pAnimFrame++;
-		if (plr[pnum]._pAnimFrame > plr[pnum]._pAnimLen) {
-			plr[pnum]._pAnimFrame = 1;
-			plr[pnum]._pAnimGameTicksSinceSequenceStarted = 0;
+	plr[pnum].AnimInfo._pAnimCnt++;
+	plr[pnum].AnimInfo._pAnimGameTicksSinceSequenceStarted++;
+	if (plr[pnum].AnimInfo._pAnimCnt > plr[pnum].AnimInfo._pAnimDelay) {
+		plr[pnum].AnimInfo._pAnimCnt = 0;
+		plr[pnum].AnimInfo._pAnimFrame++;
+		if (plr[pnum].AnimInfo._pAnimFrame > plr[pnum].AnimInfo._pAnimLen) {
+			plr[pnum].AnimInfo._pAnimFrame = 1;
+			plr[pnum].AnimInfo._pAnimGameTicksSinceSequenceStarted = 0;
 		}
 	}
 }
@@ -3732,22 +3732,22 @@ int GetFrameToUseForPlayerRendering(const PlayerStruct *pPlayer)
 	// - if no frame-skipping is required and so we have exactly one Animationframe per GameTick
 	// or
 	// - if we load from a savegame where the new variables are not stored (we don't want to break savegame compatiblity because of smoother rendering of one animation)
-	int relevantAnimationFramesForDistributing = pPlayer->_pAnimRelevantAnimationFramesForDistributing;
+	int relevantAnimationFramesForDistributing = pPlayer->AnimInfo._pAnimRelevantAnimationFramesForDistributing;
 	if (relevantAnimationFramesForDistributing <= 0)
-		return pPlayer->_pAnimFrame;
+		return pPlayer->AnimInfo._pAnimFrame;
 
-	if (pPlayer->_pAnimFrame > relevantAnimationFramesForDistributing)
-		return pPlayer->_pAnimFrame;
+	if (pPlayer->AnimInfo._pAnimFrame > relevantAnimationFramesForDistributing)
+		return pPlayer->AnimInfo._pAnimFrame;
 
-	assert(pPlayer->_pAnimGameTicksSinceSequenceStarted >= 0);
+	assert(pPlayer->AnimInfo._pAnimGameTicksSinceSequenceStarted >= 0);
 
 	float progressToNextGameTick = gfProgressToNextGameTick;
 
 	// we don't use the processed game ticks alone but also the fragtion of the next game tick (if a rendering happens between game ticks). This helps to smooth the animations.
-	float totalGameTicksForCurrentAnimationSequence = progressToNextGameTick + (float)pPlayer->_pAnimGameTicksSinceSequenceStarted;
+	float totalGameTicksForCurrentAnimationSequence = progressToNextGameTick + (float)pPlayer->AnimInfo._pAnimGameTicksSinceSequenceStarted;
 
 	// 1 added for rounding reasons. float to int cast always truncate.
-	int absoluteAnimationFrame = 1 + (int)(totalGameTicksForCurrentAnimationSequence * pPlayer->_pAnimGameTickModifier);
+	int absoluteAnimationFrame = 1 + (int)(totalGameTicksForCurrentAnimationSequence * pPlayer->AnimInfo._pAnimGameTickModifier);
 	if (absoluteAnimationFrame > relevantAnimationFramesForDistributing) {
 		// this can happen if we are at the last frame and the next game tick is due (nthread_GetProgressToNextGameTick returns 1.0f)
 		if (absoluteAnimationFrame > (relevantAnimationFramesForDistributing + 1)) {
@@ -3966,21 +3966,21 @@ void SyncPlrAnim(int pnum)
 	dir = plr[pnum]._pdir;
 	switch (plr[pnum]._pmode) {
 	case PM_STAND:
-		plr[pnum]._pAnimData = plr[pnum]._pNAnim[dir];
+		plr[pnum].AnimInfo._pAnimData = plr[pnum]._pNAnim[dir];
 		break;
 	case PM_WALK:
 	case PM_WALK2:
 	case PM_WALK3:
-		plr[pnum]._pAnimData = plr[pnum]._pWAnim[dir];
+		plr[pnum].AnimInfo._pAnimData = plr[pnum]._pWAnim[dir];
 		break;
 	case PM_ATTACK:
-		plr[pnum]._pAnimData = plr[pnum]._pAAnim[dir];
+		plr[pnum].AnimInfo._pAnimData = plr[pnum]._pAAnim[dir];
 		break;
 	case PM_RATTACK:
-		plr[pnum]._pAnimData = plr[pnum]._pAAnim[dir];
+		plr[pnum].AnimInfo._pAnimData = plr[pnum]._pAAnim[dir];
 		break;
 	case PM_BLOCK:
-		plr[pnum]._pAnimData = plr[pnum]._pBAnim[dir];
+		plr[pnum].AnimInfo._pAnimData = plr[pnum]._pBAnim[dir];
 		break;
 	case PM_SPELL:
 		if (pnum == myplr)
@@ -3988,23 +3988,23 @@ void SyncPlrAnim(int pnum)
 		else
 			sType = STYPE_FIRE;
 		if (sType == STYPE_FIRE)
-			plr[pnum]._pAnimData = plr[pnum]._pFAnim[dir];
+			plr[pnum].AnimInfo._pAnimData = plr[pnum]._pFAnim[dir];
 		if (sType == STYPE_LIGHTNING)
-			plr[pnum]._pAnimData = plr[pnum]._pLAnim[dir];
+			plr[pnum].AnimInfo._pAnimData = plr[pnum]._pLAnim[dir];
 		if (sType == STYPE_MAGIC)
-			plr[pnum]._pAnimData = plr[pnum]._pTAnim[dir];
+			plr[pnum].AnimInfo._pAnimData = plr[pnum]._pTAnim[dir];
 		break;
 	case PM_GOTHIT:
-		plr[pnum]._pAnimData = plr[pnum]._pHAnim[dir];
+		plr[pnum].AnimInfo._pAnimData = plr[pnum]._pHAnim[dir];
 		break;
 	case PM_NEWLVL:
-		plr[pnum]._pAnimData = plr[pnum]._pNAnim[dir];
+		plr[pnum].AnimInfo._pAnimData = plr[pnum]._pNAnim[dir];
 		break;
 	case PM_DEATH:
-		plr[pnum]._pAnimData = plr[pnum]._pDAnim[dir];
+		plr[pnum].AnimInfo._pAnimData = plr[pnum]._pDAnim[dir];
 		break;
 	case PM_QUIT:
-		plr[pnum]._pAnimData = plr[pnum]._pNAnim[dir];
+		plr[pnum].AnimInfo._pAnimData = plr[pnum]._pNAnim[dir];
 		break;
 	default:
 		app_fatal("SyncPlrAnim");

--- a/Source/player.h
+++ b/Source/player.h
@@ -398,7 +398,6 @@ void FreePlayerGFX(int pnum);
  */
 void NewPlrAnim(int pnum, BYTE *pData, int numberOfFrames, int delayLen, int width, AnimationDistributionParams params = AnimationDistributionParams::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
 void SetPlrAnims(int pnum);
-void ProcessPlayerAnimation(int pnum);
 void CreatePlayer(int pnum, HeroClass c);
 int CalcStatDiff(int pnum);
 #ifdef _DEBUG

--- a/Source/player.h
+++ b/Source/player.h
@@ -415,12 +415,6 @@ enum class AnimationDistributionParams : uint8_t {
 void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, AnimationDistributionParams params = AnimationDistributionParams::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
 void SetPlrAnims(int pnum);
 void ProcessPlayerAnimation(int pnum);
-/**
- * @brief Calculates the Frame to use for the Animation rendering
- * @param pPlayer Player
- * @return The Frame to use for rendering
- */
-int GetFrameToUseForPlayerRendering(const PlayerStruct *pPlayer);
 void CreatePlayer(int pnum, HeroClass c);
 int CalcStatDiff(int pnum);
 #ifdef _DEBUG

--- a/Source/player.h
+++ b/Source/player.h
@@ -16,6 +16,7 @@
 #include "path.h"
 #include "interfac.h"
 #include "utils/enum_traits.h"
+#include "engine/animationinfo.h"
 
 namespace devilution {
 
@@ -160,24 +161,11 @@ struct PlayerStruct {
 	ActorPosition position;
 	direction _pdir; // Direction faced by player (direction enum)
 	int _pgfxnum;    // Bitmask indicating what variant of the sprite the player is using. Lower byte define weapon (anim_weapon_id) and higher values define armour (starting with anim_armor_id)
-	uint8_t *_pAnimData;
-	int _pAnimDelay; // Tick length of each frame in the current animation
-	int _pAnimCnt;   // Increases by one each game tick, counting how close we are to _pAnimDelay
-	int _pAnimLen;   // Number of frames in current animation
-	int _pAnimFrame; // Current frame of animation.
+	/*
+	* @brief Contains Information for current Animation
+	*/
+	AnimationInfo AnimInfo;
 	int _pAnimWidth;
-	/*
-	* @brief Specifies how many animations-fractions are displayed between two gameticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
-	*/
-	float _pAnimGameTickModifier;
-	/*
-	* @brief Number of GameTicks after the current animation sequence started
-	*/
-	int _pAnimGameTicksSinceSequenceStarted;
-	/*
-	* @brief Animation Frames that will be adjusted for the skipped Frames/GameTicks
-	*/
-	int _pAnimRelevantAnimationFramesForDistributing;
 	int _plid;
 	int _pvid;
 	spell_id _pSpell;

--- a/Source/player.h
+++ b/Source/player.h
@@ -386,33 +386,17 @@ void InitPlrGFXMem(int pnum);
 void FreePlayerGFX(int pnum);
 
 /**
- * @brief Specifies what special logics are applied for a Animation
- */
-enum class AnimationDistributionParams : uint8_t {
-	None = 0,
-	/*
-	* @brief ProcessAnimation will be called after NewPlrAnim (in same GameTick as NewPlrAnim)
-	*/
-	ProcessAnimationPending,
-	/*
-	* @brief Delay of last Frame is ignored (for example, because only Frame and not delay is checked in game_logic)
-	*/
-	SkipsDelayOfLastFrame,
-};
-
-/**
  * @brief Sets the new Player Animation with all relevant information for rendering
-
  * @param pnum Player Id
- * @param Peq Pointer to Animation Data
- * @param numFrames Number of Frames in Animation
- * @param Delay Delay after each Animation sequence
+ * @param pData Pointer to Animation Data
+ * @param numberOfFrames Number of Frames in Animation
+ * @param delayLen Delay after each Animation sequence
  * @param width Width of sprite
  * @param params Specifies what special logics are applied to this Animation
  * @param numSkippedFrames Number of Frames that will be skipped (for example with modifier "faster attack")
  * @param distributeFramesBeforeFrame Distribute the numSkippedFrames only before this frame
  */
-void NewPlrAnim(int pnum, BYTE *Peq, int numFrames, int Delay, int width, AnimationDistributionParams params = AnimationDistributionParams::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
+void NewPlrAnim(int pnum, BYTE *pData, int numberOfFrames, int delayLen, int width, AnimationDistributionParams params = AnimationDistributionParams::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
 void SetPlrAnims(int pnum);
 void ProcessPlayerAnimation(int pnum);
 void CreatePlayer(int pnum, HeroClass c);

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -416,7 +416,7 @@ static void DrawPlayer(const CelOutputBuffer &out, int pnum, int x, int y, int p
 
 	PlayerStruct *pPlayer = &plr[pnum];
 
-	BYTE *pCelBuff = pPlayer->AnimInfo._pAnimData;
+	BYTE *pCelBuff = pPlayer->AnimInfo.pData;
 	int nCel = GetFrameToUseForPlayerRendering(pPlayer);
 	int nWidth = pPlayer->_pAnimWidth;
 

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -416,7 +416,7 @@ static void DrawPlayer(const CelOutputBuffer &out, int pnum, int x, int y, int p
 
 	PlayerStruct *pPlayer = &plr[pnum];
 
-	BYTE *pCelBuff = pPlayer->_pAnimData;
+	BYTE *pCelBuff = pPlayer->AnimInfo._pAnimData;
 	int nCel = GetFrameToUseForPlayerRendering(pPlayer);
 	int nWidth = pPlayer->_pAnimWidth;
 

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -417,7 +417,7 @@ static void DrawPlayer(const CelOutputBuffer &out, int pnum, int x, int y, int p
 	PlayerStruct *pPlayer = &plr[pnum];
 
 	BYTE *pCelBuff = pPlayer->AnimInfo.pData;
-	int nCel = GetFrameToUseForPlayerRendering(pPlayer);
+	int nCel = pPlayer->AnimInfo.GetFrameToUseForRendering();
 	int nWidth = pPlayer->_pAnimWidth;
 
 	if (pCelBuff == nullptr) {

--- a/test/animationinfo_test.cpp
+++ b/test/animationinfo_test.cpp
@@ -62,20 +62,20 @@ void RunAnimationTest(int numFrames, int delay, AnimationDistributionParams para
 		if (gameTickData != nullptr) {
 			currentGameTick += 1;
 			if (gameTickData->_FramesToSkip != 0)
-				pPlayer->AnimInfo.CurrentFrame += gameTickData->_FramesToSkip;
-			pPlayer->AnimInfo.ProcessAnimation();
-			EXPECT_EQ(pPlayer->AnimInfo.CurrentFrame, gameTickData->_ExpectedAnimationFrame);
-			EXPECT_EQ(pPlayer->AnimInfo.DelayCounter, gameTickData->_ExpectedAnimationCnt);
+				animInfo.CurrentFrame += gameTickData->_FramesToSkip;
+			animInfo.ProcessAnimation();
+			EXPECT_EQ(animInfo.CurrentFrame, gameTickData->_ExpectedAnimationFrame);
+			EXPECT_EQ(animInfo.DelayCounter, gameTickData->_ExpectedAnimationCnt);
 		}
 
 		auto renderingData = dynamic_cast<RenderingData *>(x);
 		if (renderingData != nullptr) {
 			gfProgressToNextGameTick = renderingData->_fProgressToNextGameTick;
-			EXPECT_EQ(pPlayer->AnimInfo.GetFrameToUseForRendering(), renderingData->_ExpectedRenderingFrame)
+			EXPECT_EQ(animInfo.GetFrameToUseForRendering(), renderingData->_ExpectedRenderingFrame)
 			    << std::fixed << std::setprecision(2)
 			    << "ProgressToNextGameTick: " << renderingData->_fProgressToNextGameTick
-			    << " CurrentFrame: " << pPlayer->AnimInfo.CurrentFrame
-			    << " DelayCounter: " << pPlayer->AnimInfo.DelayCounter
+			    << " CurrentFrame: " << animInfo.CurrentFrame
+			    << " DelayCounter: " << animInfo.DelayCounter
 			    << " GameTick: " << currentGameTick;
 		}
 	}
@@ -125,7 +125,7 @@ TEST(AnimationInfo, AttackSwordWarrior) // ProcessAnimationPending should be con
 	        new RenderingData(0.6f, 8),
 	        new RenderingData(0.8f, 8),
 
-			// After this GameTick, the Animation Distribution Logic is disabled
+	        // After this GameTick, the Animation Distribution Logic is disabled
 	        new GameTickData(9, 0),
 	        new RenderingData(0.1f, 9),
 	        new GameTickData(10, 0),
@@ -177,7 +177,7 @@ TEST(AnimationInfo, AttackSwordWarriorWithFastestAttack) // Skipped frames and P
 	        new RenderingData(0.6f, 8),
 	        new RenderingData(0.8f, 8),
 
-			// After this GameTick, the Animation Distribution Logic is disabled
+	        // After this GameTick, the Animation Distribution Logic is disabled
 	        new GameTickData(9, 0),
 	        new RenderingData(0.1f, 9),
 	        new GameTickData(10, 0),
@@ -371,7 +371,7 @@ TEST(AnimationInfo, Stand) // Distribution Logic shouldn't change anything here
 	        new GameTickData(10, 3),
 	        new RenderingData(0.6f, 10),
 
-			// Animation starts again
+	        // Animation starts again
 	        new GameTickData(1, 0),
 	        new RenderingData(0.1f, 1),
 	        new GameTickData(1, 1),

--- a/test/animationinfo_test.cpp
+++ b/test/animationinfo_test.cpp
@@ -62,10 +62,10 @@ void RunAnimationTest(int numFrames, int delay, AnimationDistributionParams para
 		if (gameTickData != nullptr) {
 			currentGameTick += 1;
 			if (gameTickData->_FramesToSkip != 0)
-				pPlayer->AnimInfo._pAnimFrame += gameTickData->_FramesToSkip;
+				pPlayer->AnimInfo.CurrentFrame += gameTickData->_FramesToSkip;
 			ProcessPlayerAnimation(pnum);
-			EXPECT_EQ(pPlayer->AnimInfo._pAnimFrame, gameTickData->_ExpectedAnimationFrame);
-			EXPECT_EQ(pPlayer->AnimInfo._pAnimCnt, gameTickData->_ExpectedAnimationCnt);
+			EXPECT_EQ(pPlayer->AnimInfo.CurrentFrame, gameTickData->_ExpectedAnimationFrame);
+			EXPECT_EQ(pPlayer->AnimInfo.DelayCounter, gameTickData->_ExpectedAnimationCnt);
 		}
 
 		auto renderingData = dynamic_cast<RenderingData *>(x);
@@ -74,8 +74,8 @@ void RunAnimationTest(int numFrames, int delay, AnimationDistributionParams para
 			EXPECT_EQ(GetFrameToUseForPlayerRendering(pPlayer), renderingData->_ExpectedRenderingFrame)
 			    << std::fixed << std::setprecision(2)
 			    << "ProgressToNextGameTick: " << renderingData->_fProgressToNextGameTick
-			    << " AnimFrame: " << pPlayer->AnimInfo._pAnimFrame
-			    << " AnimCnt: " << pPlayer->AnimInfo._pAnimCnt
+			    << " CurrentFrame: " << pPlayer->AnimInfo.CurrentFrame
+			    << " DelayCounter: " << pPlayer->AnimInfo.DelayCounter
 			    << " GameTick: " << currentGameTick;
 		}
 	}
@@ -142,7 +142,7 @@ TEST(AnimationInfo, AttackSwordWarrior) // ProcessAnimationPending should be con
 	        new RenderingData(0.6f, 15),
 	        new GameTickData(16, 0),
 	        new RenderingData(0.6f, 16),
-	        // Animation stopped cause PM_DoAttack would stop the Animation "if (plr[pnum]._pAnimFrame == plr[pnum]._pAFrames) {"
+	        // Animation stopped cause PM_DoAttack would stop the Animation "if (plr[pnum].AnimInfo.CurrentFrame == plr[pnum]._pAFrames) {"
 	    });
 }
 
@@ -194,7 +194,7 @@ TEST(AnimationInfo, AttackSwordWarriorWithFastestAttack) // Skipped frames and P
 	        new RenderingData(0.6f, 15),
 	        new GameTickData(16, 0),
 	        new RenderingData(0.6f, 16),
-	        // Animation stopped cause PM_DoAttack would stop the Animation "if (plr[pnum]._pAnimFrame == plr[pnum]._pAFrames) {"
+	        // Animation stopped cause PM_DoAttack would stop the Animation "if (plr[pnum].AnimInfo.CurrentFrame == plr[pnum]._pAFrames) {"
 	    });
 }
 
@@ -221,7 +221,7 @@ TEST(AnimationInfo, BlockingWarriorNormal) // Ignored delay for last Frame shoul
 	        new RenderingData(0.3f, 2),
 	        new RenderingData(0.6f, 2),
 	        new RenderingData(0.8f, 2),
-	        // Animation stopped cause PM_DoBlock would stop the Animation "if (plr[pnum]._pAnimFrame >= plr[pnum]._pBFrames) {"
+	        // Animation stopped cause PM_DoBlock would stop the Animation "if (plr[pnum].AnimInfo.CurrentFrame >= plr[pnum]._pBFrames) {"
 	    });
 }
 
@@ -248,7 +248,7 @@ TEST(AnimationInfo, BlockingSorcererWithFastBlock) // Skipped frames and ignored
 	        new RenderingData(0.3f, 5),
 	        new RenderingData(0.6f, 6),
 	        new RenderingData(0.8f, 6),
-	        // Animation stopped cause PM_DoBlock would stop the Animation "if (plr[pnum]._pAnimFrame >= plr[pnum]._pBFrames) {"
+	        // Animation stopped cause PM_DoBlock would stop the Animation "if (plr[pnum].AnimInfo.CurrentFrame >= plr[pnum]._pBFrames) {"
 	    });
 }
 
@@ -275,7 +275,7 @@ TEST(AnimationInfo, HitRecoverySorcererZenMode) // Skipped frames and ignored de
 	        new RenderingData(0.3f, 7),
 	        new RenderingData(0.6f, 8),
 	        new RenderingData(0.8f, 8),
-	        // Animation stopped cause PM_DoGotHit would stop the Animation "if (plr[pnum]._pAnimFrame >= plr[pnum]._pHFrames) {"
+	        // Animation stopped cause PM_DoGotHit would stop the Animation "if (plr[pnum].AnimInfo.CurrentFrame >= plr[pnum]._pHFrames) {"
 	    });
 }
 TEST(AnimationInfo, Stand) // Distribution Logic shouldn't change anything here

--- a/test/animationinfo_test.cpp
+++ b/test/animationinfo_test.cpp
@@ -63,7 +63,7 @@ void RunAnimationTest(int numFrames, int delay, AnimationDistributionParams para
 			currentGameTick += 1;
 			if (gameTickData->_FramesToSkip != 0)
 				pPlayer->AnimInfo.CurrentFrame += gameTickData->_FramesToSkip;
-			ProcessPlayerAnimation(pnum);
+			pPlayer->AnimInfo.ProcessAnimation();
 			EXPECT_EQ(pPlayer->AnimInfo.CurrentFrame, gameTickData->_ExpectedAnimationFrame);
 			EXPECT_EQ(pPlayer->AnimInfo.DelayCounter, gameTickData->_ExpectedAnimationCnt);
 		}

--- a/test/animationinfo_test.cpp
+++ b/test/animationinfo_test.cpp
@@ -71,7 +71,7 @@ void RunAnimationTest(int numFrames, int delay, AnimationDistributionParams para
 		auto renderingData = dynamic_cast<RenderingData *>(x);
 		if (renderingData != nullptr) {
 			gfProgressToNextGameTick = renderingData->_fProgressToNextGameTick;
-			EXPECT_EQ(GetFrameToUseForPlayerRendering(pPlayer), renderingData->_ExpectedRenderingFrame)
+			EXPECT_EQ(pPlayer->AnimInfo.GetFrameToUseForRendering(), renderingData->_ExpectedRenderingFrame)
 			    << std::fixed << std::setprecision(2)
 			    << "ProgressToNextGameTick: " << renderingData->_fProgressToNextGameTick
 			    << " CurrentFrame: " << pPlayer->AnimInfo.CurrentFrame

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -11,7 +11,7 @@ extern bool PM_DoGotHit(int pnum);
 int RunBlockTest(int frames, int flags)
 {
 	int pnum = 0;
-	plr[pnum]._pAnimFrame = 1;
+	plr[pnum].AnimInfo._pAnimFrame = 1;
 	plr[pnum]._pHFrames = frames;
 	plr[pnum].actionFrame = 1;
 	plr[pnum]._pIFlags = flags;
@@ -23,7 +23,7 @@ int RunBlockTest(int frames, int flags)
 		PM_DoGotHit(pnum);
 		if (plr[pnum]._pmode != PM_GOTHIT)
 			break;
-		plr[pnum]._pAnimFrame++;
+		plr[pnum].AnimInfo._pAnimFrame++;
 	}
 
 	return i;

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -11,7 +11,7 @@ extern bool PM_DoGotHit(int pnum);
 int RunBlockTest(int frames, int flags)
 {
 	int pnum = 0;
-	plr[pnum].AnimInfo._pAnimFrame = 1;
+	plr[pnum].AnimInfo.CurrentFrame = 1;
 	plr[pnum]._pHFrames = frames;
 	plr[pnum].actionFrame = 1;
 	plr[pnum]._pIFlags = flags;
@@ -23,7 +23,7 @@ int RunBlockTest(int frames, int flags)
 		PM_DoGotHit(pnum);
 		if (plr[pnum]._pmode != PM_GOTHIT)
 			break;
-		plr[pnum].AnimInfo._pAnimFrame++;
+		plr[pnum].AnimInfo.CurrentFrame++;
 	}
 
 	return i;

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -292,10 +292,10 @@ static void AssertPlayer(PlayerStruct *pPlayer)
 	ASSERT_EQ(pPlayer->_pmode, 0);
 	ASSERT_EQ(Count8(pPlayer->walkpath, MAX_PATH_LENGTH), 25);
 	ASSERT_EQ(pPlayer->_pgfxnum, 36);
-	ASSERT_EQ(pPlayer->AnimInfo._pAnimDelay, 3);
-	ASSERT_EQ(pPlayer->AnimInfo._pAnimCnt, 1);
-	ASSERT_EQ(pPlayer->AnimInfo._pAnimLen, 20);
-	ASSERT_EQ(pPlayer->AnimInfo._pAnimFrame, 1);
+	ASSERT_EQ(pPlayer->AnimInfo.DelayLen, 3);
+	ASSERT_EQ(pPlayer->AnimInfo.DelayCounter, 1);
+	ASSERT_EQ(pPlayer->AnimInfo.FrameLen, 20);
+	ASSERT_EQ(pPlayer->AnimInfo.CurrentFrame, 1);
 	ASSERT_EQ(pPlayer->_pAnimWidth, 96);
 	ASSERT_EQ(pPlayer->_pSpell, -1);
 	ASSERT_EQ(pPlayer->_pSplType, 4);

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -292,10 +292,10 @@ static void AssertPlayer(PlayerStruct *pPlayer)
 	ASSERT_EQ(pPlayer->_pmode, 0);
 	ASSERT_EQ(Count8(pPlayer->walkpath, MAX_PATH_LENGTH), 25);
 	ASSERT_EQ(pPlayer->_pgfxnum, 36);
-	ASSERT_EQ(pPlayer->_pAnimDelay, 3);
-	ASSERT_EQ(pPlayer->_pAnimCnt, 1);
-	ASSERT_EQ(pPlayer->_pAnimLen, 20);
-	ASSERT_EQ(pPlayer->_pAnimFrame, 1);
+	ASSERT_EQ(pPlayer->AnimInfo._pAnimDelay, 3);
+	ASSERT_EQ(pPlayer->AnimInfo._pAnimCnt, 1);
+	ASSERT_EQ(pPlayer->AnimInfo._pAnimLen, 20);
+	ASSERT_EQ(pPlayer->AnimInfo._pAnimFrame, 1);
 	ASSERT_EQ(pPlayer->_pAnimWidth, 96);
 	ASSERT_EQ(pPlayer->_pSpell, -1);
 	ASSERT_EQ(pPlayer->_pSplType, 4);

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -294,7 +294,7 @@ static void AssertPlayer(PlayerStruct *pPlayer)
 	ASSERT_EQ(pPlayer->_pgfxnum, 36);
 	ASSERT_EQ(pPlayer->AnimInfo.DelayLen, 3);
 	ASSERT_EQ(pPlayer->AnimInfo.DelayCounter, 1);
-	ASSERT_EQ(pPlayer->AnimInfo.FrameLen, 20);
+	ASSERT_EQ(pPlayer->AnimInfo.NumberOfFrames, 20);
 	ASSERT_EQ(pPlayer->AnimInfo.CurrentFrame, 1);
 	ASSERT_EQ(pPlayer->_pAnimWidth, 96);
 	ASSERT_EQ(pPlayer->_pSpell, -1);


### PR DESCRIPTION
This pr doesn't change any logic (including if conditions).

Content:

- Move Fields and Logic to new `AnimationInfos` class (every move is in a separate commit and not coupled with other changes)
- Rename Variables (in separate commits)
- Remove not needed local variables (in separate commit)

Notes:

- In the future AnimationInfos should be included in other Types (Monsters, Object, Missiles). But this is outside the scope of this pr.
- `Width` is not included cause in other types (Monsters) `Width` doesn't exist as member. That's also the reason why NewPlrAnim still exists.