### PR TITLE
Center the sub-panels (Quest, Character, Spell and Inventory)

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -456,7 +456,7 @@ int DrawDurIcon4Item(const Surface &out, ItemStruct *pItem, int x, int c)
 
 void PrintSBookStr(const Surface &out, Point position, const char *text)
 {
-	DrawString(out, text, { { RIGHT_PANEL_X + SPLICONLENGTH + position.x, position.y }, { 222, 0 } }, UiFlags::ColorSilver);
+	DrawString(out, text, { { RIGHT_PANEL_X + SPLICONLENGTH + position.x, RIGHT_PANEL_Y + position.y }, { 222, 0 } }, UiFlags::ColorSilver);
 }
 
 spell_type GetSBookTrans(spell_id ii, bool townok)
@@ -1322,16 +1322,16 @@ void DrawChr(const Surface &out)
 
 	auto &myPlayer = Players[MyPlayerId];
 
-	CelDrawTo(out, { 0, 351 }, *pChrPanel, 1);
-	DrawString(out, myPlayer._pName, { { 20, 32 }, { 131, 0 } }, UiFlags::ColorSilver | UiFlags::AlignCenter);
+	CelDrawTo(out, { LEFT_PANEL_X, LEFT_PANEL_Y + 351 }, *pChrPanel, 1);
+	DrawString(out, myPlayer._pName, { { LEFT_PANEL_X + 20, LEFT_PANEL_Y + 32 }, { 131, 0 } }, UiFlags::ColorSilver | UiFlags::AlignCenter);
 
-	DrawString(out, _(ClassStrTbl[static_cast<std::size_t>(myPlayer._pClass)]), { { 168, 32 }, { 131, 0 } }, UiFlags::ColorSilver | UiFlags::AlignCenter);
+	DrawString(out, _(ClassStrTbl[static_cast<std::size_t>(myPlayer._pClass)]), { { LEFT_PANEL_X + 168, LEFT_PANEL_Y + 32 }, { 131, 0 } }, UiFlags::ColorSilver | UiFlags::AlignCenter);
 
 	sprintf(chrstr, "%i", myPlayer._pLevel);
-	DrawString(out, chrstr, { { 66, 69 }, { 43, 0 } }, UiFlags::ColorSilver | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 66, LEFT_PANEL_Y + 69 }, { 43, 0 } }, UiFlags::ColorSilver | UiFlags::AlignCenter);
 
 	sprintf(chrstr, "%i", myPlayer._pExperience);
-	DrawString(out, chrstr, { { 216, 69 }, { 84, 0 } }, UiFlags::ColorSilver | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 216, LEFT_PANEL_Y + 69 }, { 84, 0 } }, UiFlags::ColorSilver | UiFlags::AlignCenter);
 
 	if (myPlayer._pLevel == MAXCHARLEVEL - 1) {
 		strcpy(chrstr, _("None"));
@@ -1340,10 +1340,10 @@ void DrawChr(const Surface &out)
 		sprintf(chrstr, "%i", myPlayer._pNextExper);
 		style = UiFlags::ColorSilver;
 	}
-	DrawString(out, chrstr, { { 216, 97 }, { 84, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 216, LEFT_PANEL_Y + 97 }, { 84, 0 } }, style | UiFlags::AlignCenter);
 
 	sprintf(chrstr, "%i", myPlayer._pGold);
-	DrawString(out, chrstr, { { 216, 146 }, { 84, 0 } }, UiFlags::ColorSilver | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 216, LEFT_PANEL_Y + 146 }, { 84, 0 } }, UiFlags::ColorSilver | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorSilver;
 	if (myPlayer._pIBonusAC > 0)
@@ -1351,7 +1351,7 @@ void DrawChr(const Surface &out)
 	if (myPlayer._pIBonusAC < 0)
 		style = UiFlags::ColorRed;
 	sprintf(chrstr, "%i", myPlayer.GetArmor());
-	DrawString(out, chrstr, { { 258, 183 }, { 43, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 258, LEFT_PANEL_Y + 183 }, { 43, 0 } }, style | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorSilver;
 	if (myPlayer._pIBonusToHit > 0)
@@ -1359,7 +1359,7 @@ void DrawChr(const Surface &out)
 	if (myPlayer._pIBonusToHit < 0)
 		style = UiFlags::ColorRed;
 	sprintf(chrstr, "%i%%", (myPlayer.InvBody[INVLOC_HAND_LEFT]._itype == ITYPE_BOW ? myPlayer.GetRangedToHit() : myPlayer.GetMeleeToHit()));
-	DrawString(out, chrstr, { { 258, 211 }, { 43, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 258, LEFT_PANEL_Y + 211 }, { 43, 0 } }, style | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorSilver;
 	if (myPlayer._pIBonusDam > 0)
@@ -1390,9 +1390,9 @@ void DrawChr(const Surface &out)
 	}
 	sprintf(chrstr, "%i-%i", mindam, maxdam);
 	if (mindam >= 100 || maxdam >= 100)
-		DrawString(out, chrstr, { { 254, 239 }, { 51, 0 } }, style | UiFlags::AlignCenter, -1);
+		DrawString(out, chrstr, { { LEFT_PANEL_X + 254, LEFT_PANEL_Y + 239 }, { 51, 0 } }, style | UiFlags::AlignCenter, -1);
 	else
-		DrawString(out, chrstr, { { 258, 239 }, { 43, 0 } }, style | UiFlags::AlignCenter, 0);
+		DrawString(out, chrstr, { { LEFT_PANEL_X + 258, LEFT_PANEL_Y + 239 }, { 43, 0 } }, style | UiFlags::AlignCenter, 0);
 
 	style = UiFlags::ColorBlue;
 	if (myPlayer._pMagResist == 0)
@@ -1403,7 +1403,7 @@ void DrawChr(const Surface &out)
 		style = UiFlags::ColorGold;
 		strcpy(chrstr, _(/* TRANSLATORS: UI Constrains. Keep translation short please!*/ "MAX"));
 	}
