### PR TITLE
Fix PlaceUniques calculates wrong monster type

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -927,7 +927,6 @@ static void PlaceUniques()
 			if (done)
 				break;
 		}
-		mt--;
 		if (u == UMT_GARBUD && quests[Q_GARBUD]._qactive == QUEST_NOTAVAIL)
 			done = false;
 		if (u == UMT_ZHAR && quests[Q_ZHAR]._qactive == QUEST_NOTAVAIL)


### PR DESCRIPTION
After 9ffafdfc `PlaceUniques` in monster.cpp calculates wrong monster type.
The check for `done` was [moved](https://github.com/diasurgical/devilutionX/commit/9ffafdfcc6d4aa0d1717e8df8a89d52298e6c4aa#diff-d46585089d315b53630b1035442b3d490d7b422cb05ceee76cf9041de3e39179R930).
That means that `m` was one less then before the commit.

Possible fixes:

- Move check back up
- Remove the extra decrementation.

This pr does the later.

I noted the bug cause my save game tried to load a golem as unique enemy monster. And a golem has no default stand animation, so i got a assert while loading a animation. 😉 