### PR TITLE
Initial clean up of code related to creating items

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -372,7 +372,7 @@ void RemoveGold(Player &player, int goldIndex)
 		SetPlrHandGoldCurs(player.InvList[gi]);
 	else
 		player.RemoveInvItem(gi);
-	SetPlrHandItem(player.HoldItem, IDI_GOLD);
+	InitializeItem(player.HoldItem, IDI_GOLD);
 	SetGoldSeed(player, player.HoldItem);
 	player.HoldItem._ivalue = dropGoldValue;
 	player.HoldItem._iStatFlag = true;

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -175,7 +175,7 @@ std::string DebugCmdGiveGoldCheat(const string_view parameter)
 
 		int ni = myPlayer._pNumInv++;
 		InitializeItem(myPlayer.InvList[ni], IDI_GOLD);
-		GetPlrHandSeed(&myPlayer.InvList[ni]);
+		GenerateNewSeed(myPlayer.InvList[ni]);
 		myPlayer.InvList[ni]._ivalue = GOLD_MAX_LIMIT;
 		myPlayer.InvList[ni]._iCurs = ICURS_GOLD_LARGE;
 		myPlayer._pGold += GOLD_MAX_LIMIT;

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -174,7 +174,7 @@ std::string DebugCmdGiveGoldCheat(const string_view parameter)
 			continue;
 
 		int ni = myPlayer._pNumInv++;
-		SetPlrHandItem(myPlayer.InvList[ni], IDI_GOLD);
+		InitializeItem(myPlayer.InvList[ni], IDI_GOLD);
 		GetPlrHandSeed(&myPlayer.InvList[ni]);
 		myPlayer.InvList[ni]._ivalue = GOLD_MAX_LIMIT;
 		myPlayer.InvList[ni]._iCurs = ICURS_GOLD_LARGE;

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -56,7 +56,6 @@ int8_t dPlayer[MAXDUNX][MAXDUNY];
 int16_t dMonster[MAXDUNX][MAXDUNY];
 int8_t dCorpse[MAXDUNX][MAXDUNY];
 int8_t dObject[MAXDUNX][MAXDUNY];
-int8_t dItem[MAXDUNX][MAXDUNY];
 char dSpecial[MAXDUNX][MAXDUNY];
 int themeCount;
 THEME_LOC themeLoc[MAXTHEMES];
@@ -622,7 +621,6 @@ void DRLG_Init_Globals()
 	memset(dMonster, 0, sizeof(dMonster));
 	memset(dCorpse, 0, sizeof(dCorpse));
 	memset(dObject, 0, sizeof(dObject));
-	memset(dItem, 0, sizeof(dItem));
 	memset(dSpecial, 0, sizeof(dSpecial));
 	int8_t c = DisableLighting ? 0 : 15;
 	memset(dLight, c, sizeof(dLight));

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -224,8 +224,6 @@ extern int16_t dMonster[MAXDUNX][MAXDUNY];
 extern DVL_API_FOR_TEST int8_t dCorpse[MAXDUNX][MAXDUNY];
 /** Contains the object numbers (objects array indices) of the map. */
 extern DVL_API_FOR_TEST int8_t dObject[MAXDUNX][MAXDUNY];
