### PR TITLE
fix upper left inventory corner

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -363,7 +363,7 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 	Size itemSize { icursW28, icursH28 };
 	bool done = false;
 	int r = 0;
-	for (; r < NUM_XY_SLOTS; r++) {
+	for (; r < NUM_XY_SLOTS && !done; r++) {
 		int xo = RIGHT_PANEL;
 		int yo = 0;
 		if (r >= SLOTXY_BELT_FIRST) {
@@ -374,9 +374,10 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 		if (i >= InvRect[r].x + xo && i <= InvRect[r].x + xo + InventorySlotSizeInPixels.width) {
 			if (j >= InvRect[r].y + yo - InventorySlotSizeInPixels.height - 1 && j < InvRect[r].y + yo) {
 				done = true;
+				r--;
 			}
 		}
-		if (r == SLOTXY_INV_FIRST) {
+		if (r == SLOTXY_CHEST_LAST) {
 			if ((itemSize.width & 1) == 0)
 				i -= INV_SLOT_HALF_SIZE_PX;
 			if ((itemSize.height & 1) == 0)
@@ -384,9 +385,6 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 		}
 		if (r == SLOTXY_INV_LAST && (itemSize.height & 1) == 0)
 			j += INV_SLOT_HALF_SIZE_PX;
-
-		if (done) // found a slot
-			break;
 	}
 	if (!done)
 		return;


### PR DESCRIPTION
This reverts this part of the code to before my cleanup, 
I added some log
INFO: r == slotxy_chest_last
INFO: itemSize.width & 1
INFO: itemSize.height & 1
INFO: DONE WITH SLOT: 24
INFO: r == slotxy_chest_last
INFO: itemSize.width & 1
INFO: itemSize.height & 1
INFO: GOING OUT WITH SLOT: 25

so it seems the "working" code actually hits that if twice, I have no clue how inventory works at this point so just leaving it alone

Resolves https://github.com/diasurgical/devilutionX/issues/2366