### PR TITLE
2602 Use range-based for-loop for Quests

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -417,15 +417,15 @@ void FindTrigger()
 		}
 
 		if (pcurstrig == -1) {
-			for (int i = 0; i < MAXQUESTS; i++) {
-				if (i == Q_BETRAYER || currlevel != Quests[i]._qlevel || Quests[i]._qslvl == 0)
+			for (auto &quest : Quests) {
+				if (quest._qidx == Q_BETRAYER || currlevel != quest._qlevel || quest._qslvl == 0)
 					continue;
-				const int newDistance = GetDistance(Quests[i].position, 2);
+				const int newDistance = GetDistance(quest.position, 2);
 				if (newDistance == 0)
 					continue;
-				cursmx = Quests[i].position.x;
-				cursmy = Quests[i].position.y;
-				pcursquest = i;
+				cursmx = quest.position.x;
+				cursmy = quest.position.y;
+				pcursquest = quest._qidx;
 			}
 		}
 	}

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -276,7 +276,7 @@ void DeltaImportJunk(byte *src)
 
 	int q = 0;
 	for (auto &quest : Quests) {
-		if (!QuestData[quest._idx].isSinglePlayerOnly) {
+		if (!QuestData[quest._qidx].isSinglePlayerOnly) {
 			memcpy(&sgJunk.quests[q], src, sizeof(MultiQuests));
 			src += sizeof(MultiQuests);
 			quest._qlog = sgJunk.quests[q].qlog != 0;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -240,11 +240,11 @@ byte *DeltaExportJunk(byte *dst)
 	}
 
 	int q = 0;
-	for (int i = 0; i < MAXQUESTS; i++) {
-		if (!QuestData[i].isSinglePlayerOnly) {
-			sgJunk.quests[q].qlog = Quests[i]._qlog ? 1 : 0;
-			sgJunk.quests[q].qstate = Quests[i]._qactive;
-			sgJunk.quests[q].qvar1 = Quests[i]._qvar1;
+	for (auto &quest : Quests) {
+		if (!QuestData[q].isSinglePlayerOnly) {
+			sgJunk.quests[q].qlog = quest._qlog ? 1 : 0;
+			sgJunk.quests[q].qstate = quest._qactive;
+			sgJunk.quests[q].qvar1 = quest._qvar1;
 			memcpy(dst, &sgJunk.quests[q], sizeof(MultiQuests));
 			dst += sizeof(MultiQuests);
 			q++;
@@ -275,13 +275,13 @@ void DeltaImportJunk(byte *src)
 	}
 
 	int q = 0;
-	for (int i = 0; i < MAXQUESTS; i++) {
-		if (!QuestData[i].isSinglePlayerOnly) {
+	for (auto &quest : Quests) {
+		if (!QuestData[q].isSinglePlayerOnly) {
 			memcpy(&sgJunk.quests[q], src, sizeof(MultiQuests));
 			src += sizeof(MultiQuests);
-			Quests[i]._qlog = sgJunk.quests[q].qlog != 0;
-			Quests[i]._qactive = sgJunk.quests[q].qstate;
-			Quests[i]._qvar1 = sgJunk.quests[q].qvar1;
+			quest._qlog = sgJunk.quests[q].qlog != 0;
+			quest._qactive = sgJunk.quests[q].qstate;
+			quest._qvar1 = sgJunk.quests[q].qvar1;
 			q++;
 		}
 	}

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -276,7 +276,7 @@ void DeltaImportJunk(byte *src)
 
 	int q = 0;
 	for (auto &quest : Quests) {
-		if (!QuestData[q].isSinglePlayerOnly) {
+		if (!QuestData[quest._idx].isSinglePlayerOnly) {
 			memcpy(&sgJunk.quests[q], src, sizeof(MultiQuests));
 			src += sizeof(MultiQuests);
 			quest._qlog = sgJunk.quests[q].qlog != 0;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -241,7 +241,7 @@ byte *DeltaExportJunk(byte *dst)
 
 	int q = 0;
 	for (auto &quest : Quests) {
-		if (!QuestData[q].isSinglePlayerOnly) {
+		if (!QuestData[quest._qidx].isSinglePlayerOnly) {
 			sgJunk.quests[q].qlog = quest._qlog ? 1 : 0;
 			sgJunk.quests[q].qstate = quest._qactive;
 			sgJunk.quests[q].qvar1 = quest._qvar1;

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -269,10 +269,12 @@ void InitQuests()
 			quest._qactive = QUEST_NOTAVAIL;
 		}
 	} else {
-		for (int i = 0; i < MAXQUESTS; i++) {
-			if (QuestData[i].isSinglePlayerOnly) {
-				Quests[i]._qactive = QUEST_NOTAVAIL;
+		int q = 0;
+		for (auto &quest : Quests) {
+			if (QuestData[q].isSinglePlayerOnly) {
+				quest._qactive = QUEST_NOTAVAIL;
 			}
+			q++;
 		}
 	}
 
@@ -283,31 +285,33 @@ void InitQuests()
 	WaterDone = 0;
 	int initiatedQuests = 0;
 
-	for (int i = 0; i < MAXQUESTS; i++) {
-		if (gbIsMultiplayer && QuestData[i].isSinglePlayerOnly)
+	int q = 0;
+	for (auto &quest : Quests) {
+		if (gbIsMultiplayer && QuestData[q].isSinglePlayerOnly)
 			continue;
-		Quests[i]._qtype = QuestData[i]._qdtype;
+		quest._qtype = QuestData[q]._qdtype;
 		if (gbIsMultiplayer) {
-			Quests[i]._qlevel = QuestData[i]._qdmultlvl;
+			quest._qlevel = QuestData[q]._qdmultlvl;
 			if (!delta_quest_inited(initiatedQuests)) {
-				Quests[i]._qactive = QUEST_INIT;
-				Quests[i]._qvar1 = 0;
-				Quests[i]._qlog = false;
+				quest._qactive = QUEST_INIT;
+				quest._qvar1 = 0;
+				quest._qlog = false;
 			}
 			initiatedQuests++;
 		} else {
-			Quests[i]._qactive = QUEST_INIT;
-			Quests[i]._qlevel = QuestData[i]._qdlvl;
-			Quests[i]._qvar1 = 0;
-			Quests[i]._qlog = false;
+			quest._qactive = QUEST_INIT;
+			quest._qlevel = QuestData[q]._qdlvl;
+			quest._qvar1 = 0;
+			quest._qlog = false;
 		}
 
-		Quests[i]._qslvl = QuestData[i]._qslvl;
-		Quests[i].position = { 0, 0 };
-		Quests[i]._qidx = i;
-		Quests[i]._qlvltype = QuestData[i]._qlvlt;
-		Quests[i]._qvar2 = 0;
-		Quests[i]._qmsg = QuestData[i]._qdmsg;
+		quest._qslvl = QuestData[q]._qslvl;
+		quest.position = { 0, 0 };
+		quest._qidx = q;
+		quest._qlvltype = QuestData[q]._qlvlt;
+		quest._qvar2 = 0;
+		quest._qmsg = QuestData[q]._qdmsg;
+		q++;
 	}
 
 	if (!gbIsMultiplayer && sgOptions.Gameplay.bRandomizeQuests) {
@@ -425,11 +429,11 @@ bool ForceQuests()
 		return false;
 	}
 
-	for (int i = 0; i < MAXQUESTS; i++) {
-		if (i != Q_BETRAYER && currlevel == Quests[i]._qlevel && Quests[i]._qslvl != 0) {
-			int ql = Quests[Quests[i]._qidx]._qslvl - 1;
-			int qx = Quests[i].position.x;
-			int qy = Quests[i].position.y;
+	for (auto &quest : Quests) {
+		if (quest._qidx != Q_BETRAYER && currlevel == quest._qlevel && quest._qslvl != 0) {
+			int ql = quest._qslvl - 1;
+			int qx = quest.position.x;
+			int qy = quest.position.y;
 
 			for (int j = 0; j < 7; j++) {
 				if (qx + questxoff[j] == cursmx && qy + questyoff[j] == cursmy) {
@@ -517,9 +521,9 @@ void CheckQuestKill(const MonsterStruct &monster, bool sendmsg)
 
 void DRLG_CheckQuests(int x, int y)
 {
-	for (int i = 0; i < MAXQUESTS; i++) {
-		if (QuestStatus(static_cast<quest_id>(i))) {
-			switch (Quests[i]._qtype) {
+	for (auto &quest : Quests) {
+		if (QuestStatus(static_cast<quest_id>(quest._qidx))) {
+			switch (quest._qtype) {
 			case Q_BUTCHER:
 				DrawButcher();
 				break;
@@ -536,10 +540,10 @@ void DRLG_CheckQuests(int x, int y)
 				DrawWarLord(x, y);
 				break;
 			case Q_SKELKING:
-				DrawSkelKing(i, x, y);
+				DrawSkelKing(quest._qidx, x, y);
 				break;
 			case Q_SCHAMB:
-				DrawSChamber(i, x, y);
+				DrawSChamber(quest._qidx, x, y);
 				break;
 			}
 		}
@@ -743,9 +747,9 @@ void DrawQuestLog(const Surface &out)
 void StartQuestlog()
 {
 	numqlines = 0;
-	for (int i = 0; i < MAXQUESTS; i++) {
-		if (Quests[i]._qactive == QUEST_ACTIVE && Quests[i]._qlog) {
-			qlist[numqlines] = i;
+	for (auto &quest : Quests) {
+		if (quest._qactive == QUEST_ACTIVE && quest._qlog) {
+			qlist[numqlines] = quest._qidx;
 			numqlines++;
 		}
 	}

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -287,30 +287,30 @@ void InitQuests()
 
 	int q = 0;
 	for (auto &quest : Quests) {
-		if (gbIsMultiplayer && QuestData[q].isSinglePlayerOnly)
-			continue;
-		quest._qtype = QuestData[q]._qdtype;
-		if (gbIsMultiplayer) {
-			quest._qlevel = QuestData[q]._qdmultlvl;
-			if (!delta_quest_inited(initiatedQuests)) {
+		if (!gbIsMultiplayer || !QuestData[q].isSinglePlayerOnly) {
+			quest._qtype = QuestData[q]._qdtype;
+			if (gbIsMultiplayer) {
+				quest._qlevel = QuestData[q]._qdmultlvl;
+				if (!delta_quest_inited(initiatedQuests)) {
+					quest._qactive = QUEST_INIT;
+					quest._qvar1 = 0;
+					quest._qlog = false;
+				}
+				initiatedQuests++;
+			} else {
 				quest._qactive = QUEST_INIT;
+				quest._qlevel = QuestData[q]._qdlvl;
 				quest._qvar1 = 0;
 				quest._qlog = false;
 			}
-			initiatedQuests++;
-		} else {
-			quest._qactive = QUEST_INIT;
-			quest._qlevel = QuestData[q]._qdlvl;
-			quest._qvar1 = 0;
-			quest._qlog = false;
-		}
 
-		quest._qslvl = QuestData[q]._qslvl;
-		quest.position = { 0, 0 };
-		quest._qidx = q;
-		quest._qlvltype = QuestData[q]._qlvlt;
-		quest._qvar2 = 0;
-		quest._qmsg = QuestData[q]._qdmsg;
+			quest._qslvl = QuestData[q]._qslvl;
+			quest.position = { 0, 0 };
+			quest._qidx = q;
+			quest._qlvltype = QuestData[q]._qlvlt;
+			quest._qvar2 = 0;
+			quest._qmsg = QuestData[q]._qdmsg;
+		}
 		q++;
 	}
 

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -1206,8 +1206,8 @@ void StartTalk()
 	}
 
 	int sn = 0;
-	for (int i = 0; i < MAXQUESTS; i++) {
-		if (Quests[i]._qactive == QUEST_ACTIVE && QuestDialogTable[talker][i] != TEXT_NONE && Quests[i]._qlog)
+	for (auto &quest : Quests) {
+		if (quest._qactive == QUEST_ACTIVE && QuestDialogTable[talker][quest._qidx] != TEXT_NONE && quest._qlog)
 			sn++;
 	}
 
@@ -1221,9 +1221,9 @@ void StartTalk()
 
 	int sn2 = sn - 2;
 
-	for (int i = 0; i < MAXQUESTS; i++) {
-		if (Quests[i]._qactive == QUEST_ACTIVE && QuestDialogTable[talker][i] != TEXT_NONE && Quests[i]._qlog) {
-			AddSText(0, sn, _(QuestData[i]._qlstr), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
+	for (auto &quest : Quests) {
+		if (quest._qactive == QUEST_ACTIVE && QuestDialogTable[talker][quest._qidx] != TEXT_NONE && quest._qlog) {
+			AddSText(0, sn, _(QuestData[quest._qidx]._qlstr), UiFlags::ColorSilver | UiFlags::AlignCenter, true);
 			sn += la;
 		}
 	}
@@ -2051,8 +2051,8 @@ void TalkEnter()
 	}
 
 	int sn = 0;
-	for (int i = 0; i < MAXQUESTS; i++) {
-		if (Quests[i]._qactive == QUEST_ACTIVE && QuestDialogTable[talker][i] != TEXT_NONE && Quests[i]._qlog)
+	for (auto &quest : Quests) {
+		if (quest._qactive == QUEST_ACTIVE && QuestDialogTable[talker][quest._qidx] != TEXT_NONE && quest._qlog)
 			sn++;
 	}
 	int la = 2;
@@ -2070,10 +2070,10 @@ void TalkEnter()
 		return;
 	}
 
-	for (int i = 0; i < MAXQUESTS; i++) {
-		if (Quests[i]._qactive == QUEST_ACTIVE && QuestDialogTable[talker][i] != TEXT_NONE && Quests[i]._qlog) {
+	for (auto &quest : Quests) {
+		if (quest._qactive == QUEST_ACTIVE && QuestDialogTable[talker][quest._qidx] != TEXT_NONE && quest._qlog) {
 			if (sn == stextsel) {
-				InitQTextMsg(QuestDialogTable[talker][i]);
+				InitQTextMsg(QuestDialogTable[talker][quest._qidx]);
 			}
 			sn += la;
 		}


### PR DESCRIPTION
Use range-based for-loop for Quests based on @AJenbo 's comment https://github.com/diasurgical/devilutionX/pull/2602#issuecomment-899109164

> Also it seams to be possible to use a range-loop in `ForceQuests()`, which would make it more robust :
> 
> ```c++
> bool ForceQuests()
> {
> ...
> 
> 	for (int i = 0; i < MAXQUESTS; i++) {
> 		if (i != Q_BETRAYER && currlevel == Quests[i]._qlevel && Quests[i]._qslvl != 0) {
> 			int ql = Quests[Quests[i]._qidx]._qslvl - 1;
> 			int qx = Quests[i].position.x;
> 			int qy = Quests[i].position.y;
> ...
> 		}
> 	}
> ...
> }
> ```
> 
> ->
> 
> ```c++
> bool ForceQuests()
> {
> ...
> 	for (auto &quest : Quests) {
> 		if (quest._qidx != Q_BETRAYER && currlevel == quest._qlevel && quest._qslvl != 0) {
> 			int ql = quest._qslvl - 1;
> 			int qx = quest.position.x;
> 			int qy = quest.position.y;
> ...
> 		}
> 	}
> ...
> }
> ```

