### PR TITLE
Search Spell Improvements

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -13,6 +13,7 @@
 #include "inv.h"
 #include "monster.h"
 #include "palette.h"
+#include "missiles.h"
 #include "player.h"
 #include "setmaps.h"
 #include "utils/language.h"
@@ -272,11 +273,14 @@ void SearchAutomapItem(const Surface &out, const Displacement &myPlayerOffset)
 			tile.y++;
 	}
 
-	const int startX = clamp(tile.x - 8, 0, MAXDUNX);
-	const int startY = clamp(tile.y - 8, 0, MAXDUNY);
+	int spellLevel = GetSpellLevel(MyPlayerId, SPL_SEARCH);
+	int levelRangeExtension = spellLevel / 3;
 
-	const int endX = clamp(tile.x + 8, 0, MAXDUNX);
-	const int endY = clamp(tile.y + 8, 0, MAXDUNY);
+	const int startX = clamp(tile.x - 8 - levelRangeExtension, 0, MAXDUNX);
+	const int startY = clamp(tile.y - 8 - levelRangeExtension, 0, MAXDUNY);
+
+	const int endX = clamp(tile.x + 8 + levelRangeExtension, 0, MAXDUNX);
+	const int endY = clamp(tile.y + 8 + levelRangeExtension, 0, MAXDUNY);
 
 	for (int i = startX; i < endX; i++) {
 		for (int j = startY; j < endY; j++) {

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -33,6 +33,8 @@ enum MapColors : uint8_t {
 	MapColorsDim = (PAL16_YELLOW + 8),
 	/** color for items on automap */
 	MapColorsItem = (PAL8_BLUE + 1),
+	/** color for objects on automap */
+	MapColorsObject = (PAL8_BLUE + 5), // same as used in DrawObject
 };
 
 struct AutomapTile {
@@ -278,7 +280,23 @@ void SearchAutomapItem(const Surface &out, const Displacement &myPlayerOffset)
 
 	for (int i = startX; i < endX; i++) {
 		for (int j = startY; j < endY; j++) {
-			if (dItem[i][j] == 0)
+			bool  markCell = false;
+			uint8_t cellCollor;
+			if (dItem[i][j] != 0) {
+				markCell = true;
+				cellCollor = MapColorsItem;
+			}
+
+			if (dObject[i][j] != 0)
+			{
+				int o = dObject[i][j] > 0 ? dObject[i][j] - 1 : -dObject[i][j] + 1; // why? (copied from other place
+				if (MarkObject4Search(o)) {
+					markCell = true;
+					cellCollor = MapColorsObject;
+				}
+			}
+
+			if (!markCell)
 				continue;
 
 			int px = i - 2 * AutomapOffset.deltaX - ViewX;
@@ -296,7 +314,7 @@ void SearchAutomapItem(const Surface &out, const Displacement &myPlayerOffset)
 					screen.x += 160;
 			}
 			screen.y -= AmLine8;
-			DrawDiamond(out, screen, MapColorsItem);
+			DrawDiamond(out, screen, cellCollor);
 		}
 	}
 }

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -284,15 +284,14 @@ void SearchAutomapItem(const Surface &out, const Displacement &myPlayerOffset)
 
 	for (int i = startX; i < endX; i++) {
 		for (int j = startY; j < endY; j++) {
-			bool  markCell = false;
+			bool markCell = false;
 			uint8_t cellCollor;
 			if (dItem[i][j] != 0) {
 				markCell = true;
 				cellCollor = MapColorsItem;
 			}
 
-			if (dObject[i][j] != 0)
-			{
+			if (dObject[i][j] != 0) {
 				int o = dObject[i][j] > 0 ? dObject[i][j] - 1 : -dObject[i][j] + 1; // why? (copied from other place
 				if (MarkObject4Search(o)) {
 					markCell = true;

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -19,6 +19,7 @@
 #include "utils/language.h"
 #include "utils/stdcompat/algorithm.hpp"
 #include "utils/ui_fwd.h"
+#include "options.h"
 
 namespace devilution {
 
@@ -272,9 +273,11 @@ void SearchAutomapItem(const Surface &out, const Displacement &myPlayerOffset)
 		else
 			tile.y++;
 	}
-
-	int spellLevel = GetSpellLevel(MyPlayerId, SPL_SEARCH);
-	int levelRangeExtension = spellLevel / 3;
+	int levelRangeExtension = 0;
+	if (sgOptions.Gameplay.bImprovedSearchSpell) {
+		int spellLevel = GetSpellLevel(MyPlayerId, SPL_SEARCH);
+		levelRangeExtension = spellLevel / 3;
+	}
 
 	const int startX = clamp(tile.x - 8 - levelRangeExtension, 0, MAXDUNX);
 	const int startY = clamp(tile.y - 8 - levelRangeExtension, 0, MAXDUNY);

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -291,9 +291,8 @@ void SearchAutomapItem(const Surface &out, const Displacement &myPlayerOffset)
 				cellCollor = MapColorsItem;
 			}
 
-			if (dObject[i][j] != 0) {
-				int o = dObject[i][j] > 0 ? dObject[i][j] - 1 : -dObject[i][j] + 1; // why? (copied from other place
-				if (MarkObject4Search(o)) {
+			if (dObject[i][j] > 0) {
+				if (MarkObject4Search(dObject[i][j] - 1)) {
 					markCell = true;
 					cellCollor = MapColorsObject;
 				}

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2880,7 +2880,7 @@ bool OperateShrineThaumaturgic(int pnum)
 	for (int j = 0; j < ActiveObjectCount; j++) {
 		int v1 = ActiveObjects[j];
 		assert(v1 >= 0 && v1 < MAXOBJECTS);
-		if (IsAnyOf(Objects[v1]._otype, OBJ_CHEST1, OBJ_CHEST2, OBJ_CHEST3, OBJ_TCHEST1, OBJ_TCHEST2, OBJ_TCHEST3) && Objects[v1]._oSelFlag == 0) {
+		if (Objects[v1].IsChest() && Objects[v1]._oSelFlag == 0) {
 			Objects[v1]._oRndSeed = AdvanceRndSeed();
 			Objects[v1]._oSelFlag = 1;
 			Objects[v1]._oAnimFrame -= 2;

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -137,8 +137,8 @@ struct ObjectStruct {
 	 */
 	bool IsChest() const
 	{
-		return IsAnyOf(_otype, _object_id::OBJ_CHEST1,  _object_id::OBJ_CHEST2,  _object_id::OBJ_CHEST3,
-		                       _object_id::OBJ_TCHEST1, _object_id::OBJ_TCHEST2, _object_id::OBJ_TCHEST3, _object_id::OBJ_SIGNCHEST);
+		return IsAnyOf(_otype, _object_id::OBJ_CHEST1, _object_id::OBJ_CHEST2, _object_id::OBJ_CHEST3,
+		    _object_id::OBJ_TCHEST1, _object_id::OBJ_TCHEST2, _object_id::OBJ_TCHEST3, _object_id::OBJ_SIGNCHEST);
 	}
 
 	/**
@@ -148,19 +148,16 @@ struct ObjectStruct {
 	bool IsBookContainer() const
 	{
 		return IsAnyOf(_otype, _object_id::OBJ_BOOKSHELF, _object_id::OBJ_BOOKCASEL, _object_id::OBJ_BOOKCASER,
-				               _object_id::OBJ_BOOKSTAND, _object_id::OBJ_SKELBOOK);
+		    _object_id::OBJ_BOOKSTAND, _object_id::OBJ_SKELBOOK);
 	}
 
 	bool isAnyContainer() const
 	{
-		return     IsChest()
-				|| IsBookContainer()
-				|| IsAnyOf(_otype, _object_id::OBJ_ARMORSTAND, _object_id::OBJ_WARARMOR, _object_id::OBJ_WARWEAP, _object_id::OBJ_WEAPONRACK,
-				                  _object_id::OBJ_SARC, _object_id::OBJ_BARREL, _object_id::OBJ_BARRELEX,
-				                  _object_id::OBJ_DECAP
-				   );
-				                  
-
+		return IsChest()
+		    || IsBookContainer()
+		    || IsAnyOf(_otype, _object_id::OBJ_ARMORSTAND, _object_id::OBJ_WARARMOR, _object_id::OBJ_WARWEAP, _object_id::OBJ_WEAPONRACK,
+		        _object_id::OBJ_SARC, _object_id::OBJ_BARREL, _object_id::OBJ_BARRELEX,
+		        _object_id::OBJ_DECAP);
 	}
 };
 

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -130,6 +130,38 @@ struct ObjectStruct {
 	{
 		return IsAnyOf(_otype, _object_id::OBJ_L1LDOOR, _object_id::OBJ_L1RDOOR, _object_id::OBJ_L2LDOOR, _object_id::OBJ_L2RDOOR, _object_id::OBJ_L3LDOOR, _object_id::OBJ_L3RDOOR);
 	}
+
+	/**
+	 * @brief Check if this object is a chest
+	 * @return True if the object is one of the chest types (see _object_id)
+	 */
+	bool IsChest() const
+	{
+		return IsAnyOf(_otype, _object_id::OBJ_CHEST1,  _object_id::OBJ_CHEST2,  _object_id::OBJ_CHEST3,
+		                       _object_id::OBJ_TCHEST1, _object_id::OBJ_TCHEST2, _object_id::OBJ_TCHEST3, _object_id::OBJ_SIGNCHEST);
+	}
+
+	/**
+	 * @brief Check if this object is a book container (like book case or book stands (not the quest or story things))
+	 * @return True if the object is one of the book containing boject types (see _object_id)
+	 */
+	bool IsBookContainer() const
+	{
+		return IsAnyOf(_otype, _object_id::OBJ_BOOKSHELF, _object_id::OBJ_BOOKCASEL, _object_id::OBJ_BOOKCASER,
+				               _object_id::OBJ_BOOKSTAND, _object_id::OBJ_SKELBOOK);
+	}
+
+	bool isAnyContainer() const
+	{
+		return     IsChest()
+				|| IsBookContainer()
+				|| IsAnyOf(_otype, _object_id::OBJ_ARMORSTAND, _object_id::OBJ_WARARMOR, _object_id::OBJ_WARWEAP, _object_id::OBJ_WEAPONRACK,
+				                  _object_id::OBJ_SARC, _object_id::OBJ_BARREL, _object_id::OBJ_BARRELEX,
+				                  _object_id::OBJ_DECAP
+				   );
+				                  
+
+	}
 };
 
 extern ObjectStruct Objects[MAXOBJECTS];

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -272,6 +272,7 @@ void LoadOptions()
 	sgOptions.Gameplay.bRandomizeQuests = GetIniBool("Game", "Randomize Quests", true);
 	sgOptions.Gameplay.bShowMonsterType = GetIniBool("Game", "Show Monster Type", false);
 	sgOptions.Gameplay.bDisableCripplingShrines = GetIniBool("Game", "Disable Crippling Shrines", false);
+	sgOptions.Gameplay.bImprovedSearchSpell = GetIniBool("Game", "Improved Search Spell", false);
 
 	GetIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress, sizeof(sgOptions.Network.szBindAddress), "0.0.0.0");
 	sgOptions.Network.nPort = GetIniInt("Network", "Port", 6112);
@@ -420,6 +421,7 @@ void SaveOptions()
 	SetIniValue("Game", "Randomize Quests", sgOptions.Gameplay.bRandomizeQuests);
 	SetIniValue("Game", "Show Monster Type", sgOptions.Gameplay.bShowMonsterType);
 	SetIniValue("Game", "Disable Crippling Shrines", sgOptions.Gameplay.bDisableCripplingShrines);
+	SetIniValue("Game", "Improved Search Spell", sgOptions.Gameplay.bImprovedSearchSpell);
 
 	SetIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress);
 	SetIniValue("Network", "Port", sgOptions.Network.nPort);

--- a/Source/options.h
+++ b/Source/options.h
@@ -118,6 +118,8 @@ struct GameplayOptions {
 	bool bShowMonsterType;
 	/** @brief Locally disable clicking on shrines which permanently cripple character. */
 	bool bDisableCripplingShrines;
+	/** @brief Improves the seach spell with level dependend range increase and object (container) highlighting */
+	bool bImprovedSearchSpell;
 };
 
 struct ControllerOptions {

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1348,8 +1348,8 @@ void DrawMain(int dwHgt, bool drawDesc, bool drawHp, bool drawMana, bool drawSba
 
 bool MarkObject4Search(int i)
 {
-	bool isCont   = Objects[i].isAnyContainer();
-	bool isEmpty  = Objects[i]._oSelFlag == 0;
+	bool isCont = Objects[i].isAnyContainer();
+	bool isEmpty = Objects[i]._oSelFlag == 0;
 	return AutoMapShowItems && isCont && !isEmpty;
 }
 

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1350,7 +1350,7 @@ bool MarkObject4Search(int i)
 {
 	bool isCont = Objects[i].isAnyContainer();
 	bool isEmpty = Objects[i]._oSelFlag == 0;
-	return AutoMapShowItems && isCont && !isEmpty;
+	return sgOptions.Gameplay.bImprovedSearchSpell && AutoMapShowItems && isCont && !isEmpty;
 }
 
 Displacement GetOffsetForWalking(const AnimationInfo &animationInfo, const Direction dir, bool cameraMode /*= false*/)

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -597,7 +597,7 @@ void DrawObject(const Surface &out, int x, int y, int ox, int oy, bool pre)
 	}
 
 	CelSprite cel { Objects[bv]._oAnimData, Objects[bv]._oAnimWidth };
-	if (bv == pcursobj)
+	if (bv == pcursobj || MarkObject4Search(bv))
 		CelBlitOutlineTo(out, 194, objectPosition, cel, Objects[bv]._oAnimFrame);
 	if (Objects[bv]._oLight) {
 		CelClippedDrawLightTo(out, objectPosition, cel, Objects[bv]._oAnimFrame);
@@ -1345,6 +1345,13 @@ void DrawMain(int dwHgt, bool drawDesc, bool drawHp, bool drawMana, bool drawSba
 }
 
 } // namespace
+
+bool MarkObject4Search(int i)
+{
+	bool isCont   = Objects[i].isAnyContainer();
+	bool isEmpty  = Objects[i]._oSelFlag == 0;
+	return AutoMapShowItems && isCont && !isEmpty;
+}
 
 Displacement GetOffsetForWalking(const AnimationInfo &animationInfo, const Direction dir, bool cameraMode /*= false*/)
 {

--- a/Source/scrollrt.h
+++ b/Source/scrollrt.h
@@ -51,6 +51,7 @@ int RowsCoveredByPanel();
 void CalcTileOffset(int *offsetX, int *offsetY);
 void TilesInView(int *columns, int *rows);
 void CalcViewportGeometry();
+bool MarkObject4Search(int i);
 
 void ClearScreenBuffer();
 #ifdef _DEBUG


### PR DESCRIPTION
Some Improvement of Devilution reduces the usefullness of the Search spell:
 - objects visibility due to increased screen size vs the automap range of the spell
 - Diablo 2 style item display by CTRL-key vs item highlighting 

I tried to add some features to make the spell more attractive to be used:

Also unopened container objects are highlighted
Also unopened container items are shown own map as darker blue tile marker.
The automap display range is increased by one every 3 spell levels.

![screen00](https://user-images.githubusercontent.com/1601159/128598493-c217326a-218c-4f71-a675-347240c7844b.png)
