### PR TITLE
Fix inaccurate gameplay with NOSOUND

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -401,12 +401,10 @@ void UiHandleEvents(SDL_Event *event)
 			gbActive = false;
 		} else if (event->window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
 			ReinitializeHardwareCursor();
-#ifndef NOSOUND
 		} else if (event->window.event == SDL_WINDOWEVENT_FOCUS_LOST) {
 			music_mute();
 		} else if (event->window.event == SDL_WINDOWEVENT_FOCUS_GAINED) {
 			music_unmute();
-#endif
 		}
 	}
 #endif

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -53,6 +53,7 @@
 #include "qol/itemlabels.h"
 #include "restrict.h"
 #include "setmaps.h"
+#include "sound.h"
 #include "stores.h"
 #include "storm/storm.h"
 #include "themes.h"
@@ -64,9 +65,6 @@
 #include "utils/language.h"
 #include "utils/paths.h"
 
-#ifndef NOSOUND
-#include "sound.h"
-#endif
 #ifdef GPERF_HEAP_FIRST_GAME_ITERATION
 #include <gperftools/heap-profiler.h>
 #endif
@@ -952,10 +950,8 @@ void DiabloInit()
 
 	DiabloInitScreen();
 
-#ifndef NOSOUND
 	snd_init();
 	was_snd_init = true;
-#endif
 
 	ui_sound_init();
 
@@ -990,9 +986,7 @@ void DiabloDeinit()
 		SaveOptions();
 	if (was_snd_init)
 		effects_cleanup_sfx();
-#ifndef NOSOUND
 	snd_deinit();
-#endif
 	if (was_ui_init)
 		UiDestroy();
 	if (was_archives_init)
@@ -1687,9 +1681,7 @@ void diablo_focus_pause()
 		LastMouseButtonAction = MouseActionType::None;
 	}
 
-#ifndef NOSOUND
 	music_mute();
-#endif
 
 	MinimizePaused = true;
 }
@@ -1704,9 +1696,7 @@ void diablo_focus_unpause()
 		PauseMode = 0;
 	}
 
-#ifndef NOSOUND
 	music_unmute();
-#endif
 
 	MinimizePaused = false;
 }
@@ -2039,9 +2029,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 		music_start(leveltype);
 
 	if (MinimizePaused) {
-#ifndef NOSOUND
 		music_mute();
-#endif
 	}
 
 	while (!IncProgress())

--- a/Source/effects.h
+++ b/Source/effects.h
@@ -1186,9 +1186,6 @@ void effects_cleanup_sfx();
 void sound_init();
 void ui_sound_init();
 void effects_play_sound(const char *sndFile);
-
-#ifndef NOSOUND
 int GetSFXLength(int nSFX);
-#endif
 
 } // namespace devilution

--- a/Source/effects_stubs.cpp
+++ b/Source/effects_stubs.cpp
@@ -53,6 +53,7 @@ void effects_cleanup_sfx() { }
 void sound_init() { }
 void ui_sound_init() { }
 void effects_play_sound(const char *snd_file) { }
+int GetSFXLength(int nSFX) { return 0; }
 // clang-format off
 
 } // namespace devilution

--- a/Source/effects_stubs.cpp
+++ b/Source/effects_stubs.cpp
@@ -1,6 +1,8 @@
 // Stubbed implementations of effects for the NOSOUND mode.
 #include "effects.h"
 
