### PR TITLE
Bug fix related to monster spawning

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -797,7 +797,7 @@ void LoadDiabMonsts()
 void DeleteMonster(int i)
 {
 	ActiveMonsterCount--;
-	ActiveMonsters[i] = ActiveMonsters[ActiveMonsterCount];
+	std::swap(ActiveMonsters[i], ActiveMonsters[ActiveMonsterCount]); // This ensures alive monsters are before ActiveMonsterCount in the array and any deleted monster after
 }
 
 void NewMonsterAnim(MonsterStruct &monster, MonsterGraphic graphic, Direction md, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0)


### PR DESCRIPTION
This fixes the bug mentioned here: https://github.com/diasurgical/devilutionX/discussions/2280#discussioncomment-996030

The cause was the refactor to DeleteMonster() here: https://github.com/diasurgical/devilutionX/pull/2283/commits/71241d1a31b1e2e9e4e491fe22787557a754b708#diff-d46585089d315b53630b1035442b3d490d7b422cb05ceee76cf9041de3e39179R1235

With the two values not swapped, then values in ActiveMonsters after ActiveMonsterCount could have the same id as alive monsters, thus monsters being spawned (ie, by the skeleton king) could overwrite alive monsters and all kinds of funky stuff happened.