### PR TITLE
Enable ADL for Items

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2240,13 +2240,16 @@ void SetupItem(int i)
 	int it;
 
 	it = ItemCAnimTbl[items[i]._iCurs];
-	items[i].AnimInfo.pCelSprite = itemanims[it] ? &*itemanims[it] : nullptr;
-	items[i].AnimInfo.NumberOfFrames = ItemAnimLs[it];
+	int numberOfFrames = ItemAnimLs[it];
+	auto *pCelSprite = itemanims[it] ? &*itemanims[it] : nullptr;
+	if (items[i]._iCurs != ICURS_MAGIC_ROCK)
+		items[i].AnimInfo.SetNewAnimation(pCelSprite, numberOfFrames, 0, AnimationDistributionFlags::ProcessAnimationPending, 0, numberOfFrames);
+	else
+		items[i].AnimInfo.SetNewAnimation(pCelSprite, numberOfFrames, 0);
 	items[i]._iIdentified = false;
 	items[i]._iPostDraw = false;
 
 	if (!plr[myplr].pLvlLoad) {
-		items[i].AnimInfo.CurrentFrame = 1;
 		items[i]._iAnimFlag = true;
 		items[i]._iSelFlag = 0;
 	} else {
@@ -2937,12 +2940,15 @@ void RespawnItem(ItemStruct *item, bool FlipFlag)
 	int it;
 
 	it = ItemCAnimTbl[item->_iCurs];
-	item->AnimInfo.pCelSprite = &*itemanims[it];
-	item->AnimInfo.NumberOfFrames = ItemAnimLs[it];
+	int numberOfFrames = ItemAnimLs[it];
+	auto *pCelSprite = &*itemanims[it];
+	if (item->_iCurs != ICURS_MAGIC_ROCK)
+		item->AnimInfo.SetNewAnimation(pCelSprite, numberOfFrames, 0, AnimationDistributionFlags::ProcessAnimationPending, 0, numberOfFrames);
+	else
+		item->AnimInfo.SetNewAnimation(pCelSprite, numberOfFrames, 0);
 	item->_iPostDraw = false;
 	item->_iRequest = false;
 	if (FlipFlag) {
-		item->AnimInfo.CurrentFrame = 1;
 		item->_iAnimFlag = true;
 		item->_iSelFlag = 0;
 	} else {
@@ -2995,7 +3001,7 @@ void ProcessItems()
 		int ii = itemactive[i];
 		if (!items[ii]._iAnimFlag)
 			continue;
-		items[ii].AnimInfo.CurrentFrame++;
+		items[ii].AnimInfo.ProcessAnimation();
 		if (items[ii]._iCurs == ICURS_MAGIC_ROCK) {
 			if (items[ii]._iSelFlag == 1 && items[ii].AnimInfo.CurrentFrame == 11)
 				items[ii].AnimInfo.CurrentFrame = 1;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2237,26 +2237,8 @@ void GetItemBonus(int i, int minlvl, int maxlvl, bool onlygood, bool allowspells
 
 void SetupItem(int i)
 {
-	int it;
-
-	it = ItemCAnimTbl[items[i]._iCurs];
-	int numberOfFrames = ItemAnimLs[it];
-	auto *pCelSprite = itemanims[it] ? &*itemanims[it] : nullptr;
-	if (items[i]._iCurs != ICURS_MAGIC_ROCK)
-		items[i].AnimInfo.SetNewAnimation(pCelSprite, numberOfFrames, 0, AnimationDistributionFlags::ProcessAnimationPending, 0, numberOfFrames);
-	else
-		items[i].AnimInfo.SetNewAnimation(pCelSprite, numberOfFrames, 0);
+	items[i].SetNewAnimation(!plr[myplr].pLvlLoad);
 	items[i]._iIdentified = false;
-	items[i]._iPostDraw = false;
-
-	if (!plr[myplr].pLvlLoad) {
-		items[i]._iAnimFlag = true;
-		items[i]._iSelFlag = 0;
-	} else {
-		items[i].AnimInfo.CurrentFrame = items[i].AnimInfo.NumberOfFrames;
-		items[i]._iAnimFlag = false;
-		items[i]._iSelFlag = 1;
-	}
 }
 
 int RndItem(int m)
@@ -2912,11 +2894,9 @@ void SpawnRewardItem(int itemid, Point position)
 	dItem[position.x][position.y] = ii + 1;
 	int curlv = items_get_currlevel();
 	GetItemAttrs(ii, itemid, curlv);
-	SetupItem(ii);
+	items[ii].SetNewAnimation(true);
 	items[ii]._iSelFlag = 2;
 	items[ii]._iPostDraw = true;
-	items[ii].AnimInfo.CurrentFrame = 1;
-	items[ii]._iAnimFlag = true;
 	items[ii]._iIdentified = true;
 }
 
@@ -2937,25 +2917,9 @@ void SpawnTheodore(Point position)
 
 void RespawnItem(ItemStruct *item, bool FlipFlag)
 {
-	int it;
-
-	it = ItemCAnimTbl[item->_iCurs];
-	int numberOfFrames = ItemAnimLs[it];
-	auto *pCelSprite = &*itemanims[it];
-	if (item->_iCurs != ICURS_MAGIC_ROCK)
-		item->AnimInfo.SetNewAnimation(pCelSprite, numberOfFrames, 0, AnimationDistributionFlags::ProcessAnimationPending, 0, numberOfFrames);
-	else
-		item->AnimInfo.SetNewAnimation(pCelSprite, numberOfFrames, 0);
-	item->_iPostDraw = false;
+	int it = ItemCAnimTbl[item->_iCurs];
+	item->SetNewAnimation(FlipFlag);
 	item->_iRequest = false;
-	if (FlipFlag) {
-		item->_iAnimFlag = true;
-		item->_iSelFlag = 0;
-	} else {
-		item->AnimInfo.CurrentFrame = item->AnimInfo.NumberOfFrames;
-		item->_iAnimFlag = false;
-		item->_iSelFlag = 1;
-	}
 
 	if (item->_iCurs == ICURS_MAGIC_ROCK) {
 		item->_iSelFlag = 1;
@@ -4992,6 +4956,27 @@ void PutItemRecord(int nSeed, uint16_t wCI, int nIndex)
 			NextItemRecord(i);
 			break;
 		}
+	}
+}
+
+void ItemStruct::SetNewAnimation(bool showAnimation)
+{
+	int it = ItemCAnimTbl[_iCurs];
+	int numberOfFrames = ItemAnimLs[it];
+	auto *pCelSprite = itemanims[it] ? &*itemanims[it] : nullptr;
+	if (_iCurs != ICURS_MAGIC_ROCK)
+		AnimInfo.SetNewAnimation(pCelSprite, numberOfFrames, 0, AnimationDistributionFlags::ProcessAnimationPending, 0, numberOfFrames);
+	else
+		AnimInfo.SetNewAnimation(pCelSprite, numberOfFrames, 0);
+	_iPostDraw = false;
+	_iRequest = false;
+	if (showAnimation) {
+		_iAnimFlag = true;
+		_iSelFlag = 0;
+	} else {
+		AnimInfo.CurrentFrame = AnimInfo.NumberOfFrames;
+		_iAnimFlag = false;
+		_iSelFlag = 1;
 	}
 }
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -479,7 +479,7 @@ void AddInitItems()
 
 		items[ii]._iCreateInfo = curlv | CF_PREGEN;
 		SetupItem(ii);
-		items[ii]._iAnimFrame = items[ii]._iAnimLen;
+		items[ii].AnimInfo.CurrentFrame = items[ii].AnimInfo.NumberOfFrames;
 		items[ii]._iAnimFlag = false;
 		items[ii]._iSelFlag = 1;
 		DeltaAddItem(ii);
@@ -2240,17 +2240,17 @@ void SetupItem(int i)
 	int it;
 
 	it = ItemCAnimTbl[items[i]._iCurs];
-	items[i]._iAnimData = itemanims[it] ? &*itemanims[it] : nullptr;
-	items[i]._iAnimLen = ItemAnimLs[it];
+	items[i].AnimInfo.pCelSprite = itemanims[it] ? &*itemanims[it] : nullptr;
+	items[i].AnimInfo.NumberOfFrames = ItemAnimLs[it];
 	items[i]._iIdentified = false;
 	items[i]._iPostDraw = false;
 
 	if (!plr[myplr].pLvlLoad) {
-		items[i]._iAnimFrame = 1;
+		items[i].AnimInfo.CurrentFrame = 1;
 		items[i]._iAnimFlag = true;
 		items[i]._iSelFlag = 0;
 	} else {
-		items[i]._iAnimFrame = items[i]._iAnimLen;
+		items[i].AnimInfo.CurrentFrame = items[i].AnimInfo.NumberOfFrames;
 		items[i]._iAnimFlag = false;
 		items[i]._iSelFlag = 1;
 	}
@@ -2866,7 +2866,7 @@ void SpawnQuestItem(int itemid, Point position, int randarea, int selflag)
 	items[ii]._iPostDraw = true;
 	if (selflag) {
 		items[ii]._iSelFlag = selflag;
-		items[ii]._iAnimFrame = items[ii]._iAnimLen;
+		items[ii].AnimInfo.CurrentFrame = items[ii].AnimInfo.NumberOfFrames;
 		items[ii]._iAnimFlag = false;
 	}
 }
@@ -2895,7 +2895,7 @@ void SpawnRock()
 	SetupItem(ii);
 	items[ii]._iSelFlag = 2;
 	items[ii]._iPostDraw = true;
-	items[ii]._iAnimFrame = 11;
+	items[ii].AnimInfo.CurrentFrame = 11;
 }
 
 void SpawnRewardItem(int itemid, Point position)
