### PR TITLE
Refactor sound related functions to use Point

### DIFF
--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -1261,7 +1261,7 @@ void PlaySFX(_sfx_id psfx)
 	PlaySFX_priv(&sgSFX[psfx], false, { 0, 0 });
 }
 
-void PlaySfxLoc(_sfx_id psfx, int x, int y, bool randomizeByCategory)
+void PlaySfxLoc(_sfx_id psfx, Point position, bool randomizeByCategory)
 {
 	if (randomizeByCategory) {
 		psfx = RndSFX(psfx);
@@ -1273,7 +1273,7 @@ void PlaySfxLoc(_sfx_id psfx, int x, int y, bool randomizeByCategory)
 			pSnd->start_tc = 0;
 	}
 
-	PlaySFX_priv(&sgSFX[psfx], true, { x, y });
+	PlaySFX_priv(&sgSFX[psfx], true, position);
 }
 
 void sound_stop()

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -1143,19 +1143,17 @@ void FreeMonsterSnd()
 	}
 }
 
-bool calc_snd_position(int x, int y, int *plVolume, int *plPan)
+bool calc_snd_position(Point soundPosition, int *plVolume, int *plPan)
 {
 	int pan, volume;
 
 	const auto &playerPosition = plr[myplr].position.tile;
+	const auto delta = soundPosition - playerPosition;
 
-	const int dx = x - playerPosition.x;
-	const int dy = y - playerPosition.y;
-
-	pan = (dx - dy) * 256;
+	pan = (delta.x - delta.y) * 256;
 	*plPan = clamp(pan, PAN_MIN, PAN_MAX);
 
-	volume = playerPosition.ApproxDistance({ x, y });
+	volume = playerPosition.ApproxDistance(soundPosition);
 	volume *= -64;
 
 	if (volume <= ATTENUATION_MIN)
@@ -1183,7 +1181,7 @@ static void PlaySFX_priv(TSFX *pSFX, bool loc, int x, int y)
 
 	lPan = 0;
 	lVolume = 0;
-	if (loc && !calc_snd_position(x, y, &lVolume, &lPan)) {
+	if (loc && !calc_snd_position({ x, y }, &lVolume, &lPan)) {
 		return;
 	}
 
@@ -1218,7 +1216,7 @@ void PlayEffect(int i, int mode)
 		return;
 	}
 
-	if (!calc_snd_position(monster[i].position.tile.x, monster[i].position.tile.y, &lVolume, &lPan))
+	if (!calc_snd_position(monster[i].position.tile, &lVolume, &lPan))
 		return;
 
 	snd_play_snd(snd, lVolume, lPan);

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -1164,7 +1164,7 @@ bool calc_snd_position(Point soundPosition, int *plVolume, int *plPan)
 	return true;
 }
 
-static void PlaySFX_priv(TSFX *pSFX, bool loc, int x, int y)
+static void PlaySFX_priv(TSFX *pSFX, bool loc, Point position)
 {
 	int lPan, lVolume;
 
@@ -1181,7 +1181,7 @@ static void PlaySFX_priv(TSFX *pSFX, bool loc, int x, int y)
 
 	lPan = 0;
 	lVolume = 0;
-	if (loc && !calc_snd_position({ x, y }, &lVolume, &lPan)) {
+	if (loc && !calc_snd_position(position, &lVolume, &lPan)) {
 		return;
 	}
 
@@ -1258,7 +1258,7 @@ void PlaySFX(_sfx_id psfx)
 {
 	psfx = RndSFX(psfx);
 
-	PlaySFX_priv(&sgSFX[psfx], false, 0, 0);
+	PlaySFX_priv(&sgSFX[psfx], false, { 0, 0 });
 }
 
 void PlaySfxLoc(_sfx_id psfx, int x, int y, bool randomizeByCategory)
@@ -1273,7 +1273,7 @@ void PlaySfxLoc(_sfx_id psfx, int x, int y, bool randomizeByCategory)
 			pSnd->start_tc = 0;
 	}
 
-	PlaySFX_priv(&sgSFX[psfx], true, x, y);
+	PlaySFX_priv(&sgSFX[psfx], true, { x, y });
 }
 
 void sound_stop()

--- a/Source/effects.h
+++ b/Source/effects.h
@@ -1179,7 +1179,7 @@ void InitMonsterSND(int monst);
 void FreeMonsterSnd();
 void PlayEffect(int i, int mode);
 void PlaySFX(_sfx_id psfx);
-void PlaySfxLoc(_sfx_id psfx, int x, int y, bool randomizeByCategory = true);
+void PlaySfxLoc(_sfx_id psfx, Point position, bool randomizeByCategory = true);
 void sound_stop();
 void sound_update();
 void effects_cleanup_sfx();

--- a/Source/effects.h
+++ b/Source/effects.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <memory>
 
+#include "engine.h"
 #include "sound.h"
 
 namespace devilution {
@@ -1187,7 +1188,7 @@ void ui_sound_init();
 void effects_play_sound(const char *snd_file);
 
 #ifndef NOSOUND
-bool calc_snd_position(int x, int y, int *plVolume, int *plPan);
+bool calc_snd_position(Point soundPosition, int *plVolume, int *plPan);
 int GetSFXLength(int nSFX);
 #endif
 

--- a/Source/effects_stubs.cpp
+++ b/Source/effects_stubs.cpp
@@ -14,7 +14,7 @@ void InitMonsterSND(int monst) { }
 void FreeMonsterSnd() { }
 void PlayEffect(int i, int mode) { }
 void PlaySFX(_sfx_id psfx) { }
-void PlaySfxLoc(_sfx_id psfx, int x, int y, bool randomizeByCategory) { }
+void PlaySfxLoc(_sfx_id psfx, Point position, bool randomizeByCategory) { }
 void sound_stop() { }
 void sound_update() { }
 void effects_cleanup_sfx() { }

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2918,7 +2918,7 @@ void RespawnItem(ItemStruct *item, bool FlipFlag)
 
 	if (item->_iCurs == ICURS_MAGIC_ROCK) {
 		item->_iSelFlag = 1;
-		PlaySfxLoc(ItemDropSnds[it], item->position.x, item->position.y);
+		PlaySfxLoc(ItemDropSnds[it], item->position);
 	}
 	if (item->_iCurs == ICURS_TAVERN_SIGN)
 		item->_iSelFlag = 1;
@@ -2968,7 +2968,7 @@ void ProcessItems()
 				items[ii].AnimInfo.CurrentFrame = 11;
 		} else {
 			if (items[ii].AnimInfo.CurrentFrame == items[ii].AnimInfo.NumberOfFrames / 2)
-				PlaySfxLoc(ItemDropSnds[ItemCAnimTbl[items[ii]._iCurs]], items[ii].position.x, items[ii].position.y);
+				PlaySfxLoc(ItemDropSnds[ItemCAnimTbl[items[ii]._iCurs]], items[ii].position);
 
 			if (items[ii].AnimInfo.CurrentFrame >= items[ii].AnimInfo.NumberOfFrames) {
 				items[ii].AnimInfo.CurrentFrame = items[ii].AnimInfo.NumberOfFrames;
@@ -3053,7 +3053,7 @@ void DoRepair(int pnum, int cii)
 
 	auto &player = plr[pnum];
 
-	PlaySfxLoc(IS_REPAIR, player.position.tile.x, player.position.tile.y);
+	PlaySfxLoc(IS_REPAIR, player.position.tile);
 
 	if (cii >= NUM_INVLOC) {
 		pi = &player.InvList[cii - NUM_INVLOC];

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1054,7 +1054,7 @@ void CheckMissileCol(int i, int mindam, int maxdam, bool shift, Point position, 
 		missile[i]._miHitFlag = false;
 	}
 	if (missile[i]._mirange == 0 && missiledata[missile[i]._mitype].miSFX != -1)
-		PlaySfxLoc(missiledata[missile[i]._mitype].miSFX, missile[i].position.tile.x, missile[i].position.tile.y);
+		PlaySfxLoc(missiledata[missile[i]._mitype].miSFX, missile[i].position.tile);
 }
 
 void SetMissAnim(int mi, int animtype)
@@ -1507,7 +1507,7 @@ void AddStealPotions(int mi, Point src, Point dst, int midir, int8_t mienemy, in
 					player.SpdList[si] = player.HoldItem;
 				}
 				if (!hasPlayedSFX) {
-					PlaySfxLoc(IS_POPPOP2, tx, ty);
+					PlaySfxLoc(IS_POPPOP2, { tx, ty });
 					hasPlayedSFX = true;
 				}
 			}
@@ -1536,7 +1536,7 @@ void AddManaTrap(int mi, Point src, Point dst, int midir, int8_t mienemy, int id
 					player._pManaBase = player._pMana + player._pMaxManaBase - player._pMaxMana;
 					CalcPlrInv(pid, false);
 					drawmanaflag = true;
-					PlaySfxLoc(TSFX_COW7, tx, ty);
+					PlaySfxLoc(TSFX_COW7, { tx, ty });
 				}
 			}
 			pn += 2;
