### PR TITLE
Adds `MeasureCelWidth` to quickly measure CEL width

### DIFF
--- a/Source/engine.h
+++ b/Source/engine.h
@@ -306,6 +306,11 @@ struct CelOutputBuffer {
 };
 
 /**
+ * @brief Measures the width of the given CEL buffer.
+ */
+std::uint_fast16_t MeasureCelWidth(BYTE *pCelBuf);
+
+/**
  * @brief Blit CEL sprite to the back buffer at the given coordinates
  * @param out Target buffer
  * @param sx Target buffer coordinate


### PR DESCRIPTION
This could be optimized further for CELs with frame headers,
where the width can be obtained directly from the header

https://github.com/savagesteel/d1-file-formats/blob/master/PC-Mac/CEL.md#42-cel-frame-data

Untested but hopefully works (perhaps with minor fixes)
For use in @qndel's Alt highlighting PR