### PR TITLE
🐞 Fix reading PCX files with odd widths

### DIFF
--- a/Source/DiabloUI/art.cpp
+++ b/Source/DiabloUI/art.cpp
@@ -44,6 +44,7 @@ bool LoadPcxPixelsAndPalette(HANDLE handle, int width, int height, std::uint8_t 
 		return false;
 	}
 	const unsigned xSkip = bufferPitch - width;
+	const unsigned srcSkip = width % 2;
 	BYTE *dataPtr = fileBuffer.get();
 	for (int j = 0; j < height; j++) {
 		for (int x = 0; x < width;) {
@@ -60,6 +61,7 @@ bool LoadPcxPixelsAndPalette(HANDLE handle, int width, int height, std::uint8_t 
 			buffer += runLength;
 			x += runLength;
 		}
+		dataPtr += srcSkip;
 		buffer += xSkip;
 	}
 


### PR DESCRIPTION
PCX files always have an even number of bytes on each uncompressed source line, which means there is an unused byte of each compressed line if the width is odd.

References:

1. https://kaba.hilvi.org/pastel-1.5.0/pastel/gfx/image_file/pcx/pcx_file.htm
2. https://www.moon-soft.com/program/FORMAT/graphics/pcx.htm#decoding%20.pcx%20files