### PR TITLE
Revert "Add explicit cast for LogicalToOutput"

### DIFF
--- a/Source/utils/display.h
+++ b/Source/utils/display.h
@@ -89,8 +89,8 @@ void LogicalToOutput(T *x, T *y)
 
 	float scaleX;
 	SDL_RenderGetScale(renderer, &scaleX, NULL);
-	*x = static_cast<T>(*x * scaleX);
-	*y = static_cast<T>(*x * scaleX);
+	*x *= scaleX;
+	*y *= scaleX;
 #else
 	if (!OutputRequiresScaling())
 		return;


### PR DESCRIPTION
This reverts commit d3c36166dfd53532af9fbe8b3754c269d4db632a.
Caused cursor to jump to bottom of the screen after picking an item up