### PR TITLE
Enable ADL for Monsters

### DIFF
--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -170,16 +170,26 @@ void AnimationInfo::ChangeAnimationData(CelSprite *pCelSprite, int numberOfFrame
 	DelayLen = delayLen;
 }
 
-void AnimationInfo::ProcessAnimation()
+void AnimationInfo::ProcessAnimation(bool reverseAnimation /*= false*/, bool dontProgressAnimation /*= false*/)
 {
 	DelayCounter++;
+	if (dontProgressAnimation)
+		return;
 	TicksSinceSequenceStarted++;
 	if (DelayCounter > DelayLen) {
 		DelayCounter = 0;
-		CurrentFrame++;
-		if (CurrentFrame > NumberOfFrames) {
-			CurrentFrame = 1;
-			TicksSinceSequenceStarted = 0;
+		if (reverseAnimation) {
+			CurrentFrame--;
+			if (CurrentFrame == 0) {
+				CurrentFrame = NumberOfFrames;
+				TicksSinceSequenceStarted = 0;
+			}
+		} else {
+			CurrentFrame++;
+			if (CurrentFrame > NumberOfFrames) {
+				CurrentFrame = 1;
+				TicksSinceSequenceStarted = 0;
+			}
 		}
 	}
 }

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -26,7 +26,7 @@ int AnimationInfo::GetFrameToUseForRendering() const
 	assert(TicksSinceSequenceStarted >= 0);
 
 	// we don't use the processed game ticks alone but also the fraction of the next game tick (if a rendering happens between game ticks). This helps to smooth the animations.
-	float totalTicksForCurrentAnimationSequence = gfProgressToNextGameTick + (float)TicksSinceSequenceStarted;
+	float totalTicksForCurrentAnimationSequence = GetProgressToNextGameTick() + (float)TicksSinceSequenceStarted;
 
 	// 1 added for rounding reasons. float to int cast always truncate.
 	int absoluteAnimationFrame = 1 + (int)(totalTicksForCurrentAnimationSequence * TickModifier);
@@ -58,12 +58,12 @@ float AnimationInfo::GetAnimationProgress() const
 		// This logic is used if animation distrubtion is not active (see GetFrameToUseForRendering).
 		// In this case the variables calculated with animation distribution are not initialized and we have to calculate them on the fly with the given informations.
 		float ticksPerFrame = (DelayLen + 1);
-		float totalTicksForCurrentAnimationSequence = gfProgressToNextGameTick + (float)CurrentFrame + (DelayCounter / ticksPerFrame);
+		float totalTicksForCurrentAnimationSequence = GetProgressToNextGameTick() + (float)CurrentFrame + (DelayCounter / ticksPerFrame);
 		float fAnimationFraction = totalTicksForCurrentAnimationSequence / ((float)NumberOfFrames * ticksPerFrame);
 		return fAnimationFraction;
 	}
 
-	float totalTicksForCurrentAnimationSequence = gfProgressToNextGameTick + (float)TicksSinceSequenceStarted;
+	float totalTicksForCurrentAnimationSequence = GetProgressToNextGameTick() + (float)TicksSinceSequenceStarted;
 	float fProgressInAnimationFrames = totalTicksForCurrentAnimationSequence * TickModifier;
 	float fAnimationFraction = fProgressInAnimationFrames / (float)NumberOfFrames;
 	return fAnimationFraction;
@@ -87,6 +87,7 @@ void AnimationInfo::SetNewAnimation(CelSprite *pCelSprite, int numberOfFrames, i
 	TicksSinceSequenceStarted = 0;
 	RelevantFramesForDistributing = 0;
 	TickModifier = 0.0F;
+	IsPetrified = false;
 
 	if (numSkippedFrames != 0 || flags != AnimationDistributionFlags::None) {
 		// Animation Frames that will be adjusted for the skipped Frames/game ticks
@@ -192,6 +193,13 @@ void AnimationInfo::ProcessAnimation(bool reverseAnimation /*= false*/, bool don
 			}
 		}
 	}
+}
+
+float AnimationInfo::GetProgressToNextGameTick() const
+{
+	if (IsPetrified)
+		return 0.0f;
+	return gfProgressToNextGameTick;
 }
 
 } // namespace devilution

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -56,6 +56,10 @@ public:
 	 * @brief Current frame of animation
 	 */
 	int CurrentFrame;
