### PR TITLE
Close TCP client socket when leaving game

### DIFF
--- a/Source/dvlnet/tcp_client.cpp
+++ b/Source/dvlnet/tcp_client.cpp
@@ -126,6 +126,7 @@ bool tcp_client::SNetLeaveGame(int type)
 	poll();
 	if (local_server != nullptr)
 		local_server->close();
+	sock.close();
 	return ret;
 }
 


### PR DESCRIPTION
This is just something that's been bugging me while ironing out the networking on the 3DS. The game never explicitly cleans up client sockets and so connections tend to remain open until the user enters a new game, the connection times out, or the user quits the game. This calls close on the client socket explicitly when the player leaves their game to clean up the connection as soon as it's no longer needed.