### PR TITLE
Add new debug commands, remove old hotkeys and update debug.md

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -34,6 +34,7 @@ bool DebugGodMode = false;
 bool DebugVision = false;
 bool DebugGrid = false;
 std::unordered_map<int, Point> DebugCoordsMap;
+bool DebugScrollViewEnabled = false;
 
 namespace {
 
@@ -621,6 +622,15 @@ std::string DebugCmdShowTileData(const string_view parameter)
 	return "Special powers activated.";
 }
 
+std::string DebugCmdScrollView(const string_view parameter)
+{
+	DebugScrollViewEnabled = !DebugScrollViewEnabled;
+	if (DebugScrollViewEnabled)
+		return "You can see as far as an eagle.";
+	InitMultiView();
+	return "If you want to see the world, you need to explore it yourself.";
+}
+
 std::vector<DebugCmdItem> DebugCmdList = {
 	{ "help", "Prints help overview or help for a specific command.", "({command})", &DebugCmdHelp },
 	{ "give gold", "Fills the inventory with gold.", "", &DebugCmdGiveGoldCheat },
@@ -646,6 +656,7 @@ std::vector<DebugCmdItem> DebugCmdList = {
 	{ "seedinfo", "Show seed infos for current level.", "", &DebugCmdLevelSeed },
 	{ "spawn", "Spawns monster {name}.", "({count}) {name}", &DebugCmdSpawnMonster },
 	{ "tiledata", "Toggles showing tile data {name} (leave name empty to see a list).", "{name}", &DebugCmdShowTileData },
+	{ "scrollview", "Toggles scroll view feature (with shift+mouse).", "", &DebugCmdScrollView },
 };
 
 } // namespace

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -631,6 +631,26 @@ std::string DebugCmdScrollView(const string_view parameter)
 	return "If you want to see the world, you need to explore it yourself.";
 }
 
+std::string DebugCmdItemInfo(const string_view parameter)
+{
+	auto &myPlayer = Players[MyPlayerId];
+	Item *pItem = nullptr;
+	if (pcurs >= CURSOR_FIRSTITEM) {
+		pItem = &myPlayer.HoldItem;
+	} else if (pcursinvitem != -1) {
+		if (pcursinvitem <= INVITEM_INV_LAST)
+			pItem = &myPlayer.InvList[pcursinvitem - INVITEM_INV_FIRST];
+		else
+			pItem = &myPlayer.SpdList[pcursinvitem - INVITEM_BELT_FIRST];
+	} else if (pcursitem != -1) {
+		pItem = &Items[pcursitem];
+	}
+	if (pItem != nullptr) {
+		return fmt::format("Name: {}\nIDidx: {}\nSeed: {}\nCreateInfo: {}", pItem->_iIName, pItem->IDidx, pItem->_iSeed, pItem->_iCreateInfo);
+	}
+	return fmt::format("Numitems: {}", ActiveItemCount);
+}
+
 std::vector<DebugCmdItem> DebugCmdList = {
 	{ "help", "Prints help overview or help for a specific command.", "({command})", &DebugCmdHelp },
 	{ "give gold", "Fills the inventory with gold.", "", &DebugCmdGiveGoldCheat },
@@ -657,6 +677,7 @@ std::vector<DebugCmdItem> DebugCmdList = {
 	{ "spawn", "Spawns monster {name}.", "({count}) {name}", &DebugCmdSpawnMonster },
 	{ "tiledata", "Toggles showing tile data {name} (leave name empty to see a list).", "{name}", &DebugCmdShowTileData },
 	{ "scrollview", "Toggles scroll view feature (with shift+mouse).", "", &DebugCmdScrollView },
+	{ "iteminfo", "Shows info of currently selected item.", "", &DebugCmdItemInfo },
 };
 
 } // namespace

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -26,7 +26,6 @@ extern bool DebugScrollViewEnabled;
 void FreeDebugGFX();
 void LoadDebugGFX();
 void PrintDebugPlayer(bool bNextPlayer);
-void PrintDebugQuest();
 void GetDebugMonster();
 void NextDebugMonster();
 void SetDebugLevelSeedInfos(uint32_t mid1Seed, uint32_t mid2Seed, uint32_t mid3Seed, uint32_t endSeed);

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -21,6 +21,7 @@ extern bool DebugGodMode;
 extern bool DebugVision;
 extern bool DebugGrid;
 extern std::unordered_map<int, Point> DebugCoordsMap;
