### PR TITLE
Nintendo Switch: Remove link to rdimon library to fix file truncation

### DIFF
--- a/CMake/switch/asio_defs.cmake
+++ b/CMake/switch/asio_defs.cmake
@@ -3,6 +3,3 @@ target_compile_definitions(asio INTERFACE _DEFAULT_SOURCE=ON)
 
 # Missing headers and declarations provided by DevilutionX
 target_include_directories(asio BEFORE INTERFACE CMake/switch/asio/include)
-
-# Defines the pause() function
-target_link_libraries(asio INTERFACE rdimon)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,7 @@ if(NINTENDO_SWITCH)
     Source/platform/switch/keyboard.cpp
     Source/platform/switch/docking.cpp
     Source/platform/switch/random.cpp
+    Source/platform/switch/asio/pause.c
     Source/platform/switch/asio/net/if.c
     Source/platform/switch/asio/sys/signal.c)
 endif()

--- a/Source/platform/switch/asio/pause.c
+++ b/Source/platform/switch/asio/pause.c
@@ -1,0 +1,7 @@
+#include <errno.h>
+
+int pause(void)
+{
+	errno = ENOSYS;
+	return -1;
+}


### PR DESCRIPTION
Apparently, linking in the rdimon library broke the `truncate()` function. Hopefully, ASIO doesn't need the `pause()` function.

This resolves #2702