### PR TITLE
🎉 render.cpp: Do not render out-of-bounds

### DIFF
--- a/Source/.clang-tidy
+++ b/Source/.clang-tidy
@@ -78,3 +78,6 @@ CheckOptions:
   - { key: google-runtime-int.UnsignedTypePrefix, value: "std::uint" }
   - { key: google-runtime-int.SignedTypePrefix, value: "std::int" }
   - { key: google-runtime-int.TypeSuffix, value: "_t" }
+
+  # `int8_t` aren't used as chars, disable misleading warning.
+  - { key: bugprone-signed-char-misuse.CharTypdefsToIgnore, value: "std::int8_t" }

--- a/Source/render.h
+++ b/Source/render.h
@@ -23,10 +23,10 @@ namespace devilution {
  * @param x Target buffer coordinate
  * @param y Target buffer coordinate
  */
-void RenderTile(CelOutputBuffer out, int x, int y);
+void RenderTile(const CelOutputBuffer &out, int x, int y);
 
 /**
- * @brief Render a black tile
+ * @brief Render a black 64x31 tile ◆
  * @param out Target buffer
  * @param sx Target buffer coordinate (left corner of the tile)
  * @param sy Target buffer coordinate (bottom corner of the tile)


### PR DESCRIPTION
This is part of the work to allow us to eliminate buffer padding.

As this is a hotspot, we have 4 separate functions for each non-square primitive, resulting in quite a bit of code:

1. Unclipped ("Full")
2. Vertical-only clip
3. Vertical + Left clip
4. Vertical + Right clip

FPS:
* 640x480: 1420 -> 1530
* 1280x960: 365 -> 380