### PR TITLE
🔨 CMake: Fix SDL2 on older Debian derivates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,14 +202,20 @@ if(USE_SDL1)
 else()
   find_package(SDL2 REQUIRED)
   if(TARGET SDL2::SDL2)
-    set(SDL2_TARGET SDL2::SDL2)
+    set(SDL2_MAIN SDL2::SDL2main)
   elseif(TARGET SDL2::SDL2-static)
     # On some distros, such as vitasdk, only the SDL2::SDL2-static target is available.
-    set(SDL2_TARGET SDL2::SDL2-static)
     # Alias to SDL2::SDL2 because some finder scripts may refer to SDL2::SDL2.
     add_library(SDL2::SDL2 ALIAS SDL2::SDL2-static)
+    set(SDL2_MAIN SDL2::SDL2main)
   else()
-    message(FATAL_ERROR "SDL2 cmake config found but it does not define SDL2::SDL2 nor SDL2::SDL2-static")
+    # Assume an older Debian derivate that comes with an sdl2-config.cmake
+    # that only defines `SDL2_LIBRARIES` (as -lSDL2) and `SDL2_INCLUDE_DIRS`.
+    add_library(SDL2_lib INTERFACE)
+    target_link_libraries(SDL2_lib INTERFACE ${SDL2_LIBRARIES})
+    target_include_directories(SDL2_lib INTERFACE ${SDL2_INCLUDE_DIRS})
+    # Can't define an INTERFACE target with ::, so alias instead
+    add_library(SDL2::SDL2 ALIAS SDL2_lib)
   endif()
   find_package(SDL2_ttf REQUIRED)
   find_package(SDL2_mixer REQUIRED)
@@ -605,8 +611,8 @@ if(USE_SDL1)
   target_compile_definitions(${BIN_TARGET} PRIVATE USE_SDL1)
 else()
   target_link_libraries(${BIN_TARGET} PRIVATE
-    ${SDL2_TARGET}
-    SDL2::SDL2main
+    SDL2::SDL2
+    ${SDL2_MAIN}
     SDL2::SDL2_ttf
     SDL2::SDL2_mixer)
 endif()


### PR DESCRIPTION
Older Debian and derivatives come with sdl2-config.cmake file that does
not define any targets.

One such sdl2-config.cmake looks like this:

```cmake
set(prefix "/usr")
set(exec_prefix "${prefix}")
set(libdir "${prefix}/lib/x86_64-linux-gnu")
set(SDL2_PREFIX "/usr")
set(SDL2_EXEC_PREFIX "/usr")
set(SDL2_INCLUDE_DIRS "${prefix}/include/SDL2")
set(SDL2_LIBRARIES " -lSDL2")
string(STRIP "${SDL2_LIBRARIES}" SDL2_LIBRARIES)
```

Works around this by defining an `SDL2::SDL2` target ourselves.

Removes SDL2::SDLmain because we do not use the SDL_main function and do not need it.