### PR TITLE
objects: deduplicate logic in OperateShrineGloomy using ForEachItem function

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -2174,7 +2174,7 @@ bool DropItemBeforeTrig()
  * @param player Player with equipped, inventory and belt items.
  * @param f Function to invoke on each non-empty item of the player.
  */
-void InventoryForEachItem(PlayerStruct &player, ItemFunc f)
+void ForEachInventoryItem(PlayerStruct &player, ItemFunc f)
 {
 	// Equipped items.
 	for (auto &item : player.InvBody) {

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -126,7 +126,7 @@ bool UseInvItem(int pnum, int cii);
 void DoTelekinesis();
 int CalculateGold(PlayerStruct &player);
 bool DropItemBeforeTrig();
-void InventoryForEachItem(PlayerStruct &player, ItemFunc f);
+void ForEachInventoryItem(PlayerStruct &player, ItemFunc f);
 
 /* data */
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2678,7 +2678,7 @@ bool OperateShrineGloomy(int pnum)
 	auto &player = Players[pnum];
 
 	// Increment armor class by 2 and decrements max damage by 1.
-	InventoryForEachItem(player, [](ItemStruct &item) {
+	ForEachInventoryItem(player, [](ItemStruct &item) {
 		switch (item._itype) {
 		case ITYPE_SWORD:
 		case ITYPE_AXE:


### PR DESCRIPTION
This commit is intended as a proposal for refactoring and
simplifying code dealing with player equipped, inventory
and belt items. Several functions contain a lot of
duplicated logic to handle these three item lists of players.

With this commit, the ForEachItem function is introduced which
is intended to help deduplicate logic when handling player
items.

NOTE: The code has not been tested in game, so a demo replay which
interact with a Gloomy shrine would be preferable prior to merge :)