### PR TITLE
ADL: Advance skipped Frames in SetNewAnimation and remove logic from PM_XYZ

### DIFF
--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -64,7 +64,7 @@ void AnimationInfo::SetNewAnimation(byte *pData, int numberOfFrames, int delayLe
 
 	this->pData = pData;
 	NumberOfFrames = numberOfFrames;
-	CurrentFrame = 1;
+	CurrentFrame = 1 + numSkippedFrames;
 	DelayCounter = 0;
 	DelayLen = delayLen;
 	TicksSinceSequenceStarted = 0;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2808,26 +2808,13 @@ bool PlrHitObj(int pnum, int mx, int my)
 
 bool PM_DoAttack(int pnum)
 {
-	int frame, dx, dy, m;
+	int dx, dy, m;
 	bool didhit = false;
 
 	if ((DWORD)pnum >= MAX_PLRS) {
 		app_fatal("PM_DoAttack: illegal player %d", pnum);
 	}
 
-	frame = plr[pnum].AnimInfo.CurrentFrame;
-	if (plr[pnum]._pIFlags & ISPL_QUICKATTACK && frame == 1) {
-		plr[pnum].AnimInfo.CurrentFrame++;
-	}
-	if (plr[pnum]._pIFlags & ISPL_FASTATTACK && (frame == 1 || frame == 3)) {
-		plr[pnum].AnimInfo.CurrentFrame++;
-	}
-	if (plr[pnum]._pIFlags & ISPL_FASTERATTACK && (frame == 1 || frame == 3 || frame == 5)) {
-		plr[pnum].AnimInfo.CurrentFrame++;
-	}
-	if (plr[pnum]._pIFlags & ISPL_FASTESTATTACK && (frame == 1 || frame == 4)) {
-		plr[pnum].AnimInfo.CurrentFrame += 2;
-	}
 	if (plr[pnum].AnimInfo.CurrentFrame == plr[pnum]._pAFNum - 1) {
 		PlaySfxLoc(PS_SWING, plr[pnum].position.tile.x, plr[pnum].position.tile.y);
 	}
@@ -2919,20 +2906,10 @@ bool PM_DoAttack(int pnum)
 
 bool PM_DoRangeAttack(int pnum)
 {
-	int origFrame, mistype;
+	int mistype;
 
 	if ((DWORD)pnum >= MAX_PLRS) {
 		app_fatal("PM_DoRangeAttack: illegal player %d", pnum);
-	}
-
-	if (!gbIsHellfire) {
-		origFrame = plr[pnum].AnimInfo.CurrentFrame;
-		if (plr[pnum]._pIFlags & ISPL_QUICKATTACK && origFrame == 1) {
-			plr[pnum].AnimInfo.CurrentFrame++;
-		}
-		if (plr[pnum]._pIFlags & ISPL_FASTATTACK && (origFrame == 1 || origFrame == 3)) {
-			plr[pnum].AnimInfo.CurrentFrame++;
-		}
 	}
 
 	int arrows = 0;
@@ -3041,10 +3018,6 @@ bool PM_DoBlock(int pnum)
 		app_fatal("PM_DoBlock: illegal player %d", pnum);
 	}
 
-	if (plr[pnum]._pIFlags & ISPL_FASTBLOCK && plr[pnum].AnimInfo.CurrentFrame != 1) {
-		plr[pnum].AnimInfo.CurrentFrame = plr[pnum]._pBFrames;
-	}
-
 	if (plr[pnum].AnimInfo.CurrentFrame >= plr[pnum]._pBFrames) {
 		StartStand(pnum, plr[pnum]._pdir);
 		ClearPlrPVars(pnum);
@@ -3148,21 +3121,8 @@ bool PM_DoSpell(int pnum)
 
 bool PM_DoGotHit(int pnum)
 {
-	int frame;
-
 	if ((DWORD)pnum >= MAX_PLRS) {
 		app_fatal("PM_DoGotHit: illegal player %d", pnum);
-	}
-
-	frame = plr[pnum].AnimInfo.CurrentFrame;
-	if (plr[pnum]._pIFlags & ISPL_FASTRECOVER && frame == 3) {
-		plr[pnum].AnimInfo.CurrentFrame++;
-	}
-	if (plr[pnum]._pIFlags & ISPL_FASTERRECOVER && (frame == 3 || frame == 5)) {
-		plr[pnum].AnimInfo.CurrentFrame++;
-	}
-	if (plr[pnum]._pIFlags & ISPL_FASTESTRECOVER && (frame == 1 || frame == 3 || frame == 5)) {
-		plr[pnum].AnimInfo.CurrentFrame++;
 	}
 
 	if (plr[pnum].AnimInfo.CurrentFrame >= plr[pnum]._pHFrames) {

--- a/test/animationinfo_test.cpp
+++ b/test/animationinfo_test.cpp
@@ -37,12 +37,10 @@ struct SetNewAnimationData : TestData {
 struct GameTickData : TestData {
 	int _ExpectedAnimationFrame;
 	int _ExpectedAnimationCnt;
-	int _FramesToSkip;
-	GameTickData(int expectedAnimationFrame, int expectedAnimationCnt, int framesToSkip = 0)
+	GameTickData(int expectedAnimationFrame, int expectedAnimationCnt)
 	{
 		_ExpectedAnimationFrame = expectedAnimationFrame;
 		_ExpectedAnimationCnt = expectedAnimationCnt;
-		_FramesToSkip = framesToSkip;
 	}
 };
 
@@ -84,8 +82,6 @@ void RunAnimationTest(const std::vector<TestData *> &vecTestData)
 		auto gameTickData = dynamic_cast<GameTickData *>(x);
 		if (gameTickData != nullptr) {
 			currentGameTick += 1;
-			if (gameTickData->_FramesToSkip != 0)
-				animInfo.CurrentFrame += gameTickData->_FramesToSkip;
 			animInfo.ProcessAnimation();
 			EXPECT_EQ(animInfo.CurrentFrame, gameTickData->_ExpectedAnimationFrame);
 			EXPECT_EQ(animInfo.DelayCounter, gameTickData->_ExpectedAnimationCnt);
@@ -176,22 +172,22 @@ TEST(AnimationInfo, AttackSwordWarriorWithFastestAttack) // Skipped frames and P
 	    {
 	        new SetNewAnimationData(16, 0, AnimationDistributionFlags::ProcessAnimationPending, 2, 9),
 	        // ProcessAnimation directly after StartAttack (in same GameTick). So we don't see any rendering before.
-	        new GameTickData(2, 0),
+	        new GameTickData(4, 0),
 	        new RenderingData(0.0f, 1),
 	        new RenderingData(0.3f, 1),
 	        new RenderingData(0.6f, 1),
 	        new RenderingData(0.8f, 2),
-	        new GameTickData(3, 0),
+	        new GameTickData(5, 0),
 	        new RenderingData(0.0f, 2),
 	        new RenderingData(0.3f, 3),
 	        new RenderingData(0.6f, 3),
 	        new RenderingData(0.8f, 3),
-	        new GameTickData(4, 0),
+	        new GameTickData(6, 0),
 	        new RenderingData(0.0f, 4),
 	        new RenderingData(0.3f, 4),
 	        new RenderingData(0.6f, 5),
 	        new RenderingData(0.8f, 5),
-	        new GameTickData(7, 0, 2),
+	        new GameTickData(7, 0),
 	        new RenderingData(0.0f, 5),
 	        new RenderingData(0.3f, 6),
 	        new RenderingData(0.6f, 6),
@@ -371,17 +367,17 @@ TEST(AnimationInfo, BlockingSorcererWithFastBlock) // Skipped frames and ignored
 	        new RenderingData(0.3f, 1),
 	        new RenderingData(0.6f, 1),
 	        new RenderingData(0.8f, 2),
-	        new GameTickData(1, 1),
+	        new GameTickData(5, 1),
 	        new RenderingData(0.0f, 2),
 	        new RenderingData(0.3f, 2),
 	        new RenderingData(0.6f, 3),
 	        new RenderingData(0.8f, 3),
-	        new GameTickData(1, 2),
+	        new GameTickData(5, 2),
 	        new RenderingData(0.0f, 4),
 	        new RenderingData(0.3f, 4),
 	        new RenderingData(0.6f, 4),
 	        new RenderingData(0.8f, 5),
-	        new GameTickData(2, 0),
+	        new GameTickData(6, 0),
 	        new RenderingData(0.0f, 5),
 	        new RenderingData(0.3f, 5),
 	        new RenderingData(0.6f, 6),
@@ -399,12 +395,12 @@ TEST(AnimationInfo, HitRecoverySorcererZenMode) // Skipped frames and ignored de
 	        new RenderingData(0.3f, 1),
 	        new RenderingData(0.6f, 2),
 	        new RenderingData(0.8f, 2),
-	        new GameTickData(3, 0, 1),
+	        new GameTickData(6, 0),
 	        new RenderingData(0.0f, 3),
 	        new RenderingData(0.3f, 3),
 	        new RenderingData(0.6f, 4),
 	        new RenderingData(0.8f, 4),
-	        new GameTickData(7, 0, 3),
+	        new GameTickData(7, 0),
 	        new RenderingData(0.0f, 5),
 	        new RenderingData(0.3f, 5),
 	        new RenderingData(0.6f, 6),

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -11,12 +11,10 @@ extern bool PM_DoGotHit(int pnum);
 int RunBlockTest(int frames, int flags)
 {
 	int pnum = 0;
-	plr[pnum].AnimInfo.CurrentFrame = 1;
 	plr[pnum]._pHFrames = frames;
-	plr[pnum].actionFrame = 1;
 	plr[pnum]._pIFlags = flags;
-	plr[pnum]._pmode = PM_GOTHIT;
 	plr[pnum]._pGFXLoad = -1;
+	StartPlrHit(pnum, 5, direction::DIR_S);
 
 	int i = 1;
 	for (; i < 100; i++) {


### PR DESCRIPTION
Before the game tried to distribute the skipped Frames across the game ticks/frames.
This resulted in checks like `if (plr[pnum]._pIFlags & ISPL_FASTRECOVER && frame == 3) {`.

This job is now done by the Animation Distribution Logic.
But ADL needs to know in advance how long an animation is shown (time represented as game ticks).

Simplified example with an Animation with 8 Frames and GameTick = 50ms:

- Animation with 8 Frames takes 8 * 50 ms = 400ms
- Same Animation with 2 skipped Frames takes 6 * 50ms = 300ms
  - The original logic removed 2 frames (we missed you nice content). The resulted in the 300ms shown Animation. So each Frame was constantly shown 50 ms (with or without skipping).
  - ADL also skips the 2 game ticks but it doesn't remove the frames. It shortens the frame. The calculation is frame time = 300ms / 8. So each frame is now shown 37,5ms and not 50ms. So we got the same time but all frames are shown! So every bit of nice content stays. 🙂 

But the result is that we have the logic to calculate the skipped frames in two places: the original game logic and ADL. This is not a good design and error prone.

With this pr this is changing.

Notes:

- The original skipping logic is removed.
- For the game logic the skipping now happens always at the start of the Animation. But as far as I have seen no one expect the skipping logic checks frames before the animation hits or is finished.
- This changes introduces a minor breaking change with vanilla.
   - Conditions (all must be true)
      - Skipping is involved (for example faster hit recovery)
      - You save the game while the animation is shown (for example directly after the animation started)
   - Logic/Problem
      - ADL adds the skipping directly at start (for example advances CurrentFrame from 2 to 4)
      - If now loaded in vanilla the old logic also adds the skipping. So for **one** Animation (the saved) you can be faster.
    -  In DevilutionX this can't happen cause we don't apply the logic again. Only the rendered Frame can differ a little, cause the save game logic doesn't contain the new variables from ADL that contains the distribution variables.
