### PR TITLE
End of Poisoned Water Supply no longer ignores Blended Transparency setting

### DIFF
--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -381,7 +381,8 @@ void palette_update_quest_palette(int n)
 	}
 	ApplyGamma(system_palette, logical_palette, 32);
 	palette_update();
-	GenerateBlendedLookupTable(logical_palette, 1, 31, 32 - n); // Possible optimization would be to only update color 0 as only the UI can overlap with transparency in this quest
+	if (sgOptions.Graphics.bBlendedTransparancy)
+		GenerateBlendedLookupTable(logical_palette, 1, 31, 32 - n); // Possible optimization would be to only update color 0 as only the UI can overlap with transparency in this quest
 }
 
 } // namespace devilution


### PR DESCRIPTION
Because of the frequent palette changes that change the color of water at the end of Poisoned Water Supply, the blended lookup table get regenerated every frame for 32 frames. This logic wasn't checking the `bBlendedTransparancy` flag, which caused the framerate to plummet at the end of this quest on 3DS.