### PR TITLE
Update some door related functions to take object by reference

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5215,21 +5215,20 @@ void SyncPedistal(int i)
 void SyncL2Doors(ObjectStruct &door)
 {
 	door._oMissFlag = door._oVar4 != 0;
-	int x = door.position.x;
-	int y = door.position.y;
 	door._oSelFlag = 2;
-	if (door._otype == OBJ_L2LDOOR && door._oVar4 == 0) {
-		ObjSetMicro({ x, y }, 538);
-		dSpecial[x][y] = 0;
-	} else if (door._otype == OBJ_L2LDOOR && (door._oVar4 == 1 || door._oVar4 == 2)) {
-		ObjSetMicro({ x, y }, 13);
-		dSpecial[x][y] = 5;
-	} else if (door._otype == OBJ_L2RDOOR && door._oVar4 == 0) {
-		ObjSetMicro({ x, y }, 540);
-		dSpecial[x][y] = 0;
-	} else if (door._otype == OBJ_L2RDOOR && (door._oVar4 == 1 || door._oVar4 == 2)) {
-		ObjSetMicro({ x, y }, 17);
-		dSpecial[x][y] = 6;
+
+	bool isLeftDoor = door._otype == _object_id::OBJ_L2LDOOR; // otherwise the door is type OBJ_L2RDOOR
+
+	switch (door._oVar4) {
+	case 0:
+		ObjSetMicro(door.position, isLeftDoor ? 538 : 540);
+		dSpecial[door.position.x][door.position.y] = 0;
+		break;
+	case 1:
+	case 2:
+		ObjSetMicro(door.position, isLeftDoor ? 13 : 17);
+		dSpecial[door.position.x][door.position.y] = isLeftDoor ? 5 : 6;
+		break;
 	}
 }
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5236,17 +5236,15 @@ void SyncL2Doors(int i)
 void SyncL3Doors(int i)
 {
 	Objects[i]._oMissFlag = true;
-	int x = Objects[i].position.x;
-	int y = Objects[i].position.y;
 	Objects[i]._oSelFlag = 2;
 	if (Objects[i]._otype == OBJ_L3LDOOR && Objects[i]._oVar4 == 0) {
-		ObjSetMicro({ x, y }, 531);
+		ObjSetMicro(Objects[i].position, 531);
 	} else if (Objects[i]._otype == OBJ_L3LDOOR && (Objects[i]._oVar4 == 1 || Objects[i]._oVar4 == 2)) {
-		ObjSetMicro({ x, y }, 538);
+		ObjSetMicro(Objects[i].position, 538);
 	} else if (Objects[i]._otype == OBJ_L3RDOOR && Objects[i]._oVar4 == 0) {
-		ObjSetMicro({ x, y }, 534);
+		ObjSetMicro(Objects[i].position, 534);
 	} else if (Objects[i]._otype == OBJ_L3RDOOR && (Objects[i]._oVar4 == 1 || Objects[i]._oVar4 == 2)) {
-		ObjSetMicro({ x, y }, 541);
+		ObjSetMicro(Objects[i].position, 541);
 	}
 }
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5211,33 +5211,33 @@ void SyncL1Doors(ObjectStruct &door)
 	door._oMissFlag = true;
 	door._oSelFlag = 2;
 
-	Direction doorSetDirection { Direction::DIR_OMNI };
+	bool isLeftDoor = door._otype == _object_id::OBJ_L1LDOOR; // otherwise the door is type OBJ_L1RDOOR
+
 	if (currlevel < 17) {
-		if (door._otype == _object_id::OBJ_L1LDOOR) {
+		if (isLeftDoor) {
 			ObjSetMicro(door.position, door._oVar1 == 214 ? 408 : 393);
 			dSpecial[door.position.x][door.position.y] = 7;
 			objects_set_door_piece(door.position + Direction::DIR_NW);
-			doorSetDirection = Direction::DIR_NE;
+			DoorSet(door.position + Direction::DIR_NE, door._otype);
 		} else {
 			ObjSetMicro(door.position, 395);
 			dSpecial[door.position.x][door.position.y] = 8;
 			objects_set_door_piece(door.position + Direction::DIR_NE);
-			doorSetDirection = Direction::DIR_NW;
+			DoorSet(door.position + Direction::DIR_NW, door._otype);
 		}
 	} else {
-		if (door._otype == _object_id::OBJ_L1LDOOR) {
+		if (isLeftDoor) {
 			ObjSetMicro(door.position, 206);
 			dSpecial[door.position.x][door.position.y] = 1;
 			objects_set_door_piece(door.position + Direction::DIR_NW);
-			doorSetDirection = Direction::DIR_NE;
+			DoorSet(door.position + Direction::DIR_NE, door._otype);
 		} else {
 			ObjSetMicro(door.position, 209);
 			dSpecial[door.position.x][door.position.y] = 2;
 			objects_set_door_piece(door.position + Direction::DIR_NE);
-			doorSetDirection = Direction::DIR_NW;
+			DoorSet(door.position + Direction::DIR_NW, door._otype);
 		}
 	}
-	DoorSet(door.position + doorSetDirection, door._otype);
 }
 
 void SyncL2Doors(ObjectStruct &door)

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5158,15 +5158,12 @@ void SyncL1Doors(ObjectStruct &door)
 	}
 
 	door._oMissFlag = true;
+	door._oSelFlag = 2;
 
 	Direction doorSetDirection { Direction::DIR_OMNI };
-	door._oSelFlag = 2;
 	if (currlevel < 17) {
 		if (door._otype == _object_id::OBJ_L1LDOOR) {
-			if (door._oVar1 == 214)
-				ObjSetMicro(door.position, 408);
-			else
-				ObjSetMicro(door.position, 393);
+			ObjSetMicro(door.position, door._oVar1 == 214 ? 408 : 393);
 			dSpecial[door.position.x][door.position.y] = 7;
 			objects_set_door_piece(door.position + Direction::DIR_NW);
 			doorSetDirection = Direction::DIR_NE;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5150,20 +5150,20 @@ void SyncBreakObj(int pnum, int oi)
 		BreakBarrel(pnum, oi, 0, true, false);
 }
 
-void SyncL1Doors(int i)
+void SyncL1Doors(ObjectStruct &door)
 {
-	if (Objects[i]._oVar4 == 0) {
-		Objects[i]._oMissFlag = false;
+	if (door._oVar4 == 0) {
+		door._oMissFlag = false;
 		return;
 	}
 
-	Objects[i]._oMissFlag = true;
+	door._oMissFlag = true;
 
-	auto doorPosition = Objects[i].position;
-	Objects[i]._oSelFlag = 2;
+	auto doorPosition = door.position;
+	door._oSelFlag = 2;
 	if (currlevel < 17) {
-		if (Objects[i]._otype == OBJ_L1LDOOR) {
-			if (Objects[i]._oVar1 == 214)
+		if (door._otype == _object_id::OBJ_L1LDOOR) {
+			if (door._oVar1 == 214)
 				ObjSetMicro(doorPosition, 408);
 			else
 				ObjSetMicro(doorPosition, 393);
@@ -5177,7 +5177,7 @@ void SyncL1Doors(int i)
 			doorPosition.x--;
 		}
 	} else {
-		if (Objects[i]._otype == OBJ_L1LDOOR) {
+		if (door._otype == _object_id::OBJ_L1LDOOR) {
 			ObjSetMicro(doorPosition, 206);
 			dSpecial[doorPosition.x][doorPosition.y] = 1;
 			objects_set_door_piece(doorPosition + Direction::DIR_NW);
@@ -5189,7 +5189,7 @@ void SyncL1Doors(int i)
 			doorPosition.x--;
 		}
 	}
-	DoorSet(doorPosition, Objects[i]._otype);
+	DoorSet(doorPosition, door._otype);
 }
 
 void SyncCrux(int i)
@@ -5297,7 +5297,7 @@ void SyncObjectAnim(int o)
 	switch (Objects[o]._otype) {
 	case OBJ_L1LDOOR:
 	case OBJ_L1RDOOR:
-		SyncL1Doors(o);
+		SyncL1Doors(Objects[o]);
 		break;
 	case OBJ_L2LDOOR:
 	case OBJ_L2RDOOR:

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2278,71 +2278,102 @@ void DoorSet(int oi, Point position)
 {
 	int pn = dPiece[position.x][position.y];
 	if (currlevel < 17) {
-		if (pn == 43)
+		switch (pn) {
+		case 43:
 			ObjSetMicro(position, 392);
-		if (pn == 45)
+			break;
+		case 45:
 			ObjSetMicro(position, 394);
-		if (pn == 50 && Objects[oi]._otype == OBJ_L1LDOOR)
-			ObjSetMicro(position, 411);
-		if (pn == 50 && Objects[oi]._otype == OBJ_L1RDOOR)
-			ObjSetMicro(position, 412);
-		if (pn == 54)
+			break;
+		case 50:
+			if (Objects[oi]._otype == _object_id::OBJ_L1LDOOR)
+				ObjSetMicro(position, 411);
+			else if (Objects[oi]._otype == _object_id::OBJ_L1RDOOR)
+				ObjSetMicro(position, 412);
+			break;
+		case 54:
 			ObjSetMicro(position, 397);
-		if (pn == 55)
+			break;
+		case 55:
 			ObjSetMicro(position, 398);
-		if (pn == 61)
+			break;
+		case 61:
 			ObjSetMicro(position, 399);
-		if (pn == 67)
+			break;
+		case 67:
 			ObjSetMicro(position, 400);
-		if (pn == 68)
+			break;
+		case 68:
 			ObjSetMicro(position, 401);
-		if (pn == 69)
+			break;
+		case 69:
 			ObjSetMicro(position, 403);
-		if (pn == 70)
+			break;
+		case 70:
 			ObjSetMicro(position, 404);
-		if (pn == 72)
+			break;
+		case 72:
 			ObjSetMicro(position, 406);
-		if (pn == 212)
+			break;
+		case 212:
 			ObjSetMicro(position, 407);
-		if (pn == 354)
+			break;
+		case 354:
 			ObjSetMicro(position, 409);
-		if (pn == 355)
+			break;
+		case 355:
 			ObjSetMicro(position, 410);
-		if (pn == 411)
+			break;
+		case 411:
+		case 412:
 			ObjSetMicro(position, 396);
-		if (pn == 412)
-			ObjSetMicro(position, 396);
+			break;
+		}
 	} else {
-		if (pn == 75)
+		switch (pn) {
+		case 75:
 			ObjSetMicro(position, 204);
-		if (pn == 79)
+			break;
+		case 79:
 			ObjSetMicro(position, 208);
-		if (pn == 86 && Objects[oi]._otype == OBJ_L1LDOOR) {
-			ObjSetMicro(position, 232);
-		}
-		if (pn == 86 && Objects[oi]._otype == OBJ_L1RDOOR) {
-			ObjSetMicro(position, 234);
-		}
-		if (pn == 91)
+			break;
+		case 86:
+			if (Objects[oi]._otype == _object_id::OBJ_L1LDOOR) {
+				ObjSetMicro(position, 232);
+			}
+			if (Objects[oi]._otype == _object_id::OBJ_L1RDOOR) {
+				ObjSetMicro(position, 234);
+			}
+			break;
+		case 91:
 			ObjSetMicro(position, 215);
-		if (pn == 93)
+			break;
+		case 93:
 			ObjSetMicro(position, 218);
-		if (pn == 99)
+			break;
+		case 99:
 			ObjSetMicro(position, 220);
-		if (pn == 111)
+			break;
+		case 111:
 			ObjSetMicro(position, 222);
-		if (pn == 113)
+			break;
+		case 113:
 			ObjSetMicro(position, 224);
-		if (pn == 115)
+			break;
+		case 115:
 			ObjSetMicro(position, 226);
-		if (pn == 117)
+			break;
+		case 117:
 			ObjSetMicro(position, 228);
-		if (pn == 119)
+			break;
+		case 119:
 			ObjSetMicro(position, 230);
-		if (pn == 232)
+			break;
+		case 232:
+		case 234:
 			ObjSetMicro(position, 212);
-		if (pn == 234)
-			ObjSetMicro(position, 212);
+			break;
+		}
 	}
 }
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2274,7 +2274,7 @@ void ObjL2Special(int x1, int y1, int x2, int y2)
 	}
 }
 
-void DoorSet(int oi, Point position)
+void DoorSet(Point position, _object_id doorType)
 {
 	int pn = dPiece[position.x][position.y];
 	if (currlevel < 17) {
@@ -2286,9 +2286,9 @@ void DoorSet(int oi, Point position)
 			ObjSetMicro(position, 394);
 			break;
 		case 50:
-			if (Objects[oi]._otype == _object_id::OBJ_L1LDOOR)
+			if (doorType == _object_id::OBJ_L1LDOOR)
 				ObjSetMicro(position, 411);
-			else if (Objects[oi]._otype == _object_id::OBJ_L1RDOOR)
+			else if (doorType == _object_id::OBJ_L1RDOOR)
 				ObjSetMicro(position, 412);
 			break;
 		case 54:
@@ -2338,10 +2338,10 @@ void DoorSet(int oi, Point position)
 			ObjSetMicro(position, 208);
 			break;
 		case 86:
-			if (Objects[oi]._otype == _object_id::OBJ_L1LDOOR) {
+			if (doorType == _object_id::OBJ_L1LDOOR) {
 				ObjSetMicro(position, 232);
 			}
-			if (Objects[oi]._otype == _object_id::OBJ_L1RDOOR) {
+			if (doorType == _object_id::OBJ_L1RDOOR) {
 				ObjSetMicro(position, 234);
 			}
 			break;
@@ -2431,7 +2431,7 @@ void OperateL1RDoor(int pnum, int oi, bool sendflag)
 		objects_set_door_piece(door.position + Direction::DIR_NE);
 		door._oAnimFrame += 2;
 		door._oPreFlag = true;
-		DoorSet(oi, door.position + Direction::DIR_NW);
+		DoorSet(door.position + Direction::DIR_NW, door._otype);
 		door._oVar4 = 1;
 		door._oSelFlag = 2;
 		RedoPlayerVision();
@@ -2512,7 +2512,7 @@ void OperateL1LDoor(int pnum, int oi, bool sendflag)
 		objects_set_door_piece(door.position + Direction::DIR_NW);
 		door._oAnimFrame += 2;
 		door._oPreFlag = true;
-		DoorSet(oi, door.position + Direction::DIR_NE);
+		DoorSet(door.position + Direction::DIR_NE, door._otype);
 		door._oVar4 = 1;
 		door._oSelFlag = 2;
 		RedoPlayerVision();
@@ -5189,7 +5189,7 @@ void SyncL1Doors(int i)
 			doorPosition.x--;
 		}
 	}
-	DoorSet(i, doorPosition);
+	DoorSet(doorPosition, Objects[i]._otype);
 }
 
 void SyncCrux(int i)

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5212,22 +5212,22 @@ void SyncPedistal(int i)
 	}
 }
 
-void SyncL2Doors(int i)
+void SyncL2Doors(ObjectStruct &door)
 {
-	Objects[i]._oMissFlag = Objects[i]._oVar4 != 0;
-	int x = Objects[i].position.x;
-	int y = Objects[i].position.y;
-	Objects[i]._oSelFlag = 2;
-	if (Objects[i]._otype == OBJ_L2LDOOR && Objects[i]._oVar4 == 0) {
+	door._oMissFlag = door._oVar4 != 0;
+	int x = door.position.x;
+	int y = door.position.y;
+	door._oSelFlag = 2;
+	if (door._otype == OBJ_L2LDOOR && door._oVar4 == 0) {
 		ObjSetMicro({ x, y }, 538);
 		dSpecial[x][y] = 0;
-	} else if (Objects[i]._otype == OBJ_L2LDOOR && (Objects[i]._oVar4 == 1 || Objects[i]._oVar4 == 2)) {
+	} else if (door._otype == OBJ_L2LDOOR && (door._oVar4 == 1 || door._oVar4 == 2)) {
 		ObjSetMicro({ x, y }, 13);
 		dSpecial[x][y] = 5;
-	} else if (Objects[i]._otype == OBJ_L2RDOOR && Objects[i]._oVar4 == 0) {
+	} else if (door._otype == OBJ_L2RDOOR && door._oVar4 == 0) {
 		ObjSetMicro({ x, y }, 540);
 		dSpecial[x][y] = 0;
-	} else if (Objects[i]._otype == OBJ_L2RDOOR && (Objects[i]._oVar4 == 1 || Objects[i]._oVar4 == 2)) {
+	} else if (door._otype == OBJ_L2RDOOR && (door._oVar4 == 1 || door._oVar4 == 2)) {
 		ObjSetMicro({ x, y }, 17);
 		dSpecial[x][y] = 6;
 	}
@@ -5271,7 +5271,7 @@ void SyncObjectAnim(int o)
 		break;
 	case OBJ_L2LDOOR:
 	case OBJ_L2RDOOR:
-		SyncL2Doors(o);
+		SyncL2Doors(Objects[o]);
 		break;
 	case OBJ_L3LDOOR:
 	case OBJ_L3RDOOR:

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5233,20 +5233,20 @@ void SyncL2Doors(int i)
 	}
 }
 
-void SyncL3Doors(int i)
+void SyncL3Doors(ObjectStruct &door)
 {
-	Objects[i]._oMissFlag = true;
-	Objects[i]._oSelFlag = 2;
+	door._oMissFlag = true;
+	door._oSelFlag = 2;
 
-	bool isLeftDoor = Objects[i]._otype == _object_id::OBJ_L3LDOOR; // otherwise the door is type OBJ_L3RDOOR
+	bool isLeftDoor = door._otype == _object_id::OBJ_L3LDOOR; // otherwise the door is type OBJ_L3RDOOR
 
-	switch (Objects[i]._oVar4) {
+	switch (door._oVar4) {
 	case 0:
-		ObjSetMicro(Objects[i].position, isLeftDoor ? 531 : 534);
+		ObjSetMicro(door.position, isLeftDoor ? 531 : 534);
 		break;
 	case 1:
 	case 2:
-		ObjSetMicro(Objects[i].position, isLeftDoor ? 538 : 541);
+		ObjSetMicro(door.position, isLeftDoor ? 538 : 541);
 		break;
 	}
 }
@@ -5275,7 +5275,7 @@ void SyncObjectAnim(int o)
 		break;
 	case OBJ_L3LDOOR:
 	case OBJ_L3RDOOR:
-		SyncL3Doors(o);
+		SyncL3Doors(Objects[o]);
 		break;
 	case OBJ_CRUX1:
 	case OBJ_CRUX2:

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5150,45 +5150,6 @@ void SyncBreakObj(int pnum, int oi)
 		BreakBarrel(pnum, oi, 0, true, false);
 }
 
-void SyncL1Doors(ObjectStruct &door)
-{
-	if (door._oVar4 == 0) {
-		door._oMissFlag = false;
-		return;
-	}
-
-	door._oMissFlag = true;
-	door._oSelFlag = 2;
-
-	Direction doorSetDirection { Direction::DIR_OMNI };
-	if (currlevel < 17) {
-		if (door._otype == _object_id::OBJ_L1LDOOR) {
-			ObjSetMicro(door.position, door._oVar1 == 214 ? 408 : 393);
-			dSpecial[door.position.x][door.position.y] = 7;
-			objects_set_door_piece(door.position + Direction::DIR_NW);
-			doorSetDirection = Direction::DIR_NE;
-		} else {
-			ObjSetMicro(door.position, 395);
-			dSpecial[door.position.x][door.position.y] = 8;
-			objects_set_door_piece(door.position + Direction::DIR_NE);
-			doorSetDirection = Direction::DIR_NW;
-		}
-	} else {
-		if (door._otype == _object_id::OBJ_L1LDOOR) {
-			ObjSetMicro(door.position, 206);
-			dSpecial[door.position.x][door.position.y] = 1;
-			objects_set_door_piece(door.position + Direction::DIR_NW);
-			doorSetDirection = Direction::DIR_NE;
-		} else {
-			ObjSetMicro(door.position, 209);
-			dSpecial[door.position.x][door.position.y] = 2;
-			objects_set_door_piece(door.position + Direction::DIR_NE);
-			doorSetDirection = Direction::DIR_NW;
-		}
-	}
-	DoorSet(door.position + doorSetDirection, door._otype);
-}
-
 void SyncCrux(int i)
 {
 	bool found = true;
@@ -5238,6 +5199,45 @@ void SyncPedistal(int i)
 		ObjChangeMapResync(Objects[i]._oVar1, Objects[i]._oVar2, Objects[i]._oVar3, Objects[i]._oVar4);
 		LoadMapObjs("Levels\\L2Data\\Blood2.DUN", { 2 * setpc_x, 2 * setpc_y });
 	}
+}
+
+void SyncL1Doors(ObjectStruct &door)
+{
+	if (door._oVar4 == 0) {
+		door._oMissFlag = false;
+		return;
+	}
+
+	door._oMissFlag = true;
+	door._oSelFlag = 2;
+
+	Direction doorSetDirection { Direction::DIR_OMNI };
+	if (currlevel < 17) {
+		if (door._otype == _object_id::OBJ_L1LDOOR) {
+			ObjSetMicro(door.position, door._oVar1 == 214 ? 408 : 393);
+			dSpecial[door.position.x][door.position.y] = 7;
+			objects_set_door_piece(door.position + Direction::DIR_NW);
+			doorSetDirection = Direction::DIR_NE;
+		} else {
+			ObjSetMicro(door.position, 395);
+			dSpecial[door.position.x][door.position.y] = 8;
+			objects_set_door_piece(door.position + Direction::DIR_NE);
+			doorSetDirection = Direction::DIR_NW;
+		}
+	} else {
+		if (door._otype == _object_id::OBJ_L1LDOOR) {
+			ObjSetMicro(door.position, 206);
+			dSpecial[door.position.x][door.position.y] = 1;
+			objects_set_door_piece(door.position + Direction::DIR_NW);
+			doorSetDirection = Direction::DIR_NE;
+		} else {
+			ObjSetMicro(door.position, 209);
+			dSpecial[door.position.x][door.position.y] = 2;
+			objects_set_door_piece(door.position + Direction::DIR_NE);
+			doorSetDirection = Direction::DIR_NW;
+		}
+	}
+	DoorSet(door.position + doorSetDirection, door._otype);
 }
 
 void SyncL2Doors(ObjectStruct &door)

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2274,75 +2274,75 @@ void ObjL2Special(int x1, int y1, int x2, int y2)
 	}
 }
 
