### PR TITLE
Allow heros with same name

### DIFF
--- a/Source/DiabloUI/diabloui.h
+++ b/Source/DiabloUI/diabloui.h
@@ -53,6 +53,7 @@ struct _uidefaultstats {
 };
 
 struct _uiheroinfo {
+	uint32_t saveNumber;
 	char name[16];
 	uint8_t level;
 	HeroClass heroclass;
@@ -97,8 +98,8 @@ void UiTitleDialog();
 void UiSetSpawned(bool bSpawned);
 void UiInitialize();
 bool UiValidPlayerName(const char *name); /* check */
-void UiSelHeroMultDialog(bool (*fninfo)(bool (*fninfofunc)(_uiheroinfo *)), bool (*fncreate)(_uiheroinfo *), bool (*fnremove)(_uiheroinfo *), void (*fnstats)(unsigned int, _uidefaultstats *), _selhero_selections *dlgresult, char (*name)[16]);
-void UiSelHeroSingDialog(bool (*fninfo)(bool (*fninfofunc)(_uiheroinfo *)), bool (*fncreate)(_uiheroinfo *), bool (*fnremove)(_uiheroinfo *), void (*fnstats)(unsigned int, _uidefaultstats *), _selhero_selections *dlgresult, char (*name)[16], _difficulty *difficulty);
+void UiSelHeroMultDialog(bool (*fninfo)(bool (*fninfofunc)(_uiheroinfo *)), bool (*fncreate)(_uiheroinfo *), bool (*fnremove)(_uiheroinfo *), void (*fnstats)(unsigned int, _uidefaultstats *), _selhero_selections *dlgresult, uint32_t *saveNumber);
+void UiSelHeroSingDialog(bool (*fninfo)(bool (*fninfofunc)(_uiheroinfo *)), bool (*fncreate)(_uiheroinfo *), bool (*fnremove)(_uiheroinfo *), void (*fnstats)(unsigned int, _uidefaultstats *), _selhero_selections *dlgresult, uint32_t *saveNumber, _difficulty *difficulty);
 bool UiCreditsDialog();
 bool UiSupportDialog();
 bool UiMainMenuDialog(const char *name, _mainmenu_selections *pdwResult, void (*fnSound)(const char *file), int attractTimeOut);

--- a/Source/DiabloUI/selgame.cpp
+++ b/Source/DiabloUI/selgame.cpp
@@ -120,7 +120,7 @@ void selgame_GameSelection_Focus(int value)
  */
 bool UpdateHeroLevel(_uiheroinfo *pInfo)
 {
-	if (strcasecmp(pInfo->name, gszHero) == 0)
+	if (pInfo->saveNumber == gSaveNumber)
 		heroLevel = pInfo->level;
 
 	return true;

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -32,7 +32,7 @@ std::size_t selhero_SaveCount = 0;
 _uiheroinfo selhero_heros[MAX_CHARACTERS];
 _uiheroinfo selhero_heroInfo;
 const size_t MaxViewportItems = 6;
-char textStats[5][4];
+char textStats[6][4];
 const char *title = "";
 _selhero_selections selhero_result;
 bool selhero_navigateYesNo;
@@ -81,6 +81,7 @@ void SelheroSetStats()
 	snprintf(textStats[2], sizeof(textStats[2]), "%i", selhero_heroInfo.magic);
 	snprintf(textStats[3], sizeof(textStats[3]), "%i", selhero_heroInfo.dexterity);
 	snprintf(textStats[4], sizeof(textStats[4]), "%i", selhero_heroInfo.vitality);
+	snprintf(textStats[5], sizeof(textStats[5]), "%i", selhero_heroInfo.saveNumber);
 }
 
 std::size_t listOffset = 0;
@@ -116,6 +117,7 @@ void SelheroScrollIntoView(std::size_t index)
 bool SelHeroGetHeroInfo(_uiheroinfo *pInfo)
 {
 	selhero_heros[selhero_SaveCount] = *pInfo;
+
 	selhero_SaveCount++;
 
 	return true;
@@ -140,6 +142,7 @@ void SelheroListFocus(int value)
 	strncpy(textStats[2], "--", sizeof(textStats[2]) - 1);
 	strncpy(textStats[3], "--", sizeof(textStats[3]) - 1);
 	strncpy(textStats[4], "--", sizeof(textStats[4]) - 1);
+	strncpy(textStats[5], "--", sizeof(textStats[5]) - 1);
 	SELLIST_DIALOG_DELETE_BUTTON->m_iFlags = baseFlags | UIS_DISABLED;
 	selhero_deleteEnabled = false;
 }
@@ -485,6 +488,13 @@ void selhero_Init()
 	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Vitality:"), rect12, UIS_RIGHT));
 	SDL_Rect rect13 = { (Sint16)(PANEL_LEFT + 159), (Sint16)(UI_OFFSET_Y + 422), 40, 21 };
 	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[4], rect13, UIS_CENTER));
