### PR TITLE
Highlight items hack

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -99,6 +99,8 @@ bool gbGameLoopStartup;
 bool gbRunGame;
 bool gbRunGameResult;
 bool zoomflag;
+bool drawitems_town = false;
+bool drawitems_dungeon = true;
 /** Enable updating of player character, set to false once Diablo dies */
 bool gbProcessPlayers;
 bool gbLoadGame;
@@ -536,6 +538,7 @@ static void SaveOptions()
 	setIniInt("Game", "Enemy Health Bar", sgOptions.Gameplay.bEnemyHealthBar);
 	setIniInt("Game", "Auto Gold Pickup", sgOptions.Gameplay.bAutoGoldPickup);
 	setIniInt("Game", "Adria Refills Mana", sgOptions.Gameplay.bAdriaRefillsMana);
+	setIniInt("Game", "Highlight Items", sgOptions.Gameplay.bHighlightItems);
 	setIniInt("Game", "Auto Equip Weapons", sgOptions.Gameplay.bAutoEquipWeapons);
 	setIniInt("Game", "Auto Equip Armor", sgOptions.Gameplay.bAutoEquipArmor);
 	setIniInt("Game", "Auto Equip Helms", sgOptions.Gameplay.bAutoEquipHelms);
@@ -621,6 +624,7 @@ static void LoadOptions()
 	sgOptions.Gameplay.bEnemyHealthBar = getIniBool("Game", "Enemy Health Bar", false);
 	sgOptions.Gameplay.bAutoGoldPickup = getIniBool("Game", "Auto Gold Pickup", false);
 	sgOptions.Gameplay.bAdriaRefillsMana = getIniBool("Game", "Adria Refills Mana", false);
+	sgOptions.Gameplay.bHighlightItems = getIniBool("Game", "Highlight Items", true);
 	sgOptions.Gameplay.bAutoEquipWeapons = getIniBool("Game", "Auto Equip Weapons", true);
 	sgOptions.Gameplay.bAutoEquipArmor = getIniBool("Game", "Auto Equip Armor", false);
 	sgOptions.Gameplay.bAutoEquipHelms = getIniBool("Game", "Auto Equip Helms", false);
@@ -1138,6 +1142,24 @@ static void PressKey(int vkey)
 {
 	if (gmenu_presskeys(vkey) || control_presskeys(vkey)) {
 		return;
+	}
+
+	if (vkey == DVL_VK_MENU || vkey == DVL_VK_LMENU || vkey == DVL_VK_RMENU) {
+
+		if (leveltype == DTYPE_TOWN) {
+			if (drawitems_town == false) {
+				drawitems_town = true;
+			}
+			else {
+				drawitems_town = false;
+			}
+		} else {
+			if (drawitems_dungeon == false) {
+				drawitems_dungeon = true;
+			} else {
+				drawitems_dungeon = false;
+			}
+		}
 	}
 
 	if (deathflag) {

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -33,6 +33,8 @@ extern int MouseY;
 extern bool gbRunGame;
 extern bool gbRunGameResult;
 extern bool zoomflag;
+extern bool drawitems_town;
+extern bool drawitems_dungeon;
 extern bool gbProcessPlayers;
 extern bool gbLoadGame;
 extern bool cineflag;

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -87,39 +87,39 @@ void UnsafeDrawVerticalLine(const CelOutputBuffer &out, Point from, int height, 
 	}
 }
 
-static void DrawHalfTransparentBlendedRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height)
+static void DrawHalfTransparentBlendedRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height, int color)
 {
 	BYTE *pix = out.at(sx, sy);
 
 	for (int row = 0; row < height; row++) {
 		for (int col = 0; col < width; col++) {
-			*pix = paletteTransparencyLookup[0][*pix];
+			*pix = paletteTransparencyLookup[color][*pix];
 			pix++;
 		}
 		pix += out.pitch() - width;
 	}
 }
 
-static void DrawHalfTransparentStippledRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height)
+static void DrawHalfTransparentStippledRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height, int color)
 {
 	BYTE *pix = out.at(sx, sy);
 
 	for (int row = 0; row < height; row++) {
 		for (int col = 0; col < width; col++) {
 			if (((row & 1) != 0 && (col & 1) != 0) || ((row & 1) == 0 && (col & 1) == 0))
-				*pix = 0;
+				*pix = color;
 			pix++;
 		}
 		pix += out.pitch() - width;
 	}
 }
 
