### PR TITLE
CMake: fix linking against libsodium statically

### DIFF
--- a/CMake/Findsodium.cmake
+++ b/CMake/Findsodium.cmake
@@ -55,26 +55,26 @@ if (UNIX OR CMAKE_SYSTEM_NAME STREQUAL "Generic" OR AMIGA)
     endif()
 
     if(sodium_USE_STATIC_LIBS)
-    if(sodium_PKG_STATIC_LIBRARIES)
+      if(sodium_PKG_STATIC_LIBRARIES)
         foreach(_libname ${sodium_PKG_STATIC_LIBRARIES})
-            if (NOT _libname MATCHES "^lib.*\\.a$") # ignore strings already ending with .a
-                list(INSERT sodium_PKG_STATIC_LIBRARIES 0 "lib${_libname}.a")
-            endif()
+          if (NOT _libname MATCHES "^lib.*\\.a$") # ignore strings already ending with .a
+            list(INSERT sodium_PKG_STATIC_LIBRARIES 0 "lib${_libname}.a")
+          endif()
         endforeach()
         list(REMOVE_DUPLICATES sodium_PKG_STATIC_LIBRARIES)
-    else()
+      else()
         # if pkgconfig for libsodium doesn't provide
         # static lib info, then override PKG_STATIC here..
-            set(sodium_PKG_STATIC_LIBRARIES libsodium.a)
-        endif()
+        set(sodium_PKG_STATIC_LIBRARIES libsodium.a)
+      endif()
 
-        set(XPREFIX sodium_PKG_STATIC)
+      set(XPREFIX sodium_PKG_STATIC)
     else()
-    if(sodium_PKG_LIBRARIES STREQUAL "")
-            set(sodium_PKG_LIBRARIES sodium)
-        endif()
+      if(sodium_PKG_LIBRARIES STREQUAL "")
+        set(sodium_PKG_LIBRARIES sodium)
+      endif()
 
-        set(XPREFIX sodium_PKG)
+      set(XPREFIX sodium_PKG)
     endif()
 
     find_path(sodium_INCLUDE_DIR sodium.h

--- a/CMake/Findsodium.cmake
+++ b/CMake/Findsodium.cmake
@@ -56,12 +56,19 @@ if (UNIX OR CMAKE_SYSTEM_NAME STREQUAL "Generic" OR AMIGA)
 
     if(sodium_USE_STATIC_LIBS)
       if(sodium_PKG_STATIC_LIBRARIES)
+	# Create a temporary list to manipulate the list of libraries we found
+	set(sodium_PKG_STATIC_LIBRARIES_TMP "")
+
+	# Mangle the library names into the format we need
         foreach(_libname ${sodium_PKG_STATIC_LIBRARIES})
           if (NOT _libname MATCHES "^lib.*\\.a$") # ignore strings already ending with .a
-            list(INSERT sodium_PKG_STATIC_LIBRARIES 0 "lib${_libname}.a")
+            list(APPEND sodium_PKG_STATIC_LIBRARIES_TMP "lib${_libname}.a")
           endif()
         endforeach()
-        list(REMOVE_DUPLICATES sodium_PKG_STATIC_LIBRARIES)
+
+        list(REMOVE_DUPLICATES sodium_PKG_STATIC_LIBRARIES_TMP)
+	# Replace the list with our processed one
+	set(sodium_PKG_STATIC_LIBRARIES ${sodium_PKG_STATIC_LIBRARIES_TMP})
       else()
         # if pkgconfig for libsodium doesn't provide
         # static lib info, then override PKG_STATIC here..
@@ -77,6 +84,8 @@ if (UNIX OR CMAKE_SYSTEM_NAME STREQUAL "Generic" OR AMIGA)
       set(XPREFIX sodium_PKG)
     endif()
 
+    # Feed pkgconfig results (if found) into standard find_* to populate
+    # the right CMake cache variables
     find_path(sodium_INCLUDE_DIR sodium.h
         HINTS ${${XPREFIX}_INCLUDE_DIRS}
     )

--- a/docs/building.md
+++ b/docs/building.md
@@ -7,6 +7,9 @@ cmake .. -DVERSION_NUM=1.0.0 -DVERSION_SUFFIX=FFFFFFF -DCMAKE_BUILD_TYPE=Release
 
 <details><summary>Linux</summary>
 
+Note that ```pkg-config``` is an optional dependency for finding libsodium,
+although we have a fallback if necessary.
+
 ### Installing dependencies on Debian and Ubuntu
 ```
 sudo apt-get install cmake g++ libsdl2-ttf-dev libsodium-dev


### PR DESCRIPTION
Our previous processing would throw away all but the last
entry in the found STATIC_LIBRARIES, which in newer versions
of libsodium, might be "pthread" -- hence not trying to link
against libsodium at all.

We now generate a temporary list, mangle it, then return that.

Bug: https://bugs.gentoo.org/791031
Fixes: https://github.com/diasurgical/devilutionX/issues/2615
Signed-off-by: Sam James <sam@gentoo.org>
