### PR TITLE
Remove dead code, FreeText() is never called

### DIFF
--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -195,15 +195,6 @@ void InitText()
 	}
 }
 
-void FreeText()
-{
-	fonts[GameFontSmall] = std::nullopt;
-	fonts[GameFontMed] = std::nullopt;
-	fonts[GameFontBig] = std::nullopt;
-
-	pSPentSpn2Cels = std::nullopt;
-}
-
 int GetLineWidth(const char *text, GameFontTables size, int spacing, int *charactersInLine)
 {
 	int lineWidth = 0;

--- a/Source/engine/render/text_render.hpp
+++ b/Source/engine/render/text_render.hpp
@@ -24,7 +24,6 @@ enum GameFontTables : uint8_t {
 extern std::optional<CelSprite> pSPentSpn2Cels;
 
 void InitText();
-void FreeText();
 
 /**
  * @brief Calculate pixel width of first line of text, respecting kerning


### PR DESCRIPTION
Given the program already lets the destructors get called naturally there's no need to explicitly call this function. Even if it was desirable to re-init the font data the old instances will be destroyed when the new instance is assigned to the optional.