### PR TITLE
⚙️ Show FPS option

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -482,6 +482,7 @@ static void SaveOptions()
 	setIniInt("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 	setIniInt("Graphics", "Color Cycling", sgOptions.Graphics.bColorCycling);
 	setIniInt("Graphics", "FPS Limiter", sgOptions.Graphics.bFPSLimit);
+	setIniInt("Graphics", "Show FPS", sgOptions.Graphics.bShowFPS);
 
 	setIniInt("Game", "Speed", sgOptions.Gameplay.nTickRate);
 	setIniInt("Game", "Run in Town", sgOptions.Gameplay.bRunInTown);
@@ -559,6 +560,7 @@ static void LoadOptions()
 	sgOptions.Graphics.nGammaCorrection = getIniInt("Graphics", "Gamma Correction", 100);
 	sgOptions.Graphics.bColorCycling = getIniBool("Graphics", "Color Cycling", true);
 	sgOptions.Graphics.bFPSLimit = getIniBool("Graphics", "FPS Limiter", true);
+	sgOptions.Graphics.bShowFPS = getIniInt("Graphics", "Show FPS", false);
 
 	sgOptions.Gameplay.nTickRate = getIniInt("Game", "Speed", 20);
 	sgOptions.Gameplay.bRunInTown = getIniBool("Game", "Run in Town", false);
@@ -616,6 +618,9 @@ static void diablo_init_screen()
 
 static void diablo_init()
 {
+	if (sgOptions.Graphics.bShowFPS)
+		EnableFrameCount();
+
 	init_create_window();
 	was_window_init = true;
 

--- a/Source/options.h
+++ b/Source/options.h
@@ -54,6 +54,8 @@ struct GraphicsOptions {
 	bool bColorCycling;
 	/** @brief Enable FPS Limit. */
 	bool bFPSLimit;
+	/** @brief Show FPS, even without the -f command line flag. */
+	bool bShowFPS;
 };
 
 struct GameplayOptions {


### PR DESCRIPTION
On some platforms, editing command-line flags is difficult.
This adds a `Show FPS` option to the ini file.

If set, FPS is shown even without the `-f` flag.