### PR TITLE
🎉 Final clipping fix + buffer padding removal

### DIFF
--- a/Source/DiabloUI/art_draw.cpp
+++ b/Source/DiabloUI/art_draw.cpp
@@ -52,8 +52,8 @@ void DrawArt(const CelOutputBuffer &out, Sint16 screenX, Sint16 screenY, Art *ar
 	if (srcH != 0 && srcH < srcRect.h)
 		srcRect.h = srcH;
 	SDL_Rect dstRect;
-	dstRect.x = BUFFER_BORDER_LEFT + screenX;
-	dstRect.y = BUFFER_BORDER_TOP + screenY;
+	dstRect.x = screenX;
+	dstRect.y = screenY;
 	dstRect.w = srcRect.w;
 	dstRect.h = srcRect.h;
 

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -153,13 +153,7 @@ static void RedPalette()
 		system_palette[i].b = 0;
 	}
 	palette_update();
-	SDL_Rect srcRect {
-		BUFFER_BORDER_LEFT,
-		BUFFER_BORDER_TOP,
-		gnScreenWidth,
-		gnScreenHeight,
-	};
-	BltFast(&srcRect, nullptr);
+	BltFast(nullptr, nullptr);
 	RenderPresent();
 }
 

--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -43,8 +43,8 @@ static void dx_create_back_buffer()
 {
 	pal_surface = SDL_CreateRGBSurfaceWithFormat(
 	    /*flags=*/0,
-	    /*width=*/BUFFER_BORDER_LEFT + gnScreenWidth + BUFFER_BORDER_RIGHT,
-	    /*height=*/BUFFER_BORDER_TOP + gnScreenHeight + BUFFER_BORDER_BOTTOM,
+	    /*width=*/gnScreenWidth,
+	    /*height=*/gnScreenHeight,
 	    /*depth=*/8,
 	    SDL_PIXELFORMAT_INDEX8);
 	if (pal_surface == nullptr) {
@@ -137,7 +137,7 @@ CelOutputBuffer GlobalBackBuffer()
 		return CelOutputBuffer();
 	}
 
-	return CelOutputBuffer(pal_surface, SDL_Rect { BUFFER_BORDER_LEFT, BUFFER_BORDER_TOP, gnScreenWidth, gnScreenHeight });
+	return CelOutputBuffer(pal_surface, SDL_Rect { 0, 0, gnScreenWidth, gnScreenHeight });
 }
 
 void dx_cleanup()

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -30,11 +30,6 @@
 #include "appfat.h"
 #include "miniwin/miniwin.h"
 
-#define BUFFER_BORDER_LEFT 64
-#define BUFFER_BORDER_TOP 160
-#define BUFFER_BORDER_RIGHT devilution::borderRight
-#define BUFFER_BORDER_BOTTOM 16
-
 #define TILE_WIDTH 64
 #define TILE_HEIGHT 32
 

--- a/Source/engine/render/cel_render.cpp
+++ b/Source/engine/render/cel_render.cpp
@@ -533,7 +533,7 @@ void RenderCelOutlineClippedXY(const CelOutputBuffer &out, Point position, const
 }
 
 template <bool SkipColorIndexZero>
