### PR TITLE
Scoped enums for ui_item.h

### DIFF
--- a/Source/DiabloUI/button.cpp
+++ b/Source/DiabloUI/button.cpp
@@ -29,7 +29,7 @@ void RenderButton(UiButton *button)
 
 	SDL_Color color1 = { 243, 243, 243, 0 };
 	SDL_Color color2 = { 0, 0, 0, 0 };
-	DrawTTF(button->m_text, textRect, UiFlags::UIS_CENTER,
+	DrawTTF(button->m_text, textRect, UiFlags::AlignCenter,
 	    color1, color2, button->m_render_cache);
 }
 

--- a/Source/DiabloUI/button.cpp
+++ b/Source/DiabloUI/button.cpp
@@ -29,7 +29,7 @@ void RenderButton(UiButton *button)
 
 	SDL_Color color1 = { 243, 243, 243, 0 };
 	SDL_Color color2 = { 0, 0, 0, 0 };
-	DrawTTF(button->m_text, textRect, UIS_CENTER,
+	DrawTTF(button->m_text, textRect, UiFlags::UIS_CENTER,
 	    color1, color2, button->m_render_cache);
 }
 

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -102,7 +102,7 @@ void UiInitList(int count, void (*fnFocus)(int value), void (*fnSelect)(int valu
 #endif
 	textInputActive = false;
 	for (const auto &item : items) {
-		if (item->m_type == UI_EDIT) {
+		if (item->m_type == UiType::UI_EDIT) {
 			auto *pItemUIEdit = static_cast<UiEdit *>(item.get());
 			SDL_SetTextInputRect(&item->m_rect);
 			textInputActive = true;
@@ -808,28 +808,28 @@ void RenderItem(UiItemBase *item)
 	if (item->has_flag(UiFlags::UIS_HIDDEN))
 		return;
 	switch (item->m_type) {
-	case UI_TEXT:
+	case UiType::UI_TEXT:
 		Render(static_cast<UiText *>(item));
 		break;
-	case UI_ART_TEXT:
+	case UiType::UI_ART_TEXT:
 		Render(static_cast<UiArtText *>(item));
 		break;
-	case UI_IMAGE:
+	case UiType::UI_IMAGE:
 		Render(static_cast<UiImage *>(item));
 		break;
-	case UI_ART_TEXT_BUTTON:
+	case UiType::UI_ART_TEXT_BUTTON:
 		Render(static_cast<UiArtTextButton *>(item));
 		break;
-	case UI_BUTTON:
+	case UiType::UI_BUTTON:
 		RenderButton(static_cast<UiButton *>(item));
 		break;
-	case UI_LIST:
+	case UiType::UI_LIST:
 		Render(static_cast<UiList *>(item));
 		break;
-	case UI_SCROLLBAR:
+	case UiType::UI_SCROLLBAR:
 		Render(static_cast<UiScrollBar *>(item));
 		break;
-	case UI_EDIT:
+	case UiType::UI_EDIT:
 		Render(static_cast<UiEdit *>(item));
 		break;
 	}
@@ -914,13 +914,13 @@ bool HandleMouseEvent(const SDL_Event &event, UiItemBase *item)
 	if (item->has_any_flag(UiFlags::UIS_HIDDEN | UiFlags::UIS_DISABLED) || !IsInsideRect(event, item->m_rect))
 		return false;
 	switch (item->m_type) {
-	case UI_ART_TEXT_BUTTON:
+	case UiType::UI_ART_TEXT_BUTTON:
 		return HandleMouseEventArtTextButton(event, static_cast<UiArtTextButton *>(item));
-	case UI_BUTTON:
+	case UiType::UI_BUTTON:
 		return HandleMouseEventButton(event, static_cast<UiButton *>(item));
-	case UI_LIST:
+	case UiType::UI_LIST:
 		return HandleMouseEventList(event, static_cast<UiList *>(item));
-	case UI_SCROLLBAR:
+	case UiType::UI_SCROLLBAR:
 		return HandleMouseEventScrollBar(event, static_cast<UiScrollBar *>(item));
 	default:
 		return false;
@@ -970,7 +970,7 @@ bool UiItemMouseEvents(SDL_Event *event, const std::vector<UiItemBase *> &items)
 	if (event->type == SDL_MOUSEBUTTONUP && event->button.button == SDL_BUTTON_LEFT) {
 		scrollBarState.downArrowPressed = scrollBarState.upArrowPressed = false;
 		for (const auto &item : items) {
-			if (item->m_type == UI_BUTTON)
+			if (item->m_type == UiType::UI_BUTTON)
 				HandleGlobalMouseUpButton(static_cast<UiButton *>(item));
 		}
 	}
@@ -1000,7 +1000,7 @@ bool UiItemMouseEvents(SDL_Event *event, const std::vector<std::unique_ptr<UiIte
 	if (event->type == SDL_MOUSEBUTTONUP && event->button.button == SDL_BUTTON_LEFT) {
 		scrollBarState.downArrowPressed = scrollBarState.upArrowPressed = false;
 		for (const auto &item : items) {
-			if (item->m_type == UI_BUTTON)
+			if (item->m_type == UiType::UI_BUTTON)
 				HandleGlobalMouseUpButton(static_cast<UiButton *>(item.get()));
 		}
 	}

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -126,9 +126,9 @@ void UiInitScrollBar(UiScrollBar *uiSb, std::size_t viewportSize, const std::siz
 	ListViewportSize = viewportSize;
 	ListOffset = currentOffset;
 	if (ListViewportSize >= static_cast<std::size_t>(SelectedItemMax + 1)) {
-		uiSb->add_flag(UiFlags::UIS_HIDDEN);
+		uiSb->add_flag(UiFlags::ElementHidden);
 	} else {
-		uiSb->remove_flag(UiFlags::UIS_HIDDEN);
+		uiSb->remove_flag(UiFlags::ElementHidden);
 	}
 }
 
@@ -636,17 +636,17 @@ void UiAddBackground(std::vector<std::unique_ptr<UiItemBase>> *vecDialog)
 {
 	if (ArtBackgroundWidescreen.surface != nullptr) {
 		SDL_Rect rectw = { 0, UI_OFFSET_Y, 0, 0 };
-		vecDialog->push_back(std::make_unique<UiImage>(&ArtBackgroundWidescreen, rectw, UiFlags::UIS_CENTER));
+		vecDialog->push_back(std::make_unique<UiImage>(&ArtBackgroundWidescreen, rectw, UiFlags::AlignCenter));
 	}
 
 	SDL_Rect rect = { 0, UI_OFFSET_Y, 0, 0 };
-	vecDialog->push_back(std::make_unique<UiImage>(&ArtBackground, rect, UiFlags::UIS_CENTER));
+	vecDialog->push_back(std::make_unique<UiImage>(&ArtBackground, rect, UiFlags::AlignCenter));
 }
 
 void UiAddLogo(std::vector<std::unique_ptr<UiItemBase>> *vecDialog, int size, int y)
 {
 	SDL_Rect rect = { 0, (Sint16)(UI_OFFSET_Y + y), 0, 0 };
-	vecDialog->push_back(std::make_unique<UiImage>(&ArtLogos[size], rect, UiFlags::UIS_CENTER, /*bAnimated=*/true));
+	vecDialog->push_back(std::make_unique<UiImage>(&ArtLogos[size], rect, UiFlags::AlignCenter, /*bAnimated=*/true));
 }
 
 void UiFadeIn()
@@ -734,7 +734,7 @@ void Render(const UiArtText *uiArtText)
 void Render(const UiImage *uiImage)
 {
 	int x = uiImage->m_rect.x;
-	if (HasAnyOf(uiImage->m_iFlags, UiFlags::UIS_CENTER) && uiImage->m_art != nullptr) {
+	if (HasAnyOf(uiImage->m_iFlags, UiFlags::AlignCenter) && uiImage->m_art != nullptr) {
 		const int xOffset = GetCenterOffset(uiImage->m_art->w(), uiImage->m_rect.w);
 		x += xOffset;
 	}
@@ -805,7 +805,7 @@ void Render(const UiEdit *uiEdit)
 
 void RenderItem(UiItemBase *item)
 {
-	if (item->has_flag(UiFlags::UIS_HIDDEN))
+	if (item->has_flag(UiFlags::ElementHidden))
 		return;
 	switch (item->m_type) {
 	case UiType::UI_TEXT:
@@ -911,7 +911,7 @@ bool HandleMouseEventScrollBar(const SDL_Event &event, const UiScrollBar *uiSb)
 
 bool HandleMouseEvent(const SDL_Event &event, UiItemBase *item)
 {
-	if (item->has_any_flag(UiFlags::UIS_HIDDEN | UiFlags::UIS_DISABLED) || !IsInsideRect(event, item->m_rect))
+	if (item->has_any_flag(UiFlags::ElementHidden | UiFlags::ElementDisabled) || !IsInsideRect(event, item->m_rect))
 		return false;
 	switch (item->m_type) {
 	case UiType::UI_ART_TEXT_BUTTON:

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -126,9 +126,9 @@ void UiInitScrollBar(UiScrollBar *uiSb, std::size_t viewportSize, const std::siz
 	ListViewportSize = viewportSize;
 	ListOffset = currentOffset;
 	if (ListViewportSize >= static_cast<std::size_t>(SelectedItemMax + 1)) {
-		uiSb->add_flag(UIS_HIDDEN);
+		uiSb->add_flag(UiFlags::UIS_HIDDEN);
 	} else {
-		uiSb->remove_flag(UIS_HIDDEN);
+		uiSb->remove_flag(UiFlags::UIS_HIDDEN);
 	}
 }
 
@@ -636,17 +636,17 @@ void UiAddBackground(std::vector<std::unique_ptr<UiItemBase>> *vecDialog)
 {
 	if (ArtBackgroundWidescreen.surface != nullptr) {
 		SDL_Rect rectw = { 0, UI_OFFSET_Y, 0, 0 };
-		vecDialog->push_back(std::make_unique<UiImage>(&ArtBackgroundWidescreen, /*bAnimated=*/false, /*iFrame=*/0, rectw, UIS_CENTER));
+		vecDialog->push_back(std::make_unique<UiImage>(&ArtBackgroundWidescreen, /*bAnimated=*/false, /*iFrame=*/0, rectw, UiFlags::UIS_CENTER));
 	}
 
 	SDL_Rect rect = { 0, UI_OFFSET_Y, 0, 0 };
-	vecDialog->push_back(std::make_unique<UiImage>(&ArtBackground, /*bAnimated=*/false, /*iFrame=*/0, rect, UIS_CENTER));
+	vecDialog->push_back(std::make_unique<UiImage>(&ArtBackground, /*bAnimated=*/false, /*iFrame=*/0, rect, UiFlags::UIS_CENTER));
 }
 
 void UiAddLogo(std::vector<std::unique_ptr<UiItemBase>> *vecDialog, int size, int y)
 {
 	SDL_Rect rect = { 0, (Sint16)(UI_OFFSET_Y + y), 0, 0 };
-	vecDialog->push_back(std::make_unique<UiImage>(&ArtLogos[size], /*bAnimated=*/true, /*iFrame=*/0, rect, UIS_CENTER));
+	vecDialog->push_back(std::make_unique<UiImage>(&ArtLogos[size], /*bAnimated=*/true, /*iFrame=*/0, rect, UiFlags::UIS_CENTER));
 }
 
 void UiFadeIn()
@@ -734,7 +734,7 @@ void Render(const UiArtText *uiArtText)
 void Render(const UiImage *uiImage)
 {
 	int x = uiImage->m_rect.x;
-	if ((uiImage->m_iFlags & UIS_CENTER) != 0 && uiImage->m_art != nullptr) {
+	if (HasAnyOf(uiImage->m_iFlags, UiFlags::UIS_CENTER) && uiImage->m_art != nullptr) {
 		const int xOffset = GetCenterOffset(uiImage->m_art->w(), uiImage->m_rect.w);
 		x += xOffset;
 	}
@@ -805,7 +805,7 @@ void Render(const UiEdit *uiEdit)
 
 void RenderItem(UiItemBase *item)
 {
-	if (item->has_flag(UIS_HIDDEN))
+	if (item->has_flag(UiFlags::UIS_HIDDEN))
 		return;
 	switch (item->m_type) {
 	case UI_TEXT:
@@ -911,7 +911,7 @@ bool HandleMouseEventScrollBar(const SDL_Event &event, const UiScrollBar *uiSb)
 
 bool HandleMouseEvent(const SDL_Event &event, UiItemBase *item)
 {
-	if (item->has_any_flag(UIS_HIDDEN | UIS_DISABLED) || !IsInsideRect(event, item->m_rect))
+	if (item->has_any_flag(UiFlags::UIS_HIDDEN | UiFlags::UIS_DISABLED) || !IsInsideRect(event, item->m_rect))
 		return false;
 	switch (item->m_type) {
 	case UI_ART_TEXT_BUTTON:

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -636,17 +636,17 @@ void UiAddBackground(std::vector<std::unique_ptr<UiItemBase>> *vecDialog)
 {
 	if (ArtBackgroundWidescreen.surface != nullptr) {
 		SDL_Rect rectw = { 0, UI_OFFSET_Y, 0, 0 };
-		vecDialog->push_back(std::make_unique<UiImage>(&ArtBackgroundWidescreen, /*bAnimated=*/false, /*iFrame=*/0, rectw, UiFlags::UIS_CENTER));
+		vecDialog->push_back(std::make_unique<UiImage>(&ArtBackgroundWidescreen, rectw, UiFlags::UIS_CENTER));
 	}
 
 	SDL_Rect rect = { 0, UI_OFFSET_Y, 0, 0 };
-	vecDialog->push_back(std::make_unique<UiImage>(&ArtBackground, /*bAnimated=*/false, /*iFrame=*/0, rect, UiFlags::UIS_CENTER));
+	vecDialog->push_back(std::make_unique<UiImage>(&ArtBackground, rect, UiFlags::UIS_CENTER));
 }
 
 void UiAddLogo(std::vector<std::unique_ptr<UiItemBase>> *vecDialog, int size, int y)
 {
 	SDL_Rect rect = { 0, (Sint16)(UI_OFFSET_Y + y), 0, 0 };
-	vecDialog->push_back(std::make_unique<UiImage>(&ArtLogos[size], /*bAnimated=*/true, /*iFrame=*/0, rect, UiFlags::UIS_CENTER));
+	vecDialog->push_back(std::make_unique<UiImage>(&ArtLogos[size], rect, UiFlags::UIS_CENTER, /*bAnimated=*/true));
 }
 
 void UiFadeIn()

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -102,7 +102,7 @@ void UiInitList(int count, void (*fnFocus)(int value), void (*fnSelect)(int valu
 #endif
 	textInputActive = false;
 	for (const auto &item : items) {
-		if (item->m_type == UiType::UI_EDIT) {
+		if (item->m_type == UiType::Edit) {
 			auto *pItemUIEdit = static_cast<UiEdit *>(item.get());
 			SDL_SetTextInputRect(&item->m_rect);
 			textInputActive = true;
@@ -121,7 +121,7 @@ void UiInitList(int count, void (*fnFocus)(int value), void (*fnSelect)(int valu
 	}
 }
 
-void UiInitScrollBar(UiScrollBar *uiSb, std::size_t viewportSize, const std::size_t *currentOffset)
+void UiInitScrollBar(UiScrollbar *uiSb, std::size_t viewportSize, const std::size_t *currentOffset)
 {
 	ListViewportSize = viewportSize;
 	ListOffset = currentOffset;
@@ -761,7 +761,7 @@ void Render(const UiList *uiList)
 	}
 }
 
-void Render(const UiScrollBar *uiSb)
+void Render(const UiScrollbar *uiSb)
 {
 	// Bar background (tiled):
 	{
@@ -808,28 +808,28 @@ void RenderItem(UiItemBase *item)
 	if (item->has_flag(UiFlags::ElementHidden))
 		return;
 	switch (item->m_type) {
-	case UiType::UI_TEXT:
+	case UiType::Text:
 		Render(static_cast<UiText *>(item));
 		break;
-	case UiType::UI_ART_TEXT:
+	case UiType::ArtText:
 		Render(static_cast<UiArtText *>(item));
 		break;
-	case UiType::UI_IMAGE:
+	case UiType::Image:
 		Render(static_cast<UiImage *>(item));
 		break;
-	case UiType::UI_ART_TEXT_BUTTON:
+	case UiType::ArtTextButton:
 		Render(static_cast<UiArtTextButton *>(item));
 		break;
-	case UiType::UI_BUTTON:
+	case UiType::Button:
 		RenderButton(static_cast<UiButton *>(item));
 		break;
-	case UiType::UI_LIST:
+	case UiType::List:
 		Render(static_cast<UiList *>(item));
 		break;
-	case UiType::UI_SCROLLBAR:
-		Render(static_cast<UiScrollBar *>(item));
+	case UiType::Scrollbar:
+		Render(static_cast<UiScrollbar *>(item));
 		break;
-	case UiType::UI_EDIT:
+	case UiType::Edit:
 		Render(static_cast<UiEdit *>(item));
 		break;
 	}
@@ -873,7 +873,7 @@ bool HandleMouseEventList(const SDL_Event &event, UiList *uiList)
 	return true;
 }
 
-bool HandleMouseEventScrollBar(const SDL_Event &event, const UiScrollBar *uiSb)
+bool HandleMouseEventScrollBar(const SDL_Event &event, const UiScrollbar *uiSb)
 {
 	if (event.button.button != SDL_BUTTON_LEFT)
 		return false;
@@ -914,14 +914,14 @@ bool HandleMouseEvent(const SDL_Event &event, UiItemBase *item)
 	if (item->has_any_flag(UiFlags::ElementHidden | UiFlags::ElementDisabled) || !IsInsideRect(event, item->m_rect))
 		return false;
 	switch (item->m_type) {
-	case UiType::UI_ART_TEXT_BUTTON:
+	case UiType::ArtTextButton:
 		return HandleMouseEventArtTextButton(event, static_cast<UiArtTextButton *>(item));
-	case UiType::UI_BUTTON:
+	case UiType::Button:
 		return HandleMouseEventButton(event, static_cast<UiButton *>(item));
-	case UiType::UI_LIST:
+	case UiType::List:
 		return HandleMouseEventList(event, static_cast<UiList *>(item));
-	case UiType::UI_SCROLLBAR:
-		return HandleMouseEventScrollBar(event, static_cast<UiScrollBar *>(item));
+	case UiType::Scrollbar:
+		return HandleMouseEventScrollBar(event, static_cast<UiScrollbar *>(item));
 	default:
 		return false;
 	}
@@ -970,7 +970,7 @@ bool UiItemMouseEvents(SDL_Event *event, const std::vector<UiItemBase *> &items)
 	if (event->type == SDL_MOUSEBUTTONUP && event->button.button == SDL_BUTTON_LEFT) {
 		scrollBarState.downArrowPressed = scrollBarState.upArrowPressed = false;
 		for (const auto &item : items) {
-			if (item->m_type == UiType::UI_BUTTON)
+			if (item->m_type == UiType::Button)
 				HandleGlobalMouseUpButton(static_cast<UiButton *>(item));
 		}
 	}
@@ -1000,7 +1000,7 @@ bool UiItemMouseEvents(SDL_Event *event, const std::vector<std::unique_ptr<UiIte
 	if (event->type == SDL_MOUSEBUTTONUP && event->button.button == SDL_BUTTON_LEFT) {
 		scrollBarState.downArrowPressed = scrollBarState.upArrowPressed = false;
 		for (const auto &item : items) {
-			if (item->m_type == UiType::UI_BUTTON)
+			if (item->m_type == UiType::Button)
 				HandleGlobalMouseUpButton(static_cast<UiButton *>(item.get()));
 		}
 	}

--- a/Source/DiabloUI/diabloui.h
+++ b/Source/DiabloUI/diabloui.h
@@ -120,7 +120,7 @@ void UiFocusNavigationSelect();
 void UiFocusNavigationEsc();
 void UiFocusNavigationYesNo();
 void UiInitList(int count, void (*fnFocus)(int value), void (*fnSelect)(int value), void (*fnEsc)(), const std::vector<std::unique_ptr<UiItemBase>> &items, bool wraps = false, bool (*fnYesNo)() = NULL);
-void UiInitScrollBar(UiScrollBar *uiSb, std::size_t viewportSize, const std::size_t *currentOffset);
+void UiInitScrollBar(UiScrollbar *uiSb, std::size_t viewportSize, const std::size_t *currentOffset);
 void UiClearScreen();
 void UiPollAndRender();
 void UiRenderItems(const std::vector<UiItemBase *> &items);

--- a/Source/DiabloUI/dialogs.cpp
+++ b/Source/DiabloUI/dialogs.cpp
@@ -176,7 +176,7 @@ void Init(const char *text, const char *caption, bool error, bool renderBehind)
 
 		SDL_Color color = { 255, 255, 0, 0 };
 		SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 147), (Sint16)(UI_OFFSET_Y + 110), 345, 20 };
-		vecOkDialog.push_back(std::make_unique<UiText>(text, color, rect2, UiFlags::UIS_CENTER));
+		vecOkDialog.push_back(std::make_unique<UiText>(text, rect2, UiFlags::UIS_CENTER, color));
 
 		SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 147), (Sint16)(UI_OFFSET_Y + 141), 345, 190 };
 		vecOkDialog.push_back(std::make_unique<UiText>(caption, rect3, UiFlags::UIS_CENTER));

--- a/Source/DiabloUI/dialogs.cpp
+++ b/Source/DiabloUI/dialogs.cpp
@@ -166,23 +166,23 @@ void Init(const char *text, const char *caption, bool error, bool renderBehind)
 		vecOkDialog.push_back(std::make_unique<UiImage>(&dialogArt, rect1));
 
 		SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 200), (Sint16)(UI_OFFSET_Y + 211), 240, 80 };
-		vecOkDialog.push_back(std::make_unique<UiText>(text, rect2, UIS_CENTER));
+		vecOkDialog.push_back(std::make_unique<UiText>(text, rect2, UiFlags::UIS_CENTER));
 
 		SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 265), (Sint16)(UI_OFFSET_Y + 265), SML_BUTTON_WIDTH, SML_BUTTON_HEIGHT };
-		vecOkDialog.push_back(std::make_unique<UiButton>(&SmlButton, _("OK"), &DialogActionOK, rect3, 0));
+		vecOkDialog.push_back(std::make_unique<UiButton>(&SmlButton, _("OK"), &DialogActionOK, rect3));
 	} else {
 		SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 127), (Sint16)(UI_OFFSET_Y + 100), 385, 280 };
 		vecOkDialog.push_back(std::make_unique<UiImage>(&dialogArt, rect1));
 
 		SDL_Color color = { 255, 255, 0, 0 };
 		SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 147), (Sint16)(UI_OFFSET_Y + 110), 345, 20 };
-		vecOkDialog.push_back(std::make_unique<UiText>(text, color, rect2, UIS_CENTER));
+		vecOkDialog.push_back(std::make_unique<UiText>(text, color, rect2, UiFlags::UIS_CENTER));
 
 		SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 147), (Sint16)(UI_OFFSET_Y + 141), 345, 190 };
-		vecOkDialog.push_back(std::make_unique<UiText>(caption, rect3, UIS_CENTER));
+		vecOkDialog.push_back(std::make_unique<UiText>(caption, rect3, UiFlags::UIS_CENTER));
 
 		SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 264), (Sint16)(UI_OFFSET_Y + 335), SML_BUTTON_WIDTH, SML_BUTTON_HEIGHT };
-		vecOkDialog.push_back(std::make_unique<UiButton>(&SmlButton, _("OK"), &DialogActionOK, rect4, 0));
+		vecOkDialog.push_back(std::make_unique<UiButton>(&SmlButton, _("OK"), &DialogActionOK, rect4));
 	}
 
 	if (!renderBehind) {

--- a/Source/DiabloUI/dialogs.cpp
+++ b/Source/DiabloUI/dialogs.cpp
@@ -166,7 +166,7 @@ void Init(const char *text, const char *caption, bool error, bool renderBehind)
 		vecOkDialog.push_back(std::make_unique<UiImage>(&dialogArt, rect1));
 
 		SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 200), (Sint16)(UI_OFFSET_Y + 211), 240, 80 };
-		vecOkDialog.push_back(std::make_unique<UiText>(text, rect2, UiFlags::UIS_CENTER));
+		vecOkDialog.push_back(std::make_unique<UiText>(text, rect2, UiFlags::AlignCenter));
 
 		SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 265), (Sint16)(UI_OFFSET_Y + 265), SML_BUTTON_WIDTH, SML_BUTTON_HEIGHT };
 		vecOkDialog.push_back(std::make_unique<UiButton>(&SmlButton, _("OK"), &DialogActionOK, rect3));
@@ -176,10 +176,10 @@ void Init(const char *text, const char *caption, bool error, bool renderBehind)
 
 		SDL_Color color = { 255, 255, 0, 0 };
 		SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 147), (Sint16)(UI_OFFSET_Y + 110), 345, 20 };
-		vecOkDialog.push_back(std::make_unique<UiText>(text, rect2, UiFlags::UIS_CENTER, color));
+		vecOkDialog.push_back(std::make_unique<UiText>(text, rect2, UiFlags::AlignCenter, color));
 
 		SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 147), (Sint16)(UI_OFFSET_Y + 141), 345, 190 };
-		vecOkDialog.push_back(std::make_unique<UiText>(caption, rect3, UiFlags::UIS_CENTER));
+		vecOkDialog.push_back(std::make_unique<UiText>(caption, rect3, UiFlags::AlignCenter));
 
 		SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 264), (Sint16)(UI_OFFSET_Y + 335), SML_BUTTON_WIDTH, SML_BUTTON_HEIGHT };
 		vecOkDialog.push_back(std::make_unique<UiButton>(&SmlButton, _("OK"), &DialogActionOK, rect4));

--- a/Source/DiabloUI/mainmenu.cpp
+++ b/Source/DiabloUI/mainmenu.cpp
@@ -56,10 +56,10 @@ void MainmenuLoad(const char *name, void (*fnSound)(const char *file))
 	UiAddBackground(&vecMainMenuDialog);
 	UiAddLogo(&vecMainMenuDialog);
 
-	vecMainMenuDialog.push_back(std::make_unique<UiList>(vecMenuItems, PANEL_LEFT + 64, (UI_OFFSET_Y + 192), 510, 43, UIS_HUGE | UIS_GOLD | UIS_CENTER));
+	vecMainMenuDialog.push_back(std::make_unique<UiList>(vecMenuItems, PANEL_LEFT + 64, (UI_OFFSET_Y + 192), 510, 43, UiFlags::UIS_HUGE | UiFlags::UIS_GOLD | UiFlags::UIS_CENTER));
 
 	SDL_Rect rect = { 17, (Sint16)(gnScreenHeight - 36), 605, 21 };
-	vecMainMenuDialog.push_back(std::make_unique<UiArtText>(name, rect, UIS_SMALL));
+	vecMainMenuDialog.push_back(std::make_unique<UiArtText>(name, rect, UiFlags::UIS_SMALL));
 
 	UiInitList(vecMenuItems.size(), nullptr, UiMainMenuSelect, MainmenuEsc, vecMainMenuDialog, true);
 }

--- a/Source/DiabloUI/mainmenu.cpp
+++ b/Source/DiabloUI/mainmenu.cpp
@@ -56,10 +56,10 @@ void MainmenuLoad(const char *name, void (*fnSound)(const char *file))
 	UiAddBackground(&vecMainMenuDialog);
 	UiAddLogo(&vecMainMenuDialog);
 
-	vecMainMenuDialog.push_back(std::make_unique<UiList>(vecMenuItems, PANEL_LEFT + 64, (UI_OFFSET_Y + 192), 510, 43, UiFlags::UIS_HUGE | UiFlags::UIS_GOLD | UiFlags::UIS_CENTER));
+	vecMainMenuDialog.push_back(std::make_unique<UiList>(vecMenuItems, PANEL_LEFT + 64, (UI_OFFSET_Y + 192), 510, 43, UiFlags::FontHuge | UiFlags::ColorGold | UiFlags::AlignCenter));
 
 	SDL_Rect rect = { 17, (Sint16)(gnScreenHeight - 36), 605, 21 };
-	vecMainMenuDialog.push_back(std::make_unique<UiArtText>(name, rect, UiFlags::UIS_SMALL));
+	vecMainMenuDialog.push_back(std::make_unique<UiArtText>(name, rect, UiFlags::FontSmall));
 
 	UiInitList(vecMenuItems.size(), nullptr, UiMainMenuSelect, MainmenuEsc, vecMainMenuDialog, true);
 }

--- a/Source/DiabloUI/progress.cpp
+++ b/Source/DiabloUI/progress.cpp
@@ -44,7 +44,7 @@ void ProgressLoad(const char *msg)
 		msgShadow = TTF_RenderText_Solid(font, msg, black);
 	}
 	SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 265), (Sint16)(UI_OFFSET_Y + 267), SML_BUTTON_WIDTH, SML_BUTTON_HEIGHT };
-	vecProgress.push_back(std::make_unique<UiButton>(&SmlButton, _("Cancel"), &DialogActionCancel, rect3, 0));
+	vecProgress.push_back(std::make_unique<UiButton>(&SmlButton, _("Cancel"), &DialogActionCancel, rect3));
 }
 
 void ProgressFree()

