### PR TITLE
🎉 Hardware cursor: Enable safe parts by default

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -168,10 +168,10 @@ void LoadOptions()
 	sgOptions.Graphics.bBlendedTransparancy = GetIniBool("Graphics", "Blended Transparency", true);
 	sgOptions.Graphics.nGammaCorrection = GetIniInt("Graphics", "Gamma Correction", 100);
 	sgOptions.Graphics.bColorCycling = GetIniBool("Graphics", "Color Cycling", true);
-#ifndef USE_SDL1
-	sgOptions.Graphics.bHardwareCursor = GetIniBool("Graphics", "Hardware Cursor", false);
-#else
-	sgOptions.Graphics.bHardwareCursor = false;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	sgOptions.Graphics.bHardwareCursor = GetIniBool("Graphics", "Hardware Cursor", true);
+	sgOptions.Graphics.bHardwareCursorForItems = GetIniBool("Graphics", "Hardware Cursor For Items", false);
+	sgOptions.Graphics.nHardwareCursorMaxSize = GetIniInt("Graphics", "Hardware Cursor Maximum Size", 128);
 #endif
 	sgOptions.Graphics.bFPSLimit = GetIniBool("Graphics", "FPS Limiter", true);
 	sgOptions.Graphics.bShowFPS = (GetIniInt("Graphics", "Show FPS", 0) != 0);
@@ -252,8 +252,10 @@ void SaveOptions()
 	SetIniValue("Graphics", "Blended Transparency", sgOptions.Graphics.bBlendedTransparancy);
 	SetIniValue("Graphics", "Gamma Correction", sgOptions.Graphics.nGammaCorrection);
 	SetIniValue("Graphics", "Color Cycling", sgOptions.Graphics.bColorCycling);
-#ifndef USE_SDL1
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 	SetIniValue("Graphics", "Hardware Cursor", sgOptions.Graphics.bHardwareCursor);
+	SetIniValue("Graphics", "Hardware Cursor For Items", sgOptions.Graphics.bHardwareCursorForItems);
+	SetIniValue("Graphics", "Hardware Cursor Maximum Size", sgOptions.Graphics.nHardwareCursorMaxSize);
 #endif
 	SetIniValue("Graphics", "FPS Limiter", sgOptions.Graphics.bFPSLimit);
 	SetIniValue("Graphics", "Show FPS", sgOptions.Graphics.bShowFPS);

--- a/Source/options.h
+++ b/Source/options.h
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+#include <SDL_version.h>
+
 #include "pack.h"
 
 namespace devilution {
@@ -61,8 +63,14 @@ struct GraphicsOptions {
 	int nGammaCorrection;
 	/** @brief Enable color cycling animations. */
 	bool bColorCycling;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 	/** @brief Use a hardware cursor (SDL2 only). */
 	bool bHardwareCursor;
+	/** @brief Use a hardware cursor for items. */
+	bool bHardwareCursorForItems;
+	/** @brief Maximum width / height for the hardware cursor. Larger cursors fall back to software. */
+	int nHardwareCursorMaxSize;
+#endif
 	/** @brief Enable FPS Limit. */
 	bool bFPSLimit;
 	/** @brief Show FPS, even without the -f command line flag. */


### PR DESCRIPTION
Enables safe parts of the hardware cursor by default:

1. Disabled for items due to the jumping glitch.
2. Limited to 128px size due to buggy large cursors on some systems.