### PR TITLE
Issue 2369 separate translation entrys

### DIFF
--- a/Translations/bg.po
+++ b/Translations/bg.po
@@ -2797,9 +2797,13 @@ msgstr "Обилни"
 msgid "Flaming"
 msgstr "Пламени"
 
-#: Source/itemdat.cpp:274 Source/spelldat.cpp:18
+#: Source/itemdat.cpp:274
 msgid "Lightning"
 msgstr "Мълния"
+
+#: Source/spelldat.cpp:18
+msgid "Lightning"
+msgstr "Светкавични"
 
 #: Source/itemdat.cpp:275
 msgid "Jester's"

--- a/Translations/bg.po
+++ b/Translations/bg.po
@@ -1061,8 +1061,11 @@ msgstr "Заклинания"
 msgid "Quests"
 msgstr "Задачи"
 
-#: Source/cursor.cpp:207 Source/spelldat.cpp:22
-#, fuzzy
+#: Source/cursor.cpp:230
+msgid "Town Portal"
+msgstr "Градски портал"
+
+#: Source/spelldat.cpp:22
 msgid "Town Portal"
 msgstr "Градски портал"
 

--- a/Translations/de.po
+++ b/Translations/de.po
@@ -449,19 +449,22 @@ msgstr ""
 msgid "Select Difficulty"
 msgstr "Schwierigkeitsgrad"
 
-#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
 #: Source/DiabloUI/selgame.cpp:307 Source/DiabloUI/selgame.cpp:327
-#: Source/diablo.cpp:1525
+msgid "Normal"
+msgstr "Normal"
+
+#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
+#: Source/diablo.cpp:1568
 msgid "Normal"
 msgstr "Normal"
 
 #: Source/DiabloUI/selgame.cpp:158 Source/DiabloUI/selgame.cpp:208
-#: Source/diablo.cpp:1526
+#: Source/diablo.cpp:1569
 msgid "Nightmare"
 msgstr "Alptraum"
 
 #: Source/DiabloUI/selgame.cpp:159 Source/DiabloUI/selgame.cpp:212
-#: Source/diablo.cpp:1527
+#: Source/diablo.cpp:1570
 msgid "Hell"
 msgstr "Hölle"
 

--- a/Translations/de.po
+++ b/Translations/de.po
@@ -2712,7 +2712,11 @@ msgstr "Reichlich"
 msgid "Flaming"
 msgstr "Flammend"
 
-#: Source/itemdat.cpp:274 Source/spelldat.cpp:18
+#: Source/itemdat.cpp:274
+msgid "Lightning"
+msgstr "Blitz"
+
+#: Source/spelldat.cpp:18
 msgid "Lightning"
 msgstr "Blitz"
 

--- a/Translations/de.po
+++ b/Translations/de.po
@@ -1045,7 +1045,11 @@ msgstr "{:s} Spruch"
 msgid "Quests"
 msgstr "Questtagebuch"
 
-#: Source/cursor.cpp:230 Source/spelldat.cpp:22
+#: Source/cursor.cpp:230
+msgid "Town Portal"
+msgstr "Stadtportal"
+
+#: Source/spelldat.cpp:22
 msgid "Town Portal"
 msgstr "Stadtportal"
 

--- a/Translations/devilutionx.pot
+++ b/Translations/devilutionx.pot
@@ -976,7 +976,11 @@ msgstr ""
 msgid "Quests"
 msgstr ""
 
-#: Source/cursor.cpp:230 Source/spelldat.cpp:22
+#: Source/cursor.cpp:230
+msgid "Town Portal"
+msgstr ""
+
+#: Source/spelldat.cpp:22
 msgid "Town Portal"
 msgstr ""
 

--- a/Translations/devilutionx.pot
+++ b/Translations/devilutionx.pot
@@ -442,19 +442,22 @@ msgstr ""
 msgid "Select Difficulty"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
 #: Source/DiabloUI/selgame.cpp:307 Source/DiabloUI/selgame.cpp:327
-#: Source/diablo.cpp:1522
+msgid "Normal"
+msgstr ""
+
+#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
+#: Source/diablo.cpp:1568
 msgid "Normal"
 msgstr ""
 
 #: Source/DiabloUI/selgame.cpp:158 Source/DiabloUI/selgame.cpp:208
-#: Source/diablo.cpp:1523
+#: Source/diablo.cpp:1569
 msgid "Nightmare"
 msgstr ""
 
 #: Source/DiabloUI/selgame.cpp:159 Source/DiabloUI/selgame.cpp:212
-#: Source/diablo.cpp:1524
+#: Source/diablo.cpp:1570
 msgid "Hell"
 msgstr ""
 

--- a/Translations/devilutionx.pot
+++ b/Translations/devilutionx.pot
@@ -2596,7 +2596,11 @@ msgstr ""
 msgid "Flaming"
 msgstr ""
 
