### PR TITLE
Remove PlayerStruct.actionFrame and enable ADL for Walking/Run

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -421,7 +421,8 @@ static void LoadPlayer(LoadHelper *file, int p)
 	pPlayer->_pVar5 = file->nextLE<int32_t>();
 	pPlayer->position.offset2.x = file->nextLE<int32_t>();
 	pPlayer->position.offset2.y = file->nextLE<int32_t>();
-	pPlayer->actionFrame = file->nextLE<int32_t>();
+	// Skip actionFrame
+	file->skip(4);
 	for (uint8_t i = 0; i < giNumberOfLevels; i++)
 		pPlayer->_pLvlVisited[i] = file->nextBool8();
 	for (uint8_t i = 0; i < giNumberOfLevels; i++)
@@ -1407,7 +1408,8 @@ static void SavePlayer(SaveHelper *file, int p)
 	file->writeLE<int32_t>(pPlayer->_pVar5);
 	file->writeLE<int32_t>(pPlayer->position.offset2.x);
 	file->writeLE<int32_t>(pPlayer->position.offset2.y);
-	file->writeLE<int32_t>(pPlayer->actionFrame);
+	// Write actionFrame for vanilla compatibility
+	file->writeLE<int32_t>(0);
 	for (uint8_t i = 0; i < giNumberOfLevels; i++)
 		file->writeLE<uint8_t>(pPlayer->_pLvlVisited[i]);
 	for (uint8_t i = 0; i < giNumberOfLevels; i++)

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2237,7 +2237,6 @@ static DWORD On_PLAYER_JOINLEVEL(TCmd *pCmd, int pnum)
 					plr[pnum]._pmode = PM_DEATH;
 					NewPlrAnim(pnum, plr[pnum]._pDAnim[DIR_S], plr[pnum]._pDFrames, 1, plr[pnum]._pDWidth);
 					plr[pnum].AnimInfo.CurrentFrame = plr[pnum].AnimInfo.NumberOfFrames - 1;
-					plr[pnum].actionFrame = plr[pnum].AnimInfo.NumberOfFrames * 2;
 					dFlags[plr[pnum].position.tile.x][plr[pnum].position.tile.y] |= BFLAG_DEAD_PLAYER;
 				}
 

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -881,7 +881,6 @@ void recv_plrinfo(int pnum, TCmdPlrInfoHdr *p, bool recv)
 			plr[pnum]._pmode = PM_DEATH;
 			NewPlrAnim(pnum, plr[pnum]._pDAnim[DIR_S], plr[pnum]._pDFrames, 1, plr[pnum]._pDWidth);
 			plr[pnum].AnimInfo.CurrentFrame = plr[pnum].AnimInfo.NumberOfFrames - 1;
-			plr[pnum].actionFrame = 2 * plr[pnum].AnimInfo.NumberOfFrames;
 			dFlags[plr[pnum].position.tile.x][plr[pnum].position.tile.y] |= BFLAG_DEAD_PLAYER;
 		}
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1148,7 +1148,6 @@ void InitPlayer(int pnum, bool FirstTime)
 			plr[pnum]._pmode = PM_DEATH;
 			NewPlrAnim(pnum, plr[pnum]._pDAnim[DIR_S], plr[pnum]._pDFrames, 1, plr[pnum]._pDWidth);
 			plr[pnum].AnimInfo.CurrentFrame = plr[pnum].AnimInfo.NumberOfFrames - 1;
-			plr[pnum].actionFrame = 2 * plr[pnum].AnimInfo.NumberOfFrames;
 		}
 
 		plr[pnum]._pdir = DIR_S;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -637,7 +637,6 @@ void ClearPlrPVars(int pnum)
 	plr[pnum]._pVar4 = 0;
 	plr[pnum]._pVar5 = 0;
 	plr[pnum].position.offset2 = { 0, 0 };
-	plr[pnum].actionFrame = 0;
 	plr[pnum].deathFrame = 0;
 }
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1667,7 +1667,6 @@ void StartSpell(int pnum, direction d, int cx, int cy)
 
 	plr[pnum].position.temp = { cx, cy };
 	plr[pnum]._pVar4 = GetSpellLevel(pnum, plr[pnum]._pSpell);
-	plr[pnum].actionFrame = 1;
 }
 
 void FixPlrWalkTags(int pnum)
