### PR TITLE
Fix compiling with NOSOUND defined

### DIFF
--- a/Source/monster.h
+++ b/Source/monster.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <array>
+#include <functional>
 
 #include "engine.h"
 #include "engine/actor_position.hpp"


### PR DESCRIPTION
With NOSOUND defined `std::functional` is not included to `monster.h`.
Without NOSOUND it gets included with `Aulib/Stream.h`.