### PR TITLE
Fixed download link for devilutionx-n3ds.zip

### DIFF
--- a/docs/manual/platforms/n3ds.md
+++ b/docs/manual/platforms/n3ds.md
@@ -3,7 +3,7 @@
 
 ## Installation
 
-Start by downloading [devilutionx-n3ds.zip](https://github.com/diasurgical/devilutionX/releases/download/latest/devilutionx-n3ds.zip).
+Start by downloading [devilutionx-n3ds.zip](https://github.com/diasurgical/devilutionX/releases/latest/download/devilutionx-n3ds.zip).
 
 <details><summary>.3dsx installation</summary>
 


### PR DESCRIPTION
The download links for the "latest release" seems backwards, as compared to the ones for individual releases. But it seems to work this way.