-/** Contains the item numbers (items array indices) of the map. */
-extern int8_t dItem[MAXDUNX][MAXDUNY];
 /**
  * Contains the arch frame numbers of the map from the special tileset
  * (e.g. "levels/l1data/l1s.cel"). Note, the special tileset of Tristram (i.e.

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1719,7 +1719,7 @@ void AutoGetItem(int pnum, Item *item, int ii)
 		player.Say(HeroSpeech::ICantCarryAnymore);
 	}
 	player.HoldItem = *item;
-	RespawnItem(item, true);
+	RespawnItem(*item, true);
 	NetSendCmdPItem(true, CMD_RESPAWNITEM, item->position, player.HoldItem);
 	player.HoldItem._itype = ItemType::None;
 }
@@ -1843,7 +1843,7 @@ int InvPutItem(Player &player, Point position)
 	dItem[position.x][position.y] = ii + 1;
 	Items[ii] = player.HoldItem;
 	Items[ii].position = position;
-	RespawnItem(&Items[ii], true);
+	RespawnItem(Items[ii], true);
 
 	if (currlevel == 21 && position == CornerStone.position) {
 		CornerStone.item = Items[ii];
@@ -1900,7 +1900,7 @@ int SyncDropItem(Point position, int idx, uint16_t icreateinfo, int iseed, int i
 	}
 
 	item.position = position;
-	RespawnItem(&Items[ii], true);
+	RespawnItem(Items[ii], true);
 
 	if (currlevel == 21 && position == CornerStone.position) {
 		CornerStone.item = Items[ii];

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1529,7 +1529,7 @@ bool GoldAutoPlace(Player &player)
 			SetPlrHandGoldCurs(player.HoldItem);
 			player.InvList[i]._ivalue = MaxGold;
 			if (gbIsHellfire)
-				GetPlrHandSeed(&player.HoldItem);
+				GenerateNewSeed(player.HoldItem);
 		} else {
 			player.HoldItem._ivalue = 0;
 			done = true;
@@ -1561,13 +1561,13 @@ bool GoldAutoPlaceInInventorySlot(Player &player, int slotIndex)
 	player.InvList[ii] = player.HoldItem;
 	player._pNumInv++;
 	player.InvGrid[slotIndex] = player._pNumInv;
-	GetPlrHandSeed(&player.InvList[ii]);
+	GenerateNewSeed(player.InvList[ii]);
 
 	int gold = player.HoldItem._ivalue;
 	if (gold > MaxGold) {
 		gold -= MaxGold;
 		player.HoldItem._ivalue = gold;
-		GetPlrHandSeed(&player.HoldItem);
+		GenerateNewSeed(player.HoldItem);
 		player.InvList[ii]._ivalue = MaxGold;
 		return false;
 	}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2947,9 +2947,9 @@ void InitializeItem(Item &item, int itemData)
 		item.dwBuff |= CF_HELLFIRE;
 }
 
-void GetPlrHandSeed(Item *h)
+void GenerateNewSeed(Item &item)
 {
-	h->_iSeed = AdvanceRndSeed();
+	item._iSeed = AdvanceRndSeed();
 }
 
 void SetGoldSeed(Player &player, Item &gold)
@@ -3018,79 +3018,79 @@ void CreatePlrItems(int playerId)
 	switch (player._pClass) {
 	case HeroClass::Warrior:
 		InitializeItem(player.InvBody[INVLOC_HAND_LEFT], IDI_WARRIOR);
-		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_LEFT]);
+		GenerateNewSeed(player.InvBody[INVLOC_HAND_LEFT]);
 
 		InitializeItem(player.InvBody[INVLOC_HAND_RIGHT], IDI_WARRSHLD);
-		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_RIGHT]);
+		GenerateNewSeed(player.InvBody[INVLOC_HAND_RIGHT]);
 
 		InitializeItem(player.HoldItem, IDI_WARRCLUB);
-		GetPlrHandSeed(&player.HoldItem);
+		GenerateNewSeed(player.HoldItem);
 		AutoPlaceItemInInventory(player, player.HoldItem, true);
 
 		InitializeItem(player.SpdList[0], IDI_HEAL);
-		GetPlrHandSeed(&player.SpdList[0]);
+		GenerateNewSeed(player.SpdList[0]);
 
 		InitializeItem(player.SpdList[1], IDI_HEAL);
-		GetPlrHandSeed(&player.SpdList[1]);
+		GenerateNewSeed(player.SpdList[1]);
 		break;
 	case HeroClass::Rogue:
 		InitializeItem(player.InvBody[INVLOC_HAND_LEFT], IDI_ROGUE);
-		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_LEFT]);
+		GenerateNewSeed(player.InvBody[INVLOC_HAND_LEFT]);
 
 		InitializeItem(player.SpdList[0], IDI_HEAL);
-		GetPlrHandSeed(&player.SpdList[0]);
+		GenerateNewSeed(player.SpdList[0]);
 
 		InitializeItem(player.SpdList[1], IDI_HEAL);
-		GetPlrHandSeed(&player.SpdList[1]);
+		GenerateNewSeed(player.SpdList[1]);
 		break;
 	case HeroClass::Sorcerer:
 		InitializeItem(player.InvBody[INVLOC_HAND_LEFT], gbIsHellfire ? IDI_SORCERER : 166);
-		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_LEFT]);
+		GenerateNewSeed(player.InvBody[INVLOC_HAND_LEFT]);
 
 		InitializeItem(player.SpdList[0], gbIsHellfire ? IDI_HEAL : IDI_MANA);
-		GetPlrHandSeed(&player.SpdList[0]);
+		GenerateNewSeed(player.SpdList[0]);
 
 		InitializeItem(player.SpdList[1], gbIsHellfire ? IDI_HEAL : IDI_MANA);
-		GetPlrHandSeed(&player.SpdList[1]);
+		GenerateNewSeed(player.SpdList[1]);
 		break;
 
 	case HeroClass::Monk:
 		InitializeItem(player.InvBody[INVLOC_HAND_LEFT], IDI_SHORTSTAFF);
-		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_LEFT]);
+		GenerateNewSeed(player.InvBody[INVLOC_HAND_LEFT]);
 		InitializeItem(player.SpdList[0], IDI_HEAL);
-		GetPlrHandSeed(&player.SpdList[0]);
+		GenerateNewSeed(player.SpdList[0]);
 
 		InitializeItem(player.SpdList[1], IDI_HEAL);
-		GetPlrHandSeed(&player.SpdList[1]);
+		GenerateNewSeed(player.SpdList[1]);
 		break;
 	case HeroClass::Bard:
 		InitializeItem(player.InvBody[INVLOC_HAND_LEFT], IDI_BARDSWORD);
-		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_LEFT]);
+		GenerateNewSeed(player.InvBody[INVLOC_HAND_LEFT]);
 
 		InitializeItem(player.InvBody[INVLOC_HAND_RIGHT], IDI_BARDDAGGER);
-		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_RIGHT]);
+		GenerateNewSeed(player.InvBody[INVLOC_HAND_RIGHT]);
 		InitializeItem(player.SpdList[0], IDI_HEAL);
-		GetPlrHandSeed(&player.SpdList[0]);
+		GenerateNewSeed(player.SpdList[0]);
 
 		InitializeItem(player.SpdList[1], IDI_HEAL);
-		GetPlrHandSeed(&player.SpdList[1]);
+		GenerateNewSeed(player.SpdList[1]);
 		break;
 	case HeroClass::Barbarian:
 		InitializeItem(player.InvBody[INVLOC_HAND_LEFT], 139); // TODO: add more enums to items
-		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_LEFT]);
+		GenerateNewSeed(player.InvBody[INVLOC_HAND_LEFT]);
 
 		InitializeItem(player.InvBody[INVLOC_HAND_RIGHT], IDI_WARRSHLD);
-		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_RIGHT]);
+		GenerateNewSeed(player.InvBody[INVLOC_HAND_RIGHT]);
 		InitializeItem(player.SpdList[0], IDI_HEAL);
-		GetPlrHandSeed(&player.SpdList[0]);
+		GenerateNewSeed(player.SpdList[0]);
 
 		InitializeItem(player.SpdList[1], IDI_HEAL);
-		GetPlrHandSeed(&player.SpdList[1]);
+		GenerateNewSeed(player.SpdList[1]);
 		break;
 	}
 
 	InitializeItem(player.HoldItem, IDI_GOLD);
-	GetPlrHandSeed(&player.HoldItem);
+	GenerateNewSeed(player.HoldItem);
 
 	player.HoldItem._ivalue = 100;
 	player.HoldItem._iCurs = ICURS_GOLD_SMALL;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -537,11 +537,6 @@ void CalcPlrBookVals(Player &player)
 	}
 }
 
-void SetPlrHandSeed(Item &item, int iseed)
-{
-	item._iSeed = iseed;
-}
-
 bool GetItemSpace(Point position, int8_t inum)
 {
 	int xx = 0;
@@ -2913,7 +2908,7 @@ void CalcPlrInv(Player &player, bool loadgfx)
 	}
 }
 
-void SetPlrHandItem(Item &item, int itemData)
+void InitializeItem(Item &item, int itemData)
 {
 	auto &pAllItem = AllItemsList[itemData];
 
@@ -3022,79 +3017,79 @@ void CreatePlrItems(int playerId)
 
 	switch (player._pClass) {
 	case HeroClass::Warrior:
-		SetPlrHandItem(player.InvBody[INVLOC_HAND_LEFT], IDI_WARRIOR);
+		InitializeItem(player.InvBody[INVLOC_HAND_LEFT], IDI_WARRIOR);
 		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_LEFT]);
 
-		SetPlrHandItem(player.InvBody[INVLOC_HAND_RIGHT], IDI_WARRSHLD);
+		InitializeItem(player.InvBody[INVLOC_HAND_RIGHT], IDI_WARRSHLD);
 		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_RIGHT]);
 
-		SetPlrHandItem(player.HoldItem, IDI_WARRCLUB);
+		InitializeItem(player.HoldItem, IDI_WARRCLUB);
 		GetPlrHandSeed(&player.HoldItem);
 		AutoPlaceItemInInventory(player, player.HoldItem, true);
 
-		SetPlrHandItem(player.SpdList[0], IDI_HEAL);
+		InitializeItem(player.SpdList[0], IDI_HEAL);
 		GetPlrHandSeed(&player.SpdList[0]);
 
-		SetPlrHandItem(player.SpdList[1], IDI_HEAL);
+		InitializeItem(player.SpdList[1], IDI_HEAL);
 		GetPlrHandSeed(&player.SpdList[1]);
 		break;
 	case HeroClass::Rogue:
-		SetPlrHandItem(player.InvBody[INVLOC_HAND_LEFT], IDI_ROGUE);
+		InitializeItem(player.InvBody[INVLOC_HAND_LEFT], IDI_ROGUE);
 		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_LEFT]);
 
-		SetPlrHandItem(player.SpdList[0], IDI_HEAL);
+		InitializeItem(player.SpdList[0], IDI_HEAL);
 		GetPlrHandSeed(&player.SpdList[0]);
 
-		SetPlrHandItem(player.SpdList[1], IDI_HEAL);
+		InitializeItem(player.SpdList[1], IDI_HEAL);
 		GetPlrHandSeed(&player.SpdList[1]);
 		break;
 	case HeroClass::Sorcerer:
-		SetPlrHandItem(player.InvBody[INVLOC_HAND_LEFT], gbIsHellfire ? IDI_SORCERER : 166);
+		InitializeItem(player.InvBody[INVLOC_HAND_LEFT], gbIsHellfire ? IDI_SORCERER : 166);
 		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_LEFT]);
 
-		SetPlrHandItem(player.SpdList[0], gbIsHellfire ? IDI_HEAL : IDI_MANA);
+		InitializeItem(player.SpdList[0], gbIsHellfire ? IDI_HEAL : IDI_MANA);
 		GetPlrHandSeed(&player.SpdList[0]);
 
-		SetPlrHandItem(player.SpdList[1], gbIsHellfire ? IDI_HEAL : IDI_MANA);
+		InitializeItem(player.SpdList[1], gbIsHellfire ? IDI_HEAL : IDI_MANA);
 		GetPlrHandSeed(&player.SpdList[1]);
 		break;
 
 	case HeroClass::Monk:
-		SetPlrHandItem(player.InvBody[INVLOC_HAND_LEFT], IDI_SHORTSTAFF);
+		InitializeItem(player.InvBody[INVLOC_HAND_LEFT], IDI_SHORTSTAFF);
 		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_LEFT]);
-		SetPlrHandItem(player.SpdList[0], IDI_HEAL);
+		InitializeItem(player.SpdList[0], IDI_HEAL);
 		GetPlrHandSeed(&player.SpdList[0]);
 
-		SetPlrHandItem(player.SpdList[1], IDI_HEAL);
+		InitializeItem(player.SpdList[1], IDI_HEAL);
 		GetPlrHandSeed(&player.SpdList[1]);
 		break;
 	case HeroClass::Bard:
-		SetPlrHandItem(player.InvBody[INVLOC_HAND_LEFT], IDI_BARDSWORD);
+		InitializeItem(player.InvBody[INVLOC_HAND_LEFT], IDI_BARDSWORD);
 		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_LEFT]);
 
-		SetPlrHandItem(player.InvBody[INVLOC_HAND_RIGHT], IDI_BARDDAGGER);
+		InitializeItem(player.InvBody[INVLOC_HAND_RIGHT], IDI_BARDDAGGER);
 		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_RIGHT]);
-		SetPlrHandItem(player.SpdList[0], IDI_HEAL);
+		InitializeItem(player.SpdList[0], IDI_HEAL);
 		GetPlrHandSeed(&player.SpdList[0]);
 
-		SetPlrHandItem(player.SpdList[1], IDI_HEAL);
+		InitializeItem(player.SpdList[1], IDI_HEAL);
 		GetPlrHandSeed(&player.SpdList[1]);
 		break;
 	case HeroClass::Barbarian:
-		SetPlrHandItem(player.InvBody[INVLOC_HAND_LEFT], 139); // TODO: add more enums to items
+		InitializeItem(player.InvBody[INVLOC_HAND_LEFT], 139); // TODO: add more enums to items
 		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_LEFT]);
 
-		SetPlrHandItem(player.InvBody[INVLOC_HAND_RIGHT], IDI_WARRSHLD);
+		InitializeItem(player.InvBody[INVLOC_HAND_RIGHT], IDI_WARRSHLD);
 		GetPlrHandSeed(&player.InvBody[INVLOC_HAND_RIGHT]);
-		SetPlrHandItem(player.SpdList[0], IDI_HEAL);
+		InitializeItem(player.SpdList[0], IDI_HEAL);
 		GetPlrHandSeed(&player.SpdList[0]);
 
-		SetPlrHandItem(player.SpdList[1], IDI_HEAL);
+		InitializeItem(player.SpdList[1], IDI_HEAL);
 		GetPlrHandSeed(&player.SpdList[1]);
 		break;
 	}
 
-	SetPlrHandItem(player.HoldItem, IDI_GOLD);
+	InitializeItem(player.HoldItem, IDI_GOLD);
 	GetPlrHandSeed(&player.HoldItem);
 
 	player.HoldItem._ivalue = 100;
@@ -3364,7 +3359,7 @@ void RecreateItem(Item &item, int idx, uint16_t icreateinfo, int iseed, int ival
 	gbIsHellfire = isHellfire;
 
 	if (idx == IDI_GOLD) {
-		SetPlrHandItem(item, IDI_GOLD);
+		InitializeItem(item, IDI_GOLD);
 		item._iSeed = iseed;
 		item._iCreateInfo = icreateinfo;
 		item._ivalue = ivalue;
@@ -3374,8 +3369,8 @@ void RecreateItem(Item &item, int idx, uint16_t icreateinfo, int iseed, int ival
 	}
 
 	if (icreateinfo == 0) {
-		SetPlrHandItem(item, idx);
-		SetPlrHandSeed(item, iseed);
+		InitializeItem(item, idx);
+		item._iSeed = iseed;
 		gbIsHellfire = tmpIsHellfire;
 		return;
 	}
@@ -3412,7 +3407,7 @@ void RecreateItem(Item &item, int idx, uint16_t icreateinfo, int iseed, int ival
 
 void RecreateEar(Item &item, uint16_t ic, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, int ibuff)
 {
-	SetPlrHandItem(item, IDI_EAR);
+	InitializeItem(item, IDI_EAR);
 	tempstr[0] = static_cast<char>((ic >> 8) & 0x7F);
 	tempstr[1] = static_cast<char>(ic & 0x7F);
 	tempstr[2] = static_cast<char>((iseed >> 24) & 0x7F);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3482,7 +3482,7 @@ void CornerstoneLoad(Point position)
 
 	UnPackItem(pkSItem, item, (pkSItem.dwBuff & CF_HELLFIRE) != 0);
 	item.position = position;
-	RespawnItem(&item, false);
+	RespawnItem(item, false);
 	CornerStone.item = item;
 }
 
@@ -3570,20 +3570,20 @@ void SpawnTheodore(Point position)
 	SpawnRewardItem(IDI_THEODORE, position);
 }
 
-void RespawnItem(Item *item, bool flipFlag)
+void RespawnItem(Item &item, bool flipFlag)
 {
-	int it = ItemCAnimTbl[item->_iCurs];
-	item->SetNewAnimation(flipFlag);
-	item->_iRequest = false;
+	int it = ItemCAnimTbl[item._iCurs];
+	item.SetNewAnimation(flipFlag);
+	item._iRequest = false;
 
-	if (item->_iCurs == ICURS_MAGIC_ROCK) {
-		item->_iSelFlag = 1;
-		PlaySfxLoc(ItemDropSnds[it], item->position);
+	if (item._iCurs == ICURS_MAGIC_ROCK) {
+		item._iSelFlag = 1;
+		PlaySfxLoc(ItemDropSnds[it], item.position);
 	}
-	if (item->_iCurs == ICURS_TAVERN_SIGN)
-		item->_iSelFlag = 1;
-	if (item->_iCurs == ICURS_ANVIL_OF_FURY)
-		item->_iSelFlag = 1;
+	if (item._iCurs == ICURS_TAVERN_SIGN)
+		item._iSelFlag = 1;
+	if (item._iCurs == ICURS_ANVIL_OF_FURY)
+		item._iSelFlag = 1;
 }
 
 void DeleteItem(int i)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -40,10 +40,10 @@
 
 namespace devilution {
 
-/** Contains the items on ground in the current game. */
 Item Items[MAXITEMS + 1];
 uint8_t ActiveItems[MAXITEMS];
 uint8_t ActiveItemCount;
