### PR TITLE
Replace dMissiles with BFLAG_MISSILE

### DIFF
--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -58,7 +58,6 @@ int16_t dMonster[MAXDUNX][MAXDUNY];
 int8_t dDead[MAXDUNX][MAXDUNY];
 char dObject[MAXDUNX][MAXDUNY];
 int8_t dItem[MAXDUNX][MAXDUNY];
-int8_t dMissile[MAXDUNX][MAXDUNY];
 char dSpecial[MAXDUNX][MAXDUNY];
 int themeCount;
 THEME_LOC themeLoc[MAXTHEMES];
@@ -568,7 +567,6 @@ void DRLG_Init_Globals()
 	memset(dDead, 0, sizeof(dDead));
 	memset(dObject, 0, sizeof(dObject));
 	memset(dItem, 0, sizeof(dItem));
-	memset(dMissile, 0, sizeof(dMissile));
 	memset(dSpecial, 0, sizeof(dSpecial));
 	int8_t c = DisableLighting ? 0 : 15;
 	memset(dLight, c, sizeof(dLight));

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -219,8 +219,6 @@ extern int8_t dDead[MAXDUNX][MAXDUNY];
 extern char dObject[MAXDUNX][MAXDUNY];
 /** Contains the item numbers (items array indices) of the map. */
 extern int8_t dItem[MAXDUNX][MAXDUNY];
