### PR TITLE
Clean up multiplayer XP cap clamping

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -409,9 +409,9 @@ void LoadPlayer(LoadHelper *file, int p)
 	player._pLevel = file->NextLE<int8_t>();
 	player._pMaxLvl = file->NextLE<int8_t>();
 	file->Skip(2); // Alignment
-	player._pExperience = file->NextLE<int32_t>();
-	player._pMaxExp = file->NextLE<int32_t>();
-	player._pNextExper = file->NextLE<int32_t>();
+	player._pExperience = file->NextLE<uint32_t>();
+	file->Skip<uint32_t>();                        // Skip _pMaxExp - unused
+	player._pNextExper = file->NextLE<uint32_t>(); // This can be calculated based on pLevel (which in turn could be calculated based on pExperience)
 	player._pArmorClass = file->NextLE<int8_t>();
 	player._pMagResist = file->NextLE<int8_t>();
 	player._pFireResist = file->NextLE<int8_t>();
@@ -1081,9 +1081,9 @@ void SavePlayer(SaveHelper *file, int p)
 	file->WriteLE<int8_t>(player._pLevel);
 	file->WriteLE<int8_t>(player._pMaxLvl);
 	file->Skip(2); // Alignment
-	file->WriteLE<int32_t>(player._pExperience);
-	file->WriteLE<int32_t>(player._pMaxExp);
-	file->WriteLE<int32_t>(player._pNextExper);
+	file->WriteLE<uint32_t>(player._pExperience);
+	file->Skip<uint32_t>(); // Skip _pMaxExp
+	file->WriteLE<uint32_t>(player._pNextExper);
 	file->WriteLE<int8_t>(player._pArmorClass);
 	file->WriteLE<int8_t>(player._pMagResist);
 	file->WriteLE<int8_t>(player._pFireResist);

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3409,7 +3409,7 @@ bool OperateShrineGlowing(int pnum)
 	auto &myPlayer = Players[MyPlayerId];
 
 	// Add 0-5 points to Magic (0.1% of the players XP)
-	ModifyPlrMag(MyPlayerId, std::min(myPlayer._pExperience / 1000, 5U));
+	ModifyPlrMag(MyPlayerId, static_cast<int>(std::min<uint32_t>(myPlayer._pExperience / 1000, 5)));
 
 	// Take 5% of the players experience to offset the bonus, unless they're very low level in which case take all their experience.
 	if (myPlayer._pExperience > 5000)

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3408,19 +3408,17 @@ bool OperateShrineGlowing(int pnum)
 
 	auto &myPlayer = Players[MyPlayerId];
 
-	int playerXP = myPlayer._pExperience;
-	int magicGain = playerXP / 1000;
-	int xpLoss = 0;
-	if (playerXP > 5000) {
-		magicGain = 5;
-		xpLoss = static_cast<int>(playerXP * 0.95);
-	}
-	ModifyPlrMag(MyPlayerId, magicGain);
-	myPlayer._pExperience = xpLoss;
+	// Add 0-5 points to Magic (0.1% of the players XP)
+	ModifyPlrMag(MyPlayerId, std::min(myPlayer._pExperience / 1000, 5U));
 
