### PR TITLE
♻️ Clean up `cel_header.hpp`

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1127,7 +1127,7 @@ void LoadMissileGFX(BYTE mi)
 		sprintf(pszName, "Missiles\\%s.CL2", mfd->mName);
 		byte *file = LoadFileInMem(pszName).release();
 		for (unsigned i = 0; i < mfd->mAnimFAmt; i++)
-			mfd->mAnimData[i] = CelGetFrameStart(file, i);
+			mfd->mAnimData[i] = CelGetFrame(file, i);
 	} else if (mfd->mAnimFAmt == 1) {
 		sprintf(pszName, "Missiles\\%s.CL2", mfd->mName);
 		mfd->mAnimData[0] = LoadFileInMem(pszName).release();

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -159,7 +159,7 @@ void InitMonsterTRN(CMonster &monst)
 
 		for (int j = 0; j < 8; j++) {
 			Cl2ApplyTrans(
-			    CelGetFrameStart(monst.Anims[i].CMem.get(), j),
+			    CelGetFrame(monst.Anims[i].CMem.get(), j),
 			    colorTranslations,
 			    monst.Anims[i].Frames);
 		}
@@ -359,7 +359,7 @@ void InitMonsterGFX(int monst)
 			if (Monsters[monst].mtype != MT_GOLEM || (animletter[anim] != 's' && animletter[anim] != 'd')) {
 
 				for (i = 0; i < 8; i++) {
-					byte *pCelStart = CelGetFrameStart(celBuf, i);
+					byte *pCelStart = CelGetFrame(celBuf, i);
 					Monsters[monst].Anims[anim].CelSpritesForDirections[i].emplace(pCelStart, width);
 				}
 			} else {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -400,7 +400,7 @@ void SetPlayerGPtrs(const char *path, std::unique_ptr<byte[]> &data, std::array<
 	data = LoadFileInMem(path);
 
 	for (int i = 0; i < 8; i++) {
-		byte *pCelStart = CelGetFrameStart(data.get(), i);
+		byte *pCelStart = CelGetFrame(data.get(), i);
 		anim[i].emplace(pCelStart, width);
 	}
 }

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -238,7 +238,7 @@ void InitCows(TownerStruct &towner, const TownerInit &initData)
 	towner.animOrder = nullptr;
 	towner.animOrderSize = 0;
 	for (int i = 0; i < 8; i++) {
-		towner._tNAnim[i] = CelGetFrameStart(CowCels.get(), i);
+		towner._tNAnim[i] = CelGetFrame(CowCels.get(), i);
 	}
 	NewTownerAnim(towner, towner._tNAnim[initData.dir], 12, 3);
 	towner._tAnimFrame = GenerateRnd(11) + 1;

--- a/Source/utils/endian.hpp
+++ b/Source/utils/endian.hpp
@@ -5,6 +5,14 @@
 namespace devilution {
 
 template <typename T>
+constexpr std::uint16_t LoadLE16(const T *b)
+{
+	static_assert(sizeof(T) == 1, "invalid argument");
+	// NOLINTNEXTLINE(readability-magic-numbers)
+	return (static_cast<std::uint16_t>(b[1]) << 8) | static_cast<std::uint16_t>(b[0]);
+}
+
+template <typename T>
 constexpr std::uint32_t LoadLE32(const T *b)
 {
 	static_assert(sizeof(T) == 1, "invalid argument");


### PR DESCRIPTION
1. Rename `CelGetFrameStart` to `CelGetFrame`, in line with the other 2 functions with the same name and load the `uint32_t` safely.
2. Remove redundant `FrameHeader`, simply use `LoadLE16`.
3. Document all the functions.