### PR TITLE
Fix some warnings

### DIFF
--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -313,7 +313,7 @@ typedef std::vector<std::unique_ptr<UiListItem>> vUiListItem;
 class UiList : public UiItemBase {
 public:
 	UiList(const vUiListItem &vItems, Sint16 x, Sint16 y, Uint16 item_width, Uint16 item_height, int flags = 0)
-	    : UiItemBase(x, y, item_width, item_height * vItems.size(), flags)
+	    : UiItemBase(x, y, item_width, static_cast<Uint16>(item_height * vItems.size()), flags)
 	{
 		m_type = UI_LIST;
 		for (auto &item : vItems)

--- a/Source/controls/controller_motion.cpp
+++ b/Source/controls/controller_motion.cpp
@@ -36,19 +36,19 @@ void ScaleJoystickAxes(float *x, float *y, float deadzone)
 	float magnitude = std::sqrt(analogX * analogX + analogY * analogY);
 	if (magnitude >= deadZone) {
 		// find scaled axis values with magnitudes between zero and maximum
-		float scalingFactor = 1.0 / magnitude * (magnitude - deadZone) / (maximum - deadZone);
+		float scalingFactor = 1.F / magnitude * (magnitude - deadZone) / (maximum - deadZone);
 		analogX = (analogX * scalingFactor);
 		analogY = (analogY * scalingFactor);
 
 		// clamp to ensure results will never exceed the max_axis value
-		float clampingFactor = 1.0;
+		float clampingFactor = 1.F;
 		float absAnalogX = std::fabs(analogX);
 		float absAnalogY = std::fabs(analogY);
 		if (absAnalogX > 1.0 || absAnalogY > 1.0) {
 			if (absAnalogX > absAnalogY) {
-				clampingFactor = 1 / absAnalogX;
+				clampingFactor = 1.F / absAnalogX;
 			} else {
-				clampingFactor = 1 / absAnalogY;
+				clampingFactor = 1.F / absAnalogY;
 			}
 		}
 		*x = (clampingFactor * analogX);

--- a/Source/utils/soundsample.cpp
+++ b/Source/utils/soundsample.cpp
@@ -54,7 +54,7 @@ float PanLogToLinear(int logPan)
 
 	auto factor = std::pow(LogBase, static_cast<float>(-std::abs(logPan)) / StereoSeparation);
 
-	return copysign(1.0 - factor, static_cast<float>(logPan));
+	return copysign(1.F - factor, static_cast<float>(logPan));
 }
 
 } // namespace


### PR DESCRIPTION
With this changes warnings are reduced from 166 to 51.
Especially the warning in `ui_item.h` was often reported cause it was included in multiple places.
Now there are only warnings in `.cpp` files left.