### PR TITLE
Fix NULL Cel Buffer error when blocking missiles

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -476,7 +476,7 @@ void CheckMissileCol(Missile &missile, int mindam, int maxdam, bool shift, Point
 					int mAnimFAmt = MissileSpriteData[missile._miAnimType].animFAmt;
 					if (dir < 0)
 						dir = mAnimFAmt - 1;
-					else if (dir > mAnimFAmt)
+					else if (dir >= mAnimFAmt)
 						dir = 0;
 
 					SetMissDir(missile, dir);
@@ -511,7 +511,7 @@ void CheckMissileCol(Missile &missile, int mindam, int maxdam, bool shift, Point
 					int mAnimFAmt = MissileSpriteData[missile._miAnimType].animFAmt;
 					if (dir < 0)
 						dir = mAnimFAmt - 1;
-					else if (dir > mAnimFAmt)
+					else if (dir >= mAnimFAmt)
 						dir = 0;
 
 					SetMissDir(missile, dir);
@@ -560,7 +560,7 @@ void CheckMissileCol(Missile &missile, int mindam, int maxdam, bool shift, Point
 					int mAnimFAmt = MissileSpriteData[missile._miAnimType].animFAmt;
 					if (dir < 0)
 						dir = mAnimFAmt - 1;
-					else if (dir > mAnimFAmt)
+					else if (dir >= mAnimFAmt)
 						dir = 0;
 
 					SetMissDir(missile, dir);


### PR DESCRIPTION
Fixes the off-by-one error in the missile blocking logic that was causing Blood Star missiles to disappear with a `NULL Cel Buffer` error after being blocked. For more info, see https://github.com/diasurgical/devilutionX/issues/2770#issuecomment-910369255. Tested using the save from #1531.

This resolves #2770