### PR TITLE
fix destroying renderer

### DIFF
--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -206,7 +206,8 @@ void dx_cleanup()
 	RendererTextureSurface = nullptr;
 #ifndef USE_SDL1
 	texture = nullptr;
-	SDL_DestroyRenderer(renderer);
+	if (sgOptions.Graphics.bUpscale)
+		SDL_DestroyRenderer(renderer);
 #endif
 	SDL_DestroyWindow(ghMainWnd);
 }


### PR DESCRIPTION
in
```cpp
bool SpawnWindow(const char *lpWindowName)
```
there's
```cpp
	if (sgOptions.Graphics.bUpscale) {
#ifndef USE_SDL1
		Uint32 rendererFlags = SDL_RENDERER_ACCELERATED;

		if (sgOptions.Graphics.bVSync) {
			rendererFlags |= SDL_RENDERER_PRESENTVSYNC;
		}

		renderer = SDL_CreateRenderer(ghMainWnd, -1, rendererFlags);
```
so renderer is only created if not SDL1 and bUpscale is true, this fix takes that into account when trying to destroy a renderer.