### PR TITLE
Fix camera position when loading a game with currently walking player

### DIFF
--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -19,7 +19,7 @@ int AnimationInfo::GetFrameToUseForRendering() const
 	// or
 	// - if we load from a savegame where the new variables are not stored (we don't want to break savegame compatiblity because of smoother rendering of one animation)
 	if (RelevantFramesForDistributing <= 0)
-		return CurrentFrame;
+		return std::max(1, CurrentFrame);
 
 	if (CurrentFrame > RelevantFramesForDistributing)
 		return CurrentFrame;
@@ -62,9 +62,9 @@ float AnimationInfo::GetAnimationProgress() const
 	if (RelevantFramesForDistributing <= 0) {
 		// This logic is used if animation distrubtion is not active (see GetFrameToUseForRendering).
 		// In this case the variables calculated with animation distribution are not initialized and we have to calculate them on the fly with the given information.
-		float ticksPerFrame = TicksPerFrame + 1.F;
-		float totalTicksForCurrentAnimationSequence = GetProgressToNextGameTick() + CurrentFrame + (TickCounterOfCurrentFrame / ticksPerFrame);
-		float fAnimationFraction = totalTicksForCurrentAnimationSequence / (NumberOfFrames * ticksPerFrame);
+		int passedTicks = ((CurrentFrame - 1) * TicksPerFrame) + TickCounterOfCurrentFrame;
+		float totalTicksForCurrentAnimationSequence = GetProgressToNextGameTick() + (float)passedTicks;
+		float fAnimationFraction = totalTicksForCurrentAnimationSequence / (float)(NumberOfFrames * TicksPerFrame);
 		return fAnimationFraction;
 	}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3611,6 +3611,8 @@ void SyncPlrAnim(int pnum)
 	}
 
 	player.AnimInfo.pCelSprite = &*player.AnimationData[static_cast<size_t>(graphic)].CelSpritesForDirections[static_cast<size_t>(player._pdir)];
+	// Ensure ScrollInfo is initialized correctly
+	ScrollViewPort(player, WalkSettings[static_cast<size_t>(player._pdir)].scrollDir);
 }
 
 void SyncInitPlrPos(int pnum)


### PR DESCRIPTION
Fixes #1160

<details><summary>Loaded walk in PR</summary>

https://user-images.githubusercontent.com/25415264/133609932-e32de60b-79e4-4654-8ae2-4df4c89c96a1.mp4

</details>

<details><summary>Loaded walk in Master</summary>

https://user-images.githubusercontent.com/25415264/133609956-d9174001-0f46-4bec-b97b-a6929035c6b8.mp4

</details>

<details><summary>Loaded walk in devilutionX 1.21</summary>

https://user-images.githubusercontent.com/25415264/133609978-5fd7149e-a5b3-4f1b-aabe-b269ddf69177.mp4

</details>

Notes:

- Fixed `GetAnimationProgress` return the wrong fraction if ADL wasn't active
- Correctly initialize `ScrollInfo` after load
- In devilutionX 1.21 the walk was incorrect, cause `ScrollStruct.offset` wasn't updated. In master we use `GetOffsetForWalking`.