+extern bool DebugScrollViewEnabled;
 
 void FreeDebugGFX();
 void LoadDebugGFX();

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -25,7 +25,6 @@ extern bool DebugScrollViewEnabled;
 
 void FreeDebugGFX();
 void LoadDebugGFX();
-void PrintDebugPlayer(bool bNextPlayer);
 void GetDebugMonster();
 void NextDebugMonster();
 void SetDebugLevelSeedInfos(uint32_t mid1Seed, uint32_t mid2Seed, uint32_t mid3Seed, uint32_t endSeed);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1236,24 +1236,6 @@ void HelpKeyPressed()
 	}
 }
 
-#ifdef _DEBUG
-void ItemInfoKeyPressed()
-{
-	auto &item = Items[pcursitem];
-	if (pcursitem != -1) {
-		sprintf(
-		    tempstr,
-		    "IDX = %i  :  Seed = %i  :  CF = %i",
-		    item.IDidx,
-		    item._iSeed,
-		    item._iCreateInfo);
-		NetSendCmdString(1 << MyPlayerId, tempstr);
-	}
-	sprintf(tempstr, "Numitems : %i", ActiveItemCount);
-	NetSendCmdString(1 << MyPlayerId, tempstr);
-}
-#endif
-
 void InventoryKeyPressed()
 {
 	if (stextflag != STORE_NONE)
@@ -1364,12 +1346,6 @@ void InitKeymapActions()
 	    [&]() { return !IsPlayerDead(); },
 	});
 #ifdef _DEBUG
