### PR TITLE
Fix for rare level generation bug on Crypt 1 that causes missing story book braziers

### DIFF
--- a/Source/objdat.cpp
+++ b/Source/objdat.cpp
@@ -241,7 +241,7 @@ const ObjDataStruct AllObjects[] = {
 	{      1, OFILE_MCIRL,     0,       0, DTYPE_CATHEDRAL, THEME_NONE,              Q_BETRAYER,         0,          1,        0,         96, false,      true,      true,            0,        0, false     },
 	{      1, OFILE_MCIRL,     0,       0, DTYPE_CATHEDRAL, THEME_NONE,              Q_BETRAYER,         0,          1,        0,         96, false,      true,      true,            0,        0, false     },
 	{      1, OFILE_BKSLBRNT,  1,      12, DTYPE_NONE,      THEME_NONE,              Q_INVALID,          0,          1,        0,         96, true,       true,      true,            0,        3, false     }, // BUGFIX should only be loaded on level 1-12 (crypt masks as 1-4) (fixed)
-	{      1, OFILE_CANDLE2,   2,      12, DTYPE_NONE,      THEME_NONE,              Q_BETRAYER,         1,          2,        4,         96, true,       true,      true,            0,        0, false     },
+	{      1, OFILE_CANDLE2,   1,      12, DTYPE_NONE,      THEME_NONE,              Q_BETRAYER,         1,          2,        4,         96, true,       true,      true,            0,        0, false     },
 	{      1, OFILE_BOOK1,    13,      13, DTYPE_HELL,      THEME_NONE,              Q_WARLORD,          0,          4,        0,         96, true,       true,      true,            0,        3, false     },
 	{      1, OFILE_ARMSTAND, 13,      13, DTYPE_NONE,      THEME_NONE,              Q_WARLORD,          0,          1,        0,         96, true,       false,     true,            0,        3, false     },
 	{      2, OFILE_WEAPSTND, 13,      13, DTYPE_NONE,      THEME_NONE,              Q_WARLORD,          0,          1,        0,         96, true,       false,     true,            0,        3, false     },

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -24,6 +24,7 @@
 #include "towners.h"
 #include "track.h"
 #include "utils/language.h"
+#include "utils/log.hpp"
 
 namespace devilution {
 
@@ -1276,10 +1277,15 @@ void SetupObject(int i, int x, int y, _object_id ot)
 	object[i]._otype = ot;
 	object_graphic_id ofi = AllObjects[ot].ofindex;
 	object[i].position = { x, y };
-	int j = 0;
-	while (ObjFileList[j] != ofi) {
-		j++;
+
+	const auto &found = std::find(std::begin(ObjFileList), std::end(ObjFileList), ofi);
+	if (found == std::end(ObjFileList)) {
+		LogCritical("Unable to find object_graphic_id {} in list of objects to load, level generation error.", ofi);
+		return;
 	}
+
+	const int j = std::distance(std::begin(ObjFileList), found);
+
 	object[i]._oAnimData = pObjCels[j];
 	object[i]._oAnimFlag = AllObjects[ot].oAnimFlag;
 	if (AllObjects[ot].oAnimFlag != 0) {
@@ -5418,10 +5424,14 @@ void SyncL3Doors(int i)
 void SyncObjectAnim(int o)
 {
 	object_graphic_id index = AllObjects[object[o]._otype].ofindex;
-	int i = 0;
-	while (ObjFileList[i] != index) {
-		i++;
+
+	const auto &found = std::find(std::begin(ObjFileList), std::end(ObjFileList), index);
+	if (found == std::end(ObjFileList)) {
+		LogCritical("Unable to find object_graphic_id {} in list of objects to load, level generation error.", index);
+		return;
 	}
+
+	const int i = std::distance(std::begin(ObjFileList), found);
 
 	object[o]._oAnimData = pObjCels[i];
 	switch (object[o]._otype) {
@@ -5526,9 +5536,9 @@ void GetObjectStr(int i)
 	case OBJ_BARREL:
 	case OBJ_BARRELEX:
 		if (currlevel >= 17 && currlevel <= 20)      // for hive levels
-			strcpy(infostr, _("Pod"));                  //Then a barrel is called a pod
+			strcpy(infostr, _("Pod"));               //Then a barrel is called a pod
 		else if (currlevel >= 21 && currlevel <= 24) // for crypt levels
-			strcpy(infostr, _("Urn"));                  //Then a barrel is called an urn
+			strcpy(infostr, _("Urn"));               //Then a barrel is called an urn
 		else
 			strcpy(infostr, _("Barrel"));
 		break;


### PR DESCRIPTION
Fixes #1515
- Crypt candles (braziers) around the story book were occasionally missing
- Marked OFILE_CANDLE2 to load for all levels 1 through 12, so it is always loaded for crypt as well
- Made search for object graphics a bit more secure, as in the bugged case it would run off past the end of an array