### PR TITLE
Changing Oil of Death application

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3199,12 +3199,10 @@ static bool OilItem(ItemStruct *x, PlayerStruct *p)
 		if (x->_iMaxDam - x->_iMinDam < 30)
 			x->_iMaxDam++;
 
-		auto &tempItem = items[MAXITEMS];
-		tempItem = {};
-		RecreateItem(MAXITEMS, x->IDidx, x->_iCreateInfo, x->_iSeed, x->_iIvalue, (x->dwBuff & CF_HELLFIRE) != 0);
+		const auto &orgItem = AllItemsList[x->IDidx];
 
-		const auto orgMinDmg = tempItem._iMinDam;
-		const auto orgMaxDmg = tempItem._iMaxDam;
+		const auto orgMinDmg = orgItem.iMinDam;
+		const auto orgMaxDmg = orgItem.iMaxDam;
 
 		const auto maxApplications = 30 - (orgMaxDmg - orgMinDmg);
 		const auto applicationsDone = x->_iMinDam - orgMinDmg;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3195,12 +3195,27 @@ static bool OilItem(ItemStruct *x, PlayerStruct *p)
 			x->_iMaxDam = x->_iMaxDam + 1;
 		}
 		break;
-	case IMISC_OILDEATH:
-		if (x->_iMaxDam - x->_iMinDam < 30) {
-			x->_iMinDam = x->_iMinDam + 1;
-			x->_iMaxDam = x->_iMaxDam + 2;
+	case IMISC_OILDEATH: {
+		if (x->_iMaxDam - x->_iMinDam < 30)
+			x->_iMaxDam++;
+
+		auto &tempItem = items[MAXITEMS];
+		tempItem = {};
+		RecreateItem(MAXITEMS, x->IDidx, x->_iCreateInfo, x->_iSeed, x->_iIvalue, (x->dwBuff & CF_HELLFIRE) != 0);
+
+		const auto orgMinDmg = tempItem._iMinDam;
+		const auto orgMaxDmg = tempItem._iMaxDam;
+
+		const auto maxApplications = 30 - (orgMaxDmg - orgMinDmg);
+		const auto applicationsDone = x->_iMinDam - orgMinDmg;
+
+		if (applicationsDone < maxApplications) {
+			x->_iMaxDam++;
+			x->_iMinDam++;
 		}
+
 		break;
+	}
 	case IMISC_OILSKILL:
 		r = GenerateRnd(6) + 5;
 		x->_iMinStr = std::max(0, x->_iMinStr - r);


### PR DESCRIPTION
See companion discussion #2022 

This changes Oil of Death as follows:
- The base functionality remains as previously - if MaxDmg - MinDmg < 30, it will raise MinDmg by 1 and MaxDmg by 2.
- It allows applying Oil of Death even when MaxDmg - MinDmg >= 30. In that case it will calculate the damage increase as an upgrade, bumping MinDmg and MaxDmg by 1.
- Regardless of how many Oil of Sharpness or Weird Shrines have been used, the total number of applications remains the same.