### PR TITLE
dthread.cpp revamp

### DIFF
--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -64,7 +64,7 @@ void DthreadHandler()
 
 void dthread_remove_player(uint8_t pnum)
 {
-	std::lock_guard lock(DthreadMutex);
+	std::lock_guard<SdlMutex> lock(DthreadMutex);
 	InfoList.remove_if([&](auto &pkt) {
 		return pkt.pnum == pnum;
 	});
@@ -77,7 +77,7 @@ void dthread_send_delta(int pnum, _cmd_id cmd, std::unique_ptr<byte[]> data, uin
 
 	DThreadPkt pkt { pnum, cmd, std::move(data), len };
 
-	std::lock_guard lock(DthreadMutex);
+	std::lock_guard<SdlMutex> lock(DthreadMutex);
 	InfoList.push_back(std::move(pkt));
 	SetEvent(sghWorkToDoEvent);
 }

--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -19,7 +19,7 @@ struct DThreadPkt {
 	std::unique_ptr<byte[]> data;
 	uint32_t len;
 
-	DThreadPkt(uint8_t pnum, _cmd_id(cmd), std::unique_ptr<byte[]> &&data, uint32_t len)
+	DThreadPkt(uint8_t pnum, _cmd_id(cmd), std::unique_ptr<byte[]> data, uint32_t len)
 		: pnum(pnum)
 		, cmd(cmd)
 		, data(std::move(data))

--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -14,12 +14,12 @@
 namespace devilution {
 
 struct DThreadPkt {
-	uint8_t pnum;
+	int pnum;
 	_cmd_id cmd;
 	std::unique_ptr<byte[]> data;
 	uint32_t len;
 
-	DThreadPkt(uint8_t pnum, _cmd_id(cmd), std::unique_ptr<byte[]> data, uint32_t len)
+	DThreadPkt(int pnum, _cmd_id(cmd), std::unique_ptr<byte[]> data, uint32_t len)
 		: pnum(pnum)
 		, cmd(cmd)
 		, data(std::move(data))
@@ -80,7 +80,7 @@ void dthread_remove_player(uint8_t pnum)
 	sgMemCrit.Leave();
 }
 
-void dthread_send_delta(uint8_t pnum, _cmd_id cmd, std::unique_ptr<byte[]> data, uint32_t len)
+void dthread_send_delta(int pnum, _cmd_id cmd, std::unique_ptr<byte[]> data, uint32_t len)
 {
 	if (!gbIsMultiplayer)
 		return;

--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -64,7 +64,7 @@ void DthreadHandler()
 void dthread_remove_player(uint8_t pnum)
 {
 	sgMemCrit.Enter();
-	InfoList.remove_if([&](DThreadPkt &pkt) {
+	InfoList.remove_if([&](auto &pkt) {
 		return pkt.pnum == pnum;
 	});
 	sgMemCrit.Leave();

--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -55,15 +55,7 @@ void DthreadHandler()
 		InfoList.pop_front();
 		sgMemCrit.Leave();
 
-		if (pkt.pnum != MAX_PLRS)
-			multi_send_zero_packet(pkt.pnum, pkt.cmd, pkt.data.get(), pkt.len);
-
-		DWORD dwMilliseconds = 1000 * pkt.len / gdwDeltaBytesSec;
-		if (dwMilliseconds >= 1)
-			dwMilliseconds = 1;
-
-		if (dwMilliseconds != 0)
-			SDL_Delay(dwMilliseconds);
+		multi_send_zero_packet(pkt.pnum, pkt.cmd, pkt.data.get(), pkt.len);
 	}
 }
 
@@ -72,10 +64,9 @@ void DthreadHandler()
 void dthread_remove_player(uint8_t pnum)
 {
 	sgMemCrit.Enter();
-	for (auto &pkt : InfoList) {
-		if (pkt.pnum == pnum)
-			pkt.pnum = MAX_PLRS;
-	}
+	InfoList.remove_if([&](DThreadPkt &pkt) {
+		return pkt.pnum == pnum;
+	});
 	sgMemCrit.Leave();
 }
 

--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -42,10 +42,8 @@ SDL_Thread *sghThread = nullptr;
 void DthreadHandler()
 {
 	while (dthread_running) {
-		if (sgpInfoList.empty() && WaitForEvent(sghWorkToDoEvent) == -1) {
-			const char *errorBuf = SDL_GetError();
-			app_fatal("dthread4:\n%s", errorBuf);
-		}
+		if (sgpInfoList.empty() && WaitForEvent(sghWorkToDoEvent) == -1)
+			app_fatal("dthread4:\n%s", SDL_GetError());
 
 		sgMemCrit.Enter();
 		if (sgpInfoList .empty()) {

--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -16,16 +16,15 @@ namespace devilution {
 struct DThreadPkt {
 	uint8_t pnum;
 	_cmd_id cmd;
-	uint32_t len;
 	std::unique_ptr<byte[]> data;
+	uint32_t len;
 
-	DThreadPkt(uint8_t pnum, _cmd_id(cmd), byte *src, uint32_t len)
+	DThreadPkt(uint8_t pnum, _cmd_id(cmd), std::unique_ptr<byte[]> &&data, uint32_t len)
 		: pnum(pnum)
 		, cmd(cmd)
+		, data(std::move(data))
 		, len(len)
-		, data(new byte[len])
 	{
-		memcpy(data.get(), src, len);
 	}
 };
 
@@ -81,12 +80,12 @@ void dthread_remove_player(uint8_t pnum)
 	sgMemCrit.Leave();
 }
 
-void dthread_send_delta(uint8_t pnum, _cmd_id cmd, byte *src, uint32_t len)
+void dthread_send_delta(uint8_t pnum, _cmd_id cmd, std::unique_ptr<byte[]> data, uint32_t len)
 {
 	if (!gbIsMultiplayer)
 		return;
 
-	DThreadPkt pkt { pnum, cmd, src, len };
+	DThreadPkt pkt { pnum, cmd, std::move(data), len };
 
 	sgMemCrit.Enter();
 	sgpInfoList.push_back(std::move(pkt));

--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -49,6 +49,7 @@ void DthreadHandler()
 		if (sgpInfoList.empty()) {
 			ResetEvent(sghWorkToDoEvent);
 			sgMemCrit.Leave();
+			continue;
 		}
 		DThreadPkt pkt = std::move(sgpInfoList.front());
 		sgpInfoList.pop_front();

--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -46,7 +46,7 @@ void DthreadHandler()
 			app_fatal("dthread4:\n%s", SDL_GetError());
 
 		sgMemCrit.Enter();
-		if (sgpInfoList .empty()) {
+		if (sgpInfoList.empty()) {
 			ResetEvent(sghWorkToDoEvent);
 			sgMemCrit.Leave();
 		}

--- a/Source/dthread.h
+++ b/Source/dthread.h
@@ -8,7 +8,7 @@
 namespace devilution {
 
 void dthread_remove_player(uint8_t pnum);
-void dthread_send_delta(int pnum, _cmd_id cmd, byte *pbSrc, int dwLen);
+void dthread_send_delta(int pnum, _cmd_id cmd, byte *pbSrc, uint32_t dwLen);
 void dthread_start();
 void DThreadCleanup();
 

--- a/Source/dthread.h
+++ b/Source/dthread.h
@@ -5,10 +5,13 @@
  */
 #pragma once
 
+#include <memory>
+#include "utils/stdcompat/cstddef.hpp"
+
 namespace devilution {
 
 void dthread_remove_player(uint8_t pnum);
-void dthread_send_delta(uint8_t pnum, _cmd_id cmd, byte *pbSrc, uint32_t dwLen);
+void dthread_send_delta(uint8_t pnum, _cmd_id cmd, std::unique_ptr<byte[]> data, uint32_t len);
 void dthread_start();
 void DThreadCleanup();
 

--- a/Source/dthread.h
+++ b/Source/dthread.h
@@ -8,7 +8,7 @@
 namespace devilution {
 
 void dthread_remove_player(uint8_t pnum);
-void dthread_send_delta(int pnum, _cmd_id cmd, byte *pbSrc, uint32_t dwLen);
+void dthread_send_delta(uint8_t pnum, _cmd_id cmd, byte *pbSrc, uint32_t dwLen);
 void dthread_start();
 void DThreadCleanup();
 

--- a/Source/dthread.h
+++ b/Source/dthread.h
@@ -11,7 +11,7 @@
 namespace devilution {
 
 void dthread_remove_player(uint8_t pnum);
-void dthread_send_delta(uint8_t pnum, _cmd_id cmd, std::unique_ptr<byte[]> data, uint32_t len);
+void dthread_send_delta(int pnum, _cmd_id cmd, std::unique_ptr<byte[]> data, uint32_t len);
 void dthread_start();
 void DThreadCleanup();
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1872,7 +1872,7 @@ void DeltaExportData(int pnum)
 			dthread_send_delta(pnum, static_cast<_cmd_id>(i + CMD_DLEVEL_0), std::move(dst), size);
 		}
 
-		std::unique_ptr<byte[]> dst { new byte[sizeof(DLevel) + 1] };
+		std::unique_ptr<byte[]> dst { new byte[MAXPORTAL * sizeof(DPortal) + MAXQUESTS * sizeof(MultiQuests) + 1] };
 		byte *dstEnd = &dst.get()[1];
 		dstEnd = DeltaExportJunk(dstEnd);
 		int size = CompressData(dst.get(), dstEnd);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1872,7 +1872,7 @@ void DeltaExportData(int pnum)
 			dthread_send_delta(pnum, static_cast<_cmd_id>(i + CMD_DLEVEL_0), std::move(dst), size);
 		}
 
-		std::unique_ptr<byte[]> dst { new byte[MAXPORTAL * sizeof(DPortal) + MAXQUESTS * sizeof(MultiQuests) + 1] };
+		std::unique_ptr<byte[]> dst { new byte[sizeof(DJunk) + 1] };
 		byte *dstEnd = &dst.get()[1];
 		dstEnd = DeltaExportJunk(dstEnd);
 		int size = CompressData(dst.get(), dstEnd);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1862,24 +1862,25 @@ void run_delta_info()
 void DeltaExportData(int pnum)
 {
 	if (sgbDeltaChanged) {
-		int size;
-		std::unique_ptr<byte[]> dst { new byte[sizeof(DLevel) + 1] };
-		byte *dstEnd;
 		for (int i = 0; i < NUMLEVELS; i++) {
-			dstEnd = &dst[1];
+			std::unique_ptr<byte[]> dst { new byte[sizeof(DLevel) + 1] };
+			byte *dstEnd = &dst.get()[1];
 			dstEnd = DeltaExportItem(dstEnd, sgLevels[i].item);
 			dstEnd = DeltaExportObject(dstEnd, sgLevels[i].object);
 			dstEnd = DeltaExportMonster(dstEnd, sgLevels[i].monster);
-			size = CompressData(dst.get(), dstEnd);
-			dthread_send_delta(pnum, static_cast<_cmd_id>(i + CMD_DLEVEL_0), dst.get(), size);
+			int size = CompressData(dst.get(), dstEnd);
+			dthread_send_delta(pnum, static_cast<_cmd_id>(i + CMD_DLEVEL_0), std::move(dst), size);
 		}
-		dstEnd = &dst[1];
+
+		std::unique_ptr<byte[]> dst { new byte[sizeof(DLevel) + 1] };
+		byte *dstEnd = &dst.get()[1];
 		dstEnd = DeltaExportJunk(dstEnd);
-		size = CompressData(dst.get(), dstEnd);
-		dthread_send_delta(pnum, CMD_DLEVEL_JUNK, dst.get(), size);
+		int size = CompressData(dst.get(), dstEnd);
+		dthread_send_delta(pnum, CMD_DLEVEL_JUNK, std::move(dst), size);
 	}
-	byte src { 0 };
-	dthread_send_delta(pnum, CMD_DLEVEL_END, &src, 1);
+
+	std::unique_ptr<byte[]> src { new byte[1] { static_cast<byte>(0) } };
+	dthread_send_delta(pnum, CMD_DLEVEL_END, std::move(src), 1);
 }
 
 void delta_init()

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -312,7 +312,7 @@ void ProcessTmsgs()
 
 void SendPlayerInfo(int pnum, _cmd_id cmd)
 {
-	std::unique_ptr<byte[]> pkplr { new byte[sizeof(PkPlayerStruct)] };
+	std::unique_ptr<byte[]> pkplr { reinterpret_cast<byte *>(new PkPlayerStruct()) };
 
 	PackPlayer(reinterpret_cast<PkPlayerStruct *>(pkplr.get()), Players[MyPlayerId], true);
 	dthread_send_delta(pnum, cmd, std::move(pkplr), sizeof(pkplr));

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -312,6 +312,7 @@ void ProcessTmsgs()
 
 void SendPlayerInfo(int pnum, _cmd_id cmd)
 {
+	static_assert(alignof(PkPlayerStruct) == 1, "Fix pkplr alignment");
 	std::unique_ptr<byte[]> pkplr { new byte[sizeof(PkPlayerStruct)] };
 
 	PackPlayer(reinterpret_cast<PkPlayerStruct *>(pkplr.get()), Players[MyPlayerId], true);

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -315,7 +315,7 @@ void SendPlayerInfo(int pnum, _cmd_id cmd)
 	std::unique_ptr<byte[]> pkplr { reinterpret_cast<byte *>(new PkPlayerStruct()) };
 
 	PackPlayer(reinterpret_cast<PkPlayerStruct *>(pkplr.get()), Players[MyPlayerId], true);
-	dthread_send_delta(pnum, cmd, std::move(pkplr), sizeof(pkplr));
+	dthread_send_delta(pnum, cmd, std::move(pkplr), sizeof(PkPlayerStruct));
 }
 
 dungeon_type InitLevelType(int l)

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -24,6 +24,7 @@
 #include "tmsg.h"
 #include "utils/endian.hpp"
 #include "utils/language.h"
+#include "utils/stdcompat/cstddef.hpp"
 
 namespace devilution {
 
@@ -311,10 +312,10 @@ void ProcessTmsgs()
 
 void SendPlayerInfo(int pnum, _cmd_id cmd)
 {
-	PkPlayerStruct pkplr;
+	std::unique_ptr<byte[]> pkplr { new byte[sizeof(PkPlayerStruct)] };
 
-	PackPlayer(&pkplr, Players[MyPlayerId], true);
-	dthread_send_delta(pnum, cmd, (byte *)&pkplr, sizeof(pkplr));
+	PackPlayer(reinterpret_cast<PkPlayerStruct *>(pkplr.get()), Players[MyPlayerId], true);
+	dthread_send_delta(pnum, cmd, std::move(pkplr), sizeof(pkplr));
 }
 
 dungeon_type InitLevelType(int l)

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -312,7 +312,7 @@ void ProcessTmsgs()
 
 void SendPlayerInfo(int pnum, _cmd_id cmd)
 {
-	std::unique_ptr<byte[]> pkplr { reinterpret_cast<byte *>(new PkPlayerStruct()) };
+	std::unique_ptr<byte[]> pkplr { new byte[sizeof(PkPlayerStruct)] };
 
 	PackPlayer(reinterpret_cast<PkPlayerStruct *>(pkplr.get()), Players[MyPlayerId], true);
 	dthread_send_delta(pnum, cmd, std::move(pkplr), sizeof(PkPlayerStruct));


### PR DESCRIPTION
dthread.cpp had various issues, the biggest of which is that it erroneously used TMegaPkt for its internal data structures. This patch also eliminates some needless memory copies.