-	if (sgOptions.Gameplay.bExperienceBar) {
+	// Take 5% of the players experience to offset the bonus, unless they're very low level in which case take all their experience.
+	if (myPlayer._pExperience > 5000)
+		myPlayer._pExperience = static_cast<uint32_t>(myPlayer._pExperience * 0.95);
+	else
+		myPlayer._pExperience = 0;
+
+	if (sgOptions.Gameplay.bExperienceBar)
 		force_redraw = 255;
-	}
 
 	CheckStats(Players[pnum]);
 

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -46,7 +46,7 @@ struct PkPlayerStruct {
 	uint8_t pBaseVit;
 	int8_t pLevel;
 	uint8_t pStatPts;
-	int32_t pExperience;
+	uint32_t pExperience;
 	int32_t pGold;
 	int32_t pHPBase;
 	int32_t pMaxHPBase;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2669,19 +2669,11 @@ void AddPlrExperience(int pnum, int lvl, int exp)
 
 	// Prevent power leveling
 	if (gbIsMultiplayer) {
-		int powerLvlCap = player._pLevel < 0 ? 0 : player._pLevel;
-		if (powerLvlCap >= 50) {
-			powerLvlCap = 50;
-		}
-		// cap to 1/20 of current levels xp
-		if (exp >= ExpLvlsTbl[powerLvlCap] / 20) {
-			exp = ExpLvlsTbl[powerLvlCap] / 20;
-		}
-		// cap to 200 * current level
-		int expCap = 200 * powerLvlCap;
-		if (exp >= expCap) {
-			exp = expCap;
-		}
+		auto clampedPlayerLevel = clamp(static_cast<int>(player._pLevel), 0, 50);
+
+		// for low level characters experience gain is capped to 1/20 of current levels xp
+		// for high level characters experience gain is capped to 200 * current level - this is a smaller value than 1/20 of the exp needed for the next level after level 5.
+		exp = std::min({ exp, /* level 0-5: */ ExpLvlsTbl[clampedPlayerLevel] / 20, /* level 6-50: */ 200 * clampedPlayerLevel });
 	}
 
 	player._pExperience += exp;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2655,7 +2655,7 @@ void AddPlrExperience(int pnum, int lvl, int exp)
 		return;
 	}
 
-	if ((DWORD)pnum >= MAX_PLRS) {
+	if (pnum >= MAX_PLRS || pnum < 0) {
 		app_fatal("AddPlrExperience: illegal player %i", pnum);
 	}
 	auto &player = Players[pnum];
@@ -2685,7 +2685,7 @@ void AddPlrExperience(int pnum, int lvl, int exp)
 	}
 
 	player._pExperience += exp;
-	if ((DWORD)player._pExperience > MAXEXP) {
+	if (player._pExperience > MAXEXP || player._pExperience < 0) {
 		player._pExperience = MAXEXP;
 	}
 

--- a/Source/player.h
+++ b/Source/player.h
@@ -227,9 +227,8 @@ struct PlayerStruct {
 	int _pManaPer;
 	int8_t _pLevel;
 	int8_t _pMaxLvl;
-	int _pExperience;
-	int _pMaxExp;
-	int _pNextExper;
+	uint32_t _pExperience;
+	uint32_t _pNextExper;
 	int8_t _pArmorClass;
 	int8_t _pMagResist;
 	int8_t _pFireResist;
@@ -603,6 +602,6 @@ extern int StrengthTbl[enum_size<HeroClass>::value];
 extern int MagicTbl[enum_size<HeroClass>::value];
 extern int DexterityTbl[enum_size<HeroClass>::value];
 extern int VitalityTbl[enum_size<HeroClass>::value];
-extern int ExpLvlsTbl[MAXCHARLEVEL];
+extern uint32_t ExpLvlsTbl[MAXCHARLEVEL];
 
 } // namespace devilution

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -89,7 +89,7 @@ void DrawXPBar(const Surface &out)
 		return;
 	}
 
-	const int prevXp = ExpLvlsTbl[charLevel - 1];
+	const uint64_t prevXp = ExpLvlsTbl[charLevel - 1];
 	if (player._pExperience < prevXp)
 		return;
 


### PR DESCRIPTION
Noticed this while reviewing #2572 but it got merged before I could finish the review 😅 

It may be clearer to write out the std::min call using two separate checks instead of an initialiser list. Happy to change that (or have it edited on my behalf :)).

Future cleanups are possible in this area. player._pExperience is pretty much always positive so could be an unsigned value. As far as I can tell players never lose experience (and exp is clamped to 0 at the lowest) so the addition can prevent overflows. This function is also only ever called with pnum = MyPlayerId so the first two checks are redundant.