### PR TITLE
Fix missiles don't hit horizontal walking players/monsters

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -416,7 +416,7 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	player.position.temp.y = file.NextLE<int32_t>();
 	player.tempDirection = static_cast<Direction>(file.NextLE<int32_t>());
 	player._pVar4 = file.NextLE<int32_t>();
-	player._pVar5 = file.NextLE<int32_t>();
+	file.Skip(4); // skip _pVar5, was used for storing position of a tile which should have its BFLAG_PLAYERLR flag removed after walking
 	player.position.offset2.deltaX = file.NextLE<int32_t>();
 	player.position.offset2.deltaY = file.NextLE<int32_t>();
 	file.Skip(4); // Skip actionFrame
@@ -1091,7 +1091,7 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.WriteLE<int32_t>(player.position.temp.y);
 	file.WriteLE<int32_t>(static_cast<int32_t>(player.tempDirection));
 	file.WriteLE<int32_t>(player._pVar4);
-	file.WriteLE<int32_t>(player._pVar5);
+	file.Skip<int32_t>(); // skip _pVar5, was used for storing position of a tile which should have its BFLAG_PLAYERLR flag removed after walking
 	file.WriteLE<int32_t>(player.position.offset2.deltaX);
 	file.WriteLE<int32_t>(player.position.offset2.deltaY);
 	file.Skip<int32_t>(); // Skip _pVar8
