### PR TITLE
🐞 items.cpp: Fix nullopt access

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2257,7 +2257,7 @@ void SetupItem(int i)
 	int it;
 
 	it = ItemCAnimTbl[items[i]._iCurs];
-	items[i]._iAnimData = &*itemanims[it];
+	items[i]._iAnimData = itemanims[it] ? &*itemanims[it] : nullptr;
 	items[i]._iAnimLen = ItemAnimLs[it];
 	items[i]._iAnimWidth = ItemAnimWidth;
 	items[i]._iIdentified = false;


### PR DESCRIPTION
A better fix would probably be to not call this function in the first place before the graphics are loaded. @thebigMuh 