### PR TITLE
🔨 CMake: simpleini, asio: Use HTTP for downloading

### DIFF
--- a/3rdParty/asio/CMakeLists.txt
+++ b/3rdParty/asio/CMakeLists.txt
@@ -2,8 +2,8 @@ include(FetchContent_MakeAvailableExcludeFromAll)
 
 include(FetchContent)
 FetchContent_Declare(asio
-    GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
-    GIT_TAG 77bcfe775ad63178942c9dd95d93edd10442b80f
+    URL https://github.com/chriskohlhoff/asio/archive/77bcfe775ad63178942c9dd95d93edd10442b80f.zip
+    URL_HASH MD5=bfb3071dff527a6618be8836dc753f0a
 )
 FetchContent_MakeAvailableExcludeFromAll(asio)
 

--- a/3rdParty/simpleini/CMakeLists.txt
+++ b/3rdParty/simpleini/CMakeLists.txt
@@ -2,8 +2,8 @@ include(FetchContent_MakeAvailableExcludeFromAll)
 
 include(FetchContent)
 FetchContent_Declare(simpleini
-    GIT_REPOSITORY https://github.com/brofield/simpleini.git
-    GIT_TAG 7bca74f6535a37846162383e52071f380c99a43a
+    URL https://github.com/brofield/simpleini/archive/7bca74f6535a37846162383e52071f380c99a43a.zip
+    URL_HASH MD5=af067f743dd5c7aac3212ca22da6f621
 )
 FetchContent_MakeAvailableExcludeFromAll(simpleini)
 


### PR DESCRIPTION
This is much faster than using git. HTTP should be used when possible (i.e. when there are no submodules).