### PR TITLE
"Dead Pixels" when trying to equip item

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -869,7 +869,7 @@ void CheckInvPaste(int pnum, int mx, int my)
 			yo = PANEL_TOP;
 		}
 
-		if (i >= InvRect[r].X + xo && i < InvRect[r].X + xo + INV_SLOT_SIZE_PX) {
+		if (i >= InvRect[r].X + xo && i <= InvRect[r].X + xo + INV_SLOT_SIZE_PX) {
 			if (j >= InvRect[r].Y + yo - INV_SLOT_SIZE_PX - 1 && j < InvRect[r].Y + yo) {
 				done = true;
 				r--;


### PR DESCRIPTION
One pixel was not being calculated on the X axis when trying to find for an inventory slot to put the item.

Closes #1962 and should fix controller not being able to equip when on low resolutions.

@AJenbo @glebm 