### PR TITLE
Add a demo recorder and replayer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,7 @@ set(devilutionx_SRCS
   Source/utils/language.cpp
   Source/utils/paths.cpp
   Source/utils/thread.cpp
+  Source/utils/recorder.cpp
   Source/DiabloUI/art.cpp
   Source/DiabloUI/art_draw.cpp
   Source/DiabloUI/button.cpp

--- a/Source/utils/recorder.cpp
+++ b/Source/utils/recorder.cpp
@@ -1,0 +1,68 @@
+#include "utils/recorder.hpp"
+
+#include <SDL_timer.h>
+
+#include "utils/log.hpp"
+
+namespace devilution {
+
+void Recorder::onMessage(const tagMSG &msg, std::uint64_t frameCount)
+{
+	if (status != Status::Recording)
+		return;
+
+	if (!startFrame)
+		startFrame = frameCount;
+
+	record.emplace_back(frameCount - startFrame, msg);
+}
+
+void Recorder::setStatus(Status status)
+{
+	if (this->status == status)
+		return;
+
+	this->status = status;
+
+	switch (status) {
+	case Status::Replaying:
+		Log("Replaying {} messages", record.size());
+		recordIndex = 0;
+		break;
+	case Status::Recording:
+		record.clear();
+		break;
+	case Status::Stopped:
+		startFrame = 0;
+		break;
+	}
+}
+
+bool Recorder::replay(tagMSG &msg, std::uint64_t frameCount)
+{
+	if (status != Status::Replaying)
+		return false;
+
+	if (!startFrame)
+		startFrame = frameCount;
+
+	if (recordIndex >= record.size()) {
+		Log("Replaying finished");
+		setStatus(Status::Stopped);
+		return false;
+	}
+
+	auto time = frameCount - startFrame;
+	const auto &rec = record[recordIndex];
+
+	auto recTime = std::get<std::uint64_t>(rec);
+	if (time >= recTime) {
+		msg = std::get<tagMSG>(rec);
+		++recordIndex;
+		return true;
+	}
+
+	return false;
+}
+
+} // namespace devilution

--- a/Source/utils/recorder.hpp
+++ b/Source/utils/recorder.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <vector>
+#include <tuple>
+
+#include "../miniwin/miniwin.h"
+
+namespace devilution {
+
+class Recorder final {
+public:
+	enum class Status {
+		Stopped,
+		Recording,
+		Replaying,
+	};
+
+	Recorder() = default;
+
+	void onMessage(const tagMSG &msg, std::uint64_t frameCount);
+	void setStatus(Status status);
+	Status getStatus() const
+	{
+		return status;
+	}
+	bool replay(tagMSG &msg, std::uint64_t frameCount);
+
+private:
+	std::vector<std::tuple<std::uint64_t, tagMSG>> record;
+	Status status {};
+	std::uint64_t startFrame {};
+	std::size_t recordIndex {};
+};
+
+} // namespace devilution


### PR DESCRIPTION
This adds a demo recorder and replayer PoC. Is it based on frame count and not on time, so should be resilient to CPU lag (and manages level loading).

Start/stop recording by pressing the right control key, and start/stop replaying using the right shift key.

This is missing quite a few features (like writing to file, saving random seeds, etc), so this is only to test if this can reliably record and replay gameplay. Having a record/replay system could help us to automatically detect crashes, regressions and desync bugs. Players could also record a demo to report a bug or just for fun.

See https://github.com/diasurgical/devilutionX/pull/904 for another implementation.