### PR TITLE
Fix up documentation for building and installing on 3DS

### DIFF
--- a/Packaging/ctr/README.txt
+++ b/Packaging/ctr/README.txt
@@ -1,38 +1,34 @@
 # DevilutionX (Diablo 1) for Nintendo 3DS
-*New3DS only
 
 ## Installation
 
-<details><summary>.3dsx installation</summary>
+### .3dsx installation
 
 #### Install DevilutionX: Diablo
-1. Download [devilutionx.3dsx](https://github.com/MrHuu/devilutionX-3ds/releases/latest/download/devilutionx.3dsx).
-2. Put `devilutionx.3dsx` into `sd:/3ds/devilutionx/`.
-3. Copy `diabdat.mpq` from your Diablo CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
+1. Extract `devilutionx.3dsx`, `CharisSILB.ttf`, and `devilutionx.mpq` and put them into `sd:/3ds/devilutionx/`.
+2. Copy `diabdat.mpq` from your Diablo CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
 
 #### Install DevilutionX: Diablo - Hellfire
-4. Copy `hellfire.mpq` `hfmonk.mpq` `hfmusic.mpq` and `hfvoice.mpq` from your Hellfire CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
+3. Copy `hellfire.mpq` `hfmonk.mpq` `hfmusic.mpq` and `hfvoice.mpq` from your Hellfire CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
+    1. *Note:* When the Hellfire .mpqs are installed you can still launch regular Diablo by passing `--diablo` to `devilutionx.3dsx`.
 
-*Note:* When Hellfire is install you can still launch regular Diablo by passing `--diablo` to `devilutionx.3dsx`.
-
-</details>
-<details><summary>.cia installation</summary>
+### .cia installation
 
 #### Install DevilutionX: Diablo
-1. Download [devilutionx.cia](https://github.com/MrHuu/devilutionX-3ds/releases/latest/download/devilutionx.cia).
-2. Put `devilutionx.cia` on your SD card and install with a title manager, e.g. [FBI](https://github.com/Steveice10/FBI).
-	`devilutionx.cia` can be removed after being installed.
+1. Extract `devilutionx.cia` and place it on your SD card.
+2. Extract `devilutionx.mpq` and put it into `sd:/3ds/devilutionx/`.
 3. Copy `diabdat.mpq` from your Diablo CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
+4. Put the SD card back into the 3DS and install `devilutionx.cia` using a title manager (e.g. [FBI](https://github.com/Steveice10/FBI)).
+    1. `devilutionx.cia` can be removed after being installed.
 
 ##### Install DevilutionX: Diablo - Hellfire
-4. Copy `hellfire.mpq` `hfmonk.mpq` `hfmusic.mpq` and `hfvoice.mpq` from your Hellfire CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
-</details>
+5. Copy `hellfire.mpq` `hfmonk.mpq` `hfmusic.mpq` and `hfvoice.mpq` from your Hellfire CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
 
 ## Usage
 
 When using .3dsx:
 
-- Launch `devilutionx.3dsx` with the [Homebrew Launcher](https://github.com/fincs/new-hbmenu).
+- Launch DevilutionX with the [Homebrew Launcher](https://github.com/fincs/new-hbmenu).
 
 or, when using .cia:
 

--- a/Packaging/ctr/build.sh
+++ b/Packaging/ctr/build.sh
@@ -26,9 +26,8 @@ build() {
 
 install_deps() {
 	"$DEVKITPRO/pacman/bin/pacman" -S --needed --noconfirm --quiet \
-		3ds-sdl 3ds-sdl_ttf \
-		3ds-freetype 3ds-libogg 3ds-libvorbisidec 3ds-mikmod \
-		libctru citro3d picasso devkitARM general-tools 3dslink 3dstools devkitpro-pkgbuild-helpers
+		devkitARM general-tools 3dstools devkitpro-pkgbuild-helpers \
+		libctru citro3d 3ds-sdl 3ds-sdl_ttf 3ds-freetype
 }
 
 prepare_devkitpro() {

--- a/docs/building.md
+++ b/docs/building.md
@@ -189,22 +189,25 @@ https://devkitpro.org/wiki/Getting_Started
 
 - Install required packages with (dkp-)pacman:
 ```
-sudo (dkp-)pacman -S devkitARM general-tools 3dstools devkitpro-pkgbuild-helpers \
-	libctru citro3d 3ds-sdl 3ds-sdl_ttf \
-	3ds-freetype 3ds-libogg 3ds-libvorbisidec 3ds-mikmod
+sudo (dkp-)pacman -S \
+		devkitARM general-tools 3dstools devkitpro-pkgbuild-helpers \
+		libctru citro3d 3ds-sdl 3ds-sdl_ttf 3ds-freetype
 ```
 - Download or compile [bannertool](https://github.com/Steveice10/bannertool/releases) and [makerom](https://github.com/jakcron/Project_CTR/releases)
   - Copy binaries to: `/opt/devkitpro/tools/bin/`
 
 ### Compiling
+_If you are compiling using MSYS2, you will need to run `export MSYS2_ARG_CONV_EXCL=-D` before compiling.
+Otherwise, MSYS will sanitize file paths in compiler flags which will likely lead to errors in the build._
+
 ```
 cd build
 cmake .. -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/3ds.cmake -DCMAKE_BUILD_TYPE=Release
 make -j$(nproc)
 ```
-The output-files will be generated in the build folder.
+The output files will be generated in the build folder.
 
-[Nintendo 3DS manual](docs/manual/platforms/n3ds.md)
+[Nintendo 3DS manual](/docs/manual/platforms/n3ds.md)
 </details>
 
 <details><summary>PlayStation Vita</summary>

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -64,14 +64,17 @@ sudo apt install devilutionx
 ### .3dsx installation
 
 - Copy `devilutionx.3dsx` into `sd:/3ds/devilutionx/`.
-- Copy the MPQ files to `sd:/3ds/devilutionx/`.
+- Copy the MPQ files into `sd:/3ds/devilutionx/`.
+- Copy the `CharisSILB.ttf` font file into `sd:/3ds/devilutionx/`.
 - Launch `devilutionx.3dsx` with the [Homebrew Launcher](https://github.com/fincs/new-hbmenu).
- - *Note:* When the Hellfire .mpqs are installed you can still launch regular Diablo by passing `--diablo` to `devilutionx.3dsx`.
+    - *Note:* When the Hellfire .mpqs are installed you can still launch regular Diablo by passing `--diablo` to `devilutionx.3dsx`.
 
 ### .cia installation
 
-- Copy `devilutionx.cia` to your SD card and install with a title manager, e.g. [FBI](https://github.com/Steveice10/FBI). `devilutionx.cia` can be removed after being installed.
+- Copy `devilutionx.cia` to your SD card.
 - Copy the MPQ files to `sd:/3ds/devilutionx/`.
+- Install `devilutionx.cia` with a title manager (e.g. [FBI](https://github.com/Steveice10/FBI)).
+    - `devilutionx.cia` can be removed after being installed.
 - Launch Diablo from your 3DS Homemenu.
 
 </details>

--- a/docs/manual/platforms/n3ds.md
+++ b/docs/manual/platforms/n3ds.md
@@ -3,36 +3,39 @@
 
 ## Installation
 
+Start by downloading [devilutionx-n3ds.zip](https://github.com/diasurgical/devilutionX/releases/download/latest/devilutionx-n3ds.zip).
+
 <details><summary>.3dsx installation</summary>
 
 #### Install DevilutionX: Diablo
-1. Download [devilutionx.3dsx](https://github.com/MrHuu/devilutionX-3ds/releases/latest/download/devilutionx.3dsx).
-2. Put `devilutionx.3dsx` into `sd:/3ds/devilutionx/`.
-3. Copy `diabdat.mpq` from your Diablo CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
+1. Extract `devilutionx.3dsx`, `CharisSILB.ttf`, and `devilutionx.mpq` and put them into `sd:/3ds/devilutionx/`.
+2. Copy `diabdat.mpq` from your Diablo CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
 
 #### Install DevilutionX: Diablo - Hellfire
-4. Copy `hellfire.mpq` `hfmonk.mpq` `hfmusic.mpq` and `hfvoice.mpq` from your Hellfire CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
-
-*Note:* When Hellfire is install you can still launch regular Diablo by passing `--diablo` to `devilutionx.3dsx`.
+3. Copy `hellfire.mpq` `hfmonk.mpq` `hfmusic.mpq` and `hfvoice.mpq` from your Hellfire CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
+    1. *Note:* When the Hellfire .mpqs are installed you can still launch regular Diablo by passing `--diablo` to `devilutionx.3dsx`.
 
 </details>
+
 <details><summary>.cia installation</summary>
 
 #### Install DevilutionX: Diablo
-1. Download [devilutionx.cia](https://github.com/MrHuu/devilutionX-3ds/releases/latest/download/devilutionx.cia).
-2. Put `devilutionx.cia` on your SD card and install with a title manager, e.g. [FBI](https://github.com/Steveice10/FBI).
-	`devilutionx.cia` can be removed after being installed.
+1. Extract `devilutionx.cia` and place it on your SD card.
+2. Extract `devilutionx.mpq` and put it into `sd:/3ds/devilutionx/`.
 3. Copy `diabdat.mpq` from your Diablo CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
+4. Put the SD card back into the 3DS and install `devilutionx.cia` using a title manager (e.g. [FBI](https://github.com/Steveice10/FBI)).
+    1. `devilutionx.cia` can be removed after being installed.
 
 ##### Install DevilutionX: Diablo - Hellfire
-4. Copy `hellfire.mpq` `hfmonk.mpq` `hfmusic.mpq` and `hfvoice.mpq` from your Hellfire CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
+5. Copy `hellfire.mpq` `hfmonk.mpq` `hfmusic.mpq` and `hfvoice.mpq` from your Hellfire CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
+
 </details>
 
 ## Usage
 
 When using .3dsx:
 
-- Launch `devilutionx.3dsx` with the [Homebrew Launcher](https://github.com/fincs/new-hbmenu).
+- Launch DevilutionX with the [Homebrew Launcher](https://github.com/fincs/new-hbmenu).
 
 or, when using .cia:
 


### PR DESCRIPTION
Just cleaning up the docs to reflect more up-to-date instructions for building and installing on 3DS.

Styled Markdown can be reviewed by visiting the following pages.
* https://github.com/StephenCWills/devilutionX/blob/3ds-docs/docs/installing.md
* https://github.com/StephenCWills/devilutionX/blob/3ds-docs/docs/building.md
* https://github.com/StephenCWills/devilutionX/blob/3ds-docs/docs/manual/platforms/n3ds.md