### PR TITLE
Clean-up uneccesary type conversions in player hpPer calculations

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -582,12 +582,7 @@ void DrawLifeFlask(const CelOutputBuffer &out)
 {
 	auto &myPlayer = plr[myplr];
 
-	double p = 0.0;
-	if (myPlayer._pMaxHP > 0) {
-		p = (double)myPlayer._pHitPoints / (double)myPlayer._pMaxHP * 80.0;
-	}
-	myPlayer._pHPPer = p;
-	int filled = myPlayer._pHPPer;
+	int filled = myPlayer.UpdateHitPointPercentage();
 
 	if (filled > 80)
 		filled = 80;
@@ -606,12 +601,7 @@ void UpdateLifeFlask(const CelOutputBuffer &out)
 {
 	auto &myPlayer = plr[myplr];
 
-	double p = 0.0;
-	if (myPlayer._pMaxHP > 0) {
-		p = (double)myPlayer._pHitPoints / (double)myPlayer._pMaxHP * 80.0;
-	}
-	int filled = p;
-	myPlayer._pHPPer = filled;
+	int filled = myPlayer.UpdateHitPointPercentage();
 
 	if (filled > 69)
 		filled = 69;
@@ -645,7 +635,7 @@ void control_update_life_mana()
 	int maxMana = std::max(myPlayer._pMaxMana, 0);
 	int mana = std::max(myPlayer._pMana, 0);
 	myPlayer._pManaPer = maxMana != 0 ? ((double)mana / (double)maxMana * 80.0) : 0;
-	myPlayer._pHPPer = (double)myPlayer._pHitPoints / (double)myPlayer._pMaxHP * 80.0;
+	myPlayer.UpdateHitPointPercentage();
 }
 
 void UpdateManaFlask(const CelOutputBuffer &out)

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -582,19 +582,17 @@ void DrawLifeFlask(const CelOutputBuffer &out)
 {
 	auto &myPlayer = plr[myplr];
 
-	int filled = myPlayer.UpdateHitPointPercentage();
+	int emptyPortion = 80 - myPlayer.UpdateHitPointPercentage();
 
-	if (filled > 80)
-		filled = 80;
+	// clamping because this function only draws the top 12% of the HP display
+	emptyPortion = clamp(emptyPortion, 0, 11) + 2; // +2 to account for the frame being included in the sprite
 
-	filled = 80 - filled;
-	if (filled > 11)
-		filled = 11;
-	filled += 2;
-
-	DrawFlask(out, pLifeBuff, { 13, 3 }, { PANEL_LEFT + 109, PANEL_TOP - 13 }, filled);
-	if (filled != 13)
-		DrawFlask(out, pBtmBuff, { 109, filled + 3 }, { PANEL_LEFT + 109, PANEL_TOP - 13 + filled }, 13 - filled);
+	// Draw the empty part of the flask
+	DrawFlask(out, pLifeBuff, { 13, 3 }, { PANEL_LEFT + 109, PANEL_TOP - 13 }, emptyPortion);
+	if (emptyPortion < 13) {
+		// Draw the filled part of the flask
+		DrawFlask(out, pBtmBuff, { 109, emptyPortion + 3 }, { PANEL_LEFT + 109, PANEL_TOP - 13 + emptyPortion }, 13 - emptyPortion);
+	}
 }
 
 void UpdateLifeFlask(const CelOutputBuffer &out)

--- a/Source/engine/displacement.hpp
+++ b/Source/engine/displacement.hpp
@@ -44,8 +44,8 @@ struct Displacement {
 
 	constexpr Displacement &operator*=(const float factor)
 	{
-		deltaX *= factor;
-		deltaY *= factor;
+		deltaX = static_cast<int>(deltaX * factor);
+		deltaY = static_cast<int>(deltaY * factor);
 		return *this;
 	}
 

--- a/Source/engine/point.hpp
+++ b/Source/engine/point.hpp
@@ -44,8 +44,8 @@ struct Point {
 
 	constexpr Point &operator*=(const float factor)
 	{
-		x *= factor;
-		y *= factor;
+		x = static_cast<int>(x * factor);
+		y = static_cast<int>(y * factor);
 		return *this;
 	}
 

--- a/Source/player.h
+++ b/Source/player.h
@@ -402,6 +402,27 @@ struct PlayerStruct {
 	 * @brief Resets all Data of the current PlayerStruct
 	 */
 	void Reset();
+
+	/**
+	 * @brief Calculates the players current Hit Points as a percentage of their max HP and stores it for later reference
+	 *
+	 * The stored value is unused...
+	 * @see _pHPPer
+	 * @return The players current hit points as a percentage of their maximum (from 0 to 80%)
+	*/
+	int UpdateHitPointPercentage()
+	{
+		if (_pMaxHP <= 0) { // divide by zero guard
+			_pHPPer = 0;
+		} else {
+			// Maximum achievable HP is approximately 1200. Diablo uses fixed point integers where the last 6 bits are
+			// fractional values. This means that we will never overflow HP values normally by doing this multiplication
+			// as the max value is representable in 17 bits and the multiplication result will be at most 23 bits
+			_pHPPer = _pHitPoints * 80 / _pMaxHP;
+		}
+
+		return _pHPPer;
+	}
 };
 
 extern int myplr;


### PR DESCRIPTION
The player HP/Mana percentage calculations are doing conversions that are unnecessary with the operands and the expected values during gameplay. Refactoring the life flask upper section for now, I'll have a go at the rest when I get more time.

This also includes explicit casts for Point/Displacement operator/ because I was planning on doing a bunch of small changes then I almost immediately hit the code in DrawLifeFlask 😂 . I can break it out if desired.