### PR TITLE
Debug commands: Fix level transitions

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -177,7 +177,7 @@ std::string DebugCmdWarpToLevel(const string_view parameter)
 	if (!setlevel && myPlayer.plrlevel == level)
 		return fmt::format("I did nothing but fulfilled your wish. You are already at level {}.", level);
 
-	StartNewLvl(MyPlayerId, (level != 21) ? interface_mode::WM_DIABNEXTLVL : interface_mode::WM_DIABTWARPUP, level);
+	StartNewLvl(MyPlayerId, (level != 21) ? interface_mode::WM_DIABNEXTLVL : interface_mode::WM_DIABTOWNWARP, level);
 	return fmt::format("Welcome to level {}.", level);
 }
 
@@ -204,7 +204,7 @@ std::string DebugCmdLoadMap(const string_view parameter)
 		if (level != quest._qslvl)
 			continue;
 
-		StartNewLvl(MyPlayerId, (quest._qlevel != 21) ? interface_mode::WM_DIABNEXTLVL : interface_mode::WM_DIABTWARPUP, quest._qlevel);
+		StartNewLvl(MyPlayerId, (quest._qlevel != 21) ? interface_mode::WM_DIABNEXTLVL : interface_mode::WM_DIABTOWNWARP, quest._qlevel);
 		ProcessMessages();
 
 		setlvltype = quest._qlvltype;

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -80,6 +80,20 @@ void PrintDebugMonster(int m)
 	NetSendCmdString(1 << MyPlayerId, dstr);
 }
 
+void ProcessMessages()
+{
+	tagMSG msg;
+	while (FetchMessage(&msg)) {
+		if (msg.message == DVL_WM_QUIT) {
+			gbRunGameResult = false;
+			gbRunGame = false;
+			break;
+		}
+		TranslateMessage(&msg);
+		PushMessage(&msg);
+	}
+}
+
 struct DebugCmdItem {
 	const string_view text;
 	const string_view description;
@@ -183,22 +197,23 @@ std::string DebugCmdLoadMap(const string_view parameter)
 	auto level = atoi(parameter.data());
 	if (level < 1)
 		return fmt::format("Map id must be 1 or higher", level);
-	if (setlevel && myPlayer.plrlevel == level)
-		return fmt::format("I did nothing but fulfilled your wish. You are already at level {}.", level);
+	if (setlevel && setlvlnum == level)
+		return fmt::format("I did nothing but fulfilled your wish. You are already at mapid {}.", level);
 
 	for (auto &quest : Quests) {
 		if (level != quest._qslvl)
 			continue;
 
-		setlevel = false;
+		StartNewLvl(MyPlayerId, (quest._qlevel != 21) ? interface_mode::WM_DIABNEXTLVL : interface_mode::WM_DIABTWARPUP, quest._qlevel);
+		ProcessMessages();
+
 		setlvltype = quest._qlvltype;
-		currlevel = quest._qlevel;
-		myPlayer.plrlevel = quest._qlevel;
 		StartNewLvl(MyPlayerId, WM_DIABSETLVL, level);
+
 		return fmt::format("Welcome to {}.", QuestLevelNames[level]);
 	}
 
-	return fmt::format("Level {} is not known. Do you want to write a mod?", level);
+	return fmt::format("Mapid {} is not known. Do you want to write a mod?", level);
 }
 
 std::unordered_map<string_view, _talker_id> TownerShortNameToTownerId = {

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -163,7 +163,6 @@ std::string DebugCmdWarpToLevel(const string_view parameter)
 	if (!setlevel && myPlayer.plrlevel == level)
 		return fmt::format("I did nothing but fulfilled your wish. You are already at level {}.", level);
 
-	setlevel = false;
 	StartNewLvl(MyPlayerId, (level != 21) ? interface_mode::WM_DIABNEXTLVL : interface_mode::WM_DIABTWARPUP, level);
 	return fmt::format("Welcome to level {}.", level);
 }

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -344,6 +344,7 @@ void ShowProgress(interface_mode uMsg)
 		}
 		IncProgress();
 		FreeGameMem();
+		setlevel = false;
 		currlevel = myPlayer.plrlevel;
 		leveltype = gnLevelTypeTbl[currlevel];
 		IncProgress();
@@ -359,7 +360,6 @@ void ShowProgress(interface_mode uMsg)
 		}
 		IncProgress();
 		FreeGameMem();
-		setlevel = false;
 		currlevel = myPlayer.plrlevel;
 		leveltype = gnLevelTypeTbl[currlevel];
 		IncProgress();

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -267,6 +267,7 @@ void ShowProgress(interface_mode uMsg)
 		}
 		IncProgress();
 		FreeGameMem();
+		setlevel = false;
 		currlevel = myPlayer.plrlevel;
 		leveltype = gnLevelTypeTbl[currlevel];
 		IncProgress();
@@ -358,6 +359,7 @@ void ShowProgress(interface_mode uMsg)
 		}
 		IncProgress();
 		FreeGameMem();
+		setlevel = false;
 		currlevel = myPlayer.plrlevel;
 		leveltype = gnLevelTypeTbl[currlevel];
 		IncProgress();


### PR DESCRIPTION
Could fix #2765 😉 

Background:
We start the level transition with `StartNewLvl`.
But `StartNewLvl` only `PostMessage` a level transition to the message queue.
That means that the level transition happens a lot later.
But we change the `currlevel` direclty after `StartNewLvl`.
This is a problem for the save game logic.

When you transit from level to another following code is executed:
```
		IncProgress();
		if (!gbIsMultiplayer) {
			SaveLevel();
		} else {
			DeltaSaveLevel();
		}
		IncProgress();
		FreeGameMem();
		currlevel--;
		leveltype = gnLevelTypeTbl[currlevel];
		assert(myPlayer.plrlevel == currlevel);
		IncProgress();
		LoadGameLevel(false, ENTRY_PREV);
		IncProgress();
```

First is the current level saved and `SaveLevel` uses `currlevel`.
That means we set store items, monster etc. in the wrong level.

Additional fixes:

- Not available maps are can't be accessed by `map` command
- If you leave a map the normal way, it should port you back to the expected position and not (0, 0). 😉 