### PR TITLE
Modify the calculation of panel position

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -803,34 +803,44 @@ void CalculatePanelAreas(void)
 	LeftPanel = { { 0, 0 }, { SPANEL_WIDTH, SPANEL_HEIGHT } };
 	RightPanel = { { 0, 0 }, { SPANEL_WIDTH, SPANEL_HEIGHT } };
 
-	switch (sgOptions.Gameplay.nSPanelHAlign) {
-	case 0: // left
-		LeftPanel.position.x = 0;
-		break;
-	case 1: // center
-		LeftPanel.position.x = (gnScreenWidth / 2 - LeftPanel.size.width) / 2;
-		break;
-	case 2: // right
-		LeftPanel.position.x = gnScreenWidth / 2 - LeftPanel.size.width;
-		break;
-	default:
-		LeftPanel.position.x = 0;
-		break;
-	}
+	if (sgOptions.Gameplay.bSPanelCustomPlacement) {
+		switch (sgOptions.Gameplay.nSPanelHAlign) {
+		case 0: // left
+			LeftPanel.position.x = 0;
+			break;
+		case 1: // center
+			LeftPanel.position.x = (gnScreenWidth / 2 - LeftPanel.size.width) / 2;
+			break;
+		case 2: // right
+			LeftPanel.position.x = gnScreenWidth / 2 - LeftPanel.size.width;
+			break;
+		default:
+			LeftPanel.position.x = 0;
+			break;
+		}
 
-	switch (sgOptions.Gameplay.nSPanelVAlign) {
-	case 0: // top
-		LeftPanel.position.y = 0;
-		break;
-	case 1: // center
+		switch (sgOptions.Gameplay.nSPanelVAlign) {
+		case 0: // top
+			LeftPanel.position.y = 0;
+			break;
+		case 1: // center
+			LeftPanel.position.y = (gnScreenHeight - LeftPanel.size.height - PANEL_HEIGHT) / 2;
+			break;
+		case 2: // bottom
+			LeftPanel.position.y = gnScreenHeight - LeftPanel.size.height - PANEL_HEIGHT;
+			break;
+		default:
+			LeftPanel.position.y = (gnScreenHeight - LeftPanel.size.height - PANEL_HEIGHT) / 2;
+			break;
+		}
+	} else {
+		if (gnScreenWidth - 2 * SPANEL_WIDTH > PANEL_WIDTH) {
+			LeftPanel.position.x = (gnScreenWidth - 2 * SPANEL_WIDTH - PANEL_WIDTH) / 2;
+		} else {
+			LeftPanel.position.x = 0;
+		}
+
 		LeftPanel.position.y = (gnScreenHeight - LeftPanel.size.height - PANEL_HEIGHT) / 2;
-		break;
-	case 2: // bottom
-		LeftPanel.position.y = gnScreenHeight - LeftPanel.size.height - PANEL_HEIGHT;
-		break;
-	default:
-		LeftPanel.position.y = 0;
-		break;
 	}
 
 	RightPanel.position.x = gnScreenWidth - RightPanel.size.width - LeftPanel.position.x;

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -264,6 +264,7 @@ void LoadOptions()
 	sgOptions.Gameplay.bRandomizeQuests = GetIniBool("Game", "Randomize Quests", true);
 	sgOptions.Gameplay.bShowMonsterType = GetIniBool("Game", "Show Monster Type", false);
 	sgOptions.Gameplay.bDisableCripplingShrines = GetIniBool("Game", "Disable Crippling Shrines", false);
+	sgOptions.Gameplay.bSPanelCustomPlacement = GetIniInt("Game", "Side Panel Custom Placement", 0);
 	sgOptions.Gameplay.nSPanelHAlign = GetIniInt("Game", "Side Panel Horizontal Alignment", 0);
 	sgOptions.Gameplay.nSPanelVAlign = GetIniInt("Game", "Side Panel Vertical Alignment", 1);
 
@@ -375,6 +376,7 @@ void SaveOptions()
 	SetIniValue("Game", "Randomize Quests", sgOptions.Gameplay.bRandomizeQuests);
 	SetIniValue("Game", "Show Monster Type", sgOptions.Gameplay.bShowMonsterType);
 	SetIniValue("Game", "Disable Crippling Shrines", sgOptions.Gameplay.bDisableCripplingShrines);
+	SetIniValue("Game", "Side Panel Custom Placement", sgOptions.Gameplay.bSPanelCustomPlacement);
 	SetIniValue("Game", "Side Panel Horizontal Alignment", sgOptions.Gameplay.nSPanelHAlign);
 	SetIniValue("Game", "Side Panel Vertical Alignment", sgOptions.Gameplay.nSPanelVAlign);
 

--- a/Source/options.h
+++ b/Source/options.h
@@ -118,9 +118,11 @@ struct GameplayOptions {
 	bool bShowMonsterType;
 	/** @brief Locally disable clicking on shrines which permanently cripple character. */
 	bool bDisableCripplingShrines;
-	/** @brief Side panel horizontal alignment (left/center/right) */
+	/** @brief Side panel auto/custom placement, by default, left/center combination is used, but panel distance is limited */
+	bool bSPanelCustomPlacement;
+	/** @brief Side panel horizontal alignment (left/center/right), will take effect if custom placement enabled */
 	int nSPanelHAlign;
-	/** @brief Side panel vertical alignment (top/center/bottom) */
+	/** @brief Side panel vertical alignment (top/center/bottom), will take effect if custom placement enabled */
 	int nSPanelVAlign;
 };
 


### PR DESCRIPTION
By default, the auto mode, left/center combination is used, but panel distance is limited.

If the screen width is less than 1280, the panel position will be the same as left/center combination. (The maximum panel distance is 640, which is equal to the bottom panel width)

[853x480]
![853x480](https://user-images.githubusercontent.com/88471771/128610452-2659095d-1522-4827-bfbd-f2264d5167fa.png)

[800x600]
![800x600](https://user-images.githubusercontent.com/88471771/128610457-01956419-1537-4f03-bad3-257a1f9d167d.png)

[1280x720]
![1280x720](https://user-images.githubusercontent.com/88471771/128610461-9ecbe5ac-817d-4bb4-97dc-baad479d1100.png)

[1600x900]
![1600x900](https://user-images.githubusercontent.com/88471771/128610464-81c29573-ea58-4cba-89f2-314fbcb81104.png)

If we prefer other combinations, we can still change this option in the ini file.