### PR TITLE
Fix bugs in AddRndTeleport

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1873,15 +1873,11 @@ void AddRndTeleport(MissileStruct &missile, Point dst, Direction /*midir*/)
 
 	auto &player = Players[missile._misource];
 
-	if (setlevel && setlvlnum == SL_VILEBETRAYER) {
-		int oi = dObject[dst.x][dst.y] - 1;
-		// BUGFIX: should only run magic circle check if dObject[dx][dy] is non-zero.
-		if (Objects[oi]._otype == OBJ_MCIRCLE1 || Objects[oi]._otype == OBJ_MCIRCLE2) {
-			missile.position.tile = dst;
-			if (!PosOkPlayer(player, dst))
-				UpdateVileMissPos(missile, dst);
-			return;
-		}
+	if (missile._micaster == TARGET_BOTH) {
+		missile.position.tile = dst;
+		if (!PosOkPlayer(player, dst))
+			UpdateVileMissPos(missile, dst);
+		return;
 	}
 
 	std::array<Point, 13 * 13 - 7 * 7> targets;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3049,22 +3049,7 @@ bool OperateShrineHoly(int pnum)
 	if (deltaload)
 		return false;
 
-	auto &player = Players[pnum];
-
-	int j = 0;
-	int xx;
-	int yy;
-	uint32_t lv;
-	do {
-		xx = GenerateRnd(MAXDUNX);
-		yy = GenerateRnd(MAXDUNY);
-		lv = dPiece[xx][yy];
-		j++;
-		if (j > MAXDUNX * MAXDUNY)
-			break;
-	} while (nSolidTable[lv] || dObject[xx][yy] != 0 || dMonster[xx][yy] != 0);
-
-	AddMissile(player.position.tile, { xx, yy }, player._pdir, MIS_RNDTELEPORT, TARGET_PLAYERS, pnum, 0, 2 * leveltype);
+	AddMissile(Players[pnum].position.tile, { 0, 0 }, DIR_S, MIS_RNDTELEPORT, TARGET_PLAYERS, pnum, 0, 2 * leveltype);
 
 	if (pnum != MyPlayerId)
 		return false;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1474,7 +1474,7 @@ void UpdateCircle(int i)
 		ObjChangeMapResync(Objects[i]._oVar1, Objects[i]._oVar2, Objects[i]._oVar3, Objects[i]._oVar4);
 		if (Quests[Q_BETRAYER]._qactive == QUEST_ACTIVE && Quests[Q_BETRAYER]._qvar1 <= 4) // BUGFIX stepping on the circle again will break the quest state (fixed)
 			Quests[Q_BETRAYER]._qvar1 = 4;
-		AddMissile(myPlayer.position.tile, { 35, 46 }, myPlayer._pdir, MIS_RNDTELEPORT, TARGET_MONSTERS, MyPlayerId, 0, 0);
+		AddMissile(myPlayer.position.tile, { 35, 46 }, DIR_S, MIS_RNDTELEPORT, TARGET_BOTH, MyPlayerId, 0, 0);
 		LastMouseButtonAction = MouseActionType::None;
 		sgbMouseDown = CLICK_NONE;
 		ClrPlrPath(myPlayer);
@@ -2207,7 +2207,7 @@ void OperateBook(int pnum, int i)
 			}
 			if (doAddMissile) {
 				Objects[dObject[35][36] - 1]._oVar5++;
-				AddMissile(player.position.tile, { dx, dy }, player._pdir, MIS_RNDTELEPORT, TARGET_MONSTERS, pnum, 0, 0);
+				AddMissile(player.position.tile, { dx, dy }, DIR_S, MIS_RNDTELEPORT, TARGET_BOTH, pnum, 0, 0);
 				missileAdded = true;
 				doAddMissile = false;
 			}


### PR DESCRIPTION
Phasing could end up attempting to teleport to hunreds of random
location and still fail to find a valid target and send the player in to
a wall or outside the map.

This is fixed by first finding all valid locations within range and then
picking one of them at random.

Valid targets is a 13x13 area around the player minus the inner 7x7

In total there can be no more then 120 valid tiles and on average there
should be 75 avalible.

----------

Previously an improper check was being done to see if the player was
located on the 3 teleporting pads in the level. Even if fixng this the
spell would not work correctly if the layer was standing on the pads
when casting the spell.

Simply use TARGET_BOTH to indicate that it should not be random and send
the player to the given destination