-#: Source/itemdat.cpp:274 Source/spelldat.cpp:18
+#: Source/itemdat.cpp:274
+msgid "Lightning"
+msgstr ""
+
+#: Source/spelldat.cpp:18
 msgid "Lightning"
 msgstr ""
 

--- a/Translations/es.po
+++ b/Translations/es.po
@@ -455,19 +455,22 @@ msgstr ""
 msgid "Select Difficulty"
 msgstr "Seleccione Dificultad"
 
-#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
 #: Source/DiabloUI/selgame.cpp:307 Source/DiabloUI/selgame.cpp:327
-#: Source/diablo.cpp:1525
+msgid "Normal"
+msgstr "Normal"
+
+#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
+#: Source/diablo.cpp:1568
 msgid "Normal"
 msgstr "Normal"
 
 #: Source/DiabloUI/selgame.cpp:158 Source/DiabloUI/selgame.cpp:208
-#: Source/diablo.cpp:1526
+#: Source/diablo.cpp:1569
 msgid "Nightmare"
 msgstr "Pesadilla"
 
 #: Source/DiabloUI/selgame.cpp:159 Source/DiabloUI/selgame.cpp:212
-#: Source/diablo.cpp:1527
+#: Source/diablo.cpp:1570
 msgid "Hell"
 msgstr "Infierno"
 

--- a/Translations/es.po
+++ b/Translations/es.po
@@ -2773,7 +2773,11 @@ msgstr "Generoso"
 msgid "Flaming"
 msgstr "Llameante"
 
-#: Source/itemdat.cpp:274 Source/spelldat.cpp:18
+#: Source/itemdat.cpp:274
+msgid "Lightning"
+msgstr "Relámpago"
+
+#: Source/spelldat.cpp:18
 msgid "Lightning"
 msgstr "Relámpago"
 

--- a/Translations/es.po
+++ b/Translations/es.po
@@ -1069,7 +1069,11 @@ msgstr "Hechizos"
 msgid "Quests"
 msgstr "Misiones"
 
-#: Source/cursor.cpp:230 Source/spelldat.cpp:22
+#: Source/cursor.cpp:230
+msgid "Town Portal"
+msgstr "Portal de la ciudad"
+
+#: Source/spelldat.cpp:22
 msgid "Town Portal"
 msgstr "Portal de la ciudad"
 

--- a/Translations/fr.po
+++ b/Translations/fr.po
@@ -452,19 +452,22 @@ msgstr ""
 msgid "Select Difficulty"
 msgstr "Sélection difficulté"
 
-#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
 #: Source/DiabloUI/selgame.cpp:307 Source/DiabloUI/selgame.cpp:327
-#: Source/diablo.cpp:1525
+msgid "Normal"
+msgstr "Normale"
+
+#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
+#: Source/diablo.cpp:1568
 msgid "Normal"
 msgstr "Normale"
 
 #: Source/DiabloUI/selgame.cpp:158 Source/DiabloUI/selgame.cpp:208
-#: Source/diablo.cpp:1526
+#: Source/diablo.cpp:1569
 msgid "Nightmare"
 msgstr "Cauchemar"
 
 #: Source/DiabloUI/selgame.cpp:159 Source/DiabloUI/selgame.cpp:212
-#: Source/diablo.cpp:1527
+#: Source/diablo.cpp:1570
 msgid "Hell"
 msgstr "Enfer"
 

--- a/Translations/fr.po
+++ b/Translations/fr.po
@@ -1069,7 +1069,11 @@ msgstr "Sorts"
 msgid "Quests"
 msgstr "Quêtes"
 
-#: Source/cursor.cpp:230 Source/spelldat.cpp:22
+#: Source/cursor.cpp:230
+msgid "Town Portal"
+msgstr "Portail vers la ville"
+
+#: Source/spelldat.cpp:22
 msgid "Town Portal"
 msgstr "Portail vers la ville"
 

--- a/Translations/fr.po
+++ b/Translations/fr.po
@@ -2746,7 +2746,11 @@ msgstr ""
 msgid "Flaming"
 msgstr ""
 
-#: Source/itemdat.cpp:274 Source/spelldat.cpp:18
+#: Source/itemdat.cpp:274
+msgid "Lightning"
+msgstr ""
+
+#: Source/spelldat.cpp:18
 msgid "Lightning"
 msgstr ""
 

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -2755,7 +2755,11 @@ msgstr "Munifico"
 msgid "Flaming"
 msgstr "Fiamma"
 
