### PR TITLE
fixes stone curse forever bug caused by negative monster index

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2557,8 +2557,8 @@ void AddStone(int mi, Point /*src*/, Point dst, int /*midir*/, int8_t /*mienemy*
 			int mid = dMonster[tx][ty];
 			if (mid == 0)
 				continue;
-
-			auto &monster = Monsters[abs(mid) - 1];
+			mid = abs(mid) - 1;
+			auto &monster = Monsters[mid];
 
 			if (IsAnyOf(monster.MType->mtype, MT_GOLEM, MT_DIABLO, MT_NAKRUL))
 				continue;


### PR DESCRIPTION
fixes https://github.com/diasurgical/devilutionX/issues/2550

the negative index was written to `_miVar2` and used later on in missile update in `MI_Stone`