### PR TITLE
Fix uninitialized variable exception raised in Visual Studio debugger

### DIFF
--- a/Source/misdat.cpp
+++ b/Source/misdat.cpp
@@ -200,7 +200,7 @@ std::array<T, 16> maybeAutofill(std::initializer_list<T> list)
 {
 	assert(list.size() <= 16);
 
-	std::array<T, 16> ret;
+	std::array<T, 16> ret = {};
 
 	if (list.size() == 1) {
 		ret.fill(*list.begin());


### PR DESCRIPTION
From discussion in #2593:
> FYI, the last entry in the `MissileSpriteData` array gives me a couple run-time errors at startup in Visual Studio.
> `Run-Time Check Failure #3 - The variable 'ret' is being used without being initialized.`
> 
> The exception occurs at the return statement in the `maybeAutofill()` function. Presumably, the reason this occurs is that it's operating on a list of size 0 and so no value ever gets assigned to the contents of the array. As far as I can tell, it's not actually causing any issues at runtime apart from the debugger stopping on the thrown exception.

This change merely pacifies Visual Studio by explicitly assigning to the variable at declaration.