### PR TITLE
Demo playback improvmentts

### DIFF
--- a/Source/miniwin/misc_msg.cpp
+++ b/Source/miniwin/misc_msg.cpp
@@ -703,6 +703,16 @@ bool DemoMessage(tagMSG *lpMsg)
 			timedemo = false;
 			last_tick = SDL_GetTicks();
 		}
+		if (e.type == SDL_KEYDOWN && e.key.keysym.sym == SDLK_KP_PLUS && sgGameInitInfo.nTickRate < 255) {
+			sgGameInitInfo.nTickRate++;
+			sgOptions.Gameplay.nTickRate = sgGameInitInfo.nTickRate;
+			gnTickDelay = 1000 / sgGameInitInfo.nTickRate;
+		}
+		if (e.type == SDL_KEYDOWN && e.key.keysym.sym == SDLK_KP_MINUS && sgGameInitInfo.nTickRate > 1) {
+			sgGameInitInfo.nTickRate--;
+			sgOptions.Gameplay.nTickRate = sgGameInitInfo.nTickRate;
+			gnTickDelay = 1000 / sgGameInitInfo.nTickRate;
+		}
 	}
 
 	if (!demo_message_queue.empty()) {

--- a/Source/miniwin/misc_msg.cpp
+++ b/Source/miniwin/misc_msg.cpp
@@ -48,7 +48,8 @@ void SetCursorPos(int x, int y)
 	mousePositionWarping = { x, y };
 	mouseWarping = true;
 	LogicalToOutput(&x, &y);
-	SDL_WarpMouseInWindow(ghMainWnd, x, y);
+	if (!demoMode)
+		SDL_WarpMouseInWindow(ghMainWnd, x, y);
 }
 
 // Moves the mouse to the first attribute "+" button.


### PR DESCRIPTION
- Use `+/-` to control playback speed
- Don't warp mouse while demo is playing

Besides that I recommend disabling hardware cursor for now when playing back demos to be able to see mouse moments.