### PR TITLE
Replace ASIO with SDL_net

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run: echo deb http://deb.debian.org/debian stretch-backports-sloppy main >> /etc/apt/sources.list.d/debian-backports.list
       - run: apt update -y
-      - run: apt install -y g++ libsdl2-dev libsdl2-ttf-dev git rpm wget
+      - run: apt install -y g++ libsdl2-dev libsdl2-ttf-dev libsdl2-net-dev git rpm wget
       - run: apt install -y -t 'stretch-backports*' cmake libsodium-dev
       - run: cmake -S. -Bbuild .. -DNIGHTLY_BUILD=ON -DCMAKE_INSTALL_PREFIX=/usr
       - run: cmake --build build -j 2 --target package
@@ -24,7 +24,7 @@ jobs:
     steps:
       - checkout
       - run: apt-get update -y
-      - run: apt-get install -y cmake curl g++ git lcov libgtest-dev libfmt-dev libsdl2-dev libsdl2-ttf-dev libsodium-dev
+      - run: apt-get install -y cmake curl g++ git lcov libgtest-dev libfmt-dev libsdl2-dev libsdl2-ttf-dev libsdl2-net-dev libsodium-dev
       - run: cmake -S. -Bbuild -DRUN_TESTS=ON -DENABLE_CODECOVERAGE=ON
       - run: cmake --build build -j 2
       - run: cmake --build build -j 2 --target test

--- a/.github/workflows/Linux_x86.yml
+++ b/.github/workflows/Linux_x86.yml
@@ -25,7 +25,7 @@ jobs:
       run: >
         sudo dpkg --add-architecture i386 && 
         sudo apt update -y &&
-        sudo apt install -y cmake file g++-multilib git libfmt-dev:i386 libsdl2-dev:i386 libsdl2-ttf-dev:i386 libsodium-dev:i386 rpm wget
+        sudo apt install -y cmake file g++-multilib git libfmt-dev:i386 libsdl2-dev:i386 libsdl2-ttf-dev:i386 libsdl2-net-dev:i386 libsodium-dev:i386 rpm wget
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/Linux_x86_64_SDL1.yml
+++ b/.github/workflows/Linux_x86_64_SDL1.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Create Build Environment
       run: >
         sudo apt update &&
-        sudo apt install -y cmake file g++ git libfmt-dev libsdl-dev libsdl-ttf2.0-dev libsodium-dev rpm
+        sudo apt install -y cmake file g++ git libfmt-dev libsdl-dev libsdl-ttf2.0-dev libsdl-net1.2-dev libsodium-dev rpm
 
     - name: Configure CMake
       shell: bash