+int8_t dItem[MAXDUNX][MAXDUNY];
 bool ShowUniqueItemInfoBox;
 CornerStoneStruct CornerStone;
 bool UniqueItemFlags[128];
@@ -2501,6 +2501,7 @@ void InitItems()
 	GetItemAttrs(golditem, IDI_GOLD, 1);
 	golditem._iStatFlag = true;
 	ActiveItemCount = 0;
+	memset(dItem, 0, sizeof(dItem));
 
 	for (auto &item : Items) {
 		item._itype = ItemType::None;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3089,14 +3089,15 @@ void CreatePlrItems(int playerId)
 		break;
 	}
 
-	InitializeItem(player.HoldItem, IDI_GOLD);
-	GenerateNewSeed(player.HoldItem);
-
-	player.HoldItem._ivalue = 100;
-	player.HoldItem._iCurs = ICURS_GOLD_SMALL;
-	player._pGold = player.HoldItem._ivalue;
-	player.InvList[player._pNumInv++] = player.HoldItem;
+	auto &startingGold = player.InvList[player._pNumInv];
+	player._pNumInv++;
 	player.InvGrid[30] = player._pNumInv;
+
+	InitializeItem(startingGold, IDI_GOLD);
+	GenerateNewSeed(startingGold);
+	startingGold._ivalue = 100;
+	startingGold._iCurs = ICURS_GOLD_SMALL;
+	player._pGold = startingGold._ivalue;
 
 	CalcPlrItemVals(player, false);
 }

