### PR TITLE
Fix sound volume/panning attenuation

### DIFF
--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -6,11 +6,6 @@
 #include "init.h"
 #include "player.h"
 #include "sound.h"
-#include "utils/math.h"
-
-#ifndef NOSOUND
-#include "utils/soundsample.h"
-#endif
 
 namespace devilution {
 namespace {

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -94,11 +94,11 @@ struct Point {
 	}
 
 	/**
-	 * @brief Computes fast approximate distance between this and other, using only integer arithmetic, with less than ~5% error
+	 * @brief Fast approximate distance between two point, using only integer arithmetic, with less than ~5% error
 	 * @param other Pointer to which we want the distance
 	 * @return Magnitude of vector this -> other
 	*/
-	int ApproxDistance(const Point &other) const
+	int ApproxDistance(Point other) const
 	{
 		int min;
 		int max;

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -98,7 +98,8 @@ struct Point {
 
 	 * @param other Pointer to which we want the distance
 	 * @return Magnitude of vector this -> other
-	*/
+	 */
+
 	int ApproxDistance(Point other) const
 	{
 		int min;

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -95,7 +95,6 @@ struct Point {
 
 	/**
 	 * @brief Fast approximate distance between two points, using only integer arithmetic, with less than ~5% error
-
 	 * @param other Pointer to which we want the distance
 	 * @return Magnitude of vector this -> other
 	 */

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <memory>
+#include <tuple>
 #include <utility>
 
 #include <SDL.h>
@@ -90,6 +91,25 @@ struct Point {
 	{
 		a -= b;
 		return a;
+	}
+
+	/**
+	 * @brief Computes fast approximate distance between this and other, using only integer arithmetic, with less than ~5% error
+	 * @param other Pointer to which we want the distance
+	 * @return Magnitude of vector this -> other
+	*/
+	int ApproxDistance(const Point &other) const
+	{
+		int min;
+		int max;
+
+		std::tie(min, max) = std::minmax(std::abs(other.x - x), std::abs(other.y - y));
+
+		int approx = max * 1007 + min * 441;
+		if (max < (min * 16))
+			approx -= max * 40;
+
+		return (approx + 512) / 1024;
 	}
 };
 

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -94,7 +94,8 @@ struct Point {
 	}
 
 	/**
-	 * @brief Fast approximate distance between two point, using only integer arithmetic, with less than ~5% error
+	 * @brief Fast approximate distance between two points, using only integer arithmetic, with less than ~5% error
+
 	 * @param other Pointer to which we want the distance
 	 * @return Magnitude of vector this -> other
 	*/

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -186,7 +186,7 @@ void gamemenu_sound_music_toggle(const char *const *names, TMenuItem *menu_item,
 	if (gbSndInited) {
 		menu_item->dwFlags |= GMENU_ENABLED | GMENU_SLIDER;
 		menu_item->pszStr = names[0];
-		gmenu_slider_steps(menu_item, 17);
+		gmenu_slider_steps(menu_item, VOLUME_STEPS);
 		gmenu_slider_set(menu_item, VOLUME_MIN, VOLUME_MAX, volume);
 		return;
 	}

--- a/Source/sound.h
+++ b/Source/sound.h
@@ -19,6 +19,13 @@ namespace devilution {
 
 #define VOLUME_MIN -1600
 #define VOLUME_MAX 0
+#define VOLUME_STEPS 64
+
+#define ATTENUATION_MIN -6400
+#define ATTENUATION_MAX 0
+
+#define PAN_MIN -6400
+#define PAN_MAX 6400
 
 enum _music_id : uint8_t {
 	TMUSIC_TOWN,

--- a/Source/utils/math.h
+++ b/Source/utils/math.h
@@ -14,10 +14,59 @@ namespace math {
  * @param t Value to compute sign of
  * @return -1 if t < 0, 1 if t > 0, 0 if t == 0
 */
-template<typename T>
+template <typename T>
 int Sign(T t)
 {
 	return (t > T(0)) - (t < T(0));
+}
+
+/**
+ * @brief Linearly interpolate from a towards b using mixing value t
+ * @tparam V Any arithmetic type, used for interpolants and return value
+ * @tparam T Any arithmetic type, used for interpolator
+ * @param a Low interpolation value (returned when t == 0)
+ * @param b High interpolation value (returned when t == 1)
+ * @param t Interpolator, commonly in range [0..1], values outside this range will extrapolate
+ * @return a + (b - a) * t
+*/
+template <typename V, typename T>
+V Lerp(V a, V b, T t)
+{
+	return a + (b - a) * t;
+}
+
+/**
+ * @brief Inverse lerp, given two key values a and b, and a free value v, determine mixing factor t so that v = Lerp(a, b, t)
+ * @tparam T Any arithmetic type
+ * @param a Low key value (function returns 0 if v == a)
+ * @param b High key value (function returns 1 if v == b)
+ * @param v Mixing factor, commonly in range [a..b] to get a return [0..1]
+ * @return Value t so that v = Lerp(a, b, t); or 0 if b == a
+*/
+template <typename T>
+T InvLerp(T a, T b, T v)
+{
+	if (b == a)
+		return T(0);
+
+	return (v - a) / (b - a);
+}
+
+/**
+ * @brief Remaps value v from range [inMin, inMax] to [outMin, outMax]
+ * @tparam T Any arithmetic type
+ * @param inMin First bound of input range
+ * @param inMax Second bound of input range
+ * @param outMin First bound of output range
+ * @param outMax Second bound of output range
+ * @param v Value to remap
+ * @return Transformed value so that InvLerp(inMin, inMax, v) == InvLerp(outMin, outMax, return)
+*/
+template <typename T>
+T Remap(T inMin, T inMax, T outMin, T outMax, T v)
+{
+	auto t = InvLerp(inMin, inMax, v);
+	return Lerp(outMin, outMax, t);
 }
 
 } // namespace math

--- a/Source/utils/soundsample.cpp
+++ b/Source/utils/soundsample.cpp
@@ -25,9 +25,11 @@ namespace {
 
 constexpr float LogBase = 10.0f;
 
-// Scaling factor for attenuating volume.
-// Picked so that a volume change of -10 dB results in half perceived loudness.
-// VolumeScale = -1000 / log(0.5)
+/**
+ * Scaling factor for attenuating volume.
+ * Picked so that a volume change of -10 dB results in half perceived loudness.
+ * VolumeScale = -1000 / log(0.5)
+ */
 constexpr float VolumeScale = 3321.9281f;
 
 // Min and max volume range, in millibel.

--- a/Source/utils/soundsample.cpp
+++ b/Source/utils/soundsample.cpp
@@ -51,7 +51,9 @@ float PanLogToLinear(int logPan)
 	if (logPan == 0)
 		return 0;
 
-	return copysign(1.0f - std::pow(LogBase, static_cast<float>(-std::abs(logPan)) / StereoSeparation), static_cast<float>(logPan));
+	auto factor = std::pow(LogBase, static_cast<float>(-std::abs(logPan)) / StereoSeparation);
+	
+	return copysign(1.0f - factor, static_cast<float>(logPan));
 }
 
 } // namespace

--- a/Source/utils/soundsample.cpp
+++ b/Source/utils/soundsample.cpp
@@ -32,8 +32,10 @@ constexpr float LogBase = 10.0f;
  */
 constexpr float VolumeScale = 3321.9281f;
 
-// Min and max volume range, in millibel.
-// -100 dB (muted) to 0 dB (max. loudness).
+/**
+ * Min and max volume range, in millibel.
+ * -100 dB (muted) to 0 dB (max. loudness).
+/*
 constexpr float MillibelMin = -10000.0f;
 constexpr float MillibelMax = 0.0f;
 

--- a/Source/utils/soundsample.cpp
+++ b/Source/utils/soundsample.cpp
@@ -39,8 +39,11 @@ constexpr float VolumeScale = 3321.9281f;
 constexpr float MillibelMin = -10000.0f;
 constexpr float MillibelMax = 0.0f;
 
-// Stereo separation factor for left/right speaker panning. Lower values increase separation, moving sounds further left/right, while higher values will pull sounds more towards the middle, reducing separation.
-// Current value is tuned to have ~2:1 mix for sounds that happen on the edge of a 640x480 screen.
+/**
+ * Stereo separation factor for left/right speaker panning. Lower values increase separation, moving
+ * sounds further left/right, while higher values will pull sounds more towards the middle, reducing separation.
+ * Current value is tuned to have ~2:1 mix for sounds that happen on the edge of a 640x480 screen.
+ */
 constexpr float StereoSeparation = 6000.0f;
 
 float PanLogToLinear(int logPan)

--- a/Source/utils/soundsample.cpp
+++ b/Source/utils/soundsample.cpp
@@ -35,7 +35,7 @@ constexpr float VolumeScale = 3321.9281f;
 /**
  * Min and max volume range, in millibel.
  * -100 dB (muted) to 0 dB (max. loudness).
-/*
+ */
 constexpr float MillibelMin = -10000.0f;
 constexpr float MillibelMax = 0.0f;
 

--- a/Source/utils/soundsample.h
+++ b/Source/utils/soundsample.h
@@ -11,6 +11,15 @@
 
 namespace devilution {
 
+/**
+ * @brief Converts log volume passed in into linear volume.
+ * @param logVolume Logarithmic volume in the range [logMin..logMax]
+ * @param logMin Volume range minimum (usually ATTENUATION_MIN for game sounds and VOLUME_MIN for volume sliders)
+ * @param logMax Volume range maximum (usually 0)
+ * @return Linear volume in the range [0..1]
+*/
+float VolumeLogToLinear(int logVolume, int logMin, int logMax);
+
 class SoundSample final {
 public:
 	SoundSample() = default;
@@ -19,7 +28,7 @@ public:
 
 	void Release();
 	bool IsPlaying();
-	void Play(int lVolume, int lPan, int channel = -1);
+	void Play(int logSoundVolume, int logUserVolume, int logPan, int channel = -1);
 	void Stop();
 	int SetChunkStream(std::string filePath);
 

--- a/test/effects_test.cpp
+++ b/test/effects_test.cpp
@@ -28,29 +28,29 @@ TEST(Effects, calc_snd_position_near)
 TEST(Effects, calc_snd_position_out_of_range)
 {
 	plr[myplr].position.tile = { 12, 12 };
-	int plVolume = 0;
+	int plVolume = 1234;
 	int plPan = 0;
 	EXPECT_EQ(calc_snd_position(112, 112, &plVolume, &plPan), false);
-	ASSERT_GE(plVolume, 6400);
+	EXPECT_EQ(plVolume, 1234);
 	EXPECT_EQ(plPan, 0);
 }
 
-TEST(Effects, calc_snd_position_extream_right)
+TEST(Effects, calc_snd_position_extreme_right)
 {
 	plr[myplr].position.tile = { 50, 50 };
 	int plVolume = 0;
 	int plPan = 0;
-	EXPECT_EQ(calc_snd_position(76, 50, &plVolume, &plPan), false);
-	EXPECT_EQ(plVolume, 0);
-	EXPECT_GT(plPan, 6400);
+	EXPECT_EQ(calc_snd_position(75, 25, &plVolume, &plPan), true);
+	EXPECT_EQ(plVolume, -2176);
+	EXPECT_EQ(plPan, 6400);
 }
 
-TEST(Effects, calc_snd_position_extream_left)
+TEST(Effects, calc_snd_position_extreme_left)
 {
 	plr[myplr].position.tile = { 50, 50 };
 	int plVolume = 0;
 	int plPan = 0;
-	EXPECT_EQ(calc_snd_position(24, 50, &plVolume, &plPan), false);
-	EXPECT_EQ(plVolume, 0);
-	EXPECT_LT(plPan, -6400);
+	EXPECT_EQ(calc_snd_position(25, 75, &plVolume, &plPan), true);
+	EXPECT_EQ(plVolume, -2176);
+	EXPECT_EQ(plPan, -6400);
 }


### PR DESCRIPTION
Fixes #1632 

The panning and distance attenuation calculations were very strange and nonsensical.
- Volume doesn't abruptly change from 'sorta half quiet' to 'muted on the last notch of the slider.
- Volume sliders are logarithmic, which feels way nicer than linear attenuation.
- Panning was completely hosed, and caused strange cutoff issues. You could hear only about 25 tiles left/right of your character before the sound volume snapped to zero, but about 100 tiles directly up/down.
- Volume sliders now have 64 steps (instead of 16), so you can actually have some reasonably fine control over volume. Each notch equals a bit more than 1.5 dB.