@@ -2912,7 +2912,7 @@ void SpawnRewardItem(int itemid, Point position)
 	SetupItem(ii);
 	items[ii]._iSelFlag = 2;
 	items[ii]._iPostDraw = true;
-	items[ii]._iAnimFrame = 1;
+	items[ii].AnimInfo.CurrentFrame = 1;
 	items[ii]._iAnimFlag = true;
 	items[ii]._iIdentified = true;
 }
@@ -2937,16 +2937,16 @@ void RespawnItem(ItemStruct *item, bool FlipFlag)
 	int it;
 
 	it = ItemCAnimTbl[item->_iCurs];
-	item->_iAnimData = &*itemanims[it];
-	item->_iAnimLen = ItemAnimLs[it];
+	item->AnimInfo.pCelSprite = &*itemanims[it];
+	item->AnimInfo.NumberOfFrames = ItemAnimLs[it];
 	item->_iPostDraw = false;
 	item->_iRequest = false;
 	if (FlipFlag) {
-		item->_iAnimFrame = 1;
+		item->AnimInfo.CurrentFrame = 1;
 		item->_iAnimFlag = true;
 		item->_iSelFlag = 0;
 	} else {
-		item->_iAnimFrame = item->_iAnimLen;
+		item->AnimInfo.CurrentFrame = item->AnimInfo.NumberOfFrames;
 		item->_iAnimFlag = false;
 		item->_iSelFlag = 1;
 	}