+	/**
+	 * @brief Is the animation currently petrified and shouldn't advance with gfProgressToNextGameTick
+	 */
+	bool IsPetrified;
 
 	/**
 	 * @brief Calculates the Frame to use for the Animation rendering
@@ -95,6 +99,11 @@ public:
 	void ProcessAnimation(bool reverseAnimation = false, bool dontProgressAnimation = false);
 
 private:
+	/**
+	 * @brief returns the progress as a fraction (0.0f to 1.0f) in time to the next game tick or 0.0f if the animation is frozen
+	*/
+	float GetProgressToNextGameTick() const;
+
 	/**
 	 * @brief Specifies how many animations-fractions are displayed between two game ticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
 	 */

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -89,8 +89,10 @@ public:
 
 	/*
 	 * @brief Process the Animation for a game tick (for example advances the frame)
+	 * @param reverseAnimation Play the animation backwards (for example is used for "unseen" monster fading)
+	 * @param dontProgressAnimation Increase DelayCounter but don't change CurrentFrame
 	 */
-	void ProcessAnimation();
+	void ProcessAnimation(bool reverseAnimation = false, bool dontProgressAnimation = false);
 
 private:
 	/**

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -565,10 +565,11 @@ static void LoadMonster(LoadHelper *file, int i)
 	file->skip(2); // Unused
 
 	file->skip(4); // Skip pointer _mAnimData
-	pMonster->_mAnimDelay = file->nextLE<int32_t>();
-	pMonster->_mAnimCnt = file->nextLE<int32_t>();
-	pMonster->_mAnimLen = file->nextLE<int32_t>();
-	pMonster->_mAnimFrame = file->nextLE<int32_t>();
+	pMonster->AnimInfo = {};
+	pMonster->AnimInfo.DelayLen = file->nextLE<int32_t>();
+	pMonster->AnimInfo.DelayCounter = file->nextLE<int32_t>();
+	pMonster->AnimInfo.NumberOfFrames = file->nextLE<int32_t>();
+	pMonster->AnimInfo.CurrentFrame = file->nextLE<int32_t>();
 	file->skip(4); // Skip _meflag
 	pMonster->_mDelFlag = file->nextBool32();
 	pMonster->_mVar1 = file->nextLE<int32_t>();
@@ -1619,10 +1620,10 @@ static void SaveMonster(SaveHelper *file, int i)
 	file->skip(2); // Unused
 
 	file->skip(4); // Skip pointer _mAnimData
-	file->writeLE<int32_t>(pMonster->_mAnimDelay);
-	file->writeLE<int32_t>(pMonster->_mAnimCnt);
-	file->writeLE<int32_t>(pMonster->_mAnimLen);
-	file->writeLE<int32_t>(pMonster->_mAnimFrame);
+	file->writeLE<int32_t>(pMonster->AnimInfo.DelayLen);
+	file->writeLE<int32_t>(pMonster->AnimInfo.DelayCounter);
+	file->writeLE<int32_t>(pMonster->AnimInfo.NumberOfFrames);
+	file->writeLE<int32_t>(pMonster->AnimInfo.CurrentFrame);
 	file->skip(4); // Skip _meflag
 	file->writeLE<uint32_t>(pMonster->_mDelFlag);
 	file->writeLE<int32_t>(pMonster->_mVar1);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -4349,10 +4349,12 @@ void MI_Stone(int i)
 
 	if (missile[i]._mirange == 0) {
 		missile[i]._miDelFlag = true;
-		if (monster[m]._mhitpoints > 0)
+		if (monster[m]._mhitpoints > 0) {
 			monster[m]._mmode = (MON_MODE)missile[i]._miVar1;
-		else
+			monster[m].AnimInfo.IsPetrified = false;
+		} else {
 			AddDead(monster[m].position.tile, stonendx, monster[m]._mdir);
+		}
 	}
 	if (missile[i]._miAnimType == MFILE_SHATTER1)
 		PutMissile(i);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -474,7 +474,7 @@ bool MonsterTrapHit(int m, int mindam, int maxdam, int dist, int t, bool shift)
 		if (monster[m]._mhitpoints >> 6 <= 0) {
 			if (monster[m]._mmode == MM_STONE) {
 				M_StartKill(m, -1);
-				monster[m]._mmode = MM_STONE;
+				monster[m].Petrify();
 			} else {
 				M_StartKill(m, -1);
 			}
@@ -484,7 +484,7 @@ bool MonsterTrapHit(int m, int mindam, int maxdam, int dist, int t, bool shift)
 			} else if (monster[m]._mmode == MM_STONE) {
 				if (m > MAX_PLRS - 1)
 					M_StartHit(m, -1, dam);
-				monster[m]._mmode = MM_STONE;
+				monster[m].Petrify();
 			} else {
 				if (m > MAX_PLRS - 1)
 					M_StartHit(m, -1, dam);
@@ -601,7 +601,7 @@ bool MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, int t, bool 
 	if (monster[m]._mhitpoints >> 6 <= 0) {
 		if (monster[m]._mmode == MM_STONE) {
 			M_StartKill(m, pnum);
-			monster[m]._mmode = MM_STONE;
+			monster[m].Petrify();
 		} else {
 			M_StartKill(m, pnum);
 		}
@@ -611,7 +611,7 @@ bool MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, int t, bool 
 		} else if (monster[m]._mmode == MM_STONE) {
 			if (m > MAX_PLRS - 1)
 				M_StartHit(m, pnum, dam);
-			monster[m]._mmode = MM_STONE;
+			monster[m].Petrify();
 		} else {
 			if (missiledata[t].mType == 0 && plr[pnum]._pIFlags & ISPL_KNOCKBACK) {
 				M_GetKnockback(m);
@@ -2501,7 +2501,7 @@ void AddStone(int mi, Point src, Point dst, int midir, int8_t mienemy, int id, i
 						i = 6;
 						missile[mi]._miVar1 = monster[mid]._mmode;
 						missile[mi]._miVar2 = mid;
-						monster[mid]._mmode = MM_STONE;
+						monster[mid].Petrify();
 						break;
 					}
 				}

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1854,7 +1854,7 @@ void M_SyncStartKill(int i, Point position, int pnum)
 
 	if (monster[i]._mmode == MM_STONE) {
 		MonstStartKill(i, pnum, false);
-		monster[i]._mmode = MM_STONE;
+		monster[i].Petrify();
 	} else {
 		MonstStartKill(i, pnum, false);
 	}
@@ -2028,14 +2028,14 @@ void M_TryM2MHit(int i, int mid, int hper, int mind, int maxd)
 			if (monster[mid]._mhitpoints >> 6 <= 0) {
 				if (monster[mid]._mmode == MM_STONE) {
 					M2MStartKill(i, mid);
-					monster[mid]._mmode = MM_STONE;
+					monster[mid].Petrify();
 				} else {
 					M2MStartKill(i, mid);
 				}
 			} else {
 				if (monster[mid]._mmode == MM_STONE) {
 					M2MStartHit(mid, i, dam);
-					monster[mid]._mmode = MM_STONE;
+					monster[mid].Petrify();
 				} else {
 					M2MStartHit(mid, i, dam);
 				}
@@ -5431,6 +5431,11 @@ void MonsterStruct::CheckStandAnimationIsLoaded(int mdir)
 {
 	if (_mmode == MM_STAND || _mmode == MM_TALK)
 		AnimInfo.pCelSprite = &*MType->Anims[MA_STAND].CelSpritesForDirections[mdir];
+}
+
+void MonsterStruct::Petrify()
+{
+	_mmode = MM_STONE;
 }
 
 } // namespace devilution

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1265,11 +1265,11 @@ void monster_43C785(int i)
 	}
 }
 
-void NewMonsterAnim(int i, AnimStruct *anim, Direction md)
+void NewMonsterAnim(int i, AnimStruct *anim, Direction md, AnimationDistributionFlags flags = AnimationDistributionFlags::None)
 {
 	MonsterStruct *Monst = &monster[i];
 	auto *pCelSprite = &*anim->CelSpritesForDirections[md];
-	Monst->AnimInfo.SetNewAnimation(pCelSprite, anim->Frames, anim->Rate);
+	Monst->AnimInfo.SetNewAnimation(pCelSprite, anim->Frames, anim->Rate, flags);
 	Monst->_mFlags &= ~(MFLAG_LOCK_ANIMATION | MFLAG_ALLOW_SPECIAL);
 	Monst->_mdir = md;
 }
@@ -1487,7 +1487,7 @@ void M_StartWalk3(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int y
 void M_StartAttack(int i)
 {
 	Direction md = M_GetDir(i);
-	NewMonsterAnim(i, &monster[i].MType->Anims[MA_ATTACK], md);
+	NewMonsterAnim(i, &monster[i].MType->Anims[MA_ATTACK], md, AnimationDistributionFlags::ProcessAnimationPending);
 	monster[i]._mmode = MM_ATTACK;
 	monster[i].position.offset = { 0, 0 };
 	monster[i].position.future = monster[i].position.tile;
@@ -1498,7 +1498,7 @@ void M_StartAttack(int i)
 void M_StartRAttack(int i, int missile_type, int dam)
 {
 	Direction md = M_GetDir(i);
-	NewMonsterAnim(i, &monster[i].MType->Anims[MA_ATTACK], md);
+	NewMonsterAnim(i, &monster[i].MType->Anims[MA_ATTACK], md, AnimationDistributionFlags::ProcessAnimationPending);
 	monster[i]._mmode = MM_RATTACK;
 	monster[i]._mVar1 = missile_type;
 	monster[i]._mVar2 = dam;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1268,11 +1268,8 @@ void monster_43C785(int i)
 void NewMonsterAnim(int i, AnimStruct *anim, Direction md)
 {
 	MonsterStruct *Monst = &monster[i];
-	Monst->AnimInfo.pCelSprite = &*anim->CelSpritesForDirections[md];
-	Monst->AnimInfo.NumberOfFrames = anim->Frames;
-	Monst->AnimInfo.DelayCounter = 0;
-	Monst->AnimInfo.CurrentFrame = 1;
-	Monst->AnimInfo.DelayLen = anim->Rate;
+	auto *pCelSprite = &*anim->CelSpritesForDirections[md];
+	Monst->AnimInfo.SetNewAnimation(pCelSprite, anim->Frames, anim->Rate);
 	Monst->_mFlags &= ~(MFLAG_LOCK_ANIMATION | MFLAG_ALLOW_SPECIAL);
 	Monst->_mdir = md;
 }
@@ -4624,21 +4621,7 @@ void ProcessMonsters()
 			}
 		} while (raflag);
 		if (Monst->_mmode != MM_STONE) {
-			Monst->AnimInfo.DelayCounter++;
-			if (!(Monst->_mFlags & MFLAG_ALLOW_SPECIAL) && Monst->AnimInfo.DelayCounter >= Monst->AnimInfo.DelayLen) {
-				Monst->AnimInfo.DelayCounter = 0;
-				if (Monst->_mFlags & MFLAG_LOCK_ANIMATION) {
-					Monst->AnimInfo.CurrentFrame--;
-					if (Monst->AnimInfo.CurrentFrame == 0) {
-						Monst->AnimInfo.CurrentFrame = Monst->AnimInfo.NumberOfFrames;
-					}
-				} else {
-					Monst->AnimInfo.CurrentFrame++;
-					if (Monst->AnimInfo.CurrentFrame > Monst->AnimInfo.NumberOfFrames) {
-						Monst->AnimInfo.CurrentFrame = 1;
-					}
-				}
-			}
+			Monst->AnimInfo.ProcessAnimation(Monst->_mFlags & MFLAG_LOCK_ANIMATION, Monst->_mFlags & MFLAG_ALLOW_SPECIAL);
 		}
 	}
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1265,11 +1265,11 @@ void monster_43C785(int i)
 	}
 }
 
-void NewMonsterAnim(int i, AnimStruct *anim, Direction md, AnimationDistributionFlags flags = AnimationDistributionFlags::None)
+void NewMonsterAnim(int i, AnimStruct *anim, Direction md, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0)
 {
 	MonsterStruct *Monst = &monster[i];
 	auto *pCelSprite = &*anim->CelSpritesForDirections[md];
-	Monst->AnimInfo.SetNewAnimation(pCelSprite, anim->Frames, anim->Rate, flags);
+	Monst->AnimInfo.SetNewAnimation(pCelSprite, anim->Frames, anim->Rate, flags, numSkippedFrames, distributeFramesBeforeFrame);
 	Monst->_mFlags &= ~(MFLAG_LOCK_ANIMATION | MFLAG_ALLOW_SPECIAL);
 	Monst->_mdir = md;
 }
@@ -1511,7 +1511,10 @@ void M_StartRAttack(int i, int missile_type, int dam)
 void M_StartRSpAttack(int i, int missile_type, int dam)
 {
 	Direction md = M_GetDir(i);
-	NewMonsterAnim(i, &monster[i].MType->Anims[MA_SPECIAL], md);
+	int distributeFramesBeforeFrame = 0;
+	if (monster[i]._mAi == AI_MEGA)
+		distributeFramesBeforeFrame = monster[i].MData->mAFNum2;
+	NewMonsterAnim(i, &monster[i].MType->Anims[MA_SPECIAL], md, AnimationDistributionFlags::ProcessAnimationPending, 0, distributeFramesBeforeFrame);
 	monster[i]._mmode = MM_RSPATTACK;
 	monster[i]._mVar1 = missile_type;
 	monster[i]._mVar2 = 0;
@@ -2292,7 +2295,7 @@ bool M_DoRSpAttack(int i)
 		PlayEffect(i, 3);
 	}
 
-	if (monster[i]._mAi == AI_MEGA && monster[i].AnimInfo.CurrentFrame == 3) {
+	if (monster[i]._mAi == AI_MEGA && monster[i].AnimInfo.CurrentFrame == monster[i].MData->mAFNum2) {
 		if (monster[i]._mVar2++ == 0) {
 			monster[i]._mFlags |= MFLAG_ALLOW_SPECIAL;
 		} else if (monster[i]._mVar2 == 15) {

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -5422,6 +5422,7 @@ void MonsterStruct::CheckStandAnimationIsLoaded(int mdir)
 void MonsterStruct::Petrify()
 {
 	_mmode = MM_STONE;
+	AnimInfo.IsPetrified = true;
 }
 
 } // namespace devilution

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -10,6 +10,7 @@
 
 #include "engine.h"
 #include "engine/actor_position.hpp"
+#include "engine/animationinfo.h"
 #include "engine/cel_sprite.hpp"
 #include "engine/point.hpp"
 #include "miniwin/miniwin.h"
@@ -151,15 +152,10 @@ struct MonsterStruct { // note: missing field _mAFNum
 	int _menemy;
 	/** Usually correspond's to the enemy's future position */
 	Point enemyPosition;