-void DoorSet(int oi, int dx, int dy)
+void DoorSet(int oi, Point position)
 {
-	int pn = dPiece[dx][dy];
+	int pn = dPiece[position.x][position.y];
 	if (currlevel < 17) {
 		if (pn == 43)
-			ObjSetMicro({ dx, dy }, 392);
+			ObjSetMicro(position, 392);
 		if (pn == 45)
-			ObjSetMicro({ dx, dy }, 394);
+			ObjSetMicro(position, 394);
 		if (pn == 50 && Objects[oi]._otype == OBJ_L1LDOOR)
-			ObjSetMicro({ dx, dy }, 411);
+			ObjSetMicro(position, 411);
 		if (pn == 50 && Objects[oi]._otype == OBJ_L1RDOOR)
-			ObjSetMicro({ dx, dy }, 412);
+			ObjSetMicro(position, 412);
 		if (pn == 54)
-			ObjSetMicro({ dx, dy }, 397);
+			ObjSetMicro(position, 397);
 		if (pn == 55)
-			ObjSetMicro({ dx, dy }, 398);
+			ObjSetMicro(position, 398);
 		if (pn == 61)
-			ObjSetMicro({ dx, dy }, 399);
+			ObjSetMicro(position, 399);
 		if (pn == 67)
-			ObjSetMicro({ dx, dy }, 400);
+			ObjSetMicro(position, 400);
 		if (pn == 68)
-			ObjSetMicro({ dx, dy }, 401);
+			ObjSetMicro(position, 401);
 		if (pn == 69)
-			ObjSetMicro({ dx, dy }, 403);
+			ObjSetMicro(position, 403);
 		if (pn == 70)
-			ObjSetMicro({ dx, dy }, 404);
+			ObjSetMicro(position, 404);
 		if (pn == 72)
-			ObjSetMicro({ dx, dy }, 406);
+			ObjSetMicro(position, 406);
 		if (pn == 212)
-			ObjSetMicro({ dx, dy }, 407);
+			ObjSetMicro(position, 407);
 		if (pn == 354)
-			ObjSetMicro({ dx, dy }, 409);
+			ObjSetMicro(position, 409);
 		if (pn == 355)
-			ObjSetMicro({ dx, dy }, 410);
+			ObjSetMicro(position, 410);
 		if (pn == 411)
-			ObjSetMicro({ dx, dy }, 396);
+			ObjSetMicro(position, 396);
 		if (pn == 412)
-			ObjSetMicro({ dx, dy }, 396);
+			ObjSetMicro(position, 396);
 	} else {
 		if (pn == 75)
-			ObjSetMicro({ dx, dy }, 204);
+			ObjSetMicro(position, 204);
 		if (pn == 79)
-			ObjSetMicro({ dx, dy }, 208);
+			ObjSetMicro(position, 208);
 		if (pn == 86 && Objects[oi]._otype == OBJ_L1LDOOR) {
-			ObjSetMicro({ dx, dy }, 232);
+			ObjSetMicro(position, 232);
 		}
 		if (pn == 86 && Objects[oi]._otype == OBJ_L1RDOOR) {
-			ObjSetMicro({ dx, dy }, 234);
+			ObjSetMicro(position, 234);
 		}
 		if (pn == 91)
-			ObjSetMicro({ dx, dy }, 215);
+			ObjSetMicro(position, 215);
 		if (pn == 93)
-			ObjSetMicro({ dx, dy }, 218);
+			ObjSetMicro(position, 218);
 		if (pn == 99)
-			ObjSetMicro({ dx, dy }, 220);
+			ObjSetMicro(position, 220);
 		if (pn == 111)
-			ObjSetMicro({ dx, dy }, 222);
+			ObjSetMicro(position, 222);
 		if (pn == 113)
-			ObjSetMicro({ dx, dy }, 224);
+			ObjSetMicro(position, 224);
 		if (pn == 115)
-			ObjSetMicro({ dx, dy }, 226);
+			ObjSetMicro(position, 226);
 		if (pn == 117)
-			ObjSetMicro({ dx, dy }, 228);
+			ObjSetMicro(position, 228);
 		if (pn == 119)
-			ObjSetMicro({ dx, dy }, 230);
+			ObjSetMicro(position, 230);
 		if (pn == 232)
-			ObjSetMicro({ dx, dy }, 212);
+			ObjSetMicro(position, 212);
 		if (pn == 234)
-			ObjSetMicro({ dx, dy }, 212);
+			ObjSetMicro(position, 212);
 	}
 }
 
