### PR TITLE
♻️  Store CEL width with the sprite itself

### DIFF
--- a/Source/DiabloUI/fonts.cpp
+++ b/Source/DiabloUI/fonts.cpp
@@ -8,7 +8,7 @@
 namespace devilution {
 
 TTF_Font *font = nullptr;
-BYTE *FontTables[4];
+std::unique_ptr<BYTE[]> FontTables[4];
 Art ArtFonts[4][2];
 /** This is so we know ttf has been init when we get to the diablo_deinit() function */
 bool was_fonts_init = false;
@@ -46,13 +46,9 @@ void UnloadArtFonts()
 	ArtFonts[AFT_BIG][AFC_SILVER].Unload();
 	ArtFonts[AFT_BIG][AFC_GOLD].Unload();
 	ArtFonts[AFT_HUGE][AFC_GOLD].Unload();
-	mem_free_dbg(FontTables[AFT_SMALL]);
 	FontTables[AFT_SMALL] = nullptr;
-	mem_free_dbg(FontTables[AFT_MED]);
 	FontTables[AFT_MED] = nullptr;
-	mem_free_dbg(FontTables[AFT_BIG]);
 	FontTables[AFT_BIG] = nullptr;
-	mem_free_dbg(FontTables[AFT_HUGE]);
 	FontTables[AFT_HUGE] = nullptr;
 }
 

--- a/Source/DiabloUI/fonts.cpp
+++ b/Source/DiabloUI/fonts.cpp
@@ -24,10 +24,10 @@ void LoadArtFont(const char *pszFile, int size, int color)
 
 void LoadArtFonts()
 {
-	FontTables[AFT_SMALL] = LoadFileInMem("ui_art\\font16.bin", nullptr);
-	FontTables[AFT_MED] = LoadFileInMem("ui_art\\font24.bin", nullptr);
-	FontTables[AFT_BIG] = LoadFileInMem("ui_art\\font30.bin", nullptr);
-	FontTables[AFT_HUGE] = LoadFileInMem("ui_art\\font42.bin", nullptr);
+	FontTables[AFT_SMALL] = LoadFileInMem("ui_art\\font16.bin");
+	FontTables[AFT_MED] = LoadFileInMem("ui_art\\font24.bin");
+	FontTables[AFT_BIG] = LoadFileInMem("ui_art\\font30.bin");
+	FontTables[AFT_HUGE] = LoadFileInMem("ui_art\\font42.bin");
 	LoadArtFont("ui_art\\font16s.pcx", AFT_SMALL, AFC_SILVER);
 	LoadArtFont("ui_art\\font16g.pcx", AFT_SMALL, AFC_GOLD);
 	LoadArtFont("ui_art\\font24s.pcx", AFT_MED, AFC_SILVER);

--- a/Source/DiabloUI/fonts.h
+++ b/Source/DiabloUI/fonts.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <SDL_ttf.h>
 #include <cstdint>
+#include <memory>
+
+#include <SDL_ttf.h>
 
 #include "DiabloUI/art.h"
 
@@ -20,7 +22,7 @@ enum _artFontColors : uint8_t {
 };
 
 extern TTF_Font *font;
-extern BYTE *FontTables[4];
+extern std::unique_ptr<BYTE[]> FontTables[4];
 extern Art ArtFonts[4][2];
 
 void LoadArtFonts();

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -468,7 +468,7 @@ void InitAutomapOnce()
 void InitAutomap()
 {
 	DWORD dwTiles;
-	BYTE *pAFile;
+	std::unique_ptr<BYTE[]> pAFile;
 
 	memset(AutomapTypes, 0, sizeof(AutomapTypes));
 
@@ -496,7 +496,7 @@ void InitAutomap()
 	}
 
 	dwTiles /= 2;
-	BYTE *pTmp = pAFile;
+	BYTE *pTmp = pAFile.get();
 
 	for (unsigned i = 1; i <= dwTiles; i++) {
 		uint8_t b1 = *pTmp++;
@@ -504,7 +504,7 @@ void InitAutomap()
 		AutomapTypes[i] = b1 + (b2 << 8);
 	}
 
-	mem_free_dbg(pAFile);
+	pAFile = nullptr;
 	memset(automapview, 0, sizeof(automapview));
 
 	for (auto &column : dFlags)

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -24,34 +24,37 @@
 #include "utils/language.h"
 
 namespace devilution {
-
 namespace {
-
 CelOutputBuffer pBtmBuff;
 CelOutputBuffer pLifeBuff;
 CelOutputBuffer pManaBuff;
-
+std::optional<CelSprite> pTalkBtns;
+std::optional<CelSprite> pDurIcons;
+std::optional<CelSprite> pChrButtons;
+std::optional<CelSprite> pMultiBtns;
+std::optional<CelSprite> pPanelButtons;
+std::optional<CelSprite> pChrPanel;
+std::optional<CelSprite> pGBoxBuff;
+std::optional<CelSprite> pSBkBtnCel;
+std::optional<CelSprite> pSBkIconCels;
+std::optional<CelSprite> pSpellBkCel;
+std::optional<CelSprite> pSpellCels;
 } // namespace
 
 BYTE sgbNextTalkSave;
 BYTE sgbTalkSavePos;
-BYTE *pDurIcons;
-BYTE *pChrButtons;
+
 bool drawhpflag;
 bool dropGoldFlag;
 bool panbtns[8];
 bool chrbtn[4];
-BYTE *pMultiBtns;
-BYTE *pPanelButtons;
-BYTE *pChrPanel;
 bool lvlbtndown;
 char sgszTalkSave[8][80];
 int dropGoldValue;
 bool drawmanaflag;
 bool chrbtnactive;
 char sgszTalkMsg[MAX_SEND_STR_LEN];
-BYTE *pPanelText;
-BYTE *pTalkBtns;
+std::optional<CelSprite> pPanelText;
 bool pstrjust[4];
 int pnumlines;
 bool pinfoflag;
@@ -59,26 +62,21 @@ bool talkButtonsDown[3];
 spell_id pSpell;
 text_color infoclr;
 int sgbPlrTalkTbl;
-BYTE *pGBoxBuff;
-BYTE *pSBkBtnCel;
 char tempstr[256];
 bool whisperList[MAX_PLRS];
 int sbooktab;
 spell_type pSplType;
 int initialDropGoldIndex;
 bool talkflag;
-BYTE *pSBkIconCels;
 bool sbookflag;
 bool chrflag;
 bool drawbtnflag;
-BYTE *pSpellBkCel;
 char infostr[64];
 int numpanbtns;
 char panelstr[4][64];
 bool panelflag;
 BYTE SplTransTbl[256];
 int initialDropGoldValue;
-BYTE *pSpellCels;
 bool panbtndown;
 bool spselflag;
 
@@ -277,13 +275,12 @@ spell_id SpellPages[6][7] = {
  * @param out Output buffer
  * @param xp Buffer coordinate
  * @param yp Buffer coordinate
- * @param Trans Pointer to the cel buffer.
+ * @param cel The CEL sprite
  * @param nCel Index of the cel frame to draw. 0 based.
- * @param w Width of the frame.
  */
-static void DrawSpellCel(const CelOutputBuffer &out, int xp, int yp, BYTE *trans, int nCel, int w)
+static void DrawSpellCel(const CelOutputBuffer &out, int xp, int yp, const CelSprite &cel, int nCel)
 {
-	CelDrawLightTo(out, xp, yp, trans, nCel, w, SplTransTbl);
+	CelDrawLightTo(out, xp, yp, cel, nCel, SplTransTbl);
 }
 
 void SetSpellTrans(spell_type t)
@@ -365,9 +362,9 @@ static void DrawSpell(const CelOutputBuffer &out)
 		st = RSPLTYPE_INVALID;
 	SetSpellTrans(st);
 	if (spl != SPL_INVALID)
-		DrawSpellCel(out, PANEL_X + 565, PANEL_Y + 119, pSpellCels, SpellITbl[spl], SPLICONLENGTH);
+		DrawSpellCel(out, PANEL_X + 565, PANEL_Y + 119, *pSpellCels, SpellITbl[spl]);
 	else
-		DrawSpellCel(out, PANEL_X + 565, PANEL_Y + 119, pSpellCels, 27, SPLICONLENGTH);
+		DrawSpellCel(out, PANEL_X + 565, PANEL_Y + 119, *pSpellCels, 27);
 }
 
 void DrawSpellList(const CelOutputBuffer &out)
@@ -421,7 +418,7 @@ void DrawSpellList(const CelOutputBuffer &out)
 			}
 			if (currlevel == 0 && !spelldata[j].sTownSpell)
 				SetSpellTrans(RSPLTYPE_INVALID);
-			DrawSpellCel(out, x, y, pSpellCels, SpellITbl[j], SPLICONLENGTH);
+			DrawSpellCel(out, x, y, *pSpellCels, SpellITbl[j]);
 			int lx = x;
 			int ly = y - SPLICONLENGTH;
 			if (MouseX >= lx && MouseX < lx + SPLICONLENGTH && MouseY >= ly && MouseY < ly + SPLICONLENGTH) {
@@ -429,7 +426,7 @@ void DrawSpellList(const CelOutputBuffer &out)
 				pSplType = (spell_type)i;
 				if (plr[myplr]._pClass == HeroClass::Monk && j == SPL_SEARCH)
 					pSplType = RSPLTYPE_SKILL;
-				DrawSpellCel(out, x, y, pSpellCels, c, SPLICONLENGTH);
+				DrawSpellCel(out, x, y, *pSpellCels, c);
 				switch (pSplType) {
 				case RSPLTYPE_SKILL:
 					sprintf(infostr, _("%s Skill"), _(spelldata[pSpell].sSkillText));
@@ -482,7 +479,7 @@ void DrawSpellList(const CelOutputBuffer &out)
 				}
 				for (int t = 0; t < 4; t++) {
 					if (plr[myplr]._pSplHotKey[t] == pSpell && plr[myplr]._pSplTHotKey[t] == pSplType) {
-						DrawSpellCel(out, x, y, pSpellCels, t + SPLICONLAST + 5, SPLICONLENGTH);
+						DrawSpellCel(out, x, y, *pSpellCels, t + SPLICONLAST + 5);
 						sprintf(tempstr, _("Spell Hotkey #F%i"), t + 5);
 						AddPanelString(tempstr, true);
 					}
@@ -566,7 +563,7 @@ void PrintChar(const CelOutputBuffer &out, int sx, int sy, int nCel, text_color 
 
 	switch (col) {
 	case COL_WHITE:
-		CelDrawTo(out, sx, sy, pPanelText, nCel, 13);
+		CelDrawTo(out, sx, sy, *pPanelText, nCel);
 		return;
 	case COL_BLUE:
 		for (i = 0; i < 256; i++) {
@@ -600,10 +597,10 @@ void PrintChar(const CelOutputBuffer &out, int sx, int sy, int nCel, text_color 
 		break;
 	case COL_BLACK:
 		light_table_index = 15;
-		CelDrawLightTo(out, sx, sy, pPanelText, nCel, 13, nullptr);
+		CelDrawLightTo(out, sx, sy, *pPanelText, nCel, nullptr);
 		return;
 	}
-	CelDrawLightTo(out, sx, sy, pPanelText, nCel, 13, tbl);
+	CelDrawLightTo(out, sx, sy, *pPanelText, nCel, tbl);
 }
 
 void AddPanelString(const char *str, bool just)
@@ -765,27 +762,24 @@ void InitControlPan()
 	pManaBuff = CelOutputBuffer::Alloc(88, 88);
 	pLifeBuff = CelOutputBuffer::Alloc(88, 88);
 
-	pPanelText = LoadFileInMem("CtrlPan\\SmalText.CEL", nullptr);
-	pChrPanel = LoadFileInMem("Data\\Char.CEL", nullptr);
+	pPanelText = LoadCel("CtrlPan\\SmalText.CEL", 13);
+	pChrPanel = LoadCel("Data\\Char.CEL", SPANEL_WIDTH);
 	if (!gbIsHellfire)
-		pSpellCels = LoadFileInMem("CtrlPan\\SpelIcon.CEL", nullptr);
+		pSpellCels = LoadCel("CtrlPan\\SpelIcon.CEL", SPLICONLENGTH);
 	else
-		pSpellCels = LoadFileInMem("Data\\SpelIcon.CEL", nullptr);
+		pSpellCels = LoadCel("Data\\SpelIcon.CEL", SPLICONLENGTH);
 	SetSpellTrans(RSPLTYPE_SKILL);
-	BYTE *pStatusPanel = LoadFileInMem("CtrlPan\\Panel8.CEL", nullptr);
-	CelDrawUnsafeTo(pBtmBuff, 0, (PANEL_HEIGHT + 16) - 1, pStatusPanel, 1, PANEL_WIDTH);
-	MemFreeDbg(pStatusPanel);
-	pStatusPanel = LoadFileInMem("CtrlPan\\P8Bulbs.CEL", nullptr);
-	CelDrawUnsafeTo(pLifeBuff, 0, 87, pStatusPanel, 1, 88);
-	CelDrawUnsafeTo(pManaBuff, 0, 87, pStatusPanel, 2, 88);
-	MemFreeDbg(pStatusPanel);
+	CelDrawUnsafeTo(pBtmBuff, 0, (PANEL_HEIGHT + 16) - 1, LoadCel("CtrlPan\\Panel8.CEL", PANEL_WIDTH), 1);
+	{
+		const CelSprite statusPanel = LoadCel("CtrlPan\\P8Bulbs.CEL", 88);
+		CelDrawUnsafeTo(pLifeBuff, 0, 87, statusPanel, 1);
+		CelDrawUnsafeTo(pManaBuff, 0, 87, statusPanel, 2);
+	}
 	talkflag = false;
 	if (gbIsMultiplayer) {
-		BYTE *pTalkPanel = LoadFileInMem("CtrlPan\\TalkPanl.CEL", nullptr);
-		CelDrawUnsafeTo(pBtmBuff, 0, (PANEL_HEIGHT + 16) * 2 - 1, pTalkPanel, 1, PANEL_WIDTH);
-		MemFreeDbg(pTalkPanel);
-		pMultiBtns = LoadFileInMem("CtrlPan\\P8But2.CEL", nullptr);
-		pTalkBtns = LoadFileInMem("CtrlPan\\TalkButt.CEL", nullptr);
+		CelDrawUnsafeTo(pBtmBuff, 0, (PANEL_HEIGHT + 16) * 2 - 1, LoadCel("CtrlPan\\TalkPanl.CEL", PANEL_WIDTH), 1);
+		pMultiBtns = LoadCel("CtrlPan\\P8But2.CEL", 33);
+		pTalkBtns = LoadCel("CtrlPan\\TalkButt.CEL", 61);
 		sgbPlrTalkTbl = 0;
 		sgszTalkMsg[0] = '\0';
 		for (bool &whisper : whisperList)
@@ -795,7 +789,7 @@ void InitControlPan()
 	}
 	panelflag = false;
 	lvlbtndown = false;
-	pPanelButtons = LoadFileInMem("CtrlPan\\Panel8bu.CEL", nullptr);
+	pPanelButtons = LoadCel("CtrlPan\\Panel8bu.CEL", 71);
 	for (bool &panbtn : panbtns)
 		panbtn = false;
 	panbtndown = false;
@@ -803,20 +797,26 @@ void InitControlPan()
 		numpanbtns = 6;
 	else
 		numpanbtns = 8;
-	pChrButtons = LoadFileInMem("Data\\CharBut.CEL", nullptr);
+	pChrButtons = LoadCel("Data\\CharBut.CEL", 41);
 	for (bool &buttonEnabled : chrbtn)
 		buttonEnabled = false;
 	chrbtnactive = false;
-	pDurIcons = LoadFileInMem("Items\\DurIcons.CEL", nullptr);
+	pDurIcons = LoadCel("Items\\DurIcons.CEL", 32);
 	strcpy(infostr, "");
 	ClearPanel();
 	drawhpflag = true;
 	drawmanaflag = true;
 	chrflag = false;
 	spselflag = false;
-	pSpellBkCel = LoadFileInMem("Data\\SpellBk.CEL", nullptr);
-	pSBkBtnCel = LoadFileInMem("Data\\SpellBkB.CEL", nullptr);
-	pSBkIconCels = LoadFileInMem("Data\\SpellI2.CEL", nullptr);
+	pSpellBkCel = LoadCel("Data\\SpellBk.CEL", SPANEL_WIDTH);
+
+	if (gbIsHellfire) {
+		static const int SBkBtnHellfireWidths[] = { 61, 61, 61, 61, 76 };
+		pSBkBtnCel = LoadCel("Data\\SpellBkB.CEL", SBkBtnHellfireWidths);
+	} else {
+		pSBkBtnCel = LoadCel("Data\\SpellBkB.CEL", 76);
+	}
+	pSBkIconCels = LoadCel("Data\\SpellI2.CEL", 37);
 	sbooktab = 0;
 	sbookflag = false;
 	if (plr[myplr]._pClass == HeroClass::Warrior) {
@@ -832,8 +832,8 @@ void InitControlPan()
 	} else if (plr[myplr]._pClass == HeroClass::Barbarian) {
 		SpellPages[0][0] = SPL_BLODBOIL;
 	}
-	pQLogCel = LoadFileInMem("Data\\Quest.CEL", nullptr);
-	pGBoxBuff = LoadFileInMem("CtrlPan\\Golddrop.cel", nullptr);
+	pQLogCel = LoadCel("Data\\Quest.CEL", SPANEL_WIDTH);
+	pGBoxBuff = LoadCel("CtrlPan\\Golddrop.cel", 261);
 	dropGoldFlag = false;
 	dropGoldValue = 0;
 	initialDropGoldValue = 0;
@@ -852,14 +852,14 @@ void DrawCtrlBtns(const CelOutputBuffer &out)
 		if (!panbtns[i])
 			DrawPanelBox(out, PanBtnPos[i].x, PanBtnPos[i].y + 16, 71, 20, PanBtnPos[i].x + PANEL_X, PanBtnPos[i].y + PANEL_Y);
 		else
-			CelDrawTo(out, PanBtnPos[i].x + PANEL_X, PanBtnPos[i].y + PANEL_Y + 18, pPanelButtons, i + 1, 71);
+			CelDrawTo(out, PanBtnPos[i].x + PANEL_X, PanBtnPos[i].y + PANEL_Y + 18, *pPanelButtons, i + 1);
 	}
 	if (numpanbtns == 8) {
-		CelDrawTo(out, 87 + PANEL_X, 122 + PANEL_Y, pMultiBtns, panbtns[6] ? 2 : 1, 33);
+		CelDrawTo(out, 87 + PANEL_X, 122 + PANEL_Y, *pMultiBtns, panbtns[6] ? 2 : 1);
 		if (gbFriendlyMode)
-			CelDrawTo(out, 527 + PANEL_X, 122 + PANEL_Y, pMultiBtns, panbtns[7] ? 4 : 3, 33);
+			CelDrawTo(out, 527 + PANEL_X, 122 + PANEL_Y, *pMultiBtns, panbtns[7] ? 4 : 3);
 		else
-			CelDrawTo(out, 527 + PANEL_X, 122 + PANEL_Y, pMultiBtns, panbtns[7] ? 6 : 5, 33);
+			CelDrawTo(out, 527 + PANEL_X, 122 + PANEL_Y, *pMultiBtns, panbtns[7] ? 6 : 5);
 	}
 }
 
@@ -1169,19 +1169,19 @@ void FreeControlPan()
 	pBtmBuff.Free();
 	pManaBuff.Free();
 	pLifeBuff.Free();
-	MemFreeDbg(pPanelText);
-	MemFreeDbg(pChrPanel);
-	MemFreeDbg(pSpellCels);
-	MemFreeDbg(pPanelButtons);
-	MemFreeDbg(pMultiBtns);
-	MemFreeDbg(pTalkBtns);
-	MemFreeDbg(pChrButtons);
-	MemFreeDbg(pDurIcons);
-	MemFreeDbg(pQLogCel);
-	MemFreeDbg(pSpellBkCel);
-	MemFreeDbg(pSBkBtnCel);
-	MemFreeDbg(pSBkIconCels);
-	MemFreeDbg(pGBoxBuff);
+	pPanelText = std::nullopt;
+	pChrPanel = std::nullopt;
+	pSpellCels = std::nullopt;
+	pPanelButtons = std::nullopt;
+	pMultiBtns = std::nullopt;
+	pTalkBtns = std::nullopt;
+	pChrButtons = std::nullopt;
+	pDurIcons = std::nullopt;
+	pQLogCel = std::nullopt;
+	pSpellBkCel = std::nullopt;
+	pSBkBtnCel = std::nullopt;
+	pSBkIconCels = std::nullopt;
+	pGBoxBuff = std::nullopt;
 }
 
 bool control_WriteStringToBuffer(BYTE *str)
@@ -1360,7 +1360,7 @@ void DrawChr(const CelOutputBuffer &out)
 	text_color col = COL_WHITE;
 	char chrstr[64];
 
-	CelDrawTo(out, 0, 351, pChrPanel, 1, SPANEL_WIDTH);
+	CelDrawTo(out, 0, 351, *pChrPanel, 1);
 	ADD_PlrStringXY(out, 20, 32, 151, plr[myplr]._pName, COL_WHITE);
 
 	ADD_PlrStringXY(out, 168, 32, 299, _(ClassStrTbl[static_cast<std::size_t>(plr[myplr]._pClass)]), COL_WHITE);
@@ -1533,13 +1533,13 @@ void DrawChr(const CelOutputBuffer &out)
 		sprintf(chrstr, "%i", plr[myplr]._pStatPts);
 		ADD_PlrStringXY(out, 95, 266, 126, chrstr, COL_RED);
 		if (plr[myplr]._pBaseStr < plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Strength))
-			CelDrawTo(out, 137, 159, pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Strength)] ? 3 : 2, 41);
+			CelDrawTo(out, 137, 159, *pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Strength)] ? 3 : 2);
 		if (plr[myplr]._pBaseMag < plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Magic))
