### PR TITLE
Demo: Decouple recording and playback resolution

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -78,6 +78,19 @@ Rectangle LeftPanel;
 Rectangle RightPanel;
 std::optional<OwnedSurface> pBtmBuff;
 
+const Rectangle &GetMainPanel()
+{
+	return MainPanel;
+}
+const Rectangle &GetLeftPanel()
+{
+	return LeftPanel;
+}
+const Rectangle &GetRightPanel()
+{
+	return RightPanel;
+}
+
 extern std::array<Keymapper::ActionIndex, 4> quickSpellActionIndexes;
 
 /** Maps from attribute_id to the rectangle on screen used for attribute increment buttons. */
@@ -900,15 +913,15 @@ Point GetPanelPosition(UiPanels panel, Point offset)
 
 	switch (panel) {
 	case UiPanels::Main:
-		return MainPanel.position + displacement;
+		return GetMainPanel().position + displacement;
 	case UiPanels::Quest:
 	case UiPanels::Character:
-		return LeftPanel.position + displacement;
+		return GetLeftPanel().position + displacement;
 	case UiPanels::Spell:
 	case UiPanels::Inventory:
-		return RightPanel.position + displacement;
+		return GetRightPanel().position + displacement;
 	default:
-		return MainPanel.position + displacement;
+		return GetMainPanel().position + displacement;
 	}
 }
 
