### PR TITLE
Replace all Auto Equip options with one option.

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -537,6 +537,7 @@ static void SaveOptions()
 	setIniInt("Game", "Enemy Health Bar", sgOptions.Gameplay.bEnemyHealthBar);
 	setIniInt("Game", "Auto Gold Pickup", sgOptions.Gameplay.bAutoGoldPickup);
 	setIniInt("Game", "Adria Refills Mana", sgOptions.Gameplay.bAdriaRefillsMana);
+	setIniValue("Game", "Auto Equip Items", sgOptions.Gameplay.szAutoEquipItems);
 	setIniInt("Game", "Auto Equip Weapons", sgOptions.Gameplay.bAutoEquipWeapons);
 	setIniInt("Game", "Auto Equip Armor", sgOptions.Gameplay.bAutoEquipArmor);
 	setIniInt("Game", "Auto Equip Helms", sgOptions.Gameplay.bAutoEquipHelms);
@@ -627,6 +628,12 @@ static void LoadOptions()
 	sgOptions.Gameplay.bAutoEquipHelms = getIniBool("Game", "Auto Equip Helms", false);
 	sgOptions.Gameplay.bAutoEquipShields = getIniBool("Game", "Auto Equip Shields", false);
 	sgOptions.Gameplay.bAutoEquipJewelry = getIniBool("Game", "Auto Equip Jewelry", false);
