### PR TITLE
Level seed related debug commands

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -6,6 +6,8 @@
 
 #ifdef _DEBUG
 
+#include <sstream>
+
 #include "debug.h"
 
 #include "automap.h"
@@ -249,10 +251,21 @@ std::string DebugCmdVisitTowner(const std::string_view parameter)
 std::string DebugCmdResetLevel(const std::string_view parameter)
 {
 	auto &myPlayer = Players[MyPlayerId];
-	auto level = atoi(parameter.data());
+
+	std::stringstream paramsStream(parameter.data());
+	std::string singleParameter;
+	if (!std::getline(paramsStream, singleParameter, ' '))
+		return "What level do you want to visit?";
+	auto level = atoi(singleParameter.c_str());
 	if (level < 0 || level > (gbIsHellfire ? 24 : 16))
 		return fmt::format("Level {} is not known. Do you want to write an extension mod?", level);
 	myPlayer._pLvlVisited[level] = false;
+
+	if (std::getline(paramsStream, singleParameter, ' ')) {
+		auto seed = atoi(singleParameter.c_str());
+		glSeedTbl[level] = seed;
+	}
+
 	if (myPlayer.plrlevel == level)
 		return fmt::format("Level {} can't be cleaned, cause you still occupy it!", level);
 	return fmt::format("Level {} was restored and looks fabulous.", level);
@@ -448,7 +461,7 @@ std::vector<DebugCmdItem> DebugCmdList = {
 	{ "changelevel", "Moves to specifided {level} (use 0 for town).", "{level}", &DebugCmdWarpToLevel },
 	{ "map", "Load a quest level {level}.", "{level}", &DebugCmdLoadMap },
 	{ "visit", "Visit a towner.", "{towner}", &DebugCmdVisitTowner },
-	{ "restart", "Resets specified {level}.", "{level}", &DebugCmdResetLevel },
+	{ "restart", "Resets specified {level}.", "{level} ({seed})", &DebugCmdResetLevel },
 	{ "god", "Toggles godmode.", "", &DebugCmdGodMode },
 	{ "r_drawvision", "Toggles vision debug rendering.", "", &DebugCmdVision },
 	{ "r_fullbright", "Toggles whether light shading is in effect.", "", &DebugCmdLighting },

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -587,6 +587,7 @@ bool CheckDebugTextCommand(const std::string_view text)
 	if (text.length() > (dbgCmd.text.length() + 1))
 		parameter = text.substr(dbgCmd.text.length() + 1);
 	const auto result = dbgCmd.actionProc(parameter);
+	Log("DebugCmd: {} Result: {}", text, result);
 	InitDiabloMsg(result);
 	return true;
 }

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -40,6 +40,12 @@ int DebugPlayerId;
 int DebugQuestId;
 int DebugMonsterId;
 
+// Used for debugging level generation
+uint32_t glMid1Seed[NUMLEVELS];
+uint32_t glMid2Seed[NUMLEVELS];
+uint32_t glMid3Seed[NUMLEVELS];
+uint32_t glEndSeed[NUMLEVELS];
+
 void SetSpellLevelCheat(spell_id spl, int spllvl)
 {
 	auto &myPlayer = Players[MyPlayerId];
@@ -450,6 +456,11 @@ std::string DebugCmdShowCursorCoords(const std::string_view parameter)
 	return "Cursor will never forget that.";
 }
 
+std::string DebugCmdLevelSeed(const std::string_view parameter)
+{
+	return fmt::format("Seedinfo for level {}\nseed: {}\nMid1: {}\nMid2: {}\nMid3: {}\nEnd: {}", currlevel, glSeedTbl[currlevel], glMid1Seed[currlevel], glMid2Seed[currlevel], glMid3Seed[currlevel], glEndSeed[currlevel]);
+}
+
 std::vector<DebugCmdItem> DebugCmdList = {
 	{ "help", "Prints help overview or help for a specific command.", "({command})", &DebugCmdHelp },
 	{ "give gold", "Fills the inventory with gold.", "", &DebugCmdGiveGoldCheat },
@@ -474,6 +485,7 @@ std::vector<DebugCmdItem> DebugCmdList = {
 	{ "coords", "Toggles showing tile coords.", "", &DebugCmdShowCoords },
 	{ "cursorcoords", "Toggles showing cursor coords.", "", &DebugCmdShowCursorCoords },
 	{ "grid", "Toggles showing grid.", "", &DebugCmdShowGrid },
+	{ "seedinfo", "Show seed infos for current level.", "", &DebugCmdLevelSeed },
 };
 
 } // namespace
@@ -554,6 +566,14 @@ void NextDebugMonster()
 
 	sprintf(dstr, "Current debug monster = %i", DebugMonsterId);
 	NetSendCmdString(1 << MyPlayerId, dstr);
+}
+
+void SetDebugLevelSeedInfos(uint32_t mid1Seed, uint32_t mid2Seed, uint32_t mid3Seed, uint32_t endSeed)
+{
+	glMid1Seed[currlevel] = mid1Seed;
+	glMid2Seed[currlevel] = mid2Seed;
+	glMid3Seed[currlevel] = mid3Seed;
+	glEndSeed[currlevel] = endSeed;
 }
 
 bool CheckDebugTextCommand(const std::string_view text)

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -29,6 +29,7 @@ void PrintDebugPlayer(bool bNextPlayer);
 void PrintDebugQuest();
 void GetDebugMonster();
 void NextDebugMonster();
