### PR TITLE
Fix ReadOnlyTest for Linux/Mac

### DIFF
--- a/Source/restrict.cpp
+++ b/Source/restrict.cpp
@@ -17,7 +17,7 @@ namespace devilution {
 void ReadOnlyTest()
 {
 	const std::string path = paths::PrefPath() + "Diablo1ReadOnlyTest.foo";
-	FILE *f = fopen(path.c_str(), "wt");
+	FILE *f = FOpen(path.c_str(), "wt");
 	if (f == nullptr) {
 		DirErrorDlg(paths::PrefPath().c_str());
 	}

--- a/Source/restrict.cpp
+++ b/Source/restrict.cpp
@@ -17,11 +17,12 @@ namespace devilution {
 void ReadOnlyTest()
 {
 	const std::string path = paths::PrefPath() + "Diablo1ReadOnlyTest.foo";
-	auto fileStream = CreateFileStream(path.c_str(), std::ios::in | std::ios::out);
-	if (fileStream->fail()) {
+	FILE *f = fopen(path.c_str(), "wt");
+	if (f == nullptr) {
 		DirErrorDlg(paths::PrefPath().c_str());
 	}
 
+	fclose(f);
 	RemoveFile(path.c_str());
 }
 


### PR DESCRIPTION
The same check (`FileStream`) that was introduces #1920 seems to [not work](https://github.com/diasurgical/devilutionX/pull/1920#issuecomment-836388494) under Linux/Mac.
So instead of `FileStream` use FOpen that was introduces with 6a27b37d

@AJenbo Could you try this fix?