### PR TITLE
Add portable.txt check which will set paths for save and config to ./

### DIFF
--- a/Source/storm/storm.cpp
+++ b/Source/storm/storm.cpp
@@ -1,4 +1,5 @@
 #include "storm/storm.h"
+#include "utils/file_util.h"
 
 #include <SDL.h>
 #include <SDL_endian.h>
@@ -36,8 +37,13 @@ std::string *SBasePath = nullptr;
 
 radon::File &getIni()
 {
-	static radon::File ini(paths::ConfigPath() + "diablo.ini");
-	return ini;
+	if (FileExists("portable.txt")) {
+		static radon::File ini("diablo.ini");
+		return ini;
+	} else {
+		static radon::File ini(paths::ConfigPath() + "diablo.ini");
+		return ini;
+	}
 }
 
 // Converts ASCII characters to lowercase

--- a/Source/utils/paths.cpp
+++ b/Source/utils/paths.cpp
@@ -1,4 +1,5 @@
 #include "utils/paths.h"
+#include "utils/file_util.h"
 
 #include <SDL.h>
 
@@ -73,8 +74,12 @@ const std::string &BasePath()
 
 const std::string &PrefPath()
 {
-	if (!prefPath)
+	if (!prefPath){
 		prefPath = FromSDL(SDL_GetPrefPath("diasurgical", "devilution"));
+		if (FileExists("portable.txt")){
+			prefPath = "./";
+		}
+	}
 	return *prefPath;
 }
 


### PR DESCRIPTION
This PR adds a check for the existence of portable.txt in the devilutionx executable folder. If found it sets the paths for save and config to ./