### PR TITLE
Improve collision detection for moving missiles

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -685,6 +685,7 @@ void LoadMissile(LoadHelper *file, Missile &missile)
 	missile.var6 = file->NextLE<int32_t>();
 	missile.var7 = file->NextLE<int32_t>();
 	missile.limitReached = file->NextBool32();
+	missile.lastCollisionTargetHash = 0;
 }
 
 void LoadObject(LoadHelper &file, Object &object)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -616,6 +616,15 @@ void MoveMissileAndCheckMissileCol(Missile &missile, int mindam, int maxdam, boo
 	else
 		possibleVisitTiles = prevTile.ManhattanDistance(missile.position.tile);
 
+	int16_t tileTargetHash = dMonster[missile.position.tile.x][missile.position.tile.y] ^ dPlayer[missile.position.tile.x][missile.position.tile.y];
+
+	if (possibleVisitTiles == 0) {
+		// missile didn't change the tile... check that we perform CheckMissileCol only once for any monster/player to avoid multiple hits for slow missiles
+		if (missile.lastCollisionTargetHash == tileTargetHash)
+			return;
+	}
+	// remember what target CheckMissileCol was checked against
+	missile.lastCollisionTargetHash = tileTargetHash;
 	// Did the missile skipped a tile?
 	if (possibleVisitTiles > 1) {
 		// Implementation note: If someone knows the correct math to calculate this without this step for step increase loop, I would really appreciate it.
@@ -2885,6 +2894,7 @@ int AddMissile(Point src, Point dst, Direction midir, missile_id mitype, mienemy
 	missile._miAnimType = missileData.mFileNum;
 	missile._miDrawFlag = missileData.mDraw;
 	missile._mlid = NO_LIGHT;
+	missile.lastCollisionTargetHash = 0;
 
 	if (missile._miAnimType == MFILE_NONE || MissileSpriteData[missile._miAnimType].animFAmt < 8)
 		SetMissDir(missile, 0);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -590,10 +590,76 @@ void CheckMissileCol(Missile &missile, int mindam, int maxdam, bool shift, Point
 		PlaySfxLoc(MissilesData[missile._mitype].miSFX, missile.position.tile);
 }
 
+/**
+ * @brief Could the missile collide with solid objects? (like walls or closed doors)
+ */
+bool CouldMissileCollideWithSolidObject(Point tile)
+{
+	int oid = dObject[tile.x][tile.y];
+	if (oid != 0) {
+		oid = abs(oid) - 1;
+		if (!Objects[oid]._oMissFlag)
+			return true;
+	}
+	return nMissileTable[dPiece[tile.x][tile.y]];
+}
+
 void MoveMissileAndCheckMissileCol(Missile &missile, int mindam, int maxdam, bool ignoreStart, bool ifCollidesDontMoveToHitTile)
 {
+	Point prevTile = missile.position.tile;
 	missile.position.traveled += missile.position.velocity;
 	UpdateMissilePos(missile);
+
+	int possibleVisitTiles;
+	if (missile.position.velocity.deltaX == 0 || missile.position.velocity.deltaY == 0)
+		possibleVisitTiles = prevTile.WalkingDistance(missile.position.tile);
+	else
+		possibleVisitTiles = prevTile.ManhattanDistance(missile.position.tile);
+
+	// Did the missile skipped a tile?
+	if (possibleVisitTiles > 1) {
+		// Implementation note: If someone knows the correct math to calculate this without this step for step increase loop, I would really appreciate it.
+		auto incVelocity = missile.position.velocity * (0.01f / (float)(possibleVisitTiles - 1));
+		auto traveled = missile.position.traveled - missile.position.velocity;
+		do {
+			traveled += incVelocity;
+
+			// calculate in-between tile
+			int mx = traveled.deltaX >> 16;
+			int my = traveled.deltaY >> 16;
+			int dx = (mx + 2 * my) / 64;
+			int dy = (2 * my - mx) / 64;
+
+			auto tile = missile.position.start + Displacement { dx, dy };
+
+			// we are at the orginal calculated position => resume with normal logic
+			if (tile == missile.position.tile)
+				break;
+
+			// don't call CheckMissileCol more then once for a tile
+			if (prevTile == tile)
+				continue;
+			prevTile = tile;
+
+			CheckMissileCol(missile, mindam, maxdam, false, tile, false);
+
+			// Did missile hit anything?
+			if (missile._mirange != 0)
+				continue;
+
+			if ((missile._miHitFlag && MissilesData[missile._mitype].MovementDistribution == MissileMovementDistrubution::Blockable) || CouldMissileCollideWithSolidObject(tile)) {
+				missile.position.traveled = traveled;
+				if (ifCollidesDontMoveToHitTile && missile._mirange == 0) {
+					missile.position.traveled -= incVelocity;
+					UpdateMissilePos(missile);
+					missile.position.StopMissile();
+				} else {
+					UpdateMissilePos(missile);
+				}
+				return;
+			}
+		} while (true);
+	}
 	if (ignoreStart && missile.position.start == missile.position.tile)
 		return;
 	CheckMissileCol(missile, mindam, maxdam, false, missile.position.tile, false);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -590,6 +590,20 @@ void CheckMissileCol(Missile &missile, int mindam, int maxdam, bool shift, Point
 		PlaySfxLoc(MissilesData[missile._mitype].miSFX, missile.position.tile);
 }
 
+void MoveMissileAndCheckMissileCol(Missile &missile, int mindam, int maxdam, bool ignoreStart, bool ifCollidesDontMoveToHitTile)
+{
+	missile.position.traveled += missile.position.velocity;
+	UpdateMissilePos(missile);
+	if (ignoreStart && missile.position.start == missile.position.tile)
+		return;
+	CheckMissileCol(missile, mindam, maxdam, false, missile.position.tile, false);
+	if (ifCollidesDontMoveToHitTile && missile._mirange == 0) {
+		missile.position.traveled -= missile.position.velocity;
+		UpdateMissilePos(missile);
+		missile.position.StopMissile();
+	}
+}
+
 void SetMissAnim(Missile &missile, int animtype)
 {
 	int dir = missile._mimfnum;
@@ -2856,8 +2870,6 @@ void MI_LArrow(Missile &missile)
 		MissilesData[missile._mitype].mResist = rst;
 	} else {
 		missile._midist++;
-		missile.position.traveled += missile.position.velocity;
-		UpdateMissilePos(missile);
 
 		int mind;
 		int maxd;
@@ -2874,16 +2886,13 @@ void MI_LArrow(Missile &missile)
 			maxd = GenerateRnd(10) + 1 + currlevel * 2;
 		}
 
-		if (missile.position.tile != missile.position.start) {
-			missile_resistance rst = MissilesData[missile._mitype].mResist;
-			MissilesData[missile._mitype].mResist = MISR_NONE;
-			CheckMissileCol(missile, mind, maxd, false, missile.position.tile, false);
-			MissilesData[missile._mitype].mResist = rst;
-		}
+		missile_resistance rst = MissilesData[missile._mitype].mResist;
+		MissilesData[missile._mitype].mResist = MISR_NONE;
+		MoveMissileAndCheckMissileCol(missile, mind, maxd, true, true);
+		MissilesData[missile._mitype].mResist = rst;
+
 		if (missile._mirange == 0) {
 			missile._mimfnum = 0;
-			missile.position.traveled -= missile.position.velocity;
-			UpdateMissilePos(missile);
 			if (missile._mitype == MIS_LARROW)
 				SetMissAnim(missile, MFILE_MINILTNG);
 			else
@@ -2909,8 +2918,6 @@ void MI_Arrow(Missile &missile)
 {
 	missile._mirange--;
 	missile._midist++;
-	missile.position.traveled += missile.position.velocity;
-	UpdateMissilePos(missile);
 	int p = missile._misource;
 
 	int mind;
@@ -2927,8 +2934,7 @@ void MI_Arrow(Missile &missile)
 		mind = currlevel;
 		maxd = 2 * currlevel;
 	}
-	if (missile.position.tile != missile.position.start)
-		CheckMissileCol(missile, mind, maxd, false, missile.position.tile, false);
+	MoveMissileAndCheckMissileCol(missile, mind, maxd, true, false);
 	if (missile._mirange == 0)
 		missile._miDelFlag = true;
 	PutMissile(missile);
@@ -2940,10 +2946,6 @@ void MI_Firebolt(Missile &missile)
 
 	missile._mirange--;
 	if (missile._mitype != MIS_BONESPIRIT || missile._mimfnum != 8) {
-		int omx = missile.position.traveled.deltaX;
-		int omy = missile.position.traveled.deltaY;
-		missile.position.traveled += missile.position.velocity;
-		UpdateMissilePos(missile);
 		int p = missile._misource;
 		if (p != -1) {
 			if (missile._micaster == TARGET_MONSTERS) {
@@ -2968,14 +2970,9 @@ void MI_Firebolt(Missile &missile)
 		} else {
 			d = currlevel + GenerateRnd(2 * currlevel);
 		}
-		if (missile.position.tile != missile.position.start) {
-			CheckMissileCol(missile, d, d, false, missile.position.tile, false);
-		}
+		MoveMissileAndCheckMissileCol(missile, d, d, true, true);
 		if (missile._mirange == 0) {
 			missile._miDelFlag = true;
-			missile.position.traveled = { omx, omy };
-			UpdateMissilePos(missile);
-			missile.position.StopMissile();
 			missile.var4 = -(AvailableMissiles[0] + 1);
 			Point dst = { 0, 0 };
 			auto dir = static_cast<Direction>(missile._mimfnum);
@@ -3042,10 +3039,8 @@ void MI_Lightball(Missile &missile)
 	int tx = missile.var1;
 	int ty = missile.var2;
 	missile._mirange--;
-	missile.position.traveled += missile.position.velocity;
-	UpdateMissilePos(missile);
 	int j = missile._mirange;
-	CheckMissileCol(missile, missile._midam, missile._midam, false, missile.position.tile, false);
+	MoveMissileAndCheckMissileCol(missile, missile._midam, missile._midam, false, false);
 	if (missile._miHitFlag)
 		missile._mirange = j;
 	int8_t obj = dObject[tx][ty];
@@ -3118,10 +3113,7 @@ void MI_Fireball(Missile &missile)
 		}
 	} else {
 		int dam = missile._midam;
-		missile.position.traveled += missile.position.velocity;
-		UpdateMissilePos(missile);
-		if (missile.position.tile != missile.position.start)
-			CheckMissileCol(missile, dam, dam, false, missile.position.tile, false);
+		MoveMissileAndCheckMissileCol(missile, dam, dam, true, false);
 		if (missile._mirange == 0) {
 			Point m = missile.position.tile;
 			ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame);
@@ -3512,10 +3504,8 @@ void MI_Firemove(Missile &missile)
 		SetMissDir(missile, 1);
 		missile._miAnimFrame = GenerateRnd(11) + 1;
 	}
-	missile.position.traveled += missile.position.velocity;
-	UpdateMissilePos(missile);
 	int j = missile._mirange;
-	CheckMissileCol(missile, missile._midam, missile._midam, false, missile.position.tile, false);
+	MoveMissileAndCheckMissileCol(missile, missile._midam, missile._midam, false, false);
 	if (missile._miHitFlag)
 		missile._mirange = j;
 	if (missile._mirange == 0) {
@@ -4052,9 +4042,7 @@ void MI_Cbolt(Missile &missile)
 		} else {
 			missile.var3--;
 		}
-		missile.position.traveled += missile.position.velocity;
-		UpdateMissilePos(missile);
-		CheckMissileCol(missile, missile._midam, missile._midam, false, missile.position.tile, false);
+		MoveMissileAndCheckMissileCol(missile, missile._midam, missile._midam, false, false);
 		if (missile._miHitFlag) {
 			missile.var1 = 8;
 			missile._mimfnum = 0;
@@ -4062,7 +4050,6 @@ void MI_Cbolt(Missile &missile)
 			missile.position.velocity = {};
 			SetMissAnim(missile, MFILE_LGHNING);
 			missile._mirange = missile._miAnimLen;
-			UpdateMissilePos(missile);
 		}
 		ChangeLight(missile._mlid, missile.position.tile, missile.var1);
 	}
@@ -4077,15 +4064,9 @@ void MI_Hbolt(Missile &missile)
 {
 	missile._mirange--;
 	if (missile._miAnimType != MFILE_HOLYEXPL) {
-		missile.position.traveled += missile.position.velocity;
-		UpdateMissilePos(missile);
 		int dam = missile._midam;
-		if (missile.position.tile != missile.position.start) {
-			CheckMissileCol(missile, dam, dam, false, missile.position.tile, false);
-		}
+		MoveMissileAndCheckMissileCol(missile, dam, dam, true, true);
 		if (missile._mirange == 0) {
-			missile.position.traveled -= missile.position.velocity;
-			UpdateMissilePos(missile);
 			missile._mimfnum = 0;
 			SetMissAnim(missile, MFILE_HOLYEXPL);
 			missile._mirange = missile._miAnimLen - 1;
@@ -4130,10 +4111,8 @@ void MI_Element(Missile &missile)
 			AddUnLight(missile._mlid);
 		}
 	} else {
-		missile.position.traveled += missile.position.velocity;
-		UpdateMissilePos(missile);
+		MoveMissileAndCheckMissileCol(missile, dam, dam, false, false);
 		Point c = missile.position.tile;
-		CheckMissileCol(missile, dam, dam, false, c, false);
 		if (missile.var3 == 0 && c == Point { missile.var4, missile.var5 })
 			missile.var3 = 1;
 		if (missile.var3 == 1) {
@@ -4178,10 +4157,8 @@ void MI_Bonespirit(Missile &missile)
 		}
 		PutMissile(missile);
 	} else {
-		missile.position.traveled += missile.position.velocity;
-		UpdateMissilePos(missile);
+		MoveMissileAndCheckMissileCol(missile, dam, dam, false, false);
 		Point c = missile.position.tile;
-		CheckMissileCol(missile, dam, dam, false, c, false);
 		if (missile.var3 == 0 && c == Point { missile.var4, missile.var5 })
 			missile.var3 = 1;
 		if (missile.var3 == 1) {

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -124,6 +124,10 @@ struct Missile {
 	int var6;
 	int var7;
 	bool limitReached;
+	/**
+      * @brief For moving missiles lastCollisionTargetHash contains the last entity (player or monster) that was checked in CheckMissileCol (needed to avoid multiple hits for a entity at the same tile).
+      */
+	int16_t lastCollisionTargetHash;
 };
 
 extern Missile Missiles[MAXMISSILES];


### PR DESCRIPTION
Fixes #2826
Fixes #1531
Fixes #2837

Notes:

- First Commit is only refactoring as a base for the following commits
- Check if the missile skipped tiles and do also collision checking for these skipped tiles
- Prevent perform collision detection for a target more then once at a tile (that means you can also avoid a hit by missed hit chance and not only block)
- Tested with missiles 10x faster and 10x slower then normal