### PR TITLE
[Android] Fix input not being in view for 7.1+

### DIFF
--- a/android-project/app/src/main/java/org/diasurgical/devilutionx/DevilutionXSDLActivity.java
+++ b/android-project/app/src/main/java/org/diasurgical/devilutionx/DevilutionXSDLActivity.java
@@ -4,10 +4,14 @@ import android.Manifest;
 import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.graphics.Rect;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.util.Log;
+import android.view.SurfaceHolder;
+import android.view.SurfaceView;
+import android.view.ViewTreeObserver;
 
 import org.libsdl.app.SDLActivity;
 
@@ -23,6 +27,11 @@ public class DevilutionXSDLActivity extends SDLActivity {
 	private String externalDir;
 
 	protected void onCreate(Bundle savedInstanceState) {
+		// windowSoftInputMode=adjustPan stopped working
+		// for fullscreen apps after Android 7.0
+		if (Build.VERSION.SDK_INT >= 25)
+			trackVisibleSpace();
+
 		externalDir = getExternalFilesDir(null).getAbsolutePath();
 
 		migrateAppData();
@@ -41,6 +50,22 @@ public class DevilutionXSDLActivity extends SDLActivity {
 			startActivity(intent);
 			this.finish();
 		}
+	}
+
+	private void trackVisibleSpace() {
+		this.getWindow().getDecorView().getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+			@Override
+			public void onGlobalLayout() {
+				// Software keyboard may encroach on the app's visible space so
+				// force the drawing surface to fit in the visible display frame
+				Rect visibleSpace = new Rect();
+				getWindow().getDecorView().getWindowVisibleDisplayFrame(visibleSpace);
+
+				SurfaceView surface = mSurface;
+				SurfaceHolder holder = surface.getHolder();
+				holder.setFixedSize(visibleSpace.width(), visibleSpace.height());
+			}
+		});
 	}
 
 	private boolean missingGameData() {


### PR DESCRIPTION
This just sets up a listener to force the drawing surface to fit in the window's "visible display frame". This causes the SDL window to resize to fit in that available space. The result is that the game window will shrink or grow to fit in whatever space is made available to it.

![image](https://user-images.githubusercontent.com/9203145/132265732-b47056ff-42e8-4f8c-a548-0fa79dddfe7a.png)