### PR TITLE
💨 Do not zero-initalize arrays that we write to

### DIFF
--- a/Source/DiabloUI/art.cpp
+++ b/Source/DiabloUI/art.cpp
@@ -40,7 +40,7 @@ bool LoadPcxPixelsAndPalette(HANDLE handle, int width, int height, std::uint8_t 
 
 	// We read 1 extra byte because it delimits the palette.
 	const unsigned readSize = pixelDataSize + (has256ColorPalette ? PcxPaletteSize : 0);
-	std::unique_ptr<BYTE[]> fileBuffer = std::make_unique<BYTE[]>(readSize);
+	std::unique_ptr<BYTE[]> fileBuffer { new BYTE[readSize] };
 	if (!SFileReadFile(handle, fileBuffer.get(), readSize, nullptr, nullptr)) {
 		return false;
 	}

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -116,7 +116,7 @@ static BYTE *CaptureEnc(BYTE *src, BYTE *dst, int width)
 static bool CapturePix(const CelOutputBuffer &buf, std::ofstream *out)
 {
 	int width = buf.w();
-	auto pBuffer = std::make_unique<BYTE[]>(2 * width);
+	std::unique_ptr<BYTE[]> pBuffer { new BYTE[2 * width] };
 	BYTE *pixels = buf.begin();
 	for (int height = buf.h(); height > 0; height--) {
 		const BYTE *pBufferEnd = CaptureEnc(pixels, pBuffer.get(), width);

--- a/Source/encrypt.cpp
+++ b/Source/encrypt.cpp
@@ -97,13 +97,13 @@ static void PkwareBufferWrite(char *buf, unsigned int *size, void *param)
 
 uint32_t PkwareCompress(uint8_t *srcData, uint32_t size)
 {
-	auto ptr = std::make_unique<char[]>(CMP_BUFFER_SIZE);
+	std::unique_ptr<char[]> ptr { new char[CMP_BUFFER_SIZE] };
 
 	unsigned destSize = 2 * size;
 	if (destSize < 2 * 4096)
 		destSize = 2 * 4096;
 
-	auto destData = std::make_unique<uint8_t[]>(destSize);
+	std::unique_ptr<uint8_t[]> destData { new uint8_t[destSize] };
 
 	TDataInfo param;
 	param.srcData = srcData;
@@ -128,8 +128,8 @@ void PkwareDecompress(uint8_t *inBuff, int recvSize, int maxBytes)
 {
 	TDataInfo info;
 
-	auto ptr = std::make_unique<char[]>(CMP_BUFFER_SIZE);
-	auto outBuff = std::make_unique<uint8_t[]>(maxBytes);
+	std::unique_ptr<char[]> ptr { new char[CMP_BUFFER_SIZE] };
+	std::unique_ptr<uint8_t[]> outBuff { new uint8_t[maxBytes] };
 
 	info.srcData = inBuff;
 	info.srcOffset = 0;

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -727,7 +727,7 @@ std::unique_ptr<BYTE[]> LoadFileInMem(const char *pszName, DWORD *pdwFileLen)
 	if (fileLen == 0)
 		app_fatal("Zero length SFILE:\n%s", pszName);
 
-	auto buf = std::make_unique<BYTE[]>(fileLen);
+	std::unique_ptr<BYTE[]> buf { new BYTE[fileLen] };
 
 	SFileReadFile(file, buf.get(), fileLen, nullptr, nullptr);
 	SFileCloseFile(file);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -138,9 +138,9 @@ class SaveHelper {
 
 public:
 	SaveHelper(const char *szFileName, size_t bufferLen)
-		: m_szFileName(szFileName)
-		, m_buffer(std::make_unique<uint8_t[]>(codec_get_encoded_len(bufferLen)))
-		, m_capacity(bufferLen)
+	    : m_szFileName(szFileName)
+	    , m_buffer(new uint8_t[codec_get_encoded_len(bufferLen)])
+	    , m_capacity(bufferLen)
 	{
 	}
 

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -552,7 +552,7 @@ static bool mpqapi_write_file_contents(const char *pszName, const BYTE *pbData, 
 	// We populate the table of sector offset while we write the data.
 	// We can't pre-populate it because we don't know the compressed sector sizes yet.
 	// First offset is the start of the first sector, last offset is the end of the last sector.
-	auto sectoroffsettable = std::make_unique<uint32_t[]>(num_sectors + 1);
+	std::unique_ptr<uint32_t[]> sectoroffsettable { new uint32_t[num_sectors + 1] };
 
 #ifdef CAN_SEEKP_BEYOND_EOF
 	if (!cur_archive.stream.seekp(pBlk->offset + offset_table_bytesize, std::ios::beg))
@@ -565,7 +565,7 @@ static bool mpqapi_write_file_contents(const char *pszName, const BYTE *pbData, 
 	const std::uintmax_t cur_size = stream_end - cur_archive.stream_begin;
 	if (cur_size < pBlk->offset + offset_table_bytesize) {
 		if (cur_size < pBlk->offset) {
-			auto filler = std::make_unique<char[]>(pBlk->offset - cur_size);
+			std::unique_ptr<char[]> filler { new char[pBlk->offset - cur_size] };
 			if (!cur_archive.stream.write(filler.get(), pBlk->offset - cur_size))
 				return false;
 		}

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -144,7 +144,7 @@ static std::unique_ptr<uint8_t[]> pfile_read_archive(HANDLE archive, const char 
 	if (*pdwLen == 0)
 		return nullptr;
 
-	auto buf = std::make_unique<uint8_t[]>(*pdwLen);
+	std::unique_ptr<uint8_t[]> buf { new uint8_t[*pdwLen] };
 	if (!SFileReadFile(file, buf.get(), *pdwLen, &nread, nullptr))
 		return nullptr;
 	SFileCloseFile(file);
@@ -176,7 +176,7 @@ static bool pfile_read_hero(HANDLE archive, PkPlayerStruct *pPack)
 static void pfile_encode_hero(const PkPlayerStruct *pack)
 {
 	size_t packedLen = codec_get_encoded_len(sizeof(*pack));
-	auto packed = std::make_unique<uint8_t[]>(packedLen);
+	std::unique_ptr<uint8_t[]> packed { new uint8_t[packedLen] };
 
 	memcpy(packed.get(), pack, sizeof(*pack));
 	codec_encode(packed.get(), sizeof(*pack), packedLen, pfile_get_password());

--- a/Source/storm/storm_svid.cpp
+++ b/Source/storm/storm_svid.cpp
@@ -156,7 +156,7 @@ bool SVidPlayBegin(const char *filename, int flags, HANDLE *video)
 	SVidSMK = smk_open_filepointer(file, SMK_MODE_DISK);
 #else
 	int bytestoread = SFileGetFileSize(*video, nullptr);
-	SVidBuffer = std::make_unique<uint8_t[]>(bytestoread);
+	SVidBuffer = std::unique_ptr<uint8_t[]> { new uint8_t[bytestoread] };
 	SFileReadFile(*video, SVidBuffer.get(), bytestoread, nullptr, nullptr);
 	SFileCloseFile(*video);
 	*video = nullptr;

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -262,7 +262,7 @@ void LanguageInitialize()
 	}
 
 	// Read entries of source strings
-	auto src = std::make_unique<MoEntry[]>(head.nb_mappings);
+	std::unique_ptr<MoEntry[]> src { new MoEntry[head.nb_mappings] };
 	if (fseek(fp, head.src_offset, SEEK_SET) != 0)
 		return;
 	// FIXME: Endianness.
@@ -270,7 +270,7 @@ void LanguageInitialize()
 		return;
 
 	// Read entries of target strings
-	auto dst = std::make_unique<MoEntry[]>(head.nb_mappings);
+	std::unique_ptr<MoEntry[]> dst { new MoEntry[head.nb_mappings] };
 	if (fseek(fp, head.dst_offset, SEEK_SET) != 0)
 		return;
 	// FIXME: Endianness.


### PR DESCRIPTION
`std::make_unique<T[]>(size)` always zero-initalizes the array.

C++20 has `std::make_unique_for_overwrite` to avoid that, while older C++ versions can use the approach applied here.