### PR TITLE
Introduce template form of skip to represent deprecated variables

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -163,7 +163,7 @@ public:
 	}
 
 	template<typename T>
-	constexpr void Skip(void)
+	constexpr void Skip()
 	{
 		Skip(sizeof(T));
 	}

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1510,7 +1510,6 @@ static void SavePlayer(SaveHelper *file, int p)
 	file->WriteLE<int32_t>(player.position.offset2.deltaX);
 	file->WriteLE<int32_t>(player.position.offset2.deltaY);
 	file->Skip<int32_t>(); // Skip _pVar8
-
 	for (uint8_t i = 0; i < giNumberOfLevels; i++)
 		file->WriteLE<uint8_t>(player._pLvlVisited[i] ? 1 : 0);
 	for (uint8_t i = 0; i < giNumberOfLevels; i++)

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1510,7 +1510,7 @@ static void SavePlayer(SaveHelper *file, int p)
 	file->WriteLE<int32_t>(player._pVar5);
 	file->WriteLE<int32_t>(player.position.offset2.deltaX);
 	file->WriteLE<int32_t>(player.position.offset2.deltaY);
-	file->WriteLE<int32_t>(0); // Write actionFrame for vanilla compatibility
+	file->Skip<int32_t>(); // Skip _pVar8
 
 	for (uint8_t i = 0; i < giNumberOfLevels; i++)
 		file->WriteLE<uint8_t>(player._pLvlVisited[i] ? 1 : 0);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1311,7 +1311,6 @@ static void SaveItem(SaveHelper *file, ItemStruct *pItem)
 	// write _iAnimWidth2 for vanilla compatibility
 	file->WriteLE<int32_t>(CalculateWidth2(ItemAnimWidth));
 	file->Skip<uint32_t>(); // _delFlag, unused since 1.02
-
 	file->WriteLE<uint8_t>(pItem->_iSelFlag);
 	file->Skip(3); // Alignment
 	file->WriteLE<uint32_t>(pItem->_iPostDraw ? 1 : 0);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -100,7 +100,7 @@ public:
 	}
 
 	template<typename T>
-	constexpr void Skip(void)
+	constexpr void Skip()
 	{
 		Skip(sizeof(T));
 	}

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1651,7 +1651,7 @@ static void SaveMonster(SaveHelper *file, int i)
 	file->WriteLE<int32_t>(pMonster->position.temp.y);
 	file->WriteLE<int32_t>(pMonster->position.offset2.deltaX);
 	file->WriteLE<int32_t>(pMonster->position.offset2.deltaY);
-	file->WriteLE<int32_t>(0); // Write actionFrame for vanilla compatibility
+	file->Skip<int32_t>(); // Skip _mVar8
 	file->WriteLE<int32_t>(pMonster->_mmaxhp);
 	file->WriteLE<int32_t>(pMonster->_mhitpoints);
 

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1519,7 +1519,7 @@ static void SavePlayer(SaveHelper *file, int p)
 
 	file->Skip(2); // Alignment
 
-	file->WriteLE<int32_t>(0); // Write _pGFXLoad for vanilla compatibility
+	file->Skip<int32_t>(); // Skip _pGFXLoad
 	file->Skip(4 * 8); // Skip pointers _pNAnim
 	file->WriteLE<int32_t>(player._pNFrames);
 	file->Skip(4);     // Skip _pNWidth


### PR DESCRIPTION
Also ensuring that size_t is used consistently for size/offset types.