-			CelDrawTo(out, 137, 187, pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Magic)] ? 5 : 4, 41);
+			CelDrawTo(out, 137, 187, *pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Magic)] ? 5 : 4);
 		if (plr[myplr]._pBaseDex < plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Dexterity))
-			CelDrawTo(out, 137, 216, pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Dexterity)] ? 7 : 6, 41);
+			CelDrawTo(out, 137, 216, *pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Dexterity)] ? 7 : 6);
 		if (plr[myplr]._pBaseVit < plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Vitality))
-			CelDrawTo(out, 137, 244, pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Vitality)] ? 9 : 8, 41);
+			CelDrawTo(out, 137, 244, *pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Vitality)] ? 9 : 8);
 	}
 
 	if (plr[myplr]._pMaxHP > plr[myplr]._pMaxHPBase)
@@ -1583,7 +1583,7 @@ void DrawLevelUpIcon(const CelOutputBuffer &out)
 	if (stextflag == STORE_NONE) {
 		int nCel = lvlbtndown ? 3 : 2;
 		ADD_PlrStringXY(out, PANEL_LEFT + 0, PANEL_TOP - 49, PANEL_LEFT + 120, _("Level Up"), COL_WHITE);
-		CelDrawTo(out, 40 + PANEL_X, -17 + PANEL_Y, pChrButtons, nCel, 41);
+		CelDrawTo(out, 40 + PANEL_X, -17 + PANEL_Y, *pChrButtons, nCel);
 	}
 }
 
@@ -1703,7 +1703,7 @@ static int DrawDurIcon4Item(const CelOutputBuffer &out, ItemStruct *pItem, int x
 	}
 	if (pItem->_iDurability > 2)
 		c += 8;
-	CelDrawTo(out, x, -17 + PANEL_Y, pDurIcons, c, 32);
+	CelDrawTo(out, x, -17 + PANEL_Y, *pDurIcons, c);
 	return x - 32 - 8;
 }
 
