### PR TITLE
Install gettext in 3DS CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - checkout
       - run: apt-get update -y
-      - run: apt-get install -y ffmpeg
+      - run: apt-get install -y ffmpeg gettext
       - run: wget https://github.com/Steveice10/bannertool/releases/download/1.2.0/bannertool.zip
       - run: unzip -j "bannertool.zip" "linux-x86_64/bannertool" -d "/opt/devkitpro/tools/bin"
       - run: wget https://github.com/jakcron/Project_CTR/releases/download/v0.16/makerom_016_ctrtool.zip


### PR DESCRIPTION
Adds gettext to the list of packages installed via apt in the 3DS CI build script. This should allow the build to produce the gmo files for translations.