@@ -2400,7 +2400,7 @@ void OperateL1RDoor(int pnum, int oi, bool sendflag)
 		objects_set_door_piece(door.position + Direction::DIR_NE);
 		door._oAnimFrame += 2;
 		door._oPreFlag = true;
-		DoorSet(oi, door.position.x - 1, door.position.y);
+		DoorSet(oi, door.position + Direction::DIR_NW);
 		door._oVar4 = 1;
 		door._oSelFlag = 2;
 		RedoPlayerVision();
@@ -2481,7 +2481,7 @@ void OperateL1LDoor(int pnum, int oi, bool sendflag)
 		objects_set_door_piece(door.position + Direction::DIR_NW);
 		door._oAnimFrame += 2;
 		door._oPreFlag = true;
-		DoorSet(oi, door.position.x, door.position.y - 1);
+		DoorSet(oi, door.position + Direction::DIR_NE);
 		door._oVar4 = 1;
 		door._oSelFlag = 2;
 		RedoPlayerVision();
@@ -5158,7 +5158,7 @@ void SyncL1Doors(int i)
 			doorPosition.x--;
 		}
 	}
-	DoorSet(i, doorPosition.x, doorPosition.y);
+	DoorSet(i, doorPosition);
 }
 
 void SyncCrux(int i)

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2274,7 +2274,7 @@ void objects_set_door_piece(Point position)
 	dpiece_defs_map_2[position.x][position.y].mt[1] = SDL_SwapLE16(piece[1]);
 }
 