@@ -1126,18 +1139,20 @@ void ClearPanBtn()
 
 void DoPanBtn()
 {
+	auto &mainPanelPosition = GetMainPanel().position;
+
 	for (int i = 0; i < PanelButtonIndex; i++) {
-		int x = PanBtnPos[i].x + PANEL_LEFT + PanBtnPos[i].w;
-		int y = PanBtnPos[i].y + PANEL_TOP + PanBtnPos[i].h;
-		if (MousePosition.x >= PanBtnPos[i].x + PANEL_LEFT && MousePosition.x <= x) {
-			if (MousePosition.y >= PanBtnPos[i].y + PANEL_TOP && MousePosition.y <= y) {
+		int x = PanBtnPos[i].x + mainPanelPosition.x + PanBtnPos[i].w;
+		int y = PanBtnPos[i].y + mainPanelPosition.y + PanBtnPos[i].h;
+		if (MousePosition.x >= PanBtnPos[i].x + mainPanelPosition.x && MousePosition.x <= x) {
+			if (MousePosition.y >= PanBtnPos[i].y + mainPanelPosition.y && MousePosition.y <= y) {
 				PanelButtons[i] = true;
 				drawbtnflag = true;
 				panbtndown = true;
 			}
 		}
 	}
-	if (!spselflag && MousePosition.x >= 565 + PANEL_LEFT && MousePosition.x < 621 + PANEL_LEFT && MousePosition.y >= 64 + PANEL_TOP && MousePosition.y < 120 + PANEL_TOP) {
+	if (!spselflag && MousePosition.x >= 565 + mainPanelPosition.x && MousePosition.x < 621 + mainPanelPosition.x && MousePosition.y >= 64 + mainPanelPosition.y && MousePosition.y < 120 + mainPanelPosition.y) {
 		if ((SDL_GetModState() & KMOD_SHIFT) != 0) {
 			auto &myPlayer = Players[MyPlayerId];
 			myPlayer._pRSpell = SPL_INVALID;
@@ -1152,19 +1167,20 @@ void DoPanBtn()
 
 void control_check_btn_press()
 {
-	int x = PanBtnPos[3].x + PANEL_LEFT + PanBtnPos[3].w;
-	int y = PanBtnPos[3].y + PANEL_TOP + PanBtnPos[3].h;
-	if (MousePosition.x >= PanBtnPos[3].x + PANEL_LEFT
+	auto &mainPanelPosition = GetMainPanel().position;
+	int x = PanBtnPos[3].x + mainPanelPosition.x + PanBtnPos[3].w;
+	int y = PanBtnPos[3].y + mainPanelPosition.y + PanBtnPos[3].h;
+	if (MousePosition.x >= PanBtnPos[3].x + mainPanelPosition.x
 	    && MousePosition.x <= x
-	    && MousePosition.y >= PanBtnPos[3].y + PANEL_TOP
+	    && MousePosition.y >= PanBtnPos[3].y + mainPanelPosition.y
 	    && MousePosition.y <= y) {
 		SetButtonStateDown(3);
 	}
-	x = PanBtnPos[6].x + PANEL_LEFT + PanBtnPos[6].w;
-	y = PanBtnPos[6].y + PANEL_TOP + PanBtnPos[6].h;
-	if (MousePosition.x >= PanBtnPos[6].x + PANEL_LEFT
+	x = PanBtnPos[6].x + mainPanelPosition.x + PanBtnPos[6].w;
+	y = PanBtnPos[6].y + mainPanelPosition.y + PanBtnPos[6].h;
+	if (MousePosition.x >= PanBtnPos[6].x + mainPanelPosition.x
 	    && MousePosition.x <= x
-	    && MousePosition.y >= PanBtnPos[6].y + PANEL_TOP
+	    && MousePosition.y >= PanBtnPos[6].y + mainPanelPosition.y
 	    && MousePosition.y <= y) {
 		SetButtonStateDown(6);
 	}
@@ -1185,11 +1201,12 @@ void DoAutoMap()
 void CheckPanelInfo()
 {
 	panelflag = false;
+	auto &mainPanelPosition = GetMainPanel().position;
 	ClearPanel();
 	for (int i = 0; i < PanelButtonIndex; i++) {
-		int xend = PanBtnPos[i].x + PANEL_LEFT + PanBtnPos[i].w;
-		int yend = PanBtnPos[i].y + PANEL_TOP + PanBtnPos[i].h;
-		if (MousePosition.x >= PanBtnPos[i].x + PANEL_LEFT && MousePosition.x <= xend && MousePosition.y >= PanBtnPos[i].y + PANEL_TOP && MousePosition.y <= yend) {
+		int xend = PanBtnPos[i].x + mainPanelPosition.x + PanBtnPos[i].w;
+		int yend = PanBtnPos[i].y + mainPanelPosition.y + PanBtnPos[i].h;
+		if (MousePosition.x >= PanBtnPos[i].x + mainPanelPosition.x && MousePosition.x <= xend && MousePosition.y >= PanBtnPos[i].y + mainPanelPosition.y && MousePosition.y <= yend) {
 			if (i != 7) {
 				strcpy(infostr, _(PanBtnStr[i]));
 			} else {
@@ -1206,7 +1223,7 @@ void CheckPanelInfo()
 			panelflag = true;
 		}
 	}
-	if (!spselflag && MousePosition.x >= 565 + PANEL_LEFT && MousePosition.x < 621 + PANEL_LEFT && MousePosition.y >= 64 + PANEL_TOP && MousePosition.y < 120 + PANEL_TOP) {
+	if (!spselflag && MousePosition.x >= 565 + mainPanelPosition.x && MousePosition.x < 621 + mainPanelPosition.x && MousePosition.y >= 64 + mainPanelPosition.y && MousePosition.y < 120 + mainPanelPosition.y) {
 		strcpy(infostr, _("Select current spell button"));
 		InfoColor = UiFlags::ColorWhite;
 		panelflag = true;
@@ -1251,7 +1268,7 @@ void CheckPanelInfo()
 			}
 		}
 	}
-	if (MousePosition.x > 190 + PANEL_LEFT && MousePosition.x < 437 + PANEL_LEFT && MousePosition.y > 4 + PANEL_TOP && MousePosition.y < 33 + PANEL_TOP)
+	if (MousePosition.x > 190 + mainPanelPosition.x && MousePosition.x < 437 + mainPanelPosition.x && MousePosition.y > 4 + mainPanelPosition.y && MousePosition.y < 33 + mainPanelPosition.y)
 		pcursinvitem = CheckInvHLight();
 
 	if (CheckXPBarInfo()) {
@@ -1262,6 +1279,8 @@ void CheckPanelInfo()
 void CheckBtnUp()
 {
 	bool gamemenuOff = true;
+	auto &mainPanelPosition = GetMainPanel().position;
+
 	drawbtnflag = true;
 	panbtndown = false;
 
@@ -1272,10 +1291,10 @@ void CheckBtnUp()
 
 		PanelButtons[i] = false;
 
-		if (MousePosition.x < PanBtnPos[i].x + PANEL_LEFT
-		    || MousePosition.x > PanBtnPos[i].x + PANEL_LEFT + PanBtnPos[i].w
-		    || MousePosition.y < PanBtnPos[i].y + PANEL_TOP
-		    || MousePosition.y > PanBtnPos[i].y + PANEL_TOP + PanBtnPos[i].h) {
+		if (MousePosition.x < PanBtnPos[i].x + mainPanelPosition.x
+		    || MousePosition.x > PanBtnPos[i].x + mainPanelPosition.x + PanBtnPos[i].w
+		    || MousePosition.y < PanBtnPos[i].y + mainPanelPosition.y
+		    || MousePosition.y > PanBtnPos[i].y + mainPanelPosition.y + PanBtnPos[i].h) {
 			continue;
 		}
 
@@ -1416,13 +1435,15 @@ void DrawInfoBox(const Surface &out)
 
 void CheckLvlBtn()
 {
-	if (!lvlbtndown && MousePosition.x >= 40 + PANEL_LEFT && MousePosition.x <= 81 + PANEL_LEFT && MousePosition.y >= -39 + PANEL_TOP && MousePosition.y <= -17 + PANEL_TOP)
+	auto &mainPanelPosition = GetMainPanel().position;
+	if (!lvlbtndown && MousePosition.x >= 40 + mainPanelPosition.x && MousePosition.x <= 81 + mainPanelPosition.x && MousePosition.y >= -39 + mainPanelPosition.y && MousePosition.y <= -17 + mainPanelPosition.y)
 		lvlbtndown = true;
 }
 
 void ReleaseLvlBtn()
 {
-	if (MousePosition.x >= 40 + PANEL_LEFT && MousePosition.x <= 81 + PANEL_LEFT && MousePosition.y >= -39 + PANEL_TOP && MousePosition.y <= -17 + PANEL_TOP) {
+	auto &mainPanelPosition = GetMainPanel().position;
+	if (MousePosition.x >= 40 + mainPanelPosition.x && MousePosition.x <= 81 + mainPanelPosition.x && MousePosition.y >= -39 + mainPanelPosition.y && MousePosition.y <= -17 + mainPanelPosition.y) {
 		QuestLogIsOpen = false;
 		chrflag = true;
 	}
@@ -1605,7 +1626,7 @@ void CheckSBook()
 	Rectangle iconArea = { GetPanelPosition(UiPanels::Spell, { 11, 18 }), { 48 - 11, 314 - 18 } };
 	Rectangle tabArea = { GetPanelPosition(UiPanels::Spell, { 7, 320 }), { 311 - 7, 349 - 320 } };
 	if (iconArea.Contains(MousePosition)) {
-		spell_id sn = SpellPages[sbooktab][(MousePosition.y - RightPanel.position.y - 18) / 43];
+		spell_id sn = SpellPages[sbooktab][(MousePosition.y - GetRightPanel().position.y - 18) / 43];
 		auto &myPlayer = Players[MyPlayerId];
 		uint64_t spl = myPlayer._pMemSpells | myPlayer._pISpells | myPlayer._pAblSpells;
 		if (sn != SPL_INVALID && (spl & GetSpellBitmask(sn)) != 0) {
@@ -1622,7 +1643,7 @@ void CheckSBook()
 		}
 	}
 	if (tabArea.Contains(MousePosition)) {
-		sbooktab = (MousePosition.x - (RightPanel.position.x + 7)) / (gbIsHellfire ? 61 : 76);
+		sbooktab = (MousePosition.x - (GetRightPanel().position.x + 7)) / (gbIsHellfire ? 61 : 76);
 	}
 }
 
@@ -1752,20 +1773,22 @@ bool control_check_talk_btn()
 	if (!talkflag)
 		return false;
 
-	if (MousePosition.x < 172 + PANEL_LEFT)
+	auto &mainPanelPosition = GetMainPanel().position;
+
+	if (MousePosition.x < 172 + mainPanelPosition.x)
 		return false;
-	if (MousePosition.y < 69 + PANEL_TOP)
+	if (MousePosition.y < 69 + mainPanelPosition.y)
 		return false;
-	if (MousePosition.x > 233 + PANEL_LEFT)
+	if (MousePosition.x > 233 + mainPanelPosition.x)
 		return false;
-	if (MousePosition.y > 123 + PANEL_TOP)
+	if (MousePosition.y > 123 + mainPanelPosition.y)
 		return false;
 
 	for (bool &talkButtonDown : TalkButtonsDown) {
 		talkButtonDown = false;
 	}
 
-	TalkButtonsDown[(MousePosition.y - (69 + PANEL_TOP)) / 18] = true;
+	TalkButtonsDown[(MousePosition.y - (69 + mainPanelPosition.y)) / 18] = true;
 
 	return true;
 }
@@ -1778,10 +1801,12 @@ void control_release_talk_btn()
 	for (bool &talkButtonDown : TalkButtonsDown)
 		talkButtonDown = false;
 
-	if (MousePosition.x < 172 + PANEL_LEFT || MousePosition.y < 69 + PANEL_TOP || MousePosition.x > 233 + PANEL_LEFT || MousePosition.y > 123 + PANEL_TOP)
+	auto &mainPanelPosition = GetMainPanel().position;
+
+	if (MousePosition.x < 172 + mainPanelPosition.x || MousePosition.y < 69 + mainPanelPosition.y || MousePosition.x > 233 + mainPanelPosition.x || MousePosition.y > 123 + mainPanelPosition.y)
 		return;
 
-	int off = (MousePosition.y - (69 + PANEL_TOP)) / 18;
+	int off = (MousePosition.y - (69 + mainPanelPosition.y)) / 18;
 
 	int p = 0;
 	for (; p < MAX_PLRS && off != -1; p++) {

--- a/Source/control.h
+++ b/Source/control.h
@@ -57,9 +57,9 @@ extern bool panelflag;
 extern int initialDropGoldValue;
 extern bool panbtndown;
 extern bool spselflag;
-extern Rectangle MainPanel;
-extern Rectangle LeftPanel;
-extern Rectangle RightPanel;
+const Rectangle &GetMainPanel();
+const Rectangle &GetLeftPanel();
+const Rectangle &GetRightPanel();
 extern std::optional<OwnedSurface> pBtmBuff;
 extern SDL_Rect PanBtnPos[8];
 
@@ -69,7 +69,7 @@ bool IsChatAvailable();
  */
 inline bool CanPanelsCoverView()
 {
-	return gnScreenWidth <= PANEL_WIDTH && gnScreenHeight <= SPANEL_HEIGHT + PANEL_HEIGHT;
+	return GetScreenWidth() <= PANEL_WIDTH && GetScreenHeight() <= SPANEL_HEIGHT + PANEL_HEIGHT;
 }
 
 void DrawSpellList(const Surface &out);

--- a/Source/controls/touch/event_handlers.cpp
+++ b/Source/controls/touch/event_handlers.cpp
@@ -33,7 +33,7 @@ void SimulateMouseMovement(const SDL_Event &event)
 {
 	Point position = ScaleToScreenCoordinates(event.tfinger.x, event.tfinger.y);
 
-	if (!spselflag && invflag && !MainPanel.Contains(position) && !RightPanel.Contains(position))
+	if (!spselflag && invflag && !GetMainPanel().Contains(position) && !GetRightPanel().Contains(position))
 		return;
 
 	MousePosition = position;

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -248,9 +248,9 @@ void CheckCursMove()
 
 	if (CanPanelsCoverView()) {
 		if (chrflag || QuestLogIsOpen) {
-			sx -= gnScreenWidth / 4;
+			sx -= GetScreenWidth() / 4;
 		} else if (invflag || sbookflag) {
-			sx += gnScreenWidth / 4;
+			sx += GetScreenWidth() / 4;
 		}
 	}
 	if (sy > PANEL_TOP - 1 && MousePosition.x >= PANEL_LEFT && MousePosition.x < PANEL_LEFT + PANEL_WIDTH && track_isscrolling()) {

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -253,8 +253,8 @@ void CheckCursMove()
 			sx += GetScreenWidth() / 4;
 		}
 	}
-	if (sy > PANEL_TOP - 1 && MousePosition.x >= PANEL_LEFT && MousePosition.x < PANEL_LEFT + PANEL_WIDTH && track_isscrolling()) {
-		sy = PANEL_TOP - 1;
+	if (sy > GetMainPanel().position.y - 1 && MousePosition.x >= GetMainPanel().position.x && MousePosition.x < GetMainPanel().position.x + PANEL_WIDTH && track_isscrolling()) {
+		sy = GetMainPanel().position.y - 1;
 	}
 
 	if (!zoomflag) {
@@ -380,21 +380,21 @@ void CheckCursMove()
 		cursPosition = { mx, my };
 		return;
 	}
-	if (MainPanel.Contains(MousePosition)) {
+	if (GetMainPanel().Contains(MousePosition)) {
 		CheckPanelInfo();
 		return;
 	}
 	if (DoomFlag) {
 		return;
 	}
-	if (invflag && RightPanel.Contains(MousePosition)) {
+	if (invflag && GetRightPanel().Contains(MousePosition)) {
 		pcursinvitem = CheckInvHLight();
 		return;
 	}
-	if (sbookflag && RightPanel.Contains(MousePosition)) {
+	if (sbookflag && GetRightPanel().Contains(MousePosition)) {
 		return;
 	}
-	if ((chrflag || QuestLogIsOpen) && LeftPanel.Contains(MousePosition)) {
+	if ((chrflag || QuestLogIsOpen) && GetLeftPanel().Contains(MousePosition)) {
 		return;
 	}
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -210,7 +210,7 @@ void LeftMouseCmd(bool bShift)
 {
 	bool bNear;
 
-	assert(MousePosition.y < PANEL_TOP || MousePosition.x < PANEL_LEFT || MousePosition.x >= PANEL_LEFT + PANEL_WIDTH);
+	assert(MousePosition.y < GetMainPanel().position.y || MousePosition.x < GetMainPanel().position.x || MousePosition.x >= GetMainPanel().position.x + PANEL_WIDTH);
 
 	if (leveltype == DTYPE_TOWN) {
 		if (pcursitem != -1 && pcurs == CURSOR_HAND)
@@ -312,19 +312,19 @@ void LeftMouseDown(int wParam)
 	bool isShiftHeld = (wParam & DVL_MK_SHIFT) != 0;
 	bool isCtrlHeld = (wParam & DVL_MK_CTRL) != 0;
 
-	if (!MainPanel.Contains(MousePosition)) {
+	if (!GetMainPanel().Contains(MousePosition)) {
 		if (!gmenu_is_active() && !TryIconCurs()) {
-			if (QuestLogIsOpen && LeftPanel.Contains(MousePosition)) {
+			if (QuestLogIsOpen && GetLeftPanel().Contains(MousePosition)) {
 				QuestlogESC();
 			} else if (qtextflag) {
 				qtextflag = false;
 				stream_stop();
-			} else if (chrflag && LeftPanel.Contains(MousePosition)) {
+			} else if (chrflag && GetLeftPanel().Contains(MousePosition)) {
 				CheckChrBtns();
-			} else if (invflag && RightPanel.Contains(MousePosition)) {
+			} else if (invflag && GetRightPanel().Contains(MousePosition)) {
 				if (!dropGoldFlag)
 					CheckInvItem(isShiftHeld, isCtrlHeld);
-			} else if (sbookflag && RightPanel.Contains(MousePosition)) {
+			} else if (sbookflag && GetRightPanel().Contains(MousePosition)) {
 				CheckSBook();
 			} else if (pcurs >= CURSOR_FIRSTITEM) {
 				if (TryInvPut()) {
@@ -380,7 +380,7 @@ void RightMouseDown(bool isShiftHeld)
 		SetSpell();
 		return;
 	}
-	if ((!sbookflag || !RightPanel.Contains(MousePosition))
+	if ((!sbookflag || !GetRightPanel().Contains(MousePosition))
 	    && !TryIconCurs()
 	    && (pcursinvitem == -1 || !UseInvItem(MyPlayerId, pcursinvitem))) {
 		if (pcurs == CURSOR_HAND) {
@@ -1263,11 +1263,11 @@ void InventoryKeyPressed()
 	invflag = !invflag;
 	if (!chrflag && !QuestLogIsOpen && CanPanelsCoverView()) {
 		if (!invflag) { // We closed the invetory
-			if (MousePosition.x < 480 && MousePosition.y < PANEL_TOP) {
+			if (MousePosition.x < 480 && MousePosition.y < GetMainPanel().position.y) {
 				SetCursorPos(MousePosition + Displacement { 160, 0 });
 			}
 		} else if (!sbookflag) { // We opened the invetory
-			if (MousePosition.x > 160 && MousePosition.y < PANEL_TOP) {
+			if (MousePosition.x > 160 && MousePosition.y < GetMainPanel().position.y) {
 				SetCursorPos(MousePosition - Displacement { 160, 0 });
 			}
 		}
@@ -1282,11 +1282,11 @@ void CharacterSheetKeyPressed()
 	chrflag = !chrflag;
 	if (!invflag && !sbookflag && CanPanelsCoverView()) {
 		if (!chrflag) { // We closed the character sheet
-			if (MousePosition.x > 160 && MousePosition.y < PANEL_TOP) {
+			if (MousePosition.x > 160 && MousePosition.y < GetMainPanel().position.y) {
 				SetCursorPos(MousePosition - Displacement { 160, 0 });
 			}
 		} else if (!QuestLogIsOpen) { // We opened the character sheet
-			if (MousePosition.x < 480 && MousePosition.y < PANEL_TOP) {
+			if (MousePosition.x < 480 && MousePosition.y < GetMainPanel().position.y) {
 				SetCursorPos(MousePosition + Displacement { 160, 0 });
 			}
 		}
@@ -1340,11 +1340,11 @@ void SpellBookKeyPressed()
 	sbookflag = !sbookflag;
 	if (!chrflag && !QuestLogIsOpen && CanPanelsCoverView()) {
 		if (!sbookflag) { // We closed the invetory
-			if (MousePosition.x < 480 && MousePosition.y < PANEL_TOP) {
+			if (MousePosition.x < 480 && MousePosition.y < GetMainPanel().position.y) {
 				SetCursorPos(MousePosition + Displacement { 160, 0 });
 			}
 		} else if (!invflag) { // We opened the invetory
-			if (MousePosition.x > 160 && MousePosition.y < PANEL_TOP) {
+			if (MousePosition.x > 160 && MousePosition.y < GetMainPanel().position.y) {
 				SetCursorPos(MousePosition - Displacement { 160, 0 });
 			}
 		}

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -307,13 +307,13 @@ bool gmenu_left_mouse(bool isDown)
 	if (sgpCurrentMenu == nullptr) {
 		return false;
 	}
-	if (MousePosition.y >= PANEL_TOP) {
+	if (MousePosition.y >= MainPanel.position.y) {
 		return false;
 	}
-	if (MousePosition.y - (117 + UI_OFFSET_Y) < 0) {
+	if (MousePosition.y - (117 + GetUIOffsetY()) < 0) {
 		return true;
 	}
-	int i = (MousePosition.y - (117 + UI_OFFSET_Y)) / 45;
+	int i = (MousePosition.y - (117 + GetUIOffsetY())) / 45;
 	if (i >= sgCurrentMenuIdx) {
 		return true;
 	}
@@ -322,10 +322,11 @@ bool gmenu_left_mouse(bool isDown)
 		return true;
 	}
 	int w = GmenuGetLineWidth(pItem);
-	if (MousePosition.x < gnScreenWidth / 2 - w / 2) {
+	uint16_t screenWidth = GetScreenWidth();
+	if (MousePosition.x < screenWidth / 2 - w / 2) {
 		return true;
 	}
-	if (MousePosition.x > gnScreenWidth / 2 + w / 2) {
+	if (MousePosition.x > screenWidth / 2 + w / 2) {
 		return true;
 	}
 	sgpCurrItem = pItem;

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -307,7 +307,7 @@ bool gmenu_left_mouse(bool isDown)
 	if (sgpCurrentMenu == nullptr) {
 		return false;
 	}
-	if (MousePosition.y >= MainPanel.position.y) {
+	if (MousePosition.y >= GetMainPanel().position.y) {
 		return false;
 	}
 	if (MousePosition.y - (117 + GetUIOffsetY()) < 0) {

--- a/Source/interfac.h
+++ b/Source/interfac.h
@@ -11,7 +11,11 @@
 
 namespace devilution {
 
-#define UI_OFFSET_Y ((Sint16)((gnScreenHeight - 480) / 2))
+inline Sint16 GetUIOffsetY()
+{
+	return ((Sint16)((GetScreenHeight() - 480) / 2));
+}
+#define UI_OFFSET_Y (GetUIOffsetY())
 
 enum interface_mode : uint16_t {
 	// clang-format off

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -356,11 +356,11 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 	bool done = false;
 	int r = 0;
 	for (; r < NUM_XY_SLOTS && !done; r++) {
-		int xo = RightPanel.position.x;
-		int yo = RightPanel.position.y;
+		int xo = GetRightPanel().position.x;
+		int yo = GetRightPanel().position.y;
 		if (r >= SLOTXY_BELT_FIRST) {
-			xo = PANEL_LEFT;
-			yo = PANEL_TOP;
+			xo = GetMainPanel().position.x;
+			yo = GetMainPanel().position.y;
 		}
 
 		if (i >= InvRect[r].x + xo && i <= InvRect[r].x + xo + InventorySlotSizeInPixels.width) {
@@ -692,11 +692,11 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 
 	uint32_t r = 0;
 	for (; r < NUM_XY_SLOTS; r++) {
-		int xo = RightPanel.position.x;
-		int yo = RightPanel.position.y;
+		int xo = GetRightPanel().position.x;
+		int yo = GetRightPanel().position.y;
 		if (r >= SLOTXY_BELT_FIRST) {
-			xo = PANEL_LEFT;
-			yo = PANEL_TOP;
+			xo = GetMainPanel().position.x;
+			yo = GetMainPanel().position.y;
 		}
 
 		// check which inventory rectangle the mouse is in, if any
@@ -1264,8 +1264,8 @@ void DrawInv(const Surface &out)
 						LightTableIndex = 0;
 						cel_transparency_active = true;
 
-						const int dstX = RightPanel.position.x + slotPos[INVLOC_HAND_RIGHT].x + (frameSize.width == InventorySlotSizeInPixels.width ? INV_SLOT_HALF_SIZE_PX : 0) - 1;
-						const int dstY = RightPanel.position.y + slotPos[INVLOC_HAND_RIGHT].y;
+						const int dstX = GetRightPanel().position.x + slotPos[INVLOC_HAND_RIGHT].x + (frameSize.width == InventorySlotSizeInPixels.width ? INV_SLOT_HALF_SIZE_PX : 0) - 1;
+						const int dstY = GetRightPanel().position.y + slotPos[INVLOC_HAND_RIGHT].y;
 						CelClippedBlitLightTransTo(out, { dstX, dstY }, cel, celFrame);
 
 						cel_transparency_active = false;
@@ -1607,8 +1607,9 @@ void CheckInvItem(bool isShiftHeld, bool isCtrlHeld)
 
 void CheckInvScrn(bool isShiftHeld, bool isCtrlHeld)
 {
-	if (MousePosition.x > 190 + PANEL_LEFT && MousePosition.x < 437 + PANEL_LEFT
-	    && MousePosition.y > PANEL_TOP && MousePosition.y < 33 + PANEL_TOP) {
+	auto &mainPanelPosition = GetMainPanel().position;
+	if (MousePosition.x > 190 + mainPanelPosition.x && MousePosition.x < 437 + mainPanelPosition.x
+	    && MousePosition.y > mainPanelPosition.y && MousePosition.y < 33 + mainPanelPosition.y) {
 		CheckInvItem(isShiftHeld, isCtrlHeld);
 	}
 }
@@ -1904,11 +1905,11 @@ int8_t CheckInvHLight()
 {
 	int8_t r = 0;
 	for (; r < NUM_XY_SLOTS; r++) {
-		int xo = RightPanel.position.x;
-		int yo = RightPanel.position.y;
+		int xo = GetRightPanel().position.x;
+		int yo = GetRightPanel().position.y;
 		if (r >= SLOTXY_BELT_FIRST) {
-			xo = PANEL_LEFT;
-			yo = PANEL_TOP;
+			xo = GetMainPanel().position.x;
+			yo = GetMainPanel().position.y;
 		}
 
 		if (MousePosition.x >= InvRect[r].x + xo

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2030,7 +2030,7 @@ void PrintItemOil(char iDidx)
 void DrawUniqueInfoWindow(const Surface &out)
 {
 	CelDrawTo(out, GetPanelPosition(UiPanels::Inventory, { 24 - SPANEL_WIDTH, 327 }), *pSTextBoxCels, 1);
-	DrawHalfTransparentRectTo(out, RightPanel.position.x - SPANEL_WIDTH + 27, RightPanel.position.y + 28, 265, 297);
+	DrawHalfTransparentRectTo(out, GetRightPanel().position.x - SPANEL_WIDTH + 27, GetRightPanel().position.y + 28, 265, 297);
 }
 
 void PrintItemMisc(Item &item)
@@ -4091,8 +4091,8 @@ void PrintItemPower(char plidx, Item *x)
 
 void DrawUniqueInfo(const Surface &out)
 {
-	const Point position { RightPanel.position.x - SPANEL_WIDTH, RightPanel.position.y };
-	if ((chrflag || QuestLogIsOpen) && LeftPanel.Contains(position)) {
+	const Point position { GetLeftPanel().position.x - SPANEL_WIDTH, GetLeftPanel().position.y };
+	if ((chrflag || QuestLogIsOpen) && GetLeftPanel().Contains(position)) {
 		return;
 	}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3441,12 +3441,12 @@ void CheckPlrSpell(bool isShiftHeld)
 		if (pcurs != CURSOR_HAND)
 			return;
 
-		if (MainPanel.Contains(MousePosition)) // inside main panel
+		if (GetMainPanel().Contains(MousePosition)) // inside main panel
 			return;
 
 		if (
-		    ((chrflag || QuestLogIsOpen) && LeftPanel.Contains(MousePosition)) // inside left panel
-		    || ((invflag || sbookflag) && RightPanel.Contains(MousePosition))  // inside right panel
+		    ((chrflag || QuestLogIsOpen) && GetLeftPanel().Contains(MousePosition)) // inside left panel
+		    || ((invflag || sbookflag) && GetRightPanel().Contains(MousePosition))  // inside right panel
 		) {
 			if (rspell != SPL_HEAL
 			    && rspell != SPL_IDENTIFY

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -113,11 +113,11 @@ void DrawPlrMsg(const Surface &out)
 	_plrmsg *pMsg;
 
 	if (chrflag || QuestLogIsOpen) {
-		x += LeftPanel.position.x + LeftPanel.size.width;
-		width -= LeftPanel.size.width;
+		x += GetLeftPanel().position.x + GetLeftPanel().size.width;
+		width -= GetLeftPanel().size.width;
 	}
 	if (invflag || sbookflag)
-		width -= gnScreenWidth - RightPanel.position.x;
+		width -= gnScreenWidth - GetRightPanel().position.x;
 
 	if (width < 300)
 		return;

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -93,11 +93,11 @@ void AddItemToLabelQueue(int id, int x, int y)
 
 bool IsMouseOverGameArea()
 {
-	if ((invflag || sbookflag) && RightPanel.Contains(MousePosition))
+	if ((invflag || sbookflag) && GetRightPanel().Contains(MousePosition))
 		return false;
-	if ((chrflag || QuestLogIsOpen) && LeftPanel.Contains(MousePosition))
+	if ((chrflag || QuestLogIsOpen) && GetLeftPanel().Contains(MousePosition))
 		return false;
-	if (MainPanel.Contains(MousePosition))
+	if (GetMainPanel().Contains(MousePosition))
 		return false;
 
 	return true;

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -251,7 +251,7 @@ void DrawBlood(int x, int y)
 int QuestLogMouseToEntry()
 {
 	Rectangle innerArea = InnerPanel;
-	innerArea.position += Displacement(LeftPanel.position.x, LeftPanel.position.y);
+	innerArea.position += Displacement(GetLeftPanel().position.x, GetLeftPanel().position.y);
 	if (!innerArea.Contains(MousePosition) || (EncounteredQuestCount == 0))
 		return -1;
 	int y = MousePosition.y - innerArea.position.y;

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1280,7 +1280,7 @@ void DrawView(const Surface &out, Point startPosition)
 	}
 #ifndef VIRTUAL_GAMEPAD
 	if (!chrflag && Players[MyPlayerId]._pStatPts != 0 && !spselflag
-	    && (!QuestLogIsOpen || !LeftPanel.Contains(MainPanel.position + Displacement { 0, -74 }))) {
+	    && (!QuestLogIsOpen || !GetLeftPanel().Contains(GetMainPanel().position + Displacement { 0, -74 }))) {
 		DrawLevelUpIcon(out);
 	}
 #endif

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1450,7 +1450,7 @@ void ShiftGrid(int *x, int *y, int horizontal, int vertical)
 
 int RowsCoveredByPanel()
 {
-	if (gnScreenWidth <= PANEL_WIDTH) {
+	if (GetScreenWidth() <= PANEL_WIDTH) {
 		return 0;
 	}
 
@@ -1464,15 +1464,18 @@ int RowsCoveredByPanel()
 
 void CalcTileOffset(int *offsetX, int *offsetY)
 {
+	uint16_t screenWidth = GetScreenWidth();
+	uint16_t viewportHeight = GetViewportHeight();
+
 	int x;
 	int y;
 
 	if (zoomflag) {
-		x = gnScreenWidth % TILE_WIDTH;
-		y = gnViewportHeight % TILE_HEIGHT;
+		x = screenWidth % TILE_WIDTH;
+		y = viewportHeight % TILE_HEIGHT;
 	} else {
-		x = (gnScreenWidth / 2) % TILE_WIDTH;
-		y = (gnViewportHeight / 2) % TILE_HEIGHT;
+		x = (screenWidth / 2) % TILE_WIDTH;
+		y = (viewportHeight / 2) % TILE_HEIGHT;
 	}
 
 	if (x != 0)
@@ -1486,12 +1489,15 @@ void CalcTileOffset(int *offsetX, int *offsetY)
 
 void TilesInView(int *rcolumns, int *rrows)
 {
-	int columns = gnScreenWidth / TILE_WIDTH;
-	if ((gnScreenWidth % TILE_WIDTH) != 0) {
+	uint16_t screenWidth = GetScreenWidth();
+	uint16_t viewportHeight = GetViewportHeight();
+
+	int columns = screenWidth / TILE_WIDTH;
+	if ((screenWidth % TILE_WIDTH) != 0) {
 		columns++;
 	}
-	int rows = gnViewportHeight / TILE_HEIGHT;
-	if ((gnViewportHeight % TILE_HEIGHT) != 0) {
+	int rows = viewportHeight / TILE_HEIGHT;
+	if ((viewportHeight % TILE_HEIGHT) != 0) {
 		rows++;
 	}
 

--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -749,7 +749,7 @@ void CheckTrigForce()
 {
 	trigflag = false;
 
-	if (!sgbControllerActive && MousePosition.y > PANEL_TOP - 1) {
+	if (!sgbControllerActive && MousePosition.y > GetMainPanel().position.y - 1) {
 		return;
 	}
 

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -36,6 +36,21 @@ Uint16 gnScreenWidth;
 Uint16 gnScreenHeight;
 Uint16 gnViewportHeight;
 
+Uint16 GetScreenWidth()
+{
+	return gnScreenWidth;
+}
+
+Uint16 GetScreenHeight()
+{
+	return gnScreenHeight;
+}
+
+Uint16 GetViewportHeight()
+{
+	return gnViewportHeight;
+}
+
 #ifdef USE_SDL1
 void SetVideoMode(int width, int height, int bpp, uint32_t flags)
 {

--- a/Source/utils/ui_fwd.h
+++ b/Source/utils/ui_fwd.h
@@ -8,6 +8,10 @@ extern Uint16 gnScreenWidth;
 extern Uint16 gnScreenHeight;
 extern Uint16 gnViewportHeight;
 
+Uint16 GetScreenWidth();
+Uint16 GetScreenHeight();
+Uint16 GetViewportHeight();
+
 bool SpawnWindow(const char *lpWindowName);
 void UiErrorOkDialog(const char *caption, const char *text, bool error = true);
 


### PR DESCRIPTION
With this change it is possible to play demos in a different resolution then recorded. 📹 

<details><summary>Example Videos</summary>

### Original resolution (also used for recording)

https://user-images.githubusercontent.com/25415264/131180804-681dd444-e3ea-4d2a-a628-e418b1f9402d.mp4

### Larger resolution

https://user-images.githubusercontent.com/25415264/131180840-f0fd01f6-5f59-4c99-8877-f6fc116f8e62.mp4

### Smaller resolution

https://user-images.githubusercontent.com/25415264/131180885-3e85644b-f343-473f-a1c5-0451559c0c4d.mp4

</details>

Notes:

- The difference speed of the example videos is cause I used timedemo mode. And timedemo mode tries to progress the playback as fast as possible. And cause larger resolution needs longer to render, the video is longer (see fps counter).
- This change introduces two different views. One for gameplay (used for click position calculation; uses recording solution) and one for visual/rendering (uses replay resolution). In normal gameplay both are identically. This is only needed for demo mode.
- In a follow-up pr, we could remove `PANEL_TOP`, `PANEL_LEFT`, `PANEL_X` and `PANEL_Y` and replace them with `GetMainPanel`.
- This change drives demo mode in a specific direction (demo recording contains user/click interactions). If we don't want to follow this route, this pr adds complexity that is not needed. But even if we discard this later, it can be easily removed then.