### PR TITLE
Refactor NewMonsterAnim and MonsterGraphic enum

### DIFF
--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -19,7 +19,7 @@ namespace {
 void InitDeadAnimationFromMonster(DeadStruct &dead, CMonster &mon)
 {
 	int i = 0;
-	auto &animData = mon.GetAnimData(MA_DEATH);
+	auto &animData = mon.GetAnimData(MonsterGraphic::Death);
 	for (const auto &celSprite : animData.CelSpritesForDirections)
 		dead.data[i++] = celSprite->Data();
 	dead.frame = animData.Frames;

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -16,7 +16,7 @@ DeadStruct Dead[MaxDead];
 int8_t stonendx;
 
 namespace {
-void InitDeadAnimationFromMonster(DeadStruct &dead, CMonster &mon)
+void InitDeadAnimationFromMonster(DeadStruct &dead, const CMonster &mon)
 {
 	int i = 0;
 	auto &animData = mon.GetAnimData(MonsterGraphic::Death);

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -16,13 +16,14 @@ DeadStruct Dead[MaxDead];
 int8_t stonendx;
 
 namespace {
-void InitDeadAnimationFromMonster(DeadStruct &dead, const CMonster &mon)
+void InitDeadAnimationFromMonster(DeadStruct &dead, CMonster &mon)
 {
 	int i = 0;
-	for (const auto &celSprite : mon.Anims[MA_DEATH].CelSpritesForDirections)
+	auto &animData = mon.GetAnimData(MA_DEATH);
+	for (const auto &celSprite : animData.CelSpritesForDirections)
 		dead.data[i++] = celSprite->Data();
-	dead.frame = mon.Anims[MA_DEATH].Frames;
-	dead.width = mon.Anims[MA_DEATH].CelSpritesForDirections[0]->Width();
+	dead.frame = animData.Frames;
+	dead.width = animData.CelSpritesForDirections[0]->Width();
 }
 } // namespace
 

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -73,7 +73,7 @@ float AnimationInfo::GetAnimationProgress() const
 	return fAnimationFraction;
 }
 
-void AnimationInfo::SetNewAnimation(CelSprite *celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/)
+void AnimationInfo::SetNewAnimation(const CelSprite *celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/)
 {
 	if ((flags & AnimationDistributionFlags::RepeatedAction) == AnimationDistributionFlags::RepeatedAction && distributeFramesBeforeFrame != 0 && NumberOfFrames == numberOfFrames && CurrentFrame >= distributeFramesBeforeFrame && CurrentFrame != NumberOfFrames) {
 		// We showed the same Animation (for example a melee attack) before but truncated the Animation.
@@ -161,7 +161,7 @@ void AnimationInfo::SetNewAnimation(CelSprite *celSprite, int numberOfFrames, in
 	}
 }
 
-void AnimationInfo::ChangeAnimationData(CelSprite *celSprite, int numberOfFrames, int delayLen)
+void AnimationInfo::ChangeAnimationData(const CelSprite *celSprite, int numberOfFrames, int delayLen)
 {
 	if (numberOfFrames != NumberOfFrames || delayLen != TicksPerFrame) {
 		// Ensure that the CurrentFrame is still valid and that we disable ADL cause the calculcated values (for example TickModifier) could be wrong

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -39,7 +39,7 @@ public:
 	/**
 	 * @brief Pointer to Animation Sprite
 	 */
-	CelSprite *pCelSprite;
+	const CelSprite *pCelSprite;
 	/**
 	 * @brief How many game ticks are needed to advance one Animation Frame
 	 */
@@ -81,7 +81,7 @@ public:
 	 * @param numSkippedFrames Number of Frames that will be skipped (for example with modifier "faster attack")
 	 * @param distributeFramesBeforeFrame Distribute the numSkippedFrames only before this frame
 	 */
-	void SetNewAnimation(CelSprite *celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
+	void SetNewAnimation(const CelSprite *celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
 
 	/**
 	 * @brief Changes the Animation Data on-the-fly. This is needed if a animation is currently in progress and the player changes his gear.
@@ -89,7 +89,7 @@ public:
 	 * @param numberOfFrames Number of Frames in Animation
 	 * @param delayLen Delay after each Animation sequence
 	 */
-	void ChangeAnimationData(CelSprite *celSprite, int numberOfFrames, int delayLen);
+	void ChangeAnimationData(const CelSprite *celSprite, int numberOfFrames, int delayLen);
 
 	/**
 	 * @brief Process the Animation for a game tick (for example advances the frame)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2320,7 +2320,7 @@ void AddMetlHit(int mi, Point /*src*/, Point dst, int /*midir*/, int8_t /*mienem
 }
 
 namespace {
-void InitMissileAnimationFromMonster(MissileStruct &mis, int midir, const MonsterStruct &mon, int graphic)
+void InitMissileAnimationFromMonster(MissileStruct &mis, int midir, const MonsterStruct &mon, MonsterGraphic graphic)
 {
 	const AnimStruct &anim = mon.MType->GetAnimData(graphic);
 	mis._mimfnum = midir;
@@ -2341,12 +2341,12 @@ void InitMissileAnimationFromMonster(MissileStruct &mis, int midir, const Monste
 
 void AddRhino(int mi, Point src, Point dst, int midir, int8_t /*mienemy*/, int id, int /*dam*/)
 {
-	int graphic = MA_SPECIAL;
+	MonsterGraphic graphic = MonsterGraphic::Special;
 	if (Monsters[id].MType->mtype < MT_HORNED || Monsters[id].MType->mtype > MT_OBLORD) {
 		if (Monsters[id].MType->mtype < MT_NSNAKE || Monsters[id].MType->mtype > MT_GSNAKE) {
-			graphic = MA_WALK;
+			graphic = MonsterGraphic::Walk;
 		} else {
-			graphic = MA_ATTACK;
+			graphic = MonsterGraphic::Attack;
 		}
 	}
 	UpdateMissileVel(mi, src, dst, 18);
@@ -2364,7 +2364,7 @@ void AddFireman(int mi, Point src, Point dst, int midir, int8_t /*mienemy*/, int
 {
 	UpdateMissileVel(mi, src, dst, 16);
 	auto &mon = Monsters[id];
-	InitMissileAnimationFromMonster(Missiles[mi], midir, mon, MA_WALK);
+	InitMissileAnimationFromMonster(Missiles[mi], midir, mon, MonsterGraphic::Walk);
 	if (mon._uniqtype != 0)
 		Missiles[mi]._miUniqTrans = mon._uniqtrans + 1;
 	dMonster[mon.position.tile.x][mon.position.tile.y] = 0;
@@ -4324,7 +4324,7 @@ void MI_Fireman(int i)
 	if (!PosOkMissile(0, b) || (j > 0 && (Missiles[i]._miVar1 & 1) == 0)) {
 		Missiles[i].position.velocity *= -1;
 		Missiles[i]._mimfnum = opposite[Missiles[i]._mimfnum];
-		Missiles[i]._miAnimData = Monsters[src].MType->GetAnimData(MA_WALK).CelSpritesForDirections[Missiles[i]._mimfnum]->Data();
+		Missiles[i]._miAnimData = Monsters[src].MType->GetAnimData(MonsterGraphic::Walk).CelSpritesForDirections[Missiles[i]._mimfnum]->Data();
 		Missiles[i]._miVar2++;
 		if (j > 0)
 			Missiles[i]._miVar1 |= 1;
@@ -4832,13 +4832,13 @@ void missiles_process_charge()
 
 		CMonster *mon = Monsters[mis->_misource].MType;
 
-		int graphic;
+		MonsterGraphic graphic;
 		if (mon->mtype >= MT_HORNED && mon->mtype <= MT_OBLORD) {
-			graphic = MA_SPECIAL;
+			graphic = MonsterGraphic::Special;
 		} else if (mon->mtype >= MT_NSNAKE && mon->mtype <= MT_GSNAKE) {
-			graphic = MA_ATTACK;
+			graphic = MonsterGraphic::Attack;
 		} else {
-			graphic = MA_WALK;
+			graphic = MonsterGraphic::Walk;
 		}
 		Missiles[mi]._miAnimData = mon->GetAnimData(graphic).CelSpritesForDirections[mis->_mimfnum]->Data();
 	}

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2322,7 +2322,7 @@ void AddMetlHit(int mi, Point /*src*/, Point dst, int /*midir*/, int8_t /*mienem
 namespace {
 void InitMissileAnimationFromMonster(MissileStruct &mis, int midir, const MonsterStruct &mon, int graphic)
 {
-	const AnimStruct &anim = mon.MType->Anims[graphic];
+	const AnimStruct &anim = mon.MType->GetAnimData(graphic);
 	mis._mimfnum = midir;
 	mis._miAnimFlags = 0;
 	const auto &celSprite = *anim.CelSpritesForDirections[midir];
@@ -4324,7 +4324,7 @@ void MI_Fireman(int i)
 	if (!PosOkMissile(0, b) || (j > 0 && (Missiles[i]._miVar1 & 1) == 0)) {
 		Missiles[i].position.velocity *= -1;
 		Missiles[i]._mimfnum = opposite[Missiles[i]._mimfnum];
-		Missiles[i]._miAnimData = Monsters[src].MType->Anims[MA_WALK].CelSpritesForDirections[Missiles[i]._mimfnum]->Data();
+		Missiles[i]._miAnimData = Monsters[src].MType->GetAnimData(MA_WALK).CelSpritesForDirections[Missiles[i]._mimfnum]->Data();
 		Missiles[i]._miVar2++;
 		if (j > 0)
 			Missiles[i]._miVar1 |= 1;
@@ -4832,15 +4832,15 @@ void missiles_process_charge()
 
 		CMonster *mon = Monsters[mis->_misource].MType;
 
-		AnimStruct *anim;
+		int graphic;
 		if (mon->mtype >= MT_HORNED && mon->mtype <= MT_OBLORD) {
-			anim = &mon->Anims[MA_SPECIAL];
+			graphic = MA_SPECIAL;
 		} else if (mon->mtype >= MT_NSNAKE && mon->mtype <= MT_GSNAKE) {
-			anim = &mon->Anims[MA_ATTACK];
+			graphic = MA_ATTACK;
 		} else {
-			anim = &mon->Anims[MA_WALK];
+			graphic = MA_WALK;
 		}
-		Missiles[mi]._miAnimData = anim->CelSpritesForDirections[mis->_mimfnum]->Data();
+		Missiles[mi]._miAnimData = mon->GetAnimData(graphic).CelSpritesForDirections[mis->_mimfnum]->Data();
 	}
 }
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -43,7 +43,7 @@ namespace {
 
 void NewMonsterAnim(MonsterStruct& monster, int graphic, Direction md, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0)
 {
-	auto &animData = monster.MType->Anims[graphic];
+	auto &animData = monster.MType->GetAnimData(graphic);
 	auto *pCelSprite = &*animData.CelSpritesForDirections[md];
 	monster.AnimInfo.SetNewAnimation(pCelSprite, animData.Frames, animData.Rate, flags, numSkippedFrames, distributeFramesBeforeFrame);
 	monster._mFlags &= ~(MFLAG_LOCK_ANIMATION | MFLAG_ALLOW_SPECIAL);
@@ -529,7 +529,7 @@ void InitMonster(int i, Direction rd, int mtype, Point position)
 {
 	CMonster *monst = &LevelMonsterTypes[mtype];
 
-	auto &animData = monst->Anims[MA_STAND];
+	auto &animData = monst->GetAnimData(MA_STAND);
 
 	Monsters[i]._mdir = rd;
 	Monsters[i].position.tile = position;
@@ -591,7 +591,7 @@ void InitMonster(int i, Direction rd, int mtype, Point position)
 	Monsters[i].mtalkmsg = TEXT_NONE;
 
 	if (Monsters[i]._mAi == AI_GARG) {
-		Monsters[i].AnimInfo.pCelSprite = &*monst->Anims[MA_SPECIAL].CelSpritesForDirections[rd];
+		Monsters[i].AnimInfo.pCelSprite = &*monst->GetAnimData(MA_SPECIAL).CelSpritesForDirections[rd];
 		Monsters[i].AnimInfo.CurrentFrame = 1;
 		Monsters[i]._mFlags |= MFLAG_ALLOW_SPECIAL;
 		Monsters[i]._mmode = MM_SATTACK;
@@ -933,7 +933,7 @@ void PlaceUniqueMonst(int uniqindex, int miniontype, int bosspacksize)
 	}
 
 	if (monst->_mAi != AI_GARG) {
-		monst->AnimInfo.pCelSprite = &*monst->MType->Anims[MA_STAND].CelSpritesForDirections[monst->_mdir];
+		monst->AnimInfo.pCelSprite = &*monst->MType->GetAnimData(MA_STAND).CelSpritesForDirections[monst->_mdir];
 		monst->AnimInfo.CurrentFrame = GenerateRnd(monst->AnimInfo.NumberOfFrames - 1) + 1;
 		monst->_mFlags &= ~MFLAG_ALLOW_SPECIAL;
 		monst->_mmode = MM_STAND;
@@ -1103,7 +1103,7 @@ void PlaceGroup(int mtype, int num, int leaderf, int leader)
 				}
 
 				if (Monsters[ActiveMonsterCount]._mAi != AI_GARG) {
-					Monsters[ActiveMonsterCount].AnimInfo.pCelSprite = &*Monsters[ActiveMonsterCount].MType->Anims[MA_STAND].CelSpritesForDirections[Monsters[ActiveMonsterCount]._mdir];
+					Monsters[ActiveMonsterCount].AnimInfo.pCelSprite = &*Monsters[ActiveMonsterCount].MType->GetAnimData(MA_STAND).CelSpritesForDirections[Monsters[ActiveMonsterCount]._mdir];
 					Monsters[ActiveMonsterCount].AnimInfo.CurrentFrame = GenerateRnd(Monsters[ActiveMonsterCount].AnimInfo.NumberOfFrames - 1) + 1;
 					Monsters[ActiveMonsterCount]._mFlags &= ~MFLAG_ALLOW_SPECIAL;
 					Monsters[ActiveMonsterCount]._mmode = MM_STAND;
@@ -1873,8 +1873,8 @@ void M_StartHeal(int i)
 	assurance(Monsters[i].MType != nullptr, i);
 
 	MonsterStruct *monst = &Monsters[i];
-	monst->AnimInfo.pCelSprite = &*monst->MType->Anims[MA_SPECIAL].CelSpritesForDirections[monst->_mdir];
-	monst->AnimInfo.CurrentFrame = monst->MType->Anims[MA_SPECIAL].Frames;
+	monst->AnimInfo.pCelSprite = &*monst->MType->GetAnimData(MA_SPECIAL).CelSpritesForDirections[monst->_mdir];
+	monst->AnimInfo.CurrentFrame = monst->MType->GetAnimData(MA_SPECIAL).Frames;
 	monst->_mFlags |= MFLAG_LOCK_ANIMATION;
 	monst->_mmode = MM_HEAL;
 	monst->_mVar1 = monst->_mmaxhp / (16 * (GenerateRnd(5) + 4));
@@ -1898,9 +1898,9 @@ bool M_DoStand(int i)
 
 	MonsterStruct *monst = &Monsters[i];
 	if (monst->MType->mtype == MT_GOLEM)
-		monst->AnimInfo.pCelSprite = &*monst->MType->Anims[MA_WALK].CelSpritesForDirections[monst->_mdir];
+		monst->AnimInfo.pCelSprite = &*monst->MType->GetAnimData(MA_WALK).CelSpritesForDirections[monst->_mdir];
 	else
-		monst->AnimInfo.pCelSprite = &*monst->MType->Anims[MA_STAND].CelSpritesForDirections[monst->_mdir];
+		monst->AnimInfo.pCelSprite = &*monst->MType->GetAnimData(MA_STAND).CelSpritesForDirections[monst->_mdir];
 
 	if (monst->AnimInfo.CurrentFrame == monst->AnimInfo.NumberOfFrames)
 		M_Enemy(i);
@@ -2579,7 +2579,7 @@ bool M_DoDelay(int i)
 	commitment((DWORD)i < MAXMONSTERS, i);
 	commitment(Monsters[i].MType != nullptr, i);
 
-	Monsters[i].AnimInfo.pCelSprite = &*Monsters[i].MType->Anims[MA_STAND].CelSpritesForDirections[M_GetDir(i)];
+	Monsters[i].AnimInfo.pCelSprite = &*Monsters[i].MType->GetAnimData(MA_STAND).CelSpritesForDirections[M_GetDir(i)];
 	if (Monsters[i]._mAi == AI_LAZURUS) {
 		if (Monsters[i]._mVar2 > 8 || Monsters[i]._mVar2 < 0)
 			Monsters[i]._mVar2 = 8;
@@ -2611,7 +2611,7 @@ void M_WalkDir(int i, Direction md)
 {
 	assurance((DWORD)i < MAXMONSTERS, i);
 
-	int mwi = Monsters[i].MType->Anims[MA_WALK].Frames - 1;
+	int mwi = Monsters[i].MType->GetAnimData(MA_WALK).Frames - 1;
 	switch (md) {
 	case DIR_N:
 		M_StartWalk(i, 0, -MWVel[mwi][1], -1, -1, DIR_N);
@@ -3139,7 +3139,7 @@ void MAI_Sneak(int i)
 	}
 	if (monst->_mmode == MM_STAND) {
 		if (abs(mx) >= 2 || abs(my) >= 2 || v >= 4 * monst->_mint + 10)
-			monst->AnimInfo.pCelSprite = &*monst->MType->Anims[MA_STAND].CelSpritesForDirections[md];
+			monst->AnimInfo.pCelSprite = &*monst->MType->GetAnimData(MA_STAND).CelSpritesForDirections[md];
 		else
 			M_StartAttack(i);
 	}
@@ -4644,16 +4644,16 @@ void SyncMonsterAnim(int i)
 	case MM_CHARGE:
 		graphic = MA_ATTACK;
 		Monsters[i].AnimInfo.CurrentFrame = 1;
-		Monsters[i].AnimInfo.NumberOfFrames = Monsters[i].MType->Anims[MA_ATTACK].Frames;
+		Monsters[i].AnimInfo.NumberOfFrames = Monsters[i].MType->GetAnimData(MA_ATTACK).Frames;
 		break;
 	default:
 		Monsters[i].AnimInfo.CurrentFrame = 1;
-		Monsters[i].AnimInfo.NumberOfFrames = Monsters[i].MType->Anims[MA_STAND].Frames;
+		Monsters[i].AnimInfo.NumberOfFrames = Monsters[i].MType->GetAnimData(MA_STAND).Frames;
 		break;
 	}
 
-	if (Monsters[i].MType->Anims[graphic].CelSpritesForDirections[mdir])
-		Monsters[i].AnimInfo.pCelSprite = &*Monsters[i].MType->Anims[graphic].CelSpritesForDirections[mdir];
+	if (Monsters[i].MType->GetAnimData(graphic).CelSpritesForDirections[mdir])
+		Monsters[i].AnimInfo.pCelSprite = &*Monsters[i].MType->GetAnimData(graphic).CelSpritesForDirections[mdir];
 	else
 		Monsters[i].AnimInfo.pCelSprite = nullptr;
 }
@@ -5177,7 +5177,7 @@ void MonsterStruct::CheckStandAnimationIsLoaded(Direction mdir)
 {
 	if (_mmode == MM_STAND || _mmode == MM_TALK) {
 		_mdir = mdir;
-		AnimInfo.pCelSprite = &*MType->Anims[MA_STAND].CelSpritesForDirections[mdir];
+		AnimInfo.pCelSprite = &*MType->GetAnimData(MA_STAND).CelSpritesForDirections[mdir];
 	}
 }
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1402,7 +1402,6 @@ void M_StartStand(int i, Direction md)
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
 	Monsters[i].position.old = Monsters[i].position.tile;
-	Monsters[i]._mdir = md;
 	M_Enemy(i);
 }
 
@@ -1425,7 +1424,6 @@ void M_StartSpStand(int i, Direction md)
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
 	Monsters[i].position.old = Monsters[i].position.tile;
-	Monsters[i]._mdir = md;
 }
 
 void M_StartWalk(int i, int xvel, int yvel, int xadd, int yadd, Direction endDir)
@@ -1441,7 +1439,6 @@ void M_StartWalk(int i, int xvel, int yvel, int xadd, int yadd, Direction endDir
 	Monsters[i]._mVar1 = xadd;
 	Monsters[i]._mVar2 = yadd;
 	Monsters[i]._mVar3 = endDir;
-	Monsters[i]._mdir = endDir;
 	NewMonsterAnim(Monsters[i], MA_WALK, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
 	Monsters[i].position.offset2 = { 0, 0 };
 }
@@ -1464,7 +1461,6 @@ void M_StartWalk2(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int y
 	Monsters[i]._mmode = MM_WALK2;
 	Monsters[i].position.velocity = { xvel, yvel };
 	Monsters[i]._mVar3 = endDir;
-	Monsters[i]._mdir = endDir;
 	NewMonsterAnim(Monsters[i], MA_WALK, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
 	Monsters[i].position.offset2 = { 16 * xoff, 16 * yoff };
 }
@@ -1491,7 +1487,6 @@ void M_StartWalk3(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int y
 	Monsters[i]._mVar1 = fx;
 	Monsters[i]._mVar2 = fy;
 	Monsters[i]._mVar3 = endDir;
-	Monsters[i]._mdir = endDir;
 	NewMonsterAnim(Monsters[i], MA_WALK, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
 	Monsters[i].position.offset2 = { 16 * xoff, 16 * yoff };
 }
@@ -1504,7 +1499,6 @@ void M_StartAttack(int i)
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
 	Monsters[i].position.old = Monsters[i].position.tile;
-	Monsters[i]._mdir = md;
 }
 
 void M_StartRAttack(int i, missile_id missileType, int dam)
@@ -1517,7 +1511,6 @@ void M_StartRAttack(int i, missile_id missileType, int dam)
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
 	Monsters[i].position.old = Monsters[i].position.tile;
-	Monsters[i]._mdir = md;
 }
 
 void M_StartRSpAttack(int i, missile_id missileType, int dam)
@@ -1534,7 +1527,6 @@ void M_StartRSpAttack(int i, missile_id missileType, int dam)
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
 	Monsters[i].position.old = Monsters[i].position.tile;
-	Monsters[i]._mdir = md;
 }
 
 void M_StartSpAttack(int i)
@@ -1545,7 +1537,6 @@ void M_StartSpAttack(int i)
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
 	Monsters[i].position.old = Monsters[i].position.tile;
-	Monsters[i]._mdir = md;
 }
 
 void M_StartEat(int i)
@@ -1741,7 +1732,6 @@ void MonstStartKill(int i, int pnum, bool sendmsg)
 		PlayEffect(i, 2);
 
 	Direction md = pnum >= 0 ? M_GetDir(i) : monst->_mdir;
-	monst->_mdir = md;
 	NewMonsterAnim(*monst, MA_DEATH, md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
 	monst->_mmode = MM_DEATH;
 	monst->_mgoal = MGOAL_NONE;
@@ -1787,7 +1777,6 @@ void M2MStartKill(int i, int mid)
 	if (Monsters[mid].MType->mtype == MT_GOLEM)
 		md = DIR_S;
 
-	Monsters[mid]._mdir = md;
 	NewMonsterAnim(Monsters[mid], MA_DEATH, md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
 	Monsters[mid]._mmode = MM_DEATH;
 	Monsters[mid].position.offset = { 0, 0 };
@@ -1852,7 +1841,6 @@ void M_StartFadein(int i, Direction md, bool backwards)
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
 	Monsters[i].position.old = Monsters[i].position.tile;
-	Monsters[i]._mdir = md;
 	Monsters[i]._mFlags &= ~MFLAG_HIDDEN;
 	if (backwards) {
 		Monsters[i]._mFlags |= MFLAG_LOCK_ANIMATION;
@@ -1871,7 +1859,6 @@ void M_StartFadeout(int i, Direction md, bool backwards)
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
 	Monsters[i].position.old = Monsters[i].position.tile;
-	Monsters[i]._mdir = md;
 	if (backwards) {
 		Monsters[i]._mFlags |= MFLAG_LOCK_ANIMATION;
 		Monsters[i].AnimInfo.CurrentFrame = Monsters[i].AnimInfo.NumberOfFrames;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3375,7 +3375,7 @@ void MAI_Ranged(int i, missile_id missileType, bool special)
 				else
 					M_StartRAttack(i, missileType, 4);
 			} else {
-				monst->AnimInfo.pCelSprite = &*monst->MType->Anims[MA_STAND].CelSpritesForDirections[md];
+				monst->CheckStandAnimationIsLoaded(md);
 			}
 		}
 		return;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -529,6 +529,8 @@ void InitMonster(int i, Direction rd, int mtype, Point position)
 {
 	CMonster *monst = &LevelMonsterTypes[mtype];
 
+	auto &animData = monst->Anims[MA_STAND];
+
 	Monsters[i]._mdir = rd;
 	Monsters[i].position.tile = position;
 	Monsters[i].position.future = position;
@@ -539,10 +541,10 @@ void InitMonster(int i, Direction rd, int mtype, Point position)
 	Monsters[i].MType = monst;
 	Monsters[i].MData = monst->MData;
 	Monsters[i].AnimInfo = {};
-	Monsters[i].AnimInfo.pCelSprite = monst->Anims[MA_STAND].CelSpritesForDirections[rd] ? &*monst->Anims[MA_STAND].CelSpritesForDirections[rd] : nullptr;
-	Monsters[i].AnimInfo.TicksPerFrame = monst->Anims[MA_STAND].Rate;
+	Monsters[i].AnimInfo.pCelSprite = animData.CelSpritesForDirections[rd] ? &*animData.CelSpritesForDirections[rd] : nullptr;
+	Monsters[i].AnimInfo.TicksPerFrame = animData.Rate;
 	Monsters[i].AnimInfo.TickCounterOfCurrentFrame = GenerateRnd(Monsters[i].AnimInfo.TicksPerFrame - 1);
-	Monsters[i].AnimInfo.NumberOfFrames = monst->Anims[MA_STAND].Frames;
+	Monsters[i].AnimInfo.NumberOfFrames = animData.Frames;
 	Monsters[i].AnimInfo.CurrentFrame = GenerateRnd(Monsters[i].AnimInfo.NumberOfFrames - 1) + 1;
 
 	Monsters[i].mLevel = monst->MData->mLevel;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1917,7 +1917,7 @@ bool M_DoWalk(int i, int variant)
 	commitment(Monsters[i].MType != nullptr, i);
 
 	//Check if we reached new tile
-	bool isAnimationEnd = Monsters[i].AnimInfo.CurrentFrame == Monsters[i].MType->Anims[MA_WALK].Frames;
+	bool isAnimationEnd = Monsters[i].AnimInfo.CurrentFrame == Monsters[i].AnimInfo.NumberOfFrames;
 	if (isAnimationEnd) {
 		switch (variant) {
 		case MM_WALK:

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -41,13 +41,13 @@ namespace devilution {
 
 namespace {
 
-void NewMonsterAnim(int i, AnimStruct *anim, Direction md, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0)
+void NewMonsterAnim(MonsterStruct& monster, int graphic, Direction md, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0)
 {
-	MonsterStruct *monst = &Monsters[i];
-	auto *pCelSprite = &*anim->CelSpritesForDirections[md];
-	monst->AnimInfo.SetNewAnimation(pCelSprite, anim->Frames, anim->Rate, flags, numSkippedFrames, distributeFramesBeforeFrame);
-	monst->_mFlags &= ~(MFLAG_LOCK_ANIMATION | MFLAG_ALLOW_SPECIAL);
-	monst->_mdir = md;
+	auto &animData = monster.MType->Anims[graphic];
+	auto *pCelSprite = &*animData.CelSpritesForDirections[md];
+	monster.AnimInfo.SetNewAnimation(pCelSprite, animData.Frames, animData.Rate, flags, numSkippedFrames, distributeFramesBeforeFrame);
+	monster._mFlags &= ~(MFLAG_LOCK_ANIMATION | MFLAG_ALLOW_SPECIAL);
+	monster._mdir = md;
 }
 
 void StartMonsterGotHit(int monsterId)
@@ -56,7 +56,7 @@ void StartMonsterGotHit(int monsterId)
 	if (monster.MType->mtype != MT_GOLEM) {
 		auto animationFlags = gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None;
 		int numSkippedFrames = (gbIsHellfire && monster.MType->mtype == MT_DIABLO) ? 4 : 0;
-		NewMonsterAnim(monsterId, &monster.MType->Anims[MA_GOTHIT], monster._mdir, animationFlags, numSkippedFrames);
+		NewMonsterAnim(monster, MA_GOTHIT, monster._mdir, animationFlags, numSkippedFrames);
 		monster._mmode = MM_GOTHIT;
 	}
 	monster.position.offset = { 0, 0 };
@@ -1393,9 +1393,9 @@ void M_StartStand(int i, Direction md)
 {
 	ClearMVars(i);
 	if (Monsters[i].MType->mtype == MT_GOLEM)
-		NewMonsterAnim(i, &Monsters[i].MType->Anims[MA_WALK], md);
+		NewMonsterAnim(Monsters[i], MA_WALK, md);
 	else
-		NewMonsterAnim(i, &Monsters[i].MType->Anims[MA_STAND], md);
+		NewMonsterAnim(Monsters[i], MA_STAND, md);
 	Monsters[i]._mVar1 = Monsters[i]._mmode;
 	Monsters[i]._mVar2 = 0;
 	Monsters[i]._mmode = MM_STAND;
@@ -1420,7 +1420,7 @@ void M_StartDelay(int i, int len)
 
 void M_StartSpStand(int i, Direction md)
 {
-	NewMonsterAnim(i, &Monsters[i].MType->Anims[MA_SPECIAL], md);
+	NewMonsterAnim(Monsters[i], MA_SPECIAL, md);
 	Monsters[i]._mmode = MM_SPSTAND;
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
@@ -1442,7 +1442,7 @@ void M_StartWalk(int i, int xvel, int yvel, int xadd, int yadd, Direction endDir
 	Monsters[i]._mVar2 = yadd;
 	Monsters[i]._mVar3 = endDir;
 	Monsters[i]._mdir = endDir;
-	NewMonsterAnim(i, &Monsters[i].MType->Anims[MA_WALK], endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
+	NewMonsterAnim(Monsters[i], MA_WALK, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
 	Monsters[i].position.offset2 = { 0, 0 };
 }
 
@@ -1465,7 +1465,7 @@ void M_StartWalk2(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int y
 	Monsters[i].position.velocity = { xvel, yvel };
 	Monsters[i]._mVar3 = endDir;
 	Monsters[i]._mdir = endDir;
-	NewMonsterAnim(i, &Monsters[i].MType->Anims[MA_WALK], endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
+	NewMonsterAnim(Monsters[i], MA_WALK, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
 	Monsters[i].position.offset2 = { 16 * xoff, 16 * yoff };
 }
 
@@ -1492,14 +1492,14 @@ void M_StartWalk3(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int y
 	Monsters[i]._mVar2 = fy;
 	Monsters[i]._mVar3 = endDir;
 	Monsters[i]._mdir = endDir;
-	NewMonsterAnim(i, &Monsters[i].MType->Anims[MA_WALK], endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
+	NewMonsterAnim(Monsters[i], MA_WALK, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
 	Monsters[i].position.offset2 = { 16 * xoff, 16 * yoff };
 }
 
 void M_StartAttack(int i)
 {
 	Direction md = M_GetDir(i);
-	NewMonsterAnim(i, &Monsters[i].MType->Anims[MA_ATTACK], md, AnimationDistributionFlags::ProcessAnimationPending);
+	NewMonsterAnim(Monsters[i], MA_ATTACK, md, AnimationDistributionFlags::ProcessAnimationPending);
 	Monsters[i]._mmode = MM_ATTACK;
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
@@ -1510,7 +1510,7 @@ void M_StartAttack(int i)
 void M_StartRAttack(int i, missile_id missileType, int dam)
 {
 	Direction md = M_GetDir(i);
-	NewMonsterAnim(i, &Monsters[i].MType->Anims[MA_ATTACK], md, AnimationDistributionFlags::ProcessAnimationPending);
+	NewMonsterAnim(Monsters[i], MA_ATTACK, md, AnimationDistributionFlags::ProcessAnimationPending);
 	Monsters[i]._mmode = MM_RATTACK;
 	Monsters[i]._mVar1 = missileType;
 	Monsters[i]._mVar2 = dam;
@@ -1526,7 +1526,7 @@ void M_StartRSpAttack(int i, missile_id missileType, int dam)
 	int distributeFramesBeforeFrame = 0;
 	if (Monsters[i]._mAi == AI_MEGA)
 		distributeFramesBeforeFrame = Monsters[i].MData->mAFNum2;
-	NewMonsterAnim(i, &Monsters[i].MType->Anims[MA_SPECIAL], md, AnimationDistributionFlags::ProcessAnimationPending, 0, distributeFramesBeforeFrame);
+	NewMonsterAnim(Monsters[i], MA_SPECIAL, md, AnimationDistributionFlags::ProcessAnimationPending, 0, distributeFramesBeforeFrame);
 	Monsters[i]._mmode = MM_RSPATTACK;
 	Monsters[i]._mVar1 = missileType;
 	Monsters[i]._mVar2 = 0;
@@ -1540,7 +1540,7 @@ void M_StartRSpAttack(int i, missile_id missileType, int dam)
 void M_StartSpAttack(int i)
 {
 	Direction md = M_GetDir(i);
-	NewMonsterAnim(i, &Monsters[i].MType->Anims[MA_SPECIAL], md);
+	NewMonsterAnim(Monsters[i], MA_SPECIAL, md);
 	Monsters[i]._mmode = MM_SATTACK;
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
@@ -1550,7 +1550,7 @@ void M_StartSpAttack(int i)
 
 void M_StartEat(int i)
 {
-	NewMonsterAnim(i, &Monsters[i].MType->Anims[MA_SPECIAL], Monsters[i]._mdir);
+	NewMonsterAnim(Monsters[i], MA_SPECIAL, Monsters[i]._mdir);
 	Monsters[i]._mmode = MM_SATTACK;
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
@@ -1635,7 +1635,7 @@ void M_DiabloDeath(int i, bool sendmsg)
 		if (k == i || monst->_msquelch == 0)
 			continue;
 
-		NewMonsterAnim(k, &Monsters[k].MType->Anims[MA_DEATH], Monsters[k]._mdir);
+		NewMonsterAnim(Monsters[k], MA_DEATH, Monsters[k]._mdir);
 		Monsters[k]._mmode = MM_DEATH;
 		Monsters[k].position.offset = { 0, 0 };
 		Monsters[k]._mVar1 = 0;
@@ -1742,7 +1742,7 @@ void MonstStartKill(int i, int pnum, bool sendmsg)
 
 	Direction md = pnum >= 0 ? M_GetDir(i) : monst->_mdir;
 	monst->_mdir = md;
-	NewMonsterAnim(i, &monst->MType->Anims[MA_DEATH], md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
+	NewMonsterAnim(*monst, MA_DEATH, md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
 	monst->_mmode = MM_DEATH;
 	monst->_mgoal = MGOAL_NONE;
 	monst->position.offset = { 0, 0 };
@@ -1788,7 +1788,7 @@ void M2MStartKill(int i, int mid)
 		md = DIR_S;
 
 	Monsters[mid]._mdir = md;
-	NewMonsterAnim(mid, &Monsters[mid].MType->Anims[MA_DEATH], md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
+	NewMonsterAnim(Monsters[mid], MA_DEATH, md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
 	Monsters[mid]._mmode = MM_DEATH;
 	Monsters[mid].position.offset = { 0, 0 };
 	Monsters[mid].position.tile = Monsters[mid].position.old;
@@ -1847,7 +1847,7 @@ void M_StartFadein(int i, Direction md, bool backwards)
 	assurance((DWORD)i < MAXMONSTERS, i);
 	assurance(Monsters[i].MType != nullptr, i);
 
-	NewMonsterAnim(i, &Monsters[i].MType->Anims[MA_SPECIAL], md);
+	NewMonsterAnim(Monsters[i], MA_SPECIAL, md);
 	Monsters[i]._mmode = MM_FADEIN;
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
@@ -1866,7 +1866,7 @@ void M_StartFadeout(int i, Direction md, bool backwards)
 	assurance(Monsters[i].MType != nullptr, i);
 	assurance(Monsters[i].MType != nullptr, i);
 
-	NewMonsterAnim(i, &Monsters[i].MType->Anims[MA_SPECIAL], md);
+	NewMonsterAnim(Monsters[i], MA_SPECIAL, md);
 	Monsters[i]._mmode = MM_FADEOUT;
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -41,7 +41,7 @@ namespace devilution {
 
 namespace {
 
-void NewMonsterAnim(MonsterStruct& monster, int graphic, Direction md, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0)
+void NewMonsterAnim(MonsterStruct &monster, MonsterGraphic graphic, Direction md, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0)
 {
 	auto &animData = monster.MType->GetAnimData(graphic);
 	auto *pCelSprite = &*animData.CelSpritesForDirections[md];
@@ -56,7 +56,7 @@ void StartMonsterGotHit(int monsterId)
 	if (monster.MType->mtype != MT_GOLEM) {
 		auto animationFlags = gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None;
 		int numSkippedFrames = (gbIsHellfire && monster.MType->mtype == MT_DIABLO) ? 4 : 0;
-		NewMonsterAnim(monster, MA_GOTHIT, monster._mdir, animationFlags, numSkippedFrames);
+		NewMonsterAnim(monster, MonsterGraphic::GotHit, monster._mdir, animationFlags, numSkippedFrames);
 		monster._mmode = MM_GOTHIT;
 	}
 	monster.position.offset = { 0, 0 };
@@ -529,7 +529,7 @@ void InitMonster(int i, Direction rd, int mtype, Point position)
 {
 	CMonster *monst = &LevelMonsterTypes[mtype];
 
-	auto &animData = monst->GetAnimData(MA_STAND);
+	auto &animData = monst->GetAnimData(MonsterGraphic::Stand);
 
 	Monsters[i]._mdir = rd;
 	Monsters[i].position.tile = position;
@@ -591,7 +591,7 @@ void InitMonster(int i, Direction rd, int mtype, Point position)
 	Monsters[i].mtalkmsg = TEXT_NONE;
 
 	if (Monsters[i]._mAi == AI_GARG) {
-		Monsters[i].AnimInfo.pCelSprite = &*monst->GetAnimData(MA_SPECIAL).CelSpritesForDirections[rd];
+		Monsters[i].AnimInfo.pCelSprite = &*monst->GetAnimData(MonsterGraphic::Special).CelSpritesForDirections[rd];
 		Monsters[i].AnimInfo.CurrentFrame = 1;
 		Monsters[i]._mFlags |= MFLAG_ALLOW_SPECIAL;
 		Monsters[i]._mmode = MM_SATTACK;
@@ -933,7 +933,7 @@ void PlaceUniqueMonst(int uniqindex, int miniontype, int bosspacksize)
 	}
 
 	if (monst->_mAi != AI_GARG) {
-		monst->AnimInfo.pCelSprite = &*monst->MType->GetAnimData(MA_STAND).CelSpritesForDirections[monst->_mdir];
+		monst->AnimInfo.pCelSprite = &*monst->MType->GetAnimData(MonsterGraphic::Stand).CelSpritesForDirections[monst->_mdir];
 		monst->AnimInfo.CurrentFrame = GenerateRnd(monst->AnimInfo.NumberOfFrames - 1) + 1;
 		monst->_mFlags &= ~MFLAG_ALLOW_SPECIAL;
 		monst->_mmode = MM_STAND;
@@ -1103,7 +1103,7 @@ void PlaceGroup(int mtype, int num, int leaderf, int leader)
 				}
 
 				if (Monsters[ActiveMonsterCount]._mAi != AI_GARG) {
-					Monsters[ActiveMonsterCount].AnimInfo.pCelSprite = &*Monsters[ActiveMonsterCount].MType->GetAnimData(MA_STAND).CelSpritesForDirections[Monsters[ActiveMonsterCount]._mdir];
+					Monsters[ActiveMonsterCount].AnimInfo.pCelSprite = &*Monsters[ActiveMonsterCount].MType->GetAnimData(MonsterGraphic::Stand).CelSpritesForDirections[Monsters[ActiveMonsterCount]._mdir];
 					Monsters[ActiveMonsterCount].AnimInfo.CurrentFrame = GenerateRnd(Monsters[ActiveMonsterCount].AnimInfo.NumberOfFrames - 1) + 1;
 					Monsters[ActiveMonsterCount]._mFlags &= ~MFLAG_ALLOW_SPECIAL;
 					Monsters[ActiveMonsterCount]._mmode = MM_STAND;
@@ -1395,9 +1395,9 @@ void M_StartStand(int i, Direction md)
 {
 	ClearMVars(i);
 	if (Monsters[i].MType->mtype == MT_GOLEM)
-		NewMonsterAnim(Monsters[i], MA_WALK, md);
+		NewMonsterAnim(Monsters[i], MonsterGraphic::Walk, md);
 	else
-		NewMonsterAnim(Monsters[i], MA_STAND, md);
+		NewMonsterAnim(Monsters[i], MonsterGraphic::Stand, md);
 	Monsters[i]._mVar1 = Monsters[i]._mmode;
 	Monsters[i]._mVar2 = 0;
 	Monsters[i]._mmode = MM_STAND;
@@ -1421,7 +1421,7 @@ void M_StartDelay(int i, int len)
 
 void M_StartSpStand(int i, Direction md)
 {
-	NewMonsterAnim(Monsters[i], MA_SPECIAL, md);
+	NewMonsterAnim(Monsters[i], MonsterGraphic::Special, md);
 	Monsters[i]._mmode = MM_SPSTAND;
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
@@ -1441,7 +1441,7 @@ void M_StartWalk(int i, int xvel, int yvel, int xadd, int yadd, Direction endDir
 	Monsters[i]._mVar1 = xadd;
 	Monsters[i]._mVar2 = yadd;
 	Monsters[i]._mVar3 = endDir;
-	NewMonsterAnim(Monsters[i], MA_WALK, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
+	NewMonsterAnim(Monsters[i], MonsterGraphic::Walk, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
 	Monsters[i].position.offset2 = { 0, 0 };
 }
 
@@ -1463,7 +1463,7 @@ void M_StartWalk2(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int y
 	Monsters[i]._mmode = MM_WALK2;
 	Monsters[i].position.velocity = { xvel, yvel };
 	Monsters[i]._mVar3 = endDir;
-	NewMonsterAnim(Monsters[i], MA_WALK, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
+	NewMonsterAnim(Monsters[i], MonsterGraphic::Walk, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
 	Monsters[i].position.offset2 = { 16 * xoff, 16 * yoff };
 }
 
@@ -1489,14 +1489,14 @@ void M_StartWalk3(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int y
 	Monsters[i]._mVar1 = fx;
 	Monsters[i]._mVar2 = fy;
 	Monsters[i]._mVar3 = endDir;
-	NewMonsterAnim(Monsters[i], MA_WALK, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
+	NewMonsterAnim(Monsters[i], MonsterGraphic::Walk, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
 	Monsters[i].position.offset2 = { 16 * xoff, 16 * yoff };
 }
 
 void M_StartAttack(int i)
 {
 	Direction md = M_GetDir(i);
-	NewMonsterAnim(Monsters[i], MA_ATTACK, md, AnimationDistributionFlags::ProcessAnimationPending);
+	NewMonsterAnim(Monsters[i], MonsterGraphic::Attack, md, AnimationDistributionFlags::ProcessAnimationPending);
 	Monsters[i]._mmode = MM_ATTACK;
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
@@ -1506,7 +1506,7 @@ void M_StartAttack(int i)
 void M_StartRAttack(int i, missile_id missileType, int dam)
 {
 	Direction md = M_GetDir(i);
-	NewMonsterAnim(Monsters[i], MA_ATTACK, md, AnimationDistributionFlags::ProcessAnimationPending);
+	NewMonsterAnim(Monsters[i], MonsterGraphic::Attack, md, AnimationDistributionFlags::ProcessAnimationPending);
 	Monsters[i]._mmode = MM_RATTACK;
 	Monsters[i]._mVar1 = missileType;
 	Monsters[i]._mVar2 = dam;
@@ -1521,7 +1521,7 @@ void M_StartRSpAttack(int i, missile_id missileType, int dam)
 	int distributeFramesBeforeFrame = 0;
 	if (Monsters[i]._mAi == AI_MEGA)
 		distributeFramesBeforeFrame = Monsters[i].MData->mAFNum2;
-	NewMonsterAnim(Monsters[i], MA_SPECIAL, md, AnimationDistributionFlags::ProcessAnimationPending, 0, distributeFramesBeforeFrame);
+	NewMonsterAnim(Monsters[i], MonsterGraphic::Special, md, AnimationDistributionFlags::ProcessAnimationPending, 0, distributeFramesBeforeFrame);
 	Monsters[i]._mmode = MM_RSPATTACK;
 	Monsters[i]._mVar1 = missileType;
 	Monsters[i]._mVar2 = 0;
@@ -1534,7 +1534,7 @@ void M_StartRSpAttack(int i, missile_id missileType, int dam)
 void M_StartSpAttack(int i)
 {
 	Direction md = M_GetDir(i);
-	NewMonsterAnim(Monsters[i], MA_SPECIAL, md);
+	NewMonsterAnim(Monsters[i], MonsterGraphic::Special, md);
 	Monsters[i]._mmode = MM_SATTACK;
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
@@ -1543,7 +1543,7 @@ void M_StartSpAttack(int i)
 
 void M_StartEat(int i)
 {
-	NewMonsterAnim(Monsters[i], MA_SPECIAL, Monsters[i]._mdir);
+	NewMonsterAnim(Monsters[i], MonsterGraphic::Special, Monsters[i]._mdir);
 	Monsters[i]._mmode = MM_SATTACK;
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
@@ -1628,7 +1628,7 @@ void M_DiabloDeath(int i, bool sendmsg)
 		if (k == i || monst->_msquelch == 0)
 			continue;
 
-		NewMonsterAnim(Monsters[k], MA_DEATH, Monsters[k]._mdir);
+		NewMonsterAnim(Monsters[k], MonsterGraphic::Death, Monsters[k]._mdir);
 		Monsters[k]._mmode = MM_DEATH;
 		Monsters[k].position.offset = { 0, 0 };
 		Monsters[k]._mVar1 = 0;
@@ -1734,7 +1734,7 @@ void MonstStartKill(int i, int pnum, bool sendmsg)
 		PlayEffect(i, 2);
 
 	Direction md = pnum >= 0 ? M_GetDir(i) : monst->_mdir;
-	NewMonsterAnim(*monst, MA_DEATH, md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
+	NewMonsterAnim(*monst, MonsterGraphic::Death, md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
 	monst->_mmode = MM_DEATH;
 	monst->_mgoal = MGOAL_NONE;
 	monst->position.offset = { 0, 0 };
@@ -1779,7 +1779,7 @@ void M2MStartKill(int i, int mid)
 	if (Monsters[mid].MType->mtype == MT_GOLEM)
 		md = DIR_S;
 
-	NewMonsterAnim(Monsters[mid], MA_DEATH, md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
+	NewMonsterAnim(Monsters[mid], MonsterGraphic::Death, md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
 	Monsters[mid]._mmode = MM_DEATH;
 	Monsters[mid].position.offset = { 0, 0 };
 	Monsters[mid].position.tile = Monsters[mid].position.old;
@@ -1838,7 +1838,7 @@ void M_StartFadein(int i, Direction md, bool backwards)
 	assurance((DWORD)i < MAXMONSTERS, i);
 	assurance(Monsters[i].MType != nullptr, i);
 
-	NewMonsterAnim(Monsters[i], MA_SPECIAL, md);
+	NewMonsterAnim(Monsters[i], MonsterGraphic::Special, md);
 	Monsters[i]._mmode = MM_FADEIN;
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
@@ -1856,7 +1856,7 @@ void M_StartFadeout(int i, Direction md, bool backwards)
 	assurance(Monsters[i].MType != nullptr, i);
 	assurance(Monsters[i].MType != nullptr, i);
 
-	NewMonsterAnim(Monsters[i], MA_SPECIAL, md);
+	NewMonsterAnim(Monsters[i], MonsterGraphic::Special, md);
 	Monsters[i]._mmode = MM_FADEOUT;
 	Monsters[i].position.offset = { 0, 0 };
 	Monsters[i].position.future = Monsters[i].position.tile;
@@ -1873,8 +1873,8 @@ void M_StartHeal(int i)
 	assurance(Monsters[i].MType != nullptr, i);
 
 	MonsterStruct *monst = &Monsters[i];
-	monst->AnimInfo.pCelSprite = &*monst->MType->GetAnimData(MA_SPECIAL).CelSpritesForDirections[monst->_mdir];
-	monst->AnimInfo.CurrentFrame = monst->MType->GetAnimData(MA_SPECIAL).Frames;
+	monst->AnimInfo.pCelSprite = &*monst->MType->GetAnimData(MonsterGraphic::Special).CelSpritesForDirections[monst->_mdir];
+	monst->AnimInfo.CurrentFrame = monst->MType->GetAnimData(MonsterGraphic::Special).Frames;
 	monst->_mFlags |= MFLAG_LOCK_ANIMATION;
 	monst->_mmode = MM_HEAL;
 	monst->_mVar1 = monst->_mmaxhp / (16 * (GenerateRnd(5) + 4));
@@ -1898,9 +1898,9 @@ bool M_DoStand(int i)
 
 	MonsterStruct *monst = &Monsters[i];
 	if (monst->MType->mtype == MT_GOLEM)
-		monst->AnimInfo.pCelSprite = &*monst->MType->GetAnimData(MA_WALK).CelSpritesForDirections[monst->_mdir];
+		monst->AnimInfo.pCelSprite = &*monst->MType->GetAnimData(MonsterGraphic::Walk).CelSpritesForDirections[monst->_mdir];
 	else
-		monst->AnimInfo.pCelSprite = &*monst->MType->GetAnimData(MA_STAND).CelSpritesForDirections[monst->_mdir];
+		monst->AnimInfo.pCelSprite = &*monst->MType->GetAnimData(MonsterGraphic::Stand).CelSpritesForDirections[monst->_mdir];
 
 	if (monst->AnimInfo.CurrentFrame == monst->AnimInfo.NumberOfFrames)
 		M_Enemy(i);
@@ -2579,7 +2579,7 @@ bool M_DoDelay(int i)
 	commitment((DWORD)i < MAXMONSTERS, i);
 	commitment(Monsters[i].MType != nullptr, i);
 
-	Monsters[i].AnimInfo.pCelSprite = &*Monsters[i].MType->GetAnimData(MA_STAND).CelSpritesForDirections[M_GetDir(i)];
+	Monsters[i].AnimInfo.pCelSprite = &*Monsters[i].MType->GetAnimData(MonsterGraphic::Stand).CelSpritesForDirections[M_GetDir(i)];
 	if (Monsters[i]._mAi == AI_LAZURUS) {
 		if (Monsters[i]._mVar2 > 8 || Monsters[i]._mVar2 < 0)
 			Monsters[i]._mVar2 = 8;
@@ -2611,7 +2611,7 @@ void M_WalkDir(int i, Direction md)
 {
 	assurance((DWORD)i < MAXMONSTERS, i);
 
-	int mwi = Monsters[i].MType->GetAnimData(MA_WALK).Frames - 1;
+	int mwi = Monsters[i].MType->GetAnimData(MonsterGraphic::Walk).Frames - 1;
 	switch (md) {
 	case DIR_N:
 		M_StartWalk(i, 0, -MWVel[mwi][1], -1, -1, DIR_N);
@@ -3139,7 +3139,7 @@ void MAI_Sneak(int i)
 	}
 	if (monst->_mmode == MM_STAND) {
 		if (abs(mx) >= 2 || abs(my) >= 2 || v >= 4 * monst->_mint + 10)
-			monst->AnimInfo.pCelSprite = &*monst->MType->GetAnimData(MA_STAND).CelSpritesForDirections[md];
+			monst->AnimInfo.pCelSprite = &*monst->MType->GetAnimData(MonsterGraphic::Stand).CelSpritesForDirections[md];
 		else
 			M_StartAttack(i);
 	}
@@ -4611,7 +4611,7 @@ void SyncMonsterAnim(int i)
 		Monsters[i].mName = _(Monsters[i].MData->mName);
 	int mdir = Monsters[i]._mdir;
 
-	int graphic = MA_STAND;
+	MonsterGraphic graphic = MonsterGraphic::Stand;
 
 	switch (Monsters[i]._mmode) {
 	case MM_STAND:
@@ -4621,17 +4621,17 @@ void SyncMonsterAnim(int i)
 	case MM_WALK:
 	case MM_WALK2:
 	case MM_WALK3:
-		graphic = MA_WALK;
+		graphic = MonsterGraphic::Walk;
 		break;
 	case MM_ATTACK:
 	case MM_RATTACK:
-		graphic = MA_ATTACK;
+		graphic = MonsterGraphic::Attack;
 		break;
 	case MM_GOTHIT:
-		graphic = MA_GOTHIT;
+		graphic = MonsterGraphic::GotHit;
 		break;
 	case MM_DEATH:
-		graphic = MA_DEATH;
+		graphic = MonsterGraphic::Death;
 		break;
 	case MM_SATTACK:
 	case MM_FADEIN:
@@ -4639,16 +4639,16 @@ void SyncMonsterAnim(int i)
 	case MM_SPSTAND:
 	case MM_RSPATTACK:
 	case MM_HEAL:
-		graphic = MA_SPECIAL;
+		graphic = MonsterGraphic::Special;
 		break;
 	case MM_CHARGE:
-		graphic = MA_ATTACK;
+		graphic = MonsterGraphic::Attack;
 		Monsters[i].AnimInfo.CurrentFrame = 1;
-		Monsters[i].AnimInfo.NumberOfFrames = Monsters[i].MType->GetAnimData(MA_ATTACK).Frames;
+		Monsters[i].AnimInfo.NumberOfFrames = Monsters[i].MType->GetAnimData(MonsterGraphic::Attack).Frames;
 		break;
 	default:
 		Monsters[i].AnimInfo.CurrentFrame = 1;
-		Monsters[i].AnimInfo.NumberOfFrames = Monsters[i].MType->GetAnimData(MA_STAND).Frames;
+		Monsters[i].AnimInfo.NumberOfFrames = Monsters[i].MType->GetAnimData(MonsterGraphic::Stand).Frames;
 		break;
 	}
 
@@ -5177,7 +5177,7 @@ void MonsterStruct::CheckStandAnimationIsLoaded(Direction mdir)
 {
 	if (_mmode == MM_STAND || _mmode == MM_TALK) {
 		_mdir = mdir;
-		AnimInfo.pCelSprite = &*MType->GetAnimData(MA_STAND).CelSpritesForDirections[mdir];
+		AnimInfo.pCelSprite = &*MType->GetAnimData(MonsterGraphic::Stand).CelSpritesForDirections[mdir];
 	}
 }
 

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -87,13 +87,13 @@ enum MON_MODE : uint8_t {
 	MM_TALK,
 };
 
-enum {
-	MA_STAND,
-	MA_WALK,
-	MA_ATTACK,
-	MA_GOTHIT,
-	MA_DEATH,
-	MA_SPECIAL,
+enum class MonsterGraphic {
+	Stand,
+	Walk,
+	Attack,
+	GotHit,
+	Death,
+	Special,
 };
 
 enum monster_goal : uint8_t {
@@ -130,9 +130,9 @@ struct CMonster {
 	/**
 	 * @brief Returns AnimStruct for specified graphic
 	 */
-	AnimStruct& GetAnimData(int graphic)
+	AnimStruct& GetAnimData(MonsterGraphic graphic)
 	{
-		return Anims[graphic];
+		return Anims[static_cast<int>(graphic)];
 	}
 #ifndef NOSOUND
 	std::unique_ptr<TSnd> Snds[4][2];

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -130,7 +130,7 @@ struct CMonster {
 	/**
 	 * @brief Returns AnimStruct for specified graphic
 	 */
-	AnimStruct& GetAnimData(MonsterGraphic graphic)
+	const AnimStruct& GetAnimData(MonsterGraphic graphic) const
 	{
 		return Anims[static_cast<int>(graphic)];
 	}

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -127,6 +127,13 @@ struct CMonster {
 	/** placeflag enum as a flags*/
 	uint8_t mPlaceFlags;
 	AnimStruct Anims[6];
+	/**
+	 * @brief Returns AnimStruct for specified graphic
+	 */
+	AnimStruct& GetAnimData(int graphic)
+	{
+		return Anims[graphic];
+	}
 #ifndef NOSOUND
 	std::unique_ptr<TSnd> Snds[4][2];
 #endif

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -443,7 +443,7 @@ static void DrawMonster(const Surface &out, int x, int y, int mx, int my, int m)
 		return;
 	}
 
-	CelSprite &cel = *Monsters[m].AnimInfo.pCelSprite;
+	auto &cel = *Monsters[m].AnimInfo.pCelSprite;
 
 	if ((dFlags[x][y] & BFLAG_LIT) == 0) {
 		Cl2DrawLightTbl(out, mx, my, cel, nCel, 1);


### PR DESCRIPTION
After #2354 and #2361 I thought about refactoring monster animation logic a little bit.

Content:

- Less locations where `_mdir` is set
- Less locations that directly work with `AnimStruct`
- Scoped enum `MonsterGraphic`

... and there is much more to refactor but step for step 😉 