### PR TITLE
Allow non-ASCII symbols in data/save-directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,11 @@ add_library(StormLib STATIC
   3rdParty/StormLib/src/SFileOpenFileEx.cpp
   3rdParty/StormLib/src/SFileReadFile.cpp)
 
+if(WIN32)
+# Enable Unicode for StormLib wchar_t* file APIs
+target_compile_definitions(StormLib PRIVATE -DUNICODE -D_UNICODE)
+endif()
+
 add_library(PKWare STATIC
   3rdParty/PKWare/explode.cpp
   3rdParty/PKWare/implode.cpp)

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -12,6 +12,7 @@
 #include "dx.h"
 #include "pfile.h"
 #include "storm/storm.h"
+#include "utils/file_util.h"
 #include "utils/paths.h"
 #include "utils/ui_fwd.h"
 #include "utils/log.hpp"
@@ -59,7 +60,7 @@ HANDLE init_test_access(const std::vector<std::string> &paths, const char *mpq_n
 	std::string mpq_abspath;
 	for (const auto &path : paths) {
 		mpq_abspath = path + mpq_name;
-		if (SFileOpenArchive(mpq_abspath.c_str(), 0, MPQ_OPEN_READ_ONLY, &archive)) {
+		if (SFileOpenArchiveDiablo(mpq_abspath.c_str(), 0, MPQ_OPEN_READ_ONLY, &archive)) {
 			LogVerbose("  Found: {} in {}", mpq_name, path);
 			SFileSetBasePath(path.c_str());
 			return archive;

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -90,7 +90,7 @@ struct FStreamWrapper {
 public:
 	bool Open(const char *path, std::ios::openmode mode)
 	{
-		s_ = std::make_unique<std::fstream>(path, mode);
+		s_ = CreateFileStream(path, mode);
 		return CheckError("new std::fstream(\"%s\", %s)", path, OpenModeToString(mode).c_str());
 	}
 

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -195,7 +195,7 @@ static HANDLE pfile_open_save_archive(DWORD save_num)
 {
 	HANDLE archive;
 
-	if (SFileOpenArchive(GetSavePath(save_num).c_str(), 0, 0, &archive))
+	if (SFileOpenArchiveDiablo(GetSavePath(save_num).c_str(), 0, 0, &archive))
 		return archive;
 	return nullptr;
 }

--- a/Source/restrict.cpp
+++ b/Source/restrict.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "appfat.h"
+#include "utils/file_util.h"
 #include "utils/paths.h"
 
 namespace devilution {
@@ -16,12 +17,11 @@ namespace devilution {
 void ReadOnlyTest()
 {
 	const std::string path = paths::PrefPath() + "Diablo1ReadOnlyTest.foo";
-	FILE *f = fopen(path.c_str(), "wt");
-	if (f == nullptr) {
+	auto fileStream = CreateFileStream(path.c_str(), std::ios::in | std::ios::out);
+	if (fileStream->fail()) {
 		DirErrorDlg(paths::PrefPath().c_str());
 	}
 
-	fclose(f);
 	remove(path.c_str());
 }
 

--- a/Source/storm/storm.h
+++ b/Source/storm/storm.h
@@ -244,7 +244,11 @@ bool SNetSendTurn(char *data, unsigned int databytes);
 bool SFileOpenFile(const char *filename, HANDLE *phFile);
 
 // Functions implemented in StormLib
+#if defined(_WIN64) || defined(_WIN32)
+bool WINAPI SFileOpenArchive(const wchar_t *szMpqName, DWORD dwPriority, DWORD dwFlags, HANDLE *phMpq);
+#else
 bool WINAPI SFileOpenArchive(const char *szMpqName, DWORD dwPriority, DWORD dwFlags, HANDLE *phMpq);
+#endif
 bool WINAPI SFileCloseArchive(HANDLE hArchive);
 bool WINAPI SFileOpenFileEx(HANDLE hMpq, const char *szFileName, DWORD dwSearchScope, HANDLE *phFile);
 bool WINAPI SFileReadFile(HANDLE hFile, void *buffer, DWORD nNumberOfBytesToRead, DWORD *read, int *lpDistanceToMoveHigh);

--- a/Source/utils/file_util.cpp
+++ b/Source/utils/file_util.cpp
@@ -31,6 +31,8 @@
 #include <cstdio>
 #endif
 
+#include "storm/storm.h"
+
 namespace devilution {
 
 namespace {
@@ -159,6 +161,11 @@ void RemoveFile(const char *lpFileName)
 std::unique_ptr<std::fstream> CreateFileStream(const char *path, std::ios::openmode mode)
 {
 	return std::make_unique<std::fstream>(path, mode);
+}
+
+bool SFileOpenArchiveDiablo(const char *szMpqName, DWORD dwPriority, DWORD dwFlags, HANDLE *phMpq)
+{
+	return SFileOpenArchive(szMpqName, dwPriority, dwFlags, phMpq);
 }
 
 } // namespace devilution

--- a/Source/utils/file_util.cpp
+++ b/Source/utils/file_util.cpp
@@ -174,7 +174,16 @@ std::unique_ptr<std::fstream> CreateFileStream(const char *path, std::ios::openm
 
 bool SFileOpenArchiveDiablo(const char *szMpqName, DWORD dwPriority, DWORD dwFlags, HANDLE *phMpq)
 {
+#if defined(_WIN64) || defined(_WIN32)
+	const auto szMpqNameUtf16 = ToWideChar(szMpqName);
+	if (szMpqNameUtf16 == nullptr) {
+		LogError("UTF-8 -> UTF-16 conversion error code {}", ::GetLastError());
+		return false;
+	}
+	return SFileOpenArchive(szMpqNameUtf16.get(), dwPriority, dwFlags, phMpq);
+#else
 	return SFileOpenArchive(szMpqName, dwPriority, dwFlags, phMpq);
+#endif
 }
 
 } // namespace devilution

--- a/Source/utils/file_util.cpp
+++ b/Source/utils/file_util.cpp
@@ -160,7 +160,16 @@ void RemoveFile(const char *lpFileName)
 
 std::unique_ptr<std::fstream> CreateFileStream(const char *path, std::ios::openmode mode)
 {
+#if defined(_WIN64) || defined(_WIN32)
+	const auto pathUtf16 = ToWideChar(path);
+	if (pathUtf16 == nullptr) {
+		LogError("UTF-8 -> UTF-16 conversion error code {}", ::GetLastError());
+		return nullptr;
+	}
+	return std::make_unique<std::fstream>(pathUtf16.get(), mode);
+#else
 	return std::make_unique<std::fstream>(path, mode);
+#endif
 }
 
 bool SFileOpenArchiveDiablo(const char *szMpqName, DWORD dwPriority, DWORD dwFlags, HANDLE *phMpq)

--- a/Source/utils/file_util.cpp
+++ b/Source/utils/file_util.cpp
@@ -3,7 +3,6 @@
 
 #include <algorithm>
 #include <string>
-#include <sys/stat.h>
 
 #include <SDL.h>
 
@@ -26,6 +25,7 @@
 #endif
 
 #if _POSIX_C_SOURCE >= 200112L || defined(_BSD_SOURCE) || defined(__APPLE__)
+#include <sys/stat.h>
 #include <unistd.h>
 #else
 #include <cstdio>
@@ -82,11 +82,25 @@ bool FileExists(const char *path)
 
 bool GetFileSize(const char *path, std::uintmax_t *size)
 {
+#if defined(_WIN64) || defined(_WIN32)
+	const auto pathUtf16 = ToWideChar(path);
+	if (pathUtf16 == nullptr) {
+		LogError("UTF-8 -> UTF-16 conversion error code {}", ::GetLastError());
+		return false;
+	}
+	WIN32_FILE_ATTRIBUTE_DATA attr;
+	if (!GetFileAttributesExW(&pathUtf16[0], GetFileExInfoStandard, &attr)) {
+		return false;
+	}
+	*size = (attr.nFileSizeHigh) << (sizeof(attr.nFileSizeHigh) * 8) | attr.nFileSizeLow;
+	return true;
+#else
 	struct ::stat statResult;
 	if (::stat(path, &statResult) == -1)
 		return false;
 	*size = static_cast<uintmax_t>(statResult.st_size);
 	return true;
+#endif
 }
 
 bool ResizeFile(const char *path, std::uintmax_t size)

--- a/Source/utils/file_util.cpp
+++ b/Source/utils/file_util.cpp
@@ -156,4 +156,9 @@ void RemoveFile(const char *lpFileName)
 #endif
 }
 
+std::unique_ptr<std::fstream> CreateFileStream(const char *path, std::ios::openmode mode)
+{
+	return std::make_unique<std::fstream>(path, mode);
+}
+
 } // namespace devilution

--- a/Source/utils/file_util.h
+++ b/Source/utils/file_util.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include <cstdint>
+#include <fstream>
+#include <memory>
 namespace devilution {
 
 bool FileExists(const char *path);
 bool GetFileSize(const char *path, std::uintmax_t *size);
 bool ResizeFile(const char *path, std::uintmax_t size);
 void RemoveFile(const char *lpFileName);
+std::unique_ptr<std::fstream> CreateFileStream(const char *path, std::ios::openmode mode);
 
 } // namespace devilution

--- a/Source/utils/file_util.h
+++ b/Source/utils/file_util.h
@@ -3,6 +3,9 @@
 #include <cstdint>
 #include <fstream>
 #include <memory>
+
+#include "miniwin/miniwin.h"
+
 namespace devilution {
 
 bool FileExists(const char *path);
@@ -10,5 +13,6 @@ bool GetFileSize(const char *path, std::uintmax_t *size);
 bool ResizeFile(const char *path, std::uintmax_t size);
 void RemoveFile(const char *lpFileName);
 std::unique_ptr<std::fstream> CreateFileStream(const char *path, std::ios::openmode mode);
+bool SFileOpenArchiveDiablo(const char *szMpqName, DWORD dwPriority, DWORD dwFlags, HANDLE *phMpq);
 
 } // namespace devilution

--- a/Source/utils/log.hpp
+++ b/Source/utils/log.hpp
@@ -11,7 +11,7 @@
 namespace devilution {
 
 // Local definition to fix compilation issue due to header conflict.
-void app_fatal(const char *pszFmt, ...);
+[[noreturn]] void app_fatal(const char *pszFmt, ...);
 
 enum class LogCategory {
 	Application = SDL_LOG_CATEGORY_APPLICATION,


### PR DESCRIPTION
Contributes to #747

## Background

Windows can per default only access UTF8-Paths with wchar_t function overloads.

References:
- https://stackoverflow.com/questions/396567/is-there-a-standard-way-to-do-an-fopen-with-a-unicode-string-file-path
- https://stackoverflow.com/questions/821873/how-to-open-an-stdfstream-ofstream-or-ifstream-with-a-unicode-filename

## Main Changes (on windows):

- Use `fstream`-Constructor with `wchar_t*` overload
- Definie Unicode for StormLib so that a `wchar_t*` (`TCHAR*`)  `SFileOpenArchive` is present

## Restrictions

Currently config-dir is not supported, cause it's not possible to pass a File-Handle or Stream to `Radon`.
But the game will start anyway, only the ini file is ignored (not read from or written to).

## Tested

- Open Game
- Play Intro
- Create Hero
- Save Hero
- Load Hero
- Delete Hero
- Read only check

## Alternative

An alternative could be https://docs.microsoft.com/en-us/windows/uwp/design/globalizing/use-utf8-code-page
This also works (tested with master and changed manifest) and it's much cleaner. But the main problem is that it's only supported since Windows 10 Version 1903.
If we want to go down this route, I can also open a PR with the adjusted Manifest-File.