### PR TITLE
dthread: simplify synchronization logic

### DIFF
--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -95,11 +95,12 @@ void DThreadCleanup()
 	if (!DthreadRunning)
 		return;
 
-	DthreadMutex->lock();
-	DthreadRunning = false;
-	InfoList.clear();
-	WorkToDo->signal();
-	DthreadMutex->unlock();
+	{
+		std::lock_guard<SdlMutex> lock(*DthreadMutex);
+		DthreadRunning = false;
+		InfoList.clear();
+		WorkToDo->signal();
+	}
 
 	if (sghThread != nullptr && glpDThreadId != SDL_GetThreadID(nullptr)) {
 		SDL_WaitThread(sghThread, nullptr);

--- a/Source/utils/sdl_cond.h
+++ b/Source/utils/sdl_cond.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <SDL.h>
+#include "sdl_mutex.h"
+
+namespace devilution {
+
+/*
+ * RAII wrapper for SDL_cond.
+ */
+class SdlCond final {
+public:
+	SdlCond()
+	    : cond(SDL_CreateCond())
+	{
+		if (cond == nullptr)
+			ErrSdl();
+	}
+
+	~SdlCond()
+	{
+		SDL_DestroyCond(cond);
+	}
+
+	SdlCond(const SdlCond &) = delete;
+	SdlCond(SdlCond &&) = delete;
+	SdlCond &operator=(const SdlCond &) = delete;
+	SdlCond &operator=(SdlCond &&) = delete;
+
+	void signal()
+	{
+		int err = SDL_CondSignal(cond);
+		if (err < 0)
+			ErrSdl();
+	}
+
+	void wait(SdlMutex &mutex)
+	{
+		int err = SDL_CondWait(cond, mutex.get());
+		if (err < 0)
+			ErrSdl();
+	}
+
+private:
+	SDL_cond *cond;
+};
+
+} // namespace devilution
+

--- a/Source/utils/sdl_mutex.h
+++ b/Source/utils/sdl_mutex.h
@@ -56,6 +56,11 @@ public:
 			ErrSdl();
 	}
 
+	SDL_mutex *get()
+	{
+		return mutex_;
+	}
+
 private:
 	SDL_mutex *mutex_;
 };


### PR DESCRIPTION
Dthread had some convoluted synchronization logic, and made use of 2 mutexes and 1 condition variable. It lends itself to a more standard producer-consumer approach.

On the consumer: Drain the message queue in a loop. Once empty, wait for a signal.

On the producer: Signal whenever something new is placed in the queue. If this occurs during `multi_send_zero_packet`, the signal is lost, but the consumer checks the queue again.

When killing the thread: if this happens during `multi_send_zero_packet`, `DthreadRunning = false` is sufficient to kill the thread. Otherwise, the thread is signaled again and eventually dies.