### PR TITLE
Do not show attribute warnings for Amiga builds

### DIFF
--- a/CMake/amiga_defs.cmake
+++ b/CMake/amiga_defs.cmake
@@ -8,3 +8,7 @@ set(TTF_FONT_NAME \"LiberationSerif-Bold.ttf\")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions")
 find_package(Freetype REQUIRED)
 find_package(ZLIB REQUIRED)
+
+# Do not warn about unknown attributes, such as [[nodiscard]].
+# As this build uses an older compiler, there are lots of them.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-attributes")


### PR DESCRIPTION
The compiler is currently stock at GCC 6.5 which doesn't know about some of the attributes we use.