@@ -3039,7 +3039,7 @@ int AddMissile(Point src, Point dst, int midir, int mitype, int8_t micaster, int
 	missile[mi]._mirnd = 0;
 
 	if (missiledata[mitype].mlSFX != -1) {
-		PlaySfxLoc(missiledata[mitype].mlSFX, missile[mi].position.start.x, missile[mi].position.start.y);
+		PlaySfxLoc(missiledata[mitype].mlSFX, missile[mi].position.start);
 	}
 
 	missiledata[mitype].mAddProc(mi, src, dst, midir, micaster, id, midam);
@@ -3298,7 +3298,7 @@ void MI_Firebolt(int i)
 		if (missile[i]._mlid != NO_LIGHT)
 			AddUnLight(missile[i]._mlid);
 		missile[i]._miDelFlag = true;
-		PlaySfxLoc(LS_BSIMPCT, missile[i].position.tile.x, missile[i].position.tile.y);
+		PlaySfxLoc(LS_BSIMPCT, missile[i].position.tile);
 		PutMissile(i);
 	} else
 		PutMissile(i);
@@ -3733,7 +3733,7 @@ void MI_Search(int i)
 		return;
 
 	missile[i]._miDelFlag = true;
-	PlaySfxLoc(IS_CAST7, plr[missile[i]._miVar1].position.tile.x, plr[missile[i]._miVar1].position.tile.y);
+	PlaySfxLoc(IS_CAST7, plr[missile[i]._miVar1].position.tile);
 	AutoMapShowItems = false;
 }
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2444,335 +2444,337 @@ void RedoPlayerVision()
  * @param doorPos Map tile where the door is in its closed position
  * @return true if the door is free to be closed, false if anything is blocking it
 */
-static inline bool isDoorClear(const Point &doorPos)
+static inline bool isDoorClear(const Point &doorPosition)
 {
-	return dDead[doorPos.x][doorPos.y] == 0 && dMonster[doorPos.x][doorPos.y] == 0 && dItem[doorPos.x][doorPos.y] == 0;
+	return dDead[doorPosition.x][doorPosition.y] == 0
+		&& dMonster[doorPosition.x][doorPosition.y] == 0
+		&& dItem[doorPosition.x][doorPosition.y] == 0;
 }
 
 void OperateL1RDoor(int pnum, int oi, bool sendflag)
 {
-	const Point &objPos = object[oi].position;
+	ObjectStruct &door = object[oi];
 
-	if (object[oi]._oVar4 == 2) {
+	if (door._oVar4 == 2) {
 		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, objPos);
+			PlaySfxLoc(IS_DOORCLOS, door.position);
 		return;
 	}
 
-	if (object[oi]._oVar4 == 0) {
+	if (door._oVar4 == 0) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_OPENDOOR, oi);
 		if (currlevel < 21) {
 			if (!deltaload)
-				PlaySfxLoc(IS_DOOROPEN, objPos);
-			ObjSetMicro(objPos.x, objPos.y, 395);
+				PlaySfxLoc(IS_DOOROPEN, door.position);
+			ObjSetMicro(door.position.x, door.position.y, 395);
 		} else {
 			if (!deltaload)
-				PlaySfxLoc(IS_CROPEN, objPos);
-			ObjSetMicro(objPos.x, objPos.y, 209);
+				PlaySfxLoc(IS_CROPEN, door.position);
+			ObjSetMicro(door.position.x, door.position.y, 209);
 		}
 		if (currlevel < 17) {
-			dSpecial[objPos.x][objPos.y] = 8;
+			dSpecial[door.position.x][door.position.y] = 8;
 		} else {
-			dSpecial[objPos.x][objPos.y] = 2;
+			dSpecial[door.position.x][door.position.y] = 2;
 		}
-		objects_set_door_piece(objPos.x, objPos.y - 1);
-		object[oi]._oAnimFrame += 2;
-		object[oi]._oPreFlag = true;
-		DoorSet(oi, objPos.x - 1, objPos.y);
-		object[oi]._oVar4 = 1;
-		object[oi]._oSelFlag = 2;
+		objects_set_door_piece(door.position.x, door.position.y - 1);
+		door._oAnimFrame += 2;
+		door._oPreFlag = true;
+		DoorSet(oi, door.position.x - 1, door.position.y);
+		door._oVar4 = 1;
+		door._oSelFlag = 2;
 		RedoPlayerVision();
 		return;
 	}
 
 	if (currlevel < 21) {
 		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, objPos);
+			PlaySfxLoc(IS_DOORCLOS, door.position);
 	} else {
 		if (!deltaload)
-			PlaySfxLoc(IS_CRCLOS, objPos);
+			PlaySfxLoc(IS_CRCLOS, door.position);
 	}
-	if (!deltaload && isDoorClear(objPos)) {
+	if (!deltaload && isDoorClear(door.position)) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_CLOSEDOOR, oi);
-		object[oi]._oVar4 = 0;
-		object[oi]._oSelFlag = 3;
-		ObjSetMicro(objPos.x, objPos.y, object[oi]._oVar1);
+		door._oVar4 = 0;
+		door._oSelFlag = 3;
+		ObjSetMicro(door.position.x, door.position.y, door._oVar1);
 		if (currlevel < 17) {
-			if (object[oi]._oVar2 != 50) {
-				ObjSetMicro(objPos.x - 1, objPos.y, object[oi]._oVar2);
+			if (door._oVar2 != 50) {
+				ObjSetMicro(door.position.x - 1, door.position.y, door._oVar2);
 			} else {
-				if (dPiece[objPos.x - 1][objPos.y] == 396)
-					ObjSetMicro(objPos.x - 1, objPos.y, 411);
+				if (dPiece[door.position.x - 1][door.position.y] == 396)
+					ObjSetMicro(door.position.x - 1, door.position.y, 411);
 				else
-					ObjSetMicro(objPos.x - 1, objPos.y, 50);
+					ObjSetMicro(door.position.x - 1, door.position.y, 50);
 			}
 		} else {
-			if (object[oi]._oVar2 != 86) {
-				ObjSetMicro(objPos.x - 1, objPos.y, object[oi]._oVar2);
+			if (door._oVar2 != 86) {
+				ObjSetMicro(door.position.x - 1, door.position.y, door._oVar2);
 			} else {
-				if (dPiece[objPos.x - 1][objPos.y] == 210)
-					ObjSetMicro(objPos.x - 1, objPos.y, 232);
+				if (dPiece[door.position.x - 1][door.position.y] == 210)
+					ObjSetMicro(door.position.x - 1, door.position.y, 232);
 				else
-					ObjSetMicro(objPos.x - 1, objPos.y, 86);
+					ObjSetMicro(door.position.x - 1, door.position.y, 86);
 			}
 		}
-		dSpecial[objPos.x][objPos.y] = 0;
-		object[oi]._oAnimFrame -= 2;
-		object[oi]._oPreFlag = false;
+		dSpecial[door.position.x][door.position.y] = 0;
+		door._oAnimFrame -= 2;
+		door._oPreFlag = false;
 		RedoPlayerVision();
 	} else {
-		object[oi]._oVar4 = 2;
+		door._oVar4 = 2;
 	}
 }
 
 void OperateL1LDoor(int pnum, int oi, bool sendflag)
 {
-	const Point &objPos = object[oi].position;
+	ObjectStruct &door = object[oi];
 
-	if (object[oi]._oVar4 == 2) {
+	if (door._oVar4 == 2) {
 		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, objPos);
+			PlaySfxLoc(IS_DOORCLOS, door.position);
 		return;
 	}
 
-	if (object[oi]._oVar4 == 0) {
+	if (door._oVar4 == 0) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_OPENDOOR, oi);
 		if (currlevel < 21) {
 			if (!deltaload)
-				PlaySfxLoc(IS_DOOROPEN, objPos);
-			if (object[oi]._oVar1 == 214)
-				ObjSetMicro(objPos.x, objPos.y, 408);
+				PlaySfxLoc(IS_DOOROPEN, door.position);
+			if (door._oVar1 == 214)
+				ObjSetMicro(door.position.x, door.position.y, 408);
 			else
-				ObjSetMicro(objPos.x, objPos.y, 393);
+				ObjSetMicro(door.position.x, door.position.y, 393);
 		} else {
 			if (!deltaload)
-				PlaySfxLoc(IS_CROPEN, objPos);
-			ObjSetMicro(objPos.x, objPos.y, 206);
+				PlaySfxLoc(IS_CROPEN, door.position);
+			ObjSetMicro(door.position.x, door.position.y, 206);
 		}
 		if (currlevel < 17) {
-			dSpecial[objPos.x][objPos.y] = 7;
+			dSpecial[door.position.x][door.position.y] = 7;
 		} else {
-			dSpecial[objPos.x][objPos.y] = 1;
+			dSpecial[door.position.x][door.position.y] = 1;
 		}
-		objects_set_door_piece(objPos.x - 1, objPos.y);
-		object[oi]._oAnimFrame += 2;
-		object[oi]._oPreFlag = true;
-		DoorSet(oi, objPos.x, objPos.y - 1);
-		object[oi]._oVar4 = 1;
-		object[oi]._oSelFlag = 2;
+		objects_set_door_piece(door.position.x - 1, door.position.y);
+		door._oAnimFrame += 2;
+		door._oPreFlag = true;
+		DoorSet(oi, door.position.x, door.position.y - 1);
+		door._oVar4 = 1;
+		door._oSelFlag = 2;
 		RedoPlayerVision();
 		return;
 	}
 
 	if (currlevel < 21) {
 		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, objPos);
