### PR TITLE
✏️ Fix typos and spelling mistakes on 'HeroSpeech' members

### DIFF
--- a/Source/effects.h
+++ b/Source/effects.h
@@ -62,7 +62,7 @@ enum class HeroSpeech {
 	IveGotABadFeelingAboutThis,
 	GotMilk,
 	ImNotThirsty,
-	ImNoMilkmade,
+	ImNoMilkmaid,
 	ICouldBlowUpTheWholeVillage,
 	YepThatsACowAlright,
 	TooUghHeavy,
@@ -96,7 +96,7 @@ enum class HeroSpeech {
 	TheTownIsSafeFromTheseFoulSpawn,
 	RestWellLeoricIllFindYourSon,
 	YourMadnessEndsHereBetrayer,
-	YouLureNoMoreMenToTheirDeaths,
+	YoullLureNoMoreMenToTheirDeaths,
 	ReturnToHeavenWarriorOfLight,
 	ICanSeeWhyTheyFearThisWeapon,
 	ThisMustBeWhatGriswoldWanted,
@@ -114,8 +114,8 @@ enum class HeroSpeech {
 	IMustBeGettingClose,
 	MaybeItsLockedFromTheInside,
 	LooksLikeItsRustedShut,
-	MaybeThereIsAnotherWay,
-	LAST = MaybeThereIsAnotherWay
+	MaybeTheresAnotherWay,
+	LAST = MaybeTheresAnotherWay
 };
 
 enum _sfx_id : int16_t {

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -597,7 +597,7 @@ void TalkToCow(PlayerStruct &player, TownerStruct &cow)
 	} else if (CowClicks >= 8 && !gbIsSpawn) {
 		CowClicks = 4;
 
-		static const HeroSpeech snSfx[3] = { HeroSpeech::YepThatsACowAlright, HeroSpeech::ImNotThirsty, HeroSpeech::ImNoMilkmade };
+		static const HeroSpeech snSfx[3] = { HeroSpeech::YepThatsACowAlright, HeroSpeech::ImNotThirsty, HeroSpeech::ImNoMilkmaid };
 		player.SaySpecific(snSfx[CowMsg]);
 		CowMsg++;
 		if (CowMsg >= 3)


### PR DESCRIPTION
This PR fixes a few typos/spelling issues in the newly renamed `HeroSpeech` entries.