### PR TITLE
Hardware Cursor: A couple of improvements

### DIFF
--- a/Source/DiabloUI/credits.cpp
+++ b/Source/DiabloUI/credits.cpp
@@ -200,7 +200,7 @@ bool TextDialog()
 	CreditsRenderer creditsRenderer;
 	bool endMenu = false;
 
-	if (IsHardwareCursorEnabled())
+	if (IsHardwareCursor())
 		SetHardwareCursorVisible(false);
 
 	SDL_Event event;

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -690,7 +690,7 @@ void UiPollAndRender()
 	UiFadeIn();
 
 	// Must happen after the very first UiFadeIn, which sets the cursor.
-	if (IsHardwareCursorEnabled())
+	if (IsHardwareCursor())
 		SetHardwareCursorVisible(!sgbControllerActive);
 }
 
@@ -953,7 +953,7 @@ bool UiItemMouseEvents(SDL_Event *event, const std::vector<UiItemBase *> &items)
 
 void DrawMouse()
 {
-	if (IsHardwareCursorEnabled() || sgbControllerActive)
+	if (IsHardwareCursor() || sgbControllerActive)
 		return;
 
 	DrawArt(MouseX, MouseY, &ArtCursor);

--- a/Source/DiabloUI/dialogs.cpp
+++ b/Source/DiabloUI/dialogs.cpp
@@ -264,7 +264,7 @@ void UiOkDialog(const char *text, const char *caption, bool error, const std::ve
 	static bool inDialog = false;
 
 	if (!gbActive || inDialog) {
-		if (!IsHardwareCursorEnabled()) {
+		if (!IsHardwareCursor()) {
 			if (SDL_ShowCursor(SDL_ENABLE) <= -1) {
 				Log("{}", SDL_GetError());
 			}

--- a/Source/hwcursor.hpp
+++ b/Source/hwcursor.hpp
@@ -9,6 +9,7 @@
 
 namespace devilution {
 
+// Whether the hardware cursor is enabled in settings.
 inline bool IsHardwareCursorEnabled()
 {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
@@ -60,6 +61,16 @@ public:
 		return id_;
 	}
 
+	[[nodiscard]] bool Enabled() const
+	{
+		return enabled_;
+	}
+
+	void SetEnabled(bool value)
+	{
+		enabled_ = value;
+	}
+
 	bool operator==(const CursorInfo &other) const
 	{
 		return type_ == other.type_ && (type_ != CursorType::Game || id_ == other.id_);
@@ -73,6 +84,7 @@ private:
 	explicit CursorInfo(CursorType type, int id = 0)
 	    : type_(type)
 	    , id_(id)
+	    , enabled_(false)
 	{
 	}
 
@@ -80,9 +92,17 @@ private:
 
 	// ID for CursorType::Game
 	int id_;
+
+	bool enabled_ = false;
 };
 
 CursorInfo GetCurrentCursorInfo();
+
+// Whether the current cursor is a hardware cursor.
+inline bool IsHardwareCursor()
+{
+	return GetCurrentCursorInfo().Enabled();
+}
 
 void SetHardwareCursor(CursorInfo cursorInfo);
 

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -225,7 +225,7 @@ void ShowProgress(interface_mode uMsg)
 	BlackPalette();
 	DrawCutscene();
 
-	if (IsHardwareCursorEnabled())
+	if (IsHardwareCursor())
 		SetHardwareCursorVisible(false);
 
 	PaletteFadeIn(8);

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -809,8 +809,8 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 	auto &player = plr[pnum];
 
 	SetICursor(player.HoldItem._iCurs + CURSOR_FIRSTITEM);
-	int i = cursorPosition.x + (IsHardwareCursorEnabled() ? 0 : (icursW / 2));
-	int j = cursorPosition.y + (IsHardwareCursorEnabled() ? 0 : (icursH / 2));
+	int i = cursorPosition.x + (IsHardwareCursor() ? 0 : (icursW / 2));
+	int j = cursorPosition.y + (IsHardwareCursor() ? 0 : (icursH / 2));
 	int sx = icursW28;
 	int sy = icursH28;
 	bool done = false;
@@ -1178,7 +1178,7 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 	}
 	CalcPlrInv(pnum, true);
 	if (pnum == myplr) {
-		if (cn == CURSOR_HAND && !IsHardwareCursorEnabled())
+		if (cn == CURSOR_HAND && !IsHardwareCursor())
 			SetCursorPos(MouseX + (cursW / 2), MouseY + (cursH / 2));
 		NewCursor(cn);
 	}
@@ -1417,7 +1417,7 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove)
 				holdItem._itype = ITYPE_NONE;
 			} else {
 				NewCursor(holdItem._iCurs + CURSOR_FIRSTITEM);
-				if (!IsHardwareCursorEnabled()) {
+				if (!IsHardwareCursor()) {
 					// For a hardware cursor, we set the "hot point" to the center of the item instead.
 					SetCursorPos(cursorPosition.x - (cursW / 2), cursorPosition.y - (cursH / 2));
 				}

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -11,6 +11,7 @@
 #include "cursor.h"
 #include "engine/render/cel_render.hpp"
 #include "engine/render/text_render.hpp"
+#include "hwcursor.hpp"
 #include "minitext.h"
 #include "options.h"
 #include "plrmsg.h"
@@ -808,8 +809,8 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 	auto &player = plr[pnum];
 
 	SetICursor(player.HoldItem._iCurs + CURSOR_FIRSTITEM);
-	int i = cursorPosition.x + (icursW / 2);
-	int j = cursorPosition.y + (icursH / 2);
+	int i = cursorPosition.x + (IsHardwareCursorEnabled() ? 0 : (icursW / 2));
+	int j = cursorPosition.y + (IsHardwareCursorEnabled() ? 0 : (icursH / 2));
 	int sx = icursW28;
 	int sy = icursH28;
 	bool done = false;
@@ -1177,7 +1178,7 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 	}
 	CalcPlrInv(pnum, true);
 	if (pnum == myplr) {
-		if (cn == CURSOR_HAND)
+		if (cn == CURSOR_HAND && !IsHardwareCursorEnabled())
 			SetCursorPos(MouseX + (cursW / 2), MouseY + (cursH / 2));
 		NewCursor(cn);
 	}
@@ -1416,7 +1417,10 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove)
 				holdItem._itype = ITYPE_NONE;
 			} else {
 				NewCursor(holdItem._iCurs + CURSOR_FIRSTITEM);
-				SetCursorPos(cursorPosition.x - (cursW / 2), MouseY - (cursH / 2));
+				if (!IsHardwareCursorEnabled()) {
+					// For a hardware cursor, we set the "hot point" to the center of the item instead.
+					SetCursorPos(cursorPosition.x - (cursW / 2), cursorPosition.y - (cursH / 2));
+				}
 			}
 		}
 	}

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -228,7 +228,7 @@ void SetFadeLevel(int fadeval)
 		system_palette[i].b = (fadeval * logical_palette[i].b) / 256;
 	}
 	palette_update();
