### PR TITLE
🐛 Prevent frame-perfect manipulation of spell being cast

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1096,17 +1096,18 @@ DWORD OnRangedAttackPlayer(TCmd *pCmd, Player &player)
 
 DWORD OnSpellMonster(TCmd *pCmd, Player &player)
 {
-	auto *p = (TCmdParam3 *)pCmd;
+	auto *p = (TCmdParam4 *)pCmd;
 
 	if (gbBufferMsgs != 1 && currlevel == player.plrlevel) {
 		auto spell = static_cast<spell_id>(p->wParam2);
+		auto spellType = static_cast<spell_type>(p->wParam3);
 		if (currlevel != 0 || spelldata[spell].sTownSpell) {
 			ClrPlrPath(player);
 			player.destAction = ACTION_SPELLMON;
 			player.destParam1 = p->wParam1;
-			player.destParam2 = p->wParam3;
+			player.destParam2 = p->wParam4;
 			player._pSpell = spell;
-			player._pSplType = player._pRSplType;
+			player._pSplType = spellType;
 			player._pSplFrom = 0;
 		} else {
 			PlayerMessageFormat(fmt::format(_("{:s} has cast an illegal spell."), player._pName).c_str());

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2295,6 +2295,21 @@ void NetSendCmdParam3(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wPar
 		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
 }
 
+void NetSendCmdParam4(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4)
+{
+	TCmdParam4 cmd;
+
+	cmd.bCmd = bCmd;
+	cmd.wParam1 = wParam1;
+	cmd.wParam2 = wParam2;
+	cmd.wParam3 = wParam3;
+	cmd.wParam4 = wParam4;
+	if (bHiPri)
+		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+	else
+		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+}
+
 void NetSendCmdQuest(bool bHiPri, const Quest &quest)
 {
 	TCmdQuest cmd;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -932,19 +932,20 @@ DWORD OnRangedAttackTile(TCmd *pCmd, Player &player)
 
 DWORD OnSpellWall(TCmd *pCmd, Player &player)
 {
-	auto *p = (TCmdLocParam3 *)pCmd;
+	auto *p = (TCmdLocParam4 *)pCmd;
 
 	if (gbBufferMsgs != 1 && currlevel == player.plrlevel) {
 		auto spell = static_cast<spell_id>(p->wParam1);
+		auto spellType = static_cast<spell_type>(p->wParam2);
 		if (currlevel != 0 || spelldata[spell].sTownSpell) {
 			ClrPlrPath(player);
 			player.destAction = ACTION_SPELLWALL;
 			player.destParam1 = p->x;
 			player.destParam2 = p->y;
-			player.destParam3 = static_cast<Direction>(p->wParam2);
-			player.destParam4 = p->wParam3;
+			player.destParam3 = static_cast<Direction>(p->wParam3);
+			player.destParam4 = p->wParam4;
 			player._pSpell = spell;
-			player._pSplType = player._pRSplType;
+			player._pSplType = spellType;
 			player._pSplFrom = 0;
 		} else {
 			PlayerMessageFormat(fmt::format(_("{:s} has cast an illegal spell."), player._pName).c_str());

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -956,18 +956,19 @@ DWORD OnSpellWall(TCmd *pCmd, Player &player)
 
 DWORD OnSpellTile(TCmd *pCmd, Player &player)
 {
-	auto *p = (TCmdLocParam2 *)pCmd;
+	auto *p = (TCmdLocParam3 *)pCmd;
 
 	if (gbBufferMsgs != 1 && currlevel == player.plrlevel) {
 		auto spell = static_cast<spell_id>(p->wParam1);
+		auto spellType = static_cast<spell_type>(p->wParam2);
 		if (currlevel != 0 || spelldata[spell].sTownSpell) {
 			ClrPlrPath(player);
 			player.destAction = ACTION_SPELL;
 			player.destParam1 = p->x;
 			player.destParam2 = p->y;
-			player.destParam3 = static_cast<Direction>(p->wParam2);
+			player.destParam3 = static_cast<Direction>(p->wParam3);
 			player._pSpell = spell;
-			player._pSplType = player._pRSplType;
+			player._pSplType = spellType;
 			player._pSplFrom = 0;
 		} else {
 			PlayerMessageFormat(fmt::format(_("{:s} has cast an illegal spell."), player._pName).c_str());

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1119,17 +1119,18 @@ DWORD OnSpellMonster(TCmd *pCmd, Player &player)
 
 DWORD OnSpellPlayer(TCmd *pCmd, Player &player)
 {
-	auto *p = (TCmdParam3 *)pCmd;
+	auto *p = (TCmdParam4 *)pCmd;
 
 	if (gbBufferMsgs != 1 && currlevel == player.plrlevel) {
 		auto spell = static_cast<spell_id>(p->wParam2);
+		auto spellType = static_cast<spell_type>(p->wParam3);
 		if (currlevel != 0 || spelldata[spell].sTownSpell) {
 			ClrPlrPath(player);
 			player.destAction = ACTION_SPELLPLR;
 			player.destParam1 = p->wParam1;
-			player.destParam2 = p->wParam3;
+			player.destParam2 = p->wParam4;
 			player._pSpell = spell;
-			player._pSplType = player._pRSplType;
+			player._pSplType = spellType;
 			player._pSplFrom = 0;
 		} else {
 			PlayerMessageFormat(fmt::format(_("{:s} has cast an illegal spell."), player._pName).c_str());

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2238,6 +2238,23 @@ void NetSendCmdLocParam3(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
 }
 
+void NetSendCmdLocParam4(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4)
+{
+	TCmdLocParam4 cmd;
+
+	cmd.bCmd = bCmd;
+	cmd.x = position.x;
+	cmd.y = position.y;
+	cmd.wParam1 = wParam1;
+	cmd.wParam2 = wParam2;
+	cmd.wParam3 = wParam3;
+	cmd.wParam4 = wParam4;
+	if (bHiPri)
+		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+	else
+		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+}
+
 void NetSendCmdParam1(bool bHiPri, _cmd_id bCmd, uint16_t wParam1)
 {
 	TCmdParam1 cmd;

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -193,6 +193,14 @@ struct TCmdParam3 {
 	uint16_t wParam3;
 };
 
+struct TCmdParam4 {
+	_cmd_id bCmd;
+	uint16_t wParam1;
+	uint16_t wParam2;
+	uint16_t wParam3;
+	uint16_t wParam4;
+};
+
 struct TCmdGolem {
 	_cmd_id bCmd;
 	uint8_t _mx;
@@ -439,6 +447,7 @@ void NetSendCmdLocParam4(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 void NetSendCmdParam1(bool bHiPri, _cmd_id bCmd, uint16_t wParam1);
 void NetSendCmdParam2(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2);
 void NetSendCmdParam3(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3);
+void NetSendCmdParam4(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4);
 void NetSendCmdQuest(bool bHiPri, const Quest &quest);
 void NetSendCmdGItem(bool bHiPri, _cmd_id bCmd, BYTE mast, BYTE pnum, BYTE ii);
 void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position);

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -165,6 +165,16 @@ struct TCmdLocParam3 {
 	uint16_t wParam3;
 };
 
+struct TCmdLocParam4 {
+	_cmd_id bCmd;
+	uint8_t x;
+	uint8_t y;
+	uint16_t wParam1;
+	uint16_t wParam2;
+	uint16_t wParam3;
+	uint16_t wParam4;
+};
+
 struct TCmdParam1 {
 	_cmd_id bCmd;
 	uint16_t wParam1;
@@ -425,6 +435,7 @@ void NetSendCmdLoc(int playerId, bool bHiPri, _cmd_id bCmd, Point position);
 void NetSendCmdLocParam1(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1);
 void NetSendCmdLocParam2(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2);
 void NetSendCmdLocParam3(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3);
+void NetSendCmdLocParam4(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4);
 void NetSendCmdParam1(bool bHiPri, _cmd_id bCmd, uint16_t wParam1);
 void NetSendCmdParam2(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2);
 void NetSendCmdParam3(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3554,7 +3554,7 @@ void CheckPlrSpell()
 	} else {
 		LastMouseButtonAction = MouseActionType::Spell;
 		sl = GetSpellLevel(MyPlayerId, myPlayer._pRSpell);
-		NetSendCmdLocParam2(true, CMD_SPELLXY, cursPosition, myPlayer._pRSpell, sl);
+		NetSendCmdLocParam3(true, CMD_SPELLXY, cursPosition, myPlayer._pRSpell, myPlayer._pRSplType, sl);
 	}
 }
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3542,7 +3542,7 @@ void CheckPlrSpell()
 		LastMouseButtonAction = MouseActionType::Spell;
 		Direction sd = GetDirection(myPlayer.position.tile, cursPosition);
 		sl = GetSpellLevel(MyPlayerId, myPlayer._pRSpell);
-		NetSendCmdLocParam3(true, CMD_SPELLXYD, cursPosition, myPlayer._pRSpell, static_cast<uint16_t>(sd), sl);
+		NetSendCmdLocParam4(true, CMD_SPELLXYD, cursPosition, myPlayer._pRSpell, myPlayer._pRSplType, static_cast<uint16_t>(sd), sl);
 	} else if (pcursmonst != -1) {
 		LastMouseButtonAction = MouseActionType::SpellMonsterTarget;
 		sl = GetSpellLevel(MyPlayerId, myPlayer._pRSpell);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3550,7 +3550,7 @@ void CheckPlrSpell()
 	} else if (pcursplr != -1) {
 		LastMouseButtonAction = MouseActionType::SpellPlayerTarget;
 		sl = GetSpellLevel(MyPlayerId, myPlayer._pRSpell);
-		NetSendCmdParam3(true, CMD_SPELLPID, pcursplr, myPlayer._pRSpell, sl);
+		NetSendCmdParam4(true, CMD_SPELLPID, pcursplr, myPlayer._pRSpell, myPlayer._pRSplType, sl);
 	} else {
 		LastMouseButtonAction = MouseActionType::Spell;
 		sl = GetSpellLevel(MyPlayerId, myPlayer._pRSpell);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3546,7 +3546,7 @@ void CheckPlrSpell()
 	} else if (pcursmonst != -1) {
 		LastMouseButtonAction = MouseActionType::SpellMonsterTarget;
 		sl = GetSpellLevel(MyPlayerId, myPlayer._pRSpell);
-		NetSendCmdParam3(true, CMD_SPELLID, pcursmonst, myPlayer._pRSpell, sl);
+		NetSendCmdParam4(true, CMD_SPELLID, pcursmonst, myPlayer._pRSpell, myPlayer._pRSplType, sl);
 	} else if (pcursplr != -1) {
 		LastMouseButtonAction = MouseActionType::SpellPlayerTarget;
 		sl = GetSpellLevel(MyPlayerId, myPlayer._pRSpell);


### PR DESCRIPTION
This PR changes all spell commands where the spell type was previously being inferred to explicitly pass this value at creation time.

This completely eliminates any possibility of manipulating the spell type between cast and execution and causing undefined behavior (like not consuming scrolls, staff changes, using incorrect mana values, etc).

Fixes #2844 