### PR TITLE
fix wrong sound/message

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -920,7 +920,7 @@ bool Plr2PlrMHit(int pnum, int p, int mindam, int maxdam, int dist, int mtype, b
 			dam -= (dam * resper) / 100;
 			if (pnum == myplr)
 				NetSendCmdDamage(true, p, dam);
-			plr[pnum].Say(HeroSpeech::ArghClang);
+			plr[p].Say(HeroSpeech::ArghClang);
 			return true;
 		}
 		if (blkper < blk) {

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -271,7 +271,7 @@ static void multi_player_left_msg(int pnum, bool left)
 				pszFmt = _("Player '{:s}' dropped due to timeout");
 				break;
 			}
-			EventPlrMsg(pszFmt, plr[pnum]._pName);
+			EventPlrMsg(fmt::format(pszFmt, plr[pnum]._pName).c_str());
 		}
 		plr[pnum].plractive = false;
 		plr[pnum]._pName[0] = '\0';


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14297035/120883326-d7448100-c5dc-11eb-9b47-bf49e3aac4ac.png)
+ sounds for nonphysical damage were using attacker's class, not the player being hit