### PR TITLE
[Virtual Gamepad] Fix empty potion button rendering

### DIFF
--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -1,6 +1,7 @@
 #include "control.h"
 #include "controls/touch/renderers.h"
 #include "cursor.h"
+#include "diablo.h"
 #include "doom.h"
 #include "engine.h"
 #include "engine/render/cel_render.hpp"
@@ -127,6 +128,9 @@ void LoadPotionArt(Art *potionArt, SDL_Renderer *renderer)
 
 void RenderVirtualGamepad(SDL_Renderer *renderer)
 {
+	if (!gbRunGame)
+		return;
+
 	RenderFunction renderFunction = [&](Art &art, SDL_Rect *src, SDL_Rect *dst) {
 		if (art.texture == nullptr)
 			return;
@@ -140,6 +144,9 @@ void RenderVirtualGamepad(SDL_Renderer *renderer)
 
 void RenderVirtualGamepad(SDL_Surface *surface)
 {
+	if (!gbRunGame)
+		return;
+
 	RenderFunction renderFunction = [&](Art &art, SDL_Rect *src, SDL_Rect *dst) {
 		if (art.surface == nullptr)
 			return;

--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -253,8 +253,11 @@ void VirtualPadButtonRenderer::Render(RenderFunction renderFunction, Art &button
 
 void PotionButtonRenderer::RenderPotion(RenderFunction renderFunction, Art &potionArt)
 {
-	VirtualGamepadPotionType potionType = GetPotionType();
-	int frame = potionType;
+	std::optional<VirtualGamepadPotionType> potionType = GetPotionType();
+	if (potionType == std::nullopt)
+		return;
+
+	int frame = *potionType;
 	int offset = potionArt.h() * frame;
 
 	auto center = virtualPadButton->area.position;
@@ -271,7 +274,7 @@ void PotionButtonRenderer::RenderPotion(RenderFunction renderFunction, Art &poti
 	renderFunction(potionArt, &src, &dst);
 }
 
-VirtualGamepadPotionType PotionButtonRenderer::GetPotionType()
+std::optional<VirtualGamepadPotionType> PotionButtonRenderer::GetPotionType()
 {
 	for (int i = 0; i < MAXBELTITEMS; i++) {
 		auto &myPlayer = Players[MyPlayerId];
@@ -302,6 +305,8 @@ VirtualGamepadPotionType PotionButtonRenderer::GetPotionType()
 		if (id == IMISC_FULLREJUV)
 			return GAMEPAD_FULL_REJUVENATION;
 	}
+
+	return std::nullopt;
 }
 
 VirtualGamepadButtonType PrimaryActionButtonRenderer::GetButtonType()

--- a/Source/controls/touch/renderers.h
+++ b/Source/controls/touch/renderers.h
@@ -135,7 +135,7 @@ private:
 	belt_item_type potionType;
 
 	VirtualGamepadButtonType GetButtonType();
-	VirtualGamepadPotionType GetPotionType();
+	std::optional<VirtualGamepadPotionType> GetPotionType();
 };
 
 class VirtualGamepadRenderer {


### PR DESCRIPTION
It seems MSVC was letting me be a bit sloppy.

* Rendering logic for the virtual gamepad was running even when not in a game
* `PotionButtonRenderer::GetPotionType()` had no return value when there was no relevant potion or scroll in the belt