### PR TITLE
ADL: Fix calculation of fast/faster/fastest combination (Bard)

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1464,14 +1464,14 @@ void StartAttack(int pnum, direction d)
 	}
 
 	int skippedAnimationFrames = 0;
-	if ((plr[pnum]._pIFlags & ISPL_FASTATTACK) != 0) {
-		skippedAnimationFrames += 1;
-	}
 	if ((plr[pnum]._pIFlags & ISPL_FASTERATTACK) != 0) {
-		skippedAnimationFrames += 2;
-	}
-	if ((plr[pnum]._pIFlags & ISPL_FASTESTATTACK) != 0) {
-		skippedAnimationFrames += 2;
+		// The combination of Faster and Fast Attack doesn't result in more skipped skipped frames, cause the secound frame skip of Faster Attack is not triggered.
+		skippedAnimationFrames = 2;
+	} else if ((plr[pnum]._pIFlags & ISPL_FASTATTACK) != 0) {
+		skippedAnimationFrames = 1;
+	} else if ((plr[pnum]._pIFlags & ISPL_FASTESTATTACK) != 0) {
+		// Fastest Attack is skipped if Fast or Faster Attack is also specified, cause both skip the frame that triggers fastest attack skipping
+		skippedAnimationFrames = 2;
 	}
 
 	NewPlrAnim(pnum, plr[pnum]._pAAnim[d], plr[pnum]._pAFrames, 0, plr[pnum]._pAWidth, AnimationDistributionParams::ProcessAnimationPending, skippedAnimationFrames, plr[pnum]._pAFNum);


### PR DESCRIPTION
https://github.com/diasurgical/devilution/blob/2bf6eeb125a540e83ec838d6ab9181f2b26d0983/Source/player.cpp#L3206-3221

For Bard it's possible to wield two weapons.
That mean's it's also possible that two attack modifiers are present at the same time.
In this case the skipped frame calculation doesn't calculate the skipped frames correctly, cause the combined skipping of two attack modifiers can skip the frame that triggers the next skipping.
This is the same behavior as the combined hit recovery modifiers (zen mode).

Example:

- Bard with two swords, one with fast the other with faster attack modifier
- `PM_DoAttack` at Frame 3 advances two Frames (one for Fast Attack and one for Faster Attack.) So the Frame is 5.
- Then ProcessAnimation advances the Frame again. So now the Frame is 6.
- In the next game tick `PM_DoAttack` does see Frame 6 so the check for `frame == 5` for Faster Attack is skipped and so is the skipping skipped. 😁 


