### PR TITLE
♻️ Implement std's Lockable for SDL mutex wrapper

### DIFF
--- a/Source/storm/storm.cpp
+++ b/Source/storm/storm.cpp
@@ -4,6 +4,7 @@
 #include <SDL_endian.h>
 #include <cstddef>
 #include <cstdint>
+#include <mutex>
 #include <string>
 
 #include "Radon.hpp"
@@ -34,19 +35,19 @@ namespace {
 bool directFileAccess = false;
 std::string *SBasePath = nullptr;
 
-} // namespace
+SdlMutex Mutex;
 
-SDL_mutex *Mutex = SDL_CreateMutex();
+} // namespace
 
 bool SFileReadFileThreadSafe(HANDLE hFile, void *buffer, DWORD nNumberOfBytesToRead, DWORD *read, int *lpDistanceToMoveHigh)
 {
-	SDLMutexLockGuard lock(Mutex);
+	const std::lock_guard<SdlMutex> lock(Mutex);
 	return SFileReadFile(hFile, buffer, nNumberOfBytesToRead, read, lpDistanceToMoveHigh);
 }
 
 bool SFileCloseFileThreadSafe(HANDLE hFile)
 {
-	SDLMutexLockGuard lock(Mutex);
+	const std::lock_guard<SdlMutex> lock(Mutex);
 	return SFileCloseFile(hFile);
 }
 

--- a/Source/utils/push_aulib_decoder.h
+++ b/Source/utils/push_aulib_decoder.h
@@ -20,7 +20,6 @@ public:
 	PushAulibDecoder(int numChannels, int sampleRate)
 	    : numChannels_(numChannels)
 	    , sampleRate_(sampleRate)
-	    , queue_mutex_(SDL_CreateMutex())
 	{
 	}
 
@@ -61,7 +60,7 @@ private:
 	AudioQueueItem *Next();
 
 	std::queue<AudioQueueItem> queue_;
-	SDLMutexUniquePtr queue_mutex_;
+	SdlMutex queue_mutex_;
 };
 
 } // namespace devilution


### PR DESCRIPTION
Rather than rolling our own lock guard, implement the requirements for using `std::lock_guard` et al, and use that.