-void RenderCelOutline(const CelOutputBuffer &out, Point position, const byte *src, std::size_t srcSize, // NOLINT(readability-function-cognitive-complexity)
+void RenderCelOutline(const CelOutputBuffer &out, Point position, const byte *src, std::size_t srcSize,
     std::size_t srcWidth, std::uint8_t color)
 {
 	if (position.x > 0 && position.x + static_cast<int>(srcWidth) < static_cast<int>(out.w())) {

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -231,13 +231,12 @@ void PaletteFadeIn(int fr)
 {
 	ApplyGamma(logical_palette, orig_palette, 256);
 
-	SDL_Rect SrcRect { BUFFER_BORDER_LEFT, BUFFER_BORDER_TOP, gnScreenWidth, gnScreenHeight };
 	const uint32_t tc = SDL_GetTicks();
 	fr *= 3;
 
 	for (uint32_t i = 0; i < 256; i = fr * (SDL_GetTicks() - tc) / 50) {
 		SetFadeLevel(i);
-		BltFast(&SrcRect, nullptr);
+		BltFast(nullptr, nullptr);
 		RenderPresent();
 	}
 	SetFadeLevel(256);
@@ -252,13 +251,12 @@ void PaletteFadeOut(int fr)
 	if (!sgbFadedIn)
 		return;
 
-	SDL_Rect SrcRect { BUFFER_BORDER_LEFT, BUFFER_BORDER_TOP, gnScreenWidth, gnScreenHeight };
 	const uint32_t tc = SDL_GetTicks();
 	fr *= 3;
 
 	for (uint32_t i = 0; i < 256; i = fr * (SDL_GetTicks() - tc) / 50) {
 		SetFadeLevel(256 - i);
-		BltFast(&SrcRect, nullptr);
+		BltFast(nullptr, nullptr);
 		RenderPresent();
 	}
 	SetFadeLevel(0);

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1275,14 +1275,7 @@ void ClearScreenBuffer()
 	lock_buf(3);
 
 	assert(pal_surface != nullptr);
-
-	SDL_Rect SrcRect = {
-		BUFFER_BORDER_LEFT,
-		BUFFER_BORDER_TOP,
-		gnScreenWidth,
-		gnScreenHeight,
-	};
-	SDL_FillRect(pal_surface, &SrcRect, 0);
+	SDL_FillRect(pal_surface, nullptr, 0);
 
 	unlock_buf(3);
 }
@@ -1413,8 +1406,8 @@ static void DoBlitScreen(Sint16 dwX, Sint16 dwY, Uint16 dwWdt, Uint16 dwHgt)
 	// In SDL1 SDL_Rect x and y are Sint16. Cast explicitly to avoid a compiler warning.
 	using CoordType = decltype(SDL_Rect {}.x);
 	SDL_Rect src_rect {
-		static_cast<CoordType>(BUFFER_BORDER_LEFT + dwX),
-		static_cast<CoordType>(BUFFER_BORDER_TOP + dwY),
+		static_cast<CoordType>(dwX),
+		static_cast<CoordType>(dwY),
 		dwWdt, dwHgt
 	};
 	SDL_Rect dst_rect { dwX, dwY, dwWdt, dwHgt };

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -34,7 +34,6 @@ extern SDL_Surface *renderer_texture_surface; /** defined in dx.cpp */
 Uint16 gnScreenWidth;
 Uint16 gnScreenHeight;
 Uint16 gnViewportHeight;
-Uint16 borderRight;
 
 #ifdef USE_SDL1
 void SetVideoMode(int width, int height, int bpp, uint32_t flags)
@@ -75,12 +74,6 @@ void AdjustToScreenGeometry(int width, int height)
 {
 	gnScreenWidth = width;
 	gnScreenHeight = height;
-
-	borderRight = 64;
-	if ((gnScreenWidth % 4) != 0) {
-		// The buffer needs to be divisible by 4 for the engine to blit correctly
-		borderRight += 4 - gnScreenWidth % 4;
-	}
 
 	gnViewportHeight = gnScreenHeight;
 	if (gnScreenWidth <= PANEL_WIDTH) {

--- a/Source/utils/ui_fwd.h
+++ b/Source/utils/ui_fwd.h
@@ -7,7 +7,6 @@ namespace devilution {
 extern Uint16 gnScreenWidth;
 extern Uint16 gnScreenHeight;
 extern Uint16 gnViewportHeight;
-extern Uint16 borderRight;
 
 bool SpawnWindow(const char *lpWindowName);
 void UiErrorOkDialog(const char *text, const char *caption, bool error = true);


### PR DESCRIPTION
CL2 outline is now clipped. As this is the final clipping fix, we remove the buffer padding.

After this we can start work on switching to hardware surfaces + double-buffering on platforms where we want to use 8-bit surfaces.