-void DoorSet(Point position, _object_id doorType)
+void DoorSet(Point position, bool isLeftDoor)
 {
 	int pn = dPiece[position.x][position.y];
 	if (currlevel < 17) {
@@ -2286,10 +2286,7 @@ void DoorSet(Point position, _object_id doorType)
 			ObjSetMicro(position, 394);
 			break;
 		case 50:
-			if (doorType == _object_id::OBJ_L1LDOOR)
-				ObjSetMicro(position, 411);
-			else if (doorType == _object_id::OBJ_L1RDOOR)
-				ObjSetMicro(position, 412);
+			ObjSetMicro(position, isLeftDoor ? 411 : 412);
 			break;
 		case 54:
 			ObjSetMicro(position, 397);
@@ -2338,12 +2335,7 @@ void DoorSet(Point position, _object_id doorType)
 			ObjSetMicro(position, 208);
 			break;
 		case 86:
-			if (doorType == _object_id::OBJ_L1LDOOR) {
-				ObjSetMicro(position, 232);
-			}
-			if (doorType == _object_id::OBJ_L1RDOOR) {
-				ObjSetMicro(position, 234);
-			}
+			ObjSetMicro(position, isLeftDoor ? 232 : 234);
 			break;
 		case 91:
 			ObjSetMicro(position, 215);
@@ -2431,7 +2423,7 @@ void OperateL1RDoor(int pnum, int oi, bool sendflag)
 		objects_set_door_piece(door.position + Direction::DIR_NE);
 		door._oAnimFrame += 2;
 		door._oPreFlag = true;
-		DoorSet(door.position + Direction::DIR_NW, door._otype);
+		DoorSet(door.position + Direction::DIR_NW, false);
 		door._oVar4 = 1;
 		door._oSelFlag = 2;
 		RedoPlayerVision();
@@ -2512,7 +2504,7 @@ void OperateL1LDoor(int pnum, int oi, bool sendflag)
 		objects_set_door_piece(door.position + Direction::DIR_NW);
 		door._oAnimFrame += 2;
 		door._oPreFlag = true;
-		DoorSet(door.position + Direction::DIR_NE, door._otype);
+		DoorSet(door.position + Direction::DIR_NE, true);
 		door._oVar4 = 1;
 		door._oSelFlag = 2;
 		RedoPlayerVision();
@@ -5218,24 +5210,24 @@ void SyncL1Doors(ObjectStruct &door)
 			ObjSetMicro(door.position, door._oVar1 == 214 ? 408 : 393);
 			dSpecial[door.position.x][door.position.y] = 7;
 			objects_set_door_piece(door.position + Direction::DIR_NW);
-			DoorSet(door.position + Direction::DIR_NE, door._otype);
+			DoorSet(door.position + Direction::DIR_NE, isLeftDoor);
 		} else {
 			ObjSetMicro(door.position, 395);
 			dSpecial[door.position.x][door.position.y] = 8;
 			objects_set_door_piece(door.position + Direction::DIR_NE);
-			DoorSet(door.position + Direction::DIR_NW, door._otype);
+			DoorSet(door.position + Direction::DIR_NW, isLeftDoor);
 		}
 	} else {
 		if (isLeftDoor) {
 			ObjSetMicro(door.position, 206);
 			dSpecial[door.position.x][door.position.y] = 1;
 			objects_set_door_piece(door.position + Direction::DIR_NW);
-			DoorSet(door.position + Direction::DIR_NE, door._otype);
+			DoorSet(door.position + Direction::DIR_NE, isLeftDoor);
 		} else {
 			ObjSetMicro(door.position, 209);
 			dSpecial[door.position.x][door.position.y] = 2;
 			objects_set_door_piece(door.position + Direction::DIR_NE);
-			DoorSet(door.position + Direction::DIR_NW, door._otype);
+			DoorSet(door.position + Direction::DIR_NW, isLeftDoor);
 		}
 	}
 }

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2180,16 +2180,6 @@ void ObjSetMicro(Point position, int pn)
 	}
 }
 
