### PR TITLE
🔨 ⚙️  CMake: Add NOSOUND option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,8 @@ option(DIST "Dynamically link only glibc and SDL2" OFF)
 option(BINARY_RELEASE "Enable options for binary release" OFF)
 option(NIGHTLY_BUILD "Enable options for nightly build" OFF)
 option(USE_SDL1 "Use SDL1.2 instead of SDL2" OFF)
-option(NONET "Disable network" OFF)
+option(NONET "Disable network support" OFF)
+option(NOSOUND "Disable sound support" OFF)
 option(RUN_TESTS "Build and run tests" OFF)
 option(USE_GETTEXT "Build translation files using gettext" OFF)
 
@@ -47,13 +48,17 @@ if(NIGHTLY_BUILD OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
   set(CPACK ON)
 endif()
 
-option(DEVILUTIONX_SYSTEM_SDL_AUDIOLIB "Use system-provided SDL_audiolib" OFF)
-cmake_dependent_option(DEVILUTIONX_STATIC_SDL_AUDIOLIB "Link static SDL_audiolib" OFF
-                       "DEVILUTIONX_SYSTEM_SDL_AUDIOLIB AND NOT DIST" ON)
+if(NOT NOSOUND)
+  option(DEVILUTIONX_SYSTEM_SDL_AUDIOLIB "Use system-provided SDL_audiolib" OFF)
+  cmake_dependent_option(DEVILUTIONX_STATIC_SDL_AUDIOLIB "Link static SDL_audiolib" OFF
+                        "DEVILUTIONX_SYSTEM_SDL_AUDIOLIB AND NOT DIST" ON)
+endif()
 
-option(DEVILUTIONX_SYSTEM_LIBSODIUM "Use system-provided libsodium" ON)
-cmake_dependent_option(DEVILUTIONX_STATIC_LIBSODIUM "Link static libsodium" OFF
-                       "DEVILUTIONX_SYSTEM_LIBSODIUM AND NOT DIST" ON)
+if(NOT NONET)
+  option(DEVILUTIONX_SYSTEM_LIBSODIUM "Use system-provided libsodium" ON)
+  cmake_dependent_option(DEVILUTIONX_STATIC_LIBSODIUM "Link static libsodium" OFF
+                        "DEVILUTIONX_SYSTEM_LIBSODIUM AND NOT DIST" ON)
+endif()
 
 option(DEVILUTIONX_SYSTEM_LIBFMT "Use system-provided libfmt" ON)
 cmake_dependent_option(DEVILUTIONX_STATIC_LIBFMT "Link static libfmt" OFF
@@ -173,10 +178,12 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # for clang-tidy
 set(CMAKE_THREAD_PREFER_PTHREAD ON)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
-if(DEVILUTIONX_SYSTEM_SDL_AUDIOLIB)
-  find_package(SDL_audiolib REQUIRED)
-else()
-  add_subdirectory(3rdParty/SDL_audiolib)
+if(NOT NOSOUND)
+  if(DEVILUTIONX_SYSTEM_SDL_AUDIOLIB)
+    find_package(SDL_audiolib REQUIRED)
+  else()
+    add_subdirectory(3rdParty/SDL_audiolib)
+  endif()
 endif()
 
 if(NOT N3DS)
@@ -274,7 +281,6 @@ set(devilutionx_SRCS
   Source/drlg_l4.cpp
   Source/dthread.cpp
   Source/dx.cpp
-  Source/effects.cpp
   Source/encrypt.cpp
   Source/engine.cpp
   Source/error.cpp
@@ -316,7 +322,6 @@ set(devilutionx_SRCS
   Source/scrollrt.cpp
   Source/setmaps.cpp
   Source/sha.cpp
-  Source/sound.cpp
   Source/spelldat.cpp
   Source/spells.cpp
   Source/stores.cpp
@@ -348,8 +353,6 @@ set(devilutionx_SRCS
   Source/utils/file_util.cpp
   Source/utils/language.cpp
   Source/utils/paths.cpp
-  Source/utils/push_aulib_decoder.cpp
-  Source/utils/soundsample.cpp
   Source/utils/thread.cpp
   Source/DiabloUI/art.cpp
   Source/DiabloUI/art_draw.cpp
@@ -391,6 +394,18 @@ set(devilutionx_SRCS
 
 if(USE_SDL1)
   list(APPEND devilutionx_SRCS Source/utils/sdl2_to_1_2_backports.cpp)
+endif()
+
+if(NOSOUND)
+  list(APPEND devilutionx_SRCS
+    Source/effects_stubs.cpp
+    Source/sound_stubs.cpp)
+else()
+  list(APPEND devilutionx_SRCS
+    Source/effects.cpp
+    Source/sound.cpp
+    Source/utils/push_aulib_decoder.cpp
+    Source/utils/soundsample.cpp)
 endif()
 
 if(NOT NONET)
@@ -532,6 +547,7 @@ target_compile_definitions(${BIN_TARGET} PRIVATE ASIO_STANDALONE)
 # Defines without value
 foreach(
   def_name
+  NOSOUND
   NONET
   PREFILL_PLAYER_NAME
   DISABLE_STREAMING_MUSIC
@@ -629,7 +645,9 @@ else()
     SDL2::SDL2_ttf)
 endif()
 
-target_link_libraries(${BIN_TARGET} PRIVATE SDL_audiolib)
+if(NOT NOSOUND)
+  target_link_libraries(${BIN_TARGET} PRIVATE SDL_audiolib)
+endif()
 
 if(SWITCH)
   target_link_libraries(${BIN_TARGET} PRIVATE switch::libnx

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -41,7 +41,6 @@
 #include "qol/common.h"
 #include "restrict.h"
 #include "setmaps.h"
-#include "sound.h"
 #include "stores.h"
 #include "storm/storm.h"
 #include "themes.h"
@@ -53,6 +52,10 @@
 #include "utils/language.h"
 #include "utils/paths.h"
 #include "utils/language.h"
+
+#ifndef NOSOUND
+#include "sound.h"
+#endif
 
 namespace devilution {
 
@@ -662,8 +665,10 @@ static void diablo_init()
 
 	diablo_init_screen();
 
+#ifndef NOSOUND
 	snd_init();
 	was_snd_init = true;
+#endif
 
 	ui_sound_init();
 }
@@ -694,7 +699,9 @@ static void diablo_deinit()
 	if (was_snd_init) {
 		effects_cleanup_sfx();
 	}
+#ifndef NOSOUND
 	Aulib::quit();
+#endif
 	if (was_ui_init)
 		UiDestroy();
 	if (was_archives_init)

--- a/Source/effects.h
+++ b/Source/effects.h
@@ -1069,7 +1069,6 @@ bool effect_is_playing(int nSFX);
 void stream_stop();
 void InitMonsterSND(int monst);
 void FreeMonsterSnd();
-bool calc_snd_position(int x, int y, int *plVolume, int *plPan);
 void PlayEffect(int i, int mode);
 void PlaySFX(_sfx_id psfx);
 void PlaySfxLoc(_sfx_id psfx, int x, int y, bool randomizeByCategory = true);
@@ -1079,6 +1078,10 @@ void effects_cleanup_sfx();
 void sound_init();
 void ui_sound_init();
 void effects_play_sound(const char *snd_file);
+
+#ifndef NOSOUND
+bool calc_snd_position(int x, int y, int *plVolume, int *plPan);
 int GetSFXLength(int nSFX);
+#endif
 
 } // namespace devilution

--- a/Source/effects_stubs.cpp
+++ b/Source/effects_stubs.cpp
@@ -1,0 +1,26 @@
+// Stubbed implementations of effects for the NOSOUND mode.
+#include "effects.h"
+
+namespace devilution {
+int sfxdelay;
+_sfx_id sfxdnum;
+
+// Disable clang-format here because our config says:
+// AllowShortFunctionsOnASingleLine: None
+// clang-format off
+bool effect_is_playing(int nSFX) { return false; }
+void stream_stop() { }
+void InitMonsterSND(int monst) { }
+void FreeMonsterSnd() { }
+void PlayEffect(int i, int mode) { }
+void PlaySFX(_sfx_id psfx) { }
+void PlaySfxLoc(_sfx_id psfx, int x, int y, bool randomizeByCategory) { }
+void sound_stop() { }
+void sound_update() { }
+void effects_cleanup_sfx() { }
+void sound_init() { }
+void ui_sound_init() { }
+void effects_play_sound(const char *snd_file) { }
+// clang-format off
+
+} // namespace devilution

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -12,8 +12,11 @@
 #include "loadsave.h"
 #include "options.h"
 #include "pfile.h"
-#include "sound.h"
 #include "utils/language.h"
+
+#ifndef NOSOUND
+#include "sound.h"
+#endif
 
 namespace devilution {
 namespace {
@@ -179,6 +182,7 @@ void gamemenu_restart_town(bool bActivate)
 
 void gamemenu_sound_music_toggle(const char *const *names, TMenuItem *menu_item, int volume)
 {
+#ifndef NOSOUND
 	if (gbSndInited) {
 		menu_item->dwFlags |= GMENU_ENABLED | GMENU_SLIDER;
 		menu_item->pszStr = _(names[0]);
@@ -186,6 +190,7 @@ void gamemenu_sound_music_toggle(const char *const *names, TMenuItem *menu_item,
 		gmenu_slider_set(menu_item, VOLUME_MIN, VOLUME_MAX, volume);
 		return;
 	}
+#endif
 
 	menu_item->dwFlags &= ~(GMENU_ENABLED | GMENU_SLIDER);
 	menu_item->pszStr = _(names[1]);
@@ -252,6 +257,7 @@ void gamemenu_music_volume(bool bActivate)
 {
 	int volume;
 
+#ifndef NOSOUND
 	if (bActivate) {
 		if (gbMusicOn) {
 			gbMusicOn = false;
@@ -291,11 +297,13 @@ void gamemenu_music_volume(bool bActivate)
 			music_start(lt);
 		}
 	}
+#endif
 	gamemenu_get_music();
 }
 
 void gamemenu_sound_volume(bool bActivate)
 {
+#ifndef NOSOUND
 	int volume;
 	if (bActivate) {
 		if (gbSoundOn) {
@@ -320,6 +328,7 @@ void gamemenu_sound_volume(bool bActivate)
 	}
 	PlaySFX(IS_TITLEMOV);
 	gamemenu_get_sound();
+#endif
 }
 
 void gamemenu_gamma(bool bActivate)

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -129,10 +129,17 @@ int CalcTextSpeed(int nSFX)
 	int TextHeight;
 	Uint32 SfxFrames;
 
+	const int numLines = GetLinesInText(qtextptr);
+
+#ifndef NOSOUND
 	SfxFrames = GetSFXLength(nSFX);
 	assert(SfxFrames != 0);
+#else
+	// Sound is disabled -- estimate length from the number of lines.
+	SfxFrames = numLines * 3000;
+#endif
 
-	TextHeight = lineHeight * GetLinesInText(qtextptr);
+	TextHeight = lineHeight * numLines;
 	TextHeight += lineHeight * 5; // adjust so when speaker is done two line are left
 
 	return SfxFrames / TextHeight;

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -10,7 +10,10 @@
 #include "engine.h"
 #include "miniwin/miniwin.h"
 #include "monstdat.h"
+
+#ifndef NOSOUND
 #include "sound.h"
+#endif
 
 namespace devilution {
 
@@ -116,7 +119,9 @@ struct CMonster {
 	/** placeflag enum as a flags*/
 	uint8_t mPlaceFlags;
 	AnimStruct Anims[6];
+#ifndef NOSOUND
 	TSnd *Snds[4][2];
+#endif
 	int width;
 	uint16_t mMinHP;
 	uint16_t mMaxHP;

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -6,9 +6,12 @@
 
 #include "diablo.h"
 #include "effects.h"
-#include "sound.h"
 #include "storm/storm_svid.h"
 #include "utils/display.h"
+
+#ifndef NOSOUND
+#include "sound.h"
+#endif
 
 namespace devilution {
 
@@ -27,9 +30,12 @@ void play_movie(const char *pszMovie, bool user_can_close)
 	HANDLE video_stream;
 
 	movie_playing = true;
+
+#ifndef NOSOUND
 	sound_disable_music(true);
 	stream_stop();
 	effects_play_sound("Sfx\\Misc\\blank.wav");
+#endif
 
 	SVidPlayBegin(pszMovie, loop_movie ? 0x100C0808 : 0x10280808, &video_stream);
 	MSG Msg;
@@ -53,7 +59,11 @@ void play_movie(const char *pszMovie, bool user_can_close)
 	}
 	if (video_stream != nullptr)
 		SVidPlayEnd(video_stream);
+
+#ifndef NOSOUND
 	sound_disable_music(false);
+#endif
+
 	movie_playing = false;
 	SDL_GetMouseState(&MouseX, &MouseY);
 	OutputToLogical(&MouseX, &MouseY);

--- a/Source/sound.h
+++ b/Source/sound.h
@@ -8,7 +8,10 @@
 #include <cstdint>
 
 #include "miniwin/miniwin.h"
+
+#ifndef NOSOUND
 #include "utils/soundsample.h"
+#endif
 
 namespace devilution {
 
@@ -28,11 +31,13 @@ enum _music_id : uint8_t {
 };
 
 struct TSnd {
+#ifndef NOSOUND
 	const char *sound_path;
 	/** Used for streamed audio */
 	HANDLE file_handle;
 	SoundSample *DSB;
 	Uint32 start_tc;
+#endif
 };
 
 extern bool gbSndInited;
@@ -55,6 +60,5 @@ int sound_get_or_set_sound_volume(int volume);
 
 extern bool gbMusicOn;
 extern bool gbSoundOn;
-extern bool gbDupSounds;
 
 } // namespace devilution

--- a/Source/sound_stubs.cpp
+++ b/Source/sound_stubs.cpp
@@ -1,0 +1,28 @@
+// Stubbed implementations of sound functions for the NOSOUND mode.
+#include "sound.h"
+
+namespace devilution {
+
+bool gbSndInited;
+bool gbMusicOn;
+bool gbSoundOn;
+
+// Disable clang-format here because our config says:
+// AllowShortFunctionsOnASingleLine: None
+// clang-format off
+void snd_update(bool bStopAll) { }
+void snd_stop_snd(TSnd *pSnd) { }
+bool snd_playing(TSnd *pSnd) { return false; }
+void snd_play_snd(TSnd *pSnd, int lVolume, int lPan) { }
+TSnd *sound_file_load(const char *path, bool stream) { return nullptr; }
+void sound_file_cleanup(TSnd *sound_file) { }
+void snd_init() { }
+void snd_deinit() { }
+void music_stop() { }
+void music_start(uint8_t nTrack) { }
+void sound_disable_music(bool disable) { }
+int sound_get_or_set_music_volume(int volume) { return 0; }
+int sound_get_or_set_sound_volume(int volume) { return 0; }
+// clang-format on
+
+} // namespace devilution

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -134,7 +134,10 @@ bool SpawnWindow(const char *lpWindowName)
 	SDL_setenv("SDL_AUDIODRIVER", "winmm", /*overwrite=*/false);
 #endif
 
-	int initFlags = SDL_INIT_AUDIO | SDL_INIT_VIDEO | SDL_INIT_JOYSTICK;
+	int initFlags = SDL_INIT_VIDEO | SDL_INIT_JOYSTICK;
+#ifndef NOSOUND
+	initFlags |= SDL_INIT_AUDIO;
+#endif
 #ifndef USE_SDL1
 	initFlags |= SDL_INIT_GAMECONTROLLER;
 #endif


### PR DESCRIPTION
This option completely disables all audio handling, including audio loading code and dependencies.

Dialog text length is estimated to be somewhere between Cain and Griswold speed.

This option will likely be needed for the RG-99 port and was also requested by @pgielda in 
https://github.com/diasurgical/devilutionX/pull/1651#issuecomment-825595102