### PR TITLE
Fix missing sounds

### DIFF
--- a/Source/utils/soundsample.cpp
+++ b/Source/utils/soundsample.cpp
@@ -51,6 +51,7 @@ void SoundSample::Play(int lVolume, int lPan, int channel)
 	              : copysign(1.F - std::pow(Base, static_cast<float>(-std::fabs(lPan) / Scale)),
 	                  static_cast<float>(lPan)));
 
+	stream_->rewind();
 	if (!stream_->play()) {
 		LogError(LogCategory::Audio, "Aulib::Stream::play (from SoundSample::Play): {}", SDL_GetError());
 		return;


### PR DESCRIPTION
When playing the same sound twice with in a short duration then the
sound it self, the secound request would go unfulfilled. The solution is
to simply rewind the stream pointer before requesting a playback.