### PR TITLE
Fix stray lights on some saves

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2029,6 +2029,8 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 	UpdateMonsterLights();
 	UnstuckChargers();
 	if (leveltype != DTYPE_TOWN) {
+		memcpy(dLight, dPreLight, sizeof(dLight));                                   // resets the light on entering a level to get rid of incorrect light
+		ChangeLightXY(Players[MyPlayerId]._plid, Players[MyPlayerId].position.tile); // forces player light refresh
 		ProcessLightList();
 		ProcessVisionList();
 	}

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2212,6 +2212,9 @@ void LoadLevel()
 				AutomapView[i][j] = automapView == MAP_EXP_OLD ? MAP_EXP_SELF : automapView;
 			}
 		}
+		//no need to load dLight, we can recreate it accurately from LightList
+		memcpy(dLight, dPreLight, sizeof(dLight));                                   // resets the light on entering a level to get rid of incorrect light
+		ChangeLightXY(Players[MyPlayerId]._plid, Players[MyPlayerId].position.tile); // forces player light refresh
 	}
 
 	if (gbIsHellfireSaveGame != gbIsHellfire) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14297035/120408181-c383eb00-c34e-11eb-8b3a-399d7c8a45f4.png)
[single_30.zip](https://github.com/diasurgical/devilutionX/files/6581292/single_30.zip)

That's how it looks without the fix. At this point I really don't know what's causing these weird light artifacts but it's not something I'd worry about considering we support all these vanilla/hellfire conversions and we fixed some light bugs.

Resetting all lights on loading/entering a level solves this issue once and for all.