### PR TITLE
Unify character formulas

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1358,7 +1358,7 @@ void DrawChr(const Surface &out)
 		style = UiFlags::ColorBlue;
 	if (myPlayer._pIBonusToHit < 0)
 		style = UiFlags::ColorRed;
-	sprintf(chrstr, "%i%%", (myPlayer._pDexterity / 2) + myPlayer._pIBonusToHit + 50);
+	sprintf(chrstr, "%i%%", (myPlayer.InvBody[INVLOC_HAND_LEFT]._itype == ITYPE_BOW ? myPlayer.GetRangedToHit() : myPlayer.GetMeleeToHit()));
 	DrawString(out, chrstr, { { 258, 211 }, { 43, 0 } }, style | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorSilver;

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1350,7 +1350,7 @@ void DrawChr(const Surface &out)
 		style = UiFlags::ColorBlue;
 	if (myPlayer._pIBonusAC < 0)
 		style = UiFlags::ColorRed;
-	sprintf(chrstr, "%i", myPlayer._pIBonusAC + myPlayer._pIAC + myPlayer._pDexterity / 5);
+	sprintf(chrstr, "%i", myPlayer.GetArmor());
 	DrawString(out, chrstr, { { 258, 183 }, { 43, 0 } }, style | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorSilver;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -244,23 +244,12 @@ bool MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, int t, bool 
 	if (pnum != -1) {
 		const auto &player = Players[pnum];
 		if (MissileData[t].mType == 0) {
-			hper = player._pDexterity;
-			hper += player._pIBonusToHit;
-			hper += player._pLevel;
+			hper = player.GetRangedToHit();
 			hper -= monster.mArmorClass;
 			hper -= (dist * dist) / 2;
 			hper += player._pIEnAc;
-			hper += 50;
-			if (player._pClass == HeroClass::Rogue)
-				hper += 20;
-			if (player._pClass == HeroClass::Warrior || player._pClass == HeroClass::Bard)
-				hper += 10;
 		} else {
-			hper = player._pMagic - (monster.mLevel * 2) - dist + 50;
-			if (player._pClass == HeroClass::Sorcerer)
-				hper += 20;
-			else if (player._pClass == HeroClass::Bard)
-				hper += 10;
+			hper = player.GetMagicToHit() - (monster.mLevel * 2) - dist;
 		}
 	} else {
 		hper = GenerateRnd(75) - monster.mLevel * 2;
@@ -385,24 +374,13 @@ bool Plr2PlrMHit(int pnum, int p, int mindam, int maxdam, int dist, int mtype, b
 
 	int hit;
 	if (MissileData[mtype].mType == 0) {
-		hit = player._pIBonusToHit
-		    + player._pLevel
+		hit = player.GetRangedToHit()
 		    - (dist * dist / 2)
-		    - target.GetArmor()
-		    + player._pDexterity + 50;
-		if (player._pClass == HeroClass::Rogue)
-			hit += 20;
-		if (player._pClass == HeroClass::Warrior || player._pClass == HeroClass::Bard)
-			hit += 10;
+		    - target.GetArmor();
 	} else {
-		hit = player._pMagic
+		hit = player.GetMagicToHit()
 		    - (target._pLevel * 2)
-		    - dist
-		    + 50;
-		if (player._pClass == HeroClass::Sorcerer)
-			hit += 20;
-		else if (player._pClass == HeroClass::Bard)
-			hit += 10;
+		    - dist;
 	}
 
 	hit = clamp(hit, 5, 95);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -388,9 +388,7 @@ bool Plr2PlrMHit(int pnum, int p, int mindam, int maxdam, int dist, int mtype, b
 		hit = player._pIBonusToHit
 		    + player._pLevel
 		    - (dist * dist / 2)
-		    - target._pDexterity / 5
-		    - target._pIBonusAC
-		    - target._pIAC
+		    - target.GetArmor()
 		    + player._pDexterity + 50;
 		if (player._pClass == HeroClass::Rogue)
 			hit += 20;
@@ -1136,7 +1134,7 @@ bool PlayerMHit(int pnum, MonsterStruct *monster, int dist, int mind, int maxd, 
 #endif
 	int hper = 40;
 	if (MissileData[mtype].mType == 0) {
-		int tac = player._pIAC + player._pIBonusAC + player._pDexterity / 5;
+		int tac = player.GetArmor();
 		if (monster != nullptr) {
 			hper = monster->mHit
 			    + ((monster->mLevel - player._pLevel) * 2)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1450,15 +1450,14 @@ void MonsterAttackPlayer(int i, int pnum, int hit, int minDam, int maxDam)
 	if (debug_mode_dollar_sign || debug_mode_key_inverted_v)
 		hper = 1000;
 #endif
-	int ac = player._pIBonusAC + player._pIAC;
+	int ac = player.GetArmor();
 	if ((player.pDamAcFlags & ISPLHF_ACDEMON) != 0 && monster.MData->mMonstClass == MC_DEMON)
 		ac += 40;
 	if ((player.pDamAcFlags & ISPLHF_ACUNDEAD) != 0 && monster.MData->mMonstClass == MC_UNDEAD)
 		ac += 20;
 	hit += 2 * (monster.mLevel - player._pLevel)
 	    + 30
-	    - ac
-	    - player._pDexterity / 5;
+	    - ac;
 	if (hit < 15)
 		hit = 15;
 	if (currlevel == 14 && hit < 20)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1106,7 +1106,7 @@ bool PlrHitPlr(int pnum, int8_t p)
 
 	int hit = GenerateRnd(100);
 
-	int hper = (attacker._pDexterity / 2) + attacker._pLevel + 50 - (target._pIBonusAC + target._pIAC + target._pDexterity / 5);
+	int hper = (attacker._pDexterity / 2) + attacker._pLevel + 50 - target.GetArmor();
 
 	if (attacker._pClass == HeroClass::Warrior) {
 		hper += 20;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -912,11 +912,7 @@ bool PlrHitMonst(int pnum, int m)
 		tmac -= player._pIEnAc;
 	}
 
-	hper += (player._pDexterity / 2) + player._pLevel + 50 - tmac;
-	if (player._pClass == HeroClass::Warrior) {
-		hper += 20;
-	}
-	hper += player._pIBonusToHit;
+	hper += player.GetMeleeToHit() - tmac;
 	hper = clamp(hper, 5, 95);
 
 	bool ret = false;
@@ -1106,12 +1102,8 @@ bool PlrHitPlr(int pnum, int8_t p)
 
 	int hit = GenerateRnd(100);
 
-	int hper = (attacker._pDexterity / 2) + attacker._pLevel + 50 - target.GetArmor();
+	int hper = attacker.GetMeleeToHit() - target.GetArmor();
 
-	if (attacker._pClass == HeroClass::Warrior) {
-		hper += 20;
-	}
-	hper += attacker._pIBonusToHit;
 	if (hper < 5) {
 		hper = 5;
 	}

--- a/Source/player.h
+++ b/Source/player.h
@@ -396,6 +396,14 @@ struct PlayerStruct {
 	void Reset();
 
 	/**
+	 * @brief Return player's armor value
+	 */
+	int GetArmor() const
+	{
+		return _pIBonusAC + _pIAC + _pDexterity / 5;
+	}
+
+	/**
 	 * @brief Calculates the players current Hit Points as a percentage of their max HP and stores it for later reference
 	 *
 	 * The stored value is unused...

--- a/Source/player.h
+++ b/Source/player.h
@@ -32,6 +32,8 @@ namespace devilution {
 #define MAX_SPELL_LEVEL 15
 #define PLR_NAME_LEN 32
 
+constexpr int BaseHitChance = 50;
+
 /** Walking directions */
 enum {
 	// clang-format off
@@ -401,6 +403,43 @@ struct PlayerStruct {
 	int GetArmor() const
 	{
 		return _pIBonusAC + _pIAC + _pDexterity / 5;
+	}
+
+	/**
+	 * @brief Return player's melee to hit value
+	 */
+	int GetMeleeToHit() const
+	{
+		int hper = _pLevel + _pDexterity / 2 + _pIBonusToHit + BaseHitChance;
+		if (_pClass == HeroClass::Warrior)
+			hper += 20;
+		return hper;
+	}
+
+	/**
+	 * @brief Return player's ranged to hit value
+	 */
+	int GetRangedToHit() const
+	{
+		int hper = _pLevel + _pDexterity + _pIBonusToHit + BaseHitChance;
+		if (_pClass == HeroClass::Rogue)
+			hper += 20;
+		else if (_pClass == HeroClass::Warrior || _pClass == HeroClass::Bard)
+			hper += 10;
+		return hper;
+	}
+
+	/**
+	 * @brief Return magic hit chance
+	 */
+	int GetMagicToHit() const
+	{
+		int hper = _pMagic + BaseHitChance;
+		if (_pClass == HeroClass::Sorcerer)
+			hper += 20;
+		else if (_pClass == HeroClass::Bard)
+			hper += 10;
+		return hper;
 	}
 
 	/**


### PR DESCRIPTION
This finally makes the to hit value shown in character panel useful - I had no idea how broken it was before.
It was basically always showing melee hit chance formula, which gains 1% per 2 dex while ranged gains 1% per 1 dex, which is a huge difference! I also made it include class bonuses and character level = it finally shows the real value that gets used in actual hit chance calculating