--- a/3rdParty/SDL_net/CMakeLists.txt
+++ b/3rdParty/SDL_net/CMakeLists.txt
@@ -1,0 +1,76 @@
+# Designed to work with *nix build environments
+# Windows users should use MSYS or DEVILUTIONX_SYSTEM_SDL_NET
+include(FetchContent_MakeAvailableExcludeFromAll)
+
+if(DEVILUTIONX_STATIC_SDL_NET)
+  set(sdl_net_CONFIGURE_FLAGS --enable-shared=no)
+else()
+  set(sdl_net_CONFIGURE_FLAGS --enable-static=no)
+endif()
+
+if (AUTOCONF_HOST)
+  set(sdl_net_CONFIGURE_FLAGS ${sdl_net_CONFIGURE_FLAGS} --host=${AUTOCONF_HOST})
+endif()
+
+include(FetchContent)
+include(ExternalProject)
+
+if(USE_SDL1)
+  FetchContent_Declare(SDL_net
+    URL https://github.com/libsdl-org/SDL_net/archive/08d4aef8532cf8d61daa60af66f53fd2247a7a69.zip
+    URL_HASH MD5=d5f4144da6a5dc862adab9a3e8638330)
+
+  FetchContent_MakeAvailableExcludeFromAll(SDL_net)
+
+  ExternalProject_Add(SDL_net
+    SOURCE_DIR "${sdl_net_SOURCE_DIR}"
+    CONFIGURE_COMMAND "${sdl_net_SOURCE_DIR}/autogen.sh" && "${sdl_net_SOURCE_DIR}/configure" ${sdl_net_CONFIGURE_FLAGS} --prefix "${sdl_net_BINARY_DIR}"
+    BUILD_COMMAND make && make install)
+
+  set(sdl_net_INCLUDE_DIR "${sdl_net_BINARY_DIR}/include/SDL")
+  file(MAKE_DIRECTORY ${sdl_net_INCLUDE_DIR})
+
+  if(DEVILUTIONX_STATIC_SDL_NET)
+    add_library(SDL_NET_LIBRARY STATIC IMPORTED GLOBAL)
+    set(sdl_net_BINARY "${sdl_net_BINARY_DIR}/lib/libSDL_net.a")
+  else()
+    add_library(SDL_NET_LIBRARY SHARED IMPORTED GLOBAL)
+    set(sdl_net_BINARY "${sdl_net_BINARY_DIR}/lib/libSDL_net.so")
+  endif()
+
+  set_target_properties(SDL_NET_LIBRARY
+    PROPERTIES
+    IMPORTED_LOCATION ${sdl_net_BINARY}
+    INTERFACE_INCLUDE_DIRECTORIES ${sdl_net_INCLUDE_DIR})
+
+  add_dependencies(SDL_NET_LIBRARY SDL_net)
+else()
+  FetchContent_Declare(SDL2_net
+    URL https://github.com/libsdl-org/SDL_net/archive/cecfb16da610e70ec4d6f2e93e15176ede039369.zip
+    URL_HASH MD5=8a780135189c35b8f84e344c6e05e8b0)
+
+  FetchContent_MakeAvailableExcludeFromAll(SDL2_net)
+
+  ExternalProject_Add(SDL2_net
+    SOURCE_DIR "${sdl2_net_SOURCE_DIR}"
+    CONFIGURE_COMMAND "${sdl2_net_SOURCE_DIR}/autogen.sh" && "${sdl2_net_SOURCE_DIR}/configure" ${sdl_net_CONFIGURE_FLAGS} --prefix "${sdl2_net_BINARY_DIR}"
+    BUILD_COMMAND make && make install)
+
+  set(sdl2_net_INCLUDE_DIR "${sdl2_net_BINARY_DIR}/include/SDL2")
+  file(MAKE_DIRECTORY ${sdl2_net_INCLUDE_DIR})
+
+  if(DEVILUTIONX_STATIC_SDL_NET)
+    add_library(SDL2::SDL2_net STATIC IMPORTED GLOBAL)
+    set(sdl2_net_BINARY "${sdl2_net_BINARY_DIR}/lib/libSDL2_net.a")
+  else()
+    add_library(SDL2::SDL2_net SHARED IMPORTED GLOBAL)
+    set(sdl2_net_BINARY "${sdl2_net_BINARY_DIR}/lib/libSDL2_net.so")
+  endif()
+
+  set_target_properties(SDL2::SDL2_net
+    PROPERTIES
+    IMPORTED_LOCATION ${sdl2_net_BINARY}
+    INTERFACE_INCLUDE_DIRECTORIES ${sdl2_net_INCLUDE_DIR})
+
+  add_dependencies(SDL2::SDL2_net SDL2_net)
+endif()

--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,6 @@
 brew "cmake"
 brew "fmt"
 brew "sdl2_ttf"
+brew "sdl2_net"
 brew "libsodium"
 brew "pkg-config"