-	CelSprite *_mAnimData;
-	/** Tick length of each frame in the current animation */
-	int _mAnimDelay;
-	/** Increases by one each game tick, counting how close we are to _pAnimDelay */
-	int _mAnimCnt;
-	/** Number of frames in current animation */
-	int _mAnimLen;
-	/** Current frame of animation. */
-	int _mAnimFrame;
+	/**
+	 * @brief Contains Information for current Animation
+	 */
+	AnimationInfo AnimInfo;
 	bool _mDelFlag;
 	int _mVar1;
 	int _mVar2;

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -198,6 +198,11 @@ struct MonsterStruct { // note: missing field _mAFNum
 	 * @param mdir direction of the monster
 	 */
 	void CheckStandAnimationIsLoaded(int mdir);
+
+	/**
+	 * @brief Sets _mmode to MM_STONE
+	 */
+	void Petrify();
 };
 
 extern int monstkills[MAXMONSTERS];

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2492,14 +2492,14 @@ bool PlrHitMonst(int pnum, int m)
 		if ((monster[m]._mhitpoints >> 6) <= 0) {
 			if (monster[m]._mmode == MM_STONE) {
 				M_StartKill(m, pnum);
-				monster[m]._mmode = MM_STONE;
+				monster[m].Petrify();
 			} else {
 				M_StartKill(m, pnum);
 			}
 		} else {
 			if (monster[m]._mmode == MM_STONE) {
 				M_StartHit(m, pnum, dam);
-				monster[m]._mmode = MM_STONE;
+				monster[m].Petrify();
 			} else {
 				if ((player._pIFlags & ISPL_KNOCKBACK) != 0) {
 					M_GetKnockback(m);

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -320,7 +320,7 @@ static void DrawMonster(const CelOutputBuffer &out, int x, int y, int mx, int my
 		return;
 	}
 
-	int nCel = monster[m].AnimInfo.CurrentFrame;
+	int nCel = monster[m].AnimInfo.GetFrameToUseForRendering();
 	auto frameTable = reinterpret_cast<const uint32_t *>(monster[m].AnimInfo.pCelSprite->Data());
 	int frames = SDL_SwapLE32(frameTable[0]);
 	if (nCel < 1 || frames > 50 || nCel > frames) {
@@ -701,7 +701,7 @@ static void DrawMonsterHelper(const CelOutputBuffer &out, int x, int y, int oy, 
 	px = sx + pMonster->position.offset.x - CalculateWidth2(cel.Width());
 	py = sy + pMonster->position.offset.y;
 	if (mi == pcursmonst) {
-		Cl2DrawOutline(out, 233, px, py, cel, pMonster->AnimInfo.CurrentFrame);
+		Cl2DrawOutline(out, 233, px, py, cel, pMonster->AnimInfo.GetFrameToUseForRendering());
 	}
 	DrawMonster(out, x, y, px, py, mi);
 }

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -315,13 +315,13 @@ static void DrawMonster(const CelOutputBuffer &out, int x, int y, int mx, int my
 		return;
 	}
 
-	if (monster[m]._mAnimData == nullptr) {
+	if (monster[m].AnimInfo.pCelSprite == nullptr) {
 		Log("Draw Monster \"{}\": NULL Cel Buffer", monster[m].mName);
 		return;
 	}
 
-	int nCel = monster[m]._mAnimFrame;
-	auto frameTable = reinterpret_cast<const uint32_t *>(monster[m]._mAnimData->Data());
+	int nCel = monster[m].AnimInfo.CurrentFrame;
+	auto frameTable = reinterpret_cast<const uint32_t *>(monster[m].AnimInfo.pCelSprite->Data());
 	int frames = SDL_SwapLE32(frameTable[0]);
 	if (nCel < 1 || frames > 50 || nCel > frames) {
 		const char *szMode = "unknown action";
@@ -337,10 +337,10 @@ static void DrawMonster(const CelOutputBuffer &out, int x, int y, int mx, int my
 		return;
 	}
 
-	CelSprite &cel = *monster[m]._mAnimData;
+	CelSprite &cel = *monster[m].AnimInfo.pCelSprite;
 
 	if ((dFlags[x][y] & BFLAG_LIT) == 0) {
-		Cl2DrawLightTbl(out, mx, my, cel, monster[m]._mAnimFrame, 1);
+		Cl2DrawLightTbl(out, mx, my, cel, nCel, 1);
 		return;
 	}
 
@@ -352,9 +352,9 @@ static void DrawMonster(const CelOutputBuffer &out, int x, int y, int mx, int my
 	if (plr[myplr]._pInfraFlag && light_table_index > 8)
 		trans = 1;
 	if (trans)
-		Cl2DrawLightTbl(out, mx, my, cel, monster[m]._mAnimFrame, trans);
+		Cl2DrawLightTbl(out, mx, my, cel, nCel, trans);
 	else
-		Cl2DrawLight(out, mx, my, cel, monster[m]._mAnimFrame);
+		Cl2DrawLight(out, mx, my, cel, nCel);
 }
 
 /**
@@ -696,12 +696,12 @@ static void DrawMonsterHelper(const CelOutputBuffer &out, int x, int y, int oy, 
 		return;
 	}
 
-	const CelSprite &cel = *pMonster->_mAnimData;
+	const CelSprite &cel = *pMonster->AnimInfo.pCelSprite;
 
 	px = sx + pMonster->position.offset.x - CalculateWidth2(cel.Width());
 	py = sy + pMonster->position.offset.y;
 	if (mi == pcursmonst) {
-		Cl2DrawOutline(out, 233, px, py, cel, pMonster->_mAnimFrame);
+		Cl2DrawOutline(out, 233, px, py, cel, pMonster->AnimInfo.CurrentFrame);
 	}
 	DrawMonster(out, x, y, px, py, mi);
 }


### PR DESCRIPTION
Contributes to #838

<details><summary>Example Video</summary>

### Master

https://user-images.githubusercontent.com/25415264/122987556-04e14680-d3a1-11eb-99ac-87ad25775cc7.mp4

### PR

https://user-images.githubusercontent.com/25415264/122987578-0b6fbe00-d3a1-11eb-81ff-359493dbb465.mp4

</details>

Notes:

- This PR introduces ADL to Monsters
- Currently it's used for
   - Attacks
   - Range-Attacks
   - Spell-Attacks
- The other animations are not included to make the size of the pr manageable.
- This pr lays the groundwork for future followup PRs. Similar to what was done for players:
  - Walking
  - Decouple positioning while walking from game logic
  - Blocking
  - MA_SPECIAL (for example gargoyle heal)
  - Death