### PR TITLE
Fix loading of infravision palette transformation

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -855,7 +855,7 @@ void PlaceUniqueMonst(int uniqindex, int miniontype, int bosspacksize)
 	}
 
 	sprintf(filestr, "Monsters\\Monsters\\%s.TRN", Uniq->mTrnName);
-	LoadFileInMem("PlrGFX\\Infra.TRN", &pLightTbl[256 * (uniquetrans + 19)], 256);
+	LoadFileInMem(filestr, &pLightTbl[256 * (uniquetrans + 19)], 256);
 
 	Monst->_uniqtrans = uniquetrans++;
 


### PR DESCRIPTION
...instead of actual unique monster transformation.

Fixes #1868 which made all uniques look positively sunburnt:

![image](https://user-images.githubusercontent.com/81810641/117592134-c74d9480-b137-11eb-8536-8addd5e9b270.png)
