### PR TITLE
Custom message box for 3DS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,7 +459,8 @@ if(N3DS)
   list(APPEND devilutionx_SRCS
     Source/platform/ctr/system.cpp
     Source/platform/ctr/keyboard.cpp
-    Source/platform/ctr/display.cpp)
+    Source/platform/ctr/display.cpp
+    Source/platform/ctr/messagebox.cpp)
   set(BIN_TARGET ${BIN_TARGET}.elf)
 endif()
 

--- a/Source/platform/ctr/messagebox.cpp
+++ b/Source/platform/ctr/messagebox.cpp
@@ -1,0 +1,29 @@
+#include <3ds.h>
+#include <SDL.h>
+#include <fmt/core.h>
+#include "utils/sdl2_to_1_2_backports.h"
+
+int SDL_ShowSimpleMessageBox(Uint32 flags,
+    const char *title,
+    const char *message,
+    SDL_Surface *window)
+{
+	if (SDL_ShowCursor(SDL_DISABLE) <= -1)
+		SDL_Log("%s", SDL_GetError());
+
+	bool init = !gspHasGpuRight();
+	auto text = fmt::format("{}\n\n{}", title, message);
+
+	if (init)
+		gfxInitDefault();
+
+	errorConf error;
+	errorInit(&error, ERROR_TEXT, CFG_LANGUAGE_EN);
+	errorText(&error, text.c_str());
+	errorDisp(&error);
+
+	if (init)
+		gfxExit();
+
+	return 0;
+}

--- a/Source/utils/sdl2_to_1_2_backports.h
+++ b/Source/utils/sdl2_to_1_2_backports.h
@@ -123,6 +123,12 @@ enum {
 	// clang-format on
 };
 
+#ifdef __3DS__
+int SDL_ShowSimpleMessageBox(Uint32 flags,
+    const char *title,
+    const char *message,
+    SDL_Surface *window);
+#else
 inline int SDL_ShowSimpleMessageBox(Uint32 flags,
     const char *title,
     const char *message,
@@ -131,6 +137,7 @@ inline int SDL_ShowSimpleMessageBox(Uint32 flags,
 	SDL_Log("MSGBOX: %s\n%s", title, message);
 	return 0;
 }
+#endif
 
 //= Window handling
 

--- a/Source/utils/sdl2_to_1_2_backports.h
+++ b/Source/utils/sdl2_to_1_2_backports.h
@@ -124,6 +124,7 @@ enum {
 };
 
 #ifdef __3DS__
+/** Defined in Source/platform/ctr/messagebox.cpp */
 int SDL_ShowSimpleMessageBox(Uint32 flags,
     const char *title,
     const char *message,


### PR DESCRIPTION
Custom implementation of `SDL_ShowSimpleMessageBox()` using features to display console output. Thanks to the romfs changes, it would be extremely unlikely for an error dialog to ever fall back on this function, but I feel it's still good to have a fallback that doesn't just silently "crash to desktop".