### PR TITLE
🧹 Cleanup function attributes

### DIFF
--- a/Source/appfat.h
+++ b/Source/appfat.h
@@ -7,7 +7,7 @@
 
 #include <SDL.h>
 
-#include "miniwin/miniwin.h"
+#include "utils/attributes.h"
 
 namespace devilution {
 

--- a/Source/engine/render/dun_render.cpp
+++ b/Source/engine/render/dun_render.cpp
@@ -11,6 +11,7 @@
 
 #include "lighting.h"
 #include "options.h"
+#include "utils/attributes.h"
 
 namespace devilution {
 
@@ -476,7 +477,7 @@ inline int CountLeadingZeros(std::uint32_t mask)
 }
 
 template <typename F>
-void ForEachSetBit(std::uint32_t mask, const F &f)
+DVL_ALWAYS_INLINE void ForEachSetBit(std::uint32_t mask, const F &f)
 {
 	int i = 0;
 	while (mask != 0) {
@@ -500,7 +501,7 @@ enum class LightType {
 };
 
 template <LightType Light>
-inline void RenderLineOpaque(std::uint8_t *dst, const std::uint8_t *src, std::uint_fast8_t n, const std::uint8_t *tbl)
+DVL_ALWAYS_INLINE void RenderLineOpaque(std::uint8_t *dst, const std::uint8_t *src, std::uint_fast8_t n, const std::uint8_t *tbl)
 {
 	if (Light == LightType::FullyDark) {
 		memset(dst, 0, n);
@@ -522,7 +523,7 @@ inline void RenderLineOpaque(std::uint8_t *dst, const std::uint8_t *src, std::ui
 }
 
 template <LightType Light>
-inline void RenderLineBlended(std::uint8_t *dst, const std::uint8_t *src, std::uint_fast8_t n, const std::uint8_t *tbl, std::uint32_t mask)
+DVL_ALWAYS_INLINE void RenderLineBlended(std::uint8_t *dst, const std::uint8_t *src, std::uint_fast8_t n, const std::uint8_t *tbl, std::uint32_t mask)
 {
 #ifndef DEBUG_RENDER_COLOR
 	if (Light == LightType::FullyDark) {
@@ -558,7 +559,7 @@ inline void RenderLineBlended(std::uint8_t *dst, const std::uint8_t *src, std::u
 }
 
 template <LightType Light>
-inline void RenderLineStippled(std::uint8_t *dst, const std::uint8_t *src, std::uint_fast8_t n, const std::uint8_t *tbl, std::uint32_t mask)
+DVL_ALWAYS_INLINE void RenderLineStippled(std::uint8_t *dst, const std::uint8_t *src, std::uint_fast8_t n, const std::uint8_t *tbl, std::uint32_t mask)
 {
 	if (Light == LightType::FullyDark) {
 		ForEachSetBit(mask, [=](int i) { dst[i] = 0; });
@@ -574,7 +575,7 @@ inline void RenderLineStippled(std::uint8_t *dst, const std::uint8_t *src, std::
 }
 
 template <TransparencyType Transparency, LightType Light>
-inline void RenderLine(std::uint8_t *dst, const std::uint8_t *src, std::uint_fast8_t n, const std::uint8_t *tbl, std::uint32_t mask)
+DVL_ALWAYS_INLINE void RenderLine(std::uint8_t *dst, const std::uint8_t *src, std::uint_fast8_t n, const std::uint8_t *tbl, std::uint32_t mask)
 {
 	if (Transparency == TransparencyType::Solid) {
 		RenderLineOpaque<Light>(dst, src, n, tbl);

--- a/Source/engine/render/dun_render.cpp
+++ b/Source/engine/render/dun_render.cpp
@@ -477,7 +477,7 @@ inline int CountLeadingZeros(std::uint32_t mask)
 }
 
 template <typename F>
-DVL_ALWAYS_INLINE void ForEachSetBit(std::uint32_t mask, const F &f)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void ForEachSetBit(std::uint32_t mask, const F &f)
 {
 	int i = 0;
 	while (mask != 0) {
@@ -501,7 +501,7 @@ enum class LightType {
 };
 
 template <LightType Light>
-DVL_ALWAYS_INLINE void RenderLineOpaque(std::uint8_t *dst, const std::uint8_t *src, std::uint_fast8_t n, const std::uint8_t *tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque(std::uint8_t *dst, const std::uint8_t *src, std::uint_fast8_t n, const std::uint8_t *tbl)
 {
 	if (Light == LightType::FullyDark) {
 		memset(dst, 0, n);
@@ -523,7 +523,7 @@ DVL_ALWAYS_INLINE void RenderLineOpaque(std::uint8_t *dst, const std::uint8_t *s
 }
 
 template <LightType Light>
-DVL_ALWAYS_INLINE void RenderLineBlended(std::uint8_t *dst, const std::uint8_t *src, std::uint_fast8_t n, const std::uint8_t *tbl, std::uint32_t mask)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineBlended(std::uint8_t *dst, const std::uint8_t *src, std::uint_fast8_t n, const std::uint8_t *tbl, std::uint32_t mask)
 {
 #ifndef DEBUG_RENDER_COLOR
 	if (Light == LightType::FullyDark) {
@@ -559,7 +559,7 @@ DVL_ALWAYS_INLINE void RenderLineBlended(std::uint8_t *dst, const std::uint8_t *
 }
 
 template <LightType Light>
-DVL_ALWAYS_INLINE void RenderLineStippled(std::uint8_t *dst, const std::uint8_t *src, std::uint_fast8_t n, const std::uint8_t *tbl, std::uint32_t mask)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineStippled(std::uint8_t *dst, const std::uint8_t *src, std::uint_fast8_t n, const std::uint8_t *tbl, std::uint32_t mask)
 {
 	if (Light == LightType::FullyDark) {
 		ForEachSetBit(mask, [=](int i) { dst[i] = 0; });
@@ -575,7 +575,7 @@ DVL_ALWAYS_INLINE void RenderLineStippled(std::uint8_t *dst, const std::uint8_t 
 }
 
 template <TransparencyType Transparency, LightType Light>
-DVL_ALWAYS_INLINE void RenderLine(std::uint8_t *dst, const std::uint8_t *src, std::uint_fast8_t n, const std::uint8_t *tbl, std::uint32_t mask)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLine(std::uint8_t *dst, const std::uint8_t *src, std::uint_fast8_t n, const std::uint8_t *tbl, std::uint32_t mask)
 {
 	if (Transparency == TransparencyType::Solid) {
 		RenderLineOpaque<Light>(dst, src, n, tbl);
@@ -619,7 +619,7 @@ Clip CalculateClip(std::int_fast16_t x, std::int_fast16_t y, std::int_fast16_t w
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderSquareFull(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl)
+DVL_ATTRIBUTE_HOT void RenderSquareFull(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl)
 {
 	for (auto i = 0; i < Height; ++i, dst -= dstPitch, --mask) {
 		RenderLine<Transparency, Light>(dst, src, Width, tbl, *mask);
@@ -628,7 +628,7 @@ void RenderSquareFull(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, 
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderSquareClipped(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderSquareClipped(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	src += clip.bottom * Height + clip.left;
 	for (auto i = 0; i < clip.height; ++i, dst -= dstPitch, --mask) {
@@ -638,7 +638,7 @@ void RenderSquareClipped(std::uint8_t *dst, int dstPitch, const std::uint8_t *sr
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderSquare(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderSquare(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	if (clip.width == Width && clip.height == Height) {
 		RenderSquareFull<Transparency, Light>(dst, dstPitch, src, mask, tbl);
@@ -648,7 +648,7 @@ void RenderSquare(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, cons
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderTransparentSquareFull(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl)
+DVL_ATTRIBUTE_HOT void RenderTransparentSquareFull(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl)
 {
 	for (auto i = 0; i < Height; ++i, dst -= dstPitch + Width, --mask) {
 		constexpr unsigned MaxMaskShift = 32;
@@ -671,7 +671,7 @@ void RenderTransparentSquareFull(std::uint8_t *dst, int dstPitch, const std::uin
 
 template <TransparencyType Transparency, LightType Light>
 // NOLINTNEXTLINE(readability-function-cognitive-complexity): Actually complex and has to be fast.
-void RenderTransparentSquareClipped(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderTransparentSquareClipped(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	const auto skipRestOfTheLine = [&src](std::int_fast16_t remainingWidth) {
 		while (remainingWidth > 0) {
@@ -754,7 +754,7 @@ void RenderTransparentSquareClipped(std::uint8_t *dst, int dstPitch, const std::
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderTransparentSquare(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderTransparentSquare(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	if (clip.width == Width && clip.height == Height) {
 		RenderTransparentSquareFull<Transparency, Light>(dst, dstPitch, src, mask, tbl);
@@ -802,7 +802,7 @@ std::size_t CalculateTriangleSourceSkipUpperBottom(std::int_fast16_t numLines)
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderLeftTriangleFull(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl)
+DVL_ATTRIBUTE_HOT void RenderLeftTriangleFull(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl)
 {
 	dst += XStep * (LowerHeight - 1);
 	for (auto i = 1; i <= LowerHeight; ++i, dst -= dstPitch + XStep, --mask) {
@@ -821,7 +821,7 @@ void RenderLeftTriangleFull(std::uint8_t *dst, int dstPitch, const std::uint8_t 
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderLeftTriangleClipVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderLeftTriangleClipVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	const auto clipY = CalculateDiamondClipY(clip);
 	src += CalculateTriangleSourceSkipLowerBottom(clipY.lowerBottom);
@@ -845,7 +845,7 @@ void RenderLeftTriangleClipVertical(std::uint8_t *dst, int dstPitch, const std::
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderLeftTriangleClipLeftAndVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderLeftTriangleClipLeftAndVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	const auto clipY = CalculateDiamondClipY(clip);
 	const auto clipLeft = clip.left;
@@ -876,7 +876,7 @@ void RenderLeftTriangleClipLeftAndVertical(std::uint8_t *dst, int dstPitch, cons
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderLeftTriangleClipRightAndVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderLeftTriangleClipRightAndVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	const auto clipY = CalculateDiamondClipY(clip);
 	const auto clipRight = clip.right;
@@ -904,7 +904,7 @@ void RenderLeftTriangleClipRightAndVertical(std::uint8_t *dst, int dstPitch, con
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderLeftTriangle(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderLeftTriangle(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	if (clip.width == Width) {
 		if (clip.height == TriangleHeight) {
@@ -920,7 +920,7 @@ void RenderLeftTriangle(std::uint8_t *dst, int dstPitch, const std::uint8_t *src
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderRightTriangleFull(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl)
+DVL_ATTRIBUTE_HOT void RenderRightTriangleFull(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl)
 {
 	for (auto i = 1; i <= LowerHeight; ++i, dst -= dstPitch, --mask) {
 		const auto width = XStep * i;
@@ -935,7 +935,7 @@ void RenderRightTriangleFull(std::uint8_t *dst, int dstPitch, const std::uint8_t
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderRightTriangleClipVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderRightTriangleClipVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	const auto clipY = CalculateDiamondClipY(clip);
 	src += CalculateTriangleSourceSkipLowerBottom(clipY.lowerBottom);
@@ -955,7 +955,7 @@ void RenderRightTriangleClipVertical(std::uint8_t *dst, int dstPitch, const std:
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderRightTriangleClipLeftAndVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderRightTriangleClipLeftAndVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	const auto clipY = CalculateDiamondClipY(clip);
 	const auto clipLeft = clip.left;
@@ -979,7 +979,7 @@ void RenderRightTriangleClipLeftAndVertical(std::uint8_t *dst, int dstPitch, con
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderRightTriangleClipRightAndVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderRightTriangleClipRightAndVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	const auto clipY = CalculateDiamondClipY(clip);
 	const auto clipRight = clip.right;
@@ -1004,7 +1004,7 @@ void RenderRightTriangleClipRightAndVertical(std::uint8_t *dst, int dstPitch, co
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderRightTriangle(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderRightTriangle(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	if (clip.width == Width) {
 		if (clip.height == TriangleHeight) {
@@ -1020,7 +1020,7 @@ void RenderRightTriangle(std::uint8_t *dst, int dstPitch, const std::uint8_t *sr
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderLeftTrapezoidFull(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl)
+DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidFull(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl)
 {
 	dst += XStep * (LowerHeight - 1);
 	for (auto i = 1; i <= LowerHeight; ++i, dst -= dstPitch + XStep, --mask) {
@@ -1037,7 +1037,7 @@ void RenderLeftTrapezoidFull(std::uint8_t *dst, int dstPitch, const std::uint8_t
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderLeftTrapezoidClipVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidClipVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	const auto clipY = CalculateDiamondClipY<TrapezoidUpperHeight>(clip);
 	src += CalculateTriangleSourceSkipLowerBottom(clipY.lowerBottom);
@@ -1059,7 +1059,7 @@ void RenderLeftTrapezoidClipVertical(std::uint8_t *dst, int dstPitch, const std:
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderLeftTrapezoidClipLeftAndVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidClipLeftAndVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	const auto clipY = CalculateDiamondClipY<TrapezoidUpperHeight>(clip);
 	const auto clipLeft = clip.left;
@@ -1085,7 +1085,7 @@ void RenderLeftTrapezoidClipLeftAndVertical(std::uint8_t *dst, int dstPitch, con
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderLeftTrapezoidClipRightAndVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidClipRightAndVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	const auto clipY = CalculateDiamondClipY<TrapezoidUpperHeight>(clip);
 	const auto clipRight = clip.right;
@@ -1109,7 +1109,7 @@ void RenderLeftTrapezoidClipRightAndVertical(std::uint8_t *dst, int dstPitch, co
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderLeftTrapezoid(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderLeftTrapezoid(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	if (clip.width == Width) {
 		if (clip.height == Height) {
@@ -1125,7 +1125,7 @@ void RenderLeftTrapezoid(std::uint8_t *dst, int dstPitch, const std::uint8_t *sr
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderRightTrapezoidFull(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl)
+DVL_ATTRIBUTE_HOT void RenderRightTrapezoidFull(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl)
 {
 	for (auto i = 1; i <= LowerHeight; ++i, dst -= dstPitch, --mask) {
 		const auto width = XStep * i;
@@ -1139,7 +1139,7 @@ void RenderRightTrapezoidFull(std::uint8_t *dst, int dstPitch, const std::uint8_
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderRightTrapezoidClipVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderRightTrapezoidClipVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	const auto clipY = CalculateDiamondClipY<TrapezoidUpperHeight>(clip);
 	const auto lowerMax = LowerHeight - clipY.lowerTop;
@@ -1158,7 +1158,7 @@ void RenderRightTrapezoidClipVertical(std::uint8_t *dst, int dstPitch, const std
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderRightTrapezoidClipLeftAndVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderRightTrapezoidClipLeftAndVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	const auto clipY = CalculateDiamondClipY<TrapezoidUpperHeight>(clip);
 	const auto clipLeft = clip.left;
@@ -1179,7 +1179,7 @@ void RenderRightTrapezoidClipLeftAndVertical(std::uint8_t *dst, int dstPitch, co
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderRightTrapezoidClipRightAndVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderRightTrapezoidClipRightAndVertical(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	const auto clipY = CalculateDiamondClipY<TrapezoidUpperHeight>(clip);
 	const auto clipRight = clip.right;
@@ -1201,7 +1201,7 @@ void RenderRightTrapezoidClipRightAndVertical(std::uint8_t *dst, int dstPitch, c
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderRightTrapezoid(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderRightTrapezoid(std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	if (clip.width == Width) {
 		if (clip.height == Height) {
@@ -1217,7 +1217,7 @@ void RenderRightTrapezoid(std::uint8_t *dst, int dstPitch, const std::uint8_t *s
 }
 
 template <TransparencyType Transparency, LightType Light>
-void RenderTileType(TileType tile, std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
+DVL_ATTRIBUTE_HOT void RenderTileType(TileType tile, std::uint8_t *dst, int dstPitch, const std::uint8_t *src, const std::uint32_t *mask, const std::uint8_t *tbl, Clip clip)
 {
 	switch (tile) {
 	case TileType::Square:

--- a/Source/miniwin/miniwin.h
+++ b/Source/miniwin/miniwin.h
@@ -16,19 +16,6 @@ namespace devilution {
 #define MAX_PATH 260
 #endif
 
-#ifdef __has_attribute
-#define DVL_HAVE_ATTRIBUTE(x) __has_attribute(x)
-#else
-#define DVL_HAVE_ATTRIBUTE(x) 0
-#endif
-
-#if DVL_HAVE_ATTRIBUTE(format) || (defined(__GNUC__) && !defined(__clang__))
-#define DVL_PRINTF_ATTRIBUTE(fmtargnum, firstarg) \
-	__attribute__((__format__(__printf__, fmtargnum, firstarg)))
-#else
-#define DVL_PRINTF_ATTRIBUTE(fmtargnum, firstarg)
-#endif
-
 typedef uint32_t DWORD;
 typedef unsigned char BYTE;
 

--- a/Source/sha.cpp
+++ b/Source/sha.cpp
@@ -50,11 +50,11 @@ static void SHA1Init(SHA1Context *context)
 
 static void SHA1ProcessMessageBlock(SHA1Context *context)
 {
-	DWORD i, temp;
-	DWORD W[80];
-	DWORD A, B, C, D, E;
+	std::uint32_t i, temp;
+	std::uint32_t W[80];
+	std::uint32_t A, B, C, D, E;
 
-	auto *buf = (DWORD *)context->buffer;
+	auto *buf = (std::uint32_t *)context->buffer;
 	for (i = 0; i < 16; i++)
 		W[i] = SDL_SwapLE32(buf[i]);
 
@@ -111,9 +111,9 @@ static void SHA1ProcessMessageBlock(SHA1Context *context)
 	context->state[4] += E;
 }
 
-static void SHA1Input(SHA1Context *context, const char *message_array, DWORD len)
+static void SHA1Input(SHA1Context *context, const char *message_array, std::uint32_t len)
 {
-	DWORD i, count;
+	std::uint32_t i, count;
 
 	count = context->count[0] + 8 * len;
 	if (count < context->count[0])
@@ -136,10 +136,10 @@ void SHA1Clear()
 
 void SHA1Result(int n, char Message_Digest[SHA1HashSize])
 {
-	DWORD *Message_Digest_Block;
+	std::uint32_t *Message_Digest_Block;
 	int i;
 
-	Message_Digest_Block = (DWORD *)Message_Digest;
+	Message_Digest_Block = (std::uint32_t *)Message_Digest;
 	if (Message_Digest != nullptr) {
 		for (i = 0; i < 5; i++) {
 			*Message_Digest_Block = SDL_SwapLE32(sgSHA1[n].state[i]);

--- a/Source/utils/attributes.h
+++ b/Source/utils/attributes.h
@@ -1,0 +1,27 @@
+/**
+ * @file attributes.h
+ *
+ * Macros for attributes on functions, variables, etc.
+ */
+#pragma once
+
+#ifdef __has_attribute
+#define DVL_HAVE_ATTRIBUTE(x) __has_attribute(x)
+#else
+#define DVL_HAVE_ATTRIBUTE(x) 0
+#endif
+
+#if DVL_HAVE_ATTRIBUTE(format) || (defined(__GNUC__) && !defined(__clang__))
+#define DVL_PRINTF_ATTRIBUTE(fmtargnum, firstarg) \
+	__attribute__((__format__(__printf__, fmtargnum, firstarg)))
+#else
+#define DVL_PRINTF_ATTRIBUTE(fmtargnum, firstarg)
+#endif
+
+#if DVL_HAVE_ATTRIBUTE(always_inline)
+#define DVL_ALWAYS_INLINE inline __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#define DVL_ALWAYS_INLINE __forceinline
+#else
+#define DVL_ALWAYS_INLINE inline
+#endif

--- a/Source/utils/attributes.h
+++ b/Source/utils/attributes.h
@@ -25,3 +25,9 @@
 #else
 #define DVL_ALWAYS_INLINE inline
 #endif
+
+#if DVL_HAVE_ATTRIBUTE(hot)
+#define DVL_ATTRIBUTE_HOT __attribute__((hot))
+#else
+#define DVL_ATTRIBUTE_HOT
+#endif

--- a/Source/utils/console.h
+++ b/Source/utils/console.h
@@ -3,7 +3,7 @@
 #include <cstdarg>
 #include <cstddef>
 
-#include "miniwin/miniwin.h"
+#include "utils/attributes.h"
 
 namespace devilution {
 

--- a/Source/utils/sdl2_to_1_2_backports.h
+++ b/Source/utils/sdl2_to_1_2_backports.h
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <cstddef>
 
+#include "utils/attributes.h"
 #include "utils/console.h"
 #include "utils/stubs.h"
 


### PR DESCRIPTION
1. Moves attribute macros out of miniwin into a new header.
2. Adds `DVL_ALWAYS_INLINE` and `DVL_ATTRIBUTE_HOT`, and uses them in dun_render.cpp