### PR TITLE
Eliminate a lot of string copies

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -57,7 +57,7 @@ bool talkflag;
 bool sbookflag;
 bool chrflag;
 bool drawbtnflag;
-char infostr[64];
+StringVariant infostr;
 bool panelflag;
 int initialDropGoldValue;
 bool panbtndown;
@@ -401,7 +401,7 @@ void PrintInfo(const Surface &out)
 
 	int yo = 0;
 	int lo = 1;
-	if (infostr[0] != '\0') {
+	if (infostr.length() > 0) {
 		DrawString(out, infostr, line, InfoColor | UiFlags::AlignCenter | UiFlags::KerningFitSpacing, 2);
 		yo = 1;
 		lo = 0;
@@ -591,7 +591,7 @@ void DrawSpellList(const Surface &out)
 	uint64_t mask;
 
 	pSpell = SPL_INVALID;
-	infostr[0] = '\0';
+	infostr = "";
 	Point location;
 	int &x = location.x;
 	int &y = location.y;
@@ -650,10 +650,10 @@ void DrawSpellList(const Surface &out)
 				DrawSpellCel(out, location, *pSpellCels, c);
 				switch (pSplType) {
 				case RSPLTYPE_SKILL:
-					strcpy(infostr, fmt::format(_("{:s} Skill"), _(spelldata[pSpell].sSkillText)).c_str());
+					infostr = fmt::format(_("{:s} Skill"), _(spelldata[pSpell].sSkillText));
 					break;
 				case RSPLTYPE_SPELL:
-					strcpy(infostr, fmt::format(_("{:s} Spell"), _(spelldata[pSpell].sNameText)).c_str());
+					infostr = fmt::format(_("{:s} Spell"), _(spelldata[pSpell].sNameText));
 					if (pSpell == SPL_HBOLT) {
 						strcpy(tempstr, _("Damages undead only"));
 						AddPanelString(tempstr);
@@ -665,7 +665,7 @@ void DrawSpellList(const Surface &out)
 					AddPanelString(tempstr);
 					break;
 				case RSPLTYPE_SCROLL: {
-					strcpy(infostr, fmt::format(_("Scroll of {:s}"), _(spelldata[pSpell].sNameText)).c_str());
+					infostr = fmt::format(_("Scroll of {:s}"), _(spelldata[pSpell].sNameText));
 					int v = 0;
 					for (int t = 0; t < myPlayer._pNumInv; t++) {
 						if (!myPlayer.InvList[t].isEmpty()
@@ -685,7 +685,7 @@ void DrawSpellList(const Surface &out)
 					AddPanelString(tempstr);
 				} break;
 				case RSPLTYPE_CHARGES: {
-					strcpy(infostr, fmt::format(_("Staff of {:s}"), _(spelldata[pSpell].sNameText)).c_str());
+					infostr = fmt::format(_("Staff of {:s}"), _(spelldata[pSpell].sNameText));
 					int charges = myPlayer.InvBody[INVLOC_HAND_LEFT]._iCharges;
 					strcpy(tempstr, fmt::format(ngettext("{:d} Charge", "{:d} Charges", charges), charges).c_str());
 					AddPanelString(tempstr);
@@ -876,7 +876,7 @@ void InitControlPan()
 		buttonEnabled = false;
 	chrbtnactive = false;
 	pDurIcons = LoadCel("Items\\DurIcons.CEL", 32);
-	strcpy(infostr, "");
+	infostr = "";
 	ClearPanel();
 	drawhpflag = true;
 	drawmanaflag = true;
@@ -1072,12 +1072,12 @@ void CheckPanelInfo()
 		int yend = PanBtnPos[i].y + PANEL_TOP + PanBtnPos[i].h;
 		if (MousePosition.x >= PanBtnPos[i].x + PANEL_LEFT && MousePosition.x <= xend && MousePosition.y >= PanBtnPos[i].y + PANEL_TOP && MousePosition.y <= yend) {
 			if (i != 7) {
-				strcpy(infostr, _(PanBtnStr[i]));
+				infostr = _(PanBtnStr[i]);
 			} else {
 				if (gbFriendlyMode)
-					strcpy(infostr, _("Player friendly"));
+					infostr = _("Player friendly");
 				else
-					strcpy(infostr, _("Player attack"));
+					infostr = _("Player attack");
 			}
 			if (PanBtnHotKey[i] != nullptr) {
 				strcpy(tempstr, fmt::format(_("Hotkey: {:s}"), _(PanBtnHotKey[i])).c_str());
@@ -1089,7 +1089,7 @@ void CheckPanelInfo()
 		}
 	}
 	if (!spselflag && MousePosition.x >= 565 + PANEL_LEFT && MousePosition.x < 621 + PANEL_LEFT && MousePosition.y >= 64 + PANEL_TOP && MousePosition.y < 120 + PANEL_TOP) {
-		strcpy(infostr, _("Select current spell button"));
+		infostr = _("Select current spell button");
 		InfoColor = UiFlags::ColorSilver;
 		panelflag = true;
 		pinfoflag = true;
@@ -1255,7 +1255,7 @@ void DrawInfoBox(const Surface &out)
 {
 	DrawPanelBox(out, { 177, 62, 288, 60 }, { PANEL_X + 177, PANEL_Y + 46 });
 	if (!panelflag && !trigflag && pcursinvitem == -1 && !spselflag) {
-		infostr[0] = '\0';
+		infostr = "";
 		InfoColor = UiFlags::ColorSilver;
 		ClearPanel();
 	}
@@ -1265,16 +1265,16 @@ void DrawInfoBox(const Surface &out)
 		auto &myPlayer = Players[MyPlayerId];
 		if (myPlayer.HoldItem._itype == ITYPE_GOLD) {
 			int nGold = myPlayer.HoldItem._ivalue;
-			strcpy(infostr, fmt::format(ngettext("{:d} gold piece", "{:d} gold pieces", nGold), nGold).c_str());
+			infostr = fmt::format(ngettext("{:d} gold piece", "{:d} gold pieces", nGold), nGold);
 		} else if (!myPlayer.HoldItem._iStatFlag) {
 			ClearPanel();
 			AddPanelString(_("Requirements not met"));
 			pinfoflag = true;
 		} else {
 			if (myPlayer.HoldItem._iIdentified)
-				strcpy(infostr, myPlayer.HoldItem._iIName);
+				infostr = myPlayer.HoldItem._iIName;
 			else
-				strcpy(infostr, myPlayer.HoldItem._iName);
+				infostr = myPlayer.HoldItem._iName;
 			InfoColor = myPlayer.HoldItem.getTextColor();
 		}
 	} else {
@@ -1286,7 +1286,7 @@ void DrawInfoBox(const Surface &out)
 			const auto &monster = Monsters[pcursmonst];
 			if (leveltype != DTYPE_TOWN) {
 				InfoColor = UiFlags::ColorSilver;
-				strcpy(infostr, _(monster.mName));
+				infostr = _(monster.mName);
 				ClearPanel();
 				if (monster._uniqtype != 0) {
 					InfoColor = UiFlags::ColorGold;
@@ -1295,15 +1295,13 @@ void DrawInfoBox(const Surface &out)
 					PrintMonstHistory(monster.MType->mtype);
 				}
 			} else if (pcursitem == -1) {
-				string_view townerName = Towners[pcursmonst].name;
-				strncpy(infostr, townerName.data(), townerName.length());
-				infostr[townerName.length()] = '\0';
+				infostr = Towners[pcursmonst].name;
 			}
 		}
 		if (pcursplr != -1) {
 			InfoColor = UiFlags::ColorGold;
 			auto &target = Players[pcursplr];
-			strcpy(infostr, target._pName);
+			infostr = target._pName;
 			ClearPanel();
 			strcpy(tempstr, fmt::format(_("{:s}, Level: {:d}"), _(ClassStrTbl[static_cast<std::size_t>(target._pClass)]), target._pLevel).c_str());
 			AddPanelString(tempstr);
@@ -1311,7 +1309,7 @@ void DrawInfoBox(const Surface &out)
 			AddPanelString(tempstr);
 		}
 	}
-	if (infostr[0] != '\0' || pnumlines != 0)
+	if (infostr.length() > 0 || pnumlines != 0)
 		PrintInfo(out);
 }
 

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -99,7 +99,7 @@ char TalkMessage[MAX_SEND_STR_LEN];
 bool TalkButtonsDown[3];
 int sgbPlrTalkTbl;
 bool WhisperList[MAX_PLRS];
-char panelstr[4][64];
+StringVariant panelstr[4];
 uint8_t SplTransTbl[256];
 
 /** Map of hero class names */
@@ -654,15 +654,12 @@ void DrawSpellList(const Surface &out)
 					break;
 				case RSPLTYPE_SPELL:
 					infostr = fmt::format(_("{:s} Spell"), _(spelldata[pSpell].sNameText));
-					if (pSpell == SPL_HBOLT) {
-						strcpy(tempstr, _("Damages undead only"));
-						AddPanelString(tempstr);
-					}
+					if (pSpell == SPL_HBOLT)
+						AddPanelString(_("Damages undead only"));
 					if (s == 0)
-						strcpy(tempstr, _("Spell Level 0 - Unusable"));
+						AddPanelString(_("Spell Level 0 - Unusable"));
 					else
-						strcpy(tempstr, fmt::format(_("Spell Level {:d}"), s).c_str());
-					AddPanelString(tempstr);
+						AddPanelString(fmt::format(_("Spell Level {:d}"), s));
 					break;
 				case RSPLTYPE_SCROLL: {
 					infostr = fmt::format(_("Scroll of {:s}"), _(spelldata[pSpell].sNameText));
@@ -681,14 +678,12 @@ void DrawSpellList(const Surface &out)
 							v++;
 						}
 					}
-					strcpy(tempstr, fmt::format(ngettext("{:d} Scroll", "{:d} Scrolls", v), v).c_str());
-					AddPanelString(tempstr);
+					AddPanelString(fmt::format(ngettext("{:d} Scroll", "{:d} Scrolls", v), v));
 				} break;
 				case RSPLTYPE_CHARGES: {
 					infostr = fmt::format(_("Staff of {:s}"), _(spelldata[pSpell].sNameText));
 					int charges = myPlayer.InvBody[INVLOC_HAND_LEFT]._iCharges;
-					strcpy(tempstr, fmt::format(ngettext("{:d} Charge", "{:d} Charges", charges), charges).c_str());
-					AddPanelString(tempstr);
+					AddPanelString(fmt::format(ngettext("{:d} Charge", "{:d} Charges", charges), charges));
 				} break;
 				case RSPLTYPE_INVALID:
 					break;
@@ -697,8 +692,7 @@ void DrawSpellList(const Surface &out)
 					if (myPlayer._pSplHotKey[t] == pSpell && myPlayer._pSplTHotKey[t] == pSplType) {
 						auto hotkeyName = keymapper.KeyNameForAction(quickSpellActionIndexes[t]);
 						PrintSBookHotkey(out, location, hotkeyName);
-						strcpy(tempstr, fmt::format(_("Spell Hotkey {:s}"), hotkeyName.c_str()).c_str());
-						AddPanelString(tempstr);
+						AddPanelString(fmt::format(_("Spell Hotkey {:s}"), hotkeyName.c_str()));
 					}
 				}
 			}
@@ -781,13 +775,18 @@ void ToggleSpell(int slot)
 	}
 }
 
-void AddPanelString(const char *str)
+template <typename T>
+void AddPanelString(T str)
 {
-	strcpy(panelstr[pnumlines], str);
-
+	panelstr[pnumlines] = str;
 	if (pnumlines < 4)
 		pnumlines++;
 }
+
+template void AddPanelString<const char *>(const char *);
+template void AddPanelString<char *>(char *);
+template void AddPanelString<string_view>(string_view);
+template void AddPanelString<std::string>(std::string);
 
 void ClearPanel()
 {
@@ -1079,10 +1078,8 @@ void CheckPanelInfo()
 				else
 					infostr = _("Player attack");
 			}
-			if (PanBtnHotKey[i] != nullptr) {
-				strcpy(tempstr, fmt::format(_("Hotkey: {:s}"), _(PanBtnHotKey[i])).c_str());
-				AddPanelString(tempstr);
-			}
+			if (PanBtnHotKey[i] != nullptr)
+				AddPanelString(fmt::format(_("Hotkey: {:s}"), _(PanBtnHotKey[i])));
 			InfoColor = UiFlags::ColorSilver;
 			panelflag = true;
 			pinfoflag = true;
@@ -1093,31 +1090,26 @@ void CheckPanelInfo()
 		InfoColor = UiFlags::ColorSilver;
 		panelflag = true;
 		pinfoflag = true;
-		strcpy(tempstr, _("Hotkey: 's'"));
-		AddPanelString(tempstr);
+		AddPanelString(_("Hotkey: 's'"));
 		auto &myPlayer = Players[MyPlayerId];
 		spell_id v = myPlayer._pRSpell;
 		if (v != SPL_INVALID) {
 			switch (myPlayer._pRSplType) {
 			case RSPLTYPE_SKILL:
-				strcpy(tempstr, fmt::format(_("{:s} Skill"), _(spelldata[v].sSkillText)).c_str());
-				AddPanelString(tempstr);
+				AddPanelString(fmt::format(_("{:s} Skill"), _(spelldata[v].sSkillText)));
 				break;
 			case RSPLTYPE_SPELL: {
-				strcpy(tempstr, fmt::format(_("{:s} Spell"), _(spelldata[v].sNameText)).c_str());
-				AddPanelString(tempstr);
+				AddPanelString(fmt::format(_("{:s} Spell"), _(spelldata[v].sNameText)));
 				int c = myPlayer._pISplLvlAdd + myPlayer._pSplLvl[v];
 				if (c < 0)
 					c = 0;
 				if (c == 0)
-					strcpy(tempstr, _("Spell Level 0 - Unusable"));
+					AddPanelString(_("Spell Level 0 - Unusable"));
 				else
-					strcpy(tempstr, fmt::format(_("Spell Level {:d}"), c).c_str());
-				AddPanelString(tempstr);
+					AddPanelString(fmt::format(_("Spell Level {:d}"), c));
 			} break;
 			case RSPLTYPE_SCROLL: {
-				strcpy(tempstr, fmt::format(_("Scroll of {:s}"), _(spelldata[v].sNameText)).c_str());
-				AddPanelString(tempstr);
+				AddPanelString(fmt::format(_("Scroll of {:s}"), _(spelldata[v].sNameText)));
 				int s = 0;
 				for (int i = 0; i < myPlayer._pNumInv; i++) {
 					if (!myPlayer.InvList[i].isEmpty()
@@ -1133,14 +1125,11 @@ void CheckPanelInfo()
 						s++;
 					}
 				}
-				strcpy(tempstr, fmt::format(ngettext("{:d} Scroll", "{:d} Scrolls", s), s).c_str());
-				AddPanelString(tempstr);
+				AddPanelString(fmt::format(ngettext("{:d} Scroll", "{:d} Scrolls", s), s));
 			} break;
 			case RSPLTYPE_CHARGES:
-				strcpy(tempstr, fmt::format(_("Staff of {:s}"), _(spelldata[v].sNameText)).c_str());
-				AddPanelString(tempstr);
-				strcpy(tempstr, fmt::format(ngettext("{:d} Charge", "{:d} Charges", myPlayer.InvBody[INVLOC_HAND_LEFT]._iCharges), myPlayer.InvBody[INVLOC_HAND_LEFT]._iCharges).c_str());
-				AddPanelString(tempstr);
+				AddPanelString(fmt::format(_("Staff of {:s}"), _(spelldata[v].sNameText)));
+				AddPanelString(fmt::format(ngettext("{:d} Charge", "{:d} Charges", myPlayer.InvBody[INVLOC_HAND_LEFT]._iCharges), myPlayer.InvBody[INVLOC_HAND_LEFT]._iCharges));
 				break;
 			case RSPLTYPE_INVALID:
 				break;
@@ -1303,10 +1292,8 @@ void DrawInfoBox(const Surface &out)
 			auto &target = Players[pcursplr];
 			infostr = target._pName;
 			ClearPanel();
-			strcpy(tempstr, fmt::format(_("{:s}, Level: {:d}"), _(ClassStrTbl[static_cast<std::size_t>(target._pClass)]), target._pLevel).c_str());
-			AddPanelString(tempstr);
-			strcpy(tempstr, fmt::format(_("Hit Points {:d} of {:d}"), target._pHitPoints >> 6, target._pMaxHP >> 6).c_str());
-			AddPanelString(tempstr);
+			AddPanelString(fmt::format(_("{:s}, Level: {:d}"), _(ClassStrTbl[static_cast<std::size_t>(target._pClass)]), target._pLevel));
+			AddPanelString(fmt::format(_("Hit Points {:d} of {:d}"), target._pHitPoints >> 6, target._pMaxHP >> 6).c_str());
 		}
 	}
 	if (infostr.length() > 0 || pnumlines != 0)

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -792,6 +792,8 @@ template void AddPanelString<StringVariant>(StringVariant);
 void ClearPanel()
 {
 	pnumlines = 0;
+	for (auto &str : panelstr)
+		str = "";
 	pinfoflag = false;
 }
 

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -787,6 +787,7 @@ template void AddPanelString<const char *>(const char *);
 template void AddPanelString<char *>(char *);
 template void AddPanelString<string_view>(string_view);
 template void AddPanelString<std::string>(std::string);
