### PR TITLE
Synchronize SFileCloseFile() access

### DIFF
--- a/Source/DiabloUI/art.cpp
+++ b/Source/DiabloUI/art.cpp
@@ -116,7 +116,7 @@ void LoadArt(const char *pszFile, Art *art, int frames, SDL_Color *pPalette)
 
 	if (!LoadPcxMeta(handle, width, height, bpp)) {
 		Log("LoadArt(\"{}\"): LoadPcxMeta failed with code {}", pszFile, SErrGetLastError());
-		SFileCloseFile(handle);
+		SFileCloseFileThreadSafe(handle);
 		return;
 	}
 
@@ -124,10 +124,10 @@ void LoadArt(const char *pszFile, Art *art, int frames, SDL_Color *pPalette)
 	if (!LoadPcxPixelsAndPalette(handle, width, height, bpp, static_cast<BYTE *>(artSurface->pixels),
 	        artSurface->pitch, pPalette)) {
 		Log("LoadArt(\"{}\"): LoadPcxPixelsAndPalette failed with code {}", pszFile, SErrGetLastError());
-		SFileCloseFile(handle);
+		SFileCloseFileThreadSafe(handle);
 		return;
 	}
-	SFileCloseFile(handle);
+	SFileCloseFileThreadSafe(handle);
 
 	art->logical_width = artSurface->w;
 	art->frame_height = height / frames;

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -230,7 +230,7 @@ size_t GetFileSize(const char *pszName)
 	HANDLE file;
 	SFileOpenFile(pszName, &file);
 	const size_t fileLen = SFileGetFileSize(file, nullptr);
-	SFileCloseFile(file);
+	SFileCloseFileThreadSafe(file);
 
 	return fileLen;
 }
@@ -244,7 +244,7 @@ void LoadFileData(const char *pszName, byte *buffer, size_t fileLen)
 		app_fatal("Zero length SFILE:\n%s", pszName);
 
 	SFileReadFileThreadSafe(file, buffer, fileLen);