-	DrawString(out, chrstr, { { 257, 276 }, { 43, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 257, LEFT_PANEL_Y + 276 }, { 43, 0 } }, style | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorBlue;
 	if (myPlayer._pFireResist == 0)
@@ -1414,7 +1414,7 @@ void DrawChr(const Surface &out)
 		style = UiFlags::ColorGold;
 		strcpy(chrstr, _("MAX"));
 	}
-	DrawString(out, chrstr, { { 257, 304 }, { 43, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 257, LEFT_PANEL_Y + 304 }, { 43, 0 } }, style | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorBlue;
 	if (myPlayer._pLghtResist == 0)
@@ -1425,31 +1425,31 @@ void DrawChr(const Surface &out)
 		style = UiFlags::ColorGold;
 		strcpy(chrstr, _("MAX"));
 	}
-	DrawString(out, chrstr, { { 257, 332 }, { 43, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 257, LEFT_PANEL_Y + 332 }, { 43, 0 } }, style | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorSilver;
 	sprintf(chrstr, "%i", myPlayer._pBaseStr);
 	if (myPlayer.GetMaximumAttributeValue(CharacterAttribute::Strength) == myPlayer._pBaseStr)
 		style = UiFlags::ColorGold;
-	DrawString(out, chrstr, { { 95, 155 }, { 31, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 95, LEFT_PANEL_Y + 155 }, { 31, 0 } }, style | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorSilver;
 	sprintf(chrstr, "%i", myPlayer._pBaseMag);
 	if (myPlayer.GetMaximumAttributeValue(CharacterAttribute::Magic) == myPlayer._pBaseMag)
 		style = UiFlags::ColorGold;
-	DrawString(out, chrstr, { { 95, 183 }, { 31, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 95, LEFT_PANEL_Y + 183 }, { 31, 0 } }, style | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorSilver;
 	sprintf(chrstr, "%i", myPlayer._pBaseDex);
 	if (myPlayer.GetMaximumAttributeValue(CharacterAttribute::Dexterity) == myPlayer._pBaseDex)
 		style = UiFlags::ColorGold;
-	DrawString(out, chrstr, { { 95, 211 }, { 31, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 95, LEFT_PANEL_Y + 211 }, { 31, 0 } }, style | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorSilver;
 	sprintf(chrstr, "%i", myPlayer._pBaseVit);
 	if (myPlayer.GetMaximumAttributeValue(CharacterAttribute::Vitality) == myPlayer._pBaseVit)
 		style = UiFlags::ColorGold;
-	DrawString(out, chrstr, { { 95, 239 }, { 31, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 95, LEFT_PANEL_Y + 239 }, { 31, 0 } }, style | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorSilver;
 	if (myPlayer._pStrength > myPlayer._pBaseStr)
@@ -1457,7 +1457,7 @@ void DrawChr(const Surface &out)
 	if (myPlayer._pStrength < myPlayer._pBaseStr)
 		style = UiFlags::ColorRed;
 	sprintf(chrstr, "%i", myPlayer._pStrength);
-	DrawString(out, chrstr, { { 143, 155 }, { 30, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 143, LEFT_PANEL_Y + 155 }, { 30, 0 } }, style | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorSilver;
 	if (myPlayer._pMagic > myPlayer._pBaseMag)
@@ -1465,7 +1465,7 @@ void DrawChr(const Surface &out)
 	if (myPlayer._pMagic < myPlayer._pBaseMag)
 		style = UiFlags::ColorRed;
 	sprintf(chrstr, "%i", myPlayer._pMagic);
-	DrawString(out, chrstr, { { 143, 183 }, { 30, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 143, LEFT_PANEL_Y + 183 }, { 30, 0 } }, style | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorSilver;
 	if (myPlayer._pDexterity > myPlayer._pBaseDex)
@@ -1473,7 +1473,7 @@ void DrawChr(const Surface &out)
 	if (myPlayer._pDexterity < myPlayer._pBaseDex)
 		style = UiFlags::ColorRed;
 	sprintf(chrstr, "%i", myPlayer._pDexterity);
-	DrawString(out, chrstr, { { 143, 211 }, { 30, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 143, LEFT_PANEL_Y + 211 }, { 30, 0 } }, style | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorSilver;
 	if (myPlayer._pVitality > myPlayer._pBaseVit)
@@ -1481,7 +1481,7 @@ void DrawChr(const Surface &out)
 	if (myPlayer._pVitality < myPlayer._pBaseVit)
 		style = UiFlags::ColorRed;
 	sprintf(chrstr, "%i", myPlayer._pVitality);
-	DrawString(out, chrstr, { { 143, 239 }, { 30, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 143, LEFT_PANEL_Y + 239 }, { 30, 0 } }, style | UiFlags::AlignCenter);
 
 	if (myPlayer._pStatPts > 0) {
 		if (CalcStatDiff(myPlayer) < myPlayer._pStatPts) {
@@ -1490,36 +1490,36 @@ void DrawChr(const Surface &out)
 	}
 	if (myPlayer._pStatPts > 0) {
 		sprintf(chrstr, "%i", myPlayer._pStatPts);
-		DrawString(out, chrstr, { { 95, 266 }, { 31, 0 } }, UiFlags::ColorRed | UiFlags::AlignCenter);
+		DrawString(out, chrstr, { { LEFT_PANEL_X + 95, LEFT_PANEL_Y + 266 }, { 31, 0 } }, UiFlags::ColorRed | UiFlags::AlignCenter);
 		if (myPlayer._pBaseStr < myPlayer.GetMaximumAttributeValue(CharacterAttribute::Strength))
-			CelDrawTo(out, { 137, 159 }, *pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Strength)] ? 3 : 2);
+			CelDrawTo(out, { LEFT_PANEL_X + 137, LEFT_PANEL_Y + 159 }, *pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Strength)] ? 3 : 2);
 		if (myPlayer._pBaseMag < myPlayer.GetMaximumAttributeValue(CharacterAttribute::Magic))
-			CelDrawTo(out, { 137, 187 }, *pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Magic)] ? 5 : 4);
+			CelDrawTo(out, { LEFT_PANEL_X + 137, LEFT_PANEL_Y + 187 }, *pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Magic)] ? 5 : 4);
 		if (myPlayer._pBaseDex < myPlayer.GetMaximumAttributeValue(CharacterAttribute::Dexterity))
-			CelDrawTo(out, { 137, 216 }, *pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Dexterity)] ? 7 : 6);
+			CelDrawTo(out, { LEFT_PANEL_X + 137, LEFT_PANEL_Y + 216 }, *pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Dexterity)] ? 7 : 6);
 		if (myPlayer._pBaseVit < myPlayer.GetMaximumAttributeValue(CharacterAttribute::Vitality))