--- a/Source/DiabloUI/scrollbar.h
+++ b/Source/DiabloUI/scrollbar.h
@@ -23,7 +23,7 @@ enum ScrollBarArrowFrame : uint8_t {
 extern Art ArtScrollBarThumb;
 const Uint16 SCROLLBAR_ARROW_WIDTH = 25;
 
-inline SDL_Rect UpArrowRect(const UiScrollBar *sb)
+inline SDL_Rect UpArrowRect(const UiScrollbar *sb)
 {
 	SDL_Rect Tmp;
 	Tmp.x = sb->m_rect.x;
@@ -34,7 +34,7 @@ inline SDL_Rect UpArrowRect(const UiScrollBar *sb)
 	return Tmp;
 }
 
-inline SDL_Rect DownArrowRect(const UiScrollBar *sb)
+inline SDL_Rect DownArrowRect(const UiScrollbar *sb)
 {
 	SDL_Rect Tmp;
 	Tmp.x = sb->m_rect.x;
@@ -45,12 +45,12 @@ inline SDL_Rect DownArrowRect(const UiScrollBar *sb)
 	return Tmp;
 }
 
-inline Uint16 BarHeight(const UiScrollBar *sb)
+inline Uint16 BarHeight(const UiScrollbar *sb)
 {
 	return sb->m_rect.h - 2 * sb->m_arrow->h();
 }
 
-inline SDL_Rect BarRect(const UiScrollBar *sb)
+inline SDL_Rect BarRect(const UiScrollbar *sb)
 {
 	SDL_Rect Tmp;
 	Tmp.x = sb->m_rect.x;
@@ -61,7 +61,7 @@ inline SDL_Rect BarRect(const UiScrollBar *sb)
 	return Tmp;
 }
 
-inline SDL_Rect ThumbRect(const UiScrollBar *sb, std::size_t selected_index, std::size_t num_items)
+inline SDL_Rect ThumbRect(const UiScrollbar *sb, std::size_t selected_index, std::size_t num_items)
 {
 	const int THUMB_OFFSET_X = 3;
 	const int thumb_max_y = BarHeight(sb) - sb->m_thumb->h();

--- a/Source/DiabloUI/selconn.cpp
+++ b/Source/DiabloUI/selconn.cpp
@@ -45,7 +45,7 @@ void SelconnLoad()
 	UiAddLogo(&vecSelConnDlg);
 
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-	vecSelConnDlg.push_back(std::make_unique<UiArtText>(_("Multi Player Game"), rect1, UIS_CENTER | UIS_BIG));
+	vecSelConnDlg.push_back(std::make_unique<UiArtText>(_("Multi Player Game"), rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 35), (Sint16)(UI_OFFSET_Y + 218), DESCRIPTION_WIDTH, 21 };
 	vecSelConnDlg.push_back(std::make_unique<UiArtText>(selconn_MaxPlayers, rect2));
@@ -57,24 +57,24 @@ void SelconnLoad()
 	vecSelConnDlg.push_back(std::make_unique<UiArtText>(selconn_Description, rect4));
 
 	SDL_Rect rect5 = { (Sint16)(PANEL_LEFT + 30), (Sint16)(UI_OFFSET_Y + 356), 220, 31 };
-	vecSelConnDlg.push_back(std::make_unique<UiArtText>(_("no gateway needed"), rect5, UIS_CENTER | UIS_MED));
+	vecSelConnDlg.push_back(std::make_unique<UiArtText>(_("no gateway needed"), rect5, UiFlags::UIS_CENTER | UiFlags::UIS_MED));
 
 	SDL_Rect rect6 = { (Sint16)(PANEL_LEFT + 35), (Sint16)(UI_OFFSET_Y + 393), DESCRIPTION_WIDTH, 21 };
-	vecSelConnDlg.push_back(std::make_unique<UiArtText>(selconn_Gateway, rect6, UIS_CENTER));
+	vecSelConnDlg.push_back(std::make_unique<UiArtText>(selconn_Gateway, rect6, UiFlags::UIS_CENTER));
 
 	SDL_Rect rect7 = { (Sint16)(PANEL_LEFT + 300), (Sint16)(UI_OFFSET_Y + 211), 295, 33 };
-	vecSelConnDlg.push_back(std::make_unique<UiArtText>(_("Select Connection"), rect7, UIS_CENTER | UIS_BIG));
+	vecSelConnDlg.push_back(std::make_unique<UiArtText>(_("Select Connection"), rect7, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 	SDL_Rect rect8 = { (Sint16)(PANEL_LEFT + 16), (Sint16)(UI_OFFSET_Y + 427), 250, 35 };
-	vecSelConnDlg.push_back(std::make_unique<UiArtTextButton>(_("Change Gateway"), nullptr, rect8, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD | UIS_HIDDEN));
+	vecSelConnDlg.push_back(std::make_unique<UiArtTextButton>(_("Change Gateway"), nullptr, rect8, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD | UiFlags::UIS_HIDDEN));
 
-	vecSelConnDlg.push_back(std::make_unique<UiList>(vecConnItems, PANEL_LEFT + 305, (UI_OFFSET_Y + 256), 285, 26, UIS_CENTER | UIS_VCENTER | UIS_GOLD));
+	vecSelConnDlg.push_back(std::make_unique<UiList>(vecConnItems, PANEL_LEFT + 305, (UI_OFFSET_Y + 256), 285, 26, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_GOLD));
 
 	SDL_Rect rect9 = { (Sint16)(PANEL_LEFT + 299), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-	vecSelConnDlg.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect9, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD));
+	vecSelConnDlg.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect9, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 	SDL_Rect rect10 = { (Sint16)(PANEL_LEFT + 454), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-	vecSelConnDlg.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect10, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD));
+	vecSelConnDlg.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect10, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 	UiInitList(vecConnItems.size(), SelconnFocus, SelconnSelect, SelconnEsc, vecSelConnDlg);
 }

--- a/Source/DiabloUI/selconn.cpp
+++ b/Source/DiabloUI/selconn.cpp
@@ -45,7 +45,7 @@ void SelconnLoad()
 	UiAddLogo(&vecSelConnDlg);
 
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-	vecSelConnDlg.push_back(std::make_unique<UiArtText>(_("Multi Player Game"), rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+	vecSelConnDlg.push_back(std::make_unique<UiArtText>(_("Multi Player Game"), rect1, UiFlags::AlignCenter | UiFlags::FontBig));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 35), (Sint16)(UI_OFFSET_Y + 218), DESCRIPTION_WIDTH, 21 };
 	vecSelConnDlg.push_back(std::make_unique<UiArtText>(selconn_MaxPlayers, rect2));
@@ -57,24 +57,24 @@ void SelconnLoad()
 	vecSelConnDlg.push_back(std::make_unique<UiArtText>(selconn_Description, rect4));
 
 	SDL_Rect rect5 = { (Sint16)(PANEL_LEFT + 30), (Sint16)(UI_OFFSET_Y + 356), 220, 31 };
-	vecSelConnDlg.push_back(std::make_unique<UiArtText>(_("no gateway needed"), rect5, UiFlags::UIS_CENTER | UiFlags::UIS_MED));
+	vecSelConnDlg.push_back(std::make_unique<UiArtText>(_("no gateway needed"), rect5, UiFlags::AlignCenter | UiFlags::FontMedium));
 
 	SDL_Rect rect6 = { (Sint16)(PANEL_LEFT + 35), (Sint16)(UI_OFFSET_Y + 393), DESCRIPTION_WIDTH, 21 };
-	vecSelConnDlg.push_back(std::make_unique<UiArtText>(selconn_Gateway, rect6, UiFlags::UIS_CENTER));
+	vecSelConnDlg.push_back(std::make_unique<UiArtText>(selconn_Gateway, rect6, UiFlags::AlignCenter));
 
 	SDL_Rect rect7 = { (Sint16)(PANEL_LEFT + 300), (Sint16)(UI_OFFSET_Y + 211), 295, 33 };
-	vecSelConnDlg.push_back(std::make_unique<UiArtText>(_("Select Connection"), rect7, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+	vecSelConnDlg.push_back(std::make_unique<UiArtText>(_("Select Connection"), rect7, UiFlags::AlignCenter | UiFlags::FontBig));
 
 	SDL_Rect rect8 = { (Sint16)(PANEL_LEFT + 16), (Sint16)(UI_OFFSET_Y + 427), 250, 35 };
-	vecSelConnDlg.push_back(std::make_unique<UiArtTextButton>(_("Change Gateway"), nullptr, rect8, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD | UiFlags::UIS_HIDDEN));
+	vecSelConnDlg.push_back(std::make_unique<UiArtTextButton>(_("Change Gateway"), nullptr, rect8, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontBig | UiFlags::ColorGold | UiFlags::ElementHidden));
 
-	vecSelConnDlg.push_back(std::make_unique<UiList>(vecConnItems, PANEL_LEFT + 305, (UI_OFFSET_Y + 256), 285, 26, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_GOLD));
+	vecSelConnDlg.push_back(std::make_unique<UiList>(vecConnItems, PANEL_LEFT + 305, (UI_OFFSET_Y + 256), 285, 26, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::ColorGold));
 
 	SDL_Rect rect9 = { (Sint16)(PANEL_LEFT + 299), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-	vecSelConnDlg.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect9, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+	vecSelConnDlg.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect9, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 	SDL_Rect rect10 = { (Sint16)(PANEL_LEFT + 454), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-	vecSelConnDlg.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect10, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+	vecSelConnDlg.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect10, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 	UiInitList(vecConnItems.size(), SelconnFocus, SelconnSelect, SelconnEsc, vecSelConnDlg);
 }

--- a/Source/DiabloUI/selgame.cpp
+++ b/Source/DiabloUI/selgame.cpp
@@ -75,27 +75,27 @@ void selgame_GameSelection_Init()
 	UiAddLogo(&vecSelGameDialog);
 
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Client-Server (TCP)"), rect1, UIS_CENTER | UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Client-Server (TCP)"), rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 35), (Sint16)(UI_OFFSET_Y + 211), 205, 192 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Description:"), rect2, UIS_MED));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Description:"), rect2, UiFlags::UIS_MED));
 
 	SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 35), (Sint16)(UI_OFFSET_Y + 256), DESCRIPTION_WIDTH, 192 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Description, rect3));
 
 	SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 300), (Sint16)(UI_OFFSET_Y + 211), 295, 33 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Select Action"), rect4, UIS_CENTER | UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Select Action"), rect4, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 	vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Create Game"), 0));
 	vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Join Game"), 1));
 
-	vecSelGameDialog.push_back(std::make_unique<UiList>(vecSelGameDlgItems, PANEL_LEFT + 305, (UI_OFFSET_Y + 255), 285, 26, UIS_CENTER | UIS_MED | UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiList>(vecSelGameDlgItems, PANEL_LEFT + 305, (UI_OFFSET_Y + 255), 285, 26, UiFlags::UIS_CENTER | UiFlags::UIS_MED | UiFlags::UIS_GOLD));
 
 	SDL_Rect rect5 = { (Sint16)(PANEL_LEFT + 299), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect5, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect5, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 	SDL_Rect rect6 = { (Sint16)(PANEL_LEFT + 449), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect6, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect6, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 	UiInitList(vecSelGameDlgItems.size(), selgame_GameSelection_Focus, selgame_GameSelection_Select, selgame_GameSelection_Esc, vecSelGameDialog);
 }
@@ -139,10 +139,10 @@ void selgame_GameSelection_Select(int value)
 	UiAddLogo(&vecSelGameDialog);
 
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(&title, rect1, UIS_CENTER | UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(&title, rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 34), (Sint16)(UI_OFFSET_Y + 211), 205, 33 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Label, rect2, UIS_CENTER | UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Label, rect2, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 	SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 35), (Sint16)(UI_OFFSET_Y + 256), DESCRIPTION_WIDTH, 192 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Description, rect3));
@@ -152,19 +152,19 @@ void selgame_GameSelection_Select(int value)
 		title = _("Create Game");
 
 		SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 299), (Sint16)(UI_OFFSET_Y + 211), 295, 35 };
-		vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Select Difficulty"), rect4, UIS_CENTER | UIS_BIG));
+		vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Select Difficulty"), rect4, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 		vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Normal"), DIFF_NORMAL));
 		vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Nightmare"), DIFF_NIGHTMARE));
 		vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Hell"), DIFF_HELL));
 
-		vecSelGameDialog.push_back(std::make_unique<UiList>(vecSelGameDlgItems, PANEL_LEFT + 300, (UI_OFFSET_Y + 282), 295, 26, UIS_CENTER | UIS_MED | UIS_GOLD));
+		vecSelGameDialog.push_back(std::make_unique<UiList>(vecSelGameDlgItems, PANEL_LEFT + 300, (UI_OFFSET_Y + 282), 295, 26, UiFlags::UIS_CENTER | UiFlags::UIS_MED | UiFlags::UIS_GOLD));
 
 		SDL_Rect rect5 = { (Sint16)(PANEL_LEFT + 299), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect5, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD));
+		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect5, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 		SDL_Rect rect6 = { (Sint16)(PANEL_LEFT + 449), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect6, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD));
+		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect6, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 		UiInitList(vecSelGameDlgItems.size(), selgame_Diff_Focus, selgame_Diff_Select, selgame_Diff_Esc, vecSelGameDialog, true);
 		break;
@@ -173,16 +173,16 @@ void selgame_GameSelection_Select(int value)
 		title = _("Join TCP Games");
 
 		SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 305), (Sint16)(UI_OFFSET_Y + 211), 285, 33 };
-		vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Enter address"), rect4, UIS_CENTER | UIS_BIG));
+		vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Enter address"), rect4, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 		SDL_Rect rect5 = { (Sint16)(PANEL_LEFT + 305), (Sint16)(UI_OFFSET_Y + 314), 285, 33 };
-		vecSelGameDialog.push_back(std::make_unique<UiEdit>(_("Enter address"), selgame_Ip, 128, rect5, UIS_MED | UIS_GOLD));
+		vecSelGameDialog.push_back(std::make_unique<UiEdit>(_("Enter address"), selgame_Ip, 128, rect5, UiFlags::UIS_MED | UiFlags::UIS_GOLD));
 
 		SDL_Rect rect6 = { (Sint16)(PANEL_LEFT + 299), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect6, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD));
+		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect6, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 		SDL_Rect rect7 = { (Sint16)(PANEL_LEFT + 449), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect7, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD));
+		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect7, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 		UiInitList(0, nullptr, selgame_Password_Init, selgame_GameSelection_Init, vecSelGameDialog);
 		break;
@@ -293,29 +293,29 @@ void selgame_GameSpeedSelection()
 	UiAddLogo(&vecSelGameDialog);
 
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Create Game"), rect1, UIS_CENTER | UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Create Game"), rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 34), (Sint16)(UI_OFFSET_Y + 211), 205, 33 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Label, rect2, UIS_CENTER | UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Label, rect2, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 	SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 35), (Sint16)(UI_OFFSET_Y + 256), DESCRIPTION_WIDTH, 192 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Description, rect3));
 
 	SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 299), (Sint16)(UI_OFFSET_Y + 211), 295, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Select Game Speed"), rect4, UIS_CENTER | UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Select Game Speed"), rect4, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 	vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Normal"), 20));
 	vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Fast"), 30));
 	vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Faster"), 40));
 	vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Fastest"), 50));
 
-	vecSelGameDialog.push_back(std::make_unique<UiList>(vecSelGameDlgItems, PANEL_LEFT + 300, (UI_OFFSET_Y + 279), 295, 26, UIS_CENTER | UIS_MED | UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiList>(vecSelGameDlgItems, PANEL_LEFT + 300, (UI_OFFSET_Y + 279), 295, 26, UiFlags::UIS_CENTER | UiFlags::UIS_MED | UiFlags::UIS_GOLD));
 
 	SDL_Rect rect5 = { (Sint16)(PANEL_LEFT + 299), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect5, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect5, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 	SDL_Rect rect6 = { (Sint16)(PANEL_LEFT + 449), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect6, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect6, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 	UiInitList(vecSelGameDlgItems.size(), selgame_Speed_Focus, selgame_Speed_Select, selgame_Speed_Esc, vecSelGameDialog, true);
 }
@@ -370,25 +370,25 @@ void selgame_Password_Init(int /*value*/)
 	UiAddLogo(&vecSelGameDialog);
 
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Client-Server (TCP)"), rect1, UIS_CENTER | UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Client-Server (TCP)"), rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 35), (Sint16)(UI_OFFSET_Y + 211), 205, 192 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Description:"), rect2, UIS_MED));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Description:"), rect2, UiFlags::UIS_MED));
 
 	SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 35), (Sint16)(UI_OFFSET_Y + 256), DESCRIPTION_WIDTH, 192 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Description, rect3));
 
 	SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 305), (Sint16)(UI_OFFSET_Y + 211), 285, 33 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Enter Password"), rect4, UIS_CENTER | UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Enter Password"), rect4, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 	SDL_Rect rect5 = { (Sint16)(PANEL_LEFT + 305), (Sint16)(UI_OFFSET_Y + 314), 285, 33 };
-	vecSelGameDialog.push_back(std::make_unique<UiEdit>(_("Enter Password"), selgame_Password, 15, rect5, UIS_MED | UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiEdit>(_("Enter Password"), selgame_Password, 15, rect5, UiFlags::UIS_MED | UiFlags::UIS_GOLD));
 
 	SDL_Rect rect6 = { (Sint16)(PANEL_LEFT + 299), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect6, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect6, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 	SDL_Rect rect7 = { (Sint16)(PANEL_LEFT + 449), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect7, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect7, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 	UiInitList(0, nullptr, selgame_Password_Select, selgame_Password_Esc, vecSelGameDialog);
 }

--- a/Source/DiabloUI/selgame.cpp
+++ b/Source/DiabloUI/selgame.cpp
@@ -75,27 +75,27 @@ void selgame_GameSelection_Init()
 	UiAddLogo(&vecSelGameDialog);
 
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Client-Server (TCP)"), rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Client-Server (TCP)"), rect1, UiFlags::AlignCenter | UiFlags::FontBig));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 35), (Sint16)(UI_OFFSET_Y + 211), 205, 192 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Description:"), rect2, UiFlags::UIS_MED));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Description:"), rect2, UiFlags::FontMedium));
 
 	SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 35), (Sint16)(UI_OFFSET_Y + 256), DESCRIPTION_WIDTH, 192 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Description, rect3));
 
 	SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 300), (Sint16)(UI_OFFSET_Y + 211), 295, 33 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Select Action"), rect4, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Select Action"), rect4, UiFlags::AlignCenter | UiFlags::FontBig));
 
 	vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Create Game"), 0));
 	vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Join Game"), 1));
 
-	vecSelGameDialog.push_back(std::make_unique<UiList>(vecSelGameDlgItems, PANEL_LEFT + 305, (UI_OFFSET_Y + 255), 285, 26, UiFlags::UIS_CENTER | UiFlags::UIS_MED | UiFlags::UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiList>(vecSelGameDlgItems, PANEL_LEFT + 305, (UI_OFFSET_Y + 255), 285, 26, UiFlags::AlignCenter | UiFlags::FontMedium | UiFlags::ColorGold));
 
 	SDL_Rect rect5 = { (Sint16)(PANEL_LEFT + 299), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect5, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect5, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 	SDL_Rect rect6 = { (Sint16)(PANEL_LEFT + 449), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect6, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect6, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 	UiInitList(vecSelGameDlgItems.size(), selgame_GameSelection_Focus, selgame_GameSelection_Select, selgame_GameSelection_Esc, vecSelGameDialog);
 }
@@ -139,10 +139,10 @@ void selgame_GameSelection_Select(int value)
 	UiAddLogo(&vecSelGameDialog);
 
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(&title, rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(&title, rect1, UiFlags::AlignCenter | UiFlags::FontBig));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 34), (Sint16)(UI_OFFSET_Y + 211), 205, 33 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Label, rect2, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Label, rect2, UiFlags::AlignCenter | UiFlags::FontBig));
 
 	SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 35), (Sint16)(UI_OFFSET_Y + 256), DESCRIPTION_WIDTH, 192 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Description, rect3));
@@ -152,19 +152,19 @@ void selgame_GameSelection_Select(int value)
 		title = _("Create Game");
 
 		SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 299), (Sint16)(UI_OFFSET_Y + 211), 295, 35 };
-		vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Select Difficulty"), rect4, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+		vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Select Difficulty"), rect4, UiFlags::AlignCenter | UiFlags::FontBig));
 
 		vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Normal"), DIFF_NORMAL));
 		vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Nightmare"), DIFF_NIGHTMARE));
 		vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Hell"), DIFF_HELL));
 
-		vecSelGameDialog.push_back(std::make_unique<UiList>(vecSelGameDlgItems, PANEL_LEFT + 300, (UI_OFFSET_Y + 282), 295, 26, UiFlags::UIS_CENTER | UiFlags::UIS_MED | UiFlags::UIS_GOLD));
+		vecSelGameDialog.push_back(std::make_unique<UiList>(vecSelGameDlgItems, PANEL_LEFT + 300, (UI_OFFSET_Y + 282), 295, 26, UiFlags::AlignCenter | UiFlags::FontMedium | UiFlags::ColorGold));
 
 		SDL_Rect rect5 = { (Sint16)(PANEL_LEFT + 299), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect5, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect5, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 		SDL_Rect rect6 = { (Sint16)(PANEL_LEFT + 449), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect6, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect6, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 		UiInitList(vecSelGameDlgItems.size(), selgame_Diff_Focus, selgame_Diff_Select, selgame_Diff_Esc, vecSelGameDialog, true);
 		break;
@@ -173,16 +173,16 @@ void selgame_GameSelection_Select(int value)
 		title = _("Join TCP Games");
 
 		SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 305), (Sint16)(UI_OFFSET_Y + 211), 285, 33 };
-		vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Enter address"), rect4, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+		vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Enter address"), rect4, UiFlags::AlignCenter | UiFlags::FontBig));
 
 		SDL_Rect rect5 = { (Sint16)(PANEL_LEFT + 305), (Sint16)(UI_OFFSET_Y + 314), 285, 33 };
-		vecSelGameDialog.push_back(std::make_unique<UiEdit>(_("Enter address"), selgame_Ip, 128, rect5, UiFlags::UIS_MED | UiFlags::UIS_GOLD));
+		vecSelGameDialog.push_back(std::make_unique<UiEdit>(_("Enter address"), selgame_Ip, 128, rect5, UiFlags::FontMedium | UiFlags::ColorGold));
 
 		SDL_Rect rect6 = { (Sint16)(PANEL_LEFT + 299), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect6, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect6, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 		SDL_Rect rect7 = { (Sint16)(PANEL_LEFT + 449), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect7, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect7, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 		UiInitList(0, nullptr, selgame_Password_Init, selgame_GameSelection_Init, vecSelGameDialog);
 		break;
@@ -293,29 +293,29 @@ void selgame_GameSpeedSelection()
 	UiAddLogo(&vecSelGameDialog);
 
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Create Game"), rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Create Game"), rect1, UiFlags::AlignCenter | UiFlags::FontBig));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 34), (Sint16)(UI_OFFSET_Y + 211), 205, 33 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Label, rect2, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Label, rect2, UiFlags::AlignCenter | UiFlags::FontBig));
 
 	SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 35), (Sint16)(UI_OFFSET_Y + 256), DESCRIPTION_WIDTH, 192 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Description, rect3));
 
 	SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 299), (Sint16)(UI_OFFSET_Y + 211), 295, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Select Game Speed"), rect4, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Select Game Speed"), rect4, UiFlags::AlignCenter | UiFlags::FontBig));
 
 	vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Normal"), 20));
 	vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Fast"), 30));
 	vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Faster"), 40));
 	vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Fastest"), 50));
 
-	vecSelGameDialog.push_back(std::make_unique<UiList>(vecSelGameDlgItems, PANEL_LEFT + 300, (UI_OFFSET_Y + 279), 295, 26, UiFlags::UIS_CENTER | UiFlags::UIS_MED | UiFlags::UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiList>(vecSelGameDlgItems, PANEL_LEFT + 300, (UI_OFFSET_Y + 279), 295, 26, UiFlags::AlignCenter | UiFlags::FontMedium | UiFlags::ColorGold));
 
 	SDL_Rect rect5 = { (Sint16)(PANEL_LEFT + 299), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect5, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect5, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 	SDL_Rect rect6 = { (Sint16)(PANEL_LEFT + 449), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect6, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect6, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 	UiInitList(vecSelGameDlgItems.size(), selgame_Speed_Focus, selgame_Speed_Select, selgame_Speed_Esc, vecSelGameDialog, true);
 }
@@ -370,25 +370,25 @@ void selgame_Password_Init(int /*value*/)
 	UiAddLogo(&vecSelGameDialog);
 
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Client-Server (TCP)"), rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Client-Server (TCP)"), rect1, UiFlags::AlignCenter | UiFlags::FontBig));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 35), (Sint16)(UI_OFFSET_Y + 211), 205, 192 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Description:"), rect2, UiFlags::UIS_MED));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Description:"), rect2, UiFlags::FontMedium));
 
 	SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 35), (Sint16)(UI_OFFSET_Y + 256), DESCRIPTION_WIDTH, 192 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Description, rect3));
 
 	SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 305), (Sint16)(UI_OFFSET_Y + 211), 285, 33 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Enter Password"), rect4, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Enter Password"), rect4, UiFlags::AlignCenter | UiFlags::FontBig));
 
 	SDL_Rect rect5 = { (Sint16)(PANEL_LEFT + 305), (Sint16)(UI_OFFSET_Y + 314), 285, 33 };
-	vecSelGameDialog.push_back(std::make_unique<UiEdit>(_("Enter Password"), selgame_Password, 15, rect5, UiFlags::UIS_MED | UiFlags::UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiEdit>(_("Enter Password"), selgame_Password, 15, rect5, UiFlags::FontMedium | UiFlags::ColorGold));
 
 	SDL_Rect rect6 = { (Sint16)(PANEL_LEFT + 299), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect6, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect6, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 	SDL_Rect rect7 = { (Sint16)(PANEL_LEFT + 449), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect7, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect7, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 	UiInitList(0, nullptr, selgame_Password_Select, selgame_Password_Esc, vecSelGameDialog);
 }

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -515,7 +515,7 @@ void selhero_List_Init()
 	vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, PANEL_LEFT + 265, (UI_OFFSET_Y + 256), 320, 26, UiFlags::AlignCenter | UiFlags::FontMedium | UiFlags::ColorGold));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 585), (Sint16)(UI_OFFSET_Y + 244), 25, 178 };
-	auto pinnedScrollBar = std::make_unique<UiScrollBar>(&ArtScrollBarBackground, &ArtScrollBarThumb, &ArtScrollBarArrow, rect2);
+	auto pinnedScrollBar = std::make_unique<UiScrollbar>(&ArtScrollBarBackground, &ArtScrollBarThumb, &ArtScrollBarArrow, rect2);
 	auto *scrollBar = pinnedScrollBar.get();
 	vecSelDlgItems.push_back(std::move(pinnedScrollBar));
 

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -127,11 +127,11 @@ void SelheroListFocus(int value)
 {
 	const auto index = static_cast<std::size_t>(value);
 	SelheroScrollIntoView(index);
-	int baseFlags = UIS_CENTER | UIS_BIG;
+	UiFlags baseFlags = UiFlags::UIS_CENTER | UiFlags::UIS_BIG;
 	if (selhero_SaveCount != 0 && index < selhero_SaveCount) {
 		memcpy(&selhero_heroInfo, &selhero_heros[index], sizeof(selhero_heroInfo));
 		SelheroSetStats();
-		SELLIST_DIALOG_DELETE_BUTTON->m_iFlags = baseFlags | UIS_GOLD;
+		SELLIST_DIALOG_DELETE_BUTTON->m_iFlags = baseFlags | UiFlags::UIS_GOLD;
 		selhero_deleteEnabled = true;
 		return;
 	}
@@ -143,7 +143,7 @@ void SelheroListFocus(int value)
 	strncpy(textStats[3], "--", sizeof(textStats[3]) - 1);
 	strncpy(textStats[4], "--", sizeof(textStats[4]) - 1);
 	strncpy(textStats[5], "--", sizeof(textStats[5]) - 1);
-	SELLIST_DIALOG_DELETE_BUTTON->m_iFlags = baseFlags | UIS_DISABLED;
+	SELLIST_DIALOG_DELETE_BUTTON->m_iFlags = baseFlags | UiFlags::UIS_DISABLED;
 	selhero_deleteEnabled = false;
 }
 
@@ -160,7 +160,7 @@ void SelheroListSelect(int value)
 		vecSelDlgItems.clear();
 
 		SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 264), (Sint16)(UI_OFFSET_Y + 211), 320, 33 };
-		vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Choose Class"), rect1, UIS_CENTER | UIS_BIG));
+		vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Choose Class"), rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 		vecSelHeroDlgItems.clear();
 		int itemH = 33;
@@ -179,13 +179,13 @@ void SelheroListSelect(int value)
 		if (vecSelHeroDlgItems.size() > 4)
 			itemH = 26;
 		int itemY = 246 + (176 - vecSelHeroDlgItems.size() * itemH) / 2;
-		vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, PANEL_LEFT + 264, (UI_OFFSET_Y + itemY), 320, itemH, UIS_CENTER | UIS_MED | UIS_GOLD));
+		vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, PANEL_LEFT + 264, (UI_OFFSET_Y + itemY), 320, itemH, UiFlags::UIS_CENTER | UiFlags::UIS_MED | UiFlags::UIS_GOLD));
 
 		SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 279), (Sint16)(UI_OFFSET_Y + 429), 140, 35 };
-		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect2, UIS_CENTER | UIS_BIG | UIS_GOLD));
+		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect2, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 		SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 429), (Sint16)(UI_OFFSET_Y + 429), 140, 35 };
-		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect3, UIS_CENTER | UIS_BIG | UIS_GOLD));
+		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect3, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 		UiInitList(vecSelHeroDlgItems.size(), SelheroClassSelectorFocus, SelheroClassSelectorSelect, SelheroClassSelectorEsc, vecSelDlgItems);
 		memset(&selhero_heroInfo.name, 0, sizeof(selhero_heroInfo.name));
@@ -198,18 +198,18 @@ void SelheroListSelect(int value)
 		vecSelDlgItems.clear();
 
 		SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 264), (Sint16)(UI_OFFSET_Y + 211), 320, 33 };
-		vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Save File Exists"), rect1, UIS_CENTER | UIS_BIG));
+		vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Save File Exists"), rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 		vecSelHeroDlgItems.clear();
 		vecSelHeroDlgItems.push_back(std::make_unique<UiListItem>(_("Load Game"), 0));
 		vecSelHeroDlgItems.push_back(std::make_unique<UiListItem>(_("New Game"), 1));
-		vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, PANEL_LEFT + 265, (UI_OFFSET_Y + 285), 320, 33, UIS_CENTER | UIS_MED | UIS_GOLD));
+		vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, PANEL_LEFT + 265, (UI_OFFSET_Y + 285), 320, 33, UiFlags::UIS_CENTER | UiFlags::UIS_MED | UiFlags::UIS_GOLD));
 
 		SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 279), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect2, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD));
+		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect2, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 		SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 429), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect3, UIS_CENTER | UIS_VCENTER | UIS_BIG | UIS_GOLD));
+		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect3, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 		UiInitList(vecSelHeroDlgItems.size(), SelheroLoadFocus, SelheroLoadSelect, selhero_List_Init, vecSelDlgItems, true);
 		title = _("Single Player Characters");
@@ -270,16 +270,16 @@ void SelheroClassSelectorSelect(int value)
 		strncpy(selhero_heroInfo.name, SelheroGenerateName(selhero_heroInfo.heroclass), sizeof(selhero_heroInfo.name) - 1);
 	vecSelDlgItems.clear();
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 264), (Sint16)(UI_OFFSET_Y + 211), 320, 33 };
-	vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Enter Name"), rect1, UIS_CENTER | UIS_BIG));
+	vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Enter Name"), rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 265), (Sint16)(UI_OFFSET_Y + 317), 320, 33 };
-	vecSelDlgItems.push_back(std::make_unique<UiEdit>(_("Enter Name"), selhero_heroInfo.name, 15, rect2, UIS_MED | UIS_GOLD));
+	vecSelDlgItems.push_back(std::make_unique<UiEdit>(_("Enter Name"), selhero_heroInfo.name, 15, rect2, UiFlags::UIS_MED | UiFlags::UIS_GOLD));
 
 	SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 279), (Sint16)(UI_OFFSET_Y + 429), 140, 35 };
