### PR TITLE
Fix 3DS CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,14 +46,12 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run: dkp-pacman -Syu --noconfirm
-      - run: dkp-pacman -S --needed --noconfirm --quiet devkitpro-pkgbuild-helpers
       - run: wget https://github.com/Steveice10/bannertool/releases/download/1.2.0/bannertool.zip
       - run: unzip -j "bannertool.zip" "linux-x86_64/bannertool" -d "/opt/devkitpro/tools/bin"
       - run: wget https://github.com/jakcron/Project_CTR/releases/download/v0.16/makerom_016_ctrtool.zip
       - run: unzip -j "makerom_016_ctrtool.zip" "Ubuntu/makerom" -d "/opt/devkitpro/tools/bin"
       - run: sudo chmod +rx /opt/devkitpro/tools/bin/makerom
-      - run: cmake -S. -Bbuild -DNIGHTLY_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/3ds.cmake
+      - run: cmake -S. -Bbuild -DNIGHTLY_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/3DS.cmake
       - run: cmake --build build -j 2
       - store_artifacts: {path: ./build/devilutionx.3dsx, destination: devilutionx.3dsx}
       - store_artifacts: {path: ./build/devilutionx.cia, destination: devilutionx.cia}

--- a/CMake/ctr/Tools3DS.cmake
+++ b/CMake/ctr/Tools3DS.cmake
@@ -89,7 +89,7 @@
 #
 ############################################################################
 
-if(NOT N3DS)
+if(NOT NINTENDO_3DS)
     message(WARNING "Those tools can only be used if you are using the 3DS toolchain file. Please erase this build directory or create another one, and then use -DCMAKE_TOOLCHAIN_FILE=DevkitArm3DS.cmake when calling cmake for the 1st time. For more information, see the Readme.md for more information.")
 endif()
 

--- a/CMake/ctr/modules/FindBZIP2.cmake
+++ b/CMake/ctr/modules/FindBZIP2.cmake
@@ -10,7 +10,7 @@
 # target_link_libraries(mytarget ${BZIP2_LIBRARIES})
 # target_include_directories(mytarget PRIVATE ${BZIP2_INCLUDE_DIRS})
 
-if(NOT N3DS)
+if(NOT NINTENDO_3DS)
     message(FATAL_ERROR "This module can only be used if you are using the 3DS toolchain file. Please erase this build directory or create another one, and then use -DCMAKE_TOOLCHAIN_FILE=DevkitArm3DS.cmake when calling cmake for the 1st time. For more information, see the Readme.md for more information.")
 endif()
 

--- a/CMake/ctr/modules/FindCITRO3D.cmake
+++ b/CMake/ctr/modules/FindCITRO3D.cmake
@@ -10,7 +10,7 @@
 # target_link_libraries(mytarget ${CITRO3D_LIBRARIES})
 # target_include_directories(mytarget PRIVATE ${CITRO3D_INCLUDE_DIRS})
 
-if(NOT N3DS)
+if(NOT NINTENDO_3DS)
     message(FATAL_ERROR "This module can only be used if you are using the 3DS toolchain file. Please erase this build directory or create another one, and then use -DCMAKE_TOOLCHAIN_FILE=DevkitArm3DS.cmake when calling cmake for the 1st time. For more information, see the Readme.md for more information.")
 endif()
 

--- a/CMake/ctr/modules/FindFREETYPE.cmake
+++ b/CMake/ctr/modules/FindFREETYPE.cmake
@@ -10,7 +10,7 @@
 # target_link_libraries(mytarget ${FREETYPE_LIBRARIES})
 # target_include_directories(mytarget PRIVATE ${FREETYPE_INCLUDE_DIRS})
 
-if(NOT N3DS)
+if(NOT NINTENDO_3DS)
     message(FATAL_ERROR "This module can only be used if you are using the 3DS toolchain file. Please erase this build directory or create another one, and then use -DCMAKE_TOOLCHAIN_FILE=DevkitArm3DS.cmake when calling cmake for the 1st time. For more information, see the Readme.md for more information.")
 endif()
 

