### PR TITLE
Clang-tidy: readability-uppercase-literal-suffix

### DIFF
--- a/Source/controls/controller_motion.cpp
+++ b/Source/controls/controller_motion.cpp
@@ -28,7 +28,7 @@ void ScaleJoystickAxes(float *x, float *y, float deadzone)
 		return;
 	}
 
-	const float maximum = 32767.0f;
+	const float maximum = 32767.0F;
 	float analogX = *x;
 	float analogY = *y;
 	float deadZone = deadzone * maximum;
@@ -41,7 +41,7 @@ void ScaleJoystickAxes(float *x, float *y, float deadzone)
 		analogY = (analogY * scalingFactor);
 
 		// clamp to ensure results will never exceed the max_axis value
-		float clampingFactor = 1.0f;
+		float clampingFactor = 1.0F;
 		float absAnalogX = std::fabs(analogX);
 		float absAnalogY = std::fabs(analogY);
 		if (absAnalogX > 1.0 || absAnalogY > 1.0) {

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -919,7 +919,7 @@ void InvMove(AxisDirection dir)
 		if (slot >= SLOTXY_INV_FIRST)
 			mousePos.y -= InventorySlotSizeInPixels.height;
 		else
-			mousePos.y -= (int)((icursH28 / 2.f) * InventorySlotSizeInPixels.height) + (InventorySlotSizeInPixels.height / 2);
+			mousePos.y -= (int)((icursH28 / 2.F) * InventorySlotSizeInPixels.height) + (InventorySlotSizeInPixels.height / 2);
 	} else {
 		mousePos.x += (InventorySlotSizeInPixels.width / 2);
 		mousePos.y -= (InventorySlotSizeInPixels.height / 2);

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -202,7 +202,7 @@ void AnimationInfo::ProcessAnimation(bool reverseAnimation /*= false*/, bool don
 float AnimationInfo::GetProgressToNextGameTick() const
 {
 	if (IsPetrified)
-		return 0.0f;
+		return 0.0F;
 	return gfProgressToNextGameTick;
 }
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -430,30 +430,30 @@ void InitMonsterGFX(int monst)
 		LoadMissileGFX(MFILE_ACIDPUD);
 	}
 	if (mtype == MT_LICH && (MissileFileFlag & 0x100) == 0) {
-		MissileFileFlag |= 0x100u;
+		MissileFileFlag |= 0x100U;
 		LoadMissileGFX(MFILE_LICH);
 		LoadMissileGFX(MFILE_EXORA1);
 	}
 	if (mtype == MT_ARCHLICH && (MissileFileFlag & 0x200) == 0) {
-		MissileFileFlag |= 0x200u;
+		MissileFileFlag |= 0x200U;
 		LoadMissileGFX(MFILE_ARCHLICH);
 		LoadMissileGFX(MFILE_EXYEL2);
 	}
 	if ((mtype == MT_PSYCHORB || mtype == MT_BONEDEMN) && (MissileFileFlag & 0x400) == 0) {
-		MissileFileFlag |= 0x400u;
+		MissileFileFlag |= 0x400U;
 		LoadMissileGFX(MFILE_BONEDEMON);
 	}
 	if (mtype == MT_NECRMORB && (MissileFileFlag & 0x800) == 0) {
-		MissileFileFlag |= 0x800u;
+		MissileFileFlag |= 0x800U;
 		LoadMissileGFX(MFILE_NECROMORB);
 		LoadMissileGFX(MFILE_EXRED3);
 	}
 	if (mtype == MT_PSYCHORB && (MissileFileFlag & 0x1000) == 0) {
-		MissileFileFlag |= 0x1000u;
+		MissileFileFlag |= 0x1000U;
 		LoadMissileGFX(MFILE_EXBL2);
 	}
 	if (mtype == MT_BONEDEMN && (MissileFileFlag & 0x2000) == 0) {
-		MissileFileFlag |= 0x2000u;
+		MissileFileFlag |= 0x2000U;
 		LoadMissileGFX(MFILE_EXBL3);
 	}
 	if (mtype == MT_DIABLO) {

--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -27,7 +27,7 @@ bool sgbThreadIsRunning;
 DWORD gdwLargestMsgSize;
 DWORD gdwNormalMsgSize;
 int last_tick;
-float gfProgressToNextGameTick = 0.0f;
+float gfProgressToNextGameTick = 0.0F;
 
 /* data */
 static SDL_Thread *sghThread = nullptr;
@@ -244,15 +244,15 @@ void nthread_UpdateProgressToNextGameTick()
 	int currentTickCount = SDL_GetTicks();
 	int ticksElapsed = last_tick - currentTickCount;
 	if (ticksElapsed <= 0) {
-		gfProgressToNextGameTick = 1.0f; // game tick is due
+		gfProgressToNextGameTick = 1.0F; // game tick is due
 		return;
 	}
 	int ticksAdvanced = gnTickDelay - ticksElapsed;
 	float fraction = (float)ticksAdvanced / (float)gnTickDelay;
-	if (fraction > 1.0f)
-		gfProgressToNextGameTick = 1.0f;
-	if (fraction < 0.0f)
-		gfProgressToNextGameTick = 0.0f;
+	if (fraction > 1.0F)
+		gfProgressToNextGameTick = 1.0F;
+	if (fraction < 0.0F)
+		gfProgressToNextGameTick = 0.0F;
 	gfProgressToNextGameTick = fraction;
 }
 

--- a/Source/utils/soundsample.cpp
+++ b/Source/utils/soundsample.cpp
@@ -23,28 +23,28 @@ namespace devilution {
 
 namespace {
 
-constexpr float LogBase = 10.0f;
+constexpr float LogBase = 10.0F;
 
 /**
  * Scaling factor for attenuating volume.
  * Picked so that a volume change of -10 dB results in half perceived loudness.
  * VolumeScale = -1000 / log(0.5)
  */
-constexpr float VolumeScale = 3321.9281f;
+constexpr float VolumeScale = 3321.9281F;
 
 /**
  * Min and max volume range, in millibel.
  * -100 dB (muted) to 0 dB (max. loudness).
  */
-constexpr float MillibelMin = -10000.0f;
-constexpr float MillibelMax = 0.0f;
+constexpr float MillibelMin = -10000.0F;
+constexpr float MillibelMax = 0.0F;
 
 /**
  * Stereo separation factor for left/right speaker panning. Lower values increase separation, moving
  * sounds further left/right, while higher values will pull sounds more towards the middle, reducing separation.
  * Current value is tuned to have ~2:1 mix for sounds that happen on the edge of a 640x480 screen.
  */
-constexpr float StereoSeparation = 6000.0f;
+constexpr float StereoSeparation = 6000.0F;
 
 float PanLogToLinear(int logPan)
 {
@@ -53,7 +53,7 @@ float PanLogToLinear(int logPan)
 
 	auto factor = std::pow(LogBase, static_cast<float>(-std::abs(logPan)) / StereoSeparation);
 
-	return copysign(1.0f - factor, static_cast<float>(logPan));
+	return copysign(1.0F - factor, static_cast<float>(logPan));
 }
 
 } // namespace


### PR DESCRIPTION
Suffixes are rarely used in the code and these cases do not seam to add any value, should I simply strip them instead of applying this rule?