-#: Source/itemdat.cpp:274 Source/spelldat.cpp:18
+#: Source/itemdat.cpp:274
+msgid "Lightning"
+msgstr "Fulmine"
+
+#: Source/spelldat.cpp:18
 msgid "Lightning"
 msgstr "Fulmine"
 

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -1047,7 +1047,11 @@ msgstr "Magie"
 msgid "Quests"
 msgstr "Missioni"
 
-#: Source/cursor.cpp:230 Source/spelldat.cpp:22
+#: Source/cursor.cpp:230
+msgid "Town Portal"
+msgstr "Portale Cittadino"
+
+#: Source/spelldat.cpp:22
 msgid "Town Portal"
 msgstr "Portale Cittadino"
 

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -452,19 +452,22 @@ msgstr ""
 msgid "Select Difficulty"
 msgstr "Seleziona Difficoltà"
 
-#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
 #: Source/DiabloUI/selgame.cpp:307 Source/DiabloUI/selgame.cpp:327
-#: Source/diablo.cpp:1567
+msgid "Normal"
+msgstr "Normale"
+
+#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
+#: Source/diablo.cpp:1568
 msgid "Normal"
 msgstr "Normale"
 
 #: Source/DiabloUI/selgame.cpp:158 Source/DiabloUI/selgame.cpp:208
-#: Source/diablo.cpp:1568
+#: Source/diablo.cpp:1569
 msgid "Nightmare"
 msgstr "Incubo"
 
 #: Source/DiabloUI/selgame.cpp:159 Source/DiabloUI/selgame.cpp:212
-#: Source/diablo.cpp:1569
+#: Source/diablo.cpp:1570
 msgid "Hell"
 msgstr "Inferno"
 

--- a/Translations/ko_KR.po
+++ b/Translations/ko_KR.po
@@ -1053,7 +1053,11 @@ msgstr "주문"
 msgid "Quests"
 msgstr "퀘스트"
 
-#: Source/cursor.cpp:208 Source/spelldat.cpp:22
+#: Source/cursor.cpp:230
+msgid "Town Portal"
+msgstr "마을 차원문"
+
+#: Source/spelldat.cpp:22
 msgid "Town Portal"
 msgstr "마을 차원문"
 

--- a/Translations/ko_KR.po
+++ b/Translations/ko_KR.po
@@ -2712,7 +2712,11 @@ msgstr ""
 msgid "Flaming"
 msgstr ""
 
-#: Source/itemdat.cpp:274 Source/spelldat.cpp:18
+#: Source/itemdat.cpp:274
+msgid "Lightning"
+msgstr ""
+
+#: Source/spelldat.cpp:18
 msgid "Lightning"
 msgstr ""
 

--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -455,19 +455,22 @@ msgstr ""
 msgid "Select Difficulty"
 msgstr "Selecionar dificuldade"
 
-#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
 #: Source/DiabloUI/selgame.cpp:307 Source/DiabloUI/selgame.cpp:327
-#: Source/diablo.cpp:1567
+msgid "Normal"
+msgstr "Normal"
+
+#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
+#: Source/diablo.cpp:1568
 msgid "Normal"
 msgstr "Normal"
 
 #: Source/DiabloUI/selgame.cpp:158 Source/DiabloUI/selgame.cpp:208
-#: Source/diablo.cpp:1568
+#: Source/diablo.cpp:1569
 msgid "Nightmare"
 msgstr "Pesadelo"
 
 #: Source/DiabloUI/selgame.cpp:159 Source/DiabloUI/selgame.cpp:212
-#: Source/diablo.cpp:1569
+#: Source/diablo.cpp:1570
 msgid "Hell"
 msgstr "Inferno"
 

--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -1051,7 +1051,11 @@ msgstr "Feitiços"
 msgid "Quests"
 msgstr "Missões"
 
-#: Source/cursor.cpp:230 Source/spelldat.cpp:22
+#: Source/cursor.cpp:230
+msgid "Town Portal"
+msgstr "Portal da cidade"
+
+#: Source/spelldat.cpp:22
 msgid "Town Portal"
 msgstr "Portal da cidade"
 

--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -2761,7 +2761,11 @@ msgstr "abundante"
 msgid "Flaming"
 msgstr "flamejante"
 
-#: Source/itemdat.cpp:274 Source/spelldat.cpp:18
+#: Source/itemdat.cpp:274
+msgid "Lightning"
+msgstr "relampejante"
+
+#: Source/spelldat.cpp:18
 msgid "Lightning"
 msgstr "relampejante"
 

--- a/Translations/ru.po
+++ b/Translations/ru.po
@@ -1049,7 +1049,11 @@ msgstr "Магия"
 msgid "Quests"
 msgstr "Квесты"
 
-#: Source/cursor.cpp:230 Source/spelldat.cpp:22
+#: Source/cursor.cpp:230
+msgid "Town Portal"
+msgstr "Городской портал"
+
+#: Source/spelldat.cpp:22
 msgid "Town Portal"
 msgstr "Городской портал"
 

