### PR TITLE
Fix C4244 - type conversion warnings in MSVC

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -646,7 +646,7 @@ void UiFadeIn()
 		if (fadeValue == 0 && fadeTc == 0)
 			fadeTc = SDL_GetTicks();
 		const int prevFadeValue = fadeValue;
-		fadeValue = (SDL_GetTicks() - fadeTc) / 2.083; // 32 frames @ 60hz
+		fadeValue = static_cast<int>((SDL_GetTicks() - fadeTc) / 2.083); // 32 frames @ 60hz
 		if (fadeValue > 256) {
 			fadeValue = 256;
 			fadeTc = 0;

--- a/Source/DiabloUI/ttf_render_wrapped.cpp
+++ b/Source/DiabloUI/ttf_render_wrapped.cpp
@@ -142,7 +142,7 @@ SDL_Surface *RenderUTF8_Solid_Wrapped(TTF_Font *font, const char *text, SDL_Colo
 	SDLC_SetColorKey(textbuf, 0);
 
 	// Reduced space between lines to roughly match Diablo.
-	const int lineskip = 0.7 * TTF_FontLineSkip(font);
+	const int lineskip = TTF_FontLineSkip(font) * 7 / 10; // avoids forced int > float > int conversion
 	SDL_Rect dest = { 0, 0, 0, 0 };
 	for (std::size_t line = 0; line < numLines; line++) {
 		text = strLines[line];

--- a/Source/controls/controller_motion.cpp
+++ b/Source/controls/controller_motion.cpp
@@ -76,16 +76,16 @@ bool SimulateRightStickWithDpad(ControllerButtonEvent ctrlEvent)
 		return false;
 	switch (ctrlEvent.button) {
 	case ControllerButton_BUTTON_DPAD_LEFT:
-		rightStickX = ctrlEvent.up ? 0 : -1;
+		rightStickX = ctrlEvent.up ? 0.F : -1.F;
 		break;
 	case ControllerButton_BUTTON_DPAD_RIGHT:
-		rightStickX = ctrlEvent.up ? 0 : 1;
+		rightStickX = ctrlEvent.up ? 0.F : 1.F;
 		break;
 	case ControllerButton_BUTTON_DPAD_UP:
-		rightStickY = ctrlEvent.up ? 0 : 1;
+		rightStickY = ctrlEvent.up ? 0.F : 1.F;
 		break;
 	case ControllerButton_BUTTON_DPAD_DOWN:
-		rightStickY = ctrlEvent.up ? 0 : -1;
+		rightStickY = ctrlEvent.up ? 0.F : -1.F;
 		break;
 	default:
 		return false;

--- a/Source/controls/devices/game_controller.cpp
+++ b/Source/controls/devices/game_controller.cpp
@@ -132,19 +132,19 @@ bool GameController::ProcessAxisMotion(const SDL_Event &event)
 		return false;
 	switch (event.caxis.axis) {
 	case SDL_CONTROLLER_AXIS_LEFTX:
-		leftStickXUnscaled = event.caxis.value;
+		leftStickXUnscaled = static_cast<float>(event.caxis.value);
 		leftStickNeedsScaling = true;
 		break;
 	case SDL_CONTROLLER_AXIS_LEFTY:
-		leftStickYUnscaled = -event.caxis.value;
+		leftStickYUnscaled = static_cast<float>(-event.caxis.value);
 		leftStickNeedsScaling = true;
 		break;
 	case SDL_CONTROLLER_AXIS_RIGHTX:
-		rightStickXUnscaled = event.caxis.value;
+		rightStickXUnscaled = static_cast<float>(event.caxis.value);
 		rightStickNeedsScaling = true;
 		break;
 	case SDL_CONTROLLER_AXIS_RIGHTY:
-		rightStickYUnscaled = -event.caxis.value;
+		rightStickYUnscaled = static_cast<float>(-event.caxis.value);
 		rightStickNeedsScaling = true;
 		break;
 	default:

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1175,8 +1175,8 @@ struct RightStickAccumulator {
 		const int dtc = tc - lastTc;
 		hiresDX += rightStickX * dtc;
 		hiresDY += rightStickY * dtc;
-		const int dx = hiresDX / slowdown;
-		const int dy = hiresDY / slowdown;
+		const int dx = static_cast<int>(hiresDX / slowdown);
+		const int dy = static_cast<int>(hiresDY / slowdown);
 		*x += dx;
 		*y -= dy;
 		lastTc = tc;

--- a/Source/controls/touch.cpp
+++ b/Source/controls/touch.cpp
@@ -148,8 +148,8 @@ static void PreprocessFingerDown(SDL_Event *event)
 	int y = mouse_y;
 
 	if (direct_touch) {
-		x = event->tfinger.x * visible_width + x_borderwidth;
-		y = event->tfinger.y * visible_height + y_borderwidth;
+		x = static_cast<int>(event->tfinger.x * visible_width) + x_borderwidth;
+		y = static_cast<int>(event->tfinger.y * visible_height) + y_borderwidth;
 		devilution::OutputToLogical(&x, &y);
 	}
 
@@ -269,8 +269,8 @@ static void PreprocessFingerUp(SDL_Event *event)
 				// need to raise the button later
 				simulated_click_start_time[port][0] = event->tfinger.timestamp;
 				if (direct_touch) {
-					x = event->tfinger.x * visible_width + x_borderwidth;
-					y = event->tfinger.y * visible_height + y_borderwidth;
+					x = static_cast<int>(event->tfinger.x * visible_width) + x_borderwidth;
+					y = static_cast<int>(event->tfinger.y * visible_height) + y_borderwidth;
 					devilution::OutputToLogical(&x, &y);
 				}
 			}
@@ -311,27 +311,25 @@ static void PreprocessFingerMotion(SDL_Event *event)
 	if (numFingersDown >= 1) {
 		int x = mouse_x;
 		int y = mouse_y;
-		int xrel = 0;
-		int yrel = 0;
 
 		if (direct_touch) {
-			x = event->tfinger.x * visible_width + x_borderwidth;
-			y = event->tfinger.y * visible_height + y_borderwidth;
+			x = static_cast<int>(event->tfinger.x * visible_width) + x_borderwidth;
+			y = static_cast<int>(event->tfinger.y * visible_height) + y_borderwidth;
 			devilution::OutputToLogical(&x, &y);
 		} else {
 			// for relative mode, use the pointer speed setting
-			float speedFactor = 1.0;
+			constexpr float speedFactor = 1.25F;
 
 			// convert touch events to relative mouse pointer events
 			// Whenever an SDL_event involving the mouse is processed,
-			x = (mouse_x + (event->tfinger.dx * 1.25 * speedFactor * devilution::GetOutputSurface()->w));
-			y = (mouse_y + (event->tfinger.dy * 1.25 * speedFactor * devilution::GetOutputSurface()->h));
+			x = static_cast<int>(mouse_x + (event->tfinger.dx * speedFactor * devilution::GetOutputSurface()->w));
+			y = static_cast<int>(mouse_y + (event->tfinger.dy * speedFactor * devilution::GetOutputSurface()->h));
 		}
 
 		x = clip(x, 0, devilution::GetOutputSurface()->w);
 		y = clip(y, 0, devilution::GetOutputSurface()->h);
-		xrel = x - mouse_x;
-		yrel = y - mouse_y;
+		int xrel = x - mouse_x;
+		int yrel = y - mouse_y;
 
 		// update the current finger's coordinates so we can track it later
 		for (int i = 0; i < MaxNumFingers; i++) {

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -61,15 +61,15 @@ float AnimationInfo::GetAnimationProgress() const
 	if (RelevantFramesForDistributing <= 0) {
 		// This logic is used if animation distrubtion is not active (see GetFrameToUseForRendering).
 		// In this case the variables calculated with animation distribution are not initialized and we have to calculate them on the fly with the given information.
-		float ticksPerFrame = (TicksPerFrame + 1);
-		float totalTicksForCurrentAnimationSequence = GetProgressToNextGameTick() + (float)CurrentFrame + (TickCounterOfCurrentFrame / ticksPerFrame);
-		float fAnimationFraction = totalTicksForCurrentAnimationSequence / ((float)NumberOfFrames * ticksPerFrame);
+		float ticksPerFrame = TicksPerFrame + 1.F;
+		float totalTicksForCurrentAnimationSequence = GetProgressToNextGameTick() + CurrentFrame + (TickCounterOfCurrentFrame / ticksPerFrame);
+		float fAnimationFraction = totalTicksForCurrentAnimationSequence / (NumberOfFrames * ticksPerFrame);
 		return fAnimationFraction;
 	}
 
-	float totalTicksForCurrentAnimationSequence = GetProgressToNextGameTick() + (float)TicksSinceSequenceStarted;
+	float totalTicksForCurrentAnimationSequence = GetProgressToNextGameTick() + TicksSinceSequenceStarted;
 	float fProgressInAnimationFrames = totalTicksForCurrentAnimationSequence * TickModifier;
-	float fAnimationFraction = fProgressInAnimationFrames / (float)NumberOfFrames;
+	float fAnimationFraction = fProgressInAnimationFrames / NumberOfFrames;
 	return fAnimationFraction;
 }
 

--- a/Source/hwcursor.cpp
+++ b/Source/hwcursor.cpp
@@ -56,8 +56,8 @@ bool SetHardwareCursor(SDL_Surface *surface, HotpointPosition hotpointPosition)
 		// SDL does not support BlitScaled from 8-bit to RGBA.
 		SDLSurfaceUniquePtr converted { SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_ARGB8888, 0) };
 
-		const int scaledW = surface->w * scaleX; // NOLINT(bugprone-narrowing-conversions)
-		const int scaledH = surface->h * scaleY; // NOLINT(bugprone-narrowing-conversions)
+		const int scaledW = static_cast<int>(surface->w * scaleX);
+		const int scaledH = static_cast<int>(surface->h * scaleY);
 		SDLSurfaceUniquePtr scaledSurface { SDL_CreateRGBSurfaceWithFormat(0, scaledW, scaledH, 32, SDL_PIXELFORMAT_ARGB8888) };
 		SDL_BlitScaled(converted.get(), nullptr, scaledSurface.get(), nullptr);
 		const Point hotpoint = GetHotpointPosition(*scaledSurface, hotpointPosition);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4257,7 +4257,7 @@ static void SpawnOnePremium(int i, int plvl, int playerId)
 			itemValue = 0;
 			break;
 		}
-		itemValue *= 0.8;
+		itemValue = itemValue * 4 / 5; // avoids forced int > float > int conversion
 
 		count++;
 	} while (keepGoing
@@ -4504,7 +4504,7 @@ void SpawnBoy(int lvl)
 			break;
 		}
 		}
-		ivalue *= 0.8;
+		ivalue = ivalue * 4 / 5; // avoids forced int > float > int conversion
 
 		count++;
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1347,12 +1347,12 @@ void AddBerserk(int mi, Point /*src*/, Point dst, int /*midir*/, int8_t /*mienem
 				continue;
 
 			i = 6;
-			auto slvl = static_cast<double>(GetSpellLevel(id, SPL_BERSERK));
+			auto slvl = GetSpellLevel(id, SPL_BERSERK);
 			monster[dm]._mFlags |= MFLAG_BERSERK | MFLAG_GOLEM;
-			monster[dm].mMinDamage = ((double)(GenerateRnd(10) + 20) / 100 + 1) * (double)monster[dm].mMinDamage + slvl;
-			monster[dm].mMaxDamage = ((double)(GenerateRnd(10) + 20) / 100 + 1) * (double)monster[dm].mMaxDamage + slvl;
-			monster[dm].mMinDamage2 = ((double)(GenerateRnd(10) + 20) / 100 + 1) * (double)monster[dm].mMinDamage2 + slvl;
-			monster[dm].mMaxDamage2 = ((double)(GenerateRnd(10) + 20) / 100 + 1) * (double)monster[dm].mMaxDamage2 + slvl;
+			monster[dm].mMinDamage = (GenerateRnd(10) + 120) * monster[dm].mMinDamage / 100 + slvl;
+			monster[dm].mMaxDamage = (GenerateRnd(10) + 120) * monster[dm].mMaxDamage / 100 + slvl;
+			monster[dm].mMinDamage2 = (GenerateRnd(10) + 120) * monster[dm].mMinDamage2 / 100 + slvl;
+			monster[dm].mMaxDamage2 = (GenerateRnd(10) + 120) * monster[dm].mMaxDamage2 / 100 + slvl;
 			int r = (currlevel < 17 || currlevel > 20) ? 3 : 9;
 			monster[dm].mlid = AddLight(monster[dm].position.tile, r);
 			UseMana(id, SPL_BERSERK);

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -2067,7 +2067,7 @@ void M_TryH2HHit(int i, int pnum, int hit, int minDam, int maxDam)
 			dam += plr[pnum]._pIGetHit << 6;
 			if (dam < 64)
 				dam = 64;
-			int mdam = dam * (0.01 * (GenerateRnd(10) + 20));
+			int mdam = dam * (GenerateRnd(10) + 20L) / 100;
 			monster[i]._mhitpoints -= mdam;
 			dam -= mdam;
 			if (dam < 0)
@@ -2112,7 +2112,7 @@ void M_TryH2HHit(int i, int pnum, int hit, int minDam, int maxDam)
 	if (pnum == myplr) {
 		if (plr[pnum].wReflections > 0) {
 			plr[pnum].wReflections--;
-			int mdam = dam * (0.01 * (GenerateRnd(10) + 20));
+			int mdam = dam * (GenerateRnd(10) + 20L) / 100;
 			monster[i]._mhitpoints -= mdam;
 			dam -= mdam;
 			if (dam < 0)

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4030,7 +4030,7 @@ bool OperateShrineGlowing(int pnum)
 	int xpLoss = 0;
 	if (playerXP > 5000) {
 		magicGain = 5;
-		xpLoss = ((double)playerXP * 0.95);
+		xpLoss = static_cast<int>(playerXP * 0.95);
 	}
 	ModifyPlrMag(myplr, magicGain);
 	plr[myplr]._pExperience = xpLoss;

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -207,7 +207,7 @@ void LoadOptions()
 	GetIniValue("Controller", "Mapping", sgOptions.Controller.szMapping, sizeof(sgOptions.Controller.szMapping), "");
 	sgOptions.Controller.bSwapShoulderButtonMode = GetIniBool("Controller", "Swap Shoulder Button Mode", false);
 	sgOptions.Controller.bDpadHotkeys = GetIniBool("Controller", "Dpad Hotkeys", false);
-	sgOptions.Controller.fDeadzone = GetIniFloat("Controller", "deadzone", 0.07);
+	sgOptions.Controller.fDeadzone = GetIniFloat("Controller", "deadzone", 0.07F);
 #ifdef __vita__
 	sgOptions.Controller.bRearTouch = GetIniBool("Controller", "Enable Rear Touchpad", true);
 #endif

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -41,9 +41,9 @@ void ApplyGamma(SDL_Color *dst, const SDL_Color *src, int n)
 	g = sgOptions.Graphics.nGammaCorrection / 100.0;
 
 	for (i = 0; i < n; i++) {
-		dst[i].r = pow(src[i].r / 256.0, g) * 256.0;
-		dst[i].g = pow(src[i].g / 256.0, g) * 256.0;
-		dst[i].b = pow(src[i].b / 256.0, g) * 256.0;
+		dst[i].r = static_cast<Uint8>(pow(src[i].r / 256.0, g) * 256.0);
+		dst[i].g = static_cast<Uint8>(pow(src[i].g / 256.0, g) * 256.0);
+		dst[i].b = static_cast<Uint8>(pow(src[i].b / 256.0, g) * 256.0);
 	}
 	force_redraw = 255;
 }

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1106,7 +1106,7 @@ void AddPlrExperience(int pnum, int lvl, int exp)
 	}
 
 	// Adjust xp based on difference in level between player and monster
-	exp *= 1 + ((double)lvl - player._pLevel) / 10;
+	exp = static_cast<int>(exp * (1 + (lvl - player._pLevel) / 10.0));
 	if (exp < 0) {
 		exp = 0;
 	}

--- a/Source/storm/storm_svid.cpp
+++ b/Source/storm/storm_svid.cpp
@@ -244,7 +244,7 @@ bool SVidPlayBegin(const char *filename, int flags)
 		ErrSdl();
 	}
 
-	SVidFrameEnd = SDL_GetTicks() * 1000 + SVidFrameLength;
+	SVidFrameEnd = SDL_GetTicks() * 1000.0 + SVidFrameLength;
 	SDL_FillRect(GetOutputSurface(), nullptr, 0x000000);
 	return true;
 }
@@ -275,7 +275,7 @@ bool SVidPlayContinue()
 		}
 	}
 
-	if (SDL_GetTicks() * 1000 >= SVidFrameEnd) {
+	if (SDL_GetTicks() * 1000.0 >= SVidFrameEnd) {
 		return SVidLoadNextFrame(); // Skip video and audio if the system is to slow
 	}
 
@@ -291,7 +291,7 @@ bool SVidPlayContinue()
 	}
 #endif
 
-	if (SDL_GetTicks() * 1000 >= SVidFrameEnd) {
+	if (SDL_GetTicks() * 1000.0 >= SVidFrameEnd) {
 		return SVidLoadNextFrame(); // Skip video if the system is to slow
 	}
 
@@ -349,9 +349,9 @@ bool SVidPlayContinue()
 
 	RenderPresent();
 
-	double now = SDL_GetTicks() * 1000;
+	double now = SDL_GetTicks() * 1000.0;
 	if (now < SVidFrameEnd) {
-		SDL_Delay((SVidFrameEnd - now) / 1000); // wait with next frame if the system is too fast
+		SDL_Delay(static_cast<Uint32>((SVidFrameEnd - now) / 1000.0)); // wait with next frame if the system is too fast
 	}
 
 	return SVidLoadNextFrame();

--- a/Source/utils/display.h
+++ b/Source/utils/display.h
@@ -58,8 +58,8 @@ void OutputToLogical(T *x, T *y)
 		return;
 	float scaleX;
 	SDL_RenderGetScale(renderer, &scaleX, NULL);
-	*x /= scaleX;
-	*y /= scaleX;
+	*x = static_cast<T>(*x / scaleX);
+	*y = static_cast<T>(*y / scaleX);
 
 	SDL_Rect view;
 	SDL_RenderGetViewport(renderer, &view);

--- a/Source/utils/display.h
+++ b/Source/utils/display.h
@@ -89,8 +89,8 @@ void LogicalToOutput(T *x, T *y)
 
 	float scaleX;
 	SDL_RenderGetScale(renderer, &scaleX, NULL);
-	*x *= scaleX;
-	*y *= scaleX;
+	*x = static_cast<T>(*x * scaleX);
+	*y = static_cast<T>(*x * scaleX);
 #else
 	if (!OutputRequiresScaling())
 		return;

--- a/Source/utils/file_util.cpp
+++ b/Source/utils/file_util.cpp
@@ -99,7 +99,8 @@ bool GetFileSize(const char *path, std::uintmax_t *size)
 	if (!GetFileAttributesExW(&pathUtf16[0], GetFileExInfoStandard, &attr)) {
 		return false;
 	}
-	*size = (attr.nFileSizeHigh) << (sizeof(attr.nFileSizeHigh) * 8) | attr.nFileSizeLow;
+	// C4293 in msvc when shifting a 32 bit type by 32 bits.
+	*size = static_cast<std::uintmax_t>(attr.nFileSizeHigh) << (sizeof(attr.nFileSizeHigh) * 8) | attr.nFileSizeLow;
 	return true;
 #else
 	struct ::stat statResult;

--- a/Source/utils/push_aulib_decoder.cpp
+++ b/Source/utils/push_aulib_decoder.cpp
@@ -68,7 +68,7 @@ int PushAulibDecoder::doDecoding(float buf[], int len, bool &callAgain)
 	callAgain = false;
 
 	const auto writeFloats = [&buf](const std::int16_t *samples, unsigned count) {
-		constexpr float Scale = std::numeric_limits<std::int16_t>::max() + 1;
+		constexpr float Scale = std::numeric_limits<std::int16_t>::max() + 1.F;
 		for (unsigned i = 0; i < count; ++i) {
 			buf[i] = static_cast<float>(samples[i]) / Scale;
 		}

--- a/Source/utils/soundsample.cpp
+++ b/Source/utils/soundsample.cpp
@@ -37,15 +37,15 @@ constexpr float VolumeScale = 3321.9281;
  * Min and max volume range, in millibel.
  * -100 dB (muted) to 0 dB (max. loudness).
  */
-constexpr float MillibelMin = -10000.0;
-constexpr float MillibelMax = 0.0;
+constexpr float MillibelMin = -10000.F;
+constexpr float MillibelMax = 0.F;
 
 /**
  * Stereo separation factor for left/right speaker panning. Lower values increase separation, moving
  * sounds further left/right, while higher values will pull sounds more towards the middle, reducing separation.
  * Current value is tuned to have ~2:1 mix for sounds that happen on the edge of a 640x480 screen.
  */
-constexpr float StereoSeparation = 6000.0;
+constexpr float StereoSeparation = 6000.F;
 
 float PanLogToLinear(int logPan)
 {
@@ -61,9 +61,8 @@ float PanLogToLinear(int logPan)
 
 float VolumeLogToLinear(int logVolume, int logMin, int logMax)
 {
-	const auto logScaled = math::Remap<float>(logMin, logMax, MillibelMin, MillibelMax, logVolume);
-	const auto linVolume = std::pow(LogBase, static_cast<float>(logScaled) / VolumeScale);
-	return linVolume;
+	const auto logScaled = math::Remap(static_cast<float>(logMin), static_cast<float>(logMax), MillibelMin, MillibelMax, static_cast<float>(logVolume));
+	return std::pow(LogBase, logScaled / VolumeScale); // linVolume
 }
 
 ///// SoundSample /////


### PR DESCRIPTION
Some of the c-style casts appeared to be unnecessary, they were either casting variables to the same type or forcing a narrower conversion than numeric conversion rules would have defaulted to. I've only checked this on MSVC, not sure if this was needed for a specific compiler.