### PR TITLE
Remove AvailableItems array, maintain ActiveItems instead

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1084,11 +1084,12 @@ void OpenCrypt()
 		NetSendCmdQuest(true, quest);
 }
 
-void CleanupItems(Item *item, int ii)
+void CleanupItems(int ii)
 {
-	dItem[item->position.x][item->position.y] = 0;
+	auto &item = Items[ii];
+	dItem[item.position.x][item.position.y] = 0;
 
-	if (currlevel == 21 && item->position == CornerStone.position) {
+	if (currlevel == 21 && item.position == CornerStone.position) {
 		CornerStone.item._itype = ItemType::None;
 		CornerStone.item._iSelFlag = 0;
 		CornerStone.item.position = { 0, 0 };
@@ -1627,14 +1628,15 @@ void CheckItemStats(Player &player)
 	}
 }
 
-void InvGetItem(int pnum, Item *item, int ii)
+void InvGetItem(int pnum, int ii)
 {
+	auto &item = Items[ii];
 	if (dropGoldFlag) {
 		CloseGoldDrop();
 		dropGoldValue = 0;
 	}
 
-	if (dItem[item->position.x][item->position.y] == 0)
+	if (dItem[item.position.x][item.position.y] == 0)
 		return;
 
 	auto &player = Players[pnum];
@@ -1642,15 +1644,15 @@ void InvGetItem(int pnum, Item *item, int ii)
 	if (MyPlayerId == pnum && pcurs >= CURSOR_FIRSTITEM)
 		NetSendCmdPItem(true, CMD_SYNCPUTITEM, player.position.tile);
 
-	item->_iCreateInfo &= ~CF_PREGEN;
-	player.HoldItem = *item;
+	item._iCreateInfo &= ~CF_PREGEN;
+	player.HoldItem = item;
 	CheckQuestItem(player);
 	CheckBookLevel(player);
 	CheckItemStats(player);
 	bool cursorUpdated = false;
 	if (player.HoldItem._itype == ItemType::Gold && GoldAutoPlace(player))
 		cursorUpdated = true;
-	CleanupItems(item, ii);
+	CleanupItems(ii);
 	pcursitem = -1;
 	if (!cursorUpdated)
 		NewCursor(player.HoldItem._iCurs + CURSOR_FIRSTITEM);
@@ -1706,7 +1708,7 @@ void AutoGetItem(int pnum, Item *item, int ii)
 			PlaySFX(IS_IGRAB);
 		}
 
-		CleanupItems(&Items[ii], ii);
+		CleanupItems(ii);
 		return;
 	}
 
