### PR TITLE
Close Cathedral Map when B button is pressed on the controller

### DIFF
--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -9,6 +9,7 @@
 #include "controls/menu_controls.h"
 #include "controls/modifier_hints.h"
 #include "controls/plrctrls.h"
+#include "doom.h"
 #include "gmenu.h"
 #include "options.h"
 #include "stores.h"
@@ -246,6 +247,8 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, Game
 				return true;
 			if (IsControllerButtonPressed(ControllerButton_BUTTON_BACK))
 				*action = GameActionSendKey { DVL_VK_F7, ctrlEvent.up };
+			else if (DoomFlag)
+				*action = GameActionSendKey { DVL_VK_ESCAPE, ctrlEvent.up };
 			else if (invflag)
 				*action = GameAction(GameActionType_TOGGLE_INVENTORY);
 			else if (sbookflag)


### PR DESCRIPTION
Closes the Cathedral Map when pressing the B button on the controller. Prior to this, the only way to close the Cathedral Map with controller was to attempt to open the game menu with Start+DPadUp or Start+Select.