--- a/Source/items.h
+++ b/Source/items.h
@@ -430,7 +430,7 @@ void InitItemGFX();
 void InitItems();
 void CalcPlrItemVals(Player &player, bool Loadgfx);
 void CalcPlrInv(Player &player, bool Loadgfx);
-void SetPlrHandItem(Item &item, int itemData);
+void InitializeItem(Item &item, int itemData);
 void GetPlrHandSeed(Item *h);
 
 /**

--- a/Source/items.h
+++ b/Source/items.h
@@ -431,7 +431,7 @@ void InitItems();
 void CalcPlrItemVals(Player &player, bool Loadgfx);
 void CalcPlrInv(Player &player, bool Loadgfx);
 void InitializeItem(Item &item, int itemData);
-void GetPlrHandSeed(Item *h);
+void GenerateNewSeed(Item &h);
 
 /**
  * @brief Set a new unique seed value on the given item

--- a/Source/items.h
+++ b/Source/items.h
@@ -465,7 +465,7 @@ void SpawnRewardItem(int itemid, Point position);
 void SpawnMapOfDoom(Point position);
 void SpawnRuneBomb(Point position);
 void SpawnTheodore(Point position);
-void RespawnItem(Item *item, bool FlipFlag);
+void RespawnItem(Item &item, bool FlipFlag);
 void DeleteItem(int i);
 void ProcessItems();
 void FreeItemGFX();

--- a/Source/items.h
+++ b/Source/items.h
@@ -413,9 +413,12 @@ struct CornerStoneStruct {
 
 struct Player;
 
+/** Contains the items on ground in the current game. */
 extern Item Items[MAXITEMS + 1];
 extern uint8_t ActiveItems[MAXITEMS];
 extern uint8_t ActiveItemCount;
