### PR TITLE
Add alternate RNG and proposed API for versioning Random Number Generators

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1905,7 +1905,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 	if (pcurs > CURSOR_HAND && pcurs < CURSOR_FIRSTITEM) {
 		NewCursor(CURSOR_HAND);
 	}
-	SetRndSeed(glSeedTbl[currlevel]);
+	vanilla::SetRndSeed(glSeedTbl[currlevel]);
 	IncProgress();
 	MakeLightTable();
 	LoadLvlGFX();
@@ -1920,7 +1920,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 		InitText();
 	}
 
-	SetRndSeed(glSeedTbl[currlevel]);
+	vanilla::SetRndSeed(glSeedTbl[currlevel]);
 
 	if (leveltype == DTYPE_TOWN)
 		SetupTownStores();
@@ -1942,7 +1942,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 		CreateLevel(lvldir);
 		IncProgress();
 		FillSolidBlockTbls();
-		SetRndSeed(glSeedTbl[currlevel]);
+		vanilla::SetRndSeed(glSeedTbl[currlevel]);
 
 		if (leveltype != DTYPE_TOWN) {
 			GetLevelMTypes();
@@ -1986,24 +1986,24 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 				visited = visited || player._pLvlVisited[currlevel];
 		}
 
-		SetRndSeed(glSeedTbl[currlevel]);
+		vanilla::SetRndSeed(glSeedTbl[currlevel]);
 
 		if (leveltype != DTYPE_TOWN) {
 			if (firstflag || lvldir == ENTRY_LOAD || !myPlayer._pLvlVisited[currlevel] || gbIsMultiplayer) {
 				HoldThemeRooms();
-				glMid1Seed[currlevel] = GetLCGEngineState();
+				glMid1Seed[currlevel] = vanilla::GetLCGEngineState();
 				InitMonsters();
-				glMid2Seed[currlevel] = GetLCGEngineState();
+				glMid2Seed[currlevel] = vanilla::GetLCGEngineState();
 				IncProgress();
 				InitObjects();
 				InitItems();
 				if (currlevel < 17)
 					CreateThemeRooms();
 				IncProgress();
-				glMid3Seed[currlevel] = GetLCGEngineState();
+				glMid3Seed[currlevel] = vanilla::GetLCGEngineState();
 				InitMissiles();
 				InitDead();
-				glEndSeed[currlevel] = GetLCGEngineState();
+				glEndSeed[currlevel] = vanilla::GetLCGEngineState();
 
 				if (gbIsMultiplayer)
 					DeltaLoadLevel();

--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -769,12 +769,12 @@ int PlaceMiniSet(const BYTE *miniset, int tmin, int tmax, int cx, int cy, bool s
 
 	int numt = 1;
 	if (tmax - tmin != 0) {
-		numt = GenerateRnd(tmax - tmin) + tmin;
+		numt = vanilla::GenerateRnd(tmax - tmin) + tmin;
 	}
 
 	for (int i = 0; i < numt; i++) {
-		sx = GenerateRnd(DMAXX - sw);
-		sy = GenerateRnd(DMAXY - sh);
+		sx = vanilla::GenerateRnd(DMAXX - sw);
+		sy = vanilla::GenerateRnd(DMAXY - sh);
 		bool abort = false;
 		int found = 0;
 
@@ -911,7 +911,7 @@ void PlaceMiniSetRandom(const BYTE *miniset, int rndper)
 					found = false;
 				}
 			}
-			if (found && GenerateRnd(100) < rndper) {
+			if (found && vanilla::GenerateRnd(100) < rndper) {
 				for (int yy = 0; yy < sh; yy++) {
 					for (int xx = 0; xx < sw; xx++) {
 						if (miniset[kk] != 0) {
@@ -930,7 +930,7 @@ void FillFloor()
 	for (int j = 0; j < DMAXY; j++) {
 		for (int i = 0; i < DMAXX; i++) {
 			if (L5dflags[i][j] == 0 && dungeon[i][j] == 13) {
-				int rv = GenerateRnd(3);
+				int rv = vanilla::GenerateRnd(3);
 
 				if (rv == 1)
 					dungeon[i][j] = 162;
@@ -1033,7 +1033,7 @@ bool CheckRoom(int x, int y, int width, int height)
 
 void GenerateRoom(int x, int y, int w, int h, int dir)
 {
-	int dirProb = GenerateRnd(4);
+	int dirProb = vanilla::GenerateRnd(4);
 	int num = 0;
 
 	bool ran;
@@ -1043,8 +1043,8 @@ void GenerateRoom(int x, int y, int w, int h, int dir)
 		int cx1;
 		int cy1;
 		do {
-			cw = (GenerateRnd(5) + 2) & ~1;
-			ch = (GenerateRnd(5) + 2) & ~1;
+			cw = (vanilla::GenerateRnd(5) + 2) & ~1;
+			ch = (vanilla::GenerateRnd(5) + 2) & ~1;
 			cx1 = x - cw;
 			cy1 = h / 2 + y - ch / 2;
 			ran = CheckRoom(cx1 - 1, cy1 - 1, ch + 2, cw + 1); /// BUGFIX: swap args 3 and 4 ("ch+2" and "cw+1")
@@ -1069,8 +1069,8 @@ void GenerateRoom(int x, int y, int w, int h, int dir)
 	int rx;
 	int ry;
 	do {
-		width = (GenerateRnd(5) + 2) & ~1;
-		height = (GenerateRnd(5) + 2) & ~1;
+		width = (vanilla::GenerateRnd(5) + 2) & ~1;
+		height = (vanilla::GenerateRnd(5) + 2) & ~1;
 		rx = w / 2 + x - width / 2;
 		ry = y - height;
 		ran = CheckRoom(rx - 1, ry - 1, width + 2, height + 1);
@@ -1091,13 +1091,13 @@ void GenerateRoom(int x, int y, int w, int h, int dir)
 
 void FirstRoom()
 {
-	if (GenerateRnd(2) == 0) {
+	if (vanilla::GenerateRnd(2) == 0) {
 		int ys = 1;
 		int ye = DMAXY - 1;
 
-		VR1 = (GenerateRnd(2) != 0);
-		VR2 = (GenerateRnd(2) != 0);
-		VR3 = (GenerateRnd(2) != 0);
+		VR1 = (vanilla::GenerateRnd(2) != 0);
+		VR2 = (vanilla::GenerateRnd(2) != 0);
+		VR3 = (vanilla::GenerateRnd(2) != 0);
 
 		if (!VR1 || !VR3)
 			VR2 = true;
@@ -1136,9 +1136,9 @@ void FirstRoom()
 		int xs = 1;
 		int xe = DMAXX - 1;
 
-		HR1 = GenerateRnd(2) != 0;
-		HR2 = GenerateRnd(2) != 0;
-		HR3 = GenerateRnd(2) != 0;
+		HR1 = vanilla::GenerateRnd(2) != 0;
+		HR2 = vanilla::GenerateRnd(2) != 0;
+		HR3 = vanilla::GenerateRnd(2) != 0;
 
 		if (!HR1 || !HR3)
 			HR2 = true;
@@ -1277,7 +1277,7 @@ void HorizontalWall(int i, int j, char p, int dx)
 {
 	int8_t dt;
 
-	switch (GenerateRnd(4)) {
+	switch (vanilla::GenerateRnd(4)) {
 	case 0:
 	case 1:
 		dt = 2;
@@ -1299,7 +1299,7 @@ void HorizontalWall(int i, int j, char p, int dx)
 	}
 
 	int8_t wt = 26;
-	if (GenerateRnd(6) == 5)
+	if (vanilla::GenerateRnd(6) == 5)
 		wt = 12;
 
 	if (dt == 12)
@@ -1311,7 +1311,7 @@ void HorizontalWall(int i, int j, char p, int dx)
 		dungeon[i + xx][j] = dt;
 	}
 
-	int xx = GenerateRnd(dx - 1) + 1;
+	int xx = vanilla::GenerateRnd(dx - 1) + 1;
 
 	if (wt == 12) {
 		dungeon[i + xx][j] = wt;
@@ -1325,7 +1325,7 @@ void VerticalWall(int i, int j, char p, int dy)
 {
 	int8_t dt;
 
-	switch (GenerateRnd(4)) {
+	switch (vanilla::GenerateRnd(4)) {
 	case 0:
 	case 1:
 		dt = 1;
@@ -1347,7 +1347,7 @@ void VerticalWall(int i, int j, char p, int dy)
 	}
 
 	int8_t wt = 25;
-	if (GenerateRnd(6) == 5)
+	if (vanilla::GenerateRnd(6) == 5)
 		wt = 11;
 
 	if (dt == 11)
@@ -1359,7 +1359,7 @@ void VerticalWall(int i, int j, char p, int dy)
 		dungeon[i][j + yy] = dt;
 	}
 
-	int yy = GenerateRnd(dy - 1) + 1;
+	int yy = vanilla::GenerateRnd(dy - 1) + 1;
 
 	if (wt == 11) {
 		dungeon[i][j + yy] = wt;
@@ -1375,42 +1375,42 @@ void AddWall()
 		for (int i = 0; i < DMAXX; i++) {
 			if (L5dflags[i][j] == 0) {
 				if (dungeon[i][j] == 3) {
-					AdvanceRndSeed();
+					vanilla::AdvanceRndSeed();
 					int x = HorizontalWallOk(i, j);
 					if (x != -1) {
 						HorizontalWall(i, j, 2, x);
 					}
 				}
 				if (dungeon[i][j] == 3) {
-					AdvanceRndSeed();
+					vanilla::AdvanceRndSeed();
 					int y = VerticalWallOk(i, j);
 					if (y != -1) {
 						VerticalWall(i, j, 1, y);
 					}
 				}
 				if (dungeon[i][j] == 6) {
-					AdvanceRndSeed();
+					vanilla::AdvanceRndSeed();
 					int x = HorizontalWallOk(i, j);
 					if (x != -1) {
 						HorizontalWall(i, j, 4, x);
 					}
 				}
 				if (dungeon[i][j] == 7) {
-					AdvanceRndSeed();
+					vanilla::AdvanceRndSeed();
 					int y = VerticalWallOk(i, j);
 					if (y != -1) {
 						VerticalWall(i, j, 4, y);
 					}
 				}
 				if (dungeon[i][j] == 2) {
-					AdvanceRndSeed();
+					vanilla::AdvanceRndSeed();
 					int x = HorizontalWallOk(i, j);
 					if (x != -1) {
 						HorizontalWall(i, j, 2, x);
 					}
 				}
 				if (dungeon[i][j] == 1) {
-					AdvanceRndSeed();
+					vanilla::AdvanceRndSeed();
 					int y = VerticalWallOk(i, j);
 					if (y != -1) {
 						VerticalWall(i, j, 1, y);
@@ -1642,10 +1642,10 @@ void Substitution()
 {
 	for (int y = 0; y < DMAXY; y++) {
 		for (int x = 0; x < DMAXX; x++) {
-			if (GenerateRnd(4) == 0) {
+			if (vanilla::GenerateRnd(4) == 0) {
 				uint8_t c = L5BTYPES[dungeon[x][y]];
 				if (c != 0 && L5dflags[x][y] == 0) {
-					int rv = GenerateRnd(16);
+					int rv = vanilla::GenerateRnd(16);
 					int i = -1;
 					while (rv >= 0) {
 						i++;
@@ -1782,17 +1782,17 @@ void FillChambers()
 	if (currlevel == 24) {
 		if (VR1 || VR2 || VR3) {
 			int c = 1;
-			if (!VR1 && VR2 && VR3 && GenerateRnd(2) != 0)
+			if (!VR1 && VR2 && VR3 && vanilla::GenerateRnd(2) != 0)
 				c = 2;
-			if (VR1 && VR2 && !VR3 && GenerateRnd(2) != 0)
+			if (VR1 && VR2 && !VR3 && vanilla::GenerateRnd(2) != 0)
 				c = 0;
 
 			if (VR1 && !VR2 && VR3) {
-				c = (GenerateRnd(2) != 0) ? 0 : 2;
+				c = (vanilla::GenerateRnd(2) != 0) ? 0 : 2;
 			}
 
 			if (VR1 && VR2 && VR3)
-				c = GenerateRnd(3);
+				c = vanilla::GenerateRnd(3);
 
 			switch (c) {
 			case 0:
@@ -1807,17 +1807,17 @@ void FillChambers()
 			}
 		} else {
 			int c = 1;
-			if (!HR1 && HR2 && HR3 && GenerateRnd(2) != 0)
+			if (!HR1 && HR2 && HR3 && vanilla::GenerateRnd(2) != 0)
 				c = 2;
-			if (HR1 && HR2 && !HR3 && GenerateRnd(2) != 0)
+			if (HR1 && HR2 && !HR3 && vanilla::GenerateRnd(2) != 0)
 				c = 0;
 
 			if (HR1 && !HR2 && HR3) {
-				c = (GenerateRnd(2) != 0) ? 0 : 2;
+				c = (vanilla::GenerateRnd(2) != 0) ? 0 : 2;
 			}
 
 			if (HR1 && HR2 && HR3)
-				c = GenerateRnd(3);
+				c = vanilla::GenerateRnd(3);
 
 			switch (c) {
 			case 0:
@@ -1835,20 +1835,20 @@ void FillChambers()
 	if (currlevel == 21) {
 		if (VR1 || VR2 || VR3) {
 			int c = 1;
-			if (!VR1 && VR2 && VR3 && GenerateRnd(2) != 0)
+			if (!VR1 && VR2 && VR3 && vanilla::GenerateRnd(2) != 0)
 				c = 2;
-			if (VR1 && VR2 && !VR3 && GenerateRnd(2) != 0)
+			if (VR1 && VR2 && !VR3 && vanilla::GenerateRnd(2) != 0)
 				c = 0;
 
 			if (VR1 && !VR2 && VR3) {
-				if (GenerateRnd(2) != 0)
+				if (vanilla::GenerateRnd(2) != 0)
 					c = 0;
 				else
 					c = 2;
 			}
 
 			if (VR1 && VR2 && VR3)
-				c = GenerateRnd(3);
+				c = vanilla::GenerateRnd(3);
 
 			switch (c) {
 			case 0:
@@ -1863,20 +1863,20 @@ void FillChambers()
 			}
 		} else {
 			int c = 1;
-			if (!HR1 && HR2 && HR3 && GenerateRnd(2) != 0)
+			if (!HR1 && HR2 && HR3 && vanilla::GenerateRnd(2) != 0)
 				c = 2;
-			if (HR1 && HR2 && !HR3 && GenerateRnd(2) != 0)
+			if (HR1 && HR2 && !HR3 && vanilla::GenerateRnd(2) != 0)
 				c = 0;
 
 			if (HR1 && !HR2 && HR3) {
-				if (GenerateRnd(2) != 0)
+				if (vanilla::GenerateRnd(2) != 0)
 					c = 0;
 				else
 					c = 2;
 			}
 
 			if (HR1 && HR2 && HR3)
-				c = GenerateRnd(3);
+				c = vanilla::GenerateRnd(3);
 
 			switch (c) {
 			case 0:
@@ -1894,20 +1894,20 @@ void FillChambers()
 	if (L5setloadflag) {
 		if (VR1 || VR2 || VR3) {
 			int c = 1;
-			if (!VR1 && VR2 && VR3 && GenerateRnd(2) != 0)
+			if (!VR1 && VR2 && VR3 && vanilla::GenerateRnd(2) != 0)
 				c = 2;
-			if (VR1 && VR2 && !VR3 && GenerateRnd(2) != 0)
+			if (VR1 && VR2 && !VR3 && vanilla::GenerateRnd(2) != 0)
 				c = 0;
 
 			if (VR1 && !VR2 && VR3) {
-				if (GenerateRnd(2) != 0)
+				if (vanilla::GenerateRnd(2) != 0)
 					c = 0;
 				else
 					c = 2;
 			}
 
 			if (VR1 && VR2 && VR3)
-				c = GenerateRnd(3);
+				c = vanilla::GenerateRnd(3);
 
 			switch (c) {
 			case 0:
@@ -1922,20 +1922,20 @@ void FillChambers()
 			}
 		} else {
 			int c = 1;
-			if (!HR1 && HR2 && HR3 && GenerateRnd(2) != 0)
+			if (!HR1 && HR2 && HR3 && vanilla::GenerateRnd(2) != 0)
 				c = 2;
-			if (HR1 && HR2 && !HR3 && GenerateRnd(2) != 0)
+			if (HR1 && HR2 && !HR3 && vanilla::GenerateRnd(2) != 0)
 				c = 0;
 
 			if (HR1 && !HR2 && HR3) {
-				if (GenerateRnd(2) != 0)
+				if (vanilla::GenerateRnd(2) != 0)
 					c = 0;
 				else
 					c = 2;
 			}
 
 			if (HR1 && HR2 && HR3)
-				c = GenerateRnd(3);
+				c = vanilla::GenerateRnd(3);
 
 			switch (c) {
 			case 0:
@@ -2561,7 +2561,7 @@ void LoadPreL1Dungeon(const char *path)
 
 void CreateL5Dungeon(uint32_t rseed, lvl_entry entry)
 {
-	SetRndSeed(rseed);
+	vanilla::SetRndSeed(rseed);
 
 	dminx = 16;
 	dminy = 16;

--- a/Source/drlg_l2.cpp
+++ b/Source/drlg_l2.cpp
@@ -1651,14 +1651,14 @@ bool PlaceMiniSet(const BYTE *miniset, int tmin, int tmax, int cx, int cy, bool 
 
 	int numt = 1;
 	if (tmax - tmin != 0) {
-		numt = GenerateRnd(tmax - tmin) + tmin;
+		numt = vanilla::GenerateRnd(tmax - tmin) + tmin;
 	}
 
 	int sx = 0;
 	int sy = 0;
 	for (int i = 0; i < numt; i++) {
-		sx = GenerateRnd(DMAXX - sw);
-		sy = GenerateRnd(DMAXY - sh);
+		sx = vanilla::GenerateRnd(DMAXX - sw);
+		sy = vanilla::GenerateRnd(DMAXY - sh);
 		bool abort = false;
 		int bailcnt;
 
@@ -1668,13 +1668,13 @@ bool PlaceMiniSet(const BYTE *miniset, int tmin, int tmax, int cx, int cy, bool 
 				abort = false;
 			}
 			if (cx != -1 && sx >= cx - sw && sx <= cx + 12) {
-				sx = GenerateRnd(DMAXX - sw);
-				sy = GenerateRnd(DMAXY - sh);
+				sx = vanilla::GenerateRnd(DMAXX - sw);
+				sy = vanilla::GenerateRnd(DMAXY - sh);
 				abort = false;
 			}
 			if (cy != -1 && sy >= cy - sh && sy <= cy + 12) {
-				sx = GenerateRnd(DMAXX - sw);
-				sy = GenerateRnd(DMAXY - sh);
+				sx = vanilla::GenerateRnd(DMAXX - sw);
+				sy = vanilla::GenerateRnd(DMAXY - sh);
 				abort = false;
 			}
 			int ii = 2;
@@ -1757,7 +1757,7 @@ void PlaceMiniSetRandom(const BYTE *miniset, int rndper)
 					}
 				}
 			}
-			if (found && GenerateRnd(100) < rndper) {
+			if (found && vanilla::GenerateRnd(100) < rndper) {
 				for (int yy = 0; yy < sh; yy++) {
 					for (int xx = 0; xx < sw; xx++) {
 						if (miniset[kk] != 0) {
@@ -1939,15 +1939,15 @@ void CreateRoom(int nX1, int nY1, int nX2, int nY2, int nRDest, int nHDir, bool 
 
 	int nRw = nAw;
 	if (nAw > Room_Max) {
-		nRw = GenerateRnd(Room_Max - Room_Min) + Room_Min;
+		nRw = vanilla::GenerateRnd(Room_Max - Room_Min) + Room_Min;
 	} else if (nAw > Room_Min) {
-		nRw = GenerateRnd(nAw - Room_Min) + Room_Min;
+		nRw = vanilla::GenerateRnd(nAw - Room_Min) + Room_Min;
 	}
 	int nRh = nAh;
 	if (nAh > Room_Max) {
-		nRh = GenerateRnd(Room_Max - Room_Min) + Room_Min;
+		nRh = vanilla::GenerateRnd(Room_Max - Room_Min) + Room_Min;
 	} else if (nAh > Room_Min) {
-		nRh = GenerateRnd(nAh - Room_Min) + Room_Min;
+		nRh = vanilla::GenerateRnd(nAh - Room_Min) + Room_Min;
 	}
 
 	if (forceHW) {
@@ -1955,8 +1955,8 @@ void CreateRoom(int nX1, int nY1, int nX2, int nY2, int nRDest, int nHDir, bool 
 		nRh = nH;
 	}
 
-	int nRx1 = GenerateRnd(nX2 - nX1) + nX1;
-	int nRy1 = GenerateRnd(nY2 - nY1) + nY1;
+	int nRx1 = vanilla::GenerateRnd(nX2 - nX1) + nX1;
+	int nRy1 = vanilla::GenerateRnd(nY2 - nY1) + nY1;
 	int nRx2 = nRw + nRx1;
 	int nRy2 = nRh + nRy1;
 	if (nRx2 > nX2) {
@@ -2009,32 +2009,32 @@ void CreateRoom(int nX1, int nY1, int nX2, int nY2, int nRDest, int nHDir, bool 
 		int nHx2 = 0;
 		int nHy2 = 0;
 		if (nHDir == 1) {
-			nHx1 = GenerateRnd(nRx2 - nRx1 - 2) + nRx1 + 1;
+			nHx1 = vanilla::GenerateRnd(nRx2 - nRx1 - 2) + nRx1 + 1;
 			nHy1 = nRy1;
 			int nHw = RoomList[nRDest].nRoomx2 - RoomList[nRDest].nRoomx1 - 2;
-			nHx2 = GenerateRnd(nHw) + RoomList[nRDest].nRoomx1 + 1;
+			nHx2 = vanilla::GenerateRnd(nHw) + RoomList[nRDest].nRoomx1 + 1;
 			nHy2 = RoomList[nRDest].nRoomy2;
 		}
 		if (nHDir == 3) {
-			nHx1 = GenerateRnd(nRx2 - nRx1 - 2) + nRx1 + 1;
+			nHx1 = vanilla::GenerateRnd(nRx2 - nRx1 - 2) + nRx1 + 1;
 			nHy1 = nRy2;
 			int nHw = RoomList[nRDest].nRoomx2 - RoomList[nRDest].nRoomx1 - 2;
-			nHx2 = GenerateRnd(nHw) + RoomList[nRDest].nRoomx1 + 1;
+			nHx2 = vanilla::GenerateRnd(nHw) + RoomList[nRDest].nRoomx1 + 1;
 			nHy2 = RoomList[nRDest].nRoomy1;
 		}
 		if (nHDir == 2) {
 			nHx1 = nRx2;
-			nHy1 = GenerateRnd(nRy2 - nRy1 - 2) + nRy1 + 1;
+			nHy1 = vanilla::GenerateRnd(nRy2 - nRy1 - 2) + nRy1 + 1;
 			nHx2 = RoomList[nRDest].nRoomx1;
 			int nHh = RoomList[nRDest].nRoomy2 - RoomList[nRDest].nRoomy1 - 2;
-			nHy2 = GenerateRnd(nHh) + RoomList[nRDest].nRoomy1 + 1;
+			nHy2 = vanilla::GenerateRnd(nHh) + RoomList[nRDest].nRoomy1 + 1;
 		}
 		if (nHDir == 4) {
 			nHx1 = nRx1;
-			nHy1 = GenerateRnd(nRy2 - nRy1 - 2) + nRy1 + 1;
+			nHy1 = vanilla::GenerateRnd(nRy2 - nRy1 - 2) + nRy1 + 1;
 			nHx2 = RoomList[nRDest].nRoomx2;
 			int nHh = RoomList[nRDest].nRoomy2 - RoomList[nRDest].nRoomy1 - 2;
-			nHy2 = GenerateRnd(nHh) + RoomList[nRDest].nRoomy1 + 1;
+			nHy2 = vanilla::GenerateRnd(nHh) + RoomList[nRDest].nRoomy1 + 1;
 		}
 		HallList.push_back({ nHx1, nHy1, nHx2, nHy2, nHDir });
 	}
@@ -2063,8 +2063,8 @@ void ConnectHall(const HALLNODE &node)
 	int nHd = node.nHalldir;
 
 	bool fDoneflag = false;
-	int fMinusFlag = GenerateRnd(100);
-	int fPlusFlag = GenerateRnd(100);
+	int fMinusFlag = vanilla::GenerateRnd(100);
+	int fPlusFlag = vanilla::GenerateRnd(100);
 	int nOrigX1 = nX1;
 	int nOrigY1 = nY1;
 	CreateDoorType(nX1, nY1);
@@ -2138,7 +2138,7 @@ void ConnectHall(const HALLNODE &node)
 			if (nRp > 30) {
 				nRp = 30;
 			}
-			if (GenerateRnd(100) < nRp) {
+			if (vanilla::GenerateRnd(100) < nRp) {
 				if (nX2 <= nX1 || nX1 >= DMAXX) {
 					nCurrd = 4;
 				} else {
@@ -2150,7 +2150,7 @@ void ConnectHall(const HALLNODE &node)
 			if (nRp > 80) {
 				nRp = 80;
 			}
-			if (GenerateRnd(100) < nRp) {
+			if (vanilla::GenerateRnd(100) < nRp) {
 				if (nY2 <= nY1 || nY1 >= DMAXY) {
 					nCurrd = 1;
 				} else {
@@ -2302,10 +2302,10 @@ void Substitution()
 {
 	for (int y = 0; y < DMAXY; y++) {
 		for (int x = 0; x < DMAXX; x++) {
-			if ((x < nSx1 || x > nSx2) && (y < nSy1 || y > nSy2) && GenerateRnd(4) == 0) {
+			if ((x < nSx1 || x > nSx2) && (y < nSy1 || y > nSy2) && vanilla::GenerateRnd(4) == 0) {
 				uint8_t c = BTYPESL2[dungeon[x][y]];
 				if (c != 0) {
-					int rv = GenerateRnd(16);
+					int rv = vanilla::GenerateRnd(16);
 					int i = -1;
 					while (rv >= 0) {
 						i++;
@@ -2631,8 +2631,8 @@ bool FillVoids()
 {
 	int to = 0;
 	while (CountEmptyTiles() > 700 && to < 100) {
-		int xx = GenerateRnd(38) + 1;
-		int yy = GenerateRnd(38) + 1;
+		int xx = vanilla::GenerateRnd(38) + 1;
+		int yy = vanilla::GenerateRnd(38) + 1;
 		if (predungeon[xx][yy] != 35) {
 			continue;
 		}
@@ -3236,7 +3236,7 @@ void CreateL2Dungeon(uint32_t rseed, lvl_entry entry)
 		}
 	}
 
-	SetRndSeed(rseed);
+	vanilla::SetRndSeed(rseed);
 
 	dminx = 16;
 	dminy = 16;

--- a/Source/drlg_l3.cpp
+++ b/Source/drlg_l3.cpp
@@ -877,18 +877,18 @@ bool FillRoom(int x1, int y1, int x2, int y2)
 		}
 	}
 	for (int j = y1; j <= y2; j++) {
-		if (GenerateRnd(2) != 0) {
+		if (vanilla::GenerateRnd(2) != 0) {
 			dungeon[x1][j] = 1;
 		}
-		if (GenerateRnd(2) != 0) {
+		if (vanilla::GenerateRnd(2) != 0) {
 			dungeon[x2][j] = 1;
 		}
 	}
 	for (int i = x1; i <= x2; i++) {
-		if (GenerateRnd(2) != 0) {
+		if (vanilla::GenerateRnd(2) != 0) {
 			dungeon[i][y1] = 1;
 		}
-		if (GenerateRnd(2) != 0) {
+		if (vanilla::GenerateRnd(2) != 0) {
 			dungeon[i][y2] = 1;
 		}
 	}
@@ -903,20 +903,20 @@ void CreateBlock(int x, int y, int obs, int dir)
 	int x2;
 	int y2;
 
-	int blksizex = GenerateRnd(2) + 3;
-	int blksizey = GenerateRnd(2) + 3;
+	int blksizex = vanilla::GenerateRnd(2) + 3;
+	int blksizey = vanilla::GenerateRnd(2) + 3;
 
 	if (dir == 0) {
 		y2 = y - 1;
 		y1 = y2 - blksizey;
 		if (blksizex < obs) {
-			x1 = GenerateRnd(blksizex) + x;
+			x1 = vanilla::GenerateRnd(blksizex) + x;
 		}
 		if (blksizex == obs) {
 			x1 = x;
 		}
 		if (blksizex > obs) {
-			x1 = x - GenerateRnd(blksizex);
+			x1 = x - vanilla::GenerateRnd(blksizex);
 		}
 		x2 = blksizex + x1;
 	}
@@ -924,13 +924,13 @@ void CreateBlock(int x, int y, int obs, int dir)
 		x1 = x + 1;
 		x2 = x1 + blksizex;
 		if (blksizey < obs) {
-			y1 = GenerateRnd(blksizey) + y;
+			y1 = vanilla::GenerateRnd(blksizey) + y;
 		}
 		if (blksizey == obs) {
 			y1 = y;
 		}
 		if (blksizey > obs) {
-			y1 = y - GenerateRnd(blksizey);
+			y1 = y - vanilla::GenerateRnd(blksizey);
 		}
 		y2 = y1 + blksizey;
 	}
@@ -938,13 +938,13 @@ void CreateBlock(int x, int y, int obs, int dir)
 		y1 = y + 1;
 		y2 = y1 + blksizey;
 		if (blksizex < obs) {
-			x1 = GenerateRnd(blksizex) + x;
+			x1 = vanilla::GenerateRnd(blksizex) + x;
 		}
 		if (blksizex == obs) {
 			x1 = x;
 		}
 		if (blksizex > obs) {
-			x1 = x - GenerateRnd(blksizex);
+			x1 = x - vanilla::GenerateRnd(blksizex);
 		}
 		x2 = blksizex + x1;
 	}
@@ -952,19 +952,19 @@ void CreateBlock(int x, int y, int obs, int dir)
 		x2 = x - 1;
 		x1 = x2 - blksizex;
 		if (blksizey < obs) {
-			y1 = GenerateRnd(blksizey) + y;
+			y1 = vanilla::GenerateRnd(blksizey) + y;
 		}
 		if (blksizey == obs) {
 			y1 = y;
 		}
 		if (blksizey > obs) {
-			y1 = y - GenerateRnd(blksizey);
+			y1 = y - vanilla::GenerateRnd(blksizey);
 		}
 		y2 = y1 + blksizey;
 	}
 
 	if (FillRoom(x1, y1, x2, y2)) {
-		int contflag = GenerateRnd(4);
+		int contflag = vanilla::GenerateRnd(4);
 		if (contflag != 0 && dir != 2) {
 			CreateBlock(x1, y1, blksizey, 0);
 		}
@@ -995,14 +995,14 @@ void FillDiagonals()
 		for (int i = 0; i < DMAXX - 1; i++) {
 			int v = dungeon[i + 1][j + 1] + 2 * dungeon[i][j + 1] + 4 * dungeon[i + 1][j] + 8 * dungeon[i][j];
 			if (v == 6) {
-				if (GenerateRnd(2) == 0) {
+				if (vanilla::GenerateRnd(2) == 0) {
 					dungeon[i][j] = 1;
 				} else {
 					dungeon[i + 1][j + 1] = 1;
 				}
 			}
 			if (v == 9) {
-				if (GenerateRnd(2) == 0) {
+				if (vanilla::GenerateRnd(2) == 0) {
 					dungeon[i + 1][j] = 1;
 				} else {
 					dungeon[i][j + 1] = 1;
@@ -1040,9 +1040,9 @@ void FillStraights()
 				}
 				xs++;
 			} else {
-				if (xs > 3 && GenerateRnd(2) != 0) {
+				if (xs > 3 && vanilla::GenerateRnd(2) != 0) {
 					for (int k = xc; k < i; k++) {
-						int rv = GenerateRnd(2);
+						int rv = vanilla::GenerateRnd(2);
 						dungeon[k][j] = rv;
 					}
 				}
@@ -1059,9 +1059,9 @@ void FillStraights()
 				}
 				xs++;
 			} else {
-				if (xs > 3 && GenerateRnd(2) != 0) {
+				if (xs > 3 && vanilla::GenerateRnd(2) != 0) {
 					for (int k = xc; k < i; k++) {
-						int rv = GenerateRnd(2);
+						int rv = vanilla::GenerateRnd(2);
 						dungeon[k][j + 1] = rv;
 					}
 				}
@@ -1078,9 +1078,9 @@ void FillStraights()
 				}
 				ys++;
 			} else {
-				if (ys > 3 && GenerateRnd(2) != 0) {
+				if (ys > 3 && vanilla::GenerateRnd(2) != 0) {
 					for (int k = yc; k < j; k++) {
-						int rv = GenerateRnd(2);
+						int rv = vanilla::GenerateRnd(2);
 						dungeon[i][k] = rv;
 					}
 				}
@@ -1097,9 +1097,9 @@ void FillStraights()
 				}
 				ys++;
 			} else {
-				if (ys > 3 && GenerateRnd(2) != 0) {
+				if (ys > 3 && vanilla::GenerateRnd(2) != 0) {
 					for (int k = yc; k < j; k++) {
-						int rv = GenerateRnd(2);
+						int rv = vanilla::GenerateRnd(2);
 						dungeon[i + 1][k] = rv;
 					}
 				}
@@ -1138,7 +1138,7 @@ void MakeMegas()
 		for (int i = 0; i < DMAXX - 1; i++) {
 			int v = dungeon[i + 1][j + 1] + 2 * dungeon[i][j + 1] + 4 * dungeon[i + 1][j] + 8 * dungeon[i][j];
 			if (v == 6) {
-				int rv = GenerateRnd(2);
+				int rv = vanilla::GenerateRnd(2);
 				if (rv == 0) {
 					v = 12;
 				} else {
@@ -1146,7 +1146,7 @@ void MakeMegas()
 				}
 			}
 			if (v == 9) {
-				int rv = GenerateRnd(2);
+				int rv = vanilla::GenerateRnd(2);
 				if (rv == 0) {
 					v = 13;
 				} else {
@@ -1183,8 +1183,8 @@ void River()
 			int i = 0;
 			// BUGFIX: Replace with `(ry >= DMAXY || dungeon[rx][ry] < 25 || dungeon[rx][ry] > 28) && i < 100` (fixed)
 			while ((ry >= DMAXY || dungeon[rx][ry] < 25 || dungeon[rx][ry] > 28) && i < 100) {
-				rx = GenerateRnd(DMAXX);
-				ry = GenerateRnd(DMAXY);
+				rx = vanilla::GenerateRnd(DMAXX);
+				ry = vanilla::GenerateRnd(DMAXY);
 				i++;
 				// BUGFIX: Move `ry < DMAXY` check before dungeon checks (fixed)
 				while (ry < DMAXY && (dungeon[rx][ry] < 25 || dungeon[rx][ry] > 28)) {
@@ -1232,7 +1232,7 @@ void River()
 				int px = rx;
 				int py = ry;
 				if (dircheck == 0) {
-					dir = GenerateRnd(4);
+					dir = vanilla::GenerateRnd(4);
 				} else {
 					dir = (dir + 1) & 3;
 				}
@@ -1256,10 +1256,10 @@ void River()
 				if (dungeon[rx][ry] == 7) {
 					dircheck = 0;
 					if (dir < 2) {
-						river[2][riveramt] = (BYTE)GenerateRnd(2) + 17;
+						river[2][riveramt] = (BYTE)vanilla::GenerateRnd(2) + 17;
 					}
 					if (dir > 1) {
-						river[2][riveramt] = (BYTE)GenerateRnd(2) + 15;
+						river[2][riveramt] = (BYTE)vanilla::GenerateRnd(2) + 15;
 					}
 					river[0][riveramt] = rx;
 					river[1][riveramt] = ry;
@@ -1372,7 +1372,7 @@ void River()
 			int bridge;
 			while (found == 0 && lpcnt < 30) {
 				lpcnt++;
-				bridge = GenerateRnd(riveramt);
+				bridge = vanilla::GenerateRnd(riveramt);
 				if ((river[2][bridge] == 15 || river[2][bridge] == 16)
 				    && dungeon[river[0][bridge]][river[1][bridge] - 1] == 7
 				    && dungeon[river[0][bridge]][river[1][bridge] + 1] == 7) {
@@ -1553,7 +1553,7 @@ void Pool()
 			} else {
 				found = true;
 			}
-			int poolchance = GenerateRnd(100);
+			int poolchance = vanilla::GenerateRnd(100);
 			for (int j = std::max(duny - totarea, 0); j < std::min(duny + totarea, DMAXY); j++) {
 				for (int i = std::max(dunx - totarea, 0); i < std::min(dunx + totarea, DMAXX); i++) {
 					// BUGFIX: In the following swap the order to first do the
@@ -1603,14 +1603,14 @@ bool PlaceMiniSet(const BYTE *miniset, int tmin, int tmax, int cx, int cy, bool 
 
 	int numt = 1;
 	if (tmax - tmin != 0) {
-		numt = GenerateRnd(tmax - tmin) + tmin;
+		numt = vanilla::GenerateRnd(tmax - tmin) + tmin;
 	}
 
 	int sx = 0;
 	int sy = 0;
 	for (int i = 0; i < numt; i++) {
-		sx = GenerateRnd(DMAXX - sw);
-		sy = GenerateRnd(DMAXY - sh);
+		sx = vanilla::GenerateRnd(DMAXX - sw);
+		sy = vanilla::GenerateRnd(DMAXY - sh);
 		bool abort = false;
 		int bailcnt;
 
@@ -1618,13 +1618,13 @@ bool PlaceMiniSet(const BYTE *miniset, int tmin, int tmax, int cx, int cy, bool 
 			bailcnt++;
 			abort = true;
 			if (cx != -1 && sx >= cx - sw && sx <= cx + 12) {
-				sx = GenerateRnd(DMAXX - sw);
-				sy = GenerateRnd(DMAXY - sh);
+				sx = vanilla::GenerateRnd(DMAXX - sw);
+				sy = vanilla::GenerateRnd(DMAXY - sh);
 				abort = false;
 			}
 			if (cy != -1 && sy >= cy - sh && sy <= cy + 12) {
-				sx = GenerateRnd(DMAXX - sw);
-				sy = GenerateRnd(DMAXY - sh);
+				sx = vanilla::GenerateRnd(DMAXX - sw);
+				sy = vanilla::GenerateRnd(DMAXY - sh);
 				abort = false;
 			}
 			int ii = 2;
@@ -1712,7 +1712,7 @@ void PlaceMiniSetRandom(const BYTE *miniset, int rndper)
 					}
 				}
 			}
-			if (found && GenerateRnd(100) < rndper) {
+			if (found && vanilla::GenerateRnd(100) < rndper) {
 				for (int yy = 0; yy < sh; yy++) {
 					for (int xx = 0; xx < sw; xx++) {
 						if (miniset[kk] != 0) {
@@ -1766,7 +1766,7 @@ bool HivePlaceSetRandom(const BYTE *miniset, int rndper)
 					}
 				}
 			}
-			if (found && GenerateRnd(100) < rndper) {
+			if (found && vanilla::GenerateRnd(100) < rndper) {
 				placed = true;
 				for (int yy = 0; yy < sh; yy++) {
 					for (int xx = 0; xx < sw; xx++) {
@@ -1891,7 +1891,7 @@ void Fence()
 {
 	for (int j = 1; j < DMAXY - 1; j++) {     // BUGFIX: Change '0' to '1' (fixed)
 		for (int i = 1; i < DMAXX - 1; i++) { // BUGFIX: Change '0' to '1' (fixed)
-			if (dungeon[i][j] == 10 && GenerateRnd(2) != 0) {
+			if (dungeon[i][j] == 10 && vanilla::GenerateRnd(2) != 0) {
 				int x = i;
 				while (dungeon[x][j] == 10) {
 					x++;
@@ -1900,7 +1900,7 @@ void Fence()
 				if (x - i > 0) {
 					dungeon[i][j] = 127;
 					for (int xx = i + 1; xx < x; xx++) {
-						if (GenerateRnd(2) != 0) {
+						if (vanilla::GenerateRnd(2) != 0) {
 							dungeon[xx][j] = 126;
 						} else {
 							dungeon[xx][j] = 129;
@@ -1909,7 +1909,7 @@ void Fence()
 					dungeon[x][j] = 128;
 				}
 			}
-			if (dungeon[i][j] == 9 && GenerateRnd(2) != 0) {
+			if (dungeon[i][j] == 9 && vanilla::GenerateRnd(2) != 0) {
 				int y = j;
 				while (dungeon[i][y] == 9) {
 					y++;
@@ -1918,7 +1918,7 @@ void Fence()
 				if (y - j > 0) {
 					dungeon[i][j] = 123;
 					for (int yy = j + 1; yy < y; yy++) {
-						if (GenerateRnd(2) != 0) {
+						if (vanilla::GenerateRnd(2) != 0) {
 							dungeon[i][yy] = 121;
 						} else {
 							dungeon[i][yy] = 124;
@@ -1927,7 +1927,7 @@ void Fence()
 					dungeon[i][y] = 122;
 				}
 			}
-			if (dungeon[i][j] == 11 && dungeon[i + 1][j] == 10 && dungeon[i][j + 1] == 9 && GenerateRnd(2) != 0) {
+			if (dungeon[i][j] == 11 && dungeon[i + 1][j] == 10 && dungeon[i][j + 1] == 9 && vanilla::GenerateRnd(2) != 0) {
 				dungeon[i][j] = 125;
 				int x = i + 1;
 				while (dungeon[x][j] == 10) {
@@ -1935,7 +1935,7 @@ void Fence()
 				}
 				x--;
 				for (int xx = i + 1; xx < x; xx++) {
-					if (GenerateRnd(2) != 0) {
+					if (vanilla::GenerateRnd(2) != 0) {
 						dungeon[xx][j] = 126;
 					} else {
 						dungeon[xx][j] = 129;
@@ -1948,7 +1948,7 @@ void Fence()
 				}
 				y--;
 				for (int yy = j + 1; yy < y; yy++) {
-					if (GenerateRnd(2) != 0) {
+					if (vanilla::GenerateRnd(2) != 0) {
 						dungeon[i][yy] = 121;
 					} else {
 						dungeon[i][yy] = 124;
@@ -1961,8 +1961,8 @@ void Fence()
 
 	for (int j = 1; j < DMAXY; j++) {     // BUGFIX: Change '0' to '1' (fixed)
 		for (int i = 1; i < DMAXX; i++) { // BUGFIX: Change '0' to '1' (fixed)
-			if (dungeon[i][j] == 7 && GenerateRnd(1) == 0 && SkipThemeRoom(i, j)) {
-				int rt = GenerateRnd(2);
+			if (dungeon[i][j] == 7 && vanilla::GenerateRnd(1) == 0 && SkipThemeRoom(i, j)) {
+				int rt = vanilla::GenerateRnd(2);
 				if (rt == 0) {
 					int y1 = j;
 					// BUGFIX: Check `y1 >= 0` first (fixed)
@@ -1984,13 +1984,13 @@ void Fence()
 						skip = false;
 					}
 					if (y2 - y1 > 1 && skip) {
-						int rp = GenerateRnd(y2 - y1 - 1) + y1 + 1;
+						int rp = vanilla::GenerateRnd(y2 - y1 - 1) + y1 + 1;
 						for (int y = y1; y <= y2; y++) {
 							if (y == rp) {
 								continue;
 							}
 							if (dungeon[i][y] == 7) {
-								if (GenerateRnd(2) != 0) {
+								if (vanilla::GenerateRnd(2) != 0) {
 									dungeon[i][y] = 135;
 								} else {
 									dungeon[i][y] = 137;
@@ -2038,13 +2038,13 @@ void Fence()
 						skip = false;
 					}
 					if (x2 - x1 > 1 && skip) {
-						int rp = GenerateRnd(x2 - x1 - 1) + x1 + 1;
+						int rp = vanilla::GenerateRnd(x2 - x1 - 1) + x1 + 1;
 						for (int x = x1; x <= x2; x++) {
 							if (x == rp) {
 								continue;
 							}
 							if (dungeon[x][j] == 7) {
-								if (GenerateRnd(2) != 0) {
+								if (vanilla::GenerateRnd(2) != 0) {
 									dungeon[x][j] = 134;
 								} else {
 									dungeon[x][j] = 136;
@@ -2083,8 +2083,8 @@ bool Anvil()
 {
 	int sw = L3ANVIL[0];
 	int sh = L3ANVIL[1];
-	int sx = GenerateRnd(DMAXX - sw);
-	int sy = GenerateRnd(DMAXY - sh);
+	int sx = vanilla::GenerateRnd(DMAXX - sw);
+	int sy = vanilla::GenerateRnd(DMAXY - sh);
 
 	bool found = false;
 	int trys = 0;
@@ -2230,8 +2230,8 @@ void GenerateLevel(lvl_entry entry)
 		do {
 			do {
 				InitDungeonFlags();
-				int x1 = GenerateRnd(20) + 10;
-				int y1 = GenerateRnd(20) + 10;
+				int x1 = vanilla::GenerateRnd(20) + 10;
+				int y1 = vanilla::GenerateRnd(20) + 10;
 				int x2 = x1 + 2;
 				int y2 = y1 + 2;
 				FillRoom(x1, y1, x2, y2);
@@ -2240,8 +2240,8 @@ void GenerateLevel(lvl_entry entry)
 				CreateBlock(x1, y2, 2, 2);
 				CreateBlock(x1, y1, 2, 3);
 				if (QuestStatus(Q_ANVIL)) {
-					x1 = GenerateRnd(10) + 10;
-					y1 = GenerateRnd(10) + 10;
+					x1 = vanilla::GenerateRnd(10) + 10;
+					y1 = vanilla::GenerateRnd(10) + 10;
 					x2 = x1 + 12;
 					y2 = y1 + 12;
 					FloorArea(x1, y1, x2, y2);
@@ -2482,7 +2482,7 @@ void Pass3()
 
 void CreateL3Dungeon(uint32_t rseed, lvl_entry entry)
 {
-	SetRndSeed(rseed);
+	vanilla::SetRndSeed(rseed);
 
 	dminx = 16;
 	dminy = 16;

--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -178,12 +178,12 @@ bool PlaceMiniSet(const BYTE *miniset, int tmin, int tmax, int cx, int cy, bool 
 
 	int numt = 1;
 	if (tmax - tmin != 0) {
-		numt = GenerateRnd(tmax - tmin) + tmin;
+		numt = vanilla::GenerateRnd(tmax - tmin) + tmin;
 	}
 
 	for (int i = 0; i < numt; i++) {
-		sx = GenerateRnd(DMAXX - sw);
-		sy = GenerateRnd(DMAXY - sh);
+		sx = vanilla::GenerateRnd(DMAXX - sw);
+		sy = vanilla::GenerateRnd(DMAXY - sh);
 		bool abort = false;
 		int bailcnt;
 		for (bailcnt = 0; !abort && bailcnt < 200; bailcnt++) {
@@ -192,13 +192,13 @@ bool PlaceMiniSet(const BYTE *miniset, int tmin, int tmax, int cx, int cy, bool 
 				abort = false;
 			}
 			if (cx != -1 && sx >= cx - sw && sx <= cx + 12) {
-				sx = GenerateRnd(DMAXX - sw);
-				sy = GenerateRnd(DMAXY - sh);
+				sx = vanilla::GenerateRnd(DMAXX - sw);
+				sy = vanilla::GenerateRnd(DMAXY - sh);
 				abort = false;
 			}
 			if (cy != -1 && sy >= cy - sh && sy <= cy + 12) {
-				sx = GenerateRnd(DMAXX - sw);
-				sy = GenerateRnd(DMAXY - sh);
+				sx = vanilla::GenerateRnd(DMAXX - sw);
+				sy = vanilla::GenerateRnd(DMAXY - sh);
 				abort = false;
 			}
 			int ii = 2;
@@ -333,7 +333,7 @@ bool CheckRoom(int x, int y, int width, int height)
 
 void GenerateRoom(int x, int y, int w, int h, int dir)
 {
-	int dirProb = GenerateRnd(4);
+	int dirProb = vanilla::GenerateRnd(4);
 	int num = 0;
 
 	bool ran;
@@ -343,8 +343,8 @@ void GenerateRoom(int x, int y, int w, int h, int dir)
 		int cx1;
 		int cy1;
 		do {
-			cw = (GenerateRnd(5) + 2) & ~1;
-			ch = (GenerateRnd(5) + 2) & ~1;
+			cw = (vanilla::GenerateRnd(5) + 2) & ~1;
+			ch = (vanilla::GenerateRnd(5) + 2) & ~1;
 			cx1 = x - cw;
 			cy1 = h / 2 + y - ch / 2;
 			ran = CheckRoom(cx1 - 1, cy1 - 1, ch + 2, cw + 1); /// BUGFIX: swap args 3 and 4 ("ch+2" and "cw+1")
@@ -369,8 +369,8 @@ void GenerateRoom(int x, int y, int w, int h, int dir)
 	int rx;
 	int ry;
 	do {
-		width = (GenerateRnd(5) + 2) & ~1;
-		height = (GenerateRnd(5) + 2) & ~1;
+		width = (vanilla::GenerateRnd(5) + 2) & ~1;
+		height = (vanilla::GenerateRnd(5) + 2) & ~1;
 		rx = w / 2 + x - width / 2;
 		ry = y - height;
 		ran = CheckRoom(rx - 1, ry - 1, width + 2, height + 1);
@@ -402,18 +402,18 @@ void FirstRoom()
 			w = 11;
 			h = 11;
 		} else {
-			w = GenerateRnd(5) + 2;
-			h = GenerateRnd(5) + 2;
+			w = vanilla::GenerateRnd(5) + 2;
+			h = vanilla::GenerateRnd(5) + 2;
 		}
 	}
 
 	int xmin = (20 - w) / 2;
 	int xmax = 19 - w;
-	int x = GenerateRnd(xmax - xmin + 1) + xmin;
+	int x = vanilla::GenerateRnd(xmax - xmin + 1) + xmin;
 
 	int ymin = (20 - h) / 2;
 	int ymax = 19 - h;
-	int y = GenerateRnd(ymax - ymin + 1) + ymin;
+	int y = vanilla::GenerateRnd(ymax - ymin + 1) + ymin;
 
 	if (currlevel == 16) {
 		l4holdx = x;
@@ -432,7 +432,7 @@ void FirstRoom()
 	}
 
 	MapRoom(x, y, w, h);
-	GenerateRoom(x, y, w, h, GenerateRnd(2));
+	GenerateRoom(x, y, w, h, vanilla::GenerateRnd(2));
 }
 
 void SetSetPiecesRoom(int rx1, int ry1)
@@ -575,7 +575,7 @@ void HorizontalWall(int i, int j, int dx)
 		dungeon[i + dx][j] = 29;
 	}
 
-	int xx = GenerateRnd(dx - 3) + 1;
+	int xx = vanilla::GenerateRnd(dx - 3) + 1;
 	dungeon[i + xx][j] = 57;
 	dungeon[i + xx + 2][j] = 56;
 	dungeon[i + xx + 1][j] = 60;
@@ -620,7 +620,7 @@ void VerticalWall(int i, int j, int dy)
 		dungeon[i][j + dy] = 29;
 	}
 
-	int yy = GenerateRnd(dy - 3) + 1;
+	int yy = vanilla::GenerateRnd(dy - 3) + 1;
 	dungeon[i][j + yy] = 53;
 	dungeon[i][j + yy + 2] = 52;
 	dungeon[i][j + yy + 1] = 6;
@@ -642,7 +642,7 @@ void AddWall()
 			}
 			for (auto d : { 10, 12, 13, 15, 16, 21, 22 }) {
 				if (d == dungeon[i][j]) {
-					AdvanceRndSeed();
+					vanilla::AdvanceRndSeed();
 					int x = HorizontalWallOk(i, j);
 					if (x != -1) {
 						HorizontalWall(i, j, x);
@@ -651,7 +651,7 @@ void AddWall()
 			}
 			for (auto d : { 8, 9, 11, 14, 15, 16, 21, 23 }) {
 				if (d == dungeon[i][j]) {
-					AdvanceRndSeed();
+					vanilla::AdvanceRndSeed();
 					int y = VerticalWallOk(i, j);
 					if (y != -1) {
 						VerticalWall(i, j, y);
@@ -1015,10 +1015,10 @@ void Substitution()
 {
 	for (int y = 0; y < DMAXY; y++) {
 		for (int x = 0; x < DMAXX; x++) {
-			if (GenerateRnd(3) == 0) {
+			if (vanilla::GenerateRnd(3) == 0) {
 				uint8_t c = L4BTYPES[dungeon[x][y]];
 				if (c != 0 && dflags[x][y] == 0) {
-					int rv = GenerateRnd(16);
+					int rv = vanilla::GenerateRnd(16);
 					int i = -1;
 					while (rv >= 0) {
 						i++;
@@ -1037,11 +1037,11 @@ void Substitution()
 	}
 	for (int y = 0; y < DMAXY; y++) {
 		for (int x = 0; x < DMAXX; x++) {
-			int rv = GenerateRnd(10);
+			int rv = vanilla::GenerateRnd(10);
 			if (rv == 0) {
 				uint8_t c = dungeon[x][y];
 				if (L4BTYPES[c] == 6 && dflags[x][y] == 0) {
-					dungeon[x][y] = GenerateRnd(3) + 95;
+					dungeon[x][y] = vanilla::GenerateRnd(3) + 95;
 				}
 			}
 		}
@@ -1068,7 +1068,7 @@ void UShape()
 		}
 	}
 
-	int rv = GenerateRnd(19) + 1;
+	int rv = vanilla::GenerateRnd(19) + 1;
 	do {
 		if (hallok[rv]) {
 			for (int i = 19; i >= 0; i--) {
@@ -1106,7 +1106,7 @@ void UShape()
 		}
 	}
 
-	rv = GenerateRnd(19) + 1;
+	rv = vanilla::GenerateRnd(19) + 1;
 	do {
 		if (hallok[rv]) {
 			for (int j = 19; j >= 0; j--) {
@@ -1532,7 +1532,7 @@ void Pass3()
 
 void CreateL4Dungeon(uint32_t rseed, lvl_entry entry)
 {
-	SetRndSeed(rseed);
+	vanilla::SetRndSeed(rseed);
 
 	dminx = 16;
 	dminy = 16;

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -1155,7 +1155,7 @@ _sfx_id RndSFX(_sfx_id psfx)
 		return psfx;
 	}
 
-	return static_cast<_sfx_id>(psfx + GenerateRnd(nRand));
+	return static_cast<_sfx_id>(psfx + vanilla::GenerateRnd(nRand));
 }
 
 void PrivSoundInit(BYTE bLoadMask)

--- a/Source/engine/random.cpp
+++ b/Source/engine/random.cpp
@@ -4,6 +4,56 @@
 
 namespace devilution {
 
+namespace randomV1 {
+/**
+ * @brief Randomly initialise the engine used for non-instanced RNG calls
+*/
+std::random_device rd;
+
+/**
+ * @brief The random number generator used for non-instanced calls.
+ *
+ * Callers who wish to use repeatable sequences are expected to create their own RandomEngine object, to motivate that
+ * the seed of this engine instance is deliberately not exposed and can not be set manually.
+*/
+RandomEngine engine(rd());
+
+uint32_t GetRandomEngineSeed()
+{
+	return engine();
+}
+
+int RandomLessThan(int limit)
+{
+	return engine.RandomLessThan(limit);
+}
+
+int RandomInRange(int min, int max)
+{
+	return engine.RandomInRange(min, max);
+}
+
+bool RandomBoolean(double chance)
+{
+	return engine.RandomBoolean(chance);
+}
+
+int RandomEngine::RandomInRange(int min, int max)
+{
+	std::uniform_int_distribution<int> dist(min, max);
+
+	return dist(engine);
+}
+
+bool RandomEngine::RandomBoolean(double chance)
+{
+	std::bernoulli_distribution dist(chance);
+
+	return dist(engine);
+}
+} // namespace randomV1
+
+inline namespace vanilla {
 /** Current game seed */
 uint32_t sglGameSeed;
 
@@ -38,6 +88,12 @@ int32_t AdvanceRndSeed()
 	return GetRndSeed();
 }
 
+void Discard(uint32_t rounds)
+{
+	for (uint32_t i = 0; i < rounds; i++)
+		AdvanceRndSeed();
+}
+
 int32_t GenerateRnd(int32_t v)
 {
 	if (v <= 0)
@@ -46,5 +102,7 @@ int32_t GenerateRnd(int32_t v)
 		return (AdvanceRndSeed() >> 16) % v;
 	return AdvanceRndSeed() % v;
 }
+
+} // namespace vanilla
 
 } // namespace devilution

--- a/Source/engine/random.cpp
+++ b/Source/engine/random.cpp
@@ -4,7 +4,7 @@
 
 namespace devilution {
 
-namespace randomV1 {
+inline namespace randomV1 {
 /**
  * @brief Randomly initialise the engine used for non-instanced RNG calls
 */
@@ -53,7 +53,7 @@ bool RandomEngine::RandomBoolean(double chance)
 }
 } // namespace randomV1
 
-inline namespace vanilla {
+namespace vanilla {
 /** Current game seed */
 uint32_t sglGameSeed;
 

--- a/Source/engine/random.hpp
+++ b/Source/engine/random.hpp
@@ -8,11 +8,160 @@
 #pragma once
 
 #include <cstdint>
+#include <initializer_list>
+#include <random>
 
 namespace devilution {
 
+namespace randomV1 {
+/**
+ * @brief Generates a random unsigned integer value
+ *
+ * This is intended to be used to set the initial seed for a new RandomEngine.
+ *
+ * @return A random number in the range [0, 2^32)
+ */
+uint32_t GetRandomEngineSeed();
+
+/**
+ * @brief Generates a random number in the range [0, limit)
+ * @param limit The upper bound of the desired range
+ * @return A random number v where v >= 0 and v < limit
+ */
+int RandomLessThan(int limit);
+
+/**
+ * @brief Generates a random number in the range [min, max]
+ * @param min Lower bound of the range
+ * @param max Upper bound of the range
+ * @return A random number v where v >= min and v <= max
+ */
+int RandomInRange(int min, int max);
+
+/**
+ * @brief Generates a true/false value where a true result has the given odds
+ *
+ * For example, RandomBoolean(0.75) will generate true about 75% of the time.
+ *
+ * @param chance How likely a true result should be (in the range [0, 1]). Defaults to 50%
+ * @return true/false at random
+ */
+bool RandomBoolean(double chance = 0.5);
+
+/**
+ * @brief Returns one of a list of choices at random, where each option has equal chance of being selected.
+ * @tparam T A common type that all items share
+ * @param choices The list to choose from
+ * @return One of the list chosen at random
+ */
+template <typename T>
+T RandomChoice(std::initializer_list<T> choices)
+{
+	return *(choices.begin() + RandomLessThan(choices.size()));
+}
+
+/**
+ * @brief Combines a RandomNumberEngine and helper functions using appropriate RandomNumberDistributions
+ *
+ * This allows generating a repeatable sequence of values from a known seed.
+ */
+class RandomEngine {
+public:
+	/**
+	 * @brief Constructs a random number generator with the given initial state.
+	 *
+	 * The created object will then give repeatable results when the various functions are called. For example if
+	 * created with a starting seed of 5, calling three Random* functions then calling RandomLessThan(23) might
+	 * return 16. If you then create another object with seed 5 and call RandomLessThan(23) four times, the fourth
+	 * call will return the same value (16).
+	 *
+	 * @param seed The starting state of the engine
+	 */
+	RandomEngine(uint32_t seed)
+	    : initialState(seed)
+	    , engine(seed)
+	{
+	}
+
+	/**
+	 * @brief stores a copy of the initial state of the engine, so the sequence can be repeated if desired.
+	 */
+	const uint32_t initialState;
+
+	/**
+	 * @brief Advances the engine and returns a random value
+	 * @return A random number in the range [0, 2^32)
+	 */
+	uint32_t operator()()
+	{
+		return engine();
+	}
+
+	/**
+	 * @brief Advances the engine state by the generating and discarding the given number of values
+	 *
+	 * Provided as a convenience for bringing engines in sync when unnecessary calls have been removed but the total
+	 * number of calls needs to stay the same for future use of the RNG.
+	 *
+	 * @param rounds How many values to discard.
+	 */
+	void Discard(uint32_t rounds = 1)
+	{
+		engine.discard(rounds);
+	}
+
+	/**
+	 * @brief Generates a random number in the range [0, limit)
+	 * @param limit The upper bound of the desired range
+	 * @return A random number less than the limit
+	 */
+	int RandomLessThan(int limit)
+	{
+		return RandomInRange(0, limit - 1);
+	}
+
+	/**
+	 * @brief Generates a random number in the range [min, max]
+	 * @param min Lower bound of the range
+	 * @param max Upper bound of the range
+	 * @return A random number v where v >= min and v <= max
+	 */
+	int RandomInRange(int min, int max);
+
+	/**
+	 * @brief Generates a true/false value where a true result has the given odds
+	 *
+	 * For example, RandomBoolean(0.75) will generate true about 75% of the time.
+	 *
+	 * @param chance How likely a true result should be (in the range [0, 1]). Defaults to 50%
+	 * @return true/false at random
+	 */
+	bool RandomBoolean(double chance = 0.5);
+
+	/**
+	 * @brief Returns one of a list of choices at random, where each option has equal chance of being selected.
+	 * @tparam T A common type that all items share
+	 * @param choices The list to choose from
+	 * @return One of the list chosen at random
+	 */
+	template <typename T>
+	T RandomChoice(std::initializer_list<T> choices)
+	{
+		return *(choices.begin() + RandomLessThan(choices.size()));
+	}
+
+private:
+	std::mt19937 engine;
+};
+} // namespace randomV1
+
+inline namespace vanilla {
 /**
  * @brief Set the state of the RandomNumberEngine used by the base game to the specific seed
+ * 
+ * @deprecated This sets the state of the global RNG used by vanilla code. It is provided purely to maintain
+ * compatibility with Diablo/Hellfire.
+ *
  * @param seed New engine state
  */
 void SetRndSeed(uint32_t seed);
@@ -20,41 +169,184 @@ void SetRndSeed(uint32_t seed);
 /**
  * @brief Returns the current state of the RandomNumberEngine used by the base game
  *
- * This is only exposed to allow for debugging vanilla code and testing. Using this engine for new code is discouraged
- * due to the poor randomness and bugs in the implementation that need to be retained for compatibility.
+ * @deprecated This is only exposed to allow for debugging vanilla code and testing. Using this engine for new code is
+ * discouraged due to the poor randomness and bugs in the implementation that need to be retained for compatibility.
  *
  * @return The current engine state
  */
 uint32_t GetLCGEngineState();
 
 /**
- * @brief Generates a random non-negative integer (most of the time) using the vanilla RNG
- *
- * This advances the engine state then interprets the new engine state as a signed value and calls std::abs to try
- * discard the high bit of the result. This usually returns a positive number but may very rarely return -2^31.
+ * @brief Generates a random non-negative integer (most of the time) using the vanilla RNG.
  *
  * This function is only used when the base game wants to store the seed used to generate an item or level, however
  * as the returned value is transformed about 50% of values do not reflect the actual engine state. It would be more
  * appropriate to use GetLCGEngineState() in these cases but that may break compatibility with the base game.
+ *
+ * @deprecated This function relies on implementation defined behaviour and can occasionally return a negative value
  *
  * @return A random number in the range [0,2^31) or -2^31
  */
 int32_t AdvanceRndSeed();
 
 /**
+ * @brief Advances the global engine state by the generating and discarding the given number of values
+ *
+ * Provided as a convenience for vanilla code that uses the global RNG which need to advance the state manually.
+ *
+ * @param rounds How many values to discard.
+ */
+void Discard(uint32_t rounds = 1);
+
+/**
  * @brief Generates a random integer less than the given limit using the vanilla RNG
  *
  * If v is not a positive number this function returns 0 without calling the RNG.
  *
- * Limits between 32768 and 65534 should be avoided as a bug in vanilla means this function always returns a value
- * less than 32768 for limits in that range.
- *
- * This can very rarely return a negative value in the range (-v, -1] due to the bug in AdvanceRndSeed()
+ * @deprecated Limits between 32768 and 65534 should be avoided as a bug in vanilla means this function always returns
+ * a value less than 32768 for limits in that range. This function can very rarely return a negative value in the range
+ * (-v, -1] due to the bug in AdvanceRndSeed()
  *
  * @see AdvanceRndSeed()
  * @param v The upper limit for the return value
  * @return A random number in the range [0, v) or rarely a negative value in (-v, -1]
  */
 int32_t GenerateRnd(int32_t v);
+
+/**
+ * @brief Combines a RandomNumberEngine and helper functions using appropriate RandomNumberDistributions
+ *
+ * This allows generating a repeatable sequence of values from a known seed.
+ *
+ * @deprecated This class maintains the bugs present in the base Diablo/Hellfire RNG code so that cross compatibility
+ * is preserved. Use a RandomEngine from a later version if you are writing new code.
+ *
+ * @see randomV1::RandomEngine
+ */
+class RandomEngine {
+public:
+	/**
+	 * @brief Constructs a random number generator with the given initial state.
+	 *
+	 * The created object will then give repeatable results when the various functions are called. For example if
+	 * created with a starting seed of 5, calling three Random* functions then calling RandomLessThan(23) might
+	 * return 16. If you then create another object with seed 5 and call RandomLessThan(23) four times, the fourth
+	 * call will return the same value (16).
+	 *
+	 * @param seed The starting state of the engine
+	 */
+	RandomEngine(uint32_t seed)
+	    : initialState(seed)
+	    , engine(seed)
+	{
+	}
+
+	/**
+	 * @brief stores a copy of the initial state of the engine, so the sequence can be repeated if desired.
+	 */
+	const uint32_t initialState;
+
+	/**
+	 * @brief Advances the engine and returns a random value
+	 * @return A random number in the range [0, 2^32)
+	*/
+	uint32_t operator()()
+	{
+		return engine();
+	}
+
+	/**
+	 * @brief Advances the engine state by the generating and discarding the given number of values
+	 *
+	 * Provided as a convenience for bringing engines in sync when unnecessary calls have been removed but the total
+	 * number of calls needs to stay the same for future use of the engine.
+	 *
+	 * @param rounds How many values to discard.
+	*/
+	void Discard(uint32_t rounds = 1)
+	{
+		engine.discard(rounds);
+	}
+
+	/**
+	 * @brief Generates a random positive number or rarely -2^31.
+	 *
+	 * This advances the engine state then interprets the new engine state as a signed value and calls std::abs to try
+	 * discard the high bit of the result. This usually returns a positive number but may very rarely return -2^31.
+	 *
+	 * This function is only used when the base game wants to store the seed used to generate an item or level, however
+	 * as the returned value is transformed about 50% of values do not reflect the actual engine state.
+	 *
+	 * @deprecated This method was only used to seed another RandomEngine. Use randomV1::GetRandomEngineSeed() instead.
+	 * @return a value in the range [0, 2^31) or -2^31
+	*/
+	int RandomInt()
+	{
+		return abs(static_cast<int32_t>((*this)()));
+	}
+
+	/**
+	 * @brief Generates a random number in the range [0, limit) or rarely a negative value in (-v, -1]
+	 *
+	 * If v is not a positive number this function returns 0 without calling the RNG.
+	 *
+	 * @deprecated Limits between 32768 and 65534 should be avoided as this function always returns a value less than
+	 * 32768 for limits in that range. This function can very rarely return a negative value in the range (-v, -1] due
+	 * to the bug in RandomInt()
+	 *
+	 * @see vanilla::RandomEngine::RandomInt()
+	 * @param limit The upper bound of the desired range
+	 * @return A random number in the range [0, limit) or rarely a negative value in (-limit, -1]
+	 */
+	int RandomLessThan(int limit)
+	{
+		if (limit <= 0)
+			return 0;
+
+		int value = RandomInt();
+
+		if (limit < 0xFFFF)
+			value >>= 16;
+
+		return value % limit;
+	}
+
+	/**
+	 * @brief Generates a random number usually in the range [min, max].
+	 *
+	 * This can occasionally return a result below the minimum bound due to the bug in RandomLessThan()
+	 *
+	 * @see vanilla::RandomEngine:RandomLessThan()
+	 * @param min Lower bound of the range
+	 * @param max Upper bound of the range
+	 * @return A random number which is often in the range [min, max], occasionally a value in [min-max, min)
+	 */
+	int RandomInRange(int min, int max)
+	{
+		return RandomLessThan((max - min) + 1) + min;
+	}
+
+	/**
+	 * @brief Generates a true/false value where a true result has one chance of occuring and false has n - 1 chances.
+	 *
+	 * For example, RandomBoolean(4) will generate true about 1 in 4 times (25%). This has slight bias due to the bug
+	 * in RandomInt() and bias in RandomLessThan()
+	 *
+	 * @see vanilla::RandomEngine::RandomLessThan()
+	 * @param outcomes The total number of outcomes. Defaults to 1 in 2, ~50%
+	 * @return true/false at random
+	 */
+	bool RandomBoolean(int outcomes = 2)
+	{
+		return RandomLessThan(outcomes) == 0;
+	}
+
+private:
+	/**
+	 * @brief A LCG using Borland C++ constants.
+	*/
+	std::linear_congruential_engine<uint32_t, 0x015A4E35, 1, 0> engine;
+};
+} // namespace vanilla
 
 } // namespace devilution

--- a/Source/engine/random.hpp
+++ b/Source/engine/random.hpp
@@ -13,7 +13,7 @@
 
 namespace devilution {
 
-namespace randomV1 {
+inline namespace randomV1 {
 /**
  * @brief Generates a random unsigned integer value
  *
@@ -155,7 +155,7 @@ private:
 };
 } // namespace randomV1
 
-inline namespace vanilla {
+namespace vanilla {
 /**
  * @brief Set the state of the RandomNumberEngine used by the base game to the specific seed
  * 

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -229,7 +229,7 @@ void CreateThemeRoom(int themeIndex)
 	}
 
 	if (leveltype == DTYPE_CATACOMBS) {
-		switch (GenerateRnd(2)) {
+		switch (vanilla::GenerateRnd(2)) {
 		case 0:
 			dungeon[hx - 1][(ly + hy) / 2] = 4;
 			break;
@@ -239,7 +239,7 @@ void CreateThemeRoom(int themeIndex)
 		}
 	}
 	if (leveltype == DTYPE_CAVES) {
-		switch (GenerateRnd(2)) {
+		switch (vanilla::GenerateRnd(2)) {
 		case 0:
 			dungeon[hx - 1][(ly + hy) / 2] = 147;
 			break;
@@ -249,7 +249,7 @@ void CreateThemeRoom(int themeIndex)
 		}
 	}
 	if (leveltype == DTYPE_HELL) {
-		switch (GenerateRnd(2)) {
+		switch (vanilla::GenerateRnd(2)) {
 		case 0: {
 			int yy = (ly + hy) / 2;
 			dungeon[hx - 1][yy - 1] = 53;
@@ -423,14 +423,14 @@ void DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int freq, bool rn
 		for (int i = 0; i < DMAXX; i++) {
 			int themeW = 0;
 			int themeH = 0;
-			if (dungeon[i][j] == floor && GenerateRnd(freq) == 0 && WillThemeRoomFit(floor, i, j, minSize, maxSize, &themeW, &themeH)) {
+			if (dungeon[i][j] == floor && vanilla::GenerateRnd(freq) == 0 && WillThemeRoomFit(floor, i, j, minSize, maxSize, &themeW, &themeH)) {
 				if (rndSize) {
 					int min = minSize - 2;
 					int max = maxSize - 2;
-					themeW = min + GenerateRnd(GenerateRnd(themeW - min + 1));
+					themeW = min + vanilla::GenerateRnd(vanilla::GenerateRnd(themeW - min + 1));
 					if (themeW < min || themeW > max)
 						themeW = min;
-					themeH = min + GenerateRnd(GenerateRnd(themeH - min + 1));
+					themeH = min + vanilla::GenerateRnd(vanilla::GenerateRnd(themeH - min + 1));
 					if (themeH < min || themeH > max)
 						themeH = min;
 				}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -396,7 +396,7 @@ Point GetRandomAvailableItemPosition()
 {
 	Point position = {};
 	do {
-		position = Point { GenerateRnd(80), GenerateRnd(80) } + Displacement { 16, 16 };
+		position = Point { vanilla::GenerateRnd(80), vanilla::GenerateRnd(80) } + Displacement { 16, 16 };
 	} while (!ItemPlace(position));
 
 	return position;
@@ -405,7 +405,7 @@ Point GetRandomAvailableItemPosition()
 void AddInitItems()
 {
 	int curlv = ItemsGetCurrlevel();
-	int rnd = GenerateRnd(3) + 3;
+	int rnd = vanilla::GenerateRnd(3) + 3;
 	for (int j = 0; j < rnd; j++) {
 		int ii = AllocateItem();
 
@@ -414,9 +414,9 @@ void AddInitItems()
 
 		dItem[position.x][position.y] = ii + 1;
 
-		Items[ii]._iSeed = AdvanceRndSeed();
+		Items[ii]._iSeed = vanilla::AdvanceRndSeed();
 
-		if (GenerateRnd(2) != 0)
+		if (vanilla::GenerateRnd(2) != 0)
 			GetItemAttrs(ii, IDI_HEAL, curlv);
 		else
 			GetItemAttrs(ii, IDI_MANA, curlv);
@@ -605,7 +605,7 @@ bool GetItemSpace(Point position, int8_t inum)
 		}
 	}
 
-	int rs = GenerateRnd(15) + 1;
+	int rs = vanilla::GenerateRnd(15) + 1;
 
 	if (!savail)
 		return false;
@@ -676,7 +676,7 @@ void GetBookSpell(int i, int lvl)
 
 	int maxSpells = gbIsHellfire ? MAX_SPELLS : 37;
 
-	rv = GenerateRnd(maxSpells) + 1;
+	rv = vanilla::GenerateRnd(maxSpells) + 1;
 
 	if (gbIsSpawn && lvl > 5)
 		lvl = 5;
@@ -717,7 +717,7 @@ void GetBookSpell(int i, int lvl)
 
 int RndPL(int param1, int param2)
 {
-	return param1 + GenerateRnd(param2 - param1 + 1);
+	return param1 + vanilla::GenerateRnd(param2 - param1 + 1);
 }
 
 int CalculateToHitBonus(int level)
@@ -1147,7 +1147,7 @@ void SaveItemAffix(ItemStruct &item, const PLStruct &affix)
 void GetStaffPower(int i, int lvl, int bs, bool onlygood)
 {
 	int preidx = -1;
-	if (GenerateRnd(10) == 0 || onlygood) {
+	if (vanilla::GenerateRnd(10) == 0 || onlygood) {
 		int nl = 0;
 		int l[256];
 		for (int j = 0; ItemPrefixes[j].power.type != IPL_INVALID; j++) {
@@ -1163,7 +1163,7 @@ void GetStaffPower(int i, int lvl, int bs, bool onlygood)
 			}
 		}
 		if (nl != 0) {
-			preidx = l[GenerateRnd(nl)];
+			preidx = l[vanilla::GenerateRnd(nl)];
 			char istr[128];
 			sprintf(istr, "%s %s", _(ItemPrefixes[preidx].PLName), Items[i]._iIName);
 			strcpy(Items[i]._iIName, istr);
@@ -1193,10 +1193,10 @@ void GetItemPower(int i, int minlvl, int maxlvl, affix_item_type flgs, bool only
 	char istr[128];
 	goodorevil goe;
 
-	int pre = GenerateRnd(4);
-	int post = GenerateRnd(3);
+	int pre = vanilla::GenerateRnd(4);
+	int post = vanilla::GenerateRnd(3);
 	if (pre != 0 && post == 0) {
-		if (GenerateRnd(2) != 0)
+		if (vanilla::GenerateRnd(2) != 0)
 			post = 1;
 		else
 			pre = 0;
@@ -1204,7 +1204,7 @@ void GetItemPower(int i, int minlvl, int maxlvl, affix_item_type flgs, bool only
 	int preidx = -1;
 	int sufidx = -1;
 	goe = GOE_ANY;
-	if (!onlygood && GenerateRnd(3) != 0)
+	if (!onlygood && vanilla::GenerateRnd(3) != 0)
 		onlygood = true;
 	if (pre == 0) {
 		int nt = 0;
@@ -1225,7 +1225,7 @@ void GetItemPower(int i, int minlvl, int maxlvl, affix_item_type flgs, bool only
 			}
 		}
 		if (nt != 0) {
-			preidx = l[GenerateRnd(nt)];
+			preidx = l[vanilla::GenerateRnd(nt)];
 			sprintf(istr, "%s %s", _(ItemPrefixes[preidx].PLName), Items[i]._iIName);
 			strcpy(Items[i]._iIName, istr);
 			Items[i]._iMagical = ITEM_QUALITY_MAGIC;
@@ -1246,7 +1246,7 @@ void GetItemPower(int i, int minlvl, int maxlvl, affix_item_type flgs, bool only
 			}
 		}
 		if (nl != 0) {
-			sufidx = l[GenerateRnd(nl)];
+			sufidx = l[vanilla::GenerateRnd(nl)];
 			strcpy(istr, fmt::format(_("{:s} of {:s}"), Items[i]._iIName, _(ItemSuffixes[sufidx].PLName)).c_str());
 			strcpy(Items[i]._iIName, istr);
 			Items[i]._iMagical = ITEM_QUALITY_MAGIC;
@@ -1276,7 +1276,7 @@ void GetItemPower(int i, int minlvl, int maxlvl, affix_item_type flgs, bool only
 
 void GetStaffSpell(int i, int lvl, bool onlygood)
 {
-	if (!gbIsHellfire && GenerateRnd(4) == 0) {
+	if (!gbIsHellfire && vanilla::GenerateRnd(4) == 0) {
 		GetItemPower(i, lvl / 2, lvl, PLT_STAFF, onlygood);
 		return;
 	}
@@ -1285,7 +1285,7 @@ void GetStaffSpell(int i, int lvl, bool onlygood)
 	int l = lvl / 2;
 	if (l == 0)
 		l = 1;
-	int rv = GenerateRnd(maxSpells) + 1;
+	int rv = vanilla::GenerateRnd(maxSpells) + 1;
 
 	if (gbIsSpawn && lvl > 10)
 		lvl = 10;
@@ -1317,7 +1317,7 @@ void GetStaffSpell(int i, int lvl, bool onlygood)
 	int minc = spelldata[bs].sStaffMin;
 	int maxc = spelldata[bs].sStaffMax - minc + 1;
 	Items[i]._iSpell = bs;
-	Items[i]._iCharges = minc + GenerateRnd(maxc);
+	Items[i]._iCharges = minc + vanilla::GenerateRnd(maxc);
 	Items[i]._iMaxCharges = Items[i]._iCharges;
 
 	Items[i]._iMinMag = spelldata[bs].sMinInt;
@@ -1345,7 +1345,7 @@ void GetOilType(int i, int maxLvl)
 		}
 	}
 
-	int8_t t = rnd[GenerateRnd(cnt)];
+	int8_t t = rnd[vanilla::GenerateRnd(cnt)];
 
 	strcpy(Items[i]._iName, _(OilNames[t]));
 	strcpy(Items[i]._iIName, _(OilNames[t]));
@@ -1433,12 +1433,12 @@ int RndUItem(MonsterStruct *monster)
 		}
 	}
 
-	return ril[GenerateRnd(ri)];
+	return ril[vanilla::GenerateRnd(ri)];
 }
 
 int RndAllItems()
 {
-	if (GenerateRnd(100) > 25)
+	if (vanilla::GenerateRnd(100) > 25)
 		return 0;
 
 	int ril[512];
@@ -1459,7 +1459,7 @@ int RndAllItems()
 			ri--;
 	}
 
-	return ril[GenerateRnd(ri)];
+	return ril[vanilla::GenerateRnd(ri)];
 }
 
 int RndTypeItems(int itype, int imid, int lvl)
@@ -1486,14 +1486,14 @@ int RndTypeItems(int itype, int imid, int lvl)
 		}
 	}
 
-	return ril[GenerateRnd(ri)];
+	return ril[vanilla::GenerateRnd(ri)];
 }
 
 _unique_items CheckUnique(int i, int lvl, int uper, bool recreate)
 {
 	std::bitset<128> uok = {};
 
-	if (GenerateRnd(100) > uper)
+	if (vanilla::GenerateRnd(100) > uper)
 		return UITEM_INVALID;
 
 	int numu = 0;
@@ -1511,7 +1511,7 @@ _unique_items CheckUnique(int i, int lvl, int uper, bool recreate)
 	if (numu == 0)
 		return UITEM_INVALID;
 
-	AdvanceRndSeed();
+	vanilla::AdvanceRndSeed();
 	uint8_t idata = 0;
 	while (numu > 0) {
 		if (uok[idata])
@@ -1547,7 +1547,7 @@ void GetUniqueItem(ItemStruct &item, _unique_items uid)
 void ItemRndDur(int ii)
 {
 	if (Items[ii]._iDurability > 0 && Items[ii]._iDurability != DUR_INDESTRUCTIBLE)
-		Items[ii]._iDurability = GenerateRnd(Items[ii]._iMaxDur / 2) + (Items[ii]._iMaxDur / 4) + 1;
+		Items[ii]._iDurability = vanilla::GenerateRnd(Items[ii]._iMaxDur / 2) + (Items[ii]._iMaxDur / 4) + 1;
 }
 
 void SetupAllItems(int ii, int idx, int iseed, int lvl, int uper, bool onlygood, bool recreate, bool pregen)
@@ -1555,7 +1555,7 @@ void SetupAllItems(int ii, int idx, int iseed, int lvl, int uper, bool onlygood,
 	int iblvl;
 
 	Items[ii]._iSeed = iseed;
-	SetRndSeed(iseed);
+	vanilla::SetRndSeed(iseed);
 	GetItemAttrs(ii, idx, lvl / 2);
 	Items[ii]._iCreateInfo = lvl;
 
@@ -1571,7 +1571,7 @@ void SetupAllItems(int ii, int idx, int iseed, int lvl, int uper, bool onlygood,
 
 	if (Items[ii]._iMiscId != IMISC_UNIQUE) {
 		iblvl = -1;
-		if (GenerateRnd(100) <= 10 || GenerateRnd(100) <= lvl) {
+		if (vanilla::GenerateRnd(100) <= 10 || vanilla::GenerateRnd(100) <= lvl) {
 			iblvl = lvl;
 		}
 		if (iblvl == -1 && Items[ii]._iMiscId == IMISC_STAFF) {
@@ -1614,7 +1614,7 @@ void SetupBaseItem(Point position, int idx, bool onlygood, bool sendmsg, bool de
 	GetSuperItemSpace(position, ii);
 	int curlv = ItemsGetCurrlevel();
 
-	SetupAllItems(ii, idx, AdvanceRndSeed(), 2 * curlv, 1, onlygood, false, delta);
+	SetupAllItems(ii, idx, vanilla::AdvanceRndSeed(), 2 * curlv, 1, onlygood, false, delta);
 
 	if (sendmsg)
 		NetSendCmdDItem(false, ii);
@@ -1627,10 +1627,10 @@ void SetupAllUseful(int ii, int iseed, int lvl)
 	int idx;
 
 	Items[ii]._iSeed = iseed;
-	SetRndSeed(iseed);
+	vanilla::SetRndSeed(iseed);
 
 	if (gbIsHellfire) {
-		idx = GenerateRnd(7);
+		idx = vanilla::GenerateRnd(7);
 		switch (idx) {
 		case 0:
 			idx = IDI_PORTAL;
@@ -1655,12 +1655,12 @@ void SetupAllUseful(int ii, int iseed, int lvl)
 			break;
 		}
 	} else {
-		if (GenerateRnd(2) != 0)
+		if (vanilla::GenerateRnd(2) != 0)
 			idx = IDI_HEAL;
 		else
 			idx = IDI_MANA;
 
-		if (lvl > 1 && GenerateRnd(3) == 0)
+		if (lvl > 1 && vanilla::GenerateRnd(3) == 0)
 			idx = IDI_PORTAL;
 	}
 
@@ -1745,7 +1745,7 @@ void RepairItem(ItemStruct *i, int lvl)
 
 	int rep = 0;
 	do {
-		rep += lvl + GenerateRnd(lvl);
+		rep += lvl + vanilla::GenerateRnd(lvl);
 		i->_iMaxDur -= std::max(i->_iMaxDur / (lvl + 9), 1);
 		if (i->_iMaxDur == 0) {
 			i->_itype = ITYPE_NONE;
@@ -1815,12 +1815,12 @@ bool ApplyOilToItem(ItemStruct *x, PlayerStruct &player)
 	switch (player._pOilType) {
 	case IMISC_OILACC:
 		if (x->_iPLToHit < 50) {
-			x->_iPLToHit += GenerateRnd(2) + 1;
+			x->_iPLToHit += vanilla::GenerateRnd(2) + 1;
 		}
 		break;
 	case IMISC_OILMAST:
 		if (x->_iPLToHit < 100) {
-			x->_iPLToHit += GenerateRnd(3) + 3;
+			x->_iPLToHit += vanilla::GenerateRnd(3) + 3;
 		}
 		break;
 	case IMISC_OILSHARP:
@@ -1835,7 +1835,7 @@ bool ApplyOilToItem(ItemStruct *x, PlayerStruct &player)
 		}
 		break;
 	case IMISC_OILSKILL:
-		r = GenerateRnd(6) + 5;
+		r = vanilla::GenerateRnd(6) + 5;
 		x->_iMinStr = std::max(0, x->_iMinStr - r);
 		x->_iMinMag = std::max(0, x->_iMinMag - r);
 		x->_iMinDex = std::max(0, x->_iMinDex - r);
@@ -1856,7 +1856,7 @@ bool ApplyOilToItem(ItemStruct *x, PlayerStruct &player)
 		break;
 	case IMISC_OILFORT:
 		if (x->_iMaxDur != DUR_INDESTRUCTIBLE && x->_iMaxDur < 200) {
-			r = GenerateRnd(41) + 10;
+			r = vanilla::GenerateRnd(41) + 10;
 			x->_iMaxDur += r;
 			x->_iDurability += r;
 		}
@@ -1867,12 +1867,12 @@ bool ApplyOilToItem(ItemStruct *x, PlayerStruct &player)
 		break;
 	case IMISC_OILHARD:
 		if (x->_iAC < 60) {
-			x->_iAC += GenerateRnd(2) + 1;
+			x->_iAC += vanilla::GenerateRnd(2) + 1;
 		}
 		break;
 	case IMISC_OILIMP:
 		if (x->_iAC < 120) {
-			x->_iAC += GenerateRnd(3) + 3;
+			x->_iAC += vanilla::GenerateRnd(3) + 3;
 		}
 		break;
 	default:
@@ -2152,7 +2152,7 @@ int RndVendorItem(int minlvl, int maxlvl)
 			break;
 	}
 
-	return ril[GenerateRnd(ri)] + 1;
+	return ril[vanilla::GenerateRnd(ri)] + 1;
 }
 
 int RndSmithItem(int lvl)
@@ -2221,7 +2221,7 @@ void SpawnOnePremium(int i, int plvl, int playerId)
 	do {
 		keepGoing = false;
 		memset(&Items[0], 0, sizeof(*Items));
-		Items[0]._iSeed = AdvanceRndSeed();
+		Items[0]._iSeed = vanilla::AdvanceRndSeed();
 		int itemType = RndPremiumItem(plvl / 4, plvl) - 1;
 		GetItemAttrs(0, itemType, plvl);
 		GetItemBonus(0, plvl / 2, plvl, true, !gbIsHellfire);
@@ -2357,7 +2357,7 @@ int RndHealerItem(int lvl)
 
 void RecreateSmithItem(int ii, int lvl, int iseed)
 {
-	SetRndSeed(iseed);
+	vanilla::SetRndSeed(iseed);
 	int itype = RndSmithItem(lvl) - 1;
 	GetItemAttrs(ii, itype, lvl);
 
@@ -2368,7 +2368,7 @@ void RecreateSmithItem(int ii, int lvl, int iseed)
 
 void RecreatePremiumItem(int ii, int plvl, int iseed)
 {
-	SetRndSeed(iseed);
+	vanilla::SetRndSeed(iseed);
 	int itype = RndPremiumItem(plvl / 4, plvl) - 1;
 	GetItemAttrs(ii, itype, plvl);
 	GetItemBonus(ii, plvl / 2, plvl, true, !gbIsHellfire);
@@ -2380,7 +2380,7 @@ void RecreatePremiumItem(int ii, int plvl, int iseed)
 
 void RecreateBoyItem(int ii, int lvl, int iseed)
 {
-	SetRndSeed(iseed);
+	vanilla::SetRndSeed(iseed);
 	int itype = RndBoyItem(lvl) - 1;
 	GetItemAttrs(ii, itype, lvl);
 	GetItemBonus(ii, lvl, 2 * lvl, true, true);
@@ -2395,15 +2395,15 @@ void RecreateWitchItem(int ii, int idx, int lvl, int iseed)
 	if (idx == IDI_MANA || idx == IDI_FULLMANA || idx == IDI_PORTAL) {
 		GetItemAttrs(ii, idx, lvl);
 	} else if (gbIsHellfire && idx >= 114 && idx <= 117) {
-		SetRndSeed(iseed);
-		AdvanceRndSeed();
+		vanilla::SetRndSeed(iseed);
+		vanilla::AdvanceRndSeed();
 		GetItemAttrs(ii, idx, lvl);
 	} else {
-		SetRndSeed(iseed);
+		vanilla::SetRndSeed(iseed);
 		int itype = RndWitchItem(lvl) - 1;
 		GetItemAttrs(ii, itype, lvl);
 		int iblvl = -1;
-		if (GenerateRnd(100) <= 5)
+		if (vanilla::GenerateRnd(100) <= 5)
 			iblvl = 2 * lvl;
 		if (iblvl == -1 && Items[ii]._iMiscId == IMISC_STAFF)
 			iblvl = 2 * lvl;
@@ -2421,7 +2421,7 @@ void RecreateHealerItem(int ii, int idx, int lvl, int iseed)
 	if (idx == IDI_HEAL || idx == IDI_FULLHEAL || idx == IDI_RESURRECT) {
 		GetItemAttrs(ii, idx, lvl);
 	} else {
-		SetRndSeed(iseed);
+		vanilla::SetRndSeed(iseed);
 		int itype = RndHealerItem(lvl) - 1;
 		GetItemAttrs(ii, itype, lvl);
 	}
@@ -2480,7 +2480,7 @@ void CreateMagicItem(Point position, int lvl, int imisc, int imid, int icurs, bo
 
 	while (true) {
 		memset(&Items[ii], 0, sizeof(*Items));
-		SetupAllItems(ii, idx, AdvanceRndSeed(), 2 * lvl, 1, true, false, delta);
+		SetupAllItems(ii, idx, vanilla::AdvanceRndSeed(), 2 * lvl, 1, true, false, delta);
 		if (Items[ii]._iCurs == icurs)
 			break;
 
@@ -2591,7 +2591,7 @@ void InitItems()
 	}
 
 	if (!setlevel) {
-		AdvanceRndSeed(); /* unused */
+		vanilla::AdvanceRndSeed(); /* unused */
 		if (QuestStatus(Q_ROCK))
 			SpawnRock();
 		if (QuestStatus(Q_ANVIL))
@@ -3031,7 +3031,7 @@ void SetPlrHandItem(ItemStruct *h, int idata)
 
 void GetPlrHandSeed(ItemStruct *h)
 {
-	h->_iSeed = AdvanceRndSeed();
+	h->_iSeed = vanilla::AdvanceRndSeed();
 }
 
 /**
@@ -3046,7 +3046,7 @@ void GetGoldSeed(int pnum, ItemStruct *h)
 	bool doneflag;
 	do {
 		doneflag = true;
-		s = AdvanceRndSeed();
+		s = vanilla::AdvanceRndSeed();
 		for (int i = 0; i < ActiveItemCount; i++) {
 			int ii = ActiveItems[i];
 			if (Items[ii]._iSeed == s)
@@ -3289,7 +3289,7 @@ void GetItemAttrs(int i, int idata, int lvl)
 	Items[i]._iClass = AllItemsList[idata].iClass;
 	Items[i]._iMinDam = AllItemsList[idata].iMinDam;
 	Items[i]._iMaxDam = AllItemsList[idata].iMaxDam;
-	Items[i]._iAC = AllItemsList[idata].iMinAC + GenerateRnd(AllItemsList[idata].iMaxAC - AllItemsList[idata].iMinAC + 1);
+	Items[i]._iAC = AllItemsList[idata].iMinAC + vanilla::GenerateRnd(AllItemsList[idata].iMaxAC - AllItemsList[idata].iMinAC + 1);
 	Items[i]._iFlags = AllItemsList[idata].iFlags;
 	Items[i]._iMiscId = AllItemsList[idata].iMiscId;
 	Items[i]._iSpell = AllItemsList[idata].iSpell;
@@ -3320,13 +3320,13 @@ void GetItemAttrs(int i, int idata, int lvl)
 	int itemlevel = ItemsGetCurrlevel();
 	switch (sgGameInitInfo.nDifficulty) {
 	case DIFF_NORMAL:
-		rndv = 5 * itemlevel + GenerateRnd(10 * itemlevel);
+		rndv = 5 * itemlevel + vanilla::GenerateRnd(10 * itemlevel);
 		break;
 	case DIFF_NIGHTMARE:
-		rndv = 5 * (itemlevel + 16) + GenerateRnd(10 * (itemlevel + 16));
+		rndv = 5 * (itemlevel + 16) + vanilla::GenerateRnd(10 * (itemlevel + 16));
 		break;
 	case DIFF_HELL:
-		rndv = 5 * (itemlevel + 32) + GenerateRnd(10 * (itemlevel + 32));
+		rndv = 5 * (itemlevel + 32) + vanilla::GenerateRnd(10 * (itemlevel + 32));
 		break;
 	}
 	if (leveltype == DTYPE_HELL)
@@ -3350,10 +3350,10 @@ int RndItem(const MonsterStruct &monster)
 	if ((monster.MData->mTreasure & 0x4000) != 0)
 		return 0;
 
-	if (GenerateRnd(100) > 40)
+	if (vanilla::GenerateRnd(100) > 40)
 		return 0;
 
-	if (GenerateRnd(100) > 25)
+	if (vanilla::GenerateRnd(100) > 25)
 		return IDI_GOLD + 1;
 
 	int ril[512];
@@ -3379,7 +3379,7 @@ int RndItem(const MonsterStruct &monster)
 			ri--;
 	}
 
-	int r = GenerateRnd(ri);
+	int r = vanilla::GenerateRnd(ri);
 	return ril[r] + 1;
 }
 
@@ -3440,7 +3440,7 @@ void SpawnItem(MonsterStruct &monster, Point position, bool sendmsg)
 	if (!gbIsHellfire && monster.MType->mtype == MT_DIABLO)
 		mLevel -= 15;
 
-	SetupAllItems(ii, idx, AdvanceRndSeed(), mLevel, uper, onlygood, false, false);
+	SetupAllItems(ii, idx, vanilla::AdvanceRndSeed(), mLevel, uper, onlygood, false, false);
 
 	if (sendmsg)
 		NetSendCmdDItem(false, ii);
@@ -3462,7 +3462,7 @@ void CreateRndUseful(Point position, bool sendmsg)
 	GetSuperItemSpace(position, ii);
 	int curlv = ItemsGetCurrlevel();
 
-	SetupAllUseful(ii, AdvanceRndSeed(), curlv);
+	SetupAllUseful(ii, vanilla::AdvanceRndSeed(), curlv);
 	if (sendmsg)
 		NetSendCmdDItem(false, ii);
 }
@@ -3620,8 +3620,8 @@ void SpawnQuestItem(int itemid, Point position, int randarea, int selflag)
 			if (tries > 1000 && randarea > 1)
 				randarea--;
 
-			position.x = GenerateRnd(MAXDUNX);
-			position.y = GenerateRnd(MAXDUNY);
+			position.x = vanilla::GenerateRnd(MAXDUNX);
+			position.y = vanilla::GenerateRnd(MAXDUNY);
 
 			bool failed = false;
 			for (int i = 0; i < randarea && !failed; i++) {
@@ -3647,7 +3647,7 @@ void SpawnQuestItem(int itemid, Point position, int randarea, int selflag)
 	GetItemAttrs(ii, itemid, curlv);
 
 	SetupItem(ii);
-	Items[ii]._iSeed = AdvanceRndSeed();
+	Items[ii]._iSeed = vanilla::AdvanceRndSeed();
 	Items[ii]._iPostDraw = true;
 	if (selflag != 0) {
 		Items[ii]._iSelFlag = selflag;
@@ -3816,7 +3816,7 @@ void DoRecharge(int pnum, int cii)
 	}
 	if (pi->_itype == ITYPE_STAFF && pi->_iSpell != SPL_NULL) {
 		int r = GetSpellBookLevel(pi->_iSpell);
-		r = GenerateRnd(player._pLevel / r) + 1;
+		r = vanilla::GenerateRnd(player._pLevel / r) + 1;
 		RechargeItem(pi, r);
 		CalcPlrInv(pnum, true);
 	}
@@ -4247,7 +4247,7 @@ void UseItem(int p, item_misc_id mid, spell_id spl)
 	case IMISC_HEAL:
 	case IMISC_FOOD: {
 		int j = player._pMaxHP >> 8;
-		int l = ((j / 2) + GenerateRnd(j)) << 6;
+		int l = ((j / 2) + vanilla::GenerateRnd(j)) << 6;
 		if (player._pClass == HeroClass::Warrior || player._pClass == HeroClass::Barbarian)
 			l *= 2;
 		if (player._pClass == HeroClass::Rogue || player._pClass == HeroClass::Monk || player._pClass == HeroClass::Bard)
@@ -4263,7 +4263,7 @@ void UseItem(int p, item_misc_id mid, spell_id spl)
 		break;
 	case IMISC_MANA: {
 		int j = player._pMaxMana >> 8;
-		int l = ((j / 2) + GenerateRnd(j)) << 6;
+		int l = ((j / 2) + vanilla::GenerateRnd(j)) << 6;
 		if (player._pClass == HeroClass::Sorcerer)
 			l *= 2;
 		if (player._pClass == HeroClass::Rogue || player._pClass == HeroClass::Monk || player._pClass == HeroClass::Bard)
@@ -4305,7 +4305,7 @@ void UseItem(int p, item_misc_id mid, spell_id spl)
 		break;
 	case IMISC_REJUV: {
 		int j = player._pMaxHP >> 8;
-		int l = ((j / 2) + GenerateRnd(j)) << 6;
+		int l = ((j / 2) + vanilla::GenerateRnd(j)) << 6;
 		if (player._pClass == HeroClass::Warrior || player._pClass == HeroClass::Barbarian)
 			l *= 2;
 		if (player._pClass == HeroClass::Rogue)
@@ -4314,7 +4314,7 @@ void UseItem(int p, item_misc_id mid, spell_id spl)
 		player._pHPBase = std::min(player._pHPBase + l, player._pMaxHPBase);
 		drawhpflag = true;
 		j = player._pMaxMana >> 8;
-		l = ((j / 2) + GenerateRnd(j)) << 6;
+		l = ((j / 2) + vanilla::GenerateRnd(j)) << 6;
 		if (player._pClass == HeroClass::Sorcerer)
 			l *= 2;
 		if (player._pClass == HeroClass::Rogue)
@@ -4456,11 +4456,11 @@ void SpawnSmith(int lvl)
 		maxItems = 25;
 	}
 
-	int iCnt = GenerateRnd(maxItems - 10) + 10;
+	int iCnt = vanilla::GenerateRnd(maxItems - 10) + 10;
 	for (int i = 0; i < iCnt; i++) {
 		do {
 			memset(&Items[0], 0, sizeof(*Items));
-			Items[0]._iSeed = AdvanceRndSeed();
+			Items[0]._iSeed = vanilla::AdvanceRndSeed();
 			int idata = RndSmithItem(lvl) - 1;
 			GetItemAttrs(0, idata, lvl);
 		} while (Items[0]._iIvalue > maxValue);
@@ -4537,7 +4537,7 @@ void SpawnWitch(int lvl)
 		maxValue = 200000;
 		reservedItems = 10;
 
-		int books = GenerateRnd(4);
+		int books = vanilla::GenerateRnd(4);
 		for (int i = 114, bCnt = 0; i <= 117 && bCnt < books; ++i) {
 			if (!WitchItemOk(i))
 				continue;
@@ -4545,8 +4545,8 @@ void SpawnWitch(int lvl)
 				continue;
 
 			memset(&Items[0], 0, sizeof(*Items));
-			Items[0]._iSeed = AdvanceRndSeed();
-			AdvanceRndSeed();
+			Items[0]._iSeed = vanilla::AdvanceRndSeed();
+			vanilla::AdvanceRndSeed();
 
 			GetItemAttrs(0, i, lvl);
 			witchitem[j] = Items[0];
@@ -4558,16 +4558,16 @@ void SpawnWitch(int lvl)
 			bCnt++;
 		}
 	}
-	int iCnt = GenerateRnd(WITCH_ITEMS - reservedItems) + 10;
+	int iCnt = vanilla::GenerateRnd(WITCH_ITEMS - reservedItems) + 10;
 
 	for (int i = j; i < iCnt; i++) {
 		do {
 			memset(&Items[0], 0, sizeof(*Items));
-			Items[0]._iSeed = AdvanceRndSeed();
+			Items[0]._iSeed = vanilla::AdvanceRndSeed();
 			int idata = RndWitchItem(lvl) - 1;
 			GetItemAttrs(0, idata, lvl);
 			int maxlvl = -1;
-			if (GenerateRnd(100) <= 5)
+			if (vanilla::GenerateRnd(100) <= 5)
 				maxlvl = 2 * lvl;
 			if (maxlvl == -1 && Items[0]._iMiscId == IMISC_STAFF)
 				maxlvl = 2 * lvl;
@@ -4608,7 +4608,7 @@ void SpawnBoy(int lvl)
 	do {
 		keepgoing = false;
 		memset(&Items[0], 0, sizeof(*Items));
-		Items[0]._iSeed = AdvanceRndSeed();
+		Items[0]._iSeed = vanilla::AdvanceRndSeed();
 		int itype = RndBoyItem(lvl) - 1;
 		GetItemAttrs(0, itype, lvl);
 		GetItemBonus(0, lvl, 2 * lvl, true, true);
@@ -4731,10 +4731,10 @@ void SpawnHealer(int lvl)
 	} else {
 		srnd = 2;
 	}
-	int nsi = GenerateRnd(gbIsHellfire ? 10 : 8) + 10;
+	int nsi = vanilla::GenerateRnd(gbIsHellfire ? 10 : 8) + 10;
 	for (int i = srnd; i < nsi; i++) {
 		memset(&Items[0], 0, sizeof(*Items));
-		Items[0]._iSeed = AdvanceRndSeed();
+		Items[0]._iSeed = vanilla::AdvanceRndSeed();
 		int itype = RndHealerItem(lvl) - 1;
 		GetItemAttrs(0, itype, lvl);
 		healitem[i] = Items[0];
@@ -4785,7 +4785,7 @@ void CreateSpellBook(Point position, spell_id ispell, bool sendmsg, bool delta)
 
 	while (true) {
 		memset(&Items[ii], 0, sizeof(*Items));
-		SetupAllItems(ii, idx, AdvanceRndSeed(), 2 * lvl, 1, true, false, delta);
+		SetupAllItems(ii, idx, vanilla::AdvanceRndSeed(), 2 * lvl, 1, true, false, delta);
 		if (Items[ii]._iMiscId == IMISC_BOOK && Items[ii]._iSpell == ispell)
 			break;
 	}

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2034,7 +2034,7 @@ void SaveLevel()
 	DoUnVision(Players[MyPlayerId].position.tile, Players[MyPlayerId]._pLightRad); // fix for vision staying on the level
 
 	if (currlevel == 0)
-		glSeedTbl[0] = AdvanceRndSeed();
+		glSeedTbl[0] = vanilla::AdvanceRndSeed();
 
 	char szName[MAX_PATH];
 	GetTempLevelNames(szName);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -63,7 +63,7 @@ int GenerateRndSum(int range, int iterations)
 {
 	int value = 0;
 	for (int i = 0; i < iterations; i++) {
-		value += GenerateRnd(range);
+		value += vanilla::GenerateRnd(range);
 	}
 
 	return value;
@@ -238,7 +238,7 @@ bool MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, int t, bool 
 	if (gbIsHellfire && t == MIS_HBOLT && (monster.MType->mtype == MT_DIABLO || monster.MType->mtype == MT_BONEDEMN))
 		resist = true;
 
-	int hit = GenerateRnd(100);
+	int hit = vanilla::GenerateRnd(100);
 	int hper = 0;
 	if (pnum != -1) {
 		const auto &player = Players[pnum];
@@ -262,7 +262,7 @@ bool MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, int t, bool 
 				hper += 10;
 		}
 	} else {
-		hper = GenerateRnd(75) - monster.mLevel * 2;
+		hper = vanilla::GenerateRnd(75) - monster.mLevel * 2;
 	}
 
 	hper = clamp(hper, 5, 95);
@@ -286,7 +286,7 @@ bool MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, int t, bool 
 	if (t == MIS_BONESPIRIT) {
 		dam = monster._mhitpoints / 3 >> 6;
 	} else {
-		dam = mindam + GenerateRnd(maxdam - mindam + 1);
+		dam = mindam + vanilla::GenerateRnd(maxdam - mindam + 1);
 	}
 
 	if (MissileData[t].mType == 0) {
@@ -379,7 +379,7 @@ bool Plr2PlrMHit(int pnum, int p, int mindam, int maxdam, int dist, int mtype, b
 		break;
 	}
 
-	int hper = GenerateRnd(100);
+	int hper = vanilla::GenerateRnd(100);
 
 	int hit;
 	if (MissileData[mtype].mType == 0) {
@@ -413,7 +413,7 @@ bool Plr2PlrMHit(int pnum, int p, int mindam, int maxdam, int dist, int mtype, b
 
 	int blkper = 100;
 	if (!shift && (target._pmode == PM_STAND || target._pmode == PM_ATTACK) && target._pBlockFlag) {
-		blkper = GenerateRnd(100);
+		blkper = vanilla::GenerateRnd(100);
 	}
 
 	int blk = target._pDexterity + target._pBaseToBlk + (target._pLevel * 2) - (player._pLevel * 2);
@@ -423,7 +423,7 @@ bool Plr2PlrMHit(int pnum, int p, int mindam, int maxdam, int dist, int mtype, b
 	if (mtype == MIS_BONESPIRIT) {
 		dam = target._pHitPoints / 3;
 	} else {
-		dam = mindam + GenerateRnd(maxdam - mindam + 1);
+		dam = mindam + vanilla::GenerateRnd(maxdam - mindam + 1);
 		if (MissileData[mtype].mType == 0)
 			dam += player._pIBonusDamMod + player._pDamageMod + dam * player._pIBonusDam / 100;
 		if (!shift)
@@ -507,7 +507,7 @@ void CheckMissileCol(int i, int mindam, int maxdam, bool shift, Point position, 
 			        shift,
 			        &blocked)) {
 				if (gbIsHellfire && blocked) {
-					int dir = Missiles[i]._mimfnum + (GenerateRnd(2) != 0 ? 1 : -1);
+					int dir = Missiles[i]._mimfnum + (vanilla::GenerateRnd(2) != 0 ? 1 : -1);
 					int mAnimFAmt = MissileSpriteData[Missiles[i]._miAnimType].mAnimFAmt;
 					if (dir < 0)
 						dir = mAnimFAmt - 1;
@@ -542,7 +542,7 @@ void CheckMissileCol(int i, int mindam, int maxdam, bool shift, Point position, 
 			        0,
 			        &blocked)) {
 				if (gbIsHellfire && blocked) {
-					int dir = Missiles[i]._mimfnum + (GenerateRnd(2) != 0 ? 1 : -1);
+					int dir = Missiles[i]._mimfnum + (vanilla::GenerateRnd(2) != 0 ? 1 : -1);
 					int mAnimFAmt = MissileSpriteData[Missiles[i]._miAnimType].mAnimFAmt;
 					if (dir < 0)
 						dir = mAnimFAmt - 1;
@@ -589,7 +589,7 @@ void CheckMissileCol(int i, int mindam, int maxdam, bool shift, Point position, 
 			        (Missiles[i]._miAnimType == MFILE_FIREWAL || Missiles[i]._miAnimType == MFILE_LGHNING) ? 1 : 0,
 			        &blocked)) {
 				if (gbIsHellfire && blocked) {
-					int dir = Missiles[i]._mimfnum + (GenerateRnd(2) != 0 ? 1 : -1);
+					int dir = Missiles[i]._mimfnum + (vanilla::GenerateRnd(2) != 0 ? 1 : -1);
 					int mAnimFAmt = MissileSpriteData[Missiles[i]._miAnimType].mAnimFAmt;
 					if (dir < 0)
 						dir = mAnimFAmt - 1;
@@ -1055,7 +1055,7 @@ bool MonsterTrapHit(int m, int mindam, int maxdam, int dist, int t, bool shift)
 		resist = true;
 	}
 
-	int hit = GenerateRnd(100);
+	int hit = vanilla::GenerateRnd(100);
 	int hper = 90 - (BYTE)monster.mArmorClass - dist;
 	if (hper < 5)
 		hper = 5;
@@ -1070,7 +1070,7 @@ bool MonsterTrapHit(int m, int mindam, int maxdam, int dist, int t, bool shift)
 #else
 	if (hit < hper || monster._mmode == MM_STONE) {
 #endif
-		int dam = mindam + GenerateRnd(maxdam - mindam + 1);
+		int dam = mindam + vanilla::GenerateRnd(maxdam - mindam + 1);
 		if (!shift)
 			dam <<= 6;
 		if (resist)
@@ -1123,7 +1123,7 @@ bool PlayerMHit(int pnum, MonsterStruct *monster, int dist, int mind, int maxd, 
 		return false;
 	}
 
-	int hit = GenerateRnd(100);
+	int hit = vanilla::GenerateRnd(100);
 #ifdef _DEBUG
 	if (debug_mode_dollar_sign || debug_mode_key_inverted_v)
 		hit = 1000;
@@ -1157,7 +1157,7 @@ bool PlayerMHit(int pnum, MonsterStruct *monster, int dist, int mind, int maxd, 
 
 	int blk = 100;
 	if ((player._pmode == PM_STAND || player._pmode == PM_ATTACK) && player._pBlockFlag) {
-		blk = GenerateRnd(100);
+		blk = vanilla::GenerateRnd(100);
 	}
 
 	if (shift)
@@ -1200,13 +1200,13 @@ bool PlayerMHit(int pnum, MonsterStruct *monster, int dist, int mind, int maxd, 
 		dam = player._pHitPoints / 3;
 	} else {
 		if (!shift) {
-			dam = (mind << 6) + GenerateRnd((maxd - mind + 1) << 6);
+			dam = (mind << 6) + vanilla::GenerateRnd((maxd - mind + 1) << 6);
 			if (monster == nullptr)
 				if ((player._pIFlags & ISPL_ABSHALFTRAP) != 0)
 					dam /= 2;
 			dam += (player._pIGetHit << 6);
 		} else {
-			dam = mind + GenerateRnd(maxd - mind + 1);
+			dam = mind + vanilla::GenerateRnd(maxd - mind + 1);
 			if (monster == nullptr)
 				if ((player._pIFlags & ISPL_ABSHALFTRAP) != 0)
 					dam /= 2;
@@ -1496,7 +1496,7 @@ void AddBerserk(int mi, Point /*src*/, Point dst, int /*midir*/, int8_t /*mienem
 				continue;
 			if ((monster.mMagicRes & IMMUNE_MAGIC) != 0)
 				continue;
-			if ((monster.mMagicRes & RESIST_MAGIC) != 0 && ((monster.mMagicRes & RESIST_MAGIC) != 1 || GenerateRnd(2) != 0))
+			if ((monster.mMagicRes & RESIST_MAGIC) != 0 && ((monster.mMagicRes & RESIST_MAGIC) != 1 || vanilla::GenerateRnd(2) != 0))
 				continue;
 			if (monster._mmode == MM_CHARGE)
 				continue;
@@ -1504,10 +1504,10 @@ void AddBerserk(int mi, Point /*src*/, Point dst, int /*midir*/, int8_t /*mienem
 			i = 6;
 			auto slvl = GetSpellLevel(id, SPL_BERSERK);
 			monster._mFlags |= MFLAG_BERSERK | MFLAG_GOLEM;
-			monster.mMinDamage = (GenerateRnd(10) + 120) * monster.mMinDamage / 100 + slvl;
-			monster.mMaxDamage = (GenerateRnd(10) + 120) * monster.mMaxDamage / 100 + slvl;
-			monster.mMinDamage2 = (GenerateRnd(10) + 120) * monster.mMinDamage2 / 100 + slvl;
-			monster.mMaxDamage2 = (GenerateRnd(10) + 120) * monster.mMaxDamage2 / 100 + slvl;
+			monster.mMinDamage = (vanilla::GenerateRnd(10) + 120) * monster.mMinDamage / 100 + slvl;
+			monster.mMaxDamage = (vanilla::GenerateRnd(10) + 120) * monster.mMaxDamage / 100 + slvl;
+			monster.mMinDamage2 = (vanilla::GenerateRnd(10) + 120) * monster.mMinDamage2 / 100 + slvl;
+			monster.mMaxDamage2 = (vanilla::GenerateRnd(10) + 120) * monster.mMaxDamage2 / 100 + slvl;
 			int r = (currlevel < 17 || currlevel > 20) ? 3 : 9;
 			monster.mlid = AddLight(monster.position.tile, r);
 			UseMana(id, SPL_BERSERK);
@@ -1527,7 +1527,7 @@ void AddHorkSpawn(int mi, Point src, Point dst, int midir, int8_t /*mienemy*/, i
 void AddJester(int mi, Point src, Point dst, int midir, int8_t /*mienemy*/, int id, int /*dam*/)
 {
 	int spell = MIS_FIREBOLT;
-	switch (GenerateRnd(10)) {
+	switch (vanilla::GenerateRnd(10)) {
 	case 0:
 	case 1:
 		spell = MIS_FIREBOLT;
@@ -1583,7 +1583,7 @@ void AddStealPotions(int mi, Point src, Point /*dst*/, int /*midir*/, int8_t /*m
 			for (int si = 0; si < MAXBELTITEMS; si++) {
 				int ii = -1;
 				if (player.SpdList[si]._itype == ITYPE_MISC) {
-					if (GenerateRnd(2) == 0)
+					if (vanilla::GenerateRnd(2) == 0)
 						continue;
 					switch (player.SpdList[si]._iMiscId) {
 					case IMISC_FULLHEAL:
@@ -1597,14 +1597,14 @@ void AddStealPotions(int mi, Point src, Point /*dst*/, int /*midir*/, int8_t /*m
 						ii = ItemMiscIdIdx(IMISC_MANA);
 						break;
 					case IMISC_REJUV:
-						if (GenerateRnd(2) != 0) {
+						if (vanilla::GenerateRnd(2) != 0) {
 							ii = ItemMiscIdIdx(IMISC_MANA);
 						} else {
 							ii = ItemMiscIdIdx(IMISC_HEAL);
 						}
 						break;
 					case IMISC_FULLREJUV:
-						switch (GenerateRnd(3)) {
+						switch (vanilla::GenerateRnd(3)) {
 						case 0:
 							ii = ItemMiscIdIdx(IMISC_FULLMANA);
 							break;
@@ -1729,7 +1729,7 @@ void AddLightningWall(int mi, Point src, Point dst, int /*midir*/, int8_t /*mien
 {
 	UpdateMissileVelocity(mi, src, dst, 16);
 	Missiles[mi]._midam = dam;
-	Missiles[mi]._miAnimFrame = GenerateRnd(8) + 1;
+	Missiles[mi]._miAnimFrame = vanilla::GenerateRnd(8) + 1;
 	Missiles[mi]._mirange = 255 * (Missiles[mi]._mispllvl + 1);
 	if (id < 0) {
 		Missiles[mi]._miVar1 = src.x;
@@ -1811,7 +1811,7 @@ void AddLightningArrow(int mi, Point src, Point dst, int midir, int8_t /*mienemy
 		dst += static_cast<Direction>(midir);
 	}
 	UpdateMissileVelocity(mi, src, dst, 32);
-	Missiles[mi]._miAnimFrame = GenerateRnd(8) + 1;
+	Missiles[mi]._miAnimFrame = vanilla::GenerateRnd(8) + 1;
 	Missiles[mi]._mirange = 255;
 	if (id < 0) {
 		Missiles[mi]._miVar1 = src.x;
@@ -1827,12 +1827,12 @@ void AddMana(int mi, Point /*src*/, Point /*dst*/, int /*midir*/, int8_t /*miene
 {
 	auto &player = Players[id];
 
-	int manaAmount = (GenerateRnd(10) + 1) << 6;
+	int manaAmount = (vanilla::GenerateRnd(10) + 1) << 6;
 	for (int i = 0; i < player._pLevel; i++) {
-		manaAmount += (GenerateRnd(4) + 1) << 6;
+		manaAmount += (vanilla::GenerateRnd(4) + 1) << 6;
 	}
 	for (int i = 0; i < Missiles[mi]._mispllvl; i++) {
-		manaAmount += (GenerateRnd(6) + 1) << 6;
+		manaAmount += (vanilla::GenerateRnd(6) + 1) << 6;
 	}
 	if (player._pClass == HeroClass::Sorcerer)
 		manaAmount *= 2;
@@ -1914,7 +1914,7 @@ void AddSearch(int mi, Point /*src*/, Point /*dst*/, int /*midir*/, int8_t miene
 
 void AddCboltArrow(int mi, Point src, Point dst, int midir, int8_t mienemy, int /*id*/, int /*dam*/)
 {
-	Missiles[mi]._mirnd = GenerateRnd(15) + 1;
+	Missiles[mi]._mirnd = vanilla::GenerateRnd(15) + 1;
 	if (mienemy != TARGET_MONSTERS) {
 		Missiles[mi]._midam = 15;
 	}
@@ -1922,7 +1922,7 @@ void AddCboltArrow(int mi, Point src, Point dst, int midir, int8_t mienemy, int 
 	if (src == dst) {
 		dst += static_cast<Direction>(midir);
 	}
-	Missiles[mi]._miAnimFrame = GenerateRnd(8) + 1;
+	Missiles[mi]._miAnimFrame = vanilla::GenerateRnd(8) + 1;
 	Missiles[mi]._mlid = AddLight(src, 5);
 	UpdateMissileVelocity(mi, src, dst, 8);
 	Missiles[mi]._miVar1 = 5;
@@ -1977,7 +1977,7 @@ void AddArrow(int mi, Point src, Point dst, int midir, int8_t mienemy, int id, i
 		auto &player = Players[id];
 
 		if ((player._pIFlags & ISPL_RNDARROWVEL) != 0) {
-			av = GenerateRnd(32) + 16;
+			av = vanilla::GenerateRnd(32) + 16;
 		}
 		if (player._pClass == HeroClass::Rogue)
 			av += (player._pLevel - 1) / 4;
@@ -2031,11 +2031,11 @@ void AddRndTeleport(int mi, Point src, Point dst, int /*midir*/, int8_t mienemy,
 			r2 = 0;
 			break; //BUGFIX: warps player to 0/0 in hellfire, change to return or use 1.09's version of the code
 		}
-		r1 = GenerateRnd(3) + 4;
-		r2 = GenerateRnd(3) + 4;
-		if (GenerateRnd(2) == 1)
+		r1 = vanilla::GenerateRnd(3) + 4;
+		r2 = vanilla::GenerateRnd(3) + 4;
+		if (vanilla::GenerateRnd(2) == 1)
 			r1 = -r1;
-		if (GenerateRnd(2) == 1)
+		if (vanilla::GenerateRnd(2) == 1)
 			r2 = -r2;
 
 		r1 += src.x;
@@ -2146,7 +2146,7 @@ void AddLightball(int mi, Point src, Point dst, int /*midir*/, int8_t /*mienemy*
 {
 	UpdateMissileVelocity(mi, src, dst, 16);
 	Missiles[mi]._midam = dam;
-	Missiles[mi]._miAnimFrame = GenerateRnd(8) + 1;
+	Missiles[mi]._miAnimFrame = vanilla::GenerateRnd(8) + 1;
 	Missiles[mi]._mirange = 255;
 	if (id < 0) {
 		Missiles[mi]._miVar1 = src.x;
@@ -2208,7 +2208,7 @@ void AddLightctrl(int mi, Point src, Point dst, int /*midir*/, int8_t mienemy, i
 	Missiles[mi]._miVar1 = src.x;
 	Missiles[mi]._miVar2 = src.y;
 	UpdateMissileVelocity(mi, src, dst, 32);
-	Missiles[mi]._miAnimFrame = GenerateRnd(8) + 1;
+	Missiles[mi]._miAnimFrame = vanilla::GenerateRnd(8) + 1;
 	Missiles[mi]._mirange = 256;
 }
 
@@ -2219,7 +2219,7 @@ void AddLightning(int mi, Point /*src*/, Point dst, int midir, int8_t mienemy, i
 		Missiles[mi].position.offset = Missiles[midir].position.offset;
 		Missiles[mi].position.traveled = Missiles[midir].position.traveled;
 	}
-	Missiles[mi]._miAnimFrame = GenerateRnd(8) + 1;
+	Missiles[mi]._miAnimFrame = vanilla::GenerateRnd(8) + 1;
 
 	if (midir < 0 || mienemy == TARGET_PLAYERS || id == -1) {
 		if (midir < 0 || id == -1)
@@ -2370,7 +2370,7 @@ void AddManashield(int mi, Point /*src*/, Point /*dst*/, int /*midir*/, int8_t m
 
 void AddFiremove(int mi, Point src, Point dst, int /*midir*/, int8_t /*mienemy*/, int id, int /*dam*/)
 {
-	Missiles[mi]._midam = GenerateRnd(10) + Players[id]._pLevel + 1;
+	Missiles[mi]._midam = vanilla::GenerateRnd(10) + Players[id]._pLevel + 1;
 	UpdateMissileVelocity(mi, src, dst, 16);
 	Missiles[mi]._mirange = 255;
 	Missiles[mi]._miVar1 = 0;
@@ -2382,7 +2382,7 @@ void AddFiremove(int mi, Point src, Point dst, int /*midir*/, int8_t /*mienemy*/
 
 void AddGuardian(int mi, Point src, Point dst, int /*midir*/, int8_t /*mienemy*/, int id, int /*dam*/)
 {
-	int dmg = GenerateRnd(10) + (Players[id]._pLevel / 2) + 1;
+	int dmg = vanilla::GenerateRnd(10) + (Players[id]._pLevel / 2) + 1;
 	Missiles[mi]._midam = ScaleSpellEffect(dmg, Missiles[mi]._mispllvl);
 
 	Missiles[mi]._miDelFlag = true;
@@ -2576,7 +2576,7 @@ void AddAcidpud(int mi, Point /*src*/, Point /*dst*/, int /*midir*/, int8_t /*mi
 	Missiles[mi].position.offset = { 0, 0 };
 	Missiles[mi]._miLightFlag = true;
 	int monst = Missiles[mi]._misource;
-	Missiles[mi]._mirange = GenerateRnd(15) + 40 * (Monsters[monst]._mint + 1);
+	Missiles[mi]._mirange = vanilla::GenerateRnd(15) + 40 * (Monsters[monst]._mint + 1);
 	Missiles[mi]._miPreFlag = true;
 }
 
@@ -2697,12 +2697,12 @@ void AddHeal(int mi, Point /*src*/, Point /*dst*/, int /*midir*/, int8_t /*miene
 {
 	auto &player = Players[id];
 
-	int hp = (GenerateRnd(10) + 1) << 6;
+	int hp = (vanilla::GenerateRnd(10) + 1) << 6;
 	for (int i = 0; i < player._pLevel; i++) {
-		hp += (GenerateRnd(4) + 1) << 6;
+		hp += (vanilla::GenerateRnd(4) + 1) << 6;
 	}
 	for (int i = 0; i < Missiles[mi]._mispllvl; i++) {
-		hp += (GenerateRnd(6) + 1) << 6;
+		hp += (vanilla::GenerateRnd(6) + 1) << 6;
 	}
 
 	if (player._pClass == HeroClass::Warrior || player._pClass == HeroClass::Barbarian || player._pClass == HeroClass::Monk) {
@@ -2943,11 +2943,11 @@ void AddFlame(int mi, Point src, Point dst, int midir, int8_t mienemy, int id, i
 	Missiles[mi]._mirange = Missiles[mi]._miVar2 + 20;
 	Missiles[mi]._mlid = AddLight(src, 1);
 	if (mienemy == TARGET_MONSTERS) {
-		int i = GenerateRnd(Players[id]._pLevel) + GenerateRnd(2);
+		int i = vanilla::GenerateRnd(Players[id]._pLevel) + vanilla::GenerateRnd(2);
 		Missiles[mi]._midam = 8 * i + 16 + ((8 * i + 16) / 2);
 	} else {
 		auto &monster = Monsters[id];
-		Missiles[mi]._midam = monster.mMinDamage + GenerateRnd(monster.mMaxDamage - monster.mMinDamage + 1);
+		Missiles[mi]._midam = monster.mMinDamage + vanilla::GenerateRnd(monster.mMaxDamage - monster.mMinDamage + 1);
 	}
 }
 
@@ -2970,13 +2970,13 @@ void AddCbolt(int mi, Point src, Point dst, int midir, int8_t micaster, int id, 
 {
 	assert((DWORD)mi < MAXMISSILES);
 
-	Missiles[mi]._mirnd = GenerateRnd(15) + 1;
-	Missiles[mi]._midam = (micaster == 0) ? (GenerateRnd(Players[id]._pMagic / 4) + 1) : 15;
+	Missiles[mi]._mirnd = vanilla::GenerateRnd(15) + 1;
+	Missiles[mi]._midam = (micaster == 0) ? (vanilla::GenerateRnd(Players[id]._pMagic / 4) + 1) : 15;
 
 	if (src == dst) {
 		dst += static_cast<Direction>(midir);
 	}
-	Missiles[mi]._miAnimFrame = GenerateRnd(8) + 1;
+	Missiles[mi]._miAnimFrame = vanilla::GenerateRnd(8) + 1;
 	Missiles[mi]._mlid = AddLight(src, 5);
 
 	UpdateMissileVelocity(mi, src, dst, 8);
@@ -3003,7 +3003,7 @@ void AddHbolt(int mi, Point src, Point dst, int midir, int8_t /*micaster*/, int 
 	Missiles[mi]._miVar1 = src.x;
 	Missiles[mi]._miVar2 = src.y;
 	Missiles[mi]._mlid = AddLight(src, 8);
-	Missiles[mi]._midam = GenerateRnd(10) + Players[id]._pLevel + 9;
+	Missiles[mi]._midam = vanilla::GenerateRnd(10) + Players[id]._pLevel + 9;
 	UseMana(id, SPL_HBOLT);
 }
 
@@ -3186,8 +3186,8 @@ void MI_LArrow(int i)
 				mind = Players[p]._pILMinDam;
 				maxd = Players[p]._pILMaxDam;
 			} else {
-				mind = GenerateRnd(10) + 1 + currlevel;
-				maxd = GenerateRnd(10) + 1 + currlevel * 2;
+				mind = vanilla::GenerateRnd(10) + 1 + currlevel;
+				maxd = vanilla::GenerateRnd(10) + 1 + currlevel * 2;
 			}
 			MissileData[MIS_LARROW].mResist = MISR_LIGHTNING;
 			CheckMissileCol(i, mind, maxd, false, Missiles[i].position.tile, true);
@@ -3199,8 +3199,8 @@ void MI_LArrow(int i)
 				mind = Players[p]._pIFMinDam;
 				maxd = Players[p]._pIFMaxDam;
 			} else {
-				mind = GenerateRnd(10) + 1 + currlevel;
-				maxd = GenerateRnd(10) + 1 + currlevel * 2;
+				mind = vanilla::GenerateRnd(10) + 1 + currlevel;
+				maxd = vanilla::GenerateRnd(10) + 1 + currlevel * 2;
 			}
 			MissileData[MIS_FARROW].mResist = MISR_FIRE;
 			CheckMissileCol(i, mind, maxd, false, Missiles[i].position.tile, true);
@@ -3222,8 +3222,8 @@ void MI_LArrow(int i)
 				maxd = Monsters[p].mMaxDamage;
 			}
 		} else {
-			mind = GenerateRnd(10) + 1 + currlevel;
-			maxd = GenerateRnd(10) + 1 + currlevel * 2;
+			mind = vanilla::GenerateRnd(10) + 1 + currlevel;
+			maxd = vanilla::GenerateRnd(10) + 1 + currlevel * 2;
 		}
 
 		if (Missiles[i].position.tile != Missiles[i].position.start) {
@@ -3301,7 +3301,7 @@ void MI_Firebolt(int i)
 			if (Missiles[i]._micaster == TARGET_MONSTERS) {
 				switch (Missiles[i]._mitype) {
 				case MIS_FIREBOLT:
-					d = GenerateRnd(10) + (Players[p]._pMagic / 8) + Missiles[i]._mispllvl + 1;
+					d = vanilla::GenerateRnd(10) + (Players[p]._pMagic / 8) + Missiles[i]._mispllvl + 1;
 					break;
 				case MIS_FLARE:
 					d = 3 * Missiles[i]._mispllvl - (Players[p]._pMagic / 8) + (Players[p]._pMagic / 2);
@@ -3312,10 +3312,10 @@ void MI_Firebolt(int i)
 				}
 			} else {
 				auto &monster = Monsters[p];
-				d = monster.mMinDamage + GenerateRnd(monster.mMaxDamage - monster.mMinDamage + 1);
+				d = monster.mMinDamage + vanilla::GenerateRnd(monster.mMaxDamage - monster.mMinDamage + 1);
 			}
 		} else {
-			d = currlevel + GenerateRnd(2 * currlevel);
+			d = currlevel + vanilla::GenerateRnd(2 * currlevel);
 		}
 		if (Missiles[i].position.tile != Missiles[i].position.start) {
 			CheckMissileCol(i, d, d, false, Missiles[i].position.tile, false);
@@ -3437,7 +3437,7 @@ void MI_Firewall(int i)
 	Missiles[i]._mirange--;
 	if (Missiles[i]._mirange == Missiles[i]._miVar1) {
 		SetMissDir(i, 1);
-		Missiles[i]._miAnimFrame = GenerateRnd(11) + 1;
+		Missiles[i]._miAnimFrame = vanilla::GenerateRnd(11) + 1;
 	}
 	if (Missiles[i]._mirange == Missiles[i]._miAnimLen - 1) {
 		SetMissDir(i, 0);
@@ -3782,13 +3782,13 @@ void MI_Lightctrl(int i)
 	int id = Missiles[i]._misource;
 	if (id != -1) {
 		if (Missiles[i]._micaster == TARGET_MONSTERS) {
-			dam = (GenerateRnd(2) + GenerateRnd(Players[id]._pLevel) + 2) << 6;
+			dam = (vanilla::GenerateRnd(2) + vanilla::GenerateRnd(Players[id]._pLevel) + 2) << 6;
 		} else {
 			auto &monster = Monsters[id];
-			dam = 2 * (monster.mMinDamage + GenerateRnd(monster.mMaxDamage - monster.mMinDamage + 1));
+			dam = 2 * (monster.mMinDamage + vanilla::GenerateRnd(monster.mMaxDamage - monster.mMinDamage + 1));
 		}
 	} else {
-		dam = GenerateRnd(currlevel) + 2 * currlevel;
+		dam = vanilla::GenerateRnd(currlevel) + 2 * currlevel;
 	}
 
 	Missiles[i].position.traveled += Missiles[i].position.velocity;
@@ -4002,7 +4002,7 @@ void MI_Firemove(int i)
 	Missiles[i]._miVar1++;
 	if (Missiles[i]._miVar1 == Missiles[i]._miAnimLen) {
 		SetMissDir(i, 1);
-		Missiles[i]._miAnimFrame = GenerateRnd(11) + 1;
+		Missiles[i]._miAnimFrame = vanilla::GenerateRnd(11) + 1;
 	}
 	Missiles[i].position.traveled += Missiles[i].position.velocity;
 	UpdateMissilePos(i);

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -177,12 +177,12 @@ void InitMonster(MonsterStruct &monster, Direction rd, int mtype, Point position
 	monster.AnimInfo = {};
 	monster.AnimInfo.pCelSprite = animData.CelSpritesForDirections[rd] ? &*animData.CelSpritesForDirections[rd] : nullptr;
 	monster.AnimInfo.TicksPerFrame = animData.Rate;
-	monster.AnimInfo.TickCounterOfCurrentFrame = GenerateRnd(monster.AnimInfo.TicksPerFrame - 1);
+	monster.AnimInfo.TickCounterOfCurrentFrame = vanilla::GenerateRnd(monster.AnimInfo.TicksPerFrame - 1);
 	monster.AnimInfo.NumberOfFrames = animData.Frames;
-	monster.AnimInfo.CurrentFrame = GenerateRnd(monster.AnimInfo.NumberOfFrames - 1) + 1;
+	monster.AnimInfo.CurrentFrame = vanilla::GenerateRnd(monster.AnimInfo.NumberOfFrames - 1) + 1;
 
 	monster.mLevel = monsterType.MData->mLevel;
-	monster._mmaxhp = (monsterType.mMinHP + GenerateRnd(monsterType.mMaxHP - monsterType.mMinHP + 1)) << 6;
+	monster._mmaxhp = (monsterType.mMinHP + vanilla::GenerateRnd(monsterType.mMaxHP - monsterType.mMinHP + 1)) << 6;
 	if (monsterType.mtype == MT_DIABLO && !gbIsHellfire) {
 		monster._mmaxhp /= 2;
 		monster.mLevel -= 15;
@@ -207,8 +207,8 @@ void InitMonster(MonsterStruct &monster, Direction rd, int mtype, Point position
 	monster._uniqtype = 0;
 	monster._msquelch = 0;
 	monster.mlid = NO_LIGHT; // BUGFIX monsters initial light id should be -1 (fixed)
-	monster._mRndSeed = AdvanceRndSeed();
-	monster._mAISeed = AdvanceRndSeed();
+	monster._mRndSeed = vanilla::AdvanceRndSeed();
+	monster._mAISeed = vanilla::AdvanceRndSeed();
 	monster.mWhoHit = 0;
 	monster.mExp = monsterType.MData->mExp;
 	monster.mHit = monsterType.MData->mHit;
@@ -305,7 +305,7 @@ void PlaceMonster(int i, int mtype, int x, int y)
 	}
 	dMonster[x][y] = i + 1;
 
-	auto rd = static_cast<Direction>(GenerateRnd(8));
+	auto rd = static_cast<Direction>(vanilla::GenerateRnd(8));
 	InitMonster(Monsters[i], rd, mtype, { x, y });
 }
 
@@ -325,14 +325,14 @@ void PlaceGroup(int mtype, int num, int leaderAttributes, int leaderId)
 		int xp;
 		int yp;
 		if ((leaderAttributes & 1) != 0) {
-			int offset = GenerateRnd(8);
+			int offset = vanilla::GenerateRnd(8);
 			auto position = leader.position.tile + static_cast<Direction>(offset);
 			xp = position.x;
 			yp = position.y;
 		} else {
 			do {
-				xp = GenerateRnd(80) + 16;
-				yp = GenerateRnd(80) + 16;
+				xp = vanilla::GenerateRnd(80) + 16;
+				yp = vanilla::GenerateRnd(80) + 16;
 			} while (!MonstPlace(xp, yp));
 		}
 		int x1 = xp;
@@ -343,7 +343,7 @@ void PlaceGroup(int mtype, int num, int leaderAttributes, int leaderId)
 		}
 
 		int j = 0;
-		for (int try2 = 0; j < num && try2 < 100; xp += Displacement::fromDirection(static_cast<Direction>(GenerateRnd(8))).deltaX, yp += Displacement::fromDirection(static_cast<Direction>(GenerateRnd(8))).deltaX) { /// BUGFIX: `yp += Point.y`
+		for (int try2 = 0; j < num && try2 < 100; xp += Displacement::fromDirection(static_cast<Direction>(vanilla::GenerateRnd(8))).deltaX, yp += Displacement::fromDirection(static_cast<Direction>(vanilla::GenerateRnd(8))).deltaX) { /// BUGFIX: `yp += Point.y`
 			if (!MonstPlace(xp, yp)
 			    || (dTransVal[xp][yp] != dTransVal[x1][y1])
 			    || ((leaderAttributes & 2) != 0 && (abs(xp - x1) >= 4 || abs(yp - y1) >= 4))) {
@@ -366,7 +366,7 @@ void PlaceGroup(int mtype, int num, int leaderAttributes, int leaderId)
 
 				if (minion._mAi != AI_GARG) {
 					minion.AnimInfo.pCelSprite = &*minion.MType->GetAnimData(MonsterGraphic::Stand).CelSpritesForDirections[minion._mdir];
-					minion.AnimInfo.CurrentFrame = GenerateRnd(minion.AnimInfo.NumberOfFrames - 1) + 1;
+					minion.AnimInfo.CurrentFrame = vanilla::GenerateRnd(minion.AnimInfo.NumberOfFrames - 1) + 1;
 					minion._mFlags &= ~MFLAG_ALLOW_SPECIAL;
 					minion._mmode = MM_STAND;
 				}
@@ -406,8 +406,8 @@ void PlaceUniqueMonst(int uniqindex, int miniontype, int bosspacksize)
 	int xp;
 	int yp;
 	while (true) {
-		xp = GenerateRnd(80) + 16;
-		yp = GenerateRnd(80) + 16;
+		xp = vanilla::GenerateRnd(80) + 16;
+		yp = vanilla::GenerateRnd(80) + 16;
 		int count2 = 0;
 		for (int x = xp - 3; x < xp + 3; x++) {
 			for (int y = yp - 3; y < yp + 3; y++) {
@@ -605,7 +605,7 @@ void PlaceUniqueMonst(int uniqindex, int miniontype, int bosspacksize)
 
 	if (monster._mAi != AI_GARG) {
 		monster.AnimInfo.pCelSprite = &*monster.MType->GetAnimData(MonsterGraphic::Stand).CelSpritesForDirections[monster._mdir];
-		monster.AnimInfo.CurrentFrame = GenerateRnd(monster.AnimInfo.NumberOfFrames - 1) + 1;
+		monster.AnimInfo.CurrentFrame = vanilla::GenerateRnd(monster.AnimInfo.NumberOfFrames - 1) + 1;
 		monster._mFlags &= ~MFLAG_ALLOW_SPECIAL;
 		monster._mmode = MM_STAND;
 	}
@@ -656,12 +656,12 @@ void ClrAllMonsters()
 		monster.position.tile = { 0, 0 };
 		monster.position.future = { 0, 0 };
 		monster.position.old = { 0, 0 };
-		monster._mdir = static_cast<Direction>(GenerateRnd(8));
+		monster._mdir = static_cast<Direction>(vanilla::GenerateRnd(8));
 		monster.position.velocity = { 0, 0 };
 		monster.AnimInfo = {};
 		monster._mFlags = 0;
 		monster._mDelFlag = false;
-		monster._menemy = GenerateRnd(gbActivePlayers);
+		monster._menemy = vanilla::GenerateRnd(gbActivePlayers);
 		monster.enemyPosition = Players[monster._menemy].position.future;
 	}
 }
@@ -1144,8 +1144,8 @@ void Teleport(int i)
 
 	int mx = monster.enemyPosition.x;
 	int my = monster.enemyPosition.y;
-	int rx = 2 * GenerateRnd(2) - 1;
-	int ry = 2 * GenerateRnd(2) - 1;
+	int rx = 2 * vanilla::GenerateRnd(2) - 1;
+	int ry = 2 * vanilla::GenerateRnd(2) - 1;
 
 	bool done = false;
 
@@ -1218,7 +1218,7 @@ void StartMonsterDeath(int i, int pnum, bool sendmsg)
 		AddPlrMonstExper(monster.mLevel, monster.mExp, monster.mWhoHit);
 	MonsterKillCounts[monster.MType->mtype]++;
 	monster._mhitpoints = 0;
-	SetRndSeed(monster._mRndSeed);
+	vanilla::SetRndSeed(monster._mRndSeed);
 	SpawnLoot(i, sendmsg);
 	if (monster.MType->mtype == MT_DIABLO)
 		DiabloDeath(i, true);
@@ -1260,7 +1260,7 @@ void StartDeathFromMonster(int i, int mid)
 
 	MonsterKillCounts[monster.MType->mtype]++;
 	monster._mhitpoints = 0;
-	SetRndSeed(monster._mRndSeed);
+	vanilla::SetRndSeed(monster._mRndSeed);
 
 	SpawnLoot(i, true);
 
@@ -1322,7 +1322,7 @@ void StartHeal(MonsterStruct &monster)
 	monster.AnimInfo.CurrentFrame = monster.MType->GetAnimData(MonsterGraphic::Special).Frames;
 	monster._mFlags |= MFLAG_LOCK_ANIMATION;
 	monster._mmode = MM_HEAL;
-	monster._mVar1 = monster._mmaxhp / (16 * (GenerateRnd(5) + 4));
+	monster._mVar1 = monster._mmaxhp / (16 * (vanilla::GenerateRnd(5) + 4));
 }
 
 void SyncLightPosition(MonsterStruct &monster)
@@ -1404,12 +1404,12 @@ void MonsterAttackMonster(int i, int mid, int hper, int mind, int maxd)
 	assurance(monster.MType != nullptr, mid);
 
 	if (monster._mhitpoints >> 6 > 0 && (monster.MType->mtype != MT_ILLWEAV || monster._mgoal != MGOAL_RETREAT)) {
-		int hit = GenerateRnd(100);
+		int hit = vanilla::GenerateRnd(100);
 		if (monster._mmode == MM_STONE)
 			hit = 0;
 		bool unused;
 		if (!CheckMonsterHit(monster, &unused) && hit < hper) {
-			int dam = (mind + GenerateRnd(maxd - mind + 1)) << 6;
+			int dam = (mind + vanilla::GenerateRnd(maxd - mind + 1)) << 6;
 			monster._mhitpoints -= dam;
 			if (monster._mhitpoints >> 6 <= 0) {
 				if (monster._mmode == MM_STONE) {
@@ -1445,7 +1445,7 @@ void MonsterAttackPlayer(int i, int pnum, int hit, int minDam, int maxDam)
 	if (monster.position.tile.WalkingDistance(Players[pnum].position.tile) >= 2)
 		return;
 
-	int hper = GenerateRnd(100);
+	int hper = vanilla::GenerateRnd(100);
 #ifdef _DEBUG
 	if (debug_mode_dollar_sign || debug_mode_key_inverted_v)
 		hper = 1000;
@@ -1469,7 +1469,7 @@ void MonsterAttackPlayer(int i, int pnum, int hit, int minDam, int maxDam)
 		hit = 30;
 	int blkper = 100;
 	if ((Players[pnum]._pmode == PM_STAND || Players[pnum]._pmode == PM_ATTACK) && Players[pnum]._pBlockFlag) {
-		blkper = GenerateRnd(100);
+		blkper = vanilla::GenerateRnd(100);
 	}
 	int blk = Players[pnum]._pDexterity
 	    + Players[pnum]._pBaseToBlk
@@ -1486,11 +1486,11 @@ void MonsterAttackPlayer(int i, int pnum, int hit, int minDam, int maxDam)
 		StartPlrBlock(pnum, dir);
 		if (pnum == MyPlayerId && Players[pnum].wReflections > 0) {
 			Players[pnum].wReflections--;
-			int dam = GenerateRnd((maxDam - minDam + 1) << 6) + (minDam << 6);
+			int dam = vanilla::GenerateRnd((maxDam - minDam + 1) << 6) + (minDam << 6);
 			dam += Players[pnum]._pIGetHit << 6;
 			if (dam < 64)
 				dam = 64;
-			int mdam = dam * (GenerateRnd(10) + 20L) / 100;
+			int mdam = dam * (vanilla::GenerateRnd(10) + 20L) / 100;
 			monster._mhitpoints -= mdam;
 			dam -= mdam;
 			if (dam < 0)
@@ -1528,14 +1528,14 @@ void MonsterAttackPlayer(int i, int pnum, int hit, int minDam, int maxDam)
 			}
 		}
 	}
-	int dam = (minDam << 6) + GenerateRnd((maxDam - minDam + 1) << 6);
+	int dam = (minDam << 6) + vanilla::GenerateRnd((maxDam - minDam + 1) << 6);
 	dam += (Players[pnum]._pIGetHit << 6);
 	if (dam < 64)
 		dam = 64;
 	if (pnum == MyPlayerId) {
 		if (Players[pnum].wReflections > 0) {
 			Players[pnum].wReflections--;
-			int mdam = dam * (GenerateRnd(10) + 20L) / 100;
+			int mdam = dam * (vanilla::GenerateRnd(10) + 20L) / 100;
 			monster._mhitpoints -= mdam;
 			dam -= mdam;
 			if (dam < 0)
@@ -1548,7 +1548,7 @@ void MonsterAttackPlayer(int i, int pnum, int hit, int minDam, int maxDam)
 		ApplyPlrDamage(pnum, 0, 0, dam);
 	}
 	if ((Players[pnum]._pIFlags & ISPL_THORNS) != 0) {
-		int mdam = (GenerateRnd(3) + 1) << 6;
+		int mdam = (vanilla::GenerateRnd(3) + 1) << 6;
 		monster._mhitpoints -= mdam;
 		if (monster._mhitpoints >> 6 <= 0)
 			M_StartKill(i, pnum);
@@ -1924,7 +1924,7 @@ int AddSkeleton(Point position, Direction dir, bool inMap)
 		return -1;
 	}
 
-	int skeltypes = GenerateRnd(j);
+	int skeltypes = vanilla::GenerateRnd(j);
 	int m = 0;
 	for (int i = 0; m < LevelMonsterTypeCount && i <= skeltypes; m++) {
 		if (IsSkel(LevelMonsterTypes[m].mtype))
@@ -2009,11 +2009,11 @@ bool RandomWalk(int i, Direction md)
 {
 	Direction mdtemp = md;
 	bool ok = DirOK(i, md);
-	if (GenerateRnd(2) != 0)
+	if (vanilla::GenerateRnd(2) != 0)
 		ok = ok || (md = left[mdtemp], DirOK(i, md)) || (md = right[mdtemp], DirOK(i, md));
 	else
 		ok = ok || (md = right[mdtemp], DirOK(i, md)) || (md = left[mdtemp], DirOK(i, md));
-	if (GenerateRnd(2) != 0) {
+	if (vanilla::GenerateRnd(2) != 0) {
 		ok = ok
 		    || (md = right[right[mdtemp]], DirOK(i, md))
 		    || (md = left[left[mdtemp]], DirOK(i, md));
@@ -2031,7 +2031,7 @@ bool RandomWalk2(int i, Direction md)
 {
 	Direction mdtemp = md;
 	bool ok = DirOK(i, md);    // Can we continue in the same direction
-	if (GenerateRnd(2) != 0) { // Randomly go left or right
+	if (vanilla::GenerateRnd(2) != 0) { // Randomly go left or right
 		ok = ok || (mdtemp = left[md], DirOK(i, left[md])) || (mdtemp = right[md], DirOK(i, right[md]));
 	} else {
 		ok = ok || (mdtemp = right[md], DirOK(i, right[md])) || (mdtemp = left[md], DirOK(i, left[md]));
@@ -2238,19 +2238,19 @@ void AiAvoidance(int i, bool special)
 	Direction md = GetDirection(monster.position.tile, monster.position.last);
 	if (monster._msquelch < UINT8_MAX)
 		MonstCheckDoors(monster);
-	int v = GenerateRnd(100);
+	int v = vanilla::GenerateRnd(100);
 	if ((abs(mx) >= 2 || abs(my) >= 2) && monster._msquelch == UINT8_MAX && dTransVal[monster.position.tile.x][monster.position.tile.y] == dTransVal[fx][fy]) {
-		if (monster._mgoal == MGOAL_MOVE || ((abs(mx) >= 4 || abs(my) >= 4) && GenerateRnd(4) == 0)) {
+		if (monster._mgoal == MGOAL_MOVE || ((abs(mx) >= 4 || abs(my) >= 4) && vanilla::GenerateRnd(4) == 0)) {
 			if (monster._mgoal != MGOAL_MOVE) {
 				monster._mgoalvar1 = 0;
-				monster._mgoalvar2 = GenerateRnd(2);
+				monster._mgoalvar2 = vanilla::GenerateRnd(2);
 			}
 			monster._mgoal = MGOAL_MOVE;
 			int dist = std::max(abs(mx), abs(my));
 			if ((monster._mgoalvar1++ >= 2 * dist && DirOK(i, md)) || dTransVal[monster.position.tile.x][monster.position.tile.y] != dTransVal[fx][fy]) {
 				monster._mgoal = MGOAL_NORMAL;
 			} else if (!RoundWalk(i, md, &monster._mgoalvar2)) {
-				AiDelay(monster, GenerateRnd(10) + 10);
+				AiDelay(monster, vanilla::GenerateRnd(10) + 10);
 			}
 		}
 	} else {
@@ -2266,7 +2266,7 @@ void AiAvoidance(int i, bool special)
 			}
 		} else if (v < 2 * monster._mint + 23) {
 			monster._mdir = md;
-			if (special && monster._mhitpoints < (monster._mmaxhp / 2) && GenerateRnd(2) != 0)
+			if (special && monster._mhitpoints < (monster._mmaxhp / 2) && vanilla::GenerateRnd(2) != 0)
 				StartSpecialAttack(monster);
 			else
 				StartAttack(monster);
@@ -2295,9 +2295,9 @@ void AiRanged(int i, missile_id missileType, bool special)
 			MonstCheckDoors(monster);
 		monster._mdir = md;
 		if (monster._mVar1 == MM_RATTACK) {
-			AiDelay(monster, GenerateRnd(20));
+			AiDelay(monster, vanilla::GenerateRnd(20));
 		} else if (abs(mx) < 4 && abs(my) < 4) {
-			if (GenerateRnd(100) < 10 * (monster._mint + 7))
+			if (vanilla::GenerateRnd(100) < 10 * (monster._mint + 7))
 				RandomWalk(i, opposite[md]);
 		}
 		if (monster._mmode == MM_STAND) {
@@ -2337,13 +2337,13 @@ void AiRangedAvoidance(int i, missile_id missileType, bool checkdoors, int dam, 
 	Direction md = GetDirection(monster.position.tile, monster.position.last);
 	if (checkdoors && monster._msquelch < UINT8_MAX)
 		MonstCheckDoors(monster);
-	int v = GenerateRnd(10000);
+	int v = vanilla::GenerateRnd(10000);
 	int dist = std::max(abs(mx), abs(my));
 	if (dist >= 2 && monster._msquelch == UINT8_MAX && dTransVal[monster.position.tile.x][monster.position.tile.y] == dTransVal[fx][fy]) {
-		if (monster._mgoal == MGOAL_MOVE || (dist >= 3 && GenerateRnd(4 << lessmissiles) == 0)) {
+		if (monster._mgoal == MGOAL_MOVE || (dist >= 3 && vanilla::GenerateRnd(4 << lessmissiles) == 0)) {
 			if (monster._mgoal != MGOAL_MOVE) {
 				monster._mgoalvar1 = 0;
-				monster._mgoalvar2 = GenerateRnd(2);
+				monster._mgoalvar2 = vanilla::GenerateRnd(2);
 			}
 			monster._mgoal = MGOAL_MOVE;
 			if (monster._mgoalvar1++ >= 2 * dist && DirOK(i, md)) {
@@ -2364,7 +2364,7 @@ void AiRangedAvoidance(int i, missile_id missileType, bool checkdoors, int dam, 
 		    && LineClearMissile(monster.position.tile, { fx, fy })) {
 			StartRangedSpecialAttack(monster, missileType, dam);
 		} else if (dist >= 2) {
-			v = GenerateRnd(100);
+			v = vanilla::GenerateRnd(100);
 			if (v < 1000 * (monster._mint + 5)
 			    || ((monster._mVar1 == MM_WALK || monster._mVar1 == MM_WALK2 || monster._mVar1 == MM_WALK3) && monster._mVar2 == 0 && v < 1000 * (monster._mint + 8))) {
 				RandomWalk(i, md);
@@ -2375,7 +2375,7 @@ void AiRangedAvoidance(int i, missile_id missileType, bool checkdoors, int dam, 
 		}
 	}
 	if (monster._mmode == MM_STAND) {
-		AiDelay(monster, GenerateRnd(10) + 5);
+		AiDelay(monster, vanilla::GenerateRnd(10) + 5);
 	}
 }
 
@@ -2394,13 +2394,13 @@ void ZombieAi(int i)
 		return;
 	}
 
-	if (GenerateRnd(100) < 2 * monster._mint + 10) {
+	if (vanilla::GenerateRnd(100) < 2 * monster._mint + 10) {
 		int dist = monster.enemyPosition.WalkingDistance({ mx, my });
 		if (dist >= 2) {
 			if (dist >= 2 * monster._mint + 4) {
 				Direction md = monster._mdir;
-				if (GenerateRnd(100) < 2 * monster._mint + 20) {
-					md = static_cast<Direction>(GenerateRnd(8));
+				if (vanilla::GenerateRnd(100) < 2 * monster._mint + 20) {
+					md = static_cast<Direction>(vanilla::GenerateRnd(8));
 				}
 				DumbWalk(i, md);
 			} else {
@@ -2427,7 +2427,7 @@ void OverlordAi(int i)
 	int my = monster.position.tile.y - monster.enemyPosition.y;
 	Direction md = GetMonsterDirection(monster);
 	monster._mdir = md;
-	int v = GenerateRnd(100);
+	int v = vanilla::GenerateRnd(100);
 	if (abs(mx) >= 2 || abs(my) >= 2) {
 		if ((monster._mVar2 > 20 && v < 4 * monster._mint + 20)
 		    || ((monster._mVar1 == MM_WALK || monster._mVar1 == MM_WALK2 || monster._mVar1 == MM_WALK3)
@@ -2458,16 +2458,16 @@ void SkeletonAi(int i)
 	Direction md = GetDirection(monster.position.tile, monster.position.last);
 	monster._mdir = md;
 	if (abs(x) >= 2 || abs(y) >= 2) {
-		if (monster._mVar1 == MM_DELAY || (GenerateRnd(100) >= 35 - 4 * monster._mint)) {
+		if (monster._mVar1 == MM_DELAY || (vanilla::GenerateRnd(100) >= 35 - 4 * monster._mint)) {
 			RandomWalk(i, md);
 		} else {
-			AiDelay(monster, 15 - 2 * monster._mint + GenerateRnd(10));
+			AiDelay(monster, 15 - 2 * monster._mint + vanilla::GenerateRnd(10));
 		}
 	} else {
-		if (monster._mVar1 == MM_DELAY || (GenerateRnd(100) < 2 * monster._mint + 20)) {
+		if (monster._mVar1 == MM_DELAY || (vanilla::GenerateRnd(100) < 2 * monster._mint + 20)) {
 			StartAttack(monster);
 		} else {
-			AiDelay(monster, 2 * (5 - monster._mint) + GenerateRnd(10));
+			AiDelay(monster, 2 * (5 - monster._mint) + vanilla::GenerateRnd(10));
 		}
 	}
 
@@ -2488,7 +2488,7 @@ void SkeletonBowAi(int i)
 
 	Direction md = GetMonsterDirection(monster);
 	monster._mdir = md;
-	int v = GenerateRnd(100);
+	int v = vanilla::GenerateRnd(100);
 
 	bool walking = false;
 
@@ -2502,7 +2502,7 @@ void SkeletonBowAi(int i)
 	}
 
 	if (!walking) {
-		if (GenerateRnd(100) < 2 * monster._mint + 3) {
+		if (vanilla::GenerateRnd(100) < 2 * monster._mint + 3) {
 			if (LineClearMissile(monster.position.tile, monster.enemyPosition))
 				StartRangedAttack(monster, MIS_ARROW, 4);
 		}
@@ -2555,7 +2555,7 @@ void ScavengerAi(int i)
 				bool done = false;
 				int x;
 				int y;
-				if (GenerateRnd(2) != 0) {
+				if (vanilla::GenerateRnd(2) != 0) {
 					for (y = -4; y <= 4 && !done; y++) {
 						for (x = -4; x <= 4 && !done; x++) {
 							// BUGFIX: incorrect check of offset against limits of the dungeon
@@ -2618,19 +2618,19 @@ void RhinoAi(int i)
 	Direction md = GetDirection(monster.position.tile, monster.position.last);
 	if (monster._msquelch < UINT8_MAX)
 		MonstCheckDoors(monster);
-	int v = GenerateRnd(100);
+	int v = vanilla::GenerateRnd(100);
 	int dist = std::max(abs(mx), abs(my));
 	if (dist >= 2) {
-		if (monster._mgoal == MGOAL_MOVE || (dist >= 5 && GenerateRnd(4) != 0)) {
+		if (monster._mgoal == MGOAL_MOVE || (dist >= 5 && vanilla::GenerateRnd(4) != 0)) {
 			if (monster._mgoal != MGOAL_MOVE) {
 				monster._mgoalvar1 = 0;
-				monster._mgoalvar2 = GenerateRnd(2);
+				monster._mgoalvar2 = vanilla::GenerateRnd(2);
 			}
 			monster._mgoal = MGOAL_MOVE;
 			if (monster._mgoalvar1++ >= 2 * dist || dTransVal[monster.position.tile.x][monster.position.tile.y] != dTransVal[fx][fy]) {
 				monster._mgoal = MGOAL_NORMAL;
 			} else if (!RoundWalk(i, md, &monster._mgoalvar2)) {
-				AiDelay(monster, GenerateRnd(10) + 10);
+				AiDelay(monster, vanilla::GenerateRnd(10) + 10);
 			}
 		}
 	} else {
@@ -2648,12 +2648,12 @@ void RhinoAi(int i)
 			}
 		} else {
 			if (dist >= 2) {
-				v = GenerateRnd(100);
+				v = vanilla::GenerateRnd(100);
 				if (v >= 2 * monster._mint + 33
 				    && ((monster._mVar1 != MM_WALK && monster._mVar1 != MM_WALK2 && monster._mVar1 != MM_WALK3)
 				        || monster._mVar2 != 0
 				        || v >= 2 * monster._mint + 83)) {
-					AiDelay(monster, GenerateRnd(10) + 10);
+					AiDelay(monster, vanilla::GenerateRnd(10) + 10);
 				} else {
 					RandomWalk(i, md);
 				}
@@ -2700,7 +2700,7 @@ void FallenAi(int i)
 	}
 
 	if (monster.AnimInfo.CurrentFrame == monster.AnimInfo.NumberOfFrames) {
-		if (GenerateRnd(4) != 0) {
+		if (vanilla::GenerateRnd(4) != 0) {
 			return;
 		}
 		if ((monster._mFlags & MFLAG_NOHEAL) == 0) {
@@ -2762,19 +2762,19 @@ void LeoricAi(int i)
 	Direction md = GetDirection(monster.position.tile, monster.position.last);
 	if (monster._msquelch < UINT8_MAX)
 		MonstCheckDoors(monster);
-	int v = GenerateRnd(100);
+	int v = vanilla::GenerateRnd(100);
 	int dist = std::max(abs(mx), abs(my));
 	if (dist >= 2 && monster._msquelch == UINT8_MAX && dTransVal[monster.position.tile.x][monster.position.tile.y] == dTransVal[fx][fy]) {
-		if (monster._mgoal == MGOAL_MOVE || ((abs(mx) >= 3 || abs(my) >= 3) && GenerateRnd(4) == 0)) {
+		if (monster._mgoal == MGOAL_MOVE || ((abs(mx) >= 3 || abs(my) >= 3) && vanilla::GenerateRnd(4) == 0)) {
 			if (monster._mgoal != MGOAL_MOVE) {
 				monster._mgoalvar1 = 0;
-				monster._mgoalvar2 = GenerateRnd(2);
+				monster._mgoalvar2 = vanilla::GenerateRnd(2);
 			}
 			monster._mgoal = MGOAL_MOVE;
 			if ((monster._mgoalvar1++ >= 2 * dist && DirOK(i, md)) || dTransVal[monster.position.tile.x][monster.position.tile.y] != dTransVal[fx][fy]) {
 				monster._mgoal = MGOAL_NORMAL;
 			} else if (!RoundWalk(i, md, &monster._mgoalvar2)) {
-				AiDelay(monster, GenerateRnd(10) + 10);
+				AiDelay(monster, vanilla::GenerateRnd(10) + 10);
 			}
 		}
 	} else {
@@ -2791,10 +2791,10 @@ void LeoricAi(int i)
 			}
 		} else {
 			if (dist >= 2) {
-				v = GenerateRnd(100);
+				v = vanilla::GenerateRnd(100);
 				if (v >= monster._mint + 25
 				    && ((monster._mVar1 != MM_WALK && monster._mVar1 != MM_WALK2 && monster._mVar1 != MM_WALK3) || monster._mVar2 != 0 || (v >= monster._mint + 75))) {
-					AiDelay(monster, GenerateRnd(10) + 10);
+					AiDelay(monster, vanilla::GenerateRnd(10) + 10);
 				} else {
 					RandomWalk(i, md);
 				}
@@ -2822,13 +2822,13 @@ void BatAi(int i)
 	int yd = monster.position.tile.y - monster.enemyPosition.y;
 	Direction md = GetDirection(monster.position.tile, monster.position.last);
 	monster._mdir = md;
-	int v = GenerateRnd(100);
+	int v = vanilla::GenerateRnd(100);
 	if (monster._mgoal == MGOAL_RETREAT) {
 		if (monster._mgoalvar1 == 0) {
 			RandomWalk(i, opposite[md]);
 			monster._mgoalvar1++;
 		} else {
-			if (GenerateRnd(2) != 0)
+			if (vanilla::GenerateRnd(2) != 0)
 				RandomWalk(i, left[md]);
 			else
 				RandomWalk(i, right[md]);
@@ -2859,7 +2859,7 @@ void BatAi(int i)
 		monster._mgoal = MGOAL_RETREAT;
 		monster._mgoalvar1 = 0;
 		if (monster.MType->mtype == MT_FAMILIAR) {
-			AddMissile(monster.enemyPosition, { monster.enemyPosition.x + 1, 0 }, -1, MIS_LIGHTNING, TARGET_PLAYERS, i, GenerateRnd(10) + 1, 0);
+			AddMissile(monster.enemyPosition, { monster.enemyPosition.x + 1, 0 }, -1, MIS_LIGHTNING, TARGET_PLAYERS, i, vanilla::GenerateRnd(10) + 1, 0);
 		}
 	}
 
@@ -2964,14 +2964,14 @@ void SneakAi(int i)
 			md = GetDirection(monster.position.tile, Players[monster._menemy].position.last);
 		md = opposite[md];
 		if (monster.MType->mtype == MT_UNSEEN) {
-			if (GenerateRnd(2) != 0)
+			if (vanilla::GenerateRnd(2) != 0)
 				md = left[md];
 			else
 				md = right[md];
 		}
 	}
 	monster._mdir = md;
-	int v = GenerateRnd(100);
+	int v = vanilla::GenerateRnd(100);
 	if (abs(mx) < dist && abs(my) < dist && (monster._mFlags & MFLAG_HIDDEN) != 0) {
 		StartFadein(monster, md, false);
 	} else {
@@ -3028,7 +3028,7 @@ void FiremanAi(int i)
 			StartRangedAttack(monster, MIS_KRULL, 4);
 			monster._mgoalvar1++;
 		} else {
-			AiDelay(monster, GenerateRnd(10) + 5);
+			AiDelay(monster, vanilla::GenerateRnd(10) + 5);
 			monster._mgoalvar1++;
 		}
 	} else if (monster._mgoal == MGOAL_RETREAT) {
@@ -3036,7 +3036,7 @@ void FiremanAi(int i)
 		monster._mgoal = MGOAL_ATTACK2;
 	}
 	monster._mdir = md;
-	AdvanceRndSeed();
+	vanilla::AdvanceRndSeed();
 	if (monster._mmode != MM_STAND)
 		return;
 
@@ -3177,7 +3177,7 @@ void SnakeAi(int i)
 				dMonster[monster.position.tile.x][monster.position.tile.y] = -(i + 1);
 				monster._mmode = MM_CHARGE;
 			}
-		} else if (monster._mVar1 == MM_DELAY || GenerateRnd(100) >= 35 - 2 * monster._mint) {
+		} else if (monster._mVar1 == MM_DELAY || vanilla::GenerateRnd(100) >= 35 - 2 * monster._mint) {
 			if (pattern[monster._mgoalvar1] == -1)
 				md = left[md];
 			else if (pattern[monster._mgoalvar1] == 1)
@@ -3202,15 +3202,15 @@ void SnakeAi(int i)
 			if (!DumbWalk(i, md))
 				RandomWalk2(i, monster._mdir);
 		} else {
-			AiDelay(monster, 15 - monster._mint + GenerateRnd(10));
+			AiDelay(monster, 15 - monster._mint + vanilla::GenerateRnd(10));
 		}
 	} else {
 		if (monster._mVar1 == MM_DELAY
 		    || monster._mVar1 == MM_CHARGE
-		    || (GenerateRnd(100) < monster._mint + 20)) {
+		    || (vanilla::GenerateRnd(100) < monster._mint + 20)) {
 			StartAttack(monster);
 		} else
-			AiDelay(monster, 10 - monster._mint + GenerateRnd(10));
+			AiDelay(monster, 10 - monster._mint + vanilla::GenerateRnd(10));
 	}
 
 	monster.CheckStandAnimationIsLoaded(monster._mdir);
@@ -3231,7 +3231,7 @@ void CounselorAi(int i)
 	Direction md = GetDirection(monster.position.tile, monster.position.last);
 	if (monster._msquelch < UINT8_MAX)
 		MonstCheckDoors(monster);
-	int v = GenerateRnd(100);
+	int v = vanilla::GenerateRnd(100);
 	if (monster._mgoal == MGOAL_RETREAT) {
 		if (monster._mgoalvar1++ <= 3)
 			RandomWalk(i, opposite[md]);
@@ -3253,13 +3253,13 @@ void CounselorAi(int i)
 		if (abs(mx) >= 2 || abs(my) >= 2) {
 			if (v < 5 * (monster._mint + 10) && LineClearMissile(monster.position.tile, { fx, fy })) {
 				constexpr missile_id MissileTypes[4] = { MIS_FIREBOLT, MIS_CBOLT, MIS_LIGHTCTRL, MIS_FIREBALL };
-				StartRangedAttack(monster, MissileTypes[monster._mint], monster.mMinDamage + GenerateRnd(monster.mMaxDamage - monster.mMinDamage + 1));
-			} else if (GenerateRnd(100) < 30) {
+				StartRangedAttack(monster, MissileTypes[monster._mint], monster.mMinDamage + vanilla::GenerateRnd(monster.mMaxDamage - monster.mMinDamage + 1));
+			} else if (vanilla::GenerateRnd(100) < 30) {
 				monster._mgoal = MGOAL_MOVE;
 				monster._mgoalvar1 = 0;
 				StartFadeout(monster, md, false);
 			} else
-				AiDelay(monster, GenerateRnd(10) + 2 * (5 - monster._mint));
+				AiDelay(monster, vanilla::GenerateRnd(10) + 2 * (5 - monster._mint));
 		} else {
 			monster._mdir = md;
 			if (monster._mhitpoints < (monster._mmaxhp / 2)) {
@@ -3267,16 +3267,16 @@ void CounselorAi(int i)
 				monster._mgoalvar1 = 0;
 				StartFadeout(monster, md, false);
 			} else if (monster._mVar1 == MM_DELAY
-			    || GenerateRnd(100) < 2 * monster._mint + 20) {
+			    || vanilla::GenerateRnd(100) < 2 * monster._mint + 20) {
 				StartRangedAttack(monster, MIS_NULL, 0);
 				AddMissile(monster.position.tile, { 0, 0 }, monster._mdir, MIS_FLASH, TARGET_PLAYERS, i, 4, 0);
 				AddMissile(monster.position.tile, { 0, 0 }, monster._mdir, MIS_FLASH2, TARGET_PLAYERS, i, 4, 0);
 			} else
-				AiDelay(monster, GenerateRnd(10) + 2 * (5 - monster._mint));
+				AiDelay(monster, vanilla::GenerateRnd(10) + 2 * (5 - monster._mint));
 		}
 	}
 	if (monster._mmode == MM_STAND) {
-		AiDelay(monster, GenerateRnd(10) + 5);
+		AiDelay(monster, vanilla::GenerateRnd(10) + 5);
 	}
 }
 
@@ -3336,13 +3336,13 @@ void MegaAi(int i)
 	Direction md = GetDirection(monster.position.tile, monster.position.last);
 	if (monster._msquelch < UINT8_MAX)
 		MonstCheckDoors(monster);
-	int v = GenerateRnd(100);
+	int v = vanilla::GenerateRnd(100);
 	int dist = std::max(abs(mx), abs(my));
 	if (dist >= 2 && monster._msquelch == UINT8_MAX && dTransVal[monster.position.tile.x][monster.position.tile.y] == dTransVal[fx][fy]) {
 		if (monster._mgoal == MGOAL_MOVE || dist >= 3) {
 			if (monster._mgoal != MGOAL_MOVE) {
 				monster._mgoalvar1 = 0;
-				monster._mgoalvar2 = GenerateRnd(2);
+				monster._mgoalvar2 = vanilla::GenerateRnd(2);
 			}
 			monster._mgoal = MGOAL_MOVE;
 			monster._mgoalvar3 = 4;
@@ -3359,7 +3359,7 @@ void MegaAi(int i)
 		if (((dist >= 3 && v < 5 * (monster._mint + 2)) || v < 5 * (monster._mint + 1) || monster._mgoalvar3 == 4) && LineClearMissile(monster.position.tile, { fx, fy })) {
 			StartRangedSpecialAttack(monster, MIS_FLAMEC, 0);
 		} else if (dist >= 2) {
-			v = GenerateRnd(100);
+			v = vanilla::GenerateRnd(100);
 			if (v < 2 * (5 * monster._mint + 25)
 			    || ((monster._mVar1 == MM_WALK || monster._mVar1 == MM_WALK2 || monster._mVar1 == MM_WALK3)
 			        && monster._mVar2 == 0
@@ -3367,9 +3367,9 @@ void MegaAi(int i)
 				RandomWalk(i, md);
 			}
 		} else {
-			if (GenerateRnd(100) < 10 * (monster._mint + 4)) {
+			if (vanilla::GenerateRnd(100) < 10 * (monster._mint + 4)) {
 				monster._mdir = md;
-				if (GenerateRnd(2) != 0)
+				if (vanilla::GenerateRnd(2) != 0)
 					StartAttack(monster);
 				else
 					StartRangedSpecialAttack(monster, MIS_FLAMEC, 0);
@@ -3378,7 +3378,7 @@ void MegaAi(int i)
 		monster._mgoalvar3 = 1;
 	}
 	if (monster._mmode == MM_STAND) {
-		AiDelay(monster, GenerateRnd(10) + 5);
+		AiDelay(monster, vanilla::GenerateRnd(10) + 5);
 	}
 }
 
@@ -3552,21 +3552,21 @@ void HorkDemonAi(int i)
 		MonstCheckDoors(monster);
 	}
 
-	int v = GenerateRnd(100);
+	int v = vanilla::GenerateRnd(100);
 
 	if (abs(mx) < 2 && abs(my) < 2) {
 		monster._mgoal = MGOAL_NORMAL;
-	} else if (monster._mgoal == 4 || ((abs(mx) >= 5 || abs(my) >= 5) && GenerateRnd(4) != 0)) {
+	} else if (monster._mgoal == 4 || ((abs(mx) >= 5 || abs(my) >= 5) && vanilla::GenerateRnd(4) != 0)) {
 		if (monster._mgoal != 4) {
 			monster._mgoalvar1 = 0;
-			monster._mgoalvar2 = GenerateRnd(2);
+			monster._mgoalvar2 = vanilla::GenerateRnd(2);
 		}
 		monster._mgoal = MGOAL_MOVE;
 		int dist = std::max(abs(mx), abs(my));
 		if (monster._mgoalvar1++ >= 2 * dist || dTransVal[monster.position.tile.x][monster.position.tile.y] != dTransVal[fx][fy]) {
 			monster._mgoal = MGOAL_NORMAL;
 		} else if (!RoundWalk(i, md, &monster._mgoalvar2)) {
-			AiDelay(monster, GenerateRnd(10) + 10);
+			AiDelay(monster, vanilla::GenerateRnd(10) + 10);
 		}
 	}
 
@@ -3582,12 +3582,12 @@ void HorkDemonAi(int i)
 				StartAttack(monster);
 			}
 		} else {
-			v = GenerateRnd(100);
+			v = vanilla::GenerateRnd(100);
 			if (v < 2 * monster._mint + 33
 			    || ((monster._mVar1 == MM_WALK || monster._mVar1 == MM_WALK2 || monster._mVar1 == MM_WALK3) && monster._mVar2 == 0 && v < 2 * monster._mint + 83)) {
 				RandomWalk(i, md);
 			} else {
-				AiDelay(monster, GenerateRnd(10) + 10);
+				AiDelay(monster, vanilla::GenerateRnd(10) + 10);
 			}
 		}
 	}
@@ -3781,7 +3781,7 @@ void GetLevelMTypes()
 					}
 				}
 			}
-			AddMonsterType(skeltypes[GenerateRnd(nt)], PLACE_SCATTER);
+			AddMonsterType(skeltypes[vanilla::GenerateRnd(nt)], PLACE_SCATTER);
 		}
 
 		nt = 0;
@@ -3815,7 +3815,7 @@ void GetLevelMTypes()
 				}
 
 				if (nt != 0) {
-					int i = GenerateRnd(nt);
+					int i = vanilla::GenerateRnd(nt);
 					AddMonsterType(typelist[i], PLACE_SCATTER);
 					typelist[i] = typelist[--nt];
 				}
@@ -4017,13 +4017,13 @@ void InitMonsters()
 			}
 		}
 		while (ActiveMonsterCount < totalmonsters) {
-			int mtype = scattertypes[GenerateRnd(numscattypes)];
-			if (currlevel == 1 || GenerateRnd(2) == 0)
+			int mtype = scattertypes[vanilla::GenerateRnd(numscattypes)];
+			if (currlevel == 1 || vanilla::GenerateRnd(2) == 0)
 				na = 1;
 			else if (currlevel == 2 || (currlevel >= 21 && currlevel <= 24))
-				na = GenerateRnd(2) + 2;
+				na = vanilla::GenerateRnd(2) + 2;
 			else
-				na = GenerateRnd(3) + 3;
+				na = vanilla::GenerateRnd(3) + 3;
 			PlaceGroup(mtype, na, 0, 0);
 		}
 	}
@@ -4465,8 +4465,8 @@ void ProcessMonsters()
 		auto &monster = Monsters[mi];
 		bool raflag = false;
 		if (gbIsMultiplayer) {
-			SetRndSeed(monster._mAISeed);
-			monster._mAISeed = AdvanceRndSeed();
+			vanilla::SetRndSeed(monster._mAISeed);
+			monster._mAISeed = vanilla::AdvanceRndSeed();
 		}
 		if ((monster._mFlags & MFLAG_NOHEAL) == 0 && monster._mhitpoints < monster._mmaxhp && monster._mhitpoints >> 6 > 0) {
 			if (monster.mLevel > 1) {
@@ -4927,7 +4927,7 @@ void PlayEffect(MonsterStruct &monster, int mode)
 		return;
 	}
 
-	int sndIdx = GenerateRnd(2);
+	int sndIdx = vanilla::GenerateRnd(2);
 	if (!gbSndInited || !gbSoundOn || gbBufferMsgs != 0) {
 		return;
 	}
@@ -5059,7 +5059,7 @@ bool SpawnSkeleton(int ii, Point position)
 		return false;
 	}
 
-	int rs = GenerateRnd(15) + 1;
+	int rs = vanilla::GenerateRnd(15) + 1;
 	int x2 = 0;
 	int y2 = 0;
 	while (rs > 0) {

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -383,7 +383,7 @@ void DeltaLeaveSync(BYTE bLevel)
 	if (!gbIsMultiplayer)
 		return;
 	if (currlevel == 0)
-		glSeedTbl[0] = AdvanceRndSeed();
+		glSeedTbl[0] = vanilla::AdvanceRndSeed();
 	if (currlevel <= 0)
 		return;
 

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -700,7 +700,7 @@ void NetClose()
 bool NetInit(bool bSinglePlayer)
 {
 	while (true) {
-		SetRndSeed(0);
+		vanilla::SetRndSeed(0);
 		sgGameInitInfo.size = sizeof(sgGameInitInfo);
 		sgGameInitInfo.dwSeed = time(nullptr);
 		sgGameInitInfo.programid = GAME_ID;
@@ -757,11 +757,11 @@ bool NetInit(bool bSinglePlayer)
 		NetClose();
 		gbSelectProvider = false;
 	}
-	SetRndSeed(sgGameInitInfo.dwSeed);
+	vanilla::SetRndSeed(sgGameInitInfo.dwSeed);
 	gnTickDelay = 1000 / sgGameInitInfo.nTickRate;
 
 	for (int i = 0; i < NUMLEVELS; i++) {
-		glSeedTbl[i] = AdvanceRndSeed();
+		glSeedTbl[i] = vanilla::AdvanceRndSeed();
 		gnLevelTypeTbl[i] = InitLevelType(i);
 	}
 	if (!SNetGetGameInfo(GAMEINFO_NAME, szPlayerName, 128))

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -357,12 +357,12 @@ static bool WallTrapLocOkK(int xp, int yp)
 
 void InitRndLocObj(int min, int max, _object_id objtype)
 {
-	int numobjs = GenerateRnd(max - min) + min;
+	int numobjs = vanilla::GenerateRnd(max - min) + min;
 
 	for (int i = 0; i < numobjs; i++) {
 		while (true) {
-			int xp = GenerateRnd(80) + 16;
-			int yp = GenerateRnd(80) + 16;
+			int xp = vanilla::GenerateRnd(80) + 16;
+			int yp = vanilla::GenerateRnd(80) + 16;
 			if (RndLocOk(xp - 1, yp - 1)
 			    && RndLocOk(xp, yp - 1)
 			    && RndLocOk(xp + 1, yp - 1)
@@ -381,11 +381,11 @@ void InitRndLocObj(int min, int max, _object_id objtype)
 
 void InitRndLocBigObj(int min, int max, _object_id objtype)
 {
-	int numobjs = GenerateRnd(max - min) + min;
+	int numobjs = vanilla::GenerateRnd(max - min) + min;
 	for (int i = 0; i < numobjs; i++) {
 		while (true) {
-			int xp = GenerateRnd(80) + 16;
-			int yp = GenerateRnd(80) + 16;
+			int xp = vanilla::GenerateRnd(80) + 16;
+			int yp = vanilla::GenerateRnd(80) + 16;
 			if (RndLocOk(xp - 1, yp - 2)
 			    && RndLocOk(xp, yp - 2)
 			    && RndLocOk(xp + 1, yp - 2)
@@ -407,7 +407,7 @@ void InitRndLocBigObj(int min, int max, _object_id objtype)
 
 void InitRndLocObj5x5(int min, int max, _object_id objtype)
 {
-	int numobjs = min + GenerateRnd(max - min);
+	int numobjs = min + vanilla::GenerateRnd(max - min);
 	for (int i = 0; i < numobjs; i++) {
 		int xp;
 		int yp;
@@ -415,8 +415,8 @@ void InitRndLocObj5x5(int min, int max, _object_id objtype)
 		bool exit = false;
 		while (!exit) {
 			exit = true;
-			xp = GenerateRnd(80) + 16;
-			yp = GenerateRnd(80) + 16;
+			xp = vanilla::GenerateRnd(80) + 16;
+			yp = vanilla::GenerateRnd(80) + 16;
 			for (int n = -2; n <= 2; n++) {
 				for (int m = -2; m <= 2; m++) {
 					if (!RndLocOk(xp + m, yp + n))
@@ -494,8 +494,8 @@ void AddBookLever(Rectangle affectedArea, _speech_id msg)
 	bool exit = false;
 	while (!exit) {
 		exit = true;
-		xp = GenerateRnd(80) + 16;
-		yp = GenerateRnd(80) + 16;
+		xp = vanilla::GenerateRnd(80) + 16;
+		yp = vanilla::GenerateRnd(80) + 16;
 		for (int n = -2; n <= 2; n++) {
 			for (int m = -2; m <= 2; m++) {
 				if (!RndLocOk(xp + m, yp + n))
@@ -526,29 +526,29 @@ void AddBookLever(Rectangle affectedArea, _speech_id msg)
 void InitRndBarrels()
 {
 	/** number of groups of barrels to generate */
-	int numobjs = GenerateRnd(5) + 3;
+	int numobjs = vanilla::GenerateRnd(5) + 3;
 	for (int i = 0; i < numobjs; i++) {
 		int xp;
 		int yp;
 		do {
-			xp = GenerateRnd(80) + 16;
-			yp = GenerateRnd(80) + 16;
+			xp = vanilla::GenerateRnd(80) + 16;
+			yp = vanilla::GenerateRnd(80) + 16;
 		} while (!RndLocOk(xp, yp));
-		_object_id o = (GenerateRnd(4) != 0) ? OBJ_BARREL : OBJ_BARRELEX;
+		_object_id o = (vanilla::GenerateRnd(4) != 0) ? OBJ_BARREL : OBJ_BARRELEX;
 		AddObject(o, { xp, yp });
 		bool found = true;
 		/** regulates chance to stop placing barrels in current group */
 		int p = 0;
 		/** number of barrels in current group */
 		int c = 1;
-		while (GenerateRnd(p) == 0 && found) {
+		while (vanilla::GenerateRnd(p) == 0 && found) {
 			/** number of tries of placing next barrel in current group */
 			int t = 0;
 			found = false;
 			while (true) {
 				if (t >= 3)
 					break;
-				int dir = GenerateRnd(8);
+				int dir = vanilla::GenerateRnd(8);
 				xp += bxadd[dir];
 				yp += byadd[dir];
 				found = RndLocOk(xp, yp);
@@ -557,7 +557,7 @@ void InitRndBarrels()
 					break;
 			}
 			if (found) {
-				o = (GenerateRnd(5) != 0) ? OBJ_BARREL : OBJ_BARRELEX;
+				o = (vanilla::GenerateRnd(5) != 0) ? OBJ_BARREL : OBJ_BARRELEX;
 				AddObject(o, { xp, yp });
 				c++;
 			}
@@ -633,16 +633,16 @@ void AddL2Torches()
 				continue;
 
 			int pn = dPiece[i][j];
-			if (pn == 1 && GenerateRnd(3) == 0)
+			if (pn == 1 && vanilla::GenerateRnd(3) == 0)
 				AddObject(OBJ_TORCHL2, { i, j });
 
-			if (pn == 5 && GenerateRnd(3) == 0)
+			if (pn == 5 && vanilla::GenerateRnd(3) == 0)
 				AddObject(OBJ_TORCHR2, { i, j });
 
-			if (pn == 37 && GenerateRnd(10) == 0 && dObject[i - 1][j] == 0)
+			if (pn == 37 && vanilla::GenerateRnd(10) == 0 && dObject[i - 1][j] == 0)
 				AddObject(OBJ_TORCHL, { i - 1, j });
 
-			if (pn == 41 && GenerateRnd(10) == 0 && dObject[i][j - 1] == 0)
+			if (pn == 41 && vanilla::GenerateRnd(10) == 0 && dObject[i][j - 1] == 0)
 				AddObject(OBJ_TORCHR, { i, j - 1 });
 		}
 	}
@@ -661,14 +661,14 @@ void AddObjTraps()
 		rndv = 25;
 	for (int j = 0; j < MAXDUNY; j++) {
 		for (int i = 0; i < MAXDUNX; i++) {
-			if (dObject[i][j] <= 0 || GenerateRnd(100) >= rndv)
+			if (dObject[i][j] <= 0 || vanilla::GenerateRnd(100) >= rndv)
 				continue;
 
 			int8_t oi = dObject[i][j] - 1;
 			if (!AllObjects[Objects[oi]._otype].oTrapFlag)
 				continue;
 
-			if (GenerateRnd(2) == 0) {
+			if (vanilla::GenerateRnd(2) == 0) {
 				int xp = i - 1;
 				while (!nSolidTable[dPiece[xp][j]]) // BUGFIX: check if xp >= 0
 					xp--;
@@ -705,7 +705,7 @@ void AddChestTraps()
 		for (int i = 0; i < MAXDUNX; i++) { // NOLINT(modernize-loop-convert)
 			if (dObject[i][j] > 0) {
 				int8_t oi = dObject[i][j] - 1;
-				if (Objects[oi]._otype >= OBJ_CHEST1 && Objects[oi]._otype <= OBJ_CHEST3 && !Objects[oi]._oTrapFlag && GenerateRnd(100) < 10) {
+				if (Objects[oi]._otype >= OBJ_CHEST1 && Objects[oi]._otype <= OBJ_CHEST3 && !Objects[oi]._oTrapFlag && vanilla::GenerateRnd(100) < 10) {
 					switch (Objects[oi]._otype) {
 					case OBJ_CHEST1:
 						Objects[oi]._otype = OBJ_TCHEST1;
@@ -721,9 +721,9 @@ void AddChestTraps()
 					}
 					Objects[oi]._oTrapFlag = true;
 					if (leveltype == DTYPE_CATACOMBS) {
-						Objects[oi]._oVar4 = GenerateRnd(2);
+						Objects[oi]._oVar4 = vanilla::GenerateRnd(2);
 					} else {
-						Objects[oi]._oVar4 = GenerateRnd(gbIsHellfire ? 6 : 3);
+						Objects[oi]._oVar4 = vanilla::GenerateRnd(gbIsHellfire ? 6 : 3);
 					}
 				}
 			}
@@ -812,8 +812,8 @@ void AddCryptStoryBook(int s)
 	bool exit = false;
 	while (!exit) {
 		exit = true;
-		xp = GenerateRnd(80) + 16;
-		yp = GenerateRnd(80) + 16;
+		xp = vanilla::GenerateRnd(80) + 16;
+		yp = vanilla::GenerateRnd(80) + 16;
 		for (int n = -2; n <= 2; n++) {
 			for (int m = -3; m <= 3; m++) {
 				if (!RndLocOk(xp + m, yp + n))
@@ -838,7 +838,7 @@ void AddCryptStoryBook(int s)
 void AddNakrulGate()
 {
 	AddNakrulLeaver();
-	switch (GenerateRnd(6)) {
+	switch (vanilla::GenerateRnd(6)) {
 	case 0:
 		AddNakrulBook(6, UberRow + 3, UberCol);
 		AddNakrulBook(7, UberRow + 2, UberCol - 3);
@@ -885,8 +885,8 @@ void AddStoryBooks()
 	bool done = false;
 	while (!done) {
 		done = true;
-		xp = GenerateRnd(80) + 16;
-		yp = GenerateRnd(80) + 16;
+		xp = vanilla::GenerateRnd(80) + 16;
+		yp = vanilla::GenerateRnd(80) + 16;
 		for (int yy = -2; yy <= 2; yy++) {
 			for (int xx = -3; xx <= 3; xx++) {
 				if (!RndLocOk(xx + xp, yy + yp))
@@ -916,12 +916,12 @@ void AddHookedBodies(int freq)
 			int ii = 16 + i * 2;
 			if (dungeon[i][j] != 1 && dungeon[i][j] != 2)
 				continue;
-			if (GenerateRnd(freq) != 0)
+			if (vanilla::GenerateRnd(freq) != 0)
 				continue;
 			if (!SkipThemeRoom(i, j))
 				continue;
 			if (dungeon[i][j] == 1 && dungeon[i + 1][j] == 6) {
-				switch (GenerateRnd(3)) {
+				switch (vanilla::GenerateRnd(3)) {
 				case 0:
 					AddObject(OBJ_TORTURE1, { ii + 1, jj });
 					break;
@@ -935,7 +935,7 @@ void AddHookedBodies(int freq)
 				continue;
 			}
 			if (dungeon[i][j] == 2 && dungeon[i][j + 1] == 6) {
-				switch (GenerateRnd(2)) {
+				switch (vanilla::GenerateRnd(2)) {
 				case 0:
 					AddObject(OBJ_TORTURE3, { ii, jj });
 					break;
@@ -970,8 +970,8 @@ void AddLazStand()
 	bool found = false;
 	while (!found) {
 		found = true;
-		xp = GenerateRnd(80) + 16;
-		yp = GenerateRnd(80) + 16;
+		xp = vanilla::GenerateRnd(80) + 16;
+		yp = vanilla::GenerateRnd(80) + 16;
 		for (int yy = -3; yy <= 3; yy++) {
 			for (int xx = -2; xx <= 3; xx++) {
 				if (!RndLocOk(xp + xx, yp + yy))
@@ -1006,7 +1006,7 @@ void InitObjects()
 		AddDiabObjs();
 	} else {
 		ApplyObjectLighting = true;
-		AdvanceRndSeed();
+		vanilla::AdvanceRndSeed();
 		if (currlevel == 9 && !gbIsMultiplayer)
 			AddSlainHero();
 		if (currlevel == Quests[Q_MUSHROOM]._qlevel && Quests[Q_MUSHROOM]._qactive == QUEST_INIT)
@@ -1236,9 +1236,9 @@ void SetupObject(int i, Point position, _object_id ot)
 	Objects[i]._oAnimFlag = AllObjects[ot].oAnimFlag;
 	if (AllObjects[ot].oAnimFlag != 0) {
 		Objects[i]._oAnimDelay = AllObjects[ot].oAnimDelay;
-		Objects[i]._oAnimCnt = GenerateRnd(AllObjects[ot].oAnimDelay);
+		Objects[i]._oAnimCnt = vanilla::GenerateRnd(AllObjects[ot].oAnimDelay);
 		Objects[i]._oAnimLen = AllObjects[ot].oAnimLen;
-		Objects[i]._oAnimFrame = GenerateRnd(AllObjects[ot].oAnimLen - 1) + 1;
+		Objects[i]._oAnimFrame = vanilla::GenerateRnd(AllObjects[ot].oAnimLen - 1) + 1;
 	} else {
 		Objects[i]._oAnimDelay = 1000;
 		Objects[i]._oAnimCnt = 0;
@@ -1272,9 +1272,9 @@ void AddL1Door(int i, Point position, _object_id objectType)
 
 void AddChest(int i, int t)
 {
-	if (GenerateRnd(2) == 0)
+	if (vanilla::GenerateRnd(2) == 0)
 		Objects[i]._oAnimFrame += 3;
-	Objects[i]._oRndSeed = AdvanceRndSeed();
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
 	switch (t) {
 	case OBJ_CHEST1:
 	case OBJ_TCHEST1:
@@ -1282,7 +1282,7 @@ void AddChest(int i, int t)
 			Objects[i]._oVar1 = 1;
 			break;
 		}
-		Objects[i]._oVar1 = GenerateRnd(2);
+		Objects[i]._oVar1 = vanilla::GenerateRnd(2);
 		break;
 	case OBJ_TCHEST2:
 	case OBJ_CHEST2:
@@ -1290,7 +1290,7 @@ void AddChest(int i, int t)
 			Objects[i]._oVar1 = 2;
 			break;
 		}
-		Objects[i]._oVar1 = GenerateRnd(3);
+		Objects[i]._oVar1 = vanilla::GenerateRnd(3);
 		break;
 	case OBJ_TCHEST3:
 	case OBJ_CHEST3:
@@ -1298,10 +1298,10 @@ void AddChest(int i, int t)
 			Objects[i]._oVar1 = 3;
 			break;
 		}
-		Objects[i]._oVar1 = GenerateRnd(4);
+		Objects[i]._oVar1 = vanilla::GenerateRnd(4);
 		break;
 	}
-	Objects[i]._oVar2 = GenerateRnd(8);
+	Objects[i]._oVar2 = vanilla::GenerateRnd(8);
 }
 
 void AddL2Door(int i, Point position, _object_id objectType)
@@ -1328,8 +1328,8 @@ void AddL3Door(int i, Point position, _object_id objectType)
 void AddSarc(int i)
 {
 	dObject[Objects[i].position.x][Objects[i].position.y - 1] = -(i + 1);
-	Objects[i]._oVar1 = GenerateRnd(10);
-	Objects[i]._oRndSeed = AdvanceRndSeed();
+	Objects[i]._oVar1 = vanilla::GenerateRnd(10);
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
 	if (Objects[i]._oVar1 >= 8)
 		Objects[i]._oVar2 = PreSpawnSkeleton();
 }
@@ -1357,7 +1357,7 @@ void AddTrap(int i)
 	if (currlevel > 20) {
 		mt = (currlevel - 8) / 3 + 1;
 	}
-	mt = GenerateRnd(mt);
+	mt = vanilla::GenerateRnd(mt);
 	if (mt == 0)
 		Objects[i]._oVar3 = MIS_ARROW;
 	if (mt == 1)
@@ -1380,9 +1380,9 @@ void AddObjLight(int i, int r)
 void AddBarrel(int i, int t)
 {
 	Objects[i]._oVar1 = 0;
-	Objects[i]._oRndSeed = AdvanceRndSeed();
-	Objects[i]._oVar2 = (t == OBJ_BARRELEX) ? 0 : GenerateRnd(10);
-	Objects[i]._oVar3 = GenerateRnd(3);
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
+	Objects[i]._oVar2 = (t == OBJ_BARRELEX) ? 0 : vanilla::GenerateRnd(10);
+	Objects[i]._oVar3 = vanilla::GenerateRnd(3);
 
 	if (Objects[i]._oVar2 >= 8)
 		Objects[i]._oVar4 = PreSpawnSkeleton();
@@ -1407,11 +1407,11 @@ void AddShrine(int i)
 
 	int val;
 	do {
-		val = GenerateRnd(shrines);
+		val = vanilla::GenerateRnd(shrines);
 	} while (!slist[val]);
 
 	Objects[i]._oVar1 = val;
-	if (GenerateRnd(2) != 0) {
+	if (vanilla::GenerateRnd(2) != 0) {
 		Objects[i]._oAnimFrame = 12;
 		Objects[i]._oAnimLen = 22;
 	}
@@ -1419,18 +1419,18 @@ void AddShrine(int i)
 
 void AddBookcase(int i)
 {
-	Objects[i]._oRndSeed = AdvanceRndSeed();
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
 	Objects[i]._oPreFlag = true;
 }
 
 void AddBookstand(int i)
 {
-	Objects[i]._oRndSeed = AdvanceRndSeed();
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
 }
 
 void AddBloodFtn(int i)
 {
-	Objects[i]._oRndSeed = AdvanceRndSeed();
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
 }
 
 void AddPurifyingFountain(int i)
@@ -1440,7 +1440,7 @@ void AddPurifyingFountain(int i)
 	dObject[ox][oy - 1] = -(i + 1);
 	dObject[ox - 1][oy] = -(i + 1);
 	dObject[ox - 1][oy - 1] = -(i + 1);
-	Objects[i]._oRndSeed = AdvanceRndSeed();
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
 }
 
 void AddArmorStand(int i)
@@ -1450,17 +1450,17 @@ void AddArmorStand(int i)
 		Objects[i]._oSelFlag = 0;
 	}
 
-	Objects[i]._oRndSeed = AdvanceRndSeed();
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
 }
 
 void AddGoatShrine(int i)
 {
-	Objects[i]._oRndSeed = AdvanceRndSeed();
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
 }
 
 void AddCauldron(int i)
 {
-	Objects[i]._oRndSeed = AdvanceRndSeed();
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
 }
 
 void AddMurkyFountain(int i)
@@ -1470,18 +1470,18 @@ void AddMurkyFountain(int i)
 	dObject[ox][oy - 1] = -(i + 1);
 	dObject[ox - 1][oy] = -(i + 1);
 	dObject[ox - 1][oy - 1] = -(i + 1);
-	Objects[i]._oRndSeed = AdvanceRndSeed();
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
 }
 
 void AddTearFountain(int i)
 {
-	Objects[i]._oRndSeed = AdvanceRndSeed();
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
 }
 
 void AddDecap(int i)
 {
-	Objects[i]._oRndSeed = AdvanceRndSeed();
-	Objects[i]._oAnimFrame = GenerateRnd(8) + 1;
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
+	Objects[i]._oAnimFrame = vanilla::GenerateRnd(8) + 1;
 	Objects[i]._oPreFlag = true;
 }
 
@@ -1494,7 +1494,7 @@ void AddVilebook(int i)
 
 void AddMagicCircle(int i)
 {
-	Objects[i]._oRndSeed = AdvanceRndSeed();
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
 	Objects[i]._oPreFlag = true;
 	Objects[i]._oVar6 = 0;
 	Objects[i]._oVar5 = 1;
@@ -1502,7 +1502,7 @@ void AddMagicCircle(int i)
 
 void AddBrnCross(int i)
 {
-	Objects[i]._oRndSeed = AdvanceRndSeed();
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
 }
 
 void AddPedistal(int i)
@@ -1516,9 +1516,9 @@ void AddPedistal(int i)
 
 void AddStoryBook(int i)
 {
-	SetRndSeed(glSeedTbl[16]);
+	vanilla::SetRndSeed(glSeedTbl[16]);
 
-	Objects[i]._oVar1 = GenerateRnd(3);
+	Objects[i]._oVar1 = vanilla::GenerateRnd(3);
 	if (currlevel == 4)
 		Objects[i]._oVar2 = StoryText[Objects[i]._oVar1][0];
 	else if (currlevel == 8)
@@ -1536,13 +1536,13 @@ void AddWeaponRack(int i)
 		Objects[i]._oAnimFlag = 2;
 		Objects[i]._oSelFlag = 0;
 	}
-	Objects[i]._oRndSeed = AdvanceRndSeed();
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
 }
 
 void AddTorturedBody(int i)
 {
-	Objects[i]._oRndSeed = AdvanceRndSeed();
-	Objects[i]._oAnimFrame = GenerateRnd(4) + 1;
+	Objects[i]._oRndSeed = vanilla::AdvanceRndSeed();
+	Objects[i]._oAnimFrame = vanilla::GenerateRnd(4) + 1;
 	Objects[i]._oPreFlag = true;
 }
 
@@ -1556,8 +1556,8 @@ void GetRndObjLoc(int randarea, int *xx, int *yy)
 		tries++;
 		if (tries > 1000 && randarea > 1)
 			randarea--;
-		*xx = GenerateRnd(MAXDUNX);
-		*yy = GenerateRnd(MAXDUNY);
+		*xx = vanilla::GenerateRnd(MAXDUNX);
+		*yy = vanilla::GenerateRnd(MAXDUNY);
 		bool failed = false;
 		for (int i = 0; i < randarea && !failed; i++) {
 			for (int j = 0; j < randarea && !failed; j++) {
@@ -1737,9 +1737,9 @@ void AddObject(_object_id objType, Point objPos)
 		AddChest(oi, objType);
 		Objects[oi]._oTrapFlag = true;
 		if (leveltype == DTYPE_CATACOMBS) {
-			Objects[oi]._oVar4 = GenerateRnd(2);
+			Objects[oi]._oVar4 = vanilla::GenerateRnd(2);
 		} else {
-			Objects[oi]._oVar4 = GenerateRnd(3);
+			Objects[oi]._oVar4 = vanilla::GenerateRnd(3);
 		}
 		break;
 	case OBJ_SARC:
@@ -2993,7 +2993,7 @@ void OperateChest(int pnum, int i, bool sendmsg)
 	if (deltaload) {
 		return;
 	}
-	SetRndSeed(Objects[i]._oRndSeed);
+	vanilla::SetRndSeed(Objects[i]._oRndSeed);
 	if (setlevel) {
 		for (int j = 0; j < Objects[i]._oVar1; j++) {
 			CreateRndItem(Objects[i].position, true, sendmsg, false);
@@ -3160,7 +3160,7 @@ void OperateSarc(int pnum, int i, bool sendmsg)
 	}
 	Objects[i]._oAnimFlag = 1;
 	Objects[i]._oAnimDelay = 3;
-	SetRndSeed(Objects[i]._oRndSeed);
+	vanilla::SetRndSeed(Objects[i]._oRndSeed);
 	if (Objects[i]._oVar1 <= 2)
 		CreateRndItem(Objects[i].position, false, sendmsg, false);
 	if (Objects[i]._oVar1 >= 8)
@@ -3231,7 +3231,7 @@ void TryDisarm(int pnum, int i)
 		return;
 	}
 	int trapdisper = 2 * Players[pnum]._pDexterity - 5 * currlevel;
-	if (GenerateRnd(100) > trapdisper) {
+	if (vanilla::GenerateRnd(100) > trapdisper) {
 		return;
 	}
 	for (int j = 0; j < ActiveObjectCount; j++) {
@@ -3274,7 +3274,7 @@ bool OperateShrineMysterious(int pnum)
 	ModifyPlrDex(pnum, -1);
 	ModifyPlrVit(pnum, -1);
 
-	switch (static_cast<CharacterAttribute>(GenerateRnd(4))) {
+	switch (static_cast<CharacterAttribute>(vanilla::GenerateRnd(4))) {
 	case CharacterAttribute::Strength:
 		ModifyPlrStr(pnum, 6);
 		break;
@@ -3328,7 +3328,7 @@ bool OperateShrineHidden(int pnum)
 			}
 			if (cnt == 0)
 				break;
-			int r = GenerateRnd(NUM_INVLOC);
+			int r = vanilla::GenerateRnd(NUM_INVLOC);
 			if (Players[pnum].InvBody[r].isEmpty() || Players[pnum].InvBody[r]._iMaxDur == DUR_INDESTRUCTIBLE || Players[pnum].InvBody[r]._iMaxDur == 0)
 				continue;
 
@@ -3530,7 +3530,7 @@ bool OperateShrineEnchanted(int pnum)
 		}
 		int r;
 		do {
-			r = GenerateRnd(maxSpells);
+			r = vanilla::GenerateRnd(maxSpells);
 		} while ((Players[pnum]._pMemSpells & GetSpellBitmask(r + 1)) == 0);
 		if (Players[pnum]._pSplLvl[r + 1] >= 2)
 			Players[pnum]._pSplLvl[r + 1] -= 2;
@@ -3549,7 +3549,7 @@ bool OperateShrineThaumaturgic(int pnum)
 		int v1 = ActiveObjects[j];
 		assert((DWORD)v1 < MAXOBJECTS);
 		if (IsAnyOf(Objects[v1]._otype, OBJ_CHEST1, OBJ_CHEST2, OBJ_CHEST3, OBJ_TCHEST1, OBJ_TCHEST2, OBJ_TCHEST3) && Objects[v1]._oSelFlag == 0) {
-			Objects[v1]._oRndSeed = AdvanceRndSeed();
+			Objects[v1]._oRndSeed = vanilla::AdvanceRndSeed();
 			Objects[v1]._oSelFlag = 1;
 			Objects[v1]._oAnimFrame -= 2;
 		}
@@ -3735,8 +3735,8 @@ bool OperateShrineHoly(int pnum)
 	int yy;
 	uint32_t lv;
 	do {
-		xx = GenerateRnd(MAXDUNX);
-		yy = GenerateRnd(MAXDUNY);
+		xx = vanilla::GenerateRnd(MAXDUNX);
+		yy = vanilla::GenerateRnd(MAXDUNY);
 		lv = dPiece[xx][yy];
 		j++;
 		if (j > MAXDUNX * MAXDUNY)
@@ -3795,10 +3795,10 @@ bool OperateShrineSpiritual(int pnum)
 
 	for (int8_t &gridItem : Players[pnum].InvGrid) {
 		if (gridItem == 0) {
-			int r = 5 * leveltype + GenerateRnd(10 * leveltype);
+			int r = 5 * leveltype + vanilla::GenerateRnd(10 * leveltype);
 			DWORD t = Players[pnum]._pNumInv; // check
 			Players[pnum].InvList[t] = golditem;
-			Players[pnum].InvList[t]._iSeed = AdvanceRndSeed();
+			Players[pnum].InvList[t]._iSeed = vanilla::AdvanceRndSeed();
 			Players[pnum]._pNumInv++;
 			gridItem = Players[pnum]._pNumInv;
 			Players[pnum].InvList[t]._ivalue = r;
@@ -3969,7 +3969,7 @@ bool OperateShrineTainted(int pnum)
 		return true;
 	}
 
-	int r = GenerateRnd(4);
+	int r = vanilla::GenerateRnd(4);
 
 	int v1 = r == 0 ? 1 : -1;
 	int v2 = r == 1 ? 1 : -1;
@@ -4201,7 +4201,7 @@ bool OperateShrineMurphys(int pnum)
 
 	bool broke = false;
 	for (auto &item : Players[MyPlayerId].InvBody) {
-		if (!item.isEmpty() && GenerateRnd(3) == 0) {
+		if (!item.isEmpty() && vanilla::GenerateRnd(3) == 0) {
 			if (item._iDurability != DUR_INDESTRUCTIBLE) {
 				if (item._iDurability > 0) {
 					item._iDurability /= 2;
@@ -4232,7 +4232,7 @@ void OperateShrine(int pnum, int i, _sfx_id sType)
 	if (Objects[i]._oSelFlag == 0)
 		return;
 
-	SetRndSeed(Objects[i]._oRndSeed);
+	vanilla::SetRndSeed(Objects[i]._oRndSeed);
 	Objects[i]._oSelFlag = 0;
 
 	if (!deltaload) {
@@ -4400,8 +4400,8 @@ void OperateSkelBook(int pnum, int i, bool sendmsg)
 	if (deltaload) {
 		return;
 	}
-	SetRndSeed(Objects[i]._oRndSeed);
-	if (GenerateRnd(5) != 0)
+	vanilla::SetRndSeed(Objects[i]._oRndSeed);
+	if (vanilla::GenerateRnd(5) != 0)
 		CreateTypeItem(Objects[i].position, false, ITYPE_MISC, IMISC_SCROLL, sendmsg, false);
 	else
 		CreateTypeItem(Objects[i].position, false, ITYPE_MISC, IMISC_BOOK, sendmsg, false);
@@ -4422,7 +4422,7 @@ void OperateBookCase(int pnum, int i, bool sendmsg)
 	if (deltaload) {
 		return;
 	}
-	SetRndSeed(Objects[i]._oRndSeed);
+	vanilla::SetRndSeed(Objects[i]._oRndSeed);
 	CreateTypeItem(Objects[i].position, false, ITYPE_MISC, IMISC_BOOK, sendmsg, false);
 
 	if (QuestStatus(Q_ZHAR)) {
@@ -4450,7 +4450,7 @@ void OperateDecap(int pnum, int i, bool sendmsg)
 	if (deltaload) {
 		return;
 	}
-	SetRndSeed(Objects[i]._oRndSeed);
+	vanilla::SetRndSeed(Objects[i]._oRndSeed);
 	CreateRndItem(Objects[i].position, false, sendmsg, false);
 	if (pnum == MyPlayerId)
 		NetSendCmdParam1(false, CMD_OPERATEOBJ, i);
@@ -4466,8 +4466,8 @@ void OperateArmorStand(int pnum, int i, bool sendmsg)
 	if (deltaload) {
 		return;
 	}
-	SetRndSeed(Objects[i]._oRndSeed);
-	bool uniqueRnd = (GenerateRnd(2) != 0);
+	vanilla::SetRndSeed(Objects[i]._oRndSeed);
+	bool uniqueRnd = (vanilla::GenerateRnd(2) != 0);
 	if (currlevel <= 5) {
 		CreateTypeItem(Objects[i].position, true, ITYPE_LARMOR, IMISC_NONE, sendmsg, false);
 	} else if (currlevel >= 6 && currlevel <= 9) {
@@ -4488,7 +4488,7 @@ int FindValidShrine()
 	bool done = false;
 	int rv;
 	do {
-		rv = GenerateRnd(gbIsHellfire ? NumberOfShrineTypes : 26);
+		rv = vanilla::GenerateRnd(gbIsHellfire ? NumberOfShrineTypes : 26);
 		if (currlevel >= shrinemin[rv] && currlevel <= shrinemax[rv] && rv != ShrineThaumaturgic) {
 			done = true;
 		}
@@ -4513,7 +4513,7 @@ int FindValidShrine()
 
 void OperateGoatShrine(int pnum, int i, _sfx_id sType)
 {
-	SetRndSeed(Objects[i]._oRndSeed);
+	vanilla::SetRndSeed(Objects[i]._oRndSeed);
 	Objects[i]._oVar1 = FindValidShrine();
 	OperateShrine(pnum, i, sType);
 	Objects[i]._oAnimDelay = 2;
@@ -4522,7 +4522,7 @@ void OperateGoatShrine(int pnum, int i, _sfx_id sType)
 
 void OperateCauldron(int pnum, int i, _sfx_id sType)
 {
-	SetRndSeed(Objects[i]._oRndSeed);
+	vanilla::SetRndSeed(Objects[i]._oRndSeed);
 	Objects[i]._oVar1 = FindValidShrine();
 	OperateShrine(pnum, i, sType);
 	Objects[i]._oAnimFrame = 3;
@@ -4533,7 +4533,7 @@ void OperateCauldron(int pnum, int i, _sfx_id sType)
 bool OperateFountains(int pnum, int i)
 {
 	bool applied = false;
-	SetRndSeed(Objects[i]._oRndSeed);
+	vanilla::SetRndSeed(Objects[i]._oRndSeed);
 	switch (Objects[i]._otype) {
 	case OBJ_BLOODFTN:
 		if (deltaload)
@@ -4605,8 +4605,8 @@ bool OperateFountains(int pnum, int i)
 		if (pnum != MyPlayerId)
 			return false;
 
-		int fromStat = GenerateRnd(4);
-		int toStat = abs(GenerateRnd(3));
+		int fromStat = vanilla::GenerateRnd(4);
+		int toStat = abs(vanilla::GenerateRnd(3));
 		if (toStat >= fromStat)
 			toStat++;
 
@@ -4646,9 +4646,9 @@ void OperateWeaponRack(int pnum, int i, bool sendmsg)
 
 	if (Objects[i]._oSelFlag == 0)
 		return;
-	SetRndSeed(Objects[i]._oRndSeed);
+	vanilla::SetRndSeed(Objects[i]._oRndSeed);
 
-	switch (GenerateRnd(4) + ITYPE_SWORD) {
+	switch (vanilla::GenerateRnd(4) + ITYPE_SWORD) {
 	case ITYPE_SWORD:
 		weaponType = ITYPE_SWORD;
 		break;
@@ -5104,7 +5104,7 @@ void BreakBarrel(int pnum, int i, int dam, bool forcebreak, bool sendmsg)
 			PlaySfxLoc(IS_POPPOP5, Objects[i].position);
 		else
 			PlaySfxLoc(IS_BARREL, Objects[i].position);
-		SetRndSeed(Objects[i]._oRndSeed);
+		vanilla::SetRndSeed(Objects[i]._oRndSeed);
 		if (Objects[i]._oVar2 <= 1) {
 			if (Objects[i]._oVar3 == 0)
 				CreateRndUseful(Objects[i].position, sendmsg);
@@ -5124,7 +5124,7 @@ void BreakObject(int pnum, int oi)
 	if (pnum != -1) {
 		int mind = Players[pnum]._pIMinDam;
 		int maxd = Players[pnum]._pIMaxDam;
-		objdam = GenerateRnd(maxd - mind + 1) + mind;
+		objdam = vanilla::GenerateRnd(maxd - mind + 1) + mind;
 		objdam += Players[pnum]._pDamageMod + Players[pnum]._pIBonusDamMod + objdam * Players[pnum]._pIBonusDam / 100;
 	}
 
@@ -5497,8 +5497,8 @@ void SyncNakrulRoom()
 void AddNakrulLeaver()
 {
 	while (true) {
-		int xp = GenerateRnd(80) + 16;
-		int yp = GenerateRnd(80) + 16;
+		int xp = vanilla::GenerateRnd(80) + 16;
+		int yp = vanilla::GenerateRnd(80) + 16;
 		if (RndLocOk(xp - 1, yp - 1)
 		    && RndLocOk(xp, yp - 1)
 		    && RndLocOk(xp + 1, yp - 1)

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -187,7 +187,7 @@ static void VerifyGoldSeeds(PlayerStruct &player)
 				continue;
 			if (player.InvList[i]._iSeed != player.InvList[j]._iSeed)
 				continue;
-			player.InvList[i]._iSeed = AdvanceRndSeed();
+			player.InvList[i]._iSeed = vanilla::AdvanceRndSeed();
 			j = -1;
 		}
 	}

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -164,7 +164,7 @@ void LoadRndLvlPal(dungeon_type l)
 		return;
 	}
 
-	int rv = GenerateRnd(4) + 1;
+	int rv = vanilla::GenerateRnd(4) + 1;
 	if (l == DTYPE_CRYPT) {
 		LoadPalette("NLevels\\L5Data\\L5Base.PAL");
 		return;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -859,7 +859,7 @@ void CreatePlayer(int playerId, HeroClass c)
 	auto &player = Players[playerId];
 
 	player.Reset();
-	SetRndSeed(SDL_GetTicks());
+	vanilla::SetRndSeed(SDL_GetTicks());
 
 	player._pClass = c;
 
@@ -1014,7 +1014,7 @@ void CreatePlayer(int playerId, HeroClass c)
 
 	InitDungMsgs(player);
 	CreatePlrItems(playerId);
-	SetRndSeed(0);
+	vanilla::SetRndSeed(0);
 }
 
 int CalcStatDiff(PlayerStruct &player)
@@ -1209,8 +1209,8 @@ void InitPlayer(int pnum, bool firstTime)
 		if (player._pHitPoints >> 6 > 0) {
 			player._pmode = PM_STAND;
 			NewPlrAnim(player, player_graphic::Stand, DIR_S, player._pNFrames, 4);
-			player.AnimInfo.CurrentFrame = GenerateRnd(player._pNFrames - 1) + 1;
-			player.AnimInfo.TickCounterOfCurrentFrame = GenerateRnd(3);
+			player.AnimInfo.CurrentFrame = vanilla::GenerateRnd(player._pNFrames - 1) + 1;
+			player.AnimInfo.TickCounterOfCurrentFrame = vanilla::GenerateRnd(3);
 		} else {
 			player._pmode = PM_DEATH;
 			NewPlrAnim(player, player_graphic::Death, DIR_S, player._pDFrames, 2);
@@ -2181,7 +2181,7 @@ bool WeaponDur(int pnum, int durrnd)
 	if (WeaponDurDecay(pnum, INVLOC_HAND_RIGHT))
 		return true;
 
-	if (GenerateRnd(durrnd) != 0) {
+	if (vanilla::GenerateRnd(durrnd) != 0) {
 		return false;
 	}
 
@@ -2285,7 +2285,7 @@ bool PlrHitMonst(int pnum, int m)
 		app_fatal("PlrHitMonst: illegal player %i", pnum);
 	}
 
-	int hit = GenerateRnd(100);
+	int hit = vanilla::GenerateRnd(100);
 	if (monster._mmode == MM_STONE) {
 		hit = 0;
 	}
@@ -2332,18 +2332,18 @@ bool PlrHitMonst(int pnum, int m)
 		return false;
 #endif
 	if ((player._pIFlags & ISPL_FIREDAM) != 0 && (player._pIFlags & ISPL_LIGHTDAM) != 0) {
-		int midam = player._pIFMinDam + GenerateRnd(player._pIFMaxDam - player._pIFMinDam);
+		int midam = player._pIFMinDam + vanilla::GenerateRnd(player._pIFMaxDam - player._pIFMinDam);
 		AddMissile(player.position.tile, player.position.temp, player._pdir, MIS_SPECARROW, TARGET_MONSTERS, pnum, midam, 0);
 	}
 	int mind = player._pIMinDam;
 	int maxd = player._pIMaxDam;
-	int dam = GenerateRnd(maxd - mind + 1) + mind;
+	int dam = vanilla::GenerateRnd(maxd - mind + 1) + mind;
 	dam += dam * player._pIBonusDam / 100;
 	dam += player._pIBonusDamMod;
 	int dam2 = dam << 6;
 	dam += player._pDamageMod;
 	if (player._pClass == HeroClass::Warrior || player._pClass == HeroClass::Barbarian) {
-		if (GenerateRnd(100) < player._pLevel) {
+		if (vanilla::GenerateRnd(100) < player._pLevel) {
 			dam *= 2;
 		}
 	}
@@ -2378,17 +2378,17 @@ bool PlrHitMonst(int pnum, int m)
 		break;
 	}
 
-	if ((player.pDamAcFlags & ISPLHF_DEVASTATION) != 0 && GenerateRnd(100) < 5) {
+	if ((player.pDamAcFlags & ISPLHF_DEVASTATION) != 0 && vanilla::GenerateRnd(100) < 5) {
 		dam *= 3;
 	}
 
-	if ((player.pDamAcFlags & ISPLHF_DOPPELGANGER) != 0 && monster.MType->mtype != MT_DIABLO && monster._uniqtype == 0 && GenerateRnd(100) < 10) {
+	if ((player.pDamAcFlags & ISPLHF_DOPPELGANGER) != 0 && monster.MType->mtype != MT_DIABLO && monster._uniqtype == 0 && vanilla::GenerateRnd(100) < 10) {
 		AddDoppelganger(monster);
 	}
 
 	dam <<= 6;
 	if ((player.pDamAcFlags & ISPLHF_JESTERS) != 0) {
-		int r = GenerateRnd(201);
+		int r = vanilla::GenerateRnd(201);
 		if (r >= 100)
 			r = 100 + (r - 100) * 5;
 		dam = dam * r / 100;
@@ -2410,7 +2410,7 @@ bool PlrHitMonst(int pnum, int m)
 
 	int skdam = 0;
 	if ((player._pIFlags & ISPL_RNDSTEALLIFE) != 0) {
-		skdam = GenerateRnd(dam / 8);
+		skdam = vanilla::GenerateRnd(dam / 8);
 		player._pHitPoints += skdam;
 		if (player._pHitPoints > player._pMaxHP) {
 			player._pHitPoints = player._pMaxHP;
@@ -2505,7 +2505,7 @@ bool PlrHitPlr(int pnum, int8_t p)
 	}
 	auto &attacker = Players[pnum];
 
-	int hit = GenerateRnd(100);
+	int hit = vanilla::GenerateRnd(100);
 
 	int hper = (attacker._pDexterity / 2) + attacker._pLevel + 50 - (target._pIBonusAC + target._pIAC + target._pDexterity / 5);
 
@@ -2522,7 +2522,7 @@ bool PlrHitPlr(int pnum, int8_t p)
 
 	int blk = 100;
 	if ((target._pmode == PM_STAND || target._pmode == PM_ATTACK) && target._pBlockFlag) {
-		blk = GenerateRnd(100);
+		blk = vanilla::GenerateRnd(100);
 	}
 
 	int blkper = target._pDexterity + target._pBaseToBlk + (target._pLevel * 2) - (attacker._pLevel * 2);
@@ -2545,18 +2545,18 @@ bool PlrHitPlr(int pnum, int8_t p)
 
 	int mind = attacker._pIMinDam;
 	int maxd = attacker._pIMaxDam;
-	int dam = GenerateRnd(maxd - mind + 1) + mind;
+	int dam = vanilla::GenerateRnd(maxd - mind + 1) + mind;
 	dam += (dam * attacker._pIBonusDam) / 100;
 	dam += attacker._pIBonusDamMod + attacker._pDamageMod;
 
 	if (attacker._pClass == HeroClass::Warrior || attacker._pClass == HeroClass::Barbarian) {
-		if (GenerateRnd(100) < attacker._pLevel) {
+		if (vanilla::GenerateRnd(100) < attacker._pLevel) {
 			dam *= 2;
 		}
 	}
 	int skdam = dam << 6;
 	if ((attacker._pIFlags & ISPL_RNDSTEALLIFE) != 0) {
-		int tac = GenerateRnd(skdam / 8);
+		int tac = vanilla::GenerateRnd(skdam / 8);
 		attacker._pHitPoints += tac;
 		if (attacker._pHitPoints > attacker._pMaxHP) {
 			attacker._pHitPoints = attacker._pMaxHP;
@@ -2733,7 +2733,7 @@ bool PM_DoRangeAttack(int pnum)
 			mistype = MIS_LARROW;
 		}
 		if ((player._pIFlags & ISPL_FIRE_ARROWS) != 0 && (player._pIFlags & ISPL_LIGHT_ARROWS) != 0) {
-			dmg = player._pIFMinDam + GenerateRnd(player._pIFMaxDam - player._pIFMinDam);
+			dmg = player._pIFMinDam + vanilla::GenerateRnd(player._pIFMaxDam - player._pIFMinDam);
 			mistype = MIS_SPECARROW;
 		}
 
@@ -2813,7 +2813,7 @@ bool PM_DoBlock(int pnum)
 		StartStand(pnum, player._pdir);
 		ClearPlrPVars(player);
 
-		if (GenerateRnd(10) == 0) {
+		if (vanilla::GenerateRnd(10) == 0) {
 			ShieldDur(pnum);
 		}
 		return true;
@@ -2840,7 +2840,7 @@ static void ArmorDur(int pnum)
 		return;
 	}
 
-	a = GenerateRnd(3);
+	a = vanilla::GenerateRnd(3);
 	if (!player.InvBody[INVLOC_CHEST].isEmpty() && player.InvBody[INVLOC_HEAD].isEmpty()) {
 		a = 1;
 	}
@@ -2913,7 +2913,7 @@ bool PM_DoGotHit(int pnum)
 	if (player.AnimInfo.CurrentFrame >= player._pHFrames) {
 		StartStand(pnum, player._pdir);
 		ClearPlrPVars(player);
-		if (GenerateRnd(4) != 0) {
+		if (vanilla::GenerateRnd(4) != 0) {
 			ArmorDur(pnum);
 		}
 

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -87,30 +87,6 @@ const char *const QuestTriggerNames[5] = {
 	N_(/* TRANSLATORS: Quest Map*/ "A Dark Passage"),
 	N_(/* TRANSLATORS: Quest Map*/ "Unholy Altar")
 };
-/**
- * A quest group containing the three quests the Butcher,
- * Ogden's Sign and Gharbad the Weak, which ensures that exactly
- * two of these three quests appear in any single player game.
- */
-int QuestGroup1[3] = { Q_BUTCHER, Q_LTBANNER, Q_GARBUD };
-/**
- * A quest group containing the three quests Halls of the Blind,
- * the Magic Rock and Valor, which ensures that exactly two of
- * these three quests appear in any single player game.
- */
-int QuestGroup2[3] = { Q_BLIND, Q_ROCK, Q_BLOOD };
-/**
- * A quest group containing the three quests Black Mushroom,
- * Zhar the Mad and Anvil of Fury, which ensures that exactly
- * two of these three quests appear in any single player game.
- */
-int QuestGroup3[3] = { Q_MUSHROOM, Q_ZHAR, Q_ANVIL };
-/**
- * A quest group containing the two quests Lachdanan and Warlord
- * of Blood, which ensures that exactly one of these two quests
- * appears in any single player game.
- */
-int QuestGroup4[2] = { Q_VEIL, Q_WARLORD };
 
 void InitQuests()
 {
@@ -186,16 +162,54 @@ void InitQuests()
 
 void InitialiseQuestPools(uint32_t seed, QuestStruct quests[])
 {
-	vanilla::SetRndSeed(seed);
-	if (vanilla::GenerateRnd(2) != 0)
-		quests[Q_PWATER]._qactive = QUEST_NOTAVAIL;
-	else
-		quests[Q_SKELKING]._qactive = QUEST_NOTAVAIL;
+	/**
+	 * @brief To ensure saved games have the same quests available after saving and loading an RNG is created from
+	 * the provided seed.
+	*/
+	vanilla::RandomEngine rng { seed };
 
-	quests[QuestGroup1[vanilla::GenerateRnd(sizeof(QuestGroup1) / sizeof(int))]]._qactive = QUEST_NOTAVAIL;
-	quests[QuestGroup2[vanilla::GenerateRnd(sizeof(QuestGroup2) / sizeof(int))]]._qactive = QUEST_NOTAVAIL;
-	quests[QuestGroup3[vanilla::GenerateRnd(sizeof(QuestGroup3) / sizeof(int))]]._qactive = QUEST_NOTAVAIL;
-	quests[QuestGroup4[vanilla::GenerateRnd(sizeof(QuestGroup4) / sizeof(int))]]._qactive = QUEST_NOTAVAIL;
+	/**
+	 * @brief The quests Poison Water and Skeleton King share the same quest pool, only one of the two is available in
+	 * a vanilla single player game.
+	 */
+	auto questPool1ID = rng.RandomChoice({ Q_SKELKING, Q_PWATER });
+	quests[questPool1ID.value_or(Q_SKELKING)]._qactive = QUEST_NOTAVAIL;
+
+	/**
+	 * @brief The quests Butcher, Ogden's Sign, and Gharbad the Weak share the same quest pool. A rare bug (present in
+	 * Diablo) allowed all quests to remain active but normally only two of these three quests appear in any single
+	 * player game.
+	 */
+	auto questPool2ID = rng.RandomChoice({ Q_BUTCHER, Q_LTBANNER, Q_GARBUD });
+	if (questPool2ID)
+		quests[*questPool2ID]._qactive = QUEST_NOTAVAIL;
+
+	/**
+	 * @brief The quests Halls of the Blind, the Magic Rock, and Valor share the same quest pool. As above normally only
+	 * two of these three quests appear in any single player game.
+	 */
+	auto questPool3ID = rng.RandomChoice({ Q_BLIND, Q_ROCK, Q_BLOOD });
+	if (questPool3ID)
+		quests[*questPool3ID]._qactive = QUEST_NOTAVAIL;
+
+	/**
+	 * @brief The quests Black Mushroom, Zhar the Mad, and Anvil of Fury share the same quest pool. As above normally
+	 * only two of these three quests appear in any single player game.
+	 */
+	auto questPool4ID = rng.RandomChoice({ Q_MUSHROOM, Q_ZHAR, Q_ANVIL });
+	if (questPool4ID)
+		quests[*questPool4ID]._qactive = QUEST_NOTAVAIL;
+
+	/**
+	 * @brief The quests Lachdanan and Warlord of Blood share the same quest pool. As above normally only one of these
+	 * two quests appears in any single player game.
+	 */
+	auto questPool5ID = rng.RandomChoice({ Q_VEIL, Q_WARLORD });
+	if (questPool5ID)
+		quests[*questPool5ID]._qactive = QUEST_NOTAVAIL;
+
+	// There are no calls to the global RNG functions between now and the next call to vanilla::SetRndSeed
+	// To be absolutely safe we could call vanilla::SetRndSeed(rng.initialState) then vanilla::Discard(rng.GetCount())
 }
 
 void CheckQuests()

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -186,16 +186,16 @@ void InitQuests()
 
 void InitialiseQuestPools(uint32_t seed, QuestStruct quests[])
 {
-	SetRndSeed(seed);
-	if (GenerateRnd(2) != 0)
+	vanilla::SetRndSeed(seed);
+	if (vanilla::GenerateRnd(2) != 0)
 		quests[Q_PWATER]._qactive = QUEST_NOTAVAIL;
 	else
 		quests[Q_SKELKING]._qactive = QUEST_NOTAVAIL;
 
-	quests[QuestGroup1[GenerateRnd(sizeof(QuestGroup1) / sizeof(int))]]._qactive = QUEST_NOTAVAIL;
-	quests[QuestGroup2[GenerateRnd(sizeof(QuestGroup2) / sizeof(int))]]._qactive = QUEST_NOTAVAIL;
-	quests[QuestGroup3[GenerateRnd(sizeof(QuestGroup3) / sizeof(int))]]._qactive = QUEST_NOTAVAIL;
-	quests[QuestGroup4[GenerateRnd(sizeof(QuestGroup4) / sizeof(int))]]._qactive = QUEST_NOTAVAIL;
+	quests[QuestGroup1[vanilla::GenerateRnd(sizeof(QuestGroup1) / sizeof(int))]]._qactive = QUEST_NOTAVAIL;
+	quests[QuestGroup2[vanilla::GenerateRnd(sizeof(QuestGroup2) / sizeof(int))]]._qactive = QUEST_NOTAVAIL;
+	quests[QuestGroup3[vanilla::GenerateRnd(sizeof(QuestGroup3) / sizeof(int))]]._qactive = QUEST_NOTAVAIL;
+	quests[QuestGroup4[vanilla::GenerateRnd(sizeof(QuestGroup4) / sizeof(int))]]._qactive = QUEST_NOTAVAIL;
 }
 
 void CheckQuests()

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -306,12 +306,12 @@ void DoHealOther(int pnum, uint16_t rid)
 		return;
 	}
 
-	int hp = (GenerateRnd(10) + 1) << 6;
+	int hp = (vanilla::GenerateRnd(10) + 1) << 6;
 	for (int i = 0; i < player._pLevel; i++) {
-		hp += (GenerateRnd(4) + 1) << 6;
+		hp += (vanilla::GenerateRnd(4) + 1) << 6;
 	}
 	for (int i = 0; i < GetSpellLevel(pnum, SPL_HEALOTHER); i++) {
-		hp += (GenerateRnd(6) + 1) << 6;
+		hp += (vanilla::GenerateRnd(6) + 1) << 6;
 	}
 
 	if (player._pClass == HeroClass::Warrior || player._pClass == HeroClass::Barbarian) {

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -1619,7 +1619,7 @@ void WitchBuyItem()
 	int idx = stextvhold + ((stextlhold - stextup) / 4);
 
 	if (idx < 3)
-		myPlayer.HoldItem._iSeed = AdvanceRndSeed();
+		myPlayer.HoldItem._iSeed = vanilla::AdvanceRndSeed();
 
 	TakePlrsMoney(myPlayer.HoldItem._iIvalue);
 	StoreAutoPlace();
@@ -1782,10 +1782,10 @@ void HealerBuyItem()
 	int idx = stextvhold + ((stextlhold - stextup) / 4);
 	if (!gbIsMultiplayer) {
 		if (idx < 2)
-			item._iSeed = AdvanceRndSeed();
+			item._iSeed = vanilla::AdvanceRndSeed();
 	} else {
 		if (idx < 3)
-			item._iSeed = AdvanceRndSeed();
+			item._iSeed = vanilla::AdvanceRndSeed();
 	}
 
 	TakePlrsMoney(item._iIvalue);
@@ -2050,8 +2050,8 @@ void TalkEnter()
 	}
 
 	if (stextsel == sn - 2) {
-		SetRndSeed(Towners[talker]._tSeed);
-		auto tq = static_cast<_speech_id>(gossipstart + GenerateRnd(gossipend - gossipstart + 1));
+		vanilla::SetRndSeed(Towners[talker]._tSeed);
+		auto tq = static_cast<_speech_id>(gossipstart + vanilla::GenerateRnd(gossipend - gossipstart + 1));
 		InitQTextMsg(tq);
 		return;
 	}
@@ -2206,7 +2206,7 @@ void InitStores()
 
 void SetupTownStores()
 {
-	SetRndSeed(glSeedTbl[currlevel] * SDL_GetTicks());
+	vanilla::SetRndSeed(glSeedTbl[currlevel] * SDL_GetTicks());
 
 	auto &myPlayer = Players[MyPlayerId];
 

--- a/Source/themes.cpp
+++ b/Source/themes.cpp
@@ -108,7 +108,7 @@ bool TFit_Obj5(int t)
 {
 	int xp = 0;
 	int yp = 0;
-	int r = GenerateRnd(5) + 1;
+	int r = vanilla::GenerateRnd(5) + 1;
 	int rs = r;
 
 	while (r > 0) {
@@ -188,7 +188,7 @@ bool CheckThemeObj3(int xp, int yp, int t, int f)
 			return false;
 		if (dObject[xp + trm3x[i]][yp + trm3y[i]] != 0)
 			return false;
-		if (f != -1 && GenerateRnd(f) == 0)
+		if (f != -1 && vanilla::GenerateRnd(f) == 0)
 			return false;
 	}
 
@@ -408,9 +408,9 @@ void InitThemes()
 		for (size_t i = 0; i < 256 && numthemes < MAXTHEMES; i++) {
 			if (CheckThemeRoom(i)) {
 				themes[numthemes].ttval = i;
-				theme_id j = ThemeGood[GenerateRnd(4)];
+				theme_id j = ThemeGood[vanilla::GenerateRnd(4)];
 				while (!SpecialThemeFit(numthemes, j)) {
-					j = (theme_id)GenerateRnd(17);
+					j = (theme_id)vanilla::GenerateRnd(17);
 				}
 				themes[numthemes].ttype = j;
 				numthemes++;
@@ -433,9 +433,9 @@ void InitThemes()
 		for (int i = 0; i < themeCount; i++) {
 			if (themes[i].ttype == THEME_NONE) {
 				themes[i].ttval = themeLoc[i].ttval;
-				theme_id j = ThemeGood[GenerateRnd(4)];
+				theme_id j = ThemeGood[vanilla::GenerateRnd(4)];
 				while (!SpecialThemeFit(i, j)) {
-					j = (theme_id)GenerateRnd(17);
+					j = (theme_id)vanilla::GenerateRnd(17);
 				}
 				themes[i].ttype = j;
 			}
@@ -486,12 +486,12 @@ void PlaceThemeMonsts(int t, int f)
 			numscattypes++;
 		}
 	}
-	int mtype = scattertypes[GenerateRnd(numscattypes)];
+	int mtype = scattertypes[vanilla::GenerateRnd(numscattypes)];
 	for (int yp = 0; yp < MAXDUNY; yp++) {
 		for (int xp = 0; xp < MAXDUNX; xp++) {
 			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]] && dItem[xp][yp] == 0 && dObject[xp][yp] == 0) {
-				if (GenerateRnd(f) == 0) {
-					AddMonster({ xp, yp }, static_cast<Direction>(GenerateRnd(8)), mtype, true);
+				if (vanilla::GenerateRnd(f) == 0) {
+					AddMonster({ xp, yp }, static_cast<Direction>(vanilla::GenerateRnd(8)), mtype, true);
 				}
 			}
 		}
@@ -511,9 +511,9 @@ void Theme_Barrel(int t)
 	for (int yp = 0; yp < MAXDUNY; yp++) {
 		for (int xp = 0; xp < MAXDUNX; xp++) {
 			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
-				if (GenerateRnd(barrnd[leveltype - 1]) == 0) {
+				if (vanilla::GenerateRnd(barrnd[leveltype - 1]) == 0) {
 					_object_id r = OBJ_BARREL;
-					if (GenerateRnd(barrnd[leveltype - 1]) != 0) {
+					if (vanilla::GenerateRnd(barrnd[leveltype - 1]) != 0) {
 						r = OBJ_BARRELEX;
 					}
 					AddObject(r, { xp, yp });
@@ -555,7 +555,7 @@ void Theme_MonstPit(int t)
 {
 	uint8_t monstrnd[4] = { 6, 7, 3, 9 };
 
-	int r = GenerateRnd(100) + 1;
+	int r = vanilla::GenerateRnd(100) + 1;
 	int ixp = 0;
 	int iyp = 0;
 	while (r > 0) {
@@ -594,7 +594,7 @@ void Theme_SkelRoom(int t)
 
 	AddObject(OBJ_SKFIRE, { xp, yp });
 
-	if (GenerateRnd(monstrnd[leveltype - 1]) != 0) {
+	if (vanilla::GenerateRnd(monstrnd[leveltype - 1]) != 0) {
 		int i = PreSpawnSkeleton();
 		SpawnSkeleton(i, { xp - 1, yp - 1 });
 	} else {
@@ -606,25 +606,25 @@ void Theme_SkelRoom(int t)
 		SpawnSkeleton(i, { xp, yp - 1 });
 	}
 
-	if (GenerateRnd(monstrnd[leveltype - 1]) != 0) {
+	if (vanilla::GenerateRnd(monstrnd[leveltype - 1]) != 0) {
 		int i = PreSpawnSkeleton();
 		SpawnSkeleton(i, { xp + 1, yp - 1 });
 	} else {
 		AddObject(OBJ_BANNERR, { xp + 1, yp - 1 });
 	}
-	if (GenerateRnd(monstrnd[leveltype - 1]) != 0) {
+	if (vanilla::GenerateRnd(monstrnd[leveltype - 1]) != 0) {
 		int i = PreSpawnSkeleton();
 		SpawnSkeleton(i, { xp - 1, yp });
 	} else {
 		AddObject(OBJ_BANNERM, { xp - 1, yp });
 	}
-	if (GenerateRnd(monstrnd[leveltype - 1]) != 0) {
+	if (vanilla::GenerateRnd(monstrnd[leveltype - 1]) != 0) {
 		int i = PreSpawnSkeleton();
 		SpawnSkeleton(i, { xp + 1, yp });
 	} else {
 		AddObject(OBJ_BANNERM, { xp + 1, yp });
 	}
-	if (GenerateRnd(monstrnd[leveltype - 1]) != 0) {
+	if (vanilla::GenerateRnd(monstrnd[leveltype - 1]) != 0) {
 		int i = PreSpawnSkeleton();
 		SpawnSkeleton(i, { xp - 1, yp + 1 });
 	} else {
@@ -636,7 +636,7 @@ void Theme_SkelRoom(int t)
 		SpawnSkeleton(i, { xp, yp + 1 });
 	}
 
-	if (GenerateRnd(monstrnd[leveltype - 1]) != 0) {
+	if (vanilla::GenerateRnd(monstrnd[leveltype - 1]) != 0) {
 		int i = PreSpawnSkeleton();
 		SpawnSkeleton(i, { xp + 1, yp + 1 });
 	} else {
@@ -661,13 +661,13 @@ void Theme_Treasure(int t)
 	char treasrnd[4] = { 4, 9, 7, 10 };
 	char monstrnd[4] = { 6, 8, 3, 7 };
 
-	AdvanceRndSeed();
+	vanilla::AdvanceRndSeed();
 	for (int yp = 0; yp < MAXDUNY; yp++) {
 		for (int xp = 0; xp < MAXDUNX; xp++) {
 			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
-				int rv = GenerateRnd(treasrnd[leveltype - 1]);
+				int rv = vanilla::GenerateRnd(treasrnd[leveltype - 1]);
 				// BUGFIX: the `2*` in `2*GenerateRnd(treasrnd...) == 0` has no effect, should probably be `GenerateRnd(2*treasrnd...) == 0`
-				if ((2 * GenerateRnd(treasrnd[leveltype - 1])) == 0) {
+				if ((2 * vanilla::GenerateRnd(treasrnd[leveltype - 1])) == 0) {
 					CreateTypeItem({ xp, yp }, false, ITYPE_GOLD, IMISC_NONE, false, true);
 					ItemNoFlippy();
 				}
@@ -711,9 +711,9 @@ void Theme_Library(int t)
 
 	for (int yp = 1; yp < MAXDUNY - 1; yp++) {
 		for (int xp = 1; xp < MAXDUNX - 1; xp++) {
-			if (CheckThemeObj3(xp, yp, t, -1) && dMonster[xp][yp] == 0 && GenerateRnd(librnd[leveltype - 1]) == 0) {
+			if (CheckThemeObj3(xp, yp, t, -1) && dMonster[xp][yp] == 0 && vanilla::GenerateRnd(librnd[leveltype - 1]) == 0) {
 				AddObject(OBJ_BOOKSTAND, { xp, yp });
-				if (GenerateRnd(2 * librnd[leveltype - 1]) != 0 && dObject[xp][yp] != 0) { /// BUGFIX: check dObject[xp][yp] was populated by AddObject (fixed)
+				if (vanilla::GenerateRnd(2 * librnd[leveltype - 1]) != 0 && dObject[xp][yp] != 0) { /// BUGFIX: check dObject[xp][yp] was populated by AddObject (fixed)
 					int oi = dObject[xp][yp] - 1;
 					Objects[oi]._oSelFlag = 0;
 					Objects[oi]._oAnimFrame += 2;
@@ -746,7 +746,7 @@ void Theme_Torture(int t)
 		for (int xp = 1; xp < MAXDUNX - 1; xp++) {
 			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
 				if (CheckThemeObj3(xp, yp, t, -1)) {
-					if (GenerateRnd(tortrnd[leveltype - 1]) == 0) {
+					if (vanilla::GenerateRnd(tortrnd[leveltype - 1]) == 0) {
 						AddObject(OBJ_TNUDEM2, { xp, yp });
 					}
 				}
@@ -783,7 +783,7 @@ void Theme_Decap(int t)
 		for (int xp = 1; xp < MAXDUNX - 1; xp++) {
 			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
 				if (CheckThemeObj3(xp, yp, t, -1)) {
-					if (GenerateRnd(decaprnd[leveltype - 1]) == 0) {
+					if (vanilla::GenerateRnd(decaprnd[leveltype - 1]) == 0) {
 						AddObject(OBJ_DECAP, { xp, yp });
 					}
 				}
@@ -825,7 +825,7 @@ void Theme_ArmorStand(int t)
 		for (int xp = 0; xp < MAXDUNX; xp++) {
 			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
 				if (CheckThemeObj3(xp, yp, t, -1)) {
-					if (GenerateRnd(armorrnd[leveltype - 1]) == 0) {
+					if (vanilla::GenerateRnd(armorrnd[leveltype - 1]) == 0) {
 						AddObject(OBJ_ARMORSTANDN, { xp, yp });
 					}
 				}
@@ -910,7 +910,7 @@ void Theme_BrnCross(int t)
 		for (int xp = 0; xp < MAXDUNX; xp++) {
 			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
 				if (CheckThemeObj3(xp, yp, t, -1)) {
-					if (GenerateRnd(bcrossrnd[leveltype - 1]) == 0) {
+					if (vanilla::GenerateRnd(bcrossrnd[leveltype - 1]) == 0) {
 						AddObject(OBJ_TBCROSS, { xp, yp });
 					}
 				}
@@ -938,7 +938,7 @@ void Theme_WeaponRack(int t)
 		for (int xp = 0; xp < MAXDUNX; xp++) {
 			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
 				if (CheckThemeObj3(xp, yp, t, -1)) {
-					if (GenerateRnd(weaponrnd[leveltype - 1]) == 0) {
+					if (vanilla::GenerateRnd(weaponrnd[leveltype - 1]) == 0) {
 						AddObject(OBJ_WEAPONRACKN, { xp, yp });
 					}
 				}

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -177,7 +177,7 @@ void DrlgTPass3()
 		}
 		if (gbIsSpawn || ((Players[MyPlayerId].pTownWarps & 4) == 0 && (!gbIsHellfire || Players[MyPlayerId]._pLevel < 20))) {
 			for (int x = 36; x < 46; x++) {
-				FillTile(x, 78, GenerateRnd(4) + 1);
+				FillTile(x, 78, vanilla::GenerateRnd(4) + 1);
 			}
 		}
 	}

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -50,7 +50,7 @@ void InitTownerInfo(int i, const TownerInit &initData)
 	towner._ttype = initData.type;
 	towner.position = initData.position;
 	towner.talk = initData.talk;
-	towner._tSeed = AdvanceRndSeed(); // TODO: Narrowing conversion, tSeed might need to be uint16_t
+	towner._tSeed = vanilla::AdvanceRndSeed(); // TODO: Narrowing conversion, tSeed might need to be uint16_t
 
 	dMonster[towner.position.x][towner.position.y] = i + 1;
 
@@ -224,7 +224,7 @@ void InitCows(TownerStruct &towner, const TownerInit &initData)
 		towner._tNAnim[i] = CelGetFrame(CowCels.get(), i);
 	}
 	NewTownerAnim(towner, towner._tNAnim[initData.dir], 12, 3);
-	towner._tAnimFrame = GenerateRnd(11) + 1;
+	towner._tAnimFrame = vanilla::GenerateRnd(11) + 1;
 	towner._tName = _("Cow");
 
 	const Point position = initData.position;
@@ -687,7 +687,7 @@ void TalkToCowFarmer(PlayerStruct &player, TownerStruct &cowFarmer)
 	case QUEST_HIVE_ACTIVE:
 		if (!player._pLvlVisited[9] && player._pLevel < 15) {
 			_speech_id qt = TEXT_JERSEY12;
-			switch (GenerateRnd(4)) {
+			switch (vanilla::GenerateRnd(4)) {
 			case 0:
 				qt = TEXT_JERSEY9;
 				break;

--- a/test/random_test.cpp
+++ b/test/random_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "engine/random.hpp"
 
@@ -14,26 +15,26 @@ TEST(RandomTest, RandomEngineParams)
 	constexpr uint32_t multiplicand = 22695477;
 	constexpr uint32_t increment = 1;
 
-	SetRndSeed(0);
+	vanilla::SetRndSeed(0);
 
 	// Starting from a seed of 0 means the multiplicand is dropped and the state advances by increment only
-	AdvanceRndSeed();
-	ASSERT_EQ(GetLCGEngineState(), increment) << "Increment factor is incorrect";
+	vanilla::AdvanceRndSeed();
+	ASSERT_EQ(vanilla::GetLCGEngineState(), increment) << "Increment factor is incorrect";
 
 	// LCGs use a formula of mult * seed + inc. Using a long form in the code to document the expected factors.
-	AdvanceRndSeed();
-	ASSERT_EQ(GetLCGEngineState(), (multiplicand * 1) + increment) << "Multiplicand factor is incorrect";
+	vanilla::AdvanceRndSeed();
+	ASSERT_EQ(vanilla::GetLCGEngineState(), (multiplicand * 1) + increment) << "Multiplicand factor is incorrect";
 
 	// C++11 defines the default seed for a LCG engine as 1. The ten thousandth value is commonly used for sanity checking
 	// a sequence, so as we've had one round since state 1 we need to discard another 9999 values to get to the 10000th state.
 	// This loop has an off by one error, so test the 9999th value as well as 10000th
 	for (auto i = 2; i < 10000; i++)
-		AdvanceRndSeed();
+		vanilla::AdvanceRndSeed();
 	uint32_t expectedState = 3495122800U;
-	ASSERT_EQ(GetLCGEngineState(), expectedState) << "Wrong engine state after 9999 invocations";
-	AdvanceRndSeed();
+	ASSERT_EQ(vanilla::GetLCGEngineState(), expectedState) << "Wrong engine state after 9999 invocations";
+	vanilla::AdvanceRndSeed();
 	expectedState = 3007658545U;
-	ASSERT_EQ(GetLCGEngineState(), expectedState) << "Wrong engine state after 10000 invocations";
+	ASSERT_EQ(vanilla::GetLCGEngineState(), expectedState) << "Wrong engine state after 10000 invocations";
 }
 
 TEST(RandomTest, AbsDistribution)
@@ -41,40 +42,40 @@ TEST(RandomTest, AbsDistribution)
 	// The default distribution for RNG calls is the absolute value of the generated value interpreted as a signed int
 	// This relies on undefined behaviour when called on std::numeric_limits<int_t>::min(). See C17 7.22.6.1
 	// The current behaviour is this returns the same value (the most negative number of the type).
-	SetRndSeed(1457187811); // yields -2147483648
-	ASSERT_EQ(AdvanceRndSeed(), std::numeric_limits<int32_t>::min()) << "Invalid distribution";
-	SetRndSeed(3604671459U); // yields 0
-	ASSERT_EQ(AdvanceRndSeed(), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(1457187811); // yields -2147483648
+	ASSERT_EQ(vanilla::AdvanceRndSeed(), std::numeric_limits<int32_t>::min()) << "Invalid distribution";
+	vanilla::SetRndSeed(3604671459U); // yields 0
+	ASSERT_EQ(vanilla::AdvanceRndSeed(), 0) << "Invalid distribution";
 
-	SetRndSeed(0); // yields +1
-	ASSERT_EQ(AdvanceRndSeed(), 1) << "Invalid distribution";
-	SetRndSeed(2914375622U); // yields -1
-	ASSERT_EQ(AdvanceRndSeed(), 1) << "Invalid distribution";
+	vanilla::SetRndSeed(0); // yields +1
+	ASSERT_EQ(vanilla::AdvanceRndSeed(), 1) << "Invalid distribution";
+	vanilla::SetRndSeed(2914375622U); // yields -1
+	ASSERT_EQ(vanilla::AdvanceRndSeed(), 1) << "Invalid distribution";
 
-	SetRndSeed(3604671460U); // yields +22695477
-	ASSERT_EQ(AdvanceRndSeed(), 22695477) << "Invalid distribution";
-	SetRndSeed(3604671458U); // yields -22695477
-	ASSERT_EQ(AdvanceRndSeed(), 22695477) << "Invalid distribution";
+	vanilla::SetRndSeed(3604671460U); // yields +22695477
+	ASSERT_EQ(vanilla::AdvanceRndSeed(), 22695477) << "Invalid distribution";
+	vanilla::SetRndSeed(3604671458U); // yields -22695477
+	ASSERT_EQ(vanilla::AdvanceRndSeed(), 22695477) << "Invalid distribution";
 
-	SetRndSeed(1902003768); // yields +429496729
-	ASSERT_EQ(AdvanceRndSeed(), 429496729) << "Invalid distribution";
-	SetRndSeed(1012371854); // yields -429496729
-	ASSERT_EQ(AdvanceRndSeed(), 429496729) << "Invalid distribution";
+	vanilla::SetRndSeed(1902003768); // yields +429496729
+	ASSERT_EQ(vanilla::AdvanceRndSeed(), 429496729) << "Invalid distribution";
+	vanilla::SetRndSeed(1012371854); // yields -429496729
+	ASSERT_EQ(vanilla::AdvanceRndSeed(), 429496729) << "Invalid distribution";
 
-	SetRndSeed(189776845); // yields +1212022642
-	ASSERT_EQ(AdvanceRndSeed(), 1212022642) << "Invalid distribution";
-	SetRndSeed(2724598777U); // yields -1212022642
-	ASSERT_EQ(AdvanceRndSeed(), 1212022642) << "Invalid distribution";
+	vanilla::SetRndSeed(189776845); // yields +1212022642
+	ASSERT_EQ(vanilla::AdvanceRndSeed(), 1212022642) << "Invalid distribution";
+	vanilla::SetRndSeed(2724598777U); // yields -1212022642
+	ASSERT_EQ(vanilla::AdvanceRndSeed(), 1212022642) << "Invalid distribution";
 
-	SetRndSeed(76596137); // yields +2147483646
-	ASSERT_EQ(AdvanceRndSeed(), 2147483646) << "Invalid distribution";
-	SetRndSeed(2837779485U); // yields -2147483646
-	ASSERT_EQ(AdvanceRndSeed(), 2147483646) << "Invalid distribution";
+	vanilla::SetRndSeed(76596137); // yields +2147483646
+	ASSERT_EQ(vanilla::AdvanceRndSeed(), 2147483646) << "Invalid distribution";
+	vanilla::SetRndSeed(2837779485U); // yields -2147483646
+	ASSERT_EQ(vanilla::AdvanceRndSeed(), 2147483646) << "Invalid distribution";
 
-	SetRndSeed(766891974); // yields +2147483647
-	ASSERT_EQ(AdvanceRndSeed(), 2147483647) << "Invalid distribution";
-	SetRndSeed(2147483648U); // yields -2147483647
-	ASSERT_EQ(AdvanceRndSeed(), 2147483647) << "Invalid distribution";
+	vanilla::SetRndSeed(766891974); // yields +2147483647
+	ASSERT_EQ(vanilla::AdvanceRndSeed(), 2147483647) << "Invalid distribution";
+	vanilla::SetRndSeed(2147483648U); // yields -2147483647
+	ASSERT_EQ(vanilla::AdvanceRndSeed(), 2147483647) << "Invalid distribution";
 }
 
 // The bounded distribution function used by Diablo performs a modulo operation on the result of the AbsDistribution
@@ -89,28 +90,28 @@ TEST(RandomTest, ModDistributionInvalidRange)
 {
 	// Calling the modulo distribution with an upper bound <= 0 returns 0 without advancing the engine
 	auto initialSeed = 44444444;
-	SetRndSeed(initialSeed);
-	EXPECT_EQ(GenerateRnd(0), 0) << "A distribution with an upper bound of 0 must return 0";
-	EXPECT_EQ(GetLCGEngineState(), initialSeed) << "Distribution with invalid range must not advance the engine state";
-	EXPECT_EQ(GenerateRnd(-1), 0) << "A distribution with a negative upper bound must return 0";
-	EXPECT_EQ(GetLCGEngineState(), initialSeed) << "Distribution with invalid range must not advance the engine state";
-	EXPECT_EQ(GenerateRnd(std::numeric_limits<int32_t>::min()), 0)
+	vanilla::SetRndSeed(initialSeed);
+	EXPECT_EQ(vanilla::GenerateRnd(0), 0) << "A distribution with an upper bound of 0 must return 0";
+	EXPECT_EQ(vanilla::GetLCGEngineState(), initialSeed) << "Distribution with invalid range must not advance the engine state";
+	EXPECT_EQ(vanilla::GenerateRnd(-1), 0) << "A distribution with a negative upper bound must return 0";
+	EXPECT_EQ(vanilla::GetLCGEngineState(), initialSeed) << "Distribution with invalid range must not advance the engine state";
+	EXPECT_EQ(vanilla::GenerateRnd(std::numeric_limits<int32_t>::min()), 0)
 	    << "A distribution with a negative upper bound must return 0";
-	EXPECT_EQ(GetLCGEngineState(), initialSeed) << "Distribution with invalid range must not advance the engine state";
+	EXPECT_EQ(vanilla::GetLCGEngineState(), initialSeed) << "Distribution with invalid range must not advance the engine state";
 }
 
 TEST(RandomTest, ShiftModDistributionSingleRange)
 {
 	// All results mod 1 = 0;
 	auto initialSeed = ::testing::UnitTest::GetInstance()->random_seed();
-	SetRndSeed(initialSeed);
+	vanilla::SetRndSeed(initialSeed);
 	for (auto i = 0; i < 100; i++)
-		ASSERT_EQ(GenerateRnd(1), 0) << "Interval [0, 1) must return 0";
-	ASSERT_NE(GetLCGEngineState(), initialSeed) << "Interval of 1 element must still advance the engine state";
+		ASSERT_EQ(vanilla::GenerateRnd(1), 0) << "Interval [0, 1) must return 0";
+	ASSERT_NE(vanilla::GetLCGEngineState(), initialSeed) << "Interval of 1 element must still advance the engine state";
 
 	// Just in case -0 has a distinct representation? Shouldn't be possible but cheap to test.
-	SetRndSeed(1457187811);
-	ASSERT_EQ(GenerateRnd(1), 0) << "Interval [0, 1) must return 0 when AbsDistribution yields INT_MIN";
+	vanilla::SetRndSeed(1457187811);
+	ASSERT_EQ(vanilla::GenerateRnd(1), 0) << "Interval [0, 1) must return 0 when AbsDistribution yields INT_MIN";
 }
 
 // When called with an upper bound less than 0xFFFF this distribution function discards the low 16 bits of the output
@@ -123,60 +124,61 @@ TEST(RandomTest, ShiftModDistributionSignCarry)
 
 	// The only negative value return from AbsDistribution is -2147483648
 	// A sign-preserving shift right of 16 bits gives a result of -32768.
-	SetRndSeed(1457187811); // Test mod with no division
-	ASSERT_EQ(GenerateRnd(65535 - 1), -32768) << "Distribution must map negative numbers using sign carry shifts";
-	SetRndSeed(1457187811); // Test mod when a division occurs
-	ASSERT_EQ(GenerateRnd(32768 - 1), -1) << "Distribution must map negative numbers using sign carry shifts";
+	vanilla::SetRndSeed(1457187811); // Test mod with no division
+	ASSERT_EQ(vanilla::GenerateRnd(65535 - 1), -32768) << "Distribution must map negative numbers using sign carry shifts";
+	vanilla::SetRndSeed(1457187811); // Test mod when a division occurs
+	ASSERT_EQ(vanilla::GenerateRnd(32768 - 1), -1) << "Distribution must map negative numbers using sign carry shifts";
 }
 
 // The Diablo LCG implementation attempts to improve the quality of generated numbers that would only use the low
 // bits of the LCG output but due to applying this after taking the absolute value this introduces bias. This may
 // be an inconsistency with the implementation in devilutionx, see the comment for RandomTest_ShiftModDistributionHighBits
-TEST(RandomTest, ShiftModDistributionLowBits) {
+TEST(RandomTest, ShiftModDistributionLowBits)
+{
 	// All the following seeds generate values less than 2^16, so after shifting they give a 0 value
 	constexpr auto maxBound = 65534;
 
-	SetRndSeed(3604671459U); // yields 0
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
-	SetRndSeed(0); // yields 1
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
-	SetRndSeed(2914375622U); // yields -1
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
-	SetRndSeed(538964771); // yields 64
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
-	SetRndSeed(2375410851U); // yields -64
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
-	SetRndSeed(1229260608); // yields 65
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
-	SetRndSeed(1685115014); // yields -65
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
-	SetRndSeed(1768225379); // yields 128
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
-	SetRndSeed(1146150243); // yields -128
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
-	SetRndSeed(1480523688); // yields 7625
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
-	SetRndSeed(1433851934); // yields -7625
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
-	SetRndSeed(2382565573U); // yields 32458
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
-	SetRndSeed(531810049); // yields -32458
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
-	SetRndSeed(1625910243); // yields 32768
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
-	SetRndSeed(1288465379); // yields -32768
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(3604671459U); // yields 0
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(0); // yields 1
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(2914375622U); // yields -1
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(538964771); // yields 64
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(2375410851U); // yields -64
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(1229260608); // yields 65
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(1685115014); // yields -65
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(1768225379); // yields 128
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(1146150243); // yields -128
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(1480523688); // yields 7625
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(1433851934); // yields -7625
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(2382565573U); // yields 32458
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(531810049); // yields -32458
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(1625910243); // yields 32768
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(1288465379); // yields -32768
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
 
 	// -1 from the max bound for the next two to ensure it's not due to a mod with no remainder
-	SetRndSeed(2561524649U); // yields 65534
-	ASSERT_EQ(GenerateRnd(maxBound - 1), 0) << "Invalid distribution";
-	SetRndSeed(352850973U); // yields -65534
-	ASSERT_EQ(GenerateRnd(maxBound - 1), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(2561524649U); // yields 65534
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound - 1), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(352850973U); // yields -65534
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound - 1), 0) << "Invalid distribution";
 
-	SetRndSeed(3251820486U); // yields 65535
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
-	SetRndSeed(3957522432U); // yields -65535
-	ASSERT_EQ(GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(3251820486U); // yields 65535
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
+	vanilla::SetRndSeed(3957522432U); // yields -65535
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 0) << "Invalid distribution";
 }
 
 // The highest value GenerateRnd can return is 32767 (0x7FFF). I suspect this is the Borland rand() implementation
@@ -187,38 +189,38 @@ TEST(RandomTest, ShiftModDistributionLowBits) {
 TEST(RandomTest, ShiftModDistributionHighBits)
 {
 	constexpr auto maxBound = 65534;
-	SetRndSeed(3267226595U); // yields 65536
-	ASSERT_EQ(GenerateRnd(maxBound), 1) << "Invalid distribution";
-	SetRndSeed(3942116323U); // yields -65536
-	ASSERT_EQ(GenerateRnd(maxBound), 1) << "Invalid distribution";
-	SetRndSeed(4279561187U); // yields 131072
-	ASSERT_EQ(GenerateRnd(maxBound), 2) << "Invalid distribution";
-	SetRndSeed(2929781731U); // yields -131072
-	ASSERT_EQ(GenerateRnd(maxBound), 2) << "Invalid distribution";
-	SetRndSeed(659483619); // yields 262144
-	ASSERT_EQ(GenerateRnd(maxBound), 4) << "Invalid distribution";
-	SetRndSeed(2254892003U); // yields -262144
-	ASSERT_EQ(GenerateRnd(maxBound), 4) << "Invalid distribution";
-	SetRndSeed(3604671458U); // yields 22695477
-	ASSERT_EQ(GenerateRnd(maxBound), 346) << "Invalid distribution";
-	SetRndSeed(3604671460U); // yields -22695477
-	ASSERT_EQ(GenerateRnd(maxBound), 346) << "Invalid distribution";
-	SetRndSeed(1012371854); // yields 429496729
-	ASSERT_EQ(GenerateRnd(maxBound), 6553) << "Invalid distribution";
-	SetRndSeed(1902003768); // yields -429496729
-	ASSERT_EQ(GenerateRnd(maxBound), 6553) << "Invalid distribution";
-	SetRndSeed(189776845); // yields 1212022642
-	ASSERT_EQ(GenerateRnd(maxBound), 18493) << "Invalid distribution";
-	SetRndSeed(2724598777); // yields -1212022642
-	ASSERT_EQ(GenerateRnd(maxBound), 18493) << "Invalid distribution";
-	SetRndSeed(76596137); // yields 2147483646
-	ASSERT_EQ(GenerateRnd(maxBound), 32767) << "Invalid distribution";
-	SetRndSeed(2837779485); // yields -2147483646
-	ASSERT_EQ(GenerateRnd(maxBound), 32767) << "Invalid distribution";
-	SetRndSeed(766891974); // yields 2147483647
-	ASSERT_EQ(GenerateRnd(maxBound), 32767) << "Invalid distribution";
-	SetRndSeed(2147483648); // yields -2147483647
-	ASSERT_EQ(GenerateRnd(maxBound), 32767) << "Invalid distribution";
+	vanilla::SetRndSeed(3267226595U); // yields 65536
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 1) << "Invalid distribution";
+	vanilla::SetRndSeed(3942116323U); // yields -65536
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 1) << "Invalid distribution";
+	vanilla::SetRndSeed(4279561187U); // yields 131072
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 2) << "Invalid distribution";
+	vanilla::SetRndSeed(2929781731U); // yields -131072
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 2) << "Invalid distribution";
+	vanilla::SetRndSeed(659483619); // yields 262144
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 4) << "Invalid distribution";
+	vanilla::SetRndSeed(2254892003U); // yields -262144
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 4) << "Invalid distribution";
+	vanilla::SetRndSeed(3604671458U); // yields 22695477
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 346) << "Invalid distribution";
+	vanilla::SetRndSeed(3604671460U); // yields -22695477
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 346) << "Invalid distribution";
+	vanilla::SetRndSeed(1012371854); // yields 429496729
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 6553) << "Invalid distribution";
+	vanilla::SetRndSeed(1902003768); // yields -429496729
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 6553) << "Invalid distribution";
+	vanilla::SetRndSeed(189776845); // yields 1212022642
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 18493) << "Invalid distribution";
+	vanilla::SetRndSeed(2724598777); // yields -1212022642
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 18493) << "Invalid distribution";
+	vanilla::SetRndSeed(76596137); // yields 2147483646
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 32767) << "Invalid distribution";
+	vanilla::SetRndSeed(2837779485); // yields -2147483646
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 32767) << "Invalid distribution";
+	vanilla::SetRndSeed(766891974); // yields 2147483647
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 32767) << "Invalid distribution";
+	vanilla::SetRndSeed(2147483648); // yields -2147483647
+	ASSERT_EQ(vanilla::GenerateRnd(maxBound), 32767) << "Invalid distribution";
 }
 
 TEST(RandomTest, ModDistributionSignPreserving)
@@ -226,11 +228,87 @@ TEST(RandomTest, ModDistributionSignPreserving)
 	// This distribution is used when the upper bound is a value in [65535, 2147483647]
 
 	// Sign preserving modulo when no division is performed cannot be tested in isolation with the current implementation.
-	SetRndSeed(1457187811);
-	ASSERT_EQ(GenerateRnd(65535), -32768) << "Distribution must map negative numbers using sign preserving modulo";
-	SetRndSeed(1457187811);
-	ASSERT_EQ(GenerateRnd(std::numeric_limits<int32_t>::max()), -1)
+	vanilla::SetRndSeed(1457187811);
+	ASSERT_EQ(vanilla::GenerateRnd(65535), -32768) << "Distribution must map negative numbers using sign preserving modulo";
+	vanilla::SetRndSeed(1457187811);
+	ASSERT_EQ(vanilla::GenerateRnd(std::numeric_limits<int32_t>::max()), -1)
 	    << "Distribution must map negative numbers using sign preserving modulo";
+}
+
+TEST(RandomTest, VanillaEngine)
+{
+	uint32_t seed = ::testing::UnitTest::GetInstance()->random_seed();
+	auto engine1 = vanilla::RandomEngine(seed);
+	auto engine2 = vanilla::RandomEngine(seed);
+
+	for (auto i = 0; i < 10; i++)
+		ASSERT_EQ(engine1.RandomInt(), engine2.RandomInt()) << "vanilla::RandomEngines created from the same seed must generate the same sequence";
+
+	auto engine3 = vanilla::RandomEngine(engine1.initialState);
+
+	engine3.Discard(10);
+	ASSERT_EQ(engine3.RandomInRange(5, 24), engine1.RandomInRange(5, 24))
+	    << "vanilla::RandomEngines created from the same seed must produce the same value at the same point in the sequence even if prior calls used different distributions";
+
+	auto engine4 = vanilla::RandomEngine(seed);
+	vanilla::SetRndSeed(seed);
+
+	ASSERT_EQ(abs(static_cast<int32_t>(engine4())), vanilla::AdvanceRndSeed())
+	    << "vanilla::RandomEngines must use the same base distribution as the global RNG";
+
+	for (auto i = 0; i < 10; i++) {
+		ASSERT_EQ(engine4.RandomLessThan(6435), vanilla::GenerateRnd(6435))
+		    << "vanilla::RandomEngines must generate the same sequence as the global RNG from the same starting seed";
+	}
+}
+
+TEST(RandomTest, V1Choices)
+{
+	auto choice = randomV1::RandomChoice({ -1, 1 });
+	EXPECT_THAT(choice, ::testing::AnyOf(-1, 1)) << "RandomChoice must pick from the listed elements";
+}
+
+TEST(RandomTest, V1Engine)
+{
+	uint32_t seed = ::testing::UnitTest::GetInstance()->random_seed();
+	auto engine1 = randomV1::RandomEngine(seed);
+	// Can't set a specific seed on the global RNG
+
+	{
+		auto engine2 = randomV1::RandomEngine(seed);
+
+		for (auto i = 0; i < 10; i++)
+			ASSERT_EQ(engine1(), engine2()) << "randomV1::RandomEngines created from the same seed must generate the same sequence";
+		// It is not guaranteed that the global RNG gives a repeatable sequence as the seed cannot be controlled.
+	}
+
+	{
+		auto engine3 = randomV1::RandomEngine(engine1.initialState);
+
+		engine3.Discard(10);
+		ASSERT_EQ(engine1.RandomInRange(5, 24), engine3.RandomInRange(5, 24))
+		    << "randomV1::RandomEngines created from the same seed must produce the same InRange value at the same point in the sequence";
+
+		ASSERT_EQ(engine1.RandomLessThan(24234), engine3.RandomLessThan(24234))
+		    << "randomV1::RandomEngines created from the same seed must produce the same LessThan value at the same point in the sequence";
+		// It is not guaranteed that the global RNG produces the same value at any point as the seed cannot be controlled.
+	}
+
+	{
+		auto engine4 = randomV1::RandomEngine(seed);
+
+		for (auto i = 0; i < 12; i++)
+			engine4.RandomLessThan(6435); // Purely to show the next call does not depend on any specific prior distributions
+
+		for (auto i = 0; i < 5; i++) {
+			ASSERT_EQ(engine1.RandomBoolean(0.5), engine4.RandomBoolean(0.5))
+			    << "randomV1::RandomEngines created from the same seed must generate the same Boolean value at the same point in the sequence";
+		}
+
+		ASSERT_EQ(engine1.RandomChoice({ 5, 2, -1, -8 }), engine4.RandomChoice({ 5, 2, -1, -8 }))
+		    << "randomV1::RandomEngines created from the same seed must choose the same option at the same point in the sequence";
+		// It is not guaranteed that the global RNG will choose the same option as the seed cannot be controlled.
+	}
 }
 
 } // namespace devilution


### PR DESCRIPTION
This builds on the work done by @qndel in #2084. I have not updated any of the call sites identified in that PR as I wanted to make it obvious that this does not change existing code.

This is more of a discussion point at the moment. I was thinking that namespaces would be a good way to delineate behaviour. I've implemented "vanilla" to cover the base game logic and bugs. "randomV1" is based on #2084 and uses STL concepts to add convenience functions as discussed in #2193 and #2206.

The API design is intended to be common between versions. The next step would be to update the vanilla namespace functions to align member functions of vanilla::RandomEngine. The reason for having this class is to allow creating a RandomEngine object and passing it in to the level/item generation code (for example) to make it clearer how a given object/dungeon layout is generated.

Looking at code such as quests.cpp:InitQuests() makes me think a "vanillaSafe" namespace which fixes the negative number bug would be useful, but this would be a future enhancement iff this proposal is acceptable.