### PR TITLE
Refactor plrctrls functions to use Point and Direction types

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -385,7 +385,7 @@ void FindTrigger()
 	for (int i = 0; i < nummissiles; i++) {
 		int mi = missileactive[i];
 		if (missile[mi]._mitype == MIS_TOWN || missile[mi]._mitype == MIS_RPORTAL) {
-			const int newDdistance = GetDistance(missile[mi].position.tile, 2);
+			const int newDistance = GetDistance(missile[mi].position.tile, 2);
 			if (newDdistance == 0)
 				continue;
 			if (pcursmissile != -1 && distance < newDdistance)

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1086,7 +1086,7 @@ void WalkInDir(int playerId, AxisDirection dir)
 	}
 
 	const Direction pdir = FaceDir[static_cast<std::size_t>(dir.x)][static_cast<std::size_t>(dir.y)];
-	const auto delta{ future + pdir };
+	const auto delta = player.position.future + pdir;
 
 	if (CanChangeDirection(player))
 		player._pdir = pdir;

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -49,19 +49,18 @@ int slot = SLOTXY_INV_FIRST;
 
 /**
  * Number of angles to turn to face the coordinate
- * @param x Tile coordinates
- * @param y Tile coordinates
+ * @param destination Tile coordinates
  * @return -1 == down
  */
-int GetRotaryDistance(int x, int y)
+int GetRotaryDistance(Point destination)
 {
 	auto &myPlayer = plr[myplr];
 
-	if (myPlayer.position.future.x == x && myPlayer.position.future.y == y)
+	if (myPlayer.position.future == destination)
 		return -1;
 
 	int d1 = myPlayer._pdir;
-	int d2 = GetDirection(myPlayer.position.future, { x, y });
+	int d2 = GetDirection(myPlayer.position.future, destination);
 
 	int d = abs(d1 - d2);
 	if (d > 4)
@@ -119,7 +118,7 @@ void FindItemOrObject()
 	int my = plr[myplr].position.future.y;
 	int rotations = 5;
 
-	// As the player can not stand on the edge fo the map this is safe from OOB
+	// As the player can not stand on the edge of the map this is safe from OOB
 	for (int xx = -1; xx < 2; xx++) {
 		for (int yy = -1; yy < 2; yy++) {
 			if (dItem[mx + xx][my + yy] <= 0)
@@ -128,7 +127,7 @@ void FindItemOrObject()
 			if (items[i].isEmpty()
 			    || items[i]._iSelFlag == 0)
 				continue;
-			int newRotations = GetRotaryDistance(mx + xx, my + yy);
+			int newRotations = GetRotaryDistance({ mx + xx, my + yy });
 			if (rotations < newRotations)
 				continue;
 			if (xx != 0 && yy != 0 && GetDistance(mx + xx, my + yy, 1) == 0)
@@ -152,7 +151,7 @@ void FindItemOrObject()
 				continue;
 			if (xx == 0 && yy == 0 && object[o]._oDoorFlag)
 				continue; // Ignore doorway so we don't get stuck behind barrels
-			int newRotations = GetRotaryDistance(mx + xx, my + yy);
+			int newRotations = GetRotaryDistance({ mx + xx, my + yy });
 			if (rotations < newRotations)
 				continue;
 			if (xx != 0 && yy != 0 && GetDistance(mx + xx, my + yy, 1) == 0)
@@ -223,7 +222,7 @@ void FindRangedTarget()
 		if (pcursmonst != -1 && !canTalk && newCanTalk)
 			continue;
 		const int newDdistance = GetDistanceRanged(mx, my);
-		const int newRotations = GetRotaryDistance(mx, my);
+		const int newRotations = GetRotaryDistance({ mx, my });
 		if (pcursmonst != -1 && canTalk == newCanTalk) {
 			if (distance < newDdistance)
 				continue;
@@ -282,7 +281,7 @@ void FindMeleeTarget()
 						const bool newCanTalk = CanTalkToMonst(mi);
 						if (pcursmonst != -1 && !canTalk && newCanTalk)
 							continue;
-						const int newRotations = GetRotaryDistance(dx, dy);
+						const int newRotations = GetRotaryDistance({ dx, dy });
 						if (pcursmonst != -1 && canTalk == newCanTalk && rotations < newRotations)
 							continue;
 						rotations = newRotations;
@@ -353,7 +352,7 @@ void CheckPlayerNearby()
 
 		if (pcursplr != -1 && distance < newDdistance)
 			continue;
-		const int newRotations = GetRotaryDistance(mx, my);
+		const int newRotations = GetRotaryDistance({ mx, my });
 		if (pcursplr != -1 && distance == newDdistance && rotations < newRotations)
 			continue;
 
@@ -380,7 +379,7 @@ int pcursquest;
 
 void FindTrigger()
 {
-	int rotations;
+	int rotations = 0;
 	int distance = 0;
 
 	if (pcursitem != -1 || pcursobj != -1)
@@ -396,7 +395,7 @@ void FindTrigger()
 				continue;
 			if (pcursmissile != -1 && distance < newDdistance)
 				continue;
-			const int newRotations = GetRotaryDistance(mix, miy);
+			const int newRotations = GetRotaryDistance({ mix, miy });
 			if (pcursmissile != -1 && distance == newDdistance && rotations < newRotations)
 				continue;
 			cursmx = mix;

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -107,11 +107,13 @@ int GetDistanceRanged(Point destination)
 	return plr[myplr].position.future.ExactDistance(destination);
 }
 
+/**
+ * @todo The loops in this function are iterating through tiles offset from the player position. This
+ * could be accomplished by looping over the values in the Direction enum and making use of
+ * Point math instead of nested loops from [-1, 1].
+ */
 void FindItemOrObject()
 {
-	// The loops in this function are iterating through tiles offset from the player position. This
-	// could be accomplished by looping over the values in the Direction enum and making use of
-	// Point math instead of nested loops from [-1, 1].
 	int mx = plr[myplr].position.future.x;
 	int my = plr[myplr].position.future.y;
 	int rotations = 5;

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -101,15 +101,11 @@ int GetDistance(int dx, int dy, int maxDistance)
 
 /**
  * @brief Get distance to coordinate
- * @param dx Tile coordinates
- * @param dy Tile coordinates
+ * @param destination Tile coordinates
  */
-int GetDistanceRanged(int dx, int dy)
+int GetDistanceRanged(Point destination)
 {
-	int a = plr[myplr].position.future.x - dx;
-	int b = plr[myplr].position.future.y - dy;
-
-	return sqrt(a * a + b * b);
+	return plr[myplr].position.future.ExactDistance(destination);
 }
 
 void FindItemOrObject()
@@ -212,17 +208,14 @@ void FindRangedTarget()
 
 	// The first MAX_PLRS monsters are reserved for players' golems.
 	for (int mi = MAX_PLRS; mi < MAXMONSTERS; mi++) {
-		const MonsterStruct &monst = monster[mi];
-		const int mx = monst.position.future.x;
-		const int my = monst.position.future.y;
 		if (!CanTargetMonster(mi))
 			continue;
 
 		const bool newCanTalk = CanTalkToMonst(mi);
 		if (pcursmonst != -1 && !canTalk && newCanTalk)
 			continue;
-		const int newDdistance = GetDistanceRanged(mx, my);
-		const int newRotations = GetRotaryDistance({ mx, my });
+		const int newDdistance = GetDistanceRanged(monster[mi].position.future);
+		const int newRotations = GetRotaryDistance(monster[mi].position.future);
 		if (pcursmonst != -1 && canTalk == newCanTalk) {
 			if (distance < newDdistance)
 				continue;
@@ -343,7 +336,7 @@ void CheckPlayerNearby()
 			continue;
 
 		if (myPlayer._pwtype == WT_RANGED || HasRangedSpell() || spl == SPL_HEALOTHER) {
-			newDdistance = GetDistanceRanged(mx, my);
+			newDdistance = GetDistanceRanged(player.position.future);
 		} else {
 			newDdistance = GetDistance(mx, my, distance);
 			if (newDdistance == 0)
@@ -352,7 +345,7 @@ void CheckPlayerNearby()
 
 		if (pcursplr != -1 && distance < newDdistance)
 			continue;
-		const int newRotations = GetRotaryDistance({ mx, my });
+		const int newRotations = GetRotaryDistance(player.position.future);
 		if (pcursplr != -1 && distance == newDdistance && rotations < newRotations)
 			continue;
 

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1421,7 +1421,7 @@ void UpdateSpellTarget()
 	if (plr[myplr]._pRSpell == SPL_TELEPORT)
 		range = 4;
 
-	auto cursm{ plr[myplr].position.future + Point::fromDirection(plr[myplr]._pdir) * range };
+	auto cursm = plr[myplr].position.future + Point::fromDirection(plr[myplr]._pdir) * range;
 	cursmx = cursm.x;
 	cursmy = cursm.y;
 }

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1021,16 +1021,6 @@ static const Direction FaceDir[3][3] = {
 	{ DIR_W, DIR_NW, DIR_SW },  // LEFT
 	{ DIR_E, DIR_NE, DIR_SE },  // RIGHT
 };
-static const int Offsets[8][2] = {
-	{ 1, 1 },   // DIR_S
-	{ 0, 1 },   // DIR_SW
-	{ -1, 1 },  // DIR_W
-	{ -1, 0 },  // DIR_NW
-	{ -1, -1 }, // DIR_N
-	{ 0, -1 },  // DIR_NE
-	{ 1, -1 },  // DIR_E
-	{ 1, 0 },   // DIR_SE
-};
 
 /**
  * @brief check if stepping in direction (dir) from position is blocked.
@@ -1436,8 +1426,9 @@ void UpdateSpellTarget()
 	if (plr[myplr]._pRSpell == SPL_TELEPORT)
 		range = 4;
 
-	cursmx = plr[myplr].position.future.x + Offsets[plr[myplr]._pdir][0] * range;
-	cursmy = plr[myplr].position.future.y + Offsets[plr[myplr]._pdir][1] * range;
+	auto cursm{ plr[myplr].position.future + Point::fromDirection(plr[myplr]._pdir) * range };
+	cursmx = cursm.x;
+	cursmy = cursm.y;
 }
 
 /**

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -386,17 +386,17 @@ void FindTrigger()
 		int mi = missileactive[i];
 		if (missile[mi]._mitype == MIS_TOWN || missile[mi]._mitype == MIS_RPORTAL) {
 			const int newDistance = GetDistance(missile[mi].position.tile, 2);
-			if (newDdistance == 0)
+			if (newDistance == 0)
 				continue;
-			if (pcursmissile != -1 && distance < newDdistance)
+			if (pcursmissile != -1 && distance < newDistance)
 				continue;
 			const int newRotations = GetRotaryDistance(missile[mi].position.tile);
-			if (pcursmissile != -1 && distance == newDdistance && rotations < newRotations)
+			if (pcursmissile != -1 && distance == newDistance && rotations < newRotations)
 				continue;
 			cursmx = missile[mi].position.tile.x;
 			cursmy = missile[mi].position.tile.y;
 			pcursmissile = mi;
-			distance = newDdistance;
+			distance = newDistance;
 			rotations = newRotations;
 		}
 	}
@@ -407,8 +407,8 @@ void FindTrigger()
 			int ty = trigs[i].position.y;
 			if (trigs[i]._tlvl == 13)
 				ty -= 1;
-			const int newDdistance = GetDistance({ tx, ty }, 2);
-			if (newDdistance == 0)
+			const int newDistance = GetDistance({ tx, ty }, 2);
+			if (newDistance == 0)
 				continue;
 			cursmx = tx;
 			cursmy = ty;
@@ -419,8 +419,8 @@ void FindTrigger()
 			for (int i = 0; i < MAXQUESTS; i++) {
 				if (i == Q_BETRAYER || currlevel != quests[i]._qlevel || quests[i]._qslvl == 0)
 					continue;
-				const int newDdistance = GetDistance(quests[i].position, 2);
-				if (newDdistance == 0)
+				const int newDistance = GetDistance(quests[i].position, 2);
+				if (newDistance == 0)
 					continue;
 				cursmx = quests[i].position.x;
 				cursmy = quests[i].position.y;
@@ -1051,8 +1051,8 @@ bool IsPathBlocked(Point position, Direction dir)
 		return false;
 	}
 
-	auto leftStep{ position + d1 };
-	auto rightStep{ position + d2 };
+	auto leftStep { position + d1 };
+	auto rightStep { position + d2 };
 
 	if (!nSolidTable[dPiece[leftStep.x][leftStep.y]] && !nSolidTable[dPiece[rightStep.x][rightStep.y]])
 		return false;
@@ -1077,11 +1077,9 @@ void WalkInDir(int playerId, AxisDirection dir)
 {
 	auto &player = plr[playerId];
 
-	const auto future{ player.position.future };
-
 	if (dir.x == AxisDirectionX_NONE && dir.y == AxisDirectionY_NONE) {
 		if (sgbControllerActive && player.walkpath[0] != WALK_NONE && player.destAction == ACTION_NONE)
-			NetSendCmdLoc(playerId, true, CMD_WALKXY, future); // Stop walking
+			NetSendCmdLoc(playerId, true, CMD_WALKXY, player.position.future); // Stop walking
 		return;
 	}
 
@@ -1091,7 +1089,7 @@ void WalkInDir(int playerId, AxisDirection dir)
 	if (CanChangeDirection(player))
 		player._pdir = pdir;
 
-	if (PosOkPlayer(playerId, delta) && IsPathBlocked(future, pdir))
+	if (PosOkPlayer(playerId, delta) && IsPathBlocked(player.position.future, pdir))
 		return; // Don't start backtrack around obstacles
 
 	NetSendCmdLoc(playerId, true, CMD_WALKXY, delta);

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -940,13 +940,13 @@ void InvMove(AxisDirection dir)
 /**
  * check if hot spell at X Y exists
  */
-bool HSExists(int x, int y)
+bool HSExists(Point target)
 {
 	for (int r = 0; r < speedspellcount; r++) {
-		if (x >= speedspellscoords[r].x - SPLICONLENGTH / 2
-		    && x < speedspellscoords[r].x + SPLICONLENGTH / 2
-		    && y >= speedspellscoords[r].y - SPLICONLENGTH / 2
-		    && y < speedspellscoords[r].y + SPLICONLENGTH / 2) {
+		if (target.x >= speedspellscoords[r].x - SPLICONLENGTH / 2
+		    && target.x < speedspellscoords[r].x + SPLICONLENGTH / 2
+		    && target.y >= speedspellscoords[r].y - SPLICONLENGTH / 2
+		    && target.y < speedspellscoords[r].y + SPLICONLENGTH / 2) {
 			return true;
 		}
 	}
@@ -987,11 +987,11 @@ void HotSpellMove(AxisDirection dir)
 	}
 
 	if (dir.y == AxisDirectionY_UP) {
-		if (HSExists(x, y - SPLICONLENGTH)) {
+		if (HSExists({ x, y - SPLICONLENGTH })) {
 			y -= SPLICONLENGTH;
 		}
 	} else if (dir.y == AxisDirectionY_DOWN) {
-		if (HSExists(x, y + SPLICONLENGTH)) {
+		if (HSExists({ x, y + SPLICONLENGTH })) {
 			y += SPLICONLENGTH;
 		}
 	}

--- a/Source/engine/point.hpp
+++ b/Source/engine/point.hpp
@@ -10,6 +10,30 @@ struct Point {
 	int x;
 	int y;
 
+	static constexpr Point fromDirection(Direction direction)
+	{
+		switch (direction) {
+		case DIR_S:
+			return { 1, 1 };
+		case DIR_SW:
+			return { 0, 1 };
+		case DIR_W:
+			return { -1, 1 };
+		case DIR_NW:
+			return { -1, 0 };
+		case DIR_N:
+			return { -1, -1 };
+		case DIR_NE:
+			return { 0, -1 };
+		case DIR_E:
+			return { 1, -1 };
+		case DIR_SE:
+			return { 1, 0 };
+		default:
+			return { 0, 0 };
+		}
+	};
+
 	constexpr bool operator==(const Point &other) const
 	{
 		return x == other.x && y == other.y;
@@ -129,6 +153,20 @@ struct Point {
 			approx -= max * 40;
 
 		return (approx + 512) / 1024;
+	}
+
+	/**
+	 * @brief Calculates the exact distance between two points (as accurate as the closest integer representation)
+	 *
+	 * In practice it is likely that ApproxDistance gives the same result, especially for nearby points.
+	 * @param other Point to which we want the distance
+	 * @return Exact magnitude of vector this -> other
+	*/
+	int ExactDistance(Point other) const
+	{
+		auto vector = *this - other; //No need to call abs() as we square the values anyway
+
+		return sqrt(vector.x * vector.x + vector.y * vector.y);
 	}
 
 	constexpr friend Point abs(Point a)

--- a/Source/engine/point.hpp
+++ b/Source/engine/point.hpp
@@ -55,30 +55,7 @@ struct Point {
 
 	constexpr Point &operator+=(Direction direction)
 	{
-		constexpr auto toPoint = [](Direction direction) -> Point {
-			switch (direction) {
-			case DIR_S:
-				return { 1, 1 };
-			case DIR_SW:
-				return { 0, 1 };
-			case DIR_W:
-				return { -1, 1 };
-			case DIR_NW:
-				return { -1, 0 };
-			case DIR_N:
-				return { -1, -1 };
-			case DIR_NE:
-				return { 0, -1 };
-			case DIR_E:
-				return { 1, -1 };
-			case DIR_SE:
-				return { 1, 0 };
-			default:
-				return { 0, 0 };
-			}
-		};
-
-		return (*this) += toPoint(direction);
+		return (*this) += Point::fromDirection(direction);
 	}
 
 	constexpr Point &operator-=(const Point &other)
@@ -168,8 +145,8 @@ struct Point {
 	{
 		auto vector = *this - other; //No need to call abs() as we square the values anyway
 
-		// Casting one operand to a wide type is enough to promote every value in the expression, addresses overflow warnings
-		return static_cast<int>(std::sqrt(static_cast<int64_t>(vector.x) * vector.x + vector.y * vector.y));
+		// Casting multiplication operands to a wide type to address overflow warnings
+		return static_cast<int>(std::sqrt(static_cast<int64_t>(vector.x) * vector.x + static_cast<int64_t>(vector.y) * vector.y));
 	}
 
 	constexpr friend Point abs(Point a)

--- a/Source/engine/point.hpp
+++ b/Source/engine/point.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cmath>
+
 #include "engine/direction.hpp"
 #include "utils/stdcompat/abs.hpp"
 #include "utils/stdcompat/algorithm.hpp"
@@ -166,7 +168,8 @@ struct Point {
 	{
 		auto vector = *this - other; //No need to call abs() as we square the values anyway
 
-		return sqrt(vector.x * vector.x + vector.y * vector.y);
+		// Casting one operand to a wide type is enough to promote every value in the expression, addresses overflow warnings
+		return static_cast<int>(std::sqrt(static_cast<int64_t>(vector.x) * vector.x + vector.y * vector.y));
 	}
 
 	constexpr friend Point abs(Point a)


### PR DESCRIPTION
As part of this I moved the toPoint lambda to a class function on Point (and renamed it since Point::toPoint read a little off 😂 ). Ideally this would be an explicit conversion function on Direction but as that's an enum as far as I know it's not supported in c++.

I've skipped over GetItemSizeOnSlot as this is being updated in pull request #2130.