-	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect3, UIS_CENTER | UIS_BIG | UIS_GOLD));
+	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect3, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 	SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 429), (Sint16)(UI_OFFSET_Y + 429), 140, 35 };
-	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect4, UIS_CENTER | UIS_BIG | UIS_GOLD));
+	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect4, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 	UiInitList(0, nullptr, SelheroNameSelect, SelheroNameEsc, vecSelDlgItems);
 }
@@ -454,7 +454,7 @@ void selhero_Init()
 
 	vecSelDlgItems.clear();
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(&title, rect1, UIS_CENTER | UIS_BIG));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(&title, rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 30), (Sint16)(UI_OFFSET_Y + 211), 180, 76 };
 	auto heroImg = std::make_unique<UiImage>(&ArtHero, static_cast<int>(enum_size<HeroClass>::value), rect2);
@@ -462,38 +462,38 @@ void selhero_Init()
 	vecSelHeroDialog.push_back(std::move(heroImg));
 
 	SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 39), (Sint16)(UI_OFFSET_Y + 323), 110, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Level:"), rect3, UIS_RIGHT));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Level:"), rect3, UiFlags::UIS_RIGHT));
 
 	SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 39), (Sint16)(UI_OFFSET_Y + 323), 110, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Level:"), rect4, UIS_RIGHT));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Level:"), rect4, UiFlags::UIS_RIGHT));
 	SDL_Rect rect5 = { (Sint16)(PANEL_LEFT + 159), (Sint16)(UI_OFFSET_Y + 323), 40, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[0], rect5, UIS_CENTER));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[0], rect5, UiFlags::UIS_CENTER));
 
 	SDL_Rect rect6 = { (Sint16)(PANEL_LEFT + 39), (Sint16)(UI_OFFSET_Y + 358), 110, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Strength:"), rect6, UIS_RIGHT));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Strength:"), rect6, UiFlags::UIS_RIGHT));
 	SDL_Rect rect7 = { (Sint16)(PANEL_LEFT + 159), (Sint16)(UI_OFFSET_Y + 358), 40, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[1], rect7, UIS_CENTER));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[1], rect7, UiFlags::UIS_CENTER));
 
 	SDL_Rect rect8 = { (Sint16)(PANEL_LEFT + 39), (Sint16)(UI_OFFSET_Y + 380), 110, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Magic:"), rect8, UIS_RIGHT));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Magic:"), rect8, UiFlags::UIS_RIGHT));
 	SDL_Rect rect9 = { (Sint16)(PANEL_LEFT + 159), (Sint16)(UI_OFFSET_Y + 380), 40, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[2], rect9, UIS_CENTER));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[2], rect9, UiFlags::UIS_CENTER));
 
 	SDL_Rect rect10 = { (Sint16)(PANEL_LEFT + 39), (Sint16)(UI_OFFSET_Y + 401), 110, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Dexterity:"), rect10, UIS_RIGHT));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Dexterity:"), rect10, UiFlags::UIS_RIGHT));
 	SDL_Rect rect11 = { (Sint16)(PANEL_LEFT + 159), (Sint16)(UI_OFFSET_Y + 401), 40, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[3], rect11, UIS_CENTER));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[3], rect11, UiFlags::UIS_CENTER));
 
 	SDL_Rect rect12 = { (Sint16)(PANEL_LEFT + 39), (Sint16)(UI_OFFSET_Y + 422), 110, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Vitality:"), rect12, UIS_RIGHT));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Vitality:"), rect12, UiFlags::UIS_RIGHT));
 	SDL_Rect rect13 = { (Sint16)(PANEL_LEFT + 159), (Sint16)(UI_OFFSET_Y + 422), 40, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[4], rect13, UIS_CENTER));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[4], rect13, UiFlags::UIS_CENTER));
 
 #if _DEBUG
 	SDL_Rect rect14 = { (Sint16)(PANEL_LEFT + 39), (Sint16)(UI_OFFSET_Y + 443), 110, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Savegame:"), rect14, UIS_RIGHT));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Savegame:"), rect14, UiFlags::UIS_RIGHT));
 	SDL_Rect rect15 = { (Sint16)(PANEL_LEFT + 159), (Sint16)(UI_OFFSET_Y + 443), 40, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[5], rect15, UIS_CENTER));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[5], rect15, UiFlags::UIS_CENTER));
 #endif
 }
 
@@ -503,7 +503,7 @@ void selhero_List_Init()
 	vecSelDlgItems.clear();
 
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 264), (Sint16)(UI_OFFSET_Y + 211), 320, 33 };
-	vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Select Hero"), rect1, UIS_CENTER | UIS_BIG));
+	vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Select Hero"), rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 	vecSelHeroDlgItems.clear();
 	const size_t numViewportHeroes = std::min(selhero_SaveCount + 1, MaxViewportItems);
@@ -512,7 +512,7 @@ void selhero_List_Init()
 	}
 	SelheroUpdateViewportItems();
 
-	vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, PANEL_LEFT + 265, (UI_OFFSET_Y + 256), 320, 26, UIS_CENTER | UIS_MED | UIS_GOLD));
+	vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, PANEL_LEFT + 265, (UI_OFFSET_Y + 256), 320, 26, UiFlags::UIS_CENTER | UiFlags::UIS_MED | UiFlags::UIS_GOLD));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 585), (Sint16)(UI_OFFSET_Y + 244), 25, 178 };
 	auto pinnedScrollBar = std::make_unique<UiScrollBar>(&ArtScrollBarBackground, &ArtScrollBarThumb, &ArtScrollBarArrow, rect2);
@@ -520,15 +520,15 @@ void selhero_List_Init()
 	vecSelDlgItems.push_back(std::move(pinnedScrollBar));
 
 	SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 239), (Sint16)(UI_OFFSET_Y + 429), 120, 35 };
-	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect3, UIS_CENTER | UIS_BIG | UIS_GOLD));
+	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect3, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 	SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 364), (Sint16)(UI_OFFSET_Y + 429), 120, 35 };
-	auto setlistDialogDeleteButton = std::make_unique<UiArtTextButton>(_("Delete"), &SelheroUiFocusNavigationYesNo, rect4, UIS_CENTER | UIS_BIG | UIS_DISABLED);
+	auto setlistDialogDeleteButton = std::make_unique<UiArtTextButton>(_("Delete"), &SelheroUiFocusNavigationYesNo, rect4, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_DISABLED);
 	SELLIST_DIALOG_DELETE_BUTTON = setlistDialogDeleteButton.get();
 	vecSelDlgItems.push_back(std::move(setlistDialogDeleteButton));
 
 	SDL_Rect rect5 = { (Sint16)(PANEL_LEFT + 489), (Sint16)(UI_OFFSET_Y + 429), 120, 35 };
-	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect5, UIS_CENTER | UIS_BIG | UIS_GOLD));
+	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect5, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 	UiInitList(selhero_SaveCount + 1, SelheroListFocus, SelheroListSelect, SelheroListEsc, vecSelDlgItems, false, SelheroListDeleteYesNo);
 	UiInitScrollBar(scrollBar, MaxViewportItems, &listOffset);

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -457,7 +457,7 @@ void selhero_Init()
 	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(&title, rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 30), (Sint16)(UI_OFFSET_Y + 211), 180, 76 };
-	auto heroImg = std::make_unique<UiImage>(&ArtHero, static_cast<int>(enum_size<HeroClass>::value), rect2);
+	auto heroImg = std::make_unique<UiImage>(&ArtHero, rect2, UiFlags::NONE, /*bAnimated=*/false, static_cast<int>(enum_size<HeroClass>::value));
 	SELHERO_DIALOG_HERO_IMG = heroImg.get();
 	vecSelHeroDialog.push_back(std::move(heroImg));
 

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -127,11 +127,11 @@ void SelheroListFocus(int value)
 {
 	const auto index = static_cast<std::size_t>(value);
 	SelheroScrollIntoView(index);
-	UiFlags baseFlags = UiFlags::UIS_CENTER | UiFlags::UIS_BIG;
+	UiFlags baseFlags = UiFlags::AlignCenter | UiFlags::FontBig;
 	if (selhero_SaveCount != 0 && index < selhero_SaveCount) {
 		memcpy(&selhero_heroInfo, &selhero_heros[index], sizeof(selhero_heroInfo));
 		SelheroSetStats();
-		SELLIST_DIALOG_DELETE_BUTTON->m_iFlags = baseFlags | UiFlags::UIS_GOLD;
+		SELLIST_DIALOG_DELETE_BUTTON->m_iFlags = baseFlags | UiFlags::ColorGold;
 		selhero_deleteEnabled = true;
 		return;
 	}
@@ -143,7 +143,7 @@ void SelheroListFocus(int value)
 	strncpy(textStats[3], "--", sizeof(textStats[3]) - 1);
 	strncpy(textStats[4], "--", sizeof(textStats[4]) - 1);
 	strncpy(textStats[5], "--", sizeof(textStats[5]) - 1);
-	SELLIST_DIALOG_DELETE_BUTTON->m_iFlags = baseFlags | UiFlags::UIS_DISABLED;
+	SELLIST_DIALOG_DELETE_BUTTON->m_iFlags = baseFlags | UiFlags::ElementDisabled;
 	selhero_deleteEnabled = false;
 }
 
@@ -160,7 +160,7 @@ void SelheroListSelect(int value)
 		vecSelDlgItems.clear();
 
 		SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 264), (Sint16)(UI_OFFSET_Y + 211), 320, 33 };
-		vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Choose Class"), rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+		vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Choose Class"), rect1, UiFlags::AlignCenter | UiFlags::FontBig));
 
 		vecSelHeroDlgItems.clear();
 		int itemH = 33;
@@ -179,13 +179,13 @@ void SelheroListSelect(int value)
 		if (vecSelHeroDlgItems.size() > 4)
 			itemH = 26;
 		int itemY = 246 + (176 - vecSelHeroDlgItems.size() * itemH) / 2;
-		vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, PANEL_LEFT + 264, (UI_OFFSET_Y + itemY), 320, itemH, UiFlags::UIS_CENTER | UiFlags::UIS_MED | UiFlags::UIS_GOLD));
+		vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, PANEL_LEFT + 264, (UI_OFFSET_Y + itemY), 320, itemH, UiFlags::AlignCenter | UiFlags::FontMedium | UiFlags::ColorGold));
 
 		SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 279), (Sint16)(UI_OFFSET_Y + 429), 140, 35 };
-		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect2, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect2, UiFlags::AlignCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 		SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 429), (Sint16)(UI_OFFSET_Y + 429), 140, 35 };
-		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect3, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect3, UiFlags::AlignCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 		UiInitList(vecSelHeroDlgItems.size(), SelheroClassSelectorFocus, SelheroClassSelectorSelect, SelheroClassSelectorEsc, vecSelDlgItems);
 		memset(&selhero_heroInfo.name, 0, sizeof(selhero_heroInfo.name));
@@ -198,18 +198,18 @@ void SelheroListSelect(int value)
 		vecSelDlgItems.clear();
 
 		SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 264), (Sint16)(UI_OFFSET_Y + 211), 320, 33 };
-		vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Save File Exists"), rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+		vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Save File Exists"), rect1, UiFlags::AlignCenter | UiFlags::FontBig));
 
 		vecSelHeroDlgItems.clear();
 		vecSelHeroDlgItems.push_back(std::make_unique<UiListItem>(_("Load Game"), 0));
 		vecSelHeroDlgItems.push_back(std::make_unique<UiListItem>(_("New Game"), 1));
-		vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, PANEL_LEFT + 265, (UI_OFFSET_Y + 285), 320, 33, UiFlags::UIS_CENTER | UiFlags::UIS_MED | UiFlags::UIS_GOLD));
+		vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, PANEL_LEFT + 265, (UI_OFFSET_Y + 285), 320, 33, UiFlags::AlignCenter | UiFlags::FontMedium | UiFlags::ColorGold));
 
 		SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 279), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect2, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect2, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 		SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 429), (Sint16)(UI_OFFSET_Y + 427), 140, 35 };
-		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect3, UiFlags::UIS_CENTER | UiFlags::UIS_VCENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect3, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 		UiInitList(vecSelHeroDlgItems.size(), SelheroLoadFocus, SelheroLoadSelect, selhero_List_Init, vecSelDlgItems, true);
 		title = _("Single Player Characters");
@@ -270,16 +270,16 @@ void SelheroClassSelectorSelect(int value)
 		strncpy(selhero_heroInfo.name, SelheroGenerateName(selhero_heroInfo.heroclass), sizeof(selhero_heroInfo.name) - 1);
 	vecSelDlgItems.clear();
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 264), (Sint16)(UI_OFFSET_Y + 211), 320, 33 };
-	vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Enter Name"), rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+	vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Enter Name"), rect1, UiFlags::AlignCenter | UiFlags::FontBig));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 265), (Sint16)(UI_OFFSET_Y + 317), 320, 33 };
-	vecSelDlgItems.push_back(std::make_unique<UiEdit>(_("Enter Name"), selhero_heroInfo.name, 15, rect2, UiFlags::UIS_MED | UiFlags::UIS_GOLD));
+	vecSelDlgItems.push_back(std::make_unique<UiEdit>(_("Enter Name"), selhero_heroInfo.name, 15, rect2, UiFlags::FontMedium | UiFlags::ColorGold));
 
 	SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 279), (Sint16)(UI_OFFSET_Y + 429), 140, 35 };
-	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect3, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect3, UiFlags::AlignCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 	SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 429), (Sint16)(UI_OFFSET_Y + 429), 140, 35 };
-	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect4, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect4, UiFlags::AlignCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 	UiInitList(0, nullptr, SelheroNameSelect, SelheroNameEsc, vecSelDlgItems);
 }
@@ -454,46 +454,46 @@ void selhero_Init()
 
 	vecSelDlgItems.clear();
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(&title, rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(&title, rect1, UiFlags::AlignCenter | UiFlags::FontBig));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 30), (Sint16)(UI_OFFSET_Y + 211), 180, 76 };
-	auto heroImg = std::make_unique<UiImage>(&ArtHero, rect2, UiFlags::NONE, /*bAnimated=*/false, static_cast<int>(enum_size<HeroClass>::value));
+	auto heroImg = std::make_unique<UiImage>(&ArtHero, rect2, UiFlags::None, /*bAnimated=*/false, static_cast<int>(enum_size<HeroClass>::value));
 	SELHERO_DIALOG_HERO_IMG = heroImg.get();
 	vecSelHeroDialog.push_back(std::move(heroImg));
 
 	SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 39), (Sint16)(UI_OFFSET_Y + 323), 110, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Level:"), rect3, UiFlags::UIS_RIGHT));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Level:"), rect3, UiFlags::AlignRight));
 
 	SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 39), (Sint16)(UI_OFFSET_Y + 323), 110, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Level:"), rect4, UiFlags::UIS_RIGHT));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Level:"), rect4, UiFlags::AlignRight));
 	SDL_Rect rect5 = { (Sint16)(PANEL_LEFT + 159), (Sint16)(UI_OFFSET_Y + 323), 40, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[0], rect5, UiFlags::UIS_CENTER));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[0], rect5, UiFlags::AlignCenter));
 
 	SDL_Rect rect6 = { (Sint16)(PANEL_LEFT + 39), (Sint16)(UI_OFFSET_Y + 358), 110, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Strength:"), rect6, UiFlags::UIS_RIGHT));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Strength:"), rect6, UiFlags::AlignRight));
 	SDL_Rect rect7 = { (Sint16)(PANEL_LEFT + 159), (Sint16)(UI_OFFSET_Y + 358), 40, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[1], rect7, UiFlags::UIS_CENTER));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[1], rect7, UiFlags::AlignCenter));
 
 	SDL_Rect rect8 = { (Sint16)(PANEL_LEFT + 39), (Sint16)(UI_OFFSET_Y + 380), 110, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Magic:"), rect8, UiFlags::UIS_RIGHT));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Magic:"), rect8, UiFlags::AlignRight));
 	SDL_Rect rect9 = { (Sint16)(PANEL_LEFT + 159), (Sint16)(UI_OFFSET_Y + 380), 40, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[2], rect9, UiFlags::UIS_CENTER));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[2], rect9, UiFlags::AlignCenter));
 
 	SDL_Rect rect10 = { (Sint16)(PANEL_LEFT + 39), (Sint16)(UI_OFFSET_Y + 401), 110, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Dexterity:"), rect10, UiFlags::UIS_RIGHT));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Dexterity:"), rect10, UiFlags::AlignRight));
 	SDL_Rect rect11 = { (Sint16)(PANEL_LEFT + 159), (Sint16)(UI_OFFSET_Y + 401), 40, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[3], rect11, UiFlags::UIS_CENTER));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[3], rect11, UiFlags::AlignCenter));
 
 	SDL_Rect rect12 = { (Sint16)(PANEL_LEFT + 39), (Sint16)(UI_OFFSET_Y + 422), 110, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Vitality:"), rect12, UiFlags::UIS_RIGHT));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Vitality:"), rect12, UiFlags::AlignRight));
 	SDL_Rect rect13 = { (Sint16)(PANEL_LEFT + 159), (Sint16)(UI_OFFSET_Y + 422), 40, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[4], rect13, UiFlags::UIS_CENTER));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[4], rect13, UiFlags::AlignCenter));
 
 #if _DEBUG
 	SDL_Rect rect14 = { (Sint16)(PANEL_LEFT + 39), (Sint16)(UI_OFFSET_Y + 443), 110, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Savegame:"), rect14, UiFlags::UIS_RIGHT));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(_("Savegame:"), rect14, UiFlags::AlignRight));
 	SDL_Rect rect15 = { (Sint16)(PANEL_LEFT + 159), (Sint16)(UI_OFFSET_Y + 443), 40, 21 };
-	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[5], rect15, UiFlags::UIS_CENTER));
+	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(textStats[5], rect15, UiFlags::AlignCenter));
 #endif
 }
 
@@ -503,7 +503,7 @@ void selhero_List_Init()
 	vecSelDlgItems.clear();
 
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 264), (Sint16)(UI_OFFSET_Y + 211), 320, 33 };
-	vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Select Hero"), rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+	vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Select Hero"), rect1, UiFlags::AlignCenter | UiFlags::FontBig));
 
 	vecSelHeroDlgItems.clear();
 	const size_t numViewportHeroes = std::min(selhero_SaveCount + 1, MaxViewportItems);
@@ -512,7 +512,7 @@ void selhero_List_Init()
 	}
 	SelheroUpdateViewportItems();
 
-	vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, PANEL_LEFT + 265, (UI_OFFSET_Y + 256), 320, 26, UiFlags::UIS_CENTER | UiFlags::UIS_MED | UiFlags::UIS_GOLD));
+	vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, PANEL_LEFT + 265, (UI_OFFSET_Y + 256), 320, 26, UiFlags::AlignCenter | UiFlags::FontMedium | UiFlags::ColorGold));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 585), (Sint16)(UI_OFFSET_Y + 244), 25, 178 };
 	auto pinnedScrollBar = std::make_unique<UiScrollBar>(&ArtScrollBarBackground, &ArtScrollBarThumb, &ArtScrollBarArrow, rect2);
@@ -520,15 +520,15 @@ void selhero_List_Init()
 	vecSelDlgItems.push_back(std::move(pinnedScrollBar));
 
 	SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 239), (Sint16)(UI_OFFSET_Y + 429), 120, 35 };
-	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect3, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect3, UiFlags::AlignCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 	SDL_Rect rect4 = { (Sint16)(PANEL_LEFT + 364), (Sint16)(UI_OFFSET_Y + 429), 120, 35 };
-	auto setlistDialogDeleteButton = std::make_unique<UiArtTextButton>(_("Delete"), &SelheroUiFocusNavigationYesNo, rect4, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_DISABLED);
+	auto setlistDialogDeleteButton = std::make_unique<UiArtTextButton>(_("Delete"), &SelheroUiFocusNavigationYesNo, rect4, UiFlags::AlignCenter | UiFlags::FontBig | UiFlags::ElementDisabled);
 	SELLIST_DIALOG_DELETE_BUTTON = setlistDialogDeleteButton.get();
 	vecSelDlgItems.push_back(std::move(setlistDialogDeleteButton));
 
 	SDL_Rect rect5 = { (Sint16)(PANEL_LEFT + 489), (Sint16)(UI_OFFSET_Y + 429), 120, 35 };
-	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect5, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect5, UiFlags::AlignCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 	UiInitList(selhero_SaveCount + 1, SelheroListFocus, SelheroListSelect, SelheroListEsc, vecSelDlgItems, false, SelheroListDeleteYesNo);
 	UiInitScrollBar(scrollBar, MaxViewportItems, &listOffset);

--- a/Source/DiabloUI/selok.cpp
+++ b/Source/DiabloUI/selok.cpp
@@ -56,17 +56,17 @@ void UiSelOkDialog(const char *title, const char *body, bool background)
 
 	if (title != nullptr) {
 		SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-		vecSelOkDialog.push_back(std::make_unique<UiArtText>(title, rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+		vecSelOkDialog.push_back(std::make_unique<UiArtText>(title, rect1, UiFlags::AlignCenter | UiFlags::FontBig));
 
 		SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 140), (Sint16)(UI_OFFSET_Y + 210), 560, 168 };
-		vecSelOkDialog.push_back(std::make_unique<UiArtText>(dialogText, rect2, UiFlags::UIS_MED));
+		vecSelOkDialog.push_back(std::make_unique<UiArtText>(dialogText, rect2, UiFlags::FontMedium));
 	} else {
 		SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 140), (Sint16)(UI_OFFSET_Y + 197), 560, 168 };
-		vecSelOkDialog.push_back(std::make_unique<UiArtText>(dialogText, rect1, UiFlags::UIS_MED));
+		vecSelOkDialog.push_back(std::make_unique<UiArtText>(dialogText, rect1, UiFlags::FontMedium));
 	}
 
 	vecSelOkDialogItems.push_back(std::make_unique<UiListItem>(_("OK"), 0));
