### PR TITLE
Add fmt format for translations

### DIFF
--- a/Source/DiabloUI/selconn.cpp
+++ b/Source/DiabloUI/selconn.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include "DiabloUI/diabloui.h"
 #include "DiabloUI/text.h"
 #include "stores.h"
@@ -112,7 +114,7 @@ void SelconnFocus(int value)
 		break;
 	}
 
-	snprintf(selconn_MaxPlayers, sizeof(selconn_MaxPlayers), _("Players Supported: %i"), players);
+	snprintf(selconn_MaxPlayers, sizeof(selconn_MaxPlayers), fmt::format(_("Players Supported: %i"), players).c_str());
 	WordWrapArtStr(selconn_Description, DESCRIPTION_WIDTH);
 }
 

--- a/Source/DiabloUI/selconn.cpp
+++ b/Source/DiabloUI/selconn.cpp
@@ -114,7 +114,7 @@ void SelconnFocus(int value)
 		break;
 	}
 
-	snprintf(selconn_MaxPlayers, sizeof(selconn_MaxPlayers), fmt::format(_("Players Supported: {:d}"), players).c_str());
+	strncpy(selconn_MaxPlayers, fmt::format(_("Players Supported: {:d}"), players).c_str(), sizeof(selconn_MaxPlayers));
 	WordWrapArtStr(selconn_Description, DESCRIPTION_WIDTH);
 }
 

--- a/Source/DiabloUI/selconn.cpp
+++ b/Source/DiabloUI/selconn.cpp
@@ -114,7 +114,7 @@ void SelconnFocus(int value)
 		break;
 	}
 
-	snprintf(selconn_MaxPlayers, sizeof(selconn_MaxPlayers), fmt::format(_("Players Supported: %i"), players).c_str());
+	snprintf(selconn_MaxPlayers, sizeof(selconn_MaxPlayers), fmt::format(_("Players Supported: {:d}"), players).c_str());
 	WordWrapArtStr(selconn_Description, DESCRIPTION_WIDTH);
 }
 

--- a/Source/DiabloUI/selgame.cpp
+++ b/Source/DiabloUI/selgame.cpp
@@ -1,5 +1,7 @@
 #include "selgame.h"
 
+#include <fmt/format.h>
+
 #include "DiabloUI/diabloui.h"
 #include "DiabloUI/dialogs.h"
 #include "DiabloUI/selhero.h"
@@ -412,7 +414,7 @@ static bool IsGameCompatible(GameData *data)
 		UiSelOkDialog(title, _("The host is running a different game than you."), false);
 	} else {
 		char msg[64];
-		sprintf(msg, _( /* TRANSLATORS: Error message when somebody tries to join a game running another version. */ "Your version %s does not match the host %i.%i.%i."), PROJECT_VERSION, PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR, PROJECT_VERSION_PATCH);
+		sprintf(msg, fmt::format(_(/* TRANSLATORS: Error message when somebody tries to join a game running another version. */ "Your version %s does not match the host %i.%i.%i."), PROJECT_VERSION, PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR, PROJECT_VERSION_PATCH).c_str());
 
 		UiSelOkDialog(title, msg, false);
 	}

--- a/Source/DiabloUI/selgame.cpp
+++ b/Source/DiabloUI/selgame.cpp
@@ -414,7 +414,7 @@ static bool IsGameCompatible(GameData *data)
 		UiSelOkDialog(title, _("The host is running a different game than you."), false);
 	} else {
 		char msg[64];
-		sprintf(msg, fmt::format(_(/* TRANSLATORS: Error message when somebody tries to join a game running another version. */ "Your version %s does not match the host %i.%i.%i."), PROJECT_VERSION, PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR, PROJECT_VERSION_PATCH).c_str());
+		sprintf(msg, fmt::format(_(/* TRANSLATORS: Error message when somebody tries to join a game running another version. */ "Your version {:s} does not match the host {:d}.{:d}.{:d}."), PROJECT_VERSION, PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR, PROJECT_VERSION_PATCH).c_str());
 
 		UiSelOkDialog(title, msg, false);
 	}

--- a/Source/DiabloUI/selgame.cpp
+++ b/Source/DiabloUI/selgame.cpp
@@ -414,7 +414,7 @@ static bool IsGameCompatible(GameData *data)
 		UiSelOkDialog(title, _("The host is running a different game than you."), false);
 	} else {
 		char msg[64];
-		sprintf(msg, fmt::format(_(/* TRANSLATORS: Error message when somebody tries to join a game running another version. */ "Your version {:s} does not match the host {:d}.{:d}.{:d}."), PROJECT_VERSION, PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR, PROJECT_VERSION_PATCH).c_str());
+		strcpy(msg, fmt::format(_(/* TRANSLATORS: Error message when somebody tries to join a game running another version. */ "Your version {:s} does not match the host {:d}.{:d}.{:d}."), PROJECT_VERSION, PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR, PROJECT_VERSION_PATCH).c_str());
 
 		UiSelOkDialog(title, msg, false);
 	}

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -4,6 +4,8 @@
 #include <chrono>
 #include <random>
 
+#include <fmt/format.h>
+
 #include "DiabloUI/diabloui.h"
 #include "DiabloUI/dialogs.h"
 #include "DiabloUI/scrollbar.h"
@@ -342,7 +344,7 @@ void SelheroNameSelect(int value)
 			if (strcasecmp(selhero_heros[i].name, selhero_heroInfo.name) == 0) {
 				ArtBackground.Unload();
 				char dialogText[256];
-				snprintf(dialogText, sizeof(dialogText), _( /* Error message when User tries to create multiple heros with the same name */ "Character already exists. Do you want to overwrite \"%s\"?"), selhero_heroInfo.name);
+				snprintf(dialogText, sizeof(dialogText), fmt::format(_(/* Error message when User tries to create multiple heros with the same name */ "Character already exists. Do you want to overwrite \"%s\"?"), selhero_heroInfo.name).c_str());
 
 				overwrite = UiSelHeroYesNoDialog(title, dialogText);
 				LoadBackgroundArt("ui_art\\selhero.pcx");
@@ -355,7 +357,7 @@ void SelheroNameSelect(int value)
 				SelheroLoadSelect(1);
 				return;
 			}
-			UiErrorOkDialog(_( /* TRANSLATORS: Error Message */ "Unable to create character."), vecSelDlgItems);
+			UiErrorOkDialog(_(/* TRANSLATORS: Error Message */ "Unable to create character."), vecSelDlgItems);
 		}
 	}
 
@@ -619,7 +621,7 @@ static void UiSelHeroDialog(
 			} else {
 				strncpy(dialogTitle, _("Delete Single Player Hero"), sizeof(dialogTitle) - 1);
 			}
-			snprintf(dialogText, sizeof(dialogText), _("Are you sure you want to delete the character \"%s\"?"), selhero_heroInfo.name);
+			snprintf(dialogText, sizeof(dialogText), fmt::format(_("Are you sure you want to delete the character \"%s\"?"), selhero_heroInfo.name).c_str());
 
 			if (UiSelHeroYesNoDialog(dialogTitle, dialogText))
 				fnremove(&selhero_heroInfo);

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -344,7 +344,7 @@ void SelheroNameSelect(int value)
 			if (strcasecmp(selhero_heros[i].name, selhero_heroInfo.name) == 0) {
 				ArtBackground.Unload();
 				char dialogText[256];
-				snprintf(dialogText, sizeof(dialogText), fmt::format(_(/* Error message when User tries to create multiple heros with the same name */ "Character already exists. Do you want to overwrite \"%s\"?"), selhero_heroInfo.name).c_str());
+				snprintf(dialogText, sizeof(dialogText), fmt::format(_(/* Error message when User tries to create multiple heros with the same name */ "Character already exists. Do you want to overwrite \"{:s}\"?"), selhero_heroInfo.name).c_str());
 
 				overwrite = UiSelHeroYesNoDialog(title, dialogText);
 				LoadBackgroundArt("ui_art\\selhero.pcx");
@@ -621,7 +621,7 @@ static void UiSelHeroDialog(
 			} else {
 				strncpy(dialogTitle, _("Delete Single Player Hero"), sizeof(dialogTitle) - 1);
 			}
-			snprintf(dialogText, sizeof(dialogText), fmt::format(_("Are you sure you want to delete the character \"%s\"?"), selhero_heroInfo.name).c_str());
+			snprintf(dialogText, sizeof(dialogText), fmt::format(_("Are you sure you want to delete the character \"{:s}\"?"), selhero_heroInfo.name).c_str());
 
 			if (UiSelHeroYesNoDialog(dialogTitle, dialogText))
 				fnremove(&selhero_heroInfo);

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -344,7 +344,7 @@ void SelheroNameSelect(int value)
 			if (strcasecmp(selhero_heros[i].name, selhero_heroInfo.name) == 0) {
 				ArtBackground.Unload();
 				char dialogText[256];
-				snprintf(dialogText, sizeof(dialogText), fmt::format(_(/* Error message when User tries to create multiple heros with the same name */ "Character already exists. Do you want to overwrite \"{:s}\"?"), selhero_heroInfo.name).c_str());
+				strncpy(dialogText, fmt::format(_(/* Error message when User tries to create multiple heros with the same name */ "Character already exists. Do you want to overwrite \"{:s}\"?"), selhero_heroInfo.name).c_str(), sizeof(dialogText));
 
 				overwrite = UiSelHeroYesNoDialog(title, dialogText);
 				LoadBackgroundArt("ui_art\\selhero.pcx");
@@ -621,7 +621,7 @@ static void UiSelHeroDialog(
 			} else {
 				strncpy(dialogTitle, _("Delete Single Player Hero"), sizeof(dialogTitle) - 1);
 			}
-			snprintf(dialogText, sizeof(dialogText), fmt::format(_("Are you sure you want to delete the character \"{:s}\"?"), selhero_heroInfo.name).c_str());
+			strncpy(dialogText, fmt::format(_("Are you sure you want to delete the character \"{:s}\"?"), selhero_heroInfo.name).c_str(), sizeof(dialogText));
 
 			if (UiSelHeroYesNoDialog(dialogTitle, dialogText))
 				fnremove(&selhero_heroInfo);

--- a/Source/appfat.cpp
+++ b/Source/appfat.cpp
@@ -6,6 +6,8 @@
 
 #include <config.h>
 
+#include <fmt/format.h>
+
 #include "diablo.h"
 #include "storm/storm.h"
 #include "utils/ui_fwd.h"
@@ -114,7 +116,7 @@ void ErrDlg(const char *title, const char *error, const char *logFilePath, int l
 
 	FreeDlg();
 
-	snprintf(text, sizeof(text), _( /* TRANSLATORS: Error message that displays relevant information for bug report */ "%s\n\nThe error occurred at: %s line %i"), error, logFilePath, logLineNr);
+	snprintf(text, sizeof(text), fmt::format(_(/* TRANSLATORS: Error message that displays relevant information for bug report */ "%s\n\nThe error occurred at: %s line %i"), error, logFilePath, logLineNr).c_str());
 
 	UiErrorOkDialog(title, text);
 	app_fatal(nullptr);
@@ -134,13 +136,13 @@ void FileErrDlg(const char *error)
 	snprintf(
 	    text,
 	    sizeof(text),
-	    _( /* TRANSLATORS: Error Message when diabdat.mpq is broken. Keep values unchanged. */ "Unable to open a required file.\n"
-	      "\n"
-	      "Verify that the MD5 of diabdat.mpq matches one of the following values\n"
-	      "011bc6518e6166206231080a4440b373\n"
-	      "68f049866b44688a7af65ba766bef75a\n"
-	      "\n"
-	      "The problem occurred when loading:\n%s"),
+	    _(/* TRANSLATORS: Error Message when diabdat.mpq is broken. Keep values unchanged. */ "Unable to open a required file.\n"
+	                                                                                          "\n"
+	                                                                                          "Verify that the MD5 of diabdat.mpq matches one of the following values\n"
+	                                                                                          "011bc6518e6166206231080a4440b373\n"
+	                                                                                          "68f049866b44688a7af65ba766bef75a\n"
+	                                                                                          "\n"
+	                                                                                          "The problem occurred when loading:\n%s"),
 	    error);
 
 	UiErrorOkDialog(_("Data File Error"), text);
@@ -173,7 +175,7 @@ void DirErrorDlg(const char *error)
 {
 	char text[1024];
 
-	snprintf(text, sizeof(text), _( /* TRANSLATORS: Error when Program is not allowed to write data */"Unable to write to location:\n%s"), error);
+	snprintf(text, sizeof(text), fmt::format(_(/* TRANSLATORS: Error when Program is not allowed to write data */ "Unable to write to location:\n%s"), error).c_str());
 
 	UiErrorOkDialog(_("Read-Only Directory Error"), text);
 	app_fatal(nullptr);

--- a/Source/appfat.cpp
+++ b/Source/appfat.cpp
@@ -116,7 +116,7 @@ void ErrDlg(const char *title, const char *error, const char *logFilePath, int l
 
 	FreeDlg();
 
-	snprintf(text, sizeof(text), fmt::format(_(/* TRANSLATORS: Error message that displays relevant information for bug report */ "{:s}\n\nThe error occurred at: {:s} line {:d}"), error, logFilePath, logLineNr).c_str());
+	strncpy(text, fmt::format(_(/* TRANSLATORS: Error message that displays relevant information for bug report */ "{:s}\n\nThe error occurred at: {:s} line {:d}"), error, logFilePath, logLineNr).c_str(), sizeof(text));
 
 	UiErrorOkDialog(title, text);
 	app_fatal(nullptr);
@@ -175,7 +175,7 @@ void DirErrorDlg(const char *error)
 {
 	char text[1024];
 
-	snprintf(text, sizeof(text), fmt::format(_(/* TRANSLATORS: Error when Program is not allowed to write data */ "Unable to write to location:\n{:s}"), error).c_str());
+	strncpy(text, fmt::format(_(/* TRANSLATORS: Error when Program is not allowed to write data */ "Unable to write to location:\n{:s}"), error).c_str(), sizeof(text));
 
 	UiErrorOkDialog(_("Read-Only Directory Error"), text);
 	app_fatal(nullptr);

--- a/Source/appfat.cpp
+++ b/Source/appfat.cpp
@@ -116,7 +116,7 @@ void ErrDlg(const char *title, const char *error, const char *logFilePath, int l
 
 	FreeDlg();
 
-	snprintf(text, sizeof(text), fmt::format(_(/* TRANSLATORS: Error message that displays relevant information for bug report */ "%s\n\nThe error occurred at: %s line %i"), error, logFilePath, logLineNr).c_str());
+	snprintf(text, sizeof(text), fmt::format(_(/* TRANSLATORS: Error message that displays relevant information for bug report */ "{:s}\n\nThe error occurred at: {:s} line {:d}"), error, logFilePath, logLineNr).c_str());
 
 	UiErrorOkDialog(title, text);
 	app_fatal(nullptr);
@@ -175,7 +175,7 @@ void DirErrorDlg(const char *error)
 {
 	char text[1024];
 
-	snprintf(text, sizeof(text), fmt::format(_(/* TRANSLATORS: Error when Program is not allowed to write data */ "Unable to write to location:\n%s"), error).c_str());
+	snprintf(text, sizeof(text), fmt::format(_(/* TRANSLATORS: Error when Program is not allowed to write data */ "Unable to write to location:\n{:s}"), error).c_str());
 
 	UiErrorOkDialog(_("Read-Only Directory Error"), text);
 	app_fatal(nullptr);

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -404,11 +404,11 @@ void DrawAutomapText(const CelOutputBuffer &out)
 
 	if (currlevel != 0) {
 		if (currlevel >= 17 && currlevel <= 20) {
-			sprintf(desc, fmt::format(_("Level: Nest {:d}"), currlevel - 16).c_str());
+			strcpy(desc, fmt::format(_("Level: Nest {:d}"), currlevel - 16).c_str());
 		} else if (currlevel >= 21 && currlevel <= 24) {
-			sprintf(desc, fmt::format(_("Level: Crypt {:d}"), currlevel - 20).c_str());
+			strcpy(desc, fmt::format(_("Level: Crypt {:d}"), currlevel - 20).c_str());
 		} else {
-			sprintf(desc, fmt::format(_("Level: {:d}"), currlevel).c_str());
+			strcpy(desc, fmt::format(_("Level: {:d}"), currlevel).c_str());
 		}
 
 		DrawString(out, desc, { 8, nextLine, 0, 0 });

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -7,6 +7,8 @@
 
 #include <algorithm>
 
+#include <fmt/format.h>
+
 #include "control.h"
 #include "engine/render/automap_render.hpp"
 #include "inv.h"
@@ -402,11 +404,11 @@ void DrawAutomapText(const CelOutputBuffer &out)
 
 	if (currlevel != 0) {
 		if (currlevel >= 17 && currlevel <= 20) {
-			sprintf(desc, _("Level: Nest %i"), currlevel - 16);
+			sprintf(desc, fmt::format(_("Level: Nest %i"), currlevel - 16).c_str());
 		} else if (currlevel >= 21 && currlevel <= 24) {
-			sprintf(desc, _("Level: Crypt %i"), currlevel - 20);
+			sprintf(desc, fmt::format(_("Level: Crypt %i"), currlevel - 20).c_str());
 		} else {
-			sprintf(desc, _("Level: %i"), currlevel);
+			sprintf(desc, fmt::format(_("Level: %i"), currlevel).c_str());
 		}
 
 		DrawString(out, desc, { 8, nextLine, 0, 0 });

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -404,11 +404,11 @@ void DrawAutomapText(const CelOutputBuffer &out)
 
 	if (currlevel != 0) {
 		if (currlevel >= 17 && currlevel <= 20) {
-			sprintf(desc, fmt::format(_("Level: Nest %i"), currlevel - 16).c_str());
+			sprintf(desc, fmt::format(_("Level: Nest {:d}"), currlevel - 16).c_str());
 		} else if (currlevel >= 21 && currlevel <= 24) {
-			sprintf(desc, fmt::format(_("Level: Crypt %i"), currlevel - 20).c_str());
+			sprintf(desc, fmt::format(_("Level: Crypt {:d}"), currlevel - 20).c_str());
 		} else {
-			sprintf(desc, fmt::format(_("Level: %i"), currlevel).c_str());
+			sprintf(desc, fmt::format(_("Level: {:d}"), currlevel).c_str());
 		}
 
 		DrawString(out, desc, { 8, nextLine, 0, 0 });

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -393,10 +393,10 @@ void DrawSpellList(const CelOutputBuffer &out)
 				DrawSpellCel(out, x, y, *pSpellCels, c);
 				switch (pSplType) {
 				case RSPLTYPE_SKILL:
-					sprintf(infostr, fmt::format(_("%s Skill"), _(spelldata[pSpell].sSkillText)).c_str());
+					sprintf(infostr, fmt::format(_("{:s} Skill"), _(spelldata[pSpell].sSkillText)).c_str());
 					break;
 				case RSPLTYPE_SPELL:
-					sprintf(infostr, fmt::format(_("%s Spell"), _(spelldata[pSpell].sNameText)).c_str());
+					sprintf(infostr, fmt::format(_("{:s} Spell"), _(spelldata[pSpell].sNameText)).c_str());
 					if (pSpell == SPL_HBOLT) {
 						strcpy(tempstr, _("Damages undead only"));
 						AddPanelString(tempstr);
@@ -404,11 +404,11 @@ void DrawSpellList(const CelOutputBuffer &out)
 					if (s == 0)
 						strcpy(tempstr, _("Spell Level 0 - Unusable"));
 					else
-						sprintf(tempstr, fmt::format(_("Spell Level %i"), s).c_str());
+						sprintf(tempstr, fmt::format(_("Spell Level {:d}"), s).c_str());
 					AddPanelString(tempstr);
 					break;
 				case RSPLTYPE_SCROLL: {
-					sprintf(infostr, fmt::format(_("Scroll of %s"), _(spelldata[pSpell].sNameText)).c_str());
+					sprintf(infostr, fmt::format(_("Scroll of {:s}"), _(spelldata[pSpell].sNameText)).c_str());
 					int v = 0;
 					for (int t = 0; t < plr[myplr]._pNumInv; t++) {
 						if (!plr[myplr].InvList[t].isEmpty()
@@ -428,7 +428,7 @@ void DrawSpellList(const CelOutputBuffer &out)
 					AddPanelString(tempstr);
 				} break;
 				case RSPLTYPE_CHARGES: {
-					sprintf(infostr, fmt::format(_("Staff of %s"), _(spelldata[pSpell].sNameText)).c_str());
+					sprintf(infostr, fmt::format(_("Staff of {:s}"), _(spelldata[pSpell].sNameText)).c_str());
 					int charges = plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges;
 					sprintf(tempstr, ngettext("%i Charge", "%i Charges", charges), charges);
 					AddPanelString(tempstr);
@@ -440,7 +440,7 @@ void DrawSpellList(const CelOutputBuffer &out)
 					if (plr[myplr]._pSplHotKey[t] == pSpell && plr[myplr]._pSplTHotKey[t] == pSplType) {
 						auto hotkeyName = keymapper.keyNameForAction(quickSpellActionIndexes[t]);
 						PrintSBookHotkey(out, x, y, hotkeyName);
-						sprintf(tempstr, fmt::format(_("Spell Hotkey %s"), hotkeyName.c_str()).c_str());
+						sprintf(tempstr, fmt::format(_("Spell Hotkey {:s}"), hotkeyName.c_str()).c_str());
 						AddPanelString(tempstr);
 					}
 				}
@@ -917,7 +917,7 @@ void CheckPanelInfo()
 					strcpy(infostr, _("Player attack"));
 			}
 			if (PanBtnHotKey[i] != nullptr) {
-				sprintf(tempstr, fmt::format(_("Hotkey: %s"), _(PanBtnHotKey[i])).c_str());
+				sprintf(tempstr, fmt::format(_("Hotkey: {:s}"), _(PanBtnHotKey[i])).c_str());
 				AddPanelString(tempstr);
 			}
 			infoclr = UIS_SILVER;
@@ -936,11 +936,11 @@ void CheckPanelInfo()
 		if (v != SPL_INVALID) {
 			switch (plr[myplr]._pRSplType) {
 			case RSPLTYPE_SKILL:
-				sprintf(tempstr, fmt::format(_("%s Skill"), _(spelldata[v].sSkillText)).c_str());
+				sprintf(tempstr, fmt::format(_("{:s} Skill"), _(spelldata[v].sSkillText)).c_str());
 				AddPanelString(tempstr);
 				break;
 			case RSPLTYPE_SPELL: {
-				sprintf(tempstr, fmt::format(_("%s Spell"), _(spelldata[v].sNameText)).c_str());
+				sprintf(tempstr, fmt::format(_("{:s} Spell"), _(spelldata[v].sNameText)).c_str());
 				AddPanelString(tempstr);
 				int c = plr[myplr]._pISplLvlAdd + plr[myplr]._pSplLvl[v];
 				if (c < 0)
@@ -948,11 +948,11 @@ void CheckPanelInfo()
 				if (c == 0)
 					strcpy(tempstr, _("Spell Level 0 - Unusable"));
 				else
-					sprintf(tempstr, fmt::format(_("Spell Level %i"), c).c_str());
+					sprintf(tempstr, fmt::format(_("Spell Level {:d}"), c).c_str());
 				AddPanelString(tempstr);
 			} break;
 			case RSPLTYPE_SCROLL: {
-				sprintf(tempstr, fmt::format(_("Scroll of %s"), _(spelldata[v].sNameText)).c_str());
+				sprintf(tempstr, fmt::format(_("Scroll of {:s}"), _(spelldata[v].sNameText)).c_str());
 				AddPanelString(tempstr);
 				int s = 0;
 				for (int i = 0; i < plr[myplr]._pNumInv; i++) {
@@ -973,7 +973,7 @@ void CheckPanelInfo()
 				AddPanelString(tempstr);
 			} break;
 			case RSPLTYPE_CHARGES:
-				sprintf(tempstr, fmt::format(_("Staff of %s"), _(spelldata[v].sNameText)).c_str());
+				sprintf(tempstr, fmt::format(_("Staff of {:s}"), _(spelldata[v].sNameText)).c_str());
 				AddPanelString(tempstr);
 				sprintf(tempstr, ngettext("%i Charge", "%i Charges", plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges), plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges);
 				AddPanelString(tempstr);
@@ -1162,9 +1162,9 @@ void DrawInfoBox(const CelOutputBuffer &out)
 			infoclr = UIS_GOLD;
 			strcpy(infostr, plr[pcursplr]._pName);
 			ClearPanel();
-			sprintf(tempstr, fmt::format(_("%s, Level: %i"), _(ClassStrTbl[static_cast<std::size_t>(plr[pcursplr]._pClass)]), plr[pcursplr]._pLevel).c_str());
+			sprintf(tempstr, fmt::format(_("{:s}, Level: {:d}"), _(ClassStrTbl[static_cast<std::size_t>(plr[pcursplr]._pClass)]), plr[pcursplr]._pLevel).c_str());
 			AddPanelString(tempstr);
-			sprintf(tempstr, fmt::format(_("Hit Points %i of %i"), plr[pcursplr]._pHitPoints >> 6, plr[pcursplr]._pMaxHP >> 6).c_str());
+			sprintf(tempstr, fmt::format(_("Hit Points {:d} of {:d}"), plr[pcursplr]._pHitPoints >> 6, plr[pcursplr]._pMaxHP >> 6).c_str());
 			AddPanelString(tempstr);
 		}
 	}
@@ -1627,12 +1627,12 @@ void DrawSpellBook(const CelOutputBuffer &out)
 				int max;
 				GetDamageAmt(sn, &min, &max);
 				if (min != -1) {
-					sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: %i  Dam: %i - %i"), mana, min, max).c_str());
+					sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: {:d}  Dam: {:d} - {:d}"), mana, min, max).c_str());
 				} else {
-					sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: %i   Dam: n/a"), mana).c_str());
+					sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: {:d}   Dam: n/a"), mana).c_str());
 				}
 				if (sn == SPL_BONESPIRIT) {
-					sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: %i  Dam: 1/3 tgt hp"), mana).c_str());
+					sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: {:d}  Dam: 1/3 tgt hp"), mana).c_str());
 				}
 				PrintSBookStr(out, 10, yp - 1, tempstr);
 				int lvl = plr[myplr]._pSplLvl[sn] + plr[myplr]._pISplLvlAdd;
@@ -1642,7 +1642,7 @@ void DrawSpellBook(const CelOutputBuffer &out)
 				if (lvl == 0) {
 					strcpy(tempstr, _("Spell Level 0 - Unusable"));
 				} else {
-					sprintf(tempstr, fmt::format(_("Spell Level %i"), lvl).c_str());
+					sprintf(tempstr, fmt::format(_("Spell Level {:d}"), lvl).c_str());
 				}
 			} break;
 			}

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -424,13 +424,13 @@ void DrawSpellList(const CelOutputBuffer &out)
 							v++;
 						}
 					}
-					sprintf(tempstr, ngettext("%i Scroll", "%i Scrolls", v), v);
+					strcpy(tempstr, fmt::format(ngettext("{:d} Scroll", "{:d} Scrolls", v), v).c_str());
 					AddPanelString(tempstr);
 				} break;
 				case RSPLTYPE_CHARGES: {
 					strcpy(infostr, fmt::format(_("Staff of {:s}"), _(spelldata[pSpell].sNameText)).c_str());
 					int charges = plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges;
-					sprintf(tempstr, ngettext("%i Charge", "%i Charges", charges), charges);
+					strcpy(tempstr, fmt::format(ngettext("{:d} Charge", "{:d} Charges", charges), charges).c_str());
 					AddPanelString(tempstr);
 				} break;
 				case RSPLTYPE_INVALID:
@@ -969,13 +969,13 @@ void CheckPanelInfo()
 						s++;
 					}
 				}
-				sprintf(tempstr, ngettext("%i Scroll", "%i Scrolls", s), s);
+				strcpy(tempstr, fmt::format(ngettext("{:d} Scroll", "{:d} Scrolls", s), s).c_str());
 				AddPanelString(tempstr);
 			} break;
 			case RSPLTYPE_CHARGES:
 				strcpy(tempstr, fmt::format(_("Staff of {:s}"), _(spelldata[v].sNameText)).c_str());
 				AddPanelString(tempstr);
-				sprintf(tempstr, ngettext("%i Charge", "%i Charges", plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges), plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges);
+				strcpy(tempstr, fmt::format(ngettext("{:d} Charge", "{:d} Charges", plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges), plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges).c_str());
 				AddPanelString(tempstr);
 				break;
 			case RSPLTYPE_INVALID:
@@ -1121,7 +1121,7 @@ void DrawInfoBox(const CelOutputBuffer &out)
 	} else if (pcurs >= CURSOR_FIRSTITEM) {
 		if (plr[myplr].HoldItem._itype == ITYPE_GOLD) {
 			int nGold = plr[myplr].HoldItem._ivalue;
-			sprintf(infostr, ngettext("%i gold piece", "%i gold pieces", nGold), nGold);
+			strcpy(infostr, fmt::format(ngettext("{:d} gold piece", "{:d} gold pieces", nGold), nGold).c_str());
 		} else if (!plr[myplr].HoldItem._iStatFlag) {
 			ClearPanel();
 			AddPanelString(_("Requirements not met"));
@@ -1619,7 +1619,7 @@ void DrawSpellBook(const CelOutputBuffer &out)
 				break;
 			case RSPLTYPE_CHARGES: {
 				int charges = plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges;
-				sprintf(tempstr, ngettext("Staff (%i charge)", "Staff (%i charges)", charges), charges);
+				strcpy(tempstr, fmt::format(ngettext("Staff ({:d} charge)", "Staff ({:d} charges)", charges), charges).c_str());
 			} break;
 			default: {
 				int mana = GetManaAmount(myplr, sn) >> 6;
@@ -1681,13 +1681,14 @@ void DrawGoldSplit(const CelOutputBuffer &out, int amount)
 
 	CelDrawTo(out, dialogX, 178, *pGBoxBuff, 1);
 
-	sprintf(
+	strcpy(
 	    tempstr,
-	    ngettext(
-	        /* TRANSLATORS: %u is a number. Dialog is shown when splitting a stash of Gold.*/ "You have %u gold piece. How many do you want to remove?",
-	        "You have %u gold pieces. How many do you want to remove?",
-	        initialDropGoldValue),
-	    initialDropGoldValue);
+	    fmt::format(ngettext(
+	                    /* TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.*/ "You have {:d} gold piece. How many do you want to remove?",
+	                    "You have {:d} gold pieces. How many do you want to remove?",
+	                    initialDropGoldValue),
+	        initialDropGoldValue)
+	        .c_str());
 	WordWrapGameString(tempstr, 200);
 	DrawString(out, tempstr, { dialogX + 31, 87, 200, 50 }, UIS_GOLD | UIS_CENTER, 1, 17);
 

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -393,10 +393,10 @@ void DrawSpellList(const CelOutputBuffer &out)
 				DrawSpellCel(out, x, y, *pSpellCels, c);
 				switch (pSplType) {
 				case RSPLTYPE_SKILL:
-					sprintf(infostr, fmt::format(_("{:s} Skill"), _(spelldata[pSpell].sSkillText)).c_str());
+					strcpy(infostr, fmt::format(_("{:s} Skill"), _(spelldata[pSpell].sSkillText)).c_str());
 					break;
 				case RSPLTYPE_SPELL:
-					sprintf(infostr, fmt::format(_("{:s} Spell"), _(spelldata[pSpell].sNameText)).c_str());
+					strcpy(infostr, fmt::format(_("{:s} Spell"), _(spelldata[pSpell].sNameText)).c_str());
 					if (pSpell == SPL_HBOLT) {
 						strcpy(tempstr, _("Damages undead only"));
 						AddPanelString(tempstr);
@@ -404,11 +404,11 @@ void DrawSpellList(const CelOutputBuffer &out)
 					if (s == 0)
 						strcpy(tempstr, _("Spell Level 0 - Unusable"));
 					else
-						sprintf(tempstr, fmt::format(_("Spell Level {:d}"), s).c_str());
+						strcpy(tempstr, fmt::format(_("Spell Level {:d}"), s).c_str());
 					AddPanelString(tempstr);
 					break;
 				case RSPLTYPE_SCROLL: {
-					sprintf(infostr, fmt::format(_("Scroll of {:s}"), _(spelldata[pSpell].sNameText)).c_str());
+					strcpy(infostr, fmt::format(_("Scroll of {:s}"), _(spelldata[pSpell].sNameText)).c_str());
 					int v = 0;
 					for (int t = 0; t < plr[myplr]._pNumInv; t++) {
 						if (!plr[myplr].InvList[t].isEmpty()
@@ -428,7 +428,7 @@ void DrawSpellList(const CelOutputBuffer &out)
 					AddPanelString(tempstr);
 				} break;
 				case RSPLTYPE_CHARGES: {
-					sprintf(infostr, fmt::format(_("Staff of {:s}"), _(spelldata[pSpell].sNameText)).c_str());
+					strcpy(infostr, fmt::format(_("Staff of {:s}"), _(spelldata[pSpell].sNameText)).c_str());
 					int charges = plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges;
 					sprintf(tempstr, ngettext("%i Charge", "%i Charges", charges), charges);
 					AddPanelString(tempstr);
@@ -440,7 +440,7 @@ void DrawSpellList(const CelOutputBuffer &out)
 					if (plr[myplr]._pSplHotKey[t] == pSpell && plr[myplr]._pSplTHotKey[t] == pSplType) {
 						auto hotkeyName = keymapper.keyNameForAction(quickSpellActionIndexes[t]);
 						PrintSBookHotkey(out, x, y, hotkeyName);
-						sprintf(tempstr, fmt::format(_("Spell Hotkey {:s}"), hotkeyName.c_str()).c_str());
+						strcpy(tempstr, fmt::format(_("Spell Hotkey {:s}"), hotkeyName.c_str()).c_str());
 						AddPanelString(tempstr);
 					}
 				}
@@ -917,7 +917,7 @@ void CheckPanelInfo()
 					strcpy(infostr, _("Player attack"));
 			}
 			if (PanBtnHotKey[i] != nullptr) {
-				sprintf(tempstr, fmt::format(_("Hotkey: {:s}"), _(PanBtnHotKey[i])).c_str());
+				strcpy(tempstr, fmt::format(_("Hotkey: {:s}"), _(PanBtnHotKey[i])).c_str());
 				AddPanelString(tempstr);
 			}
 			infoclr = UIS_SILVER;
@@ -936,11 +936,11 @@ void CheckPanelInfo()
 		if (v != SPL_INVALID) {
 			switch (plr[myplr]._pRSplType) {
 			case RSPLTYPE_SKILL:
-				sprintf(tempstr, fmt::format(_("{:s} Skill"), _(spelldata[v].sSkillText)).c_str());
+				strcpy(tempstr, fmt::format(_("{:s} Skill"), _(spelldata[v].sSkillText)).c_str());
 				AddPanelString(tempstr);
 				break;
 			case RSPLTYPE_SPELL: {
-				sprintf(tempstr, fmt::format(_("{:s} Spell"), _(spelldata[v].sNameText)).c_str());
+				strcpy(tempstr, fmt::format(_("{:s} Spell"), _(spelldata[v].sNameText)).c_str());
 				AddPanelString(tempstr);
 				int c = plr[myplr]._pISplLvlAdd + plr[myplr]._pSplLvl[v];
 				if (c < 0)
@@ -948,11 +948,11 @@ void CheckPanelInfo()
 				if (c == 0)
 					strcpy(tempstr, _("Spell Level 0 - Unusable"));
 				else
-					sprintf(tempstr, fmt::format(_("Spell Level {:d}"), c).c_str());
+					strcpy(tempstr, fmt::format(_("Spell Level {:d}"), c).c_str());
 				AddPanelString(tempstr);
 			} break;
 			case RSPLTYPE_SCROLL: {
-				sprintf(tempstr, fmt::format(_("Scroll of {:s}"), _(spelldata[v].sNameText)).c_str());
+				strcpy(tempstr, fmt::format(_("Scroll of {:s}"), _(spelldata[v].sNameText)).c_str());
 				AddPanelString(tempstr);
 				int s = 0;
 				for (int i = 0; i < plr[myplr]._pNumInv; i++) {
@@ -973,7 +973,7 @@ void CheckPanelInfo()
 				AddPanelString(tempstr);
 			} break;
 			case RSPLTYPE_CHARGES:
-				sprintf(tempstr, fmt::format(_("Staff of {:s}"), _(spelldata[v].sNameText)).c_str());
+				strcpy(tempstr, fmt::format(_("Staff of {:s}"), _(spelldata[v].sNameText)).c_str());
 				AddPanelString(tempstr);
 				sprintf(tempstr, ngettext("%i Charge", "%i Charges", plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges), plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges);
 				AddPanelString(tempstr);
@@ -1162,9 +1162,9 @@ void DrawInfoBox(const CelOutputBuffer &out)
 			infoclr = UIS_GOLD;
 			strcpy(infostr, plr[pcursplr]._pName);
 			ClearPanel();
-			sprintf(tempstr, fmt::format(_("{:s}, Level: {:d}"), _(ClassStrTbl[static_cast<std::size_t>(plr[pcursplr]._pClass)]), plr[pcursplr]._pLevel).c_str());
+			strcpy(tempstr, fmt::format(_("{:s}, Level: {:d}"), _(ClassStrTbl[static_cast<std::size_t>(plr[pcursplr]._pClass)]), plr[pcursplr]._pLevel).c_str());
 			AddPanelString(tempstr);
-			sprintf(tempstr, fmt::format(_("Hit Points {:d} of {:d}"), plr[pcursplr]._pHitPoints >> 6, plr[pcursplr]._pMaxHP >> 6).c_str());
+			strcpy(tempstr, fmt::format(_("Hit Points {:d} of {:d}"), plr[pcursplr]._pHitPoints >> 6, plr[pcursplr]._pMaxHP >> 6).c_str());
 			AddPanelString(tempstr);
 		}
 	}
@@ -1627,12 +1627,12 @@ void DrawSpellBook(const CelOutputBuffer &out)
 				int max;
 				GetDamageAmt(sn, &min, &max);
 				if (min != -1) {
-					sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: {:d}  Dam: {:d} - {:d}"), mana, min, max).c_str());
+					strcpy(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: {:d}  Dam: {:d} - {:d}"), mana, min, max).c_str());
 				} else {
-					sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: {:d}   Dam: n/a"), mana).c_str());
+					strcpy(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: {:d}   Dam: n/a"), mana).c_str());
 				}
 				if (sn == SPL_BONESPIRIT) {
-					sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: {:d}  Dam: 1/3 tgt hp"), mana).c_str());
+					strcpy(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: {:d}  Dam: 1/3 tgt hp"), mana).c_str());
 				}
 				PrintSBookStr(out, 10, yp - 1, tempstr);
 				int lvl = plr[myplr]._pSplLvl[sn] + plr[myplr]._pISplLvlAdd;
@@ -1642,7 +1642,7 @@ void DrawSpellBook(const CelOutputBuffer &out)
 				if (lvl == 0) {
 					strcpy(tempstr, _("Spell Level 0 - Unusable"));
 				} else {
-					sprintf(tempstr, fmt::format(_("Spell Level {:d}"), lvl).c_str());
+					strcpy(tempstr, fmt::format(_("Spell Level {:d}"), lvl).c_str());
 				}
 			} break;
 			}

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -8,6 +8,8 @@
 #include <cstddef>
 #include <array>
 
+#include <fmt/format.h>
+
 #include "DiabloUI/diabloui.h"
 #include "automap.h"
 #include "controls/keymapper.hpp"
@@ -391,10 +393,10 @@ void DrawSpellList(const CelOutputBuffer &out)
 				DrawSpellCel(out, x, y, *pSpellCels, c);
 				switch (pSplType) {
 				case RSPLTYPE_SKILL:
-					sprintf(infostr, _("%s Skill"), _(spelldata[pSpell].sSkillText));
+					sprintf(infostr, fmt::format(_("%s Skill"), _(spelldata[pSpell].sSkillText)).c_str());
 					break;
 				case RSPLTYPE_SPELL:
-					sprintf(infostr, _("%s Spell"), _(spelldata[pSpell].sNameText));
+					sprintf(infostr, fmt::format(_("%s Spell"), _(spelldata[pSpell].sNameText)).c_str());
 					if (pSpell == SPL_HBOLT) {
 						strcpy(tempstr, _("Damages undead only"));
 						AddPanelString(tempstr);
@@ -402,11 +404,11 @@ void DrawSpellList(const CelOutputBuffer &out)
 					if (s == 0)
 						strcpy(tempstr, _("Spell Level 0 - Unusable"));
 					else
-						sprintf(tempstr, _("Spell Level %i"), s);
+						sprintf(tempstr, fmt::format(_("Spell Level %i"), s).c_str());
 					AddPanelString(tempstr);
 					break;
 				case RSPLTYPE_SCROLL: {
-					sprintf(infostr, _("Scroll of %s"), _(spelldata[pSpell].sNameText));
+					sprintf(infostr, fmt::format(_("Scroll of %s"), _(spelldata[pSpell].sNameText)).c_str());
 					int v = 0;
 					for (int t = 0; t < plr[myplr]._pNumInv; t++) {
 						if (!plr[myplr].InvList[t].isEmpty()
@@ -426,7 +428,7 @@ void DrawSpellList(const CelOutputBuffer &out)
 					AddPanelString(tempstr);
 				} break;
 				case RSPLTYPE_CHARGES: {
-					sprintf(infostr, _("Staff of %s"), _(spelldata[pSpell].sNameText));
+					sprintf(infostr, fmt::format(_("Staff of %s"), _(spelldata[pSpell].sNameText)).c_str());
 					int charges = plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges;
 					sprintf(tempstr, ngettext("%i Charge", "%i Charges", charges), charges);
 					AddPanelString(tempstr);
@@ -438,7 +440,7 @@ void DrawSpellList(const CelOutputBuffer &out)
 					if (plr[myplr]._pSplHotKey[t] == pSpell && plr[myplr]._pSplTHotKey[t] == pSplType) {
 						auto hotkeyName = keymapper.keyNameForAction(quickSpellActionIndexes[t]);
 						PrintSBookHotkey(out, x, y, hotkeyName);
-						sprintf(tempstr, _("Spell Hotkey %s"), hotkeyName.c_str());
+						sprintf(tempstr, fmt::format(_("Spell Hotkey %s"), hotkeyName.c_str()).c_str());
 						AddPanelString(tempstr);
 					}
 				}
@@ -915,7 +917,7 @@ void CheckPanelInfo()
 					strcpy(infostr, _("Player attack"));
 			}
 			if (PanBtnHotKey[i] != nullptr) {
-				sprintf(tempstr, _("Hotkey: %s"), _(PanBtnHotKey[i]));
+				sprintf(tempstr, fmt::format(_("Hotkey: %s"), _(PanBtnHotKey[i])).c_str());
 				AddPanelString(tempstr);
 			}
 			infoclr = UIS_SILVER;
@@ -934,11 +936,11 @@ void CheckPanelInfo()
 		if (v != SPL_INVALID) {
 			switch (plr[myplr]._pRSplType) {
 			case RSPLTYPE_SKILL:
-				sprintf(tempstr, _("%s Skill"), _(spelldata[v].sSkillText));
+				sprintf(tempstr, fmt::format(_("%s Skill"), _(spelldata[v].sSkillText)).c_str());
 				AddPanelString(tempstr);
 				break;
 			case RSPLTYPE_SPELL: {
-				sprintf(tempstr, _("%s Spell"), _(spelldata[v].sNameText));
+				sprintf(tempstr, fmt::format(_("%s Spell"), _(spelldata[v].sNameText)).c_str());
 				AddPanelString(tempstr);
 				int c = plr[myplr]._pISplLvlAdd + plr[myplr]._pSplLvl[v];
 				if (c < 0)
@@ -946,11 +948,11 @@ void CheckPanelInfo()
 				if (c == 0)
 					strcpy(tempstr, _("Spell Level 0 - Unusable"));
 				else
-					sprintf(tempstr, _("Spell Level %i"), c);
+					sprintf(tempstr, fmt::format(_("Spell Level %i"), c).c_str());
 				AddPanelString(tempstr);
 			} break;
 			case RSPLTYPE_SCROLL: {
-				sprintf(tempstr, _("Scroll of %s"), _(spelldata[v].sNameText));
+				sprintf(tempstr, fmt::format(_("Scroll of %s"), _(spelldata[v].sNameText)).c_str());
 				AddPanelString(tempstr);
 				int s = 0;
 				for (int i = 0; i < plr[myplr]._pNumInv; i++) {
@@ -971,7 +973,7 @@ void CheckPanelInfo()
 				AddPanelString(tempstr);
 			} break;
 			case RSPLTYPE_CHARGES:
-				sprintf(tempstr, _("Staff of %s"), _(spelldata[v].sNameText));
+				sprintf(tempstr, fmt::format(_("Staff of %s"), _(spelldata[v].sNameText)).c_str());
 				AddPanelString(tempstr);
 				sprintf(tempstr, ngettext("%i Charge", "%i Charges", plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges), plr[myplr].InvBody[INVLOC_HAND_LEFT]._iCharges);
 				AddPanelString(tempstr);
@@ -1160,9 +1162,9 @@ void DrawInfoBox(const CelOutputBuffer &out)
 			infoclr = UIS_GOLD;
 			strcpy(infostr, plr[pcursplr]._pName);
 			ClearPanel();
-			sprintf(tempstr, _("%s, Level: %i"), _(ClassStrTbl[static_cast<std::size_t>(plr[pcursplr]._pClass)]), plr[pcursplr]._pLevel);
+			sprintf(tempstr, fmt::format(_("%s, Level: %i"), _(ClassStrTbl[static_cast<std::size_t>(plr[pcursplr]._pClass)]), plr[pcursplr]._pLevel).c_str());
 			AddPanelString(tempstr);
-			sprintf(tempstr, _("Hit Points %i of %i"), plr[pcursplr]._pHitPoints >> 6, plr[pcursplr]._pMaxHP >> 6);
+			sprintf(tempstr, fmt::format(_("Hit Points %i of %i"), plr[pcursplr]._pHitPoints >> 6, plr[pcursplr]._pMaxHP >> 6).c_str());
 			AddPanelString(tempstr);
 		}
 	}
@@ -1625,12 +1627,12 @@ void DrawSpellBook(const CelOutputBuffer &out)
 				int max;
 				GetDamageAmt(sn, &min, &max);
 				if (min != -1) {
-					sprintf(tempstr, _(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: %i  Dam: %i - %i"), mana, min, max);
+					sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: %i  Dam: %i - %i"), mana, min, max).c_str());
 				} else {
-					sprintf(tempstr, _(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: %i   Dam: n/a"), mana);
+					sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: %i   Dam: n/a"), mana).c_str());
 				}
 				if (sn == SPL_BONESPIRIT) {
-					sprintf(tempstr, _(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: %i  Dam: 1/3 tgt hp"), mana);
+					sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: %i  Dam: 1/3 tgt hp"), mana).c_str());
 				}
 				PrintSBookStr(out, 10, yp - 1, tempstr);
 				int lvl = plr[myplr]._pSplLvl[sn] + plr[myplr]._pISplLvlAdd;
@@ -1640,7 +1642,7 @@ void DrawSpellBook(const CelOutputBuffer &out)
 				if (lvl == 0) {
 					strcpy(tempstr, _("Spell Level 0 - Unusable"));
 				} else {
-					sprintf(tempstr, _("Spell Level %i"), lvl);
+					sprintf(tempstr, fmt::format(_("Spell Level %i"), lvl).c_str());
 				}
 			} break;
 			}

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -5,6 +5,8 @@
  */
 #include "cursor.h"
 
+#include <fmt/format.h>
+
 #include "control.h"
 #include "doom.h"
 #include "engine.h"
@@ -203,7 +205,7 @@ void CheckTown()
 				trigflag = true;
 				ClearPanel();
 				strcpy(infostr, _("Town Portal"));
-				sprintf(tempstr, _("from %s"), plr[missile[mx]._misource]._pName);
+				sprintf(tempstr, fmt::format(_("from %s"), plr[missile[mx]._misource]._pName).c_str());
 				AddPanelString(tempstr);
 				cursmx = missile[mx].position.tile.x;
 				cursmy = missile[mx].position.tile.y;

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -205,7 +205,7 @@ void CheckTown()
 				trigflag = true;
 				ClearPanel();
 				strcpy(infostr, _("Town Portal"));
-				sprintf(tempstr, fmt::format(_("from %s"), plr[missile[mx]._misource]._pName).c_str());
+				sprintf(tempstr, fmt::format(_("from {:s}"), plr[missile[mx]._misource]._pName).c_str());
 				AddPanelString(tempstr);
 				cursmx = missile[mx].position.tile.x;
 				cursmy = missile[mx].position.tile.y;

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -205,7 +205,7 @@ void CheckTown()
 				trigflag = true;
 				ClearPanel();
 				strcpy(infostr, _("Town Portal"));
-				sprintf(tempstr, fmt::format(_("from {:s}"), plr[missile[mx]._misource]._pName).c_str());
+				strcpy(tempstr, fmt::format(_("from {:s}"), plr[missile[mx]._misource]._pName).c_str());
 				AddPanelString(tempstr);
 				cursmx = missile[mx].position.tile.x;
 				cursmy = missile[mx].position.tile.y;

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -283,7 +283,7 @@ static void diablo_parse_flags(int argc, char **argv)
 			debug_mode_key_w = true;
 #endif
 		} else {
-			printInConsole(fmt::format(_("unrecognized option '%s'\n"), argv[i]).c_str());
+			printInConsole(fmt::format(_("unrecognized option '{:s}'\n"), argv[i]).c_str());
 			print_help_and_exit();
 		}
 	}
@@ -671,7 +671,7 @@ char gszProductName[64] = "DevilutionX vUnknown";
 static void SetApplicationVersions()
 {
 	snprintf(gszProductName, sizeof(gszProductName) / sizeof(char), "%s v%s", PROJECT_NAME, PROJECT_VERSION);
-	snprintf(gszVersionNumber, sizeof(gszVersionNumber) / sizeof(char), fmt::format(_("version %s"), PROJECT_VERSION).c_str());
+	snprintf(gszVersionNumber, sizeof(gszVersionNumber) / sizeof(char), fmt::format(_("version {:s}"), PROJECT_VERSION).c_str());
 }
 
 static void diablo_init()
@@ -2203,7 +2203,7 @@ void initKeymapActions()
 			    _("Nightmare"),
 			    _("Hell"),
 		    };
-		    sprintf(pszStr, fmt::format(_(/* TRANSLATORS: %s means: Character Name, Game Version, Game Difficulty. */ "%s, version = %s, mode = %s"), gszProductName, PROJECT_VERSION, difficulties[sgGameInitInfo.nDifficulty]).c_str());
+		    sprintf(pszStr, fmt::format(_(/* TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty. */ "{:s}, version = {:s}, mode = {:s}"), gszProductName, PROJECT_VERSION, difficulties[sgGameInitInfo.nDifficulty]).c_str());
 		    NetSendCmdString(1 << myplr, pszStr);
 	    },
 	});

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -283,7 +283,7 @@ static void diablo_parse_flags(int argc, char **argv)
 			debug_mode_key_w = true;
 #endif
 		} else {
-			printInConsole(fmt::format(_("unrecognized option '{:s}'\n"), argv[i]).c_str());
+			printInConsole("%s", fmt::format(_("unrecognized option '{:s}'\n"), argv[i]).c_str());
 			print_help_and_exit();
 		}
 	}
@@ -671,7 +671,7 @@ char gszProductName[64] = "DevilutionX vUnknown";
 static void SetApplicationVersions()
 {
 	snprintf(gszProductName, sizeof(gszProductName) / sizeof(char), "%s v%s", PROJECT_NAME, PROJECT_VERSION);
-	snprintf(gszVersionNumber, sizeof(gszVersionNumber) / sizeof(char), fmt::format(_("version {:s}"), PROJECT_VERSION).c_str());
+	strncpy(gszVersionNumber, fmt::format(_("version {:s}"), PROJECT_VERSION).c_str(), sizeof(gszVersionNumber) / sizeof(char));
 }
 
 static void diablo_init()
@@ -2203,7 +2203,7 @@ void initKeymapActions()
 			    _("Nightmare"),
 			    _("Hell"),
 		    };
-		    sprintf(pszStr, fmt::format(_(/* TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty. */ "{:s}, version = {:s}, mode = {:s}"), gszProductName, PROJECT_VERSION, difficulties[sgGameInitInfo.nDifficulty]).c_str());
+		    strcpy(pszStr, fmt::format(_(/* TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty. */ "{:s}, version = {:s}, mode = {:s}"), gszProductName, PROJECT_VERSION, difficulties[sgGameInitInfo.nDifficulty]).c_str());
 		    NetSendCmdString(1 << myplr, pszStr);
 	    },
 	});

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -5,6 +5,8 @@
  */
 #include <array>
 
+#include <fmt/format.h>
+
 #include <config.h>
 
 #include "automap.h"
@@ -177,22 +179,22 @@ void initKeymapActions();
 
 [[noreturn]] static void print_help_and_exit()
 {
-	printInConsole("%s", _( /* TRANSLATORS: Commandline Option */ "Options:\n"));
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */  "-h, --help", _("Print this message and exit"));
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */  "--version", _("Print the version and exit"));
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */  "--data-dir", _("Specify the folder of diabdat.mpq"));
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */  "--save-dir", _("Specify the folder of save files"));
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */  "--config-dir", _("Specify the location of diablo.ini"));
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */  "--ttf-dir", _("Specify the location of the .ttf font"));
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */  "--ttf-name", _("Specify the name of a custom .ttf font"));
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */  "-n", _("Skip startup videos"));
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */  "-f", _("Display frames per second"));
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */  "-x", _("Run in windowed mode"));
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */  "--verbose", _("Enable verbose logging"));
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */  "--spawn", _("Force spawn mode even if diabdat.mpq is found"));
-	printInConsole("%s", _( /* TRANSLATORS: Commandline Option */ "\nHellfire options:\n"));
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */  "--diablo", _("Force diablo mode even if hellfire.mpq is found"));
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */  "--nestart", _("Use alternate nest palette"));
+	printInConsole("%s", _(/* TRANSLATORS: Commandline Option */ "Options:\n"));
+	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "-h, --help", _("Print this message and exit"));
+	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--version", _("Print the version and exit"));
+	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--data-dir", _("Specify the folder of diabdat.mpq"));
+	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--save-dir", _("Specify the folder of save files"));
+	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--config-dir", _("Specify the location of diablo.ini"));
+	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--ttf-dir", _("Specify the location of the .ttf font"));
+	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--ttf-name", _("Specify the name of a custom .ttf font"));
+	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "-n", _("Skip startup videos"));
+	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "-f", _("Display frames per second"));
+	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "-x", _("Run in windowed mode"));
+	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--verbose", _("Enable verbose logging"));
+	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--spawn", _("Force spawn mode even if diabdat.mpq is found"));
+	printInConsole("%s", _(/* TRANSLATORS: Commandline Option */ "\nHellfire options:\n"));
+	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--diablo", _("Force diablo mode even if hellfire.mpq is found"));
+	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--nestart", _("Use alternate nest palette"));
 #ifdef _DEBUG
 	printInConsole("\nDebug options:\n");
 	printInConsole("    %-20s %-30s\n", "-w", "Enable cheats");
@@ -281,7 +283,7 @@ static void diablo_parse_flags(int argc, char **argv)
 			debug_mode_key_w = true;
 #endif
 		} else {
-			printInConsole(_("unrecognized option '%s'\n"), argv[i]);
+			printInConsole(fmt::format(_("unrecognized option '%s'\n"), argv[i]).c_str());
 			print_help_and_exit();
 		}
 	}
@@ -421,8 +423,8 @@ static void run_game_loop(interface_mode uMsg)
 		gbGameLoopStartup = false;
 		DrawAndBlit();
 #ifdef GPERF_HEAP_FIRST_GAME_ITERATION
-	if (run_game_iteration++ == 0)
-		HeapProfilerDump("first_game_iteration");
+		if (run_game_iteration++ == 0)
+			HeapProfilerDump("first_game_iteration");
 #endif
 	}
 
@@ -669,7 +671,7 @@ char gszProductName[64] = "DevilutionX vUnknown";
 static void SetApplicationVersions()
 {
 	snprintf(gszProductName, sizeof(gszProductName) / sizeof(char), "%s v%s", PROJECT_NAME, PROJECT_VERSION);
-	snprintf(gszVersionNumber, sizeof(gszVersionNumber) / sizeof(char), _("version %s"), PROJECT_VERSION);
+	snprintf(gszVersionNumber, sizeof(gszVersionNumber) / sizeof(char), fmt::format(_("version %s"), PROJECT_VERSION).c_str());
 }
 
 static void diablo_init()
@@ -2201,7 +2203,7 @@ void initKeymapActions()
 			    _("Nightmare"),
 			    _("Hell"),
 		    };
-		    sprintf(pszStr, _( /* TRANSLATORS: %s means: Character Name, Game Version, Game Difficulty. */ "%s, version = %s, mode = %s"), gszProductName, PROJECT_VERSION, difficulties[sgGameInitInfo.nDifficulty]);
+		    sprintf(pszStr, fmt::format(_(/* TRANSLATORS: %s means: Character Name, Game Version, Game Difficulty. */ "%s, version = %s, mode = %s"), gszProductName, PROJECT_VERSION, difficulties[sgGameInitInfo.nDifficulty]).c_str());
 		    NetSendCmdString(1 << myplr, pszStr);
 	    },
 	});

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -5,6 +5,8 @@
  */
 #include <utility>
 
+#include <fmt/format.h>
+
 #include "cursor.h"
 #include "engine/render/cel_render.hpp"
 #include "engine/render/text_render.hpp"
@@ -2048,7 +2050,7 @@ char CheckInvHLight()
 
 	if (pi->_itype == ITYPE_GOLD) {
 		nGold = pi->_ivalue;
-		sprintf(infostr, ngettext("%i gold piece", "%i gold pieces", nGold), nGold);
+		strcpy(infostr, fmt::format(ngettext("{:d} gold piece", "{:d} gold pieces", nGold), nGold).c_str());
 	} else {
 		if (pi->_iMagical == ITEM_QUALITY_MAGIC) {
 			infoclr = UIS_BLUE;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3037,7 +3037,7 @@ void GetItemStr(int i)
 			infoclr = UIS_GOLD;
 	} else {
 		int nGold = items[i]._ivalue;
-		sprintf(infostr, ngettext("%i gold piece", "%i gold pieces", nGold), nGold);
+		strcpy(infostr, fmt::format(ngettext("{:d} gold piece", "{:d} gold pieces", nGold), nGold).c_str());
 	}
 }
 
@@ -3464,9 +3464,9 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		break;
 	case IPL_SPLLVLADD:
 		if (x->_iSplLvlAdd > 0)
-			sprintf(tempstr, ngettext("spells are increased %i level", "spells are increased %i levels", x->_iSplLvlAdd), x->_iSplLvlAdd);
+			strcpy(tempstr, fmt::format(ngettext("spells are increased {:d} level", "spells are increased {:d} levels", x->_iSplLvlAdd), x->_iSplLvlAdd).c_str());
 		else if (x->_iSplLvlAdd < 0)
-			sprintf(tempstr, ngettext("spells are decreased %i level", "spells are decreased %i levels", -x->_iSplLvlAdd), -x->_iSplLvlAdd);
+			strcpy(tempstr, fmt::format(ngettext("spells are decreased {:d} level", "spells are decreased {:d} levels", -x->_iSplLvlAdd), -x->_iSplLvlAdd).c_str());
 		else if (x->_iSplLvlAdd == 0)
 			strcpy(tempstr, _("spell levels unchanged (?)"));
 		break;
@@ -3474,7 +3474,7 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		strcpy(tempstr, _("Extra charges"));
 		break;
 	case IPL_SPELL:
-		sprintf(tempstr, ngettext("%i %s charge", "%i %s charges", x->_iMaxCharges), x->_iMaxCharges, _(spelldata[x->_iSpell].sNameText));
+		strcpy(tempstr, fmt::format(ngettext("{:d} {:s} charge", "{:d} {:s} charges", x->_iMaxCharges), x->_iMaxCharges, _(spelldata[x->_iSpell].sNameText)).c_str());
 		break;
 	case IPL_FIREDAM:
 		if (x->_iFMinDam == x->_iFMaxDam)
@@ -3617,7 +3617,7 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		strcpy(tempstr, _("fast block"));
 		break;
 	case IPL_DAMMOD:
-		sprintf(tempstr, ngettext("adds %i point to damage", "adds %i points to damage", x->_iPLDamMod), x->_iPLDamMod);
+		strcpy(tempstr, fmt::format(ngettext("adds {:d} point to damage", "adds {:d} points to damage", x->_iPLDamMod), x->_iPLDamMod).c_str());
 		break;
 	case IPL_RNDARROWVEL:
 		strcpy(tempstr, _("fires random speed arrows"));

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1526,7 +1526,7 @@ void GetStaffPower(int i, int lvl, int bs, bool onlygood)
 			sprintf(istr, "%s %s", _(PL_Prefix[preidx].PLName), items[i]._iIName);
 			strcpy(items[i]._iIName, istr);
 		}
-		sprintf(istr, fmt::format(_(/* TRANSLATORS: Constructs item names. Format: <Prefix> <Item> of <Suffix>. Example: King's Long Sword of the Whale */ "{:s} of {:s}"), items[i]._iIName, _(spelldata[bs].sNameText)).c_str());
+		strcpy(istr, fmt::format(_(/* TRANSLATORS: Constructs item names. Format: <Prefix> <Item> of <Suffix>. Example: King's Long Sword of the Whale */ "{:s} of {:s}"), items[i]._iIName, _(spelldata[bs].sNameText)).c_str());
 		strcpy(items[i]._iIName, istr);
 		if (items[i]._iMagical == ITEM_QUALITY_NORMAL)
 			strcpy(items[i]._iName, items[i]._iIName);
@@ -1568,8 +1568,8 @@ void GetStaffSpell(int i, int lvl, bool onlygood)
 				s = SPL_FIREBOLT;
 		}
 		if (!control_WriteStringToBuffer(istr))
-			sprintf(istr, fmt::format(_("{:s} of {:s}"), items[i]._iName, _(spelldata[bs].sNameText)).c_str());
-		sprintf(istr, fmt::format(_("Staff of {:s}"), _(spelldata[bs].sNameText)).c_str());
+			strcpy(istr, fmt::format(_("{:s} of {:s}"), items[i]._iName, _(spelldata[bs].sNameText)).c_str());
+		strcpy(istr, fmt::format(_("Staff of {:s}"), _(spelldata[bs].sNameText)).c_str());
 		strcpy(items[i]._iName, istr);
 		strcpy(items[i]._iIName, istr);
 
@@ -2163,7 +2163,7 @@ void GetItemPower(int i, int minlvl, int maxlvl, affix_item_type flgs, bool only
 		}
 		if (nl != 0) {
 			sufidx = l[GenerateRnd(nl)];
-			sprintf(istr, fmt::format(_("{:s} of {:s}"), items[i]._iIName, _(PL_Suffix[sufidx].PLName)).c_str());
+			strcpy(istr, fmt::format(_("{:s} of {:s}"), items[i]._iIName, _(PL_Suffix[sufidx].PLName)).c_str());
 			strcpy(items[i]._iIName, istr);
 			items[i]._iMagical = ITEM_QUALITY_MAGIC;
 			SaveItemSuffix(i, sufidx);
@@ -2182,7 +2182,7 @@ void GetItemPower(int i, int minlvl, int maxlvl, affix_item_type flgs, bool only
 			strcpy(items[i]._iIName, istr);
 		}
 		if (sufidx != -1) {
-			sprintf(istr, fmt::format(_("{:s} of {:s}"), items[i]._iIName, _(PL_Suffix[sufidx].PLName)).c_str());
+			strcpy(istr, fmt::format(_("{:s} of {:s}"), items[i]._iIName, _(PL_Suffix[sufidx].PLName)).c_str());
 			strcpy(items[i]._iIName, istr);
 		}
 	}
@@ -2746,7 +2746,7 @@ void RecreateEar(int ii, uint16_t ic, int iseed, int Id, int dur, int mdur, int 
 	tempstr[14] = (ibuff >> 8) & 0x7F;
 	tempstr[15] = ibuff & 0x7F;
 	tempstr[16] = '\0';
-	sprintf(items[ii]._iName, fmt::format(_(/* TRANSLATORS: {:s} will be a Character Name */ "Ear of {:s}"), tempstr).c_str());
+	strcpy(items[ii]._iName, fmt::format(_(/* TRANSLATORS: {:s} will be a Character Name */ "Ear of {:s}"), tempstr).c_str());
 	items[ii]._iCurs = ((ivalue >> 6) & 3) + ICURS_EAR_SORCERER;
 	items[ii]._ivalue = ivalue & 0x3F;
 	items[ii]._iCreateInfo = ic;
@@ -3414,51 +3414,51 @@ void PrintItemPower(char plidx, ItemStruct *x)
 	switch (plidx) {
 	case IPL_TOHIT:
 	case IPL_TOHIT_CURSE:
-		sprintf(tempstr, fmt::format(_("chance to hit: {:+d}%"), x->_iPLToHit).c_str());
+		strcpy(tempstr, fmt::format(_("chance to hit: {:+d}%"), x->_iPLToHit).c_str());
 		break;
 	case IPL_DAMP:
 	case IPL_DAMP_CURSE:
-		sprintf(tempstr, fmt::format(_("{:+d}% damage"), x->_iPLDam).c_str());
+		strcpy(tempstr, fmt::format(_("{:+d}% damage"), x->_iPLDam).c_str());
 		break;
 	case IPL_TOHIT_DAMP:
 	case IPL_TOHIT_DAMP_CURSE:
-		sprintf(tempstr, fmt::format(_("to hit: {:+d}%, {:+d}% damage"), x->_iPLToHit, x->_iPLDam).c_str());
+		strcpy(tempstr, fmt::format(_("to hit: {:+d}%, {:+d}% damage"), x->_iPLToHit, x->_iPLDam).c_str());
 		break;
 	case IPL_ACP:
 	case IPL_ACP_CURSE:
-		sprintf(tempstr, fmt::format(_("{:+d}% armor"), x->_iPLAC).c_str());
+		strcpy(tempstr, fmt::format(_("{:+d}% armor"), x->_iPLAC).c_str());
 		break;
 	case IPL_SETAC:
-		sprintf(tempstr, fmt::format(_("armor class: {:d}"), x->_iAC).c_str());
+		strcpy(tempstr, fmt::format(_("armor class: {:d}"), x->_iAC).c_str());
 		break;
 	case IPL_AC_CURSE:
-		sprintf(tempstr, fmt::format(_("armor class: {:d}"), x->_iAC).c_str());
+		strcpy(tempstr, fmt::format(_("armor class: {:d}"), x->_iAC).c_str());
 		break;
 	case IPL_FIRERES:
 	case IPL_FIRERES_CURSE:
 		if (x->_iPLFR < 75)
-			sprintf(tempstr, fmt::format(_("Resist Fire: {:+d}%"), x->_iPLFR).c_str());
+			strcpy(tempstr, fmt::format(_("Resist Fire: {:+d}%"), x->_iPLFR).c_str());
 		else
 			/*xgettext:no-c-format*/ strcpy(tempstr, _("Resist Fire: 75% MAX"));
 		break;
 	case IPL_LIGHTRES:
 	case IPL_LIGHTRES_CURSE:
 		if (x->_iPLLR < 75)
-			sprintf(tempstr, fmt::format(_("Resist Lightning: {:+d}%"), x->_iPLLR).c_str());
+			strcpy(tempstr, fmt::format(_("Resist Lightning: {:+d}%"), x->_iPLLR).c_str());
 		else
 			/*xgettext:no-c-format*/ strcpy(tempstr, _("Resist Lightning: 75% MAX"));
 		break;
 	case IPL_MAGICRES:
 	case IPL_MAGICRES_CURSE:
 		if (x->_iPLMR < 75)
-			sprintf(tempstr, fmt::format(_("Resist Magic: {:+d}%"), x->_iPLMR).c_str());
+			strcpy(tempstr, fmt::format(_("Resist Magic: {:+d}%"), x->_iPLMR).c_str());
 		else
 			/*xgettext:no-c-format*/ strcpy(tempstr, _("Resist Magic: 75% MAX"));
 		break;
 	case IPL_ALLRES:
 	case IPL_ALLRES_CURSE:
 		if (x->_iPLFR < 75)
-			sprintf(tempstr, fmt::format(_("Resist All: {:+d}%"), x->_iPLFR).c_str());
+			strcpy(tempstr, fmt::format(_("Resist All: {:+d}%"), x->_iPLFR).c_str());
 		if (x->_iPLFR >= 75)
 			/*xgettext:no-c-format*/ strcpy(tempstr, _("Resist All: 75% MAX"));
 		break;
@@ -3478,47 +3478,47 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		break;
 	case IPL_FIREDAM:
 		if (x->_iFMinDam == x->_iFMaxDam)
-			sprintf(tempstr, fmt::format(_("Fire hit damage: {:d}"), x->_iFMinDam).c_str());
+			strcpy(tempstr, fmt::format(_("Fire hit damage: {:d}"), x->_iFMinDam).c_str());
 		else
-			sprintf(tempstr, fmt::format(_("Fire hit damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam).c_str());
+			strcpy(tempstr, fmt::format(_("Fire hit damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam).c_str());
 		break;
 	case IPL_LIGHTDAM:
 		if (x->_iLMinDam == x->_iLMaxDam)
-			sprintf(tempstr, fmt::format(_("Lightning hit damage: {:d}"), x->_iLMinDam).c_str());
+			strcpy(tempstr, fmt::format(_("Lightning hit damage: {:d}"), x->_iLMinDam).c_str());
 		else
-			sprintf(tempstr, fmt::format(_("Lightning hit damage: {:d}-{:d}"), x->_iLMinDam, x->_iLMaxDam).c_str());
+			strcpy(tempstr, fmt::format(_("Lightning hit damage: {:d}-{:d}"), x->_iLMinDam, x->_iLMaxDam).c_str());
 		break;
 	case IPL_STR:
 	case IPL_STR_CURSE:
-		sprintf(tempstr, fmt::format(_("{:+d} to strength"), x->_iPLStr).c_str());
+		strcpy(tempstr, fmt::format(_("{:+d} to strength"), x->_iPLStr).c_str());
 		break;
 	case IPL_MAG:
 	case IPL_MAG_CURSE:
-		sprintf(tempstr, fmt::format(_("{:+d} to magic"), x->_iPLMag).c_str());
+		strcpy(tempstr, fmt::format(_("{:+d} to magic"), x->_iPLMag).c_str());
 		break;
 	case IPL_DEX:
 	case IPL_DEX_CURSE:
-		sprintf(tempstr, fmt::format(_("{:+d} to dexterity"), x->_iPLDex).c_str());
+		strcpy(tempstr, fmt::format(_("{:+d} to dexterity"), x->_iPLDex).c_str());
 		break;
 	case IPL_VIT:
 	case IPL_VIT_CURSE:
-		sprintf(tempstr, fmt::format(_("{:+d} to vitality"), x->_iPLVit).c_str());
+		strcpy(tempstr, fmt::format(_("{:+d} to vitality"), x->_iPLVit).c_str());
 		break;
 	case IPL_ATTRIBS:
 	case IPL_ATTRIBS_CURSE:
-		sprintf(tempstr, fmt::format(_("{:+d} to all attributes"), x->_iPLStr).c_str());
+		strcpy(tempstr, fmt::format(_("{:+d} to all attributes"), x->_iPLStr).c_str());
 		break;
 	case IPL_GETHIT_CURSE:
 	case IPL_GETHIT:
-		sprintf(tempstr, fmt::format(_("{:+d} damage from enemies"), x->_iPLGetHit).c_str());
+		strcpy(tempstr, fmt::format(_("{:+d} damage from enemies"), x->_iPLGetHit).c_str());
 		break;
 	case IPL_LIFE:
 	case IPL_LIFE_CURSE:
-		sprintf(tempstr, fmt::format(_("Hit Points: {:+d}"), x->_iPLHP >> 6).c_str());
+		strcpy(tempstr, fmt::format(_("Hit Points: {:+d}"), x->_iPLHP >> 6).c_str());
 		break;
 	case IPL_MANA:
 	case IPL_MANA_CURSE:
-		sprintf(tempstr, fmt::format(_("Mana: {:+d}"), x->_iPLMana >> 6).c_str());
+		strcpy(tempstr, fmt::format(_("Mana: {:+d}"), x->_iPLMana >> 6).c_str());
 		break;
 	case IPL_DUR:
 		strcpy(tempstr, _("high durability"));
@@ -3530,31 +3530,31 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		strcpy(tempstr, _("indestructible"));
 		break;
 	case IPL_LIGHT:
-		sprintf(tempstr, fmt::format(_("+{:d}% light radius"), 10 * x->_iPLLight).c_str());
+		strcpy(tempstr, fmt::format(_("+{:d}% light radius"), 10 * x->_iPLLight).c_str());
 		break;
 	case IPL_LIGHT_CURSE:
-		sprintf(tempstr, fmt::format(_("-{:d}% light radius"), -10 * x->_iPLLight).c_str());
+		strcpy(tempstr, fmt::format(_("-{:d}% light radius"), -10 * x->_iPLLight).c_str());
 		break;
 	case IPL_MULT_ARROWS:
 		strcpy(tempstr, _("multiple arrows per shot"));
 		break;
 	case IPL_FIRE_ARROWS:
 		if (x->_iFMinDam == x->_iFMaxDam)
-			sprintf(tempstr, fmt::format(_("fire arrows damage: {:d}"), x->_iFMinDam).c_str());
+			strcpy(tempstr, fmt::format(_("fire arrows damage: {:d}"), x->_iFMinDam).c_str());
 		else
-			sprintf(tempstr, fmt::format(_("fire arrows damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam).c_str());
+			strcpy(tempstr, fmt::format(_("fire arrows damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam).c_str());
 		break;
 	case IPL_LIGHT_ARROWS:
 		if (x->_iLMinDam == x->_iLMaxDam)
-			sprintf(tempstr, fmt::format(_("lightning arrows damage {:d}"), x->_iLMinDam).c_str());
+			strcpy(tempstr, fmt::format(_("lightning arrows damage {:d}"), x->_iLMinDam).c_str());
 		else
-			sprintf(tempstr, fmt::format(_("lightning arrows damage {:d}-{:d}"), x->_iLMinDam, x->_iLMaxDam).c_str());
+			strcpy(tempstr, fmt::format(_("lightning arrows damage {:d}-{:d}"), x->_iLMinDam, x->_iLMaxDam).c_str());
 		break;
 	case IPL_FIREBALL:
 		if (x->_iFMinDam == x->_iFMaxDam)
-			sprintf(tempstr, fmt::format(_("fireball damage: {:d}"), x->_iFMinDam).c_str());
+			strcpy(tempstr, fmt::format(_("fireball damage: {:d}"), x->_iFMinDam).c_str());
 		else
-			sprintf(tempstr, fmt::format(_("fireball damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam).c_str());
+			strcpy(tempstr, fmt::format(_("fireball damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam).c_str());
 		break;
 	case IPL_THORNS:
 		strcpy(tempstr, _("attacker takes 1-3 damage"));
@@ -3651,9 +3651,9 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		break;
 	case IPL_ADDACLIFE:
 		if (x->_iFMinDam == x->_iFMaxDam)
-			sprintf(tempstr, fmt::format(_("lightning damage: {:d}"), x->_iFMinDam).c_str());
+			strcpy(tempstr, fmt::format(_("lightning damage: {:d}"), x->_iFMinDam).c_str());
 		else
-			sprintf(tempstr, fmt::format(_("lightning damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam).c_str());
+			strcpy(tempstr, fmt::format(_("lightning damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam).c_str());
 		break;
 	case IPL_ADDMANAAC:
 		strcpy(tempstr, _("charged bolts on hits"));
@@ -3662,13 +3662,13 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		if (x->_iPLFR <= 0)
 			strcpy(tempstr, " ");
 		else if (x->_iPLFR >= 1)
-			sprintf(tempstr, fmt::format(_("Resist Fire: {:+d}%"), x->_iPLFR).c_str());
+			strcpy(tempstr, fmt::format(_("Resist Fire: {:+d}%"), x->_iPLFR).c_str());
 		break;
 	case IPL_DEVASTATION:
 		strcpy(tempstr, _("occasional triple damage"));
 		break;
 	case IPL_DECAY:
-		sprintf(tempstr, fmt::format(_("decaying {:+d}% damage"), x->_iPLDam).c_str());
+		strcpy(tempstr, fmt::format(_("decaying {:+d}% damage"), x->_iPLDam).c_str());
 		break;
 	case IPL_PERIL:
 		strcpy(tempstr, _("2x dmg to monst, 1x to you"));
@@ -3677,10 +3677,10 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		/*xgettext:no-c-format*/ strcpy(tempstr, _("Random 0 - 500% damage"));
 		break;
 	case IPL_CRYSTALLINE:
-		sprintf(tempstr, fmt::format(_("low dur, {:+d}% damage"), x->_iPLDam).c_str());
+		strcpy(tempstr, fmt::format(_("low dur, {:+d}% damage"), x->_iPLDam).c_str());
 		break;
 	case IPL_DOPPELGANGER:
-		sprintf(tempstr, fmt::format(_("to hit: {:+d}%, {:+d}% damage"), x->_iPLToHit, x->_iPLDam).c_str());
+		strcpy(tempstr, fmt::format(_("to hit: {:+d}%, {:+d}% damage"), x->_iPLToHit, x->_iPLDam).c_str());
 		break;
 	case IPL_ACDEMON:
 		strcpy(tempstr, _("extra AC vs demons"));
@@ -3799,7 +3799,7 @@ void PrintItemMisc(ItemStruct *x)
 		AddPanelString(tempstr);
 	}
 	if (x->_iMiscId == IMISC_EAR) {
-		sprintf(tempstr, fmt::format(_("Level: {:d}"), x->_ivalue).c_str());
+		strcpy(tempstr, fmt::format(_("Level: {:d}"), x->_ivalue).c_str());
 		AddPanelString(tempstr);
 	}
 	if (x->_iMiscId == IMISC_AURIC) {
@@ -3817,11 +3817,11 @@ static void PrintItemInfo(ItemStruct *x)
 	if (str != 0 || mag != 0 || dex != 0) {
 		strcpy(tempstr, _("Required:"));
 		if (str)
-			sprintf(tempstr + strlen(tempstr), fmt::format(_(" {:d} Str"), str).c_str());
+			strcpy(tempstr + strlen(tempstr), fmt::format(_(" {:d} Str"), str).c_str());
 		if (mag)
-			sprintf(tempstr + strlen(tempstr), fmt::format(_(" {:d} Mag"), mag).c_str());
+			strcpy(tempstr + strlen(tempstr), fmt::format(_(" {:d} Mag"), mag).c_str());
 		if (dex)
-			sprintf(tempstr + strlen(tempstr), fmt::format(_(" {:d} Dex"), dex).c_str());
+			strcpy(tempstr + strlen(tempstr), fmt::format(_(" {:d} Dex"), dex).c_str());
 		AddPanelString(tempstr);
 	}
 	pinfoflag = true;
@@ -3832,30 +3832,30 @@ void PrintItemDetails(ItemStruct *x)
 	if (x->_iClass == ICLASS_WEAPON) {
 		if (x->_iMinDam == x->_iMaxDam) {
 			if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-				sprintf(tempstr, fmt::format(_("damage: {:d}  Indestructible"), x->_iMinDam).c_str());
+				strcpy(tempstr, fmt::format(_("damage: {:d}  Indestructible"), x->_iMinDam).c_str());
 			else
-				sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "damage: {:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
+				strcpy(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "damage: {:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
 		} else {
 			if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-				sprintf(tempstr, fmt::format(_("damage: {:d}-{:d}  Indestructible"), x->_iMinDam, x->_iMaxDam).c_str());
+				strcpy(tempstr, fmt::format(_("damage: {:d}-{:d}  Indestructible"), x->_iMinDam, x->_iMaxDam).c_str());
 			else
-				sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "damage: {:d}-{:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
+				strcpy(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "damage: {:d}-{:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
 		}
 		AddPanelString(tempstr);
 	}
 	if (x->_iClass == ICLASS_ARMOR) {
 		if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-			sprintf(tempstr, fmt::format(_("armor: {:d}  Indestructible"), x->_iAC).c_str());
+			strcpy(tempstr, fmt::format(_("armor: {:d}  Indestructible"), x->_iAC).c_str());
 		else
-			sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "armor: {:d}  Dur: {:d}/{:d}"), x->_iAC, x->_iDurability, x->_iMaxDur).c_str());
+			strcpy(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "armor: {:d}  Dur: {:d}/{:d}"), x->_iAC, x->_iDurability, x->_iMaxDur).c_str());
 		AddPanelString(tempstr);
 	}
 	if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges != 0) {
 		if (x->_iMinDam == x->_iMaxDam)
-			sprintf(tempstr, fmt::format(_(/* TRANSLATORS: dam: is damage Dur: is durability */ "dam: {:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
+			strcpy(tempstr, fmt::format(_(/* TRANSLATORS: dam: is damage Dur: is durability */ "dam: {:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
 		else
-			sprintf(tempstr, fmt::format(_(/* TRANSLATORS: dam: is damage Dur: is durability */ "dam: {:d}-{:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
-		sprintf(tempstr, fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges).c_str());
+			strcpy(tempstr, fmt::format(_(/* TRANSLATORS: dam: is damage Dur: is durability */ "dam: {:d}-{:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
+		strcpy(tempstr, fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges).c_str());
 		AddPanelString(tempstr);
 	}
 	if (x->_iPrePower != -1) {
@@ -3879,18 +3879,18 @@ void PrintItemDur(ItemStruct *x)
 	if (x->_iClass == ICLASS_WEAPON) {
 		if (x->_iMinDam == x->_iMaxDam) {
 			if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-				sprintf(tempstr, fmt::format(_("damage: {:d}  Indestructible"), x->_iMinDam).c_str());
+				strcpy(tempstr, fmt::format(_("damage: {:d}  Indestructible"), x->_iMinDam).c_str());
 			else
-				sprintf(tempstr, fmt::format(_("damage: {:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
+				strcpy(tempstr, fmt::format(_("damage: {:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
 		} else {
 			if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-				sprintf(tempstr, fmt::format(_("damage: {:d}-{:d}  Indestructible"), x->_iMinDam, x->_iMaxDam).c_str());
+				strcpy(tempstr, fmt::format(_("damage: {:d}-{:d}  Indestructible"), x->_iMinDam, x->_iMaxDam).c_str());
 			else
-				sprintf(tempstr, fmt::format(_("damage: {:d}-{:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
+				strcpy(tempstr, fmt::format(_("damage: {:d}-{:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
 		}
 		AddPanelString(tempstr);
 		if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges) {
-			sprintf(tempstr, fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges).c_str());
+			strcpy(tempstr, fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges).c_str());
 			AddPanelString(tempstr);
 		}
 		if (x->_iMagical != ITEM_QUALITY_NORMAL)
@@ -3898,14 +3898,14 @@ void PrintItemDur(ItemStruct *x)
 	}
 	if (x->_iClass == ICLASS_ARMOR) {
 		if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-			sprintf(tempstr, fmt::format(_("armor: {:d}  Indestructible"), x->_iAC).c_str());
+			strcpy(tempstr, fmt::format(_("armor: {:d}  Indestructible"), x->_iAC).c_str());
 		else
-			sprintf(tempstr, fmt::format(_("armor: {:d}  Dur: {:d}/{:d}"), x->_iAC, x->_iDurability, x->_iMaxDur).c_str());
+			strcpy(tempstr, fmt::format(_("armor: {:d}  Dur: {:d}/{:d}"), x->_iAC, x->_iDurability, x->_iMaxDur).c_str());
 		AddPanelString(tempstr);
 		if (x->_iMagical != ITEM_QUALITY_NORMAL)
 			AddPanelString(_("Not Identified"));
 		if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges) {
-			sprintf(tempstr, fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges).c_str());
+			strcpy(tempstr, fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges).c_str());
 			AddPanelString(tempstr);
 		}
 	}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -8,6 +8,8 @@
 #include <cstdint>
 #include <bitset>
 
+#include <fmt/format.h>
+
 #include "cursor.h"
 #include "doom.h"
 #include "dx.h"
@@ -1524,7 +1526,7 @@ void GetStaffPower(int i, int lvl, int bs, bool onlygood)
 			sprintf(istr, "%s %s", _(PL_Prefix[preidx].PLName), items[i]._iIName);
 			strcpy(items[i]._iIName, istr);
 		}
-		sprintf(istr, _( /* TRANSLATORS: Constructs item names. Format: <Prefix> <Item> of <Suffix>. Example: King's Long Sword of the Whale */ "%s of %s"), items[i]._iIName, _(spelldata[bs].sNameText));
+		sprintf(istr, fmt::format(_(/* TRANSLATORS: Constructs item names. Format: <Prefix> <Item> of <Suffix>. Example: King's Long Sword of the Whale */ "%s of %s"), items[i]._iIName, _(spelldata[bs].sNameText)).c_str());
 		strcpy(items[i]._iIName, istr);
 		if (items[i]._iMagical == ITEM_QUALITY_NORMAL)
 			strcpy(items[i]._iName, items[i]._iIName);
@@ -1566,8 +1568,8 @@ void GetStaffSpell(int i, int lvl, bool onlygood)
 				s = SPL_FIREBOLT;
 		}
 		if (!control_WriteStringToBuffer(istr))
-			sprintf(istr, _("%s of %s"), items[i]._iName, _(spelldata[bs].sNameText));
-		sprintf(istr, _("Staff of %s"), _(spelldata[bs].sNameText));
+			sprintf(istr, fmt::format(_("%s of %s"), items[i]._iName, _(spelldata[bs].sNameText)).c_str());
+		sprintf(istr, fmt::format(_("Staff of %s"), _(spelldata[bs].sNameText)).c_str());
 		strcpy(items[i]._iName, istr);
 		strcpy(items[i]._iIName, istr);
 
@@ -2161,7 +2163,7 @@ void GetItemPower(int i, int minlvl, int maxlvl, affix_item_type flgs, bool only
 		}
 		if (nl != 0) {
 			sufidx = l[GenerateRnd(nl)];
-			sprintf(istr, _("%s of %s"), items[i]._iIName, _(PL_Suffix[sufidx].PLName));
+			sprintf(istr, fmt::format(_("%s of %s"), items[i]._iIName, _(PL_Suffix[sufidx].PLName)).c_str());
 			strcpy(items[i]._iIName, istr);
 			items[i]._iMagical = ITEM_QUALITY_MAGIC;
 			SaveItemSuffix(i, sufidx);
@@ -2180,7 +2182,7 @@ void GetItemPower(int i, int minlvl, int maxlvl, affix_item_type flgs, bool only
 			strcpy(items[i]._iIName, istr);
 		}
 		if (sufidx != -1) {
-			sprintf(istr, _("%s of %s"), items[i]._iIName, _(PL_Suffix[sufidx].PLName));
+			sprintf(istr, fmt::format(_("%s of %s"), items[i]._iIName, _(PL_Suffix[sufidx].PLName)).c_str());
 			strcpy(items[i]._iIName, istr);
 		}
 	}
@@ -2744,7 +2746,7 @@ void RecreateEar(int ii, uint16_t ic, int iseed, int Id, int dur, int mdur, int 
 	tempstr[14] = (ibuff >> 8) & 0x7F;
 	tempstr[15] = ibuff & 0x7F;
 	tempstr[16] = '\0';
-	sprintf(items[ii]._iName, _( /* TRANSLATORS: %s will be a Character Name */ "Ear of %s"), tempstr);
+	sprintf(items[ii]._iName, fmt::format(_(/* TRANSLATORS: %s will be a Character Name */ "Ear of %s"), tempstr).c_str());
 	items[ii]._iCurs = ((ivalue >> 6) & 3) + ICURS_EAR_SORCERER;
 	items[ii]._ivalue = ivalue & 0x3F;
 	items[ii]._iCreateInfo = ic;
@@ -3412,51 +3414,51 @@ void PrintItemPower(char plidx, ItemStruct *x)
 	switch (plidx) {
 	case IPL_TOHIT:
 	case IPL_TOHIT_CURSE:
-		sprintf(tempstr, _("chance to hit: %+i%%"), x->_iPLToHit);
+		sprintf(tempstr, fmt::format(_("chance to hit: %+i%%"), x->_iPLToHit).c_str());
 		break;
 	case IPL_DAMP:
 	case IPL_DAMP_CURSE:
-		sprintf(tempstr, _("%+i%% damage"), x->_iPLDam);
+		sprintf(tempstr, fmt::format(_("%+i%% damage"), x->_iPLDam).c_str());
 		break;
 	case IPL_TOHIT_DAMP:
 	case IPL_TOHIT_DAMP_CURSE:
-		sprintf(tempstr, _("to hit: %+i%%, %+i%% damage"), x->_iPLToHit, x->_iPLDam);
+		sprintf(tempstr, fmt::format(_("to hit: %+i%%, %+i%% damage"), x->_iPLToHit, x->_iPLDam).c_str());
 		break;
 	case IPL_ACP:
 	case IPL_ACP_CURSE:
-		sprintf(tempstr, _("%+i%% armor"), x->_iPLAC);
+		sprintf(tempstr, fmt::format(_("%+i%% armor"), x->_iPLAC).c_str());
 		break;
 	case IPL_SETAC:
-		sprintf(tempstr, _("armor class: %i"), x->_iAC);
+		sprintf(tempstr, fmt::format(_("armor class: %i"), x->_iAC).c_str());
 		break;
 	case IPL_AC_CURSE:
-		sprintf(tempstr, _("armor class: %i"), x->_iAC);
+		sprintf(tempstr, fmt::format(_("armor class: %i"), x->_iAC).c_str());
 		break;
 	case IPL_FIRERES:
 	case IPL_FIRERES_CURSE:
 		if (x->_iPLFR < 75)
-			sprintf(tempstr, _("Resist Fire: %+i%%"), x->_iPLFR);
+			sprintf(tempstr, fmt::format(_("Resist Fire: %+i%%"), x->_iPLFR).c_str());
 		else
 			/*xgettext:no-c-format*/ strcpy(tempstr, _("Resist Fire: 75% MAX"));
 		break;
 	case IPL_LIGHTRES:
 	case IPL_LIGHTRES_CURSE:
 		if (x->_iPLLR < 75)
-			sprintf(tempstr, _("Resist Lightning: %+i%%"), x->_iPLLR);
+			sprintf(tempstr, fmt::format(_("Resist Lightning: %+i%%"), x->_iPLLR).c_str());
 		else
 			/*xgettext:no-c-format*/ strcpy(tempstr, _("Resist Lightning: 75% MAX"));
 		break;
 	case IPL_MAGICRES:
 	case IPL_MAGICRES_CURSE:
 		if (x->_iPLMR < 75)
-			sprintf(tempstr, _("Resist Magic: %+i%%"), x->_iPLMR);
+			sprintf(tempstr, fmt::format(_("Resist Magic: %+i%%"), x->_iPLMR).c_str());
 		else
 			/*xgettext:no-c-format*/ strcpy(tempstr, _("Resist Magic: 75% MAX"));
 		break;
 	case IPL_ALLRES:
 	case IPL_ALLRES_CURSE:
 		if (x->_iPLFR < 75)
-			sprintf(tempstr, _("Resist All: %+i%%"), x->_iPLFR);
+			sprintf(tempstr, fmt::format(_("Resist All: %+i%%"), x->_iPLFR).c_str());
 		if (x->_iPLFR >= 75)
 			/*xgettext:no-c-format*/ strcpy(tempstr, _("Resist All: 75% MAX"));
 		break;
@@ -3476,47 +3478,47 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		break;
 	case IPL_FIREDAM:
 		if (x->_iFMinDam == x->_iFMaxDam)
-			sprintf(tempstr, _("Fire hit damage: %i"), x->_iFMinDam);
+			sprintf(tempstr, fmt::format(_("Fire hit damage: %i"), x->_iFMinDam).c_str());
 		else
-			sprintf(tempstr, _("Fire hit damage: %i-%i"), x->_iFMinDam, x->_iFMaxDam);
+			sprintf(tempstr, fmt::format(_("Fire hit damage: %i-%i"), x->_iFMinDam, x->_iFMaxDam).c_str());
 		break;
 	case IPL_LIGHTDAM:
 		if (x->_iLMinDam == x->_iLMaxDam)
-			sprintf(tempstr, _("Lightning hit damage: %i"), x->_iLMinDam);
+			sprintf(tempstr, fmt::format(_("Lightning hit damage: %i"), x->_iLMinDam).c_str());
 		else
-			sprintf(tempstr, _("Lightning hit damage: %i-%i"), x->_iLMinDam, x->_iLMaxDam);
+			sprintf(tempstr, fmt::format(_("Lightning hit damage: %i-%i"), x->_iLMinDam, x->_iLMaxDam).c_str());
 		break;
 	case IPL_STR:
 	case IPL_STR_CURSE:
-		sprintf(tempstr, _("%+i to strength"), x->_iPLStr);
+		sprintf(tempstr, fmt::format(_("%+i to strength"), x->_iPLStr).c_str());
 		break;
 	case IPL_MAG:
 	case IPL_MAG_CURSE:
-		sprintf(tempstr, _("%+i to magic"), x->_iPLMag);
+		sprintf(tempstr, fmt::format(_("%+i to magic"), x->_iPLMag).c_str());
 		break;
 	case IPL_DEX:
 	case IPL_DEX_CURSE:
-		sprintf(tempstr, _("%+i to dexterity"), x->_iPLDex);
+		sprintf(tempstr, fmt::format(_("%+i to dexterity"), x->_iPLDex).c_str());
 		break;
 	case IPL_VIT:
 	case IPL_VIT_CURSE:
-		sprintf(tempstr, _("%+i to vitality"), x->_iPLVit);
+		sprintf(tempstr, fmt::format(_("%+i to vitality"), x->_iPLVit).c_str());
 		break;
 	case IPL_ATTRIBS:
 	case IPL_ATTRIBS_CURSE:
-		sprintf(tempstr, _("%+i to all attributes"), x->_iPLStr);
+		sprintf(tempstr, fmt::format(_("%+i to all attributes"), x->_iPLStr).c_str());
 		break;
 	case IPL_GETHIT_CURSE:
 	case IPL_GETHIT:
-		sprintf(tempstr, _("%+i damage from enemies"), x->_iPLGetHit);
+		sprintf(tempstr, fmt::format(_("%+i damage from enemies"), x->_iPLGetHit).c_str());
 		break;
 	case IPL_LIFE:
 	case IPL_LIFE_CURSE:
-		sprintf(tempstr, _("Hit Points: %+i"), x->_iPLHP >> 6);
+		sprintf(tempstr, fmt::format(_("Hit Points: %+i"), x->_iPLHP >> 6).c_str());
 		break;
 	case IPL_MANA:
 	case IPL_MANA_CURSE:
-		sprintf(tempstr, _("Mana: %+i"), x->_iPLMana >> 6);
+		sprintf(tempstr, fmt::format(_("Mana: %+i"), x->_iPLMana >> 6).c_str());
 		break;
 	case IPL_DUR:
 		strcpy(tempstr, _("high durability"));
@@ -3528,31 +3530,31 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		strcpy(tempstr, _("indestructible"));
 		break;
 	case IPL_LIGHT:
-		sprintf(tempstr, _("+%i%% light radius"), 10 * x->_iPLLight);
+		sprintf(tempstr, fmt::format(_("+%i%% light radius"), 10 * x->_iPLLight).c_str());
 		break;
 	case IPL_LIGHT_CURSE:
-		sprintf(tempstr, _("-%i%% light radius"), -10 * x->_iPLLight);
+		sprintf(tempstr, fmt::format(_("-%i%% light radius"), -10 * x->_iPLLight).c_str());
 		break;
 	case IPL_MULT_ARROWS:
 		strcpy(tempstr, _("multiple arrows per shot"));
 		break;
 	case IPL_FIRE_ARROWS:
 		if (x->_iFMinDam == x->_iFMaxDam)
-			sprintf(tempstr, _("fire arrows damage: %i"), x->_iFMinDam);
+			sprintf(tempstr, fmt::format(_("fire arrows damage: %i"), x->_iFMinDam).c_str());
 		else
-			sprintf(tempstr, _("fire arrows damage: %i-%i"), x->_iFMinDam, x->_iFMaxDam);
+			sprintf(tempstr, fmt::format(_("fire arrows damage: %i-%i"), x->_iFMinDam, x->_iFMaxDam).c_str());
 		break;
 	case IPL_LIGHT_ARROWS:
 		if (x->_iLMinDam == x->_iLMaxDam)
-			sprintf(tempstr, _("lightning arrows damage %i"), x->_iLMinDam);
+			sprintf(tempstr, fmt::format(_("lightning arrows damage %i"), x->_iLMinDam).c_str());
 		else
-			sprintf(tempstr, _("lightning arrows damage %i-%i"), x->_iLMinDam, x->_iLMaxDam);
+			sprintf(tempstr, fmt::format(_("lightning arrows damage %i-%i"), x->_iLMinDam, x->_iLMaxDam).c_str());
 		break;
 	case IPL_FIREBALL:
 		if (x->_iFMinDam == x->_iFMaxDam)
-			sprintf(tempstr, _("fireball damage: %i"), x->_iFMinDam);
+			sprintf(tempstr, fmt::format(_("fireball damage: %i"), x->_iFMinDam).c_str());
 		else
-			sprintf(tempstr, _("fireball damage: %i-%i"), x->_iFMinDam, x->_iFMaxDam);
+			sprintf(tempstr, fmt::format(_("fireball damage: %i-%i"), x->_iFMinDam, x->_iFMaxDam).c_str());
 		break;
 	case IPL_THORNS:
 		strcpy(tempstr, _("attacker takes 1-3 damage"));
@@ -3649,9 +3651,9 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		break;
 	case IPL_ADDACLIFE:
 		if (x->_iFMinDam == x->_iFMaxDam)
-			sprintf(tempstr, _("lightning damage: %i"), x->_iFMinDam);
+			sprintf(tempstr, fmt::format(_("lightning damage: %i"), x->_iFMinDam).c_str());
 		else
-			sprintf(tempstr, _("lightning damage: %i-%i"), x->_iFMinDam, x->_iFMaxDam);
+			sprintf(tempstr, fmt::format(_("lightning damage: %i-%i"), x->_iFMinDam, x->_iFMaxDam).c_str());
 		break;
 	case IPL_ADDMANAAC:
 		strcpy(tempstr, _("charged bolts on hits"));
@@ -3660,13 +3662,13 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		if (x->_iPLFR <= 0)
 			strcpy(tempstr, " ");
 		else if (x->_iPLFR >= 1)
-			sprintf(tempstr, _("Resist Fire: %+i%%"), x->_iPLFR);
+			sprintf(tempstr, fmt::format(_("Resist Fire: %+i%%"), x->_iPLFR).c_str());
 		break;
 	case IPL_DEVASTATION:
 		strcpy(tempstr, _("occasional triple damage"));
 		break;
 	case IPL_DECAY:
-		sprintf(tempstr, _("decaying %+i%% damage"), x->_iPLDam);
+		sprintf(tempstr, fmt::format(_("decaying %+i%% damage"), x->_iPLDam).c_str());
 		break;
 	case IPL_PERIL:
 		strcpy(tempstr, _("2x dmg to monst, 1x to you"));
@@ -3675,10 +3677,10 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		/*xgettext:no-c-format*/ strcpy(tempstr, _("Random 0 - 500% damage"));
 		break;
 	case IPL_CRYSTALLINE:
-		sprintf(tempstr, _("low dur, %+i%% damage"), x->_iPLDam);
+		sprintf(tempstr, fmt::format(_("low dur, %+i%% damage"), x->_iPLDam).c_str());
 		break;
 	case IPL_DOPPELGANGER:
-		sprintf(tempstr, _("to hit: %+i%%, %+i%% damage"), x->_iPLToHit, x->_iPLDam);
+		sprintf(tempstr, fmt::format(_("to hit: %+i%%, %+i%% damage"), x->_iPLToHit, x->_iPLDam).c_str());
 		break;
 	case IPL_ACDEMON:
 		strcpy(tempstr, _("extra AC vs demons"));
@@ -3797,7 +3799,7 @@ void PrintItemMisc(ItemStruct *x)
 		AddPanelString(tempstr);
 	}
 	if (x->_iMiscId == IMISC_EAR) {
-		sprintf(tempstr, _("Level: %i"), x->_ivalue);
+		sprintf(tempstr, fmt::format(_("Level: %i"), x->_ivalue).c_str());
 		AddPanelString(tempstr);
 	}
 	if (x->_iMiscId == IMISC_AURIC) {
@@ -3815,11 +3817,11 @@ static void PrintItemInfo(ItemStruct *x)
 	if (str != 0 || mag != 0 || dex != 0) {
 		strcpy(tempstr, _("Required:"));
 		if (str)
-			sprintf(tempstr + strlen(tempstr), _(" %i Str"), str);
+			sprintf(tempstr + strlen(tempstr), fmt::format(_(" %i Str"), str).c_str());
 		if (mag)
-			sprintf(tempstr + strlen(tempstr), _(" %i Mag"), mag);
+			sprintf(tempstr + strlen(tempstr), fmt::format(_(" %i Mag"), mag).c_str());
 		if (dex)
-			sprintf(tempstr + strlen(tempstr), _(" %i Dex"), dex);
+			sprintf(tempstr + strlen(tempstr), fmt::format(_(" %i Dex"), dex).c_str());
 		AddPanelString(tempstr);
 	}
 	pinfoflag = true;
@@ -3830,30 +3832,30 @@ void PrintItemDetails(ItemStruct *x)
 	if (x->_iClass == ICLASS_WEAPON) {
 		if (x->_iMinDam == x->_iMaxDam) {
 			if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-				sprintf(tempstr, _("damage: %i  Indestructible"), x->_iMinDam);
+				sprintf(tempstr, fmt::format(_("damage: %i  Indestructible"), x->_iMinDam).c_str());
 			else
-				sprintf(tempstr, _( /* TRANSLATORS: Dur: is durability */ "damage: %i  Dur: %i/%i"), x->_iMinDam, x->_iDurability, x->_iMaxDur);
+				sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "damage: %i  Dur: %i/%i"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
 		} else {
 			if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-				sprintf(tempstr, _("damage: %i-%i  Indestructible"), x->_iMinDam, x->_iMaxDam);
+				sprintf(tempstr, fmt::format(_("damage: %i-%i  Indestructible"), x->_iMinDam, x->_iMaxDam).c_str());
 			else
-				sprintf(tempstr, _( /* TRANSLATORS: Dur: is durability */ "damage: %i-%i  Dur: %i/%i"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur);
+				sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "damage: %i-%i  Dur: %i/%i"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
 		}
 		AddPanelString(tempstr);
 	}
 	if (x->_iClass == ICLASS_ARMOR) {
 		if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-			sprintf(tempstr, _("armor: %i  Indestructible"), x->_iAC);
+			sprintf(tempstr, fmt::format(_("armor: %i  Indestructible"), x->_iAC).c_str());
 		else
-			sprintf(tempstr, _( /* TRANSLATORS: Dur: is durability */ "armor: %i  Dur: %i/%i"), x->_iAC, x->_iDurability, x->_iMaxDur);
+			sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "armor: %i  Dur: %i/%i"), x->_iAC, x->_iDurability, x->_iMaxDur).c_str());
 		AddPanelString(tempstr);
 	}
 	if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges != 0) {
 		if (x->_iMinDam == x->_iMaxDam)
-			sprintf(tempstr, _( /* TRANSLATORS: dam: is damage Dur: is durability */ "dam: %i  Dur: %i/%i"), x->_iMinDam, x->_iDurability, x->_iMaxDur);
+			sprintf(tempstr, fmt::format(_(/* TRANSLATORS: dam: is damage Dur: is durability */ "dam: %i  Dur: %i/%i"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
 		else
-			sprintf(tempstr, _( /* TRANSLATORS: dam: is damage Dur: is durability */ "dam: %i-%i  Dur: %i/%i"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur);
-		sprintf(tempstr, _("Charges: %i/%i"), x->_iCharges, x->_iMaxCharges);
+			sprintf(tempstr, fmt::format(_(/* TRANSLATORS: dam: is damage Dur: is durability */ "dam: %i-%i  Dur: %i/%i"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
+		sprintf(tempstr, fmt::format(_("Charges: %i/%i"), x->_iCharges, x->_iMaxCharges).c_str());
 		AddPanelString(tempstr);
 	}
 	if (x->_iPrePower != -1) {
@@ -3877,18 +3879,18 @@ void PrintItemDur(ItemStruct *x)
 	if (x->_iClass == ICLASS_WEAPON) {
 		if (x->_iMinDam == x->_iMaxDam) {
 			if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-				sprintf(tempstr, _("damage: %i  Indestructible"), x->_iMinDam);
+				sprintf(tempstr, fmt::format(_("damage: %i  Indestructible"), x->_iMinDam).c_str());
 			else
-				sprintf(tempstr, _("damage: %i  Dur: %i/%i"), x->_iMinDam, x->_iDurability, x->_iMaxDur);
+				sprintf(tempstr, fmt::format(_("damage: %i  Dur: %i/%i"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
 		} else {
 			if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-				sprintf(tempstr, _("damage: %i-%i  Indestructible"), x->_iMinDam, x->_iMaxDam);
+				sprintf(tempstr, fmt::format(_("damage: %i-%i  Indestructible"), x->_iMinDam, x->_iMaxDam).c_str());
 			else
-				sprintf(tempstr, _("damage: %i-%i  Dur: %i/%i"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur);
+				sprintf(tempstr, fmt::format(_("damage: %i-%i  Dur: %i/%i"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
 		}
 		AddPanelString(tempstr);
 		if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges) {
-			sprintf(tempstr, _("Charges: %i/%i"), x->_iCharges, x->_iMaxCharges);
+			sprintf(tempstr, fmt::format(_("Charges: %i/%i"), x->_iCharges, x->_iMaxCharges).c_str());
 			AddPanelString(tempstr);
 		}
 		if (x->_iMagical != ITEM_QUALITY_NORMAL)
@@ -3896,14 +3898,14 @@ void PrintItemDur(ItemStruct *x)
 	}
 	if (x->_iClass == ICLASS_ARMOR) {
 		if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-			sprintf(tempstr, _("armor: %i  Indestructible"), x->_iAC);
+			sprintf(tempstr, fmt::format(_("armor: %i  Indestructible"), x->_iAC).c_str());
 		else
-			sprintf(tempstr, _("armor: %i  Dur: %i/%i"), x->_iAC, x->_iDurability, x->_iMaxDur);
+			sprintf(tempstr, fmt::format(_("armor: %i  Dur: %i/%i"), x->_iAC, x->_iDurability, x->_iMaxDur).c_str());
 		AddPanelString(tempstr);
 		if (x->_iMagical != ITEM_QUALITY_NORMAL)
 			AddPanelString(_("Not Identified"));
 		if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges) {
-			sprintf(tempstr, _("Charges: %i/%i"), x->_iCharges, x->_iMaxCharges);
+			sprintf(tempstr, fmt::format(_("Charges: %i/%i"), x->_iCharges, x->_iMaxCharges).c_str());
 			AddPanelString(tempstr);
 		}
 	}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1526,7 +1526,7 @@ void GetStaffPower(int i, int lvl, int bs, bool onlygood)
 			sprintf(istr, "%s %s", _(PL_Prefix[preidx].PLName), items[i]._iIName);
 			strcpy(items[i]._iIName, istr);
 		}
-		sprintf(istr, fmt::format(_(/* TRANSLATORS: Constructs item names. Format: <Prefix> <Item> of <Suffix>. Example: King's Long Sword of the Whale */ "%s of %s"), items[i]._iIName, _(spelldata[bs].sNameText)).c_str());
+		sprintf(istr, fmt::format(_(/* TRANSLATORS: Constructs item names. Format: <Prefix> <Item> of <Suffix>. Example: King's Long Sword of the Whale */ "{:s} of {:s}"), items[i]._iIName, _(spelldata[bs].sNameText)).c_str());
 		strcpy(items[i]._iIName, istr);
 		if (items[i]._iMagical == ITEM_QUALITY_NORMAL)
 			strcpy(items[i]._iName, items[i]._iIName);
@@ -1568,8 +1568,8 @@ void GetStaffSpell(int i, int lvl, bool onlygood)
 				s = SPL_FIREBOLT;
 		}
 		if (!control_WriteStringToBuffer(istr))
-			sprintf(istr, fmt::format(_("%s of %s"), items[i]._iName, _(spelldata[bs].sNameText)).c_str());
-		sprintf(istr, fmt::format(_("Staff of %s"), _(spelldata[bs].sNameText)).c_str());
+			sprintf(istr, fmt::format(_("{:s} of {:s}"), items[i]._iName, _(spelldata[bs].sNameText)).c_str());
+		sprintf(istr, fmt::format(_("Staff of {:s}"), _(spelldata[bs].sNameText)).c_str());
 		strcpy(items[i]._iName, istr);
 		strcpy(items[i]._iIName, istr);
 
@@ -2163,7 +2163,7 @@ void GetItemPower(int i, int minlvl, int maxlvl, affix_item_type flgs, bool only
 		}
 		if (nl != 0) {
 			sufidx = l[GenerateRnd(nl)];
-			sprintf(istr, fmt::format(_("%s of %s"), items[i]._iIName, _(PL_Suffix[sufidx].PLName)).c_str());
+			sprintf(istr, fmt::format(_("{:s} of {:s}"), items[i]._iIName, _(PL_Suffix[sufidx].PLName)).c_str());
 			strcpy(items[i]._iIName, istr);
 			items[i]._iMagical = ITEM_QUALITY_MAGIC;
 			SaveItemSuffix(i, sufidx);
@@ -2182,7 +2182,7 @@ void GetItemPower(int i, int minlvl, int maxlvl, affix_item_type flgs, bool only
 			strcpy(items[i]._iIName, istr);
 		}
 		if (sufidx != -1) {
-			sprintf(istr, fmt::format(_("%s of %s"), items[i]._iIName, _(PL_Suffix[sufidx].PLName)).c_str());
+			sprintf(istr, fmt::format(_("{:s} of {:s}"), items[i]._iIName, _(PL_Suffix[sufidx].PLName)).c_str());
 			strcpy(items[i]._iIName, istr);
 		}
 	}
@@ -2746,7 +2746,7 @@ void RecreateEar(int ii, uint16_t ic, int iseed, int Id, int dur, int mdur, int 
 	tempstr[14] = (ibuff >> 8) & 0x7F;
 	tempstr[15] = ibuff & 0x7F;
 	tempstr[16] = '\0';
-	sprintf(items[ii]._iName, fmt::format(_(/* TRANSLATORS: %s will be a Character Name */ "Ear of %s"), tempstr).c_str());
+	sprintf(items[ii]._iName, fmt::format(_(/* TRANSLATORS: {:s} will be a Character Name */ "Ear of {:s}"), tempstr).c_str());
 	items[ii]._iCurs = ((ivalue >> 6) & 3) + ICURS_EAR_SORCERER;
 	items[ii]._ivalue = ivalue & 0x3F;
 	items[ii]._iCreateInfo = ic;
@@ -3414,51 +3414,51 @@ void PrintItemPower(char plidx, ItemStruct *x)
 	switch (plidx) {
 	case IPL_TOHIT:
 	case IPL_TOHIT_CURSE:
-		sprintf(tempstr, fmt::format(_("chance to hit: %+i%%"), x->_iPLToHit).c_str());
+		sprintf(tempstr, fmt::format(_("chance to hit: {:+d}%"), x->_iPLToHit).c_str());
 		break;
 	case IPL_DAMP:
 	case IPL_DAMP_CURSE:
-		sprintf(tempstr, fmt::format(_("%+i%% damage"), x->_iPLDam).c_str());
+		sprintf(tempstr, fmt::format(_("{:+d}% damage"), x->_iPLDam).c_str());
 		break;
 	case IPL_TOHIT_DAMP:
 	case IPL_TOHIT_DAMP_CURSE:
-		sprintf(tempstr, fmt::format(_("to hit: %+i%%, %+i%% damage"), x->_iPLToHit, x->_iPLDam).c_str());
+		sprintf(tempstr, fmt::format(_("to hit: {:+d}%, {:+d}% damage"), x->_iPLToHit, x->_iPLDam).c_str());
 		break;
 	case IPL_ACP:
 	case IPL_ACP_CURSE:
-		sprintf(tempstr, fmt::format(_("%+i%% armor"), x->_iPLAC).c_str());
+		sprintf(tempstr, fmt::format(_("{:+d}% armor"), x->_iPLAC).c_str());
 		break;
 	case IPL_SETAC:
-		sprintf(tempstr, fmt::format(_("armor class: %i"), x->_iAC).c_str());
+		sprintf(tempstr, fmt::format(_("armor class: {:d}"), x->_iAC).c_str());
 		break;
 	case IPL_AC_CURSE:
-		sprintf(tempstr, fmt::format(_("armor class: %i"), x->_iAC).c_str());
+		sprintf(tempstr, fmt::format(_("armor class: {:d}"), x->_iAC).c_str());
 		break;
 	case IPL_FIRERES:
 	case IPL_FIRERES_CURSE:
 		if (x->_iPLFR < 75)
-			sprintf(tempstr, fmt::format(_("Resist Fire: %+i%%"), x->_iPLFR).c_str());
+			sprintf(tempstr, fmt::format(_("Resist Fire: {:+d}%"), x->_iPLFR).c_str());
 		else
 			/*xgettext:no-c-format*/ strcpy(tempstr, _("Resist Fire: 75% MAX"));
 		break;
 	case IPL_LIGHTRES:
 	case IPL_LIGHTRES_CURSE:
 		if (x->_iPLLR < 75)
-			sprintf(tempstr, fmt::format(_("Resist Lightning: %+i%%"), x->_iPLLR).c_str());
+			sprintf(tempstr, fmt::format(_("Resist Lightning: {:+d}%"), x->_iPLLR).c_str());
 		else
 			/*xgettext:no-c-format*/ strcpy(tempstr, _("Resist Lightning: 75% MAX"));
 		break;
 	case IPL_MAGICRES:
 	case IPL_MAGICRES_CURSE:
 		if (x->_iPLMR < 75)
-			sprintf(tempstr, fmt::format(_("Resist Magic: %+i%%"), x->_iPLMR).c_str());
+			sprintf(tempstr, fmt::format(_("Resist Magic: {:+d}%"), x->_iPLMR).c_str());
 		else
 			/*xgettext:no-c-format*/ strcpy(tempstr, _("Resist Magic: 75% MAX"));
 		break;
 	case IPL_ALLRES:
 	case IPL_ALLRES_CURSE:
 		if (x->_iPLFR < 75)
-			sprintf(tempstr, fmt::format(_("Resist All: %+i%%"), x->_iPLFR).c_str());
+			sprintf(tempstr, fmt::format(_("Resist All: {:+d}%"), x->_iPLFR).c_str());
 		if (x->_iPLFR >= 75)
 			/*xgettext:no-c-format*/ strcpy(tempstr, _("Resist All: 75% MAX"));
 		break;
@@ -3478,47 +3478,47 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		break;
 	case IPL_FIREDAM:
 		if (x->_iFMinDam == x->_iFMaxDam)
-			sprintf(tempstr, fmt::format(_("Fire hit damage: %i"), x->_iFMinDam).c_str());
+			sprintf(tempstr, fmt::format(_("Fire hit damage: {:d}"), x->_iFMinDam).c_str());
 		else
-			sprintf(tempstr, fmt::format(_("Fire hit damage: %i-%i"), x->_iFMinDam, x->_iFMaxDam).c_str());
+			sprintf(tempstr, fmt::format(_("Fire hit damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam).c_str());
 		break;
 	case IPL_LIGHTDAM:
 		if (x->_iLMinDam == x->_iLMaxDam)
-			sprintf(tempstr, fmt::format(_("Lightning hit damage: %i"), x->_iLMinDam).c_str());
+			sprintf(tempstr, fmt::format(_("Lightning hit damage: {:d}"), x->_iLMinDam).c_str());
 		else
-			sprintf(tempstr, fmt::format(_("Lightning hit damage: %i-%i"), x->_iLMinDam, x->_iLMaxDam).c_str());
+			sprintf(tempstr, fmt::format(_("Lightning hit damage: {:d}-{:d}"), x->_iLMinDam, x->_iLMaxDam).c_str());
 		break;
 	case IPL_STR:
 	case IPL_STR_CURSE:
-		sprintf(tempstr, fmt::format(_("%+i to strength"), x->_iPLStr).c_str());
+		sprintf(tempstr, fmt::format(_("{:+d} to strength"), x->_iPLStr).c_str());
 		break;
 	case IPL_MAG:
 	case IPL_MAG_CURSE:
-		sprintf(tempstr, fmt::format(_("%+i to magic"), x->_iPLMag).c_str());
+		sprintf(tempstr, fmt::format(_("{:+d} to magic"), x->_iPLMag).c_str());
 		break;
 	case IPL_DEX:
 	case IPL_DEX_CURSE:
-		sprintf(tempstr, fmt::format(_("%+i to dexterity"), x->_iPLDex).c_str());
+		sprintf(tempstr, fmt::format(_("{:+d} to dexterity"), x->_iPLDex).c_str());
 		break;
 	case IPL_VIT:
 	case IPL_VIT_CURSE:
-		sprintf(tempstr, fmt::format(_("%+i to vitality"), x->_iPLVit).c_str());
+		sprintf(tempstr, fmt::format(_("{:+d} to vitality"), x->_iPLVit).c_str());
 		break;
 	case IPL_ATTRIBS:
 	case IPL_ATTRIBS_CURSE:
-		sprintf(tempstr, fmt::format(_("%+i to all attributes"), x->_iPLStr).c_str());
+		sprintf(tempstr, fmt::format(_("{:+d} to all attributes"), x->_iPLStr).c_str());
 		break;
 	case IPL_GETHIT_CURSE:
 	case IPL_GETHIT:
-		sprintf(tempstr, fmt::format(_("%+i damage from enemies"), x->_iPLGetHit).c_str());
+		sprintf(tempstr, fmt::format(_("{:+d} damage from enemies"), x->_iPLGetHit).c_str());
 		break;
 	case IPL_LIFE:
 	case IPL_LIFE_CURSE:
-		sprintf(tempstr, fmt::format(_("Hit Points: %+i"), x->_iPLHP >> 6).c_str());
+		sprintf(tempstr, fmt::format(_("Hit Points: {:+d}"), x->_iPLHP >> 6).c_str());
 		break;
 	case IPL_MANA:
 	case IPL_MANA_CURSE:
-		sprintf(tempstr, fmt::format(_("Mana: %+i"), x->_iPLMana >> 6).c_str());
+		sprintf(tempstr, fmt::format(_("Mana: {:+d}"), x->_iPLMana >> 6).c_str());
 		break;
 	case IPL_DUR:
 		strcpy(tempstr, _("high durability"));
@@ -3530,31 +3530,31 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		strcpy(tempstr, _("indestructible"));
 		break;
 	case IPL_LIGHT:
-		sprintf(tempstr, fmt::format(_("+%i%% light radius"), 10 * x->_iPLLight).c_str());
+		sprintf(tempstr, fmt::format(_("+{:d}% light radius"), 10 * x->_iPLLight).c_str());
 		break;
 	case IPL_LIGHT_CURSE:
-		sprintf(tempstr, fmt::format(_("-%i%% light radius"), -10 * x->_iPLLight).c_str());
+		sprintf(tempstr, fmt::format(_("-{:d}% light radius"), -10 * x->_iPLLight).c_str());
 		break;
 	case IPL_MULT_ARROWS:
 		strcpy(tempstr, _("multiple arrows per shot"));
 		break;
 	case IPL_FIRE_ARROWS:
 		if (x->_iFMinDam == x->_iFMaxDam)
-			sprintf(tempstr, fmt::format(_("fire arrows damage: %i"), x->_iFMinDam).c_str());
+			sprintf(tempstr, fmt::format(_("fire arrows damage: {:d}"), x->_iFMinDam).c_str());
 		else
-			sprintf(tempstr, fmt::format(_("fire arrows damage: %i-%i"), x->_iFMinDam, x->_iFMaxDam).c_str());
+			sprintf(tempstr, fmt::format(_("fire arrows damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam).c_str());
 		break;
 	case IPL_LIGHT_ARROWS:
 		if (x->_iLMinDam == x->_iLMaxDam)
-			sprintf(tempstr, fmt::format(_("lightning arrows damage %i"), x->_iLMinDam).c_str());
+			sprintf(tempstr, fmt::format(_("lightning arrows damage {:d}"), x->_iLMinDam).c_str());
 		else
-			sprintf(tempstr, fmt::format(_("lightning arrows damage %i-%i"), x->_iLMinDam, x->_iLMaxDam).c_str());
+			sprintf(tempstr, fmt::format(_("lightning arrows damage {:d}-{:d}"), x->_iLMinDam, x->_iLMaxDam).c_str());
 		break;
 	case IPL_FIREBALL:
 		if (x->_iFMinDam == x->_iFMaxDam)
-			sprintf(tempstr, fmt::format(_("fireball damage: %i"), x->_iFMinDam).c_str());
+			sprintf(tempstr, fmt::format(_("fireball damage: {:d}"), x->_iFMinDam).c_str());
 		else
-			sprintf(tempstr, fmt::format(_("fireball damage: %i-%i"), x->_iFMinDam, x->_iFMaxDam).c_str());
+			sprintf(tempstr, fmt::format(_("fireball damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam).c_str());
 		break;
 	case IPL_THORNS:
 		strcpy(tempstr, _("attacker takes 1-3 damage"));
@@ -3651,9 +3651,9 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		break;
 	case IPL_ADDACLIFE:
 		if (x->_iFMinDam == x->_iFMaxDam)
-			sprintf(tempstr, fmt::format(_("lightning damage: %i"), x->_iFMinDam).c_str());
+			sprintf(tempstr, fmt::format(_("lightning damage: {:d}"), x->_iFMinDam).c_str());
 		else
-			sprintf(tempstr, fmt::format(_("lightning damage: %i-%i"), x->_iFMinDam, x->_iFMaxDam).c_str());
+			sprintf(tempstr, fmt::format(_("lightning damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam).c_str());
 		break;
 	case IPL_ADDMANAAC:
 		strcpy(tempstr, _("charged bolts on hits"));
@@ -3662,13 +3662,13 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		if (x->_iPLFR <= 0)
 			strcpy(tempstr, " ");
 		else if (x->_iPLFR >= 1)
-			sprintf(tempstr, fmt::format(_("Resist Fire: %+i%%"), x->_iPLFR).c_str());
+			sprintf(tempstr, fmt::format(_("Resist Fire: {:+d}%"), x->_iPLFR).c_str());
 		break;
 	case IPL_DEVASTATION:
 		strcpy(tempstr, _("occasional triple damage"));
 		break;
 	case IPL_DECAY:
-		sprintf(tempstr, fmt::format(_("decaying %+i%% damage"), x->_iPLDam).c_str());
+		sprintf(tempstr, fmt::format(_("decaying {:+d}% damage"), x->_iPLDam).c_str());
 		break;
 	case IPL_PERIL:
 		strcpy(tempstr, _("2x dmg to monst, 1x to you"));
@@ -3677,10 +3677,10 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		/*xgettext:no-c-format*/ strcpy(tempstr, _("Random 0 - 500% damage"));
 		break;
 	case IPL_CRYSTALLINE:
-		sprintf(tempstr, fmt::format(_("low dur, %+i%% damage"), x->_iPLDam).c_str());
+		sprintf(tempstr, fmt::format(_("low dur, {:+d}% damage"), x->_iPLDam).c_str());
 		break;
 	case IPL_DOPPELGANGER:
-		sprintf(tempstr, fmt::format(_("to hit: %+i%%, %+i%% damage"), x->_iPLToHit, x->_iPLDam).c_str());
+		sprintf(tempstr, fmt::format(_("to hit: {:+d}%, {:+d}% damage"), x->_iPLToHit, x->_iPLDam).c_str());
 		break;
 	case IPL_ACDEMON:
 		strcpy(tempstr, _("extra AC vs demons"));
@@ -3799,7 +3799,7 @@ void PrintItemMisc(ItemStruct *x)
 		AddPanelString(tempstr);
 	}
 	if (x->_iMiscId == IMISC_EAR) {
-		sprintf(tempstr, fmt::format(_("Level: %i"), x->_ivalue).c_str());
+		sprintf(tempstr, fmt::format(_("Level: {:d}"), x->_ivalue).c_str());
 		AddPanelString(tempstr);
 	}
 	if (x->_iMiscId == IMISC_AURIC) {
@@ -3817,11 +3817,11 @@ static void PrintItemInfo(ItemStruct *x)
 	if (str != 0 || mag != 0 || dex != 0) {
 		strcpy(tempstr, _("Required:"));
 		if (str)
-			sprintf(tempstr + strlen(tempstr), fmt::format(_(" %i Str"), str).c_str());
+			sprintf(tempstr + strlen(tempstr), fmt::format(_(" {:d} Str"), str).c_str());
 		if (mag)
-			sprintf(tempstr + strlen(tempstr), fmt::format(_(" %i Mag"), mag).c_str());
+			sprintf(tempstr + strlen(tempstr), fmt::format(_(" {:d} Mag"), mag).c_str());
 		if (dex)
-			sprintf(tempstr + strlen(tempstr), fmt::format(_(" %i Dex"), dex).c_str());
+			sprintf(tempstr + strlen(tempstr), fmt::format(_(" {:d} Dex"), dex).c_str());
 		AddPanelString(tempstr);
 	}
 	pinfoflag = true;
@@ -3832,30 +3832,30 @@ void PrintItemDetails(ItemStruct *x)
 	if (x->_iClass == ICLASS_WEAPON) {
 		if (x->_iMinDam == x->_iMaxDam) {
 			if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-				sprintf(tempstr, fmt::format(_("damage: %i  Indestructible"), x->_iMinDam).c_str());
+				sprintf(tempstr, fmt::format(_("damage: {:d}  Indestructible"), x->_iMinDam).c_str());
 			else
-				sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "damage: %i  Dur: %i/%i"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
+				sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "damage: {:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
 		} else {
 			if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-				sprintf(tempstr, fmt::format(_("damage: %i-%i  Indestructible"), x->_iMinDam, x->_iMaxDam).c_str());
+				sprintf(tempstr, fmt::format(_("damage: {:d}-{:d}  Indestructible"), x->_iMinDam, x->_iMaxDam).c_str());
 			else
-				sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "damage: %i-%i  Dur: %i/%i"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
+				sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "damage: {:d}-{:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
 		}
 		AddPanelString(tempstr);
 	}
 	if (x->_iClass == ICLASS_ARMOR) {
 		if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-			sprintf(tempstr, fmt::format(_("armor: %i  Indestructible"), x->_iAC).c_str());
+			sprintf(tempstr, fmt::format(_("armor: {:d}  Indestructible"), x->_iAC).c_str());
 		else
-			sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "armor: %i  Dur: %i/%i"), x->_iAC, x->_iDurability, x->_iMaxDur).c_str());
+			sprintf(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "armor: {:d}  Dur: {:d}/{:d}"), x->_iAC, x->_iDurability, x->_iMaxDur).c_str());
 		AddPanelString(tempstr);
 	}
 	if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges != 0) {
 		if (x->_iMinDam == x->_iMaxDam)
-			sprintf(tempstr, fmt::format(_(/* TRANSLATORS: dam: is damage Dur: is durability */ "dam: %i  Dur: %i/%i"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
+			sprintf(tempstr, fmt::format(_(/* TRANSLATORS: dam: is damage Dur: is durability */ "dam: {:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
 		else
-			sprintf(tempstr, fmt::format(_(/* TRANSLATORS: dam: is damage Dur: is durability */ "dam: %i-%i  Dur: %i/%i"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
-		sprintf(tempstr, fmt::format(_("Charges: %i/%i"), x->_iCharges, x->_iMaxCharges).c_str());
+			sprintf(tempstr, fmt::format(_(/* TRANSLATORS: dam: is damage Dur: is durability */ "dam: {:d}-{:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
+		sprintf(tempstr, fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges).c_str());
 		AddPanelString(tempstr);
 	}
 	if (x->_iPrePower != -1) {
@@ -3879,18 +3879,18 @@ void PrintItemDur(ItemStruct *x)
 	if (x->_iClass == ICLASS_WEAPON) {
 		if (x->_iMinDam == x->_iMaxDam) {
 			if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-				sprintf(tempstr, fmt::format(_("damage: %i  Indestructible"), x->_iMinDam).c_str());
+				sprintf(tempstr, fmt::format(_("damage: {:d}  Indestructible"), x->_iMinDam).c_str());
 			else
-				sprintf(tempstr, fmt::format(_("damage: %i  Dur: %i/%i"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
+				sprintf(tempstr, fmt::format(_("damage: {:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
 		} else {
 			if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-				sprintf(tempstr, fmt::format(_("damage: %i-%i  Indestructible"), x->_iMinDam, x->_iMaxDam).c_str());
+				sprintf(tempstr, fmt::format(_("damage: {:d}-{:d}  Indestructible"), x->_iMinDam, x->_iMaxDam).c_str());
 			else
-				sprintf(tempstr, fmt::format(_("damage: %i-%i  Dur: %i/%i"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
+				sprintf(tempstr, fmt::format(_("damage: {:d}-{:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
 		}
 		AddPanelString(tempstr);
 		if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges) {
-			sprintf(tempstr, fmt::format(_("Charges: %i/%i"), x->_iCharges, x->_iMaxCharges).c_str());
+			sprintf(tempstr, fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges).c_str());
 			AddPanelString(tempstr);
 		}
 		if (x->_iMagical != ITEM_QUALITY_NORMAL)
@@ -3898,14 +3898,14 @@ void PrintItemDur(ItemStruct *x)
 	}
 	if (x->_iClass == ICLASS_ARMOR) {
 		if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-			sprintf(tempstr, fmt::format(_("armor: %i  Indestructible"), x->_iAC).c_str());
+			sprintf(tempstr, fmt::format(_("armor: {:d}  Indestructible"), x->_iAC).c_str());
 		else
-			sprintf(tempstr, fmt::format(_("armor: %i  Dur: %i/%i"), x->_iAC, x->_iDurability, x->_iMaxDur).c_str());
+			sprintf(tempstr, fmt::format(_("armor: {:d}  Dur: {:d}/{:d}"), x->_iAC, x->_iDurability, x->_iMaxDur).c_str());
 		AddPanelString(tempstr);
 		if (x->_iMagical != ITEM_QUALITY_NORMAL)
 			AddPanelString(_("Not Identified"));
 		if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges) {
-			sprintf(tempstr, fmt::format(_("Charges: %i/%i"), x->_iCharges, x->_iMaxCharges).c_str());
+			sprintf(tempstr, fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges).c_str());
 			AddPanelString(tempstr);
 		}
 	}

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4965,9 +4965,9 @@ void PrintMonstHistory(int mt)
 	int minHP, maxHP, res;
 
 	if (sgOptions.Gameplay.bShowMonsterType) {
-		sprintf(tempstr, fmt::format(_("Type: %s  Kills: %i"), GetMonsterTypeText(monsterdata[mt])).c_str(), monstkills[mt]);
+		sprintf(tempstr, fmt::format(_("Type: {:s}  Kills: {:d}"), GetMonsterTypeText(monsterdata[mt])).c_str(), monstkills[mt]);
 	} else {
-		sprintf(tempstr, fmt::format(_("Total kills: %i"), monstkills[mt]).c_str());
+		sprintf(tempstr, fmt::format(_("Total kills: {:d}"), monstkills[mt]).c_str());
 	}
 
 	AddPanelString(tempstr);
@@ -5000,7 +5000,7 @@ void PrintMonstHistory(int mt)
 			minHP = 4 * minHP + hpBonusHell;
 			maxHP = 4 * maxHP + hpBonusHell;
 		}
-		sprintf(tempstr, fmt::format(_("Hit Points: %i-%i"), minHP, maxHP).c_str());
+		sprintf(tempstr, fmt::format(_("Hit Points: {:d}-{:d}"), minHP, maxHP).c_str());
 		AddPanelString(tempstr);
 	}
 	if (monstkills[mt] >= 15) {
@@ -5045,7 +5045,7 @@ void PrintUniqueHistory()
 	int res;
 
 	if (sgOptions.Gameplay.bShowMonsterType) {
-		sprintf(tempstr, fmt::format(_("Type: %s"), GetMonsterTypeText(*monster[pcursmonst].MData)).c_str());
+		sprintf(tempstr, fmt::format(_("Type: {:s}"), GetMonsterTypeText(*monster[pcursmonst].MData)).c_str());
 		AddPanelString(tempstr);
 	}
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4965,9 +4965,9 @@ void PrintMonstHistory(int mt)
 	int minHP, maxHP, res;
 
 	if (sgOptions.Gameplay.bShowMonsterType) {
-		sprintf(tempstr, fmt::format(_("Type: {:s}  Kills: {:d}"), GetMonsterTypeText(monsterdata[mt])).c_str(), monstkills[mt]);
+		strcpy(tempstr, fmt::format(_("Type: {:s}  Kills: {:d}"), GetMonsterTypeText(monsterdata[mt]), monstkills[mt]).c_str());
 	} else {
-		sprintf(tempstr, fmt::format(_("Total kills: {:d}"), monstkills[mt]).c_str());
+		strcpy(tempstr, fmt::format(_("Total kills: {:d}"), monstkills[mt]).c_str());
 	}
 
 	AddPanelString(tempstr);
@@ -5000,7 +5000,7 @@ void PrintMonstHistory(int mt)
 			minHP = 4 * minHP + hpBonusHell;
 			maxHP = 4 * maxHP + hpBonusHell;
 		}
-		sprintf(tempstr, fmt::format(_("Hit Points: {:d}-{:d}"), minHP, maxHP).c_str());
+		strcpy(tempstr, fmt::format(_("Hit Points: {:d}-{:d}"), minHP, maxHP).c_str());
 		AddPanelString(tempstr);
 	}
 	if (monstkills[mt] >= 15) {
@@ -5045,7 +5045,7 @@ void PrintUniqueHistory()
 	int res;
 
 	if (sgOptions.Gameplay.bShowMonsterType) {
-		sprintf(tempstr, fmt::format(_("Type: {:s}"), GetMonsterTypeText(*monster[pcursmonst].MData)).c_str());
+		strcpy(tempstr, fmt::format(_("Type: {:s}"), GetMonsterTypeText(*monster[pcursmonst].MData)).c_str());
 		AddPanelString(tempstr);
 	}
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -9,6 +9,8 @@
 #include <array>
 #include <climits>
 
+#include <fmt/format.h>
+
 #include "control.h"
 #include "cursor.h"
 #include "dead.h"
@@ -1671,7 +1673,7 @@ void SpawnLoot(int i, bool sendmsg)
 
 	Monst = &monster[i];
 	if (QuestStatus(Q_GARBUD) && Monst->_uniqtype - 1 == UMT_GARBUD) {
-		CreateTypeItem(Monst->position.tile + Point{1, 1}, true, ITYPE_MACE, IMISC_NONE, true, false);
+		CreateTypeItem(Monst->position.tile + Point { 1, 1 }, true, ITYPE_MACE, IMISC_NONE, true, false);
 	} else if (Monst->_uniqtype - 1 == UMT_DEFILER) {
 		if (effect_is_playing(USFX_DEFILER8))
 			stream_stop();
@@ -2415,7 +2417,7 @@ bool M_DoTalk(int i)
 			quests[Q_GARBUD]._qlog = true; // BUGFIX: (?) for other quests qactive and qlog go together, maybe this should actually go into the if above (fixed)
 		}
 		if (monster[i].mtalkmsg == TEXT_GARBUD2 && !(monster[i]._mFlags & MFLAG_QUEST_COMPLETE)) {
-			SpawnItem(i, monster[i].position.tile + Point{1, 1}, true);
+			SpawnItem(i, monster[i].position.tile + Point { 1, 1 }, true);
 			monster[i]._mFlags |= MFLAG_QUEST_COMPLETE;
 		}
 	}
@@ -2424,7 +2426,7 @@ bool M_DoTalk(int i)
 	    && !(monster[i]._mFlags & MFLAG_QUEST_COMPLETE)) {
 		quests[Q_ZHAR]._qactive = QUEST_ACTIVE;
 		quests[Q_ZHAR]._qlog = true;
-		CreateTypeItem(monster[i].position.tile + Point{1,1}, false, ITYPE_MISC, IMISC_BOOK, true, false);
+		CreateTypeItem(monster[i].position.tile + Point { 1, 1 }, false, ITYPE_MISC, IMISC_BOOK, true, false);
 		monster[i]._mFlags |= MFLAG_QUEST_COMPLETE;
 	}
 	if (monster[i]._uniqtype - 1 == UMT_SNOTSPIL) {
@@ -4963,9 +4965,9 @@ void PrintMonstHistory(int mt)
 	int minHP, maxHP, res;
 
 	if (sgOptions.Gameplay.bShowMonsterType) {
-		sprintf(tempstr, _("Type: %s  Kills: %i"), GetMonsterTypeText(monsterdata[mt]), monstkills[mt]);
+		sprintf(tempstr, fmt::format(_("Type: %s  Kills: %i"), GetMonsterTypeText(monsterdata[mt])).c_str(), monstkills[mt]);
 	} else {
-		sprintf(tempstr, _("Total kills: %i"), monstkills[mt]);
+		sprintf(tempstr, fmt::format(_("Total kills: %i"), monstkills[mt]).c_str());
 	}
 
 	AddPanelString(tempstr);
@@ -4998,7 +5000,7 @@ void PrintMonstHistory(int mt)
 			minHP = 4 * minHP + hpBonusHell;
 			maxHP = 4 * maxHP + hpBonusHell;
 		}
-		sprintf(tempstr, _("Hit Points: %i-%i"), minHP, maxHP);
+		sprintf(tempstr, fmt::format(_("Hit Points: %i-%i"), minHP, maxHP).c_str());
 		AddPanelString(tempstr);
 	}
 	if (monstkills[mt] >= 15) {
@@ -5043,7 +5045,7 @@ void PrintUniqueHistory()
 	int res;
 
 	if (sgOptions.Gameplay.bShowMonsterType) {
-		sprintf(tempstr, _("Type: %s"), GetMonsterTypeText(*monster[pcursmonst].MData));
+		sprintf(tempstr, fmt::format(_("Type: %s"), GetMonsterTypeText(*monster[pcursmonst].MData)).c_str());
 		AddPanelString(tempstr);
 	}
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -6,6 +6,8 @@
 #include <climits>
 #include <memory>
 
+#include <fmt/format.h>
+
 #include "DiabloUI/diabloui.h"
 #include "automap.h"
 #include "control.h"
@@ -1391,7 +1393,7 @@ static DWORD On_SBSPELL(TCmd *pCmd, int pnum)
 			plr[pnum]._pSplFrom = 1;
 			plr[pnum].destAction = ACTION_SPELL;
 		} else
-			msg_errorf(_("%s has cast an illegal spell."), plr[pnum]._pName);
+			msg_errorf(fmt::format(_("%s has cast an illegal spell."), plr[pnum]._pName).c_str());
 	}
 
 	return sizeof(*p);
@@ -1662,7 +1664,7 @@ static DWORD On_SPELLXYD(TCmd *pCmd, int pnum)
 			plr[pnum]._pSplType = plr[pnum]._pRSplType;
 			plr[pnum]._pSplFrom = 0;
 		} else
-			msg_errorf(_("%s has cast an illegal spell."), plr[pnum]._pName);
+			msg_errorf(fmt::format(_("%s has cast an illegal spell."), plr[pnum]._pName).c_str());
 	}
 
 	return sizeof(*p);
@@ -1684,7 +1686,7 @@ static DWORD On_SPELLXY(TCmd *pCmd, int pnum)
 			plr[pnum]._pSplType = plr[pnum]._pRSplType;
 			plr[pnum]._pSplFrom = 0;
 		} else
-			msg_errorf(_("%s has cast an illegal spell."), plr[pnum]._pName);
+			msg_errorf(fmt::format(_("%s has cast an illegal spell."), plr[pnum]._pName).c_str());
 	}
 
 	return sizeof(*p);
@@ -1706,7 +1708,7 @@ static DWORD On_TSPELLXY(TCmd *pCmd, int pnum)
 			plr[pnum]._pSplType = plr[pnum]._pTSplType;
 			plr[pnum]._pSplFrom = 2;
 		} else
-			msg_errorf(_("%s has cast an illegal spell."), plr[pnum]._pName);
+			msg_errorf(fmt::format(_("%s has cast an illegal spell."), plr[pnum]._pName).c_str());
 	}
 
 	return sizeof(*p);
@@ -1826,7 +1828,7 @@ static DWORD On_SPELLID(TCmd *pCmd, int pnum)
 			plr[pnum]._pSplType = plr[pnum]._pRSplType;
 			plr[pnum]._pSplFrom = 0;
 		} else
-			msg_errorf(_("%s has cast an illegal spell."), plr[pnum]._pName);
+			msg_errorf(fmt::format(_("%s has cast an illegal spell."), plr[pnum]._pName).c_str());
 	}
 
 	return sizeof(*p);
@@ -1847,7 +1849,7 @@ static DWORD On_SPELLPID(TCmd *pCmd, int pnum)
 			plr[pnum]._pSplType = plr[pnum]._pRSplType;
 			plr[pnum]._pSplFrom = 0;
 		} else
-			msg_errorf(_("%s has cast an illegal spell."), plr[pnum]._pName);
+			msg_errorf(fmt::format(_("%s has cast an illegal spell."), plr[pnum]._pName).c_str());
 	}
 
 	return sizeof(*p);
@@ -1868,7 +1870,7 @@ static DWORD On_TSPELLID(TCmd *pCmd, int pnum)
 			plr[pnum]._pSplType = plr[pnum]._pTSplType;
 			plr[pnum]._pSplFrom = 2;
 		} else
-			msg_errorf(_("%s has cast an illegal spell."), plr[pnum]._pName);
+			msg_errorf(fmt::format(_("%s has cast an illegal spell."), plr[pnum]._pName).c_str());
 	}
 
 	return sizeof(*p);
@@ -1889,7 +1891,7 @@ static DWORD On_TSPELLPID(TCmd *pCmd, int pnum)
 			plr[pnum]._pSplType = plr[pnum]._pTSplType;
 			plr[pnum]._pSplFrom = 2;
 		} else
-			msg_errorf(_("%s has cast an illegal spell."), plr[pnum]._pName);
+			msg_errorf(fmt::format(_("%s has cast an illegal spell."), plr[pnum]._pName).c_str());
 	}
 
 	return sizeof(*p);
@@ -2225,7 +2227,7 @@ static DWORD On_PLAYER_JOINLEVEL(TCmd *pCmd, int pnum)
 			InitPlrGFXMem(plr[pnum]);
 			plr[pnum].plractive = true;
 			gbActivePlayers++;
-			EventPlrMsg(_("Player '%s' (level %i) just joined the game"), plr[pnum]._pName, plr[pnum]._pLevel);
+			EventPlrMsg(fmt::format(_("Player '%s' (level %i) just joined the game"), plr[pnum]._pName, plr[pnum]._pLevel).c_str());
 		}
 
 		if (plr[pnum].plractive && myplr != pnum) {

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1393,7 +1393,7 @@ static DWORD On_SBSPELL(TCmd *pCmd, int pnum)
 			plr[pnum]._pSplFrom = 1;
 			plr[pnum].destAction = ACTION_SPELL;
 		} else
-			msg_errorf(fmt::format(_("%s has cast an illegal spell."), plr[pnum]._pName).c_str());
+			msg_errorf(fmt::format(_("{:s} has cast an illegal spell."), plr[pnum]._pName).c_str());
 	}
 
 	return sizeof(*p);
@@ -1664,7 +1664,7 @@ static DWORD On_SPELLXYD(TCmd *pCmd, int pnum)
 			plr[pnum]._pSplType = plr[pnum]._pRSplType;
 			plr[pnum]._pSplFrom = 0;
 		} else
-			msg_errorf(fmt::format(_("%s has cast an illegal spell."), plr[pnum]._pName).c_str());
+			msg_errorf(fmt::format(_("{:s} has cast an illegal spell."), plr[pnum]._pName).c_str());
 	}
 
 	return sizeof(*p);
@@ -1686,7 +1686,7 @@ static DWORD On_SPELLXY(TCmd *pCmd, int pnum)
 			plr[pnum]._pSplType = plr[pnum]._pRSplType;
 			plr[pnum]._pSplFrom = 0;
 		} else
-			msg_errorf(fmt::format(_("%s has cast an illegal spell."), plr[pnum]._pName).c_str());
+			msg_errorf(fmt::format(_("{:s} has cast an illegal spell."), plr[pnum]._pName).c_str());
 	}
 
 	return sizeof(*p);
@@ -1708,7 +1708,7 @@ static DWORD On_TSPELLXY(TCmd *pCmd, int pnum)
 			plr[pnum]._pSplType = plr[pnum]._pTSplType;
 			plr[pnum]._pSplFrom = 2;
 		} else
-			msg_errorf(fmt::format(_("%s has cast an illegal spell."), plr[pnum]._pName).c_str());
+			msg_errorf(fmt::format(_("{:s} has cast an illegal spell."), plr[pnum]._pName).c_str());
 	}
 
 	return sizeof(*p);
@@ -1828,7 +1828,7 @@ static DWORD On_SPELLID(TCmd *pCmd, int pnum)
 			plr[pnum]._pSplType = plr[pnum]._pRSplType;
 			plr[pnum]._pSplFrom = 0;
 		} else
-			msg_errorf(fmt::format(_("%s has cast an illegal spell."), plr[pnum]._pName).c_str());
+			msg_errorf(fmt::format(_("{:s} has cast an illegal spell."), plr[pnum]._pName).c_str());
 	}
 
 	return sizeof(*p);
@@ -1849,7 +1849,7 @@ static DWORD On_SPELLPID(TCmd *pCmd, int pnum)
 			plr[pnum]._pSplType = plr[pnum]._pRSplType;
 			plr[pnum]._pSplFrom = 0;
 		} else
-			msg_errorf(fmt::format(_("%s has cast an illegal spell."), plr[pnum]._pName).c_str());
+			msg_errorf(fmt::format(_("{:s} has cast an illegal spell."), plr[pnum]._pName).c_str());
 	}
 
 	return sizeof(*p);
@@ -1870,7 +1870,7 @@ static DWORD On_TSPELLID(TCmd *pCmd, int pnum)
 			plr[pnum]._pSplType = plr[pnum]._pTSplType;
 			plr[pnum]._pSplFrom = 2;
 		} else
-			msg_errorf(fmt::format(_("%s has cast an illegal spell."), plr[pnum]._pName).c_str());
+			msg_errorf(fmt::format(_("{:s} has cast an illegal spell."), plr[pnum]._pName).c_str());
 	}
 
 	return sizeof(*p);
@@ -1891,7 +1891,7 @@ static DWORD On_TSPELLPID(TCmd *pCmd, int pnum)
 			plr[pnum]._pSplType = plr[pnum]._pTSplType;
 			plr[pnum]._pSplFrom = 2;
 		} else
-			msg_errorf(fmt::format(_("%s has cast an illegal spell."), plr[pnum]._pName).c_str());
+			msg_errorf(fmt::format(_("{:s} has cast an illegal spell."), plr[pnum]._pName).c_str());
 	}
 
 	return sizeof(*p);
@@ -2227,7 +2227,7 @@ static DWORD On_PLAYER_JOINLEVEL(TCmd *pCmd, int pnum)
 			InitPlrGFXMem(plr[pnum]);
 			plr[pnum].plractive = true;
 			gbActivePlayers++;
-			EventPlrMsg(fmt::format(_("Player '%s' (level %i) just joined the game"), plr[pnum]._pName, plr[pnum]._pLevel).c_str());
+			EventPlrMsg(fmt::format(_("Player '{:s}' (level {:d}) just joined the game"), plr[pnum]._pName, plr[pnum]._pLevel).c_str());
 		}
 
 		if (plr[pnum].plractive && myplr != pnum) {

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -261,14 +261,14 @@ static void multi_player_left_msg(int pnum, bool left)
 		delta_close_portal(pnum);
 		RemovePlrMissiles(pnum);
 		if (left) {
-			pszFmt = _("Player '%s' just left the game");
+			pszFmt = _("Player '{:s}' just left the game");
 			switch (sgdwPlayerLeftReasonTbl[pnum]) {
 			case LEAVE_ENDING:
-				pszFmt = _("Player '%s' killed Diablo and left the game!");
+				pszFmt = _("Player '{:s}' killed Diablo and left the game!");
 				gbSomebodyWonGameKludge = true;
 				break;
 			case LEAVE_DROP:
-				pszFmt = _("Player '%s' dropped due to timeout");
+				pszFmt = _("Player '{:s}' dropped due to timeout");
 				break;
 			}
 			EventPlrMsg(pszFmt, plr[pnum]._pName);
@@ -858,9 +858,9 @@ void recv_plrinfo(int pnum, TCmdPlrInfoHdr *p, bool recv)
 	gbActivePlayers++;
 
 	if (sgbPlayerTurnBitTbl[pnum]) {
-		szEvent = _("Player '%s' (level %i) just joined the game");
+		szEvent = _("Player '{:s}' (level {:d}) just joined the game");
 	} else {
-		szEvent = _("Player '%s' (level %i) is already in the game");
+		szEvent = _("Player '{:s}' (level {:d}) is already in the game");
 	}
 	EventPlrMsg(fmt::format(szEvent, plr[pnum]._pName, plr[pnum]._pLevel).c_str());
 

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -7,6 +7,8 @@
 #include <SDL.h>
 #include <config.h>
 
+#include <fmt/format.h>
+
 #include "DiabloUI/diabloui.h"
 #include "diablo.h"
 #include "dthread.h"
@@ -860,7 +862,7 @@ void recv_plrinfo(int pnum, TCmdPlrInfoHdr *p, bool recv)
 	} else {
 		szEvent = _("Player '%s' (level %i) is already in the game");
 	}
-	EventPlrMsg(szEvent, plr[pnum]._pName, plr[pnum]._pLevel);
+	EventPlrMsg(fmt::format(szEvent, plr[pnum]._pName, plr[pnum]._pLevel).c_str());
 
 	LoadPlrGFX(pnum, PFILE_STAND);
 	SyncInitPlr(pnum);

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5501,7 +5501,7 @@ void GetObjectStr(int i)
 		break;
 	case OBJ_SHRINEL:
 	case OBJ_SHRINER:
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: %s will be a name from the Shrine block above */ "%s Shrine"), _(shrinestrs[object[i]._oVar1])).c_str());
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: {:s} will be a name from the Shrine block above */ "{:s} Shrine"), _(shrinestrs[object[i]._oVar1])).c_str());
 		strcpy(infostr, tempstr);
 		break;
 	case OBJ_SKELBOOK:
@@ -5570,13 +5570,13 @@ void GetObjectStr(int i)
 	}
 	if (plr[myplr]._pClass == HeroClass::Rogue) {
 		if (object[i]._oTrapFlag) {
-			sprintf(tempstr, fmt::format(_(/* TRANSLATORS: %s will either be a chest or a door */ "Trapped %s"), infostr).c_str());
+			sprintf(tempstr, fmt::format(_(/* TRANSLATORS: {:s} will either be a chest or a door */ "Trapped {:s}"), infostr).c_str());
 			strcpy(infostr, tempstr);
 			infoclr = UIS_RED;
 		}
 	}
 	if (objectIsDisabled(i)) {
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver */ "%s (disabled)"), infostr).c_str());
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver */ "{:s} (disabled)"), infostr).c_str());
 		strcpy(infostr, tempstr);
 		infoclr = UIS_RED;
 	}

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -87,7 +87,7 @@ int bxadd[8] = { -1, 0, 1, -1, 1, -1, 0, 1 };
 int byadd[8] = { -1, -1, -1, 0, 0, 1, 1, 1 };
 /** Maps from shrine_id to shrine name. */
 const char *const shrinestrs[] = {
-	// TRANSLATORS: Shrine Name Block	
+	// TRANSLATORS: Shrine Name Block
 	N_("Mysterious"),
 	N_("Hidden"),
 	N_("Gloomy"),
@@ -252,22 +252,22 @@ shrine_gametype shrineavail[] = {
 };
 /** Maps from book_id to book name. */
 const char *const StoryBookName[] = {
-	N_( /* TRANSLATORS: Book Title */ "The Great Conflict"),
-	N_( /* TRANSLATORS: Book Title */ "The Wages of Sin are War"),
-	N_( /* TRANSLATORS: Book Title */ "The Tale of the Horadrim"),
-	N_( /* TRANSLATORS: Book Title */ "The Dark Exile"),
-	N_( /* TRANSLATORS: Book Title */ "The Sin War"),
-	N_( /* TRANSLATORS: Book Title */ "The Binding of the Three"),
-	N_( /* TRANSLATORS: Book Title */ "The Realms Beyond"),
-	N_( /* TRANSLATORS: Book Title */ "Tale of the Three"),
-	N_( /* TRANSLATORS: Book Title */ "The Black King"),
-	N_( /* TRANSLATORS: Book Title */ "Journal: The Ensorcellment"),
-	N_( /* TRANSLATORS: Book Title */ "Journal: The Meeting"),
-	N_( /* TRANSLATORS: Book Title */ "Journal: The Tirade"),
-	N_( /* TRANSLATORS: Book Title */ "Journal: His Power Grows"),
-	N_( /* TRANSLATORS: Book Title */ "Journal: NA-KRUL"),
-	N_( /* TRANSLATORS: Book Title */ "Journal: The End"),
-	N_( /* TRANSLATORS: Book Title */ "A Spellbook"),
+	N_(/* TRANSLATORS: Book Title */ "The Great Conflict"),
+	N_(/* TRANSLATORS: Book Title */ "The Wages of Sin are War"),
+	N_(/* TRANSLATORS: Book Title */ "The Tale of the Horadrim"),
+	N_(/* TRANSLATORS: Book Title */ "The Dark Exile"),
+	N_(/* TRANSLATORS: Book Title */ "The Sin War"),
+	N_(/* TRANSLATORS: Book Title */ "The Binding of the Three"),
+	N_(/* TRANSLATORS: Book Title */ "The Realms Beyond"),
+	N_(/* TRANSLATORS: Book Title */ "Tale of the Three"),
+	N_(/* TRANSLATORS: Book Title */ "The Black King"),
+	N_(/* TRANSLATORS: Book Title */ "Journal: The Ensorcellment"),
+	N_(/* TRANSLATORS: Book Title */ "Journal: The Meeting"),
+	N_(/* TRANSLATORS: Book Title */ "Journal: The Tirade"),
+	N_(/* TRANSLATORS: Book Title */ "Journal: His Power Grows"),
+	N_(/* TRANSLATORS: Book Title */ "Journal: NA-KRUL"),
+	N_(/* TRANSLATORS: Book Title */ "Journal: The End"),
+	N_(/* TRANSLATORS: Book Title */ "A Spellbook"),
 };
 /** Specifies the speech IDs of each dungeon type narrator book, for each player class. */
 _speech_id StoryText[3][3] = {
@@ -3006,7 +3006,7 @@ void OperateBookLever(int pnum, int i)
 			quests[Q_BLOOD]._qactive = QUEST_ACTIVE;
 			quests[Q_BLOOD]._qlog = true;
 			quests[Q_BLOOD]._qvar1 = 1;
-			SpawnQuestItem(IDI_BLDSTONE, {2 * setpc_x + 25, 2 * setpc_y + 33}, 0, true);
+			SpawnQuestItem(IDI_BLDSTONE, { 2 * setpc_x + 25, 2 * setpc_y + 33 }, 0, true);
 		}
 		object[i]._otype = object[i]._otype;
 		if (object[i]._otype == OBJ_STEELTOME && quests[Q_WARLORD]._qvar1 == 0) {
@@ -3303,13 +3303,13 @@ void OperatePedistal(int pnum, int i)
 		if (!deltaload)
 			PlaySfxLoc(LS_PUDDLE, object[i].position.x, object[i].position.y);
 		ObjChangeMap(setpc_x, setpc_y + 3, setpc_x + 2, setpc_y + 7);
-		SpawnQuestItem(IDI_BLDSTONE, {2 * setpc_x + 19, 2 * setpc_y + 26}, 0, true);
+		SpawnQuestItem(IDI_BLDSTONE, { 2 * setpc_x + 19, 2 * setpc_y + 26 }, 0, true);
 	}
 	if (object[i]._oVar6 == 2) {
 		if (!deltaload)
 			PlaySfxLoc(LS_PUDDLE, object[i].position.x, object[i].position.y);
 		ObjChangeMap(setpc_x + 6, setpc_y + 3, setpc_x + setpc_w, setpc_y + 7);
-		SpawnQuestItem(IDI_BLDSTONE, {2 * setpc_x + 31, 2 * setpc_y + 26}, 0, true);
+		SpawnQuestItem(IDI_BLDSTONE, { 2 * setpc_x + 31, 2 * setpc_y + 26 }, 0, true);
 	}
 	if (object[i]._oVar6 == 3) {
 		if (!deltaload)
@@ -3808,11 +3808,11 @@ bool OperateShrineDivine(int pnum, int x, int y)
 		return false;
 
 	if (currlevel < 4) {
-		CreateTypeItem({x, y}, false, ITYPE_MISC, IMISC_FULLMANA, false, true);
-		CreateTypeItem({x, y}, false, ITYPE_MISC, IMISC_FULLHEAL, false, true);
+		CreateTypeItem({ x, y }, false, ITYPE_MISC, IMISC_FULLMANA, false, true);
+		CreateTypeItem({ x, y }, false, ITYPE_MISC, IMISC_FULLHEAL, false, true);
 	} else {
-		CreateTypeItem({x, y}, false, ITYPE_MISC, IMISC_FULLREJUV, false, true);
-		CreateTypeItem({x, y}, false, ITYPE_MISC, IMISC_FULLREJUV, false, true);
+		CreateTypeItem({ x, y }, false, ITYPE_MISC, IMISC_FULLREJUV, false, true);
+		CreateTypeItem({ x, y }, false, ITYPE_MISC, IMISC_FULLREJUV, false, true);
 	}
 
 	plr[pnum]._pMana = plr[pnum]._pMaxMana;
@@ -5501,7 +5501,7 @@ void GetObjectStr(int i)
 		break;
 	case OBJ_SHRINEL:
 	case OBJ_SHRINER:
-		sprintf(tempstr, _( /* TRANSLATORS: %s will be a name from the Shrine block above */ "%s Shrine"), _(shrinestrs[object[i]._oVar1]));
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: %s will be a name from the Shrine block above */ "%s Shrine"), _(shrinestrs[object[i]._oVar1])).c_str());
 		strcpy(infostr, tempstr);
 		break;
 	case OBJ_SKELBOOK:
@@ -5570,13 +5570,13 @@ void GetObjectStr(int i)
 	}
 	if (plr[myplr]._pClass == HeroClass::Rogue) {
 		if (object[i]._oTrapFlag) {
-			sprintf(tempstr, _( /* TRANSLATORS: %s will either be a chest or a door */ "Trapped %s"), infostr);
+			sprintf(tempstr, fmt::format(_(/* TRANSLATORS: %s will either be a chest or a door */ "Trapped %s"), infostr).c_str());
 			strcpy(infostr, tempstr);
 			infoclr = UIS_RED;
 		}
 	}
 	if (objectIsDisabled(i)) {
-		sprintf(tempstr, _( /* TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver */ "%s (disabled)"), infostr);
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver */ "%s (disabled)"), infostr).c_str());
 		strcpy(infostr, tempstr);
 		infoclr = UIS_RED;
 	}

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5501,7 +5501,7 @@ void GetObjectStr(int i)
 		break;
 	case OBJ_SHRINEL:
 	case OBJ_SHRINER:
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: {:s} will be a name from the Shrine block above */ "{:s} Shrine"), _(shrinestrs[object[i]._oVar1])).c_str());
+		strcpy(tempstr, fmt::format(_(/* TRANSLATORS: {:s} will be a name from the Shrine block above */ "{:s} Shrine"), _(shrinestrs[object[i]._oVar1])).c_str());
 		strcpy(infostr, tempstr);
 		break;
 	case OBJ_SKELBOOK:
@@ -5570,13 +5570,13 @@ void GetObjectStr(int i)
 	}
 	if (plr[myplr]._pClass == HeroClass::Rogue) {
 		if (object[i]._oTrapFlag) {
-			sprintf(tempstr, fmt::format(_(/* TRANSLATORS: {:s} will either be a chest or a door */ "Trapped {:s}"), infostr).c_str());
+			strcpy(tempstr, fmt::format(_(/* TRANSLATORS: {:s} will either be a chest or a door */ "Trapped {:s}"), infostr).c_str());
 			strcpy(infostr, tempstr);
 			infoclr = UIS_RED;
 		}
 	}
 	if (objectIsDisabled(i)) {
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver */ "{:s} (disabled)"), infostr).c_str());
+		strcpy(tempstr, fmt::format(_(/* TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver */ "{:s} (disabled)"), infostr).c_str());
 		strcpy(infostr, tempstr);
 		infoclr = UIS_RED;
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1883,7 +1883,7 @@ StartPlayerKill(int pnum, int earflag)
 				if (earflag != -1) {
 					if (earflag != 0) {
 						SetPlrHandItem(&ear, IDI_EAR);
-						sprintf(ear._iName, fmt::format(_("Ear of {:s}"), player._pName).c_str());
+						strcpy(ear._iName, fmt::format(_("Ear of {:s}"), player._pName).c_str());
 						if (player._pClass == HeroClass::Sorcerer) {
 							ear._iCurs = ICURS_EAR_SORCERER;
 						} else if (player._pClass == HeroClass::Warrior) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -357,8 +357,7 @@ void PlayerStruct::Stop()
 
 bool PlayerStruct::IsWalking() const
 {
-	switch (_pmode)
-	{
+	switch (_pmode) {
 	case PM_WALK:
 	case PM_WALK2:
 	case PM_WALK3:
@@ -1884,7 +1883,7 @@ StartPlayerKill(int pnum, int earflag)
 				if (earflag != -1) {
 					if (earflag != 0) {
 						SetPlrHandItem(&ear, IDI_EAR);
-						sprintf(ear._iName, _("Ear of %s"), player._pName);
+						sprintf(ear._iName, fmt::format(_("Ear of %s"), player._pName).c_str());
 						if (player._pClass == HeroClass::Sorcerer) {
 							ear._iCurs = ICURS_EAR_SORCERER;
 						} else if (player._pClass == HeroClass::Warrior) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1883,7 +1883,7 @@ StartPlayerKill(int pnum, int earflag)
 				if (earflag != -1) {
 					if (earflag != 0) {
 						SetPlrHandItem(&ear, IDI_EAR);
-						sprintf(ear._iName, fmt::format(_("Ear of %s"), player._pName).c_str());
+						sprintf(ear._iName, fmt::format(_("Ear of {:s}"), player._pName).c_str());
 						if (player._pClass == HeroClass::Sorcerer) {
 							ear._iCurs = ICURS_EAR_SORCERER;
 						} else if (player._pClass == HeroClass::Warrior) {

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -5,6 +5,8 @@
  */
 #include "plrmsg.h"
 
+#include <fmt/format.h>
+
 #include "control.h"
 #include "engine/render/text_render.hpp"
 #include "inv.h"
@@ -70,7 +72,7 @@ void SendPlrMsg(int pnum, const char *pszStr)
 	pMsg->time = SDL_GetTicks();
 	assert(strlen(plr[pnum]._pName) < PLR_NAME_LEN);
 	assert(strlen(pszStr) < MAX_SEND_STR_LEN);
-	sprintf(pMsg->str, _(/* TRANSLATORS: Shown if player presses "v" button. %s is player name, %i is level, %s is location */ "%s (lvl %i): %s"), plr[pnum]._pName, plr[pnum]._pLevel, pszStr);
+	sprintf(pMsg->str, fmt::format(_(/* TRANSLATORS: Shown if player presses "v" button. %s is player name, %i is level, %s is location */ "%s (lvl %i): %s"), plr[pnum]._pName, plr[pnum]._pLevel, pszStr).c_str());
 }
 
 void ClearPlrMsg()

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -72,7 +72,7 @@ void SendPlrMsg(int pnum, const char *pszStr)
 	pMsg->time = SDL_GetTicks();
 	assert(strlen(plr[pnum]._pName) < PLR_NAME_LEN);
 	assert(strlen(pszStr) < MAX_SEND_STR_LEN);
-	sprintf(pMsg->str, fmt::format(_(/* TRANSLATORS: Shown if player presses "v" button. {:s} is player name, {:d} is level, {:s} is location */ "{:s} (lvl {:d}): {:s}"), plr[pnum]._pName, plr[pnum]._pLevel, pszStr).c_str());
+	strcpy(pMsg->str, fmt::format(_(/* TRANSLATORS: Shown if player presses "v" button. {:s} is player name, {:d} is level, {:s} is location */ "{:s} (lvl {:d}): {:s}"), plr[pnum]._pName, plr[pnum]._pLevel, pszStr).c_str());
 }
 
 void ClearPlrMsg()

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -72,7 +72,7 @@ void SendPlrMsg(int pnum, const char *pszStr)
 	pMsg->time = SDL_GetTicks();
 	assert(strlen(plr[pnum]._pName) < PLR_NAME_LEN);
 	assert(strlen(pszStr) < MAX_SEND_STR_LEN);
-	sprintf(pMsg->str, fmt::format(_(/* TRANSLATORS: Shown if player presses "v" button. %s is player name, %i is level, %s is location */ "%s (lvl %i): %s"), plr[pnum]._pName, plr[pnum]._pLevel, pszStr).c_str());
+	sprintf(pMsg->str, fmt::format(_(/* TRANSLATORS: Shown if player presses "v" button. {:s} is player name, {:d} is level, {:s} is location */ "{:s} (lvl {:d}): {:s}"), plr[pnum]._pName, plr[pnum]._pLevel, pszStr).c_str());
 }
 
 void ClearPlrMsg()

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -123,7 +123,7 @@ bool CheckXPBarInfo()
 
 	const int charLevel = player._pLevel;
 
-	sprintf(tempstr, fmt::format(_("Level %i"), charLevel).c_str());
+	sprintf(tempstr, fmt::format(_("Level {:d}"), charLevel).c_str());
 	AddPanelString(tempstr);
 
 	if (charLevel == MAXCHARLEVEL - 1) {
@@ -149,7 +149,7 @@ bool CheckXPBarInfo()
 	PrintWithSeparator(tempstr + SDL_arraysize("Next Level: ") - 1, ExpLvlsTbl[charLevel]);
 	AddPanelString(tempstr);
 
-	sprintf(PrintWithSeparator(tempstr, ExpLvlsTbl[charLevel] - player._pExperience), fmt::format(_(" to Level %i"), charLevel + 1).c_str());
+	sprintf(PrintWithSeparator(tempstr, ExpLvlsTbl[charLevel] - player._pExperience), fmt::format(_(" to Level {:d}"), charLevel + 1).c_str());
 	AddPanelString(tempstr);
 
 	return true;

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -4,13 +4,15 @@
 * Adds XP bar QoL feature
 */
 
+#include <array>
+
+#include <fmt/format.h>
+
 #include "DiabloUI/art_draw.h"
 #include "common.h"
 #include "control.h"
 #include "options.h"
 #include "utils/language.h"
-
-#include <array>
 
 namespace devilution {
 
@@ -121,7 +123,7 @@ bool CheckXPBarInfo()
 
 	const int charLevel = player._pLevel;
 
-	sprintf(tempstr, _("Level %i"), charLevel);
+	sprintf(tempstr, fmt::format(_("Level %i"), charLevel).c_str());
 	AddPanelString(tempstr);
 
 	if (charLevel == MAXCHARLEVEL - 1) {
@@ -147,7 +149,7 @@ bool CheckXPBarInfo()
 	PrintWithSeparator(tempstr + SDL_arraysize("Next Level: ") - 1, ExpLvlsTbl[charLevel]);
 	AddPanelString(tempstr);
 
-	sprintf(PrintWithSeparator(tempstr, ExpLvlsTbl[charLevel] - player._pExperience), _(" to Level %i"), charLevel + 1);
+	sprintf(PrintWithSeparator(tempstr, ExpLvlsTbl[charLevel] - player._pExperience), fmt::format(_(" to Level %i"), charLevel + 1).c_str());
 	AddPanelString(tempstr);
 
 	return true;

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -123,7 +123,7 @@ bool CheckXPBarInfo()
 
 	const int charLevel = player._pLevel;
 
-	sprintf(tempstr, fmt::format(_("Level {:d}"), charLevel).c_str());
+	strcpy(tempstr, fmt::format(_("Level {:d}"), charLevel).c_str());
 	AddPanelString(tempstr);
 
 	if (charLevel == MAXCHARLEVEL - 1) {
@@ -149,7 +149,7 @@ bool CheckXPBarInfo()
 	PrintWithSeparator(tempstr + SDL_arraysize("Next Level: ") - 1, ExpLvlsTbl[charLevel]);
 	AddPanelString(tempstr);
 
-	sprintf(PrintWithSeparator(tempstr, ExpLvlsTbl[charLevel] - player._pExperience), fmt::format(_(" to Level {:d}"), charLevel + 1).c_str());
+	strcpy(PrintWithSeparator(tempstr, ExpLvlsTbl[charLevel] - player._pExperience), fmt::format(_(" to Level {:d}"), charLevel + 1).c_str());
 	AddPanelString(tempstr);
 
 	return true;

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -281,7 +281,7 @@ bool ForceQuests()
 
 			for (j = 0; j < 7; j++) {
 				if (qx + questxoff[j] == cursmx && qy + questyoff[j] == cursmy) {
-					sprintf(infostr, fmt::format(_(/* TRANSLATORS: Used for Quest Portals. {:s} is a Map Name */ "To {:s}"), _(questtrigstr[ql])).c_str());
+					strcpy(infostr, fmt::format(_(/* TRANSLATORS: Used for Quest Portals. {:s} is a Map Name */ "To {:s}"), _(questtrigstr[ql])).c_str());
 					cursmx = qx;
 					cursmy = qy;
 					return true;

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -281,7 +281,7 @@ bool ForceQuests()
 
 			for (j = 0; j < 7; j++) {
 				if (qx + questxoff[j] == cursmx && qy + questyoff[j] == cursmy) {
-					sprintf(infostr, fmt::format(_(/* TRANSLATORS: Used for Quest Portals. %s is a Map Name */ "To %s"), _(questtrigstr[ql])).c_str());
+					sprintf(infostr, fmt::format(_(/* TRANSLATORS: Used for Quest Portals. {:s} is a Map Name */ "To {:s}"), _(questtrigstr[ql])).c_str());
 					cursmx = qx;
 					cursmy = qy;
 					return true;

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -4,6 +4,8 @@
  * Implementation of functionality for handling quests.
  */
 
+#include <fmt/format.h>
+
 #include "control.h"
 #include "cursor.h"
 #include "engine/render/cel_render.hpp"
@@ -75,11 +77,11 @@ char questxoff[7] = { 0, -1, 0, -1, -2, -1, -2 };
  */
 char questyoff[7] = { 0, 0, -1, -1, -1, -2, -2 };
 const char *const questtrigstr[5] = {
-	N_( /* TRANSLATORS: Quest Map*/ "King Leoric's Tomb"),
-	N_( /* TRANSLATORS: Quest Map*/ "The Chamber of Bone"),
-	N_( /* TRANSLATORS: Quest Map*/ "Maze"),
-	N_( /* TRANSLATORS: Quest Map*/ "A Dark Passage"),
-	N_( /* TRANSLATORS: Quest Map*/ "Unholy Altar")
+	N_(/* TRANSLATORS: Quest Map*/ "King Leoric's Tomb"),
+	N_(/* TRANSLATORS: Quest Map*/ "The Chamber of Bone"),
+	N_(/* TRANSLATORS: Quest Map*/ "Maze"),
+	N_(/* TRANSLATORS: Quest Map*/ "A Dark Passage"),
+	N_(/* TRANSLATORS: Quest Map*/ "Unholy Altar")
 };
 /**
  * A quest group containing the three quests the Butcher,
@@ -279,7 +281,7 @@ bool ForceQuests()
 
 			for (j = 0; j < 7; j++) {
 				if (qx + questxoff[j] == cursmx && qy + questyoff[j] == cursmy) {
-					sprintf(infostr, _( /* TRANSLATORS: Used for Quest Portals. %s is a Map Name */ "To %s"), _(questtrigstr[ql]));
+					sprintf(infostr, fmt::format(_(/* TRANSLATORS: Used for Quest Portals. %s is a Map Name */ "To %s"), _(questtrigstr[ql])).c_str());
 					cursmx = qx;
 					cursmy = qy;
 					return true;
@@ -675,7 +677,7 @@ void ResyncQuests()
 	}
 	if (currlevel == quests[Q_MUSHROOM]._qlevel) {
 		if (quests[Q_MUSHROOM]._qactive == QUEST_INIT && quests[Q_MUSHROOM]._qvar1 == QS_INIT) {
-			SpawnQuestItem(IDI_FUNGALTM, {0, 0}, 5, true);
+			SpawnQuestItem(IDI_FUNGALTM, { 0, 0 }, 5, true);
 			quests[Q_MUSHROOM]._qvar1 = QS_TOMESPAWNED;
 		} else {
 			if (quests[Q_MUSHROOM]._qactive == QUEST_ACTIVE) {
@@ -690,7 +692,7 @@ void ResyncQuests()
 	}
 	if (currlevel == quests[Q_VEIL]._qlevel + 1 && quests[Q_VEIL]._qactive == QUEST_ACTIVE && quests[Q_VEIL]._qvar1 == 0) {
 		quests[Q_VEIL]._qvar1 = 1;
-		SpawnQuestItem(IDI_GLDNELIX, {0, 0}, 5, true);
+		SpawnQuestItem(IDI_GLDNELIX, { 0, 0 }, 5, true);
 	}
 	if (setlevel && setlvlnum == SL_VILEBETRAYER) {
 		if (quests[Q_BETRAYER]._qvar1 >= 4)

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -7,6 +7,8 @@
 
 #include <algorithm>
 
+#include <fmt/format.h>
+
 #include "cursor.h"
 #include "engine/render/cel_render.hpp"
 #include "engine/render/text_render.hpp"
@@ -167,7 +169,7 @@ void PrintStoreItem(ItemStruct *x, int l, uint16_t flags)
 		}
 	}
 	if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges) {
-		sprintf(tempstr, _("Charges: %i/%i"), x->_iCharges, x->_iMaxCharges);
+		sprintf(tempstr, fmt::format(_("Charges: %i/%i"), x->_iCharges, x->_iMaxCharges).c_str());
 		if (sstr[0])
 			strcat(sstr, _(",  "));
 		strcat(sstr, tempstr);
@@ -178,11 +180,11 @@ void PrintStoreItem(ItemStruct *x, int l, uint16_t flags)
 	}
 	sstr[0] = '\0';
 	if (x->_iClass == ICLASS_WEAPON)
-		sprintf(sstr, _("Damage: %i-%i  "), x->_iMinDam, x->_iMaxDam);
+		sprintf(sstr, fmt::format(_("Damage: %i-%i  "), x->_iMinDam, x->_iMaxDam).c_str());
 	if (x->_iClass == ICLASS_ARMOR)
-		sprintf(sstr, _("Armor: %i  "), x->_iAC);
+		sprintf(sstr, fmt::format(_("Armor: %i  "), x->_iAC).c_str());
 	if (x->_iMaxDur != DUR_INDESTRUCTIBLE && x->_iMaxDur) {
-		sprintf(tempstr, _("Dur: %i/%i,  "), x->_iDurability, x->_iMaxDur);
+		sprintf(tempstr, fmt::format(_("Dur: %i/%i,  "), x->_iDurability, x->_iMaxDur).c_str());
 		strcat(sstr, tempstr);
 	} else {
 		strcat(sstr, _("Indestructible,  "));
@@ -197,11 +199,11 @@ void PrintStoreItem(ItemStruct *x, int l, uint16_t flags)
 	} else {
 		strcpy(tempstr, _("Required:"));
 		if (str)
-			sprintf(tempstr + strlen(tempstr), _(" %i Str"), str);
+			sprintf(tempstr + strlen(tempstr), fmt::format(_(" %i Str"), str).c_str());
 		if (mag)
-			sprintf(tempstr + strlen(tempstr), _(" %i Mag"), mag);
+			sprintf(tempstr + strlen(tempstr), fmt::format(_(" %i Mag"), mag).c_str());
 		if (dex)
-			sprintf(tempstr + strlen(tempstr), _(" %i Dex"), dex);
+			sprintf(tempstr + strlen(tempstr), fmt::format(_(" %i Dex"), dex).c_str());
 		strcat(sstr, tempstr);
 	}
 	AddSText(40, l++, sstr, flags, false);
@@ -272,7 +274,7 @@ void S_StartSBuy()
 	stextsize = true;
 	stextscrl = true;
 	stextsval = 0;
-	sprintf(tempstr, _( /* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: %i"), plr[myplr]._pGold);
+	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: %i"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -337,7 +339,7 @@ bool S_StartSPBuy()
 	stextscrl = true;
 	stextsval = 0;
 
-	sprintf(tempstr, _( /* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these premium items for sale:     Your gold: %i"), plr[myplr]._pGold);
+	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these premium items for sale:     Your gold: %i"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -465,7 +467,7 @@ void S_StartSSell()
 
 	if (!sellok) {
 		stextscrl = false;
-		sprintf(tempstr, _( /* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing I want.             Your gold: %i"), plr[myplr]._pGold);
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing I want.             Your gold: %i"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -475,7 +477,7 @@ void S_StartSSell()
 		stextscrl = true;
 		stextsval = 0;
 		stextsmax = plr[myplr]._pNumInv;
-		sprintf(tempstr, _( /* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Which item is for sale?             Your gold: %i"), plr[myplr]._pGold);
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Which item is for sale?             Your gold: %i"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -535,7 +537,7 @@ void S_StartSRepair()
 	}
 	if (!repairok) {
 		stextscrl = false;
-		sprintf(tempstr, _( /* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to repair.             Your gold: %i"), plr[myplr]._pGold);
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to repair.             Your gold: %i"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -547,7 +549,7 @@ void S_StartSRepair()
 	stextscrl = true;
 	stextsval = 0;
 	stextsmax = plr[myplr]._pNumInv;
-	sprintf(tempstr, _( /* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Repair which item?             Your gold: %i"), plr[myplr]._pGold);
+	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Repair which item?             Your gold: %i"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -621,7 +623,7 @@ void S_StartWBuy()
 	stextscrl = true;
 	stextsval = 0;
 	stextsmax = 20;
-	sprintf(tempstr, _( /* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: %i"), plr[myplr]._pGold);
+	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: %i"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -715,7 +717,7 @@ void S_StartWSell()
 
 	if (!sellok) {
 		stextscrl = false;
-		sprintf(tempstr, _( /* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing I want.             Your gold: %i"), plr[myplr]._pGold);
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing I want.             Your gold: %i"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -725,7 +727,7 @@ void S_StartWSell()
 		stextscrl = true;
 		stextsval = 0;
 		stextsmax = plr[myplr]._pNumInv;
-		sprintf(tempstr, _( /* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Which item is for sale?             Your gold: %i"), plr[myplr]._pGold);
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Which item is for sale?             Your gold: %i"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -791,7 +793,7 @@ void S_StartWRecharge()
 
 	if (!rechargeok) {
 		stextscrl = false;
-		sprintf(tempstr, _( /* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to recharge.             Your gold: %i"), plr[myplr]._pGold);
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to recharge.             Your gold: %i"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -801,7 +803,7 @@ void S_StartWRecharge()
 		stextscrl = true;
 		stextsval = 0;
 		stextsmax = plr[myplr]._pNumInv;
-		sprintf(tempstr, _( /* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Recharge which item?             Your gold: %i"), plr[myplr]._pGold);
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Recharge which item?             Your gold: %i"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -913,7 +915,7 @@ void S_StartBBoy()
 {
 	stextsize = true;
 	stextscrl = false;
-	sprintf(tempstr, _( /* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have this item for sale:             Your gold: %i"), plr[myplr]._pGold);
+	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have this item for sale:             Your gold: %i"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -987,7 +989,7 @@ void S_StartHBuy()
 	stextsize = true;
 	stextscrl = true;
 	stextsval = 0;
-	sprintf(tempstr, _( /* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: %i"), plr[myplr]._pGold);
+	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: %i"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -1088,7 +1090,7 @@ void S_StartSIdentify()
 
 	if (!idok) {
 		stextscrl = false;
-		sprintf(tempstr, _( /* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to identify.             Your gold: %i"), plr[myplr]._pGold);
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to identify.             Your gold: %i"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -1098,7 +1100,7 @@ void S_StartSIdentify()
 		stextscrl = true;
 		stextsval = 0;
 		stextsmax = plr[myplr]._pNumInv;
-		sprintf(tempstr, _( /* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Identify which item?             Your gold: %i"), plr[myplr]._pGold);
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Identify which item?             Your gold: %i"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -1127,11 +1129,11 @@ void S_StartTalk()
 
 	stextsize = false;
 	stextscrl = false;
-	sprintf(tempstr, _("Talk to %s"), talkname[talker]);
+	sprintf(tempstr, fmt::format(_("Talk to %s"), talkname[talker]).c_str());
 	AddSText(0, 2, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(5);
 	if (gbIsSpawn) {
-		sprintf(tempstr, _("Talking to %s"), talkname[talker]);
+		sprintf(tempstr, fmt::format(_("Talking to %s"), talkname[talker]).c_str());
 		AddSText(0, 10, tempstr, UIS_SILVER | UIS_CENTER, false);
 		AddSText(0, 12, _("is not available"), UIS_SILVER | UIS_CENTER, false);
 		AddSText(0, 14, _("in the shareware"), UIS_SILVER | UIS_CENTER, false);

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -169,7 +169,7 @@ void PrintStoreItem(ItemStruct *x, int l, uint16_t flags)
 		}
 	}
 	if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges) {
-		sprintf(tempstr, fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges).c_str());
+		strcpy(tempstr, fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges).c_str());
 		if (sstr[0])
 			strcat(sstr, _(",  "));
 		strcat(sstr, tempstr);
@@ -180,11 +180,11 @@ void PrintStoreItem(ItemStruct *x, int l, uint16_t flags)
 	}
 	sstr[0] = '\0';
 	if (x->_iClass == ICLASS_WEAPON)
-		sprintf(sstr, fmt::format(_("Damage: {:d}-{:d}  "), x->_iMinDam, x->_iMaxDam).c_str());
+		strcpy(sstr, fmt::format(_("Damage: {:d}-{:d}  "), x->_iMinDam, x->_iMaxDam).c_str());
 	if (x->_iClass == ICLASS_ARMOR)
-		sprintf(sstr, fmt::format(_("Armor: {:d}  "), x->_iAC).c_str());
+		strcpy(sstr, fmt::format(_("Armor: {:d}  "), x->_iAC).c_str());
 	if (x->_iMaxDur != DUR_INDESTRUCTIBLE && x->_iMaxDur) {
-		sprintf(tempstr, fmt::format(_("Dur: {:d}/{:d},  "), x->_iDurability, x->_iMaxDur).c_str());
+		strcpy(tempstr, fmt::format(_("Dur: {:d}/{:d},  "), x->_iDurability, x->_iMaxDur).c_str());
 		strcat(sstr, tempstr);
 	} else {
 		strcat(sstr, _("Indestructible,  "));
@@ -199,11 +199,11 @@ void PrintStoreItem(ItemStruct *x, int l, uint16_t flags)
 	} else {
 		strcpy(tempstr, _("Required:"));
 		if (str)
-			sprintf(tempstr + strlen(tempstr), fmt::format(_(" {:d} Str"), str).c_str());
+			strcpy(tempstr + strlen(tempstr), fmt::format(_(" {:d} Str"), str).c_str());
 		if (mag)
-			sprintf(tempstr + strlen(tempstr), fmt::format(_(" {:d} Mag"), mag).c_str());
+			strcpy(tempstr + strlen(tempstr), fmt::format(_(" {:d} Mag"), mag).c_str());
 		if (dex)
-			sprintf(tempstr + strlen(tempstr), fmt::format(_(" {:d} Dex"), dex).c_str());
+			strcpy(tempstr + strlen(tempstr), fmt::format(_(" {:d} Dex"), dex).c_str());
 		strcat(sstr, tempstr);
 	}
 	AddSText(40, l++, sstr, flags, false);
@@ -274,7 +274,7 @@ void S_StartSBuy()
 	stextsize = true;
 	stextscrl = true;
 	stextsval = 0;
-	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: {:d}"), plr[myplr]._pGold).c_str());
+	strcpy(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -339,7 +339,7 @@ bool S_StartSPBuy()
 	stextscrl = true;
 	stextsval = 0;
 
-	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these premium items for sale:     Your gold: {:d}"), plr[myplr]._pGold).c_str());
+	strcpy(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these premium items for sale:     Your gold: {:d}"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -467,7 +467,7 @@ void S_StartSSell()
 
 	if (!sellok) {
 		stextscrl = false;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing I want.             Your gold: {:d}"), plr[myplr]._pGold).c_str());
+		strcpy(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing I want.             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -477,7 +477,7 @@ void S_StartSSell()
 		stextscrl = true;
 		stextsval = 0;
 		stextsmax = plr[myplr]._pNumInv;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Which item is for sale?             Your gold: {:d}"), plr[myplr]._pGold).c_str());
+		strcpy(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Which item is for sale?             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -537,7 +537,7 @@ void S_StartSRepair()
 	}
 	if (!repairok) {
 		stextscrl = false;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to repair.             Your gold: {:d}"), plr[myplr]._pGold).c_str());
+		strcpy(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to repair.             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -549,7 +549,7 @@ void S_StartSRepair()
 	stextscrl = true;
 	stextsval = 0;
 	stextsmax = plr[myplr]._pNumInv;
-	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Repair which item?             Your gold: {:d}"), plr[myplr]._pGold).c_str());
+	strcpy(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Repair which item?             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -623,7 +623,7 @@ void S_StartWBuy()
 	stextscrl = true;
 	stextsval = 0;
 	stextsmax = 20;
-	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: {:d}"), plr[myplr]._pGold).c_str());
+	strcpy(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -717,7 +717,7 @@ void S_StartWSell()
 
 	if (!sellok) {
 		stextscrl = false;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing I want.             Your gold: {:d}"), plr[myplr]._pGold).c_str());
+		strcpy(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing I want.             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -727,7 +727,7 @@ void S_StartWSell()
 		stextscrl = true;
 		stextsval = 0;
 		stextsmax = plr[myplr]._pNumInv;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Which item is for sale?             Your gold: {:d}"), plr[myplr]._pGold).c_str());
+		strcpy(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Which item is for sale?             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -793,7 +793,7 @@ void S_StartWRecharge()
 
 	if (!rechargeok) {
 		stextscrl = false;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to recharge.             Your gold: {:d}"), plr[myplr]._pGold).c_str());
+		strcpy(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to recharge.             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -803,7 +803,7 @@ void S_StartWRecharge()
 		stextscrl = true;
 		stextsval = 0;
 		stextsmax = plr[myplr]._pNumInv;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Recharge which item?             Your gold: {:d}"), plr[myplr]._pGold).c_str());
+		strcpy(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Recharge which item?             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -915,7 +915,7 @@ void S_StartBBoy()
 {
 	stextsize = true;
 	stextscrl = false;
-	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have this item for sale:             Your gold: {:d}"), plr[myplr]._pGold).c_str());
+	strcpy(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have this item for sale:             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -989,7 +989,7 @@ void S_StartHBuy()
 	stextsize = true;
 	stextscrl = true;
 	stextsval = 0;
-	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: {:d}"), plr[myplr]._pGold).c_str());
+	strcpy(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -1090,7 +1090,7 @@ void S_StartSIdentify()
 
 	if (!idok) {
 		stextscrl = false;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to identify.             Your gold: {:d}"), plr[myplr]._pGold).c_str());
+		strcpy(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to identify.             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -1100,7 +1100,7 @@ void S_StartSIdentify()
 		stextscrl = true;
 		stextsval = 0;
 		stextsmax = plr[myplr]._pNumInv;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Identify which item?             Your gold: {:d}"), plr[myplr]._pGold).c_str());
+		strcpy(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Identify which item?             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -1129,11 +1129,11 @@ void S_StartTalk()
 
 	stextsize = false;
 	stextscrl = false;
-	sprintf(tempstr, fmt::format(_("Talk to {:s}"), talkname[talker]).c_str());
+	strcpy(tempstr, fmt::format(_("Talk to {:s}"), talkname[talker]).c_str());
 	AddSText(0, 2, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(5);
 	if (gbIsSpawn) {
-		sprintf(tempstr, fmt::format(_("Talking to {:s}"), talkname[talker]).c_str());
+		strcpy(tempstr, fmt::format(_("Talking to {:s}"), talkname[talker]).c_str());
 		AddSText(0, 10, tempstr, UIS_SILVER | UIS_CENTER, false);
 		AddSText(0, 12, _("is not available"), UIS_SILVER | UIS_CENTER, false);
 		AddSText(0, 14, _("in the shareware"), UIS_SILVER | UIS_CENTER, false);

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -169,7 +169,7 @@ void PrintStoreItem(ItemStruct *x, int l, uint16_t flags)
 		}
 	}
 	if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges) {
-		sprintf(tempstr, fmt::format(_("Charges: %i/%i"), x->_iCharges, x->_iMaxCharges).c_str());
+		sprintf(tempstr, fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges).c_str());
 		if (sstr[0])
 			strcat(sstr, _(",  "));
 		strcat(sstr, tempstr);
@@ -180,11 +180,11 @@ void PrintStoreItem(ItemStruct *x, int l, uint16_t flags)
 	}
 	sstr[0] = '\0';
 	if (x->_iClass == ICLASS_WEAPON)
-		sprintf(sstr, fmt::format(_("Damage: %i-%i  "), x->_iMinDam, x->_iMaxDam).c_str());
+		sprintf(sstr, fmt::format(_("Damage: {:d}-{:d}  "), x->_iMinDam, x->_iMaxDam).c_str());
 	if (x->_iClass == ICLASS_ARMOR)
-		sprintf(sstr, fmt::format(_("Armor: %i  "), x->_iAC).c_str());
+		sprintf(sstr, fmt::format(_("Armor: {:d}  "), x->_iAC).c_str());
 	if (x->_iMaxDur != DUR_INDESTRUCTIBLE && x->_iMaxDur) {
-		sprintf(tempstr, fmt::format(_("Dur: %i/%i,  "), x->_iDurability, x->_iMaxDur).c_str());
+		sprintf(tempstr, fmt::format(_("Dur: {:d}/{:d},  "), x->_iDurability, x->_iMaxDur).c_str());
 		strcat(sstr, tempstr);
 	} else {
 		strcat(sstr, _("Indestructible,  "));
@@ -199,11 +199,11 @@ void PrintStoreItem(ItemStruct *x, int l, uint16_t flags)
 	} else {
 		strcpy(tempstr, _("Required:"));
 		if (str)
-			sprintf(tempstr + strlen(tempstr), fmt::format(_(" %i Str"), str).c_str());
+			sprintf(tempstr + strlen(tempstr), fmt::format(_(" {:d} Str"), str).c_str());
 		if (mag)
-			sprintf(tempstr + strlen(tempstr), fmt::format(_(" %i Mag"), mag).c_str());
+			sprintf(tempstr + strlen(tempstr), fmt::format(_(" {:d} Mag"), mag).c_str());
 		if (dex)
-			sprintf(tempstr + strlen(tempstr), fmt::format(_(" %i Dex"), dex).c_str());
+			sprintf(tempstr + strlen(tempstr), fmt::format(_(" {:d} Dex"), dex).c_str());
 		strcat(sstr, tempstr);
 	}
 	AddSText(40, l++, sstr, flags, false);
@@ -274,7 +274,7 @@ void S_StartSBuy()
 	stextsize = true;
 	stextscrl = true;
 	stextsval = 0;
-	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: %i"), plr[myplr]._pGold).c_str());
+	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -339,7 +339,7 @@ bool S_StartSPBuy()
 	stextscrl = true;
 	stextsval = 0;
 
-	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these premium items for sale:     Your gold: %i"), plr[myplr]._pGold).c_str());
+	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these premium items for sale:     Your gold: {:d}"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -467,7 +467,7 @@ void S_StartSSell()
 
 	if (!sellok) {
 		stextscrl = false;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing I want.             Your gold: %i"), plr[myplr]._pGold).c_str());
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing I want.             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -477,7 +477,7 @@ void S_StartSSell()
 		stextscrl = true;
 		stextsval = 0;
 		stextsmax = plr[myplr]._pNumInv;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Which item is for sale?             Your gold: %i"), plr[myplr]._pGold).c_str());
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Which item is for sale?             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -537,7 +537,7 @@ void S_StartSRepair()
 	}
 	if (!repairok) {
 		stextscrl = false;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to repair.             Your gold: %i"), plr[myplr]._pGold).c_str());
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to repair.             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -549,7 +549,7 @@ void S_StartSRepair()
 	stextscrl = true;
 	stextsval = 0;
 	stextsmax = plr[myplr]._pNumInv;
-	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Repair which item?             Your gold: %i"), plr[myplr]._pGold).c_str());
+	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Repair which item?             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -623,7 +623,7 @@ void S_StartWBuy()
 	stextscrl = true;
 	stextsval = 0;
 	stextsmax = 20;
-	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: %i"), plr[myplr]._pGold).c_str());
+	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -717,7 +717,7 @@ void S_StartWSell()
 
 	if (!sellok) {
 		stextscrl = false;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing I want.             Your gold: %i"), plr[myplr]._pGold).c_str());
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing I want.             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -727,7 +727,7 @@ void S_StartWSell()
 		stextscrl = true;
 		stextsval = 0;
 		stextsmax = plr[myplr]._pNumInv;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Which item is for sale?             Your gold: %i"), plr[myplr]._pGold).c_str());
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Which item is for sale?             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -793,7 +793,7 @@ void S_StartWRecharge()
 
 	if (!rechargeok) {
 		stextscrl = false;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to recharge.             Your gold: %i"), plr[myplr]._pGold).c_str());
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to recharge.             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -803,7 +803,7 @@ void S_StartWRecharge()
 		stextscrl = true;
 		stextsval = 0;
 		stextsmax = plr[myplr]._pNumInv;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Recharge which item?             Your gold: %i"), plr[myplr]._pGold).c_str());
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Recharge which item?             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -915,7 +915,7 @@ void S_StartBBoy()
 {
 	stextsize = true;
 	stextscrl = false;
-	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have this item for sale:             Your gold: %i"), plr[myplr]._pGold).c_str());
+	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have this item for sale:             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -989,7 +989,7 @@ void S_StartHBuy()
 	stextsize = true;
 	stextscrl = true;
 	stextsval = 0;
-	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: %i"), plr[myplr]._pGold).c_str());
+	sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "I have these items for sale:             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
@@ -1090,7 +1090,7 @@ void S_StartSIdentify()
 
 	if (!idok) {
 		stextscrl = false;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to identify.             Your gold: %i"), plr[myplr]._pGold).c_str());
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "You have nothing to identify.             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -1100,7 +1100,7 @@ void S_StartSIdentify()
 		stextscrl = true;
 		stextsval = 0;
 		stextsmax = plr[myplr]._pNumInv;
-		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Identify which item?             Your gold: %i"), plr[myplr]._pGold).c_str());
+		sprintf(tempstr, fmt::format(_(/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */ "Identify which item?             Your gold: {:d}"), plr[myplr]._pGold).c_str());
 		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
@@ -1129,11 +1129,11 @@ void S_StartTalk()
 
 	stextsize = false;
 	stextscrl = false;
-	sprintf(tempstr, fmt::format(_("Talk to %s"), talkname[talker]).c_str());
+	sprintf(tempstr, fmt::format(_("Talk to {:s}"), talkname[talker]).c_str());
 	AddSText(0, 2, tempstr, UIS_GOLD | UIS_CENTER, false);
 	AddSLine(5);
 	if (gbIsSpawn) {
-		sprintf(tempstr, fmt::format(_("Talking to %s"), talkname[talker]).c_str());
+		sprintf(tempstr, fmt::format(_("Talking to {:s}"), talkname[talker]).c_str());
 		AddSText(0, 10, tempstr, UIS_SILVER | UIS_CENTER, false);
 		AddSText(0, 12, _("is not available"), UIS_SILVER | UIS_CENTER, false);
 		AddSText(0, 14, _("in the shareware"), UIS_SILVER | UIS_CENTER, false);

--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -396,7 +396,7 @@ bool ForceL1Trig()
 		for (i = 0; L1UpList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L1UpList[i]) {
 				if (currlevel > 1)
-					sprintf(infostr, fmt::format(_("Up to level %i"), currlevel - 1).c_str());
+					sprintf(infostr, fmt::format(_("Up to level {:d}"), currlevel - 1).c_str());
 				else
 					strcpy(infostr, _("Up to town"));
 				for (j = 0; j < numtrigs; j++) {
@@ -410,7 +410,7 @@ bool ForceL1Trig()
 		}
 		for (i = 0; L1DownList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L1DownList[i]) {
-				sprintf(infostr, fmt::format(_("Down to level %i"), currlevel + 1).c_str());
+				sprintf(infostr, fmt::format(_("Down to level {:d}"), currlevel + 1).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -423,7 +423,7 @@ bool ForceL1Trig()
 	} else {
 		for (i = 0; L5UpList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L5UpList[i]) {
-				sprintf(infostr, fmt::format(_("Up to Crypt level %i"), currlevel - 21).c_str());
+				sprintf(infostr, fmt::format(_("Up to Crypt level {:d}"), currlevel - 21).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 						cursmx = trigs[j].position.x;
@@ -439,7 +439,7 @@ bool ForceL1Trig()
 		}
 		for (i = 0; L5DownList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L5DownList[i]) {
-				sprintf(infostr, fmt::format(_("Down to Crypt level %i"), currlevel - 19).c_str());
+				sprintf(infostr, fmt::format(_("Down to Crypt level {:d}"), currlevel - 19).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -483,7 +483,7 @@ bool ForceL2Trig()
 					dx = abs(trigs[j].position.x - cursmx);
 					dy = abs(trigs[j].position.y - cursmy);
 					if (dx < 4 && dy < 4) {
-						sprintf(infostr, fmt::format(_("Up to level %i"), currlevel - 1).c_str());
+						sprintf(infostr, fmt::format(_("Up to level {:d}"), currlevel - 1).c_str());
 						cursmx = trigs[j].position.x;
 						cursmy = trigs[j].position.y;
 						return true;
@@ -495,7 +495,7 @@ bool ForceL2Trig()
 
 	for (i = 0; L2DownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L2DownList[i]) {
-			sprintf(infostr, fmt::format(_("Down to level %i"), currlevel + 1).c_str());
+			sprintf(infostr, fmt::format(_("Down to level {:d}"), currlevel + 1).c_str());
 			for (j = 0; j < numtrigs; j++) {
 				if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 					cursmx = trigs[j].position.x;
@@ -535,7 +535,7 @@ bool ForceL3Trig()
 	if (currlevel < 17) {
 		for (i = 0; L3UpList[i] != -1; ++i) {
 			if (dPiece[cursmx][cursmy] == L3UpList[i]) {
-				sprintf(infostr, fmt::format(_("Up to level %i"), currlevel - 1).c_str());
+				sprintf(infostr, fmt::format(_("Up to level {:d}"), currlevel - 1).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 						cursmx = trigs[j].position.x;
@@ -549,7 +549,7 @@ bool ForceL3Trig()
 			if (dPiece[cursmx][cursmy] == L3DownList[i]
 			    || dPiece[cursmx + 1][cursmy] == L3DownList[i]
 			    || dPiece[cursmx + 2][cursmy] == L3DownList[i]) {
-				sprintf(infostr, fmt::format(_("Down to level %i"), currlevel + 1).c_str());
+				sprintf(infostr, fmt::format(_("Down to level {:d}"), currlevel + 1).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -562,7 +562,7 @@ bool ForceL3Trig()
 	} else {
 		for (i = 0; L6UpList[i] != -1; ++i) {
 			if (dPiece[cursmx][cursmy] == L6UpList[i]) {
-				sprintf(infostr, fmt::format(_("Up to Nest level %i"), currlevel - 17).c_str());
+				sprintf(infostr, fmt::format(_("Up to Nest level {:d}"), currlevel - 17).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 						cursmx = trigs[j].position.x;
@@ -576,7 +576,7 @@ bool ForceL3Trig()
 			if (dPiece[cursmx][cursmy] == L6DownList[i]
 			    || dPiece[cursmx + 1][cursmy] == L6DownList[i]
 			    || dPiece[cursmx + 2][cursmy] == L6DownList[i]) {
-				sprintf(infostr, fmt::format(_("Down to level %i"), currlevel - 15).c_str());
+				sprintf(infostr, fmt::format(_("Down to level {:d}"), currlevel - 15).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -634,7 +634,7 @@ bool ForceL4Trig()
 
 	for (i = 0; L4UpList[i] != -1; ++i) {
 		if (dPiece[cursmx][cursmy] == L4UpList[i]) {
-			sprintf(infostr, fmt::format(_("Up to level %i"), currlevel - 1).c_str());
+			sprintf(infostr, fmt::format(_("Up to level {:d}"), currlevel - 1).c_str());
 			for (j = 0; j < numtrigs; j++) {
 				if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 					cursmx = trigs[j].position.x;
@@ -647,7 +647,7 @@ bool ForceL4Trig()
 
 	for (i = 0; L4DownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L4DownList[i]) {
-			sprintf(infostr, fmt::format(_("Down to level %i"), currlevel + 1).c_str());
+			sprintf(infostr, fmt::format(_("Down to level {:d}"), currlevel + 1).c_str());
 			for (j = 0; j < numtrigs; j++) {
 				if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 					cursmx = trigs[j].position.x;
@@ -717,7 +717,7 @@ bool ForceSKingTrig()
 
 	for (i = 0; L1UpList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L1UpList[i]) {
-			sprintf(infostr, fmt::format(_("Back to Level %i"), quests[Q_SKELKING]._qlevel).c_str());
+			sprintf(infostr, fmt::format(_("Back to Level {:d}"), quests[Q_SKELKING]._qlevel).c_str());
 			cursmx = trigs[0].position.x;
 			cursmy = trigs[0].position.y;
 
@@ -734,7 +734,7 @@ bool ForceSChambTrig()
 
 	for (i = 0; L2DownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L2DownList[i]) {
-			sprintf(infostr, fmt::format(_("Back to Level %i"), quests[Q_SCHAMB]._qlevel).c_str());
+			sprintf(infostr, fmt::format(_("Back to Level {:d}"), quests[Q_SCHAMB]._qlevel).c_str());
 			cursmx = trigs[0].position.x;
 			cursmy = trigs[0].position.y;
 
@@ -751,7 +751,7 @@ bool ForcePWaterTrig()
 
 	for (i = 0; L3DownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L3DownList[i]) {
-			sprintf(infostr, fmt::format(_("Back to Level %i"), quests[Q_PWATER]._qlevel).c_str());
+			sprintf(infostr, fmt::format(_("Back to Level {:d}"), quests[Q_PWATER]._qlevel).c_str());
 			cursmx = trigs[0].position.x;
 			cursmy = trigs[0].position.y;
 

--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -5,6 +5,8 @@
  */
 #include "trigs.h"
 
+#include <fmt/format.h>
+
 #include "control.h"
 #include "cursor.h"
 #include "error.h"
@@ -394,7 +396,7 @@ bool ForceL1Trig()
 		for (i = 0; L1UpList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L1UpList[i]) {
 				if (currlevel > 1)
-					sprintf(infostr, _("Up to level %i"), currlevel - 1);
+					sprintf(infostr, fmt::format(_("Up to level %i"), currlevel - 1).c_str());
 				else
 					strcpy(infostr, _("Up to town"));
 				for (j = 0; j < numtrigs; j++) {
@@ -408,7 +410,7 @@ bool ForceL1Trig()
 		}
 		for (i = 0; L1DownList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L1DownList[i]) {
-				sprintf(infostr, _("Down to level %i"), currlevel + 1);
+				sprintf(infostr, fmt::format(_("Down to level %i"), currlevel + 1).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -421,7 +423,7 @@ bool ForceL1Trig()
 	} else {
 		for (i = 0; L5UpList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L5UpList[i]) {
-				sprintf(infostr, _("Up to Crypt level %i"), currlevel - 21);
+				sprintf(infostr, fmt::format(_("Up to Crypt level %i"), currlevel - 21).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 						cursmx = trigs[j].position.x;
@@ -437,7 +439,7 @@ bool ForceL1Trig()
 		}
 		for (i = 0; L5DownList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L5DownList[i]) {
-				sprintf(infostr, _("Down to Crypt level %i"), currlevel - 19);
+				sprintf(infostr, fmt::format(_("Down to Crypt level %i"), currlevel - 19).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -481,7 +483,7 @@ bool ForceL2Trig()
 					dx = abs(trigs[j].position.x - cursmx);
 					dy = abs(trigs[j].position.y - cursmy);
 					if (dx < 4 && dy < 4) {
-						sprintf(infostr, _("Up to level %i"), currlevel - 1);
+						sprintf(infostr, fmt::format(_("Up to level %i"), currlevel - 1).c_str());
 						cursmx = trigs[j].position.x;
 						cursmy = trigs[j].position.y;
 						return true;
@@ -493,7 +495,7 @@ bool ForceL2Trig()
 
 	for (i = 0; L2DownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L2DownList[i]) {
-			sprintf(infostr, _("Down to level %i"), currlevel + 1);
+			sprintf(infostr, fmt::format(_("Down to level %i"), currlevel + 1).c_str());
 			for (j = 0; j < numtrigs; j++) {
 				if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 					cursmx = trigs[j].position.x;
@@ -533,7 +535,7 @@ bool ForceL3Trig()
 	if (currlevel < 17) {
 		for (i = 0; L3UpList[i] != -1; ++i) {
 			if (dPiece[cursmx][cursmy] == L3UpList[i]) {
-				sprintf(infostr, _("Up to level %i"), currlevel - 1);
+				sprintf(infostr, fmt::format(_("Up to level %i"), currlevel - 1).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 						cursmx = trigs[j].position.x;
@@ -547,7 +549,7 @@ bool ForceL3Trig()
 			if (dPiece[cursmx][cursmy] == L3DownList[i]
 			    || dPiece[cursmx + 1][cursmy] == L3DownList[i]
 			    || dPiece[cursmx + 2][cursmy] == L3DownList[i]) {
-				sprintf(infostr, _("Down to level %i"), currlevel + 1);
+				sprintf(infostr, fmt::format(_("Down to level %i"), currlevel + 1).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -560,7 +562,7 @@ bool ForceL3Trig()
 	} else {
 		for (i = 0; L6UpList[i] != -1; ++i) {
 			if (dPiece[cursmx][cursmy] == L6UpList[i]) {
-				sprintf(infostr, _("Up to Nest level %i"), currlevel - 17);
+				sprintf(infostr, fmt::format(_("Up to Nest level %i"), currlevel - 17).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 						cursmx = trigs[j].position.x;
@@ -574,7 +576,7 @@ bool ForceL3Trig()
 			if (dPiece[cursmx][cursmy] == L6DownList[i]
 			    || dPiece[cursmx + 1][cursmy] == L6DownList[i]
 			    || dPiece[cursmx + 2][cursmy] == L6DownList[i]) {
-				sprintf(infostr, _("Down to level %i"), currlevel - 15);
+				sprintf(infostr, fmt::format(_("Down to level %i"), currlevel - 15).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -632,7 +634,7 @@ bool ForceL4Trig()
 
 	for (i = 0; L4UpList[i] != -1; ++i) {
 		if (dPiece[cursmx][cursmy] == L4UpList[i]) {
-			sprintf(infostr, _("Up to level %i"), currlevel - 1);
+			sprintf(infostr, fmt::format(_("Up to level %i"), currlevel - 1).c_str());
 			for (j = 0; j < numtrigs; j++) {
 				if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 					cursmx = trigs[j].position.x;
@@ -645,7 +647,7 @@ bool ForceL4Trig()
 
 	for (i = 0; L4DownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L4DownList[i]) {
-			sprintf(infostr, _("Down to level %i"), currlevel + 1);
+			sprintf(infostr, fmt::format(_("Down to level %i"), currlevel + 1).c_str());
 			for (j = 0; j < numtrigs; j++) {
 				if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 					cursmx = trigs[j].position.x;
@@ -715,7 +717,7 @@ bool ForceSKingTrig()
 
 	for (i = 0; L1UpList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L1UpList[i]) {
-			sprintf(infostr, _("Back to Level %i"), quests[Q_SKELKING]._qlevel);
+			sprintf(infostr, fmt::format(_("Back to Level %i"), quests[Q_SKELKING]._qlevel).c_str());
 			cursmx = trigs[0].position.x;
 			cursmy = trigs[0].position.y;
 
@@ -732,7 +734,7 @@ bool ForceSChambTrig()
 
 	for (i = 0; L2DownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L2DownList[i]) {
-			sprintf(infostr, _("Back to Level %i"), quests[Q_SCHAMB]._qlevel);
+			sprintf(infostr, fmt::format(_("Back to Level %i"), quests[Q_SCHAMB]._qlevel).c_str());
 			cursmx = trigs[0].position.x;
 			cursmy = trigs[0].position.y;
 
@@ -749,7 +751,7 @@ bool ForcePWaterTrig()
 
 	for (i = 0; L3DownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L3DownList[i]) {
-			sprintf(infostr, _("Back to Level %i"), quests[Q_PWATER]._qlevel);
+			sprintf(infostr, fmt::format(_("Back to Level %i"), quests[Q_PWATER]._qlevel).c_str());
 			cursmx = trigs[0].position.x;
 			cursmy = trigs[0].position.y;
 

--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -396,7 +396,7 @@ bool ForceL1Trig()
 		for (i = 0; L1UpList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L1UpList[i]) {
 				if (currlevel > 1)
-					sprintf(infostr, fmt::format(_("Up to level {:d}"), currlevel - 1).c_str());
+					strcpy(infostr, fmt::format(_("Up to level {:d}"), currlevel - 1).c_str());
 				else
 					strcpy(infostr, _("Up to town"));
 				for (j = 0; j < numtrigs; j++) {
@@ -410,7 +410,7 @@ bool ForceL1Trig()
 		}
 		for (i = 0; L1DownList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L1DownList[i]) {
-				sprintf(infostr, fmt::format(_("Down to level {:d}"), currlevel + 1).c_str());
+				strcpy(infostr, fmt::format(_("Down to level {:d}"), currlevel + 1).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -423,7 +423,7 @@ bool ForceL1Trig()
 	} else {
 		for (i = 0; L5UpList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L5UpList[i]) {
-				sprintf(infostr, fmt::format(_("Up to Crypt level {:d}"), currlevel - 21).c_str());
+				strcpy(infostr, fmt::format(_("Up to Crypt level {:d}"), currlevel - 21).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 						cursmx = trigs[j].position.x;
@@ -439,7 +439,7 @@ bool ForceL1Trig()
 		}
 		for (i = 0; L5DownList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L5DownList[i]) {
-				sprintf(infostr, fmt::format(_("Down to Crypt level {:d}"), currlevel - 19).c_str());
+				strcpy(infostr, fmt::format(_("Down to Crypt level {:d}"), currlevel - 19).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -483,7 +483,7 @@ bool ForceL2Trig()
 					dx = abs(trigs[j].position.x - cursmx);
 					dy = abs(trigs[j].position.y - cursmy);
 					if (dx < 4 && dy < 4) {
-						sprintf(infostr, fmt::format(_("Up to level {:d}"), currlevel - 1).c_str());
+						strcpy(infostr, fmt::format(_("Up to level {:d}"), currlevel - 1).c_str());
 						cursmx = trigs[j].position.x;
 						cursmy = trigs[j].position.y;
 						return true;
@@ -495,7 +495,7 @@ bool ForceL2Trig()
 
 	for (i = 0; L2DownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L2DownList[i]) {
-			sprintf(infostr, fmt::format(_("Down to level {:d}"), currlevel + 1).c_str());
+			strcpy(infostr, fmt::format(_("Down to level {:d}"), currlevel + 1).c_str());
 			for (j = 0; j < numtrigs; j++) {
 				if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 					cursmx = trigs[j].position.x;
@@ -535,7 +535,7 @@ bool ForceL3Trig()
 	if (currlevel < 17) {
 		for (i = 0; L3UpList[i] != -1; ++i) {
 			if (dPiece[cursmx][cursmy] == L3UpList[i]) {
-				sprintf(infostr, fmt::format(_("Up to level {:d}"), currlevel - 1).c_str());
+				strcpy(infostr, fmt::format(_("Up to level {:d}"), currlevel - 1).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 						cursmx = trigs[j].position.x;
@@ -549,7 +549,7 @@ bool ForceL3Trig()
 			if (dPiece[cursmx][cursmy] == L3DownList[i]
 			    || dPiece[cursmx + 1][cursmy] == L3DownList[i]
 			    || dPiece[cursmx + 2][cursmy] == L3DownList[i]) {
-				sprintf(infostr, fmt::format(_("Down to level {:d}"), currlevel + 1).c_str());
+				strcpy(infostr, fmt::format(_("Down to level {:d}"), currlevel + 1).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -562,7 +562,7 @@ bool ForceL3Trig()
 	} else {
 		for (i = 0; L6UpList[i] != -1; ++i) {
 			if (dPiece[cursmx][cursmy] == L6UpList[i]) {
-				sprintf(infostr, fmt::format(_("Up to Nest level {:d}"), currlevel - 17).c_str());
+				strcpy(infostr, fmt::format(_("Up to Nest level {:d}"), currlevel - 17).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 						cursmx = trigs[j].position.x;
@@ -576,7 +576,7 @@ bool ForceL3Trig()
 			if (dPiece[cursmx][cursmy] == L6DownList[i]
 			    || dPiece[cursmx + 1][cursmy] == L6DownList[i]
 			    || dPiece[cursmx + 2][cursmy] == L6DownList[i]) {
-				sprintf(infostr, fmt::format(_("Down to level {:d}"), currlevel - 15).c_str());
+				strcpy(infostr, fmt::format(_("Down to level {:d}"), currlevel - 15).c_str());
 				for (j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -634,7 +634,7 @@ bool ForceL4Trig()
 
 	for (i = 0; L4UpList[i] != -1; ++i) {
 		if (dPiece[cursmx][cursmy] == L4UpList[i]) {
-			sprintf(infostr, fmt::format(_("Up to level {:d}"), currlevel - 1).c_str());
+			strcpy(infostr, fmt::format(_("Up to level {:d}"), currlevel - 1).c_str());
 			for (j = 0; j < numtrigs; j++) {
 				if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 					cursmx = trigs[j].position.x;
@@ -647,7 +647,7 @@ bool ForceL4Trig()
 
 	for (i = 0; L4DownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L4DownList[i]) {
-			sprintf(infostr, fmt::format(_("Down to level {:d}"), currlevel + 1).c_str());
+			strcpy(infostr, fmt::format(_("Down to level {:d}"), currlevel + 1).c_str());
 			for (j = 0; j < numtrigs; j++) {
 				if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 					cursmx = trigs[j].position.x;
@@ -717,7 +717,7 @@ bool ForceSKingTrig()
 
 	for (i = 0; L1UpList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L1UpList[i]) {
-			sprintf(infostr, fmt::format(_("Back to Level {:d}"), quests[Q_SKELKING]._qlevel).c_str());
+			strcpy(infostr, fmt::format(_("Back to Level {:d}"), quests[Q_SKELKING]._qlevel).c_str());
 			cursmx = trigs[0].position.x;
 			cursmy = trigs[0].position.y;
 
@@ -734,7 +734,7 @@ bool ForceSChambTrig()
 
 	for (i = 0; L2DownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L2DownList[i]) {
-			sprintf(infostr, fmt::format(_("Back to Level {:d}"), quests[Q_SCHAMB]._qlevel).c_str());
+			strcpy(infostr, fmt::format(_("Back to Level {:d}"), quests[Q_SCHAMB]._qlevel).c_str());
 			cursmx = trigs[0].position.x;
 			cursmy = trigs[0].position.y;
 
@@ -751,7 +751,7 @@ bool ForcePWaterTrig()
 
 	for (i = 0; L3DownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L3DownList[i]) {
-			sprintf(infostr, fmt::format(_("Back to Level {:d}"), quests[Q_PWATER]._qlevel).c_str());
+			strcpy(infostr, fmt::format(_("Back to Level {:d}"), quests[Q_PWATER]._qlevel).c_str());
 			cursmx = trigs[0].position.x;
 			cursmy = trigs[0].position.y;
 

--- a/Translations/da.po
+++ b/Translations/da.po
@@ -817,7 +817,7 @@ msgstr ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "Problemet opstod ved indlæsning af:\n"
-"% s"
+"%s"
 
 #: Source/appfat.cpp:159
 #, fuzzy, c-format

--- a/Translations/da.po
+++ b/Translations/da.po
@@ -437,7 +437,6 @@ msgid "Play by yourself with no network exposure."
 msgstr "Spil alene uden nogen netværkseksponering."
 
 #: Source/DiabloUI/selconn.cpp:115
-#, c-format
 msgid "Players Supported: {:d}"
 msgstr "Understøttede spillere: {:d}"
 
@@ -617,7 +616,6 @@ msgid "The host is running a different game than you."
 msgstr ""
 
 #: Source/DiabloUI/selgame.cpp:415
-#, c-format
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr ""
 
@@ -705,7 +703,6 @@ msgstr ""
 "reserverede ord.\n"
 
 #: Source/DiabloUI/selhero.cpp:345
-#, c-format
 msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
 msgstr "Karakteren findes allerede. Vil du overskrive \"{:s}\"?"
 
@@ -778,7 +775,6 @@ msgid "Error"
 msgstr "Fejl"
 
 #: Source/appfat.cpp:117
-#, c-format
 msgid ""
 "{:s}\n"
 "\n"
@@ -837,7 +833,6 @@ msgstr ""
 "Sørg for, at den findes i spilmappen, og at filnavnet er med små bogstaver."
 
 #: Source/appfat.cpp:174
-#, c-format
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -918,22 +913,18 @@ msgid ",  "
 msgstr ""
 
 #: Source/stores.cpp:169
-#, c-format
 msgid "Charges: {:d}/{:d}"
 msgstr ""
 
 #: Source/stores.cpp:180
-#, c-format
 msgid "Damage: {:d}-{:d}  "
 msgstr ""
 
 #: Source/stores.cpp:182
-#, c-format
 msgid "Armor: {:d}  "
 msgstr ""
 
 #: Source/stores.cpp:184
-#, c-format
 msgid "Dur: {:d}/{:d},  "
 msgstr ""
 
@@ -952,17 +943,14 @@ msgid "Required:"
 msgstr "Krav:"
 
 #: Source/stores.cpp:199
-#, c-format
 msgid " {:d} Str"
 msgstr ""
 
 #: Source/stores.cpp:201
-#, c-format
 msgid " {:d} Mag"
 msgstr ""
 
 #: Source/stores.cpp:203
-#, c-format
 msgid " {:d} Dex"
 msgstr ""
 
@@ -1015,7 +1003,6 @@ msgid "Leave the shop"
 msgstr "Forlad healers hjem"
 
 #: Source/stores.cpp:274 Source/stores.cpp:623 Source/stores.cpp:989
-#, c-format
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr ""
 
@@ -1029,27 +1016,22 @@ msgid "Back"
 msgstr ""
 
 #: Source/stores.cpp:339
-#, c-format
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:467 Source/stores.cpp:717
-#, c-format
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:477 Source/stores.cpp:727
-#, c-format
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:537
-#, c-format
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:549
-#, c-format
 msgid "Repair which item?             Your gold: {:d}"
 msgstr ""
 
@@ -1076,12 +1058,10 @@ msgid "Leave the shack"
 msgstr ""
 
 #: Source/stores.cpp:793
-#, c-format
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:803
-#, c-format
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr ""
 
@@ -1159,7 +1139,6 @@ msgid "Say goodbye"
 msgstr ""
 
 #: Source/stores.cpp:915
-#, c-format
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr ""
 
@@ -1194,12 +1173,10 @@ msgid "Identify an item"
 msgstr ""
 
 #: Source/stores.cpp:1090
-#, c-format
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:1100
-#, c-format
 msgid "Identify which item?             Your gold: {:d}"
 msgstr ""
 

--- a/Translations/da.po
+++ b/Translations/da.po
@@ -438,8 +438,8 @@ msgstr "Spil alene uden nogen netværkseksponering."
 
 #: Source/DiabloUI/selconn.cpp:115
 #, c-format
-msgid "Players Supported: %d"
-msgstr "Understøttede spillere: %d"
+msgid "Players Supported: {:d}"
+msgstr "Understøttede spillere: {:d}"
 
 #: Source/DiabloUI/selgame.cpp:85 Source/DiabloUI/selgame.cpp:380
 msgid "Description:"
@@ -618,7 +618,7 @@ msgstr ""
 
 #: Source/DiabloUI/selgame.cpp:415
 #, c-format
-msgid "Your version %s does not match the host %d.%d.%d."
+msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:123
@@ -706,8 +706,8 @@ msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:345
 #, c-format
-msgid "Character already exists. Do you want to overwrite \"%s\"?"
-msgstr "Karakteren findes allerede. Vil du overskrive \"%s\"?"
+msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
+msgstr "Karakteren findes allerede. Vil du overskrive \"{:s}\"?"
 
 #: Source/DiabloUI/selhero.cpp:357
 msgid "Unable to create character."
@@ -755,9 +755,9 @@ msgstr "Slet singleplayer-helt"
 
 #: Source/DiabloUI/selhero.cpp:621
 #, fuzzy, c-format
-#| msgid "Are you sure you want to delete the character \"%s\"?"
-msgid "Are you sure you want to delete the character \"%s\"?"
-msgstr "Er du sikker på, at du vil slette karakteren \"%s\"?"
+#| msgid "Are you sure you want to delete the character \"{:s}\"?"
+msgid "Are you sure you want to delete the character \"{:s}\"?"
+msgstr "Er du sikker på, at du vil slette karakteren \"{:s}\"?"
 
 #: Source/DiabloUI/selyesno.cpp:61 Source/stores.cpp:888
 msgid "Yes"
@@ -780,13 +780,13 @@ msgstr "Fejl"
 #: Source/appfat.cpp:117
 #, c-format
 msgid ""
-"%s\n"
+"{:s}\n"
 "\n"
-"The error occurred at: %s line %d"
+"The error occurred at: {:s} line {:d}"
 msgstr ""
-"%s\n"
+"{:s}\n"
 "\n"
-"Fejlen opstod ved: %s linje %d"
+"Fejlen opstod ved: {:s} linje {:d}"
 
 #: Source/appfat.cpp:137
 #, fuzzy, c-format
@@ -798,7 +798,7 @@ msgstr ""
 #| "68f049866b44688a7af65ba766bef75a\n"
 #| "\n"
 #| "The problem occurred when loading:\n"
-#| "%s"
+#| "{:s}"
 msgid ""
 "Unable to open a required file.\n"
 "\n"
@@ -807,7 +807,7 @@ msgid ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "The problem occurred when loading:\n"
-"%s"
+"{:s}"
 msgstr ""
 "Kan ikke åbne en påkrævet fil.\n"
 "\n"
@@ -817,12 +817,12 @@ msgstr ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "Problemet opstod ved indlæsning af:\n"
-"%s"
+"{:s}"
 
 #: Source/appfat.cpp:159
 #, fuzzy, c-format
 #| msgid ""
-#| "Unable to open %s.\n"
+#| "Unable to open {:s}.\n"
 #| "\n"
 #| "Make sure that it is in the game folder and that the file name is in all "
 #| "lowercase."
@@ -832,7 +832,7 @@ msgid ""
 "Make sure that it is in the game folder and that the file name is in all "
 "lowercase."
 msgstr ""
-"Kan ikke åbne %s.\n"
+"Kan ikke åbne {:s}.\n"
 "\n"
 "Sørg for, at den findes i spilmappen, og at filnavnet er med små bogstaver."
 
@@ -840,10 +840,10 @@ msgstr ""
 #, c-format
 msgid ""
 "Unable to write to location:\n"
-"%s"
+"{:s}"
 msgstr ""
 "Kan ikke skrive til lokation:\n"
-"%s"
+"{:s}"
 
 #: Source/appfat.cpp:176
 msgid "Read-Only Directory Error"
@@ -919,22 +919,22 @@ msgstr ""
 
 #: Source/stores.cpp:169
 #, c-format
-msgid "Charges: %i/%i"
+msgid "Charges: {:d}/{:d}"
 msgstr ""
 
 #: Source/stores.cpp:180
 #, c-format
-msgid "Damage: %i-%i  "
+msgid "Damage: {:d}-{:d}  "
 msgstr ""
 
 #: Source/stores.cpp:182
 #, c-format
-msgid "Armor: %i  "
+msgid "Armor: {:d}  "
 msgstr ""
 
 #: Source/stores.cpp:184
 #, c-format
-msgid "Dur: %i/%i,  "
+msgid "Dur: {:d}/{:d},  "
 msgstr ""
 
 #: Source/stores.cpp:187
@@ -953,17 +953,17 @@ msgstr "Krav:"
 
 #: Source/stores.cpp:199
 #, c-format
-msgid " %i Str"
+msgid " {:d} Str"
 msgstr ""
 
 #: Source/stores.cpp:201
 #, c-format
-msgid " %i Mag"
+msgid " {:d} Mag"
 msgstr ""
 
 #: Source/stores.cpp:203
 #, c-format
-msgid " %i Dex"
+msgid " {:d} Dex"
 msgstr ""
 
 #: Source/stores.cpp:225 Source/stores.cpp:950 Source/stores.cpp:1172
@@ -1016,7 +1016,7 @@ msgstr "Forlad healers hjem"
 
 #: Source/stores.cpp:274 Source/stores.cpp:623 Source/stores.cpp:989
 #, c-format
-msgid "I have these items for sale:             Your gold: %i"
+msgid "I have these items for sale:             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:279 Source/stores.cpp:343 Source/stores.cpp:471
@@ -1030,27 +1030,27 @@ msgstr ""
 
 #: Source/stores.cpp:339
 #, c-format
-msgid "I have these premium items for sale:     Your gold: %i"
+msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:467 Source/stores.cpp:717
 #, c-format
-msgid "You have nothing I want.             Your gold: %i"
+msgid "You have nothing I want.             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:477 Source/stores.cpp:727
 #, c-format
-msgid "Which item is for sale?             Your gold: %i"
+msgid "Which item is for sale?             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:537
 #, c-format
-msgid "You have nothing to repair.             Your gold: %i"
+msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:549
 #, c-format
-msgid "Repair which item?             Your gold: %i"
+msgid "Repair which item?             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:575
@@ -1077,12 +1077,12 @@ msgstr ""
 
 #: Source/stores.cpp:793
 #, c-format
-msgid "You have nothing to recharge.             Your gold: %i"
+msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:803
 #, c-format
-msgid "Recharge which item?             Your gold: %i"
+msgid "Recharge which item?             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:819
@@ -1099,33 +1099,33 @@ msgstr ""
 
 #: Source/stores.cpp:866
 #, fuzzy
-#| msgid "Are you sure you want to delete the character \"%s\"?"
+#| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to identify this item?"
-msgstr "Er du sikker på, at du vil slette karakteren \"%s\"?"
+msgstr "Er du sikker på, at du vil slette karakteren \"{:s}\"?"
 
 #: Source/stores.cpp:872
 #, fuzzy
-#| msgid "Are you sure you want to delete the character \"%s\"?"
+#| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to buy this item?"
-msgstr "Er du sikker på, at du vil slette karakteren \"%s\"?"
+msgstr "Er du sikker på, at du vil slette karakteren \"{:s}\"?"
 
 #: Source/stores.cpp:875
 #, fuzzy
-#| msgid "Are you sure you want to delete the character \"%s\"?"
+#| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to recharge this item?"
-msgstr "Er du sikker på, at du vil slette karakteren \"%s\"?"
+msgstr "Er du sikker på, at du vil slette karakteren \"{:s}\"?"
 
 #: Source/stores.cpp:879
 #, fuzzy
-#| msgid "Are you sure you want to delete the character \"%s\"?"
+#| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to sell this item?"
-msgstr "Er du sikker på, at du vil slette karakteren \"%s\"?"
+msgstr "Er du sikker på, at du vil slette karakteren \"{:s}\"?"
 
 #: Source/stores.cpp:882
 #, fuzzy
-#| msgid "Are you sure you want to delete the character \"%s\"?"
+#| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to repair this item?"
-msgstr "Er du sikker på, at du vil slette karakteren \"%s\"?"
+msgstr "Er du sikker på, at du vil slette karakteren \"{:s}\"?"
 
 #: Source/stores.cpp:896 Source/towners.cpp:319
 msgid "Wirt the Peg-legged boy"
@@ -1160,7 +1160,7 @@ msgstr ""
 
 #: Source/stores.cpp:915
 #, c-format
-msgid "I have this item for sale:             Your gold: %i"
+msgid "I have this item for sale:             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:931
@@ -1195,12 +1195,12 @@ msgstr ""
 
 #: Source/stores.cpp:1090
 #, c-format
-msgid "You have nothing to identify.             Your gold: %i"
+msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:1100
 #, c-format
-msgid "Identify which item?             Your gold: %i"
+msgid "Identify which item?             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:1117
@@ -1214,13 +1214,13 @@ msgstr ""
 #: Source/stores.cpp:1129
 #, fuzzy, c-format
 #| msgid "Talk to Pepin"
-msgid "Talk to %s"
+msgid "Talk to {:s}"
 msgstr "Tal med Pepin"
 
 #: Source/stores.cpp:1133
 #, fuzzy, c-format
 #| msgid "Talk to Pepin"
-msgid "Talking to %s"
+msgid "Talking to {:s}"
 msgstr "Tal med Pepin"
 
 #: Source/stores.cpp:1135

--- a/Translations/devilutionx.pot
+++ b/Translations/devilutionx.pot
@@ -405,7 +405,7 @@ msgstr ""
 
 #: Source/DiabloUI/selconn.cpp:115
 #, c-format
-msgid "Players Supported: %d"
+msgid "Players Supported: {:d}"
 msgstr ""
 
 #: Source/DiabloUI/selgame.cpp:85 Source/DiabloUI/selgame.cpp:380
@@ -544,7 +544,7 @@ msgstr ""
 #. TRANSLATORS: Error message when somebody tries to join a game running another version.
 #: Source/DiabloUI/selgame.cpp:415
 #, c-format
-msgid "Your version %s does not match the host %d.%d.%d."
+msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:123
@@ -618,7 +618,7 @@ msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:345
 #, c-format
-msgid "Character already exists. Do you want to overwrite \"%s\"?"
+msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
 msgstr ""
 
 #. TRANSLATORS: Error Message
@@ -668,7 +668,7 @@ msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:622
 #, c-format
-msgid "Are you sure you want to delete the character \"%s\"?"
+msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr ""
 
 #: Source/DiabloUI/selyesno.cpp:61 Source/stores.cpp:889
@@ -743,9 +743,9 @@ msgstr ""
 #: Source/appfat.cpp:117
 #, c-format
 msgid ""
-"%s\n"
+"{:s}\n"
 "\n"
-"The error occurred at: %s line %d"
+"The error occurred at: {:s} line {:d}"
 msgstr ""
 
 #. TRANSLATORS: Error Message when diabdat.mpq is broken. Keep values unchanged.
@@ -759,7 +759,7 @@ msgid ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "The problem occurred when loading:\n"
-"%s"
+"{:s}"
 msgstr ""
 
 #: Source/appfat.cpp:146 Source/appfat.cpp:165
@@ -778,7 +778,7 @@ msgstr ""
 #, c-format
 msgid ""
 "Unable to write to location:\n"
-"%s"
+"{:s}"
 msgstr ""
 
 #: Source/appfat.cpp:178
@@ -850,12 +850,12 @@ msgstr ""
 
 #: Source/control.cpp:394 Source/control.cpp:937
 #, c-format
-msgid "%s Skill"
+msgid "{:s} Skill"
 msgstr ""
 
 #: Source/control.cpp:397 Source/control.cpp:941
 #, c-format
-msgid "%s Spell"
+msgid "{:s} Spell"
 msgstr ""
 
 #: Source/control.cpp:399
@@ -873,7 +873,7 @@ msgstr ""
 
 #: Source/control.cpp:409 Source/control.cpp:953
 #, c-format
-msgid "Scroll of %s"
+msgid "Scroll of {:s}"
 msgstr ""
 
 #: Source/control.cpp:425 Source/control.cpp:970
@@ -885,7 +885,7 @@ msgstr[1] ""
 
 #: Source/control.cpp:429 Source/control.cpp:974 Source/items.cpp:1570
 #, c-format
-msgid "Staff of %s"
+msgid "Staff of {:s}"
 msgstr ""
 
 #: Source/control.cpp:431 Source/control.cpp:976
@@ -897,7 +897,7 @@ msgstr[1] ""
 
 #: Source/control.cpp:441
 #, c-format
-msgid "Spell Hotkey %s"
+msgid "Spell Hotkey {:s}"
 msgstr ""
 
 #: Source/control.cpp:913
@@ -910,7 +910,7 @@ msgstr ""
 
 #: Source/control.cpp:918
 #, c-format
-msgid "Hotkey: %s"
+msgid "Hotkey: {:s}"
 msgstr ""
 
 #: Source/control.cpp:927
@@ -934,7 +934,7 @@ msgstr ""
 
 #: Source/control.cpp:1163
 #, c-format
-msgid "%s, Level: %i"
+msgid "{:s}, Level: %i"
 msgstr ""
 
 #: Source/control.cpp:1165
@@ -1022,7 +1022,7 @@ msgstr ""
 
 #: Source/cursor.cpp:206
 #, c-format
-msgid "from %s"
+msgid "from {:s}"
 msgstr ""
 
 #: Source/cursor.cpp:231
@@ -1143,12 +1143,12 @@ msgstr ""
 
 #: Source/diablo.cpp:283
 #, c-format
-msgid "unrecognized option '%s'\n"
+msgid "unrecognized option '{:s}'\n"
 msgstr ""
 
 #: Source/diablo.cpp:671
 #, c-format
-msgid "version %s"
+msgid "version {:s}"
 msgstr ""
 
 #: Source/diablo.cpp:1916
@@ -1167,10 +1167,10 @@ msgstr ""
 msgid "while in stores"
 msgstr ""
 
-#. TRANSLATORS: %s means: Character Name, Game Version, Game Difficulty.
+#. TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty.
 #: Source/diablo.cpp:2203
 #, c-format
-msgid "%s, version = %s, mode = %s"
+msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr ""
 
 #: Source/dvlnet/loopback.cpp:113
@@ -2499,7 +2499,7 @@ msgstr ""
 msgid "Doppelganger's"
 msgstr ""
 
-#. TRANSLATORS: Item suffix section. All items will have a word binding word. (Format: %s of %s - e.g. Rags of Valor)
+#. TRANSLATORS: Item suffix section. All items will have a word binding word. (Format: {:s} of {:s} - e.g. Rags of Valor)
 #: Source/itemdat.cpp:288
 msgid "quality"
 msgstr ""
@@ -3331,13 +3331,13 @@ msgstr ""
 #: Source/items.cpp:1527 Source/items.cpp:1569 Source/items.cpp:2161
 #: Source/items.cpp:2180
 #, c-format
-msgid "%s of %s"
+msgid "{:s} of {:s}"
 msgstr ""
 
-#. TRANSLATORS: %s will be a Character Name
+#. TRANSLATORS: {:s} will be a Character Name
 #: Source/items.cpp:2753 Source/player.cpp:1874
 #, c-format
-msgid "Ear of %s"
+msgid "Ear of {:s}"
 msgstr ""
 
 #: Source/items.cpp:3282 Source/items.cpp:3294
@@ -3574,8 +3574,8 @@ msgstr ""
 
 #: Source/items.cpp:3491
 #, c-format
-msgid "%i %s charge"
-msgid_plural "%i %s charges"
+msgid "%i {:s} charge"
+msgid_plural "%i {:s} charges"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -4897,7 +4897,7 @@ msgstr ""
 
 #: Source/monster.cpp:4966
 #, c-format
-msgid "Type: %s  Kills: %i"
+msgid "Type: {:s}  Kills: %i"
 msgstr ""
 
 #: Source/monster.cpp:4968
@@ -4936,7 +4936,7 @@ msgstr ""
 
 #: Source/monster.cpp:5046
 #, c-format
-msgid "Type: %s"
+msgid "Type: {:s}"
 msgstr ""
 
 #: Source/monster.cpp:5052 Source/monster.cpp:5059
@@ -4975,32 +4975,32 @@ msgstr ""
 #: Source/msg.cpp:1709 Source/msg.cpp:1829 Source/msg.cpp:1850
 #: Source/msg.cpp:1871 Source/msg.cpp:1892
 #, c-format
-msgid "%s has cast an illegal spell."
+msgid "{:s} has cast an illegal spell."
 msgstr ""
 
 #: Source/msg.cpp:2228 Source/multi.cpp:859
 #, c-format
-msgid "Player '%s' (level %d) just joined the game"
+msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr ""
 
 #: Source/multi.cpp:262
 #, c-format
-msgid "Player '%s' just left the game"
+msgid "Player '{:s}' just left the game"
 msgstr ""
 
 #: Source/multi.cpp:265
 #, c-format
-msgid "Player '%s' killed Diablo and left the game!"
+msgid "Player '{:s}' killed Diablo and left the game!"
 msgstr ""
 
 #: Source/multi.cpp:269
 #, c-format
-msgid "Player '%s' dropped due to timeout"
+msgid "Player '{:s}' dropped due to timeout"
 msgstr ""
 
 #: Source/multi.cpp:861
 #, c-format
-msgid "Player '%s' (level %d) is already in the game"
+msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr ""
 
 #. TRANSLATORS: Shrine Name Block
@@ -5277,10 +5277,10 @@ msgstr ""
 msgid "Barrel"
 msgstr ""
 
-#. TRANSLATORS: %s will be a name from the Shrine block above
+#. TRANSLATORS: {:s} will be a name from the Shrine block above
 #: Source/objects.cpp:5510
 #, c-format
-msgid "%s Shrine"
+msgid "{:s} Shrine"
 msgstr ""
 
 #: Source/objects.cpp:5514
@@ -5351,16 +5351,16 @@ msgstr ""
 msgid "Slain Hero"
 msgstr ""
 
-#. TRANSLATORS: %s will either be a chest or a door
+#. TRANSLATORS: {:s} will either be a chest or a door
 #: Source/objects.cpp:5579
 #, c-format
-msgid "Trapped %s"
+msgid "Trapped {:s}"
 msgstr ""
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
 #: Source/objects.cpp:5585
 #, c-format
-msgid "%s (disabled)"
+msgid "{:s} (disabled)"
 msgstr ""
 
 #: Source/pfile.cpp:219
@@ -5383,10 +5383,10 @@ msgstr ""
 msgid "Unable to write to save file archive"
 msgstr ""
 
-#. TRANSLATORS: Shown if player presses "v" button. %s is player name, %d is level, %s is location
+#. TRANSLATORS: Shown if player presses "v" button. {:s} is player name, {:d} is level, {:s} is location
 #: Source/plrmsg.cpp:73
 #, c-format
-msgid "%s (lvl %d): %s"
+msgid "{:s} (lvl {:d}): {:s}"
 msgstr ""
 
 #: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:52
@@ -5398,7 +5398,7 @@ msgstr ""
 
 #: Source/qol/xpbar.cpp:124
 #, c-format
-msgid "Level %d"
+msgid "Level {:d}"
 msgstr ""
 
 #: Source/qol/xpbar.cpp:131 Source/qol/xpbar.cpp:142
@@ -5415,7 +5415,7 @@ msgstr ""
 
 #: Source/qol/xpbar.cpp:150
 #, c-format
-msgid " to Level %d"
+msgid " to Level {:d}"
 msgstr ""
 
 #. TRANSLATORS: Quest Name Block
@@ -5501,10 +5501,10 @@ msgstr ""
 msgid "Unholy Altar"
 msgstr ""
 
-#. TRANSLATORS: Used for Quest Portals. %s is a Map Name
+#. TRANSLATORS: Used for Quest Portals. {:s} is a Map Name
 #: Source/quests.cpp:282
 #, c-format
-msgid "To %s"
+msgid "To {:s}"
 msgstr ""
 
 #: Source/quests.cpp:729
@@ -5962,12 +5962,12 @@ msgstr ""
 
 #: Source/stores.cpp:1130
 #, c-format
-msgid "Talk to %s"
+msgid "Talk to {:s}"
 msgstr ""
 
 #: Source/stores.cpp:1134
 #, c-format
-msgid "Talking to %s"
+msgid "Talking to {:s}"
 msgstr ""
 
 #: Source/stores.cpp:1136

--- a/Translations/devilutionx.pot
+++ b/Translations/devilutionx.pot
@@ -984,11 +984,11 @@ msgstr ""
 msgid "Mana: %i  Dam: 1/3 tgt hp"
 msgstr ""
 
-#. TRANSLATORS: %u is a number. Dialog is shown when splitting a stash of Gold.
+#. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1707
 #, c-format
-msgid "You have %u gold piece. How many do you want to remove?"
-msgid_plural "You have %u gold pieces. How many do you want to remove?"
+msgid "You have {:d} gold piece. How many do you want to remove?"
+msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/Translations/es.po
+++ b/Translations/es.po
@@ -416,8 +416,8 @@ msgstr "Juega solo sin exposición a la red."
 
 #: Source/DiabloUI/selconn.cpp:115
 #, c-format
-msgid "Players Supported: %d"
-msgstr "Jugadores Soportados: %d"
+msgid "Players Supported: {:d}"
+msgstr "Jugadores Soportados: {:d}"
 
 #: Source/DiabloUI/selgame.cpp:85 Source/DiabloUI/selgame.cpp:380
 msgid "Description:"
@@ -568,8 +568,8 @@ msgstr "El anfitrión está ejecutando un juego diferente al tuyo."
 
 #: Source/DiabloUI/selgame.cpp:415
 #, c-format
-msgid "Your version %s does not match the host %d.%d.%d."
-msgstr "Su versión %s no coincide con el host %d.%d.%d."
+msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
+msgstr "Su versión {:s} no coincide con el host {:d}.{:d}.{:d}."
 
 #: Source/DiabloUI/selhero.cpp:123
 msgid "New Hero"
@@ -642,8 +642,8 @@ msgstr "Nombre inválido. Un nombre no puede contener espacios, caracteres reser
 
 #: Source/DiabloUI/selhero.cpp:345
 #, c-format
-msgid "Character already exists. Do you want to overwrite \"%s\"?"
-msgstr "El personaje ya existe. ¿Quiere sobrescribir \"%s\"?"
+msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
+msgstr "El personaje ya existe. ¿Quiere sobrescribir \"{:s}\"?"
 
 #: Source/DiabloUI/selhero.cpp:357
 msgid "Unable to create character."
@@ -691,8 +691,8 @@ msgstr "Eliminar héroe multijugador"
 
 #: Source/DiabloUI/selhero.cpp:621
 #, c-format
-msgid "Are you sure you want to delete the character \"%s\"?"
-msgstr "¿Está seguro de que desea eliminar el personaje \"%s\"?"
+msgid "Are you sure you want to delete the character \"{:s}\"?"
+msgstr "¿Está seguro de que desea eliminar el personaje \"{:s}\"?"
 
 #: Source/DiabloUI/selyesno.cpp:61 Source/stores.cpp:888
 msgid "Yes"
@@ -765,13 +765,13 @@ msgstr "Error"
 #: Source/appfat.cpp:117
 #, c-format
 msgid ""
-"%s\n"
+"{:s}\n"
 "\n"
-"The error occurred at: %s line %d"
+"The error occurred at: {:s} line {:d}"
 msgstr ""
-"%s\n"
+"{:s}\n"
 "\n"
-"El error ocurrió en: %s línea %d"
+"El error ocurrió en: {:s} línea {:d}"
 
 #: Source/appfat.cpp:137
 #, c-format
@@ -783,7 +783,7 @@ msgid ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "The problem occurred when loading:\n"
-"%s"
+"{:s}"
 msgstr ""
 "No se puede abrir un archivo requerido\n"
 "\n"
@@ -791,7 +791,7 @@ msgstr ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "El problema ocurrió al cargar:\n"
-"%s"
+"{:s}"
 
 #: Source/appfat.cpp:146 Source/appfat.cpp:164
 msgid "Data File Error"
@@ -811,10 +811,10 @@ msgstr ""
 #, c-format
 msgid ""
 "Unable to write to location:\n"
-"%s"
+"{:s}"
 msgstr ""
 "No se puede escribir en la ubicación:\n"
-"%s"
+"{:s}"
 
 #: Source/appfat.cpp:177
 msgid "Read-Only Directory Error"
@@ -830,18 +830,18 @@ msgstr "contraseña: "
 
 #: Source/automap.cpp:434 Source/items.cpp:3868
 #, c-format
-msgid "Level: %i"
-msgstr "Nivel: %i"
+msgid "Level: {:d}"
+msgstr "Nivel: {:d}"
 
 #: Source/automap.cpp:436
 #, c-format
-msgid "Level: Crypt %i"
-msgstr "Nivel: Cripta %i"
+msgid "Level: Crypt {:d}"
+msgstr "Nivel: Cripta {:d}"
 
 #: Source/automap.cpp:438
 #, c-format
-msgid "Level: Nest %i"
-msgstr "Nivel: Nest %i"
+msgid "Level: Nest {:d}"
+msgstr "Nivel: Nest {:d}"
 
 #: Source/control.cpp:239
 msgid "Tab"
@@ -885,13 +885,13 @@ msgstr "Enviar mensaje"
 
 #: Source/control.cpp:432 Source/control.cpp:1029
 #, c-format
-msgid "%s Skill"
-msgstr "%s Habilidad"
+msgid "{:s} Skill"
+msgstr "{:s} Habilidad"
 
 #: Source/control.cpp:435 Source/control.cpp:1033
 #, c-format
-msgid "%s Spell"
-msgstr "%s hechizo"
+msgid "{:s} Spell"
+msgstr "{:s} hechizo"
 
 #: Source/control.cpp:437
 msgid "Damages undead only"
@@ -903,13 +903,13 @@ msgstr "Nivel de hechizo 0: inutilizable"
 
 #: Source/control.cpp:443 Source/control.cpp:1041 Source/control.cpp:1867
 #, c-format
-msgid "Spell Level %i"
-msgstr "Nivel de hechizo %i"
+msgid "Spell Level {:d}"
+msgstr "Nivel de hechizo {:d}"
 
 #: Source/control.cpp:447 Source/control.cpp:1045
 #, c-format
-msgid "Scroll of %s"
-msgstr "Desplazamiento de %s"
+msgid "Scroll of {:s}"
+msgstr "Desplazamiento de {:s}"
 
 #: Source/control.cpp:464 Source/control.cpp:1063
 msgid "1 Scroll"
@@ -917,13 +917,13 @@ msgstr "1 desplazamiento"
 
 #: Source/control.cpp:466 Source/control.cpp:1065
 #, c-format
-msgid "%i Scrolls"
-msgstr "%i se desplaza"
+msgid "{:d} Scrolls"
+msgstr "{:d} se desplaza"
 
 #: Source/control.cpp:470 Source/control.cpp:1069 Source/items.cpp:1597
 #, c-format
-msgid "Staff of %s"
-msgstr "Vara de %s"
+msgid "Staff of {:s}"
+msgstr "Vara de {:s}"
 
 #: Source/control.cpp:472 Source/control.cpp:1072
 msgid "1 Charge"
@@ -931,13 +931,13 @@ msgstr "1 carga"
 
 #: Source/control.cpp:474 Source/control.cpp:1074
 #, c-format
-msgid "%i Charges"
-msgstr "%i Cargas"
+msgid "{:d} Charges"
+msgstr "{:d} Cargas"
 
 #: Source/control.cpp:483
 #, c-format
-msgid "Spell Hotkey #F%i"
-msgstr "Deletrear tecla de acceso rápido #F%i"
+msgid "Spell Hotkey #F{:d}"
+msgstr "Deletrear tecla de acceso rápido #F{:d}"
 
 #: Source/control.cpp:1005
 msgid "Player friendly"
@@ -949,8 +949,8 @@ msgstr "Ataque del jugador"
 
 #: Source/control.cpp:1010
 #, c-format
-msgid "Hotkey: %s"
-msgstr "Tecla de acceso rápido: %s"
+msgid "Hotkey: {:s}"
+msgstr "Tecla de acceso rápido: {:s}"
 
 #: Source/control.cpp:1019
 msgid "Select current spell button"
@@ -962,10 +962,10 @@ msgstr "Tecla de acceso rápido: 's'"
 
 #: Source/control.cpp:1261
 #, c-format
-msgid "%i gold piece"
-msgid_plural "%i gold pieces"
-msgstr[0] "%i pieza de oro"
-msgstr[1] "%i piezas de oro"
+msgid "{:d} gold piece"
+msgid_plural "{:d} gold pieces"
+msgstr[0] "{:d} pieza de oro"
+msgstr[1] "{:d} piezas de oro"
 
 #: Source/control.cpp:1264
 msgid "Requirements not met"
@@ -973,13 +973,13 @@ msgstr "Requisitos no cumplidos"
 
 #: Source/control.cpp:1300
 #, c-format
-msgid "%s, Level: %i"
-msgstr "%s, Nivel: %i"
+msgid "{:s}, Level: {:d}"
+msgstr "{:s}, Nivel: {:d}"
 
 #: Source/control.cpp:1302
 #, c-format
-msgid "Hit Points %i of %i"
-msgstr "Puntos de golpe %i de %i"
+msgid "Hit Points {:d} of {:d}"
+msgstr "Puntos de golpe {:d} de {:d}"
 
 #: Source/control.cpp:1375
 msgid "None"
@@ -1000,23 +1000,23 @@ msgstr "Habilidad"
 
 #: Source/control.cpp:1844
 #, c-format
-msgid "Staff (%i charges)"
-msgstr "Vara (%i cargas)"
+msgid "Staff ({:d} charges)"
+msgstr "Vara ({:d} cargas)"
 
 #: Source/control.cpp:1852
 #, c-format
-msgid "Mana: %i  Dam: %i - %i"
-msgstr "Maná: %i Dañ: %i - %i"
+msgid "Mana: {:d}  Dam: {:d} - {:d}"
+msgstr "Maná: {:d} Dañ: {:d} - {:d}"
 
 #: Source/control.cpp:1854
 #, c-format
-msgid "Mana: %i   Dam: n/a"
-msgstr "Maná: %i Dañ: n/a"
+msgid "Mana: {:d}   Dam: n/a"
+msgstr "Maná: {:d} Dañ: n/a"
 
 #: Source/control.cpp:1857
 #, c-format
-msgid "Mana: %i  Dam: 1/3 tgt hp"
-msgstr "Maná: %i Dañ: 1/3 tgt hp"
+msgid "Mana: {:d}  Dam: 1/3 tgt hp"
+msgstr "Maná: {:d} Dañ: 1/3 tgt hp"
 
 #: Source/control.cpp:1902
 msgid "piece"
@@ -1072,8 +1072,8 @@ msgstr "Portal de la ciudad"
 
 #: Source/cursor.cpp:182
 #, c-format
-msgid "from %s"
-msgstr "de %s"
+msgid "from {:s}"
+msgstr "de {:s}"
 
 #: Source/cursor.cpp:207
 msgid "Portal to"
@@ -1181,13 +1181,13 @@ msgstr ""
 
 #: Source/diablo.cpp:267
 #, c-format
-msgid "unrecognized option '%s'\n"
-msgstr "opción no reconocida '%s'\n"
+msgid "unrecognized option '{:s}'\n"
+msgstr "opción no reconocida '{:s}'\n"
 
 #: Source/diablo.cpp:649
 #, c-format
-msgid "version %s"
-msgstr "versión %s"
+msgid "version {:s}"
+msgstr "versión {:s}"
 
 #: Source/diablo.cpp:1172
 msgid "No help available"
@@ -1199,8 +1199,8 @@ msgstr "mientras que en las tiendas"
 
 #: Source/diablo.cpp:1453
 #, c-format
-msgid "%s, mode = %s"
-msgstr "%s, modo = %s"
+msgid "{:s}, mode = {:s}"
+msgstr "{:s}, modo = {:s}"
 
 #: Source/diablo.cpp:2152
 msgid "-- Network timeout --"
@@ -1536,8 +1536,8 @@ msgstr "No se pudo crear la ventana principal"
 
 #: Source/inv.cpp:2117 Source/items.cpp:3079
 #, c-format
-msgid "%i gold %s"
-msgstr "%i oro %s"
+msgid "{:d} gold {:s}"
+msgstr "{:d} oro {:s}"
 
 #: Source/itemdat.cpp:16 Source/itemdat.cpp:197
 msgid "Gold"
@@ -3323,13 +3323,13 @@ msgstr "Aceite de impermeabilidad"
 #: Source/items.cpp:1554 Source/items.cpp:1595 Source/items.cpp:2188
 #: Source/items.cpp:2207
 #, c-format
-msgid "%s of %s"
-msgstr "%s de %s"
+msgid "{:s} of {:s}"
+msgstr "{:s} de {:s}"
 
 #: Source/items.cpp:2781 Source/player.cpp:1817
 #, c-format
-msgid "Ear of %s"
-msgstr "Oído de %s"
+msgid "Ear of {:s}"
+msgstr "Oído de {:s}"
 
 #: Source/items.cpp:3311 Source/items.cpp:3323
 msgid "increases a weapon's"
@@ -3478,33 +3478,33 @@ msgstr "recupera completamente la vida y el maná"
 
 #: Source/items.cpp:3460
 #, c-format
-msgid "chance to hit: %+i%%"
-msgstr "probabilidad de acertar: %+i%%"
+msgid "chance to hit: {:+d}%"
+msgstr "probabilidad de acertar: {:+d}%"
 
 #: Source/items.cpp:3464
 #, c-format
-msgid "%+i%% damage"
-msgstr "%+i% %de daño"
+msgid "{:+d}% damage"
+msgstr "{:+d} {:d}e daño"
 
 #: Source/items.cpp:3468 Source/items.cpp:3730
 #, c-format
-msgid "to hit: %+i%%, %+i%% damage"
-msgstr "para golpear: %+i%%,%+i% %de daño"
+msgid "to hit: {:+d}%, {:+d}% damage"
+msgstr "para golpear: {:+d}%,{:+d} {:d}e daño"
 
 #: Source/items.cpp:3472
 #, c-format
-msgid "%+i%% armor"
-msgstr "%+i%% armadura"
+msgid "{:+d}% armor"
+msgstr "{:+d}% armadura"
 
 #: Source/items.cpp:3475 Source/items.cpp:3478
 #, c-format
-msgid "armor class: %i"
-msgstr "clase de armadura: %i"
+msgid "armor class: {:d}"
+msgstr "clase de armadura: {:d}"
 
 #: Source/items.cpp:3483 Source/items.cpp:3712
 #, c-format
-msgid "Resist Fire: %+i%%"
-msgstr "Resistencia al fuego: %+i%%"
+msgid "Resist Fire: {:+d}%"
+msgstr "Resistencia al fuego: {:+d}%"
 
 #: Source/items.cpp:3485
 msgid "Resist Fire: 75% MAX"
@@ -3512,8 +3512,8 @@ msgstr "Resistencia al fuego: 75% MAX"
 
 #: Source/items.cpp:3490
 #, c-format
-msgid "Resist Lightning: %+i%%"
-msgstr "Resistir rayos: %+i%%"
+msgid "Resist Lightning: {:+d}%"
+msgstr "Resistir rayos: {:+d}%"
 
 #: Source/items.cpp:3492
 msgid "Resist Lightning: 75% MAX"
@@ -3521,8 +3521,8 @@ msgstr "Resistir rayos: 75% MAX"
 
 #: Source/items.cpp:3497
 #, c-format
-msgid "Resist Magic: %+i%%"
-msgstr "Resistencia a la magia: %+i%%"
+msgid "Resist Magic: {:+d}%"
+msgstr "Resistencia a la magia: {:+d}%"
 
 #: Source/items.cpp:3499
 msgid "Resist Magic: 75% MAX"
@@ -3530,8 +3530,8 @@ msgstr "Resistencia a la magia: 75% MAX"
 
 #: Source/items.cpp:3504
 #, c-format
-msgid "Resist All: %+i%%"
-msgstr "Resistir todo: %+i%%"
+msgid "Resist All: {:+d}%"
+msgstr "Resistir todo: {:+d}%"
 
 #: Source/items.cpp:3506
 msgid "Resist All: 75% MAX"
@@ -3543,8 +3543,8 @@ msgstr "los hechizos aumentan 1 nivel"
 
 #: Source/items.cpp:3512
 #, c-format
-msgid "spells are increased %i levels"
-msgstr "los hechizos aumentan %i niveles"
+msgid "spells are increased {:d} levels"
+msgstr "los hechizos aumentan {:d} niveles"
 
 #: Source/items.cpp:3514
 msgid "spells are decreased 1 level"
@@ -3552,8 +3552,8 @@ msgstr "los hechizos se reducen 1 nivel"
 
 #: Source/items.cpp:3516
 #, c-format
-msgid "spells are decreased %i levels"
-msgstr "los hechizos se reducen %i niveles"
+msgid "spells are decreased {:d} levels"
+msgstr "los hechizos se reducen {:d} niveles"
 
 #: Source/items.cpp:3518
 msgid "spell levels unchanged (?)"
@@ -3565,68 +3565,68 @@ msgstr "Cargos extras"
 
 #: Source/items.cpp:3524
 #, c-format
-msgid "%i %s charges"
-msgstr "%i %s cargas"
+msgid "{:d} {:s} charges"
+msgstr "{:d} {:s} cargas"
 
 #: Source/items.cpp:3528
 #, c-format
-msgid "Fire hit damage: %i"
-msgstr "Daño por impacto de fuego: %i"
+msgid "Fire hit damage: {:d}"
+msgstr "Daño por impacto de fuego: {:d}"
 
 #: Source/items.cpp:3530
 #, c-format
-msgid "Fire hit damage: %i-%i"
-msgstr "Daño por impacto de fuego: %i- %i"
+msgid "Fire hit damage: {:d}-{:d}"
+msgstr "Daño por impacto de fuego: {:d}- {:d}"
 
 #: Source/items.cpp:3534
 #, c-format
-msgid "Lightning hit damage: %i"
-msgstr "Daño por impacto de rayo: %i"
+msgid "Lightning hit damage: {:d}"
+msgstr "Daño por impacto de rayo: {:d}"
 
 #: Source/items.cpp:3536
 #, c-format
-msgid "Lightning hit damage: %i-%i"
-msgstr "Daño por impacto de rayo: %i- %i"
+msgid "Lightning hit damage: {:d}-{:d}"
+msgstr "Daño por impacto de rayo: {:d}- {:d}"
 
 #: Source/items.cpp:3540
 #, c-format
-msgid "%+i to strength"
-msgstr "%+i a la fuerza"
+msgid "{:+d} to strength"
+msgstr "{:+d} a la fuerza"
 
 #: Source/items.cpp:3544
 #, c-format
-msgid "%+i to magic"
-msgstr "%+i a la magia"
+msgid "{:+d} to magic"
+msgstr "{:+d} a la magia"
 
 #: Source/items.cpp:3548
 #, c-format
-msgid "%+i to dexterity"
-msgstr "%+i a la destreza"
+msgid "{:+d} to dexterity"
+msgstr "{:+d} a la destreza"
 
 #: Source/items.cpp:3552
 #, c-format
-msgid "%+i to vitality"
-msgstr "%+i a la vitalidad"
+msgid "{:+d} to vitality"
+msgstr "{:+d} a la vitalidad"
 
 #: Source/items.cpp:3556
 #, c-format
-msgid "%+i to all attributes"
-msgstr "%+i a todos los atributos"
+msgid "{:+d} to all attributes"
+msgstr "{:+d} a todos los atributos"
 
 #: Source/items.cpp:3560
 #, c-format
-msgid "%+i damage from enemies"
-msgstr "%+i de daño de enemigos"
+msgid "{:+d} damage from enemies"
+msgstr "{:+d} de daño de enemigos"
 
 #: Source/items.cpp:3564
 #, c-format
-msgid "Hit Points: %+i"
-msgstr "Puntos de vida: %+i"
+msgid "Hit Points: {:+d}"
+msgstr "Puntos de vida: {:+d}"
 
 #: Source/items.cpp:3568
 #, c-format
-msgid "Mana: %+i"
-msgstr "Control: %+i"
+msgid "Mana: {:+d}"
+msgstr "Control: {:+d}"
 
 #: Source/items.cpp:3571
 msgid "high durability"
@@ -3642,13 +3642,13 @@ msgstr "indestructible"
 
 #: Source/items.cpp:3580
 #, c-format
-msgid "+%i%% light radius"
-msgstr "+%i%% radio de luz"
+msgid "+{:d}%% light radius"
+msgstr "+{:d}%% radio de luz"
 
 #: Source/items.cpp:3583
 #, c-format
-msgid "-%i%% light radius"
-msgstr "-%i%% radio de luz"
+msgid "-{:d}%% light radius"
+msgstr "-{:d}%% radio de luz"
 
 #: Source/items.cpp:3586
 msgid "multiple arrows per shot"
@@ -3656,33 +3656,33 @@ msgstr "múltiples flechas por disparo"
 
 #: Source/items.cpp:3590
 #, c-format
-msgid "fire arrows damage: %i"
-msgstr "daño de las flechas de fuego: %i"
+msgid "fire arrows damage: {:d}"
+msgstr "daño de las flechas de fuego: {:d}"
 
 #: Source/items.cpp:3592
 #, c-format
-msgid "fire arrows damage: %i-%i"
-msgstr "daño de las flechas de fuego: %i-%i"
+msgid "fire arrows damage: {:d}-{:d}"
+msgstr "daño de las flechas de fuego: {:d}-{:d}"
 
 #: Source/items.cpp:3596
 #, c-format
-msgid "lightning arrows damage %i"
-msgstr "flechas de relámpago daño %i"
+msgid "lightning arrows damage {:d}"
+msgstr "flechas de relámpago daño {:d}"
 
 #: Source/items.cpp:3598
 #, c-format
-msgid "lightning arrows damage %i-%i"
-msgstr "flechas de relámpago daño %i-%i"
+msgid "lightning arrows damage {:d}-{:d}"
+msgstr "flechas de relámpago daño {:d}-{:d}"
 
 #: Source/items.cpp:3602
 #, c-format
-msgid "fireball damage: %i"
-msgstr "daño de bola de fuego: %i"
+msgid "fireball damage: {:d}"
+msgstr "daño de bola de fuego: {:d}"
 
 #: Source/items.cpp:3604
 #, c-format
-msgid "fireball damage: %i-%i"
-msgstr "daño de las flechas de fuego: %i-%i"
+msgid "fireball damage: {:d}-{:d}"
+msgstr "daño de las flechas de fuego: {:d}-{:d}"
 
 #: Source/items.cpp:3607
 msgid "attacker takes 1-3 damage"
@@ -3775,8 +3775,8 @@ msgstr "bloqueo rapido"
 
 #: Source/items.cpp:3667
 #, c-format
-msgid "adds %i points to damage"
-msgstr "agrega %i puntos al daño"
+msgid "adds {:d} points to damage"
+msgstr "agrega {:d} puntos al daño"
 
 #: Source/items.cpp:3670
 msgid "fires random speed arrows"
@@ -3816,13 +3816,13 @@ msgstr "ver con infravision"
 
 #: Source/items.cpp:3701
 #, c-format
-msgid "lightning damage: %i"
-msgstr "daño por rayo: %i"
+msgid "lightning damage: {:d}"
+msgstr "daño por rayo: {:d}"
 
 #: Source/items.cpp:3703
 #, c-format
-msgid "lightning damage: %i-%i"
-msgstr "daño por rayo: %i-%i"
+msgid "lightning damage: {:d}-{:d}"
+msgstr "daño por rayo: {:d}-{:d}"
 
 #: Source/items.cpp:3706
 msgid "charged bolts on hits"
@@ -3834,8 +3834,8 @@ msgstr "triple daño ocasional"
 
 #: Source/items.cpp:3718
 #, c-format
-msgid "decaying %+i%% damage"
-msgstr "%+i%% de daño en descomposición"
+msgid "decaying {:+d}% damage"
+msgstr "{:+d}% de daño en descomposición"
 
 #: Source/items.cpp:3721
 msgid "2x dmg to monst, 1x to you"
@@ -3848,8 +3848,8 @@ msgstr "Daño aleatorio 0 - 500%"
 
 #: Source/items.cpp:3727
 #, c-format
-msgid "low dur, %+i%% damage"
-msgstr "bajo dur, %+i%% de daño"
+msgid "low dur, {:+d}% damage"
+msgstr "bajo dur, {:+d}% de daño"
 
 #: Source/items.cpp:3733
 msgid "extra AC vs demons"
@@ -3909,64 +3909,64 @@ msgstr "Requerido:"
 
 #: Source/items.cpp:3886 Source/stores.cpp:199
 #, c-format
-msgid " %i Str"
-msgstr " %i Fue"
+msgid " {:d} Str"
+msgstr " {:d} Fue"
 
 #: Source/items.cpp:3888 Source/stores.cpp:201
 #, c-format
-msgid " %i Mag"
-msgstr " %i Mag"
+msgid " {:d} Mag"
+msgstr " {:d} Mag"
 
 #: Source/items.cpp:3890 Source/stores.cpp:203
 #, c-format
-msgid " %i Dex"
-msgstr " %i Dez"
+msgid " {:d} Dex"
+msgstr " {:d} Dez"
 
 #: Source/items.cpp:3901 Source/items.cpp:3948
 #, c-format
-msgid "damage: %i  Indestructible"
-msgstr "daño: %i Indestructible"
+msgid "damage: {:d}  Indestructible"
+msgstr "daño: {:d} Indestructible"
 
 #: Source/items.cpp:3903 Source/items.cpp:3950
 #, c-format
-msgid "damage: %i  Dur: %i/%i"
-msgstr "daño: %i  Dur: %i/%i"
+msgid "damage: {:d}  Dur: {:d}/{:d}"
+msgstr "daño: {:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3906 Source/items.cpp:3953
 #, c-format
-msgid "damage: %i-%i  Indestructible"
-msgstr "daño: %i-%i Indestructible"
+msgid "damage: {:d}-{:d}  Indestructible"
+msgstr "daño: {:d}-{:d} Indestructible"
 
 #: Source/items.cpp:3908 Source/items.cpp:3955
 #, c-format
-msgid "damage: %i-%i  Dur: %i/%i"
-msgstr "daño: %i-%i Dur: %i/%i"
+msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
+msgstr "daño: {:d}-{:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3914 Source/items.cpp:3967
 #, c-format
-msgid "armor: %i  Indestructible"
-msgstr "armadura: %i Indestructible"
+msgid "armor: {:d}  Indestructible"
+msgstr "armadura: {:d} Indestructible"
 
 #: Source/items.cpp:3916 Source/items.cpp:3969
 #, c-format
-msgid "armor: %i  Dur: %i/%i"
-msgstr "armadura: %i Dur: %i/%i"
+msgid "armor: {:d}  Dur: {:d}/{:d}"
+msgstr "armadura: {:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3921
 #, c-format
-msgid "dam: %i  Dur: %i/%i"
-msgstr "dañ: %i Dur: %i/%i"
+msgid "dam: {:d}  Dur: {:d}/{:d}"
+msgstr "dañ: {:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3923
 #, c-format
-msgid "dam: %i-%i  Dur: %i/%i"
-msgstr "dañ: %i-%i Dur: %i/%i"
+msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
+msgstr "dañ: {:d}-{:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3924 Source/items.cpp:3959 Source/items.cpp:3974
 #: Source/stores.cpp:169
 #, c-format
-msgid "Charges: %i/%i"
-msgstr "Cargos: %i/%i"
+msgid "Charges: {:d}/{:d}"
+msgstr "Cargos: {:d}/{:d}"
 
 #: Source/items.cpp:3936
 msgid "unique item"
@@ -4874,18 +4874,18 @@ msgstr "No Muerto"
 
 #: Source/monster.cpp:4969
 #, c-format
-msgid "Type: %s  Kills: %i"
-msgstr "Tipo: %s Muertes: %i"
+msgid "Type: {:s}  Kills: {:d}"
+msgstr "Tipo: {:s} Muertes: {:d}"
 
 #: Source/monster.cpp:4971
 #, c-format
-msgid "Total kills: %i"
-msgstr "Muertes totales: %i"
+msgid "Total kills: {:d}"
+msgstr "Muertes totales: {:d}"
 
 #: Source/monster.cpp:5004
 #, c-format
-msgid "Hit Points: %i-%i"
-msgstr "Puntos de vida: %i- %i"
+msgid "Hit Points: {:d}-{:d}"
+msgstr "Puntos de vida: {:d}- {:d}"
 
 #: Source/monster.cpp:5014
 msgid "No magic resistance"
@@ -4913,8 +4913,8 @@ msgstr "Inmune: "
 
 #: Source/monster.cpp:5049
 #, c-format
-msgid "Type: %s"
-msgstr "Tipo: %s"
+msgid "Type: {:s}"
+msgstr "Tipo: {:s}"
 
 #: Source/monster.cpp:5055 Source/monster.cpp:5062
 msgid "No resistances"
@@ -4952,33 +4952,33 @@ msgstr "¿Está intentando dejar caer un artículo del suelo?"
 #: Source/msg.cpp:1702 Source/msg.cpp:1822 Source/msg.cpp:1843
 #: Source/msg.cpp:1864 Source/msg.cpp:1885
 #, c-format
-msgid "%s has cast an illegal spell."
-msgstr "%s ha lanzado un hechizo ilegal."
+msgid "{:s} has cast an illegal spell."
+msgstr "{:s} ha lanzado un hechizo ilegal."
 
 #: Source/msg.cpp:2221 Source/multi.cpp:866
 #, c-format
-msgid "Player '%s' (level %d) just joined the game"
-msgstr "El jugador ' %s' (nivel %d) acaba de unirse al juego"
+msgid "Player '{:s}' (level {:d}) just joined the game"
+msgstr "El jugador ' {:s}' (nivel {:d}) acaba de unirse al juego"
 
 #: Source/multi.cpp:269
 #, c-format
-msgid "Player '%s' just left the game"
-msgstr "El jugador ' %s' acaba de salir del juego"
+msgid "Player '{:s}' just left the game"
+msgstr "El jugador ' {:s}' acaba de salir del juego"
 
 #: Source/multi.cpp:272
 #, c-format
-msgid "Player '%s' killed Diablo and left the game!"
-msgstr "¡El jugador ' %s' mató a Diablo y abandonó el juego!"
+msgid "Player '{:s}' killed Diablo and left the game!"
+msgstr "¡El jugador ' {:s}' mató a Diablo y abandonó el juego!"
 
 #: Source/multi.cpp:276
 #, c-format
-msgid "Player '%s' dropped due to timeout"
-msgstr "El jugador ' %s' cayó debido al tiempo de espera"
+msgid "Player '{:s}' dropped due to timeout"
+msgstr "El jugador ' {:s}' cayó debido al tiempo de espera"
 
 #: Source/multi.cpp:868
 #, c-format
-msgid "Player '%s' (level %d) is already in the game"
-msgstr "El jugador ' %s' (nivel %d) ya está en el juego"
+msgid "Player '{:s}' (level {:d}) is already in the game"
+msgstr "El jugador ' {:s}' (nivel {:d}) ya está en el juego"
 
 #: Source/objects.cpp:90
 msgid "Mysterious"
@@ -5238,8 +5238,8 @@ msgstr "Barril"
 
 #: Source/objects.cpp:5544
 #, c-format
-msgid "%s Shrine"
-msgstr "%s Santuario"
+msgid "{:s} Shrine"
+msgstr "{:s} Santuario"
 
 #: Source/objects.cpp:5548
 msgid "Skeleton Tome"
@@ -5311,13 +5311,13 @@ msgstr "Héroe asesinado"
 
 #: Source/objects.cpp:5613
 #, c-format
-msgid "Trapped %s"
-msgstr "Atrapado %s"
+msgid "Trapped {:s}"
+msgstr "Atrapado {:s}"
 
 #: Source/objects.cpp:5619
 #, c-format
-msgid "%s (disabled)"
-msgstr "%s (deshabilitado)"
+msgid "{:s} (disabled)"
+msgstr "{:s} (deshabilitado)"
 
 #: Source/pfile.cpp:217
 msgid "Failed to open player archive for writing."
@@ -5341,8 +5341,8 @@ msgstr "No se puede escribir para guardar el archivo"
 
 #: Source/plrmsg.cpp:72
 #, c-format
-msgid "%s (lvl %d): %s"
-msgstr "%s (nivel %d): %s"
+msgid "{:s} (lvl {:d}): {:s}"
+msgstr "{:s} (nivel {:d}): {:s}"
 
 #: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:52
 msgid "Failed to load UI resources. Is devilutionx.mpq accessible and up to date?"
@@ -5350,8 +5350,8 @@ msgstr "No se pudieron cargar los recursos de la IU. ¿Devilutionx.mpq es accesi
 
 #: Source/qol/xpbar.cpp:122
 #, c-format
-msgid "Level %d"
-msgstr "Nivel: %d"
+msgid "Level {:d}"
+msgstr "Nivel: {:d}"
 
 #: Source/qol/xpbar.cpp:129 Source/qol/xpbar.cpp:140
 #, c-format
@@ -5369,8 +5369,8 @@ msgstr "Siguiente nivel: "
 
 #: Source/qol/xpbar.cpp:148
 #, c-format
-msgid " to Level %d"
-msgstr " al Nivel %d"
+msgid " to Level {:d}"
+msgstr " al Nivel {:d}"
 
 #: Source/quests.cpp:39
 msgid "The Magic Rock"
@@ -5450,8 +5450,8 @@ msgstr "Altar impío"
 
 #: Source/quests.cpp:283
 #, c-format
-msgid "To %s"
-msgstr "A %s"
+msgid "To {:s}"
+msgstr "A {:s}"
 
 #: Source/quests.cpp:760
 msgid "Quest Log"
@@ -5655,18 +5655,18 @@ msgstr ",  "
 
 #: Source/stores.cpp:180
 #, c-format
-msgid "Damage: %i-%i  "
-msgstr "Daño: %i-%i "
+msgid "Damage: {:d}-{:d}  "
+msgstr "Daño: {:d}-{:d} "
 
 #: Source/stores.cpp:182
 #, c-format
-msgid "Armor: %i  "
-msgstr "Armadura:%i "
+msgid "Armor: {:d}  "
+msgstr "Armadura:{:d} "
 
 #: Source/stores.cpp:184
 #, c-format
-msgid "Dur: %i/%i,  "
-msgstr "Dur:  %i/ %i, "
+msgid "Dur: {:d}/{:d},  "
+msgstr "Dur:  {:d}/ {:d}, "
 
 #: Source/stores.cpp:187
 msgid "Indestructible,  "
@@ -5716,8 +5716,8 @@ msgstr "Salir de la tienda"
 
 #: Source/stores.cpp:274 Source/stores.cpp:623 Source/stores.cpp:989
 #, c-format
-msgid "I have these items for sale:             Your gold: %i"
-msgstr "Tengo estos artículos a la venta: Tu oro:             %i"
+msgid "I have these items for sale:             Your gold: {:d}"
+msgstr "Tengo estos artículos a la venta: Tu oro:             {:d}"
 
 #: Source/stores.cpp:279 Source/stores.cpp:343 Source/stores.cpp:471
 #: Source/stores.cpp:482 Source/stores.cpp:541 Source/stores.cpp:554
@@ -5730,28 +5730,28 @@ msgstr "Atrás"
 
 #: Source/stores.cpp:339
 #, c-format
-msgid "I have these premium items for sale:     Your gold: %i"
-msgstr "Tengo estos artículos premium a la venta:     Tu oro: %i"
+msgid "I have these premium items for sale:     Your gold: {:d}"
+msgstr "Tengo estos artículos premium a la venta:     Tu oro: {:d}"
 
 #: Source/stores.cpp:467 Source/stores.cpp:717
 #, c-format
-msgid "You have nothing I want.             Your gold: %i"
-msgstr "No tienes nada que yo quiera.             Tu oro: %i"
+msgid "You have nothing I want.             Your gold: {:d}"
+msgstr "No tienes nada que yo quiera.             Tu oro: {:d}"
 
 #: Source/stores.cpp:477 Source/stores.cpp:727
 #, c-format
-msgid "Which item is for sale?             Your gold: %i"
-msgstr "¿Qué artículo está a la venta?             Tu oro: %i"
+msgid "Which item is for sale?             Your gold: {:d}"
+msgstr "¿Qué artículo está a la venta?             Tu oro: {:d}"
 
 #: Source/stores.cpp:537
 #, c-format
-msgid "You have nothing to repair.             Your gold: %i"
-msgstr "No tienes nada que reparar.             Tu oro: %i"
+msgid "You have nothing to repair.             Your gold: {:d}"
+msgstr "No tienes nada que reparar.             Tu oro: {:d}"
 
 #: Source/stores.cpp:549
 #, c-format
-msgid "Repair which item?             Your gold: %i"
-msgstr "¿Reparar qué artículo?             Tu oro: %i"
+msgid "Repair which item?             Your gold: {:d}"
+msgstr "¿Reparar qué artículo?             Tu oro: {:d}"
 
 #: Source/stores.cpp:575
 msgid "Witch's shack"
@@ -5775,13 +5775,13 @@ msgstr "Deja la choza"
 
 #: Source/stores.cpp:793
 #, c-format
-msgid "You have nothing to recharge.             Your gold: %i"
-msgstr "No tienes nada que recargar.             Tu oro: %i"
+msgid "You have nothing to recharge.             Your gold: {:d}"
+msgstr "No tienes nada que recargar.             Tu oro: {:d}"
 
 #: Source/stores.cpp:803
 #, c-format
-msgid "Recharge which item?             Your gold: %i"
-msgstr "¿Recargar qué artículo?             Tu oro: %i"
+msgid "Recharge which item?             Your gold: {:d}"
+msgstr "¿Recargar qué artículo?             Tu oro: {:d}"
 
 #: Source/stores.cpp:819
 msgid "You do not have enough gold"
@@ -5846,8 +5846,8 @@ msgstr "Decir adiós"
 
 #: Source/stores.cpp:915
 #, c-format
-msgid "I have this item for sale:             Your gold: %i"
-msgstr "Tengo este artículo a la venta:             Tu oro: %i"
+msgid "I have this item for sale:             Your gold: {:d}"
+msgstr "Tengo este artículo a la venta:             Tu oro: {:d}"
 
 #: Source/stores.cpp:931
 msgid "Leave"
@@ -5879,13 +5879,13 @@ msgstr "Identificar un artículo"
 
 #: Source/stores.cpp:1090
 #, c-format
-msgid "You have nothing to identify.             Your gold: %i"
-msgstr "No tienes nada que identificar.             Tu oro: %i"
+msgid "You have nothing to identify.             Your gold: {:d}"
+msgstr "No tienes nada que identificar.             Tu oro: {:d}"
 
 #: Source/stores.cpp:1100
 #, c-format
-msgid "Identify which item?             Your gold: %i"
-msgstr "¿Identifica qué artículo?             Tu oro: %i"
+msgid "Identify which item?             Your gold: {:d}"
+msgstr "¿Identifica qué artículo?             Tu oro: {:d}"
 
 #: Source/stores.cpp:1117
 msgid "This item is:"
@@ -5897,13 +5897,13 @@ msgstr "Hecho"
 
 #: Source/stores.cpp:1129
 #, c-format
-msgid "Talk to %s"
-msgstr "Habla con %s"
+msgid "Talk to {:s}"
+msgstr "Habla con {:s}"
 
 #: Source/stores.cpp:1133
 #, c-format
-msgid "Talking to %s"
-msgstr "Hablando con %s"
+msgid "Talking to {:s}"
+msgstr "Hablando con {:s}"
 
 #: Source/stores.cpp:1135
 msgid "is not available"
@@ -7557,8 +7557,8 @@ msgstr "Hasta la colmena"
 #: Source/trigs.cpp:397 Source/trigs.cpp:484 Source/trigs.cpp:536
 #: Source/trigs.cpp:635
 #, c-format
-msgid "Up to level %i"
-msgstr "Hasta el nivel %i"
+msgid "Up to level {:d}"
+msgstr "Hasta el nivel {:d}"
 
 #: Source/trigs.cpp:399 Source/trigs.cpp:458 Source/trigs.cpp:515
 #: Source/trigs.cpp:597 Source/trigs.cpp:615 Source/trigs.cpp:667
@@ -7568,23 +7568,23 @@ msgstr "Hasta la ciudad"
 #: Source/trigs.cpp:411 Source/trigs.cpp:496 Source/trigs.cpp:550
 #: Source/trigs.cpp:577 Source/trigs.cpp:648
 #, c-format
-msgid "Down to level %i"
-msgstr "Hasta el nivel %i"
+msgid "Down to level {:d}"
+msgstr "Hasta el nivel {:d}"
 
 #: Source/trigs.cpp:424
 #, c-format
-msgid "Up to Crypt level %i"
-msgstr "Hasta el nivel de la Cripta %i"
+msgid "Up to Crypt level {:d}"
+msgstr "Hasta el nivel de la Cripta {:d}"
 
 #: Source/trigs.cpp:440
 #, c-format
-msgid "Down to Crypt level %i"
-msgstr "Hasta el nivel de la Cripta %i"
+msgid "Down to Crypt level {:d}"
+msgstr "Hasta el nivel de la Cripta {:d}"
 
 #: Source/trigs.cpp:563
 #, c-format
-msgid "Up to Nest level %i"
-msgstr "Hasta el nivel de Nest %i"
+msgid "Up to Nest level {:d}"
+msgstr "Hasta el nivel de Nest {:d}"
 
 #: Source/trigs.cpp:681
 msgid "Down to Diablo"
@@ -7592,5 +7592,5 @@ msgstr "Hasta el Diablo"
 
 #: Source/trigs.cpp:718 Source/trigs.cpp:735 Source/trigs.cpp:752
 #, c-format
-msgid "Back to Level %i"
-msgstr "Volver al nivel %i"
+msgid "Back to Level {:d}"
+msgstr "Volver al nivel {:d}"

--- a/Translations/es.po
+++ b/Translations/es.po
@@ -1000,8 +1000,8 @@ msgid "pieces"
 msgstr "piezas"
 
 #: Source/control.cpp:1912
-msgid "You have %u gold"
-msgstr "Tienes %u oro"
+msgid "You have {:d} gold"
+msgstr "Tienes {:d} oro"
 
 #: Source/control.cpp:1906
 msgid "piece.  How many do"

--- a/Translations/es.po
+++ b/Translations/es.po
@@ -415,7 +415,6 @@ msgid "Play by yourself with no network exposure."
 msgstr "Juega solo sin exposición a la red."
 
 #: Source/DiabloUI/selconn.cpp:115
-#, c-format
 msgid "Players Supported: {:d}"
 msgstr "Jugadores Soportados: {:d}"
 
@@ -567,7 +566,6 @@ msgid "The host is running a different game than you."
 msgstr "El anfitrión está ejecutando un juego diferente al tuyo."
 
 #: Source/DiabloUI/selgame.cpp:415
-#, c-format
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr "Su versión {:s} no coincide con el host {:d}.{:d}.{:d}."
 
@@ -641,7 +639,6 @@ msgid "Invalid name. A name cannot contain spaces, reserved characters, or reser
 msgstr "Nombre inválido. Un nombre no puede contener espacios, caracteres reservados ni palabras reservadas.\n"
 
 #: Source/DiabloUI/selhero.cpp:345
-#, c-format
 msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
 msgstr "El personaje ya existe. ¿Quiere sobrescribir \"{:s}\"?"
 
@@ -690,7 +687,6 @@ msgid "Delete Single Player Hero"
 msgstr "Eliminar héroe multijugador"
 
 #: Source/DiabloUI/selhero.cpp:621
-#, c-format
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "¿Está seguro de que desea eliminar el personaje \"{:s}\"?"
 
@@ -763,7 +759,6 @@ msgid "Error"
 msgstr "Error"
 
 #: Source/appfat.cpp:117
-#, c-format
 msgid ""
 "{:s}\n"
 "\n"
@@ -774,7 +769,6 @@ msgstr ""
 "El error ocurrió en: {:s} línea {:d}"
 
 #: Source/appfat.cpp:137
-#, c-format
 msgid ""
 "Unable to open a required file.\n"
 "\n"
@@ -808,7 +802,6 @@ msgstr ""
 "Asegúrate de que esté en la carpeta del juego y que el nombre del archivo esté en minúsculas."
 
 #: Source/appfat.cpp:175
-#, c-format
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -829,17 +822,14 @@ msgid "password: "
 msgstr "contraseña: "
 
 #: Source/automap.cpp:434 Source/items.cpp:3868
-#, c-format
 msgid "Level: {:d}"
 msgstr "Nivel: {:d}"
 
 #: Source/automap.cpp:436
-#, c-format
 msgid "Level: Crypt {:d}"
 msgstr "Nivel: Cripta {:d}"
 
 #: Source/automap.cpp:438
-#, c-format
 msgid "Level: Nest {:d}"
 msgstr "Nivel: Nest {:d}"
 
@@ -884,12 +874,10 @@ msgid "Send Message"
 msgstr "Enviar mensaje"
 
 #: Source/control.cpp:432 Source/control.cpp:1029
-#, c-format
 msgid "{:s} Skill"
 msgstr "{:s} Habilidad"
 
 #: Source/control.cpp:435 Source/control.cpp:1033
-#, c-format
 msgid "{:s} Spell"
 msgstr "{:s} hechizo"
 
@@ -902,12 +890,10 @@ msgid "Spell Level 0 - Unusable"
 msgstr "Nivel de hechizo 0: inutilizable"
 
 #: Source/control.cpp:443 Source/control.cpp:1041 Source/control.cpp:1867
-#, c-format
 msgid "Spell Level {:d}"
 msgstr "Nivel de hechizo {:d}"
 
 #: Source/control.cpp:447 Source/control.cpp:1045
-#, c-format
 msgid "Scroll of {:s}"
 msgstr "Desplazamiento de {:s}"
 
@@ -916,12 +902,10 @@ msgid "1 Scroll"
 msgstr "1 desplazamiento"
 
 #: Source/control.cpp:466 Source/control.cpp:1065
-#, c-format
 msgid "{:d} Scrolls"
 msgstr "{:d} se desplaza"
 
 #: Source/control.cpp:470 Source/control.cpp:1069 Source/items.cpp:1597
-#, c-format
 msgid "Staff of {:s}"
 msgstr "Vara de {:s}"
 
@@ -930,12 +914,10 @@ msgid "1 Charge"
 msgstr "1 carga"
 
 #: Source/control.cpp:474 Source/control.cpp:1074
-#, c-format
 msgid "{:d} Charges"
 msgstr "{:d} Cargas"
 
 #: Source/control.cpp:483
-#, c-format
 msgid "Spell Hotkey #F{:d}"
 msgstr "Deletrear tecla de acceso rápido #F{:d}"
 
@@ -948,7 +930,6 @@ msgid "Player attack"
 msgstr "Ataque del jugador"
 
 #: Source/control.cpp:1010
-#, c-format
 msgid "Hotkey: {:s}"
 msgstr "Tecla de acceso rápido: {:s}"
 
@@ -961,7 +942,6 @@ msgid "Hotkey: 's'"
 msgstr "Tecla de acceso rápido: 's'"
 
 #: Source/control.cpp:1261
-#, c-format
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "{:d} pieza de oro"
@@ -972,12 +952,10 @@ msgid "Requirements not met"
 msgstr "Requisitos no cumplidos"
 
 #: Source/control.cpp:1300
-#, c-format
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Nivel: {:d}"
 
 #: Source/control.cpp:1302
-#, c-format
 msgid "Hit Points {:d} of {:d}"
 msgstr "Puntos de golpe {:d} de {:d}"
 
@@ -986,7 +964,6 @@ msgid "None"
 msgstr "Ninguno"
 
 #: Source/control.cpp:1443 Source/control.cpp:1455 Source/control.cpp:1467
-#, c-format
 msgid "MAX"
 msgstr "MAX"
 
@@ -999,22 +976,18 @@ msgid "Skill"
 msgstr "Habilidad"
 
 #: Source/control.cpp:1844
-#, c-format
 msgid "Staff ({:d} charges)"
 msgstr "Vara ({:d} cargas)"
 
 #: Source/control.cpp:1852
-#, c-format
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "Maná: {:d} Dañ: {:d} - {:d}"
 
 #: Source/control.cpp:1854
-#, c-format
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "Maná: {:d} Dañ: n/a"
 
 #: Source/control.cpp:1857
-#, c-format
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "Maná: {:d} Dañ: 1/3 tgt hp"
 
@@ -1027,12 +1000,10 @@ msgid "pieces"
 msgstr "piezas"
 
 #: Source/control.cpp:1912
-#, c-format
 msgid "You have %u gold"
 msgstr "Tienes %u oro"
 
 #: Source/control.cpp:1906
-#, c-format
 msgid "piece.  How many do"
 msgid_plural "pieces.  How many do"
 msgstr[0] "pieza. Cuanto hace"
@@ -1071,7 +1042,6 @@ msgid "Town Portal"
 msgstr "Portal de la ciudad"
 
 #: Source/cursor.cpp:182
-#, c-format
 msgid "from {:s}"
 msgstr "de {:s}"
 
@@ -1180,12 +1150,10 @@ msgstr ""
 "Reportar errores a https://github.com/diasurgical/devilutionX/\n"
 
 #: Source/diablo.cpp:267
-#, c-format
 msgid "unrecognized option '{:s}'\n"
 msgstr "opción no reconocida '{:s}'\n"
 
 #: Source/diablo.cpp:649
-#, c-format
 msgid "version {:s}"
 msgstr "versión {:s}"
 
@@ -1198,7 +1166,6 @@ msgid "while in stores"
 msgstr "mientras que en las tiendas"
 
 #: Source/diablo.cpp:1453
-#, c-format
 msgid "{:s}, mode = {:s}"
 msgstr "{:s}, modo = {:s}"
 
@@ -1535,7 +1502,6 @@ msgid "Unable to create main window"
 msgstr "No se pudo crear la ventana principal"
 
 #: Source/inv.cpp:2117 Source/items.cpp:3079
-#, c-format
 msgid "{:d} gold {:s}"
 msgstr "{:d} oro {:s}"
 
@@ -3322,12 +3288,10 @@ msgstr "Aceite de impermeabilidad"
 
 #: Source/items.cpp:1554 Source/items.cpp:1595 Source/items.cpp:2188
 #: Source/items.cpp:2207
-#, c-format
 msgid "{:s} of {:s}"
 msgstr "{:s} de {:s}"
 
 #: Source/items.cpp:2781 Source/player.cpp:1817
-#, c-format
 msgid "Ear of {:s}"
 msgstr "Oído de {:s}"
 
@@ -3477,32 +3441,26 @@ msgid "fully recover life and mana"
 msgstr "recupera completamente la vida y el maná"
 
 #: Source/items.cpp:3460
-#, c-format
 msgid "chance to hit: {:+d}%"
 msgstr "probabilidad de acertar: {:+d}%"
 
 #: Source/items.cpp:3464
-#, c-format
 msgid "{:+d}% damage"
 msgstr "{:+d} {:d}e daño"
 
 #: Source/items.cpp:3468 Source/items.cpp:3730
-#, c-format
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "para golpear: {:+d}%,{:+d} {:d}e daño"
 
 #: Source/items.cpp:3472
-#, c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% armadura"
 
 #: Source/items.cpp:3475 Source/items.cpp:3478
-#, c-format
 msgid "armor class: {:d}"
 msgstr "clase de armadura: {:d}"
 
 #: Source/items.cpp:3483 Source/items.cpp:3712
-#, c-format
 msgid "Resist Fire: {:+d}%"
 msgstr "Resistencia al fuego: {:+d}%"
 
@@ -3511,7 +3469,6 @@ msgid "Resist Fire: 75% MAX"
 msgstr "Resistencia al fuego: 75% MAX"
 
 #: Source/items.cpp:3490
-#, c-format
 msgid "Resist Lightning: {:+d}%"
 msgstr "Resistir rayos: {:+d}%"
 
@@ -3520,7 +3477,6 @@ msgid "Resist Lightning: 75% MAX"
 msgstr "Resistir rayos: 75% MAX"
 
 #: Source/items.cpp:3497
-#, c-format
 msgid "Resist Magic: {:+d}%"
 msgstr "Resistencia a la magia: {:+d}%"
 
@@ -3529,7 +3485,6 @@ msgid "Resist Magic: 75% MAX"
 msgstr "Resistencia a la magia: 75% MAX"
 
 #: Source/items.cpp:3504
-#, c-format
 msgid "Resist All: {:+d}%"
 msgstr "Resistir todo: {:+d}%"
 
@@ -3542,7 +3497,6 @@ msgid "spells are increased 1 level"
 msgstr "los hechizos aumentan 1 nivel"
 
 #: Source/items.cpp:3512
-#, c-format
 msgid "spells are increased {:d} levels"
 msgstr "los hechizos aumentan {:d} niveles"
 
@@ -3551,7 +3505,6 @@ msgid "spells are decreased 1 level"
 msgstr "los hechizos se reducen 1 nivel"
 
 #: Source/items.cpp:3516
-#, c-format
 msgid "spells are decreased {:d} levels"
 msgstr "los hechizos se reducen {:d} niveles"
 
@@ -3564,67 +3517,54 @@ msgid "Extra charges"
 msgstr "Cargos extras"
 
 #: Source/items.cpp:3524
-#, c-format
 msgid "{:d} {:s} charges"
 msgstr "{:d} {:s} cargas"
 
 #: Source/items.cpp:3528
-#, c-format
 msgid "Fire hit damage: {:d}"
 msgstr "Daño por impacto de fuego: {:d}"
 
 #: Source/items.cpp:3530
-#, c-format
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "Daño por impacto de fuego: {:d}- {:d}"
 
 #: Source/items.cpp:3534
-#, c-format
 msgid "Lightning hit damage: {:d}"
 msgstr "Daño por impacto de rayo: {:d}"
 
 #: Source/items.cpp:3536
-#, c-format
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "Daño por impacto de rayo: {:d}- {:d}"
 
 #: Source/items.cpp:3540
-#, c-format
 msgid "{:+d} to strength"
 msgstr "{:+d} a la fuerza"
 
 #: Source/items.cpp:3544
-#, c-format
 msgid "{:+d} to magic"
 msgstr "{:+d} a la magia"
 
 #: Source/items.cpp:3548
-#, c-format
 msgid "{:+d} to dexterity"
 msgstr "{:+d} a la destreza"
 
 #: Source/items.cpp:3552
-#, c-format
 msgid "{:+d} to vitality"
 msgstr "{:+d} a la vitalidad"
 
 #: Source/items.cpp:3556
-#, c-format
 msgid "{:+d} to all attributes"
 msgstr "{:+d} a todos los atributos"
 
 #: Source/items.cpp:3560
-#, c-format
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} de daño de enemigos"
 
 #: Source/items.cpp:3564
-#, c-format
 msgid "Hit Points: {:+d}"
 msgstr "Puntos de vida: {:+d}"
 
 #: Source/items.cpp:3568
-#, c-format
 msgid "Mana: {:+d}"
 msgstr "Control: {:+d}"
 
@@ -3641,12 +3581,10 @@ msgid "indestructible"
 msgstr "indestructible"
 
 #: Source/items.cpp:3580
-#, c-format
 msgid "+{:d}%% light radius"
 msgstr "+{:d}%% radio de luz"
 
 #: Source/items.cpp:3583
-#, c-format
 msgid "-{:d}%% light radius"
 msgstr "-{:d}%% radio de luz"
 
@@ -3655,32 +3593,26 @@ msgid "multiple arrows per shot"
 msgstr "múltiples flechas por disparo"
 
 #: Source/items.cpp:3590
-#, c-format
 msgid "fire arrows damage: {:d}"
 msgstr "daño de las flechas de fuego: {:d}"
 
 #: Source/items.cpp:3592
-#, c-format
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "daño de las flechas de fuego: {:d}-{:d}"
 
 #: Source/items.cpp:3596
-#, c-format
 msgid "lightning arrows damage {:d}"
 msgstr "flechas de relámpago daño {:d}"
 
 #: Source/items.cpp:3598
-#, c-format
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "flechas de relámpago daño {:d}-{:d}"
 
 #: Source/items.cpp:3602
-#, c-format
 msgid "fireball damage: {:d}"
 msgstr "daño de bola de fuego: {:d}"
 
 #: Source/items.cpp:3604
-#, c-format
 msgid "fireball damage: {:d}-{:d}"
 msgstr "daño de las flechas de fuego: {:d}-{:d}"
 
@@ -3774,7 +3706,6 @@ msgid "fast block"
 msgstr "bloqueo rapido"
 
 #: Source/items.cpp:3667
-#, c-format
 msgid "adds {:d} points to damage"
 msgstr "agrega {:d} puntos al daño"
 
@@ -3815,12 +3746,10 @@ msgid "see with infravision"
 msgstr "ver con infravision"
 
 #: Source/items.cpp:3701
-#, c-format
 msgid "lightning damage: {:d}"
 msgstr "daño por rayo: {:d}"
 
 #: Source/items.cpp:3703
-#, c-format
 msgid "lightning damage: {:d}-{:d}"
 msgstr "daño por rayo: {:d}-{:d}"
 
@@ -3833,7 +3762,6 @@ msgid "occasional triple damage"
 msgstr "triple daño ocasional"
 
 #: Source/items.cpp:3718
-#, c-format
 msgid "decaying {:+d}% damage"
 msgstr "{:+d}% de daño en descomposición"
 
@@ -3847,7 +3775,6 @@ msgid "Random 0 - 500% damage"
 msgstr "Daño aleatorio 0 - 500%"
 
 #: Source/items.cpp:3727
-#, c-format
 msgid "low dur, {:+d}% damage"
 msgstr "bajo dur, {:+d}% de daño"
 
@@ -3908,63 +3835,51 @@ msgid "Required:"
 msgstr "Requerido:"
 
 #: Source/items.cpp:3886 Source/stores.cpp:199
-#, c-format
 msgid " {:d} Str"
 msgstr " {:d} Fue"
 
 #: Source/items.cpp:3888 Source/stores.cpp:201
-#, c-format
 msgid " {:d} Mag"
 msgstr " {:d} Mag"
 
 #: Source/items.cpp:3890 Source/stores.cpp:203
-#, c-format
 msgid " {:d} Dex"
 msgstr " {:d} Dez"
 
 #: Source/items.cpp:3901 Source/items.cpp:3948
-#, c-format
 msgid "damage: {:d}  Indestructible"
 msgstr "daño: {:d} Indestructible"
 
 #: Source/items.cpp:3903 Source/items.cpp:3950
-#, c-format
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "daño: {:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3906 Source/items.cpp:3953
-#, c-format
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "daño: {:d}-{:d} Indestructible"
 
 #: Source/items.cpp:3908 Source/items.cpp:3955
-#, c-format
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "daño: {:d}-{:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3914 Source/items.cpp:3967
-#, c-format
 msgid "armor: {:d}  Indestructible"
 msgstr "armadura: {:d} Indestructible"
 
 #: Source/items.cpp:3916 Source/items.cpp:3969
-#, c-format
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "armadura: {:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3921
-#, c-format
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "dañ: {:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3923
-#, c-format
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "dañ: {:d}-{:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3924 Source/items.cpp:3959 Source/items.cpp:3974
 #: Source/stores.cpp:169
-#, c-format
 msgid "Charges: {:d}/{:d}"
 msgstr "Cargos: {:d}/{:d}"
 
@@ -4873,17 +4788,14 @@ msgid "Undead"
 msgstr "No Muerto"
 
 #: Source/monster.cpp:4969
-#, c-format
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "Tipo: {:s} Muertes: {:d}"
 
 #: Source/monster.cpp:4971
-#, c-format
 msgid "Total kills: {:d}"
 msgstr "Muertes totales: {:d}"
 
 #: Source/monster.cpp:5004
-#, c-format
 msgid "Hit Points: {:d}-{:d}"
 msgstr "Puntos de vida: {:d}- {:d}"
 
@@ -4912,7 +4824,6 @@ msgid "Immune: "
 msgstr "Inmune: "
 
 #: Source/monster.cpp:5049
-#, c-format
 msgid "Type: {:s}"
 msgstr "Tipo: {:s}"
 
@@ -4951,32 +4862,26 @@ msgstr "¿Está intentando dejar caer un artículo del suelo?"
 #: Source/msg.cpp:1387 Source/msg.cpp:1658 Source/msg.cpp:1680
 #: Source/msg.cpp:1702 Source/msg.cpp:1822 Source/msg.cpp:1843
 #: Source/msg.cpp:1864 Source/msg.cpp:1885
-#, c-format
 msgid "{:s} has cast an illegal spell."
 msgstr "{:s} ha lanzado un hechizo ilegal."
 
 #: Source/msg.cpp:2221 Source/multi.cpp:866
-#, c-format
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr "El jugador ' {:s}' (nivel {:d}) acaba de unirse al juego"
 
 #: Source/multi.cpp:269
-#, c-format
 msgid "Player '{:s}' just left the game"
 msgstr "El jugador ' {:s}' acaba de salir del juego"
 
 #: Source/multi.cpp:272
-#, c-format
 msgid "Player '{:s}' killed Diablo and left the game!"
 msgstr "¡El jugador ' {:s}' mató a Diablo y abandonó el juego!"
 
 #: Source/multi.cpp:276
-#, c-format
 msgid "Player '{:s}' dropped due to timeout"
 msgstr "El jugador ' {:s}' cayó debido al tiempo de espera"
 
 #: Source/multi.cpp:868
-#, c-format
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr "El jugador ' {:s}' (nivel {:d}) ya está en el juego"
 
@@ -5237,7 +5142,6 @@ msgid "Barrel"
 msgstr "Barril"
 
 #: Source/objects.cpp:5544
-#, c-format
 msgid "{:s} Shrine"
 msgstr "{:s} Santuario"
 
@@ -5310,12 +5214,10 @@ msgid "Slain Hero"
 msgstr "Héroe asesinado"
 
 #: Source/objects.cpp:5613
-#, c-format
 msgid "Trapped {:s}"
 msgstr "Atrapado {:s}"
 
 #: Source/objects.cpp:5619
-#, c-format
 msgid "{:s} (disabled)"
 msgstr "{:s} (deshabilitado)"
 
@@ -5340,7 +5242,6 @@ msgid "Unable to write to save file archive"
 msgstr "No se puede escribir para guardar el archivo"
 
 #: Source/plrmsg.cpp:72
-#, c-format
 msgid "{:s} (lvl {:d}): {:s}"
 msgstr "{:s} (nivel {:d}): {:s}"
 
@@ -5349,12 +5250,10 @@ msgid "Failed to load UI resources. Is devilutionx.mpq accessible and up to date
 msgstr "No se pudieron cargar los recursos de la IU. ¿Devilutionx.mpq es accesible y está actualizado?"
 
 #: Source/qol/xpbar.cpp:122
-#, c-format
 msgid "Level {:d}"
 msgstr "Nivel: {:d}"
 
 #: Source/qol/xpbar.cpp:129 Source/qol/xpbar.cpp:140
-#, c-format
 msgid "Experience: "
 msgstr "Experiencia: "
 
@@ -5363,12 +5262,10 @@ msgid "Maximum Level"
 msgstr "Nivel Máximo"
 
 #: Source/qol/xpbar.cpp:144
-#, c-format
 msgid "Next Level: "
 msgstr "Siguiente nivel: "
 
 #: Source/qol/xpbar.cpp:148
-#, c-format
 msgid " to Level {:d}"
 msgstr " al Nivel {:d}"
 
@@ -5449,7 +5346,6 @@ msgid "Unholy Altar"
 msgstr "Altar impío"
 
 #: Source/quests.cpp:283
-#, c-format
 msgid "To {:s}"
 msgstr "A {:s}"
 
@@ -5654,17 +5550,14 @@ msgid ",  "
 msgstr ",  "
 
 #: Source/stores.cpp:180
-#, c-format
 msgid "Damage: {:d}-{:d}  "
 msgstr "Daño: {:d}-{:d} "
 
 #: Source/stores.cpp:182
-#, c-format
 msgid "Armor: {:d}  "
 msgstr "Armadura:{:d} "
 
 #: Source/stores.cpp:184
-#, c-format
 msgid "Dur: {:d}/{:d},  "
 msgstr "Dur:  {:d}/ {:d}, "
 
@@ -5715,7 +5608,6 @@ msgid "Leave the shop"
 msgstr "Salir de la tienda"
 
 #: Source/stores.cpp:274 Source/stores.cpp:623 Source/stores.cpp:989
-#, c-format
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "Tengo estos artículos a la venta: Tu oro:             {:d}"
 
@@ -5729,27 +5621,22 @@ msgid "Back"
 msgstr "Atrás"
 
 #: Source/stores.cpp:339
-#, c-format
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "Tengo estos artículos premium a la venta:     Tu oro: {:d}"
 
 #: Source/stores.cpp:467 Source/stores.cpp:717
-#, c-format
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "No tienes nada que yo quiera.             Tu oro: {:d}"
 
 #: Source/stores.cpp:477 Source/stores.cpp:727
-#, c-format
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "¿Qué artículo está a la venta?             Tu oro: {:d}"
 
 #: Source/stores.cpp:537
-#, c-format
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "No tienes nada que reparar.             Tu oro: {:d}"
 
 #: Source/stores.cpp:549
-#, c-format
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "¿Reparar qué artículo?             Tu oro: {:d}"
 
@@ -5774,12 +5661,10 @@ msgid "Leave the shack"
 msgstr "Deja la choza"
 
 #: Source/stores.cpp:793
-#, c-format
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "No tienes nada que recargar.             Tu oro: {:d}"
 
 #: Source/stores.cpp:803
-#, c-format
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "¿Recargar qué artículo?             Tu oro: {:d}"
 
@@ -5845,7 +5730,6 @@ msgid "Say goodbye"
 msgstr "Decir adiós"
 
 #: Source/stores.cpp:915
-#, c-format
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "Tengo este artículo a la venta:             Tu oro: {:d}"
 
@@ -5878,12 +5762,10 @@ msgid "Identify an item"
 msgstr "Identificar un artículo"
 
 #: Source/stores.cpp:1090
-#, c-format
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "No tienes nada que identificar.             Tu oro: {:d}"
 
 #: Source/stores.cpp:1100
-#, c-format
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "¿Identifica qué artículo?             Tu oro: {:d}"
 
@@ -5896,12 +5778,10 @@ msgid "Done"
 msgstr "Hecho"
 
 #: Source/stores.cpp:1129
-#, c-format
 msgid "Talk to {:s}"
 msgstr "Habla con {:s}"
 
 #: Source/stores.cpp:1133
-#, c-format
 msgid "Talking to {:s}"
 msgstr "Hablando con {:s}"
 
@@ -7556,7 +7436,6 @@ msgstr "Hasta la colmena"
 
 #: Source/trigs.cpp:397 Source/trigs.cpp:484 Source/trigs.cpp:536
 #: Source/trigs.cpp:635
-#, c-format
 msgid "Up to level {:d}"
 msgstr "Hasta el nivel {:d}"
 
@@ -7567,22 +7446,18 @@ msgstr "Hasta la ciudad"
 
 #: Source/trigs.cpp:411 Source/trigs.cpp:496 Source/trigs.cpp:550
 #: Source/trigs.cpp:577 Source/trigs.cpp:648
-#, c-format
 msgid "Down to level {:d}"
 msgstr "Hasta el nivel {:d}"
 
 #: Source/trigs.cpp:424
-#, c-format
 msgid "Up to Crypt level {:d}"
 msgstr "Hasta el nivel de la Cripta {:d}"
 
 #: Source/trigs.cpp:440
-#, c-format
 msgid "Down to Crypt level {:d}"
 msgstr "Hasta el nivel de la Cripta {:d}"
 
 #: Source/trigs.cpp:563
-#, c-format
 msgid "Up to Nest level {:d}"
 msgstr "Hasta el nivel de Nest {:d}"
 
@@ -7591,6 +7466,5 @@ msgid "Down to Diablo"
 msgstr "Hasta el Diablo"
 
 #: Source/trigs.cpp:718 Source/trigs.cpp:735 Source/trigs.cpp:752
-#, c-format
 msgid "Back to Level {:d}"
 msgstr "Volver al nivel {:d}"

--- a/Translations/fr.po
+++ b/Translations/fr.po
@@ -421,8 +421,8 @@ msgstr "Jouez seul sans connexion à internet."
 
 #: Source/DiabloUI/selconn.cpp:115
 #, c-format
-msgid "Players Supported: %d"
-msgstr "Joueurs Max: %d"
+msgid "Players Supported: {:d}"
+msgstr "Joueurs Max: {:d}"
 
 #: Source/DiabloUI/selgame.cpp:85 Source/DiabloUI/selgame.cpp:380
 msgid "Description:"
@@ -598,8 +598,8 @@ msgstr "L'hôte utilise un jeu différente du vôtre."
 
 #: Source/DiabloUI/selgame.cpp:415
 #, c-format
-msgid "Your version %s does not match the host %d.%d.%d."
-msgstr "Votre version %s ne correspond pas à celle de l'hôte %d.%d.%d."
+msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
+msgstr "Votre version {:s} ne correspond pas à celle de l'hôte {:d}.{:d}.{:d}."
 
 #: Source/DiabloUI/selhero.cpp:123
 msgid "New Hero"
@@ -680,8 +680,8 @@ msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:345
 #, c-format
-msgid "Character already exists. Do you want to overwrite \"%s\"?"
-msgstr "Le personnage existe déjà. Voulez-vous écraser \"%s\" ?"
+msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
+msgstr "Le personnage existe déjà. Voulez-vous écraser \"{:s}\" ?"
 
 #: Source/DiabloUI/selhero.cpp:357
 msgid "Unable to create character."
@@ -729,8 +729,8 @@ msgstr "Effacer un Personnage Solo"
 
 #: Source/DiabloUI/selhero.cpp:621
 #, c-format
-msgid "Are you sure you want to delete the character \"%s\"?"
-msgstr "Voulez vous vraiment supprimer le personnage \"%s\"?"
+msgid "Are you sure you want to delete the character \"{:s}\"?"
+msgstr "Voulez vous vraiment supprimer le personnage \"{:s}\"?"
 
 #: Source/DiabloUI/selyesno.cpp:61 Source/stores.cpp:888
 msgid "Yes"
@@ -811,13 +811,13 @@ msgstr "Erreur"
 #: Source/appfat.cpp:117
 #, c-format
 msgid ""
-"%s\n"
+"{:s}\n"
 "\n"
-"The error occurred at: %s line %d"
+"The error occurred at: {:s} line {:d}"
 msgstr ""
-"%s\n"
+"{:s}\n"
 "\n"
-"Erreur dans : %s ligne %d"
+"Erreur dans : {:s} ligne {:d}"
 
 #: Source/appfat.cpp:137
 #, c-format
@@ -829,7 +829,7 @@ msgid ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "The problem occurred when loading:\n"
-"%s"
+"{:s}"
 msgstr ""
 "Impossible de charger un fichier requis.\n"
 "\n"
@@ -838,7 +838,7 @@ msgstr ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "Le problème est survenu lors du chargement:\n"
-"%s"
+"{:s}"
 
 #: Source/appfat.cpp:146 Source/appfat.cpp:163
 msgid "Data File Error"
@@ -862,10 +862,10 @@ msgstr ""
 #, c-format
 msgid ""
 "Unable to write to location:\n"
-"%s"
+"{:s}"
 msgstr ""
 "Impossible d'écrire dans l'emplacement:\n"
-"%s"
+"{:s}"
 
 #: Source/appfat.cpp:176
 msgid "Read-Only Directory Error"
@@ -881,18 +881,18 @@ msgstr "password: "
 
 #: Source/automap.cpp:434 Source/items.cpp:3865
 #, c-format
-msgid "Level: %i"
-msgstr "Niveau: %i"
+msgid "Level: {:d}"
+msgstr "Niveau: {:d}"
 
 #: Source/automap.cpp:436
 #, c-format
-msgid "Level: Crypt %i"
-msgstr "Niveau: Crypte %i"
+msgid "Level: Crypt {:d}"
+msgstr "Niveau: Crypte {:d}"
 
 #: Source/automap.cpp:438
 #, c-format
-msgid "Level: Nest %i"
-msgstr "Niveau: Nid %i"
+msgid "Level: Nest {:d}"
+msgstr "Niveau: Nid {:d}"
 
 #: Source/control.cpp:244
 msgid "Character Information"
@@ -924,13 +924,13 @@ msgstr "Envoyer un Message"
 
 #: Source/control.cpp:435 Source/control.cpp:1029
 #, c-format
-msgid "%s Skill"
-msgstr "%s Compétence"
+msgid "{:s} Skill"
+msgstr "{:s} Compétence"
 
 #: Source/control.cpp:438 Source/control.cpp:1033
 #, c-format
-msgid "%s Spell"
-msgstr "%s Sort"
+msgid "{:s} Spell"
+msgstr "{:s} Sort"
 
 #: Source/control.cpp:440
 #, no-c-format
@@ -944,13 +944,13 @@ msgstr "Sort Niveau 0 - Inutilisable"
 
 #: Source/control.cpp:446 Source/control.cpp:1041 Source/control.cpp:1867
 #, c-format
-msgid "Spell Level %i"
-msgstr "Sort Niveau %i"
+msgid "Spell Level {:d}"
+msgstr "Sort Niveau {:d}"
 
 #: Source/control.cpp:450 Source/control.cpp:1045
 #, c-format
-msgid "Scroll of %s"
-msgstr "Parchemin de %s"
+msgid "Scroll of {:s}"
+msgstr "Parchemin de {:s}"
 
 #: Source/control.cpp:467 Source/control.cpp:1063
 msgid "1 Scroll"
@@ -958,13 +958,13 @@ msgstr "1Parchemin"
 
 #: Source/control.cpp:469 Source/control.cpp:1065
 #, c-format
-msgid "%i Scrolls"
-msgstr "%i Parchemins"
+msgid "{:d} Scrolls"
+msgstr "{:d} Parchemins"
 
 #: Source/control.cpp:473 Source/control.cpp:1069 Source/items.cpp:1595
 #, c-format
-msgid "Staff of %s"
-msgstr "Baton de %s"
+msgid "Staff of {:s}"
+msgstr "Baton de {:s}"
 
 #: Source/control.cpp:475 Source/control.cpp:1072
 msgid "1 Charge"
@@ -972,13 +972,13 @@ msgstr "1 Charge"
 
 #: Source/control.cpp:477 Source/control.cpp:1074
 #, c-format
-msgid "%i Charges"
-msgstr "%i Charges"
+msgid "{:d} Charges"
+msgstr "{:d} Charges"
 
 #: Source/control.cpp:486
 #, c-format
-msgid "Spell Hotkey #F%i"
-msgstr "Touche Sort #F%i"
+msgid "Spell Hotkey #F{:d}"
+msgstr "Touche Sort #F{:d}"
 
 #: Source/control.cpp:1005
 msgid "Player friendly"
@@ -990,8 +990,8 @@ msgstr "Joueur hostile"
 
 #: Source/control.cpp:1010
 #, c-format
-msgid "Hotkey: %s"
-msgstr "Touche: %s"
+msgid "Hotkey: {:s}"
+msgstr "Touche: {:s}"
 
 #: Source/control.cpp:1019
 msgid "Select current spell button"
@@ -1003,8 +1003,8 @@ msgstr "Touche: 's'"
 
 #: Source/control.cpp:1261 Source/inv.cpp:2120 Source/items.cpp:3076
 #, c-format
-msgid "%i gold %s"
-msgstr "%i or %s"
+msgid "{:d} gold {:s}"
+msgstr "{:d} or {:s}"
 
 #: Source/control.cpp:1264
 msgid "Requirements not met"
@@ -1012,13 +1012,13 @@ msgstr "Requis insuffisant"
 
 #: Source/control.cpp:1300
 #, c-format
-msgid "%s, Level: %i"
-msgstr "%s, Niveau: %i"
+msgid "{:s}, Level: {:d}"
+msgstr "{:s}, Niveau: {:d}"
 
 #: Source/control.cpp:1302
 #, c-format
-msgid "Hit Points %i of %i"
-msgstr "Dommages %i sur %i"
+msgid "Hit Points {:d} of {:d}"
+msgstr "Dommages {:d} sur {:d}"
 
 #: Source/control.cpp:1375
 msgid "None"
@@ -1035,23 +1035,23 @@ msgstr ""
 
 #: Source/control.cpp:1844
 #, c-format
-msgid "Staff (%i charges)"
-msgstr "Bâton (%i charges)"
+msgid "Staff ({:d} charges)"
+msgstr "Bâton ({:d} charges)"
 
 #: Source/control.cpp:1852
 #, c-format
-msgid "Mana: %i  Dam: %i - %i"
-msgstr "Mana: %i  Dom: %i - %i"
+msgid "Mana: {:d}  Dam: {:d} - {:d}"
+msgstr "Mana: {:d}  Dom: {:d} - {:d}"
 
 #: Source/control.cpp:1854
 #, c-format
-msgid "Mana: %i   Dam: n/a"
-msgstr "Mana: %i   Dom: n/a"
+msgid "Mana: {:d}   Dam: n/a"
+msgstr "Mana: {:d}   Dom: n/a"
 
 #: Source/control.cpp:1857
 #, c-format
-msgid "Mana: %i  Dam: 1/3 tgt hp"
-msgstr "Mana: %i  Dom: 1/3 tgt hp"
+msgid "Mana: {:d}  Dam: 1/3 tgt hp"
+msgstr "Mana: {:d}  Dom: 1/3 tgt hp"
 
 #: Source/control.cpp:1902
 msgid "piece"
@@ -1068,8 +1068,8 @@ msgstr "Vous avez %u d'or"
 
 #: Source/control.cpp:1914
 #, c-format
-msgid "%s.  How many do"
-msgstr "%s.  Combien voulez"
+msgid "{:s}.  How many do"
+msgstr "{:s}.  Combien voulez"
 
 #: Source/control.cpp:1916
 msgid "you want to remove?"
@@ -1105,8 +1105,8 @@ msgstr "Portail vers la ville"
 
 #: Source/cursor.cpp:182
 #, c-format
-msgid "from %s"
-msgstr "de %s"
+msgid "from {:s}"
+msgstr "de {:s}"
 
 #: Source/cursor.cpp:207
 msgid "Portal to"
@@ -1214,8 +1214,8 @@ msgstr ""
 
 #: Source/diablo.cpp:264
 #, c-format
-msgid "unrecognized option '%s'\n"
-msgstr "option '%s' inconnue \n"
+msgid "unrecognized option '{:s}'\n"
+msgstr "option '{:s}' inconnue \n"
 
 #: Source/diablo.cpp:1146
 msgid "No help available"
@@ -1227,8 +1227,8 @@ msgstr "dans les magasins"
 
 #: Source/diablo.cpp:1427
 #, c-format
-msgid "%s, mode = %s"
-msgstr "%s, mode = %s"
+msgid "{:s}, mode = {:s}"
+msgstr "{:s}, mode = {:s}"
 
 #: Source/diablo.cpp:2125
 msgid "-- Network timeout --"
@@ -1801,8 +1801,8 @@ msgstr "Appuyez sur ESC pour terminer ou sur les flèches pour faire défiler."
 
 #: Source/init.cpp:146
 #, c-format
-msgid "version %s"
-msgstr "version %s"
+msgid "version {:s}"
+msgstr "version {:s}"
 
 #: Source/init.cpp:215
 msgid "Some Hellfire MPQs are missing"
@@ -3604,13 +3604,13 @@ msgstr "Huile d'Imperméabilité"
 #: Source/items.cpp:1552 Source/items.cpp:1593 Source/items.cpp:2186
 #: Source/items.cpp:2205
 #, c-format
-msgid "%s of %s"
-msgstr "%s de %s"
+msgid "{:s} of {:s}"
+msgstr "{:s} de {:s}"
 
 #: Source/items.cpp:2779 Source/player.cpp:1887
 #, c-format
-msgid "Ear of %s"
-msgstr "Oreille de %s"
+msgid "Ear of {:s}"
+msgstr "Oreille de {:s}"
 
 #: Source/items.cpp:3308 Source/items.cpp:3320
 msgid "increases a weapon's"
@@ -3759,33 +3759,33 @@ msgstr "rétablie complètement la vie et le mana"
 
 #: Source/items.cpp:3457
 #, c-format
-msgid "chance to hit: %+i%%"
-msgstr "chance de toucher: %+i %%"
+msgid "chance to hit: {:+d}%"
+msgstr "chance de toucher: {:+d} %%"
 
 #: Source/items.cpp:3461
 #, c-format
-msgid "%+i%% damage"
-msgstr "%+i%% dégats"
+msgid "{:+d}% damage"
+msgstr "{:+d}% dégats"
 
 #: Source/items.cpp:3465 Source/items.cpp:3727
 #, c-format
-msgid "to hit: %+i%%, %+i%% damage"
-msgstr "toucher: %+i%%, %+i%% dégats"
+msgid "to hit: {:+d}%, {:+d}% damage"
+msgstr "toucher: {:+d}%, {:+d}% dégats"
 
 #: Source/items.cpp:3469
 #, c-format
-msgid "%+i%% armor"
-msgstr "%+i%% armure"
+msgid "{:+d}% armor"
+msgstr "{:+d}% armure"
 
 #: Source/items.cpp:3472 Source/items.cpp:3475
 #, c-format
-msgid "armor class: %i"
-msgstr "classe d'armure: %i"
+msgid "armor class: {:d}"
+msgstr "classe d'armure: {:d}"
 
 #: Source/items.cpp:3480 Source/items.cpp:3709
 #, c-format
-msgid "Resist Fire: %+i%%"
-msgstr "Résistance au Feu: %+i%%"
+msgid "Resist Fire: {:+d}%"
+msgstr "Résistance au Feu: {:+d}%"
 
 #: Source/items.cpp:3482
 #, no-c-format
@@ -3794,8 +3794,8 @@ msgstr "Résistance au Feu: 75% MAX"
 
 #: Source/items.cpp:3487
 #, c-format
-msgid "Resist Lightning: %+i%%"
-msgstr "Résistance à la Foudre: %+i%%"
+msgid "Resist Lightning: {:+d}%"
+msgstr "Résistance à la Foudre: {:+d}%"
 
 #: Source/items.cpp:3489
 #, no-c-format
@@ -3804,8 +3804,8 @@ msgstr "Résistance à la Foudre: 75% MAX"
 
 #: Source/items.cpp:3494
 #, c-format
-msgid "Resist Magic: %+i%%"
-msgstr "Résistance à la Magie: %+i%%"
+msgid "Resist Magic: {:+d}%"
+msgstr "Résistance à la Magie: {:+d}%"
 
 #: Source/items.cpp:3496
 #, no-c-format
@@ -3814,8 +3814,8 @@ msgstr "Résistance à la Magie: 75% MAX"
 
 #: Source/items.cpp:3501
 #, c-format
-msgid "Resist All: %+i%%"
-msgstr "Résistance à tout: %+i%%"
+msgid "Resist All: {:+d}%"
+msgstr "Résistance à tout: {:+d}%"
 
 #: Source/items.cpp:3503
 #, no-c-format
@@ -3828,8 +3828,8 @@ msgstr "les sorts sont augmentés d'un niveau"
 
 #: Source/items.cpp:3509
 #, c-format
-msgid "spells are increased %i levels"
-msgstr "les sorts sont augmentés de %i niveaux"
+msgid "spells are increased {:d} levels"
+msgstr "les sorts sont augmentés de {:d} niveaux"
 
 #: Source/items.cpp:3511
 msgid "spells are decreased 1 level"
@@ -3837,8 +3837,8 @@ msgstr "les sorts sont réduits d'un niveau"
 
 #: Source/items.cpp:3513
 #, c-format
-msgid "spells are decreased %i levels"
-msgstr "les sorts sont réduits de %i niveaux"
+msgid "spells are decreased {:d} levels"
+msgstr "les sorts sont réduits de {:d} niveaux"
 
 #: Source/items.cpp:3515
 msgid "spell levels unchanged (?)"
@@ -3850,68 +3850,68 @@ msgstr "Charges supplémentaires"
 
 #: Source/items.cpp:3521
 #, c-format
-msgid "%i %s charges"
-msgstr "%i %s charges"
+msgid "{:d} {:s} charges"
+msgstr "{:d} {:s} charges"
 
 #: Source/items.cpp:3525
 #, c-format
-msgid "Fire hit damage: %i"
-msgstr "Dégâts de Feu: %i"
+msgid "Fire hit damage: {:d}"
+msgstr "Dégâts de Feu: {:d}"
 
 #: Source/items.cpp:3527
 #, c-format
-msgid "Fire hit damage: %i-%i"
-msgstr "Dégâts de Feu: %i-%i"
+msgid "Fire hit damage: {:d}-{:d}"
+msgstr "Dégâts de Feu: {:d}-{:d}"
 
 #: Source/items.cpp:3531
 #, c-format
-msgid "Lightning hit damage: %i"
-msgstr "Dégâts de Foudre: %i"
+msgid "Lightning hit damage: {:d}"
+msgstr "Dégâts de Foudre: {:d}"
 
 #: Source/items.cpp:3533
 #, c-format
-msgid "Lightning hit damage: %i-%i"
-msgstr "Dégâts de Foudre: %i-%i"
+msgid "Lightning hit damage: {:d}-{:d}"
+msgstr "Dégâts de Foudre: {:d}-{:d}"
 
 #: Source/items.cpp:3537
 #, c-format
-msgid "%+i to strength"
-msgstr "%+i en force"
+msgid "{:+d} to strength"
+msgstr "{:+d} en force"
 
 #: Source/items.cpp:3541
 #, c-format
-msgid "%+i to magic"
-msgstr "%+i en magie"
+msgid "{:+d} to magic"
+msgstr "{:+d} en magie"
 
 #: Source/items.cpp:3545
 #, c-format
-msgid "%+i to dexterity"
-msgstr "%+i en dexterité"
+msgid "{:+d} to dexterity"
+msgstr "{:+d} en dexterité"
 
 #: Source/items.cpp:3549
 #, c-format
-msgid "%+i to vitality"
-msgstr "%+i en vitalité"
+msgid "{:+d} to vitality"
+msgstr "{:+d} en vitalité"
 
 #: Source/items.cpp:3553
 #, c-format
-msgid "%+i to all attributes"
-msgstr "%+i à tous les attributs"
+msgid "{:+d} to all attributes"
+msgstr "{:+d} à tous les attributs"
 
 #: Source/items.cpp:3557
 #, c-format
-msgid "%+i damage from enemies"
-msgstr "%+i dégâts des ennemis"
+msgid "{:+d} damage from enemies"
+msgstr "{:+d} dégâts des ennemis"
 
 #: Source/items.cpp:3561
 #, c-format
-msgid "Hit Points: %+i"
-msgstr "Points de vie:%+i"
+msgid "Hit Points: {:+d}"
+msgstr "Points de vie:{:+d}"
 
 #: Source/items.cpp:3565
 #, c-format
-msgid "Mana: %+i"
-msgstr "Mana: %+i"
+msgid "Mana: {:+d}"
+msgstr "Mana: {:+d}"
 
 #: Source/items.cpp:3568
 msgid "high durability"
@@ -3927,12 +3927,12 @@ msgstr "indestructible"
 
 #: Source/items.cpp:3577
 #, c-format
-msgid "+%i%% light radius"
+msgid "+{:d}%% light radius"
 msgstr ""
 
 #: Source/items.cpp:3580
 #, c-format
-msgid "-%i%% light radius"
+msgid "-{:d}%% light radius"
 msgstr ""
 
 #: Source/items.cpp:3583
@@ -3942,33 +3942,33 @@ msgstr "plusieurs flèches par tir"
 
 #: Source/items.cpp:3587
 #, c-format
-msgid "fire arrows damage: %i"
-msgstr "dégâts de flèches de feu: %i"
+msgid "fire arrows damage: {:d}"
+msgstr "dégâts de flèches de feu: {:d}"
 
 #: Source/items.cpp:3589
 #, c-format
-msgid "fire arrows damage: %i-%i"
-msgstr "dégâts de flèches de feu: %i-%i"
+msgid "fire arrows damage: {:d}-{:d}"
+msgstr "dégâts de flèches de feu: {:d}-{:d}"
 
 #: Source/items.cpp:3593
 #, c-format
-msgid "lightning arrows damage %i"
-msgstr "dégâts de flèches de foudre: %i"
+msgid "lightning arrows damage {:d}"
+msgstr "dégâts de flèches de foudre: {:d}"
 
 #: Source/items.cpp:3595
 #, c-format
-msgid "lightning arrows damage %i-%i"
-msgstr "dégâts de flèches de foudre: %i-%i"
+msgid "lightning arrows damage {:d}-{:d}"
+msgstr "dégâts de flèches de foudre: {:d}-{:d}"
 
 #: Source/items.cpp:3599
 #, c-format
-msgid "fireball damage: %i"
-msgstr "dégâts boule de feu: %i"
+msgid "fireball damage: {:d}"
+msgstr "dégâts boule de feu: {:d}"
 
 #: Source/items.cpp:3601
 #, c-format
-msgid "fireball damage: %i-%i"
-msgstr "dégâts boule de feu: %i-%i"
+msgid "fireball damage: {:d}-{:d}"
+msgstr "dégâts boule de feu: {:d}-{:d}"
 
 #: Source/items.cpp:3604
 msgid "attacker takes 1-3 damage"
@@ -4065,8 +4065,8 @@ msgstr "blocage rapide"
 
 #: Source/items.cpp:3664
 #, c-format
-msgid "adds %i points to damage"
-msgstr "ajoute %i points aux dégâts"
+msgid "adds {:d} points to damage"
+msgstr "ajoute {:d} points aux dégâts"
 
 #: Source/items.cpp:3667
 msgid "fires random speed arrows"
@@ -4111,13 +4111,13 @@ msgstr ""
 
 #: Source/items.cpp:3698
 #, c-format
-msgid "lightning damage: %i"
-msgstr "dégâts de foudre: %i"
+msgid "lightning damage: {:d}"
+msgstr "dégâts de foudre: {:d}"
 
 #: Source/items.cpp:3700
 #, c-format
-msgid "lightning damage: %i-%i"
-msgstr "dégâts de foudre: %i-%i"
+msgid "lightning damage: {:d}-{:d}"
+msgstr "dégâts de foudre: {:d}-{:d}"
 
 #: Source/items.cpp:3703
 msgid "charged bolts on hits"
@@ -4129,7 +4129,7 @@ msgstr "triple dommage occasionnel"
 
 #: Source/items.cpp:3715
 #, c-format
-msgid "decaying %+i%% damage"
+msgid "decaying {:+d}% damage"
 msgstr ""
 
 #: Source/items.cpp:3718
@@ -4144,7 +4144,7 @@ msgstr "Dégâts 0-500% aléatoire"
 
 #: Source/items.cpp:3724
 #, c-format
-msgid "low dur, %+i%% damage"
+msgid "low dur, {:+d}% damage"
 msgstr ""
 
 #: Source/items.cpp:3730
@@ -4210,64 +4210,64 @@ msgstr "Requis:"
 
 #: Source/items.cpp:3883 Source/stores.cpp:199
 #, c-format
-msgid " %i Str"
-msgstr " %i For"
+msgid " {:d} Str"
+msgstr " {:d} For"
 
 #: Source/items.cpp:3885 Source/stores.cpp:201
 #, c-format
-msgid " %i Mag"
-msgstr " %i Mag"
+msgid " {:d} Mag"
+msgstr " {:d} Mag"
 
 #: Source/items.cpp:3887 Source/stores.cpp:203
 #, c-format
-msgid " %i Dex"
-msgstr " %i Dex"
+msgid " {:d} Dex"
+msgstr " {:d} Dex"
 
 #: Source/items.cpp:3898 Source/items.cpp:3945
 #, c-format
-msgid "damage: %i  Indestructible"
-msgstr "dégâts: %i  Indestructible"
+msgid "damage: {:d}  Indestructible"
+msgstr "dégâts: {:d}  Indestructible"
 
 #: Source/items.cpp:3900 Source/items.cpp:3947
 #, c-format
-msgid "damage: %i  Dur: %i/%i"
-msgstr "dégâts: %i  Dur: %i/%i"
+msgid "damage: {:d}  Dur: {:d}/{:d}"
+msgstr "dégâts: {:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3903 Source/items.cpp:3950
 #, c-format
-msgid "damage: %i-%i  Indestructible"
-msgstr "dégâts: %i-%i  Indestructible"
+msgid "damage: {:d}-{:d}  Indestructible"
+msgstr "dégâts: {:d}-{:d}  Indestructible"
 
 #: Source/items.cpp:3905 Source/items.cpp:3952
 #, c-format
-msgid "damage: %i-%i  Dur: %i/%i"
-msgstr "dégâts: %i-%i Dur: %i/%i"
+msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
+msgstr "dégâts: {:d}-{:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3911 Source/items.cpp:3964
 #, c-format
-msgid "armor: %i  Indestructible"
-msgstr "armure: %i Indestructible"
+msgid "armor: {:d}  Indestructible"
+msgstr "armure: {:d} Indestructible"
 
 #: Source/items.cpp:3913 Source/items.cpp:3966
 #, c-format
-msgid "armor: %i  Dur: %i/%i"
-msgstr "armure: %i  Dur: %i/%i"
+msgid "armor: {:d}  Dur: {:d}/{:d}"
+msgstr "armure: {:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3918
 #, c-format
-msgid "dam: %i  Dur: %i/%i"
-msgstr "deg: %i Dur: %i/%i"
+msgid "dam: {:d}  Dur: {:d}/{:d}"
+msgstr "deg: {:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3920
 #, c-format
-msgid "dam: %i-%i  Dur: %i/%i"
-msgstr "deg: %i-%i Dur: %i/%i"
+msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
+msgstr "deg: {:d}-{:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3921 Source/items.cpp:3956 Source/items.cpp:3971
 #: Source/stores.cpp:169
 #, c-format
-msgid "Charges: %i/%i"
-msgstr "Charges: %i/%i"
+msgid "Charges: {:d}/{:d}"
+msgstr "Charges: {:d}/{:d}"
 
 #: Source/items.cpp:3933
 msgid "unique item"
@@ -5177,18 +5177,18 @@ msgstr "Mort-vivant"
 
 #: Source/monster.cpp:4971
 #, c-format
-msgid "Type: %s  Kills: %i"
-msgstr "Type: %s  Tués: %i"
+msgid "Type: {:s}  Kills: {:d}"
+msgstr "Type: {:s}  Tués: {:d}"
 
 #: Source/monster.cpp:4973
 #, c-format
-msgid "Total kills: %i"
-msgstr "Total Victimes: %i"
+msgid "Total kills: {:d}"
+msgstr "Total Victimes: {:d}"
 
 #: Source/monster.cpp:5006
 #, c-format
-msgid "Hit Points: %i-%i"
-msgstr "Points de vie:%i-%i"
+msgid "Hit Points: {:d}-{:d}"
+msgstr "Points de vie:{:d}-{:d}"
 
 #: Source/monster.cpp:5016
 msgid "No magic resistance"
@@ -5216,8 +5216,8 @@ msgstr "Immunisé: "
 
 #: Source/monster.cpp:5051
 #, c-format
-msgid "Type: %s"
-msgstr "Type: %s"
+msgid "Type: {:s}"
+msgstr "Type: {:s}"
 
 #: Source/monster.cpp:5057 Source/monster.cpp:5064
 msgid "No resistances"
@@ -5255,32 +5255,32 @@ msgstr ""
 #: Source/msg.cpp:1702 Source/msg.cpp:1822 Source/msg.cpp:1843
 #: Source/msg.cpp:1864 Source/msg.cpp:1885
 #, c-format
-msgid "%s has cast an illegal spell."
+msgid "{:s} has cast an illegal spell."
 msgstr ""
 
 #: Source/msg.cpp:2221 Source/multi.cpp:866
 #, c-format
-msgid "Player '%s' (level %d) just joined the game"
+msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr ""
 
 #: Source/multi.cpp:269
 #, c-format
-msgid "Player '%s' just left the game"
+msgid "Player '{:s}' just left the game"
 msgstr ""
 
 #: Source/multi.cpp:272
 #, c-format
-msgid "Player '%s' killed Diablo and left the game!"
+msgid "Player '{:s}' killed Diablo and left the game!"
 msgstr ""
 
 #: Source/multi.cpp:276
 #, c-format
-msgid "Player '%s' dropped due to timeout"
+msgid "Player '{:s}' dropped due to timeout"
 msgstr ""
 
 #: Source/multi.cpp:868
 #, c-format
-msgid "Player '%s' (level %d) is already in the game"
+msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr ""
 
 #: Source/objects.cpp:89
@@ -5541,7 +5541,7 @@ msgstr ""
 
 #: Source/objects.cpp:5537
 #, c-format
-msgid "%s Shrine"
+msgid "{:s} Shrine"
 msgstr ""
 
 #: Source/objects.cpp:5541
@@ -5614,12 +5614,12 @@ msgstr ""
 
 #: Source/objects.cpp:5606
 #, c-format
-msgid "Trapped %s"
+msgid "Trapped {:s}"
 msgstr ""
 
 #: Source/objects.cpp:5612
 #, c-format
-msgid "%s (disabled)"
+msgid "{:s} (disabled)"
 msgstr ""
 
 #: Source/pfile.cpp:223
@@ -5644,7 +5644,7 @@ msgstr ""
 
 #: Source/plrmsg.cpp:72
 #, c-format
-msgid "%s (lvl %d): %s"
+msgid "{:s} (lvl {:d}): {:s}"
 msgstr ""
 
 #: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:52
@@ -5654,7 +5654,7 @@ msgstr ""
 
 #: Source/qol/xpbar.cpp:122
 #, c-format
-msgid "Level %d"
+msgid "Level {:d}"
 msgstr ""
 
 #: Source/qol/xpbar.cpp:129 Source/qol/xpbar.cpp:140
@@ -5673,7 +5673,7 @@ msgstr ""
 
 #: Source/qol/xpbar.cpp:148
 #, c-format
-msgid " to Level %d"
+msgid " to Level {:d}"
 msgstr ""
 
 #: Source/quests.cpp:39
@@ -5754,7 +5754,7 @@ msgstr ""
 
 #: Source/quests.cpp:284
 #, c-format
-msgid "To %s"
+msgid "To {:s}"
 msgstr ""
 
 #: Source/quests.cpp:766
@@ -5959,18 +5959,18 @@ msgstr ", "
 
 #: Source/stores.cpp:180
 #, c-format
-msgid "Damage: %i-%i  "
-msgstr "Dégâts: %i-%i "
+msgid "Damage: {:d}-{:d}  "
+msgstr "Dégâts: {:d}-{:d} "
 
 #: Source/stores.cpp:182
 #, c-format
-msgid "Armor: %i  "
-msgstr "Armure: %i "
+msgid "Armor: {:d}  "
+msgstr "Armure: {:d} "
 
 #: Source/stores.cpp:184
 #, c-format
-msgid "Dur: %i/%i,  "
-msgstr "Dur: %i/%i,  "
+msgid "Dur: {:d}/{:d},  "
+msgstr "Dur: {:d}/{:d},  "
 
 #: Source/stores.cpp:187
 msgid "Indestructible,  "
@@ -6020,8 +6020,8 @@ msgstr "Quitter la boutique"
 
 #: Source/stores.cpp:274 Source/stores.cpp:623 Source/stores.cpp:989
 #, c-format
-msgid "I have these items for sale:             Your gold: %i"
-msgstr "J'ai ces objets à vendre:             Votre or: %i"
+msgid "I have these items for sale:             Your gold: {:d}"
+msgstr "J'ai ces objets à vendre:             Votre or: {:d}"
 
 #: Source/stores.cpp:279 Source/stores.cpp:343 Source/stores.cpp:471
 #: Source/stores.cpp:482 Source/stores.cpp:541 Source/stores.cpp:554
@@ -6034,28 +6034,28 @@ msgstr "Retour"
 
 #: Source/stores.cpp:339
 #, c-format
-msgid "I have these premium items for sale:     Your gold: %i"
-msgstr "J'ai ces objets premim à vendre:             Votre or: %i"
+msgid "I have these premium items for sale:     Your gold: {:d}"
+msgstr "J'ai ces objets premim à vendre:             Votre or: {:d}"
 
 #: Source/stores.cpp:467 Source/stores.cpp:717
 #, c-format
-msgid "You have nothing I want.             Your gold: %i"
-msgstr "Vous n'avez rien pour moi.             Votre or: %i"
+msgid "You have nothing I want.             Your gold: {:d}"
+msgstr "Vous n'avez rien pour moi.             Votre or: {:d}"
 
 #: Source/stores.cpp:477 Source/stores.cpp:727
 #, c-format
-msgid "Which item is for sale?             Your gold: %i"
-msgstr "Quel objet est à vendre?             Votre or: %i"
+msgid "Which item is for sale?             Your gold: {:d}"
+msgstr "Quel objet est à vendre?             Votre or: {:d}"
 
 #: Source/stores.cpp:537
 #, c-format
-msgid "You have nothing to repair.             Your gold: %i"
-msgstr "Vous n'avez rien à réparer.             Votre or: %i"
+msgid "You have nothing to repair.             Your gold: {:d}"
+msgstr "Vous n'avez rien à réparer.             Votre or: {:d}"
 
 #: Source/stores.cpp:549
 #, c-format
-msgid "Repair which item?             Your gold: %i"
-msgstr "Réparer quel article?             Votre or: %i"
+msgid "Repair which item?             Your gold: {:d}"
+msgstr "Réparer quel article?             Votre or: {:d}"
 
 #: Source/stores.cpp:575
 msgid "Witch's shack"
@@ -6079,13 +6079,13 @@ msgstr "Quitter la cabane"
 
 #: Source/stores.cpp:793
 #, c-format
-msgid "You have nothing to recharge.             Your gold: %i"
-msgstr "Vous n'avez rien à recharger.              Votre or: %i"
+msgid "You have nothing to recharge.             Your gold: {:d}"
+msgstr "Vous n'avez rien à recharger.              Votre or: {:d}"
 
 #: Source/stores.cpp:803
 #, c-format
-msgid "Recharge which item?             Your gold: %i"
-msgstr "Recharger quel article?             Votre or: %i"
+msgid "Recharge which item?             Your gold: {:d}"
+msgstr "Recharger quel article?             Votre or: {:d}"
 
 #: Source/stores.cpp:819
 msgid "You do not have enough gold"
@@ -6150,8 +6150,8 @@ msgstr "Dire aurevoir"
 
 #: Source/stores.cpp:915
 #, c-format
-msgid "I have this item for sale:             Your gold: %i"
-msgstr "J'ai cet objet à vendre:             Votre or: %i"
+msgid "I have this item for sale:             Your gold: {:d}"
+msgstr "J'ai cet objet à vendre:             Votre or: {:d}"
 
 #: Source/stores.cpp:931
 msgid "Leave"
@@ -6183,13 +6183,13 @@ msgstr "Identifier un objet"
 
 #: Source/stores.cpp:1090
 #, c-format
-msgid "You have nothing to identify.             Your gold: %i"
-msgstr "Vous n'avez rien à identifier.             Votre or: %i"
+msgid "You have nothing to identify.             Your gold: {:d}"
+msgstr "Vous n'avez rien à identifier.             Votre or: {:d}"
 
 #: Source/stores.cpp:1100
 #, c-format
-msgid "Identify which item?             Your gold: %i"
-msgstr "Identifier quel article?             Votre or: %i"
+msgid "Identify which item?             Your gold: {:d}"
+msgstr "Identifier quel article?             Votre or: {:d}"
 
 #: Source/stores.cpp:1117
 msgid "This item is:"
@@ -6201,13 +6201,13 @@ msgstr "Fait"
 
 #: Source/stores.cpp:1129
 #, c-format
-msgid "Talk to %s"
-msgstr "Parler à %s"
+msgid "Talk to {:s}"
+msgstr "Parler à {:s}"
 
 #: Source/stores.cpp:1133
 #, c-format
-msgid "Talking to %s"
-msgstr "Parler à %s"
+msgid "Talking to {:s}"
+msgstr "Parler à {:s}"
 
 #: Source/stores.cpp:1135
 msgid "is not available"
@@ -8703,7 +8703,7 @@ msgstr ""
 #: Source/trigs.cpp:397 Source/trigs.cpp:484 Source/trigs.cpp:536
 #: Source/trigs.cpp:635
 #, c-format
-msgid "Up to level %i"
+msgid "Up to level {:d}"
 msgstr ""
 
 #: Source/trigs.cpp:399 Source/trigs.cpp:458 Source/trigs.cpp:515
@@ -8714,22 +8714,22 @@ msgstr ""
 #: Source/trigs.cpp:411 Source/trigs.cpp:496 Source/trigs.cpp:550
 #: Source/trigs.cpp:577 Source/trigs.cpp:648
 #, c-format
-msgid "Down to level %i"
+msgid "Down to level {:d}"
 msgstr ""
 
 #: Source/trigs.cpp:424
 #, c-format
-msgid "Up to Crypt level %i"
+msgid "Up to Crypt level {:d}"
 msgstr ""
 
 #: Source/trigs.cpp:440
 #, c-format
-msgid "Down to Crypt level %i"
+msgid "Down to Crypt level {:d}"
 msgstr ""
 
 #: Source/trigs.cpp:563
 #, c-format
-msgid "Up to Nest level %i"
+msgid "Up to Nest level {:d}"
 msgstr ""
 
 #: Source/trigs.cpp:681
@@ -8738,7 +8738,7 @@ msgstr ""
 
 #: Source/trigs.cpp:718 Source/trigs.cpp:735 Source/trigs.cpp:752
 #, c-format
-msgid "Back to Level %i"
+msgid "Back to Level {:d}"
 msgstr ""
 
 #~ msgid "Enter Hero name.."

--- a/Translations/fr.po
+++ b/Translations/fr.po
@@ -1035,8 +1035,8 @@ msgid "pieces"
 msgstr "pièces"
 
 #: Source/control.cpp:1912
-msgid "You have %u gold"
-msgstr "Vous avez %u d'or"
+msgid "You have {:d} gold"
+msgstr "Vous avez {:d} d'or"
 
 #: Source/control.cpp:1914
 msgid "{:s}.  How many do"

--- a/Translations/fr.po
+++ b/Translations/fr.po
@@ -420,7 +420,6 @@ msgid "Play by yourself with no network exposure."
 msgstr "Jouez seul sans connexion à internet."
 
 #: Source/DiabloUI/selconn.cpp:115
-#, c-format
 msgid "Players Supported: {:d}"
 msgstr "Joueurs Max: {:d}"
 
@@ -597,7 +596,6 @@ msgid "The host is running a different game than you."
 msgstr "L'hôte utilise un jeu différente du vôtre."
 
 #: Source/DiabloUI/selgame.cpp:415
-#, c-format
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr "Votre version {:s} ne correspond pas à celle de l'hôte {:d}.{:d}.{:d}."
 
@@ -679,7 +677,6 @@ msgstr ""
 "ou de mots réservés.\n"
 
 #: Source/DiabloUI/selhero.cpp:345
-#, c-format
 msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
 msgstr "Le personnage existe déjà. Voulez-vous écraser \"{:s}\" ?"
 
@@ -728,7 +725,6 @@ msgid "Delete Single Player Hero"
 msgstr "Effacer un Personnage Solo"
 
 #: Source/DiabloUI/selhero.cpp:621
-#, c-format
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "Voulez vous vraiment supprimer le personnage \"{:s}\"?"
 
@@ -809,7 +805,6 @@ msgid "Error"
 msgstr "Erreur"
 
 #: Source/appfat.cpp:117
-#, c-format
 msgid ""
 "{:s}\n"
 "\n"
@@ -820,7 +815,6 @@ msgstr ""
 "Erreur dans : {:s} ligne {:d}"
 
 #: Source/appfat.cpp:137
-#, c-format
 msgid ""
 "Unable to open a required file.\n"
 "\n"
@@ -845,7 +839,6 @@ msgid "Data File Error"
 msgstr "Erreur de fichier de données"
 
 #: Source/appfat.cpp:159
-#, c-format
 msgid ""
 "Unable to open main data archive (diabdat.mpq or spawn.mpq).\n"
 "\n"
@@ -859,7 +852,6 @@ msgstr ""
 "est en minuscules."
 
 #: Source/appfat.cpp:174
-#, c-format
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -880,17 +872,14 @@ msgid "password: "
 msgstr "password: "
 
 #: Source/automap.cpp:434 Source/items.cpp:3865
-#, c-format
 msgid "Level: {:d}"
 msgstr "Niveau: {:d}"
 
 #: Source/automap.cpp:436
-#, c-format
 msgid "Level: Crypt {:d}"
 msgstr "Niveau: Crypte {:d}"
 
 #: Source/automap.cpp:438
-#, c-format
 msgid "Level: Nest {:d}"
 msgstr "Niveau: Nid {:d}"
 
@@ -923,12 +912,10 @@ msgid "Send Message"
 msgstr "Envoyer un Message"
 
 #: Source/control.cpp:435 Source/control.cpp:1029
-#, c-format
 msgid "{:s} Skill"
 msgstr "{:s} Compétence"
 
 #: Source/control.cpp:438 Source/control.cpp:1033
-#, c-format
 msgid "{:s} Spell"
 msgstr "{:s} Sort"
 
@@ -943,12 +930,10 @@ msgid "Spell Level 0 - Unusable"
 msgstr "Sort Niveau 0 - Inutilisable"
 
 #: Source/control.cpp:446 Source/control.cpp:1041 Source/control.cpp:1867
-#, c-format
 msgid "Spell Level {:d}"
 msgstr "Sort Niveau {:d}"
 
 #: Source/control.cpp:450 Source/control.cpp:1045
-#, c-format
 msgid "Scroll of {:s}"
 msgstr "Parchemin de {:s}"
 
@@ -957,12 +942,10 @@ msgid "1 Scroll"
 msgstr "1Parchemin"
 
 #: Source/control.cpp:469 Source/control.cpp:1065
-#, c-format
 msgid "{:d} Scrolls"
 msgstr "{:d} Parchemins"
 
 #: Source/control.cpp:473 Source/control.cpp:1069 Source/items.cpp:1595
-#, c-format
 msgid "Staff of {:s}"
 msgstr "Baton de {:s}"
 
@@ -971,12 +954,10 @@ msgid "1 Charge"
 msgstr "1 Charge"
 
 #: Source/control.cpp:477 Source/control.cpp:1074
-#, c-format
 msgid "{:d} Charges"
 msgstr "{:d} Charges"
 
 #: Source/control.cpp:486
-#, c-format
 msgid "Spell Hotkey #F{:d}"
 msgstr "Touche Sort #F{:d}"
 
@@ -989,7 +970,6 @@ msgid "Player attack"
 msgstr "Joueur hostile"
 
 #: Source/control.cpp:1010
-#, c-format
 msgid "Hotkey: {:s}"
 msgstr "Touche: {:s}"
 
@@ -1002,7 +982,6 @@ msgid "Hotkey: 's'"
 msgstr "Touche: 's'"
 
 #: Source/control.cpp:1261 Source/inv.cpp:2120 Source/items.cpp:3076
-#, c-format
 msgid "{:d} gold {:s}"
 msgstr "{:d} or {:s}"
 
@@ -1011,12 +990,10 @@ msgid "Requirements not met"
 msgstr "Requis insuffisant"
 
 #: Source/control.cpp:1300
-#, c-format
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Niveau: {:d}"
 
 #: Source/control.cpp:1302
-#, c-format
 msgid "Hit Points {:d} of {:d}"
 msgstr "Dommages {:d} sur {:d}"
 
@@ -1034,22 +1011,18 @@ msgid "Skill"
 msgstr ""
 
 #: Source/control.cpp:1844
-#, c-format
 msgid "Staff ({:d} charges)"
 msgstr "Bâton ({:d} charges)"
 
 #: Source/control.cpp:1852
-#, c-format
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "Mana: {:d}  Dom: {:d} - {:d}"
 
 #: Source/control.cpp:1854
-#, c-format
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "Mana: {:d}   Dom: n/a"
 
 #: Source/control.cpp:1857
-#, c-format
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "Mana: {:d}  Dom: 1/3 tgt hp"
 
@@ -1062,12 +1035,10 @@ msgid "pieces"
 msgstr "pièces"
 
 #: Source/control.cpp:1912
-#, c-format
 msgid "You have %u gold"
 msgstr "Vous avez %u d'or"
 
 #: Source/control.cpp:1914
-#, c-format
 msgid "{:s}.  How many do"
 msgstr "{:s}.  Combien voulez"
 
@@ -1104,7 +1075,6 @@ msgid "Town Portal"
 msgstr "Portail vers la ville"
 
 #: Source/cursor.cpp:182
-#, c-format
 msgid "from {:s}"
 msgstr "de {:s}"
 
@@ -1213,7 +1183,6 @@ msgstr ""
 "Signalez les bogues sur https://github.com/diasurgical/devilutionX/\n"
 
 #: Source/diablo.cpp:264
-#, c-format
 msgid "unrecognized option '{:s}'\n"
 msgstr "option '{:s}' inconnue \n"
 
@@ -1226,7 +1195,6 @@ msgid "while in stores"
 msgstr "dans les magasins"
 
 #: Source/diablo.cpp:1427
-#, c-format
 msgid "{:s}, mode = {:s}"
 msgstr "{:s}, mode = {:s}"
 
@@ -1800,7 +1768,6 @@ msgid "Press ESC to end or the arrow keys to scroll."
 msgstr "Appuyez sur ESC pour terminer ou sur les flèches pour faire défiler."
 
 #: Source/init.cpp:146
-#, c-format
 msgid "version {:s}"
 msgstr "version {:s}"
 
@@ -3603,12 +3570,10 @@ msgstr "Huile d'Imperméabilité"
 
 #: Source/items.cpp:1552 Source/items.cpp:1593 Source/items.cpp:2186
 #: Source/items.cpp:2205
-#, c-format
 msgid "{:s} of {:s}"
 msgstr "{:s} de {:s}"
 
 #: Source/items.cpp:2779 Source/player.cpp:1887
-#, c-format
 msgid "Ear of {:s}"
 msgstr "Oreille de {:s}"
 
@@ -3649,7 +3614,6 @@ msgid "to use armor or weapons"
 msgstr ""
 
 #: Source/items.cpp:3338
-#, c-format
 msgid "restores 20% of an"
 msgstr ""
 
@@ -3758,32 +3722,26 @@ msgid "fully recover life and mana"
 msgstr "rétablie complètement la vie et le mana"
 
 #: Source/items.cpp:3457
-#, c-format
 msgid "chance to hit: {:+d}%"
 msgstr "chance de toucher: {:+d} %%"
 
 #: Source/items.cpp:3461
-#, c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% dégats"
 
 #: Source/items.cpp:3465 Source/items.cpp:3727
-#, c-format
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "toucher: {:+d}%, {:+d}% dégats"
 
 #: Source/items.cpp:3469
-#, c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% armure"
 
 #: Source/items.cpp:3472 Source/items.cpp:3475
-#, c-format
 msgid "armor class: {:d}"
 msgstr "classe d'armure: {:d}"
 
 #: Source/items.cpp:3480 Source/items.cpp:3709
-#, c-format
 msgid "Resist Fire: {:+d}%"
 msgstr "Résistance au Feu: {:+d}%"
 
@@ -3793,7 +3751,6 @@ msgid "Resist Fire: 75% MAX"
 msgstr "Résistance au Feu: 75% MAX"
 
 #: Source/items.cpp:3487
-#, c-format
 msgid "Resist Lightning: {:+d}%"
 msgstr "Résistance à la Foudre: {:+d}%"
 
@@ -3803,7 +3760,6 @@ msgid "Resist Lightning: 75% MAX"
 msgstr "Résistance à la Foudre: 75% MAX"
 
 #: Source/items.cpp:3494
-#, c-format
 msgid "Resist Magic: {:+d}%"
 msgstr "Résistance à la Magie: {:+d}%"
 
@@ -3813,7 +3769,6 @@ msgid "Resist Magic: 75% MAX"
 msgstr "Résistance à la Magie: 75% MAX"
 
 #: Source/items.cpp:3501
-#, c-format
 msgid "Resist All: {:+d}%"
 msgstr "Résistance à tout: {:+d}%"
 
@@ -3827,7 +3782,6 @@ msgid "spells are increased 1 level"
 msgstr "les sorts sont augmentés d'un niveau"
 
 #: Source/items.cpp:3509
-#, c-format
 msgid "spells are increased {:d} levels"
 msgstr "les sorts sont augmentés de {:d} niveaux"
 
@@ -3836,7 +3790,6 @@ msgid "spells are decreased 1 level"
 msgstr "les sorts sont réduits d'un niveau"
 
 #: Source/items.cpp:3513
-#, c-format
 msgid "spells are decreased {:d} levels"
 msgstr "les sorts sont réduits de {:d} niveaux"
 
@@ -3849,67 +3802,54 @@ msgid "Extra charges"
 msgstr "Charges supplémentaires"
 
 #: Source/items.cpp:3521
-#, c-format
 msgid "{:d} {:s} charges"
 msgstr "{:d} {:s} charges"
 
 #: Source/items.cpp:3525
-#, c-format
 msgid "Fire hit damage: {:d}"
 msgstr "Dégâts de Feu: {:d}"
 
 #: Source/items.cpp:3527
-#, c-format
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "Dégâts de Feu: {:d}-{:d}"
 
 #: Source/items.cpp:3531
-#, c-format
 msgid "Lightning hit damage: {:d}"
 msgstr "Dégâts de Foudre: {:d}"
 
 #: Source/items.cpp:3533
-#, c-format
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "Dégâts de Foudre: {:d}-{:d}"
 
 #: Source/items.cpp:3537
-#, c-format
 msgid "{:+d} to strength"
 msgstr "{:+d} en force"
 
 #: Source/items.cpp:3541
-#, c-format
 msgid "{:+d} to magic"
 msgstr "{:+d} en magie"
 
 #: Source/items.cpp:3545
-#, c-format
 msgid "{:+d} to dexterity"
 msgstr "{:+d} en dexterité"
 
 #: Source/items.cpp:3549
-#, c-format
 msgid "{:+d} to vitality"
 msgstr "{:+d} en vitalité"
 
 #: Source/items.cpp:3553
-#, c-format
 msgid "{:+d} to all attributes"
 msgstr "{:+d} à tous les attributs"
 
 #: Source/items.cpp:3557
-#, c-format
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} dégâts des ennemis"
 
 #: Source/items.cpp:3561
-#, c-format
 msgid "Hit Points: {:+d}"
 msgstr "Points de vie:{:+d}"
 
 #: Source/items.cpp:3565
-#, c-format
 msgid "Mana: {:+d}"
 msgstr "Mana: {:+d}"
 
@@ -3926,12 +3866,10 @@ msgid "indestructible"
 msgstr "indestructible"
 
 #: Source/items.cpp:3577
-#, c-format
 msgid "+{:d}%% light radius"
 msgstr ""
 
 #: Source/items.cpp:3580
-#, c-format
 msgid "-{:d}%% light radius"
 msgstr ""
 
@@ -3941,32 +3879,26 @@ msgid "multiple arrows per shot"
 msgstr "plusieurs flèches par tir"
 
 #: Source/items.cpp:3587
-#, c-format
 msgid "fire arrows damage: {:d}"
 msgstr "dégâts de flèches de feu: {:d}"
 
 #: Source/items.cpp:3589
-#, c-format
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "dégâts de flèches de feu: {:d}-{:d}"
 
 #: Source/items.cpp:3593
-#, c-format
 msgid "lightning arrows damage {:d}"
 msgstr "dégâts de flèches de foudre: {:d}"
 
 #: Source/items.cpp:3595
-#, c-format
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "dégâts de flèches de foudre: {:d}-{:d}"
 
 #: Source/items.cpp:3599
-#, c-format
 msgid "fireball damage: {:d}"
 msgstr "dégâts boule de feu: {:d}"
 
 #: Source/items.cpp:3601
-#, c-format
 msgid "fireball damage: {:d}-{:d}"
 msgstr "dégâts boule de feu: {:d}-{:d}"
 
@@ -3991,7 +3923,6 @@ msgid "knocks target back"
 msgstr "repousse la cible"
 
 #: Source/items.cpp:3619
-#, c-format
 msgid "+200% damage vs. demons"
 msgstr "+200% dégâts vs. démons"
 
@@ -4064,7 +3995,6 @@ msgid "fast block"
 msgstr "blocage rapide"
 
 #: Source/items.cpp:3664
-#, c-format
 msgid "adds {:d} points to damage"
 msgstr "ajoute {:d} points aux dégâts"
 
@@ -4110,12 +4040,10 @@ msgid " "
 msgstr ""
 
 #: Source/items.cpp:3698
-#, c-format
 msgid "lightning damage: {:d}"
 msgstr "dégâts de foudre: {:d}"
 
 #: Source/items.cpp:3700
-#, c-format
 msgid "lightning damage: {:d}-{:d}"
 msgstr "dégâts de foudre: {:d}-{:d}"
 
@@ -4128,7 +4056,6 @@ msgid "occasional triple damage"
 msgstr "triple dommage occasionnel"
 
 #: Source/items.cpp:3715
-#, c-format
 msgid "decaying {:+d}% damage"
 msgstr ""
 
@@ -4143,7 +4070,6 @@ msgid "Random 0 - 500% damage"
 msgstr "Dégâts 0-500% aléatoire"
 
 #: Source/items.cpp:3724
-#, c-format
 msgid "low dur, {:+d}% damage"
 msgstr ""
 
@@ -4209,63 +4135,51 @@ msgid "Required:"
 msgstr "Requis:"
 
 #: Source/items.cpp:3883 Source/stores.cpp:199
-#, c-format
 msgid " {:d} Str"
 msgstr " {:d} For"
 
 #: Source/items.cpp:3885 Source/stores.cpp:201
-#, c-format
 msgid " {:d} Mag"
 msgstr " {:d} Mag"
 
 #: Source/items.cpp:3887 Source/stores.cpp:203
-#, c-format
 msgid " {:d} Dex"
 msgstr " {:d} Dex"
 
 #: Source/items.cpp:3898 Source/items.cpp:3945
-#, c-format
 msgid "damage: {:d}  Indestructible"
 msgstr "dégâts: {:d}  Indestructible"
 
 #: Source/items.cpp:3900 Source/items.cpp:3947
-#, c-format
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "dégâts: {:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3903 Source/items.cpp:3950
-#, c-format
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "dégâts: {:d}-{:d}  Indestructible"
 
 #: Source/items.cpp:3905 Source/items.cpp:3952
-#, c-format
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "dégâts: {:d}-{:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3911 Source/items.cpp:3964
-#, c-format
 msgid "armor: {:d}  Indestructible"
 msgstr "armure: {:d} Indestructible"
 
 #: Source/items.cpp:3913 Source/items.cpp:3966
-#, c-format
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "armure: {:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3918
-#, c-format
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "deg: {:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3920
-#, c-format
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "deg: {:d}-{:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3921 Source/items.cpp:3956 Source/items.cpp:3971
 #: Source/stores.cpp:169
-#, c-format
 msgid "Charges: {:d}/{:d}"
 msgstr "Charges: {:d}/{:d}"
 
@@ -5176,17 +5090,14 @@ msgid "Undead"
 msgstr "Mort-vivant"
 
 #: Source/monster.cpp:4971
-#, c-format
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "Type: {:s}  Tués: {:d}"
 
 #: Source/monster.cpp:4973
-#, c-format
 msgid "Total kills: {:d}"
 msgstr "Total Victimes: {:d}"
 
 #: Source/monster.cpp:5006
-#, c-format
 msgid "Hit Points: {:d}-{:d}"
 msgstr "Points de vie:{:d}-{:d}"
 
@@ -5215,7 +5126,6 @@ msgid "Immune: "
 msgstr "Immunisé: "
 
 #: Source/monster.cpp:5051
-#, c-format
 msgid "Type: {:s}"
 msgstr "Type: {:s}"
 
@@ -5254,32 +5164,26 @@ msgstr ""
 #: Source/msg.cpp:1387 Source/msg.cpp:1658 Source/msg.cpp:1680
 #: Source/msg.cpp:1702 Source/msg.cpp:1822 Source/msg.cpp:1843
 #: Source/msg.cpp:1864 Source/msg.cpp:1885
-#, c-format
 msgid "{:s} has cast an illegal spell."
 msgstr ""
 
 #: Source/msg.cpp:2221 Source/multi.cpp:866
-#, c-format
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr ""
 
 #: Source/multi.cpp:269
-#, c-format
 msgid "Player '{:s}' just left the game"
 msgstr ""
 
 #: Source/multi.cpp:272
-#, c-format
 msgid "Player '{:s}' killed Diablo and left the game!"
 msgstr ""
 
 #: Source/multi.cpp:276
-#, c-format
 msgid "Player '{:s}' dropped due to timeout"
 msgstr ""
 
 #: Source/multi.cpp:868
-#, c-format
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr ""
 
@@ -5540,7 +5444,6 @@ msgid "Barrel"
 msgstr ""
 
 #: Source/objects.cpp:5537
-#, c-format
 msgid "{:s} Shrine"
 msgstr ""
 
@@ -5613,12 +5516,10 @@ msgid "Slain Hero"
 msgstr ""
 
 #: Source/objects.cpp:5606
-#, c-format
 msgid "Trapped {:s}"
 msgstr ""
 
 #: Source/objects.cpp:5612
-#, c-format
 msgid "{:s} (disabled)"
 msgstr ""
 
@@ -5643,7 +5544,6 @@ msgid "Unable to write to save file archive"
 msgstr ""
 
 #: Source/plrmsg.cpp:72
-#, c-format
 msgid "{:s} (lvl {:d}): {:s}"
 msgstr ""
 
@@ -5653,7 +5553,6 @@ msgid ""
 msgstr ""
 
 #: Source/qol/xpbar.cpp:122
-#, c-format
 msgid "Level {:d}"
 msgstr ""
 
@@ -5672,7 +5571,6 @@ msgid "Next Level: "
 msgstr ""
 
 #: Source/qol/xpbar.cpp:148
-#, c-format
 msgid " to Level {:d}"
 msgstr ""
 
@@ -5753,7 +5651,6 @@ msgid "Unholy Altar"
 msgstr ""
 
 #: Source/quests.cpp:284
-#, c-format
 msgid "To {:s}"
 msgstr ""
 
@@ -5958,17 +5855,14 @@ msgid ",  "
 msgstr ", "
 
 #: Source/stores.cpp:180
-#, c-format
 msgid "Damage: {:d}-{:d}  "
 msgstr "Dégâts: {:d}-{:d} "
 
 #: Source/stores.cpp:182
-#, c-format
 msgid "Armor: {:d}  "
 msgstr "Armure: {:d} "
 
 #: Source/stores.cpp:184
-#, c-format
 msgid "Dur: {:d}/{:d},  "
 msgstr "Dur: {:d}/{:d},  "
 
@@ -6019,7 +5913,6 @@ msgid "Leave the shop"
 msgstr "Quitter la boutique"
 
 #: Source/stores.cpp:274 Source/stores.cpp:623 Source/stores.cpp:989
-#, c-format
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "J'ai ces objets à vendre:             Votre or: {:d}"
 
@@ -6033,27 +5926,22 @@ msgid "Back"
 msgstr "Retour"
 
 #: Source/stores.cpp:339
-#, c-format
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "J'ai ces objets premim à vendre:             Votre or: {:d}"
 
 #: Source/stores.cpp:467 Source/stores.cpp:717
-#, c-format
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "Vous n'avez rien pour moi.             Votre or: {:d}"
 
 #: Source/stores.cpp:477 Source/stores.cpp:727
-#, c-format
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "Quel objet est à vendre?             Votre or: {:d}"
 
 #: Source/stores.cpp:537
-#, c-format
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "Vous n'avez rien à réparer.             Votre or: {:d}"
 
 #: Source/stores.cpp:549
-#, c-format
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "Réparer quel article?             Votre or: {:d}"
 
@@ -6078,12 +5966,10 @@ msgid "Leave the shack"
 msgstr "Quitter la cabane"
 
 #: Source/stores.cpp:793
-#, c-format
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "Vous n'avez rien à recharger.              Votre or: {:d}"
 
 #: Source/stores.cpp:803
-#, c-format
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "Recharger quel article?             Votre or: {:d}"
 
@@ -6149,7 +6035,6 @@ msgid "Say goodbye"
 msgstr "Dire aurevoir"
 
 #: Source/stores.cpp:915
-#, c-format
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "J'ai cet objet à vendre:             Votre or: {:d}"
 
@@ -6182,12 +6067,10 @@ msgid "Identify an item"
 msgstr "Identifier un objet"
 
 #: Source/stores.cpp:1090
-#, c-format
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "Vous n'avez rien à identifier.             Votre or: {:d}"
 
 #: Source/stores.cpp:1100
-#, c-format
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "Identifier quel article?             Votre or: {:d}"
 
@@ -6200,12 +6083,10 @@ msgid "Done"
 msgstr "Fait"
 
 #: Source/stores.cpp:1129
-#, c-format
 msgid "Talk to {:s}"
 msgstr "Parler à {:s}"
 
 #: Source/stores.cpp:1133
-#, c-format
 msgid "Talking to {:s}"
 msgstr "Parler à {:s}"
 
@@ -8702,7 +8583,6 @@ msgstr ""
 
 #: Source/trigs.cpp:397 Source/trigs.cpp:484 Source/trigs.cpp:536
 #: Source/trigs.cpp:635
-#, c-format
 msgid "Up to level {:d}"
 msgstr ""
 
@@ -8713,22 +8593,18 @@ msgstr ""
 
 #: Source/trigs.cpp:411 Source/trigs.cpp:496 Source/trigs.cpp:550
 #: Source/trigs.cpp:577 Source/trigs.cpp:648
-#, c-format
 msgid "Down to level {:d}"
 msgstr ""
 
 #: Source/trigs.cpp:424
-#, c-format
 msgid "Up to Crypt level {:d}"
 msgstr ""
 
 #: Source/trigs.cpp:440
-#, c-format
 msgid "Down to Crypt level {:d}"
 msgstr ""
 
 #: Source/trigs.cpp:563
-#, c-format
 msgid "Up to Nest level {:d}"
 msgstr ""
 
@@ -8737,7 +8613,6 @@ msgid "Down to Diablo"
 msgstr ""
 
 #: Source/trigs.cpp:718 Source/trigs.cpp:735 Source/trigs.cpp:752
-#, c-format
 msgid "Back to Level {:d}"
 msgstr ""
 

--- a/Translations/fr.po
+++ b/Translations/fr.po
@@ -838,7 +838,7 @@ msgstr ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "Le problème est survenu lors du chargement:\n"
-"% s"
+"%s"
 
 #: Source/appfat.cpp:146 Source/appfat.cpp:163
 msgid "Data File Error"
@@ -865,7 +865,7 @@ msgid ""
 "%s"
 msgstr ""
 "Impossible d'écrire dans l'emplacement:\n"
-"% s"
+"%s"
 
 #: Source/appfat.cpp:176
 msgid "Read-Only Directory Error"
@@ -6021,7 +6021,7 @@ msgstr "Quitter la boutique"
 #: Source/stores.cpp:274 Source/stores.cpp:623 Source/stores.cpp:989
 #, c-format
 msgid "I have these items for sale:             Your gold: %i"
-msgstr "J'ai ces objets à vendre:             Votre or:% i"
+msgstr "J'ai ces objets à vendre:             Votre or: %i"
 
 #: Source/stores.cpp:279 Source/stores.cpp:343 Source/stores.cpp:471
 #: Source/stores.cpp:482 Source/stores.cpp:541 Source/stores.cpp:554
@@ -6035,27 +6035,27 @@ msgstr "Retour"
 #: Source/stores.cpp:339
 #, c-format
 msgid "I have these premium items for sale:     Your gold: %i"
-msgstr "J'ai ces objets premim à vendre:             Votre or:% i"
+msgstr "J'ai ces objets premim à vendre:             Votre or: %i"
 
 #: Source/stores.cpp:467 Source/stores.cpp:717
 #, c-format
 msgid "You have nothing I want.             Your gold: %i"
-msgstr "Vous n'avez rien pour moi.             Votre or:% i"
+msgstr "Vous n'avez rien pour moi.             Votre or: %i"
 
 #: Source/stores.cpp:477 Source/stores.cpp:727
 #, c-format
 msgid "Which item is for sale?             Your gold: %i"
-msgstr "Quel objet est à vendre?             Votre or:% i"
+msgstr "Quel objet est à vendre?             Votre or: %i"
 
 #: Source/stores.cpp:537
 #, c-format
 msgid "You have nothing to repair.             Your gold: %i"
-msgstr "Vous n'avez rien à réparer.             Votre or:% i"
+msgstr "Vous n'avez rien à réparer.             Votre or: %i"
 
 #: Source/stores.cpp:549
 #, c-format
 msgid "Repair which item?             Your gold: %i"
-msgstr "Réparer quel article?             Votre or:% i"
+msgstr "Réparer quel article?             Votre or: %i"
 
 #: Source/stores.cpp:575
 msgid "Witch's shack"
@@ -6080,12 +6080,12 @@ msgstr "Quitter la cabane"
 #: Source/stores.cpp:793
 #, c-format
 msgid "You have nothing to recharge.             Your gold: %i"
-msgstr "Vous n'avez rien à recharger.              Votre or:% i"
+msgstr "Vous n'avez rien à recharger.              Votre or: %i"
 
 #: Source/stores.cpp:803
 #, c-format
 msgid "Recharge which item?             Your gold: %i"
-msgstr "Recharger quel article?             Votre or:% i"
+msgstr "Recharger quel article?             Votre or: %i"
 
 #: Source/stores.cpp:819
 msgid "You do not have enough gold"
@@ -6151,7 +6151,7 @@ msgstr "Dire aurevoir"
 #: Source/stores.cpp:915
 #, c-format
 msgid "I have this item for sale:             Your gold: %i"
-msgstr "J'ai cet objet à vendre:             Votre or:% i"
+msgstr "J'ai cet objet à vendre:             Votre or: %i"
 
 #: Source/stores.cpp:931
 msgid "Leave"
@@ -6184,12 +6184,12 @@ msgstr "Identifier un objet"
 #: Source/stores.cpp:1090
 #, c-format
 msgid "You have nothing to identify.             Your gold: %i"
-msgstr "Vous n'avez rien à identifier.             Votre or:% i"
+msgstr "Vous n'avez rien à identifier.             Votre or: %i"
 
 #: Source/stores.cpp:1100
 #, c-format
 msgid "Identify which item?             Your gold: %i"
-msgstr "Identifier quel article?             Votre or:% i"
+msgstr "Identifier quel article?             Votre or: %i"
 
 #: Source/stores.cpp:1117
 msgid "This item is:"

--- a/Translations/hr.po
+++ b/Translations/hr.po
@@ -444,8 +444,8 @@ msgstr "Igrajte sami sa sobom bez pristupa mreži."
 
 #: Source/DiabloUI/selconn.cpp:115
 #, c-format
-msgid "Players Supported: %d"
-msgstr "Podržano igrača: %d"
+msgid "Players Supported: {:d}"
+msgstr "Podržano igrača: {:d}"
 
 #: Source/DiabloUI/selgame.cpp:85 Source/DiabloUI/selgame.cpp:380
 msgid "Description:"
@@ -624,7 +624,7 @@ msgstr ""
 
 #: Source/DiabloUI/selgame.cpp:415
 #, c-format
-msgid "Your version %s does not match the host %d.%d.%d."
+msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:123
@@ -712,8 +712,8 @@ msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:345
 #, c-format
-msgid "Character already exists. Do you want to overwrite \"%s\"?"
-msgstr "Lik već postoji. Želite li prebrisati \"%s\"?"
+msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
+msgstr "Lik već postoji. Želite li prebrisati \"{:s}\"?"
 
 #: Source/DiabloUI/selhero.cpp:357
 msgid "Unable to create character."
@@ -761,9 +761,9 @@ msgstr "Obriši heroja jednog igrača"
 
 #: Source/DiabloUI/selhero.cpp:621
 #, fuzzy, c-format
-#| msgid "Are you sure you want to delete the character \"%s\"?"
-msgid "Are you sure you want to delete the character \"%s\"?"
-msgstr "Sigurno želite obrisati \"%s\" lik?"
+#| msgid "Are you sure you want to delete the character \"{:s}\"?"
+msgid "Are you sure you want to delete the character \"{:s}\"?"
+msgstr "Sigurno želite obrisati \"{:s}\" lik?"
 
 #: Source/DiabloUI/selyesno.cpp:61 Source/stores.cpp:888
 msgid "Yes"
@@ -786,13 +786,13 @@ msgstr "Greška"
 #: Source/appfat.cpp:117
 #, c-format
 msgid ""
-"%s\n"
+"{:s}\n"
 "\n"
-"The error occurred at: %s line %d"
+"The error occurred at: {:s} line {:d}"
 msgstr ""
-"%s\n"
+"{:s}\n"
 "\n"
-"Greška se dogodila na: %s redak %d"
+"Greška se dogodila na: {:s} redak {:d}"
 
 #: Source/appfat.cpp:137
 #, fuzzy, c-format
@@ -804,7 +804,7 @@ msgstr ""
 #| "68f049866b44688a7af65ba766bef75a\n"
 #| "\n"
 #| "The problem occurred when loading:\n"
-#| "%s"
+#| "{:s}"
 msgid ""
 "Unable to open a required file.\n"
 "\n"
@@ -813,7 +813,7 @@ msgid ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "The problem occurred when loading:\n"
-"%s"
+"{:s}"
 msgstr ""
 "Nemoguće otvaranje potrebne datoteke.\n"
 "\n"
@@ -823,12 +823,12 @@ msgstr ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "Došlo je do problema učitavanja:\n"
-"%s"
+"{:s}"
 
 #: Source/appfat.cpp:159
 #, fuzzy, c-format
 #| msgid ""
-#| "Unable to open %s.\n"
+#| "Unable to open {:s}.\n"
 #| "\n"
 #| "Make sure that it is in the game folder and that the file name is in all "
 #| "lowercase."
@@ -838,7 +838,7 @@ msgid ""
 "Make sure that it is in the game folder and that the file name is in all "
 "lowercase."
 msgstr ""
-"Nemoguće je otvoriti %s.\n"
+"Nemoguće je otvoriti {:s}.\n"
 "\n"
 "Provjerite nalazi li se u mapi igre i je li naziv datoteke u malim slovima."
 
@@ -846,10 +846,10 @@ msgstr ""
 #, c-format
 msgid ""
 "Unable to write to location:\n"
-"%s"
+"{:s}"
 msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
-"%s"
+"{:s}"
 
 #: Source/appfat.cpp:176
 msgid "Read-Only Directory Error"
@@ -925,22 +925,22 @@ msgstr ""
 
 #: Source/stores.cpp:169
 #, c-format
-msgid "Charges: %i/%i"
+msgid "Charges: {:d}/{:d}"
 msgstr ""
 
 #: Source/stores.cpp:180
 #, c-format
-msgid "Damage: %i-%i  "
+msgid "Damage: {:d}-{:d}  "
 msgstr ""
 
 #: Source/stores.cpp:182
 #, c-format
-msgid "Armor: %i  "
+msgid "Armor: {:d}  "
 msgstr ""
 
 #: Source/stores.cpp:184
 #, c-format
-msgid "Dur: %i/%i,  "
+msgid "Dur: {:d}/{:d},  "
 msgstr ""
 
 #: Source/stores.cpp:187
@@ -959,17 +959,17 @@ msgstr "Zahtjevi:"
 
 #: Source/stores.cpp:199
 #, c-format
-msgid " %i Str"
+msgid " {:d} Str"
 msgstr ""
 
 #: Source/stores.cpp:201
 #, c-format
-msgid " %i Mag"
+msgid " {:d} Mag"
 msgstr ""
 
 #: Source/stores.cpp:203
 #, c-format
-msgid " %i Dex"
+msgid " {:d} Dex"
 msgstr ""
 
 #: Source/stores.cpp:225 Source/stores.cpp:950 Source/stores.cpp:1172
@@ -1012,7 +1012,7 @@ msgstr ""
 
 #: Source/stores.cpp:274 Source/stores.cpp:623 Source/stores.cpp:989
 #, c-format
-msgid "I have these items for sale:             Your gold: %i"
+msgid "I have these items for sale:             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:279 Source/stores.cpp:343 Source/stores.cpp:471
@@ -1026,27 +1026,27 @@ msgstr ""
 
 #: Source/stores.cpp:339
 #, c-format
-msgid "I have these premium items for sale:     Your gold: %i"
+msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:467 Source/stores.cpp:717
 #, c-format
-msgid "You have nothing I want.             Your gold: %i"
+msgid "You have nothing I want.             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:477 Source/stores.cpp:727
 #, c-format
-msgid "Which item is for sale?             Your gold: %i"
+msgid "Which item is for sale?             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:537
 #, c-format
-msgid "You have nothing to repair.             Your gold: %i"
+msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:549
 #, c-format
-msgid "Repair which item?             Your gold: %i"
+msgid "Repair which item?             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:575
@@ -1071,12 +1071,12 @@ msgstr ""
 
 #: Source/stores.cpp:793
 #, c-format
-msgid "You have nothing to recharge.             Your gold: %i"
+msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:803
 #, c-format
-msgid "Recharge which item?             Your gold: %i"
+msgid "Recharge which item?             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:819
@@ -1093,33 +1093,33 @@ msgstr ""
 
 #: Source/stores.cpp:866
 #, fuzzy
-#| msgid "Are you sure you want to delete the character \"%s\"?"
+#| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to identify this item?"
-msgstr "Sigurno želite obrisati \"%s\" lik?"
+msgstr "Sigurno želite obrisati \"{:s}\" lik?"
 
 #: Source/stores.cpp:872
 #, fuzzy
-#| msgid "Are you sure you want to delete the character \"%s\"?"
+#| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to buy this item?"
-msgstr "Sigurno želite obrisati \"%s\" lik?"
+msgstr "Sigurno želite obrisati \"{:s}\" lik?"
 
 #: Source/stores.cpp:875
 #, fuzzy
-#| msgid "Are you sure you want to delete the character \"%s\"?"
+#| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to recharge this item?"
-msgstr "Sigurno želite obrisati \"%s\" lik?"
+msgstr "Sigurno želite obrisati \"{:s}\" lik?"
 
 #: Source/stores.cpp:879
 #, fuzzy
-#| msgid "Are you sure you want to delete the character \"%s\"?"
+#| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to sell this item?"
-msgstr "Sigurno želite obrisati \"%s\" lik?"
+msgstr "Sigurno želite obrisati \"{:s}\" lik?"
 
 #: Source/stores.cpp:882
 #, fuzzy
-#| msgid "Are you sure you want to delete the character \"%s\"?"
+#| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to repair this item?"
-msgstr "Sigurno želite obrisati \"%s\" lik?"
+msgstr "Sigurno želite obrisati \"{:s}\" lik?"
 
 #: Source/stores.cpp:896 Source/towners.cpp:319
 msgid "Wirt the Peg-legged boy"
@@ -1152,7 +1152,7 @@ msgstr ""
 
 #: Source/stores.cpp:915
 #, c-format
-msgid "I have this item for sale:             Your gold: %i"
+msgid "I have this item for sale:             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:931
@@ -1185,12 +1185,12 @@ msgstr ""
 
 #: Source/stores.cpp:1090
 #, c-format
-msgid "You have nothing to identify.             Your gold: %i"
+msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:1100
 #, c-format
-msgid "Identify which item?             Your gold: %i"
+msgid "Identify which item?             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:1117
@@ -1203,12 +1203,12 @@ msgstr ""
 
 #: Source/stores.cpp:1129
 #, c-format
-msgid "Talk to %s"
+msgid "Talk to {:s}"
 msgstr ""
 
 #: Source/stores.cpp:1133
 #, c-format
-msgid "Talking to %s"
+msgid "Talking to {:s}"
 msgstr ""
 
 #: Source/stores.cpp:1135

--- a/Translations/hr.po
+++ b/Translations/hr.po
@@ -443,7 +443,6 @@ msgid "Play by yourself with no network exposure."
 msgstr "Igrajte sami sa sobom bez pristupa mreži."
 
 #: Source/DiabloUI/selconn.cpp:115
-#, c-format
 msgid "Players Supported: {:d}"
 msgstr "Podržano igrača: {:d}"
 
@@ -623,7 +622,6 @@ msgid "The host is running a different game than you."
 msgstr ""
 
 #: Source/DiabloUI/selgame.cpp:415
-#, c-format
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr ""
 
@@ -711,7 +709,6 @@ msgstr ""
 "rezervirane riječi.\n"
 
 #: Source/DiabloUI/selhero.cpp:345
-#, c-format
 msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
 msgstr "Lik već postoji. Želite li prebrisati \"{:s}\"?"
 
@@ -784,7 +781,6 @@ msgid "Error"
 msgstr "Greška"
 
 #: Source/appfat.cpp:117
-#, c-format
 msgid ""
 "{:s}\n"
 "\n"
@@ -843,7 +839,6 @@ msgstr ""
 "Provjerite nalazi li se u mapi igre i je li naziv datoteke u malim slovima."
 
 #: Source/appfat.cpp:174
-#, c-format
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -924,22 +919,18 @@ msgid ",  "
 msgstr ""
 
 #: Source/stores.cpp:169
-#, c-format
 msgid "Charges: {:d}/{:d}"
 msgstr ""
 
 #: Source/stores.cpp:180
-#, c-format
 msgid "Damage: {:d}-{:d}  "
 msgstr ""
 
 #: Source/stores.cpp:182
-#, c-format
 msgid "Armor: {:d}  "
 msgstr ""
 
 #: Source/stores.cpp:184
-#, c-format
 msgid "Dur: {:d}/{:d},  "
 msgstr ""
 
@@ -958,17 +949,14 @@ msgid "Required:"
 msgstr "Zahtjevi:"
 
 #: Source/stores.cpp:199
-#, c-format
 msgid " {:d} Str"
 msgstr ""
 
 #: Source/stores.cpp:201
-#, c-format
 msgid " {:d} Mag"
 msgstr ""
 
 #: Source/stores.cpp:203
-#, c-format
 msgid " {:d} Dex"
 msgstr ""
 
@@ -1011,7 +999,6 @@ msgid "Leave the shop"
 msgstr ""
 
 #: Source/stores.cpp:274 Source/stores.cpp:623 Source/stores.cpp:989
-#, c-format
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr ""
 
@@ -1025,27 +1012,22 @@ msgid "Back"
 msgstr ""
 
 #: Source/stores.cpp:339
-#, c-format
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:467 Source/stores.cpp:717
-#, c-format
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:477 Source/stores.cpp:727
-#, c-format
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:537
-#, c-format
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:549
-#, c-format
 msgid "Repair which item?             Your gold: {:d}"
 msgstr ""
 
@@ -1070,12 +1052,10 @@ msgid "Leave the shack"
 msgstr ""
 
 #: Source/stores.cpp:793
-#, c-format
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:803
-#, c-format
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr ""
 
@@ -1151,7 +1131,6 @@ msgid "Say goodbye"
 msgstr ""
 
 #: Source/stores.cpp:915
-#, c-format
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr ""
 
@@ -1184,12 +1163,10 @@ msgid "Identify an item"
 msgstr ""
 
 #: Source/stores.cpp:1090
-#, c-format
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr ""
 
 #: Source/stores.cpp:1100
-#, c-format
 msgid "Identify which item?             Your gold: {:d}"
 msgstr ""
 
@@ -1202,12 +1179,10 @@ msgid "Done"
 msgstr ""
 
 #: Source/stores.cpp:1129
-#, c-format
 msgid "Talk to {:s}"
 msgstr ""
 
 #: Source/stores.cpp:1133
-#, c-format
 msgid "Talking to {:s}"
 msgstr ""
 

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -1037,12 +1037,12 @@ msgstr "Mana: {:d}   Dan: n/a"
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "Mana: {:d}  Dan: 1/3 tgt hp"
 
-#. TRANSLATORS: %u is a number. Dialog is shown when splitting a stash of Gold.
+#. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1685
-msgid "You have %u gold piece. How many do you want to remove?"
-msgid_plural "You have %u gold pieces. How many do you want to remove?"
-msgstr[0] "Possiedi %u moneta d'oro. Quante ne vuoi rimuovere?"
-msgstr[1] "Possiedi %u monete d'oro. Quante ne vuoi rimuovere?"
+msgid "You have {:d} gold piece. How many do you want to remove?"
+msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
+msgstr[0] "Possiedi {:d} moneta d'oro. Quante ne vuoi rimuovere?"
+msgstr[1] "Possiedi {:d} monete d'oro. Quante ne vuoi rimuovere?"
 
 #: Source/controls/modifier_hints.cpp:117
 msgid "Menu"

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -591,7 +591,7 @@ msgstr "L'host sta eseguendo un gioco diverso dal tuo."
 #: Source/DiabloUI/selgame.cpp:415
 #, c-format
 msgid "Your version %s does not match the host %i.%i.%i."
-msgstr "La tua versione %s non corrisponde all'host %i.% i.%i."
+msgstr "La tua versione %s non corrisponde all'host %i.%i.%i."
 
 #: Source/DiabloUI/selhero.cpp:123
 msgid "New Hero"

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -411,8 +411,8 @@ msgstr "Gioca da solo senza esporti sulla rete."
 
 #: Source/DiabloUI/selconn.cpp:115
 #, c-format
-msgid "Players Supported: %i"
-msgstr "Giocatori Supportati: %i"
+msgid "Players Supported: {:d}"
+msgstr "Giocatori Supportati: {:d}"
 
 #: Source/DiabloUI/selgame.cpp:85 Source/DiabloUI/selgame.cpp:380
 msgid "Description:"
@@ -590,8 +590,8 @@ msgstr "L'host sta eseguendo un gioco diverso dal tuo."
 #. TRANSLATORS: Error message when somebody tries to join a game running another version.
 #: Source/DiabloUI/selgame.cpp:415
 #, c-format
-msgid "Your version %s does not match the host %i.%i.%i."
-msgstr "La tua versione %s non corrisponde all'host %i.%i.%i."
+msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
+msgstr "La tua versione {:s} non corrisponde all'host {:d}.{:d}.{:d}."
 
 #: Source/DiabloUI/selhero.cpp:123
 msgid "New Hero"
@@ -672,8 +672,8 @@ msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:345
 #, c-format
-msgid "Character already exists. Do you want to overwrite \"%s\"?"
-msgstr "Personaggio esistente. Vuoi sovrascrivere \"%s\"?"
+msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
+msgstr "Personaggio esistente. Vuoi sovrascrivere \"{:s}\"?"
 
 #. TRANSLATORS: Error Message
 #: Source/DiabloUI/selhero.cpp:358
@@ -722,8 +722,8 @@ msgstr "Elimina Eroe Giocatore Singolo"
 
 #: Source/DiabloUI/selhero.cpp:622
 #, c-format
-msgid "Are you sure you want to delete the character \"%s\"?"
-msgstr "Sei sicuro di voler eliminare il personaggio \"%s\"?"
+msgid "Are you sure you want to delete the character \"{:s}\"?"
+msgstr "Sei sicuro di voler eliminare il personaggio \"{:s}\"?"
 
 #: Source/DiabloUI/selyesno.cpp:61 Source/stores.cpp:889
 msgid "Yes"
@@ -806,13 +806,13 @@ msgstr "Errore"
 #: Source/appfat.cpp:117
 #, c-format
 msgid ""
-"%s\n"
+"{:s}\n"
 "\n"
-"The error occurred at: %s line %i"
+"The error occurred at: {:s} line {:d}"
 msgstr ""
-"%s\n"
+"{:s}\n"
 "\n"
-"L'errore si è verificato alla linea: %s %i"
+"L'errore si è verificato alla linea: {:s} {:d}"
 
 #. TRANSLATORS: Error Message when diabdat.mpq is broken. Keep values unchanged.
 #: Source/appfat.cpp:137
@@ -825,7 +825,7 @@ msgid ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "The problem occurred when loading:\n"
-"%s"
+"{:s}"
 msgstr ""
 "Impossibile aprire un file necessario.\n"
 "\n"
@@ -834,7 +834,7 @@ msgstr ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "Si è verificato un problema nel caricamento di:\n"
-"%s"
+"{:s}"
 
 #: Source/appfat.cpp:146 Source/appfat.cpp:165
 msgid "Data File Error"
@@ -855,10 +855,10 @@ msgstr ""
 #, c-format
 msgid ""
 "Unable to write to location:\n"
-"%s"
+"{:s}"
 msgstr ""
 "Impossibile scrivere nella posizione:\n"
-"%s"
+"{:s}"
 
 #: Source/appfat.cpp:178
 msgid "Read-Only Directory Error"
@@ -874,18 +874,18 @@ msgstr "password: "
 
 #: Source/automap.cpp:405
 #, c-format
-msgid "Level: Nest %i"
-msgstr "Livello: Covo %i"
+msgid "Level: Nest {:d}"
+msgstr "Livello: Covo {:d}"
 
 #: Source/automap.cpp:407
 #, c-format
-msgid "Level: Crypt %i"
-msgstr "Livello: Cripta %i"
+msgid "Level: Crypt {:d}"
+msgstr "Livello: Cripta {:d}"
 
 #: Source/automap.cpp:409 Source/items.cpp:3793
 #, c-format
-msgid "Level: %i"
-msgstr "Liv. : %i"
+msgid "Level: {:d}"
+msgstr "Liv. : {:d}"
 
 #: Source/control.cpp:190
 msgid "Tab"
@@ -929,13 +929,13 @@ msgstr "Invia Messaggio"
 
 #: Source/control.cpp:394 Source/control.cpp:937
 #, c-format
-msgid "%s Skill"
-msgstr "%s Abilità"
+msgid "{:s} Skill"
+msgstr "{:s} Abilità"
 
 #: Source/control.cpp:397 Source/control.cpp:941
 #, c-format
-msgid "%s Spell"
-msgstr "%s Magia"
+msgid "{:s} Spell"
+msgstr "{:s} Magia"
 
 #: Source/control.cpp:399
 msgid "Damages undead only"
@@ -947,37 +947,37 @@ msgstr "Liv. Magia 0 - Inusabile"
 
 #: Source/control.cpp:405 Source/control.cpp:949 Source/control.cpp:1643
 #, c-format
-msgid "Spell Level %i"
-msgstr "Livello Magia %i"
+msgid "Spell Level {:d}"
+msgstr "Livello Magia {:d}"
 
 #: Source/control.cpp:409 Source/control.cpp:953
 #, c-format
-msgid "Scroll of %s"
-msgstr "Pergamena %s"
+msgid "Scroll of {:s}"
+msgstr "Pergamena {:s}"
 
 #: Source/control.cpp:425 Source/control.cpp:970
 #, c-format
-msgid "%i Scroll"
-msgid_plural "%i Scrolls"
-msgstr[0] "%i Pergamena"
-msgstr[1] "%i Pergamene"
+msgid "{:d} Scroll"
+msgid_plural "{:d} Scrolls"
+msgstr[0] "{:d} Pergamena"
+msgstr[1] "{:d} Pergamene"
 
 #: Source/control.cpp:429 Source/control.cpp:974 Source/items.cpp:1563
 #, c-format
-msgid "Staff of %s"
-msgstr "Verga di %s"
+msgid "Staff of {:s}"
+msgstr "Verga di {:s}"
 
 #: Source/control.cpp:431 Source/control.cpp:976
 #, c-format
-msgid "%i Charge"
-msgid_plural "%i Charges"
-msgstr[0] "%i Carica"
-msgstr[1] "%i Cariche"
+msgid "{:d} Charge"
+msgid_plural "{:d} Charges"
+msgstr[0] "{:d} Carica"
+msgstr[1] "{:d} Cariche"
 
 #: Source/control.cpp:441
 #, c-format
-msgid "Spell Hotkey %s"
-msgstr "Tasto Rapido %s"
+msgid "Spell Hotkey {:s}"
+msgstr "Tasto Rapido {:s}"
 
 #: Source/control.cpp:913
 msgid "Player friendly"
@@ -989,8 +989,8 @@ msgstr "Offensivo"
 
 #: Source/control.cpp:918
 #, c-format
-msgid "Hotkey: %s"
-msgstr "Tasto: %s"
+msgid "Hotkey: {:s}"
+msgstr "Tasto: {:s}"
 
 #: Source/control.cpp:927
 msgid "Select current spell button"
@@ -1002,10 +1002,10 @@ msgstr "Tasto: 's'"
 
 #: Source/control.cpp:1122 Source/inv.cpp:2051 Source/items.cpp:3031
 #, c-format
-msgid "%i gold piece"
-msgid_plural "%i gold pieces"
-msgstr[0] "%i moneta"
-msgstr[1] "%i monete"
+msgid "{:d} gold piece"
+msgid_plural "{:d} gold pieces"
+msgstr[0] "{:d} moneta"
+msgstr[1] "{:d} monete"
 
 #: Source/control.cpp:1125
 msgid "Requirements not met"
@@ -1013,13 +1013,13 @@ msgstr "Requisiti inadeguati"
 
 #: Source/control.cpp:1163
 #, c-format
-msgid "%s, Level: %i"
-msgstr "%s, Livello: %i"
+msgid "{:s}, Level: {:d}"
+msgstr "{:s}, Livello: {:d}"
 
 #: Source/control.cpp:1165
 #, c-format
-msgid "Hit Points %i of %i"
-msgstr "Punti Ferita %i di %i"
+msgid "Hit Points {:d} of {:d}"
+msgstr "Punti Ferita {:d} di {:d}"
 
 #: Source/control.cpp:1190
 msgid "None"
@@ -1040,28 +1040,28 @@ msgstr "Abilità"
 
 #: Source/control.cpp:1620
 #, c-format
-msgid "Staff (%i charge)"
-msgid_plural "Staff (%i charges)"
-msgstr[0] "Verga (%i carica)"
-msgstr[1] "Verga (%i cariche)"
+msgid "Staff ({:d} charge)"
+msgid_plural "Staff ({:d} charges)"
+msgstr[0] "Verga ({:d} carica)"
+msgstr[1] "Verga ({:d} cariche)"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
 #: Source/control.cpp:1628
 #, c-format
-msgid "Mana: %i  Dam: %i - %i"
-msgstr "Mana: %i  Dan: %i - %i"
+msgid "Mana: {:d}  Dam: {:d} - {:d}"
+msgstr "Mana: {:d}  Dan: {:d} - {:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
 #: Source/control.cpp:1630
 #, c-format
-msgid "Mana: %i   Dam: n/a"
-msgstr "Mana: %i   Dan: n/a"
+msgid "Mana: {:d}   Dam: n/a"
+msgstr "Mana: {:d}   Dan: n/a"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
 #: Source/control.cpp:1633
 #, c-format
-msgid "Mana: %i  Dam: 1/3 tgt hp"
-msgstr "Mana: %i  Dan: 1/3 tgt hp"
+msgid "Mana: {:d}  Dam: 1/3 tgt hp"
+msgstr "Mana: {:d}  Dan: 1/3 tgt hp"
 
 #. TRANSLATORS: %u is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1685
@@ -1101,8 +1101,8 @@ msgstr "Portale Cittadino"
 
 #: Source/cursor.cpp:206
 #, c-format
-msgid "from %s"
-msgstr "da %s"
+msgid "from {:s}"
+msgstr "da {:s}"
 
 #: Source/cursor.cpp:231
 msgid "Portal to"
@@ -1226,13 +1226,13 @@ msgstr ""
 
 #: Source/diablo.cpp:284
 #, c-format
-msgid "unrecognized option '%s'\n"
-msgstr "opzione sconosciuta '%s'\n"
+msgid "unrecognized option '{:s}'\n"
+msgstr "opzione sconosciuta '{:s}'\n"
 
 #: Source/diablo.cpp:672
 #, c-format
-msgid "version %s"
-msgstr "versione %s"
+msgid "version {:s}"
+msgstr "versione {:s}"
 
 #: Source/diablo.cpp:1917
 msgid "-- Network timeout --"
@@ -1250,11 +1250,11 @@ msgstr "Nessun aiuto disponibile"
 msgid "while in stores"
 msgstr "mentre nei negozi"
 
-#. TRANSLATORS: %s means: Character Name, Game Version, Game Difficulty.
+#. TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty.
 #: Source/diablo.cpp:2204
 #, c-format
-msgid "%s, version = %s, mode = %s"
-msgstr "%s, versione = %s, modalità = %s"
+msgid "{:s}, version = {:s}, mode = {:s}"
+msgstr "{:s}, versione = {:s}, modalità = {:s}"
 
 #: Source/dvlnet/loopback.cpp:113
 msgid "loopback"
@@ -2652,7 +2652,7 @@ msgstr "Cristallino"
 msgid "Doppelganger's"
 msgstr "del Sosia"
 
-#. TRANSLATORS: Item suffix section. All items will have a word binding word. (Format: %s of %s - e.g. Rags of Valor)
+#. TRANSLATORS: Item suffix section. All items will have a word binding word. (Format: {:s} of {:s} - e.g. Rags of Valor)
 #: Source/itemdat.cpp:288
 msgid "quality"
 msgstr "qualità"
@@ -3484,14 +3484,14 @@ msgstr "Olio dell'Impermeabilità"
 #: Source/items.cpp:1520 Source/items.cpp:1562 Source/items.cpp:2157
 #: Source/items.cpp:2176
 #, c-format
-msgid "%s of %s"
-msgstr "%s di %s"
+msgid "{:s} of {:s}"
+msgstr "{:s} di {:s}"
 
-#. TRANSLATORS: %s will be a Character Name
+#. TRANSLATORS: {:s} will be a Character Name
 #: Source/items.cpp:2740 Source/player.cpp:1887
 #, c-format
-msgid "Ear of %s"
-msgstr "Orecchio di %s"
+msgid "Ear of {:s}"
+msgstr "Orecchio di {:s}"
 
 #: Source/items.cpp:3259 Source/items.cpp:3271
 msgid "increases a weapon's"
@@ -3640,33 +3640,33 @@ msgstr "recupero totale vita e mana"
 
 #: Source/items.cpp:3408
 #, c-format
-msgid "chance to hit: %+i%%"
-msgstr "possibilità di colpire: %+i%%"
+msgid "chance to hit: {:+d}%"
+msgstr "possibilità di colpire: {:+d}%"
 
 #: Source/items.cpp:3412
 #, c-format
-msgid "%+i%% damage"
-msgstr "%+i%% danno"
+msgid "{:+d}% damage"
+msgstr "{:+d}% danno"
 
 #: Source/items.cpp:3416 Source/items.cpp:3674
 #, c-format
-msgid "to hit: %+i%%, %+i%% damage"
-msgstr "colpo: %+i%%, %+i%% danno"
+msgid "to hit: {:+d}%, {:+d}% damage"
+msgstr "colpo: {:+d}%, {:+d}% danno"
 
 #: Source/items.cpp:3420
 #, c-format
-msgid "%+i%% armor"
-msgstr "%+i%% armatura"
+msgid "{:+d}% armor"
+msgstr "{:+d}% armatura"
 
 #: Source/items.cpp:3423 Source/items.cpp:3426
 #, c-format
-msgid "armor class: %i"
-msgstr "classe armatura: %i"
+msgid "armor class: {:d}"
+msgstr "classe armatura: {:d}"
 
 #: Source/items.cpp:3431 Source/items.cpp:3656
 #, c-format
-msgid "Resist Fire: %+i%%"
-msgstr "Resistenza Fuoco: %+i%%"
+msgid "Resist Fire: {:+d}%"
+msgstr "Resistenza Fuoco: {:+d}%"
 
 #: Source/items.cpp:3433
 #, no-c-format
@@ -3675,8 +3675,8 @@ msgstr "Resistenza Fuoco: 75% MAX"
 
 #: Source/items.cpp:3438
 #, c-format
-msgid "Resist Lightning: %+i%%"
-msgstr "Resistenza Fulmine: %+i%%"
+msgid "Resist Lightning: {:+d}%"
+msgstr "Resistenza Fulmine: {:+d}%"
 
 #: Source/items.cpp:3440
 #, no-c-format
@@ -3685,8 +3685,8 @@ msgstr "Resistenza Fulmine: 75% MAX"
 
 #: Source/items.cpp:3445
 #, c-format
-msgid "Resist Magic: %+i%%"
-msgstr "Resistenza Magia: %+i%%"
+msgid "Resist Magic: {:+d}%"
+msgstr "Resistenza Magia: {:+d}%"
 
 #: Source/items.cpp:3447
 #, no-c-format
@@ -3695,8 +3695,8 @@ msgstr "Resistenza Magia: 75% MAX"
 
 #: Source/items.cpp:3452
 #, c-format
-msgid "Resist All: %+i%%"
-msgstr "Resistenza Tutto: %+i%%"
+msgid "Resist All: {:+d}%"
+msgstr "Resistenza Tutto: {:+d}%"
 
 #: Source/items.cpp:3454
 #, no-c-format
@@ -3705,17 +3705,17 @@ msgstr "Resistenza Tutto: 75% MAX"
 
 #: Source/items.cpp:3458
 #, c-format
-msgid "spells are increased %i level"
-msgid_plural "spells are increased %i levels"
-msgstr[0] "magie aumentate di %i livello"
-msgstr[1] "magie aumentate di %i livelli"
+msgid "spells are increased {:d} level"
+msgid_plural "spells are increased {:d} levels"
+msgstr[0] "magie aumentate di {:d} livello"
+msgstr[1] "magie aumentate di {:d} livelli"
 
 #: Source/items.cpp:3460
 #, c-format
-msgid "spells are decreased %i level"
-msgid_plural "spells are decreased %i levels"
-msgstr[0] "magie ridotte di %i livello"
-msgstr[1] "magie ridotte di %i livelli"
+msgid "spells are decreased {:d} level"
+msgid_plural "spells are decreased {:d} levels"
+msgstr[0] "magie ridotte di {:d} livello"
+msgstr[1] "magie ridotte di {:d} livelli"
 
 #: Source/items.cpp:3462
 msgid "spell levels unchanged (?)"
@@ -3727,70 +3727,70 @@ msgstr "Cariche extra"
 
 #: Source/items.cpp:3468
 #, c-format
-msgid "%i %s charge"
-msgid_plural "%i %s charges"
-msgstr[0] "%i %s carica"
-msgstr[1] "%i %s cariche"
+msgid "{:d} {:s} charge"
+msgid_plural "{:d} {:s} charges"
+msgstr[0] "{:d} {:s} carica"
+msgstr[1] "{:d} {:s} cariche"
 
 #: Source/items.cpp:3472
 #, c-format
-msgid "Fire hit damage: %i"
-msgstr "Danno fuoco: %i"
+msgid "Fire hit damage: {:d}"
+msgstr "Danno fuoco: {:d}"
 
 #: Source/items.cpp:3474
 #, c-format
-msgid "Fire hit damage: %i-%i"
-msgstr "Danno Fuoco: %i-%i"
+msgid "Fire hit damage: {:d}-{:d}"
+msgstr "Danno Fuoco: {:d}-{:d}"
 
 #: Source/items.cpp:3478
 #, c-format
-msgid "Lightning hit damage: %i"
-msgstr "Danno Fulmine : %i"
+msgid "Lightning hit damage: {:d}"
+msgstr "Danno Fulmine : {:d}"
 
 #: Source/items.cpp:3480
 #, c-format
-msgid "Lightning hit damage: %i-%i"
-msgstr "Danno Fulmine : %i-%i"
+msgid "Lightning hit damage: {:d}-{:d}"
+msgstr "Danno Fulmine : {:d}-{:d}"
 
 #: Source/items.cpp:3484
 #, c-format
-msgid "%+i to strength"
-msgstr "%+i alla Forza"
+msgid "{:+d} to strength"
+msgstr "{:+d} alla Forza"
 
 #: Source/items.cpp:3488
 #, c-format
-msgid "%+i to magic"
-msgstr "%+i di magia"
+msgid "{:+d} to magic"
+msgstr "{:+d} di magia"
 
 #: Source/items.cpp:3492
 #, c-format
-msgid "%+i to dexterity"
-msgstr "%+i di destrezza"
+msgid "{:+d} to dexterity"
+msgstr "{:+d} di destrezza"
 
 #: Source/items.cpp:3496
 #, c-format
-msgid "%+i to vitality"
-msgstr "%+i di vitalità"
+msgid "{:+d} to vitality"
+msgstr "{:+d} di vitalità"
 
 #: Source/items.cpp:3500
 #, c-format
-msgid "%+i to all attributes"
-msgstr "%+i a ogni attributo"
+msgid "{:+d} to all attributes"
+msgstr "{:+d} a ogni attributo"
 
 #: Source/items.cpp:3504
 #, c-format
-msgid "%+i damage from enemies"
-msgstr "%+i danno dai nemici"
+msgid "{:+d} damage from enemies"
+msgstr "{:+d} danno dai nemici"
 
 #: Source/items.cpp:3508
 #, c-format
-msgid "Hit Points: %+i"
-msgstr "Punti Ferita: %+i"
+msgid "Hit Points: {:+d}"
+msgstr "Punti Ferita: {:+d}"
 
 #: Source/items.cpp:3512
 #, c-format
-msgid "Mana: %+i"
-msgstr "Mana : %+i"
+msgid "Mana: {:+d}"
+msgstr "Mana : {:+d}"
 
 #: Source/items.cpp:3515
 msgid "high durability"
@@ -3806,13 +3806,13 @@ msgstr "indistruttibile"
 
 #: Source/items.cpp:3524
 #, c-format
-msgid "+%i%% light radius"
-msgstr "+%i%% bagliore"
+msgid "+{:d}%% light radius"
+msgstr "+{:d}%% bagliore"
 
 #: Source/items.cpp:3527
 #, c-format
-msgid "-%i%% light radius"
-msgstr "-%i%% bagliore"
+msgid "-{:d}%% light radius"
+msgstr "-{:d}%% bagliore"
 
 #: Source/items.cpp:3530
 msgid "multiple arrows per shot"
@@ -3820,33 +3820,33 @@ msgstr "frecce multiple per tiro"
 
 #: Source/items.cpp:3534
 #, c-format
-msgid "fire arrows damage: %i"
-msgstr "danno dardi infuocati: %i"
+msgid "fire arrows damage: {:d}"
+msgstr "danno dardi infuocati: {:d}"
 
 #: Source/items.cpp:3536
 #, c-format
-msgid "fire arrows damage: %i-%i"
-msgstr "danno dardi infuocati: %i-%i"
+msgid "fire arrows damage: {:d}-{:d}"
+msgstr "danno dardi infuocati: {:d}-{:d}"
 
 #: Source/items.cpp:3540
 #, c-format
-msgid "lightning arrows damage %i"
-msgstr "danno frecce fulminee: %i"
+msgid "lightning arrows damage {:d}"
+msgstr "danno frecce fulminee: {:d}"
 
 #: Source/items.cpp:3542
 #, c-format
-msgid "lightning arrows damage %i-%i"
-msgstr "danno frecce fulminee: %i-%i"
+msgid "lightning arrows damage {:d}-{:d}"
+msgstr "danno frecce fulminee: {:d}-{:d}"
 
 #: Source/items.cpp:3546
 #, c-format
-msgid "fireball damage: %i"
-msgstr "danno sfera infuocata: %i"
+msgid "fireball damage: {:d}"
+msgstr "danno sfera infuocata: {:d}"
 
 #: Source/items.cpp:3548
 #, c-format
-msgid "fireball damage: %i-%i"
-msgstr "danno sfera infuocata: %i-%i"
+msgid "fireball damage: {:d}-{:d}"
+msgstr "danno sfera infuocata: {:d}-{:d}"
 
 #: Source/items.cpp:3551
 msgid "attacker takes 1-3 damage"
@@ -3939,10 +3939,10 @@ msgstr "blocco veloce"
 
 #: Source/items.cpp:3611
 #, c-format
-msgid "adds %i point to damage"
-msgid_plural "adds %i points to damage"
-msgstr[0] "aggiunge %i punto al danno"
-msgstr[1] "aggiunge %i punti al danno"
+msgid "adds {:d} point to damage"
+msgid_plural "adds {:d} points to damage"
+msgstr[0] "aggiunge {:d} punto al danno"
+msgstr[1] "aggiunge {:d} punti al danno"
 
 #: Source/items.cpp:3614
 msgid "fires random speed arrows"
@@ -3982,13 +3982,13 @@ msgstr "usa infravisione"
 
 #: Source/items.cpp:3645
 #, c-format
-msgid "lightning damage: %i"
-msgstr "danno fulmineo: %i"
+msgid "lightning damage: {:d}"
+msgstr "danno fulmineo: {:d}"
 
 #: Source/items.cpp:3647
 #, c-format
-msgid "lightning damage: %i-%i"
-msgstr "danno fulmineo: %i-%i"
+msgid "lightning damage: {:d}-{:d}"
+msgstr "danno fulmineo: {:d}-{:d}"
 
 #: Source/items.cpp:3650
 msgid "charged bolts on hits"
@@ -4000,8 +4000,8 @@ msgstr "danno triplo occasionale"
 
 #: Source/items.cpp:3662
 #, c-format
-msgid "decaying %+i%% damage"
-msgstr "decadimento danno %+i%%"
+msgid "decaying {:+d}% damage"
+msgstr "decadimento danno {:+d}%"
 
 #: Source/items.cpp:3665
 msgid "2x dmg to monst, 1x to you"
@@ -4014,8 +4014,8 @@ msgstr "Danno casuale 0 - 500%"
 
 #: Source/items.cpp:3671
 #, c-format
-msgid "low dur, %+i%% damage"
-msgstr "dur ridotta, %+i%% danno"
+msgid "low dur, {:+d}% damage"
+msgstr "dur ridotta, {:+d}% danno"
 
 #: Source/items.cpp:3677
 msgid "extra AC vs demons"
@@ -4077,69 +4077,69 @@ msgstr "Richiede:"
 
 #: Source/items.cpp:3811 Source/stores.cpp:200
 #, c-format
-msgid " %i Str"
-msgstr " %i Frz"
+msgid " {:d} Str"
+msgstr " {:d} Frz"
 
 #: Source/items.cpp:3813 Source/stores.cpp:202
 #, c-format
-msgid " %i Mag"
-msgstr " %i Mag"
+msgid " {:d} Mag"
+msgstr " {:d} Mag"
 
 #: Source/items.cpp:3815 Source/stores.cpp:204
 #, c-format
-msgid " %i Dex"
-msgstr " %i Des"
+msgid " {:d} Dex"
+msgstr " {:d} Des"
 
 #: Source/items.cpp:3826 Source/items.cpp:3873
 #, c-format
-msgid "damage: %i  Indestructible"
-msgstr "danno: %i  Invulnerabile"
+msgid "damage: {:d}  Indestructible"
+msgstr "danno: {:d}  Invulnerabile"
 
 #. TRANSLATORS: Dur: is durability
 #: Source/items.cpp:3828 Source/items.cpp:3875
 #, c-format
-msgid "damage: %i  Dur: %i/%i"
-msgstr "danno: %i  Dur: %i/%i"
+msgid "damage: {:d}  Dur: {:d}/{:d}"
+msgstr "danno: {:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3831 Source/items.cpp:3878
 #, c-format
-msgid "damage: %i-%i  Indestructible"
-msgstr "danno: %i-%i  Indistruttibile"
+msgid "damage: {:d}-{:d}  Indestructible"
+msgstr "danno: {:d}-{:d}  Indistruttibile"
 
 #. TRANSLATORS: Dur: is durability
 #: Source/items.cpp:3833 Source/items.cpp:3880
 #, c-format
-msgid "damage: %i-%i  Dur: %i/%i"
-msgstr "danno: %i-%i  Dur: %i/%i"
+msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
+msgstr "danno: {:d}-{:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3839 Source/items.cpp:3892
 #, c-format
-msgid "armor: %i  Indestructible"
-msgstr "armatura: %i  Indistruttibile"
+msgid "armor: {:d}  Indestructible"
+msgstr "armatura: {:d}  Indistruttibile"
 
 #. TRANSLATORS: Dur: is durability
 #: Source/items.cpp:3841 Source/items.cpp:3894
 #, c-format
-msgid "armor: %i  Dur: %i/%i"
-msgstr "armatura: %i  Dur: %i/%i"
+msgid "armor: {:d}  Dur: {:d}/{:d}"
+msgstr "armatura: {:d}  Dur: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
 #: Source/items.cpp:3846
 #, c-format
-msgid "dam: %i  Dur: %i/%i"
-msgstr "dan: %i  Dur: %i/%i"
+msgid "dam: {:d}  Dur: {:d}/{:d}"
+msgstr "dan: {:d}  Dur: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
 #: Source/items.cpp:3848
 #, c-format
-msgid "dam: %i-%i  Dur: %i/%i"
-msgstr "dan: %i-%i  Dur: %i/%i"
+msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
+msgstr "dan: {:d}-{:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3849 Source/items.cpp:3884 Source/items.cpp:3899
 #: Source/stores.cpp:170
 #, c-format
-msgid "Charges: %i/%i"
-msgstr "Cariche: %i/%i"
+msgid "Charges: {:d}/{:d}"
+msgstr "Cariche: {:d}/{:d}"
 
 #: Source/items.cpp:3861
 msgid "unique item"
@@ -5050,18 +5050,18 @@ msgstr "Non morto"
 
 #: Source/monster.cpp:4966
 #, c-format
-msgid "Type: %s  Kills: %i"
-msgstr "Tipo: %s  Uccisioni: %i"
+msgid "Type: {:s}  Kills: {:d}"
+msgstr "Tipo: {:s}  Uccisioni: {:d}"
 
 #: Source/monster.cpp:4968
 #, c-format
-msgid "Total kills: %i"
-msgstr "Tot. uccisioni : %i"
+msgid "Total kills: {:d}"
+msgstr "Tot. uccisioni : {:d}"
 
 #: Source/monster.cpp:5001
 #, c-format
-msgid "Hit Points: %i-%i"
-msgstr "Punti Ferita: %i-%i"
+msgid "Hit Points: {:d}-{:d}"
+msgstr "Punti Ferita: {:d}-{:d}"
 
 #: Source/monster.cpp:5011
 msgid "No magic resistance"
@@ -5089,8 +5089,8 @@ msgstr "Immune: "
 
 #: Source/monster.cpp:5046
 #, c-format
-msgid "Type: %s"
-msgstr "Tipo: %s"
+msgid "Type: {:s}"
+msgstr "Tipo: {:s}"
 
 #: Source/monster.cpp:5052 Source/monster.cpp:5059
 msgid "No resistances"
@@ -5128,33 +5128,33 @@ msgstr "Abbandonare un oggetto a terra?"
 #: Source/msg.cpp:1709 Source/msg.cpp:1829 Source/msg.cpp:1850
 #: Source/msg.cpp:1871 Source/msg.cpp:1892
 #, c-format
-msgid "%s has cast an illegal spell."
-msgstr "%s ha usato magia illegale."
+msgid "{:s} has cast an illegal spell."
+msgstr "{:s} ha usato magia illegale."
 
 #: Source/msg.cpp:2228 Source/multi.cpp:859
 #, c-format
-msgid "Player '%s' (level %i) just joined the game"
-msgstr "'%s' (livello %i) si è unito alla partita"
+msgid "Player '{:s}' (level {:d}) just joined the game"
+msgstr "'{:s}' (livello {:d}) si è unito alla partita"
 
 #: Source/multi.cpp:262
 #, c-format
-msgid "Player '%s' just left the game"
-msgstr "'%s' ha abbandonato la partita"
+msgid "Player '{:s}' just left the game"
+msgstr "'{:s}' ha abbandonato la partita"
 
 #: Source/multi.cpp:265
 #, c-format
-msgid "Player '%s' killed Diablo and left the game!"
-msgstr "'%s' ha ucciso Diablo e ha lasciato la partita!"
+msgid "Player '{:s}' killed Diablo and left the game!"
+msgstr "'{:s}' ha ucciso Diablo e ha lasciato la partita!"
 
 #: Source/multi.cpp:269
 #, c-format
-msgid "Player '%s' dropped due to timeout"
-msgstr "'%s' disconnesso per timeout"
+msgid "Player '{:s}' dropped due to timeout"
+msgstr "'{:s}' disconnesso per timeout"
 
 #: Source/multi.cpp:861
 #, c-format
-msgid "Player '%s' (level %i) is already in the game"
-msgstr "'%s' (liv. %i) è già in partita"
+msgid "Player '{:s}' (level {:d}) is already in the game"
+msgstr "'{:s}' (liv. {:d}) è già in partita"
 
 #. TRANSLATORS: Shrine Name Block
 #: Source/objects.cpp:91
@@ -5430,11 +5430,11 @@ msgstr "Urna"
 msgid "Barrel"
 msgstr "Barile"
 
-#. TRANSLATORS: %s will be a name from the Shrine block above
+#. TRANSLATORS: {:s} will be a name from the Shrine block above
 #: Source/objects.cpp:5504
 #, c-format
-msgid "%s Shrine"
-msgstr "%s Santuario"
+msgid "{:s} Shrine"
+msgstr "{:s} Santuario"
 
 #: Source/objects.cpp:5508
 msgid "Skeleton Tome"
@@ -5504,17 +5504,17 @@ msgstr "Stallo del Vile"
 msgid "Slain Hero"
 msgstr "Eroe Ucciso"
 
-#. TRANSLATORS: %s will either be a chest or a door
+#. TRANSLATORS: {:s} will either be a chest or a door
 #: Source/objects.cpp:5573
 #, c-format
-msgid "Trapped %s"
-msgstr "Trappola %s"
+msgid "Trapped {:s}"
+msgstr "Trappola {:s}"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
 #: Source/objects.cpp:5579
 #, c-format
-msgid "%s (disabled)"
-msgstr "%s (disabilitato)"
+msgid "{:s} (disabled)"
+msgstr "{:s} (disabilitato)"
 
 #: Source/pfile.cpp:219
 msgid "Failed to open player archive for writing."
@@ -5536,11 +5536,11 @@ msgstr "Impossibile leggere archivio di salvataggio"
 msgid "Unable to write to save file archive"
 msgstr "Impossibile scrivere archivio di salvataggio"
 
-#. TRANSLATORS: Shown if player presses "v" button. %s is player name, %i is level, %s is location
+#. TRANSLATORS: Shown if player presses "v" button. {:s} is player name, {:d} is level, {:s} is location
 #: Source/plrmsg.cpp:73
 #, c-format
-msgid "%s (lvl %i): %s"
-msgstr "%s (liv %i): %s"
+msgid "{:s} (lvl {:d}): {:s}"
+msgstr "{:s} (liv {:d}): {:s}"
 
 #: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:52
 msgid ""
@@ -5554,8 +5554,8 @@ msgstr ""
 
 #: Source/qol/xpbar.cpp:124
 #, c-format
-msgid "Level %i"
-msgstr "Livello %i"
+msgid "Level {:d}"
+msgstr "Livello {:d}"
 
 #: Source/qol/xpbar.cpp:131 Source/qol/xpbar.cpp:142
 msgid "Experience: "
@@ -5571,8 +5571,8 @@ msgstr "Livello Successivo: "
 
 #: Source/qol/xpbar.cpp:150
 #, c-format
-msgid " to Level %i"
-msgstr " al Livello %i"
+msgid " to Level {:d}"
+msgstr " al Livello {:d}"
 
 #. TRANSLATORS: Quest Name Block
 #: Source/quests.cpp:41
@@ -5657,11 +5657,11 @@ msgstr "Un Tunnel Oscuro"
 msgid "Unholy Altar"
 msgstr "L'Empio Altare"
 
-#. TRANSLATORS: Used for Quest Portals. %s is a Map Name
+#. TRANSLATORS: Used for Quest Portals. {:s} is a Map Name
 #: Source/quests.cpp:282
 #, c-format
-msgid "To %s"
-msgstr "Verso %s"
+msgid "To {:s}"
+msgstr "Verso {:s}"
 
 #: Source/quests.cpp:729
 msgid "Quest Log"
@@ -5865,18 +5865,18 @@ msgstr ",  "
 
 #: Source/stores.cpp:181
 #, c-format
-msgid "Damage: %i-%i  "
-msgstr "Danno : %i-%i  "
+msgid "Damage: {:d}-{:d}  "
+msgstr "Danno : {:d}-{:d}  "
 
 #: Source/stores.cpp:183
 #, c-format
-msgid "Armor: %i  "
-msgstr "Armat: %i  "
+msgid "Armor: {:d}  "
+msgstr "Armat: {:d}  "
 
 #: Source/stores.cpp:185
 #, c-format
-msgid "Dur: %i/%i,  "
-msgstr "Dur: %i/%i,  "
+msgid "Dur: {:d}/{:d},  "
+msgstr "Dur: {:d}/{:d},  "
 
 #: Source/stores.cpp:188
 msgid "Indestructible,  "
@@ -5927,8 +5927,8 @@ msgstr "Lascia bottega"
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:275 Source/stores.cpp:624 Source/stores.cpp:990
 #, c-format
-msgid "I have these items for sale:             Your gold: %i"
-msgstr "Merce in vendita:             Monete : %i"
+msgid "I have these items for sale:             Your gold: {:d}"
+msgstr "Merce in vendita:             Monete : {:d}"
 
 #: Source/stores.cpp:280 Source/stores.cpp:344 Source/stores.cpp:472
 #: Source/stores.cpp:483 Source/stores.cpp:542 Source/stores.cpp:555
@@ -5942,32 +5942,32 @@ msgstr "Indietro"
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:340
 #, c-format
-msgid "I have these premium items for sale:     Your gold: %i"
-msgstr "Armi speciali in vendita:     Monete : %i"
+msgid "I have these premium items for sale:     Your gold: {:d}"
+msgstr "Armi speciali in vendita:     Monete : {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:468 Source/stores.cpp:718
 #, c-format
-msgid "You have nothing I want.             Your gold: %i"
-msgstr "Non mi interessa nulla.             Monete: %i"
+msgid "You have nothing I want.             Your gold: {:d}"
+msgstr "Non mi interessa nulla.             Monete: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:478 Source/stores.cpp:728
 #, c-format
-msgid "Which item is for sale?             Your gold: %i"
-msgstr "Cosa proponi in vendita?             Monete: %i"
+msgid "Which item is for sale?             Your gold: {:d}"
+msgstr "Cosa proponi in vendita?             Monete: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:538
 #, c-format
-msgid "You have nothing to repair.             Your gold: %i"
-msgstr "Nulla da riparare.             Monete: %i"
+msgid "You have nothing to repair.             Your gold: {:d}"
+msgstr "Nulla da riparare.             Monete: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:550
 #, c-format
-msgid "Repair which item?             Your gold: %i"
-msgstr "Cosa vuoi riparare?             Monete: %i"
+msgid "Repair which item?             Your gold: {:d}"
+msgstr "Cosa vuoi riparare?             Monete: {:d}"
 
 #: Source/stores.cpp:576
 msgid "Witch's shack"
@@ -5992,14 +5992,14 @@ msgstr "Lascia baracca"
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:794
 #, c-format
-msgid "You have nothing to recharge.             Your gold: %i"
-msgstr "Nulla da ricaricare.             Monete: %i"
+msgid "You have nothing to recharge.             Your gold: {:d}"
+msgstr "Nulla da ricaricare.             Monete: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:804
 #, c-format
-msgid "Recharge which item?             Your gold: %i"
-msgstr "Cosa vuoi ricaricare?             Monete: %i"
+msgid "Recharge which item?             Your gold: {:d}"
+msgstr "Cosa vuoi ricaricare?             Monete: {:d}"
 
 #: Source/stores.cpp:820
 msgid "You do not have enough gold"
@@ -6065,8 +6065,8 @@ msgstr "Saluta"
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:916
 #, c-format
-msgid "I have this item for sale:             Your gold: %i"
-msgstr "Oggetti in vendita:             Monete: %i"
+msgid "I have this item for sale:             Your gold: {:d}"
+msgstr "Oggetti in vendita:             Monete: {:d}"
 
 #: Source/stores.cpp:932
 msgid "Leave"
@@ -6099,14 +6099,14 @@ msgstr "Identifica oggetti"
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:1091
 #, c-format
-msgid "You have nothing to identify.             Your gold: %i"
-msgstr "Nulla da identificare.             Monete: %i"
+msgid "You have nothing to identify.             Your gold: {:d}"
+msgstr "Nulla da identificare.             Monete: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:1101
 #, c-format
-msgid "Identify which item?             Your gold: %i"
-msgstr "Cosa vuoi identificare?             Monete: %i"
+msgid "Identify which item?             Your gold: {:d}"
+msgstr "Cosa vuoi identificare?             Monete: {:d}"
 
 #: Source/stores.cpp:1118
 msgid "This item is:"
@@ -6118,13 +6118,13 @@ msgstr "Fatto"
 
 #: Source/stores.cpp:1130
 #, c-format
-msgid "Talk to %s"
-msgstr "Parla con %s"
+msgid "Talk to {:s}"
+msgstr "Parla con {:s}"
 
 #: Source/stores.cpp:1134
 #, c-format
-msgid "Talking to %s"
-msgstr "Parlare con %s"
+msgid "Talking to {:s}"
+msgstr "Parlare con {:s}"
 
 #: Source/stores.cpp:1136
 msgid "is not available"
@@ -10072,8 +10072,8 @@ msgstr "Giù all'Alveare"
 #: Source/trigs.cpp:397 Source/trigs.cpp:484 Source/trigs.cpp:536
 #: Source/trigs.cpp:635
 #, c-format
-msgid "Up to level %i"
-msgstr "Su al livello %i"
+msgid "Up to level {:d}"
+msgstr "Su al livello {:d}"
 
 #: Source/trigs.cpp:399 Source/trigs.cpp:458 Source/trigs.cpp:515
 #: Source/trigs.cpp:597 Source/trigs.cpp:615 Source/trigs.cpp:667
@@ -10083,23 +10083,23 @@ msgstr "Su in città"
 #: Source/trigs.cpp:411 Source/trigs.cpp:496 Source/trigs.cpp:550
 #: Source/trigs.cpp:577 Source/trigs.cpp:648
 #, c-format
-msgid "Down to level %i"
-msgstr "Giù al livello %i"
+msgid "Down to level {:d}"
+msgstr "Giù al livello {:d}"
 
 #: Source/trigs.cpp:424
 #, c-format
-msgid "Up to Crypt level %i"
-msgstr "Giù al livello della Cripta %i"
+msgid "Up to Crypt level {:d}"
+msgstr "Giù al livello della Cripta {:d}"
 
 #: Source/trigs.cpp:440
 #, c-format
-msgid "Down to Crypt level %i"
-msgstr "Giù al livello della Cripta %i"
+msgid "Down to Crypt level {:d}"
+msgstr "Giù al livello della Cripta {:d}"
 
 #: Source/trigs.cpp:563
 #, c-format
-msgid "Up to Nest level %i"
-msgstr "Su al livello del Covo %i"
+msgid "Up to Nest level {:d}"
+msgstr "Su al livello del Covo {:d}"
 
 #: Source/trigs.cpp:681
 msgid "Down to Diablo"
@@ -10107,5 +10107,5 @@ msgstr "Giù da Diablo"
 
 #: Source/trigs.cpp:718 Source/trigs.cpp:735 Source/trigs.cpp:752
 #, c-format
-msgid "Back to Level %i"
-msgstr "Torna al Livello %i"
+msgid "Back to Level {:d}"
+msgstr "Torna al Livello {:d}"

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -410,7 +410,6 @@ msgid "Play by yourself with no network exposure."
 msgstr "Gioca da solo senza esporti sulla rete."
 
 #: Source/DiabloUI/selconn.cpp:115
-#, c-format
 msgid "Players Supported: {:d}"
 msgstr "Giocatori Supportati: {:d}"
 
@@ -589,7 +588,6 @@ msgstr "L'host sta eseguendo un gioco diverso dal tuo."
 
 #. TRANSLATORS: Error message when somebody tries to join a game running another version.
 #: Source/DiabloUI/selgame.cpp:415
-#, c-format
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr "La tua versione {:s} non corrisponde all'host {:d}.{:d}.{:d}."
 
@@ -671,7 +669,6 @@ msgstr ""
 "speciali.\n"
 
 #: Source/DiabloUI/selhero.cpp:345
-#, c-format
 msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
 msgstr "Personaggio esistente. Vuoi sovrascrivere \"{:s}\"?"
 
@@ -721,7 +718,6 @@ msgid "Delete Single Player Hero"
 msgstr "Elimina Eroe Giocatore Singolo"
 
 #: Source/DiabloUI/selhero.cpp:622
-#, c-format
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "Sei sicuro di voler eliminare il personaggio \"{:s}\"?"
 
@@ -804,7 +800,6 @@ msgstr "Errore"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
 #: Source/appfat.cpp:117
-#, c-format
 msgid ""
 "{:s}\n"
 "\n"
@@ -816,7 +811,6 @@ msgstr ""
 
 #. TRANSLATORS: Error Message when diabdat.mpq is broken. Keep values unchanged.
 #: Source/appfat.cpp:137
-#, c-format
 msgid ""
 "Unable to open a required file.\n"
 "\n"
@@ -852,7 +846,6 @@ msgstr ""
 
 #. TRANSLATORS: Error when Program is not allowed to write data
 #: Source/appfat.cpp:176
-#, c-format
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -873,17 +866,14 @@ msgid "password: "
 msgstr "password: "
 
 #: Source/automap.cpp:405
-#, c-format
 msgid "Level: Nest {:d}"
 msgstr "Livello: Covo {:d}"
 
 #: Source/automap.cpp:407
-#, c-format
 msgid "Level: Crypt {:d}"
 msgstr "Livello: Cripta {:d}"
 
 #: Source/automap.cpp:409 Source/items.cpp:3793
-#, c-format
 msgid "Level: {:d}"
 msgstr "Liv. : {:d}"
 
@@ -928,12 +918,10 @@ msgid "Send Message"
 msgstr "Invia Messaggio"
 
 #: Source/control.cpp:394 Source/control.cpp:937
-#, c-format
 msgid "{:s} Skill"
 msgstr "{:s} Abilità"
 
 #: Source/control.cpp:397 Source/control.cpp:941
-#, c-format
 msgid "{:s} Spell"
 msgstr "{:s} Magia"
 
@@ -946,36 +934,30 @@ msgid "Spell Level 0 - Unusable"
 msgstr "Liv. Magia 0 - Inusabile"
 
 #: Source/control.cpp:405 Source/control.cpp:949 Source/control.cpp:1643
-#, c-format
 msgid "Spell Level {:d}"
 msgstr "Livello Magia {:d}"
 
 #: Source/control.cpp:409 Source/control.cpp:953
-#, c-format
 msgid "Scroll of {:s}"
 msgstr "Pergamena {:s}"
 
 #: Source/control.cpp:425 Source/control.cpp:970
-#, c-format
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "{:d} Pergamena"
 msgstr[1] "{:d} Pergamene"
 
 #: Source/control.cpp:429 Source/control.cpp:974 Source/items.cpp:1563
-#, c-format
 msgid "Staff of {:s}"
 msgstr "Verga di {:s}"
 
 #: Source/control.cpp:431 Source/control.cpp:976
-#, c-format
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "{:d} Carica"
 msgstr[1] "{:d} Cariche"
 
 #: Source/control.cpp:441
-#, c-format
 msgid "Spell Hotkey {:s}"
 msgstr "Tasto Rapido {:s}"
 
@@ -988,7 +970,6 @@ msgid "Player attack"
 msgstr "Offensivo"
 
 #: Source/control.cpp:918
-#, c-format
 msgid "Hotkey: {:s}"
 msgstr "Tasto: {:s}"
 
@@ -1001,7 +982,6 @@ msgid "Hotkey: 's'"
 msgstr "Tasto: 's'"
 
 #: Source/control.cpp:1122 Source/inv.cpp:2051 Source/items.cpp:3031
-#, c-format
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "{:d} moneta"
@@ -1012,12 +992,10 @@ msgid "Requirements not met"
 msgstr "Requisiti inadeguati"
 
 #: Source/control.cpp:1163
-#, c-format
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Livello: {:d}"
 
 #: Source/control.cpp:1165
-#, c-format
 msgid "Hit Points {:d} of {:d}"
 msgstr "Punti Ferita {:d} di {:d}"
 
@@ -1039,7 +1017,6 @@ msgid "Skill"
 msgstr "Abilità"
 
 #: Source/control.cpp:1620
-#, c-format
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] "Verga ({:d} carica)"
@@ -1047,25 +1024,21 @@ msgstr[1] "Verga ({:d} cariche)"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
 #: Source/control.cpp:1628
-#, c-format
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "Mana: {:d}  Dan: {:d} - {:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
 #: Source/control.cpp:1630
-#, c-format
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "Mana: {:d}   Dan: n/a"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
 #: Source/control.cpp:1633
-#, c-format
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "Mana: {:d}  Dan: 1/3 tgt hp"
 
 #. TRANSLATORS: %u is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1685
-#, c-format
 msgid "You have %u gold piece. How many do you want to remove?"
 msgid_plural "You have %u gold pieces. How many do you want to remove?"
 msgstr[0] "Possiedi %u moneta d'oro. Quante ne vuoi rimuovere?"
@@ -1100,7 +1073,6 @@ msgid "Town Portal"
 msgstr "Portale Cittadino"
 
 #: Source/cursor.cpp:206
-#, c-format
 msgid "from {:s}"
 msgstr "da {:s}"
 
@@ -1225,12 +1197,10 @@ msgstr ""
 "Segnala gli errori a https://github.com/diasurgical/devilutionX/\n"
 
 #: Source/diablo.cpp:284
-#, c-format
 msgid "unrecognized option '{:s}'\n"
 msgstr "opzione sconosciuta '{:s}'\n"
 
 #: Source/diablo.cpp:672
-#, c-format
 msgid "version {:s}"
 msgstr "versione {:s}"
 
@@ -1252,7 +1222,6 @@ msgstr "mentre nei negozi"
 
 #. TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty.
 #: Source/diablo.cpp:2204
-#, c-format
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr "{:s}, versione = {:s}, modalità = {:s}"
 
@@ -3483,13 +3452,11 @@ msgstr "Olio dell'Impermeabilità"
 #. TRANSLATORS: Constructs item names. Format: <Prefix> <Item> of <Suffix>. Example: King's Long Sword of the Whale
 #: Source/items.cpp:1520 Source/items.cpp:1562 Source/items.cpp:2157
 #: Source/items.cpp:2176
-#, c-format
 msgid "{:s} of {:s}"
 msgstr "{:s} di {:s}"
 
 #. TRANSLATORS: {:s} will be a Character Name
 #: Source/items.cpp:2740 Source/player.cpp:1887
-#, c-format
 msgid "Ear of {:s}"
 msgstr "Orecchio di {:s}"
 
@@ -3639,32 +3606,26 @@ msgid "fully recover life and mana"
 msgstr "recupero totale vita e mana"
 
 #: Source/items.cpp:3408
-#, c-format
 msgid "chance to hit: {:+d}%"
 msgstr "possibilità di colpire: {:+d}%"
 
 #: Source/items.cpp:3412
-#, c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% danno"
 
 #: Source/items.cpp:3416 Source/items.cpp:3674
-#, c-format
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "colpo: {:+d}%, {:+d}% danno"
 
 #: Source/items.cpp:3420
-#, c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% armatura"
 
 #: Source/items.cpp:3423 Source/items.cpp:3426
-#, c-format
 msgid "armor class: {:d}"
 msgstr "classe armatura: {:d}"
 
 #: Source/items.cpp:3431 Source/items.cpp:3656
-#, c-format
 msgid "Resist Fire: {:+d}%"
 msgstr "Resistenza Fuoco: {:+d}%"
 
@@ -3674,7 +3635,6 @@ msgid "Resist Fire: 75% MAX"
 msgstr "Resistenza Fuoco: 75% MAX"
 
 #: Source/items.cpp:3438
-#, c-format
 msgid "Resist Lightning: {:+d}%"
 msgstr "Resistenza Fulmine: {:+d}%"
 
@@ -3684,7 +3644,6 @@ msgid "Resist Lightning: 75% MAX"
 msgstr "Resistenza Fulmine: 75% MAX"
 
 #: Source/items.cpp:3445
-#, c-format
 msgid "Resist Magic: {:+d}%"
 msgstr "Resistenza Magia: {:+d}%"
 
@@ -3694,7 +3653,6 @@ msgid "Resist Magic: 75% MAX"
 msgstr "Resistenza Magia: 75% MAX"
 
 #: Source/items.cpp:3452
-#, c-format
 msgid "Resist All: {:+d}%"
 msgstr "Resistenza Tutto: {:+d}%"
 
@@ -3704,14 +3662,12 @@ msgid "Resist All: 75% MAX"
 msgstr "Resistenza Tutto: 75% MAX"
 
 #: Source/items.cpp:3458
-#, c-format
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] "magie aumentate di {:d} livello"
 msgstr[1] "magie aumentate di {:d} livelli"
 
 #: Source/items.cpp:3460
-#, c-format
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "magie ridotte di {:d} livello"
@@ -3726,69 +3682,56 @@ msgid "Extra charges"
 msgstr "Cariche extra"
 
 #: Source/items.cpp:3468
-#, c-format
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:d} {:s} carica"
 msgstr[1] "{:d} {:s} cariche"
 
 #: Source/items.cpp:3472
-#, c-format
 msgid "Fire hit damage: {:d}"
 msgstr "Danno fuoco: {:d}"
 
 #: Source/items.cpp:3474
-#, c-format
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "Danno Fuoco: {:d}-{:d}"
 
 #: Source/items.cpp:3478
-#, c-format
 msgid "Lightning hit damage: {:d}"
 msgstr "Danno Fulmine : {:d}"
 
 #: Source/items.cpp:3480
-#, c-format
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "Danno Fulmine : {:d}-{:d}"
 
 #: Source/items.cpp:3484
-#, c-format
 msgid "{:+d} to strength"
 msgstr "{:+d} alla Forza"
 
 #: Source/items.cpp:3488
-#, c-format
 msgid "{:+d} to magic"
 msgstr "{:+d} di magia"
 
 #: Source/items.cpp:3492
-#, c-format
 msgid "{:+d} to dexterity"
 msgstr "{:+d} di destrezza"
 
 #: Source/items.cpp:3496
-#, c-format
 msgid "{:+d} to vitality"
 msgstr "{:+d} di vitalità"
 
 #: Source/items.cpp:3500
-#, c-format
 msgid "{:+d} to all attributes"
 msgstr "{:+d} a ogni attributo"
 
 #: Source/items.cpp:3504
-#, c-format
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} danno dai nemici"
 
 #: Source/items.cpp:3508
-#, c-format
 msgid "Hit Points: {:+d}"
 msgstr "Punti Ferita: {:+d}"
 
 #: Source/items.cpp:3512
-#, c-format
 msgid "Mana: {:+d}"
 msgstr "Mana : {:+d}"
 
@@ -3805,12 +3748,10 @@ msgid "indestructible"
 msgstr "indistruttibile"
 
 #: Source/items.cpp:3524
-#, c-format
 msgid "+{:d}%% light radius"
 msgstr "+{:d}%% bagliore"
 
 #: Source/items.cpp:3527
-#, c-format
 msgid "-{:d}%% light radius"
 msgstr "-{:d}%% bagliore"
 
@@ -3819,32 +3760,26 @@ msgid "multiple arrows per shot"
 msgstr "frecce multiple per tiro"
 
 #: Source/items.cpp:3534
-#, c-format
 msgid "fire arrows damage: {:d}"
 msgstr "danno dardi infuocati: {:d}"
 
 #: Source/items.cpp:3536
-#, c-format
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "danno dardi infuocati: {:d}-{:d}"
 
 #: Source/items.cpp:3540
-#, c-format
 msgid "lightning arrows damage {:d}"
 msgstr "danno frecce fulminee: {:d}"
 
 #: Source/items.cpp:3542
-#, c-format
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "danno frecce fulminee: {:d}-{:d}"
 
 #: Source/items.cpp:3546
-#, c-format
 msgid "fireball damage: {:d}"
 msgstr "danno sfera infuocata: {:d}"
 
 #: Source/items.cpp:3548
-#, c-format
 msgid "fireball damage: {:d}-{:d}"
 msgstr "danno sfera infuocata: {:d}-{:d}"
 
@@ -3938,7 +3873,6 @@ msgid "fast block"
 msgstr "blocco veloce"
 
 #: Source/items.cpp:3611
-#, c-format
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] "aggiunge {:d} punto al danno"
@@ -3981,12 +3915,10 @@ msgid "see with infravision"
 msgstr "usa infravisione"
 
 #: Source/items.cpp:3645
-#, c-format
 msgid "lightning damage: {:d}"
 msgstr "danno fulmineo: {:d}"
 
 #: Source/items.cpp:3647
-#, c-format
 msgid "lightning damage: {:d}-{:d}"
 msgstr "danno fulmineo: {:d}-{:d}"
 
@@ -3999,7 +3931,6 @@ msgid "occasional triple damage"
 msgstr "danno triplo occasionale"
 
 #: Source/items.cpp:3662
-#, c-format
 msgid "decaying {:+d}% damage"
 msgstr "decadimento danno {:+d}%"
 
@@ -4013,7 +3944,6 @@ msgid "Random 0 - 500% damage"
 msgstr "Danno casuale 0 - 500%"
 
 #: Source/items.cpp:3671
-#, c-format
 msgid "low dur, {:+d}% damage"
 msgstr "dur ridotta, {:+d}% danno"
 
@@ -4076,68 +4006,56 @@ msgid "Required:"
 msgstr "Richiede:"
 
 #: Source/items.cpp:3811 Source/stores.cpp:200
-#, c-format
 msgid " {:d} Str"
 msgstr " {:d} Frz"
 
 #: Source/items.cpp:3813 Source/stores.cpp:202
-#, c-format
 msgid " {:d} Mag"
 msgstr " {:d} Mag"
 
 #: Source/items.cpp:3815 Source/stores.cpp:204
-#, c-format
 msgid " {:d} Dex"
 msgstr " {:d} Des"
 
 #: Source/items.cpp:3826 Source/items.cpp:3873
-#, c-format
 msgid "damage: {:d}  Indestructible"
 msgstr "danno: {:d}  Invulnerabile"
 
 #. TRANSLATORS: Dur: is durability
 #: Source/items.cpp:3828 Source/items.cpp:3875
-#, c-format
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "danno: {:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3831 Source/items.cpp:3878
-#, c-format
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "danno: {:d}-{:d}  Indistruttibile"
 
 #. TRANSLATORS: Dur: is durability
 #: Source/items.cpp:3833 Source/items.cpp:3880
-#, c-format
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "danno: {:d}-{:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3839 Source/items.cpp:3892
-#, c-format
 msgid "armor: {:d}  Indestructible"
 msgstr "armatura: {:d}  Indistruttibile"
 
 #. TRANSLATORS: Dur: is durability
 #: Source/items.cpp:3841 Source/items.cpp:3894
-#, c-format
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "armatura: {:d}  Dur: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
 #: Source/items.cpp:3846
-#, c-format
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "dan: {:d}  Dur: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
 #: Source/items.cpp:3848
-#, c-format
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "dan: {:d}-{:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3849 Source/items.cpp:3884 Source/items.cpp:3899
 #: Source/stores.cpp:170
-#, c-format
 msgid "Charges: {:d}/{:d}"
 msgstr "Cariche: {:d}/{:d}"
 
@@ -5049,17 +4967,14 @@ msgid "Undead"
 msgstr "Non morto"
 
 #: Source/monster.cpp:4966
-#, c-format
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "Tipo: {:s}  Uccisioni: {:d}"
 
 #: Source/monster.cpp:4968
-#, c-format
 msgid "Total kills: {:d}"
 msgstr "Tot. uccisioni : {:d}"
 
 #: Source/monster.cpp:5001
-#, c-format
 msgid "Hit Points: {:d}-{:d}"
 msgstr "Punti Ferita: {:d}-{:d}"
 
@@ -5088,7 +5003,6 @@ msgid "Immune: "
 msgstr "Immune: "
 
 #: Source/monster.cpp:5046
-#, c-format
 msgid "Type: {:s}"
 msgstr "Tipo: {:s}"
 
@@ -5127,32 +5041,26 @@ msgstr "Abbandonare un oggetto a terra?"
 #: Source/msg.cpp:1394 Source/msg.cpp:1665 Source/msg.cpp:1687
 #: Source/msg.cpp:1709 Source/msg.cpp:1829 Source/msg.cpp:1850
 #: Source/msg.cpp:1871 Source/msg.cpp:1892
-#, c-format
 msgid "{:s} has cast an illegal spell."
 msgstr "{:s} ha usato magia illegale."
 
 #: Source/msg.cpp:2228 Source/multi.cpp:859
-#, c-format
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr "'{:s}' (livello {:d}) si è unito alla partita"
 
 #: Source/multi.cpp:262
-#, c-format
 msgid "Player '{:s}' just left the game"
 msgstr "'{:s}' ha abbandonato la partita"
 
 #: Source/multi.cpp:265
-#, c-format
 msgid "Player '{:s}' killed Diablo and left the game!"
 msgstr "'{:s}' ha ucciso Diablo e ha lasciato la partita!"
 
 #: Source/multi.cpp:269
-#, c-format
 msgid "Player '{:s}' dropped due to timeout"
 msgstr "'{:s}' disconnesso per timeout"
 
 #: Source/multi.cpp:861
-#, c-format
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr "'{:s}' (liv. {:d}) è già in partita"
 
@@ -5432,7 +5340,6 @@ msgstr "Barile"
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
 #: Source/objects.cpp:5504
-#, c-format
 msgid "{:s} Shrine"
 msgstr "{:s} Santuario"
 
@@ -5506,13 +5413,11 @@ msgstr "Eroe Ucciso"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
 #: Source/objects.cpp:5573
-#, c-format
 msgid "Trapped {:s}"
 msgstr "Trappola {:s}"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
 #: Source/objects.cpp:5579
-#, c-format
 msgid "{:s} (disabled)"
 msgstr "{:s} (disabilitato)"
 
@@ -5538,7 +5443,6 @@ msgstr "Impossibile scrivere archivio di salvataggio"
 
 #. TRANSLATORS: Shown if player presses "v" button. {:s} is player name, {:d} is level, {:s} is location
 #: Source/plrmsg.cpp:73
-#, c-format
 msgid "{:s} (lvl {:d}): {:s}"
 msgstr "{:s} (liv {:d}): {:s}"
 
@@ -5553,7 +5457,6 @@ msgstr ""
 "Assicurati che devilutionx.mpq sia nella cartella di gioco e aggiornato."
 
 #: Source/qol/xpbar.cpp:124
-#, c-format
 msgid "Level {:d}"
 msgstr "Livello {:d}"
 
@@ -5570,7 +5473,6 @@ msgid "Next Level: "
 msgstr "Livello Successivo: "
 
 #: Source/qol/xpbar.cpp:150
-#, c-format
 msgid " to Level {:d}"
 msgstr " al Livello {:d}"
 
@@ -5659,7 +5561,6 @@ msgstr "L'Empio Altare"
 
 #. TRANSLATORS: Used for Quest Portals. {:s} is a Map Name
 #: Source/quests.cpp:282
-#, c-format
 msgid "To {:s}"
 msgstr "Verso {:s}"
 
@@ -5864,17 +5765,14 @@ msgid ",  "
 msgstr ",  "
 
 #: Source/stores.cpp:181
-#, c-format
 msgid "Damage: {:d}-{:d}  "
 msgstr "Danno : {:d}-{:d}  "
 
 #: Source/stores.cpp:183
-#, c-format
 msgid "Armor: {:d}  "
 msgstr "Armat: {:d}  "
 
 #: Source/stores.cpp:185
-#, c-format
 msgid "Dur: {:d}/{:d},  "
 msgstr "Dur: {:d}/{:d},  "
 
@@ -5926,7 +5824,6 @@ msgstr "Lascia bottega"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:275 Source/stores.cpp:624 Source/stores.cpp:990
-#, c-format
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "Merce in vendita:             Monete : {:d}"
 
@@ -5941,31 +5838,26 @@ msgstr "Indietro"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:340
-#, c-format
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "Armi speciali in vendita:     Monete : {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:468 Source/stores.cpp:718
-#, c-format
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "Non mi interessa nulla.             Monete: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:478 Source/stores.cpp:728
-#, c-format
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "Cosa proponi in vendita?             Monete: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:538
-#, c-format
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "Nulla da riparare.             Monete: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:550
-#, c-format
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "Cosa vuoi riparare?             Monete: {:d}"
 
@@ -5991,13 +5883,11 @@ msgstr "Lascia baracca"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:794
-#, c-format
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "Nulla da ricaricare.             Monete: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:804
-#, c-format
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "Cosa vuoi ricaricare?             Monete: {:d}"
 
@@ -6064,7 +5954,6 @@ msgstr "Saluta"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:916
-#, c-format
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "Oggetti in vendita:             Monete: {:d}"
 
@@ -6098,13 +5987,11 @@ msgstr "Identifica oggetti"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:1091
-#, c-format
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "Nulla da identificare.             Monete: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:1101
-#, c-format
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "Cosa vuoi identificare?             Monete: {:d}"
 
@@ -6117,12 +6004,10 @@ msgid "Done"
 msgstr "Fatto"
 
 #: Source/stores.cpp:1130
-#, c-format
 msgid "Talk to {:s}"
 msgstr "Parla con {:s}"
 
 #: Source/stores.cpp:1134
-#, c-format
 msgid "Talking to {:s}"
 msgstr "Parlare con {:s}"
 
@@ -10071,7 +9956,6 @@ msgstr "Giù all'Alveare"
 
 #: Source/trigs.cpp:397 Source/trigs.cpp:484 Source/trigs.cpp:536
 #: Source/trigs.cpp:635
-#, c-format
 msgid "Up to level {:d}"
 msgstr "Su al livello {:d}"
 
@@ -10082,22 +9966,18 @@ msgstr "Su in città"
 
 #: Source/trigs.cpp:411 Source/trigs.cpp:496 Source/trigs.cpp:550
 #: Source/trigs.cpp:577 Source/trigs.cpp:648
-#, c-format
 msgid "Down to level {:d}"
 msgstr "Giù al livello {:d}"
 
 #: Source/trigs.cpp:424
-#, c-format
 msgid "Up to Crypt level {:d}"
 msgstr "Giù al livello della Cripta {:d}"
 
 #: Source/trigs.cpp:440
-#, c-format
 msgid "Down to Crypt level {:d}"
 msgstr "Giù al livello della Cripta {:d}"
 
 #: Source/trigs.cpp:563
-#, c-format
 msgid "Up to Nest level {:d}"
 msgstr "Su al livello del Covo {:d}"
 
@@ -10106,6 +9986,5 @@ msgid "Down to Diablo"
 msgstr "Giù da Diablo"
 
 #: Source/trigs.cpp:718 Source/trigs.cpp:735 Source/trigs.cpp:752
-#, c-format
 msgid "Back to Level {:d}"
 msgstr "Torna al Livello {:d}"

--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -422,8 +422,8 @@ msgstr "Jogue sozinho sem exposição na rede."
 
 #: Source/DiabloUI/selconn.cpp:115
 #, c-format
-msgid "Players Supported: %d"
-msgstr "Jogadores suport.: %d"
+msgid "Players Supported: {:d}"
+msgstr "Jogadores suport.: {:d}"
 
 #: Source/DiabloUI/selgame.cpp:85 Source/DiabloUI/selgame.cpp:380
 msgid "Description:"
@@ -596,8 +596,8 @@ msgstr "O anfitrião está executando um jogo diferente de você."
 
 #: Source/DiabloUI/selgame.cpp:415
 #, c-format
-msgid "Your version %s does not match the host %d.%d.%d."
-msgstr "Sua versão %s não corresponde com a do anfitrião %d.%d.%d."
+msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
+msgstr "Sua versão {:s} não corresponde com a do anfitrião {:d}.{:d}.{:d}."
 
 #: Source/DiabloUI/selhero.cpp:123
 msgid "New Hero"
@@ -677,8 +677,8 @@ msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:345
 #, c-format
-msgid "Character already exists. Do you want to overwrite \"%s\"?"
-msgstr "O personagem já existe. Você deseja substituir \"%s\"?"
+msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
+msgstr "O personagem já existe. Você deseja substituir \"{:s}\"?"
 
 #: Source/DiabloUI/selhero.cpp:357
 msgid "Unable to create character."
@@ -726,8 +726,8 @@ msgstr "Apagar herói"
 
 #: Source/DiabloUI/selhero.cpp:621
 #, c-format
-msgid "Are you sure you want to delete the character \"%s\"?"
-msgstr "Tem certeza de que deseja apagar o personagem \"%s\"?"
+msgid "Are you sure you want to delete the character \"{:s}\"?"
+msgstr "Tem certeza de que deseja apagar o personagem \"{:s}\"?"
 
 #: Source/DiabloUI/selyesno.cpp:61 Source/stores.cpp:888
 msgid "Yes"
@@ -802,13 +802,13 @@ msgstr "Erro"
 #: Source/appfat.cpp:117
 #, c-format
 msgid ""
-"%s\n"
+"{:s}\n"
 "\n"
-"The error occurred at: %s line %d"
+"The error occurred at: {:s} line {:d}"
 msgstr ""
-"%s\n"
+"{:s}\n"
 "\n"
-"O erro ocorreu em: %s linha %d"
+"O erro ocorreu em: {:s} linha {:d}"
 
 #: Source/appfat.cpp:137
 #, c-format
@@ -820,7 +820,7 @@ msgid ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "The problem occurred when loading:\n"
-"%s"
+"{:s}"
 msgstr ""
 "Não foi possível abrir um arquivo necessário.\n"
 "\n"
@@ -829,7 +829,7 @@ msgstr ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "O problema ocorreu ao carregar:\n"
-"%s"
+"{:s}"
 
 #: Source/appfat.cpp:146 Source/appfat.cpp:164
 msgid "Data File Error"
@@ -852,10 +852,10 @@ msgstr ""
 #, c-format
 msgid ""
 "Unable to write to location:\n"
-"%s"
+"{:s}"
 msgstr ""
 "Não foi possível gravar no local:\n"
-"%s"
+"{:s}"
 
 #: Source/appfat.cpp:177
 msgid "Read-Only Directory Error"
@@ -871,18 +871,18 @@ msgstr "senha: "
 
 #: Source/automap.cpp:434 Source/items.cpp:3868
 #, c-format
-msgid "Level: %i"
-msgstr "Nível: %i"
+msgid "Level: {:d}"
+msgstr "Nível: {:d}"
 
 #: Source/automap.cpp:436
 #, c-format
-msgid "Level: Crypt %i"
-msgstr "Nível: Cripta %i"
+msgid "Level: Crypt {:d}"
+msgstr "Nível: Cripta {:d}"
 
 #: Source/automap.cpp:438
 #, c-format
-msgid "Level: Nest %i"
-msgstr "Nível: Enxame %i"
+msgid "Level: Nest {:d}"
+msgstr "Nível: Enxame {:d}"
 
 #: Source/control.cpp:239
 msgid "Tab"
@@ -926,13 +926,13 @@ msgstr "Enviar Mensagem"
 
 #: Source/control.cpp:432 Source/control.cpp:1029
 #, c-format
-msgid "%s Skill"
-msgstr "Habilidade de %s"
+msgid "{:s} Skill"
+msgstr "Habilidade de {:s}"
 
 #: Source/control.cpp:435 Source/control.cpp:1033
 #, c-format
-msgid "%s Spell"
-msgstr "Magia de %s"
+msgid "{:s} Spell"
+msgstr "Magia de {:s}"
 
 #: Source/control.cpp:437
 msgid "Damages undead only"
@@ -944,13 +944,13 @@ msgstr "Nível da magia 0 - Inutilizável"
 
 #: Source/control.cpp:443 Source/control.cpp:1041 Source/control.cpp:1867
 #, c-format
-msgid "Spell Level %i"
-msgstr "Nível do feitiço %i"
+msgid "Spell Level {:d}"
+msgstr "Nível do feitiço {:d}"
 
 #: Source/control.cpp:447 Source/control.cpp:1045
 #, c-format
-msgid "Scroll of %s"
-msgstr "Pergaminho de %s"
+msgid "Scroll of {:s}"
+msgstr "Pergaminho de {:s}"
 
 #: Source/control.cpp:464 Source/control.cpp:1063
 msgid "1 Scroll"
@@ -958,13 +958,13 @@ msgstr "1 Pergaminho"
 
 #: Source/control.cpp:466 Source/control.cpp:1065
 #, c-format
-msgid "%i Scrolls"
-msgstr "%i Pergaminhos"
+msgid "{:d} Scrolls"
+msgstr "{:d} Pergaminhos"
 
 #: Source/control.cpp:470 Source/control.cpp:1069 Source/items.cpp:1597
 #, c-format
-msgid "Staff of %s"
-msgstr "Cajado de %s"
+msgid "Staff of {:s}"
+msgstr "Cajado de {:s}"
 
 #: Source/control.cpp:472 Source/control.cpp:1072
 msgid "1 Charge"
@@ -972,13 +972,13 @@ msgstr "1 Carga"
 
 #: Source/control.cpp:474 Source/control.cpp:1074
 #, c-format
-msgid "%i Charges"
-msgstr "%i Cargas"
+msgid "{:d} Charges"
+msgstr "{:d} Cargas"
 
 #: Source/control.cpp:483
 #, c-format
-msgid "Spell Hotkey #F%i"
-msgstr "Tecla de atalho #F%i"
+msgid "Spell Hotkey #F{:d}"
+msgstr "Tecla de atalho #F{:d}"
 
 #: Source/control.cpp:1005
 msgid "Player friendly"
@@ -990,8 +990,8 @@ msgstr "Hostil a jogadores"
 
 #: Source/control.cpp:1010
 #, c-format
-msgid "Hotkey: %s"
-msgstr "Tecla de atalho: %s"
+msgid "Hotkey: {:s}"
+msgstr "Tecla de atalho: {:s}"
 
 #: Source/control.cpp:1019
 msgid "Select current spell button"
@@ -1003,11 +1003,11 @@ msgstr "Tecla de atalho: 's'"
 
 #: Source/control.cpp:1261
 #, fuzzy, c-format
-#| msgid "%i gold %s"
-msgid "%i gold piece"
-msgid_plural "%i gold pieces"
-msgstr[0] "%i %s de ouro"
-msgstr[1] "%i %s de ouro"
+#| msgid "{:d} gold {:s}"
+msgid "{:d} gold piece"
+msgid_plural "{:d} gold pieces"
+msgstr[0] "{:d} {:s} de ouro"
+msgstr[1] "{:d} {:s} de ouro"
 
 #: Source/control.cpp:1264
 msgid "Requirements not met"
@@ -1015,13 +1015,13 @@ msgstr "Pré-requisitos não atendidos"
 
 #: Source/control.cpp:1300
 #, c-format
-msgid "%s, Level: %i"
-msgstr "%s, Nível: %i"
+msgid "{:s}, Level: {:d}"
+msgstr "{:s}, Nível: {:d}"
 
 #: Source/control.cpp:1302
 #, c-format
-msgid "Hit Points %i of %i"
-msgstr "Pontos de vida %i de %i"
+msgid "Hit Points {:d} of {:d}"
+msgstr "Pontos de vida {:d} de {:d}"
 
 #: Source/control.cpp:1375
 msgid "None"
@@ -1041,23 +1041,23 @@ msgstr "Habilidade"
 
 #: Source/control.cpp:1844
 #, c-format
-msgid "Staff (%i charges)"
-msgstr "Cajado (%i cargas)"
+msgid "Staff ({:d} charges)"
+msgstr "Cajado ({:d} cargas)"
 
 #: Source/control.cpp:1852
 #, c-format
-msgid "Mana: %i  Dam: %i - %i"
-msgstr "Mana:%i  Dano:%i - %i"
+msgid "Mana: {:d}  Dam: {:d} - {:d}"
+msgstr "Mana:{:d}  Dano:{:d} - {:d}"
 
 #: Source/control.cpp:1854
 #, c-format
-msgid "Mana: %i   Dam: n/a"
-msgstr "Mana: %i   Dano: NA"
+msgid "Mana: {:d}   Dam: n/a"
+msgstr "Mana: {:d}   Dano: NA"
 
 #: Source/control.cpp:1857
 #, c-format
-msgid "Mana: %i  Dam: 1/3 tgt hp"
-msgstr "Mana: %i  Dano: 1/3 da vida do oponente"
+msgid "Mana: {:d}  Dam: 1/3 tgt hp"
+msgstr "Mana: {:d}  Dano: 1/3 da vida do oponente"
 
 #: Source/control.cpp:1904
 #, c-format
@@ -1066,11 +1066,11 @@ msgstr "Você tem %u peças de ouro"
 
 #: Source/control.cpp:1906
 #, fuzzy, c-format
-#| msgid "%s.  How many do"
+#| msgid "{:s}.  How many do"
 msgid "piece.  How many do"
 msgid_plural "pieces.  How many do"
-msgstr[0] "%s.  Quantos quer"
-msgstr[1] "%s.  Quantos quer"
+msgstr[0] "{:s}.  Quantos quer"
+msgstr[1] "{:s}.  Quantos quer"
 
 #: Source/control.cpp:1908
 msgid "you want to remove?"
@@ -1106,8 +1106,8 @@ msgstr "Portal da cidade"
 
 #: Source/cursor.cpp:182
 #, c-format
-msgid "from %s"
-msgstr "de %s"
+msgid "from {:s}"
+msgstr "de {:s}"
 
 #: Source/cursor.cpp:207
 msgid "Portal to"
@@ -1213,13 +1213,13 @@ msgstr ""
 
 #: Source/diablo.cpp:267
 #, c-format
-msgid "unrecognized option '%s'\n"
+msgid "unrecognized option '{:s}'\n"
 msgstr ""
 
 #: Source/diablo.cpp:649
 #, c-format
-msgid "version %s"
-msgstr "versão %s"
+msgid "version {:s}"
+msgstr "versão {:s}"
 
 #: Source/diablo.cpp:1172
 msgid "No help available"
@@ -1231,8 +1231,8 @@ msgstr "enquanto estiver em lojas"
 
 #: Source/diablo.cpp:1453
 #, c-format
-msgid "%s, mode = %s"
-msgstr "%s, modo = %s"
+msgid "{:s}, mode = {:s}"
+msgstr "{:s}, modo = {:s}"
 
 #: Source/diablo.cpp:2152
 msgid "-- Network timeout --"
@@ -1815,8 +1815,8 @@ msgstr "Não foi possível criar a janela principal"
 
 #: Source/inv.cpp:2117 Source/items.cpp:3079
 #, c-format
-msgid "%i gold %s"
-msgstr "%i %s de ouro"
+msgid "{:d} gold {:s}"
+msgstr "{:d} {:s} de ouro"
 
 #: Source/itemdat.cpp:16 Source/itemdat.cpp:197
 msgid "Gold"
@@ -3602,13 +3602,13 @@ msgstr ""
 #: Source/items.cpp:1554 Source/items.cpp:1595 Source/items.cpp:2188
 #: Source/items.cpp:2207
 #, c-format
-msgid "%s of %s"
-msgstr "%s de %s"
+msgid "{:s} of {:s}"
+msgstr "{:s} de {:s}"
 
 #: Source/items.cpp:2781 Source/player.cpp:1817
 #, c-format
-msgid "Ear of %s"
-msgstr "Orelha de %s"
+msgid "Ear of {:s}"
+msgstr "Orelha de {:s}"
 
 #: Source/items.cpp:3311 Source/items.cpp:3323
 msgid "increases a weapon's"
@@ -3757,33 +3757,33 @@ msgstr "recupera toda vida e mana"
 
 #: Source/items.cpp:3460
 #, c-format
-msgid "chance to hit: %+i%%"
-msgstr "chance de acerto: %+i%%"
+msgid "chance to hit: {:+d}%"
+msgstr "chance de acerto: {:+d}%"
 
 #: Source/items.cpp:3464
 #, c-format
-msgid "%+i%% damage"
-msgstr "%+i%% de dano"
+msgid "{:+d}% damage"
+msgstr "{:+d}% de dano"
 
 #: Source/items.cpp:3468 Source/items.cpp:3730
 #, c-format
-msgid "to hit: %+i%%, %+i%% damage"
-msgstr "acerto: %+i%%, %+i%% de dano"
+msgid "to hit: {:+d}%, {:+d}% damage"
+msgstr "acerto: {:+d}%, {:+d}% de dano"
 
 #: Source/items.cpp:3472
 #, c-format
-msgid "%+i%% armor"
-msgstr "%+i%% de armadura"
+msgid "{:+d}% armor"
+msgstr "{:+d}% de armadura"
 
 #: Source/items.cpp:3475 Source/items.cpp:3478
 #, c-format
-msgid "armor class: %i"
-msgstr "classe de armadura: %i"
+msgid "armor class: {:d}"
+msgstr "classe de armadura: {:d}"
 
 #: Source/items.cpp:3483 Source/items.cpp:3712
 #, c-format
-msgid "Resist Fire: %+i%%"
-msgstr "Resistência a fogo: %+i%%"
+msgid "Resist Fire: {:+d}%"
+msgstr "Resistência a fogo: {:+d}%"
 
 #: Source/items.cpp:3485
 msgid "Resist Fire: 75% MAX"
@@ -3791,8 +3791,8 @@ msgstr "Resiste a fogo:75% MÁX"
 
 #: Source/items.cpp:3490
 #, c-format
-msgid "Resist Lightning: %+i%%"
-msgstr "Resistência a raios: %+i%%"
+msgid "Resist Lightning: {:+d}%"
+msgstr "Resistência a raios: {:+d}%"
 
 #: Source/items.cpp:3492
 msgid "Resist Lightning: 75% MAX"
@@ -3800,8 +3800,8 @@ msgstr "Resiste a raios:75% MÁX"
 
 #: Source/items.cpp:3497
 #, c-format
-msgid "Resist Magic: %+i%%"
-msgstr "Resistência à magia: %+i%%"
+msgid "Resist Magic: {:+d}%"
+msgstr "Resistência à magia: {:+d}%"
 
 #: Source/items.cpp:3499
 msgid "Resist Magic: 75% MAX"
@@ -3809,8 +3809,8 @@ msgstr "Resiste a magia:75% MÁX"
 
 #: Source/items.cpp:3504
 #, c-format
-msgid "Resist All: %+i%%"
-msgstr "Resistência a tudo: %+i%%"
+msgid "Resist All: {:+d}%"
+msgstr "Resistência a tudo: {:+d}%"
 
 #: Source/items.cpp:3506
 msgid "Resist All: 75% MAX"
@@ -3822,8 +3822,8 @@ msgstr "feitiços aumentam 1 nível"
 
 #: Source/items.cpp:3512
 #, c-format
-msgid "spells are increased %i levels"
-msgstr "feitiços aumentam %i níveis"
+msgid "spells are increased {:d} levels"
+msgstr "feitiços aumentam {:d} níveis"
 
 #: Source/items.cpp:3514
 msgid "spells are decreased 1 level"
@@ -3831,8 +3831,8 @@ msgstr "feitiços diminuem 1 nível"
 
 #: Source/items.cpp:3516
 #, c-format
-msgid "spells are decreased %i levels"
-msgstr "feitiços diminuem %i níveis"
+msgid "spells are decreased {:d} levels"
+msgstr "feitiços diminuem {:d} níveis"
 
 #: Source/items.cpp:3518
 msgid "spell levels unchanged (?)"
@@ -3844,68 +3844,68 @@ msgstr "Cargas extra"
 
 #: Source/items.cpp:3524
 #, c-format
-msgid "%i %s charges"
-msgstr "%i %s cargas"
+msgid "{:d} {:s} charges"
+msgstr "{:d} {:s} cargas"
 
 #: Source/items.cpp:3528
 #, c-format
-msgid "Fire hit damage: %i"
-msgstr "Dano do acerto de fogo: %i"
+msgid "Fire hit damage: {:d}"
+msgstr "Dano do acerto de fogo: {:d}"
 
 #: Source/items.cpp:3530
 #, c-format
-msgid "Fire hit damage: %i-%i"
-msgstr "Dano do acerto de fogo: %i-%i"
+msgid "Fire hit damage: {:d}-{:d}"
+msgstr "Dano do acerto de fogo: {:d}-{:d}"
 
 #: Source/items.cpp:3534
 #, c-format
-msgid "Lightning hit damage: %i"
-msgstr "Dano do acerto de raios: %i"
+msgid "Lightning hit damage: {:d}"
+msgstr "Dano do acerto de raios: {:d}"
 
 #: Source/items.cpp:3536
 #, c-format
-msgid "Lightning hit damage: %i-%i"
-msgstr "Dano do acerto de raios: %i-%i"
+msgid "Lightning hit damage: {:d}-{:d}"
+msgstr "Dano do acerto de raios: {:d}-{:d}"
 
 #: Source/items.cpp:3540
 #, c-format
-msgid "%+i to strength"
-msgstr "%+i para força"
+msgid "{:+d} to strength"
+msgstr "{:+d} para força"
 
 #: Source/items.cpp:3544
 #, c-format
-msgid "%+i to magic"
-msgstr "%+i para magia"
+msgid "{:+d} to magic"
+msgstr "{:+d} para magia"
 
 #: Source/items.cpp:3548
 #, c-format
-msgid "%+i to dexterity"
-msgstr "%+i para destreza"
+msgid "{:+d} to dexterity"
+msgstr "{:+d} para destreza"
 
 #: Source/items.cpp:3552
 #, c-format
-msgid "%+i to vitality"
-msgstr "%+i para vitalidade"
+msgid "{:+d} to vitality"
+msgstr "{:+d} para vitalidade"
 
 #: Source/items.cpp:3556
 #, c-format
-msgid "%+i to all attributes"
-msgstr "%+i a todos os atributos"
+msgid "{:+d} to all attributes"
+msgstr "{:+d} a todos os atributos"
 
 #: Source/items.cpp:3560
 #, c-format
-msgid "%+i damage from enemies"
-msgstr "%+i de dano de inimigos"
+msgid "{:+d} damage from enemies"
+msgstr "{:+d} de dano de inimigos"
 
 #: Source/items.cpp:3564
 #, c-format
-msgid "Hit Points: %+i"
-msgstr "Pontos de vida: %+i"
+msgid "Hit Points: {:+d}"
+msgstr "Pontos de vida: {:+d}"
 
 #: Source/items.cpp:3568
 #, c-format
-msgid "Mana: %+i"
-msgstr "Mana: %+i"
+msgid "Mana: {:+d}"
+msgstr "Mana: {:+d}"
 
 #: Source/items.cpp:3571
 msgid "high durability"
@@ -3921,13 +3921,13 @@ msgstr "indestrutível"
 
 #: Source/items.cpp:3580
 #, c-format
-msgid "+%i%% light radius"
-msgstr "+%i%%  de alcance de visão"
+msgid "+{:d}%% light radius"
+msgstr "+{:d}%%  de alcance de visão"
 
 #: Source/items.cpp:3583
 #, c-format
-msgid "-%i%% light radius"
-msgstr "-%i%%  de alcance de visão"
+msgid "-{:d}%% light radius"
+msgstr "-{:d}%%  de alcance de visão"
 
 #: Source/items.cpp:3586
 msgid "multiple arrows per shot"
@@ -3935,33 +3935,33 @@ msgstr "várias flechas por tiro"
 
 #: Source/items.cpp:3590
 #, c-format
-msgid "fire arrows damage: %i"
-msgstr "dano das flechas de fogo: %i"
+msgid "fire arrows damage: {:d}"
+msgstr "dano das flechas de fogo: {:d}"
 
 #: Source/items.cpp:3592
 #, c-format
-msgid "fire arrows damage: %i-%i"
-msgstr "dano das flechas de fogo: %i-%i"
+msgid "fire arrows damage: {:d}-{:d}"
+msgstr "dano das flechas de fogo: {:d}-{:d}"
 
 #: Source/items.cpp:3596
 #, c-format
-msgid "lightning arrows damage %i"
-msgstr "flechas de raios %i"
+msgid "lightning arrows damage {:d}"
+msgstr "flechas de raios {:d}"
 
 #: Source/items.cpp:3598
 #, c-format
-msgid "lightning arrows damage %i-%i"
-msgstr "flechas de raios %i-%i"
+msgid "lightning arrows damage {:d}-{:d}"
+msgstr "flechas de raios {:d}-{:d}"
 
 #: Source/items.cpp:3602
 #, c-format
-msgid "fireball damage: %i"
-msgstr "dano das bolas de fogo: %i"
+msgid "fireball damage: {:d}"
+msgstr "dano das bolas de fogo: {:d}"
 
 #: Source/items.cpp:3604
 #, c-format
-msgid "fireball damage: %i-%i"
-msgstr "dano das bolas de fogo: %i-%i"
+msgid "fireball damage: {:d}-{:d}"
+msgstr "dano das bolas de fogo: {:d}-{:d}"
 
 #: Source/items.cpp:3607
 msgid "attacker takes 1-3 damage"
@@ -4054,8 +4054,8 @@ msgstr "bloqueio rápido"
 
 #: Source/items.cpp:3667
 #, c-format
-msgid "adds %i points to damage"
-msgstr "adiciona %i ao dano"
+msgid "adds {:d} points to damage"
+msgstr "adiciona {:d} ao dano"
 
 #: Source/items.cpp:3670
 msgid "fires random speed arrows"
@@ -4095,13 +4095,13 @@ msgstr "enxerga com infravisão"
 
 #: Source/items.cpp:3701
 #, c-format
-msgid "lightning damage: %i"
-msgstr "dano de raio: %i"
+msgid "lightning damage: {:d}"
+msgstr "dano de raio: {:d}"
 
 #: Source/items.cpp:3703
 #, c-format
-msgid "lightning damage: %i-%i"
-msgstr "dano de raio: %i-%i"
+msgid "lightning damage: {:d}-{:d}"
+msgstr "dano de raio: {:d}-{:d}"
 
 #: Source/items.cpp:3706
 msgid "charged bolts on hits"
@@ -4113,7 +4113,7 @@ msgstr ""
 
 #: Source/items.cpp:3718
 #, c-format
-msgid "decaying %+i%% damage"
+msgid "decaying {:+d}% damage"
 msgstr ""
 
 #: Source/items.cpp:3721
@@ -4127,7 +4127,7 @@ msgstr ""
 
 #: Source/items.cpp:3727
 #, c-format
-msgid "low dur, %+i%% damage"
+msgid "low dur, {:+d}% damage"
 msgstr ""
 
 #: Source/items.cpp:3733
@@ -4188,64 +4188,64 @@ msgstr "Requerido:"
 
 #: Source/items.cpp:3886 Source/stores.cpp:199
 #, c-format
-msgid " %i Str"
-msgstr " %i For."
+msgid " {:d} Str"
+msgstr " {:d} For."
 
 #: Source/items.cpp:3888 Source/stores.cpp:201
 #, c-format
-msgid " %i Mag"
-msgstr " %i Mag."
+msgid " {:d} Mag"
+msgstr " {:d} Mag."
 
 #: Source/items.cpp:3890 Source/stores.cpp:203
 #, c-format
-msgid " %i Dex"
-msgstr " %i Des."
+msgid " {:d} Dex"
+msgstr " {:d} Des."
 
 #: Source/items.cpp:3901 Source/items.cpp:3948
 #, c-format
-msgid "damage: %i  Indestructible"
-msgstr "dano: %i  Indestrutível"
+msgid "damage: {:d}  Indestructible"
+msgstr "dano: {:d}  Indestrutível"
 
 #: Source/items.cpp:3903 Source/items.cpp:3950
 #, c-format
-msgid "damage: %i  Dur: %i/%i"
-msgstr "dano: %i  Dur: %i/%i"
+msgid "damage: {:d}  Dur: {:d}/{:d}"
+msgstr "dano: {:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3906 Source/items.cpp:3953
 #, c-format
-msgid "damage: %i-%i  Indestructible"
-msgstr "dano: %i-%i  Indestrutível"
+msgid "damage: {:d}-{:d}  Indestructible"
+msgstr "dano: {:d}-{:d}  Indestrutível"
 
 #: Source/items.cpp:3908 Source/items.cpp:3955
 #, c-format
-msgid "damage: %i-%i  Dur: %i/%i"
-msgstr "dano: %i-%i  Dur: %i/%i"
+msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
+msgstr "dano: {:d}-{:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3914 Source/items.cpp:3967
 #, c-format
-msgid "armor: %i  Indestructible"
-msgstr "armadura: %i  Indestrutível"
+msgid "armor: {:d}  Indestructible"
+msgstr "armadura: {:d}  Indestrutível"
 
 #: Source/items.cpp:3916 Source/items.cpp:3969
 #, c-format
-msgid "armor: %i  Dur: %i/%i"
-msgstr "armadura: %i  Dur: %i/%i"
+msgid "armor: {:d}  Dur: {:d}/{:d}"
+msgstr "armadura: {:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3921
 #, c-format
-msgid "dam: %i  Dur: %i/%i"
-msgstr "dano: %i  Dur: %i/%i"
+msgid "dam: {:d}  Dur: {:d}/{:d}"
+msgstr "dano: {:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3923
 #, c-format
-msgid "dam: %i-%i  Dur: %i/%i"
-msgstr "dano: %i-%i  Dur: %i/%i"
+msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
+msgstr "dano: {:d}-{:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3924 Source/items.cpp:3959 Source/items.cpp:3974
 #: Source/stores.cpp:169
 #, c-format
-msgid "Charges: %i/%i"
-msgstr "Cargas: %i/%i"
+msgid "Charges: {:d}/{:d}"
+msgstr "Cargas: {:d}/{:d}"
 
 #: Source/items.cpp:3936
 msgid "unique item"
@@ -5153,18 +5153,18 @@ msgstr ""
 
 #: Source/monster.cpp:4969
 #, c-format
-msgid "Type: %s  Kills: %i"
-msgstr "Tipo: %s  Mortos: %i"
+msgid "Type: {:s}  Kills: {:d}"
+msgstr "Tipo: {:s}  Mortos: {:d}"
 
 #: Source/monster.cpp:4971
 #, c-format
-msgid "Total kills: %i"
-msgstr "Total de mortos: %i"
+msgid "Total kills: {:d}"
+msgstr "Total de mortos: {:d}"
 
 #: Source/monster.cpp:5004
 #, c-format
-msgid "Hit Points: %i-%i"
-msgstr "Pontos de vida: %i-%i"
+msgid "Hit Points: {:d}-{:d}"
+msgstr "Pontos de vida: {:d}-{:d}"
 
 #: Source/monster.cpp:5014
 msgid "No magic resistance"
@@ -5192,8 +5192,8 @@ msgstr "Imune a: "
 
 #: Source/monster.cpp:5049
 #, c-format
-msgid "Type: %s"
-msgstr "Tipo: %s"
+msgid "Type: {:s}"
+msgstr "Tipo: {:s}"
 
 #: Source/monster.cpp:5055 Source/monster.cpp:5062
 msgid "No resistances"
@@ -5231,33 +5231,33 @@ msgstr ""
 #: Source/msg.cpp:1702 Source/msg.cpp:1822 Source/msg.cpp:1843
 #: Source/msg.cpp:1864 Source/msg.cpp:1885
 #, c-format
-msgid "%s has cast an illegal spell."
+msgid "{:s} has cast an illegal spell."
 msgstr ""
 
 #: Source/msg.cpp:2221 Source/multi.cpp:866
 #, c-format
-msgid "Player '%s' (level %d) just joined the game"
-msgstr "Jogador '%s' (nível %d) acabou de entrar no jogo"
+msgid "Player '{:s}' (level {:d}) just joined the game"
+msgstr "Jogador '{:s}' (nível {:d}) acabou de entrar no jogo"
 
 #: Source/multi.cpp:269
 #, c-format
-msgid "Player '%s' just left the game"
-msgstr "Jogador '%s' acabou de sair do jogo"
+msgid "Player '{:s}' just left the game"
+msgstr "Jogador '{:s}' acabou de sair do jogo"
 
 #: Source/multi.cpp:272
 #, c-format
-msgid "Player '%s' killed Diablo and left the game!"
-msgstr "Jogador '%s' matou Diablo e saiu do jogo!"
+msgid "Player '{:s}' killed Diablo and left the game!"
+msgstr "Jogador '{:s}' matou Diablo e saiu do jogo!"
 
 #: Source/multi.cpp:276
 #, c-format
-msgid "Player '%s' dropped due to timeout"
-msgstr "Jogador '%s' caiu devido a tempo esgotado"
+msgid "Player '{:s}' dropped due to timeout"
+msgstr "Jogador '{:s}' caiu devido a tempo esgotado"
 
 #: Source/multi.cpp:868
 #, c-format
-msgid "Player '%s' (level %d) is already in the game"
-msgstr "Jogador '%s' (nível %d) já está no jogo"
+msgid "Player '{:s}' (level {:d}) is already in the game"
+msgstr "Jogador '{:s}' (nível {:d}) já está no jogo"
 
 #: Source/objects.cpp:90
 msgid "Mysterious"
@@ -5517,8 +5517,8 @@ msgstr "Barril"
 
 #: Source/objects.cpp:5544
 #, c-format
-msgid "%s Shrine"
-msgstr "Altar %s"
+msgid "{:s} Shrine"
+msgstr "Altar {:s}"
 
 #: Source/objects.cpp:5548
 msgid "Skeleton Tome"
@@ -5590,13 +5590,13 @@ msgstr "Herói assassinado"
 
 #: Source/objects.cpp:5613
 #, c-format
-msgid "Trapped %s"
-msgstr "%s aprisionado"
+msgid "Trapped {:s}"
+msgstr "{:s} aprisionado"
 
 #: Source/objects.cpp:5619
 #, c-format
-msgid "%s (disabled)"
-msgstr "%s (desativado)"
+msgid "{:s} (disabled)"
+msgstr "{:s} (desativado)"
 
 #: Source/pfile.cpp:217
 msgid "Failed to open player archive for writing."
@@ -5620,8 +5620,8 @@ msgstr ""
 
 #: Source/plrmsg.cpp:72
 #, c-format
-msgid "%s (lvl %d): %s"
-msgstr "%s (nvl %d): %s"
+msgid "{:s} (lvl {:d}): {:s}"
+msgstr "{:s} (nvl {:d}): {:s}"
 
 #: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:52
 msgid ""
@@ -5630,8 +5630,8 @@ msgstr ""
 
 #: Source/qol/xpbar.cpp:122
 #, c-format
-msgid "Level %d"
-msgstr "Nível %d"
+msgid "Level {:d}"
+msgstr "Nível {:d}"
 
 #: Source/qol/xpbar.cpp:129 Source/qol/xpbar.cpp:140
 msgid "Experience: "
@@ -5647,8 +5647,8 @@ msgstr "Próximo nível: "
 
 #: Source/qol/xpbar.cpp:148
 #, c-format
-msgid " to Level %d"
-msgstr " para o nível %d"
+msgid " to Level {:d}"
+msgstr " para o nível {:d}"
 
 #: Source/quests.cpp:39
 msgid "The Magic Rock"
@@ -5728,8 +5728,8 @@ msgstr "Altar profano"
 
 #: Source/quests.cpp:283
 #, c-format
-msgid "To %s"
-msgstr "Para %s"
+msgid "To {:s}"
+msgstr "Para {:s}"
 
 #: Source/quests.cpp:760
 msgid "Quest Log"
@@ -5933,18 +5933,18 @@ msgstr ",  "
 
 #: Source/stores.cpp:180
 #, c-format
-msgid "Damage: %i-%i  "
-msgstr "Dano: %i-%i  "
+msgid "Damage: {:d}-{:d}  "
+msgstr "Dano: {:d}-{:d}  "
 
 #: Source/stores.cpp:182
 #, c-format
-msgid "Armor: %i  "
-msgstr "Armadura: %i  "
+msgid "Armor: {:d}  "
+msgstr "Armadura: {:d}  "
 
 #: Source/stores.cpp:184
 #, c-format
-msgid "Dur: %i/%i,  "
-msgstr "Dur: %i/%i,  "
+msgid "Dur: {:d}/{:d},  "
+msgstr "Dur: {:d}/{:d},  "
 
 #: Source/stores.cpp:187
 msgid "Indestructible,  "
@@ -5994,8 +5994,8 @@ msgstr "Sair da loja"
 
 #: Source/stores.cpp:274 Source/stores.cpp:623 Source/stores.cpp:989
 #, c-format
-msgid "I have these items for sale:             Your gold: %i"
-msgstr "Eu tenho estes itens para vender:             Seu ouro: %i"
+msgid "I have these items for sale:             Your gold: {:d}"
+msgstr "Eu tenho estes itens para vender:             Seu ouro: {:d}"
 
 #: Source/stores.cpp:279 Source/stores.cpp:343 Source/stores.cpp:471
 #: Source/stores.cpp:482 Source/stores.cpp:541 Source/stores.cpp:554
@@ -6008,28 +6008,28 @@ msgstr "Voltar"
 
 #: Source/stores.cpp:339
 #, c-format
-msgid "I have these premium items for sale:     Your gold: %i"
-msgstr "Eu tenho estes itens especiais para vender:     Seu ouro: %i"
+msgid "I have these premium items for sale:     Your gold: {:d}"
+msgstr "Eu tenho estes itens especiais para vender:     Seu ouro: {:d}"
 
 #: Source/stores.cpp:467 Source/stores.cpp:717
 #, c-format
-msgid "You have nothing I want.             Your gold: %i"
-msgstr "Você não tem nada que eu queira.             Seu ouro: %i"
+msgid "You have nothing I want.             Your gold: {:d}"
+msgstr "Você não tem nada que eu queira.             Seu ouro: {:d}"
 
 #: Source/stores.cpp:477 Source/stores.cpp:727
 #, c-format
-msgid "Which item is for sale?             Your gold: %i"
-msgstr "Qual item está à venda?             Seu ouro: %i"
+msgid "Which item is for sale?             Your gold: {:d}"
+msgstr "Qual item está à venda?             Seu ouro: {:d}"
 
 #: Source/stores.cpp:537
 #, c-format
-msgid "You have nothing to repair.             Your gold: %i"
-msgstr "Você não tem nada para reparar.             Seu ouro: %i"
+msgid "You have nothing to repair.             Your gold: {:d}"
+msgstr "Você não tem nada para reparar.             Seu ouro: {:d}"
 
 #: Source/stores.cpp:549
 #, c-format
-msgid "Repair which item?             Your gold: %i"
-msgstr "Reparar qual item?             Seu ouro: %i"
+msgid "Repair which item?             Your gold: {:d}"
+msgstr "Reparar qual item?             Seu ouro: {:d}"
 
 #: Source/stores.cpp:575
 msgid "Witch's shack"
@@ -6053,13 +6053,13 @@ msgstr "Sair da cabana"
 
 #: Source/stores.cpp:793
 #, c-format
-msgid "You have nothing to recharge.             Your gold: %i"
-msgstr "Você não tem nada para recarregar.             Seu ouro: %i"
+msgid "You have nothing to recharge.             Your gold: {:d}"
+msgstr "Você não tem nada para recarregar.             Seu ouro: {:d}"
 
 #: Source/stores.cpp:803
 #, c-format
-msgid "Recharge which item?             Your gold: %i"
-msgstr "Recarregar qual item?             Seu ouro: %i"
+msgid "Recharge which item?             Your gold: {:d}"
+msgstr "Recarregar qual item?             Seu ouro: {:d}"
 
 #: Source/stores.cpp:819
 msgid "You do not have enough gold"
@@ -6124,8 +6124,8 @@ msgstr "Dizer adeus"
 
 #: Source/stores.cpp:915
 #, c-format
-msgid "I have this item for sale:             Your gold: %i"
-msgstr "Eu tenho este item para vender:             Seu ouro: %i"
+msgid "I have this item for sale:             Your gold: {:d}"
+msgstr "Eu tenho este item para vender:             Seu ouro: {:d}"
 
 #: Source/stores.cpp:931
 msgid "Leave"
@@ -6157,13 +6157,13 @@ msgstr "Identificar um item"
 
 #: Source/stores.cpp:1090
 #, c-format
-msgid "You have nothing to identify.             Your gold: %i"
-msgstr "Você não tem nada para identificar.             Seu ouro: %i"
+msgid "You have nothing to identify.             Your gold: {:d}"
+msgstr "Você não tem nada para identificar.             Seu ouro: {:d}"
 
 #: Source/stores.cpp:1100
 #, c-format
-msgid "Identify which item?             Your gold: %i"
-msgstr "Identificar qual item?             Seu ouro: %i"
+msgid "Identify which item?             Your gold: {:d}"
+msgstr "Identificar qual item?             Seu ouro: {:d}"
 
 #: Source/stores.cpp:1117
 msgid "This item is:"
@@ -6175,13 +6175,13 @@ msgstr "Pronto"
 
 #: Source/stores.cpp:1129
 #, c-format
-msgid "Talk to %s"
-msgstr "Falar com %s"
+msgid "Talk to {:s}"
+msgstr "Falar com {:s}"
 
 #: Source/stores.cpp:1133
 #, c-format
-msgid "Talking to %s"
-msgstr "Falar com %s"
+msgid "Talking to {:s}"
+msgstr "Falar com {:s}"
 
 #: Source/stores.cpp:1135
 msgid "is not available"
@@ -9688,8 +9688,8 @@ msgstr ""
 #: Source/trigs.cpp:397 Source/trigs.cpp:484 Source/trigs.cpp:536
 #: Source/trigs.cpp:635
 #, c-format
-msgid "Up to level %i"
-msgstr "Subir para o nível %i"
+msgid "Up to level {:d}"
+msgstr "Subir para o nível {:d}"
 
 #: Source/trigs.cpp:399 Source/trigs.cpp:458 Source/trigs.cpp:515
 #: Source/trigs.cpp:597 Source/trigs.cpp:615 Source/trigs.cpp:667
@@ -9699,22 +9699,22 @@ msgstr "Subir para a cidade"
 #: Source/trigs.cpp:411 Source/trigs.cpp:496 Source/trigs.cpp:550
 #: Source/trigs.cpp:577 Source/trigs.cpp:648
 #, c-format
-msgid "Down to level %i"
-msgstr "Descer para o nível %i"
+msgid "Down to level {:d}"
+msgstr "Descer para o nível {:d}"
 
 #: Source/trigs.cpp:424
 #, c-format
-msgid "Up to Crypt level %i"
-msgstr "Subir para o nível %i da cripta"
+msgid "Up to Crypt level {:d}"
+msgstr "Subir para o nível {:d} da cripta"
 
 #: Source/trigs.cpp:440
 #, c-format
-msgid "Down to Crypt level %i"
-msgstr "Descer para o nível %i da cripta"
+msgid "Down to Crypt level {:d}"
+msgstr "Descer para o nível {:d} da cripta"
 
 #: Source/trigs.cpp:563
 #, c-format
-msgid "Up to Nest level %i"
+msgid "Up to Nest level {:d}"
 msgstr ""
 
 #: Source/trigs.cpp:681
@@ -9723,8 +9723,8 @@ msgstr "Descer para Diablo"
 
 #: Source/trigs.cpp:718 Source/trigs.cpp:735 Source/trigs.cpp:752
 #, c-format
-msgid "Back to Level %i"
-msgstr "Voltar ao Nível %i"
+msgid "Back to Level {:d}"
+msgstr "Voltar ao Nível {:d}"
 
 #~ msgid "piece"
 #~ msgstr "peça"

--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -1035,8 +1035,8 @@ msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "Mana: {:d}  Dano: 1/3 da vida do oponente"
 
 #: Source/control.cpp:1904
-msgid "You have %u gold"
-msgstr "Você tem %u peças de ouro"
+msgid "You have {:d} gold"
+msgstr "Você tem {:d} peças de ouro"
 
 #: Source/control.cpp:1906
 #, fuzzy, c-format

--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -421,7 +421,6 @@ msgid "Play by yourself with no network exposure."
 msgstr "Jogue sozinho sem exposição na rede."
 
 #: Source/DiabloUI/selconn.cpp:115
-#, c-format
 msgid "Players Supported: {:d}"
 msgstr "Jogadores suport.: {:d}"
 
@@ -595,7 +594,6 @@ msgid "The host is running a different game than you."
 msgstr "O anfitrião está executando um jogo diferente de você."
 
 #: Source/DiabloUI/selgame.cpp:415
-#, c-format
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr "Sua versão {:s} não corresponde com a do anfitrião {:d}.{:d}.{:d}."
 
@@ -676,7 +674,6 @@ msgstr ""
 "palavras.\n"
 
 #: Source/DiabloUI/selhero.cpp:345
-#, c-format
 msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
 msgstr "O personagem já existe. Você deseja substituir \"{:s}\"?"
 
@@ -725,7 +722,6 @@ msgid "Delete Single Player Hero"
 msgstr "Apagar herói"
 
 #: Source/DiabloUI/selhero.cpp:621
-#, c-format
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "Tem certeza de que deseja apagar o personagem \"{:s}\"?"
 
@@ -800,7 +796,6 @@ msgid "Error"
 msgstr "Erro"
 
 #: Source/appfat.cpp:117
-#, c-format
 msgid ""
 "{:s}\n"
 "\n"
@@ -811,7 +806,6 @@ msgstr ""
 "O erro ocorreu em: {:s} linha {:d}"
 
 #: Source/appfat.cpp:137
-#, c-format
 msgid ""
 "Unable to open a required file.\n"
 "\n"
@@ -849,7 +843,6 @@ msgstr ""
 "em minúsculas."
 
 #: Source/appfat.cpp:175
-#, c-format
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -870,17 +863,14 @@ msgid "password: "
 msgstr "senha: "
 
 #: Source/automap.cpp:434 Source/items.cpp:3868
-#, c-format
 msgid "Level: {:d}"
 msgstr "Nível: {:d}"
 
 #: Source/automap.cpp:436
-#, c-format
 msgid "Level: Crypt {:d}"
 msgstr "Nível: Cripta {:d}"
 
 #: Source/automap.cpp:438
-#, c-format
 msgid "Level: Nest {:d}"
 msgstr "Nível: Enxame {:d}"
 
@@ -925,12 +915,10 @@ msgid "Send Message"
 msgstr "Enviar Mensagem"
 
 #: Source/control.cpp:432 Source/control.cpp:1029
-#, c-format
 msgid "{:s} Skill"
 msgstr "Habilidade de {:s}"
 
 #: Source/control.cpp:435 Source/control.cpp:1033
-#, c-format
 msgid "{:s} Spell"
 msgstr "Magia de {:s}"
 
@@ -943,12 +931,10 @@ msgid "Spell Level 0 - Unusable"
 msgstr "Nível da magia 0 - Inutilizável"
 
 #: Source/control.cpp:443 Source/control.cpp:1041 Source/control.cpp:1867
-#, c-format
 msgid "Spell Level {:d}"
 msgstr "Nível do feitiço {:d}"
 
 #: Source/control.cpp:447 Source/control.cpp:1045
-#, c-format
 msgid "Scroll of {:s}"
 msgstr "Pergaminho de {:s}"
 
@@ -957,12 +943,10 @@ msgid "1 Scroll"
 msgstr "1 Pergaminho"
 
 #: Source/control.cpp:466 Source/control.cpp:1065
-#, c-format
 msgid "{:d} Scrolls"
 msgstr "{:d} Pergaminhos"
 
 #: Source/control.cpp:470 Source/control.cpp:1069 Source/items.cpp:1597
-#, c-format
 msgid "Staff of {:s}"
 msgstr "Cajado de {:s}"
 
@@ -971,12 +955,10 @@ msgid "1 Charge"
 msgstr "1 Carga"
 
 #: Source/control.cpp:474 Source/control.cpp:1074
-#, c-format
 msgid "{:d} Charges"
 msgstr "{:d} Cargas"
 
 #: Source/control.cpp:483
-#, c-format
 msgid "Spell Hotkey #F{:d}"
 msgstr "Tecla de atalho #F{:d}"
 
@@ -989,7 +971,6 @@ msgid "Player attack"
 msgstr "Hostil a jogadores"
 
 #: Source/control.cpp:1010
-#, c-format
 msgid "Hotkey: {:s}"
 msgstr "Tecla de atalho: {:s}"
 
@@ -1014,12 +995,10 @@ msgid "Requirements not met"
 msgstr "Pré-requisitos não atendidos"
 
 #: Source/control.cpp:1300
-#, c-format
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Nível: {:d}"
 
 #: Source/control.cpp:1302
-#, c-format
 msgid "Hit Points {:d} of {:d}"
 msgstr "Pontos de vida {:d} de {:d}"
 
@@ -1040,27 +1019,22 @@ msgid "Skill"
 msgstr "Habilidade"
 
 #: Source/control.cpp:1844
-#, c-format
 msgid "Staff ({:d} charges)"
 msgstr "Cajado ({:d} cargas)"
 
 #: Source/control.cpp:1852
-#, c-format
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "Mana:{:d}  Dano:{:d} - {:d}"
 
 #: Source/control.cpp:1854
-#, c-format
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "Mana: {:d}   Dano: NA"
 
 #: Source/control.cpp:1857
-#, c-format
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "Mana: {:d}  Dano: 1/3 da vida do oponente"
 
 #: Source/control.cpp:1904
-#, c-format
 msgid "You have %u gold"
 msgstr "Você tem %u peças de ouro"
 
@@ -1105,7 +1079,6 @@ msgid "Town Portal"
 msgstr "Portal da cidade"
 
 #: Source/cursor.cpp:182
-#, c-format
 msgid "from {:s}"
 msgstr "de {:s}"
 
@@ -1212,12 +1185,10 @@ msgid ""
 msgstr ""
 
 #: Source/diablo.cpp:267
-#, c-format
 msgid "unrecognized option '{:s}'\n"
 msgstr ""
 
 #: Source/diablo.cpp:649
-#, c-format
 msgid "version {:s}"
 msgstr "versão {:s}"
 
@@ -1230,7 +1201,6 @@ msgid "while in stores"
 msgstr "enquanto estiver em lojas"
 
 #: Source/diablo.cpp:1453
-#, c-format
 msgid "{:s}, mode = {:s}"
 msgstr "{:s}, modo = {:s}"
 
@@ -1814,7 +1784,6 @@ msgid "Unable to create main window"
 msgstr "Não foi possível criar a janela principal"
 
 #: Source/inv.cpp:2117 Source/items.cpp:3079
-#, c-format
 msgid "{:d} gold {:s}"
 msgstr "{:d} {:s} de ouro"
 
@@ -3601,12 +3570,10 @@ msgstr ""
 
 #: Source/items.cpp:1554 Source/items.cpp:1595 Source/items.cpp:2188
 #: Source/items.cpp:2207
-#, c-format
 msgid "{:s} of {:s}"
 msgstr "{:s} de {:s}"
 
 #: Source/items.cpp:2781 Source/player.cpp:1817
-#, c-format
 msgid "Ear of {:s}"
 msgstr "Orelha de {:s}"
 
@@ -3647,7 +3614,6 @@ msgid "to use armor or weapons"
 msgstr ""
 
 #: Source/items.cpp:3341
-#, c-format
 msgid "restores 20% of an"
 msgstr ""
 
@@ -3756,32 +3722,26 @@ msgid "fully recover life and mana"
 msgstr "recupera toda vida e mana"
 
 #: Source/items.cpp:3460
-#, c-format
 msgid "chance to hit: {:+d}%"
 msgstr "chance de acerto: {:+d}%"
 
 #: Source/items.cpp:3464
-#, c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% de dano"
 
 #: Source/items.cpp:3468 Source/items.cpp:3730
-#, c-format
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "acerto: {:+d}%, {:+d}% de dano"
 
 #: Source/items.cpp:3472
-#, c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% de armadura"
 
 #: Source/items.cpp:3475 Source/items.cpp:3478
-#, c-format
 msgid "armor class: {:d}"
 msgstr "classe de armadura: {:d}"
 
 #: Source/items.cpp:3483 Source/items.cpp:3712
-#, c-format
 msgid "Resist Fire: {:+d}%"
 msgstr "Resistência a fogo: {:+d}%"
 
@@ -3790,7 +3750,6 @@ msgid "Resist Fire: 75% MAX"
 msgstr "Resiste a fogo:75% MÁX"
 
 #: Source/items.cpp:3490
-#, c-format
 msgid "Resist Lightning: {:+d}%"
 msgstr "Resistência a raios: {:+d}%"
 
@@ -3799,7 +3758,6 @@ msgid "Resist Lightning: 75% MAX"
 msgstr "Resiste a raios:75% MÁX"
 
 #: Source/items.cpp:3497
-#, c-format
 msgid "Resist Magic: {:+d}%"
 msgstr "Resistência à magia: {:+d}%"
 
@@ -3808,7 +3766,6 @@ msgid "Resist Magic: 75% MAX"
 msgstr "Resiste a magia:75% MÁX"
 
 #: Source/items.cpp:3504
-#, c-format
 msgid "Resist All: {:+d}%"
 msgstr "Resistência a tudo: {:+d}%"
 
@@ -3821,7 +3778,6 @@ msgid "spells are increased 1 level"
 msgstr "feitiços aumentam 1 nível"
 
 #: Source/items.cpp:3512
-#, c-format
 msgid "spells are increased {:d} levels"
 msgstr "feitiços aumentam {:d} níveis"
 
@@ -3830,7 +3786,6 @@ msgid "spells are decreased 1 level"
 msgstr "feitiços diminuem 1 nível"
 
 #: Source/items.cpp:3516
-#, c-format
 msgid "spells are decreased {:d} levels"
 msgstr "feitiços diminuem {:d} níveis"
 
@@ -3843,67 +3798,54 @@ msgid "Extra charges"
 msgstr "Cargas extra"
 
 #: Source/items.cpp:3524
-#, c-format
 msgid "{:d} {:s} charges"
 msgstr "{:d} {:s} cargas"
 
 #: Source/items.cpp:3528
-#, c-format
 msgid "Fire hit damage: {:d}"
 msgstr "Dano do acerto de fogo: {:d}"
 
 #: Source/items.cpp:3530
-#, c-format
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "Dano do acerto de fogo: {:d}-{:d}"
 
 #: Source/items.cpp:3534
-#, c-format
 msgid "Lightning hit damage: {:d}"
 msgstr "Dano do acerto de raios: {:d}"
 
 #: Source/items.cpp:3536
-#, c-format
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "Dano do acerto de raios: {:d}-{:d}"
 
 #: Source/items.cpp:3540
-#, c-format
 msgid "{:+d} to strength"
 msgstr "{:+d} para força"
 
 #: Source/items.cpp:3544
-#, c-format
 msgid "{:+d} to magic"
 msgstr "{:+d} para magia"
 
 #: Source/items.cpp:3548
-#, c-format
 msgid "{:+d} to dexterity"
 msgstr "{:+d} para destreza"
 
 #: Source/items.cpp:3552
-#, c-format
 msgid "{:+d} to vitality"
 msgstr "{:+d} para vitalidade"
 
 #: Source/items.cpp:3556
-#, c-format
 msgid "{:+d} to all attributes"
 msgstr "{:+d} a todos os atributos"
 
 #: Source/items.cpp:3560
-#, c-format
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} de dano de inimigos"
 
 #: Source/items.cpp:3564
-#, c-format
 msgid "Hit Points: {:+d}"
 msgstr "Pontos de vida: {:+d}"
 
 #: Source/items.cpp:3568
-#, c-format
 msgid "Mana: {:+d}"
 msgstr "Mana: {:+d}"
 
@@ -3920,12 +3862,10 @@ msgid "indestructible"
 msgstr "indestrutível"
 
 #: Source/items.cpp:3580
-#, c-format
 msgid "+{:d}%% light radius"
 msgstr "+{:d}%%  de alcance de visão"
 
 #: Source/items.cpp:3583
-#, c-format
 msgid "-{:d}%% light radius"
 msgstr "-{:d}%%  de alcance de visão"
 
@@ -3934,32 +3874,26 @@ msgid "multiple arrows per shot"
 msgstr "várias flechas por tiro"
 
 #: Source/items.cpp:3590
-#, c-format
 msgid "fire arrows damage: {:d}"
 msgstr "dano das flechas de fogo: {:d}"
 
 #: Source/items.cpp:3592
-#, c-format
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "dano das flechas de fogo: {:d}-{:d}"
 
 #: Source/items.cpp:3596
-#, c-format
 msgid "lightning arrows damage {:d}"
 msgstr "flechas de raios {:d}"
 
 #: Source/items.cpp:3598
-#, c-format
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "flechas de raios {:d}-{:d}"
 
 #: Source/items.cpp:3602
-#, c-format
 msgid "fireball damage: {:d}"
 msgstr "dano das bolas de fogo: {:d}"
 
 #: Source/items.cpp:3604
-#, c-format
 msgid "fireball damage: {:d}-{:d}"
 msgstr "dano das bolas de fogo: {:d}-{:d}"
 
@@ -4053,7 +3987,6 @@ msgid "fast block"
 msgstr "bloqueio rápido"
 
 #: Source/items.cpp:3667
-#, c-format
 msgid "adds {:d} points to damage"
 msgstr "adiciona {:d} ao dano"
 
@@ -4094,12 +4027,10 @@ msgid "see with infravision"
 msgstr "enxerga com infravisão"
 
 #: Source/items.cpp:3701
-#, c-format
 msgid "lightning damage: {:d}"
 msgstr "dano de raio: {:d}"
 
 #: Source/items.cpp:3703
-#, c-format
 msgid "lightning damage: {:d}-{:d}"
 msgstr "dano de raio: {:d}-{:d}"
 
@@ -4112,7 +4043,6 @@ msgid "occasional triple damage"
 msgstr ""
 
 #: Source/items.cpp:3718
-#, c-format
 msgid "decaying {:+d}% damage"
 msgstr ""
 
@@ -4126,7 +4056,6 @@ msgid "Random 0 - 500% damage"
 msgstr ""
 
 #: Source/items.cpp:3727
-#, c-format
 msgid "low dur, {:+d}% damage"
 msgstr ""
 
@@ -4187,63 +4116,51 @@ msgid "Required:"
 msgstr "Requerido:"
 
 #: Source/items.cpp:3886 Source/stores.cpp:199
-#, c-format
 msgid " {:d} Str"
 msgstr " {:d} For."
 
 #: Source/items.cpp:3888 Source/stores.cpp:201
-#, c-format
 msgid " {:d} Mag"
 msgstr " {:d} Mag."
 
 #: Source/items.cpp:3890 Source/stores.cpp:203
-#, c-format
 msgid " {:d} Dex"
 msgstr " {:d} Des."
 
 #: Source/items.cpp:3901 Source/items.cpp:3948
-#, c-format
 msgid "damage: {:d}  Indestructible"
 msgstr "dano: {:d}  Indestrutível"
 
 #: Source/items.cpp:3903 Source/items.cpp:3950
-#, c-format
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "dano: {:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3906 Source/items.cpp:3953
-#, c-format
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "dano: {:d}-{:d}  Indestrutível"
 
 #: Source/items.cpp:3908 Source/items.cpp:3955
-#, c-format
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "dano: {:d}-{:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3914 Source/items.cpp:3967
-#, c-format
 msgid "armor: {:d}  Indestructible"
 msgstr "armadura: {:d}  Indestrutível"
 
 #: Source/items.cpp:3916 Source/items.cpp:3969
-#, c-format
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "armadura: {:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3921
-#, c-format
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "dano: {:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3923
-#, c-format
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "dano: {:d}-{:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3924 Source/items.cpp:3959 Source/items.cpp:3974
 #: Source/stores.cpp:169
-#, c-format
 msgid "Charges: {:d}/{:d}"
 msgstr "Cargas: {:d}/{:d}"
 
@@ -5152,17 +5069,14 @@ msgid "Undead"
 msgstr ""
 
 #: Source/monster.cpp:4969
-#, c-format
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "Tipo: {:s}  Mortos: {:d}"
 
 #: Source/monster.cpp:4971
-#, c-format
 msgid "Total kills: {:d}"
 msgstr "Total de mortos: {:d}"
 
 #: Source/monster.cpp:5004
-#, c-format
 msgid "Hit Points: {:d}-{:d}"
 msgstr "Pontos de vida: {:d}-{:d}"
 
@@ -5191,7 +5105,6 @@ msgid "Immune: "
 msgstr "Imune a: "
 
 #: Source/monster.cpp:5049
-#, c-format
 msgid "Type: {:s}"
 msgstr "Tipo: {:s}"
 
@@ -5230,32 +5143,26 @@ msgstr ""
 #: Source/msg.cpp:1387 Source/msg.cpp:1658 Source/msg.cpp:1680
 #: Source/msg.cpp:1702 Source/msg.cpp:1822 Source/msg.cpp:1843
 #: Source/msg.cpp:1864 Source/msg.cpp:1885
-#, c-format
 msgid "{:s} has cast an illegal spell."
 msgstr ""
 
 #: Source/msg.cpp:2221 Source/multi.cpp:866
-#, c-format
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr "Jogador '{:s}' (nível {:d}) acabou de entrar no jogo"
 
 #: Source/multi.cpp:269
-#, c-format
 msgid "Player '{:s}' just left the game"
 msgstr "Jogador '{:s}' acabou de sair do jogo"
 
 #: Source/multi.cpp:272
-#, c-format
 msgid "Player '{:s}' killed Diablo and left the game!"
 msgstr "Jogador '{:s}' matou Diablo e saiu do jogo!"
 
 #: Source/multi.cpp:276
-#, c-format
 msgid "Player '{:s}' dropped due to timeout"
 msgstr "Jogador '{:s}' caiu devido a tempo esgotado"
 
 #: Source/multi.cpp:868
-#, c-format
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr "Jogador '{:s}' (nível {:d}) já está no jogo"
 
@@ -5516,7 +5423,6 @@ msgid "Barrel"
 msgstr "Barril"
 
 #: Source/objects.cpp:5544
-#, c-format
 msgid "{:s} Shrine"
 msgstr "Altar {:s}"
 
@@ -5589,12 +5495,10 @@ msgid "Slain Hero"
 msgstr "Herói assassinado"
 
 #: Source/objects.cpp:5613
-#, c-format
 msgid "Trapped {:s}"
 msgstr "{:s} aprisionado"
 
 #: Source/objects.cpp:5619
-#, c-format
 msgid "{:s} (disabled)"
 msgstr "{:s} (desativado)"
 
@@ -5619,7 +5523,6 @@ msgid "Unable to write to save file archive"
 msgstr ""
 
 #: Source/plrmsg.cpp:72
-#, c-format
 msgid "{:s} (lvl {:d}): {:s}"
 msgstr "{:s} (nvl {:d}): {:s}"
 
@@ -5629,7 +5532,6 @@ msgid ""
 msgstr ""
 
 #: Source/qol/xpbar.cpp:122
-#, c-format
 msgid "Level {:d}"
 msgstr "Nível {:d}"
 
@@ -5646,7 +5548,6 @@ msgid "Next Level: "
 msgstr "Próximo nível: "
 
 #: Source/qol/xpbar.cpp:148
-#, c-format
 msgid " to Level {:d}"
 msgstr " para o nível {:d}"
 
@@ -5727,7 +5628,6 @@ msgid "Unholy Altar"
 msgstr "Altar profano"
 
 #: Source/quests.cpp:283
-#, c-format
 msgid "To {:s}"
 msgstr "Para {:s}"
 
@@ -5932,17 +5832,14 @@ msgid ",  "
 msgstr ",  "
 
 #: Source/stores.cpp:180
-#, c-format
 msgid "Damage: {:d}-{:d}  "
 msgstr "Dano: {:d}-{:d}  "
 
 #: Source/stores.cpp:182
-#, c-format
 msgid "Armor: {:d}  "
 msgstr "Armadura: {:d}  "
 
 #: Source/stores.cpp:184
-#, c-format
 msgid "Dur: {:d}/{:d},  "
 msgstr "Dur: {:d}/{:d},  "
 
@@ -5993,7 +5890,6 @@ msgid "Leave the shop"
 msgstr "Sair da loja"
 
 #: Source/stores.cpp:274 Source/stores.cpp:623 Source/stores.cpp:989
-#, c-format
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "Eu tenho estes itens para vender:             Seu ouro: {:d}"
 
@@ -6007,27 +5903,22 @@ msgid "Back"
 msgstr "Voltar"
 
 #: Source/stores.cpp:339
-#, c-format
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "Eu tenho estes itens especiais para vender:     Seu ouro: {:d}"
 
 #: Source/stores.cpp:467 Source/stores.cpp:717
-#, c-format
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "Você não tem nada que eu queira.             Seu ouro: {:d}"
 
 #: Source/stores.cpp:477 Source/stores.cpp:727
-#, c-format
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "Qual item está à venda?             Seu ouro: {:d}"
 
 #: Source/stores.cpp:537
-#, c-format
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "Você não tem nada para reparar.             Seu ouro: {:d}"
 
 #: Source/stores.cpp:549
-#, c-format
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "Reparar qual item?             Seu ouro: {:d}"
 
@@ -6052,12 +5943,10 @@ msgid "Leave the shack"
 msgstr "Sair da cabana"
 
 #: Source/stores.cpp:793
-#, c-format
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "Você não tem nada para recarregar.             Seu ouro: {:d}"
 
 #: Source/stores.cpp:803
-#, c-format
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "Recarregar qual item?             Seu ouro: {:d}"
 
@@ -6123,7 +6012,6 @@ msgid "Say goodbye"
 msgstr "Dizer adeus"
 
 #: Source/stores.cpp:915
-#, c-format
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "Eu tenho este item para vender:             Seu ouro: {:d}"
 
@@ -6156,12 +6044,10 @@ msgid "Identify an item"
 msgstr "Identificar um item"
 
 #: Source/stores.cpp:1090
-#, c-format
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "Você não tem nada para identificar.             Seu ouro: {:d}"
 
 #: Source/stores.cpp:1100
-#, c-format
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "Identificar qual item?             Seu ouro: {:d}"
 
@@ -6174,12 +6060,10 @@ msgid "Done"
 msgstr "Pronto"
 
 #: Source/stores.cpp:1129
-#, c-format
 msgid "Talk to {:s}"
 msgstr "Falar com {:s}"
 
 #: Source/stores.cpp:1133
-#, c-format
 msgid "Talking to {:s}"
 msgstr "Falar com {:s}"
 
@@ -9687,7 +9571,6 @@ msgstr ""
 
 #: Source/trigs.cpp:397 Source/trigs.cpp:484 Source/trigs.cpp:536
 #: Source/trigs.cpp:635
-#, c-format
 msgid "Up to level {:d}"
 msgstr "Subir para o nível {:d}"
 
@@ -9698,22 +9581,18 @@ msgstr "Subir para a cidade"
 
 #: Source/trigs.cpp:411 Source/trigs.cpp:496 Source/trigs.cpp:550
 #: Source/trigs.cpp:577 Source/trigs.cpp:648
-#, c-format
 msgid "Down to level {:d}"
 msgstr "Descer para o nível {:d}"
 
 #: Source/trigs.cpp:424
-#, c-format
 msgid "Up to Crypt level {:d}"
 msgstr "Subir para o nível {:d} da cripta"
 
 #: Source/trigs.cpp:440
-#, c-format
 msgid "Down to Crypt level {:d}"
 msgstr "Descer para o nível {:d} da cripta"
 
 #: Source/trigs.cpp:563
-#, c-format
 msgid "Up to Nest level {:d}"
 msgstr ""
 
@@ -9722,7 +9601,6 @@ msgid "Down to Diablo"
 msgstr "Descer para Diablo"
 
 #: Source/trigs.cpp:718 Source/trigs.cpp:735 Source/trigs.cpp:752
-#, c-format
 msgid "Back to Level {:d}"
 msgstr "Voltar ao Nível {:d}"
 

--- a/Translations/ru.po
+++ b/Translations/ru.po
@@ -1038,11 +1038,11 @@ msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr ""
 
 #: Source/control.cpp:1704
-msgid "You have %u gold piece. How many do you want to remove?"
-msgid_plural "You have %u gold pieces. How many do you want to remove?"
-msgstr[0] "У вас %u золотой. Сколько вы хотите забрать?"
-msgstr[1] "У вас %u золотых. Сколько вы хотите забрать?"
-msgstr[2] "У вас %u золотых. Сколько вы хотите забрать?"
+msgid "You have {:d} gold piece. How many do you want to remove?"
+msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
+msgstr[0] "У вас {:d} золотой. Сколько вы хотите забрать?"
+msgstr[1] "У вас {:d} золотых. Сколько вы хотите забрать?"
+msgstr[2] "У вас {:d} золотых. Сколько вы хотите забрать?"
 
 #: Source/controls/modifier_hints.cpp:117
 msgid "Menu"

--- a/Translations/ru.po
+++ b/Translations/ru.po
@@ -420,7 +420,6 @@ msgid "Play by yourself with no network exposure."
 msgstr "Играть в одиночной игре без подключения к интернету."
 
 #: Source/DiabloUI/selconn.cpp:115
-#, c-format
 msgid "Players Supported: {:d}"
 msgstr "Поддержка игроков: {:d}"
 
@@ -594,7 +593,6 @@ msgid "The host is running a different game than you."
 msgstr "На сервере запущена другая игра."
 
 #: Source/DiabloUI/selgame.cpp:415
-#, c-format
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr ""
 "Ваша версия игры ({:s}) не соответствует с версией игры на сервере ({:d}.{:d}.{:d})"
@@ -677,7 +675,6 @@ msgstr ""
 "специальные слова.\n"
 
 #: Source/DiabloUI/selhero.cpp:345
-#, c-format
 msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
 msgstr "Персонаж уже существует. Хотите его перезаписать \"{:s}\"?"
 
@@ -726,7 +723,6 @@ msgid "Delete Single Player Hero"
 msgstr "Удалить персонажа для одиночной игры"
 
 #: Source/DiabloUI/selhero.cpp:621
-#, c-format
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "Вы действительно хотите удалить персонажа \"{:s}\"?"
 
@@ -806,7 +802,6 @@ msgid "Error"
 msgstr "Ошибка"
 
 #: Source/appfat.cpp:117
-#, c-format
 msgid ""
 "{:s}\n"
 "\n"
@@ -817,7 +812,6 @@ msgstr ""
 "Ошибка: в {:s} в строке {:d}"
 
 #: Source/appfat.cpp:137
-#, c-format
 msgid ""
 "Unable to open a required file.\n"
 "\n"
@@ -852,7 +846,6 @@ msgstr ""
 "Убедитесь, что файлы находятся в папке игры."
 
 #: Source/appfat.cpp:176
-#, c-format
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -873,17 +866,14 @@ msgid "password: "
 msgstr "пароль: "
 
 #: Source/automap.cpp:405
-#, c-format
 msgid "Level: Nest {:d}"
 msgstr "Уровень: Nest {:d}"
 
 #: Source/automap.cpp:407
-#, c-format
 msgid "Level: Crypt {:d}"
 msgstr "Уровень: Crypt {:d}"
 
 #: Source/automap.cpp:409 Source/items.cpp:3816
-#, c-format
 msgid "Level: {:d}"
 msgstr "Уровень: {:d}"
 
@@ -928,12 +918,10 @@ msgid "Send Message"
 msgstr "Отправить сообщение"
 
 #: Source/control.cpp:394 Source/control.cpp:937
-#, c-format
 msgid "{:s} Skill"
 msgstr "{:s} навык"
 
 #: Source/control.cpp:397 Source/control.cpp:941
-#, c-format
 msgid "{:s} Spell"
 msgstr "Заклинание {:s}"
 
@@ -946,17 +934,14 @@ msgid "Spell Level 0 - Unusable"
 msgstr "Уровень заклинаний 0 - Нельзя использовать"
 
 #: Source/control.cpp:405 Source/control.cpp:949 Source/control.cpp:1662
-#, c-format
 msgid "Spell Level {:d}"
 msgstr "Уровень заклинания {:d}"
 
 #: Source/control.cpp:409 Source/control.cpp:953
-#, c-format
 msgid "Scroll of {:s}"
 msgstr "Свиток о {:s}"
 
 #: Source/control.cpp:425 Source/control.cpp:970
-#, c-format
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "{:d} свиток"
@@ -964,12 +949,10 @@ msgstr[1] "{:d} свитка"
 msgstr[2] "{:d} свитков"
 
 #: Source/control.cpp:429 Source/control.cpp:974 Source/items.cpp:1570
-#, c-format
 msgid "Staff of {:s}"
 msgstr "Посох {:s}"
 
 #: Source/control.cpp:431 Source/control.cpp:976
-#, c-format
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "{:d} заряд"
@@ -977,7 +960,6 @@ msgstr[1] "{:d} заряда"
 msgstr[2] "{:d} зарядов"
 
 #: Source/control.cpp:441
-#, c-format
 msgid "Spell Hotkey {:s}"
 msgstr "Горячая клавиша {:s}"
 
@@ -990,7 +972,6 @@ msgid "Player attack"
 msgstr ""
 
 #: Source/control.cpp:918
-#, c-format
 msgid "Hotkey: {:s}"
 msgstr "Горячая клавиша: {:s}"
 
@@ -1003,7 +984,6 @@ msgid "Hotkey: 's'"
 msgstr "Горячая клавиша: 's'"
 
 #: Source/control.cpp:1122 Source/inv.cpp:2066 Source/items.cpp:3050
-#, c-format
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "{:d} золотой"
@@ -1015,12 +995,10 @@ msgid "Requirements not met"
 msgstr ""
 
 #: Source/control.cpp:1163
-#, c-format
 msgid "{:s}, Level: {:d}"
 msgstr ""
 
 #: Source/control.cpp:1165
-#, c-format
 msgid "Hit Points {:d} of {:d}"
 msgstr ""
 
@@ -1041,7 +1019,6 @@ msgid "Skill"
 msgstr ""
 
 #: Source/control.cpp:1639
-#, c-format
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] ""
@@ -1049,22 +1026,18 @@ msgstr[1] ""
 msgstr[2] ""
 
 #: Source/control.cpp:1647
-#, c-format
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr ""
 
 #: Source/control.cpp:1649
-#, c-format
 msgid "Mana: {:d}   Dam: n/a"
 msgstr ""
 
 #: Source/control.cpp:1652
-#, c-format
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr ""
 
 #: Source/control.cpp:1704
-#, c-format
 msgid "You have %u gold piece. How many do you want to remove?"
 msgid_plural "You have %u gold pieces. How many do you want to remove?"
 msgstr[0] "У вас %u золотой. Сколько вы хотите забрать?"
@@ -1100,7 +1073,6 @@ msgid "Town Portal"
 msgstr ""
 
 #: Source/cursor.cpp:206
-#, c-format
 msgid "from {:s}"
 msgstr ""
 
@@ -1209,12 +1181,10 @@ msgstr ""
 "Сообщайте об ошибках на https://github.com/diasurgical/devilutionX/\n"
 
 #: Source/diablo.cpp:283
-#, c-format
 msgid "unrecognized option '{:s}'\n"
 msgstr "неизвестный параметр '{:s}'\n"
 
 #: Source/diablo.cpp:671
-#, c-format
 msgid "version {:s}"
 msgstr "версия {:s}"
 
@@ -1235,7 +1205,6 @@ msgid "while in stores"
 msgstr ""
 
 #: Source/diablo.cpp:2201
-#, c-format
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr ""
 
@@ -3604,12 +3573,10 @@ msgstr ""
 
 #: Source/items.cpp:1527 Source/items.cpp:1569 Source/items.cpp:2161
 #: Source/items.cpp:2180
-#, c-format
 msgid "{:s} of {:s}"
 msgstr ""
 
 #: Source/items.cpp:2753 Source/player.cpp:1874
-#, c-format
 msgid "Ear of {:s}"
 msgstr ""
 
@@ -3759,32 +3726,26 @@ msgid "fully recover life and mana"
 msgstr ""
 
 #: Source/items.cpp:3431
-#, c-format
 msgid "chance to hit: {:+d}%"
 msgstr ""
 
 #: Source/items.cpp:3435
-#, c-format
 msgid "{:+d}% damage"
 msgstr ""
 
 #: Source/items.cpp:3439 Source/items.cpp:3697
-#, c-format
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr ""
 
 #: Source/items.cpp:3443
-#, c-format
 msgid "{:+d}% armor"
 msgstr ""
 
 #: Source/items.cpp:3446 Source/items.cpp:3449
-#, c-format
 msgid "armor class: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3454 Source/items.cpp:3679
-#, c-format
 msgid "Resist Fire: {:+d}%"
 msgstr ""
 
@@ -3794,7 +3755,6 @@ msgid "Resist Fire: 75% MAX"
 msgstr ""
 
 #: Source/items.cpp:3461
-#, c-format
 msgid "Resist Lightning: {:+d}%"
 msgstr ""
 
@@ -3804,7 +3764,6 @@ msgid "Resist Lightning: 75% MAX"
 msgstr ""
 
 #: Source/items.cpp:3468
-#, c-format
 msgid "Resist Magic: {:+d}%"
 msgstr ""
 
@@ -3814,7 +3773,6 @@ msgid "Resist Magic: 75% MAX"
 msgstr ""
 
 #: Source/items.cpp:3475
-#, c-format
 msgid "Resist All: {:+d}%"
 msgstr ""
 
@@ -3824,7 +3782,6 @@ msgid "Resist All: 75% MAX"
 msgstr ""
 
 #: Source/items.cpp:3481
-#, c-format
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] ""
@@ -3832,7 +3789,6 @@ msgstr[1] ""
 msgstr[2] ""
 
 #: Source/items.cpp:3483
-#, c-format
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] ""
@@ -3848,7 +3804,6 @@ msgid "Extra charges"
 msgstr ""
 
 #: Source/items.cpp:3491
-#, c-format
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] ""
@@ -3856,62 +3811,50 @@ msgstr[1] ""
 msgstr[2] ""
 
 #: Source/items.cpp:3495
-#, c-format
 msgid "Fire hit damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3497
-#, c-format
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3501
-#, c-format
 msgid "Lightning hit damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3503
-#, c-format
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3507
-#, c-format
 msgid "{:+d} to strength"
 msgstr ""
 
 #: Source/items.cpp:3511
-#, c-format
 msgid "{:+d} to magic"
 msgstr ""
 
 #: Source/items.cpp:3515
-#, c-format
 msgid "{:+d} to dexterity"
 msgstr ""
 
 #: Source/items.cpp:3519
-#, c-format
 msgid "{:+d} to vitality"
 msgstr ""
 
 #: Source/items.cpp:3523
-#, c-format
 msgid "{:+d} to all attributes"
 msgstr ""
 
 #: Source/items.cpp:3527
-#, c-format
 msgid "{:+d} damage from enemies"
 msgstr ""
 
 #: Source/items.cpp:3531
-#, c-format
 msgid "Hit Points: {:+d}"
 msgstr ""
 
 #: Source/items.cpp:3535
-#, c-format
 msgid "Mana: {:+d}"
 msgstr ""
 
@@ -3928,12 +3871,10 @@ msgid "indestructible"
 msgstr ""
 
 #: Source/items.cpp:3547
-#, c-format
 msgid "+{:d}%% light radius"
 msgstr ""
 
 #: Source/items.cpp:3550
-#, c-format
 msgid "-{:d}%% light radius"
 msgstr ""
 
@@ -3942,32 +3883,26 @@ msgid "multiple arrows per shot"
 msgstr ""
 
 #: Source/items.cpp:3557
-#, c-format
 msgid "fire arrows damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3559
-#, c-format
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3563
-#, c-format
 msgid "lightning arrows damage {:d}"
 msgstr ""
 
 #: Source/items.cpp:3565
-#, c-format
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3569
-#, c-format
 msgid "fireball damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3571
-#, c-format
 msgid "fireball damage: {:d}-{:d}"
 msgstr ""
 
@@ -4061,7 +3996,6 @@ msgid "fast block"
 msgstr ""
 
 #: Source/items.cpp:3634
-#, c-format
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] ""
@@ -4105,12 +4039,10 @@ msgid "see with infravision"
 msgstr ""
 
 #: Source/items.cpp:3668
-#, c-format
 msgid "lightning damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3670
-#, c-format
 msgid "lightning damage: {:d}-{:d}"
 msgstr ""
 
@@ -4123,7 +4055,6 @@ msgid "occasional triple damage"
 msgstr ""
 
 #: Source/items.cpp:3685
-#, c-format
 msgid "decaying {:+d}% damage"
 msgstr ""
 
@@ -4137,7 +4068,6 @@ msgid "Random 0 - 500% damage"
 msgstr ""
 
 #: Source/items.cpp:3694
-#, c-format
 msgid "low dur, {:+d}% damage"
 msgstr ""
 
@@ -4200,63 +4130,51 @@ msgid "Required:"
 msgstr ""
 
 #: Source/items.cpp:3834 Source/stores.cpp:201
-#, c-format
 msgid " {:d} Str"
 msgstr ""
 
 #: Source/items.cpp:3836 Source/stores.cpp:203
-#, c-format
 msgid " {:d} Mag"
 msgstr ""
 
 #: Source/items.cpp:3838 Source/stores.cpp:205
-#, c-format
 msgid " {:d} Dex"
 msgstr ""
 
 #: Source/items.cpp:3849 Source/items.cpp:3896
-#, c-format
 msgid "damage: {:d}  Indestructible"
 msgstr ""
 
 #: Source/items.cpp:3851 Source/items.cpp:3898
-#, c-format
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3854 Source/items.cpp:3901
-#, c-format
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr ""
 
 #: Source/items.cpp:3856 Source/items.cpp:3903
-#, c-format
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3862 Source/items.cpp:3915
-#, c-format
 msgid "armor: {:d}  Indestructible"
 msgstr ""
 
 #: Source/items.cpp:3864 Source/items.cpp:3917
-#, c-format
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3869
-#, c-format
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3871
-#, c-format
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3872 Source/items.cpp:3907 Source/items.cpp:3922
 #: Source/stores.cpp:171
-#, c-format
 msgid "Charges: {:d}/{:d}"
 msgstr ""
 
@@ -5165,17 +5083,14 @@ msgid "Undead"
 msgstr "Нежить"
 
 #: Source/monster.cpp:4966
-#, c-format
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "Тип: {:s}  Убито: {:d}"
 
 #: Source/monster.cpp:4968
-#, c-format
 msgid "Total kills: {:d}"
 msgstr "Убито: {:d}"
 
 #: Source/monster.cpp:5001
-#, c-format
 msgid "Hit Points: {:d}-{:d}"
 msgstr "Здоровье: {:d}-{:d}"
 
@@ -5204,7 +5119,6 @@ msgid "Immune: "
 msgstr "Иммунитет: "
 
 #: Source/monster.cpp:5046
-#, c-format
 msgid "Type: {:s}"
 msgstr "Тип: {:s}"
 
@@ -5243,32 +5157,26 @@ msgstr ""
 #: Source/msg.cpp:1394 Source/msg.cpp:1665 Source/msg.cpp:1687
 #: Source/msg.cpp:1709 Source/msg.cpp:1829 Source/msg.cpp:1850
 #: Source/msg.cpp:1871 Source/msg.cpp:1892
-#, c-format
 msgid "{:s} has cast an illegal spell."
 msgstr ""
 
 #: Source/msg.cpp:2228 Source/multi.cpp:859
-#, c-format
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr ""
 
 #: Source/multi.cpp:262
-#, c-format
 msgid "Player '{:s}' just left the game"
 msgstr ""
 
 #: Source/multi.cpp:265
-#, c-format
 msgid "Player '{:s}' killed Diablo and left the game!"
 msgstr ""
 
 #: Source/multi.cpp:269
-#, c-format
 msgid "Player '{:s}' dropped due to timeout"
 msgstr ""
 
 #: Source/multi.cpp:861
-#, c-format
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr ""
 
@@ -5531,7 +5439,6 @@ msgid "Barrel"
 msgstr "Бочка"
 
 #: Source/objects.cpp:5508
-#, c-format
 msgid "{:s} Shrine"
 msgstr "{:s} святыня"
 
@@ -5609,7 +5516,6 @@ msgid "Trapped {:s}"
 msgstr "Пойманная {:s}"
 
 #: Source/objects.cpp:5583
-#, c-format
 msgid "{:s} (disabled)"
 msgstr "{:s} (отключено)"
 
@@ -5634,7 +5540,6 @@ msgid "Unable to write to save file archive"
 msgstr ""
 
 #: Source/plrmsg.cpp:73
-#, c-format
 msgid "{:s} (lvl {:d}): {:s}"
 msgstr ""
 
@@ -5646,7 +5551,6 @@ msgid ""
 msgstr ""
 
 #: Source/qol/xpbar.cpp:124
-#, c-format
 msgid "Level {:d}"
 msgstr "Уровень {:d}"
 
@@ -5663,7 +5567,6 @@ msgid "Next Level: "
 msgstr "Следующий Уровень: "
 
 #: Source/qol/xpbar.cpp:150
-#, c-format
 msgid " to Level {:d}"
 msgstr " до Уровня {:d}"
 
@@ -5746,7 +5649,6 @@ msgid "Unholy Altar"
 msgstr "Нечестивый алтарь"
 
 #: Source/quests.cpp:285
-#, c-format
 msgid "To {:s}"
 msgstr "К {:s}"
 
@@ -5951,17 +5853,14 @@ msgid ",  "
 msgstr ""
 
 #: Source/stores.cpp:182
-#, c-format
 msgid "Damage: {:d}-{:d}  "
 msgstr ""
 
 #: Source/stores.cpp:184
-#, c-format
 msgid "Armor: {:d}  "
 msgstr ""
 
 #: Source/stores.cpp:186
-#, c-format
 msgid "Dur: {:d}/{:d},  "
 msgstr ""
 
@@ -6012,7 +5911,6 @@ msgid "Leave the shop"
 msgstr "Покинуть магазин"
 
 #: Source/stores.cpp:276 Source/stores.cpp:625 Source/stores.cpp:991
-#, c-format
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "У меня есть на продажу:                Ваше золото: {:d}"
 
@@ -6027,27 +5925,22 @@ msgstr "Назад"
 
 # “премиальные прдеметы” не влезают в длину строки
 #: Source/stores.cpp:341
-#, c-format
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "У меня есть на продажу:                Ваше золото: {:d}"
 
 #: Source/stores.cpp:469 Source/stores.cpp:719
-#, c-format
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "У вас нет ничего нужного мне.      Ваше золото: {:d}"
 
 #: Source/stores.cpp:479 Source/stores.cpp:729
-#, c-format
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "Какой предмет продать?            Ваше золото: {:d}"
 
 #: Source/stores.cpp:539
-#, c-format
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "У вас нечего чинить.                  Ваше золото: {:d}"
 
 #: Source/stores.cpp:551
-#, c-format
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "Какой предмет починить?      Ваше золото: {:d}"
 
@@ -6072,12 +5965,10 @@ msgid "Leave the shack"
 msgstr "Покинуть хижину"
 
 #: Source/stores.cpp:795
-#, c-format
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "У вас нечего заряжать.                  Ваше золото: {:d}"
 
 #: Source/stores.cpp:805
-#, c-format
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "Какой предмет зарядить?        Ваше золото: {:d}"
 
@@ -6143,7 +6034,6 @@ msgid "Say goodbye"
 msgstr "Попрощаться"
 
 #: Source/stores.cpp:917
-#, c-format
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "У меня есть на продажу:              Ваше золото: {:d}"
 
@@ -6178,13 +6068,11 @@ msgid "Identify an item"
 msgstr "Идентифицировать предмет"
 
 #: Source/stores.cpp:1092
-#, c-format
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "У вас нечего идентифицировать.          Ваше золото: {:d}"
 
 # Нужно выровнять с остальными строками
 #: Source/stores.cpp:1102
-#, c-format
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "Какой предмет идентифицировать? Ваше золото: {:d}"
 
@@ -6197,12 +6085,10 @@ msgid "Done"
 msgstr "Готово"
 
 #: Source/stores.cpp:1131
-#, c-format
 msgid "Talk to {:s}"
 msgstr "Поговорить с {:s}"
 
 #: Source/stores.cpp:1135
-#, c-format
 msgid "Talking to {:s}"
 msgstr "Разговор с {:s}"
 
@@ -9879,7 +9765,6 @@ msgstr "Спустится в Улей"
 
 #: Source/trigs.cpp:397 Source/trigs.cpp:484 Source/trigs.cpp:536
 #: Source/trigs.cpp:635
-#, c-format
 msgid "Up to level {:d}"
 msgstr "Подняться на уровень {:d}"
 
@@ -9890,22 +9775,18 @@ msgstr "Подняться в город"
 
 #: Source/trigs.cpp:411 Source/trigs.cpp:496 Source/trigs.cpp:550
 #: Source/trigs.cpp:577 Source/trigs.cpp:648
-#, c-format
 msgid "Down to level {:d}"
 msgstr "Спуститься на уровень {:d}"
 
 #: Source/trigs.cpp:424
-#, c-format
 msgid "Up to Crypt level {:d}"
 msgstr "Подняться в Склеп на уровень {:d}"
 
 #: Source/trigs.cpp:440
-#, c-format
 msgid "Down to Crypt level {:d}"
 msgstr "Спуститься в Склеп на уровень {:d}"
 
 #: Source/trigs.cpp:563
-#, c-format
 msgid "Up to Nest level {:d}"
 msgstr "Подняться в Гнездо на уровень {:d}"
 
@@ -9914,6 +9795,5 @@ msgid "Down to Diablo"
 msgstr "Спуститься к Диабло"
 
 #: Source/trigs.cpp:718 Source/trigs.cpp:735 Source/trigs.cpp:752
-#, c-format
 msgid "Back to Level {:d}"
 msgstr "Вернуться на Уровень {:d}"

--- a/Translations/ru.po
+++ b/Translations/ru.po
@@ -421,8 +421,8 @@ msgstr "Играть в одиночной игре без подключени�
 
 #: Source/DiabloUI/selconn.cpp:115
 #, c-format
-msgid "Players Supported: %d"
-msgstr "Поддержка игроков: %d"
+msgid "Players Supported: {:d}"
+msgstr "Поддержка игроков: {:d}"
 
 #: Source/DiabloUI/selgame.cpp:85 Source/DiabloUI/selgame.cpp:380
 msgid "Description:"
@@ -595,9 +595,9 @@ msgstr "На сервере запущена другая игра."
 
 #: Source/DiabloUI/selgame.cpp:415
 #, c-format
-msgid "Your version %s does not match the host %d.%d.%d."
+msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr ""
-"Ваша версия игры (%s) не соответствует с версией игры на сервере (%d.%d.%d)"
+"Ваша версия игры ({:s}) не соответствует с версией игры на сервере ({:d}.{:d}.{:d})"
 
 #: Source/DiabloUI/selhero.cpp:123
 msgid "New Hero"
@@ -678,8 +678,8 @@ msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:345
 #, c-format
-msgid "Character already exists. Do you want to overwrite \"%s\"?"
-msgstr "Персонаж уже существует. Хотите его перезаписать \"%s\"?"
+msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
+msgstr "Персонаж уже существует. Хотите его перезаписать \"{:s}\"?"
 
 #: Source/DiabloUI/selhero.cpp:357
 msgid "Unable to create character."
@@ -727,8 +727,8 @@ msgstr "Удалить персонажа для одиночной игры"
 
 #: Source/DiabloUI/selhero.cpp:621
 #, c-format
-msgid "Are you sure you want to delete the character \"%s\"?"
-msgstr "Вы действительно хотите удалить персонажа \"%s\"?"
+msgid "Are you sure you want to delete the character \"{:s}\"?"
+msgstr "Вы действительно хотите удалить персонажа \"{:s}\"?"
 
 #: Source/DiabloUI/selyesno.cpp:61 Source/stores.cpp:890
 msgid "Yes"
@@ -808,13 +808,13 @@ msgstr "Ошибка"
 #: Source/appfat.cpp:117
 #, c-format
 msgid ""
-"%s\n"
+"{:s}\n"
 "\n"
-"The error occurred at: %s line %d"
+"The error occurred at: {:s} line {:d}"
 msgstr ""
-"%s\n"
+"{:s}\n"
 "\n"
-"Ошибка: в %s в строке %d"
+"Ошибка: в {:s} в строке {:d}"
 
 #: Source/appfat.cpp:137
 #, c-format
@@ -826,7 +826,7 @@ msgid ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "The problem occurred when loading:\n"
-"%s"
+"{:s}"
 msgstr ""
 "Невозможно открыть нужный файл.\n"
 "\n"
@@ -835,7 +835,7 @@ msgstr ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "Ошибка произошла во время загрузки:\n"
-"%s"
+"{:s}"
 
 #: Source/appfat.cpp:146 Source/appfat.cpp:165
 msgid "Data File Error"
@@ -855,10 +855,10 @@ msgstr ""
 #, c-format
 msgid ""
 "Unable to write to location:\n"
-"%s"
+"{:s}"
 msgstr ""
 "Невозможно записать в:\n"
-"%s"
+"{:s}"
 
 #: Source/appfat.cpp:178
 msgid "Read-Only Directory Error"
@@ -874,18 +874,18 @@ msgstr "пароль: "
 
 #: Source/automap.cpp:405
 #, c-format
-msgid "Level: Nest %i"
-msgstr "Уровень: Nest %i"
+msgid "Level: Nest {:d}"
+msgstr "Уровень: Nest {:d}"
 
 #: Source/automap.cpp:407
 #, c-format
-msgid "Level: Crypt %i"
-msgstr "Уровень: Crypt %i"
+msgid "Level: Crypt {:d}"
+msgstr "Уровень: Crypt {:d}"
 
 #: Source/automap.cpp:409 Source/items.cpp:3816
 #, c-format
-msgid "Level: %i"
-msgstr "Уровень: %i"
+msgid "Level: {:d}"
+msgstr "Уровень: {:d}"
 
 #: Source/control.cpp:190
 msgid "Tab"
@@ -929,13 +929,13 @@ msgstr "Отправить сообщение"
 
 #: Source/control.cpp:394 Source/control.cpp:937
 #, c-format
-msgid "%s Skill"
-msgstr "%s навык"
+msgid "{:s} Skill"
+msgstr "{:s} навык"
 
 #: Source/control.cpp:397 Source/control.cpp:941
 #, c-format
-msgid "%s Spell"
-msgstr "Заклинание %s"
+msgid "{:s} Spell"
+msgstr "Заклинание {:s}"
 
 #: Source/control.cpp:399
 msgid "Damages undead only"
@@ -947,39 +947,39 @@ msgstr "Уровень заклинаний 0 - Нельзя использов�
 
 #: Source/control.cpp:405 Source/control.cpp:949 Source/control.cpp:1662
 #, c-format
-msgid "Spell Level %i"
-msgstr "Уровень заклинания %i"
+msgid "Spell Level {:d}"
+msgstr "Уровень заклинания {:d}"
 
 #: Source/control.cpp:409 Source/control.cpp:953
 #, c-format
-msgid "Scroll of %s"
-msgstr "Свиток о %s"
+msgid "Scroll of {:s}"
+msgstr "Свиток о {:s}"
 
 #: Source/control.cpp:425 Source/control.cpp:970
 #, c-format
-msgid "%i Scroll"
-msgid_plural "%i Scrolls"
-msgstr[0] "%i свиток"
-msgstr[1] "%i свитка"
-msgstr[2] "%i свитков"
+msgid "{:d} Scroll"
+msgid_plural "{:d} Scrolls"
+msgstr[0] "{:d} свиток"
+msgstr[1] "{:d} свитка"
+msgstr[2] "{:d} свитков"
 
 #: Source/control.cpp:429 Source/control.cpp:974 Source/items.cpp:1570
 #, c-format
-msgid "Staff of %s"
-msgstr "Посох %s"
+msgid "Staff of {:s}"
+msgstr "Посох {:s}"
 
 #: Source/control.cpp:431 Source/control.cpp:976
 #, c-format
-msgid "%i Charge"
-msgid_plural "%i Charges"
-msgstr[0] "%i заряд"
-msgstr[1] "%i заряда"
-msgstr[2] "%i зарядов"
+msgid "{:d} Charge"
+msgid_plural "{:d} Charges"
+msgstr[0] "{:d} заряд"
+msgstr[1] "{:d} заряда"
+msgstr[2] "{:d} зарядов"
 
 #: Source/control.cpp:441
 #, c-format
-msgid "Spell Hotkey %s"
-msgstr "Горячая клавиша %s"
+msgid "Spell Hotkey {:s}"
+msgstr "Горячая клавиша {:s}"
 
 #: Source/control.cpp:913
 msgid "Player friendly"
@@ -991,8 +991,8 @@ msgstr ""
 
 #: Source/control.cpp:918
 #, c-format
-msgid "Hotkey: %s"
-msgstr "Горячая клавиша: %s"
+msgid "Hotkey: {:s}"
+msgstr "Горячая клавиша: {:s}"
 
 #: Source/control.cpp:927
 msgid "Select current spell button"
@@ -1004,11 +1004,11 @@ msgstr "Горячая клавиша: 's'"
 
 #: Source/control.cpp:1122 Source/inv.cpp:2066 Source/items.cpp:3050
 #, c-format
-msgid "%i gold piece"
-msgid_plural "%i gold pieces"
-msgstr[0] "%i золотой"
-msgstr[1] "%i золотых"
-msgstr[2] "%i золотых"
+msgid "{:d} gold piece"
+msgid_plural "{:d} gold pieces"
+msgstr[0] "{:d} золотой"
+msgstr[1] "{:d} золотых"
+msgstr[2] "{:d} золотых"
 
 #: Source/control.cpp:1125
 msgid "Requirements not met"
@@ -1016,12 +1016,12 @@ msgstr ""
 
 #: Source/control.cpp:1163
 #, c-format
-msgid "%s, Level: %i"
+msgid "{:s}, Level: {:d}"
 msgstr ""
 
 #: Source/control.cpp:1165
 #, c-format
-msgid "Hit Points %i of %i"
+msgid "Hit Points {:d} of {:d}"
 msgstr ""
 
 #: Source/control.cpp:1190
@@ -1042,25 +1042,25 @@ msgstr ""
 
 #: Source/control.cpp:1639
 #, c-format
-msgid "Staff (%i charge)"
-msgid_plural "Staff (%i charges)"
+msgid "Staff ({:d} charge)"
+msgid_plural "Staff ({:d} charges)"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
 #: Source/control.cpp:1647
 #, c-format
-msgid "Mana: %i  Dam: %i - %i"
+msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr ""
 
 #: Source/control.cpp:1649
 #, c-format
-msgid "Mana: %i   Dam: n/a"
+msgid "Mana: {:d}   Dam: n/a"
 msgstr ""
 
 #: Source/control.cpp:1652
 #, c-format
-msgid "Mana: %i  Dam: 1/3 tgt hp"
+msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr ""
 
 #: Source/control.cpp:1704
@@ -1101,7 +1101,7 @@ msgstr ""
 
 #: Source/cursor.cpp:206
 #, c-format
-msgid "from %s"
+msgid "from {:s}"
 msgstr ""
 
 #: Source/cursor.cpp:231
@@ -1210,13 +1210,13 @@ msgstr ""
 
 #: Source/diablo.cpp:283
 #, c-format
-msgid "unrecognized option '%s'\n"
-msgstr "неизвестный параметр '%s'\n"
+msgid "unrecognized option '{:s}'\n"
+msgstr "неизвестный параметр '{:s}'\n"
 
 #: Source/diablo.cpp:671
 #, c-format
-msgid "version %s"
-msgstr "версия %s"
+msgid "version {:s}"
+msgstr "версия {:s}"
 
 #: Source/diablo.cpp:1916
 msgid "-- Network timeout --"
@@ -1236,7 +1236,7 @@ msgstr ""
 
 #: Source/diablo.cpp:2201
 #, c-format
-msgid "%s, version = %s, mode = %s"
+msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr ""
 
 #: Source/dvlnet/loopback.cpp:113
@@ -3605,12 +3605,12 @@ msgstr ""
 #: Source/items.cpp:1527 Source/items.cpp:1569 Source/items.cpp:2161
 #: Source/items.cpp:2180
 #, c-format
-msgid "%s of %s"
+msgid "{:s} of {:s}"
 msgstr ""
 
 #: Source/items.cpp:2753 Source/player.cpp:1874
 #, c-format
-msgid "Ear of %s"
+msgid "Ear of {:s}"
 msgstr ""
 
 #: Source/items.cpp:3282 Source/items.cpp:3294
@@ -3760,32 +3760,32 @@ msgstr ""
 
 #: Source/items.cpp:3431
 #, c-format
-msgid "chance to hit: %+i%%"
+msgid "chance to hit: {:+d}%"
 msgstr ""
 
 #: Source/items.cpp:3435
 #, c-format
-msgid "%+i%% damage"
+msgid "{:+d}% damage"
 msgstr ""
 
 #: Source/items.cpp:3439 Source/items.cpp:3697
 #, c-format
-msgid "to hit: %+i%%, %+i%% damage"
+msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr ""
 
 #: Source/items.cpp:3443
 #, c-format
-msgid "%+i%% armor"
+msgid "{:+d}% armor"
 msgstr ""
 
 #: Source/items.cpp:3446 Source/items.cpp:3449
 #, c-format
-msgid "armor class: %i"
+msgid "armor class: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3454 Source/items.cpp:3679
 #, c-format
-msgid "Resist Fire: %+i%%"
+msgid "Resist Fire: {:+d}%"
 msgstr ""
 
 #: Source/items.cpp:3456
@@ -3795,7 +3795,7 @@ msgstr ""
 
 #: Source/items.cpp:3461
 #, c-format
-msgid "Resist Lightning: %+i%%"
+msgid "Resist Lightning: {:+d}%"
 msgstr ""
 
 #: Source/items.cpp:3463
@@ -3805,7 +3805,7 @@ msgstr ""
 
 #: Source/items.cpp:3468
 #, c-format
-msgid "Resist Magic: %+i%%"
+msgid "Resist Magic: {:+d}%"
 msgstr ""
 
 #: Source/items.cpp:3470
@@ -3815,7 +3815,7 @@ msgstr ""
 
 #: Source/items.cpp:3475
 #, c-format
-msgid "Resist All: %+i%%"
+msgid "Resist All: {:+d}%"
 msgstr ""
 
 #: Source/items.cpp:3477
@@ -3825,16 +3825,16 @@ msgstr ""
 
 #: Source/items.cpp:3481
 #, c-format
-msgid "spells are increased %i level"
-msgid_plural "spells are increased %i levels"
+msgid "spells are increased {:d} level"
+msgid_plural "spells are increased {:d} levels"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
 #: Source/items.cpp:3483
 #, c-format
-msgid "spells are decreased %i level"
-msgid_plural "spells are decreased %i levels"
+msgid "spells are decreased {:d} level"
+msgid_plural "spells are decreased {:d} levels"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
@@ -3849,70 +3849,70 @@ msgstr ""
 
 #: Source/items.cpp:3491
 #, c-format
-msgid "%i %s charge"
-msgid_plural "%i %s charges"
+msgid "{:d} {:s} charge"
+msgid_plural "{:d} {:s} charges"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
 #: Source/items.cpp:3495
 #, c-format
-msgid "Fire hit damage: %i"
+msgid "Fire hit damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3497
 #, c-format
-msgid "Fire hit damage: %i-%i"
+msgid "Fire hit damage: {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3501
 #, c-format
-msgid "Lightning hit damage: %i"
+msgid "Lightning hit damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3503
 #, c-format
-msgid "Lightning hit damage: %i-%i"
+msgid "Lightning hit damage: {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3507
 #, c-format
-msgid "%+i to strength"
+msgid "{:+d} to strength"
 msgstr ""
 
 #: Source/items.cpp:3511
 #, c-format
-msgid "%+i to magic"
+msgid "{:+d} to magic"
 msgstr ""
 
 #: Source/items.cpp:3515
 #, c-format
-msgid "%+i to dexterity"
+msgid "{:+d} to dexterity"
 msgstr ""
 
 #: Source/items.cpp:3519
 #, c-format
-msgid "%+i to vitality"
+msgid "{:+d} to vitality"
 msgstr ""
 
 #: Source/items.cpp:3523
 #, c-format
-msgid "%+i to all attributes"
+msgid "{:+d} to all attributes"
 msgstr ""
 
 #: Source/items.cpp:3527
 #, c-format
-msgid "%+i damage from enemies"
+msgid "{:+d} damage from enemies"
 msgstr ""
 
 #: Source/items.cpp:3531
 #, c-format
-msgid "Hit Points: %+i"
+msgid "Hit Points: {:+d}"
 msgstr ""
 
 #: Source/items.cpp:3535
 #, c-format
-msgid "Mana: %+i"
+msgid "Mana: {:+d}"
 msgstr ""
 
 #: Source/items.cpp:3538
@@ -3929,12 +3929,12 @@ msgstr ""
 
 #: Source/items.cpp:3547
 #, c-format
-msgid "+%i%% light radius"
+msgid "+{:d}%% light radius"
 msgstr ""
 
 #: Source/items.cpp:3550
 #, c-format
-msgid "-%i%% light radius"
+msgid "-{:d}%% light radius"
 msgstr ""
 
 #: Source/items.cpp:3553
@@ -3943,32 +3943,32 @@ msgstr ""
 
 #: Source/items.cpp:3557
 #, c-format
-msgid "fire arrows damage: %i"
+msgid "fire arrows damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3559
 #, c-format
-msgid "fire arrows damage: %i-%i"
+msgid "fire arrows damage: {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3563
 #, c-format
-msgid "lightning arrows damage %i"
+msgid "lightning arrows damage {:d}"
 msgstr ""
 
 #: Source/items.cpp:3565
 #, c-format
-msgid "lightning arrows damage %i-%i"
+msgid "lightning arrows damage {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3569
 #, c-format
-msgid "fireball damage: %i"
+msgid "fireball damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3571
 #, c-format
-msgid "fireball damage: %i-%i"
+msgid "fireball damage: {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3574
@@ -4062,8 +4062,8 @@ msgstr ""
 
 #: Source/items.cpp:3634
 #, c-format
-msgid "adds %i point to damage"
-msgid_plural "adds %i points to damage"
+msgid "adds {:d} point to damage"
+msgid_plural "adds {:d} points to damage"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
@@ -4106,12 +4106,12 @@ msgstr ""
 
 #: Source/items.cpp:3668
 #, c-format
-msgid "lightning damage: %i"
+msgid "lightning damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3670
 #, c-format
-msgid "lightning damage: %i-%i"
+msgid "lightning damage: {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3673
@@ -4124,7 +4124,7 @@ msgstr ""
 
 #: Source/items.cpp:3685
 #, c-format
-msgid "decaying %+i%% damage"
+msgid "decaying {:+d}% damage"
 msgstr ""
 
 #: Source/items.cpp:3688
@@ -4138,7 +4138,7 @@ msgstr ""
 
 #: Source/items.cpp:3694
 #, c-format
-msgid "low dur, %+i%% damage"
+msgid "low dur, {:+d}% damage"
 msgstr ""
 
 #: Source/items.cpp:3700
@@ -4201,63 +4201,63 @@ msgstr ""
 
 #: Source/items.cpp:3834 Source/stores.cpp:201
 #, c-format
-msgid " %i Str"
+msgid " {:d} Str"
 msgstr ""
 
 #: Source/items.cpp:3836 Source/stores.cpp:203
 #, c-format
-msgid " %i Mag"
+msgid " {:d} Mag"
 msgstr ""
 
 #: Source/items.cpp:3838 Source/stores.cpp:205
 #, c-format
-msgid " %i Dex"
+msgid " {:d} Dex"
 msgstr ""
 
 #: Source/items.cpp:3849 Source/items.cpp:3896
 #, c-format
-msgid "damage: %i  Indestructible"
+msgid "damage: {:d}  Indestructible"
 msgstr ""
 
 #: Source/items.cpp:3851 Source/items.cpp:3898
 #, c-format
-msgid "damage: %i  Dur: %i/%i"
+msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3854 Source/items.cpp:3901
 #, c-format
-msgid "damage: %i-%i  Indestructible"
+msgid "damage: {:d}-{:d}  Indestructible"
 msgstr ""
 
 #: Source/items.cpp:3856 Source/items.cpp:3903
 #, c-format
-msgid "damage: %i-%i  Dur: %i/%i"
+msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3862 Source/items.cpp:3915
 #, c-format
-msgid "armor: %i  Indestructible"
+msgid "armor: {:d}  Indestructible"
 msgstr ""
 
 #: Source/items.cpp:3864 Source/items.cpp:3917
 #, c-format
-msgid "armor: %i  Dur: %i/%i"
+msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3869
 #, c-format
-msgid "dam: %i  Dur: %i/%i"
+msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3871
 #, c-format
-msgid "dam: %i-%i  Dur: %i/%i"
+msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3872 Source/items.cpp:3907 Source/items.cpp:3922
 #: Source/stores.cpp:171
 #, c-format
-msgid "Charges: %i/%i"
+msgid "Charges: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3884
@@ -5166,18 +5166,18 @@ msgstr "Нежить"
 
 #: Source/monster.cpp:4966
 #, c-format
-msgid "Type: %s  Kills: %i"
-msgstr "Тип: %s  Убито: %i"
+msgid "Type: {:s}  Kills: {:d}"
+msgstr "Тип: {:s}  Убито: {:d}"
 
 #: Source/monster.cpp:4968
 #, c-format
-msgid "Total kills: %i"
-msgstr "Убито: %i"
+msgid "Total kills: {:d}"
+msgstr "Убито: {:d}"
 
 #: Source/monster.cpp:5001
 #, c-format
-msgid "Hit Points: %i-%i"
-msgstr "Здоровье: %i-%i"
+msgid "Hit Points: {:d}-{:d}"
+msgstr "Здоровье: {:d}-{:d}"
 
 #: Source/monster.cpp:5011
 msgid "No magic resistance"
@@ -5205,8 +5205,8 @@ msgstr "Иммунитет: "
 
 #: Source/monster.cpp:5046
 #, c-format
-msgid "Type: %s"
-msgstr "Тип: %s"
+msgid "Type: {:s}"
+msgstr "Тип: {:s}"
 
 #: Source/monster.cpp:5052 Source/monster.cpp:5059
 msgid "No resistances"
@@ -5244,32 +5244,32 @@ msgstr ""
 #: Source/msg.cpp:1709 Source/msg.cpp:1829 Source/msg.cpp:1850
 #: Source/msg.cpp:1871 Source/msg.cpp:1892
 #, c-format
-msgid "%s has cast an illegal spell."
+msgid "{:s} has cast an illegal spell."
 msgstr ""
 
 #: Source/msg.cpp:2228 Source/multi.cpp:859
 #, c-format
-msgid "Player '%s' (level %d) just joined the game"
+msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr ""
 
 #: Source/multi.cpp:262
 #, c-format
-msgid "Player '%s' just left the game"
+msgid "Player '{:s}' just left the game"
 msgstr ""
 
 #: Source/multi.cpp:265
 #, c-format
-msgid "Player '%s' killed Diablo and left the game!"
+msgid "Player '{:s}' killed Diablo and left the game!"
 msgstr ""
 
 #: Source/multi.cpp:269
 #, c-format
-msgid "Player '%s' dropped due to timeout"
+msgid "Player '{:s}' dropped due to timeout"
 msgstr ""
 
 #: Source/multi.cpp:861
 #, c-format
-msgid "Player '%s' (level %d) is already in the game"
+msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr ""
 
 #: Source/objects.cpp:90
@@ -5532,8 +5532,8 @@ msgstr "Бочка"
 
 #: Source/objects.cpp:5508
 #, c-format
-msgid "%s Shrine"
-msgstr "%s святыня"
+msgid "{:s} Shrine"
+msgstr "{:s} святыня"
 
 #: Source/objects.cpp:5512
 msgid "Skeleton Tome"
@@ -5605,13 +5605,13 @@ msgstr "Убитый Герой"
 
 #: Source/objects.cpp:5577
 #, fuzzy, c-format
-msgid "Trapped %s"
-msgstr "Пойманная %s"
+msgid "Trapped {:s}"
+msgstr "Пойманная {:s}"
 
 #: Source/objects.cpp:5583
 #, c-format
-msgid "%s (disabled)"
-msgstr "%s (отключено)"
+msgid "{:s} (disabled)"
+msgstr "{:s} (отключено)"
 
 #: Source/pfile.cpp:219
 msgid "Failed to open player archive for writing."
@@ -5635,7 +5635,7 @@ msgstr ""
 
 #: Source/plrmsg.cpp:73
 #, c-format
-msgid "%s (lvl %d): %s"
+msgid "{:s} (lvl {:d}): {:s}"
 msgstr ""
 
 #: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:52
@@ -5647,8 +5647,8 @@ msgstr ""
 
 #: Source/qol/xpbar.cpp:124
 #, c-format
-msgid "Level %d"
-msgstr "Уровень %d"
+msgid "Level {:d}"
+msgstr "Уровень {:d}"
 
 #: Source/qol/xpbar.cpp:131 Source/qol/xpbar.cpp:142
 msgid "Experience: "
@@ -5664,8 +5664,8 @@ msgstr "Следующий Уровень: "
 
 #: Source/qol/xpbar.cpp:150
 #, c-format
-msgid " to Level %d"
-msgstr " до Уровня %d"
+msgid " to Level {:d}"
+msgstr " до Уровня {:d}"
 
 #: Source/quests.cpp:41
 msgid "The Magic Rock"
@@ -5747,8 +5747,8 @@ msgstr "Нечестивый алтарь"
 
 #: Source/quests.cpp:285
 #, c-format
-msgid "To %s"
-msgstr "К %s"
+msgid "To {:s}"
+msgstr "К {:s}"
 
 #: Source/quests.cpp:722
 msgid "Quest Log"
@@ -5952,17 +5952,17 @@ msgstr ""
 
 #: Source/stores.cpp:182
 #, c-format
-msgid "Damage: %i-%i  "
+msgid "Damage: {:d}-{:d}  "
 msgstr ""
 
 #: Source/stores.cpp:184
 #, c-format
-msgid "Armor: %i  "
+msgid "Armor: {:d}  "
 msgstr ""
 
 #: Source/stores.cpp:186
 #, c-format
-msgid "Dur: %i/%i,  "
+msgid "Dur: {:d}/{:d},  "
 msgstr ""
 
 #: Source/stores.cpp:189
@@ -6013,8 +6013,8 @@ msgstr "Покинуть магазин"
 
 #: Source/stores.cpp:276 Source/stores.cpp:625 Source/stores.cpp:991
 #, c-format
-msgid "I have these items for sale:             Your gold: %i"
-msgstr "У меня есть на продажу:                Ваше золото: %i"
+msgid "I have these items for sale:             Your gold: {:d}"
+msgstr "У меня есть на продажу:                Ваше золото: {:d}"
 
 #: Source/stores.cpp:281 Source/stores.cpp:345 Source/stores.cpp:473
 #: Source/stores.cpp:484 Source/stores.cpp:543 Source/stores.cpp:556
@@ -6028,28 +6028,28 @@ msgstr "Назад"
 # “премиальные прдеметы” не влезают в длину строки
 #: Source/stores.cpp:341
 #, c-format
-msgid "I have these premium items for sale:     Your gold: %i"
-msgstr "У меня есть на продажу:                Ваше золото: %i"
+msgid "I have these premium items for sale:     Your gold: {:d}"
+msgstr "У меня есть на продажу:                Ваше золото: {:d}"
 
 #: Source/stores.cpp:469 Source/stores.cpp:719
 #, c-format
-msgid "You have nothing I want.             Your gold: %i"
-msgstr "У вас нет ничего нужного мне.      Ваше золото: %i"
+msgid "You have nothing I want.             Your gold: {:d}"
+msgstr "У вас нет ничего нужного мне.      Ваше золото: {:d}"
 
 #: Source/stores.cpp:479 Source/stores.cpp:729
 #, c-format
-msgid "Which item is for sale?             Your gold: %i"
-msgstr "Какой предмет продать?            Ваше золото: %i"
+msgid "Which item is for sale?             Your gold: {:d}"
+msgstr "Какой предмет продать?            Ваше золото: {:d}"
 
 #: Source/stores.cpp:539
 #, c-format
-msgid "You have nothing to repair.             Your gold: %i"
-msgstr "У вас нечего чинить.                  Ваше золото: %i"
+msgid "You have nothing to repair.             Your gold: {:d}"
+msgstr "У вас нечего чинить.                  Ваше золото: {:d}"
 
 #: Source/stores.cpp:551
 #, c-format
-msgid "Repair which item?             Your gold: %i"
-msgstr "Какой предмет починить?      Ваше золото: %i"
+msgid "Repair which item?             Your gold: {:d}"
+msgstr "Какой предмет починить?      Ваше золото: {:d}"
 
 #: Source/stores.cpp:577
 msgid "Witch's shack"
@@ -6073,13 +6073,13 @@ msgstr "Покинуть хижину"
 
 #: Source/stores.cpp:795
 #, c-format
-msgid "You have nothing to recharge.             Your gold: %i"
-msgstr "У вас нечего заряжать.                  Ваше золото: %i"
+msgid "You have nothing to recharge.             Your gold: {:d}"
+msgstr "У вас нечего заряжать.                  Ваше золото: {:d}"
 
 #: Source/stores.cpp:805
 #, c-format
-msgid "Recharge which item?             Your gold: %i"
-msgstr "Какой предмет зарядить?        Ваше золото: %i"
+msgid "Recharge which item?             Your gold: {:d}"
+msgstr "Какой предмет зарядить?        Ваше золото: {:d}"
 
 #: Source/stores.cpp:821
 msgid "You do not have enough gold"
@@ -6144,8 +6144,8 @@ msgstr "Попрощаться"
 
 #: Source/stores.cpp:917
 #, c-format
-msgid "I have this item for sale:             Your gold: %i"
-msgstr "У меня есть на продажу:              Ваше золото: %i"
+msgid "I have this item for sale:             Your gold: {:d}"
+msgstr "У меня есть на продажу:              Ваше золото: {:d}"
 
 # уйти
 # выйти
@@ -6179,14 +6179,14 @@ msgstr "Идентифицировать предмет"
 
 #: Source/stores.cpp:1092
 #, c-format
-msgid "You have nothing to identify.             Your gold: %i"
-msgstr "У вас нечего идентифицировать.          Ваше золото: %i"
+msgid "You have nothing to identify.             Your gold: {:d}"
+msgstr "У вас нечего идентифицировать.          Ваше золото: {:d}"
 
 # Нужно выровнять с остальными строками
 #: Source/stores.cpp:1102
 #, c-format
-msgid "Identify which item?             Your gold: %i"
-msgstr "Какой предмет идентифицировать? Ваше золото: %i"
+msgid "Identify which item?             Your gold: {:d}"
+msgstr "Какой предмет идентифицировать? Ваше золото: {:d}"
 
 #: Source/stores.cpp:1119
 msgid "This item is:"
@@ -6198,13 +6198,13 @@ msgstr "Готово"
 
 #: Source/stores.cpp:1131
 #, c-format
-msgid "Talk to %s"
-msgstr "Поговорить с %s"
+msgid "Talk to {:s}"
+msgstr "Поговорить с {:s}"
 
 #: Source/stores.cpp:1135
 #, c-format
-msgid "Talking to %s"
-msgstr "Разговор с %s"
+msgid "Talking to {:s}"
+msgstr "Разговор с {:s}"
 
 #: Source/stores.cpp:1137
 msgid "is not available"
@@ -9880,8 +9880,8 @@ msgstr "Спустится в Улей"
 #: Source/trigs.cpp:397 Source/trigs.cpp:484 Source/trigs.cpp:536
 #: Source/trigs.cpp:635
 #, c-format
-msgid "Up to level %i"
-msgstr "Подняться на уровень %i"
+msgid "Up to level {:d}"
+msgstr "Подняться на уровень {:d}"
 
 #: Source/trigs.cpp:399 Source/trigs.cpp:458 Source/trigs.cpp:515
 #: Source/trigs.cpp:597 Source/trigs.cpp:615 Source/trigs.cpp:667
@@ -9891,23 +9891,23 @@ msgstr "Подняться в город"
 #: Source/trigs.cpp:411 Source/trigs.cpp:496 Source/trigs.cpp:550
 #: Source/trigs.cpp:577 Source/trigs.cpp:648
 #, c-format
-msgid "Down to level %i"
-msgstr "Спуститься на уровень %i"
+msgid "Down to level {:d}"
+msgstr "Спуститься на уровень {:d}"
 
 #: Source/trigs.cpp:424
 #, c-format
-msgid "Up to Crypt level %i"
-msgstr "Подняться в Склеп на уровень %i"
+msgid "Up to Crypt level {:d}"
+msgstr "Подняться в Склеп на уровень {:d}"
 
 #: Source/trigs.cpp:440
 #, c-format
-msgid "Down to Crypt level %i"
-msgstr "Спуститься в Склеп на уровень %i"
+msgid "Down to Crypt level {:d}"
+msgstr "Спуститься в Склеп на уровень {:d}"
 
 #: Source/trigs.cpp:563
 #, c-format
-msgid "Up to Nest level %i"
-msgstr "Подняться в Гнездо на уровень %i"
+msgid "Up to Nest level {:d}"
+msgstr "Подняться в Гнездо на уровень {:d}"
 
 #: Source/trigs.cpp:681
 msgid "Down to Diablo"
@@ -9915,5 +9915,5 @@ msgstr "Спуститься к Диабло"
 
 #: Source/trigs.cpp:718 Source/trigs.cpp:735 Source/trigs.cpp:752
 #, c-format
-msgid "Back to Level %i"
-msgstr "Вернуться на Уровень %i"
+msgid "Back to Level {:d}"
+msgstr "Вернуться на Уровень {:d}"

--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -417,7 +417,6 @@ msgid "Play by yourself with no network exposure."
 msgstr ""
 
 #: Source/DiabloUI/selconn.cpp:115
-#, c-format
 msgid "Players Supported: {:d}"
 msgstr ""
 
@@ -566,7 +565,6 @@ msgid "The host is running a different game than you."
 msgstr ""
 
 #: Source/DiabloUI/selgame.cpp:415
-#, c-format
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr ""
 
@@ -644,7 +642,6 @@ msgid ""
 msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:345
-#, c-format
 msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
 msgstr ""
 
@@ -693,7 +690,6 @@ msgid "Delete Single Player Hero"
 msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:621
-#, c-format
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr ""
 
@@ -770,7 +766,6 @@ msgid "Error"
 msgstr ""
 
 #: Source/appfat.cpp:117
-#, c-format
 msgid ""
 "{:s}\n"
 "\n"
@@ -778,7 +773,6 @@ msgid ""
 msgstr ""
 
 #: Source/appfat.cpp:137
-#, c-format
 msgid ""
 "Unable to open a required file.\n"
 "\n"
@@ -803,7 +797,6 @@ msgid ""
 msgstr ""
 
 #: Source/appfat.cpp:175
-#, c-format
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -822,17 +815,14 @@ msgid "password: "
 msgstr ""
 
 #: Source/automap.cpp:434 Source/items.cpp:3861
-#, c-format
 msgid "Level: {:d}"
 msgstr "等 级： {:d}"
 
 #: Source/automap.cpp:436
-#, c-format
 msgid "Level: Crypt {:d}"
 msgstr ""
 
 #: Source/automap.cpp:438
-#, c-format
 msgid "Level: Nest {:d}"
 msgstr ""
 
@@ -877,12 +867,10 @@ msgid "Send Message"
 msgstr "发 送 信 息"
 
 #: Source/control.cpp:432 Source/control.cpp:1024
-#, c-format
 msgid "{:s} Skill"
 msgstr "{:s} 技 能"
 
 #: Source/control.cpp:435 Source/control.cpp:1028
-#, c-format
 msgid "{:s} Spell"
 msgstr "{:s} 魔 法"
 
@@ -895,12 +883,10 @@ msgid "Spell Level 0 - Unusable"
 msgstr "0 级 魔 法 -- 不 可 使 用"
 
 #: Source/control.cpp:443 Source/control.cpp:1036 Source/control.cpp:1863
-#, c-format
 msgid "Spell Level {:d}"
 msgstr "魔 法 等 级 {:d}"
 
 #: Source/control.cpp:447 Source/control.cpp:1040
-#, c-format
 msgid "Scroll of {:s}"
 msgstr "{:s} 卷 轴"
 
@@ -910,7 +896,6 @@ msgid_plural "{:d} Scrolls"
 msgstr[0] "{:d} 卷 轴"
 
 #: Source/control.cpp:467 Source/control.cpp:1064 Source/items.cpp:1596
-#, c-format
 msgid "Staff of {:s}"
 msgstr "{:s} 法 杖"
 
@@ -920,7 +905,6 @@ msgid_plural "{:d} Charges"
 msgstr[0] "{:d} 回复"
 
 #: Source/control.cpp:478
-#, c-format
 msgid "Spell Hotkey #F{:d}"
 msgstr "魔 法 快 捷 键 #F{:d}"
 
@@ -933,7 +917,6 @@ msgid "Player attack"
 msgstr "玩 家 互 攻"
 
 #: Source/control.cpp:1005
-#, c-format
 msgid "Hotkey: {:s}"
 msgstr "热 键 ：{:s}"
 
@@ -950,7 +933,6 @@ msgid "1 Scroll"
 msgstr "1 个 卷 轴"
 
 #: Source/control.cpp:1060
-#, c-format
 msgid "{:d} Scrolls"
 msgstr "{:d} 卷 轴"
 
@@ -959,7 +941,6 @@ msgid "1 Charge"
 msgstr "1 金 币"
 
 #: Source/control.cpp:1069
-#, c-format
 msgid "{:d} Charges"
 msgstr "{:d} 回复"
 
@@ -975,12 +956,10 @@ msgid "Requirements not met"
 msgstr "需 要 的 等 级 没 有 达 到"
 
 #: Source/control.cpp:1295
-#, c-format
 msgid "{:s}, Level: {:d}"
 msgstr ""
 
 #: Source/control.cpp:1297
-#, c-format
 msgid "Hit Points {:d} of {:d}"
 msgstr "攻 击 点 数  {:d} / {:d}"
 
@@ -1008,27 +987,22 @@ msgid_plural "Staff ({:d} charges)"
 msgstr[0] "法 杖（{:d} 回复 ）"
 
 #: Source/control.cpp:1848
-#, c-format
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "法 力 ： {:d} 伤 害 ： {:d} - {:d}"
 
 #: Source/control.cpp:1850
-#, c-format
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "法 力 ： {:d} 伤 害 ：n/a"
 
 #: Source/control.cpp:1853
-#, c-format
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "法 力 ： {:d} 伤 害 ：1/3  tgt hp"
 
 #: Source/control.cpp:1900
-#, c-format
 msgid "You have %u gold"
 msgstr "你拥有 %u 金币"
 
 #: Source/control.cpp:1902
-#, c-format
 msgid "piece.  How many do"
 msgid_plural "pieces.  How many do"
 msgstr[0] ""
@@ -1066,7 +1040,6 @@ msgid "Town Portal"
 msgstr "时 空 之 门"
 
 #: Source/cursor.cpp:182
-#, c-format
 msgid "from {:s}"
 msgstr "从 {:s}"
 
@@ -1171,12 +1144,10 @@ msgid ""
 msgstr ""
 
 #: Source/diablo.cpp:267
-#, c-format
 msgid "unrecognized option '{:s}'\n"
 msgstr ""
 
 #: Source/diablo.cpp:649
-#, c-format
 msgid "version {:s}"
 msgstr ""
 
@@ -1189,7 +1160,6 @@ msgid "while in stores"
 msgstr ""
 
 #: Source/diablo.cpp:1453
-#, c-format
 msgid "{:s}, mode = {:s}"
 msgstr ""
 
@@ -3559,12 +3529,10 @@ msgstr ""
 
 #: Source/items.cpp:1553 Source/items.cpp:1594 Source/items.cpp:2187
 #: Source/items.cpp:2206
-#, c-format
 msgid "{:s} of {:s}"
 msgstr "{:s} / {:s}"
 
 #: Source/items.cpp:2779 Source/player.cpp:1817
-#, c-format
 msgid "Ear of {:s}"
 msgstr ""
 
@@ -3714,32 +3682,26 @@ msgid "fully recover life and mana"
 msgstr "完 全 恢 复 生 命 值 和 魔 法 力"
 
 #: Source/items.cpp:3457
-#, c-format
 msgid "chance to hit: {:+d}%"
 msgstr ""
 
 #: Source/items.cpp:3461
-#, c-format
 msgid "{:+d}% damage"
 msgstr ""
 
 #: Source/items.cpp:3465 Source/items.cpp:3723
-#, c-format
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr ""
 
 #: Source/items.cpp:3469
-#, c-format
 msgid "{:+d}% armor"
 msgstr ""
 
 #: Source/items.cpp:3472 Source/items.cpp:3475
-#, c-format
 msgid "armor class: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3480 Source/items.cpp:3705
-#, c-format
 msgid "Resist Fire: {:+d}%"
 msgstr ""
 
@@ -3749,7 +3711,6 @@ msgid "Resist Fire: 75% MAX"
 msgstr ""
 
 #: Source/items.cpp:3487
-#, c-format
 msgid "Resist Lightning: {:+d}%"
 msgstr ""
 
@@ -3759,7 +3720,6 @@ msgid "Resist Lightning: 75% MAX"
 msgstr ""
 
 #: Source/items.cpp:3494
-#, c-format
 msgid "Resist Magic: {:+d}%"
 msgstr ""
 
@@ -3769,7 +3729,6 @@ msgid "Resist Magic: 75% MAX"
 msgstr ""
 
 #: Source/items.cpp:3501
-#, c-format
 msgid "Resist All: {:+d}%"
 msgstr ""
 
@@ -3802,62 +3761,50 @@ msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:d} {:s} 回 复"
 
 #: Source/items.cpp:3521
-#, c-format
 msgid "Fire hit damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3523
-#, c-format
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3527
-#, c-format
 msgid "Lightning hit damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3529
-#, c-format
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3533
-#, c-format
 msgid "{:+d} to strength"
 msgstr ""
 
 #: Source/items.cpp:3537
-#, c-format
 msgid "{:+d} to magic"
 msgstr ""
 
 #: Source/items.cpp:3541
-#, c-format
 msgid "{:+d} to dexterity"
 msgstr ""
 
 #: Source/items.cpp:3545
-#, c-format
 msgid "{:+d} to vitality"
 msgstr ""
 
 #: Source/items.cpp:3549
-#, c-format
 msgid "{:+d} to all attributes"
 msgstr ""
 
 #: Source/items.cpp:3553
-#, c-format
 msgid "{:+d} damage from enemies"
 msgstr ""
 
 #: Source/items.cpp:3557
-#, c-format
 msgid "Hit Points: {:+d}"
 msgstr ""
 
 #: Source/items.cpp:3561
-#, c-format
 msgid "Mana: {:+d}"
 msgstr "魔法: {:+d}"
 
@@ -3874,12 +3821,10 @@ msgid "indestructible"
 msgstr "不 可 毁 坏 的"
 
 #: Source/items.cpp:3573
-#, c-format
 msgid "+{:d}%% light radius"
 msgstr ""
 
 #: Source/items.cpp:3576
-#, c-format
 msgid "-{:d}%% light radius"
 msgstr ""
 
@@ -3888,32 +3833,26 @@ msgid "multiple arrows per shot"
 msgstr ""
 
 #: Source/items.cpp:3583
-#, c-format
 msgid "fire arrows damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3585
-#, c-format
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3589
-#, c-format
 msgid "lightning arrows damage {:d}"
 msgstr ""
 
 #: Source/items.cpp:3591
-#, c-format
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3595
-#, c-format
 msgid "fireball damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3597
-#, c-format
 msgid "fireball damage: {:d}-{:d}"
 msgstr ""
 
@@ -4007,7 +3946,6 @@ msgid "fast block"
 msgstr ""
 
 #: Source/items.cpp:3660
-#, c-format
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] ""
@@ -4049,12 +3987,10 @@ msgid "see with infravision"
 msgstr ""
 
 #: Source/items.cpp:3694
-#, c-format
 msgid "lightning damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3696
-#, c-format
 msgid "lightning damage: {:d}-{:d}"
 msgstr ""
 
@@ -4067,7 +4003,6 @@ msgid "occasional triple damage"
 msgstr ""
 
 #: Source/items.cpp:3711
-#, c-format
 msgid "decaying {:+d}% damage"
 msgstr ""
 
@@ -4081,7 +4016,6 @@ msgid "Random 0 - 500% damage"
 msgstr ""
 
 #: Source/items.cpp:3720
-#, c-format
 msgid "low dur, {:+d}% damage"
 msgstr ""
 
@@ -4144,63 +4078,51 @@ msgid "Required:"
 msgstr ""
 
 #: Source/items.cpp:3879 Source/stores.cpp:199
-#, c-format
 msgid " {:d} Str"
 msgstr ""
 
 #: Source/items.cpp:3881 Source/stores.cpp:201
-#, c-format
 msgid " {:d} Mag"
 msgstr ""
 
 #: Source/items.cpp:3883 Source/stores.cpp:203
-#, c-format
 msgid " {:d} Dex"
 msgstr ""
 
 #: Source/items.cpp:3894 Source/items.cpp:3941
-#, c-format
 msgid "damage: {:d}  Indestructible"
 msgstr ""
 
 #: Source/items.cpp:3896 Source/items.cpp:3943
-#, c-format
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3899 Source/items.cpp:3946
-#, c-format
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr ""
 
 #: Source/items.cpp:3901 Source/items.cpp:3948
-#, c-format
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3907 Source/items.cpp:3960
-#, c-format
 msgid "armor: {:d}  Indestructible"
 msgstr ""
 
 #: Source/items.cpp:3909 Source/items.cpp:3962
-#, c-format
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3914
-#, c-format
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3916
-#, c-format
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3917 Source/items.cpp:3952 Source/items.cpp:3967
 #: Source/stores.cpp:169
-#, c-format
 msgid "Charges: {:d}/{:d}"
 msgstr "回复: {:d}/{:d}"
 
@@ -5111,17 +5033,14 @@ msgid "Undead"
 msgstr ""
 
 #: Source/monster.cpp:4969
-#, c-format
 msgid "Type: {:s}  Kills: {:d}"
 msgstr ""
 
 #: Source/monster.cpp:4971
-#, c-format
 msgid "Total kills: {:d}"
 msgstr ""
 
 #: Source/monster.cpp:5004
-#, c-format
 msgid "Hit Points: {:d}-{:d}"
 msgstr "攻 击 点 数 魔 法 岩 石：{:d} / {:d}"
 
@@ -5150,7 +5069,6 @@ msgid "Immune: "
 msgstr ""
 
 #: Source/monster.cpp:5049
-#, c-format
 msgid "Type: {:s}"
 msgstr ""
 
@@ -5189,32 +5107,26 @@ msgstr ""
 #: Source/msg.cpp:1387 Source/msg.cpp:1658 Source/msg.cpp:1680
 #: Source/msg.cpp:1702 Source/msg.cpp:1822 Source/msg.cpp:1843
 #: Source/msg.cpp:1864 Source/msg.cpp:1885
-#, c-format
 msgid "{:s} has cast an illegal spell."
 msgstr ""
 
 #: Source/msg.cpp:2221 Source/multi.cpp:866
-#, c-format
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr ""
 
 #: Source/multi.cpp:269
-#, c-format
 msgid "Player '{:s}' just left the game"
 msgstr ""
 
 #: Source/multi.cpp:272
-#, c-format
 msgid "Player '{:s}' killed Diablo and left the game!"
 msgstr ""
 
 #: Source/multi.cpp:276
-#, c-format
 msgid "Player '{:s}' dropped due to timeout"
 msgstr ""
 
 #: Source/multi.cpp:868
-#, c-format
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr ""
 
@@ -5475,7 +5387,6 @@ msgid "Barrel"
 msgstr ""
 
 #: Source/objects.cpp:5544
-#, c-format
 msgid "{:s} Shrine"
 msgstr ""
 
@@ -5548,12 +5459,10 @@ msgid "Slain Hero"
 msgstr "被 杀 死 的 英 雄"
 
 #: Source/objects.cpp:5613
-#, c-format
 msgid "Trapped {:s}"
 msgstr ""
 
 #: Source/objects.cpp:5619
-#, c-format
 msgid "{:s} (disabled)"
 msgstr ""
 
@@ -5578,7 +5487,6 @@ msgid "Unable to write to save file archive"
 msgstr ""
 
 #: Source/plrmsg.cpp:72
-#, c-format
 msgid "{:s} (lvl {:d}): {:s}"
 msgstr ""
 
@@ -5588,7 +5496,6 @@ msgid ""
 msgstr ""
 
 #: Source/qol/xpbar.cpp:122
-#, c-format
 msgid "Level {:d}"
 msgstr "等 级 {:d}"
 
@@ -5605,7 +5512,6 @@ msgid "Next Level: "
 msgstr ""
 
 #: Source/qol/xpbar.cpp:148
-#, c-format
 msgid " to Level {:d}"
 msgstr ""
 
@@ -5688,7 +5594,6 @@ msgid "Unholy Altar"
 msgstr "邪 恶 祭 坛"
 
 #: Source/quests.cpp:283
-#, c-format
 msgid "To {:s}"
 msgstr ""
 
@@ -5896,17 +5801,14 @@ msgid ",  "
 msgstr ""
 
 #: Source/stores.cpp:180
-#, c-format
 msgid "Damage: {:d}-{:d}  "
 msgstr ""
 
 #: Source/stores.cpp:182
-#, c-format
 msgid "Armor: {:d}  "
 msgstr "防 御：{:d}  "
 
 #: Source/stores.cpp:184
-#, c-format
 msgid "Dur: {:d}/{:d},  "
 msgstr ""
 
@@ -5957,7 +5859,6 @@ msgid "Leave the shop"
 msgstr "离 开 铁 匠 铺"
 
 #: Source/stores.cpp:274 Source/stores.cpp:623 Source/stores.cpp:989
-#, c-format
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "我 有 一 些 物 品 要 卖 ：              你 的 金 币：{:d}"
 
@@ -5971,27 +5872,22 @@ msgid "Back"
 msgstr "回 到 上 一 级"
 
 #: Source/stores.cpp:339
-#, c-format
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "我 有 一 些 高 级 物 品 要 卖 ：      你 的 金 币：{:d}"
 
 #: Source/stores.cpp:467 Source/stores.cpp:717
-#, c-format
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "你 没 有 我 想 要 的 物 品 ？             你 的 金 币 ：{:d}"
 
 #: Source/stores.cpp:477 Source/stores.cpp:727
-#, c-format
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "你 想 卖 哪 个 物 品 ？             你 的 金 币 ：{:d}"
 
 #: Source/stores.cpp:537
-#, c-format
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "你 没 有 需 要 修 补 的 物 品 ？             你 的 金 币 ：{:d}"
 
 #: Source/stores.cpp:549
-#, c-format
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "要 修 补 哪 个 物 品 ？              你 的 金 币 ：{:d}"
 
@@ -6016,12 +5912,10 @@ msgid "Leave the shack"
 msgstr "离 开 女 巫 小 屋"
 
 #: Source/stores.cpp:793
-#, c-format
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "你没有东西可以回购。             你的金币: {:d}"
 
 #: Source/stores.cpp:803
-#, c-format
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "回购哪个物品？             你的金币：{:d}"
 
@@ -6087,7 +5981,6 @@ msgid "Say goodbye"
 msgstr "结 束 交 谈"
 
 #: Source/stores.cpp:915
-#, c-format
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "我有这个物品要出售。             你的金币: {:d}"
 
@@ -6120,12 +6013,10 @@ msgid "Identify an item"
 msgstr "鉴 定 物 品"
 
 #: Source/stores.cpp:1090
-#, c-format
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "你没有需要鉴定的物品。             你的金币: {:d}"
 
 #: Source/stores.cpp:1100
-#, c-format
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "鉴定哪样物品。             你的金币: {:d}"
 
@@ -6138,12 +6029,10 @@ msgid "Done"
 msgstr "好"
 
 #: Source/stores.cpp:1129
-#, c-format
 msgid "Talk to {:s}"
 msgstr "和 {:s} 聊天"
 
 #: Source/stores.cpp:1133
-#, c-format
 msgid "Talking to {:s}"
 msgstr ""
 
@@ -9439,7 +9328,6 @@ msgstr ""
 
 #: Source/trigs.cpp:397 Source/trigs.cpp:484 Source/trigs.cpp:536
 #: Source/trigs.cpp:635
-#, c-format
 msgid "Up to level {:d}"
 msgstr "上 到 第 {:d} 层"
 
@@ -9450,22 +9338,18 @@ msgstr "返 回 城 镇"
 
 #: Source/trigs.cpp:411 Source/trigs.cpp:496 Source/trigs.cpp:550
 #: Source/trigs.cpp:577 Source/trigs.cpp:648
-#, c-format
 msgid "Down to level {:d}"
 msgstr "下 到 第 {:d} 层"
 
 #: Source/trigs.cpp:424
-#, c-format
 msgid "Up to Crypt level {:d}"
 msgstr ""
 
 #: Source/trigs.cpp:440
-#, c-format
 msgid "Down to Crypt level {:d}"
 msgstr ""
 
 #: Source/trigs.cpp:563
-#, c-format
 msgid "Up to Nest level {:d}"
 msgstr ""
 
@@ -9474,7 +9358,6 @@ msgid "Down to Diablo"
 msgstr "下 到 Diablo"
 
 #: Source/trigs.cpp:718 Source/trigs.cpp:735 Source/trigs.cpp:752
-#, c-format
 msgid "Back to Level {:d}"
 msgstr "返 回 第 {:d} 层"
 

--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -418,7 +418,7 @@ msgstr ""
 
 #: Source/DiabloUI/selconn.cpp:115
 #, c-format
-msgid "Players Supported: %d"
+msgid "Players Supported: {:d}"
 msgstr ""
 
 #: Source/DiabloUI/selgame.cpp:85 Source/DiabloUI/selgame.cpp:380
@@ -567,7 +567,7 @@ msgstr ""
 
 #: Source/DiabloUI/selgame.cpp:415
 #, c-format
-msgid "Your version %s does not match the host %d.%d.%d."
+msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:123
@@ -645,7 +645,7 @@ msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:345
 #, c-format
-msgid "Character already exists. Do you want to overwrite \"%s\"?"
+msgid "Character already exists. Do you want to overwrite \"{:s}\"?"
 msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:357
@@ -694,7 +694,7 @@ msgstr ""
 
 #: Source/DiabloUI/selhero.cpp:621
 #, c-format
-msgid "Are you sure you want to delete the character \"%s\"?"
+msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr ""
 
 #: Source/DiabloUI/selyesno.cpp:61 Source/stores.cpp:888
@@ -772,9 +772,9 @@ msgstr ""
 #: Source/appfat.cpp:117
 #, c-format
 msgid ""
-"%s\n"
+"{:s}\n"
 "\n"
-"The error occurred at: %s line %d"
+"The error occurred at: {:s} line {:d}"
 msgstr ""
 
 #: Source/appfat.cpp:137
@@ -787,7 +787,7 @@ msgid ""
 "68f049866b44688a7af65ba766bef75a\n"
 "\n"
 "The problem occurred when loading:\n"
-"%s"
+"{:s}"
 msgstr ""
 
 #: Source/appfat.cpp:146 Source/appfat.cpp:164
@@ -806,7 +806,7 @@ msgstr ""
 #, c-format
 msgid ""
 "Unable to write to location:\n"
-"%s"
+"{:s}"
 msgstr ""
 
 #: Source/appfat.cpp:177
@@ -823,17 +823,17 @@ msgstr ""
 
 #: Source/automap.cpp:434 Source/items.cpp:3861
 #, c-format
-msgid "Level: %i"
-msgstr "等 级： %i"
+msgid "Level: {:d}"
+msgstr "等 级： {:d}"
 
 #: Source/automap.cpp:436
 #, c-format
-msgid "Level: Crypt %i"
+msgid "Level: Crypt {:d}"
 msgstr ""
 
 #: Source/automap.cpp:438
 #, c-format
-msgid "Level: Nest %i"
+msgid "Level: Nest {:d}"
 msgstr ""
 
 #: Source/control.cpp:239
@@ -878,13 +878,13 @@ msgstr "发 送 信 息"
 
 #: Source/control.cpp:432 Source/control.cpp:1024
 #, c-format
-msgid "%s Skill"
-msgstr "%s 技 能"
+msgid "{:s} Skill"
+msgstr "{:s} 技 能"
 
 #: Source/control.cpp:435 Source/control.cpp:1028
 #, c-format
-msgid "%s Spell"
-msgstr "%s 魔 法"
+msgid "{:s} Spell"
+msgstr "{:s} 魔 法"
 
 #: Source/control.cpp:437
 msgid "Damages undead only"
@@ -896,33 +896,33 @@ msgstr "0 级 魔 法 -- 不 可 使 用"
 
 #: Source/control.cpp:443 Source/control.cpp:1036 Source/control.cpp:1863
 #, c-format
-msgid "Spell Level %i"
-msgstr "魔 法 等 级 %i"
+msgid "Spell Level {:d}"
+msgstr "魔 法 等 级 {:d}"
 
 #: Source/control.cpp:447 Source/control.cpp:1040
 #, c-format
-msgid "Scroll of %s"
-msgstr "%s 卷 轴"
+msgid "Scroll of {:s}"
+msgstr "{:s} 卷 轴"
 
 #: Source/control.cpp:463
-msgid "%i Scroll"
-msgid_plural "%i Scrolls"
-msgstr[0] "%i 卷 轴"
+msgid "{:d} Scroll"
+msgid_plural "{:d} Scrolls"
+msgstr[0] "{:d} 卷 轴"
 
 #: Source/control.cpp:467 Source/control.cpp:1064 Source/items.cpp:1596
 #, c-format
-msgid "Staff of %s"
-msgstr "%s 法 杖"
+msgid "Staff of {:s}"
+msgstr "{:s} 法 杖"
 
 #: Source/control.cpp:469
-msgid "%i Charge"
-msgid_plural "%i Charges"
-msgstr[0] "%i 回复"
+msgid "{:d} Charge"
+msgid_plural "{:d} Charges"
+msgstr[0] "{:d} 回复"
 
 #: Source/control.cpp:478
 #, c-format
-msgid "Spell Hotkey #F%i"
-msgstr "魔 法 快 捷 键 #F%i"
+msgid "Spell Hotkey #F{:d}"
+msgstr "魔 法 快 捷 键 #F{:d}"
 
 #: Source/control.cpp:1000
 msgid "Player friendly"
@@ -934,8 +934,8 @@ msgstr "玩 家 互 攻"
 
 #: Source/control.cpp:1005
 #, c-format
-msgid "Hotkey: %s"
-msgstr "热 键 ：%s"
+msgid "Hotkey: {:s}"
+msgstr "热 键 ：{:s}"
 
 #: Source/control.cpp:1014
 msgid "Select current spell button"
@@ -951,8 +951,8 @@ msgstr "1 个 卷 轴"
 
 #: Source/control.cpp:1060
 #, c-format
-msgid "%i Scrolls"
-msgstr "%i 卷 轴"
+msgid "{:d} Scrolls"
+msgstr "{:d} 卷 轴"
 
 #: Source/control.cpp:1067
 msgid "1 Charge"
@@ -960,15 +960,15 @@ msgstr "1 金 币"
 
 #: Source/control.cpp:1069
 #, c-format
-msgid "%i Charges"
-msgstr "%i 回复"
+msgid "{:d} Charges"
+msgstr "{:d} 回复"
 
 #: Source/control.cpp:1256 Source/inv.cpp:2117 Source/items.cpp:3076
 #, fuzzy, c-format
-#| msgid "%i gold %s"
-msgid "%i gold piece"
-msgid_plural "%i gold pieces"
-msgstr[0] "%i 金 币 %s"
+#| msgid "{:d} gold {:s}"
+msgid "{:d} gold piece"
+msgid_plural "{:d} gold pieces"
+msgstr[0] "{:d} 金 币 {:s}"
 
 #: Source/control.cpp:1259
 msgid "Requirements not met"
@@ -976,13 +976,13 @@ msgstr "需 要 的 等 级 没 有 达 到"
 
 #: Source/control.cpp:1295
 #, c-format
-msgid "%s, Level: %i"
+msgid "{:s}, Level: {:d}"
 msgstr ""
 
 #: Source/control.cpp:1297
 #, c-format
-msgid "Hit Points %i of %i"
-msgstr "攻 击 点 数  %i / %i"
+msgid "Hit Points {:d} of {:d}"
+msgstr "攻 击 点 数  {:d} / {:d}"
 
 #: Source/control.cpp:1370
 msgid "None"
@@ -994,33 +994,33 @@ msgstr ""
 
 #: Source/control.cpp:1580
 #, fuzzy
-#| msgid "Level %d"
+#| msgid "Level {:d}"
 msgid "Level Up"
-msgstr "等 级 %i"
+msgstr "等 级 {:d}"
 
 #: Source/control.cpp:1836
 msgid "Skill"
 msgstr "技 巧"
 
 #: Source/control.cpp:1840
-msgid "Staff (%i charge)"
-msgid_plural "Staff (%i charges)"
-msgstr[0] "法 杖（%i 回复 ）"
+msgid "Staff ({:d} charge)"
+msgid_plural "Staff ({:d} charges)"
+msgstr[0] "法 杖（{:d} 回复 ）"
 
 #: Source/control.cpp:1848
 #, c-format
-msgid "Mana: %i  Dam: %i - %i"
-msgstr "法 力 ： %i 伤 害 ： %i - %i"
+msgid "Mana: {:d}  Dam: {:d} - {:d}"
+msgstr "法 力 ： {:d} 伤 害 ： {:d} - {:d}"
 
 #: Source/control.cpp:1850
 #, c-format
-msgid "Mana: %i   Dam: n/a"
-msgstr "法 力 ： %i 伤 害 ：n/a"
+msgid "Mana: {:d}   Dam: n/a"
+msgstr "法 力 ： {:d} 伤 害 ：n/a"
 
 #: Source/control.cpp:1853
 #, c-format
-msgid "Mana: %i  Dam: 1/3 tgt hp"
-msgstr "法 力 ： %i 伤 害 ：1/3  tgt hp"
+msgid "Mana: {:d}  Dam: 1/3 tgt hp"
+msgstr "法 力 ： {:d} 伤 害 ：1/3  tgt hp"
 
 #: Source/control.cpp:1900
 #, c-format
@@ -1067,8 +1067,8 @@ msgstr "时 空 之 门"
 
 #: Source/cursor.cpp:182
 #, c-format
-msgid "from %s"
-msgstr "从 %s"
+msgid "from {:s}"
+msgstr "从 {:s}"
 
 #: Source/cursor.cpp:207
 msgid "Portal to"
@@ -1172,12 +1172,12 @@ msgstr ""
 
 #: Source/diablo.cpp:267
 #, c-format
-msgid "unrecognized option '%s'\n"
+msgid "unrecognized option '{:s}'\n"
 msgstr ""
 
 #: Source/diablo.cpp:649
 #, c-format
-msgid "version %s"
+msgid "version {:s}"
 msgstr ""
 
 #: Source/diablo.cpp:1172
@@ -1190,7 +1190,7 @@ msgstr ""
 
 #: Source/diablo.cpp:1453
 #, c-format
-msgid "%s, mode = %s"
+msgid "{:s}, mode = {:s}"
 msgstr ""
 
 #: Source/diablo.cpp:2152
@@ -3560,12 +3560,12 @@ msgstr ""
 #: Source/items.cpp:1553 Source/items.cpp:1594 Source/items.cpp:2187
 #: Source/items.cpp:2206
 #, c-format
-msgid "%s of %s"
-msgstr "%s / %s"
+msgid "{:s} of {:s}"
+msgstr "{:s} / {:s}"
 
 #: Source/items.cpp:2779 Source/player.cpp:1817
 #, c-format
-msgid "Ear of %s"
+msgid "Ear of {:s}"
 msgstr ""
 
 #: Source/items.cpp:3308 Source/items.cpp:3320
@@ -3715,32 +3715,32 @@ msgstr "完 全 恢 复 生 命 值 和 魔 法 力"
 
 #: Source/items.cpp:3457
 #, c-format
-msgid "chance to hit: %+i%%"
+msgid "chance to hit: {:+d}%"
 msgstr ""
 
 #: Source/items.cpp:3461
 #, c-format
-msgid "%+i%% damage"
+msgid "{:+d}% damage"
 msgstr ""
 
 #: Source/items.cpp:3465 Source/items.cpp:3723
 #, c-format
-msgid "to hit: %+i%%, %+i%% damage"
+msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr ""
 
 #: Source/items.cpp:3469
 #, c-format
-msgid "%+i%% armor"
+msgid "{:+d}% armor"
 msgstr ""
 
 #: Source/items.cpp:3472 Source/items.cpp:3475
 #, c-format
-msgid "armor class: %i"
+msgid "armor class: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3480 Source/items.cpp:3705
 #, c-format
-msgid "Resist Fire: %+i%%"
+msgid "Resist Fire: {:+d}%"
 msgstr ""
 
 #: Source/items.cpp:3482
@@ -3750,7 +3750,7 @@ msgstr ""
 
 #: Source/items.cpp:3487
 #, c-format
-msgid "Resist Lightning: %+i%%"
+msgid "Resist Lightning: {:+d}%"
 msgstr ""
 
 #: Source/items.cpp:3489
@@ -3760,7 +3760,7 @@ msgstr ""
 
 #: Source/items.cpp:3494
 #, c-format
-msgid "Resist Magic: %+i%%"
+msgid "Resist Magic: {:+d}%"
 msgstr ""
 
 #: Source/items.cpp:3496
@@ -3770,7 +3770,7 @@ msgstr ""
 
 #: Source/items.cpp:3501
 #, c-format
-msgid "Resist All: %+i%%"
+msgid "Resist All: {:+d}%"
 msgstr ""
 
 #: Source/items.cpp:3503
@@ -3779,13 +3779,13 @@ msgid "Resist All: 75% MAX"
 msgstr ""
 
 #: Source/items.cpp:3507
-msgid "spells are increased %i level"
-msgid_plural "spells are increased %i levels"
+msgid "spells are increased {:d} level"
+msgid_plural "spells are increased {:d} levels"
 msgstr[0] "魔 法 提 升 一 个 等 级"
 
 #: Source/items.cpp:3509
-msgid "spells are decreased %i level"
-msgid_plural "spells are decreased %i levels"
+msgid "spells are decreased {:d} level"
+msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "魔 法 降 低 一 个 等 级"
 
 #: Source/items.cpp:3511
@@ -3797,69 +3797,69 @@ msgid "Extra charges"
 msgstr "额 外 补 充"
 
 #: Source/items.cpp:3517
-msgid "%i %s charge"
-msgid_plural "%i %s charges"
-msgstr[0] "%i %s 回 复"
+msgid "{:d} {:s} charge"
+msgid_plural "{:d} {:s} charges"
+msgstr[0] "{:d} {:s} 回 复"
 
 #: Source/items.cpp:3521
 #, c-format
-msgid "Fire hit damage: %i"
+msgid "Fire hit damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3523
 #, c-format
-msgid "Fire hit damage: %i-%i"
+msgid "Fire hit damage: {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3527
 #, c-format
-msgid "Lightning hit damage: %i"
+msgid "Lightning hit damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3529
 #, c-format
-msgid "Lightning hit damage: %i-%i"
+msgid "Lightning hit damage: {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3533
 #, c-format
-msgid "%+i to strength"
+msgid "{:+d} to strength"
 msgstr ""
 
 #: Source/items.cpp:3537
 #, c-format
-msgid "%+i to magic"
+msgid "{:+d} to magic"
 msgstr ""
 
 #: Source/items.cpp:3541
 #, c-format
-msgid "%+i to dexterity"
+msgid "{:+d} to dexterity"
 msgstr ""
 
 #: Source/items.cpp:3545
 #, c-format
-msgid "%+i to vitality"
+msgid "{:+d} to vitality"
 msgstr ""
 
 #: Source/items.cpp:3549
 #, c-format
-msgid "%+i to all attributes"
+msgid "{:+d} to all attributes"
 msgstr ""
 
 #: Source/items.cpp:3553
 #, c-format
-msgid "%+i damage from enemies"
+msgid "{:+d} damage from enemies"
 msgstr ""
 
 #: Source/items.cpp:3557
 #, c-format
-msgid "Hit Points: %+i"
+msgid "Hit Points: {:+d}"
 msgstr ""
 
 #: Source/items.cpp:3561
 #, c-format
-msgid "Mana: %+i"
-msgstr "魔法: %+i"
+msgid "Mana: {:+d}"
+msgstr "魔法: {:+d}"
 
 #: Source/items.cpp:3564
 msgid "high durability"
@@ -3875,12 +3875,12 @@ msgstr "不 可 毁 坏 的"
 
 #: Source/items.cpp:3573
 #, c-format
-msgid "+%i%% light radius"
+msgid "+{:d}%% light radius"
 msgstr ""
 
 #: Source/items.cpp:3576
 #, c-format
-msgid "-%i%% light radius"
+msgid "-{:d}%% light radius"
 msgstr ""
 
 #: Source/items.cpp:3579
@@ -3889,32 +3889,32 @@ msgstr ""
 
 #: Source/items.cpp:3583
 #, c-format
-msgid "fire arrows damage: %i"
+msgid "fire arrows damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3585
 #, c-format
-msgid "fire arrows damage: %i-%i"
+msgid "fire arrows damage: {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3589
 #, c-format
-msgid "lightning arrows damage %i"
+msgid "lightning arrows damage {:d}"
 msgstr ""
 
 #: Source/items.cpp:3591
 #, c-format
-msgid "lightning arrows damage %i-%i"
+msgid "lightning arrows damage {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3595
 #, c-format
-msgid "fireball damage: %i"
+msgid "fireball damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3597
 #, c-format
-msgid "fireball damage: %i-%i"
+msgid "fireball damage: {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3600
@@ -4008,8 +4008,8 @@ msgstr ""
 
 #: Source/items.cpp:3660
 #, c-format
-msgid "adds %i point to damage"
-msgid_plural "adds %i points to damage"
+msgid "adds {:d} point to damage"
+msgid_plural "adds {:d} points to damage"
 msgstr[0] ""
 
 #: Source/items.cpp:3663
@@ -4050,12 +4050,12 @@ msgstr ""
 
 #: Source/items.cpp:3694
 #, c-format
-msgid "lightning damage: %i"
+msgid "lightning damage: {:d}"
 msgstr ""
 
 #: Source/items.cpp:3696
 #, c-format
-msgid "lightning damage: %i-%i"
+msgid "lightning damage: {:d}-{:d}"
 msgstr ""
 
 #: Source/items.cpp:3699
@@ -4068,7 +4068,7 @@ msgstr ""
 
 #: Source/items.cpp:3711
 #, c-format
-msgid "decaying %+i%% damage"
+msgid "decaying {:+d}% damage"
 msgstr ""
 
 #: Source/items.cpp:3714
@@ -4082,7 +4082,7 @@ msgstr ""
 
 #: Source/items.cpp:3720
 #, c-format
-msgid "low dur, %+i%% damage"
+msgid "low dur, {:+d}% damage"
 msgstr ""
 
 #: Source/items.cpp:3726
@@ -4145,64 +4145,64 @@ msgstr ""
 
 #: Source/items.cpp:3879 Source/stores.cpp:199
 #, c-format
-msgid " %i Str"
+msgid " {:d} Str"
 msgstr ""
 
 #: Source/items.cpp:3881 Source/stores.cpp:201
 #, c-format
-msgid " %i Mag"
+msgid " {:d} Mag"
 msgstr ""
 
 #: Source/items.cpp:3883 Source/stores.cpp:203
 #, c-format
-msgid " %i Dex"
+msgid " {:d} Dex"
 msgstr ""
 
 #: Source/items.cpp:3894 Source/items.cpp:3941
 #, c-format
-msgid "damage: %i  Indestructible"
+msgid "damage: {:d}  Indestructible"
 msgstr ""
 
 #: Source/items.cpp:3896 Source/items.cpp:3943
 #, c-format
-msgid "damage: %i  Dur: %i/%i"
+msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3899 Source/items.cpp:3946
 #, c-format
-msgid "damage: %i-%i  Indestructible"
+msgid "damage: {:d}-{:d}  Indestructible"
 msgstr ""
 
 #: Source/items.cpp:3901 Source/items.cpp:3948
 #, c-format
-msgid "damage: %i-%i  Dur: %i/%i"
+msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3907 Source/items.cpp:3960
 #, c-format
-msgid "armor: %i  Indestructible"
+msgid "armor: {:d}  Indestructible"
 msgstr ""
 
 #: Source/items.cpp:3909 Source/items.cpp:3962
 #, c-format
-msgid "armor: %i  Dur: %i/%i"
+msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3914
 #, c-format
-msgid "dam: %i  Dur: %i/%i"
+msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3916
 #, c-format
-msgid "dam: %i-%i  Dur: %i/%i"
+msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #: Source/items.cpp:3917 Source/items.cpp:3952 Source/items.cpp:3967
 #: Source/stores.cpp:169
 #, c-format
-msgid "Charges: %i/%i"
-msgstr "回复: %i/%i"
+msgid "Charges: {:d}/{:d}"
+msgstr "回复: {:d}/{:d}"
 
 #: Source/items.cpp:3929
 msgid "unique item"
@@ -5112,18 +5112,18 @@ msgstr ""
 
 #: Source/monster.cpp:4969
 #, c-format
-msgid "Type: %s  Kills: %i"
+msgid "Type: {:s}  Kills: {:d}"
 msgstr ""
 
 #: Source/monster.cpp:4971
 #, c-format
-msgid "Total kills: %i"
+msgid "Total kills: {:d}"
 msgstr ""
 
 #: Source/monster.cpp:5004
 #, c-format
-msgid "Hit Points: %i-%i"
-msgstr "攻 击 点 数 魔 法 岩 石：%i / %i"
+msgid "Hit Points: {:d}-{:d}"
+msgstr "攻 击 点 数 魔 法 岩 石：{:d} / {:d}"
 
 #: Source/monster.cpp:5014
 msgid "No magic resistance"
@@ -5151,7 +5151,7 @@ msgstr ""
 
 #: Source/monster.cpp:5049
 #, c-format
-msgid "Type: %s"
+msgid "Type: {:s}"
 msgstr ""
 
 #: Source/monster.cpp:5055 Source/monster.cpp:5062
@@ -5190,32 +5190,32 @@ msgstr ""
 #: Source/msg.cpp:1702 Source/msg.cpp:1822 Source/msg.cpp:1843
 #: Source/msg.cpp:1864 Source/msg.cpp:1885
 #, c-format
-msgid "%s has cast an illegal spell."
+msgid "{:s} has cast an illegal spell."
 msgstr ""
 
 #: Source/msg.cpp:2221 Source/multi.cpp:866
 #, c-format
-msgid "Player '%s' (level %d) just joined the game"
+msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr ""
 
 #: Source/multi.cpp:269
 #, c-format
-msgid "Player '%s' just left the game"
+msgid "Player '{:s}' just left the game"
 msgstr ""
 
 #: Source/multi.cpp:272
 #, c-format
-msgid "Player '%s' killed Diablo and left the game!"
+msgid "Player '{:s}' killed Diablo and left the game!"
 msgstr ""
 
 #: Source/multi.cpp:276
 #, c-format
-msgid "Player '%s' dropped due to timeout"
+msgid "Player '{:s}' dropped due to timeout"
 msgstr ""
 
 #: Source/multi.cpp:868
 #, c-format
-msgid "Player '%s' (level %d) is already in the game"
+msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr ""
 
 #: Source/objects.cpp:90
@@ -5476,7 +5476,7 @@ msgstr ""
 
 #: Source/objects.cpp:5544
 #, c-format
-msgid "%s Shrine"
+msgid "{:s} Shrine"
 msgstr ""
 
 #: Source/objects.cpp:5548
@@ -5549,12 +5549,12 @@ msgstr "被 杀 死 的 英 雄"
 
 #: Source/objects.cpp:5613
 #, c-format
-msgid "Trapped %s"
+msgid "Trapped {:s}"
 msgstr ""
 
 #: Source/objects.cpp:5619
 #, c-format
-msgid "%s (disabled)"
+msgid "{:s} (disabled)"
 msgstr ""
 
 #: Source/pfile.cpp:217
@@ -5579,7 +5579,7 @@ msgstr ""
 
 #: Source/plrmsg.cpp:72
 #, c-format
-msgid "%s (lvl %d): %s"
+msgid "{:s} (lvl {:d}): {:s}"
 msgstr ""
 
 #: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:52
@@ -5589,8 +5589,8 @@ msgstr ""
 
 #: Source/qol/xpbar.cpp:122
 #, c-format
-msgid "Level %d"
-msgstr "等 级 %i"
+msgid "Level {:d}"
+msgstr "等 级 {:d}"
 
 #: Source/qol/xpbar.cpp:129 Source/qol/xpbar.cpp:140
 msgid "Experience: "
@@ -5606,7 +5606,7 @@ msgstr ""
 
 #: Source/qol/xpbar.cpp:148
 #, c-format
-msgid " to Level %d"
+msgid " to Level {:d}"
 msgstr ""
 
 #: Source/quests.cpp:39
@@ -5689,7 +5689,7 @@ msgstr "邪 恶 祭 坛"
 
 #: Source/quests.cpp:283
 #, c-format
-msgid "To %s"
+msgid "To {:s}"
 msgstr ""
 
 #: Source/quests.cpp:760
@@ -5897,17 +5897,17 @@ msgstr ""
 
 #: Source/stores.cpp:180
 #, c-format
-msgid "Damage: %i-%i  "
+msgid "Damage: {:d}-{:d}  "
 msgstr ""
 
 #: Source/stores.cpp:182
 #, c-format
-msgid "Armor: %i  "
-msgstr "防 御：%i  "
+msgid "Armor: {:d}  "
+msgstr "防 御：{:d}  "
 
 #: Source/stores.cpp:184
 #, c-format
-msgid "Dur: %i/%i,  "
+msgid "Dur: {:d}/{:d},  "
 msgstr ""
 
 #: Source/stores.cpp:187
@@ -5958,8 +5958,8 @@ msgstr "离 开 铁 匠 铺"
 
 #: Source/stores.cpp:274 Source/stores.cpp:623 Source/stores.cpp:989
 #, c-format
-msgid "I have these items for sale:             Your gold: %i"
-msgstr "我 有 一 些 物 品 要 卖 ：              你 的 金 币：%i"
+msgid "I have these items for sale:             Your gold: {:d}"
+msgstr "我 有 一 些 物 品 要 卖 ：              你 的 金 币：{:d}"
 
 #: Source/stores.cpp:279 Source/stores.cpp:343 Source/stores.cpp:471
 #: Source/stores.cpp:482 Source/stores.cpp:541 Source/stores.cpp:554
@@ -5972,28 +5972,28 @@ msgstr "回 到 上 一 级"
 
 #: Source/stores.cpp:339
 #, c-format
-msgid "I have these premium items for sale:     Your gold: %i"
-msgstr "我 有 一 些 高 级 物 品 要 卖 ：      你 的 金 币：%i"
+msgid "I have these premium items for sale:     Your gold: {:d}"
+msgstr "我 有 一 些 高 级 物 品 要 卖 ：      你 的 金 币：{:d}"
 
 #: Source/stores.cpp:467 Source/stores.cpp:717
 #, c-format
-msgid "You have nothing I want.             Your gold: %i"
-msgstr "你 没 有 我 想 要 的 物 品 ？             你 的 金 币 ：%i"
+msgid "You have nothing I want.             Your gold: {:d}"
+msgstr "你 没 有 我 想 要 的 物 品 ？             你 的 金 币 ：{:d}"
 
 #: Source/stores.cpp:477 Source/stores.cpp:727
 #, c-format
-msgid "Which item is for sale?             Your gold: %i"
-msgstr "你 想 卖 哪 个 物 品 ？             你 的 金 币 ：%i"
+msgid "Which item is for sale?             Your gold: {:d}"
+msgstr "你 想 卖 哪 个 物 品 ？             你 的 金 币 ：{:d}"
 
 #: Source/stores.cpp:537
 #, c-format
-msgid "You have nothing to repair.             Your gold: %i"
-msgstr "你 没 有 需 要 修 补 的 物 品 ？             你 的 金 币 ：%i"
+msgid "You have nothing to repair.             Your gold: {:d}"
+msgstr "你 没 有 需 要 修 补 的 物 品 ？             你 的 金 币 ：{:d}"
 
 #: Source/stores.cpp:549
 #, c-format
-msgid "Repair which item?             Your gold: %i"
-msgstr "要 修 补 哪 个 物 品 ？              你 的 金 币 ：%i"
+msgid "Repair which item?             Your gold: {:d}"
+msgstr "要 修 补 哪 个 物 品 ？              你 的 金 币 ：{:d}"
 
 #: Source/stores.cpp:575
 msgid "Witch's shack"
@@ -6017,13 +6017,13 @@ msgstr "离 开 女 巫 小 屋"
 
 #: Source/stores.cpp:793
 #, c-format
-msgid "You have nothing to recharge.             Your gold: %i"
-msgstr "你没有东西可以回购。             你的金币: %i"
+msgid "You have nothing to recharge.             Your gold: {:d}"
+msgstr "你没有东西可以回购。             你的金币: {:d}"
 
 #: Source/stores.cpp:803
 #, c-format
-msgid "Recharge which item?             Your gold: %i"
-msgstr "回购哪个物品？             你的金币：%i"
+msgid "Recharge which item?             Your gold: {:d}"
+msgstr "回购哪个物品？             你的金币：{:d}"
 
 #: Source/stores.cpp:819
 msgid "You do not have enough gold"
@@ -6088,8 +6088,8 @@ msgstr "结 束 交 谈"
 
 #: Source/stores.cpp:915
 #, c-format
-msgid "I have this item for sale:             Your gold: %i"
-msgstr "我有这个物品要出售。             你的金币: %i"
+msgid "I have this item for sale:             Your gold: {:d}"
+msgstr "我有这个物品要出售。             你的金币: {:d}"
 
 #: Source/stores.cpp:931
 msgid "Leave"
@@ -6121,13 +6121,13 @@ msgstr "鉴 定 物 品"
 
 #: Source/stores.cpp:1090
 #, c-format
-msgid "You have nothing to identify.             Your gold: %i"
-msgstr "你没有需要鉴定的物品。             你的金币: %i"
+msgid "You have nothing to identify.             Your gold: {:d}"
+msgstr "你没有需要鉴定的物品。             你的金币: {:d}"
 
 #: Source/stores.cpp:1100
 #, c-format
-msgid "Identify which item?             Your gold: %i"
-msgstr "鉴定哪样物品。             你的金币: %i"
+msgid "Identify which item?             Your gold: {:d}"
+msgstr "鉴定哪样物品。             你的金币: {:d}"
 
 #: Source/stores.cpp:1117
 msgid "This item is:"
@@ -6139,12 +6139,12 @@ msgstr "好"
 
 #: Source/stores.cpp:1129
 #, c-format
-msgid "Talk to %s"
-msgstr "和 %s 聊天"
+msgid "Talk to {:s}"
+msgstr "和 {:s} 聊天"
 
 #: Source/stores.cpp:1133
 #, c-format
-msgid "Talking to %s"
+msgid "Talking to {:s}"
 msgstr ""
 
 #: Source/stores.cpp:1135
@@ -9440,8 +9440,8 @@ msgstr ""
 #: Source/trigs.cpp:397 Source/trigs.cpp:484 Source/trigs.cpp:536
 #: Source/trigs.cpp:635
 #, c-format
-msgid "Up to level %i"
-msgstr "上 到 第 %i 层"
+msgid "Up to level {:d}"
+msgstr "上 到 第 {:d} 层"
 
 #: Source/trigs.cpp:399 Source/trigs.cpp:458 Source/trigs.cpp:515
 #: Source/trigs.cpp:597 Source/trigs.cpp:615 Source/trigs.cpp:667
@@ -9451,22 +9451,22 @@ msgstr "返 回 城 镇"
 #: Source/trigs.cpp:411 Source/trigs.cpp:496 Source/trigs.cpp:550
 #: Source/trigs.cpp:577 Source/trigs.cpp:648
 #, c-format
-msgid "Down to level %i"
-msgstr "下 到 第 %i 层"
+msgid "Down to level {:d}"
+msgstr "下 到 第 {:d} 层"
 
 #: Source/trigs.cpp:424
 #, c-format
-msgid "Up to Crypt level %i"
+msgid "Up to Crypt level {:d}"
 msgstr ""
 
 #: Source/trigs.cpp:440
 #, c-format
-msgid "Down to Crypt level %i"
+msgid "Down to Crypt level {:d}"
 msgstr ""
 
 #: Source/trigs.cpp:563
 #, c-format
-msgid "Up to Nest level %i"
+msgid "Up to Nest level {:d}"
 msgstr ""
 
 #: Source/trigs.cpp:681
@@ -9475,6 +9475,6 @@ msgstr "下 到 Diablo"
 
 #: Source/trigs.cpp:718 Source/trigs.cpp:735 Source/trigs.cpp:752
 #, c-format
-msgid "Back to Level %i"
-msgstr "返 回 第 %i 层"
+msgid "Back to Level {:d}"
+msgstr "返 回 第 {:d} 层"
 

--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -999,8 +999,8 @@ msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "法 力 ： {:d} 伤 害 ：1/3  tgt hp"
 
 #: Source/control.cpp:1900
-msgid "You have %u gold"
-msgstr "你拥有 %u 金币"
+msgid "You have {:d} gold"
+msgstr "你拥有 {:d} 金币"
 
 #: Source/control.cpp:1902
 msgid "piece.  How many do"


### PR DESCRIPTION
This adds `fmt`'s format support for translated texts.

In its current state this is very experimental, it does compile but some texts are corrupted. The main issue lies with the menus.