### PR TITLE
Ensure scrolls and charges are cleared using correct spell after use

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1911,7 +1911,7 @@ void RemoveScroll(Player &player)
 	for (int i = 0; i < player._pNumInv; i++) {
 		if (!player.InvList[i].isEmpty()
 		    && (player.InvList[i]._iMiscId == IMISC_SCROLL || player.InvList[i]._iMiscId == IMISC_SCROLLT)
-		    && player.InvList[i]._iSpell == player._pRSpell) {
+		    && player.InvList[i]._iSpell == player._pSpell) {
 			player.RemoveInvItem(i);
 			player.CalcScrolls();
 			return;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1960,7 +1960,7 @@ void UseStaffCharge(Player &player)
 {
 	auto &staff = player.InvBody[INVLOC_HAND_LEFT];
 
-	if (!CanUseStaff(staff, player._pRSpell))
+	if (!CanUseStaff(staff, player._pSpell))
 		return;
 
 	staff._iCharges--;

--- a/test/inv_test.cpp
+++ b/test/inv_test.cpp
@@ -198,7 +198,7 @@ TEST(Inv, RemoveScroll_inventory)
 
 	// Put a firebolt scroll into the inventory
 	Players[MyPlayerId]._pNumInv = 1;
-	Players[MyPlayerId]._pRSpell = static_cast<spell_id>(SPL_FIREBOLT);
+	Players[MyPlayerId]._pSpell = static_cast<spell_id>(SPL_FIREBOLT);
 	Players[MyPlayerId].InvList[0]._itype = ITYPE_MISC;
 	Players[MyPlayerId].InvList[0]._iMiscId = IMISC_SCROLL;
 	Players[MyPlayerId].InvList[0]._iSpell = SPL_FIREBOLT;


### PR DESCRIPTION
This PR changes the variable we rely on to match the scroll or staff spell when removing a scroll or a staff charge that was just used via right clicking. 

Instead of picking the spell from the "readied spell" value (the spell currently selected), we pick the spell being cast by the player. This ensures the player cannot change the spell into something else right after casting and either causing wrong scrolls to be removed or no scrolls/charges removed at all.

Fixes #792