-/** Contains the missile numbers (missiles array indices) of the map. */
-extern int8_t dMissile[MAXDUNX][MAXDUNY];
 /**
  * Contains the arch frame numbers of the map from the special tileset
  * (e.g. "levels/l1data/l1s.cel"). Note, the special tileset of Tristram (i.e.

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -149,11 +149,6 @@ void PutMissile(int8_t i)
 
 	dFlags[position.x][position.y] |= BFLAG_MISSILE;
 
-	if (dMissile[position.x][position.y] == 0)
-		dMissile[position.x][position.y] = i + 1;
-	else
-		dMissile[position.x][position.y] = -1;
-
 	if (missile._miPreFlag)
 		MissilePreFlag = true;
 }
@@ -638,7 +633,7 @@ bool MissilesFoundTarget(MissileStruct &missile, Point *position, int rad)
 				continue;
 
 			int dp = dPiece[tx][ty];
-			if (nSolidTable[dp] || dObject[tx][ty] != 0 || dMissile[tx][ty] != 0)
+			if (nSolidTable[dp] || dObject[tx][ty] != 0 || (dFlags[i][j] & BFLAG_MISSILE) != 0)
 				continue;
 
 			missile.position.tile = { tx, ty };
@@ -2179,7 +2174,7 @@ void AddTown(int mi, Point /*src*/, Point dst, int /*midir*/, int8_t /*mienemy*/
 				ty = dst.y + CrawlTable[ck];
 				if (InDungeonBounds({ tx, ty })) {
 					int dp = dPiece[tx][ty];
-					if (dMissile[tx][ty] == 0 && !nSolidTable[dp] && !nMissileTable[dp] && dObject[tx][ty] == 0 && dPlayer[tx][ty] == 0) {
+					if ((dFlags[i][j] & BFLAG_MISSILE) == 0 && !nSolidTable[dp] && !nMissileTable[dp] && dObject[tx][ty] == 0 && dPlayer[tx][ty] == 0) {
 						if (!CheckIfTrig({ tx, ty })) {
 							missile.position.tile = { tx, ty };
 							missile.position.start = { tx, ty };
@@ -2292,7 +2287,7 @@ void AddGuardian(int mi, Point src, Point dst, int /*midir*/, int8_t /*mienemy*/
 			k = dPiece[tx][ty];
 			if (InDungeonBounds({ tx, ty })) {
 				if (LineClearMissile(src, { tx, ty })) {
-					if (dMonster[tx][ty] == 0 && !nSolidTable[k] && !nMissileTable[k] && dObject[tx][ty] == 0 && dMissile[tx][ty] == 0) {
+					if (dMonster[tx][ty] == 0 && !nSolidTable[k] && !nMissileTable[k] && dObject[tx][ty] == 0 && (dFlags[i][j] & BFLAG_MISSILE) == 0) {
 						missile.position.tile = { tx, ty };
 						missile.position.start = { tx, ty };
 						missile._miDelFlag = false;
@@ -4611,7 +4606,6 @@ void ProcessMissiles()
 		auto &missile = Missiles[ActiveMissiles[i]];
 		const auto &position = missile.position.tile;
 		dFlags[position.x][position.y] &= ~BFLAG_MISSILE;
-		dMissile[position.x][position.y] = 0;
 		if (!InDungeonBounds(position))
 			missile._miDelFlag = true;
 	}
@@ -4666,11 +4660,17 @@ void missiles_process_charge()
 	}
 }
 
+void RedoMissileFlags()
+{
+	for (int i = 0; i < ActiveMissileCount; i++) {
+		PutMissile(ActiveMissiles[i]);
+	}
+}
+
 void ClearMissileSpot(const MissileStruct &missile)
 {
 	const Point tile = missile.position.tile;
 	dFlags[tile.x][tile.y] &= ~BFLAG_MISSILE;
-	dMissile[tile.x][tile.y] = 0;
 }
 
 } // namespace devilution

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -268,6 +268,7 @@ void MI_ResurrectBeam(int i);
 void MI_Rportal(int i);
 void ProcessMissiles();
 void missiles_process_charge();
+void RedoMissileFlags();
 void ClearMissileSpot(const MissileStruct &missile);
 
 } // namespace devilution

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -2009,28 +2009,21 @@ bool IsTileSafe(const MonsterStruct &monster, Point position)
 		return true;
 	}
 
-	bool fire = false;
-	bool lightning = false;
+	bool fearsFire = (monster.mMagicRes & IMMUNE_FIRE) == 0 || monster.MType->mtype == MT_DIABLO;
+	bool fearsLightning = (monster.mMagicRes & IMMUNE_LIGHTNING) == 0 || monster.MType->mtype == MT_DIABLO;
 
 	for (int j = 0; j < ActiveMissileCount; j++) {
 		uint8_t mi = ActiveMissiles[j];
 		auto &missile = Missiles[mi];
 		if (missile.position.tile == position) {
-			if (missile._mitype == MIS_FIREWALL) {
-				fire = true;
-				break;
+			if (fearsFire && missile._mitype == MIS_FIREWALL) {
+				return false;
 			}
-			if (missile._mitype == MIS_LIGHTWALL) {
-				lightning = true;
-				break;
+			if (fearsLightning && missile._mitype == MIS_LIGHTWALL) {
+				return false;
 			}
 		}
 	}
-
-	if (fire && ((monster.mMagicRes & IMMUNE_FIRE) == 0 || monster.MType->mtype == MT_DIABLO))
-		return false;
-	if (lightning && ((monster.mMagicRes & IMMUNE_LIGHTNING) == 0 || monster.MType->mtype == MT_DIABLO))
-		return false;
 
 	return true;
 }

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -2005,33 +2005,24 @@ bool RandomWalk2(int i, Direction md)
  */
 bool IsTileSafe(const MonsterStruct &monster, Point position)
 {
-	int8_t mi = dMissile[position.x][position.y];
-	if (mi == 0) {
+	if ((dFlags[position.x][position.y] & BFLAG_MISSILE) == 0) {
 		return true;
 	}
 
 	bool fire = false;
 	bool lightning = false;
-	if (mi > 0) {
-		auto &missile = Missiles[mi - 1]; // BUGFIX: Change 'mi' to 'mi - 1' (fixed)
-		if (missile._mitype == MIS_FIREWALL) {
-			fire = true;
-		} else if (missile._mitype == MIS_LIGHTWALL) {
-			lightning = true;
-		}
-	} else {
-		for (int j = 0; j < ActiveMissileCount; j++) {
-			mi = ActiveMissiles[j];
-			auto &missile = Missiles[mi];
-			if (missile.position.tile == position) {
-				if (missile._mitype == MIS_FIREWALL) {
-					fire = true;
-					break;
-				}
-				if (missile._mitype == MIS_LIGHTWALL) {
-					lightning = true;
-					break;
-				}
+
+	for (int j = 0; j < ActiveMissileCount; j++) {
+		uint8_t mi = ActiveMissiles[j];
+		auto &missile = Missiles[mi];
+		if (missile.position.tile == position) {
+			if (missile._mitype == MIS_FIREWALL) {
+				fire = true;
+				break;
+			}
+			if (missile._mitype == MIS_LIGHTWALL) {
+				lightning = true;
+				break;
 			}
 		}
 	}

--- a/Source/portal.cpp
+++ b/Source/portal.cpp
@@ -47,21 +47,19 @@ void SetPortalStats(int i, bool o, int x, int y, int lvl, dungeon_type lvltype)
 
 void AddWarpMissile(int i, int x, int y)
 {
-	int mi;
-
 	MissileData[MIS_TOWN].mlSFX = SFX_NONE;
-	dMissile[x][y] = 0;
-	mi = AddMissile({ 0, 0 }, { x, y }, 0, MIS_TOWN, TARGET_MONSTERS, i, 0, 0);
 
-	if (mi != -1) {
-		auto &missile = Missiles[mi];
-		SetMissDir(missile, 1);
+	int mi = AddMissile({ 0, 0 }, { x, y }, 0, MIS_TOWN, TARGET_MONSTERS, i, 0, 0);
+	if (mi == -1)
+		return;
 
-		if (currlevel != 0)
-			missile._mlid = AddLight(missile.position.tile, 15);
+	auto &missile = Missiles[mi];
+	SetMissDir(missile, 1);
 
-		MissileData[MIS_TOWN].mlSFX = LS_SENTINEL;
-	}
+	if (currlevel != 0)
+		missile._mlid = AddLight(missile.position.tile, 15);
+
+	MissileData[MIS_TOWN].mlSFX = LS_SENTINEL;
 }
 
 void SyncPortals()
@@ -118,7 +116,6 @@ void RemovePortalMissile(int id)
 		auto &missile = Missiles[mi];
 		if (missile._mitype == MIS_TOWN && missile._misource == id) {
 			dFlags[missile.position.tile.x][missile.position.tile.y] &= ~BFLAG_MISSILE;
-			dMissile[missile.position.tile.x][missile.position.tile.y] = 0;
 
 			if (Portals[id].level != 0)
 				AddUnLight(missile._mlid);


### PR DESCRIPTION
This is prep that lets us change most missile functions to use MissileStruct as the input rather then an index in a follow up PR.

@bcko once this is merged you can try and change all the missile add functions if you like :)