### PR TITLE
Update libzt to fix MinGW build on case-insensitive file systems

### DIFF
--- a/3rdParty/libzt/CMakeLists.txt
+++ b/3rdParty/libzt/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent_MakeAvailableExcludeFromAll)
 include(FetchContent)
 FetchContent_Declare(libzt
   GIT_REPOSITORY https://github.com/diasurgical/libzt.git
-  GIT_TAG 97a405529d64d9589e9fc785d6d1d2c597f92478)
+  GIT_TAG 2607962e3b2c1def68479f7dc382c7508c367365)
 FetchContent_MakeAvailableExcludeFromAll(libzt)
 
 # External library, ignore all warnings


### PR DESCRIPTION
Fixes an issue identified by @ropufu in #2472 where placing the DevilutionX source code on a case-insensitive file system and running a MinGW build will lead to a recursive include causing the build to fail.