@@ -2995,18 +2995,18 @@ void ProcessItems()
 		int ii = itemactive[i];
 		if (!items[ii]._iAnimFlag)
 			continue;
-		items[ii]._iAnimFrame++;
+		items[ii].AnimInfo.CurrentFrame++;
 		if (items[ii]._iCurs == ICURS_MAGIC_ROCK) {
-			if (items[ii]._iSelFlag == 1 && items[ii]._iAnimFrame == 11)
-				items[ii]._iAnimFrame = 1;
-			if (items[ii]._iSelFlag == 2 && items[ii]._iAnimFrame == 21)
-				items[ii]._iAnimFrame = 11;
+			if (items[ii]._iSelFlag == 1 && items[ii].AnimInfo.CurrentFrame == 11)
+				items[ii].AnimInfo.CurrentFrame = 1;
+			if (items[ii]._iSelFlag == 2 && items[ii].AnimInfo.CurrentFrame == 21)
+				items[ii].AnimInfo.CurrentFrame = 11;
 		} else {
-			if (items[ii]._iAnimFrame == items[ii]._iAnimLen / 2)
+			if (items[ii].AnimInfo.CurrentFrame == items[ii].AnimInfo.NumberOfFrames / 2)
 				PlaySfxLoc(ItemDropSnds[ItemCAnimTbl[items[ii]._iCurs]], items[ii].position.x, items[ii].position.y);
 
-			if (items[ii]._iAnimFrame >= items[ii]._iAnimLen) {
-				items[ii]._iAnimFrame = items[ii]._iAnimLen;
+			if (items[ii].AnimInfo.CurrentFrame >= items[ii].AnimInfo.NumberOfFrames) {
+				items[ii].AnimInfo.CurrentFrame = items[ii].AnimInfo.NumberOfFrames;
 				items[ii]._iAnimFlag = false;
 				items[ii]._iSelFlag = 1;
 			}
@@ -3024,7 +3024,7 @@ void FreeItemGFX()
 
 void GetItemFrm(int i)
 {
-	items[i]._iAnimData = &*itemanims[ItemCAnimTbl[items[i]._iCurs]];
+	items[i].AnimInfo.pCelSprite = &*itemanims[ItemCAnimTbl[items[i]._iCurs]];
 }
 
 void GetItemStr(int i)
@@ -4845,7 +4845,7 @@ void RecalcStoreStats()
 int ItemNoFlippy()
 {
 	int r = itemactive[numitems - 1];
-	items[r]._iAnimFrame = items[r]._iAnimLen;
+	items[r].AnimInfo.CurrentFrame = items[r].AnimInfo.NumberOfFrames;
 	items[r]._iAnimFlag = false;
 	items[r]._iSelFlag = 1;
 

--- a/Source/items.h
+++ b/Source/items.h
@@ -371,6 +371,12 @@ struct ItemStruct {
 			return UIS_RED;
 		return getTextColor();
 	}
+
+	/**
+	 * @brief Sets the current Animation for the Item
+	 * @param showAnimation Definies if the Animation (Flipping) is shown or if only the final Frame (item on the ground) is shown
+	 */
+	void SetNewAnimation(bool showAnimation);
 };
 
 struct ItemGetRecordStruct {

--- a/Source/items.h
+++ b/Source/items.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 
 #include "DiabloUI/ui_item.h"
+#include "engine/animationinfo.h"
 #include "engine.h"
 #include "itemdat.h"
 #include "utils/stdcompat/optional.hpp"
@@ -174,10 +175,11 @@ struct ItemStruct {
 	enum item_type _itype;
 	Point position;
 	bool _iAnimFlag;
-	CelSprite *_iAnimData; // PSX name -> ItemFrame
-	uint8_t _iAnimLen;     // Number of frames in current animation
-	uint8_t _iAnimFrame;   // Current frame of animation.
-	bool _iDelFlag;        // set when item is flagged for deletion, deprecated in 1.02
+	/*
+	 * @brief Contains Information for current Animation
+	 */
+	AnimationInfo AnimInfo;
+	bool _iDelFlag; // set when item is flagged for deletion, deprecated in 1.02
 	uint8_t _iSelFlag;
 	bool _iPostDraw;
 	bool _iIdentified;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -217,8 +217,8 @@ static void LoadItemData(LoadHelper *file, ItemStruct *pItem)
 	pItem->position.y = file->nextLE<int32_t>();
 	pItem->_iAnimFlag = file->nextBool32();
 	file->skip(4); // Skip pointer _iAnimData
-	pItem->_iAnimLen = file->nextLE<int32_t>();
-	pItem->_iAnimFrame = file->nextLE<int32_t>();
+	pItem->AnimInfo.NumberOfFrames = file->nextLE<int32_t>();
+	pItem->AnimInfo.CurrentFrame = file->nextLE<int32_t>();
 	file->skip(8); // Skip _iAnimWidth and _iAnimWidth2
 	file->skip(4); // Unused since 1.02
 	pItem->_iSelFlag = file->nextLE<uint8_t>();
@@ -1261,8 +1261,8 @@ static void SaveItem(SaveHelper *file, ItemStruct *pItem)
 	file->writeLE<int32_t>(pItem->position.y);
 	file->writeLE<uint32_t>(pItem->_iAnimFlag);
 	file->skip(4); // Skip pointer _iAnimData
-	file->writeLE<int32_t>(pItem->_iAnimLen);
-	file->writeLE<int32_t>(pItem->_iAnimFrame);
+	file->writeLE<int32_t>(pItem->AnimInfo.NumberOfFrames);
+	file->writeLE<int32_t>(pItem->AnimInfo.CurrentFrame);
 	// write _iAnimWidth for vanilla compatibility
 	file->writeLE<int32_t>(ItemAnimWidth);
 	// write _iAnimWidth2 for vanilla compatibility

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -74,7 +74,7 @@ void AddItemToLabelQueue(int id, int x, int y)
 	nameWidth += marginX * 2;
 	int index = ItemCAnimTbl[it->_iCurs];
 	if (!labelCenterOffsets[index]) {
-		std::pair<int, int> itemBounds = MeasureSolidHorizontalBounds(*it->_iAnimData, it->_iAnimFrame);
+		std::pair<int, int> itemBounds = MeasureSolidHorizontalBounds(*it->AnimInfo.pCelSprite, it->AnimInfo.CurrentFrame);
 		labelCenterOffsets[index].emplace((itemBounds.first + itemBounds.second) / 2);
 	}
 

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -627,7 +627,7 @@ static void DrawItem(const CelOutputBuffer &out, int x, int y, int sx, int sy, b
 		return;
 	}
 
-	int nCel = pItem->AnimInfo.CurrentFrame;
+	int nCel = pItem->AnimInfo.GetFrameToUseForRendering();
 	int frames = SDL_SwapLE32(*(DWORD *)cel->Data());
 	if (nCel < 1 || frames > 50 || nCel > frames) {
 		Log("Draw \"{}\" Item 1: frame {} of {}, item type=={}", pItem->_iIName, nCel, frames, pItem->_itype);

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -621,13 +621,13 @@ static void DrawItem(const CelOutputBuffer &out, int x, int y, int sx, int sy, b
 	if (pItem->_iPostDraw == pre)
 		return;
 
-	auto *cel = pItem->_iAnimData;
+	auto *cel = pItem->AnimInfo.pCelSprite;
 	if (cel == nullptr) {
 		Log("Draw Item \"{}\" 1: NULL CelSprite", pItem->_iIName);
 		return;
 	}
 
-	int nCel = pItem->_iAnimFrame;
+	int nCel = pItem->AnimInfo.CurrentFrame;
 	int frames = SDL_SwapLE32(*(DWORD *)cel->Data());
 	if (nCel < 1 || frames > 50 || nCel > frames) {
 		Log("Draw \"{}\" Item 1: frame {} of {}, item type=={}", pItem->_iIName, nCel, frames, pItem->_itype);
@@ -640,7 +640,7 @@ static void DrawItem(const CelOutputBuffer &out, int x, int y, int sx, int sy, b
 		CelBlitOutlineTo(out, GetOutlineColor(*pItem, false), position, *cel, nCel);
 	}
 	CelClippedDrawLightTo(out, position, *cel, nCel);
-	if (pItem->_iAnimFrame == pItem->_iAnimLen || pItem->_iCurs == ICURS_MAGIC_ROCK)
+	if (pItem->AnimInfo.CurrentFrame == pItem->AnimInfo.NumberOfFrames || pItem->_iCurs == ICURS_MAGIC_ROCK)
 		AddItemToLabelQueue(bItem - 1, px, sy);
 }
 


### PR DESCRIPTION
Contributes to #838

This uses `AnimationInfo` in `ItemStruct`.

Notes:

- This change shows the first Frame of Flipping that wasn't shown previous.
- Magic Rock uses normal/old Logic cause it's the only item that didn't stop the Animation with the last Frame, so ADL doesn't help here anyway.

<details><summary>Example Video (5% game speed)</summary>

## devilutionX 1.21

https://user-images.githubusercontent.com/25415264/119418493-6bb70580-bcf8-11eb-86c6-5a45696df657.mp4

## PR

https://user-images.githubusercontent.com/25415264/119418507-71145000-bcf8-11eb-9362-23cae37c8c6f.mp4

</details>