+
+#if _DEBUG
+	SDL_Rect rect14 = { (Sint16)(PANEL_LEFT + 39), (Sint16)(UI_OFFSET_Y + 443), 110, 21 };
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Savegame:"), rect14, UIS_RIGHT));
+	SDL_Rect rect15 = { (Sint16)(PANEL_LEFT + 159), (Sint16)(UI_OFFSET_Y + 443), 40, 21 };
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[5], rect15, UIS_CENTER));
+#endif
 }
 
 void selhero_List_Init()

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -296,33 +296,17 @@ void SelheroClassSelectorEsc()
 
 void SelheroNameSelect(int /*value*/)
 {
-
 	if (!UiValidPlayerName(selhero_heroInfo.name)) {
 		ArtBackground.Unload();
 		UiSelOkDialog(title, _("Invalid name. A name cannot contain spaces, reserved characters, or reserved words.\n"), false);
 		LoadBackgroundArt("ui_art\\selhero.pcx");
-	} else {
-		bool overwrite = true;
-		for (std::size_t i = 0; i < selhero_SaveCount; i++) {
-			if (strcasecmp(selhero_heros[i].name, selhero_heroInfo.name) == 0) {
-				ArtBackground.Unload();
-				char dialogText[256];
-				strncpy(dialogText, fmt::format(_(/* Error message when User tries to create multiple heros with the same name */ "Character already exists. Do you want to overwrite \"{:s}\"?"), selhero_heroInfo.name).c_str(), sizeof(dialogText));
-
-				overwrite = UiSelHeroYesNoDialog(title, dialogText);
-				LoadBackgroundArt("ui_art\\selhero.pcx");
-				break;
-			}
-		}
-
-		if (overwrite) {
-			if (gfnHeroCreate(&selhero_heroInfo)) {
-				SelheroLoadSelect(1);
-				return;
-			}
-			UiErrorOkDialog(_(/* TRANSLATORS: Error Message */ "Unable to create character."), vecSelDlgItems);
-		}
 	}
+
+	if (gfnHeroCreate(&selhero_heroInfo)) {
+		SelheroLoadSelect(1);
+		return;
+	}
+	UiErrorOkDialog(_(/* TRANSLATORS: Error Message */ "Unable to create character."), vecSelDlgItems);
 
 	memset(selhero_heroInfo.name, '\0', sizeof(selhero_heroInfo.name));
 	SelheroClassSelectorSelect(0);

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -186,6 +186,7 @@ void SelheroListSelect(int value)
 
 		UiInitList(vecSelHeroDlgItems.size(), SelheroClassSelectorFocus, SelheroClassSelectorSelect, SelheroClassSelectorEsc, vecSelDlgItems);
 		memset(&selhero_heroInfo.name, 0, sizeof(selhero_heroInfo.name));
+		selhero_heroInfo.saveNumber = MAX_CHARACTERS;
 		title = selhero_isMultiPlayer ? _("New Multi Player Hero") : _("New Single Player Hero");
 		return;
 	}
