### PR TITLE
Improve inventory filling algorithm

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -779,8 +779,13 @@ bool GoldAutoPlace(int pnum)
 		plr[pnum]._pGold = CalculateGold(pnum);
 	}
 
-	for (int i = 39; i >= 0 && !done; i--) {
+	for (int i = 39; i >= 30 && !done; i--) {
 		done = GoldAutoPlaceInInventorySlot(pnum, i);
+	}
+	for (int x = 9; x >= 0 && !done; x--) {
+		for (int y = 2; y >= 0 && !done; y--) {
+			done = GoldAutoPlaceInInventorySlot(pnum, 10 * y + x);
+		}
 	}
 
 	return done;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -780,26 +780,35 @@ bool GoldAutoPlace(int pnum)
 	}
 
 	for (int i = 39; i >= 0 && !done; i--) {
-		int yy = 10 * (i / 10);
-		int xx = i % 10;
-		if (plr[pnum].InvGrid[xx + yy] == 0) {
-			int ii = plr[pnum]._pNumInv;
-			plr[pnum].InvList[ii] = plr[pnum].HoldItem;
-			plr[pnum]._pNumInv = plr[pnum]._pNumInv + 1;
-			plr[pnum].InvGrid[xx + yy] = plr[pnum]._pNumInv;
-			GetPlrHandSeed(&plr[pnum].InvList[ii]);
-			int gold = plr[pnum].HoldItem._ivalue;
-			if (gold > MaxGold) {
-				gold -= MaxGold;
-				plr[pnum].HoldItem._ivalue = gold;
-				GetPlrHandSeed(&plr[pnum].HoldItem);
-				plr[pnum].InvList[ii]._ivalue = MaxGold;
-			} else {
-				plr[pnum].HoldItem._ivalue = 0;
-				done = true;
-				plr[pnum]._pGold = CalculateGold(pnum);
-				NewCursor(CURSOR_HAND);
-			}
+		done = GoldAutoPlaceInInventorySlot(pnum, i);
+	}
+
+	return done;
+}
+
+bool GoldAutoPlaceInInventorySlot(int pnum, int slotIndex)
+{
+	bool done = false;
+
+	int yy = 10 * (slotIndex / 10);
+	int xx = slotIndex % 10;
+	if (plr[pnum].InvGrid[xx + yy] == 0) {
+		int ii = plr[pnum]._pNumInv;
+		plr[pnum].InvList[ii] = plr[pnum].HoldItem;
+		plr[pnum]._pNumInv = plr[pnum]._pNumInv + 1;
+		plr[pnum].InvGrid[xx + yy] = plr[pnum]._pNumInv;
+		GetPlrHandSeed(&plr[pnum].InvList[ii]);
+		int gold = plr[pnum].HoldItem._ivalue;
+		if (gold > MaxGold) {
+			gold -= MaxGold;
+			plr[pnum].HoldItem._ivalue = gold;
+			GetPlrHandSeed(&plr[pnum].HoldItem);
+			plr[pnum].InvList[ii]._ivalue = MaxGold;
+		} else {
+			plr[pnum].HoldItem._ivalue = 0;
+			done = true;
+			plr[pnum]._pGold = CalculateGold(pnum);
+			NewCursor(CURSOR_HAND);
 		}
 	}
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -642,6 +642,7 @@ bool AutoPlaceItemInInventory(int playerNumber, const ItemStruct &item, bool per
 				done = AutoPlaceItemInInventorySlot(playerNumber, 10 * y + x, item, persistItem);
 			}
 		}
+		return done;
 	}
 
 	if (itemSize.Y == 2) {
@@ -657,12 +658,14 @@ bool AutoPlaceItemInInventory(int playerNumber, const ItemStruct &item, bool per
 				}
 			}
 		}
+		return done;
 	}
 
 	if (itemSize.X == 1 && itemSize.Y == 3) {
 		for (int i = 0; i < 20 && !done; i++) {
 			done = AutoPlaceItemInInventorySlot(playerNumber, i, item, persistItem);
 		}
+		return done;
 	}
 
 	if (itemSize.X == 2 && itemSize.Y == 3) {
@@ -673,9 +676,10 @@ bool AutoPlaceItemInInventory(int playerNumber, const ItemStruct &item, bool per
 		for (int i = 10; i < 19 && !done; i++) {
 			done = AutoPlaceItemInInventorySlot(playerNumber, i, item, persistItem);
 		}
+		return done;
 	}
 
-	return done;
+	return false;
 }
 
 /**

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -119,8 +119,6 @@ const InvXY InvRect[] = {
 };
 
 /* data */
-/** Specifies the starting inventory slots for placement of 2x2 items. */
-int AP2x2Tbl[10] = { 8, 28, 6, 26, 4, 24, 2, 22, 0, 20 };
 
 void FreeInvGFX()
 {
@@ -646,40 +644,23 @@ bool AutoPlaceItemInInventory(int playerNumber, const ItemStruct &item, bool per
 		}
 	}
 