+/** Contains the location of dropped items. */
+extern int8_t dItem[MAXDUNX][MAXDUNY];
 extern bool ShowUniqueItemInfoBox;
 extern CornerStoneStruct CornerStone;
 extern bool UniqueItemFlags[128];

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1421,7 +1421,7 @@ void AddStealPotions(Missile &missile, const AddMissileParameter & /*parameter*/
 				}
 				if (ii != -1) {
 					InitializeItem(player.HoldItem, ii);
-					GetPlrHandSeed(&player.HoldItem);
+					GenerateNewSeed(player.HoldItem);
 					player.HoldItem._iStatFlag = true;
 					player.SpdList[si] = player.HoldItem;
 				}

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1420,7 +1420,7 @@ void AddStealPotions(Missile &missile, const AddMissileParameter & /*parameter*/
 					}
 				}
 				if (ii != -1) {
-					SetPlrHandItem(player.HoldItem, ii);
+					InitializeItem(player.HoldItem, ii);
 					GetPlrHandSeed(&player.HoldItem);
 					player.HoldItem._iStatFlag = true;
 					player.SpdList[si] = player.HoldItem;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2292,7 +2292,7 @@ void DeltaLoadLevel()
 			int y = sgLevels[currlevel].item[i].y;
 			item.position = GetItemPosition({ x, y });
 			dItem[item.position.x][item.position.y] = ii + 1;
-			RespawnItem(&Items[ii], false);
+			RespawnItem(Items[ii], false);
 		}
 	}
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2954,14 +2954,14 @@ bool OperateShrineEldritch(int pnum)
 			if (item._iMiscId == IMISC_HEAL
 			    || item._iMiscId == IMISC_MANA) {
 				InitializeItem(player.HoldItem, ItemMiscIdIdx(IMISC_REJUV));
-				GetPlrHandSeed(&player.HoldItem);
+				GenerateNewSeed(player.HoldItem);
 				player.HoldItem._iStatFlag = true;
 				item = player.HoldItem;
 			}
 			if (item._iMiscId == IMISC_FULLHEAL
 			    || item._iMiscId == IMISC_FULLMANA) {
 				InitializeItem(player.HoldItem, ItemMiscIdIdx(IMISC_FULLREJUV));
-				GetPlrHandSeed(&player.HoldItem);
+				GenerateNewSeed(player.HoldItem);
 				player.HoldItem._iStatFlag = true;
 				item = player.HoldItem;
 			}

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2953,14 +2953,14 @@ bool OperateShrineEldritch(int pnum)
 		if (item._itype == ItemType::Misc) {
 			if (item._iMiscId == IMISC_HEAL
 			    || item._iMiscId == IMISC_MANA) {
-				SetPlrHandItem(player.HoldItem, ItemMiscIdIdx(IMISC_REJUV));
+				InitializeItem(player.HoldItem, ItemMiscIdIdx(IMISC_REJUV));
 				GetPlrHandSeed(&player.HoldItem);
 				player.HoldItem._iStatFlag = true;
 				item = player.HoldItem;
 			}
 			if (item._iMiscId == IMISC_FULLHEAL
 			    || item._iMiscId == IMISC_FULLMANA) {
-				SetPlrHandItem(player.HoldItem, ItemMiscIdIdx(IMISC_FULLREJUV));
+				InitializeItem(player.HoldItem, ItemMiscIdIdx(IMISC_FULLREJUV));
 				GetPlrHandSeed(&player.HoldItem);
 				player.HoldItem._iStatFlag = true;
 				item = player.HoldItem;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -549,7 +549,7 @@ void RespawnDeadItem(Item *itm, Point target)
 
 	Items[ii] = *itm;
 	Items[ii].position = target;
-	RespawnItem(&Items[ii], true);
+	RespawnItem(Items[ii], true);
 
 	itm->_itype = ItemType::None;
 }

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -594,7 +594,7 @@ int DropGold(int pnum, int amount, bool skipFullStacks)
 
 		if (amount < item._ivalue) {
 			item._ivalue -= amount;
-			SetPlrHandItem(player.HoldItem, IDI_GOLD);
+			InitializeItem(player.HoldItem, IDI_GOLD);
 			SetGoldSeed(player, player.HoldItem);
 			SetPlrHandGoldCurs(player.HoldItem);
 			player.HoldItem._ivalue = amount;
@@ -604,7 +604,7 @@ int DropGold(int pnum, int amount, bool skipFullStacks)
 
 		amount -= item._ivalue;
 		player.RemoveInvItem(i);
-		SetPlrHandItem(player.HoldItem, IDI_GOLD);
+		InitializeItem(player.HoldItem, IDI_GOLD);
 		SetGoldSeed(player, player.HoldItem);
 		SetPlrHandGoldCurs(player.HoldItem);
 		player.HoldItem._ivalue = item._ivalue;
@@ -3165,7 +3165,7 @@ StartPlayerKill(int pnum, int earflag)
 				if (earflag != -1) {
 					if (earflag != 0) {
 						Item ear;
-						SetPlrHandItem(ear, IDI_EAR);
+						InitializeItem(ear, IDI_EAR);
 						strcpy(ear._iName, fmt::format(_("Ear of {:s}"), player._pName).c_str());
 						switch (player._pClass) {
 						case HeroClass::Sorcerer:
@@ -3214,7 +3214,7 @@ void StripTopGold(Player &player)
 			if (item._ivalue > MaxGold) {
 				int val = item._ivalue - MaxGold;
 				item._ivalue = MaxGold;
-				SetPlrHandItem(player.HoldItem, 0);
+				InitializeItem(player.HoldItem, 0);
 				SetGoldSeed(player, player.HoldItem);
 				player.HoldItem._ivalue = val;
 				SetPlrHandGoldCurs(player.HoldItem);


### PR DESCRIPTION
This is part of the ongoing cleanup for #2586. #2932 has effectively got `DeleteItem` to the point where it can be replaced by an STL container's `erase` method, the aim with this branch is to get `AllocateItem` ready to be replaced with a `push_back` equivalent.

To make it easier to reason about how items are spawned and dropped on the ground I've started working through the code responsible for creating items in general. This set of commits is mainly cleanups for items.cpp, using `const Item &` for functions which do not modify the argument and renaming some initialisation functions to match their purpose better.