### PR TITLE
Enable ADL for Monster Death and Got-Hit Animation

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -138,6 +138,7 @@ int arrowdebug = 0;
 #endif
 /** Specifies whether players are in non-PvP mode. */
 bool gbFriendlyMode = true;
+GameLogicStep gGameLogicStep = GameLogicStep::None;
 QuickMessage QuickMessages[QUICK_MESSAGE_OPTIONS] = {
 	{ "QuickMessage1", N_("I need help! Come Here!") },
 	{ "QuickMessage2", N_("Follow me.") },
@@ -1713,20 +1714,29 @@ static void game_logic()
 		return;
 	}
 	if (gbProcessPlayers) {
+		gGameLogicStep = GameLogicStep::ProcessPlayers;
 		ProcessPlayers();
 	}
 	if (leveltype != DTYPE_TOWN) {
+		gGameLogicStep = GameLogicStep::ProcessMonsters;
 		ProcessMonsters();
+		gGameLogicStep = GameLogicStep::ProcessObjects;
 		ProcessObjects();
+		gGameLogicStep = GameLogicStep::ProcessMissiles;
 		ProcessMissiles();
+		gGameLogicStep = GameLogicStep::ProcessItems;
 		ProcessItems();
 		ProcessLightList();
 		ProcessVisionList();
 	} else {
+		gGameLogicStep = GameLogicStep::ProcessTowners;
 		ProcessTowners();
+		gGameLogicStep = GameLogicStep::ProcessItemsTown;
 		ProcessItems();
+		gGameLogicStep = GameLogicStep::ProcessMissilesTown;
 		ProcessMissiles();
 	}
+	gGameLogicStep = GameLogicStep::None;
 
 #ifdef _DEBUG
 	if (debug_mode_key_inverted_v && GetAsyncKeyState(DVL_VK_SHIFT)) {

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -28,6 +28,21 @@ enum clicktype : int8_t {
 	CLICK_RIGHT,
 };
 
+/**
+ * @brief Specifices what game logic step is currently executed
+ */
+enum class GameLogicStep {
+	None,
+	ProcessPlayers,
+	ProcessMonsters,
+	ProcessObjects,
+	ProcessMissiles,
+	ProcessItems,
+	ProcessTowners,
+	ProcessItemsTown,
+	ProcessMissilesTown,
+};
+
 extern SDL_Window *ghMainWnd;
 extern DWORD glSeedTbl[NUMLEVELS];
 extern dungeon_type gnLevelTypeTbl[NUMLEVELS];
@@ -95,5 +110,9 @@ struct QuickMessage {
 constexpr size_t QUICK_MESSAGE_OPTIONS = 4;
 extern QuickMessage QuickMessages[QUICK_MESSAGE_OPTIONS];
 extern bool gbFriendlyMode;
+/**
+ * @brief Specifices what game logic step is currently executed
+ */
+extern GameLogicStep gGameLogicStep;
 
 } // namespace devilution

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1757,7 +1757,7 @@ void MonstStartKill(int i, int pnum, bool sendmsg)
 
 	Direction md = pnum >= 0 ? M_GetDir(i) : Monst->_mdir;
 	Monst->_mdir = md;
-	NewMonsterAnim(i, &Monst->MType->Anims[MA_DEATH], md);
+	NewMonsterAnim(i, &Monst->MType->Anims[MA_DEATH], md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
 	Monst->_mmode = MM_DEATH;
 	Monst->_mgoal = MGOAL_NONE;
 	Monst->position.offset = { 0, 0 };
@@ -1803,7 +1803,7 @@ void M2MStartKill(int i, int mid)
 		md = DIR_S;
 
 	monster[mid]._mdir = md;
-	NewMonsterAnim(mid, &monster[mid].MType->Anims[MA_DEATH], md);
+	NewMonsterAnim(mid, &monster[mid].MType->Anims[MA_DEATH], md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
 	monster[mid]._mmode = MM_DEATH;
 	monster[mid].position.offset = { 0, 0 };
 	monster[mid].position.tile = monster[mid].position.old;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1572,7 +1572,7 @@ void M_GetKnockback(int i)
 	if (DirOK(i, d)) {
 		M_ClearSquares(i);
 		monster[i].position.old += d;
-		NewMonsterAnim(i, &monster[i].MType->Anims[MA_GOTHIT], monster[i]._mdir);
+		NewMonsterAnim(i, &monster[i].MType->Anims[MA_GOTHIT], monster[i]._mdir, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
 		monster[i]._mmode = MM_GOTHIT;
 		monster[i].position.offset = { 0, 0 };
 		monster[i].position.tile = monster[i].position.old;
@@ -1607,7 +1607,7 @@ void M_StartHit(int i, int pnum, int dam)
 			monster[i]._mgoalvar2 = 0;
 		}
 		if (monster[i]._mmode != MM_STONE) {
-			NewMonsterAnim(i, &monster[i].MType->Anims[MA_GOTHIT], monster[i]._mdir);
+			NewMonsterAnim(i, &monster[i].MType->Anims[MA_GOTHIT], monster[i]._mdir, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
 			monster[i]._mmode = MM_GOTHIT;
 			monster[i].position.offset = { 0, 0 };
 			monster[i].position.tile = monster[i].position.old;
@@ -1720,7 +1720,7 @@ void M2MStartHit(int mid, int i, int dam)
 
 		if (monster[mid]._mmode != MM_STONE) {
 			if (monster[mid].MType->mtype != MT_GOLEM) {
-				NewMonsterAnim(mid, &monster[mid].MType->Anims[MA_GOTHIT], monster[mid]._mdir);
+				NewMonsterAnim(mid, &monster[mid].MType->Anims[MA_GOTHIT], monster[mid]._mdir, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
 				monster[mid]._mmode = MM_GOTHIT;
 			}
 


### PR DESCRIPTION
Contributes to #838

<details><summary>Example Video Death Animation</summary>

### Master

https://user-images.githubusercontent.com/25415264/123561175-35612000-d7a7-11eb-86c4-cee3d5036e06.mp4

### PR

https://user-images.githubusercontent.com/25415264/123561179-3d20c480-d7a7-11eb-81f0-dfcf6200f707.mp4

</details>

<details><summary>Example Video Got Hit Animation</summary>

### Master

https://user-images.githubusercontent.com/25415264/123561188-4ad64a00-d7a7-11eb-94ea-03a2e4206e15.mp4

### PR

https://user-images.githubusercontent.com/25415264/123561191-4f026780-d7a7-11eb-9744-b5450c4083c9.mp4

</details>

Notes:

- The death and got hit animation can be truncated if the attack is executed in `ProcessPlayer` (cause `ProcessPlayer` runs for `ProcessMonsters`). This doesn't happen if the hit comes from a missile (cause `ProcessMissiles` runs after `ProcessMonsters`). My first prototype passed all functions a flag if we are in `ProcessPlayer` or not. But this was quite frustrating. So I introduced `GameLogicStep`.
- No behavior changes, only animations.