--- a/CMake/FindSDL2_net.cmake
+++ b/CMake/FindSDL2_net.cmake
@@ -1,0 +1,197 @@
+# - Find SDL2_net
+# Find the SDL2 headers and libraries
+#
+#  SDL2::SDL2_net - Imported target
+#
+#  SDL2_net_FOUND - True if SDL2_net was found.
+#  SDL2_net_DYNAMIC - If we found a DLL version of SDL2_net
+#
+# Modified for SDL2_net of FindSDL2.cmake
+# Original Author:
+# 2015 Ryan Pavlik <ryan.pavlik@gmail.com> <abiryan@ryand.net>
+#
+# Copyright Sensics, Inc. 2015.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+# Set up architectures (for windows) and prefixes (for mingw builds)
+if(WIN32)
+	if(MINGW)
+		include(MinGWSearchPathExtras OPTIONAL)
+		if(MINGWSEARCH_TARGET_TRIPLE)
+			set(SDL2_net_PREFIX ${MINGWSEARCH_TARGET_TRIPLE})
+		endif()
+	endif()
+	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+		set(SDL2_net_LIB_PATH_SUFFIX lib/x64)
+		if(NOT MSVC AND NOT SDL2_net_PREFIX)
+			set(SDL2_net_PREFIX x86_64-w64-mingw32)
+		endif()
+	else()
+		set(SDL2_net_LIB_PATH_SUFFIX lib/x86)
+		if(NOT MSVC AND NOT SDL2_net_PREFIX)
+			set(SDL2_net_PREFIX i686-w64-mingw32)
+		endif()
+	endif()
+endif()
+
+if(SDL2_net_PREFIX)
+	set(SDL2_net_ORIGPREFIXPATH ${CMAKE_PREFIX_PATH})
+	if(SDL2_net_ROOT_DIR)
+		list(APPEND CMAKE_PREFIX_PATH "${SDL2_net_ROOT_DIR}")
+	endif()
+	if(CMAKE_PREFIX_PATH)
+		foreach(_prefix ${CMAKE_PREFIX_PATH})
+			list(APPEND CMAKE_PREFIX_PATH "${_prefix}/${SDL2_net_PREFIX}")
+		endforeach()
+	endif()
+	if(MINGWSEARCH_PREFIXES)
+		list(APPEND CMAKE_PREFIX_PATH ${MINGWSEARCH_PREFIXES})
+	endif()
+endif()
+
+# Invoke pkgconfig for hints
+find_package(PkgConfig QUIET)
+set(SDL2_net_INCLUDE_HINTS)
+set(SDL2_net_LIB_HINTS)
+if(PKG_CONFIG_FOUND)
+	pkg_search_module(SDL2_netPC QUIET SDL2_net)
+	if(SDL2_netPC_INCLUDE_DIRS)
+		set(SDL2_net_INCLUDE_HINTS ${SDL2_netPC_INCLUDE_DIRS})
+	endif()
+	if(SDL2_netPC_LIBRARY_DIRS)
+		set(SDL2_net_LIB_HINTS ${SDL2_netPC_LIBRARY_DIRS})
+	endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+
+find_library(SDL2_net_LIBRARY
+	NAMES
+	SDL2_net
+	HINTS
+	${SDL2_net_LIB_HINTS}
+	PATHS
+	${SDL2_net_ROOT_DIR}
+	ENV SDL2DIR
+	PATH_SUFFIXES lib SDL2 ${SDL2_net_LIB_PATH_SUFFIX})
+
+set(_sdl2_framework FALSE)
+# Some special-casing if we've found/been given a framework.
+# Handles whether we're given the library inside the framework or the framework itself.
+if(APPLE AND "${SDL2_net_LIBRARY}" MATCHES "(/[^/]+)*.framework(/.*)?$")
+	set(_sdl2_framework TRUE)
+	set(SDL2_net_FRAMEWORK "${SDL2_net_LIBRARY}")
+	# Move up in the directory tree as required to get the framework directory.
+	while("${SDL2_net_FRAMEWORK}" MATCHES "(/[^/]+)*.framework(/.*)$" AND NOT "${SDL2_net_FRAMEWORK}" MATCHES "(/[^/]+)*.framework$")
+		get_filename_component(SDL2_net_FRAMEWORK "${SDL2_net_FRAMEWORK}" DIRECTORY)
+	endwhile()
+	if("${SDL2_net_FRAMEWORK}" MATCHES "(/[^/]+)*.framework$")
+		set(SDL2_net_FRAMEWORK_NAME ${CMAKE_MATCH_1})
+		# If we found a framework, do a search for the header ahead of time that will be more likely to get the framework header.
+		find_path(SDL2_net_INCLUDE_DIR
+			NAMES
+			SDL_net.h 
+			HINTS
+			"${SDL2_net_FRAMEWORK}/Headers/")
+	else()
+		# For some reason we couldn't get the framework directory itself.
+		# Shouldn't happen, but might if something is weird.
+		unset(SDL2_net_FRAMEWORK)
+	endif()
+endif()
+
+find_path(SDL2_net_INCLUDE_DIR
+	NAMES
+	SDL_net.h 
+	HINTS
+	${SDL2_net_INCLUDE_HINTS}
+	PATHS
+	${SDL2_net_ROOT_DIR}
+	ENV SDL2DIR
+	PATH_SUFFIXES include include/sdl2 include/SDL2 SDL2)
+
+if(WIN32 AND SDL2_net_LIBRARY)
+	find_file(SDL2_net_RUNTIME_LIBRARY
+		NAMES
+		SDL2_net.dll
+		libSDL2_net.dll
+		HINTS
+		${SDL2_net_LIB_HINTS}
+		PATHS
+		${SDL2_net_ROOT_DIR}
+		ENV SDL2DIR
+		PATH_SUFFIXES bin lib ${SDL2_net_LIB_PATH_SUFFIX})
+endif()
+
+if(MINGW AND NOT SDL2_netPC_FOUND)
+	find_library(SDL2_net_MINGW_LIBRARY mingw32)
+	find_library(SDL2_net_MWINDOWS_LIBRARY mwindows)
+endif()
+
+if(SDL2_net_PREFIX)
+	# Restore things the way they used to be.
+	set(CMAKE_PREFIX_PATH ${SDL2_net_ORIGPREFIXPATH})
+endif()
+
+# handle the QUIETLY and REQUIRED arguments and set QUATLIB_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SDL2_net
+	DEFAULT_MSG
+	SDL2_net_LIBRARY
+	SDL2_net_INCLUDE_DIR
+	${SDL2_net_EXTRA_REQUIRED})
+
+if(SDL2_net_FOUND)
+	if(NOT TARGET SDL2::SDL2_net)
+		# Create SDL2::SDL2_net
+		if(WIN32 AND SDL2_net_RUNTIME_LIBRARY)
+			set(SDL2_net_DYNAMIC TRUE)
+			add_library(SDL2::SDL2_net SHARED IMPORTED)
+			set_target_properties(SDL2::SDL2_net
+				PROPERTIES
+				IMPORTED_IMPLIB "${SDL2_net_LIBRARY}"
+				IMPORTED_LOCATION "${SDL2_net_RUNTIME_LIBRARY}"
+				INTERFACE_INCLUDE_DIRECTORIES "${SDL2_net_INCLUDE_DIR}"
+			)
+		else()
+			add_library(SDL2::SDL2_net UNKNOWN IMPORTED)
+			if(SDL2_net_FRAMEWORK AND SDL2_net_FRAMEWORK_NAME)
+				# Handle the case that SDL2_net is a framework and we were able to decompose it above.
+				set_target_properties(SDL2::SDL2_net PROPERTIES
+					IMPORTED_LOCATION "${SDL2_net_FRAMEWORK}/${SDL2_net_FRAMEWORK_NAME}")
+			elseif(_sdl2_framework AND SDL2_net_LIBRARY MATCHES "(/[^/]+)*.framework$")
+				# Handle the case that SDL2_net is a framework and SDL_LIBRARY is just the framework itself.
+
+				# This takes the basename of the framework, without the extension,
+				# and sets it (as a child of the framework) as the imported location for the target.
+				# This is the library symlink inside of the framework.
+				set_target_properties(SDL2::SDL2_net PROPERTIES
+					IMPORTED_LOCATION "${SDL2_net_LIBRARY}/${CMAKE_MATCH_1}")
+			else()
+				# Handle non-frameworks (including non-Mac), as well as the case that we're given the library inside of the framework
+				set_target_properties(SDL2::SDL2_net PROPERTIES
+					IMPORTED_LOCATION "${SDL2_net_LIBRARY}")
+			endif()
+			set_target_properties(SDL2::SDL2_net
+				PROPERTIES
+				INTERFACE_INCLUDE_DIRECTORIES "${SDL2_net_INCLUDE_DIR}"
+			)
+		endif()
+	endif()
+	mark_as_advanced(SDL2_net_ROOT_DIR)
+endif()
+
+mark_as_advanced(SDL2_net_LIBRARY
+	SDL2_net_RUNTIME_LIBRARY
+	SDL2_net_INCLUDE_DIR
+	SDL2_net_SDLMAIN_LIBRARY
+	SDL2_net_COCOA_LIBRARY
+	SDL2_net_MINGW_LIBRARY
+	SDL2_net_MWINDOWS_LIBRARY)
+
+find_package(SDL2 REQUIRED)
+set_property(TARGET SDL2::SDL2_net APPEND PROPERTY
+	INTERFACE_LINK_LIBRARIES SDL2::SDL2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,12 @@ if(NOT NONET)
   option(DEVILUTIONX_SYSTEM_LIBSODIUM "Use system-provided libsodium" ON)
   cmake_dependent_option(DEVILUTIONX_STATIC_LIBSODIUM "Link static libsodium" OFF
                         "DEVILUTIONX_SYSTEM_LIBSODIUM AND NOT DIST" ON)
+
+  if(NOT DISABLE_TCP)
+    option(DEVILUTIONX_SYSTEM_SDL_NET "Use system-provided SDL_net" ON)
+    cmake_dependent_option(DEVILUTIONX_STATIC_SDL_NET "Link static SDL_net" OFF
+                          "DEVILUTIONX_SYSTEM_SDL_NET AND NOT DIST" ON)
+  endif()
 endif()
 
 option(DEVILUTIONX_SYSTEM_LIBFMT "Use system-provided libfmt" ON)
@@ -234,6 +240,11 @@ endif()
 if(USE_SDL1)
   find_package(SDL REQUIRED)
   find_package(SDL_ttf REQUIRED)
+  if(NOT NONET AND NOT DISABLE_TCP AND DEVILUTIONX_SYSTEM_SDL_NET)
+    find_package(SDL_net REQUIRED)
+    add_library(SDL_NET_LIBRARY INTERFACE)
+    target_link_libraries(SDL_NET_LIBRARY INTERFACE ${SDL_NET_LIBRARY})
+  endif()
   include_directories(${SDL_INCLUDE_DIR})
 else()
   find_package(SDL2 REQUIRED)
@@ -258,10 +269,13 @@ else()
     add_library(SDL2::SDL2 ALIAS SDL2_lib)
   endif()
   find_package(SDL2_ttf REQUIRED)
+  if(NOT NONET AND NOT DISABLE_TCP AND DEVILUTIONX_SYSTEM_SDL_NET)
+    find_package(SDL2_net REQUIRED)
+  endif()
 endif()
 
-if(NOT NONET AND NOT DISABLE_TCP)
-  add_subdirectory(3rdParty/asio)
+if(NOT NONET AND NOT DISABLE_TCP AND NOT DEVILUTIONX_SYSTEM_SDL_NET)
+  add_subdirectory(3rdParty/SDL_net)
 endif()
 
 add_library(smacker STATIC
@@ -590,9 +604,6 @@ target_link_libraries(libdevilutionx PUBLIC
   simpleini)
 
 if(NOT NONET)
-  if(NOT DISABLE_TCP)
-    target_link_libraries(libdevilutionx PUBLIC asio)
-  endif()
   target_link_libraries(libdevilutionx PUBLIC sodium)
 endif()
 
@@ -600,10 +611,6 @@ target_link_libraries(libdevilutionx PUBLIC fmt::fmt)
 
 genex_for_option(DEBUG)
 target_compile_definitions(libdevilutionx PUBLIC "$<${DEBUG_GENEX}:_DEBUG>")
-
-if(NOT NONET AND NOT DISABLE_TCP)
-  target_compile_definitions(libdevilutionx PUBLIC ASIO_STANDALONE)
-endif()
 
 # Defines without value
 foreach(
@@ -710,12 +717,18 @@ if(USE_SDL1)
   target_link_libraries(libdevilutionx PUBLIC
     ${SDL_TTF_LIBRARY}
     ${SDL_LIBRARY})
+  if(NOT NONET AND NOT DISABLE_TCP)
+    target_link_libraries(libdevilutionx PUBLIC SDL_NET_LIBRARY)
+  endif()
   target_compile_definitions(libdevilutionx PUBLIC USE_SDL1)
 else()
   target_link_libraries(libdevilutionx PUBLIC
     SDL2::SDL2
     ${SDL2_MAIN}
     SDL2::SDL2_ttf)
+  if(NOT NONET AND NOT DISABLE_TCP)
+    target_link_libraries(libdevilutionx PUBLIC SDL2::SDL2_net)
+  endif()
 endif()
 
 if(NOT NOSOUND)

--- a/Packaging/windows/mingw-prep.sh
+++ b/Packaging/windows/mingw-prep.sh
@@ -9,6 +9,8 @@ wget https://www.libsdl.org/release/SDL2-devel-2.0.14-mingw.tar.gz
 tar -xzf SDL2-devel-2.0.14-mingw.tar.gz
 wget https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.15-mingw.tar.gz
 tar -xzf SDL2_ttf-devel-2.0.15-mingw.tar.gz
+wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-devel-2.0.1-mingw.tar.gz
+tar -xzf SDL2_net-devel-2.0.1-mingw.tar.gz
 sudo cp -r SDL2*/i686-w64-mingw32 /usr
 
 wget https://github.com/jedisct1/libsodium/releases/download/1.0.18-RELEASE/libsodium-1.0.18-mingw.tar.gz

--- a/Packaging/windows/mingw-prep64.sh
+++ b/Packaging/windows/mingw-prep64.sh
@@ -9,6 +9,8 @@ wget https://www.libsdl.org/release/SDL2-devel-2.0.14-mingw.tar.gz
 tar -xzf SDL2-devel-2.0.14-mingw.tar.gz
 wget https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.15-mingw.tar.gz
 tar -xzf SDL2_ttf-devel-2.0.15-mingw.tar.gz
+wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-devel-2.0.1-mingw.tar.gz
+tar -xzf SDL2_net-devel-2.0.1-mingw.tar.gz
 sudo cp -r SDL2*/x86_64-w64-mingw32 /usr
 
 wget https://github.com/jedisct1/libsodium/releases/download/1.0.18-RELEASE/libsodium-1.0.18-mingw.tar.gz

--- a/Source/appfat.h
+++ b/Source/appfat.h
@@ -6,12 +6,16 @@
 #pragma once
 
 #include <SDL.h>
+#if !defined(NONET) && !defined(DISABLE_TCP)
+#include <SDL_net.h>
+#endif
 
 #include "utils/attributes.h"
 
 namespace devilution {
 
 #define ErrSdl() ErrDlg("SDL Error", SDL_GetError(), __FILE__, __LINE__)
+#define ErrSdlNet() ErrDlg("SDL_net Error", SDLNet_GetError(), __FILE__, __LINE__)
 
 #undef assert
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -546,7 +546,6 @@ static void SaveOptions()
 	setIniInt("Game", "Show Monster Type", sgOptions.Gameplay.bShowMonsterType);
 	setIniInt("Game", "Disable Crippling Shrines", sgOptions.Gameplay.bDisableCripplingShrines);
 
-	setIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress);
 	setIniInt("Network", "Port", sgOptions.Network.nPort);
 	setIniValue("Network", "Previous Host", sgOptions.Network.szPreviousHost);
 
@@ -631,7 +630,6 @@ static void LoadOptions()
 	sgOptions.Gameplay.bShowMonsterType = getIniBool("Game", "Show Monster Type", false);
 	sgOptions.Gameplay.bDisableCripplingShrines = getIniBool("Game", "Disable Crippling Shrines", false);
 
-	getIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress, sizeof(sgOptions.Network.szBindAddress), "0.0.0.0");
 	sgOptions.Network.nPort = getIniInt("Network", "Port", 6112);
 	getIniValue("Network", "Previous Host", sgOptions.Network.szPreviousHost, sizeof(sgOptions.Network.szPreviousHost), "");
 
@@ -756,6 +754,9 @@ static void diablo_deinit()
 	}
 #ifndef NOSOUND
 	Aulib::quit();
+#endif
+#if !defined(NONET) && !defined(DISABLE_TCP)
+	SDLNet_Quit();
 #endif
 	if (was_ui_init)
 		UiDestroy();

--- a/Source/dvlnet/tcp_client.cpp
+++ b/Source/dvlnet/tcp_client.cpp
@@ -111,6 +111,8 @@ bool tcp_client::SNetLeaveGame(int type)
 {
 	auto ret = base::SNetLeaveGame(type);
 	poll();
+	SDLNet_TCP_Close(socket);
+	SDLNet_FreeSocketSet(socketSet);
 	if (local_server != nullptr)
 		local_server->close();
 	return ret;
@@ -123,7 +125,6 @@ std::string tcp_client::make_default_gamename()
 
 tcp_client::~tcp_client()
 {
-	SDLNet_FreeSocketSet(socketSet);
 }
 
 } // namespace net

--- a/Source/dvlnet/tcp_client.h
+++ b/Source/dvlnet/tcp_client.h
@@ -2,10 +2,7 @@
 
 #include <string>
 #include <memory>
-#include <asio/ts/buffer.hpp>
-#include <asio/ts/internet.hpp>
-#include <asio/ts/io_context.hpp>
-#include <asio/ts/net.hpp>
+#include <SDL_net.h>
 
 #include "dvlnet/packet.h"
 #include "dvlnet/frame_queue.h"
@@ -33,14 +30,9 @@ private:
 	frame_queue recv_queue;
 	buffer_t recv_buffer = buffer_t(frame_queue::max_frame_size);
 
-	asio::io_context ioc;
-	asio::ip::tcp::resolver resolver = asio::ip::tcp::resolver(ioc);
-	asio::ip::tcp::socket sock = asio::ip::tcp::socket(ioc);
+	TCPsocket socket;
+	SDLNet_SocketSet socketSet = SDLNet_AllocSocketSet(1);
 	std::unique_ptr<tcp_server> local_server; // must be declared *after* ioc
-
-	void handle_recv(const asio::error_code &error, size_t bytes_read);
-	void start_recv();
-	void handle_send(const asio::error_code &error, size_t bytes_sent);
 };
 
 } // namespace net

