### PR TITLE
Fix breaking glass sound is missing for small life/mana potions

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1537,7 +1537,6 @@ void AddStealPotions(int mi, int sx, int sy, int dx, int dy, int midir, int8_t m
 								} else {
 									ii = ItemMiscIdIdx(IMISC_HEAL);
 								}
-								ii = ItemMiscIdIdx(IMISC_HEAL);
 								break;
 							case IMISC_FULLREJUV:
 								switch (GenerateRnd(3)) {

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1527,7 +1527,7 @@ void AddStealPotions(int mi, int sx, int sy, int dx, int dy, int midir, int8_t m
 							case IMISC_HEAL:
 							case IMISC_MANA:
 								RemoveSpdBarItem(pnum, si);
-								continue;
+								break;
 							case IMISC_FULLMANA:
 								ii = ItemMiscIdIdx(IMISC_MANA);
 								break;


### PR DESCRIPTION
Fixex #1642
If we break something, we should break and don't continue if nothing happens 🤣 

Thanks @Chance4us for the nice save and reporting 🙂 