@@ -1772,7 +1772,7 @@ void LoadGame(bool firstflag)
 	}
 	for (int j = 0; j < MAXDUNY; j++) {
 		for (int i = 0; i < MAXDUNX; i++) // NOLINT(modernize-loop-convert)
-			dFlags[i][j] = file.NextLE<int8_t>();
+			dFlags[i][j] = file.NextLE<int8_t>() & ~BFLAG_PLAYERLR;
 	}
 	for (int j = 0; j < MAXDUNY; j++) {
 		for (int i = 0; i < MAXDUNX; i++) // NOLINT(modernize-loop-convert)
@@ -2159,7 +2159,7 @@ void LoadLevel()
 
 	for (int j = 0; j < MAXDUNY; j++) {
 		for (int i = 0; i < MAXDUNX; i++) // NOLINT(modernize-loop-convert)
-			dFlags[i][j] = file.NextLE<int8_t>();
+			dFlags[i][j] = file.NextLE<int8_t>() & ~BFLAG_PLAYERLR;
 	}
 	for (int j = 0; j < MAXDUNY; j++) {
 		for (int i = 0; i < MAXDUNX; i++) // NOLINT(modernize-loop-convert)

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -415,7 +415,7 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	player.position.temp.x = file.NextLE<int32_t>();
 	player.position.temp.y = file.NextLE<int32_t>();
 	player.tempDirection = static_cast<Direction>(file.NextLE<int32_t>());
-	player._pVar4 = file.NextLE<int32_t>();
+	player.spellLevel = file.NextLE<int32_t>();
 	file.Skip(4); // skip _pVar5, was used for storing position of a tile which should have its BFLAG_PLAYERLR flag removed after walking
 	player.position.offset2.deltaX = file.NextLE<int32_t>();
 	player.position.offset2.deltaY = file.NextLE<int32_t>();
@@ -1090,7 +1090,7 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.WriteLE<int32_t>(player.position.temp.x);
 	file.WriteLE<int32_t>(player.position.temp.y);
 	file.WriteLE<int32_t>(static_cast<int32_t>(player.tempDirection));
-	file.WriteLE<int32_t>(player._pVar4);
+	file.WriteLE<int32_t>(player.spellLevel);
 	file.Skip<int32_t>(); // skip _pVar5, was used for storing position of a tile which should have its BFLAG_PLAYERLR flag removed after walking
 	file.WriteLE<int32_t>(player.position.offset2.deltaX);
 	file.WriteLE<int32_t>(player.position.offset2.deltaY);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1772,7 +1772,7 @@ void LoadGame(bool firstflag)
 	}
 	for (int j = 0; j < MAXDUNY; j++) {
 		for (int i = 0; i < MAXDUNX; i++) // NOLINT(modernize-loop-convert)
-			dFlags[i][j] = file.NextLE<int8_t>() & ~BFLAG_PLAYERLR;
+			dFlags[i][j] = file.NextLE<int8_t>() & ~(BFLAG_PLAYERLR | BFLAG_MONSTLR);
 	}
 	for (int j = 0; j < MAXDUNY; j++) {
 		for (int i = 0; i < MAXDUNX; i++) // NOLINT(modernize-loop-convert)
@@ -2159,7 +2159,7 @@ void LoadLevel()
 
 	for (int j = 0; j < MAXDUNY; j++) {
 		for (int i = 0; i < MAXDUNX; i++) // NOLINT(modernize-loop-convert)
-			dFlags[i][j] = file.NextLE<int8_t>() & ~BFLAG_PLAYERLR;
+			dFlags[i][j] = file.NextLE<int8_t>() & ~(BFLAG_PLAYERLR | BFLAG_MONSTLR);
 	}
 	for (int j = 0; j < MAXDUNY; j++) {
 		for (int i = 0; i < MAXDUNX; i++) // NOLINT(modernize-loop-convert)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -973,7 +973,7 @@ void StartWalk3(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int yad
 		ChangeLightXY(monster.mlid, { x, y });
 
 	dMonster[monster.position.tile.x][monster.position.tile.y] = -(i + 1);
-	dMonster[fx][fy] = -(i + 1);
+	dMonster[fx][fy] = i + 1;
 	monster.position.temp = { x, y };
 	dFlags[x][y] |= BFLAG_MONSTLR;
 	monster.position.old = monster.position.tile;
@@ -1357,6 +1357,7 @@ bool MonsterWalk(int i, MonsterMode variant)
 			dMonster[monster.position.tile.x][monster.position.tile.y] = 0;
 			monster.position.tile = { monster._mVar1, monster._mVar2 };
 			dFlags[monster.position.temp.x][monster.position.temp.y] &= ~BFLAG_MONSTLR;
+			// dMonster is set here for backwards comparability, without it the monster would be invisible if loaded from a vanilla save.
 			dMonster[monster.position.tile.x][monster.position.tile.y] = i + 1;
 			break;
 		default:

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -975,7 +975,6 @@ void StartWalk3(int i, int xvel, int yvel, int xoff, int yoff, int xadd, int yad
 	dMonster[monster.position.tile.x][monster.position.tile.y] = -(i + 1);
 	dMonster[fx][fy] = i + 1;
 	monster.position.temp = { x, y };
-	dFlags[x][y] |= BFLAG_MONSTLR;
 	monster.position.old = monster.position.tile;
 	monster.position.future = { fx, fy };
 	monster.position.offset = { xoff, yoff };
@@ -1356,7 +1355,6 @@ bool MonsterWalk(int i, MonsterMode variant)
 		case MonsterMode::MoveSideways:
 			dMonster[monster.position.tile.x][monster.position.tile.y] = 0;
 			monster.position.tile = { monster._mVar1, monster._mVar2 };
-			dFlags[monster.position.temp.x][monster.position.temp.y] &= ~BFLAG_MONSTLR;
 			// dMonster is set here for backwards comparability, without it the monster would be invisible if loaded from a vanilla save.
 			dMonster[monster.position.tile.x][monster.position.tile.y] = i + 1;
 			break;
@@ -3959,11 +3957,6 @@ void M_ClearSquares(int i)
 			}
 		}
 	}
-
-	if (mx + 1 < MAXDUNX)
-		dFlags[mx + 1][my] &= ~BFLAG_MONSTLR;
-	if (my + 1 < MAXDUNY)
-		dFlags[mx][my + 1] &= ~BFLAG_MONSTLR;
 }
 
 void M_GetKnockback(int i)