+template void AddPanelString<StringVariant>(StringVariant);
 
 void ClearPanel()
 {

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -454,7 +454,7 @@ int DrawDurIcon4Item(const Surface &out, ItemStruct *pItem, int x, int c)
 	return x - 32 - 8;
 }
 
-void PrintSBookStr(const Surface &out, Point position, const char *text)
+void PrintSBookStr(const Surface &out, Point position, string_view text)
 {
 	DrawString(out, text, { { RIGHT_PANEL_X + SPLICONLENGTH + position.x, position.y }, { 222, 0 } }, UiFlags::ColorSilver);
 }
@@ -1668,40 +1668,42 @@ void DrawSpellBook(const Surface &out)
 				DrawSpellCel(out, spellCellPosition, *pSBkIconCels, SPLICONLAST);
 			}
 			PrintSBookStr(out, { 10, yp - 23 }, _(spelldata[sn].sNameText));
+			StringVariant lastLine;
 			switch (GetSBookTrans(sn, false)) {
 			case RSPLTYPE_SKILL:
-				strcpy(tempstr, _("Skill"));
+				lastLine = _("Skill");
 				break;
 			case RSPLTYPE_CHARGES: {
 				int charges = myPlayer.InvBody[INVLOC_HAND_LEFT]._iCharges;
-				strcpy(tempstr, fmt::format(ngettext("Staff ({:d} charge)", "Staff ({:d} charges)", charges), charges).c_str());
+				lastLine = fmt::format(ngettext("Staff ({:d} charge)", "Staff ({:d} charges)", charges), charges);
 			} break;
 			default: {
 				int mana = GetManaAmount(myPlayer, sn) >> 6;
 				int min;
 				int max;
 				GetDamageAmt(sn, &min, &max);
+				StringVariant line;
 				if (min != -1) {
-					strcpy(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: {:d}  Dam: {:d} - {:d}"), mana, min, max).c_str());
+					line = fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: {:d}  Dam: {:d} - {:d}"), mana, min, max);
 				} else {
-					strcpy(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: {:d}   Dam: n/a"), mana).c_str());
+					line = fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: {:d}   Dam: n/a"), mana);
 				}
 				if (sn == SPL_BONESPIRIT) {
-					strcpy(tempstr, fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: {:d}  Dam: 1/3 tgt hp"), mana).c_str());
+					line = fmt::format(_(/* TRANSLATORS: Dam refers to damage. UI constrains, keep short please.*/ "Mana: {:d}  Dam: 1/3 tgt hp"), mana);
 				}
-				PrintSBookStr(out, { 10, yp - 1 }, tempstr);
+				PrintSBookStr(out, { 10, yp - 1 }, line);
 				int lvl = myPlayer._pSplLvl[sn] + myPlayer._pISplLvlAdd;
 				if (lvl < 0) {
 					lvl = 0;
 				}
 				if (lvl == 0) {
-					strcpy(tempstr, _("Spell Level 0 - Unusable"));
+					lastLine = _("Spell Level 0 - Unusable");
 				} else {
-					strcpy(tempstr, fmt::format(_("Spell Level {:d}"), lvl).c_str());
+					lastLine =  fmt::format(_("Spell Level {:d}"), lvl);
 				}
 			} break;
 			}
-			PrintSBookStr(out, { 10, yp - 12 }, tempstr);
+			PrintSBookStr(out, { 10, yp - 12 }, lastLine);
 		}
 		yp += 43;
 	}

--- a/Source/control.h
+++ b/Source/control.h
@@ -15,6 +15,7 @@
 #include "spells.h"
 #include "utils/stdcompat/optional.hpp"
 #include "utils/ui_fwd.h"
+#include "utils/string_variant.hpp"
 
 namespace devilution {
 
@@ -49,7 +50,7 @@ extern bool talkflag;
 extern bool sbookflag;
 extern bool chrflag;
 extern bool drawbtnflag;
-extern char infostr[64];
+extern StringVariant infostr;
 extern bool panelflag;
 extern int initialDropGoldValue;
 extern bool panbtndown;

--- a/Source/control.h
+++ b/Source/control.h
@@ -69,7 +69,9 @@ void SetSpell();
 void SetSpeedSpell(int slot);
 void ToggleSpell(int slot);
 
-void AddPanelString(const char *str);
+template <typename T>
+void AddPanelString(T str);
+
 void ClearPanel();
 void DrawPanelBox(const Surface &out, SDL_Rect srcRect, Point targetPosition);
 

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1312,7 +1312,7 @@ void plrctrls_after_check_curs_move()
 			return;
 		}
 		if (!invflag) {
-			*infostr = '\0';
+			infostr = "";
 			ClearPanel();
 			FindActor();
 			FindItemOrObject();

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -227,7 +227,7 @@ void CheckTown()
 			    || (cursmx == Missiles[mx].position.tile.x && cursmy == Missiles[mx].position.tile.y)) {
 				trigflag = true;
 				ClearPanel();
-				strcpy(infostr, _("Town Portal"));
+				infostr = _("Town Portal");
 				strcpy(tempstr, fmt::format(_("from {:s}"), Players[Missiles[mx]._misource]._pName).c_str());
 				AddPanelString(tempstr);
 				cursmx = Missiles[mx].position.tile.x;
@@ -251,7 +251,7 @@ void CheckRportal()
 			    || (cursmx == Missiles[mx].position.tile.x && cursmy == Missiles[mx].position.tile.y)) {
 				trigflag = true;
 				ClearPanel();
-				strcpy(infostr, _("Portal to"));
+				infostr = _("Portal to");
 				if (!setlevel)
 					strcpy(tempstr, _("The Unholy Altar"));
 				else

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -228,8 +228,7 @@ void CheckTown()
 				trigflag = true;
 				ClearPanel();
 				infostr = _("Town Portal");
-				strcpy(tempstr, fmt::format(_("from {:s}"), Players[Missiles[mx]._misource]._pName).c_str());
-				AddPanelString(tempstr);
+				AddPanelString(fmt::format(_("from {:s}"), Players[Missiles[mx]._misource]._pName));
 				cursmx = Missiles[mx].position.tile.x;
 				cursmy = Missiles[mx].position.tile.y;
 			}
@@ -253,10 +252,9 @@ void CheckRportal()
 				ClearPanel();
 				infostr = _("Portal to");
 				if (!setlevel)
-					strcpy(tempstr, _("The Unholy Altar"));
+					AddPanelString(_("The Unholy Altar"));
 				else
-					strcpy(tempstr, _("level 15"));
-				AddPanelString(tempstr);
+					AddPanelString(_("level 15"));
 				cursmx = Missiles[mx].position.tile.x;
 				cursmy = Missiles[mx].position.tile.y;
 			}

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -132,8 +132,7 @@ void DrawDiabloMsg(const Surface &out)
 
 	DrawHalfTransparentRectTo(out, PANEL_X + 104, DIALOG_Y - 8, 432, 54);
 
