### PR TITLE
Fix walking command gets ignored

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -235,6 +235,7 @@ void LeftMouseCmd(bool bShift)
 			NetSendCmdLocParam1(true, CMD_TALKXY, { cursmx, cursmy }, pcursmonst);
 		if (pcursitem == -1 && pcursmonst == -1 && pcursplr == -1) {
 			LastMouseButtonAction = MouseActionType::Walk;
+			NetSendCmdLoc(MyPlayerId, true, CMD_WALKXY, { cursmx, cursmy });
 		}
 		return;
 	}
@@ -284,6 +285,7 @@ void LeftMouseCmd(bool bShift)
 	}
 	if (!bShift && pcursitem == -1 && pcursobj == -1 && pcursmonst == -1 && pcursplr == -1) {
 		LastMouseButtonAction = MouseActionType::Walk;
+		NetSendCmdLoc(MyPlayerId, true, CMD_WALKXY, { cursmx, cursmy });
 	}
 }
 


### PR DESCRIPTION
Every mouse interaction in [`LeftMouseCmd`](https://github.com/diasurgical/devilutionX/blob/cfa3c8fa4e08e19a1976fd64cbc1472762e9d150/Source/diablo.cpp#L225) calls `NetSendCmdXYZ` expect walking.
In most cases this results in no problems and is not necessary cause `RepeatWalk` will send the message.

But if

- the player does some action (walking, attacking ,.. )
- and you click only once
- and release the button fast enough

then `RepeatWalk` will see [`CanChangeAction`](https://github.com/diasurgical/devilutionX/blob/cfa3c8fa4e08e19a1976fd64cbc1472762e9d150/Source/track.cpp#L49) = false and does nothing.
And cause you released the button fast enough, `RepeatWalk` will never be called with `CanChangeAction` = false.
This results in ignored input (user click).

This PR simply handles Walking Command similar to other interactions (see above). 

Contributes to #2475

Note: This restores the behavior that is present in vanilla and DevilutionX 1.21