### PR TITLE
Vita link fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -681,7 +681,6 @@ if (VITA)
         ScePower_stub
         freetype
         png
-        m
         z
   )
   target_compile_definitions(${BIN_TARGET} PRIVATE VITA)

--- a/Source/controls/keymapper.cpp
+++ b/Source/controls/keymapper.cpp
@@ -19,11 +19,7 @@ Keymapper::Keymapper(SetConfigKeyFunction setKeyFunction, GetConfigKeyFunction g
     , getKeyFunction(getKeyFunction)
 {
 	// Insert all supported keys: a-z, 0-9 and F1-F12.
-#ifndef __vita__
-	// HACK: Disable reserving on Vita because it triggers a linking error:
-	// "multiple definition of `ceill'".
 	keyIDToKeyName.reserve(('Z' - 'A' + 1) + ('9' - '0' + 1) + 12);
-#endif
 	for (char c = 'A'; c <= 'Z'; ++c) {
 		keyIDToKeyName.emplace(c, std::string(1, c));
 	}
@@ -34,11 +30,7 @@ Keymapper::Keymapper(SetConfigKeyFunction setKeyFunction, GetConfigKeyFunction g
 		keyIDToKeyName.emplace(DVL_VK_F1 + i, fmt::format("F{}", i + 1));
 	}
 
-#ifndef __vita__
-	// HACK: Disable reserving on Vita because it triggers a linking error:
-	// "multiple definition of `ceill'".
 	keyNameToKeyID.reserve(keyIDToKeyName.size());
-#endif
 	for (const auto &kv : keyIDToKeyName) {
 		keyNameToKeyID.emplace(kv.second, kv.first);
 	}


### PR DESCRIPTION
Remove libm from linked libs list. It's already linked in by sdl2 import target, and having it not-last-in-list leads to link problems with duplicate symbols.
This also makes vita keymapper hack unnecessary. 