-	vecSelOkDialog.push_back(std::make_unique<UiList>(vecSelOkDialogItems, PANEL_LEFT + 230, (UI_OFFSET_Y + 390), 180, 35, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+	vecSelOkDialog.push_back(std::make_unique<UiList>(vecSelOkDialogItems, PANEL_LEFT + 230, (UI_OFFSET_Y + 390), 180, 35, UiFlags::AlignCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 	strncpy(dialogText, body, sizeof(dialogText) - 1);
 	WordWrapArtStr(dialogText, MESSAGE_WIDTH);

--- a/Source/DiabloUI/selok.cpp
+++ b/Source/DiabloUI/selok.cpp
@@ -56,17 +56,17 @@ void UiSelOkDialog(const char *title, const char *body, bool background)
 
 	if (title != nullptr) {
 		SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-		vecSelOkDialog.push_back(std::make_unique<UiArtText>(title, rect1, UIS_CENTER | UIS_BIG));
+		vecSelOkDialog.push_back(std::make_unique<UiArtText>(title, rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 		SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 140), (Sint16)(UI_OFFSET_Y + 210), 560, 168 };
-		vecSelOkDialog.push_back(std::make_unique<UiArtText>(dialogText, rect2, UIS_MED));
+		vecSelOkDialog.push_back(std::make_unique<UiArtText>(dialogText, rect2, UiFlags::UIS_MED));
 	} else {
 		SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 140), (Sint16)(UI_OFFSET_Y + 197), 560, 168 };
-		vecSelOkDialog.push_back(std::make_unique<UiArtText>(dialogText, rect1, UIS_MED));
+		vecSelOkDialog.push_back(std::make_unique<UiArtText>(dialogText, rect1, UiFlags::UIS_MED));
 	}
 
 	vecSelOkDialogItems.push_back(std::make_unique<UiListItem>(_("OK"), 0));
-	vecSelOkDialog.push_back(std::make_unique<UiList>(vecSelOkDialogItems, PANEL_LEFT + 230, (UI_OFFSET_Y + 390), 180, 35, UIS_CENTER | UIS_BIG | UIS_GOLD));
+	vecSelOkDialog.push_back(std::make_unique<UiList>(vecSelOkDialogItems, PANEL_LEFT + 230, (UI_OFFSET_Y + 390), 180, 35, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 	strncpy(dialogText, body, sizeof(dialogText) - 1);
 	WordWrapArtStr(dialogText, MESSAGE_WIDTH);

--- a/Source/DiabloUI/selyesno.cpp
+++ b/Source/DiabloUI/selyesno.cpp
@@ -47,14 +47,14 @@ bool UiSelHeroYesNoDialog(const char *title, const char *body)
 	UiAddLogo(&vecSelYesNoDialog);
 
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-	vecSelYesNoDialog.push_back(std::make_unique<UiArtText>(title, rect1, UIS_CENTER | UIS_BIG));
+	vecSelYesNoDialog.push_back(std::make_unique<UiArtText>(title, rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 120), (Sint16)(UI_OFFSET_Y + 236), MESSAGE_WIDTH, 168 };
-	vecSelYesNoDialog.push_back(std::make_unique<UiArtText>(selyesno_confirmationMessage, rect2, UIS_MED));
+	vecSelYesNoDialog.push_back(std::make_unique<UiArtText>(selyesno_confirmationMessage, rect2, UiFlags::UIS_MED));
 
 	vecSelYesNoDialogItems.push_back(std::make_unique<UiListItem>(_("Yes"), 0));
 	vecSelYesNoDialogItems.push_back(std::make_unique<UiListItem>(_("No"), 1));
-	vecSelYesNoDialog.push_back(std::make_unique<UiList>(vecSelYesNoDialogItems, PANEL_LEFT + 230, (UI_OFFSET_Y + 390), 180, 35, UIS_CENTER | UIS_BIG | UIS_GOLD));
+	vecSelYesNoDialog.push_back(std::make_unique<UiList>(vecSelYesNoDialogItems, PANEL_LEFT + 230, (UI_OFFSET_Y + 390), 180, 35, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
 
 	strncpy(selyesno_confirmationMessage, body, sizeof(selyesno_confirmationMessage) - 1);
 	WordWrapArtStr(selyesno_confirmationMessage, MESSAGE_WIDTH);

--- a/Source/DiabloUI/selyesno.cpp
+++ b/Source/DiabloUI/selyesno.cpp
@@ -47,14 +47,14 @@ bool UiSelHeroYesNoDialog(const char *title, const char *body)
 	UiAddLogo(&vecSelYesNoDialog);
 
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 24), (Sint16)(UI_OFFSET_Y + 161), 590, 35 };
-	vecSelYesNoDialog.push_back(std::make_unique<UiArtText>(title, rect1, UiFlags::UIS_CENTER | UiFlags::UIS_BIG));
+	vecSelYesNoDialog.push_back(std::make_unique<UiArtText>(title, rect1, UiFlags::AlignCenter | UiFlags::FontBig));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 120), (Sint16)(UI_OFFSET_Y + 236), MESSAGE_WIDTH, 168 };
-	vecSelYesNoDialog.push_back(std::make_unique<UiArtText>(selyesno_confirmationMessage, rect2, UiFlags::UIS_MED));
+	vecSelYesNoDialog.push_back(std::make_unique<UiArtText>(selyesno_confirmationMessage, rect2, UiFlags::FontMedium));
 
 	vecSelYesNoDialogItems.push_back(std::make_unique<UiListItem>(_("Yes"), 0));
 	vecSelYesNoDialogItems.push_back(std::make_unique<UiListItem>(_("No"), 1));
-	vecSelYesNoDialog.push_back(std::make_unique<UiList>(vecSelYesNoDialogItems, PANEL_LEFT + 230, (UI_OFFSET_Y + 390), 180, 35, UiFlags::UIS_CENTER | UiFlags::UIS_BIG | UiFlags::UIS_GOLD));
+	vecSelYesNoDialog.push_back(std::make_unique<UiList>(vecSelYesNoDialogItems, PANEL_LEFT + 230, (UI_OFFSET_Y + 390), 180, 35, UiFlags::AlignCenter | UiFlags::FontBig | UiFlags::ColorGold));
 
 	strncpy(selyesno_confirmationMessage, body, sizeof(selyesno_confirmationMessage) - 1);
 	WordWrapArtStr(selyesno_confirmationMessage, MESSAGE_WIDTH);

--- a/Source/DiabloUI/text_draw.cpp
+++ b/Source/DiabloUI/text_draw.cpp
@@ -14,18 +14,18 @@ namespace {
 
 TextAlignment XAlignmentFromFlags(UiFlags flags)
 {
-	if (HasAnyOf(flags, UiFlags::UIS_CENTER))
+	if (HasAnyOf(flags, UiFlags::AlignCenter))
 		return TextAlignment_CENTER;
-	if (HasAnyOf(flags, UiFlags::UIS_RIGHT))
+	if (HasAnyOf(flags, UiFlags::AlignRight))
 		return TextAlignment_END;
 	return TextAlignment_BEGIN;
 }
 
 int AlignXOffset(UiFlags flags, const SDL_Rect &dest, int w)
 {
-	if (HasAnyOf(flags, UiFlags::UIS_CENTER))
+	if (HasAnyOf(flags, UiFlags::AlignCenter))
 		return (dest.w - w) / 2;
-	if (HasAnyOf(flags, UiFlags::UIS_RIGHT))
+	if (HasAnyOf(flags, UiFlags::AlignRight))
 		return dest.w - w;
 	return 0;
 }
@@ -54,7 +54,7 @@ void DrawTTF(const char *text, const SDL_Rect &rectIn, UiFlags flags,
 	SDL_Rect destRect = rect;
 	ScaleOutputRect(&destRect);
 	destRect.x += AlignXOffset(flags, destRect, textSurface->w);
-	destRect.y += HasAnyOf(flags, UiFlags::UIS_VCENTER) ? (destRect.h - textSurface->h) / 2 : 0;
+	destRect.y += HasAnyOf(flags, UiFlags::VerticalCenter) ? (destRect.h - textSurface->h) / 2 : 0;
 
 	SDL_Rect shadowRect = destRect;
 	++shadowRect.x;
@@ -68,17 +68,17 @@ void DrawTTF(const char *text, const SDL_Rect &rectIn, UiFlags flags,
 void DrawArtStr(const char *text, const SDL_Rect &rect, UiFlags flags, bool drawTextCursor)
 {
 	_artFontTables size = AFT_SMALL;
-	_artFontColors color = HasAnyOf(flags, UiFlags::UIS_GOLD) ? AFC_GOLD : AFC_SILVER;
+	_artFontColors color = HasAnyOf(flags, UiFlags::ColorGold) ? AFC_GOLD : AFC_SILVER;
 
-	if (HasAnyOf(flags, UiFlags::UIS_MED))
+	if (HasAnyOf(flags, UiFlags::FontMedium))
 		size = AFT_MED;
-	else if (HasAnyOf(flags, UiFlags::UIS_BIG))
+	else if (HasAnyOf(flags, UiFlags::FontBig))
 		size = AFT_BIG;
-	else if (HasAnyOf(flags, UiFlags::UIS_HUGE))
+	else if (HasAnyOf(flags, UiFlags::FontHuge))
 		size = AFT_HUGE;
 
 	const int x = rect.x + AlignXOffset(flags, rect, GetArtStrWidth(text, size));
-	const int y = rect.y + (HasAnyOf(flags, UiFlags::UIS_VCENTER) ? (rect.h - ArtFonts[size][color].h()) / 2 : 0);
+	const int y = rect.y + (HasAnyOf(flags, UiFlags::VerticalCenter) ? (rect.h - ArtFonts[size][color].h()) / 2 : 0);
 
 	int sx = x;
 	int sy = y;

--- a/Source/DiabloUI/text_draw.cpp
+++ b/Source/DiabloUI/text_draw.cpp
@@ -12,27 +12,27 @@ namespace devilution {
 
 namespace {
 
-TextAlignment XAlignmentFromFlags(int flags)
+TextAlignment XAlignmentFromFlags(UiFlags flags)
 {
-	if ((flags & UIS_CENTER) != 0)
+	if (HasAnyOf(flags, UiFlags::UIS_CENTER))
 		return TextAlignment_CENTER;
-	if ((flags & UIS_RIGHT) != 0)
+	if (HasAnyOf(flags, UiFlags::UIS_RIGHT))
 		return TextAlignment_END;
 	return TextAlignment_BEGIN;
 }
 
-int AlignXOffset(int flags, const SDL_Rect &dest, int w)
+int AlignXOffset(UiFlags flags, const SDL_Rect &dest, int w)
 {
-	if ((flags & UIS_CENTER) != 0)
+	if (HasAnyOf(flags, UiFlags::UIS_CENTER))
 		return (dest.w - w) / 2;
-	if ((flags & UIS_RIGHT) != 0)
+	if (HasAnyOf(flags, UiFlags::UIS_RIGHT))
 		return dest.w - w;
 	return 0;
 }
 
 } // namespace
 
-void DrawTTF(const char *text, const SDL_Rect &rectIn, int flags,
+void DrawTTF(const char *text, const SDL_Rect &rectIn, UiFlags flags,
     const SDL_Color &textColor, const SDL_Color &shadowColor,
     TtfSurfaceCache &renderCache)
 {
@@ -54,7 +54,7 @@ void DrawTTF(const char *text, const SDL_Rect &rectIn, int flags,
 	SDL_Rect destRect = rect;
 	ScaleOutputRect(&destRect);
 	destRect.x += AlignXOffset(flags, destRect, textSurface->w);
-	destRect.y += (flags & UIS_VCENTER) != 0 ? (destRect.h - textSurface->h) / 2 : 0;
+	destRect.y += HasAnyOf(flags, UiFlags::UIS_VCENTER) ? (destRect.h - textSurface->h) / 2 : 0;
 
 	SDL_Rect shadowRect = destRect;
 	++shadowRect.x;
@@ -65,20 +65,20 @@ void DrawTTF(const char *text, const SDL_Rect &rectIn, int flags,
 		ErrSdl();
 }
 
-void DrawArtStr(const char *text, const SDL_Rect &rect, int flags, bool drawTextCursor)
+void DrawArtStr(const char *text, const SDL_Rect &rect, UiFlags flags, bool drawTextCursor)
 {
 	_artFontTables size = AFT_SMALL;
-	_artFontColors color = (flags & UIS_GOLD) != 0 ? AFC_GOLD : AFC_SILVER;
+	_artFontColors color = HasAnyOf(flags, UiFlags::UIS_GOLD) ? AFC_GOLD : AFC_SILVER;
 
-	if ((flags & UIS_MED) != 0)
+	if (HasAnyOf(flags, UiFlags::UIS_MED))
 		size = AFT_MED;
-	else if ((flags & UIS_BIG) != 0)
+	else if (HasAnyOf(flags, UiFlags::UIS_BIG))
 		size = AFT_BIG;
-	else if ((flags & UIS_HUGE) != 0)
+	else if (HasAnyOf(flags, UiFlags::UIS_HUGE))
 		size = AFT_HUGE;
 
 	const int x = rect.x + AlignXOffset(flags, rect, GetArtStrWidth(text, size));
-	const int y = rect.y + ((flags & UIS_VCENTER) != 0 ? (rect.h - ArtFonts[size][color].h()) / 2 : 0);
+	const int y = rect.y + (HasAnyOf(flags, UiFlags::UIS_VCENTER) ? (rect.h - ArtFonts[size][color].h()) / 2 : 0);
 
 	int sx = x;
 	int sy = y;

--- a/Source/DiabloUI/text_draw.h
+++ b/Source/DiabloUI/text_draw.h
@@ -11,10 +11,12 @@ struct TtfSurfaceCache {
 	SDLSurfaceUniquePtr shadow;
 };
 
-void DrawTTF(const char *text, const SDL_Rect &rect, int flags,
+enum class UiFlags; // Defined in ui_item.h, declared here to avoid circular dependency
+
+void DrawTTF(const char *text, const SDL_Rect &rect, UiFlags flags,
     const SDL_Color &textColor, const SDL_Color &shadowColor,
     TtfSurfaceCache &renderCache);
 
-void DrawArtStr(const char *text, const SDL_Rect &rect, int flags, bool drawTextCursor = false);
+void DrawArtStr(const char *text, const SDL_Rect &rect, UiFlags flags, bool drawTextCursor = false);
 
 } // namespace devilution

--- a/Source/DiabloUI/title.cpp
+++ b/Source/DiabloUI/title.cpp
@@ -34,8 +34,8 @@ void UiTitleDialog()
 {
 	if (gbIsHellfire) {
 		SDL_Rect rect = { 0, UI_OFFSET_Y, 0, 0 };
-		vecTitleScreen.push_back(std::make_unique<UiImage>(&ArtBackgroundWidescreen, /*bAnimated=*/true, /*iFrame=*/0, rect, UiFlags::UIS_CENTER));
-		vecTitleScreen.push_back(std::make_unique<UiImage>(&ArtBackground, /*bAnimated=*/true, /*iFrame=*/0, rect, UiFlags::UIS_CENTER));
+		vecTitleScreen.push_back(std::make_unique<UiImage>(&ArtBackgroundWidescreen, rect, UiFlags::UIS_CENTER, /*bAnimated=*/true));
+		vecTitleScreen.push_back(std::make_unique<UiImage>(&ArtBackground, rect, UiFlags::UIS_CENTER, /*bAnimated=*/true));
 	} else {
 		UiAddBackground(&vecTitleScreen);
 		UiAddLogo(&vecTitleScreen, LOGO_BIG, 182);

--- a/Source/DiabloUI/title.cpp
+++ b/Source/DiabloUI/title.cpp
@@ -34,14 +34,14 @@ void UiTitleDialog()
 {
 	if (gbIsHellfire) {
 		SDL_Rect rect = { 0, UI_OFFSET_Y, 0, 0 };
-		vecTitleScreen.push_back(std::make_unique<UiImage>(&ArtBackgroundWidescreen, /*bAnimated=*/true, /*iFrame=*/0, rect, UIS_CENTER));
-		vecTitleScreen.push_back(std::make_unique<UiImage>(&ArtBackground, /*bAnimated=*/true, /*iFrame=*/0, rect, UIS_CENTER));
+		vecTitleScreen.push_back(std::make_unique<UiImage>(&ArtBackgroundWidescreen, /*bAnimated=*/true, /*iFrame=*/0, rect, UiFlags::UIS_CENTER));
+		vecTitleScreen.push_back(std::make_unique<UiImage>(&ArtBackground, /*bAnimated=*/true, /*iFrame=*/0, rect, UiFlags::UIS_CENTER));
 	} else {
 		UiAddBackground(&vecTitleScreen);
 		UiAddLogo(&vecTitleScreen, LOGO_BIG, 182);
 
 		SDL_Rect rect = { (Sint16)(PANEL_LEFT + 49), (Sint16)(UI_OFFSET_Y + 410), 550, 26 };
-		vecTitleScreen.push_back(std::make_unique<UiArtText>(_("Copyright © 1996-2001 Blizzard Entertainment"), rect, UIS_MED | UIS_CENTER));
+		vecTitleScreen.push_back(std::make_unique<UiArtText>(_("Copyright © 1996-2001 Blizzard Entertainment"), rect, UiFlags::UIS_MED | UiFlags::UIS_CENTER));
 	}
 	TitleLoad();
 

--- a/Source/DiabloUI/title.cpp
+++ b/Source/DiabloUI/title.cpp
@@ -34,14 +34,14 @@ void UiTitleDialog()
 {
 	if (gbIsHellfire) {
 		SDL_Rect rect = { 0, UI_OFFSET_Y, 0, 0 };
-		vecTitleScreen.push_back(std::make_unique<UiImage>(&ArtBackgroundWidescreen, rect, UiFlags::UIS_CENTER, /*bAnimated=*/true));
-		vecTitleScreen.push_back(std::make_unique<UiImage>(&ArtBackground, rect, UiFlags::UIS_CENTER, /*bAnimated=*/true));
+		vecTitleScreen.push_back(std::make_unique<UiImage>(&ArtBackgroundWidescreen, rect, UiFlags::AlignCenter, /*bAnimated=*/true));
+		vecTitleScreen.push_back(std::make_unique<UiImage>(&ArtBackground, rect, UiFlags::AlignCenter, /*bAnimated=*/true));
 	} else {
 		UiAddBackground(&vecTitleScreen);
 		UiAddLogo(&vecTitleScreen, LOGO_BIG, 182);
 
 		SDL_Rect rect = { (Sint16)(PANEL_LEFT + 49), (Sint16)(UI_OFFSET_Y + 410), 550, 26 };
-		vecTitleScreen.push_back(std::make_unique<UiArtText>(_("Copyright © 1996-2001 Blizzard Entertainment"), rect, UiFlags::UIS_MED | UiFlags::UIS_CENTER));
+		vecTitleScreen.push_back(std::make_unique<UiArtText>(_("Copyright © 1996-2001 Blizzard Entertainment"), rect, UiFlags::FontMedium | UiFlags::AlignCenter));
 	}
 	TitleLoad();
 

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -11,7 +11,7 @@
 
 namespace devilution {
 
-enum UiType : uint8_t {
+enum class UiType {
 	UI_TEXT,
 	UI_ART_TEXT,
 	UI_ART_TEXT_BUTTON,
@@ -120,7 +120,7 @@ public:
 class UiImage : public UiItemBase {
 public:
 	UiImage(Art *art, SDL_Rect rect, UiFlags flags = UiFlags::NONE, bool animated = false, int frame = 0)
-	    : UiItemBase(UI_IMAGE, rect, flags)
+	    : UiItemBase(UiType::UI_IMAGE, rect, flags)
 	    , m_art(art)
 	    , m_animated(animated)
 	    , m_frame(frame)
@@ -146,7 +146,7 @@ public:
 	 * @param flags UiFlags controlling color/alignment/size
 	 */
 	UiArtText(const char *text, SDL_Rect rect, UiFlags flags = UiFlags::NONE)
-	    : UiItemBase(UI_ART_TEXT, rect, flags)
+	    : UiItemBase(UiType::UI_ART_TEXT, rect, flags)
 	    , m_text(text)
 	{
 	}
@@ -158,7 +158,7 @@ public:
 	 * @param flags UiFlags controlling color/alignment/size
 	 */
 	UiArtText(const char **ptext, SDL_Rect rect, UiFlags flags = UiFlags::NONE)
-	    : UiItemBase(UI_ART_TEXT, rect, flags)
+	    : UiItemBase(UiType::UI_ART_TEXT, rect, flags)
 	    , m_ptext(ptext)
 	{
 	}
@@ -182,7 +182,7 @@ private:
 class UiScrollBar : public UiItemBase {
 public:
 	UiScrollBar(Art *bg, Art *thumb, Art *arrow, SDL_Rect rect, UiFlags flags = UiFlags::NONE)
-	    : UiItemBase(UI_SCROLLBAR, rect, flags)
+	    : UiItemBase(UiType::UI_SCROLLBAR, rect, flags)
 	    , m_bg(bg)
 	    , m_thumb(thumb)
 	    , m_arrow(arrow)
@@ -200,7 +200,7 @@ public:
 class UiArtTextButton : public UiItemBase {
 public:
 	UiArtTextButton(const char *text, void (*action)(), SDL_Rect rect, UiFlags flags = UiFlags::NONE)
-	    : UiItemBase(UI_ART_TEXT_BUTTON, rect, flags)
+	    : UiItemBase(UiType::UI_ART_TEXT_BUTTON, rect, flags)
 	    , m_text(text)
 	    , m_action(action)
 	{
@@ -216,7 +216,7 @@ public:
 class UiEdit : public UiItemBase {
 public:
 	UiEdit(const char *hint, char *value, std::size_t max_length, SDL_Rect rect, UiFlags flags = UiFlags::NONE)
-	    : UiItemBase(UI_EDIT, rect, flags)
+	    : UiItemBase(UiType::UI_EDIT, rect, flags)
 	    , m_hint(hint)
 	    , m_value(value)
 	    , m_max_length(max_length)
@@ -236,7 +236,7 @@ public:
 class UiText : public UiItemBase {
 public:
 	UiText(const char *text, SDL_Rect rect, UiFlags flags = UiFlags::NONE, SDL_Color color = { 243, 243, 243, 0 })
-	    : UiItemBase(UI_TEXT, rect, flags)
+	    : UiItemBase(UiType::UI_TEXT, rect, flags)
 	    , m_color(color)
 	    , m_shadow_color({ 0, 0, 0, 0 })
 	    , m_text(text)
@@ -260,7 +260,7 @@ public:
 class UiButton : public UiItemBase {
 public:
 	UiButton(Art *art, const char *text, void (*action)(), SDL_Rect rect, UiFlags flags = UiFlags::NONE)
-	    : UiItemBase(UI_BUTTON, rect, flags)
+	    : UiItemBase(UiType::UI_BUTTON, rect, flags)
 	    , m_art(art)
 	    , m_text(text)
 	    , m_action(action)
@@ -308,7 +308,7 @@ typedef std::vector<std::unique_ptr<UiListItem>> vUiListItem;
 class UiList : public UiItemBase {
 public:
 	UiList(const vUiListItem &vItems, Sint16 x, Sint16 y, Uint16 item_width, Uint16 item_height, UiFlags flags = UiFlags::NONE)
-	    : UiItemBase(UI_LIST, { x, y, item_width, static_cast<Uint16>(item_height * vItems.size()) }, flags)
+	    : UiItemBase(UiType::UI_LIST, { x, y, item_width, static_cast<Uint16>(item_height * vItems.size()) }, flags)
 	    , m_x(x)
 	    , m_y(y)
 	    , m_width(item_width)

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -12,14 +12,14 @@
 namespace devilution {
 
 enum class UiType {
-	UI_TEXT,
-	UI_ART_TEXT,
-	UI_ART_TEXT_BUTTON,
-	UI_IMAGE,
-	UI_BUTTON,
-	UI_LIST,
-	UI_SCROLLBAR,
-	UI_EDIT,
+	Text,
+	ArtText,
+	ArtTextButton,
+	Image,
+	Button,
+	List,
+	Scrollbar,
+	Edit,
 };
 
 enum class UiFlags {
@@ -120,7 +120,7 @@ public:
 class UiImage : public UiItemBase {
 public:
 	UiImage(Art *art, SDL_Rect rect, UiFlags flags = UiFlags::None, bool animated = false, int frame = 0)
-	    : UiItemBase(UiType::UI_IMAGE, rect, flags)
+	    : UiItemBase(UiType::Image, rect, flags)
 	    , m_art(art)
 	    , m_animated(animated)
 	    , m_frame(frame)
@@ -146,7 +146,7 @@ public:
 	 * @param flags UiFlags controlling color/alignment/size
 	 */
 	UiArtText(const char *text, SDL_Rect rect, UiFlags flags = UiFlags::None)
-	    : UiItemBase(UiType::UI_ART_TEXT, rect, flags)
+	    : UiItemBase(UiType::ArtText, rect, flags)
 	    , m_text(text)
 	{
 	}
@@ -158,7 +158,7 @@ public:
 	 * @param flags UiFlags controlling color/alignment/size
 	 */
 	UiArtText(const char **ptext, SDL_Rect rect, UiFlags flags = UiFlags::None)
-	    : UiItemBase(UiType::UI_ART_TEXT, rect, flags)
+	    : UiItemBase(UiType::ArtText, rect, flags)
 	    , m_ptext(ptext)
 	{
 	}
@@ -179,10 +179,10 @@ private:
 
 //=============================================================================
 
-class UiScrollBar : public UiItemBase {
+class UiScrollbar : public UiItemBase {
 public:
-	UiScrollBar(Art *bg, Art *thumb, Art *arrow, SDL_Rect rect, UiFlags flags = UiFlags::None)
-	    : UiItemBase(UiType::UI_SCROLLBAR, rect, flags)
+	UiScrollbar(Art *bg, Art *thumb, Art *arrow, SDL_Rect rect, UiFlags flags = UiFlags::None)
+	    : UiItemBase(UiType::Scrollbar, rect, flags)
 	    , m_bg(bg)
 	    , m_thumb(thumb)
 	    , m_arrow(arrow)
@@ -200,7 +200,7 @@ public:
 class UiArtTextButton : public UiItemBase {
 public:
 	UiArtTextButton(const char *text, void (*action)(), SDL_Rect rect, UiFlags flags = UiFlags::None)
-	    : UiItemBase(UiType::UI_ART_TEXT_BUTTON, rect, flags)
+	    : UiItemBase(UiType::ArtTextButton, rect, flags)
 	    , m_text(text)
 	    , m_action(action)
 	{
@@ -216,7 +216,7 @@ public:
 class UiEdit : public UiItemBase {
 public:
 	UiEdit(const char *hint, char *value, std::size_t max_length, SDL_Rect rect, UiFlags flags = UiFlags::None)
-	    : UiItemBase(UiType::UI_EDIT, rect, flags)
+	    : UiItemBase(UiType::Edit, rect, flags)
 	    , m_hint(hint)
 	    , m_value(value)
 	    , m_max_length(max_length)
@@ -236,7 +236,7 @@ public:
 class UiText : public UiItemBase {
 public:
 	UiText(const char *text, SDL_Rect rect, UiFlags flags = UiFlags::None, SDL_Color color = { 243, 243, 243, 0 })
-	    : UiItemBase(UiType::UI_TEXT, rect, flags)
+	    : UiItemBase(UiType::Text, rect, flags)
 	    , m_color(color)
 	    , m_shadow_color({ 0, 0, 0, 0 })
 	    , m_text(text)
@@ -260,7 +260,7 @@ public:
 class UiButton : public UiItemBase {
 public:
 	UiButton(Art *art, const char *text, void (*action)(), SDL_Rect rect, UiFlags flags = UiFlags::None)
-	    : UiItemBase(UiType::UI_BUTTON, rect, flags)
+	    : UiItemBase(UiType::Button, rect, flags)
 	    , m_art(art)
 	    , m_text(text)
 	    , m_action(action)
@@ -308,7 +308,7 @@ typedef std::vector<std::unique_ptr<UiListItem>> vUiListItem;
 class UiList : public UiItemBase {
 public:
 	UiList(const vUiListItem &vItems, Sint16 x, Sint16 y, Uint16 item_width, Uint16 item_height, UiFlags flags = UiFlags::None)
-	    : UiItemBase(UiType::UI_LIST, { x, y, item_width, static_cast<Uint16>(item_height * vItems.size()) }, flags)
+	    : UiItemBase(UiType::List, { x, y, item_width, static_cast<Uint16>(item_height * vItems.size()) }, flags)
 	    , m_x(x)
 	    , m_y(y)
 	    , m_width(item_width)

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -24,22 +24,22 @@ enum class UiType {
 
 enum class UiFlags {
 	// clang-format off
-	NONE            = 0,
-	UIS_SMALL       = 1 << 0,
-	UIS_MED         = 1 << 1,
-	UIS_BIG         = 1 << 2,
-	UIS_HUGE        = 1 << 3,
-	UIS_CENTER      = 1 << 4,
-	UIS_RIGHT       = 1 << 5,
-	UIS_VCENTER     = 1 << 6,
-	UIS_SILVER      = 1 << 7,
-	UIS_GOLD        = 1 << 8,
-	UIS_RED         = 1 << 9,
-	UIS_BLUE        = 1 << 10,
-	UIS_BLACK       = 1 << 11,
-	UIS_DISABLED    = 1 << 12,
-	UIS_HIDDEN      = 1 << 13,
-	UIS_FIT_SPACING = 1 << 14,
+	None              = 0,
+	FontSmall         = 1 << 0,
+	FontMedium        = 1 << 1,
+	FontBig           = 1 << 2,
+	FontHuge          = 1 << 3,
+	AlignCenter       = 1 << 4,
+	AlignRight        = 1 << 5,
+	VerticalCenter    = 1 << 6,
+	ColorSilver       = 1 << 7,
+	ColorGold         = 1 << 8,
+	ColorRed          = 1 << 9,
+	ColorBlue         = 1 << 10,
+	ColorBlack        = 1 << 11,
+	ElementDisabled   = 1 << 12,
+	ElementHidden     = 1 << 13,
+	KerningFitSpacing = 1 << 14,
 	// clang-format on
 };
 
@@ -75,7 +75,7 @@ inline UiFlags operator~(UiFlags value)
 
 inline bool HasAnyOf(UiFlags lhs, UiFlags test)
 {
-	return (lhs & test) != UiFlags::NONE;
+	return (lhs & test) != UiFlags::None;
 }
 
 class UiItemBase {
@@ -119,7 +119,7 @@ public:
 
 class UiImage : public UiItemBase {
 public:
-	UiImage(Art *art, SDL_Rect rect, UiFlags flags = UiFlags::NONE, bool animated = false, int frame = 0)
+	UiImage(Art *art, SDL_Rect rect, UiFlags flags = UiFlags::None, bool animated = false, int frame = 0)
 	    : UiItemBase(UiType::UI_IMAGE, rect, flags)
 	    , m_art(art)
 	    , m_animated(animated)
@@ -145,7 +145,7 @@ public:
 	 * @param rect screen region defining the area to draw the text
 	 * @param flags UiFlags controlling color/alignment/size
 	 */
-	UiArtText(const char *text, SDL_Rect rect, UiFlags flags = UiFlags::NONE)
+	UiArtText(const char *text, SDL_Rect rect, UiFlags flags = UiFlags::None)
 	    : UiItemBase(UiType::UI_ART_TEXT, rect, flags)
 	    , m_text(text)
 	{
@@ -157,7 +157,7 @@ public:
 	 * @param rect screen region defining the area to draw the text
 	 * @param flags UiFlags controlling color/alignment/size
 	 */
-	UiArtText(const char **ptext, SDL_Rect rect, UiFlags flags = UiFlags::NONE)
+	UiArtText(const char **ptext, SDL_Rect rect, UiFlags flags = UiFlags::None)
 	    : UiItemBase(UiType::UI_ART_TEXT, rect, flags)
 	    , m_ptext(ptext)
 	{
@@ -181,7 +181,7 @@ private:
 
 class UiScrollBar : public UiItemBase {
 public:
-	UiScrollBar(Art *bg, Art *thumb, Art *arrow, SDL_Rect rect, UiFlags flags = UiFlags::NONE)
+	UiScrollBar(Art *bg, Art *thumb, Art *arrow, SDL_Rect rect, UiFlags flags = UiFlags::None)
 	    : UiItemBase(UiType::UI_SCROLLBAR, rect, flags)
 	    , m_bg(bg)
 	    , m_thumb(thumb)
@@ -199,7 +199,7 @@ public:
 
 class UiArtTextButton : public UiItemBase {
 public:
-	UiArtTextButton(const char *text, void (*action)(), SDL_Rect rect, UiFlags flags = UiFlags::NONE)
+	UiArtTextButton(const char *text, void (*action)(), SDL_Rect rect, UiFlags flags = UiFlags::None)
 	    : UiItemBase(UiType::UI_ART_TEXT_BUTTON, rect, flags)
 	    , m_text(text)
 	    , m_action(action)
@@ -215,7 +215,7 @@ public:
 
 class UiEdit : public UiItemBase {
 public:
-	UiEdit(const char *hint, char *value, std::size_t max_length, SDL_Rect rect, UiFlags flags = UiFlags::NONE)
+	UiEdit(const char *hint, char *value, std::size_t max_length, SDL_Rect rect, UiFlags flags = UiFlags::None)
 	    : UiItemBase(UiType::UI_EDIT, rect, flags)
 	    , m_hint(hint)
 	    , m_value(value)
@@ -235,7 +235,7 @@ public:
 
 class UiText : public UiItemBase {
 public:
-	UiText(const char *text, SDL_Rect rect, UiFlags flags = UiFlags::NONE, SDL_Color color = { 243, 243, 243, 0 })
+	UiText(const char *text, SDL_Rect rect, UiFlags flags = UiFlags::None, SDL_Color color = { 243, 243, 243, 0 })
 	    : UiItemBase(UiType::UI_TEXT, rect, flags)
 	    , m_color(color)
 	    , m_shadow_color({ 0, 0, 0, 0 })
@@ -259,7 +259,7 @@ public:
 
 class UiButton : public UiItemBase {
 public:
-	UiButton(Art *art, const char *text, void (*action)(), SDL_Rect rect, UiFlags flags = UiFlags::NONE)
+	UiButton(Art *art, const char *text, void (*action)(), SDL_Rect rect, UiFlags flags = UiFlags::None)
 	    : UiItemBase(UiType::UI_BUTTON, rect, flags)
 	    , m_art(art)
 	    , m_text(text)
@@ -307,7 +307,7 @@ typedef std::vector<std::unique_ptr<UiListItem>> vUiListItem;
 
 class UiList : public UiItemBase {
 public:
-	UiList(const vUiListItem &vItems, Sint16 x, Sint16 y, Uint16 item_width, Uint16 item_height, UiFlags flags = UiFlags::NONE)
+	UiList(const vUiListItem &vItems, Sint16 x, Sint16 y, Uint16 item_width, Uint16 item_height, UiFlags flags = UiFlags::None)
 	    : UiItemBase(UiType::UI_LIST, { x, y, item_width, static_cast<Uint16>(item_height * vItems.size()) }, flags)
 	    , m_x(x)
 	    , m_y(y)

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -48,7 +48,7 @@ bool chrbtnactive;
 int pnumlines;
 bool pinfoflag;
 spell_id pSpell;
-uint16_t infoclr;
+UiFlags InfoColor;
 char tempstr[256];
 int sbooktab;
 spell_type pSplType;
@@ -309,9 +309,9 @@ void PrintSBookHotkey(const Surface &out, Point position, const std::string &tex
 	position += Displacement { SPLICONLENGTH - (GetLineWidth(text.c_str()) + 5), 17 - SPLICONLENGTH };
 
 	// Draw a drop shadow below and to the left of the text
-	DrawString(out, text.c_str(), position + Displacement { -1, 1 }, UIS_BLACK);
+	DrawString(out, text.c_str(), position + Displacement { -1, 1 }, UiFlags::UIS_BLACK);
 	// Then draw the text over the top
-	DrawString(out, text.c_str(), position, UIS_SILVER);
+	DrawString(out, text.c_str(), position, UiFlags::UIS_SILVER);
 }
 
 /**
@@ -403,14 +403,14 @@ void PrintInfo(const Surface &out)
 	int yo = 0;
 	int lo = 1;
 	if (infostr[0] != '\0') {
-		DrawString(out, infostr, line, infoclr | UIS_CENTER | UIS_FIT_SPACING, 2);
+		DrawString(out, infostr, line, InfoColor | UiFlags::UIS_CENTER | UiFlags::UIS_FIT_SPACING, 2);
 		yo = 1;
 		lo = 0;
 	}
 
 	for (int i = 0; i < pnumlines; i++) {
 		line.position.y = PANEL_Y + LineOffsets[pnumlines - lo][i + yo];
-		DrawString(out, panelstr[i], line, infoclr | UIS_CENTER | UIS_FIT_SPACING, 2);
+		DrawString(out, panelstr[i], line, InfoColor | UiFlags::UIS_CENTER | UiFlags::UIS_FIT_SPACING, 2);
 	}
 }
 
@@ -457,7 +457,7 @@ int DrawDurIcon4Item(const Surface &out, ItemStruct *pItem, int x, int c)
 
 void PrintSBookStr(const Surface &out, Point position, const char *text)
 {
-	DrawString(out, text, { { RIGHT_PANEL_X + SPLICONLENGTH + position.x, position.y }, { 222, 0 } }, UIS_SILVER);
+	DrawString(out, text, { { RIGHT_PANEL_X + SPLICONLENGTH + position.x, position.y }, { 222, 0 } }, UiFlags::UIS_SILVER);
 }
 
 spell_type GetSBookTrans(spell_id ii, bool townok)
@@ -1084,14 +1084,14 @@ void CheckPanelInfo()
 				strcpy(tempstr, fmt::format(_("Hotkey: {:s}"), _(PanBtnHotKey[i])).c_str());
 				AddPanelString(tempstr);
 			}
-			infoclr = UIS_SILVER;
+			InfoColor = UiFlags::UIS_SILVER;
 			panelflag = true;
 			pinfoflag = true;
 		}
 	}
 	if (!spselflag && MousePosition.x >= 565 + PANEL_LEFT && MousePosition.x < 621 + PANEL_LEFT && MousePosition.y >= 64 + PANEL_TOP && MousePosition.y < 120 + PANEL_TOP) {
 		strcpy(infostr, _("Select current spell button"));
-		infoclr = UIS_SILVER;
+		InfoColor = UiFlags::UIS_SILVER;
 		panelflag = true;
 		pinfoflag = true;
 		strcpy(tempstr, _("Hotkey: 's'"));
@@ -1257,11 +1257,11 @@ void DrawInfoBox(const Surface &out)
 	DrawPanelBox(out, { 177, 62, 288, 60 }, { PANEL_X + 177, PANEL_Y + 46 });
 	if (!panelflag && !trigflag && pcursinvitem == -1 && !spselflag) {
 		infostr[0] = '\0';
-		infoclr = UIS_SILVER;
+		InfoColor = UiFlags::UIS_SILVER;
 		ClearPanel();
 	}
 	if (spselflag || trigflag) {
-		infoclr = UIS_SILVER;
+		InfoColor = UiFlags::UIS_SILVER;
 	} else if (pcurs >= CURSOR_FIRSTITEM) {
 		auto &myPlayer = Players[MyPlayerId];
 		if (myPlayer.HoldItem._itype == ITYPE_GOLD) {
@@ -1276,7 +1276,7 @@ void DrawInfoBox(const Surface &out)
 				strcpy(infostr, myPlayer.HoldItem._iIName);
 			else
 				strcpy(infostr, myPlayer.HoldItem._iName);
-			infoclr = myPlayer.HoldItem.getTextColor();
+			InfoColor = myPlayer.HoldItem.getTextColor();
 		}
 	} else {
 		if (pcursitem != -1)
@@ -1286,11 +1286,11 @@ void DrawInfoBox(const Surface &out)
 		if (pcursmonst != -1) {
 			const auto &monster = Monsters[pcursmonst];
 			if (leveltype != DTYPE_TOWN) {
-				infoclr = UIS_SILVER;
+				InfoColor = UiFlags::UIS_SILVER;
 				strcpy(infostr, _(monster.mName));
 				ClearPanel();
 				if (monster._uniqtype != 0) {
-					infoclr = UIS_GOLD;
+					InfoColor = UiFlags::UIS_GOLD;
 					PrintUniqueHistory();
 				} else {
 					PrintMonstHistory(monster.MType->mtype);
@@ -1302,7 +1302,7 @@ void DrawInfoBox(const Surface &out)
 			}
 		}
 		if (pcursplr != -1) {
-			infoclr = UIS_GOLD;
+			InfoColor = UiFlags::UIS_GOLD;
 			auto &target = Players[pcursplr];
 			strcpy(infostr, target._pName);
 			ClearPanel();
@@ -1318,55 +1318,55 @@ void DrawInfoBox(const Surface &out)
 
 void DrawChr(const Surface &out)
 {
-	uint32_t style = UIS_SILVER;
+	UiFlags style = UiFlags::UIS_SILVER;
 	char chrstr[64];
 
 	auto &myPlayer = Players[MyPlayerId];
 
 	CelDrawTo(out, { 0, 351 }, *pChrPanel, 1);
-	DrawString(out, myPlayer._pName, { { 20, 32 }, { 131, 0 } }, UIS_SILVER | UIS_CENTER);
+	DrawString(out, myPlayer._pName, { { 20, 32 }, { 131, 0 } }, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER);
 
-	DrawString(out, _(ClassStrTbl[static_cast<std::size_t>(myPlayer._pClass)]), { { 168, 32 }, { 131, 0 } }, UIS_SILVER | UIS_CENTER);
+	DrawString(out, _(ClassStrTbl[static_cast<std::size_t>(myPlayer._pClass)]), { { 168, 32 }, { 131, 0 } }, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER);
 
 	sprintf(chrstr, "%i", myPlayer._pLevel);
-	DrawString(out, chrstr, { { 66, 69 }, { 43, 0 } }, UIS_SILVER | UIS_CENTER);
+	DrawString(out, chrstr, { { 66, 69 }, { 43, 0 } }, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER);
 
 	sprintf(chrstr, "%i", myPlayer._pExperience);
-	DrawString(out, chrstr, { { 216, 69 }, { 84, 0 } }, UIS_SILVER | UIS_CENTER);
+	DrawString(out, chrstr, { { 216, 69 }, { 84, 0 } }, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER);
 
 	if (myPlayer._pLevel == MAXCHARLEVEL - 1) {
 		strcpy(chrstr, _("None"));
-		style = UIS_GOLD;
+		style = UiFlags::UIS_GOLD;
 	} else {
 		sprintf(chrstr, "%i", myPlayer._pNextExper);
-		style = UIS_SILVER;
+		style = UiFlags::UIS_SILVER;
 	}
-	DrawString(out, chrstr, { { 216, 97 }, { 84, 0 } }, style | UIS_CENTER);
+	DrawString(out, chrstr, { { 216, 97 }, { 84, 0 } }, style | UiFlags::UIS_CENTER);
 
 	sprintf(chrstr, "%i", myPlayer._pGold);
-	DrawString(out, chrstr, { { 216, 146 }, { 84, 0 } }, UIS_SILVER | UIS_CENTER);
+	DrawString(out, chrstr, { { 216, 146 }, { 84, 0 } }, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER);
 
-	style = UIS_SILVER;
+	style = UiFlags::UIS_SILVER;
 	if (myPlayer._pIBonusAC > 0)
-		style = UIS_BLUE;
+		style = UiFlags::UIS_BLUE;
 	if (myPlayer._pIBonusAC < 0)
-		style = UIS_RED;
+		style = UiFlags::UIS_RED;
 	sprintf(chrstr, "%i", myPlayer._pIBonusAC + myPlayer._pIAC + myPlayer._pDexterity / 5);
-	DrawString(out, chrstr, { { 258, 183 }, { 43, 0 } }, style | UIS_CENTER);
+	DrawString(out, chrstr, { { 258, 183 }, { 43, 0 } }, style | UiFlags::UIS_CENTER);
 
-	style = UIS_SILVER;
+	style = UiFlags::UIS_SILVER;
 	if (myPlayer._pIBonusToHit > 0)
-		style = UIS_BLUE;
+		style = UiFlags::UIS_BLUE;
 	if (myPlayer._pIBonusToHit < 0)
-		style = UIS_RED;
+		style = UiFlags::UIS_RED;
 	sprintf(chrstr, "%i%%", (myPlayer._pDexterity / 2) + myPlayer._pIBonusToHit + 50);
-	DrawString(out, chrstr, { { 258, 211 }, { 43, 0 } }, style | UIS_CENTER);
+	DrawString(out, chrstr, { { 258, 211 }, { 43, 0 } }, style | UiFlags::UIS_CENTER);
 
-	style = UIS_SILVER;
+	style = UiFlags::UIS_SILVER;
 	if (myPlayer._pIBonusDam > 0)
-		style = UIS_BLUE;
+		style = UiFlags::UIS_BLUE;
 	if (myPlayer._pIBonusDam < 0)
-		style = UIS_RED;
+		style = UiFlags::UIS_RED;
 	int mindam = myPlayer._pIMinDam;
 	mindam += myPlayer._pIBonusDam * mindam / 100;
 	mindam += myPlayer._pIBonusDamMod;
@@ -1391,98 +1391,98 @@ void DrawChr(const Surface &out)
 	}
 	sprintf(chrstr, "%i-%i", mindam, maxdam);
 	if (mindam >= 100 || maxdam >= 100)
-		DrawString(out, chrstr, { { 254, 239 }, { 51, 0 } }, style | UIS_CENTER, -1);
+		DrawString(out, chrstr, { { 254, 239 }, { 51, 0 } }, style | UiFlags::UIS_CENTER, -1);
 	else
-		DrawString(out, chrstr, { { 258, 239 }, { 43, 0 } }, style | UIS_CENTER, 0);
+		DrawString(out, chrstr, { { 258, 239 }, { 43, 0 } }, style | UiFlags::UIS_CENTER, 0);
 
-	style = UIS_BLUE;
+	style = UiFlags::UIS_BLUE;
 	if (myPlayer._pMagResist == 0)
-		style = UIS_SILVER;
+		style = UiFlags::UIS_SILVER;
 	if (myPlayer._pMagResist < MAXRESIST) {
 		sprintf(chrstr, "%i%%", myPlayer._pMagResist);
 	} else {
-		style = UIS_GOLD;
+		style = UiFlags::UIS_GOLD;
 		strcpy(chrstr, _(/* TRANSLATORS: UI Constrains. Keep translation short please!*/ "MAX"));
 	}
-	DrawString(out, chrstr, { { 257, 276 }, { 43, 0 } }, style | UIS_CENTER);
+	DrawString(out, chrstr, { { 257, 276 }, { 43, 0 } }, style | UiFlags::UIS_CENTER);
 
-	style = UIS_BLUE;
+	style = UiFlags::UIS_BLUE;
 	if (myPlayer._pFireResist == 0)
-		style = UIS_SILVER;
+		style = UiFlags::UIS_SILVER;
 	if (myPlayer._pFireResist < MAXRESIST) {
 		sprintf(chrstr, "%i%%", myPlayer._pFireResist);
 	} else {
-		style = UIS_GOLD;
+		style = UiFlags::UIS_GOLD;
 		strcpy(chrstr, _("MAX"));
 	}
-	DrawString(out, chrstr, { { 257, 304 }, { 43, 0 } }, style | UIS_CENTER);
+	DrawString(out, chrstr, { { 257, 304 }, { 43, 0 } }, style | UiFlags::UIS_CENTER);
 
-	style = UIS_BLUE;
+	style = UiFlags::UIS_BLUE;
 	if (myPlayer._pLghtResist == 0)
-		style = UIS_SILVER;
+		style = UiFlags::UIS_SILVER;
 	if (myPlayer._pLghtResist < MAXRESIST) {
 		sprintf(chrstr, "%i%%", myPlayer._pLghtResist);
 	} else {
-		style = UIS_GOLD;
+		style = UiFlags::UIS_GOLD;
 		strcpy(chrstr, _("MAX"));
 	}
-	DrawString(out, chrstr, { { 257, 332 }, { 43, 0 } }, style | UIS_CENTER);
+	DrawString(out, chrstr, { { 257, 332 }, { 43, 0 } }, style | UiFlags::UIS_CENTER);
 
-	style = UIS_SILVER;
+	style = UiFlags::UIS_SILVER;
 	sprintf(chrstr, "%i", myPlayer._pBaseStr);
 	if (myPlayer.GetMaximumAttributeValue(CharacterAttribute::Strength) == myPlayer._pBaseStr)
-		style = UIS_GOLD;
-	DrawString(out, chrstr, { { 95, 155 }, { 31, 0 } }, style | UIS_CENTER);
+		style = UiFlags::UIS_GOLD;
+	DrawString(out, chrstr, { { 95, 155 }, { 31, 0 } }, style | UiFlags::UIS_CENTER);
 
-	style = UIS_SILVER;
+	style = UiFlags::UIS_SILVER;
 	sprintf(chrstr, "%i", myPlayer._pBaseMag);
 	if (myPlayer.GetMaximumAttributeValue(CharacterAttribute::Magic) == myPlayer._pBaseMag)
-		style = UIS_GOLD;
-	DrawString(out, chrstr, { { 95, 183 }, { 31, 0 } }, style | UIS_CENTER);
+		style = UiFlags::UIS_GOLD;
+	DrawString(out, chrstr, { { 95, 183 }, { 31, 0 } }, style | UiFlags::UIS_CENTER);
 
-	style = UIS_SILVER;
+	style = UiFlags::UIS_SILVER;
 	sprintf(chrstr, "%i", myPlayer._pBaseDex);
 	if (myPlayer.GetMaximumAttributeValue(CharacterAttribute::Dexterity) == myPlayer._pBaseDex)
-		style = UIS_GOLD;
-	DrawString(out, chrstr, { { 95, 211 }, { 31, 0 } }, style | UIS_CENTER);
+		style = UiFlags::UIS_GOLD;
+	DrawString(out, chrstr, { { 95, 211 }, { 31, 0 } }, style | UiFlags::UIS_CENTER);
 
-	style = UIS_SILVER;
+	style = UiFlags::UIS_SILVER;
 	sprintf(chrstr, "%i", myPlayer._pBaseVit);
 	if (myPlayer.GetMaximumAttributeValue(CharacterAttribute::Vitality) == myPlayer._pBaseVit)
-		style = UIS_GOLD;
-	DrawString(out, chrstr, { { 95, 239 }, { 31, 0 } }, style | UIS_CENTER);
+		style = UiFlags::UIS_GOLD;
+	DrawString(out, chrstr, { { 95, 239 }, { 31, 0 } }, style | UiFlags::UIS_CENTER);
 
-	style = UIS_SILVER;
+	style = UiFlags::UIS_SILVER;
 	if (myPlayer._pStrength > myPlayer._pBaseStr)
-		style = UIS_BLUE;
+		style = UiFlags::UIS_BLUE;
 	if (myPlayer._pStrength < myPlayer._pBaseStr)
-		style = UIS_RED;
+		style = UiFlags::UIS_RED;
 	sprintf(chrstr, "%i", myPlayer._pStrength);
-	DrawString(out, chrstr, { { 143, 155 }, { 30, 0 } }, style | UIS_CENTER);
+	DrawString(out, chrstr, { { 143, 155 }, { 30, 0 } }, style | UiFlags::UIS_CENTER);
 
-	style = UIS_SILVER;
+	style = UiFlags::UIS_SILVER;
 	if (myPlayer._pMagic > myPlayer._pBaseMag)
-		style = UIS_BLUE;
+		style = UiFlags::UIS_BLUE;
 	if (myPlayer._pMagic < myPlayer._pBaseMag)
-		style = UIS_RED;
+		style = UiFlags::UIS_RED;
 	sprintf(chrstr, "%i", myPlayer._pMagic);
-	DrawString(out, chrstr, { { 143, 183 }, { 30, 0 } }, style | UIS_CENTER);
+	DrawString(out, chrstr, { { 143, 183 }, { 30, 0 } }, style | UiFlags::UIS_CENTER);
 
-	style = UIS_SILVER;
+	style = UiFlags::UIS_SILVER;
 	if (myPlayer._pDexterity > myPlayer._pBaseDex)
-		style = UIS_BLUE;
+		style = UiFlags::UIS_BLUE;
 	if (myPlayer._pDexterity < myPlayer._pBaseDex)
-		style = UIS_RED;
+		style = UiFlags::UIS_RED;
 	sprintf(chrstr, "%i", myPlayer._pDexterity);
-	DrawString(out, chrstr, { { 143, 211 }, { 30, 0 } }, style | UIS_CENTER);
+	DrawString(out, chrstr, { { 143, 211 }, { 30, 0 } }, style | UiFlags::UIS_CENTER);
 
-	style = UIS_SILVER;
+	style = UiFlags::UIS_SILVER;
 	if (myPlayer._pVitality > myPlayer._pBaseVit)
-		style = UIS_BLUE;
+		style = UiFlags::UIS_BLUE;
 	if (myPlayer._pVitality < myPlayer._pBaseVit)
-		style = UIS_RED;
+		style = UiFlags::UIS_RED;
 	sprintf(chrstr, "%i", myPlayer._pVitality);
-	DrawString(out, chrstr, { { 143, 239 }, { 30, 0 } }, style | UIS_CENTER);
+	DrawString(out, chrstr, { { 143, 239 }, { 30, 0 } }, style | UiFlags::UIS_CENTER);
 
 	if (myPlayer._pStatPts > 0) {
 		if (CalcStatDiff(myPlayer) < myPlayer._pStatPts) {
@@ -1491,7 +1491,7 @@ void DrawChr(const Surface &out)
 	}
 	if (myPlayer._pStatPts > 0) {
 		sprintf(chrstr, "%i", myPlayer._pStatPts);
-		DrawString(out, chrstr, { { 95, 266 }, { 31, 0 } }, UIS_RED | UIS_CENTER);
+		DrawString(out, chrstr, { { 95, 266 }, { 31, 0 } }, UiFlags::UIS_RED | UiFlags::UIS_CENTER);
 		if (myPlayer._pBaseStr < myPlayer.GetMaximumAttributeValue(CharacterAttribute::Strength))
 			CelDrawTo(out, { 137, 159 }, *pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Strength)] ? 3 : 2);
 		if (myPlayer._pBaseMag < myPlayer.GetMaximumAttributeValue(CharacterAttribute::Magic))
@@ -1502,25 +1502,25 @@ void DrawChr(const Surface &out)
 			CelDrawTo(out, { 137, 244 }, *pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Vitality)] ? 9 : 8);
 	}
 
-	style = UIS_SILVER;
+	style = UiFlags::UIS_SILVER;
 	if (myPlayer._pMaxHP > myPlayer._pMaxHPBase)
-		style = UIS_BLUE;
+		style = UiFlags::UIS_BLUE;
 	sprintf(chrstr, "%i", myPlayer._pMaxHP >> 6);
-	DrawString(out, chrstr, { { 95, 304 }, { 31, 0 } }, style | UIS_CENTER);
+	DrawString(out, chrstr, { { 95, 304 }, { 31, 0 } }, style | UiFlags::UIS_CENTER);
 	if (myPlayer._pHitPoints != myPlayer._pMaxHP)
-		style = UIS_RED;
+		style = UiFlags::UIS_RED;
 	sprintf(chrstr, "%i", myPlayer._pHitPoints >> 6);
-	DrawString(out, chrstr, { { 143, 304 }, { 31, 0 } }, style | UIS_CENTER);
+	DrawString(out, chrstr, { { 143, 304 }, { 31, 0 } }, style | UiFlags::UIS_CENTER);
 
-	style = UIS_SILVER;
+	style = UiFlags::UIS_SILVER;
 	if (myPlayer._pMaxMana > myPlayer._pMaxManaBase)
-		style = UIS_BLUE;
+		style = UiFlags::UIS_BLUE;
 	sprintf(chrstr, "%i", myPlayer._pMaxMana >> 6);
-	DrawString(out, chrstr, { { 95, 332 }, { 31, 0 } }, style | UIS_CENTER);
+	DrawString(out, chrstr, { { 95, 332 }, { 31, 0 } }, style | UiFlags::UIS_CENTER);
 	if (myPlayer._pMana != myPlayer._pMaxMana)
-		style = UIS_RED;
+		style = UiFlags::UIS_RED;
 	sprintf(chrstr, "%i", myPlayer._pMana >> 6);
-	DrawString(out, chrstr, { { 143, 332 }, { 31, 0 } }, style | UIS_CENTER);
+	DrawString(out, chrstr, { { 143, 332 }, { 31, 0 } }, style | UiFlags::UIS_CENTER);
 }
 
 void CheckLvlBtn()
@@ -1540,7 +1540,7 @@ void DrawLevelUpIcon(const Surface &out)
 {
 	if (stextflag == STORE_NONE) {
 		int nCel = lvlbtndown ? 3 : 2;
-		DrawString(out, _("Level Up"), { { PANEL_LEFT + 0, PANEL_TOP - 49 }, { 120, 0 } }, UIS_SILVER | UIS_CENTER);
+		DrawString(out, _("Level Up"), { { PANEL_LEFT + 0, PANEL_TOP - 49 }, { 120, 0 } }, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER);
 		CelDrawTo(out, { 40 + PANEL_X, -17 + PANEL_Y }, *pChrButtons, nCel);
 	}
 }
@@ -1776,7 +1776,7 @@ void DrawGoldSplit(const Surface &out, int amount)
 	// The split gold dialog is roughly 4 lines high, but we need at least one line for the player to input an amount.
 	// Using a clipping region 50 units high (approx 3 lines with a lineheight of 17) to ensure there is enough room left
 	//  for the text entered by the player.
-	DrawString(out, tempstr, { { dialogX + 31, 87 }, { 200, 50 } }, UIS_GOLD | UIS_CENTER, 1, 17);
+	DrawString(out, tempstr, { { dialogX + 31, 87 }, { 200, 50 } }, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, 1, 17);
 
 	tempstr[0] = '\0';
 	if (amount > 0) {
@@ -1785,7 +1785,7 @@ void DrawGoldSplit(const Surface &out, int amount)
 	}
 	// Even a ten digit amount of gold only takes up about half a line. There's no need to wrap or clip text here so we
 	// use the Point form of DrawString.
-	DrawString(out, tempstr, Point { dialogX + 37, 140 }, UIS_SILVER, 1, -1, true);
+	DrawString(out, tempstr, Point { dialogX + 37, 140 }, UiFlags::UIS_SILVER, 1, -1, true);
 }
 
 void control_drop_gold(char vkey)
@@ -1843,7 +1843,7 @@ void DrawTalkPan(const Surface &out)
 	int x = PANEL_LEFT + 200;
 	int y = PANEL_Y + 22;
 
-	int idx = DrawString(out, msg, { { x, y }, { 250, 39 } }, UIS_SILVER, 1, 13, true);
+	int idx = DrawString(out, msg, { { x, y }, { 250, 39 } }, UiFlags::UIS_SILVER, 1, 13, true);
 	msg[idx] = '\0';
 
 	x += 46;
@@ -1852,10 +1852,10 @@ void DrawTalkPan(const Surface &out)
 		if (i == MyPlayerId)
 			continue;
 
-		uint16_t color = UIS_RED;
+		UiFlags color = UiFlags::UIS_RED;
 		const Point talkPanPosition { 172 + PANEL_X, 84 + 18 * talkBtn + PANEL_Y };
 		if (WhisperList[i]) {
-			color = UIS_GOLD;
+			color = UiFlags::UIS_GOLD;
 			if (TalkButtonsDown[talkBtn]) {
 				int nCel = talkBtn != 0 ? 4 : 3;
 				CelDrawTo(out, talkPanPosition, *talkButtons, nCel);

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -309,9 +309,9 @@ void PrintSBookHotkey(const Surface &out, Point position, const std::string &tex
 	position += Displacement { SPLICONLENGTH - (GetLineWidth(text.c_str()) + 5), 17 - SPLICONLENGTH };
 
 	// Draw a drop shadow below and to the left of the text
-	DrawString(out, text.c_str(), position + Displacement { -1, 1 }, UiFlags::UIS_BLACK);
+	DrawString(out, text.c_str(), position + Displacement { -1, 1 }, UiFlags::ColorBlack);
 	// Then draw the text over the top
-	DrawString(out, text.c_str(), position, UiFlags::UIS_SILVER);
+	DrawString(out, text.c_str(), position, UiFlags::ColorSilver);
 }
 
 /**
@@ -403,14 +403,14 @@ void PrintInfo(const Surface &out)
 	int yo = 0;
 	int lo = 1;
 	if (infostr[0] != '\0') {
-		DrawString(out, infostr, line, InfoColor | UiFlags::UIS_CENTER | UiFlags::UIS_FIT_SPACING, 2);
+		DrawString(out, infostr, line, InfoColor | UiFlags::AlignCenter | UiFlags::KerningFitSpacing, 2);
 		yo = 1;
 		lo = 0;
 	}
 
 	for (int i = 0; i < pnumlines; i++) {
 		line.position.y = PANEL_Y + LineOffsets[pnumlines - lo][i + yo];
-		DrawString(out, panelstr[i], line, InfoColor | UiFlags::UIS_CENTER | UiFlags::UIS_FIT_SPACING, 2);
+		DrawString(out, panelstr[i], line, InfoColor | UiFlags::AlignCenter | UiFlags::KerningFitSpacing, 2);
 	}
 }
 
@@ -457,7 +457,7 @@ int DrawDurIcon4Item(const Surface &out, ItemStruct *pItem, int x, int c)
 
 void PrintSBookStr(const Surface &out, Point position, const char *text)
 {
-	DrawString(out, text, { { RIGHT_PANEL_X + SPLICONLENGTH + position.x, position.y }, { 222, 0 } }, UiFlags::UIS_SILVER);
+	DrawString(out, text, { { RIGHT_PANEL_X + SPLICONLENGTH + position.x, position.y }, { 222, 0 } }, UiFlags::ColorSilver);
 }
 
 spell_type GetSBookTrans(spell_id ii, bool townok)
@@ -1084,14 +1084,14 @@ void CheckPanelInfo()
 				strcpy(tempstr, fmt::format(_("Hotkey: {:s}"), _(PanBtnHotKey[i])).c_str());
 				AddPanelString(tempstr);
 			}
-			InfoColor = UiFlags::UIS_SILVER;
+			InfoColor = UiFlags::ColorSilver;
 			panelflag = true;
 			pinfoflag = true;
 		}
 	}
 	if (!spselflag && MousePosition.x >= 565 + PANEL_LEFT && MousePosition.x < 621 + PANEL_LEFT && MousePosition.y >= 64 + PANEL_TOP && MousePosition.y < 120 + PANEL_TOP) {
 		strcpy(infostr, _("Select current spell button"));
-		InfoColor = UiFlags::UIS_SILVER;
+		InfoColor = UiFlags::ColorSilver;
 		panelflag = true;
 		pinfoflag = true;
 		strcpy(tempstr, _("Hotkey: 's'"));
@@ -1257,11 +1257,11 @@ void DrawInfoBox(const Surface &out)
 	DrawPanelBox(out, { 177, 62, 288, 60 }, { PANEL_X + 177, PANEL_Y + 46 });
 	if (!panelflag && !trigflag && pcursinvitem == -1 && !spselflag) {
 		infostr[0] = '\0';
-		InfoColor = UiFlags::UIS_SILVER;
+		InfoColor = UiFlags::ColorSilver;
 		ClearPanel();
 	}
 	if (spselflag || trigflag) {
-		InfoColor = UiFlags::UIS_SILVER;
+		InfoColor = UiFlags::ColorSilver;
 	} else if (pcurs >= CURSOR_FIRSTITEM) {
 		auto &myPlayer = Players[MyPlayerId];
 		if (myPlayer.HoldItem._itype == ITYPE_GOLD) {
@@ -1286,11 +1286,11 @@ void DrawInfoBox(const Surface &out)
 		if (pcursmonst != -1) {
 			const auto &monster = Monsters[pcursmonst];
 			if (leveltype != DTYPE_TOWN) {
-				InfoColor = UiFlags::UIS_SILVER;
+				InfoColor = UiFlags::ColorSilver;
 				strcpy(infostr, _(monster.mName));
 				ClearPanel();
 				if (monster._uniqtype != 0) {
-					InfoColor = UiFlags::UIS_GOLD;
+					InfoColor = UiFlags::ColorGold;
 					PrintUniqueHistory();
 				} else {
 					PrintMonstHistory(monster.MType->mtype);
@@ -1302,7 +1302,7 @@ void DrawInfoBox(const Surface &out)
 			}
 		}
 		if (pcursplr != -1) {
-			InfoColor = UiFlags::UIS_GOLD;
+			InfoColor = UiFlags::ColorGold;
 			auto &target = Players[pcursplr];
 			strcpy(infostr, target._pName);
 			ClearPanel();
@@ -1318,55 +1318,55 @@ void DrawInfoBox(const Surface &out)
 
 void DrawChr(const Surface &out)
 {
-	UiFlags style = UiFlags::UIS_SILVER;
+	UiFlags style = UiFlags::ColorSilver;
 	char chrstr[64];
 
 	auto &myPlayer = Players[MyPlayerId];
 
 	CelDrawTo(out, { 0, 351 }, *pChrPanel, 1);
-	DrawString(out, myPlayer._pName, { { 20, 32 }, { 131, 0 } }, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER);
+	DrawString(out, myPlayer._pName, { { 20, 32 }, { 131, 0 } }, UiFlags::ColorSilver | UiFlags::AlignCenter);
 
-	DrawString(out, _(ClassStrTbl[static_cast<std::size_t>(myPlayer._pClass)]), { { 168, 32 }, { 131, 0 } }, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER);
+	DrawString(out, _(ClassStrTbl[static_cast<std::size_t>(myPlayer._pClass)]), { { 168, 32 }, { 131, 0 } }, UiFlags::ColorSilver | UiFlags::AlignCenter);
 
 	sprintf(chrstr, "%i", myPlayer._pLevel);
-	DrawString(out, chrstr, { { 66, 69 }, { 43, 0 } }, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 66, 69 }, { 43, 0 } }, UiFlags::ColorSilver | UiFlags::AlignCenter);
 
 	sprintf(chrstr, "%i", myPlayer._pExperience);
-	DrawString(out, chrstr, { { 216, 69 }, { 84, 0 } }, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 216, 69 }, { 84, 0 } }, UiFlags::ColorSilver | UiFlags::AlignCenter);
 
 	if (myPlayer._pLevel == MAXCHARLEVEL - 1) {
 		strcpy(chrstr, _("None"));
-		style = UiFlags::UIS_GOLD;
+		style = UiFlags::ColorGold;
 	} else {
 		sprintf(chrstr, "%i", myPlayer._pNextExper);
-		style = UiFlags::UIS_SILVER;
+		style = UiFlags::ColorSilver;
 	}
-	DrawString(out, chrstr, { { 216, 97 }, { 84, 0 } }, style | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 216, 97 }, { 84, 0 } }, style | UiFlags::AlignCenter);
 
 	sprintf(chrstr, "%i", myPlayer._pGold);
-	DrawString(out, chrstr, { { 216, 146 }, { 84, 0 } }, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 216, 146 }, { 84, 0 } }, UiFlags::ColorSilver | UiFlags::AlignCenter);
 
-	style = UiFlags::UIS_SILVER;
+	style = UiFlags::ColorSilver;
 	if (myPlayer._pIBonusAC > 0)
-		style = UiFlags::UIS_BLUE;
+		style = UiFlags::ColorBlue;
 	if (myPlayer._pIBonusAC < 0)
-		style = UiFlags::UIS_RED;
+		style = UiFlags::ColorRed;
 	sprintf(chrstr, "%i", myPlayer._pIBonusAC + myPlayer._pIAC + myPlayer._pDexterity / 5);
-	DrawString(out, chrstr, { { 258, 183 }, { 43, 0 } }, style | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 258, 183 }, { 43, 0 } }, style | UiFlags::AlignCenter);
 
-	style = UiFlags::UIS_SILVER;
+	style = UiFlags::ColorSilver;
 	if (myPlayer._pIBonusToHit > 0)
-		style = UiFlags::UIS_BLUE;
+		style = UiFlags::ColorBlue;
 	if (myPlayer._pIBonusToHit < 0)
-		style = UiFlags::UIS_RED;
+		style = UiFlags::ColorRed;
 	sprintf(chrstr, "%i%%", (myPlayer._pDexterity / 2) + myPlayer._pIBonusToHit + 50);
-	DrawString(out, chrstr, { { 258, 211 }, { 43, 0 } }, style | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 258, 211 }, { 43, 0 } }, style | UiFlags::AlignCenter);
 
-	style = UiFlags::UIS_SILVER;
+	style = UiFlags::ColorSilver;
 	if (myPlayer._pIBonusDam > 0)
-		style = UiFlags::UIS_BLUE;
+		style = UiFlags::ColorBlue;
 	if (myPlayer._pIBonusDam < 0)
-		style = UiFlags::UIS_RED;
+		style = UiFlags::ColorRed;
 	int mindam = myPlayer._pIMinDam;
 	mindam += myPlayer._pIBonusDam * mindam / 100;
 	mindam += myPlayer._pIBonusDamMod;
@@ -1391,98 +1391,98 @@ void DrawChr(const Surface &out)
 	}
 	sprintf(chrstr, "%i-%i", mindam, maxdam);
 	if (mindam >= 100 || maxdam >= 100)
-		DrawString(out, chrstr, { { 254, 239 }, { 51, 0 } }, style | UiFlags::UIS_CENTER, -1);
+		DrawString(out, chrstr, { { 254, 239 }, { 51, 0 } }, style | UiFlags::AlignCenter, -1);
 	else
-		DrawString(out, chrstr, { { 258, 239 }, { 43, 0 } }, style | UiFlags::UIS_CENTER, 0);
+		DrawString(out, chrstr, { { 258, 239 }, { 43, 0 } }, style | UiFlags::AlignCenter, 0);
 
-	style = UiFlags::UIS_BLUE;
+	style = UiFlags::ColorBlue;
 	if (myPlayer._pMagResist == 0)
-		style = UiFlags::UIS_SILVER;
+		style = UiFlags::ColorSilver;
 	if (myPlayer._pMagResist < MAXRESIST) {
 		sprintf(chrstr, "%i%%", myPlayer._pMagResist);
 	} else {
-		style = UiFlags::UIS_GOLD;
+		style = UiFlags::ColorGold;
 		strcpy(chrstr, _(/* TRANSLATORS: UI Constrains. Keep translation short please!*/ "MAX"));
 	}
-	DrawString(out, chrstr, { { 257, 276 }, { 43, 0 } }, style | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 257, 276 }, { 43, 0 } }, style | UiFlags::AlignCenter);
 
-	style = UiFlags::UIS_BLUE;
+	style = UiFlags::ColorBlue;
 	if (myPlayer._pFireResist == 0)
-		style = UiFlags::UIS_SILVER;
+		style = UiFlags::ColorSilver;
 	if (myPlayer._pFireResist < MAXRESIST) {
 		sprintf(chrstr, "%i%%", myPlayer._pFireResist);
 	} else {
-		style = UiFlags::UIS_GOLD;
+		style = UiFlags::ColorGold;
 		strcpy(chrstr, _("MAX"));
 	}
-	DrawString(out, chrstr, { { 257, 304 }, { 43, 0 } }, style | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 257, 304 }, { 43, 0 } }, style | UiFlags::AlignCenter);
 
-	style = UiFlags::UIS_BLUE;
+	style = UiFlags::ColorBlue;
 	if (myPlayer._pLghtResist == 0)
-		style = UiFlags::UIS_SILVER;
+		style = UiFlags::ColorSilver;
 	if (myPlayer._pLghtResist < MAXRESIST) {
 		sprintf(chrstr, "%i%%", myPlayer._pLghtResist);
 	} else {
-		style = UiFlags::UIS_GOLD;
+		style = UiFlags::ColorGold;
 		strcpy(chrstr, _("MAX"));
 	}
-	DrawString(out, chrstr, { { 257, 332 }, { 43, 0 } }, style | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 257, 332 }, { 43, 0 } }, style | UiFlags::AlignCenter);
 
-	style = UiFlags::UIS_SILVER;
+	style = UiFlags::ColorSilver;
 	sprintf(chrstr, "%i", myPlayer._pBaseStr);
 	if (myPlayer.GetMaximumAttributeValue(CharacterAttribute::Strength) == myPlayer._pBaseStr)
-		style = UiFlags::UIS_GOLD;
-	DrawString(out, chrstr, { { 95, 155 }, { 31, 0 } }, style | UiFlags::UIS_CENTER);
+		style = UiFlags::ColorGold;
+	DrawString(out, chrstr, { { 95, 155 }, { 31, 0 } }, style | UiFlags::AlignCenter);
 
-	style = UiFlags::UIS_SILVER;
+	style = UiFlags::ColorSilver;
 	sprintf(chrstr, "%i", myPlayer._pBaseMag);
 	if (myPlayer.GetMaximumAttributeValue(CharacterAttribute::Magic) == myPlayer._pBaseMag)
-		style = UiFlags::UIS_GOLD;
-	DrawString(out, chrstr, { { 95, 183 }, { 31, 0 } }, style | UiFlags::UIS_CENTER);
+		style = UiFlags::ColorGold;
+	DrawString(out, chrstr, { { 95, 183 }, { 31, 0 } }, style | UiFlags::AlignCenter);
 
-	style = UiFlags::UIS_SILVER;
+	style = UiFlags::ColorSilver;
 	sprintf(chrstr, "%i", myPlayer._pBaseDex);
 	if (myPlayer.GetMaximumAttributeValue(CharacterAttribute::Dexterity) == myPlayer._pBaseDex)
-		style = UiFlags::UIS_GOLD;
-	DrawString(out, chrstr, { { 95, 211 }, { 31, 0 } }, style | UiFlags::UIS_CENTER);
+		style = UiFlags::ColorGold;
+	DrawString(out, chrstr, { { 95, 211 }, { 31, 0 } }, style | UiFlags::AlignCenter);
 
-	style = UiFlags::UIS_SILVER;
+	style = UiFlags::ColorSilver;
 	sprintf(chrstr, "%i", myPlayer._pBaseVit);
 	if (myPlayer.GetMaximumAttributeValue(CharacterAttribute::Vitality) == myPlayer._pBaseVit)
-		style = UiFlags::UIS_GOLD;
-	DrawString(out, chrstr, { { 95, 239 }, { 31, 0 } }, style | UiFlags::UIS_CENTER);
+		style = UiFlags::ColorGold;
+	DrawString(out, chrstr, { { 95, 239 }, { 31, 0 } }, style | UiFlags::AlignCenter);
 
-	style = UiFlags::UIS_SILVER;
+	style = UiFlags::ColorSilver;
 	if (myPlayer._pStrength > myPlayer._pBaseStr)
-		style = UiFlags::UIS_BLUE;
+		style = UiFlags::ColorBlue;
 	if (myPlayer._pStrength < myPlayer._pBaseStr)
-		style = UiFlags::UIS_RED;
+		style = UiFlags::ColorRed;
 	sprintf(chrstr, "%i", myPlayer._pStrength);
-	DrawString(out, chrstr, { { 143, 155 }, { 30, 0 } }, style | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 143, 155 }, { 30, 0 } }, style | UiFlags::AlignCenter);
 
-	style = UiFlags::UIS_SILVER;
+	style = UiFlags::ColorSilver;
 	if (myPlayer._pMagic > myPlayer._pBaseMag)
-		style = UiFlags::UIS_BLUE;
+		style = UiFlags::ColorBlue;
 	if (myPlayer._pMagic < myPlayer._pBaseMag)
-		style = UiFlags::UIS_RED;
+		style = UiFlags::ColorRed;
 	sprintf(chrstr, "%i", myPlayer._pMagic);
-	DrawString(out, chrstr, { { 143, 183 }, { 30, 0 } }, style | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 143, 183 }, { 30, 0 } }, style | UiFlags::AlignCenter);
 
-	style = UiFlags::UIS_SILVER;
+	style = UiFlags::ColorSilver;
 	if (myPlayer._pDexterity > myPlayer._pBaseDex)
-		style = UiFlags::UIS_BLUE;
+		style = UiFlags::ColorBlue;
 	if (myPlayer._pDexterity < myPlayer._pBaseDex)
-		style = UiFlags::UIS_RED;
+		style = UiFlags::ColorRed;
 	sprintf(chrstr, "%i", myPlayer._pDexterity);
-	DrawString(out, chrstr, { { 143, 211 }, { 30, 0 } }, style | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 143, 211 }, { 30, 0 } }, style | UiFlags::AlignCenter);
 
-	style = UiFlags::UIS_SILVER;
+	style = UiFlags::ColorSilver;
 	if (myPlayer._pVitality > myPlayer._pBaseVit)
-		style = UiFlags::UIS_BLUE;
+		style = UiFlags::ColorBlue;
 	if (myPlayer._pVitality < myPlayer._pBaseVit)
-		style = UiFlags::UIS_RED;
+		style = UiFlags::ColorRed;
 	sprintf(chrstr, "%i", myPlayer._pVitality);
-	DrawString(out, chrstr, { { 143, 239 }, { 30, 0 } }, style | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 143, 239 }, { 30, 0 } }, style | UiFlags::AlignCenter);
 
 	if (myPlayer._pStatPts > 0) {
 		if (CalcStatDiff(myPlayer) < myPlayer._pStatPts) {
@@ -1491,7 +1491,7 @@ void DrawChr(const Surface &out)
 	}
 	if (myPlayer._pStatPts > 0) {
 		sprintf(chrstr, "%i", myPlayer._pStatPts);
-		DrawString(out, chrstr, { { 95, 266 }, { 31, 0 } }, UiFlags::UIS_RED | UiFlags::UIS_CENTER);
+		DrawString(out, chrstr, { { 95, 266 }, { 31, 0 } }, UiFlags::ColorRed | UiFlags::AlignCenter);
 		if (myPlayer._pBaseStr < myPlayer.GetMaximumAttributeValue(CharacterAttribute::Strength))
 			CelDrawTo(out, { 137, 159 }, *pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Strength)] ? 3 : 2);
 		if (myPlayer._pBaseMag < myPlayer.GetMaximumAttributeValue(CharacterAttribute::Magic))
@@ -1502,25 +1502,25 @@ void DrawChr(const Surface &out)
 			CelDrawTo(out, { 137, 244 }, *pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Vitality)] ? 9 : 8);
 	}
 
-	style = UiFlags::UIS_SILVER;
+	style = UiFlags::ColorSilver;
 	if (myPlayer._pMaxHP > myPlayer._pMaxHPBase)
-		style = UiFlags::UIS_BLUE;
+		style = UiFlags::ColorBlue;
 	sprintf(chrstr, "%i", myPlayer._pMaxHP >> 6);
-	DrawString(out, chrstr, { { 95, 304 }, { 31, 0 } }, style | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 95, 304 }, { 31, 0 } }, style | UiFlags::AlignCenter);
 	if (myPlayer._pHitPoints != myPlayer._pMaxHP)
-		style = UiFlags::UIS_RED;
+		style = UiFlags::ColorRed;
 	sprintf(chrstr, "%i", myPlayer._pHitPoints >> 6);
-	DrawString(out, chrstr, { { 143, 304 }, { 31, 0 } }, style | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 143, 304 }, { 31, 0 } }, style | UiFlags::AlignCenter);
 
-	style = UiFlags::UIS_SILVER;
+	style = UiFlags::ColorSilver;
 	if (myPlayer._pMaxMana > myPlayer._pMaxManaBase)
-		style = UiFlags::UIS_BLUE;
+		style = UiFlags::ColorBlue;
 	sprintf(chrstr, "%i", myPlayer._pMaxMana >> 6);
-	DrawString(out, chrstr, { { 95, 332 }, { 31, 0 } }, style | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 95, 332 }, { 31, 0 } }, style | UiFlags::AlignCenter);
 	if (myPlayer._pMana != myPlayer._pMaxMana)
-		style = UiFlags::UIS_RED;
+		style = UiFlags::ColorRed;
 	sprintf(chrstr, "%i", myPlayer._pMana >> 6);
-	DrawString(out, chrstr, { { 143, 332 }, { 31, 0 } }, style | UiFlags::UIS_CENTER);
+	DrawString(out, chrstr, { { 143, 332 }, { 31, 0 } }, style | UiFlags::AlignCenter);
 }
 
 void CheckLvlBtn()
@@ -1540,7 +1540,7 @@ void DrawLevelUpIcon(const Surface &out)
 {
 	if (stextflag == STORE_NONE) {
 		int nCel = lvlbtndown ? 3 : 2;
-		DrawString(out, _("Level Up"), { { PANEL_LEFT + 0, PANEL_TOP - 49 }, { 120, 0 } }, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER);
+		DrawString(out, _("Level Up"), { { PANEL_LEFT + 0, PANEL_TOP - 49 }, { 120, 0 } }, UiFlags::ColorSilver | UiFlags::AlignCenter);
 		CelDrawTo(out, { 40 + PANEL_X, -17 + PANEL_Y }, *pChrButtons, nCel);
 	}
 }
@@ -1776,7 +1776,7 @@ void DrawGoldSplit(const Surface &out, int amount)
 	// The split gold dialog is roughly 4 lines high, but we need at least one line for the player to input an amount.
 	// Using a clipping region 50 units high (approx 3 lines with a lineheight of 17) to ensure there is enough room left
 	//  for the text entered by the player.
-	DrawString(out, tempstr, { { dialogX + 31, 87 }, { 200, 50 } }, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, 1, 17);
+	DrawString(out, tempstr, { { dialogX + 31, 87 }, { 200, 50 } }, UiFlags::ColorGold | UiFlags::AlignCenter, 1, 17);
 
 	tempstr[0] = '\0';
 	if (amount > 0) {
@@ -1785,7 +1785,7 @@ void DrawGoldSplit(const Surface &out, int amount)
 	}
 	// Even a ten digit amount of gold only takes up about half a line. There's no need to wrap or clip text here so we
 	// use the Point form of DrawString.
-	DrawString(out, tempstr, Point { dialogX + 37, 140 }, UiFlags::UIS_SILVER, 1, -1, true);
+	DrawString(out, tempstr, Point { dialogX + 37, 140 }, UiFlags::ColorSilver, 1, -1, true);
 }
 
 void control_drop_gold(char vkey)
@@ -1843,7 +1843,7 @@ void DrawTalkPan(const Surface &out)
 	int x = PANEL_LEFT + 200;
 	int y = PANEL_Y + 22;
 
-	int idx = DrawString(out, msg, { { x, y }, { 250, 39 } }, UiFlags::UIS_SILVER, 1, 13, true);
+	int idx = DrawString(out, msg, { { x, y }, { 250, 39 } }, UiFlags::ColorSilver, 1, 13, true);
 	msg[idx] = '\0';
 
 	x += 46;
@@ -1852,10 +1852,10 @@ void DrawTalkPan(const Surface &out)
 		if (i == MyPlayerId)
 			continue;
 
-		UiFlags color = UiFlags::UIS_RED;
+		UiFlags color = UiFlags::ColorRed;
 		const Point talkPanPosition { 172 + PANEL_X, 84 + 18 * talkBtn + PANEL_Y };
 		if (WhisperList[i]) {
-			color = UiFlags::UIS_GOLD;
+			color = UiFlags::ColorGold;
 			if (TalkButtonsDown[talkBtn]) {
 				int nCel = talkBtn != 0 ? 4 : 3;
 				CelDrawTo(out, talkPanPosition, *talkButtons, nCel);

--- a/Source/control.h
+++ b/Source/control.h
@@ -40,7 +40,7 @@ extern bool chrbtnactive;
 extern int pnumlines;
 extern bool pinfoflag;
 extern spell_id pSpell;
-extern uint16_t infoclr;
+extern UiFlags InfoColor;
 extern char tempstr[256];
 extern int sbooktab;
 extern spell_type pSplType;

--- a/Source/controls/modifier_hints.cpp
+++ b/Source/controls/modifier_hints.cpp
@@ -95,7 +95,7 @@ bool IsLeftActive(const CircleMenuHint &hint)
 
 UiFlags CircleMenuHintTextColor(bool active)
 {
-	return active ? UiFlags::UIS_BLUE : UiFlags::UIS_GOLD;
+	return active ? UiFlags::ColorBlue : UiFlags::ColorGold;
 }
 
 /**

--- a/Source/controls/modifier_hints.cpp
+++ b/Source/controls/modifier_hints.cpp
@@ -93,9 +93,9 @@ bool IsLeftActive(const CircleMenuHint &hint)
 	return IsControllerButtonPressed(ControllerButton_BUTTON_X);
 }
 
-uint16_t CircleMenuHintTextColor(bool active)
+UiFlags CircleMenuHintTextColor(bool active)
 {
-	return active ? UIS_BLUE : UIS_GOLD;
+	return active ? UiFlags::UIS_BLUE : UiFlags::UIS_GOLD;
 }
 
 /**

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -274,36 +274,36 @@ void WordWrapGameString(char *text, size_t width, GameFontTables size, int spaci
 uint16_t DrawString(const Surface &out, const char *text, const Rectangle &rect, UiFlags flags, int spacing, int lineHeight, bool drawTextCursor)
 {
 	GameFontTables size = GameFontSmall;
-	if (HasAnyOf(flags, UiFlags::UIS_MED))
+	if (HasAnyOf(flags, UiFlags::FontMedium))
 		size = GameFontMed;
-	else if (HasAnyOf(flags, UiFlags::UIS_HUGE))
+	else if (HasAnyOf(flags, UiFlags::FontHuge))
 		size = GameFontBig;
 
 	text_color color = ColorGold;
-	if (HasAnyOf(flags, UiFlags::UIS_SILVER))
+	if (HasAnyOf(flags, UiFlags::ColorSilver))
 		color = ColorWhite;
-	else if (HasAnyOf(flags, UiFlags::UIS_BLUE))
+	else if (HasAnyOf(flags, UiFlags::ColorBlue))
 		color = ColorBlue;
-	else if (HasAnyOf(flags, UiFlags::UIS_RED))
+	else if (HasAnyOf(flags, UiFlags::ColorRed))
 		color = ColorRed;
-	else if (HasAnyOf(flags, UiFlags::UIS_BLACK))
+	else if (HasAnyOf(flags, UiFlags::ColorBlack))
 		color = ColorBlack;
 
 	const size_t textLength = strlen(text);
 
 	int charactersInLine = 0;
 	int lineWidth = 0;
-	if (HasAnyOf(flags, (UiFlags::UIS_CENTER | UiFlags::UIS_RIGHT | UiFlags::UIS_FIT_SPACING)))
+	if (HasAnyOf(flags, (UiFlags::AlignCenter | UiFlags::AlignRight | UiFlags::KerningFitSpacing)))
 		lineWidth = GetLineWidth(text, size, spacing, &charactersInLine);
 
 	int maxSpacing = spacing;
-	if (HasAnyOf(flags, UiFlags::UIS_FIT_SPACING))
+	if (HasAnyOf(flags, UiFlags::KerningFitSpacing))
 		spacing = AdjustSpacingToFitHorizontally(lineWidth, maxSpacing, charactersInLine, rect.size.width);
 
 	Point characterPosition = rect.position;
-	if (HasAnyOf(flags, UiFlags::UIS_CENTER))
+	if (HasAnyOf(flags, UiFlags::AlignCenter))
 		characterPosition.x += (rect.size.width - lineWidth) / 2;
-	else if (HasAnyOf(flags, UiFlags::UIS_RIGHT))
+	else if (HasAnyOf(flags, UiFlags::AlignRight))
 		characterPosition.x += rect.size.width - lineWidth;
 
 	int rightMargin = rect.position.x + rect.size.width;
@@ -321,16 +321,16 @@ uint16_t DrawString(const Surface &out, const char *text, const Rectangle &rect,
 				break;
 			characterPosition.y += lineHeight;
 
-			if (HasAnyOf(flags, (UiFlags::UIS_CENTER | UiFlags::UIS_RIGHT | UiFlags::UIS_FIT_SPACING)))
+			if (HasAnyOf(flags, (UiFlags::AlignCenter | UiFlags::AlignRight | UiFlags::KerningFitSpacing)))
 				lineWidth = GetLineWidth(&text[i + 1], size, spacing, &charactersInLine);
 
-			if (HasAnyOf(flags, UiFlags::UIS_FIT_SPACING))
+			if (HasAnyOf(flags, UiFlags::KerningFitSpacing))
 				spacing = AdjustSpacingToFitHorizontally(lineWidth, maxSpacing, charactersInLine, rect.size.width);
 
 			characterPosition.x = rect.position.x;
-			if (HasAnyOf(flags, UiFlags::UIS_CENTER))
+			if (HasAnyOf(flags, UiFlags::AlignCenter))
 				characterPosition.x += (rect.size.width - lineWidth) / 2;
-			else if (HasAnyOf(flags, UiFlags::UIS_RIGHT))
+			else if (HasAnyOf(flags, UiFlags::AlignRight))
 				characterPosition.x += rect.size.width - lineWidth;
 		}
 		if (frame != 0) {

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -271,39 +271,39 @@ void WordWrapGameString(char *text, size_t width, GameFontTables size, int spaci
 /**
  * @todo replace Rectangle with cropped Surface
  */
-uint16_t DrawString(const Surface &out, const char *text, const Rectangle &rect, uint16_t flags, int spacing, int lineHeight, bool drawTextCursor)
+uint16_t DrawString(const Surface &out, const char *text, const Rectangle &rect, UiFlags flags, int spacing, int lineHeight, bool drawTextCursor)
 {
 	GameFontTables size = GameFontSmall;
-	if ((flags & UIS_MED) != 0)
+	if (HasAnyOf(flags, UiFlags::UIS_MED))
 		size = GameFontMed;
-	else if ((flags & UIS_HUGE) != 0)
+	else if (HasAnyOf(flags, UiFlags::UIS_HUGE))
 		size = GameFontBig;
 
 	text_color color = ColorGold;
-	if ((flags & UIS_SILVER) != 0)
+	if (HasAnyOf(flags, UiFlags::UIS_SILVER))
 		color = ColorWhite;
-	else if ((flags & UIS_BLUE) != 0)
+	else if (HasAnyOf(flags, UiFlags::UIS_BLUE))
 		color = ColorBlue;
-	else if ((flags & UIS_RED) != 0)
+	else if (HasAnyOf(flags, UiFlags::UIS_RED))
 		color = ColorRed;
-	else if ((flags & UIS_BLACK) != 0)
+	else if (HasAnyOf(flags, UiFlags::UIS_BLACK))
 		color = ColorBlack;
 
 	const size_t textLength = strlen(text);
 
 	int charactersInLine = 0;
 	int lineWidth = 0;
-	if ((flags & (UIS_CENTER | UIS_RIGHT | UIS_FIT_SPACING)) != 0)
+	if (HasAnyOf(flags, (UiFlags::UIS_CENTER | UiFlags::UIS_RIGHT | UiFlags::UIS_FIT_SPACING)))
 		lineWidth = GetLineWidth(text, size, spacing, &charactersInLine);
 
 	int maxSpacing = spacing;
-	if ((flags & UIS_FIT_SPACING) != 0)
+	if (HasAnyOf(flags, UiFlags::UIS_FIT_SPACING))
 		spacing = AdjustSpacingToFitHorizontally(lineWidth, maxSpacing, charactersInLine, rect.size.width);
 
 	Point characterPosition = rect.position;
-	if ((flags & UIS_CENTER) != 0)
+	if (HasAnyOf(flags, UiFlags::UIS_CENTER))
 		characterPosition.x += (rect.size.width - lineWidth) / 2;
-	else if ((flags & UIS_RIGHT) != 0)
+	else if (HasAnyOf(flags, UiFlags::UIS_RIGHT))
 		characterPosition.x += rect.size.width - lineWidth;
 
 	int rightMargin = rect.position.x + rect.size.width;
@@ -321,16 +321,16 @@ uint16_t DrawString(const Surface &out, const char *text, const Rectangle &rect,
 				break;
 			characterPosition.y += lineHeight;
 
-			if ((flags & (UIS_CENTER | UIS_RIGHT | UIS_FIT_SPACING)) != 0)
+			if (HasAnyOf(flags, (UiFlags::UIS_CENTER | UiFlags::UIS_RIGHT | UiFlags::UIS_FIT_SPACING)))
 				lineWidth = GetLineWidth(&text[i + 1], size, spacing, &charactersInLine);
 
-			if ((flags & UIS_FIT_SPACING) != 0)
+			if (HasAnyOf(flags, UiFlags::UIS_FIT_SPACING))
 				spacing = AdjustSpacingToFitHorizontally(lineWidth, maxSpacing, charactersInLine, rect.size.width);
 
 			characterPosition.x = rect.position.x;
-			if ((flags & UIS_CENTER) != 0)
+			if (HasAnyOf(flags, UiFlags::UIS_CENTER))
 				characterPosition.x += (rect.size.width - lineWidth) / 2;
-			else if ((flags & UIS_RIGHT) != 0)
+			else if (HasAnyOf(flags, UiFlags::UIS_RIGHT))
 				characterPosition.x += rect.size.width - lineWidth;
 		}
 		if (frame != 0) {

--- a/Source/engine/render/text_render.hpp
+++ b/Source/engine/render/text_render.hpp
@@ -58,7 +58,7 @@ void WordWrapGameString(char *text, size_t width, GameFontTables size = GameFont
  * @param drawTextCursor Whether to draw an animated cursor sprite at the end of the text (default is to display nothing).
  * @return The number of characters rendered, including characters "drawn" outside the buffer.
  */
-uint16_t DrawString(const Surface &out, const char *text, const Rectangle &rect, uint16_t flags = 0, int spacing = 1, int lineHeight = -1, bool drawTextCursor = false);
+uint16_t DrawString(const Surface &out, const char *text, const Rectangle &rect, UiFlags flags = UiFlags::NONE, int spacing = 1, int lineHeight = -1, bool drawTextCursor = false);
 
 /**
  * @brief Draws a line of text at the given position relative to the origin of the output buffer.
@@ -78,7 +78,7 @@ uint16_t DrawString(const Surface &out, const char *text, const Rectangle &rect,
  * @param drawTextCursor Whether to draw an animated cursor sprite at the end of the text (default is to display nothing).
  * @return The number of characters rendered (could be less than the string length if it wrapped past the bottom of the buffer).
  */
-inline uint16_t DrawString(const Surface &out, const char *text, const Point &position, uint16_t flags = 0, int spacing = 1, int lineHeight = -1, bool drawTextCursor = false)
+inline uint16_t DrawString(const Surface &out, const char *text, const Point &position, UiFlags flags = UiFlags::NONE, int spacing = 1, int lineHeight = -1, bool drawTextCursor = false)
 {
 	return DrawString(out, text, { position, { out.w() - position.x, 0 } }, flags, spacing, lineHeight, drawTextCursor);
 }

--- a/Source/engine/render/text_render.hpp
+++ b/Source/engine/render/text_render.hpp
@@ -58,7 +58,7 @@ void WordWrapGameString(char *text, size_t width, GameFontTables size = GameFont
  * @param drawTextCursor Whether to draw an animated cursor sprite at the end of the text (default is to display nothing).
  * @return The number of characters rendered, including characters "drawn" outside the buffer.
  */
-uint16_t DrawString(const Surface &out, const char *text, const Rectangle &rect, UiFlags flags = UiFlags::NONE, int spacing = 1, int lineHeight = -1, bool drawTextCursor = false);
+uint16_t DrawString(const Surface &out, const char *text, const Rectangle &rect, UiFlags flags = UiFlags::None, int spacing = 1, int lineHeight = -1, bool drawTextCursor = false);
 
 /**
  * @brief Draws a line of text at the given position relative to the origin of the output buffer.
@@ -78,7 +78,7 @@ uint16_t DrawString(const Surface &out, const char *text, const Rectangle &rect,
  * @param drawTextCursor Whether to draw an animated cursor sprite at the end of the text (default is to display nothing).
  * @return The number of characters rendered (could be less than the string length if it wrapped past the bottom of the buffer).
  */
-inline uint16_t DrawString(const Surface &out, const char *text, const Point &position, UiFlags flags = UiFlags::NONE, int spacing = 1, int lineHeight = -1, bool drawTextCursor = false)
+inline uint16_t DrawString(const Surface &out, const char *text, const Point &position, UiFlags flags = UiFlags::None, int spacing = 1, int lineHeight = -1, bool drawTextCursor = false)
 {
 	return DrawString(out, text, { position, { out.w() - position.x, 0 } }, flags, spacing, lineHeight, drawTextCursor);
 }

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -133,7 +133,7 @@ void DrawDiabloMsg(const Surface &out)
 	DrawHalfTransparentRectTo(out, PANEL_X + 104, DIALOG_Y - 8, 432, 54);
 
 	strcpy(tempstr, _(MsgStrings[msgflag]));
-	DrawString(out, tempstr, { { PANEL_X + 101, DIALOG_Y + 24 }, { 442, 0 } }, UIS_CENTER);
+	DrawString(out, tempstr, { { PANEL_X + 101, DIALOG_Y + 24 }, { 442, 0 } }, UiFlags::UIS_CENTER);
 
 	if (msgdelay > 0 && msgdelay <= SDL_GetTicks() - 3500) {
 		msgdelay = 0;

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -133,7 +133,7 @@ void DrawDiabloMsg(const Surface &out)
 	DrawHalfTransparentRectTo(out, PANEL_X + 104, DIALOG_Y - 8, 432, 54);
 
 	strcpy(tempstr, _(MsgStrings[msgflag]));
-	DrawString(out, tempstr, { { PANEL_X + 101, DIALOG_Y + 24 }, { 442, 0 } }, UiFlags::UIS_CENTER);
+	DrawString(out, tempstr, { { PANEL_X + 101, DIALOG_Y + 24 }, { 442, 0 } }, UiFlags::AlignCenter);
 
 	if (msgdelay > 0 && msgdelay <= SDL_GetTicks() - 3500) {
 		msgdelay = 0;

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -113,8 +113,8 @@ void GmenuDrawMenuItem(const Surface &out, TMenuItem *pItem, int y)
 	}
 
 	int x = (gnScreenWidth - w) / 2;
-	UiFlags style = (pItem->dwFlags & GMENU_ENABLED) != 0 ? UiFlags::UIS_SILVER : UiFlags::UIS_BLACK;
-	DrawString(out, _(pItem->pszStr), Point { x, y }, style | UiFlags::UIS_HUGE, 2);
+	UiFlags style = (pItem->dwFlags & GMENU_ENABLED) != 0 ? UiFlags::ColorSilver : UiFlags::ColorBlack;
+	DrawString(out, _(pItem->pszStr), Point { x, y }, style | UiFlags::FontHuge, 2);
 	if (pItem == sgpCurrItem) {
 		CelDrawTo(out, { x - 54, y + 1 }, *PentSpin_cel, PentSpn2Spin());
 		CelDrawTo(out, { x + 4 + w, y + 1 }, *PentSpin_cel, PentSpn2Spin());
@@ -163,7 +163,7 @@ void gmenu_draw_pause(const Surface &out)
 		RedBack(out);
 	if (sgpCurrentMenu == nullptr) {
 		LightTableIndex = 0;
-		DrawString(out, _("Pause"), Point { 0, PANEL_TOP / 2 }, UiFlags::UIS_HUGE | UiFlags::UIS_CENTER, 2);
+		DrawString(out, _("Pause"), Point { 0, PANEL_TOP / 2 }, UiFlags::FontHuge | UiFlags::AlignCenter, 2);
 	}
 }
 

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -113,8 +113,8 @@ void GmenuDrawMenuItem(const Surface &out, TMenuItem *pItem, int y)
 	}
 
 	int x = (gnScreenWidth - w) / 2;
-	uint16_t style = (pItem->dwFlags & GMENU_ENABLED) != 0 ? UIS_SILVER : UIS_BLACK;
-	DrawString(out, _(pItem->pszStr), Point { x, y }, style | UIS_HUGE, 2);
+	UiFlags style = (pItem->dwFlags & GMENU_ENABLED) != 0 ? UiFlags::UIS_SILVER : UiFlags::UIS_BLACK;
+	DrawString(out, _(pItem->pszStr), Point { x, y }, style | UiFlags::UIS_HUGE, 2);
 	if (pItem == sgpCurrItem) {
 		CelDrawTo(out, { x - 54, y + 1 }, *PentSpin_cel, PentSpn2Spin());
 		CelDrawTo(out, { x + 4 + w, y + 1 }, *PentSpin_cel, PentSpn2Spin());
@@ -163,7 +163,7 @@ void gmenu_draw_pause(const Surface &out)
 		RedBack(out);
 	if (sgpCurrentMenu == nullptr) {
 		LightTableIndex = 0;
-		DrawString(out, _("Pause"), Point { 0, PANEL_TOP / 2 }, UIS_HUGE | UIS_CENTER, 2);
+		DrawString(out, _("Pause"), Point { 0, PANEL_TOP / 2 }, UiFlags::UIS_HUGE | UiFlags::UIS_CENTER, 2);
 	}
 }
 

--- a/Source/help.cpp
+++ b/Source/help.cpp
@@ -130,7 +130,7 @@ void DrawHelp(const Surface &out)
 		title = gbIsSpawn ? _("Shareware Hellfire Help") : _("Hellfire Help");
 	else
 		title = gbIsSpawn ? _("Shareware Diablo Help") : _("Diablo Help");
-	PrintSString(out, 0, 2, title, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER);
+	PrintSString(out, 0, 2, title, UiFlags::ColorGold | UiFlags::AlignCenter);
 
 	DrawSLine(out, 5);
 
@@ -144,16 +144,16 @@ void DrawHelp(const Surface &out)
 		}
 
 		int offset = 0;
-		UiFlags style = UiFlags::UIS_SILVER;
+		UiFlags style = UiFlags::ColorSilver;
 		if (line[0] == '$') {
 			offset = 1;
-			style = UiFlags::UIS_RED;
+			style = UiFlags::ColorRed;
 		}
 
 		DrawString(out, &line[offset], { { sx, sy + i * 12 }, { 577, 12 } }, style);
 	}
 
-	PrintSString(out, 0, 23, _("Press ESC to end or the arrow keys to scroll."), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER);
+	PrintSString(out, 0, 23, _("Press ESC to end or the arrow keys to scroll."), UiFlags::ColorGold | UiFlags::AlignCenter);
 }
 
 void DisplayHelp()

--- a/Source/help.cpp
+++ b/Source/help.cpp
@@ -130,7 +130,7 @@ void DrawHelp(const Surface &out)
 		title = gbIsSpawn ? _("Shareware Hellfire Help") : _("Hellfire Help");
 	else
 		title = gbIsSpawn ? _("Shareware Diablo Help") : _("Diablo Help");
-	PrintSString(out, 0, 2, title, UIS_GOLD | UIS_CENTER);
+	PrintSString(out, 0, 2, title, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER);
 
 	DrawSLine(out, 5);
 
@@ -144,16 +144,16 @@ void DrawHelp(const Surface &out)
 		}
 
 		int offset = 0;
-		uint16_t style = UIS_SILVER;
+		UiFlags style = UiFlags::UIS_SILVER;
 		if (line[0] == '$') {
 			offset = 1;
-			style = UIS_RED;
+			style = UiFlags::UIS_RED;
 		}
 
 		DrawString(out, &line[offset], { { sx, sy + i * 12 }, { 577, 12 } }, style);
 	}
 
-	PrintSString(out, 0, 23, _("Press ESC to end or the arrow keys to scroll."), UIS_GOLD | UIS_CENTER);
+	PrintSString(out, 0, 23, _("Press ESC to end or the arrow keys to scroll."), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER);
 }
 
 void DisplayHelp()

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1267,7 +1267,7 @@ void DrawInvBelt(const Surface &out)
 		    && myPlayer.SpdList[i]._iStatFlag
 		    && myPlayer.SpdList[i]._itype != ITYPE_GOLD) {
 			snprintf(tempstr, sizeof(tempstr) / sizeof(*tempstr), "%i", i + 1);
-			DrawString(out, tempstr, { position, InventorySlotSizeInPixels }, UiFlags::UIS_SILVER | UiFlags::UIS_RIGHT);
+			DrawString(out, tempstr, { position, InventorySlotSizeInPixels }, UiFlags::ColorSilver | UiFlags::AlignRight);
 		}
 	}
 }
@@ -1899,7 +1899,7 @@ char CheckInvHLight()
 		return -1;
 
 	int8_t rv = -1;
-	InfoColor = UiFlags::UIS_SILVER;
+	InfoColor = UiFlags::ColorSilver;
 	ItemStruct *pi = nullptr;
 	auto &myPlayer = Players[MyPlayerId];
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1267,7 +1267,7 @@ void DrawInvBelt(const Surface &out)
 		    && myPlayer.SpdList[i]._iStatFlag
 		    && myPlayer.SpdList[i]._itype != ITYPE_GOLD) {
 			snprintf(tempstr, sizeof(tempstr) / sizeof(*tempstr), "%i", i + 1);
-			DrawString(out, tempstr, { position, InventorySlotSizeInPixels }, UIS_SILVER | UIS_RIGHT);
+			DrawString(out, tempstr, { position, InventorySlotSizeInPixels }, UiFlags::UIS_SILVER | UiFlags::UIS_RIGHT);
 		}
 	}
 }
@@ -1899,7 +1899,7 @@ char CheckInvHLight()
 		return -1;
 
 	int8_t rv = -1;
-	infoclr = UIS_SILVER;
+	InfoColor = UiFlags::UIS_SILVER;
 	ItemStruct *pi = nullptr;
 	auto &myPlayer = Players[MyPlayerId];
 
@@ -1954,7 +1954,7 @@ char CheckInvHLight()
 		int nGold = pi->_ivalue;
 		strcpy(infostr, fmt::format(ngettext("{:d} gold piece", "{:d} gold pieces", nGold), nGold).c_str());
 	} else {
-		infoclr = pi->getTextColor();
+		InfoColor = pi->getTextColor();
 		if (pi->_iIdentified) {
 			strcpy(infostr, pi->_iIName);
 			PrintItemDetails(pi);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3761,7 +3761,7 @@ void GetItemStr(int i)
 		else
 			strcpy(infostr, Items[i]._iName);
 
-		infoclr = Items[i].getTextColor();
+		InfoColor = Items[i].getTextColor();
 	} else {
 		int nGold = Items[i]._ivalue;
 		strcpy(infostr, fmt::format(ngettext("{:d} gold piece", "{:d} gold pieces", nGold), nGold).c_str());
@@ -4138,7 +4138,7 @@ void DrawUniqueInfo(const Surface &out)
 
 	Rectangle rect { { 32 + RIGHT_PANEL - SPANEL_WIDTH, 44 + 2 * 12 }, { 257, 0 } };
 	const UItemStruct &uitem = UniqueItemList[curruitem._iUid];
-	DrawString(out, _(uitem.UIName), rect, UIS_CENTER);
+	DrawString(out, _(uitem.UIName), rect, UiFlags::UIS_CENTER);
 
 	DrawUniqueInfoDevider(out, 5);
 
@@ -4149,7 +4149,7 @@ void DrawUniqueInfo(const Surface &out)
 			break;
 		rect.position.y += 2 * 12;
 		PrintItemPower(power.type, &curruitem);
-		DrawString(out, tempstr, rect, UIS_SILVER | UIS_CENTER);
+		DrawString(out, tempstr, rect, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER);
 	}
 }
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4138,7 +4138,7 @@ void DrawUniqueInfo(const Surface &out)
 
 	Rectangle rect { { 32 + RIGHT_PANEL - SPANEL_WIDTH, 44 + 2 * 12 }, { 257, 0 } };
 	const UItemStruct &uitem = UniqueItemList[curruitem._iUid];
-	DrawString(out, _(uitem.UIName), rect, UiFlags::UIS_CENTER);
+	DrawString(out, _(uitem.UIName), rect, UiFlags::AlignCenter);
 
 	DrawUniqueInfoDevider(out, 5);
 
@@ -4149,7 +4149,7 @@ void DrawUniqueInfo(const Surface &out)
 			break;
 		rect.position.y += 2 * 12;
 		PrintItemPower(power.type, &curruitem);
-		DrawString(out, tempstr, rect, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER);
+		DrawString(out, tempstr, rect, UiFlags::ColorSilver | UiFlags::AlignCenter);
 	}
 }
 

--- a/Source/items.h
+++ b/Source/items.h
@@ -361,18 +361,18 @@ struct ItemStruct {
 	{
 		switch (_iMagical) {
 		case ITEM_QUALITY_MAGIC:
-			return UIS_BLUE;
+			return UiFlags::UIS_BLUE;
 		case ITEM_QUALITY_UNIQUE:
-			return UIS_GOLD;
+			return UiFlags::UIS_GOLD;
 		default:
-			return UIS_SILVER;
+			return UiFlags::UIS_SILVER;
 		}
 	}
 
 	UiFlags getTextColorWithStatCheck() const
 	{
 		if (!_iStatFlag)
-			return UIS_RED;
+			return UiFlags::UIS_RED;
 		return getTextColor();
 	}
 

--- a/Source/items.h
+++ b/Source/items.h
@@ -361,18 +361,18 @@ struct ItemStruct {
 	{
 		switch (_iMagical) {
 		case ITEM_QUALITY_MAGIC:
-			return UiFlags::UIS_BLUE;
+			return UiFlags::ColorBlue;
 		case ITEM_QUALITY_UNIQUE:
-			return UiFlags::UIS_GOLD;
+			return UiFlags::ColorGold;
 		default:
-			return UiFlags::UIS_SILVER;
+			return UiFlags::ColorSilver;
 		}
 	}
 
 	UiFlags getTextColorWithStatCheck() const
 	{
 		if (!_iStatFlag)
-			return UiFlags::UIS_RED;
+			return UiFlags::ColorRed;
 		return getTextColor();
 	}
 

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -117,7 +117,7 @@ void DrawQTextContent(const Surface &out)
 			continue;
 		}
 
-		DrawString(out, line, { { sx, sy + i * LineHeight }, { 543, LineHeight } }, UiFlags::UIS_MED, 2);
+		DrawString(out, line, { { sx, sy + i * LineHeight }, { 543, LineHeight } }, UiFlags::FontMedium, 2);
 	}
 }
 

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -117,7 +117,7 @@ void DrawQTextContent(const Surface &out)
 			continue;
 		}
 
-		DrawString(out, line, { { sx, sy + i * LineHeight }, { 543, LineHeight } }, UIS_MED, 2);
+		DrawString(out, line, { { sx, sy + i * LineHeight }, { 543, LineHeight } }, UiFlags::UIS_MED, 2);
 	}
 }
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5552,13 +5552,13 @@ void GetObjectStr(int i)
 		if (Objects[i]._oTrapFlag) {
 			strcpy(tempstr, fmt::format(_(/* TRANSLATORS: {:s} will either be a chest or a door */ "Trapped {:s}"), infostr).c_str());
 			strcpy(infostr, tempstr);
-			InfoColor = UiFlags::UIS_RED;
+			InfoColor = UiFlags::ColorRed;
 		}
 	}
 	if (objectIsDisabled(i)) {
 		strcpy(tempstr, fmt::format(_(/* TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver */ "{:s} (disabled)"), infostr).c_str());
 		strcpy(infostr, tempstr);
-		InfoColor = UiFlags::UIS_RED;
+		InfoColor = UiFlags::ColorRed;
 	}
 }
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5552,13 +5552,13 @@ void GetObjectStr(int i)
 		if (Objects[i]._oTrapFlag) {
 			strcpy(tempstr, fmt::format(_(/* TRANSLATORS: {:s} will either be a chest or a door */ "Trapped {:s}"), infostr).c_str());
 			strcpy(infostr, tempstr);
-			infoclr = UIS_RED;
+			InfoColor = UiFlags::UIS_RED;
 		}
 	}
 	if (objectIsDisabled(i)) {
 		strcpy(tempstr, fmt::format(_(/* TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver */ "{:s} (disabled)"), infostr).c_str());
 		strcpy(infostr, tempstr);
-		infoclr = UIS_RED;
+		InfoColor = UiFlags::UIS_RED;
 	}
 }
 

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -22,9 +22,9 @@ uint8_t plr_msg_slot;
 _plrmsg plr_msgs[PMSG_COUNT];
 
 /** Maps from player_num to text color, as used in chat messages. */