-	if (IsHardwareCursorEnabled()) {
+	if (IsHardwareCursor()) {
 		ReinitializeHardwareCursor();
 	}
 }

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1528,7 +1528,7 @@ void scrollrt_draw_game_screen()
 		hgt = gnScreenHeight;
 	}
 
-	if (IsHardwareCursorEnabled()) {
+	if (IsHardwareCursor()) {
 		SetHardwareCursorVisible(ShouldShowCursor());
 	} else {
 		lock_buf(0);
@@ -1540,7 +1540,7 @@ void scrollrt_draw_game_screen()
 
 	RenderPresent();
 
-	if (!IsHardwareCursorEnabled()) {
+	if (!IsHardwareCursor()) {
 		lock_buf(0);
 		UndrawCursor(GlobalBackBuffer());
 		unlock_buf(0);
@@ -1604,7 +1604,7 @@ void DrawAndBlit()
 	}
 	DrawXPBar(out);
 
-	if (IsHardwareCursorEnabled()) {
+	if (IsHardwareCursor()) {
 		SetHardwareCursorVisible(ShouldShowCursor());
 	} else {
 		DrawCursor(out);


### PR DESCRIPTION
1. Use the native hotpoint capability of the hardware item cursor instead of doing it ourselves.
2. Fall back to software cursor if the hardware one fails to initialize.