### PR TITLE
♻️ Standardize 'Direction' to 'Displacement' conversions

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1405,7 +1405,7 @@ void UpdateSpellTarget()
 
 	int range = myPlayer._pRSpell == SPL_TELEPORT ? 4 : 1;
 
-	cursPosition = myPlayer.position.future + Displacement::fromDirection(myPlayer._pdir) * range;
+	cursPosition = myPlayer.position.future + Displacement(myPlayer._pdir) * range;
 }
 
 /**

--- a/Source/engine/displacement.hpp
+++ b/Source/engine/displacement.hpp
@@ -103,6 +103,7 @@ struct Displacement {
 		return { abs(a.deltaX), abs(a.deltaY) };
 	}
 
+private:
 	static constexpr Displacement fromDirection(Direction direction)
 	{
 		switch (direction) {

--- a/Source/engine/displacement.hpp
+++ b/Source/engine/displacement.hpp
@@ -26,6 +26,11 @@ struct Displacement {
 	{
 	}
 
+	explicit constexpr Displacement(Direction direction)
+	    : Displacement(fromDirection(direction))
+	{
+	}
+
 	constexpr bool operator==(const Displacement &other) const
 	{
 		return deltaX == other.deltaX && deltaY == other.deltaY;

--- a/Source/engine/point.hpp
+++ b/Source/engine/point.hpp
@@ -35,7 +35,7 @@ struct Point {
 
 	constexpr Point &operator+=(Direction direction)
 	{
-		return (*this) += Displacement::fromDirection(direction);
+		return (*this) += Displacement(direction);
 	}
 
 	constexpr Point &operator-=(const Displacement &displacement)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -339,7 +339,7 @@ void PlaceGroup(int mtype, int num, UniqueMonsterPack uniqueMonsterPack, int lea
 		}
 
 		int j = 0;
-		for (int try2 = 0; j < num && try2 < 100; xp += Displacement::fromDirection(static_cast<Direction>(GenerateRnd(8))).deltaX, yp += Displacement::fromDirection(static_cast<Direction>(GenerateRnd(8))).deltaX) { /// BUGFIX: `yp += Point.y`
+		for (int try2 = 0; j < num && try2 < 100; xp += Displacement(static_cast<Direction>(GenerateRnd(8))).deltaX, yp += Displacement(static_cast<Direction>(GenerateRnd(8))).deltaX) { /// BUGFIX: `yp += Point.y`
 			if (!CanPlaceMonster(xp, yp)
 			    || (dTransVal[xp][yp] != dTransVal[x1][y1])
 			    || (uniqueMonsterPack == UniqueMonsterPack::Leashed && (abs(xp - x1) >= 4 || abs(yp - y1) >= 4))) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3090,7 +3090,7 @@ StartPlayerKill(int pnum, int earflag)
 						Direction pdd = player._pdir;
 						for (auto &item : player.InvBody) {
 							pdd = left[pdd];
-							DeadItem(player, &item, Displacement::fromDirection(pdd));
+							DeadItem(player, &item, Displacement(pdd));
 						}
 
 						CalcPlrInv(player, false);

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -947,7 +947,7 @@ void DrawFloor(const Surface &out, Point tilePosition, Point targetBufferPositio
 			targetBufferPosition.x += TILE_WIDTH;
 		}
 		// Return to start of row
-		tilePosition += Displacement::fromDirection(DIR_W) * columns;
+		tilePosition += Displacement(DIR_W) * columns;
 		targetBufferPosition.x -= columns * TILE_WIDTH;
 
 		// Jump to next row
@@ -1003,7 +1003,7 @@ void DrawTileContent(const Surface &out, Point tilePosition, Point targetBufferP
 			targetBufferPosition.x += TILE_WIDTH;
 		}
 		// Return to start of row
-		tilePosition += Displacement::fromDirection(DIR_W) * columns;
+		tilePosition += Displacement(DIR_W) * columns;
 		targetBufferPosition.x -= columns * TILE_WIDTH;
 
 		// Jump to next row
@@ -1109,12 +1109,12 @@ void DrawGame(const Surface &fullOut, Point position)
 	if (CanPanelsCoverView()) {
 		if (zoomflag) {
 			if (chrflag || QuestLogIsOpen) {
-				position += Displacement::fromDirection(DIR_E) * 2;
+				position += Displacement(DIR_E) * 2;
 				columns -= 4;
 				sx += SPANEL_WIDTH - TILE_WIDTH / 2;
 			}
 			if (invflag || sbookflag) {
-				position += Displacement::fromDirection(DIR_E) * 2;
+				position += Displacement(DIR_E) * 2;
 				columns -= 4;
 				sx += -TILE_WIDTH / 2;
 			}
@@ -1530,8 +1530,8 @@ void CalcViewportGeometry()
 	int lrow = tileRows - RowsCoveredByPanel();
 
 	// Center player tile on screen
-	tileShift += Displacement::fromDirection(DIR_W) * (tileColums / 2);
-	tileShift += Displacement::fromDirection(DIR_N) * (lrow / 2);
+	tileShift += Displacement(DIR_W) * (tileColums / 2);
+	tileShift += Displacement(DIR_N) * (lrow / 2);
 
 	tileRows *= 2;
 
@@ -1545,7 +1545,7 @@ void CalcViewportGeometry()
 		}
 	} else if ((tileColums & 1) != 0 && (lrow & 1) != 0) {
 		// Offset tile to vertically align the player when both rows and colums are odd
-		tileShift += Displacement::fromDirection(DIR_N);
+		tileShift += Displacement(DIR_N);
 		tileRows++;
 		tileOffset.deltaY -= TILE_HEIGHT / 2;
 	}


### PR DESCRIPTION
This PR changes how we usually convert from a `Direction` instance to a `Displacement` by introducing an explicit conversion constructor that is used in place of the old `fromDirection` static method. This leads to simpler and more standardized code since we currently use this approach for other types like `Size` as well.

The old method is kept to simplify the construction logic (leveraging the automatic copy constructor) but is made `private` to encourage the use of the constructor instead.