-	keymapper.AddAction({
-	    "ItemInfo",
-	    DVL_VK_INVALID,
-	    ItemInfoKeyPressed,
-	    [&]() { return !IsPlayerDead(); },
-	});
 	keymapper.AddAction({
 	    "QuestDebug",
 	    DVL_VK_INVALID,

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -101,7 +101,6 @@ std::array<Keymapper::ActionIndex, 4> quickSpellActionIndexes;
 
 bool gbForceWindowed = false;
 #ifdef _DEBUG
-bool debug_mode_key_inverted_v = false;
 bool debug_mode_key_i = false;
 std::vector<std::string> DebugCmdsFromCommandLine;
 #endif
@@ -584,13 +583,11 @@ void PressChar(char vkey)
 		return;
 	case 'T':
 	case 't':
-		if (debug_mode_key_inverted_v) {
-			auto &myPlayer = Players[MyPlayerId];
-			sprintf(tempstr, "PX = %i  PY = %i", myPlayer.position.tile.x, myPlayer.position.tile.y);
-			NetSendCmdString(1 << MyPlayerId, tempstr);
-			sprintf(tempstr, "CX = %i  CY = %i  DP = %i", cursPosition.x, cursPosition.y, dungeon[cursPosition.x][cursPosition.y]);
-			NetSendCmdString(1 << MyPlayerId, tempstr);
-		}
+		auto &myPlayer = Players[MyPlayerId];
+		sprintf(tempstr, "PX = %i  PY = %i", myPlayer.position.tile.x, myPlayer.position.tile.y);
+		NetSendCmdString(1 << MyPlayerId, tempstr);
+		sprintf(tempstr, "CX = %i  CY = %i  DP = %i", cursPosition.x, cursPosition.y, dungeon[cursPosition.x][cursPosition.y]);
+		NetSendCmdString(1 << MyPlayerId, tempstr);
 		return;
 #endif
 	}
@@ -812,7 +809,6 @@ void RunGameLoop(interface_mode uMsg)
 	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--nestart", _("Use alternate nest palette"));
 #ifdef _DEBUG
 	printInConsole("\nDebug options:\n");
-	printInConsole("    %-20s %-30s\n", "-^", "Enable debug tools");
 	printInConsole("    %-20s %-30s\n", "-i", "Ignore network timeout");
 	printInConsole("    %-20s %-30s\n", "+<internal command>", "Pass commands to the engine");
 #endif
@@ -871,8 +867,6 @@ void DiabloParseFlags(int argc, char **argv)
 		} else if (strcasecmp("--verbose", argv[i]) == 0) {
 			SDL_LogSetAllPriority(SDL_LOG_PRIORITY_VERBOSE);
 #ifdef _DEBUG
-		} else if (strcasecmp("-^", argv[i]) == 0) {
-			debug_mode_key_inverted_v = true;
 		} else if (strcasecmp("-i", argv[i]) == 0) {
 			debug_mode_key_i = true;
 		} else if (argv[i][0] == '+') {
@@ -1179,7 +1173,7 @@ void GameLogic()
 	gGameLogicStep = GameLogicStep::None;
 
 #ifdef _DEBUG
-	if (debug_mode_key_inverted_v && GetAsyncKeyState(DVL_VK_SHIFT)) {
+	if (DebugScrollViewEnabled && GetAsyncKeyState(DVL_VK_SHIFT)) {
 		ScrollView();
 	}
 #endif

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -101,7 +101,7 @@ std::array<Keymapper::ActionIndex, 4> quickSpellActionIndexes;
 
 bool gbForceWindowed = false;
 #ifdef _DEBUG
-bool debug_mode_key_i = false;
+bool DebugDisableNetworkTimeout = false;
 std::vector<std::string> DebugCmdsFromCommandLine;
 #endif
 /** Specifies whether players are in non-PvP mode. */
@@ -868,7 +868,7 @@ void DiabloParseFlags(int argc, char **argv)
 			SDL_LogSetAllPriority(SDL_LOG_PRIORITY_VERBOSE);
 #ifdef _DEBUG
 		} else if (strcasecmp("-i", argv[i]) == 0) {
-			debug_mode_key_i = true;
+			DebugDisableNetworkTimeout = true;
 		} else if (argv[i][0] == '+') {
 			if (!currentCommand.empty())
 				DebugCmdsFromCommandLine.push_back(currentCommand);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -101,9 +101,6 @@ std::array<Keymapper::ActionIndex, 4> quickSpellActionIndexes;
 
 bool gbForceWindowed = false;
 #ifdef _DEBUG
-bool monstdebug = false;
-_monster_id DebugMonsters[10];
-int debugmonsttypes = 0;
 bool debug_mode_key_inverted_v = false;
 bool debug_mode_key_i = false;
 std::vector<std::string> DebugCmdsFromCommandLine;
@@ -817,7 +814,6 @@ void RunGameLoop(interface_mode uMsg)
 	printInConsole("\nDebug options:\n");
 	printInConsole("    %-20s %-30s\n", "-^", "Enable debug tools");
 	printInConsole("    %-20s %-30s\n", "-i", "Ignore network timeout");
-	printInConsole("    %-20s %-30s\n", "-m <##>", "Add debug monster, up to 10 allowed");
 	printInConsole("    %-20s %-30s\n", "+<internal command>", "Pass commands to the engine");
 #endif
 	printInConsole("%s", _("\nReport bugs at https://github.com/diasurgical/devilutionX/\n"));
@@ -879,9 +875,6 @@ void DiabloParseFlags(int argc, char **argv)
 			debug_mode_key_inverted_v = true;
 		} else if (strcasecmp("-i", argv[i]) == 0) {
 			debug_mode_key_i = true;
-		} else if (strcasecmp("-m", argv[i]) == 0) {
-			monstdebug = true;
-			DebugMonsters[debugmonsttypes++] = (_monster_id)SDL_atoi(argv[++i]);
 		} else if (argv[i][0] == '+') {
 			if (!currentCommand.empty())
 				DebugCmdsFromCommandLine.push_back(currentCommand);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1345,14 +1345,6 @@ void InitKeymapActions()
 	    HelpKeyPressed,
 	    [&]() { return !IsPlayerDead(); },
 	});
-#ifdef _DEBUG
-	keymapper.AddAction({
-	    "QuestDebug",
-	    DVL_VK_INVALID,
-	    PrintDebugQuest,
-	    [&]() { return !IsPlayerDead(); },
-	});
-#endif
 	for (int i = 0; i < 4; ++i) {
 		quickSpellActionIndexes[i] = keymapper.AddAction({
 		    std::string("QuickSpell") + std::to_string(i + 1),

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -581,14 +581,6 @@ void PressChar(char vkey)
 	case 'm':
 		GetDebugMonster();
 		return;
-	case 'T':
-	case 't':
-		auto &myPlayer = Players[MyPlayerId];
-		sprintf(tempstr, "PX = %i  PY = %i", myPlayer.position.tile.x, myPlayer.position.tile.y);
-		NetSendCmdString(1 << MyPlayerId, tempstr);
-		sprintf(tempstr, "CX = %i  CY = %i  DP = %i", cursPosition.x, cursPosition.y, dungeon[cursPosition.x][cursPosition.y]);
-		NetSendCmdString(1 << MyPlayerId, tempstr);
-		return;
 #endif
 	}
 }

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -569,12 +569,6 @@ void PressChar(char vkey)
 		}
 		return;
 #ifdef _DEBUG
