### PR TITLE
🔨 Fix Switch CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,6 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run: echo deb http://deb.debian.org/debian stretch-backports main > /etc/apt/sources.list.d/debian-backports.list
-      - run: echo deb http://deb.debian.org/debian stretch-backports-sloppy main >> /etc/apt/sources.list.d/debian-backports.list
-      - run: apt-get update && apt-get install -y -t 'stretch-backports*' cmake
       - run: dkp-pacman -Syu --noconfirm
       # Install cmake files (https://github.com/devkitPro/docker/issues/3)
       - run: dkp-pacman -S --needed --noconfirm --quiet devkitpro-pkgbuild-helpers


### PR DESCRIPTION
The image was updated from Debian Stretch to Debian Buster in https://github.com/devkitPro/docker/commit/491845c3c3a2c9deff5ff1ad05152732bebb2d49