@@ -4402,10 +4395,10 @@ bool DirOK(int i, Direction mdir)
 	if (futurePosition.y < 0 || futurePosition.y >= MAXDUNY || futurePosition.x < 0 || futurePosition.x >= MAXDUNX || !IsTileAvailable(monster, futurePosition))
 		return false;
 	if (mdir == Direction::East) {
-		if (IsTileSolid(position + Direction::SouthEast) || (dFlags[position.x + 1][position.y] & BFLAG_MONSTLR) != 0)
+		if (IsTileSolid(position + Direction::SouthEast))
 			return false;
 	} else if (mdir == Direction::West) {
-		if (IsTileSolid(position + Direction::SouthWest) || (dFlags[position.x][position.y + 1] & BFLAG_MONSTLR) != 0)
+		if (IsTileSolid(position + Direction::SouthWest))
 			return false;
 	} else if (mdir == Direction::North) {
 		if (IsTileSolid(position + Direction::NorthEast) || IsTileSolid(position + Direction::NorthWest))
@@ -4440,7 +4433,7 @@ bool DirOK(int i, Direction mdir)
 
 bool PosOkMissile(Point position)
 {
-	return !nMissileTable[dPiece[position.x][position.y]] && (dFlags[position.x][position.y] & BFLAG_MONSTLR) == 0;
+	return !nMissileTable[dPiece[position.x][position.y]];
 }
 
 bool LineClearMissile(Point startPoint, Point endPoint)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -269,7 +269,7 @@ void WalkSides(int pnum, const DirectionSettings &walkParams)
 	Point const nextPosition = player.position.tile + walkParams.map;
 
 	dPlayer[player.position.tile.x][player.position.tile.y] = -(pnum + 1);
-	dPlayer[player.position.future.x][player.position.future.y] = -(pnum + 1);
+	dPlayer[player.position.future.x][player.position.future.y] = pnum + 1;
 	player._pVar4 = nextPosition.x;
 	player._pVar5 = nextPosition.y;
 	dFlags[nextPosition.x][nextPosition.y] |= BFLAG_PLAYERLR;
@@ -732,6 +732,7 @@ bool DoWalk(int pnum, int variant)
 			dPlayer[player.position.tile.x][player.position.tile.y] = 0;
 			dFlags[player._pVar4][player._pVar5] &= ~BFLAG_PLAYERLR;
 			player.position.tile = player.position.temp;
+			// dPlayer is set here for backwards comparability, without it the player would be invisible if loaded from a vanilla save.
 			dPlayer[player.position.tile.x][player.position.tile.y] = pnum + 1;
 			break;
 		}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -270,9 +270,6 @@ void WalkSides(int pnum, const DirectionSettings &walkParams)
 
 	dPlayer[player.position.tile.x][player.position.tile.y] = -(pnum + 1);
 	dPlayer[player.position.future.x][player.position.future.y] = pnum + 1;
-	player._pVar4 = nextPosition.x;
-	player._pVar5 = nextPosition.y;
-	dFlags[nextPosition.x][nextPosition.y] |= BFLAG_PLAYERLR;
 
 	if (leveltype != DTYPE_TOWN) {
 		ChangeLightXY(player._plid, nextPosition);
@@ -332,11 +329,11 @@ bool PlrDirOK(const Player &player, Direction dir)
 	}
 
 	if (dir == Direction::East) {
-		return !IsTileSolid(position + Direction::SouthEast) && (dFlags[position.x + 1][position.y] & BFLAG_PLAYERLR) == 0;
+		return !IsTileSolid(position + Direction::SouthEast);
 	}
 
 	if (dir == Direction::West) {
-		return !IsTileSolid(position + Direction::SouthWest) && (dFlags[position.x][position.y + 1] & BFLAG_PLAYERLR) == 0;
+		return !IsTileSolid(position + Direction::SouthWest);
 	}
 
 	return true;