-	case 'D':
-		PrintDebugPlayer(true);
-		return;
-	case 'd':
-		PrintDebugPlayer(false);
-		return;
 	case 'M':
 		NextDebugMonster();
 		return;

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -106,9 +106,6 @@ void diablo_color_cyc_logic();
 extern Keymapper keymapper;
 extern bool gbForceWindowed;
 #ifdef _DEBUG
-extern bool monstdebug;
-extern _monster_id DebugMonsters[10];
-extern int debugmonsttypes;
 extern bool debug_mode_key_inverted_v;
 extern bool debug_mode_key_i;
 #endif

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -106,7 +106,7 @@ void diablo_color_cyc_logic();
 extern Keymapper keymapper;
 extern bool gbForceWindowed;
 #ifdef _DEBUG
-extern bool debug_mode_key_i;
+extern bool DebugDisableNetworkTimeout;
 #endif
 
 struct QuickMessage {

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -106,7 +106,6 @@ void diablo_color_cyc_logic();
 extern Keymapper keymapper;
 extern bool gbForceWindowed;
 #ifdef _DEBUG
-extern bool debug_mode_key_inverted_v;
 extern bool debug_mode_key_i;
 #endif
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3643,29 +3643,20 @@ void GetLevelMTypes()
 			}
 		}
 