@@ -1811,16 +1811,16 @@ spell_type GetSBookTrans(spell_id ii, bool townok)
 
 void DrawSpellBook(const CelOutputBuffer &out)
 {
-	CelDrawTo(out, RIGHT_PANEL_X, 351, pSpellBkCel, 1, SPANEL_WIDTH);
+	CelDrawTo(out, RIGHT_PANEL_X, 351, *pSpellBkCel, 1);
 	if (gbIsHellfire && sbooktab < 5) {
-		CelDrawTo(out, RIGHT_PANEL_X + 61 * sbooktab + 7, 348, pSBkBtnCel, sbooktab + 1, 61);
+		CelDrawTo(out, RIGHT_PANEL_X + 61 * sbooktab + 7, 348, *pSBkBtnCel, sbooktab + 1);
 	} else {
 		// BUGFIX: rendering of page 3 and page 4 buttons are both off-by-one pixel (fixed).
 		int sx = RIGHT_PANEL_X + 76 * sbooktab + 7;
 		if (sbooktab == 2 || sbooktab == 3) {
 			sx++;
 		}
-		CelDrawTo(out, sx, 348, pSBkBtnCel, sbooktab + 1, 76);
+		CelDrawTo(out, sx, 348, *pSBkBtnCel, sbooktab + 1);
 	}
 	uint64_t spl = plr[myplr]._pMemSpells | plr[myplr]._pISpells | plr[myplr]._pAblSpells;
 
@@ -1830,10 +1830,10 @@ void DrawSpellBook(const CelOutputBuffer &out)
 		if (sn != SPL_INVALID && (spl & GetSpellBitmask(sn)) != 0) {
 			spell_type st = GetSBookTrans(sn, true);
 			SetSpellTrans(st);
-			DrawSpellCel(out, RIGHT_PANEL_X + 11, yp, pSBkIconCels, SpellITbl[sn], 37);
+			DrawSpellCel(out, RIGHT_PANEL_X + 11, yp, *pSBkIconCels, SpellITbl[sn]);
 			if (sn == plr[myplr]._pRSpell && st == plr[myplr]._pRSplType) {
 				SetSpellTrans(RSPLTYPE_SKILL);
-				DrawSpellCel(out, RIGHT_PANEL_X + 11, yp, pSBkIconCels, SPLICONLAST, 37);
+				DrawSpellCel(out, RIGHT_PANEL_X + 11, yp, *pSBkIconCels, SPLICONLAST);
 			}
 			PrintSBookStr(out, 10, yp - 23, false, _(spelldata[sn].sNameText), COL_WHITE);
 			switch (GetSBookTrans(sn, false)) {
@@ -1908,7 +1908,7 @@ const char *get_pieces_str(int nGold)
 void DrawGoldSplit(const CelOutputBuffer &out, int amount)
 {
 	int screenX = 0;
-	CelDrawTo(out, 351, 178, pGBoxBuff, 1, 261);
+	CelDrawTo(out, 351, 178, *pGBoxBuff, 1);
 	sprintf(tempstr, _("You have %u gold"), initialDropGoldValue);
 	ADD_PlrStringXY(out, 366, 87, 600, tempstr, COL_GOLD);
 	sprintf(tempstr, _("%s.  How many do"), get_pieces_str(initialDropGoldValue));
@@ -1927,7 +1927,7 @@ void DrawGoldSplit(const CelOutputBuffer &out, int amount)
 	} else {
 		screenX = 386;
 	}
-	CelDrawTo(out, screenX, 140, pSPentSpn2Cels, PentSpn2Spin(), 12);
+	CelDrawTo(out, screenX, 140, *pSPentSpn2Cels, PentSpn2Spin());
 }
 
 void control_drop_gold(char vkey)
@@ -2045,7 +2045,7 @@ void DrawTalkPan(const CelOutputBuffer &out)
 	}
 	if (msg != nullptr)
 		*msg = '\0';
-	CelDrawTo(out, x, i + 22 + PANEL_Y, pSPentSpn2Cels, PentSpn2Spin(), 12);
+	CelDrawTo(out, x, i + 22 + PANEL_Y, *pSPentSpn2Cels, PentSpn2Spin());
 	int talkBtn = 0;
 	for (int i = 0; i < 4; i++) {
 		if (i == myplr)
@@ -2055,13 +2055,13 @@ void DrawTalkPan(const CelOutputBuffer &out)
 			color = COL_GOLD;
 			if (talkButtonsDown[talkBtn]) {
 				int nCel = talkBtn != 0 ? 4 : 3;
-				CelDrawTo(out, 172 + PANEL_X, 84 + 18 * talkBtn + PANEL_Y, pTalkBtns, nCel, 61);
+				CelDrawTo(out, 172 + PANEL_X, 84 + 18 * talkBtn + PANEL_Y, *pTalkBtns, nCel);
 			}
 		} else {
 			int nCel = talkBtn != 0 ? 2 : 1;
 			if (talkButtonsDown[talkBtn])
 				nCel += 4;
-			CelDrawTo(out, 172 + PANEL_X, 84 + 18 * talkBtn + PANEL_Y, pTalkBtns, nCel, 61);
+			CelDrawTo(out, 172 + PANEL_X, 84 + 18 * talkBtn + PANEL_Y, *pTalkBtns, nCel);
 		}
 		if (plr[i].plractive) {
 			int x = 46 + PANEL_LEFT;

--- a/Source/control.h
+++ b/Source/control.h
@@ -11,6 +11,7 @@
 #include "spelldat.h"
 #include "spells.h"
 #include "utils/ui_fwd.h"
+#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 
@@ -48,7 +49,7 @@ extern bool lvlbtndown;
 extern int dropGoldValue;
 extern bool drawmanaflag;
 extern bool chrbtnactive;
-extern BYTE *pPanelText;
+extern std::optional<CelSprite> pPanelText;
 extern int pnumlines;
 extern bool pinfoflag;
 extern spell_id pSpell;

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -28,8 +28,8 @@ int icursW28;
 /** Height of current cursor in inventory cells */
 int icursH28;
 /** Cursor images CEL */
-BYTE *pCursCels;
-BYTE *pCursCels2;
+std::optional<CelSprite> pCursCels;
+std::optional<CelSprite> pCursCels2;
 
 /** inv_item value */
 int8_t pcursinvitem;
@@ -120,16 +120,16 @@ const int InvItemHeight[] = {
 void InitCursor()
 {
 	assert(!pCursCels);
-	pCursCels = LoadFileInMem("Data\\Inv\\Objcurs.CEL", nullptr);
+	pCursCels = LoadCel("Data\\Inv\\Objcurs.CEL", InvItemWidth);
 	if (gbIsHellfire)
-		pCursCels2 = LoadFileInMem("Data\\Inv\\Objcurs2.CEL", nullptr);
+		pCursCels2 = LoadCel("Data\\Inv\\Objcurs2.CEL", InvItemWidth);
 	ClearCursor();
 }
 
 void FreeCursor()
 {
-	MemFreeDbg(pCursCels);
-	MemFreeDbg(pCursCels2);
+	pCursCels = std::nullopt;
+	pCursCels2 = std::nullopt;
 	ClearCursor();
 }
 

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -7,7 +7,9 @@
 
 #include <cstdint>
 
+#include "engine.h"
 #include "miniwin/miniwin.h"
+#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 
@@ -32,8 +34,8 @@ extern int cursH;
 extern int pcursmonst;
 extern int icursW28;
 extern int icursH28;
-extern BYTE *pCursCels;
-extern BYTE *pCursCels2;
+extern std::optional<CelSprite> pCursCels;
+extern std::optional<CelSprite> pCursCels2;
 extern int icursH;
 extern int8_t pcursinvitem;
 extern int icursW;

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -19,19 +19,19 @@ int seed_index;
 int level_seeds[NUMLEVELS + 1];
 int seed_table[DEBUGSEEDS];
 
-BYTE *pSquareCel;
+std::optional<CelSprite> pSquareCel;
 char dMonsDbg[NUMLEVELS][MAXDUNX][MAXDUNY];
 char dFlagDbg[NUMLEVELS][MAXDUNX][MAXDUNY];
 
 void LoadDebugGFX()
 {
 	if (visiondebug)
-		pSquareCel = LoadFileInMem("Data\\Square.CEL", nullptr);
+		pSquareCel = LoadCel("Data\\Square.CEL", 64);
 }
 
 void FreeDebugGFX()
 {
-	MemFreeDbg(pSquareCel);
+	pSquareCel = std::nullopt;
 }
 
 void CheckDungeonClear()

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -5,11 +5,13 @@
  */
 #pragma once
 
+#include "engine.h"
 #include "miniwin/miniwin.h"
+#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 
-extern BYTE *pSquareCel;
+extern std::optional<CelSprite> pSquareCel;
 
 void FreeDebugGFX();
 void CheckDungeonClear();

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -274,10 +274,10 @@ void FreeGameMem()
 {
 	music_stop();
 
-	MemFreeDbg(pDungeonCels);
-	MemFreeDbg(pMegaTiles);
-	MemFreeDbg(pLevelPieces);
-	MemFreeDbg(pSpecialCels);
+	pDungeonCels = nullptr;
+	pMegaTiles = nullptr;
+	pLevelPieces = nullptr;
+	pSpecialCels = std::nullopt;
 
 	FreeMissiles();
 	FreeMonsters();
@@ -1715,7 +1715,8 @@ void GM_Game(uint32_t uMsg, int32_t wParam, int32_t lParam)
 
 void LoadLvlGFX()
 {
-	assert(!pDungeonCels);
+	assert(pDungeonCels == nullptr);
+	constexpr int SpecialCelWidth = 64;
 
 	switch (leveltype) {
 	case DTYPE_TOWN:
@@ -1728,26 +1729,26 @@ void LoadLvlGFX()
 			pMegaTiles = LoadFileInMem("Levels\\TownData\\Town.TIL", nullptr);
 			pLevelPieces = LoadFileInMem("Levels\\TownData\\Town.MIN", nullptr);
 		}
-		pSpecialCels = LoadFileInMem("Levels\\TownData\\TownS.CEL", nullptr);
+		pSpecialCels = LoadCel("Levels\\TownData\\TownS.CEL", SpecialCelWidth);
 		break;
 	case DTYPE_CATHEDRAL:
 		if (currlevel < 21) {
 			pDungeonCels = LoadFileInMem("Levels\\L1Data\\L1.CEL", nullptr);
 			pMegaTiles = LoadFileInMem("Levels\\L1Data\\L1.TIL", nullptr);
 			pLevelPieces = LoadFileInMem("Levels\\L1Data\\L1.MIN", nullptr);
-			pSpecialCels = LoadFileInMem("Levels\\L1Data\\L1S.CEL", nullptr);
+			pSpecialCels = LoadCel("Levels\\L1Data\\L1S.CEL", SpecialCelWidth);
 		} else {
 			pDungeonCels = LoadFileInMem("NLevels\\L5Data\\L5.CEL", nullptr);
 			pMegaTiles = LoadFileInMem("NLevels\\L5Data\\L5.TIL", nullptr);
 			pLevelPieces = LoadFileInMem("NLevels\\L5Data\\L5.MIN", nullptr);
-			pSpecialCels = LoadFileInMem("NLevels\\L5Data\\L5S.CEL", nullptr);
+			pSpecialCels = LoadCel("NLevels\\L5Data\\L5S.CEL", SpecialCelWidth);
 		}
 		break;
 	case DTYPE_CATACOMBS:
 		pDungeonCels = LoadFileInMem("Levels\\L2Data\\L2.CEL", nullptr);
 		pMegaTiles = LoadFileInMem("Levels\\L2Data\\L2.TIL", nullptr);
 		pLevelPieces = LoadFileInMem("Levels\\L2Data\\L2.MIN", nullptr);
-		pSpecialCels = LoadFileInMem("Levels\\L2Data\\L2S.CEL", nullptr);
+		pSpecialCels = LoadCel("Levels\\L2Data\\L2S.CEL", SpecialCelWidth);
 		break;
 	case DTYPE_CAVES:
 		if (currlevel < 17) {
@@ -1759,13 +1760,13 @@ void LoadLvlGFX()
 			pMegaTiles = LoadFileInMem("NLevels\\L6Data\\L6.TIL", nullptr);
 			pLevelPieces = LoadFileInMem("NLevels\\L6Data\\L6.MIN", nullptr);
 		}
-		pSpecialCels = LoadFileInMem("Levels\\L1Data\\L1S.CEL", nullptr);
+		pSpecialCels = LoadCel("Levels\\L1Data\\L1S.CEL", SpecialCelWidth);
 		break;
 	case DTYPE_HELL:
 		pDungeonCels = LoadFileInMem("Levels\\L4Data\\L4.CEL", nullptr);
 		pMegaTiles = LoadFileInMem("Levels\\L4Data\\L4.TIL", nullptr);
 		pLevelPieces = LoadFileInMem("Levels\\L4Data\\L4.MIN", nullptr);
-		pSpecialCels = LoadFileInMem("Levels\\L2Data\\L2S.CEL", nullptr);
+		pSpecialCels = LoadCel("Levels\\L2Data\\L2S.CEL", SpecialCelWidth);
 		break;
 	default:
 		app_fatal("LoadLvlGFX");

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1721,51 +1721,51 @@ void LoadLvlGFX()
 	switch (leveltype) {
 	case DTYPE_TOWN:
 		if (gbIsHellfire) {
-			pDungeonCels = LoadFileInMem("NLevels\\TownData\\Town.CEL", nullptr);
-			pMegaTiles = LoadFileInMem("NLevels\\TownData\\Town.TIL", nullptr);
-			pLevelPieces = LoadFileInMem("NLevels\\TownData\\Town.MIN", nullptr);
+			pDungeonCels = LoadFileInMem("NLevels\\TownData\\Town.CEL");
+			pMegaTiles = LoadFileInMem("NLevels\\TownData\\Town.TIL");
+			pLevelPieces = LoadFileInMem("NLevels\\TownData\\Town.MIN");
 		} else {
-			pDungeonCels = LoadFileInMem("Levels\\TownData\\Town.CEL", nullptr);
-			pMegaTiles = LoadFileInMem("Levels\\TownData\\Town.TIL", nullptr);
-			pLevelPieces = LoadFileInMem("Levels\\TownData\\Town.MIN", nullptr);
+			pDungeonCels = LoadFileInMem("Levels\\TownData\\Town.CEL");
+			pMegaTiles = LoadFileInMem("Levels\\TownData\\Town.TIL");
+			pLevelPieces = LoadFileInMem("Levels\\TownData\\Town.MIN");
 		}
 		pSpecialCels = LoadCel("Levels\\TownData\\TownS.CEL", SpecialCelWidth);
 		break;
 	case DTYPE_CATHEDRAL:
 		if (currlevel < 21) {
-			pDungeonCels = LoadFileInMem("Levels\\L1Data\\L1.CEL", nullptr);
-			pMegaTiles = LoadFileInMem("Levels\\L1Data\\L1.TIL", nullptr);
-			pLevelPieces = LoadFileInMem("Levels\\L1Data\\L1.MIN", nullptr);
+			pDungeonCels = LoadFileInMem("Levels\\L1Data\\L1.CEL");
+			pMegaTiles = LoadFileInMem("Levels\\L1Data\\L1.TIL");
+			pLevelPieces = LoadFileInMem("Levels\\L1Data\\L1.MIN");
 			pSpecialCels = LoadCel("Levels\\L1Data\\L1S.CEL", SpecialCelWidth);
 		} else {
-			pDungeonCels = LoadFileInMem("NLevels\\L5Data\\L5.CEL", nullptr);
-			pMegaTiles = LoadFileInMem("NLevels\\L5Data\\L5.TIL", nullptr);
-			pLevelPieces = LoadFileInMem("NLevels\\L5Data\\L5.MIN", nullptr);
+			pDungeonCels = LoadFileInMem("NLevels\\L5Data\\L5.CEL");
+			pMegaTiles = LoadFileInMem("NLevels\\L5Data\\L5.TIL");
+			pLevelPieces = LoadFileInMem("NLevels\\L5Data\\L5.MIN");
 			pSpecialCels = LoadCel("NLevels\\L5Data\\L5S.CEL", SpecialCelWidth);
 		}
 		break;
 	case DTYPE_CATACOMBS:
-		pDungeonCels = LoadFileInMem("Levels\\L2Data\\L2.CEL", nullptr);
-		pMegaTiles = LoadFileInMem("Levels\\L2Data\\L2.TIL", nullptr);
-		pLevelPieces = LoadFileInMem("Levels\\L2Data\\L2.MIN", nullptr);
+		pDungeonCels = LoadFileInMem("Levels\\L2Data\\L2.CEL");
+		pMegaTiles = LoadFileInMem("Levels\\L2Data\\L2.TIL");
+		pLevelPieces = LoadFileInMem("Levels\\L2Data\\L2.MIN");
 		pSpecialCels = LoadCel("Levels\\L2Data\\L2S.CEL", SpecialCelWidth);
 		break;
 	case DTYPE_CAVES:
 		if (currlevel < 17) {
-			pDungeonCels = LoadFileInMem("Levels\\L3Data\\L3.CEL", nullptr);
-			pMegaTiles = LoadFileInMem("Levels\\L3Data\\L3.TIL", nullptr);
-			pLevelPieces = LoadFileInMem("Levels\\L3Data\\L3.MIN", nullptr);
+			pDungeonCels = LoadFileInMem("Levels\\L3Data\\L3.CEL");
+			pMegaTiles = LoadFileInMem("Levels\\L3Data\\L3.TIL");
+			pLevelPieces = LoadFileInMem("Levels\\L3Data\\L3.MIN");
 		} else {
-			pDungeonCels = LoadFileInMem("NLevels\\L6Data\\L6.CEL", nullptr);
-			pMegaTiles = LoadFileInMem("NLevels\\L6Data\\L6.TIL", nullptr);
-			pLevelPieces = LoadFileInMem("NLevels\\L6Data\\L6.MIN", nullptr);
+			pDungeonCels = LoadFileInMem("NLevels\\L6Data\\L6.CEL");
+			pMegaTiles = LoadFileInMem("NLevels\\L6Data\\L6.TIL");
+			pLevelPieces = LoadFileInMem("NLevels\\L6Data\\L6.MIN");
 		}
 		pSpecialCels = LoadCel("Levels\\L1Data\\L1S.CEL", SpecialCelWidth);
 		break;
 	case DTYPE_HELL:
-		pDungeonCels = LoadFileInMem("Levels\\L4Data\\L4.CEL", nullptr);
-		pMegaTiles = LoadFileInMem("Levels\\L4Data\\L4.TIL", nullptr);
-		pLevelPieces = LoadFileInMem("Levels\\L4Data\\L4.MIN", nullptr);
+		pDungeonCels = LoadFileInMem("Levels\\L4Data\\L4.CEL");
+		pMegaTiles = LoadFileInMem("Levels\\L4Data\\L4.TIL");
+		pLevelPieces = LoadFileInMem("Levels\\L4Data\\L4.MIN");
 		pSpecialCels = LoadCel("Levels\\L2Data\\L2S.CEL", SpecialCelWidth);
 		break;
 	default:

--- a/Source/doom.cpp
+++ b/Source/doom.cpp
@@ -6,11 +6,15 @@
 #include "doom.h"
 
 #include "control.h"
+#include "engine.h"
+#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
+namespace {
+std::optional<CelSprite> DoomCel;
+} // namespace
 
 int DoomQuestTime;
-std::unique_ptr<uint8_t[]> DoomCel;
 bool DoomFlag;
 int DoomQuestState;
 
@@ -43,18 +47,12 @@ int doom_get_frame_from_time()
 
 static bool doom_load_graphics()
 {
-	bool ret;
-
-	ret = false;
-	strcpy(tempstr, "Items\\Map\\MapZtown.CEL");
-	if (LoadFileWithMem(tempstr, DoomCel.get()) != 0)
-		ret = true;
-	return ret;
+	DoomCel = LoadCel("Items\\Map\\MapZtown.CEL", 640);
+	return true;
 }
 
 void doom_init()
 {
-	DoomCel = std::make_unique<uint8_t[]>(0x39000);
 	DoomQuestTime = doom_get_frame_from_time() == 31 ? 31 : 0;
 	if (doom_load_graphics()) {
 		DoomFlag = true;
@@ -66,7 +64,7 @@ void doom_init()
 void doom_close()
 {
 	DoomFlag = false;
-	DoomCel = nullptr;
+	DoomCel = std::nullopt;
 }
 
 void doom_draw(const CelOutputBuffer &out)
@@ -75,7 +73,7 @@ void doom_draw(const CelOutputBuffer &out)
 		return;
 	}
 
-	CelDrawTo(out, PANEL_X, PANEL_Y - 1, DoomCel.get(), 1, 640);
+	CelDrawTo(out, PANEL_X, PANEL_Y - 1, *DoomCel, 1);
 }
 
 } // namespace devilution

--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -1120,15 +1120,15 @@ static void DRLG_LoadL1SP()
 {
 	L5setloadflag = false;
 	if (QuestStatus(Q_BUTCHER)) {
-		L5pSetPiece = LoadFileInMem("Levels\\L1Data\\rnd6.DUN", nullptr);
+		L5pSetPiece = LoadFileInMem("Levels\\L1Data\\rnd6.DUN");
 		L5setloadflag = true;
 	}
 	if (QuestStatus(Q_SKELKING) && !gbIsMultiplayer) {
-		L5pSetPiece = LoadFileInMem("Levels\\L1Data\\SKngDO.DUN", nullptr);
+		L5pSetPiece = LoadFileInMem("Levels\\L1Data\\SKngDO.DUN");
 		L5setloadflag = true;
 	}
 	if (QuestStatus(Q_LTBANNER)) {
-		L5pSetPiece = LoadFileInMem("Levels\\L1Data\\Banner2.DUN", nullptr);
+		L5pSetPiece = LoadFileInMem("Levels\\L1Data\\Banner2.DUN");
 		L5setloadflag = true;
 	}
 }
@@ -1218,7 +1218,7 @@ void LoadL1Dungeon(const char *sFileName, int vx, int vy)
 	dmaxy = 96;
 
 	DRLG_InitTrans();
-	auto pLevelMap = LoadFileInMem(sFileName, nullptr);
+	auto pLevelMap = LoadFileInMem(sFileName);
 
 	for (j = 0; j < DMAXY; j++) {
 		for (i = 0; i < DMAXX; i++) {
@@ -1266,7 +1266,7 @@ void LoadPreL1Dungeon(const char *sFileName)
 	dmaxx = 96;
 	dmaxy = 96;
 
-	auto pLevelMap = LoadFileInMem(sFileName, nullptr);
+	auto pLevelMap = LoadFileInMem(sFileName);
 
 	for (j = 0; j < DMAXY; j++) {
 		for (i = 0; i < DMAXX; i++) {

--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -40,7 +40,7 @@ bool VR2;
 /** Specifies whether to generate a vertical room at position 3 in the Cathedral. */
 bool VR3;
 /** Contains the contents of the single player quest DUN file. */
-BYTE *L5pSetPiece;
+std::unique_ptr<BYTE[]> L5pSetPiece;
 
 /** Contains shadows for 2x2 blocks of base tile IDs in the Cathedral. */
 const ShadowStruct SPATS[37] = {
@@ -1135,7 +1135,7 @@ static void DRLG_LoadL1SP()
 
 static void DRLG_FreeL1SP()
 {
-	MemFreeDbg(L5pSetPiece);
+	L5pSetPiece = nullptr;
 }
 
 void DRLG_Init_Globals()
@@ -1210,7 +1210,7 @@ static void DRLG_InitL1Vals()
 void LoadL1Dungeon(const char *sFileName, int vx, int vy)
 {
 	int i, j, rw, rh;
-	BYTE *pLevelMap, *lm;
+	BYTE *lm;
 
 	dminx = 16;
 	dminy = 16;
@@ -1218,7 +1218,7 @@ void LoadL1Dungeon(const char *sFileName, int vx, int vy)
 	dmaxy = 96;
 
 	DRLG_InitTrans();
-	pLevelMap = LoadFileInMem(sFileName, nullptr);
+	auto pLevelMap = LoadFileInMem(sFileName, nullptr);
 
 	for (j = 0; j < DMAXY; j++) {
 		for (i = 0; i < DMAXX; i++) {
@@ -1227,7 +1227,7 @@ void LoadL1Dungeon(const char *sFileName, int vx, int vy)
 		}
 	}
 
-	lm = pLevelMap;
+	lm = pLevelMap.get();
 	rw = *lm;
 	lm += 2;
 	rh = *lm;
@@ -1252,22 +1252,21 @@ void LoadL1Dungeon(const char *sFileName, int vx, int vy)
 	DRLG_Init_Globals();
 	if (currlevel < 17)
 		DRLG_InitL1Vals();
-	SetMapMonsters(pLevelMap, 0, 0);
-	SetMapObjects(pLevelMap, 0, 0);
-	mem_free_dbg(pLevelMap);
+	SetMapMonsters(pLevelMap.get(), 0, 0);
+	SetMapObjects(pLevelMap.get(), 0, 0);
 }
 
 void LoadPreL1Dungeon(const char *sFileName)
 {
 	int i, j, rw, rh;
-	BYTE *pLevelMap, *lm;
+	BYTE *lm;
 
 	dminx = 16;
 	dminy = 16;
 	dmaxx = 96;
 	dmaxy = 96;
 
-	pLevelMap = LoadFileInMem(sFileName, nullptr);
+	auto pLevelMap = LoadFileInMem(sFileName, nullptr);
 
 	for (j = 0; j < DMAXY; j++) {
 		for (i = 0; i < DMAXX; i++) {
@@ -1276,7 +1275,7 @@ void LoadPreL1Dungeon(const char *sFileName)
 		}
 	}
 
-	lm = pLevelMap;
+	lm = pLevelMap.get();
 	rw = *lm;
 	lm += 2;
 	rh = *lm;
@@ -1301,8 +1300,6 @@ void LoadPreL1Dungeon(const char *sFileName)
 			pdungeon[i][j] = dungeon[i][j];
 		}
 	}
-
-	mem_free_dbg(pLevelMap);
 }
 
 static void InitL5Dungeon()
@@ -2044,15 +2041,15 @@ static void DRLG_L5SetRoom(int rx1, int ry1)
 	int rw, rh, i, j;
 	BYTE *sp;
 
-	rw = *L5pSetPiece;
-	rh = *(L5pSetPiece + 2);
+	rw = L5pSetPiece[0];
+	rh = L5pSetPiece[2];
 
 	setpc_x = rx1;
 	setpc_y = ry1;
 	setpc_w = rw;
 	setpc_h = rh;
 
-	sp = L5pSetPiece + 4;
+	sp = &L5pSetPiece[4];
 
 	for (j = 0; j < rh; j++) {
 		for (i = 0; i < rw; i++) {

--- a/Source/drlg_l2.cpp
+++ b/Source/drlg_l2.cpp
@@ -1843,15 +1843,15 @@ static void DRLG_LoadL2SP()
 	setloadflag = false;
 
 	if (QuestStatus(Q_BLIND)) {
-		pSetPiece = LoadFileInMem("Levels\\L2Data\\Blind1.DUN", nullptr);
+		pSetPiece = LoadFileInMem("Levels\\L2Data\\Blind1.DUN");
 		pSetPiece[26] = 154;  // Close outer wall
 		pSetPiece[200] = 154; // Close outer wall
 		setloadflag = true;
 	} else if (QuestStatus(Q_BLOOD)) {
-		pSetPiece = LoadFileInMem("Levels\\L2Data\\Blood1.DUN", nullptr);
+		pSetPiece = LoadFileInMem("Levels\\L2Data\\Blood1.DUN");
 		setloadflag = true;
 	} else if (QuestStatus(Q_SCHAMB)) {
-		pSetPiece = LoadFileInMem("Levels\\L2Data\\Bonestr2.DUN", nullptr);
+		pSetPiece = LoadFileInMem("Levels\\L2Data\\Bonestr2.DUN");
 		setloadflag = true;
 	}
 }
@@ -3274,7 +3274,7 @@ static void LoadL2DungeonData(BYTE *pLevelMap)
 
 void LoadL2Dungeon(const char *sFileName, int vx, int vy)
 {
-	auto pLevelMap = LoadFileInMem(sFileName, nullptr);
+	auto pLevelMap = LoadFileInMem(sFileName);
 
 	LoadL2DungeonData(pLevelMap.get());
 
@@ -3323,7 +3323,7 @@ void LoadL2Dungeon(const char *sFileName, int vx, int vy)
 void LoadPreL2Dungeon(const char *sFileName)
 {
 	{
-		auto pLevelMap = LoadFileInMem(sFileName, nullptr);
+		auto pLevelMap = LoadFileInMem(sFileName);
 		LoadL2DungeonData(pLevelMap.get());
 	}
 

--- a/Source/drlg_l2.cpp
+++ b/Source/drlg_l2.cpp
@@ -1858,7 +1858,7 @@ static void DRLG_LoadL2SP()
 
 static void DRLG_FreeL2SP()
 {
-	MemFreeDbg(pSetPiece);
+	pSetPiece = nullptr;
 }
 
 static void DRLG_L2SetRoom(int rx1, int ry1)
@@ -3274,9 +3274,9 @@ static void LoadL2DungeonData(BYTE *pLevelMap)
 
 void LoadL2Dungeon(const char *sFileName, int vx, int vy)
 {
-	BYTE *pLevelMap = LoadFileInMem(sFileName, nullptr);
+	auto pLevelMap = LoadFileInMem(sFileName, nullptr);
 
-	LoadL2DungeonData(pLevelMap);
+	LoadL2DungeonData(pLevelMap.get());
 
 	DRLG_L2Pass3();
 	DRLG_Init_Globals();
@@ -3316,16 +3316,16 @@ void LoadL2Dungeon(const char *sFileName, int vx, int vy)
 
 	ViewX = vx;
 	ViewY = vy;
-	SetMapMonsters(pLevelMap, 0, 0);
-	SetMapObjects(pLevelMap, 0, 0);
-	mem_free_dbg(pLevelMap);
+	SetMapMonsters(pLevelMap.get(), 0, 0);
+	SetMapObjects(pLevelMap.get(), 0, 0);
 }
 
 void LoadPreL2Dungeon(const char *sFileName)
 {
-	BYTE *pLevelMap = LoadFileInMem(sFileName, nullptr);
-	LoadL2DungeonData(pLevelMap);
-	mem_free_dbg(pLevelMap);
+	{
+		auto pLevelMap = LoadFileInMem(sFileName, nullptr);
+		LoadL2DungeonData(pLevelMap.get());
+	}
 
 	for (int j = 0; j < DMAXY; j++) {
 		for (int i = 0; i < DMAXX; i++) {

--- a/Source/drlg_l3.cpp
+++ b/Source/drlg_l3.cpp
@@ -2630,7 +2630,7 @@ void LoadL3Dungeon(const char *sFileName, int vx, int vy)
 	dmaxx = 96;
 	dmaxy = 96;
 	DRLG_InitTrans();
-	auto pLevelMap = LoadFileInMem(sFileName, nullptr);
+	auto pLevelMap = LoadFileInMem(sFileName);
 
 	lm = pLevelMap.get();
 	rw = *lm;
@@ -2685,7 +2685,7 @@ void LoadPreL3Dungeon(const char *sFileName)
 
 	InitL3Dungeon();
 	DRLG_InitTrans();
-	auto pLevelMap = LoadFileInMem(sFileName, nullptr);
+	auto pLevelMap = LoadFileInMem(sFileName);
 
 	lm = pLevelMap.get();
 	rw = *lm;

--- a/Source/drlg_l3.cpp
+++ b/Source/drlg_l3.cpp
@@ -2622,7 +2622,7 @@ void CreateL3Dungeon(uint32_t rseed, lvl_entry entry)
 void LoadL3Dungeon(const char *sFileName, int vx, int vy)
 {
 	int i, j, rw, rh;
-	BYTE *pLevelMap, *lm;
+	BYTE *lm;
 
 	InitL3Dungeon();
 	dminx = 16;
@@ -2630,9 +2630,9 @@ void LoadL3Dungeon(const char *sFileName, int vx, int vy)
 	dmaxx = 96;
 	dmaxy = 96;
 	DRLG_InitTrans();
-	pLevelMap = LoadFileInMem(sFileName, nullptr);
+	auto pLevelMap = LoadFileInMem(sFileName, nullptr);
 
-	lm = pLevelMap;
+	lm = pLevelMap.get();
 	rw = *lm;
 	lm += 2;
 	rh = *lm;
@@ -2660,8 +2660,8 @@ void LoadL3Dungeon(const char *sFileName, int vx, int vy)
 	DRLG_Init_Globals();
 	ViewX = vx;
 	ViewY = vy;
-	SetMapMonsters(pLevelMap, 0, 0);
-	SetMapObjects(pLevelMap, 0, 0);
+	SetMapMonsters(pLevelMap.get(), 0, 0);
+	SetMapObjects(pLevelMap.get(), 0, 0);
 
 	for (j = 0; j < MAXDUNY; j++) {
 		for (i = 0; i < MAXDUNX; i++) {
@@ -2676,20 +2676,18 @@ void LoadL3Dungeon(const char *sFileName, int vx, int vy)
 			}
 		}
 	}
-
-	mem_free_dbg(pLevelMap);
 }
 
 void LoadPreL3Dungeon(const char *sFileName)
 {
 	int i, j, rw, rh;
-	BYTE *pLevelMap, *lm;
+	BYTE *lm;
 
 	InitL3Dungeon();
 	DRLG_InitTrans();
-	pLevelMap = LoadFileInMem(sFileName, nullptr);
+	auto pLevelMap = LoadFileInMem(sFileName, nullptr);
 
-	lm = pLevelMap;
+	lm = pLevelMap.get();
 	rw = *lm;
 	lm += 2;
 	rh = *lm;
@@ -2714,7 +2712,6 @@ void LoadPreL3Dungeon(const char *sFileName)
 	}
 
 	memcpy(pdungeon, dungeon, sizeof(pdungeon));
-	mem_free_dbg(pLevelMap);
 }
 
 } // namespace devilution

--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -213,7 +213,7 @@ void DRLG_LoadL4SP()
 
 void DRLG_FreeL4SP()
 {
-	MemFreeDbg(pSetPiece);
+	pSetPiece = nullptr;
 }
 
 void DRLG_L4SetSPRoom(int rx1, int ry1)
@@ -1276,43 +1276,30 @@ void DRLG_L4SetRoom(BYTE *pSetPiece, int rx1, int ry1)
 
 void DRLG_LoadDiabQuads(bool preflag)
 {
-	BYTE *lpSetPiece;
-
-	lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab1.DUN", nullptr);
-	diabquad1x = 4 + l4holdx;
-	diabquad1y = 4 + l4holdy;
-	DRLG_L4SetRoom(lpSetPiece, diabquad1x, diabquad1y);
-	mem_free_dbg(lpSetPiece);
-
-	if (preflag) {
-		lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab2b.DUN", nullptr);
-	} else {
-		lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab2a.DUN", nullptr);
+	{
+		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab1.DUN");
+		diabquad1x = 4 + l4holdx;
+		diabquad1y = 4 + l4holdy;
+		DRLG_L4SetRoom(lpSetPiece.get(), diabquad1x, diabquad1y);
 	}
-	diabquad2x = 27 - l4holdx;
-	diabquad2y = 1 + l4holdy;
-	DRLG_L4SetRoom(lpSetPiece, diabquad2x, diabquad2y);
-	mem_free_dbg(lpSetPiece);
-
-	if (preflag) {
-		lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab3b.DUN", nullptr);
-	} else {
-		lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab3a.DUN", nullptr);
+	{
+		auto lpSetPiece = LoadFileInMem(preflag ? "Levels\\L4Data\\diab2b.DUN" : "Levels\\L4Data\\diab2a.DUN");
+		diabquad2x = 27 - l4holdx;
+		diabquad2y = 1 + l4holdy;
+		DRLG_L4SetRoom(lpSetPiece.get(), diabquad2x, diabquad2y);
 	}
-	diabquad3x = 1 + l4holdx;
-	diabquad3y = 27 - l4holdy;
-	DRLG_L4SetRoom(lpSetPiece, diabquad3x, diabquad3y);
-	mem_free_dbg(lpSetPiece);
-
-	if (preflag) {
-		lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab4b.DUN", nullptr);
-	} else {
-		lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab4a.DUN", nullptr);
+	{
+		auto lpSetPiece = LoadFileInMem(preflag ? "Levels\\L4Data\\diab3b.DUN" : "Levels\\L4Data\\diab3a.DUN");
+		diabquad3x = 1 + l4holdx;
+		diabquad3y = 27 - l4holdy;
+		DRLG_L4SetRoom(lpSetPiece.get(), diabquad3x, diabquad3y);
 	}
-	diabquad4x = 28 - l4holdx;
-	diabquad4y = 28 - l4holdy;
-	DRLG_L4SetRoom(lpSetPiece, diabquad4x, diabquad4y);
-	mem_free_dbg(lpSetPiece);
+	{
+		auto lpSetPiece = LoadFileInMem(preflag ? "Levels\\L4Data\\diab4b.DUN" : "Levels\\L4Data\\diab4a.DUN");
+		diabquad4x = 28 - l4holdx;
+		diabquad4y = 28 - l4holdy;
+		DRLG_L4SetRoom(lpSetPiece.get(), diabquad4x, diabquad4y);
+	}
 }
 
 static bool DRLG_L4PlaceMiniSet(const BYTE *miniset, int tmin, int tmax, int cx, int cy, bool setview, int ldir)
@@ -1774,7 +1761,7 @@ void CreateL4Dungeon(uint32_t rseed, lvl_entry entry)
 void LoadL4Dungeon(char *sFileName, int vx, int vy)
 {
 	int i, j, rw, rh;
-	BYTE *pLevelMap, *lm;
+	BYTE *lm;
 
 	dminx = 16;
 	dminy = 16;
@@ -1783,9 +1770,9 @@ void LoadL4Dungeon(char *sFileName, int vx, int vy)
 
 	DRLG_InitTrans();
 	InitL4Dungeon();
-	pLevelMap = LoadFileInMem(sFileName, nullptr);
+	auto pLevelMap = LoadFileInMem(sFileName, nullptr);
 
-	lm = pLevelMap;
+	lm = pLevelMap.get();
 	rw = *lm;
 	lm += 2;
 	rh = *lm;
@@ -1808,15 +1795,14 @@ void LoadL4Dungeon(char *sFileName, int vx, int vy)
 	DRLG_L4Pass3();
 	DRLG_Init_Globals();
 
-	SetMapMonsters(pLevelMap, 0, 0);
-	SetMapObjects(pLevelMap, 0, 0);
-	mem_free_dbg(pLevelMap);
+	SetMapMonsters(pLevelMap.get(), 0, 0);
+	SetMapObjects(pLevelMap.get(), 0, 0);
 }
 
 void LoadPreL4Dungeon(char *sFileName)
 {
 	int i, j, rw, rh;
-	BYTE *pLevelMap, *lm;
+	BYTE *lm;
 
 	dminx = 16;
 	dminy = 16;
@@ -1825,9 +1811,9 @@ void LoadPreL4Dungeon(char *sFileName)
 
 	InitL4Dungeon();
 
-	pLevelMap = LoadFileInMem(sFileName, nullptr);
+	auto pLevelMap = LoadFileInMem(sFileName, nullptr);
 
-	lm = pLevelMap;
+	lm = pLevelMap.get();
 	rw = *lm;
 	lm += 2;
 	rh = *lm;
@@ -1844,7 +1830,6 @@ void LoadPreL4Dungeon(char *sFileName)
 			lm += 2;
 		}
 	}
-	mem_free_dbg(pLevelMap);
 }
 
 } // namespace devilution

--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -202,11 +202,11 @@ void DRLG_LoadL4SP()
 {
 	setloadflag = false;
 	if (QuestStatus(Q_WARLORD)) {
-		pSetPiece = LoadFileInMem("Levels\\L4Data\\Warlord.DUN", nullptr);
+		pSetPiece = LoadFileInMem("Levels\\L4Data\\Warlord.DUN");
 		setloadflag = true;
 	}
 	if (currlevel == 15 && gbIsMultiplayer) {
-		pSetPiece = LoadFileInMem("Levels\\L4Data\\Vile1.DUN", nullptr);
+		pSetPiece = LoadFileInMem("Levels\\L4Data\\Vile1.DUN");
 		setloadflag = true;
 	}
 }
@@ -1770,7 +1770,7 @@ void LoadL4Dungeon(char *sFileName, int vx, int vy)
 
 	DRLG_InitTrans();
 	InitL4Dungeon();
-	auto pLevelMap = LoadFileInMem(sFileName, nullptr);
+	auto pLevelMap = LoadFileInMem(sFileName);
 
 	lm = pLevelMap.get();
 	rw = *lm;
@@ -1811,7 +1811,7 @@ void LoadPreL4Dungeon(char *sFileName)
 
 	InitL4Dungeon();
 
-	auto pLevelMap = LoadFileInMem(sFileName, nullptr);
+	auto pLevelMap = LoadFileInMem(sFileName);
 
 	lm = pLevelMap.get();
 	rw = *lm;

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -14,9 +14,11 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <cstdlib>
-#include <SDL.h>
 #include <cstdint>
+#include <cstdlib>
+#include <memory>
+
+#include <SDL.h>
 
 #ifdef USE_SDL1
 #include "utils/sdl2_to_1_2_backports.h"
@@ -169,17 +171,22 @@ constexpr uint32_t LoadBE32(const T *b)
 
 inline BYTE *CelGetFrame(BYTE *pCelBuff, int nCel, int *nDataSize)
 {
-	DWORD nCellStart;
-
-	nCellStart = LoadLE32(&pCelBuff[nCel * 4]);
+	DWORD nCellStart = LoadLE32(&pCelBuff[nCel * 4]);
 	*nDataSize = LoadLE32(&pCelBuff[(nCel + 1) * 4]) - nCellStart;
 	return pCelBuff + nCellStart;
 }
 
-inline BYTE *CelGetFrameClipped(BYTE *pCelBuff, int nCel, int *nDataSize)
+inline const BYTE *CelGetFrame(const BYTE *pCelBuff, int nCel, int *nDataSize)
+{
+	DWORD nCellStart = LoadLE32(&pCelBuff[nCel * 4]);
+	*nDataSize = LoadLE32(&pCelBuff[(nCel + 1) * 4]) - nCellStart;
+	return pCelBuff + nCellStart;
+}
+
+inline const BYTE *CelGetFrameClipped(const BYTE *pCelBuff, int nCel, int *nDataSize)
 {
 	DWORD nDataStart;
-	BYTE *pRLEBytes = CelGetFrame(pCelBuff, nCel, nDataSize);
+	const BYTE *pRLEBytes = CelGetFrame(pCelBuff, nCel, nDataSize);
 
 	nDataStart = pRLEBytes[1] << 8 | pRLEBytes[0];
 	*nDataSize -= nDataStart;
@@ -306,82 +313,133 @@ struct CelOutputBuffer {
 };
 
 /**
+ * Stores a CEL or CL2 sprite and its width(s).
+ *
+ * The data may be unowned.
+ * Eventually we'd like to remove the unowned version.
+ */
+class CelSprite {
+public:
+	CelSprite(std::unique_ptr<BYTE[]> data, int width)
+	    : data_(std::move(data))
+	    , data_ptr_(data_.get())
+	    , width_(width)
+	{
+	}
+
+	CelSprite(std::unique_ptr<BYTE[]> data, const int *widths)
+	    : data_(std::move(data))
+	    , data_ptr_(data_.get())
+	    , widths_(widths)
+	{
+	}
+
+	/**
+	 * Constructs an unowned sprite.
+	 * Ideally we'd like to remove all uses of this constructor.
+	 */
+	CelSprite(const BYTE *data, int width)
+	    : data_ptr_(data)
+	    , width_(width)
+	{
+	}
+
+	CelSprite(CelSprite &&) noexcept = default;
+	CelSprite &operator=(CelSprite &&) noexcept = default;
+
+	[[nodiscard]] const BYTE *Data() const
+	{
+		return data_ptr_;
+	}
+
+	[[nodiscard]] int Width(std::size_t frame = 1) const
+	{
+		return widths_ == nullptr ? width_ : widths_[frame];
+	}
+
+private:
+	std::unique_ptr<BYTE[]> data_;
+	const BYTE *data_ptr_;
+	int width_ = 0;
+	const int *widths_ = nullptr; // unowned
+};
+
+/**
+ * @brief Loads a Cel sprite and sets its width
+ */
+CelSprite LoadCel(const char *pszName, int width);
+CelSprite LoadCel(const char *pszName, const int *widths);
+
+/**
  * @brief Blit CEL sprite to the back buffer at the given coordinates
  * @param out Target buffer
  * @param sx Target buffer coordinate
  * @param sy Target buffer coordinate
- * @param pCelBuff Cel data
- * @param nCel CEL frame number
- * @param nWidth Width of sprite
+ * @param cel CEL sprite
+ * @param frame CEL frame number
  */
-void CelDrawTo(const CelOutputBuffer &out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+void CelDrawTo(const CelOutputBuffer &out, int sx, int sy, const CelSprite &cel, int frame);
 
 /**
  * @briefBlit CEL sprite to the given buffer, does not perform bounds-checking.
  * @param out Target buffer
  * @param x Cordinate in the target buffer
  * @param y Cordinate in the target buffer
- * @param pCelBuff Cel data
- * @param nCel CEL frame number
- * @param nWidth Width of cel
+ * @param cel CEL sprite
+ * @param frame CEL frame number
  */
-void CelDrawUnsafeTo(const CelOutputBuffer &out, int x, int y, BYTE *pCelBuff, int nCel, int nWidth);
+void CelDrawUnsafeTo(const CelOutputBuffer &out, int x, int y, const CelSprite &cel, int frame);
 
 /**
  * @brief Same as CelDrawTo but with the option to skip parts of the top and bottom of the sprite
  * @param out Target buffer
  * @param sx Target buffer coordinate
  * @param sy Target buffer coordinate
- * @param pCelBuff Cel data
- * @param nCel CEL frame number
- * @param nWidth Width of sprite
+ * @param cel CEL sprite
+ * @param frame CEL frame number
  */
-void CelClippedDrawTo(const CelOutputBuffer &out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+void CelClippedDrawTo(const CelOutputBuffer &out, int sx, int sy, const CelSprite &cel, int frame);
 
 /**
  * @brief Blit CEL sprite, and apply lighting, to the back buffer at the given coordinates
  * @param out Target buffer
  * @param sx Target buffer coordinate
  * @param sy Target buffer coordinate
- * @param pCelBuff Cel data
- * @param nCel CEL frame number
- * @param nWidth Width of sprite
+ * @param cel CEL sprite
+ * @param frame CEL frame number
  */
-void CelDrawLightTo(const CelOutputBuffer &out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, BYTE *tbl);
+void CelDrawLightTo(const CelOutputBuffer &out, int sx, int sy, const CelSprite &cel, int frame, BYTE *tbl);
 
 /**
  * @brief Same as CelDrawLightTo but with the option to skip parts of the top and bottom of the sprite
  * @param out Target buffer
  * @param sx Target buffer coordinate
  * @param sy Target buffer coordinate
- * @param pCelBuff Cel data
- * @param nCel CEL frame number
- * @param nWidth Width of sprite
+ * @param cel CEL sprite
+ * @param frame CEL frame number
  */
-void CelClippedDrawLightTo(const CelOutputBuffer &out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+void CelClippedDrawLightTo(const CelOutputBuffer &out, int sx, int sy, const CelSprite &cel, int frame);
 
 /**
  * @brief Same as CelBlitLightTransSafeTo
  * @param out Target buffer
  * @param sx Target buffer coordinate
  * @param sy Target buffer coordinate
- * @param pCelBuff Cel data
- * @param nCel CEL frame number
- * @param nWidth Width of sprite
+ * @param cel CEL sprite
+ * @param frame CEL frame number
  */
-void CelClippedBlitLightTransTo(const CelOutputBuffer &out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+void CelClippedBlitLightTransTo(const CelOutputBuffer &out, int sx, int sy, const CelSprite &cel, int frame);
 
 /**
  * @brief Blit CEL sprite, and apply lighting, to the back buffer at the given coordinates, translated to a red hue
  * @param out Target buffer
  * @param sx Target buffer coordinate
  * @param sy Target buffer coordinate
- * @param pCelBuff Cel data
- * @param nCel CEL frame number
- * @param nWidth Width of sprite
+ * @param cel CEL sprite
+ * @param frame CEL frame number
  * @param light Light shade to use
  */
-void CelDrawLightRedTo(const CelOutputBuffer &out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, char light);
+void CelDrawLightRedTo(const CelOutputBuffer &out, int sx, int sy, const CelSprite &cel, int frame, char light);
 
 /**
  * @brief Blit CEL sprite to the given buffer, checks for drawing outside the buffer.
@@ -390,20 +448,18 @@ void CelDrawLightRedTo(const CelOutputBuffer &out, int sx, int sy, BYTE *pCelBuf
  * @param sy Target buffer coordinate
  * @param pRLEBytes CEL pixel stream (run-length encoded)
  * @param nDataSize Size of CEL in bytes
- * @param nWidth Width of sprite
  */
-void CelBlitSafeTo(const CelOutputBuffer &out, int sx, int sy, BYTE *pRLEBytes, int nDataSize, int nWidth);
+void CelBlitSafeTo(const CelOutputBuffer &out, int sx, int sy, const BYTE *pRLEBytes, int nDataSize, int nWidth);
 
 /**
  * @brief Same as CelClippedDrawTo but checks for drawing outside the buffer
  * @param out Target buffer
  * @param sx Target buffer coordinate
  * @param sy Target buffer coordinate
- * @param pCelBuff Cel data
- * @param nCel CEL frame number
- * @param nWidth Width of sprite
+ * @param cel CEL sprite
+ * @param frame CEL frame number
  */
-void CelClippedDrawSafeTo(const CelOutputBuffer &out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+void CelClippedDrawSafeTo(const CelOutputBuffer &out, int sx, int sy, const CelSprite &cel, int frame);
 
 /**
  * @brief Blit CEL sprite, and apply lighting, to the given buffer, checks for drawing outside the buffer
@@ -412,10 +468,9 @@ void CelClippedDrawSafeTo(const CelOutputBuffer &out, int sx, int sy, BYTE *pCel
  * @param sy Target buffer coordinate
  * @param pRLEBytes CEL pixel stream (run-length encoded)
  * @param nDataSize Size of CEL in bytes
- * @param nWidth Width of sprite
  * @param tbl Palette translation table
  */
-void CelBlitLightSafeTo(const CelOutputBuffer &out, int sx, int sy, BYTE *pRLEBytes, int nDataSize, int nWidth, BYTE *tbl);
+void CelBlitLightSafeTo(const CelOutputBuffer &out, int sx, int sy, const BYTE *pRLEBytes, int nDataSize, int nWidth, BYTE *tbl);
 
 /**
  * @brief Same as CelBlitLightSafeTo but with stippled transparancy applied
@@ -424,21 +479,19 @@ void CelBlitLightSafeTo(const CelOutputBuffer &out, int sx, int sy, BYTE *pRLEBy
  * @param sy Target buffer coordinate
  * @param pRLEBytes CEL pixel stream (run-length encoded)
  * @param nDataSize Size of CEL in bytes
- * @param nWidth Width of sprite
  */
-void CelBlitLightTransSafeTo(const CelOutputBuffer &out, int sx, int sy, BYTE *pRLEBytes, int nDataSize, int nWidth);
+void CelBlitLightTransSafeTo(const CelOutputBuffer &out, int sx, int sy, const BYTE *pRLEBytes, int nDataSize, int nWidth);
 
 /**
  * @brief Same as CelDrawLightRedTo but checks for drawing outside the buffer
  * @param out Target buffer
  * @param sx Target buffer coordinate
  * @param sy Target buffer coordinate
- * @param pCelBuff Cel data
- * @param nCel CEL frame number
- * @param nWidth Width of cel
+ * @param cel CEL sprite
+ * @param frame CEL frame number
  * @param light Light shade to use
  */
-void CelDrawLightRedSafeTo(const CelOutputBuffer &out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, char light);
+void CelDrawLightRedSafeTo(const CelOutputBuffer &out, int sx, int sy, const CelSprite &cel, int frame, char light);
 
 /**
  * @brief Blit a solid colder shape one pixel larger then the given sprite shape, to the target buffer at the given coordianates
@@ -447,11 +500,10 @@ void CelDrawLightRedSafeTo(const CelOutputBuffer &out, int sx, int sy, BYTE *pCe
  * @param sx Target buffer coordinate
  * @param sy Target buffer coordinate
  * @param pCelBuff CEL buffer
- * @param nCel CEL frame number
- * @param nWidth Width of sprite
+ * @param frame CEL frame number
  * @param skipColorIndexZero If true, color in index 0 will be treated as transparent (these are typically used for shadows in sprites)
  */
-void CelBlitOutlineTo(const CelOutputBuffer &out, BYTE col, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, bool skipColorIndexZero = true);
+void CelBlitOutlineTo(const CelOutputBuffer &out, BYTE col, int sx, int sy, const CelSprite &cel, int frame, bool skipColorIndexZero = true);
 
 /**
  * @brief Set the value of a single pixel in the back buffer, checks bounds
@@ -469,9 +521,8 @@ void SetPixel(const CelOutputBuffer &out, int sx, int sy, BYTE col);
  * @param sy Output buffer coordinate
  * @param pCelBuff CL2 buffer
  * @param nCel CL2 frame number
- * @param nWidth Width of sprite
  */
-void Cl2Draw(const CelOutputBuffer &out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+void Cl2Draw(const CelOutputBuffer &out, int sx, int sy, const CelSprite &cel, int frame);
 
 /**
  * @brief Blit a solid colder shape one pixel larger then the given sprite shape, to the given buffer at the given coordianates
@@ -481,9 +532,8 @@ void Cl2Draw(const CelOutputBuffer &out, int sx, int sy, BYTE *pCelBuff, int nCe
  * @param sy Output buffer coordinate
  * @param pCelBuff CL2 buffer
  * @param nCel CL2 frame number
- * @param nWidth Width of sprite
  */
-void Cl2DrawOutline(const CelOutputBuffer &out, BYTE col, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+void Cl2DrawOutline(const CelOutputBuffer &out, BYTE col, int sx, int sy, const CelSprite &cel, int frame);
 
 /**
  * @brief Blit CL2 sprite, and apply a given lighting, to the given buffer at the given coordianates
@@ -492,10 +542,9 @@ void Cl2DrawOutline(const CelOutputBuffer &out, BYTE col, int sx, int sy, BYTE *
  * @param sy Output buffer coordinate
  * @param pCelBuff CL2 buffer
  * @param nCel CL2 frame number
- * @param nWidth Width of sprite
  * @param light Light shade to use
  */
-void Cl2DrawLightTbl(const CelOutputBuffer &out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, char light);
+void Cl2DrawLightTbl(const CelOutputBuffer &out, int sx, int sy, const CelSprite &cel, int frame, char light);
 
 /**
  * @brief Blit CL2 sprite, and apply lighting, to the given buffer at the given coordinates
@@ -504,9 +553,8 @@ void Cl2DrawLightTbl(const CelOutputBuffer &out, int sx, int sy, BYTE *pCelBuff,
  * @param sy Output buffer coordinate
  * @param pCelBuff CL2 buffer
  * @param nCel CL2 frame number
- * @param nWidth Width of sprite
  */
-void Cl2DrawLight(const CelOutputBuffer &out, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+void Cl2DrawLight(const CelOutputBuffer &out, int sx, int sy, const CelSprite &cel, int frame);
 
 /**
  * @brief Draw a line in the target buffer
@@ -551,7 +599,7 @@ void SetRndSeed(int32_t s);
 int32_t AdvanceRndSeed();
 int32_t GetRndSeed();
 int32_t GenerateRnd(int32_t v);
-BYTE *LoadFileInMem(const char *pszName, DWORD *pdwFileLen);
+std::unique_ptr<BYTE[]> LoadFileInMem(const char *pszName, DWORD *pdwFileLen = nullptr);
 DWORD LoadFileWithMem(const char *pszName, BYTE *p);
 void Cl2ApplyTrans(BYTE *p, BYTE *ttbl, int nCel);
 void PlayInGameMovie(const char *pszMovie);

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -110,21 +110,21 @@ void DrawDiabloMsg(const CelOutputBuffer &out)
 	int i, len, width, sx, sy;
 	BYTE c;
 
-	CelDrawTo(out, PANEL_X + 101, DIALOG_Y, pSTextSlidCels, 1, 12);
-	CelDrawTo(out, PANEL_X + 527, DIALOG_Y, pSTextSlidCels, 4, 12);
-	CelDrawTo(out, PANEL_X + 101, DIALOG_Y + 48, pSTextSlidCels, 2, 12);
-	CelDrawTo(out, PANEL_X + 527, DIALOG_Y + 48, pSTextSlidCels, 3, 12);
+	CelDrawTo(out, PANEL_X + 101, DIALOG_Y, *pSTextSlidCels, 1);
+	CelDrawTo(out, PANEL_X + 527, DIALOG_Y, *pSTextSlidCels, 4);
+	CelDrawTo(out, PANEL_X + 101, DIALOG_Y + 48, *pSTextSlidCels, 2);
+	CelDrawTo(out, PANEL_X + 527, DIALOG_Y + 48, *pSTextSlidCels, 3);
 
 	sx = PANEL_X + 109;
 	for (i = 0; i < 35; i++) {
-		CelDrawTo(out, sx, DIALOG_Y, pSTextSlidCels, 5, 12);
-		CelDrawTo(out, sx, DIALOG_Y + 48, pSTextSlidCels, 7, 12);
+		CelDrawTo(out, sx, DIALOG_Y, *pSTextSlidCels, 5);
+		CelDrawTo(out, sx, DIALOG_Y + 48, *pSTextSlidCels, 7);
 		sx += 12;
 	}
 	sy = DIALOG_Y + 12;
 	for (i = 0; i < 3; i++) {
-		CelDrawTo(out, PANEL_X + 101, sy, pSTextSlidCels, 6, 12);
-		CelDrawTo(out, PANEL_X + 527, sy, pSTextSlidCels, 8, 12);
+		CelDrawTo(out, PANEL_X + 101, sy, *pSTextSlidCels, 6);
+		CelDrawTo(out, PANEL_X + 527, sy, *pSTextSlidCels, 8);
 		sy += 12;
 	}
 

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -23,14 +23,14 @@ int setpc_w;
 /** Specifies the height of the active set level of the map. */
 int setpc_h;
 /** Contains the contents of the single player quest DUN file. */
-BYTE *pSetPiece;
+std::unique_ptr<BYTE[]> pSetPiece;
 /** Specifies whether a single player quest DUN has been loaded. */
 bool setloadflag;
-BYTE *pSpecialCels;
+std::optional<CelSprite> pSpecialCels;
 /** Specifies the tile definitions of the active dungeon type; (e.g. levels/l1data/l1.til). */
-BYTE *pMegaTiles;
-BYTE *pLevelPieces;
-BYTE *pDungeonCels;
+std::unique_ptr<BYTE[]> pMegaTiles;
+std::unique_ptr<BYTE[]> pLevelPieces;
+std::unique_ptr<BYTE[]> pDungeonCels;
 /**
  * List of transparancy masks to use for dPieces
  */
@@ -129,7 +129,6 @@ void FillSolidBlockTbls()
 {
 	BYTE bv;
 	DWORD i, dwTiles;
-	BYTE *pSBFile, *pTmp;
 
 	memset(nBlockTable, 0, sizeof(nBlockTable));
 	memset(nSolidTable, 0, sizeof(nSolidTable));
@@ -137,6 +136,7 @@ void FillSolidBlockTbls()
 	memset(nMissileTable, 0, sizeof(nMissileTable));
 	memset(nTrapTable, 0, sizeof(nTrapTable));
 
+	std::unique_ptr<BYTE[]> pSBFile;
 	switch (leveltype) {
 	case DTYPE_TOWN:
 		if (gbIsHellfire)
@@ -166,7 +166,7 @@ void FillSolidBlockTbls()
 		app_fatal("FillSolidBlockTbls");
 	}
 
-	pTmp = pSBFile;
+	const BYTE *pTmp = pSBFile.get();
 
 	for (i = 1; i <= dwTiles; i++) {
 		bv = *pTmp++;
@@ -182,8 +182,6 @@ void FillSolidBlockTbls()
 			nTrapTable[i] = true;
 		block_lvid[i] = (bv & 0x70) >> 4; /* beta: (bv >> 4) & 7 */
 	}
-
-	mem_free_dbg(pSBFile);
 }
 
 void SetDungeonMicros()

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -6,9 +6,11 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 
 #include "engine.h"
 #include "scrollrt.h"
+#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 
@@ -118,12 +120,12 @@ extern int setpc_x;
 extern int setpc_y;
 extern int setpc_w;
 extern int setpc_h;
-extern BYTE *pSetPiece;
+extern std::unique_ptr<BYTE[]> pSetPiece;
 extern bool setloadflag;
-extern BYTE *pSpecialCels;
-extern BYTE *pMegaTiles;
-extern BYTE *pLevelPieces;
-extern BYTE *pDungeonCels;
+extern std::optional<CelSprite> pSpecialCels;
+extern std::unique_ptr<BYTE[]> pMegaTiles;
+extern std::unique_ptr<BYTE[]> pLevelPieces;
+extern std::unique_ptr<BYTE[]> pDungeonCels;
 extern char block_lvid[MAXTILES + 1];
 extern bool nBlockTable[MAXTILES + 1];
 extern bool nSolidTable[MAXTILES + 1];

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -8,24 +8,28 @@
 #include "control.h"
 #include "controls/axis_direction.h"
 #include "controls/controller_motion.h"
+#include "engine.h"
 #include "stores.h"
-#include "utils/ui_fwd.h"
 #include "utils/language.h"
+#include "utils/stdcompat/optional.hpp"
+#include "utils/ui_fwd.h"
 
 namespace devilution {
+namespace {
+std::optional<CelSprite> optbar_cel;
+std::optional<CelSprite> PentSpin_cel;
+std::optional<CelSprite> BigTGold_cel;
+std::optional<CelSprite> option_cel;
+std::optional<CelSprite> sgpLogo;
+} // namespace
 
-BYTE *optbar_cel;
 bool mouseNavigation;
-BYTE *PentSpin_cel;
 TMenuItem *sgpCurrItem;
-BYTE *BigTGold_cel;
 int LogoAnim_tick;
 BYTE LogoAnim_frame;
 int PentSpin_tick;
 void (*gmenu_current_option)();
 TMenuItem *sgpCurrentMenu;
-BYTE *option_cel;
-BYTE *sgpLogo;
 int sgCurrentMenuIdx;
 
 /** Maps from font index to bigtgold.cel frame number. */
@@ -63,7 +67,7 @@ static void gmenu_print_text(const CelOutputBuffer &out, int x, int y, const cha
 		c = gbFontTransTbl[(BYTE)*pszStr++];
 		c = lfontframe[c];
 		if (c != 0)
-			CelDrawLightTo(out, x, y, BigTGold_cel, c, 46, nullptr);
+			CelDrawLightTo(out, x, y, *BigTGold_cel, c, nullptr);
 		x += lfontkern[c] + 2;
 	}
 }
@@ -80,11 +84,11 @@ void gmenu_draw_pause(const CelOutputBuffer &out)
 
 void FreeGMenu()
 {
-	MemFreeDbg(sgpLogo);
-	MemFreeDbg(BigTGold_cel);
-	MemFreeDbg(PentSpin_cel);
-	MemFreeDbg(option_cel);
-	MemFreeDbg(optbar_cel);
+	sgpLogo = std::nullopt;
+	BigTGold_cel = std::nullopt;
+	PentSpin_cel = std::nullopt;
+	option_cel = std::nullopt;
+	optbar_cel = std::nullopt;
 }
 
 void gmenu_init_menu()
@@ -96,13 +100,13 @@ void gmenu_init_menu()
 	sgCurrentMenuIdx = 0;
 	mouseNavigation = false;
 	if (gbIsHellfire)
-		sgpLogo = LoadFileInMem("Data\\hf_logo3.CEL", nullptr);
+		sgpLogo = LoadCel("Data\\hf_logo3.CEL", 430);
 	else
-		sgpLogo = LoadFileInMem("Data\\Diabsmal.CEL", nullptr);
-	BigTGold_cel = LoadFileInMem("Data\\BigTGold.CEL", nullptr);
-	PentSpin_cel = LoadFileInMem("Data\\PentSpin.CEL", nullptr);
-	option_cel = LoadFileInMem("Data\\option.CEL", nullptr);
-	optbar_cel = LoadFileInMem("Data\\optbar.CEL", nullptr);
+		sgpLogo = LoadCel("Data\\Diabsmal.CEL", 296);
+	BigTGold_cel = LoadCel("Data\\BigTGold.CEL", 46);
+	PentSpin_cel = LoadCel("Data\\PentSpin.CEL", 48);
+	option_cel = LoadCel("Data\\option.CEL", 27);
+	optbar_cel = LoadCel("Data\\optbar.CEL", 287);
 }
 
 bool gmenu_is_active()
@@ -218,21 +222,21 @@ static void gmenu_draw_menu_item(const CelOutputBuffer &out, TMenuItem *pItem, i
 	w = gmenu_get_lfont(pItem);
 	if ((pItem->dwFlags & GMENU_SLIDER) != 0) {
 		x = 16 + w / 2;
-		CelDrawTo(out, x + PANEL_LEFT, y - 10, optbar_cel, 1, 287);
+		CelDrawTo(out, x + PANEL_LEFT, y - 10, *optbar_cel, 1);
 		step = pItem->dwFlags & 0xFFF;
 		nSteps = (pItem->dwFlags & 0xFFF000) >> 12;
 		if (nSteps < 2)
 			nSteps = 2;
 		pos = step * 256 / nSteps;
 		gmenu_clear_buffer(out, x + 2 + PANEL_LEFT, y - 12, pos + 13, 28);
-		CelDrawTo(out, x + 2 + pos + PANEL_LEFT, y - 12, option_cel, 1, 27);
+		CelDrawTo(out, x + 2 + pos + PANEL_LEFT, y - 12, *option_cel, 1);
 	}
 	x = gnScreenWidth / 2 - w / 2;
 	light_table_index = (pItem->dwFlags & GMENU_ENABLED) ? 0 : 15;
 	gmenu_print_text(out, x, y, _(pItem->pszStr));
 	if (pItem == sgpCurrItem) {
-		CelDrawTo(out, x - 54, y + 1, PentSpin_cel, PentSpn2Spin(), 48);
-		CelDrawTo(out, x + 4 + w, y + 1, PentSpin_cel, PentSpn2Spin(), 48);
+		CelDrawTo(out, x - 54, y + 1, *PentSpin_cel, PentSpn2Spin());
+		CelDrawTo(out, x + 4 + w, y + 1, *PentSpin_cel, PentSpn2Spin());
 	}
 }
 
@@ -250,24 +254,21 @@ void gmenu_draw(const CelOutputBuffer &out)
 {
 	int y;
 	TMenuItem *i;
-	DWORD ticks;
 
 	if (sgpCurrentMenu != nullptr) {
 		GameMenuMove();
 		if (gmenu_current_option != nullptr)
 			gmenu_current_option();
 		if (gbIsHellfire) {
-			ticks = SDL_GetTicks();
+			const DWORD ticks = SDL_GetTicks();
 			if ((int)(ticks - LogoAnim_tick) > 25) {
 				LogoAnim_frame++;
 				if (LogoAnim_frame > 16)
 					LogoAnim_frame = 1;
 				LogoAnim_tick = ticks;
 			}
-			CelDrawTo(out, (gnScreenWidth - 430) / 2, 102 + UI_OFFSET_Y, sgpLogo, LogoAnim_frame, 430);
-		} else {
-			CelDrawTo(out, (gnScreenWidth - 296) / 2, 102 + UI_OFFSET_Y, sgpLogo, 1, 296);
 		}
+		CelDrawTo(out, (gnScreenWidth - sgpLogo->Width()) / 2, 102 + UI_OFFSET_Y, *sgpLogo, LogoAnim_frame);
 		y = 160 + UI_OFFSET_Y;
 		i = sgpCurrentMenu;
 		if (sgpCurrentMenu->fnMenu != nullptr) {

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -11,11 +11,14 @@
 #include "stores.h"
 #include "towners.h"
 #include "utils/language.h"
+#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
+namespace {
+std::optional<CelSprite> pInvCels;
+} // namespace
 
 bool invflag;
-BYTE *pInvCels;
 bool drawsbarflag;
 int sgdwLastTime; // check name
 
@@ -120,26 +123,26 @@ int AP2x2Tbl[10] = { 8, 28, 6, 26, 4, 24, 2, 22, 0, 20 };
 
 void FreeInvGFX()
 {
-	MemFreeDbg(pInvCels);
+	pInvCels = std::nullopt;
 }
 
 void InitInv()
 {
 	if (plr[myplr]._pClass == HeroClass::Warrior) {
-		pInvCels = LoadFileInMem("Data\\Inv\\Inv.CEL", nullptr);
+		pInvCels = LoadCel("Data\\Inv\\Inv.CEL", SPANEL_WIDTH);
 	} else if (plr[myplr]._pClass == HeroClass::Rogue) {
-		pInvCels = LoadFileInMem("Data\\Inv\\Inv_rog.CEL", nullptr);
+		pInvCels = LoadCel("Data\\Inv\\Inv_rog.CEL", SPANEL_WIDTH);
 	} else if (plr[myplr]._pClass == HeroClass::Sorcerer) {
-		pInvCels = LoadFileInMem("Data\\Inv\\Inv_Sor.CEL", nullptr);
+		pInvCels = LoadCel("Data\\Inv\\Inv_Sor.CEL", SPANEL_WIDTH);
 	} else if (plr[myplr]._pClass == HeroClass::Monk) {
 		if (!gbIsSpawn)
-			pInvCels = LoadFileInMem("Data\\Inv\\Inv_Sor.CEL", nullptr);
+			pInvCels = LoadCel("Data\\Inv\\Inv_Sor.CEL", SPANEL_WIDTH);
 		else
-			pInvCels = LoadFileInMem("Data\\Inv\\Inv.CEL", nullptr);
+			pInvCels = LoadCel("Data\\Inv\\Inv.CEL", SPANEL_WIDTH);
 	} else if (plr[myplr]._pClass == HeroClass::Bard) {
-		pInvCels = LoadFileInMem("Data\\Inv\\Inv_rog.CEL", nullptr);
+		pInvCels = LoadCel("Data\\Inv\\Inv_rog.CEL", SPANEL_WIDTH);
 	} else if (plr[myplr]._pClass == HeroClass::Barbarian) {
-		pInvCels = LoadFileInMem("Data\\Inv\\Inv.CEL", nullptr);
+		pInvCels = LoadCel("Data\\Inv\\Inv.CEL", SPANEL_WIDTH);
 	}
 
 	invflag = false;
@@ -172,9 +175,7 @@ static void InvDrawSlotBack(const CelOutputBuffer &out, int X, int Y, int W, int
 void DrawInv(const CelOutputBuffer &out)
 {
 	int frame, frame_width, i, j, ii;
-	BYTE *cels;
-
-	CelDrawTo(out, RIGHT_PANEL_X, 351, pInvCels, 1, SPANEL_WIDTH);
+	CelDrawTo(out, RIGHT_PANEL_X, 351, *pInvCels, 1);
 
 	InvXY slotSize[] = {
 		{ 2, 2 }, //head
@@ -214,21 +215,22 @@ void DrawInv(const CelOutputBuffer &out)
 				screen_y += InvItemHeight[frame] == 3 * INV_SLOT_SIZE_PX ? 0 : -14;
 			}
 
+			const CelSprite *cels;
 			if (frame <= 179) {
-				cels = pCursCels;
+				cels = &*pCursCels;
 			} else {
 				frame -= 179;
-				cels = pCursCels2;
+				cels = &*pCursCels2;
 			}
 
 			if (pcursinvitem == slot) {
-				CelBlitOutlineTo(out, GetOutlineColor(plr[myplr].InvBody[slot], true), RIGHT_PANEL_X + screen_x, screen_y, cels, frame, frame_width, false);
+				CelBlitOutlineTo(out, GetOutlineColor(plr[myplr].InvBody[slot], true), RIGHT_PANEL_X + screen_x, screen_y, *cels, frame, false);
 			}
 
 			if (plr[myplr].InvBody[slot]._iStatFlag) {
-				CelClippedDrawTo(out, RIGHT_PANEL_X + screen_x, screen_y, cels, frame, frame_width);
+				CelClippedDrawTo(out, RIGHT_PANEL_X + screen_x, screen_y, *cels, frame);
 			} else {
-				CelDrawLightRedTo(out, RIGHT_PANEL_X + screen_x, screen_y, cels, frame, frame_width, 1);
+				CelDrawLightRedTo(out, RIGHT_PANEL_X + screen_x, screen_y, *cels, frame, 1);
 			}
 
 			if (slot == INVLOC_HAND_LEFT) {
@@ -242,7 +244,7 @@ void DrawInv(const CelOutputBuffer &out)
 
 						const int dst_x = RIGHT_PANEL_X + slotPos[INVLOC_HAND_RIGHT].X + (frame_width == INV_SLOT_SIZE_PX ? 13 : -1);
 						const int dst_y = slotPos[INVLOC_HAND_RIGHT].Y;
-						CelClippedBlitLightTransTo(out, dst_x, dst_y, cels, frame, frame_width);
+						CelClippedBlitLightTransTo(out, dst_x, dst_y, *cels, frame);
 
 						cel_transparency_active = false;
 					}
@@ -268,11 +270,12 @@ void DrawInv(const CelOutputBuffer &out)
 			frame = plr[myplr].InvList[ii]._iCurs + CURSOR_FIRSTITEM;
 			frame_width = InvItemWidth[frame];
 
+			const CelSprite *cels;
 			if (frame <= 179) {
-				cels = pCursCels;
+				cels = &*pCursCels;
 			} else {
 				frame -= 179;
-				cels = pCursCels2;
+				cels = &*pCursCels2;
 			}
 
 			if (pcursinvitem == ii + INVITEM_INV_FIRST) {
@@ -281,7 +284,7 @@ void DrawInv(const CelOutputBuffer &out)
 				    GetOutlineColor(plr[myplr].InvList[ii], true),
 				    InvRect[j + SLOTXY_INV_FIRST].X + RIGHT_PANEL_X,
 				    InvRect[j + SLOTXY_INV_FIRST].Y - 1,
-				    cels, frame, frame_width, false);
+				    *cels, frame, false);
 			}
 
 			if (plr[myplr].InvList[ii]._iStatFlag) {
@@ -289,13 +292,13 @@ void DrawInv(const CelOutputBuffer &out)
 				    out,
 				    InvRect[j + SLOTXY_INV_FIRST].X + RIGHT_PANEL_X,
 				    InvRect[j + SLOTXY_INV_FIRST].Y - 1,
-				    cels, frame, frame_width);
+				    *cels, frame);
 			} else {
 				CelDrawLightRedTo(
 				    out,
 				    InvRect[j + SLOTXY_INV_FIRST].X + RIGHT_PANEL_X,
 				    InvRect[j + SLOTXY_INV_FIRST].Y - 1,
-				    cels, frame, frame_width, 1);
+				    *cels, frame, 1);
 			}
 		}
 	}
@@ -303,9 +306,7 @@ void DrawInv(const CelOutputBuffer &out)
 
 void DrawInvBelt(const CelOutputBuffer &out)
 {
-	int i, frame, frame_width;
 	BYTE fi, ff;
-	BYTE *cels;
 
 	if (talkflag) {
 		return;
@@ -313,32 +314,32 @@ void DrawInvBelt(const CelOutputBuffer &out)
 
 	DrawPanelBox(out, 205, 21, 232, 28, PANEL_X + 205, PANEL_Y + 5);
 
-	for (i = 0; i < MAXBELTITEMS; i++) {
+	for (int i = 0; i < MAXBELTITEMS; i++) {
 		if (plr[myplr].SpdList[i].isEmpty()) {
 			continue;
 		}
 
 		InvDrawSlotBack(out, InvRect[i + SLOTXY_BELT_FIRST].X + PANEL_X, InvRect[i + SLOTXY_BELT_FIRST].Y + PANEL_Y - 1, INV_SLOT_SIZE_PX, INV_SLOT_SIZE_PX);
-		frame = plr[myplr].SpdList[i]._iCurs + CURSOR_FIRSTITEM;
-		frame_width = InvItemWidth[frame];
+		int frame = plr[myplr].SpdList[i]._iCurs + CURSOR_FIRSTITEM;
 
+		const CelSprite *cels;
 		if (frame <= 179) {
-			cels = pCursCels;
+			cels = &*pCursCels;
 		} else {
 			frame -= 179;
-			cels = pCursCels2;
+			cels = &*pCursCels2;
 		}
 
 		if (pcursinvitem == i + INVITEM_BELT_FIRST) {
 			if (!sgbControllerActive || invflag) {
-				CelBlitOutlineTo(out, GetOutlineColor(plr[myplr].SpdList[i], true), InvRect[i + SLOTXY_BELT_FIRST].X + PANEL_X, InvRect[i + SLOTXY_BELT_FIRST].Y + PANEL_Y - 1, cels, frame, frame_width, false);
+				CelBlitOutlineTo(out, GetOutlineColor(plr[myplr].SpdList[i], true), InvRect[i + SLOTXY_BELT_FIRST].X + PANEL_X, InvRect[i + SLOTXY_BELT_FIRST].Y + PANEL_Y - 1, *cels, frame, false);
 			}
 		}
 
 		if (plr[myplr].SpdList[i]._iStatFlag) {
-			CelClippedDrawTo(out, InvRect[i + SLOTXY_BELT_FIRST].X + PANEL_X, InvRect[i + SLOTXY_BELT_FIRST].Y + PANEL_Y - 1, cels, frame, frame_width);
+			CelClippedDrawTo(out, InvRect[i + SLOTXY_BELT_FIRST].X + PANEL_X, InvRect[i + SLOTXY_BELT_FIRST].Y + PANEL_Y - 1, *cels, frame);
 		} else {
-			CelDrawLightRedTo(out, InvRect[i + SLOTXY_BELT_FIRST].X + PANEL_X, InvRect[i + SLOTXY_BELT_FIRST].Y + PANEL_Y - 1, cels, frame, frame_width, 1);
+			CelDrawLightRedTo(out, InvRect[i + SLOTXY_BELT_FIRST].X + PANEL_X, InvRect[i + SLOTXY_BELT_FIRST].Y + PANEL_Y - 1, *cels, frame, 1);
 		}
 
 		if (AllItemsList[plr[myplr].SpdList[i].IDidx].iUsable

--- a/Source/items.h
+++ b/Source/items.h
@@ -9,6 +9,7 @@
 
 #include "engine.h"
 #include "itemdat.h"
+#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 
@@ -168,7 +169,7 @@ struct ItemStruct {
 	enum item_type _itype;
 	Point position;
 	bool _iAnimFlag;
-	uint8_t *_iAnimData; // PSX name -> ItemFrame
+	CelSprite *_iAnimData; // PSX name -> ItemFrame
 	uint8_t _iAnimLen;   // Number of frames in current animation
 	uint8_t _iAnimFrame; // Current frame of animation.
 	int _iAnimWidth;

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -780,7 +780,7 @@ void MakeLightTable()
 	int i, j, k, l, lights, shade, l1, l2, cnt, rem, div;
 	double fs, fa;
 	BYTE col, max;
-	BYTE *tbl, *trn;
+	BYTE *tbl;
 	BYTE blood[16];
 
 	tbl = pLightTbl;
@@ -904,17 +904,19 @@ void MakeLightTable()
 		tbl += 240;
 	}
 
-	trn = LoadFileInMem("PlrGFX\\Infra.TRN", nullptr);
-	for (i = 0; i < 256; i++) {
-		*tbl++ = trn[i];
+	{
+		auto trn = LoadFileInMem("PlrGFX\\Infra.TRN", nullptr);
+		for (i = 0; i < 256; i++) {
+			*tbl++ = trn[i];
+		}
 	}
-	mem_free_dbg(trn);
 
-	trn = LoadFileInMem("PlrGFX\\Stone.TRN", nullptr);
-	for (i = 0; i < 256; i++) {
-		*tbl++ = trn[i];
+	{
+		auto trn = LoadFileInMem("PlrGFX\\Stone.TRN", nullptr);
+		for (i = 0; i < 256; i++) {
+			*tbl++ = trn[i];
+		}
 	}
-	mem_free_dbg(trn);
 
 	for (i = 0; i < 8; i++) {
 		for (col = 226; col < 239; col++) {

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -905,14 +905,14 @@ void MakeLightTable()
 	}
 
 	{
-		auto trn = LoadFileInMem("PlrGFX\\Infra.TRN", nullptr);
+		auto trn = LoadFileInMem("PlrGFX\\Infra.TRN");
 		for (i = 0; i < 256; i++) {
 			*tbl++ = trn[i];
 		}
 	}
 
 	{
-		auto trn = LoadFileInMem("PlrGFX\\Stone.TRN", nullptr);
+		auto trn = LoadFileInMem("PlrGFX\\Stone.TRN");
 		for (i = 0; i < 256; i++) {
 			*tbl++ = trn[i];
 		}

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1140,16 +1140,16 @@ void LoadMissileGFX(BYTE mi)
 	char pszName[256];
 	if ((mfd->mFlags & MFLAG_ALLOW_SPECIAL) != 0) {
 		sprintf(pszName, "Missiles\\%s.CL2", mfd->mName);
-		BYTE *file = LoadFileInMem(pszName, nullptr);
+		BYTE *file = LoadFileInMem(pszName, nullptr).release();
 		for (unsigned i = 0; i < mfd->mAnimFAmt; i++)
 			mfd->mAnimData[i] = CelGetFrameStart(file, i);
 	} else if (mfd->mAnimFAmt == 1) {
 		sprintf(pszName, "Missiles\\%s.CL2", mfd->mName);
-		mfd->mAnimData[0] = LoadFileInMem(pszName, nullptr);
+		mfd->mAnimData[0] = LoadFileInMem(pszName, nullptr).release();
 	} else {
 		for (unsigned i = 0; i < mfd->mAnimFAmt; i++) {
 			sprintf(pszName, "Missiles\\%s%u.CL2", mfd->mName, i + 1);
-			mfd->mAnimData[i] = LoadFileInMem(pszName, nullptr);
+			mfd->mAnimData[i] = LoadFileInMem(pszName, nullptr).release();
 		}
 	}
 }
@@ -1175,7 +1175,7 @@ void FreeMissileGFX(int mi)
 		if (misfiledata[mi].mAnimData[0]) {
 			p = (DWORD *)misfiledata[mi].mAnimData[0];
 			p -= misfiledata[mi].mAnimFAmt;
-			MemFreeDbg(p);
+			delete[] p;
 			misfiledata[mi].mAnimData[0] = nullptr;
 		}
 		return;
@@ -1183,7 +1183,8 @@ void FreeMissileGFX(int mi)
 
 	for (i = 0; i < misfiledata[mi].mAnimFAmt; i++) {
 		if (misfiledata[mi].mAnimData[i] != nullptr) {
-			MemFreeDbg(misfiledata[mi].mAnimData[i]);
+			delete[] misfiledata[mi].mAnimData[i];
+			misfiledata[mi].mAnimData[i] = nullptr;
 		}
 	}
 }

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -351,7 +351,7 @@ void InitMonsterGFX(int monst)
 
 			BYTE *celBuf;
 			{
-				auto celData = LoadFileInMem(strBuff, nullptr);
+				auto celData = LoadFileInMem(strBuff);
 				celBuf = celData.get();
 				Monsters[monst].Anims[anim].CMem = std::move(celData);
 			}
@@ -950,23 +950,23 @@ void PlaceQuestMonsters()
 		}
 
 		if (QuestStatus(Q_LTBANNER)) {
-			auto setp = LoadFileInMem("Levels\\L1Data\\Banner1.DUN", nullptr);
+			auto setp = LoadFileInMem("Levels\\L1Data\\Banner1.DUN");
 			SetMapMonsters(setp.get(), 2 * setpc_x, 2 * setpc_y);
 		}
 		if (QuestStatus(Q_BLOOD)) {
-			auto setp = LoadFileInMem("Levels\\L2Data\\Blood2.DUN", nullptr);
+			auto setp = LoadFileInMem("Levels\\L2Data\\Blood2.DUN");
 			SetMapMonsters(setp.get(), 2 * setpc_x, 2 * setpc_y);
 		}
 		if (QuestStatus(Q_BLIND)) {
-			auto setp = LoadFileInMem("Levels\\L2Data\\Blind2.DUN", nullptr);
+			auto setp = LoadFileInMem("Levels\\L2Data\\Blind2.DUN");
 			SetMapMonsters(setp.get(), 2 * setpc_x, 2 * setpc_y);
 		}
 		if (QuestStatus(Q_ANVIL)) {
-			auto setp = LoadFileInMem("Levels\\L3Data\\Anvil.DUN", nullptr);
+			auto setp = LoadFileInMem("Levels\\L3Data\\Anvil.DUN");
 			SetMapMonsters(setp.get(), 2 * setpc_x + 2, 2 * setpc_y + 2);
 		}
 		if (QuestStatus(Q_WARLORD)) {
-			auto setp = LoadFileInMem("Levels\\L4Data\\Warlord.DUN", nullptr);
+			auto setp = LoadFileInMem("Levels\\L4Data\\Warlord.DUN");
 			SetMapMonsters(setp.get(), 2 * setpc_x, 2 * setpc_y);
 			AddMonsterType(UniqMonst[UMT_WARLORD].mtype, PLACE_SCATTER);
 		}
@@ -983,7 +983,7 @@ void PlaceQuestMonsters()
 			PlaceUniqueMonst(UMT_LAZURUS, 0, 0);
 			PlaceUniqueMonst(UMT_RED_VEX, 0, 0);
 			PlaceUniqueMonst(UMT_BLACKJADE, 0, 0);
-			auto setp = LoadFileInMem("Levels\\L4Data\\Vile1.DUN", nullptr);
+			auto setp = LoadFileInMem("Levels\\L4Data\\Vile1.DUN");
 			SetMapMonsters(setp.get(), 2 * setpc_x, 2 * setpc_y);
 		}
 
@@ -1090,15 +1090,15 @@ void LoadDiabMonsts()
 		SetMapMonsters(lpSetPiece.get(), 2 * diabquad1x, 2 * diabquad1y);
 	}
 	{
-		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab2a.DUN", nullptr);
+		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab2a.DUN");
 		SetMapMonsters(lpSetPiece.get(), 2 * diabquad2x, 2 * diabquad2y);
 	}
 	{
-		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab3a.DUN", nullptr);
+		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab3a.DUN");
 		SetMapMonsters(lpSetPiece.get(), 2 * diabquad3x, 2 * diabquad3y);
 	}
 	{
-		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab4a.DUN", nullptr);
+		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab4a.DUN");
 		SetMapMonsters(lpSetPiece.get(), 2 * diabquad4x, 2 * diabquad4y);
 	}
 }

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -338,7 +338,6 @@ void InitMonsterGFX(int monst)
 {
 	int mtype, anim, i;
 	char strBuff[256];
-	BYTE *celBuf;
 
 	mtype = Monsters[monst].mtype;
 
@@ -350,8 +349,12 @@ void InitMonsterGFX(int monst)
 		if ((animletter[anim] != 's' || monsterdata[mtype].has_special) && frames > 0) {
 			sprintf(strBuff, monsterdata[mtype].GraphicType, animletter[anim]);
 
-			celBuf = LoadFileInMem(strBuff, nullptr);
-			Monsters[monst].Anims[anim].CMem = celBuf;
+			BYTE *celBuf;
+			{
+				auto celData = LoadFileInMem(strBuff, nullptr);
+				celBuf = celData.get();
+				Monsters[monst].Anims[anim].CMem = std::move(celData);
+			}
 
 			if (Monsters[monst].mtype != MT_GOLEM || (animletter[anim] != 's' && animletter[anim] != 'd')) {
 
@@ -381,9 +384,9 @@ void InitMonsterGFX(int monst)
 	Monsters[monst].MData = &monsterdata[mtype];
 
 	if (monsterdata[mtype].has_trans) {
-		Monsters[monst].trans_file = LoadFileInMem(monsterdata[mtype].TransFile, nullptr);
+		Monsters[monst].trans_file = LoadFileInMem(monsterdata[mtype].TransFile, nullptr).release();
 		InitMonsterTRN(monst, monsterdata[mtype].has_special);
-		MemFreeDbg(Monsters[monst].trans_file);
+		delete[] Monsters[monst].trans_file;
 	}
 
 	if (mtype >= MT_NMAGMA && mtype <= MT_WMAGMA && !(MissileFileFlag & 1)) {
@@ -928,7 +931,6 @@ static void PlaceUniques()
 void PlaceQuestMonsters()
 {
 	int skeltype;
-	BYTE *setp;
 
 	if (!setlevel) {
 		if (QuestStatus(Q_BUTCHER)) {
@@ -948,29 +950,24 @@ void PlaceQuestMonsters()
 		}
 
 		if (QuestStatus(Q_LTBANNER)) {
-			setp = LoadFileInMem("Levels\\L1Data\\Banner1.DUN", nullptr);
-			SetMapMonsters(setp, 2 * setpc_x, 2 * setpc_y);
-			mem_free_dbg(setp);
+			auto setp = LoadFileInMem("Levels\\L1Data\\Banner1.DUN", nullptr);
+			SetMapMonsters(setp.get(), 2 * setpc_x, 2 * setpc_y);
 		}
 		if (QuestStatus(Q_BLOOD)) {
-			setp = LoadFileInMem("Levels\\L2Data\\Blood2.DUN", nullptr);
-			SetMapMonsters(setp, 2 * setpc_x, 2 * setpc_y);
-			mem_free_dbg(setp);
+			auto setp = LoadFileInMem("Levels\\L2Data\\Blood2.DUN", nullptr);
+			SetMapMonsters(setp.get(), 2 * setpc_x, 2 * setpc_y);
 		}
 		if (QuestStatus(Q_BLIND)) {
-			setp = LoadFileInMem("Levels\\L2Data\\Blind2.DUN", nullptr);
-			SetMapMonsters(setp, 2 * setpc_x, 2 * setpc_y);
-			mem_free_dbg(setp);
+			auto setp = LoadFileInMem("Levels\\L2Data\\Blind2.DUN", nullptr);
+			SetMapMonsters(setp.get(), 2 * setpc_x, 2 * setpc_y);
 		}
 		if (QuestStatus(Q_ANVIL)) {
-			setp = LoadFileInMem("Levels\\L3Data\\Anvil.DUN", nullptr);
-			SetMapMonsters(setp, 2 * setpc_x + 2, 2 * setpc_y + 2);
-			mem_free_dbg(setp);
+			auto setp = LoadFileInMem("Levels\\L3Data\\Anvil.DUN", nullptr);
+			SetMapMonsters(setp.get(), 2 * setpc_x + 2, 2 * setpc_y + 2);
 		}
 		if (QuestStatus(Q_WARLORD)) {
-			setp = LoadFileInMem("Levels\\L4Data\\Warlord.DUN", nullptr);
-			SetMapMonsters(setp, 2 * setpc_x, 2 * setpc_y);
-			mem_free_dbg(setp);
+			auto setp = LoadFileInMem("Levels\\L4Data\\Warlord.DUN", nullptr);
+			SetMapMonsters(setp.get(), 2 * setpc_x, 2 * setpc_y);
 			AddMonsterType(UniqMonst[UMT_WARLORD].mtype, PLACE_SCATTER);
 		}
 		if (QuestStatus(Q_VEIL)) {
@@ -986,9 +983,8 @@ void PlaceQuestMonsters()
 			PlaceUniqueMonst(UMT_LAZURUS, 0, 0);
 			PlaceUniqueMonst(UMT_RED_VEX, 0, 0);
 			PlaceUniqueMonst(UMT_BLACKJADE, 0, 0);
-			setp = LoadFileInMem("Levels\\L4Data\\Vile1.DUN", nullptr);
-			SetMapMonsters(setp, 2 * setpc_x, 2 * setpc_y);
-			mem_free_dbg(setp);
+			auto setp = LoadFileInMem("Levels\\L4Data\\Vile1.DUN", nullptr);
+			SetMapMonsters(setp.get(), 2 * setpc_x, 2 * setpc_y);
 		}
 
 		if (currlevel == 24) {
@@ -1089,20 +1085,22 @@ void PlaceGroup(int mtype, int num, int leaderf, int leader)
 
 void LoadDiabMonsts()
 {
-	BYTE *lpSetPiece;
-
-	lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab1.DUN", nullptr);
-	SetMapMonsters(lpSetPiece, 2 * diabquad1x, 2 * diabquad1y);
-	mem_free_dbg(lpSetPiece);
-	lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab2a.DUN", nullptr);
-	SetMapMonsters(lpSetPiece, 2 * diabquad2x, 2 * diabquad2y);
-	mem_free_dbg(lpSetPiece);
-	lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab3a.DUN", nullptr);
-	SetMapMonsters(lpSetPiece, 2 * diabquad3x, 2 * diabquad3y);
-	mem_free_dbg(lpSetPiece);
-	lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab4a.DUN", nullptr);
-	SetMapMonsters(lpSetPiece, 2 * diabquad4x, 2 * diabquad4y);
-	mem_free_dbg(lpSetPiece);
+	{
+		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab1.DUN");
+		SetMapMonsters(lpSetPiece.get(), 2 * diabquad1x, 2 * diabquad1y);
+	}
+	{
+		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab2a.DUN", nullptr);
+		SetMapMonsters(lpSetPiece.get(), 2 * diabquad2x, 2 * diabquad2y);
+	}
+	{
+		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab3a.DUN", nullptr);
+		SetMapMonsters(lpSetPiece.get(), 2 * diabquad3x, 2 * diabquad3y);
+	}
+	{
+		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab4a.DUN", nullptr);
+		SetMapMonsters(lpSetPiece.get(), 2 * diabquad4x, 2 * diabquad4y);
+	}
 }
 
 void InitMonsters()
@@ -4684,7 +4682,7 @@ void FreeMonsters()
 		mtype = Monsters[i].mtype;
 		for (j = 0; j < 6; j++) {
 			if (animletter[j] != 's' || monsterdata[mtype].has_special) {
-				MemFreeDbg(Monsters[i].Anims[j].CMem);
+				Monsters[i].Anims[j].CMem = nullptr;
 			}
 		}
 	}

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -109,7 +109,7 @@ enum placeflag : uint8_t {
 };
 
 struct AnimStruct {
-	uint8_t *CMem;
+	std::unique_ptr<uint8_t[]> CMem;
 	std::array<uint8_t *, 8> Data;
 	int Frames;
 	int Rate;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -314,7 +314,7 @@ void InitObjectGFX()
 				sprintf(filestr, "Objects\\%s.CEL", ObjHiveLoadList[i]);
 			else if (currlevel >= 21)
 				sprintf(filestr, "Objects\\%s.CEL", ObjCryptLoadList[i]);
-			pObjCels[numobjfiles] = LoadFileInMem(filestr, nullptr);
+			pObjCels[numobjfiles] = LoadFileInMem(filestr);
 			numobjfiles++;
 		}
 	}
@@ -830,15 +830,15 @@ void LoadMapObjs(BYTE *pMap, int startx, int starty)
 void AddDiabObjs()
 {
 	{
-		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab1.DUN", nullptr);
+		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab1.DUN");
 		LoadMapObjects(lpSetPiece.get(), 2 * diabquad1x, 2 * diabquad1y, diabquad2x, diabquad2y, 11, 12, 1);
 	}
 	{
-		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab2a.DUN", nullptr);
+		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab2a.DUN");
 		LoadMapObjects(lpSetPiece.get(), 2 * diabquad2x, 2 * diabquad2y, diabquad3x, diabquad3y, 11, 11, 2);
 	}
 	{
-		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab3a.DUN", nullptr);
+		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab3a.DUN");
 		LoadMapObjects(lpSetPiece.get(), 2 * diabquad3x, 2 * diabquad3y, diabquad4x, diabquad4y, 9, 9, 3);
 	}
 }
@@ -1118,7 +1118,7 @@ void InitObjects()
 				quests[Q_BLIND]._qmsg = sp_id;
 				AddBookLever(setpc_x, setpc_y, setpc_w + setpc_x + 1, setpc_h + setpc_y + 1, sp_id);
 				{
-					auto mem = LoadFileInMem("Levels\\L2Data\\Blind2.DUN", nullptr);
+					auto mem = LoadFileInMem("Levels\\L2Data\\Blind2.DUN");
 					LoadMapObjs(mem.get(), 2 * setpc_x, 2 * setpc_y);
 				}
 			}
@@ -1180,7 +1180,7 @@ void InitObjects()
 				quests[Q_WARLORD]._qmsg = sp_id;
 				AddBookLever(setpc_x, setpc_y, setpc_x + setpc_w, setpc_y + setpc_h, sp_id);
 				{
-					auto mem = LoadFileInMem("Levels\\L4Data\\Warlord.DUN", nullptr);
+					auto mem = LoadFileInMem("Levels\\L4Data\\Warlord.DUN");
 					LoadMapObjs(mem.get(), 2 * setpc_x, 2 * setpc_y);
 				}
 			}
@@ -1245,7 +1245,7 @@ void SetMapObjects(BYTE *pMap, int startx, int starty)
 
 		ObjFileList[numobjfiles] = (object_graphic_id)i;
 		sprintf(filestr, "Objects\\%s.CEL", ObjMasterLoadList[i]);
-		pObjCels[numobjfiles] = LoadFileInMem(filestr, nullptr);
+		pObjCels[numobjfiles] = LoadFileInMem(filestr);
 		numobjfiles++;
 	}
 
@@ -3350,7 +3350,7 @@ void OperatePedistal(int pnum, int i)
 				PlaySfxLoc(LS_BLODSTAR, object[i].position.x, object[i].position.y);
 			ObjChangeMap(object[i]._oVar1, object[i]._oVar2, object[i]._oVar3, object[i]._oVar4);
 			{
-				auto mem = LoadFileInMem("Levels\\L2Data\\Blood2.DUN", nullptr);
+				auto mem = LoadFileInMem("Levels\\L2Data\\Blood2.DUN");
 				LoadMapObjs(mem.get(), 2 * setpc_x, 2 * setpc_y);
 			}
 			SpawnUnique(UITEM_ARMOFVAL, 2 * setpc_x + 25, 2 * setpc_y + 19);
@@ -5368,7 +5368,7 @@ void SyncPedistal(int i)
 	}
 	if (object[i]._oVar6 == 3) {
 		ObjChangeMapResync(object[i]._oVar1, object[i]._oVar2, object[i]._oVar3, object[i]._oVar4);
-		auto setp = LoadFileInMem("Levels\\L2Data\\Blood2.DUN", nullptr);
+		auto setp = LoadFileInMem("Levels\\L2Data\\Blood2.DUN");
 		LoadMapObjs(setp.get(), 2 * setpc_x, 2 * setpc_y);
 	}
 }

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -68,7 +68,7 @@ enum shrine_type : uint8_t {
 
 int trapid;
 int trapdir;
-BYTE *pObjCels[40];
+std::unique_ptr<BYTE[]> pObjCels[40];
 object_graphic_id ObjFileList[40];
 int objectactive[MAXOBJECTS];
 /** Specifies the number of active objects. */
@@ -325,7 +325,7 @@ void FreeObjectGFX()
 	int i;
 
 	for (i = 0; i < numobjfiles; i++) {
-		MemFreeDbg(pObjCels[i]);
+		pObjCels[i] = nullptr;
 	}
 	numobjfiles = 0;
 }
@@ -829,17 +829,18 @@ void LoadMapObjs(BYTE *pMap, int startx, int starty)
 
 void AddDiabObjs()
 {
-	BYTE *lpSetPiece;
-
-	lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab1.DUN", nullptr);
-	LoadMapObjects(lpSetPiece, 2 * diabquad1x, 2 * diabquad1y, diabquad2x, diabquad2y, 11, 12, 1);
-	mem_free_dbg(lpSetPiece);
-	lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab2a.DUN", nullptr);
-	LoadMapObjects(lpSetPiece, 2 * diabquad2x, 2 * diabquad2y, diabquad3x, diabquad3y, 11, 11, 2);
-	mem_free_dbg(lpSetPiece);
-	lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab3a.DUN", nullptr);
-	LoadMapObjects(lpSetPiece, 2 * diabquad3x, 2 * diabquad3y, diabquad4x, diabquad4y, 9, 9, 3);
-	mem_free_dbg(lpSetPiece);
+	{
+		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab1.DUN", nullptr);
+		LoadMapObjects(lpSetPiece.get(), 2 * diabquad1x, 2 * diabquad1y, diabquad2x, diabquad2y, 11, 12, 1);
+	}
+	{
+		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab2a.DUN", nullptr);
+		LoadMapObjects(lpSetPiece.get(), 2 * diabquad2x, 2 * diabquad2y, diabquad3x, diabquad3y, 11, 11, 2);
+	}
+	{
+		auto lpSetPiece = LoadFileInMem("Levels\\L4Data\\diab3a.DUN", nullptr);
+		LoadMapObjects(lpSetPiece.get(), 2 * diabquad3x, 2 * diabquad3y, diabquad4x, diabquad4y, 9, 9, 3);
+	}
 }
 
 void objects_add_lv22(int s)
@@ -1045,8 +1046,6 @@ void AddLazStand()
 
 void InitObjects()
 {
-	BYTE *mem;
-
 	ClrAllObjects();
 	dword_6DE0E0 = 0;
 	if (currlevel == 16) {
@@ -1118,9 +1117,10 @@ void InitObjects()
 				}
 				quests[Q_BLIND]._qmsg = sp_id;
 				AddBookLever(setpc_x, setpc_y, setpc_w + setpc_x + 1, setpc_h + setpc_y + 1, sp_id);
-				mem = LoadFileInMem("Levels\\L2Data\\Blind2.DUN", nullptr);
-				LoadMapObjs(mem, 2 * setpc_x, 2 * setpc_y);
-				mem_free_dbg(mem);
+				{
+					auto mem = LoadFileInMem("Levels\\L2Data\\Blind2.DUN", nullptr);
+					LoadMapObjs(mem.get(), 2 * setpc_x, 2 * setpc_y);
+				}
 			}
 			if (QuestStatus(Q_BLOOD)) {
 				_speech_id sp_id;
@@ -1179,9 +1179,10 @@ void InitObjects()
 				}
 				quests[Q_WARLORD]._qmsg = sp_id;
 				AddBookLever(setpc_x, setpc_y, setpc_x + setpc_w, setpc_y + setpc_h, sp_id);
-				mem = LoadFileInMem("Levels\\L4Data\\Warlord.DUN", nullptr);
-				LoadMapObjs(mem, 2 * setpc_x, 2 * setpc_y);
-				mem_free_dbg(mem);
+				{
+					auto mem = LoadFileInMem("Levels\\L4Data\\Warlord.DUN", nullptr);
+					LoadMapObjs(mem.get(), 2 * setpc_x, 2 * setpc_y);
+				}
 			}
 			if (QuestStatus(Q_BETRAYER) && !gbIsMultiplayer)
 				AddLazStand();
@@ -1286,7 +1287,7 @@ void SetupObject(int i, int x, int y, _object_id ot)
 
 	const int j = std::distance(std::begin(ObjFileList), found);
 
-	object[i]._oAnimData = pObjCels[j];
+	object[i]._oAnimData = pObjCels[j].get();
 	object[i]._oAnimFlag = AllObjects[ot].oAnimFlag;
 	if (AllObjects[ot].oAnimFlag != 0) {
 		object[i]._oAnimDelay = AllObjects[ot].oAnimDelay;
@@ -2263,12 +2264,12 @@ void ObjSetMicro(int dx, int dy, int pn)
 	pn--;
 	defs = &dpiece_defs_map_2[dx][dy];
 	if (leveltype != DTYPE_HELL) {
-		v = (uint16_t *)pLevelPieces + 10 * pn;
+		v = (uint16_t *)pLevelPieces.get() + 10 * pn;
 		for (i = 0; i < 10; i++) {
 			defs->mt[i] = SDL_SwapLE16(v[(i & 1) - (i & 0xE) + 8]);
 		}
 	} else {
-		v = (uint16_t *)pLevelPieces + 16 * pn;
+		v = (uint16_t *)pLevelPieces.get() + 16 * pn;
 		for (i = 0; i < 16; i++) {
 			defs->mt[i] = SDL_SwapLE16(v[(i & 1) - (i & 0xE) + 14]);
 		}
@@ -2282,8 +2283,8 @@ void objects_set_door_piece(int x, int y)
 
 	pn = dPiece[x][y] - 1;
 
-	v1 = *((uint16_t *)pLevelPieces + 10 * pn + 8);
-	v2 = *((uint16_t *)pLevelPieces + 10 * pn + 9);
+	v1 = *((uint16_t *)pLevelPieces.get() + 10 * pn + 8);
+	v2 = *((uint16_t *)pLevelPieces.get() + 10 * pn + 9);
 	dpiece_defs_map_2[x][y].mt[0] = SDL_SwapLE16(v1);
 	dpiece_defs_map_2[x][y].mt[1] = SDL_SwapLE16(v2);
 }
@@ -3322,7 +3323,6 @@ void OperateL3Door(int pnum, int i, bool sendflag)
 
 void OperatePedistal(int pnum, int i)
 {
-	BYTE *mem;
 	int iv;
 
 	if (numitems >= MAXITEMS) {
@@ -3349,9 +3349,10 @@ void OperatePedistal(int pnum, int i)
 			if (!deltaload)
 				PlaySfxLoc(LS_BLODSTAR, object[i].position.x, object[i].position.y);
 			ObjChangeMap(object[i]._oVar1, object[i]._oVar2, object[i]._oVar3, object[i]._oVar4);
-			mem = LoadFileInMem("Levels\\L2Data\\Blood2.DUN", nullptr);
-			LoadMapObjs(mem, 2 * setpc_x, 2 * setpc_y);
-			mem_free_dbg(mem);
+			{
+				auto mem = LoadFileInMem("Levels\\L2Data\\Blood2.DUN", nullptr);
+				LoadMapObjs(mem.get(), 2 * setpc_x, 2 * setpc_y);
+			}
 			SpawnUnique(UITEM_ARMOFVAL, 2 * setpc_x + 25, 2 * setpc_y + 19);
 			object[i]._oSelFlag = 0;
 		}
@@ -5359,8 +5360,6 @@ void SyncQSTLever(int i)
 
 void SyncPedistal(int i)
 {
-	BYTE *setp;
-
 	if (object[i]._oVar6 == 1)
 		ObjChangeMapResync(setpc_x, setpc_y + 3, setpc_x + 2, setpc_y + 7);
 	if (object[i]._oVar6 == 2) {
@@ -5369,9 +5368,8 @@ void SyncPedistal(int i)
 	}
 	if (object[i]._oVar6 == 3) {
 		ObjChangeMapResync(object[i]._oVar1, object[i]._oVar2, object[i]._oVar3, object[i]._oVar4);
-		setp = LoadFileInMem("Levels\\L2Data\\Blood2.DUN", nullptr);
-		LoadMapObjs(setp, 2 * setpc_x, 2 * setpc_y);
-		mem_free_dbg(setp);
+		auto setp = LoadFileInMem("Levels\\L2Data\\Blood2.DUN", nullptr);
+		LoadMapObjs(setp.get(), 2 * setpc_x, 2 * setpc_y);
 	}
 }
 
@@ -5432,7 +5430,7 @@ void SyncObjectAnim(int o)
 
 	const int i = std::distance(std::begin(ObjFileList), found);
 
-	object[o]._oAnimData = pObjCels[i];
+	object[o]._oAnimData = pObjCels[i].get();
 	switch (object[o]._otype) {
 	case OBJ_L1LDOOR:
 	case OBJ_L1RDOOR:

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -20,7 +20,7 @@ namespace devilution {
 
 int qtopline;
 bool questlog;
-BYTE *pQLogCel;
+std::optional<CelSprite> pQLogCel;
 /** Contains the quests of the current game. */
 QuestStruct quests[MAXQUESTS];
 int qline;
@@ -380,12 +380,12 @@ void DrawWarLord(int x, int y)
 {
 	int rw, rh;
 	int i, j;
-	BYTE *sp, *setp;
+	BYTE *sp;
 	int v;
 
-	setp = LoadFileInMem("Levels\\L4Data\\Warlord2.DUN", nullptr);
-	rw = *setp;
-	sp = setp + 2;
+	auto setp = LoadFileInMem("Levels\\L4Data\\Warlord2.DUN", nullptr);
+	rw = setp[0];
+	sp = &setp[2];
 	rh = *sp;
 	sp += 2;
 	setpc_w = rw;
@@ -403,7 +403,6 @@ void DrawWarLord(int x, int y)
 			sp += 2;
 		}
 	}
-	mem_free_dbg(setp);
 }
 
 void DrawSChamber(int q, int x, int y)
@@ -411,12 +410,12 @@ void DrawSChamber(int q, int x, int y)
 	int i, j;
 	int rw, rh;
 	int xx, yy;
-	BYTE *sp, *setp;
+	BYTE *sp;
 	int v;
 
-	setp = LoadFileInMem("Levels\\L2Data\\Bonestr1.DUN", nullptr);
-	rw = *setp;
-	sp = setp + 2;
+	auto setp = LoadFileInMem("Levels\\L2Data\\Bonestr1.DUN", nullptr);
+	rw = setp[0];
+	sp = &setp[2];
 	rh = *sp;
 	sp += 2;
 	setpc_w = rw;
@@ -437,18 +436,17 @@ void DrawSChamber(int q, int x, int y)
 	xx = 2 * x + 22;
 	yy = 2 * y + 23;
 	quests[q].position = { xx, yy };
-	mem_free_dbg(setp);
 }
 
 void DrawLTBanner(int x, int y)
 {
 	int rw, rh;
 	int i, j;
-	BYTE *sp, *setp;
+	BYTE *sp;
 
-	setp = LoadFileInMem("Levels\\L1Data\\Banner1.DUN", nullptr);
-	rw = *setp;
-	sp = setp + 2;
+	auto setp = LoadFileInMem("Levels\\L1Data\\Banner1.DUN", nullptr);
+	rw = setp[0];
+	sp = &setp[2];
 	rh = *sp;
 	sp += 2;
 	setpc_w = rw;
@@ -463,18 +461,17 @@ void DrawLTBanner(int x, int y)
 			sp += 2;
 		}
 	}
-	mem_free_dbg(setp);
 }
 
 void DrawBlind(int x, int y)
 {
 	int rw, rh;
 	int i, j;
-	BYTE *sp, *setp;
+	BYTE *sp;
 
-	setp = LoadFileInMem("Levels\\L2Data\\Blind1.DUN", nullptr);
-	rw = *setp;
-	sp = setp + 2;
+	auto setp = LoadFileInMem("Levels\\L2Data\\Blind1.DUN", nullptr);
+	rw = setp[0];
+	sp = &setp[2];
 	rh = *sp;
 	sp += 2;
 	setpc_x = x;
@@ -489,18 +486,17 @@ void DrawBlind(int x, int y)
 			sp += 2;
 		}
 	}
-	mem_free_dbg(setp);
 }
 
 void DrawBlood(int x, int y)
 {
 	int rw, rh;
 	int i, j;
-	BYTE *sp, *setp;
+	BYTE *sp;
 
-	setp = LoadFileInMem("Levels\\L2Data\\Blood2.DUN", nullptr);
-	rw = *setp;
-	sp = setp + 2;
+	auto setp = LoadFileInMem("Levels\\L2Data\\Blood2.DUN", nullptr);
+	rw = setp[0];
+	sp = &setp[2];
 	rh = *sp;
 	sp += 2;
 	setpc_x = x;
@@ -515,7 +511,6 @@ void DrawBlood(int x, int y)
 			sp += 2;
 		}
 	}
-	mem_free_dbg(setp);
 }
 
 void DRLG_CheckQuests(int x, int y)
@@ -743,7 +738,7 @@ static void PrintQLString(const CelOutputBuffer &out, int x, int y, bool cjustfl
 		sx += k;
 	}
 	if (qline == y) {
-		CelDrawTo(out, cjustflag ? x + k + 12 : x + 12, sy + 1, pSPentSpn2Cels, PentSpn2Spin(), 12);
+		CelDrawTo(out, cjustflag ? x + k + 12 : x + 12, sy + 1, *pSPentSpn2Cels, PentSpn2Spin());
 	}
 	for (i = 0; i < len; i++) {
 		c = fontframe[gbFontTransTbl[(BYTE)str[i]]];
@@ -754,7 +749,7 @@ static void PrintQLString(const CelOutputBuffer &out, int x, int y, bool cjustfl
 		sx += fontkern[c] + 1;
 	}
 	if (qline == y) {
-		CelDrawTo(out, cjustflag ? x + k + 36 : 276 - x, sy + 1, pSPentSpn2Cels, PentSpn2Spin(), 12);
+		CelDrawTo(out, cjustflag ? x + k + 36 : 276 - x, sy + 1, *pSPentSpn2Cels, PentSpn2Spin());
 	}
 }
 
@@ -763,7 +758,7 @@ void DrawQuestLog(const CelOutputBuffer &out)
 	int y, i;
 
 	PrintQLString(out, 0, 2, true, _("Quest Log"), COL_GOLD);
-	CelDrawTo(out, 0, 351, pQLogCel, 1, SPANEL_WIDTH);
+	CelDrawTo(out, 0, 351, *pQLogCel, 1);
 	y = qtopline;
 	for (i = 0; i < numqlines; i++) {
 		PrintQLString(out, 0, y, true, _(questlist[qlist[i]]._qlstr), COL_WHITE);

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -383,7 +383,7 @@ void DrawWarLord(int x, int y)
 	BYTE *sp;
 	int v;
 
-	auto setp = LoadFileInMem("Levels\\L4Data\\Warlord2.DUN", nullptr);
+	auto setp = LoadFileInMem("Levels\\L4Data\\Warlord2.DUN");
 	rw = setp[0];
 	sp = &setp[2];
 	rh = *sp;
@@ -413,7 +413,7 @@ void DrawSChamber(int q, int x, int y)
 	BYTE *sp;
 	int v;
 
-	auto setp = LoadFileInMem("Levels\\L2Data\\Bonestr1.DUN", nullptr);
+	auto setp = LoadFileInMem("Levels\\L2Data\\Bonestr1.DUN");
 	rw = setp[0];
 	sp = &setp[2];
 	rh = *sp;
@@ -444,7 +444,7 @@ void DrawLTBanner(int x, int y)
 	int i, j;
 	BYTE *sp;
 
-	auto setp = LoadFileInMem("Levels\\L1Data\\Banner1.DUN", nullptr);
+	auto setp = LoadFileInMem("Levels\\L1Data\\Banner1.DUN");
 	rw = setp[0];
 	sp = &setp[2];
 	rh = *sp;
@@ -469,7 +469,7 @@ void DrawBlind(int x, int y)
 	int i, j;
 	BYTE *sp;
 
-	auto setp = LoadFileInMem("Levels\\L2Data\\Blind1.DUN", nullptr);
+	auto setp = LoadFileInMem("Levels\\L2Data\\Blind1.DUN");
 	rw = setp[0];
 	sp = &setp[2];
 	rh = *sp;
@@ -494,7 +494,7 @@ void DrawBlood(int x, int y)
 	int i, j;
 	BYTE *sp;
 
-	auto setp = LoadFileInMem("Levels\\L2Data\\Blood2.DUN", nullptr);
+	auto setp = LoadFileInMem("Levels\\L2Data\\Blood2.DUN");
 	rw = setp[0];
 	sp = &setp[2];
 	rh = *sp;

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -10,6 +10,7 @@
 #include "engine.h"
 #include "gendung.h"
 #include "textdat.h"
+#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 
@@ -66,7 +67,7 @@ struct QuestData {
 };
 
 extern bool questlog;
-extern BYTE *pQLogCel;
+extern std::optional<CelSprite> pQLogCel;
 extern QuestStruct quests[MAXQUESTS];
 extern int ReturnLvlX;
 extern int ReturnLvlY;

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -471,7 +471,7 @@ RenderTile(CelOutputBuffer out, int x, int y)
 	x += BUFFER_BORDER_LEFT;
 	y += BUFFER_BORDER_TOP;
 
-	pFrameTable = (DWORD *)pDungeonCels;
+	pFrameTable = reinterpret_cast<DWORD *>(pDungeonCels.get());
 
 	src = &pDungeonCels[SDL_SwapLE32(pFrameTable[level_cel_block & 0xFFF])];
 	tile = (level_cel_block & 0x7000) >> 12;

--- a/Source/setmaps.cpp
+++ b/Source/setmaps.cpp
@@ -121,12 +121,11 @@ void DRLG_SetMapTrans(const char *sFileName)
 {
 	int x, y;
 	int i, j;
-	BYTE *pLevelMap;
 	BYTE *d;
 	DWORD dwOffset;
 
-	pLevelMap = LoadFileInMem(sFileName, nullptr);
-	d = pLevelMap + 2;
+	auto pLevelMap = LoadFileInMem(sFileName, nullptr);
+	d = &pLevelMap[2];
 	x = pLevelMap[0];
 	y = *d;
 	dwOffset = (x * y + 1) * 2;
@@ -141,7 +140,6 @@ void DRLG_SetMapTrans(const char *sFileName)
 			d += 2;
 		}
 	}
-	mem_free_dbg(pLevelMap);
 }
 
 /**

--- a/Source/setmaps.cpp
+++ b/Source/setmaps.cpp
@@ -124,7 +124,7 @@ void DRLG_SetMapTrans(const char *sFileName)
 	BYTE *d;
 	DWORD dwOffset;
 
-	auto pLevelMap = LoadFileInMem(sFileName, nullptr);
+	auto pLevelMap = LoadFileInMem(sFileName);
 	d = &pLevelMap[2];
 	x = pLevelMap[0];
 	y = *d;

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -82,7 +82,7 @@ text_color GetItemTextColor(ItemStruct &item)
 
 void DrawSTextBack(const CelOutputBuffer &out)
 {
-	CelDrawTo(out, PANEL_X + 344, 327 + UI_OFFSET_Y, pSTextBoxCels, 1, 271);
+	CelDrawTo(out, PANEL_X + 344, 327 + UI_OFFSET_Y, *pSTextBoxCels, 1);
 	DrawHalfTransparentRectTo(out, PANEL_X + 347, UI_OFFSET_Y + 28, 265, 297);
 }
 
@@ -93,16 +93,16 @@ void DrawSSlider(const CelOutputBuffer &out, int y1, int y2)
 	yd1 = y1 * 12 + 44 + UI_OFFSET_Y;
 	yd2 = y2 * 12 + 44 + UI_OFFSET_Y;
 	if (stextscrlubtn != -1)
-		CelDrawTo(out, PANEL_X + 601, yd1, pSTextSlidCels, 12, 12);
+		CelDrawTo(out, PANEL_X + 601, yd1, *pSTextSlidCels, 12);
 	else
-		CelDrawTo(out, PANEL_X + 601, yd1, pSTextSlidCels, 10, 12);
+		CelDrawTo(out, PANEL_X + 601, yd1, *pSTextSlidCels, 10);
 	if (stextscrldbtn != -1)
-		CelDrawTo(out, PANEL_X + 601, yd2, pSTextSlidCels, 11, 12);
+		CelDrawTo(out, PANEL_X + 601, yd2, *pSTextSlidCels, 11);
 	else
-		CelDrawTo(out, PANEL_X + 601, yd2, pSTextSlidCels, 9, 12);
+		CelDrawTo(out, PANEL_X + 601, yd2, *pSTextSlidCels, 9);
 	yd1 += 12;
 	for (yd3 = yd1; yd3 < yd2; yd3 += 12) {
-		CelDrawTo(out, PANEL_X + 601, yd3, pSTextSlidCels, 14, 12);
+		CelDrawTo(out, PANEL_X + 601, yd3, *pSTextSlidCels, 14);
 	}
 	if (stextsel == 22)
 		yd3 = stextlhold;
@@ -112,7 +112,7 @@ void DrawSSlider(const CelOutputBuffer &out, int y1, int y2)
 		yd3 = 1000 * (stextsval + ((yd3 - stextup) / 4)) / (storenumh - 1) * (y2 * 12 - y1 * 12 - 24) / 1000;
 	else
 		yd3 = 0;
-	CelDrawTo(out, PANEL_X + 601, (y1 + 1) * 12 + 44 + UI_OFFSET_Y + yd3, pSTextSlidCels, 13, 12);
+	CelDrawTo(out, PANEL_X + 601, (y1 + 1) * 12 + 44 + UI_OFFSET_Y + yd3, *pSTextSlidCels, 13);
 }
 
 void AddSLine(int y)
@@ -2058,9 +2058,9 @@ void S_DrunkEnter()
 
 ItemStruct golditem;
 
-BYTE *pSTextBoxCels;
-BYTE *pSPentSpn2Cels;
-BYTE *pSTextSlidCels;
+std::optional<CelSprite> pSTextBoxCels;
+std::optional<CelSprite> pSPentSpn2Cels;
+std::optional<CelSprite> pSTextSlidCels;
 
 talk_id stextflag;
 
@@ -2105,9 +2105,9 @@ void AddStoreHoldRepair(ItemStruct *itm, int i)
 
 void InitStores()
 {
-	pSTextBoxCels = LoadFileInMem("Data\\TextBox2.CEL", nullptr);
-	pSPentSpn2Cels = LoadFileInMem("Data\\PentSpn2.CEL", nullptr);
-	pSTextSlidCels = LoadFileInMem("Data\\TextSlid.CEL", nullptr);
+	pSTextBoxCels = LoadCel("Data\\TextBox2.CEL", 271);
+	pSPentSpn2Cels = LoadCel("Data\\PentSpn2.CEL", 12);
+	pSTextSlidCels = LoadCel("Data\\TextSlid.CEL", 12);
 	ClearSText(0, STORE_LINES);
 	stextflag = STORE_NONE;
 	stextsize = false;
@@ -2156,9 +2156,9 @@ void SetupTownStores()
 
 void FreeStoreMem()
 {
-	MemFreeDbg(pSTextBoxCels);
-	MemFreeDbg(pSPentSpn2Cels);
-	MemFreeDbg(pSTextSlidCels);
+	pSTextBoxCels = std::nullopt;
+	pSPentSpn2Cels = std::nullopt;
+	pSTextSlidCels = std::nullopt;
 }
 
 void PrintSString(const CelOutputBuffer &out, int x, int y, bool cjustflag, const char *str, text_color col, int val)
@@ -2190,7 +2190,7 @@ void PrintSString(const CelOutputBuffer &out, int x, int y, bool cjustflag, cons
 		sx += k;
 	}
 	if (stextsel == y) {
-		CelDrawTo(out, cjustflag ? xx + x + k - 20 : xx + x - 20, s + 45 + UI_OFFSET_Y, pSPentSpn2Cels, PentSpn2Spin(), 12);
+		CelDrawTo(out, cjustflag ? xx + x + k - 20 : xx + x - 20, s + 45 + UI_OFFSET_Y, *pSPentSpn2Cels, PentSpn2Spin());
 	}
 	for (i = 0; i < len; i++) {
 		c = fontframe[gbFontTransTbl[(BYTE)str[i]]];
@@ -2213,7 +2213,7 @@ void PrintSString(const CelOutputBuffer &out, int x, int y, bool cjustflag, cons
 		}
 	}
 	if (stextsel == y) {
-		CelDrawTo(out, cjustflag ? (xx + x + k + 4) : (PANEL_X + 596 - x), s + 45 + UI_OFFSET_Y, pSPentSpn2Cels, PentSpn2Spin(), 12);
+		CelDrawTo(out, cjustflag ? (xx + x + k + 4) : (PANEL_X + 596 - x), s + 45 + UI_OFFSET_Y, *pSPentSpn2Cels, PentSpn2Spin());
 	}
 }
 

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -7,6 +7,7 @@
 
 #include "control.h"
 #include "engine.h"
+#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 
@@ -54,11 +55,11 @@ struct STextStruct {
 };
 
 /** Shop frame graphics */
-extern BYTE *pSTextBoxCels;
+extern std::optional<CelSprite> pSTextBoxCels;
 /** Small text selection cursor */
-extern BYTE *pSPentSpn2Cels;
+extern std::optional<CelSprite> pSPentSpn2Cels;
 /** Scrollbar graphics */
-extern BYTE *pSTextSlidCels;
+extern std::optional<CelSprite> pSTextSlidCels;
 
 /** Currently active store */
 extern talk_id stextflag;

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -165,7 +165,6 @@ void TownCloseGrave()
 void T_Pass3()
 {
 	int xx, yy, x;
-	BYTE *P3Tiles, *pSector;
 
 	for (yy = 0; yy < MAXDUNY; yy += 2) {
 		for (xx = 0; xx < MAXDUNX; xx += 2) {
@@ -176,31 +175,35 @@ void T_Pass3()
 		}
 	}
 
-	P3Tiles = LoadFileInMem("Levels\\TownData\\Town.TIL", nullptr);
-	pSector = LoadFileInMem("Levels\\TownData\\Sector1s.DUN", nullptr);
-	T_FillSector(P3Tiles, pSector, 46, 46, 25, 25);
-	mem_free_dbg(pSector);
-	pSector = LoadFileInMem("Levels\\TownData\\Sector2s.DUN", nullptr);
-	T_FillSector(P3Tiles, pSector, 46, 0, 25, 23);
-	mem_free_dbg(pSector);
-	pSector = LoadFileInMem("Levels\\TownData\\Sector3s.DUN", nullptr);
-	T_FillSector(P3Tiles, pSector, 0, 46, 23, 25);
-	mem_free_dbg(pSector);
-	pSector = LoadFileInMem("Levels\\TownData\\Sector4s.DUN", nullptr);
-	T_FillSector(P3Tiles, pSector, 0, 0, 23, 23);
-	mem_free_dbg(pSector);
+	auto P3Tiles = LoadFileInMem("Levels\\TownData\\Town.TIL", nullptr);
+	{
+		auto pSector = LoadFileInMem("Levels\\TownData\\Sector1s.DUN", nullptr);
+		T_FillSector(P3Tiles.get(), pSector.get(), 46, 46, 25, 25);
+	}
+	{
+		auto pSector = LoadFileInMem("Levels\\TownData\\Sector2s.DUN", nullptr);
+		T_FillSector(P3Tiles.get(), pSector.get(), 46, 0, 25, 23);
+	}
+	{
+		auto pSector = LoadFileInMem("Levels\\TownData\\Sector3s.DUN", nullptr);
+		T_FillSector(P3Tiles.get(), pSector.get(), 0, 46, 23, 25);
+	}
+	{
+		auto pSector = LoadFileInMem("Levels\\TownData\\Sector4s.DUN", nullptr);
+		T_FillSector(P3Tiles.get(), pSector.get(), 0, 0, 23, 23);
+	}
 
 	if (gbIsSpawn || !gbIsMultiplayer) {
 		if (gbIsSpawn || (!(plr[myplr].pTownWarps & 1) && (!gbIsHellfire || plr[myplr]._pLevel < 10))) {
-			T_FillTile(P3Tiles, 48, 20, 320);
+			T_FillTile(P3Tiles.get(), 48, 20, 320);
 		}
 		if (gbIsSpawn || (!(plr[myplr].pTownWarps & 2) && (!gbIsHellfire || plr[myplr]._pLevel < 15))) {
-			T_FillTile(P3Tiles, 16, 68, 332);
-			T_FillTile(P3Tiles, 16, 70, 331);
+			T_FillTile(P3Tiles.get(), 16, 68, 332);
+			T_FillTile(P3Tiles.get(), 16, 70, 331);
 		}
 		if (gbIsSpawn || (!(plr[myplr].pTownWarps & 4) && (!gbIsHellfire || plr[myplr]._pLevel < 20))) {
 			for (x = 36; x < 46; x++) {
-				T_FillTile(P3Tiles, x, 78, GenerateRnd(4) + 1);
+				T_FillTile(P3Tiles.get(), x, 78, GenerateRnd(4) + 1);
 			}
 		}
 	}
@@ -218,12 +221,10 @@ void T_Pass3()
 	}
 
 	if (quests[Q_PWATER]._qactive != QUEST_DONE && quests[Q_PWATER]._qactive != QUEST_NOTAVAIL) {
-		T_FillTile(P3Tiles, 60, 70, 342);
+		T_FillTile(P3Tiles.get(), 60, 70, 342);
 	} else {
-		T_FillTile(P3Tiles, 60, 70, 71);
+		T_FillTile(P3Tiles.get(), 60, 70, 71);
 	}
-
-	mem_free_dbg(P3Tiles);
 }
 
 } // namespace

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -175,21 +175,21 @@ void T_Pass3()
 		}
 	}
 
-	auto P3Tiles = LoadFileInMem("Levels\\TownData\\Town.TIL", nullptr);
+	auto P3Tiles = LoadFileInMem("Levels\\TownData\\Town.TIL");
 	{
-		auto pSector = LoadFileInMem("Levels\\TownData\\Sector1s.DUN", nullptr);
+		auto pSector = LoadFileInMem("Levels\\TownData\\Sector1s.DUN");
 		T_FillSector(P3Tiles.get(), pSector.get(), 46, 46, 25, 25);
 	}
 	{
-		auto pSector = LoadFileInMem("Levels\\TownData\\Sector2s.DUN", nullptr);
+		auto pSector = LoadFileInMem("Levels\\TownData\\Sector2s.DUN");
 		T_FillSector(P3Tiles.get(), pSector.get(), 46, 0, 25, 23);
 	}
 	{
-		auto pSector = LoadFileInMem("Levels\\TownData\\Sector3s.DUN", nullptr);
+		auto pSector = LoadFileInMem("Levels\\TownData\\Sector3s.DUN");
 		T_FillSector(P3Tiles.get(), pSector.get(), 0, 46, 23, 25);
 	}
 	{
-		auto pSector = LoadFileInMem("Levels\\TownData\\Sector4s.DUN", nullptr);
+		auto pSector = LoadFileInMem("Levels\\TownData\\Sector4s.DUN");
 		T_FillSector(P3Tiles.get(), pSector.get(), 0, 0, 23, 23);
 	}
 

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -233,7 +233,7 @@ void InitSmith()
 
 	InitTownerInfo(numtowners, 96, true, TOWN_SMITH, 62, 63, 0);
 	InitQstSnds(numtowners, TOWN_SMITH);
-	towners[numtowners]._tNData = LoadFileInMem("Towners\\Smith\\SmithN.CEL", nullptr);
+	towners[numtowners]._tNData = LoadFileInMem("Towners\\Smith\\SmithN.CEL");
 	for (i = 0; i < 8; i++) {
 		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
@@ -247,7 +247,7 @@ void InitBarOwner()
 {
 	InitTownerInfo(numtowners, 96, true, TOWN_TAVERN, 55, 62, 3);
 	InitQstSnds(numtowners, TOWN_TAVERN);
-	towners[numtowners]._tNData = LoadFileInMem("Towners\\TwnF\\TwnFN.CEL", nullptr);
+	towners[numtowners]._tNData = LoadFileInMem("Towners\\TwnF\\TwnFN.CEL");
 	for (auto &towner : towners[numtowners]._tNAnim) {
 		towner = towners[numtowners]._tNData.get();
 	}
@@ -263,7 +263,7 @@ void InitTownDead()
 
 	InitTownerInfo(numtowners, 96, true, TOWN_DEADGUY, 24, 32, -1);
 	InitQstSnds(numtowners, TOWN_DEADGUY);
-	towners[numtowners]._tNData = LoadFileInMem("Towners\\Butch\\Deadguy.CEL", nullptr);
+	towners[numtowners]._tNData = LoadFileInMem("Towners\\Butch\\Deadguy.CEL");
 	for (i = 0; i < 8; i++) {
 		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
@@ -279,7 +279,7 @@ void InitWitch()
 
 	InitTownerInfo(numtowners, 96, true, TOWN_WITCH, 80, 20, 5);
 	InitQstSnds(numtowners, TOWN_WITCH);
-	towners[numtowners]._tNData = LoadFileInMem("Towners\\TownWmn1\\Witch.CEL", nullptr);
+	towners[numtowners]._tNData = LoadFileInMem("Towners\\TownWmn1\\Witch.CEL");
 	for (i = 0; i < 8; i++) {
 		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
@@ -295,7 +295,7 @@ void InitBarmaid()
 
 	InitTownerInfo(numtowners, 96, true, TOWN_BMAID, 43, 66, -1);
 	InitQstSnds(numtowners, TOWN_BMAID);
-	towners[numtowners]._tNData = LoadFileInMem("Towners\\TownWmn1\\WmnN.CEL", nullptr);
+	towners[numtowners]._tNData = LoadFileInMem("Towners\\TownWmn1\\WmnN.CEL");
 	for (i = 0; i < 8; i++) {
 		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
@@ -311,7 +311,7 @@ void InitBoy()
 
 	InitTownerInfo(numtowners, 96, true, TOWN_PEGBOY, 11, 53, -1);
 	InitQstSnds(numtowners, TOWN_PEGBOY);
-	towners[numtowners]._tNData = LoadFileInMem("Towners\\TownBoy\\PegKid1.CEL", nullptr);
+	towners[numtowners]._tNData = LoadFileInMem("Towners\\TownBoy\\PegKid1.CEL");
 	for (i = 0; i < 8; i++) {
 		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
@@ -327,7 +327,7 @@ void InitHealer()
 
 	InitTownerInfo(numtowners, 96, true, TOWN_HEALER, 55, 79, 1);
 	InitQstSnds(numtowners, TOWN_HEALER);
-	towners[numtowners]._tNData = LoadFileInMem("Towners\\Healer\\Healer.CEL", nullptr);
+	towners[numtowners]._tNData = LoadFileInMem("Towners\\Healer\\Healer.CEL");
 	for (i = 0; i < 8; i++) {
 		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
@@ -343,7 +343,7 @@ void InitTeller()
 
 	InitTownerInfo(numtowners, 96, true, TOWN_STORY, 62, 71, 2);
 	InitQstSnds(numtowners, TOWN_STORY);
-	towners[numtowners]._tNData = LoadFileInMem("Towners\\Strytell\\Strytell.CEL", nullptr);
+	towners[numtowners]._tNData = LoadFileInMem("Towners\\Strytell\\Strytell.CEL");
 	for (i = 0; i < 8; i++) {
 		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
@@ -359,7 +359,7 @@ void InitDrunk()
 
 	InitTownerInfo(numtowners, 96, true, TOWN_DRUNK, 71, 84, 4);
 	InitQstSnds(numtowners, TOWN_DRUNK);
-	towners[numtowners]._tNData = LoadFileInMem("Towners\\Drunk\\TwnDrunk.CEL", nullptr);
+	towners[numtowners]._tNData = LoadFileInMem("Towners\\Drunk\\TwnDrunk.CEL");
 	for (i = 0; i < 8; i++) {
 		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
@@ -376,7 +376,7 @@ void InitCows()
 
 	//if ( pCowCels )
 	// assertion_failed(__LINE__, __FILE__, "! pCowCels");
-	pCowCels = LoadFileInMem("Towners\\Animals\\Cow.CEL", nullptr);
+	pCowCels = LoadFileInMem("Towners\\Animals\\Cow.CEL");
 	for (i = 0; i < 3; i++) {
 		x = TownCowX[i];
 		y = TownCowY[i];
@@ -409,7 +409,7 @@ void InitFarmer()
 
 	InitTownerInfo(numtowners, 96, true, TOWN_FARMER, 62, 16, -1);
 	InitQstSnds(numtowners, TOWN_FARMER);
-	towners[numtowners]._tNData = LoadFileInMem("Towners\\Farmer\\Farmrn2.CEL", nullptr);
+	towners[numtowners]._tNData = LoadFileInMem("Towners\\Farmer\\Farmrn2.CEL");
 	for (i = 0; i < 8; i++) {
 		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
@@ -426,9 +426,9 @@ void InitCowFarmer()
 	InitTownerInfo(numtowners, 96, true, TOWN_COWFARM, 61, 22, -1);
 	InitQstSnds(numtowners, TOWN_COWFARM);
 	if (quests[Q_JERSEY]._qactive != QUEST_DONE) {
-		towners[numtowners]._tNData = LoadFileInMem("Towners\\Farmer\\cfrmrn2.CEL", nullptr);
+		towners[numtowners]._tNData = LoadFileInMem("Towners\\Farmer\\cfrmrn2.CEL");
 	} else {
-		towners[numtowners]._tNData = LoadFileInMem("Towners\\Farmer\\mfrmrn2.CEL", nullptr);
+		towners[numtowners]._tNData = LoadFileInMem("Towners\\Farmer\\mfrmrn2.CEL");
 	}
 	for (i = 0; i < 8; i++) {
 		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
@@ -446,9 +446,9 @@ void InitGirl()
 	InitTownerInfo(numtowners, 96, true, TOWN_GIRL, 77, 43, -1);
 	InitQstSnds(numtowners, TOWN_GIRL);
 	if (quests[Q_GIRL]._qactive != QUEST_DONE) {
-		towners[numtowners]._tNData = LoadFileInMem("Towners\\Girl\\Girlw1.CEL", nullptr);
+		towners[numtowners]._tNData = LoadFileInMem("Towners\\Girl\\Girlw1.CEL");
 	} else {
-		towners[numtowners]._tNData = LoadFileInMem("Towners\\Girl\\Girls1.CEL", nullptr);
+		towners[numtowners]._tNData = LoadFileInMem("Towners\\Girl\\Girls1.CEL");
 	}
 	for (i = 0; i < 8; i++) {
 		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -12,12 +12,14 @@
 #include "utils/language.h"
 
 namespace devilution {
+namespace {
+std::unique_ptr<BYTE[]> pCowCels;
+} // namespace
 
 bool storeflag;
 int sgnCowMsg;
 int numtowners;
 DWORD sgdwCowClicks;
-BYTE *pCowCels;
 TownerStruct towners[NUM_TOWNERS];
 
 /**
@@ -233,7 +235,7 @@ void InitSmith()
 	InitQstSnds(numtowners, TOWN_SMITH);
 	towners[numtowners]._tNData = LoadFileInMem("Towners\\Smith\\SmithN.CEL", nullptr);
 	for (i = 0; i < 8; i++) {
-		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData;
+		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
 	towners[numtowners]._tNFrames = 16;
 	NewTownerAnim(numtowners, towners[numtowners]._tNAnim[DIR_SW], towners[numtowners]._tNFrames, 3);
@@ -247,7 +249,7 @@ void InitBarOwner()
 	InitQstSnds(numtowners, TOWN_TAVERN);
 	towners[numtowners]._tNData = LoadFileInMem("Towners\\TwnF\\TwnFN.CEL", nullptr);
 	for (auto &towner : towners[numtowners]._tNAnim) {
-		towner = towners[numtowners]._tNData;
+		towner = towners[numtowners]._tNData.get();
 	}
 	towners[numtowners]._tNFrames = 16;
 	NewTownerAnim(numtowners, towners[numtowners]._tNAnim[DIR_SW], towners[numtowners]._tNFrames, 3);
@@ -263,7 +265,7 @@ void InitTownDead()
 	InitQstSnds(numtowners, TOWN_DEADGUY);
 	towners[numtowners]._tNData = LoadFileInMem("Towners\\Butch\\Deadguy.CEL", nullptr);
 	for (i = 0; i < 8; i++) {
-		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData;
+		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
 	towners[numtowners]._tNFrames = 8;
 	NewTownerAnim(numtowners, towners[numtowners]._tNAnim[DIR_N], towners[numtowners]._tNFrames, 6);
@@ -279,7 +281,7 @@ void InitWitch()
 	InitQstSnds(numtowners, TOWN_WITCH);
 	towners[numtowners]._tNData = LoadFileInMem("Towners\\TownWmn1\\Witch.CEL", nullptr);
 	for (i = 0; i < 8; i++) {
-		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData;
+		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
 	towners[numtowners]._tNFrames = 19;
 	NewTownerAnim(numtowners, towners[numtowners]._tNAnim[DIR_S], towners[numtowners]._tNFrames, 6);
@@ -295,7 +297,7 @@ void InitBarmaid()
 	InitQstSnds(numtowners, TOWN_BMAID);
 	towners[numtowners]._tNData = LoadFileInMem("Towners\\TownWmn1\\WmnN.CEL", nullptr);
 	for (i = 0; i < 8; i++) {
-		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData;
+		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
 	towners[numtowners]._tNFrames = 18;
 	NewTownerAnim(numtowners, towners[numtowners]._tNAnim[DIR_S], towners[numtowners]._tNFrames, 6);
@@ -311,7 +313,7 @@ void InitBoy()
 	InitQstSnds(numtowners, TOWN_PEGBOY);
 	towners[numtowners]._tNData = LoadFileInMem("Towners\\TownBoy\\PegKid1.CEL", nullptr);
 	for (i = 0; i < 8; i++) {
-		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData;
+		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
 	towners[numtowners]._tNFrames = 20;
 	NewTownerAnim(numtowners, towners[numtowners]._tNAnim[DIR_S], towners[numtowners]._tNFrames, 6);
@@ -327,7 +329,7 @@ void InitHealer()
 	InitQstSnds(numtowners, TOWN_HEALER);
 	towners[numtowners]._tNData = LoadFileInMem("Towners\\Healer\\Healer.CEL", nullptr);
 	for (i = 0; i < 8; i++) {
-		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData;
+		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
 	towners[numtowners]._tNFrames = 20;
 	NewTownerAnim(numtowners, towners[numtowners]._tNAnim[DIR_SE], towners[numtowners]._tNFrames, 6);
@@ -343,7 +345,7 @@ void InitTeller()
 	InitQstSnds(numtowners, TOWN_STORY);
 	towners[numtowners]._tNData = LoadFileInMem("Towners\\Strytell\\Strytell.CEL", nullptr);
 	for (i = 0; i < 8; i++) {
-		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData;
+		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
 	towners[numtowners]._tNFrames = 25;
 	NewTownerAnim(numtowners, towners[numtowners]._tNAnim[DIR_S], towners[numtowners]._tNFrames, 3);
@@ -359,7 +361,7 @@ void InitDrunk()
 	InitQstSnds(numtowners, TOWN_DRUNK);
 	towners[numtowners]._tNData = LoadFileInMem("Towners\\Drunk\\TwnDrunk.CEL", nullptr);
 	for (i = 0; i < 8; i++) {
-		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData;
+		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
 	towners[numtowners]._tNFrames = 18;
 	NewTownerAnim(numtowners, towners[numtowners]._tNAnim[DIR_S], towners[numtowners]._tNFrames, 3);
@@ -380,8 +382,8 @@ void InitCows()
 		y = TownCowY[i];
 		dir = TownCowDir[i];
 		InitTownerInfo(numtowners, 128, false, TOWN_COW, x, y, -1);
-		towners[numtowners]._tNData = pCowCels;
-		SetTownerGPtrs(towners[numtowners]._tNData, towners[numtowners]._tNAnim);
+		towners[numtowners]._tNData = nullptr;
+		SetTownerGPtrs(pCowCels.get(), towners[numtowners]._tNAnim);
 		towners[numtowners]._tNFrames = 12;
 		NewTownerAnim(numtowners, towners[numtowners]._tNAnim[dir], towners[numtowners]._tNFrames, 3);
 		towners[numtowners]._tAnimFrame = GenerateRnd(11) + 1;
@@ -409,7 +411,7 @@ void InitFarmer()
 	InitQstSnds(numtowners, TOWN_FARMER);
 	towners[numtowners]._tNData = LoadFileInMem("Towners\\Farmer\\Farmrn2.CEL", nullptr);
 	for (i = 0; i < 8; i++) {
-		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData;
+		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
 	towners[numtowners]._tNFrames = 15;
 	NewTownerAnim(numtowners, towners[numtowners]._tNAnim[DIR_S], towners[numtowners]._tNFrames, 3);
@@ -429,7 +431,7 @@ void InitCowFarmer()
 		towners[numtowners]._tNData = LoadFileInMem("Towners\\Farmer\\mfrmrn2.CEL", nullptr);
 	}
 	for (i = 0; i < 8; i++) {
-		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData;
+		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
 	towners[numtowners]._tNFrames = 15;
 	NewTownerAnim(numtowners, towners[numtowners]._tNAnim[DIR_SW], towners[numtowners]._tNFrames, 3);
@@ -449,7 +451,7 @@ void InitGirl()
 		towners[numtowners]._tNData = LoadFileInMem("Towners\\Girl\\Girls1.CEL", nullptr);
 	}
 	for (i = 0; i < 8; i++) {
-		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData;
+		towners[numtowners]._tNAnim[i] = towners[numtowners]._tNData.get();
 	}
 	towners[numtowners]._tNFrames = 20;
 	NewTownerAnim(numtowners, towners[numtowners]._tNAnim[DIR_S], towners[numtowners]._tNFrames, 6);
@@ -490,14 +492,10 @@ void FreeTownerGFX()
 	int i;
 
 	for (i = 0; i < NUM_TOWNERS; i++) {
-		if (towners[i]._tNData == pCowCels) {
-			towners[i]._tNData = nullptr;
-		} else if (towners[i]._tNData != nullptr) {
-			MemFreeDbg(towners[i]._tNData);
-		}
+		towners[i]._tNData = nullptr;
 	}
 
-	MemFreeDbg(pCowCels);
+	pCowCels = nullptr;
 }
 
 void TownCtrlMsg(int i)

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 
 #include "items.h"
 #include "player.h"
@@ -40,7 +41,7 @@ struct TNQ {
 
 struct TownerStruct {
 	uint8_t *_tNAnim[8];
-	uint8_t *_tNData;
+	std::unique_ptr<BYTE[]> _tNData;
 	uint8_t *_tAnimData;
 	int16_t _tSeed;
 	/** Tile position of NPC */


### PR DESCRIPTION
Instead of passing the CEL sprite width when drawing, store the CEL width at load time in the new `CelSprite` struct.

Implemented for most sprites except towners, missiles, or monsters.