### PR TITLE
Add vcpkg.json to the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,11 @@ mark_as_advanced(DISABLE_STREAMING_SOUNDS)
 option(STREAM_ALL_AUDIO "Stream all the audio. For extremely RAM-constrained platforms.")
 mark_as_advanced(STREAM_ALL_AUDIO)
 
+# The gettext[tools] package takes a very long time to install
+if(CMAKE_TOOLCHAIN_FILE MATCHES "vcpkg.cmake$")
+  option(USE_GETTEXT_FROM_VCPKG "Add vcpkg dependency for gettext[tools] for compiling translations" OFF)
+endif()
+
 RELEASE_OPTION(CPACK "Configure CPack")
 
 
@@ -58,6 +63,13 @@ if(NIGHTLY_BUILD OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "")
   set(DIST ON)
   set(CPACK ON)
+endif()
+
+if(USE_GETTEXT_FROM_VCPKG)
+  list(APPEND VCPKG_MANIFEST_FEATURES "translations")
+endif()
+if(RUN_TESTS)
+  list(APPEND VCPKG_MANIFEST_FEATURES "tests")
 endif()
 
 if(NOT NOSOUND)
@@ -639,6 +651,10 @@ if(GPERF)
   find_package(Gperftools REQUIRED)
 endif()
 
+if(USE_GETTEXT_FROM_VCPKG)
+  # vcpkg doesn't add its own tools directory to the search path
+  list(APPEND Gettext_ROOT ${CMAKE_CURRENT_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/tools/gettext/bin)
+endif()
 find_package(Gettext)
 if (Gettext_FOUND)
   foreach(lang bg da de es fr hr it ko_KR pt_BR ru sv zh_CN zh_TW)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,14 +3,13 @@ version: 1.0.{build}
 pull_requests:
   do_not_increment_build_number: true
 image: Visual Studio 2019
-cache: c:\tools\vcpkg\installed\
+cache: '%LOCALAPPDATA%\vcpkg\archives'
 
 install:
   - cd C:\Tools\vcpkg
   - git pull
   - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%
-  - vcpkg install --recurse fmt:x64-windows sdl2:x64-windows sdl2-ttf:x64-windows libsodium:x64-windows libpng:x64-windows
 
 before_build:
   - cmake -G "Visual Studio 16 2019" -A x64 -DNIGHTLY_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake .

--- a/docs/building.md
+++ b/docs/building.md
@@ -124,22 +124,8 @@ of the `(i686|x86_64)-w64-mingw32` directory.
 ### Installing dependencies
 Make sure to install the `C++ CMake tools for Windows` component for Visual Studio.
 
-1. Install vcpkg following the instructions from https://github.com/microsoft/vcpkg#quick-start.
-
-   Don't forget to perform _user-wide integration_ step for additional convenience.
-2. Install required dependencies by executing the following command (via cmd or powershell):
-
-   For the 64-bit version of the dependencies please run this command:
-
-   ```
-   vcpkg install fmt:x64-windows sdl2:x64-windows sdl2-ttf:x64-windows libsodium:x64-windows libpng:x64-windows gtest:x64-windows
-   ```
-
-   For the 32-bit version of the dependencies please run this command:
-
-   ```
-   vcpkg install fmt:x86-windows sdl2:x86-windows sdl2-ttf:x86-windows libsodium:x86-windows libpng:x86-windows gtest:x86-windows
-   ```
+Install vcpkg following the instructions from https://github.com/microsoft/vcpkg#quick-start.
+Don't forget to perform _user-wide integration_ step for additional convenience.
 
 ### Compiling
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,27 @@
+{
+    "name": "devilutionx",
+    "version-string": "1.2.1",
+    "dependencies": [
+        "fmt",
+        "freetype",
+        "libpng",
+        "libsodium",
+        "sdl2",
+        "sdl2-ttf"
+    ],
+    "features": {
+        "translations": {
+            "description": "Build translation files",
+            "dependencies": [
+                {
+                    "name": "gettext",
+                    "features": [ "tools" ]
+                }
+            ]
+        },
+        "tests": {
+            "description": "Build tests",
+            "dependencies": [ "gtest" ]
+        }
+    }
+}


### PR DESCRIPTION
After installing and integrating vcpkg, CMake will use vcpkg.json to automatically determine dependencies for the project and place them in `${CMAKE_CURRENT_BINARY_DIR}/vcpkg_installed` during the configure step.

This behavior requires the `VCPKG_MANIFEST_MODE` CMake variable to be set, which will happen automatically for new builds during the configure step, based on the presence of the vcpkg.json file. In other words, users who already have build directories set up would have to delete their CMakeCache.txt files to make use of this.

By default, packages appear to be cached in `%localappdata%\vcpkg\archives` so packages don't need to be redownloaded or built once installed. This means that Debug and Release builds can share the same packages, and it's safe to delete build directories without taking a debilitating hit to build performance on the next build.

Translations and tests are included as features which can be optionally turned on by modifying the `VCPKG_MANIFEST_FEATURES` CMake variable. I added a bit of logic to CMakeLists.txt to automatically turn those on based on the `BUILD_TRANSLATIONS` and `RUN_TESTS` options. The former needed to be optional because it takes about an hour to install the gettext[tools] package from vcpkg. The latter ensures that the gtest dependency gets downloaded automatically when targeting the x64-Debug-UnitTests or x86-Debug-UnitTests CMake configurations.

---

See https://github.com/microsoft/vcpkg/blob/master/docs/users/manifests.md for more detailed information about vcpkg manifests.