### PR TITLE
Use '_item_indexes' in the 'ItemStruct' model and make item conversion code typesafe

### DIFF
--- a/Source/itemdat.h
+++ b/Source/itemdat.h
@@ -13,7 +13,7 @@
 namespace devilution {
 
 /** @todo add missing values and apply */
-enum _item_indexes : uint8_t {
+enum _item_indexes : uint16_t {
 	IDI_GOLD,
 	IDI_WARRIOR,
 	IDI_WARRSHLD,

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1087,7 +1087,7 @@ void SetPlrHandItem(ItemStruct *h, int idata)
 	h->_iPrePower = IPL_INVALID;
 	h->_iSufPower = IPL_INVALID;
 	h->_iMagical = ITEM_QUALITY_NORMAL;
-	h->IDidx = idata;
+	h->IDidx = static_cast<_item_indexes>(idata);
 	if (gbIsHellfire)
 		h->dwBuff |= CF_HELLFIRE;
 }
@@ -1643,7 +1643,7 @@ void GetItemAttrs(int i, int idata, int lvl)
 	items[i]._iMinStr = AllItemsList[idata].iMinStr;
 	items[i]._iMinMag = AllItemsList[idata].iMinMag;
 	items[i]._iMinDex = AllItemsList[idata].iMinDex;
-	items[i].IDidx = idata;
+	items[i].IDidx = static_cast<_item_indexes>(idata);
 	if (gbIsHellfire)
 		items[i].dwBuff |= CF_HELLFIRE;
 	items[i]._iPrePower = IPL_INVALID;

--- a/Source/items.h
+++ b/Source/items.h
@@ -234,7 +234,7 @@ struct ItemStruct {
 	uint8_t _iMinMag;
 	int8_t _iMinDex;
 	bool _iStatFlag;
-	int IDidx;
+	_item_indexes IDidx;
 	uint32_t dwBuff;
 	uint32_t _iDamAcFlags;
 

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -280,7 +280,7 @@ static void LoadItemData(LoadHelper *file, ItemStruct *pItem)
 	pItem->_iMinDex = file->nextLE<int8_t>();
 	file->skip(1); // Alignment
 	pItem->_iStatFlag = file->nextBool32();
-	pItem->IDidx = file->nextLE<int32_t>();
+	pItem->IDidx = static_cast<_item_indexes>(file->nextLE<int32_t>());
 	if (gbIsSpawn) {
 		pItem->IDidx = RemapItemIdxFromSpawn(pItem->IDidx);
 	}
@@ -796,94 +796,110 @@ static void LoadPortal(LoadHelper *file, int i)
 	pPortal->setlvl = file->nextBool32();
 }
 
-int RemapItemIdxFromDiablo(int i)
+_item_indexes RemapItemIdxFromDiablo(_item_indexes i)
 {
-	if (i == IDI_SORCERER) {
-		return 166;
-	}
-	if (i >= 156) {
-		i += 5; // Hellfire exclusive items
-	}
-	if (i >= 88) {
-		i += 1; // Scroll of Search
-	}
-	if (i >= 83) {
-		i += 4; // Oils
-	}
+	constexpr auto getItemIdValue = [](int i) -> int {
+		if (i == IDI_SORCERER) {
+			return 166;
+		}
+		if (i >= 156) {
+			i += 5; // Hellfire exclusive items
+		}
+		if (i >= 88) {
+			i += 1; // Scroll of Search
+		}
+		if (i >= 83) {
+			i += 4; // Oils
+		}
 
-	return i;
+		return i;
+	};
+
+	return static_cast<_item_indexes>(getItemIdValue(i));
 }
 
-int RemapItemIdxToDiablo(int i)
+_item_indexes RemapItemIdxToDiablo(_item_indexes i)
 {
-	if (i == 166) {
-		return IDI_SORCERER;
-	}
-	if ((i >= 83 && i <= 86) || i == 92 || i >= 161) {
-		return -1; // Hellfire exclusive items
-	}
-	if (i >= 93) {
-		i -= 1; // Scroll of Search
-	}
-	if (i >= 87) {
-		i -= 4; // Oils
-	}
+	constexpr auto getItemIdValue = [](int i) -> int {
+		if (i == 166) {
+			return IDI_SORCERER;
+		}
+		if ((i >= 83 && i <= 86) || i == 92 || i >= 161) {
+			return -1; // Hellfire exclusive items
+		}
+		if (i >= 93) {
+			i -= 1; // Scroll of Search
+		}
+		if (i >= 87) {
+			i -= 4; // Oils
+		}
 
-	return i;
+		return i;
+	};
+
+	return static_cast<_item_indexes>(getItemIdValue(i));
 }
 
-int RemapItemIdxFromSpawn(int i)
+_item_indexes RemapItemIdxFromSpawn(_item_indexes i)
 {
-	if (i >= 62) {
-		i += 9; // Medium and heavy armors
-	}
-	if (i >= 96) {
-		i += 1; // Scroll of Stone Curse
-	}
-	if (i >= 98) {
-		i += 1; // Scroll of Guardian
-	}
-	if (i >= 99) {
-		i += 1; // Scroll of ...
-	}
-	if (i >= 101) {
-		i += 1; // Scroll of Golem
-	}
-	if (i >= 102) {
-		i += 1; // Scroll of None
-	}
-	if (i >= 104) {
-		i += 1; // Scroll of Apocalypse
-	}
+	constexpr auto getItemIdValue = [](int i) {
+		if (i >= 62) {
+			i += 9; // Medium and heavy armors
+		}
+		if (i >= 96) {
+			i += 1; // Scroll of Stone Curse
+		}
+		if (i >= 98) {
+			i += 1; // Scroll of Guardian
+		}
+		if (i >= 99) {
+			i += 1; // Scroll of ...
+		}
+		if (i >= 101) {
+			i += 1; // Scroll of Golem
+		}
+		if (i >= 102) {
+			i += 1; // Scroll of None
+		}
+		if (i >= 104) {
+			i += 1; // Scroll of Apocalypse
+		}
 
-	return i;
+		return i;
+	};
+
+	return static_cast<_item_indexes>(getItemIdValue(i));
 }
 
-int RemapItemIdxToSpawn(int i)
+_item_indexes RemapItemIdxToSpawn(_item_indexes i)
 {
-	if (i >= 104) {
-		i -= 1; // Scroll of Apocalypse
-	}
-	if (i >= 102) {
-		i -= 1; // Scroll of None
-	}
-	if (i >= 101) {
-		i -= 1; // Scroll of Golem
-	}
-	if (i >= 99) {
-		i -= 1; // Scroll of ...
-	}
-	if (i >= 98) {
-		i -= 1; // Scroll of Guardian
-	}
-	if (i >= 96) {
-		i -= 1; // Scroll of Stone Curse
-	}
-	if (i >= 71) {
-		i -= 9; // Medium and heavy armors
-	}
+	constexpr auto getItemIdValue = [](int i) {
+		if (i >= 104) {
+			i -= 1; // Scroll of Apocalypse
+		}
+		if (i >= 102) {
+			i -= 1; // Scroll of None
+		}
+		if (i >= 101) {
+			i -= 1; // Scroll of Golem
+		}
+		if (i >= 99) {
+			i -= 1; // Scroll of ...
+		}
+		if (i >= 98) {
+			i -= 1; // Scroll of Guardian
+		}
+		if (i >= 96) {
+			i -= 1; // Scroll of Stone Curse
+		}
+		if (i >= 71) {
+			i -= 9; // Medium and heavy armors
+		}
 
-	return i;
+		return i;
+	};
+
+	return static_cast<_item_indexes>(getItemIdValue(i));
 }
 
 bool IsHeaderValid(uint32_t magicNumber)
@@ -1242,14 +1258,14 @@ void LoadGame(bool firstflag)
 
 static void SaveItem(SaveHelper *file, ItemStruct *pItem)
 {
-	int idx = pItem->IDidx;
+	auto idx = pItem->IDidx;
 	if (!gbIsHellfire)
 		idx = RemapItemIdxToDiablo(idx);
 	if (gbIsSpawn)
 		idx = RemapItemIdxToSpawn(idx);
 	int iType = pItem->_itype;
 	if (idx == -1) {
-		idx = 0;
+		idx = _item_indexes::IDI_GOLD;
 		iType = ITYPE_NONE;
 	}
 

--- a/Source/loadsave.h
+++ b/Source/loadsave.h
@@ -13,10 +13,10 @@ extern bool gbIsHellfireSaveGame;
 extern uint8_t giNumberOfLevels;
 
 void RemoveInvalidItem(ItemStruct *pItem);
-int RemapItemIdxFromDiablo(int i);
-int RemapItemIdxToDiablo(int i);
-int RemapItemIdxFromSpawn(int i);
-int RemapItemIdxToSpawn(int i);
+_item_indexes RemapItemIdxFromDiablo(_item_indexes i);
+_item_indexes RemapItemIdxToDiablo(_item_indexes i);
+_item_indexes RemapItemIdxFromSpawn(_item_indexes i);
+_item_indexes RemapItemIdxToSpawn(_item_indexes i);
 bool IsHeaderValid(uint32_t magicNumber);
 void LoadHotkeys();
 void LoadHeroItems(PlayerStruct &pPlayer);

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -17,7 +17,7 @@ void PackItem(PkItemStruct *id, const ItemStruct *is)
 	if (is->isEmpty()) {
 		id->idx = 0xFFFF;
 	} else {
-		int idx = is->IDidx;
+		auto idx = is->IDidx;
 		if (!gbIsHellfire) {
 			idx = RemapItemIdxToDiablo(idx);
 		}
@@ -123,7 +123,7 @@ void PackPlayer(PkPlayerStruct *pPack, const PlayerStruct &player, bool manashie
  */
 void UnPackItem(const PkItemStruct *is, ItemStruct *id, bool isHellfire)
 {
-	uint16_t idx = SDL_SwapLE16(is->idx);
+	auto idx = static_cast<_item_indexes>(SDL_SwapLE16(is->idx));
 	if (idx == 0xFFFF) {
 		id->_itype = ITYPE_NONE;
 		return;


### PR DESCRIPTION
This PR is an initial change to allow us to use the `_item_indexes` enum directly in a few places instead of relying on raw 'int' values.

It replaces the raw int in the `ItemStruct` and then makes a few changes to ensure places that populate and read that value (packing and unpacking for now) are updated to handle the value as a proper enum.