### PR TITLE
Get rid of unchecked calls to malloc

### DIFF
--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -81,6 +81,8 @@ void dthread_send_delta(int pnum, _cmd_id cmd, byte *pbSrc, int dwLen)
 	}
 
 	pkt = static_cast<TMegaPkt *>(std::malloc(dwLen + 20));
+	if (pkt == nullptr)
+		app_fatal("Failed to allocate memory");
 	pkt->pNext = nullptr;
 	pkt->dwSpaceLeft = pnum;
 	pkt->data[0] = static_cast<byte>(cmd);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -60,6 +60,8 @@ void GetNextPacket()
 	TMegaPkt *result;
 
 	sgpCurrPkt = static_cast<TMegaPkt *>(std::malloc(sizeof(TMegaPkt)));
+	if (sgpCurrPkt == nullptr)
+		app_fatal("Failed to allocate memory");
 	sgpCurrPkt->pNext = nullptr;
 	sgpCurrPkt->dwSpaceLeft = sizeof(result->data);
 

--- a/Source/tmsg.cpp
+++ b/Source/tmsg.cpp
@@ -38,6 +38,8 @@ void tmsg_add(byte *pbMsg, uint8_t bLen)
 	TMsg **tail;
 
 	TMsg *msg = static_cast<TMsg *>(std::malloc(bLen + sizeof(*msg)));
+	if (msg == nullptr)
+		app_fatal("Failed to allocate memory");
 	msg->hdr.pNext = nullptr;
 	msg->hdr.dwTime = SDL_GetTicks() + gnTickDelay * 10;
 	msg->hdr.bLen = bLen;

--- a/Source/utils/thread.cpp
+++ b/Source/utils/thread.cpp
@@ -35,7 +35,7 @@ SDL_Thread *CreateThread(void (*handler)(), SDL_threadID *threadId)
 event_emul *StartEvent()
 {
 	event_emul *ret;
-	ret = (event_emul *)malloc(sizeof(event_emul));
+	ret = new event_emul();
 	ret->mutex = SDL_CreateMutex();
 	if (ret->mutex == nullptr) {
 		ErrSdl();
@@ -51,7 +51,7 @@ void EndEvent(event_emul *event)
 {
 	SDL_DestroyCond(event->cond);
 	SDL_DestroyMutex(event->mutex);
-	free(event);
+	delete event;
 }
 
 void SetEvent(event_emul *e)


### PR DESCRIPTION
When malloc fails, it does so silently and returns NULL. Not checking the returned value causes the program to segfault sometime later.

Such calls were replaced with new, which fails right away with bad_alloc.