### PR TITLE
Introduce MissilePosition.StopMissile

### DIFF
--- a/Source/misdat.cpp
+++ b/Source/misdat.cpp
@@ -74,7 +74,7 @@ MissileDataStruct MissileData[] = {
 	{  &AddMisexp,                 &MI_Acidsplat,      MIS_MISEXP3,       true,      2, MISR_ACID,      MFILE_ACIDSPLA,  SFX_NONE,    SFX_NONE,    MissileMovementDistrubution::Disabled    },
 	{  &AddAcidpud,                &MI_Acidpud,        MIS_ACIDPUD,       true,      2, MISR_ACID,      MFILE_ACIDPUD,   LS_PUDDLE,   SFX_NONE,    MissileMovementDistrubution::Disabled    },
 	{  &AddHealOther,              &MI_Dummy,          MIS_HEALOTHER,     false,     1, MISR_NONE,      MFILE_NONE,      SFX_NONE,    SFX_NONE,    MissileMovementDistrubution::Disabled    },
-	{  &AddElement,                &MI_Element,        MIS_ELEMENT,       true,      1, MISR_FIRE,      MFILE_FIRERUN,   LS_ELEMENTL, SFX_NONE,    MissileMovementDistrubution::Blockable   },
+	{  &AddElement,                &MI_Element,        MIS_ELEMENT,       true,      1, MISR_FIRE,      MFILE_FIRERUN,   LS_ELEMENTL, SFX_NONE,    MissileMovementDistrubution::Unblockable },
 	{  &AddResurrectBeam,          &MI_ResurrectBeam,  MIS_RESURRECTBEAM, true,      1, MISR_NONE,      MFILE_RESSUR1,   SFX_NONE,    SFX_NONE,    MissileMovementDistrubution::Disabled    },
 	{  &AddBoneSpirit,             &MI_Bonespirit,     MIS_BONESPIRIT,    true,      1, MISR_MAGIC,     MFILE_SKLBALL,   LS_BONESP,   LS_BSIMPCT,  MissileMovementDistrubution::Blockable   },
 	{  &AddWeapexp,                &MI_Weapexp,        MIS_WEAPEXP,       true,      2, MISR_NONE,      MFILE_NONE,      SFX_NONE,    SFX_NONE,    MissileMovementDistrubution::Disabled    },

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -765,6 +765,7 @@ void FireballUpdate(int i, Displacement offset, bool alwaysDelete)
 			Missiles[i]._mimfnum = 0;
 			SetMissAnim(i, MFILE_BIGEXP);
 			Missiles[i]._mirange = Missiles[i]._miAnimLen - 1;
+			Missiles[i].position.velocity = {};
 		} else if (Missiles[i].position.tile.x != Missiles[i]._miVar1 || Missiles[i].position.tile.y != Missiles[i]._miVar2) {
 			Missiles[i]._miVar1 = Missiles[i].position.tile.x;
 			Missiles[i]._miVar2 = Missiles[i].position.tile.y;
@@ -2257,9 +2258,6 @@ void AddMisexp(int mi, Point /*src*/, Point dst, int /*midir*/, int8_t mienemy, 
 	Missiles[mi].position.offset = Missiles[dst.x].position.offset;
 	Missiles[mi].position.traveled = Missiles[dst.x].position.traveled;
 	Missiles[mi].position.velocity = { 0, 0 };
-	Missiles[mi].position.renderingIsFixed = true;
-	Missiles[mi].position.tileForRendering = Missiles[dst.x].position.tileForRendering;
-	Missiles[mi].position.offsetForRendering = Missiles[dst.x].position.offsetForRendering;
 	Missiles[mi]._mirange = Missiles[mi]._miAnimLen;
 	Missiles[mi]._miVar1 = 0;
 }
@@ -3236,14 +3234,14 @@ void MI_LArrow(int i)
 		}
 		if (Missiles[i]._mirange == 0) {
 			Missiles[i]._mimfnum = 0;
-			Missiles[i].position.traveled.deltaX -= Missiles[i].position.velocity.deltaX;
-			Missiles[i].position.traveled.deltaY -= Missiles[i].position.velocity.deltaY;
+			Missiles[i].position.traveled -= Missiles[i].position.velocity;
 			UpdateMissilePos(i);
 			if (Missiles[i]._mitype == MIS_LARROW)
 				SetMissAnim(i, MFILE_MINILTNG);
 			else
 				SetMissAnim(i, MFILE_MAGBLOS);
 			Missiles[i]._mirange = Missiles[i]._miAnimLen - 1;
+			Missiles[i].position.StopMissile();
 		} else {
 			if (Missiles[i].position.tile.x != Missiles[i]._miVar1 || Missiles[i].position.tile.y != Missiles[i]._miVar2) {
 				Missiles[i]._miVar1 = Missiles[i].position.tile.x;
@@ -3326,6 +3324,7 @@ void MI_Firebolt(int i)
 			Missiles[i]._miDelFlag = true;
 			Missiles[i].position.traveled = { omx, omy };
 			UpdateMissilePos(i);
+			Missiles[i].position.StopMissile();
 			switch (Missiles[i]._mitype) {
 			case MIS_FIREBOLT:
 			case MIS_MAGMABALL:
@@ -3339,7 +3338,6 @@ void MI_Firebolt(int i)
 				break;
 			case MIS_BONESPIRIT:
 				SetMissDir(i, DIR_OMNI);
-				Missiles[i].position.velocity = {};
 				Missiles[i]._mirange = 7;
 				Missiles[i]._miDelFlag = false;
 				PutMissile(i);
@@ -4597,6 +4595,7 @@ void MI_Cbolt(int i)
 			Missiles[i]._miVar1 = 8;
 			Missiles[i]._mimfnum = 0;
 			Missiles[i].position.offset = { 0, 0 };
+			Missiles[i].position.velocity = {};
 			SetMissAnim(i, MFILE_LGHNING);
 			Missiles[i]._mirange = Missiles[i]._miAnimLen;
 			UpdateMissilePos(i);
@@ -4626,6 +4625,7 @@ void MI_Hbolt(int i)
 			Missiles[i]._mimfnum = 0;
 			SetMissAnim(i, MFILE_HOLYEXPL);
 			Missiles[i]._mirange = Missiles[i]._miAnimLen - 1;
+			Missiles[i].position.StopMissile();
 		} else {
 			if (Missiles[i].position.tile != Point { Missiles[i]._miVar1, Missiles[i]._miVar2 }) {
 				Missiles[i]._miVar1 = Missiles[i].position.tile.x;
@@ -4695,6 +4695,7 @@ void MI_Element(int i)
 			Missiles[i]._mimfnum = 0;
 			SetMissAnim(i, MFILE_BIGEXP);
 			Missiles[i]._mirange = Missiles[i]._miAnimLen - 1;
+			Missiles[i].position.StopMissile();
 		}
 	}
 	PutMissile(i);

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -43,10 +43,16 @@ struct MissilePosition {
       * @brief Specifies the location (offset) while rendering
       */
 	Displacement offsetForRendering;
+
 	/**
-      * @brief tileForRendering and offsetForRendering shouldn't be updated while rendering. This is needed for explosion.
+      * @brief Stops the missile (set velocity to zero and set offset to last renderer location; shouldn't matter cause the missile don't move anymore)
       */
-	bool renderingIsFixed;
+	void StopMissile()
+	{
+		velocity = {};
+		if (tileForRendering == tile)
+			offset = offsetForRendering;
+	}
 };
 
 /*

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -80,19 +80,12 @@ bool CouldMissileCollide(Point tile, bool checkPlayerAndMonster)
 
 void UpdateMissileRendererData(MissileStruct &m)
 {
-	if (m.position.renderingIsFixed)
-		return;
-
 	m.position.tileForRendering = m.position.tile;
 	m.position.offsetForRendering = m.position.offset;
 
 	const MissileMovementDistrubution missileMovement = MissileData[m._mitype].MovementDistribution;
 	// don't calculate missile position if they don't move
-	if (missileMovement == MissileMovementDistrubution::Disabled)
-		return;
-
-	// when some missiles hit, they change there animation to a explosion and the explosion shouldn't move (for example fireball)
-	if (MissileData[m._mitype].mFileNum != m._miAnimType)
+	if (missileMovement == MissileMovementDistrubution::Disabled || m.position.velocity == Displacement {})
 		return;
 
 	float fProgress = gfProgressToNextGameTick;


### PR DESCRIPTION
Fixes #2371

Now when a missile hits, the velocity is set to zero.
So ADL doesn't calculate a new position.
In some cases also the offset is copied (for example firebolt).
This should be okay, cause the offset isn't used (apart from rendering) for the game logic.