### PR TITLE
diablo_quit also frees game state (and with this sound objects)

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1689,6 +1689,7 @@ bool StartGame(bool bNewGame, bool bSinglePlayer)
 
 void diablo_quit(int exitStatus)
 {
+	FreeGameMem();
 	DiabloDeinit();
 	exit(exitStatus);
 }


### PR DESCRIPTION
Fixes #2220 (at least on my pc) 🙂 

Notes:

- Sound was still playing, that was the cause of the exception (at least on my pc)
- `FreeGameMem` stops music and sound
- `FreeGameMem` is called if you exit a running game normally (in `RunGameLoop`).
- In menu only `music_stop` is called, but `FreeGameMem` includes `music_stop`.
- `FreeGameMem` can be called multiple times
- Alternative Solution would be to only stop music & sound.