-			CelDrawTo(out, { 137, 244 }, *pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Vitality)] ? 9 : 8);
+			CelDrawTo(out, { LEFT_PANEL_X + 137, LEFT_PANEL_Y + 244 }, *pChrButtons, chrbtn[static_cast<size_t>(CharacterAttribute::Vitality)] ? 9 : 8);
 	}
 
 	style = UiFlags::ColorSilver;
 	if (myPlayer._pMaxHP > myPlayer._pMaxHPBase)
 		style = UiFlags::ColorBlue;
 	sprintf(chrstr, "%i", myPlayer._pMaxHP >> 6);
-	DrawString(out, chrstr, { { 95, 304 }, { 31, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 95, LEFT_PANEL_Y + 304 }, { 31, 0 } }, style | UiFlags::AlignCenter);
 	if (myPlayer._pHitPoints != myPlayer._pMaxHP)
 		style = UiFlags::ColorRed;
 	sprintf(chrstr, "%i", myPlayer._pHitPoints >> 6);
-	DrawString(out, chrstr, { { 143, 304 }, { 31, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 143, LEFT_PANEL_Y + 304 }, { 31, 0 } }, style | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorSilver;
 	if (myPlayer._pMaxMana > myPlayer._pMaxManaBase)
 		style = UiFlags::ColorBlue;
 	sprintf(chrstr, "%i", myPlayer._pMaxMana >> 6);
-	DrawString(out, chrstr, { { 95, 332 }, { 31, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 95, LEFT_PANEL_Y + 332 }, { 31, 0 } }, style | UiFlags::AlignCenter);
 	if (myPlayer._pMana != myPlayer._pMaxMana)
 		style = UiFlags::ColorRed;
 	sprintf(chrstr, "%i", myPlayer._pMana >> 6);
-	DrawString(out, chrstr, { { 143, 332 }, { 31, 0 } }, style | UiFlags::AlignCenter);
+	DrawString(out, chrstr, { { LEFT_PANEL_X + 143, LEFT_PANEL_Y + 332 }, { 31, 0 } }, style | UiFlags::AlignCenter);
 }
 
 void CheckLvlBtn()
@@ -1574,7 +1574,7 @@ void CheckChrBtns()
 			continue;
 		}
 		auto buttonId = static_cast<size_t>(attribute);
