### PR TITLE
Fix Discord links in platform manuals

### DIFF
--- a/Packaging/ctr/README.txt
+++ b/Packaging/ctr/README.txt
@@ -66,5 +66,5 @@ or, when using .cia:
 
 ## Resources
 
-* Discord: https://discord.gg/aQBQdDe
+* Discord: https://discord.gg/YQKCAYQ
 * GitHub: https://github.com/diasurgical/devilutionX

--- a/docs/manual/platforms/gkd350h.md
+++ b/docs/manual/platforms/gkd350h.md
@@ -38,5 +38,5 @@ Saves are compatible with PC saves from Diablo 1 and DevilutionX.
 
 ## Resources
 
-* Discord: https://discord.gg/aQBQdDe
+* Discord: https://discord.gg/YQKCAYQ
 * GitHub: https://github.com/diasurgical/devilutionX

--- a/docs/manual/platforms/n3ds.md
+++ b/docs/manual/platforms/n3ds.md
@@ -67,5 +67,5 @@ or, when using .cia:
 
 ## Resources
 
-* Discord: https://discord.gg/aQBQdDe
+* Discord: https://discord.gg/YQKCAYQ
 * GitHub: https://github.com/diasurgical/devilutionX

--- a/docs/manual/platforms/retrofw.md
+++ b/docs/manual/platforms/retrofw.md
@@ -50,5 +50,5 @@ Saves are compatible with PC saves from Diablo 1 and DevilutionX.
 
 ## Resources
 
-* Discord: https://discord.gg/aQBQdDe
+* Discord: https://discord.gg/YQKCAYQ
 * GitHub: https://github.com/diasurgical/devilutionX

--- a/docs/manual/platforms/rg350.md
+++ b/docs/manual/platforms/rg350.md
@@ -54,5 +54,5 @@ Saves are compatible with PC saves from Diablo 1 and DevilutionX.
 
 ## Resources
 
-* Discord: https://discord.gg/aQBQdDe
+* Discord: https://discord.gg/YQKCAYQ
 * GitHub: https://github.com/diasurgical/devilutionX

--- a/docs/manual/platforms/switch.md
+++ b/docs/manual/platforms/switch.md
@@ -42,5 +42,5 @@ Launch `devilutionx.nro`. (Do not use album to launch; see the note below.)
 
 ## Resources
 
-* Discord: https://discord.gg/aQBQdDe
+* Discord: https://discord.gg/YQKCAYQ
 * GitHub: https://github.com/diasurgical/devilutionX


### PR DESCRIPTION
Since I made a small fuss in the Discord, I thought I might as well do what I can to make sure the Discord links are all up to date.