-	if (itemSize.X == 1 && itemSize.Y == 2) {
-		for (int i = 29; i >= 20 && !done; i--) {
-			done = AutoPlaceItemInInventorySlot(playerNumber, i, item, persistItem);
+	if (itemSize.Y == 2) {
+		for (int x = 10 - itemSize.X; x >= 0 && !done; x -= itemSize.X) {
+			for (int y = 0; y < 3 && !done; y++) {
+				done = AutoPlaceItemInInventorySlot(playerNumber, 10 * y + x, item, persistItem);
+			}
 		}
-
-		for (int i = 9; i >= 0 && !done; i--) {
-			done = AutoPlaceItemInInventorySlot(playerNumber, i, item, persistItem);
-		}
-
-		for (int i = 19; i >= 10 && !done; i--) {
-			done = AutoPlaceItemInInventorySlot(playerNumber, i, item, persistItem);
+		if (itemSize.X == 2) {
+			for (int x = 7; x >= 0 && !done; x -= 2) {
+				for (int y = 0; y < 3 && !done; y++) {
+					done = AutoPlaceItemInInventorySlot(playerNumber, 10 * y + x, item, persistItem);
+				}
+			}
 		}
 	}
 
 	if (itemSize.X == 1 && itemSize.Y == 3) {
 		for (int i = 0; i < 20 && !done; i++) {
-			done = AutoPlaceItemInInventorySlot(playerNumber, i, item, persistItem);
-		}
-	}
-
-	if (itemSize.X == 2 && itemSize.Y == 2) {
-		for (int i = 0; i < 10 && !done; i++) {
-			done = AutoPlaceItemInInventorySlot(playerNumber, AP2x2Tbl[i], item, persistItem);
-		}
-
-		for (int i = 21; i < 29 && !done; i += 2) {
-			done = AutoPlaceItemInInventorySlot(playerNumber, i, item, persistItem);
-		}
-
-		for (int i = 1; i < 9 && !done; i += 2) {
-			done = AutoPlaceItemInInventorySlot(playerNumber, i, item, persistItem);
-		}
-
-		for (int i = 10; i < 19 && !done; i++) {
 			done = AutoPlaceItemInInventorySlot(playerNumber, i, item, persistItem);
 		}
 	}

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -635,21 +635,14 @@ bool AutoPlaceItemInInventory(int playerNumber, const ItemStruct &item, bool per
 	InvXY itemSize = GetInventorySize(item);
 	bool done = false;
 
-	if (itemSize.X == 1 && itemSize.Y == 1) {
+	if (itemSize.Y == 1) {
 		for (int i = 30; i <= 39 && !done; i++) {
 			done = AutoPlaceItemInInventorySlot(playerNumber, i, item, persistItem);
 		}
-
-		for (int i = 20; i <= 29 && !done; i++) {
-			done = AutoPlaceItemInInventorySlot(playerNumber, i, item, persistItem);
-		}
-
-		for (int i = 10; i <= 19 && !done; i++) {
-			done = AutoPlaceItemInInventorySlot(playerNumber, i, item, persistItem);
-		}
-
-		for (int i = 0; i <= 9 && !done; i++) {
-			done = AutoPlaceItemInInventorySlot(playerNumber, i, item, persistItem);
+		for (int x = 9; x >= 0 && !done; x--) {
+			for (int y = 2; y >= 0 && !done; y--) {
+				done = AutoPlaceItemInInventorySlot(playerNumber, 10 * y + x, item, persistItem);
+			}
 		}
 	}
 

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -93,6 +93,7 @@ bool AutoPlaceItemInInventory(int playerNumber, const ItemStruct &item, bool per
 bool AutoPlaceItemInInventorySlot(int playerNumber, int slotIndex, const ItemStruct &item, bool persistItem);
 bool AutoPlaceItemInBelt(int playerNumber, const ItemStruct &item, bool persistItem = false);
 bool GoldAutoPlace(int pnum);
+bool GoldAutoPlaceInInventorySlot(int pnum, int slotIndex);
 void CheckInvSwap(int pnum, BYTE bLoc, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff);
 void inv_update_rem_item(int pnum, BYTE iv);
 

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -130,6 +130,4 @@ bool DropItemBeforeTrig();
 
 /* data */
 
-extern int AP2x2Tbl[10];
-
 } // namespace devilution


### PR DESCRIPTION
I've seen some discussions about auto-sorting/packing the inventory, which seems a bit contentious. This PR just ~~adds an option to tweak~~ tweaks the slot placement for picked up items, without making deeper changes.

The big differences are in the gold, which goes like this:
![image](https://user-images.githubusercontent.com/77006/117203815-647e9500-ade7-11eb-834e-74843f8643fc.png)
And other 1x1 items, which go like this:
![image](https://user-images.githubusercontent.com/77006/117203859-719b8400-ade7-11eb-8172-8ff80d13cce1.png)
In other words, they try to fill the bottom row from opposite ends, and once it's full they then both start working up in columns starting from the right.

2-height item placement is also changed slightly - the details for that are in the commit log. 3-height item placement is unchanged.

Not sure if anyone else is interested in this and perhaps it might be impossible to reach a consensus on the "best" filling algorithm, but this is how I want it to work so I thought it would be worth posting.