+			PlaySfxLoc(IS_DOORCLOS, door.position);
 	} else {
 		if (!deltaload)
-			PlaySfxLoc(IS_CRCLOS, objPos);
+			PlaySfxLoc(IS_CRCLOS, door.position);
 	}
-	if (isDoorClear(objPos)) {
+	if (isDoorClear(door.position)) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_CLOSEDOOR, oi);
-		object[oi]._oVar4 = 0;
-		object[oi]._oSelFlag = 3;
-		ObjSetMicro(objPos.x, objPos.y, object[oi]._oVar1);
+		door._oVar4 = 0;
+		door._oSelFlag = 3;
+		ObjSetMicro(door.position.x, door.position.y, door._oVar1);
 		if (currlevel < 17) {
-			if (object[oi]._oVar2 != 50) {
-				ObjSetMicro(objPos.x, objPos.y - 1, object[oi]._oVar2);
+			if (door._oVar2 != 50) {
+				ObjSetMicro(door.position.x, door.position.y - 1, door._oVar2);
 			} else {
-				if (dPiece[objPos.x][objPos.y - 1] == 396)
-					ObjSetMicro(objPos.x, objPos.y - 1, 412);
+				if (dPiece[door.position.x][door.position.y - 1] == 396)
+					ObjSetMicro(door.position.x, door.position.y - 1, 412);
 				else
-					ObjSetMicro(objPos.x, objPos.y - 1, 50);
+					ObjSetMicro(door.position.x, door.position.y - 1, 50);
 			}
 		} else {
-			if (object[oi]._oVar2 != 86) {
-				ObjSetMicro(objPos.x, objPos.y - 1, object[oi]._oVar2);
+			if (door._oVar2 != 86) {
+				ObjSetMicro(door.position.x, door.position.y - 1, door._oVar2);
 			} else {
-				if (dPiece[objPos.x][objPos.y - 1] == 210)
-					ObjSetMicro(objPos.x, objPos.y - 1, 234);
+				if (dPiece[door.position.x][door.position.y - 1] == 210)
+					ObjSetMicro(door.position.x, door.position.y - 1, 234);
 				else
-					ObjSetMicro(objPos.x, objPos.y - 1, 86);
+					ObjSetMicro(door.position.x, door.position.y - 1, 86);
 			}
 		}
-		dSpecial[objPos.x][objPos.y] = 0;
-		object[oi]._oAnimFrame -= 2;
-		object[oi]._oPreFlag = false;
+		dSpecial[door.position.x][door.position.y] = 0;
+		door._oAnimFrame -= 2;
+		door._oPreFlag = false;
 		RedoPlayerVision();
 	} else {
-		object[oi]._oVar4 = 2;
+		door._oVar4 = 2;
 	}
 }
 
 void OperateL2RDoor(int pnum, int oi, bool sendflag)
 {
-	const Point &objPos = object[oi].position;
+	ObjectStruct &door = object[oi];
 
-	if (object[oi]._oVar4 == 2) {
+	if (door._oVar4 == 2) {
 		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, objPos);
+			PlaySfxLoc(IS_DOORCLOS, door.position);
 		return;
 	}
 
-	if (object[oi]._oVar4 == 0) {
+	if (door._oVar4 == 0) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_OPENDOOR, oi);
 		if (!deltaload)
-			PlaySfxLoc(IS_DOOROPEN, objPos);
-		ObjSetMicro(objPos.x, objPos.y, 17);
-		dSpecial[objPos.x][objPos.y] = 6;
-		object[oi]._oAnimFrame += 2;
-		object[oi]._oPreFlag = true;
-		object[oi]._oVar4 = 1;
-		object[oi]._oSelFlag = 2;
+			PlaySfxLoc(IS_DOOROPEN, door.position);
+		ObjSetMicro(door.position.x, door.position.y, 17);
+		dSpecial[door.position.x][door.position.y] = 6;
+		door._oAnimFrame += 2;
+		door._oPreFlag = true;
+		door._oVar4 = 1;
+		door._oSelFlag = 2;
 		RedoPlayerVision();
 		return;
 	}
 
 	if (!deltaload)
-		PlaySfxLoc(IS_DOORCLOS, objPos);
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 
-	if (isDoorClear(objPos)) {
+	if (isDoorClear(door.position)) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_CLOSEDOOR, oi);
-		object[oi]._oVar4 = 0;
-		object[oi]._oSelFlag = 3;
-		ObjSetMicro(objPos.x, objPos.y, 540);
-		dSpecial[objPos.x][objPos.y] = 0;
-		object[oi]._oAnimFrame -= 2;
-		object[oi]._oPreFlag = false;
+		door._oVar4 = 0;
+		door._oSelFlag = 3;
+		ObjSetMicro(door.position.x, door.position.y, 540);
+		dSpecial[door.position.x][door.position.y] = 0;
+		door._oAnimFrame -= 2;
+		door._oPreFlag = false;
 		RedoPlayerVision();
 	} else {
-		object[oi]._oVar4 = 2;
+		door._oVar4 = 2;
 	}
 }
 
 void OperateL2LDoor(int pnum, int oi, bool sendflag)
 {
-	const Point &objPos = object[oi].position;
+	ObjectStruct &door = object[oi];
 
-	if (object[oi]._oVar4 == 2) {
+	if (door._oVar4 == 2) {
 		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, objPos);
+			PlaySfxLoc(IS_DOORCLOS, door.position);
 		return;
 	}
 
-	if (object[oi]._oVar4 == 0) {
+	if (door._oVar4 == 0) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_OPENDOOR, oi);
 		if (!deltaload)
-			PlaySfxLoc(IS_DOOROPEN, objPos);
-		ObjSetMicro(objPos.x, objPos.y, 13);
-		dSpecial[objPos.x][objPos.y] = 5;
-		object[oi]._oAnimFrame += 2;
-		object[oi]._oPreFlag = true;
-		object[oi]._oVar4 = 1;
-		object[oi]._oSelFlag = 2;
+			PlaySfxLoc(IS_DOOROPEN, door.position);
+		ObjSetMicro(door.position.x, door.position.y, 13);
+		dSpecial[door.position.x][door.position.y] = 5;
+		door._oAnimFrame += 2;
+		door._oPreFlag = true;
+		door._oVar4 = 1;
+		door._oSelFlag = 2;
 		RedoPlayerVision();
 		return;
 	}
 
 	if (!deltaload)
