### PR TITLE
Avoid segfaults when using randomly generated array indexes in items.cpp

### DIFF
--- a/Source/engine/random.cpp
+++ b/Source/engine/random.cpp
@@ -1,6 +1,7 @@
 #include "engine/random.hpp"
 
 #include "utils/stdcompat/abs.hpp"
+#include "utils/stdcompat/algorithm.hpp"
 
 namespace devilution {
 
@@ -45,6 +46,11 @@ int32_t GenerateRnd(int32_t v)
 	if (v < 0xFFFF)
 		return (AdvanceRndSeed() >> 16) % v;
 	return AdvanceRndSeed() % v;
+}
+
+int32_t GenerateNonNegativeRnd(int32_t v)
+{
+	return std::max<int32_t>(GenerateRnd(v), 0);
 }
 
 } // namespace devilution

--- a/Source/engine/random.hpp
+++ b/Source/engine/random.hpp
@@ -7,7 +7,6 @@
  */
 #pragma once
 
-#include <algorithm>
 #include <cstdint>
 #include <initializer_list>
 
@@ -60,6 +59,17 @@ int32_t AdvanceRndSeed();
 int32_t GenerateRnd(int32_t v);
 
 /**
+ * @brief Generates a random integer in the range [0, v)
+ *
+ * Will not return a negative value, provided to avoid segfaults in legacy code.
+ *
+ * @see AdvanceRndSeed()
+ * @param v The upper limit for the return value
+ * @return A random number in the range [0, v)
+ */
+int32_t GenerateNonNegativeRnd(int32_t v);
+
+/**
  * @brief Picks one of the elements in the list randomly.
  *
  * @param values The values to pick from
@@ -68,7 +78,7 @@ int32_t GenerateRnd(int32_t v);
 template <typename T>
 const T PickRandomlyAmong(const std::initializer_list<T> &values)
 {
-	const auto index { std::max<int32_t>(GenerateRnd(values.size()), 0) };
+	const auto index { GenerateNonNegativeRnd(values.size()) };
 
 	return *(values.begin() + index);
 }

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -394,6 +394,8 @@ int ItemsGetCurrlevel()
 
 bool ItemPlace(Point position)
 {
+	if (!InDungeonBounds(position))
+		return false;
 	if (dMonster[position.x][position.y] != 0)
 		return false;
 	if (dPlayer[position.x][position.y] != 0)
@@ -1121,10 +1123,13 @@ void GetStaffPower(Item &item, int lvl, int bs, bool onlygood)
 			}
 		}
 		if (nl != 0) {
-			preidx = l[GenerateRnd(nl)];
-			item._iMagical = ITEM_QUALITY_MAGIC;
-			SaveItemAffix(item, ItemPrefixes[preidx]);
-			item._iPrePower = ItemPrefixes[preidx].power.type;
+			int lookupIndex = GenerateRnd(nl);
+			if (lookupIndex >= 0) {
+				preidx = l[lookupIndex];
+				item._iMagical = ITEM_QUALITY_MAGIC;
+				SaveItemAffix(item, ItemPrefixes[preidx]);
+				item._iPrePower = ItemPrefixes[preidx].power.type;
+			}
 		}
 	}
 
@@ -1209,11 +1214,14 @@ void GetItemPower(Item &item, int minlvl, int maxlvl, AffixItemType flgs, bool o
 			}
 		}
 		if (nt != 0) {
-			preidx = l[GenerateRnd(nt)];
-			item._iMagical = ITEM_QUALITY_MAGIC;
-			SaveItemAffix(item, ItemPrefixes[preidx]);
-			item._iPrePower = ItemPrefixes[preidx].power.type;
-			goe = ItemPrefixes[preidx].PLGOE;
+			int lookupIndex = GenerateRnd(nt);
+			if (lookupIndex >= 0) {
+				preidx = l[lookupIndex];
+				item._iMagical = ITEM_QUALITY_MAGIC;
+				SaveItemAffix(item, ItemPrefixes[preidx]);
+				item._iPrePower = ItemPrefixes[preidx].power.type;
+				goe = ItemPrefixes[preidx].PLGOE;
+			}
 		}
 	}
 	if (post != 0) {
@@ -1228,10 +1236,13 @@ void GetItemPower(Item &item, int minlvl, int maxlvl, AffixItemType flgs, bool o
 			}
 		}
 		if (nl != 0) {
-			sufidx = l[GenerateRnd(nl)];
-			item._iMagical = ITEM_QUALITY_MAGIC;
-			SaveItemAffix(item, ItemSuffixes[sufidx]);
-			item._iSufPower = ItemSuffixes[sufidx].power.type;
+			int lookupIndex = GenerateRnd(nl);
+			if (lookupIndex >= 0) {
+				sufidx = l[lookupIndex];
+				item._iMagical = ITEM_QUALITY_MAGIC;
+				SaveItemAffix(item, ItemSuffixes[sufidx]);
+				item._iSufPower = ItemSuffixes[sufidx].power.type;
+			}
 		}
 	}
 
@@ -1307,13 +1318,16 @@ void GetOilType(Item &item, int maxLvl)
 		}
 	}
 
-	int8_t t = rnd[GenerateRnd(cnt)];
+	int lookupIndex = GenerateRnd(cnt);
+	if (lookupIndex >= 0) {
+		int8_t t = rnd[lookupIndex];
 
-	CopyUtf8(item._iName, _(OilNames[t]), sizeof(item._iName));
-	CopyUtf8(item._iIName, _(OilNames[t]), sizeof(item._iIName));
-	item._iMiscId = OilMagic[t];
-	item._ivalue = OilValues[t];
-	item._iIvalue = OilValues[t];
+		CopyUtf8(item._iName, _(OilNames[t]), sizeof(item._iName));
+		CopyUtf8(item._iIName, _(OilNames[t]), sizeof(item._iIName));
+		item._iMiscId = OilMagic[t];
+		item._ivalue = OilValues[t];
+		item._iIvalue = OilValues[t];
+	}
 }
 
 void GetItemBonus(Item &item, int minlvl, int maxlvl, bool onlygood, bool allowspells)
@@ -1395,7 +1409,7 @@ int RndUItem(Monster *monster)
 		}
 	}
 
-	return ril[GenerateRnd(ri)];
+	return ril[GenerateNonNegativeRnd(ri)];
 }
 
 int RndAllItems()
@@ -1421,7 +1435,7 @@ int RndAllItems()
 			ri--;
 	}
 
-	return ril[GenerateRnd(ri)];
+	return ril[GenerateNonNegativeRnd(ri)];
 }
 
 int RndTypeItems(ItemType itemType, int imid, int lvl)
@@ -1448,7 +1462,7 @@ int RndTypeItems(ItemType itemType, int imid, int lvl)
 		}
 	}
 
-	return ril[GenerateRnd(ri)];
+	return ril[GenerateNonNegativeRnd(ri)];
 }
 
 _unique_items CheckUnique(Item &item, int lvl, int uper, bool recreate)
@@ -1941,7 +1955,7 @@ int RndVendorItem(int minlvl, int maxlvl)
 			break;
 	}
 
-	return ril[GenerateRnd(ri)] + 1;
+	return ril[GenerateNonNegativeRnd(ri)] + 1;
 }
 
 int RndSmithItem(int lvl)
@@ -3068,7 +3082,7 @@ int RndItem(const Monster &monster)
 			ri--;
 	}
 
-	int r = GenerateRnd(ri);
+	int r = GenerateNonNegativeRnd(ri);
 	return ril[r] + 1;
 }
 


### PR DESCRIPTION
The first couple of commits set up helpers for future checks. Items.cpp was one of the easier wins, drlg1.cpp is probably the worst offender so I'm trying to avoid that one as long as possible 😂 