### PR TITLE
fix loading screens:

### DIFF
--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -51,11 +51,8 @@ static Cutscenes PickCutscene(interface_mode uMsg)
 	case WM_DIABPREVLVL:
 	case WM_DIABTOWNWARP:
 	case WM_DIABTWARPUP: {
-		int lvl = currlevel;
-		if (uMsg == WM_DIABTWARPUP)
-			lvl = plr[myplr].plrlevel;
-
-		if (lvl == 1 && uMsg == WM_DIABPREVLVL)
+		int lvl = plr[myplr].plrlevel;
+		if (lvl == 1 && uMsg == WM_DIABNEXTLVL)
 			return CutTown;
 		if (lvl == 16 && uMsg == WM_DIABNEXTLVL)
 			return CutGate;


### PR DESCRIPTION
I guess currlevel gets updated at a later point, so during transitions between levels, currlevel holds old level and plr[myplr].plrlevel has new
Resolves https://github.com/diasurgical/devilutionX/issues/2097