### PR TITLE
Add required libsdl2-mixer-2.0-0 to ubuntu dependencies

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -18,7 +18,7 @@ Download the latest [DevilutionX release](https://github.com/diasurgical/devilut
 
 - Copy the MPQ files to the folder containing the DevilutionX executable, or to the data folder. The data folder path may differ depending on distro, version, and security settings, but will normally be `~/.local/share/diasurgical/devilution/`
 - Install [SDL2](https://www.libsdl.org/download-2.0.php) and [SDL2_ttf](https://www.libsdl.org/projects/SDL_ttf/):
- - Ubuntu/Debian/Rasbian `sudo apt install libsdl2-2.0-0 libsdl2-ttf-2.0-0`
+ - Ubuntu/Debian/Rasbian `sudo apt install libsdl2-2.0-0 libsdl2-ttf-2.0-0 libsdl2-mixer-2.0-0`
  - Fedora `sudo dnf install SDL2 SDL2_ttf`
 - Run `./devilutionx`
 


### PR DESCRIPTION
I found it was necessary, at least with Ubuntu 21.04.


Thanks for the great project.