### PR TITLE
make ReadySpellFromEquipment have correct item data

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1445,11 +1445,12 @@ DWORD OnChangePlayerItems(TCmd *pCmd, int pnum)
 	auto *p = (TCmdChItem *)pCmd;
 	auto bodyLocation = static_cast<inv_body_loc>(p->bLoc);
 
-	Players[pnum].ReadySpellFromEquipment(bodyLocation);
 	if (gbBufferMsgs == 1)
 		SendPacket(pnum, p, sizeof(*p));
 	else if (pnum != MyPlayerId)
 		CheckInvSwap(pnum, p->bLoc, p->wIndx, p->wCI, p->dwSeed, p->bId != 0, p->dwBuff);
+
+	Players[pnum].ReadySpellFromEquipment(bodyLocation);
 
 	return sizeof(*p);
 }


### PR DESCRIPTION
If it's executed before CheckInvSwap. then itype is -1, as we are at a point where we only know the other player unequipped something, we haven't received the data about the stuff that got equipped (CheckInvSwap)