### PR TITLE
Place LigthTbl in bss

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1736,7 +1736,7 @@ void RedBack(const CelOutputBuffer &out)
 
 	if (leveltype != DTYPE_HELL) {
 		BYTE *dst = out.begin();
-		BYTE *tbl = &pLightTbl[idx];
+		BYTE *tbl = &LightTbl[idx];
 		for (int h = gnViewportHeight; h != 0; h--, dst += out.pitch() - gnScreenWidth) {
 			for (int w = gnScreenWidth; w != 0; w--) {
 				*dst = tbl[*dst];
@@ -1745,7 +1745,7 @@ void RedBack(const CelOutputBuffer &out)
 		}
 	} else {
 		BYTE *dst = out.begin();
-		BYTE *tbl = &pLightTbl[idx];
+		BYTE *tbl = &LightTbl[idx];
 		for (int h = gnViewportHeight; h != 0; h--, dst += out.pitch() - gnScreenWidth) {
 			for (int w = gnScreenWidth; w != 0; w--) {
 				if (*dst >= 32)

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -292,7 +292,6 @@ static void start_game(interface_mode uMsg)
 	CalcViewportGeometry();
 	cineflag = false;
 	InitCursor();
-	InitLightTable();
 #ifdef _DEBUG
 	LoadDebugGFX();
 #endif
@@ -323,7 +322,6 @@ static void free_game()
 
 	FreeItemGFX();
 	FreeCursor();
-	FreeLightTable();
 #ifdef _DEBUG
 	FreeDebugGFX();
 #endif

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -44,7 +44,7 @@ BYTE *GetLightTable(char light) {
 		idx += 256; // gray colors
 	if (light >= 4)
 		idx += (light - 1) << 8;
-	return &pLightTbl[idx];
+	return &LightTbl[idx];
 }
 
 } // namespace
@@ -166,7 +166,7 @@ void CelBlitLightSafeTo(const CelOutputBuffer &out, int sx, int sy, BYTE *pRLEBy
 	BYTE *dst = out.at(sx, sy);
 
 	if (tbl == nullptr)
-		tbl = &pLightTbl[light_table_index * 256];
+		tbl = &LightTbl[light_table_index * 256];
 
 	for (; src != &pRLEBytes[nDataSize]; dst -= out.pitch() + nWidth) {
 		for (int w = nWidth; w > 0;) {
@@ -214,7 +214,7 @@ void CelBlitLightTransSafeTo(const CelOutputBuffer &out, int sx, int sy, BYTE *p
 
 	BYTE *src = pRLEBytes;
 	BYTE *dst = out.at(sx, sy);
-	BYTE *tbl = &pLightTbl[light_table_index * 256];
+	BYTE *tbl = &LightTbl[light_table_index * 256];
 	bool shift = ((size_t)dst % 2) != 0;
 
 	for (; src != &pRLEBytes[nDataSize]; dst -= out.pitch() + nWidth, shift = !shift) {
@@ -295,7 +295,7 @@ static void CelBlitLightBlendedSafeTo(const CelOutputBuffer &out, int sx, int sy
 	BYTE *src = pRLEBytes;
 	BYTE *dst = out.at(sx, sy);
 	if (tbl == nullptr)
-		tbl = &pLightTbl[light_table_index * 256];
+		tbl = &LightTbl[light_table_index * 256];
 
 	for (; src != &pRLEBytes[nDataSize]; dst -= out.pitch() + nWidth) {
 		for (int w = nWidth; w > 0;) {
@@ -996,7 +996,7 @@ void Cl2DrawLight(const CelOutputBuffer &out, int sx, int sy, BYTE *pCelBuff, in
 	BYTE *pRLEBytes = CelGetFrameClipped(pCelBuff, nCel, &nDataSize);
 
 	if (light_table_index != 0)
-		Cl2BlitLightSafe(out, sx, sy, pRLEBytes, nDataSize, nWidth, &pLightTbl[light_table_index * 256]);
+		Cl2BlitLightSafe(out, sx, sy, pRLEBytes, nDataSize, nWidth, &LightTbl[light_table_index * 256]);
 	else
 		Cl2BlitSafe(out, sx, sy, pRLEBytes, nDataSize, nWidth);
 }

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -22,7 +22,7 @@ char lightmax;
 bool dolighting;
 BYTE lightblock[64][16][16];
 int visionid;
-BYTE *pLightTbl;
+uint8_t LightTbl[LIGHTSIZE];
 bool lightflag;
 
 /**
@@ -764,17 +764,6 @@ void DoVision(int nXPos, int nYPos, int nRadius, bool doautomap, bool visible)
 	}
 }
 
-void FreeLightTable()
-{
-	MemFreeDbg(pLightTbl);
-}
-
-void InitLightTable()
-{
-	assert(!pLightTbl);
-	pLightTbl = DiabloAllocPtr(LIGHTSIZE);
-}
-
 void MakeLightTable()
 {
 	int i, j, k, l, lights, shade, l1, l2, cnt, rem, div;
@@ -783,7 +772,7 @@ void MakeLightTable()
 	BYTE *tbl, *trn;
 	BYTE blood[16];
 
-	tbl = pLightTbl;
+	tbl = LightTbl;
 	shade = 0;
 
 	if (light4flag) {
@@ -851,7 +840,7 @@ void MakeLightTable()
 	}
 
 	if (leveltype == DTYPE_HELL) {
-		tbl = pLightTbl;
+		tbl = LightTbl;
 		for (i = 0; i < lights; i++) {
 			l1 = lights - i;
 			l2 = l1;
@@ -891,7 +880,7 @@ void MakeLightTable()
 		tbl += 224;
 	}
 	if (currlevel >= 17) {
-		tbl = pLightTbl;
+		tbl = LightTbl;
 		for (i = 0; i < lights; i++) {
 			*tbl++ = 0;
 			for (j = 1; j < 16; j++)
@@ -1275,7 +1264,7 @@ void lighting_color_cycling()
 		return;
 	}
 
-	tbl = pLightTbl;
+	tbl = LightTbl;
 
 	for (j = 0; j < l; j++) {
 		tbl++;

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -41,14 +41,12 @@ extern int numvision;
 extern char lightmax;
 extern bool dolighting;
 extern int visionid;
-extern BYTE *pLightTbl;
+extern uint8_t LightTbl[LIGHTSIZE];
 extern bool lightflag;
 
 void DoLighting(int nXPos, int nYPos, int nRadius, int Lnum);
 void DoUnVision(int nXPos, int nYPos, int nRadius);
 void DoVision(int nXPos, int nYPos, int nRadius, bool doautomap, bool visible);
-void FreeLightTable();
-void InitLightTable();
 void MakeLightTable();
 #ifdef _DEBUG
 void ToggleLighting();

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -855,7 +855,7 @@ void PlaceUniqueMonst(int uniqindex, int miniontype, int bosspacksize)
 	}
 
 	sprintf(filestr, "Monsters\\Monsters\\%s.TRN", Uniq->mTrnName);
-	LoadFileWithMem(filestr, &pLightTbl[256 * (uniquetrans + 19)]);
+	LoadFileWithMem(filestr, &LightTbl[256 * (uniquetrans + 19)]);
 
 	Monst->_uniqtrans = uniquetrans++;
 

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -475,7 +475,7 @@ RenderTile(CelOutputBuffer out, int x, int y)
 
 	src = &pDungeonCels[SDL_SwapLE32(pFrameTable[level_cel_block & 0xFFF])];
 	tile = (level_cel_block & 0x7000) >> 12;
-	tbl = &pLightTbl[256 * light_table_index];
+	tbl = &LightTbl[256 * light_table_index];
 
 	// The mask defines what parts of the tile is opaque
 	mask = &SolidMask[TILE_HEIGHT - 1];


### PR DESCRIPTION
LigthTbl is always in use while playing. Sparing 7K of RAM while in the menu (and presumably about to start playing) is pointless.