### PR TITLE
🔨 Add `STREAM_ALL_AUDIO` build setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ option(DISABLE_STREAMING_MUSIC "Disable streaming music (to work around broken p
 mark_as_advanced(DISABLE_STREAMING_MUSIC)
 option(DISABLE_STREAMING_SOUNDS "Disable streaming sounds (to work around broken platform implementations)" OFF)
 mark_as_advanced(DISABLE_STREAMING_SOUNDS)
+option(STREAM_ALL_AUDIO "Stream all the audio. For extremely RAM-constrained platforms.")
+mark_as_advanced(STREAM_ALL_AUDIO)
 
 RELEASE_OPTION(CPACK "Configure CPack")
 
@@ -626,6 +628,7 @@ foreach(
   GPERF
   GPERF_HEAP_MAIN
   GPERF_HEAP_FIRST_GAME_ITERATION
+  STREAM_ALL_AUDIO
 )
 if(${def_name})
   list(APPEND def_list ${def_name})

--- a/Source/sound.cpp
+++ b/Source/sound.cpp
@@ -165,11 +165,14 @@ std::unique_ptr<TSnd> sound_file_load(const char *path, bool stream)
 	auto snd = std::make_unique<TSnd>();
 	snd->start_tc = SDL_GetTicks() - 80 - 1;
 
+#ifndef STREAM_ALL_AUDIO
 	if (stream) {
+#endif
 		error = snd->DSB.SetChunkStream(path);
 		if (error != 0) {
 			ErrSdl();
 		}
+#ifndef STREAM_ALL_AUDIO
 	} else {
 		HANDLE file;
 		if (!SFileOpenFile(path, &file)) {
@@ -181,6 +184,7 @@ std::unique_ptr<TSnd> sound_file_load(const char *path, bool stream)
 		error = snd->DSB.SetChunk(wave_file, dwBytes);
 		SFileCloseFileThreadSafe(file);
 	}
+#endif
 	if (error != 0) {
 		ErrSdl();
 	}

--- a/Source/utils/soundsample.cpp
+++ b/Source/utils/soundsample.cpp
@@ -70,8 +70,10 @@ float VolumeLogToLinear(int logVolume, int logMin, int logMax)
 void SoundSample::Release()
 {
 	stream_ = nullptr;
+#ifndef STREAM_ALL_AUDIO
 	file_data_ = nullptr;
 	file_data_size_ = 0;
+#endif
 };
 
 /**
@@ -131,6 +133,7 @@ int SoundSample::SetChunkStream(std::string filePath)
 	return 0;
 }
 
+#ifndef STREAM_ALL_AUDIO
 int SoundSample::SetChunk(ArraySharedPtr<std::uint8_t> fileData, std::size_t dwBytes)
 {
 	file_data_ = fileData;
@@ -151,6 +154,7 @@ int SoundSample::SetChunk(ArraySharedPtr<std::uint8_t> fileData, std::size_t dwB
 
 	return 0;
 };
+#endif
 
 /**
  * @return Audio duration in ms

--- a/Source/utils/soundsample.h
+++ b/Source/utils/soundsample.h
@@ -36,6 +36,7 @@ public:
 		stream_->setFinishCallback(std::forward<Aulib::Stream::Callback>(callback));
 	}
 
+#ifndef STREAM_ALL_AUDIO
 	/**
 	 * @brief Sets the sample's WAV, FLAC, or Ogg/Vorbis data.
 	 * @param fileData Buffer containing the data
@@ -43,25 +44,34 @@ public:
 	 * @return 0 on success, -1 otherwise
 	 */
 	int SetChunk(ArraySharedPtr<std::uint8_t> file_data, std::size_t dwBytes);
+#endif
 
+#ifndef STREAM_ALL_AUDIO
 	[[nodiscard]] bool IsStreaming() const
 	{
 		return file_data_ == nullptr;
 	}
+#endif
 
 	int DuplicateFrom(const SoundSample &other)
 	{
+#ifdef STREAM_ALL_AUDIO
+		return SetChunkStream(other.file_path_);
+#else
 		if (other.IsStreaming())
 			return SetChunkStream(other.file_path_);
 		return SetChunk(other.file_data_, other.file_data_size_);
+#endif
 	}
 
 	int GetLength() const;
 
 private:
+#ifndef STREAM_ALL_AUDIO
 	// Non-streaming audio fields:
 	ArraySharedPtr<std::uint8_t> file_data_;
 	std::size_t file_data_size_;
+#endif
 
 	// Set for streaming audio to allow for duplicating it:
 	std::string file_path_;


### PR DESCRIPTION
For extremely memory-constrained devices. Gets into town on RG99 (18 FPS -> 14 FPS).