### PR TITLE
Fix movement with hold mouse button and stand animation

### DIFF
--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -26,10 +26,12 @@ void track_process()
 	if (cursmx < 0 || cursmx >= MAXDUNX - 1 || cursmy < 0 || cursmy >= MAXDUNY - 1)
 		return;
 
-	if (plr[myplr].AnimInfo.GetFrameToUseForRendering() <= 6 || (!plr[myplr].IsWalking() && plr[myplr]._pmode != PM_STAND))
+	const auto &player = plr[myplr];
+
+	if (player.AnimInfo.GetFrameToUseForRendering() <= 6 || (!player.IsWalking() && player._pmode != PM_STAND))
 		return;
 
-	const Point target = plr[myplr].GetTargetPosition();
+	const Point target = player.GetTargetPosition();
 	if (cursmx != target.x || cursmy != target.y) {
 		Uint32 tick = SDL_GetTicks();
 		if ((int)(tick - sgdwLastWalk) >= gnTickDelay * 6) {

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -28,7 +28,7 @@ void track_process()
 
 	const auto &player = plr[myplr];
 
-	if (player.AnimInfo.GetFrameToUseForRendering() <= 6 || (!player.IsWalking() && player._pmode != PM_STAND))
+	if (player._pmode != PM_STAND && !(player.IsWalking() && player.AnimInfo.GetFrameToUseForRendering() > 6))
 		return;
 
 	const Point target = player.GetTargetPosition();


### PR DESCRIPTION
Fixes #1993

Condition before my changes:
[`if (plr[myplr].actionFrame <= 6 && plr[myplr]._pmode != PM_STAND)`](https://github.com/diasurgical/devilutionX/blob/23cec61f155961918460fe5d896e686ed4249e0c/Source/track.cpp#L29)
Note: `actionFrame` was only used for walking and spell casting. In all other cases it was 0.

Buggy condition:
`if (plr[myplr].AnimInfo.GetFrameToUseForRendering() <= 6 || (!plr[myplr].IsWalking() && plr[myplr]._pmode != PM_STAND))`
This returns also if we are at the first 6 frames of the stand animation (the delay mentioned in #1993). So we don't track the changed mouse cursor in that case => Bug. 😉 

This is the new condition:
`if (player._pmode != PM_STAND && !(player.IsWalking() && player.AnimInfo.GetFrameToUseForRendering() >= 6))`
We check if we don't stand or are at the last walking animation frames.