### PR TITLE
Fix automap jiggling for player arrow

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -275,8 +275,8 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, int 
 		playerOffset = GetOffsetForWalking(player.AnimInfo, player._pdir);
 
 	Point base = {
-		(playerOffset.deltaX * AutoMapScale / 100 / 2) + (myPlayerOffset.deltaX * AutoMapScale / 100 / 2) + (px - py) * AmLine16 + gnScreenWidth / 2,
-		(playerOffset.deltaY * AutoMapScale / 100 / 2) + (myPlayerOffset.deltaY * AutoMapScale / 100 / 2) + (px + py) * AmLine8 + (gnScreenHeight - PANEL_HEIGHT) / 2
+		((playerOffset.deltaX + myPlayerOffset.deltaX) * AutoMapScale / 100 / 2) + (px - py) * AmLine16 + gnScreenWidth / 2,
+		((playerOffset.deltaY + myPlayerOffset.deltaY) * AutoMapScale / 100 / 2) + (px + py) * AmLine8 + (gnScreenHeight - PANEL_HEIGHT) / 2
 	};
 
 	if (CanPanelsCoverView()) {


### PR DESCRIPTION
Fixes player arrow jiggling in automap.

<details><summary>Sample video 5% game speed</summary>

### Master

https://user-images.githubusercontent.com/25415264/126181509-bdf28587-b58d-4746-af30-ea577dae2872.mp4

### PR

https://user-images.githubusercontent.com/25415264/126181546-74554463-9be5-41cf-b7ff-ec80bf6fc855.mp4

</details>

Integer precision/rounding issue:
5 * 50 / 100 / 2 = 1
27 * 50 / 100 / 2 = 6
but
(5+27)  * 50 / 100 / 2 = 8
😉 

Note:
The jiggling is also present in vanilla.