### PR TITLE
items: add BUGFIX, reset item get records when resetting items

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -127,8 +127,13 @@ enum class PlayerArmorGraphic : uint8_t {
 	// clang-format on
 };
 ItemStruct curruitem;
+
+/** Holds item get records, tracking items being recently looted. This is in an effort to prevent items being picked up more than once. */
 ItemGetRecordStruct itemrecord[MAXITEMS];
+
 bool itemhold[3][3];
+
+/** gnNumGetRecords specifies the number of active item get records. */
 int gnNumGetRecords;
 
 int OilLevels[] = { 1, 10, 1, 10, 4, 1, 5, 17, 1, 10 };
@@ -2628,6 +2633,9 @@ void InitItems()
 	}
 
 	ShowUniqueItemInfoBox = false;
+
+	// BUGFIX: item get records not reset when resetting items (fixed).
+	initItemGetRecords();
 }
 
 void CalcPlrItemVals(int playerId, bool loadgfx)
@@ -4962,6 +4970,15 @@ void ItemStruct::SetNewAnimation(bool showAnimation)
 		_iAnimFlag = false;
 		_iSelFlag = 1;
 	}
+}
+
+/**
+ * @brief Resets item get records.
+ */
+void initItemGetRecords()
+{
+	memset(itemrecord, 0, sizeof(itemrecord));
+	gnNumGetRecords = 0;
 }
 
 } // namespace devilution

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -133,7 +133,7 @@ ItemGetRecordStruct itemrecord[MAXITEMS];
 
 bool itemhold[3][3];
 
-/** gnNumGetRecords specifies the number of active item get records. */
+/** Specifies the number of active item get records. */
 int gnNumGetRecords;
 
 int OilLevels[] = { 1, 10, 1, 10, 4, 1, 5, 17, 1, 10 };

--- a/Source/items.h
+++ b/Source/items.h
@@ -466,6 +466,7 @@ void CreateMagicWeapon(Point position, int imisc, int icurs, bool sendmsg, bool 
 bool GetItemRecord(int nSeed, uint16_t wCI, int nIndex);
 void SetItemRecord(int nSeed, uint16_t wCI, int nIndex);
 void PutItemRecord(int nSeed, uint16_t wCI, int nIndex);
+void initItemGetRecords();
 
 #ifdef _DEBUG
 std::string DebugSpawnItem(std::string itemName, bool unique);


### PR DESCRIPTION
The item get record array tracks items being recently looted in an
effort to prevent the same item from being looted more than once.
Prior to this commit, the item get record array (and corresponding
item get record array length) variables were not cleared when
creating a new game. Therefore, the item get record array of a
previous game could remain in between games and prevent an item
from being looted (if it was looted in a previous), even if it was
never looted in the current game. In practice this almost never
shows up, since each item get record is valid for a total of 6
seconds before being cleared. So, you would either have to save
a game, quickly loot an item, when load the game and try to loot
the same item before 6 seconds pass. OR, you could use the demo
replay functionality to run test cases, and speed up execution to
run e.g. 10'000'000 logic ticks per second. Both would exhibit the
bug and prevent the item from being looted.

This commit fixes such issues by explicitly clearing the item get
record array and item get record array length variables whenever
items are initialized.