### PR TITLE
Fix an assert at the wrong place

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4156,7 +4156,6 @@ void M_WalkDir(int i, Direction md)
 
 void GolumAi(int i)
 {
-	assert(i >= 0 && i < MAX_PLRS);
 	auto &golem = Monsters[i];
 
 	if (golem.position.tile.x == 1 && golem.position.tile.y == 0) {
@@ -4203,6 +4202,7 @@ void GolumAi(int i)
 	if (golem._pathcount > 8)
 		golem._pathcount = 5;
 
+	assert(i >= 0 && i < MAX_PLRS);
 	if (RandomWalk(i, Players[i]._pdir))
 		return;
 


### PR DESCRIPTION
It seems that the assert try to protect an out of bound access to the
Players array, but it legitime to access the Monsters Array with the
same index before