### PR TITLE
fix loot - use proper monster level for generating items

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3424,9 +3424,11 @@ void SpawnItem(MonsterStruct &monster, Point position, bool sendmsg)
 	GetSuperItemSpace(position, ii);
 	int uper = monster._uniqtype != 0 ? 15 : 1;
 
-	int8_t mLevel = monster.MData->mLevel;
+	int8_t mLevel = monster.mLevel;
 	if (!gbIsHellfire && monster.MType->mtype == MT_DIABLO)
 		mLevel -= 15;
+	if (mLevel > CF_LEVEL)
+		mLevel = CF_LEVEL;
 
 	SetupAllItems(item, idx, AdvanceRndSeed(), mLevel, uper, onlygood, false, false);
 


### PR DESCRIPTION
This is the most important PR ever - this is the reason why loot was the same on all difficulties, hell, it was even worse than that, despite unique monsters having a custom data table with lvls and level getting increased by 4 for item generating, it was always taking the level of base monster straight from the data table - means no bonus from difficulty, no bonus from being unique xD

I did the math for lazarus (30 lvl) on hell (+30 lvl)
that alone brings him to 60, he has 0 in unique data level, so that's a +5 bonus and there's a flat +4 bonus hardcoded on top of that so final level would be 69.
According to

```cpp
enum icreateinfo_flag {
	// clang-format off
	CF_LEVEL        = (1 << 6) - 1,
```
Max item level can be 63 (not sure if before or after that hardcoded +4 bonus), so we'd need to cap the level to max range.

#Added capping the level to 63, hardcoded +4 for bosses happens after the level gets loaded so we effectively have max lvl 67 items!