-		PlaySfxLoc(IS_DOORCLOS, objPos);
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 
-	if (isDoorClear(objPos)) {
+	if (isDoorClear(door.position)) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_CLOSEDOOR, oi);
-		object[oi]._oVar4 = 0;
-		object[oi]._oSelFlag = 3;
-		ObjSetMicro(objPos.x, objPos.y, 538);
-		dSpecial[objPos.x][objPos.y] = 0;
-		object[oi]._oAnimFrame -= 2;
-		object[oi]._oPreFlag = false;
+		door._oVar4 = 0;
+		door._oSelFlag = 3;
+		ObjSetMicro(door.position.x, door.position.y, 538);
+		dSpecial[door.position.x][door.position.y] = 0;
+		door._oAnimFrame -= 2;
+		door._oPreFlag = false;
 		RedoPlayerVision();
 	} else {
-		object[oi]._oVar4 = 2;
+		door._oVar4 = 2;
 	}
 }
 
 void OperateL3RDoor(int pnum, int oi, bool sendflag)
 {
-	const Point &objPos = object[oi].position;
+	ObjectStruct &door = object[oi];
 
-	if (object[oi]._oVar4 == 2) {
+	if (door._oVar4 == 2) {
 		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, objPos);
+			PlaySfxLoc(IS_DOORCLOS, door.position);
 		return;
 	}
 
-	if (object[oi]._oVar4 == 0) {
+	if (door._oVar4 == 0) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_OPENDOOR, oi);
 		if (!deltaload)
-			PlaySfxLoc(IS_DOOROPEN, objPos);
-		ObjSetMicro(objPos.x, objPos.y, 541);
-		object[oi]._oAnimFrame += 2;
-		object[oi]._oPreFlag = true;
-		object[oi]._oVar4 = 1;
-		object[oi]._oSelFlag = 2;
+			PlaySfxLoc(IS_DOOROPEN, door.position);
+		ObjSetMicro(door.position.x, door.position.y, 541);
+		door._oAnimFrame += 2;
+		door._oPreFlag = true;
+		door._oVar4 = 1;
+		door._oSelFlag = 2;
 		RedoPlayerVision();
 		return;
 	}
 
 	if (!deltaload)
-		PlaySfxLoc(IS_DOORCLOS, objPos);
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 
-	if (isDoorClear(objPos)) {
+	if (isDoorClear(door.position)) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_CLOSEDOOR, oi);
-		object[oi]._oVar4 = 0;
-		object[oi]._oSelFlag = 3;
-		ObjSetMicro(objPos.x, objPos.y, 534);
-		object[oi]._oAnimFrame -= 2;
-		object[oi]._oPreFlag = false;
+		door._oVar4 = 0;
+		door._oSelFlag = 3;
+		ObjSetMicro(door.position.x, door.position.y, 534);
+		door._oAnimFrame -= 2;
+		door._oPreFlag = false;
 		RedoPlayerVision();
 	} else {
-		object[oi]._oVar4 = 2;
+		door._oVar4 = 2;
 	}
 }
 
 void OperateL3LDoor(int pnum, int oi, bool sendflag)
 {
-	const Point &objPos = object[oi].position;
+	ObjectStruct &door = object[oi];
 
-	if (object[oi]._oVar4 == 2) {
+	if (door._oVar4 == 2) {
 		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, objPos);
+			PlaySfxLoc(IS_DOORCLOS, door.position);
 		return;
 	}
 
-	if (object[oi]._oVar4 == 0) {
+	if (door._oVar4 == 0) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_OPENDOOR, oi);
 		if (!deltaload)
-			PlaySfxLoc(IS_DOOROPEN, objPos);
-		ObjSetMicro(objPos.x, objPos.y, 538);
-		object[oi]._oAnimFrame += 2;
-		object[oi]._oPreFlag = true;
-		object[oi]._oVar4 = 1;
-		object[oi]._oSelFlag = 2;
+			PlaySfxLoc(IS_DOOROPEN, door.position);
+		ObjSetMicro(door.position.x, door.position.y, 538);
+		door._oAnimFrame += 2;
+		door._oPreFlag = true;
+		door._oVar4 = 1;
+		door._oSelFlag = 2;
 		RedoPlayerVision();
 		return;
 	}
 
 	if (!deltaload)
-		PlaySfxLoc(IS_DOORCLOS, objPos);
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 
-	if (isDoorClear(objPos)) {
+	if (isDoorClear(door.position)) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_CLOSEDOOR, oi);
-		object[oi]._oVar4 = 0;
-		object[oi]._oSelFlag = 3;
-		ObjSetMicro(objPos.x, objPos.y, 531);
-		object[oi]._oAnimFrame -= 2;
-		object[oi]._oPreFlag = false;
+		door._oVar4 = 0;
+		door._oSelFlag = 3;
+		ObjSetMicro(door.position.x, door.position.y, 531);
+		door._oAnimFrame -= 2;
+		door._oPreFlag = false;
 		RedoPlayerVision();
 	} else {
-		object[oi]._oVar4 = 2;
+		door._oVar4 = 2;
 	}
 }
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2122,7 +2122,7 @@ void Obj_Trap(int i)
 	if (!deltaload) {
 		Direction dir = GetDirection(object[i].position, target);
 		AddMissile(object[i].position, target, dir, object[i]._oVar3, TARGET_PLAYERS, -1, 0, 0);
-		PlaySfxLoc(IS_TRAP, object[oti].position.x, object[oti].position.y);
+		PlaySfxLoc(IS_TRAP, object[oti].position);
 	}
 	object[oti]._oTrapFlag = false;
 }
@@ -2436,39 +2436,50 @@ void RedoPlayerVision()
 	}
 }
 
+/**
+ * @brief Checks if an open door can be closed
+ *
+ * In order to be able to close a door the space where the closed door would be must be free of bodies, monsters, and items
+ *
+ * @param doorPos Map tile where the door is in its closed position
+ * @return true if the door is free to be closed, false if anything is blocking it
+*/
+static inline bool isDoorClear(const Point &doorPos)
+{
+	return dDead[doorPos.x][doorPos.y] == 0 && dMonster[doorPos.x][doorPos.y] == 0 && dItem[doorPos.x][doorPos.y] == 0;
+}
+
 void OperateL1RDoor(int pnum, int oi, bool sendflag)
 {
-	int xp, yp;
+	const Point &objPos = object[oi].position;
 
 	if (object[oi]._oVar4 == 2) {
 		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, object[oi].position.x, object[oi].position.y);
+			PlaySfxLoc(IS_DOORCLOS, objPos);
 		return;
 	}
 
-	xp = object[oi].position.x;
-	yp = object[oi].position.y;
 	if (object[oi]._oVar4 == 0) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_OPENDOOR, oi);
 		if (currlevel < 21) {
 			if (!deltaload)
-				PlaySfxLoc(IS_DOOROPEN, object[oi].position.x, object[oi].position.y);
-			ObjSetMicro(xp, yp, 395);
+				PlaySfxLoc(IS_DOOROPEN, objPos);
+			ObjSetMicro(objPos.x, objPos.y, 395);
 		} else {
 			if (!deltaload)
-				PlaySfxLoc(IS_CROPEN, object[oi].position.x, object[oi].position.y);
-			ObjSetMicro(xp, yp, 209);
+				PlaySfxLoc(IS_CROPEN, objPos);
+			ObjSetMicro(objPos.x, objPos.y, 209);
 		}
 		if (currlevel < 17) {
-			dSpecial[xp][yp] = 8;
+			dSpecial[objPos.x][objPos.y] = 8;
 		} else {
-			dSpecial[xp][yp] = 2;
+			dSpecial[objPos.x][objPos.y] = 2;
 		}
-		objects_set_door_piece(xp, yp - 1);
+		objects_set_door_piece(objPos.x, objPos.y - 1);
 		object[oi]._oAnimFrame += 2;
 		object[oi]._oPreFlag = true;
-		DoorSet(oi, xp - 1, yp);
+		DoorSet(oi, objPos.x - 1, objPos.y);
 		object[oi]._oVar4 = 1;
 		object[oi]._oSelFlag = 2;
 		RedoPlayerVision();
@@ -2477,37 +2488,37 @@ void OperateL1RDoor(int pnum, int oi, bool sendflag)
 
 	if (currlevel < 21) {
 		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, xp, object[oi].position.y);
+			PlaySfxLoc(IS_DOORCLOS, objPos);
 	} else {
 		if (!deltaload)
-			PlaySfxLoc(IS_CRCLOS, xp, object[oi].position.y);
+			PlaySfxLoc(IS_CRCLOS, objPos);
 	}
-	if (!deltaload && dDead[xp][yp] == 0 && dMonster[xp][yp] == 0 && dItem[xp][yp] == 0) {
+	if (!deltaload && isDoorClear(objPos)) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_CLOSEDOOR, oi);
 		object[oi]._oVar4 = 0;
 		object[oi]._oSelFlag = 3;