-void objects_set_door_piece(Point position)
-{
-	int pn = dPiece[position.x][position.y] - 1;
-
-	uint16_t *piece = &pLevelPieces[10 * pn + 8];
-
-	dpiece_defs_map_2[position.x][position.y].mt[0] = SDL_SwapLE16(piece[0]);
-	dpiece_defs_map_2[position.x][position.y].mt[1] = SDL_SwapLE16(piece[1]);
-}
-
 void ObjSetMini(Point position, int v)
 {
 	MegaTile mega = pMegaTiles[v - 1];
@@ -2272,6 +2262,16 @@ void ObjL2Special(int x1, int y1, int x2, int y2)
 			}
 		}
 	}
+}
+
+void objects_set_door_piece(Point position)
+{
+	int pn = dPiece[position.x][position.y] - 1;
+
+	uint16_t *piece = &pLevelPieces[10 * pn + 8];
+
+	dpiece_defs_map_2[position.x][position.y].mt[0] = SDL_SwapLE16(piece[0]);
+	dpiece_defs_map_2[position.x][position.y].mt[1] = SDL_SwapLE16(piece[1]);
 }
 
 void DoorSet(Point position, _object_id doorType)

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5237,14 +5237,17 @@ void SyncL3Doors(int i)
 {
 	Objects[i]._oMissFlag = true;
 	Objects[i]._oSelFlag = 2;
-	if (Objects[i]._otype == OBJ_L3LDOOR && Objects[i]._oVar4 == 0) {
-		ObjSetMicro(Objects[i].position, 531);
-	} else if (Objects[i]._otype == OBJ_L3LDOOR && (Objects[i]._oVar4 == 1 || Objects[i]._oVar4 == 2)) {
-		ObjSetMicro(Objects[i].position, 538);
-	} else if (Objects[i]._otype == OBJ_L3RDOOR && Objects[i]._oVar4 == 0) {
-		ObjSetMicro(Objects[i].position, 534);
-	} else if (Objects[i]._otype == OBJ_L3RDOOR && (Objects[i]._oVar4 == 1 || Objects[i]._oVar4 == 2)) {
-		ObjSetMicro(Objects[i].position, 541);
+
+	bool isLeftDoor = Objects[i]._otype == _object_id::OBJ_L3LDOOR; // otherwise the door is type OBJ_L3RDOOR
+
+	switch (Objects[i]._oVar4) {
+	case 0:
+		ObjSetMicro(Objects[i].position, isLeftDoor ? 531 : 534);
+		break;
+	case 1:
+	case 2:
+		ObjSetMicro(Objects[i].position, isLeftDoor ? 538 : 541);
+		break;
 	}
 }
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5159,37 +5159,37 @@ void SyncL1Doors(ObjectStruct &door)
 
 	door._oMissFlag = true;
 
-	auto doorPosition = door.position;
+	Direction doorSetDirection { Direction::DIR_OMNI };
 	door._oSelFlag = 2;
 	if (currlevel < 17) {
 		if (door._otype == _object_id::OBJ_L1LDOOR) {
 			if (door._oVar1 == 214)
-				ObjSetMicro(doorPosition, 408);
+				ObjSetMicro(door.position, 408);
 			else
-				ObjSetMicro(doorPosition, 393);
-			dSpecial[doorPosition.x][doorPosition.y] = 7;
-			objects_set_door_piece(doorPosition + Direction::DIR_NW);
-			doorPosition.y--;
+				ObjSetMicro(door.position, 393);
+			dSpecial[door.position.x][door.position.y] = 7;
+			objects_set_door_piece(door.position + Direction::DIR_NW);
+			doorSetDirection = Direction::DIR_NE;
 		} else {
-			ObjSetMicro(doorPosition, 395);
-			dSpecial[doorPosition.x][doorPosition.y] = 8;
-			objects_set_door_piece(doorPosition + Direction::DIR_NE);
-			doorPosition.x--;
+			ObjSetMicro(door.position, 395);
+			dSpecial[door.position.x][door.position.y] = 8;
+			objects_set_door_piece(door.position + Direction::DIR_NE);
+			doorSetDirection = Direction::DIR_NW;
 		}
 	} else {
 		if (door._otype == _object_id::OBJ_L1LDOOR) {
-			ObjSetMicro(doorPosition, 206);
-			dSpecial[doorPosition.x][doorPosition.y] = 1;
-			objects_set_door_piece(doorPosition + Direction::DIR_NW);
-			doorPosition.y--;
+			ObjSetMicro(door.position, 206);
+			dSpecial[door.position.x][door.position.y] = 1;
+			objects_set_door_piece(door.position + Direction::DIR_NW);
+			doorSetDirection = Direction::DIR_NE;
 		} else {
-			ObjSetMicro(doorPosition, 209);
-			dSpecial[doorPosition.x][doorPosition.y] = 2;
-			objects_set_door_piece(doorPosition + Direction::DIR_NE);
-			doorPosition.x--;
+			ObjSetMicro(door.position, 209);
+			dSpecial[door.position.x][door.position.y] = 2;
+			objects_set_door_piece(door.position + Direction::DIR_NE);
+			doorSetDirection = Direction::DIR_NW;
 		}
 	}
-	DoorSet(doorPosition, door._otype);
+	DoorSet(door.position + doorSetDirection, door._otype);
 }
 
 void SyncCrux(int i)


### PR DESCRIPTION
Started out as trying to use point but then focused on removing the use of globals/passing object indexes around the various SyncDoors and DoorSet functions.

Probably easiest to go through this one by commit as well since I moved a couple of functions to be defined next to the related functions.