### PR TITLE
Use OS GUI to display error message if font fails to load

### DIFF
--- a/Source/DiabloUI/dialogs.cpp
+++ b/Source/DiabloUI/dialogs.cpp
@@ -280,7 +280,10 @@ void UiOkDialog(const char *text, const char *caption, bool error, const std::ve
 
 	inDialog = true;
 	Init(text, caption, error, !renderBehind.empty());
-	DialogLoop(vecOkDialog, renderBehind);
+	if (font != nullptr)
+		DialogLoop(vecOkDialog, renderBehind);
+	else
+		UiOkDialog(text, caption, error, renderBehind);
 	Deinit();
 	inDialog = false;
 }


### PR DESCRIPTION
This turned out to be much simpler than I anticipated. The routine that displays the error dialog was already designed to fall back on the OS GUI if an error occurs while displaying the dialog so all I had to do was call it recursively.

On platforms using SDL1, it uses `SDL_Log()` instead of displaying the error message.
https://github.com/diasurgical/devilutionX/blob/73a90502de8bab62f55b9ebe5ce3a615dcb32f22/Source/utils/sdl2_to_1_2_backports.h#L126-L133

This presents opportunities for platform-specific improvements.