-		ObjSetMicro(xp, yp, object[oi]._oVar1);
+		ObjSetMicro(objPos.x, objPos.y, object[oi]._oVar1);
 		if (currlevel < 17) {
 			if (object[oi]._oVar2 != 50) {
-				ObjSetMicro(xp - 1, yp, object[oi]._oVar2);
+				ObjSetMicro(objPos.x - 1, objPos.y, object[oi]._oVar2);
 			} else {
-				if (dPiece[xp - 1][yp] == 396)
-					ObjSetMicro(xp - 1, yp, 411);
+				if (dPiece[objPos.x - 1][objPos.y] == 396)
+					ObjSetMicro(objPos.x - 1, objPos.y, 411);
 				else
-					ObjSetMicro(xp - 1, yp, 50);
+					ObjSetMicro(objPos.x - 1, objPos.y, 50);
 			}
 		} else {
 			if (object[oi]._oVar2 != 86) {
-				ObjSetMicro(xp - 1, yp, object[oi]._oVar2);
+				ObjSetMicro(objPos.x - 1, objPos.y, object[oi]._oVar2);
 			} else {
-				if (dPiece[xp - 1][yp] == 210)
-					ObjSetMicro(xp - 1, yp, 232);
+				if (dPiece[objPos.x - 1][objPos.y] == 210)
+					ObjSetMicro(objPos.x - 1, objPos.y, 232);
 				else
-					ObjSetMicro(xp - 1, yp, 86);
+					ObjSetMicro(objPos.x - 1, objPos.y, 86);
 			}
 		}
-		dSpecial[xp][yp] = 0;
+		dSpecial[objPos.x][objPos.y] = 0;
 		object[oi]._oAnimFrame -= 2;
 		object[oi]._oPreFlag = false;
 		RedoPlayerVision();
@@ -2518,40 +2529,38 @@ void OperateL1RDoor(int pnum, int oi, bool sendflag)
 
 void OperateL1LDoor(int pnum, int oi, bool sendflag)
 {
-	int xp, yp;
+	const Point &objPos = object[oi].position;
 
 	if (object[oi]._oVar4 == 2) {
 		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, object[oi].position.x, object[oi].position.y);
+			PlaySfxLoc(IS_DOORCLOS, objPos);
 		return;
 	}
 
-	xp = object[oi].position.x;
-	yp = object[oi].position.y;
 	if (object[oi]._oVar4 == 0) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_OPENDOOR, oi);
 		if (currlevel < 21) {
 			if (!deltaload)
-				PlaySfxLoc(IS_DOOROPEN, object[oi].position.x, object[oi].position.y);
+				PlaySfxLoc(IS_DOOROPEN, objPos);
 			if (object[oi]._oVar1 == 214)
-				ObjSetMicro(xp, yp, 408);
+				ObjSetMicro(objPos.x, objPos.y, 408);
 			else
-				ObjSetMicro(xp, yp, 393);
+				ObjSetMicro(objPos.x, objPos.y, 393);
 		} else {
 			if (!deltaload)
-				PlaySfxLoc(IS_CROPEN, object[oi].position.x, object[oi].position.y);
-			ObjSetMicro(xp, yp, 206);
+				PlaySfxLoc(IS_CROPEN, objPos);
+			ObjSetMicro(objPos.x, objPos.y, 206);
 		}
 		if (currlevel < 17) {
-			dSpecial[xp][yp] = 7;
+			dSpecial[objPos.x][objPos.y] = 7;
 		} else {
-			dSpecial[xp][yp] = 1;
+			dSpecial[objPos.x][objPos.y] = 1;
 		}
-		objects_set_door_piece(xp - 1, yp);
+		objects_set_door_piece(objPos.x - 1, objPos.y);
 		object[oi]._oAnimFrame += 2;
 		object[oi]._oPreFlag = true;
-		DoorSet(oi, xp, yp - 1);
+		DoorSet(oi, objPos.x, objPos.y - 1);
 		object[oi]._oVar4 = 1;
 		object[oi]._oSelFlag = 2;
 		RedoPlayerVision();
@@ -2560,37 +2569,37 @@ void OperateL1LDoor(int pnum, int oi, bool sendflag)
 
 	if (currlevel < 21) {
 		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, xp, object[oi].position.y);
+			PlaySfxLoc(IS_DOORCLOS, objPos);
 	} else {
 		if (!deltaload)
-			PlaySfxLoc(IS_CRCLOS, xp, object[oi].position.y);
+			PlaySfxLoc(IS_CRCLOS, objPos);
 	}
-	if (dDead[xp][yp] == 0 && dMonster[xp][yp] == 0 && dItem[xp][yp] == 0) {
+	if (isDoorClear(objPos)) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_CLOSEDOOR, oi);
 		object[oi]._oVar4 = 0;
 		object[oi]._oSelFlag = 3;
-		ObjSetMicro(xp, yp, object[oi]._oVar1);
+		ObjSetMicro(objPos.x, objPos.y, object[oi]._oVar1);
 		if (currlevel < 17) {
 			if (object[oi]._oVar2 != 50) {
-				ObjSetMicro(xp, yp - 1, object[oi]._oVar2);
+				ObjSetMicro(objPos.x, objPos.y - 1, object[oi]._oVar2);
 			} else {
-				if (dPiece[xp][yp - 1] == 396)
-					ObjSetMicro(xp, yp - 1, 412);
+				if (dPiece[objPos.x][objPos.y - 1] == 396)
+					ObjSetMicro(objPos.x, objPos.y - 1, 412);
 				else
-					ObjSetMicro(xp, yp - 1, 50);
+					ObjSetMicro(objPos.x, objPos.y - 1, 50);
 			}
 		} else {
 			if (object[oi]._oVar2 != 86) {
-				ObjSetMicro(xp, yp - 1, object[oi]._oVar2);
+				ObjSetMicro(objPos.x, objPos.y - 1, object[oi]._oVar2);
 			} else {
-				if (dPiece[xp][yp - 1] == 210)
-					ObjSetMicro(xp, yp - 1, 234);
+				if (dPiece[objPos.x][objPos.y - 1] == 210)
+					ObjSetMicro(objPos.x, objPos.y - 1, 234);
 				else
-					ObjSetMicro(xp, yp - 1, 86);
+					ObjSetMicro(objPos.x, objPos.y - 1, 86);
 			}
 		}
-		dSpecial[xp][yp] = 0;
+		dSpecial[objPos.x][objPos.y] = 0;
 		object[oi]._oAnimFrame -= 2;
 		object[oi]._oPreFlag = false;
 		RedoPlayerVision();
@@ -2601,23 +2610,21 @@ void OperateL1LDoor(int pnum, int oi, bool sendflag)
 
 void OperateL2RDoor(int pnum, int oi, bool sendflag)
 {
-	int xp, yp;
-	bool dok;
+	const Point &objPos = object[oi].position;
 
 	if (object[oi]._oVar4 == 2) {
 		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, object[oi].position.x, object[oi].position.y);
+			PlaySfxLoc(IS_DOORCLOS, objPos);
 		return;
 	}
-	xp = object[oi].position.x;
-	yp = object[oi].position.y;
+
 	if (object[oi]._oVar4 == 0) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_OPENDOOR, oi);
 		if (!deltaload)
-			PlaySfxLoc(IS_DOOROPEN, object[oi].position.x, object[oi].position.y);
-		ObjSetMicro(xp, yp, 17);
-		dSpecial[xp][yp] = 6;
+			PlaySfxLoc(IS_DOOROPEN, objPos);
+		ObjSetMicro(objPos.x, objPos.y, 17);
+		dSpecial[objPos.x][objPos.y] = 6;
 		object[oi]._oAnimFrame += 2;
 		object[oi]._oPreFlag = true;
 		object[oi]._oVar4 = 1;
@@ -2627,17 +2634,15 @@ void OperateL2RDoor(int pnum, int oi, bool sendflag)
 	}
 
 	if (!deltaload)
-		PlaySfxLoc(IS_DOORCLOS, object[oi].position.x, yp);
-	dok = dMonster[xp][yp] == 0;
-	dok = dok && dItem[xp][yp] == 0;
-	dok = dok && dDead[xp][yp] == 0;
-	if (dok) {
+		PlaySfxLoc(IS_DOORCLOS, objPos);
+
+	if (isDoorClear(objPos)) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_CLOSEDOOR, oi);
 		object[oi]._oVar4 = 0;
 		object[oi]._oSelFlag = 3;
-		ObjSetMicro(xp, yp, 540);
-		dSpecial[xp][yp] = 0;
+		ObjSetMicro(objPos.x, objPos.y, 540);
+		dSpecial[objPos.x][objPos.y] = 0;
 		object[oi]._oAnimFrame -= 2;
 		object[oi]._oPreFlag = false;
 		RedoPlayerVision();
