### PR TITLE
Item trns

### DIFF
--- a/Source/engine/render/cel_render.cpp
+++ b/Source/engine/render/cel_render.cpp
@@ -771,8 +771,7 @@ void RenderCelWithMultipleTRN(const ItemStruct &item, const CelOutputBuffer &out
 	RenderCel(
 	    out, position, src, srcSize, srcWidth, [](std::uint8_t *dst, const std::uint8_t *src, std::size_t w) {
 		    while (w-- > 0) {
-				*dst++ = *src;
-			    ++src;
+				*dst++ = *src++;
 		    } },
 	    NullLineEndFn);
 

--- a/Source/engine/render/cel_render.hpp
+++ b/Source/engine/render/cel_render.hpp
@@ -122,4 +122,30 @@ void CelDrawLightRedSafeTo(const CelOutputBuffer &out, Point position, const Cel
  */
 void CelBlitOutlineTo(const CelOutputBuffer &out, uint8_t col, Point position, const CelSprite &cel, int frame, bool skipColorIndexZero = true);
 
+struct PixelOrPercent {
+	bool isPercent;
+	int value;
+};
+
+struct PixelOrPercentRect {
+	PixelOrPercent x, y, w, h;
+};
+
+struct trnRegion {
+	PixelOrPercentRect region;
+	std::string trn;
+};
+
+constexpr PixelOrPercent operator"" _px(unsigned long long int n)
+{
+	return PixelOrPercent { false, static_cast<int>(n) };
+}
+
+constexpr PixelOrPercent operator"" _perc(unsigned long long int n)
+{
+	return PixelOrPercent { true, static_cast<int>(n) };
+}
+
+void CelDrawLightMultiTRNTo(const ItemStruct &item, const CelOutputBuffer &out, Point position, const CelSprite &cel, int frame, const std::vector<trnRegion> &v);
+
 } // namespace devilution


### PR DESCRIPTION
Lets you define trn regions, supports pixel and % offsets, allows infinite trns
Example:
![image](https://user-images.githubusercontent.com/14297035/123821387-a3b6f700-d8fb-11eb-9989-a98b432107e9.png)
(Old pic, it doesn't recolor cursor anymore xD)
A modding feature, no current ingame stuff makes use of it

![image](https://user-images.githubusercontent.com/14297035/123827173-aec05600-d900-11eb-8333-7be468e50069.png)

Usage example in CelDrawItem:
```cpp
void CelDrawItem(const ItemStruct &item, const CelOutputBuffer &out, Point position, const CelSprite &cel, int frame)
{
	bool usable = item._iStatFlag;
	if (!usable) {
		CelDrawLightRedTo(out, position, cel, frame);
	} else {
		//CelClippedDrawTo(out, position, cel, frame);
		CelDrawLightMultiTRNTo(item, out, position, cel, frame,
		    {
		        { { 0_px, 0_px, 50_perc, 50_perc }, "Monsters\\Bat\\orange.trn" },          //bottom left
		        { { 50_perc, 0_px, 50_perc, 50_perc }, "Monsters\\Succ\\succbw.trn" },      // bottom right
		        { { 0_px, 50_perc, 50_perc, 50_perc }, "Monsters\\Bat\\Red.TRN" },          // top left
		        { { 50_perc, 50_perc, 50_perc, 50_perc }, "Monsters\\Sneak\\Sneakv3.TRN" }, // top right
		    });
	}
}
```