### PR TITLE
Fix some 64bit warnings

### DIFF
--- a/Source/DiabloUI/scrollbar.h
+++ b/Source/DiabloUI/scrollbar.h
@@ -65,7 +65,7 @@ inline SDL_Rect ThumbRect(const UiScrollBar *sb, std::size_t selected_index, std
 {
 	const int THUMB_OFFSET_X = 3;
 	const int thumb_max_y = BarHeight(sb) - sb->m_thumb->h();
-	const int thumb_y = (selected_index * thumb_max_y / (num_items - 1));
+	const int thumb_y = static_cast<int>(selected_index * thumb_max_y / (num_items - 1));
 
 	SDL_Rect Tmp;
 	Tmp.x = static_cast<Sint16>(sb->m_rect.x + THUMB_OFFSET_X);

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -340,7 +340,7 @@ public:
 	int indexAt(Sint16 y) const
 	{
 		ASSERT(y >= m_rect.y);
-		const std::size_t index = (y - m_rect.y) / m_height;
+		const int index = (y - m_rect.y) / m_height;
 		ASSERT(index < m_vecItems.size());
 		return index;
 	}

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1953,7 +1953,7 @@ bool control_talk_last_key(int vkey)
 	if ((DWORD)vkey < DVL_VK_SPACE)
 		return false;
 
-	int result = strlen(sgszTalkMsg);
+	std::size_t result = strlen(sgszTalkMsg);
 	if (result < 78) {
 		sgszTalkMsg[result] = vkey;
 		sgszTalkMsg[result + 1] = '\0';
@@ -1973,7 +1973,7 @@ bool control_presskeys(int vkey)
 	} else if (vkey == DVL_VK_RETURN) {
 		ControlPressEnter();
 	} else if (vkey == DVL_VK_BACK) {
-		int len = strlen(sgszTalkMsg);
+		std::size_t len = strlen(sgszTalkMsg);
 		if (len > 0)
 			sgszTalkMsg[len - 1] = '\0';
 	} else if (vkey == DVL_VK_DOWN) {

--- a/Source/engine/surface.hpp
+++ b/Source/engine/surface.hpp
@@ -49,7 +49,7 @@ struct Surface {
 	/**
 	 * @brief Allocate a buffer that owns its underlying data.
 	 */
-	static Surface Alloc(std::size_t width, std::size_t height)
+	static Surface Alloc(int width, int height)
 	{
 		return Surface(SDL_CreateRGBSurfaceWithFormat(0, width, height, 8, SDL_PIXELFORMAT_INDEX8));
 	}


### PR DESCRIPTION
The 64bit build has more warnings then the 32bit build, cause `size_t` is defined differently.

This PR fixes the 64bit specific warnings in header files caused by `size_t`.
With this changes the warnings for 64bit builds are reduced from 381 to 120.

All numbers for MSVC. 😉 