@@ -3087,7 +3086,7 @@ bool PM_DoSpell(int pnum)
 		app_fatal("PM_DoSpell: illegal player %d", pnum);
 	}
 
-	if (plr[pnum].actionFrame == plr[pnum]._pSFNum) {
+	if (plr[pnum].AnimInfo.CurrentFrame == (plr[pnum]._pSFNum + 1)) {
 		CastSpell(
 		    pnum,
 		    plr[pnum]._pSpell,
@@ -3102,10 +3101,8 @@ bool PM_DoSpell(int pnum)
 		}
 	}
 
-	plr[pnum].actionFrame++;
-
 	if (leveltype == DTYPE_TOWN) {
-		if (plr[pnum].actionFrame > plr[pnum]._pSFrames) {
+		if (plr[pnum].AnimInfo.CurrentFrame > plr[pnum]._pSFrames) {
 			StartWalkStand(pnum);
 			ClearPlrPVars(pnum);
 			return true;

--- a/Source/player.h
+++ b/Source/player.h
@@ -229,8 +229,6 @@ struct PlayerStruct {
 	int _pVar4;
 	/** Used for storing position of a tile which should have its BFLAG_PLAYERLR flag removed after walking. When starting to walk the game places the player in the dPlayer array -1 in the Y coordinate, and uses BFLAG_PLAYERLR to check if it should be using -1 to the Y coordinate when rendering the player (also used for storing the level of a spell when the player casts it) */
 	int _pVar5;
-	/** Used for counting how close we are to reaching the next tile when walking (usually counts to 8, which is equal to the walk animation length). */
-	int actionFrame;
 	/** Used for stalling the appearance of the options screen after dying in singleplayer */
 	int deathFrame;
 	bool _pLvlVisited[NUMLEVELS];

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -26,7 +26,7 @@ void track_process()
 	if (cursmx < 0 || cursmx >= MAXDUNX - 1 || cursmy < 0 || cursmy >= MAXDUNY - 1)
 		return;
 
-	if (plr[myplr].actionFrame <= 6 && plr[myplr]._pmode != PM_STAND)
+	if (plr[myplr].AnimInfo.GetFrameToUseForRendering() <= 6 || (plr[myplr]._pmode != PM_WALK && plr[myplr]._pmode != PM_WALK2 && plr[myplr]._pmode != PM_WALK3 && plr[myplr]._pmode != PM_STAND))
 		return;
 
 	const Point target = plr[myplr].GetTargetPosition();


### PR DESCRIPTION
## Content

- Removes `PlayerStruct.actionFrame`
- Adjusts Walking Animation to start correctly with frame 1 and ends with frame 8
- Shows skipped frames for running Animation

<Details>
<Summary>Example Videos</Summary>

## Running in Town

### V1.2.1
https://user-images.githubusercontent.com/25415264/117880996-018a7380-b2a9-11eb-8d07-d1376664902b.mp4

### PR
https://user-images.githubusercontent.com/25415264/117880970-fa636580-b2a8-11eb-92cd-1e0f6ecca901.mp4

## Walk in Dungeon (25% Gamespeed)

### V1.2.1
https://user-images.githubusercontent.com/25415264/117881533-9d1be400-b2a9-11eb-9e6d-ba74dcadf939.mp4

### PR
https://user-images.githubusercontent.com/25415264/117881304-647c0a80-b2a9-11eb-8ca1-13e33d2f56b4.mp4

</Details>

## Notes

- Similar to #1781 this introduces a minor breaking change (one animation)
- It would be good if someone checks the change in tracks.cpp. I tested walking with held left mouse.

## Teaser

This pr enables Animation Distribution Logic and plays animations in the correct order and don't skip any frames (when running in town).
But we still don't update position (of the player and the camera). So this is stuttering a little.
This pr is the ground work to fix this.
Now we now correctly how much progress we have to reach the next tile (independent of the game ticks) and this is important to decouple updating the position from the game ticks (same as ADL).
Currently I have a prototyp based on this pr. See Example Video of Prototyp. 😉 

<Details>
<Summary>Example Video of Prototyp (5% Gamespeed)</Summary>

https://user-images.githubusercontent.com/25415264/117882710-e7519500-b2aa-11eb-9f45-758b88de8bf4.mp4

Note: You can see that the position is updated even if we don't show a new animation frame.

</Details>