### PR TITLE
Fallen fear: Use _mgoalvar2 for new direction instead of _mdir

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3232,7 +3232,7 @@ void MAI_Fallen(int i)
 	if (monst->_mgoal == MGOAL_RETREAT) {
 		if (monst->_mgoalvar1-- == 0) {
 			monst->_mgoal = MGOAL_NORMAL;
-			M_StartStand(i, opposite[monst->_mdir]);
+			M_StartStand(i, opposite[monst->_mgoalvar2]);
 		}
 	}
 
@@ -4716,7 +4716,7 @@ void M_FallenFear(Point position)
 		    && m->_mhitpoints >> 6 > 0) {
 			m->_mgoal = MGOAL_RETREAT;
 			m->_mgoalvar1 = rundist;
-			m->_mdir = GetDirection(position, m->position.tile);
+			m->_mgoalvar2 = GetDirection(position, m->position.tile);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2338

## Notes

- This slightly breaks save game compatibility, cause vanilla doesn't use `_mgoalvar2`. But it's only when a fallen is retreating.
- The bug is also present in vanilla. Just with a different manifestation. When you save a game with a fallen that retreated and load it again it shows the wrong animation. This is cause `SyncMonsterAnim` uses `_mdir` to load the animation. And so `_mmode` and the animation doesn't match. 😉 

## Alternative Solutions

- Introduce new Variable `RealMonsterDirection` to `MonsterStruct` 😛
- Calculate the direction from used `CelSprite` (comparing pointers) :open_mouth:

But both wouldn't fix the vanilla bug and the way `SyncMonsterAnim` is used it seams that the game expects that `_mdir` and animation always matches (this should also be the case for players etc.).

@Chance4us Thanks for reporting the issue. Could you test this PR? That would help a lot. 🙂 