### PR TITLE
🚚 Rename 'Dead' concept to 'Corpse' everywhere

### DIFF
--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -12,18 +12,18 @@
 
 namespace devilution {
 
-DeadStruct Corpses[MaxCorpses];
+Corpse Corpses[MaxCorpses];
 int8_t stonendx;
 
 namespace {
-void InitDeadAnimationFromMonster(DeadStruct &dead, const CMonster &mon)
+void InitDeadAnimationFromMonster(Corpse &corpse, const CMonster &mon)
 {
 	int i = 0;
 	const auto &animData = mon.GetAnimData(MonsterGraphic::Death);
 	for (const auto &celSprite : animData.CelSpritesForDirections)
-		dead.data[i++] = celSprite->Data();
-	dead.frame = animData.Frames;
-	dead.width = animData.CelSpritesForDirections[0]->Width();
+		corpse.data[i++] = celSprite->Data();
+	corpse.frame = animData.Frames;
+	corpse.width = animData.CelSpritesForDirections[0]->Width();
 }
 } // namespace
 

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -12,7 +12,7 @@
 
 namespace devilution {
 
-DeadStruct Dead[MaxDead];
+DeadStruct Dead[MaxCorpses];
 int8_t stonendx;
 
 namespace {
@@ -68,7 +68,7 @@ void InitDead()
 		}
 	}
 
-	assert(static_cast<unsigned>(nd) <= MaxDead);
+	assert(static_cast<unsigned>(nd) <= MaxCorpses);
 }
 
 void AddDead(Point tilePosition, int8_t dv, Direction ddir)

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -12,7 +12,7 @@
 
 namespace devilution {
 
-DeadStruct Dead[MaxCorpses];
+DeadStruct Corpses[MaxCorpses];
 int8_t stonendx;
 
 namespace {
@@ -37,8 +37,8 @@ void InitDead()
 		if (mtypes[LevelMonsterTypes[i].mtype] != 0)
 			continue;
 
-		InitDeadAnimationFromMonster(Dead[nd], LevelMonsterTypes[i]);
-		Dead[nd].translationPaletteIndex = 0;
+		InitDeadAnimationFromMonster(Corpses[nd], LevelMonsterTypes[i]);
+		Corpses[nd].translationPaletteIndex = 0;
 		nd++;
 
 		LevelMonsterTypes[i].mdeadval = nd;
@@ -47,12 +47,12 @@ void InitDead()
 
 	nd++; // Unused blood spatter
 
-	for (auto &dead : Dead[nd].data)
-		dead = MissileSpriteData[MFILE_SHATTER1].animData[0].get();
+	for (auto &corpse : Corpses[nd].data)
+		corpse = MissileSpriteData[MFILE_SHATTER1].animData[0].get();
 
-	Dead[nd].frame = 12;
-	Dead[nd].width = 128;
-	Dead[nd].translationPaletteIndex = 0;
+	Corpses[nd].frame = 12;
+	Corpses[nd].width = 128;
+	Corpses[nd].translationPaletteIndex = 0;
 	nd++;
 
 	stonendx = nd;
@@ -60,8 +60,8 @@ void InitDead()
 	for (int i = 0; i < ActiveMonsterCount; i++) {
 		auto &monster = Monsters[ActiveMonsters[i]];
 		if (monster._uniqtype != 0) {
-			InitDeadAnimationFromMonster(Dead[nd], *monster.MType);
-			Dead[nd].translationPaletteIndex = monster._uniqtrans + 4;
+			InitDeadAnimationFromMonster(Corpses[nd], *monster.MType);
+			Corpses[nd].translationPaletteIndex = monster._uniqtrans + 4;
 			nd++;
 
 			monster._udeadval = nd;

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -71,7 +71,7 @@ void InitCorpses()
 	assert(static_cast<unsigned>(nd) <= MaxCorpses);
 }
 
-void AddDead(Point tilePosition, int8_t dv, Direction ddir)
+void AddCorpse(Point tilePosition, int8_t dv, Direction ddir)
 {
 	dDead[tilePosition.x][tilePosition.y] = (dv & 0x1F) + (ddir << 5);
 }

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -73,7 +73,7 @@ void InitCorpses()
 
 void AddCorpse(Point tilePosition, int8_t dv, Direction ddir)
 {
-	dDead[tilePosition.x][tilePosition.y] = (dv & 0x1F) + (ddir << 5);
+	dCorpse[tilePosition.x][tilePosition.y] = (dv & 0x1F) + (ddir << 5);
 }
 
 void SyncUniqDead()
@@ -84,7 +84,7 @@ void SyncUniqDead()
 			continue;
 		for (int dx = 0; dx < MAXDUNX; dx++) {
 			for (int dy = 0; dy < MAXDUNY; dy++) {
-				if ((dDead[dx][dy] & 0x1F) == monster._udeadval)
+				if ((dCorpse[dx][dy] & 0x1F) == monster._udeadval)
 					ChangeLightXY(monster.mlid, { dx, dy });
 			}
 		}

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -27,7 +27,7 @@ void InitDeadAnimationFromMonster(Corpse &corpse, const CMonster &mon)
 }
 } // namespace
 
-void InitDead()
+void InitCorpses()
 {
 	int8_t mtypes[MAXMONSTERS] = {};
 

--- a/Source/dead.h
+++ b/Source/dead.h
@@ -13,7 +13,7 @@
 
 namespace devilution {
 
-static constexpr unsigned MaxDead = 31;
+static constexpr unsigned MaxCorpses = 31;
 
 struct DeadStruct {
 	std::array<const byte *, 8> data;
@@ -22,7 +22,7 @@ struct DeadStruct {
 	uint8_t translationPaletteIndex;
 };
 
-extern DeadStruct Dead[MaxDead];
+extern DeadStruct Dead[MaxCorpses];
 extern int8_t stonendx;
 
 void InitDead();

--- a/Source/dead.h
+++ b/Source/dead.h
@@ -26,7 +26,7 @@ extern Corpse Corpses[MaxCorpses];
 extern int8_t stonendx;
 
 void InitCorpses();
-void AddDead(Point tilePosition, int8_t dv, Direction ddir);
+void AddCorpse(Point tilePosition, int8_t dv, Direction ddir);
 void SyncUniqDead();
 
 } // namespace devilution

--- a/Source/dead.h
+++ b/Source/dead.h
@@ -25,7 +25,7 @@ struct Corpse {
 extern Corpse Corpses[MaxCorpses];
 extern int8_t stonendx;
 
-void InitDead();
+void InitCorpses();
 void AddDead(Point tilePosition, int8_t dv, Direction ddir);
 void SyncUniqDead();
 

--- a/Source/dead.h
+++ b/Source/dead.h
@@ -15,14 +15,14 @@ namespace devilution {
 
 static constexpr unsigned MaxCorpses = 31;
 
-struct DeadStruct {
+struct Corpse {
 	std::array<const byte *, 8> data;
 	int frame;
 	int width;
 	uint8_t translationPaletteIndex;
 };
 
-extern DeadStruct Corpses[MaxCorpses];
+extern Corpse Corpses[MaxCorpses];
 extern int8_t stonendx;
 
 void InitDead();

--- a/Source/dead.h
+++ b/Source/dead.h
@@ -22,7 +22,7 @@ struct DeadStruct {
 	uint8_t translationPaletteIndex;
 };
 
-extern DeadStruct Dead[MaxCorpses];
+extern DeadStruct Corpses[MaxCorpses];
 extern int8_t stonendx;
 
 void InitDead();

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1909,7 +1909,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 				IncProgress();
 				uint32_t mid3Seed = GetLCGEngineState();
 				InitMissiles();
-				InitDead();
+				InitCorpses();
 #if _DEBUG
 				SetDebugLevelSeedInfos(mid1Seed, mid2Seed, mid3Seed, GetLCGEngineState());
 #endif
@@ -1923,7 +1923,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 				HoldThemeRooms();
 				InitMonsters();
 				InitMissiles();
-				InitDead();
+				InitCorpses();
 				IncProgress();
 				LoadLevel();
 				IncProgress();
@@ -1960,7 +1960,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 		IncProgress();
 		InitMissileGFX();
 		IncProgress();
-		InitDead();
+		InitCorpses();
 		IncProgress();
 		FillSolidBlockTbls();
 		IncProgress();

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -52,7 +52,7 @@ char dPreLight[MAXDUNX][MAXDUNY];
 int8_t dFlags[MAXDUNX][MAXDUNY];
 int8_t dPlayer[MAXDUNX][MAXDUNY];
 int16_t dMonster[MAXDUNX][MAXDUNY];
-int8_t dDead[MAXDUNX][MAXDUNY];
+int8_t dCorpse[MAXDUNX][MAXDUNY];
 char dObject[MAXDUNX][MAXDUNY];
 int8_t dItem[MAXDUNX][MAXDUNY];
 char dSpecial[MAXDUNX][MAXDUNY];
@@ -561,7 +561,7 @@ void DRLG_Init_Globals()
 	memset(dFlags, 0, sizeof(dFlags));
 	memset(dPlayer, 0, sizeof(dPlayer));
 	memset(dMonster, 0, sizeof(dMonster));
-	memset(dDead, 0, sizeof(dDead));
+	memset(dCorpse, 0, sizeof(dCorpse));
 	memset(dObject, 0, sizeof(dObject));
 	memset(dItem, 0, sizeof(dItem));
 	memset(dSpecial, 0, sizeof(dSpecial));

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -208,7 +208,7 @@ extern int16_t dMonster[MAXDUNX][MAXDUNY];
  * dDead[x][y] & 0x1F - index of dead
  * dDead[x][y] >> 0x5 - direction
  */
-extern int8_t dDead[MAXDUNX][MAXDUNY];
+extern int8_t dCorpse[MAXDUNX][MAXDUNY];
 /** Contains the object numbers (objects array indices) of the map. */
 extern char dObject[MAXDUNX][MAXDUNY];
 /** Contains the item numbers (items array indices) of the map. */

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1792,7 +1792,7 @@ void LoadGame(bool firstflag)
 		}
 		for (int j = 0; j < MAXDUNY; j++) {
 			for (int i = 0; i < MAXDUNX; i++) // NOLINT(modernize-loop-convert)
-				dDead[i][j] = file.NextLE<int8_t>();
+				dCorpse[i][j] = file.NextLE<int8_t>();
 		}
 		for (int j = 0; j < MAXDUNY; j++) {
 			for (int i = 0; i < MAXDUNX; i++) // NOLINT(modernize-loop-convert)
@@ -1987,7 +1987,7 @@ void SaveGameData()
 		}
 		for (int j = 0; j < MAXDUNY; j++) {
 			for (int i = 0; i < MAXDUNX; i++) // NOLINT(modernize-loop-convert)
-				file.WriteLE<int8_t>(dDead[i][j]);
+				file.WriteLE<int8_t>(dCorpse[i][j]);
 		}
 		for (int j = 0; j < MAXDUNY; j++) {
 			for (int i = 0; i < MAXDUNX; i++) // NOLINT(modernize-loop-convert)
@@ -2045,7 +2045,7 @@ void SaveLevel()
 	if (leveltype != DTYPE_TOWN) {
 		for (int j = 0; j < MAXDUNY; j++) {
 			for (int i = 0; i < MAXDUNX; i++) // NOLINT(modernize-loop-convert)
-				file.WriteLE<int8_t>(dDead[i][j]);
+				file.WriteLE<int8_t>(dCorpse[i][j]);
 		}
 	}
 
@@ -2123,7 +2123,7 @@ void LoadLevel()
 	if (leveltype != DTYPE_TOWN) {
 		for (int j = 0; j < MAXDUNY; j++) {
 			for (int i = 0; i < MAXDUNX; i++) // NOLINT(modernize-loop-convert)
-				dDead[i][j] = file.NextLE<int8_t>();
+				dCorpse[i][j] = file.NextLE<int8_t>();
 		}
 		SyncUniqDead();
 	}

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3786,7 +3786,7 @@ void MI_Stone(Missile &missile)
 			monster._mmode = static_cast<MonsterMode>(missile.var1);
 			monster.AnimInfo.IsPetrified = false;
 		} else {
-			AddDead(monster.position.tile, stonendx, monster._mdir);
+			AddCorpse(monster.position.tile, stonendx, monster._mdir);
 		}
 	}
 	if (missile._miAnimType == MFILE_SHATTER1)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1822,9 +1822,9 @@ bool MonsterDeath(int i)
 			PrepDoEnding();
 	} else if (monster.AnimInfo.CurrentFrame == monster.AnimInfo.NumberOfFrames) {
 		if (monster._uniqtype == 0)
-			AddDead(monster.position.tile, monster.MType->mdeadval, monster._mdir);
+			AddCorpse(monster.position.tile, monster.MType->mdeadval, monster._mdir);
 		else
-			AddDead(monster.position.tile, monster._udeadval, monster._mdir);
+			AddCorpse(monster.position.tile, monster._udeadval, monster._mdir);
 
 		dMonster[monster.position.tile.x][monster.position.tile.y] = 0;
 		monster._mDelFlag = true;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -2439,7 +2439,7 @@ void ScavengerAi(int i)
 	}
 	if (monster._mgoal == MGOAL_HEALING && monster._mgoalvar3 != 0) {
 		monster._mgoalvar3--;
-		if (dDead[monster.position.tile.x][monster.position.tile.y] != 0) {
+		if (dCorpse[monster.position.tile.x][monster.position.tile.y] != 0) {
 			StartEating(monster);
 			if ((monster._mFlags & MFLAG_NOHEAL) == 0) {
 				if (gbIsHellfire) {
@@ -2448,7 +2448,7 @@ void ScavengerAi(int i)
 					if (monster._mhitpoints > monster._mmaxhp)
 						monster._mhitpoints = monster._mmaxhp;
 					if (monster._mgoalvar3 <= 0 || monster._mhitpoints == monster._mmaxhp)
-						dDead[monster.position.tile.x][monster.position.tile.y] = 0;
+						dCorpse[monster.position.tile.x][monster.position.tile.y] = 0;
 				} else {
 					monster._mhitpoints += 64;
 				}
@@ -2472,7 +2472,7 @@ void ScavengerAi(int i)
 							// BUGFIX: incorrect check of offset against limits of the dungeon
 							if (y < 0 || y >= MAXDUNY || x < 0 || x >= MAXDUNX)
 								continue;
-							done = dDead[monster.position.tile.x + x][monster.position.tile.y + y] != 0
+							done = dCorpse[monster.position.tile.x + x][monster.position.tile.y + y] != 0
 							    && IsLineNotSolid(
 							        monster.position.tile,
 							        monster.position.tile + Displacement { x, y });
@@ -2486,7 +2486,7 @@ void ScavengerAi(int i)
 							// BUGFIX: incorrect check of offset against limits of the dungeon
 							if (y < 0 || y >= MAXDUNY || x < 0 || x >= MAXDUNX)
 								continue;
-							done = dDead[monster.position.tile.x + x][monster.position.tile.y + y] != 0
+							done = dCorpse[monster.position.tile.x + x][monster.position.tile.y + y] != 0
 							    && IsLineNotSolid(
 							        monster.position.tile,
 							        monster.position.tile + Displacement { x, y });

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2044,9 +2044,9 @@ void DeltaLoadLevel()
 				if (monster._mAi != AI_DIABLO) {
 					if (monster._uniqtype == 0) {
 						assert(monster.MType != nullptr);
-						AddDead(monster.position.tile, monster.MType->mdeadval, monster._mdir);
+						AddCorpse(monster.position.tile, monster.MType->mdeadval, monster._mdir);
 					} else {
-						AddDead(monster.position.tile, monster._udeadval, monster._mdir);
+						AddCorpse(monster.position.tile, monster._udeadval, monster._mdir);
 					}
 				}
 				monster._mDelFlag = true;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1503,7 +1503,7 @@ void UpdateDoor(int i)
 	int dy = Objects[i].position.y;
 	bool dok = dMonster[dx][dy] == 0;
 	dok = dok && dItem[dx][dy] == 0;
-	dok = dok && dDead[dx][dy] == 0;
+	dok = dok && dCorpse[dx][dy] == 0;
 	dok = dok && dPlayer[dx][dy] == 0;
 	Objects[i]._oSelFlag = 2;
 	Objects[i]._oVar4 = dok ? 1 : 2;
@@ -1804,7 +1804,7 @@ void DoorSet(Point position, bool isLeftDoor)
  */
 inline bool IsDoorClear(const Point &doorPosition)
 {
-	return dDead[doorPosition.x][doorPosition.y] == 0
+	return dCorpse[doorPosition.x][doorPosition.y] == 0
 	    && dMonster[doorPosition.x][doorPosition.y] == 0
 	    && dItem[doorPosition.x][doorPosition.y] == 0;
 }

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3189,7 +3189,7 @@ void RemovePlrMissiles(int pnum)
 		auto &golem = Monsters[MyPlayerId];
 		if (golem.position.tile.x != 1 || golem.position.tile.y != 0) {
 			M_StartKill(MyPlayerId, MyPlayerId);
-			AddDead(golem.position.tile, golem.MType->mdeadval, golem._mdir);
+			AddCorpse(golem.position.tile, golem.MType->mdeadval, golem._mdir);
 			int mx = golem.position.tile.x;
 			int my = golem.position.tile.y;
 			dMonster[mx][my] = 0;

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -829,7 +829,7 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 	DrawCell(out, tilePosition, targetBufferPosition);
 
 	int8_t bFlag = dFlags[tilePosition.x][tilePosition.y];
-	int8_t bDead = dDead[tilePosition.x][tilePosition.y];
+	int8_t bDead = dCorpse[tilePosition.x][tilePosition.y];
 	int8_t bMap = dTransVal[tilePosition.x][tilePosition.y];
 
 	int negMon = 0;

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -849,7 +849,7 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 
 	if (LightTableIndex < LightsMax && bDead != 0) {
 		do {
-			DeadStruct *pDeadGuy = &Dead[(bDead & 0x1F) - 1];
+			DeadStruct *pDeadGuy = &Corpses[(bDead & 0x1F) - 1];
 			auto dd = static_cast<Direction>((bDead >> 5) & 7);
 			int px = targetBufferPosition.x - CalculateWidth2(pDeadGuy->width);
 			const byte *pCelBuff = pDeadGuy->data[dd];

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -849,7 +849,7 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 
 	if (LightTableIndex < LightsMax && bDead != 0) {
 		do {
-			DeadStruct *pDeadGuy = &Corpses[(bDead & 0x1F) - 1];
+			Corpse *pDeadGuy = &Corpses[(bDead & 0x1F) - 1];
 			auto dd = static_cast<Direction>((bDead >> 5) & 7);
 			int px = targetBufferPosition.x - CalculateWidth2(pDeadGuy->width);
 			const byte *pCelBuff = pDeadGuy->data[dd];

--- a/test/dead_test.cpp
+++ b/test/dead_test.cpp
@@ -9,11 +9,11 @@ using namespace devilution;
 TEST(Corpses, AddCorpse)
 {
 	AddCorpse({ 21, 48 }, 8, DIR_W);
-	EXPECT_EQ(dDead[21][48], 8 + (DIR_W << 5));
+	EXPECT_EQ(dCorpse[21][48], 8 + (DIR_W << 5));
 }
 
 TEST(Corpses, AddCorpse_OOB)
 {
 	AddCorpse({ 21, 48 }, MaxCorpses + 1, DIR_W);
-	EXPECT_EQ(dDead[21][48], 0 + (DIR_W << 5));
+	EXPECT_EQ(dCorpse[21][48], 0 + (DIR_W << 5));
 }

--- a/test/dead_test.cpp
+++ b/test/dead_test.cpp
@@ -6,14 +6,14 @@
 
 using namespace devilution;
 
-TEST(Corpses, AddDead)
+TEST(Corpses, AddCorpse)
 {
-	AddDead({ 21, 48 }, 8, DIR_W);
+	AddCorpse({ 21, 48 }, 8, DIR_W);
 	EXPECT_EQ(dDead[21][48], 8 + (DIR_W << 5));
 }
 
-TEST(Corpses, AddDead_OOB)
+TEST(Corpses, AddCorpse_OOB)
 {
-	AddDead({ 21, 48 }, MaxCorpses + 1, DIR_W);
+	AddCorpse({ 21, 48 }, MaxCorpses + 1, DIR_W);
 	EXPECT_EQ(dDead[21][48], 0 + (DIR_W << 5));
 }

--- a/test/dead_test.cpp
+++ b/test/dead_test.cpp
@@ -14,6 +14,6 @@ TEST(Dead, AddDead)
 
 TEST(Dead, AddDead_OOB)
 {
-	AddDead({ 21, 48 }, MaxDead + 1, DIR_W);
+	AddDead({ 21, 48 }, MaxCorpses + 1, DIR_W);
 	EXPECT_EQ(dDead[21][48], 0 + (DIR_W << 5));
 }

--- a/test/dead_test.cpp
+++ b/test/dead_test.cpp
@@ -6,13 +6,13 @@
 
 using namespace devilution;
 
-TEST(Dead, AddDead)
+TEST(Corpses, AddDead)
 {
 	AddDead({ 21, 48 }, 8, DIR_W);
 	EXPECT_EQ(dDead[21][48], 8 + (DIR_W << 5));
 }
 
-TEST(Dead, AddDead_OOB)
+TEST(Corpses, AddDead_OOB)
 {
 	AddDead({ 21, 48 }, MaxCorpses + 1, DIR_W);
 	EXPECT_EQ(dDead[21][48], 0 + (DIR_W << 5));


### PR DESCRIPTION
This PR renames most members that refer to dead bodies by 'Dead' to 'Corpse'. This includes the methods, variables and associated structs.