### PR TITLE
Ensure shift+click and auto-equip properly update readied spell from staff

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -605,11 +605,7 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 			NetSendCmdChItem(false, INVLOC_HAND_LEFT);
 			player.InvBody[INVLOC_HAND_LEFT] = player.HoldItem;
 		}
-		if (player.InvBody[INVLOC_HAND_LEFT]._itype == ITYPE_STAFF && player.InvBody[INVLOC_HAND_LEFT]._iSpell != SPL_NULL && player.InvBody[INVLOC_HAND_LEFT]._iCharges > 0) {
-			player._pRSpell = player.InvBody[INVLOC_HAND_LEFT]._iSpell;
-			player._pRSplType = RSPLTYPE_CHARGES;
-			force_redraw = 255;
-		}
+		player.ReadySpellFromEquipment(inv_body_loc::INVLOC_HAND_LEFT);
 		break;
 	case ILOC_UNEQUIPABLE:
 		if (player.HoldItem._itype == ITYPE_GOLD && it == 0) {

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -605,7 +605,6 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 			NetSendCmdChItem(false, INVLOC_HAND_LEFT);
 			player.InvBody[INVLOC_HAND_LEFT] = player.HoldItem;
 		}
-		player.ReadySpellFromEquipment(inv_body_loc::INVLOC_HAND_LEFT);
 		break;
 	case ILOC_UNEQUIPABLE:
 		if (player.HoldItem._itype == ITYPE_GOLD && it == 0) {

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1443,7 +1443,9 @@ DWORD OnBreakObject(TCmd *pCmd, int pnum)
 DWORD OnChangePlayerItems(TCmd *pCmd, int pnum)
 {
 	auto *p = (TCmdChItem *)pCmd;
+	auto bodyLocation = static_cast<inv_body_loc>(p->bLoc);
 
+	Players[pnum].ReadySpellFromEquipment(bodyLocation);
 	if (gbBufferMsgs == 1)
 		SendPacket(pnum, p, sizeof(*p));
 	else if (pnum != MyPlayerId)

--- a/Source/player.h
+++ b/Source/player.h
@@ -487,6 +487,20 @@ struct PlayerStruct {
 	}
 
 	/**
+	 * @brief Sets the readied spell to the spell in the specified equipment slot. Does nothing if the item does not have a valid spell.
+	 * @param bodyLocation - the body location whose item will be checked for the spell.
+	 */
+	void ReadySpellFromEquipment(inv_body_loc bodyLocation)
+	{
+		auto &item = InvBody[bodyLocation];
+		if (item._itype == ITYPE_STAFF && item._iSpell != SPL_NULL && item._iCharges > 0) {
+			_pRSpell = item._iSpell;
+			_pRSplType = RSPLTYPE_CHARGES;
+			force_redraw = 255;
+		}
+	}
+
+	/**
 	 * @brief Does the player currently have a ranged weapon equipped?
 	 */
 	bool UsesRangedWeapon() const


### PR DESCRIPTION
This PR fixes a problem that caused auto-equipping staves from the groud or equipping them with shift+click in the inventory to not automatically ready the staff's charge spell when charges are available.

We are now making sure that the same logic that sets the readied spell applies on every equipment change situation by moving the processing logic directly into the command processing method for "equipment change", which is broadcast everytime an item is equipped or updated.

Resolves #2509