--- a/CMake/ctr/modules/FindPNG.cmake
+++ b/CMake/ctr/modules/FindPNG.cmake
@@ -10,7 +10,7 @@
 # target_link_libraries(mytarget ${PNG_LIBRARIES})
 # target_include_directories(mytarget PRIVATE ${PNG_INCLUDE_DIRS})
 
-if(NOT N3DS)
+if(NOT NINTENDO_3DS)
     message(FATAL_ERROR "This module can only be used if you are using the 3DS toolchain file. Please erase this build directory or create another one, and then use -DCMAKE_TOOLCHAIN_FILE=DevkitArm3DS.cmake when calling cmake for the 1st time. For more information, see the Readme.md for more information.")
 endif()
 

--- a/CMake/ctr/modules/FindZLIB.cmake
+++ b/CMake/ctr/modules/FindZLIB.cmake
@@ -9,7 +9,7 @@
 # target_link_libraries(mytarget ${ZLIB_LIBRARY})
 # target_include_directories(mytarget PRIVATE ${ZLIB_INCLUDE_DIRS})
 
-if(NOT N3DS)
+if(NOT NINTENDO_3DS)
     message(FATAL_ERROR "This module can only be used if you are using the 3DS toolchain file. Please erase this build directory or create another one, and then use -DCMAKE_TOOLCHAIN_FILE=DevkitArm3DS.cmake when calling cmake for the 1st time. For more information, see the Readme.md for more information.")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ if(AMIGA)
   include(amiga_defs)
 endif()
 
-if(N3DS)
+if(NINTENDO_3DS)
   list(APPEND CMAKE_MODULE_PATH "${DevilutionX_SOURCE_DIR}/CMake/ctr")
   include(n3ds_defs)
 endif()
@@ -206,7 +206,7 @@ if(NOT NOSOUND)
   endif()
 endif()
 
-if(NOT N3DS)
+if(NOT NINTENDO_3DS)
   find_package(Threads REQUIRED)
 endif()
 
@@ -477,7 +477,7 @@ if(VITA)
     Source/platform/vita/keyboard.cpp)
 endif()
 
-if(N3DS)
+if(NINTENDO_3DS)
   list(APPEND libdevilutionx_SRCS
     Source/platform/ctr/system.cpp
     Source/platform/ctr/keyboard.cpp
@@ -578,7 +578,7 @@ target_include_directories(libdevilutionx PUBLIC
   Source
   ${CMAKE_CURRENT_BINARY_DIR})
 
-if(NOT N3DS)
+if(NOT NINTENDO_3DS)
   target_link_libraries(libdevilutionx PUBLIC
   Threads::Threads)
 endif()
@@ -741,7 +741,7 @@ if (VITA)
   target_compile_definitions(libdevilutionx PUBLIC VITA)
 endif()
 
-if(N3DS)
+if(NINTENDO_3DS)
   target_link_libraries(libdevilutionx PUBLIC 3ds::freetype 3ds::bzip2 3ds::png)
   target_link_libraries(libdevilutionx PUBLIC 3ds::citro3d 3ds::ctrulib)
 endif()
@@ -872,7 +872,7 @@ if(VITA)
   )
 endif()
 
-if(N3DS)
+if(NINTENDO_3DS)
   set(APP_TITLE       "DevilutionX")
   set(APP_DESCRIPTION "DevilutionX port for 3DS")
   set(APP_AUTHOR      "Diasurgical Team")


### PR DESCRIPTION
The latest 3DS packages from devkitpro have capitalized the name of the CMake toolchain file and moved it to a `cmake` subdirectory. It also changed the CMake platform variable to `NINTENDO_3DS` instead of `N3DS`.

Furthermore, their docker image has the latest packages for the moment. The maintainer has requested we do not update packages on our CI container and instead request updates to the docker images if we need them. See: https://github.com/devkitPro/docker/issues/17