### PR TITLE
Fix item swapping and AnimationInfo::ChangeAnimationData

### DIFF
--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -7,6 +7,7 @@
 #include "animationinfo.h"
 #include "appfat.h"
 #include "nthread.h"
+#include "utils/stdcompat/algorithm.hpp"
 #include "utils/log.hpp"
 
 namespace devilution {
@@ -161,20 +162,19 @@ void AnimationInfo::SetNewAnimation(const CelSprite *celSprite, int numberOfFram
 	}
 }
 
-void AnimationInfo::ChangeAnimationData(const CelSprite *celSprite, int numberOfFrames, int delayLen)
+void AnimationInfo::ChangeAnimationData(const CelSprite *celSprite, int numberOfFrames, int ticksPerFrame)
 {
-	if (numberOfFrames != NumberOfFrames || delayLen != TicksPerFrame) {
+	if (numberOfFrames != NumberOfFrames || ticksPerFrame != TicksPerFrame) {
 		// Ensure that the CurrentFrame is still valid and that we disable ADL cause the calculcated values (for example TickModifier) could be wrong
-		if (CurrentFrame > numberOfFrames)
-			CurrentFrame = numberOfFrames;
+		CurrentFrame = clamp(CurrentFrame, 1, numberOfFrames);
 		NumberOfFrames = numberOfFrames;
-		TicksPerFrame = delayLen;
+		TicksPerFrame = ticksPerFrame;
 		TicksSinceSequenceStarted = 0;
 		RelevantFramesForDistributing = 0;
 		TickModifier = 0.0F;
 	}
 	this->pCelSprite = celSprite;
-	TicksPerFrame = delayLen;
+	TicksPerFrame = ticksPerFrame;
 }
 
 void AnimationInfo::ProcessAnimation(bool reverseAnimation /*= false*/, bool dontProgressAnimation /*= false*/)

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -87,9 +87,9 @@ public:
 	 * @brief Changes the Animation Data on-the-fly. This is needed if a animation is currently in progress and the player changes his gear.
 	 * @param celSprite Pointer to Animation Sprite
 	 * @param numberOfFrames Number of Frames in Animation
-	 * @param delayLen Delay after each Animation sequence
+	 * @param ticksPerFrame How many game ticks are needed to advance one Animation Frame
 	 */
-	void ChangeAnimationData(const CelSprite *celSprite, int numberOfFrames, int delayLen);
+	void ChangeAnimationData(const CelSprite *celSprite, int numberOfFrames, int ticksPerFrame);
 
 	/**
 	 * @brief Process the Animation for a game tick (for example advances the frame)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2949,10 +2949,10 @@ void CalcPlrItemVals(int playerId, bool loadgfx)
 		SetPlrAnims(player);
 		if (player._pmode == PM_STAND) {
 			LoadPlrGFX(player, player_graphic::Stand);
-			player.AnimInfo.ChangeAnimationData(&*player.AnimationData[static_cast<size_t>(player_graphic::Stand)].CelSpritesForDirections[player._pdir], player._pNFrames, 3);
+			player.AnimInfo.ChangeAnimationData(&*player.AnimationData[static_cast<size_t>(player_graphic::Stand)].CelSpritesForDirections[player._pdir], player._pNFrames, 4);
 		} else {
 			LoadPlrGFX(player, player_graphic::Walk);
-			player.AnimInfo.ChangeAnimationData(&*player.AnimationData[static_cast<size_t>(player_graphic::Walk)].CelSpritesForDirections[player._pdir], player._pWFrames, 0);
+			player.AnimInfo.ChangeAnimationData(&*player.AnimationData[static_cast<size_t>(player_graphic::Walk)].CelSpritesForDirections[player._pdir], player._pWFrames, 1);
 		}
 	} else {
 		player._pgfxnum = gfxNum;


### PR DESCRIPTION
Fixes #2455 

Notes:

- Main problem was that we [changed](https://github.com/diasurgical/devilutionX/pull/2244) from `delayLen` to `ticksPerFrame` but the call in `items.cpp` wasn't adjusted.
- Secondary problem was that we could end up with a currentframe=0 if we swap animations in `ChangeAnimationData`. But this only surfaced cause we passed the wrong parameter (see main problem). Fixed anyway. 😉 
- I also found the issue while working at #2457 😄