### PR TITLE
Item Highlight transparency

### DIFF
--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -87,34 +87,34 @@ void UnsafeDrawVerticalLine(const CelOutputBuffer &out, Point from, int height, 
 	}
 }
 
-static void DrawHalfTransparentBlendedRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height)
+static void DrawTransparentBlendedRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height, int colorIndex)
 {
 	BYTE *pix = out.at(sx, sy);
 
 	for (int row = 0; row < height; row++) {
 		for (int col = 0; col < width; col++) {
-			*pix = paletteTransparencyLookup[0][*pix];
+			*pix = paletteTransparencyLookup[colorIndex][*pix];
 			pix++;
 		}
 		pix += out.pitch() - width;
 	}
 }
 
-static void DrawHalfTransparentStippledRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height)
+static void DrawTransparentStippledRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height, int colorIndex)
 {
 	BYTE *pix = out.at(sx, sy);
 
 	for (int row = 0; row < height; row++) {
 		for (int col = 0; col < width; col++) {
 			if (((row & 1) != 0 && (col & 1) != 0) || ((row & 1) == 0 && (col & 1) == 0))
-				*pix = 0;
+				*pix = colorIndex;
 			pix++;
 		}
 		pix += out.pitch() - width;
 	}
 }
 
-void DrawHalfTransparentRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height)
+void DrawTransparentRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height, int colorIndex)
 {
 	if (sx + width < 0)
 		return;
@@ -140,10 +140,15 @@ void DrawHalfTransparentRectTo(const CelOutputBuffer &out, int sx, int sy, int w
 	}
 
 	if (sgOptions.Graphics.bBlendedTransparancy) {
-		DrawHalfTransparentBlendedRectTo(out, sx, sy, width, height);
+		DrawTransparentBlendedRectTo(out, sx, sy, width, height, colorIndex);
 	} else {
-		DrawHalfTransparentStippledRectTo(out, sx, sy, width, height);
+		DrawTransparentStippledRectTo(out, sx, sy, width, height, colorIndex);
 	}
+}
+
+void DrawHalfTransparentRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height)
+{
+	DrawTransparentRectTo(out, sx, sy, width, height, 0);
 }
 
 /**

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -530,6 +530,20 @@ void UnsafeDrawVerticalLine(const CelOutputBuffer &out, Point from, int height, 
 void DrawHalfTransparentRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height);
 
 /**
+ * Draws a transparent rectangle by blacking out odd pixels on odd lines,
+ * even pixels on even lines.
+ *
+ * @brief Render a colored transparent rectangle
+ * @param out Target buffer
+ * @param sx Screen coordinate
+ * @param sy Screen coordinate
+ * @param width Rectangle width
+ * @param height Rectangle height
+ * @param colorIndex Color index from current palette
+ */
+void DrawTransparentRectTo(const CelOutputBuffer &out, int sx, int sy, int width, int height, int colorIndex);
+
+/**
  * @brief Calculate the best fit direction between two points
  * @param start Tile coordinate
  * @param destination Tile coordinate

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -30,8 +30,8 @@ bool invertHighlightToggle = false;
 
 const int borderX = 4;   // minimal horizontal space between labels
 const int borderY = 2;   // minimal vertical space between labels
-const int marginX = 2; // horizontal margins between text and edges of the label
-const int marginY = 1; // vertical margins between text and edges of the label
+const int marginX = 6; // horizontal margins between text and edges of the label
+const int marginY = 2; // vertical margins between text and edges of the label
 const int height = 11 + marginY * 2; // going above 13 scatters labels of items that are next to each other
 
 } // namespace
@@ -153,7 +153,7 @@ void DrawItemNameLabels(const CelOutputBuffer &out)
 			}
 		}
 		if (pcursitem == label.id)
-			FillRect(out, label.pos.x, label.pos.y - height + marginY, label.width, height, PAL8_BLUE + 6);
+			DrawTransparentRectTo(out, label.pos.x, label.pos.y - height + marginY, label.width, height, PAL8_BLUE + 5);
 		else
 			DrawHalfTransparentRectTo(out, label.pos.x, label.pos.y - height + marginY, label.width, height);
 		DrawString(out, label.text.c_str(), { label.pos.x + marginX, label.pos.y, label.width, height }, itm.getTextColor());


### PR DESCRIPTION
This PR just tweaks the item highlight appearance a little, increasing margin/padding and turning the rectangle "transparent" when the mouse is over it.

Proposed Highlight:
![highlight-pr](https://user-images.githubusercontent.com/1824878/121284113-a9985a00-c8b2-11eb-91ed-800f7d5ac541.png)

Original Highlight:
![highlight-original](https://user-images.githubusercontent.com/1824878/121284232-dfd5d980-c8b2-11eb-8def-8db085f716ae.png)

Edit: Ok, it's not really transparent but I still think it looks better than the current opaque rectangle.