@@ -2648,23 +2653,21 @@ void OperateL2RDoor(int pnum, int oi, bool sendflag)
 
 void OperateL2LDoor(int pnum, int oi, bool sendflag)
 {
-	int xp, yp;
-	bool dok;
+	const Point &objPos = object[oi].position;
 
 	if (object[oi]._oVar4 == 2) {
 		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, object[oi].position.x, object[oi].position.y);
+			PlaySfxLoc(IS_DOORCLOS, objPos);
 		return;
 	}
-	xp = object[oi].position.x;
-	yp = object[oi].position.y;
+
 	if (object[oi]._oVar4 == 0) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_OPENDOOR, oi);
 		if (!deltaload)
-			PlaySfxLoc(IS_DOOROPEN, object[oi].position.x, object[oi].position.y);
-		ObjSetMicro(xp, yp, 13);
-		dSpecial[xp][yp] = 5;
+			PlaySfxLoc(IS_DOOROPEN, objPos);
+		ObjSetMicro(objPos.x, objPos.y, 13);
+		dSpecial[objPos.x][objPos.y] = 5;
 		object[oi]._oAnimFrame += 2;
 		object[oi]._oPreFlag = true;
 		object[oi]._oVar4 = 1;
@@ -2674,17 +2677,15 @@ void OperateL2LDoor(int pnum, int oi, bool sendflag)
 	}
 
 	if (!deltaload)
-		PlaySfxLoc(IS_DOORCLOS, object[oi].position.x, yp);
-	dok = dMonster[xp][yp] == 0;
-	dok = dok && dItem[xp][yp] == 0;
-	dok = dok && dDead[xp][yp] == 0;
-	if (dok) {
+		PlaySfxLoc(IS_DOORCLOS, objPos);
+
+	if (isDoorClear(objPos)) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_CLOSEDOOR, oi);
 		object[oi]._oVar4 = 0;
 		object[oi]._oSelFlag = 3;
-		ObjSetMicro(xp, yp, 538);
-		dSpecial[xp][yp] = 0;
+		ObjSetMicro(objPos.x, objPos.y, 538);
+		dSpecial[objPos.x][objPos.y] = 0;
 		object[oi]._oAnimFrame -= 2;
 		object[oi]._oPreFlag = false;
 		RedoPlayerVision();
@@ -2695,23 +2696,20 @@ void OperateL2LDoor(int pnum, int oi, bool sendflag)
 
 void OperateL3RDoor(int pnum, int oi, bool sendflag)
 {
-	int xp, yp;
-	bool dok;
+	const Point &objPos = object[oi].position;
 
 	if (object[oi]._oVar4 == 2) {
 		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, object[oi].position.x, object[oi].position.y);
+			PlaySfxLoc(IS_DOORCLOS, objPos);
 		return;
 	}
 
-	xp = object[oi].position.x;
-	yp = object[oi].position.y;
 	if (object[oi]._oVar4 == 0) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_OPENDOOR, oi);
 		if (!deltaload)
-			PlaySfxLoc(IS_DOOROPEN, object[oi].position.x, object[oi].position.y);
-		ObjSetMicro(xp, yp, 541);
+			PlaySfxLoc(IS_DOOROPEN, objPos);
+		ObjSetMicro(objPos.x, objPos.y, 541);
 		object[oi]._oAnimFrame += 2;
 		object[oi]._oPreFlag = true;
 		object[oi]._oVar4 = 1;
@@ -2721,16 +2719,14 @@ void OperateL3RDoor(int pnum, int oi, bool sendflag)
 	}
 
 	if (!deltaload)
-		PlaySfxLoc(IS_DOORCLOS, object[oi].position.x, yp);
-	dok = dMonster[xp][yp] == 0;
-	dok = dok && dItem[xp][yp] == 0;
-	dok = dok && dDead[xp][yp] == 0;
-	if (dok) {
+		PlaySfxLoc(IS_DOORCLOS, objPos);
+
+	if (isDoorClear(objPos)) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_CLOSEDOOR, oi);
 		object[oi]._oVar4 = 0;
 		object[oi]._oSelFlag = 3;
-		ObjSetMicro(xp, yp, 534);
+		ObjSetMicro(objPos.x, objPos.y, 534);
 		object[oi]._oAnimFrame -= 2;
 		object[oi]._oPreFlag = false;
 		RedoPlayerVision();
@@ -2741,23 +2737,20 @@ void OperateL3RDoor(int pnum, int oi, bool sendflag)
 
 void OperateL3LDoor(int pnum, int oi, bool sendflag)
 {
-	int xp, yp;
-	bool dok;
+	const Point &objPos = object[oi].position;
 
 	if (object[oi]._oVar4 == 2) {
 		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, object[oi].position.x, object[oi].position.y);
+			PlaySfxLoc(IS_DOORCLOS, objPos);
 		return;
 	}
 
-	xp = object[oi].position.x;
-	yp = object[oi].position.y;
 	if (object[oi]._oVar4 == 0) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_OPENDOOR, oi);
 		if (!deltaload)
-			PlaySfxLoc(IS_DOOROPEN, object[oi].position.x, object[oi].position.y);
-		ObjSetMicro(xp, yp, 538);
+			PlaySfxLoc(IS_DOOROPEN, objPos);
+		ObjSetMicro(objPos.x, objPos.y, 538);
 		object[oi]._oAnimFrame += 2;
 		object[oi]._oPreFlag = true;
 		object[oi]._oVar4 = 1;
@@ -2767,16 +2760,14 @@ void OperateL3LDoor(int pnum, int oi, bool sendflag)
 	}
 
 	if (!deltaload)
