### PR TITLE
Translation quickfix

### DIFF
--- a/Source/controls/modifier_hints.cpp
+++ b/Source/controls/modifier_hints.cpp
@@ -30,14 +30,14 @@ int SpaceWidth()
 struct CircleMenuHint {
 	CircleMenuHint(bool isDpad, const char *top, const char *right, const char *bottom, const char *left)
 	    : is_dpad(isDpad)
-	    , top(_(top))
-	    , top_w(CalculateTextWidth(_(top)))
-	    , right(_(right))
-	    , right_w(CalculateTextWidth(_(right)))
-	    , bottom(_(bottom))
-	    , bottom_w(CalculateTextWidth(_(bottom)))
-	    , left(_(left))
-	    , left_w(CalculateTextWidth(_(left)))
+	    , top(top)
+	    , top_w(CalculateTextWidth(top))
+	    , right(right)
+	    , right_w(CalculateTextWidth(right))
+	    , bottom(bottom)
+	    , bottom_w(CalculateTextWidth(bottom))
+	    , left(left)
+	    , left_w(CalculateTextWidth(left))
 	    , x_mid(left_w + SpaceWidth() * 2.5)
 	{
 	}
@@ -114,8 +114,8 @@ void DrawStartModifierMenu(const CelOutputBuffer &out)
 {
 	if (!start_modifier_active)
 		return;
-	static const CircleMenuHint dPad(/*is_dpad=*/true, /*top=*/N_("Menu"), /*right=*/N_("Inv"), /*bottom=*/N_("Map"), /*left=*/N_("Char"));
-	static const CircleMenuHint buttons(/*is_dpad=*/false, /*top=*/"", /*right=*/"", /*bottom=*/N_("Spells"), /*left=*/N_("Quests"));
+	static const CircleMenuHint dPad(/*is_dpad=*/true, /*top=*/_("Menu"), /*right=*/_("Inv"), /*bottom=*/_("Map"), /*left=*/_("Char"));
+	static const CircleMenuHint buttons(/*is_dpad=*/false, /*top=*/"", /*right=*/"", /*bottom=*/_("Spells"), /*left=*/_("Quests"));
 	DrawCircleMenuHint(out, dPad, PANEL_LEFT + CircleMarginX, PANEL_TOP - CirclesTop);
 	DrawCircleMenuHint(out, buttons, PANEL_LEFT + PANEL_WIDTH - buttons.Width() - CircleMarginX, PANEL_TOP - CirclesTop);
 }

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3615,7 +3615,7 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		strcpy(tempstr, _("knocks target back"));
 		break;
 	case IPL_3XDAMVDEM:
-		strcpy(tempstr, _("+200% damage vs. demons"));
+		/*xgettext:no-c-format*/ strcpy(tempstr, _("+200% damage vs. demons"));
 		break;
 	case IPL_ALLRESZERO:
 		strcpy(tempstr, _("All Resistance equals 0"));
@@ -3625,15 +3625,15 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		break;
 	case IPL_STEALMANA:
 		if ((x->_iFlags & ISPL_STEALMANA_3) != 0)
-			strcpy(tempstr, _("hit steals 3% mana"));
+			/*xgettext:no-c-format*/ strcpy(tempstr, _("hit steals 3% mana"));
 		if ((x->_iFlags & ISPL_STEALMANA_5) != 0)
-			strcpy(tempstr, _("hit steals 5% mana"));
+			/*xgettext:no-c-format*/ strcpy(tempstr, _("hit steals 5% mana"));
 		break;
 	case IPL_STEALLIFE:
 		if ((x->_iFlags & ISPL_STEALLIFE_3) != 0)
-			strcpy(tempstr, _("hit steals 3% life"));
+			/*xgettext:no-c-format*/ strcpy(tempstr, _("hit steals 3% life"));
 		if ((x->_iFlags & ISPL_STEALLIFE_5) != 0)
-			strcpy(tempstr, _("hit steals 5% life"));
+			/*xgettext:no-c-format*/ strcpy(tempstr, _("hit steals 5% life"));
 		break;
 	case IPL_TARGAC:
 		strcpy(tempstr, _("penetrates target's armor"));
@@ -3717,7 +3717,7 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		strcpy(tempstr, _("2x dmg to monst, 1x to you"));
 		break;
 	case IPL_JESTERS:
-		strcpy(tempstr, _("Random 0 - 500% damage"));
+		/*xgettext:no-c-format*/ strcpy(tempstr, _("Random 0 - 500% damage"));
 		break;
 	case IPL_CRYSTALLINE:
 		sprintf(tempstr, _("low dur, %+i%% damage"), x->_iPLDam);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3690,7 +3690,7 @@ void PrintItemPower(char plidx, ItemStruct *x)
 		strcpy(tempstr, _("see with infravision"));
 		break;
 	case IPL_INVCURS:
-		strcpy(tempstr, _(" "));
+		strcpy(tempstr, " ");
 		break;
 	case IPL_ADDACLIFE:
 		if (x->_iFMinDam == x->_iFMaxDam)

--- a/Translations/devilutionx.pot
+++ b/Translations/devilutionx.pot
@@ -3665,22 +3665,22 @@ msgid "hit monster doesn't heal"
 msgstr ""
 
 #: Source/items.cpp:3629
-#, c-format
+#, no-c-format
 msgid "hit steals 3% mana"
 msgstr ""
 
 #: Source/items.cpp:3631
-#, c-format
+#, no-c-format
 msgid "hit steals 5% mana"
 msgstr ""
 
 #: Source/items.cpp:3635
-#, c-format
+#, no-c-format
 msgid "hit steals 3% life"
 msgstr ""
 
 #: Source/items.cpp:3637
-#, c-format
+#, no-c-format
 msgid "hit steals 5% life"
 msgstr ""
 
@@ -3794,7 +3794,7 @@ msgid "2x dmg to monst, 1x to you"
 msgstr ""
 
 #: Source/items.cpp:3721
-#, c-format
+#, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr ""
 


### PR DESCRIPTION
 c-format string are checked by poedit
 "hit steals 5% life" could be translated into "vole 5% de vie". and poedit would like to make sure that %d would be filled with a int