### PR TITLE
Fix crash when using Town Portal on controller

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -10,6 +10,7 @@
 #include "controls/controller_motion.h"
 #include "controls/game_controls.h"
 #include "cursor.h"
+#include "doom.h"
 #include "gmenu.h"
 #include "help.h"
 #include "inv.h"
@@ -1317,6 +1318,12 @@ void plrctrls_after_check_curs_move()
 		pcursquest = -1;
 		cursmx = -1;
 		cursmy = -1;
+		if (plr[myplr]._pInvincible) {
+			return;
+		}
+		if (DoomFlag) {
+			return;
+		}
 		if (!invflag) {
 			*infostr = '\0';
 			ClearPanel();


### PR DESCRIPTION
Applies the special cases for `_pInvincible` and `DoomFlag` that are present in `CheckCursMove()` logic to `plrctrls_after_check_curs_move()` as well. With the check for `_pInvincible`, the player will lose their target just before the loading screen when moving between dungeon floors or entering a Town Portal. The `DoomFlag` check simply causes the player to lose their target when the Cathedral Map is up.

This resolves #2001