### PR TITLE
ADL: Introduce preview Frame (reduce input lag feeling)

### DIFF
--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -75,7 +75,7 @@ float AnimationInfo::GetAnimationProgress() const
 	return animationFraction;
 }
 
-void AnimationInfo::SetNewAnimation(const CelSprite *celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/)
+void AnimationInfo::SetNewAnimation(const CelSprite *celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/, float previewShownGameTickFragments /*= 0.F*/)
 {
 	if ((flags & AnimationDistributionFlags::RepeatedAction) == AnimationDistributionFlags::RepeatedAction && distributeFramesBeforeFrame != 0 && NumberOfFrames == numberOfFrames && CurrentFrame >= distributeFramesBeforeFrame && CurrentFrame != NumberOfFrames) {
 		// We showed the same Animation (for example a melee attack) before but truncated the Animation.
@@ -128,6 +128,11 @@ void AnimationInfo::SetNewAnimation(const CelSprite *celSprite, int numberOfFram
 			// This also means Rendering should never hapen with TicksSinceSequenceStarted < 0.
 			TicksSinceSequenceStarted = -1.F;
 		}
+
+		// The preview animation was shown some times (less then one game tick)
+		// So we overall have a longer time the animation is shown
+		TicksSinceSequenceStarted += previewShownGameTickFragments;
+		relevantAnimationTicksWithSkipping += previewShownGameTickFragments;
 
 		if ((flags & AnimationDistributionFlags::SkipsDelayOfLastFrame) == AnimationDistributionFlags::SkipsDelayOfLastFrame) {
 			// The logic for player/monster/... (not ProcessAnimation) only checks the frame not the delay.

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -24,7 +24,7 @@ int AnimationInfo::GetFrameToUseForRendering() const
 	if (CurrentFrame > RelevantFramesForDistributing)
 		return CurrentFrame;
 
-	float ticksSinceSequenceStarted = static_cast<float>(TicksSinceSequenceStarted);
+	float ticksSinceSequenceStarted = TicksSinceSequenceStarted;
 	if (TicksSinceSequenceStarted < 0) {
 		ticksSinceSequenceStarted = 0.0F;
 		Log("GetFrameToUseForRendering: Invalid TicksSinceSequenceStarted {}", TicksSinceSequenceStarted);
@@ -95,7 +95,7 @@ void AnimationInfo::SetNewAnimation(const CelSprite *celSprite, int numberOfFram
 	CurrentFrame = 1 + numSkippedFrames;
 	TickCounterOfCurrentFrame = 0;
 	TicksPerFrame = ticksPerFrame;
-	TicksSinceSequenceStarted = 0;
+	TicksSinceSequenceStarted = 0.F;
 	RelevantFramesForDistributing = 0;
 	TickModifier = 0.0F;
 	IsPetrified = false;
@@ -115,18 +115,18 @@ void AnimationInfo::SetNewAnimation(const CelSprite *celSprite, int numberOfFram
 		int relevantAnimationTicksForDistribution = relevantAnimationFramesForDistributing * ticksPerFrame;
 
 		// How many game ticks will the Animation be really shown (skipped Frames and game ticks removed)
-		int relevantAnimationTicksWithSkipping = relevantAnimationTicksForDistribution - (numSkippedFrames * ticksPerFrame);
+		float relevantAnimationTicksWithSkipping = relevantAnimationTicksForDistribution - (numSkippedFrames * ticksPerFrame);
 
 		if ((flags & AnimationDistributionFlags::ProcessAnimationPending) == AnimationDistributionFlags::ProcessAnimationPending) {
 			// If ProcessAnimation will be called after SetNewAnimation (in same game tick as SetNewAnimation), we increment the Animation-Counter.
 			// If no delay is specified, this will result in complete skipped frame (see ProcessAnimation).
 			// But if we have a delay specified, this would only result in a reduced time the first frame is shown (one skipped delay).
 			// Because of that, we only the remove one game tick from the time the Animation is shown
-			relevantAnimationTicksWithSkipping -= 1;
+			relevantAnimationTicksWithSkipping -= 1.F;
 			// The Animation Distribution Logic needs to account how many game ticks passed since the Animation started.
 			// Because ProcessAnimation will increase this later (in same game tick as SetNewAnimation), we correct this upfront.
 			// This also means Rendering should never hapen with TicksSinceSequenceStarted < 0.
-			TicksSinceSequenceStarted = -1;
+			TicksSinceSequenceStarted = -1.F;
 		}
 
 		if ((flags & AnimationDistributionFlags::SkipsDelayOfLastFrame) == AnimationDistributionFlags::SkipsDelayOfLastFrame) {
@@ -153,7 +153,7 @@ void AnimationInfo::SetNewAnimation(const CelSprite *celSprite, int numberOfFram
 		relevantAnimationTicksForDistribution += (SkippedFramesFromPreviousAnimation * ticksPerFrame);
 
 		// if we skipped Frames we need to expand the game ticks to make one game tick for this Animation "faster"
-		float tickModifier = static_cast<float>(relevantAnimationTicksForDistribution) / static_cast<float>(relevantAnimationTicksWithSkipping);
+		float tickModifier = static_cast<float>(relevantAnimationTicksForDistribution) / relevantAnimationTicksWithSkipping;
 
 		// tickModifier specifies the Animation fraction per game tick, so we have to remove the delay from the variable
 		tickModifier /= static_cast<float>(ticksPerFrame);
@@ -174,7 +174,7 @@ void AnimationInfo::ChangeAnimationData(const CelSprite *celSprite, int numberOf
 
 		NumberOfFrames = numberOfFrames;
 		TicksPerFrame = ticksPerFrame;
-		TicksSinceSequenceStarted = 0;
+		TicksSinceSequenceStarted = 0.F;
 		RelevantFramesForDistributing = 0;
 		TickModifier = 0.0F;
 	}
@@ -193,13 +193,13 @@ void AnimationInfo::ProcessAnimation(bool reverseAnimation /*= false*/, bool don
 			CurrentFrame--;
 			if (CurrentFrame == 0) {
 				CurrentFrame = NumberOfFrames;
-				TicksSinceSequenceStarted = 0;
+				TicksSinceSequenceStarted = 0.F;
 			}
 		} else {
 			CurrentFrame++;
 			if (CurrentFrame > NumberOfFrames) {
 				CurrentFrame = 1;
-				TicksSinceSequenceStarted = 0;
+				TicksSinceSequenceStarted = 0.F;
 			}
 		}
 	}

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -80,8 +80,9 @@ public:
 	 * @param flags Specifies what special logics are applied to this Animation
 	 * @param numSkippedFrames Number of Frames that will be skipped (for example with modifier "faster attack")
 	 * @param distributeFramesBeforeFrame Distribute the numSkippedFrames only before this frame
+	 * @param previewShownGameTickFragments Defines how long (in game ticks fraction) the preview animation was shown
 	 */
-	void SetNewAnimation(const CelSprite *celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0);
+	void SetNewAnimation(const CelSprite *celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0, float previewShownGameTickFragments = 0.F);
 
 	/**
 	 * @brief Changes the Animation Data on-the-fly. This is needed if a animation is currently in progress and the player changes his gear.

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -111,7 +111,7 @@ private:
 	/**
 	 * @brief Number of game ticks after the current animation sequence started
 	 */
-	int TicksSinceSequenceStarted;
+	float TicksSinceSequenceStarted;
 	/**
 	 * @brief Animation Frames that will be adjusted for the skipped Frames/game ticks
 	 */

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2873,6 +2873,7 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 		player._pgfxnum = gfxNum;
 		ResetPlayerGFX(player);
 		SetPlrAnims(player);
+		player.pPreviewCelSprite = nullptr;
 		if (player._pmode == PM_STAND) {
 			LoadPlrGFX(player, player_graphic::Stand);
 			player.AnimInfo.ChangeAnimationData(&*player.AnimationData[static_cast<size_t>(player_graphic::Stand)].GetCelSpritesForDirection(player._pdir), player._pNFrames, 4);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2346,6 +2346,9 @@ void NetSendCmdLoc(int playerId, bool bHiPri, _cmd_id bCmd, Point position)
 		NetSendHiPri(playerId, (byte *)&cmd, sizeof(cmd));
 	else
 		NetSendLoPri(playerId, (byte *)&cmd, sizeof(cmd));
+
+	auto &myPlayer = Players[MyPlayerId];
+	myPlayer.UpdatePreviewCelSprite(bCmd, position, 0, 0);
 }
 
 void NetSendCmdLocParam1(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1)
@@ -2360,6 +2363,9 @@ void NetSendCmdLocParam1(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
 	else
 		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+
+	auto &myPlayer = Players[MyPlayerId];
+	myPlayer.UpdatePreviewCelSprite(bCmd, position, wParam1, 0);
 }
 
 void NetSendCmdLocParam2(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2)
@@ -2375,6 +2381,9 @@ void NetSendCmdLocParam2(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
 	else
 		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+
+	auto &myPlayer = Players[MyPlayerId];
+	myPlayer.UpdatePreviewCelSprite(bCmd, position, wParam1, wParam2);
 }
 
 void NetSendCmdLocParam3(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3)
@@ -2391,6 +2400,9 @@ void NetSendCmdLocParam3(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
 	else
 		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+
+	auto &myPlayer = Players[MyPlayerId];
+	myPlayer.UpdatePreviewCelSprite(bCmd, position, wParam1, wParam2);
 }
 
 void NetSendCmdLocParam4(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4)
@@ -2420,6 +2432,9 @@ void NetSendCmdParam1(bool bHiPri, _cmd_id bCmd, uint16_t wParam1)
 		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
 	else
 		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+
+	auto &myPlayer = Players[MyPlayerId];
+	myPlayer.UpdatePreviewCelSprite(bCmd, {}, wParam1, 0);
 }
 
 void NetSendCmdParam2(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2129,6 +2129,10 @@ void Player::RestorePartialMana()
 
 void LoadPlrGFX(Player &player, player_graphic graphic)
 {
+	auto &animationData = player.AnimationData[static_cast<size_t>(graphic)];
+	if (animationData.RawData != nullptr)
+		return;
+
 	char prefix[16];
 	char pszName[256];
 	const char *szCel;
@@ -2224,12 +2228,13 @@ void LoadPlrGFX(Player &player, player_graphic graphic)
 	}
 
 	sprintf(pszName, R"(PlrGFX\%s\%s\%s%s.CL2)", cs, prefix, prefix, szCel);
-	auto &animationData = player.AnimationData[static_cast<size_t>(graphic)];
 	SetPlayerGPtrs(pszName, animationData.RawData, animationData.CelSpritesForDirections, animationWidth);
 }
 
 void InitPlayerGFX(Player &player)
 {
+	ResetPlayerGFX(player);
+
 	if (player._pHitPoints >> 6 == 0) {
 		player._pgfxnum = 0;
 		LoadPlrGFX(player, player_graphic::Death);
@@ -2256,8 +2261,7 @@ void ResetPlayerGFX(Player &player)
 
 void NewPlrAnim(Player &player, player_graphic graphic, Direction dir, int numberOfFrames, int delayLen, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/)
 {
-	if (player.AnimationData[static_cast<size_t>(graphic)].RawData == nullptr)
-		LoadPlrGFX(player, graphic);
+	LoadPlrGFX(player, graphic);
 
 	auto &celSprite = player.AnimationData[static_cast<size_t>(graphic)].CelSpritesForDirections[static_cast<size_t>(dir)];
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -23,6 +23,7 @@
 #include "loadsave.h"
 #include "minitext.h"
 #include "missiles.h"
+#include "nthread.h"
 #include "options.h"
 #include "player.h"
 #include "qol/autopickup.h"
@@ -2263,6 +2264,7 @@ void Player::UpdatePreviewCelSprite(_cmd_id cmdId, Point point, uint16_t wParam1
 	auto &celSprites = AnimationData[static_cast<size_t>(*graphic)].CelSpritesForDirections[static_cast<size_t>(dir)];
 	if (celSprites && pPreviewCelSprite != &*celSprites) {
 		pPreviewCelSprite = &*celSprites;
+		progressToNextGameTickWhenPreviewWasSet = gfProgressToNextGameTick;
 	}
 }
 
@@ -2406,7 +2408,10 @@ void NewPlrAnim(Player &player, player_graphic graphic, Direction dir, int numbe
 
 	CelSprite *pCelSprite = celSprite ? &*celSprite : nullptr;
 
-	player.AnimInfo.SetNewAnimation(pCelSprite, numberOfFrames, delayLen, flags, numSkippedFrames, distributeFramesBeforeFrame);
+	float previewShownGameTickFragments = 0.F;
+	if (pCelSprite == player.pPreviewCelSprite)
+		previewShownGameTickFragments = clamp(1.F - player.progressToNextGameTickWhenPreviewWasSet, 0.F, 1.F);
+	player.AnimInfo.SetNewAnimation(pCelSprite, numberOfFrames, delayLen, flags, numSkippedFrames, distributeFramesBeforeFrame, previewShownGameTickFragments);
 }
 
 void SetPlrAnims(Player &player)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -490,6 +490,18 @@ void StartRangeAttack(int pnum, Direction d, int cx, int cy)
 	player.position.temp = { cx, cy };
 }
 
+player_graphic GetPlayerGraphicForSpell(spell_id spellId)
+{
+	switch (spelldata[spellId].sType) {
+	case STYPE_FIRE:
+		return player_graphic::Fire;
+	case STYPE_LIGHTNING:
+		return player_graphic::Lightning;
+	default:
+		return player_graphic::Magic;
+	}
+}
+
 void StartSpell(int pnum, Direction d, int cx, int cy)
 {
 	if ((DWORD)pnum >= MAX_PLRS)
@@ -505,18 +517,7 @@ void StartSpell(int pnum, Direction d, int cx, int cy)
 		auto animationFlags = AnimationDistributionFlags::ProcessAnimationPending;
 		if (player._pmode == PM_SPELL)
 			animationFlags = static_cast<AnimationDistributionFlags>(animationFlags | AnimationDistributionFlags::RepeatedAction);
-
-		switch (spelldata[player._pSpell].sType) {
-		case STYPE_FIRE:
-			NewPlrAnim(player, player_graphic::Fire, d, player._pSFrames, 1, animationFlags, 0, player._pSFNum);
-			break;
-		case STYPE_LIGHTNING:
-			NewPlrAnim(player, player_graphic::Lightning, d, player._pSFrames, 1, animationFlags, 0, player._pSFNum);
-			break;
-		case STYPE_MAGIC:
-			NewPlrAnim(player, player_graphic::Magic, d, player._pSFrames, 1, animationFlags, 0, player._pSFNum);
-			break;
-		}
+		NewPlrAnim(player, GetPlayerGraphicForSpell(player._pSpell), d, player._pSFrames, 1, animationFlags, 0, player._pSFNum);
 	} else {
 		// Start new stand animation so that currentframe is reset
 		d = player._pdir;

--- a/Source/player.h
+++ b/Source/player.h
@@ -217,6 +217,10 @@ struct Player {
 	 * @brief Contains Information for current Animation
 	 */
 	AnimationInfo AnimInfo;
+	/**
+	 * @brief Contains a optional preview CelSprite that is displayed until the current command is handled by the game logic
+	 */
+	CelSprite *pPreviewCelSprite;
 	int _plid;
 	int _pvid;
 	spell_id _pSpell;
@@ -651,6 +655,15 @@ struct Player {
 			return true;
 		return false;
 	}
+
+	/**
+	 * @brief Updates pPreviewCelSprite according to new requested command
+	 * @param cmdId What command is requested
+	 * @param point Point for the command
+	 * @param wParam1 First Parameter
+	 * @param wParam2 Second Parameter
+	 */
+	void UpdatePreviewCelSprite(_cmd_id cmdId, Point point, uint16_t wParam1, uint16_t wParam2);
 };
 
 extern DVL_API_FOR_TEST int MyPlayerId;

--- a/Source/player.h
+++ b/Source/player.h
@@ -221,6 +221,10 @@ struct Player {
 	 * @brief Contains a optional preview CelSprite that is displayed until the current command is handled by the game logic
 	 */
 	CelSprite *pPreviewCelSprite;
+	/**
+	 * @brief Contains the progress to next game tick when pPreviewCelSprite was set
+	 */
+	float progressToNextGameTickWhenPreviewWasSet;
 	int _plid;
 	int _pvid;
 	spell_id _pSpell;

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -519,6 +519,8 @@ void DrawPlayer(const Surface &out, int pnum, Point tilePosition, Point targetBu
 		return;
 	}
 
+	targetBufferPosition -= { CalculateWidth2(pCelSprite == nullptr ? 96 : pCelSprite->Width()), 0 };
+
 	int frames = SDL_SwapLE32(*reinterpret_cast<const DWORD *>(pCelSprite->Data()));
 	if (nCel < 1 || frames > 50 || nCel > frames) {
 		const char *szMode = "unknown action";
@@ -806,8 +808,7 @@ void DrawPlayerHelper(const Surface &out, Point tilePosition, Point targetBuffer
 		offset = GetOffsetForWalking(player.AnimInfo, player._pdir);
 	}
 
-	const Displacement center { CalculateWidth2(player.AnimInfo.pCelSprite == nullptr ? 96 : player.AnimInfo.pCelSprite->Width()), 0 };
-	const Point playerRenderPosition { targetBufferPosition + offset - center };
+	const Point playerRenderPosition { targetBufferPosition + offset };
 
 	DrawPlayer(out, p, tilePosition, playerRenderPosition);
 }

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -514,6 +514,11 @@ void DrawPlayer(const Surface &out, int pnum, Point tilePosition, Point targetBu
 	const auto *pCelSprite = player.AnimInfo.pCelSprite;
 	int nCel = player.AnimInfo.GetFrameToUseForRendering();
 
+	if (player.pPreviewCelSprite != nullptr) {
+		pCelSprite = player.pPreviewCelSprite;
+		nCel = 1;
+	}
+
 	if (pCelSprite == nullptr) {
 		Log("Drawing player {} \"{}\": NULL CelSprite", pnum, player._pName);
 		return;


### PR DESCRIPTION
## Introduction

PR#2322
The [missiles](https://github.com/diasurgical/devilutionX/pull/2322) and [monsters](https://github.com/diasurgical/devilutionX/pull/2230) got faster, But our mighty hero seems sometimes slow... like his is thinking too much. This is now gone! We got instant reflexes.

## Content

This PR tries to address input lag. This was done in the same way some other (multiplayer) games handle it.
We decouple shown animation in some cases from game logic.
If the player does nothing (stand animation) and we got an input we analyse the input.
We will anticipate what animation the game logic will show for this input.
Then we will show this preview animation until the next game tick (game logic run).

## Examples

<details><summary>Example Video (1% game speed)</summary>

https://user-images.githubusercontent.com/25415264/127044184-3c0349c1-cc43-4654-9945-3d1fd492f53f.mp4

</details>

<details><summary>Example Logs (Time in ms)</summary>

Event | Start-Time | Duration
-- | -- | --
DVL_WM_LBUTTONDOWN | 7342 | 0
PreviewWalk | 7342 | 12
StartWalk | 7354 |  
DVL_WM_LBUTTONDOWN | 16278 | 0
PreviewWalk | 16278 | 24
StartWalk | 16302 |  
DVL_WM_LBUTTONDOWN | 22934 | 0
PreviewWalk | 22934 | 18
StartWalk | 22952 |  
DVL_WM_LBUTTONDOWN | 46950 | 0
PreviewWalk | 46950 | 0
StartWalk | 46950 |  
DVL_WM_LBUTTONDOWN | 52509 | 0
PreviewWalk | 52509 | 42
StartWalk | 52551 |  
DVL_WM_LBUTTONDOWN | 62139 | 0
PreviewWalk | 62139 | 13
StartWalk | 62152 |  
DVL_WM_LBUTTONDOWN | 66839 | 0
PreviewWalk | 66839 | 12
StartWalk | 66851 |  
DVL_WM_LBUTTONDOWN | 67644 | 0
PreviewWalk | 67644 | 6
StartWalk | 67650 |  
DVL_WM_LBUTTONDOWN | 68436 | 0
PreviewWalk | 68436 | 18
StartWalk | 68454 |  
DVL_WM_LBUTTONDOWN | 69149 | 0
PreviewWalk | 69149 | 1
StartWalk | 69150 |  
DVL_WM_LBUTTONDOWN | 69868 | 1
PreviewWalk | 69869 | 30
StartWalk | 69899 |  
DVL_WM_LBUTTONDOWN | 70515 | 0
PreviewWalk | 70515 | 36
StartWalk | 70551 |  
DVL_WM_LBUTTONDOWN | 71149 | 0
PreviewWalk | 71149 | 0
StartWalk | 71149 |  
DVL_WM_LBUTTONDOWN | 71898 | 0
PreviewWalk | 71898 | 6
StartWalk | 71904 |  
DVL_WM_LBUTTONDOWN | 72587 | 0
PreviewWalk | 72587 | 12
StartWalk | 72599 |  


</body>

</html>


</details>

## Notes

- No behavior changes. Only animations.
- The time until your action is displayed on screen is still limited by fps. Cause if we render too slow, we can't show something. 😉 
- We always show the latest action, cause the last action would override/set `destAction` of the player. This can also result in multiple/different animations shown (see example video). But this is unlikely to happen at normal game speed.
- The preview can be wrong. For example if one player attacks another player and the player walked to next tile at the next game tick.
- In preview we always show the first frame of the animation. The other frames should be shown with the normal game logic.
- If the player is currently executing any other task (not standing), we don't show a preview frame, cause this would interrupt the normal animation and the task will be executed _far_ later anyway.
- Handling of input must be done in `NetSendCmdXYZ` cause the messages get only iterated/parsed when the game logic runs ( `multi_process_network_packets` calls `ParseCmd` and this sets players `destAction`).
- This adds complexity to the source code. So it would be great if you could play test it. That would help to decide if it's worth it or not. 🙂 