### PR TITLE
Fix MSVC specific warnings

### DIFF
--- a/3rdParty/libzt/CMakeLists.txt
+++ b/3rdParty/libzt/CMakeLists.txt
@@ -7,12 +7,18 @@ FetchContent_Declare(libzt
 FetchContent_MakeAvailableExcludeFromAll(libzt)
 
 # External library, ignore all warnings
-target_compile_options(zto_obj PRIVATE -fpermissive -w)
+target_compile_options(zto_obj PRIVATE -w)
 target_compile_options(libnatpmp_obj PRIVATE -w)
-target_compile_options(libzt_obj PRIVATE -fpermissive -w)
+target_compile_options(libzt_obj PRIVATE -w)
 target_compile_options(lwip_obj PRIVATE -w)
 target_compile_options(miniupnpc_obj PRIVATE -w)
-target_compile_options(zt-static PRIVATE -fpermissive -w)
+target_compile_options(zt-static PRIVATE -w)
+
+if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  target_compile_options(zto_obj PRIVATE -fpermissive)
+  target_compile_options(libzt_obj PRIVATE -fpermissive)
+  target_compile_options(zt-static PRIVATE -fpermissive)
+endif()
 
 target_include_directories(zt-static INTERFACE
   "${libzt_SOURCE_DIR}/include"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -835,6 +835,7 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_compile_options(libdevilutionx PUBLIC "/W3")
+  target_compile_definitions(libdevilutionx PUBLIC _CRT_SECURE_NO_WARNINGS)
   target_compile_options(libdevilutionx PUBLIC "/Zc:__cplusplus")
 endif()
 


### PR DESCRIPTION
### fpermissive

`-fpermissive` is not supported in MSVC (and I think in clang too?).
So we get a warning that it's unknown:
`Command line warning D9002: ignoring unknown option '-fpermissive'`
Solution: Don't set `-fpermissive` if MSVC is used.

### _CRT_SECURE_NO_WARNINGS

Set [`_CRT_SECURE_NO_WARNINGS`](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996) this disables warnings like:
`warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.`
Alternative solutions: use `strcpy_s` and friends. But I don't know if this is desired and if it is supported on all platforms that devilutionX is running.
That's why I think it would be a good idea to disable the warning until we have a commit what we want to do with `strcpy`.

### Result

This reduces warnings from 740 to 166 with debug x86