@@ -1742,25 +1744,30 @@ int FindGetItem(int idx, uint16_t ci, int iseed)
 
 void SyncGetItem(Point position, int idx, uint16_t ci, int iseed)
 {
-	int ii;
+	// Check what the local client has at the target position
+	int ii = dItem[position.x][position.y] - 1;
 
-	if (dItem[position.x][position.y] != 0) {
-		ii = dItem[position.x][position.y] - 1;
-		if (Items[ii].IDidx == idx
-		    && Items[ii]._iSeed == iseed
-		    && Items[ii]._iCreateInfo == ci) {
-			FindGetItem(idx, ci, iseed);
-		} else {
-			ii = FindGetItem(idx, ci, iseed);
+	if (ii >= 0 && ii < MAXITEMS) {
+		// If there was an item there, check that it's the same item as the remote player has
+		if (Items[ii].IDidx != idx
+		    || Items[ii]._iSeed != iseed
+		    || Items[ii]._iCreateInfo != ci) {
+			// Key attributes don't match so we must've desynced, ignore this index and try find a matching item via lookup
+			ii = -1;
 		}
-	} else {
+	}
+
+	if (ii == -1) {
+		// Either there's no item at the expected position or it doesn't match what is being picked up, so look for an item that matches the key attributes
 		ii = FindGetItem(idx, ci, iseed);
 	}
 
-	if (ii == -1)
+	if (ii == -1) {
+		// Still can't find the expected item, assume it was collected earlier and this caused the desync
 		return;
+	}
 
-	CleanupItems(&Items[ii], ii);
+	CleanupItems(ii);
 }
 
 bool CanPut(Point position)

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1101,7 +1101,7 @@ void CleanupItems(int ii)
 	int i = 0;
 	while (i < ActiveItemCount) {
 		if (ActiveItems[i] == ii) {
-			DeleteItem(ActiveItems[i], i);
+			DeleteItem(i);
 			i = 0;
 			continue;
 		}

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -159,7 +159,7 @@ void CheckInvItem(bool isShiftHeld = false, bool isCtrlHeld = false);
  */
 void CheckInvScrn(bool isShiftHeld, bool isCtrlHeld);
 void CheckItemStats(Player &player);
-void InvGetItem(int pnum, Item *item, int ii);
+void InvGetItem(int pnum, int ii);
 void AutoGetItem(int pnum, Item *item, int ii);
 int FindGetItem(int idx, uint16_t ci, int iseed);
 void SyncGetItem(Point position, int idx, uint16_t ci, int iseed);

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -161,8 +161,16 @@ void CheckInvScrn(bool isShiftHeld, bool isCtrlHeld);
 void CheckItemStats(Player &player);
 void InvGetItem(int pnum, int ii);
 void AutoGetItem(int pnum, Item *item, int ii);
-int FindGetItem(int idx, uint16_t ci, int iseed);
-void SyncGetItem(Point position, int idx, uint16_t ci, int iseed);
+
+/**
+ * @brief Searches for a dropped item with the same type/createInfo/seed
+ * @param iseed The value used to initialise the RNG when generating the item
+ * @param idx The overarching type of the target item
+ * @param createInfo Flags used to describe the specific subtype of the target item
+ * @return An index into ActiveItems or -1 if no matching item was found
+*/
+int FindGetItem(int32_t iseed, _item_indexes idx, uint16_t ci);
+void SyncGetItem(Point position, int32_t iseed, _item_indexes idx, uint16_t ci);
 bool CanPut(Point position);
 bool TryInvPut();
 int InvPutItem(Player &player, Point position);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -42,6 +42,12 @@ namespace devilution {
 Item Items[MAXITEMS + 1];
 int ActiveItems[MAXITEMS];
 int ActiveItemCount;
+/**
+ * @brief Contains indexes of empty spaces in Items.
+ *
+ * This array effectively duplicates ActiveItems due to differences in implementation to other fixed buffers.
+ * Eventually this can be removed and Items can be treated the same as how Missiles are tracked
+ */
 int AvailableItems[MAXITEMS];
 bool ShowUniqueItemInfoBox;
 CornerStoneStruct CornerStone;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -40,15 +40,15 @@ namespace devilution {
 
 /** Contains the items on ground in the current game. */
 Item Items[MAXITEMS + 1];
-int ActiveItems[MAXITEMS];
-int ActiveItemCount;
+uint8_t ActiveItems[MAXITEMS];
+uint8_t ActiveItemCount;
 /**
  * @brief Contains indexes of empty spaces in Items.
  *
  * This array effectively duplicates ActiveItems due to differences in implementation to other fixed buffers.
  * Eventually this can be removed and Items can be treated the same as how Missiles are tracked
  */
-int AvailableItems[MAXITEMS];
+uint8_t AvailableItems[MAXITEMS];
 bool ShowUniqueItemInfoBox;
 CornerStoneStruct CornerStone;
 bool UniqueItemFlags[128];
@@ -2597,9 +2597,9 @@ void InitItems()
 		item._iPostDraw = false;
 	}
 
-	for (int i = 0; i < MAXITEMS; i++) {
+	for (uint8_t i = 0; i < MAXITEMS; i++) {
+		ActiveItems[i] = i;
 		AvailableItems[i] = i;
-		ActiveItems[i] = 0;
 	}
 
 	if (!setlevel) {

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3567,7 +3567,7 @@ void CornerstoneLoad(Point position)
 		int ii = dItem[position.x][position.y] - 1;
 		for (int i = 0; i < ActiveItemCount; i++) {
 			if (ActiveItems[i] == ii) {
-				DeleteItem(ii, i);
+				DeleteItem(ActiveItems[i], i);
 				break;
 			}
 		}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3567,7 +3567,7 @@ void CornerstoneLoad(Point position)
 		int ii = dItem[position.x][position.y] - 1;
 		for (int i = 0; i < ActiveItemCount; i++) {
 			if (ActiveItems[i] == ii) {
-				DeleteItem(ActiveItems[i], i);
+				DeleteItem(i);
 				break;
 			}
 		}
@@ -3686,14 +3686,15 @@ void RespawnItem(Item *item, bool flipFlag)
 		item->_iSelFlag = 1;
 }
 
-void DeleteItem(int ii, int i)
+void DeleteItem(int i)
 {
-	AvailableItems[MAXITEMS - ActiveItemCount] = ii;
+	if (pcursitem == ActiveItems[i]) // Unselect item if player has it highlighted
+		pcursitem = -1;
+
+	AvailableItems[MAXITEMS - ActiveItemCount] = ActiveItems[i];
 	ActiveItemCount--;
 	if (ActiveItemCount > 0 && i != ActiveItemCount)
 		ActiveItems[i] = ActiveItems[ActiveItemCount];
-	if (pcursitem == ii) // Unselect item if player has it highlighted
-		pcursitem = -1;
 }
 
 void ProcessItems()

--- a/Source/items.h
+++ b/Source/items.h
@@ -414,9 +414,9 @@ struct CornerStoneStruct {
 struct Player;
 
 extern Item Items[MAXITEMS + 1];
-extern int ActiveItems[MAXITEMS];
-extern int ActiveItemCount;
-extern int AvailableItems[MAXITEMS];
+extern uint8_t ActiveItems[MAXITEMS];
+extern uint8_t ActiveItemCount;
+extern uint8_t AvailableItems[MAXITEMS];
 extern bool ShowUniqueItemInfoBox;
 extern CornerStoneStruct CornerStone;
 extern bool UniqueItemFlags[128];

--- a/Source/items.h
+++ b/Source/items.h
@@ -367,7 +367,7 @@ struct Item {
 		return IsScroll() && _iSpell == spellId;
 	}
 
-	[[nodiscard]] bool KeyAttributesMatch(int32_t seed, _item_indexes itemIndex, uint16_t createInfo)
+	[[nodiscard]] bool KeyAttributesMatch(int32_t seed, _item_indexes itemIndex, uint16_t createInfo) const
 	{
 		return _iSeed == seed && IDidx == itemIndex && _iCreateInfo == createInfo;
 	}

--- a/Source/items.h
+++ b/Source/items.h
@@ -416,7 +416,6 @@ struct Player;
 extern Item Items[MAXITEMS + 1];
 extern uint8_t ActiveItems[MAXITEMS];
 extern uint8_t ActiveItemCount;
-extern uint8_t AvailableItems[MAXITEMS];
 extern bool ShowUniqueItemInfoBox;
 extern CornerStoneStruct CornerStone;
 extern bool UniqueItemFlags[128];

--- a/Source/items.h
+++ b/Source/items.h
@@ -464,7 +464,7 @@ void SpawnMapOfDoom(Point position);
 void SpawnRuneBomb(Point position);
 void SpawnTheodore(Point position);
 void RespawnItem(Item *item, bool FlipFlag);
-void DeleteItem(int ii, int i);
+void DeleteItem(int i);
 void ProcessItems();
 void FreeItemGFX();
 void GetItemFrm(Item &item);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -928,11 +928,10 @@ void LoadDroppedItemLocations(LoadHelper &file, const std::unordered_map<uint8_t
 void RemoveEmptyLevelItems()
 {
 	for (int i = ActiveItemCount; i > 0; i--) {
-		int ii = ActiveItems[i];
-		auto &item = Items[ii];
+		auto &item = Items[ActiveItems[i]];
 		if (item.isEmpty()) {
 			dItem[item.position.x][item.position.y] = 0;
-			DeleteItem(ii, i);
+			DeleteItem(ActiveItems[i], i);
 		}
 	}
 }

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -900,7 +900,7 @@ std::unordered_map<uint8_t, uint8_t> LoadDroppedItems(LoadHelper &file)
 	}
 	file.Skip(MAXITEMS * 2 - static_cast<size_t>(ActiveItemCount)); // Skip loading the rest of ActiveItems and AvailableItems, the indices are initialised below based on the number of active items
 
-	for (int i = 0; i < MAXITEMS; i++) {
+	for (uint8_t i = 0; i < MAXITEMS; i++) {
 		if (i < ActiveItemCount)
 			LoadItem(file, Items[i]);
 
@@ -1512,13 +1512,13 @@ void SavePortal(SaveHelper *file, int i)
 std::unordered_map<uint8_t, uint8_t> SaveDroppedItems(SaveHelper &file)
 {
 	// Vanilla Diablo/Hellfire initialise the ActiveItems and AvailableItems arrays based on saved data, so write valid values for compatibility
-	for (int i = 0; i < MAXITEMS; i++)
-		file.WriteLE<int8_t>(i); // Strictly speaking everything from ActiveItemCount onwards is unused but no harm writing non-zero values here.
-	for (int i = 0; i < MAXITEMS; i++)
-		file.WriteLE<int8_t>((i + ActiveItemCount) % MAXITEMS);
+	for (uint8_t i = 0; i < MAXITEMS; i++)
+		file.WriteLE<uint8_t>(i); // Strictly speaking everything from ActiveItemCount onwards is unused but no harm writing non-zero values here.
+	for (uint8_t i = 0; i < MAXITEMS; i++)
+		file.WriteLE<uint8_t>((i + ActiveItemCount) % MAXITEMS);
 
 	std::unordered_map<uint8_t, uint8_t> itemIndexes = { { 0, 0 } };
-	for (int i = 0; i < ActiveItemCount; i++) {
+	for (uint8_t i = 0; i < ActiveItemCount; i++) {
 		itemIndexes[ActiveItems[i] + 1] = i + 1;
 		SaveItem(file, Items[ActiveItems[i]]);
 	}
@@ -1534,7 +1534,7 @@ void SaveDroppedItemLocations(SaveHelper &file, const std::unordered_map<uint8_t
 {
 	for (int j = 0; j < MAXDUNY; j++) {
 		for (int i = 0; i < MAXDUNX; i++) // NOLINT(modernize-loop-convert)
-			file.WriteLE<int8_t>(itemIndexes.at(dItem[i][j]));
+			file.WriteLE<uint8_t>(itemIndexes.at(dItem[i][j]));
 	}
 }
 

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -904,9 +904,8 @@ std::unordered_map<uint8_t, uint8_t> LoadDroppedItems(LoadHelper &file)
 		if (i < ActiveItemCount)
 			LoadItem(file, Items[i]);
 
-		// Initialise the ActiveItems and AvailableItems arrays so the existing logic for dropping items can stay unchanged
+		// Initialise ActiveItems to reflect the order the items were loaded from the file
 		ActiveItems[i] = i;
-		AvailableItems[i] = (i + ActiveItemCount) % MAXITEMS;
 	}
 
 	return itemIndexes;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -931,7 +931,7 @@ void RemoveEmptyLevelItems()
 		auto &item = Items[ActiveItems[i]];
 		if (item.isEmpty()) {
 			dItem[item.position.x][item.position.y] = 0;
-			DeleteItem(ActiveItems[i], i);
+			DeleteItem(i);
 		}
 	}
 }

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -724,7 +724,7 @@ DWORD OnRequestGetItem(const TCmd *pCmd, Player &player)
 				if (message.bPnum != MyPlayerId)
 					SyncGetItem(position, message.wIndx, message.wCI, message.dwSeed);
 				else
-					InvGetItem(MyPlayerId, &Items[ii], ii);
+					InvGetItem(MyPlayerId, ii);
 				SetItemRecord(message.dwSeed, message.wCI, message.wIndx);
 			} else if (!NetSendCmdReq2(CMD_REQUESTGITEM, MyPlayerId, message.bPnum, message)) {
 				NetSendCmdExtra(message);
@@ -751,9 +751,9 @@ DWORD OnGetItem(const TCmd *pCmd, int pnum)
 						auto &player = Players[MyPlayerId];
 						ii = SyncPutItem(player, player.position.tile, message.wIndx, message.wCI, message.dwSeed, message.bId, message.bDur, message.bMDur, message.bCh, message.bMCh, message.wValue, message.dwBuff, message.wToHit, message.wMaxDam, message.bMinStr, message.bMinMag, message.bMinDex, message.bAC);
 						if (ii != -1)
-							InvGetItem(MyPlayerId, &Items[ii], ii);
+							InvGetItem(MyPlayerId, ii);
 					} else {
-						InvGetItem(MyPlayerId, &Items[ii], ii);
+						InvGetItem(MyPlayerId, ii);
 					}
 				} else {
 					SyncGetItem(position, message.wIndx, message.wCI, message.dwSeed);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -715,14 +715,18 @@ DWORD OnRequestGetItem(const TCmd *pCmd, Player &player)
 				}
 			}
 
-			if (ii == -1) { // No item at the target position or the key attributes don't match, so try find a matching item.
-				ii = FindGetItem(message.wIndx, message.wCI, message.dwSeed);
+			if (ii == -1) {
+				// No item at the target position or the key attributes don't match, so try find a matching item.
+				int activeItemIndex = FindGetItem(message.dwSeed, message.wIndx, message.wCI);
+				if (activeItemIndex != -1) {
+					ii = ActiveItems[activeItemIndex];
+				}
 			}
 
 			if (ii != -1) {
 				NetSendCmdGItem2(false, CMD_GETITEM, MyPlayerId, message.bPnum, message);
 				if (message.bPnum != MyPlayerId)
-					SyncGetItem(position, message.wIndx, message.wCI, message.dwSeed);
+					SyncGetItem(position, message.dwSeed, message.wIndx, message.wCI);
 				else
 					InvGetItem(MyPlayerId, ii);
 				SetItemRecord(message.dwSeed, message.wCI, message.wIndx);
@@ -743,20 +747,20 @@ DWORD OnGetItem(const TCmd *pCmd, int pnum)
 		SendPacket(pnum, &message, sizeof(message));
 	} else if (IsGItemValid(message)) {
 		const Point position { message.x, message.y };
-		int ii = FindGetItem(message.wIndx, message.wCI, message.dwSeed);
 		if (DeltaGetItem(message, message.bLevel)) {
 			if ((currlevel == message.bLevel || message.bPnum == MyPlayerId) && message.bMaster != MyPlayerId) {
 				if (message.bPnum == MyPlayerId) {
 					if (currlevel != message.bLevel) {
 						auto &player = Players[MyPlayerId];
-						ii = SyncPutItem(player, player.position.tile, message.wIndx, message.wCI, message.dwSeed, message.bId, message.bDur, message.bMDur, message.bCh, message.bMCh, message.wValue, message.dwBuff, message.wToHit, message.wMaxDam, message.bMinStr, message.bMinMag, message.bMinDex, message.bAC);
+						int ii = SyncPutItem(player, player.position.tile, message.wIndx, message.wCI, message.dwSeed, message.bId, message.bDur, message.bMDur, message.bCh, message.bMCh, message.wValue, message.dwBuff, message.wToHit, message.wMaxDam, message.bMinStr, message.bMinMag, message.bMinDex, message.bAC);
 						if (ii != -1)
 							InvGetItem(MyPlayerId, ii);
 					} else {
-						InvGetItem(MyPlayerId, ii);
+						int activeItemIndex = FindGetItem(message.dwSeed, message.wIndx, message.wCI);
+						InvGetItem(MyPlayerId, ActiveItems[activeItemIndex]);
 					}
 				} else {
-					SyncGetItem(position, message.wIndx, message.wCI, message.dwSeed);
+					SyncGetItem(position, message.dwSeed, message.wIndx, message.wCI);
 				}
 			}
 		} else {
@@ -788,11 +792,10 @@ DWORD OnRequestAutoGetItem(const TCmd *pCmd, Player &player)
 	if (gbBufferMsgs != 1 && IOwnLevel(player.plrlevel) && IsGItemValid(message)) {
 		const Point position { message.x, message.y };
 		if (GetItemRecord(message.dwSeed, message.wCI, message.wIndx)) {
-			int ii = FindGetItem(message.wIndx, message.wCI, message.dwSeed);
-			if (ii != -1) {
+			if (FindGetItem(message.dwSeed, message.wIndx, message.wCI) != -1) {
 				NetSendCmdGItem2(false, CMD_AGETITEM, MyPlayerId, message.bPnum, message);
 				if (message.bPnum != MyPlayerId)
-					SyncGetItem(position, message.wIndx, message.wCI, message.dwSeed);
+					SyncGetItem(position, message.dwSeed, message.wIndx, message.wCI);
 				else
 					AutoGetItem(MyPlayerId, &Items[message.bCursitem], message.bCursitem);
 				SetItemRecord(message.dwSeed, message.wCI, message.wIndx);
@@ -825,7 +828,7 @@ DWORD OnAutoGetItem(const TCmd *pCmd, int pnum)
 						AutoGetItem(MyPlayerId, &Items[message.bCursitem], message.bCursitem);
 					}
 				} else {
-					SyncGetItem(position, message.wIndx, message.wCI, message.dwSeed);
+					SyncGetItem(position, message.dwSeed, message.wIndx, message.wCI);
 				}
 			}
 		} else {
@@ -843,10 +846,11 @@ DWORD OnItemExtra(const TCmd *pCmd, int pnum)
 	if (gbBufferMsgs == 1) {
 		SendPacket(pnum, &message, sizeof(message));
 	} else if (IsGItemValid(message)) {
-		const Point position { message.x, message.y };
 		DeltaGetItem(message, message.bLevel);
-		if (currlevel == Players[pnum].plrlevel)
-			SyncGetItem(position, message.wIndx, message.wCI, message.dwSeed);
+		if (currlevel == Players[pnum].plrlevel) {
+			const Point position { message.x, message.y };
+			SyncGetItem(position, message.dwSeed, message.wIndx, message.wCI);
+		}
 	}
 
 	return sizeof(message);
@@ -2223,14 +2227,15 @@ void DeltaLoadLevel()
 			continue;
 
 		if (sgLevels[currlevel].item[i].bCmd == CMD_WALKXY) {
-			int ii = FindGetItem(
+			int activeItemIndex = FindGetItem(
+			    sgLevels[currlevel].item[i].dwSeed,
 			    sgLevels[currlevel].item[i].wIndx,
-			    sgLevels[currlevel].item[i].wCI,
-			    sgLevels[currlevel].item[i].dwSeed);
-			if (ii != -1) {
-				if (dItem[Items[ii].position.x][Items[ii].position.y] == ii + 1)
-					dItem[Items[ii].position.x][Items[ii].position.y] = 0;
-				DeleteItem(ii, i);
+			    sgLevels[currlevel].item[i].wCI);
+			if (activeItemIndex != -1) {
+				const auto &position = Items[ActiveItems[activeItemIndex]].position;
+				if (dItem[position.x][position.y] == ActiveItems[activeItemIndex] + 1)
+					dItem[position.x][position.y] = 0;
+				DeleteItem(ActiveItems[activeItemIndex], activeItemIndex);
 			}
 		}
 		if (sgLevels[currlevel].item[i].bCmd == CMD_ACK_PLRINFO) {

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2235,7 +2235,7 @@ void DeltaLoadLevel()
 				const auto &position = Items[ActiveItems[activeItemIndex]].position;
 				if (dItem[position.x][position.y] == ActiveItems[activeItemIndex] + 1)
 					dItem[position.x][position.y] = 0;
-				DeleteItem(ActiveItems[activeItemIndex], activeItemIndex);
+				DeleteItem(activeItemIndex);
 			}
 		}
 		if (sgLevels[currlevel].item[i].bCmd == CMD_ACK_PLRINFO) {

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -230,7 +230,7 @@ struct TCmdGItem {
 	uint8_t bLevel;
 	uint8_t x;
 	uint8_t y;
-	uint16_t wIndx;
+	_item_indexes wIndx;
 	uint16_t wCI;
 	int32_t dwSeed;
 	uint8_t bId;
@@ -256,7 +256,7 @@ struct TCmdPItem {
 	_cmd_id bCmd;
 	uint8_t x;
 	uint8_t y;
-	uint16_t wIndx;
+	_item_indexes wIndx;
 	uint16_t wCI;
 	/**
 	 * Item identifier

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3022,7 +3022,7 @@ StartPlayerKill(int pnum, int earflag)
 						ear._iSeed = player._pName[2] << 24 | player._pName[3] << 16 | player._pName[4] << 8 | player._pName[5];
 						ear._ivalue = player._pLevel;
 
-						if (FindGetItem(IDI_EAR, ear._iCreateInfo, ear._iSeed) == -1) {
+						if (FindGetItem(ear._iSeed, IDI_EAR, ear._iCreateInfo) == -1) {
 							DeadItem(player, &ear, { 0, 0 });
 						}
 					} else {


### PR DESCRIPTION
This PR refactors Items to remove the redundant AvailableItems array, essentially splitting the ActiveElements (ActiveItems) array into a section for live entities and a section for "free" memory. (This is prep work for #2586). Edit: I thought this had already been done for Missiles for some reason, the same approach can be used there.

I also updated the save/load from file code to decouple the indexes in the save file from the position in the Items array, this allows us to keep save compatibility with vanilla which uses AvailableItems as a list of free indexes. The only real difficulty there was ensuring that dItems maps from the saved values to the appropriate runtime values.

The Item sync code for DeltaLoadLevel originally tried to delete items based on position in the replay/sync data instead of the actual location in the current client for some reason, this PR updates that code to only attempt to delete client side items that match the expected identifiers. The old logic would potentially leave items visible for one player if they were on a different floor and another player picks up an item, this change handles that situation fine. I am not sure if there are any other situations where desync would be possible.