### PR TITLE
Tidyups

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -4379,10 +4379,4 @@ void RedoMissileFlags()
 	}
 }
 
-void ClearMissileSpot(const MissileStruct &missile)
-{
-	const Point tile = missile.position.tile;
-	dFlags[tile.x][tile.y] &= ~BFLAG_MISSILE;
-}
-
 } // namespace devilution

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -268,6 +268,5 @@ void MI_Rportal(MissileStruct &missile);
 void ProcessMissiles();
 void missiles_process_charge();
 void RedoMissileFlags();
-void ClearMissileSpot(const MissileStruct &missile);
 
 } // namespace devilution


### PR DESCRIPTION
`UpdateFIreball()` was originally created to deduplicate `MI_Fireball` and `MI_Immolation`, but MI_Immolation was dead code and has been removed previously, so we can now revert `MI_Fireball` to it original state without having code duplication as a consequence.

`ClearMissileSpot` was only used by Manashield which has since been rewritten no longer need it :wave: 