### PR TITLE
Adding offset to enable items being able to be equipped on lower resolutions

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -492,7 +492,7 @@ void AttrIncBtnSnap(AxisDirection dir)
 
 coords InvGetEquipSlotCoord(const inv_body_loc inv_slot)
 {
-	coords result { RIGHT_PANEL, 0 };
+	coords result { RIGHT_PANEL - 1, -1 };
 	result.x -= (icursW28 - 1) * (INV_SLOT_SIZE_PX / 2);
 	switch (inv_slot) {
 	case INVLOC_HEAD:


### PR DESCRIPTION
Fixes problem found by @glebm in https://github.com/diasurgical/devilutionX/issues/1885#issuecomment-840274498.

_Did not fix the underlying cause. Opened https://github.com/diasurgical/devilutionX/issues/1962 to fix that._