### PR TITLE
Vita fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -782,6 +782,7 @@ if(VITA)
     FILE Packaging/vita/sce_sys/livearea/contents/logo0.png sce_sys/livearea/contents/logo0.png
     FILE Packaging/vita/sce_sys/livearea/contents/template.xml sce_sys/livearea/contents/template.xml
     FILE Packaging/resources/CharisSILB.ttf CharisSILB.ttf
+    FILE Packaging/resources/devilutionx.mpq devilutionx.mpq
   )
 endif()
 

--- a/Source/utils/paths.cpp
+++ b/Source/utils/paths.cpp
@@ -62,11 +62,7 @@ std::string FromSDL(char *s)
 const std::string &BasePath()
 {
 	if (!basePath) {
-#ifdef __vita__
-		basePath = PrefPath();
-#else
 		basePath = FromSDL(SDL_GetBasePath());
-#endif
 	}
 	return *basePath;
 }


### PR DESCRIPTION
That should properly load font and datafile packaged inside app.
There's no need to distribute devilutionx.mpq or CharisSILB.ttf in vita zip file along with .vpk anymore.