### PR TITLE
DiabloUI: make UiArtText follow mutating char*

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -725,7 +725,7 @@ void Render(UiText *uiText)
 
 void Render(const UiArtText *uiArtText)
 {
-	DrawArtStr(uiArtText->m_text, uiArtText->m_rect, uiArtText->m_iFlags);
+	DrawArtStr(uiArtText->text(), uiArtText->m_rect, uiArtText->m_iFlags);
 }
 
 void Render(const UiImage *uiImage)

--- a/Source/DiabloUI/selgame.cpp
+++ b/Source/DiabloUI/selgame.cpp
@@ -139,7 +139,7 @@ void selgame_GameSelection_Select(int value)
 	UiAddLogo(&vecSelGameDialog);
 
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(title, rect1, UIS_CENTER | UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(&title, rect1, UIS_CENTER | UIS_BIG));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 34), (Sint16)(UI_OFFSET_Y + 211), 205, 33 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Label, rect2, UIS_CENTER | UIS_BIG));

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -466,7 +466,7 @@ void selhero_Init()
 
 	vecSelDlgItems.clear();
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(title, rect1, UIS_CENTER | UIS_BIG));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(&title, rect1, UIS_CENTER | UIS_BIG));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 30), (Sint16)(UI_OFFSET_Y + 211), 180, 76 };
 	auto heroImg = std::make_unique<UiImage>(&ArtHero, static_cast<int>(enum_size<HeroClass>::value), rect2);

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -135,15 +135,30 @@ class UiArtText : public UiItemBase {
 public:
 	UiArtText(const char *text, SDL_Rect rect, int flags = 0)
 	    : UiItemBase(rect, flags)
+	    , m_text(text)
 	{
 		m_type = UI_ART_TEXT;
-		m_text = text;
 	};
+
+	UiArtText(const char **ptext, SDL_Rect rect, int flags = 0)
+	    : UiItemBase(rect, flags)
+	    , m_ptext(ptext)
+	{
+		m_type = UI_ART_TEXT;
+	};
+
+	const char *text() const
+	{
+		if (m_text != nullptr)
+			return m_text;
+		return *m_ptext;
+	}
 
 	~UiArtText() {};
 
-	//private:
-	const char *m_text;
+private:
+	const char *m_text = nullptr;
+	const char **m_ptext = nullptr;
 };
 
 //=============================================================================


### PR DESCRIPTION
There are two instances where a UiArtText of the title is created before setting the title.

The title used to be a char[], so updating the title before the UiArtText is draws used to be sufficient. After a change introduced in https://github.com/diasurgical/devilutionX/pull/2303, the UiArtText retains the contents of title at the time of its instantiation.

This fixes https://github.com/diasurgical/devilutionX/issues/2373 as well as something similar happening for Create/Join TCP Game.