### PR TITLE
Timedemo: Regard ProcessInput and gfProgressToNextGameTick

### DIFF
--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -80,7 +80,6 @@ extern bool gbBarbarian;
 extern bool gbQuietMode;
 extern clicktype sgbMouseDown;
 extern uint16_t gnTickDelay;
-extern int logicTick;
 extern char gszProductName[64];
 
 extern MouseActionType LastMouseButtonAction;

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -194,7 +194,7 @@ void interface_msg_pump()
 {
 	tagMSG msg;
 
-	while (FetchMessage(&msg, -1)) {
+	while (FetchMessage(&msg)) {
 		if (msg.message != DVL_WM_QUIT) {
 			TranslateMessage(&msg);
 			PushMessage(&msg);

--- a/Source/miniwin/miniwin.h
+++ b/Source/miniwin/miniwin.h
@@ -33,14 +33,22 @@ struct tagMSG {
 	int32_t lParam;
 };
 
+enum class DemoMsgType {
+	GameTick = 0,
+	Rendering = 1,
+	Message = 2,
+};
+
 struct demoMsg {
-	int tick;
+	DemoMsgType type;
 	uint32_t message;
 	int32_t wParam;
 	int32_t lParam;
+	float progressToNextGameTick;
 };
 
 extern std::ofstream demoRecording;
+bool GetDemoRunGameLoop();
 
 //
 // Everything else
@@ -53,7 +61,7 @@ bool GetAsyncKeyState(int vKey);
 
 void CreateDemoFile(int i);
 bool LoadDemoMessages(int i);
-bool FetchMessage(tagMSG *lpMsg, int tick);
+bool FetchMessage(tagMSG *lpMsg);
 
 bool TranslateMessage(const tagMSG *lpMsg);
 void PushMessage(const tagMSG *lpMsg);

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -42,7 +42,7 @@ void play_movie(const char *pszMovie, bool userCanClose)
 	if (SVidPlayBegin(pszMovie, loop_movie ? 0x100C0808 : 0x10280808)) {
 		tagMSG msg;
 		while (movie_playing) {
-			while (movie_playing && FetchMessage(&msg, -1)) {
+			while (movie_playing && FetchMessage(&msg)) {
 				switch (msg.message) {
 				case DVL_WM_KEYDOWN:
 				case DVL_WM_LBUTTONDOWN:

--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -230,7 +230,7 @@ bool nthread_has_500ms_passed()
 
 void nthread_UpdateProgressToNextGameTick()
 {
-	if (!gbRunGame || PauseMode != 0 || (!gbIsMultiplayer && gmenu_is_active()) || !gbProcessPlayers) // if game is not running or paused there is no next gametick in the near future
+	if (!gbRunGame || PauseMode != 0 || (!gbIsMultiplayer && gmenu_is_active()) || !gbProcessPlayers || timedemo) // if game is not running or paused there is no next gametick in the near future
 		return;
 	int currentTickCount = SDL_GetTicks();
 	int ticksElapsed = last_tick - currentTickCount;


### PR DESCRIPTION
## Example Replay

<details><summary>Example Video</summary>

https://user-images.githubusercontent.com/25415264/127667604-53ef7f87-6d82-475a-a77a-e10b0fd9c37c.mp4

</details>

## Changes

### `ProcessInput` was skipped in replay

Previous the replay only calculated game ticks and never called the [only rendering part](https://github.com/diasurgical/devilutionX/compare/timedemo...obligaron:timedemo?expand=1#diff-84e63ba430a13546a287665b7640118b2f9d66fb9586056bfbab8215bab319c0L842-L847) (game tick is not due). Cause `nthread_has_500ms_passed` returned always true.
That skipped the additional [call](https://github.com/diasurgical/devilutionX/compare/timedemo...obligaron:timedemo?expand=1#diff-84e63ba430a13546a287665b7640118b2f9d66fb9586056bfbab8215bab319c0L843) to `ProcessInput`.
But that changes the replay.
Cause `ProcessInput` sends new _network_ message (for example in `RepeatMouseAction` we have `NetSendCmdParam1(true, rangedAttack ? CMD_RATTACKID : CMD_ATTACKID, pcursmonst);`).

The Problem is that this _network_ messages are added to an internal `message_queue`. And this queue is then parsed in `multi_process_network_packets` and sets for example new `player.destAction`.

But if we skip the additional `ProcessInput` it will be called [too late](https://github.com/diasurgical/devilutionX/blob/2baca9a5ce3798e0ca3cc72fb6b23ccccee9d317/Source/diablo.cpp#L1212) and the game logic doesn't see the new state that otherwise `multi_process_network_packets` would set.

#### Alternative Solutions

- Reorder `ProcessInput` so it's always called before `multi_process_network_packets`.
- Disable additional rendering (and with that `ProcessInput` calls) while recording

### `gfProgressToNextGameTick` needed for game coordinate calculation

ADL and `gfProgressToNextGameTick` is only used for rendering and you could think that rendering is independent from replay logic.
That could be the case, but in our records we store SDL events. SDL events represents mouse movements, clicks etc.
And if we calculate a `game position` from the `mouse position`, we must know what we render to get the correct `game position`. For that case we use [GetOffsetForWalking](https://github.com/diasurgical/devilutionX/blob/2baca9a5ce3798e0ca3cc72fb6b23ccccee9d317/Source/cursor.cpp#L306) and this depends on `gfProgressToNextGameTick`.
That's the reason why this pr stores the current `gfProgressToNextGameTick` for every recorded sdl event.

#### Alternative Solutions

- Use network messages instead of sdl events. But that has it own problems.
- Disable ADL while recording.

## Notes

- This can be improved further. But i think it's a good step.
- While testing I got one desync with the game menu (try to quit the game). But I couldn't reproduce it with another replay and there are still some `SDL_GetTicks` left. So there is still work to do.

I hope this helps a little for future work, testing and more stable releases 🙂 