+	getIniValue("Game", "Auto Equip Items", sgOptions.Gameplay.szAutoEquipItems, 99, "Weapon");
+	sgOptions.Gameplay.bAutoEquipWeapons |= IniFound(sgOptions.Gameplay.szAutoEquipItems, "Weapon");
+	sgOptions.Gameplay.bAutoEquipArmor |= IniFound(sgOptions.Gameplay.szAutoEquipItems, "Armor");
+	sgOptions.Gameplay.bAutoEquipHelms |= IniFound(sgOptions.Gameplay.szAutoEquipItems, "Helm");
+	sgOptions.Gameplay.bAutoEquipShields |= IniFound(sgOptions.Gameplay.szAutoEquipItems, "Shield");
+	sgOptions.Gameplay.bAutoEquipJewelry |= IniFound(sgOptions.Gameplay.szAutoEquipItems, "Jewelry");
 	sgOptions.Gameplay.bRandomizeQuests = getIniBool("Game", "Randomize Quests", true);
 	sgOptions.Gameplay.bShowMonsterType = getIniBool("Game", "Show Monster Type", false);
 	sgOptions.Gameplay.bDisableCripplingShrines = getIniBool("Game", "Disable Crippling Shrines", false);

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -591,6 +591,14 @@ bool AutoEquip(int playerNumber, const ItemStruct &item, bool persistItem)
  */
 bool AutoEquipEnabled(const PlayerStruct &player, const ItemStruct &item)
 {
+	/*
+	// Use this when Gameplay.bAutoEquipXXX flags are removed.
+	return ((item.isWeapon() && player._pClass != HeroClass::Monk && IniFound(sgOptions.Gameplay.szAutoEquipItems, "Weapon"))
+		|| (item.isArmor() && IniFound(sgOptions.Gameplay.szAutoEquipItems, "Armor"))
+		|| (item.isHelm() && IniFound(sgOptions.Gameplay.szAutoEquipItems, "Helm"))
+		|| (item.isShield() && IniFound(sgOptions.Gameplay.szAutoEquipItems, "Shield"))
+		|| (item.isJewelry() && IniFound(sgOptions.Gameplay.szAutoEquipItems, "Jewelry")));
+	*/
 	if (item.isWeapon()) {
 		// Monk can use unarmed attack as an encouraged option, thus we do not automatically equip weapons on him so as to not
 		// annoy players who prefer that playstyle.

--- a/Source/options.h
+++ b/Source/options.h
@@ -92,6 +92,8 @@ struct GameplayOptions {
 	bool bAutoGoldPickup;
 	/** @brief Recover mana when talking to Adria. */
 	bool bAdriaRefillsMana;
+	/** @brief Automatically attempt to equip items when picking them up. */
+	char szAutoEquipItems[100];
 	/** @brief Automatically attempt to equip weapon-type items when picking them up. */
 	bool bAutoEquipWeapons;
 	/** @brief Automatically attempt to equip armor-type items when picking them up. */

--- a/Source/storm/storm.cpp
+++ b/Source/storm/storm.cpp
@@ -243,8 +243,8 @@ const char *strcasestr(const char *haystack, const char *needle)
 			return NULL;
 
 		for (pp = needle + 1, qq = look + 1; tolower(*pp) == tolower(*qq); pp++, qq++) {
-		    if (!*pp)	// match found!
-			return (look);
+			if (!*pp)	// match found!
+				return (look);
 		}
 	}
 	return NULL;

--- a/Source/storm/storm.cpp
+++ b/Source/storm/storm.cpp
@@ -216,13 +216,14 @@ void setIniFloat(const char *keyname, const char *valuename, float value)
 }
 
 /**
- * @brief Find item in comma-sparated list
+ * @brief Check item exists in comma-sparated list
  */
 bool IniFound(const char *list, const char *item)
 {
 	const char *look = strcasestr(list, item);
 	if (!look)
 		return false;
+
 	look += strlen(item);
 	while (*look == ' ')
 		look++;
@@ -235,19 +236,20 @@ bool IniFound(const char *list, const char *item)
 const char *strcasestr(const char *haystack, const char *needle)
 {
 	const char *look, *pp, *qq;
+	assert(haystack && needle);
 
 	for (look = haystack; *look; look++) {
 		while (*look && (tolower(*look) != tolower(*needle)))
 			look++;
 		if (!*look)
-			return NULL;
+			return nullptr;
 
-		for (pp = needle + 1, qq = look + 1; tolower(*pp) == tolower(*qq); pp++, qq++) {
+		for (pp = needle+1, qq = look+1; tolower(*pp) == tolower(*qq); pp++, qq++) {
 			if (!*pp)	// match found!
 				return (look);
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 DWORD SErrGetLastError()

--- a/Source/storm/storm.cpp
+++ b/Source/storm/storm.cpp
@@ -215,6 +215,41 @@ void setIniFloat(const char *keyname, const char *valuename, float value)
 	getIni().SetDoubleValue(keyname, valuename, value);
 }
 
+/**
+ * @brief Find item in comma-sparated list
+ */
+bool IniFound(const char *list, const char *item)
+{
+	const char *look = strcasestr(list, item);
+	if (!look)
+		return false;
+	look += strlen(item)+1;
+	while (*look == ' ')
+		look++;
+	return (bool) strchr(",;:", *look); // delimters including '\0'
+}
+
+/**
+ * @brief Find needle pattern in haystack, ignoring case
+ */
+const char *strcasestr(const char *haystack, const char *needle)
+{
+	const char *look, *pp, *qq;
+
+	for (look = haystack; *look; look++) {
+		while (*look && (tolower(*look) != tolower(*needle)))
+			look++;
+		if (!*look)
+			return NULL;
+
+		for (pp = needle + 1, qq = look + 1; tolower(*pp) == tolower(*qq); pp++, qq++) {
+		    if (!*pp)	// match found!
+			return (look);
+		}
+	}
+	return NULL;
+}
+
 DWORD SErrGetLastError()
 {
 	return ::GetLastError();

--- a/Source/storm/storm.cpp
+++ b/Source/storm/storm.cpp
@@ -238,15 +238,13 @@ const char *strcasestr(const char *haystack, const char *needle)
 	const char *look, *pp, *qq;
 	assert(haystack && needle);
 
-	for (look = haystack; *look; look++) {
-		while (*look && (tolower(*look) != tolower(*needle)))
-			look++;
-		if (!*look)
-			return nullptr;
-
-		for (pp = needle+1, qq = look+1; tolower(*pp) == tolower(*qq); pp++, qq++) {
-			if (!*pp)	// match found!
-				return (look);
+	for ( look = haystack; *look; look++ ) {
+		if (tolower(*look) == tolower(*needle)) {
+			pp = needle + 1; qq = look + 1;
+			while (*pp && (tolower(*pp) == tolower(*qq)))
+				pp++, qq++;
+			if (!*pp)
+				return look;	// match found!
 		}
 	}
 	return nullptr;

--- a/Source/storm/storm.cpp
+++ b/Source/storm/storm.cpp
@@ -223,7 +223,7 @@ bool IniFound(const char *list, const char *item)
 	const char *look = strcasestr(list, item);
 	if (!look)
 		return false;
-	look += strlen(item)+1;
+	look += strlen(item);
 	while (*look == ' ')
 		look++;
 	return (bool) strchr(",;:", *look); // delimters including '\0'

--- a/Source/storm/storm.h
+++ b/Source/storm/storm.h
@@ -265,7 +265,7 @@ int getIniInt(const char *keyname, const char *valuename, int defaultValue);
 void setIniInt(const char *keyname, const char *valuename, int value);
 void setIniFloat(const char *keyname, const char *valuename, float value);
 
-bool IniFound(const char* list, const char* item);
+bool IniFound(const char *list, const char *item);
 const char *strcasestr(const char *haystack, const char *needle);
 
 // These error codes are used and returned by StormLib.

--- a/Source/storm/storm.h
+++ b/Source/storm/storm.h
@@ -265,6 +265,9 @@ int getIniInt(const char *keyname, const char *valuename, int defaultValue);
 void setIniInt(const char *keyname, const char *valuename, int value);
 void setIniFloat(const char *keyname, const char *valuename, float value);
 
+bool IniFound(const char* list, const char* item);
+const char *strcasestr(const char *haystack, const char *needle);
+
 // These error codes are used and returned by StormLib.
 // See StormLib/src/StormPort.h
 #if defined(_WIN32)


### PR DESCRIPTION
Replace all Auto Equip options with one Auto Equip Items option.

New Option: Auto Equip Items to replace all Auto Equip XXX flags in `Diablo.ini` config file.
Old:
```
Auto Equip Weapons=1
Auto Equip Armor=0
Auto Equip Helms=1
Auto Equip Shields=1
Auto Equip Jewelry=0
```
New:
```
Auto Equip Items=Weapon, Helm, Shield
```
Valid item names are `Weapon, Armor, Helm, Shield, Jewelry` (all singular words) in any order, case ignored.
Currently, old Auto Equip XXX flags and source code are preserved for transition, but will be removed eventually later times.

Thank you for motivation from @julealgon on discussion thread #1804.
