### PR TITLE
Hardware rendering for the virtual gamepad

### DIFF
--- a/Source/DiabloUI/art.h
+++ b/Source/DiabloUI/art.h
@@ -13,6 +13,10 @@ struct Art {
 	int frame_height;
 	unsigned int palette_version;
 
+#ifndef USE_SDL1
+	SDLTextureUniquePtr texture;
+#endif
+
 	Art()
 	{
 		surface = nullptr;
@@ -20,6 +24,10 @@ struct Art {
 		logical_width = 0;
 		frame_height = 0; // logical frame height (before scaling)
 		palette_version = 0;
+
+#ifndef USE_SDL1
+		texture = nullptr;
+#endif
 	}
 
 	int w() const
@@ -35,6 +43,10 @@ struct Art {
 	void Unload()
 	{
 		surface = nullptr;
+
+#ifndef USE_SDL1
+		texture = nullptr;
+#endif
 	}
 };
 

--- a/Source/controls/touch/renderers.h
+++ b/Source/controls/touch/renderers.h
@@ -26,6 +26,8 @@ enum VirtualGamepadButtonType {
 	GAMEPAD_BLANKDOWN,
 };
 
+typedef std::function<void(Art &art, SDL_Rect *src, SDL_Rect *dst)> RenderFunction;
+
 class VirtualDirectionPadRenderer {
 public:
 	VirtualDirectionPadRenderer(VirtualDirectionPad *virtualDirectionPad)
@@ -33,42 +35,38 @@ public:
 	{
 	}
 
-	void LoadArt();
-	void Render(const Surface &out);
+	void LoadArt(SDL_Renderer *renderer);
+	void Render(RenderFunction renderFunction);
 	void UnloadArt();
 
 private:
 	VirtualDirectionPad *virtualDirectionPad;
-	SDLSurfaceUniquePtr padSurface;
-	SDLSurfaceUniquePtr knobSurface;
+	Art padArt;
+	Art knobArt;
 
-	void RenderPad(const Surface &out);
-	void RenderKnob(const Surface &out);
+	void RenderPad(RenderFunction renderFunction);
+	void RenderKnob(RenderFunction renderFunction);
 };
 
 class VirtualPadButtonRenderer {
 public:
-	VirtualPadButtonRenderer(VirtualPadButton *virtualPadButton, Art *buttonArt)
+	VirtualPadButtonRenderer(VirtualPadButton *virtualPadButton)
 	    : virtualPadButton(virtualPadButton)
-	    , buttonArt(buttonArt)
 	{
 	}
 
-	void Render(const Surface &out);
+	void Render(RenderFunction renderFunction, Art &buttonArt);
 
 protected:
 	VirtualPadButton *virtualPadButton;
 
 	virtual VirtualGamepadButtonType GetButtonType() = 0;
-
-private:
-	Art *buttonArt;
 };
 
 class PrimaryActionButtonRenderer : public VirtualPadButtonRenderer {
 public:
-	PrimaryActionButtonRenderer(VirtualPadButton *primaryActionButton, Art *buttonArt)
-	    : VirtualPadButtonRenderer(primaryActionButton, buttonArt)
+	PrimaryActionButtonRenderer(VirtualPadButton *primaryActionButton)
+	    : VirtualPadButtonRenderer(primaryActionButton)
 	{
 	}
 
@@ -81,8 +79,8 @@ private:
 
 class SecondaryActionButtonRenderer : public VirtualPadButtonRenderer {
 public:
-	SecondaryActionButtonRenderer(VirtualPadButton *secondaryActionButton, Art *buttonArt)
-	    : VirtualPadButtonRenderer(secondaryActionButton, buttonArt)
+	SecondaryActionButtonRenderer(VirtualPadButton *secondaryActionButton)
+	    : VirtualPadButtonRenderer(secondaryActionButton)
 	{
 	}
 
@@ -92,8 +90,8 @@ private:
 
 class SpellActionButtonRenderer : public VirtualPadButtonRenderer {
 public:
-	SpellActionButtonRenderer(VirtualPadButton *spellActionButton, Art *buttonArt)
-	    : VirtualPadButtonRenderer(spellActionButton, buttonArt)
+	SpellActionButtonRenderer(VirtualPadButton *spellActionButton)
+	    : VirtualPadButtonRenderer(spellActionButton)
 	{
 	}
 
@@ -103,8 +101,8 @@ private:
 
 class CancelButtonRenderer : public VirtualPadButtonRenderer {
 public:
-	CancelButtonRenderer(VirtualPadButton *cancelButton, Art *buttonArt)
-	    : VirtualPadButtonRenderer(cancelButton, buttonArt)
+	CancelButtonRenderer(VirtualPadButton *cancelButton)
+	    : VirtualPadButtonRenderer(cancelButton)
 	{
 	}
 
@@ -116,15 +114,15 @@ class VirtualGamepadRenderer {
 public:
 	VirtualGamepadRenderer(VirtualGamepad *virtualGamepad)
 	    : directionPadRenderer(&virtualGamepad->directionPad)
-	    , primaryActionButtonRenderer(&virtualGamepad->primaryActionButton, &buttonArt)
-	    , secondaryActionButtonRenderer(&virtualGamepad->secondaryActionButton, &buttonArt)
-	    , spellActionButtonRenderer(&virtualGamepad->spellActionButton, &buttonArt)
-	    , cancelButtonRenderer(&virtualGamepad->cancelButton, &buttonArt)
+	    , primaryActionButtonRenderer(&virtualGamepad->primaryActionButton)
+	    , secondaryActionButtonRenderer(&virtualGamepad->secondaryActionButton)
+	    , spellActionButtonRenderer(&virtualGamepad->spellActionButton)
+	    , cancelButtonRenderer(&virtualGamepad->cancelButton)
 	{
 	}
 
-	void LoadArt();
-	void Render(const Surface &out);
+	void LoadArt(SDL_Renderer *renderer);
+	void Render(RenderFunction renderFunction);
 	void UnloadArt();
 
 private:
@@ -136,9 +134,9 @@ private:
 	Art buttonArt;
 };
 
-void DrawVirtualGamepad(const Surface &out);
-
-void InitVirtualGamepadGFX();
+void InitVirtualGamepadGFX(SDL_Renderer *renderer);
+void RenderVirtualGamepad(SDL_Renderer *renderer);
+void RenderVirtualGamepad(SDL_Surface *surface);
 void FreeVirtualGamepadGFX();
 
 } // namespace devilution

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1057,7 +1057,7 @@ void LoadAllGFX()
 {
 	IncProgress();
 #if defined(VIRTUAL_GAMEPAD) && !defined(USE_SDL1)
-	InitVirtualGamepadGFX();
+	InitVirtualGamepadGFX(renderer);
 #endif
 	IncProgress();
 	InitObjectGFX();
@@ -1861,7 +1861,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 		} else {
 			IncProgress();
 #if defined(VIRTUAL_GAMEPAD) && !defined(USE_SDL1)
-			InitVirtualGamepadGFX();
+			InitVirtualGamepadGFX(renderer);
 #endif
 			IncProgress();
 			InitMissileGFX(gbIsHellfire);

--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -7,6 +7,7 @@
 
 #include <SDL.h>
 
+#include "controls/touch/renderers.h"
 #include "engine.h"
 #include "options.h"
 #include "storm/storm.h"
@@ -323,12 +324,18 @@ void RenderPresent()
 		if (SDL_RenderCopy(renderer, texture.get(), nullptr, nullptr) <= -1) {
 			ErrSdl();
 		}
+#ifdef VIRTUAL_GAMEPAD
+		RenderVirtualGamepad(renderer);
+#endif
 		SDL_RenderPresent(renderer);
 
 		if (!sgOptions.Graphics.bVSync) {
 			LimitFrameRate();
 		}
 	} else {
+#ifdef VIRTUAL_GAMEPAD
+		RenderVirtualGamepad(surface);
+#endif
 		if (SDL_UpdateWindowSurface(ghMainWnd) <= -1) {
 			ErrSdl();
 		}

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1725,12 +1725,6 @@ void DrawAndBlit()
 
 	DrawMain(hgt, ddsdesc, drawhpflag, drawmanaflag, drawsbarflag, drawbtnflag);
 
-#if defined(VIRTUAL_GAMEPAD) && !defined(USE_SDL1)
-	SDL_Surface *sdlOutputSurface = GetOutputSurface();
-	Surface outputSurface(sdlOutputSurface);
-	DrawVirtualGamepad(outputSurface);
-#endif
-
 	RenderPresent();
 
 	drawhpflag = false;


### PR DESCRIPTION
This PR renders the gamepad using the SDL rendering API instead of `SDL_BlitScaled()` to the output surface.

This should solve the following rendering issues...
* Dissatisfactory scaling algorithms in `SDL_BlitScaled()`
* Downscaling to the the game's resolution before upscaling to the display resolution

---

Here is a particularly extreme comparison using the following settings on my 1920x1200 display.

```ini
[Graphics]
Width=640
Height=480
Fullscreen=1
Upscale=1
Fit to Screen=1
Scaling Quality=2
Integer Scaling=0
```

**SDL_BlitScaled:**
![image](https://user-images.githubusercontent.com/9203145/134231564-db0ae03e-73f1-4a14-b60d-5e4f1cc5e2ed.png)

**HW render:**
![image](https://user-images.githubusercontent.com/9203145/134231574-84f78c9e-204c-4559-ac36-a775fda471cf.png)