-		PlaySfxLoc(IS_DOORCLOS, object[oi].position.x, yp);
-	dok = dMonster[xp][yp] == 0;
-	dok = dok && dItem[xp][yp] == 0;
-	dok = dok && dDead[xp][yp] == 0;
-	if (dok) {
+		PlaySfxLoc(IS_DOORCLOS, objPos);
+
+	if (isDoorClear(objPos)) {
 		if (pnum == myplr && sendflag)
 			NetSendCmdParam1(true, CMD_CLOSEDOOR, oi);
 		object[oi]._oVar4 = 0;
 		object[oi]._oSelFlag = 3;
-		ObjSetMicro(xp, yp, 531);
+		ObjSetMicro(objPos.x, objPos.y, 531);
 		object[oi]._oAnimFrame -= 2;
 		object[oi]._oPreFlag = false;
 		RedoPlayerVision();
@@ -2887,7 +2878,7 @@ void OperateLever(int pnum, int i)
 
 	if (object[i]._oSelFlag != 0) {
 		if (!deltaload)
-			PlaySfxLoc(IS_LEVER, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(IS_LEVER, object[i].position);
 		object[i]._oSelFlag = 0;
 		object[i]._oAnimFrame++;
 		mapflag = true;
@@ -2962,7 +2953,7 @@ void OperateBook(int pnum, int i)
 			plr[pnum]._pSplLvl[SPL_GUARDIAN]++;
 		quests[Q_SCHAMB]._qactive = QUEST_DONE;
 		if (!deltaload)
-			PlaySfxLoc(IS_QUESTDN, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(IS_QUESTDN, object[i].position);
 		InitDiabloMsg(EMSG_BONECHAMB);
 		AddMissile(
 		    plr[pnum].position.tile,
@@ -3078,7 +3069,7 @@ void OperateChest(int pnum, int i, bool sendmsg)
 
 	if (object[i]._oSelFlag != 0) {
 		if (!deltaload)
-			PlaySfxLoc(IS_CHEST, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(IS_CHEST, object[i].position);
 		object[i]._oSelFlag = 0;
 		object[i]._oAnimFrame += 2;
 		if (!deltaload) {
@@ -3144,7 +3135,7 @@ void OperateMushPatch(int pnum, int i)
 
 	if (object[i]._oSelFlag != 0) {
 		if (!deltaload)
-			PlaySfxLoc(IS_CHEST, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(IS_CHEST, object[i].position);
 		object[i]._oSelFlag = 0;
 		object[i]._oAnimFrame++;
 		if (!deltaload) {
@@ -3168,7 +3159,7 @@ void OperateInnSignChest(int pnum, int i)
 	} else {
 		if (object[i]._oSelFlag != 0) {
 			if (!deltaload)
-				PlaySfxLoc(IS_CHEST, object[i].position.x, object[i].position.y);
+				PlaySfxLoc(IS_CHEST, object[i].position);
 			object[i]._oSelFlag = 0;
 			object[i]._oAnimFrame += 2;
 			if (!deltaload) {
@@ -3212,7 +3203,7 @@ void OperateTrapLvr(int i)
 	j = 0;
 
 	if (!deltaload)
-		PlaySfxLoc(IS_LEVER, object[i].position.x, object[i].position.y);
+		PlaySfxLoc(IS_LEVER, object[i].position);
 
 	if (frame == 1) {
 		object[i]._oAnimFrame = 2;
@@ -3241,7 +3232,7 @@ void OperateSarc(int pnum, int i, bool sendmsg)
 {
 	if (object[i]._oSelFlag != 0) {
 		if (!deltaload)
-			PlaySfxLoc(IS_SARC, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(IS_SARC, object[i].position);
 		object[i]._oSelFlag = 0;
 		if (deltaload) {
 			object[i]._oAnimFrame = object[i]._oAnimLen;
@@ -3297,19 +3288,19 @@ void OperatePedistal(int pnum, int i)
 	object[i]._oVar6++;
 	if (object[i]._oVar6 == 1) {
 		if (!deltaload)
-			PlaySfxLoc(LS_PUDDLE, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(LS_PUDDLE, object[i].position);
 		ObjChangeMap(setpc_x, setpc_y + 3, setpc_x + 2, setpc_y + 7);
 		SpawnQuestItem(IDI_BLDSTONE, { 2 * setpc_x + 19, 2 * setpc_y + 26 }, 0, true);
 	}
 	if (object[i]._oVar6 == 2) {
 		if (!deltaload)
-			PlaySfxLoc(LS_PUDDLE, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(LS_PUDDLE, object[i].position);
 		ObjChangeMap(setpc_x + 6, setpc_y + 3, setpc_x + setpc_w, setpc_y + 7);
 		SpawnQuestItem(IDI_BLDSTONE, { 2 * setpc_x + 31, 2 * setpc_y + 26 }, 0, true);
 	}
 	if (object[i]._oVar6 == 3) {
 		if (!deltaload)
-			PlaySfxLoc(LS_BLODSTAR, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(LS_BLODSTAR, object[i].position);
 		ObjChangeMap(object[i]._oVar1, object[i]._oVar2, object[i]._oVar3, object[i]._oVar4);
 		LoadMapObjs("Levels\\L2Data\\Blood2.DUN", 2 * setpc_x, 2 * setpc_y);
 		SpawnUnique(UITEM_ARMOFVAL, Point { setpc_x, setpc_y } * 2 + Point { 25, 19 });
@@ -4310,7 +4301,7 @@ void OperateShrine(int pnum, int i, _sfx_id sType)
 	object[i]._oSelFlag = 0;
 
 	if (!deltaload) {
-		PlaySfxLoc(sType, object[i].position.x, object[i].position.y);
+		PlaySfxLoc(sType, object[i].position);
 		object[i]._oAnimFlag = 1;
 		object[i]._oAnimDelay = 1;
 	} else {
@@ -4465,7 +4456,7 @@ void OperateSkelBook(int pnum, int i, bool sendmsg)
 {
 	if (object[i]._oSelFlag != 0) {
 		if (!deltaload)
-			PlaySfxLoc(IS_ISCROL, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(IS_ISCROL, object[i].position);
 		object[i]._oSelFlag = 0;
 		object[i]._oAnimFrame += 2;
 		if (!deltaload) {
@@ -4484,7 +4475,7 @@ void OperateBookCase(int pnum, int i, bool sendmsg)
 {
 	if (object[i]._oSelFlag != 0) {
 		if (!deltaload)
-			PlaySfxLoc(IS_ISCROL, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(IS_ISCROL, object[i].position);
 		object[i]._oSelFlag = 0;
 		object[i]._oAnimFrame -= 2;
 		if (!deltaload) {
@@ -4612,7 +4603,7 @@ bool OperateFountains(int pnum, int i)
 			return false;
 
 		if (plr[pnum]._pHitPoints < plr[pnum]._pMaxHP) {
-			PlaySfxLoc(LS_FOUNTAIN, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(LS_FOUNTAIN, object[i].position);
 			plr[pnum]._pHitPoints += 64;
 			plr[pnum]._pHPBase += 64;
 			if (plr[pnum]._pHitPoints > plr[pnum]._pMaxHP) {
@@ -4621,7 +4612,7 @@ bool OperateFountains(int pnum, int i)
 			}
 			applied = true;
 		} else
-			PlaySfxLoc(LS_FOUNTAIN, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(LS_FOUNTAIN, object[i].position);
 		break;
 	case OBJ_PURIFYINGFTN:
 		if (deltaload)
@@ -4630,7 +4621,7 @@ bool OperateFountains(int pnum, int i)
 			return false;
 
 		if (plr[pnum]._pMana < plr[pnum]._pMaxMana) {
-			PlaySfxLoc(LS_FOUNTAIN, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(LS_FOUNTAIN, object[i].position);
 
 			plr[pnum]._pMana += 64;
 			plr[pnum]._pManaBase += 64;
@@ -4641,13 +4632,13 @@ bool OperateFountains(int pnum, int i)
 
 			applied = true;
 		} else
-			PlaySfxLoc(LS_FOUNTAIN, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(LS_FOUNTAIN, object[i].position);
 		break;
 	case OBJ_MURKYFTN:
 		if (object[i]._oSelFlag == 0)
 			break;
 		if (!deltaload)
-			PlaySfxLoc(LS_FOUNTAIN, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(LS_FOUNTAIN, object[i].position);
 		object[i]._oSelFlag = 0;
 		if (deltaload)
 			return false;
@@ -4672,7 +4663,7 @@ bool OperateFountains(int pnum, int i)
 		done = false;
 		cnt = 0;
 		if (!deltaload)
-			PlaySfxLoc(LS_FOUNTAIN, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(LS_FOUNTAIN, object[i].position);
 		object[i]._oSelFlag = 0;
 		if (deltaload)
 			return false;
@@ -4754,7 +4745,7 @@ void OperateStoryBook(int pnum, int i)
 {
 	if (object[i]._oSelFlag != 0 && !deltaload && !qtextflag && pnum == myplr) {
 		object[i]._oAnimFrame = object[i]._oVar4;
-		PlaySfxLoc(IS_ISCROL, object[i].position.x, object[i].position.y);
+		PlaySfxLoc(IS_ISCROL, object[i].position);
 		auto msg = static_cast<_speech_id>(object[i]._oVar2);
 		if (object[i]._oVar8 != 0 && currlevel == 24) {
 			if (!IsUberLeverActivated && quests[Q_NAKRUL]._qactive != QUEST_DONE && NaKrulSpellTomesActive(object[i]._oVar8)) {
@@ -5104,7 +5095,7 @@ void BreakCrux(int i)
 	if (!triggered)
 		return;
 	if (!deltaload)
-		PlaySfxLoc(IS_LEVER, object[i].position.x, object[i].position.y);
+		PlaySfxLoc(IS_LEVER, object[i].position);
 	ObjChangeMap(object[i]._oVar1, object[i]._oVar2, object[i]._oVar3, object[i]._oVar4);
 }
 
@@ -5126,7 +5117,7 @@ void BreakBarrel(int pnum, int i, int dam, bool forcebreak, bool sendmsg)
 		if (deltaload)
 			return;
 
-		PlaySfxLoc(IS_IBOW, object[i].position.x, object[i].position.y);
+		PlaySfxLoc(IS_IBOW, object[i].position);
 		return;
 	}
 
@@ -5148,11 +5139,11 @@ void BreakBarrel(int pnum, int i, int dam, bool forcebreak, bool sendmsg)
 
 	if (object[i]._otype == OBJ_BARRELEX) {
 		if (currlevel >= 21 && currlevel <= 24)
-			PlaySfxLoc(IS_POPPOP3, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(IS_POPPOP3, object[i].position);
 		else if (currlevel >= 17 && currlevel <= 20)
-			PlaySfxLoc(IS_POPPOP8, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(IS_POPPOP8, object[i].position);
 		else
-			PlaySfxLoc(IS_BARLFIRE, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(IS_BARLFIRE, object[i].position);
 		for (yp = object[i].position.y - 1; yp <= object[i].position.y + 1; yp++) {
 			for (xp = object[i].position.x - 1; xp <= object[i].position.x + 1; xp++) {
 				if (dMonster[xp][yp] > 0)
@@ -5169,11 +5160,11 @@ void BreakBarrel(int pnum, int i, int dam, bool forcebreak, bool sendmsg)
 		}
 	} else {
 		if (currlevel >= 21 && currlevel <= 24)
-			PlaySfxLoc(IS_POPPOP2, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(IS_POPPOP2, object[i].position);
 		else if (currlevel >= 17 && currlevel <= 20)
-			PlaySfxLoc(IS_POPPOP5, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(IS_POPPOP5, object[i].position);
 		else
-			PlaySfxLoc(IS_BARREL, object[i].position.x, object[i].position.y);
+			PlaySfxLoc(IS_BARREL, object[i].position);
 		SetRndSeed(object[i]._oRndSeed);
 		if (object[i]._oVar2 <= 1) {
 			if (object[i]._oVar3 == 0)
@@ -5572,7 +5563,7 @@ void GetObjectStr(int i)
 void operate_lv24_lever()
 {
 	if (currlevel == 24) {
-		PlaySfxLoc(IS_CROPEN, UberRow, UberCol);
+		PlaySfxLoc(IS_CROPEN, { UberRow, UberCol });
 		//the part below is the same as objects_454BA8
 		dPiece[UberRow][UberCol] = 298;
 		dPiece[UberRow][UberCol - 1] = 301;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -531,7 +531,7 @@ void PlayerStruct::Say(HeroSpeech speechId) const
 {
 	_sfx_id soundEffect = herosounds[static_cast<size_t>(_pClass)][static_cast<size_t>(speechId)];
 
-	PlaySfxLoc(soundEffect, position.tile.x, position.tile.y);
+	PlaySfxLoc(soundEffect, position.tile);
 }
 
 void PlayerStruct::SaySpecific(HeroSpeech speechId) const
@@ -541,7 +541,7 @@ void PlayerStruct::SaySpecific(HeroSpeech speechId) const
 	if (effect_is_playing(soundEffect))
 		return;
 
-	PlaySfxLoc(soundEffect, position.tile.x, position.tile.y, false);
+	PlaySfxLoc(soundEffect, position.tile, false);
 }
 
 void PlayerStruct::Say(HeroSpeech speechId, int delay) const
@@ -1500,7 +1500,7 @@ void StartPlrBlock(int pnum, Direction dir)
 		return;
 	}
 
-	PlaySfxLoc(IS_ISWORD, player.position.tile.x, player.position.tile.y);
+	PlaySfxLoc(IS_ISWORD, player.position.tile);
 
 	int skippedAnimationFrames = 0;
 	if ((player._pIFlags & ISPL_FASTBLOCK) != 0) {
@@ -1546,7 +1546,7 @@ void StartSpell(int pnum, Direction d, int cx, int cy)
 		StartStand(pnum, d);
 	}
 
-	PlaySfxLoc(spelldata[player._pSpell].sSFX, player.position.tile.x, player.position.tile.y);
+	PlaySfxLoc(spelldata[player._pSpell].sSFX, player.position.tile);
 
 	player._pmode = PM_SPELL;
 
@@ -2121,7 +2121,7 @@ bool PM_DoWalk(int pnum, int variant)
 	if (sgOptions.Audio.bWalkingSound && (currlevel != 0 || !sgGameInitInfo.bRunInTown)) {
 		if (player.AnimInfo.CurrentFrame == 1
 		    || player.AnimInfo.CurrentFrame == 5) {
-			PlaySfxLoc(PS_WALK1, player.position.tile.x, player.position.tile.y);
+			PlaySfxLoc(PS_WALK1, player.position.tile);
 		}
 	}
 
@@ -2638,7 +2638,7 @@ bool PM_DoAttack(int pnum)
 	auto &player = plr[pnum];
 
 	if (player.AnimInfo.CurrentFrame == player._pAFNum - 1) {
-		PlaySfxLoc(PS_SWING, player.position.tile.x, player.position.tile.y);
+		PlaySfxLoc(PS_SWING, player.position.tile);
 	}
 
 	if (player.AnimInfo.CurrentFrame == player._pAFNum) {
@@ -2782,7 +2782,7 @@ bool PM_DoRangeAttack(int pnum)
 		    0);
 
 		if (arrow == 0 && mistype != MIS_SPECARROW) {
-			PlaySfxLoc(arrows != 1 ? IS_STING1 : PS_BFIRE, player.position.tile.x, player.position.tile.y);
+			PlaySfxLoc(arrows != 1 ? IS_STING1 : PS_BFIRE, player.position.tile);
 		}
 
 		if (WeaponDur(pnum, 40)) {

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -243,7 +243,7 @@ void CheckQuests()
 		    && nummonsters == 4
 		    && quests[Q_PWATER]._qactive != QUEST_DONE) {
 			quests[Q_PWATER]._qactive = QUEST_DONE;
-			PlaySfxLoc(IS_QUESTDN, plr[myplr].position.tile.x, plr[myplr].position.tile.y);
+			PlaySfxLoc(IS_QUESTDN, plr[myplr].position.tile);
 			LoadPalette("Levels\\L3Data\\L3pwater.pal", false);
 			UpdatePWaterPalette();
 			WaterDone = 32;

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -595,7 +595,7 @@ void TalkToCow(PlayerStruct &player, TownerStruct &cow)
 			CowMsg = 0;
 	}
 
-	PlaySfxLoc(CowPlaying, cow.position.x, cow.position.y);
+	PlaySfxLoc(CowPlaying, cow.position);
 }
 
 void TalkToFarmer(PlayerStruct &player, TownerStruct &farmer)

--- a/test/effects_test.cpp
+++ b/test/effects_test.cpp
@@ -10,7 +10,7 @@ TEST(Effects, calc_snd_position_center)
 	plr[myplr].position.tile = { 50, 50 };
 	int plVolume = 0;
 	int plPan = 0;
-	EXPECT_EQ(calc_snd_position(50, 50, &plVolume, &plPan), true);
+	EXPECT_EQ(calc_snd_position({ 50, 50 }, &plVolume, &plPan), true);
 	EXPECT_EQ(plVolume, 0);
 	EXPECT_EQ(plPan, 0);
 }
@@ -20,7 +20,7 @@ TEST(Effects, calc_snd_position_near)
 	plr[myplr].position.tile = { 50, 50 };
 	int plVolume = 0;
 	int plPan = 0;
-	EXPECT_EQ(calc_snd_position(55, 50, &plVolume, &plPan), true);
+	EXPECT_EQ(calc_snd_position({ 55, 50 }, &plVolume, &plPan), true);
 	EXPECT_EQ(plVolume, -320);
 	EXPECT_EQ(plPan, 1280);
 }
@@ -30,7 +30,7 @@ TEST(Effects, calc_snd_position_out_of_range)
 	plr[myplr].position.tile = { 12, 12 };
 	int plVolume = 1234;
 	int plPan = 0;
-	EXPECT_EQ(calc_snd_position(112, 112, &plVolume, &plPan), false);
+	EXPECT_EQ(calc_snd_position({ 112, 112 }, &plVolume, &plPan), false);
 	EXPECT_EQ(plVolume, 1234);
 	EXPECT_EQ(plPan, 0);
 }
@@ -40,7 +40,7 @@ TEST(Effects, calc_snd_position_extreme_right)
 	plr[myplr].position.tile = { 50, 50 };
 	int plVolume = 0;
 	int plPan = 0;
-	EXPECT_EQ(calc_snd_position(75, 25, &plVolume, &plPan), true);
+	EXPECT_EQ(calc_snd_position({ 75, 25 }, &plVolume, &plPan), true);
 	EXPECT_EQ(plVolume, -2176);
 	EXPECT_EQ(plPan, 6400);
 }
@@ -50,7 +50,7 @@ TEST(Effects, calc_snd_position_extreme_left)
 	plr[myplr].position.tile = { 50, 50 };
 	int plVolume = 0;
 	int plPan = 0;
-	EXPECT_EQ(calc_snd_position(25, 75, &plVolume, &plPan), true);
+	EXPECT_EQ(calc_snd_position({ 25, 75 }, &plVolume, &plPan), true);
 	EXPECT_EQ(plVolume, -2176);
 	EXPECT_EQ(plPan, -6400);
 }


### PR DESCRIPTION
This is used in quite a few places in objects.cpp and had some very confusing invocations in the various Operate*Door functions due to the inconsistent use of temporary/alias variables. I've included some refactoring of these functions to try and make it clearer while I was in the area.

This may conflict with pull request #2115, would be worth approving that request before this one so I can fix any conflicts I cause.

I plan to open a separate pull request for ObjSetMicro and other related functions in objects.cpp, I've picked these changes out to try keep the diffs manageable.