-#ifdef _DEBUG
-		if (monstdebug) {
-			for (int i = 0; i < debugmonsttypes; i++)
-				AddMonsterType(DebugMonsters[i], PLACE_SCATTER);
-		} else
-#endif
-		{
-
-			while (nt > 0 && LevelMonsterTypeCount < MAX_LVLMTYPES && monstimgtot < 4000) {
-				for (int i = 0; i < nt;) {
-					if (MonstersData[typelist[i]].mImage > 4000 - monstimgtot) {
-						typelist[i] = typelist[--nt];
-						continue;
-					}
-
-					i++;
-				}
-
-				if (nt != 0) {
-					int i = GenerateRnd(nt);
-					AddMonsterType(typelist[i], PLACE_SCATTER);
+		while (nt > 0 && LevelMonsterTypeCount < MAX_LVLMTYPES && monstimgtot < 4000) {
+			for (int i = 0; i < nt;) {
+				if (MonstersData[typelist[i]].mImage > 4000 - monstimgtot) {
 					typelist[i] = typelist[--nt];
+					continue;
 				}
+
+				i++;
+			}
+
+			if (nt != 0) {
+				int i = GenerateRnd(nt);
+				AddMonsterType(typelist[i], PLACE_SCATTER);
+				typelist[i] = typelist[--nt];
 			}
 		}
 

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -240,7 +240,7 @@ void BeginTimeout()
 		return;
 	}
 #ifdef _DEBUG
-	if (debug_mode_key_i) {
+	if (DebugDisableNetworkTimeout) {
 		return;
 	}
 #endif

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2780,12 +2780,6 @@ void InitPlayer(Player &player, bool firstTime)
 		player._pAblSpells = GetSpellBitmask(SPL_BLODBOIL);
 	}
 
-#ifdef _DEBUG
-	if (debug_mode_key_inverted_v && firstTime) {
-		player._pMemSpells = SPL_INVALID;
-	}
-#endif
-
 	player._pNextExper = ExpLvlsTbl[player._pLevel];
 	player._pInvincible = false;
 

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -1,54 +1,34 @@
-There are debug features available through both in-game and through the command-line. These have been ported from the 12-21-96 debug build. Note that not all of them are available yet.
+## Introduction
 
-Command-line parameters
-- `-^` : enable god mode and debug tools
-- `-$` : enable god mode with less stuff (further documenting needed) [NOT YET IMPLEMENTED]
-- `-b` : enable item drop log [NOT YET IMPLEMENTED]
-- `-d` : disable startup video + increased item drops [PARTIALLY IMPLEMENTED]
-- `-f` : display frames per second
-- `-i` : disable network timeout
-- `-n` : disable startup video
-- `-s` : unused
-- `-v` : draw yellow debug tiles
-- `-w` : enable cheats
-- `-x` : disable exclusive DirectDraw access [NOT YET IMPLEMENTED]
-- `-j <##>` : init trigger at level [NOT YET IMPLEMENTED]
-- `-l <#> <##>` : start in level as type
-- `-m <###>` : add debug monster, up to 10 allowed
-- `-q <#>` : force a certain quest
-- `-r <##########>` : set map seed to
-- `-t <##>` : sets current quest level
+If you compile the game in debug, you have multiple debug features available.
 
-In-game hotkeys
-- `?` -> enter quest text mode [NOT YET IMPLEMENTED]
-  - `-`/`_` -> decrease message number/speed
-  - `+`/`=` -> increase message number/speed
-  - `Enter` -> play selected message
-  - `Esc` -> stop quest text mode
-- `Shift` -> while holding, use the mouse to scroll screen
-- `F2` -> display dungeon information [NOT YET IMPLEMENTED]
-- `F3` -> display number of items on the ground/cursor item
-- `F4` -> display quest status information
-- `0`/`)` -> cycle between regular/magic arrows
-- `8`/`*` -> level up character
-- `~` -> refresh vendor items (Griswold premium and Adria)
-- `]` -> all spells level 10
-- `:` -> all spells preset level
-- `[` -> delete all gold in inventory
-- `|` -> fill inventory with gold (5000 piece piles)
-- `.` -> display dungeon Y/sum [NOT YET IMPLEMENTED]
-- `a` -> increase level of the last spell casted and enable `Teleport` in town
-- `A` -> display "Mid" monster related
-- `d` -> print debug player info
-- `D` -> switch current debug player
-- `e` -> display "EFlag"
-- `l`/`L` -> toggle lighting in dungeon
-- `m` -> print debug monster info
-- `M` -> switch current debug monster
-- `r`/`R` -> display game seeds
-- `t`/`T` -> display player and cursor coordinates
+## Debug commands
 
-Multiplayer hotkeys [NOT YET IMPLEMENTED]
-- `Ctrl`+`C` -> trigger breakpoint
-- `Ctrl`+`P` -> print mouse clicks and frame counter for each player
-- `Ctrl`+`S` -> sleep the network thread
+In-game you have the possibility to use the chat to trigger debug commands.
+This is currently a replacment for a console.
+
+| Command | Description |
+| ------- | ----------- |
+| `help` | Shows a list of all debug commands with descriptions. |
+| `god` | Toggles godmode. |
+| ... | For the other commands see `help` ingame and there are a lot. |
+
+Tip: Debug commands are also supported in quick messages. If you need a debug command frequently, put it in a quick message. :wink:
+
+## Command-line parameters
+
+| Command | Description |
+| ------- | ----------- |
+| `+` | Executes a debug command when loading the first game. For exampel `+god` or `+changelevel 1 +spawn 4 skeleton`. |
+| `-f` | Display frames per second. |
+| `-i` | Disable network timeout. |
+| `-n` | Disable startup video. |
+
+## In-game hotkeys
+
+| Hotkey | Description |
+| ------ | ----------- |
+| `Shift` | While holding, you can use the mouse to scroll screen. |
+| `m` | Print debug monster info. |
+| `M` | Switch current debug monster. |
+| `x` | Toggles `DebugToggle` variable. `DebugToggle` is a generic solution for temporary toggles needed for debugging. |


### PR DESCRIPTION
## Content

- Remove `-m` debug command line parameter. Was used for spawning monsters but now we have `spawn` debug command. 😉 
- Remove `-^` debug command line parameter. Was only used for scrolling with shift. Now on per default in debug (hope that's okay).
- Rename `debug_mode_key_i` to `DebugDisableNetworkTimeout`.
- Introduce `iteminfo` debug command to show item infos. Replaces `ItemInfo` keybinding and now also works for inventory and held items.
- Introduce `questinfo` debug command that replaces `PrintDebugQuest` keybinding and now allows to specify what quest to show instead of needing to iterate all previous quests.
- Remove `-t` debug hotkey. Was used for showing tile related info but now we have `tiledata` debug command. 😉 
- Introduce `playerinfo` debug command to show player infos. Replaces `d` hotke. Thios also allows now to specify what player to show instead of needing to iterate all previous players (even the not active ones).
- Reworked `debug.md` to match current debug capacities.
- More code in `debug.cpp` and less debug related code elsewhere. 🙂