### PR TITLE
DebugCmdResetLevel: Use stoul for parameter seed parsing

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -268,7 +268,7 @@ std::string DebugCmdResetLevel(const std::string_view parameter)
 	myPlayer._pLvlVisited[level] = false;
 
 	if (std::getline(paramsStream, singleParameter, ' ')) {
-		auto seed = atoi(singleParameter.c_str());
+		uint32_t seed = static_cast<uint32_t>(std::stoul(singleParameter));
 		glSeedTbl[level] = seed;
 	}
 


### PR DESCRIPTION
To avoid undefined behavior, see {comment](https://github.com/diasurgical/devilutionX/pull/2744#discussion_r697986644).
Thanks @ephphatha 🙂 