### PR TITLE
Fix 3DS crash at startup

### DIFF
--- a/Source/controls/devices/joystick.cpp
+++ b/Source/controls/devices/joystick.cpp
@@ -222,25 +222,25 @@ bool Joystick::ProcessAxisMotion(const SDL_Event &event)
 	case JOY_AXIS_LEFTX:
 		leftStickXUnscaled = event.jaxis.value;
 		leftStickNeedsScaling = true;
-		break;
+		return true;
 #endif
 #ifdef JOY_AXIS_LEFTY
 	case JOY_AXIS_LEFTY:
 		leftStickYUnscaled = -event.jaxis.value;
 		leftStickNeedsScaling = true;
-		break;
+		return true;
 #endif
 #ifdef JOY_AXIS_RIGHTX
 	case JOY_AXIS_RIGHTX:
 		rightStickXUnscaled = event.jaxis.value;
 		rightStickNeedsScaling = true;
-		break;
+		return true;
 #endif
 #ifdef JOY_AXIS_RIGHTY
 	case JOY_AXIS_RIGHTY:
 		rightStickYUnscaled = -event.jaxis.value;
 		rightStickNeedsScaling = true;
-		break;
+		return true;
 #endif
 	default:
 		return false;


### PR DESCRIPTION
I assume this return statement was removed by mistake because most platforms do not define these `JOY_AXIS_*` variables.

This resolves #2442