### PR TITLE
Replace all Auto Equip options with one option

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -537,6 +537,7 @@ static void SaveOptions()
 	setIniInt("Game", "Enemy Health Bar", sgOptions.Gameplay.bEnemyHealthBar);
 	setIniInt("Game", "Auto Gold Pickup", sgOptions.Gameplay.bAutoGoldPickup);
 	setIniInt("Game", "Adria Refills Mana", sgOptions.Gameplay.bAdriaRefillsMana);
+	setIniValue("Game", "Auto Equip Items", sgOptions.Gameplay.szAutoEquipItems);
 	setIniInt("Game", "Auto Equip Weapons", sgOptions.Gameplay.bAutoEquipWeapons);
 	setIniInt("Game", "Auto Equip Armor", sgOptions.Gameplay.bAutoEquipArmor);
 	setIniInt("Game", "Auto Equip Helms", sgOptions.Gameplay.bAutoEquipHelms);
@@ -627,6 +628,14 @@ static void LoadOptions()
 	sgOptions.Gameplay.bAutoEquipHelms = getIniBool("Game", "Auto Equip Helms", false);
 	sgOptions.Gameplay.bAutoEquipShields = getIniBool("Game", "Auto Equip Shields", false);
 	sgOptions.Gameplay.bAutoEquipJewelry = getIniBool("Game", "Auto Equip Jewelry", false);
+
+	getIniValue("Game", "Auto Equip Items", sgOptions.Gameplay.szAutoEquipItems, 99, "Weapon");
+	sgOptions.Gameplay.bAutoEquipWeapons |= IniFound(sgOptions.Gameplay.szAutoEquipItems, "Weapon");
+	sgOptions.Gameplay.bAutoEquipArmor |= IniFound(sgOptions.Gameplay.szAutoEquipItems, "Armor");
+	sgOptions.Gameplay.bAutoEquipHelms |= IniFound(sgOptions.Gameplay.szAutoEquipItems, "Helm");
+	sgOptions.Gameplay.bAutoEquipShields |= IniFound(sgOptions.Gameplay.szAutoEquipItems, "Shield");
+	sgOptions.Gameplay.bAutoEquipJewelry |= IniFound(sgOptions.Gameplay.szAutoEquipItems, "Jewelry");
+
 	sgOptions.Gameplay.bRandomizeQuests = getIniBool("Game", "Randomize Quests", true);
 	sgOptions.Gameplay.bShowMonsterType = getIniBool("Game", "Show Monster Type", false);
 	sgOptions.Gameplay.bDisableCripplingShrines = getIniBool("Game", "Disable Crippling Shrines", false);

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -591,6 +591,16 @@ bool AutoEquip(int playerNumber, const ItemStruct &item, bool persistItem)
  */
 bool AutoEquipEnabled(const PlayerStruct &player, const ItemStruct &item)
 {
+        /*
+	* Uncoment when Gameplay.bAutoEquipXXX flags are no longer used.
+	if ((item.isWeapon() && player._pClass != HeroClass::Monk && IniFound(sgOptions.Gameplay.szAutoEquipItems, "Weapon"))
+		|| (item.isArmor() && IniFound(sgOptions.Gameplay.szAutoEquipItems, "Armor"))
+		|| (item.isHelm() && IniFound(sgOptions.Gameplay.szAutoEquipItems, "Helm"))
+		|| (item.isShield() && IniFound(sgOptions.Gameplay.szAutoEquipItems, "Shield"))
+		|| (item.isJewelry() && IniFound(sgOptions.Gameplay.szAutoEquipItems, "Jewelry")))
+	    return true;
+	*/
+
 	if (item.isWeapon()) {
 		// Monk can use unarmed attack as an encouraged option, thus we do not automatically equip weapons on him so as to not
 		// annoy players who prefer that playstyle.

--- a/Source/options.h
+++ b/Source/options.h
@@ -92,6 +92,9 @@ struct GameplayOptions {
 	bool bAutoGoldPickup;
 	/** @brief Recover mana when talking to Adria. */
 	bool bAdriaRefillsMana;
+	/** @brief List of automatically attempt to equip items when picking them up. */
+	// valid value is "Weapon, Armor, Helm, Shield, Jewelry"
+	char szAutoEquipItems[100];
 	/** @brief Automatically attempt to equip weapon-type items when picking them up. */
 	bool bAutoEquipWeapons;
 	/** @brief Automatically attempt to equip armor-type items when picking them up. */

--- a/Source/storm/storm.cpp
+++ b/Source/storm/storm.cpp
@@ -215,6 +215,41 @@ void setIniFloat(const char *keyname, const char *valuename, float value)
 	getIni().SetDoubleValue(keyname, valuename, value);
 }
 
+// find match of needle pattern in haystack, ignoring case.
+const char* strcasestr(const char* haystack, const char* needle)
+{
+	const char *pp, *qq, *look;
+
+	for (look = haystack; *look; look++)
+	{
+		while(*look && (tolower(*look) != tolower(*needle)))
+			look++;
+		if (!*look)
+			return NULL;
+
+		pp = needle; qq = look;
+
+		while (tolower(*qq) == tolower(*pp))
+		{
+		    pp++; qq++;
+		    if (!*pp)	// match found!
+			    return (look);
+		}
+	}
+	return NULL;
+}
+
+bool IniFound(const char* list, const char* item)
+{
+	const char* look = strcasestr(list, item);
+	if (!look)
+		return false;
+	look += strlen(item)+1;
+	while (*look == ' ')
+		look++;
+	return (bool) strchr(",;:", *look); // delimters including '\0'
+}
+
 DWORD SErrGetLastError()
 {
 	return ::GetLastError();

--- a/Source/storm/storm.h
+++ b/Source/storm/storm.h
@@ -265,6 +265,9 @@ int getIniInt(const char *keyname, const char *valuename, int defaultValue);
 void setIniInt(const char *keyname, const char *valuename, int value);
 void setIniFloat(const char *keyname, const char *valuename, float value);
 
+const char* strcasestr(const char* haystack, const char* needle);
+bool IniFound(const char* list, const char* item);
+
 // These error codes are used and returned by StormLib.
 // See StormLib/src/StormPort.h
 #if defined(_WIN32)


### PR DESCRIPTION
New Option: Auto Equip Items to replace Auto Equip XXX flags in `Diablo.ini` config file.
Old:
```
Auto Equip Weapons=1
Auto Equip Armor=0
Auto Equip Helms=1
Auto Equip Shields=1
Auto Equip Jewelry=0
```
New:
```
Auto Equip Items=Weapon, Helm, Shield
```
Valid item names are `Weapon, Armor, Helm, Shield, Jewelry` (all singular word) in any order, case ignored.
Currently, old Auto Equip XXX flags and source code are preserved for transition, but will be removed eventually later times.

Thank you for motivation from @julealgon on discussion thread #1804.
