### PR TITLE
🔨 MSVC: Enable standards mode (/permissive-)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -710,6 +710,7 @@ endif()
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_compile_options(${BIN_TARGET} PRIVATE "/W0")
   target_compile_options(${BIN_TARGET} PRIVATE "/Zc:__cplusplus")
+  target_compile_options(${BIN_TARGET} PRIVATE "/permissive-")
 endif()
 
 if(APPLE)


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance

Background: https://github.com/realnc/SDL_audiolib/issues/15