### PR TITLE
Fix Bard incorrect number of sword animation frames

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -674,8 +674,6 @@ void SetPlrAnims(int pnum)
 		} else if (gn == ANIM_ID_STAFF) {
 			plr[pnum]._pAFrames = 16;
 			plr[pnum]._pAFNum = 11;
-		} else if (gn == ANIM_ID_SWORD_SHIELD || gn == ANIM_ID_SWORD) {
-			plr[pnum]._pAFrames = 10;
 		}
 	} else if (pc == HeroClass::Barbarian) {
 		if (gn == ANIM_ID_AXE) {


### PR DESCRIPTION
Fixes #1755

Before the fix:

Class | Weapon | Hitframe | Number of Frames
-- | -- | -- | --
Bard | Sword | 10 | 10
Bard | Bow | 11 | 12
Warrior | Sword | 9 | 16
Warrior | Bow | 11 | 16
Rogue | Sword | 10 | 18
Rogue | Bow | 7 | 12

You can see that the Number of Frames differ for Bard and Rogue but not the Hitframe (the Frame where the Attack hits and after that the Animation can be canceled or next Attack can be executed).
So it's not overpowered but the animation is cropped.
The fix is to restore the original 18 Number of Frames for Sword Attacks.

Notes:

- The thing that I don't understand is why this didn't occur in vanilla Hellfire. It could mean it was fixed in another way or the source in [devilution](https://github.com/diasurgical/devilution/blob/2bf6eeb125a540e83ec838d6ab9181f2b26d0983/Source/player.cpp#L674) is wrong.
- The animation for Bard with Bow is not nice. Cause it fires at Frame 10 and at Frame 10 the Bow is already lowered. So this doesn't look good. But this is another issue.