### PR TITLE
fix golems on maps with set pieces

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3859,8 +3859,9 @@ void InitMonsters()
 void SetMapMonsters(const uint16_t *dunData, Point startPosition)
 {
 	AddMonsterType(MT_GOLEM, PLACE_SPECIAL);
-	for (int i = 0; i < MAX_PLRS; i++)
-		AddMonster(GolemHoldingCell, DIR_S, 0, false);
+	if (setlevel)
+		for (int i = 0; i < MAX_PLRS; i++)
+			AddMonster(GolemHoldingCell, DIR_S, 0, false);
 
 	if (setlevel && setlvlnum == SL_VILEBETRAYER) {
 		AddMonsterType(UniqueMonstersData[UMT_LAZARUS].mtype, PLACE_UNIQUE);


### PR DESCRIPTION
This fixes a bug where 4 golems (1 for each player) were added twice when a map contained set pieces (halls of the blind, anvil of fury etc.) - since it doesn't happen for butcher's room or poisoned water supply entrance, I'm assuming this has to be a set piece with enemies. (Means there were 20 golems in monsters array on dlvl 16 ... yay)

```cpp
void InitMonsters()
{
	if (!setlevel) {
		for (int i = 0; i < MAX_PLRS; i++)
			AddMonster(GolemHoldingCell, DIR_S, 0, false);
	}
```
since it wasn't a "setlevel", this part would trigger.
```cpp
void SetMapMonsters(const uint16_t *dunData, Point startPosition)
{
	AddMonsterType(MT_GOLEM, PLACE_SPECIAL);
	for (int i = 0; i < MAX_PLRS; i++)
		AddMonster(GolemHoldingCell, DIR_S, 0, false);
```
but this one too = you end up with 2x golems and hitting new fixed golem assert.
Adding a check for setlevel in SetMapMonsters fixes the problem.