### PR TITLE
fix coords jumping when in inventory

### DIFF
--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -276,17 +276,9 @@ void CheckCursMove()
 
 	if (CanPanelsCoverView()) {
 		if (chrflag || QuestLogIsOpen) {
-			if (sx >= gnScreenWidth / 2) { /// BUGFIX: (sx >= gnScreenWidth / 2) (fixed)
-				sx -= gnScreenWidth / 4;
-			} else {
-				sx = 0;
-			}
+			sx -= gnScreenWidth / 4;
 		} else if (invflag || sbookflag) {
-			if (sx <= gnScreenWidth / 2) {
-				sx += gnScreenWidth / 4;
-			} else {
-				sx = 0;
-			}
+			sx += gnScreenWidth / 4;
 		}
 	}
 	if (sy > PANEL_TOP - 1 && MousePosition.x >= PANEL_LEFT && MousePosition.x < PANEL_LEFT + PANEL_WIDTH && track_isscrolling()) {


### PR DESCRIPTION

![walkleft](https://user-images.githubusercontent.com/14297035/130848515-f6def5e4-619f-425a-b3cc-8c399130e4cd.gif)
![shitaim](https://user-images.githubusercontent.com/14297035/130848204-760b40f5-1d06-4a99-92a1-a5f04ff3566e.gif)

Fixes these 2 issues, it was a vanilla bug, cursmx/cursmy were being way off when inside the panels but nothing in the panels made use of it except casting a targetted scroll then aiming inside inventory and "hold to keep clicking" introduced another way to bug it - move it to inventory while walking and you suddenly changed directions because cursmx/cursmy were somewhere offscreen southwest.