### PR TITLE
ADL: Cleanup comments & clang-format

### DIFF
--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -17,13 +17,13 @@ namespace devilution {
  */
 enum AnimationDistributionFlags : uint8_t {
 	None = 0,
-	/*
-	* @brief ProcessAnimation will be called after SetNewAnimation (in same game tick as NewPlrAnim)
-	*/
+	/**
+	 * @brief ProcessAnimation will be called after SetNewAnimation (in same game tick as NewPlrAnim)
+	 */
 	ProcessAnimationPending = 1 << 0,
-	/*
-	* @brief Delay of last Frame is ignored (for example, because only Frame and not delay is checked in game_logic)
-	*/
+	/**
+	 * @brief Delay of last Frame is ignored (for example, because only Frame and not delay is checked in game_logic)
+	 */
 	SkipsDelayOfLastFrame = 1 << 1,
 	/**
 	 * @brief Repeated Animation (for example same player melee attack, that can be repeated directly after hit frame and doesn't need to show all animation frames)
@@ -36,25 +36,25 @@ enum AnimationDistributionFlags : uint8_t {
 */
 class AnimationInfo {
 public:
-	/*
-	* @brief Pointer to Animation Data
-	*/
+	/**
+	 * @brief Pointer to Animation Data
+	 */
 	byte *pData;
-	/*
-	* @brief Additional delay of each animation in the current animation
-	*/
+	/**
+	 * @brief Additional delay of each animation in the current animation
+	 */
 	int DelayLen;
-	/*
-	* @brief Increases by one each game tick, counting how close we are to DelayLen
-	*/
+	/**
+	 * @brief Increases by one each game tick, counting how close we are to DelayLen
+	 */
 	int DelayCounter;
-	/*
-	* @brief Number of frames in current animation
-	*/
+	/**
+	 * @brief Number of frames in current animation
+	 */
 	int NumberOfFrames;
-	/*
-	* @brief Current frame of animation
-	*/
+	/**
+	 * @brief Current frame of animation
+	 */
 	int CurrentFrame;
 
 	/**
@@ -75,22 +75,22 @@ public:
 	void SetNewAnimation(byte *pData, int numberOfFrames, int delayLen, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
 
 	/*
-	* @brief Process the Animation for a game tick (for example advances the frame)
-	*/
+	 * @brief Process the Animation for a game tick (for example advances the frame)
+	 */
 	void ProcessAnimation();
 
 private:
-	/*
-	* @brief Specifies how many animations-fractions are displayed between two game ticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
-	*/
+	/**
+	 * @brief Specifies how many animations-fractions are displayed between two game ticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
+	 */
 	float TickModifier;
-	/*
-	* @brief Number of game ticks after the current animation sequence started
-	*/
+	/**
+	 * @brief Number of game ticks after the current animation sequence started
+	 */
 	int TicksSinceSequenceStarted;
-	/*
-	* @brief Animation Frames that will be adjusted for the skipped Frames/game ticks
-	*/
+	/**
+	 * @brief Animation Frames that will be adjusted for the skipped Frames/game ticks
+	 */
 	int RelevantFramesForDistributing;
 	/**
 	 * @brief Animation Frames that wasn't shown from previous Animation

--- a/Source/player.h
+++ b/Source/player.h
@@ -162,8 +162,8 @@ struct PlayerStruct {
 	direction _pdir; // Direction faced by player (direction enum)
 	int _pgfxnum;    // Bitmask indicating what variant of the sprite the player is using. Lower byte define weapon (anim_weapon_id) and higher values define armour (starting with anim_armor_id)
 	/*
-	* @brief Contains Information for current Animation
-	*/
+	 * @brief Contains Information for current Animation
+	 */
 	AnimationInfo AnimInfo;
 	int _pAnimWidth;
 	int _plid;

--- a/test/animationinfo_test.cpp
+++ b/test/animationinfo_test.cpp
@@ -111,7 +111,7 @@ TEST(AnimationInfo, AttackSwordWarrior) // ProcessAnimationPending should be con
 {
 	RunAnimationTest(
 	    {
-		    new SetNewAnimationData(16, 0, AnimationDistributionFlags::ProcessAnimationPending, 0, 9),
+	        new SetNewAnimationData(16, 0, AnimationDistributionFlags::ProcessAnimationPending, 0, 9),
 	        // ProcessAnimation directly after StartAttack (in same GameTick). So we don't see any rendering before.
 	        new GameTickData(2, 0),
 	        new RenderingData(0.0f, 1),
@@ -274,7 +274,7 @@ TEST(AnimationInfo, AttackSwordWarriorRepeated)
 	        new GameTickData(10, 0),
 	        new RenderingData(0.3f, 10),
 
-			// Start of repeated attack, cause plr[pnum].AnimInfo.CurrentFrame > plr[myplr]._pAFNum
+	        // Start of repeated attack, cause plr[pnum].AnimInfo.CurrentFrame > plr[myplr]._pAFNum
 	        new SetNewAnimationData(16, 0, static_cast<AnimationDistributionFlags>(AnimationDistributionFlags::ProcessAnimationPending | AnimationDistributionFlags::RepeatedAction), 0, 9),
 	        // ProcessAnimation directly after StartAttack (in same GameTick). So we don't see any rendering before.
 	        new GameTickData(2, 0),


### PR DESCRIPTION
Content:

- Cleaned-up all comments with fixed Doxygen Style
- run clang-format on animationinfo.h/.cpp and animationinfo_test.cpp

@AJenbo I'm not sure how to correctly check the line ending.
Is it enough if I run clang-format / check in Visual Studio or Notepad++ the Line-Ending settings before I commit?
Sorry for this perhaps silly question. I just don't want to repeat this error anymore. :pensive: