### PR TITLE
fixes casting level 0 spell says "not enough mana"

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -491,7 +491,7 @@ spell_type GetSBookTrans(spell_id ii, bool townok)
 		st = RSPLTYPE_SKILL;
 	}
 	if (st == RSPLTYPE_SPELL) {
-		if (!CheckSpell(MyPlayerId, ii, st, true)) {
+		if (CheckSpell(MyPlayerId, ii, st, true) != SpellCheckResult::Success) {
 			st = RSPLTYPE_INVALID;
 		}
 		if ((char)(myPlayer._pSplLvl[ii] + myPlayer._pISplLvlAdd) <= 0) {
@@ -668,7 +668,7 @@ void DrawSpell(const Surface &out)
 	// BUGFIX: Move the next line into the if statement to avoid OOB (SPL_INVALID is -1) (fixed)
 	if (st == RSPLTYPE_SPELL && spl != SPL_INVALID) {
 		int tlvl = myPlayer._pISplLvlAdd + myPlayer._pSplLvl[spl];
-		if (!CheckSpell(MyPlayerId, spl, st, true))
+		if (CheckSpell(MyPlayerId, spl, st, true) != SpellCheckResult::Success)
 			st = RSPLTYPE_INVALID;
 		if (tlvl <= 0)
 			st = RSPLTYPE_INVALID;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3575,19 +3575,17 @@ void CheckPlrSpell()
 
 	if (!addflag) {
 		if (myPlayer._pRSplType == RSPLTYPE_SPELL) {
-			HeroSpeech sentence;
 			switch (spellcheck) {
 			case SpellCheckResult::Fail_NoMana:
-				sentence = HeroSpeech::NotEnoughMana;
+				myPlayer.Say(HeroSpeech::NotEnoughMana);
 				break;
 			case SpellCheckResult::Fail_Level0:
-				sentence = HeroSpeech::ICantCastThatYet;
+				myPlayer.Say(HeroSpeech::ICantCastThatYet);
 				break;
 			default:
-				sentence = HeroSpeech::ICantDoThat;
+				myPlayer.Say(HeroSpeech::ICantDoThat);
 				break;
 			}
-			myPlayer.Say(sentence);
 			LastMouseButtonAction = MouseActionType::None;
 		}
 		return;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3556,11 +3556,12 @@ void CheckPlrSpell()
 				return;
 		}
 	}
-
+	SpellCheckResult spellcheck = SpellCheckResult::Success;
 	switch (myPlayer._pRSplType) {
 	case RSPLTYPE_SKILL:
 	case RSPLTYPE_SPELL:
-		addflag = CheckSpell(MyPlayerId, rspell, myPlayer._pRSplType, false);
+		spellcheck = CheckSpell(MyPlayerId, rspell, myPlayer._pRSplType, false);
+		addflag = spellcheck == SpellCheckResult::Success;
 		break;
 	case RSPLTYPE_SCROLL:
 		addflag = UseScroll();
@@ -3574,7 +3575,19 @@ void CheckPlrSpell()
 
 	if (!addflag) {
 		if (myPlayer._pRSplType == RSPLTYPE_SPELL) {
-			myPlayer.Say(HeroSpeech::NotEnoughMana);
+			HeroSpeech sentence;
+			switch (spellcheck) {
+			case SpellCheckResult::Fail_NoMana:
+				sentence = HeroSpeech::NotEnoughMana;
+				break;
+			case SpellCheckResult::Fail_Level0:
+				sentence = HeroSpeech::ICantCastThatYet;
+				break;
+			default:
+				sentence = HeroSpeech::ICantDoThat;
+				break;
+			}
+			myPlayer.Say(sentence);
 			LastMouseButtonAction = MouseActionType::None;
 		}
 		return;

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -196,28 +196,31 @@ void EnsureValidReadiedSpell(PlayerStruct &player)
 	}
 }
 
-bool CheckSpell(int id, spell_id sn, spell_type st, bool manaonly)
+SpellCheckResult CheckSpell(int id, spell_id sn, spell_type st, bool manaonly)
 {
 #ifdef _DEBUG
 	if (debug_mode_key_inverted_v)
-		return true;
+		return SpellCheckResult::Success;
 #endif
 
 	if (!manaonly && pcurs != CURSOR_HAND) {
-		return false;
+		return SpellCheckResult::Fail_Busy;
 	}
 
 	if (st == RSPLTYPE_SKILL) {
-		return true;
+		return SpellCheckResult::Success;
 	}
 
 	if (GetSpellLevel(id, sn) <= 0) {
-		return false;
+		return SpellCheckResult::Fail_Level0;
 	}
 
 	auto &player = Players[id];
+	if (player._pMana < GetManaAmount(player, sn)) {
+		return SpellCheckResult::Fail_NoMana;
+	}
 
-	return player._pMana >= GetManaAmount(player, sn);
+	return SpellCheckResult::Success;
 }
 
 void CastSpell(int id, int spl, int sx, int sy, int dx, int dy, int spllvl)

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -10,15 +10,10 @@
 namespace devilution {
 
 enum class SpellCheckResult : uint8_t {
-	Success = 0,
+	Success,
 	Fail_NoMana,
 	Fail_Level0,
 	Fail_Busy,
-	/* following values may be used as result of refactored UseStaff or UseScroll function
-	Fail_NoCharge,
-	Fail_NoScroll,
-	Fail_WrongPlace,
-	*/
 };
 
 int GetManaAmount(PlayerStruct &player, spell_id sn);

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -9,9 +9,21 @@
 
 namespace devilution {
 
+enum class SpellCheckResult : uint8_t {
+	Success = 0,
+	Fail_NoMana,
+	Fail_Level0,
+	Fail_Busy,
+	/* following values may be used as result of refactored UseStaff or UseScroll function
+	Fail_NoCharge,
+	Fail_NoScroll,
+	Fail_WrongPlace,
+	*/
+};
+
 int GetManaAmount(PlayerStruct &player, spell_id sn);
 void UseMana(int id, spell_id sn);
-bool CheckSpell(int id, spell_id sn, spell_type st, bool manaonly);
+SpellCheckResult CheckSpell(int id, spell_id sn, spell_type st, bool manaonly);
 void EnsureValidReadiedSpell(PlayerStruct &player);
 void CastSpell(int id, int spl, int sx, int sy, int dx, int dy, int spllvl);
 void DoResurrect(int pnum, int rid);


### PR DESCRIPTION
fixes https://github.com/diasurgical/devilutionX/issues/1610
fixes casting level 0 spell says "not enough mana"-> changed return value of `CheckSpell` to enum to reflect the fail reason

Iam not sure about the Busy-Case - Could not reproduce it. If the cursor is not "Hand" (e.g. on using town portal or oil) its impossible to cast without first aborting the other spell/task.