-const UiFlags TextColorFromPlayerId[MAX_PLRS + 1] = { UIS_SILVER, UIS_SILVER, UIS_SILVER, UIS_SILVER, UIS_GOLD };
+const UiFlags TextColorFromPlayerId[MAX_PLRS + 1] = { UiFlags::UIS_SILVER, UiFlags::UIS_SILVER, UiFlags::UIS_SILVER, UiFlags::UIS_SILVER, UiFlags::UIS_GOLD };
 
-void PrintChatMessage(const Surface &out, int x, int y, int width, char *text, uint16_t style)
+void PrintChatMessage(const Surface &out, int x, int y, int width, char *text, UiFlags style)
 {
 	int length = strlen(text);
 	for (int i = 0; i < length; i++) {

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -22,7 +22,7 @@ uint8_t plr_msg_slot;
 _plrmsg plr_msgs[PMSG_COUNT];
 
 /** Maps from player_num to text color, as used in chat messages. */
-const UiFlags TextColorFromPlayerId[MAX_PLRS + 1] = { UiFlags::UIS_SILVER, UiFlags::UIS_SILVER, UiFlags::UIS_SILVER, UiFlags::UIS_SILVER, UiFlags::UIS_GOLD };
+const UiFlags TextColorFromPlayerId[MAX_PLRS + 1] = { UiFlags::ColorSilver, UiFlags::ColorSilver, UiFlags::ColorSilver, UiFlags::ColorSilver, UiFlags::ColorGold };
 
 void PrintChatMessage(const Surface &out, int x, int y, int width, char *text, UiFlags style)
 {

--- a/Source/qol/monhealthbar.cpp
+++ b/Source/qol/monhealthbar.cpp
@@ -96,13 +96,13 @@ void DrawMonsterHealthBar(const Surface &out)
 	}
 
 	int barLabelY = yPos + 10 + (height - 11) / 2;
-	DrawString(out, monster.mName, { { xPos - 1, barLabelY + 1 }, { width, height } }, UIS_CENTER | UIS_BLACK);
-	uint16_t style = UIS_SILVER;
+	DrawString(out, monster.mName, { { xPos - 1, barLabelY + 1 }, { width, height } }, UiFlags::UIS_CENTER | UiFlags::UIS_BLACK);
+	UiFlags style = UiFlags::UIS_SILVER;
 	if (monster._uniqtype != 0)
-		style = UIS_GOLD;
+		style = UiFlags::UIS_GOLD;
 	else if (monster.leader != 0)
-		style = UIS_BLUE;
-	DrawString(out, monster.mName, { { xPos, barLabelY }, { width, height } }, UIS_CENTER | style);
+		style = UiFlags::UIS_BLUE;
+	DrawString(out, monster.mName, { { xPos, barLabelY }, { width, height } }, UiFlags::UIS_CENTER | style);
 
 	if (monster._uniqtype != 0 || MonsterKillCounts[monster.MType->mtype] >= 15) {
 		monster_resistance immunes[] = { IMMUNE_MAGIC, IMMUNE_FIRE, IMMUNE_LIGHTNING };

--- a/Source/qol/monhealthbar.cpp
+++ b/Source/qol/monhealthbar.cpp
@@ -96,13 +96,13 @@ void DrawMonsterHealthBar(const Surface &out)
 	}
 
 	int barLabelY = yPos + 10 + (height - 11) / 2;
-	DrawString(out, monster.mName, { { xPos - 1, barLabelY + 1 }, { width, height } }, UiFlags::UIS_CENTER | UiFlags::UIS_BLACK);
-	UiFlags style = UiFlags::UIS_SILVER;
+	DrawString(out, monster.mName, { { xPos - 1, barLabelY + 1 }, { width, height } }, UiFlags::AlignCenter | UiFlags::ColorBlack);
+	UiFlags style = UiFlags::ColorSilver;
 	if (monster._uniqtype != 0)
-		style = UiFlags::UIS_GOLD;
+		style = UiFlags::ColorGold;
 	else if (monster.leader != 0)
-		style = UiFlags::UIS_BLUE;
-	DrawString(out, monster.mName, { { xPos, barLabelY }, { width, height } }, UiFlags::UIS_CENTER | style);
+		style = UiFlags::ColorBlue;
+	DrawString(out, monster.mName, { { xPos, barLabelY }, { width, height } }, UiFlags::AlignCenter | style);
 
 	if (monster._uniqtype != 0 || MonsterKillCounts[monster.MType->mtype] >= 15) {
 		monster_resistance immunes[] = { IMMUNE_MAGIC, IMMUNE_FIRE, IMMUNE_LIGHTNING };

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -130,7 +130,7 @@ bool CheckXPBarInfo()
 
 	if (charLevel == MAXCHARLEVEL - 1) {
 		// Show a maximum level indicator for max level players.
-		infoclr = UIS_GOLD;
+		InfoColor = UiFlags::UIS_GOLD;
 
 		strcpy(tempstr, _("Experience: "));
 		PrintWithSeparator(tempstr + strlen(tempstr), ExpLvlsTbl[charLevel - 1]);
@@ -141,7 +141,7 @@ bool CheckXPBarInfo()
 		return true;
 	}
 
-	infoclr = UIS_SILVER;
+	InfoColor = UiFlags::UIS_SILVER;
 
 	strcpy(tempstr, _("Experience: "));
 	PrintWithSeparator(tempstr + strlen(tempstr), player._pExperience);

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -130,7 +130,7 @@ bool CheckXPBarInfo()
 
 	if (charLevel == MAXCHARLEVEL - 1) {
 		// Show a maximum level indicator for max level players.
-		InfoColor = UiFlags::UIS_GOLD;
+		InfoColor = UiFlags::ColorGold;
 
 		strcpy(tempstr, _("Experience: "));
 		PrintWithSeparator(tempstr + strlen(tempstr), ExpLvlsTbl[charLevel - 1]);
@@ -141,7 +141,7 @@ bool CheckXPBarInfo()
 		return true;
 	}
 
-	InfoColor = UiFlags::UIS_SILVER;
+	InfoColor = UiFlags::ColorSilver;
 
 	strcpy(tempstr, _("Experience: "));
 	PrintWithSeparator(tempstr + strlen(tempstr), player._pExperience);

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -254,7 +254,7 @@ void PrintQLString(const Surface &out, int x, int line, const char *str)
 	if (qline == line) {
 		CelDrawTo(out, { sx - 20, sy + 1 }, *pSPentSpn2Cels, PentSpn2Spin());
 	}
-	DrawString(out, str, { { sx, sy }, { 257, 0 } }, UiFlags::UIS_SILVER);
+	DrawString(out, str, { { sx, sy }, { 257, 0 } }, UiFlags::ColorSilver);
 	if (qline == line) {
 		CelDrawTo(out, { sx + width + 7, sy + 1 }, *pSPentSpn2Cels, PentSpn2Spin());
 	}
@@ -730,7 +730,7 @@ void ResyncQuests()
 
 void DrawQuestLog(const Surface &out)
 {
-	DrawString(out, _("Quest Log"), { { 32, 44 }, { 257, 0 } }, UiFlags::UIS_CENTER);
+	DrawString(out, _("Quest Log"), { { 32, 44 }, { 257, 0 } }, UiFlags::AlignCenter);
 	CelDrawTo(out, { 0, 351 }, *pQLogCel, 1);
 	int line = qtopline;
 	for (int i = 0; i < numqlines; i++) {

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -254,7 +254,7 @@ void PrintQLString(const Surface &out, int x, int line, const char *str)
 	if (qline == line) {
 		CelDrawTo(out, { sx - 20, sy + 1 }, *pSPentSpn2Cels, PentSpn2Spin());
 	}
-	DrawString(out, str, { { sx, sy }, { 257, 0 } }, UIS_SILVER);
+	DrawString(out, str, { { sx, sy }, { 257, 0 } }, UiFlags::UIS_SILVER);
 	if (qline == line) {
 		CelDrawTo(out, { sx + width + 7, sy + 1 }, *pSPentSpn2Cels, PentSpn2Spin());
 	}
@@ -730,7 +730,7 @@ void ResyncQuests()
 
 void DrawQuestLog(const Surface &out)
 {
-	DrawString(out, _("Quest Log"), { { 32, 44 }, { 257, 0 } }, UIS_CENTER);
+	DrawString(out, _("Quest Log"), { { 32, 44 }, { 257, 0 } }, UiFlags::UIS_CENTER);
 	CelDrawTo(out, { 0, 351 }, *pQLogCel, 1);
 	int line = qtopline;
 	for (int i = 0; i < numqlines; i++) {

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1269,7 +1269,7 @@ void DrawFPS(const Surface &out)
 		frameend = 0;
 	}
 	snprintf(string, 12, "%i FPS", framerate);
-	DrawString(out, string, Point { 8, 65 }, UiFlags::UIS_RED);
+	DrawString(out, string, Point { 8, 65 }, UiFlags::ColorRed);
 }
 
 /**

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1269,7 +1269,7 @@ void DrawFPS(const Surface &out)
 		frameend = 0;
 	}
 	snprintf(string, 12, "%i FPS", framerate);
-	DrawString(out, string, Point { 8, 65 }, UIS_RED);
+	DrawString(out, string, Point { 8, 65 }, UiFlags::UIS_RED);
 }
 
 /**

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -150,7 +150,7 @@ void OffsetSTextY(int y, int yo)
 	stext[y]._syoff = yo;
 }
 
-void AddSText(int x, int y, const char *str, uint16_t flags, bool sel)
+void AddSText(int x, int y, const char *str, UiFlags flags, bool sel)
 {
 	stext[y]._sx = x;
 	stext[y]._syoff = 0;
@@ -160,7 +160,7 @@ void AddSText(int x, int y, const char *str, uint16_t flags, bool sel)
 	stext[y]._ssel = sel;
 }
 
-void PrintStoreItem(ItemStruct *x, int l, uint16_t flags)
+void PrintStoreItem(ItemStruct *x, int l, UiFlags flags)
 {
 	char sstr[128];
 
@@ -239,15 +239,15 @@ void StartSmith()
 {
 	stextsize = false;
 	stextscrl = false;
-	AddSText(0, 1, _("Welcome to the"), UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 3, _("Blacksmith's shop"), UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 7, _("Would you like to:"), UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 10, _("Talk to Griswold"), UIS_BLUE | UIS_CENTER, true);
-	AddSText(0, 12, _("Buy basic items"), UIS_SILVER | UIS_CENTER, true);
-	AddSText(0, 14, _("Buy premium items"), UIS_SILVER | UIS_CENTER, true);
-	AddSText(0, 16, _("Sell items"), UIS_SILVER | UIS_CENTER, true);
-	AddSText(0, 18, _("Repair items"), UIS_SILVER | UIS_CENTER, true);
-	AddSText(0, 20, _("Leave the shop"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, 1, _("Welcome to the"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 3, _("Blacksmith's shop"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 7, _("Would you like to:"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 10, _("Talk to Griswold"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
+	AddSText(0, 12, _("Buy basic items"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 14, _("Buy premium items"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 16, _("Sell items"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 18, _("Repair items"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 20, _("Leave the shop"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 	AddSLine(5);
 	storenumh = 20;
 }
@@ -259,16 +259,16 @@ void ScrollSmithBuy(int idx)
 
 	for (int l = 5; l < 20; l += 4) {
 		if (!smithitem[idx].isEmpty()) {
-			uint16_t iclr = smithitem[idx].getTextColorWithStatCheck();
+			UiFlags itemColor = smithitem[idx].getTextColorWithStatCheck();
 
 			if (smithitem[idx]._iMagical != ITEM_QUALITY_NORMAL) {
-				AddSText(20, l, smithitem[idx]._iIName, iclr, true);
+				AddSText(20, l, smithitem[idx]._iIName, itemColor, true);
 			} else {
-				AddSText(20, l, smithitem[idx]._iName, iclr, true);
+				AddSText(20, l, smithitem[idx]._iName, itemColor, true);
 			}
 
 			AddSTextVal(l, smithitem[idx]._iIvalue);
-			PrintStoreItem(&smithitem[idx], l + 1, iclr);
+			PrintStoreItem(&smithitem[idx], l + 1, itemColor);
 			stextdown = l;
 			idx++;
 		}
@@ -287,11 +287,11 @@ void StartSmithBuy()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("I have these items for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithBuy(stextsval);
-	AddSText(0, 22, _("Back"), UIS_SILVER | UIS_CENTER, false);
+	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
 	OffsetSTextY(22, 6);
 
 	storenumh = 0;
@@ -317,10 +317,10 @@ void ScrollSmithPremiumBuy(int boughtitems)
 
 	for (int l = 5; l < 20 && idx < SMITH_PREMIUM_ITEMS; l += 4) {
 		if (!premiumitems[idx].isEmpty()) {
-			uint16_t iclr = premiumitems[idx].getTextColorWithStatCheck();
-			AddSText(20, l, premiumitems[idx]._iIName, iclr, true);
+			UiFlags itemColor = premiumitems[idx].getTextColorWithStatCheck();
+			AddSText(20, l, premiumitems[idx]._iIName, itemColor, true);
 			AddSTextVal(l, premiumitems[idx]._iIvalue);
-			PrintStoreItem(&premiumitems[idx], l + 1, iclr);
+			PrintStoreItem(&premiumitems[idx], l + 1, itemColor);
 			stextdown = l;
 		} else {
 			l -= 4;
@@ -351,10 +351,10 @@ bool StartSmithPremiumBuy()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("I have these premium items for sale:     Your gold: {:d}"), Players[MyPlayerId]._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
-	AddSText(0, 22, _("Back"), UIS_SILVER | UIS_CENTER, false);
+	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
 	OffsetSTextY(22, 6);
 
 	stextsmax = storenumh - 4;
@@ -405,17 +405,17 @@ void ScrollSmithSell(int idx)
 		if (idx >= storenumh)
 			break;
 		if (!storehold[idx].isEmpty()) {
-			uint16_t iclr = storehold[idx].getTextColorWithStatCheck();
+			UiFlags itemColor = storehold[idx].getTextColorWithStatCheck();
 
 			if (storehold[idx]._iMagical != ITEM_QUALITY_NORMAL && storehold[idx]._iIdentified) {
-				AddSText(20, l, storehold[idx]._iIName, iclr, true);
+				AddSText(20, l, storehold[idx]._iIName, itemColor, true);
 				AddSTextVal(l, storehold[idx]._iIvalue);
 			} else {
-				AddSText(20, l, storehold[idx]._iName, iclr, true);
+				AddSText(20, l, storehold[idx]._iName, itemColor, true);
 				AddSTextVal(l, storehold[idx]._ivalue);
 			}
 
-			PrintStoreItem(&storehold[idx], l + 1, iclr);
+			PrintStoreItem(&storehold[idx], l + 1, itemColor);
 			stextdown = l;
 		}
 		idx++;
@@ -478,10 +478,10 @@ void StartSmithSell()
 		/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 		strcpy(tempstr, fmt::format(_("You have nothing I want.             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
+		AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
-		AddSText(0, 22, _("Back"), UIS_SILVER | UIS_CENTER, true);
+		AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 		OffsetSTextY(22, 6);
 		return;
 	}
@@ -493,11 +493,11 @@ void StartSmithSell()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("Which item is for sale?             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithSell(stextsval);
-	AddSText(0, 22, _("Back"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 	OffsetSTextY(22, 6);
 }
 
@@ -568,10 +568,10 @@ void StartSmithRepair()
 		/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 		strcpy(tempstr, fmt::format(_("You have nothing to repair.             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
+		AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
-		AddSText(0, 22, _("Back"), UIS_SILVER | UIS_CENTER, true);
+		AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 		OffsetSTextY(22, 6);
 		return;
 	}
@@ -583,11 +583,11 @@ void StartSmithRepair()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("Repair which item?             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithSell(stextsval);
-	AddSText(0, 22, _("Back"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 	OffsetSTextY(22, 6);
 }
 
@@ -611,13 +611,13 @@ void StartWitch()
 	FillManaPlayer();
 	stextsize = false;
 	stextscrl = false;
-	AddSText(0, 2, _("Witch's shack"), UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 9, _("Would you like to:"), UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 12, _("Talk to Adria"), UIS_BLUE | UIS_CENTER, true);
-	AddSText(0, 14, _("Buy items"), UIS_SILVER | UIS_CENTER, true);
-	AddSText(0, 16, _("Sell items"), UIS_SILVER | UIS_CENTER, true);
-	AddSText(0, 18, _("Recharge staves"), UIS_SILVER | UIS_CENTER, true);
-	AddSText(0, 20, _("Leave the shack"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, 2, _("Witch's shack"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 9, _("Would you like to:"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 12, _("Talk to Adria"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
+	AddSText(0, 14, _("Buy items"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 16, _("Sell items"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 18, _("Recharge staves"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 20, _("Leave the shack"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 	AddSLine(5);
 	storenumh = 20;
 }
@@ -629,16 +629,16 @@ void ScrollWitchBuy(int idx)
 
 	for (int l = 5; l < 20; l += 4) {
 		if (!witchitem[idx].isEmpty()) {
-			uint16_t iclr = witchitem[idx].getTextColorWithStatCheck();
+			UiFlags itemColor = witchitem[idx].getTextColorWithStatCheck();
 
 			if (witchitem[idx]._iMagical != ITEM_QUALITY_NORMAL) {
-				AddSText(20, l, witchitem[idx]._iIName, iclr, true);
+				AddSText(20, l, witchitem[idx]._iIName, itemColor, true);
 			} else {
-				AddSText(20, l, witchitem[idx]._iName, iclr, true);
+				AddSText(20, l, witchitem[idx]._iName, itemColor, true);
 			}
 
 			AddSTextVal(l, witchitem[idx]._iIvalue);
-			PrintStoreItem(&witchitem[idx], l + 1, iclr);
+			PrintStoreItem(&witchitem[idx], l + 1, itemColor);
 			stextdown = l;
 			idx++;
 		}
@@ -658,11 +658,11 @@ void StartWitchBuy()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("I have these items for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollWitchBuy(stextsval);
-	AddSText(0, 22, _("Back"), UIS_SILVER | UIS_CENTER, false);
+	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
 	OffsetSTextY(22, 6);
 
 	storenumh = 0;
@@ -752,10 +752,10 @@ void StartWitchSell()
 		/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 		strcpy(tempstr, fmt::format(_("You have nothing I want.             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
+		AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
-		AddSText(0, 22, _("Back"), UIS_SILVER | UIS_CENTER, true);
+		AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 		OffsetSTextY(22, 6);
 		return;
 	}
@@ -767,11 +767,11 @@ void StartWitchSell()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("Which item is for sale?             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithSell(stextsval);
-	AddSText(0, 22, _("Back"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 	OffsetSTextY(22, 6);
 }
 
@@ -833,10 +833,10 @@ void StartWitchRecharge()
 		/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 		strcpy(tempstr, fmt::format(_("You have nothing to recharge.             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
+		AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
-		AddSText(0, 22, _("Back"), UIS_SILVER | UIS_CENTER, true);
+		AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 		OffsetSTextY(22, 6);
 		return;
 	}
@@ -848,11 +848,11 @@ void StartWitchRecharge()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("Recharge which item?             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithSell(stextsval);
-	AddSText(0, 22, _("Back"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 	OffsetSTextY(22, 6);
 }
 
@@ -862,7 +862,7 @@ void StoreNoMoney()
 	stextscrl = false;
 	stextsize = true;
 	ClearSText(5, 23);
-	AddSText(0, 14, _("You do not have enough gold"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, 14, _("You do not have enough gold"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 }
 
 void StoreNoRoom()
@@ -870,7 +870,7 @@ void StoreNoRoom()
 	StartStore(stextshold);
 	stextscrl = false;
 	ClearSText(5, 23);
-	AddSText(0, 14, _("You do not have enough room in inventory"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, 14, _("You do not have enough room in inventory"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 }
 
 void StoreConfirm()
@@ -881,7 +881,7 @@ void StoreConfirm()
 
 	auto &item = Players[MyPlayerId].HoldItem;
 
-	uint16_t iclr = item.getTextColorWithStatCheck();
+	UiFlags itemColor = item.getTextColorWithStatCheck();
 
 	bool idprint = item._iMagical != ITEM_QUALITY_NORMAL;
 
@@ -898,12 +898,12 @@ void StoreConfirm()
 			idprint = false;
 	}
 	if (idprint)
-		AddSText(20, 8, item._iIName, iclr, false);
+		AddSText(20, 8, item._iIName, itemColor, false);
 	else
-		AddSText(20, 8, item._iName, iclr, false);
+		AddSText(20, 8, item._iName, itemColor, false);
 
 	AddSTextVal(8, item._iIvalue);
-	PrintStoreItem(&item, 9, iclr);
+	PrintStoreItem(&item, 9, itemColor);
 
 	switch (stextshold) {
 	case STORE_BBOY:
@@ -931,27 +931,27 @@ void StoreConfirm()
 	default:
 		app_fatal("Unknown store dialog %i", stextshold);
 	}
-	AddSText(0, 15, tempstr, UIS_SILVER | UIS_CENTER, false);
-	AddSText(0, 18, _("Yes"), UIS_SILVER | UIS_CENTER, true);
-	AddSText(0, 20, _("No"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, 15, tempstr, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
+	AddSText(0, 18, _("Yes"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 20, _("No"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 }
 
 void StartBoy()
 {
 	stextsize = false;
 	stextscrl = false;
-	AddSText(0, 2, _("Wirt the Peg-legged boy"), UIS_GOLD | UIS_CENTER, false);
+	AddSText(0, 2, _("Wirt the Peg-legged boy"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 	AddSLine(5);
 	if (!boyitem.isEmpty()) {
-		AddSText(0, 8, _("Talk to Wirt"), UIS_BLUE | UIS_CENTER, true);
-		AddSText(0, 12, _("I have something for sale,"), UIS_GOLD | UIS_CENTER, false);
-		AddSText(0, 14, _("but it will cost 50 gold"), UIS_GOLD | UIS_CENTER, false);
-		AddSText(0, 16, _("just to take a look. "), UIS_GOLD | UIS_CENTER, false);
-		AddSText(0, 18, _("What have you got?"), UIS_SILVER | UIS_CENTER, true);
-		AddSText(0, 20, _("Say goodbye"), UIS_SILVER | UIS_CENTER, true);
+		AddSText(0, 8, _("Talk to Wirt"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
+		AddSText(0, 12, _("I have something for sale,"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+		AddSText(0, 14, _("but it will cost 50 gold"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+		AddSText(0, 16, _("just to take a look. "), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+		AddSText(0, 18, _("What have you got?"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+		AddSText(0, 20, _("Say goodbye"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 	} else {
-		AddSText(0, 12, _("Talk to Wirt"), UIS_BLUE | UIS_CENTER, true);
-		AddSText(0, 18, _("Say goodbye"), UIS_SILVER | UIS_CENTER, true);
+		AddSText(0, 12, _("Talk to Wirt"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
+		AddSText(0, 18, _("Say goodbye"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 	}
 }
 
@@ -963,22 +963,22 @@ void SStartBoyBuy()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("I have this item for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
-	uint16_t iclr = boyitem.getTextColorWithStatCheck();
+	UiFlags itemColor = boyitem.getTextColorWithStatCheck();
 
 	if (boyitem._iMagical != ITEM_QUALITY_NORMAL)
-		AddSText(20, 10, boyitem._iIName, iclr, true);
+		AddSText(20, 10, boyitem._iIName, itemColor, true);
 	else
-		AddSText(20, 10, boyitem._iName, iclr, true);
+		AddSText(20, 10, boyitem._iName, itemColor, true);
 
 	if (gbIsHellfire)
 		AddSTextVal(10, boyitem._iIvalue - (boyitem._iIvalue / 4));
 	else
 		AddSTextVal(10, boyitem._iIvalue + (boyitem._iIvalue / 2));
-	PrintStoreItem(&boyitem, 11, iclr);
-	AddSText(0, 22, _("Leave"), UIS_SILVER | UIS_CENTER, true);
+	PrintStoreItem(&boyitem, 11, itemColor);
+	AddSText(0, 22, _("Leave"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 	OffsetSTextY(22, 6);
 }
 
@@ -999,12 +999,12 @@ void StartHealer()
 	HealPlayer();
 	stextsize = false;
 	stextscrl = false;
-	AddSText(0, 1, _("Welcome to the"), UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 3, _("Healer's home"), UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 9, _("Would you like to:"), UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 12, _("Talk to Pepin"), UIS_BLUE | UIS_CENTER, true);
-	AddSText(0, 14, _("Buy items"), UIS_SILVER | UIS_CENTER, true);
-	AddSText(0, 16, _("Leave Healer's home"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, 1, _("Welcome to the"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 3, _("Healer's home"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 9, _("Would you like to:"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 12, _("Talk to Pepin"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
+	AddSText(0, 14, _("Buy items"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 16, _("Leave Healer's home"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 	AddSLine(5);
 	storenumh = 20;
 }
@@ -1015,11 +1015,11 @@ void ScrollHealerBuy(int idx)
 	stextup = 5;
 	for (int l = 5; l < 20; l += 4) {
 		if (!healitem[idx].isEmpty()) {
-			uint16_t iclr = healitem[idx].getTextColorWithStatCheck();
+			UiFlags itemColor = healitem[idx].getTextColorWithStatCheck();
 
-			AddSText(20, l, healitem[idx]._iName, iclr, true);
+			AddSText(20, l, healitem[idx]._iName, itemColor, true);
 			AddSTextVal(l, healitem[idx]._iIvalue);
-			PrintStoreItem(&healitem[idx], l + 1, iclr);
+			PrintStoreItem(&healitem[idx], l + 1, itemColor);
 			stextdown = l;
 			idx++;
 		}
@@ -1038,11 +1038,11 @@ void StartHealerBuy()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("I have these items for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollHealerBuy(stextsval);
-	AddSText(0, 22, _("Back"), UIS_SILVER | UIS_CENTER, false);
+	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
 	OffsetSTextY(22, 6);
 
 	storenumh = 0;
@@ -1058,11 +1058,11 @@ void StartStoryteller()
 {
 	stextsize = false;
 	stextscrl = false;
-	AddSText(0, 2, _("The Town Elder"), UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 9, _("Would you like to:"), UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 12, _("Talk to Cain"), UIS_BLUE | UIS_CENTER, true);
-	AddSText(0, 14, _("Identify an item"), UIS_SILVER | UIS_CENTER, true);
-	AddSText(0, 18, _("Say goodbye"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, 2, _("The Town Elder"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 9, _("Would you like to:"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 12, _("Talk to Cain"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
+	AddSText(0, 14, _("Identify an item"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 18, _("Say goodbye"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 	AddSLine(5);
 }
 
@@ -1156,10 +1156,10 @@ void StartStorytellerIdentify()
 		/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 		strcpy(tempstr, fmt::format(_("You have nothing to identify.             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-		AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
+		AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 		AddSLine(3);
 		AddSLine(21);
-		AddSText(0, 22, _("Back"), UIS_SILVER | UIS_CENTER, true);
+		AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 		OffsetSTextY(22, 6);
 		return;
 	}
@@ -1171,11 +1171,11 @@ void StartStorytellerIdentify()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("Identify which item?             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UIS_GOLD | UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithSell(stextsval);
-	AddSText(0, 22, _("Back"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 	OffsetSTextY(22, 6);
 }
 
@@ -1187,12 +1187,12 @@ void StartStorytellerIdentifyShow()
 
 	auto &item = Players[MyPlayerId].HoldItem;
 
-	uint16_t iclr = item.getTextColorWithStatCheck();
+	UiFlags itemColor = item.getTextColorWithStatCheck();
 
-	AddSText(0, 7, _("This item is:"), UIS_SILVER | UIS_CENTER, false);
-	AddSText(20, 11, item._iIName, iclr, false);
-	PrintStoreItem(&item, 12, iclr);
-	AddSText(0, 18, _("Done"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, 7, _("This item is:"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
+	AddSText(20, 11, item._iIName, itemColor, false);
+	PrintStoreItem(&item, 12, itemColor);
+	AddSText(0, 18, _("Done"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 }
 
 void StartTalk()
@@ -1202,15 +1202,15 @@ void StartTalk()
 	stextsize = false;
 	stextscrl = false;
 	strcpy(tempstr, fmt::format(_("Talk to {:s}"), TownerNames[talker]).c_str());
-	AddSText(0, 2, tempstr, UIS_GOLD | UIS_CENTER, false);
+	AddSText(0, 2, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
 	AddSLine(5);
 	if (gbIsSpawn) {
 		strcpy(tempstr, fmt::format(_("Talking to {:s}"), TownerNames[talker]).c_str());
-		AddSText(0, 10, tempstr, UIS_SILVER | UIS_CENTER, false);
-		AddSText(0, 12, _("is not available"), UIS_SILVER | UIS_CENTER, false);
-		AddSText(0, 14, _("in the shareware"), UIS_SILVER | UIS_CENTER, false);
-		AddSText(0, 16, _("version"), UIS_SILVER | UIS_CENTER, false);
-		AddSText(0, 22, _("Back"), UIS_SILVER | UIS_CENTER, true);
+		AddSText(0, 10, tempstr, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
+		AddSText(0, 12, _("is not available"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
+		AddSText(0, 14, _("in the shareware"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
+		AddSText(0, 16, _("version"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
+		AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 		return;
 	}
 
@@ -1232,23 +1232,23 @@ void StartTalk()
 
 	for (int i = 0; i < MAXQUESTS; i++) {
 		if (Quests[i]._qactive == QUEST_ACTIVE && QuestDialogTable[talker][i] != TEXT_NONE && Quests[i]._qlog) {
-			AddSText(0, sn, _(QuestData[i]._qlstr), UIS_SILVER | UIS_CENTER, true);
+			AddSText(0, sn, _(QuestData[i]._qlstr), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 			sn += la;
 		}
 	}
-	AddSText(0, sn2, _("Gossip"), UIS_BLUE | UIS_CENTER, true);
-	AddSText(0, 22, _("Back"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, sn2, _("Gossip"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
+	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 }
 
 void StartTavern()
 {
 	stextsize = false;
 	stextscrl = false;
-	AddSText(0, 1, _("Welcome to the"), UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 3, _("Rising Sun"), UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 9, _("Would you like to:"), UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 12, _("Talk to Ogden"), UIS_BLUE | UIS_CENTER, true);
-	AddSText(0, 18, _("Leave the tavern"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, 1, _("Welcome to the"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 3, _("Rising Sun"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 9, _("Would you like to:"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 12, _("Talk to Ogden"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
+	AddSText(0, 18, _("Leave the tavern"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 	AddSLine(5);
 	storenumh = 20;
 }
@@ -1257,10 +1257,10 @@ void StartBarmaid()
 {
 	stextsize = false;
 	stextscrl = false;
-	AddSText(0, 2, "Gillian", UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 9, _("Would you like to:"), UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 12, _("Talk to Gillian"), UIS_BLUE | UIS_CENTER, true);
-	AddSText(0, 18, _("Say goodbye"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, 2, "Gillian", UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 9, _("Would you like to:"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 12, _("Talk to Gillian"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
+	AddSText(0, 18, _("Say goodbye"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 	AddSLine(5);
 	storenumh = 20;
 }
@@ -1269,10 +1269,10 @@ void StartDrunk()
 {
 	stextsize = false;
 	stextscrl = false;
-	AddSText(0, 2, _("Farnham the Drunk"), UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 9, _("Would you like to:"), UIS_GOLD | UIS_CENTER, false);
-	AddSText(0, 12, _("Talk to Farnham"), UIS_BLUE | UIS_CENTER, true);
-	AddSText(0, 18, _("Say Goodbye"), UIS_SILVER | UIS_CENTER, true);
+	AddSText(0, 2, _("Farnham the Drunk"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 9, _("Would you like to:"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 12, _("Talk to Farnham"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
+	AddSText(0, 18, _("Say Goodbye"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
 	AddSLine(5);
 	storenumh = 20;
 }
@@ -2161,18 +2161,18 @@ int TakeGold(PlayerStruct &player, int cost, bool skipMaxPiles)
 	return cost;
 }
 
-void DrawSelector(const Surface &out, const Rectangle &rect, const char *text, uint16_t flags)
+void DrawSelector(const Surface &out, const Rectangle &rect, const char *text, UiFlags flags)
 {
 	int lineWidth = GetLineWidth(text);
 
 	int x1 = rect.position.x - 20;
-	if ((flags & UIS_CENTER) != 0)
+	if (HasAnyOf(flags, UiFlags::UIS_CENTER))
 		x1 += (rect.size.width - lineWidth) / 2;
 
 	CelDrawTo(out, { x1, rect.position.y + 1 }, *pSPentSpn2Cels, PentSpn2Spin());
 
 	int x2 = rect.position.x + rect.size.width + 5;
-	if ((flags & UIS_CENTER) != 0)
+	if (HasAnyOf(flags, UiFlags::UIS_CENTER))
 		x2 = rect.position.x + (rect.size.width - lineWidth) / 2 + lineWidth + 5;
 
 	CelDrawTo(out, { x2, rect.position.y + 1 }, *pSPentSpn2Cels, PentSpn2Spin());
@@ -2251,7 +2251,7 @@ void FreeStoreMem()
 	pSTextSlidCels = std::nullopt;
 }
 
-void PrintSString(const Surface &out, int margin, int line, const char *text, uint16_t flags, int price)
+void PrintSString(const Surface &out, int margin, int line, const char *text, UiFlags flags, int price)
 {
 	int sx = PANEL_X + 32 + margin;
 	if (!stextsize) {
@@ -2271,7 +2271,7 @@ void PrintSString(const Surface &out, int margin, int line, const char *text, ui
 	if (price > 0) {
 		char valstr[32];
 		sprintf(valstr, "%i", price);
-		DrawString(out, valstr, rect, flags | UIS_RIGHT);
+		DrawString(out, valstr, rect, flags | UiFlags::UIS_RIGHT);
 	}
 
 	if (stextsel == line) {
@@ -2309,7 +2309,7 @@ void ClearSText(int s, int e)
 		stext[i]._sx = 0;
 		stext[i]._syoff = 0;
 		stext[i]._sstr[0] = 0;
-		stext[i].flags = 0;
+		stext[i].flags = UiFlags::NONE;
 		stext[i]._sline = 0;
 		stext[i]._ssel = false;
 		stext[i]._sval = 0;

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -239,15 +239,15 @@ void StartSmith()
 {
 	stextsize = false;
 	stextscrl = false;
-	AddSText(0, 1, _("Welcome to the"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 3, _("Blacksmith's shop"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 7, _("Would you like to:"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 10, _("Talk to Griswold"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
-	AddSText(0, 12, _("Buy basic items"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
-	AddSText(0, 14, _("Buy premium items"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
-	AddSText(0, 16, _("Sell items"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
-	AddSText(0, 18, _("Repair items"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
-	AddSText(0, 20, _("Leave the shop"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 1, _("Welcome to the"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 3, _("Blacksmith's shop"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 7, _("Would you like to:"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 10, _("Talk to Griswold"), UiFlags::ColorBlue | UiFlags::AlignCenter, true);
+	AddSText(0, 12, _("Buy basic items"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
+	AddSText(0, 14, _("Buy premium items"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
+	AddSText(0, 16, _("Sell items"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
+	AddSText(0, 18, _("Repair items"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
+	AddSText(0, 20, _("Leave the shop"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 	AddSLine(5);
 	storenumh = 20;
 }
@@ -287,11 +287,11 @@ void StartSmithBuy()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("I have these items for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithBuy(stextsval);
-	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
+	AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, false);
 	OffsetSTextY(22, 6);
 
 	storenumh = 0;
@@ -351,10 +351,10 @@ bool StartSmithPremiumBuy()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("I have these premium items for sale:     Your gold: {:d}"), Players[MyPlayerId]._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
-	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
+	AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, false);
 	OffsetSTextY(22, 6);
 
 	stextsmax = storenumh - 4;
@@ -478,10 +478,10 @@ void StartSmithSell()
 		/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 		strcpy(tempstr, fmt::format(_("You have nothing I want.             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-		AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+		AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
 		AddSLine(3);
 		AddSLine(21);
-		AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+		AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 		OffsetSTextY(22, 6);
 		return;
 	}
@@ -493,11 +493,11 @@ void StartSmithSell()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("Which item is for sale?             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithSell(stextsval);
-	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 	OffsetSTextY(22, 6);
 }
 
@@ -568,10 +568,10 @@ void StartSmithRepair()
 		/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 		strcpy(tempstr, fmt::format(_("You have nothing to repair.             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-		AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+		AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
 		AddSLine(3);
 		AddSLine(21);
-		AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+		AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 		OffsetSTextY(22, 6);
 		return;
 	}
@@ -583,11 +583,11 @@ void StartSmithRepair()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("Repair which item?             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithSell(stextsval);
-	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 	OffsetSTextY(22, 6);
 }
 
@@ -611,13 +611,13 @@ void StartWitch()
 	FillManaPlayer();
 	stextsize = false;
 	stextscrl = false;
-	AddSText(0, 2, _("Witch's shack"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 9, _("Would you like to:"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 12, _("Talk to Adria"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
-	AddSText(0, 14, _("Buy items"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
-	AddSText(0, 16, _("Sell items"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
-	AddSText(0, 18, _("Recharge staves"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
-	AddSText(0, 20, _("Leave the shack"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 2, _("Witch's shack"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 9, _("Would you like to:"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 12, _("Talk to Adria"), UiFlags::ColorBlue | UiFlags::AlignCenter, true);
+	AddSText(0, 14, _("Buy items"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
+	AddSText(0, 16, _("Sell items"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
+	AddSText(0, 18, _("Recharge staves"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
+	AddSText(0, 20, _("Leave the shack"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 	AddSLine(5);
 	storenumh = 20;
 }
@@ -658,11 +658,11 @@ void StartWitchBuy()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("I have these items for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollWitchBuy(stextsval);
-	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
+	AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, false);
 	OffsetSTextY(22, 6);
 
 	storenumh = 0;
@@ -752,10 +752,10 @@ void StartWitchSell()
 		/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 		strcpy(tempstr, fmt::format(_("You have nothing I want.             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-		AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+		AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
 		AddSLine(3);
 		AddSLine(21);
-		AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+		AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 		OffsetSTextY(22, 6);
 		return;
 	}
@@ -767,11 +767,11 @@ void StartWitchSell()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("Which item is for sale?             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithSell(stextsval);
-	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 	OffsetSTextY(22, 6);
 }
 
@@ -833,10 +833,10 @@ void StartWitchRecharge()
 		/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 		strcpy(tempstr, fmt::format(_("You have nothing to recharge.             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-		AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+		AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
 		AddSLine(3);
 		AddSLine(21);
-		AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+		AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 		OffsetSTextY(22, 6);
 		return;
 	}
@@ -848,11 +848,11 @@ void StartWitchRecharge()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("Recharge which item?             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithSell(stextsval);
-	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 	OffsetSTextY(22, 6);
 }
 
@@ -862,7 +862,7 @@ void StoreNoMoney()
 	stextscrl = false;
 	stextsize = true;
 	ClearSText(5, 23);
-	AddSText(0, 14, _("You do not have enough gold"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 14, _("You do not have enough gold"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 }
 
 void StoreNoRoom()
@@ -870,7 +870,7 @@ void StoreNoRoom()
 	StartStore(stextshold);
 	stextscrl = false;
 	ClearSText(5, 23);
-	AddSText(0, 14, _("You do not have enough room in inventory"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 14, _("You do not have enough room in inventory"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 }
 
 void StoreConfirm()
@@ -931,27 +931,27 @@ void StoreConfirm()
 	default:
 		app_fatal("Unknown store dialog %i", stextshold);
 	}
-	AddSText(0, 15, tempstr, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
-	AddSText(0, 18, _("Yes"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
-	AddSText(0, 20, _("No"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 15, tempstr, UiFlags::ColorSilver | UiFlags::AlignCenter, false);
+	AddSText(0, 18, _("Yes"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
+	AddSText(0, 20, _("No"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 }
 
 void StartBoy()
 {
 	stextsize = false;
 	stextscrl = false;
-	AddSText(0, 2, _("Wirt the Peg-legged boy"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 2, _("Wirt the Peg-legged boy"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(5);
 	if (!boyitem.isEmpty()) {
-		AddSText(0, 8, _("Talk to Wirt"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
-		AddSText(0, 12, _("I have something for sale,"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-		AddSText(0, 14, _("but it will cost 50 gold"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-		AddSText(0, 16, _("just to take a look. "), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-		AddSText(0, 18, _("What have you got?"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
-		AddSText(0, 20, _("Say goodbye"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+		AddSText(0, 8, _("Talk to Wirt"), UiFlags::ColorBlue | UiFlags::AlignCenter, true);
+		AddSText(0, 12, _("I have something for sale,"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+		AddSText(0, 14, _("but it will cost 50 gold"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+		AddSText(0, 16, _("just to take a look. "), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+		AddSText(0, 18, _("What have you got?"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
+		AddSText(0, 20, _("Say goodbye"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 	} else {
-		AddSText(0, 12, _("Talk to Wirt"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
-		AddSText(0, 18, _("Say goodbye"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+		AddSText(0, 12, _("Talk to Wirt"), UiFlags::ColorBlue | UiFlags::AlignCenter, true);
+		AddSText(0, 18, _("Say goodbye"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 	}
 }
 
@@ -963,7 +963,7 @@ void SStartBoyBuy()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("I have this item for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	UiFlags itemColor = boyitem.getTextColorWithStatCheck();
@@ -978,7 +978,7 @@ void SStartBoyBuy()
 	else
 		AddSTextVal(10, boyitem._iIvalue + (boyitem._iIvalue / 2));
 	PrintStoreItem(&boyitem, 11, itemColor);
-	AddSText(0, 22, _("Leave"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 22, _("Leave"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 	OffsetSTextY(22, 6);
 }
 
@@ -999,12 +999,12 @@ void StartHealer()
 	HealPlayer();
 	stextsize = false;
 	stextscrl = false;
-	AddSText(0, 1, _("Welcome to the"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 3, _("Healer's home"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 9, _("Would you like to:"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 12, _("Talk to Pepin"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
-	AddSText(0, 14, _("Buy items"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
-	AddSText(0, 16, _("Leave Healer's home"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 1, _("Welcome to the"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 3, _("Healer's home"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 9, _("Would you like to:"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 12, _("Talk to Pepin"), UiFlags::ColorBlue | UiFlags::AlignCenter, true);
+	AddSText(0, 14, _("Buy items"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
+	AddSText(0, 16, _("Leave Healer's home"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 	AddSLine(5);
 	storenumh = 20;
 }
@@ -1038,11 +1038,11 @@ void StartHealerBuy()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("I have these items for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollHealerBuy(stextsval);
-	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
+	AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, false);
 	OffsetSTextY(22, 6);
 
 	storenumh = 0;
@@ -1058,11 +1058,11 @@ void StartStoryteller()
 {
 	stextsize = false;
 	stextscrl = false;
-	AddSText(0, 2, _("The Town Elder"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 9, _("Would you like to:"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 12, _("Talk to Cain"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
-	AddSText(0, 14, _("Identify an item"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
-	AddSText(0, 18, _("Say goodbye"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 2, _("The Town Elder"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 9, _("Would you like to:"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 12, _("Talk to Cain"), UiFlags::ColorBlue | UiFlags::AlignCenter, true);
+	AddSText(0, 14, _("Identify an item"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
+	AddSText(0, 18, _("Say goodbye"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 	AddSLine(5);
 }
 
@@ -1156,10 +1156,10 @@ void StartStorytellerIdentify()
 		/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 		strcpy(tempstr, fmt::format(_("You have nothing to identify.             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-		AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+		AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
 		AddSLine(3);
 		AddSLine(21);
-		AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+		AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 		OffsetSTextY(22, 6);
 		return;
 	}
@@ -1171,11 +1171,11 @@ void StartStorytellerIdentify()
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
 	strcpy(tempstr, fmt::format(_("Identify which item?             Your gold: {:d}"), myPlayer._pGold).c_str());
 
-	AddSText(0, 1, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithSell(stextsval);
-	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 	OffsetSTextY(22, 6);
 }
 
@@ -1189,10 +1189,10 @@ void StartStorytellerIdentifyShow()
 
 	UiFlags itemColor = item.getTextColorWithStatCheck();
 
-	AddSText(0, 7, _("This item is:"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
+	AddSText(0, 7, _("This item is:"), UiFlags::ColorSilver | UiFlags::AlignCenter, false);
 	AddSText(20, 11, item._iIName, itemColor, false);
 	PrintStoreItem(&item, 12, itemColor);
-	AddSText(0, 18, _("Done"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 18, _("Done"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 }
 
 void StartTalk()
@@ -1202,15 +1202,15 @@ void StartTalk()
 	stextsize = false;
 	stextscrl = false;
 	strcpy(tempstr, fmt::format(_("Talk to {:s}"), TownerNames[talker]).c_str());
-	AddSText(0, 2, tempstr, UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
+	AddSText(0, 2, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(5);
 	if (gbIsSpawn) {
 		strcpy(tempstr, fmt::format(_("Talking to {:s}"), TownerNames[talker]).c_str());
-		AddSText(0, 10, tempstr, UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
-		AddSText(0, 12, _("is not available"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
-		AddSText(0, 14, _("in the shareware"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
-		AddSText(0, 16, _("version"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, false);
-		AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+		AddSText(0, 10, tempstr, UiFlags::ColorSilver | UiFlags::AlignCenter, false);
+		AddSText(0, 12, _("is not available"), UiFlags::ColorSilver | UiFlags::AlignCenter, false);
+		AddSText(0, 14, _("in the shareware"), UiFlags::ColorSilver | UiFlags::AlignCenter, false);
+		AddSText(0, 16, _("version"), UiFlags::ColorSilver | UiFlags::AlignCenter, false);
+		AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 		return;
 	}
 
@@ -1232,23 +1232,23 @@ void StartTalk()
 
 	for (int i = 0; i < MAXQUESTS; i++) {
 		if (Quests[i]._qactive == QUEST_ACTIVE && QuestDialogTable[talker][i] != TEXT_NONE && Quests[i]._qlog) {
-			AddSText(0, sn, _(QuestData[i]._qlstr), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+			AddSText(0, sn, _(QuestData[i]._qlstr), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 			sn += la;
 		}
 	}
-	AddSText(0, sn2, _("Gossip"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
-	AddSText(0, 22, _("Back"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, sn2, _("Gossip"), UiFlags::ColorBlue | UiFlags::AlignCenter, true);
+	AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 }
 
 void StartTavern()
 {
 	stextsize = false;
 	stextscrl = false;
-	AddSText(0, 1, _("Welcome to the"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 3, _("Rising Sun"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 9, _("Would you like to:"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 12, _("Talk to Ogden"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
-	AddSText(0, 18, _("Leave the tavern"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 1, _("Welcome to the"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 3, _("Rising Sun"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 9, _("Would you like to:"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 12, _("Talk to Ogden"), UiFlags::ColorBlue | UiFlags::AlignCenter, true);
+	AddSText(0, 18, _("Leave the tavern"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 	AddSLine(5);
 	storenumh = 20;
 }
@@ -1257,10 +1257,10 @@ void StartBarmaid()
 {
 	stextsize = false;
 	stextscrl = false;
-	AddSText(0, 2, "Gillian", UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 9, _("Would you like to:"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 12, _("Talk to Gillian"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
-	AddSText(0, 18, _("Say goodbye"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 2, "Gillian", UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 9, _("Would you like to:"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 12, _("Talk to Gillian"), UiFlags::ColorBlue | UiFlags::AlignCenter, true);
+	AddSText(0, 18, _("Say goodbye"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 	AddSLine(5);
 	storenumh = 20;
 }
@@ -1269,10 +1269,10 @@ void StartDrunk()
 {
 	stextsize = false;
 	stextscrl = false;
-	AddSText(0, 2, _("Farnham the Drunk"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 9, _("Would you like to:"), UiFlags::UIS_GOLD | UiFlags::UIS_CENTER, false);
-	AddSText(0, 12, _("Talk to Farnham"), UiFlags::UIS_BLUE | UiFlags::UIS_CENTER, true);
-	AddSText(0, 18, _("Say Goodbye"), UiFlags::UIS_SILVER | UiFlags::UIS_CENTER, true);
+	AddSText(0, 2, _("Farnham the Drunk"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 9, _("Would you like to:"), UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 12, _("Talk to Farnham"), UiFlags::ColorBlue | UiFlags::AlignCenter, true);
+	AddSText(0, 18, _("Say Goodbye"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 	AddSLine(5);
 	storenumh = 20;
 }
@@ -2166,13 +2166,13 @@ void DrawSelector(const Surface &out, const Rectangle &rect, const char *text, U
 	int lineWidth = GetLineWidth(text);
 
 	int x1 = rect.position.x - 20;
-	if (HasAnyOf(flags, UiFlags::UIS_CENTER))
+	if (HasAnyOf(flags, UiFlags::AlignCenter))
 		x1 += (rect.size.width - lineWidth) / 2;
 
 	CelDrawTo(out, { x1, rect.position.y + 1 }, *pSPentSpn2Cels, PentSpn2Spin());
 
 	int x2 = rect.position.x + rect.size.width + 5;
-	if (HasAnyOf(flags, UiFlags::UIS_CENTER))
+	if (HasAnyOf(flags, UiFlags::AlignCenter))
 		x2 = rect.position.x + (rect.size.width - lineWidth) / 2 + lineWidth + 5;
 
 	CelDrawTo(out, { x2, rect.position.y + 1 }, *pSPentSpn2Cels, PentSpn2Spin());
@@ -2271,7 +2271,7 @@ void PrintSString(const Surface &out, int margin, int line, const char *text, Ui
 	if (price > 0) {
 		char valstr[32];
 		sprintf(valstr, "%i", price);
-		DrawString(out, valstr, rect, flags | UiFlags::UIS_RIGHT);
+		DrawString(out, valstr, rect, flags | UiFlags::AlignRight);
 	}
 
 	if (stextsel == line) {
@@ -2309,7 +2309,7 @@ void ClearSText(int s, int e)
 		stext[i]._sx = 0;
 		stext[i]._syoff = 0;
 		stext[i]._sstr[0] = 0;
-		stext[i].flags = UiFlags::NONE;
+		stext[i].flags = UiFlags::None;
 		stext[i]._sline = 0;
 		stext[i]._ssel = false;
 		stext[i]._sval = 0;

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -48,7 +48,7 @@ struct STextStruct {
 	int _sx;
 	int _syoff;
 	char _sstr[128];
-	uint16_t flags;
+	UiFlags flags;
 	int _sline;
 	bool _ssel;
 	int _sval;
@@ -98,7 +98,7 @@ void AddStoreHoldRepair(ItemStruct *itm, int8_t i);
 void InitStores();
 void SetupTownStores();
 void FreeStoreMem();
-void PrintSString(const Surface &out, int margin, int line, const char *text, uint16_t flags, int price = 0);
+void PrintSString(const Surface &out, int margin, int line, const char *text, UiFlags flags, int price = 0);
 void DrawSLine(const Surface &out, int y);
 void DrawSTextHelp();
 void ClearSText(int s, int e);


### PR DESCRIPTION
Bit of an experiment to see how scoped enums read when used as a collection of flags, happy for any feedback. The operator overloads are mainly to replicate the implicit conversion to/from int that is allowed with unscoped enums.

~Also provides `operator&&` as a test if a flag is set, though this does cause syntax errors if used in a conditional statement without parentheses to force correct precedence. This may be desirable :)~