@@ -550,7 +551,7 @@ static void UiSelHeroDialog(
     void (*fnstats)(unsigned int, _uidefaultstats *),
     bool (*fnremove)(_uiheroinfo *),
     _selhero_selections *dlgresult,
-    char (*name)[16])
+    uint32_t *saveNumber)
 {
 	do {
 		gfnHeroInfo = fninfo;
@@ -592,7 +593,7 @@ static void UiSelHeroDialog(
 	} while (selhero_navigateYesNo);
 
 	*dlgresult = selhero_result;
-	strncpy(*name, selhero_heroInfo.name, sizeof(*name));
+	*saveNumber = selhero_heroInfo.saveNumber;
 }
 
 void UiSelHeroSingDialog(
@@ -601,11 +602,11 @@ void UiSelHeroSingDialog(
     bool (*fnremove)(_uiheroinfo *),
     void (*fnstats)(unsigned int, _uidefaultstats *),
     _selhero_selections *dlgresult,
-    char (*name)[16],
+    uint32_t *saveNumber,
     _difficulty *difficulty)
 {
 	selhero_isMultiPlayer = false;
-	UiSelHeroDialog(fninfo, fncreate, fnstats, fnremove, dlgresult, name);
+	UiSelHeroDialog(fninfo, fncreate, fnstats, fnremove, dlgresult, saveNumber);
 	*difficulty = nDifficulty;
 }
 
@@ -615,10 +616,10 @@ void UiSelHeroMultDialog(
     bool (*fnremove)(_uiheroinfo *),
     void (*fnstats)(unsigned int, _uidefaultstats *),
     _selhero_selections *dlgresult,
-    char (*name)[16])
+    uint32_t *saveNumber)
 {
 	selhero_isMultiPlayer = true;
-	UiSelHeroDialog(fninfo, fncreate, fnstats, fnremove, dlgresult, name);
+	UiSelHeroDialog(fninfo, fncreate, fnstats, fnremove, dlgresult, saveNumber);
 }
 
 } // namespace devilution

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -14,7 +14,7 @@
 
 namespace devilution {
 
-char gszHero[16];
+uint32_t gSaveNumber;
 
 namespace {
 
@@ -88,7 +88,7 @@ bool mainmenu_select_hero_dialog(GameData *gameData)
 		    pfile_delete_save,
 		    pfile_ui_set_class_stats,
 		    &dlgresult,
-		    &gszHero,
+		    &gSaveNumber,
 		    &gameData->nDifficulty);
 
 		gbLoadGame = (dlgresult == SELHERO_CONTINUE);
@@ -99,14 +99,14 @@ bool mainmenu_select_hero_dialog(GameData *gameData)
 		    pfile_delete_save,
 		    pfile_ui_set_class_stats,
 		    &dlgresult,
-		    &gszHero);
+		    &gSaveNumber);
 	}
 	if (dlgresult == SELHERO_PREVIOUS) {
 		SErrSetLastError(1223);
 		return false;
 	}
 
-	pfile_read_player_from_save(gszHero, MyPlayerId);
+	pfile_read_player_from_save(gSaveNumber, MyPlayerId);
 
 	return true;
 }

--- a/Source/mainmenu.h
+++ b/Source/mainmenu.h
@@ -9,7 +9,7 @@
 
 namespace devilution {
 
-extern char gszHero[16];
+extern uint32_t gSaveNumber;
 
 bool mainmenu_select_hero_dialog(GameData *gameData);
 void mainmenu_loop();

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -454,7 +454,7 @@ bool InitMulti(GameData *gameData)
 	MyPlayerId = playerId;
 	gbIsMultiplayer = true;
 
-	pfile_read_player_from_save(gszHero, MyPlayerId);
+	pfile_read_player_from_save(gSaveNumber, MyPlayerId);
 
 	return true;
 }

--- a/Source/pfile.h
+++ b/Source/pfile.h
@@ -33,7 +33,7 @@ bool pfile_ui_set_hero_infos(bool (*uiAddHeroInfo)(_uiheroinfo *));
 void pfile_ui_set_class_stats(unsigned int playerClass, _uidefaultstats *classStats);
 bool pfile_ui_save_create(_uiheroinfo *heroinfo);
 bool pfile_delete_save(_uiheroinfo *heroInfo);
-void pfile_read_player_from_save(char name[16], int playerId);
+void pfile_read_player_from_save(uint32_t saveNum, int playerId);
 bool LevelFileExists();
 void GetTempLevelNames(char *szTemp);
 void GetPermLevelNames(char *szPerm);


### PR DESCRIPTION
## Content

- Replaces all usages of hero name to load/save games with save number
- Allows creation of a hero with same name
- In debug shows save number as information

<details><summary>Debug Sample</summary>

![grafik](https://user-images.githubusercontent.com/25415264/125865318-413c10a0-28ed-4ab6-9dd2-6bc8bd6e4bd2.png)

</details>

I did this cause it was sometimes frustrating to debug reported issues.
I copy the save game into my save folder and sometimes there is already a hero with the same name.
Before this PR it was impossible to select them correctly. It was always the first one loaded.

It would be good if someone else could test this PR before it get merged.