### PR TITLE
Remove unused function declaration from VirtualGamepad

### DIFF
--- a/Source/controls/touch/gamepad.h
+++ b/Source/controls/touch/gamepad.h
@@ -52,8 +52,6 @@ struct VirtualGamepad {
 	VirtualGamepad()
 	{
 	}
-
-	bool IsControllerButtonPressed(ControllerButton button) const;
 };
 
 void InitializeVirtualGamepad();


### PR DESCRIPTION
This function was removed during the cleanup for the precompiler checks, but I left the declaration in the struct.