### PR TITLE
Fix SetPlayerGPtrs with RUN_TESTS definied

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -395,14 +395,14 @@ void StartWalk(int pnum, Displacement vel, Direction dir, bool pmWillBeCalled)
 void SetPlayerGPtrs(const char *path, std::unique_ptr<byte[]> &data, std::array<std::optional<CelSprite>, 8> &anim, int width)
 {
 	data = nullptr;
-#ifndef RUN_TESTS
 	data = LoadFileInMem(path);
+	if (data == nullptr && gbQuietMode)
+		return;
 
 	for (int i = 0; i < 8; i++) {
 		byte *pCelStart = CelGetFrame(data.get(), i);
 		anim[i].emplace(pCelStart, width);
 	}
-#endif
 }
 
 void ClearStateVariables(Player &player)


### PR DESCRIPTION
#2873 broke the possibility to run the binary when RUN_TESTS is defined, cause no player animation was loaded.