-		if (ChrBtnsRect[buttonId].Contains(MousePosition)) {
+		if (ChrBtnsRect[buttonId].Contains({ MousePosition.x - LEFT_PANEL_X, MousePosition.y - LEFT_PANEL_Y })) {
 			chrbtn[buttonId] = true;
 			chrbtnactive = true;
 		}
@@ -1590,7 +1590,7 @@ void ReleaseChrBtns(bool addAllStatPoints)
 			continue;
 
 		chrbtn[buttonId] = false;
-		if (ChrBtnsRect[buttonId].Contains(MousePosition)) {
+		if (ChrBtnsRect[buttonId].Contains({ MousePosition.x - LEFT_PANEL_X, MousePosition.y - LEFT_PANEL_Y })) {
 			auto &myPlayer = Players[MyPlayerId];
 			int statPointsToAdd = 1;
 			if (addAllStatPoints)
@@ -1655,16 +1655,16 @@ void RedBack(const Surface &out)
 
 void DrawSpellBook(const Surface &out)
 {
-	CelDrawTo(out, { RIGHT_PANEL_X, 351 }, *pSpellBkCel, 1);
+	CelDrawTo(out, { RIGHT_PANEL_X, RIGHT_PANEL_Y + 351 }, *pSpellBkCel, 1);
 	if (gbIsHellfire && sbooktab < 5) {
-		CelDrawTo(out, { RIGHT_PANEL_X + 61 * sbooktab + 7, 348 }, *pSBkBtnCel, sbooktab + 1);
+		CelDrawTo(out, { RIGHT_PANEL_X + 61 * sbooktab + 7, RIGHT_PANEL_Y + 348 }, *pSBkBtnCel, sbooktab + 1);
 	} else {
 		// BUGFIX: rendering of page 3 and page 4 buttons are both off-by-one pixel (fixed).
 		int sx = RIGHT_PANEL_X + 76 * sbooktab + 7;
 		if (sbooktab == 2 || sbooktab == 3) {
 			sx++;
 		}
-		CelDrawTo(out, { sx, 348 }, *pSBkBtnCel, sbooktab + 1);
+		CelDrawTo(out, { sx, RIGHT_PANEL_Y + 348 }, *pSBkBtnCel, sbooktab + 1);
 	}
 	auto &myPlayer = Players[MyPlayerId];
 	uint64_t spl = myPlayer._pMemSpells | myPlayer._pISpells | myPlayer._pAblSpells;
@@ -1675,7 +1675,7 @@ void DrawSpellBook(const Surface &out)
 		if (sn != SPL_INVALID && (spl & GetSpellBitmask(sn)) != 0) {
 			spell_type st = GetSBookTrans(sn, true);
 			SetSpellTrans(st);
-			const Point spellCellPosition { RIGHT_PANEL_X + 11, yp };
+			const Point spellCellPosition { RIGHT_PANEL_X + 11, RIGHT_PANEL_Y + yp };
 			DrawSpellCel(out, spellCellPosition, *pSBkIconCels, SpellITbl[sn]);
 			if (sn == myPlayer._pRSpell && st == myPlayer._pRSplType) {
 				SetSpellTrans(RSPLTYPE_SKILL);
@@ -1723,8 +1723,8 @@ void DrawSpellBook(const Surface &out)
 
 void CheckSBook()
 {
-	if (MousePosition.x >= RIGHT_PANEL + 11 && MousePosition.x < RIGHT_PANEL + 48 && MousePosition.y >= 18 && MousePosition.y < 314) {
-		spell_id sn = SpellPages[sbooktab][(MousePosition.y - 18) / 43];
+	if (MousePosition.x >= RIGHT_PANEL_X + 11 && MousePosition.x < RIGHT_PANEL_X + 48 && MousePosition.y >= RIGHT_PANEL_Y + 18 && MousePosition.y < RIGHT_PANEL_Y + 314) {
+		spell_id sn = SpellPages[sbooktab][(MousePosition.y - RIGHT_PANEL_Y - 18) / 43];
 		auto &myPlayer = Players[MyPlayerId];
 		uint64_t spl = myPlayer._pMemSpells | myPlayer._pISpells | myPlayer._pAblSpells;
 		if (sn != SPL_INVALID && (spl & GetSpellBitmask(sn)) != 0) {
@@ -1740,8 +1740,8 @@ void CheckSBook()
 			force_redraw = 255;
 		}
 	}
-	if (MousePosition.x >= RIGHT_PANEL + 7 && MousePosition.x < RIGHT_PANEL + 311 && MousePosition.y >= SPANEL_WIDTH && MousePosition.y < 349) {
-		sbooktab = (MousePosition.x - (RIGHT_PANEL + 7)) / (gbIsHellfire ? 61 : 76);
+	if (MousePosition.x >= RIGHT_PANEL_X + 7 && MousePosition.x < RIGHT_PANEL_X + 311 && MousePosition.y >= RIGHT_PANEL_Y + SPANEL_WIDTH && MousePosition.y < RIGHT_PANEL_Y + 349) {
+		sbooktab = (MousePosition.x - (RIGHT_PANEL_X + 7)) / (gbIsHellfire ? 61 : 76);
 	}
 }
 
@@ -1749,7 +1749,7 @@ void DrawGoldSplit(const Surface &out, int amount)
 {
 	const int dialogX = RIGHT_PANEL_X + 30;
 
-	CelDrawTo(out, { dialogX, 178 }, *pGBoxBuff, 1);
+	CelDrawTo(out, { dialogX, RIGHT_PANEL_Y + 178 }, *pGBoxBuff, 1);
 
 	constexpr auto BufferSize = sizeof(tempstr) / sizeof(*tempstr);
 
@@ -1775,7 +1775,7 @@ void DrawGoldSplit(const Surface &out, int amount)
 	// The split gold dialog is roughly 4 lines high, but we need at least one line for the player to input an amount.
 	// Using a clipping region 50 units high (approx 3 lines with a lineheight of 17) to ensure there is enough room left
 	//  for the text entered by the player.
-	DrawString(out, tempstr, { { dialogX + 31, 87 }, { 200, 50 } }, UiFlags::ColorGold | UiFlags::AlignCenter, 1, 17);
+	DrawString(out, tempstr, { { dialogX + 31, RIGHT_PANEL_Y + 87 }, { 200, 50 } }, UiFlags::ColorGold | UiFlags::AlignCenter, 1, 17);
 
 	tempstr[0] = '\0';
 	if (amount > 0) {
@@ -1784,7 +1784,7 @@ void DrawGoldSplit(const Surface &out, int amount)
 	}
 	// Even a ten digit amount of gold only takes up about half a line. There's no need to wrap or clip text here so we
 	// use the Point form of DrawString.
-	DrawString(out, tempstr, Point { dialogX + 37, 140 }, UiFlags::ColorSilver, 1, -1, true);
+	DrawString(out, tempstr, Point { dialogX + 37, RIGHT_PANEL_Y + 140 }, UiFlags::ColorSilver, 1, -1, true);
 }
 
 void control_drop_gold(char vkey)

--- a/Source/control.h
+++ b/Source/control.h
@@ -27,8 +27,10 @@ namespace devilution {
 
 #define SPANEL_WIDTH 320
 #define SPANEL_HEIGHT 352
-#define RIGHT_PANEL (gnScreenWidth - SPANEL_WIDTH)
-#define RIGHT_PANEL_X RIGHT_PANEL
+#define LEFT_PANEL_X (gnScreenWidth / 4 - SPANEL_WIDTH / 2)
+#define LEFT_PANEL_Y ((gnScreenHeight - PANEL_HEIGHT - SPANEL_HEIGHT) / 2)
+#define RIGHT_PANEL_X (LEFT_PANEL_X + gnScreenWidth / 2)
+#define RIGHT_PANEL_Y LEFT_PANEL_Y
 
 extern bool drawhpflag;
 extern bool dropGoldFlag;

--- a/Source/control.h
+++ b/Source/control.h
@@ -27,9 +27,9 @@ namespace devilution {
 
 #define SPANEL_WIDTH 320
 #define SPANEL_HEIGHT 352
-#define LEFT_PANEL_X (gnScreenWidth / 4 - SPANEL_WIDTH / 2)
+#define LEFT_PANEL_X 0
 #define LEFT_PANEL_Y ((gnScreenHeight - PANEL_HEIGHT - SPANEL_HEIGHT) / 2)
-#define RIGHT_PANEL_X (LEFT_PANEL_X + gnScreenWidth / 2)
+#define RIGHT_PANEL_X (gnScreenWidth - SPANEL_WIDTH)
 #define RIGHT_PANEL_Y LEFT_PANEL_Y
 
 extern bool drawhpflag;

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -488,7 +488,7 @@ void AttrIncBtnSnap(AxisDirection dir)
 
 Point InvGetEquipSlotCoord(const inv_body_loc invSlot)
 {
-	Point result { RIGHT_PANEL, 0 };
+	Point result { RIGHT_PANEL_X, RIGHT_PANEL_Y };
 	result.x -= (icursW28 - 1) * (InventorySlotSizeInPixels.width / 2);
 	switch (invSlot) {
 	case INVLOC_HEAD:
@@ -558,7 +558,7 @@ Point InvGetEquipSlotCoordFromInvSlot(const inv_xy_slot slot)
 Point InvGetSlotCoord(int slot)
 {
 	assert(slot <= SLOTXY_INV_LAST);
-	return { InvRect[slot].x + RIGHT_PANEL, InvRect[slot].y };
+	return { InvRect[slot].x + RIGHT_PANEL_X, InvRect[slot].y + RIGHT_PANEL_Y };
 }
 
 /**

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -430,14 +430,14 @@ void CheckCursMove()
 	if (DoomFlag) {
 		return;
 	}
-	if (invflag && MousePosition.x > RIGHT_PANEL && MousePosition.y <= SPANEL_HEIGHT) {
+	if (invflag && MousePosition.x > RIGHT_PANEL_X && MousePosition.x < RIGHT_PANEL_X + SPANEL_WIDTH && MousePosition.y > RIGHT_PANEL_Y && MousePosition.y < RIGHT_PANEL_Y + SPANEL_HEIGHT) {
 		pcursinvitem = CheckInvHLight();
 		return;
 	}
-	if (sbookflag && MousePosition.x > RIGHT_PANEL && MousePosition.y <= SPANEL_HEIGHT) {
+	if (sbookflag && MousePosition.x > RIGHT_PANEL_X && MousePosition.x < RIGHT_PANEL_X + SPANEL_WIDTH && MousePosition.y > RIGHT_PANEL_Y && MousePosition.y < RIGHT_PANEL_Y + SPANEL_HEIGHT) {
 		return;
 	}
-	if ((chrflag || QuestLogIsOpen) && MousePosition.x < SPANEL_WIDTH && MousePosition.y <= SPANEL_HEIGHT) {
+	if ((chrflag || QuestLogIsOpen) && MousePosition.x > LEFT_PANEL_X && MousePosition.x < LEFT_PANEL_X + SPANEL_WIDTH && MousePosition.y > LEFT_PANEL_Y && MousePosition.y < LEFT_PANEL_Y + SPANEL_HEIGHT) {
 		return;
 	}
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -327,17 +327,17 @@ void LeftMouseDown(int wParam)
 
 	if (MousePosition.y < PANEL_TOP || MousePosition.x < PANEL_LEFT || MousePosition.x >= PANEL_LEFT + PANEL_WIDTH) {
 		if (!gmenu_is_active() && !TryIconCurs()) {
-			if (QuestLogIsOpen && MousePosition.x > 32 && MousePosition.x < 288 && MousePosition.y > 32 && MousePosition.y < 308) {
+			if (QuestLogIsOpen && MousePosition.x > LEFT_PANEL_X + 32 && MousePosition.x < LEFT_PANEL_X + 288 && MousePosition.y > LEFT_PANEL_Y + 32 && MousePosition.y < LEFT_PANEL_Y + 308) {
 				QuestlogESC();
 			} else if (qtextflag) {
 				qtextflag = false;
 				stream_stop();
-			} else if (chrflag && MousePosition.x < SPANEL_WIDTH && MousePosition.y < SPANEL_HEIGHT) {
+			} else if (chrflag && MousePosition.x > LEFT_PANEL_X && MousePosition.x < LEFT_PANEL_X + SPANEL_WIDTH && MousePosition.y > LEFT_PANEL_Y && MousePosition.y < LEFT_PANEL_Y + SPANEL_HEIGHT) {
 				CheckChrBtns();
-			} else if (invflag && MousePosition.x > RIGHT_PANEL && MousePosition.y < SPANEL_HEIGHT) {
+			} else if (invflag && MousePosition.x > RIGHT_PANEL_X && MousePosition.x < RIGHT_PANEL_X + SPANEL_WIDTH && MousePosition.y > RIGHT_PANEL_Y && MousePosition.y < RIGHT_PANEL_Y + SPANEL_HEIGHT) {
 				if (!dropGoldFlag)
 					CheckInvItem(isShiftHeld);
-			} else if (sbookflag && MousePosition.x > RIGHT_PANEL && MousePosition.y < SPANEL_HEIGHT) {
+			} else if (sbookflag && MousePosition.x > RIGHT_PANEL_X && MousePosition.x < RIGHT_PANEL_X + SPANEL_WIDTH && MousePosition.y > RIGHT_PANEL_Y && MousePosition.y < RIGHT_PANEL_Y + SPANEL_HEIGHT) {
 				CheckSBook();
 			} else if (pcurs >= CURSOR_FIRSTITEM) {
 				if (TryInvPut()) {
@@ -393,8 +393,8 @@ void RightMouseDown()
 		SetSpell();
 		return;
 	}
-	if (MousePosition.y >= SPANEL_HEIGHT
-	    || ((!sbookflag || MousePosition.x <= RIGHT_PANEL)
+	if (MousePosition.y <= RIGHT_PANEL_Y || MousePosition.y >= RIGHT_PANEL_Y + SPANEL_HEIGHT
+	    || ((!sbookflag || MousePosition.x <= RIGHT_PANEL_X || MousePosition.x >= RIGHT_PANEL_X + SPANEL_WIDTH)
 	        && !TryIconCurs()
 	        && (pcursinvitem == -1 || !UseInvItem(MyPlayerId, pcursinvitem)))) {
 		if (pcurs == CURSOR_HAND) {

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -364,8 +364,8 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 	bool done = false;
 	int r = 0;
 	for (; r < NUM_XY_SLOTS && !done; r++) {
-		int xo = RIGHT_PANEL;
-		int yo = 0;
+		int xo = RIGHT_PANEL_X;
+		int yo = RIGHT_PANEL_Y;
 		if (r >= SLOTXY_BELT_FIRST) {
 			xo = PANEL_LEFT;
 			yo = PANEL_TOP;
@@ -708,8 +708,8 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove)
 
 	uint32_t r = 0;
 	for (; r < NUM_XY_SLOTS; r++) {
-		int xo = RIGHT_PANEL;
-		int yo = 0;
+		int xo = RIGHT_PANEL_X;
+		int yo = RIGHT_PANEL_Y;
 		if (r >= SLOTXY_BELT_FIRST) {
 			xo = PANEL_LEFT;
 			yo = PANEL_TOP;
@@ -1126,7 +1126,7 @@ void InitInv()
 
 void DrawInv(const Surface &out)
 {
-	CelDrawTo(out, { RIGHT_PANEL_X, 351 }, *pInvCels, 1);
+	CelDrawTo(out, { RIGHT_PANEL_X, RIGHT_PANEL_Y + 351 }, *pInvCels, 1);
 
 	Size slotSize[] = {
 		{ 2, 2 }, //head
@@ -1154,7 +1154,7 @@ void DrawInv(const Surface &out)
 		if (!myPlayer.InvBody[slot].isEmpty()) {
 			int screenX = slotPos[slot].x;
 			int screenY = slotPos[slot].y;
-			InvDrawSlotBack(out, { RIGHT_PANEL_X + screenX, screenY }, { slotSize[slot].width * InventorySlotSizeInPixels.width, slotSize[slot].height * InventorySlotSizeInPixels.height });
+			InvDrawSlotBack(out, { RIGHT_PANEL_X + screenX, RIGHT_PANEL_Y + screenY }, { slotSize[slot].width * InventorySlotSizeInPixels.width, slotSize[slot].height * InventorySlotSizeInPixels.height });
 
 			int frame = myPlayer.InvBody[slot]._iCurs + CURSOR_FIRSTITEM;
 
@@ -1171,7 +1171,7 @@ void DrawInv(const Surface &out)
 
 			const auto &cel = GetInvItemSprite(frame);
 			const int celFrame = GetInvItemFrame(frame);
-			const Point position { RIGHT_PANEL_X + screenX, screenY };
+			const Point position { RIGHT_PANEL_X + screenX, RIGHT_PANEL_Y + screenY };
 
 			if (pcursinvitem == slot) {
 				CelBlitOutlineTo(out, GetOutlineColor(myPlayer.InvBody[slot], true), position, cel, celFrame, false);
@@ -1184,12 +1184,12 @@ void DrawInv(const Surface &out)
 					if (myPlayer._pClass != HeroClass::Barbarian
 					    || (myPlayer.InvBody[slot]._itype != ITYPE_SWORD
 					        && myPlayer.InvBody[slot]._itype != ITYPE_MACE)) {
-						InvDrawSlotBack(out, { RIGHT_PANEL_X + slotPos[INVLOC_HAND_RIGHT].x, slotPos[INVLOC_HAND_RIGHT].y }, { slotSize[INVLOC_HAND_RIGHT].width * InventorySlotSizeInPixels.width, slotSize[INVLOC_HAND_RIGHT].height * InventorySlotSizeInPixels.height });
+						InvDrawSlotBack(out, { RIGHT_PANEL_X + slotPos[INVLOC_HAND_RIGHT].x, RIGHT_PANEL_Y + slotPos[INVLOC_HAND_RIGHT].y }, { slotSize[INVLOC_HAND_RIGHT].width * InventorySlotSizeInPixels.width, slotSize[INVLOC_HAND_RIGHT].height * InventorySlotSizeInPixels.height });
 						LightTableIndex = 0;
 						cel_transparency_active = true;
 
 						const int dstX = RIGHT_PANEL_X + slotPos[INVLOC_HAND_RIGHT].x + (frameSize.width == InventorySlotSizeInPixels.width ? INV_SLOT_HALF_SIZE_PX : 0) - 1;
-						const int dstY = slotPos[INVLOC_HAND_RIGHT].y;
+						const int dstY = RIGHT_PANEL_Y + slotPos[INVLOC_HAND_RIGHT].y;
 						CelClippedBlitLightTransTo(out, { dstX, dstY }, cel, celFrame);
 
 						cel_transparency_active = false;
@@ -1203,7 +1203,7 @@ void DrawInv(const Surface &out)
 		if (myPlayer.InvGrid[i] != 0) {
 			InvDrawSlotBack(
 			    out,
-			    InvRect[i + SLOTXY_INV_FIRST] + Displacement { RIGHT_PANEL_X, -1 },
+			    InvRect[i + SLOTXY_INV_FIRST] + Displacement { RIGHT_PANEL_X, RIGHT_PANEL_Y - 1 },
 			    InventorySlotSizeInPixels);
 		}
 	}
@@ -1215,7 +1215,7 @@ void DrawInv(const Surface &out)
 
 			const auto &cel = GetInvItemSprite(frame);
 			const int celFrame = GetInvItemFrame(frame);
-			const Point position { InvRect[j + SLOTXY_INV_FIRST].x + RIGHT_PANEL_X, InvRect[j + SLOTXY_INV_FIRST].y - 1 };
+			const Point position { InvRect[j + SLOTXY_INV_FIRST].x + RIGHT_PANEL_X, InvRect[j + SLOTXY_INV_FIRST].y + RIGHT_PANEL_Y - 1 };
 			if (pcursinvitem == ii + INVITEM_INV_FIRST) {
 				CelBlitOutlineTo(
 				    out,
@@ -1880,8 +1880,8 @@ char CheckInvHLight()
 {
 	uint32_t r = 0;
 	for (; r < NUM_XY_SLOTS; r++) {
-		int xo = RIGHT_PANEL;
-		int yo = 0;
+		int xo = RIGHT_PANEL_X;
+		int yo = RIGHT_PANEL_Y;
 		if (r >= SLOTXY_BELT_FIRST) {
 			xo = PANEL_LEFT;
 			yo = PANEL_TOP;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2025,14 +2025,14 @@ void PrintItemOil(char iDidx)
 
 void DrawUniqueInfoWindow(const Surface &out)
 {
-	CelDrawTo(out, { RIGHT_PANEL_X - SPANEL_WIDTH + 24, 327 }, *pSTextBoxCels, 1);
-	DrawHalfTransparentRectTo(out, RIGHT_PANEL_X - SPANEL_WIDTH + 27, 28, 265, 297);
+	CelDrawTo(out, { RIGHT_PANEL_X - SPANEL_WIDTH + 24, RIGHT_PANEL_Y + 327 }, *pSTextBoxCels, 1);
+	DrawHalfTransparentRectTo(out, RIGHT_PANEL_X - SPANEL_WIDTH + 27, RIGHT_PANEL_Y + 28, 265, 297);
 }
 
 void DrawUniqueInfoDevider(const Surface &out, int y)
 {
-	BYTE *src = out.at(26 + RIGHT_PANEL - SPANEL_WIDTH, 25);
-	BYTE *dst = out.at(26 + RIGHT_PANEL_X - SPANEL_WIDTH, y * 12 + 38);
+	BYTE *src = out.at(26 + RIGHT_PANEL_X - SPANEL_WIDTH, RIGHT_PANEL_Y + 25);
+	BYTE *dst = out.at(26 + RIGHT_PANEL_X - SPANEL_WIDTH, RIGHT_PANEL_Y + y * 12 + 38);
 
 	for (int i = 0; i < 3; i++, src += out.pitch(), dst += out.pitch())
 		memcpy(dst, src, 267); // BUGFIX: should be 267 (fixed)
@@ -4130,13 +4130,13 @@ void PrintItemPower(char plidx, ItemStruct *x)
 
 void DrawUniqueInfo(const Surface &out)
 {
-	if ((chrflag || QuestLogIsOpen) && gnScreenWidth < SPANEL_WIDTH * 3) {
+	if ((chrflag || QuestLogIsOpen) && RIGHT_PANEL_X - SPANEL_WIDTH < LEFT_PANEL_X + SPANEL_WIDTH) {
 		return;
 	}
 
 	DrawUniqueInfoWindow(GlobalBackBuffer());
 
-	Rectangle rect { { 32 + RIGHT_PANEL - SPANEL_WIDTH, 44 + 2 * 12 }, { 257, 0 } };
+	Rectangle rect { { 32 + RIGHT_PANEL_X - SPANEL_WIDTH, 44 + RIGHT_PANEL_Y + 2 * 12 }, { 257, 0 } };
 	const UItemStruct &uitem = UniqueItemList[curruitem._iUid];
 	DrawString(out, _(uitem.UIName), rect, UiFlags::AlignCenter);
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3544,12 +3544,12 @@ void CheckPlrSpell()
 		if (pcurs != CURSOR_HAND)
 			return;
 
-		if (MousePosition.y >= PANEL_TOP && MousePosition.x >= PANEL_LEFT && MousePosition.x <= RIGHT_PANEL) // inside main panel
+		if (MousePosition.y >= PANEL_TOP && MousePosition.x >= PANEL_LEFT && MousePosition.x <= PANEL_LEFT + PANEL_WIDTH) // inside main panel
 			return;
 
 		if (
-		    ((chrflag || QuestLogIsOpen) && MousePosition.x < SPANEL_WIDTH && MousePosition.y < SPANEL_HEIGHT) // inside left panel
-		    || ((invflag || sbookflag) && MousePosition.x > RIGHT_PANEL && MousePosition.y < SPANEL_HEIGHT)    // inside right panel
+		    ((chrflag || QuestLogIsOpen) && MousePosition.x > LEFT_PANEL_X && MousePosition.x < LEFT_PANEL_X + SPANEL_WIDTH && MousePosition.y > LEFT_PANEL_Y && MousePosition.y < LEFT_PANEL_Y + SPANEL_HEIGHT) // inside left panel
+		    || ((invflag || sbookflag) && MousePosition.x > RIGHT_PANEL_X && MousePosition.x < RIGHT_PANEL_X + SPANEL_WIDTH && MousePosition.y > RIGHT_PANEL_Y && MousePosition.y < RIGHT_PANEL_Y + SPANEL_HEIGHT) // inside right panel
 		) {
 			if (rspell != SPL_HEAL
 			    && rspell != SPL_IDENTIFY

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -93,9 +93,9 @@ void AddItemToLabelQueue(int id, int x, int y)
 
 bool IsMouseOverGameArea()
 {
-	if ((invflag || sbookflag) && MousePosition.x > RIGHT_PANEL && MousePosition.y <= SPANEL_HEIGHT)
+	if ((invflag || sbookflag) && MousePosition.x > RIGHT_PANEL_X && MousePosition.x < RIGHT_PANEL_X + SPANEL_WIDTH && MousePosition.y > RIGHT_PANEL_Y && MousePosition.y < RIGHT_PANEL_Y + SPANEL_HEIGHT)
 		return false;
-	if ((chrflag || QuestLogIsOpen) && MousePosition.x < SPANEL_WIDTH && MousePosition.y <= SPANEL_HEIGHT)
+	if ((chrflag || QuestLogIsOpen) && MousePosition.x > LEFT_PANEL_X && MousePosition.x < LEFT_PANEL_X + SPANEL_WIDTH && MousePosition.y > LEFT_PANEL_Y && MousePosition.y < LEFT_PANEL_Y + SPANEL_HEIGHT)
 		return false;
 	if (MousePosition.y >= PANEL_TOP && MousePosition.x >= PANEL_LEFT && MousePosition.x <= PANEL_LEFT + PANEL_WIDTH)
 		return false;

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -252,11 +252,11 @@ void PrintQLString(const Surface &out, int x, int line, const char *str)
 	int sx = x + std::max((257 - width) / 2, 0);
 	int sy = line * 12 + 44;
 	if (qline == line) {
-		CelDrawTo(out, { sx - 20, sy + 1 }, *pSPentSpn2Cels, PentSpn2Spin());
+		CelDrawTo(out, { LEFT_PANEL_X + sx - 20, LEFT_PANEL_Y + sy + 1 }, *pSPentSpn2Cels, PentSpn2Spin());
 	}
-	DrawString(out, str, { { sx, sy }, { 257, 0 } }, UiFlags::ColorSilver);
+	DrawString(out, str, { { LEFT_PANEL_X + sx, LEFT_PANEL_Y + sy }, { 257, 0 } }, UiFlags::ColorSilver);
 	if (qline == line) {
-		CelDrawTo(out, { sx + width + 7, sy + 1 }, *pSPentSpn2Cels, PentSpn2Spin());
+		CelDrawTo(out, { LEFT_PANEL_X + sx + width + 7, LEFT_PANEL_Y + sy + 1 }, *pSPentSpn2Cels, PentSpn2Spin());
 	}
 }
 
@@ -730,8 +730,8 @@ void ResyncQuests()
 
 void DrawQuestLog(const Surface &out)
 {
-	DrawString(out, _("Quest Log"), { { 32, 44 }, { 257, 0 } }, UiFlags::AlignCenter);
-	CelDrawTo(out, { 0, 351 }, *pQLogCel, 1);
+	DrawString(out, _("Quest Log"), { { LEFT_PANEL_X + 32, LEFT_PANEL_Y + 44 }, { 257, 0 } }, UiFlags::AlignCenter);
+	CelDrawTo(out, { LEFT_PANEL_X, LEFT_PANEL_Y + 351 }, *pQLogCel, 1);
 	int line = qtopline;
 	for (int i = 0; i < numqlines; i++) {
 		PrintQLString(out, 32, line, _(QuestData[qlist[i]]._qlstr));
@@ -798,7 +798,7 @@ void QuestlogEnter()
 
 void QuestlogESC()
 {
-	int y = (MousePosition.y - 32) / 12;
+	int y = (MousePosition.y - LEFT_PANEL_Y - 32) / 12;
 	for (int i = 0; i < numqlines; i++) {
 		if (y == qtopline + 2 * i) {
 			qline = y;

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1212,7 +1212,7 @@ void DrawView(const Surface &out, int startX, int startY)
 		DrawQuestLog(out);
 	}
 	if (!chrflag && Players[MyPlayerId]._pStatPts != 0 && !spselflag
-	    && (!QuestLogIsOpen || gnScreenHeight >= SPANEL_HEIGHT + PANEL_HEIGHT + 74 || gnScreenWidth >= 4 * SPANEL_WIDTH)) {
+	    && (!QuestLogIsOpen || PANEL_Y >= LEFT_PANEL_Y + SPANEL_HEIGHT + 74 || PANEL_X >= LEFT_PANEL_X + SPANEL_WIDTH)) {
 		DrawLevelUpIcon(out);
 	}
 	if (ShowUniqueItemInfoBox) {


### PR DESCRIPTION
According to screen resolution to center the sub-panels

[1440x900]
![1440x900_Char_Inv](https://user-images.githubusercontent.com/88471771/128295671-b5f4b28b-10cb-4f72-8af5-a489d2a74ea0.png)
![1440x900_Quest_Spell](https://user-images.githubusercontent.com/88471771/128295693-aecb6dd4-9a5e-4b55-adf1-4d50bdd20a6e.png)

[800x600]
![800x600_Char_Inv](https://user-images.githubusercontent.com/88471771/128295707-f8ebab15-5169-4b6c-97b5-11ce9e9619fc.png)
![800x600_Quest_Spell](https://user-images.githubusercontent.com/88471771/128295717-f24fc5d4-5911-4423-bce5-ec4bf3ca2edd.png)

[640x480]
![640x480_Char_Inv](https://user-images.githubusercontent.com/88471771/128295727-6720e02c-38f0-4cd9-aa02-fa83a29eb468.png)
![640x480_Quest_Spell](https://user-images.githubusercontent.com/88471771/128295739-45c34272-d0c0-4c20-9efb-4b90a22b4e21.png)