--- a/Translations/ru.po
+++ b/Translations/ru.po
@@ -2761,7 +2761,11 @@ msgstr "Щедрый"
 msgid "Flaming"
 msgstr "Пылающий"
 
-#: Source/itemdat.cpp:274 Source/spelldat.cpp:18
+#: Source/itemdat.cpp:274
+msgid "Lightning"
+msgstr "Светящийся"
+
+#: Source/spelldat.cpp:18
 msgid "Lightning"
 msgstr "Светящийся"
 

--- a/Translations/ru.po
+++ b/Translations/ru.po
@@ -453,19 +453,22 @@ msgstr ""
 msgid "Select Difficulty"
 msgstr "Выберете сложность"
 
-#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
 #: Source/DiabloUI/selgame.cpp:307 Source/DiabloUI/selgame.cpp:327
-#: Source/diablo.cpp:1567
+msgid "Normal"
+msgstr "Нормальная"
+
+#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
+#: Source/diablo.cpp:1568
 msgid "Normal"
 msgstr "Нормальная"
 
 #: Source/DiabloUI/selgame.cpp:158 Source/DiabloUI/selgame.cpp:208
-#: Source/diablo.cpp:1568
+#: Source/diablo.cpp:1569
 msgid "Nightmare"
 msgstr "Кошмарная"
 
 #: Source/DiabloUI/selgame.cpp:159 Source/DiabloUI/selgame.cpp:212
-#: Source/diablo.cpp:1569
+#: Source/diablo.cpp:1570
 msgid "Hell"
 msgstr "Адская"
 

--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -2705,7 +2705,11 @@ msgstr "慷慨的"
 msgid "Flaming"
 msgstr "烈焰"
 
-#: Source/itemdat.cpp:274 Source/spelldat.cpp:18
+#: Source/itemdat.cpp:274
+msgid "Lightning"
+msgstr "闪电术"
+
+#: Source/spelldat.cpp:18
 msgid "Lightning"
 msgstr "闪电术"
 

--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -449,8 +449,11 @@ msgstr "输入IP或主机名，然后在该地址加入正在进行的游戏。"
 msgid "Select Difficulty"
 msgstr "选择难度"
 
-#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
 #: Source/DiabloUI/selgame.cpp:307 Source/DiabloUI/selgame.cpp:327
+msgid "Normal"
+msgstr "正常"
+
+#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
 #: Source/diablo.cpp:1568
 msgid "Normal"
 msgstr "正常"

--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -1021,7 +1021,11 @@ msgstr "法术"
 msgid "Quests"
 msgstr "任务"
 
-#: Source/cursor.cpp:230 Source/spelldat.cpp:22
+#: Source/cursor.cpp:230
+msgid "Town Portal"
+msgstr "城镇传送门"
+
+#: Source/spelldat.cpp:22
 msgid "Town Portal"
 msgstr "城镇传送门"
 

--- a/Translations/zh_TW.po
+++ b/Translations/zh_TW.po
@@ -1039,7 +1039,11 @@ msgstr "法術"
 msgid "Quests"
 msgstr "任務"
 
-#: Source/cursor.cpp:230 Source/spelldat.cpp:22
+#: Source/cursor.cpp:230
+msgid "Town Portal"
+msgstr "城鎮傳送門"
+
+#: Source/spelldat.cpp:22
 msgid "Town Portal"
 msgstr "城鎮傳送門"
 

--- a/Translations/zh_TW.po
+++ b/Translations/zh_TW.po
@@ -2731,7 +2731,11 @@ msgstr "慷慨的"
 msgid "Flaming"
 msgstr "烈焰"
 
-#: Source/itemdat.cpp:274 Source/spelldat.cpp:18
+#: Source/itemdat.cpp:274
+msgid "Lightning"
+msgstr "閃電術"
+
+#: Source/spelldat.cpp:18
 msgid "Lightning"
 msgstr "閃電術"
 

--- a/Translations/zh_TW.po
+++ b/Translations/zh_TW.po
@@ -449,8 +449,11 @@ msgstr "輸入IP或主機名，然後在該地址加入正在進行的遊戲。"
 msgid "Select Difficulty"
 msgstr "選擇難度"
 
-#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
 #: Source/DiabloUI/selgame.cpp:307 Source/DiabloUI/selgame.cpp:327
+msgid "Normal"
+msgstr "正常"
+
+#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
 #: Source/diablo.cpp:1568
 msgid "Normal"
 msgstr "正常"


### PR DESCRIPTION
I separated some translation entrys. I also updated the line numbers on my changed lines if they have changed.
I'm not quite sure how the translation system works and who (and when) those line numbers are generated but I think having them point to the right source code line can't be that wrong, even if I have to do it by hand.