@@ -411,7 +408,6 @@ void ClearStateVariables(Player &player)
 	player.position.temp = { 0, 0 };
 	player.tempDirection = Direction::South;
 	player._pVar4 = 0;
-	player._pVar5 = 0;
 	player.position.offset2 = { 0, 0 };
 	player.deathFrame = 0;
 }
@@ -730,7 +726,6 @@ bool DoWalk(int pnum, int variant)
 			break;
 		case PM_WALK3:
 			dPlayer[player.position.tile.x][player.position.tile.y] = 0;
-			dFlags[player._pVar4][player._pVar5] &= ~BFLAG_PLAYERLR;
 			player.position.tile = player.position.temp;
 			// dPlayer is set here for backwards comparability, without it the player would be invisible if loaded from a vanilla save.
 			dPlayer[player.position.tile.x][player.position.tile.y] = pnum + 1;
@@ -2921,27 +2916,12 @@ void FixPlrWalkTags(int pnum)
 			}
 		}
 	}
-
-	if (dx >= 0 && dx < MAXDUNX - 1 && dy >= 0 && dy < MAXDUNY - 1) {
-		dFlags[dx + 1][dy] &= ~BFLAG_PLAYERLR;
-		dFlags[dx][dy + 1] &= ~BFLAG_PLAYERLR;
-	}
 }
 
 void RemovePlrFromMap(int pnum)
 {
 	int pp = pnum + 1;
 	int pn = -(pnum + 1);
-
-	for (int y = 1; y < MAXDUNY; y++) {
-		for (int x = 1; x < MAXDUNX; x++) {
-			if (dPlayer[x][y - 1] == pn || dPlayer[x - 1][y] == pn) {
-				if ((dFlags[x][y] & BFLAG_PLAYERLR) != 0) {
-					dFlags[x][y] &= ~BFLAG_PLAYERLR;
-				}
-			}
-		}
-	}
 
 	for (int y = 0; y < MAXDUNY; y++) {
 		for (int x = 0; x < MAXDUNX; x++) // NOLINT(modernize-loop-convert)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -407,7 +407,7 @@ void ClearStateVariables(Player &player)
 {
 	player.position.temp = { 0, 0 };
 	player.tempDirection = Direction::South;
-	player._pVar4 = 0;
+	player.spellLevel = 0;
 	player.position.offset2 = { 0, 0 };
 	player.deathFrame = 0;
 }
@@ -561,7 +561,7 @@ void StartSpell(int pnum, Direction d, int cx, int cy)
 	SetPlayerOld(player);
 
 	player.position.temp = { cx, cy };
-	player._pVar4 = GetSpellLevel(pnum, player._pSpell);
+	player.spellLevel = GetSpellLevel(pnum, player._pSpell);
 }
 
 void RespawnDeadItem(Item *itm, Point target)
@@ -1456,7 +1456,7 @@ bool DoSpell(int pnum)
 		    player.position.tile.y,
 		    player.position.temp.x,
 		    player.position.temp.y,
-		    player._pVar4);
+		    player.spellLevel);
 
 		if (player._pSplFrom == 0) {
 			EnsureValidReadiedSpell(player);
@@ -1701,22 +1701,22 @@ void CheckNewPath(int pnum, bool pmWillBeCalled)
 		case ACTION_SPELL:
 			d = GetDirection(player.position.tile, { player.destParam1, player.destParam2 });
 			StartSpell(pnum, d, player.destParam1, player.destParam2);
-			player._pVar4 = static_cast<int>(player.destParam3);
+			player.spellLevel = static_cast<int>(player.destParam3);
 			break;
 		case ACTION_SPELLWALL:
 			StartSpell(pnum, player.destParam3, player.destParam1, player.destParam2);
 			player.tempDirection = player.destParam3;
-			player._pVar4 = player.destParam4;
+			player.spellLevel = player.destParam4;
 			break;
 		case ACTION_SPELLMON:
 			d = GetDirection(player.position.tile, monster->position.future);
 			StartSpell(pnum, d, monster->position.future.x, monster->position.future.y);
-			player._pVar4 = player.destParam2;
+			player.spellLevel = player.destParam2;
 			break;
 		case ACTION_SPELLPLR:
 			d = GetDirection(player.position.tile, target->position.future);
 			StartSpell(pnum, d, target->position.future.x, target->position.future.y);
-			player._pVar4 = player.destParam2;
+			player.spellLevel = player.destParam2;
 			break;
 		case ACTION_OPERATE:
 			x = abs(player.position.tile.x - object->position.x);

--- a/Source/player.h
+++ b/Source/player.h
@@ -242,10 +242,8 @@ struct Player {
 	bool _pInfraFlag;
 	/** Player's direction when ending movement. Also used for casting direction of SPL_FIREWALL. */
 	Direction tempDirection;
-	/** Used for spell level, and X component of _pVar5 */
+	/** Used for spell level */
 	int _pVar4;
-	/** Used for storing position of a tile which should have its BFLAG_PLAYERLR flag removed after walking. When starting to walk the game places the player in the dPlayer array -1 in the Y coordinate, and uses BFLAG_PLAYERLR to check if it should be using -1 to the Y coordinate when rendering the player (also used for storing the level of a spell when the player casts it) */
-	int _pVar5;
 	/** Used for stalling the appearance of the options screen after dying in singleplayer */
 	int deathFrame;
 	bool _pLvlVisited[NUMLEVELS];

--- a/Source/player.h
+++ b/Source/player.h
@@ -243,7 +243,7 @@ struct Player {
 	/** Player's direction when ending movement. Also used for casting direction of SPL_FIREWALL. */
 	Direction tempDirection;
 	/** Used for spell level */
-	int _pVar4;
+	int spellLevel;
 	/** Used for stalling the appearance of the options screen after dying in singleplayer */
 	int deathFrame;
 	bool _pLvlVisited[NUMLEVELS];

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -731,12 +731,11 @@ void DrawItem(const Surface &out, Point tilePosition, Point targetBufferPosition
  * @brief Check if and how a monster should be rendered
  * @param out Output buffer
  * @param tilePosition dPiece coordinates
- * @param oy dPiece Y offset
  * @param targetBufferPosition Output buffer coordinates
  */
-void DrawMonsterHelper(const Surface &out, Point tilePosition, int oy, Point targetBufferPosition)
+void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBufferPosition)
 {
-	int mi = dMonster[tilePosition.x][tilePosition.y + oy];
+	int mi = dMonster[tilePosition.x][tilePosition.y];
 	mi = mi > 0 ? mi - 1 : -(mi + 1);
 
 	if (leveltype == DTYPE_TOWN) {
@@ -834,10 +833,6 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 	int8_t bDead = dCorpse[tilePosition.x][tilePosition.y];
 	int8_t bMap = dTransVal[tilePosition.x][tilePosition.y];
 
-	int negMon = 0;
-	if (tilePosition.y > 0) // check for OOB
-		negMon = dMonster[tilePosition.x][tilePosition.y - 1];
-
 #ifdef _DEBUG
 	if (DebugVision && (bFlag & BFLAG_LIT) != 0) {
 		CelClippedDrawTo(out, targetBufferPosition, *pSquareCel, 1);
@@ -871,14 +866,7 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 	}
 	DrawObject(out, tilePosition, targetBufferPosition, true);
 	DrawItem(out, tilePosition, targetBufferPosition, true);
-	if ((bFlag & BFLAG_PLAYERLR) != 0) {
-		int syy = tilePosition.y - 1;
-		assert(syy >= 0 && syy < MAXDUNY);
-		DrawPlayerHelper(out, { tilePosition.x, syy }, targetBufferPosition);
-	}
-	if ((bFlag & BFLAG_MONSTLR) != 0 && negMon < 0) {
-		DrawMonsterHelper(out, tilePosition, -1, targetBufferPosition);
-	}
+
 	if ((bFlag & BFLAG_DEAD_PLAYER) != 0) {
 		DrawDeadPlayer(out, tilePosition, targetBufferPosition);
 	}
@@ -886,7 +874,7 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 		DrawPlayerHelper(out, tilePosition, targetBufferPosition);
 	}
 	if (dMonster[tilePosition.x][tilePosition.y] > 0) {
-		DrawMonsterHelper(out, tilePosition, 0, targetBufferPosition);
+		DrawMonsterHelper(out, tilePosition, targetBufferPosition);
 	}
 	DrawMissile(out, tilePosition, targetBufferPosition, false);
 	DrawObject(out, tilePosition, targetBufferPosition, false);
@@ -1407,7 +1395,7 @@ Displacement GetOffsetForWalking(const AnimationInfo &animationInfo, const Direc
 {
 	// clang-format off
 	//                                           South,        SouthWest,    West,         NorthWest,    North,        NorthEast,     East,         SouthEast,
-	constexpr Displacement StartOffset[8]    = { {   0, -32 }, {  32, -16 }, {  32, -16 }, {   0,   0 }, {   0,   0 }, {  0,    0 },  { -32, -16 }, { -32, -16 } };
+	constexpr Displacement StartOffset[8]    = { {   0, -32 }, {  32, -16 }, {  64,   0 }, {   0,   0 }, {   0,   0 }, {  0,    0 },  { -64,   0 }, { -32, -16 } };
 	constexpr Displacement MovingOffset[8]   = { {   0,  32 }, { -32,  16 }, { -64,   0 }, { -32, -16 }, {   0, -32 }, {  32, -16 },  {  64,   0 }, {  32,  16 } };
 	// clang-format on
 


### PR DESCRIPTION
## Content
In Master and Vanilla missiles can't hit players/monsters that walk horizontal.
This is cause while horizontal walking the player/monster _disappears_ from `dPlayers`/`dMonster`.
Both arrays contains what player/monster is located at a specific tile.
If a player/monster moves he is between two tiles and both are marked as occupied.
But only one location result in a missile hit. In the game engine this is represented as a positive Id (can be hit) and a negative number (only needed to mark the tile as occupied, so that no other player/monster can walk on this tile).

When the player/monster walks horizontal both tiles get a negative id, so you the player/monster can't be hit by a missile.
This PR changes this that also in horizontal walk one tile is used with a positive id (can be hit).

## Sample Video
This videos are created with extra long horizontal walking animations. This effect was only used for the video and is not part of this pr. 😉 
The shown Id's are presented by @qndel debug command `tiledata` #2847 🙂 

<details><summary>Master</summary>

https://user-images.githubusercontent.com/25415264/133337123-2e2ecc33-fa35-4b37-9571-288140870a9b.mp4

</details>

<details><summary>PR</summary>

https://user-images.githubusercontent.com/25415264/133337143-bc68d0ad-1a64-4433-966a-7cf02c49556f.mp4

</details>

## Notes

- This PR includes a breaking change that only affects a saved currently active horizontal walking and will go away after the walking animation is finished.
   - From vanilla to PR: The player/monster will not be drawn, cause the special logic for drawing is removed.
   - From PR to vanilla: The player/monster will be drawn at incorrect location.
- This PR affects game balance and PvP 😉 
- BFLAG_PLAYERLR and BFLAG_MONSTLR was used for [PlrDirOK](https://github.com/diasurgical/devilutionX/compare/master...obligaron:moveside?expand=1#diff-71461699ae2f94f652e6cba2136d3c696151ba3a6c0e357eaf55438a5c212ad3L334-L340) and [(Monster)DirOK](https://github.com/diasurgical/devilutionX/compare/master...obligaron:moveside?expand=1#diff-d46585089d315b53630b1035442b3d490d7b422cb05ceee76cf9041de3e39179L4403-L4408). I removed this specials cause I didn't hit them and they seem suspicious. Cause monster don't check horizontal walking players and vice versa. But perhaps I miss something. So please take a careful look.