### PR TITLE
Fix OOB error in DrawString

### DIFF
--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -201,8 +201,13 @@ uint32_t DrawString(const Surface &out, string_view text, const Rectangle &rect,
 				break;
 			characterPosition.y += lineHeight;
 
-			if (HasAnyOf(flags, (UiFlags::AlignCenter | UiFlags::AlignRight | UiFlags::KerningFitSpacing)))
-				lineWidth = GetLineWidth(&text[i + 1], size, spacing, &charactersInLine);
+			if (HasAnyOf(flags, (UiFlags::AlignCenter | UiFlags::AlignRight | UiFlags::KerningFitSpacing))) {
+				int nextLineIndex = text[i] == '\n' ? i + 1 : i;
+				if (nextLineIndex < text.length())
+					lineWidth = GetLineWidth(&text[nextLineIndex], size, spacing, &charactersInLine);
+				else
+					lineWidth = 0;
+			}
 
 			if (HasAnyOf(flags, UiFlags::KerningFitSpacing))
 				spacing = AdjustSpacingToFitHorizontally(lineWidth, maxSpacing, charactersInLine, rect.size.width);


### PR DESCRIPTION
See https://github.com/diasurgical/devilutionX/pull/2791#discussion_r705485943

With #2848 having been merged, this fix has become relevant again. I wouldn't worry so much about it except there's a good chance translators will run into issues when trying different words and abbreviations to get things to fit. So here's the fix.