### PR TITLE
🌐 Lot of enhancements on Italian localization

### DIFF
--- a/Translations/it.po
+++ b/Translations/it.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-05-02 04:34+0200\n"
-"PO-Revision-Date: 2021-05-02 17:23+0200\n"
+"POT-Creation-Date: 2021-05-02 23:31+0200\n"
+"PO-Revision-Date: 2021-05-04 13:10+0200\n"
 "Last-Translator: Gianluca Boiano <morf3089@gmail.com>\n"
 "Language-Team: zuminator.altervista.org\n"
 "Language: it\n"
@@ -278,7 +278,7 @@ msgstr "Ringraziamenti a"
 
 #: Source/DiabloUI/credits_lines.cpp:265
 msgid "\t\t\tSpecial Thanks to Blizzard Entertainment"
-msgstr "\t\t\tCopyright © 1996-2001 Blizzard Entertainment"
+msgstr "\t\t\tRingraziamenti Speciali a Blizzard Entertainment"
 
 #: Source/DiabloUI/credits_lines.cpp:270
 msgid "\t\t\tSierra On-Line Inc. Northwest"
@@ -318,8 +318,7 @@ msgstr "L'Anello dei Mille"
 
 #: Source/DiabloUI/credits_lines.cpp:547
 msgid "\tNo souls were sold in the making of this game."
-msgstr ""
-"\tNessuna anima è stata venduta durante la realizzazione di questo gioco."
+msgstr "\tNessuna anima è stata venduta durante la realizzazione di questo gioco."
 
 #: Source/DiabloUI/dialogs.cpp:171 Source/DiabloUI/dialogs.cpp:184
 #: Source/DiabloUI/selconn.cpp:68 Source/DiabloUI/selgame.cpp:99
@@ -337,15 +336,15 @@ msgstr "Giocatore Singolo"
 
 #: Source/DiabloUI/mainmenu.cpp:37
 msgid "Multi Player"
-msgstr "Multigiocatore"
+msgstr "Multi Giocatore"
 
 #: Source/DiabloUI/mainmenu.cpp:38
 msgid "Replay Intro"
-msgstr "Mostra Intro"
+msgstr "Introduzione"
 
 #: Source/DiabloUI/mainmenu.cpp:39
 msgid "Support"
-msgstr "Assistenza"
+msgstr "Supporto"
 
 #: Source/DiabloUI/mainmenu.cpp:41
 msgid "Credits"
@@ -357,19 +356,19 @@ msgstr "Esci da Hellfire"
 
 #: Source/DiabloUI/mainmenu.cpp:44
 msgid "Show Credits"
-msgstr "Mostra Crediti"
+msgstr "Ringraziamenti"
 
 #: Source/DiabloUI/mainmenu.cpp:45
 msgid "Exit Diablo"
-msgstr "Esci"
+msgstr "Esci da Diablo"
 
 #: Source/DiabloUI/mainmenu.cpp:110
 msgid ""
-"The Diablo introduction cinematic is only available in the full retail "
-"version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
+"The Diablo introduction cinematic is only available in the full retail version of "
+"Diablo. Visit https://www.gog.com/game/diablo to purchase."
 msgstr ""
-"Il filmato introduttivo di Diablo è disponibile solo nella versione "
-"completa. Visita https://www.gog.com/game/diablo per acquistare."
+"Il filmato introduttivo di Diablo è disponibile solo nella versione completa. "
+"Visita https://www.gog.com/game/diablo per acquistare."
 
 #: Source/DiabloUI/progress.cpp:46 Source/DiabloUI/selconn.cpp:71
 #: Source/DiabloUI/selhero.cpp:210 Source/DiabloUI/selhero.cpp:236
@@ -389,7 +388,7 @@ msgstr "Loopback"
 #: Source/DiabloUI/selconn.cpp:42 Source/DiabloUI/selgame.cpp:439
 #: Source/DiabloUI/selgame.cpp:457
 msgid "Multi Player Game"
-msgstr "Multigiocatore"
+msgstr "Multi Giocatore"
 
 #: Source/DiabloUI/selconn.cpp:48
 msgid "Requirements:"
@@ -397,7 +396,7 @@ msgstr "Requisiti:"
 
 #: Source/DiabloUI/selconn.cpp:54
 msgid "no gateway needed"
-msgstr "gateway non richiesto"
+msgstr "senza gateway"
 
 #: Source/DiabloUI/selconn.cpp:60
 msgid "Select Connection"
@@ -435,7 +434,7 @@ msgstr "Seleziona Azione"
 #: Source/DiabloUI/selgame.cpp:93 Source/DiabloUI/selgame.cpp:156
 #: Source/DiabloUI/selgame.cpp:300
 msgid "Create Game"
-msgstr "Nuovo"
+msgstr "Crea Gioco"
 
 #: Source/DiabloUI/selgame.cpp:94
 msgid "Join Game"
@@ -453,8 +452,7 @@ msgstr "Crea un nuovo gioco con una difficoltà a tua scelta."
 
 #: Source/DiabloUI/selgame.cpp:114
 msgid ""
-"Enter an IP or a hostname and join a game already in progress at that "
-"address."
+"Enter an IP or a hostname and join a game already in progress at that address."
 msgstr ""
 "Inserisci un IP o un nome host e unisciti ad un gioco già iniziato a "
 "quell'indirizzo."
@@ -465,17 +463,17 @@ msgstr "Seleziona Difficoltà"
 
 #: Source/DiabloUI/selgame.cpp:161 Source/DiabloUI/selgame.cpp:208
 #: Source/DiabloUI/selgame.cpp:311 Source/DiabloUI/selgame.cpp:331
-#: Source/diablo.cpp:1449
+#: Source/diablo.cpp:1451
 msgid "Normal"
 msgstr "Normale"
 
 #: Source/DiabloUI/selgame.cpp:162 Source/DiabloUI/selgame.cpp:212
-#: Source/diablo.cpp:1450
+#: Source/diablo.cpp:1452
 msgid "Nightmare"
 msgstr "Incubo"
 
 #: Source/DiabloUI/selgame.cpp:163 Source/DiabloUI/selgame.cpp:216
-#: Source/diablo.cpp:1451
+#: Source/diablo.cpp:1453
 msgid "Hell"
 msgstr "Inferno"
 
@@ -493,49 +491,48 @@ msgid ""
 "This is where a starting character should begin the quest to defeat Diablo."
 msgstr ""
 "Difficoltà Normale\n"
-"Qui è dove un personaggio iniziale dovrebbe iniziare la missione "
-"persconfiggere Diablo."
+"Qui è dove un personaggio iniziale dovrebbe iniziare la missione persconfiggere "
+"Diablo."
 
 #: Source/DiabloUI/selgame.cpp:213
 msgid ""
 "Nightmare Difficulty\n"
-"The denizens of the Labyrinth have been bolstered and will prove to be a "
-"greater challenge. This is recommended for experienced characters only."
+"The denizens of the Labyrinth have been bolstered and will prove to be a greater "
+"challenge. This is recommended for experienced characters only."
 msgstr ""
 "Difficoltà Incubo\n"
-"Gli abitanti del Labirinto sono stati rafforzati e si rivelerà una sfidapiù "
+"Gli abitanti del Labirinto sono stati rafforzati e si rivelerà una sfida più "
 "grande. Raccomandato solo per personaggi esperti."
 
 #: Source/DiabloUI/selgame.cpp:217
 msgid ""
 "Hell Difficulty\n"
-"The most powerful of the underworld's creatures lurk at the gateway into "
-"Hell. Only the most experienced characters should venture in this realm."
+"The most powerful of the underworld's creatures lurk at the gateway into Hell. "
+"Only the most experienced characters should venture in this realm."
 msgstr ""
 "Difficoltà Inferno\n"
-"La più potente delle creature degli inferi si nasconde alle "
-"portedell'Inferno. Solo i personaggi più esperti dovrebbero avventurarsi "
-"inquesto regno."
+"La più potente delle creature degli inferi si nasconde alle porte dell'Inferno. "
+"Solo i personaggi più esperti dovrebbero avventurarsi in questo regno."
 
 #: Source/DiabloUI/selgame.cpp:232
 msgid ""
-"Your character must reach level 20 before you can enter a multiplayer game "
-"of Nightmare difficulty."
+"Your character must reach level 20 before you can enter a multiplayer game of "
+"Nightmare difficulty."
 msgstr ""
-"Il tuo personaggio deve raggiungere il livello 20 prima di poterpartecipare "
-"al multiplayer di difficoltà Incubo."
+"Il tuo personaggio deve raggiungere il livello 20 prima di poter partecipare al "
+"multi giocatore di difficoltà Incubo."
 
 #: Source/DiabloUI/selgame.cpp:234
 msgid ""
-"Your character must reach level 30 before you can enter a multiplayer game "
-"of Hell difficulty."
+"Your character must reach level 30 before you can enter a multiplayer game of Hell "
+"difficulty."
 msgstr ""
-"Il tuo personaggio deve raggiungere il livello 30 prima di poterpartecipare "
-"al multiplayer di difficoltà Inferno."
+"Il tuo personaggio deve raggiungere il livello 30 prima di poter partecipare al "
+"multi giocatore di difficoltà Inferno."
 
 #: Source/DiabloUI/selgame.cpp:309
 msgid "Select Game Speed"
-msgstr "Seleziona Velocità di Gioco"
+msgstr "Seleziona Ritmo di Gioco"
 
 #: Source/DiabloUI/selgame.cpp:312 Source/DiabloUI/selgame.cpp:335
 msgid "Fast"
@@ -554,40 +551,39 @@ msgid ""
 "Normal Speed\n"
 "This is where a starting character should begin the quest to defeat Diablo."
 msgstr ""
-"Velocità Normale\n"
+"Normale\n"
 "Qui è dove un personaggio agli inizi dovrebbe intraprendere la missione per "
 "sconfiggere Diablo."
 
 #: Source/DiabloUI/selgame.cpp:336
 msgid ""
 "Fast Speed\n"
-"The denizens of the Labyrinth have been hastened and will prove to be a "
-"greater challenge. This is recommended for experienced characters only."
+"The denizens of the Labyrinth have been hastened and will prove to be a greater "
+"challenge. This is recommended for experienced characters only."
 msgstr ""
 "Veloce\n"
-"Gli abitanti del Labirinto sono rapidi e dimostreranno di esser una sfida "
-"più grande. Consigliato solo a personaggi esperti."
+"Gli abitanti del Labirinto sono rapidi e dimostreranno di esser una sfida più "
+"grande. Consigliato solo a personaggi esperti."
 
 #: Source/DiabloUI/selgame.cpp:340
 msgid ""
 "Faster Speed\n"
-"Most monsters of the dungeon will seek you out quicker than ever before. "
-"Only an experienced champion should try their luck at this speed."
+"Most monsters of the dungeon will seek you out quicker than ever before. Only an "
+"experienced champion should try their luck at this speed."
 msgstr ""
 "Molto Veloce\n"
-"La maggior parte dei mostri del sotterraneo ti cercheranno più velocemente "
-"che mai. Solo un campione esperto dovrebbe tentare la fortuna a questa "
-"velocità."
+"La maggior parte dei mostri del sotterraneo ti cercheranno più velocemente che "
+"mai. Solo un campione esperto dovrebbe tentare la fortuna a questa velocità."
 
 #: Source/DiabloUI/selgame.cpp:344
 msgid ""
 "Fastest Speed\n"
-"The minions of the underworld will rush to attack without hesitation. Only a "
-"true speed demon should enter at this pace."
+"The minions of the underworld will rush to attack without hesitation. Only a true "
+"speed demon should enter at this pace."
 msgstr ""
 "Velocissimo\n"
-"I tirapiedi degli inferi si precipiteranno ad attaccare senza esitazione. "
-"Solo un vero demone della velocità dovrebbe entrare a questo ritmo."
+"I tirapiedi degli inferi si precipiteranno ad attaccare senza esitazione. Solo un "
+"vero demone della velocità dovrebbe entrare a questo ritmo."
 
 #: Source/DiabloUI/selgame.cpp:386
 msgid "Enter Password"
@@ -636,11 +632,11 @@ msgstr "Barbaro"
 
 #: Source/DiabloUI/selhero.cpp:214 Source/DiabloUI/selhero.cpp:293
 msgid "New Single Player Hero"
-msgstr "Nuovo Eroe Single Player"
+msgstr "Nuovo Eroe Giocatore Singolo"
 
 #: Source/DiabloUI/selhero.cpp:216 Source/DiabloUI/selhero.cpp:295
 msgid "New Multi Player Hero"
-msgstr "Nuovo Eroe Multi Player"
+msgstr "Nuovo Eroe Multi Giocatore"
 
 #: Source/DiabloUI/selhero.cpp:225
 msgid "Save File Exists"
@@ -650,22 +646,21 @@ msgstr "Salvataggio Esistente"
 msgid "Load Game"
 msgstr "Carica"
 
-#: Source/DiabloUI/selhero.cpp:229 Source/gamemenu.cpp:43
-#: Source/gamemenu.cpp:54
+#: Source/DiabloUI/selhero.cpp:229 Source/gamemenu.cpp:43 Source/gamemenu.cpp:54
 msgid "New Game"
 msgstr "Nuovo"
 
 #: Source/DiabloUI/selhero.cpp:239 Source/DiabloUI/selhero.cpp:575
 msgid "Single Player Characters"
-msgstr "Personaggi Single Player"
+msgstr "Personaggi Giocatore Singolo"
 
 #: Source/DiabloUI/selhero.cpp:287
 msgid ""
-"The Rogue and Sorcerer are only available in the full retail version of "
-"Diablo. Visit https://www.gog.com/game/diablo to purchase."
+"The Rogue and Sorcerer are only available in the full retail version of Diablo. "
+"Visit https://www.gog.com/game/diablo to purchase."
 msgstr ""
-"Il Ladro e il Mago sono disponibili solo nella versione completa diDiablo. "
-"Visita https://www.gog.com/game/diablo per acquistare."
+"Il Ladro e il Mago sono disponibili solo nella versione completa diDiablo. Visita "
+"https://www.gog.com/game/diablo per acquistare."
 
 #: Source/DiabloUI/selhero.cpp:299 Source/DiabloUI/selhero.cpp:305
 msgid "Enter Name"
@@ -676,8 +671,7 @@ msgid ""
 "Invalid name. A name cannot contain spaces, reserved characters, or reserved "
 "words.\n"
 msgstr ""
-"Nome non valido. Non può contenere spazi, caratteri speciali, o "
-"parolespeciali.\n"
+"Nome non valido. Non può contenere spazi, caratteri speciali, o parolespeciali.\n"
 "\n"
 
 #: Source/DiabloUI/selhero.cpp:345
@@ -719,15 +713,15 @@ msgstr "Elimina"
 
 #: Source/DiabloUI/selhero.cpp:573
 msgid "Multi Player Characters"
-msgstr "Personaggi Multi Player"
+msgstr "Personaggi Multi Giocatore"
 
 #: Source/DiabloUI/selhero.cpp:617
 msgid "Delete Multi Player Hero"
-msgstr "Elimina Eroe Multi Player"
+msgstr "Elimina Eroe Multi Giocatore"
 
 #: Source/DiabloUI/selhero.cpp:619
 msgid "Delete Single Player Hero"
-msgstr "Elimina Eroe Single Player"
+msgstr "Elimina Eroe Giocatore Singolo"
 
 #: Source/DiabloUI/selhero.cpp:621
 #, c-format
@@ -744,7 +738,7 @@ msgstr "No"
 
 #: Source/DiabloUI/support_lines.cpp:8
 msgid "GOG.com maintains a web site at https://www.gog.com/forum/diablo"
-msgstr "GOG.com detiene un sito all'indirizzo https://www.gog.com/forum/diablo"
+msgstr "GOG.com fornisce un sito all'indirizzo https://www.gog.com/forum/diablo"
 
 #: Source/DiabloUI/support_lines.cpp:9
 msgid "Follow the links to visit the discussion boards associated with Diablo."
@@ -755,22 +749,17 @@ msgid "and the Hellfire expansion."
 msgstr "e all'espansione Hellfire."
 
 #: Source/DiabloUI/support_lines.cpp:12
-msgid ""
-"DevilutionX is maintained by Diasurgical, issues and bugs can be reported"
-msgstr ""
-"DevilutionX è gestito da Diasurgical, problemi ed errori possono essere "
-"segnalati"
+msgid "DevilutionX is maintained by Diasurgical, issues and bugs can be reported"
+msgstr "DevilutionX è gestito da Diasurgical, ogni problema può essere segnalato"
 
 #: Source/DiabloUI/support_lines.cpp:13
 msgid "at this address: https://github.com/diasurgical/devilutionX"
 msgstr "a questo indirizzo: https://github.com/diasurgical/devilutionX"
 
 #: Source/DiabloUI/support_lines.cpp:14
-msgid ""
-"To help us better serve you, please be sure to include the version number,"
+msgid "To help us better serve you, please be sure to include the version number,"
 msgstr ""
-"Per aiutarci a servirti meglio, assicurati di includere il numero di "
-"versione,"
+"Per aiutarci a servirti meglio, assicurati di includere il numero di versione,"
 
 #: Source/DiabloUI/support_lines.cpp:15
 msgid "operating system, and the nature of the problem."
@@ -786,23 +775,19 @@ msgstr "  DevilutionX non è supportato o gestito da Blizzard Entertainment,"
 
 #: Source/DiabloUI/support_lines.cpp:20
 msgid "  nor GOG.com. Neither Blizzard Entertainment or GOG.com has not tested"
-msgstr " o da GOG.com. Né Blizzard Entertainment né GOG.com hanno testato"
+msgstr "  o da GOG.com. Né Blizzard Entertainment né GOG.com hanno testato"
 
 #: Source/DiabloUI/support_lines.cpp:21
-msgid ""
-"  or certified the quality or compatibility of DevilutionX. All inquiries"
-msgstr ""
-" o certificato la qualità o la compatibilità di DevilutionX. Tutte le domande"
+msgid "  or certified the quality or compatibility of DevilutionX. All inquiries"
+msgstr "  o certificato la qualità o la compatibilità di DevilutionX. Tutte le"
 
 #: Source/DiabloUI/support_lines.cpp:22
-msgid ""
-"  regarding DevilutionX should be directed to Diasurgical, not to Blizzard"
-msgstr ""
-" riguardanti DeviltutionX dovrebbero essere dirette a Diasurgical, escludendo"
+msgid "  regarding DevilutionX should be directed to Diasurgical, not to Blizzard"
+msgstr "  domande su DevilutionX dovrebbero essere dirette a Diasurgical, non a"
 
 #: Source/DiabloUI/support_lines.cpp:23
 msgid "  Entertainment or GOG.com."
-msgstr " Blizzard Entertainment o Gog.com."
+msgstr "  Blizzard Entertainment o Gog.com."
 
 #: Source/DiabloUI/title.cpp:47
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
@@ -844,23 +829,22 @@ msgstr ""
 "Si è verificato un problema nel caricamento di:\n"
 "%s"
 
-#: Source/appfat.cpp:146 Source/appfat.cpp:164
+#: Source/appfat.cpp:146 Source/appfat.cpp:165
 msgid "Data File Error"
 msgstr "Errore File Dati"
 
-#: Source/appfat.cpp:160
+#: Source/appfat.cpp:161
 msgid ""
 "Unable to open main data archive (diabdat.mpq or spawn.mpq).\n"
 "\n"
-"Make sure that it is in the game folder and that the file name is in all "
-"lowercase."
+"Make sure that it is in the game folder and that the file name is in all lowercase."
 msgstr ""
 "Impossibile aprire l'archivio dati principale (diabdat.mpq o spawn.mpq).\n"
 "\n"
 "Assicurati che sia nella cartella del gioco e che il nome del file sia tutto "
 "minuscolo."
 
-#: Source/appfat.cpp:175
+#: Source/appfat.cpp:176
 #, c-format
 msgid ""
 "Unable to write to location:\n"
@@ -869,32 +853,32 @@ msgstr ""
 "Impossibile scrivere nella posizione:\n"
 "%s"
 
-#: Source/appfat.cpp:177
+#: Source/appfat.cpp:178
 msgid "Read-Only Directory Error"
 msgstr "Errore di Cartella in Sola Lettura"
 
-#: Source/automap.cpp:420
+#: Source/automap.cpp:388
 msgid "game: "
 msgstr "gioco: "
 
-#: Source/automap.cpp:424
+#: Source/automap.cpp:392
 msgid "password: "
 msgstr "password: "
 
-#: Source/automap.cpp:434 Source/items.cpp:3861
+#: Source/automap.cpp:402 Source/items.cpp:3861
 #, c-format
 msgid "Level: %i"
 msgstr "Liv. : %i"
 
-#: Source/automap.cpp:436
+#: Source/automap.cpp:404
 #, c-format
 msgid "Level: Crypt %i"
 msgstr "Livello: Cripta %i"
 
-#: Source/automap.cpp:438
+#: Source/automap.cpp:406
 #, c-format
 msgid "Level: Nest %i"
-msgstr "Level: Covo %i"
+msgstr "Livello: Covo %i"
 
 #: Source/control.cpp:239
 msgid "Tab"
@@ -910,11 +894,11 @@ msgstr "Inserisci"
 
 #: Source/control.cpp:242
 msgid "Character Information"
-msgstr "Informazioni Eroe"
+msgstr "Dettagli Personaggio"
 
 #: Source/control.cpp:243
 msgid "Quests log"
-msgstr "Diario"
+msgstr "Missioni"
 
 #: Source/control.cpp:244
 msgid "Automap"
@@ -922,7 +906,7 @@ msgstr "Mappa"
 
 #: Source/control.cpp:245
 msgid "Main Menu"
-msgstr "Menu"
+msgstr "Menu Principale"
 
 #: Source/control.cpp:246
 msgid "Inventory"
@@ -948,16 +932,16 @@ msgstr "%s Incantesimo"
 
 #: Source/control.cpp:437
 msgid "Damages undead only"
-msgstr "Danneggia Non-Morti"
+msgstr "Danneggia solo non morti"
 
-#: Source/control.cpp:441 Source/control.cpp:1034 Source/control.cpp:1861
+#: Source/control.cpp:441 Source/control.cpp:1034 Source/control.cpp:1857
 msgid "Spell Level 0 - Unusable"
-msgstr "Liv. Magico 0 - Inagibile"
+msgstr "Liv. Magia 0 - Inusabile"
 
-#: Source/control.cpp:443 Source/control.cpp:1036 Source/control.cpp:1863
+#: Source/control.cpp:443 Source/control.cpp:1036 Source/control.cpp:1859
 #, c-format
 msgid "Spell Level %i"
-msgstr "Liv. Magico %i"
+msgstr "Liv. Magia %i"
 
 #: Source/control.cpp:447 Source/control.cpp:1040
 #, c-format
@@ -971,12 +955,12 @@ msgid_plural "%i Scrolls"
 msgstr[0] "%i Pergamena"
 msgstr[1] "%i Pergamene"
 
-#: Source/control.cpp:467 Source/control.cpp:1064 Source/items.cpp:1596
+#: Source/control.cpp:467 Source/control.cpp:1061 Source/items.cpp:1596
 #, c-format
 msgid "Staff of %s"
-msgstr "Asta di %s"
+msgstr "Verga di %s"
 
-#: Source/control.cpp:469
+#: Source/control.cpp:469 Source/control.cpp:1063
 #, c-format
 msgid "%i Charge"
 msgid_plural "%i Charges"
@@ -999,106 +983,95 @@ msgstr "Attacca Eroi"
 #: Source/control.cpp:1005
 #, c-format
 msgid "Hotkey: %s"
-msgstr "Tasto : %s"
+msgstr "Tasto: %s"
 
 #: Source/control.cpp:1014
 msgid "Select current spell button"
-msgstr "Seleziona Abilità Magiche"
+msgstr "Tasto di selezione magia"
 
 #: Source/control.cpp:1018
 msgid "Hotkey: 's'"
-msgstr "Tasto : 's'"
+msgstr "Tasto: 's'"
 
-#: Source/control.cpp:1058
-msgid "1 Scroll"
-msgstr "1 Pergamena"
-
-#: Source/control.cpp:1060
+#: Source/control.cpp:1057
 #, c-format
-msgid "%i Scrolls"
-msgstr "%i Pergamene"
+msgid "%s Scroll"
+msgid_plural "%i Scrolls"
+msgstr[0] "%s Pergamena"
+msgstr[1] "%i Pergamene"
 
-#: Source/control.cpp:1067
-msgid "1 Charge"
-msgstr "1 Carica"
-
-#: Source/control.cpp:1069
-#, c-format
-msgid "%i Charges"
-msgstr "%i Cariche"
-
-#: Source/control.cpp:1256 Source/inv.cpp:2117 Source/items.cpp:3076
+#: Source/control.cpp:1250 Source/inv.cpp:2104 Source/items.cpp:3076
 #, c-format
 msgid "%i gold piece"
 msgid_plural "%i gold pieces"
-msgstr[0] "%i pezzo d'oro"
-msgstr[1] "%i pezzi d'oro"
+msgstr[0] "%i moneta"
+msgstr[1] "%i monete"
 
-#: Source/control.cpp:1259
+#: Source/control.cpp:1253
 msgid "Requirements not met"
-msgstr "Requisiti Inadeguati"
+msgstr "Requisiti inadeguati"
 
-#: Source/control.cpp:1295
+#: Source/control.cpp:1291
 #, c-format
 msgid "%s, Level: %i"
-msgstr "%s, Liv. : %i"
+msgstr "%s, Livello: %i"
 
-#: Source/control.cpp:1297
+#: Source/control.cpp:1293
 #, c-format
 msgid "Hit Points %i of %i"
-msgstr "Punti Vita %i di %i"
+msgstr "Punti Ferita %i di %i"
 
-#: Source/control.cpp:1370
+#: Source/control.cpp:1366
 msgid "None"
 msgstr "Nessuno"
 
-#: Source/control.cpp:1438 Source/control.cpp:1450 Source/control.cpp:1462
+#: Source/control.cpp:1434 Source/control.cpp:1446 Source/control.cpp:1458
 msgid "MAX"
 msgstr "MAX"
 
-#: Source/control.cpp:1580
+#: Source/control.cpp:1576
 msgid "Level Up"
 msgstr "Su di Livello"
 
-#: Source/control.cpp:1836
+#: Source/control.cpp:1832
 msgid "Skill"
 msgstr "Abilità"
 
-#: Source/control.cpp:1840
+#: Source/control.cpp:1836
 #, c-format
 msgid "Staff (%i charge)"
 msgid_plural "Staff (%i charges)"
 msgstr[0] "Verga (%i carica)"
 msgstr[1] "Verga (%i cariche)"
 
-#: Source/control.cpp:1848
+#: Source/control.cpp:1844
 #, c-format
 msgid "Mana: %i  Dam: %i - %i"
 msgstr "Mana: %i Dan: %i - %i"
 
-#: Source/control.cpp:1850
+#: Source/control.cpp:1846
 #, c-format
 msgid "Mana: %i   Dam: n/a"
 msgstr "Mana: %i Dan: n/a"
 
-#: Source/control.cpp:1853
+#: Source/control.cpp:1849
 #, c-format
 msgid "Mana: %i  Dam: 1/3 tgt hp"
 msgstr "Mana: %i Dan: 1/3 tgt hp"
 
-#: Source/control.cpp:1900
+#: Source/control.cpp:1896
 #, c-format
 msgid "You have %u gold"
-msgstr "Possiedi %u in oro"
+msgstr "Possiedi %u"
 
-#: Source/control.cpp:1902
+#: Source/control.cpp:1898
 #, c-format
 msgid "piece.  How many do"
 msgid_plural "pieces.  How many do"
-msgstr[0] "pezzo. Che importo"
-msgstr[1] "pezzi. Che importo"
+msgstr[0] "moneta. Che importo"
+msgstr[1] "monete. Che importo"
 
-#: Source/control.cpp:1904
+#: Source/control.cpp:1900
 msgid "you want to remove?"
 msgstr "desideri prelevare?"
 
@@ -1126,24 +1099,24 @@ msgstr "Incantesimi"
 msgid "Quests"
 msgstr "Missioni"
 
-#: Source/cursor.cpp:181 Source/spelldat.cpp:22
+#: Source/cursor.cpp:205 Source/spelldat.cpp:22
 msgid "Town Portal"
 msgstr "Portale"
 
-#: Source/cursor.cpp:182
+#: Source/cursor.cpp:206
 #, c-format
 msgid "from %s"
 msgstr "da %s"
 
-#: Source/cursor.cpp:207
+#: Source/cursor.cpp:231
 msgid "Portal to"
 msgstr "Portale verso"
 
-#: Source/cursor.cpp:209
+#: Source/cursor.cpp:233
 msgid "The Unholy Altar"
 msgstr "L'Altare Sacrilego"
 
-#: Source/cursor.cpp:211
+#: Source/cursor.cpp:235
 msgid "level 15"
 msgstr "livello 15"
 
@@ -1244,31 +1217,31 @@ msgstr ""
 msgid "unrecognized option '%s'\n"
 msgstr "opzione sconosciuta '%s'\n"
 
-#: Source/diablo.cpp:649
+#: Source/diablo.cpp:646
 #, c-format
 msgid "version %s"
 msgstr "versione %s"
 
-#: Source/diablo.cpp:1172
+#: Source/diablo.cpp:1174
 msgid "No help available"
 msgstr "Nessun aiuto disponibile"
 
-#: Source/diablo.cpp:1173
+#: Source/diablo.cpp:1175
 msgid "while in stores"
 msgstr "mentre nei negozi"
 
-#: Source/diablo.cpp:1453
+#: Source/diablo.cpp:1455
 #, c-format
 msgid "%s, mode = %s"
 msgstr "%s, modalità = %s"
 
-#: Source/diablo.cpp:2152
-msgid "-- Network timeout --"
-msgstr "-- Network Sospeso --"
-
 #: Source/diablo.cpp:2153
+msgid "-- Network timeout --"
+msgstr "-- Tempo di rete scaduto --"
+
+#: Source/diablo.cpp:2154
 msgid "-- Waiting for players --"
-msgstr "-- In Attesa dell'Eroe --"
+msgstr "-- In attesa di giocatori --"
 
 #: Source/dvlnet/loopback.cpp:113
 msgid "loopback"
@@ -1288,43 +1261,43 @@ msgstr "Non puoi usare la mappa qui"
 
 #: Source/error.cpp:23
 msgid "No multiplayer functions in demo"
-msgstr "No Funzioni Multiplayer in Demo"
+msgstr "No funzioni multigiocatore in demo"
 
 #: Source/error.cpp:24
 msgid "Direct Sound Creation Failed"
-msgstr "Creazione Dei Suoni Fallita"
+msgstr "Problemi con Direct Sound"
 
 #: Source/error.cpp:25
 msgid "Not available in shareware version"
-msgstr "Non Disponibile in Versione Demo"
+msgstr "Non disponibile in shareware"
 
 #: Source/error.cpp:26
 msgid "Not enough space to save"
-msgstr "Manca Spazio Per Salvare"
+msgstr "Spazio per salvare insufficiente"
 
 #: Source/error.cpp:27
 msgid "No Pause in town"
-msgstr "Non Puoi Fermare"
+msgstr "No Pausa in città"
 
 #: Source/error.cpp:28
 msgid "Copying to a hard disk is recommended"
-msgstr "È Raccomandata la Copia su Hard-Disk"
+msgstr "Si consiglia la copia su disco fisso"
 
 #: Source/error.cpp:29
 msgid "Multiplayer sync problem"
-msgstr "Multiplayer Sync Problem"
+msgstr "Sincronizzazione fallita in multigiocatore"
 
 #: Source/error.cpp:30
 msgid "No pause in multiplayer"
-msgstr "No pausa in Multiplayer"
+msgstr "No pausa in multigiocatore"
 
 #: Source/error.cpp:31
 msgid "Loading..."
-msgstr "Carica..."
+msgstr "Caricamento..."
 
 #: Source/error.cpp:32
 msgid "Saving..."
-msgstr "Salva..."
+msgstr "Salvataggio..."
 
 #: Source/error.cpp:33
 msgid "Some are weakened as one grows strong"
@@ -1340,7 +1313,7 @@ msgstr "Chi difende raramente attacca"
 
 #: Source/error.cpp:36
 msgid "The sword of justice is swift and sharp"
-msgstr "La Spada della giustizia è impeccabile"
+msgstr "La spada della giustizia è impeccabile"
 
 #: Source/error.cpp:37
 msgid "While the spirit is vigilant the body thrives"
@@ -1348,7 +1321,7 @@ msgstr "Il corpo prospera se lo spirito è guardingo"
 
 #: Source/error.cpp:38
 msgid "The powers of mana refocused renews"
-msgstr "Il potere del Mana viene ricaricato"
+msgstr "Il potere del mana viene ricaricato"
 
 #: Source/error.cpp:39
 msgid "Time cannot diminish the power of steel"
@@ -1364,7 +1337,7 @@ msgstr "Ciò che ebbe inizio ora ha fine"
 
 #: Source/error.cpp:42
 msgid "Intensity comes at the cost of wisdom"
-msgstr "L'Intensità vien data dalla saggezza"
+msgstr "L'intensità vien data dalla saggezza"
 
 #: Source/error.cpp:43
 msgid "Arcane power brings destruction"
@@ -1376,23 +1349,23 @@ msgstr "Che non può essere danneggiato o posseduto da nessuno"
 
 #: Source/error.cpp:45
 msgid "Crimson and Azure become as the sun"
-msgstr "Cremisi come il sole"
+msgstr "Cremisi e Azzurro come il sole"
 
 #: Source/error.cpp:46
 msgid "Knowledge and wisdom at the cost of self"
-msgstr "Conoscienza e Saggezza al solito costo"
+msgstr "Conoscienza e saggezza al solito costo"
 
 #: Source/error.cpp:47
 msgid "Drink and be refreshed"
-msgstr "Bevi e Rinfrescati"
+msgstr "Bevi e rinfrescati"
 
 #: Source/error.cpp:48
 msgid "Wherever you go, there you are"
-msgstr "Ovunque tu vai, Ovunque tu sei"
+msgstr "Ovunque tu vada, eccoti qua"
 
 #: Source/error.cpp:49
 msgid "Energy comes at the cost of wisdom"
-msgstr "L'Energia viene dalla tua Saggezza"
+msgstr "L'Energia viene dalla tua saggezza"
 
 #: Source/error.cpp:50
 msgid "Riches abound when least expected"
@@ -1412,11 +1385,11 @@ msgstr "Il fato può guidare le mani dell'uomo"
 
 #: Source/error.cpp:54
 msgid "Strength is bolstered by heavenly faith"
-msgstr "La Forza è sostenuta dalla Divina Fede"
+msgstr "La Forza è sostenuta dalla divina fede"
 
 #: Source/error.cpp:55
 msgid "The essence of life flows from within"
-msgstr "Il Flusso della vita ti pervade"
+msgstr "Il flusso della vita ti pervade"
 
 #: Source/error.cpp:56
 msgid "The way is made clear when viewed from above"
@@ -1424,7 +1397,7 @@ msgstr "La strada è sgombra solo se vista dall'alto"
 
 #: Source/error.cpp:57
 msgid "Salvation comes at the cost of wisdom"
-msgstr "La Salvezza costa molta Saggezza"
+msgstr "La salvezza costa molta saggezza"
 
 #: Source/error.cpp:58
 msgid "Mysteries are revealed in the light of reason"
@@ -1436,7 +1409,7 @@ msgstr "Gli ultimi potranno essere i prim"
 
 #: Source/error.cpp:60
 msgid "Generosity brings its own rewards"
-msgstr "La tua Generosità ti ricompensa"
+msgstr "La tua generosità ti ricompensa"
 
 #: Source/error.cpp:61
 msgid "You must be at least level 8 to use this."
@@ -1452,7 +1425,7 @@ msgstr "Per usarlo devi essere di Livello 17."
 
 #: Source/error.cpp:64
 msgid "Arcane knowledge gained!"
-msgstr "Appresi Arcani Segreti!"
+msgstr "Appresi arcani segreti!"
 
 #: Source/error.cpp:65
 msgid "That which does not kill you..."
@@ -1520,7 +1493,7 @@ msgstr "Gamma"
 
 #: Source/gamemenu.cpp:66 Source/gamemenu.cpp:237
 msgid "Speed"
-msgstr "Velocità"
+msgstr "Ritmo"
 
 #: Source/gamemenu.cpp:67
 msgid "Previous Menu"
@@ -1540,19 +1513,19 @@ msgstr "Suoni Spenti"
 
 #: Source/gamemenu.cpp:225
 msgid "Speed: Fastest"
-msgstr "Velocità: Velocissimo"
+msgstr "Ritmo: Velocissimo"
 
 #: Source/gamemenu.cpp:227
 msgid "Speed: Faster"
-msgstr "Velocità: Molto veloce"
+msgstr "Ritmo: Molto veloce"
 
 #: Source/gamemenu.cpp:229
 msgid "Speed: Fast"
-msgstr "Velocità: Veloce"
+msgstr "Ritmo: Veloce"
 
 #: Source/gamemenu.cpp:231
 msgid "Speed: Normal"
-msgstr "Velocità: Normale"
+msgstr "Ritmo: Normale"
 
 #: Source/gmenu.cpp:81
 msgid "Pause"
@@ -1560,513 +1533,499 @@ msgstr "Pausa"
 
 #: Source/help.cpp:20
 msgid ""
-"Shareware Diablo Help||$Keyboard Shortcuts:|Diablo can be played exclusively "
-"by using the mouse controls.  There are times, however, when you may want to "
-"use shortcuts to some commands by using the keyboard.  These shortcuts are "
-"listed below:||F1:    Open the Help Screen|Esc:    Displays the main menu|"
-"Tab:    Displays the Auto-map|Space:  Removes any pop-up menus or maps from "
-"the play area|S:  Open Speedbook|B:  Open Spellbook|I:  Opens the Inventory "
-"screen|C:  Opens the Character screen|Z:  Zooms the game screen in and out|"
-"F:  Reduces the brightness of the screen|G:  Increases the brightness of the "
-"screen|Q:  Opens the Quest log (non-functional in the Shareware version)|1 - "
-"8:  Use that item from your Belt|F5, F6, F7, F8:  Sets a hotkey for a "
-"selected skill or spell|Shift + Left Mouse Button: Use any weapon without "
-"moving|Shift + Left Mouse Button (on character screen): Assign all stat "
-"points|Shift + Left Mouse Button (on inventory): Move item to belt or equip/"
-"unequip item|Shift + Left Mouse Button (on belt): Move item to inventory|||"
-"$Movement:|Movement is controlled by the mouse.  The gauntlet on the screen "
-"is your cursor.  Use this to indicate the destination of your character and "
-"then left-click to move to that area. If you hold the mouse button down "
-"while moving, the character will continue to move in that direction.||"
-"$Selecting Items:|What you can interact with within the game is easily "
-"identifiable. Move the cursor over any object or creature. If the object can "
-"be picked up, attacked, activated or used in any way, it will be immediately "
-"outlined. A description of the highlighted object appears in the text area "
-"on the control panel.||Example: If you select a door and then left-click the "
-"character will walk to the door and open it. If you left-click on a "
-"highlighted weapon, the character will walk over to it and put it in his "
-"inventory. If you left-click on a highlighted creature...||$Combat:|Combat "
-"is initiated by left-clicking on a creature that has been highlighted. If "
+"Shareware Diablo Help||$Keyboard Shortcuts:|Diablo can be played exclusively by "
+"using the mouse controls.  There are times, however, when you may want to use "
+"shortcuts to some commands by using the keyboard.  These shortcuts are listed "
+"below:||F1:    Open the Help Screen|Esc:    Displays the main menu|Tab:    "
+"Displays the Auto-map|Space:  Removes any pop-up menus or maps from the play area|"
+"S:  Open Speedbook|B:  Open Spellbook|I:  Opens the Inventory screen|C:  Opens the "
+"Character screen|Z:  Zooms the game screen in and out|F:  Reduces the brightness "
+"of the screen|G:  Increases the brightness of the screen|Q:  Opens the Quest log "
+"(non-functional in the Shareware version)|1 - 8:  Use that item from your Belt|F5, "
+"F6, F7, F8:  Sets a hotkey for a selected skill or spell|Shift + Left Mouse "
+"Button: Use any weapon without moving|Shift + Left Mouse Button (on character "
+"screen): Assign all stat points|Shift + Left Mouse Button (on inventory): Move "
+"item to belt or equip/unequip item|Shift + Left Mouse Button (on belt): Move item "
+"to inventory|||$Movement:|Movement is controlled by the mouse.  The gauntlet on "
+"the screen is your cursor.  Use this to indicate the destination of your character "
+"and then left-click to move to that area. If you hold the mouse button down while "
+"moving, the character will continue to move in that direction.||$Selecting Items:|"
+"What you can interact with within the game is easily identifiable. Move the cursor "
+"over any object or creature. If the object can be picked up, attacked, activated "
+"or used in any way, it will be immediately outlined. A description of the "
+"highlighted object appears in the text area on the control panel.||Example: If you "
+"select a door and then left-click the character will walk to the door and open it. "
+"If you left-click on a highlighted weapon, the character will walk over to it and "
+"put it in his inventory. If you left-click on a highlighted creature...||$Combat:|"
+"Combat is initiated by left-clicking on a creature that has been highlighted. If "
 "your character is equipped with a melee weapon (Sword, Mace, Ax, etc.) your "
-"character will move to range and attack. If your character is equipped with "
-"a bow, left-clicking will fire an arrow at the highlighted creature. Holding "
-"down the shift key and then left-clicking allows the character to attack "
-"without moving.||$Picking up Objects:|If you left-click on an item - such as "
-"a weapon, shield, armor or book - your character will move to that item and "
-"add it to his inventory automatically.||Useable items that are small in size "
-"- such as a potion or scroll - are automatically placed in your 'belt', "
-"located at the top of the Interface bar . When an item is placed in the "
-"belt, a small number appears in that box. Items may be used by either right-"
-"clicking on the item or pressing the corresponding number on the keyboard.||"
-"If you do not have enough room in your inventory or belt for an item that "
-"you try to pick up, it will fall from your grasp. Open your inventory screen "
-"and try re-arranging or removing items to carry what you really want or "
-"need.||$Inventory:|You can toggle the Inventory screen on and off by "
-"clicking the INV> button on the control panel.  Items may be moved around in "
-"your inventory by selecting them and then left-clicking to pick them up.  "
-"When you pick up an item while in the inventory screen, your cursor changes "
-"into the item. You can then place this item into empty spaces in your "
-"inventory, swap them with other items in your inventory or equip them.||If "
-"you have an item that you no longer wish to carry, simply grab the item from "
-"your inventory and then left-click in the play area to drop it.||$Equipping "
-"Items:|To equip an item, open the inventory screen and pick up the desired "
-"item, either from play or from your inventory, placing it in the appropriate "
-"box on the figure in the inventory screen. Weapons and shields go into the "
-"large spaces to the  right or left of the figure. Two-handed weapons such as "
-"bows and axes preclude the use of a shield and will take up both of these "
-"large spaces.||Cloaks, robes, capes and all other armor must go in the "
-"central torso slot of the figure. ||Helmets and caps go in the box over the "
-"head of the character.||Rings go into the small boxes at the hands of the "
-"figure.||Amulets go into the small box at the next to the neck of the "
-"figure.||To change items that your character has equipped, pick up a new "
-"item and place it on top of the item you wish to remove.  Your character "
-"will automatically swap the items and the cursor will now change into the "
-"item that was in that box.||$Usable Items:|Potions, elixirs and books are "
-"classified as usable items.  These items can be used by right-clicking on "
-"them in the inventory screen.  Books are too large to be placed in the belt, "
-"but any potions or scrolls that are put there can also be used by pressing "
-"the corresponding number on the keyboard.||$Gold:|You can select a specific "
-"amount of gold to drop by right-clicking on a pile of gold in your "
-"inventory. A dialog will appear that allows you to select a specific amount "
-"of gold to take. When you have entered that number, your cursor will change "
-"into that amount of gold.||$Item Information:|Many items in Diablo share "
-"certain common attributes.  These are damage, durability, charges and "
-"minimum requirements..||Damage: This is represented by a range that "
-"indicates the minimum and maximum damage that item can inflict. A short "
-"sword has a (2-6) after its name, meaning it inflicts a minimum of two "
-"damage and a maximum of six when it hits. Damage can be modified by the "
-"quality of the weapon, the character's strength and magical effects.||"
-"Durability: This is the amount of damage that an item can take before it is "
-"rendered useless. Durability is represented by a ratio of current durability "
-"to maximum durability. A shield that has a durability of 15/20 would still "
-"have 15 points of damage it could take from use before it was rendered "
-"useless. Maximum durability can be affected by the quality of the item, "
-"enchantments or repairs made upon the item. The minimum durability can be "
-"raised by repairing an item.||Charges: Some items have charges associated "
-"with them. Charges indicate how many times that item can be used to cast the "
-"spell or affect indicated in its description.  Charges are represented by a "
-"ratio of charges left to maximum charges. A staff that has charges listed as "
-"2/5 could be used to cast 2 more spells before it was rendered powerless. It "
-"could still be used to attack with as a physical weapon, however. Maximum "
-"charges can be affected by the magic or recharges cast upon the item. "
-"Minimum charges can be raised by recharging the item.||Minimum Requirements: "
-"These are the minimum requirements that a character must meet to wield the "
-"item. The more powerful an item is, the higher the minimum requirements will "
-"be.  If a character does not meet these requirements, he will be unable to "
-"equip the item and its name and information will be displayed in red.  The "
-"item artwork will also have a red tint in the Inventory screen.||$Items "
-"Classes:|There are three classes of items in Diablo - Mundane, Magic and "
-"Unique:||Mundane items have no special attributes. Their information is "
-"displayed in white text.||Magic Items are represented by blue names and text "
-"descriptions. Use the Identify spell or speak to Cain in town to determine "
-"their exact properties and attributes.||Unique items are represented by gold "
-"names and text descriptions. Use the Identify spell or speak to Cain in town "
-"to determine their exact properties and attributes.||$Skills & Spells:|You "
-"can access your list of skills and spells by left-clicking on the SPELLS "
-"button in the interface bar. This 'Spellbook' contains all of the skills and "
-"spells that your character knows. Spells available through staffs are also "
-"listed here. Left-clicking on the Icon of the spell you wish to ready will "
-"place it in the 'select current spell' icon/area and set it as the current "
-"readied spell. A readied spell may be cast by simply right-clicking in the "
-"play area.||Left-clicking on the 'select current spell' button will also "
-"open a 'Speedbook' menu that also allows you to ready a skill or spell for "
-"use.  To use a readied skill or spell, simply right-click in the main play "
-"area.|Shift + Left-clicking on the 'select current spell' button will clear "
-"the readied spell||Skills are the innate abilities of your character. These "
-"skills are different depending on what class you choose and require no mana "
-"to use.||Warrior:|The Warrior has the skill of Repair Items. This allows him "
-"to fix an item that has been worn by use or is damaged in combat. To "
-"accomplish this, select the Repair Skill through the Spellbook or Speedbook "
-"and right-click the mouse as if you were casting a spell. Your cursor will "
-"change into a Hammer Icon that you will use to select the item to be "
-"repaired.  Although Repairing an item in this way will decrease the maximum "
+"character will move to range and attack. If your character is equipped with a bow, "
+"left-clicking will fire an arrow at the highlighted creature. Holding down the "
+"shift key and then left-clicking allows the character to attack without moving.||"
+"$Picking up Objects:|If you left-click on an item - such as a weapon, shield, "
+"armor or book - your character will move to that item and add it to his inventory "
+"automatically.||Useable items that are small in size - such as a potion or scroll "
+"- are automatically placed in your 'belt', located at the top of the Interface "
+"bar . When an item is placed in the belt, a small number appears in that box. "
+"Items may be used by either right-clicking on the item or pressing the "
+"corresponding number on the keyboard.||If you do not have enough room in your "
+"inventory or belt for an item that you try to pick up, it will fall from your "
+"grasp. Open your inventory screen and try re-arranging or removing items to carry "
+"what you really want or need.||$Inventory:|You can toggle the Inventory screen on "
+"and off by clicking the INV> button on the control panel.  Items may be moved "
+"around in your inventory by selecting them and then left-clicking to pick them "
+"up.  When you pick up an item while in the inventory screen, your cursor changes "
+"into the item. You can then place this item into empty spaces in your inventory, "
+"swap them with other items in your inventory or equip them.||If you have an item "
+"that you no longer wish to carry, simply grab the item from your inventory and "
+"then left-click in the play area to drop it.||$Equipping Items:|To equip an item, "
+"open the inventory screen and pick up the desired item, either from play or from "
+"your inventory, placing it in the appropriate box on the figure in the inventory "
+"screen. Weapons and shields go into the large spaces to the  right or left of the "
+"figure. Two-handed weapons such as bows and axes preclude the use of a shield and "
+"will take up both of these large spaces.||Cloaks, robes, capes and all other armor "
+"must go in the central torso slot of the figure. ||Helmets and caps go in the box "
+"over the head of the character.||Rings go into the small boxes at the hands of the "
+"figure.||Amulets go into the small box at the next to the neck of the figure.||To "
+"change items that your character has equipped, pick up a new item and place it on "
+"top of the item you wish to remove.  Your character will automatically swap the "
+"items and the cursor will now change into the item that was in that box.||$Usable "
+"Items:|Potions, elixirs and books are classified as usable items.  These items can "
+"be used by right-clicking on them in the inventory screen.  Books are too large to "
+"be placed in the belt, but any potions or scrolls that are put there can also be "
+"used by pressing the corresponding number on the keyboard.||$Gold:|You can select "
+"a specific amount of gold to drop by right-clicking on a pile of gold in your "
+"inventory. A dialog will appear that allows you to select a specific amount of "
+"gold to take. When you have entered that number, your cursor will change into that "
+"amount of gold.||$Item Information:|Many items in Diablo share certain common "
+"attributes.  These are damage, durability, charges and minimum requirements..||"
+"Damage: This is represented by a range that indicates the minimum and maximum "
+"damage that item can inflict. A short sword has a (2-6) after its name, meaning it "
+"inflicts a minimum of two damage and a maximum of six when it hits. Damage can be "
+"modified by the quality of the weapon, the character's strength and magical "
+"effects.||Durability: This is the amount of damage that an item can take before it "
+"is rendered useless. Durability is represented by a ratio of current durability to "
+"maximum durability. A shield that has a durability of 15/20 would still have 15 "
+"points of damage it could take from use before it was rendered useless. Maximum "
+"durability can be affected by the quality of the item, enchantments or repairs "
+"made upon the item. The minimum durability can be raised by repairing an item.||"
+"Charges: Some items have charges associated with them. Charges indicate how many "
+"times that item can be used to cast the spell or affect indicated in its "
+"description.  Charges are represented by a ratio of charges left to maximum "
+"charges. A staff that has charges listed as 2/5 could be used to cast 2 more "
+"spells before it was rendered powerless. It could still be used to attack with as "
+"a physical weapon, however. Maximum charges can be affected by the magic or "
+"recharges cast upon the item. Minimum charges can be raised by recharging the "
+"item.||Minimum Requirements: These are the minimum requirements that a character "
+"must meet to wield the item. The more powerful an item is, the higher the minimum "
+"requirements will be.  If a character does not meet these requirements, he will be "
+"unable to equip the item and its name and information will be displayed in red.  "
+"The item artwork will also have a red tint in the Inventory screen.||$Items "
+"Classes:|There are three classes of items in Diablo - Mundane, Magic and Unique:||"
+"Mundane items have no special attributes. Their information is displayed in white "
+"text.||Magic Items are represented by blue names and text descriptions. Use the "
+"Identify spell or speak to Cain in town to determine their exact properties and "
+"attributes.||Unique items are represented by gold names and text descriptions. Use "
+"the Identify spell or speak to Cain in town to determine their exact properties "
+"and attributes.||$Skills & Spells:|You can access your list of skills and spells "
+"by left-clicking on the SPELLS button in the interface bar. This 'Spellbook' "
+"contains all of the skills and spells that your character knows. Spells available "
+"through staffs are also listed here. Left-clicking on the Icon of the spell you "
+"wish to ready will place it in the 'select current spell' icon/area and set it as "
+"the current readied spell. A readied spell may be cast by simply right-clicking in "
+"the play area.||Left-clicking on the 'select current spell' button will also open "
+"a 'Speedbook' menu that also allows you to ready a skill or spell for use.  To use "
+"a readied skill or spell, simply right-click in the main play area.|Shift + Left-"
+"clicking on the 'select current spell' button will clear the readied spell||Skills "
+"are the innate abilities of your character. These skills are different depending "
+"on what class you choose and require no mana to use.||Warrior:|The Warrior has the "
+"skill of Repair Items. This allows him to fix an item that has been worn by use or "
+"is damaged in combat. To accomplish this, select the Repair Skill through the "
+"Spellbook or Speedbook and right-click the mouse as if you were casting a spell. "
+"Your cursor will change into a Hammer Icon that you will use to select the item to "
+"be repaired.  Although Repairing an item in this way will decrease the maximum "
 "durability of that item, it can be done without leaving the labyrinth.||The "
-"Blacksmith can also repair items for a price. When the Blacksmith performs "
-"this service, it does decrease the maximum durability of the item.||Rogue:|"
-"The Rogue has the skill of Disarm Traps. This allows her to not only remove "
-"traps, but also acts as a 'sixth sense' that warns her of where these "
-"trapped items are located. To accomplish this, select the Disarm Trap skill "
-"through the Spellbook or Speedbook and right-click the mouse as if you were "
-"casting a spell.  Your cursor will change into a Targeting Cursor that you "
-"will use to select the item to be disarmed.  The success of this attempt is "
-"based on the level of the Rogue and the expertise of whomever set the trap.||"
-"Sorcerer:|The Sorcerer has the skill of Recharge Staffs. This allows him to "
-"focus his mana into an staff that has been drained of its magical energies.  "
-"To accomplish this, select the Recharge Staffs skill through the Spellbook "
-"or Speedbook and right-click the mouse as if you were casting a spell.  Your "
-"cursor will change into a Staff Icon that you will use to select the item to "
-"be recharged.  Although Recharging a staff in this way will decrease its "
-"maximum charges, it can be done without leaving the labyrinth.||The Witch "
-"can also recharge staffs for a price. When the Witch performs this service, "
-"it does decrease the maximum charges of the item.||Spells are magical "
-"effects that can be cast from a scroll, a staff or memorized from a book. "
-"Spells may or may not require mana to use and are available to all classes.||"
-"Spells cast from a scroll cost no mana to use, but are limited to only one "
-"charge. Casting a spell from a scroll is accomplished by either right-"
-"clicking on the scroll or, if it is located in our belt, pressing the "
-"corresponding number on the keyboard. Scrolls can also be readied in the "
-"Speedbook and are represented by a red icon/button in the 'select current "
-"spell' area.||Spells cast from staffs cost no mana to use, but are limited "
-"by the number of charges available. To cast spells from a staff, it must "
-"first be equipped. The 'select current spell' icon/button will change to "
-"indicate that the spell on the staff is currently ready to cast. Scrolls can "
-"also be readied in the Spellbook or Speedbook and are represented by an "
-"orange icon/button in the 'select current spell' area.||Spells that are "
-"memorized cost mana to cast, but they can be used as long as the character "
-"has mana to power them. The Warrior and Rogue start the game with no "
-"memorized spells while the sorcerer begins with Firebolt.  If the character "
-"finds a book in the labyrinth, he can memorize the spell written in that "
-"book by opening the Inventory screen and right-clicking on the book.  This "
-"will make that spell always available to the character for casting. "
-"Memorized spells can be readied through either the Spellbook or Speedbook "
-"and are represented by a blue icon/button in the 'select current spell' "
-"area.||$Important note on books:|Reading more than one book increases your "
-"knowledge of that spell and gives you the spell at a higher level. The "
-"higher the level of a spell the more effective it is.||While some spells "
-"affect the caster, other spells require a target. These targeted spells are "
-"cast in the direction that you indicate with your cursor on the play area.  "
-"If you highlight a creature, you will cast that spell at that creature.  Not "
-"all items within the labyrinth can be targeted.||Example: A fireball spell "
-"will travel at the creature or to the location you right-click on.  A "
-"Healing spell will simply add health to your character while diminishing his "
-"available mana and requires no targeting.||You can also set a spell or "
-"scroll as a Hotkey position for instant selection.  Start by opening the pop-"
-"up menu as described in the skill section above.  Assign Hotkeys by hitting "
-"the F5, F6, F7 or F8 keys on your keyboard after scrolling through the "
-"available spells and highlighting the one you wish to assign. ||$Health and "
-"Mana:|The two orbs in the Information Bar display your life and mana. The "
-"red sphere of fluid on the left side of the control panel represents the "
-"overall health of your character. When the fluid is gone - your character is "
-"dead.||The blue fluid on the right side of the control panel represents your "
-"character's available mana. Mana is the magical force used by your character "
-"to cast spells.  When the liquid in the sphere is low or depleted, you may "
-"be unable to cast some (or all) of your spells.||$Information Bar:|The "
-"Information Bar is where you receive detailed information in Diablo and "
-"interact with much of your surroundings.  Here is a quick run-down of the "
-"control panel areas and their use:||CHAR: This button is used to access your "
-"Character Statistics screen|INV:  This button is used to access your "
-"Inventory screen|Quest: This button displays your Quest Log (inactive in "
-"Shareware version)|Automap: This button activates the mapping overlay|Menu: "
-"This button activates the game menu screen|Spells: This button is used to "
-"access your Spellbook|Current Spell: This is the spell that has been readied "
-"for immediate casting|Life Orb: This is the amount of health your character "
-"currently has|Mana Orb: This is the amount of mana your character currently "
-"has|Multiplayer Message: This activates the Message Area|Description Area: "
-"This is where any important information about creatures or items you can "
-"interact with is displayed. This is also where you will enter the text you "
-"wish to send when sending multiplayer messages.||$Character Info:|Toggle the "
-"Character Statistics Screen on and off by clicking the <CHAR button on the "
-"Information Bar.  This screen shows the 'nuts and bolts' of your character.  "
-"There are four major attributes that dictate how your character progresses "
-"in the game.||STRENGTH: This is how physically powerful your character is. "
-"This statistic plays a large part in  determining how much damage you can do "
-"when attacking creatures.||MAGIC: This is how attuned your character is with "
-"the arcane powers of the world. This statistic plays a large part in  "
-"determining how much mana you have available for casting spells.||DEXTERITY: "
-"This is how quick of foot and hand your character is. This statistic plays a "
-"large part in  determining the chance you have to hit creatures in combat.||"
-"VITALITY: This is how physically fit your character is. This statistic plays "
-"a large part in  determining how much health your character has when he is "
-"undamaged.||$In Game Menu:|To activate the Game Menu, click the MENU button "
-"on the Information Bar.  You have three options in this menu:||New Game: "
-"This exits you from your current game and returns you to the Main Menu.||"
-"Options: This opens the options menu that allows you to adjust your music "
-"and sound effects settings as well as the gamma level of the screen.||Quit "
-"Game: This exits the program. Please note that this automatically saves your "
-"character.||$Auto-map:|Your character automatically maps where he has been "
-"in the labyrinth.  To access the auto-map, click the MAP button on the "
-"Information Bar.  You can also press TAB on your keyboard to activate the "
-"auto-map. Zooming in and out of the map is done with the + and - keys while "
-"scrolling the map uses the arrow keys.|&"
+"Blacksmith can also repair items for a price. When the Blacksmith performs this "
+"service, it does decrease the maximum durability of the item.||Rogue:|The Rogue "
+"has the skill of Disarm Traps. This allows her to not only remove traps, but also "
+"acts as a 'sixth sense' that warns her of where these trapped items are located. "
+"To accomplish this, select the Disarm Trap skill through the Spellbook or "
+"Speedbook and right-click the mouse as if you were casting a spell.  Your cursor "
+"will change into a Targeting Cursor that you will use to select the item to be "
+"disarmed.  The success of this attempt is based on the level of the Rogue and the "
+"expertise of whomever set the trap.||Sorcerer:|The Sorcerer has the skill of "
+"Recharge Staffs. This allows him to focus his mana into an staff that has been "
+"drained of its magical energies.  To accomplish this, select the Recharge Staffs "
+"skill through the Spellbook or Speedbook and right-click the mouse as if you were "
+"casting a spell.  Your cursor will change into a Staff Icon that you will use to "
+"select the item to be recharged.  Although Recharging a staff in this way will "
+"decrease its maximum charges, it can be done without leaving the labyrinth.||The "
+"Witch can also recharge staffs for a price. When the Witch performs this service, "
+"it does decrease the maximum charges of the item.||Spells are magical effects that "
+"can be cast from a scroll, a staff or memorized from a book. Spells may or may not "
+"require mana to use and are available to all classes.||Spells cast from a scroll "
+"cost no mana to use, but are limited to only one charge. Casting a spell from a "
+"scroll is accomplished by either right-clicking on the scroll or, if it is located "
+"in our belt, pressing the corresponding number on the keyboard. Scrolls can also "
+"be readied in the Speedbook and are represented by a red icon/button in the "
+"'select current spell' area.||Spells cast from staffs cost no mana to use, but are "
+"limited by the number of charges available. To cast spells from a staff, it must "
+"first be equipped. The 'select current spell' icon/button will change to indicate "
+"that the spell on the staff is currently ready to cast. Scrolls can also be "
+"readied in the Spellbook or Speedbook and are represented by an orange icon/button "
+"in the 'select current spell' area.||Spells that are memorized cost mana to cast, "
+"but they can be used as long as the character has mana to power them. The Warrior "
+"and Rogue start the game with no memorized spells while the sorcerer begins with "
+"Firebolt.  If the character finds a book in the labyrinth, he can memorize the "
+"spell written in that book by opening the Inventory screen and right-clicking on "
+"the book.  This will make that spell always available to the character for "
+"casting. Memorized spells can be readied through either the Spellbook or Speedbook "
+"and are represented by a blue icon/button in the 'select current spell' area.||"
+"$Important note on books:|Reading more than one book increases your knowledge of "
+"that spell and gives you the spell at a higher level. The higher the level of a "
+"spell the more effective it is.||While some spells affect the caster, other spells "
+"require a target. These targeted spells are cast in the direction that you "
+"indicate with your cursor on the play area.  If you highlight a creature, you will "
+"cast that spell at that creature.  Not all items within the labyrinth can be "
+"targeted.||Example: A fireball spell will travel at the creature or to the "
+"location you right-click on.  A Healing spell will simply add health to your "
+"character while diminishing his available mana and requires no targeting.||You can "
+"also set a spell or scroll as a Hotkey position for instant selection.  Start by "
+"opening the pop-up menu as described in the skill section above.  Assign Hotkeys "
+"by hitting the F5, F6, F7 or F8 keys on your keyboard after scrolling through the "
+"available spells and highlighting the one you wish to assign. ||$Health and Mana:|"
+"The two orbs in the Information Bar display your life and mana. The red sphere of "
+"fluid on the left side of the control panel represents the overall health of your "
+"character. When the fluid is gone - your character is dead.||The blue fluid on the "
+"right side of the control panel represents your character's available mana. Mana "
+"is the magical force used by your character to cast spells.  When the liquid in "
+"the sphere is low or depleted, you may be unable to cast some (or all) of your "
+"spells.||$Information Bar:|The Information Bar is where you receive detailed "
+"information in Diablo and interact with much of your surroundings.  Here is a "
+"quick run-down of the control panel areas and their use:||CHAR: This button is "
+"used to access your Character Statistics screen|INV:  This button is used to "
+"access your Inventory screen|Quest: This button displays your Quest Log (inactive "
+"in Shareware version)|Automap: This button activates the mapping overlay|Menu: "
+"This button activates the game menu screen|Spells: This button is used to access "
+"your Spellbook|Current Spell: This is the spell that has been readied for "
+"immediate casting|Life Orb: This is the amount of health your character currently "
+"has|Mana Orb: This is the amount of mana your character currently has|Multiplayer "
+"Message: This activates the Message Area|Description Area: This is where any "
+"important information about creatures or items you can interact with is displayed. "
+"This is also where you will enter the text you wish to send when sending "
+"multiplayer messages.||$Character Info:|Toggle the Character Statistics Screen on "
+"and off by clicking the <CHAR button on the Information Bar.  This screen shows "
+"the 'nuts and bolts' of your character.  There are four major attributes that "
+"dictate how your character progresses in the game.||STRENGTH: This is how "
+"physically powerful your character is. This statistic plays a large part in  "
+"determining how much damage you can do when attacking creatures.||MAGIC: This is "
+"how attuned your character is with the arcane powers of the world. This statistic "
+"plays a large part in  determining how much mana you have available for casting "
+"spells.||DEXTERITY: This is how quick of foot and hand your character is. This "
+"statistic plays a large part in  determining the chance you have to hit creatures "
+"in combat.||VITALITY: This is how physically fit your character is. This statistic "
+"plays a large part in  determining how much health your character has when he is "
+"undamaged.||$In Game Menu:|To activate the Game Menu, click the MENU button on the "
+"Information Bar.  You have three options in this menu:||New Game: This exits you "
+"from your current game and returns you to the Main Menu.||Options: This opens the "
+"options menu that allows you to adjust your music and sound effects settings as "
+"well as the gamma level of the screen.||Quit Game: This exits the program. Please "
+"note that this automatically saves your character.||$Auto-map:|Your character "
+"automatically maps where he has been in the labyrinth.  To access the auto-map, "
+"click the MAP button on the Information Bar.  You can also press TAB on your "
+"keyboard to activate the auto-map. Zooming in and out of the map is done with the "
+"+ and - keys while scrolling the map uses the arrow keys.|&"
 msgstr ""
-"Shareware Diablo Guida||$Scorciatoie:|Diablo può essere giocato "
-"esclusivamente utilizzando il mouse.  A volte, tuttavia, potresti voler "
-"utilizzare scorciatoie per alcuni comandi utilizzando la tastiera.  Le "
-"scorciatoie sono elencate di seguito:||F1:    Apri la Guida|Esc:    Mostra "
-"menu|Tab:    Mostra mappa|Space:  Rimuove eventuali menu a comparsa o mappe "
-"dall'area di gioco|S:  Open Speedbook|B:  Open Spellbook|I:  Opens the "
-"Inventory screen|C:  Opens the Character screen|Z:  Zooms the game screen in "
-"and out|F:  Reduces the brightness of the screen|G:  Increases the "
-"brightness of the screen|Q:  Opens the Quest log (non-functional in the "
-"Shareware version)|1 - 8:  Use that item from your Belt|F5, F6, F7, F8:  "
-"Sets a hotkey for a selected skill or spell|Shift + Left Mouse Button: Use "
-"any weapon without moving|Shift + Left Mouse Button (on character screen): "
-"Assign all stat points|Shift + Left Mouse Button (on inventory): Move item "
-"to belt or equip/unequip item|Shift + Left Mouse Button (on belt): Move item "
-"to inventory|||$Movement:|Movement is controlled by the mouse.  The gauntlet "
-"on the screen is your cursor.  Use this to indicate the destination of your "
-"character and then left-click to move to that area. If you hold the mouse "
-"button down while moving, the character will continue to move in that "
-"direction.||$Selecting Items:|What you can interact with within the game is "
-"easily identifiable. Move the cursor over any object or creature. If the "
-"object can be picked up, attacked, activated or used in any way, it will be "
-"immediately outlined. A description of the highlighted object appears in the "
-"text area on the control panel.||Example: If you select a door and then left-"
-"click the character will walk to the door and open it. If you left-click on "
-"a highlighted weapon, the character will walk over to it and put it in his "
-"inventory. If you left-click on a highlighted creature...||$Combat:|Combat "
-"is initiated by left-clicking on a creature that has been highlighted. If "
-"your character is equipped with a melee weapon (Sword, Mace, Ax, etc.) your "
-"character will move to range and attack. If your character is equipped with "
-"a bow, left-clicking will fire an arrow at the highlighted creature. Holding "
-"down the shift key and then left-clicking allows the character to attack "
-"without moving.||$Picking up Objects:|If you left-click on an item - such as "
-"a weapon, shield, armor or book - your character will move to that item and "
-"add it to his inventory automatically.||Useable items that are small in size "
-"- such as a potion or scroll - are automatically placed in your 'belt', "
-"located at the top of the Interface bar . When an item is placed in the "
-"belt, a small number appears in that box. Items may be used by either right-"
-"clicking on the item or pressing the corresponding number on the keyboard.||"
-"If you do not have enough room in your inventory or belt for an item that "
-"you try to pick up, it will fall from your grasp. Open your inventory screen "
-"and try re-arranging or removing items to carry what you really want or "
-"need.||$Inventory:|You can toggle the Inventory screen on and off by "
-"clicking the INV> button on the control panel.  Items may be moved around in "
-"your inventory by selecting them and then left-clicking to pick them up.  "
-"When you pick up an item while in the inventory screen, your cursor changes "
-"into the item. You can then place this item into empty spaces in your "
-"inventory, swap them with other items in your inventory or equip them.||If "
-"you have an item that you no longer wish to carry, simply grab the item from "
-"your inventory and then left-click in the play area to drop it.||$Equipping "
-"Items:|To equip an item, open the inventory screen and pick up the desired "
-"item, either from play or from your inventory, placing it in the appropriate "
-"box on the figure in the inventory screen. Weapons and shields go into the "
-"large spaces to the  right or left of the figure. Two-handed weapons such as "
-"bows and axes preclude the use of a shield and will take up both of these "
-"large spaces.||Cloaks, robes, capes and all other armor must go in the "
-"central torso slot of the figure. ||Helmets and caps go in the box over the "
-"head of the character.||Rings go into the small boxes at the hands of the "
-"figure.||Amulets go into the small box at the next to the neck of the "
-"figure.||To change items that your character has equipped, pick up a new "
-"item and place it on top of the item you wish to remove.  Your character "
-"will automatically swap the items and the cursor will now change into the "
-"item that was in that box.||$Usable Items:|Potions, elixirs and books are "
-"classified as usable items.  These items can be used by right-clicking on "
-"them in the inventory screen.  Books are too large to be placed in the belt, "
-"but any potions or scrolls that are put there can also be used by pressing "
-"the corresponding number on the keyboard.||$Gold:|You can select a specific "
-"amount of gold to drop by right-clicking on a pile of gold in your "
-"inventory. A dialog will appear that allows you to select a specific amount "
-"of gold to take. When you have entered that number, your cursor will change "
-"into that amount of gold.||$Item Information:|Many items in Diablo share "
-"certain common attributes.  These are damage, durability, charges and "
-"minimum requirements..||Damage: This is represented by a range that "
-"indicates the minimum and maximum damage that item can inflict. A short "
-"sword has a (2-6) after its name, meaning it inflicts a minimum of two "
-"damage and a maximum of six when it hits. Damage can be modified by the "
-"quality of the weapon, the character's strength and magical effects.||"
-"Durability: This is the amount of damage that an item can take before it is "
-"rendered useless. Durability is represented by a ratio of current durability "
-"to maximum durability. A shield that has a durability of 15/20 would still "
-"have 15 points of damage it could take from use before it was rendered "
-"useless. Maximum durability can be affected by the quality of the item, "
-"enchantments or repairs made upon the item. The minimum durability can be "
-"raised by repairing an item.||Charges: Some items have charges associated "
-"with them. Charges indicate how many times that item can be used to cast the "
-"spell or affect indicated in its description.  Charges are represented by a "
-"ratio of charges left to maximum charges. A staff that has charges listed as "
-"2/5 could be used to cast 2 more spells before it was rendered powerless. It "
-"could still be used to attack with as a physical weapon, however. Maximum "
-"charges can be affected by the magic or recharges cast upon the item. "
-"Minimum charges can be raised by recharging the item.||Minimum Requirements: "
-"These are the minimum requirements that a character must meet to wield the "
-"item. The more powerful an item is, the higher the minimum requirements will "
-"be.  If a character does not meet these requirements, he will be unable to "
-"equip the item and its name and information will be displayed in red.  The "
-"item artwork will also have a red tint in the Inventory screen.||$Items "
-"Classes:|There are three classes of items in Diablo - Mundane, Magic and "
-"Unique:||Mundane items have no special attributes. Their information is "
-"displayed in white text.||Magic Items are represented by blue names and text "
-"descriptions. Use the Identify spell or speak to Cain in town to determine "
-"their exact properties and attributes.||Unique items are represented by gold "
-"names and text descriptions. Use the Identify spell or speak to Cain in town "
-"to determine their exact properties and attributes.||$Skills & Spells:|You "
-"can access your list of skills and spells by left-clicking on the SPELLS "
-"button in the interface bar. This 'Spellbook' contains all of the skills and "
-"spells that your character knows. Spells available through staffs are also "
-"listed here. Left-clicking on the Icon of the spell you wish to ready will "
-"place it in the 'select current spell' icon/area and set it as the current "
-"readied spell. A readied spell may be cast by simply right-clicking in the "
-"play area.||Left-clicking on the 'select current spell' button will also "
-"open a 'Speedbook' menu that also allows you to ready a skill or spell for "
-"use.  To use a readied skill or spell, simply right-click in the main play "
-"area.|Shift + Left-clicking on the 'select current spell' button will clear "
-"the readied spell||Skills are the innate abilities of your character. These "
-"skills are different depending on what class you choose and require no mana "
-"to use.||Warrior:|The Warrior has the skill of Repair Items. This allows him "
-"to fix an item that has been worn by use or is damaged in combat. To "
-"accomplish this, select the Repair Skill through the Spellbook or Speedbook "
-"and right-click the mouse as if you were casting a spell. Your cursor will "
-"change into a Hammer Icon that you will use to select the item to be "
-"repaired.  Although Repairing an item in this way will decrease the maximum "
-"durability of that item, it can be done without leaving the labyrinth.||The "
-"Blacksmith can also repair items for a price. When the Blacksmith performs "
-"this service, it does decrease the maximum durability of the item.||Rogue:|"
-"The Rogue has the skill of Disarm Traps. This allows her to not only remove "
-"traps, but also acts as a 'sixth sense' that warns her of where these "
-"trapped items are located. To accomplish this, select the Disarm Trap skill "
-"through the Spellbook or Speedbook and right-click the mouse as if you were "
-"casting a spell.  Your cursor will change into a Targeting Cursor that you "
-"will use to select the item to be disarmed.  The success of this attempt is "
-"based on the level of the Rogue and the expertise of whomever set the trap.||"
-"Sorcerer:|The Sorcerer has the skill of Recharge Staffs. This allows him to "
-"focus his mana into an staff that has been drained of its magical energies.  "
-"To accomplish this, select the Recharge Staffs skill through the Spellbook "
-"or Speedbook and right-click the mouse as if you were casting a spell.  Your "
-"cursor will change into a Staff Icon that you will use to select the item to "
-"be recharged.  Although Recharging a staff in this way will decrease its "
-"maximum charges, it can be done without leaving the labyrinth.||The Witch "
-"can also recharge staffs for a price. When the Witch performs this service, "
-"it does decrease the maximum charges of the item.||Spells are magical "
-"effects that can be cast from a scroll, a staff or memorized from a book. "
-"Spells may or may not require mana to use and are available to all classes.||"
-"Spells cast from a scroll cost no mana to use, but are limited to only one "
-"charge. Casting a spell from a scroll is accomplished by either right-"
-"clicking on the scroll or, if it is located in our belt, pressing the "
-"corresponding number on the keyboard. Scrolls can also be readied in the "
-"Speedbook and are represented by a red icon/button in the 'select current "
-"spell' area.||Spells cast from staffs cost no mana to use, but are limited "
-"by the number of charges available. To cast spells from a staff, it must "
-"first be equipped. The 'select current spell' icon/button will change to "
-"indicate that the spell on the staff is currently ready to cast. Scrolls can "
-"also be readied in the Spellbook or Speedbook and are represented by an "
-"orange icon/button in the 'select current spell' area.||Spells that are "
-"memorized cost mana to cast, but they can be used as long as the character "
-"has mana to power them. The Warrior and Rogue start the game with no "
-"memorized spells while the sorcerer begins with Firebolt.  If the character "
-"finds a book in the labyrinth, he can memorize the spell written in that "
-"book by opening the Inventory screen and right-clicking on the book.  This "
-"will make that spell always available to the character for casting. "
-"Memorized spells can be readied through either the Spellbook or Speedbook "
-"and are represented by a blue icon/button in the 'select current spell' "
-"area.||$Important note on books:|Reading more than one book increases your "
-"knowledge of that spell and gives you the spell at a higher level. The "
-"higher the level of a spell the more effective it is.||While some spells "
-"affect the caster, other spells require a target. These targeted spells are "
-"cast in the direction that you indicate with your cursor on the play area.  "
-"If you highlight a creature, you will cast that spell at that creature.  Not "
-"all items within the labyrinth can be targeted.||Example: A fireball spell "
-"will travel at the creature or to the location you right-click on.  A "
-"Healing spell will simply add health to your character while diminishing his "
-"available mana and requires no targeting.||You can also set a spell or "
-"scroll as a Hotkey position for instant selection.  Start by opening the pop-"
-"up menu as described in the skill section above.  Assign Hotkeys by hitting "
-"the F5, F6, F7 or F8 keys on your keyboard after scrolling through the "
-"available spells and highlighting the one you wish to assign. ||$Health and "
-"Mana:|The two orbs in the Information Bar display your life and mana. The "
-"red sphere of fluid on the left side of the control panel represents the "
-"overall health of your character. When the fluid is gone - your character is "
-"dead.||The blue fluid on the right side of the control panel represents your "
-"character's available mana. Mana is the magical force used by your character "
-"to cast spells.  When the liquid in the sphere is low or depleted, you may "
-"be unable to cast some (or all) of your spells.||$Information Bar:|The "
-"Information Bar is where you receive detailed information in Diablo and "
-"interact with much of your surroundings.  Here is a quick run-down of the "
-"control panel areas and their use:||CHAR: This button is used to access your "
-"Character Statistics screen|INV:  This button is used to access your "
-"Inventory screen|Quest: This button displays your Quest Log (inactive in "
-"Shareware version)|Automap: This button activates the mapping overlay|Menu: "
-"This button activates the game menu screen|Spells: This button is used to "
-"access your Spellbook|Current Spell: This is the spell that has been readied "
-"for immediate casting|Life Orb: This is the amount of health your character "
-"currently has|Mana Orb: This is the amount of mana your character currently "
-"has|Multiplayer Message: This activates the Message Area|Description Area: "
-"This is where any important information about creatures or items you can "
-"interact with is displayed. This is also where you will enter the text you "
-"wish to send when sending multiplayer messages.||$Character Info:|Toggle the "
-"Character Statistics Screen on and off by clicking the <CHAR button on the "
-"Information Bar.  This screen shows the 'nuts and bolts' of your character.  "
-"There are four major attributes that dictate how your character progresses "
-"in the game.||STRENGTH: This is how physically powerful your character is. "
-"This statistic plays a large part in  determining how much damage you can do "
-"when attacking creatures.||MAGIC: This is how attuned your character is with "
-"the arcane powers of the world. This statistic plays a large part in  "
-"determining how much mana you have available for casting spells.||DEXTERITY: "
-"This is how quick of foot and hand your character is. This statistic plays a "
-"large part in  determining the chance you have to hit creatures in combat.||"
-"VITALITY: This is how physically fit your character is. This statistic plays "
-"a large part in  determining how much health your character has when he is "
-"undamaged.||$In Game Menu:|To activate the Game Menu, click the MENU button "
-"on the Information Bar.  You have three options in this menu:||New Game: "
-"This exits you from your current game and returns you to the Main Menu.||"
-"Options: This opens the options menu that allows you to adjust your music "
-"and sound effects settings as well as the gamma level of the screen.||Quit "
-"Game: This exits the program. Please note that this automatically saves your "
-"character.||$Auto-map:|Your character automatically maps where he has been "
-"in the labyrinth.  To access the auto-map, click the MAP button on the "
-"Information Bar.  You can also press TAB on your keyboard to activate the "
-"auto-map. Zooming in and out of the map is done with the + and - keys while "
-"scrolling the map uses the arrow keys.|&"
+"Guida Diablo Shareware||$Tasti:|Diablo può essere giocato esclusivamente \"\n"
+"con i controlli del mouse.  Ci sono momenti, tuttavia, in cui potresti voler usare "
+"scorciatoie per alcuni comandi usando la tastiera. Queste scorciatoie sono \"\n"
+"elencate di seguito:||F1:    Mostra la Guida|Esc:    Mostra menu principale|"
+"Tab:    Mostra la Mappa|Spazio:  Rimuove eventuali menu a comparsa o mappe "
+"dall'area di gioco|S:  Mostra Speedbook|B:  Mostra Incantesimi|I:  Mostra "
+"Inventario |C:  Mostra dettagli del Personaggio|Z:  Ingrandisce e rimpicciolisce "
+"la schermata di gioco|F:  Riduci luminosità dello schermo|G:  Aumenta luminosità "
+"dello schermo|Q:  Mostra le Missioni (non attivo nella versione Shareware)|1 - 8:  "
+"Usa quell'oggetto dalla cintura|F5, F6, F7, F8:  Imposta una scorciatoia per "
+"un'abilità o un incantesimo selezionato|Maiusc + Clic Sinistro: usa qualsiasi arma "
+"senza muoverti|Maiusc + Clic Sinistro (in dettagli personaggio): Assegna tutti i "
+"punti |Maiusc + Clic Sinistro (in inventario): Sposta oggetto nella cintura o "
+"usalo/non usarlo|Maiusc + Clic Sinistro (in cintura): Sposta oggetto in "
+"inventario|||$Movimento:|Il movimento è controllato dal mouse. Il guanto di sfida "
+"sullo schermo è il tuo cursore. Usalo per indicare la destinazione del tuo "
+"personaggio e poi clicca con il tasto sinistro per spostarti in quell'area. Se "
+"tieni premuto il pulsante del mouse mentre ti muovi, il personaggio continuerà a "
+"muoversi in quella direzione.||$Selezione Oggetti:|Ciò con cui puoi interagire "
+"all'interno del gioco è facilmente identificabile. Sposta il cursore su qualsiasi "
+"oggetto o creatura. Se l'oggetto può essere raccolto, attaccato, attivato o "
+"utilizzato in qualsiasi modo, verrà evidenziato. Nell'area di testo del pannello "
+"di controllo viene visualizzata una descrizione dell'oggetto evidenziato.||"
+"Esempio: se selezioni una porta e fai clic sinistro del mouse, il personaggio "
+"camminerà verso la porta e la aprirà. Se fai clic sinistro del mouse su un'arma "
+"evidenziata, il personaggio si avvicinerà ad essa e la metterà nel suo inventario. "
+"Se fai clic sinistro su una creatura evidenziata...|$Combattimento:|Il "
+"combattimento inizia facendo clic sinistro del mouse su una creatura che è stata "
+"evidenziata. Se il tuo personaggio è equipaggiato con un'arma da mischia (spada, "
+"mazza, ascia, ecc.) egli si sposterà e attaccherà. Se il tuo personaggio è "
+"equipaggiato con un arco, facendo clic sinistro del mouse verrà lanciata una "
+"freccia sulla creatura evidenziata. Tenendo premuto il tasto Maiusc e quindi "
+"facendo clic sinistro, il personaggio attacca senza muoversi.||$Raccogliere "
+"oggetti:|Se fai clic sinistro del mouse su un oggetto, come un'arma, uno scudo, "
+"un'armatura o un libro, il tuo personaggio si sposterà su quell'oggetto e lo "
+"aggiungerà automaticamente al suo inventario.||Oggetti utilizzabili di piccole "
+"dimensioni, come una pozione o una pergamena, vengono automaticamente posizionate "
+"nella tua \"cintura\", situata nella parte superiore della barra dell'Interfaccia. "
+"Quando un oggetto viene inserito nella cintura, in quella casella appare un "
+"piccolo numero. Gli oggetti possono essere usati facendo clic destro sull'oggetto "
+"o premendo il numero corrispondente sulla tastiera.||Se non hai abbastanza spazio "
+"nell'inventario o nella cintura, l'oggetto che cerchi di raccogliere non verrà "
+"preso. Apri l'inventario e prova a riorganizzare o rimuovere gli oggetti per "
+"trasportare ciò che desideri o di cui hai veramente bisogno.||$Inventario:|Puoi "
+"mostrare o meno l'Inventario facendo clic sul pulsante INV> sul pannello di "
+"controllo. Gli oggetti possono essere spostati nell' inventario selezionandoli e "
+"quindi facendo clic sinistro del mouse per raccoglierli. Quando raccogli un "
+"oggetto ad inventario aperto, il cursore si trasforma nell'oggetto. Puoi quindi "
+"posizionare questo oggetto in spazi vuoti del tuo inventario, scambiarli con altri "
+"o equipaggiarli.||Se hai un oggetto che non desideri più trasportare, prendilo dal "
+"tuo inventario e poi fai clic nell'area di gioco per rilasciarlo.||"
+"$Equipaggiamento:|Per equipaggiare un oggetto, apri l'inventario e raccogli "
+"l'oggetto desiderato, dal gioco o dall'inventario, posizionandolo nella casella "
+"appropriata. Armi e scudi vanno negli ampi spazi a destra o a sinistra della "
+"figura. Armi a due mani come archi e asce precludono l'uso di uno scudo e "
+"occuperanno entrambi questi ampi spazi.||Mantelli, vesti, corazze e tutte le altre "
+"armature devono entrare nello spazio centrale del busto della figura.||Elmi e "
+"copricapi nello spazio superiore della figura.||Gli anelli vanno nei piccoli spazi "
+"delle mani della figura.||Gli amuleti vanno nel piccolo spazio vicino al collo "
+"della figura.||Per cambiare gli oggetti equipaggiati, raccogli un nuovo oggetto e "
+"posizionalo sopra l'oggetto che desideri rimuovere. Il tuo personaggio cambierà "
+"automaticamente gli oggetti e il cursore si trasformerà nell'oggetto che era in "
+"quello spazio.||$Oggetti Utilizzabili:|Pozioni, elisir e libri sono classificati "
+"come oggetti utilizzabili. Questi oggetti possono essere utilizzati facendo clic "
+"destro del mouse su di essi nell'inventario. I libri sono troppo grandi per essere "
+"riposti nella cintura, ma eventuali pozioni o pergamene che vengono messe lì "
+"possono essere utilizzati anche premendo il numero corrispondente sulla tastiera.||"
+"$Monete:|Puoi selezionare una quantità specifica di monete da rilasciare facendo "
+"clic destro del mouse su una pila d'oro nel tuo inventario. Apparirà una finestra "
+"di dialogo che ti permetterà di selezionare una specifica quantità di monete da "
+"prendere. Dopo aver inserito il numero, il cursore si trasformerà in quella "
+"quantità di oro.||$Dettagli Oggetto:|Molti oggetti in Diablo condividono alcuni "
+"attributi. Si tratta di danno, durata, cariche e requisiti minimi..||Danno: è "
+"rappresentato da un raggio che indica il danno minimo e massimo che l'oggetto può "
+"infliggere. Una spada corta ha un (2-6) dopo il nome, il che significa che "
+"infligge un minimo di due danni e un massimo di sei quando colpisce. Il danno può "
+"essere modificato dalla qualità dell'arma, dalla forza del personaggio e dagli "
+"effetti magici.||Durabilità: è la quantità di danni che un oggetto può subire "
+"prima che sia reso inutilizzabile. È rappresentata da un rapporto tra la "
+"durevolezza attuale e quella massima. Uno scudo ccon durevolezza di 15/20 ha "
+"ancora 15 punti di danno che può subire prima di diventare inutilizzabile. La "
+"durevolezza massima può essere influenzata dalla qualità dell'oggetto, dagli "
+"incantesimi o dalle riparazioni effettuate sull'oggetto. Quella minima può essere "
+"aumentata riparando un oggetto.||Cariche: ad alcuni oggetti sono associate delle "
+"cariche. Le cariche indicano quante volte quell'oggetto può essere usato per "
+"lanciare l'incantesimo o l'effetto indicato nei suoi dettagli. Le cariche sono "
+"rappresentate da un rapporto tra cariche rimaste e massime. Una verga con cariche "
+"2/5 può lanciare solo altri 2 incantesimi. Tuttavia, può ancora essere usato per "
+"colpire. Le cariche massime possono essere influenzate dalla magia o da "
+"incantesimi lanciati sull'oggetto. Quelle minime possono essere aumentate "
+"ricaricando l'oggetto.|Requisiti Minimi: questi sono i requisiti minimi che un "
+"personaggio deve soddisfare per impugnare l'oggetto. Più potente è un oggetto, "
+"maggiori saranno i requisiti minimi. Se un personaggio non soddisfa questi "
+"requisiti, non sarà in grado di equipaggiare l'oggetto e il suo nome e i dettagli "
+"verranno visualizzati in rosso. La grafica dell'oggetto avrà anche una tinta rossa "
+"nell'Inventario.||$Classi Oggetti:|Ci sono tre classi di oggetti in Diablo: "
+"Mondano, Magico e Unico: ||I Mondani non hanno attributi speciali. I dettagli sono "
+"visualizzati in bianco.||I Magici sono rappresentati da nomi e dettagli in blu. "
+"Usa l'incantesimo Identifica o parla con Cain in città per determinarne le "
+"proprietà e gli attributi esatti.||Gli Unici sono rappresentati da nomi e "
+"descrizioni testuali d'oro. Usa l'incantesimo Identifica o parla con Cain in città "
+"per determinarne le proprietà e gli attributi esatti.||$Abilità ed Incantesimi:|"
+"Puoi accedere alle abilità e incantesimi facendo clic sinistro del mouse sul "
+"pulsante SPELLS nella barra dell'interfaccia. Questo \"Libro degli incantesimi\" "
+"contiene tutte le abilità e gli incantesimi che il tuo personaggio conosce. Anche "
+"gli incantesimi disponibili con la verga sono elencati qui. Facendo clic sinistro "
+"del mouse sull'icona dell'incantesimo che desideri preparare, lo posizionerai "
+"nell'icona/area \"seleziona incantesimo corrente\" e lo imposterai come "
+"incantesimo pronto, che può essere lanciato semplicemente facendo clic destro del "
+"mouse nell'area di gioco.||Facendo clic sinistro del mouse sul pulsante "
+"\"seleziona incantesimo corrente\" si aprirà anche uno \"Speedbook\" che ti "
+"consente di preparare per l'uso un'abilità o un incantesimo. Per usare un'abilità "
+"o un incantesimo preparato, fai semplicemente clic destro del mouse nell'area di "
+"gioco.|Maiusc + clic sinistro sul pulsante \"seleziona incantesimo corrente\" "
+"cancellerà l'incantesimo pronto||Le abilità sono le qualità innate del tuo "
+"personaggio. Esse sono diverse a seconda della classe scelta e non richiedono mana "
+"da usare.||Guerriero:|Il Guerriero ha l'abilità di riparare gli oggetti. Ciò gli "
+"consente di riparare un oggetto usato o danneggiato in combattimento. Per fare "
+"ciò, seleziona l'Abilità di Riparazione tramite Libro Incantesimi o Speedbook e "
+"fai clic destro come se stessi lanciando un incantesimo. Il cursore si trasformerà "
+"in un'icona a forma di martello che utilizzerai per selezionare l'oggetto da "
+"riparare. Sebbene riparare un oggetto in questo modo ridurrà la sua durata "
+"massima, può essere fatto senza lasciare il labirinto.||Anche il Fabbro può "
+"riparare gli oggetti a un prezzo. Quando il Fabbro esegue questo servizio, "
+"diminuisce la durata massima dell'oggetto.||Ladro:|Il Ladro ha l'abilità di "
+"disarmare le trappole. Ciò gli consente non solo di rimuovere le trappole, ma "
+"agisce anche come \"sesto senso\" che lo avverte di dove si trovano le trappole. "
+"Per farlo, seleziona l'abilità Disarma Trappola tramite Libro Incantesimi o "
+"Speedbook e fai clic destro del mouse come se stessi lanciando un incantesimo. Il "
+"cursore si trasformerà in un mirino che utilizzerai per selezionare l'elemento da "
+"disarmare. Il successo di questo tentativo si basa sul livello del Ladro e "
+"sull'esperienza di chiunque abbia piazzato la trappola.||Stregone:|Lo Stregone ha "
+"l'abilità di Ricarica Verga. Questo gli permette di concentrare il suo mana in un "
+"bastone prosciugato delle sue energie magiche. Per farlo, seleziona l'abilità "
+"Ricarica Verga tramite Libro Incantesimi o Speedbook e fai clic destro del mouse "
+"come se stessi lanciando un incantesimo. Il cursore si trasformerà in una Verga "
+"che utilizzerai per selezionare l'elemento da ricaricare. Sebbene ricaricare un "
+"bastone in questo modo ridurrà le sue cariche massime, può essere fatto senza "
+"lasciare il labirinto.||Anche la Strega può ricaricare la verga a un prezzo. "
+"Quando la Strega esegue questo servizio, riduce le cariche massime dell'oggetto.||"
+"Gli Incantesimi sono effetti magici lanciati da una pergamena, una verga o "
+"memorizzati in un libro. Gli Incantesimi possono richiedere o meno mana per essere "
+"usati e sono disponibili per tutte le classi.||Gli Incantesimi lanciati da una "
+"pergamena non costano mana da usare, ma sono limitati a una sola carica. Lanciare "
+"un incantesimo da una pergamena si ottiene facendo clic destro del mouse sulla "
+"pergamena o, se si trova nella nostra cintura, premendo il numero corrispondente "
+"sulla tastiera. Le pergamene possono anche essere preparate nello Speedbook e sono "
+"rappresentate da un'icona/pulsante rosso nell'area \"seleziona incantesimo corrente"
+"\".||Gli Incantesimi lanciati dalla verga non costano mana, ma sono limitati dal "
+"numero di cariche disponibili. Per lanciare incantesimi da una verga, deve prima "
+"equipaggiarlo. L'icona/pulsante \"seleziona incantesimo corrente\" cambierà per "
+"indicare che l'incantesimo sulla verga è attualmente pronto per essere lanciato. "
+"Le pergamene possono anche essere preparate nel Libro Incantesimi o nello "
+"Speedbook e sono rappresentate da un'icona/pulsante arancione nell'area "
+"\"seleziona l'incantesimo corrente\".||Gli Incantesimi memorizzati costano mana "
+"per essere lanciati, ma possono essere usati fintanto che il personaggio ha mana "
+"per potenziarli. Il Guerriero e il Ladro iniziano il gioco senza incantesimi "
+"memorizzati mentre il Mago inizia con Sfere Infuocate. Se il personaggio trova un "
+"libro nel labirinto, può memorizzare l'incantesimo scritto in quel libro aprendo "
+"l'Inventario e facendo clic destro del mouse sul libro. Questo renderà "
+"l'incantesimo sempre disponibile per il lancio. Gli Incantesimi memorizzati "
+"possono essere preparati tramite Libro Incantesimi o Speedbook e sono "
+"rappresentati da un'icona/pulsante blu nell'area \"seleziona incantesimo corrente"
+"\".||$Nota importante sui libri:|Leggere più di un libro aumenta la tua conoscenza "
+"di quell'incantesimo e ne incrementa il livello. Più il livello di un incantesimo "
+"è alto, più esso è efficace.||Mentre alcuni incantesimi influenzano l'incantatore, "
+"altri richiedono un bersaglio. Questi incantesimi mirati vengono lanciati nella "
+"direzione indicata dal cursore sull'area di gioco. Se evidenzi una creatura, "
+"lancerai quell'incantesimo su quella creatura. Non tutti gli oggetti all'interno "
+"del labirinto possono essere bersagliati.||Esempio: un incantesimo Sfera Infuocata "
+"viaggerà verso la creatura o verso la posizione su cui fai clic destro del mouse. "
+"Un incantesimo di guarigione aggiungerà semplicemente salute al tuo personaggio "
+"diminuendo il suo mana disponibile e non richiede bersagli.||Puoi anche impostare "
+"un incantesimo o scegliere un tasto rapido per la selezione istantanea. Inizia "
+"aprendo il menu a comparsa come descritto nella sezione abilità sopra. Assegna i "
+"tasti rapidi premendo i tasti F5, F6, F7 o F8 sulla tastiera dopo aver fatto "
+"scorrere gli incantesimi disponibili ed evidenziando quello che desideri "
+"assegnare.||$Salute e Mana:|Le due sfere nella barra dei dettagli mostrano la tua "
+"vita e il tuo mana. La sfera col fluido rosso a sinistra del pannello rappresenta "
+"la salute generale del tuo personaggio. Quando il fluido è finito, il tuo "
+"personaggio è morto.||Il fluido blu sul lato destro del pannello rappresenta il "
+"mana disponibile del tuo personaggio. Il mana è la forza magica usata dal tuo "
+"personaggio per lanciare incantesimi. Quando il liquido nella sfera è basso o "
+"esaurito, potresti non essere in grado di lanciare alcuni (o tutti) i tuoi "
+"incantesimi.||$Barra dei Dettagli:|La Barra dei Dettagli è dove ricevi "
+"informazioni in Diablo e interagisci con ciò che ti circonda. Ecco una rapida "
+"carrellata delle aree del pannello e del loro utilizzo:||CHAR: Utilizzato per "
+"accedere alla statistiche del personaggio|INV: Utilizzato per accedere "
+"all'Inventario|QUEST: Mostra la tua missione (inattivo nella versione Shareware)|"
+"MAP: Attiva la sovrapposizione della mappa|MENU: Attiva la schermata del menu di "
+"gioco|SPELLS: Utilizzato per accedere al Libro degli Incantesimi|Incantesimo "
+"corrente: l'incantesimo preparato per il lancio immediato|Sfera Vitale: la "
+"quantità di salute che il tuo personaggio ha attualmente|Sfera del Mana: la "
+"quantità di mana che il tuo personaggio ha attualmente|Messaggio Multigiocatore: "
+"Attiva l'area dei messaggi|Area Dettagli: Tutte le informazioni importanti su "
+"creature o oggetti con cui puoi interagire. Qui inserirai anche il testo da "
+"inviare come messaggio multigiocatore.||$Dettagli Personaggio:|Mostra le "
+"statistiche del personaggio facendo clic sul pulsante <CHAR sulla Barra dei "
+"Dettagli. Essa mostra \"gli ingranaggi\" del tuo personaggio. Ci sono quattro "
+"attributi principali che determinano il modo in cui il personaggio evolve.||FORZA: "
+"Quanto è potente fisicamente il personaggio. Gioca un ruolo importante nel "
+"determinare quanto danno puoi fare quando attacchi le creature.||MAGIA: Il modo in "
+"cui personaggio è in sintonia con i poteri arcani del mondo. Gioca un ruolo "
+"importante nel determinare quanto mana hai a disposizione per lanciare magie.||"
+"DESTREZZA: Quanto è veloce il personaggio con i piedi e le mani. Gioca un ruolo "
+"importante nel determinare la possibilità che hai di colpire le creature in "
+"combattimento.||VITALITÀ: Quanto è fisicamente in forma il personaggio. Gioca un "
+"ruolo importante nel determinare la salute del personaggio quando non è ferito.||"
+"$Menu di Gioco:|Per attivare il menu di gioco, fai clic sul pulsante MENU nella "
+"barra dei dettagli. Ci sono tre voci:||Nuovo: Ti fa uscire dal gioco corrente e ti "
+"riporta al Menu Principale.||Opzioni: Apre il menu delle opzioni che ti permette "
+"di regolare musica ed effetti sonori o il livello gamma dello schermo.||Esci: Esce "
+"dal programma. Nota che questo salva automaticamente il tuo personaggio.||$Mappa:| "
+"Il personaggio mappa automaticamente dove è stato nel labirinto. Per accedere alla "
+"mappa, fare clic sul pulsante MAP sulla Barra dei Dettagli. Puoi anche premere TAB "
+"sulla tastiera per attivare la mappa. Puoi ingrandire o meno la mappa con i tasti "
+"+ e -. Puoi scorrere la mappa con i tasti freccia.|&"
 
 #: Source/help.cpp:384
 msgid ""
 "$Keyboard Shortcuts:|F1:    Open Help Screen|Esc:   Display Main Menu|Tab:   "
-"Display Auto-map|Space: Hide all info screens|S: Open Speedbook|B: Open "
-"Spellbook|I: Open Inventory screen|C: Open Character screen|Q: Open Quest "
-"log|F: Reduce screen brightness|G: Increase screen brightness|Z: Zoom Game "
-"Screen|+ / -: Zoom Automap|1 - 8: Use Belt item|F5, F6, F7, F8:     Set "
-"hotkey for skill or spell|Shift + Left Mouse Button: Attack without moving|"
-"Shift + Left Mouse Button (on character screen): Assign all stat points|"
-"Shift + Left Mouse Button (on inventory): Move item to belt or equip/unequip "
-"item|Shift + Left Mouse Button (on belt): Move item to inventory||$Movement:|"
-"If you hold the mouse button down while moving, the character will continue "
-"to move in that direction.||$Combat:|Holding down the shift key and then "
-"left-clicking allows the character to attack without moving.||$Auto-map:|To "
-"access the auto-map, click the 'MAP' button on the Information Bar or press "
-"'TAB' on the keyboard. Zooming in and out of the map is done with the + and "
-"- keys. Scrolling the map uses the arrow keys.||$Picking up Objects:|Useable "
-"items that are small in size, such as potions or scrolls, are automatically "
-"placed in your 'belt' located at the top of the Interface bar . When an item "
-"is placed in the belt, a small number appears in that box. Items may be used "
-"by either pressing the corresponding number or right-clicking on the item.||"
-"$Gold|You can select a specific amount of gold to drop byright-clicking on a "
-"pile of gold in your inventory.||$Skills & Spells:|You can access your list "
-"of skills and spells by left-clicking on the 'SPELLS' button in the "
-"interface bar. Memorized spells and those available through staffs are "
-"listed here. Left-clicking on the spell you wish to cast will ready the "
-"spell. A readied spell may be cast by simply right-clicking in the play "
-"area.||$Using the Speedbook for Spells|Left-clicking on the 'readied spell' "
-"button will open the 'Speedbook' which allows you to select a skill or spell "
-"for immediate use.  To use a readied skill or spell, simply right-click in "
-"the main play area.|Shift + Left-clicking on the 'select current spell' "
-"button will clear the readied spell||$Setting Spell Hotkeys|You can assign "
-"up to four Hotkeys for skills, spells or scrolls.  Start by opening the "
-"'speedbook' as described in the section above. Press the F5, F6, F7 or F8 "
-"keys after highlighting the spell you wish to assign.||$Spell Books|Reading "
-"more than one book increases your knowledge of that spell, allowing you to "
-"cast the spell more effectively.|&"
+"Display Auto-map|Space: Hide all info screens|S: Open Speedbook|B: Open Spellbook|"
+"I: Open Inventory screen|C: Open Character screen|Q: Open Quest log|F: Reduce "
+"screen brightness|G: Increase screen brightness|Z: Zoom Game Screen|+ / -: Zoom "
+"Automap|1 - 8: Use Belt item|F5, F6, F7, F8:     Set hotkey for skill or spell|"
+"Shift + Left Mouse Button: Attack without moving|Shift + Left Mouse Button (on "
+"character screen): Assign all stat points|Shift + Left Mouse Button (on "
+"inventory): Move item to belt or equip/unequip item|Shift + Left Mouse Button (on "
+"belt): Move item to inventory||$Movement:|If you hold the mouse button down while "
+"moving, the character will continue to move in that direction.||$Combat:|Holding "
+"down the shift key and then left-clicking allows the character to attack without "
+"moving.||$Auto-map:|To access the auto-map, click the 'MAP' button on the "
+"Information Bar or press 'TAB' on the keyboard. Zooming in and out of the map is "
+"done with the + and - keys. Scrolling the map uses the arrow keys.||$Picking up "
+"Objects:|Useable items that are small in size, such as potions or scrolls, are "
+"automatically placed in your 'belt' located at the top of the Interface bar . When "
+"an item is placed in the belt, a small number appears in that box. Items may be "
+"used by either pressing the corresponding number or right-clicking on the item.||"
+"$Gold|You can select a specific amount of gold to drop byright-clicking on a pile "
+"of gold in your inventory.||$Skills & Spells:|You can access your list of skills "
+"and spells by left-clicking on the 'SPELLS' button in the interface bar. Memorized "
+"spells and those available through staffs are listed here. Left-clicking on the "
+"spell you wish to cast will ready the spell. A readied spell may be cast by simply "
+"right-clicking in the play area.||$Using the Speedbook for Spells|Left-clicking on "
+"the 'readied spell' button will open the 'Speedbook' which allows you to select a "
+"skill or spell for immediate use.  To use a readied skill or spell, simply right-"
+"click in the main play area.|Shift + Left-clicking on the 'select current spell' "
+"button will clear the readied spell||$Setting Spell Hotkeys|You can assign up to "
+"four Hotkeys for skills, spells or scrolls.  Start by opening the 'speedbook' as "
+"described in the section above. Press the F5, F6, F7 or F8 keys after highlighting "
+"the spell you wish to assign.||$Spell Books|Reading more than one book increases "
+"your knowledge of that spell, allowing you to cast the spell more effectively.|&"
 msgstr ""
-"$Lista Tasti Rapidi:|F1:    Apri Guida|Esc:   Menu|Tab:   Mappa di Gioco|"
-"Space: Nascondi Finestre|S: Elenco Magie|B: Libro Magie|I: Accedi "
-"all'Inventario|C: Caratteristiche Eroe|Q: DiarioMissioni|F: Riduci la "
-"Luminosità|G: Aumenta la Luminosità|Z: Zoom di Gioco|+ / -: Zoom Mappa|1 - "
-"8: Usa Cintura|F5, F6, F7, F8:     Tasti rapidi di Magie e Abilità|Shift"
-"+Left Click: Attacco dal Posto||$Movimento|Mentre il Mouse è in movimento, "
-"la pressione sul pulsante permetterà lo spostamento del personaggio.||"
-"$Attacco|Tieni premuto 'Shift' e clicca il Tasto Sinistro del Mouse per "
-"attaccare senza doverti muovere. ||$Mappa |Attiva la Mappa cliccando il "
-"tasto 'MAPPA' del menù rapido o premendo 'TAB' sulla tastiera. Per "
-"ingrandire o diminuire le dimensioni premi sui tasti + e -. Per lo "
-"spostamento utilizza i tasti cursore.||$Raccolta di Oggetti|Gli Oggetti "
-"Utilizzabili di piccola taglia, come pozioni e pergamene, una volta raccolti "
-"vengono automaticamente collocati nella cintura e attribuiti di un numero "
-"che ne permette l'utilizzo mediante la sua pressione su tastiera, o "
-"semplicemente cliccando sull'oggetto stesso con il tasto destro del mouse. ||"
-"$Oro |Premi il tasto destro del mouse su una pila d'Oro del tuo inventario "
-"per lasciare un importo specifico.||$Abilità & Magie|Puoi visualizzare "
-"l'elenco delle Abilità e degli Incantesimi dei quali disponi cliccando sul "
-"tasto 'MAGIÈ del menù rapido. Utilizza il tasto sinistro del mouse per "
-"selezionare la magia desiderata. Per lanciare gli incantesimi è sufficiente "
-"premere con il tasto destro del mouse all'interno dell'area di Gioco.||"
-"$Usare le Magie in modo Rapido |Premendo con il Tasto Sinistro del Mouse sul "
-"'LEGGIO' situato in basso a destra della schermata di gioco, apparirà un "
-"elenco completo delle magie e delle abilità disponibili, per un uso rapido "
-"ed immediato.||$Assegna Tasti a Magie|Puoi assegnare fino a 4 tasti per le "
-"Abilità, gli Incantesimi o le Pergamene. Per farlo è sufficiente aprire il "
-"'LEGGIO', e una volta evidenziata la magia desiderata, premere uno dei tasti "
-"fra F5, F6, F7 o F8. ||$Tomi Magici|Leggendo i Libri Magici accrescerai la "
-"tua conoscienza degli Incantesimi, aumentandone livello ed Efficacia stessa.|"
-"&"
+"$Scorciatoie:|F1:    Mostra Guida|Esc:   Mostra Menu|Tab:   Mostra Mappa|Spazio: "
+"Nascondi Finestre|S: Apri Speedbook|B: Apri Incantesimi|I: Inventario|C: Dettagli "
+"Personaggio|Q: Missioni|F: Riduci Luminosità|G: Aumenta Luminosità|Z: Zoom Gioco|"
+"+ / -: Zoom Mappa|1 - 8: Usa Cintura|F5, F6, F7, F8:     Imposta tasti Magie e "
+"Abilità|Maiusc+Clic Sinistro: Attacco sul Posto|Maiusc + Clic Sinistro (in "
+"dettagli personaggio): Assegna tutti i punti|Maiusc + Clic Sinistro (in "
+"inventario): Sposta oggetto in cintura o equipaggia|Maiusc + Clic Sinistro (in "
+"cintura): Sposta oggetto in inventario||||$Movimento|Tieni premuto il mouse "
+"durante un movimento, il personaggio continuerà a spostarsi in quella direzione.||"
+"$Attacco:|Tieni premuto 'Maiusc' e clicca col sinistro del mouse per attaccare "
+"senza muoverti.||$Mappa:|Per accedere alla mappa, fare clic sul pulsante \"MAPP\" "
+"sulla Barra dei Dettagli o premere \"TAB\" sulla tastiera. L'ingrandimento e la "
+"riduzione della mappa si effettuano con i tasti + e -. Lo scorrimento con i tasti "
+"freccia.||$Raccogliere Oggetti:|Gli oggetti utilizzabili di piccole dimensioni, "
+"come pozioni o pergamene, vengono automaticamente posizionati nella tua \"cintura"
+"\" situata nella parte superiore della barra dell'Interfaccia. Quando un oggetto "
+"viene inserito nella cintura, in quella casella appare un piccolo numero. Gli "
+"oggetti possono essere utilizzati premendo il numero corrispondente o facendo clic "
+"destro del mouse sull'oggetto.||$Oro|Puoi selezionare una quantità specifica di "
+"monete da rilasciare facendo clic destro del mouse su una pila d'oro "
+"nell'inventario.||$Abilità & Incantesimi:|Puoi accedere alle abilità e incantesimi "
+"facendo clic sinistro del mouse sul pulsante \"SPELLS\" nella barra "
+"dell'interfaccia. Gli incantesimi memorizzati e quelli disponibili tramite la "
+"verga sono elencati qui. Fare clic sinistro del mouse sull'incantesimo che si "
+"desidera lanciare renderà pronto l'incantesimo. Un incantesimo pronto può essere "
+"lanciato semplicemente col clic destro del mouse nell'area di gioco.||$Speedbook "
+"per gli Incantesimi|Facendo clicsinistro sul pulsante \"Incantesimo pronto\" si "
+"aprirà lo \"Speedbook\" che ti consente di selezionare un'abilità o un incantesimo "
+"per uso immediato. Per usare un'abilità o un incantesimo preparato, fai "
+"semplicemente clic destro del mouse nell'area di gioco.|Maiusc + Clic sinistro sul "
+"pulsante \"seleziona incantesimo corrente\" cancellerà l'incantesimo pronto||"
+"$Scorciatoie per Incantesimi|Puoi assegnarne fino a quattro Tasti rapidi per "
+"abilità, incantesimi o pergamene. Inizia aprendo lo \"speedbook\" come descritto "
+"nella sezione precedente. Premi i tasti F5, F6, F7 o F8 dopo aver evidenziato "
+"l'incantesimo che desideri assegnare.||$Libri di Incantesimi|Leggere più di un "
+"libro aumenta la tua conoscenza di quell'incantesimo, permettendoti di lanciarlo "
+"in modo più efficace.|&"
 
 #: Source/help.cpp:490
 msgid "Hellfire Help"
@@ -2122,7 +2081,7 @@ msgstr "Verga Corta del Mana"
 
 #: Source/itemdat.cpp:22
 msgid "Cleaver"
-msgstr "Cleaver"
+msgstr "Mannaia"
 
 #: Source/itemdat.cpp:23 Source/itemdat.cpp:392
 msgid "The Undead Crown"
@@ -2182,7 +2141,7 @@ msgstr "Elisir Spettrale"
 
 #: Source/itemdat.cpp:37 Source/monstdat.cpp:79
 msgid "Blood Stone"
-msgstr "Pietr"
+msgstr "Pietra di Sangue"
 
 #: Source/itemdat.cpp:38
 msgid "Cathedral Map"
@@ -2321,7 +2280,7 @@ msgstr "Cappa"
 
 #: Source/itemdat.cpp:71
 msgid "Rags"
-msgstr "Cenci"
+msgstr "Vestito"
 
 #: Source/itemdat.cpp:72
 msgid "Cloak"
@@ -2433,7 +2392,7 @@ msgstr "Gran Pozione di Giovinezza"
 
 #: Source/itemdat.cpp:100 Source/items.cpp:67
 msgid "Oil of Accuracy"
-msgstr "Olio della Precisione"
+msgstr "Olio di Precisione"
 
 #: Source/itemdat.cpp:101 Source/items.cpp:69
 msgid "Oil of Sharpness"
@@ -2457,7 +2416,7 @@ msgstr "Elisir di Destrezza"
 
 #: Source/itemdat.cpp:106
 msgid "Elixir of Vitality"
-msgstr "Elisir di Vitalita"
+msgstr "Elisir di Vitalità"
 
 #: Source/itemdat.cpp:107
 msgid "Scroll of Healing"
@@ -2469,7 +2428,7 @@ msgstr "Pergamena della Ricerca"
 
 #: Source/itemdat.cpp:109
 msgid "Scroll of Lightning"
-msgstr "PergamenaDelFulmine"
+msgstr "Pergamena del Fulmine"
 
 #: Source/itemdat.cpp:112
 msgid "Scroll of Fire Wall"
@@ -2501,15 +2460,15 @@ msgstr "Pergamena Ondata di Fuoco"
 
 #: Source/itemdat.cpp:120
 msgid "Scroll of Fireball"
-msgstr "Pergamena PallaDiFuoco"
+msgstr "Pergamena Sfera Infuocata"
 
 #: Source/itemdat.cpp:121
 msgid "Scroll of Stone Curse"
-msgstr "Pergamena Rocce Malefiche"
+msgstr "Pergamena Pietra Malefica"
 
 #: Source/itemdat.cpp:122
 msgid "Scroll of Chain Lightning"
-msgstr "Pergamena Fulmini a Catena"
+msgstr "Pergamena della Tempesta"
 
 #: Source/itemdat.cpp:123
 msgid "Scroll of Guardian"
@@ -2678,11 +2637,11 @@ msgstr "Verga Composita"
 
 #: Source/itemdat.cpp:170
 msgid "Quarter Staff"
-msgstr "LanciaOblunga"
+msgstr "Picca"
 
 #: Source/itemdat.cpp:171
 msgid "War Staff"
-msgstr "Randello"
+msgstr "Verga da Guerra"
 
 #: Source/itemdat.cpp:172 Source/itemdat.cpp:173 Source/itemdat.cpp:174
 msgid "Ring"
@@ -2791,7 +2750,7 @@ msgstr "Grave"
 
 #: Source/itemdat.cpp:209
 msgid "Vicious"
-msgstr "Vizioso"
+msgstr "Violento"
 
 #: Source/itemdat.cpp:210
 msgid "Brutal"
@@ -2823,7 +2782,7 @@ msgstr "Cupo"
 
 #: Source/itemdat.cpp:217
 msgid "Sharp"
-msgstr "Acuto"
+msgstr "Affilato"
 
 #: Source/itemdat.cpp:218 Source/itemdat.cpp:228
 msgid "Fine"
@@ -3003,11 +2962,11 @@ msgstr "di Serpente"
 
 #: Source/itemdat.cpp:264
 msgid "Drake's"
-msgstr "d'Anitra"
+msgstr "di Drago"
 
 #: Source/itemdat.cpp:265
 msgid "Dragon's"
-msgstr "di Drago"
+msgstr "di Dragone"
 
 #: Source/itemdat.cpp:266
 msgid "Wyrm's"
@@ -3095,7 +3054,7 @@ msgstr "protezione"
 
 #: Source/itemdat.cpp:295
 msgid "absorption"
-msgstr "assorbente"
+msgstr "assorbimento"
 
 #: Source/itemdat.cpp:296
 msgid "deflection"
@@ -3107,31 +3066,31 @@ msgstr "osmosi"
 
 #: Source/itemdat.cpp:298
 msgid "frailty"
-msgstr "fragile"
+msgstr "fragilità"
 
 #: Source/itemdat.cpp:299
 msgid "weakness"
-msgstr "debole"
+msgstr "debolezza"
 
 #: Source/itemdat.cpp:300
 msgid "strength"
-msgstr "potenza"
+msgstr "forza"
 
 #: Source/itemdat.cpp:301
 msgid "might"
-msgstr "mito"
+msgstr "potenza"
 
 #: Source/itemdat.cpp:302
 msgid "power"
-msgstr "forte"
+msgstr "potere"
 
 #: Source/itemdat.cpp:303
 msgid "giants"
-msgstr "enorme"
+msgstr "giganti"
 
 #: Source/itemdat.cpp:304
 msgid "titans"
-msgstr "titano"
+msgstr "titani"
 
 #: Source/itemdat.cpp:305
 msgid "paralysis"
@@ -3147,15 +3106,15 @@ msgstr "destrezza"
 
 #: Source/itemdat.cpp:308
 msgid "skill"
-msgstr "skill"
+msgstr "abilità"
 
 #: Source/itemdat.cpp:309
 msgid "accuracy"
-msgstr "accurato"
+msgstr "accuratezza"
 
 #: Source/itemdat.cpp:310
 msgid "precision"
-msgstr "preciso"
+msgstr "precisione"
 
 #: Source/itemdat.cpp:311
 msgid "perfection"
@@ -3163,7 +3122,7 @@ msgstr "perfezione"
 
 #: Source/itemdat.cpp:312
 msgid "the fool"
-msgstr "menzogna"
+msgstr "stolto"
 
 #: Source/itemdat.cpp:313
 msgid "dyslexia"
@@ -3175,35 +3134,35 @@ msgstr "magia"
 
 #: Source/itemdat.cpp:315
 msgid "the mind"
-msgstr "mentale"
+msgstr "mente"
 
 #: Source/itemdat.cpp:316
 msgid "brilliance"
-msgstr "brillante"
+msgstr "splendore"
 
 #: Source/itemdat.cpp:317
 msgid "sorcery"
-msgstr "fatato"
+msgstr "sortilegio"
 
 #: Source/itemdat.cpp:318
 msgid "wizardry"
-msgstr "magica"
+msgstr "magia"
 
 #: Source/itemdat.cpp:319
 msgid "illness"
-msgstr "tortura"
+msgstr "malattia"
 
 #: Source/itemdat.cpp:320
 msgid "disease"
-msgstr "malanno"
+msgstr "morbo"
 
 #: Source/itemdat.cpp:321
 msgid "vitality"
-msgstr "vitalita"
+msgstr "vitalità"
 
 #: Source/itemdat.cpp:322
 msgid "zest"
-msgstr "zest"
+msgstr "gusto"
 
 #: Source/itemdat.cpp:323
 msgid "vim"
@@ -3211,7 +3170,7 @@ msgstr "energia"
 
 #: Source/itemdat.cpp:324
 msgid "vigor"
-msgstr "vigor"
+msgstr "vigore"
 
 #: Source/itemdat.cpp:325
 msgid "life"
@@ -3219,7 +3178,7 @@ msgstr "vita"
 
 #: Source/itemdat.cpp:326
 msgid "trouble"
-msgstr "astrusa"
+msgstr "problema"
 
 #: Source/itemdat.cpp:327
 msgid "the pit"
@@ -3227,19 +3186,19 @@ msgstr "fossa"
 
 #: Source/itemdat.cpp:328
 msgid "the sky"
-msgstr "empirea"
+msgstr "cielo"
 
 #: Source/itemdat.cpp:329
 msgid "the moon"
-msgstr "lunare"
+msgstr "luna"
 
 #: Source/itemdat.cpp:330
 msgid "the stars"
-msgstr "stellata"
+msgstr "stelle"
 
 #: Source/itemdat.cpp:331
 msgid "the heavens"
-msgstr "paradisiaca"
+msgstr "paradiso"
 
 #: Source/itemdat.cpp:332
 msgid "the zodiac"
@@ -3247,43 +3206,43 @@ msgstr "zodiacale"
 
 #: Source/itemdat.cpp:333
 msgid "the vulture"
-msgstr "d'Avvoltoio"
+msgstr "avvoltoio"
 
 #: Source/itemdat.cpp:334
 msgid "the jackal"
-msgstr "di iena"
+msgstr "sciacallo"
 
 #: Source/itemdat.cpp:335
 msgid "the fox"
-msgstr "di volpe"
+msgstr "volpe"
 
 #: Source/itemdat.cpp:336
 msgid "the jaguar"
-msgstr "da giaguaro"
+msgstr "giaguaro"
 
 #: Source/itemdat.cpp:337
 msgid "the eagle"
-msgstr "d'aquila"
+msgstr "aquila"
 
 #: Source/itemdat.cpp:338
 msgid "the wolf"
-msgstr "di lupo"
+msgstr "lupo"
 
 #: Source/itemdat.cpp:339
 msgid "the tiger"
-msgstr "di tigre"
+msgstr "tigre"
 
 #: Source/itemdat.cpp:340
 msgid "the lion"
-msgstr "di leone"
+msgstr "leone"
 
 #: Source/itemdat.cpp:341
 msgid "the mammoth"
-msgstr "di mammoth"
+msgstr "mammut"
 
 #: Source/itemdat.cpp:342
 msgid "the whale"
-msgstr "di balena"
+msgstr "balena"
 
 #: Source/itemdat.cpp:343
 msgid "fragility"
@@ -3291,15 +3250,15 @@ msgstr "fragilità"
 
 #: Source/itemdat.cpp:344
 msgid "brittleness"
-msgstr "cagionevole"
+msgstr "debolezza"
 
 #: Source/itemdat.cpp:345
 msgid "sturdiness"
-msgstr "stordente"
+msgstr "solidità"
 
 #: Source/itemdat.cpp:346
 msgid "craftsmanship"
-msgstr "craftsmanship"
+msgstr "maestria"
 
 #: Source/itemdat.cpp:347
 msgid "structure"
@@ -3307,15 +3266,15 @@ msgstr "struttura"
 
 #: Source/itemdat.cpp:348
 msgid "the ages"
-msgstr "dell'Età"
+msgstr "epoche"
 
 #: Source/itemdat.cpp:349
 msgid "the dark"
-msgstr "l'oscurità"
+msgstr "oscurità"
 
 #: Source/itemdat.cpp:350
 msgid "the night"
-msgstr "di notte"
+msgstr "notte"
 
 #: Source/itemdat.cpp:351
 msgid "light"
@@ -3323,15 +3282,15 @@ msgstr "luce"
 
 #: Source/itemdat.cpp:352
 msgid "radiance"
-msgstr "lucente"
+msgstr "bagliore"
 
 #: Source/itemdat.cpp:353
 msgid "flame"
-msgstr "flame"
+msgstr "fiamma"
 
 #: Source/itemdat.cpp:354
 msgid "fire"
-msgstr "fire"
+msgstr "fuoco"
 
 #: Source/itemdat.cpp:355
 msgid "burning"
@@ -3351,11 +3310,11 @@ msgstr "tuono"
 
 #: Source/itemdat.cpp:359
 msgid "many"
-msgstr "many"
+msgstr "molto"
 
 #: Source/itemdat.cpp:360
 msgid "plenty"
-msgstr "plenty"
+msgstr "parecchio"
 
 #: Source/itemdat.cpp:361
 msgid "thorns"
@@ -3367,7 +3326,7 @@ msgstr "corruzione"
 
 #: Source/itemdat.cpp:363
 msgid "thieves"
-msgstr "ladro"
+msgstr "ladri"
 
 #: Source/itemdat.cpp:364
 msgid "the bear"
@@ -3379,7 +3338,7 @@ msgstr "pipistrello"
 
 #: Source/itemdat.cpp:366
 msgid "vampires"
-msgstr "vampiro"
+msgstr "vampiri"
 
 #: Source/itemdat.cpp:367
 msgid "the leech"
@@ -3387,19 +3346,19 @@ msgstr "sanguisuga"
 
 #: Source/itemdat.cpp:368
 msgid "blood"
-msgstr "blood"
+msgstr "sangue"
 
 #: Source/itemdat.cpp:369
 msgid "piercing"
-msgstr "trapasso"
+msgstr "perforazione"
 
 #: Source/itemdat.cpp:370
 msgid "puncturing"
-msgstr "perforante"
+msgstr "penetrazione"
 
 #: Source/itemdat.cpp:371
 msgid "bashing"
-msgstr "attacco"
+msgstr "stordimento"
 
 #: Source/itemdat.cpp:372
 msgid "readiness"
@@ -3451,7 +3410,7 @@ msgstr "Mannaia Del Macellaio"
 
 #: Source/itemdat.cpp:401
 msgid "The Rift Bow"
-msgstr "ArcoFendente"
+msgstr "Arco del Dissenso"
 
 #: Source/itemdat.cpp:402
 msgid "The Needler"
@@ -3463,35 +3422,35 @@ msgstr "Arco Celestiale"
 
 #: Source/itemdat.cpp:404
 msgid "Deadly Hunter"
-msgstr "Deadly Hunter"
+msgstr "Cacciatore Letale"
 
 #: Source/itemdat.cpp:405
 msgid "Bow of the Dead"
-msgstr "Arco DellaMorte"
+msgstr "Arco del Morto"
 
 #: Source/itemdat.cpp:406
 msgid "The Blackoak Bow"
-msgstr "Arco Foglia Nera"
+msgstr "Arco di Rovere Nero"
 
 #: Source/itemdat.cpp:407
 msgid "Flamedart"
-msgstr "Flamedart"
+msgstr "Dardo di Fuoco"
 
 #: Source/itemdat.cpp:408
 msgid "Fleshstinger"
-msgstr "Rapido Colpo"
+msgstr "Pungicarne"
 
 #: Source/itemdat.cpp:409
 msgid "Windforce"
-msgstr "Windforce"
+msgstr "Forza del Vento"
 
 #: Source/itemdat.cpp:410
 msgid "Eaglehorn"
-msgstr "Eaglehorn"
+msgstr "Corno d'Aquila"
 
 #: Source/itemdat.cpp:411
 msgid "Gonnagal's Dirk"
-msgstr "PugnaleGonnagal"
+msgstr "Pugnale di Gonnagal"
 
 #: Source/itemdat.cpp:412
 msgid "The Defender"
@@ -3499,7 +3458,7 @@ msgstr "Il Difensore"
 
 #: Source/itemdat.cpp:413
 msgid "Gryphons Claw"
-msgstr "Zampa Grifone"
+msgstr "Artiglio di Grifoni"
 
 #: Source/itemdat.cpp:414
 msgid "Black Razor"
@@ -3511,7 +3470,7 @@ msgstr "Luna Gibbosa"
 
 #: Source/itemdat.cpp:416
 msgid "Ice Shank"
-msgstr ""
+msgstr "Stinco di Ghiaccio"
 
 #: Source/itemdat.cpp:417
 msgid "The Executioner's Blade"
@@ -3523,15 +3482,15 @@ msgstr "Il Segaossa"
 
 #: Source/itemdat.cpp:419
 msgid "Shadowhawk"
-msgstr "Falcoscuro"
+msgstr "Falco Ombra"
 
 #: Source/itemdat.cpp:420
 msgid "Wizardspike"
-msgstr "Asta Magica"
+msgstr "Picca del Mago"
 
 #: Source/itemdat.cpp:421
 msgid "Lightsabre"
-msgstr "LamaDiLuce"
+msgstr "Lama di Luce"
 
 #: Source/itemdat.cpp:422
 msgid "The Falcon's Talon"
@@ -3543,7 +3502,7 @@ msgstr "Inferno"
 
 #: Source/itemdat.cpp:424
 msgid "Doombringer"
-msgstr "Porta Morte"
+msgstr "Iettatore"
 
 #: Source/itemdat.cpp:425
 msgid "The Grizzly"
@@ -3555,15 +3514,15 @@ msgstr "Il Nonno"
 
 #: Source/itemdat.cpp:427
 msgid "The Mangler"
-msgstr "Divoratore"
+msgstr "Il Divoratore"
 
 #: Source/itemdat.cpp:428
 msgid "Sharp Beak"
-msgstr "Punta Aghi"
+msgstr "Becco Affilato"
 
 #: Source/itemdat.cpp:429
 msgid "BloodSlayer"
-msgstr "BloodSlayer"
+msgstr "Assassino Cruento"
 
 #: Source/itemdat.cpp:430
 msgid "The Celestial Axe"
@@ -3571,11 +3530,11 @@ msgstr "Ascia Celestiale"
 
 #: Source/itemdat.cpp:431
 msgid "Wicked Axe"
-msgstr "Ascia Atroce"
+msgstr "Ascia Nefasta"
 
 #: Source/itemdat.cpp:432
 msgid "Stonecleaver"
-msgstr "Fendi Roccia"
+msgstr "Fendiroccia"
 
 #: Source/itemdat.cpp:433
 msgid "Aguinara's Hatchet"
@@ -3583,7 +3542,7 @@ msgstr "Accetta di Aguinara"
 
 #: Source/itemdat.cpp:434
 msgid "Hellslayer"
-msgstr "Hellslayer"
+msgstr "Assassino Infernale"
 
 #: Source/itemdat.cpp:435
 msgid "Messerschmidt's Reaver"
@@ -3607,7 +3566,7 @@ msgstr "Stella Celestiale"
 
 #: Source/itemdat.cpp:440
 msgid "Baranar's Star"
-msgstr "Stella Baranar"
+msgstr "Stella di Baranar"
 
 #: Source/itemdat.cpp:441
 msgid "Gnarled Root"
@@ -3619,31 +3578,31 @@ msgstr "Sfascia Cranio"
 
 #: Source/itemdat.cpp:443
 msgid "Schaefer's Hammer"
-msgstr "Ascia di Schaefer"
+msgstr "Maglio di Schaefer"
 
 #: Source/itemdat.cpp:444
 msgid "Dreamflange"
-msgstr "Sognatore"
+msgstr "Dreamflange"
 
 #: Source/itemdat.cpp:445
 msgid "Staff of Shadows"
-msgstr "Asta delle Ombre"
+msgstr "Verga delle Ombre"
 
 #: Source/itemdat.cpp:446
 msgid "Immolator"
-msgstr "Languido"
+msgstr "Immolatore"
 
 #: Source/itemdat.cpp:447
 msgid "Storm Spire"
-msgstr "Storm Spire"
+msgstr "Spira della Bufera"
 
 #: Source/itemdat.cpp:448
 msgid "Gleamsong"
-msgstr "Melodioso"
+msgstr "Gleamsong"
 
 #: Source/itemdat.cpp:449
 msgid "Thundercall"
-msgstr "ChiamaTuoni"
+msgstr "Invoca Tuoni"
 
 #: Source/itemdat.cpp:450
 msgid "The Protector"
@@ -3651,7 +3610,7 @@ msgstr "Il Protettore"
 
 #: Source/itemdat.cpp:451
 msgid "Naj's Puzzler"
-msgstr "Enigma Jaj"
+msgstr "Enigma di Naj"
 
 #: Source/itemdat.cpp:452
 msgid "Mindcry"
@@ -3659,27 +3618,27 @@ msgstr "Mindcry"
 
 #: Source/itemdat.cpp:453
 msgid "Rod of Onan"
-msgstr "VergaDiOnan"
+msgstr "Verga di Onan"
 
 #: Source/itemdat.cpp:454
 msgid "Helm of Sprits"
-msgstr "Elmo Spirituale"
+msgstr "Elmo di Sprits"
 
 #: Source/itemdat.cpp:455
 msgid "Thinking Cap"
-msgstr "Elmo Pensante"
+msgstr "Cappuccio del Pensiero"
 
 #: Source/itemdat.cpp:456
 msgid "OverLord's Helm"
-msgstr "Elmo Sovrano"
+msgstr "Elmo del Signore"
 
 #: Source/itemdat.cpp:457
 msgid "Fool's Crest"
-msgstr "Elmo Stolto"
+msgstr "Cresta del Giullare"
 
 #: Source/itemdat.cpp:458
 msgid "Gotterdamerung"
-msgstr "Gotterdamerung"
+msgstr "Crepuscolo degli Dei"
 
 #: Source/itemdat.cpp:459
 msgid "Royal Circlet"
@@ -3687,7 +3646,7 @@ msgstr "Cerchio Regale"
 
 #: Source/itemdat.cpp:460
 msgid "Torn Flesh of Souls"
-msgstr "Anime Combattute"
+msgstr "Brandelli di Anime"
 
 #: Source/itemdat.cpp:461
 msgid "The Gladiator's Bane"
@@ -3699,31 +3658,31 @@ msgstr "Manto Arcobaleno"
 
 #: Source/itemdat.cpp:463
 msgid "Leather of Aut"
-msgstr "Legame di Cuoio"
+msgstr "Cuoio di Aut"
 
 #: Source/itemdat.cpp:464
 msgid "Wisdom's Wrap"
-msgstr "Saggie Vesti"
+msgstr "Mantello di Saggezza"
 
 #: Source/itemdat.cpp:465
 msgid "Sparking Mail"
-msgstr "Maglia Lucente"
+msgstr "Corazza Lucente"
 
 #: Source/itemdat.cpp:466
 msgid "Scavenger Carapace"
-msgstr "Sciacallo Carapace"
+msgstr "Corazza Necrofaga"
 
 #: Source/itemdat.cpp:467
 msgid "Nightscape"
-msgstr "Nightscape"
+msgstr "Paesaggio Notturno"
 
 #: Source/itemdat.cpp:468
 msgid "Naj's Light Plate"
-msgstr "Veste Naj Leggera"
+msgstr "Busto di Naj's"
 
 #: Source/itemdat.cpp:469
 msgid "Demonspike Coat"
-msgstr "Manto Demoniaco"
+msgstr "Manto Demonspike"
 
 #: Source/itemdat.cpp:470
 msgid "The Deflector"
@@ -3735,19 +3694,19 @@ msgstr "Scudo Osseo Rotto"
 
 #: Source/itemdat.cpp:472
 msgid "Dragon's Breach"
-msgstr "Varco Del Drago"
+msgstr "Varco del Dragone"
 
 #: Source/itemdat.cpp:473
 msgid "Blackoak Shield"
-msgstr "Scudo Bellicoso"
+msgstr "Scudo di Rovere Nero"
 
 #: Source/itemdat.cpp:474
 msgid "Holy Defender"
-msgstr "Sacra Difesa"
+msgstr "Sacro Difensore"
 
 #: Source/itemdat.cpp:475
 msgid "Stormshield"
-msgstr "Scudo Tuono"
+msgstr "Scudo Tempesta"
 
 #: Source/itemdat.cpp:476
 msgid "Bramble"
@@ -3755,7 +3714,7 @@ msgstr "Rovo"
 
 #: Source/itemdat.cpp:477
 msgid "Ring of Regha"
-msgstr "Regio Anello"
+msgstr "Anello di Regha"
 
 #: Source/itemdat.cpp:478
 msgid "The Bleeder"
@@ -3763,11 +3722,11 @@ msgstr "Salassatore"
 
 #: Source/itemdat.cpp:479
 msgid "Constricting Ring"
-msgstr "Anello Inibitore"
+msgstr "Anello Costrittivo"
 
 #: Source/itemdat.cpp:480
 msgid "Ring of Engagement"
-msgstr "Anello Del Dovere"
+msgstr "Anello del Dovere"
 
 #: Source/itemdat.cpp:481
 msgid "Giant's Knuckle"
@@ -3883,14 +3842,14 @@ msgstr "Olio dell'Impermeabilità"
 msgid "%s of %s"
 msgstr "%s di %s"
 
-#: Source/items.cpp:2779 Source/player.cpp:1817
+#: Source/items.cpp:2779 Source/player.cpp:1826
 #, c-format
 msgid "Ear of %s"
 msgstr "Orecchio di %s"
 
 #: Source/items.cpp:3308 Source/items.cpp:3320
 msgid "increases a weapon's"
-msgstr "aumenta dell'arma"
+msgstr "dell'arma, aumenta"
 
 #: Source/items.cpp:3310
 msgid "chance to hit"
@@ -3898,7 +3857,7 @@ msgstr "possibilità di colpire"
 
 #: Source/items.cpp:3314
 msgid "greatly increases a"
-msgstr "aumenta molto"
+msgstr "aumenta di molto"
 
 #: Source/items.cpp:3316
 msgid "weapon's chance to hit"
@@ -3910,7 +3869,7 @@ msgstr "potenziale danno"
 
 #: Source/items.cpp:3326
 msgid "greatly increases a weapon's"
-msgstr "aumenta molto dell'arma"
+msgstr "aumenta di molto dell'arma"
 
 #: Source/items.cpp:3328
 msgid "damage potential - not bows"
@@ -3927,7 +3886,7 @@ msgstr "per usare armature o armi"
 #: Source/items.cpp:3338
 #, no-c-format
 msgid "restores 20% of an"
-msgstr "ripristna 20%"
+msgstr "ripristina 20% di"
 
 #: Source/items.cpp:3340
 msgid "item's durability"
@@ -3935,7 +3894,7 @@ msgstr "durabilità dell'oggetto"
 
 #: Source/items.cpp:3344
 msgid "increases an item's"
-msgstr "aumenta dell'oggetto"
+msgstr "dell'oggetto, aumenta"
 
 #: Source/items.cpp:3346
 msgid "current and max durability"
@@ -3955,7 +3914,7 @@ msgstr "di armatura e scudi"
 
 #: Source/items.cpp:3360
 msgid "greatly increases the armor"
-msgstr "aumenta molto la classe"
+msgstr "aumenta di molto la classe"
 
 #: Source/items.cpp:3362
 msgid "class of armor and shields"
@@ -3967,7 +3926,7 @@ msgstr "imposta trappola fuoco"
 
 #: Source/items.cpp:3370 Source/items.cpp:3374
 msgid "sets lightning trap"
-msgstr "imposta trappola bagliore"
+msgstr "imposta trappola fulmine"
 
 #: Source/items.cpp:3382
 msgid "sets petrification trap"
@@ -4118,7 +4077,7 @@ msgstr "livelli incantesimo invariati (?)"
 
 #: Source/items.cpp:3514
 msgid "Extra charges"
-msgstr "Cariche Extra"
+msgstr "Cariche extra"
 
 #: Source/items.cpp:3517
 #, c-format
@@ -4130,22 +4089,22 @@ msgstr[1] "%i %s cariche"
 #: Source/items.cpp:3521
 #, c-format
 msgid "Fire hit damage: %i"
-msgstr "DannoColpiFuoco: %i"
+msgstr "Danno fuoco: %i"
 
 #: Source/items.cpp:3523
 #, c-format
 msgid "Fire hit damage: %i-%i"
-msgstr "DannoColpiFuoco: %i-%i"
+msgstr "Danno Fuoco: %i-%i"
 
 #: Source/items.cpp:3527
 #, c-format
 msgid "Lightning hit damage: %i"
-msgstr "DannoColpiDaFulmine : %i"
+msgstr "Danno Fulmine : %i"
 
 #: Source/items.cpp:3529
 #, c-format
 msgid "Lightning hit damage: %i-%i"
-msgstr "DannoColpiDaFulmine : %i-%i"
+msgstr "Danno Fulmine : %i-%i"
 
 #: Source/items.cpp:3533
 #, c-format
@@ -4155,22 +4114,22 @@ msgstr "%+i alla Forza"
 #: Source/items.cpp:3537
 #, c-format
 msgid "%+i to magic"
-msgstr "%+i di Magia"
+msgstr "%+i di magia"
 
 #: Source/items.cpp:3541
 #, c-format
 msgid "%+i to dexterity"
-msgstr "%+i di Destrezza"
+msgstr "%+i di destrezza"
 
 #: Source/items.cpp:3545
 #, c-format
 msgid "%+i to vitality"
-msgstr "%+i di Vitalità"
+msgstr "%+i di vitalità"
 
 #: Source/items.cpp:3549
 #, c-format
 msgid "%+i to all attributes"
-msgstr "%+i a ogni Attributo"
+msgstr "%+i a ogni attributo"
 
 #: Source/items.cpp:3553
 #, c-format
@@ -4202,12 +4161,12 @@ msgstr "indistruttibile"
 #: Source/items.cpp:3573
 #, c-format
 msgid "+%i%% light radius"
-msgstr "+%i%% bagliore luce"
+msgstr "+%i%% bagliore"
 
 #: Source/items.cpp:3576
 #, c-format
 msgid "-%i%% light radius"
-msgstr "-%i%% bagliore luce"
+msgstr "-%i%% bagliore"
 
 #: Source/items.cpp:3579
 msgid "multiple arrows per shot"
@@ -4216,22 +4175,22 @@ msgstr "frecce multiple per tiro"
 #: Source/items.cpp:3583
 #, c-format
 msgid "fire arrows damage: %i"
-msgstr "danno frecce infuocate: %i"
+msgstr "danno dardi infuocati: %i"
 
 #: Source/items.cpp:3585
 #, c-format
 msgid "fire arrows damage: %i-%i"
-msgstr "danno frecce fuoco: %i-%i"
+msgstr "danno dardi infuocati: %i-%i"
 
 #: Source/items.cpp:3589
 #, c-format
 msgid "lightning arrows damage %i"
-msgstr "danno frecce abbaglianti: %i"
+msgstr "danno frecce fulminee: %i"
 
 #: Source/items.cpp:3591
 #, c-format
 msgid "lightning arrows damage %i-%i"
-msgstr "danno frecce fulmine: %i-%i"
+msgstr "danno frecce fulminee: %i-%i"
 
 #: Source/items.cpp:3595
 #, c-format
@@ -4341,15 +4300,15 @@ msgstr[1] "aggiunge %i punti al danno"
 
 #: Source/items.cpp:3663
 msgid "fires random speed arrows"
-msgstr "velocitàdi gittata casuale"
+msgstr "velocità di gittata casuale"
 
 #: Source/items.cpp:3666
 msgid "unusual item damage"
-msgstr "provoca forte danno"
+msgstr "danno non comune"
 
 #: Source/items.cpp:3669
 msgid "altered durability"
-msgstr "permanenza alterata"
+msgstr "durabilità alterata"
 
 #: Source/items.cpp:3672
 msgid "Faster attack swing"
@@ -4369,25 +4328,25 @@ msgstr "sottrae vita"
 
 #: Source/items.cpp:3684
 msgid "no strength requirement"
-msgstr "nessuna Forza Richiesta"
+msgstr "nessun requisito di forza"
 
 #: Source/items.cpp:3687
 msgid "see with infravision"
-msgstr "vedi ConInfravisione"
+msgstr "usa infravisione"
 
 #: Source/items.cpp:3694
 #, c-format
 msgid "lightning damage: %i"
-msgstr "danno bagliore: %i"
+msgstr "danno fulmineo: %i"
 
 #: Source/items.cpp:3696
 #, c-format
 msgid "lightning damage: %i-%i"
-msgstr "danno bagliore: %i-%i"
+msgstr "danno fulmineo: %i-%i"
 
 #: Source/items.cpp:3699
 msgid "charged bolts on hits"
-msgstr ""
+msgstr "scariche fulminee al colpo"
 
 #: Source/items.cpp:3708
 msgid "occasional triple damage"
@@ -4410,29 +4369,29 @@ msgstr "Danno casuale 0 - 500%"
 #: Source/items.cpp:3720
 #, c-format
 msgid "low dur, %+i%% damage"
-msgstr ""
+msgstr "dur ridotta, %+i%% danno"
 
 #: Source/items.cpp:3726
 msgid "extra AC vs demons"
-msgstr ""
+msgstr "AC extra contro demoni"
 
 #: Source/items.cpp:3729
 msgid "extra AC vs undead"
-msgstr ""
+msgstr "AC extra contro non morti"
 
 #: Source/items.cpp:3732
 #, no-c-format
 msgid "50% Mana moved to Health"
-msgstr ""
+msgstr "50% Mana spostato a Salute"
 
 #: Source/items.cpp:3735
 #, no-c-format
 msgid "40% Health moved to Mana"
-msgstr ""
+msgstr "40% Salute spostato a Mana"
 
 #: Source/items.cpp:3738
 msgid "Another ability (NW)"
-msgstr "Altra Abilità (NW)"
+msgstr "Altra abilità (NW)"
 
 #: Source/items.cpp:3824 Source/items.cpp:3849
 msgid "Right-click to read"
@@ -4498,7 +4457,7 @@ msgstr "danno: %i  Dur: %i/%i"
 #: Source/items.cpp:3899 Source/items.cpp:3946
 #, c-format
 msgid "damage: %i-%i  Indestructible"
-msgstr "danno: %i-%i Invulnerabile"
+msgstr "danno: %i-%i Indistruttibile"
 
 #: Source/items.cpp:3901 Source/items.cpp:3948
 #, c-format
@@ -4508,28 +4467,28 @@ msgstr "danno: %i-%i Dur: %i/%i"
 #: Source/items.cpp:3907 Source/items.cpp:3960
 #, c-format
 msgid "armor: %i  Indestructible"
-msgstr "armat.:%i Invulnerabile"
+msgstr "armatura:%i Indistruttibile"
 
 #: Source/items.cpp:3909 Source/items.cpp:3962
 #, c-format
 msgid "armor: %i  Dur: %i/%i"
-msgstr "armat.:%i Dur: %i/%i"
+msgstr "armatura:%i Dur: %i/%i"
 
 #: Source/items.cpp:3914
 #, c-format
 msgid "dam: %i  Dur: %i/%i"
-msgstr "dan.: %i  Dur: %i/%i"
+msgstr "dan: %i  Dur: %i/%i"
 
 #: Source/items.cpp:3916
 #, c-format
 msgid "dam: %i-%i  Dur: %i/%i"
-msgstr "dan.:%i-%i Dur: %i/%i"
+msgstr "dan: %i-%i Dur: %i/%i"
 
 #: Source/items.cpp:3917 Source/items.cpp:3952 Source/items.cpp:3967
 #: Source/stores.cpp:169
 #, c-format
 msgid "Charges: %i/%i"
-msgstr "Cariche: %i/%i"
+msgstr "Ricariche: %i/%i"
 
 #: Source/items.cpp:3929
 msgid "unique item"
@@ -4537,7 +4496,7 @@ msgstr "oggetto unico"
 
 #: Source/items.cpp:3956 Source/items.cpp:3965 Source/items.cpp:3972
 msgid "Not Identified"
-msgstr "Ignoto"
+msgstr "Sconosciuto"
 
 #: Source/loadsave.cpp:995 Source/loadsave.cpp:2023
 msgid "Unable to open save file archive"
@@ -4557,11 +4516,11 @@ msgstr "Stato del gioco non valido"
 
 #: Source/mainmenu.cpp:123
 msgid "Unable to display mainmenu"
-msgstr "Unable to display mainmenu"
+msgstr "Impossibile mostrare menu"
 
 #: Source/monstdat.cpp:18
 msgid "Zombie"
-msgstr "Zombie"
+msgstr "Zombi"
 
 #: Source/monstdat.cpp:19
 msgid "Ghoul"
@@ -4569,47 +4528,47 @@ msgstr "Ghoul"
 
 #: Source/monstdat.cpp:20
 msgid "Rotting Carcass"
-msgstr "Rotting Carcass"
+msgstr "Carcassa in Decomposizione"
 
 #: Source/monstdat.cpp:21
 msgid "Black Death"
-msgstr "Black Death"
+msgstr "Morte Nera"
 
 #: Source/monstdat.cpp:22 Source/monstdat.cpp:30
 msgid "Fallen One"
-msgstr "Fallen One"
+msgstr "Il Caduto"
 
 #: Source/monstdat.cpp:23 Source/monstdat.cpp:31
 msgid "Carver"
-msgstr "Carver"
+msgstr "Intagliatore"
 
 #: Source/monstdat.cpp:24 Source/monstdat.cpp:32
 msgid "Devil Kin"
-msgstr "Devil Kin"
+msgstr "Stirpe del Diavolo"
 
 #: Source/monstdat.cpp:25 Source/monstdat.cpp:33
 msgid "Dark One"
-msgstr "Dark One"
+msgstr "L'Oscuro"
 
 #: Source/monstdat.cpp:26 Source/monstdat.cpp:38
 msgid "Skeleton"
-msgstr "Skeleton"
+msgstr "Scheletro"
 
 #: Source/monstdat.cpp:27
 msgid "Corpse Axe"
-msgstr "Corpse Axe"
+msgstr "Cadavere con Ascia"
 
 #: Source/monstdat.cpp:28 Source/monstdat.cpp:40
 msgid "Burning Dead"
-msgstr "Burning Dead"
+msgstr "Morto al Rogo"
 
 #: Source/monstdat.cpp:29 Source/monstdat.cpp:41
 msgid "Horror"
-msgstr "Horror"
+msgstr "Orrore"
 
 #: Source/monstdat.cpp:34
 msgid "Scavenger"
-msgstr "Scavenger"
+msgstr "Necrofago"
 
 #: Source/monstdat.cpp:35
 msgid "Plague Eater"
@@ -4629,59 +4588,59 @@ msgstr "Corpse Bow"
 
 #: Source/monstdat.cpp:42
 msgid "Skeleton Captain"
-msgstr "Skeleton Captain"
+msgstr "Scheletro Capo"
 
 #: Source/monstdat.cpp:43
 msgid "Corpse Captain"
-msgstr "Corpse Captain"
+msgstr "Cadavere Capo"
 
 #: Source/monstdat.cpp:44
 msgid "Burning Dead Captain"
-msgstr "Burning Dead Captain"
+msgstr "Morto al Rogo Capo"
 
 #: Source/monstdat.cpp:45
 msgid "Horror Captain"
-msgstr "Horror Captain"
+msgstr "Orrore Capo"
 
 #: Source/monstdat.cpp:46
 msgid "Invisible Lord"
-msgstr "Invisible Lord"
+msgstr "Lord Invisibile"
 
 #: Source/monstdat.cpp:47 Source/objects.cpp:91
 msgid "Hidden"
-msgstr "Hidden"
+msgstr "Nascosto"
 
 #: Source/monstdat.cpp:48
 msgid "Stalker"
-msgstr "Stalker"
+msgstr "Molestatore"
 
 #: Source/monstdat.cpp:49
 msgid "Unseen"
-msgstr "Unseen"
+msgstr "Inosservato"
 
 #: Source/monstdat.cpp:50
 msgid "Illusion Weaver"
-msgstr "Illusion Weaver"
+msgstr "Tessitore di Illusione"
 
 #: Source/monstdat.cpp:51
 msgid "Satyr Lord"
-msgstr ""
+msgstr "Lord dei Satiri"
 
 #: Source/monstdat.cpp:52 Source/monstdat.cpp:60
 msgid "Flesh Clan"
-msgstr "Flesh Clan"
+msgstr "Clan delle Viscere"
 
 #: Source/monstdat.cpp:53 Source/monstdat.cpp:61
 msgid "Stone Clan"
-msgstr "Stone Clan"
+msgstr "Clan di Pietra"
 
 #: Source/monstdat.cpp:54 Source/monstdat.cpp:62
 msgid "Fire Clan"
-msgstr "Fire Clan"
+msgstr "Clan del Fuoco"
 
 #: Source/monstdat.cpp:55 Source/monstdat.cpp:63
 msgid "Night Clan"
-msgstr "Night Clan"
+msgstr "Clan delle Tenebre"
 
 #: Source/monstdat.cpp:56
 msgid "Fiend"
@@ -4701,43 +4660,43 @@ msgstr "Familiar"
 
 #: Source/monstdat.cpp:64
 msgid "Acid Beast"
-msgstr "Acid Beast"
+msgstr "Bestia d'Acido"
 
 #: Source/monstdat.cpp:65
 msgid "Poison Spitter"
-msgstr "Poison Spitter"
+msgstr "Sputa Veleno"
 
 #: Source/monstdat.cpp:66
 msgid "Pit Beast"
-msgstr "Pit Beast"
+msgstr "Bestia da Fossa"
 
 #: Source/monstdat.cpp:67
 msgid "Lava Maw"
-msgstr "Lava Maw"
+msgstr "Fauci di Lava"
 
 #: Source/monstdat.cpp:68 Source/monstdat.cpp:470
 msgid "Skeleton King"
-msgstr "Skeleton King"
+msgstr "Re Scheletro"
 
 #: Source/monstdat.cpp:69 Source/monstdat.cpp:478 Source/quests.cpp:45
 msgid "The Butcher"
-msgstr "The Butcher"
+msgstr "Il Macellaio"
 
 #: Source/monstdat.cpp:70
 msgid "Overlord"
-msgstr "Overlord"
+msgstr "Signore"
 
 #: Source/monstdat.cpp:71
 msgid "Mud Man"
-msgstr "Mud Man"
+msgstr "Uomo Melma"
 
 #: Source/monstdat.cpp:72
 msgid "Toad Demon"
-msgstr "Toad Demon"
+msgstr "Demone Rospo"
 
 #: Source/monstdat.cpp:73
 msgid "Flayed One"
-msgstr "Flayed One"
+msgstr "Lo Scuoiato"
 
 #: Source/monstdat.cpp:74
 msgid "Wyrm"
@@ -4745,19 +4704,19 @@ msgstr "Wyrm"
 
 #: Source/monstdat.cpp:75
 msgid "Cave Slug"
-msgstr "Cave Slug"
+msgstr "Lumaca di Caverna"
 
 #: Source/monstdat.cpp:76
 msgid "Devil Wyrm"
-msgstr "Devil Wyrm"
+msgstr "Wyrm Demoniaco"
 
 #: Source/monstdat.cpp:77
 msgid "Devourer"
-msgstr "Devourer"
+msgstr "Divoratore"
 
 #: Source/monstdat.cpp:78
 msgid "Magma Demon"
-msgstr "Magma Demon"
+msgstr "Demone di Magma"
 
 #: Source/monstdat.cpp:80
 msgid "Hell Stone"
@@ -4765,15 +4724,15 @@ msgstr "Hell Stone"
 
 #: Source/monstdat.cpp:81
 msgid "Lava Lord"
-msgstr "Lava Lord"
+msgstr "Lord di Lava"
 
 #: Source/monstdat.cpp:82
 msgid "Horned Demon"
-msgstr "Horned Demon"
+msgstr "Demone Cornuto"
 
 #: Source/monstdat.cpp:83
 msgid "Mud Runner"
-msgstr "Mud Runner"
+msgstr "Velocista di Fango"
 
 #: Source/monstdat.cpp:84
 msgid "Frost Charger"
@@ -4785,11 +4744,11 @@ msgstr "Obsidian Lord"
 
 #: Source/monstdat.cpp:86
 msgid "oldboned"
-msgstr ""
+msgstr "dissossato"
 
 #: Source/monstdat.cpp:87
 msgid "Red Death"
-msgstr "Red Death"
+msgstr "Morte Rossa"
 
 #: Source/monstdat.cpp:88
 msgid "Litch Demon"
@@ -4809,35 +4768,35 @@ msgstr "Flame Lord"
 
 #: Source/monstdat.cpp:92
 msgid "Doom Fire"
-msgstr "Doom Fire"
+msgstr "Fuoco di Sventura"
 
 #: Source/monstdat.cpp:93
 msgid "Hell Burner"
-msgstr "Hell Burner"
+msgstr "Fucina Infernale"
 
 #: Source/monstdat.cpp:94
 msgid "Red Storm"
-msgstr "Red Storm"
+msgstr "Tempesta Rossa"
 
 #: Source/monstdat.cpp:95
 msgid "Storm Rider"
-msgstr "Storm Rider"
+msgstr "Velocista della Tempesta"
 
 #: Source/monstdat.cpp:96
 msgid "Storm Lord"
-msgstr "Storm Lord"
+msgstr "Lord della Tempesta"
 
 #: Source/monstdat.cpp:97
 msgid "Maelstorm"
-msgstr "Maelstorm"
+msgstr "Maelstrom"
 
 #: Source/monstdat.cpp:98
 msgid "Devil Kin Brute"
-msgstr "Devil Kin Brute"
+msgstr "Bruto Stirpe del Diavolo"
 
 #: Source/monstdat.cpp:99
 msgid "Winged-Demon"
-msgstr "Winged-Demon"
+msgstr "Demone Alato"
 
 #: Source/monstdat.cpp:100
 msgid "Gargoyle"
@@ -4845,23 +4804,23 @@ msgstr "Gargoyle"
 
 #: Source/monstdat.cpp:101
 msgid "Blood Claw"
-msgstr "Blood Claw"
+msgstr "Artiglio Insanguinato"
 
 #: Source/monstdat.cpp:102
 msgid "Death Wing"
-msgstr "Death Wing"
+msgstr "Morte Alata"
 
 #: Source/monstdat.cpp:103
 msgid "Slayer"
-msgstr "Slayer"
+msgstr "Assassino"
 
 #: Source/monstdat.cpp:104 Source/spelldat.cpp:28
 msgid "Guardian"
-msgstr "Guardian"
+msgstr "Custode"
 
 #: Source/monstdat.cpp:105
 msgid "Vortex Lord"
-msgstr "Vortex Lord"
+msgstr "Lord Vortice"
 
 #: Source/monstdat.cpp:106
 msgid "Balrog"
@@ -4869,83 +4828,83 @@ msgstr "Balrog"
 
 #: Source/monstdat.cpp:107
 msgid "Cave Viper"
-msgstr "Cave Viper"
+msgstr "Vipera di Caverna"
 
 #: Source/monstdat.cpp:108
 msgid "Fire Drake"
-msgstr "Fire Drake"
+msgstr "Drago di Fuoco"
 
 #: Source/monstdat.cpp:109
 msgid "Gold Viper"
-msgstr "Gold Viper"
+msgstr "Vipera d'Oro"
 
 #: Source/monstdat.cpp:110
 msgid "Azure Drake"
-msgstr "Azure Drake"
+msgstr "Drago Azzurro"
 
 #: Source/monstdat.cpp:111
 msgid "Black Knight"
-msgstr "Black Knight"
+msgstr "Cavaliere Nero"
 
 #: Source/monstdat.cpp:112
 msgid "Doom Guard"
-msgstr "Doom Guard"
+msgstr "Custode del Destino"
 
 #: Source/monstdat.cpp:113
 msgid "Steel Lord"
-msgstr "Steel Lord"
+msgstr "Lord d'Acciaio"
 
 #: Source/monstdat.cpp:114
 msgid "Blood Knight"
-msgstr "Blood Knight"
+msgstr "Cavaliere di Sangue"
 
 #: Source/monstdat.cpp:115
 msgid "The Shredded"
-msgstr ""
+msgstr "Il Triturato"
 
 #: Source/monstdat.cpp:116
 msgid "Hollow One"
-msgstr "Hollow One"
+msgstr "L'Incavato"
 
 #: Source/monstdat.cpp:117
 msgid "Pain Master"
-msgstr "Pain Master"
+msgstr "Signore del Dolore"
 
 #: Source/monstdat.cpp:118
 msgid "Reality Weaver"
-msgstr "Reality Weaver"
+msgstr "Tessitore di Realtà"
 
 #: Source/monstdat.cpp:119
 msgid "Succubus"
-msgstr "Succubus"
+msgstr "Succubo"
 
 #: Source/monstdat.cpp:120
 msgid "Snow Witch"
-msgstr "Snow Witch"
+msgstr "Strega della Neve"
 
 #: Source/monstdat.cpp:121
 msgid "Hell Spawn"
-msgstr "Hell Spawn"
+msgstr "Prole Infernale"
 
 #: Source/monstdat.cpp:122
 msgid "Soul Burner"
-msgstr "Soul Burner"
+msgstr "Fucina di Anime"
 
 #: Source/monstdat.cpp:123
 msgid "Counselor"
-msgstr "Counselor"
+msgstr "Consigliere"
 
 #: Source/monstdat.cpp:124
 msgid "Magistrate"
-msgstr "Magistrate"
+msgstr "Magistrato"
 
 #: Source/monstdat.cpp:125
 msgid "Cabalist"
-msgstr "Cabalist"
+msgstr "Cabalista"
 
 #: Source/monstdat.cpp:126
 msgid "Advocate"
-msgstr "Advocate"
+msgstr "Difensore"
 
 #: Source/monstdat.cpp:127 Source/spelldat.cpp:36
 msgid "Golem"
@@ -4953,39 +4912,39 @@ msgstr "Golem"
 
 #: Source/monstdat.cpp:128
 msgid "The Dark Lord"
-msgstr "The Dark Lord"
+msgstr "Il Signore Oscuro"
 
 #: Source/monstdat.cpp:129
 msgid "The Arch-Litch Malignus"
-msgstr "The Arch-Litch Malignus"
+msgstr "Il Maligno Arci Litch"
 
 #: Source/monstdat.cpp:130
 msgid "Hellboar"
-msgstr ""
+msgstr "Cinghiale infernale"
 
 #: Source/monstdat.cpp:131
 msgid "Stinger"
-msgstr ""
+msgstr "Pungiglione"
 
 #: Source/monstdat.cpp:132
 msgid "Psychorb"
-msgstr ""
+msgstr "Psychorb"
 
 #: Source/monstdat.cpp:133
 msgid "Arachnon"
-msgstr ""
+msgstr "Arachnon"
 
 #: Source/monstdat.cpp:134
 msgid "Felltwin"
-msgstr ""
+msgstr "Felltwin"
 
 #: Source/monstdat.cpp:135
 msgid "Hork Spawn"
-msgstr ""
+msgstr "Prole di Hork"
 
 #: Source/monstdat.cpp:136
 msgid "Venomtail"
-msgstr ""
+msgstr "Coda Velenosa"
 
 #: Source/monstdat.cpp:137
 msgid "Necromorb"
@@ -5017,27 +4976,27 @@ msgstr "Becchino"
 
 #: Source/monstdat.cpp:144
 msgid "Tomb Rat"
-msgstr ""
+msgstr "Ratto del Sepolcro"
 
 #: Source/monstdat.cpp:145
 msgid "Firebat"
-msgstr ""
+msgstr "Pipistrello Infuocato"
 
 #: Source/monstdat.cpp:146
 msgid "Skullwing"
-msgstr ""
+msgstr "Teschio Alato"
 
 #: Source/monstdat.cpp:147
 msgid "Lich"
-msgstr ""
+msgstr "Lich"
 
 #: Source/monstdat.cpp:148
 msgid "Crypt Demon"
-msgstr ""
+msgstr "Demone della Cripta"
 
 #: Source/monstdat.cpp:149
 msgid "Hellbat"
-msgstr ""
+msgstr "Pipistrello Infernale"
 
 #: Source/monstdat.cpp:150
 msgid "Bone Demon"
@@ -5045,23 +5004,23 @@ msgstr "Bone Demon"
 
 #: Source/monstdat.cpp:151
 msgid "Arch Lich"
-msgstr ""
+msgstr "Arch Lich"
 
 #: Source/monstdat.cpp:152
 msgid "Biclops"
-msgstr ""
+msgstr "Biciclope"
 
 #: Source/monstdat.cpp:153
 msgid "Flesh Thing"
-msgstr ""
+msgstr "Pasticcio di Carne"
 
 #: Source/monstdat.cpp:154
 msgid "Reaper"
-msgstr ""
+msgstr "Il Mietitore"
 
 #: Source/monstdat.cpp:469
 msgid "Gharbad the Weak"
-msgstr "Gharbad l'Esile"
+msgstr "Gharbad il Fiacco"
 
 #: Source/monstdat.cpp:471 Source/quests.cpp:42
 msgid "Zhar the Mad"
@@ -5069,7 +5028,7 @@ msgstr "Zhar ilFolle"
 
 #: Source/monstdat.cpp:472
 msgid "Snotspill"
-msgstr "Snotspill"
+msgstr "Moccio"
 
 #: Source/monstdat.cpp:473
 msgid "Arch-Bishop Lazarus"
@@ -5077,7 +5036,7 @@ msgstr "Arcivescovo Lazarus"
 
 #: Source/monstdat.cpp:474
 msgid "Red Vex"
-msgstr "Red Vex"
+msgstr "Tormento Rosso"
 
 #: Source/monstdat.cpp:475
 msgid "Black Jade"
@@ -5089,7 +5048,7 @@ msgstr "Signore - Sangue"
 
 #: Source/monstdat.cpp:480 Source/quests.cpp:59
 msgid "The Defiler"
-msgstr ""
+msgstr "Il Profanatore"
 
 #: Source/monstdat.cpp:482
 msgid "Bonehead Keenaxe"
@@ -5101,7 +5060,7 @@ msgstr "Bladeskin the Slasher"
 
 #: Source/monstdat.cpp:484
 msgid "Soulpus"
-msgstr "Soulpus"
+msgstr "Purulento"
 
 #: Source/monstdat.cpp:485
 msgid "Pukerat the Unclean"
@@ -5109,15 +5068,15 @@ msgstr "Pukerat l'Impuro"
 
 #: Source/monstdat.cpp:486
 msgid "Boneripper"
-msgstr "SpaccaOssa"
+msgstr "Squarta Ossa"
 
 #: Source/monstdat.cpp:487
 msgid "Rotfeast the Hungry"
-msgstr "Rotfeast Affamato"
+msgstr "Rotfeast il Famelico"
 
 #: Source/monstdat.cpp:488
 msgid "Gutshank the Quick"
-msgstr "Gutshank the Quick"
+msgstr "Gutshank il Lesto"
 
 #: Source/monstdat.cpp:489
 msgid "Brokenhead Bangshield"
@@ -5137,7 +5096,7 @@ msgstr "Deadeye"
 
 #: Source/monstdat.cpp:494
 msgid "Madeye the Dead"
-msgstr "Madeye the Dead"
+msgstr "Madeye il Morto"
 
 #: Source/monstdat.cpp:496
 msgid "Skullfire"
@@ -5169,7 +5128,7 @@ msgstr "Spineeater"
 
 #: Source/monstdat.cpp:503
 msgid "Blackash the Burning"
-msgstr "Blackash the Burning"
+msgstr "Blackash il Bruciato"
 
 #: Source/monstdat.cpp:504
 msgid "Shadowcrow"
@@ -5177,11 +5136,11 @@ msgstr "Shadowcrow"
 
 #: Source/monstdat.cpp:505
 msgid "Blightstone the Weak"
-msgstr "Blightstone the Weak"
+msgstr "Blightstone il Fiacco"
 
 #: Source/monstdat.cpp:506
 msgid "Bilefroth the Pit Master"
-msgstr "Bilefroth the Pit Master"
+msgstr "Bilefroth Padron del Fosso"
 
 #: Source/monstdat.cpp:507
 msgid "Bloodskin Darkbow"
@@ -5225,7 +5184,7 @@ msgstr "Blightfire"
 
 #: Source/monstdat.cpp:517
 msgid "Nightwing the Cold"
-msgstr "Nightwing the Cold"
+msgstr "Nightwing il Gelido"
 
 #: Source/monstdat.cpp:518
 msgid "Gorestone"
@@ -5237,15 +5196,15 @@ msgstr "Bronzefist Firestone"
 
 #: Source/monstdat.cpp:520
 msgid "Wrathfire the Doomed"
-msgstr "Empia Furia di Fuoco"
+msgstr "Wrathfire il Dannato"
 
 #: Source/monstdat.cpp:521
 msgid "Firewound the Grim"
-msgstr "AvvolgiFiammaBieco"
+msgstr "Firewound il Bieco"
 
 #: Source/monstdat.cpp:522
 msgid "Baron Sludge"
-msgstr "Baron Sludge"
+msgstr "Barone "
 
 #: Source/monstdat.cpp:523
 msgid "Blighthorn Steelmace"
@@ -5257,7 +5216,7 @@ msgstr "Chaoshowler"
 
 #: Source/monstdat.cpp:525
 msgid "Doomgrin the Rotting"
-msgstr "Doomgrin Putrescente"
+msgstr "Doomgrin il Marcio"
 
 #: Source/monstdat.cpp:526
 msgid "Madburner"
@@ -5265,15 +5224,15 @@ msgstr "Madburner"
 
 #: Source/monstdat.cpp:527
 msgid "Bonesaw the Litch"
-msgstr "Segaossa Avizzito"
+msgstr "Bonesaw il Litch"
 
 #: Source/monstdat.cpp:528
 msgid "Breakspine"
-msgstr "RompiSpine"
+msgstr "Breakspine"
 
 #: Source/monstdat.cpp:529
 msgid "Devilskull Sharpbone"
-msgstr "TeschioDemonePuntuto"
+msgstr "Devilskull Sharpbone"
 
 #: Source/monstdat.cpp:530
 msgid "Brokenstorm"
@@ -5301,11 +5260,11 @@ msgstr "Appestato"
 
 #: Source/monstdat.cpp:536
 msgid "The Flayer"
-msgstr "Volatile"
+msgstr "Lo Scuoiato"
 
 #: Source/monstdat.cpp:537
 msgid "Bluehorn"
-msgstr "CornoBlu"
+msgstr "Bluehorn"
 
 #: Source/monstdat.cpp:538
 msgid "Warpfire Hellspawn"
@@ -5321,11 +5280,11 @@ msgstr "Festerskull"
 
 #: Source/monstdat.cpp:541
 msgid "Lionskull the Bent"
-msgstr "Lionskull the Bent"
+msgstr "Lionskull il Curvo"
 
 #: Source/monstdat.cpp:542
 msgid "Blacktongue"
-msgstr "Lingua Nera"
+msgstr "Blacktongue"
 
 #: Source/monstdat.cpp:543
 msgid "Viletouch"
@@ -5341,7 +5300,7 @@ msgstr "Fangskin"
 
 #: Source/monstdat.cpp:546
 msgid "Witchfire the Unholy"
-msgstr "Strega del Fuoco"
+msgstr "Witchfire l'Empio"
 
 #: Source/monstdat.cpp:547
 msgid "Blackskull"
@@ -5357,7 +5316,7 @@ msgstr "Windspawn"
 
 #: Source/monstdat.cpp:550
 msgid "Lord of the Pit"
-msgstr "SovranoDelFosso"
+msgstr "Lord della Fossa"
 
 #: Source/monstdat.cpp:551
 msgid "Rustweaver"
@@ -5385,7 +5344,7 @@ msgstr "Gorefeast"
 
 #: Source/monstdat.cpp:557
 msgid "Graywar the Slayer"
-msgstr "Graywar the Slayer"
+msgstr "Graywar l'Assassino"
 
 #: Source/monstdat.cpp:558
 msgid "Dreadjudge"
@@ -5397,7 +5356,7 @@ msgstr "Stareye La Strega"
 
 #: Source/monstdat.cpp:560
 msgid "Steelskull the Hunter"
-msgstr "Steelskull the Hunter"
+msgstr "Steelskull il Cacciatore"
 
 #: Source/monstdat.cpp:561
 msgid "Sir Gorash"
@@ -5438,7 +5397,7 @@ msgstr "Non morto"
 #: Source/monster.cpp:4969
 #, c-format
 msgid "Type: %s  Kills: %i"
-msgstr ""
+msgstr "Tipo: %s  Uccisioni: %i"
 
 #: Source/monster.cpp:4971
 #, c-format
@@ -5456,7 +5415,7 @@ msgstr "Nessuna Res. Magica"
 
 #: Source/monster.cpp:5018
 msgid "Resists: "
-msgstr ""
+msgstr "Resiste: "
 
 #: Source/monster.cpp:5020 Source/monster.cpp:5031
 msgid "Magic "
@@ -5477,7 +5436,7 @@ msgstr "Immune: "
 #: Source/monster.cpp:5049
 #, c-format
 msgid "Type: %s"
-msgstr ""
+msgstr "Tipo: %s"
 
 #: Source/monster.cpp:5055 Source/monster.cpp:5062
 msgid "No resistances"
@@ -5495,30 +5454,29 @@ msgstr "Resistente alle Magie"
 msgid "Some Magic Immunities"
 msgstr "Immune a molte Magie"
 
-#: Source/msg.cpp:171
+#: Source/msg.cpp:172
 msgid "Waiting for game data..."
 msgstr "Attendi Dati di Gioco..."
 
-#: Source/msg.cpp:179
+#: Source/msg.cpp:180
 msgid "The game ended"
 msgstr "Gioco Concluso"
 
-#: Source/msg.cpp:185
+#: Source/msg.cpp:186
 msgid "Unable to get level data"
 msgstr "Imposs.OttenereDatiGioco"
 
-#: Source/msg.cpp:610
+#: Source/msg.cpp:611
 msgid "Trying to drop a floor item?"
 msgstr "Provi a Lasciare un oggetto?"
 
-#: Source/msg.cpp:1387 Source/msg.cpp:1658 Source/msg.cpp:1680
-#: Source/msg.cpp:1702 Source/msg.cpp:1822 Source/msg.cpp:1843
-#: Source/msg.cpp:1864 Source/msg.cpp:1885
+#: Source/msg.cpp:1388 Source/msg.cpp:1659 Source/msg.cpp:1681 Source/msg.cpp:1703
+#: Source/msg.cpp:1823 Source/msg.cpp:1844 Source/msg.cpp:1865 Source/msg.cpp:1886
 #, c-format
 msgid "%s has cast an illegal spell."
 msgstr "%s Ha usato Magia Illegale ."
 
-#: Source/msg.cpp:2221 Source/multi.cpp:866
+#: Source/msg.cpp:2222 Source/multi.cpp:866
 #, c-format
 msgid "Player '%s' (level %d) just joined the game"
 msgstr "L'Eroe '%s' (liv. %d) si è Unito al Gioco"
@@ -5541,7 +5499,7 @@ msgstr "L'Eroe '%s' è caduto per timeout"
 #: Source/multi.cpp:868
 #, c-format
 msgid "Player '%s' (level %d) is already in the game"
-msgstr "L'Eroe '%s' (liv. %d) è goà nel Gioco"
+msgstr "L'Eroe '%s' (liv. %d) è già in partita"
 
 #: Source/objects.cpp:90
 msgid "Mysterious"
@@ -5633,19 +5591,19 @@ msgstr "Tainted"
 
 #: Source/objects.cpp:116
 msgid "Oily"
-msgstr ""
+msgstr "Untuoso"
 
 #: Source/objects.cpp:117
 msgid "Glowing"
-msgstr ""
+msgstr "Brillante"
 
 #: Source/objects.cpp:118
 msgid "Mendicant's"
-msgstr ""
+msgstr "del Mendicante"
 
 #: Source/objects.cpp:119
 msgid "Sparkling"
-msgstr ""
+msgstr "Sfavillante"
 
 #: Source/objects.cpp:120
 msgid "Town"
@@ -5653,11 +5611,11 @@ msgstr "Città"
 
 #: Source/objects.cpp:121
 msgid "Shimmering"
-msgstr ""
+msgstr "Scintillante"
 
 #: Source/objects.cpp:122
 msgid "Solar"
-msgstr ""
+msgstr "Solare"
 
 #: Source/objects.cpp:123
 msgid "Murphy's"
@@ -5733,7 +5691,7 @@ msgstr "Scheletro Crocifisso"
 
 #: Source/objects.cpp:5480
 msgid "Lever"
-msgstr ""
+msgstr "Leva"
 
 #: Source/objects.cpp:5489
 msgid "Open Door"
@@ -5842,7 +5800,7 @@ msgstr "Goat Shrine"
 
 #: Source/objects.cpp:5579
 msgid "Cauldron"
-msgstr "Marmitta"
+msgstr "Calderone"
 
 #: Source/objects.cpp:5582
 msgid "Murky Pool"
@@ -5862,20 +5820,20 @@ msgstr "Colonna di Sangue"
 
 #: Source/objects.cpp:5600
 msgid "Mushroom Patch"
-msgstr "Pezzo di Fungo"
+msgstr "Pugno di Funghi"
 
 #: Source/objects.cpp:5603
 msgid "Vile Stand"
-msgstr "Base Vile"
+msgstr "Stallo del Vile"
 
 #: Source/objects.cpp:5606
 msgid "Slain Hero"
-msgstr "Eroe Morto"
+msgstr "Eroe Ucciso"
 
 #: Source/objects.cpp:5613
 #, c-format
 msgid "Trapped %s"
-msgstr "Trapped %s"
+msgstr "Trappola %s"
 
 #: Source/objects.cpp:5619
 #, c-format
@@ -5908,8 +5866,7 @@ msgid "%s (lvl %d): %s"
 msgstr "%s (liv %d): %s"
 
 #: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:52
-msgid ""
-"Failed to load UI resources. Is devilutionx.mpq accessible and up to date?"
+msgid "Failed to load UI resources. Is devilutionx.mpq accessible and up to date?"
 msgstr ""
 "Caricamento risorse di interfaccia fallito. devilutionx.mpq è accessibile ed "
 "aggiornato?"
@@ -5974,35 +5931,35 @@ msgstr "Arcivescovo Lazarus"
 
 #: Source/quests.cpp:55
 msgid "Grave Matters"
-msgstr ""
+msgstr "Questioni di Tomba"
 
 #: Source/quests.cpp:56
 msgid "Farmer's Orchard"
-msgstr ""
+msgstr "L'Orto del Contadino"
 
 #: Source/quests.cpp:57
 msgid "Little Girl"
-msgstr "Fanciulla"
+msgstr "La Fanciulla"
 
 #: Source/quests.cpp:58
 msgid "Wandering Trader"
-msgstr ""
+msgstr "Il Commerciante Errante"
 
 #: Source/quests.cpp:61 Source/trigs.cpp:435
 msgid "Cornerstone of the World"
-msgstr ""
+msgstr "La Pietra Angolare del Mondo"
 
 #: Source/quests.cpp:62
 msgid "The Jersey's Jersey"
-msgstr ""
+msgstr "Il Jersey di Jersey"
 
 #: Source/quests.cpp:76
 msgid "King Leoric's Tomb"
-msgstr "Tomba di Re Leoric"
+msgstr "La Tomba di Re Leoric"
 
 #: Source/quests.cpp:78 Source/setmaps.cpp:79
 msgid "Maze"
-msgstr "Maze"
+msgstr "Il Labirinto"
 
 #: Source/quests.cpp:79
 msgid "A Dark Passage"
@@ -6010,16 +5967,16 @@ msgstr "Un Tunnel Oscuro"
 
 #: Source/quests.cpp:80
 msgid "Unholy Altar"
-msgstr "Empio Altare"
+msgstr "L'Empio Altare"
 
 #: Source/quests.cpp:283
 #, c-format
 msgid "To %s"
-msgstr "To %s"
+msgstr "Verso %s"
 
 #: Source/quests.cpp:760
 msgid "Quest Log"
-msgstr "Quest Log"
+msgstr "Missioni"
 
 #: Source/quests.cpp:767
 msgid "Close Quest Log"
@@ -6039,19 +5996,19 @@ msgstr "Covo Arivescovo Lazarus"
 
 #: Source/spelldat.cpp:16
 msgid "Firebolt"
-msgstr "Firebolt"
+msgstr "Sfera infuocata"
 
 #: Source/spelldat.cpp:17
 msgid "Healing"
-msgstr "Guarit"
+msgstr "Guarigione"
 
 #: Source/spelldat.cpp:19
 msgid "Flash"
-msgstr "Flash"
+msgstr "Bagliore"
 
 #: Source/spelldat.cpp:20
 msgid "Identify"
-msgstr "Identif"
+msgstr "Identifica"
 
 #: Source/spelldat.cpp:21
 msgid "Fire Wall"
@@ -6075,23 +6032,23 @@ msgstr "Mana Shield"
 
 #: Source/spelldat.cpp:27
 msgid "Fireball"
-msgstr "Fireball"
+msgstr "Sfera infuocata"
 
 #: Source/spelldat.cpp:29
 msgid "Chain Lightning"
-msgstr "Chain Lightning"
+msgstr "Tempesta"
 
 #: Source/spelldat.cpp:30
 msgid "Flame Wave"
-msgstr "Flame Wave"
+msgstr "Ondata di Fiamme"
 
 #: Source/spelldat.cpp:31
 msgid "Doom Serpents"
-msgstr "Doom Serpents"
+msgstr "Serpenti del Fato"
 
 #: Source/spelldat.cpp:32
 msgid "Blood Ritual"
-msgstr "Blood Ritual"
+msgstr "Rito di Sangue"
 
 #: Source/spelldat.cpp:33
 msgid "Nova"
@@ -6099,15 +6056,15 @@ msgstr "Nova"
 
 #: Source/spelldat.cpp:34
 msgid "Invisibility"
-msgstr "Invisibilita"
+msgstr "Invisibilità"
 
 #: Source/spelldat.cpp:37
 msgid "Rage"
-msgstr ""
+msgstr "Ira"
 
 #: Source/spelldat.cpp:38
 msgid "Teleport"
-msgstr "Teleport"
+msgstr "Teletrasporto"
 
 #: Source/spelldat.cpp:39
 msgid "Apocalypse"
@@ -6115,35 +6072,35 @@ msgstr "Apocalisse"
 
 #: Source/spelldat.cpp:40
 msgid "Etherealize"
-msgstr "Etherealize"
+msgstr "Eterealiza"
 
 #: Source/spelldat.cpp:41
 msgid "Item Repair"
-msgstr "Ripara Ogg"
+msgstr "Ripara Oggetto"
 
 #: Source/spelldat.cpp:42
 msgid "Staff Recharge"
-msgstr "RicaricaStaffe"
+msgstr "Ricarica Verga"
 
 #: Source/spelldat.cpp:43
 msgid "Trap Disarm"
-msgstr "Trap Disarm"
+msgstr "Disarma Trappola"
 
 #: Source/spelldat.cpp:44
 msgid "Elemental"
-msgstr "Elemental"
+msgstr "Elementale"
 
 #: Source/spelldat.cpp:45
 msgid "Charged Bolt"
-msgstr "Charged Bolt"
+msgstr "Scarica Fulminea"
 
 #: Source/spelldat.cpp:46
 msgid "Holy Bolt"
-msgstr "Holy Bolt"
+msgstr "Scarica Energetica"
 
 #: Source/spelldat.cpp:47
 msgid "Resurrect"
-msgstr "Resurrect"
+msgstr "Resurrezione"
 
 #: Source/spelldat.cpp:48
 msgid "Telekinesis"
@@ -6151,15 +6108,15 @@ msgstr "Telecinesi"
 
 #: Source/spelldat.cpp:49
 msgid "Heal Other"
-msgstr "Heal Other"
+msgstr "Cura"
 
 #: Source/spelldat.cpp:50
 msgid "Blood Star"
-msgstr "Blood Star"
+msgstr "Stella Cruenta"
 
 #: Source/spelldat.cpp:51
 msgid "Bone Spirit"
-msgstr "Bone Spirit"
+msgstr "Spirito Osseo"
 
 #: Source/spelldat.cpp:52
 msgid "Mana"
@@ -6167,31 +6124,31 @@ msgstr "Mana"
 
 #: Source/spelldat.cpp:53
 msgid "the Magi"
-msgstr ""
+msgstr "Magi"
 
 #: Source/spelldat.cpp:54
 msgid "the Jester"
-msgstr ""
+msgstr "Jester"
 
 #: Source/spelldat.cpp:55
 msgid "Lightning Wall"
-msgstr ""
+msgstr "Muro Fulmineo"
 
 #: Source/spelldat.cpp:56
 msgid "Immolation"
-msgstr "Immolazione"
+msgstr "Sacrificio"
 
 #: Source/spelldat.cpp:57
 msgid "Warp"
-msgstr "Deforma"
+msgstr "Deformazione"
 
 #: Source/spelldat.cpp:58
 msgid "Reflect"
-msgstr "Riflette"
+msgstr "Riflesso"
 
 #: Source/spelldat.cpp:59
 msgid "Berserk"
-msgstr ""
+msgstr "Berserk"
 
 #: Source/spelldat.cpp:60
 msgid "Ring of Fire"
@@ -6234,19 +6191,19 @@ msgstr "Dur: %i/%i, "
 
 #: Source/stores.cpp:187
 msgid "Indestructible,  "
-msgstr "Invulnerabile , "
+msgstr "Indistruttibile, "
 
 #: Source/stores.cpp:195
 msgid "No required attributes"
-msgstr "Non Richiede attributi"
+msgstr "Non richiede attributi"
 
 #: Source/stores.cpp:225 Source/stores.cpp:950 Source/stores.cpp:1172
 msgid "Welcome to the"
-msgstr "Benvenuti dal"
+msgstr "Benvenuti alla"
 
 #: Source/stores.cpp:226
 msgid "Blacksmith's shop"
-msgstr "Fabbro - Griswold"
+msgstr "Bottega del fabbro"
 
 #: Source/stores.cpp:227 Source/stores.cpp:576 Source/stores.cpp:952
 #: Source/stores.cpp:1011 Source/stores.cpp:1174 Source/stores.cpp:1186
@@ -6260,28 +6217,28 @@ msgstr "Parla a Griswold"
 
 #: Source/stores.cpp:229
 msgid "Buy basic items"
-msgstr "Acquista Armi"
+msgstr "Compra armi"
 
 #: Source/stores.cpp:230
 msgid "Buy premium items"
-msgstr "Le Armi Migliori"
+msgstr "Compra armi speciali"
 
 #: Source/stores.cpp:231 Source/stores.cpp:579
 msgid "Sell items"
-msgstr "Vendi Armi"
+msgstr "Vendi merce"
 
 #: Source/stores.cpp:232
 msgid "Repair items"
-msgstr "Ripara Armi"
+msgstr "Ripara armi"
 
 #: Source/stores.cpp:233
 msgid "Leave the shop"
-msgstr "Lascia Negozio"
+msgstr "Lascia bottega"
 
 #: Source/stores.cpp:274 Source/stores.cpp:623 Source/stores.cpp:989
 #, c-format
 msgid "I have these items for sale:             Your gold: %i"
-msgstr "Ho questi oggetti in vendita: Il tuo Oro : %i"
+msgstr "Merce in vendita:             Monete : %i"
 
 #: Source/stores.cpp:279 Source/stores.cpp:343 Source/stores.cpp:471
 #: Source/stores.cpp:482 Source/stores.cpp:541 Source/stores.cpp:554
@@ -6290,36 +6247,36 @@ msgstr "Ho questi oggetti in vendita: Il tuo Oro : %i"
 #: Source/stores.cpp:1094 Source/stores.cpp:1105 Source/stores.cpp:1138
 #: Source/stores.cpp:1165
 msgid "Back"
-msgstr "Esci"
+msgstr "Indietro"
 
 #: Source/stores.cpp:339
 #, c-format
 msgid "I have these premium items for sale:     Your gold: %i"
-msgstr "Ecco i migliori oggetti che vendo: Il tuo Oro : %i"
+msgstr "Armi speciali in vendita:     Monete : %i"
 
 #: Source/stores.cpp:467 Source/stores.cpp:717
 #, c-format
 msgid "You have nothing I want.             Your gold: %i"
-msgstr "Non hai niente che mi interessa. Il tuo Oro : %i"
+msgstr "Non mi interessa nulla.             Monete: %i"
 
 #: Source/stores.cpp:477 Source/stores.cpp:727
 #, c-format
 msgid "Which item is for sale?             Your gold: %i"
-msgstr "Che cosa intendi vendermi? Il tuo Oro : %i"
+msgstr "Cosa proponi in vendita?             Monete: %i"
 
 #: Source/stores.cpp:537
 #, c-format
 msgid "You have nothing to repair.             Your gold: %i"
-msgstr "Non hai niente da riparare.  Il tuo Oro : %i"
+msgstr "Nulla da riparare.             Monete: %i"
 
 #: Source/stores.cpp:549
 #, c-format
 msgid "Repair which item?             Your gold: %i"
-msgstr "Intendi riparare qualcosa? Il tuo Oro : %i"
+msgstr "Cosa vuoi riparare?             Monete: %i"
 
 #: Source/stores.cpp:575
 msgid "Witch's shack"
-msgstr "Dalla Strega"
+msgstr "Baracca della strega"
 
 #: Source/stores.cpp:577
 msgid "Talk to Adria"
@@ -6327,33 +6284,33 @@ msgstr "Parla a Adria"
 
 #: Source/stores.cpp:578 Source/stores.cpp:954
 msgid "Buy items"
-msgstr "Compra"
+msgstr "Compra merce"
 
 #: Source/stores.cpp:580
 msgid "Recharge staves"
-msgstr "Ricarica Staffe"
+msgstr "Ricarica verghe"
 
 #: Source/stores.cpp:581
 msgid "Leave the shack"
-msgstr "Vattene Via"
+msgstr "Lascia baracca"
 
 #: Source/stores.cpp:793
 #, c-format
 msgid "You have nothing to recharge.             Your gold: %i"
-msgstr "Non hai niente da ricaricare.  Il tuo Oro : %i"
+msgstr "Nulla da ricaricare.             Monete: %i"
 
 #: Source/stores.cpp:803
 #, c-format
 msgid "Recharge which item?             Your gold: %i"
-msgstr "Cosa intendi ricaricare? Il tuo Oro : %i"
+msgstr "Cosa vuoi ricaricare?             Monete: %i"
 
 #: Source/stores.cpp:819
 msgid "You do not have enough gold"
-msgstr "Non hai abbastanza Oro"
+msgstr "Non hai abbastanza oro"
 
 #: Source/stores.cpp:827
 msgid "You do not have enough room in inventory"
-msgstr "Non hai abbastanza spazio nel Inventario"
+msgstr "Non hai abbastanza spazio in inventario"
 
 #: Source/stores.cpp:863
 msgid "Do we have a deal?"
@@ -6381,7 +6338,7 @@ msgstr "Sei sicuro di voler riparare l'oggetto?"
 
 #: Source/stores.cpp:896 Source/towners.cpp:319
 msgid "Wirt the Peg-legged boy"
-msgstr "Wirt - Gamba di Legno"
+msgstr "Wirt gamba di legno"
 
 #: Source/stores.cpp:899 Source/stores.cpp:906
 msgid "Talk to Wirt"
@@ -6393,33 +6350,33 @@ msgstr "Ho qualcosa in vendita,"
 
 #: Source/stores.cpp:901
 msgid "but it will cost 50 gold"
-msgstr "ma devi darmi 50 monete"
+msgstr "ma ti costerà 50 monete"
 
 #: Source/stores.cpp:902
 msgid "just to take a look. "
-msgstr "per sapere cose'! . "
+msgstr "solo sbirciare. "
 
 #: Source/stores.cpp:903
 msgid "What have you got?"
-msgstr "Paga per vedere?"
+msgstr "Di cosa si tratta?"
 
 #: Source/stores.cpp:904 Source/stores.cpp:907 Source/stores.cpp:1014
 #: Source/stores.cpp:1188
 msgid "Say goodbye"
-msgstr "Te ne Vai"
+msgstr "Saluta"
 
 #: Source/stores.cpp:915
 #, c-format
 msgid "I have this item for sale:             Your gold: %i"
-msgstr "Ho questi oggetti in vendita: Il tuo Oro : %i"
+msgstr "Oggetti in vendita:             Monete: %i"
 
 #: Source/stores.cpp:931
 msgid "Leave"
-msgstr "Via"
+msgstr "Lascia"
 
 #: Source/stores.cpp:951
 msgid "Healer's home"
-msgstr "Guaritore"
+msgstr "Dimora del Guaritore"
 
 #: Source/stores.cpp:953
 msgid "Talk to Pepin"
@@ -6427,11 +6384,11 @@ msgstr "Parla a Pepin"
 
 #: Source/stores.cpp:955
 msgid "Leave Healer's home"
-msgstr "Saluta Pepin e Vai"
+msgstr "Lascia dimora del Guaritore"
 
 #: Source/stores.cpp:1010
 msgid "The Town Elder"
-msgstr "Il Narratore"
+msgstr "Il Saggio della Città"
 
 #: Source/stores.cpp:1012
 msgid "Talk to Cain"
@@ -6439,21 +6396,21 @@ msgstr "Parla a Cain"
 
 #: Source/stores.cpp:1013
 msgid "Identify an item"
-msgstr "Ravvisa Oggetti"
+msgstr "Identifica oggetti"
 
 #: Source/stores.cpp:1090
 #, c-format
 msgid "You have nothing to identify.             Your gold: %i"
-msgstr "Non hai niente da identificare. Il tuo Oro : %i"
+msgstr "Nulla da identificare.             Monete: %i"
 
 #: Source/stores.cpp:1100
 #, c-format
 msgid "Identify which item?             Your gold: %i"
-msgstr "Cosa vuoi identificare? Il tuo Oro : %i"
+msgstr "Cosa vuoi identificare?             Monete: %i"
 
 #: Source/stores.cpp:1117
 msgid "This item is:"
-msgstr "Descrizione :"
+msgstr "Questo oggetto è:"
 
 #: Source/stores.cpp:1120
 msgid "Done"
@@ -6475,7 +6432,7 @@ msgstr "non è disponibile"
 
 #: Source/stores.cpp:1136
 msgid "in the shareware"
-msgstr "nella shareware"
+msgstr "nello shareware"
 
 #: Source/stores.cpp:1137
 msgid "version"
@@ -6483,11 +6440,11 @@ msgstr "versione"
 
 #: Source/stores.cpp:1164
 msgid "Gossip"
-msgstr "Storie"
+msgstr "Pettegolezzo"
 
 #: Source/stores.cpp:1173
 msgid "Rising Sun"
-msgstr "Taverniere"
+msgstr "Il Sol Levante"
 
 #: Source/stores.cpp:1175
 msgid "Talk to Ogden"
@@ -6495,7 +6452,7 @@ msgstr "Parla a Ogden"
 
 #: Source/stores.cpp:1176
 msgid "Leave the tavern"
-msgstr "Lascia Taverna"
+msgstr "Lascia taverna"
 
 #: Source/stores.cpp:1187
 msgid "Talk to Gillian"
@@ -6511,247 +6468,232 @@ msgstr "Parla a Farnham"
 
 #: Source/stores.cpp:1200
 msgid "Say Goodbye"
-msgstr "Allontanati"
+msgstr "Saluta"
 
 #: Source/textdat.cpp:15
 msgid ""
-" Ahh, the story of our King, is it? The tragic fall of Leoric was a harsh "
-"blow to this land. The people always loved the King, and now they live in "
-"mortal fear of him. The question that I keep asking myself is how he could "
-"have fallen so far from the Light, as Leoric had always been the holiest of "
-"men. Only the vilest powers of Hell could so utterly destroy a man from "
-"within... |"
+" Ahh, the story of our King, is it? The tragic fall of Leoric was a harsh blow to "
+"this land. The people always loved the King, and now they live in mortal fear of "
+"him. The question that I keep asking myself is how he could have fallen so far "
+"from the Light, as Leoric had always been the holiest of men. Only the vilest "
+"powers of Hell could so utterly destroy a man from within... |"
 msgstr ""
 " Ahh, la storia del nostro re? La caduta di Leoric è stata un duro colpo per "
-"questa terra. La gente ha sempre amato il re e ora vivono nel terrore di "
-"lui. Quello che non capisco è come è stato possibile che sia caduto cosi' "
-"lontano dalla luce, dato che Leoric è sempre stato il più santo degli "
-"uomini. Solo i più malvagi poteri infernali avrebbero potuto cambiarlo "
-"cosi'. |"
+"questa terra. La gente ha sempre amato il re e ora vivono nel terrore di lui. "
+"Quello che non capisco è come è stato possibile che sia caduto così lontano dalla "
+"luce, dato che Leoric è sempre stato il più santo degli uomini. Solo i più malvagi "
+"poteri infernali avrebbero potuto cambiarlo così. |"
 
 #: Source/textdat.cpp:17
 msgid ""
 "The village needs your help, good master! Some months ago King Leoric's son, "
-"Prince Albrecht, was kidnapped. The King went into a rage and scoured the "
-"village for his missing child. With each passing day, Leoric seemed to slip "
-"deeper into madness. He sought to blame innocent townsfolk for the boy's "
-"disappearance and had them brutally executed. Less than half of us survived "
-"his insanity...\n"
+"Prince Albrecht, was kidnapped. The King went into a rage and scoured the village "
+"for his missing child. With each passing day, Leoric seemed to slip deeper into "
+"madness. He sought to blame innocent townsfolk for the boy's disappearance and had "
+"them brutally executed. Less than half of us survived his insanity...\n"
 " \n"
-"The King's Knights and Priests tried to placate him, but he turned against "
-"them and sadly, they were forced to kill him. With his dying breath the King "
-"called down a terrible curse upon his former followers. He vowed that they "
-"would serve him in darkness forever...\n"
+"The King's Knights and Priests tried to placate him, but he turned against them "
+"and sadly, they were forced to kill him. With his dying breath the King called "
+"down a terrible curse upon his former followers. He vowed that they would serve "
+"him in darkness forever...\n"
 " \n"
-"This is where things take an even darker twist than I thought possible! Our "
-"former King has risen from his eternal sleep and now commands a legion of "
-"undead minions within the Labyrinth. His body was buried in a tomb three "
-"levels beneath the Cathedral. Please, good master, put his soul at ease by "
-"destroying his now cursed form... |"
+"This is where things take an even darker twist than I thought possible! Our former "
+"King has risen from his eternal sleep and now commands a legion of undead minions "
+"within the Labyrinth. His body was buried in a tomb three levels beneath the "
+"Cathedral. Please, good master, put his soul at ease by destroying his now cursed "
+"form... |"
 msgstr ""
-"La città necessita del tuo aiuto, signore! Alcuni mesi fa il figlio di Re "
-"Leoric, il Principe Albrecht, venne rapito. Il re, furioso, fece perquisire "
-"il villaggio per ritrovare il figlio. Col passare dei giorni, il re sembrò "
-"scivolare sempre più nella pazzia. Incolpò cittadini innocenti della "
-"scomparsa del figlio e li giustiziò. Meno della metà di noi scamparono alla "
-"sua follia...\n"
-"I cavalieri e i sacerdoti provarono a placarlo, ma si rivoltò contro di loro "
-"e purtroppo, furono costretti ad ucciderlo. Con il suo ultimo respiro invocò "
-"una terribile maledizione contro i suoi passati seguaci. Giurò che lo "
-"avrebbero servito per sempre nell'oscurità... \n"
-"Da qui le cose prendono una piega ancora peggiore di quello che pensavo "
-"possibile! Il nostro ex re e' sorto dal suo sonno eterno e comanda una "
-"legione di non morti nel labirinto. Il suo corpo fu sepolto tre livelli "
-"sotto la cattedrale. Ti prego, signore, distruggi il suo corpo così che la "
-"sua anima possa riposare in pace... |"
+"La città necessita del tuo aiuto, signore! Alcuni mesi fa il figlio di Re Leoric, "
+"il Principe Albrecht, venne rapito. Il re, furioso, fece perquisire il villaggio "
+"per ritrovare il figlio. Col passare dei giorni, il re sembrò scivolare sempre più "
+"nella pazzia. Incolpò cittadini innocenti della scomparsa del figlio e li "
+"giustiziò. Meno della metà di noi scamparono alla sua follia...\n"
+"I cavalieri e i sacerdoti provarono a placarlo, ma si rivoltò contro di loro e "
+"purtroppo, furono costretti ad ucciderlo. Con il suo ultimo respiro invocò una "
+"terribile maledizione contro i suoi passati seguaci. Giurò che lo avrebbero "
+"servito per sempre nell'oscurità... \n"
+"Da qui le cose prendono una piega ancora peggiore di quello che pensavo possibile! "
+"Il nostro ex re è sorto dal suo sonno eterno e comanda una legione di non morti "
+"nel labirinto. Il suo corpo fu sepolto tre livelli sotto la cattedrale. Ti prego, "
+"signore, distruggi il suo corpo così che la sua anima possa riposare in pace... |"
 
 #: Source/textdat.cpp:19
 msgid ""
-"As I told you, good master, the King was entombed three levels below. He's "
-"down there, waiting in the putrid darkness for his chance to destroy this "
-"land... |"
+"As I told you, good master, the King was entombed three levels below. He's down "
+"there, waiting in the putrid darkness for his chance to destroy this land... |"
 msgstr ""
-"Come ti ho detto Signore, il Re fu seppellito tre livelli qui sotto. Giù "
-"egli attende nella putrida oscurità l'opportunità per distruggere questa "
-"terra... |"
+"Come ti ho detto Signore, il Re fu seppellito tre livelli qui sotto. Giù egli "
+"attende nella putrida oscurità l'opportunità per distruggere questa terra... |"
 
 #: Source/textdat.cpp:21
 msgid ""
-"The curse of our King has passed, but I fear that it was only part of a "
-"greater evil at work. However, we may yet be saved from the darkness that "
-"consumes our land, for your victory is a good omen. May Light guide you on "
-"your way, good master. |"
+"The curse of our King has passed, but I fear that it was only part of a greater "
+"evil at work. However, we may yet be saved from the darkness that consumes our "
+"land, for your victory is a good omen. May Light guide you on your way, good "
+"master. |"
 msgstr ""
-"La maledizione del re è finita, ma temo che fosse parte di un male più "
-"grande. Comunque possiamo ancora salvarci dall'oscurità che consuma la "
-"nostra terra, la tua vittoria è un buon auspicio. Possa la luce guidarti sul "
-"tuo cammino, signore. |"
+"La maledizione del re è finita, ma temo che fosse parte di un male più grande. "
+"Comunque possiamo ancora salvarci dall'oscurità che consuma la nostra terra, la "
+"tua vittoria è un buon auspicio. Possa la luce guidarti sul tuo cammino, signore. |"
 
 #: Source/textdat.cpp:23
 msgid ""
-"The loss of his son was too much for King Leoric. I did what I could to ease "
-"his madness, but in the end it overcame him. A black curse has hung over "
-"this kingdom from that day forward, but perhaps if you were to free his "
-"spirit from his earthly prison, the curse would be lifted... |"
+"The loss of his son was too much for King Leoric. I did what I could to ease his "
+"madness, but in the end it overcame him. A black curse has hung over this kingdom "
+"from that day forward, but perhaps if you were to free his spirit from his earthly "
+"prison, the curse would be lifted... |"
 msgstr ""
-"La perdita del figlio fu troppo per Re Leoric. Tentai quel che potei per "
-"calmare la sua pazzia, ma alla fine venni sopraffatto. Da quel giorno su "
-"questo Regno pesa una Nera Maledizione, ma magari se tu liberassi la sua "
-"anima dalla sua prigione terrena la maledizione cesserebbe... |"
+"La perdita del figlio fu troppo per Re Leoric. Tentai quel che potei per calmare "
+"la sua pazzia, ma alla fine venni sopraffatto. Da quel giorno su questo Regno pesa "
+"una Nera Maledizione, ma magari se tu liberassi la sua anima dalla sua prigione "
+"terrena la maledizione cesserebbe... |"
 
 #: Source/textdat.cpp:25
 msgid ""
-"I don't like to think about how the King died. I like to remember him for "
-"the kind and just ruler that he was. His death was so sad and seemed very "
-"wrong, somehow. |"
+"I don't like to think about how the King died. I like to remember him for the kind "
+"and just ruler that he was. His death was so sad and seemed very wrong, somehow. |"
 msgstr ""
-"Non mi piace pesare a come mori' il Re. Preferisco ricordarlo per l'uomo "
-"buono e giusto che era. La sua morte è stata tanto triste quanto ingiusta. |"
+"Non mi piace pesare a come morì il Re. Preferisco ricordarlo per l'uomo buono e "
+"giusto che era. La sua morte è stata tanto triste quanto ingiusta. |"
 
 #: Source/textdat.cpp:27
 msgid ""
-"I made many of the weapons and most of the armor that King Leoric used to "
-"outfit his knights. I even crafted a huge two-handed sword of the finest "
-"mithril for him, as well as a field crown to match. I still cannot believe "
-"how he died, but it must have been some sinister force that drove him "
-"insane! |"
+"I made many of the weapons and most of the armor that King Leoric used to outfit "
+"his knights. I even crafted a huge two-handed sword of the finest mithril for him, "
+"as well as a field crown to match. I still cannot believe how he died, but it must "
+"have been some sinister force that drove him insane! |"
 msgstr ""
-"Forgiai la maggior parte delle armi e delle armature che Re Leoric forniva "
-"ai suoi Cavalieri. Usai la mia maestria per forgiargli una spada a due mani "
-"del miglior mithril e una corona da battaglia. Non riesco ancora a credere "
-"che sia morto, di sicuro qualche forza malvagia lo portò alla pazzia! |"
+"Forgiai la maggior parte delle armi e delle armature che Re Leoric forniva ai suoi "
+"Cavalieri. Usai la mia maestria per forgiargli una spada a due mani del miglior "
+"mithril e una corona da battaglia. Non riesco ancora a credere che sia morto, di "
+"sicuro qualche forza malvagia lo portò alla pazzia! |"
 
 #: Source/textdat.cpp:29
 msgid ""
-"I don't care about that. Listen, no skeleton is gonna be MY king. Leoric is "
-"King. King, so you hear me? HAIL TO THE KING! |"
+"I don't care about that. Listen, no skeleton is gonna be MY king. Leoric is King. "
+"King, so you hear me? HAIL TO THE KING! |"
 msgstr ""
-"Non m'importa! Ascolta, Nessuno scheletro diventerà il mio re. Leoric è il "
-"RE. Re, mi senti? LUNGA VITA AL RE! |"
+"Non m'importa! Ascolta, Nessuno scheletro diventerà il mio re. Leoric è il RE. Re, "
+"mi senti? LUNGA VITA AL RE! |"
 
 #: Source/textdat.cpp:31
 msgid ""
-"The dead who walk among the living follow the cursed King. He holds the "
-"power to raise yet more warriors for an ever growing army of the undead. If "
-"you do not stop his reign, he will surely march across this land and slay "
-"all who still live here. |"
+"The dead who walk among the living follow the cursed King. He holds the power to "
+"raise yet more warriors for an ever growing army of the undead. If you do not stop "
+"his reign, he will surely march across this land and slay all who still live here. "
+"|"
 msgstr ""
-"...La morte cammina fra i vivi a causa della maledizione del re. Egli ha il "
-"potere di sollevare altri guerrieri in una crescente armata di non-morti. Se "
-"non lo fermerai, marcerà su questa terra e massacrerà tutti quelli che "
-"ancora vivono qui. |"
+"...La morte cammina fra i vivi a causa della maledizione del re. Egli ha il potere "
+"di sollevare altri guerrieri in una crescente armata di non-morti. Se non lo "
+"fermerai, marcerà su questa terra e massacrerà tutti quelli che ancora vivono qui. "
+"|"
 
 #: Source/textdat.cpp:33
 msgid ""
-"Look, I'm running a business here. I don't sell information, and I don't "
-"care about some King that's been dead longer than I've been alive. If you "
-"need something to use against this King of the undead, then I can help you "
-"out... |"
+"Look, I'm running a business here. I don't sell information, and I don't care "
+"about some King that's been dead longer than I've been alive. If you need "
+"something to use against this King of the undead, then I can help you out... |"
 msgstr ""
-"Senti, sto lavorando. Non vendo informazioni e non m'importa di nessun Re "
-"che è morto da più tempo di quanto io sia stato in vita. Se ti occorre "
-"qualcosa da usare contro questo Re dei non-morti, allora ti posso anche "
-"aiutare... |"
+"Senti, sto lavorando. Non vendo informazioni e non m'importa di nessun Re che è "
+"morto da più tempo di quanto io sia stato in vita. Se ti occorre qualcosa da usare "
+"contro questo Re dei non-morti, allora ti posso anche aiutare... |"
 
 #: Source/textdat.cpp:35
 msgid ""
-"The warmth of life has entered my tomb. Prepare yourself, mortal, to serve "
-"my Master for eternity! |"
+"The warmth of life has entered my tomb. Prepare yourself, mortal, to serve my "
+"Master for eternity! |"
 msgstr ""
-"La fiamma della vita è tornata a me. Preparati mortale, a servire il mio "
-"padrone per l'eternità! |"
+"La fiamma della vita è tornata a me. Preparati mortale, a servire il mio padrone "
+"per l'eternità! |"
 
 #: Source/textdat.cpp:37
 msgid ""
-"I see that this strange behavior puzzles you as well. I would surmise that "
-"since many demons fear the light of the sun and believe that it holds great "
-"power, it may be that the rising sun depicted on the sign you speak of has "
-"led them to believe that it too holds some arcane powers. Hmm, perhaps they "
-"are not all as smart as we had feared... |"
+"I see that this strange behavior puzzles you as well. I would surmise that since "
+"many demons fear the light of the sun and believe that it holds great power, it "
+"may be that the rising sun depicted on the sign you speak of has led them to "
+"believe that it too holds some arcane powers. Hmm, perhaps they are not all as "
+"smart as we had feared... |"
 msgstr ""
-"Vedo che quello strano comportamento ti ha confuso. Suppongo che dato che "
-"molti demoni temono la luce del sole e pensano che contenga una grande "
-"forza, può essere che il sole nascente dipinto sull'insegna di cui parli "
-"abbia fatto loro credere che essa contenga arcani poteri. Hmm, forse non "
-"tutti sono cosi' abili come temevamo... |"
+"Vedo che quello strano comportamento ti ha confuso. Suppongo che dato che molti "
+"demoni temono la luce del sole e pensano che contenga una grande forza, può essere "
+"che il sole nascente dipinto sull'insegna di cui parli abbia fatto loro credere "
+"che essa contenga arcani poteri. Hmm, forse non tutti sono così abili come "
+"temevamo... |"
 
 #: Source/textdat.cpp:39
 msgid ""
 "Master, I have a strange experience to relate. I know that you have a great "
-"knowledge of those monstrosities that inhabit the labyrinth, and this is "
-"something that I cannot understand for the very life of me... I was awakened "
-"during the night by a scraping sound just outside of my tavern. When I "
-"looked out from my bedroom, I saw the shapes of small demon-like creatures "
-"in the inn yard. After a short time, they ran off, but not before stealing "
-"the sign to my inn. I don't know why the demons would steal my sign but "
-"leave my family in peace... 'tis strange, no? |"
+"knowledge of those monstrosities that inhabit the labyrinth, and this is something "
+"that I cannot understand for the very life of me... I was awakened during the "
+"night by a scraping sound just outside of my tavern. When I looked out from my "
+"bedroom, I saw the shapes of small demon-like creatures in the inn yard. After a "
+"short time, they ran off, but not before stealing the sign to my inn. I don't know "
+"why the demons would steal my sign but leave my family in peace... 'tis strange, "
+"no? |"
 msgstr ""
 "Signore, vorrei raccontarti cosa mi è accaduto. So che tu conosci bene le "
-"mostruosità che vivono nel labirinto e quello che sto per raccontarti è una "
-"cosa che non riesco a capire... Ieri notte un rumore stridulo proveniente "
-"appena fuori dalla mia taverna mi ha tenuto sveglio. Guardando fuori ho "
-"notato delle sagome di piccoli demoni somiglianti a creaturine. Poco tempo "
-"dopo, sono fuggiti, ma non prima di avermi rubato l'insegna. Non voglio "
-"sapere perché i demoni hanno rubato la mia insegna, ma perché non lasciano "
-"in pace la mia famiglia... È strano, no? |"
+"mostruosità che vivono nel labirinto e quello che sto per raccontarti è una cosa "
+"che non riesco a capire... Ieri notte un rumore stridulo proveniente appena fuori "
+"dalla mia taverna mi ha tenuto sveglio. Guardando fuori ho notato delle sagome di "
+"piccoli demoni somiglianti a creaturine. Poco tempo dopo, sono fuggiti, ma non "
+"prima di avermi rubato l'insegna. Non voglio sapere perché i demoni hanno rubato "
+"la mia insegna, ma perché non lasciano in pace la mia famiglia... è strano, no? |"
 
 #: Source/textdat.cpp:41
 msgid ""
-"Oh, you didn't have to bring back my sign, but I suppose that it does save "
-"me the expense of having another one made. Well, let me see, what could I "
-"give you as a fee for finding it? Hmmm, what have we here... ah, yes! This "
-"cap was left in one of the rooms by a magician who stayed here some time "
-"ago. Perhaps it may be of some value to you. |"
+"Oh, you didn't have to bring back my sign, but I suppose that it does save me the "
+"expense of having another one made. Well, let me see, what could I give you as a "
+"fee for finding it? Hmmm, what have we here... ah, yes! This cap was left in one "
+"of the rooms by a magician who stayed here some time ago. Perhaps it may be of "
+"some value to you. |"
 msgstr ""
-"Oh, non dovevi riportarmi l'insegna, suppongo che questo mi risparmi il "
-"costo di doverne fare un'altra. Bene, fammi pensare, cosa poso darti in "
-"cambio? Hmmm, cosa abbiamo qui?... Ah, si! Questo copricapo è stato lasciato "
-"in una delle stanze da un mago che passò di qui qualche tempo fa. Forse per "
-"te potrebbe avere qualche utilità. |"
+"Oh, non dovevi riportarmi l'insegna, suppongo che questo mi risparmi il costo di "
+"doverne fare un'altra. Bene, fammi pensare, cosa poso darti in cambio? Hmmm, cosa "
+"abbiamo qui?... Ah, si! Questo copricapo è stato lasciato in una delle stanze da "
+"un mago che passò di qui qualche tempo fa. Forse per te potrebbe avere qualche "
+"utilità. |"
 
 #: Source/textdat.cpp:43
 msgid ""
-"My goodness, demons running about the village at night, pillaging our homes "
-"- is nothing sacred? I hope that Ogden and Garda are all right. I suppose "
-"that they would come to see me if they were hurt... |"
+"My goodness, demons running about the village at night, pillaging our homes - is "
+"nothing sacred? I hope that Ogden and Garda are all right. I suppose that they "
+"would come to see me if they were hurt... |"
 msgstr ""
-"Signore, demoni che girano per il villaggio di notte, saccheggiando le "
-"nostre case non c'è più niente di sacro? Spero che Ogden e Garda stiano "
-"bene. Penso sarebbero venuti da me se fossero feriti... |"
+"Signore, demoni che girano per il villaggio di notte, saccheggiando le nostre case "
+"non c'è più niente di sacro? Spero che Ogden e Garda stiano bene. Penso sarebbero "
+"venuti da me se fossero feriti... |"
 
 #: Source/textdat.cpp:45
 msgid ""
-"Oh my! Is that where the sign went? My Grandmother and I must have slept "
-"right through the whole thing. Thank the Light that those monsters didn't "
-"attack the inn. |"
+"Oh my! Is that where the sign went? My Grandmother and I must have slept right "
+"through the whole thing. Thank the Light that those monsters didn't attack the "
+"inn. |"
 msgstr ""
-"..Oh, dio! È questa la fine che ha fatto l'insegna? Io e mia nonna dobbiamo "
-"aver dormito mentre accadeva. Grazie a Dio quei mostri non hanno attaccato "
-"la locanda. |"
+"..Oh, dio! è questa la fine che ha fatto l'insegna? Io e mia nonna dobbiamo aver "
+"dormito mentre accadeva. Grazie a Dio quei mostri non hanno attaccato la locanda. |"
 
 #: Source/textdat.cpp:47
 msgid ""
-"Demons stole Ogden's sign, you say? That doesn't sound much like the "
-"atrocities I've heard of - or seen. \n"
+"Demons stole Ogden's sign, you say? That doesn't sound much like the atrocities "
+"I've heard of - or seen. \n"
 " \n"
 "Demons are concerned with ripping out your heart, not your signpost. |"
 msgstr ""
-"I demoni hanno rubato l'insegna di Ogden? Questo non combacia con le "
-"atrocità di cui ho sentito, e a cui ho assistito. \n"
+"I demoni hanno rubato l'insegna di Ogden? Questo non combacia con le atrocità di "
+"cui ho sentito, e a cui ho assistito. \n"
 " \n"
 "Ai demoni interessa strapparti il cuore, non l'insegna. |"
 
 #: Source/textdat.cpp:49
 msgid ""
-"You know what I think? Somebody took that sign, and they gonna want lots of "
-"money for it. If I was Ogden... and I'm not, but if I was... I'd just buy a "
-"new sign with some pretty drawing on it. Maybe a nice mug of ale or a piece "
-"of cheese... |"
+"You know what I think? Somebody took that sign, and they gonna want lots of money "
+"for it. If I was Ogden... and I'm not, but if I was... I'd just buy a new sign "
+"with some pretty drawing on it. Maybe a nice mug of ale or a piece of cheese... |"
 msgstr ""
 "Sai cosa penso? Qualcuno ha preso l'insegna, e ora vuole molti soldi per "
-"restituirla. Se fossi Ogden... e non lo sono, ma se lo fossi... Ne comprerei "
-"una nuova con un bel disegno. Un Boccale di birra o un pezzo di formaggio, "
-"per esempio... |"
+"restituirla. Se fossi Ogden... e non lo sono, ma se lo fossi... Ne comprerei una "
+"nuova con un bel disegno. Un Boccale di birra o un pezzo di formaggio, per "
+"esempio... |"
 
 #: Source/textdat.cpp:51
 msgid ""
@@ -6765,26 +6707,25 @@ msgstr ""
 
 #: Source/textdat.cpp:53
 msgid ""
-"What - is he saying I took that? I suppose that Griswold is on his side, "
-"too. \n"
+"What - is he saying I took that? I suppose that Griswold is on his side, too. \n"
 " \n"
-"Look, I got over simple sign stealing months ago. You can't turn a profit on "
-"a piece of wood. |"
+"Look, I got over simple sign stealing months ago. You can't turn a profit on a "
+"piece of wood. |"
 msgstr ""
 "Cosa? - Dice che l'ho presa io? Scommetto che Griswold è dalla sua parte. \n"
 " \n"
-"Senti ho superato la fase del ladro d'insegne mesi fa. Non trarrai profitto "
-"da un pezzo di legno. |"
+"Senti ho superato la fase del ladro d'insegne mesi fa. Non trarrai profitto da un "
+"pezzo di legno. |"
 
 #: Source/textdat.cpp:55
 msgid ""
-"Hey - You that one that kill all! You get me Magic Banner or we attack! You "
-"no leave with life! You kill big uglies and give back Magic. Go past corner "
-"and door, find uglies. You give, you go! |"
+"Hey - You that one that kill all! You get me Magic Banner or we attack! You no "
+"leave with life! You kill big uglies and give back Magic. Go past corner and door, "
+"find uglies. You give, you go! |"
 msgstr ""
-"Ehi - Tu quello che uccide tutti! Tu porta me Stendardo Magico o "
-"attacchiamo! Tu non sopravvivi! Uccidi grossi cattivi e riporta Magia. Passa "
-"angolo e porta, trova cattivi. Tu dai, tu vai ! |"
+"Ehi - Tu quello che uccide tutti! Tu porta me Stendardo Magico o attacchiamo! Tu "
+"non sopravvivi! Uccidi grossi cattivi e riporta Magia. Passa angolo e porta, trova "
+"cattivi. Tu dai, tu vai ! |"
 
 #: Source/textdat.cpp:57
 msgid "You kill uglies, get banner. You bring to me, or else... |"
@@ -6796,252 +6737,249 @@ msgstr "Tu dai! Bene! Vai ora, noi forti. Uccidiamo tutti con grande Magia! |"
 
 #: Source/textdat.cpp:61
 msgid ""
-"This does not bode well, for it confirms my darkest fears. While I did not "
-"allow myself to believe the ancient legends, I cannot deny them now. Perhaps "
-"the time has come to reveal who I am.\n"
+"This does not bode well, for it confirms my darkest fears. While I did not allow "
+"myself to believe the ancient legends, I cannot deny them now. Perhaps the time "
+"has come to reveal who I am.\n"
 " \n"
-"My true name is Deckard Cain the Elder, and I am the last descendant of an "
-"ancient Brotherhood that was dedicated to safeguarding the secrets of a "
-"timeless evil. An evil that quite obviously has now been released.\n"
+"My true name is Deckard Cain the Elder, and I am the last descendant of an ancient "
+"Brotherhood that was dedicated to safeguarding the secrets of a timeless evil. An "
+"evil that quite obviously has now been released.\n"
 " \n"
-"The Archbishop Lazarus, once King Leoric's most trusted advisor, led a party "
-"of simple townsfolk into the Labyrinth to find the King's missing son, "
-"Albrecht. Quite some time passed before they returned, and only a few of "
-"them escaped with their lives.\n"
+"The Archbishop Lazarus, once King Leoric's most trusted advisor, led a party of "
+"simple townsfolk into the Labyrinth to find the King's missing son, Albrecht. "
+"Quite some time passed before they returned, and only a few of them escaped with "
+"their lives.\n"
 " \n"
-"Curse me for a fool! I should have suspected his veiled treachery then. It "
-"must have been Lazarus himself who kidnapped Albrecht and has since hidden "
-"him within the Labyrinth. I do not understand why the Archbishop turned to "
-"the darkness, or what his interest is in the child, unless he means to "
-"sacrifice him to his dark masters!\n"
+"Curse me for a fool! I should have suspected his veiled treachery then. It must "
+"have been Lazarus himself who kidnapped Albrecht and has since hidden him within "
+"the Labyrinth. I do not understand why the Archbishop turned to the darkness, or "
+"what his interest is in the child, unless he means to sacrifice him to his dark "
+"masters!\n"
 " \n"
-"That must be what he has planned! The survivors of his 'rescue party' say "
-"that Lazarus was last seen running into the deepest bowels of the labyrinth. "
-"You must hurry and save the prince from the sacrificial blade of this "
-"demented fiend! |"
+"That must be what he has planned! The survivors of his 'rescue party' say that "
+"Lazarus was last seen running into the deepest bowels of the labyrinth. You must "
+"hurry and save the prince from the sacrificial blade of this demented fiend! |"
 msgstr ""
-"Questo non promette bene, perché conferma le mie paure più profonde. Anche "
-"se non ho mai creduto alle antiche leggende, ora non posso negarle. Forse è "
-"il momento di rivelare chi sono.\n"
+"Questo non promette bene, perché conferma le mie paure più profonde. Anche se non "
+"ho mai creduto alle antiche leggende, ora non posso negarle. Forse è il momento di "
+"rivelare chi sono.\n"
 " \n"
 "Il mio vero nome è Deckard Cain il Saggio, e sono l'ultimo discendente di "
-"un'antica Fratellanza il cui compito era custodire i segreti di un male "
-"senza tempo. Un male che apparentemente è stato liberato.\n"
+"un'antica Fratellanza il cui compito era custodire i segreti di un male senza "
+"tempo. Un male che apparentemente è stato liberato.\n"
 " \n"
-"L'Arcivescovo Lazarus, un tempo il consigliere più fidato del re Leoric, "
-"guidò un gruppo di paesani nel labirinto, per ritrovare il figlio scomparso "
-"del re, Albrecht. Passò molto tempo prima del loro ritorno, e solo pochi "
-"ritornarono vivi.\n"
+"L'Arcivescovo Lazarus, un tempo il consigliere più fidato del re Leoric, guidò un "
+"gruppo di paesani nel labirinto, per ritrovare il figlio scomparso del re, "
+"Albrecht. Passò molto tempo prima del loro ritorno, e solo pochi ritornarono "
+"vivi.\n"
 " \n"
-"Maledicimi per la mia stupidità! Avrei dovuto sospettare il suo inganno "
-"allora. Dev'essere stato Lazarus stesso a rapire Albrecht e a nasconderlo "
-"nel labirinto. Non capisco perché l'Arcivescovo sia diventato malvagio, o "
-"quale sia il suo interesse per il bambino. A meno che non intenda "
-"sacrificarlo ai suoi signori oscuri! Questo dev'essere il suo piano! I "
-"sopravvissuti del suo gruppo di salvataggio!\n"
+"Maledicimi per la mia stupidità! Avrei dovuto sospettare il suo inganno allora. "
+"Dev'essere stato Lazarus stesso a rapire Albrecht e a nasconderlo nel labirinto. "
+"Non capisco perché l'Arcivescovo sia diventato malvagio, o quale sia il suo "
+"interesse per il bambino. A meno che non intenda sacrificarlo ai suoi signori "
+"oscuri! Questo dev'essere il suo piano! I sopravvissuti del suo gruppo di "
+"salvataggio!\n"
 " \n"
-"dicono di aver visto Lazarus per l'ultima volta mentre correva nelle viscere "
-"più profonde del labirinto. Devi sbrigarti e salvare il principe dalla lama "
+"dicono di aver visto Lazarus per l'ultima volta mentre correva nelle viscere più "
+"profonde del labirinto. Devi sbrigarti e salvare il principe dalla lama "
 "sacrificale di quel pazzo! |\""
 
 #: Source/textdat.cpp:63
 msgid ""
-"You must hurry and rescue Albrecht from the hands of Lazarus. The prince and "
-"the people of this kingdom are counting on you! |"
+"You must hurry and rescue Albrecht from the hands of Lazarus. The prince and the "
+"people of this kingdom are counting on you! |"
 msgstr ""
 "Devi affrettarti a liberare Albrecht dalle mani di Lazarus. Il Principe e le "
 "persone di questo regno contano su di te! |"
 
 #: Source/textdat.cpp:65
 msgid ""
-"Your story is quite grim, my friend. Lazarus will surely burn in Hell for "
-"his horrific deed. The boy that you describe is not our prince, but I "
-"believe that Albrecht may yet be in danger. The symbol of power that you "
-"speak of must be a portal in the very heart of the labyrinth.\n"
+"Your story is quite grim, my friend. Lazarus will surely burn in Hell for his "
+"horrific deed. The boy that you describe is not our prince, but I believe that "
+"Albrecht may yet be in danger. The symbol of power that you speak of must be a "
+"portal in the very heart of the labyrinth.\n"
 " \n"
-"Know this, my friend - The evil that you move against is the dark Lord of "
-"Terror. He is known to mortal men as Diablo. It was he who was imprisoned "
-"within the Labyrinth many centuries ago and I fear that he seeks to once "
-"again sow chaos in the realm of mankind. You must venture through the portal "
-"and destroy Diablo before it is too late! |"
+"Know this, my friend - The evil that you move against is the dark Lord of Terror. "
+"He is known to mortal men as Diablo. It was he who was imprisoned within the "
+"Labyrinth many centuries ago and I fear that he seeks to once again sow chaos in "
+"the realm of mankind. You must venture through the portal and destroy Diablo "
+"before it is too late! |"
 msgstr ""
-"La tua storia è strana, amico mio. Lazarus brucerà all'inferno per quel che "
-"ha fatto. Il ragazzo che descrivi non è il nostro principe, ma credo che "
-"Albrecht possa essere ancora in pericolo. Il simbolo di potere di cui parli "
-"dev'essere un portale per il cuore del labirinto.\n"
+"La tua storia è strana, amico mio. Lazarus brucerà all'inferno per quel che ha "
+"fatto. Il ragazzo che descrivi non è il nostro principe, ma credo che Albrecht "
+"possa essere ancora in pericolo. Il simbolo di potere di cui parli dev'essere un "
+"portale per il cuore del labirinto.\n"
 " \n"
-"Sappi questo - amico mio - Il male che affronterai è l'Oscuro Signore del "
-"Terrore. Meglio conosciuto fra i mortali come Diablo. È lui che venne "
-"imprigionato nel labirinto molti secoli fa, e temo che cerchi di seminare di "
-"nuovo il caos fra l'umanità. Devi avventurarti attraverso il portale e "
-"sconfiggere Diablo prima che sia troppo tardi! |"
+"Sappi questo - amico mio - Il male che affronterai è l'Oscuro Signore del Terrore. "
+"Meglio conosciuto fra i mortali come Diablo. È lui che venne imprigionato nel "
+"labirinto molti secoli fa, e temo che cerchi di seminare di nuovo il caos fra "
+"l'umanità. Devi avventurarti attraverso il portale e sconfiggere Diablo prima che "
+"sia troppo tardi! |"
 
 #: Source/textdat.cpp:67
 msgid ""
-"Lazarus was the Archbishop who led many of the townspeople into the "
-"labyrinth. I lost many good friends that day, and Lazarus never returned. I "
-"suppose he was killed along with most of the others. If you would do me a "
-"favor, good master - please do not talk to Farnham about that day. |"
+"Lazarus was the Archbishop who led many of the townspeople into the labyrinth. I "
+"lost many good friends that day, and Lazarus never returned. I suppose he was "
+"killed along with most of the others. If you would do me a favor, good master - "
+"please do not talk to Farnham about that day. |"
 msgstr ""
-"Lazarus era l'Arcivescovo che guidò molti dei paesani nel labirinto. Persi "
-"molti buoni amici quel giorno, e Lazarus non tornò mai. Suppongo sia stato "
-"ucciso assieme alla maggior parte degli altri. Se puoi farmi un favore, "
-"signore - ti prego, non parlare a Farnham di quel giorno. |"
+"Lazarus era l'Arcivescovo che guidò molti dei paesani nel labirinto. Persi molti "
+"buoni amici quel giorno, e Lazarus non tornò mai. Suppongo sia stato ucciso "
+"assieme alla maggior parte degli altri. Se puoi farmi un favore, signore - ti "
+"prego, non parlare a Farnham di quel giorno. |"
 
 #: Source/textdat.cpp:71
 msgid ""
-"I was shocked when I heard of what the townspeople were planning to do that "
-"night. I thought that of all people, Lazarus would have had more sense than "
-"that. He was an Archbishop, and always seemed to care so much for the "
-"townsfolk of Tristram. So many were injured, I could not save them all... |"
+"I was shocked when I heard of what the townspeople were planning to do that night. "
+"I thought that of all people, Lazarus would have had more sense than that. He was "
+"an Archbishop, and always seemed to care so much for the townsfolk of Tristram. So "
+"many were injured, I could not save them all... |"
 msgstr ""
-"Fui scioccato quando seppi quello che i paesani stavano progettando di fare "
-"quella notte. Pensavo che fra tutti, Lazarus avesse più buonsenso. Era "
-"Arcivescovo e sembrava sempre preoccuparsi molto per la gente di Tristram. "
-"Molti furono feriti, e non potei salvarli tutti... |"
+"Fui scioccato quando seppi quello che i paesani stavano progettando di fare quella "
+"notte. Pensavo che fra tutti, Lazarus avesse più buonsenso. Era Arcivescovo e "
+"sembrava sempre preoccuparsi molto per la gente di Tristram. Molti furono feriti, "
+"e non potei salvarli tutti... |"
 
 #: Source/textdat.cpp:73
 msgid ""
-"I remember Lazarus as being a very kind and giving man. He spoke at my "
-"mother's funeral, and was supportive of my grandmother and myself in a very "
-"troubled time. I pray every night that somehow, he is still alive and safe. |"
+"I remember Lazarus as being a very kind and giving man. He spoke at my mother's "
+"funeral, and was supportive of my grandmother and myself in a very troubled time. "
+"I pray every night that somehow, he is still alive and safe. |"
 msgstr ""
-"Ricordo Lazarus come un uomo buono e gentile. Celebrò il funerale di mia "
-"madre, e aiutò mia nonna e me a superare quel bruttissimo momento. Prego "
-"ogni notte che in qualche modo, sia ancora vivo e al sicuro. |"
+"Ricordo Lazarus come un uomo buono e gentile. Celebrò il funerale di mia madre, e "
+"aiutò mia nonna e me a superare quel bruttissimo momento. Prego ogni notte che in "
+"qualche modo, sia ancora vivo e al sicuro. |"
 
 #: Source/textdat.cpp:75
 msgid ""
-"I was there when Lazarus led us into the labyrinth. He spoke of holy "
-"retribution, but when we started fighting those hellspawn, he did not so "
-"much as lift his mace against them. He just ran deeper into the dim, endless "
-"chambers that were filled with the servants of darkness! |"
+"I was there when Lazarus led us into the labyrinth. He spoke of holy retribution, "
+"but when we started fighting those hellspawn, he did not so much as lift his mace "
+"against them. He just ran deeper into the dim, endless chambers that were filled "
+"with the servants of darkness! |"
 msgstr ""
-"Ero là quando Lazarus ci guidò nel labirinto. Parlò di Punizione Divina, ma "
-"quando cominciammo a lottare contro quelle creature infernali, lui non alzò "
-"un dito su di loro. Prosegui' sempre più in profondità nelle buie, infinite "
-"stanze piene di servitori dell'oscurità! |"
+"Ero là quando Lazarus ci guidò nel labirinto. Parlò di Punizione Divina, ma quando "
+"cominciammo a lottare contro quelle creature infernali, lui non alzò un dito su di "
+"loro. Proseguì sempre più in profondità nelle buie, infinite stanze piene di "
+"servitori dell'oscurità! |"
 
 #: Source/textdat.cpp:77
 msgid ""
-"They stab, then bite, then they're all around you. Liar! LIAR! They're all "
-"dead! Dead! Do you hear me? They just keep falling and falling... their "
-"blood spilling out all over the floor... all his fault... |"
+"They stab, then bite, then they're all around you. Liar! LIAR! They're all dead! "
+"Dead! Do you hear me? They just keep falling and falling... their blood spilling "
+"out all over the floor... all his fault... |"
 msgstr ""
-"Pugnalano, poi mordono, poi ti sono tutti attorno. Bugiardo! BUGIARDO! Sono "
-"tutti morti! MORTI! Mi senti? Continuano a cadere e a cadere... il loro "
-"sangue si sparge sul pavimento... tutta colpa sua... |"
+"Pugnalano, poi mordono, poi ti sono tutti attorno. Bugiardo! BUGIARDO! Sono tutti "
+"morti! MORTI! Mi senti? Continuano a cadere e a cadere... il loro sangue si sparge "
+"sul pavimento... tutta colpa sua... |"
 
 #: Source/textdat.cpp:79
 msgid ""
-"I did not know this Lazarus of whom you speak, but I do sense a great "
-"conflict within his being. He poses a great danger, and will stop at nothing "
-"to serve the powers of darkness which have claimed him as theirs. |"
+"I did not know this Lazarus of whom you speak, but I do sense a great conflict "
+"within his being. He poses a great danger, and will stop at nothing to serve the "
+"powers of darkness which have claimed him as theirs. |"
 msgstr ""
-"Non conoscevo questo Lazarus di cui parli, ma sento un gran conflitto nel "
-"suo essere. Pone un grave pericolo, e non si fermerà davanti a nulla per "
-"servire i poteri dell'oscurità che l'hanno reclamato per loro. |"
+"Non conoscevo questo Lazarus di cui parli, ma sento un gran conflitto nel suo "
+"essere. Pone un grave pericolo, e non si fermerà davanti a nulla per servire i "
+"poteri dell'oscurità che l'hanno reclamato per loro. |"
 
 #: Source/textdat.cpp:81
 msgid ""
-"Yes, the righteous Lazarus, who was sooo effective against those monsters "
-"down there. Didn't help save my leg, did it? Look, I'll give you a free "
-"piece of advice. Ask Farnham, he was there. |"
+"Yes, the righteous Lazarus, who was sooo effective against those monsters down "
+"there. Didn't help save my leg, did it? Look, I'll give you a free piece of "
+"advice. Ask Farnham, he was there. |"
 msgstr ""
-"Si, l'onesto Lazarus, che fu di grande aiuto contro quei mostri. Come no! "
-"Come mai non mi aiutò a salvare la MIA gamba? Guarda, ti do un consiglio. "
-"Chiedi a Farnham, anche lui era li. |"
+"Si, l'onesto Lazarus, che fu di grande aiuto contro quei mostri. Come no! Come mai "
+"non mi aiutò a salvare la MIA gamba? Guarda, ti do un consiglio. Chiedi a Farnham, "
+"anche lui era li. |"
 
 #: Source/textdat.cpp:83
 msgid ""
-"Abandon your foolish quest. All that awaits you is the wrath of my Master! "
-"You are too late to save the child. Now you will join him in Hell! |"
+"Abandon your foolish quest. All that awaits you is the wrath of my Master! You are "
+"too late to save the child. Now you will join him in Hell! |"
 msgstr ""
-"Abbandona la tua folle cerca. Quello che t'aspetta è l'ira del mio padrone. "
-"È tardi per salvare il bambino. Unisciti a lui all'inferno! |"
+"Abbandona la tua folle cerca. Quello che t'aspetta è l'ira del mio padrone. È "
+"tardi per salvare il bambino. Unisciti a lui all'inferno! |"
 
 #: Source/textdat.cpp:86
 msgid ""
-"Hmm, I don't know what I can really tell you about this that will be of any "
-"help. The water that fills our wells comes from an underground spring. I "
-"have heard of a tunnel that leads to a great lake - perhaps they are one and "
-"the same. Unfortunately, I do not know what would cause our water supply to "
-"be tainted. |"
+"Hmm, I don't know what I can really tell you about this that will be of any help. "
+"The water that fills our wells comes from an underground spring. I have heard of a "
+"tunnel that leads to a great lake - perhaps they are one and the same. "
+"Unfortunately, I do not know what would cause our water supply to be tainted. |"
 msgstr ""
-"Hmm, non so se quello che sto per dirti ti potrà essere di aiuto. L'acqua "
-"che noi usiamo proviene da una sorgente sotterranea. Ho sentito parlare di "
-"un tunnel che conduce ad un grande lago - forse è quella la sorgente. "
-"Sfortunatamente, non so che cosa abbia causato l'avvelenamento dell'acqua. |"
+"Hmm, non so se quello che sto per dirti ti potrà essere di aiuto. L'acqua che noi "
+"usiamo proviene da una sorgente sotterranea. Ho sentito parlare di un tunnel che "
+"conduce ad un grande lago - forse è quella la sorgente. Sfortunatamente, non so "
+"che cosa abbia causato l'avvelenamento dell'acqua. |"
 
 #: Source/textdat.cpp:88
 msgid ""
-"I have always tried to keep a large supply of foodstuffs and drink in our "
-"storage cellar, but with the entire town having no source of fresh water, "
-"even our stores will soon run dry. \n"
+"I have always tried to keep a large supply of foodstuffs and drink in our storage "
+"cellar, but with the entire town having no source of fresh water, even our stores "
+"will soon run dry. \n"
 " \n"
 "Please, do what you can or I don't know what we will do. |"
 msgstr ""
-"Ho sempre cercato di avere delle provviste di cibo e bevande in magazzino, "
-"ma con l'intera città senza una fonte d'acqua fresca, presto le mie scorte "
-"finiranno. \n"
+"Ho sempre cercato di avere delle provviste di cibo e bevande in magazzino, ma con "
+"l'intera città senza una fonte d'acqua fresca, presto le mie scorte finiranno. \n"
 " \n"
 "Ti prego, aiutaci come puoi, o non sapremo più che fare. |"
 
 #: Source/textdat.cpp:90
 msgid ""
-"I'm glad I caught up to you in time! Our wells have become brackish and "
-"stagnant and some of the townspeople have become ill drinking from them. Our "
-"reserves of fresh water are quickly running dry. I believe that there is a "
-"passage that leads to the springs that serve our town. Please find what has "
-"caused this calamity, or we all will surely perish. |"
+"I'm glad I caught up to you in time! Our wells have become brackish and stagnant "
+"and some of the townspeople have become ill drinking from them. Our reserves of "
+"fresh water are quickly running dry. I believe that there is a passage that leads "
+"to the springs that serve our town. Please find what has caused this calamity, or "
+"we all will surely perish. |"
 msgstr ""
-"Sono fortunato ad averti trovato in tempo! La nostra acqua è diventata "
-"torbida e stagnante e alcuni paesani bevendola si sono ammalati. Le riserve "
-"di acqua fresca si stanno esaurendo in fretta. Credo ci sia un passaggio che "
-"porta alla fonte che serve il villaggio. Ti prego, scopri chi ha causato "
-"questo disastro, o per noi sarà di certo la fine. |"
+"Sono fortunato ad averti trovato in tempo! La nostra acqua è diventata torbida e "
+"stagnante e alcuni paesani bevendola si sono ammalati. Le riserve di acqua fresca "
+"si stanno esaurendo in fretta. Credo ci sia un passaggio che porta alla fonte che "
+"serve il villaggio. Ti prego, scopri chi ha causato questo disastro, o per noi "
+"sarà di certo la fine. |"
 
 #: Source/textdat.cpp:92
 msgid ""
-"Please, you must hurry. Every hour that passes brings us closer to having no "
-"water to drink. \n"
+"Please, you must hurry. Every hour that passes brings us closer to having no water "
+"to drink. \n"
 " \n"
 "We cannot survive for long without your help. |"
 msgstr ""
-"Ti prego, sbrigati. Man mano che passano le ore anche l'acqua da bere inizia "
-"a diminuire.\n"
+"Ti prego, sbrigati. Man mano che passano le ore anche l'acqua da bere inizia a "
+"diminuire.\n"
 "\n"
 "Senza il tuo aiuto non sopravviveremo a lungo. |"
 
 #: Source/textdat.cpp:94
 msgid ""
-"What's that you say - the mere presence of the demons had caused the water "
-"to become tainted? Oh, truly a great evil lurks beneath our town, but your "
-"perseverance and courage gives us hope. Please take this ring - perhaps it "
-"will aid you in the destruction of such vile creatures. |"
+"What's that you say - the mere presence of the demons had caused the water to "
+"become tainted? Oh, truly a great evil lurks beneath our town, but your "
+"perseverance and courage gives us hope. Please take this ring - perhaps it will "
+"aid you in the destruction of such vile creatures. |"
 msgstr ""
 "Cosa stai dicendo - la mera presenza dei demoni ha contaminato l'acqua? Oh, "
-"davvero un grande male deve giacere sotto la città, ma il tuo coraggio e la "
-"tua perseveranza ci fanno sperare, ti prego, accetta questo anello - forse "
-"ti aiuterà a eliminare quelle vili creature. |"
+"davvero un grande male deve giacere sotto la città, ma il tuo coraggio e la tua "
+"perseveranza ci fanno sperare, ti prego, accetta questo anello - forse ti aiuterà "
+"a eliminare quelle vili creature. |"
 
 #: Source/textdat.cpp:96
 msgid ""
-"My grandmother is very weak, and Garda says that we cannot drink the water "
-"from the wells. Please, can you do something to help us? |"
+"My grandmother is very weak, and Garda says that we cannot drink the water from "
+"the wells. Please, can you do something to help us? |"
 msgstr ""
-"Mia nonna è molto debole, e Garda dice che non possiamo bere l'acqua delle "
-"fonti. Per favore, puoi fare qualcosa per aiutarci? |"
+"Mia nonna è molto debole, e Garda dice che non possiamo bere l'acqua delle fonti. "
+"Per favore, puoi fare qualcosa per aiutarci? |"
 
 #: Source/textdat.cpp:98
 msgid ""
-"Pepin has told you the truth. We will need fresh water badly, and soon. I "
-"have tried to clear one of the smaller wells, but it reeks of stagnant "
-"filth. It must be getting clogged at the source. |"
+"Pepin has told you the truth. We will need fresh water badly, and soon. I have "
+"tried to clear one of the smaller wells, but it reeks of stagnant filth. It must "
+"be getting clogged at the source. |"
 msgstr ""
 "Pepin ti ha detto la verità. Abbiamo davvero bisogno di acqua, e subito. Ho "
-"tentato di rendere potabile quella di una piccola fonte, ma era troppo "
-"putrida. Deve essere inquinata alla fonte. |"
+"tentato di rendere potabile quella di una piccola fonte, ma era troppo putrida. "
+"Deve essere inquinata alla fonte. |"
 
 #: Source/textdat.cpp:100
 msgid "You drink water? |"
@@ -7052,273 +6990,264 @@ msgid ""
 "The people of Tristram will die if you cannot restore fresh water to their "
 "wells. \n"
 " \n"
-"Know this - demons are at the heart of this matter, but they remain ignorant "
-"of what they have spawned. |"
+"Know this - demons are at the heart of this matter, but they remain ignorant of "
+"what they have spawned. |"
 msgstr ""
 "Se non fai tornare pura l'acqua della fonte, la gente di Tristram morirà. \n"
 " \n"
-"Sappi solo che i demoni sono gli artefici di quello che sta accadendo, anche "
-"se loro ignorano di averlo fatto. |"
+"Sappi solo che i demoni sono gli artefici di quello che sta accadendo, anche se "
+"loro ignorano di averlo fatto. |"
 
 #: Source/textdat.cpp:103
 msgid ""
-"For once, I'm with you. My business runs dry - so to speak - if I have no "
-"market to sell to. You better find out what is going on, and soon! |"
+"For once, I'm with you. My business runs dry - so to speak - if I have no market "
+"to sell to. You better find out what is going on, and soon! |"
 msgstr ""
-"Per stavolta, sono con te. I miei affari vanno male, ti dirò, se non ho "
-"nessun mercato a cui vendere. Scopri in fretta che sta succedendo! |"
+"Per stavolta, sono con te. I miei affari vanno male, ti dirò, se non ho nessun "
+"mercato a cui vendere. Scopri in fretta che sta succedendo! |"
 
 #: Source/textdat.cpp:105
 msgid ""
 "A book that speaks of a chamber of human bones? Well, a Chamber of Bone is "
-"mentioned in certain archaic writings that I studied in the libraries of the "
-"East. These tomes inferred that when the Lords of the underworld desired to "
-"protect great treasures, they would create domains where those who died in "
-"the attempt to steal that treasure would be forever bound to defend it. A "
-"twisted, but strangely fitting, end? |"
+"mentioned in certain archaic writings that I studied in the libraries of the East. "
+"These tomes inferred that when the Lords of the underworld desired to protect "
+"great treasures, they would create domains where those who died in the attempt to "
+"steal that treasure would be forever bound to defend it. A twisted, but strangely "
+"fitting, end? |"
 msgstr ""
-"Un libro che narra di una camera di ossa umane? Beh, una Camera d'Ossa è "
-"narrata in alcune scritture arcaiche da me studiate nelle biblioteche "
-"dell'Est. Questi tomi raccontano che quando i Signori dell'Aldilà desiderano "
-"proteggere i loro tesori, creano luoghi dove chi muore nel tentativo di "
-"saccheggiarli viene condannato a proteggerli per sempre. Una fine contorta, "
-"ma meritata, no? |"
+"Un libro che narra di una camera di ossa umane? Beh, una Camera d'Ossa è narrata "
+"in alcune scritture arcaiche da me studiate nelle biblioteche dell'Est. Questi "
+"tomi raccontano che quando i Signori dell'Aldilà desiderano proteggere i loro "
+"tesori, creano luoghi dove chi muore nel tentativo di saccheggiarli viene "
+"condannato a proteggerli per sempre. Una fine contorta, ma meritata, no? |"
 
 #: Source/textdat.cpp:107
 msgid ""
-"I am afraid that I don't know anything about that, good master. Cain has "
-"many books that may be of some help. |"
+"I am afraid that I don't know anything about that, good master. Cain has many "
+"books that may be of some help. |"
 msgstr ""
 "Temo di non sapere niente su questo, signore. Cain però ha molti libri che "
 "potrebbero esserti d'aiuto. |"
 
 #: Source/textdat.cpp:109
 msgid ""
-"This sounds like a very dangerous place. If you venture there, please take "
-"great care. |"
+"This sounds like a very dangerous place. If you venture there, please take great "
+"care. |"
 msgstr ""
 "Sembra un posto molto pericoloso. Ti prego, se decidi di andarci, fai molta "
 "attenzione.|"
 
 #: Source/textdat.cpp:111
 msgid ""
-"I am afraid that I haven't heard anything about that. Perhaps Cain the "
-"Storyteller could be of some help. |"
+"I am afraid that I haven't heard anything about that. Perhaps Cain the Storyteller "
+"could be of some help. |"
 msgstr ""
 "Ho paura di non aver mai sentito nulla a riguardo. Forse Cain il Narratore "
 "potrebbe esserti d'aiuto... |"
 
 #: Source/textdat.cpp:113
 msgid ""
-"I know nothing of this place, but you may try asking Cain. He talks about "
-"many things, and it would not surprise me if he had some answers to your "
-"question. |"
+"I know nothing of this place, but you may try asking Cain. He talks about many "
+"things, and it would not surprise me if he had some answers to your question. |"
 msgstr ""
-"Non so nulla di quel posto, ma puoi provare a chiederlo a Cain. Lui sa molte "
-"cose, e non mi sorprenderebbe se avesse delle risposte alla tua domanda. |"
+"Non so nulla di quel posto, ma puoi provare a chiederlo a Cain. Lui sa molte cose, "
+"e non mi sorprenderebbe se avesse delle risposte alla tua domanda. |"
 
 #: Source/textdat.cpp:115
 msgid ""
-"Okay, so listen. There's this chamber of wood, see. And his wife, you know - "
-"her - tells the tree... cause you gotta wait. Then I says, that might work "
-"against him, but if you think I'm gonna PAY for this... you... uh... yeah. |"
+"Okay, so listen. There's this chamber of wood, see. And his wife, you know - her - "
+"tells the tree... cause you gotta wait. Then I says, that might work against him, "
+"but if you think I'm gonna PAY for this... you... uh... yeah. |"
 msgstr ""
-"Ok, senti. C'è questa gabbia di legno, vedi. E sua moglie... mi ha detto "
-"l'albero che tu lo sai... perché devi aspettare. Poi io dico, è facile che "
-"funzioni su di lui, ma se pensi che io paghi per questo... uh... già. |"
+"Ok, senti. C'è questa gabbia di legno, vedi. E sua moglie... mi ha detto l'albero "
+"che tu lo sai... perché devi aspettare. Poi io dico, è facile che funzioni su di "
+"lui, ma se pensi che io paghi per questo... uh... già. |"
 
 #: Source/textdat.cpp:117
 msgid ""
-"You will become an eternal servant of the dark lords should you perish "
-"within this cursed domain. \n"
+"You will become an eternal servant of the dark lords should you perish within this "
+"cursed domain. \n"
 " \n"
 "Enter the Chamber of Bone at your own peril. |"
 msgstr ""
-"Diventerai eterno schiavo dei Signori Oscuri se morirai all'interno di "
-"questo luogo maledetto.\n"
+"Diventerai eterno schiavo dei Signori Oscuri se morirai all'interno di questo "
+"luogo maledetto.\n"
 "\n"
 "Entra nella Camera d'Ossa a tuo rischio e pericolo. |"
 
 #: Source/textdat.cpp:119
 msgid ""
-"A vast and mysterious treasure, you say? Maybe I could be interested in "
-"picking up a few things from you... or better yet, don't you need some rare "
-"and expensive supplies to get you through this ordeal? |"
+"A vast and mysterious treasure, you say? Maybe I could be interested in picking up "
+"a few things from you... or better yet, don't you need some rare and expensive "
+"supplies to get you through this ordeal? |"
 msgstr ""
-"Come dici? Un grande e misterioso tesoro? Potrei essere interessato "
-"all'acquisto di alcune cose da te... o ancora meglio, non sei interessato ad "
-"alcuni rari e costosi oggetti per aiutarti nell'impresa? |"
+"Come dici? Un grande e misterioso tesoro? Potrei essere interessato all'acquisto "
+"di alcune cose da te... o ancora meglio, non sei interessato ad alcuni rari e "
+"costosi oggetti per aiutarti nell'impresa? |"
 
 #: Source/textdat.cpp:121
 msgid ""
-"It seems that the Archbishop Lazarus goaded many of the townsmen into "
-"venturing into the Labyrinth to find the King's missing son. He played upon "
-"their fears and whipped them into a frenzied mob. None of them were prepared "
-"for what lay within the cold earth... Lazarus abandoned them down there - "
-"left in the clutches of unspeakable horrors - to die. |"
+"It seems that the Archbishop Lazarus goaded many of the townsmen into venturing "
+"into the Labyrinth to find the King's missing son. He played upon their fears and "
+"whipped them into a frenzied mob. None of them were prepared for what lay within "
+"the cold earth... Lazarus abandoned them down there - left in the clutches of "
+"unspeakable horrors - to die. |"
 msgstr ""
 "Sembra che l'Arcivescovo Lazarus spinse molti paesani ad avventurarsi nel "
-"labirinto per ritrovare il figlio scomparso del re. Sfruttò le loro paure "
-"per trasformarli in una folla scatenata. Nessuno di loro era preparato per "
-"quello che giaceva sottoterra. Lazarus li abbandonò - fra le grinfie di "
-"orrori inenarrabili - a morire laggiù.  |"
+"labirinto per ritrovare il figlio scomparso del re. Sfruttò le loro paure per "
+"trasformarli in una folla scatenata. Nessuno di loro era preparato per quello che "
+"giaceva sottoterra. Lazarus li abbandonò - fra le grinfie di orrori inenarrabili - "
+"a morire laggiù.  |"
 
 #: Source/textdat.cpp:123
 msgid ""
-"Yes, Farnham has mumbled something about a hulking brute who wielded a "
-"fierce weapon. I believe he called him a butcher. |"
+"Yes, Farnham has mumbled something about a hulking brute who wielded a fierce "
+"weapon. I believe he called him a butcher. |"
 msgstr ""
-"Si, Farnham disse qualcosa a proposito di un goffo mostro che brandiva una "
-"grossa arma. Mi pare lo chiamasse il macellaio|"
+"Si, Farnham disse qualcosa a proposito di un goffo mostro che brandiva una grossa "
+"arma. Mi pare lo chiamasse il macellaio|"
 
 #: Source/textdat.cpp:125
 msgid ""
-"By the Light, I know of this vile demon. There were many that bore the scars "
-"of his wrath upon their bodies when the few survivors of the charge led by "
-"Lazarus crawled from the Cathedral. I don't know what he used to slice open "
-"his victims, but it could not have been of this world. It left wounds "
-"festering with disease and even I found them almost impossible to treat. "
-"Beware if you plan to battle this fiend... |"
+"By the Light, I know of this vile demon. There were many that bore the scars of "
+"his wrath upon their bodies when the few survivors of the charge led by Lazarus "
+"crawled from the Cathedral. I don't know what he used to slice open his victims, "
+"but it could not have been of this world. It left wounds festering with disease "
+"and even I found them almost impossible to treat. Beware if you plan to battle "
+"this fiend... |"
 msgstr ""
-"Per Dio, io so di questo vile demone! Molti erano terrorizzati dalle ferite "
-"che egli fece sui loro corpi, quando i pochi sopravvissuti dell'assalto "
-"guidato da Lazarus fuggirono dalla cattedrale. Non so cosa esso usi per "
-"squartare le sue vittime, ma sicuramente non è un'arma di questo mondo. "
-"Lascia ferite infettate di malattie impossibili da curare. Attento se pensi "
-"di combattere contro questo nemico... |"
+"Per Dio, io so di questo vile demone! Molti erano terrorizzati dalle ferite che "
+"egli fece sui loro corpi, quando i pochi sopravvissuti dell'assalto guidato da "
+"Lazarus fuggirono dalla cattedrale. Non so cosa esso usi per squartare le sue "
+"vittime, ma sicuramente non è un'arma di questo mondo. Lascia ferite infettate di "
+"malattie impossibili da curare. Attento se pensi di combattere contro questo "
+"nemico... |"
 
 #: Source/textdat.cpp:127
 msgid ""
 "When Farnham said something about a butcher killing people, I immediately "
 "discounted it. But since you brought it up, maybe it is true. |"
 msgstr ""
-"Quando Farnham raccontò di un macellaio assassino, non gli diedi peso. Ma "
-"visto che anche tu ne parli, forse diceva la verità. |"
+"Quando Farnham raccontò di un macellaio assassino, non gli diedi peso. Ma visto "
+"che anche tu ne parli, forse diceva la verità. |"
 
 #: Source/textdat.cpp:129
 msgid ""
-"I saw what Farnham calls the Butcher as it swathed a path through the bodies "
-"of my friends. He swung a cleaver as large as an axe, hewing limbs and "
-"cutting down brave men where they stood. I was separated from the fray by a "
-"host of small screeching demons and somehow found the stairway leading out. "
-"I never saw that hideous beast again, but his blood-stained visage haunts me "
-"to this day. |"
+"I saw what Farnham calls the Butcher as it swathed a path through the bodies of my "
+"friends. He swung a cleaver as large as an axe, hewing limbs and cutting down "
+"brave men where they stood. I was separated from the fray by a host of small "
+"screeching demons and somehow found the stairway leading out. I never saw that "
+"hideous beast again, but his blood-stained visage haunts me to this day. |"
 msgstr ""
-"Ho visto quello che Farnham chiama il Macellaio mentre si scavava un "
-"passaggio fra i miei amici. Impugnava una Mannaia Grossa come un'Ascia "
-"squartando le persone in un attimo. Fui separato dal combattimento da una "
-"folla di piccoli demoni urlanti e in qualche modo trovai le scale che "
-"conducevano all'esterno. Da allora non l'ho più visto, ma non scorderò mai "
-"quel Viso sporco di Sangue. |"
+"Ho visto quello che Farnham chiama il Macellaio mentre si scavava un passaggio fra "
+"i miei amici. Impugnava una Mannaia Grossa come un'Ascia squartando le persone in "
+"un attimo. Fui separato dal combattimento da una folla di piccoli demoni urlanti e "
+"in qualche modo trovai le scale che conducevano all'esterno. Da allora non l'ho "
+"più visto, ma non scorderò mai quel Viso sporco di Sangue. |"
 
 #: Source/textdat.cpp:131
 msgid ""
 "Big! Big cleaver killing all my friends. Couldn't stop him, had to run away, "
-"couldn't save them. Trapped in a room with so many bodies... so many "
-"friends... NOOOOOOOOOO! |"
+"couldn't save them. Trapped in a room with so many bodies... so many friends... "
+"NOOOOOOOOOO! |"
 msgstr ""
-"Grande! Grande mannaia uccide i miei amici. Non posso fermarla, devo "
-"fuggire, non posso salvarli. Intrappolato in una stanza piena di cadaveri "
-"Piena di amici NOOOOOO! |"
+"Grande! Grande mannaia uccide i miei amici. Non posso fermarla, devo fuggire, non "
+"posso salvarli. Intrappolato in una stanza piena di cadaveri Piena di amici "
+"NOOOOOO! |"
 
 #: Source/textdat.cpp:133
 msgid ""
 "The Butcher is a sadistic creature that delights in the torture and pain of "
-"others. You have seen his handiwork in the drunkard Farnham. His destruction "
-"will do much to ensure the safety of this village. |"
+"others. You have seen his handiwork in the drunkard Farnham. His destruction will "
+"do much to ensure the safety of this village. |"
 msgstr ""
-"Il Macellaio è una creatura sadica che si diverte a torturare e a far "
-"soffrire gli altri. Hai visto cosa ha fatto a Farnham l'ubriacone. Ucciderlo "
-"garantirebbe di certo la sicurezza del villaggio. |"
+"Il Macellaio è una creatura sadica che si diverte a torturare e a far soffrire gli "
+"altri. Hai visto cosa ha fatto a Farnham l'ubriacone. Ucciderlo garantirebbe di "
+"certo la sicurezza del villaggio. |"
 
 #: Source/textdat.cpp:135
 msgid ""
-"I know more than you'd think about that grisly fiend. His little friends got "
-"a hold of me and managed to get my leg before Griswold pulled me out of that "
-"hole. \n"
+"I know more than you'd think about that grisly fiend. His little friends got a "
+"hold of me and managed to get my leg before Griswold pulled me out of that hole. \n"
 " \n"
-"I'll put it bluntly - kill him before he kills you and adds your corpse to "
-"his collection. |"
+"I'll put it bluntly - kill him before he kills you and adds your corpse to his "
+"collection. |"
 msgstr ""
-"So più di quel che pensi su quel mostro. I suoi piccoli amici mi catturarono "
-"e riuscirono a prendermi la gamba prima che Griswold mi tirasse fuori da "
-"quel buco. \n"
+"So più di quel che pensi su quel mostro. I suoi piccoli amici mi catturarono e "
+"riuscirono a prendermi la gamba prima che Griswold mi tirasse fuori da quel "
+"buco. \n"
 " \n"
-"Te la metto giù dura - uccidilo prima che lo faccia lui e ti aggiunga alla "
-"sua collezione. |"
+"Te la metto giù dura - uccidilo prima che lo faccia lui e ti aggiunga alla sua "
+"collezione. |"
 
 #: Source/textdat.cpp:137
 msgid ""
-"Please, listen to me. The Archbishop Lazarus, he led us down here to find "
-"the lost prince. The bastard led us into a trap! Now everyone is dead... "
-"killed by a demon he called the Butcher. Avenge us! Find this Butcher and "
-"slay him so that our souls may finally rest... |"
+"Please, listen to me. The Archbishop Lazarus, he led us down here to find the lost "
+"prince. The bastard led us into a trap! Now everyone is dead... killed by a demon "
+"he called the Butcher. Avenge us! Find this Butcher and slay him so that our souls "
+"may finally rest... |"
 msgstr ""
-"Ti prego, ascoltami. L'Arcivescovo Lazarus ci condusse laggiù per ritrovare "
-"il principe. Il bastardo ci guidò in trappola! Ora sono tutti morti. Uccisi "
-"da un demone chiamato Macellaio. Vendicaci! Trova il demone e fermalo cosi' "
-"che le nostre anime possano riposare... |"
+"Ti prego, ascoltami. L'Arcivescovo Lazarus ci condusse laggiù per ritrovare il "
+"principe. Il bastardo ci guidò in trappola! Ora sono tutti morti. Uccisi da un "
+"demone chiamato Macellaio. Vendicaci! Trova il demone e fermalo così che le nostre "
+"anime possano riposare... |"
 
 #: Source/textdat.cpp:140
 msgid ""
-"You recite an interesting rhyme written in a style that reminds me of other "
-"works. Let me think now - what was it?\n"
+"You recite an interesting rhyme written in a style that reminds me of other works. "
+"Let me think now - what was it?\n"
 " \n"
-"...Darkness shrouds the Hidden. Eyes glowing unseen with only the sounds of "
-"razor claws briefly scraping to torment those poor souls who have been made "
-"sightless for all eternity. The prison for those so damned is named the "
-"Halls of the Blind... |"
+"...Darkness shrouds the Hidden. Eyes glowing unseen with only the sounds of razor "
+"claws briefly scraping to torment those poor souls who have been made sightless "
+"for all eternity. The prison for those so damned is named the Halls of the "
+"Blind... |"
 msgstr ""
-"Reciti dei versi interessanti scritti in uno stile che mi ricorda di altre "
-"opere. Fammi pensare - come faceva?\n"
+"Reciti dei versi interessanti scritti in uno stile che mi ricorda di altre opere. "
+"Fammi pensare - come faceva?\n"
 " \n"
-"... L'Oscurità copre l'ignoto. Occhi invisibili brillano, mentre il rumore "
-"di artigli affilati tormenta quelle povere anime rese cieche per l'eternità. "
-"La prigione per quelle anime dannate è detta la Sala degli Accecati... |"
+"... L'Oscurità copre l'ignoto. Occhi invisibili brillano, mentre il rumore di "
+"artigli affilati tormenta quelle povere anime rese cieche per l'eternità. La "
+"prigione per quelle anime dannate è detta la Sala degli Accecati... |"
 
 #: Source/textdat.cpp:142
 msgid ""
-"I never much cared for poetry. Occasionally, I had cause to hire minstrels "
-"when the inn was doing well, but that seems like such a long time ago now. \n"
+"I never much cared for poetry. Occasionally, I had cause to hire minstrels when "
+"the inn was doing well, but that seems like such a long time ago now. \n"
 " \n"
 "What? Oh, yes... uh, well, I suppose you could see what someone else knows. |"
 msgstr ""
-"La poesia non mi ha mai interessato molto. Qualche volta ho pagato un "
-"menestrello per ravvivare la locanda quando gli affari andavano bene ma è "
-"stato tempo fa. \n"
+"La poesia non mi ha mai interessato molto. Qualche volta ho pagato un menestrello "
+"per ravvivare la locanda quando gli affari andavano bene ma è stato tempo fa. \n"
 " \n"
 "Cosa? Oh, si... Penso tu debba vedere se gli altri sanno qualcosa. |"
 
 #: Source/textdat.cpp:144
 msgid ""
-"This does seem familiar, somehow. I seem to recall reading something very "
-"much like that poem while researching the history of demonic afflictions. It "
-"spoke of a place of great evil that... wait - you're not going there are "
-"you? |"
+"This does seem familiar, somehow. I seem to recall reading something very much "
+"like that poem while researching the history of demonic afflictions. It spoke of a "
+"place of great evil that... wait - you're not going there are you? |"
 msgstr ""
-"Quel che dici sembra familiare. Mi pare di aver trovato qualcosa di simile a "
-"quel poema mentre ricercavo la storia delle malattie demoniache. Parlava di "
-"un luogo dalla grande malvagità... aspetta - non vorrai andare la? |"
+"Quel che dici sembra familiare. Mi pare di aver trovato qualcosa di simile a quel "
+"poema mentre ricercavo la storia delle malattie demoniache. Parlava di un luogo "
+"dalla grande malvagità... aspetta - non vorrai andare là? |"
 
 #: Source/textdat.cpp:146
 msgid ""
-"If you have questions about blindness, you should talk to Pepin. I know that "
-"he gave my grandmother a potion that helped clear her vision, so maybe he "
-"can help you, too. |"
+"If you have questions about blindness, you should talk to Pepin. I know that he "
+"gave my grandmother a potion that helped clear her vision, so maybe he can help "
+"you, too. |"
 msgstr ""
-"Se hai domande sulla cecità, dovresti parlare a Pepin. So che diede a mia "
-"nonna una pozione che l'aiutò a schiarirsi la vista, forse potrebbe essere "
-"d'aiuto anche a te.|"
+"Se hai domande sulla cecità, dovresti parlare a Pepin. So che diede a mia nonna "
+"una pozione che l'aiutò a schiarirsi la vista, forse potrebbe essere d'aiuto anche "
+"a te.|"
 
 #: Source/textdat.cpp:148
 msgid ""
-"I am afraid that I have neither heard nor seen a place that matches your "
-"vivid description, my friend. Perhaps Cain the Storyteller could be of some "
-"help. |"
+"I am afraid that I have neither heard nor seen a place that matches your vivid "
+"description, my friend. Perhaps Cain the Storyteller could be of some help. |"
 msgstr ""
-"Temo di non aver mai visto o sentito parlare di un luogo che corrisponda "
-"alla tua descrizione, amico mio. Forse Cain il Narratore potrebbe darti un "
-"aiuto. |"
+"Temo di non aver mai visto o sentito parlare di un luogo che corrisponda alla tua "
+"descrizione, amico mio. Forse Cain il Narratore potrebbe darti un aiuto. |"
 
 #: Source/textdat.cpp:150
 msgid "Look here... that's pretty funny, huh? Get it? Blind - look here? |"
@@ -7326,8 +7255,7 @@ msgstr "Guarda qua... Buffo, huh? Capito? Cieco - vedi? |"
 
 #: Source/textdat.cpp:152
 msgid ""
-"This is a place of great anguish and terror, and so serves its master "
-"well. \n"
+"This is a place of great anguish and terror, and so serves its master well. \n"
 " \n"
 "Tread carefully or you may yourself be staying much longer than you had "
 "anticipated. |"
@@ -7339,234 +7267,225 @@ msgstr ""
 
 #: Source/textdat.cpp:154
 msgid ""
-"Lets see, am I selling you something? No. Are you giving me money to tell "
-"you about this? No. Are you now leaving and going to talk to the storyteller "
-"who lives for this kind of thing? Yes. |"
+"Lets see, am I selling you something? No. Are you giving me money to tell you "
+"about this? No. Are you now leaving and going to talk to the storyteller who lives "
+"for this kind of thing? Yes. |"
 msgstr ""
-"Vediamo, ti sto vendendo qualcosa? No! Mi dai del denaro per parlarti di "
-"questo? No! Te ne stai andando a parlare col Narratore che vive per questo "
-"genere di cose? Si. |"
+"Vediamo, ti sto vendendo qualcosa? No! Mi dai del denaro per parlarti di questo? "
+"No! Te ne stai andando a parlare col Narratore che vive per questo genere di cose? "
+"Si. |"
 
 #: Source/textdat.cpp:156
 msgid ""
-"You claim to have spoken with Lachdanan? He was a great hero during his "
-"life. Lachdanan was an honorable and just man who served his King faithfully "
-"for years. But of course, you already know that.\n"
+"You claim to have spoken with Lachdanan? He was a great hero during his life. "
+"Lachdanan was an honorable and just man who served his King faithfully for years. "
+"But of course, you already know that.\n"
 " \n"
-"Of those who were caught within the grasp of the King's Curse, Lachdanan "
-"would be the least likely to submit to the darkness without a fight, so I "
-"suppose that your story could be true. If I were in your place, my friend, I "
-"would find a way to release him from his torture. |"
+"Of those who were caught within the grasp of the King's Curse, Lachdanan would be "
+"the least likely to submit to the darkness without a fight, so I suppose that your "
+"story could be true. If I were in your place, my friend, I would find a way to "
+"release him from his torture. |"
 msgstr ""
 "Dici di aver parlato con Lachdanan? Fu un grande eroe quando era in vita. "
-"Lachdanan era un uomo giusto e onorevole che servi' fedelmente il suo Re per "
-"anni. Ma poi come già saprai.\n"
+"Lachdanan era un uomo giusto e onorevole che servì fedelmente il suo Re per anni. "
+"Ma poi come già saprai.\n"
 " \n"
-"Fra tutti quelli colpiti dalla Maledizione del Re, Lachdanan difficilmente "
-"si sarebbe arreso senza combattere quindi posso credere alla tua storia. Se "
-"fossi in te, amico mio. Cercherei un modo per liberarlo dal suo tormento. |"
+"Fra tutti quelli colpiti dalla Maledizione del Re, Lachdanan difficilmente si "
+"sarebbe arreso senza combattere quindi posso credere alla tua storia. Se fossi in "
+"te, amico mio. Cercherei un modo per liberarlo dal suo tormento. |"
 
 #: Source/textdat.cpp:158
 msgid ""
-"You speak of a brave warrior long dead! I'll have no such talk of speaking "
-"with departed souls in my inn yard, thank you very much. |"
+"You speak of a brave warrior long dead! I'll have no such talk of speaking with "
+"departed souls in my inn yard, thank you very much. |"
 msgstr ""
-"Stai parlando di un guerriero morto da tempo! Non ho nessuna intenzione di "
-"parlare di questo nel cortile della mia locanda, Grazie. |"
+"Stai parlando di un guerriero morto da tempo! Non ho nessuna intenzione di parlare "
+"di questo nel cortile della mia locanda, Grazie. |"
 
 #: Source/textdat.cpp:160
 msgid ""
-"A golden elixir, you say. I have never concocted a potion of that color "
-"before, so I can't tell you how it would effect you if you were to try to "
-"drink it. As your healer, I strongly advise that should you find such an "
-"elixir, do as Lachdanan asks and DO NOT try to use it. |"
+"A golden elixir, you say. I have never concocted a potion of that color before, so "
+"I can't tell you how it would effect you if you were to try to drink it. As your "
+"healer, I strongly advise that should you find such an elixir, do as Lachdanan "
+"asks and DO NOT try to use it. |"
 msgstr ""
-"Un elisir dorato, dici. Non ho mai preparato una pozione di quel colore, "
-"quindi non posso dirti che effetto avrebbe se tu decidessi di berlo. Come "
-"tuo guaritore, ti metto in guardia nel caso dovessi trovarlo, fai quel che "
-"ti ha chiesto Lachdanan, ma non tentare di usarlo. |"
+"Un elisir dorato, dici. Non ho mai preparato una pozione di quel colore, quindi "
+"non posso dirti che effetto avrebbe se tu decidessi di berlo. Come tuo guaritore, "
+"ti metto in guardia nel caso dovessi trovarlo, fai quel che ti ha chiesto "
+"Lachdanan, ma non tentare di usarlo. |"
 
 #: Source/textdat.cpp:162
 msgid ""
-"I've never heard of a Lachdanan before. I'm sorry, but I don't think that I "
-"can be of much help to you. |"
+"I've never heard of a Lachdanan before. I'm sorry, but I don't think that I can be "
+"of much help to you. |"
 msgstr ""
-"Non ho mai sentito parlare prima di questo Lachdanan. Sono spiacente, ma non "
-"posso esserti di aiuto. |"
+"Non ho mai sentito parlare prima di questo Lachdanan. Sono spiacente, ma non posso "
+"esserti di aiuto. |"
 
 #: Source/textdat.cpp:164
 msgid ""
-"If it is actually Lachdanan that you have met, then I would advise that you "
-"aid him. I dealt with him on several occasions and found him to be honest "
-"and loyal in nature. The curse that fell upon the followers of King Leoric "
-"would fall especially hard upon him. |"
+"If it is actually Lachdanan that you have met, then I would advise that you aid "
+"him. I dealt with him on several occasions and found him to be honest and loyal in "
+"nature. The curse that fell upon the followers of King Leoric would fall "
+"especially hard upon him. |"
 msgstr ""
-"Se era davvero Lachdanan la persona da te incontrata, allora ti raccomando "
-"di aiutarlo. Ho avuto spesso a che fare con lui, e l'ho trovato onesto e "
-"fedele per natura. La Maledizione calata sui seguaci di Re Leoric, "
-"dev'essere stata particolarmente dura per lui. |"
+"Se era davvero Lachdanan la persona da te incontrata, allora ti raccomando di "
+"aiutarlo. Ho avuto spesso a che fare con lui, e l'ho trovato onesto e fedele per "
+"natura. La Maledizione calata sui seguaci di Re Leoric, dev'essere stata "
+"particolarmente dura per lui. |"
 
 #: Source/textdat.cpp:166
 msgid ""
-" Lachdanan is dead. Everybody knows that, and you can't fool me into "
-"thinking any other way. You can't talk to the dead. I know! |"
+" Lachdanan is dead. Everybody knows that, and you can't fool me into thinking any "
+"other way. You can't talk to the dead. I know! |"
 msgstr ""
-" Lachdanan è morto. Tutti lo sanno, non puoi trovare alcun modo per farmi "
-"cambiare idea. Non puoi parlare a un morto. Lo so! |"
+" Lachdanan è morto. Tutti lo sanno, non puoi trovare alcun modo per farmi cambiare "
+"idea. Non puoi parlare a un morto. Lo so! |"
 
 #: Source/textdat.cpp:168
 msgid ""
-"You may meet people who are trapped within the Labyrinth, such as "
-"Lachdanan. \n"
+"You may meet people who are trapped within the Labyrinth, such as Lachdanan. \n"
 " \n"
 "I sense in him honor and great guilt. Aid him, and you aid all of Tristram. |"
 msgstr ""
-"Potresti incontrare persone che sono intrappolate nel Labirinto, come "
-"Lachdanan. \n"
+"Potresti incontrare persone che sono intrappolate nel Labirinto, come Lachdanan. \n"
 " \n"
-"Percepisco in lui onore e grande senso di colpa. Aiutalo e aiuti tutta "
-"Tristram. |"
+"Percepisco in lui onore e grande senso di colpa. Aiutalo e aiuti tutta Tristram. |"
 
 #: Source/textdat.cpp:170
 msgid ""
 "Wait, let me guess. Cain was swallowed up in a gigantic fissure that opened "
 "beneath him. He was incinerated in a ball of hellfire, and can't answer your "
-"questions anymore. Oh, that isn't what happened? Then I guess you'll be "
-"buying something or you'll be on your way. |"
+"questions anymore. Oh, that isn't what happened? Then I guess you'll be buying "
+"something or you'll be on your way. |"
 msgstr ""
-"Aspetta, fammi indovinare. Cain è stato ingoiato da un baratro gigantesco "
-"che si è aperto sotto di lui. È stato incenerito in una palla di fuoco "
-"infernale, e non può più darti delle risposte. Non è forse successo questo? "
-"Ora o comprerai qualcosa o te ne andrai. |"
+"Aspetta, fammi indovinare. Cain è stato ingoiato da un baratro gigantesco che si è "
+"aperto sotto di lui. È stato incenerito in una palla di fuoco infernale, e non può "
+"più darti delle risposte. Non è forse successo questo? Ora o comprerai qualcosa o "
+"te ne andrai. |"
 
 #: Source/textdat.cpp:172
 msgid ""
 "Please, don't kill me, just hear me out. I was once Captain of King Leoric's "
-"Knights, upholding the laws of this land with justice and honor. Then his "
-"dark Curse fell upon us for the role we played in his tragic death. As my "
-"fellow Knights succumbed to their twisted fate, I fled from the King's "
-"burial chamber, searching for some way to free myself from the Curse. I "
-"failed...\n"
+"Knights, upholding the laws of this land with justice and honor. Then his dark "
+"Curse fell upon us for the role we played in his tragic death. As my fellow "
+"Knights succumbed to their twisted fate, I fled from the King's burial chamber, "
+"searching for some way to free myself from the Curse. I failed...\n"
 " \n"
-"I have heard of a Golden Elixir that could lift the Curse and allow my soul "
-"to rest, but I have been unable to find it. My strength now wanes, and with "
-"it the last of my humanity as well. Please aid me and find the Elixir. I "
-"will repay your efforts - I swear upon my honor. |"
+"I have heard of a Golden Elixir that could lift the Curse and allow my soul to "
+"rest, but I have been unable to find it. My strength now wanes, and with it the "
+"last of my humanity as well. Please aid me and find the Elixir. I will repay your "
+"efforts - I swear upon my honor. |"
 msgstr ""
-"Per favore, non uccidermi, solo ascoltami. Una volta ero il Capitano dei "
-"Cavalieri di Re Leoric, e mantenevo le leggi di questa terra con giustizia e "
-"onore. Poi la sua Oscura Maledizione cadde su di noi. Mentre i miei compagni "
-"soccombevano al loro triste fato, io fuggii dal sepolcro del Re, per cercare "
-"un modo per porre fine alla Maledizione. Ma fallii...\n"
+"Per favore, non uccidermi, solo ascoltami. Una volta ero il Capitano dei Cavalieri "
+"di Re Leoric, e mantenevo le leggi di questa terra con giustizia e onore. Poi la "
+"sua Oscura Maledizione cadde su di noi. Mentre i miei compagni soccombevano al "
+"loro triste fato, io fuggii dal sepolcro del Re, per cercare un modo per porre "
+"fine alla Maledizione. Ma fallii...\n"
 " \n"
-"Ho sentito parlare di un Elisir dorato che dovrebbe sollevare la Maledizione "
-"e permettere alla mia anima di riposare, ma non sono riuscito a trovarlo. La "
-"mia forza ora svanisce, e con essa la mia umanità. Ti prego, aiutami e trova "
-"l'elisir. Ricompenserò i tuoi sforzi - lo giuro sul mio onore. |"
+"Ho sentito parlare di un Elisir dorato che dovrebbe sollevare la Maledizione e "
+"permettere alla mia anima di riposare, ma non sono riuscito a trovarlo. La mia "
+"forza ora svanisce, e con essa la mia umanità. Ti prego, aiutami e trova l'elisir. "
+"Ricompenserò i tuoi sforzi - lo giuro sul mio onore. |"
 
 #: Source/textdat.cpp:174
 msgid ""
 "You have not found the Golden Elixir. I fear that I am doomed for eternity. "
 "Please, keep trying... |"
 msgstr ""
-"Non hai trovato l'elisir Dorato. Temo di essere condannato per l'eternità. "
-"Per favore, tieni duro.|"
+"Non hai trovato l'elisir Dorato. Temo di essere condannato per l'eternità. Per "
+"favore, tieni duro.|"
 
 #: Source/textdat.cpp:176
 msgid ""
-"You have saved my soul from damnation, and for that I am in your debt. If "
-"there is ever a way that I can repay you from beyond the grave I will find "
-"it, but for now - take my helm. On the journey I am about to take I will "
-"have little use for it. May it protect you against the dark powers below. Go "
-"with the Light, my friend... |"
+"You have saved my soul from damnation, and for that I am in your debt. If there is "
+"ever a way that I can repay you from beyond the grave I will find it, but for now "
+"- take my helm. On the journey I am about to take I will have little use for it. "
+"May it protect you against the dark powers below. Go with the Light, my friend... |"
 msgstr ""
-"Tu hai salvato la mia anima dalla dannazione e per questo ti sono debitore. "
-"Se troverò un modo per sdebitarmi dall'oltretomba lo farò, ma per ora... "
-"prendi il mio elmo. Nel viaggio che sto per fare mi servirà ben poco. Che "
-"possa proteggerti dagli Oscuri Poteri. Ora vai e che la luce ti assista nel "
-"tuo cammino, amico mio...|"
+"Tu hai salvato la mia anima dalla dannazione e per questo ti sono debitore. Se "
+"troverò un modo per sdebitarmi dall'oltretomba lo farò, ma per ora... prendi il "
+"mio elmo. Nel viaggio che sto per fare mi servirà ben poco. Che possa proteggerti "
+"dagli Oscuri Poteri. Ora vai e che la luce ti assista nel tuo cammino, amico "
+"mio...|"
 
 #: Source/textdat.cpp:178
 msgid ""
-"Griswold speaks of The Anvil of Fury - a legendary artifact long searched "
-"for, but never found. Crafted from the metallic bones of the Razor Pit "
-"demons, the Anvil of Fury was smelt around the skulls of the five most "
-"powerful magi of the underworld. Carved with runes of power and chaos, any "
-"weapon or armor forged upon this Anvil will be immersed into the realm of "
-"Chaos, imbedding it with magical properties. It is said that the "
-"unpredictable nature of Chaos makes it difficult to know what the outcome of "
-"this smithing will be... |"
+"Griswold speaks of The Anvil of Fury - a legendary artifact long searched for, but "
+"never found. Crafted from the metallic bones of the Razor Pit demons, the Anvil of "
+"Fury was smelt around the skulls of the five most powerful magi of the underworld. "
+"Carved with runes of power and chaos, any weapon or armor forged upon this Anvil "
+"will be immersed into the realm of Chaos, imbedding it with magical properties. It "
+"is said that the unpredictable nature of Chaos makes it difficult to know what the "
+"outcome of this smithing will be... |"
 msgstr ""
-"Griswold mi ha parlato dell'Incudine della Furia, un manufatto leggendario "
-"che molti cercano, ma che nessuno ha mai trovato. Forgiato con le ossa "
-"metalliche dei demoni dei pozzi taglienti, l'Incudine della Furia venne fusa "
-"circondata dai crani dei cinque più potenti stregoni dell'aldilà. Cesellata "
-"con rune di Caos e Potere, qualsiasi arma forgiata su questa Incudine "
-"acquista proprietà magiche ignote. Si dice che la natura imprevedibile del "
-"Caos, renda impossibile sapere quali saranno le conseguenze della "
-"forgiatura. |"
+"Griswold mi ha parlato dell'Incudine della Furia, un manufatto leggendario che "
+"molti cercano, ma che nessuno ha mai trovato. Forgiato con le ossa metalliche dei "
+"demoni dei pozzi taglienti, l'Incudine della Furia venne fusa circondata dai crani "
+"dei cinque più potenti stregoni dell'aldilà. Cesellata con rune di Caos e Potere, "
+"qualsiasi arma forgiata su questa Incudine acquista proprietà magiche ignote. Si "
+"dice che la natura imprevedibile del Caos, renda impossibile sapere quali saranno "
+"le conseguenze della forgiatura. |"
 
 #: Source/textdat.cpp:180
 msgid ""
-"Don't you think that Griswold would be a better person to ask about this? "
-"He's quite handy, you know. |"
+"Don't you think that Griswold would be a better person to ask about this? He's "
+"quite handy, you know. |"
 msgstr ""
 "Non pensi che Griswold sia la persona più adatta a cui domandarlo? Dopotutto "
 "questo è il suo campo. |"
 
 #: Source/textdat.cpp:182
 msgid ""
-"If you had been looking for information on the Pestle of Curing or the "
-"Silver Chalice of Purification, I could have assisted you, my friend. "
-"However, in this matter, you would be better served to speak to either "
-"Griswold or Cain. |"
+"If you had been looking for information on the Pestle of Curing or the Silver "
+"Chalice of Purification, I could have assisted you, my friend. However, in this "
+"matter, you would be better served to speak to either Griswold or Cain. |"
 msgstr ""
-"Se tu stessi cercando informazioni sul Pestello della Cura o sul Calice "
-"d'Argento della Purificazione, ti avrei potuto assistere, amico mio. Ma in "
-"questo caso, ti converrebbe di più parlare con Griswold o addirittura con "
-"Cain. |"
+"Se tu stessi cercando informazioni sul Pestello della Cura o sul Calice d'Argento "
+"della Purificazione, ti avrei potuto assistere, amico mio. Ma in questo caso, ti "
+"converrebbe di più parlare con Griswold o addirittura con Cain. |"
 
 #: Source/textdat.cpp:184
 msgid ""
-"Griswold's father used to tell some of us when we were growing up about a "
-"giant anvil that was used to make mighty weapons. He said that when a hammer "
-"was struck upon this anvil, the ground would shake with a great fury. "
-"Whenever the earth moves, I always remember that story. |"
+"Griswold's father used to tell some of us when we were growing up about a giant "
+"anvil that was used to make mighty weapons. He said that when a hammer was struck "
+"upon this anvil, the ground would shake with a great fury. Whenever the earth "
+"moves, I always remember that story. |"
 msgstr ""
 "Il padre di Griswold era solito raccontarci quando eravamo piccoli, di una "
 "gigantesca incudine usata per fabbricare potenti armi. Diceva che quando un "
-"martello colpiva quest'incudine il suolo tremava con una grande furia. "
-"Ricordo questa storia ogni volta che la terra si muove.|"
+"martello colpiva quest'incudine il suolo tremava con una grande furia. Ricordo "
+"questa storia ogni volta che la terra si muove.|"
 
 #: Source/textdat.cpp:186
 msgid ""
-"Greetings! It's always a pleasure to see one of my best customers! I know "
-"that you have been venturing deeper into the Labyrinth, and there is a story "
-"I was told that you may find worth the time to listen to...\n"
+"Greetings! It's always a pleasure to see one of my best customers! I know that you "
+"have been venturing deeper into the Labyrinth, and there is a story I was told "
+"that you may find worth the time to listen to...\n"
 " \n"
-"One of the men who returned from the Labyrinth told me about a mystic anvil "
-"that he came across during his escape. His description reminded me of "
-"legends I had heard in my youth about the burning Hellforge where powerful "
-"weapons of magic are crafted. The legend had it that deep within the "
-"Hellforge rested the Anvil of Fury! This Anvil contained within it the very "
-"essence of the demonic underworld...\n"
+"One of the men who returned from the Labyrinth told me about a mystic anvil that "
+"he came across during his escape. His description reminded me of legends I had "
+"heard in my youth about the burning Hellforge where powerful weapons of magic are "
+"crafted. The legend had it that deep within the Hellforge rested the Anvil of "
+"Fury! This Anvil contained within it the very essence of the demonic "
+"underworld...\n"
 " \n"
-"It is said that any weapon crafted upon the burning Anvil is imbued with "
-"great power. If this anvil is indeed the Anvil of Fury, I may be able to "
-"make you a weapon capable of defeating even the darkest lord of Hell! \n"
+"It is said that any weapon crafted upon the burning Anvil is imbued with great "
+"power. If this anvil is indeed the Anvil of Fury, I may be able to make you a "
+"weapon capable of defeating even the darkest lord of Hell! \n"
 " \n"
 "Find the Anvil for me, and I'll get to work! |"
 msgstr ""
-"Benvenuto! È sempre un piacere vedere uno dei miei migliori clienti! So che "
-"stai penetrando sempre più nel Labirinto, e c'e' una storia che mi hanno "
-"raccontato che potrebbe interessarti...\n"
+"Benvenuto! è sempre un piacere vedere uno dei miei migliori clienti! So che stai "
+"penetrando sempre più nel Labirinto, e c'è una storia che mi hanno raccontato che "
+"potrebbe interessarti...\n"
 " \n"
-"Uno degli uomini che tornò dal Labirinto parlò di un'Incudine Mistica, in "
-"cui si imbatte' durante la fuga. Il suo racconto mi ricordò alcune leggende "
-"che avevo sentito durante l'infanzia riguardo la fornace Infernale, nella "
-"quale venivano forgiate potenti armi magiche. Si narra che nelle profondità "
-"della fornace giaccia l'incudine della Furia! Quest'incudine contiene al suo "
-"interno l'essenza del mondo demoniaco...\n"
+"Uno degli uomini che tornò dal Labirinto parlò di un'Incudine Mistica, in cui si "
+"imbatté durante la fuga. Il suo racconto mi ricordò alcune leggende che avevo "
+"sentito durante l'infanzia riguardo la fornace Infernale, nella quale venivano "
+"forgiate potenti armi magiche. Si narra che nelle profondità della fornace giaccia "
+"l'incudine della Furia! Quest'incudine contiene al suo interno l'essenza del mondo "
+"demoniaco...\n"
 " \n"
 "Qualunque arma forgiata su di essa si imbeve di un grande potere. Se "
 "quell'incudine è davvero l'Incudine della Furia, potrei essere in grado di "
@@ -7577,23 +7496,21 @@ msgstr ""
 
 #: Source/textdat.cpp:188
 msgid ""
-"Nothing yet, eh? Well, keep searching. A weapon forged upon the Anvil could "
-"be your best hope, and I am sure that I can make you one of legendary "
-"proportions. |"
+"Nothing yet, eh? Well, keep searching. A weapon forged upon the Anvil could be "
+"your best hope, and I am sure that I can make you one of legendary proportions. |"
 msgstr ""
-"Ancora niente,eh? Continua a cercare. Un'arma fatta su quell'incudine puo "
-"essere la nostra sola speranza e so di potertene fare una di proporzioni "
-"leggendarie. |"
+"Ancora niente,eh? Continua a cercare. Un'arma fatta su quell'incudine puo essere "
+"la nostra sola speranza e so di potertene fare una di proporzioni leggendarie. |"
 
 #: Source/textdat.cpp:190
 msgid ""
-"I can hardly believe it! This is the Anvil of Fury - good work, my friend. "
-"Now we'll show those bastards that there are no weapons in Hell more deadly "
-"than those made by men! Take this and may Light protect you. |"
+"I can hardly believe it! This is the Anvil of Fury - good work, my friend. Now "
+"we'll show those bastards that there are no weapons in Hell more deadly than those "
+"made by men! Take this and may Light protect you. |"
 msgstr ""
-"Non riesco a crederci! Questa è l'Incudine della Furia, ottimo lavoro, amico "
-"mio. Ora mostreremo a quei bastardi che nessuna arma Infernale è più letale "
-"di una fatta da un uomo! Tieni, e che la luce ti protegga. |"
+"Non riesco a crederci! Questa è l'Incudine della Furia, ottimo lavoro, amico mio. "
+"Ora mostreremo a quei bastardi che nessuna arma Infernale è più letale di una "
+"fatta da un uomo! Tieni, e che la luce ti protegga. |"
 
 #: Source/textdat.cpp:192
 msgid ""
@@ -7606,99 +7523,94 @@ msgstr ""
 #: Source/textdat.cpp:194
 msgid ""
 "There are many artifacts within the Labyrinth that hold powers beyond the "
-"comprehension of mortals. Some of these hold fantastic power that can be "
-"used by either the Light or the Darkness. Securing the Anvil from below "
-"could shift the course of the Sin War towards the Light. |"
+"comprehension of mortals. Some of these hold fantastic power that can be used by "
+"either the Light or the Darkness. Securing the Anvil from below could shift the "
+"course of the Sin War towards the Light. |"
 msgstr ""
 "Ci sono molti manufatti nel labirinto con poteri oltre la comprensione dei "
-"mortali. Alcuni contengono fantastici poteri che possono essere usati sia "
-"dalla Luce che dall'Oscurità. Mettere al sicuro l'incudine potrebbe cambiare "
-"il corso della Guerra del Peccato verso la luce. |"
+"mortali. Alcuni contengono fantastici poteri che possono essere usati sia dalla "
+"Luce che dall'Oscurità. Mettere al sicuro l'incudine potrebbe cambiare il corso "
+"della Guerra del Peccato verso la luce. |"
 
 #: Source/textdat.cpp:196
 msgid ""
-"If you were to find this artifact for Griswold, it could put a serious "
-"damper on my business here. Awwww, you'll never find it. |"
+"If you were to find this artifact for Griswold, it could put a serious damper on "
+"my business here. Awwww, you'll never find it. |"
 msgstr ""
-"Se tu trovassi quel manufatto per Griswold, potresti rovinare l'andamento "
-"dei miei affari. Awww, tanto non lo troverai mai. |"
+"Se tu trovassi quel manufatto per Griswold, potresti rovinare l'andamento dei miei "
+"affari. Awww, tanto non lo troverai mai. |"
 
 #: Source/textdat.cpp:198
 msgid ""
 "The Gateway of Blood and the Halls of Fire are landmarks of mystic origin. "
-"Wherever this book you read from resides it is surely a place of great "
-"power.\n"
+"Wherever this book you read from resides it is surely a place of great power.\n"
 " \n"
-"Legends speak of a pedestal that is carved from obsidian stone and has a "
-"pool of boiling blood atop its bone encrusted surface. There are also "
-"allusions to Stones of Blood that will open a door that guards an ancient "
-"treasure...\n"
+"Legends speak of a pedestal that is carved from obsidian stone and has a pool of "
+"boiling blood atop its bone encrusted surface. There are also allusions to Stones "
+"of Blood that will open a door that guards an ancient treasure...\n"
 " \n"
-"The nature of this treasure is shrouded in speculation, my friend, but it is "
-"said that the ancient hero Arkaine placed the holy armor Valor in a secret "
-"vault. Arkaine was the first mortal to turn the tide of the Sin War and "
-"chase the legions of darkness back to the Burning Hells.\n"
+"The nature of this treasure is shrouded in speculation, my friend, but it is said "
+"that the ancient hero Arkaine placed the holy armor Valor in a secret vault. "
+"Arkaine was the first mortal to turn the tide of the Sin War and chase the legions "
+"of darkness back to the Burning Hells.\n"
 " \n"
-"Just before Arkaine died, his armor was hidden away in a secret vault. It is "
-"said that when this holy armor is again needed, a hero will arise to don "
-"Valor once more. Perhaps you are that hero... |"
+"Just before Arkaine died, his armor was hidden away in a secret vault. It is said "
+"that when this holy armor is again needed, a hero will arise to don Valor once "
+"more. Perhaps you are that hero... |"
 msgstr ""
-"Il Cancello di Sangue e le Sale di Fuoco sono riferimenti di origine "
-"mistica. Ovunque tu abbia letto quel libro è sicuramente un luogo di grande "
-"potere.\n"
+"Il Cancello di Sangue e le Sale di Fuoco sono riferimenti di origine mistica. "
+"Ovunque tu abbia letto quel libro è sicuramente un luogo di grande potere.\n"
 " \n"
-"Le leggende parlano di un piedistallo d'ossidiana scolpita con una pozza di "
-"sangue ribollente sulla sua sommità d'ossa. Ci sono anche allusioni a Pietre "
-"di Sangue che apriranno una porta che cela un antico tesoro...\n"
+"Le leggende parlano di un piedistallo d'ossidiana scolpita con una pozza di sangue "
+"ribollente sulla sua sommità d'ossa. Ci sono anche allusioni a Pietre di Sangue "
+"che apriranno una porta che cela un antico tesoro...\n"
 " \n"
 "La natura di questo tesoro è avvolta nel mistero, amico mio, ma si narra che "
 "l'antico eroe Arkaine nascose la sua armatura sacra Valor in un sotterraneo "
-"segreto. Arkaine fu il primo mortale che cambiò il corso della Guerra del "
-"Peccato ricacciando le legioni dell'oscurità negli Inferi Fiammeggianti.\n"
+"segreto. Arkaine fu il primo mortale che cambiò il corso della Guerra del Peccato "
+"ricacciando le legioni dell'oscurità negli Inferi Fiammeggianti.\n"
 " \n"
-"Poco prima che morisse, la sua armatura fu nascosta in un luogo segreto. Si "
-"dice che quando ce ne sarà bisogno, sorgerà un eroe che indosserà Valor "
-"ancora una volta. Forse tu sei quell'eroe... |"
+"Poco prima che morisse, la sua armatura fu nascosta in un luogo segreto. Si dice "
+"che quando ce ne sarà bisogno, sorgerà un eroe che indosserà Valor ancora una "
+"volta. Forse tu sei quell'eroe... |"
 
 #: Source/textdat.cpp:200
 msgid ""
-"Every child hears the story of the warrior Arkaine and his mystic armor "
-"known as Valor. If you could find its resting place, you would be well "
-"protected against the evil in the Labyrinth. |"
+"Every child hears the story of the warrior Arkaine and his mystic armor known as "
+"Valor. If you could find its resting place, you would be well protected against "
+"the evil in the Labyrinth. |"
 msgstr ""
-"Ogni bambino conosce la storia del guerriero Arkaine e della sua mistica "
-"Armatura Valor. Se tu trovassi il posto dov'è conservata, saresti ben "
-"protetto contro il male del Labirinto. |"
+"Ogni bambino conosce la storia del guerriero Arkaine e della sua mistica Armatura "
+"Valor. Se tu trovassi il posto dov'è conservata, saresti ben protetto contro il "
+"male del Labirinto. |"
 
 #: Source/textdat.cpp:202
 msgid ""
-"Hmm... it sounds like something I should remember, but I've been so busy "
-"learning new cures and creating better elixirs that I must have forgotten. "
-"Sorry... |"
+"Hmm... it sounds like something I should remember, but I've been so busy learning "
+"new cures and creating better elixirs that I must have forgotten. Sorry... |"
 msgstr ""
-"Hmm... Sembra qualcosa che dovrei sapere, ma sono stato cosi' occupato a "
-"cercare nuove cure e a creare migliori elisir che ora non ricordo. Mi "
-"spiace... |"
+"Hmm... Sembra qualcosa che dovrei sapere, ma sono stato così occupato a cercare "
+"nuove cure e a creare migliori elisir che ora non ricordo. Mi spiace... |"
 
 #: Source/textdat.cpp:204
 msgid ""
-"The story of the magic armor called Valor is something I often heard the "
-"boys talk about. You had better ask one of the men in the village. |"
+"The story of the magic armor called Valor is something I often heard the boys talk "
+"about. You had better ask one of the men in the village. |"
 msgstr ""
-"Ho sentito spesso i ragazzi raccontarsi la storia dell'armatura magica "
-"chiamata Valor. Prova a chiederlo a uno degli uomini del villaggio. |"
+"Ho sentito spesso i ragazzi raccontarsi la storia dell'armatura magica chiamata "
+"Valor. Prova a chiederlo a uno degli uomini del villaggio. |"
 
 #: Source/textdat.cpp:206
 msgid ""
-"The armor known as Valor could be what tips the scales in your favor. I will "
-"tell you that many have looked for it - including myself. Arkaine hid it "
-"well, my friend, and it will take more than a bit of luck to unlock the "
-"secrets that have kept it concealed oh, lo these many years. |"
+"The armor known as Valor could be what tips the scales in your favor. I will tell "
+"you that many have looked for it - including myself. Arkaine hid it well, my "
+"friend, and it will take more than a bit of luck to unlock the secrets that have "
+"kept it concealed oh, lo these many years. |"
 msgstr ""
-"L'armatura nota come Valor potrebbe essere la cosa che aumenterà le "
-"opportunità a tuo favore. Molti l'hanno cercata - me compreso. Ma Arkaine la "
-"nascose bene, amico mio, ti servirà più di un pizzico di fortuna per svelare "
-"i segreti che l'hanno celata per tutti questi anni. |"
+"L'armatura nota come Valor potrebbe essere la cosa che aumenterà le opportunità a "
+"tuo favore. Molti l'hanno cercata - me compreso. Ma Arkaine la nascose bene, amico "
+"mio, ti servirà più di un pizzico di fortuna per svelare i segreti che l'hanno "
+"celata per tutti questi anni. |"
 
 #: Source/textdat.cpp:208
 msgid "Zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz... |"
@@ -7708,8 +7620,7 @@ msgstr "Zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz... |"
 msgid ""
 "Should you find these Stones of Blood, use them carefully. \n"
 " \n"
-"The way is fraught with danger and your only hope rests within your self "
-"trust. |"
+"The way is fraught with danger and your only hope rests within your self trust. |"
 msgstr ""
 "Se dovessi trovare queste Pietre di Sangue, usale con attenzione. \n"
 " \n"
@@ -7719,8 +7630,8 @@ msgstr ""
 msgid ""
 "You intend to find the armor known as Valor? \n"
 " \n"
-"No one has ever figured out where Arkaine stashed the stuff, and if my "
-"contacts couldn't find it, I seriously doubt you ever will either. |"
+"No one has ever figured out where Arkaine stashed the stuff, and if my contacts "
+"couldn't find it, I seriously doubt you ever will either. |"
 msgstr ""
 "Intendi trovare l'armatura nota come Valor? \n"
 " \n"
@@ -7729,29 +7640,28 @@ msgstr ""
 
 #: Source/textdat.cpp:213
 msgid ""
-"I know of only one legend that speaks of such a warrior as you describe. His "
-"story is found within the ancient chronicles of the Sin War...\n"
+"I know of only one legend that speaks of such a warrior as you describe. His story "
+"is found within the ancient chronicles of the Sin War...\n"
 " \n"
-"Stained by a thousand years of war, blood and death, the Warlord of Blood "
-"stands upon a mountain of his tattered victims. His dark blade screams a "
-"black curse to the living; a tortured invitation to any who would stand "
-"before this Executioner of Hell.\n"
+"Stained by a thousand years of war, blood and death, the Warlord of Blood stands "
+"upon a mountain of his tattered victims. His dark blade screams a black curse to "
+"the living; a tortured invitation to any who would stand before this Executioner "
+"of Hell.\n"
 " \n"
-"It is also written that although he was once a mortal who fought beside the "
-"Legion of Darkness during the Sin War, he lost his humanity to his "
-"insatiable hunger for blood. |"
+"It is also written that although he was once a mortal who fought beside the Legion "
+"of Darkness during the Sin War, he lost his humanity to his insatiable hunger for "
+"blood. |"
 msgstr ""
-"So solo di una leggenda che narra del guerriero che hai descritto. La sua "
-"storia si può trovare nelle Antiche Cronache della Guerra del Peccato...\n"
+"So solo di una leggenda che narra del guerriero che hai descritto. La sua storia "
+"si può trovare nelle Antiche Cronache della Guerra del Peccato...\n"
 " \n"
-"Macchiato da mille anni di guerra, sangue e morte, il Comandante Supremo si "
-"erge su una montagna di vittime lacerate. La sua Lama nera lancia un'oscura "
-"Maledizione ai vivi; un tormentoso invito per chiunque incontri questo "
-"Carnefice dell'Inferno.\n"
+"Macchiato da mille anni di guerra, sangue e morte, il Comandante Supremo si erge "
+"su una montagna di vittime lacerate. La sua Lama nera lancia un'oscura Maledizione "
+"ai vivi; un tormentoso invito per chiunque incontri questo Carnefice "
+"dell'Inferno.\n"
 " \n"
-"Si dice che anche se un tempo fu un mortale che combatté con l'oscurità "
-"durante la guerra del peccato, perse l'umanità per la sua insaziabile sete "
-"di sangue. |"
+"Si dice che anche se un tempo fu un mortale che combatté con l'oscurità durante la "
+"guerra del peccato, perse l'umanità per la sua insaziabile sete di sangue. |"
 
 #: Source/textdat.cpp:215
 msgid ""
@@ -7759,261 +7669,251 @@ msgid ""
 "master. I hope that you do not have to fight him, for he sounds extremely "
 "dangerous. |"
 msgstr ""
-"Temo di non aver mai sentito parlare di un Guerriero così Perverso, Signore. "
-"Spero che tu non debba lottare contro di lui, mi sembra sia estremamente "
-"pericoloso. |"
+"Temo di non aver mai sentito parlare di un Guerriero così Perverso, Signore. Spero "
+"che tu non debba lottare contro di lui, mi sembra sia estremamente pericoloso. |"
 
 #: Source/textdat.cpp:217
 msgid ""
-"Cain would be able to tell you much more about something like this than I "
-"would ever wish to know. |"
+"Cain would be able to tell you much more about something like this than I would "
+"ever wish to know. |"
 msgstr ""
-"Cain saprà dirti più cose a riguardo, di quante io possa mai sperare di "
-"conoscere. |"
+"Cain saprà dirti più cose a riguardo, di quante io possa mai sperare di conoscere. "
+"|"
 
 #: Source/textdat.cpp:219
 msgid ""
-"If you are to battle such a fierce opponent, may Light be your guide and "
-"your defender. I will keep you in my thoughts. |"
+"If you are to battle such a fierce opponent, may Light be your guide and your "
+"defender. I will keep you in my thoughts. |"
 msgstr ""
-"Se devi batterti contro un così feroce avversario, che la luce sia la tua "
-"guida e la tua protezione. Pregherò per te. |"
+"Se devi batterti contro un così feroce avversario, che la luce sia la tua guida e "
+"la tua protezione. Pregherò per te. |"
 
 #: Source/textdat.cpp:221
 msgid ""
-"Dark and wicked legends surrounds the one Warlord of Blood. Be well "
-"prepared, my friend, for he shows no mercy or quarter. |"
+"Dark and wicked legends surrounds the one Warlord of Blood. Be well prepared, my "
+"friend, for he shows no mercy or quarter. |"
 msgstr ""
-"Oscure e malvagie leggende circondano il Comandante Supremo del Sangue. "
-"Preparati amico mio, egli non esita e non ha pietà. |"
+"Oscure e malvagie leggende circondano il Comandante Supremo del Sangue. Preparati "
+"amico mio, egli non esita e non ha pietà. |"
 
 #: Source/textdat.cpp:223
 msgid ""
-"Always you gotta talk about Blood? What about flowers, and sunshine, and "
-"that pretty girl that brings the drinks. Listen here, friend - you're "
-"obsessive, you know that? |"
+"Always you gotta talk about Blood? What about flowers, and sunshine, and that "
+"pretty girl that brings the drinks. Listen here, friend - you're obsessive, you "
+"know that? |"
 msgstr ""
-"Devi sempre parlare di Sangue? Perché non di fiori, della luce del sole, o "
-"di quella bella ragazza che porta da bere. Ascolta, amico, sei davvero "
-"ossessionante, sai? |"
+"Devi sempre parlare di Sangue? Perché non di fiori, della luce del sole, o di "
+"quella bella ragazza che porta da bere. Ascolta, amico, sei davvero ossessionante, "
+"sai? |"
 
 #: Source/textdat.cpp:225
 msgid ""
-"His prowess with the blade is awesome, and he has lived for thousands of "
-"years knowing only warfare. I am sorry... I can not see if you will defeat "
-"him. |"
+"His prowess with the blade is awesome, and he has lived for thousands of years "
+"knowing only warfare. I am sorry... I can not see if you will defeat him. |"
 msgstr ""
 "La sua abilità con la spada è terrificante, ha vissuto per migliaia d'anni "
 "conoscendo solo guerra. Mi spiace... ma non so predire se lo sconfiggerai. |"
 
 #: Source/textdat.cpp:227
 msgid ""
-"I haven't ever dealt with this Warlord you speak of, but he sounds like he's "
-"going through a lot of swords. Wouldn't mind supplying his armies... |"
+"I haven't ever dealt with this Warlord you speak of, but he sounds like he's going "
+"through a lot of swords. Wouldn't mind supplying his armies... |"
 msgstr ""
-"Non ho mai avuto a che fare con questo Comandante, ma da come ne parli pare "
-"che necessiti di molte spade. Mi piacerebbe armare il suo esercito... |"
+"Non ho mai avuto a che fare con questo Comandante, ma da come ne parli pare che "
+"necessiti di molte spade. Mi piacerebbe armare il suo esercito... |"
 
 #: Source/textdat.cpp:229
 msgid ""
-"My blade sings for your blood, mortal, and by my dark masters it shall not "
-"be denied. |"
+"My blade sings for your blood, mortal, and by my dark masters it shall not be "
+"denied. |"
 msgstr ""
-"La mia spada brama il tuo Sangue, mortale, e per i miei Padroni non la "
-"deluderò. |"
+"La mia spada brama il tuo Sangue, mortale, e per i miei Padroni non la deluderò. |"
 
 #: Source/textdat.cpp:231
 msgid ""
-"Griswold speaks of the Heaven Stone that was destined for the enclave "
-"located in the east. It was being taken there for further study. This stone "
-"glowed with an energy that somehow granted vision beyond that which a normal "
-"man could possess. I do not know what secrets it holds, my friend, but "
-"finding this stone would certainly prove most valuable. |"
+"Griswold speaks of the Heaven Stone that was destined for the enclave located in "
+"the east. It was being taken there for further study. This stone glowed with an "
+"energy that somehow granted vision beyond that which a normal man could possess. I "
+"do not know what secrets it holds, my friend, but finding this stone would "
+"certainly prove most valuable. |"
 msgstr ""
-"Griswold parlò della Pietra Celeste destinata all'Enclave situata ad "
-"oriente. Sarebbe stata portata là per ulteriori studi. Questa pietra arde di "
-"un'energia che concede di vedere al di la delle normali possibilità di un "
-"uomo. Non so che segreti contenga, amico mio, ma il ritrovamento di questa "
-"pietra si dimostrerebbe certamente molto importante. |"
+"Griswold parlò della Pietra Celeste destinata all'Enclave situata ad oriente. "
+"Sarebbe stata portata là per ulteriori studi. Questa pietra arde di un'energia che "
+"concede di vedere al di là delle normali possibilità di un uomo. Non so che "
+"segreti contenga, amico mio, ma il ritrovamento di questa pietra si dimostrerebbe "
+"certamente molto importante. |"
 
 #: Source/textdat.cpp:233
 msgid ""
-"The caravan stopped here to take on some supplies for their journey to the "
-"east. I sold them quite an array of fresh fruits and some excellent "
-"sweetbreads that Garda has just finished baking. Shame what happened to "
-"them... |"
+"The caravan stopped here to take on some supplies for their journey to the east. I "
+"sold them quite an array of fresh fruits and some excellent sweetbreads that Garda "
+"has just finished baking. Shame what happened to them... |"
 msgstr ""
-"La carovana si fermò qui per rifornirsi per il loro viaggio verso est. Ho "
-"venduto loro della frutta fresca e delle eccellenti animelle che Garda aveva "
-"appena sfornato. Fu un peccato quello che capitò loro... |"
+"La carovana si fermò qui per rifornirsi per il loro viaggio verso est. Ho venduto "
+"loro della frutta fresca e delle eccellenti animelle che Garda aveva appena "
+"sfornato. Fu un peccato quello che capitò loro... |"
 
 #: Source/textdat.cpp:235
 msgid ""
-"I don't know what it is that they thought they could see with that rock, but "
-"I will say this. If rocks are falling from the sky, you had better be "
-"careful! |"
+"I don't know what it is that they thought they could see with that rock, but I "
+"will say this. If rocks are falling from the sky, you had better be careful! |"
 msgstr ""
-"Io non so cosa pensano di poter trovare in quella pietra, ma ti dirò una "
-"cosa. Se le pietre iniziano a cadere dal cielo, tu faresti meglio a stare "
-"attento! |"
+"Io non so cosa pensano di poter trovare in quella pietra, ma ti dirò una cosa. Se "
+"le pietre iniziano a cadere dal cielo, tu faresti meglio a stare attento! |"
 
 #: Source/textdat.cpp:237
 msgid ""
-"Well, a caravan of some very important people did stop here, but that was "
-"quite a while ago. They had strange accents and were starting on a long "
-"journey, as I recall. \n"
+"Well, a caravan of some very important people did stop here, but that was quite a "
+"while ago. They had strange accents and were starting on a long journey, as I "
+"recall. \n"
 " \n"
 "I don't see how you could hope to find anything that they would have been "
 "carrying. |"
 msgstr ""
-"Si, una carovana composta da delle persone importanti si fermò qui, ma "
-"accadde tanto tempo fa. Avevano accenti strani e stavano per fare un lungo "
-"viaggio, per quel che mi ricordo. \n"
+"Si, una carovana composta da delle persone importanti si fermò qui, ma accadde "
+"tanto tempo fa. Avevano accenti strani e stavano per fare un lungo viaggio, per "
+"quel che mi ricordo. \n"
 " \n"
 "Non vedo come potresti sperare di trovare quello che stavano trasportando. |"
 
 #: Source/textdat.cpp:239
 msgid ""
-"Stay for a moment - I have a story you might find interesting. A caravan "
-"that was bound for the eastern kingdoms passed through here some time ago. "
-"It was supposedly carrying a piece of the heavens that had fallen to earth! "
-"The caravan was ambushed by cloaked riders just north of here along the "
-"roadway. I searched the wreckage for this sky rock, but it was nowhere to be "
-"found. If you should find it, I believe that I can fashion something useful "
-"from it. |"
+"Stay for a moment - I have a story you might find interesting. A caravan that was "
+"bound for the eastern kingdoms passed through here some time ago. It was "
+"supposedly carrying a piece of the heavens that had fallen to earth! The caravan "
+"was ambushed by cloaked riders just north of here along the roadway. I searched "
+"the wreckage for this sky rock, but it was nowhere to be found. If you should find "
+"it, I believe that I can fashion something useful from it. |"
 msgstr ""
-"Fermati un momento, ho una storia che potresti trovare interessante. Una "
-"carovana diretta ai regni orientali, passò da qui qualche tempo fa. Si "
-"presume portasse un pezzo di Paradiso caduto sulla terra! La carovana fu "
-"assalita da cavalieri incappucciati appena a nord di qui lungo il tragitto. "
-"Ispezionai tra i rottami per trovare questa pietra del cielo, ma non c'era. "
-"Se tu dovessi trovarla, credo di poterti creare qualcosa di utile. |"
+"Fermati un momento, ho una storia che potresti trovare interessante. Una carovana "
+"diretta ai regni orientali, passò da qui qualche tempo fa. Si presume portasse un "
+"pezzo di Paradiso caduto sulla terra! La carovana fu assalita da cavalieri "
+"incappucciati appena a nord di qui lungo il tragitto. Ispezionai tra i rottami per "
+"trovare questa pietra del cielo, ma non c'era. Se tu dovessi trovarla, credo di "
+"poterti creare qualcosa di utile. |"
 
 #: Source/textdat.cpp:241
 msgid ""
-"I am still waiting for you to bring me that stone from the heavens. I know "
-"that I can make something powerful out of it. |"
+"I am still waiting for you to bring me that stone from the heavens. I know that I "
+"can make something powerful out of it. |"
 msgstr ""
-"Sto ancora aspettando che tu mi porti la Pietra del Paradiso. So di poterti "
-"creare qualcosa di molto potente con essa. |"
+"Sto ancora aspettando che tu mi porti la Pietra del Paradiso. So di poterti creare "
+"qualcosa di molto potente con essa. |"
 
 #: Source/textdat.cpp:243
 msgid ""
 "Let me see that - aye... aye, it is as I believed. Give me a moment...\n"
 " \n"
-"Ah, Here you are. I arranged pieces of the stone within a silver ring that "
-"my father left me. I hope it serves you well. |"
+"Ah, Here you are. I arranged pieces of the stone within a silver ring that my "
+"father left me. I hope it serves you well. |"
 msgstr ""
 "Fammi dare un'occhiata... si... si, è come credevo. Aspetta...\n"
 " \n"
-"Ah, eccolo qua. Ho sistemato alcuni frammenti della pietra in un anello "
-"d'argento lasciatomi da mio padre. Spero possa aiutarti. |"
+"Ah, eccolo qua. Ho sistemato alcuni frammenti della pietra in un anello d'argento "
+"lasciatomi da mio padre. Spero possa aiutarti. |"
 
 #: Source/textdat.cpp:245
 msgid ""
-"I used to have a nice ring; it was a really expensive one, with blue and "
-"green and red and silver. Don't remember what happened to it, though. I "
-"really miss that ring... |"
+"I used to have a nice ring; it was a really expensive one, with blue and green and "
+"red and silver. Don't remember what happened to it, though. I really miss that "
+"ring... |"
 msgstr ""
 "Avevo un bell'Anello; uno molto prezioso, con pietre blu e verdi e rosse e "
 "d'argento. Però non ricordo che fine fece. Mi manca molto quell'anello... |"
 
 #: Source/textdat.cpp:247
 msgid ""
-"The Heaven Stone is very powerful, and were it any but Griswold who bid you "
-"find it, I would prevent it. He will harness its powers and its use will be "
-"for the good of us all. |"
+"The Heaven Stone is very powerful, and were it any but Griswold who bid you find "
+"it, I would prevent it. He will harness its powers and its use will be for the "
+"good of us all. |"
 msgstr ""
-"La Pietra del Paradiso è molto potente, se altri al posto di Griswold ti "
-"avessero chiesto di trovarla, l'avrei impedito. Lui vuole usare quei poteri "
-"per il bene di noi tutti. |"
+"La Pietra del Paradiso è molto potente, se altri al posto di Griswold ti avessero "
+"chiesto di trovarla, l'avrei impedito. Lui vuole usare quei poteri per il bene di "
+"noi tutti. |"
 
 #: Source/textdat.cpp:249
 msgid ""
-"If anyone can make something out of that rock, Griswold can. He knows what "
-"he is doing, and as much as I try to steal his customers, I respect the "
-"quality of his work. |"
+"If anyone can make something out of that rock, Griswold can. He knows what he is "
+"doing, and as much as I try to steal his customers, I respect the quality of his "
+"work. |"
 msgstr ""
-"Se c'è qualcuno che può trarre qualcosa da quella pietra, quello è Griswold. "
-"Sa quello che fa, e rispetto il suo lavoro per quanto cerchi di rubargli i "
-"clienti. |"
+"Se c'è qualcuno che può trarre qualcosa da quella pietra, quello è Griswold. Sa "
+"quello che fa, e rispetto il suo lavoro per quanto cerchi di rubargli i clienti. |"
 
 #: Source/textdat.cpp:251
 msgid ""
-"The witch Adria seeks a black mushroom? I know as much about Black Mushrooms "
-"as I do about Red Herrings. Perhaps Pepin the Healer could tell you more, "
-"but this is something that cannot be found in any of my stories or books. |"
+"The witch Adria seeks a black mushroom? I know as much about Black Mushrooms as I "
+"do about Red Herrings. Perhaps Pepin the Healer could tell you more, but this is "
+"something that cannot be found in any of my stories or books. |"
 msgstr ""
-"Adria la strega sta cercando un fungo nero? So tanto di funghi neri quanto "
-"di aringhe rosse. Forse Pepin il Guaritore può dirti di più, purtroppo "
-"questo è qualcosa che non può essere trovato in nessuno dei miei libri. |"
+"Adria la strega sta cercando un fungo nero? So tanto di funghi neri quanto di "
+"aringhe rosse. Forse Pepin il Guaritore può dirti di più, purtroppo questo è "
+"qualcosa che non può essere trovato in nessuno dei miei libri. |"
 
 #: Source/textdat.cpp:253
 msgid ""
-"Let me just say this. Both Garda and I would never, EVER serve black "
-"mushrooms to our honored guests. If Adria wants some mushrooms in her stew, "
-"then that is her business, but I can't help you find any. Black mushrooms... "
-"disgusting! |"
+"Let me just say this. Both Garda and I would never, EVER serve black mushrooms to "
+"our honored guests. If Adria wants some mushrooms in her stew, then that is her "
+"business, but I can't help you find any. Black mushrooms... disgusting! |"
 msgstr ""
-"Permettimi di dire solo una cosa. Né Garda né io, potremmo mai servire "
-"funghi neri ai nostri stimati ospiti. Se Adria vuole funghi per il suo "
-"stufato, sono affari suoi, ma non posso aiutarti a trovarli. Funghi neri... "
-"disgustoso! |"
+"Permettimi di dire solo una cosa. Né Garda né io, potremmo mai servire funghi neri "
+"ai nostri stimati ospiti. Se Adria vuole funghi per il suo stufato, sono affari "
+"suoi, ma non posso aiutarti a trovarli. Funghi neri... disgustoso! |"
 
 #: Source/textdat.cpp:255
 msgid ""
-"The witch told me that you were searching for the brain of a demon to assist "
-"me in creating my elixir. It should be of great value to the many who are "
-"injured by those foul beasts, if I can just unlock the secrets I suspect "
-"that its alchemy holds. If you can remove the brain of a demon when you kill "
-"it, I would be grateful if you could bring it to me. |"
+"The witch told me that you were searching for the brain of a demon to assist me in "
+"creating my elixir. It should be of great value to the many who are injured by "
+"those foul beasts, if I can just unlock the secrets I suspect that its alchemy "
+"holds. If you can remove the brain of a demon when you kill it, I would be "
+"grateful if you could bring it to me. |"
 msgstr ""
-"La strega mi ha detto che stai cercando il cervello di un demone per "
-"aiutarmi nella creazione del mio elisir. Sarebbe di grande aiuto per i tanti "
-"che sono stati feriti da quelle orribili bestie, se potessi svelare i "
-"segreti che penso contenga la sua alchimia. Se rimuoverai il cervello di un "
-"demone dopo averlo ucciso, ti sarei grato se me lo portassi. |"
+"La strega mi ha detto che stai cercando il cervello di un demone per aiutarmi "
+"nella creazione del mio elisir. Sarebbe di grande aiuto per i tanti che sono stati "
+"feriti da quelle orribili bestie, se potessi svelare i segreti che penso contenga "
+"la sua alchimia. Se rimuoverai il cervello di un demone dopo averlo ucciso, ti "
+"sarei grato se me lo portassi. |"
 
 #: Source/textdat.cpp:257
 msgid ""
 "Excellent, this is just what I had in mind. I was able to finish the elixir "
-"without this, but it can't hurt to have this to study. Would you please "
-"carry this to the witch? I believe that she is expecting it. |"
+"without this, but it can't hurt to have this to study. Would you please carry this "
+"to the witch? I believe that she is expecting it. |"
 msgstr ""
 "Eccellente, proprio quello che avevo in mente. Sono stato in grado di finire "
-"l'elisir senza questo, ma non farà male studiarlo. Per favore potresti "
-"portare questo alla strega? Credo che lo stia aspettando. |"
+"l'elisir senza questo, ma non farà male studiarlo. Per favore potresti portare "
+"questo alla strega? Credo che lo stia aspettando. |"
 
 #: Source/textdat.cpp:259
 msgid ""
-"I think Ogden might have some mushrooms in the storage cellar. Why don't you "
-"ask him? |"
+"I think Ogden might have some mushrooms in the storage cellar. Why don't you ask "
+"him? |"
 msgstr ""
 "Penso che Ogden possa avere dei funghi in cantina. Perché non chiedi a lui? |"
 
 #: Source/textdat.cpp:261
 msgid ""
-"If Adria doesn't have one of these, you can bet that's a rare thing indeed. "
-"I can offer you no more help than that, but it sounds like... a huge, "
-"gargantuan, swollen, bloated mushroom! Well, good hunting, I suppose. |"
+"If Adria doesn't have one of these, you can bet that's a rare thing indeed. I can "
+"offer you no more help than that, but it sounds like... a huge, gargantuan, "
+"swollen, bloated mushroom! Well, good hunting, I suppose. |"
 msgstr ""
-"Se Adria non ne ha nemmeno uno, puoi scommettere che è davvero una cosa "
-"rara. Non posso offrirti molto più aiuto di questo ma sembra che sia... un "
-"grosso, enorme, gigantesco fungo! Beh, buona caccia, allora. |"
+"Se Adria non ne ha nemmeno uno, puoi scommettere che è davvero una cosa rara. Non "
+"posso offrirti molto più aiuto di questo ma sembra che sia... un grosso, enorme, "
+"gigantesco fungo! Beh, buona caccia, allora. |"
 
 #: Source/textdat.cpp:263
 msgid ""
 "Ogden mixes a MEAN black mushroom, but I get sick if I drink that. Listen, "
 "listen... here's the secret - moderation is the key! |"
 msgstr ""
-"Ogden ha fatto una mistura con un fungo nero e cattivo, mi ammalerei "
-"bevendolo. Ascolta, ascolta. il segreto, è la moderazione!|"
+"Ogden ha fatto una mistura con un fungo nero e cattivo, mi ammalerei bevendolo. "
+"Ascolta, ascolta. il segreto, è la moderazione!|"
 
 #: Source/textdat.cpp:265
 msgid ""
-"What do we have here? Interesting, it looks like a book of reagents. Keep "
-"your eyes open for a black mushroom. It should be fairly large and easy to "
-"identify. If you find it, bring it to me, won't you? |"
+"What do we have here? Interesting, it looks like a book of reagents. Keep your "
+"eyes open for a black mushroom. It should be fairly large and easy to identify. If "
+"you find it, bring it to me, won't you? |"
 msgstr ""
 "Cosa abbiamo qui? Interessante, sembra un libro di reagenti. Tieni gli occhi "
 "aperti per un Fungo Nero. Dovrebbe essere abbastanza grande e facile da "
@@ -8021,135 +7921,131 @@ msgstr ""
 
 #: Source/textdat.cpp:267
 msgid ""
-"It's a big, black mushroom that I need. Now run off and get it for me so "
-"that I can use it for a special concoction that I am working on. |"
+"It's a big, black mushroom that I need. Now run off and get it for me so that I "
+"can use it for a special concoction that I am working on. |"
 msgstr ""
-"Ho bisogno di un grosso fungo nero. Ora vai a cercarlo e portamelo, così che "
-"possa ultimare una mistura speciale a cui sto lavorando. |"
+"Ho bisogno di un grosso fungo nero. Ora vai a cercarlo e portamelo, così che possa "
+"ultimare una mistura speciale a cui sto lavorando. |"
 
 #: Source/textdat.cpp:269
 msgid ""
-"Yes, this will be perfect for a brew that I am creating. By the way, the "
-"healer is looking for the brain of some demon or another so he can treat "
-"those who have been afflicted by their poisonous venom. I believe that he "
-"intends to make an elixir from it. If you help him find what he needs, "
-"please see if you can get a sample of the elixir for me. |"
+"Yes, this will be perfect for a brew that I am creating. By the way, the healer is "
+"looking for the brain of some demon or another so he can treat those who have been "
+"afflicted by their poisonous venom. I believe that he intends to make an elixir "
+"from it. If you help him find what he needs, please see if you can get a sample of "
+"the elixir for me. |"
 msgstr ""
-"Si, questo è perfetto per l'infuso che sto preparando. A proposito, il "
-"Guaritore sta cercando il cervello di un demone cosi' da curare chi è stato "
-"intossicato dal loro veleno. Credo voglia preparare un antidoto. Se lo "
-"aiuterai a procurarsi ciò di cui ha bisogno, per favore, vedi se puoi farti "
-"dare un campione di quell'elisir per me. |"
+"Si, questo è perfetto per l'infuso che sto preparando. A proposito, il Guaritore "
+"sta cercando il cervello di un demone così da curare chi è stato intossicato dal "
+"loro veleno. Credo voglia preparare un antidoto. Se lo aiuterai a procurarsi ciò "
+"di cui ha bisogno, per favore, vedi se puoi farti dare un campione di quell'elisir "
+"per me. |"
 
 #: Source/textdat.cpp:271
 msgid ""
-"Why have you brought that here? I have no need for a demon's brain at this "
-"time. I do need some of the elixir that the Healer is working on. He needs "
-"that grotesque organ that you are holding, and then bring me the elixir. "
-"Simple when you think about it, isn't it? |"
+"Why have you brought that here? I have no need for a demon's brain at this time. I "
+"do need some of the elixir that the Healer is working on. He needs that grotesque "
+"organ that you are holding, and then bring me the elixir. Simple when you think "
+"about it, isn't it? |"
 msgstr ""
-"Perché lo hai portato da me? Non ho bisogno del cervello di un demone. Mi "
-"serve solo l'elisir al quale il Guaritore sta lavorando. È lui che ha "
-"bisogno di questo bizzarro organo, e ricordati di portarmi un po' di elisir. "
-"Pensi di farcela? |"
+"Perché lo hai portato da me? Non ho bisogno del cervello di un demone. Mi serve "
+"solo l'elisir al quale il Guaritore sta lavorando. È lui che ha bisogno di questo "
+"bizzarro organo, e ricordati di portarmi un pò di elisir. Pensi di farcela? |"
 
 #: Source/textdat.cpp:273
 msgid ""
-"What? Now you bring me that elixir from the healer? I was able to finish my "
-"brew without it. Why don't you just keep it... |"
+"What? Now you bring me that elixir from the healer? I was able to finish my brew "
+"without it. Why don't you just keep it... |"
 msgstr ""
-"Cosa? Ora mi porti l'elisir del guaritore? Sono stata in grado di finire il "
-"mio infuso anche senza. Puoi anche tenertelo... |"
+"Cosa? Ora mi porti l'elisir del guaritore? Sono stata in grado di finire il mio "
+"infuso anche senza. Puoi anche tenertelo... |"
 
 #: Source/textdat.cpp:275
 msgid ""
-"I don't have any mushrooms of any size or color for sale. How about "
-"something a bit more useful? |"
+"I don't have any mushrooms of any size or color for sale. How about something a "
+"bit more useful? |"
 msgstr ""
-"Non vendo alcun tipo di fungo di qualsiasi forma o colore. Che ne dici di "
-"qualcosa di più utile? |"
+"Non vendo alcun tipo di fungo di qualsiasi forma o colore. Che ne dici di qualcosa "
+"di più utile? |"
 
 #: Source/textdat.cpp:277
 msgid ""
 "So, the legend of the Map is real. Even I never truly believed any of it! I "
-"suppose it is time that I told you the truth about who I am, my friend. You "
-"see, I am not all that I seem...\n"
+"suppose it is time that I told you the truth about who I am, my friend. You see, I "
+"am not all that I seem...\n"
 " \n"
-"My true name is Deckard Cain the Elder, and I am the last descendant of an "
-"ancient Brotherhood that was dedicated to keeping and safeguarding the "
-"secrets of a timeless evil. An evil that quite obviously has now been "
-"released...\n"
+"My true name is Deckard Cain the Elder, and I am the last descendant of an ancient "
+"Brotherhood that was dedicated to keeping and safeguarding the secrets of a "
+"timeless evil. An evil that quite obviously has now been released...\n"
 " \n"
-"The evil that you move against is the dark Lord of Terror - known to mortal "
-"men as Diablo. It was he who was imprisoned within the Labyrinth many "
-"centuries ago. The Map that you hold now was created ages ago to mark the "
-"time when Diablo would rise again from his imprisonment. When the two stars "
-"on that map align, Diablo will be at the height of his power. He will be all "
-"but invincible...\n"
+"The evil that you move against is the dark Lord of Terror - known to mortal men as "
+"Diablo. It was he who was imprisoned within the Labyrinth many centuries ago. The "
+"Map that you hold now was created ages ago to mark the time when Diablo would rise "
+"again from his imprisonment. When the two stars on that map align, Diablo will be "
+"at the height of his power. He will be all but invincible...\n"
 " \n"
-"You are now in a race against time, my friend! Find Diablo and destroy him "
-"before the stars align, for we may never have a chance to rid the world of "
-"his evil again! |"
+"You are now in a race against time, my friend! Find Diablo and destroy him before "
+"the stars align, for we may never have a chance to rid the world of his evil "
+"again! |"
 msgstr ""
-"Quindi la leggenda della mappa è vera. Non credevo esistesse veramente! "
-"Penso sia il tempo che ti riveli chi sono, amico mio. Vedi, non sono quello "
-"che sembro...\n"
+"Quindi la leggenda della mappa è vera. Non credevo esistesse veramente! Penso sia "
+"il tempo che ti riveli chi sono, amico mio. Vedi, non sono quello che sembro...\n"
 " \n"
-"Il mio vero nome è Deckard Cain il Saggio, l'ultimo discendente di una "
-"antica Fratellanza che ha il compito di custodire i segreti di un male senza "
-"tempo. Un male che a quanto pare è riuscito a liberarsi...\n"
+"Il mio vero nome è Deckard Cain il Saggio, l'ultimo discendente di una antica "
+"Fratellanza che ha il compito di custodire i segreti di un male senza tempo. Un "
+"male che a quanto pare è riuscito a liberarsi...\n"
 " \n"
-"Sappi solo che il male contro cui ti batterai è l'Oscuro Signore del Terrore "
-"- conosciuto fra i mortali col nome di Diablo. Fu lui che venne imprigionato "
-"nel Labirinto molti secoli fa. La Mappa che ti porti appresso fu creata "
-"molti anni fa per indicare il tempo in cui Diablo sarebbe risorto dalla sua "
-"prigionia. Quando le due stelle si allineeranno, Diablo giungerà al massimo "
-"del suo potere. E potrebbe diventare invincibile...\n"
+"Sappi solo che il male contro cui ti batterai è l'Oscuro Signore del Terrore - "
+"conosciuto fra i mortali col nome di Diablo. Fu lui che venne imprigionato nel "
+"Labirinto molti secoli fa. La Mappa che ti porti appresso fu creata molti anni fa "
+"per indicare il tempo in cui Diablo sarebbe risorto dalla sua prigionia. Quando le "
+"due stelle si allineeranno, Diablo giungerà al massimo del suo potere. E potrebbe "
+"diventare invincibile...\n"
 " \n"
-"Ora sei in corsa contro il tempo, amico mio! Trova Diablo e distruggilo "
-"prima dell'allineamento, forse non avrai altre possibilità di liberare di "
-"nuovo il mondo dal male! |"
+"Ora sei in corsa contro il tempo, amico mio! Trova Diablo e distruggilo prima "
+"dell'allineamento, forse non avrai altre possibilità di liberare di nuovo il mondo "
+"dal male! |"
 
 #: Source/textdat.cpp:279
 msgid ""
-"Our time is running short! I sense his dark power building and only you can "
-"stop him from attaining his full might. |"
+"Our time is running short! I sense his dark power building and only you can stop "
+"him from attaining his full might. |"
 msgstr ""
-"Il tempo stringe! Sento crescere la sua Energia Oscura e solo tu puoi "
-"fermarlo dal raggiungere la sua piena potenza. |"
+"Il tempo stringe! Sento crescere la sua Energia Oscura e solo tu puoi fermarlo dal "
+"raggiungere la sua piena potenza. |"
 
 #: Source/textdat.cpp:281
 msgid ""
-"I am sure that you tried your best, but I fear that even your strength and "
-"will may not be enough. Diablo is now at the height of his earthly power, "
-"and you will need all your courage and strength to defeat him. May the Light "
-"protect and guide you, my friend. I will help in any way that I am able. |"
+"I am sure that you tried your best, but I fear that even your strength and will "
+"may not be enough. Diablo is now at the height of his earthly power, and you will "
+"need all your courage and strength to defeat him. May the Light protect and guide "
+"you, my friend. I will help in any way that I am able. |"
 msgstr ""
 "Sono sicuro che farai del tuo meglio, ma temo che nemmeno la tua forza potrà "
-"bastare. Diablo ora è al massimo del suo potere, e tu avrai bisogno di tutto "
-"il tuo coraggio e della tua forza per sconfiggerlo. Che possa la luce "
-"guidarti e proteggerti, amico mio. Io farò quel che posso per aiutarti. |"
+"bastare. Diablo ora è al massimo del suo potere, e tu avrai bisogno di tutto il "
+"tuo coraggio e della tua forza per sconfiggerlo. Che possa la luce guidarti e "
+"proteggerti, amico mio. Io farò quel che posso per aiutarti. |"
 
 #: Source/textdat.cpp:283
 msgid ""
-"If the witch can't help you and suggests you see Cain, what makes you think "
-"that I would know anything? It sounds like this is a very serious matter. "
-"You should hurry along and see the storyteller as Adria suggests. |"
+"If the witch can't help you and suggests you see Cain, what makes you think that I "
+"would know anything? It sounds like this is a very serious matter. You should "
+"hurry along and see the storyteller as Adria suggests. |"
 msgstr ""
 "Se la strega non ti ha aiutato e ti ha suggerito di vedere Cain, cosa ti fa "
-"pensare che io possa farlo? Questa, sembra una questione molto seria. Ti "
-"dovresti sbrigare, e dovresti consultare Cain come ha detto Adria. |"
+"pensare che io possa farlo? Questa, sembra una questione molto seria. Ti dovresti "
+"sbrigare, e dovresti consultare Cain come ha detto Adria. |"
 
 #: Source/textdat.cpp:285
 msgid ""
-"I can't make much of the writing on this map, but perhaps Adria or Cain "
-"could help you decipher what this refers to. \n"
+"I can't make much of the writing on this map, but perhaps Adria or Cain could help "
+"you decipher what this refers to. \n"
 " \n"
-"I can see that it is a map of the stars in our sky, but any more than that "
-"is beyond my talents. |"
+"I can see that it is a map of the stars in our sky, but any more than that is "
+"beyond my talents. |"
 msgstr ""
-"Non so dirti molto su questa mappa, ma forse Adria o Cain potrebbero "
-"aiutarti a decifrarla, e a capire che cosa essa rappresenti realmente. \n"
+"Non so dirti molto su questa mappa, ma forse Adria o Cain potrebbero aiutarti a "
+"decifrarla, e a capire che cosa essa rappresenti realmente. \n"
 " \n"
 "Io posso solo dirti che illustra le stelle del nostro cielo, altro non so. |"
 
@@ -8157,8 +8053,8 @@ msgstr ""
 msgid ""
 "The best person to ask about that sort of thing would be our storyteller. \n"
 " \n"
-"Cain is very knowledgeable about ancient writings, and that is easily the "
-"oldest looking piece of paper that I have ever seen. |"
+"Cain is very knowledgeable about ancient writings, and that is easily the oldest "
+"looking piece of paper that I have ever seen. |"
 msgstr ""
 "Faresti meglio a chiedere questo genere di cose al Narratore. \n"
 " \n"
@@ -8167,52 +8063,49 @@ msgstr ""
 
 #: Source/textdat.cpp:289
 msgid ""
-"I have never seen a map of this sort before. Where'd you get it? Although I "
-"have no idea how to read this, Cain or Adria may be able to provide the "
-"answers that you seek. |"
+"I have never seen a map of this sort before. Where'd you get it? Although I have "
+"no idea how to read this, Cain or Adria may be able to provide the answers that "
+"you seek. |"
 msgstr ""
-"Non ho mai visto prima d'ora una mappa di questo tipo. Dove l'hai trovata? "
-"Non ho idea di come si legga, ma penso che Cain o Adria potrebbero essere in "
-"grado di farlo. |"
+"Non ho mai visto prima d'ora una mappa di questo tipo. Dove l'hai trovata? Non ho "
+"idea di come si legga, ma penso che Cain o Adria potrebbero essere in grado di "
+"farlo. |"
 
 #: Source/textdat.cpp:291
 msgid ""
-"Listen here, come close. I don't know if you know what I know, but you have "
-"really got somethin' here. That's a map. |"
+"Listen here, come close. I don't know if you know what I know, but you have really "
+"got somethin' here. That's a map. |"
 msgstr ""
-"Ascolta, vieni qui. Io non so se tu sai quello che so, ma hai trovato "
-"davvero qualcosa. Quella è una mappa! |"
+"Ascolta, vieni qui. Io non so se tu sai quello che so, ma hai trovato davvero "
+"qualcosa. Quella è una mappa! |"
 
 #: Source/textdat.cpp:293
 msgid ""
-"Oh, I'm afraid this does not bode well at all. This map of the stars "
-"portends great disaster, but its secrets are not mine to tell. The time has "
-"come for you to have a very serious conversation with the Storyteller... |"
+"Oh, I'm afraid this does not bode well at all. This map of the stars portends "
+"great disaster, but its secrets are not mine to tell. The time has come for you to "
+"have a very serious conversation with the Storyteller... |"
 msgstr ""
-"Oh, non è un buon segno. Questa mappa delle stelle predice un grande "
-"disastro, ma non tocca me rivelarti i suoi segreti. È giunto il momento per "
-"te di fare una conversazione molto seria col Narratore... |"
+"Oh, non è un buon segno. Questa mappa delle stelle predice un grande disastro, ma "
+"non tocca me rivelarti i suoi segreti. È giunto il momento per te di fare una "
+"conversazione molto seria col Narratore... |"
 
 #: Source/textdat.cpp:295
 msgid ""
-"I've been looking for a map, but that certainly isn't it. You should show "
-"that to Adria - she can probably tell you what it is. I'll say one thing; it "
-"looks old, and old usually means valuable. |"
+"I've been looking for a map, but that certainly isn't it. You should show that to "
+"Adria - she can probably tell you what it is. I'll say one thing; it looks old, "
+"and old usually means valuable. |"
 msgstr ""
-"Sto cercando una mappa, ma certamente non è quella. Dovresti mostrarla ad "
-"Adria - lei probabilmente può dirti cos'è. Ti dirò una cosa; sembra antica, "
-"e di solito antico vuol dire prezioso! |"
+"Sto cercando una mappa, ma certamente non è quella. Dovresti mostrarla ad Adria - "
+"lei probabilmente può dirti cos'è. Ti dirò una cosa; sembra antica, e di solito "
+"antico vuol dire prezioso! |"
 
 #: Source/textdat.cpp:297
-msgid ""
-"Pleeeease, no hurt. No Kill. Keep alive and next time good bring to you. |"
-msgstr ""
-"Per favoreeee, no male. No uccidere. Prossima volta fare bel dono per te. |"
+msgid "Pleeeease, no hurt. No Kill. Keep alive and next time good bring to you. |"
+msgstr "Per favoreeee, no male. No uccidere. Prossima volta fare bel dono per te. |"
 
 #: Source/textdat.cpp:299
 msgid ""
-"Something for you I am making. Again, not kill Gharbad. Live and give "
-"good. \n"
+"Something for you I am making. Again, not kill Gharbad. Live and give good. \n"
 " \n"
 "You take this as proof I keep word... |"
 msgstr ""
@@ -8240,11 +8133,11 @@ msgstr "Questo troppo per te. Molto Potente! Se vuoi - tu prendere! |"
 
 #: Source/textdat.cpp:305
 msgid ""
-"What?! Why are you here? All these interruptions are enough to make one "
-"insane. Here, take this and leave me to my work. Trouble me no more! |"
+"What?! Why are you here? All these interruptions are enough to make one insane. "
+"Here, take this and leave me to my work. Trouble me no more! |"
 msgstr ""
-"Cosa? Perché sei qui? Tutte queste interruzioni mi faranno impazzire. Ecco, "
-"prendi questo e lasciami lavorare. E non disturbarmi più! |"
+"Cosa? Perché sei qui? Tutte queste interruzioni mi faranno impazzire. Ecco, prendi "
+"questo e lasciami lavorare. E non disturbarmi più! |"
 
 #: Source/textdat.cpp:307
 msgid "Arrrrgh! Your curiosity will be the death of you!!! |"
@@ -8252,223 +8145,213 @@ msgstr "Arrrrgh! La tua curiosità ti porterà alla morte!!! |"
 
 #: Source/textdat.cpp:308
 msgid "Hello, my friend. Stay awhile and listen... |"
-msgstr "Ciao, amico mio. Resta un po' e ascolta... |"
+msgstr "Ciao, amico mio. Resta un pò e ascolta... |"
 
 #: Source/textdat.cpp:309
 msgid ""
-"While you are venturing deeper into the Labyrinth you may find tomes of "
-"great knowledge hidden there. \n"
+"While you are venturing deeper into the Labyrinth you may find tomes of great "
+"knowledge hidden there. \n"
 " \n"
 "Read them carefully for they can tell you things that even I cannot. |"
 msgstr ""
-"Mentre ti avventuri sempre più nel Labirinto potresti trovare dei Tomi di "
-"grande conoscenza. \n"
+"Mentre ti avventuri sempre più nel Labirinto potresti trovare dei Tomi di grande "
+"conoscenza. \n"
 " \n"
-"Leggili attentamente perché' possono dirti cose che nemmeno io so. |"
+"Leggili attentamente perché possono dirti cose che nemmeno io so. |"
 
 #: Source/textdat.cpp:311
 msgid ""
-"I know of many myths and legends that may contain answers to questions that "
-"may arise in your journeys into the Labyrinth. If you come across challenges "
-"and questions to which you seek knowledge, seek me out and I will tell you "
-"what I can. |"
+"I know of many myths and legends that may contain answers to questions that may "
+"arise in your journeys into the Labyrinth. If you come across challenges and "
+"questions to which you seek knowledge, seek me out and I will tell you what I can. "
+"|"
 msgstr ""
-"Conosco molti miti e leggende che possono contenere risposte a domande che "
-"ti farai durante i tuoi viaggi nel Labirinto. Se ti imbatti in qualche sfida "
-"o domanda della quale ti serve una risposta, chiedimelo e io ti dirò quello "
-"che posso. |"
+"Conosco molti miti e leggende che possono contenere risposte a domande che ti "
+"farai durante i tuoi viaggi nel Labirinto. Se ti imbatti in qualche sfida o "
+"domanda della quale ti serve una risposta, chiedimelo e io ti dirò quello che "
+"posso. |"
 
 #: Source/textdat.cpp:313
 msgid ""
-"Griswold - a man of great action and great courage. I bet he never told you "
-"about the time he went into the Labyrinth to save Wirt, did he? He knows his "
-"fair share of the dangers to be found there, but then again - so do you. He "
-"is a skilled craftsman, and if he claims to be able to help you in any way, "
-"you can count on his honesty and his skill. |"
+"Griswold - a man of great action and great courage. I bet he never told you about "
+"the time he went into the Labyrinth to save Wirt, did he? He knows his fair share "
+"of the dangers to be found there, but then again - so do you. He is a skilled "
+"craftsman, and if he claims to be able to help you in any way, you can count on "
+"his honesty and his skill. |"
 msgstr ""
-"Griswold? È un uomo d'azione e di grande coraggio. Scommetto che non ti ha "
-"raccontato di quando lui è andato nel Labirinto per salvare Wirt, Vero? "
-"Sapeva a quali pericoli andava in contro, andando là, e ora anche tu... fai "
-"lo stesso. Lui è un artigiano specializzato, e se dice di poterti aiutare, "
-"conta pure sulla sua abilità e la sua onestà. |"
+"Griswold? è un uomo d'azione e di grande coraggio. Scommetto che non ti ha "
+"raccontato di quando lui è andato nel Labirinto per salvare Wirt, Vero? Sapeva a "
+"quali pericoli andava in contro, andando là, e ora anche tu... fai lo stesso. Lui "
+"è un artigiano specializzato, e se dice di poterti aiutare, conta pure sulla sua "
+"abilità e la sua onestà. |"
 
 #: Source/textdat.cpp:315
 msgid ""
-"Ogden has owned and run the Rising Sun Inn and Tavern for almost four years "
-"now. He purchased it just a few short months before everything here went to "
-"hell. He and his wife Garda do not have the money to leave as they invested "
-"all they had in making a life for themselves here. He is a good man with a "
-"deep sense of responsibility. |"
+"Ogden has owned and run the Rising Sun Inn and Tavern for almost four years now. "
+"He purchased it just a few short months before everything here went to hell. He "
+"and his wife Garda do not have the money to leave as they invested all they had in "
+"making a life for themselves here. He is a good man with a deep sense of "
+"responsibility. |"
 msgstr ""
-"Ogden ha comprato e gestisce la Locanda del Sol Levante da quasi quattro "
-"anni. La comprò alcuni mesi prima che le cose qui diventassero un inferno. "
-"Lui e sua moglie Garda non hanno i soldi per andarsene perché' hanno "
-"investito tutti i loro averi per farsi una vita qui. È un brav'uomo e con un "
-"profondo senso di responsabilità. |"
+"Ogden ha comprato e gestisce la Locanda del Sol Levante da quasi quattro anni. La "
+"comprò alcuni mesi prima che le cose qui diventassero un inferno. Lui e sua moglie "
+"Garda non hanno i soldi per andarsene perché hanno investito tutti i loro averi "
+"per farsi una vita qui. È un brav'uomo e con un profondo senso di responsabilità. |"
 
 #: Source/textdat.cpp:317
 msgid ""
-"Poor Farnham. He is a disquieting reminder of the doomed assembly that "
-"entered into the Cathedral with Lazarus on that dark day. He escaped with "
-"his life, but his courage and much of his sanity were left in some dark pit. "
-"He finds comfort only at the bottom of his tankard nowadays, but there are "
-"occasional bits of truth buried within his constant ramblings. |"
+"Poor Farnham. He is a disquieting reminder of the doomed assembly that entered "
+"into the Cathedral with Lazarus on that dark day. He escaped with his life, but "
+"his courage and much of his sanity were left in some dark pit. He finds comfort "
+"only at the bottom of his tankard nowadays, but there are occasional bits of truth "
+"buried within his constant ramblings. |"
 msgstr ""
-"Povero Farnham. Lui è un inquietante promemoria del gruppo condannato ad "
-"entrare nella Cattedrale con Lazarus, in quel nero giorno. Riusci' a "
-"salvarsi, ma il suo coraggio e la sua sanità mentale rimasero laggiù "
-"nell'oscurità. Oggi trova conforto solo sul fondo del suo boccale, ma a "
-"volte si distinguono brandelli di verità nel suo vaneggiare. |"
+"Povero Farnham. Lui è un inquietante promemoria del gruppo condannato ad entrare "
+"nella Cattedrale con Lazarus, in quel nero giorno. Riuscì a salvarsi, ma il suo "
+"coraggio e la sua sanità mentale rimasero laggiù nell'oscurità. Oggi trova "
+"conforto solo sul fondo del suo boccale, ma a volte si distinguono brandelli di "
+"verità nel suo vaneggiare. |"
 
 #: Source/textdat.cpp:319
 msgid ""
-"The witch, Adria, is an anomaly here in Tristram. She arrived shortly after "
-"the Cathedral was desecrated while most everyone else was fleeing. She had a "
-"small hut constructed at the edge of town, seemingly overnight, and has "
-"access to many strange and arcane artifacts and tomes of knowledge that even "
-"I have never seen before. |"
+"The witch, Adria, is an anomaly here in Tristram. She arrived shortly after the "
+"Cathedral was desecrated while most everyone else was fleeing. She had a small hut "
+"constructed at the edge of town, seemingly overnight, and has access to many "
+"strange and arcane artifacts and tomes of knowledge that even I have never seen "
+"before. |"
 msgstr ""
-"La strega, Adria, è un'anomalia qui a Tristram. Giunse poco dopo che la "
-"Cattedrale venne sconsacrata, mentre molti di noi se ne stava andando. "
-"Costruì, a quanto pare in una notte una piccola capanna ai limiti della "
-"città e ha accesso a strani e arcani manufatti e tomi di conoscenza, che "
-"nemmeno io avevo mai visto prima. |"
+"La strega, Adria, è un'anomalia qui a Tristram. Giunse poco dopo che la Cattedrale "
+"venne sconsacrata, mentre molti di noi se ne stava andando. Costruì, a quanto pare "
+"in una notte una piccola capanna ai limiti della città e ha accesso a strani e "
+"arcani manufatti e tomi di conoscenza, che nemmeno io avevo mai visto prima. |"
 
 #: Source/textdat.cpp:321
 msgid ""
-"The story of Wirt is a frightening and tragic one. He was taken from the "
-"arms of his mother and dragged into the labyrinth by the small, foul demons "
-"that wield wicked spears. There were many other children taken that day, "
-"including the son of King Leoric. The Knights of the palace went below, but "
-"never returned. The Blacksmith found the boy, but only after the foul beasts "
-"had begun to torture him for their sadistic pleasures. |"
+"The story of Wirt is a frightening and tragic one. He was taken from the arms of "
+"his mother and dragged into the labyrinth by the small, foul demons that wield "
+"wicked spears. There were many other children taken that day, including the son of "
+"King Leoric. The Knights of the palace went below, but never returned. The "
+"Blacksmith found the boy, but only after the foul beasts had begun to torture him "
+"for their sadistic pleasures. |"
 msgstr ""
-"Quella di Wirt è una storia tanto spaventosa quanto tragica. Venne rapito "
-"alla madre e trascinato nel Labirinto, lasciato preda di piccoli e orribili "
-"demoni. Furono presi molti altri bambini quel giorno, incluso il figlio di "
-"Re Leoric. I cavalieri del palazzo andarono la sotto, ma non ritornarono "
-"mai. Fu il Fabbro a ritrovare il ragazzo, ma solo dopo che le bestie avevano "
-"incominciato a torturarlo per i loro sadici piaceri. |"
+"Quella di Wirt è una storia tanto spaventosa quanto tragica. Venne rapito alla "
+"madre e trascinato nel Labirinto, lasciato preda di piccoli e orribili demoni. "
+"Furono presi molti altri bambini quel giorno, incluso il figlio di Re Leoric. I "
+"cavalieri del palazzo andarono la sotto, ma non ritornarono mai. Fu il Fabbro a "
+"ritrovare il ragazzo, ma solo dopo che le bestie avevano incominciato a torturarlo "
+"per i loro sadici piaceri. |"
 
 #: Source/textdat.cpp:323
 msgid ""
-"Ah, Pepin. I count him as a true friend - perhaps the closest I have here. "
-"He is a bit addled at times, but never a more caring or considerate soul has "
-"existed. His knowledge and skills are equaled by few, and his door is always "
-"open. |"
+"Ah, Pepin. I count him as a true friend - perhaps the closest I have here. He is a "
+"bit addled at times, but never a more caring or considerate soul has existed. His "
+"knowledge and skills are equaled by few, and his door is always open. |"
 msgstr ""
-"Ah, Pepin. Lui per me è un vero amico, forse il migliore che ho. A volte è "
-"un po' confuso, ma non esiste nessuno con un animo così premuroso. Pochi "
-"eguagliano la sua conoscenza e le sue abilità, e la sua porta è sempre "
-"aperta. |"
+"Ah, Pepin. Lui per me è un vero amico, forse il migliore che ho. A volte è un pò "
+"confuso, ma non esiste nessuno con un animo così premuroso. Pochi eguagliano la "
+"sua conoscenza e le sue abilità, e la sua porta è sempre aperta. |"
 
 #: Source/textdat.cpp:325
 msgid ""
-"Gillian is a fine woman. Much adored for her high spirits and her quick "
-"laugh, she holds a special place in my heart. She stays on at the tavern to "
-"support her elderly grandmother who is too sick to travel. I sometimes fear "
-"for her safety, but I know that any man in the village would rather die than "
-"see her harmed. |"
+"Gillian is a fine woman. Much adored for her high spirits and her quick laugh, she "
+"holds a special place in my heart. She stays on at the tavern to support her "
+"elderly grandmother who is too sick to travel. I sometimes fear for her safety, "
+"but I know that any man in the village would rather die than see her harmed. |"
 msgstr ""
-"Gillian è una bella donna. Molto amata per il suo spirito e la risata "
-"facile, ha un posto speciale nel mio cuore. Lavora alla taverna per aiutare "
-"sua nonna, che è troppo malata per viaggiare. A volte temo per la sua "
-"sicurezza, ma so che ogni uomo del villaggio morirebbe piuttosto che vederla "
-"ferita. |"
+"Gillian è una bella donna. Molto amata per il suo spirito e la risata facile, ha "
+"un posto speciale nel mio cuore. Lavora alla taverna per aiutare sua nonna, che è "
+"troppo malata per viaggiare. A volte temo per la sua sicurezza, ma so che ogni "
+"uomo del villaggio morirebbe piuttosto che vederla ferita. |"
 
 #: Source/textdat.cpp:327
 msgid "Greetings, good master. Welcome to the Tavern of the Rising Sun! |"
-msgstr "Salve, Signore. Benvenuto alla Taverna del Sol Levante! |"
+msgstr "Salve, signore. Benvenuto alla Taverna del Sol Levante! |"
 
 #: Source/textdat.cpp:329
 msgid ""
 "Many adventurers have graced the tables of my tavern, and ten times as many "
-"stories have been told over as much ale. The only thing that I ever heard "
-"any of them agree on was this old axiom. Perhaps it will help you. You can "
-"cut the flesh, but you must crush the bone. |"
+"stories have been told over as much ale. The only thing that I ever heard any of "
+"them agree on was this old axiom. Perhaps it will help you. You can cut the flesh, "
+"but you must crush the bone. |"
 msgstr ""
 "Molti avventurieri hanno onorato le tavole della mia taverna, e le storie "
-"raccontate sono state dieci volte la birra consumata. L'unica cosa su cui "
-"tutti erano d'accordo era questo vecchio assioma. Forse ti aiuterà. Puoi "
-"tagliare la carne, ma devi spezzare le ossa. |"
+"raccontate sono state dieci volte la birra consumata. L'unica cosa su cui tutti "
+"erano d'accordo era questo vecchio assioma. Forse ti aiuterà. Puoi tagliare la "
+"carne, ma devi spezzare le ossa. |"
 
 #: Source/textdat.cpp:331
 msgid ""
-"Griswold the blacksmith is extremely knowledgeable about weapons and armor. "
-"If you ever need work done on your gear, he is definitely the man to see. |"
+"Griswold the blacksmith is extremely knowledgeable about weapons and armor. If you "
+"ever need work done on your gear, he is definitely the man to see. |"
 msgstr ""
-"Griswold il fabbro è bene informato su armi e armature. Se hai bisogno di "
-"fare modifiche al tuo equipaggiamento, lui è di sicuro l'uomo che cerchi. |"
+"Griswold il fabbro è bene informato su armi e armature. Se hai bisogno di fare "
+"modifiche al tuo equipaggiamento, lui è di sicuro l'uomo che cerchi. |"
 
 #: Source/textdat.cpp:333
 msgid ""
-"Farnham spends far too much time here, drowning his sorrows in cheap ale. I "
-"would make him leave, but he did suffer so during his time in the Labyrinth. "
-"|"
+"Farnham spends far too much time here, drowning his sorrows in cheap ale. I would "
+"make him leave, but he did suffer so during his time in the Labyrinth. |"
 msgstr ""
 "Farnham passa fin troppo tempo qui, affogando i suoi dolori con birra da due "
 "soldi. Io lo manderei via, ma ha sofferto troppo mentre era nel Labirinto. |"
 
 #: Source/textdat.cpp:335
 msgid ""
-"Adria is wise beyond her years, but I must admit - she frightens me a "
-"little. \n"
+"Adria is wise beyond her years, but I must admit - she frightens me a little. \n"
 " \n"
-"Well, no matter. If you ever have need to trade in items of sorcery, she "
-"maintains a strangely well-stocked hut just across the river. |"
+"Well, no matter. If you ever have need to trade in items of sorcery, she maintains "
+"a strangely well-stocked hut just across the river. |"
 msgstr ""
-"Adria è molto saggia per la sua età, ma devo ammettere che mi spaventa un "
-"po'. \n"
+"Adria è molto saggia per la sua età, ma devo ammettere che mi spaventa un po'. \n"
 " \n"
-"Beh, non importa. Se hai bisogno di trattare articoli magici, lei possiede "
-"una capanna stranamente ben fornita al di la del fiume. |"
+"Beh, non importa. Se hai bisogno di trattare articoli magici, lei possiede una "
+"capanna stranamente ben fornita al di là del fiume. |"
 
 #: Source/textdat.cpp:337
 msgid ""
-"If you want to know more about the history of our village, the storyteller "
-"Cain knows quite a bit about the past. |"
+"If you want to know more about the history of our village, the storyteller Cain "
+"knows quite a bit about the past. |"
 msgstr ""
-"Se vuoi saperne di più sulla storia del nostro villaggio, Cain il Narratore "
-"sa un bel po' di cose sul passato. |"
+"Se vuoi saperne di più sulla storia del nostro villaggio, Cain il Narratore sa un "
+"bel pò di cose sul passato. |"
 
 #: Source/textdat.cpp:339
 msgid ""
-"Wirt is a rapscallion and a little scoundrel. He was always getting into "
-"trouble, and it's no surprise what happened to him. \n"
+"Wirt is a rapscallion and a little scoundrel. He was always getting into trouble, "
+"and it's no surprise what happened to him. \n"
 " \n"
-"He probably went fooling about someplace that he shouldn't have been. I feel "
-"sorry for the boy, but I don't abide the company that he keeps. |"
+"He probably went fooling about someplace that he shouldn't have been. I feel sorry "
+"for the boy, but I don't abide the company that he keeps. |"
 msgstr ""
 "Wirt è un furfante e un piccolo farabutto. Si mette sempre nei guai, non fui "
 "sorpreso per quello che gli accadde. \n"
 " \n"
-"Probabilmente si aggirava in qualche posto dove non sarebbe mai dovuto "
-"andare. Mi dispiace per il ragazzo, ma non sopporto le compagnie che "
-"frequenta. |"
+"Probabilmente si aggirava in qualche posto dove non sarebbe mai dovuto andare. Mi "
+"dispiace per il ragazzo, ma non sopporto le compagnie che frequenta. |"
 
 #: Source/textdat.cpp:341
 msgid ""
-"Pepin is a good man - and certainly the most generous in the village. He is "
-"always attending to the needs of others, but trouble of some sort or another "
-"does seem to follow him wherever he goes... |"
+"Pepin is a good man - and certainly the most generous in the village. He is always "
+"attending to the needs of others, but trouble of some sort or another does seem to "
+"follow him wherever he goes... |"
 msgstr ""
-"Pepin è una brava persona - certamente il più generoso del villaggio. Cerca "
-"sempre di prestare attenzione ai bisogni degli altri, ma problemi di ogni "
-"sorta sembrano seguirlo ovunque lui vada... |"
+"Pepin è una brava persona - certamente il più generoso del villaggio. Cerca sempre "
+"di prestare attenzione ai bisogni degli altri, ma problemi di ogni sorta sembrano "
+"seguirlo ovunque lui vada... |"
 
 #: Source/textdat.cpp:343
 msgid ""
-"Gillian, my Barmaid? If it were not for her sense of duty to her grand-dam, "
-"she would have fled from here long ago. \n"
+"Gillian, my Barmaid? If it were not for her sense of duty to her grand-dam, she "
+"would have fled from here long ago. \n"
 " \n"
-"Goodness knows I begged her to leave, telling her that I would watch after "
-"the old woman, but she is too sweet and caring to have done so. |"
+"Goodness knows I begged her to leave, telling her that I would watch after the old "
+"woman, but she is too sweet and caring to have done so. |"
 msgstr ""
-"Gillian, la mia cameriera? Sarebbe fuggita da qui tempo fa, se non fosse per "
-"la sua riconoscenza verso la nonna. \n"
+"Gillian, la mia cameriera? Sarebbe fuggita da qui tempo fa, se non fosse per la "
+"sua riconoscenza verso la nonna. \n"
 " \n"
-"Dio sa se non l'ho implorata di andar via, dicendole che avrei pensato io a "
-"lei, ma è troppo dolce e premurosa, per comportarsi così. |"
+"Dio sa se non l'ho implorata di andar via, dicendole che avrei pensato io a lei, "
+"ma è troppo dolce e premurosa, per comportarsi così. |"
 
 #: Source/textdat.cpp:345
 msgid "What ails you, my friend? |"
@@ -8477,104 +8360,96 @@ msgstr "Come ti senti, amico mio? |"
 #: Source/textdat.cpp:346
 msgid ""
 "I have made a very interesting discovery. Unlike us, the creatures in the "
-"Labyrinth can heal themselves without the aid of potions or magic. If you "
-"hurt one of the monsters, make sure it is dead or it very well may "
-"regenerate itself. |"
+"Labyrinth can heal themselves without the aid of potions or magic. If you hurt one "
+"of the monsters, make sure it is dead or it very well may regenerate itself. |"
 msgstr ""
-"Ho fatto una scoperta molto interessante. Diversamente da noi, le creature "
-"nel Labirinto possono guarirsi senza l'aiuto di pozioni o magie. Se tu "
-"ferissi uno di quei mostri, assicurati che sia morto, perché' potrebbe "
-"rigenerarsi. |"
+"Ho fatto una scoperta molto interessante. Diversamente da noi, le creature nel "
+"Labirinto possono guarirsi senza l'aiuto di pozioni o magie. Se tu ferissi uno di "
+"quei mostri, assicurati che sia morto, perché potrebbe rigenerarsi. |"
 
 #: Source/textdat.cpp:348
 msgid ""
-"Before it was taken over by, well, whatever lurks below, the Cathedral was a "
-"place of great learning. There are many books to be found there. If you find "
-"any, you should read them all, for some may hold secrets to the workings of "
-"the Labyrinth. |"
+"Before it was taken over by, well, whatever lurks below, the Cathedral was a place "
+"of great learning. There are many books to be found there. If you find any, you "
+"should read them all, for some may hold secrets to the workings of the Labyrinth. |"
 msgstr ""
-"Prima di essere presa da qualunque cosa si celi lì sotto, la Cattedrale era "
-"un luogo di cultura. Potresti scoprire molti libri nella tua cerca. Leggili "
-"tutti, alcuni potrebbero contenere segreti di quello che sta succedendo nel "
-"Labirinto. |"
+"Prima di essere presa da qualunque cosa si celi lì sotto, la Cattedrale era un "
+"luogo di cultura. Potresti scoprire molti libri nella tua cerca. Leggili tutti, "
+"alcuni potrebbero contenere segreti di quello che sta succedendo nel Labirinto. |"
 
 #: Source/textdat.cpp:350
 msgid ""
-"Griswold knows as much about the art of war as I do about the art of "
-"healing. He is a shrewd merchant, but his work is second to none. Oh, I "
-"suppose that may be because he is the only blacksmith left here. |"
+"Griswold knows as much about the art of war as I do about the art of healing. He "
+"is a shrewd merchant, but his work is second to none. Oh, I suppose that may be "
+"because he is the only blacksmith left here. |"
 msgstr ""
-"Griswold conosce tanto dell'arte della guerra quanto io dell'arte curativa. "
-"È un mercante astuto, ma il suo lavoro non ha rivali. Oh, penso che potrebbe "
-"essere perché' è l'unico fabbro rimasto qui. |"
+"Griswold conosce tanto dell'arte della guerra quanto io dell'arte curativa. È un "
+"mercante astuto, ma il suo lavoro non ha rivali. Oh, penso che potrebbe essere "
+"perché è l'unico fabbro rimasto qui. |"
 
 #: Source/textdat.cpp:352
 msgid ""
-"Cain is a true friend and a wise sage. He maintains a vast library and has "
-"an innate ability to discern the true nature of many things. If you ever "
-"have any questions, he is the person to go to. |"
+"Cain is a true friend and a wise sage. He maintains a vast library and has an "
+"innate ability to discern the true nature of many things. If you ever have any "
+"questions, he is the person to go to. |"
 msgstr ""
 "Cain è un vero amico ed un saggio avveduto. Possiede una vasta biblioteca e "
-"l'abilità di discernere la vera natura di molte cose. Se avessi mai una "
-"domanda, lui è la persona a cui rivolgersi. |"
+"l'abilità di discernere la vera natura di molte cose. Se avessi mai una domanda, "
+"lui è la persona a cui rivolgersi. |"
 
 #: Source/textdat.cpp:354
 msgid ""
-"Even my skills have been unable to fully heal Farnham. Oh, I have been able "
-"to mend his body, but his mind and spirit are beyond anything I can do. |"
+"Even my skills have been unable to fully heal Farnham. Oh, I have been able to "
+"mend his body, but his mind and spirit are beyond anything I can do. |"
 msgstr ""
-"Persino le mie abilità sono state incapaci di guarire pienamente Farnham. "
-"Curai il suo corpo, ma mente e spirito sono aldilà delle mie capacità. |"
+"Persino le mie abilità sono state incapaci di guarire pienamente Farnham. Curai il "
+"suo corpo, ma mente e spirito sono aldilà delle mie capacità. |"
 
 #: Source/textdat.cpp:356
 msgid ""
-"While I use some limited forms of magic to create the potions and elixirs I "
-"store here, Adria is a true sorceress. She never seems to sleep, and she "
-"always has access to many mystic tomes and artifacts. I believe her hut may "
-"be much more than the hovel it appears to be, but I can never seem to get "
-"inside the place. |"
+"While I use some limited forms of magic to create the potions and elixirs I store "
+"here, Adria is a true sorceress. She never seems to sleep, and she always has "
+"access to many mystic tomes and artifacts. I believe her hut may be much more than "
+"the hovel it appears to be, but I can never seem to get inside the place. |"
 msgstr ""
-"Anche se uso alcune forme limitate di magia per creare le pozioni che tengo "
-"qui, Adria è una vera incantatrice. Non sembra dormire mai, e ha sempre "
-"accesso a molti artefatti e tomi mistici. Credo che la sua capanna sia molto "
-"più del tugurio a cui assomiglia, ma non sono mai riuscito ad entrarvi. |"
+"Anche se uso alcune forme limitate di magia per creare le pozioni che tengo qui, "
+"Adria è una vera incantatrice. Non sembra dormire mai, e ha sempre accesso a molti "
+"artefatti e tomi mistici. Credo che la sua capanna sia molto più del tugurio a cui "
+"assomiglia, ma non sono mai riuscito ad entrarvi. |"
 
 #: Source/textdat.cpp:358
 msgid ""
-"Poor Wirt. I did all that was possible for the child, but I know he despises "
-"that wooden peg that I was forced to attach to his leg. His wounds were "
-"hideous. No one - and especially such a young child - should have to suffer "
-"the way he did. |"
+"Poor Wirt. I did all that was possible for the child, but I know he despises that "
+"wooden peg that I was forced to attach to his leg. His wounds were hideous. No one "
+"- and especially such a young child - should have to suffer the way he did. |"
 msgstr ""
-"Povero Wirt. Feci tutto il possibile per il ragazzo, ma so che lui disprezza "
-"quel piolo di legno che sono stato costretto ad attaccagli alla gamba. Le "
-"sue ferite erano orrende, nessuno dovrebbe soffrire cosi', tanto meno un "
-"ragazzo giovane. |"
+"Povero Wirt. Feci tutto il possibile per il ragazzo, ma so che lui disprezza quel "
+"piolo di legno che sono stato costretto ad attaccagli alla gamba. Le sue ferite "
+"erano orrende, nessuno dovrebbe soffrire così, tanto meno un ragazzo giovane. |"
 
 #: Source/textdat.cpp:360
 msgid ""
-"I really don't understand why Ogden stays here in Tristram. He suffers from "
-"a slight nervous condition, but he is an intelligent and industrious man who "
-"would do very well wherever he went. I suppose it may be the fear of the "
-"many murders that happen in the surrounding countryside, or perhaps the "
-"wishes of his wife that keep him and his family where they are. |"
+"I really don't understand why Ogden stays here in Tristram. He suffers from a "
+"slight nervous condition, but he is an intelligent and industrious man who would "
+"do very well wherever he went. I suppose it may be the fear of the many murders "
+"that happen in the surrounding countryside, or perhaps the wishes of his wife that "
+"keep him and his family where they are. |"
 msgstr ""
-"Non capisco perché Ogden rimanga a Tristram. Ha qualche problema di nervi, "
-"ma un uomo intelligente e ingegnoso come lui avrebbe successo ovunque "
-"andasse. Forse è la paura dei molti omicidi che si verificano nella campagna "
-"circostante, o forse è la volontà della moglie che trattengono qui lui e la "
-"sua famiglia. |"
+"Non capisco perché Ogden rimanga a Tristram. Ha qualche problema di nervi, ma un "
+"uomo intelligente e ingegnoso come lui avrebbe successo ovunque andasse. Forse è "
+"la paura dei molti omicidi che si verificano nella campagna circostante, o forse è "
+"la volontà della moglie che trattengono qui lui e la sua famiglia. |"
 
 #: Source/textdat.cpp:362
 msgid ""
-"Ogden's barmaid is a sweet girl. Her grandmother is quite ill, and suffers "
-"from delusions. \n"
+"Ogden's barmaid is a sweet girl. Her grandmother is quite ill, and suffers from "
+"delusions. \n"
 " \n"
 "She claims that they are visions, but I have no proof of that one way or the "
 "other. |"
 msgstr ""
-"La Cameriera di Ogden è una ragazza dolce. Sua nonna è piuttosto malata, e "
-"soffre di allucinazioni.\n"
+"La Cameriera di Ogden è una ragazza dolce. Sua nonna è piuttosto malata, e soffre "
+"di allucinazioni.\n"
 "\n"
 "Lei afferma che sono visioni, ma io non ho nessuna prova che sia vero. |"
 
@@ -8584,101 +8459,93 @@ msgstr "Buondì! Come posso servirti? |"
 
 #: Source/textdat.cpp:365
 msgid ""
-"My grandmother had a dream that you would come and talk to me. She has "
-"visions, you know and can see into the future. |"
+"My grandmother had a dream that you would come and talk to me. She has visions, "
+"you know and can see into the future. |"
 msgstr ""
 "Mia nonna ha sognato che saresti venuto e avresti parlato con me, ha delle "
 "visioni, sai, e può scorgere il futuro. |"
 
 #: Source/textdat.cpp:367
 msgid ""
-"The woman at the edge of town is a witch! She seems nice enough, and her "
-"name, Adria, is very pleasing to the ear, but I am very afraid of her. \n"
+"The woman at the edge of town is a witch! She seems nice enough, and her name, "
+"Adria, is very pleasing to the ear, but I am very afraid of her. \n"
 " \n"
-"It would take someone quite brave, like you, to see what she is doing out "
-"there. |"
+"It would take someone quite brave, like you, to see what she is doing out there. |"
 msgstr ""
-"La donna ai confini della città è una strega! Sembra simpatica, e il suo "
-"nome, Adria, è piacevole all'orecchio, ma mi terrorizza. \n"
+"La donna ai confini della città è una strega! Sembra simpatica, e il suo nome, "
+"Adria, è piacevole all'orecchio, ma mi terrorizza. \n"
 "\n"
 "Ci vorrebbe qualcuno di coraggioso, come te, per sapere cosa fa laggiù. |"
 
 #: Source/textdat.cpp:369
 msgid ""
-"Our Blacksmith is a point of pride to the people of Tristram. Not only is he "
-"a master craftsman who has won many contests within his guild, but he "
-"received praises from our King Leoric himself - may his soul rest in peace. "
-"Griswold is also a great hero; just ask Cain. |"
+"Our Blacksmith is a point of pride to the people of Tristram. Not only is he a "
+"master craftsman who has won many contests within his guild, but he received "
+"praises from our King Leoric himself - may his soul rest in peace. Griswold is "
+"also a great hero; just ask Cain. |"
 msgstr ""
-"Il nostro Fabbro è un punto d'orgoglio alle persone di Tristram. Non solo è "
-"un ottimo artigiano che ha vinto molte dispute all'interno della sua gilda, "
-"ma ricevette encomi da Re Leoric stesso - Pace all'anima sua. Griswold è "
-"anche un grande eroe; Domandalo a Cain. |"
+"Il nostro Fabbro è un punto d'orgoglio alle persone di Tristram. Non solo è un "
+"ottimo artigiano che ha vinto molte dispute all'interno della sua gilda, ma "
+"ricevette encomi da Re Leoric stesso - Pace all'anima sua. Griswold è anche un "
+"grande eroe; Domandalo a Cain. |"
 
 #: Source/textdat.cpp:371
 msgid ""
-"Cain has been the storyteller of Tristram for as long as I can remember. He "
-"knows so much, and can tell you just about anything about almost everything. "
-"|"
+"Cain has been the storyteller of Tristram for as long as I can remember. He knows "
+"so much, and can tell you just about anything about almost everything. |"
 msgstr ""
-"Cain è stato il cantastorie di Tristram da quando riesco a ricordare. Sa "
-"molto, e ti può informare su tutto quel che c'è da sapere riguardo ogni "
-"cosa. |"
+"Cain è stato il cantastorie di Tristram da quando riesco a ricordare. Sa molto, e "
+"ti può informare su tutto quel che c'è da sapere riguardo ogni cosa. |"
 
 #: Source/textdat.cpp:373
 msgid ""
-"Farnham is a drunkard who fills his belly with ale and everyone else's ears "
-"with nonsense. \n"
+"Farnham is a drunkard who fills his belly with ale and everyone else's ears with "
+"nonsense. \n"
 " \n"
-"I know that both Pepin and Ogden feel sympathy for him, but I get so "
-"frustrated watching him slip farther and farther into a befuddled stupor "
-"every night. |"
+"I know that both Pepin and Ogden feel sympathy for him, but I get so frustrated "
+"watching him slip farther and farther into a befuddled stupor every night. |"
 msgstr ""
-"Farnham è un ubriacone che si riempie la pancia di birra e le orecchie degli "
-"altri con sciocchezze. \n"
+"Farnham è un ubriacone che si riempie la pancia di birra e le orecchie degli altri "
+"con sciocchezze. \n"
 " \n"
 "So che sia Pepin che Ogden provano simpatia per lui, ma è frustrante vederlo "
 "scivolare sempre più profondamente in un confuso torpore ogni notte. |"
 
 #: Source/textdat.cpp:375
 msgid ""
-"Pepin saved my grandmother's life, and I know that I can never repay him for "
-"that. His ability to heal any sickness is more powerful than the mightiest "
-"sword and more mysterious than any spell you can name. If you ever are in "
-"need of healing, Pepin can help you. |"
+"Pepin saved my grandmother's life, and I know that I can never repay him for that. "
+"His ability to heal any sickness is more powerful than the mightiest sword and "
+"more mysterious than any spell you can name. If you ever are in need of healing, "
+"Pepin can help you. |"
 msgstr ""
-"Pepin salvò la vita di mia nonna, e so che non potrò mai ripagarlo per "
-"questo. La sua abilità di guarire i malati è più potente della spada più "
-"maestosa, e più misteriosa di ogni incantesimo che puoi nominare. Se hai "
-"bisogno di cure, Pepin può aiutarti. |"
+"Pepin salvò la vita di mia nonna, e so che non potrò mai ripagarlo per questo. La "
+"sua abilità di guarire i malati è più potente della spada più maestosa, e più "
+"misteriosa di ogni incantesimo che puoi nominare. Se hai bisogno di cure, Pepin "
+"può aiutarti. |"
 
 #: Source/textdat.cpp:377
 msgid ""
-"I grew up with Wirt's mother, Canace. Although she was only slightly hurt "
-"when those hideous creatures stole him, she never recovered. I think she "
-"died of a broken heart. Wirt has become a mean-spirited youngster, looking "
-"only to profit from the sweat of others. I know that he suffered and has "
-"seen horrors that I cannot even imagine, but some of that darkness hangs "
-"over him still. |"
+"I grew up with Wirt's mother, Canace. Although she was only slightly hurt when "
+"those hideous creatures stole him, she never recovered. I think she died of a "
+"broken heart. Wirt has become a mean-spirited youngster, looking only to profit "
+"from the sweat of others. I know that he suffered and has seen horrors that I "
+"cannot even imagine, but some of that darkness hangs over him still. |"
 msgstr ""
-"Sono cresciuta con la madre di Wirt, Canace. Anche se era solo lievemente "
-"ferita quando quelle orrende creature lo rapirono, non si riprese più. Penso "
-"sia morta di crepacuore. Wirt è diventato un cattivo ragazzo, cerca solo il "
-"profitto attraverso gli sforzi degli altri. So che ha sofferto e ha visto "
-"orrori che non posso nemmeno immaginare, ma l'oscurità incombe ancora su di "
-"lui. |"
+"Sono cresciuta con la madre di Wirt, Canace. Anche se era solo lievemente ferita "
+"quando quelle orrende creature lo rapirono, non si riprese più. Penso sia morta di "
+"crepacuore. Wirt è diventato un cattivo ragazzo, cerca solo il profitto attraverso "
+"gli sforzi degli altri. So che ha sofferto e ha visto orrori che non posso nemmeno "
+"immaginare, ma l'oscurità incombe ancora su di lui. |"
 
 #: Source/textdat.cpp:379
 msgid ""
-"Ogden and his wife have taken me and my grandmother into their home and have "
-"even let me earn a few gold pieces by working at the inn. I owe so much to "
-"them, and hope one day to leave this place and help them start a grand hotel "
-"in the east. |"
+"Ogden and his wife have taken me and my grandmother into their home and have even "
+"let me earn a few gold pieces by working at the inn. I owe so much to them, and "
+"hope one day to leave this place and help them start a grand hotel in the east. |"
 msgstr ""
-"Ogden e sua moglie hanno accolto me e la nonna in casa loro, permettendomi "
-"di guadagnare qualche soldo lavorando alla locanda. Devo molto a loro, e "
-"spero un giorno di lasciare questo posto ed aiutarli ad aprire un grande "
-"albergo all'est. |"
+"Ogden e sua moglie hanno accolto me e la nonna in casa loro, permettendomi di "
+"guadagnare qualche soldo lavorando alla locanda. Devo molto a loro, e spero un "
+"giorno di lasciare questo posto ed aiutarli ad aprire un grande albergo all'est. |"
 
 #: Source/textdat.cpp:381
 msgid "Well, what can I do for ya? |"
@@ -8686,248 +8553,233 @@ msgstr "Bene, che posso fare per te? |"
 
 #: Source/textdat.cpp:382
 msgid ""
-"If you're looking for a good weapon, let me show this to you. Take your "
-"basic blunt weapon, such as a mace. Works like a charm against most of those "
-"undying horrors down there, and there's nothing better to shatter skinny "
-"little skeletons! |"
+"If you're looking for a good weapon, let me show this to you. Take your basic "
+"blunt weapon, such as a mace. Works like a charm against most of those undying "
+"horrors down there, and there's nothing better to shatter skinny little skeletons! "
+"|"
 msgstr ""
-"Se cerchi una buona arma, lascia che ti faccia vedere questo. Prendi un "
-"corpo contundente, come una mazza. Funziona alla perfezione contro molti di "
-"quegli orrori non-morti laggiù, e non c'è niente di meglio per schiantare "
-"scheletrini! |"
+"Se cerchi una buona arma, lascia che ti faccia vedere questo. Prendi un corpo "
+"contundente, come una mazza. Funziona alla perfezione contro molti di quegli "
+"orrori non-morti laggiù, e non c'è niente di meglio per schiantare scheletrini! |"
 
 #: Source/textdat.cpp:384
 msgid ""
-"The axe? Aye, that's a good weapon, balanced against any foe. Look how it "
-"cleaves the air, and then imagine a nice fat demon head in its path. Keep in "
-"mind, however, that it is slow to swing - but talk about dealing a heavy "
-"blow! |"
+"The axe? Aye, that's a good weapon, balanced against any foe. Look how it cleaves "
+"the air, and then imagine a nice fat demon head in its path. Keep in mind, "
+"however, that it is slow to swing - but talk about dealing a heavy blow! |"
 msgstr ""
-"L'Ascia? Ah, quella è una buona arma, bilanciata rispetto ad ogni nemico. "
-"Guarda come fende l'aria, e ora immagina la testa di un demone sul suo "
-"cammino. Ricorda, però, che il colpo è lento da vibrare - ma lascia un bel "
-"segno! |"
+"L'Ascia? Ah, quella è una buona arma, bilanciata rispetto ad ogni nemico. Guarda "
+"come fende l'aria, e ora immagina la testa di un demone sul suo cammino. Ricorda, "
+"però, che il colpo è lento da vibrare - ma lascia un bel segno! |"
 
 #: Source/textdat.cpp:386
 msgid ""
-"Look at that edge, that balance. A sword in the right hands, and against the "
-"right foe, is the master of all weapons. Its keen blade finds little to hack "
-"or pierce on the undead, but against a living, breathing enemy, a sword will "
-"better slice their flesh! |"
+"Look at that edge, that balance. A sword in the right hands, and against the right "
+"foe, is the master of all weapons. Its keen blade finds little to hack or pierce "
+"on the undead, but against a living, breathing enemy, a sword will better slice "
+"their flesh! |"
 msgstr ""
-"Osserva questo filo e questo bilanciamento. Una spada nelle mani giuste, e "
-"contro il nemico giusto, è la signora di tutte le armi. La sua lama affilata "
-"trova poco da tagliare o trafiggere sui non-morti, ma affetterà le carni dei "
-"nemici vivi e respiranti. |"
+"Osserva questo filo e questo bilanciamento. Una spada nelle mani giuste, e contro "
+"il nemico giusto, è la signora di tutte le armi. La sua lama affilata trova poco "
+"da tagliare o trafiggere sui non-morti, ma affetterà le carni dei nemici vivi e "
+"respiranti. |"
 
 #: Source/textdat.cpp:388
 msgid ""
-"Your weapons and armor will show the signs of your struggles against the "
-"Darkness. If you bring them to me, with a bit of work and a hot forge, I can "
-"restore them to top fighting form. |"
+"Your weapons and armor will show the signs of your struggles against the Darkness. "
+"If you bring them to me, with a bit of work and a hot forge, I can restore them to "
+"top fighting form. |"
 msgstr ""
-"Le tue armi e la tua armatura porteranno i segni della lotta contro "
-"l'oscurità. Se me li porterai, un po' di lavoro e una fornace calda, li "
-"riporteranno alla loro migliore condizione. |"
+"Le tue armi e la tua armatura porteranno i segni della lotta contro l'oscurità. Se "
+"me li porterai, un pò di lavoro e una fornace calda, li riporteranno alla loro "
+"migliore condizione. |"
 
 #: Source/textdat.cpp:390
 msgid ""
-"While I have to practically smuggle in the metals and tools I need from "
-"caravans that skirt the edges of our damned town, that witch, Adria, always "
-"seems to get whatever she needs. If I knew even the smallest bit about how "
-"to harness magic as she did, I could make some truly incredible things. |"
+"While I have to practically smuggle in the metals and tools I need from caravans "
+"that skirt the edges of our damned town, that witch, Adria, always seems to get "
+"whatever she needs. If I knew even the smallest bit about how to harness magic as "
+"she did, I could make some truly incredible things. |"
 msgstr ""
-"Mentre io devo praticamente contrabbandare i metalli e gli strumenti di cui "
-"ho bisogno dalle carovane che passano per i limiti della nostra maledetta "
-"città, Adria ha sempre quello di cui necessita. Se potessi controllare solo "
-"un po' della sua magia, potrei fare cose veramente incredibili. |"
+"Mentre io devo praticamente contrabbandare i metalli e gli strumenti di cui ho "
+"bisogno dalle carovane che passano per i limiti della nostra maledetta città, "
+"Adria ha sempre quello di cui necessita. Se potessi controllare solo un pò della "
+"sua magia, potrei fare cose veramente incredibili. |"
 
 #: Source/textdat.cpp:392
 msgid ""
-"Gillian is a nice lass. Shame that her gammer is in such poor health or I "
-"would arrange to get both of them out of here on one of the trading "
-"caravans. |"
+"Gillian is a nice lass. Shame that her gammer is in such poor health or I would "
+"arrange to get both of them out of here on one of the trading caravans. |"
 msgstr ""
-"Gillian è una brava ragazza. Peccato che sua nonna sia in poca salute, "
-"altrimenti avrei cercato di farle andare lontano da qui con una delle "
-"carovane. |"
+"Gillian è una brava ragazza. Peccato che sua nonna sia in poca salute, altrimenti "
+"avrei cercato di farle andare lontano da qui con una delle carovane. |"
 
 #: Source/textdat.cpp:394
 msgid ""
-"Sometimes I think that Cain talks too much, but I guess that is his calling "
-"in life. If I could bend steel as well as he can bend your ear, I could make "
-"a suit of court plate good enough for an Emperor! |"
+"Sometimes I think that Cain talks too much, but I guess that is his calling in "
+"life. If I could bend steel as well as he can bend your ear, I could make a suit "
+"of court plate good enough for an Emperor! |"
 msgstr ""
 "A volte credo che Cain parli troppo, ma credo sia il suo destino. Se potessi "
-"piegare l'acciaio come lui è in grado di far tendere le orecchie. Potrei "
-"fare un'armatura decorata degna di un imperatore! |"
+"piegare l'acciaio come lui è in grado di far tendere le orecchie. Potrei fare "
+"un'armatura decorata degna di un imperatore! |"
 
 #: Source/textdat.cpp:396
 msgid ""
-"I was with Farnham that night that Lazarus led us into Labyrinth. I never "
-"saw the Archbishop again, and I may not have survived if Farnham was not at "
-"my side. I fear that the attack left his soul as crippled as, well, another "
-"did my leg. I cannot fight this battle for him now, but I would if I could. |"
+"I was with Farnham that night that Lazarus led us into Labyrinth. I never saw the "
+"Archbishop again, and I may not have survived if Farnham was not at my side. I "
+"fear that the attack left his soul as crippled as, well, another did my leg. I "
+"cannot fight this battle for him now, but I would if I could. |"
 msgstr ""
-"Ero con Farnham la notte in cui Lazarus ci guidò nel Labirinto. Non ho più "
-"rivisto l'Arcivescovo, e potrei non essere qui se Farnham non fosse stato al "
-"mio fianco. Ho paura che l'attacco abbia lasciato un segno nella sua anima. "
-"Non posso combattere questa battaglia per lui, ma se potessi lo farei. |"
+"Ero con Farnham la notte in cui Lazarus ci guidò nel Labirinto. Non ho più rivisto "
+"l'Arcivescovo, e potrei non essere qui se Farnham non fosse stato al mio fianco. "
+"Ho paura che l'attacco abbia lasciato un segno nella sua anima. Non posso "
+"combattere questa battaglia per lui, ma se potessi lo farei. |"
 
 #: Source/textdat.cpp:398
 msgid ""
-"A good man who puts the needs of others above his own. You won't find anyone "
-"left in Tristram - or anywhere else for that matter - who has a bad thing to "
-"say about the healer. |"
+"A good man who puts the needs of others above his own. You won't find anyone left "
+"in Tristram - or anywhere else for that matter - who has a bad thing to say about "
+"the healer. |"
 msgstr ""
-"Un buon uomo che mette i problemi degli altri al di sopra dei suoi. Non "
-"troverai nessuno a Tristram - o da qualsiasi altra parte - che abbia brutte "
-"cose da dire sul guaritore. |"
+"Un buon uomo che mette i problemi degli altri al di sopra dei suoi. Non troverai "
+"nessuno a Tristram - o da qualsiasi altra parte - che abbia brutte cose da dire "
+"sul guaritore. |"
 
 #: Source/textdat.cpp:400
 msgid ""
-"That lad is going to get himself into serious trouble... or I guess I should "
-"say, again. I've tried to interest him in working here and learning an "
-"honest trade, but he prefers the high profits of dealing in goods of dubious "
-"origin. I cannot hold that against him after what happened to him, but I do "
-"wish he would at least be careful. |"
+"That lad is going to get himself into serious trouble... or I guess I should say, "
+"again. I've tried to interest him in working here and learning an honest trade, "
+"but he prefers the high profits of dealing in goods of dubious origin. I cannot "
+"hold that against him after what happened to him, but I do wish he would at least "
+"be careful. |"
 msgstr ""
-"Quel ragazzo sta per ficcarsi in guai seri... e aggiungerei, di nuovo. Ho "
-"provato ad appassionarlo al lavoro qui e a fargli imparare un commercio "
-"onesto, ma preferisce ottenere alti guadagni trafficando con beni di dubbia "
-"origine. Non posso biasimarlo dopo quello che gli è accaduto, ma vorrei che "
-"facesse almeno attenzione. |"
+"Quel ragazzo sta per ficcarsi in guai seri... e aggiungerei, di nuovo. Ho provato "
+"ad appassionarlo al lavoro qui e a fargli imparare un commercio onesto, ma "
+"preferisce ottenere alti guadagni trafficando con beni di dubbia origine. Non "
+"posso biasimarlo dopo quello che gli è accaduto, ma vorrei che facesse almeno "
+"attenzione. |"
 
 #: Source/textdat.cpp:402
 msgid ""
-"The Innkeeper has little business and no real way of turning a profit. He "
-"manages to make ends meet by providing food and lodging for those who "
-"occasionally drift through the village, but they are as likely to sneak off "
-"into the night as they are to pay him. If it weren't for the stores of "
-"grains and dried meats he kept in his cellar, why, most of us would have "
-"starved during that first year when the entire countryside was overrun by "
-"demons. |"
+"The Innkeeper has little business and no real way of turning a profit. He manages "
+"to make ends meet by providing food and lodging for those who occasionally drift "
+"through the village, but they are as likely to sneak off into the night as they "
+"are to pay him. If it weren't for the stores of grains and dried meats he kept in "
+"his cellar, why, most of us would have starved during that first year when the "
+"entire countryside was overrun by demons. |"
 msgstr ""
-"Il Taverniere fa pochi affari e non ha nessun modo di trarre un profitto. "
-"Cerca di guadagnare qualcosa fornendo vitto e alloggio per quelli che "
-"passano di tanto in tanto per il villaggio, ma è più probabile che fuggano "
-"nella notte piuttosto che lo paghino. Se non fosse per le riserve di "
-"granaglie e carne secca che teneva in cantina, molti di noi sarebbero morti "
-"di fame durante il primo anno quando l'intera campagna era infestata dai "
-"demoni.|"
+"Il Taverniere fa pochi affari e non ha nessun modo di trarre un profitto. Cerca di "
+"guadagnare qualcosa fornendo vitto e alloggio per quelli che passano di tanto in "
+"tanto per il villaggio, ma è più probabile che fuggano nella notte piuttosto che "
+"lo paghino. Se non fosse per le riserve di granaglie e carne secca che teneva in "
+"cantina, molti di noi sarebbero morti di fame durante il primo anno quando "
+"l'intera campagna era infestata dai demoni.|"
 
 #: Source/textdat.cpp:404
 msgid "Can't a fella drink in peace? |"
 msgstr "Un uomo non può bere in pace? |"
 
 #: Source/textdat.cpp:405
-msgid ""
-"The gal who brings the drinks? Oh, yeah, what a pretty lady. So nice, too. |"
-msgstr ""
-"La ragazza che porta da bere? Oh, si, Che ragazza carina. Così attraente. |"
+msgid "The gal who brings the drinks? Oh, yeah, what a pretty lady. So nice, too. |"
+msgstr "La ragazza che porta da bere? Oh, si, Che ragazza carina. Così attraente. |"
 
 #: Source/textdat.cpp:407
 msgid ""
-"Why don't that old crone do somethin' for a change. Sure, sure, she's got "
-"stuff, but you listen to me... she's unnatural. I ain't never seen her eat "
-"or drink - and you can't trust somebody who doesn't drink at least a little. "
-"|"
+"Why don't that old crone do somethin' for a change. Sure, sure, she's got stuff, "
+"but you listen to me... she's unnatural. I ain't never seen her eat or drink - and "
+"you can't trust somebody who doesn't drink at least a little. |"
 msgstr ""
-"Perché' quella vecchiaccia non fa qualcosa tanto per cambiare. D'accordo, ha "
-"delle qualità, ma ascoltami... non è normale. Non l'ho mai vista bere o "
-"mangiare - e non puoi fidarti di qualcuno che non beve almeno un po'. |"
+"Perché quella vecchiaccia non fa qualcosa tanto per cambiare. D'accordo, ha delle "
+"qualità, ma ascoltami... non è normale. Non l'ho mai vista bere o mangiare - e non "
+"puoi fidarti di qualcuno che non beve almeno un po'. |"
 
 #: Source/textdat.cpp:409
 msgid ""
-"Cain isn't what he says he is. Sure, sure, he talks a good story... some of "
-"'em are real scary or funny... but I think he knows more than he knows he "
-"knows. |"
+"Cain isn't what he says he is. Sure, sure, he talks a good story... some of 'em "
+"are real scary or funny... but I think he knows more than he knows he knows. |"
 msgstr ""
-"Cain non è chi dice di essere. Certo, racconta belle storie... alcune sono "
-"davvero paurose o divertenti... ma penso che lui sappia più di quanto ci "
-"mostri. |"
+"Cain non è chi dice di essere. Certo, racconta belle storie... alcune sono davvero "
+"paurose o divertenti... ma penso che lui sappia più di quanto ci mostri. |"
 
 #: Source/textdat.cpp:411
 msgid ""
-"Griswold? Good old Griswold. I love him like a brother! We fought together, "
-"you know, back when... we... Lazarus...  Lazarus... Lazarus!!! |"
+"Griswold? Good old Griswold. I love him like a brother! We fought together, you "
+"know, back when... we... Lazarus...  Lazarus... Lazarus!!! |"
 msgstr ""
-"Griswold? Buon Vecchio Griswold! L'amo come un fratello! Lottammo insieme, "
-"sai, quando... noi... Lazarus... Lazarus... Lazarus!!! |"
+"Griswold? Buon Vecchio Griswold! L'amo come un fratello! Lottammo insieme, sai, "
+"quando... noi... Lazarus... Lazarus... Lazarus!!! |"
 
 #: Source/textdat.cpp:413
 msgid ""
-"Hehehe, I like Pepin. He really tries, you know. Listen here, you should "
-"make sure you get to know him. Good fella like that with people always "
-"wantin' help. Hey, I guess that would be kinda like you, huh hero? I was a "
-"hero too... |"
+"Hehehe, I like Pepin. He really tries, you know. Listen here, you should make sure "
+"you get to know him. Good fella like that with people always wantin' help. Hey, I "
+"guess that would be kinda like you, huh hero? I was a hero too... |"
 msgstr ""
-"Hehehe, mi piace Pepin. A volte ci prova veramente. Ascoltami, devi "
-"assolutamente conoscerlo. Una brava persona a cui piacciono le persone in "
-"cerca d'aiuto. Ehi, credo che sia un po' come te, huh, eroe? Anch'io ero un "
-"eroe... |"
+"Hehehe, mi piace Pepin. A volte ci prova veramente. Ascoltami, devi assolutamente "
+"conoscerlo. Una brava persona a cui piacciono le persone in cerca d'aiuto. Ehi, "
+"credo che sia un pò come te, huh, eroe? Anch'io ero un eroe... |"
 
 #: Source/textdat.cpp:415
 msgid ""
-"Wirt is a kid with more problems than even me, and I know all about "
-"problems. Listen here - that kid is gotta sweet deal, but he's been there, "
-"you know? Lost a leg! Gotta walk around on a piece of wood. So sad, so "
-"sad... |"
+"Wirt is a kid with more problems than even me, and I know all about problems. "
+"Listen here - that kid is gotta sweet deal, but he's been there, you know? Lost a "
+"leg! Gotta walk around on a piece of wood. So sad, so sad... |"
 msgstr ""
-"Wirt è un ragazzo con più problemi di me, e conosco tutto sui problemi. "
-"Ascolta, il ragazzo sta facendo buoni affari, ma è stato là, sai? Ha perso "
-"una gamba! Cammina su un pezzo di legno. Molto triste, molto triste... |"
+"Wirt è un ragazzo con più problemi di me, e conosco tutto sui problemi. Ascolta, "
+"il ragazzo sta facendo buoni affari, ma è stato là, sai? Ha perso una gamba! "
+"Cammina su un pezzo di legno. Molto triste, molto triste... |"
 
 #: Source/textdat.cpp:417
 msgid ""
-"Ogden is the best man in town. I don't think his wife likes me much, but as "
-"long as she keeps tappin' kegs, I'll like her just fine. Seems like I been "
-"spendin' more time with Ogden than most, but he's so good to me... |"
+"Ogden is the best man in town. I don't think his wife likes me much, but as long "
+"as she keeps tappin' kegs, I'll like her just fine. Seems like I been spendin' "
+"more time with Ogden than most, but he's so good to me... |"
 msgstr ""
-"Ogden è il miglior uomo in città. Non penso di piacere a sua moglie, ma "
-"finché continuerà a spillare vino, mi starà simpatica. Sembra che io passi "
-"con Ogden la maggior parte del tempo, ma è cosi' buono con me... |"
+"Ogden è il miglior uomo in città. Non penso di piacere a sua moglie, ma finché "
+"continuerà a spillare vino, mi starà simpatica. Sembra che io passi con Ogden la "
+"maggior parte del tempo, ma è così buono con me... |"
 
 #: Source/textdat.cpp:419
 msgid ""
-"I wanna tell ya sumthin', 'cause I know all about this stuff. It's my "
-"specialty. This here is the best... theeeee best! That other ale ain't no "
-"good since those stupid dogs... |"
+"I wanna tell ya sumthin', 'cause I know all about this stuff. It's my specialty. "
+"This here is the best... theeeee best! That other ale ain't no good since those "
+"stupid dogs... |"
 msgstr ""
-"Voglio dirti una cosa, perché so tutto a riguardo. È la mia specialità. "
-"Questa è la migliore... laaa migliore! L'altra birra è disgustosa da quando "
-"quegli stupidi cani... |"
+"Voglio dirti una cosa, perché so tutto a riguardo. È la mia specialità. Questa è "
+"la migliore... laaa migliore! L'altra birra è disgustosa da quando quegli stupidi "
+"cani... |"
 
 #: Source/textdat.cpp:421
 msgid ""
-"No one ever lis... listens to me. Somewhere - I ain't too sure - but "
-"somewhere under the church is a whole pile o' gold. Gleamin' and shinin' and "
-"just waitin' for someone to get it. |"
+"No one ever lis... listens to me. Somewhere - I ain't too sure - but somewhere "
+"under the church is a whole pile o' gold. Gleamin' and shinin' and just waitin' "
+"for someone to get it. |"
 msgstr ""
-"Nessuno mi as... ascolta. Da qualche parte - non sono sicuro - ma da qualche "
-"parte sotto la chiesa c'è un'enorme montagna d'oro. Splende, brilla e "
-"aspetta che qualcuno se la prenda. |"
+"Nessuno mi as... ascolta. Da qualche parte - non sono sicuro - ma da qualche parte "
+"sotto la chiesa c'è un'enorme montagna d'oro. Splende, brilla e aspetta che "
+"qualcuno se la prenda. |"
 
 #: Source/textdat.cpp:423
 msgid ""
-"I know you gots your own ideas, and I know you're not gonna believe this, "
-"but that weapon you got there - it just ain't no good against those big "
-"brutes! Oh, I don't care what Griswold says, they can't make anything like "
-"they used to in the old days... |"
+"I know you gots your own ideas, and I know you're not gonna believe this, but that "
+"weapon you got there - it just ain't no good against those big brutes! Oh, I don't "
+"care what Griswold says, they can't make anything like they used to in the old "
+"days... |"
 msgstr ""
-"So che hai le tue idee, e so che non crederai a questo, ma quell'arma che "
-"hai lì - non è buona contro quei grossi mostri! Oh, non m'importa di quello "
-"che dice Griswold, non faranno mai le cose come si usava una volta... |"
+"So che hai le tue idee, e so che non crederai a questo, ma quell'arma che hai lì - "
+"non è buona contro quei grossi mostri! Oh, non m'importa di quello che dice "
+"Griswold, non faranno mai le cose come si usava una volta... |"
 
 #: Source/textdat.cpp:425
 msgid ""
-"If I was you... and I ain't... but if I was, I'd sell all that stuff you got "
-"and get out of here. That boy out there... He's always got somethin good, "
-"but you gotta give him some gold or he won't even show you what he's got. |"
+"If I was you... and I ain't... but if I was, I'd sell all that stuff you got and "
+"get out of here. That boy out there... He's always got somethin good, but you "
+"gotta give him some gold or he won't even show you what he's got. |"
 msgstr ""
-"Se fossi in te... e non lo sono... ma se lo fossi, venderei tutte le cose "
-"che hai e me ne andrei da qui. Il ragazzo là fuori... Ha sempre qualcosa di "
-"buono, ma devi dargli dell'oro o non ti mostrerà nemmeno quello che ha. |"
+"Se fossi in te... e non lo sono... ma se lo fossi, venderei tutte le cose che hai "
+"e me ne andrei da qui. Il ragazzo là fuori... Ha sempre qualcosa di buono, ma devi "
+"dargli dell'oro o non ti mostrerà nemmeno quello che ha. |"
 
 #: Source/textdat.cpp:427
 msgid "I sense a soul in search of answers... |"
@@ -8936,148 +8788,141 @@ msgstr "Sento un'anima in cerca di risposte... |"
 #: Source/textdat.cpp:428
 msgid ""
 "Wisdom is earned, not given. If you discover a tome of knowledge, devour its "
-"words. Should you already have knowledge of the arcane mysteries scribed "
-"within a book, remember - that level of mastery can always increase. |"
+"words. Should you already have knowledge of the arcane mysteries scribed within a "
+"book, remember - that level of mastery can always increase. |"
 msgstr ""
-"La saggezza si guadagna, non è data. Se scopri tomi di conoscenza,divora le "
-"loro parole. Se avessi già nozione dei misteri arcani scritti in un libro, "
-"ricorda - il tuo padroneggiarli può sempre migliorare. |"
+"La saggezza si guadagna, non è data. Se scopri tomi di conoscenza,divora le loro "
+"parole. Se avessi già nozione dei misteri arcani scritti in un libro, ricorda - il "
+"tuo padroneggiarli può sempre migliorare. |"
 
 #: Source/textdat.cpp:430
 msgid ""
-"The greatest power is often the shortest lived. You may find ancient words "
-"of power written upon scrolls of parchment. The strength of these scrolls "
-"lies in the ability of either apprentice or adept to cast them with equal "
-"ability. Their weakness is that they must first be read aloud and can never "
-"be kept at the ready in your mind. Know also that these scrolls can be read "
-"but once, so use them with care. |"
+"The greatest power is often the shortest lived. You may find ancient words of "
+"power written upon scrolls of parchment. The strength of these scrolls lies in the "
+"ability of either apprentice or adept to cast them with equal ability. Their "
+"weakness is that they must first be read aloud and can never be kept at the ready "
+"in your mind. Know also that these scrolls can be read but once, so use them with "
+"care. |"
 msgstr ""
-"Il potere maggiore è spesso quello dalla vita più corta. Potresti trovare "
-"parole di potere scritte su pergamene. La loro forza giace nella possibilità "
-"per chiunque sia di lanciare incantesimi con uguale abilità. La loro "
-"debolezza sta nel fatto che prima devono essere lette ad alta voce e non "
-"possono essere ripetute. Sappi che questi rotoli possono essere letti solo "
-"una volta, quindi usali con cautela. |"
+"Il potere maggiore è spesso quello dalla vita più corta. Potresti trovare parole "
+"di potere scritte su pergamene. La loro forza giace nella possibilità per chiunque "
+"sia di lanciare incantesimi con uguale abilità. La loro debolezza sta nel fatto "
+"che prima devono essere lette ad alta voce e non possono essere ripetute. Sappi "
+"che questi rotoli possono essere letti solo una volta, quindi usali con cautela. |"
 
 #: Source/textdat.cpp:432
 msgid ""
-"Though the heat of the sun is beyond measure, the mere flame of a candle is "
-"of greater danger. No energies, no matter how great, can be used without the "
-"proper focus. For many spells, ensorcelled Staves may be charged with "
-"magical energies many times over. I have the ability to restore their power "
-"- but know that nothing is done without a price. |"
+"Though the heat of the sun is beyond measure, the mere flame of a candle is of "
+"greater danger. No energies, no matter how great, can be used without the proper "
+"focus. For many spells, ensorcelled Staves may be charged with magical energies "
+"many times over. I have the ability to restore their power - but know that nothing "
+"is done without a price. |"
 msgstr ""
-"Anche se il calore del sole è oltre misura, la mera fiamma di una candela è "
-"un pericolo maggiore. Nessuna energia, per quanto grande, può essere usata "
-"senza una focalizzazione. Per molti incantesimi, Staffe istoriate possono "
-"essere ricaricate più volte con energie magiche. Ho la capacità di "
-"ristabilire quel potere, ma a pagamento ovviamente. |"
+"Anche se il calore del sole è oltre misura, la mera fiamma di una candela è un "
+"pericolo maggiore. Nessuna energia, per quanto grande, può essere usata senza una "
+"focalizzazione. Per molti incantesimi, Staffe istoriate possono essere ricaricate "
+"più volte con energie magiche. Ho la capacità di ristabilire quel potere, ma a "
+"pagamento ovviamente. |"
 
 #: Source/textdat.cpp:434
 msgid ""
-"The sum of our knowledge is in the sum of its people. Should you find a book "
-"or scroll that you cannot decipher, do not hesitate to bring it to me. If I "
-"can make sense of it I will share what I find. |"
+"The sum of our knowledge is in the sum of its people. Should you find a book or "
+"scroll that you cannot decipher, do not hesitate to bring it to me. If I can make "
+"sense of it I will share what I find. |"
 msgstr ""
-"La conoscenza è la somma di quella di tutte le persone. Se dovessi trovare "
-"un libro o una pergamena che non riesci a decifrare, non esitare a "
-"portarmela. Se posso trarne un senso lo spartirò con te. |"
+"La conoscenza è la somma di quella di tutte le persone. Se dovessi trovare un "
+"libro o una pergamena che non riesci a decifrare, non esitare a portarmela. Se "
+"posso trarne un senso lo spartirò con te. |"
 
 #: Source/textdat.cpp:436
 msgid ""
-"To a man who only knows Iron, there is no greater magic than Steel. The "
-"blacksmith Griswold is more of a sorcerer than he knows. His ability to meld "
-"fire and metal is unequaled in this land. |"
+"To a man who only knows Iron, there is no greater magic than Steel. The blacksmith "
+"Griswold is more of a sorcerer than he knows. His ability to meld fire and metal "
+"is unequaled in this land. |"
 msgstr ""
-"Per chi conosce solo il ferro non c'è miglior magia dell'acciaio. C'è più "
-"del mago in Griswold di quanto non sappia. La sua abilità di unire fuoco e "
-"metallo è insuperata in questa zona. |"
+"Per chi conosce solo il ferro non c'è miglior magia dell'acciaio. C'è più del mago "
+"in Griswold di quanto non sappia. La sua abilità di unire fuoco e metallo è "
+"insuperata in questa zona. |"
 
 #: Source/textdat.cpp:438
 msgid ""
-"Corruption has the strength of deceit, but innocence holds the power of "
-"purity. The young woman Gillian has a pure heart, placing the needs of her "
-"matriarch over her own. She fears me, but it is only because she does not "
-"understand me. |"
+"Corruption has the strength of deceit, but innocence holds the power of purity. "
+"The young woman Gillian has a pure heart, placing the needs of her matriarch over "
+"her own. She fears me, but it is only because she does not understand me. |"
 msgstr ""
-"La corruzione ha la forza dell'inganno, ma l'innocenza detiene il potere "
-"della purezza. La giovane donna Gillian ha un cuore puro, ponendo gli "
-"interessi della sua patriarca sopra i propri. Mi teme, ma solo perché non mi "
-"comprende. |"
+"La corruzione ha la forza dell'inganno, ma l'innocenza detiene il potere della "
+"purezza. La giovane donna Gillian ha un cuore puro, ponendo gli interessi della "
+"sua patriarca sopra i propri. Mi teme, ma solo perché non mi comprende. |"
 
 #: Source/textdat.cpp:440
 msgid ""
-"A chest opened in darkness holds no greater treasure than when it is opened "
-"in the light. The storyteller Cain is an enigma, but only to those who do "
-"not look. His knowledge of what lies beneath the cathedral is far greater "
-"than even he allows himself to realize. |"
+"A chest opened in darkness holds no greater treasure than when it is opened in the "
+"light. The storyteller Cain is an enigma, but only to those who do not look. His "
+"knowledge of what lies beneath the cathedral is far greater than even he allows "
+"himself to realize. |"
 msgstr ""
-"Uno scrigno aperto al buio, non contiene un tesoro maggiore di quando lo è "
-"alla luce. Cain il cantastorie è un enigma, ma solo per chi non osserva. La "
-"sua conoscenza di ciò che giace sotto la cattedrale è più grande di quanto "
-"lui si permetta di realizzare. |"
+"Uno scrigno aperto al buio, non contiene un tesoro maggiore di quando lo è alla "
+"luce. Cain il cantastorie è un enigma, ma solo per chi non osserva. La sua "
+"conoscenza di ciò che giace sotto la cattedrale è più grande di quanto lui si "
+"permetta di realizzare. |"
 
 #: Source/textdat.cpp:442
 msgid ""
-"The higher you place your faith in one man, the farther it has to fall. "
-"Farnham has lost his soul, but not to any demon. It was lost when he saw his "
-"fellow townspeople betrayed by the Archbishop Lazarus. He has knowledge to "
-"be gleaned, but you must separate fact from fantasy. |"
+"The higher you place your faith in one man, the farther it has to fall. Farnham "
+"has lost his soul, but not to any demon. It was lost when he saw his fellow "
+"townspeople betrayed by the Archbishop Lazarus. He has knowledge to be gleaned, "
+"but you must separate fact from fantasy. |"
 msgstr ""
-"Più fiducia riponi in una persona, più è dura sopportare il tradimento. "
-"Farnham ha perso la sua anima, ma non per via di un demone.L'ha persa quando "
-"ha visto i suoi concittadini traditi dall'Arcivescovo Lazarus. Sa qualcosa, "
-"ma devi distinguere la realtà dalla fantasia. |"
+"Più fiducia riponi in una persona, più è dura sopportare il tradimento. Farnham ha "
+"perso la sua anima, ma non per via di un demone.L'ha persa quando ha visto i suoi "
+"concittadini traditi dall'Arcivescovo Lazarus. Sa qualcosa, ma devi distinguere la "
+"realtà dalla fantasia. |"
 
 #: Source/textdat.cpp:444
 msgid ""
-"The hand, the heart and the mind can perform miracles when they are in "
-"perfect harmony. The healer Pepin sees into the body in a way that even I "
-"cannot. His ability to restore the sick and injured is magnified by his "
-"understanding of the creation of elixirs and potions. He is as great an ally "
-"as you have in Tristram. |"
+"The hand, the heart and the mind can perform miracles when they are in perfect "
+"harmony. The healer Pepin sees into the body in a way that even I cannot. His "
+"ability to restore the sick and injured is magnified by his understanding of the "
+"creation of elixirs and potions. He is as great an ally as you have in Tristram. |"
 msgstr ""
-"Mente, corpo e anima possono compiere miracoli quando sono in perfetta "
-"armonia. Pepin il guaritore vede il corpo in una maniera a me sconosciuta. "
-"La sua capacità di curare malati e feriti è amplificata dalla sua conoscenza "
-"nella creazione di elisir e pozioni. È uno dei più grandi alleati che hai a "
-"Tristram. |"
+"Mente, corpo e anima possono compiere miracoli quando sono in perfetta armonia. "
+"Pepin il guaritore vede il corpo in una maniera a me sconosciuta. La sua capacità "
+"di curare malati e feriti è amplificata dalla sua conoscenza nella creazione di "
+"elisir e pozioni. È uno dei più grandi alleati che hai a Tristram. |"
 
 #: Source/textdat.cpp:446
 msgid ""
-"There is much about the future we cannot see, but when it comes it will be "
-"the children who wield it. The boy Wirt has a blackness upon his soul, but "
-"he poses no threat to the town or its people. His secretive dealings with "
-"the urchins and unspoken guilds of nearby towns gain him access to many "
-"devices that cannot be easily found in Tristram. While his methods may be "
-"reproachful, Wirt can provide assistance for your battle against the "
-"encroaching Darkness. |"
+"There is much about the future we cannot see, but when it comes it will be the "
+"children who wield it. The boy Wirt has a blackness upon his soul, but he poses no "
+"threat to the town or its people. His secretive dealings with the urchins and "
+"unspoken guilds of nearby towns gain him access to many devices that cannot be "
+"easily found in Tristram. While his methods may be reproachful, Wirt can provide "
+"assistance for your battle against the encroaching Darkness. |"
 msgstr ""
-"C'è molto del futuro che non sappiamo, ma quando arriverà, saranno i giovani "
-"che dovranno affrontarlo. Wirt ha un peso sull'animo, ma non è una minaccia "
-"per la città o per chi vi abita. I suoi affari segreti con misteriose gilde "
-"delle città vicine gli garantiscono accesso a molti oggetti che non possono "
-"essere facilmente trovati a Tristram. Anche se i suoi metodi sono "
-"riprovevoli, Wirt può fornirti assistenza per la tua battaglia contro "
-"l'oscurità. |"
+"C'è molto del futuro che non sappiamo, ma quando arriverà, saranno i giovani che "
+"dovranno affrontarlo. Wirt ha un peso sull'animo, ma non è una minaccia per la "
+"città o per chi vi abita. I suoi affari segreti con misteriose gilde delle città "
+"vicine gli garantiscono accesso a molti oggetti che non possono essere facilmente "
+"trovati a Tristram. Anche se i suoi metodi sono riprovevoli, Wirt può fornirti "
+"assistenza per la tua battaglia contro l'oscurità. |"
 
 #: Source/textdat.cpp:448
 msgid ""
-"Earthen walls and thatched canopy do not a home create. The innkeeper Ogden "
-"serves more of a purpose in this town than many understand. He provides "
-"shelter for Gillian and her matriarch, maintains what life Farnham has left "
-"to him, and provides an anchor for all who are left in the town to what "
-"Tristram once was. His tavern, and the simple pleasures that can still be "
-"found there, provide a glimpse of a life that the people here remember. It "
-"is that memory that continues to feed their hopes for your success. |"
+"Earthen walls and thatched canopy do not a home create. The innkeeper Ogden serves "
+"more of a purpose in this town than many understand. He provides shelter for "
+"Gillian and her matriarch, maintains what life Farnham has left to him, and "
+"provides an anchor for all who are left in the town to what Tristram once was. His "
+"tavern, and the simple pleasures that can still be found there, provide a glimpse "
+"of a life that the people here remember. It is that memory that continues to feed "
+"their hopes for your success. |"
 msgstr ""
-"Mura di pietra e tetti di paglia non fanno una casa. Ogden il locandiere ha "
-"più ruoli in questa città di quanti molti comprendano. Fornisce assistenza a "
-"Gillian e a sua nonna, mantiene la poca vita che Farnham ha ancora in sé, e "
-"garantisce un ricordo di quello che Tristram era a tutti quelli rimasti in "
-"città. La sua taverna, e i semplici piaceri che vi si possono trovare, danno "
-"un barlume di vita che la gente qui ricorda. È questo ricordo che continua a "
-"nutrire le loro speranze di un tuo successo. |"
+"Mura di pietra e tetti di paglia non fanno una casa. Ogden il locandiere ha più "
+"ruoli in questa città di quanti molti comprendano. Fornisce assistenza a Gillian e "
+"a sua nonna, mantiene la poca vita che Farnham ha ancora in sé, e garantisce un "
+"ricordo di quello che Tristram era a tutti quelli rimasti in città. La sua "
+"taverna, e i semplici piaceri che vi si possono trovare, danno un barlume di vita "
+"che la gente qui ricorda. È questo ricordo che continua a nutrire le loro speranze "
+"di un tuo successo. |"
 
 #: Source/textdat.cpp:450
 msgid "Pssst... over here... |"
@@ -9085,8 +8930,8 @@ msgstr "Pssst... qui... |"
 
 #: Source/textdat.cpp:451
 msgid ""
-"Not everyone in Tristram has a use - or a market - for everything you will "
-"find in the labyrinth. Not even me, as hard as that is to believe. \n"
+"Not everyone in Tristram has a use - or a market - for everything you will find in "
+"the labyrinth. Not even me, as hard as that is to believe. \n"
 " \n"
 "Sometimes, only you will be able to find a purpose for some things. |"
 msgstr ""
@@ -9097,128 +8942,125 @@ msgstr ""
 
 #: Source/textdat.cpp:453
 msgid ""
-"Don't trust everything the drunk says. Too many ales have fogged his vision "
-"and his good sense. |"
+"Don't trust everything the drunk says. Too many ales have fogged his vision and "
+"his good sense. |"
 msgstr ""
-"Non credere a tutto quel che dice l'ubriaco. Troppe birre annebbiano la "
-"vista e il buon senso. |"
+"Non credere a tutto quel che dice l'ubriaco. Troppe birre annebbiano la vista e il "
+"buon senso. |"
 
 #: Source/textdat.cpp:455
 msgid ""
-"In case you haven't noticed, I don't buy anything from Tristram. I am an "
-"importer of quality goods. If you want to peddle junk, you'll have to see "
-"Griswold, Pepin or that witch, Adria. I'm sure that they will snap up "
-"whatever you can bring them... |"
+"In case you haven't noticed, I don't buy anything from Tristram. I am an importer "
+"of quality goods. If you want to peddle junk, you'll have to see Griswold, Pepin "
+"or that witch, Adria. I'm sure that they will snap up whatever you can bring "
+"them... |"
 msgstr ""
-"In caso non l'avessi notato, non compro niente a Tristram. Sono un "
-"importatore di beni di qualità. Se vuoi vendere spazzatura, rivolgiti a "
-"Griswold, Pepin o alla strega, Adria. Sono sicuro che addenteranno qualsiasi "
-"cosa tu possa portar loro... |"
+"In caso non l'avessi notato, non compro niente a Tristram. Sono un importatore di "
+"beni di qualità. Se vuoi vendere spazzatura, rivolgiti a Griswold, Pepin o alla "
+"strega, Adria. Sono sicuro che addenteranno qualsiasi cosa tu possa portar loro... "
+"|"
 
 #: Source/textdat.cpp:457
 msgid ""
-"I guess I owe the blacksmith my life - what there is of it. Sure, Griswold "
-"offered me an apprenticeship at the smithy, and he is a nice enough guy, but "
-"I'll never get enough money to... well, let's just say that I have definite "
-"plans that require a large amount of gold. |"
+"I guess I owe the blacksmith my life - what there is of it. Sure, Griswold offered "
+"me an apprenticeship at the smithy, and he is a nice enough guy, but I'll never "
+"get enough money to... well, let's just say that I have definite plans that "
+"require a large amount of gold. |"
 msgstr ""
 "Penso di dovere al fabbro la vita, o almeno quel che ne è rimasto. È vero, "
-"Griswold mi ha offerto un apprendistato alla fucina, ed è un buon tipo, ma "
-"non potrò mai fare abbastanza soldi da... beh, diciamo solo che ho dei piani "
-"che richiedono un vasto ammontare d'oro.|"
+"Griswold mi ha offerto un apprendistato alla fucina, ed è un buon tipo, ma non "
+"potrò mai fare abbastanza soldi da... beh, diciamo solo che ho dei piani che "
+"richiedono un vasto ammontare d'oro.|"
 
 #: Source/textdat.cpp:459
 msgid ""
 "If I were a few years older, I would shower her with whatever riches I could "
-"muster, and let me assure you I can get my hands on some very nice stuff. "
-"Gillian is a beautiful girl who should get out of Tristram as soon as it is "
-"safe. Hmmm... maybe I'll take her with me when I go... |"
+"muster, and let me assure you I can get my hands on some very nice stuff. Gillian "
+"is a beautiful girl who should get out of Tristram as soon as it is safe. Hmmm... "
+"maybe I'll take her with me when I go... |"
 msgstr ""
-"Se fossi solo un po' più vecchio, la coprirei di ricchezze, e ti assicuro "
-"che posso mettere le mani su oggetti molto preziosi. Gillian è una "
-"bellissima ragazza che dovrebbe lasciare Tristram finché è ancora sicuro. "
-"Hmm... forse la porterò con me quando me ne andrò... |"
+"Se fossi solo un pò più vecchio, la coprirei di ricchezze, e ti assicuro che posso "
+"mettere le mani su oggetti molto preziosi. Gillian è una bellissima ragazza che "
+"dovrebbe lasciare Tristram finché è ancora sicuro. Hmm... forse la porterò con me "
+"quando me ne andrò... |"
 
 #: Source/textdat.cpp:461
 msgid ""
-"Cain knows too much. He scares the life out of me - even more than that "
-"woman across the river. He keeps telling me about how lucky I am to be "
-"alive, and how my story is foretold in legend. I think he's off his crock. |"
+"Cain knows too much. He scares the life out of me - even more than that woman "
+"across the river. He keeps telling me about how lucky I am to be alive, and how my "
+"story is foretold in legend. I think he's off his crock. |"
 msgstr ""
 "Cain sa troppe cose. Mi terrorizza - anche più della donna aldilà del fiume. "
-"Continua a ripetermi quanto sono fortunato ad essere vivo, e come la mia "
-"storia sia profetizzata nelle leggende. Penso sia mezzo impazzito. |"
+"Continua a ripetermi quanto sono fortunato ad essere vivo, e come la mia storia "
+"sia profetizzata nelle leggende. Penso sia mezzo impazzito. |"
 
 #: Source/textdat.cpp:463
 msgid ""
 "Farnham - now there is a man with serious problems, and I know all about how "
-"serious problems can be. He trusted too much in the integrity of one man, "
-"and Lazarus led him into the very jaws of death. Oh, I know what it's like "
-"down there, so don't even start telling me about your plans to destroy the "
-"evil that dwells in that Labyrinth. Just watch your legs... |"
+"serious problems can be. He trusted too much in the integrity of one man, and "
+"Lazarus led him into the very jaws of death. Oh, I know what it's like down there, "
+"so don't even start telling me about your plans to destroy the evil that dwells in "
+"that Labyrinth. Just watch your legs... |"
 msgstr ""
-"Farnham - quello è un uomo con seri problemi, e io so quanto seri possono "
-"esserlo. Ha creduto troppo nell'onestà di un uomo, e Lazarus l'ha guidato "
-"verso la morte. Oh, so come stanno le cose laggiù, quindi non iniziare "
-"nemmeno a parlarmi dei tuoi progetti d'eliminare il male che dimora nel "
-"Labirinto. Solo, fa attenzione alle tue gambe... |"
+"Farnham - quello è un uomo con seri problemi, e io so quanto seri possono esserlo. "
+"Ha creduto troppo nell'onestà di un uomo, e Lazarus l'ha guidato verso la morte. "
+"Oh, so come stanno le cose laggiù, quindi non iniziare nemmeno a parlarmi dei tuoi "
+"progetti d'eliminare il male che dimora nel Labirinto. Solo, fa attenzione alle "
+"tue gambe... |"
 
 #: Source/textdat.cpp:465
 msgid ""
 "As long as you don't need anything reattached, old Pepin is as good as they "
 "come. \n"
 " \n"
-"If I'd have had some of those potions he brews, I might still have my leg... "
-"|"
+"If I'd have had some of those potions he brews, I might still have my leg... |"
 msgstr ""
-"Finché non hai bisogno di riattaccarti qualcosa il vecchio Pepin è il "
-"migliore. \n"
+"Finché non hai bisogno di riattaccarti qualcosa il vecchio Pepin è il migliore. \n"
 "\n"
-"Se avessi avuto alcune delle pozioni che rimesta, forse avrei ancora la "
-"gamba... |"
+"Se avessi avuto alcune delle pozioni che rimesta, forse avrei ancora la gamba... |"
 
 #: Source/textdat.cpp:467
 msgid ""
-"Adria truly bothers me. Sure, Cain is creepy in what he can tell you about "
-"the past, but that witch can see into your past. She always has some way to "
-"get whatever she needs, too. Adria gets her hands on more merchandise than "
-"I've seen pass through the gates of the King's Bazaar during High Festival. |"
+"Adria truly bothers me. Sure, Cain is creepy in what he can tell you about the "
+"past, but that witch can see into your past. She always has some way to get "
+"whatever she needs, too. Adria gets her hands on more merchandise than I've seen "
+"pass through the gates of the King's Bazaar during High Festival. |"
 msgstr ""
-"Adria fa paura. Cain dà i brividi per quello che può dirti sul passato, ma "
-"quella strega può vedere nel tuo passato. Inoltre, ha sempre un modo per "
-"avere quello di cui ha bisogno. Adria mette le mani su più mercanzia di "
-"quella che ho visto passare per i cancelli del Bazaar Reale in piena festa. |"
+"Adria fa paura. Cain dà i brividi per quello che può dirti sul passato, ma quella "
+"strega può vedere nel tuo passato. Inoltre, ha sempre un modo per avere quello di "
+"cui ha bisogno. Adria mette le mani su più mercanzia di quella che ho visto "
+"passare per i cancelli del Bazaar Reale in piena festa. |"
 
 #: Source/textdat.cpp:469
 msgid ""
 "Ogden is a fool for staying here. I could get him out of town for a very "
-"reasonable price, but he insists on trying to make a go of it with that "
-"stupid tavern. I guess at the least he gives Gillian a place to work, and "
-"his wife Garda does make a superb Shepherd's pie... |"
+"reasonable price, but he insists on trying to make a go of it with that stupid "
+"tavern. I guess at the least he gives Gillian a place to work, and his wife Garda "
+"does make a superb Shepherd's pie... |"
 msgstr ""
 "Ogden è un pazzo a rimanere qui. Posso farlo uscire dalla città ad un prezzo "
-"ragionevole, ma continua ad insistere a mandare avanti quella stupida "
-"taverna. Almeno da a Gillian un lavoro, e sua moglie Garda prepara una "
-"superba torta del pastore a base di carne e patate. |"
+"ragionevole, ma continua ad insistere a mandare avanti quella stupida taverna. "
+"Almeno da a Gillian un lavoro, e sua moglie Garda prepara una superba torta del "
+"pastore a base di carne e patate. |"
 
 #: Source/textdat.cpp:471 Source/textdat.cpp:479 Source/textdat.cpp:487
 msgid ""
-"Beyond the Hall of Heroes lies the Chamber of Bone. Eternal death awaits any "
-"who would seek to steal the treasures secured within this room. So speaks "
-"the Lord of Terror, and so it is written. |"
+"Beyond the Hall of Heroes lies the Chamber of Bone. Eternal death awaits any who "
+"would seek to steal the treasures secured within this room. So speaks the Lord of "
+"Terror, and so it is written. |"
 msgstr ""
-"Oltre la Sala degli Eroi si trova la Camera d'Ossa. Morte eterna attende "
-"coloro che cercassero di rubare i tesori protetti in essa. Così parla il "
-"Signore del Terrore, e così è scritto. |"
+"Oltre la Sala degli Eroi si trova la Camera d'Ossa. Morte eterna attende coloro "
+"che cercassero di rubare i tesori protetti in essa. Così parla il Signore del "
+"Terrore, e così è scritto. |"
 
 #: Source/textdat.cpp:473 Source/textdat.cpp:481 Source/textdat.cpp:489
 #: Source/textdat.cpp:527 Source/textdat.cpp:535
 msgid ""
-"...and so, locked beyond the Gateway of Blood and past the Hall of Fire, "
-"Valor awaits for the Hero of Light to awaken... |"
+"...and so, locked beyond the Gateway of Blood and past the Hall of Fire, Valor "
+"awaits for the Hero of Light to awaken... |"
 msgstr ""
-"...e così, chiusa oltre l'Ingresso di Sangue e la Sala di Fuoco, Valor "
-"attende l'Eroe della Luce per svegliarsi... |"
+"...e così, chiusa oltre l'Ingresso di Sangue e la Sala di Fuoco, Valor attende "
+"l'Eroe della Luce per svegliarsi... |"
 
 #: Source/textdat.cpp:475 Source/textdat.cpp:483 Source/textdat.cpp:491
 #: Source/textdat.cpp:529 Source/textdat.cpp:537
@@ -9237,420 +9079,399 @@ msgstr ""
 "Se ti giri spariranno.\n"
 "Canzon segrete sussurreranno.\n"
 "Tu vedrai ciò che esser non può.\n"
-"Ombre in luce muoversi un pò.\n"
+"Ombre in luce muoversi un po'.\n"
 "Lontani da luce e oscurità.\n"
 "La Camera dei Ciechi ti opprimerà. |\n"
 
 #: Source/textdat.cpp:477 Source/textdat.cpp:485 Source/textdat.cpp:493
 msgid ""
 "The armories of Hell are home to the Warlord of Blood. In his wake lay the "
-"mutilated bodies of thousands. Angels and men alike have been cut down to "
-"fulfill his endless sacrifices to the Dark ones who scream for one thing - "
-"blood. |"
+"mutilated bodies of thousands. Angels and men alike have been cut down to fulfill "
+"his endless sacrifices to the Dark ones who scream for one thing - blood. |"
 msgstr ""
-"Nelle armerie infernali risiede il Signore del Sangue. Sul suo cammino "
-"giacciono migliaia di corpi mutilati. Senza distinzione angeli e uomini sono "
-"stati trucidati per i suoi sacrifici agli Oscuri che esigono solo una cosa - "
-"sangue.|"
+"Nelle armerie infernali risiede il Signore del Sangue. Sul suo cammino giacciono "
+"migliaia di corpi mutilati. Senza distinzione angeli e uomini sono stati trucidati "
+"per i suoi sacrifici agli Oscuri che esigono solo una cosa - sangue.|"
 
 #: Source/textdat.cpp:505
 msgid ""
-"Take heed and bear witness to the truths that lie herein, for they are the "
-"last legacy of the Horadrim. There is a war that rages on even now, beyond "
-"the fields that we know - between the utopian kingdoms of the High Heavens "
-"and the chaotic pits of the Burning Hells. This war is known as the Great "
-"Conflict, and it has raged and burned longer than any of the stars in the "
-"sky. Neither side ever gains sway for long as the forces of Light and "
-"Darkness constantly vie for control over all creation. |"
+"Take heed and bear witness to the truths that lie herein, for they are the last "
+"legacy of the Horadrim. There is a war that rages on even now, beyond the fields "
+"that we know - between the utopian kingdoms of the High Heavens and the chaotic "
+"pits of the Burning Hells. This war is known as the Great Conflict, and it has "
+"raged and burned longer than any of the stars in the sky. Neither side ever gains "
+"sway for long as the forces of Light and Darkness constantly vie for control over "
+"all creation. |"
 msgstr ""
-"Presta attenzione e porta testimonianza della verità che qui leggerai, "
-"perché sono l'ultimo lascito dell'Horadrim. C'è una guerra che infuria,ben "
-"oltre quello che conosciamo - fra gli utopici Regni Celesti e i pozzi "
-"caotici degli Inferni - Questa guerra è conosciuta come il Grande Conflitto, "
-"e dura da molto più delle stelle. Nessuna parte ha guadagnato influenza a "
-"lungo mentre la luce e l'oscurità continuano a gareggiare per il controllo "
-"su tutto il creato. |"
+"Presta attenzione e porta testimonianza della verità che qui leggerai, perché sono "
+"l'ultimo lascito dell'Horadrim. C'è una guerra che infuria,ben oltre quello che "
+"conosciamo - fra gli utopici Regni Celesti e i pozzi caotici degli Inferni - "
+"Questa guerra è conosciuta come il Grande Conflitto, e dura da molto più delle "
+"stelle. Nessuna parte ha guadagnato influenza a lungo mentre la luce e l'oscurità "
+"continuano a gareggiare per il controllo su tutto il creato. |"
 
 #: Source/textdat.cpp:507
 msgid ""
-"Take heed and bear witness to the truths that lie herein, for they are the "
-"last legacy of the Horadrim. When the Eternal Conflict between the High "
-"Heavens and the Burning Hells falls upon mortal soil, it is called the Sin "
-"War. Angels and Demons walk amongst humanity in disguise, fighting in "
-"secret, away from the prying eyes of mortals. Some daring, powerful mortals "
-"have even allied themselves with either side, and helped to dictate the "
-"course of the Sin War. |"
+"Take heed and bear witness to the truths that lie herein, for they are the last "
+"legacy of the Horadrim. When the Eternal Conflict between the High Heavens and the "
+"Burning Hells falls upon mortal soil, it is called the Sin War. Angels and Demons "
+"walk amongst humanity in disguise, fighting in secret, away from the prying eyes "
+"of mortals. Some daring, powerful mortals have even allied themselves with either "
+"side, and helped to dictate the course of the Sin War. |"
 msgstr ""
-"Presta attenzione e porta testimonianza delle verità che qui leggerai, "
-"perché sono l'ultimo lascito dell'Horadrim. Quando il Conflitto Eterno fra i "
-"Regni Celesti e gli Inferni Fiammeggianti si sposta su suolo mortale, è "
-"detta la Guerra del Peccato. Angeli e demoni girano in incognito fra gli "
-"uomini, combattendo in segreto lontani da occhi mortali. Alcuni potenti "
-"mortali si allearono con l'una o l'altra parte, e aiutarono a dettare il "
-"corso della guerra. |"
+"Presta attenzione e porta testimonianza delle verità che qui leggerai, perché sono "
+"l'ultimo lascito dell'Horadrim. Quando il Conflitto Eterno fra i Regni Celesti e "
+"gli Inferni Fiammeggianti si sposta su suolo mortale, è detta la Guerra del "
+"Peccato. Angeli e demoni girano in incognito fra gli uomini, combattendo in "
+"segreto lontani da occhi mortali. Alcuni potenti mortali si allearono con l'una o "
+"l'altra parte, e aiutarono a dettare il corso della guerra. |"
 
 #: Source/textdat.cpp:509
 msgid ""
-"Take heed and bear witness to the truths that lie herein, for they are the "
-"last legacy of the Horadrim. Nearly three hundred years ago, it came to be "
-"known that the Three Prime Evils of the Burning Hells had mysteriously come "
-"to our world. The Three Brothers ravaged the lands of the east for decades, "
-"while humanity was left trembling in their wake. Our Order - the Horadrim - "
-"was founded by a group of secretive magi to hunt down and capture the Three "
-"Evils once and for all.\n"
+"Take heed and bear witness to the truths that lie herein, for they are the last "
+"legacy of the Horadrim. Nearly three hundred years ago, it came to be known that "
+"the Three Prime Evils of the Burning Hells had mysteriously come to our world. The "
+"Three Brothers ravaged the lands of the east for decades, while humanity was left "
+"trembling in their wake. Our Order - the Horadrim - was founded by a group of "
+"secretive magi to hunt down and capture the Three Evils once and for all.\n"
 " \n"
-"The original Horadrim captured two of the Three within powerful artifacts "
-"known as Soulstones and buried them deep beneath the desolate eastern sands. "
-"The third Evil escaped capture and fled to the west with many of the "
-"Horadrim in pursuit. The Third Evil - known as Diablo, the Lord of Terror - "
-"was eventually captured, his essence set in a Soulstone and buried within "
-"this Labyrinth.\n"
+"The original Horadrim captured two of the Three within powerful artifacts known as "
+"Soulstones and buried them deep beneath the desolate eastern sands. The third Evil "
+"escaped capture and fled to the west with many of the Horadrim in pursuit. The "
+"Third Evil - known as Diablo, the Lord of Terror - was eventually captured, his "
+"essence set in a Soulstone and buried within this Labyrinth.\n"
 " \n"
 "Be warned that the soulstone must be kept from discovery by those not of the "
 "faith. If Diablo were to be released, he would seek a body that is easily "
-"controlled as he would be very weak - perhaps that of an old man or a child. "
-"|"
+"controlled as he would be very weak - perhaps that of an old man or a child. |"
 msgstr ""
-"Presta attenzione e porta testimonianza delle verità che qui leggerai, "
-"perché sono l'ultimo lascito dell'Horadrim. Quasi trecento anni fa, i Tre "
-"Mali Maggiori degli Inferni Fiammeggianti giunsero misteriosamente nel "
-"nostro mondo. I tre fratelli devastarono l'oriente per decadi, mentre "
-"l'umanità tremava al loro passaggio. Il nostro ordine - l'Horadrim - fu "
-"fondato da un gruppo segreto di maghi per catturare i tre mali una volta per "
-"tutte.\n"
+"Presta attenzione e porta testimonianza delle verità che qui leggerai, perché sono "
+"l'ultimo lascito dell'Horadrim. Quasi trecento anni fa, i Tre Mali Maggiori degli "
+"Inferni Fiammeggianti giunsero misteriosamente nel nostro mondo. I tre fratelli "
+"devastarono l'oriente per decadi, mentre l'umanità tremava al loro passaggio. Il "
+"nostro ordine - l'Horadrim - fu fondato da un gruppo segreto di maghi per "
+"catturare i tre mali una volta per tutte.\n"
 "\n"
-"Gli Horadrim catturarono due dei tre all'interno di potenti artefatti noti "
-"come Pietre dell'Anima e li seppellirono nelle profondità dei deserti "
-"orientali. Il terzo male evitò la cattura e fuggì ad ovest con molti "
-"Horadrim sulle sue tracce. Il terzo male - conosciuto come Diablo, il "
-"Signore del Terrore - venne poi catturato, la sua essenza intrappolata in "
-"una pietra dell'anima e sepolta in questo Labirinto.\n"
+"Gli Horadrim catturarono due dei tre all'interno di potenti artefatti noti come "
+"Pietre dell'Anima e li seppellirono nelle profondità dei deserti orientali. Il "
+"terzo male evitò la cattura e fuggì ad ovest con molti Horadrim sulle sue tracce. "
+"Il terzo male - conosciuto come Diablo, il Signore del Terrore - venne poi "
+"catturato, la sua essenza intrappolata in una pietra dell'anima e sepolta in "
+"questo Labirinto.\n"
 "\n"
-"Fai attenzione, la pietra dell'anima dev'essere celata a chi non è "
-"preparato. Se Diablo venisse liberato, cercherebbe un corpo facilmente "
-"controllabile perché sarebbe molto debole - probabilmente quello di un "
-"vecchio o di un bambino. |"
+"Fai attenzione, la pietra dell'anima dev'essere celata a chi non è preparato. Se "
+"Diablo venisse liberato, cercherebbe un corpo facilmente controllabile perché "
+"sarebbe molto debole - probabilmente quello di un vecchio o di un bambino. |"
 
 #: Source/textdat.cpp:511
 msgid ""
-"So it came to be that there was a great revolution within the Burning Hells "
-"known as The Dark Exile. The Lesser Evils overthrew the Three Prime Evils "
-"and banished their spirit forms to the mortal realm. The demons Belial (the "
-"Lord of Lies) and Azmodan (the Lord of Sin) fought to claim rulership of "
-"Hell during the absence of the Three Brothers. All of Hell polarized between "
-"the factions of Belial and Azmodan while the forces of the High Heavens "
-"continually battered upon the very Gates of Hell. |"
+"So it came to be that there was a great revolution within the Burning Hells known "
+"as The Dark Exile. The Lesser Evils overthrew the Three Prime Evils and banished "
+"their spirit forms to the mortal realm. The demons Belial (the Lord of Lies) and "
+"Azmodan (the Lord of Sin) fought to claim rulership of Hell during the absence of "
+"the Three Brothers. All of Hell polarized between the factions of Belial and "
+"Azmodan while the forces of the High Heavens continually battered upon the very "
+"Gates of Hell. |"
 msgstr ""
-"Così ebbe inizio un grande tumulto negli inferni fiammeggianti conosciuto "
-"come Esilio Oscuro. I Mali Minori spodestarono i Tre Mali Maggiori e "
-"bandirono le loro forme spirituali nel reame dei mortali. I demoni Belial "
-"(il Signore della Menzogna) e Azmodan (il Signore del Peccato) combatterono "
-"per affermare il proprio dominio sull'Inferno durante l'assenza dei tre. "
-"L'Inferno si divise fra le fazioni di Belial e Azmodan, mentre le forze "
-"celesti continuavano a premere sui Cancelli Infernali. |"
+"Così ebbe inizio un grande tumulto negli inferni fiammeggianti conosciuto come "
+"Esilio Oscuro. I Mali Minori spodestarono i Tre Mali Maggiori e bandirono le loro "
+"forme spirituali nel reame dei mortali. I demoni Belial (il Signore della "
+"Menzogna) e Azmodan (il Signore del Peccato) combatterono per affermare il proprio "
+"dominio sull'Inferno durante l'assenza dei tre. L'Inferno si divise fra le fazioni "
+"di Belial e Azmodan, mentre le forze celesti continuavano a premere sui Cancelli "
+"Infernali. |"
 
 #: Source/textdat.cpp:513
 msgid ""
-"Many demons traveled to the mortal realm in search of the Three Brothers. "
-"These demons were followed to the mortal plane by Angels who hunted them "
-"throughout the vast cities of the East. The Angels allied themselves with a "
-"secretive Order of mortal magi named the Horadrim, who quickly became adept "
-"at hunting demons. They also made many dark enemies in the underworlds. |"
+"Many demons traveled to the mortal realm in search of the Three Brothers. These "
+"demons were followed to the mortal plane by Angels who hunted them throughout the "
+"vast cities of the East. The Angels allied themselves with a secretive Order of "
+"mortal magi named the Horadrim, who quickly became adept at hunting demons. They "
+"also made many dark enemies in the underworlds. |"
 msgstr ""
-"Molti demoni si spostarono nel reame dei mortali in cerca dei tre fratelli. "
-"Questi demoni vennero seguiti da Angeli che li perseguitarono attraverso le "
-"vaste città d'oriente. Gli angeli si allearono con un ordine segreto di "
-"maghi mortali chiamato Horadrim, che divennero ben presto maestri nel "
-"cacciare demoni. Si fecero anche molti oscuri nemici nei regni d'oltretomba. "
-"|"
+"Molti demoni si spostarono nel reame dei mortali in cerca dei tre fratelli. Questi "
+"demoni vennero seguiti da Angeli che li perseguitarono attraverso le vaste città "
+"d'oriente. Gli angeli si allearono con un ordine segreto di maghi mortali chiamato "
+"Horadrim, che divennero ben presto maestri nel cacciare demoni. Si fecero anche "
+"molti oscuri nemici nei regni d'oltretomba. |"
 
 #: Source/textdat.cpp:515
 msgid ""
-"So it came to be that the Three Prime Evils were banished in spirit form to "
-"the mortal realm and after sewing chaos across the East for decades, they "
-"were hunted down by the cursed Order of the mortal Horadrim. The Horadrim "
-"used artifacts called Soulstones to contain the essence of Mephisto, the "
-"Lord of Hatred and his brother Baal, the Lord of Destruction. The youngest "
-"brother - Diablo, the Lord of Terror - escaped to the west.\n"
+"So it came to be that the Three Prime Evils were banished in spirit form to the "
+"mortal realm and after sewing chaos across the East for decades, they were hunted "
+"down by the cursed Order of the mortal Horadrim. The Horadrim used artifacts "
+"called Soulstones to contain the essence of Mephisto, the Lord of Hatred and his "
+"brother Baal, the Lord of Destruction. The youngest brother - Diablo, the Lord of "
+"Terror - escaped to the west.\n"
 " \n"
-"Eventually the Horadrim captured Diablo within a Soulstone as well, and "
-"buried him under an ancient, forgotten Cathedral. There, the Lord of Terror "
-"sleeps and awaits the time of his rebirth. Know ye that he will seek a body "
-"of youth and power to possess - one that is innocent and easily controlled. "
-"He will then arise to free his Brothers and once more fan the flames of the "
-"Sin War... |"
+"Eventually the Horadrim captured Diablo within a Soulstone as well, and buried him "
+"under an ancient, forgotten Cathedral. There, the Lord of Terror sleeps and awaits "
+"the time of his rebirth. Know ye that he will seek a body of youth and power to "
+"possess - one that is innocent and easily controlled. He will then arise to free "
+"his Brothers and once more fan the flames of the Sin War... |"
 msgstr ""
-"Così accadde che i Tre Mali Maggiori furono banditi in forma spirituale nel "
-"reame dei mortali e dopo aver sparso caos in oriente per decadi, vennero "
-"cacciati dal maledetto Ordine Horadrim. L'Horadrim usò artefatti chiamati "
-"Pietre dell'Anima per contenere l'essenza di Mephisto, il Signore dell'Odio "
-"e di Baal, il Signore della Distruzione. Il fratello più giovane - Diablo, "
-"il Signore del Terrore - fuggì ad ovest.\n"
+"Così accadde che i Tre Mali Maggiori furono banditi in forma spirituale nel reame "
+"dei mortali e dopo aver sparso caos in oriente per decadi, vennero cacciati dal "
+"maledetto Ordine Horadrim. L'Horadrim usò artefatti chiamati Pietre dell'Anima per "
+"contenere l'essenza di Mephisto, il Signore dell'Odio e di Baal, il Signore della "
+"Distruzione. Il fratello più giovane - Diablo, il Signore del Terrore - fuggì ad "
+"ovest.\n"
 "\n"
-"L'Horadrim riuscì poi a catturare anche Diablo in una Pietra dell'Anima, che "
-"venne sepolta sotto un'antica Cattedrale dimenticata. Qui, il Signore del "
-"Terrore dorme e attende il tempo della sua rinascita. Egli cercherà un corpo "
-"giovane e forte da possedere - uno che sia innocente e facile da "
-"controllare. Sorgerà quindi per liberare i suoi fratelli e attizzare le "
-"fiamme della Guerra del Peccato... |"
+"L'Horadrim riuscì poi a catturare anche Diablo in una Pietra dell'Anima, che venne "
+"sepolta sotto un'antica Cattedrale dimenticata. Qui, il Signore del Terrore dorme "
+"e attende il tempo della sua rinascita. Egli cercherà un corpo giovane e forte da "
+"possedere - uno che sia innocente e facile da controllare. Sorgerà quindi per "
+"liberare i suoi fratelli e attizzare le fiamme della Guerra del Peccato... |"
 
 #: Source/textdat.cpp:517
 msgid ""
-"All praises to Diablo - Lord of Terror and Survivor of The Dark Exile. When "
-"he awakened from his long slumber, my Lord and Master spoke to me of secrets "
-"that few mortals know. He told me the kingdoms of the High Heavens and the "
-"pits of the Burning Hells engage in an eternal war. He revealed the powers "
-"that have brought this discord to the realms of man. My lord has named the "
-"battle for this world and all who exist here the Sin War. |"
+"All praises to Diablo - Lord of Terror and Survivor of The Dark Exile. When he "
+"awakened from his long slumber, my Lord and Master spoke to me of secrets that few "
+"mortals know. He told me the kingdoms of the High Heavens and the pits of the "
+"Burning Hells engage in an eternal war. He revealed the powers that have brought "
+"this discord to the realms of man. My lord has named the battle for this world and "
+"all who exist here the Sin War. |"
 msgstr ""
-"Tutti adorino Diablo, Signore del Terrore e superstite dell'Esilio Oscuro. "
-"Quando si svegliò dal suo sonno, il mio signore e padrone mi parlò di "
-"segreti che pochi mortali conoscono. Mi raccontò come i Regni Celesti e i "
-"pozzi dell'Inferno si scontrarono in una eterna guerra. Mi rivelò i fatti "
-"che portarono questa lotta nei reami umani. Egli ha chiamato questa "
-"battaglia per tutti i mondi che esistono, la Guerra del Peccato. |"
+"Tutti adorino Diablo, Signore del Terrore e superstite dell'Esilio Oscuro. Quando "
+"si svegliò dal suo sonno, il mio signore e padrone mi parlò di segreti che pochi "
+"mortali conoscono. Mi raccontò come i Regni Celesti e i pozzi dell'Inferno si "
+"scontrarono in una eterna guerra. Mi rivelò i fatti che portarono questa lotta nei "
+"reami umani. Egli ha chiamato questa battaglia per tutti i mondi che esistono, la "
+"Guerra del Peccato. |"
 
 #: Source/textdat.cpp:519
 msgid ""
-"Glory and Approbation to Diablo - Lord of Terror and Leader of the Three. My "
-"Lord spoke to me of his two Brothers, Mephisto and Baal, who were banished "
-"to this world long ago. My Lord wishes to bide his time and harness his "
-"awesome power so that he may free his captive brothers from their tombs "
-"beneath the sands of the east. Once my Lord releases his Brothers, the Sin "
-"War will once again know the fury of the Three. |"
+"Glory and Approbation to Diablo - Lord of Terror and Leader of the Three. My Lord "
+"spoke to me of his two Brothers, Mephisto and Baal, who were banished to this "
+"world long ago. My Lord wishes to bide his time and harness his awesome power so "
+"that he may free his captive brothers from their tombs beneath the sands of the "
+"east. Once my Lord releases his Brothers, the Sin War will once again know the "
+"fury of the Three. |"
 msgstr ""
-"Gloria e Onori a Diablo, Signore del Terrore e leader dei Tre. Il mio "
-"Signore mi parlò dei suoi fratelli, Mephisto e Baal, banditi in questo mondo "
-"secoli fa. Egli attende per scatenare il suo immenso potere che può liberare "
-"i suoi fratelli rinchiusi nei loro sepolcri sotto le sabbie dell'est. Una "
-"volta che il mio signore avrà liberato i suoi fratelli, la guerra del "
-"peccato conoscerà di nuovo la furia dei tre. |"
+"Gloria e Onori a Diablo, Signore del Terrore e leader dei Tre. Il mio Signore mi "
+"parlò dei suoi fratelli, Mephisto e Baal, banditi in questo mondo secoli fa. Egli "
+"attende per scatenare il suo immenso potere che può liberare i suoi fratelli "
+"rinchiusi nei loro sepolcri sotto le sabbie dell'est. Una volta che il mio signore "
+"avrà liberato i suoi fratelli, la guerra del peccato conoscerà di nuovo la furia "
+"dei tre. |"
 
 #: Source/textdat.cpp:521
 msgid ""
-"Hail and Sacrifice to Diablo - Lord of Terror and Destroyer of Souls. When I "
-"awoke my Master from his sleep, he attempted to possess a mortal's form. "
-"Diablo attempted to claim the body of King Leoric, but my Master was too "
-"weak from his imprisonment. My Lord required a simple and innocent anchor to "
-"this world, and so found the boy Albrecht to be perfect for the task. While "
-"the good King Leoric was left maddened by Diablo's unsuccessful possession, "
-"I kidnapped his son Albrecht and brought him before my Master. I now await "
-"Diablo's call and pray that I will be rewarded when he at last emerges as "
-"the Lord of this world. |"
+"Hail and Sacrifice to Diablo - Lord of Terror and Destroyer of Souls. When I awoke "
+"my Master from his sleep, he attempted to possess a mortal's form. Diablo "
+"attempted to claim the body of King Leoric, but my Master was too weak from his "
+"imprisonment. My Lord required a simple and innocent anchor to this world, and so "
+"found the boy Albrecht to be perfect for the task. While the good King Leoric was "
+"left maddened by Diablo's unsuccessful possession, I kidnapped his son Albrecht "
+"and brought him before my Master. I now await Diablo's call and pray that I will "
+"be rewarded when he at last emerges as the Lord of this world. |"
 msgstr ""
-"Saluti e onori a Diablo - Signore del Terrore e Distruttore d'Anime. Quando "
-"ho destato il mio Padrone dal suo sonno, tentò di possedere una forma "
-"mortale. Diablo provò a reclamare il corpo di Re Leoric, ma il mio Padrone "
-"era troppo provato dalla sua prigionia. Il mio Signore abbisognava di un "
-"innocente legame a questo mondo, e trovò il giovane Albrecht perfetto in "
-"questo ruolo. Mentre Re Leoric impazziva, per il fallito tentativo di "
-"possessione di Diablo, rapii Albrecht e lo donai al mio Padrone. Ora aspetto "
-"la chiamata di Diablo e spero in una ricompensa quando alla fine si ergerà "
-"come Signore del mondo. |"
+"Saluti e onori a Diablo - Signore del Terrore e Distruttore d'Anime. Quando ho "
+"destato il mio Padrone dal suo sonno, tentò di possedere una forma mortale. Diablo "
+"provò a reclamare il corpo di Re Leoric, ma il mio Padrone era troppo provato "
+"dalla sua prigionia. Il mio Signore abbisognava di un innocente legame a questo "
+"mondo, e trovò il giovane Albrecht perfetto in questo ruolo. Mentre Re Leoric "
+"impazziva, per il fallito tentativo di possessione di Diablo, rapii Albrecht e lo "
+"donai al mio Padrone. Ora aspetto la chiamata di Diablo e spero in una ricompensa "
+"quando alla fine si ergerà come Signore del mondo. |"
 
 #: Source/textdat.cpp:523
 msgid ""
 "Thank goodness you've returned!\n"
-"Much has changed since you lived here, my friend. All was peaceful until the "
-"dark riders came and destroyed our village. Many were cut down where they "
-"stood, and those who took up arms were slain or dragged away to become "
-"slaves - or worse. The church at the edge of town has been desecrated and is "
-"being used for dark rituals. The screams that echo in the night are inhuman, "
-"but some of our townsfolk may yet survive. Follow the path that lies between "
-"my tavern and the blacksmith shop to find the church and save who you can. \n"
+"Much has changed since you lived here, my friend. All was peaceful until the dark "
+"riders came and destroyed our village. Many were cut down where they stood, and "
+"those who took up arms were slain or dragged away to become slaves - or worse. The "
+"church at the edge of town has been desecrated and is being used for dark rituals. "
+"The screams that echo in the night are inhuman, but some of our townsfolk may yet "
+"survive. Follow the path that lies between my tavern and the blacksmith shop to "
+"find the church and save who you can. \n"
 " \n"
 "Perhaps I can tell you more if we speak again. Good luck.|"
 msgstr ""
 "Grazie al cielo sei tornato!\n"
-"Molto è cambiato da quando vivevi qui amico mio. Tutto era pacifico fin "
-"quanto i cavalieri neri non razziarono il villaggio. Molti vennero uccisi "
-"subito e quelli che si difesero furono trucidati o trascinati via per "
-"diventare schiavi, o peggio. La chiesa ai limiti del paese è stata "
-"sconsacrata ed è usata per oscuri rituali. Le urla che risuonano nella notte "
-"sono inumane, ma alcuni dei nostri compaesani potrebbero ancora essere vivi. "
-"Per trovare la chiesa segui il sentiero fra la mia taverna e la fucina, "
-"cerca di salvarli. \n"
+"Molto è cambiato da quando vivevi qui amico mio. Tutto era pacifico fin quando i "
+"cavalieri neri non razziarono il villaggio. Molti vennero uccisi subito e quelli "
+"che si difesero furono trucidati o trascinati via per diventare schiavi, o peggio. "
+"La chiesa ai limiti del paese è stata sconsacrata ed è usata per oscuri rituali. "
+"Le urla che risuonano nella notte sono inumane, ma alcuni dei nostri compaesani "
+"potrebbero ancora essere vivi. Per trovare la chiesa segui il sentiero fra la mia "
+"taverna e la fucina, cerca di salvarli. \n"
 " \n"
 "Forse la prossima volta saprò dirti di più. Buona fortuna.|"
 
 #: Source/textdat.cpp:525 Source/textdat.cpp:533
 msgid ""
-"Beyond the Hall of Heroes lies the Chamber of Bone.  Eternal death awaits "
-"any who would seek to steal the treasures secured within this room.  So "
-"speaks the Lord of Terror, and so it is written. |"
+"Beyond the Hall of Heroes lies the Chamber of Bone.  Eternal death awaits any who "
+"would seek to steal the treasures secured within this room.  So speaks the Lord of "
+"Terror, and so it is written. |"
 msgstr ""
-"Oltre la Sala degli Eroi si trova la Camera d'Ossa. Morte eterna attende "
-"coloro che cercassero di rubare i tesori protetti in essa. Cosi' parla il "
-"Signore del Terrore, e cosi' è scritto. |"
+"Oltre la Sala degli Eroi si trova la Camera d'Ossa. Morte eterna attende coloro "
+"che cercassero di rubare i tesori protetti in essa. Così parla il Signore del "
+"Terrore, e così è scritto. |"
 
 #: Source/textdat.cpp:531 Source/textdat.cpp:539
 msgid ""
 "The armories of Hell are home to the Warlord of Blood.  In his wake lay the "
-"mutilated bodies of thousands.  Angels and man alike have been cut down to "
-"fulfill his endless sacrifices to the Dark ones who scream for one thing - "
-"blood. |"
+"mutilated bodies of thousands.  Angels and man alike have been cut down to fulfill "
+"his endless sacrifices to the Dark ones who scream for one thing - blood. |"
 msgstr ""
-"Nelle armerie infernali risiede il Signore del Sangue. Sul suo cammino "
-"giacciono migliaia di corpi mutilati. Senza distinzione angeli e uomini sono "
-"stati trucidati per i suoi sacrifici agli Oscuri che esigono solo una cosa - "
-"sangue. |"
+"Nelle armerie infernali risiede il Signore del Sangue. Sul suo cammino giacciono "
+"migliaia di corpi mutilati. Senza distinzione angeli e uomini sono stati trucidati "
+"per i suoi sacrifici agli Oscuri che esigono solo una cosa - sangue. |"
 
 #: Source/textdat.cpp:541
 msgid ""
-"Maintain your quest.  Finding a treasure that is lost is not easy.  Finding "
-"a treasure that is hidden less so.  I will leave you with this.  Do not let "
-"the sands of time confuse your search.|"
+"Maintain your quest.  Finding a treasure that is lost is not easy.  Finding a "
+"treasure that is hidden less so.  I will leave you with this.  Do not let the "
+"sands of time confuse your search.|"
 msgstr ""
-"Perdura nella tua missione. Trovare un tesoro disperso non è facile. Scovare "
-"un tesoro celato ancor meno. Ti lascio con questo. Non lasciare che le "
-"sabbie del tempo confondano la tua ricerca.|"
+"Perdura nella tua missione. Trovare un tesoro disperso non è facile. Scovare un "
+"tesoro celato ancor meno. Ti lascio con questo. Non lasciare che le sabbie del "
+"tempo confondano la tua ricerca.|"
 
 #: Source/textdat.cpp:543
 msgid ""
-"A what?!  This is foolishness.  There's no treasure buried here in "
-"Tristram.  Let me see that!!  Ah, Look these drawings are inaccurate.  They "
-"don't match our town at all.  I'd keep my mind on what lies below the "
-"cathedral and not what lies below our topsoil.|"
+"A what?!  This is foolishness.  There's no treasure buried here in Tristram.  Let "
+"me see that!!  Ah, Look these drawings are inaccurate.  They don't match our town "
+"at all.  I'd keep my mind on what lies below the cathedral and not what lies below "
+"our topsoil.|"
 msgstr ""
-"Un cosa?! Questa è follia. Non c'è tesoro sepolto a Tristram. Fammi vedere! "
-"Ah, guarda questi disegni inesatti. Non combaciano con la nostra città. "
-"Rimarrò con la mente su ciò che si trova sotto la cattedrale e non su ciò "
-"che sta nel nostro sottosuolo.|"
+"Un cosa?! Questa è follia. Non c'è tesoro sepolto a Tristram. Fammi vedere! Ah, "
+"guarda questi disegni inesatti. Non combaciano con la nostra città. Rimarrò con la "
+"mente su ciò che si trova sotto la cattedrale e non su ciò che sta nel nostro "
+"sottosuolo.|"
 
 #: Source/textdat.cpp:545
 msgid ""
-"I really don't have time to discuss some map you are looking for.  I have "
-"many sick people that require my help and yours as well.|"
+"I really don't have time to discuss some map you are looking for.  I have many "
+"sick people that require my help and yours as well.|"
 msgstr ""
-"Non ho veramente tempo di discutere sulla mappa che stai cercando. Ho molta "
-"gente malata che richiede il mio aiuto e anche il tuo.|"
+"Non ho veramente tempo di discutere sulla mappa che stai cercando. Ho molta gente "
+"malata che richiede il mio aiuto e anche il tuo.|"
 
 #: Source/textdat.cpp:547 Source/textdat.cpp:559
 msgid ""
-"The once proud Iswall is trapped deep beneath the surface of this world.  "
-"His honor stripped and his visage altered.  He is trapped in immortal "
-"torment.  Charged to conceal the very thing that could free him.|"
+"The once proud Iswall is trapped deep beneath the surface of this world.  His "
+"honor stripped and his visage altered.  He is trapped in immortal torment.  "
+"Charged to conceal the very thing that could free him.|"
 msgstr ""
 "Il fiero Iswall è intrappolato nelle profondità di questo mondo. Spogliato "
-"dell'onore e sfigurato in viso. Egli è intrappolato in un tormento "
-"immortale. Incaricato a celare la cosa che potrebbe liberarlo.|"
+"dell'onore e sfigurato in viso. Egli è intrappolato in un tormento immortale. "
+"Incaricato a celare la cosa che potrebbe liberarlo.|"
 
 #: Source/textdat.cpp:549
 msgid ""
-"I'll bet that Wirt saw you coming and put on an act just so he could laugh "
-"at you later when you were running around the town with your nose in the "
-"dirt.  I'd ignore it.|"
+"I'll bet that Wirt saw you coming and put on an act just so he could laugh at you "
+"later when you were running around the town with your nose in the dirt.  I'd "
+"ignore it.|"
 msgstr ""
-"Scommetto che Wirt vedendoti arrivare improvvisò una sceneggiata per "
-"deriderti più tardi, quando avresti girato in città col tuo naso "
-"nell'immondizia. Io l'ignorerei.|"
+"Scommetto che Wirt vedendoti arrivare improvvisò una sceneggiata per deriderti più "
+"tardi, quando avresti girato in città col tuo naso nell'immondizia. Io "
+"l'ignorerei.|"
 
 #: Source/textdat.cpp:551
 msgid ""
-"There was a time when this town was a frequent stop for travelers from far "
-"and wide.  Much has changed since then.  But hidden caves and buried "
-"treasure are common fantasies of any child.  Wirt seldom indulges in "
-"youthful games.  So it may just be his imagination.|"
+"There was a time when this town was a frequent stop for travelers from far and "
+"wide.  Much has changed since then.  But hidden caves and buried treasure are "
+"common fantasies of any child.  Wirt seldom indulges in youthful games.  So it may "
+"just be his imagination.|"
 msgstr ""
-"Ci fu un tempo in cui la città era meta frequente per viaggiatori "
-"provenienti da ogni dove. Molto è cambiato da allora. Ma caverne ignote e "
-"tesori sepolti sono fantasie comuni nei bambini. Wirt fa di raro giochi "
-"infantili. Quindi può esserselo solo immaginato.|"
+"Ci fu un tempo in cui la città era meta frequente per viaggiatori provenienti da "
+"ogni dove. Molto è cambiato da allora. Ma caverne ignote e tesori sepolti sono "
+"fantasie comuni nei bambini. Wirt fa di raro giochi infantili. Quindi può "
+"esserselo solo immaginato.|"
 
 #: Source/textdat.cpp:553
 msgid ""
-"Listen here.  Come close.  I don't know if you know what I know, but you've "
-"have really got something here.  That's a map.|"
+"Listen here.  Come close.  I don't know if you know what I know, but you've have "
+"really got something here.  That's a map.|"
 msgstr ""
-"Ascolta, vieni qui. Io non so se tu sai quello che so, ma hai trovato "
-"davvero qualcosa. Quella è una mappa.|"
+"Ascolta, vieni qui. Io non so se tu sai quello che so, ma hai trovato davvero "
+"qualcosa. Quella è una mappa.|"
 
 #: Source/textdat.cpp:555
 msgid ""
-"My grandmother often tells me stories about the strange forces that inhabit "
-"the graveyard outside of the church.  And it may well interest you to hear "
-"one of them.  She said that if you were to leave the proper offering in the "
-"cemetary, enter the cathedral to pray for the dead, and then return, the "
-"offering would be altered in some strange way.  I don't know if this is just "
-"the talk of an old sick woman, but anything seems possible these days.|"
+"My grandmother often tells me stories about the strange forces that inhabit the "
+"graveyard outside of the church.  And it may well interest you to hear one of "
+"them.  She said that if you were to leave the proper offering in the cemetary, "
+"enter the cathedral to pray for the dead, and then return, the offering would be "
+"altered in some strange way.  I don't know if this is just the talk of an old sick "
+"woman, but anything seems possible these days.|"
 msgstr ""
-"Mia nonna mi racconta spesso storie riguardo strane forze sconosciute che "
-"popolano il cimitero al di fuori della chiesa. Potrebbe interessarti "
-"sentirne una. Ha detto che se lasci un'offerta adeguata nel cimitero, entri "
-"nella cattedrale per pregare i morti, e ritorni, l'offerta si sarebbe "
-"alterata in qualche strano modo. Io non so se questi sono solo i "
-"vaneggiamenti di un'anziana donna malata, ma qualsiasi cosa pare possibile "
-"di questi giorni.|"
+"Mia nonna mi racconta spesso storie riguardo strane forze sconosciute che popolano "
+"il cimitero al di fuori della chiesa. Potrebbe interessarti sentirne una. Ha detto "
+"che se lasci un'offerta adeguata nel cimitero, entri nella cattedrale per pregare "
+"i morti, e ritorni, l'offerta si sarebbe alterata in qualche strano modo. Io non "
+"so se questi sono solo i vaneggiamenti di un'anziana donna malata, ma qualsiasi "
+"cosa pare possibile di questi giorni.|"
 
 #: Source/textdat.cpp:557
 msgid ""
-"Hmmm.  A vast and mysterious treasure you say.  Mmmm.  Maybe I could be "
-"interested in picking up a few things from you.  Or better yet, don't you "
-"need some rare and expensive supplies to get you through this ordeal?|"
+"Hmmm.  A vast and mysterious treasure you say.  Mmmm.  Maybe I could be interested "
+"in picking up a few things from you.  Or better yet, don't you need some rare and "
+"expensive supplies to get you through this ordeal?|"
 msgstr ""
-"Hmmm. Un tesoro vasto e misterioso, dici. Mmmm. Forse potrei essere "
-"interessato a raccogliere alcune cose da te. O meglio ancora, non hai "
-"bisogno di rifornimenti rari e costosi per superare questo calvario? |"
+"Hmmm. Un tesoro vasto e misterioso, dici. Mmmm. Forse potrei essere interessato a "
+"raccogliere alcune cose da te. O meglio ancora, non hai bisogno di rifornimenti "
+"rari e costosi per superare questo calvario? |"
 
 #: Source/textdat.cpp:561
 msgid ""
-"So, you're the hero everyone's been talking about. Perhaps you could help a "
-"poor, simple farmer out of a terrible mess? At the edge of my orchard, just "
-"south of here, there's a horrible thing swelling out of the ground! I can't "
-"get to my crops or my bales of hay, and my poor cows will starve. The witch "
-"gave this to me and said that it would blast that thing out of my field. If "
-"you could destroy it, I would be forever grateful. I'd do it myself, but "
-"someone has to stay here with the cows...|"
+"So, you're the hero everyone's been talking about. Perhaps you could help a poor, "
+"simple farmer out of a terrible mess? At the edge of my orchard, just south of "
+"here, there's a horrible thing swelling out of the ground! I can't get to my crops "
+"or my bales of hay, and my poor cows will starve. The witch gave this to me and "
+"said that it would blast that thing out of my field. If you could destroy it, I "
+"would be forever grateful. I'd do it myself, but someone has to stay here with the "
+"cows...|"
 msgstr ""
-"Quindi, sei tu l'eroe di cui tutti parlano. Forse potresti aiutare un "
-"povero, umile contadino a uscire da un terribile guaio? Al confine del mio "
-"orto, appena a sud di qui, un terribile rigonfiamento è sbucato dal suolo! "
-"Non posso recarmi al mio raccolto o alle balle di fieno, le mie povere "
-"mucche moriranno di fame. La strega mi ha dato questo dicendo che avrebbe "
-"dilaniato quella cosa nel mio campo. Se potessi eliminarla, te ne sarei "
-"grato. Lo farei io, ma qualcuno deve badare alle mucche...|"
+"Quindi, sei tu l'eroe di cui tutti parlano. Forse potresti aiutare un povero, "
+"umile contadino a uscire da un terribile guaio? Al confine del mio orto, appena a "
+"sud di qui, un terribile rigonfiamento è sbucato dal suolo! Non posso recarmi al "
+"mio raccolto o alle balle di fieno, le mie povere mucche moriranno di fame. La "
+"strega mi ha dato questo dicendo che avrebbe dilaniato quella cosa nel mio campo. "
+"Se potessi eliminarla, te ne sarei grato. Lo farei io, ma qualcuno deve badare "
+"alle mucche...|"
 
 #: Source/textdat.cpp:563
 msgid ""
-"I knew that it couldn't be as simple as that witch made it sound. It's a sad "
-"world when you can't even trust your neighbors.|"
+"I knew that it couldn't be as simple as that witch made it sound. It's a sad world "
+"when you can't even trust your neighbors.|"
 msgstr ""
-"Sapevo che non sarebbe stato semplice come la strega l'ha fatto sembrare. "
-"Che mondo triste se non puoi fidarti del prossimo.|"
+"Sapevo che non sarebbe stato semplice come la strega l'ha fatto sembrare. Che "
+"mondo triste se non puoi fidarti del prossimo.|"
 
 #: Source/textdat.cpp:565
 msgid ""
-"Is it gone? Did you send it back to the dark recesses of Hades that spawned "
-"it? You what? Oh, don't tell me you lost it! Those things don't come cheap, "
-"you know. You've got to find it, and then blast that horror out of our town.|"
+"Is it gone? Did you send it back to the dark recesses of Hades that spawned it? "
+"You what? Oh, don't tell me you lost it! Those things don't come cheap, you know. "
+"You've got to find it, and then blast that horror out of our town.|"
 msgstr ""
-"È andato? L'hai rispedito negli oscuri recessi dell'Ade da dove era venuto? "
-"Tu cosa? Oh, non dirmi che l'hai perso! Queste cose sono sconvenienti, sai. "
-"Devi trovarlo, e distruggere quell'orrore scacciandolo dalla nostra città.|"
+"È andato? L'hai rispedito negli oscuri recessi dell'Ade da dove era venuto? Tu "
+"cosa? Oh, non dirmi che l'hai perso! Queste cose sono sconvenienti, sai. Devi "
+"trovarlo, e distruggere quell'orrore scacciandolo dalla nostra città.|"
 
 #: Source/textdat.cpp:567
 msgid ""
-"I heard the explosion from here! Many thanks to you, kind stranger. What "
-"with all these things comin' out of the ground, monsters taking over the "
-"church, and so forth, these are trying times. I am but a poor farmer, but "
-"here -- take this with my great thanks.|"
+"I heard the explosion from here! Many thanks to you, kind stranger. What with all "
+"these things comin' out of the ground, monsters taking over the church, and so "
+"forth, these are trying times. I am but a poor farmer, but here -- take this with "
+"my great thanks.|"
 msgstr ""
-"Ho udito l'esplosione fin qui! Grazie, generoso straniero. Con tutte queste "
-"cose provenienti dal sottosuolo, mostri che corrompono la chiesa, e così "
-"via, questi sono tempi duri. Sono solo un povero contadino, ma ecco, prendi "
-"questo con mia somma gratitudine.|"
+"Ho udito l'esplosione fin qui! Grazie, generoso straniero. Con tutte queste cose "
+"provenienti dal sottosuolo, mostri che corrompono la chiesa, e così via, questi "
+"sono tempi duri. Sono solo un povero contadino, ma ecco, prendi questo con mia "
+"somma gratitudine.|"
 
 #: Source/textdat.cpp:569
 msgid ""
-"Oh, such a trouble I have...maybe...No, I couldn't impose on you, what with "
-"all the other troubles. Maybe after you've cleansed the church of some of "
-"those creatures you could come back... and spare a little time to help a "
-"poor farmer?|"
+"Oh, such a trouble I have...maybe...No, I couldn't impose on you, what with all "
+"the other troubles. Maybe after you've cleansed the church of some of those "
+"creatures you could come back... and spare a little time to help a poor farmer?|"
 msgstr ""
-"Oh, che problema che ho...forse...No, non posso importelo, con tutti i "
-"problemi che hai. Forse dopo che avrai ripulito la chiesa da queste creature "
-"potresti ritornare... e dedicare un po' del tuo tempo per aiutare un povero "
-"contadino?|"
+"Oh, che problema che ho...forse...No, non posso importelo, con tutti i problemi "
+"che hai. Forse dopo che avrai ripulito la chiesa da queste creature potresti "
+"ritornare... e dedicare un pò del tuo tempo per aiutare un povero contadino?|"
 
 #: Source/textdat.cpp:571
 msgid "Waaaah! (sniff) Waaaah! (sniff)|"
@@ -9658,98 +9479,96 @@ msgstr "Waaaah! (sniff) Waaaah! (sniff)|"
 
 #: Source/textdat.cpp:572
 msgid ""
-"I lost Theo!  I lost my best friend!  We were playing over by the river, and "
-"Theo said he wanted to go look at the big green thing.  I said we shouldn't, "
-"but we snuck over there, and then suddenly this BUG came out!  We ran away "
-"but Theo fell down and the bug GRABBED him and took him away!|"
+"I lost Theo!  I lost my best friend!  We were playing over by the river, and Theo "
+"said he wanted to go look at the big green thing.  I said we shouldn't, but we "
+"snuck over there, and then suddenly this BUG came out!  We ran away but Theo fell "
+"down and the bug GRABBED him and took him away!|"
 msgstr ""
-"Ho perso Theo! Ho perso il mio migliore amico! Giocavamo sul fiume, e Theo "
-"disse di voler andare a vedere la grande cosa verde. Dissi che non dovevamo, "
-"ma sgattaiolammo fino a là, e improvvisamente questo INSETTO uscì! Siamo "
-"fuggiti ma Theo cadde e l'insetto l'AFFERRÒ portandoselo via!|"
+"Ho perso Theo! Ho perso il mio migliore amico! Giocavamo sul fiume, e Theo disse "
+"di voler andare a vedere la grande cosa verde. Dissi che non dovevamo, ma "
+"sgattaiolammo fino a là, e improvvisamente questo INSETTO uscì! Siamo fuggiti ma "
+"Theo cadde e l'insetto l'AFFERRò portandoselo via!|"
 
 #: Source/textdat.cpp:574
 msgid ""
-"Didja find him?  You gotta find Theodore, please!  He's just little.  He "
-"can't take care of himself!  Please!|"
+"Didja find him?  You gotta find Theodore, please!  He's just little.  He can't "
+"take care of himself!  Please!|"
 msgstr ""
-"L'hai trovato? Ritrova Theodore, per favore! È piccolo. Non è in grado di "
+"L'hai trovato? Ritrova Theodore, per favore! è piccolo. Non è in grado di "
 "prendersi cura di sé. Ti prego!|"
 
 #: Source/textdat.cpp:576
 msgid ""
-"You found him!  You found him!  Thank you!  Oh Theo, did those nasty bugs "
-"scare you?  Hey!  Ugh!  There's something stuck to your fur!  Ick!  Come on, "
-"Theo, let's go home!  Thanks again, hero person!|"
+"You found him!  You found him!  Thank you!  Oh Theo, did those nasty bugs scare "
+"you?  Hey!  Ugh!  There's something stuck to your fur!  Ick!  Come on, Theo, let's "
+"go home!  Thanks again, hero person!|"
 msgstr ""
 "L'hai trovato! L'hai trovato! Grazie! Oh Theo, quei brutti insetti ti hanno "
-"spaventato? Ehi! Ugh! Hai qualcosa attaccato alla pelle! Ick! Su, Theo, "
-"torniamo a casa! Grazie di nuovo, eroico individuo!|"
+"spaventato? Ehi! Ugh! Hai qualcosa attaccato alla pelle! Ick! Su, Theo, torniamo a "
+"casa! Grazie di nuovo, eroico individuo!|"
 
 #: Source/textdat.cpp:578
 msgid ""
-"We have long lain dormant, and the time to awaken has come.  After our long "
-"sleep, we are filled with great hunger.  Soon, now, we shall feed...|"
+"We have long lain dormant, and the time to awaken has come.  After our long sleep, "
+"we are filled with great hunger.  Soon, now, we shall feed...|"
 msgstr ""
 "Siamo rimasti a lungo sopiti, il tempo del risveglio è ormai giunto. Dopo il "
 "nostro lungo sonno, siamo affamati. Presto, ora, ci nutriremo... |"
 
 #: Source/textdat.cpp:580
 msgid ""
-"Have you been enjoying yourself, little mammal?  How pathetic. Your little "
-"world will be no challenge at all.|"
+"Have you been enjoying yourself, little mammal?  How pathetic. Your little world "
+"will be no challenge at all.|"
 msgstr ""
 "Ti diverti, piccolo mammifero? Com'è patetico. Il tuo piccolo mondo non sarà "
 "minimamente una minaccia.|"
 
 #: Source/textdat.cpp:582
 msgid ""
-"These lands shall be defiled, and our brood shall overrun the fields that "
-"men call home.  Our tendrils shall envelop this world, and we will feast on "
-"the flesh of its denizens.  Man shall become our chattel and sustenance.|"
+"These lands shall be defiled, and our brood shall overrun the fields that men call "
+"home.  Our tendrils shall envelop this world, and we will feast on the flesh of "
+"its denizens.  Man shall become our chattel and sustenance.|"
 msgstr ""
-"Contamineremo queste terre, la nostra stirpe invaderà le distese che gli "
-"uomini chiamano casa. I nostri viticci avvolgeranno il mondo, e noi "
-"banchetteremo con la carne dei suoi abitanti. L'uomo sarà il nostro "
-"nutrimento.|"
+"Contamineremo queste terre, la nostra stirpe invaderà le distese che gli uomini "
+"chiamano casa. I nostri viticci avvolgeranno il mondo, e noi banchetteremo con la "
+"carne dei suoi abitanti. L'uomo sarà il nostro nutrimento.|"
 
 #: Source/textdat.cpp:584
 msgid ""
-"Ah, I can smell you...you are close! Close! Ssss...the scent of blood and "
-"fear...how enticing...|"
+"Ah, I can smell you...you are close! Close! Ssss...the scent of blood and fear..."
+"how enticing...|"
 msgstr ""
-"Ah, sento il tuo odore...sei vicino! Vicino! Ssss...odore di sangue e "
-"paura...com'è allettante...|"
+"Ah, sento il tuo odore...sei vicino! Vicino! Ssss...odore di sangue e paura..."
+"com'è allettante...|"
 
 #: Source/textdat.cpp:592
 msgid ""
-"And in the year of the Golden Light, it was so decreed that a great "
-"Cathedral be raised.  The cornerstone of this holy place was to be carved "
-"from the translucent stone Antyrael, named for the Angel who shared his "
-"power with the Horadrim.  \n"
+"And in the year of the Golden Light, it was so decreed that a great Cathedral be "
+"raised.  The cornerstone of this holy place was to be carved from the translucent "
+"stone Antyrael, named for the Angel who shared his power with the Horadrim.  \n"
 " \n"
-"In the Year of Drawing Shadows, the ground shook and the Cathedral shattered "
-"and fell.  As the building of catacombs and castles began and man stood "
-"against the ravages of the Sin War, the ruins were scavenged for their "
-"stones.  And so it was that the cornerstone vanished from the eyes of man. \n"
+"In the Year of Drawing Shadows, the ground shook and the Cathedral shattered and "
+"fell.  As the building of catacombs and castles began and man stood against the "
+"ravages of the Sin War, the ruins were scavenged for their stones.  And so it was "
+"that the cornerstone vanished from the eyes of man. \n"
 " \n"
-"The stone was of this world -- and of all worlds -- as the Light is both "
-"within all things and beyond all things. Light and unity are the products of "
-"this holy foundation, a unity of purpose and a unity of possession.|"
+"The stone was of this world -- and of all worlds -- as the Light is both within "
+"all things and beyond all things. Light and unity are the products of this holy "
+"foundation, a unity of purpose and a unity of possession.|"
 msgstr ""
-"E nell'anno della Luce Dorata, fu decretato che una maestosa Cattedrale "
-"fosse eretta. La pietra angolare di questo sacro luogo doveva essere scavata "
-"nella pietra traslucida di Antyrael, così chiamata in nome dell'Angelo che "
-"ha condiviso il suo potere con gli Horadrim. \n"
+"E nell'anno della Luce Dorata, fu decretato che una maestosa Cattedrale fosse "
+"eretta. La pietra angolare di questo sacro luogo doveva essere scavata nella "
+"pietra traslucida di Antyrael, così chiamata in nome dell'Angelo che ha condiviso "
+"il suo potere con gli Horadrim. \n"
 "\n"
 "Nell'anno designato all'Oscurità, la terra tremò e la Cattedrale cadde in "
-"frantumi. Quando iniziò la costruzione di catacombe e castelli e l'uomo si "
-"oppose alle devastazioni della Guerra del Peccato, le rovine vennero "
-"spazzate via da tutte le loro pietre. E così la pietra angolare svanì. \n"
+"frantumi. Quando iniziò la costruzione di catacombe e castelli e l'uomo si oppose "
+"alle devastazioni della Guerra del Peccato, le rovine vennero spazzate via da "
+"tutte le loro pietre. E così la pietra angolare svanì. \n"
 "\n"
-"La pietra era di questo mondo - e di tutti i mondi - come la luce è sia "
-"dentro che fuori da ogni cosa. La luce e l'unità sono le fondamenta di "
-"questa sacra creazione, un'unione di scopi e di beni.|"
+"La pietra era di questo mondo - e di tutti i mondi - come la luce è sia dentro che "
+"fuori da ogni cosa. La luce e l'unità sono le fondamenta di questa sacra "
+"creazione, un'unione di scopi e di beni.|"
 
 #: Source/textdat.cpp:594
 msgid "Moo.|"
@@ -9765,75 +9584,71 @@ msgstr "Sono solo una mucca, OK?|"
 
 #: Source/textdat.cpp:597
 msgid ""
-"All right, all right.  I'm not really a cow.  I don't normally go around "
-"like this; but, I was sitting at home minding my own business and all of a "
-"sudden these bugs & vines & bulbs & stuff started coming out of the floor... "
-"it was horrible!  If only I had something normal to wear, it wouldn't be so "
-"bad.  Hey!  Could you go back to my place and get my suit for me?  The brown "
-"one, not the gray one, that's for evening wear.  I'd do it myself, but I "
-"don't want anyone seeing me like this.  Here, take this, you might need "
-"it... to kill those things that have overgrown everything.  You can't miss "
-"my house, it's just south of the fork in the river... you know... the one "
-"with the overgrown vegetable garden.|"
+"All right, all right.  I'm not really a cow.  I don't normally go around like "
+"this; but, I was sitting at home minding my own business and all of a sudden these "
+"bugs & vines & bulbs & stuff started coming out of the floor... it was horrible!  "
+"If only I had something normal to wear, it wouldn't be so bad.  Hey!  Could you go "
+"back to my place and get my suit for me?  The brown one, not the gray one, that's "
+"for evening wear.  I'd do it myself, but I don't want anyone seeing me like this.  "
+"Here, take this, you might need it... to kill those things that have overgrown "
+"everything.  You can't miss my house, it's just south of the fork in the river... "
+"you know... the one with the overgrown vegetable garden.|"
 msgstr ""
 "Va bene, va bene. Non sono una mucca. di solito non giro in questo modo; ero "
-"seduto a casa a farmi gli affari miei quando a un tratto questi insetti, "
-"tralci e bulbi e altro sono iniziati ad uscire fuori dal pavimento... "
-"orribile! Se soltanto avessi qualcosa di decente da indossare, non sarebbe "
-"così male. Ehi! Potresti tornare alla mia dimora a prendere il mio vestito? "
-"Quello marrone, non il grigio, che sfrutto solo di sera. Lo farei io, ma non "
-"voglio che mi vedano conciato così. Ecco, prendi questo, potrebbe "
-"servirti... per uccidere quelle cose che hanno invaso tutto. Non puoi "
-"mancare la mia casa, è poco più a sud del biforcarsi del fiume... sai... "
-"quella con l'orto incolto.|"
+"seduto a casa a farmi gli affari miei quando a un tratto questi insetti, tralci e "
+"bulbi e altro sono iniziati ad uscire fuori dal pavimento... orribile! Se soltanto "
+"avessi qualcosa di decente da indossare, non sarebbe così male. Ehi! Potresti "
+"tornare alla mia dimora a prendere il mio vestito? Quello marrone, non il grigio, "
+"che sfrutto solo di sera. Lo farei io, ma non voglio che mi vedano conciato così. "
+"Ecco, prendi questo, potrebbe servirti... per uccidere quelle cose che hanno "
+"invaso tutto. Non puoi mancare la mia casa, è poco più a sud del biforcarsi del "
+"fiume... sai... quella con l'orto incolto.|"
 
 #: Source/textdat.cpp:599
 msgid ""
-"What are you wasting time for?  Go get my suit!  And hurry!  That Holstein "
-"over there keeps winking at me! |"
+"What are you wasting time for?  Go get my suit!  And hurry!  That Holstein over "
+"there keeps winking at me! |"
 msgstr ""
 "Perché perdi tempo? Riportami il vestito! Sbrigati! Quella Holstein laggiù "
 "continua a farmi l'occhiolino! |"
 
 #: Source/textdat.cpp:601
 msgid ""
-"Hey, have you got my suit there?  Quick, pass it over!  These ears itch like "
-"you wouldn't believe!|"
+"Hey, have you got my suit there?  Quick, pass it over!  These ears itch like you "
+"wouldn't believe!|"
 msgstr ""
-"Ehi, hai preso il mio vestito? Presto, passamelo! Queste orecchie prudono "
-"come non crederesti mai!|"
+"Ehi, hai preso il mio vestito? Presto, passamelo! Queste orecchie prudono come non "
+"crederesti mai!|"
 
 #: Source/textdat.cpp:603
 msgid ""
-"No no no no!  This is my GRAY suit!  It's for evening wear!  Formal "
-"occasions!  I can't wear THIS.  What are you, some kind of weirdo?  I need "
-"the BROWN suit.|"
+"No no no no!  This is my GRAY suit!  It's for evening wear!  Formal occasions!  I "
+"can't wear THIS.  What are you, some kind of weirdo?  I need the BROWN suit.|"
 msgstr ""
-"No no no no! Questo è l'abito GRIGIO! È per la sera! Da occasioni formali! "
-"Non posso indossarlo. Cosa sei, un tipo strambo? Ho bisogno dell'abito "
-"MARRONE.|"
+"No no no no! Questo è l'abito GRIGIO! è per la sera! Da occasioni formali! Non "
+"posso indossarlo. Cosa sei, un tipo strambo? Ho bisogno dell'abito MARRONE.|"
 
 #: Source/textdat.cpp:605
 msgid ""
 "Ahh, that's MUCH better.  Whew!  At last, some dignity!  Are my antlers on "
-"straight?  Good.  Look, thanks a lot for helping me out.  Here, take this as "
-"a gift; and, you know... a little fashion tip... you could use a little... "
-"you could use a new... yknowwhatImean?  The whole adventurer motif is just "
-"so... retro.  Just a word of advice, eh?  Ciao.|"
+"straight?  Good.  Look, thanks a lot for helping me out.  Here, take this as a "
+"gift; and, you know... a little fashion tip... you could use a little... you could "
+"use a new... yknowwhatImean?  The whole adventurer motif is just so... retro.  "
+"Just a word of advice, eh?  Ciao.|"
 msgstr ""
-"Ahh, MOLTO meglio. Wow! Infine, un po' di dignità! Le mie corna son dritte? "
-"Bene. Guarda, grazie dell'aiuto. Ecco, prendi questo dono; e, sai.. una "
-"piccola dritta sulla moda.. potresti usarne uno piccolo.. potresti usarne "
-"uno nuovo.. sai cosa intendo? Il vero motto dell'avventuriero è solo "
-"questo... retrò. È solo un consiglio eh? Ciao.|"
+"Ahh, MOLTO meglio. Wow! Infine, un pò di dignità! Le mie corna son dritte? Bene. "
+"Guarda, grazie dell'aiuto. Ecco, prendi questo dono; e, sai.. una piccola dritta "
+"sulla moda.. potresti usarne uno piccolo.. potresti usarne uno nuovo.. sai cosa "
+"intendo? Il vero motto dell'avventuriero è solo questo... retrò. È solo un "
+"consiglio eh? Ciao.|"
 
 #: Source/textdat.cpp:607
 msgid ""
-"Look.  I'm a cow.  And you, you're monster bait. Get some experience under "
-"your belt!  We'll talk...|"
+"Look.  I'm a cow.  And you, you're monster bait. Get some experience under your "
+"belt!  We'll talk...|"
 msgstr ""
-"Guarda. Io sono una mucca. E tu, sei un'esca da mostro. Fai un po' di "
-"esperienza! E poi parleremo...|"
+"Guarda. Io sono una mucca. E tu, sei un'esca da mostro. Fai un pò di esperienza! E "
+"poi parleremo...|"
 
 #: Source/textdat.cpp:609
 msgid "|"
@@ -9841,195 +9656,184 @@ msgstr "|"
 
 #: Source/textdat.cpp:610
 msgid ""
-"It must truly be a fearsome task I've set before you. If there was just some "
-"way that I could... would a flagon of some nice, fresh milk help?|"
+"It must truly be a fearsome task I've set before you. If there was just some way "
+"that I could... would a flagon of some nice, fresh milk help?|"
 msgstr ""
-"E' veramente un terribile compito che ti ho posto innanzi. Se solamente "
-"potessi fare qualcosa... una caraffa di buon latte fresco, aiuterebbe?|"
+"È veramente un terribile compito che ti ho posto innanzi. Se solamente potessi "
+"fare qualcosa... una caraffa di buon latte fresco, aiuterebbe?|"
 
 #: Source/textdat.cpp:612
 msgid ""
-"Oh, I could use your help, but perhaps after you've saved the catacombs from "
-"the desecration of those beasts.|"
+"Oh, I could use your help, but perhaps after you've saved the catacombs from the "
+"desecration of those beasts.|"
 msgstr ""
-"Oh, potrei servirmi del tuo aiuto, ma solo dopo che salverai le catacombe "
-"dalla profanazione di quelle bestie.|"
+"Oh, potrei servirmi del tuo aiuto, ma solo dopo che salverai le catacombe dalla "
+"profanazione di quelle bestie.|"
 
 #: Source/textdat.cpp:614
 msgid ""
-"I need something done, but I couldn't impose on a perfect stranger. Perhaps "
-"after you've been here a while I might feel more comfortable asking a favor.|"
+"I need something done, but I couldn't impose on a perfect stranger. Perhaps after "
+"you've been here a while I might feel more comfortable asking a favor.|"
 msgstr ""
-"Mi serve aiuto per una cosa, ma non posso imporlo a un perfetto estraneo. "
-"Forse dopo che sarai ambientato mi sentirò più a mio agio a esigere un "
-"favore.|"
+"Mi serve aiuto per una cosa, ma non posso imporlo a un perfetto estraneo. Forse "
+"dopo che sarai ambientato mi sentirò più a mio agio a esigere un favore.|"
 
 #: Source/textdat.cpp:616
 msgid ""
 "I see in you the potential for greatness.  Perhaps sometime while you are "
 "fulfilling your destiny, you could stop by and do a little favor for me?|"
 msgstr ""
-"Io vedo in te un potenziale di grandezza. Forse un giorno mentre adempirai "
-"al tuo destino, potresti fermarti e farmi un piccolo favore?|"
+"Io vedo in te un potenziale di grandezza. Forse un giorno mentre adempirai al tuo "
+"destino, potresti fermarti e farmi un piccolo favore?|"
 
 #: Source/textdat.cpp:618
 msgid ""
-"I think you could probably help me, but perhaps after you've gotten a little "
-"more powerful. I wouldn't want to injure the village's only chance to "
-"destroy the menace in the church!|"
+"I think you could probably help me, but perhaps after you've gotten a little more "
+"powerful. I wouldn't want to injure the village's only chance to destroy the "
+"menace in the church!|"
 msgstr ""
-"Penso che potresti aiutarmi,ma forse dopo che sarai diventato un po' più "
-"potente. Non vorrei pregiudicare al villaggio l'unica possibilità di "
-"distruggere la minaccia nella chiesa!|"
+"Penso che potresti aiutarmi,ma forse dopo che sarai diventato un pò più potente. "
+"Non vorrei pregiudicare al villaggio l'unica possibilità di distruggere la "
+"minaccia nella chiesa!|"
 
 #: Source/textdat.cpp:620
 msgid ""
-"Me, I'm a self-made cow.  Make something of yourself, and... then we'll "
-"talk.|"
-msgstr ""
-"Io, sono una mucca fatta da sé. Realizzati pure tu, e... poi ne parleremo.|"
+"Me, I'm a self-made cow.  Make something of yourself, and... then we'll talk.|"
+msgstr "Io, sono una mucca fatta da sé. Realizzati pure tu, e... poi ne parleremo.|"
 
 #: Source/textdat.cpp:622
 msgid ""
-"I don't have to explain myself to every tourist that walks by!  Don't you "
-"have some monsters to kill?  Maybe we'll talk later.  If you live...|"
+"I don't have to explain myself to every tourist that walks by!  Don't you have "
+"some monsters to kill?  Maybe we'll talk later.  If you live...|"
 msgstr ""
-"Non sono tenuto a giustificarmi con ogni turista che passa da qui! Non hai "
-"dei mostri da uccidere? Forse ne riparleremo dopo. Se sarai vivo...|"
+"Non sono tenuto a giustificarmi con ogni turista che passa da qui! Non hai dei "
+"mostri da uccidere? Forse ne riparleremo dopo. Se sarai vivo...|"
 
 #: Source/textdat.cpp:624
 msgid ""
-"Quit bugging me.  I'm looking for someone really heroic.  And you're not "
-"it.  I can't trust you, you're going to get eaten by monsters any day now... "
-"I need someone who's an experienced hero.|"
+"Quit bugging me.  I'm looking for someone really heroic.  And you're not it.  I "
+"can't trust you, you're going to get eaten by monsters any day now... I need "
+"someone who's an experienced hero.|"
 msgstr ""
-"Smettila di irritarmi. Sto cercando qualcuno di veramente eroico. E tu non "
-"lo sei. Non posso fidarmi di te, sarai mangiato dai mostri a giorni... "
-"Necessito di un eroe di una certa esperienza.|"
+"Smettila di irritarmi. Sto cercando qualcuno di veramente eroico. E tu non lo sei. "
+"Non posso fidarmi di te, sarai mangiato dai mostri a giorni... Necessito di un "
+"eroe di una certa esperienza.|"
 
 #: Source/textdat.cpp:626
 msgid ""
-"All right, I'll cut the bull.  I didn't mean to steer you wrong.  I was "
-"sitting at home, feeling moo-dy, when things got really un-stable; a whole "
-"stampede of monsters came out of the floor!  I just cowed.  I just happened "
-"to be wearing this Jersey when I ran out the door, and now I look udderly "
-"ridiculous.  If only I had something normal to wear, it wouldn't be so bad.  "
-"Hey!  Can you go back to my place and get my suit for me?  The brown one, "
-"not the gray one, that's for evening wear.  I'd do it myself, but I don't "
-"want anyone seeing me like this.  Here, take this, you might need it... to "
-"kill those things that have overgrown everything.  You can't miss my house, "
-"it's just south of the fork in the river... you know... the one with the "
-"overgrown vegetable garden.|"
+"All right, I'll cut the bull.  I didn't mean to steer you wrong.  I was sitting at "
+"home, feeling moo-dy, when things got really un-stable; a whole stampede of "
+"monsters came out of the floor!  I just cowed.  I just happened to be wearing this "
+"Jersey when I ran out the door, and now I look udderly ridiculous.  If only I had "
+"something normal to wear, it wouldn't be so bad.  Hey!  Can you go back to my "
+"place and get my suit for me?  The brown one, not the gray one, that's for evening "
+"wear.  I'd do it myself, but I don't want anyone seeing me like this.  Here, take "
+"this, you might need it... to kill those things that have overgrown everything.  "
+"You can't miss my house, it's just south of the fork in the river... you know... "
+"the one with the overgrown vegetable garden.|"
 msgstr ""
-"Va bene, diamoci un taglio col toro. Non voglio sviarti. Stavo seduto a "
-"casa, di malumore, quando le cose sono degenerate, un gruppo di mostri in "
-"fuga uscì dal pavimento! Ero atterrito, a malapena ho indossato questo "
-"travestimento da mucca del Jersey uscendo dalla porta, e ora guardo queste "
-"ridicole mammelle. Se solo avessi qualcosa di normale da indossare, non "
-"sarebbe così male. Ehi! Potresti tornare alla mia dimora a prendere il mio "
-"vestito? Quello marrone, non quello grigio, che sfrutto solo di sera. Lo "
-"farei io, ma non voglio che nessuno mi veda conciato così. Ecco, prendi "
-"questo, potrebbe servirti... per uccidere quella cosa che ha invaso tutto. "
-"Non puoi mancare la mia casa, è poco più a sud del biforcarsi del fiume... "
-"sai... quella con l'orto incolto.|"
+"Va bene, diamoci un taglio col toro. Non voglio sviarti. Stavo seduto a casa, di "
+"malumore, quando le cose sono degenerate, un gruppo di mostri in fuga uscì dal "
+"pavimento! Ero atterrito, a malapena ho indossato questo travestimento da mucca "
+"del Jersey uscendo dalla porta, e ora guardo queste ridicole mammelle. Se solo "
+"avessi qualcosa di normale da indossare, non sarebbe così male. Ehi! Potresti "
+"tornare alla mia dimora a prendere il mio vestito? Quello marrone, non quello "
+"grigio, che sfrutto solo di sera. Lo farei io, ma non voglio che nessuno mi veda "
+"conciato così. Ecco, prendi questo, potrebbe servirti... per uccidere quella cosa "
+"che ha invaso tutto. Non puoi mancare la mia casa, è poco più a sud del biforcarsi "
+"del fiume... sai... quella con l'orto incolto.|"
 
 #: Source/textdat.cpp:628
 msgid ""
-"Cloudy and cooler today.  Casting the nets of necromancy across the void "
-"landed two new subspecies of flying horror; a good day's work.  Must "
-"remember to order some more bat guano and black candles from Adria; I'm "
-"running a bit low.|"
+"Cloudy and cooler today.  Casting the nets of necromancy across the void landed "
+"two new subspecies of flying horror; a good day's work.  Must remember to order "
+"some more bat guano and black candles from Adria; I'm running a bit low.|"
 msgstr ""
-"Nuvoloso e fresco oggi. Lanciando trappole di necromanzia nel vuoto cadranno "
-"due nuove sottospecie di orrori volanti; un bel giorno di lavoro. Ricorda di "
-"ordinare guano di pipistrello e candele nere da Adria; la mia è una piccola "
-"parte.|"
+"Nuvoloso e fresco oggi. Lanciando trappole di necromanzia nel vuoto cadranno due "
+"nuove sottospecie di orrori volanti; un bel giorno di lavoro. Ricorda di ordinare "
+"guano di pipistrello e candele nere da Adria; la mia è una piccola parte.|"
 
 #: Source/textdat.cpp:630
 msgid ""
-"I have tried spells, threats, abjuration and bargaining with this foul "
-"creature -- to no avail.  My methods of enslaving lesser demons seem to have "
-"no effect on this fearsome beast.|"
+"I have tried spells, threats, abjuration and bargaining with this foul creature -- "
+"to no avail.  My methods of enslaving lesser demons seem to have no effect on this "
+"fearsome beast.|"
 msgstr ""
 "Ho provato incantesimi, minacce, abiura e negoziazione con questa disgustosa "
-"creatura -- inutilmente. I miei metodi di costrizione dei demoni non hanno "
-"effetto su questa spaventosa bestia|"
+"creatura -- inutilmente. I miei metodi di costrizione dei demoni non hanno effetto "
+"su questa spaventosa bestia|"
 
 #: Source/textdat.cpp:632
 msgid ""
-"My home is slowly becoming corrupted by the vileness of this unwanted "
-"prisoner.  The crypts are\tfull of shadows that move just beyond the corners "
-"of my vision.  The faint scrabble of claws dances at the edges of my "
-"hearing. They are searching, I think, for this journal.|"
+"My home is slowly becoming corrupted by the vileness of this unwanted prisoner.  "
+"The crypts are\tfull of shadows that move just beyond the corners of my vision.  "
+"The faint scrabble of claws dances at the edges of my hearing. They are searching, "
+"I think, for this journal.|"
 msgstr ""
-"La mia casa si sta lentamente contaminando dall'abiezione di questo "
-"prigioniero indesiderato. Le cripte sono\tpiene di ombre che si muovono "
-"svanendo dalla mia vista. Il languido strisciare di artigli pulsa nelle mie "
-"orecchie. Loro stanno cercando, credo, questo diario.|"
+"La mia casa si sta lentamente contaminando dall'abiezione di questo prigioniero "
+"indesiderato. Le cripte sono\tpiene di ombre che si muovono svanendo dalla mia "
+"vista. Il languido strisciare di artigli pulsa nelle mie orecchie. Loro stanno "
+"cercando, credo, questo diario.|"
 
 #: Source/textdat.cpp:634
 msgid ""
-"In its ranting, the creature has let slip its name -- Na-Krul.  I have "
-"attempted to research the name, but the smaller demons have somehow "
-"destroyed my library.  Na-Krul... The name fills me with a cold dread.  I "
-"prefer to think of it only as The Creature rather than ponder its true name.|"
+"In its ranting, the creature has let slip its name -- Na-Krul.  I have attempted "
+"to research the name, but the smaller demons have somehow destroyed my library.  "
+"Na-Krul... The name fills me with a cold dread.  I prefer to think of it only as "
+"The Creature rather than ponder its true name.|"
 msgstr ""
-"Nel suo sbraitare, alla creatura è sfuggito il suo nome -- Na-Krul. Ho "
-"indagato sul suo nome, ma i demoni minori hanno in qualche modo distrutto la "
-"mia biblioteca. Na-Krul... Il nome mi fa raggelare. Preferisco pensare a lui "
-"solamente come La Creatura piuttosto che al suo vero nome.|"
+"Nel suo sbraitare, alla creatura è sfuggito il suo nome -- Na-Krul. Ho indagato "
+"sul suo nome, ma i demoni minori hanno in qualche modo distrutto la mia "
+"biblioteca. Na-Krul... Il nome mi fa raggelare. Preferisco pensare a lui solamente "
+"come La Creatura piuttosto che al suo vero nome.|"
 
 #: Source/textdat.cpp:636
 msgid ""
-"The entrapped creature's howls of fury keep me from gaining much needed "
-"sleep.  It rages against the one who sent it to the Void, and it calls foul "
-"curses upon me for trapping it here.  Its words fill my heart with terror, "
-"and yet I cannot block out its voice.|"
+"The entrapped creature's howls of fury keep me from gaining much needed sleep.  It "
+"rages against the one who sent it to the Void, and it calls foul curses upon me "
+"for trapping it here.  Its words fill my heart with terror, and yet I cannot block "
+"out its voice.|"
 msgstr ""
-"La creatura intrappolata ulula con furia negandomi il sonno. È accanita "
-"contro colui che l'ha segregata nel vuoto,e fa appello a sleali maledizioni "
-"su di me per intrappolarmi qui. Le sue parole mi riempono il cuore di "
-"terrore,e non riesco a ignorare la sua voce.|"
+"La creatura intrappolata ulula con furia negandomi il sonno. È accanita contro "
+"colui che l'ha segregata nel vuoto,e fa appello a sleali maledizioni su di me per "
+"intrappolarmi qui. Le sue parole mi riempono il cuore di terrore,e non riesco a "
+"ignorare la sua voce.|"
 
 #: Source/textdat.cpp:638
 msgid ""
-"My time is quickly running out.  I must record the ways to weaken the demon, "
-"and then conceal that text, lest his minions find some way to use my "
-"knowledge to free their lord.  I hope that whoever finds this journal will "
-"seek the knowledge.|"
+"My time is quickly running out.  I must record the ways to weaken the demon, and "
+"then conceal that text, lest his minions find some way to use my knowledge to free "
+"their lord.  I hope that whoever finds this journal will seek the knowledge.|"
 msgstr ""
-"Il mio tempo è giunto al termine. Devo tramandare i modi per indebolire il "
-"demone, e nascondere i testi, affinché i suoi servitori non li usino per "
-"liberare il loro signore. Mi auguro che chiunque trovi questo diario sia in "
-"cerca del sapere.|"
+"Il mio tempo è giunto al termine. Devo tramandare i modi per indebolire il demone, "
+"e nascondere i testi, affinché i suoi servitori non li usino per liberare il loro "
+"signore. Mi auguro che chiunque trovi questo diario sia in cerca del sapere.|"
 
 #: Source/textdat.cpp:640
 msgid ""
-"Whoever finds this scroll is charged with stopping the demonic creature that "
-"lies within these walls.  My time is over. Even now, its hellish minions "
-"claw at the frail door behind which I hide.  \n"
+"Whoever finds this scroll is charged with stopping the demonic creature that lies "
+"within these walls.  My time is over. Even now, its hellish minions claw at the "
+"frail door behind which I hide.  \n"
 " \n"
-"I have hobbled the demon with arcane magic and encased it within great "
-"walls, but I fear that will not be enough. \n"
+"I have hobbled the demon with arcane magic and encased it within great walls, but "
+"I fear that will not be enough. \n"
 " \n"
-"The spells found in my three grimoires will provide you protected entrance "
-"to his domain, but only if cast in their proper sequence.  The levers at the "
-"entryway will remove the barriers and free the demon; touch them not!  Use "
-"only these spells to gain entry or his power may be too great for you to "
-"defeat.|"
+"The spells found in my three grimoires will provide you protected entrance to his "
+"domain, but only if cast in their proper sequence.  The levers at the entryway "
+"will remove the barriers and free the demon; touch them not!  Use only these "
+"spells to gain entry or his power may be too great for you to defeat.|"
 msgstr ""
-"Chi trova questo libro ha il dovere di fermare la creatura demoniaca che si "
-"cela all'interno di queste mura. Il mio tempo è finito. Anche ora, i suoi "
-"tirapiedi infernali graffiano da dietro la porta che li nasconde. \n"
+"Chi trova questo libro ha il dovere di fermare la creatura demoniaca che si cela "
+"all'interno di queste mura. Il mio tempo è finito. Anche ora, i suoi tirapiedi "
+"infernali graffiano da dietro la porta che li nasconde. \n"
 "\n"
-"Ho bloccato il Demone con arcane magie segregandolo dietro delle grandi "
-"mura, ma temo non sarà sufficiente. \n"
+"Ho bloccato il Demone con arcane magie segregandolo dietro delle grandi mura, ma "
+"temo non sarà sufficiente. \n"
 "\n"
-"Gli incantesimi ritrovati nei miei tre grimori proteggeranno il suo "
-"possessore, ma solo se lanciati nel giusto ordine. Le leve all'entrata "
-"rimuovono le barriere liberando il demone; non toccarle! Usa solo questi "
-"incantesimi per entrare o il suo potere potrebbe essere troppo grande da "
-"sconfiggere.|"
+"Gli incantesimi ritrovati nei miei tre grimori proteggeranno il suo possessore, ma "
+"solo se lanciati nel giusto ordine. Le leve all'entrata rimuovono le barriere "
+"liberando il demone; non toccarle! Usa solo questi incantesimi per entrare o il "
+"suo potere potrebbe essere troppo grande da sconfiggere.|"
 
 #: Source/textdat.cpp:642 Source/textdat.cpp:645 Source/textdat.cpp:648
 #: Source/textdat.cpp:651 Source/textdat.cpp:654
@@ -10154,19 +9958,3 @@ msgstr "Giù da Diablo"
 #, c-format
 msgid "Back to Level %i"
 msgstr "Torna al Livello %i"
-
-#, c-format
-#~ msgid "%i gold %s"
-#~ msgstr "%i Pz. %s"
-
-#~ msgid "spells are increased 1 level"
-#~ msgstr "incantesimi saliti di 1 livello"
-
-#~ msgid "piece"
-#~ msgstr "pezzo"
-
-#~ msgid "pieces"
-#~ msgstr "pezzi"
-
-#~ msgid "Lachdanan"
-#~ msgstr "Lachdanan"

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -995,9 +995,9 @@ msgstr "Tasto: 's'"
 
 #: Source/control.cpp:1057
 #, c-format
-msgid "%s Scroll"
+msgid "%i Scroll"
 msgid_plural "%i Scrolls"
-msgstr[0] "%s Pergamena"
+msgstr[0] "%i Pergamena"
 msgstr[1] "%i Pergamene"
 
 #: Source/control.cpp:1250 Source/inv.cpp:2104 Source/items.cpp:3076


### PR DESCRIPTION
Hereby I submit a lot of enhancements in particular:
* Menu entries
* Accented vowels (such a pity that accents are not supported in textdat strings, so I'm forced to replace `à` with `a'`)
* Tristram experience (Shops in particular)

Another issue that I encountered is related to items qualities. An example is more than thousand words

In English I say `Silver Sword` and the piece of code that concatenate strings displays  `Silver Sword`.
In Italian I say `Sword` (Spada) `of` (di) `Silver` (Argento) and strings are concatenated as `Argento Spada` (a sort of `Sword Silver`).
That's because adjective and nouns are naturally swapped between Italian and English. Use of `of` could be avoided playing on grammar, but the swapping make the text not so delightful

At a first glance seems to be related at least to modifiers that describe the kind of material (brass, silver, obsidian and so on)