### PR TITLE
Fix buffer overflow when sending game messages as chat

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -75,7 +75,7 @@ void SetSpellLevelCheat(spell_id spl, int spllvl)
 
 void PrintDebugMonster(int m)
 {
-	char dstr[128];
+	char dstr[MAX_SEND_STR_LEN];
 
 	auto &monster = Monsters[m];
 
@@ -748,7 +748,7 @@ void GetDebugMonster()
 
 void NextDebugMonster()
 {
-	char dstr[128];
+	char dstr[MAX_SEND_STR_LEN];
 
 	DebugMonsterId++;
 	if (DebugMonsterId == MAXMONSTERS)

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1433,16 +1433,17 @@ void InitKeymapActions()
 	    "GameInfo",
 	    'V',
 	    [] {
-		    char pszStr[120];
+		    char pszStr[MAX_SEND_STR_LEN];
 		    const char *difficulties[3] = {
 			    _("Normal"),
 			    _("Nightmare"),
 			    _("Hell"),
 		    };
-		    strcpy(pszStr, fmt::format(_(/* TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty. */
-		                                   "{:s}, version = {:s}, mode = {:s}"),
-		                       gszProductName, PROJECT_VERSION, difficulties[sgGameInitInfo.nDifficulty])
-		                       .c_str());
+		    strncpy(pszStr, fmt::format(_(/* TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty. */
+		                                    "{:s}, version = {:s}, mode = {:s}"),
+		                        PROJECT_NAME, PROJECT_VERSION, difficulties[sgGameInitInfo.nDifficulty])
+		                        .c_str(),
+		        MAX_SEND_STR_LEN - 1);
 		    NetSendCmdString(1 << MyPlayerId, pszStr);
 	    },
 	    [&]() { return !IsPlayerDead(); },


### PR DESCRIPTION
Previously the game would crash when pressing `v` when some translations where loaded because it would overflow the 80 char limit. This is additionally solved by not having the version string in there twice :D