### PR TITLE
mpqapi: saner handling of hash/block tables

### DIFF
--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -377,13 +377,13 @@ void AllocBlock(uint32_t blockOffset, uint32_t blockSize)
 			if (block->offset + block->sizealloc == blockOffset) {
 				blockOffset = block->offset;
 				blockSize += block->sizealloc;
-				memset(block, 0, sizeof(BlockEntry));
+				*block = {};
 				AllocBlock(blockOffset, blockSize);
 				return;
 			}
 			if (blockOffset + blockSize == block->offset) {
 				blockSize += block->sizealloc;
-				memset(block, 0, sizeof(BlockEntry));
+				*block = {};
 				AllocBlock(blockOffset, blockSize);
 				return;
 			}
@@ -407,23 +407,23 @@ void AllocBlock(uint32_t blockOffset, uint32_t blockSize)
 int FindFreeBlock(uint32_t size, uint32_t *blockSize)
 {
 	for (int i = 0; i < INDEX_ENTRIES; i++) {
-		BlockEntry *pBlockTbl = &cur_archive.blockTbl[i];
-		if (pBlockTbl->offset == 0)
+		BlockEntry *block = &cur_archive.blockTbl[i];
+		if (block->offset == 0)
 			continue;
-		if (pBlockTbl->flags != 0)
+		if (block->flags != 0)
 			continue;
-		if (pBlockTbl->sizefile != 0)
+		if (block->sizefile != 0)
 			continue;
-		if (pBlockTbl->sizealloc < size)
+		if (block->sizealloc < size)
 			continue;
 
-		int result = pBlockTbl->offset;
+		int result = block->offset;
 		*blockSize = size;
-		pBlockTbl->offset += size;
-		pBlockTbl->sizealloc -= size;
+		block->offset += size;
+		block->sizealloc -= size;
 
-		if (pBlockTbl->sizealloc == 0)
-			memset(pBlockTbl, 0, sizeof(*pBlockTbl));
+		if (block->sizealloc == 0)
+			*block = {};
 
 		return result;
 	}
@@ -583,7 +583,7 @@ void mpqapi_remove_hash_entry(const char *pszName)
 	pHashTbl->block = -2;
 	int blockOffset = blockEntry->offset;
 	int blockSize = blockEntry->sizealloc;
-	memset(blockEntry, 0, sizeof(*blockEntry));
+	*blockEntry = {};
 	AllocBlock(blockOffset, blockSize);
 	cur_archive.modified = true;
 }

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -46,16 +46,16 @@ struct FileHeader {
 };
 
 struct HashEntry {
-	uint32_t hashcheck[2];
-	uint32_t lcid;
-	int32_t block;
+	uint32_t hashcheck[2] = { UINT32_MAX, UINT32_MAX };
+	uint32_t lcid = UINT32_MAX;
+	int32_t block = -1;
 };
 
 struct BlockEntry {
-	uint32_t offset;
-	uint32_t sizealloc;
-	uint32_t sizefile;
-	uint32_t flags;
+	uint32_t offset = 0;
+	uint32_t sizealloc = 0;
+	uint32_t sizefile = 0;
+	uint32_t flags = 0;
 };
 
 // Validates that a Type is of a particular size and that its alignment is <= the size of the type.
@@ -651,16 +651,14 @@ bool OpenMPQ(const char *pszArchive)
 		} else if (!ReadMPQHeader(&cur_archive, &fhdr)) {
 			goto on_error;
 		}
-		cur_archive.sgpBlockTbl = new BlockEntry[BlockEntrySize / sizeof(BlockEntry)];
-		std::memset(cur_archive.sgpBlockTbl, 0, BlockEntrySize);
+		cur_archive.sgpBlockTbl = new BlockEntry[INDEX_ENTRIES];
 		if (fhdr.blockcount > 0) {
 			if (!cur_archive.stream.Read(reinterpret_cast<char *>(cur_archive.sgpBlockTbl), BlockEntrySize))
 				goto on_error;
 			uint32_t key = Hash("(block table)", 3);
 			Decrypt((DWORD *)cur_archive.sgpBlockTbl, BlockEntrySize, key);
 		}
-		cur_archive.sgpHashTbl = new HashEntry[HashEntrySize / sizeof(HashEntry)];
-		std::memset(cur_archive.sgpHashTbl, 255, HashEntrySize);
+		cur_archive.sgpHashTbl = new HashEntry[INDEX_ENTRIES];
 		if (fhdr.hashcount > 0) {
 			if (!cur_archive.stream.Read(reinterpret_cast<char *>(cur_archive.sgpHashTbl), HashEntrySize))
 				goto on_error;

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -419,24 +419,23 @@ void AllocBlock(uint32_t blockOffset, uint32_t blockSize)
 
 int FindFreeBlock(uint32_t size, uint32_t *blockSize)
 {
-	for (int i = 0; i < INDEX_ENTRIES; i++) {
-		BlockEntry *block = &cur_archive.blockTbl[i];
-		if (block->offset == 0)
+	for (BlockEntry &block : cur_archive.blockTbl) {
+		if (block.offset == 0)
 			continue;
-		if (block->flags != 0)
+		if (block.flags != 0)
 			continue;
-		if (block->sizefile != 0)
+		if (block.sizefile != 0)
 			continue;
-		if (block->sizealloc < size)
+		if (block.sizealloc < size)
 			continue;
 
-		int result = block->offset;
+		int result = block.offset;
 		*blockSize = size;
-		block->offset += size;
-		block->sizealloc -= size;
+		block.offset += size;
+		block.sizealloc -= size;
 
-		if (block->sizealloc == 0)
-			*block = {};
+		if (block.sizealloc == 0)
+			block = {};
 
 		return result;
 	}

--- a/Source/mpqapi.h
+++ b/Source/mpqapi.h
@@ -11,32 +11,6 @@
 
 namespace devilution {
 
-struct _FILEHEADER {
-	uint32_t signature;
-	int headersize;
-	uint32_t filesize;
-	uint16_t version;
-	int16_t sectorsizeid;
-	int hashoffset;
-	int blockoffset;
-	int hashcount;
-	int blockcount;
-	uint8_t pad[72];
-};
-
-struct _HASHENTRY {
-	uint32_t hashcheck[2];
-	uint32_t lcid;
-	int32_t block;
-};
-
-struct _BLOCKENTRY {
-	uint32_t offset;
-	uint32_t sizealloc;
-	uint32_t sizefile;
-	uint32_t flags;
-};
-
 void mpqapi_remove_hash_entry(const char *pszName);
 void mpqapi_remove_hash_entries(bool (*fnGetName)(uint8_t, char *));
 bool mpqapi_write_file(const char *pszName, const byte *pbData, size_t dwLen);


### PR DESCRIPTION
The rationale for this is two-fold:

- `std::vector` is used to store the tables;  `new` and `delete` are gone
- Caching of the tables was brittle: basically, the programmer basically promised that the same archive would be loaded next time, and that was that. This PR checks the name of the file; if it doesn't match, the cache is disregarded.
