### PR TITLE
Fix `-Wswitch` in `UseInvItem`

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -2128,13 +2128,14 @@ bool UseInvItem(int pnum, int cii)
 		speedlist = true;
 	}
 
-	switch (item->IDidx) {
-	case IDI_MUSHROOM:
-		player.Say(HeroSpeech::NowThatsOneBigMushroom, 10);
+	constexpr int SpeechDelay = 10;
+	if (item->IDidx == IDI_MUSHROOM) {
+		player.Say(HeroSpeech::NowThatsOneBigMushroom, SpeechDelay);
 		return true;
-	case IDI_FUNGALTM:
+	}
+	if (item->IDidx == IDI_FUNGALTM) {
 		PlaySFX(IS_IBOOK);
-		player.Say(HeroSpeech::ThatDidntDoAnything, 10);
+		player.Say(HeroSpeech::ThatDidntDoAnything, SpeechDelay);
 		return true;
 	}
 


### PR DESCRIPTION
Fixes a giant non-exhaustive switch warning in `UseInvItem`:

```
../Source/inv.cpp: In function ‘bool devilution::UseInvItem(int, int)’:
../Source/inv.cpp:2131:9: warning: enumeration value ‘IDI_GOLD’ not handled in switch [-Wswitch]
 2131 |  switch (item->IDidx) {
      |         ^
../Source/inv.cpp:2131:9: warning: enumeration value ‘IDI_WARRIOR’ not handled in switch [-Wswitch]
../Source/inv.cpp:2131:9: warning: enumeration value ‘IDI_WARRSHLD’ not handled in switch [-Wswitch]
../Source/inv.cpp:2131:9: warning: enumeration value ‘IDI_WARRCLUB’ not handled in switch [-Wswitch]
...
```