### PR TITLE
🧹 towners.cpp: Avoid allocations for animOrder

### DIFF
--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -100,7 +100,7 @@ void InitSmith(TownerStruct &towner, const TownerInit &initData)
 {
 	InitQstSnds(towner, initData.type);
 	towner._tAnimWidth = 96;
-	towner.animOrder = {
+	static const uint8_t AnimOrder[] = {
 		// clang-format off
 		5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5,
 		5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5,
@@ -111,6 +111,8 @@ void InitSmith(TownerStruct &towner, const TownerInit &initData)
 		1, 1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 2, 3, 4
 		// clang-format on
 	};
+	towner.animOrder = AnimOrder;
+	towner.animOrderSize = sizeof(AnimOrder);
 	LoadTownerAnimations(towner, "Towners\\Smith\\SmithN.CEL", 16, initData.dir, 3);
 	towner._tName = _("Griswold the Blacksmith");
 }
@@ -119,7 +121,7 @@ void InitBarOwner(TownerStruct &towner, const TownerInit &initData)
 {
 	InitQstSnds(towner, initData.type);
 	towner._tAnimWidth = 96;
-	towner.animOrder = {
+	static const uint8_t AnimOrder[] = {
 		// clang-format off
 		1, 2, 3, 3, 2,  1, 16, 15, 14, 14, 15, 16,
 		1, 2, 3, 3, 2,  1, 16, 15, 14, 14, 15, 16,
@@ -132,6 +134,8 @@ void InitBarOwner(TownerStruct &towner, const TownerInit &initData)
 		1, 2, 3, 4, 5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16
 		// clang-format on
 	};
+	towner.animOrder = AnimOrder;
+	towner.animOrderSize = sizeof(AnimOrder);
 	LoadTownerAnimations(towner, "Towners\\TwnF\\TwnFN.CEL", 16, initData.dir, 3);
 	towner._tName = _("Ogden the Tavern owner");
 }
@@ -140,7 +144,8 @@ void InitTownDead(TownerStruct &towner, const TownerInit &initData)
 {
 	InitQstSnds(towner, initData.type);
 	towner._tAnimWidth = 96;
-	towner.animOrder.clear();
+	towner.animOrder = nullptr;
+	towner.animOrderSize = 0;
 	LoadTownerAnimations(towner, "Towners\\Butch\\Deadguy.CEL", 8, initData.dir, 6);
 	towner._tName = _("Wounded Townsman");
 }
@@ -149,7 +154,7 @@ void InitWitch(TownerStruct &towner, const TownerInit &initData)
 {
 	InitQstSnds(towner, initData.type);
 	towner._tAnimWidth = 96;
-	towner.animOrder = {
+	static const uint8_t AnimOrder[] = {
 		// clang-format off
 		 4,  4,  4,  5,  6,  6,  6,  5,  4, 15, 14, 13, 13, 13, 14, 15, 4, 5, 6, 6, 6, 5,
 		 4,  4,  4,  5,  6,  6,  6,  5,  4, 15, 14, 13, 13, 13, 14, 15, 4, 5, 6, 6, 6, 5,
@@ -162,6 +167,8 @@ void InitWitch(TownerStruct &towner, const TownerInit &initData)
 		 1,  2,  1, 19, 18, 19,  1,  2,  1,  2,  3
 		// clang-format on
 	};
+	towner.animOrder = AnimOrder;
+	towner.animOrderSize = sizeof(AnimOrder);
 	LoadTownerAnimations(towner, "Towners\\TownWmn1\\Witch.CEL", 19, initData.dir, 6);
 	towner._tName = _("Adria the Witch");
 }
@@ -170,7 +177,8 @@ void InitBarmaid(TownerStruct &towner, const TownerInit &initData)
 {
 	InitQstSnds(towner, initData.type);
 	towner._tAnimWidth = 96;
-	towner.animOrder.clear();
+	towner.animOrder = nullptr;
+	towner.animOrderSize = 0;
 	LoadTownerAnimations(towner, "Towners\\TownWmn1\\WmnN.CEL", 18, initData.dir, 6);
 	towner._tName = _("Gillian the Barmaid");
 }
@@ -179,7 +187,8 @@ void InitBoy(TownerStruct &towner, const TownerInit &initData)
 {
 	InitQstSnds(towner, initData.type);
 	towner._tAnimWidth = 96;
-	towner.animOrder.clear();
+	towner.animOrder = nullptr;
+	towner.animOrderSize = 0;
 	LoadTownerAnimations(towner, "Towners\\TownBoy\\PegKid1.CEL", 20, initData.dir, 6);
 	towner._tName = _("Wirt the Peg-legged boy");
 }
@@ -188,7 +197,7 @@ void InitHealer(TownerStruct &towner, const TownerInit &initData)
 {
 	InitQstSnds(towner, initData.type);
 	towner._tAnimWidth = 96;
-	towner.animOrder = {
+	static const uint8_t AnimOrder[] = {
 		// clang-format off
 		 1,  2,  3,  3,  2,  1, 20, 19, 19, 20,
 		 1,  2,  3,  3,  2,  1, 20, 19, 19, 20,
@@ -201,6 +210,8 @@ void InitHealer(TownerStruct &towner, const TownerInit &initData)
 		 5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20
 		// clang-format on
 	};
+	towner.animOrder = AnimOrder;
+	towner.animOrderSize = sizeof(AnimOrder);
 	LoadTownerAnimations(towner, "Towners\\Healer\\Healer.CEL", 20, initData.dir, 6);
 	towner._tName = _("Pepin the Healer");
 }
@@ -209,7 +220,7 @@ void InitTeller(TownerStruct &towner, const TownerInit &initData)
 {
 	InitQstSnds(towner, initData.type);
 	towner._tAnimWidth = 96;
-	towner.animOrder = {
+	static const uint8_t AnimOrder[] = {
 		// clang-format off
 		 1,  1, 25, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15,
 		16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 25, 25,  1,  1,  1, 25,
@@ -217,6 +228,8 @@ void InitTeller(TownerStruct &towner, const TownerInit &initData)
 		14, 13, 12, 11, 10,  9,  8,  7,  6,  5,  4,  3,  2,  1
 		// clang-format on
 	};
+	towner.animOrder = AnimOrder;
+	towner.animOrderSize = sizeof(AnimOrder);
 	LoadTownerAnimations(towner, "Towners\\Strytell\\Strytell.CEL", 25, initData.dir, 3);
 	towner._tName = _("Cain the Elder");
 }
@@ -225,13 +238,15 @@ void InitDrunk(TownerStruct &towner, const TownerInit &initData)
 {
 	InitQstSnds(towner, initData.type);
 	towner._tAnimWidth = 96;
-	towner.animOrder = {
+	static const uint8_t AnimOrder[] = {
 		// clang-format off
 		 1, 1, 1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 11, 11, 11, 12, 13, 14, 15, 16, 17, 18, 18,
 		 1, 1, 1, 18, 17, 16, 15, 14, 13, 12, 11, 10, 11, 12, 13, 14, 15, 16, 17, 18,
 		 1, 2, 3,  4,  5,  5,  5,  4,  3,  2
 		// clang-format off
 	};
+		towner.animOrder = AnimOrder;
+	towner.animOrderSize = sizeof(AnimOrder);
 	LoadTownerAnimations(towner, "Towners\\Drunk\\TwnDrunk.CEL", 18, initData.dir, 3);
 	towner._tName = _("Farnham the Drunk");
 }
@@ -239,7 +254,8 @@ void InitDrunk(TownerStruct &towner, const TownerInit &initData)
 void InitCows(TownerStruct &towner, const TownerInit &initData)
 {
 	towner._tAnimWidth = 128;
-	towner.animOrder.clear();
+	towner.animOrder = nullptr;
+	towner.animOrderSize = 0;
 	for (int i = 0; i < 8; i++) {
 		towner._tNAnim[i] = CelGetFrameStart(CowCels.get(), i);
 	}
@@ -262,7 +278,8 @@ void InitFarmer(TownerStruct &towner, const TownerInit &initData)
 {
 	InitQstSnds(towner, initData.type);
 	towner._tAnimWidth = 96;
-	towner.animOrder.clear();
+	towner.animOrder = nullptr;
+	towner.animOrderSize = 0;
 	LoadTownerAnimations(towner, "Towners\\Farmer\\Farmrn2.CEL", 15, initData.dir, 3);
 	towner._tName = _("Lester the farmer");
 }
@@ -275,7 +292,8 @@ void InitCowFarmer(TownerStruct &towner, const TownerInit &initData)
 		celPath = "Towners\\Farmer\\mfrmrn2.CEL";
 	}
 	towner._tAnimWidth = 96;
-	towner.animOrder.clear();
+	towner.animOrder = nullptr;
+	towner.animOrderSize = 0;
 	LoadTownerAnimations(towner, celPath, 15, initData.dir, 3);
 	towner._tName = _("Complete Nut");
 }
@@ -288,7 +306,8 @@ void InitGirl(TownerStruct &towner, const TownerInit &initData)
 		celPath = "Towners\\Girl\\Girls1.CEL";
 	}
 	towner._tAnimWidth = 96;
-	towner.animOrder.clear();
+	towner.animOrder = nullptr;
+	towner.animOrderSize = 0;
 	LoadTownerAnimations(towner, celPath, 20, initData.dir, 6);
 	towner._tName = "Celia";
 }
@@ -1031,9 +1050,9 @@ void ProcessTowners()
 
 		towner._tAnimCnt = 0;
 
-		if (towner.animOrder.size() > 0) {
+		if (towner.animOrderSize > 0) {
 			towner._tAnimFrameCnt++;
-			if (towner._tAnimFrameCnt > towner.animOrder.size() - 1)
+			if (towner._tAnimFrameCnt > towner.animOrderSize - 1)
 				towner._tAnimFrameCnt = 0;
 
 			towner._tAnimFrame = towner.animOrder[towner._tAnimFrameCnt];

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -5,9 +5,9 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <vector>
 #include "utils/stdcompat/string_view.hpp"
 
 #include "items.h"
@@ -60,7 +60,8 @@ struct TownerStruct {
 	bool _tSelFlag;
 	bool _tMsgSaid;
 	/** Specifies the animation frame sequence. */
-	std::vector<uint8_t> animOrder;
+	const uint8_t *animOrder; // unowned
+	std::size_t animOrderSize;
 	PlayerStruct *_tTalkingToPlayer;
 	void (*talk)(PlayerStruct &player, TownerStruct &barOwner);
 	bool _tbtcnt;


### PR DESCRIPTION
There is no need for `animOrder` to be a vector -- it's static data.

We don't have `std::span` yet, so opted for pointer + size.