### PR TITLE
Fix AddDoppelganger

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1236,31 +1236,35 @@ int AddMonster(Point position, Direction dir, int mtype, bool InMap)
 	return -1;
 }
 
-void monster_43C785(int i)
+void AddDoppelganger(MonsterStruct &monster)
 {
-	int d, j, oi;
-	Point position = {};
+	if (monster.MType == nullptr) {
+		return;
+	}
 
-	if (monster[i].MType != nullptr) {
-		for (d = 0; d < 8; d++) {
-			position = monster[i].position.tile + monster[i]._mdir;
-			if (!SolidLoc(position)) {
-				if (dPlayer[position.x][position.y] == 0 && dMonster[position.x][position.y] == 0) {
-					if (dObject[position.x][position.y] == 0)
-						break;
-					oi = dObject[position.x][position.y] > 0 ? dObject[position.x][position.y] - 1 : -(dObject[position.x][position.y] + 1);
-					if (!object[oi]._oSolidFlag)
-						break;
+	Point target = { 0, 0 };
+	for (int d = 0; d < 8; d++) {
+		const Point position = monster.position.tile + static_cast<Direction>(d);
+		if (!SolidLoc(position)) {
+			if (dPlayer[position.x][position.y] == 0 && dMonster[position.x][position.y] == 0) {
+				if (dObject[position.x][position.y] == 0) {
+					target = position;
+					break;
+				}
+				int oi = dObject[position.x][position.y] > 0 ? dObject[position.x][position.y] - 1 : -(dObject[position.x][position.y] + 1);
+				if (!object[oi]._oSolidFlag) {
+					target = position;
+					break;
 				}
 			}
 		}
-		if (d < 8) {
-			for (j = 0; j < MAX_LVLMTYPES; j++) {
-				if (Monsters[j].mtype == monster[i].MType->mtype)
-					break;
+	}
+	if (target != Point { 0, 0 }) {
+		for (int j = 0; j < MAX_LVLMTYPES; j++) {
+			if (Monsters[j].mtype == monster.MType->mtype) {
+				AddMonster(target, monster._mdir, j, true);
+				break;
 			}
-			if (j < MAX_LVLMTYPES)
-				AddMonster(position, monster[i]._mdir, j, true);
 		}
 	}
 }

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -229,7 +229,7 @@ void InitMonsters();
 void SetMapMonsters(const uint16_t *dunData, Point startPosition);
 void DeleteMonster(int i);
 int AddMonster(Point position, Direction dir, int mtype, bool InMap);
-void monster_43C785(int i);
+void AddDoppelganger(MonsterStruct &monster);
 bool M_Talker(int i);
 void M_StartStand(int i, Direction md);
 void M_ClearSquares(int i);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2379,7 +2379,7 @@ bool PlrHitMonst(int pnum, int m)
 	}
 
 	if ((player.pDamAcFlags & 0x10) != 0 && monster[m].MType->mtype != MT_DIABLO && monster[m]._uniqtype == 0 && GenerateRnd(100) < 10) {
-		monster_43C785(m);
+		AddDoppelganger(monster[m]);
 	}
 
 	dam <<= 6;


### PR DESCRIPTION
This was broken during a previous refactoring.

https://github.com/diasurgical/devilutionX/commit/21fdb0dcd951ab5adee57b5a212e2d86e6ac036f#diff-d46585089d315b53630b1035442b3d490d7b422cb05ceee76cf9041de3e39179L1251-L1252

The name is taken from the cleanup that was done to Devilution but hasn't been merged yet: https://github.com/diasurgical/devilution/blob/master/Source/monster.cpp#L1323

I noticed this while doing a general clean up so it's a bit tangled with with the clean up of the function it self.