### PR TITLE
Adding text rendering flag to fit horizontally

### DIFF
--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -38,6 +38,7 @@ enum UiFlags : uint16_t {
 	UIS_BLACK    = 1 << 11,
 	UIS_DISABLED = 1 << 12,
 	UIS_HIDDEN   = 1 << 13,
+	UIS_FIT_HORZ = 1 << 14,
 	// clang-format on
 };
 

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1095,14 +1095,14 @@ static void PrintInfo(const CelOutputBuffer &out)
 	int yo = 0;
 	int lo = 1;
 	if (infostr[0] != '\0') {
-		DrawString(out, infostr, line, infoclr | UIS_CENTER, 2);
+		DrawString(out, infostr, line, infoclr | UIS_CENTER | UIS_FIT_HORZ, 2);
 		yo = 1;
 		lo = 0;
 	}
 
 	for (int i = 0; i < pnumlines; i++) {
 		line.y = PANEL_Y + LineOffsets[pnumlines - lo][i + yo];
-		DrawString(out, panelstr[i], line, infoclr | UIS_CENTER, 2);
+		DrawString(out, panelstr[i], line, infoclr | UIS_CENTER | UIS_FIT_HORZ, 2);
 	}
 }
 

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -272,19 +272,30 @@ void DrawString(const CelOutputBuffer &out, const char *text, const SDL_Rect &re
 		color = COL_BLACK;
 
 	const int w = rect.w != 0 ? rect.w : out.w() - rect.x;
-	const int h = rect.h != 0 ? rect.h : out.h() - rect.x;
+	const int h = rect.h != 0 ? rect.h : out.h() - rect.y;
+
+	const size_t textLength = strlen(text);
+
+	int lineWidth = GetLineWidth(text, size, spacing);
+	if ((flags & UIS_FIT_HORZ) != 0) {
+		if (lineWidth > rect.w && textLength > 1) {
+			const int superfluousSpacing = lineWidth - rect.w;
+			const int spacingRedux = (superfluousSpacing + textLength - 2) / (textLength - 1);
+			spacing -= spacingRedux;
+			lineWidth -= spacingRedux * (textLength - 1);
+		}
+	}
 
 	int sx = rect.x;
 	if ((flags & UIS_CENTER) != 0)
-		sx += (w - GetLineWidth(text, size, spacing)) / 2;
+		sx += (w - lineWidth) / 2;
 	else if ((flags & UIS_RIGHT) != 0)
-		sx += w - GetLineWidth(text, size, spacing);
+		sx += w - lineWidth;
 	int sy = rect.y;
 
 	int rightMargin = rect.x + w;
 	int bottomMargin = rect.y + h;
 
-	const size_t textLength = strlen(text);
 	for (unsigned i = 0; i < textLength; i++) {
 		uint8_t frame = fontframe[size][gbFontTransTbl[static_cast<uint8_t>(text[i])]];
 		int symbolWidth = fontkern[size][frame] + spacing;

--- a/Source/engine/render/text_render.hpp
+++ b/Source/engine/render/text_render.hpp
@@ -50,7 +50,16 @@ void FreeText();
  * @param col text_color color value
  */
 void PrintChar(const CelOutputBuffer &out, int sx, int sy, int nCel, text_color col);
-int GetLineWidth(const char *text, GameFontTables size = GameFontSmall, int spacing = 1);
+
+/**
+ * @brief Calculate pixel width of first line of text, respecting kerning
+ * @param text Text to check, will read until first eol or terminator
+ * @param size Font size to use
+ * @param spacing Extra spacing to add per character
+ * @param lineLength Receives characters read until newline or terminator
+ * @return Line width in pixels
+*/
+int GetLineWidth(const char *text, GameFontTables size = GameFontSmall, int spacing = 1, int* lineLength = nullptr);
 void WordWrapGameString(char *text, size_t width, size_t size = GameFontSmall, int spacing = 1);
 void DrawString(const CelOutputBuffer &out, const char *text, const SDL_Rect &rect, uint16_t flags = 0, int spacing = 1, bool drawTextCursor = false);
 int PentSpn2Spin();


### PR DESCRIPTION
Allows extra-long strings to fit into the info box by removing enough spacing between characters.

Old:
![image](https://user-images.githubusercontent.com/81810641/118343187-b8942280-b527-11eb-80f3-d11d4bcf09f9.png)

New:
![image](https://user-images.githubusercontent.com/81810641/118343193-c184f400-b527-11eb-9462-c0124b0e2e01.png)

Stupid long:
![image](https://user-images.githubusercontent.com/81810641/118343200-c9449880-b527-11eb-8a3d-7b763c9cc983.png)
