### PR TITLE
Fix floating Dialogs (Walking while in store)

### DIFF
--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -10,6 +10,7 @@
 #include "cursor.h"
 #include "engine/point.hpp"
 #include "player.h"
+#include "stores.h"
 
 namespace devilution {
 
@@ -38,6 +39,9 @@ void RepeatMouseAction()
 		return;
 
 	if (sgbMouseDown == CLICK_NONE)
+		return;
+
+	if (stextflag != STORE_NONE)
 		return;
 
 	if (LastMouseButtonAction == MouseActionType::None)


### PR DESCRIPTION
`RepeatMouseAction` didn't regard `stextflag` (Store Talk Flag) like [LeftMouseDown](https://github.com/diasurgical/devilutionX/blob/cfa3c8fa4e08e19a1976fd64cbc1472762e9d150/Source/diablo.cpp#L321) do.
Contributes to #2475