### PR TITLE
Enable ADL for Monster walking and decouple positioning while walking from game logic

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -579,7 +579,7 @@ static void LoadMonster(LoadHelper *file, int i)
 	pMonster->position.temp.y = file->nextLE<int32_t>();
 	pMonster->position.offset2.x = file->nextLE<int32_t>();
 	pMonster->position.offset2.y = file->nextLE<int32_t>();
-	pMonster->actionFrame = file->nextLE<int32_t>();
+	file->skip(4); // Skip actionFrame
 	pMonster->_mmaxhp = file->nextLE<int32_t>();
 	pMonster->_mhitpoints = file->nextLE<int32_t>();
 
@@ -1633,7 +1633,8 @@ static void SaveMonster(SaveHelper *file, int i)
 	file->writeLE<int32_t>(pMonster->position.temp.y);
 	file->writeLE<int32_t>(pMonster->position.offset2.x);
 	file->writeLE<int32_t>(pMonster->position.offset2.y);
-	file->writeLE<int32_t>(pMonster->actionFrame);
+	// Write actionFrame for vanilla compatibility
+	file->writeLE<int32_t>(0);
 	file->writeLE<int32_t>(pMonster->_mmaxhp);
 	file->writeLE<int32_t>(pMonster->_mhitpoints);
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -5420,4 +5420,16 @@ void MonsterStruct::Petrify()
 	AnimInfo.IsPetrified = true;
 }
 
+bool MonsterStruct::IsWalking() const
+{
+	switch (_mmode) {
+	case MM_WALK:
+	case MM_WALK2:
+	case MM_WALK3:
+		return true;
+	default:
+		return false;
+	}
+}
+
 } // namespace devilution

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -468,7 +468,6 @@ void ClearMVars(int i)
 	monster[i]._mVar3 = 0;
 	monster[i].position.temp = { 0, 0 };
 	monster[i].position.offset2 = { 0, 0 };
-	monster[i].actionFrame = 0;
 }
 
 void InitMonster(int i, Direction rd, int mtype, Point position)
@@ -1427,9 +1426,8 @@ void M_StartWalk(int i, int xvel, int yvel, int xadd, int yadd, Direction EndDir
 	monster[i]._mVar2 = yadd;
 	monster[i]._mVar3 = EndDir;
 	monster[i]._mdir = EndDir;
-	NewMonsterAnim(i, &monster[i].MType->Anims[MA_WALK], EndDir);
+	NewMonsterAnim(i, &monster[i].MType->Anims[MA_WALK], EndDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
 	monster[i].position.offset2 = { 0, 0 };
-	monster[i].actionFrame = 0;
 }
 
 void M_StartWalk2(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int yadd, Direction EndDir)
@@ -1451,9 +1449,8 @@ void M_StartWalk2(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int y
 	monster[i].position.velocity = { xvel, yvel };
 	monster[i]._mVar3 = EndDir;
 	monster[i]._mdir = EndDir;
-	NewMonsterAnim(i, &monster[i].MType->Anims[MA_WALK], EndDir);
+	NewMonsterAnim(i, &monster[i].MType->Anims[MA_WALK], EndDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
 	monster[i].position.offset2 = { 16 * xoff, 16 * yoff };
-	monster[i].actionFrame = 0;
 }
 
 void M_StartWalk3(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int yadd, int mapx, int mapy, Direction EndDir)
@@ -1479,9 +1476,8 @@ void M_StartWalk3(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int y
 	monster[i]._mVar2 = fy;
 	monster[i]._mVar3 = EndDir;
 	monster[i]._mdir = EndDir;
-	NewMonsterAnim(i, &monster[i].MType->Anims[MA_WALK], EndDir);
+	NewMonsterAnim(i, &monster[i].MType->Anims[MA_WALK], EndDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
 	monster[i].position.offset2 = { 16 * xoff, 16 * yoff };
-	monster[i].actionFrame = 0;
 }
 
 void M_StartAttack(int i)
@@ -1972,7 +1968,7 @@ bool M_DoWalk(int i, int variant)
 	commitment(monster[i].MType != nullptr, i);
 
 	//Check if we reached new tile
-	if (monster[i].actionFrame == monster[i].MType->Anims[MA_WALK].Frames) {
+	if (monster[i].AnimInfo.CurrentFrame == monster[i].MType->Anims[MA_WALK].Frames) {
 		switch (variant) {
 		case MM_WALK:
 			dMonster[monster[i].position.tile.x][monster[i].position.tile.y] = 0;
@@ -1996,9 +1992,8 @@ bool M_DoWalk(int i, int variant)
 		returnValue = true;
 	} else { //We didn't reach new tile so update monster's "sub-tile" position
 		if (monster[i].AnimInfo.DelayCounter == 0) {
-			if (monster[i].actionFrame == 0 && monster[i].MType->mtype == MT_FLESTHNG)
+			if (monster[i].AnimInfo.CurrentFrame == 0 && monster[i].MType->mtype == MT_FLESTHNG)
 				PlayEffect(i, 3);
-			monster[i].actionFrame++;
 			monster[i].position.offset2 += monster[i].position.velocity;
 			monster[i].position.offset.x = monster[i].position.offset2.x >> 4;
 			monster[i].position.offset.y = monster[i].position.offset2.y >> 4;

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -201,6 +201,11 @@ struct MonsterStruct { // note: missing field _mAFNum
 	 * @brief Sets _mmode to MM_STONE
 	 */
 	void Petrify();
+
+	/**
+	 * @brief Is the monster currently walking?
+	 */
+	bool IsWalking() const;
 };
 
 extern int monstkills[MAXMONSTERS];

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -160,8 +160,6 @@ struct MonsterStruct { // note: missing field _mAFNum
 	int _mVar1;
 	int _mVar2;
 	int _mVar3;
-	/** Value used to measure progress for moving from one tile to another */
-	int actionFrame;
 	int _mmaxhp;
 	int _mhitpoints;
 	_mai_id _mAi;

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -698,8 +698,13 @@ static void DrawMonsterHelper(const CelOutputBuffer &out, int x, int y, int oy, 
 
 	const CelSprite &cel = *pMonster->AnimInfo.pCelSprite;
 
-	px = sx + pMonster->position.offset.x - CalculateWidth2(cel.Width());
-	py = sy + pMonster->position.offset.y;
+	Point offset = pMonster->position.offset;
+	if (pMonster->IsWalking()) {
+		offset = GetOffsetForWalking(pMonster->AnimInfo, pMonster->_mdir);
+	}
+
+	px = sx + offset.x - CalculateWidth2(cel.Width());
+	py = sy + offset.y;
 	if (mi == pcursmonst) {
 		Cl2DrawOutline(out, 233, px, py, cel, pMonster->AnimInfo.GetFrameToUseForRendering());
 	}


### PR DESCRIPTION
Beware! The monsters are getting faster! 👹 

Contributes to #838

<details><summary>Example Video</summary>

### Master

https://user-images.githubusercontent.com/25415264/123510936-8de8ce00-d67e-11eb-8397-fe39538104d1.mp4

### PR

https://user-images.githubusercontent.com/25415264/123510939-950fdc00-d67e-11eb-9854-fbb0638937b8.mp4

</details>

Notes:

- No behavior changes
- Similar to #1939 this introduces a minor breaking change (one animation)