-	strcpy(tempstr, _(MsgStrings[msgflag]));
-	DrawString(out, tempstr, { { PANEL_X + 101, DIALOG_Y + 24 }, { 442, 0 } }, UiFlags::AlignCenter);
+	DrawString(out, _(MsgStrings[msgflag]), { { PANEL_X + 101, DIALOG_Y + 24 }, { 442, 0 } }, UiFlags::AlignCenter);
 
 	if (msgdelay > 0 && msgdelay <= SDL_GetTicks() - 3500) {
 		msgdelay = 0;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1952,14 +1952,14 @@ char CheckInvHLight()
 
 	if (pi->_itype == ITYPE_GOLD) {
 		int nGold = pi->_ivalue;
-		strcpy(infostr, fmt::format(ngettext("{:d} gold piece", "{:d} gold pieces", nGold), nGold).c_str());
+		infostr = fmt::format(ngettext("{:d} gold piece", "{:d} gold pieces", nGold), nGold);
 	} else {
 		InfoColor = pi->getTextColor();
 		if (pi->_iIdentified) {
-			strcpy(infostr, pi->_iIName);
+			infostr = pi->_iIName;
 			PrintItemDetails(pi);
 		} else {
-			strcpy(infostr, pi->_iName);
+			infostr = pi->_iName;
 			PrintItemDur(pi);
 		}
 	}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1885,140 +1885,102 @@ void PrintItemOil(char iDidx)
 {
 	switch (iDidx) {
 	case IMISC_OILACC:
-		strcpy(tempstr, _("increases a weapon's"));
-		AddPanelString(tempstr);
-		strcpy(tempstr, _("chance to hit"));
-		AddPanelString(tempstr);
+		AddPanelString(_("increases a weapon's"));
+		AddPanelString(_("chance to hit"));
 		break;
 	case IMISC_OILMAST:
-		strcpy(tempstr, _("greatly increases a"));
-		AddPanelString(tempstr);
-		strcpy(tempstr, _("weapon's chance to hit"));
-		AddPanelString(tempstr);
+		AddPanelString(_("greatly increases a"));
+		AddPanelString(_("weapon's chance to hit"));
 		break;
 	case IMISC_OILSHARP:
-		strcpy(tempstr, _("increases a weapon's"));
-		AddPanelString(tempstr);
-		strcpy(tempstr, _("damage potential"));
-		AddPanelString(tempstr);
+		AddPanelString(_("increases a weapon's"));
+		AddPanelString(_("damage potential"));
 		break;
 	case IMISC_OILDEATH:
-		strcpy(tempstr, _("greatly increases a weapon's"));
-		AddPanelString(tempstr);
-		strcpy(tempstr, _("damage potential - not bows"));
-		AddPanelString(tempstr);
+		AddPanelString(_("greatly increases a weapon's"));
+		AddPanelString(_("damage potential - not bows"));
 		break;
 	case IMISC_OILSKILL:
-		strcpy(tempstr, _("reduces attributes needed"));
-		AddPanelString(tempstr);
-		strcpy(tempstr, _("to use armor or weapons"));
-		AddPanelString(tempstr);
+		AddPanelString(_("reduces attributes needed"));
+		AddPanelString(_("to use armor or weapons"));
 		break;
 	case IMISC_OILBSMTH:
-		/*xgettext:no-c-format*/ strcpy(tempstr, _("restores 20% of an"));
-		AddPanelString(tempstr);
-		strcpy(tempstr, _("item's durability"));
-		AddPanelString(tempstr);
+		/*xgettext:no-c-format*/ AddPanelString(_("restores 20% of an"));
+		AddPanelString(_("item's durability"));
 		break;
 	case IMISC_OILFORT:
-		strcpy(tempstr, _("increases an item's"));
-		AddPanelString(tempstr);
-		strcpy(tempstr, _("current and max durability"));
-		AddPanelString(tempstr);
+		AddPanelString(_("increases an item's"));
+		AddPanelString(_("current and max durability"));
 		break;
 	case IMISC_OILPERM:
-		strcpy(tempstr, _("makes an item indestructible"));
-		AddPanelString(tempstr);
+		AddPanelString(_("makes an item indestructible"));
 		break;
 	case IMISC_OILHARD:
-		strcpy(tempstr, _("increases the armor class"));
-		AddPanelString(tempstr);
-		strcpy(tempstr, _("of armor and shields"));
-		AddPanelString(tempstr);
+		AddPanelString(_("increases the armor class"));
+		AddPanelString(_("of armor and shields"));
 		break;
 	case IMISC_OILIMP:
-		strcpy(tempstr, _("greatly increases the armor"));
-		AddPanelString(tempstr);
-		strcpy(tempstr, _("class of armor and shields"));
-		AddPanelString(tempstr);
+		AddPanelString(_("greatly increases the armor"));
+		AddPanelString(_("class of armor and shields"));
 		break;
 	case IMISC_RUNEF:
-		strcpy(tempstr, _("sets fire trap"));
-		AddPanelString(tempstr);
+		AddPanelString(_("sets fire trap"));
 		break;
 	case IMISC_RUNEL:
 	case IMISC_GR_RUNEL:
-		strcpy(tempstr, _("sets lightning trap"));
-		AddPanelString(tempstr);
+		AddPanelString(_("sets lightning trap"));
 		break;
 	case IMISC_GR_RUNEF:
-		strcpy(tempstr, _("sets fire trap"));
-		AddPanelString(tempstr);
+		AddPanelString(_("sets fire trap"));
 		break;
 	case IMISC_RUNES:
-		strcpy(tempstr, _("sets petrification trap"));
-		AddPanelString(tempstr);
+		AddPanelString(_("sets petrification trap"));
 		break;
 	case IMISC_FULLHEAL:
-		strcpy(tempstr, _("restore all life"));
-		AddPanelString(tempstr);
+		AddPanelString(_("restore all life"));
 		break;
 	case IMISC_HEAL:
-		strcpy(tempstr, _("restore some life"));
-		AddPanelString(tempstr);
+		AddPanelString(_("restore some life"));
 		break;
 	case IMISC_OLDHEAL:
-		strcpy(tempstr, _("recover life"));
-		AddPanelString(tempstr);
+		AddPanelString(_("recover life"));
 		break;
 	case IMISC_DEADHEAL:
-		strcpy(tempstr, _("deadly heal"));
-		AddPanelString(tempstr);
+		AddPanelString(_("deadly heal"));
 		break;
 	case IMISC_MANA:
-		strcpy(tempstr, _("restore some mana"));
-		AddPanelString(tempstr);
+		AddPanelString(_("restore some mana"));
 		break;
 	case IMISC_FULLMANA:
-		strcpy(tempstr, _("restore all mana"));
-		AddPanelString(tempstr);
+		AddPanelString(_("restore all mana"));
 		break;
 	case IMISC_ELIXSTR:
-		strcpy(tempstr, _("increase strength"));
-		AddPanelString(tempstr);
+		AddPanelString(_("increase strength"));
 		break;
 	case IMISC_ELIXMAG:
-		strcpy(tempstr, _("increase magic"));
-		AddPanelString(tempstr);
+		AddPanelString(_("increase magic"));
 		break;
 	case IMISC_ELIXDEX:
-		strcpy(tempstr, _("increase dexterity"));
-		AddPanelString(tempstr);
+		AddPanelString(_("increase dexterity"));
 		break;
 	case IMISC_ELIXVIT:
-		strcpy(tempstr, _("increase vitality"));
-		AddPanelString(tempstr);
+		AddPanelString(_("increase vitality"));
 		break;
 	case IMISC_ELIXWEAK:
 	case IMISC_ELIXDIS:
-		strcpy(tempstr, _("decrease strength"));
-		AddPanelString(tempstr);
+		AddPanelString(_("decrease strength"));
 		break;
 	case IMISC_ELIXCLUM:
-		strcpy(tempstr, _("decrease dexterity"));
-		AddPanelString(tempstr);
+		AddPanelString(_("decrease dexterity"));
 		break;
 	case IMISC_ELIXSICK:
-		strcpy(tempstr, _("decrease vitality"));
-		AddPanelString(tempstr);
+		AddPanelString(_("decrease vitality"));
 		break;
 	case IMISC_REJUV:
-		strcpy(tempstr, _("restore some life and mana"));
-		AddPanelString(tempstr);
+		AddPanelString(_("restore some life and mana"));
 		break;
 	case IMISC_FULLREJUV:
-		strcpy(tempstr, _("restore all life and mana"));
-		AddPanelString(tempstr);
+		AddPanelString(_("restore all life and mana"));
 		break;
 	}
 }
@@ -2040,51 +2002,35 @@ void DrawUniqueInfoDevider(const Surface &out, int y)
 
 void PrintItemMisc(ItemStruct *x)
 {
-	if (x->_iMiscId == IMISC_SCROLL) {
-		strcpy(tempstr, _("Right-click to read"));
-		AddPanelString(tempstr);
-	}
+	if (x->_iMiscId == IMISC_SCROLL)
+		AddPanelString(_("Right-click to read"));
 	if (x->_iMiscId == IMISC_SCROLLT) {
-		strcpy(tempstr, _("Right-click to read, then"));
-		AddPanelString(tempstr);
-		strcpy(tempstr, _("left-click to target"));
-		AddPanelString(tempstr);
+		AddPanelString(_("Right-click to read, then"));
+		AddPanelString(_("left-click to target"));
 	}
 	if (x->_iMiscId >= IMISC_USEFIRST && x->_iMiscId <= IMISC_USELAST) {
 		PrintItemOil(x->_iMiscId);
-		strcpy(tempstr, _("Right-click to use"));
-		AddPanelString(tempstr);
+		AddPanelString(_("Right-click to use"));
 	}
 	if (x->_iMiscId > IMISC_OILFIRST && x->_iMiscId < IMISC_OILLAST) {
 		PrintItemOil(x->_iMiscId);
-		strcpy(tempstr, _("Right click to use"));
-		AddPanelString(tempstr);
+		AddPanelString(_("Right click to use"));
 	}
 	if (x->_iMiscId > IMISC_RUNEFIRST && x->_iMiscId < IMISC_RUNELAST) {
 		PrintItemOil(x->_iMiscId);
-		strcpy(tempstr, _("Right click to use"));
-		AddPanelString(tempstr);
+		AddPanelString(_("Right click to use"));
 	}
 	if (x->_iMiscId == IMISC_BOOK) {
-		strcpy(tempstr, _("Right-click to read"));
-		AddPanelString(tempstr);
+		AddPanelString(_("Right-click to read"));
 	}
-	if (x->_iMiscId == IMISC_NOTE) {
-		strcpy(tempstr, _("Right click to read"));
-		AddPanelString(tempstr);
-	}
-	if (x->_iMiscId == IMISC_MAPOFDOOM) {
-		strcpy(tempstr, _("Right-click to view"));
-		AddPanelString(tempstr);
-	}
-	if (x->_iMiscId == IMISC_EAR) {
-		strcpy(tempstr, fmt::format(_("Level: {:d}"), x->_ivalue).c_str());
-		AddPanelString(tempstr);
-	}
-	if (x->_iMiscId == IMISC_AURIC) {
-		strcpy(tempstr, _("Doubles gold capacity"));
-		AddPanelString(tempstr);
-	}
+	if (x->_iMiscId == IMISC_NOTE)
+		AddPanelString(_("Right click to read"));
+	if (x->_iMiscId == IMISC_MAPOFDOOM)
+		AddPanelString(_("Right-click to view"));
+	if (x->_iMiscId == IMISC_EAR)
+		AddPanelString(fmt::format(_("Level: {:d}"), x->_ivalue));
+	if (x->_iMiscId == IMISC_AURIC)
+		AddPanelString(_("Doubles gold capacity"));
 }
 
 void PrintItemInfo(ItemStruct *x)
@@ -4158,32 +4104,24 @@ void PrintItemDetails(ItemStruct *x)
 	if (x->_iClass == ICLASS_WEAPON) {
 		if (x->_iMinDam == x->_iMaxDam) {
 			if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-				strcpy(tempstr, fmt::format(_("damage: {:d}  Indestructible"), x->_iMinDam).c_str());
+				AddPanelString(fmt::format(_("damage: {:d}  Indestructible"), x->_iMinDam));
 			else
-				strcpy(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "damage: {:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
+				AddPanelString(fmt::format(_(/* TRANSLATORS: Dur: is durability */ "damage: {:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iDurability, x->_iMaxDur));
 		} else {
 			if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-				strcpy(tempstr, fmt::format(_("damage: {:d}-{:d}  Indestructible"), x->_iMinDam, x->_iMaxDam).c_str());
+				AddPanelString(fmt::format(_("damage: {:d}-{:d}  Indestructible"), x->_iMinDam, x->_iMaxDam));
 			else
-				strcpy(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "damage: {:d}-{:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
+				AddPanelString(fmt::format(_(/* TRANSLATORS: Dur: is durability */ "damage: {:d}-{:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur));
 		}
-		AddPanelString(tempstr);
 	}
 	if (x->_iClass == ICLASS_ARMOR) {
 		if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-			strcpy(tempstr, fmt::format(_("armor: {:d}  Indestructible"), x->_iAC).c_str());
+			AddPanelString(fmt::format(_("armor: {:d}  Indestructible"), x->_iAC));
 		else
-			strcpy(tempstr, fmt::format(_(/* TRANSLATORS: Dur: is durability */ "armor: {:d}  Dur: {:d}/{:d}"), x->_iAC, x->_iDurability, x->_iMaxDur).c_str());
-		AddPanelString(tempstr);
+			AddPanelString(fmt::format(_(/* TRANSLATORS: Dur: is durability */ "armor: {:d}  Dur: {:d}/{:d}"), x->_iAC, x->_iDurability, x->_iMaxDur));
 	}
-	if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges != 0) {
-		if (x->_iMinDam == x->_iMaxDam)
-			strcpy(tempstr, fmt::format(_(/* TRANSLATORS: dam: is damage Dur: is durability */ "dam: {:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
-		else
-			strcpy(tempstr, fmt::format(_(/* TRANSLATORS: dam: is damage Dur: is durability */ "dam: {:d}-{:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
-		strcpy(tempstr, fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges).c_str());
-		AddPanelString(tempstr);
-	}
+	if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges != 0)
+		AddPanelString(fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges));
 	if (x->_iPrePower != -1) {
 		PrintItemPower(x->_iPrePower, x);
 		AddPanelString(tempstr);
@@ -4205,35 +4143,29 @@ void PrintItemDur(ItemStruct *x)
 	if (x->_iClass == ICLASS_WEAPON) {
 		if (x->_iMinDam == x->_iMaxDam) {
 			if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-				strcpy(tempstr, fmt::format(_("damage: {:d}  Indestructible"), x->_iMinDam).c_str());
+				AddPanelString(fmt::format(_("damage: {:d}  Indestructible"), x->_iMinDam));
 			else
-				strcpy(tempstr, fmt::format(_("damage: {:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iDurability, x->_iMaxDur).c_str());
+				AddPanelString(fmt::format(_("damage: {:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iDurability, x->_iMaxDur));
 		} else {
 			if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-				strcpy(tempstr, fmt::format(_("damage: {:d}-{:d}  Indestructible"), x->_iMinDam, x->_iMaxDam).c_str());
+				AddPanelString(fmt::format(_("damage: {:d}-{:d}  Indestructible"), x->_iMinDam, x->_iMaxDam));
 			else
-				strcpy(tempstr, fmt::format(_("damage: {:d}-{:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur).c_str());
+				AddPanelString(fmt::format(_("damage: {:d}-{:d}  Dur: {:d}/{:d}"), x->_iMinDam, x->_iMaxDam, x->_iDurability, x->_iMaxDur));
 		}
-		AddPanelString(tempstr);
-		if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges > 0) {
-			strcpy(tempstr, fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges).c_str());
-			AddPanelString(tempstr);
-		}
+		if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges > 0)
+			AddPanelString(fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges));
 		if (x->_iMagical != ITEM_QUALITY_NORMAL)
 			AddPanelString(_("Not Identified"));
 	}
 	if (x->_iClass == ICLASS_ARMOR) {
 		if (x->_iMaxDur == DUR_INDESTRUCTIBLE)
-			strcpy(tempstr, fmt::format(_("armor: {:d}  Indestructible"), x->_iAC).c_str());
+			AddPanelString(fmt::format(_("armor: {:d}  Indestructible"), x->_iAC));
 		else
-			strcpy(tempstr, fmt::format(_("armor: {:d}  Dur: {:d}/{:d}"), x->_iAC, x->_iDurability, x->_iMaxDur).c_str());
-		AddPanelString(tempstr);
+			AddPanelString(fmt::format(_("armor: {:d}  Dur: {:d}/{:d}"), x->_iAC, x->_iDurability, x->_iMaxDur));
 		if (x->_iMagical != ITEM_QUALITY_NORMAL)
 			AddPanelString(_("Not Identified"));
-		if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges > 0) {
-			strcpy(tempstr, fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges).c_str());
-			AddPanelString(tempstr);
-		}
+		if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges > 0)
+			AddPanelString(fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges));
 	}
 	if (x->_itype == ITYPE_RING || x->_itype == ITYPE_AMULET)
 		AddPanelString(_("Not Identified"));

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3794,165 +3794,118 @@ StringVariant FormatItemPower(char plidx, ItemStruct *x)
 	case IPL_DAMP:
 	case IPL_DAMP_CURSE:
 		/*xgettext:no-c-format*/ return StringVariant{ fmt::format(_("{:+d}% damage"), x->_iPLDam) };
-		break;
 	case IPL_TOHIT_DAMP:
 	case IPL_TOHIT_DAMP_CURSE:
 		return StringVariant{ fmt::format(_("to hit: {:+d}%, {:+d}% damage"), x->_iPLToHit, x->_iPLDam) };
-		break;
 	case IPL_ACP:
 	case IPL_ACP_CURSE:
 		/*xgettext:no-c-format*/ return StringVariant{ fmt::format(_("{:+d}% armor"), x->_iPLAC) };
-		break;
 	case IPL_SETAC:
 	case IPL_AC_CURSE:
 		return StringVariant{ fmt::format(_("armor class: {:d}"), x->_iAC) };
-		break;
 	case IPL_FIRERES:
 	case IPL_FIRERES_CURSE:
 		if (x->_iPLFR < 75)
 			return StringVariant{ fmt::format(_("Resist Fire: {:+d}%"), x->_iPLFR) };
-		else
-			/*xgettext:no-c-format*/ return StringVariant{ _("Resist Fire: 75% MAX") };
-		break;
+		/*xgettext:no-c-format*/ return StringVariant{ _("Resist Fire: 75% MAX") };
 	case IPL_LIGHTRES:
 	case IPL_LIGHTRES_CURSE:
 		if (x->_iPLLR < 75)
 			return StringVariant{ fmt::format(_("Resist Lightning: {:+d}%"), x->_iPLLR) };
-		else
-			/*xgettext:no-c-format*/ return StringVariant{ _("Resist Lightning: 75% MAX") };
-		break;
+		/*xgettext:no-c-format*/ return StringVariant{ _("Resist Lightning: 75% MAX") };
 	case IPL_MAGICRES:
 	case IPL_MAGICRES_CURSE:
 		if (x->_iPLMR < 75)
 			return StringVariant{ fmt::format(_("Resist Magic: {:+d}%"), x->_iPLMR) };
-		else
-			/*xgettext:no-c-format*/ return StringVariant{ _("Resist Magic: 75% MAX") };
-		break;
+		/*xgettext:no-c-format*/ return StringVariant{ _("Resist Magic: 75% MAX") };
 	case IPL_ALLRES:
 	case IPL_ALLRES_CURSE:
 		if (x->_iPLFR < 75)
 			return StringVariant{ fmt::format(_("Resist All: {:+d}%"), x->_iPLFR) };
-		if (x->_iPLFR >= 75)
-			/*xgettext:no-c-format*/ return StringVariant{ _("Resist All: 75% MAX") };
-		break;
+		/*xgettext:no-c-format*/ return StringVariant{ _("Resist All: 75% MAX") };
 	case IPL_SPLLVLADD:
 		if (x->_iSplLvlAdd > 0)
 			return StringVariant{ fmt::format(ngettext("spells are increased {:d} level", "spells are increased {:d} levels", x->_iSplLvlAdd), x->_iSplLvlAdd) };
-		else if (x->_iSplLvlAdd < 0)
+		if (x->_iSplLvlAdd < 0)
 			return StringVariant{ fmt::format(ngettext("spells are decreased {:d} level", "spells are decreased {:d} levels", -x->_iSplLvlAdd), -x->_iSplLvlAdd) };
-		else if (x->_iSplLvlAdd == 0)
-			return StringVariant{ _("spell levels unchanged (?)") };
-		break;
+		// x->_iSplLvlAdd == 0
+		return StringVariant{ _("spell levels unchanged (?)") };
 	case IPL_CHARGES:
 		return StringVariant{ _("Extra charges") };
-		break;
 	case IPL_SPELL:
 		return StringVariant{ fmt::format(ngettext("{:d} {:s} charge", "{:d} {:s} charges", x->_iMaxCharges), x->_iMaxCharges, _(spelldata[x->_iSpell].sNameText)) };
-		break;
 	case IPL_FIREDAM:
 		if (x->_iFMinDam == x->_iFMaxDam)
 			return StringVariant{ fmt::format(_("Fire hit damage: {:d}"), x->_iFMinDam) };
-		else
-			return StringVariant{ fmt::format(_("Fire hit damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam) };
-		break;
+		return StringVariant{ fmt::format(_("Fire hit damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam) };
 	case IPL_LIGHTDAM:
 		if (x->_iLMinDam == x->_iLMaxDam)
 			return StringVariant{ fmt::format(_("Lightning hit damage: {:d}"), x->_iLMinDam) };
-		else
-			return StringVariant{ fmt::format(_("Lightning hit damage: {:d}-{:d}"), x->_iLMinDam, x->_iLMaxDam) };
-		break;
+		return StringVariant{ fmt::format(_("Lightning hit damage: {:d}-{:d}"), x->_iLMinDam, x->_iLMaxDam) };
 	case IPL_STR:
 	case IPL_STR_CURSE:
 		return StringVariant{ fmt::format(_("{:+d} to strength"), x->_iPLStr) };
-		break;
 	case IPL_MAG:
 	case IPL_MAG_CURSE:
 		return StringVariant{ fmt::format(_("{:+d} to magic"), x->_iPLMag) };
-		break;
 	case IPL_DEX:
 	case IPL_DEX_CURSE:
 		return StringVariant{ fmt::format(_("{:+d} to dexterity"), x->_iPLDex) };
-		break;
 	case IPL_VIT:
 	case IPL_VIT_CURSE:
 		return StringVariant{ fmt::format(_("{:+d} to vitality"), x->_iPLVit) };
-		break;
 	case IPL_ATTRIBS:
 	case IPL_ATTRIBS_CURSE:
 		return StringVariant{ fmt::format(_("{:+d} to all attributes"), x->_iPLStr) };
-		break;
 	case IPL_GETHIT_CURSE:
 	case IPL_GETHIT:
 		return StringVariant{ fmt::format(_("{:+d} damage from enemies"), x->_iPLGetHit) };
-		break;
 	case IPL_LIFE:
 	case IPL_LIFE_CURSE:
 		return StringVariant{ fmt::format(_("Hit Points: {:+d}"), x->_iPLHP >> 6) };
-		break;
 	case IPL_MANA:
 	case IPL_MANA_CURSE:
 		return StringVariant{ fmt::format(_("Mana: {:+d}"), x->_iPLMana >> 6) };
-		break;
 	case IPL_DUR:
 		return StringVariant{ _("high durability") };
-		break;
 	case IPL_DUR_CURSE:
 		return StringVariant{ _("decreased durability") };
-		break;
 	case IPL_INDESTRUCTIBLE:
 		return StringVariant{ _("indestructible") };
-		break;
 	case IPL_LIGHT:
 		/*xgettext:no-c-format*/ return StringVariant{ fmt::format(_("+{:d}% light radius"), 10 * x->_iPLLight) };
-		break;
 	case IPL_LIGHT_CURSE:
 		/*xgettext:no-c-format*/ return StringVariant{ fmt::format(_("-{:d}% light radius"), -10 * x->_iPLLight) };
-		break;
 	case IPL_MULT_ARROWS:
 		return StringVariant{ _("multiple arrows per shot") };
-		break;
 	case IPL_FIRE_ARROWS:
 		if (x->_iFMinDam == x->_iFMaxDam)
 			return StringVariant{ fmt::format(_("fire arrows damage: {:d}"), x->_iFMinDam) };
-		else
-			return StringVariant{ fmt::format(_("fire arrows damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam) };
-		break;
+		return StringVariant{ fmt::format(_("fire arrows damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam) };
 	case IPL_LIGHT_ARROWS:
 		if (x->_iLMinDam == x->_iLMaxDam)
 			return StringVariant{ fmt::format(_("lightning arrows damage {:d}"), x->_iLMinDam) };
-		else
-			return StringVariant{ fmt::format(_("lightning arrows damage {:d}-{:d}"), x->_iLMinDam, x->_iLMaxDam) };
-		break;
+		return StringVariant{ fmt::format(_("lightning arrows damage {:d}-{:d}"), x->_iLMinDam, x->_iLMaxDam) };
 	case IPL_FIREBALL:
 		if (x->_iFMinDam == x->_iFMaxDam)
 			return StringVariant{ fmt::format(_("fireball damage: {:d}"), x->_iFMinDam) };
-		else
-			return StringVariant{ fmt::format(_("fireball damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam) };
-		break;
+		return StringVariant{ fmt::format(_("fireball damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam) };
 	case IPL_THORNS:
 		return StringVariant{ _("attacker takes 1-3 damage") };
-		break;
 	case IPL_NOMANA:
 		return StringVariant{ _("user loses all mana") };
-		break;
 	case IPL_NOHEALPLR:
 		return StringVariant{ _("you can't heal") };
-		break;
 	case IPL_ABSHALFTRAP:
 		return StringVariant{ _("absorbs half of trap damage") };
-		break;
 	case IPL_KNOCKBACK:
 		return StringVariant{ _("knocks target back") };
-		break;
 	case IPL_3XDAMVDEM:
 		/*xgettext:no-c-format*/ return StringVariant{ _("+200% damage vs. demons") };
-		break;
 	case IPL_ALLRESZERO:
 		return StringVariant{ _("All Resistance equals 0") };
-		break;
 	case IPL_NOHEALMON:
 		return StringVariant{ _("hit monster doesn't heal") };
-		break;
 	case IPL_STEALMANA:
 		if ((x->_iFlags & ISPL_STEALMANA_3) != 0)
 			/*xgettext:no-c-format*/ return StringVariant{ _("hit steals 3% mana") };
@@ -3967,7 +3920,6 @@ StringVariant FormatItemPower(char plidx, ItemStruct *x)
 		break;
 	case IPL_TARGAC:
 		return StringVariant{ _("penetrates target's armor") };
-		break;
 	case IPL_FASTATTACK:
 		if ((x->_iFlags & ISPL_QUICKATTACK) != 0)
 			return StringVariant{ _("quick attack") };
@@ -3988,88 +3940,61 @@ StringVariant FormatItemPower(char plidx, ItemStruct *x)
 		break;
 	case IPL_FASTBLOCK:
 		return StringVariant{ _("fast block") };
-		break;
 	case IPL_DAMMOD:
 		return StringVariant{ fmt::format(ngettext("adds {:d} point to damage", "adds {:d} points to damage", x->_iPLDamMod), x->_iPLDamMod) };
-		break;
 	case IPL_RNDARROWVEL:
 		return StringVariant{ _("fires random speed arrows") };
-		break;
 	case IPL_SETDAM:
 		return StringVariant{ _("unusual item damage") };
-		break;
 	case IPL_SETDUR:
 		return StringVariant{ _("altered durability") };
-		break;
 	case IPL_FASTSWING:
 		return StringVariant{ _("Faster attack swing") };
-		break;
 	case IPL_ONEHAND:
 		return StringVariant{ _("one handed sword") };
-		break;
 	case IPL_DRAINLIFE:
 		return StringVariant{ _("constantly lose hit points") };
-		break;
 	case IPL_RNDSTEALLIFE:
 		return StringVariant{ _("life stealing") };
-		break;
 	case IPL_NOMINSTR:
 		return StringVariant{ _("no strength requirement") };
-		break;
 	case IPL_INFRAVISION:
 		return StringVariant{ _("see with infravision") };
-		break;
 	case IPL_INVCURS:
 		return StringVariant{ " " };
-		break;
 	case IPL_ADDACLIFE:
 		if (x->_iFMinDam == x->_iFMaxDam)
 			return StringVariant{ fmt::format(_("lightning damage: {:d}"), x->_iFMinDam) };
-		else
-			return StringVariant{ fmt::format(_("lightning damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam) };
-		break;
+		return StringVariant{ fmt::format(_("lightning damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam) };
 	case IPL_ADDMANAAC:
 		return StringVariant{ _("charged bolts on hits") };
-		break;
 	case IPL_FIRERESCLVL:
 		if (x->_iPLFR <= 0)
 			return StringVariant{ " " };
-		else if (x->_iPLFR >= 1)
-			return StringVariant{ fmt::format(_("Resist Fire: {:+d}%"), x->_iPLFR) };
-		break;
+		// x->_iPLFR >= 1
+		return StringVariant{ fmt::format(_("Resist Fire: {:+d}%"), x->_iPLFR) };
 	case IPL_DEVASTATION:
 		return StringVariant{ _("occasional triple damage") };
-		break;
 	case IPL_DECAY:
 		/*xgettext:no-c-format*/ return StringVariant{ fmt::format(_("decaying {:+d}% damage"), x->_iPLDam) };
-		break;
 	case IPL_PERIL:
 		return StringVariant{ _("2x dmg to monst, 1x to you") };
-		break;
 	case IPL_JESTERS:
 		/*xgettext:no-c-format*/ return StringVariant{ _("Random 0 - 500% damage") };
-		break;
 	case IPL_CRYSTALLINE:
 		/*xgettext:no-c-format*/ return StringVariant{ fmt::format(_("low dur, {:+d}% damage"), x->_iPLDam) };
-		break;
 	case IPL_DOPPELGANGER:
 		return StringVariant{ fmt::format(_("to hit: {:+d}%, {:+d}% damage"), x->_iPLToHit, x->_iPLDam) };
-		break;
 	case IPL_ACDEMON:
 		return StringVariant{ _("extra AC vs demons") };
-		break;
 	case IPL_ACUNDEAD:
 		return StringVariant{ _("extra AC vs undead") };
-		break;
 	case IPL_MANATOLIFE:
 		/*xgettext:no-c-format*/ return StringVariant{ _("50% Mana moved to Health") };
-		break;
 	case IPL_LIFETOMANA:
 		/*xgettext:no-c-format*/ return StringVariant{ _("40% Health moved to Mana") };
-		break;
 	default:
 		return StringVariant{ _("Another ability (NW)") };
-		break;
 	}
 }
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3757,14 +3757,14 @@ void GetItemStr(int i)
 {
 	if (Items[i]._itype != ITYPE_GOLD) {
 		if (Items[i]._iIdentified)
-			strcpy(infostr, Items[i]._iIName);
+			infostr = Items[i]._iIName;
 		else
-			strcpy(infostr, Items[i]._iName);
+			infostr = Items[i]._iName;
 
 		InfoColor = Items[i].getTextColor();
 	} else {
 		int nGold = Items[i]._ivalue;
-		strcpy(infostr, fmt::format(ngettext("{:d} gold piece", "{:d} gold pieces", nGold), nGold).c_str());
+		infostr = fmt::format(ngettext("{:d} gold piece", "{:d} gold pieces", nGold), nGold);
 	}
 }
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3785,293 +3785,299 @@ void DoOil(int pnum, int cii)
 	}
 }
 
-void PrintItemPower(char plidx, ItemStruct *x)
+StringVariant FormatItemPower(char plidx, ItemStruct *x)
 {
 	switch (plidx) {
 	case IPL_TOHIT:
 	case IPL_TOHIT_CURSE:
-		strcpy(tempstr, fmt::format(_("chance to hit: {:+d}%"), x->_iPLToHit).c_str());
-		break;
+		return StringVariant{ fmt::format(_("chance to hit: {:+d}%"), x->_iPLToHit) };
 	case IPL_DAMP:
 	case IPL_DAMP_CURSE:
-		/*xgettext:no-c-format*/ strcpy(tempstr, fmt::format(_("{:+d}% damage"), x->_iPLDam).c_str());
+		/*xgettext:no-c-format*/ return StringVariant{ fmt::format(_("{:+d}% damage"), x->_iPLDam) };
 		break;
 	case IPL_TOHIT_DAMP:
 	case IPL_TOHIT_DAMP_CURSE:
-		strcpy(tempstr, fmt::format(_("to hit: {:+d}%, {:+d}% damage"), x->_iPLToHit, x->_iPLDam).c_str());
+		return StringVariant{ fmt::format(_("to hit: {:+d}%, {:+d}% damage"), x->_iPLToHit, x->_iPLDam) };
 		break;
 	case IPL_ACP:
 	case IPL_ACP_CURSE:
-		/*xgettext:no-c-format*/ strcpy(tempstr, fmt::format(_("{:+d}% armor"), x->_iPLAC).c_str());
+		/*xgettext:no-c-format*/ return StringVariant{ fmt::format(_("{:+d}% armor"), x->_iPLAC) };
 		break;
 	case IPL_SETAC:
 	case IPL_AC_CURSE:
-		strcpy(tempstr, fmt::format(_("armor class: {:d}"), x->_iAC).c_str());
+		return StringVariant{ fmt::format(_("armor class: {:d}"), x->_iAC) };
 		break;
 	case IPL_FIRERES:
 	case IPL_FIRERES_CURSE:
 		if (x->_iPLFR < 75)
-			strcpy(tempstr, fmt::format(_("Resist Fire: {:+d}%"), x->_iPLFR).c_str());
+			return StringVariant{ fmt::format(_("Resist Fire: {:+d}%"), x->_iPLFR) };
 		else
-			/*xgettext:no-c-format*/ strcpy(tempstr, _("Resist Fire: 75% MAX"));
+			/*xgettext:no-c-format*/ return StringVariant{ _("Resist Fire: 75% MAX") };
 		break;
 	case IPL_LIGHTRES:
 	case IPL_LIGHTRES_CURSE:
 		if (x->_iPLLR < 75)
-			strcpy(tempstr, fmt::format(_("Resist Lightning: {:+d}%"), x->_iPLLR).c_str());
+			return StringVariant{ fmt::format(_("Resist Lightning: {:+d}%"), x->_iPLLR) };
 		else
-			/*xgettext:no-c-format*/ strcpy(tempstr, _("Resist Lightning: 75% MAX"));
+			/*xgettext:no-c-format*/ return StringVariant{ _("Resist Lightning: 75% MAX") };
 		break;
 	case IPL_MAGICRES:
 	case IPL_MAGICRES_CURSE:
 		if (x->_iPLMR < 75)
-			strcpy(tempstr, fmt::format(_("Resist Magic: {:+d}%"), x->_iPLMR).c_str());
+			return StringVariant{ fmt::format(_("Resist Magic: {:+d}%"), x->_iPLMR) };
 		else
-			/*xgettext:no-c-format*/ strcpy(tempstr, _("Resist Magic: 75% MAX"));
+			/*xgettext:no-c-format*/ return StringVariant{ _("Resist Magic: 75% MAX") };
 		break;
 	case IPL_ALLRES:
 	case IPL_ALLRES_CURSE:
 		if (x->_iPLFR < 75)
-			strcpy(tempstr, fmt::format(_("Resist All: {:+d}%"), x->_iPLFR).c_str());
+			return StringVariant{ fmt::format(_("Resist All: {:+d}%"), x->_iPLFR) };
 		if (x->_iPLFR >= 75)
-			/*xgettext:no-c-format*/ strcpy(tempstr, _("Resist All: 75% MAX"));
+			/*xgettext:no-c-format*/ return StringVariant{ _("Resist All: 75% MAX") };
 		break;
 	case IPL_SPLLVLADD:
 		if (x->_iSplLvlAdd > 0)
-			strcpy(tempstr, fmt::format(ngettext("spells are increased {:d} level", "spells are increased {:d} levels", x->_iSplLvlAdd), x->_iSplLvlAdd).c_str());
+			return StringVariant{ fmt::format(ngettext("spells are increased {:d} level", "spells are increased {:d} levels", x->_iSplLvlAdd), x->_iSplLvlAdd) };
 		else if (x->_iSplLvlAdd < 0)
-			strcpy(tempstr, fmt::format(ngettext("spells are decreased {:d} level", "spells are decreased {:d} levels", -x->_iSplLvlAdd), -x->_iSplLvlAdd).c_str());
+			return StringVariant{ fmt::format(ngettext("spells are decreased {:d} level", "spells are decreased {:d} levels", -x->_iSplLvlAdd), -x->_iSplLvlAdd) };
 		else if (x->_iSplLvlAdd == 0)
-			strcpy(tempstr, _("spell levels unchanged (?)"));
+			return StringVariant{ _("spell levels unchanged (?)") };
 		break;
 	case IPL_CHARGES:
-		strcpy(tempstr, _("Extra charges"));
+		return StringVariant{ _("Extra charges") };
 		break;
 	case IPL_SPELL:
-		strcpy(tempstr, fmt::format(ngettext("{:d} {:s} charge", "{:d} {:s} charges", x->_iMaxCharges), x->_iMaxCharges, _(spelldata[x->_iSpell].sNameText)).c_str());
+		return StringVariant{ fmt::format(ngettext("{:d} {:s} charge", "{:d} {:s} charges", x->_iMaxCharges), x->_iMaxCharges, _(spelldata[x->_iSpell].sNameText)) };
 		break;
 	case IPL_FIREDAM:
 		if (x->_iFMinDam == x->_iFMaxDam)
-			strcpy(tempstr, fmt::format(_("Fire hit damage: {:d}"), x->_iFMinDam).c_str());
+			return StringVariant{ fmt::format(_("Fire hit damage: {:d}"), x->_iFMinDam) };
 		else
-			strcpy(tempstr, fmt::format(_("Fire hit damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam).c_str());
+			return StringVariant{ fmt::format(_("Fire hit damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam) };
 		break;
 	case IPL_LIGHTDAM:
 		if (x->_iLMinDam == x->_iLMaxDam)
-			strcpy(tempstr, fmt::format(_("Lightning hit damage: {:d}"), x->_iLMinDam).c_str());
+			return StringVariant{ fmt::format(_("Lightning hit damage: {:d}"), x->_iLMinDam) };
 		else
-			strcpy(tempstr, fmt::format(_("Lightning hit damage: {:d}-{:d}"), x->_iLMinDam, x->_iLMaxDam).c_str());
+			return StringVariant{ fmt::format(_("Lightning hit damage: {:d}-{:d}"), x->_iLMinDam, x->_iLMaxDam) };
 		break;
 	case IPL_STR:
 	case IPL_STR_CURSE:
-		strcpy(tempstr, fmt::format(_("{:+d} to strength"), x->_iPLStr).c_str());
+		return StringVariant{ fmt::format(_("{:+d} to strength"), x->_iPLStr) };
 		break;
 	case IPL_MAG:
 	case IPL_MAG_CURSE:
-		strcpy(tempstr, fmt::format(_("{:+d} to magic"), x->_iPLMag).c_str());
+		return StringVariant{ fmt::format(_("{:+d} to magic"), x->_iPLMag) };
 		break;
 	case IPL_DEX:
 	case IPL_DEX_CURSE:
-		strcpy(tempstr, fmt::format(_("{:+d} to dexterity"), x->_iPLDex).c_str());
+		return StringVariant{ fmt::format(_("{:+d} to dexterity"), x->_iPLDex) };
 		break;
 	case IPL_VIT:
 	case IPL_VIT_CURSE:
-		strcpy(tempstr, fmt::format(_("{:+d} to vitality"), x->_iPLVit).c_str());
+		return StringVariant{ fmt::format(_("{:+d} to vitality"), x->_iPLVit) };
 		break;
 	case IPL_ATTRIBS:
 	case IPL_ATTRIBS_CURSE:
-		strcpy(tempstr, fmt::format(_("{:+d} to all attributes"), x->_iPLStr).c_str());
+		return StringVariant{ fmt::format(_("{:+d} to all attributes"), x->_iPLStr) };
 		break;
 	case IPL_GETHIT_CURSE:
 	case IPL_GETHIT:
-		strcpy(tempstr, fmt::format(_("{:+d} damage from enemies"), x->_iPLGetHit).c_str());
+		return StringVariant{ fmt::format(_("{:+d} damage from enemies"), x->_iPLGetHit) };
 		break;
 	case IPL_LIFE:
 	case IPL_LIFE_CURSE:
-		strcpy(tempstr, fmt::format(_("Hit Points: {:+d}"), x->_iPLHP >> 6).c_str());
+		return StringVariant{ fmt::format(_("Hit Points: {:+d}"), x->_iPLHP >> 6) };
 		break;
 	case IPL_MANA:
 	case IPL_MANA_CURSE:
-		strcpy(tempstr, fmt::format(_("Mana: {:+d}"), x->_iPLMana >> 6).c_str());
+		return StringVariant{ fmt::format(_("Mana: {:+d}"), x->_iPLMana >> 6) };
 		break;
 	case IPL_DUR:
-		strcpy(tempstr, _("high durability"));
+		return StringVariant{ _("high durability") };
 		break;
 	case IPL_DUR_CURSE:
-		strcpy(tempstr, _("decreased durability"));
+		return StringVariant{ _("decreased durability") };
 		break;
 	case IPL_INDESTRUCTIBLE:
-		strcpy(tempstr, _("indestructible"));
+		return StringVariant{ _("indestructible") };
 		break;
 	case IPL_LIGHT:
-		/*xgettext:no-c-format*/ strcpy(tempstr, fmt::format(_("+{:d}% light radius"), 10 * x->_iPLLight).c_str());
+		/*xgettext:no-c-format*/ return StringVariant{ fmt::format(_("+{:d}% light radius"), 10 * x->_iPLLight) };
 		break;
 	case IPL_LIGHT_CURSE:
-		/*xgettext:no-c-format*/ strcpy(tempstr, fmt::format(_("-{:d}% light radius"), -10 * x->_iPLLight).c_str());
+		/*xgettext:no-c-format*/ return StringVariant{ fmt::format(_("-{:d}% light radius"), -10 * x->_iPLLight) };
 		break;
 	case IPL_MULT_ARROWS:
-		strcpy(tempstr, _("multiple arrows per shot"));
+		return StringVariant{ _("multiple arrows per shot") };
 		break;
 	case IPL_FIRE_ARROWS:
 		if (x->_iFMinDam == x->_iFMaxDam)
-			strcpy(tempstr, fmt::format(_("fire arrows damage: {:d}"), x->_iFMinDam).c_str());
+			return StringVariant{ fmt::format(_("fire arrows damage: {:d}"), x->_iFMinDam) };
 		else
-			strcpy(tempstr, fmt::format(_("fire arrows damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam).c_str());
+			return StringVariant{ fmt::format(_("fire arrows damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam) };
 		break;
 	case IPL_LIGHT_ARROWS:
 		if (x->_iLMinDam == x->_iLMaxDam)
-			strcpy(tempstr, fmt::format(_("lightning arrows damage {:d}"), x->_iLMinDam).c_str());
+			return StringVariant{ fmt::format(_("lightning arrows damage {:d}"), x->_iLMinDam) };
 		else
-			strcpy(tempstr, fmt::format(_("lightning arrows damage {:d}-{:d}"), x->_iLMinDam, x->_iLMaxDam).c_str());
+			return StringVariant{ fmt::format(_("lightning arrows damage {:d}-{:d}"), x->_iLMinDam, x->_iLMaxDam) };
 		break;
 	case IPL_FIREBALL:
 		if (x->_iFMinDam == x->_iFMaxDam)
-			strcpy(tempstr, fmt::format(_("fireball damage: {:d}"), x->_iFMinDam).c_str());
+			return StringVariant{ fmt::format(_("fireball damage: {:d}"), x->_iFMinDam) };
 		else
-			strcpy(tempstr, fmt::format(_("fireball damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam).c_str());
+			return StringVariant{ fmt::format(_("fireball damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam) };
 		break;
 	case IPL_THORNS:
-		strcpy(tempstr, _("attacker takes 1-3 damage"));
+		return StringVariant{ _("attacker takes 1-3 damage") };
 		break;
 	case IPL_NOMANA:
-		strcpy(tempstr, _("user loses all mana"));
+		return StringVariant{ _("user loses all mana") };
 		break;
 	case IPL_NOHEALPLR:
-		strcpy(tempstr, _("you can't heal"));
+		return StringVariant{ _("you can't heal") };
 		break;
 	case IPL_ABSHALFTRAP:
-		strcpy(tempstr, _("absorbs half of trap damage"));
+		return StringVariant{ _("absorbs half of trap damage") };
 		break;
 	case IPL_KNOCKBACK:
-		strcpy(tempstr, _("knocks target back"));
+		return StringVariant{ _("knocks target back") };
 		break;
 	case IPL_3XDAMVDEM:
-		/*xgettext:no-c-format*/ strcpy(tempstr, _("+200% damage vs. demons"));
+		/*xgettext:no-c-format*/ return StringVariant{ _("+200% damage vs. demons") };
 		break;
 	case IPL_ALLRESZERO:
-		strcpy(tempstr, _("All Resistance equals 0"));
+		return StringVariant{ _("All Resistance equals 0") };
 		break;
 	case IPL_NOHEALMON:
-		strcpy(tempstr, _("hit monster doesn't heal"));
+		return StringVariant{ _("hit monster doesn't heal") };
 		break;
 	case IPL_STEALMANA:
 		if ((x->_iFlags & ISPL_STEALMANA_3) != 0)
-			/*xgettext:no-c-format*/ strcpy(tempstr, _("hit steals 3% mana"));
+			/*xgettext:no-c-format*/ return StringVariant{ _("hit steals 3% mana") };
 		if ((x->_iFlags & ISPL_STEALMANA_5) != 0)
-			/*xgettext:no-c-format*/ strcpy(tempstr, _("hit steals 5% mana"));
+			/*xgettext:no-c-format*/ return StringVariant{ _("hit steals 5% mana") };
 		break;
 	case IPL_STEALLIFE:
 		if ((x->_iFlags & ISPL_STEALLIFE_3) != 0)
-			/*xgettext:no-c-format*/ strcpy(tempstr, _("hit steals 3% life"));
+			/*xgettext:no-c-format*/ return StringVariant{ _("hit steals 3% life") };
 		if ((x->_iFlags & ISPL_STEALLIFE_5) != 0)
-			/*xgettext:no-c-format*/ strcpy(tempstr, _("hit steals 5% life"));
+			/*xgettext:no-c-format*/ return StringVariant{ _("hit steals 5% life") };
 		break;
 	case IPL_TARGAC:
-		strcpy(tempstr, _("penetrates target's armor"));
+		return StringVariant{ _("penetrates target's armor") };
 		break;
 	case IPL_FASTATTACK:
 		if ((x->_iFlags & ISPL_QUICKATTACK) != 0)
-			strcpy(tempstr, _("quick attack"));
+			return StringVariant{ _("quick attack") };
 		if ((x->_iFlags & ISPL_FASTATTACK) != 0)
-			strcpy(tempstr, _("fast attack"));
+			return StringVariant{ _("fast attack") };
 		if ((x->_iFlags & ISPL_FASTERATTACK) != 0)
-			strcpy(tempstr, _("faster attack"));
+			return StringVariant{ _("faster attack") };
 		if ((x->_iFlags & ISPL_FASTESTATTACK) != 0)
-			strcpy(tempstr, _("fastest attack"));
+			return StringVariant{ _("fastest attack") };
 		break;
 	case IPL_FASTRECOVER:
 		if ((x->_iFlags & ISPL_FASTRECOVER) != 0)
-			strcpy(tempstr, _("fast hit recovery"));
+			return StringVariant{ _("fast hit recovery") };
 		if ((x->_iFlags & ISPL_FASTERRECOVER) != 0)
-			strcpy(tempstr, _("faster hit recovery"));
+			return StringVariant{ _("faster hit recovery") };
 		if ((x->_iFlags & ISPL_FASTESTRECOVER) != 0)
-			strcpy(tempstr, _("fastest hit recovery"));
+			return StringVariant{ _("fastest hit recovery") };
 		break;
 	case IPL_FASTBLOCK:
-		strcpy(tempstr, _("fast block"));
+		return StringVariant{ _("fast block") };
 		break;
 	case IPL_DAMMOD:
-		strcpy(tempstr, fmt::format(ngettext("adds {:d} point to damage", "adds {:d} points to damage", x->_iPLDamMod), x->_iPLDamMod).c_str());
+		return StringVariant{ fmt::format(ngettext("adds {:d} point to damage", "adds {:d} points to damage", x->_iPLDamMod), x->_iPLDamMod) };
 		break;
 	case IPL_RNDARROWVEL:
-		strcpy(tempstr, _("fires random speed arrows"));
+		return StringVariant{ _("fires random speed arrows") };
 		break;
 	case IPL_SETDAM:
-		strcpy(tempstr, _("unusual item damage"));
+		return StringVariant{ _("unusual item damage") };
 		break;
 	case IPL_SETDUR:
-		strcpy(tempstr, _("altered durability"));
+		return StringVariant{ _("altered durability") };
 		break;
 	case IPL_FASTSWING:
-		strcpy(tempstr, _("Faster attack swing"));
+		return StringVariant{ _("Faster attack swing") };
 		break;
 	case IPL_ONEHAND:
-		strcpy(tempstr, _("one handed sword"));
+		return StringVariant{ _("one handed sword") };
 		break;
 	case IPL_DRAINLIFE:
-		strcpy(tempstr, _("constantly lose hit points"));
+		return StringVariant{ _("constantly lose hit points") };
 		break;
 	case IPL_RNDSTEALLIFE:
-		strcpy(tempstr, _("life stealing"));
+		return StringVariant{ _("life stealing") };
 		break;
 	case IPL_NOMINSTR:
-		strcpy(tempstr, _("no strength requirement"));
+		return StringVariant{ _("no strength requirement") };
 		break;
 	case IPL_INFRAVISION:
-		strcpy(tempstr, _("see with infravision"));
+		return StringVariant{ _("see with infravision") };
 		break;
 	case IPL_INVCURS:
-		strcpy(tempstr, " ");
+		return StringVariant{ " " };
 		break;
 	case IPL_ADDACLIFE:
 		if (x->_iFMinDam == x->_iFMaxDam)
-			strcpy(tempstr, fmt::format(_("lightning damage: {:d}"), x->_iFMinDam).c_str());
+			return StringVariant{ fmt::format(_("lightning damage: {:d}"), x->_iFMinDam) };
 		else
-			strcpy(tempstr, fmt::format(_("lightning damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam).c_str());
+			return StringVariant{ fmt::format(_("lightning damage: {:d}-{:d}"), x->_iFMinDam, x->_iFMaxDam) };
 		break;
 	case IPL_ADDMANAAC:
-		strcpy(tempstr, _("charged bolts on hits"));
+		return StringVariant{ _("charged bolts on hits") };
 		break;
 	case IPL_FIRERESCLVL:
 		if (x->_iPLFR <= 0)
-			strcpy(tempstr, " ");
+			return StringVariant{ " " };
 		else if (x->_iPLFR >= 1)
-			strcpy(tempstr, fmt::format(_("Resist Fire: {:+d}%"), x->_iPLFR).c_str());
+			return StringVariant{ fmt::format(_("Resist Fire: {:+d}%"), x->_iPLFR) };
 		break;
 	case IPL_DEVASTATION:
-		strcpy(tempstr, _("occasional triple damage"));
+		return StringVariant{ _("occasional triple damage") };
 		break;
 	case IPL_DECAY:
-		/*xgettext:no-c-format*/ strcpy(tempstr, fmt::format(_("decaying {:+d}% damage"), x->_iPLDam).c_str());
+		/*xgettext:no-c-format*/ return StringVariant{ fmt::format(_("decaying {:+d}% damage"), x->_iPLDam) };
 		break;
 	case IPL_PERIL:
-		strcpy(tempstr, _("2x dmg to monst, 1x to you"));
+		return StringVariant{ _("2x dmg to monst, 1x to you") };
 		break;
 	case IPL_JESTERS:
-		/*xgettext:no-c-format*/ strcpy(tempstr, _("Random 0 - 500% damage"));
+		/*xgettext:no-c-format*/ return StringVariant{ _("Random 0 - 500% damage") };
 		break;
 	case IPL_CRYSTALLINE:
-		/*xgettext:no-c-format*/ strcpy(tempstr, fmt::format(_("low dur, {:+d}% damage"), x->_iPLDam).c_str());
+		/*xgettext:no-c-format*/ return StringVariant{ fmt::format(_("low dur, {:+d}% damage"), x->_iPLDam) };
 		break;
 	case IPL_DOPPELGANGER:
-		strcpy(tempstr, fmt::format(_("to hit: {:+d}%, {:+d}% damage"), x->_iPLToHit, x->_iPLDam).c_str());
+		return StringVariant{ fmt::format(_("to hit: {:+d}%, {:+d}% damage"), x->_iPLToHit, x->_iPLDam) };
 		break;
 	case IPL_ACDEMON:
-		strcpy(tempstr, _("extra AC vs demons"));
+		return StringVariant{ _("extra AC vs demons") };
 		break;
 	case IPL_ACUNDEAD:
-		strcpy(tempstr, _("extra AC vs undead"));
+		return StringVariant{ _("extra AC vs undead") };
 		break;
 	case IPL_MANATOLIFE:
-		/*xgettext:no-c-format*/ strcpy(tempstr, _("50% Mana moved to Health"));
+		/*xgettext:no-c-format*/ return StringVariant{ _("50% Mana moved to Health") };
 		break;
 	case IPL_LIFETOMANA:
-		/*xgettext:no-c-format*/ strcpy(tempstr, _("40% Health moved to Mana"));
+		/*xgettext:no-c-format*/ return StringVariant{ _("40% Health moved to Mana") };
 		break;
 	default:
-		strcpy(tempstr, _("Another ability (NW)"));
+		return StringVariant{ _("Another ability (NW)") };
 		break;
 	}
+}
+
+void PrintItemPower(char plidx, ItemStruct *x)
+{
+	string_view text = FormatItemPower(plidx, x);
+	strncpy(tempstr, text.data(), text.length());
+	tempstr[text.length()] = '\0';
 }
 
 void DrawUniqueInfo(const Surface &out)
@@ -4094,8 +4100,7 @@ void DrawUniqueInfo(const Surface &out)
 		if (power.type == IPL_INVALID)
 			break;
 		rect.position.y += 2 * 12;
-		PrintItemPower(power.type, &curruitem);
-		DrawString(out, tempstr, rect, UiFlags::ColorSilver | UiFlags::AlignCenter);
+		DrawString(out, FormatItemPower(power.type, &curruitem), rect, UiFlags::ColorSilver | UiFlags::AlignCenter);
 	}
 }
 
@@ -4122,14 +4127,10 @@ void PrintItemDetails(ItemStruct *x)
 	}
 	if (x->_iMiscId == IMISC_STAFF && x->_iMaxCharges != 0)
 		AddPanelString(fmt::format(_("Charges: {:d}/{:d}"), x->_iCharges, x->_iMaxCharges));
-	if (x->_iPrePower != -1) {
-		PrintItemPower(x->_iPrePower, x);
-		AddPanelString(tempstr);
-	}
-	if (x->_iSufPower != -1) {
-		PrintItemPower(x->_iSufPower, x);
-		AddPanelString(tempstr);
-	}
+	if (x->_iPrePower != -1)
+		AddPanelString(FormatItemPower(x->_iPrePower, x));
+	if (x->_iSufPower != -1)
+		AddPanelString(FormatItemPower(x->_iSufPower, x));
 	if (x->_iMagical == ITEM_QUALITY_UNIQUE) {
 		AddPanelString(_("unique item"));
 		ShowUniqueItemInfoBox = true;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4783,12 +4783,11 @@ void M_FallenFear(Point position)
 void PrintMonstHistory(int mt)
 {
 	if (sgOptions.Gameplay.bShowMonsterType) {
-		strcpy(tempstr, fmt::format(_("Type: {:s}  Kills: {:d}"), GetMonsterTypeText(MonsterData[mt]), MonsterKillCounts[mt]).c_str());
+		AddPanelString(fmt::format(_("Type: {:s}  Kills: {:d}"), GetMonsterTypeText(MonsterData[mt]), MonsterKillCounts[mt]));
 	} else {
-		strcpy(tempstr, fmt::format(_("Total kills: {:d}"), MonsterKillCounts[mt]).c_str());
+		AddPanelString(fmt::format(_("Total kills: {:d}"), MonsterKillCounts[mt]));
 	}
 
-	AddPanelString(tempstr);
 	if (MonsterKillCounts[mt] >= 30) {
 		int minHP = MonsterData[mt].mMinHP;
 		int maxHP = MonsterData[mt].mMaxHP;
@@ -4818,14 +4817,12 @@ void PrintMonstHistory(int mt)
 			minHP = 4 * minHP + hpBonusHell;
 			maxHP = 4 * maxHP + hpBonusHell;
 		}
-		strcpy(tempstr, fmt::format(_("Hit Points: {:d}-{:d}"), minHP, maxHP).c_str());
-		AddPanelString(tempstr);
+		AddPanelString(fmt::format(_("Hit Points: {:d}-{:d}"), minHP, maxHP));
 	}
 	if (MonsterKillCounts[mt] >= 15) {
 		int res = (sgGameInitInfo.nDifficulty != DIFF_HELL) ? MonsterData[mt].mMagicRes : MonsterData[mt].mMagicRes2;
 		if ((res & (RESIST_MAGIC | RESIST_FIRE | RESIST_LIGHTNING | IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING)) == 0) {
-			strcpy(tempstr, _("No magic resistance"));
-			AddPanelString(tempstr);
+			AddPanelString(_("No magic resistance"));
 		} else {
 			if ((res & (RESIST_MAGIC | RESIST_FIRE | RESIST_LIGHTNING)) != 0) {
 				strcpy(tempstr, _("Resists: "));
@@ -4857,15 +4854,12 @@ void PrintMonstHistory(int mt)
 void PrintUniqueHistory()
 {
 	auto &monster = Monsters[pcursmonst];
-	if (sgOptions.Gameplay.bShowMonsterType) {
-		strcpy(tempstr, fmt::format(_("Type: {:s}"), GetMonsterTypeText(*monster.MData)).c_str());
-		AddPanelString(tempstr);
-	}
+	if (sgOptions.Gameplay.bShowMonsterType)
+		AddPanelString(fmt::format(_("Type: {:s}"), GetMonsterTypeText(*monster.MData)));
 
 	int res = monster.mMagicRes & (RESIST_MAGIC | RESIST_FIRE | RESIST_LIGHTNING | IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING);
 	if (res == 0) {
-		strcpy(tempstr, _("No resistances"));
-		AddPanelString(tempstr);
+		AddPanelString(_("No resistances"));
 		strcpy(tempstr, _("No Immunities"));
 	} else {
 		if ((res & (RESIST_MAGIC | RESIST_FIRE | RESIST_LIGHTNING)) != 0)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4860,20 +4860,18 @@ void PrintUniqueHistory()
 	int res = monster.mMagicRes & (RESIST_MAGIC | RESIST_FIRE | RESIST_LIGHTNING | IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING);
 	if (res == 0) {
 		AddPanelString(_("No resistances"));
-		strcpy(tempstr, _("No Immunities"));
+		AddPanelString(_("No Immunities"));
 	} else {
 		if ((res & (RESIST_MAGIC | RESIST_FIRE | RESIST_LIGHTNING)) != 0)
-			strcpy(tempstr, _("Some Magic Resistances"));
+			AddPanelString(_("Some Magic Resistances"));
 		else
-			strcpy(tempstr, _("No resistances"));
-		AddPanelString(tempstr);
+			AddPanelString(_("No resistances"));
 		if ((res & (IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING)) != 0) {
-			strcpy(tempstr, _("Some Magic Immunities"));
+			AddPanelString(_("Some Magic Immunities"));
 		} else {
-			strcpy(tempstr, _("No Immunities"));
+			AddPanelString(_("No Immunities"));
 		}
 	}
-	AddPanelString(tempstr);
 	pinfoflag = true;
 }
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5413,11 +5413,11 @@ void GetObjectStr(int i)
 	case OBJ_CRUX1:
 	case OBJ_CRUX2:
 	case OBJ_CRUX3:
-		strcpy(infostr, _("Crucified Skeleton"));
+		infostr = _("Crucified Skeleton");
 		break;
 	case OBJ_LEVER:
 	case OBJ_FLAMELVR:
-		strcpy(infostr, _("Lever"));
+		infostr = _("Lever");
 		break;
 	case OBJ_L1LDOOR:
 	case OBJ_L1RDOOR:
@@ -5426,138 +5426,135 @@ void GetObjectStr(int i)
 	case OBJ_L3LDOOR:
 	case OBJ_L3RDOOR:
 		if (Objects[i]._oVar4 == 1)
-			strcpy(infostr, _("Open Door"));
+			infostr = _("Open Door");
 		if (Objects[i]._oVar4 == 0)
-			strcpy(infostr, _("Closed Door"));
+			infostr = _("Closed Door");
 		if (Objects[i]._oVar4 == 2)
-			strcpy(infostr, _("Blocked Door"));
+			infostr = _("Blocked Door");
 		break;
 	case OBJ_BOOK2L:
 		if (setlevel) {
 			if (setlvlnum == SL_BONECHAMB) {
-				strcpy(infostr, _("Ancient Tome"));
+				infostr = _("Ancient Tome");
 			} else if (setlvlnum == SL_VILEBETRAYER) {
-				strcpy(infostr, _("Book of Vileness"));
+				infostr = _("Book of Vileness");
 			}
 		}
 		break;
 	case OBJ_SWITCHSKL:
-		strcpy(infostr, _("Skull Lever"));
+		infostr = _("Skull Lever");
 		break;
 	case OBJ_BOOK2R:
-		strcpy(infostr, _("Mythical Book"));
+		infostr = _("Mythical Book");
 		break;
 	case OBJ_CHEST1:
 	case OBJ_TCHEST1:
-		strcpy(infostr, _("Small Chest"));
+		infostr = _("Small Chest");
 		break;
 	case OBJ_CHEST2:
 	case OBJ_TCHEST2:
-		strcpy(infostr, _("Chest"));
+		infostr = _("Chest");
 		break;
 	case OBJ_CHEST3:
 	case OBJ_TCHEST3:
 	case OBJ_SIGNCHEST:
-		strcpy(infostr, _("Large Chest"));
+		infostr = _("Large Chest");
 		break;
 	case OBJ_SARC:
-		strcpy(infostr, _("Sarcophagus"));
+		infostr = _("Sarcophagus");
 		break;
 	case OBJ_BOOKSHELF:
-		strcpy(infostr, _("Bookshelf"));
+		infostr = _("Bookshelf");
 		break;
 	case OBJ_BOOKCASEL:
 	case OBJ_BOOKCASER:
-		strcpy(infostr, _("Bookcase"));
+		infostr = _("Bookcase");
 		break;
 	case OBJ_BARREL:
 	case OBJ_BARRELEX:
 		if (currlevel >= 17 && currlevel <= 20)      // for hive levels
-			strcpy(infostr, _("Pod"));               //Then a barrel is called a pod
+			infostr = _("Pod");               //Then a barrel is called a pod
 		else if (currlevel >= 21 && currlevel <= 24) // for crypt levels
-			strcpy(infostr, _("Urn"));               //Then a barrel is called an urn
+			infostr = _("Urn");               //Then a barrel is called an urn
 		else
-			strcpy(infostr, _("Barrel"));
+			infostr = _("Barrel");
 		break;
 	case OBJ_SHRINEL:
 	case OBJ_SHRINER:
-		strcpy(tempstr, fmt::format(_(/* TRANSLATORS: {:s} will be a name from the Shrine block above */ "{:s} Shrine"), _(ShrineNames[Objects[i]._oVar1])).c_str());
-		strcpy(infostr, tempstr);
+		infostr = fmt::format(_(/* TRANSLATORS: {:s} will be a name from the Shrine block above */ "{:s} Shrine"), _(ShrineNames[Objects[i]._oVar1]));
 		break;
 	case OBJ_SKELBOOK:
-		strcpy(infostr, _("Skeleton Tome"));
+		infostr = _("Skeleton Tome");
 		break;
 	case OBJ_BOOKSTAND:
-		strcpy(infostr, _("Library Book"));
+		infostr = _("Library Book");
 		break;
 	case OBJ_BLOODFTN:
-		strcpy(infostr, _("Blood Fountain"));
+		infostr = _("Blood Fountain");
 		break;
 	case OBJ_DECAP:
-		strcpy(infostr, _("Decapitated Body"));
+		infostr = _("Decapitated Body");
 		break;
 	case OBJ_BLINDBOOK:
-		strcpy(infostr, _("Book of the Blind"));
+		infostr = _("Book of the Blind");
 		break;
 	case OBJ_BLOODBOOK:
-		strcpy(infostr, _("Book of Blood"));
+		infostr = _("Book of Blood");
 		break;
 	case OBJ_PURIFYINGFTN:
-		strcpy(infostr, _("Purifying Spring"));
+		infostr = _("Purifying Spring");
 		break;
 	case OBJ_ARMORSTAND:
 	case OBJ_WARARMOR:
-		strcpy(infostr, _("Armor"));
+		infostr = _("Armor");
 		break;
 	case OBJ_WARWEAP:
-		strcpy(infostr, _("Weapon Rack"));
+		infostr = _("Weapon Rack");
 		break;
 	case OBJ_GOATSHRINE:
-		strcpy(infostr, _("Goat Shrine"));
+		infostr = _("Goat Shrine");
 		break;
 	case OBJ_CAULDRON:
-		strcpy(infostr, _("Cauldron"));
+		infostr = _("Cauldron");
 		break;
 	case OBJ_MURKYFTN:
-		strcpy(infostr, _("Murky Pool"));
+		infostr = _("Murky Pool");
 		break;
 	case OBJ_TEARFTN:
-		strcpy(infostr, _("Fountain of Tears"));
+		infostr = _("Fountain of Tears");
 		break;
 	case OBJ_STEELTOME:
-		strcpy(infostr, _("Steel Tome"));
+		infostr = _("Steel Tome");
 		break;
 	case OBJ_PEDISTAL:
-		strcpy(infostr, _("Pedestal of Blood"));
+		infostr = _("Pedestal of Blood");
 		break;
 	case OBJ_STORYBOOK:
-		strcpy(infostr, _(StoryBookName[Objects[i]._oVar3]));
+		infostr = _(StoryBookName[Objects[i]._oVar3]);
 		break;
 	case OBJ_WEAPONRACK:
-		strcpy(infostr, _("Weapon Rack"));
+		infostr = _("Weapon Rack");
 		break;
 	case OBJ_MUSHPATCH:
-		strcpy(infostr, _("Mushroom Patch"));
+		infostr = _("Mushroom Patch");
 		break;
 	case OBJ_LAZSTAND:
-		strcpy(infostr, _("Vile Stand"));
+		infostr = _("Vile Stand");
 		break;
 	case OBJ_SLAINHERO:
-		strcpy(infostr, _("Slain Hero"));
+		infostr = _("Slain Hero");
 		break;
 	default:
 		break;
 	}
 	if (Players[MyPlayerId]._pClass == HeroClass::Rogue) {
 		if (Objects[i]._oTrapFlag) {
-			strcpy(tempstr, fmt::format(_(/* TRANSLATORS: {:s} will either be a chest or a door */ "Trapped {:s}"), infostr).c_str());
-			strcpy(infostr, tempstr);
+			infostr = fmt::format(_(/* TRANSLATORS: {:s} will either be a chest or a door */ "Trapped {:s}"), infostr);
 			InfoColor = UiFlags::ColorRed;
 		}
 	}
 	if (objectIsDisabled(i)) {
-		strcpy(tempstr, fmt::format(_(/* TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver */ "{:s} (disabled)"), infostr).c_str());
-		strcpy(infostr, tempstr);
+		infostr = fmt::format(_(/* TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver */ "{:s} (disabled)"), infostr);
 		InfoColor = UiFlags::ColorRed;
 	}
 }

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -125,8 +125,7 @@ bool CheckXPBarInfo()
 
 	const int8_t charLevel = player._pLevel;
 
-	strcpy(tempstr, fmt::format(_("Level {:d}"), charLevel).c_str());
-	AddPanelString(tempstr);
+	AddPanelString(fmt::format(_("Level {:d}"), charLevel));
 
 	if (charLevel == MAXCHARLEVEL - 1) {
 		// Show a maximum level indicator for max level players.

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -433,7 +433,7 @@ bool ForceQuests()
 
 			for (int j = 0; j < 7; j++) {
 				if (qx + questxoff[j] == cursmx && qy + questyoff[j] == cursmy) {
-					strcpy(infostr, fmt::format(_(/* TRANSLATORS: Used for Quest Portals. {:s} is a Map Name */ "To {:s}"), _(QuestTriggerNames[ql])).c_str());
+					infostr = fmt::format(_(/* TRANSLATORS: Used for Quest Portals. {:s} is a Map Name */ "To {:s}"), _(QuestTriggerNames[ql]));
 					cursmx = qx;
 					cursmy = qy;
 					return true;

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -136,7 +136,7 @@ void AddSLine(int y)
 {
 	stext[y]._sx = 0;
 	stext[y]._syoff = 0;
-	stext[y]._sstr[0] = 0;
+	stext[y]._sstr = "";
 	stext[y]._sline = 1;
 }
 
@@ -150,11 +150,12 @@ void OffsetSTextY(int y, int yo)
 	stext[y]._syoff = yo;
 }
 
-void AddSText(int x, int y, const char *str, UiFlags flags, bool sel)
+template <typename T>
+void AddSText(int x, int y, T str, UiFlags flags, bool sel)
 {
 	stext[y]._sx = x;
 	stext[y]._syoff = 0;
-	strcpy(stext[y]._sstr, str);
+	stext[y]._sstr = str;
 	stext[y].flags = flags;
 	stext[y]._sline = 0;
 	stext[y]._ssel = sel;
@@ -2161,7 +2162,7 @@ int TakeGold(PlayerStruct &player, int cost, bool skipMaxPiles)
 	return cost;
 }
 
-void DrawSelector(const Surface &out, const Rectangle &rect, const char *text, UiFlags flags)
+void DrawSelector(const Surface &out, const Rectangle &rect, string_view text, UiFlags flags)
 {
 	int lineWidth = GetLineWidth(text);
 
@@ -2251,7 +2252,7 @@ void FreeStoreMem()
 	pSTextSlidCels = std::nullopt;
 }
 
-void PrintSString(const Surface &out, int margin, int line, const char *text, UiFlags flags, int price)
+void PrintSString(const Surface &out, int margin, int line, string_view text, UiFlags flags, int price)
 {
 	int sx = PANEL_X + 32 + margin;
 	if (!stextsize) {
@@ -2308,7 +2309,7 @@ void ClearSText(int s, int e)
 	for (int i = s; i < e; i++) {
 		stext[i]._sx = 0;
 		stext[i]._syoff = 0;
-		stext[i]._sstr[0] = 0;
+		stext[i]._sstr = "";
 		stext[i].flags = UiFlags::None;
 		stext[i]._sline = 0;
 		stext[i]._ssel = false;
@@ -2452,7 +2453,7 @@ void DrawSText(const Surface &out)
 	for (int i = 0; i < STORE_LINES; i++) {
 		if (stext[i]._sline != 0)
 			DrawSLine(out, i);
-		if (stext[i]._sstr[0] != '\0')
+		if (stext[i]._sstr.length() > 0)
 			PrintSString(out, stext[i]._sx, i, stext[i]._sstr, stext[i].flags, stext[i]._sval);
 	}
 

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -286,9 +286,9 @@ void StartSmithBuy()
 	stextsval = 0;
 
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
-	strcpy(tempstr, fmt::format(_("I have these items for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold).c_str());
+	std::string prompt = fmt::format(_("I have these items for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold);
 
-	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 1, std::move(prompt), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithBuy(stextsval);
@@ -350,9 +350,9 @@ bool StartSmithPremiumBuy()
 	stextsval = 0;
 
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
-	strcpy(tempstr, fmt::format(_("I have these premium items for sale:     Your gold: {:d}"), Players[MyPlayerId]._pGold).c_str());
+	std::string prompt = fmt::format(_("I have these premium items for sale:     Your gold: {:d}"), Players[MyPlayerId]._pGold);
 
-	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 1, std::move(prompt), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, false);
@@ -477,9 +477,9 @@ void StartSmithSell()
 		stextscrl = false;
 
 		/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
-		strcpy(tempstr, fmt::format(_("You have nothing I want.             Your gold: {:d}"), myPlayer._pGold).c_str());
+		std::string prompt = fmt::format(_("You have nothing I want.             Your gold: {:d}"), myPlayer._pGold);
 
-		AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
+		AddSText(0, 1, std::move(prompt), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 		AddSLine(3);
 		AddSLine(21);
 		AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
@@ -492,9 +492,9 @@ void StartSmithSell()
 	stextsmax = myPlayer._pNumInv;
 
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
-	strcpy(tempstr, fmt::format(_("Which item is for sale?             Your gold: {:d}"), myPlayer._pGold).c_str());
+	std::string prompt = fmt::format(_("Which item is for sale?             Your gold: {:d}"), myPlayer._pGold);
 
-	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 1, std::move(prompt), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithSell(stextsval);
@@ -567,9 +567,9 @@ void StartSmithRepair()
 		stextscrl = false;
 
 		/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
-		strcpy(tempstr, fmt::format(_("You have nothing to repair.             Your gold: {:d}"), myPlayer._pGold).c_str());
+		std::string prompt = fmt::format(_("You have nothing to repair.             Your gold: {:d}"), myPlayer._pGold);
 
-		AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
+		AddSText(0, 1, std::move(prompt), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 		AddSLine(3);
 		AddSLine(21);
 		AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
@@ -582,9 +582,9 @@ void StartSmithRepair()
 	stextsmax = myPlayer._pNumInv;
 
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
-	strcpy(tempstr, fmt::format(_("Repair which item?             Your gold: {:d}"), myPlayer._pGold).c_str());
+	std::string prompt = fmt::format(_("Repair which item?             Your gold: {:d}"), myPlayer._pGold);
 
-	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 1, std::move(prompt), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithSell(stextsval);
@@ -657,9 +657,9 @@ void StartWitchBuy()
 	stextsmax = 20;
 
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
-	strcpy(tempstr, fmt::format(_("I have these items for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold).c_str());
+	std::string prompt = fmt::format(_("I have these items for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold);
 
-	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 1, std::move(prompt), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollWitchBuy(stextsval);
@@ -751,9 +751,9 @@ void StartWitchSell()
 		stextscrl = false;
 
 		/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
-		strcpy(tempstr, fmt::format(_("You have nothing I want.             Your gold: {:d}"), myPlayer._pGold).c_str());
+		std::string prompt = fmt::format(_("You have nothing I want.             Your gold: {:d}"), myPlayer._pGold);
 
-		AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
+		AddSText(0, 1, std::move(prompt), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 		AddSLine(3);
 		AddSLine(21);
 		AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
@@ -766,9 +766,9 @@ void StartWitchSell()
 	stextsmax = myPlayer._pNumInv;
 
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
-	strcpy(tempstr, fmt::format(_("Which item is for sale?             Your gold: {:d}"), myPlayer._pGold).c_str());
+	std::string prompt = fmt::format(_("Which item is for sale?             Your gold: {:d}"), myPlayer._pGold);
 
-	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 1, std::move(prompt), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithSell(stextsval);
@@ -832,9 +832,9 @@ void StartWitchRecharge()
 		stextscrl = false;
 
 		/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
-		strcpy(tempstr, fmt::format(_("You have nothing to recharge.             Your gold: {:d}"), myPlayer._pGold).c_str());
+		std::string prompt = fmt::format(_("You have nothing to recharge.             Your gold: {:d}"), myPlayer._pGold);
 
-		AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
+		AddSText(0, 1, std::move(prompt), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 		AddSLine(3);
 		AddSLine(21);
 		AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
@@ -847,9 +847,9 @@ void StartWitchRecharge()
 	stextsmax = myPlayer._pNumInv;
 
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
-	strcpy(tempstr, fmt::format(_("Recharge which item?             Your gold: {:d}"), myPlayer._pGold).c_str());
+	std::string prompt = fmt::format(_("Recharge which item?             Your gold: {:d}"), myPlayer._pGold);
 
-	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 1, std::move(prompt), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithSell(stextsval);
@@ -906,33 +906,34 @@ void StoreConfirm()
 	AddSTextVal(8, item._iIvalue);
 	PrintStoreItem(&item, 9, itemColor);
 
+	string_view prompt;
 	switch (stextshold) {
 	case STORE_BBOY:
-		strcpy(tempstr, _("Do we have a deal?"));
+		prompt = _("Do we have a deal?");
 		break;
 	case STORE_SIDENTIFY:
-		strcpy(tempstr, _("Are you sure you want to identify this item?"));
+		prompt = _("Are you sure you want to identify this item?");
 		break;
 	case STORE_HBUY:
 	case STORE_SPBUY:
 	case STORE_WBUY:
 	case STORE_SBUY:
-		strcpy(tempstr, _("Are you sure you want to buy this item?"));
+		prompt = _("Are you sure you want to buy this item?");
 		break;
 	case STORE_WRECHARGE:
-		strcpy(tempstr, _("Are you sure you want to recharge this item?"));
+		prompt = _("Are you sure you want to recharge this item?");
 		break;
 	case STORE_SSELL:
 	case STORE_WSELL:
-		strcpy(tempstr, _("Are you sure you want to sell this item?"));
+		prompt = _("Are you sure you want to sell this item?");
 		break;
 	case STORE_SREPAIR:
-		strcpy(tempstr, _("Are you sure you want to repair this item?"));
+		prompt = _("Are you sure you want to repair this item?");
 		break;
 	default:
 		app_fatal("Unknown store dialog %i", stextshold);
 	}
-	AddSText(0, 15, tempstr, UiFlags::ColorSilver | UiFlags::AlignCenter, false);
+	AddSText(0, 15, prompt, UiFlags::ColorSilver | UiFlags::AlignCenter, false);
 	AddSText(0, 18, _("Yes"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 	AddSText(0, 20, _("No"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 }
@@ -962,9 +963,9 @@ void SStartBoyBuy()
 	stextscrl = false;
 
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
-	strcpy(tempstr, fmt::format(_("I have this item for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold).c_str());
+	std::string prompt = fmt::format(_("I have this item for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold);
 
-	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 1, std::move(prompt), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	UiFlags itemColor = boyitem.getTextColorWithStatCheck();
@@ -1037,9 +1038,9 @@ void StartHealerBuy()
 	stextsval = 0;
 
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
-	strcpy(tempstr, fmt::format(_("I have these items for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold).c_str());
+	std::string prompt = fmt::format(_("I have these items for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold);
 
-	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 1, std::move(prompt), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollHealerBuy(stextsval);
@@ -1155,9 +1156,9 @@ void StartStorytellerIdentify()
 		stextscrl = false;
 
 		/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
-		strcpy(tempstr, fmt::format(_("You have nothing to identify.             Your gold: {:d}"), myPlayer._pGold).c_str());
+		std::string prompt = fmt::format(_("You have nothing to identify.             Your gold: {:d}"), myPlayer._pGold);
 
-		AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
+		AddSText(0, 1, std::move(prompt), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 		AddSLine(3);
 		AddSLine(21);
 		AddSText(0, 22, _("Back"), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
@@ -1170,9 +1171,9 @@ void StartStorytellerIdentify()
 	stextsmax = myPlayer._pNumInv;
 
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
-	strcpy(tempstr, fmt::format(_("Identify which item?             Your gold: {:d}"), myPlayer._pGold).c_str());
+	std::string prompt = fmt::format(_("Identify which item?             Your gold: {:d}"), myPlayer._pGold);
 
-	AddSText(0, 1, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 1, std::move(prompt), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 	AddSLine(21);
 	ScrollSmithSell(stextsval);
@@ -1202,12 +1203,10 @@ void StartTalk()
 
 	stextsize = false;
 	stextscrl = false;
-	strcpy(tempstr, fmt::format(_("Talk to {:s}"), TownerNames[talker]).c_str());
-	AddSText(0, 2, tempstr, UiFlags::ColorGold | UiFlags::AlignCenter, false);
+	AddSText(0, 2, fmt::format(_("Talk to {:s}"), TownerNames[talker]), UiFlags::ColorGold | UiFlags::AlignCenter, false);
 	AddSLine(5);
 	if (gbIsSpawn) {
-		strcpy(tempstr, fmt::format(_("Talking to {:s}"), TownerNames[talker]).c_str());
-		AddSText(0, 10, tempstr, UiFlags::ColorSilver | UiFlags::AlignCenter, false);
+		AddSText(0, 10, fmt::format(_("Talking to {:s}"), TownerNames[talker]), UiFlags::ColorSilver | UiFlags::AlignCenter, false);
 		AddSText(0, 12, _("is not available"), UiFlags::ColorSilver | UiFlags::AlignCenter, false);
 		AddSText(0, 14, _("in the shareware"), UiFlags::ColorSilver | UiFlags::AlignCenter, false);
 		AddSText(0, 16, _("version"), UiFlags::ColorSilver | UiFlags::AlignCenter, false);

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -47,7 +47,7 @@ enum talk_id : uint8_t {
 struct STextStruct {
 	int _sx;
 	int _syoff;
-	char _sstr[128];
+	StringVariant _sstr;
 	UiFlags flags;
 	int _sline;
 	bool _ssel;
@@ -98,7 +98,7 @@ void AddStoreHoldRepair(ItemStruct *itm, int8_t i);
 void InitStores();
 void SetupTownStores();
 void FreeStoreMem();
-void PrintSString(const Surface &out, int margin, int line, const char *text, UiFlags flags, int price = 0);
+void PrintSString(const Surface &out, int margin, int line, string_view text, UiFlags flags, int price = 0);
 void DrawSLine(const Surface &out, int y);
 void DrawSTextHelp();
 void ClearSText(int s, int e);

--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -317,7 +317,7 @@ bool ForceTownTrig()
 {
 	for (int i = 0; TownDownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == TownDownList[i]) {
-			strcpy(infostr, _("Down to dungeon"));
+			infostr = _("Down to dungeon");
 			cursmx = 25;
 			cursmy = 29;
 			return true;
@@ -327,7 +327,7 @@ bool ForceTownTrig()
 	if (townwarps[0]) {
 		for (int i = 0; TownWarp1List[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == TownWarp1List[i]) {
-				strcpy(infostr, _("Down to catacombs"));
+				infostr = _("Down to catacombs");
 				cursmx = 49;
 				cursmy = 21;
 				return true;
@@ -338,7 +338,7 @@ bool ForceTownTrig()
 	if (townwarps[1]) {
 		for (int i = 1199; i <= 1220; i++) {
 			if (dPiece[cursmx][cursmy] == i) {
-				strcpy(infostr, _("Down to caves"));
+				infostr = _("Down to caves");
 				cursmx = 17;
 				cursmy = 69;
 				return true;
@@ -349,7 +349,7 @@ bool ForceTownTrig()
 	if (townwarps[2]) {
 		for (int i = 1240; i <= 1255; i++) {
 			if (dPiece[cursmx][cursmy] == i) {
-				strcpy(infostr, _("Down to hell"));
+				infostr = _("Down to hell");
 				cursmx = 41;
 				cursmy = 80;
 				return true;
@@ -360,7 +360,7 @@ bool ForceTownTrig()
 	if (gbIsHellfire) {
 		for (int i = 0; TownCryptList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == TownCryptList[i]) {
-				strcpy(infostr, _("Down to Crypt"));
+				infostr = _("Down to Crypt");
 				cursmx = 36;
 				cursmy = 24;
 				return true;
@@ -368,7 +368,7 @@ bool ForceTownTrig()
 		}
 		for (int i = 0; TownHiveList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == TownHiveList[i]) {
-				strcpy(infostr, _("Down to Hive"));
+				infostr = _("Down to Hive");
 				cursmx = 80;
 				cursmy = 62;
 				return true;
@@ -385,9 +385,9 @@ bool ForceL1Trig()
 		for (int i = 0; L1UpList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L1UpList[i]) {
 				if (currlevel > 1)
-					strcpy(infostr, fmt::format(_("Up to level {:d}"), currlevel - 1).c_str());
+					infostr = fmt::format(_("Up to level {:d}"), currlevel - 1);
 				else
-					strcpy(infostr, _("Up to town"));
+					infostr = _("Up to town");
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 						cursmx = trigs[j].position.x;
@@ -399,7 +399,7 @@ bool ForceL1Trig()
 		}
 		for (int i = 0; L1DownList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L1DownList[i]) {
-				strcpy(infostr, fmt::format(_("Down to level {:d}"), currlevel + 1).c_str());
+				infostr = fmt::format(_("Down to level {:d}"), currlevel + 1);
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -412,7 +412,7 @@ bool ForceL1Trig()
 	} else {
 		for (int i = 0; L5UpList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L5UpList[i]) {
-				strcpy(infostr, fmt::format(_("Up to Crypt level {:d}"), currlevel - 21).c_str());
+				infostr = fmt::format(_("Up to Crypt level {:d}"), currlevel - 21);
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 						cursmx = trigs[j].position.x;
@@ -423,12 +423,12 @@ bool ForceL1Trig()
 			}
 		}
 		if (dPiece[cursmx][cursmy] == 317) {
-			strcpy(infostr, _("Cornerstone of the World"));
+			infostr = _("Cornerstone of the World");
 			return true;
 		}
 		for (int i = 0; L5DownList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L5DownList[i]) {
-				strcpy(infostr, fmt::format(_("Down to Crypt level {:d}"), currlevel - 19).c_str());
+				infostr = fmt::format(_("Down to Crypt level {:d}"), currlevel - 19);
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -446,7 +446,7 @@ bool ForceL1Trig()
 							int dx = abs(trigs[j].position.x - cursmx);
 							int dy = abs(trigs[j].position.y - cursmy);
 							if (dx < 4 && dy < 4) {
-								strcpy(infostr, _("Up to town"));
+								infostr = _("Up to town");
 								cursmx = trigs[j].position.x;
 								cursmy = trigs[j].position.y;
 								return true;
@@ -470,7 +470,7 @@ bool ForceL2Trig()
 					int dx = abs(trigs[j].position.x - cursmx);
 					int dy = abs(trigs[j].position.y - cursmy);
 					if (dx < 4 && dy < 4) {
-						strcpy(infostr, fmt::format(_("Up to level {:d}"), currlevel - 1).c_str());
+						infostr = fmt::format(_("Up to level {:d}"), currlevel - 1);
 						cursmx = trigs[j].position.x;
 						cursmy = trigs[j].position.y;
 						return true;
@@ -482,7 +482,7 @@ bool ForceL2Trig()
 
 	for (int i = 0; L2DownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L2DownList[i]) {
-			strcpy(infostr, fmt::format(_("Down to level {:d}"), currlevel + 1).c_str());
+			infostr = fmt::format(_("Down to level {:d}"), currlevel + 1);
 			for (int j = 0; j < numtrigs; j++) {
 				if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 					cursmx = trigs[j].position.x;
@@ -501,7 +501,7 @@ bool ForceL2Trig()
 						int dx = abs(trigs[j].position.x - cursmx);
 						int dy = abs(trigs[j].position.y - cursmy);
 						if (dx < 4 && dy < 4) {
-							strcpy(infostr, _("Up to town"));
+							infostr = _("Up to town");
 							cursmx = trigs[j].position.x;
 							cursmy = trigs[j].position.y;
 							return true;
@@ -520,7 +520,7 @@ bool ForceL3Trig()
 	if (currlevel < 17) {
 		for (int i = 0; L3UpList[i] != -1; ++i) {
 			if (dPiece[cursmx][cursmy] == L3UpList[i]) {
-				strcpy(infostr, fmt::format(_("Up to level {:d}"), currlevel - 1).c_str());
+				infostr = fmt::format(_("Up to level {:d}"), currlevel - 1);
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 						cursmx = trigs[j].position.x;
@@ -534,7 +534,7 @@ bool ForceL3Trig()
 			if (dPiece[cursmx][cursmy] == L3DownList[i]
 			    || dPiece[cursmx + 1][cursmy] == L3DownList[i]
 			    || dPiece[cursmx + 2][cursmy] == L3DownList[i]) {
-				strcpy(infostr, fmt::format(_("Down to level {:d}"), currlevel + 1).c_str());
+				infostr = fmt::format(_("Down to level {:d}"), currlevel + 1);
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -547,7 +547,7 @@ bool ForceL3Trig()
 	} else {
 		for (int i = 0; L6UpList[i] != -1; ++i) {
 			if (dPiece[cursmx][cursmy] == L6UpList[i]) {
-				strcpy(infostr, fmt::format(_("Up to Nest level {:d}"), currlevel - 17).c_str());
+				infostr = fmt::format(_("Up to Nest level {:d}"), currlevel - 17);
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 						cursmx = trigs[j].position.x;
@@ -561,7 +561,7 @@ bool ForceL3Trig()
 			if (dPiece[cursmx][cursmy] == L6DownList[i]
 			    || dPiece[cursmx + 1][cursmy] == L6DownList[i]
 			    || dPiece[cursmx + 2][cursmy] == L6DownList[i]) {
-				strcpy(infostr, fmt::format(_("Down to level {:d}"), currlevel - 15).c_str());
+				infostr = fmt::format(_("Down to level {:d}"), currlevel - 15);
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -581,7 +581,7 @@ bool ForceL3Trig()
 						int dx = abs(trigs[j].position.x - cursmx);
 						int dy = abs(trigs[j].position.y - cursmy);
 						if (dx < 4 && dy < 4) {
-							strcpy(infostr, _("Up to town"));
+							infostr = _("Up to town");
 							cursmx = trigs[j].position.x;
 							cursmy = trigs[j].position.y;
 							return true;
@@ -599,7 +599,7 @@ bool ForceL3Trig()
 						int dx = abs(trigs[j].position.x - cursmx);
 						int dy = abs(trigs[j].position.y - cursmy);
 						if (dx < 4 && dy < 4) {
-							strcpy(infostr, _("Up to town"));
+							infostr = _("Up to town");
 							cursmx = trigs[j].position.x;
 							cursmy = trigs[j].position.y;
 							return true;
@@ -617,7 +617,7 @@ bool ForceL4Trig()
 {
 	for (int i = 0; L4UpList[i] != -1; ++i) {
 		if (dPiece[cursmx][cursmy] == L4UpList[i]) {
-			strcpy(infostr, fmt::format(_("Up to level {:d}"), currlevel - 1).c_str());
+			infostr = fmt::format(_("Up to level {:d}"), currlevel - 1);
 			for (int j = 0; j < numtrigs; j++) {
 				if (trigs[j]._tmsg == WM_DIABPREVLVL) {
 					cursmx = trigs[j].position.x;
@@ -630,7 +630,7 @@ bool ForceL4Trig()
 
 	for (int i = 0; L4DownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L4DownList[i]) {
-			strcpy(infostr, fmt::format(_("Down to level {:d}"), currlevel + 1).c_str());
+			infostr = fmt::format(_("Down to level {:d}"), currlevel + 1);
 			for (int j = 0; j < numtrigs; j++) {
 				if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 					cursmx = trigs[j].position.x;
@@ -649,7 +649,7 @@ bool ForceL4Trig()
 						int dx = abs(trigs[j].position.x - cursmx);
 						int dy = abs(trigs[j].position.y - cursmy);
 						if (dx < 4 && dy < 4) {
-							strcpy(infostr, _("Up to town"));
+							infostr = _("Up to town");
 							cursmx = trigs[j].position.x;
 							cursmy = trigs[j].position.y;
 							return true;
@@ -663,7 +663,7 @@ bool ForceL4Trig()
 	if (currlevel == 15) {
 		for (int i = 0; L4PentaList[i] != -1; i++) {
 			if (dPiece[cursmx][cursmy] == L4PentaList[i]) {
-				strcpy(infostr, _("Down to Diablo"));
+				infostr = _("Down to Diablo");
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABNEXTLVL) {
 						cursmx = trigs[j].position.x;
@@ -697,7 +697,7 @@ bool ForceSKingTrig()
 {
 	for (int i = 0; L1UpList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L1UpList[i]) {
-			strcpy(infostr, fmt::format(_("Back to Level {:d}"), Quests[Q_SKELKING]._qlevel).c_str());
+			infostr = fmt::format(_("Back to Level {:d}"), Quests[Q_SKELKING]._qlevel);
 			cursmx = trigs[0].position.x;
 			cursmy = trigs[0].position.y;
 
@@ -712,7 +712,7 @@ bool ForceSChambTrig()
 {
 	for (int i = 0; L2DownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L2DownList[i]) {
-			strcpy(infostr, fmt::format(_("Back to Level {:d}"), Quests[Q_SCHAMB]._qlevel).c_str());
+			infostr = fmt::format(_("Back to Level {:d}"), Quests[Q_SCHAMB]._qlevel);
 			cursmx = trigs[0].position.x;
 			cursmy = trigs[0].position.y;
 
@@ -727,7 +727,7 @@ bool ForcePWaterTrig()
 {
 	for (int i = 0; L3DownList[i] != -1; i++) {
 		if (dPiece[cursmx][cursmy] == L3DownList[i]) {
-			strcpy(infostr, fmt::format(_("Back to Level {:d}"), Quests[Q_PWATER]._qlevel).c_str());
+			infostr = fmt::format(_("Back to Level {:d}"), Quests[Q_PWATER]._qlevel);
 			cursmx = trigs[0].position.x;
 			cursmy = trigs[0].position.y;
 

--- a/Source/utils/string_variant.hpp
+++ b/Source/utils/string_variant.hpp
@@ -30,7 +30,18 @@ public:
 	{
 	}
 
+	explicit StringVariant(char *cstr)
+	    : str(cstr)
+	{
+	}
+
 	StringVariant &operator =(const char *cstr)
+	{
+		*this = StringVariant(cstr);
+		return *this;
+	}
+
+	StringVariant &operator =(char *cstr)
 	{
 		*this = StringVariant(cstr);
 		return *this;

--- a/Source/utils/string_variant.hpp
+++ b/Source/utils/string_variant.hpp
@@ -53,7 +53,7 @@ public:
 		return *this;
 	}
 
-	StringVariant &operator =(const std::string &str)
+	StringVariant &operator =(std::string &str)
 	{
 		*this = StringVariant(std::move(str));
 		return *this;

--- a/Source/utils/string_variant.hpp
+++ b/Source/utils/string_variant.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <string>
+#include "utils/stdcompat/string_view.hpp"
+
+namespace devilution {
+
+class StringVariant
+{
+	std::string str;
+	string_view view;
+
+public:
+	StringVariant()
+	{
+	}
+
+	explicit StringVariant(string_view view)
+	    : view(view)
+	{
+	}
+
+	explicit StringVariant(std::string str)
+	    : str(std::move(str))
+	{
+	}
+
+	explicit StringVariant(const char *cstr)
+	    : view(cstr)
+	{
+	}
+
+	StringVariant &operator =(const char *cstr)
+	{
+		*this = StringVariant(cstr);
+		return *this;
+	}
+
+	StringVariant &operator =(const string_view &view)
+	{
+		*this = StringVariant(view);
+		return *this;
+	}
+
+	StringVariant &operator =(const std::string &str)
+	{
+		*this = StringVariant(std::move(str));
+		return *this;
+	}
+
+	size_t length() const
+	{
+		if (str.length() > 0)
+			return str.length();
+		return view.length();
+	}
+
+	operator string_view() const
+	{
+		if (str.length() > 0)
+			return str;
+		return view;
+	}
+};
+
+} // namespace devilution

--- a/Source/utils/string_variant.hpp
+++ b/Source/utils/string_variant.hpp
@@ -5,6 +5,12 @@
 
 namespace devilution {
 
+/**
+ * @brief Offers an interface similar to variant<string, string_view>
+ * Assignments from char * work like assignments from string, and those from const char *, like assignments from string_view.
+ * The intention is to use string and string_view almost exclusively in the codebase.
+ * The constructors and assignment operators dealing with (const) char * will go away once a critical mass is reached.
+ */
 class StringVariant
 {
 	std::string str;


### PR DESCRIPTION
This PR introduces StringVariant (stupid name, feel free to suggest a different one). It is a wrapper around string_view, with an optional backing string.

Various stuff, like messages that appear in the panel at the bottom of the screen, can now either be either copied or passed as a string_view, as appropriate.