### PR TITLE
Fix "Pause" stops music playing

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -982,7 +982,6 @@ void diablo_pause_game()
 			PauseMode = 0;
 		} else {
 			PauseMode = 2;
-			sound_stop();
 			track_repeat_walk(false);
 		}
 		force_redraw = 255;


### PR DESCRIPTION
Fix for Keyboard hit "P" - "Pause" stops music playing #1782
sound_stop makes no sense when the game is paused.
In vanilla the music does not stop as well.