### PR TITLE
Fix memleak in CapturePix

### DIFF
--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -116,7 +116,7 @@ static BYTE *CaptureEnc(BYTE *src, BYTE *dst, int width)
 static bool CapturePix(const CelOutputBuffer &buf, std::ofstream *out)
 {
 	int width = buf.w();
-	std::unique_ptr<BYTE, DiabloDeleter> pBuffer {(BYTE *)DiabloAllocPtr(2 * width)};
+	DiabloUniqPtr<BYTE> pBuffer = DiabloMakeUnique<BYTE>(2 * width);
 	BYTE *pixels = buf.begin();
 	for (int height = buf.h(); height > 0; height--) {
 		const BYTE *pBufferEnd = CaptureEnc(pixels, pBuffer.get(), width);

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -116,7 +116,7 @@ static BYTE *CaptureEnc(BYTE *src, BYTE *dst, int width)
 static bool CapturePix(const CelOutputBuffer &buf, std::ofstream *out)
 {
 	int width = buf.w();
-	std::unique_ptr<BYTE []> pBuffer = std::make_unique<BYTE[]>(2 * width);
+	auto pBuffer = std::make_unique<BYTE[]>(2 * width);
 	BYTE *pixels = buf.begin();
 	for (int height = buf.h(); height > 0; height--) {
 		const BYTE *pBufferEnd = CaptureEnc(pixels, pBuffer.get(), width);

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -116,16 +116,15 @@ static BYTE *CaptureEnc(BYTE *src, BYTE *dst, int width)
 static bool CapturePix(const CelOutputBuffer &buf, std::ofstream *out)
 {
 	int width = buf.w();
-	BYTE *pBuffer = (BYTE *)DiabloAllocPtr(2 * width);
+	std::unique_ptr<BYTE, DiabloDeleter> pBuffer {(BYTE *)DiabloAllocPtr(2 * width)};
 	BYTE *pixels = buf.begin();
 	for (int height = buf.h(); height > 0; height--) {
-		const BYTE *pBufferEnd = CaptureEnc(pixels, pBuffer, width);
+		const BYTE *pBufferEnd = CaptureEnc(pixels, pBuffer.get(), width);
 		pixels += buf.pitch();
-		out->write(reinterpret_cast<const char *>(pBuffer), pBufferEnd - pBuffer);
+		out->write(reinterpret_cast<const char *>(pBuffer.get()), pBufferEnd - pBuffer.get());
 		if (out->fail())
 			return false;
 	}
-	mem_free_dbg(pBuffer);
 	return true;
 }
 

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -116,7 +116,7 @@ static BYTE *CaptureEnc(BYTE *src, BYTE *dst, int width)
 static bool CapturePix(const CelOutputBuffer &buf, std::ofstream *out)
 {
 	int width = buf.w();
-	DiabloUniqPtr<BYTE> pBuffer = DiabloMakeUnique(BYTE, 2 * width);
+	std::unique_ptr<BYTE> pBuffer = DiabloMakeUnique(BYTE, 2 * width);
 	BYTE *pixels = buf.begin();
 	for (int height = buf.h(); height > 0; height--) {
 		const BYTE *pBufferEnd = CaptureEnc(pixels, pBuffer.get(), width);

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -116,7 +116,7 @@ static BYTE *CaptureEnc(BYTE *src, BYTE *dst, int width)
 static bool CapturePix(const CelOutputBuffer &buf, std::ofstream *out)
 {
 	int width = buf.w();
-	std::unique_ptr<BYTE> pBuffer = DiabloMakeUnique(BYTE, 2 * width);
+	std::unique_ptr<BYTE> pBuffer = DiabloMakeUnique<BYTE>(2 * width);
 	BYTE *pixels = buf.begin();
 	for (int height = buf.h(); height > 0; height--) {
 		const BYTE *pBufferEnd = CaptureEnc(pixels, pBuffer.get(), width);

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -116,7 +116,7 @@ static BYTE *CaptureEnc(BYTE *src, BYTE *dst, int width)
 static bool CapturePix(const CelOutputBuffer &buf, std::ofstream *out)
 {
 	int width = buf.w();
-	std::unique_ptr<BYTE> pBuffer = DiabloMakeUnique<BYTE>(2 * width);
+	std::unique_ptr<BYTE []> pBuffer = std::make_unique<BYTE[]>(2 * width);
 	BYTE *pixels = buf.begin();
 	for (int height = buf.h(); height > 0; height--) {
 		const BYTE *pBufferEnd = CaptureEnc(pixels, pBuffer.get(), width);

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -116,7 +116,7 @@ static BYTE *CaptureEnc(BYTE *src, BYTE *dst, int width)
 static bool CapturePix(const CelOutputBuffer &buf, std::ofstream *out)
 {
 	int width = buf.w();
-	DiabloUniqPtr<BYTE> pBuffer = DiabloMakeUnique<BYTE>(2 * width);
+	DiabloUniqPtr<BYTE> pBuffer = DiabloMakeUnique(BYTE, 2 * width);
 	BYTE *pixels = buf.begin();
 	for (int height = buf.h(); height > 0; height--) {
 		const BYTE *pBufferEnd = CaptureEnc(pixels, pBuffer.get(), width);

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -137,7 +137,7 @@ struct ActorPosition {
 
 #define DiabloMakeUnique(T, NUM_BYTES) \
 	[](size_t size) {\
-		assert(sizeof(T) >= size); \
+		assert(sizeof(T) <= size); \
 		auto ret = std::unique_ptr<T>{reinterpret_cast<T *>(new uint8_t[size])}; \
 		new(ret.get())T(); \
 		return ret; \

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -146,11 +146,8 @@ struct DiabloDeleter
 template <typename T>
 using DiabloUniqPtr = std::unique_ptr<T, DiabloDeleter>;
 
-template <typename T>
-DiabloUniqPtr<T> DiabloMakeUnique(size_t size)
-{
-	return DiabloUniqPtr<T>{reinterpret_cast<T *>(DiabloAllocPtr(size))};
-}
+#define DiabloMakeUnique(T, size) \
+	DiabloUniqPtr<T>{reinterpret_cast<T *>(DiabloAllocPtr(size))}
 
 inline BYTE *CelGetFrameStart(BYTE *pCelBuff, int nCel)
 {

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -17,6 +17,7 @@
 #include <cstdlib>
 #include <SDL.h>
 #include <cstdint>
+#include <memory>
 
 #ifdef USE_SDL1
 #include "utils/sdl2_to_1_2_backports.h"
@@ -141,6 +142,15 @@ struct DiabloDeleter
 		mem_free_dbg(ptr);
 	}
 };
+
+template <typename T>
+using DiabloUniqPtr = std::unique_ptr<T, DiabloDeleter>;
+
+template <typename T>
+DiabloUniqPtr<T> DiabloMakeUnique(size_t size)
+{
+	return DiabloUniqPtr<T>{reinterpret_cast<T *>(DiabloAllocPtr(size))};
+}
 
 inline BYTE *CelGetFrameStart(BYTE *pCelBuff, int nCel)
 {

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -148,6 +148,7 @@ using DiabloUniqPtr = std::unique_ptr<T, DiabloDeleter>;
 
 #define DiabloMakeUnique(T, NUM_BYTES) \
 	[](size_t size) {\
+		assert(sizeof(T) >= size); \
 		auto ret = DiabloUniqPtr<T>{reinterpret_cast<T *>(DiabloAllocPtr(size))}; \
 		new(ret.get())T(); \
 		return ret; \

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -146,8 +146,12 @@ struct DiabloDeleter
 template <typename T>
 using DiabloUniqPtr = std::unique_ptr<T, DiabloDeleter>;
 
-#define DiabloMakeUnique(T, size) \
-	DiabloUniqPtr<T>{reinterpret_cast<T *>(DiabloAllocPtr(size))}
+#define DiabloMakeUnique(T, NUM_BYTES) \
+	[](size_t size) {\
+		auto ret = DiabloUniqPtr<T>{reinterpret_cast<T *>(DiabloAllocPtr(size))}; \
+		new(ret.get())T(); \
+		return ret; \
+	}(NUM_BYTES)
 
 inline BYTE *CelGetFrameStart(BYTE *pCelBuff, int nCel)
 {

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -135,18 +135,6 @@ struct ActorPosition {
 #define mem_free_dbg(PTR) \
 	std::free(PTR)
 
-template <typename T>
-std::unique_ptr<T> DiabloMakeUnique(size_t size)
-{
-	assert(sizeof(T) <= size);
-
-	uint8_t *mem = new uint8_t[size];
-	auto ret = std::unique_ptr<T>{reinterpret_cast<T *>(mem)};
-
-	new(mem)T();
-	return ret;
-}
-
 inline BYTE *CelGetFrameStart(BYTE *pCelBuff, int nCel)
 {
 	DWORD *pFrameTable;

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -135,21 +135,10 @@ struct ActorPosition {
 #define mem_free_dbg(PTR) \
 	std::free(PTR)
 
-struct DiabloDeleter
-{
-	void operator ()(void *ptr)
-	{
-		mem_free_dbg(ptr);
-	}
-};
-
-template <typename T>
-using DiabloUniqPtr = std::unique_ptr<T, DiabloDeleter>;
-
 #define DiabloMakeUnique(T, NUM_BYTES) \
 	[](size_t size) {\
 		assert(sizeof(T) >= size); \
-		auto ret = DiabloUniqPtr<T>{reinterpret_cast<T *>(DiabloAllocPtr(size))}; \
+		auto ret = std::unique_ptr<T>{reinterpret_cast<T *>(new uint8_t[size])}; \
 		new(ret.get())T(); \
 		return ret; \
 	}(NUM_BYTES)

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -134,6 +134,14 @@ struct ActorPosition {
 #define mem_free_dbg(PTR) \
 	std::free(PTR)
 
+struct DiabloDeleter
+{
+	void operator ()(void *ptr)
+	{
+		mem_free_dbg(ptr);
+	}
+};
+
 inline BYTE *CelGetFrameStart(BYTE *pCelBuff, int nCel)
 {
 	DWORD *pFrameTable;

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -17,7 +17,6 @@
 #include <cstdlib>
 #include <SDL.h>
 #include <cstdint>
-#include <memory>
 
 #ifdef USE_SDL1
 #include "utils/sdl2_to_1_2_backports.h"

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -135,13 +135,17 @@ struct ActorPosition {
 #define mem_free_dbg(PTR) \
 	std::free(PTR)
 
-#define DiabloMakeUnique(T, NUM_BYTES) \
-	[](size_t size) {\
-		assert(sizeof(T) <= size); \
-		auto ret = std::unique_ptr<T>{reinterpret_cast<T *>(new uint8_t[size])}; \
-		new(ret.get())T(); \
-		return ret; \
-	}(NUM_BYTES)
+template <typename T>
+std::unique_ptr<T> DiabloMakeUnique(size_t size)
+{
+	assert(sizeof(T) <= size);
+
+	uint8_t *mem = new uint8_t[size];
+	auto ret = std::unique_ptr<T>{reinterpret_cast<T *>(mem)};
+
+	new(mem)T();
+	return ret;
+}
 
 inline BYTE *CelGetFrameStart(BYTE *pCelBuff, int nCel)
 {


### PR DESCRIPTION
If there's some error when writing the screenshot to the file, the buffer does not get freed.

(As a fun fact, this is literally the first hit that my IDE yielded when searching for DiabloAllocPtr.)

I was conservative with this commit, and used the DiabloAllocPtr and mem_free_dbg macros. Going forward, should we still use them in cases where we can make memory management automatic? (The network code, for example, does not use them.)