### PR TITLE
unify ranged and melee pierce

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1447,7 +1447,7 @@ void DrawChr(const Surface &out)
 		style = UiFlags::ColorBlue;
 	if (myPlayer._pIBonusToHit < 0)
 		style = UiFlags::ColorRed;
-	sprintf(chrstr, "%i%%", (myPlayer.InvBody[INVLOC_HAND_LEFT]._itype == ITYPE_BOW ? myPlayer.GetRangedToHit() : myPlayer.GetMeleeToHit()));
+	sprintf(chrstr, "%i%%", (myPlayer.InvBody[INVLOC_HAND_LEFT]._itype == ITYPE_BOW ? myPlayer.GetRangedPiercingToHit() : myPlayer.GetMeleePiercingToHit()));
 	DrawString(out, chrstr, { GetPanelPosition(UiPanels::Character, { 258, 211 }), { 43, 0 } }, style | UiFlags::AlignCenter);
 
 	style = UiFlags::ColorSilver;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -234,10 +234,9 @@ bool MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, missile_id t
 	if (pnum != -1) {
 		const auto &player = Players[pnum];
 		if (MissileData[t].mType == 0) {
-			hper = player.GetRangedToHit();
-			hper -= monster.mArmorClass;
+			hper = player.GetRangedPiercingToHit();
+			hper -= player.CalculateArmorPierce(monster.mArmorClass, false);
 			hper -= (dist * dist) / 2;
-			hper += player._pIEnAc;
 		} else {
 			hper = player.GetMagicToHit() - (monster.mLevel * 2) - dist;
 		}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -905,25 +905,7 @@ bool PlrHitMonst(int pnum, int m)
 		hit = 0;
 	}
 
-	int tmac = monster.mArmorClass;
-	if (gbIsHellfire && player._pIEnAc > 0) {
-		int pIEnAc = player._pIEnAc - 1;
-		if (pIEnAc > 0)
-			tmac >>= pIEnAc;
-		else
-			tmac -= tmac / 4;
-
-		if (player._pClass == HeroClass::Barbarian) {
-			tmac -= monster.mArmorClass / 8;
-		}
-
-		if (tmac < 0)
-			tmac = 0;
-	} else {
-		tmac -= player._pIEnAc;
-	}
-
-	hper += player.GetMeleeToHit() - tmac;
+	hper += player.GetMeleePiercingToHit() - player.CalculateArmorPierce(monster.mArmorClass, true);
 	hper = clamp(hper, 5, 95);
 
 	bool ret = false;

--- a/Source/player.h
+++ b/Source/player.h
@@ -416,7 +416,20 @@ struct PlayerStruct {
 	}
 
 	/**
+	 * @brief Return player's melee to hit value, including armor piercing
+	 */
+	int GetMeleePiercingToHit() const
+	{
+		int hper = GetMeleeToHit();
+		//in hellfire armor piercing ignores % of enemy armor instead, no way to include it here
+		if (!gbIsHellfire)
+			hper += _pIEnAc;
+		return hper;
+	}
+
+	/**
 	 * @brief Return player's ranged to hit value
+	 * @param pierceArmor - indicate if player's armor piercing should be included - true vs monsters, false vs players
 	 */
 	int GetRangedToHit() const
 	{
@@ -425,6 +438,15 @@ struct PlayerStruct {
 			hper += 20;
 		else if (_pClass == HeroClass::Warrior || _pClass == HeroClass::Bard)
 			hper += 10;
+		return hper;
+	}
+
+	int GetRangedPiercingToHit() const
+	{
+		int hper = GetRangedToHit();
+		//in hellfire armor piercing ignores % of enemy armor instead, no way to include it here
+		if (!gbIsHellfire)
+			hper += _pIEnAc;
 		return hper;
 	}
 
@@ -451,6 +473,30 @@ struct PlayerStruct {
 		if (useLevel)
 			blkper += _pLevel * 2;
 		return blkper;
+	}
+
+	/**
+	 * @brief Return monster armor value after including player's armor piercing % (hellfire only)
+	 * @param monsterArmor - monster armor before applying % armor pierce
+	 * @param isMelee - indicates if it's melee or ranged combat
+	 */
+	int CalculateArmorPierce(int monsterArmor, bool isMelee) const
+	{
+		int tmac = monsterArmor;
+		if (gbIsHellfire && _pIEnAc > 0) {
+			int pIEnAc = _pIEnAc - 1;
+			if (pIEnAc > 0)
+				tmac >>= pIEnAc;
+			else
+				tmac -= tmac / 4;
+		}
+		if (isMelee && _pClass == HeroClass::Barbarian) {
+			tmac -= monsterArmor / 8;
+		}
+		if (tmac < 0)
+			tmac = 0;
+
+		return tmac;
 	}
 
 	/**


### PR DESCRIPTION
1. Make hit chance displayed in character sheet in vanilla include armor pierce - this gives us an option to somehow check the real value of armor piercing affixes before we get a proper description for them

2. Unify hellfire's melee and ranged pierce.
Hellfire values are pretty low and indicate tiers of % armor that should be ignored
1 = 25%
2 = 50%
3 = 75% armor ignored.

Ofc hellfire didn't do such a thing for ranged, in hellfire ranged pierce even had a wrong sign, so it actually decreased hit chance by these 1/2/3%.

This makes ranged pierce follow the same rules as melee's for hellfire - ofc barbarian's passive 12.5% pierce stays only melee.