### PR TITLE
Fix separated monster pack handling

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -619,7 +619,7 @@ void LoadMonster(LoadHelper *file, MonsterStruct &monster)
 	if (monster.mtalkmsg == TEXT_KING1) // Fix original bad mapping of NONE for monsters
 		monster.mtalkmsg = TEXT_NONE;
 	monster.leader = file->NextLE<uint8_t>();
-	monster.leaderflag = static_cast<MonsterRelation>(file->NextLE<uint8_t>());
+	monster.leaderRelation = static_cast<LeaderRelation>(file->NextLE<uint8_t>());
 	monster.packsize = file->NextLE<uint8_t>();
 	monster.mlid = file->NextLE<int8_t>();
 	if (monster.mlid == Players[MyPlayerId]._plid)
@@ -1275,7 +1275,7 @@ void SaveMonster(SaveHelper *file, MonsterStruct &monster)
 
 	file->WriteLE<int32_t>(monster.mtalkmsg == TEXT_NONE ? 0 : monster.mtalkmsg); // Replicate original bad mapping of none for monsters
 	file->WriteLE<uint8_t>(monster.leader);
-	file->WriteLE<uint8_t>(static_cast<std::uint8_t>(monster.leaderflag));
+	file->WriteLE<uint8_t>(static_cast<std::uint8_t>(monster.leaderRelation));
 	file->WriteLE<uint8_t>(monster.packsize);
 	file->WriteLE<int8_t>(monster.mlid);
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1952,7 +1952,10 @@ void GroupUnity(int i)
 	if (monster.leaderRelation == LeaderRelation::None)
 		return;
 
+	// Someone with a leaderRelation should have a leader ...
 	assert(monster.leader >= 0);
+	// And no unique monster would be a minion of someone else!
+	assert(monster._uniqtype == 0);
 
 	auto &leader = Monsters[monster.leader];
 	if (IsLineNotSolid(monster.position.tile, leader.position.future)) {
@@ -1975,23 +1978,6 @@ void GroupUnity(int i)
 		if (leader._mAi == AI_GARG && (leader._mFlags & MFLAG_ALLOW_SPECIAL) != 0) {
 			leader._mFlags &= ~MFLAG_ALLOW_SPECIAL;
 			leader._mmode = MM_SATTACK;
-		}
-		return;
-	}
-
-	if (monster._uniqtype == 0 || (UniqMonst[monster._uniqtype - 1].mUnqAttr & 2) == 0)
-		return;
-	for (int j = 0; j < ActiveMonsterCount; j++) {
-		auto &minion = Monsters[ActiveMonsters[j]];
-		if (minion.leaderRelation != LeaderRelation::Leashed || minion.leader != i)
-			continue;
-		if (monster._msquelch > minion._msquelch) {
-			minion.position.last = monster.position.tile;
-			minion._msquelch = monster._msquelch - 1;
-		}
-		if (minion._mAi == AI_GARG && (minion._mFlags & MFLAG_ALLOW_SPECIAL) != 0) {
-			minion._mFlags &= ~MFLAG_ALLOW_SPECIAL;
-			minion._mmode = MM_SATTACK;
 		}
 	}
 }

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -115,10 +115,20 @@ enum placeflag : uint8_t {
 	// clang-format on
 };
 
-enum class MonsterRelation : uint8_t {
-	Individual,
-	Minion,
-	Leader,
+/**
+ * @brief Defines the relation of the monster to a monster pack.
+ *        If value is differnt from Individual MonsterStruct.leader must also be set
+ */
+enum class LeaderRelation : uint8_t {
+	None,
+	/**
+	 * @brief Minion that sticks with the leader
+	 */
+	Leashed,
+	/**
+	 * @brief Minion that was separated from leader and acts individual until it reaches the leader again
+	 */
+	Separated,
 };
 
 struct AnimStruct {
@@ -199,7 +209,7 @@ struct MonsterStruct { // note: missing field _mAFNum
 	uint16_t mMagicRes;
 	_speech_id mtalkmsg;
 	uint8_t leader;
-	MonsterRelation leaderflag;
+	LeaderRelation leaderRelation;
 	uint8_t packsize;
 	int8_t mlid; // BUGFIX -1 is used when not emitting light this should be signed (fixed)
 	const char *mName;


### PR DESCRIPTION
Fixes #2413

Bug was introduced in #2379 commit a44781bd73d440628a096f4e79e4dbc27cbcc590

`packsize` got a negative overflow.
This is cause the [new check](https://github.com/diasurgical/devilutionX/pull/2379/commits/a44781bd73d440628a096f4e79e4dbc27cbcc590#diff-d46585089d315b53630b1035442b3d490d7b422cb05ceee76cf9041de3e39179R1966) can [subtract separated minions](https://github.com/diasurgical/devilutionX/pull/2379/commits/a44781bd73d440628a096f4e79e4dbc27cbcc590#diff-d46585089d315b53630b1035442b3d490d7b422cb05ceee76cf9041de3e39179R1972-R1973) multiple times from `packsize`.

First I reverted to the original logic (first commit), refactored the logic again (second commit) and last did some renaming to reduce future misunderstandings (third commit).

Notes:

- Existing saves can't be fixed by this pr, cause the wrong `packsize` is already saved.
- Now I have enough from Bongo, cause I killed his pack around 20 times.