### PR TITLE
♻️  Make `SFileRw` own the Storm file handle

### DIFF
--- a/Source/storm/storm_sdl_rw.cpp
+++ b/Source/storm/storm_sdl_rw.cpp
@@ -71,6 +71,7 @@ static int SFileRwRead(struct SDL_RWops *context, void *ptr, int size, int maxnu
 
 static int SFileRwClose(struct SDL_RWops *context)
 {
+	SFileCloseFile(SFileRwGetHandle(context));
 	delete context;
 	return 0;
 }

--- a/Source/storm/storm_sdl_rw.h
+++ b/Source/storm/storm_sdl_rw.h
@@ -9,7 +9,7 @@ namespace devilution {
 /**
  * @brief Creates a read-only SDL_RWops from a Storm file handle.
  *
- * Does not close the handle when it gets closed.
+ * Closes the handle when it gets closed.
  */
 SDL_RWops *SFileRw_FromStormHandle(HANDLE handle);
 

--- a/Source/utils/soundsample.h
+++ b/Source/utils/soundsample.h
@@ -16,7 +16,6 @@ public:
 	SoundSample() = default;
 	SoundSample(SoundSample &&) noexcept = default;
 	SoundSample &operator=(SoundSample &&) noexcept = default;
-	~SoundSample();
 
 	void Release();
 	bool IsPlaying();
@@ -51,8 +50,7 @@ private:
 	ArraySharedPtr<std::uint8_t> file_data_;
 	std::size_t file_data_size_;
 
-	// Streaming audio fields:
-	HANDLE file_handle_ = nullptr;
+	// Set for streaming audio to allow for duplicating it:
 	std::string file_path_;
 
 	std::unique_ptr<Aulib::Stream> stream_;


### PR DESCRIPTION
All of our use-cases for `SDL_RWops` Storm file require closing the file when closing the `SDL_RWops` -- doing this automatically simplifies the code.