### PR TITLE
ADL: Minor Cleanup

### DIFF
--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -60,7 +60,7 @@ float AnimationInfo::GetAnimationProgress() const
 {
 	if (RelevantFramesForDistributing <= 0) {
 		// This logic is used if animation distrubtion is not active (see GetFrameToUseForRendering).
-		// In this case the variables calculated with animation distribution are not initialized and we have to calculate them on the fly with the given informations.
+		// In this case the variables calculated with animation distribution are not initialized and we have to calculate them on the fly with the given information.
 		float ticksPerFrame = (DelayLen + 1);
 		float totalTicksForCurrentAnimationSequence = GetProgressToNextGameTick() + (float)CurrentFrame + (DelayCounter / ticksPerFrame);
 		float fAnimationFraction = totalTicksForCurrentAnimationSequence / ((float)NumberOfFrames * ticksPerFrame);

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -23,10 +23,14 @@ int AnimationInfo::GetFrameToUseForRendering() const
 	if (CurrentFrame > RelevantFramesForDistributing)
 		return CurrentFrame;
 
-	assert(TicksSinceSequenceStarted >= 0);
+	float ticksSinceSequenceStarted = (float)TicksSinceSequenceStarted;
+	if (TicksSinceSequenceStarted < 0) {
+		ticksSinceSequenceStarted = 0.0F;
+		Log("GetFrameToUseForRendering: Invalid TicksSinceSequenceStarted {}", TicksSinceSequenceStarted);
+	}
 
 	// we don't use the processed game ticks alone but also the fraction of the next game tick (if a rendering happens between game ticks). This helps to smooth the animations.
-	float totalTicksForCurrentAnimationSequence = GetProgressToNextGameTick() + (float)TicksSinceSequenceStarted;
+	float totalTicksForCurrentAnimationSequence = GetProgressToNextGameTick() + ticksSinceSequenceStarted;
 
 	// 1 added for rounding reasons. float to int cast always truncate.
 	int absoluteAnimationFrame = 1 + (int)(totalTicksForCurrentAnimationSequence * TickModifier);

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -31,9 +31,9 @@ enum AnimationDistributionFlags : uint8_t {
 	RepeatedAction = 1 << 2,
 };
 
-/*
-* @brief Contains the core animation information and related logic
-*/
+/**
+ * @brief Contains the core animation information and related logic
+ */
 class AnimationInfo {
 public:
 	/**
@@ -91,7 +91,7 @@ public:
 	 */
 	void ChangeAnimationData(CelSprite *pCelSprite, int numberOfFrames, int delayLen);
 
-	/*
+	/**
 	 * @brief Process the Animation for a game tick (for example advances the frame)
 	 * @param reverseAnimation Play the animation backwards (for example is used for "unseen" monster fading)
 	 * @param dontProgressAnimation Increase DelayCounter but don't change CurrentFrame
@@ -101,7 +101,7 @@ public:
 private:
 	/**
 	 * @brief returns the progress as a fraction (0.0f to 1.0f) in time to the next game tick or 0.0f if the animation is frozen
-	*/
+	 */
 	float GetProgressToNextGameTick() const;
 
 	/**


### PR DESCRIPTION
Notes:

- No behavior or animation changes
- `TicksSinceSequenceStarted` should never be < 0 when `GetFrameToUseForRendering` is called. Else it's a bug. But if we get a bug, this information should help a little bit.