### PR TITLE
Remove unused variable.

### DIFF
--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -21,8 +21,6 @@
 
 namespace devilution {
 
-/** Seed value before the most recent call to SetRndSeed() */
-int32_t orgseed;
 /** Current game seed */
 int32_t sglGameSeed;
 
@@ -258,7 +256,6 @@ int CalculateWidth2(int width)
 void SetRndSeed(int32_t s)
 {
 	sglGameSeed = s;
-	orgseed = s;
 }
 
 /**


### PR DESCRIPTION
It was documented as if this stored a seed in the previous LCG cycle but it actually stored the initial seed for the current cycle. This value is never used.