### PR TITLE
Fix camera jerking when changing direction on controller

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1078,6 +1078,19 @@ bool IsPathBlocked(int x, int y, int dir)
 	return !PosOkPlayer(myplr, d1x, d1y) && !PosOkPlayer(myplr, d2x, d2y);
 }
 
+bool CanChangeDirection(const PlayerStruct &player)
+{
+	if (player._pmode == PM_STAND)
+		return true;
+	if (player._pmode == PM_ATTACK && player.AnimInfo.CurrentFrame > player._pAFNum)
+		return true;
+	if (player._pmode == PM_RATTACK && player.AnimInfo.CurrentFrame > player._pAFNum)
+		return true;
+	if (player._pmode == PM_SPELL && player.AnimInfo.CurrentFrame > player._pSFNum)
+		return true;
+	return false;
+}
+
 void WalkInDir(int playerId, AxisDirection dir)
 {
 	const int x = plr[playerId].position.future.x;
@@ -1092,7 +1105,9 @@ void WalkInDir(int playerId, AxisDirection dir)
 	const direction pdir = FaceDir[static_cast<std::size_t>(dir.x)][static_cast<std::size_t>(dir.y)];
 	const int dx = x + Offsets[pdir][0];
 	const int dy = y + Offsets[pdir][1];
-	plr[playerId]._pdir = pdir;
+
+	if (CanChangeDirection(plr[playerId]))
+		plr[playerId]._pdir = pdir;
 
 	if (PosOkPlayer(playerId, dx, dy) && IsPathBlocked(x, y, pdir))
 		return; // Don't start backtrack around obstacles


### PR DESCRIPTION
Digging into past commits, I found the reason why the logic for gamepad controls was fiddling with the player's direction. It allows the player to change the direction their character is facing even if their movement is blocked. This is especially important because it's what enables the player to change targets when their character can't otherwise move.

I considered allowing players to change direction at any time so long as they aren't walking. Some additional testing revealed there were situations where the player can change targets in the middle of an attack. It seems reasonable to want to change the character's target in the middle of a series of queued attacks, but it's important to wait for the hit frame so the player doesn't end up hitting an enemy they didn't swing at. Furthermore, it's easy to imagine that there are some states in which the player probably shouldn't be allowed to change direction, such as blocking and hit recovery.

This resolves #2011