### PR TITLE
SDL stuff: automatic memory management and error checking, part 1 of N

### DIFF
--- a/Source/DiabloUI/art.cpp
+++ b/Source/DiabloUI/art.cpp
@@ -8,6 +8,7 @@
 #include "utils/display.h"
 #include "utils/log.hpp"
 #include "utils/sdl_compat.h"
+#include "utils/sdl_wrap.h"
 
 namespace devilution {
 namespace {
@@ -121,7 +122,7 @@ void LoadArt(const char *pszFile, Art *art, int frames, SDL_Color *pPalette)
 		return;
 	}
 
-	SDLSurfaceUniquePtr artSurface { SDL_CreateRGBSurfaceWithFormat(SDL_SWSURFACE, width, height, bpp, GetPcxSdlPixelFormat(bpp)) };
+	SDLSurfaceUniquePtr artSurface = SDLWrap::CreateRGBSurfaceWithFormat(SDL_SWSURFACE, width, height, bpp, GetPcxSdlPixelFormat(bpp));
 	if (!LoadPcxPixelsAndPalette(handle, width, height, bpp, static_cast<BYTE *>(artSurface->pixels),
 	        artSurface->pitch, pPalette)) {
 		Log("LoadArt(\"{}\"): LoadPcxPixelsAndPalette failed with code {}", pszFile, SErrGetLastError());

--- a/Source/DiabloUI/credits.cpp
+++ b/Source/DiabloUI/credits.cpp
@@ -16,6 +16,7 @@
 #include "utils/log.hpp"
 #include "utils/sdl_compat.h"
 #include "utils/sdl_ptrs.h"
+#include "utils/sdl_wrap.h"
 
 namespace devilution {
 
@@ -77,7 +78,7 @@ CachedLine PrepareLine(std::size_t index)
 	SDLSurfaceUniquePtr surface;
 	if (text != nullptr) {
 		// Set up the target surface to have 3 colors: mask, text, and shadow.
-		surface = SDLSurfaceUniquePtr { SDL_CreateRGBSurfaceWithFormat(0, text->w + ShadowOffsetX, text->h + ShadowOffsetY, 8, SDL_PIXELFORMAT_INDEX8) };
+		surface = SDLWrap::CreateRGBSurfaceWithFormat(0, text->w + ShadowOffsetX, text->h + ShadowOffsetY, 8, SDL_PIXELFORMAT_INDEX8);
 		const SDL_Color maskColor = { 0, 255, 0, 0 }; // Any color different from both shadow and text
 		const SDL_Color &textColor = Palette->colors[224];
 		SDL_Color colors[3] = { maskColor, textColor, shadowColor };

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -18,7 +18,7 @@
 #include "utils/display.h"
 #include "utils/log.hpp"
 #include "utils/sdl_compat.h"
-#include "utils/sdl_ptrs.h"
+#include "utils/sdl_wrap.h"
 #include "utils/stubs.h"
 #include "utils/utf8.h"
 
@@ -484,7 +484,7 @@ void LoadHeros()
 		portraitOrder[static_cast<std::size_t>(HeroClass::Barbarian)] = 6;
 	}
 
-	SDL_Surface *heros = SDL_CreateRGBSurfaceWithFormat(0, ArtHero.w(), portraitHeight * (static_cast<int>(enum_size<HeroClass>::value) + 1), 8, SDL_PIXELFORMAT_INDEX8);
+	SDLSurfaceUniquePtr heros = SDLWrap::CreateRGBSurfaceWithFormat(0, ArtHero.w(), portraitHeight * (static_cast<int>(enum_size<HeroClass>::value) + 1), 8, SDL_PIXELFORMAT_INDEX8);
 
 	for (int i = 0; i <= static_cast<int>(enum_size<HeroClass>::value); i++) {
 		int offset = portraitOrder[i] * portraitHeight;
@@ -493,7 +493,7 @@ void LoadHeros()
 		}
 		SDL_Rect srcRect = MakeRect(0, offset, ArtHero.w(), portraitHeight);
 		SDL_Rect dstRect = MakeRect(0, i * portraitHeight, ArtHero.w(), portraitHeight);
-		SDL_BlitSurface(ArtHero.surface.get(), &srcRect, heros, &dstRect);
+		SDL_BlitSurface(ArtHero.surface.get(), &srcRect, heros.get(), &dstRect);
 	}
 
 	for (int i = 0; i <= static_cast<int>(enum_size<HeroClass>::value); i++) {
@@ -505,10 +505,10 @@ void LoadHeros()
 			continue;
 
 		SDL_Rect dstRect = MakeRect(0, i * portraitHeight, portrait.w(), portraitHeight);
-		SDL_BlitSurface(portrait.surface.get(), nullptr, heros, &dstRect);
+		SDL_BlitSurface(portrait.surface.get(), nullptr, heros.get(), &dstRect);
 	}
 
-	ArtHero.surface = SDLSurfaceUniquePtr { heros };
+	ArtHero.surface = std::move(heros);
 	ArtHero.frame_height = portraitHeight;
 	ArtHero.frames = static_cast<int>(enum_size<HeroClass>::value);
 }

--- a/Source/DiabloUI/text_draw.cpp
+++ b/Source/DiabloUI/text_draw.cpp
@@ -42,9 +42,9 @@ void DrawTTF(const char *text, const SDL_Rect &rectIn, UiFlags flags,
 
 	const auto xAlign = XAlignmentFromFlags(flags);
 	if (renderCache.text == nullptr)
-		renderCache.text = ScaleSurfaceToOutput(SDLSurfaceUniquePtr { RenderUTF8_Solid_Wrapped(font, text, textColor, rect.w, xAlign) });
+		renderCache.text = ScaleSurfaceToOutput(RenderUTF8_Solid_Wrapped(font, text, textColor, rect.w, xAlign));
 	if (renderCache.shadow == nullptr)
-		renderCache.shadow = ScaleSurfaceToOutput(SDLSurfaceUniquePtr { RenderUTF8_Solid_Wrapped(font, text, shadowColor, rect.w, xAlign) });
+		renderCache.shadow = ScaleSurfaceToOutput(RenderUTF8_Solid_Wrapped(font, text, shadowColor, rect.w, xAlign));
 
 	SDL_Surface *textSurface = renderCache.text.get();
 	SDL_Surface *shadowSurface = renderCache.shadow.get();

--- a/Source/DiabloUI/ttf_render_wrapped.cpp
+++ b/Source/DiabloUI/ttf_render_wrapped.cpp
@@ -14,6 +14,7 @@
 
 #include "utils/log.hpp"
 #include "utils/sdl_compat.h"
+#include "utils/sdl_wrap.h"
 
 namespace devilution {
 
@@ -107,9 +108,7 @@ SDLSurfaceUniquePtr RenderUTF8_Solid_Wrapped(TTF_Font *font, const char *text, S
 		return SDLSurfaceUniquePtr{ TTF_RenderText_Solid(font, text, fg) };
 
 	/* Create the target surface */
-	SDLSurfaceUniquePtr textbuf { SDL_CreateRGBSurface(SDL_SWSURFACE, (strLines.size() > 1) ? wrapLength : width, height * strLines.size() + (lineSpace * (strLines.size() - 1)), 8, 0, 0, 0, 0) };
-	if (textbuf == nullptr)
-		return {};
+	auto textbuf = SDLWrap::CreateRGBSurface(SDL_SWSURFACE, (strLines.size() > 1) ? wrapLength : width, height * strLines.size() + (lineSpace * (strLines.size() - 1)), 8, 0, 0, 0, 0);
 
 	/* Fill the palette with the foreground color */
 	SDL_Palette *palette = textbuf->format->palette;

--- a/Source/DiabloUI/ttf_render_wrapped.cpp
+++ b/Source/DiabloUI/ttf_render_wrapped.cpp
@@ -43,7 +43,7 @@ SDLSurfaceUniquePtr RenderUTF8_Solid_Wrapped(TTF_Font *font, const char *text, S
 		return {};
 	}
 
-	std::unique_ptr<char []> str;
+	std::unique_ptr<char[]> str;
 	std::vector<char *> strLines;
 	if (wrapLength > 0 && *text != '\0') {
 		const std::size_t strLen = std::strlen(text);

--- a/Source/DiabloUI/ttf_render_wrapped.cpp
+++ b/Source/DiabloUI/ttf_render_wrapped.cpp
@@ -15,6 +15,7 @@
 #include "utils/log.hpp"
 #include "utils/sdl_compat.h"
 #include "utils/sdl_wrap.h"
+#include "utils/ttf_wrap.h"
 
 namespace devilution {
 
@@ -105,7 +106,7 @@ SDLSurfaceUniquePtr RenderUTF8_Solid_Wrapped(TTF_Font *font, const char *text, S
 	}
 
 	if (strLines.empty())
-		return SDLSurfaceUniquePtr{ TTF_RenderText_Solid(font, text, fg) };
+		return TTFWrap::RenderText_Solid(font, text, fg);
 
 	/* Create the target surface */
 	auto textbuf = SDLWrap::CreateRGBSurface(SDL_SWSURFACE, (strLines.size() > 1) ? wrapLength : width, height * strLines.size() + (lineSpace * (strLines.size() - 1)), 8, 0, 0, 0, 0);
@@ -128,11 +129,7 @@ SDLSurfaceUniquePtr RenderUTF8_Solid_Wrapped(TTF_Font *font, const char *text, S
 			dest.y += lineskip;
 			continue;
 		}
-		SDLSurfaceUniquePtr tmp { TTF_RenderText_Solid(font, text, fg) };
-		if (tmp == nullptr) {
-			Log("{}", TTF_GetError());
-			return {};
-		}
+		SDLSurfaceUniquePtr tmp = TTFWrap::RenderText_Solid(font, text, fg);
 
 		dest.w = static_cast<Uint16>(tmp->w);
 		dest.h = static_cast<Uint16>(tmp->h);

--- a/Source/DiabloUI/ttf_render_wrapped.h
+++ b/Source/DiabloUI/ttf_render_wrapped.h
@@ -2,6 +2,7 @@
 
 #include <SDL_ttf.h>
 #include <cstdint>
+#include "utils/sdl_ptrs.h"
 
 namespace devilution {
 
@@ -17,7 +18,7 @@ enum TextAlignment : uint8_t {
  *
  * This method is slow. Caching the result is recommended.
  */
-SDL_Surface *RenderUTF8_Solid_Wrapped(
+SDLSurfaceUniquePtr RenderUTF8_Solid_Wrapped(
     TTF_Font *font, const char *text, SDL_Color fg, Uint32 wrapLength, const int xAlign = TextAlignment_BEGIN);
 
 } // namespace devilution

--- a/Source/appfat.h
+++ b/Source/appfat.h
@@ -13,6 +13,8 @@ namespace devilution {
 
 #define ErrSdl() ErrDlg("SDL Error", SDL_GetError(), __FILE__, __LINE__)
 
+#define ErrTtf() ErrDlg("TTF Error", TTF_GetError(), __FILE__, __LINE__)
+
 #undef assert
 
 #ifndef _DEBUG

--- a/Source/hwcursor.cpp
+++ b/Source/hwcursor.cpp
@@ -74,7 +74,7 @@ bool SetHardwareCursor(SDL_Surface *surface, HotpointPosition hotpointPosition)
 		// SDL does not support BlitScaled from 8-bit to RGBA.
 		SDLSurfaceUniquePtr converted { SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_ARGB8888, 0) };
 
-		SDLSurfaceUniquePtr scaledSurface =  SDLWrap::CreateRGBSurfaceWithFormat(0, scaledSize.width, scaledSize.height, 32, SDL_PIXELFORMAT_ARGB8888);
+		SDLSurfaceUniquePtr scaledSurface = SDLWrap::CreateRGBSurfaceWithFormat(0, scaledSize.width, scaledSize.height, 32, SDL_PIXELFORMAT_ARGB8888);
 		SDL_BlitScaled(converted.get(), nullptr, scaledSurface.get(), nullptr);
 		const Point hotpoint = GetHotpointPosition(*scaledSurface, hotpointPosition);
 		newCursor = SDLCursorUniquePtr { SDL_CreateColorCursor(scaledSurface.get(), hotpoint.x, hotpoint.y) };
@@ -101,7 +101,7 @@ bool SetHardwareCursorFromSprite(int pcurs)
 	if (!IsCursorSizeAllowed(size))
 		return false;
 
-	auto out = Surface::Alloc(size.width, size.height);
+	OwnedSurface out { size };
 	SDL_SetSurfacePalette(out.surface, Palette);
 
 	// Transparent color must not be used in the sprite itself.
@@ -112,7 +112,6 @@ bool SetHardwareCursorFromSprite(int pcurs)
 	CelDrawCursor(out, { outlineWidth, size.height - outlineWidth }, pcurs);
 
 	const bool result = SetHardwareCursor(out.surface, isItem ? HotpointPosition::Center : HotpointPosition::TopLeft);
-	out.Free();
 	return result;
 }
 #endif

--- a/Source/hwcursor.cpp
+++ b/Source/hwcursor.cpp
@@ -15,7 +15,7 @@
 #include "cursor.h"
 #include "engine.h"
 #include "utils/display.h"
-#include "utils/sdl_ptrs.h"
+#include "utils/sdl_wrap.h"
 
 namespace devilution {
 namespace {
@@ -74,7 +74,7 @@ bool SetHardwareCursor(SDL_Surface *surface, HotpointPosition hotpointPosition)
 		// SDL does not support BlitScaled from 8-bit to RGBA.
 		SDLSurfaceUniquePtr converted { SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_ARGB8888, 0) };
 
-		SDLSurfaceUniquePtr scaledSurface { SDL_CreateRGBSurfaceWithFormat(0, scaledSize.width, scaledSize.height, 32, SDL_PIXELFORMAT_ARGB8888) };
+		SDLSurfaceUniquePtr scaledSurface =  SDLWrap::CreateRGBSurfaceWithFormat(0, scaledSize.width, scaledSize.height, 32, SDL_PIXELFORMAT_ARGB8888);
 		SDL_BlitScaled(converted.get(), nullptr, scaledSurface.get(), nullptr);
 		const Point hotpoint = GetHotpointPosition(*scaledSurface, hotpointPosition);
 		newCursor = SDLCursorUniquePtr { SDL_CreateColorCursor(scaledSurface.get(), hotpoint.x, hotpoint.y) };

--- a/Source/utils/sdl_wrap.h
+++ b/Source/utils/sdl_wrap.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <SDL.h>
+#ifdef USE_SDL1
+#include "utils/sdl2_to_1_2_backports.h"
+#else
+#include "utils/sdl2_backports.h"
+#endif
+
+#include "appfat.h"
+#include "utils/sdl_ptrs.h"
+
+namespace devilution {
+
+namespace SDLWrap {
+
+inline SDLSurfaceUniquePtr CreateRGBSurface(Uint32 flags, int width, int height, int depth, Uint32 Rmask, Uint32 Gmask, Uint32 Bmask, Uint32 Amask)
+{
+	SDLSurfaceUniquePtr ret { SDL_CreateRGBSurface(flags, width, height, depth, Rmask, Gmask, Bmask, Amask) };
+	if (ret == nullptr)
+		ErrSdl();
+
+	return ret;
+}
+
+} //namespace SDLWrap
+
+} //namespace devilution

--- a/Source/utils/sdl_wrap.h
+++ b/Source/utils/sdl_wrap.h
@@ -23,6 +23,15 @@ inline SDLSurfaceUniquePtr CreateRGBSurface(Uint32 flags, int width, int height,
 	return ret;
 }
 
+inline SDLSurfaceUniquePtr CreateRGBSurfaceWithFormat(Uint32 flags, int width, int height, int depth, Uint32 format)
+{
+	SDLSurfaceUniquePtr ret { SDL_CreateRGBSurfaceWithFormat(flags, width, height, depth, format) };
+	if (ret == nullptr)
+		ErrSdl();
+
+	return ret;
+}
+
 } //namespace SDLWrap
 
 } //namespace devilution

--- a/Source/utils/ttf_wrap.h
+++ b/Source/utils/ttf_wrap.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <SDL_ttf.h>
+#include <SDL.h>
+#ifdef USE_SDL1
+#include "utils/sdl2_to_1_2_backports.h"
+#else
+#include "utils/sdl2_backports.h"
+#endif
+
+#include "appfat.h"
+#include "utils/sdl_ptrs.h"
+
+namespace devilution {
+
+namespace TTFWrap {
+
+inline SDLSurfaceUniquePtr RenderText_Solid(TTF_Font *font, const char *text, SDL_Color fg)
+{
+	SDLSurfaceUniquePtr ret { TTF_RenderText_Solid(font, text, fg) };
+	if (ret == nullptr)
+		ErrTtf();
+
+	return ret;
+}
+
+} //namespace TTFWrap
+
+} //namespace devilution


### PR DESCRIPTION
This patch introduces wrappers for a few SDL functions. These wrappers perform error checking and return the appropriate type of unique_ptr.

The wrappers introduced are not employed exhaustively yet. It also includes a refactoring of RenderUTF8_Solid_Wrapped.

The rationale is two-fold:

- Automatic error checking: there are multiple instances in the codebase where the function inside one of these wrappers is called, but no error checking is performed. If the function returns NULL, something bad will happen at a later time.
- The programmer no longer has to figure out what kind of unique_ptr to wrap the result in.

Case in point: RenderUTF8_Solid_Wrapped would return an error when the string was empty, or when some SDL-related error occurred. Its caller, DrawTTF, calls it twice, passing the same text, but only checks the 1st result, falsely assuming that either both would succeed or both would fail.