### PR TITLE
fix armor piercing affix range

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1127,8 +1127,8 @@ void SaveItemAffix(ItemStruct &item, const PLStruct &affix)
 
 	if (!gbIsHellfire) {
 		if (power.type == IPL_TARGAC) {
-			power.param1 = 2 << power.param1;
-			power.param2 = 6 << power.param2;
+			power.param1 = 1 << power.param1;
+			power.param2 = 3 << power.param2;
 		}
 	}
 


### PR DESCRIPTION
this is a pretty serious one, devilutionx made armor piercing have 2x larger stat range than the original
(example bashing 8-24, devx 16-48)