-void DrawHalfTransparentRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height)
+void DrawHalfTransparentRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height, int color)
 {
 	if (sgOptions.Graphics.bBlendedTransparancy) {
-		DrawHalfTransparentBlendedRectTo(out, sx, sy, width, height);
+		DrawHalfTransparentBlendedRectTo(out, sx, sy, width, height, color);
 	} else {
-		DrawHalfTransparentStippledRectTo(out, sx, sy, width, height);
+		DrawHalfTransparentStippledRectTo(out, sx, sy, width, height, color);
 	}
 }
 

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -489,7 +489,7 @@ void UnsafeDrawVerticalLine(const CelOutputBuffer &out, Point from, int height, 
  * @param width Rectangle width
  * @param height Rectangle height
  */
-void DrawHalfTransparentRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height);
+void DrawHalfTransparentRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height, int color);
 
 /**
  * @brief Calculate the best fit direction between two points

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -127,7 +127,7 @@ void DrawDiabloMsg(const CelOutputBuffer &out)
 		sy += 12;
 	}
 
-	DrawHalfTransparentRectTo(out, PANEL_X + 104, DIALOG_Y - 8, 432, 54);
+	DrawHalfTransparentRectTo(out, PANEL_X + 104, DIALOG_Y - 8, 432, 54, 0);
 
 	strcpy(tempstr, _(MsgStrings[msgflag]));
 	DrawString(out, tempstr, { PANEL_X + 101, DIALOG_Y + 24, 442, 0 }, UIS_CENTER);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3703,7 +3703,7 @@ void PrintItemPower(char plidx, ItemStruct *x)
 static void DrawUTextBack(const CelOutputBuffer &out)
 {
 	CelDrawTo(out, RIGHT_PANEL_X - SPANEL_WIDTH + 24, 327, *pSTextBoxCels, 1);
-	DrawHalfTransparentRectTo(out, RIGHT_PANEL_X - SPANEL_WIDTH + 27, 28, 265, 297);
+	DrawHalfTransparentRectTo(out, RIGHT_PANEL_X - SPANEL_WIDTH + 27, 28, 265, 297, 0);
 }
 
 static void DrawULine(const CelOutputBuffer &out, int y)

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -156,7 +156,7 @@ void InitQTextMsg(_speech_id m)
 void DrawQTextBack(const CelOutputBuffer &out)
 {
 	CelDrawTo(out, PANEL_X + 24, 327 + UI_OFFSET_Y, *pTextBoxCels, 1);
-	DrawHalfTransparentRectTo(out, PANEL_X + 27, UI_OFFSET_Y + 28, 585, 297);
+	DrawHalfTransparentRectTo(out, PANEL_X + 27, UI_OFFSET_Y + 28, 585, 297, 0);
 }
 
 void DrawQText(const CelOutputBuffer &out)

--- a/Source/options.h
+++ b/Source/options.h
@@ -92,6 +92,8 @@ struct GameplayOptions {
 	bool bAutoGoldPickup;
 	/** @brief Recover mana when talking to Adria. */
 	bool bAdriaRefillsMana;
+	/** @brief Enable highlightning items. */
+	int bHighlightItems;
 	/** @brief Automatically attempt to equip weapon-type items when picking them up. */
 	bool bAutoEquipWeapons;
 	/** @brief Automatically attempt to equip armor-type items when picking them up. */

--- a/Source/qol/monhealthbar.cpp
+++ b/Source/qol/monhealthbar.cpp
@@ -78,7 +78,7 @@ void DrawMonsterHealthBar(const CelOutputBuffer &out)
 	const int maxLife = std::max(mon._mmaxhp, mon._mhitpoints);
 
 	DrawArt(out, xPos, yPos, &healthBox);
-	DrawHalfTransparentRectTo(out, xPos + border, yPos + border, width - (border * 2), height - (border * 2));
+	DrawHalfTransparentRectTo(out, xPos + border, yPos + border, width - (border * 2), height - (border * 2), 0);
 	int barProgress = (width * mon._mhitpoints) / maxLife;
 	if (barProgress) {
 		DrawArt(out, xPos + border + 1, yPos + border + 1, &health, 0, barProgress, height - (border * 2) - 2);

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -76,7 +76,7 @@ const char *const TownerNames[] = {
 void DrawSTextBack(const CelOutputBuffer &out)
 {
 	CelDrawTo(out, PANEL_X + 320 + 24, 327 + UI_OFFSET_Y, *pSTextBoxCels, 1);
-	DrawHalfTransparentRectTo(out, PANEL_X + 347, UI_OFFSET_Y + 28, 265, 297);
+	DrawHalfTransparentRectTo(out, PANEL_X + 347, UI_OFFSET_Y + 28, 265, 297, 0);
 }
 
 void DrawSSlider(const CelOutputBuffer &out, int y1, int y2)


### PR DESCRIPTION
@qndel 's Highlight items hack

Default behavior:
1. Highlight items ini setting - ON
2. In town - highlight OFF, can be toggled between "always on" an "always off" with the ALT key
3. In dungeon - highlight ON, can be toggled between "always on" an "always off" with the ALT key

Highlight in town or dungeon can be toggled independently.