### PR TITLE
♻️  Remove `_iAnimWidth`

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -23,7 +23,6 @@
 namespace devilution {
 namespace {
 std::optional<CelSprite> itemanims[ITEMTYPES];
-constexpr int ItemAnimWidth = 96;
 
 } // namespace
 
@@ -2259,7 +2258,6 @@ void SetupItem(int i)
 	it = ItemCAnimTbl[items[i]._iCurs];
 	items[i]._iAnimData = itemanims[it] ? &*itemanims[it] : nullptr;
 	items[i]._iAnimLen = ItemAnimLs[it];
-	items[i]._iAnimWidth = ItemAnimWidth;
 	items[i]._iIdentified = false;
 	items[i]._iPostDraw = false;
 
@@ -2969,7 +2967,6 @@ void RespawnItem(ItemStruct *item, bool FlipFlag)
 	it = ItemCAnimTbl[item->_iCurs];
 	item->_iAnimData = &*itemanims[it];
 	item->_iAnimLen = ItemAnimLs[it];
-	item->_iAnimWidth = ItemAnimWidth;
 	item->_iPostDraw = false;
 	item->_iRequest = false;
 	if (FlipFlag) {

--- a/Source/items.h
+++ b/Source/items.h
@@ -163,6 +163,9 @@ enum icreateinfo_flag2 {
 	// clang-format on
 };
 
+// All item animation frames have this width.
+constexpr int ItemAnimWidth = 96;
+
 struct ItemStruct {
 	int32_t _iSeed;
 	uint16_t _iCreateInfo;
@@ -172,7 +175,6 @@ struct ItemStruct {
 	CelSprite *_iAnimData; // PSX name -> ItemFrame
 	uint8_t _iAnimLen;   // Number of frames in current animation
 	uint8_t _iAnimFrame; // Current frame of animation.
-	int _iAnimWidth;
 	bool _iDelFlag;   // set when item is flagged for deletion, deprecated in 1.02
 	uint8_t _iSelFlag;
 	bool _iPostDraw;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -218,9 +218,7 @@ static void LoadItemData(LoadHelper *file, ItemStruct *pItem)
 	file->skip(4); // Skip pointer _iAnimData
 	pItem->_iAnimLen = file->nextLE<int32_t>();
 	pItem->_iAnimFrame = file->nextLE<int32_t>();
-	pItem->_iAnimWidth = file->nextLE<int32_t>();
-	// Skip _iAnimWidth2
-	file->skip(4);
+	file->skip(8); // Skip _iAnimWidth and _iAnimWidth2
 	file->skip(4); // Unused since 1.02
 	pItem->_iSelFlag = file->nextLE<uint8_t>();
 	file->skip(3); // Alignment
@@ -1206,9 +1204,10 @@ static void SaveItem(SaveHelper *file, ItemStruct *pItem)
 	file->skip(4); // Skip pointer _iAnimData
 	file->writeLE<int32_t>(pItem->_iAnimLen);
 	file->writeLE<int32_t>(pItem->_iAnimFrame);
-	file->writeLE<int32_t>(pItem->_iAnimWidth);
+	// write _iAnimWidth for vanilla compatibility
+	file->writeLE<int32_t>(ItemAnimWidth);
 	// write _iAnimWidth2 for vanilla compatibility
-	file->writeLE<int32_t>(CalculateWidth2(pItem->_iAnimWidth));
+	file->writeLE<int32_t>(CalculateWidth2(ItemAnimWidth));
 	file->skip(4); // Unused since 1.02
 	file->writeLE<uint8_t>(pItem->_iSelFlag);
 	file->skip(3); // Alignment


### PR DESCRIPTION
No longer needed as of #1796

We could probably go further and not expose `ItemAnimWidth`,
but it'd be dangerous because sometimes `_iAnimData` is null.