### PR TITLE
added path for CharisSILB.ttf on android

### DIFF
--- a/SourceX/DiabloUI/fonts.cpp
+++ b/SourceX/DiabloUI/fonts.cpp
@@ -68,10 +68,6 @@ void LoadTtfFont()
 	if (!FileExists(ttf_font_path.c_str())) {
 		ttf_font_path = "/usr/share/fonts/truetype/" + GetTtfName();
 	}
-#elif defined(__ANDROID__)
-	if (!FileExists(ttf_font_path.c_str())) {
-		ttf_font_path = GetTtfName();
-	}
 #endif
 	font = TTF_OpenFont(ttf_font_path.c_str(), 17);
 	if (font == NULL) {

--- a/SourceX/DiabloUI/fonts.cpp
+++ b/SourceX/DiabloUI/fonts.cpp
@@ -64,12 +64,11 @@ void LoadTtfFont()
 	}
 
 	std::string ttf_font_path = GetTtfPath() + GetTtfName();
-#ifdef __linux__
+#if defined(__linux__) && !defined(__ANDROID__)
 	if (!FileExists(ttf_font_path.c_str())) {
 		ttf_font_path = "/usr/share/fonts/truetype/" + GetTtfName();
 	}
-#endif
-#ifdef __ANDROID__
+#elif defined(__ANDROID__)
 	if (!FileExists(ttf_font_path.c_str())) {
 		ttf_font_path = GetTtfName();
 	}

--- a/SourceX/DiabloUI/fonts.cpp
+++ b/SourceX/DiabloUI/fonts.cpp
@@ -69,6 +69,11 @@ void LoadTtfFont()
 		ttf_font_path = "/usr/share/fonts/truetype/" + GetTtfName();
 	}
 #endif
+#ifdef __ANDROID__
+	if (!FileExists(ttf_font_path.c_str())) {
+		ttf_font_path = GetTtfName();
+	}
+#endif
 	font = TTF_OpenFont(ttf_font_path.c_str(), 17);
 	if (font == NULL) {
 		SDL_Log("TTF_OpenFont: %s", TTF_GetError());


### PR DESCRIPTION
Hello,
I noticed that simply the pathing is hard coded for many things including the paths of preferred directories. The font which you are wanting to load to android - because it is located in the assets directory it will the path can be referenced form there . 


Another thing to mention, I tried to use #elif for preprocessor and it wasn't recognized .  So I made another #ifdef __ANDROID__ statement. 