### PR TITLE
3DS: Add devilutionx.mpq to romfs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -817,7 +817,9 @@ if(N3DS)
   set(APP_AUDIO       "${PROJECT_SOURCE_DIR}/Packaging/ctr/audio_silent.wav")
   set(APP_RSF         "${PROJECT_SOURCE_DIR}/Packaging/ctr/template.rsf")
   set(APP_ROMFS       "${CMAKE_BINARY_DIR}/romfs")
-  set(APP_ROMFS_FILES "${PROJECT_SOURCE_DIR}/Packaging/resources/CharisSILB.ttf")
+  set(APP_ROMFS_FILES
+    "${PROJECT_SOURCE_DIR}/Packaging/resources/CharisSILB.ttf"
+    "${PROJECT_SOURCE_DIR}/Packaging/resources/devilutionx.mpq")
   file(MAKE_DIRECTORY ${APP_ROMFS})
   file(COPY ${APP_ROMFS_FILES}
      DESTINATION ${APP_ROMFS})

--- a/Packaging/ctr/README.txt
+++ b/Packaging/ctr/README.txt
@@ -5,7 +5,7 @@
 ### .3dsx installation
 
 #### Install DevilutionX: Diablo
-1. Extract `devilutionx.3dsx`, `CharisSILB.ttf`, and `devilutionx.mpq` and put them into `sd:/3ds/devilutionx/`.
+1. Extract `devilutionx.3dsx` and put it into `sd:/3ds/devilutionx/`.
 2. Copy `diabdat.mpq` from your Diablo CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
 
 #### Install DevilutionX: Diablo - Hellfire
@@ -16,13 +16,12 @@
 
 #### Install DevilutionX: Diablo
 1. Extract `devilutionx.cia` and place it on your SD card.
-2. Extract `devilutionx.mpq` and put it into `sd:/3ds/devilutionx/`.
-3. Copy `diabdat.mpq` from your Diablo CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
-4. Put the SD card back into the 3DS and install `devilutionx.cia` using a title manager (e.g. [FBI](https://github.com/Steveice10/FBI)).
+2. Copy `diabdat.mpq` from your Diablo CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
+3. Put the SD card back into the 3DS and install `devilutionx.cia` using a title manager (e.g. [FBI](https://github.com/Steveice10/FBI)).
     1. `devilutionx.cia` can be removed after being installed.
 
 ##### Install DevilutionX: Diablo - Hellfire
-5. Copy `hellfire.mpq` `hfmonk.mpq` `hfmusic.mpq` and `hfvoice.mpq` from your Hellfire CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
+4. Copy `hellfire.mpq` `hfmonk.mpq` `hfmusic.mpq` and `hfvoice.mpq` from your Hellfire CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
 
 ## Usage
 
@@ -57,6 +56,13 @@ or, when using .cia:
 
 - Single finger drag: move the mouse pointer (pointer jumps to finger)
 - Single short tap: left mouse click
+
+## Tips
+
+- For improved performance, change the game's resolution to 640x480. This may be necessary on old 3DS models which may otherwise run slower than the game's intended framerate.
+    - Open diablo.ini located in sd:/3ds/devilutionx.
+    - Update Graphics settings by changing to `Width=640`.
+    - By default, the game will scale to fill the entire top screen. To keep the aspect ratio when scaling, change to `Fit to Screen=0` in Graphics settings as well.
 
 ## Resources
 

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -148,6 +148,9 @@ void init_archives()
 	paths.emplace_back("/usr/share/diasurgical/devilutionx/");
 	paths.emplace_back("/usr/local/share/diasurgical/devilutionx/");
 #endif
+#ifdef __3DS__
+	paths.emplace_back("romfs:/");
+#endif
 
 	paths.emplace_back(""); // PWD
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -73,6 +73,7 @@ sudo apt install devilutionx
 
 - Copy `devilutionx.cia` to your SD card.
 - Copy the MPQ files to `sd:/3ds/devilutionx/`.
+- Copy the `CharisSILB.ttf` font file into `sd:/3ds/devilutionx/`.
 - Install `devilutionx.cia` with a title manager (e.g. [FBI](https://github.com/Steveice10/FBI)).
     - `devilutionx.cia` can be removed after being installed.
 - Launch Diablo from your 3DS Homemenu.

--- a/docs/manual/platforms/n3ds.md
+++ b/docs/manual/platforms/n3ds.md
@@ -21,7 +21,7 @@ Start by downloading [devilutionx-n3ds.zip](https://github.com/diasurgical/devil
 
 #### Install DevilutionX: Diablo
 1. Extract `devilutionx.cia` and place it on your SD card.
-2. Extract `devilutionx.mpq` and put it into `sd:/3ds/devilutionx/`.
+2. Extract `devilutionx.mpq` and `CharisSILB.ttf` and put them into `sd:/3ds/devilutionx/`.
 3. Copy `diabdat.mpq` from your Diablo CD (or GoG install folder) to `sd:/3ds/devilutionx/`.
 4. Put the SD card back into the 3DS and install `devilutionx.cia` using a title manager (e.g. [FBI](https://github.com/Steveice10/FBI)).
     1. `devilutionx.cia` can be removed after being installed.


### PR DESCRIPTION
Adds devilutionx.mpq to romfs for the 3DS build so it does not have to be deployed to the SD card separately. This includes updates to the readme to reflect this change. I also spotted a couple errors with the installation instructions for 1.2.1 and updated those accordingly.