### PR TITLE
Fix ScrollViewPort

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -170,6 +170,10 @@ void HandleWalkMode(int pnum, Displacement vel, Direction dir)
 	//The player's tile position after finishing this movement action
 	player.position.future = player.position.tile + dirModeParams.tileAdd;
 
+	if (pnum == MyPlayerId) {
+		ScrollViewPort(player, WalkSettings[dir].scrollDir);
+	}
+
 	dirModeParams.walkModeHandler(pnum, dirModeParams);
 
 	player.position.velocity = vel;
@@ -204,10 +208,6 @@ void StartWalk(int pnum, Displacement vel, Direction dir, bool pmWillBeCalled)
 
 	HandleWalkMode(pnum, vel, dir);
 	StartWalkAnimation(player, dir, pmWillBeCalled);
-
-	if (pnum == MyPlayerId) {
-		ScrollViewPort(player, WalkSettings[dir].scrollDir);
-	}
 }
 } // namespace
 


### PR DESCRIPTION
Fixes #2377

Was introduced with 5ee7edbde1fcb92daac41b58f5bdac4942261a67 

> 5ee7edbde1fcb92daac41b58f5bdac4942261a67 is the first bad commit
> commit 5ee7edbde1fcb92daac41b58f5bdac4942261a67
> Date:   Wed Jun 16 21:30:39 2021 +0100
> 
>     Refactored "StartWalk(...)" into different functions and moved tightly coupled "Direction" parameters into an array.
> 
>  Source/player.cpp | 352 +++++++++++++++++++++++++++++-------------------------
>  1 file changed, 189 insertions(+), 163 deletions(-)

Before 5ee7edbde1fcb92daac41b58f5bdac4942261a67 `ScrollViewPort` was called [before](https://github.com/diasurgical/devilutionX/commit/5ee7edbde1fcb92daac41b58f5bdac4942261a67#diff-71461699ae2f94f652e6cba2136d3c696151ba3a6c0e357eaf55438a5c212ad3L1325-L1328) the `player.position.tile` was updated.
After 5ee7edbde1fcb92daac41b58f5bdac4942261a67 `ScrollViewPort` sees the updated `player.position.tile`.