### PR TITLE
3DS: Detect system language and select the appropriate translation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,6 +507,7 @@ if(NINTENDO_3DS)
     Source/platform/ctr/messagebox.cpp
     Source/platform/ctr/random.cpp
     Source/platform/ctr/sockets.cpp
+    Source/platform/ctr/locale.cpp
     Source/platform/ctr/asio/net/if.c
     Source/platform/ctr/asio/sys/socket.c
     Source/platform/ctr/asio/sys/uio.c)

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -18,6 +18,10 @@
 #include <psp2/system_param.h>
 #endif
 
+#ifdef __3DS__
+#include "platform/ctr/locale.hpp"
+#endif
+
 #define SI_SUPPORT_IOSTREAMS
 #include <SimpleIni.h>
 
@@ -329,6 +333,8 @@ void LoadOptions()
 	sceAppUtilSystemParamGetInt(SCE_SYSTEM_PARAM_ID_LANG, &language);
 	std::string locale = std::string(vita_locales[language]);
 	sceAppUtilShutdown();
+#elif defined(__3DS__)
+	std::string locale = n3ds::GetLocale();
 #else
 	std::string locale = std::locale("").name().substr(0, 5);
 #endif

--- a/Source/platform/ctr/locale.cpp
+++ b/Source/platform/ctr/locale.cpp
@@ -1,0 +1,66 @@
+#include "platform/ctr/locale.hpp"
+
+#include <3ds.h>
+
+namespace devilution {
+namespace n3ds {
+
+namespace {
+
+class CFGUService {
+public:
+	CFGUService()
+	{
+		cfguInit();
+	}
+
+	~CFGUService()
+	{
+		cfguExit();
+	}
+};
+
+}
+
+std::string GetLocale()
+{
+	CFGUService cfguService;
+
+	u8 language;
+	Result res = CFGU_GetSystemLanguage(&language);
+
+	if (!R_SUCCEEDED(res))
+		return "";
+
+	switch (language) {
+	case CFG_LANGUAGE_JP:
+		return "ja";
+	case CFG_LANGUAGE_EN:
+		return "en";
+	case CFG_LANGUAGE_FR:
+		return "fr";
+	case CFG_LANGUAGE_DE:
+		return "de";
+	case CFG_LANGUAGE_IT:
+		return "it";
+	case CFG_LANGUAGE_ES:
+		return "es";
+	case CFG_LANGUAGE_ZH:
+		return "zh_CN";
+	case CFG_LANGUAGE_KO:
+		return "ko_KR";
+	case CFG_LANGUAGE_NL:
+		return "nl";
+	case CFG_LANGUAGE_PT:
+		return "pt_BR";
+	case CFG_LANGUAGE_RU:
+		return "ru";
+	case CFG_LANGUAGE_TW:
+		return "zh_TW";
+	default:
+		return "";
+	}
+}
+
+} // namespace n3ds
+} // namespace devilution

--- a/Source/platform/ctr/locale.hpp
+++ b/Source/platform/ctr/locale.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string>
+
+namespace devilution {
+namespace n3ds {
+
+std::string GetLocale();
+
+} // namespace n3ds
+} // namespace devilution


### PR DESCRIPTION
I can only select English, French, Spanish, and Portuguese on my console, but here's the full list of supported languages according to libctru:
* Japanese (ja)
* English (en)
* French (fr)
* German (de)
* Italian (it)
* Spanish (es)
* Simplified Chinese (zh_CN)
* Korean (ko_KR)
* Dutch (nl)
* Portuguese (pt_BR)
* Russian (ru)
* Traditional Chinese (zh_TW)

The language codes I listed aren't provided by the OS, but rather are the ones I selected based on the OS language setting. I did my best to select language codes based on the translations we have so far (e.g., `ko_KR` instead of just `ko`).