### PR TITLE
ADL: Decouple positioning while walking from game logic

### DIFF
--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -276,8 +276,12 @@ void CheckCursMove()
 
 	// Adjust by player offset and tile grid alignment
 	CalcTileOffset(&xo, &yo);
-	sx -= ScrollInfo.offset.x - xo;
-	sy -= ScrollInfo.offset.y - yo;
+	PlayerStruct *pPlayer = &plr[myplr];
+	Point offset = ScrollInfo.offset;
+	if (pPlayer->IsWalking())
+		offset = GetOffsetForWalking(pPlayer->AnimInfo, pPlayer->_pdir, true);
+	sx -= offset.x - xo;
+	sy -= offset.y - yo;
 
 	// Predict the next frame when walking to avoid input jitter
 	fx = plr[myplr].position.offset2.x / 256;

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -91,6 +91,13 @@ struct Point {
 		return *this;
 	}
 
+	Point &operator*=(const float factor)
+	{
+		x *= factor;
+		y *= factor;
+		return *this;
+	}
+
 	friend Point operator+(Point a, const Point &b)
 	{
 		a += b;
@@ -100,6 +107,20 @@ struct Point {
 	friend Point operator-(Point a, const Point &b)
 	{
 		a -= b;
+		return a;
+	}
+
+	friend Point operator-(const Point &a)
+	{
+		Point b;
+		b.x = -a.x;
+		b.y = -a.y;
+		return b;
+	}
+
+	friend Point operator*(Point a, const float factor)
+	{
+		a *= factor;
 		return a;
 	}
 

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -52,6 +52,23 @@ int AnimationInfo::GetFrameToUseForRendering() const
 	return absoluteAnimationFrame;
 }
 
+float AnimationInfo::GetAnimationProgress() const
+{
+	if (RelevantFramesForDistributing <= 0) {
+		// This logic is used if animation distrubtion is not active (see GetFrameToUseForRendering).
+		// In this case the variables calculated with animation distribution are not initialized and we have to calculate them on the fly with the given informations.
+		float ticksPerFrame = (DelayLen + 1);
+		float totalTicksForCurrentAnimationSequence = gfProgressToNextGameTick + (float)CurrentFrame + (DelayCounter / ticksPerFrame);
+		float fAnimationFraction = totalTicksForCurrentAnimationSequence / ((float)NumberOfFrames * ticksPerFrame);
+		return fAnimationFraction;
+	}
+
+	float totalTicksForCurrentAnimationSequence = gfProgressToNextGameTick + (float)TicksSinceSequenceStarted;
+	float fProgressInAnimationFrames = totalTicksForCurrentAnimationSequence * TickModifier;
+	float fAnimationFraction = fProgressInAnimationFrames / (float)NumberOfFrames;
+	return fAnimationFraction;
+}
+
 void AnimationInfo::SetNewAnimation(byte *pData, int numberOfFrames, int delayLen, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/)
 {
 	if ((flags & AnimationDistributionFlags::RepeatedAction) == AnimationDistributionFlags::RepeatedAction && distributeFramesBeforeFrame != 0 && NumberOfFrames == numberOfFrames && CurrentFrame >= distributeFramesBeforeFrame && CurrentFrame != NumberOfFrames) {

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -64,6 +64,11 @@ public:
 	int GetFrameToUseForRendering() const;
 
 	/**
+	 * @brief Calculates the progress of the current animation as a fraction (0.0f to 1.0f)
+	*/
+	float GetAnimationProgress() const;
+
+	/**
 	 * @brief Sets the new Animation with all relevant information for rendering
 	 * @param pData Pointer to Animation Data
 	 * @param numberOfFrames Number of Frames in Animation

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -355,6 +355,19 @@ void PlayerStruct::Stop()
 	destAction = ACTION_NONE;
 }
 
+bool PlayerStruct::IsWalking() const
+{
+	switch (_pmode)
+	{
+	case PM_WALK:
+	case PM_WALK2:
+	case PM_WALK3:
+		return true;
+	default:
+		return false;
+	}
+}
+
 void SetPlayerGPtrs(byte *pData, byte **pAnim)
 {
 	int i;

--- a/Source/player.h
+++ b/Source/player.h
@@ -390,6 +390,11 @@ struct PlayerStruct {
 	 * opening a chest, picking an item up, etc) this action will also be cancelled.
 	 */
 	void Stop();
+
+	/**
+	 * @brief Is the player currently walking?
+	*/
+	bool IsWalking() const;
 };
 
 extern int myplr;

--- a/Source/scrollrt.h
+++ b/Source/scrollrt.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 
+#include "engine/animationinfo.h"
 #include "engine.h"
 
 namespace devilution {
@@ -34,6 +35,14 @@ extern bool cel_transparency_active;
 extern bool cel_foliage_active;
 extern int level_piece_id;
 extern bool AutoMapShowItems;
+
+/**
+ * @brief Returns the offset for the walking animation
+ * @param animationInfo the current active walking animation
+ * @param dir walking direction
+ * @param cameraMode Adjusts the offset relative to the camera
+ */
+Point GetOffsetForWalking(const AnimationInfo &animationInfo, const direction dir, bool cameraMode = false);
 
 void ClearCursor();
 void ShiftGrid(int *x, int *y, int horizontal, int vertical);

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -26,7 +26,7 @@ void track_process()
 	if (cursmx < 0 || cursmx >= MAXDUNX - 1 || cursmy < 0 || cursmy >= MAXDUNY - 1)
 		return;
 
-	if (plr[myplr].AnimInfo.GetFrameToUseForRendering() <= 6 || (plr[myplr]._pmode != PM_WALK && plr[myplr]._pmode != PM_WALK2 && plr[myplr]._pmode != PM_WALK3 && plr[myplr]._pmode != PM_STAND))
+	if (plr[myplr].AnimInfo.GetFrameToUseForRendering() <= 6 || (!plr[myplr].IsWalking() && plr[myplr]._pmode != PM_STAND))
 		return;
 
 	const Point target = plr[myplr].GetTargetPosition();


### PR DESCRIPTION
With this change the position of the player is now calculated independent from the game logic.
The already present information from `AnimationInfo` (ADL) is used for this.

## Restriction
Before this pr the player and camera position was updated 8 times for each walked tile.
With ADL we can calculate the offset relative to the animation fraction (0.0 to 1.0).
As this is a floating variable this can calculate many small steps and so positions updates.
But currently the rendering logic restricts this.

The current game logic operates on the pixel definitions of the original resolution.
For example the walking offset from one tile to another (to the east) are 64 pixels in x-axis.
As the current rendering logic is based on the game logic it's interface is also based on pixel basis.
That mean's currently we can calculate that we would be on pixel 8.4 but can't pass it to the rendering.
We have to squeeze the value in an integer and lose the precision.

This lose of precision is not dramatic if you walk in direct lines. cause we still have 64 pixels and means we have 64 different update positions. That's enough for smooth scrolling.
But in case of diagonal walking we only have 16 pixels at the y-axis. Compared to the original it's twice as much (8 -> 16) and better but still visible (see examples).

To lift this restriction the rendering logic must be adjusted to pass more fine granular positions.
The good thing is, this can happen at separate independent steps.

<details><summary>Example Videos</summary>

## Walk in dungeon (25% game speed)

### Version 1.21x

https://user-images.githubusercontent.com/25415264/118393062-431a7600-b63d-11eb-9795-5ac4e5a5bc21.mp4

### PR

https://user-images.githubusercontent.com/25415264/118392923-64c72d80-b63c-11eb-96dd-952d6aac9f17.mp4

## Running in town (25% game speed)</summary>

### Version 1.21x

https://user-images.githubusercontent.com/25415264/118392854-fda97900-b63b-11eb-84cb-cb6fce1b9b28.mp4

### PR

https://user-images.githubusercontent.com/25415264/118392859-07cb7780-b63c-11eb-8dde-4979296d9f95.mp4

</details>