### PR TITLE
Support changing animation data on-the-fly even if the number of frames differ

### DIFF
--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -154,6 +154,22 @@ void AnimationInfo::SetNewAnimation(byte *pData, int numberOfFrames, int delayLe
 	}
 }
 
+void AnimationInfo::ChangeAnimationData(byte *pData, int numberOfFrames, int delayLen)
+{
+	if (numberOfFrames != NumberOfFrames || delayLen != DelayLen) {
+		// Ensure that the CurrentFrame is still valid and that we disable ADL cause the calculcated values (for example TickModifier) could be wrong
+		if (CurrentFrame > numberOfFrames)
+			CurrentFrame = numberOfFrames;
+		NumberOfFrames = numberOfFrames;
+		DelayLen = delayLen;
+		TicksSinceSequenceStarted = 0;
+		RelevantFramesForDistributing = 0;
+		TickModifier = 0.0f;
+	}
+	this->pData = pData;
+	DelayLen = delayLen;
+}
+
 void AnimationInfo::ProcessAnimation()
 {
 	DelayCounter++;

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -79,6 +79,14 @@ public:
 	 */
 	void SetNewAnimation(byte *pData, int numberOfFrames, int delayLen, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
 
+	/**
+	 * @brief Changes the Animation Data on-the-fly. This is needed if a animation is currently in progress and the player changes his gear.
+	 * @param pData Pointer to Animation Data
+	 * @param numberOfFrames Number of Frames in Animation
+	 * @param delayLen Delay after each Animation sequence
+	 */
+	void ChangeAnimationData(byte *pData, int numberOfFrames, int delayLen);
+
 	/*
 	 * @brief Process the Animation for a game tick (for example advances the frame)
 	 */

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -883,8 +883,15 @@ void CalcPlrItemVals(int playerId, bool Loadgfx)
 	if (player._pgfxnum != g && Loadgfx) {
 		player._pgfxnum = g;
 		player._pGFXLoad = 0;
-		LoadPlrGFX(playerId, static_cast<player_graphic>(PFILE_STAND | PFILE_WALK));
 		SetPlrAnims(player);
+		LoadPlrGFX(playerId, static_cast<player_graphic>(PFILE_STAND | PFILE_WALK));
+		if (player._pmode == PM_STAND) {
+			player._pAnimWidth = player._pNWidth;
+			player.AnimInfo.ChangeAnimationData(player._pNAnim[player._pdir], player._pNFrames, 3);
+		} else {
+			player._pAnimWidth = player._pWWidth;
+			player.AnimInfo.ChangeAnimationData(player._pWAnim[player._pdir], player._pWFrames, 0);
+		}
 	} else {
 		player._pgfxnum = g;
 	}


### PR DESCRIPTION
Follow up to #1988

The number of frames for the standing animation of a [warrior with bow](https://github.com/diasurgical/devilutionX/blob/23cec61f155961918460fe5d896e686ed4249e0c/Source/player.cpp#L611) (and babarian) differs from the normal standing animation.

The following statement from #1985 was wrong:
> This is elegant but would require that all animations have the same length. **This is currently the case** but could differ if we supported loading this animation info's dynamic and a mod would change them. Example mod change: walking with heavy armor takes longer.

With the new changes even mods future should be supported.