### PR TITLE
Disable hardware cursor for demo playback

### DIFF
--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -147,6 +147,9 @@ void OverrideOptions()
 	sgOptions.Graphics.nWidth = DemoGraphicsWidth;
 	sgOptions.Graphics.nHeight = DemoGraphicsHeight;
 	sgOptions.Graphics.bFitToScreen = false;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	sgOptions.Graphics.bHardwareCursor = false;
+#endif
 	if (Timedemo) {
 		sgOptions.Graphics.bVSync = false;
 		sgOptions.Graphics.bFPSLimit = false;


### PR DESCRIPTION
This way you always see the cursor of the player and doesn't have to adjust your `diablo.ini` for that.