### PR TITLE
fix reconstructed note + HasItem/RemoveInvItem combo rewritten into TryRemoveInvItemById

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1478,39 +1478,24 @@ static void CheckBookLevel(PlayerStruct &player)
 static void CheckNaKrulNotes(PlayerStruct &player)
 {
 	int idx = player.HoldItem.IDidx;
+	_item_indexes notes[] = { IDI_NOTE1, IDI_NOTE2, IDI_NOTE3 };
 
 	if (idx != IDI_NOTE1 && idx != IDI_NOTE2 && idx != IDI_NOTE3) {
 		return;
 	}
 
-	int n1;
-	if (idx != IDI_NOTE1 && !player.HasItem(IDI_NOTE1, &n1)) {
-		return;
-	}
-
-	int n2;
-	if (idx != IDI_NOTE2 && !player.HasItem(IDI_NOTE2, &n2)) {
-		return;
-	}
-
-	int n3;
-	if (idx != IDI_NOTE3 && !player.HasItem(IDI_NOTE3, &n3)) {
-		return;
+	for (auto note : notes) {
+		if (idx != note && !player.HasItem(note)) {
+			return; // the player doesn't have all notes
+		}
 	}
 
 	plr[myplr].Say(HeroSpeech::JustWhatIWasLookingFor, 10);
 
-	if (idx != IDI_NOTE1) {
-		player.HasItem(IDI_NOTE1, &n1);
-		player.RemoveInvItem(n1);
-	}
-	if (idx != IDI_NOTE2) {
-		player.HasItem(IDI_NOTE2, &n2);
-		player.RemoveInvItem(n2);
-	}
-	if (idx != IDI_NOTE3) {
-		player.HasItem(IDI_NOTE3, &n3);
-		player.RemoveInvItem(n3);
+	for (auto note : notes) {
+		if (idx != note) {
+			player.TryRemoveInvItemById(note);
+		}
 	}
 
 	int itemNum = itemactive[0];

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1501,12 +1501,15 @@ static void CheckNaKrulNotes(PlayerStruct &player)
 	plr[myplr].Say(HeroSpeech::JustWhatIWasLookingFor, 10);
 
 	if (idx != IDI_NOTE1) {
+		player.HasItem(IDI_NOTE1, &n1);
 		player.RemoveInvItem(n1);
 	}
 	if (idx != IDI_NOTE2) {
+		player.HasItem(IDI_NOTE2, &n2);
 		player.RemoveInvItem(n2);
 	}
 	if (idx != IDI_NOTE3) {
+		player.HasItem(IDI_NOTE3, &n3);
 		player.RemoveInvItem(n3);
 	}
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -5348,16 +5348,15 @@ void TalktoMonster(int i)
 	int pnum = Monst->_menemy;
 	Monst->_mmode = MM_TALK;
 	if (Monst->_mAi == AI_SNOTSPIL || Monst->_mAi == AI_LACHDAN) {
-		int itm;
-		if (QuestStatus(Q_LTBANNER) && quests[Q_LTBANNER]._qvar1 == 2 && plr[pnum].HasItem(IDI_BANNER, &itm)) {
-			plr[pnum].RemoveInvItem(itm);
-			quests[Q_LTBANNER]._qactive = QUEST_DONE;
-			Monst->mtalkmsg = TEXT_BANNER12;
-			Monst->_mgoal = MGOAL_INQUIRING;
+		if (QuestStatus(Q_LTBANNER) && quests[Q_LTBANNER]._qvar1 == 2) {
+			if (plr[pnum].TryRemoveInvItemById(IDI_BANNER)) {
+				quests[Q_LTBANNER]._qactive = QUEST_DONE;
+				Monst->mtalkmsg = TEXT_BANNER12;
+				Monst->_mgoal = MGOAL_INQUIRING;
+			}
 		}
 		if (QuestStatus(Q_VEIL) && Monst->mtalkmsg >= TEXT_VEIL9) {
-			if (plr[pnum].HasItem(IDI_GLDNELIX, &itm)) {
-				plr[pnum].RemoveInvItem(itm);
+			if (plr[pnum].TryRemoveInvItemById(IDI_GLDNELIX)) {
 				Monst->mtalkmsg = TEXT_VEIL11;
 				Monst->_mgoal = MGOAL_INQUIRING;
 			}

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2221,32 +2221,32 @@ static DWORD On_PLAYER_JOINLEVEL(TCmd *pCmd, int pnum)
 	if (gbBufferMsgs == 1)
 		msg_send_packet(pnum, p, sizeof(*p));
 	else {
-		plr[pnum]._pLvlChanging = false;
-		if (plr[pnum]._pName[0] != 0 && !plr[pnum].plractive) {
-			ResetPlayerGFX(plr[pnum]);
-			plr[pnum].plractive = true;
+		player._pLvlChanging = false;
+		if (player._pName[0] != 0 && !player.plractive) {
+			ResetPlayerGFX(player);
+			player.plractive = true;
 			gbActivePlayers++;
-			EventPlrMsg(fmt::format(_("Player '{:s}' (level {:d}) just joined the game"), plr[pnum]._pName, plr[pnum]._pLevel).c_str());
+			EventPlrMsg(fmt::format(_("Player '{:s}' (level {:d}) just joined the game"), player._pName, player._pLevel).c_str());
 		}
 
-		if (plr[pnum].plractive && myplr != pnum) {
-			plr[pnum].position.tile = { p->x, p->y };
-			plr[pnum].plrlevel = p->wParam1;
-			ResetPlayerGFX(plr[pnum]);
-			if (currlevel == plr[pnum].plrlevel) {
+		if (player.plractive && myplr != pnum) {
+			player.position.tile = { p->x, p->y };
+			player.plrlevel = p->wParam1;
+			ResetPlayerGFX(player);
+			if (currlevel == player.plrlevel) {
 				SyncInitPlr(pnum);
-				if ((plr[pnum]._pHitPoints >> 6) > 0)
+				if ((player._pHitPoints >> 6) > 0)
 					StartStand(pnum, DIR_S);
 				else {
-					plr[pnum]._pgfxnum = 0;
-					plr[pnum]._pmode = PM_DEATH;
-					NewPlrAnim(plr[pnum], player_graphic::Death, DIR_S, plr[pnum]._pDFrames, 1);
-					plr[pnum].AnimInfo.CurrentFrame = plr[pnum].AnimInfo.NumberOfFrames - 1;
-					dFlags[plr[pnum].position.tile.x][plr[pnum].position.tile.y] |= BFLAG_DEAD_PLAYER;
+					player._pgfxnum = 0;
+					player._pmode = PM_DEATH;
+					NewPlrAnim(player, player_graphic::Death, DIR_S, player._pDFrames, 1);
+					player.AnimInfo.CurrentFrame = player.AnimInfo.NumberOfFrames - 1;
+					dFlags[player.position.tile.x][player.position.tile.y] |= BFLAG_DEAD_PLAYER;
 				}
 
-				plr[pnum]._pvid = AddVision(plr[pnum].position.tile, plr[pnum]._pLightRad, pnum == myplr);
-				plr[pnum]._plid = NO_LIGHT;
+				player._pvid = AddVision(player.position.tile, player._pLightRad, pnum == myplr);
+				player._plid = NO_LIGHT;
 			}
 		}
 	}

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -720,7 +720,7 @@ bool NetInit(bool bSinglePlayer)
 		memset(sgbPlayerLeftGameTbl, 0, sizeof(sgbPlayerLeftGameTbl));
 		memset(sgdwPlayerLeftReasonTbl, 0, sizeof(sgdwPlayerLeftReasonTbl));
 		memset(sgbSendDeltaTbl, 0, sizeof(sgbSendDeltaTbl));
-		memset(plr, 0, sizeof(plr));
+		plr[0].Reset();
 		memset(sgwPackPlrOffsetTbl, 0, sizeof(sgwPackPlrOffsetTbl));
 		SNetSetBasePlayer(0);
 		if (bSinglePlayer) {

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3291,12 +3291,10 @@ void OperatePedistal(int pnum, int i)
 		return;
 	}
 
-	int iv;
-	if (object[i]._oVar6 == 3 || !plr[pnum].HasItem(IDI_BLDSTONE, &iv)) {
+	if (object[i]._oVar6 == 3 || !plr[pnum].TryRemoveInvItemById(IDI_BLDSTONE)) {
 		return;
 	}
 
-	plr[pnum].RemoveInvItem(iv);
 	object[i]._oAnimFrame++;
 	object[i]._oVar6++;
 	if (object[i]._oVar6 == 1) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -265,6 +265,16 @@ void PlayerStruct::RemoveInvItem(int iv, bool calcScrolls)
 		CalcScrolls();
 }
 
+bool PlayerStruct::TryRemoveInvItemById(int item)
+{
+	int idx;
+	if (HasItem(item, &idx)) {
+		RemoveInvItem(idx);
+		return true;
+	}
+	return false;
+}
+
 void PlayerStruct::RemoveSpdBarItem(int iv)
 {
 	SpdList[iv]._itype = ITYPE_NONE;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -515,7 +515,7 @@ void InitPlayerGFX(int pnum)
 		player._pgfxnum = 0;
 		LoadPlrGFX(player, player_graphic::Death);
 	} else {
-		for (int i = 0; i < enum_size<player_graphic>::value; i++) {
+		for (size_t i = 0; i < enum_size<player_graphic>::value; i++) {
 			auto graphic = static_cast<player_graphic>(i);
 			if (graphic == player_graphic::Death)
 				continue;
@@ -3657,7 +3657,7 @@ void CheckPlrSpell()
 
 void SyncPlrAnim(int pnum)
 {
-	int dir, sType;
+	int sType;
 
 	if ((DWORD)pnum >= MAX_PLRS) {
 		app_fatal("SyncPlrAnim: illegal player %i", pnum);

--- a/Source/player.h
+++ b/Source/player.h
@@ -146,15 +146,15 @@ enum player_weapon_type : uint8_t {
 	WT_RANGED,
 };
 
-/*
+/**
  * @brief Contains Data (CelSprites) for a player graphic (player_graphic)
  */
 struct PlayerAnimationData {
-	/*
+	/**
 	 * @brief CelSprites for the different directions
 	 */
 	std::array<std::optional<CelSprite>, 8> CelSpritesForDirections;
-	/*
+	/**
 	 * @brief Raw Data (binary) of the CL2 file.
 	 *        Is referenced from CelSprite in CelSpritesForDirections
 	 */
@@ -178,7 +178,7 @@ struct PlayerStruct {
 	ActorPosition position;
 	Direction _pdir; // Direction faced by player (direction enum)
 	int _pgfxnum;    // Bitmask indicating what variant of the sprite the player is using. Lower byte define weapon (anim_weapon_id) and higher values define armour (starting with anim_armor_id)
-	/*
+	/**
 	 * @brief Contains Information for current Animation
 	 */
 	AnimationInfo AnimInfo;
@@ -249,7 +249,7 @@ struct PlayerStruct {
 	int deathFrame;
 	bool _pLvlVisited[NUMLEVELS];
 	bool _pSLvlVisited[NUMLEVELS]; // only 10 used
-	/*
+	/**
 	 * @brief Contains Data (Sprites) for the different Animations
 	 */
 	std::array<PlayerAnimationData, enum_size<player_graphic>::value> AnimationData;
@@ -305,12 +305,17 @@ struct PlayerStruct {
 	bool HasItem(int item, int *idx = nullptr) const;
 
 	/**
-     * @brief Remove an item from player inventory
-     * @param pnum Player index
-     * @param iv invList index of item to be removed
-     * @param calcScrolls If true, CalcScrolls() gets called after removing item
-     */
+	 * @brief Remove an item from player inventory
+	 * @param iv invList index of item to be removed
+	 * @param calcScrolls If true, CalcScrolls() gets called after removing item
+	 */
 	void RemoveInvItem(int iv, bool calcScrolls = true);
+
+	/**
+	 * @brief Remove an item from player inventory and return true if the player has the item, return false otherwise
+	 * @param item IDidx of item to be removed
+	 */
+	bool TryRemoveInvItemById(int item);
 
 	void RemoveSpdBarItem(int iv);
 
@@ -387,12 +392,12 @@ struct PlayerStruct {
 
 	/**
 	 * @brief Is the player currently walking?
-	*/
+	 */
 	bool IsWalking() const;
 
 	/**
 	 * @brief Resets all Data of the current PlayerStruct
-	*/
+	 */
 	void Reset();
 };
 

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -222,7 +222,7 @@ void InitDrunk(TownerStruct &towner, const TownerInit &initData)
 		 1, 1, 1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 11, 11, 11, 12, 13, 14, 15, 16, 17, 18, 18,
 		 1, 1, 1, 18, 17, 16, 15, 14, 13, 12, 11, 10, 11, 12, 13, 14, 15, 16, 17, 18,
 		 1, 2, 3,  4,  5,  5,  5,  4,  3,  2
-		// clang-format off
+		// clang-format on
 	};
 	towner.animOrder = AnimOrder;
 	towner.animOrderSize = sizeof(AnimOrder);
@@ -528,7 +528,7 @@ void TalkToHealer(PlayerStruct &player, TownerStruct &healer)
 	if (quests[Q_MUSHROOM]._qactive == QUEST_ACTIVE) {
 		if (quests[Q_MUSHROOM]._qvar1 >= QS_MUSHGIVEN && quests[Q_MUSHROOM]._qvar1 < QS_BRAINGIVEN && player.HasItem(IDI_BRAIN, &i)) {
 			player.RemoveInvItem(i);
-			SpawnQuestItem(IDI_SPECELIX, healer.position + Point{0, 1}, 0, 0);
+			SpawnQuestItem(IDI_SPECELIX, healer.position + Point { 0, 1 }, 0, 0);
 			InitQTextMsg(TEXT_MUSH4);
 			quests[Q_MUSHROOM]._qvar1 = QS_BRAINGIVEN;
 			Qtalklist[TOWN_HEALER][Q_MUSHROOM] = TEXT_NONE;
@@ -640,7 +640,7 @@ void TalkToFarmer(PlayerStruct &player, TownerStruct &farmer)
 		quests[Q_FARMER]._qvar1 = 1;
 		quests[Q_FARMER]._qlog = true;
 		quests[Q_FARMER]._qmsg = TEXT_FARMER1;
-		SpawnRuneBomb(farmer.position + Point{1, 0});
+		SpawnRuneBomb(farmer.position + Point { 1, 0 });
 		if (gbIsMultiplayer)
 			NetSendCmdQuest(true, Q_FARMER);
 		break;
@@ -649,7 +649,7 @@ void TalkToFarmer(PlayerStruct &player, TownerStruct &farmer)
 		break;
 	case QUEST_DONE:
 		InitQTextMsg(TEXT_FARMER4);
-		SpawnRewardItem(IDI_AURIC, farmer.position + Point{1, 0});
+		SpawnRewardItem(IDI_AURIC, farmer.position + Point { 1, 0 });
 		quests[Q_FARMER]._qactive = QUEST_HIVE_DONE;
 		quests[Q_FARMER]._qlog = false;
 		if (gbIsMultiplayer)
@@ -735,7 +735,7 @@ void TalkToCowFarmer(PlayerStruct &player, TownerStruct &cowFarmer)
 		quests[Q_JERSEY]._qvar1 = 1;
 		quests[Q_JERSEY]._qmsg = TEXT_JERSEY4;
 		quests[Q_JERSEY]._qlog = true;
-		SpawnRuneBomb(cowFarmer.position + Point{1, 0});
+		SpawnRuneBomb(cowFarmer.position + Point { 1, 0 });
 		if (gbIsMultiplayer)
 			NetSendCmdQuest(true, Q_JERSEY);
 		break;

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -354,11 +354,10 @@ void TalkToBarOwner(PlayerStruct &player, TownerStruct &barOwner)
 				InitQTextMsg(TEXT_BANNER2);
 				return;
 			}
-			int i;
-			if (quests[Q_LTBANNER]._qvar2 == 1 && player.HasItem(IDI_BANNER, &i)) {
+
+			if (quests[Q_LTBANNER]._qvar2 == 1 && player.TryRemoveInvItemById(IDI_BANNER)) {
 				quests[Q_LTBANNER]._qactive = QUEST_DONE;
 				quests[Q_LTBANNER]._qvar1 = 3;
-				player.RemoveInvItem(i);
 				SpawnUnique(UITEM_HARCREST, barOwner.position + DIR_SW);
 				InitQTextMsg(TEXT_BANNER3);
 				return;
@@ -401,10 +400,9 @@ void TalkToBlackSmith(PlayerStruct &player, TownerStruct &blackSmith)
 				InitQTextMsg(TEXT_INFRA5);
 				return;
 			}
-			int i;
-			if (quests[Q_ROCK]._qvar2 == 1 && player.HasItem(IDI_ROCK, &i)) {
+
+			if (quests[Q_ROCK]._qvar2 == 1 && player.TryRemoveInvItemById(IDI_ROCK)) {
 				quests[Q_ROCK]._qactive = QUEST_DONE;
-				player.RemoveInvItem(i);
 				SpawnUnique(UITEM_INFRARING, blackSmith.position + DIR_SW);
 				InitQTextMsg(TEXT_INFRA7);
 				return;
@@ -422,10 +420,9 @@ void TalkToBlackSmith(PlayerStruct &player, TownerStruct &blackSmith)
 				InitQTextMsg(TEXT_ANVIL5);
 				return;
 			}
-			int i;
-			if (quests[Q_ANVIL]._qvar2 == 1 && player.HasItem(IDI_ANVIL, &i)) {
+
+			if (quests[Q_ANVIL]._qvar2 == 1 && player.TryRemoveInvItemById(IDI_ANVIL)) {
 				quests[Q_ANVIL]._qactive = QUEST_DONE;
-				player.RemoveInvItem(i);
 				SpawnUnique(UITEM_GRISWOLD, blackSmith.position + DIR_SW);
 				InitQTextMsg(TEXT_ANVIL7);
 				return;
@@ -440,9 +437,7 @@ void TalkToBlackSmith(PlayerStruct &player, TownerStruct &blackSmith)
 void TalkToWitch(PlayerStruct &player, TownerStruct & /*witch*/)
 {
 	if (quests[Q_MUSHROOM]._qactive != QUEST_NOTAVAIL) {
-		int i;
-		if (quests[Q_MUSHROOM]._qactive == QUEST_INIT && player.HasItem(IDI_FUNGALTM, &i)) {
-			player.RemoveInvItem(i);
+		if (quests[Q_MUSHROOM]._qactive == QUEST_INIT && player.TryRemoveInvItemById(IDI_FUNGALTM)) {
 			quests[Q_MUSHROOM]._qactive = QUEST_ACTIVE;
 			quests[Q_MUSHROOM]._qlog = true;
 			quests[Q_MUSHROOM]._qvar1 = QS_TOMEGIVEN;
@@ -451,9 +446,7 @@ void TalkToWitch(PlayerStruct &player, TownerStruct & /*witch*/)
 		}
 		if (quests[Q_MUSHROOM]._qactive == QUEST_ACTIVE) {
 			if (quests[Q_MUSHROOM]._qvar1 >= QS_TOMEGIVEN && quests[Q_MUSHROOM]._qvar1 < QS_MUSHGIVEN) {
-				int i;
-				if (player.HasItem(IDI_MUSHROOM, &i)) {
-					player.RemoveInvItem(i);
+				if (player.TryRemoveInvItemById(IDI_MUSHROOM)) {
 					quests[Q_MUSHROOM]._qvar1 = QS_MUSHGIVEN;
 					Qtalklist[TOWN_HEALER][Q_MUSHROOM] = TEXT_MUSH3;
 					Qtalklist[TOWN_WITCH][Q_MUSHROOM] = TEXT_NONE;
@@ -524,10 +517,8 @@ void TalkToHealer(PlayerStruct &player, TownerStruct &healer)
 			return;
 		}
 	}
-	int i;
 	if (quests[Q_MUSHROOM]._qactive == QUEST_ACTIVE) {
-		if (quests[Q_MUSHROOM]._qvar1 >= QS_MUSHGIVEN && quests[Q_MUSHROOM]._qvar1 < QS_BRAINGIVEN && player.HasItem(IDI_BRAIN, &i)) {
-			player.RemoveInvItem(i);
+		if (quests[Q_MUSHROOM]._qvar1 >= QS_MUSHGIVEN && quests[Q_MUSHROOM]._qvar1 < QS_BRAINGIVEN && player.TryRemoveInvItemById(IDI_BRAIN)) {
 			SpawnQuestItem(IDI_SPECELIX, healer.position + Point { 0, 1 }, 0, 0);
 			InitQTextMsg(TEXT_MUSH4);
 			quests[Q_MUSHROOM]._qvar1 = QS_BRAINGIVEN;
@@ -549,13 +540,11 @@ void TalkToBoy(PlayerStruct & /*player*/, TownerStruct & /*boy*/)
 void TalkToStoryteller(PlayerStruct &player, TownerStruct & /*storyteller*/)
 {
 	if (!gbIsMultiplayer) {
-		int i;
-		if (quests[Q_BETRAYER]._qactive == QUEST_INIT && player.HasItem(IDI_LAZSTAFF, &i)) {
+		if (quests[Q_BETRAYER]._qactive == QUEST_INIT && player.TryRemoveInvItemById(IDI_LAZSTAFF)) {
 			InitQTextMsg(TEXT_VILE1);
 			quests[Q_BETRAYER]._qlog = true;
 			quests[Q_BETRAYER]._qactive = QUEST_ACTIVE;
 			quests[Q_BETRAYER]._qvar1 = 2;
-			player.RemoveInvItem(i);
 			return;
 		}
 	} else {
@@ -663,15 +652,12 @@ void TalkToFarmer(PlayerStruct &player, TownerStruct &farmer)
 
 void TalkToCowFarmer(PlayerStruct &player, TownerStruct &cowFarmer)
 {
-	int i;
-	if (player.HasItem(IDI_GREYSUIT, &i)) {
+	if (player.TryRemoveInvItemById(IDI_GREYSUIT)) {
 		InitQTextMsg(TEXT_JERSEY7);
-		player.RemoveInvItem(i);
 	}
 
-	if (player.HasItem(IDI_BROWNSUIT, &i)) {
+	if (player.TryRemoveInvItemById(IDI_BROWNSUIT)) {
 		SpawnUnique(UITEM_BOVINE, cowFarmer.position + DIR_SE);
-		player.RemoveInvItem(i);
 		InitQTextMsg(TEXT_JERSEY8);
 		quests[Q_JERSEY]._qactive = QUEST_DONE;
 		return;
@@ -747,10 +733,8 @@ void TalkToCowFarmer(PlayerStruct &player, TownerStruct &cowFarmer)
 
 void TalkToGirl(PlayerStruct &player, TownerStruct &girl)
 {
-	int i;
-	if (player.HasItem(IDI_THEODORE, &i) && quests[Q_GIRL]._qactive != QUEST_DONE) {
+	if (quests[Q_GIRL]._qactive != QUEST_DONE && player.TryRemoveInvItemById(IDI_THEODORE)) {
 		InitQTextMsg(TEXT_GIRL4);
-		player.RemoveInvItem(i);
 		CreateAmulet(girl.position, 13, false, true);
 		quests[Q_GIRL]._qlog = false;
 		quests[Q_GIRL]._qactive = QUEST_DONE;

--- a/test/animationinfo_test.cpp
+++ b/test/animationinfo_test.cpp
@@ -69,7 +69,6 @@ struct RenderingData : TestData {
 */
 void RunAnimationTest(const std::vector<TestData *> &vecTestData)
 {
-	const int pnum = 0;
 	AnimationInfo animInfo = {};
 
 	int currentGameTick = 0;
@@ -220,7 +219,7 @@ TEST(AnimationInfo, AttackSwordWarriorWithFastestAttack) // Skipped frames and P
 }
 
 /*
-* @brief The Warrior make two attacks. The second queued attack cancels the first after the Hit Frame. 
+* @brief The Warrior make two attacks. The second queued attack cancels the first after the Hit Frame.
 */
 TEST(AnimationInfo, AttackSwordWarriorRepeated)
 {


### PR DESCRIPTION
Resolves https://github.com/diasurgical/devilutionX/issues/2140

From what I understand, you cannot just save the indexes of 3 items like this and then remove them one by one, as removing an item might affect other indexes, so you have to perform the check again to obtain a valid index

Actually this was a good opportunity to rewrite that ugly HasItem / RemoveInvItem combo, the code looks much cleaner imo
I moved `TryRemoveInvItemById` to separate conditions to make it more visible that this check actually performs an action so it has to be last. Otherwise an if could fail but you'd remove an item!