### PR TITLE
fix currlevel in map command

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -193,6 +193,8 @@ std::string DebugCmdLoadMap(const string_view parameter)
 
 		setlevel = false;
 		setlvltype = quest._qlvltype;
+		currlevel = quest._qlevel;
+		myPlayer.plrlevel = quest._qlevel;
 		StartNewLvl(MyPlayerId, WM_DIABSETLVL, level);
 		return fmt::format("Welcome to {}.", QuestLevelNames[level]);
 	}


### PR DESCRIPTION
Resolves https://github.com/diasurgical/devilutionX/issues/2764
Setting only one of these values ends up with a black screen because of 
```cpp
	for (auto &player : Players) {
			if (player.plractive && currlevel == player.plrlevel) {
				InitPlayerGFX(player);
				if (lvldir != ENTRY_LOAD)
					InitPlayer(player, firstflag);
			}
		}
```
in LoadGameLevel