### PR TITLE
♻️ Use '_item_indexes' instead of 'int' where possible

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1477,7 +1477,7 @@ static void CheckBookLevel(PlayerStruct &player)
 
 static void CheckNaKrulNotes(PlayerStruct &player)
 {
-	int idx = player.HoldItem.IDidx;
+	auto idx = player.HoldItem.IDidx;
 	_item_indexes notes[] = { IDI_NOTE1, IDI_NOTE2, IDI_NOTE3 };
 
 	if (idx != IDI_NOTE1 && idx != IDI_NOTE2 && idx != IDI_NOTE3) {

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1862,7 +1862,7 @@ int InvPutItem(PlayerStruct &player, Point position)
 	return ii;
 }
 
-int SyncPutItem(PlayerStruct &player, Point position, int idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, DWORD ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac)
+int SyncPutItem(PlayerStruct &player, Point position, _item_indexes idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, DWORD ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac)
 {
 	if (!PutItem(player, position))
 		return -1;
@@ -1876,7 +1876,7 @@ int SyncPutItem(PlayerStruct &player, Point position, int idx, uint16_t icreatei
 	if (idx == IDI_EAR) {
 		RecreateEar(ii, icreateinfo, iseed, id, dur, mdur, ch, mch, ivalue, ibuff);
 	} else {
-		RecreateItem(ii, static_cast<_item_indexes>(idx), icreateinfo, iseed, ivalue, (ibuff & CF_HELLFIRE) != 0);
+		RecreateItem(ii, idx, icreateinfo, iseed, ivalue, (ibuff & CF_HELLFIRE) != 0);
 		if (id != 0)
 			items[ii]._iIdentified = true;
 		items[ii]._iDurability = dur;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1664,7 +1664,7 @@ void AutoGetItem(int pnum, ItemStruct *item, int ii)
 	player.HoldItem._itype = ITYPE_NONE;
 }
 
-int FindGetItem(int idx, uint16_t ci, int iseed)
+int FindGetItem(_item_indexes idx, uint16_t ci, int iseed)
 {
 	if (numitems <= 0)
 		return -1;
@@ -1694,19 +1694,19 @@ void SyncGetItem(Point position, int idx, uint16_t ci, int iseed)
 		if (items[ii].IDidx == idx
 		    && items[ii]._iSeed == iseed
 		    && items[ii]._iCreateInfo == ci) {
-			FindGetItem(idx, ci, iseed);
+			FindGetItem(static_cast<_item_indexes>(idx), ci, iseed);
 		} else {
-			ii = FindGetItem(idx, ci, iseed);
+			ii = FindGetItem(static_cast<_item_indexes>(idx), ci, iseed);
 		}
 	} else {
-		ii = FindGetItem(idx, ci, iseed);
+		ii = FindGetItem(static_cast<_item_indexes>(idx), ci, iseed);
 	}
 
 	if (ii == -1)
 		return;
 
 	CleanupItems(&items[ii], ii);
-	assert(FindGetItem(idx, ci, iseed) == -1);
+	assert(FindGetItem(static_cast<_item_indexes>(idx), ci, iseed) == -1);
 }
 
 bool CanPut(Point position)

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1685,7 +1685,7 @@ int FindGetItem(_item_indexes idx, uint16_t ci, int iseed)
 	return ii;
 }
 
-void SyncGetItem(Point position, int idx, uint16_t ci, int iseed)
+void SyncGetItem(Point position, _item_indexes idx, uint16_t ci, int iseed)
 {
 	int ii;
 
@@ -1694,19 +1694,19 @@ void SyncGetItem(Point position, int idx, uint16_t ci, int iseed)
 		if (items[ii].IDidx == idx
 		    && items[ii]._iSeed == iseed
 		    && items[ii]._iCreateInfo == ci) {
-			FindGetItem(static_cast<_item_indexes>(idx), ci, iseed);
+			FindGetItem(idx, ci, iseed);
 		} else {
-			ii = FindGetItem(static_cast<_item_indexes>(idx), ci, iseed);
+			ii = FindGetItem(idx, ci, iseed);
 		}
 	} else {
-		ii = FindGetItem(static_cast<_item_indexes>(idx), ci, iseed);
+		ii = FindGetItem(idx, ci, iseed);
 	}
 
 	if (ii == -1)
 		return;
 
 	CleanupItems(&items[ii], ii);
-	assert(FindGetItem(static_cast<_item_indexes>(idx), ci, iseed) == -1);
+	assert(FindGetItem(idx, ci, iseed) == -1);
 }
 
 bool CanPut(Point position)

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1178,7 +1178,7 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 void CheckInvSwap(int pnum, BYTE bLoc, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff)
 {
 	memset(&items[MAXITEMS], 0, sizeof(*items));
-	RecreateItem(MAXITEMS, idx, wCI, seed, 0, (dwBuff & CF_HELLFIRE) != 0);
+	RecreateItem(MAXITEMS, static_cast<_item_indexes>(idx), wCI, seed, 0, (dwBuff & CF_HELLFIRE) != 0);
 
 	auto &player = plr[pnum];
 
@@ -1876,7 +1876,7 @@ int SyncPutItem(PlayerStruct &player, Point position, int idx, uint16_t icreatei
 	if (idx == IDI_EAR) {
 		RecreateEar(ii, icreateinfo, iseed, id, dur, mdur, ch, mch, ivalue, ibuff);
 	} else {
-		RecreateItem(ii, idx, icreateinfo, iseed, ivalue, (ibuff & CF_HELLFIRE) != 0);
+		RecreateItem(ii, static_cast<_item_indexes>(idx), icreateinfo, iseed, ivalue, (ibuff & CF_HELLFIRE) != 0);
 		if (id != 0)
 			items[ii]._iIdentified = true;
 		items[ii]._iDurability = dur;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1175,10 +1175,10 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 	}
 }
 
-void CheckInvSwap(int pnum, BYTE bLoc, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff)
+void CheckInvSwap(int pnum, BYTE bLoc, _item_indexes idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff)
 {
 	memset(&items[MAXITEMS], 0, sizeof(*items));
-	RecreateItem(MAXITEMS, static_cast<_item_indexes>(idx), wCI, seed, 0, (dwBuff & CF_HELLFIRE) != 0);
+	RecreateItem(MAXITEMS, idx, wCI, seed, 0, (dwBuff & CF_HELLFIRE) != 0);
 
 	auto &player = plr[pnum];
 

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -111,7 +111,7 @@ bool CanPut(Point position);
 bool TryInvPut();
 void DrawInvMsg(const char *msg);
 int InvPutItem(PlayerStruct &player, Point position);
-int SyncPutItem(PlayerStruct &player, Point position, int idx, uint16_t icreateinfo, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, DWORD ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
+int SyncPutItem(PlayerStruct &player, Point position, _item_indexes idx, uint16_t icreateinfo, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, DWORD ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
 char CheckInvHLight();
 void RemoveScroll(int pnum);
 bool UseScroll();

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -105,7 +105,7 @@ void CheckInvScrn(bool isShiftHeld);
 void CheckItemStats(PlayerStruct &player);
 void InvGetItem(int pnum, ItemStruct *item, int ii);
 void AutoGetItem(int pnum, ItemStruct *item, int ii);
-int FindGetItem(int idx, uint16_t ci, int iseed);
+int FindGetItem(_item_indexes idx, uint16_t ci, int iseed);
 void SyncGetItem(Point position, int idx, uint16_t ci, int iseed);
 bool CanPut(Point position);
 bool TryInvPut();

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -106,7 +106,7 @@ void CheckItemStats(PlayerStruct &player);
 void InvGetItem(int pnum, ItemStruct *item, int ii);
 void AutoGetItem(int pnum, ItemStruct *item, int ii);
 int FindGetItem(_item_indexes idx, uint16_t ci, int iseed);
-void SyncGetItem(Point position, int idx, uint16_t ci, int iseed);
+void SyncGetItem(Point position, _item_indexes idx, uint16_t ci, int iseed);
 bool CanPut(Point position);
 bool TryInvPut();
 void DrawInvMsg(const char *msg);

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -98,7 +98,7 @@ bool AutoPlaceItemInInventorySlot(PlayerStruct &player, int slotIndex, const Ite
 bool AutoPlaceItemInBelt(PlayerStruct &player, const ItemStruct &item, bool persistItem = false);
 bool GoldAutoPlace(PlayerStruct &player);
 bool GoldAutoPlaceInInventorySlot(PlayerStruct &player, int slotIndex);
-void CheckInvSwap(int pnum, BYTE bLoc, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff);
+void CheckInvSwap(int pnum, BYTE bLoc, _item_indexes idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff);
 void inv_update_rem_item(int pnum, BYTE iv);
 void CheckInvItem(bool isShiftHeld = false);
 void CheckInvScrn(bool isShiftHeld);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -322,7 +322,7 @@ int premiumLvlAddHellfire[] = {
 	// clang-format on
 };
 
-bool IsItemAvailable(int i)
+bool IsItemAvailable(_item_indexes i)
 {
 	if (gbIsSpawn) {
 		if (i >= 62 && i <= 71)
@@ -2260,7 +2260,7 @@ int RndItem(int m)
 
 	ri = 0;
 	for (i = 0; AllItemsList[i].iLoc != ILOC_INVALID; i++) {
-		if (!IsItemAvailable(i))
+		if (!IsItemAvailable(static_cast<_item_indexes>(i)))
 			continue;
 
 		if (AllItemsList[i].iRnd == IDROP_DOUBLE && monster[m].mLevel >= AllItemsList[i].iMinMLvl
@@ -2294,7 +2294,7 @@ _item_indexes RndUItem(int m)
 	int curlv = items_get_currlevel();
 	int ri = 0;
 	for (int i = 0; AllItemsList[i].iLoc != ILOC_INVALID; i++) {
-		if (!IsItemAvailable(i))
+		if (!IsItemAvailable(static_cast<_item_indexes>(i)))
 			continue;
 
 		okflag = true;
@@ -2336,7 +2336,7 @@ _item_indexes RndAllItems()
 	int curlv = items_get_currlevel();
 	int ri = 0;
 	for (int i = 0; AllItemsList[i].iLoc != ILOC_INVALID; i++) {
-		if (!IsItemAvailable(i))
+		if (!IsItemAvailable(static_cast<_item_indexes>(i)))
 			continue;
 
 		if (AllItemsList[i].iRnd != IDROP_NEVER && 2 * curlv >= AllItemsList[i].iMinMLvl && ri < 512) {
@@ -2358,7 +2358,7 @@ _item_indexes RndTypeItems(int itype, int imid, int lvl)
 
 	int ri = 0;
 	for (int i = 0; AllItemsList[i].iLoc != ILOC_INVALID; i++) {
-		if (!IsItemAvailable(i))
+		if (!IsItemAvailable(static_cast<_item_indexes>(i)))
 			continue;
 
 		bool okflag = true;
@@ -4132,7 +4132,7 @@ _item_indexes RndVendorItem(int minlvl, int maxlvl)
 
 	int ri = 0;
 	for (int i = 1; AllItemsList[i].iLoc != ILOC_INVALID; i++) {
-		if (!IsItemAvailable(i))
+		if (!IsItemAvailable(static_cast<_item_indexes>(i)))
 			continue;
 		if (AllItemsList[i].iRnd == IDROP_NEVER)
 			continue;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2466,13 +2466,13 @@ void ItemRndDur(int ii)
 		items[ii]._iDurability = GenerateRnd(items[ii]._iMaxDur / 2) + (items[ii]._iMaxDur / 4) + 1;
 }
 
-void SetupAllItems(int ii, int idx, int iseed, int lvl, int uper, bool onlygood, bool recreate, bool pregen)
+void SetupAllItems(int ii, _item_indexes idx, int iseed, int lvl, int uper, bool onlygood, bool recreate, bool pregen)
 {
 	int iblvl;
 
 	items[ii]._iSeed = iseed;
 	SetRndSeed(iseed);
-	GetItemAttrs(ii, static_cast<_item_indexes>(idx), lvl / 2);
+	GetItemAttrs(ii, idx, lvl / 2);
 	items[ii]._iCreateInfo = lvl;
 
 	if (pregen)
@@ -2560,7 +2560,7 @@ void SpawnItem(int m, Point position, bool sendmsg)
 	if (!gbIsHellfire && monster[m].MType->mtype == MT_DIABLO)
 		mLevel -= 15;
 
-	SetupAllItems(ii, idx, AdvanceRndSeed(), mLevel, uper, onlygood, false, false);
+	SetupAllItems(ii, static_cast<_item_indexes>(idx), AdvanceRndSeed(), mLevel, uper, onlygood, false, false);
 
 	if (sendmsg)
 		NetSendCmdDItem(false, ii);
@@ -2575,7 +2575,7 @@ static void SetupBaseItem(Point position, int idx, bool onlygood, bool sendmsg, 
 	GetSuperItemSpace(position, ii);
 	int curlv = items_get_currlevel();
 
-	SetupAllItems(ii, idx, AdvanceRndSeed(), 2 * curlv, 1, onlygood, false, delta);
+	SetupAllItems(ii, static_cast<_item_indexes>(idx), AdvanceRndSeed(), 2 * curlv, 1, onlygood, false, delta);
 
 	if (sendmsg)
 		NetSendCmdDItem(false, ii);
@@ -4831,7 +4831,7 @@ void CreateSpellBook(Point position, spell_id ispell, bool sendmsg, bool delta)
 		}
 	}
 
-	int idx = RndTypeItems(ITYPE_MISC, IMISC_BOOK, lvl);
+	auto idx = static_cast<_item_indexes>(RndTypeItems(ITYPE_MISC, IMISC_BOOK, lvl));
 	if (numitems >= MAXITEMS)
 		return;
 
@@ -4857,7 +4857,7 @@ static void CreateMagicItem(Point position, int lvl, int imisc, int imid, int ic
 		return;
 
 	int ii = AllocateItem();
-	int idx = RndTypeItems(imisc, imid, lvl);
+	auto idx = static_cast<_item_indexes>(RndTypeItems(imisc, imid, lvl));
 
 	while (true) {
 		memset(&items[ii], 0, sizeof(*items));
@@ -4865,7 +4865,7 @@ static void CreateMagicItem(Point position, int lvl, int imisc, int imid, int ic
 		if (items[ii]._iCurs == icurs)
 			break;
 
-		idx = RndTypeItems(imisc, imid, lvl);
+		idx = static_cast<_item_indexes>(RndTypeItems(imisc, imid, lvl));
 	}
 	GetSuperItemSpace(position, ii);
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2882,7 +2882,7 @@ void SpawnRock()
 	items[ii].AnimInfo.CurrentFrame = 11;
 }
 
-void SpawnRewardItem(int itemid, Point position)
+void SpawnRewardItem(_item_indexes itemid, Point position)
 {
 	if (numitems >= MAXITEMS)
 		return;
@@ -2892,7 +2892,7 @@ void SpawnRewardItem(int itemid, Point position)
 	items[ii].position = position;
 	dItem[position.x][position.y] = ii + 1;
 	int curlv = items_get_currlevel();
-	GetItemAttrs(ii, static_cast<_item_indexes>(itemid), curlv);
+	GetItemAttrs(ii, itemid, curlv);
 	items[ii].SetNewAnimation(true);
 	items[ii]._iSelFlag = 2;
 	items[ii]._iPostDraw = true;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2566,7 +2566,7 @@ void SpawnItem(int m, Point position, bool sendmsg)
 		NetSendCmdDItem(false, ii);
 }
 
-static void SetupBaseItem(Point position, int idx, bool onlygood, bool sendmsg, bool delta)
+static void SetupBaseItem(Point position, _item_indexes idx, bool onlygood, bool sendmsg, bool delta)
 {
 	if (numitems >= MAXITEMS)
 		return;
@@ -2575,7 +2575,7 @@ static void SetupBaseItem(Point position, int idx, bool onlygood, bool sendmsg, 
 	GetSuperItemSpace(position, ii);
 	int curlv = items_get_currlevel();
 
-	SetupAllItems(ii, static_cast<_item_indexes>(idx), AdvanceRndSeed(), 2 * curlv, 1, onlygood, false, delta);
+	SetupAllItems(ii, idx, AdvanceRndSeed(), 2 * curlv, 1, onlygood, false, delta);
 
 	if (sendmsg)
 		NetSendCmdDItem(false, ii);
@@ -2585,7 +2585,7 @@ static void SetupBaseItem(Point position, int idx, bool onlygood, bool sendmsg, 
 
 void CreateRndItem(Point position, bool onlygood, bool sendmsg, bool delta)
 {
-	int idx = onlygood ? RndUItem(-1) : RndAllItems();
+	auto idx = static_cast<_item_indexes>(onlygood ? RndUItem(-1) : RndAllItems());
 
 	SetupBaseItem(position, idx, onlygood, sendmsg, delta);
 }
@@ -2652,11 +2652,11 @@ void CreateRndUseful(Point position, bool sendmsg)
 
 void CreateTypeItem(Point position, bool onlygood, int itype, int imisc, bool sendmsg, bool delta)
 {
-	int idx;
+	_item_indexes idx;
 
 	int curlv = items_get_currlevel();
 	if (itype != ITYPE_GOLD)
-		idx = RndTypeItems(itype, imisc, curlv);
+		idx = static_cast<_item_indexes>(RndTypeItems(itype, imisc, curlv));
 	else
 		idx = IDI_GOLD;
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4106,23 +4106,26 @@ bool StoreStatOk(ItemStruct *h)
 	return true;
 }
 
-bool SmithItemOk(int i)
+bool SmithItemOk(_item_indexes i)
 {
-	if (AllItemsList[i].itype == ITYPE_MISC)
-		return false;
-	if (AllItemsList[i].itype == ITYPE_GOLD)
-		return false;
-	if (AllItemsList[i].itype == ITYPE_STAFF && (!gbIsHellfire || AllItemsList[i].iSpell))
-		return false;
-	if (AllItemsList[i].itype == ITYPE_RING)
-		return false;
-	if (AllItemsList[i].itype == ITYPE_AMULET)
+	auto item = AllItemsList[static_cast<size_t>(i)];
+
+	switch (item.itype) {
+	case ITYPE_MISC:
+	case ITYPE_GOLD:
+	case ITYPE_RING:
+	case ITYPE_AMULET:
 		return false;
 
-	return true;
+	case ITYPE_STAFF:
+		return gbIsHellfire && item.iSpell == spell_id::SPL_NULL;
+
+	default:
+		return true;
+	}
 }
 
-template <bool (*Ok)(int), bool ConsiderDropRate = false>
+template <bool (*Ok)(_item_indexes), bool ConsiderDropRate = false>
 _item_indexes RndVendorItem(int minlvl, int maxlvl)
 {
 	int ril[512];
@@ -4133,7 +4136,7 @@ _item_indexes RndVendorItem(int minlvl, int maxlvl)
 			continue;
 		if (AllItemsList[i].iRnd == IDROP_NEVER)
 			continue;
-		if (!Ok(i))
+		if (!Ok(static_cast<_item_indexes>(i)))
 			continue;
 		if (AllItemsList[i].iMinMLvl < minlvl || AllItemsList[i].iMinMLvl > maxlvl)
 			continue;
@@ -4210,21 +4213,23 @@ void SpawnSmith(int lvl)
 	items[0] = holditem;
 }
 
-bool PremiumItemOk(int i)
+bool PremiumItemOk(_item_indexes i)
 {
-	if (AllItemsList[i].itype == ITYPE_MISC)
+	auto item = AllItemsList[static_cast<size_t>(i)];
+
+	if (item.itype == ITYPE_MISC)
 		return false;
-	if (AllItemsList[i].itype == ITYPE_GOLD)
+	if (item.itype == ITYPE_GOLD)
 		return false;
-	if (!gbIsHellfire && AllItemsList[i].itype == ITYPE_STAFF)
+	if (!gbIsHellfire && item.itype == ITYPE_STAFF)
 		return false;
 
 	if (gbIsMultiplayer) {
-		if (AllItemsList[i].iMiscId == IMISC_OILOF)
+		if (item.iMiscId == IMISC_OILOF)
 			return false;
-		if (AllItemsList[i].itype == ITYPE_RING)
+		if (item.itype == ITYPE_RING)
 			return false;
-		if (AllItemsList[i].itype == ITYPE_AMULET)
+		if (item.itype == ITYPE_AMULET)
 			return false;
 	}
 
@@ -4362,25 +4367,27 @@ void SpawnPremium(int pnum)
 	}
 }
 
-bool WitchItemOk(int i)
+bool WitchItemOk(_item_indexes i)
 {
-	if (AllItemsList[i].itype != ITYPE_MISC && AllItemsList[i].itype != ITYPE_STAFF)
+	auto item = AllItemsList[static_cast<size_t>(i)];
+
+	if (item.itype != ITYPE_MISC && item.itype != ITYPE_STAFF)
 		return false;
-	if (AllItemsList[i].iMiscId == IMISC_MANA)
+	if (item.iMiscId == IMISC_MANA)
 		return false;
-	if (AllItemsList[i].iMiscId == IMISC_FULLMANA)
+	if (item.iMiscId == IMISC_FULLMANA)
 		return false;
-	if (AllItemsList[i].iSpell == SPL_TOWN)
+	if (item.iSpell == SPL_TOWN)
 		return false;
-	if (AllItemsList[i].iMiscId == IMISC_FULLHEAL)
+	if (item.iMiscId == IMISC_FULLHEAL)
 		return false;
-	if (AllItemsList[i].iMiscId == IMISC_HEAL)
+	if (item.iMiscId == IMISC_HEAL)
 		return false;
-	if (AllItemsList[i].iMiscId > IMISC_OILFIRST && AllItemsList[i].iMiscId < IMISC_OILLAST)
+	if (item.iMiscId > IMISC_OILFIRST && item.iMiscId < IMISC_OILLAST)
 		return false;
-	if (AllItemsList[i].iSpell == SPL_RESURRECT && !gbIsMultiplayer)
+	if (item.iSpell == SPL_RESURRECT && !gbIsMultiplayer)
 		return false;
-	if (AllItemsList[i].iSpell == SPL_HEALOTHER && !gbIsMultiplayer)
+	if (item.iSpell == SPL_HEALOTHER && !gbIsMultiplayer)
 		return false;
 
 	return true;
@@ -4439,7 +4446,7 @@ void SpawnWitch(int lvl)
 		int books = GenerateRnd(4);
 		for (int i = 114, bCnt = 0; i <= 117 && bCnt < books; ++i) {
 			auto itemIndex = static_cast<_item_indexes>(i);
-			if (!WitchItemOk(i))
+			if (!WitchItemOk(itemIndex))
 				continue;
 			if (lvl < AllItemsList[i].iMinMLvl)
 				continue;
@@ -4607,30 +4614,32 @@ void SpawnBoy(int lvl)
 	boylevel = lvl / 2;
 }
 
-bool HealerItemOk(int i)
+bool HealerItemOk(_item_indexes i)
 {
-	if (AllItemsList[i].itype != ITYPE_MISC)
+	auto item = AllItemsList[static_cast<size_t>(i)];
+
+	if (item.itype != ITYPE_MISC)
 		return false;
 
-	if (AllItemsList[i].iMiscId == IMISC_SCROLL)
-		return AllItemsList[i].iSpell == SPL_HEAL;
-	if (AllItemsList[i].iMiscId == IMISC_SCROLLT)
-		return AllItemsList[i].iSpell == SPL_HEALOTHER && gbIsMultiplayer;
+	if (item.iMiscId == IMISC_SCROLL)
+		return item.iSpell == SPL_HEAL;
+	if (item.iMiscId == IMISC_SCROLLT)
+		return item.iSpell == SPL_HEALOTHER && gbIsMultiplayer;
 
 	if (!gbIsMultiplayer) {
-		if (AllItemsList[i].iMiscId == IMISC_ELIXSTR)
+		if (item.iMiscId == IMISC_ELIXSTR)
 			return !gbIsHellfire || plr[myplr]._pBaseStr < plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Strength);
-		if (AllItemsList[i].iMiscId == IMISC_ELIXMAG)
+		if (item.iMiscId == IMISC_ELIXMAG)
 			return !gbIsHellfire || plr[myplr]._pBaseMag < plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Magic);
-		if (AllItemsList[i].iMiscId == IMISC_ELIXDEX)
+		if (item.iMiscId == IMISC_ELIXDEX)
 			return !gbIsHellfire || plr[myplr]._pBaseDex < plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Dexterity);
-		if (AllItemsList[i].iMiscId == IMISC_ELIXVIT)
+		if (item.iMiscId == IMISC_ELIXVIT)
 			return !gbIsHellfire || plr[myplr]._pBaseVit < plr[myplr].GetMaximumAttributeValue(CharacterAttribute::Vitality);
 	}
 
-	if (AllItemsList[i].iMiscId == IMISC_REJUV)
+	if (item.iMiscId == IMISC_REJUV)
 		return true;
-	if (AllItemsList[i].iMiscId == IMISC_FULLREJUV)
+	if (item.iMiscId == IMISC_FULLREJUV)
 		return true;
 
 	return false;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4758,7 +4758,7 @@ void RecreateWitchItem(int ii, _item_indexes idx, int lvl, int iseed)
 	items[ii]._iIdentified = true;
 }
 
-void RecreateHealerItem(int ii, int idx, int lvl, int iseed)
+void RecreateHealerItem(int ii, _item_indexes idx, int lvl, int iseed)
 {
 	if (idx == IDI_HEAL || idx == IDI_FULLHEAL || idx == IDI_RESURRECT) {
 		GetItemAttrs(ii, idx, lvl);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4773,7 +4773,7 @@ void RecreateHealerItem(int ii, int idx, int lvl, int iseed)
 	items[ii]._iIdentified = true;
 }
 
-void RecreateTownItem(int ii, int idx, uint16_t icreateinfo, int iseed)
+void RecreateTownItem(int ii, _item_indexes idx, uint16_t icreateinfo, int iseed)
 {
 	if ((icreateinfo & CF_SMITH) != 0)
 		RecreateSmithItem(ii, icreateinfo & CF_LEVEL, iseed);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4231,9 +4231,9 @@ bool PremiumItemOk(int i)
 	return true;
 }
 
-int RndPremiumItem(int minlvl, int maxlvl)
+_item_indexes RndPremiumItem(int minlvl, int maxlvl)
 {
-	return RndVendorItem<PremiumItemOk>(minlvl, maxlvl);
+	return static_cast<_item_indexes>(RndVendorItem<PremiumItemOk>(minlvl, maxlvl) - 1);
 }
 
 static void SpawnOnePremium(int i, int plvl, int myplr)
@@ -4257,7 +4257,7 @@ static void SpawnOnePremium(int i, int plvl, int myplr)
 		keepgoing = false;
 		memset(&items[0], 0, sizeof(*items));
 		items[0]._iSeed = AdvanceRndSeed();
-		auto itype = static_cast<_item_indexes>(RndPremiumItem(plvl / 4, plvl) - 1);
+		auto itype = RndPremiumItem(plvl / 4, plvl);
 		GetItemAttrs(0, itype, plvl);
 		GetItemBonus(0, plvl / 2, plvl, true, !gbIsHellfire);
 
@@ -4709,7 +4709,7 @@ void RecreateSmithItem(int ii, int lvl, int iseed)
 void RecreatePremiumItem(int ii, int plvl, int iseed)
 {
 	SetRndSeed(iseed);
-	auto itype = static_cast<_item_indexes>(RndPremiumItem(plvl / 4, plvl) - 1);
+	auto itype = RndPremiumItem(plvl / 4, plvl);
 	GetItemAttrs(ii, itype, plvl);
 	GetItemBonus(ii, plvl / 2, plvl, true, !gbIsHellfire);
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -488,7 +488,7 @@ void AddInitItems()
 
 static void items_42390F()
 {
-	int id;
+	_item_indexes id;
 
 	switch (currlevel) {
 	case 22:
@@ -2810,7 +2810,7 @@ void items_427ABA(Point position)
 	CornerStone.item = items[ii];
 }
 
-void SpawnQuestItem(int itemid, Point position, int randarea, int selflag)
+void SpawnQuestItem(_item_indexes itemid, Point position, int randarea, int selflag)
 {
 	if (randarea) {
 		int tries = 0;
@@ -2843,7 +2843,7 @@ void SpawnQuestItem(int itemid, Point position, int randarea, int selflag)
 	dItem[position.x][position.y] = ii + 1;
 
 	int curlv = items_get_currlevel();
-	GetItemAttrs(ii, static_cast<_item_indexes>(itemid), curlv);
+	GetItemAttrs(ii, itemid, curlv);
 
 	SetupItem(ii);
 	items[ii]._iSeed = AdvanceRndSeed();

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4123,7 +4123,7 @@ bool SmithItemOk(int i)
 }
 
 template <bool (*Ok)(int), bool ConsiderDropRate = false>
-int RndVendorItem(int minlvl, int maxlvl)
+_item_indexes RndVendorItem(int minlvl, int maxlvl)
 {
 	int ril[512];
 
@@ -4152,7 +4152,7 @@ int RndVendorItem(int minlvl, int maxlvl)
 			break;
 	}
 
-	return ril[GenerateRnd(ri)] + 1;
+	return static_cast<_item_indexes>(ril[GenerateRnd(ri)] + 1);
 }
 
 _item_indexes RndSmithItem(int lvl)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2664,7 +2664,7 @@ void CreateTypeItem(Point position, bool onlygood, int itype, int imisc, bool se
 	SetupBaseItem(position, idx, onlygood, sendmsg, delta);
 }
 
-void RecreateItem(int ii, int idx, uint16_t icreateinfo, int iseed, int ivalue, bool isHellfire)
+void RecreateItem(int ii, _item_indexes idx, uint16_t icreateinfo, int iseed, int ivalue, bool isHellfire)
 {
 	bool _gbIsHellfire = gbIsHellfire;
 	gbIsHellfire = isHellfire;
@@ -2680,7 +2680,7 @@ void RecreateItem(int ii, int idx, uint16_t icreateinfo, int iseed, int ivalue, 
 	}
 
 	if (icreateinfo == 0) {
-		SetPlrHandItem(&items[ii], static_cast<_item_indexes>(idx));
+		SetPlrHandItem(&items[ii], idx);
 		SetPlrHandSeed(&items[ii], iseed);
 		gbIsHellfire = _gbIsHellfire;
 		return;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2283,13 +2283,13 @@ int RndItem(int m)
 	return ril[r] + 1;
 }
 
-int RndUItem(int m)
+_item_indexes RndUItem(int m)
 {
 	int ril[512];
 	bool okflag;
 
 	if (m != -1 && (monster[m].MData->mTreasure & 0x8000) != 0 && !gbIsMultiplayer)
-		return -((monster[m].MData->mTreasure & 0xFFF) + 1);
+		return static_cast<_item_indexes>(-((monster[m].MData->mTreasure & 0xFFF) + 1));
 
 	int curlv = items_get_currlevel();
 	int ri = 0;
@@ -2323,7 +2323,7 @@ int RndUItem(int m)
 		}
 	}
 
-	return ril[GenerateRnd(ri)];
+	return static_cast<_item_indexes>(ril[GenerateRnd(ri)]);
 }
 
 _item_indexes RndAllItems()
@@ -2585,7 +2585,7 @@ static void SetupBaseItem(Point position, _item_indexes idx, bool onlygood, bool
 
 void CreateRndItem(Point position, bool onlygood, bool sendmsg, bool delta)
 {
-	auto idx = onlygood ? static_cast<_item_indexes>(RndUItem(-1)) : RndAllItems();
+	auto idx = onlygood ? RndUItem(-1) : RndAllItems();
 
 	SetupBaseItem(position, idx, onlygood, sendmsg, delta);
 }

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1621,7 +1621,7 @@ void GetOilType(int i, int max_lvl)
 	items[i]._iIvalue = OilValues[t];
 }
 
-void GetItemAttrs(int i, int idata, int lvl)
+void GetItemAttrs(int i, _item_indexes idata, int lvl)
 {
 	items[i]._itype = AllItemsList[idata].itype;
 	items[i]._iCurs = AllItemsList[idata].iCurs;
@@ -1643,7 +1643,7 @@ void GetItemAttrs(int i, int idata, int lvl)
 	items[i]._iMinStr = AllItemsList[idata].iMinStr;
 	items[i]._iMinMag = AllItemsList[idata].iMinMag;
 	items[i]._iMinDex = AllItemsList[idata].iMinDex;
-	items[i].IDidx = static_cast<_item_indexes>(idata);
+	items[i].IDidx = idata;
 	if (gbIsHellfire)
 		items[i].dwBuff |= CF_HELLFIRE;
 	items[i]._iPrePower = IPL_INVALID;
@@ -2453,7 +2453,7 @@ void SpawnUnique(_unique_items uid, Point position)
 	while (AllItemsList[idx].iItemId != UniqueItemList[uid].UIItemId)
 		idx++;
 
-	GetItemAttrs(ii, idx, curlv);
+	GetItemAttrs(ii, static_cast<_item_indexes>(idx), curlv);
 	GetUniqueItem(ii, uid);
 	SetupItem(ii);
 
@@ -2472,7 +2472,7 @@ void SetupAllItems(int ii, int idx, int iseed, int lvl, int uper, bool onlygood,
 
 	items[ii]._iSeed = iseed;
 	SetRndSeed(iseed);
-	GetItemAttrs(ii, idx, lvl / 2);
+	GetItemAttrs(ii, static_cast<_item_indexes>(idx), lvl / 2);
 	items[ii]._iCreateInfo = lvl;
 
 	if (pregen)
@@ -2592,14 +2592,13 @@ void CreateRndItem(Point position, bool onlygood, bool sendmsg, bool delta)
 
 void SetupAllUseful(int ii, int iseed, int lvl)
 {
-	int idx;
+	_item_indexes idx;
 
 	items[ii]._iSeed = iseed;
 	SetRndSeed(iseed);
 
 	if (gbIsHellfire) {
-		idx = GenerateRnd(7);
-		switch (idx) {
+		switch (GenerateRnd(7)) {
 		case 0:
 			idx = IDI_PORTAL;
 			if ((lvl <= 1))
@@ -2844,7 +2843,7 @@ void SpawnQuestItem(int itemid, Point position, int randarea, int selflag)
 	dItem[position.x][position.y] = ii + 1;
 
 	int curlv = items_get_currlevel();
-	GetItemAttrs(ii, itemid, curlv);
+	GetItemAttrs(ii, static_cast<_item_indexes>(itemid), curlv);
 
 	SetupItem(ii);
 	items[ii]._iSeed = AdvanceRndSeed();
@@ -2893,7 +2892,7 @@ void SpawnRewardItem(int itemid, Point position)
 	items[ii].position = position;
 	dItem[position.x][position.y] = ii + 1;
 	int curlv = items_get_currlevel();
-	GetItemAttrs(ii, itemid, curlv);
+	GetItemAttrs(ii, static_cast<_item_indexes>(itemid), curlv);
 	items[ii].SetNewAnimation(true);
 	items[ii]._iSelFlag = 2;
 	items[ii]._iPostDraw = true;
@@ -4196,7 +4195,7 @@ void SpawnSmith(int lvl)
 		do {
 			memset(&items[0], 0, sizeof(*items));
 			items[0]._iSeed = AdvanceRndSeed();
-			int idata = RndSmithItem(lvl) - 1;
+			auto idata = static_cast<_item_indexes>(RndSmithItem(lvl) - 1);
 			GetItemAttrs(0, idata, lvl);
 		} while (items[0]._iIvalue > maxValue);
 		smithitem[i] = items[0];
@@ -4258,7 +4257,7 @@ static void SpawnOnePremium(int i, int plvl, int myplr)
 		keepgoing = false;
 		memset(&items[0], 0, sizeof(*items));
 		items[0]._iSeed = AdvanceRndSeed();
-		int itype = RndPremiumItem(plvl / 4, plvl) - 1;
+		auto itype = static_cast<_item_indexes>(RndPremiumItem(plvl / 4, plvl) - 1);
 		GetItemAttrs(0, itype, plvl);
 		GetItemBonus(0, plvl / 2, plvl, true, !gbIsHellfire);
 
@@ -4413,7 +4412,7 @@ void SpawnWitch(int lvl)
 	constexpr int PinnedItemCount = 3;
 
 	int iCnt;
-	int idata, maxlvl, maxValue;
+	int maxlvl, maxValue;
 
 	int j = PinnedItemCount;
 
@@ -4439,6 +4438,7 @@ void SpawnWitch(int lvl)
 
 		int books = GenerateRnd(4);
 		for (int i = 114, bCnt = 0; i <= 117 && bCnt < books; ++i) {
+			auto itemIndex = static_cast<_item_indexes>(i);
 			if (!WitchItemOk(i))
 				continue;
 			if (lvl < AllItemsList[i].iMinMLvl)
@@ -4448,7 +4448,7 @@ void SpawnWitch(int lvl)
 			items[0]._iSeed = AdvanceRndSeed();
 			GenerateRnd(1);
 
-			GetItemAttrs(0, i, lvl);
+			GetItemAttrs(0, itemIndex, lvl);
 			witchitem[j] = items[0];
 			witchitem[j]._iCreateInfo = lvl | CF_WITCH;
 			witchitem[j]._iIdentified = true;
@@ -4466,7 +4466,7 @@ void SpawnWitch(int lvl)
 		do {
 			memset(&items[0], 0, sizeof(*items));
 			items[0]._iSeed = AdvanceRndSeed();
-			idata = RndWitchItem(lvl) - 1;
+			auto idata = static_cast<_item_indexes>(RndWitchItem(lvl) - 1);
 			GetItemAttrs(0, idata, lvl);
 			maxlvl = -1;
 			if (GenerateRnd(100) <= 5)
@@ -4496,8 +4496,6 @@ int RndBoyItem(int lvl)
 
 void SpawnBoy(int lvl)
 {
-	int itype;
-
 	int ivalue = 0;
 	bool keepgoing = false;
 	int count = 0;
@@ -4516,7 +4514,7 @@ void SpawnBoy(int lvl)
 		keepgoing = false;
 		memset(&items[0], 0, sizeof(*items));
 		items[0]._iSeed = AdvanceRndSeed();
-		itype = RndBoyItem(lvl) - 1;
+		auto itype = static_cast<_item_indexes>(RndBoyItem(lvl) - 1);
 		GetItemAttrs(0, itype, lvl);
 		GetItemBonus(0, lvl, 2 * lvl, true, true);
 
@@ -4676,7 +4674,7 @@ void SpawnHealer(int lvl)
 	for (int i = srnd; i < nsi; i++) {
 		memset(&items[0], 0, sizeof(*items));
 		items[0]._iSeed = AdvanceRndSeed();
-		int itype = RndHealerItem(lvl) - 1;
+		auto itype = static_cast<_item_indexes>(RndHealerItem(lvl) - 1);
 		GetItemAttrs(0, itype, lvl);
 		healitem[i] = items[0];
 		healitem[i]._iCreateInfo = lvl | CF_HEALER;
@@ -4700,7 +4698,7 @@ void SpawnStoreGold()
 void RecreateSmithItem(int ii, int lvl, int iseed)
 {
 	SetRndSeed(iseed);
-	int itype = RndSmithItem(lvl) - 1;
+	auto itype = static_cast<_item_indexes>(RndSmithItem(lvl) - 1);
 	GetItemAttrs(ii, itype, lvl);
 
 	items[ii]._iSeed = iseed;
@@ -4711,7 +4709,7 @@ void RecreateSmithItem(int ii, int lvl, int iseed)
 void RecreatePremiumItem(int ii, int plvl, int iseed)
 {
 	SetRndSeed(iseed);
-	int itype = RndPremiumItem(plvl / 4, plvl) - 1;
+	auto itype = static_cast<_item_indexes>(RndPremiumItem(plvl / 4, plvl) - 1);
 	GetItemAttrs(ii, itype, plvl);
 	GetItemBonus(ii, plvl / 2, plvl, true, !gbIsHellfire);
 
@@ -4723,7 +4721,7 @@ void RecreatePremiumItem(int ii, int plvl, int iseed)
 void RecreateBoyItem(int ii, int lvl, int iseed)
 {
 	SetRndSeed(iseed);
-	int itype = RndBoyItem(lvl) - 1;
+	auto itype = static_cast<_item_indexes>(RndBoyItem(lvl) - 1);
 	GetItemAttrs(ii, itype, lvl);
 	GetItemBonus(ii, lvl, 2 * lvl, true, true);
 
@@ -4742,7 +4740,7 @@ void RecreateWitchItem(int ii, _item_indexes idx, int lvl, int iseed)
 		GetItemAttrs(ii, idx, lvl);
 	} else {
 		SetRndSeed(iseed);
-		int itype = RndWitchItem(lvl) - 1;
+		auto itype = static_cast<_item_indexes>(RndWitchItem(lvl) - 1);
 		GetItemAttrs(ii, itype, lvl);
 		int iblvl = -1;
 		if (GenerateRnd(100) <= 5)
@@ -4764,7 +4762,7 @@ void RecreateHealerItem(int ii, _item_indexes idx, int lvl, int iseed)
 		GetItemAttrs(ii, idx, lvl);
 	} else {
 		SetRndSeed(iseed);
-		int itype = RndHealerItem(lvl) - 1;
+		auto itype = static_cast<_item_indexes>(RndHealerItem(lvl) - 1);
 		GetItemAttrs(ii, itype, lvl);
 	}
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2326,12 +2326,12 @@ int RndUItem(int m)
 	return ril[GenerateRnd(ri)];
 }
 
-int RndAllItems()
+_item_indexes RndAllItems()
 {
 	int ril[512];
 
 	if (GenerateRnd(100) > 25)
-		return 0;
+		return IDI_GOLD;
 
 	int curlv = items_get_currlevel();
 	int ri = 0;
@@ -2349,7 +2349,7 @@ int RndAllItems()
 			ri--;
 	}
 
-	return ril[GenerateRnd(ri)];
+	return static_cast<_item_indexes>(ril[GenerateRnd(ri)]);
 }
 
 int RndTypeItems(int itype, int imid, int lvl)
@@ -2585,7 +2585,7 @@ static void SetupBaseItem(Point position, _item_indexes idx, bool onlygood, bool
 
 void CreateRndItem(Point position, bool onlygood, bool sendmsg, bool delta)
 {
-	auto idx = static_cast<_item_indexes>(onlygood ? RndUItem(-1) : RndAllItems());
+	auto idx = onlygood ? static_cast<_item_indexes>(RndUItem(-1)) : RndAllItems();
 
 	SetupBaseItem(position, idx, onlygood, sendmsg, delta);
 }

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4732,7 +4732,7 @@ void RecreateBoyItem(int ii, int lvl, int iseed)
 	items[ii]._iIdentified = true;
 }
 
-void RecreateWitchItem(int ii, int idx, int lvl, int iseed)
+void RecreateWitchItem(int ii, _item_indexes idx, int lvl, int iseed)
 {
 	if (idx == IDI_MANA || idx == IDI_FULLMANA || idx == IDI_PORTAL) {
 		GetItemAttrs(ii, idx, lvl);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4489,9 +4489,9 @@ void SpawnWitch(int lvl)
 	SortVendor(witchitem + PinnedItemCount);
 }
 
-int RndBoyItem(int lvl)
+_item_indexes RndBoyItem(int lvl)
 {
-	return RndVendorItem<PremiumItemOk>(0, lvl);
+	return static_cast<_item_indexes>(RndVendorItem<PremiumItemOk>(0, lvl) - 1);
 }
 
 void SpawnBoy(int lvl)
@@ -4514,7 +4514,7 @@ void SpawnBoy(int lvl)
 		keepgoing = false;
 		memset(&items[0], 0, sizeof(*items));
 		items[0]._iSeed = AdvanceRndSeed();
-		auto itype = static_cast<_item_indexes>(RndBoyItem(lvl) - 1);
+		auto itype = RndBoyItem(lvl);
 		GetItemAttrs(0, itype, lvl);
 		GetItemBonus(0, lvl, 2 * lvl, true, true);
 
@@ -4721,7 +4721,7 @@ void RecreatePremiumItem(int ii, int plvl, int iseed)
 void RecreateBoyItem(int ii, int lvl, int iseed)
 {
 	SetRndSeed(iseed);
-	auto itype = static_cast<_item_indexes>(RndBoyItem(lvl) - 1);
+	auto itype = RndBoyItem(lvl);
 	GetItemAttrs(ii, itype, lvl);
 	GetItemBonus(ii, lvl, 2 * lvl, true, true);
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2352,7 +2352,7 @@ _item_indexes RndAllItems()
 	return static_cast<_item_indexes>(ril[GenerateRnd(ri)]);
 }
 
-int RndTypeItems(int itype, int imid, int lvl)
+_item_indexes RndTypeItems(int itype, int imid, int lvl)
 {
 	int ril[512];
 
@@ -2376,7 +2376,7 @@ int RndTypeItems(int itype, int imid, int lvl)
 		}
 	}
 
-	return ril[GenerateRnd(ri)];
+	return static_cast<_item_indexes>(ril[GenerateRnd(ri)]);
 }
 
 _unique_items CheckUnique(int i, int lvl, int uper, bool recreate)
@@ -2656,7 +2656,7 @@ void CreateTypeItem(Point position, bool onlygood, int itype, int imisc, bool se
 
 	int curlv = items_get_currlevel();
 	if (itype != ITYPE_GOLD)
-		idx = static_cast<_item_indexes>(RndTypeItems(itype, imisc, curlv));
+		idx = RndTypeItems(itype, imisc, curlv);
 	else
 		idx = IDI_GOLD;
 
@@ -4831,7 +4831,7 @@ void CreateSpellBook(Point position, spell_id ispell, bool sendmsg, bool delta)
 		}
 	}
 
-	auto idx = static_cast<_item_indexes>(RndTypeItems(ITYPE_MISC, IMISC_BOOK, lvl));
+	auto idx = RndTypeItems(ITYPE_MISC, IMISC_BOOK, lvl);
 	if (numitems >= MAXITEMS)
 		return;
 
@@ -4857,7 +4857,7 @@ static void CreateMagicItem(Point position, int lvl, int imisc, int imid, int ic
 		return;
 
 	int ii = AllocateItem();
-	auto idx = static_cast<_item_indexes>(RndTypeItems(imisc, imid, lvl));
+	auto idx = RndTypeItems(imisc, imid, lvl);
 
 	while (true) {
 		memset(&items[ii], 0, sizeof(*items));
@@ -4865,7 +4865,7 @@ static void CreateMagicItem(Point position, int lvl, int imisc, int imid, int ic
 		if (items[ii]._iCurs == icurs)
 			break;
 
-		idx = static_cast<_item_indexes>(RndTypeItems(imisc, imid, lvl));
+		idx = RndTypeItems(imisc, imid, lvl);
 	}
 	GetSuperItemSpace(position, ii);
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4155,9 +4155,9 @@ int RndVendorItem(int minlvl, int maxlvl)
 	return ril[GenerateRnd(ri)] + 1;
 }
 
-int RndSmithItem(int lvl)
+_item_indexes RndSmithItem(int lvl)
 {
-	return RndVendorItem<SmithItemOk, true>(0, lvl);
+	return static_cast<_item_indexes>(RndVendorItem<SmithItemOk, true>(0, lvl) - 1);
 }
 
 void SortVendor(ItemStruct *items)
@@ -4195,7 +4195,7 @@ void SpawnSmith(int lvl)
 		do {
 			memset(&items[0], 0, sizeof(*items));
 			items[0]._iSeed = AdvanceRndSeed();
-			auto idata = static_cast<_item_indexes>(RndSmithItem(lvl) - 1);
+			auto idata = RndSmithItem(lvl);
 			GetItemAttrs(0, idata, lvl);
 		} while (items[0]._iIvalue > maxValue);
 		smithitem[i] = items[0];
@@ -4698,7 +4698,7 @@ void SpawnStoreGold()
 void RecreateSmithItem(int ii, int lvl, int iseed)
 {
 	SetRndSeed(iseed);
-	auto itype = static_cast<_item_indexes>(RndSmithItem(lvl) - 1);
+	auto itype = RndSmithItem(lvl);
 	GetItemAttrs(ii, itype, lvl);
 
 	items[ii]._iSeed = iseed;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1051,7 +1051,7 @@ void CalcPlrInv(int playerId, bool Loadgfx)
 	}
 }
 
-void SetPlrHandItem(ItemStruct *h, int idata)
+void SetPlrHandItem(ItemStruct *h, _item_indexes idata)
 {
 	ItemDataStruct *pAllItem;
 
@@ -1087,7 +1087,7 @@ void SetPlrHandItem(ItemStruct *h, int idata)
 	h->_iPrePower = IPL_INVALID;
 	h->_iSufPower = IPL_INVALID;
 	h->_iMagical = ITEM_QUALITY_NORMAL;
-	h->IDidx = static_cast<_item_indexes>(idata);
+	h->IDidx = idata;
 	if (gbIsHellfire)
 		h->dwBuff |= CF_HELLFIRE;
 }
@@ -1207,7 +1207,7 @@ void CreatePlrItems(int playerId)
 		GetPlrHandSeed(&player.SpdList[1]);
 		break;
 	case HeroClass::Sorcerer:
-		SetPlrHandItem(&player.InvBody[INVLOC_HAND_LEFT], gbIsHellfire ? IDI_SORCERER : 166);
+		SetPlrHandItem(&player.InvBody[INVLOC_HAND_LEFT], gbIsHellfire ? IDI_SORCERER : static_cast<_item_indexes>(166));
 		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_LEFT]);
 
 		SetPlrHandItem(&player.SpdList[0], gbIsHellfire ? IDI_HEAL : IDI_MANA);
@@ -1239,7 +1239,7 @@ void CreatePlrItems(int playerId)
 		GetPlrHandSeed(&player.SpdList[1]);
 		break;
 	case HeroClass::Barbarian:
-		SetPlrHandItem(&player.InvBody[INVLOC_HAND_LEFT], 139); // TODO: add more enums to items
+		SetPlrHandItem(&player.InvBody[INVLOC_HAND_LEFT], static_cast<_item_indexes>(139)); // TODO: add more enums to items
 		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_LEFT]);
 
 		SetPlrHandItem(&player.InvBody[INVLOC_HAND_RIGHT], IDI_WARRSHLD);
@@ -2680,7 +2680,7 @@ void RecreateItem(int ii, int idx, uint16_t icreateinfo, int iseed, int ivalue, 
 	}
 
 	if (icreateinfo == 0) {
-		SetPlrHandItem(&items[ii], idx);
+		SetPlrHandItem(&items[ii], static_cast<_item_indexes>(idx));
 		SetPlrHandSeed(&items[ii], iseed);
 		gbIsHellfire = _gbIsHellfire;
 		return;

--- a/Source/items.h
+++ b/Source/items.h
@@ -433,7 +433,7 @@ void items_427A72();
 void items_427ABA(Point position);
 void SpawnQuestItem(_item_indexes itemid, Point position, int randarea, int selflag);
 void SpawnRock();
-void SpawnRewardItem(int itemid, Point position);
+void SpawnRewardItem(_item_indexes itemid, Point position);
 void SpawnMapOfDoom(Point position);
 void SpawnRuneBomb(Point position);
 void SpawnTheodore(Point position);

--- a/Source/items.h
+++ b/Source/items.h
@@ -401,7 +401,7 @@ extern bool UniqueItemFlags[128];
 extern int numitems;
 
 BYTE GetOutlineColor(const ItemStruct &item, bool checkReq);
-bool IsItemAvailable(int i);
+bool IsItemAvailable(_item_indexes i);
 bool IsUniqueAvailable(int i);
 void InitItemGFX();
 void InitItems();

--- a/Source/items.h
+++ b/Source/items.h
@@ -408,7 +408,7 @@ void InitItems();
 void CalcPlrItemVals(int p, bool Loadgfx);
 void CalcPlrStaff(int p);
 void CalcPlrInv(int p, bool Loadgfx);
-void SetPlrHandItem(ItemStruct *h, int idata);
+void SetPlrHandItem(ItemStruct *h, _item_indexes idata);
 void GetPlrHandSeed(ItemStruct *h);
 void GetGoldSeed(int pnum, ItemStruct *h);
 int GetGoldCursor(int value);

--- a/Source/items.h
+++ b/Source/items.h
@@ -427,7 +427,7 @@ void SpawnItem(int m, Point position, bool sendmsg);
 void CreateRndItem(Point position, bool onlygood, bool sendmsg, bool delta);
 void CreateRndUseful(Point position, bool sendmsg);
 void CreateTypeItem(Point position, bool onlygood, int itype, int imisc, bool sendmsg, bool delta);
-void RecreateItem(int ii, int idx, uint16_t icreateinfo, int iseed, int ivalue, bool isHellfire);
+void RecreateItem(int ii, _item_indexes idx, uint16_t icreateinfo, int iseed, int ivalue, bool isHellfire);
 void RecreateEar(int ii, uint16_t ic, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, int ibuff);
 void items_427A72();
 void items_427ABA(Point position);

--- a/Source/items.h
+++ b/Source/items.h
@@ -460,7 +460,7 @@ void SpawnWitch(int lvl);
 void SpawnBoy(int lvl);
 void SpawnHealer(int lvl);
 void SpawnStoreGold();
-void RecreateTownItem(int ii, int idx, uint16_t icreateinfo, int iseed);
+void RecreateTownItem(int ii, _item_indexes idx, uint16_t icreateinfo, int iseed);
 void RecalcStoreStats();
 int ItemNoFlippy();
 void CreateSpellBook(Point position, spell_id ispell, bool sendmsg, bool delta);

--- a/Source/items.h
+++ b/Source/items.h
@@ -417,7 +417,7 @@ void CreatePlrItems(int playerId);
 bool ItemSpaceOk(Point position);
 int AllocateItem();
 Point GetSuperItemLoc(Point position);
-void GetItemAttrs(int i, int idata, int lvl);
+void GetItemAttrs(int i, _item_indexes idata, int lvl);
 void SaveItemPower(int i, item_effect_type power, int param1, int param2, int minval, int maxval, int multval);
 void GetItemPower(int i, int minlvl, int maxlvl, affix_item_type flgs, bool onlygood);
 void SetupItem(int i);

--- a/Source/items.h
+++ b/Source/items.h
@@ -431,7 +431,7 @@ void RecreateItem(int ii, _item_indexes idx, uint16_t icreateinfo, int iseed, in
 void RecreateEar(int ii, uint16_t ic, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, int ibuff);
 void items_427A72();
 void items_427ABA(Point position);
-void SpawnQuestItem(int itemid, Point position, int randarea, int selflag);
+void SpawnQuestItem(_item_indexes itemid, Point position, int randarea, int selflag);
 void SpawnRock();
 void SpawnRewardItem(int itemid, Point position);
 void SpawnMapOfDoom(Point position);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1556,7 +1556,7 @@ void AddStealPotions(int mi, int sx, int sy, int dx, int dy, int midir, int8_t m
 							}
 						}
 						if (ii != -1) {
-							SetPlrHandItem(&plr[pnum].HoldItem, ii);
+							SetPlrHandItem(&plr[pnum].HoldItem, static_cast<_item_indexes>(ii));
 							GetPlrHandSeed(&plr[pnum].HoldItem);
 							plr[pnum].HoldItem._iStatFlag = true;
 							plr[pnum].SpdList[si] = plr[pnum].HoldItem;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -784,7 +784,7 @@ void DeltaLoadLevel()
 				} else {
 					RecreateItem(
 					    ii,
-					    sgLevels[currlevel].item[i].wIndx,
+					    static_cast<_item_indexes>(sgLevels[currlevel].item[i].wIndx),
 					    sgLevels[currlevel].item[i].wCI,
 					    sgLevels[currlevel].item[i].dwSeed,
 					    sgLevels[currlevel].item[i].wValue,

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2155,7 +2155,7 @@ static DWORD On_CHANGEPLRITEMS(TCmd *pCmd, int pnum)
 	if (gbBufferMsgs == 1)
 		msg_send_packet(pnum, p, sizeof(*p));
 	else if (pnum != myplr)
-		CheckInvSwap(pnum, p->bLoc, p->wIndx, p->wCI, p->dwSeed, p->bId, p->dwBuff);
+		CheckInvSwap(pnum, p->bLoc, static_cast<_item_indexes>(p->wIndx), p->wCI, p->dwSeed, p->bId, p->dwBuff);
 
 	return sizeof(*p);
 }

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1446,7 +1446,7 @@ static DWORD On_GETITEM(TCmd *pCmd, int pnum)
 			if ((currlevel == p->bLevel || p->bPnum == myplr) && p->bMaster != myplr) {
 				if (p->bPnum == myplr) {
 					if (currlevel != p->bLevel) {
-						ii = SyncPutItem(plr[myplr], plr[myplr].position.tile, p->wIndx, p->wCI, p->dwSeed, p->bId, p->bDur, p->bMDur, p->bCh, p->bMCh, p->wValue, p->dwBuff, p->wToHit, p->wMaxDam, p->bMinStr, p->bMinMag, p->bMinDex, p->bAC);
+						ii = SyncPutItem(plr[myplr], plr[myplr].position.tile, static_cast<_item_indexes>(p->wIndx), p->wCI, p->dwSeed, p->bId, p->bDur, p->bMDur, p->bCh, p->bMCh, p->wValue, p->dwBuff, p->wToHit, p->wMaxDam, p->bMinStr, p->bMinMag, p->bMinDex, p->bAC);
 						if (ii != -1)
 							InvGetItem(myplr, &items[ii], ii);
 					} else
@@ -1508,7 +1508,7 @@ static DWORD On_AGETITEM(TCmd *pCmd, int pnum)
 			if ((currlevel == p->bLevel || p->bPnum == myplr) && p->bMaster != myplr) {
 				if (p->bPnum == myplr) {
 					if (currlevel != p->bLevel) {
-						int ii = SyncPutItem(plr[myplr], plr[myplr].position.tile, p->wIndx, p->wCI, p->dwSeed, p->bId, p->bDur, p->bMDur, p->bCh, p->bMCh, p->wValue, p->dwBuff, p->wToHit, p->wMaxDam, p->bMinStr, p->bMinMag, p->bMinDex, p->bAC);
+						int ii = SyncPutItem(plr[myplr], plr[myplr].position.tile, static_cast<_item_indexes>(p->wIndx), p->wCI, p->dwSeed, p->bId, p->bDur, p->bMDur, p->bCh, p->bMCh, p->wValue, p->dwBuff, p->wToHit, p->wMaxDam, p->bMinStr, p->bMinMag, p->bMinDex, p->bAC);
 						if (ii != -1)
 							AutoGetItem(myplr, &items[ii], ii);
 					} else
@@ -1549,7 +1549,7 @@ static DWORD On_PUTITEM(TCmd *pCmd, int pnum)
 		if (pnum == myplr)
 			ii = InvPutItem(plr[pnum], { p->x, p->y });
 		else
-			ii = SyncPutItem(plr[pnum], { p->x, p->y }, p->wIndx, p->wCI, p->dwSeed, p->bId, p->bDur, p->bMDur, p->bCh, p->bMCh, p->wValue, p->dwBuff, p->wToHit, p->wMaxDam, p->bMinStr, p->bMinMag, p->bMinDex, p->bAC);
+			ii = SyncPutItem(plr[pnum], { p->x, p->y }, static_cast<_item_indexes>(p->wIndx), p->wCI, p->dwSeed, p->bId, p->bDur, p->bMDur, p->bCh, p->bMCh, p->wValue, p->dwBuff, p->wToHit, p->wMaxDam, p->bMinStr, p->bMinMag, p->bMinDex, p->bAC);
 		if (ii != -1) {
 			PutItemRecord(p->dwSeed, p->wCI, p->wIndx);
 			delta_put_item(p, items[ii].position.x, items[ii].position.y, plr[pnum].plrlevel);
@@ -1572,7 +1572,7 @@ static DWORD On_SYNCPUTITEM(TCmd *pCmd, int pnum)
 	if (gbBufferMsgs == 1)
 		msg_send_packet(pnum, p, sizeof(*p));
 	else if (currlevel == plr[pnum].plrlevel) {
-		int ii = SyncPutItem(plr[pnum], { p->x, p->y }, p->wIndx, p->wCI, p->dwSeed, p->bId, p->bDur, p->bMDur, p->bCh, p->bMCh, p->wValue, p->dwBuff, p->wToHit, p->wMaxDam, p->bMinStr, p->bMinMag, p->bMinDex, p->bAC);
+		int ii = SyncPutItem(plr[pnum], { p->x, p->y }, static_cast<_item_indexes>(p->wIndx), p->wCI, p->dwSeed, p->bId, p->bDur, p->bMDur, p->bCh, p->bMCh, p->wValue, p->dwBuff, p->wToHit, p->wMaxDam, p->bMinStr, p->bMinMag, p->bMinDex, p->bAC);
 		if (ii != -1) {
 			PutItemRecord(p->dwSeed, p->wCI, p->wIndx);
 			delta_put_item(p, items[ii].position.x, items[ii].position.y, plr[pnum].plrlevel);
@@ -1596,7 +1596,7 @@ static DWORD On_RESPAWNITEM(TCmd *pCmd, int pnum)
 		msg_send_packet(pnum, p, sizeof(*p));
 	else {
 		if (currlevel == plr[pnum].plrlevel && pnum != myplr) {
-			SyncPutItem(plr[pnum], { p->x, p->y }, p->wIndx, p->wCI, p->dwSeed, p->bId, p->bDur, p->bMDur, p->bCh, p->bMCh, p->wValue, p->dwBuff, p->wToHit, p->wMaxDam, p->bMinStr, p->bMinMag, p->bMinDex, p->bAC);
+			SyncPutItem(plr[pnum], { p->x, p->y }, static_cast<_item_indexes>(p->wIndx), p->wCI, p->dwSeed, p->bId, p->bDur, p->bMDur, p->bCh, p->bMCh, p->wValue, p->dwBuff, p->wToHit, p->wMaxDam, p->bMinStr, p->bMinMag, p->bMinDex, p->bAC);
 		}
 		PutItemRecord(p->dwSeed, p->wCI, p->wIndx);
 		delta_put_item(p, p->x, p->y, plr[pnum].plrlevel);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2155,7 +2155,7 @@ static DWORD On_CHANGEPLRITEMS(TCmd *pCmd, int pnum)
 	if (gbBufferMsgs == 1)
 		msg_send_packet(pnum, p, sizeof(*p));
 	else if (pnum != myplr)
-		CheckInvSwap(pnum, p->bLoc, static_cast<_item_indexes>(p->wIndx), p->wCI, p->dwSeed, p->bId, p->dwBuff);
+		CheckInvSwap(pnum, p->bLoc, p->wIndx, p->wCI, p->dwSeed, p->bId, p->dwBuff);
 
 	return sizeof(*p);
 }

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -210,7 +210,7 @@ struct TCmdGItem {
 	uint8_t bLevel;
 	uint8_t x;
 	uint8_t y;
-	uint16_t wIndx;
+	_item_indexes wIndx;
 	uint16_t wCI;
 	int32_t dwSeed;
 	uint8_t bId;

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -254,7 +254,7 @@ struct TCmdPItem {
 struct TCmdChItem {
 	_cmd_id bCmd;
 	uint8_t bLoc;
-	uint16_t wIndx;
+	_item_indexes wIndx;
 	uint16_t wCI;
 	int32_t dwSeed;
 	uint8_t bId;

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -233,7 +233,7 @@ struct TCmdPItem {
 	_cmd_id bCmd;
 	uint8_t x;
 	uint8_t y;
-	uint16_t wIndx;
+	_item_indexes wIndx;
 	uint16_t wCI;
 	int32_t dwSeed;
 	uint8_t bId;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3351,7 +3351,7 @@ void TryDisarm(int pnum, int i)
 	}
 }
 
-int ItemMiscIdIdx(item_misc_id imiscid)
+_item_indexes ItemMiscIdIdx(item_misc_id imiscid)
 {
 	int i;
 
@@ -3360,7 +3360,7 @@ int ItemMiscIdIdx(item_misc_id imiscid)
 		i++;
 	}
 
-	return i;
+	return static_cast<_item_indexes>(i);
 }
 
 bool OperateShrineMysterious(int pnum)
@@ -3750,14 +3750,14 @@ bool OperateShrineEldritch(int pnum)
 		if (plr[pnum].InvList[j]._itype == ITYPE_MISC) {
 			if (plr[pnum].InvList[j]._iMiscId == IMISC_HEAL
 			    || plr[pnum].InvList[j]._iMiscId == IMISC_MANA) {
-				SetPlrHandItem(&plr[pnum].HoldItem, static_cast<_item_indexes>(ItemMiscIdIdx(IMISC_REJUV)));
+				SetPlrHandItem(&plr[pnum].HoldItem, ItemMiscIdIdx(IMISC_REJUV));
 				GetPlrHandSeed(&plr[pnum].HoldItem);
 				plr[pnum].HoldItem._iStatFlag = true;
 				plr[pnum].InvList[j] = plr[pnum].HoldItem;
 			}
 			if (plr[pnum].InvList[j]._iMiscId == IMISC_FULLHEAL
 			    || plr[pnum].InvList[j]._iMiscId == IMISC_FULLMANA) {
-				SetPlrHandItem(&plr[pnum].HoldItem, static_cast<_item_indexes>(ItemMiscIdIdx(IMISC_FULLREJUV)));
+				SetPlrHandItem(&plr[pnum].HoldItem, ItemMiscIdIdx(IMISC_FULLREJUV));
 				GetPlrHandSeed(&plr[pnum].HoldItem);
 				plr[pnum].HoldItem._iStatFlag = true;
 				plr[pnum].InvList[j] = plr[pnum].HoldItem;
@@ -3768,14 +3768,14 @@ bool OperateShrineEldritch(int pnum)
 		if (item._itype == ITYPE_MISC) {
 			if (item._iMiscId == IMISC_HEAL
 			    || item._iMiscId == IMISC_MANA) {
-				SetPlrHandItem(&plr[pnum].HoldItem, static_cast<_item_indexes>(ItemMiscIdIdx(IMISC_REJUV)));
+				SetPlrHandItem(&plr[pnum].HoldItem, ItemMiscIdIdx(IMISC_REJUV));
 				GetPlrHandSeed(&plr[pnum].HoldItem);
 				plr[pnum].HoldItem._iStatFlag = true;
 				item = plr[pnum].HoldItem;
 			}
 			if (item._iMiscId == IMISC_FULLHEAL
 			    || item._iMiscId == IMISC_FULLMANA) {
-				SetPlrHandItem(&plr[pnum].HoldItem, static_cast<_item_indexes>(ItemMiscIdIdx(IMISC_FULLREJUV)));
+				SetPlrHandItem(&plr[pnum].HoldItem, ItemMiscIdIdx(IMISC_FULLREJUV));
 				GetPlrHandSeed(&plr[pnum].HoldItem);
 				plr[pnum].HoldItem._iStatFlag = true;
 				item = plr[pnum].HoldItem;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3750,14 +3750,14 @@ bool OperateShrineEldritch(int pnum)
 		if (plr[pnum].InvList[j]._itype == ITYPE_MISC) {
 			if (plr[pnum].InvList[j]._iMiscId == IMISC_HEAL
 			    || plr[pnum].InvList[j]._iMiscId == IMISC_MANA) {
-				SetPlrHandItem(&plr[pnum].HoldItem, ItemMiscIdIdx(IMISC_REJUV));
+				SetPlrHandItem(&plr[pnum].HoldItem, static_cast<_item_indexes>(ItemMiscIdIdx(IMISC_REJUV)));
 				GetPlrHandSeed(&plr[pnum].HoldItem);
 				plr[pnum].HoldItem._iStatFlag = true;
 				plr[pnum].InvList[j] = plr[pnum].HoldItem;
 			}
 			if (plr[pnum].InvList[j]._iMiscId == IMISC_FULLHEAL
 			    || plr[pnum].InvList[j]._iMiscId == IMISC_FULLMANA) {
-				SetPlrHandItem(&plr[pnum].HoldItem, ItemMiscIdIdx(IMISC_FULLREJUV));
+				SetPlrHandItem(&plr[pnum].HoldItem, static_cast<_item_indexes>(ItemMiscIdIdx(IMISC_FULLREJUV)));
 				GetPlrHandSeed(&plr[pnum].HoldItem);
 				plr[pnum].HoldItem._iStatFlag = true;
 				plr[pnum].InvList[j] = plr[pnum].HoldItem;
@@ -3768,14 +3768,14 @@ bool OperateShrineEldritch(int pnum)
 		if (item._itype == ITYPE_MISC) {
 			if (item._iMiscId == IMISC_HEAL
 			    || item._iMiscId == IMISC_MANA) {
-				SetPlrHandItem(&plr[pnum].HoldItem, ItemMiscIdIdx(IMISC_REJUV));
+				SetPlrHandItem(&plr[pnum].HoldItem, static_cast<_item_indexes>(ItemMiscIdIdx(IMISC_REJUV)));
 				GetPlrHandSeed(&plr[pnum].HoldItem);
 				plr[pnum].HoldItem._iStatFlag = true;
 				item = plr[pnum].HoldItem;
 			}
 			if (item._iMiscId == IMISC_FULLHEAL
 			    || item._iMiscId == IMISC_FULLMANA) {
-				SetPlrHandItem(&plr[pnum].HoldItem, ItemMiscIdIdx(IMISC_FULLREJUV));
+				SetPlrHandItem(&plr[pnum].HoldItem, static_cast<_item_indexes>(ItemMiscIdIdx(IMISC_FULLREJUV)));
 				GetPlrHandSeed(&plr[pnum].HoldItem);
 				plr[pnum].HoldItem._iStatFlag = true;
 				item = plr[pnum].HoldItem;

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -76,7 +76,7 @@ void MonstCheckDoors(int m);
 void ObjChangeMap(int x1, int y1, int x2, int y2);
 void ObjChangeMapResync(int x1, int y1, int x2, int y2);
 void TryDisarm(int pnum, int i);
-int ItemMiscIdIdx(item_misc_id imiscid);
+_item_indexes ItemMiscIdIdx(item_misc_id imiscid);
 void OperateObject(int pnum, int i, bool TeleFlag);
 void SyncOpObject(int pnum, int cmd, int i);
 void BreakObject(int pnum, int oi);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1854,7 +1854,7 @@ void StripTopGold(int pnum)
 			if (player.InvList[i]._ivalue > MaxGold) {
 				val = player.InvList[i]._ivalue - MaxGold;
 				player.InvList[i]._ivalue = MaxGold;
-				SetPlrHandItem(&player.HoldItem, 0);
+				SetPlrHandItem(&player.HoldItem, IDI_GOLD);
 				GetGoldSeed(pnum, &player.HoldItem);
 				player.HoldItem._ivalue = val;
 				SetPlrHandGoldCurs(&player.HoldItem);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -220,7 +220,7 @@ void PlayerStruct::CalcScrolls()
 	EnsureValidReadiedSpell(*this);
 }
 
-bool PlayerStruct::HasItem(int item, int *idx) const
+bool PlayerStruct::HasItem(_item_indexes item, int *idx) const
 {
 	for (int i = 0; i < _pNumInv; i++) {
 		if (InvList[i].IDidx == item) {
@@ -268,7 +268,7 @@ void PlayerStruct::RemoveInvItem(int iv, bool calcScrolls)
 bool PlayerStruct::TryRemoveInvItemById(int item)
 {
 	int idx;
-	if (HasItem(item, &idx)) {
+	if (HasItem(static_cast<_item_indexes>(item), &idx)) {
 		RemoveInvItem(idx);
 		return true;
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -265,10 +265,10 @@ void PlayerStruct::RemoveInvItem(int iv, bool calcScrolls)
 		CalcScrolls();
 }
 
-bool PlayerStruct::TryRemoveInvItemById(int item)
+bool PlayerStruct::TryRemoveInvItemById(_item_indexes item)
 {
 	int idx;
-	if (HasItem(static_cast<_item_indexes>(item), &idx)) {
+	if (HasItem(item, &idx)) {
 		RemoveInvItem(idx);
 		return true;
 	}

--- a/Source/player.h
+++ b/Source/player.h
@@ -315,7 +315,7 @@ struct PlayerStruct {
 	 * @brief Remove an item from player inventory and return true if the player has the item, return false otherwise
 	 * @param item IDidx of item to be removed
 	 */
-	bool TryRemoveInvItemById(int item);
+	bool TryRemoveInvItemById(_item_indexes item);
 
 	void RemoveSpdBarItem(int iv);
 

--- a/Source/player.h
+++ b/Source/player.h
@@ -302,7 +302,7 @@ struct PlayerStruct {
 
 	void CalcScrolls();
 
-	bool HasItem(int item, int *idx = nullptr) const;
+	bool HasItem(_item_indexes item, int *idx = nullptr) const;
 
 	/**
 	 * @brief Remove an item from player inventory


### PR DESCRIPTION
This PR leverages the `_item_indexes` enum in a multitude of places where raw `int`s were being used to represent item IDs.

This is a preparation for converting the enum into an enum class and adding missing entries.