### PR TITLE
SaveHelper: Write zeroes on `skip`

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -5,8 +5,10 @@
  */
 #include "loadsave.h"
 
-#include <SDL.h>
 #include <climits>
+#include <cstring>
+
+#include <SDL.h>
 
 #include "automap.h"
 #include "codec.h"
@@ -156,6 +158,7 @@ public:
 
 	void skip(uint32_t len)
 	{
+		std::memset(&m_buffer_[m_cur_], 0, len);
 		m_cur_ += len;
 	}
 


### PR DESCRIPTION
Instead of writing uninitialized memory to the file, which can lead to
issues with older game versions, we now write zeroes.

One alternative would be to have separate `skip` and `blank` functions
but I think we want the save files from the same state to be
byte-identical, so we always write zeroes.

Fixes #2281