### PR TITLE
colored stairs

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -282,6 +282,7 @@ void LoadOptions()
 	sgOptions.Gameplay.bShowMonsterType = GetIniBool("Game", "Show Monster Type", false);
 	sgOptions.Gameplay.bDisableCripplingShrines = GetIniBool("Game", "Disable Crippling Shrines", false);
 	sgOptions.Gameplay.bAutoRefillBelt = GetIniBool("Game", "Auto Refill Belt", AUTO_PICKUP_DEFAULT(false));
+	sgOptions.Gameplay.bCustomStairsShapes = GetIniBool("Game", "Automap Shows Stairs Type", false);
 
 	GetIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress, sizeof(sgOptions.Network.szBindAddress), "0.0.0.0");
 	sgOptions.Network.nPort = GetIniInt("Network", "Port", 6112);
@@ -434,6 +435,7 @@ void SaveOptions()
 	SetIniValue("Game", "Show Monster Type", sgOptions.Gameplay.bShowMonsterType);
 	SetIniValue("Game", "Disable Crippling Shrines", sgOptions.Gameplay.bDisableCripplingShrines);
 	SetIniValue("Game", "Auto Refill Belt", sgOptions.Gameplay.bAutoRefillBelt);
+	SetIniValue("Game", "Automap Shows Stairs Type", sgOptions.Gameplay.bCustomStairsShapes);
 
 	SetIniValue("Network", "Bind Address", sgOptions.Network.szBindAddress);
 	SetIniValue("Network", "Port", sgOptions.Network.nPort);

--- a/Source/options.h
+++ b/Source/options.h
@@ -138,6 +138,8 @@ struct GameplayOptions {
 	bool bAutoRefillBelt;
 	/** @brief Locally disable clicking on shrines which permanently cripple character. */
 	bool bDisableCripplingShrines;
+	/** @brief Stairs shape shown on automap indicates type - up/down/town/quest */
+	bool bCustomStairsShapes;
 };
 
 struct ControllerOptions {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14297035/132359909-cfbaa637-a3ee-4cec-9933-681d4ff6f4dd.png)

White = town
Blue = up
Red = down
Yellow (original color) = quest

# update
since colors got kind of taken by shared multiplayer automap, here's a different approach

![image](https://user-images.githubusercontent.com/14297035/138675820-bef22d74-5342-4632-ae4f-fafd93aaf7fa.png)

Standard stairs = quest level
Doubled top stair = up
Doubled bottom stair = down
Doubled all = town