### PR TITLE
ADL: Bugfix hero flicker when Diablo is killed

### DIFF
--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -247,7 +247,7 @@ bool nthread_has_500ms_passed()
 
 void nthread_UpdateProgressToNextGameTick()
 {
-	if (!gbRunGame || PauseMode || (!gbIsMultiplayer && gmenu_is_active())) // if game is not running or paused there is no next gametick in the near future
+	if (!gbRunGame || PauseMode || (!gbIsMultiplayer && gmenu_is_active()) || !gbProcessPlayers) // if game is not running or paused there is no next gametick in the near future
 		return;
 	int currentTickCount = SDL_GetTicks();
 	int ticksElapsed = last_tick - currentTickCount;


### PR DESCRIPTION
Fixes #1893
Thanks @Chance4us for reporting and savegame 🙂 

I killed a him 3 times with apocalypse and didn't saw any flickering.
Without this pr, I got the flickering at the first time.