### PR TITLE
ADL: Handle skipped Frames for Diablo Got-Hit Animation

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -50,6 +50,21 @@ void NewMonsterAnim(int i, AnimStruct *anim, Direction md, AnimationDistribution
 	monst->_mdir = md;
 }
 
+void StartMonsterGotHit(int monsterId)
+{
+	auto &monster = Monsters[monsterId];
+	if (monster.MType->mtype != MT_GOLEM) {
+		auto animationFlags = gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None;
+		NewMonsterAnim(monsterId, &monster.MType->Anims[MA_GOTHIT], monster._mdir, animationFlags);
+		monster._mmode = MM_GOTHIT;
+	}
+	monster.position.offset = { 0, 0 };
+	monster.position.tile = monster.position.old;
+	monster.position.future = monster.position.old;
+	M_ClearSquares(monsterId);
+	dMonster[monster.position.tile.x][monster.position.tile.y] = monsterId + 1;
+}
+
 } // namespace
 
 #define NIGHTMARE_TO_HIT_BONUS 85
@@ -1574,13 +1589,7 @@ void M_GetKnockback(int i)
 
 	M_ClearSquares(i);
 	Monsters[i].position.old += d;
-	NewMonsterAnim(i, &Monsters[i].MType->Anims[MA_GOTHIT], Monsters[i]._mdir, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
-	Monsters[i]._mmode = MM_GOTHIT;
-	Monsters[i].position.offset = { 0, 0 };
-	Monsters[i].position.tile = Monsters[i].position.old;
-	Monsters[i].position.future = Monsters[i].position.tile;
-	M_ClearSquares(i);
-	dMonster[Monsters[i].position.tile.x][Monsters[i].position.tile.y] = i + 1;
+	StartMonsterGotHit(i);
 }
 
 void M_StartHit(int i, int pnum, int dam)
@@ -1608,13 +1617,7 @@ void M_StartHit(int i, int pnum, int dam)
 			Monsters[i]._mgoalvar2 = 0;
 		}
 		if (Monsters[i]._mmode != MM_STONE) {
-			NewMonsterAnim(i, &Monsters[i].MType->Anims[MA_GOTHIT], Monsters[i]._mdir, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
-			Monsters[i]._mmode = MM_GOTHIT;
-			Monsters[i].position.offset = { 0, 0 };
-			Monsters[i].position.tile = Monsters[i].position.old;
-			Monsters[i].position.future = Monsters[i].position.old;
-			M_ClearSquares(i);
-			dMonster[Monsters[i].position.tile.x][Monsters[i].position.tile.y] = i + 1;
+			StartMonsterGotHit(i);
 		}
 	}
 }
@@ -1713,16 +1716,7 @@ void M2MStartHit(int mid, int i, int dam)
 		}
 
 		if (Monsters[mid]._mmode != MM_STONE) {
-			if (Monsters[mid].MType->mtype != MT_GOLEM) {
-				NewMonsterAnim(mid, &Monsters[mid].MType->Anims[MA_GOTHIT], Monsters[mid]._mdir, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
-				Monsters[mid]._mmode = MM_GOTHIT;
-			}
-
-			Monsters[mid].position.offset = { 0, 0 };
-			Monsters[mid].position.tile = Monsters[mid].position.old;
-			Monsters[mid].position.future = Monsters[mid].position.old;
-			M_ClearSquares(mid);
-			dMonster[Monsters[mid].position.tile.x][Monsters[mid].position.tile.y] = mid + 1;
+			StartMonsterGotHit(mid);
 		}
 	}
 }

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -55,7 +55,8 @@ void StartMonsterGotHit(int monsterId)
 	auto &monster = Monsters[monsterId];
 	if (monster.MType->mtype != MT_GOLEM) {
 		auto animationFlags = gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None;
-		NewMonsterAnim(monsterId, &monster.MType->Anims[MA_GOTHIT], monster._mdir, animationFlags);
+		int numSkippedFrames = (gbIsHellfire && monster.MType->mtype == MT_DIABLO) ? 4 : 0;
+		NewMonsterAnim(monsterId, &monster.MType->Anims[MA_GOTHIT], monster._mdir, animationFlags, numSkippedFrames);
 		monster._mmode = MM_GOTHIT;
 	}
 	monster.position.offset = { 0, 0 };
@@ -400,8 +401,6 @@ void InitMonsterGFX(int monst)
 
 	for (int anim = 0; anim < 6; anim++) {
 		int frames = MonsterData[mtype].Frames[anim];
-		if (gbIsHellfire && mtype == MT_DIABLO && anim == 3)
-			frames = 2;
 
 		if ((animletter[anim] != 's' || MonsterData[mtype].has_special) && frames > 0) {
 			char strBuff[256];

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -39,6 +39,19 @@
 
 namespace devilution {
 
+namespace {
+
+void NewMonsterAnim(int i, AnimStruct *anim, Direction md, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0)
+{
+	MonsterStruct *monst = &Monsters[i];
+	auto *pCelSprite = &*anim->CelSpritesForDirections[md];
+	monst->AnimInfo.SetNewAnimation(pCelSprite, anim->Frames, anim->Rate, flags, numSkippedFrames, distributeFramesBeforeFrame);
+	monst->_mFlags &= ~(MFLAG_LOCK_ANIMATION | MFLAG_ALLOW_SPECIAL);
+	monst->_mdir = md;
+}
+
+} // namespace
+
 #define NIGHTMARE_TO_HIT_BONUS 85
 #define HELL_TO_HIT_BONUS 120
 
@@ -1273,15 +1286,6 @@ void AddDoppelganger(MonsterStruct &monster)
 			}
 		}
 	}
-}
-
-void NewMonsterAnim(int i, AnimStruct *anim, Direction md, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0)
-{
-	MonsterStruct *monst = &Monsters[i];
-	auto *pCelSprite = &*anim->CelSpritesForDirections[md];
-	monst->AnimInfo.SetNewAnimation(pCelSprite, anim->Frames, anim->Rate, flags, numSkippedFrames, distributeFramesBeforeFrame);
-	monst->_mFlags &= ~(MFLAG_LOCK_ANIMATION | MFLAG_ALLOW_SPECIAL);
-	monst->_mdir = md;
 }
 
 bool M_Ranged(int i)


### PR DESCRIPTION
Diablo is the only monster that contains skipped frames, only for the got-hit animation and only in hellfire.
Now we get the missing frames back.

<details><summary>Example Video (10% game speed)</summary>

### Master

https://user-images.githubusercontent.com/25415264/125210759-192eaa00-e2a2-11eb-984e-184e0a36d348.mp4

### PR

https://user-images.githubusercontent.com/25415264/125210761-1df35e00-e2a2-11eb-937e-4075d0490ab8.mp4

</details>


Notes:

- No behavior changes, only animations
- Golem has no Got-Hit animation, so `NewMonsterAnim` shouldn't be called with Golem and Got-Hit. That's why I think that the path that previous didn't checked for `MT_GOLEM` should be fine.