### PR TITLE
debug X toggle

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -27,6 +27,7 @@
 namespace devilution {
 
 std::optional<CelSprite> pSquareCel;
+bool DebugToggle = false;
 bool DebugGodMode = false;
 bool DebugVision = false;
 bool DebugCoords = false;

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -16,6 +16,7 @@
 namespace devilution {
 
 extern std::optional<CelSprite> pSquareCel;
+extern bool DebugToggle;
 extern bool DebugGodMode;
 extern bool DebugVision;
 extern bool DebugCoords;

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1507,6 +1507,16 @@ void InitKeymapActions()
 	    [] { Players[MyPlayerId].Stop(); },
 	    [&]() { return !IsPlayerDead(); },
 	});
+#ifdef _DEBUG
+	keymapper.AddAction({
+	    "DebugToggle",
+	    'X',
+	    [] {
+		    DebugToggle = !DebugToggle;
+	    },
+	    [&]() { return true; },
+	});
+#endif
 }
 
 } // namespace


### PR DESCRIPTION
Adds a `DebugToggle` debug variable and connects it to currently unused X hotkey - this is to make debugging stuff that needs turning on/off easier, up till now I've always had to cook some code for it myself, then remove it knowing I'd need it again soon. NO MORE 🤪 