### PR TITLE
🐞 Fix spellbook rendering crash in hellfire

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -806,7 +806,7 @@ void InitControlPan()
 	pSpellBkCel = LoadCel("Data\\SpellBk.CEL", SPANEL_WIDTH);
 
 	if (gbIsHellfire) {
-		static const int SBkBtnHellfireWidths[] = { 61, 61, 61, 61, 76 };
+		static const int SBkBtnHellfireWidths[] = { 0, 61, 61, 61, 61, 61, 76 };
 		pSBkBtnCel = LoadCel("Data\\SpellBkB.CEL", SBkBtnHellfireWidths);
 	} else {
 		pSBkBtnCel = LoadCel("Data\\SpellBkB.CEL", 76);


### PR DESCRIPTION
Fixes a bug introduced in #1796
Frame numbers are 1-based and there are 6, not 5 frames there.