### PR TITLE
Fix AppVeyor badge build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ We hope to provide a good starting point for mods, in addition to the full Devil
 If you want to help test the latest state of the next version you can fetch the build artifact from one of the build server:
 
 [![CircleCI](https://circleci.com/gh/diasurgical/devilutionX.svg?style=shield)](https://circleci.com/gh/diasurgical/devilutionX)
-[![AppVeyor](https://ci.appveyor.com/api/projects/status/1a0jus2372qvksht?svg=true)](https://ci.appveyor.com/project/AJenbo/devilutionx)
+[![AppVeyor](https://ci.appveyor.com/api/projects/status/1a0jus2372qvksht/branch/master?svg=true)](https://ci.appveyor.com/project/AJenbo/devilutionx)
 [![Linux_x86](https://github.com/diasurgical/devilutionX/actions/workflows/Linux_x86.yml/badge.svg)](https://github.com/diasurgical/devilutionX/actions/workflows/Linux_x86.yml)
 [![Linux_x86_64](https://github.com/diasurgical/devilutionX/actions/workflows/Linux_x86_64.yml/badge.svg)](https://github.com/diasurgical/devilutionX/actions/workflows/Linux_x86_64.yml)
 [![Linux_x86_64_SDL1](https://github.com/diasurgical/devilutionX/actions/workflows/Linux_x86_64_SDL1.yml/badge.svg)](https://github.com/diasurgical/devilutionX/actions/workflows/Linux_x86_64_SDL1.yml)


### PR DESCRIPTION
I noticed today that the AppVeyor badge under the `Test builds` section of the readme shows a status of "failing" because of the latest build on the zt branch. This PR simply modifies the badge URL to show only the status for the master branch.