### PR TITLE
Add debug text commands

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -657,6 +657,11 @@ bool GetSpellListSelection(spell_id &pSpell, spell_type &pSplType)
 	return false;
 }
 
+bool IsChatAvailable()
+{
+	return gbIsMultiplayer;
+}
+
 } // namespace
 
 void DrawSpell(const Surface &out)
@@ -905,7 +910,7 @@ void control_update_life_mana()
 
 void InitControlPan()
 {
-	pBtmBuff = Surface::Alloc(PANEL_WIDTH, (PANEL_HEIGHT + 16) * (gbIsMultiplayer ? 2 : 1));
+	pBtmBuff = Surface::Alloc(PANEL_WIDTH, (PANEL_HEIGHT + 16) * (IsChatAvailable() ? 2 : 1));
 	pManaBuff = Surface::Alloc(88, 88);
 	pLifeBuff = Surface::Alloc(88, 88);
 
@@ -923,7 +928,7 @@ void InitControlPan()
 		CelDrawUnsafeTo(pManaBuff, bulbsPosition, statusPanel, 2);
 	}
 	talkflag = false;
-	if (gbIsMultiplayer) {
+	if (IsChatAvailable()) {
 		CelDrawUnsafeTo(pBtmBuff, { 0, (PANEL_HEIGHT + 16) * 2 - 1 }, LoadCel("CtrlPan\\TalkPanl.CEL", PANEL_WIDTH), 1);
 		multiButtons = LoadCel("CtrlPan\\P8But2.CEL", 33);
 		talkButtons = LoadCel("CtrlPan\\TalkButt.CEL", 61);
@@ -940,7 +945,7 @@ void InitControlPan()
 	for (bool &panbtn : PanelButtons)
 		panbtn = false;
 	panbtndown = false;
-	if (!gbIsMultiplayer)
+	if (!IsChatAvailable())
 		PanelButtonIndex = 6;
 	else
 		PanelButtonIndex = 8;
@@ -1995,7 +2000,7 @@ void control_release_talk_btn()
 
 void control_type_message()
 {
-	if (!gbIsMultiplayer)
+	if (!IsChatAvailable())
 		return;
 
 	talkflag = true;
@@ -2017,7 +2022,7 @@ void control_reset_talk()
 
 bool control_talk_last_key(char vkey)
 {
-	if (!gbIsMultiplayer)
+	if (!IsChatAvailable())
 		return false;
 
 	if (!talkflag)
@@ -2036,7 +2041,7 @@ bool control_talk_last_key(char vkey)
 
 bool control_presskeys(int vkey)
 {
-	if (!gbIsMultiplayer)
+	if (!IsChatAvailable())
 		return false;
 	if (!talkflag)
 		return false;

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -2065,4 +2065,15 @@ bool control_presskeys(int vkey)
 	return true;
 }
 
+void DiabloHotkeyMsg(uint32_t dwMsg)
+{
+	if (!IsChatAvailable()) {
+		return;
+	}
+
+	assert(dwMsg < QUICK_MESSAGE_OPTIONS);
+
+	NetSendCmdString(0xFFFFFF, sgOptions.Chat.szHotKeyMsgs[dwMsg]);
+}
+
 } // namespace devilution

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -32,6 +32,10 @@
 #include "utils/sdl_geometry.h"
 #include "options.h"
 
+#ifdef _DEBUG
+#include "debug.h"
+#endif
+
 namespace devilution {
 /**
  * @brief Set if the life flask needs to be redrawn during next frame
@@ -513,12 +517,18 @@ void ControlSetGoldCurs(PlayerStruct &player)
 
 void ResetTalkMsg()
 {
+#ifdef _DEBUG
+	if (CheckDebugTextCommand(TalkMessage))
+		return;
+#endif
+
 	uint32_t pmask = 0;
 
 	for (int i = 0; i < MAX_PLRS; i++) {
 		if (WhisperList[i])
 			pmask |= 1 << i;
 	}
+
 	NetSendCmdString(pmask, TalkMessage);
 }
 
@@ -659,7 +669,11 @@ bool GetSpellListSelection(spell_id &pSpell, spell_type &pSplType)
 
 bool IsChatAvailable()
 {
+#ifdef _DEBUG
+	return true;
+#else
 	return gbIsMultiplayer;
+#endif
 }
 
 } // namespace
@@ -2074,6 +2088,10 @@ void DiabloHotkeyMsg(uint32_t dwMsg)
 	assert(dwMsg < QUICK_MESSAGE_OPTIONS);
 
 	NetSendCmdString(0xFFFFFF, sgOptions.Chat.szHotKeyMsgs[dwMsg]);
+
+#ifdef _DEBUG
+	CheckDebugTextCommand(sgOptions.Chat.szHotKeyMsgs[dwMsg]);
+#endif
 }
 
 } // namespace devilution

--- a/Source/control.h
+++ b/Source/control.h
@@ -152,6 +152,7 @@ void control_type_message();
 void control_reset_talk();
 bool control_talk_last_key(char vkey);
 bool control_presskeys(int vkey);
+void DiabloHotkeyMsg(uint32_t dwMsg);
 
 extern Rectangle ChrBtnsRect[4];
 

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <string_view>
+
 #include "engine.h"
 #include "miniwin/miniwin.h"
 #include "utils/stdcompat/optional.hpp"
@@ -23,5 +25,6 @@ void PrintDebugPlayer(bool bNextPlayer);
 void PrintDebugQuest();
 void GetDebugMonster();
 void NextDebugMonster();
+bool CheckDebugTextCommand(const std::string_view text);
 
 } // namespace devilution

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -405,17 +405,6 @@ void RightMouseDown()
 	}
 }
 
-void DiabloHotkeyMsg(uint32_t dwMsg)
-{
-	if (!gbIsMultiplayer) {
-		return;
-	}
-
-	assert(dwMsg < QUICK_MESSAGE_OPTIONS);
-
-	NetSendCmdString(0xFFFFFF, sgOptions.Chat.szHotKeyMsgs[dwMsg]);
-}
-
 bool PressSysKey(int wParam)
 {
 	if (gmenu_is_active() || wParam != DVL_VK_F10)

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -267,9 +267,8 @@ void ShowProgress(interface_mode uMsg)
 		}
 		IncProgress();
 		FreeGameMem();
-		currlevel++;
+		currlevel = myPlayer.plrlevel;
 		leveltype = gnLevelTypeTbl[currlevel];
-		assert(myPlayer.plrlevel == currlevel);
 		IncProgress();
 		LoadGameLevel(false, ENTRY_MAIN);
 		IncProgress();


### PR DESCRIPTION
### Intro

This PR introduces something like a debug `console`.
In debug mode you can write chat text and this will be analyzed by `CheckDebugTextCommand`.
For this change it was necessary to allow chat in singleplayer (only in debug).
Change is inspired by @qndel #2128. 🙂 

<details><summary>Example Usage Video</summary>

https://user-images.githubusercontent.com/25415264/129446094-1dba7f03-29e8-45f4-a1ce-2e2dfe195ff1.mp4

</details>

### Notes
- Works only in debug and is not in production/release version.
- This PR lays the groundwork to easily add more debug commands.
- With this PR only some commands are realized. This list can be expanded in followup PRs.
- Many commands that are available per debug text commands have currently hard coded keys (for example `lvl up` command). The discussion if we want to have this hard coded keys remaining or not is not part of this pr.
- This PR introduces `warp to lvl`, `reset lvl` and `godmode` toggle.
- Includes help command 😉 
- It's also possible to use `QuickMessage` and debug text commands together. So only one click for godmode. 😜