### PR TITLE
loot system fixes and tweaks

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1480,6 +1480,7 @@ void CheckInvSwap(Player &player, inv_body_loc bLoc, int idx, uint16_t wCI, int 
 {
 	auto &item = Items[MAXITEMS];
 	memset(&item, 0, sizeof(item));
+	item.dwBuff = dwBuff;
 	RecreateItem(item, idx, wCI, seed, 0, (dwBuff & CF_HELLFIRE) != 0);
 
 	player.HoldItem = item;
@@ -1785,6 +1786,7 @@ int SyncPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, i
 	if (idx == IDI_EAR) {
 		RecreateEar(item, icreateinfo, iseed, id, dur, mdur, ch, mch, ivalue, ibuff);
 	} else {
+		item.dwBuff = ibuff;
 		RecreateItem(item, idx, icreateinfo, iseed, ivalue, (ibuff & CF_HELLFIRE) != 0);
 		if (id != 0)
 			item._iIdentified = true;
@@ -1798,7 +1800,6 @@ int SyncPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, i
 		item._iMinMag = minMag;
 		item._iMinDex = minDex;
 		item._iAC = ac;
-		item.dwBuff = ibuff;
 	}
 
 	item.position = position;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3412,9 +3412,11 @@ void SpawnItem(Monster &monster, Point position, bool sendmsg)
 	GetSuperItemSpace(position, ii);
 	int uper = monster._uniqtype != 0 ? 15 : 1;
 
-	int8_t mLevel = monster.MData->mLevel;
+	int8_t mLevel = monster.mLevel;
 	if (!gbIsHellfire && monster.MType->mtype == MT_DIABLO)
 		mLevel -= 15;
+	if (mLevel > CF_LEVEL)
+		mLevel = CF_LEVEL;
 	item.dwBuff |= CF_NEW_UNIQ;
 	SetupAllItems(item, idx, AdvanceRndSeed(), mLevel, uper, onlygood, false, false);
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1517,7 +1517,11 @@ _unique_items CheckUnique(Item &item, int lvl, int uper, bool recreate)
 	if (numu == 0)
 		return UITEM_INVALID;
 
-	AdvanceRndSeed();
+	// two algorithms to keep old items compatible
+	if ((item.dwBuff & CF_NEW_UNIQ) != 0)
+		numu = GenerateRnd(numu) + 1;
+	else
+		AdvanceRndSeed();
 	uint8_t itemData = 0;
 	while (numu > 0) {
 		if (uok[itemData])
@@ -3411,7 +3415,7 @@ void SpawnItem(Monster &monster, Point position, bool sendmsg)
 	int8_t mLevel = monster.MData->mLevel;
 	if (!gbIsHellfire && monster.MType->mtype == MT_DIABLO)
 		mLevel -= 15;
-
+	item.dwBuff |= CF_NEW_UNIQ;
 	SetupAllItems(item, idx, AdvanceRndSeed(), mLevel, uper, onlygood, false, false);
 
 	if (sendmsg)
@@ -4965,6 +4969,7 @@ std::string DebugSpawnUniqueItem(std::string itemName)
 		for (auto &flag : UniqueItemFlags)
 			flag = true;
 		UniqueItemFlags[uniqueIndex] = false;
+		item.dwBuff |= CF_NEW_UNIQ;
 		SetupAllItems(item, uniqueBaseIndex, AdvanceRndSeed(), uniqueItem.UIMinLvl, 1, false, false, false);
 		for (auto &flag : UniqueItemFlags)
 			flag = false;
@@ -4976,7 +4981,6 @@ std::string DebugSpawnUniqueItem(std::string itemName)
 		std::transform(tmp.begin(), tmp.end(), tmp.begin(), [](unsigned char c) { return std::tolower(c); });
 		if (tmp.find(itemName) != std::string::npos)
 			break;
-		return "Impossible to generate!";
 	}
 
 	item._iIdentified = true;

--- a/Source/items.h
+++ b/Source/items.h
@@ -165,6 +165,7 @@ enum icreateinfo_flag {
 enum icreateinfo_flag2 {
 	// clang-format off
 	CF_HELLFIRE = 1,
+	CF_NEW_UNIQ = 2,
 	// clang-format on
 };
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2201,6 +2201,7 @@ void DeltaLoadLevel()
 				    sgLevels[currlevel].item[i].wValue,
 				    sgLevels[currlevel].item[i].dwBuff);
 			} else {
+				item.dwBuff = sgLevels[currlevel].item[i].dwBuff;
 				RecreateItem(
 				    item,
 				    sgLevels[currlevel].item[i].wIndx,
@@ -2220,7 +2221,6 @@ void DeltaLoadLevel()
 				item._iMinMag = sgLevels[currlevel].item[i].bMinMag;
 				item._iMinDex = sgLevels[currlevel].item[i].bMinDex;
 				item._iAC = sgLevels[currlevel].item[i].bAC;
-				item.dwBuff = sgLevels[currlevel].item[i].dwBuff;
 			}
 			int x = sgLevels[currlevel].item[i].x;
 			int y = sgLevels[currlevel].item[i].y;

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -167,6 +167,7 @@ void UnPackItem(const ItemPack *is, Item *id, bool isHellfire)
 		    SDL_SwapLE32(is->dwBuff));
 	} else {
 		memset(&item, 0, sizeof(item));
+		item.dwBuff = is->dwBuff;
 		RecreateItem(item, idx, SDL_SwapLE16(is->iCreateInfo), SDL_SwapLE32(is->iSeed), SDL_SwapLE16(is->wValue), isHellfire);
 		item._iMagical = static_cast<item_quality>(is->bId >> 1);
 		item._iIdentified = (is->bId & 1) != 0;


### PR DESCRIPTION
Part 2 of the "oneliners that flip the game upside down"
Now required because of https://github.com/diasurgical/devilutionX/pull/2763
Turns out the previous loot fix actually makes some uniques unfindable as they were only findable because of that bug which we fixed. This will apply to all uniques dropped in devilutionx and they might morph into a different unique of the same base in vanilla - In my opinion that's acceptable as there's literally no way we can keep it compatible so there's no reason to even attempt to.
I think that along with #2763 this puts Diablo's loot in a nice state and I'd even consider the game almost playable ;)

- Needs a fat changelog entry!

#edit
Added 1 way compatibility - uniques from vanilla won't morph, but devx uniques will morph in vanilla - there's simply no way around that :P

It's worth considering if we wouldn't want to improve the rng for regular magic items as well, since this PR is introducing a way to tell the difference between vanilla items and devilutionx ones.