### PR TITLE
Simplify TTF_FONT_DIR definition in 3DS cmake file

### DIFF
--- a/CMake/ctr/n3ds_defs.cmake
+++ b/CMake/ctr/n3ds_defs.cmake
@@ -11,7 +11,7 @@ find_package(PNG REQUIRED)
 
 #additional compilation definitions
 add_definitions(-D__3DS__)
-set(CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE}\ -DTTF_FONT_DIR=\\"romfs:/\\")
+set(TTF_FONT_DIR \"romfs:/\")
 
 #Force scaling, for now..
 set(SDL1_VIDEO_MODE_BPP 8)


### PR DESCRIPTION
Based on comments from @glebm. https://github.com/diasurgical/devilutionX/issues/1865#issuecomment-833866115
> Instead of setting `CMAKE_CXX_FLAGS_RELEASE`, simply `set(TTF_FONT_DIR \"romfs:/\")` and add `TTF_FONT_DIR` to the `# Defines with value` list in CMakeLists.txt

`TTF_FONT_DIR` is already listed in the `# Defines with value` list so this should be all that's necessary.