-	SFileCloseFile(file);
+	SFileCloseFileThreadSafe(file);
 }
 
 /**

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -177,7 +177,7 @@ void init_archives()
 	HANDLE fh = nullptr;
 	if (!SFileOpenFile("ui_art\\title.pcx", &fh))
 		InsertCDDlg();
-	SFileCloseFile(fh);
+	SFileCloseFileThreadSafe(fh);
 
 	patch_rt_mpq = init_test_access(paths, "patch_rt.mpq");
 	if (patch_rt_mpq == nullptr)

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -147,7 +147,7 @@ static std::unique_ptr<uint8_t[]> pfile_read_archive(HANDLE archive, const char 
 	std::unique_ptr<uint8_t[]> buf { new uint8_t[*pdwLen] };
 	if (!SFileReadFileThreadSafe(file, buf.get(), *pdwLen, &nread))
 		return nullptr;
-	SFileCloseFile(file);
+	SFileCloseFileThreadSafe(file);
 
 	*pdwLen = codec_decode(buf.get(), *pdwLen, pfile_get_password());
 	if (*pdwLen == 0)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -538,7 +538,7 @@ static DWORD GetPlrGFXSize(HeroClass c, const char *szCel)
 			if (SFileOpenFile(pszName, &hsFile)) {
 				assert(hsFile);
 				dwSize = SFileGetFileSize(hsFile, nullptr);
-				SFileCloseFile(hsFile);
+				SFileCloseFileThreadSafe(hsFile);
 				if (dwMaxSize <= dwSize) {
 					dwMaxSize = dwSize;
 				}

--- a/Source/sound.cpp
+++ b/Source/sound.cpp
@@ -48,7 +48,7 @@ void LoadMusic(HANDLE handle)
 	int bytestoread = SFileGetFileSize(handle, 0);
 	musicBuffer = new char[bytestoread];
 	SFileReadFileThreadSafe(handle, musicBuffer, bytestoread);
-	SFileCloseFile(handle);
+	SFileCloseFileThreadSafe(handle);
 
 	SDL_RWops *musicRw = SDL_RWFromConstMem(musicBuffer, bytestoread);
 #endif
@@ -178,7 +178,7 @@ std::unique_ptr<TSnd> sound_file_load(const char *path, bool stream)
 		auto wave_file = MakeArraySharedPtr<std::uint8_t>(dwBytes);
 		SFileReadFileThreadSafe(file, wave_file.get(), dwBytes);
 		error = snd->DSB.SetChunk(wave_file, dwBytes);
-		SFileCloseFile(file);
+		SFileCloseFileThreadSafe(file);
 	}
 	if (error != 0) {
 		ErrSdl();

--- a/Source/storm/storm.cpp
+++ b/Source/storm/storm.cpp
@@ -35,11 +35,18 @@ std::string *SBasePath = nullptr;
 
 } // namespace
 
+SDL_mutex *Mutex = SDL_CreateMutex();
+
 bool SFileReadFileThreadSafe(HANDLE hFile, void *buffer, DWORD nNumberOfBytesToRead, DWORD *read, int *lpDistanceToMoveHigh)
 {
-	static SDL_mutex *Mutex = SDL_CreateMutex();
 	SDLMutexLockGuard lock(Mutex);
 	return SFileReadFile(hFile, buffer, nNumberOfBytesToRead, read, lpDistanceToMoveHigh);
+}
+
+bool SFileCloseFileThreadSafe(HANDLE hFile)
+{
+	SDLMutexLockGuard lock(Mutex);
+	return SFileCloseFile(hFile);
 }
 
 radon::File &getIni()

--- a/Source/storm/storm.h
+++ b/Source/storm/storm.h
@@ -321,9 +321,10 @@ bool SFileEnableDirectAccess(bool enable);
 
 // Additions to Storm API:
 
-// Locks ReadFile under a mutex.
+// Locks ReadFile and CloseFile under a mutex.
 // See https://github.com/ladislav-zezula/StormLib/issues/175
 bool SFileReadFileThreadSafe(HANDLE hFile, void *buffer, DWORD nNumberOfBytesToRead, DWORD *read = nullptr, int *lpDistanceToMoveHigh = nullptr);
+bool SFileCloseFileThreadSafe(HANDLE hFile);
 
 // Sets the file's 64-bit seek position.
 inline std::uint64_t SFileSetFilePointer(HANDLE hFile, std::int64_t offset, int whence)

--- a/Source/storm/storm_file_wrapper.cpp
+++ b/Source/storm/storm_file_wrapper.cpp
@@ -49,7 +49,7 @@ int SFileCookieSeek(void *cookie, off64_t *pos, int whence)
 
 int SFileCookieClose(void *cookie)
 {
-	return SFileCloseFile(static_cast<HANDLE>(cookie)) ? 0 : -1;
+	return SFileCloseFileThreadSafe(static_cast<HANDLE>(cookie)) ? 0 : -1;
 }
 
 } // extern "C"

--- a/Source/storm/storm_sdl_rw.cpp
+++ b/Source/storm/storm_sdl_rw.cpp
@@ -71,7 +71,7 @@ static int SFileRwRead(struct SDL_RWops *context, void *ptr, int size, int maxnu
 
 static int SFileRwClose(struct SDL_RWops *context)
 {
-	SFileCloseFile(SFileRwGetHandle(context));
+	SFileCloseFileThreadSafe(SFileRwGetHandle(context));
 	delete context;
 	return 0;
 }

--- a/Source/storm/storm_svid.cpp
+++ b/Source/storm/storm_svid.cpp
@@ -158,7 +158,7 @@ bool SVidPlayBegin(const char *filename, int flags, HANDLE *video)
 	int bytestoread = SFileGetFileSize(*video, nullptr);
 	SVidBuffer = std::unique_ptr<uint8_t[]> { new uint8_t[bytestoread] };
 	SFileReadFileThreadSafe(*video, SVidBuffer.get(), bytestoread);
-	SFileCloseFile(*video);
+	SFileCloseFileThreadSafe(*video);
 	*video = nullptr;
 	SVidSMK = smk_open_memory(SVidBuffer.get(), bytestoread);
 #endif


### PR DESCRIPTION
Fixes more crashes on the 3DS by applying the `SFileReadFile()` mutex to `SFileCloseFile()` as well.