### PR TITLE
Timedemo: Support demomode with different speed and decouple fps from recording and replay

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -840,11 +840,13 @@ void RunGameLoop(interface_mode uMsg)
 			break;
 
 		bool drawGame = true;
-		bool runGameLoop = demoMode ? GetDemoRunGameLoop(drawGame) : nthread_has_500ms_passed();
+		bool processInput = true;
+		bool runGameLoop = demoMode ? GetDemoRunGameLoop(drawGame, processInput) : nthread_has_500ms_passed();
 		if (!runGameLoop) {
 			if (recordDemo != -1)
 				demoRecording << static_cast<uint32_t>(DemoMsgType::Rendering) << "," << gfProgressToNextGameTick << "\n";
-			ProcessInput();
+			if (processInput)
+				ProcessInput();
 			if (!drawGame)
 				continue;
 			force_redraw |= 1;

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -839,12 +839,13 @@ void RunGameLoop(interface_mode uMsg)
 		if (!gbRunGame)
 			break;
 
-		bool runGameLoop = demoMode ? GetDemoRunGameLoop() : nthread_has_500ms_passed();
+		bool drawGame = true;
+		bool runGameLoop = demoMode ? GetDemoRunGameLoop(drawGame) : nthread_has_500ms_passed();
 		if (!runGameLoop) {
 			if (recordDemo != -1)
 				demoRecording << static_cast<uint32_t>(DemoMsgType::Rendering) << "," << gfProgressToNextGameTick << "\n";
 			ProcessInput();
-			if (timedemo)
+			if (!drawGame)
 				continue;
 			force_redraw |= 1;
 			DrawAndBlit();
@@ -856,7 +857,8 @@ void RunGameLoop(interface_mode uMsg)
 		multi_process_network_packets();
 		game_loop(gbGameLoopStartup);
 		gbGameLoopStartup = false;
-		DrawAndBlit();
+		if (drawGame)
+			DrawAndBlit();
 		logicTick++;
 #ifdef GPERF_HEAP_FIRST_GAME_ITERATION
 		if (run_game_iteration++ == 0)
@@ -2206,7 +2208,7 @@ void game_loop(bool bStartup)
 		TimeoutCursor(false);
 		GameLogic();
 
-		if (!gbRunGame || !gbIsMultiplayer || !nthread_has_500ms_passed() || timedemo || recordDemo != -1)
+		if (!gbRunGame || !gbIsMultiplayer || !nthread_has_500ms_passed() || demoMode || recordDemo != -1)
 			break;
 	}
 }

--- a/Source/miniwin/miniwin.h
+++ b/Source/miniwin/miniwin.h
@@ -48,7 +48,7 @@ struct demoMsg {
 };
 
 extern std::ofstream demoRecording;
-bool GetDemoRunGameLoop(bool &drawGame);
+bool GetDemoRunGameLoop(bool &drawGame, bool &processInput);
 
 //
 // Everything else

--- a/Source/miniwin/miniwin.h
+++ b/Source/miniwin/miniwin.h
@@ -48,7 +48,7 @@ struct demoMsg {
 };
 
 extern std::ofstream demoRecording;
-bool GetDemoRunGameLoop();
+bool GetDemoRunGameLoop(bool &drawGame);
 
 //
 // Everything else


### PR DESCRIPTION
## Introduction

The new demomode will attract many new customers.
This way we can enhance our profit around 370%!
Also everyone working on the project will get a pay rise of 200% !!!
In my case that means going from 0 straight to 0 * 200% = 0 ! Magnificent! 🤣 

## Content

This PR allows playing the demomode at different speeds then recording (first commit).

After that I separated rendering from recording and replay.
That means the demomode can render more frames and that the rendering frames (between two game ticks) are time-wise correct distributed.