--- a/Source/dvlnet/tcp_server.cpp
+++ b/Source/dvlnet/tcp_server.cpp
@@ -281,12 +281,12 @@ void tcp_server::close()
 		if (connection)
 			drop_connection(connection);
 	}
+	SDLNet_FreeSocketSet(socketSet);
 	SDLNet_TCP_Close(socket);
 }
 
 tcp_server::~tcp_server()
 {
-	SDLNet_FreeSocketSet(socketSet);
 }
 
 } // namespace net

--- a/Source/options.h
+++ b/Source/options.h
@@ -126,8 +126,6 @@ struct ControllerOptions {
 };
 
 struct NetworkOptions {
-	/** @brief Optionally bind to a specific network interface. */
-	char szBindAddress[129];
 	/** @brief Most recently entered Hostname in join dialog. */
 	char szPreviousHost[129];
 	/** @brief What network port to use. */

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -147,6 +147,11 @@ bool SpawnWindow(const char *lpWindowName)
 	if (SDL_Init(initFlags) <= -1) {
 		ErrSdl();
 	}
+#if !defined(NONET) && !defined(DISABLE_TCP)
+	if (SDLNet_Init() <= -1) {
+		ErrSdlNet();
+	}
+#endif
 
 #ifndef USE_SDL1
 	if (sgOptions.Controller.szMapping[0] != '\0') {

--- a/Source/utils/display.h
+++ b/Source/utils/display.h
@@ -9,6 +9,9 @@
 #else
 #include "utils/sdl2_backports.h"
 #endif
+#if !defined(NONET) && !defined(DISABLE_TCP)
+#include <SDL_net.h>
+#endif
 
 #include "utils/sdl_ptrs.h"
 #include "utils/ui_fwd.h"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ install:
   - git pull
   - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%
-  - vcpkg install --recurse fmt:x64-windows sdl2:x64-windows sdl2-ttf:x64-windows libsodium:x64-windows
+  - vcpkg install --recurse fmt:x64-windows sdl2:x64-windows sdl2-ttf:x64-windows sdl2-net:x64-windows libsodium:x64-windows
 
 before_build:
   - cmake -G "Visual Studio 16 2019" -A x64 -DNIGHTLY_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake .


### PR DESCRIPTION
Here I was experimenting with replacing ASIO with SDL_net to see if I could get multiplayer working on 3DS. If you mock an empty `net/if.h` header and tweak the settings to turn off NONET and ZeroTier, you can get this to build on 3DS. To actually join a game, you also have to add some keyboard support to some of the menus. However, it crashes when attempting to join a game so there are still some things to iron out.

FYI, 3DS is the whole reason I went through the headache of adding the `3rdParty` build script and the `DEVILUTIONX_SYSTEM_SDL_NET` option. Windows and Linux can both use system dependencies for SDL_net, but 3DS doesn't have one. That's also why the `3rdParty` build script is only designed to work for *nix build environments.

I have tested the build on Windows, Linux, and 3DS. I have done minimal in-game testing on Windows with clients on localhost. This is by no means a comprehensive test, but it does seem to work for this simple case.

---

**Notes:**
* SDL_net has no API call for `setsockopt()`. I think it does have some logic for setting nodelay and reuseaddress on some platforms, but I'm not familiar with what the logic is.
* `SDLNet_TCP_Accept()` doesn't block, but it does generate a debug message when it fails. I think it would be better to use `SDLNet_CheckSockets()`, to avoid generating countless debug messages.
* SDL_net only supports IPv4 and can only bind to 0.0.0.0. This renders the `Bind Address` option in the INI obsolete so I removed it.
* ~I should have also mentioned, the CI checks are going to fail for platforms that build with TCP because there's a new dependency. The build scripts will need to be updated as well.~