### PR TITLE
Pause game and mute music when game window loses focus

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -401,6 +401,10 @@ void UiHandleEvents(SDL_Event *event)
 			gbActive = false;
 		else if (event->window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
 			ReinitializeHardwareCursor();
+		else if (event->window.event == SDL_WINDOWEVENT_FOCUS_LOST)
+			music_mute();
+		else if (event->window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
+			music_unmute();
 	}
 #endif
 }

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1658,29 +1658,29 @@ bool MinimizePaused = false;
 
 void diablo_focus_pause()
 {
-	if (!gbIsMultiplayer) {
-		if (!minimizePaused) {
-			gameWasAlreadyPaused = PauseMode != 0;
-
-			if (!gameWasAlreadyPaused) {
-				PauseMode = 2;
-				sound_stop();
-				track_repeat_walk(false);
-			}
-
-			music_mute();
-			minimizePaused = true;
-		} else {
-			if (!gameWasAlreadyPaused) {
-				PauseMode = 0;
-			}
-
-			music_unmute();
-			minimizePaused = false;
-		}
-		
-		//force_redraw = 255;
+	if (gbIsMultiplayer) {
+		return;
 	}
+
+	if (!MinimizePaused) {
+		GameWasAlreadyPaused = PauseMode != 0;
+
+		if (!GameWasAlreadyPaused) {
+			PauseMode = 2;
+			sound_stop();
+			track_repeat_walk(false);
+		}
+
+		music_mute();
+	} else {
+		if (!GameWasAlreadyPaused) {
+			PauseMode = 0;
+		}
+
+		music_unmute();
+	}
+
+	MinimizePaused = !MinimizePaused;
 }
 
 bool PressEscKey()

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1648,7 +1648,38 @@ void diablo_pause_game()
 			sound_stop();
 			track_repeat_walk(false);
 		}
+
 		force_redraw = 255;
+	}
+}
+
+bool gameWasAlreadyPaused = false;
+bool minimizePaused = false;
+
+void diablo_focus_pause()
+{
+	if (!gbIsMultiplayer) {
+		if (!minimizePaused) {
+			gameWasAlreadyPaused = PauseMode != 0;
+
+			if (!gameWasAlreadyPaused) {
+				PauseMode = 2;
+				sound_stop();
+				track_repeat_walk(false);
+			}
+
+			music_mute();
+			minimizePaused = true;
+		} else {
+			if (!gameWasAlreadyPaused) {
+				PauseMode = 0;
+			}
+
+			music_unmute();
+			minimizePaused = false;
+		}
+		
+		//force_redraw = 255;
 	}
 }
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1653,8 +1653,8 @@ void diablo_pause_game()
 	}
 }
 
-bool gameWasAlreadyPaused = false;
-bool minimizePaused = false;
+bool GameWasAlreadyPaused = false;
+bool MinimizePaused = false;
 
 void diablo_focus_pause()
 {

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -75,6 +75,7 @@ bool StartGame(bool bNewGame, bool bSinglePlayer);
 int DiabloMain(int argc, char **argv);
 bool TryIconCurs();
 void diablo_pause_game();
+void diablo_focus_pause();
 bool PressEscKey();
 void DisableInputWndProc(uint32_t uMsg, int32_t wParam, int32_t lParam);
 void GM_Game(uint32_t uMsg, int32_t wParam, int32_t lParam);

--- a/Source/miniwin/misc_msg.cpp
+++ b/Source/miniwin/misc_msg.cpp
@@ -549,8 +549,6 @@ bool FetchMessage(tagMSG *lpMsg)
 		case SDL_WINDOWEVENT_MINIMIZED:
 		case SDL_WINDOWEVENT_MAXIMIZED:
 		case SDL_WINDOWEVENT_RESTORED:
-		case SDL_WINDOWEVENT_FOCUS_GAINED:
-		case SDL_WINDOWEVENT_FOCUS_LOST:
 #if SDL_VERSION_ATLEAST(2, 0, 5)
 		case SDL_WINDOWEVENT_TAKE_FOCUS:
 #endif
@@ -567,6 +565,14 @@ bool FetchMessage(tagMSG *lpMsg)
 		case SDL_WINDOWEVENT_CLOSE:
 			lpMsg->message = DVL_WM_QUERYENDSESSION;
 			break;
+
+		case SDL_WINDOWEVENT_FOCUS_LOST:
+		case SDL_WINDOWEVENT_FOCUS_GAINED:
+			if (gbRunGameResult) {
+				diablo_focus_pause();
+			}
+			break;
+
 		default:
 			return FalseAvail("SDL_WINDOWEVENT", e.window.event);
 		}

--- a/Source/sound.cpp
+++ b/Source/sound.cpp
@@ -306,4 +306,16 @@ int sound_get_or_set_sound_volume(int volume)
 	return sgOptions.Audio.nSoundVolume;
 }
 
+void music_mute()
+{
+	if (music)
+		music->setVolume(VolumeLogToLinear(VOLUME_MIN, VOLUME_MIN, VOLUME_MAX));
+}
+
+void music_unmute()
+{
+	if (music)
+		music->setVolume(VolumeLogToLinear(sgOptions.Audio.nMusicVolume, VOLUME_MIN, VOLUME_MAX));
+}
+
 } // namespace devilution

--- a/Source/sound.h
+++ b/Source/sound.h
@@ -65,6 +65,8 @@ void music_start(uint8_t nTrack);
 void sound_disable_music(bool disable);
 int sound_get_or_set_music_volume(int volume);
 int sound_get_or_set_sound_volume(int volume);
+void music_mute();
+void music_unmute();
 
 /* data */
 


### PR DESCRIPTION
When playing singleplayer, when the game window loses focus, I thought it would be nice to mute the music and pause the game.

This is very useful when you're playing for 10-15 at home and a pesky Teams meeting springs up and you just want to answer without having the music playing in the back.