+void SetDebugLevelSeedInfos(uint32_t mid1Seed, uint32_t mid2Seed, uint32_t mid3Seed, uint32_t endSeed);
 bool CheckDebugTextCommand(const std::string_view text);
 
 } // namespace devilution

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -128,12 +128,6 @@ namespace {
 
 char gszVersionNumber[64] = "internal version unknown";
 
-// Used for debugging level generation
-uint32_t glEndSeed[NUMLEVELS];
-uint32_t glMid1Seed[NUMLEVELS];
-uint32_t glMid2Seed[NUMLEVELS];
-uint32_t glMid3Seed[NUMLEVELS];
-
 bool gbGameLoopStartup;
 bool forceSpawn;
 bool forceDiablo;
@@ -587,15 +581,6 @@ void PressChar(char vkey)
 		return;
 	case 'm':
 		GetDebugMonster();
-		return;
-	case 'R':
-	case 'r':
-		sprintf(tempstr, "seed = %i", glSeedTbl[currlevel]);
-		NetSendCmdString(1 << MyPlayerId, tempstr);
-		sprintf(tempstr, "Mid1 = %i : Mid2 = %i : Mid3 = %i", glMid1Seed[currlevel], glMid2Seed[currlevel], glMid3Seed[currlevel]);
-		NetSendCmdString(1 << MyPlayerId, tempstr);
-		sprintf(tempstr, "End = %i", glEndSeed[currlevel]);
-		NetSendCmdString(1 << MyPlayerId, tempstr);
 		return;
 	case 'T':
 	case 't':
@@ -1893,19 +1878,21 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 		if (leveltype != DTYPE_TOWN) {
 			if (firstflag || lvldir == ENTRY_LOAD || !myPlayer._pLvlVisited[currlevel] || gbIsMultiplayer) {
 				HoldThemeRooms();
-				glMid1Seed[currlevel] = GetLCGEngineState();
+				uint32_t mid1Seed = GetLCGEngineState();
 				InitMonsters();
-				glMid2Seed[currlevel] = GetLCGEngineState();
+				uint32_t mid2Seed = GetLCGEngineState();
 				IncProgress();
 				InitObjects();
 				InitItems();
 				if (currlevel < 17)
 					CreateThemeRooms();
 				IncProgress();
-				glMid3Seed[currlevel] = GetLCGEngineState();
+				uint32_t mid3Seed = GetLCGEngineState();
 				InitMissiles();
 				InitDead();
-				glEndSeed[currlevel] = GetLCGEngineState();
+#if _DEBUG
+				SetDebugLevelSeedInfos(mid1Seed, mid2Seed, mid3Seed, GetLCGEngineState());
+#endif
 
 				if (gbIsMultiplayer)
 					DeltaLoadLevel();

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -135,7 +135,6 @@ uint32_t glMid2Seed[NUMLEVELS];
 uint32_t glMid3Seed[NUMLEVELS];
 
 bool gbGameLoopStartup;
-int setseed;
 bool forceSpawn;
 bool forceDiablo;
 int sgnTimeoutCurs;
@@ -821,7 +820,6 @@ void RunGameLoop(interface_mode uMsg)
 	printInConsole("    %-20s %-30s\n", "-^", "Enable debug tools");
 	printInConsole("    %-20s %-30s\n", "-i", "Ignore network timeout");
 	printInConsole("    %-20s %-30s\n", "-m <##>", "Add debug monster, up to 10 allowed");
-	printInConsole("    %-20s %-30s\n", "-r <##########>", "Set map seed");
 #endif
 	printInConsole("%s", _("\nReport bugs at https://github.com/diasurgical/devilutionX/\n"));
 	diablo_quit(0);
@@ -881,8 +879,6 @@ void DiabloParseFlags(int argc, char **argv)
 		} else if (strcasecmp("-m", argv[i]) == 0) {
 			monstdebug = true;
 			DebugMonsters[debugmonsttypes++] = (_monster_id)SDL_atoi(argv[++i]);
-		} else if (strcasecmp("-r", argv[i]) == 0) {
-			setseed = SDL_atoi(argv[++i]);
 #endif
 		} else {
 			printInConsole("%s", fmt::format(_("unrecognized option '{:s}'\n"), argv[i]).c_str());
@@ -1807,9 +1803,6 @@ void DisableInputWndProc(uint32_t uMsg, int32_t /*wParam*/, int32_t lParam)
 
 void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 {
-	if (setseed != 0)
-		glSeedTbl[currlevel] = setseed;
-
 	music_stop();
 	if (pcurs > CURSOR_HAND && pcurs < CURSOR_FIRSTITEM) {
 		NewCursor(CURSOR_HAND);


### PR DESCRIPTION
Content

- restart can now (optional) set a new seed for a level. This is a replacement for `-r` command line argument.
- new command `seedinfo` that is replacement for `r` and `R` keys
- executed debug commands gets logged to the console (if you want to expect the printed information (for example seed) longer then the info is displayed on screen)