+#include "engine/random.hpp"
+
 namespace devilution {
 int sfxdelay;
 _sfx_id sfxdnum;
@@ -13,8 +15,38 @@ void stream_stop() { }
 void InitMonsterSND(int monst) { }
 void FreeMonsterSnd() { }
 bool CalculateSoundPosition(Point soundPosition, int *plVolume, int *plPan) { return false; }
-void PlaySFX(_sfx_id psfx) { }
-void PlaySfxLoc(_sfx_id psfx, Point position, bool randomizeByCategory) { }
+void PlaySFX(_sfx_id psfx)
+{
+	switch (psfx) {
+	case PS_WARR69:
+	case PS_MAGE69:
+	case PS_ROGUE69:
+	case PS_MONK69:
+	case PS_SWING:
+	case LS_ACID:
+	case IS_FMAG:
+	case IS_MAGIC:
+	case IS_BHIT:
+	case PS_WARR14:
+	case PS_WARR15:
+	case PS_WARR16:
+	case PS_WARR2:
+	case PS_ROGUE14:
+	case PS_MAGE14:
+	case PS_MONK14:
+		AdvanceRndSeed();
+		break;
+	default:
+		break;
+	}
+}
+void PlaySfxLoc(_sfx_id psfx, Point position, bool randomizeByCategory)
+{
+	if (!randomizeByCategory)
+		return;
+
+	PlaySFX(psfx);
+}
 void sound_stop() { }
 void sound_update() { }
 void effects_cleanup_sfx() { }

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -12,11 +12,8 @@
 #include "loadsave.h"
 #include "options.h"
 #include "pfile.h"
-#include "utils/language.h"
-
-#ifndef NOSOUND
 #include "sound.h"
-#endif
+#include "utils/language.h"
 
 namespace devilution {
 namespace {
@@ -117,7 +114,6 @@ void GamemenuRestartTown(bool /*bActivate*/)
 
 void GamemenuSoundMusicToggle(const char *const *names, TMenuItem *menuItem, int volume)
 {
-#ifndef NOSOUND
 	if (gbSndInited) {
 		menuItem->dwFlags |= GMENU_ENABLED | GMENU_SLIDER;
 		menuItem->pszStr = names[0];
@@ -125,18 +121,15 @@ void GamemenuSoundMusicToggle(const char *const *names, TMenuItem *menuItem, int
 		gmenu_slider_set(menuItem, VOLUME_MIN, VOLUME_MAX, volume);
 		return;
 	}
-#endif
 
 	menuItem->dwFlags &= ~(GMENU_ENABLED | GMENU_SLIDER);
 	menuItem->pszStr = names[1];
 }
 
-#ifndef NOSOUND
 int GamemenuSliderMusicSound(TMenuItem *menuItem)
 {
 	return gmenu_slider_get(menuItem, VOLUME_MIN, VOLUME_MAX);
 }
-#endif
 
 void GamemenuGetMusic()
 {
@@ -192,7 +185,6 @@ void GamemenuOptions(bool /*bActivate*/)
 
 void GamemenuMusicVolume(bool bActivate)
 {
-#ifndef NOSOUND
 	if (bActivate) {
 		if (gbMusicOn) {
 			gbMusicOn = false;
@@ -232,13 +224,12 @@ void GamemenuMusicVolume(bool bActivate)
 			music_start(lt);
 		}
 	}
-#endif
+
 	GamemenuGetMusic();
 }
 
 void GamemenuSoundVolume(bool bActivate)
 {
-#ifndef NOSOUND
 	if (bActivate) {
 		if (gbSoundOn) {
 			gbSoundOn = false;
@@ -262,7 +253,6 @@ void GamemenuSoundVolume(bool bActivate)
 	}
 	PlaySFX(IS_TITLEMOV);
 	GamemenuGetSound();
-#endif
 }
 
 void GamemenuGamma(bool bActivate)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -7,6 +7,9 @@
 
 #include <algorithm>
 #include <bitset>
+#ifdef _DEBUG
+#include <chrono>
+#endif
 #include <climits>
 #include <cstdint>
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1025,7 +1025,6 @@ Direction16 GetDirection16(Point p1, Point p2)
 
 void DeleteMissile(int mi, int i)
 {
-	auto &missile = Missiles[mi];
 	AvailableMissiles[MAXMISSILES - ActiveMissileCount] = mi;
 	ActiveMissileCount--;
 	if (ActiveMissileCount > 0 && i != ActiveMissileCount)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4749,7 +4749,6 @@ void PlayEffect(MonsterStruct &monster, int mode)
 	}
 
 	int sndIdx = GenerateRnd(2);
-#ifndef NOSOUND
 	if (!gbSndInited || !gbSoundOn || gbBufferMsgs != 0) {
 		return;
 	}
@@ -4766,7 +4765,6 @@ void PlayEffect(MonsterStruct &monster, int mode)
 		return;
 
 	snd_play_snd(snd, lVolume, lPan);
-#endif
 }
 
 void MissToMonst(int i, Point position)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4744,12 +4744,12 @@ void PrintUniqueHistory()
 
 void PlayEffect(MonsterStruct &monster, int mode)
 {
-#ifndef NOSOUND
 	if (Players[MyPlayerId].pLvlLoad != 0) {
 		return;
 	}
 
 	int sndIdx = GenerateRnd(2);
+#ifndef NOSOUND
 	if (!gbSndInited || !gbSoundOn || gbBufferMsgs != 0) {
 		return;
 	}

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -16,12 +16,9 @@
 #include "miniwin/miniwin.h"
 #include "utils/stdcompat/optional.hpp"
 #include "monstdat.h"
+#include "sound.h"
 #include "spelldat.h"
 #include "textdat.h"
-
-#ifndef NOSOUND
-#include "sound.h"
-#endif
 
 namespace devilution {
 
@@ -152,9 +149,7 @@ struct CMonster {
 	{
 		return Anims[static_cast<int>(graphic)];
 	}
-#ifndef NOSOUND
 	std::unique_ptr<TSnd> Snds[4][2];
-#endif
 	uint16_t mMinHP;
 	uint16_t mMaxHP;
 	uint8_t mAFNum;

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -8,12 +8,9 @@
 #include "effects.h"
 #include "engine/demomode.h"
 #include "hwcursor.hpp"
+#include "sound.h"
 #include "storm/storm_svid.h"
 #include "utils/display.h"
-
-#ifndef NOSOUND
-#include "sound.h"
-#endif
 
 namespace devilution {
 
@@ -34,11 +31,9 @@ void play_movie(const char *pszMovie, bool userCanClose)
 
 	movie_playing = true;
 
-#ifndef NOSOUND
 	sound_disable_music(true);
 	stream_stop();
 	effects_play_sound("Sfx\\Misc\\blank.wav");
-#endif
 
 	if (IsHardwareCursorEnabled()) {
 		SetHardwareCursorVisible(false);
@@ -66,9 +61,7 @@ void play_movie(const char *pszMovie, bool userCanClose)
 		SVidPlayEnd();
 	}
 
-#ifndef NOSOUND
 	sound_disable_music(false);
-#endif
 
 	movie_playing = false;
 

--- a/Source/mpqapi.h
+++ b/Source/mpqapi.h
@@ -12,7 +12,7 @@
 namespace devilution {
 
 struct _FILEHEADER {
-	int signature;
+	uint32_t signature;
 	int headersize;
 	uint32_t filesize;
 	uint16_t version;

--- a/Source/sound.cpp
+++ b/Source/sound.cpp
@@ -184,13 +184,11 @@ std::unique_ptr<TSnd> sound_file_load(const char *path, bool stream)
 	return snd;
 }
 
-#ifndef NOSOUND
 TSnd::~TSnd()
 {
 	DSB.Stop();
 	DSB.Release();
 }
-#endif
 
 void snd_init()
 {

--- a/Source/sound.h
+++ b/Source/sound.h
@@ -40,17 +40,23 @@ enum _music_id : uint8_t {
 };
 
 struct TSnd {
+	uint32_t start_tc;
+
 #ifndef NOSOUND
 	SoundSample DSB;
-	Uint32 start_tc;
 
 	bool isPlaying()
 	{
 		return DSB.IsPlaying();
 	}
+#else
+	bool isPlaying()
+	{
+		return false;
+	}
+#endif
 
 	~TSnd();
-#endif
 };
 
 extern bool gbSndInited;

--- a/Source/sound_stubs.cpp
+++ b/Source/sound_stubs.cpp
@@ -11,10 +11,8 @@ bool gbSoundOn;
 // AllowShortFunctionsOnASingleLine: None
 // clang-format off
 void ClearDuplicateSounds() { }
-void snd_stop_snd(TSnd *pSnd) { }
 void snd_play_snd(TSnd *pSnd, int lVolume, int lPan) { }
 std::unique_ptr<TSnd> sound_file_load(const char *path, bool stream) { return nullptr; }
-void sound_file_cleanup(TSnd *sound_file) { }
 void snd_init() { }
 void snd_deinit() { }
 void music_stop() { }

--- a/Source/sound_stubs.cpp
+++ b/Source/sound_stubs.cpp
@@ -13,6 +13,9 @@ bool gbSoundOn;
 void ClearDuplicateSounds() { }
 void snd_play_snd(TSnd *pSnd, int lVolume, int lPan) { }
 std::unique_ptr<TSnd> sound_file_load(const char *path, bool stream) { return nullptr; }
+TSnd::~TSnd()
+{
+}
 void snd_init() { }
 void snd_deinit() { }
 void music_stop() { }
@@ -20,6 +23,8 @@ void music_start(uint8_t nTrack) { }
 void sound_disable_music(bool disable) { }
 int sound_get_or_set_music_volume(int volume) { return 0; }
 int sound_get_or_set_sound_volume(int volume) { return 0; }
+void music_mute() { }
+void music_unmute() { }
 // clang-format on
 
 } // namespace devilution

--- a/Source/storm/storm_svid.cpp
+++ b/Source/storm/storm_svid.cpp
@@ -111,7 +111,7 @@ void TrySetVideoModeToSVidForSDL1()
 #endif
 
 #ifndef NOSOUND
-bool HaveAudio()
+bool HasAudio()
 {
 	return SVidAudioStream && SVidAudioStream->isPlaying();
 }
@@ -280,7 +280,7 @@ bool SVidPlayContinue()
 	}
 
 #ifndef NOSOUND
-	if (HaveAudio()) {
+	if (HasAudio()) {
 		const auto len = smk_get_audio_size(SVidSMK, 0);
 		const unsigned char *buf = smk_get_audio(SVidSMK, 0);
 		if (SVidAudioDepth == 16) {
@@ -360,7 +360,7 @@ bool SVidPlayContinue()
 void SVidPlayEnd()
 {
 #ifndef NOSOUND
-	if (HaveAudio()) {
+	if (HasAudio()) {
 		SVidAudioStream = std::nullopt;
 		SVidAudioDecoder = nullptr;
 	}


### PR DESCRIPTION
There where 3 calls to `GenerateRnd()` which would not get triggered if the game was compiled without sound support, which resulted in the game-play diverging from a full build.