### PR TITLE
🧹 CMake: Try removing freetype and png

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -663,7 +663,7 @@ endif()
 
 if(SWITCH)
   target_link_libraries(${BIN_TARGET} PRIVATE switch::libnx
-    -lfreetype -lEGL -lglapi -ldrm_nouveau -lpng -lbz2 -lz -lnx)
+    -lEGL -lglapi -ldrm_nouveau -lbz2 -lz -lnx)
 endif()
 
 if(AMIGA)


### PR DESCRIPTION
These SDL2_ttf dependencies should be picked up automatically by pkg-config