### PR TITLE
Add explicit casts/replace c-style casts for type conversions

### DIFF
--- a/Source/hwcursor.cpp
+++ b/Source/hwcursor.cpp
@@ -35,8 +35,8 @@ Size ScaledSize(Size size)
 		float scaleX;
 		float scaleY;
 		SDL_RenderGetScale(renderer, &scaleX, &scaleY);
-		size.width *= scaleX;  // NOLINT(bugprone-narrowing-conversions)
-		size.height *= scaleY; // NOLINT(bugprone-narrowing-conversions)
+		size.width = static_cast<int>(size.width * scaleX);
+		size.height = static_cast<int>(size.height * scaleY);
 	}
 	return size;
 }

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -919,10 +919,9 @@ void MakeLightTable()
 		for (int i = 0; i < 8; i++) {
 			for (int k = 0; k < 16; k++) {
 				for (int l = 0; l < 16; l++) {
-					double fs = (BYTE)sqrt((double)(8 * l - j) * (8 * l - j) + (8 * k - i) * (8 * k - i));
-					fs += fs < 0 ? -0.5 : 0.5;
-
-					lightblock[j * 8 + i][k][l] = fs;
+					int a = (8 * l - j);
+					int b = (8 * k - i);
+					lightblock[j * 8 + i][k][l] = static_cast<uint8_t>(sqrt(a * a + b * b));
 				}
 			}
 		}

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -321,8 +321,8 @@ static void UpdateMissileVel(int i, Point source, Point destination, int v)
 	double dxp = (destination.x + source.y - source.x - destination.y) * (1 << 21);
 	double dyp = (destination.y + destination.x - source.x - source.y) * (1 << 21);
 	double dr = sqrt(dxp * dxp + dyp * dyp);
-	Missiles[i].position.velocity.deltaX = (dxp * (v << 16)) / dr;
-	Missiles[i].position.velocity.deltaY = (dyp * (v << 15)) / dr;
+	Missiles[i].position.velocity.deltaX = static_cast<int>((dxp * (v << 16)) / dr);
+	Missiles[i].position.velocity.deltaY = static_cast<int>((dyp * (v << 15)) / dr);
 }
 
 static void PutMissile(int8_t i)


### PR DESCRIPTION
Addresses the last remaining C4244 warnings (ignoring third party code).

missiles.cpp is doing a lot of conversion between screen space and world space which really shouldn't be necessary, but I couldn't be bothered trying to unpick it now. That'll be a later job unless someone else wants to take it on.