### PR TITLE
Fix: Holding mouse when shift is held shouldn't lock to a target & Trigger Text is incorrectly shown

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1441,7 +1441,7 @@ void PerformSpellAction()
 	}
 
 	UpdateSpellTarget();
-	CheckPlrSpell();
+	CheckPlrSpell(false);
 }
 
 void CtrlUseInvItem()

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -330,7 +330,7 @@ void CheckCursMove()
 	my = clamp(my, 0, MAXDUNY - 1);
 
 	// While holding the button down we should retain target (but potentially lose it if it dies, goes out of view, etc)
-	if (sgbMouseDown != CLICK_NONE && pcursinvitem == -1) {
+	if (sgbMouseDown != CLICK_NONE && pcursinvitem == -1 && IsNoneOf(LastMouseButtonAction, MouseActionType::Attack)) {
 		if (pcursmonst != -1) {
 			if (Monsters[pcursmonst]._mDelFlag || Monsters[pcursmonst]._mhitpoints >> 6 <= 0
 			    || ((dFlags[Monsters[pcursmonst].position.tile.x][Monsters[pcursmonst].position.tile.y] & BFLAG_VISIBLE) == 0))

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -330,7 +330,7 @@ void CheckCursMove()
 	my = clamp(my, 0, MAXDUNY - 1);
 
 	// While holding the button down we should retain target (but potentially lose it if it dies, goes out of view, etc)
-	if (sgbMouseDown != CLICK_NONE && pcursinvitem == -1 && IsNoneOf(LastMouseButtonAction, MouseActionType::Attack, MouseActionType::Spell)) {
+	if (sgbMouseDown != CLICK_NONE && IsNoneOf(LastMouseButtonAction, MouseActionType::None, MouseActionType::Attack, MouseActionType::Spell)) {
 		if (pcursmonst != -1) {
 			if (Monsters[pcursmonst]._mDelFlag || Monsters[pcursmonst]._mhitpoints >> 6 <= 0
 			    || ((dFlags[Monsters[pcursmonst].position.tile.x][Monsters[pcursmonst].position.tile.y] & BFLAG_VISIBLE) == 0))

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -330,7 +330,7 @@ void CheckCursMove()
 	my = clamp(my, 0, MAXDUNY - 1);
 
 	// While holding the button down we should retain target (but potentially lose it if it dies, goes out of view, etc)
-	if (sgbMouseDown != CLICK_NONE && pcursinvitem == -1 && IsNoneOf(LastMouseButtonAction, MouseActionType::Attack)) {
+	if (sgbMouseDown != CLICK_NONE && pcursinvitem == -1 && IsNoneOf(LastMouseButtonAction, MouseActionType::Attack, MouseActionType::Spell)) {
 		if (pcursmonst != -1) {
 			if (Monsters[pcursmonst]._mDelFlag || Monsters[pcursmonst]._mhitpoints >> 6 <= 0
 			    || ((dFlags[Monsters[pcursmonst].position.tile.x][Monsters[pcursmonst].position.tile.y] & BFLAG_VISIBLE) == 0))

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -359,7 +359,7 @@ void LeftMouseUp(int wParam)
 		ReleaseStoreBtn();
 }
 
-void RightMouseDown()
+void RightMouseDown(bool isShiftHeld)
 {
 	LastMouseButtonAction = MouseActionType::None;
 
@@ -382,7 +382,7 @@ void RightMouseDown()
 	    && (pcursinvitem == -1 || !UseInvItem(MyPlayerId, pcursinvitem))) {
 		if (pcurs == CURSOR_HAND) {
 			if (pcursinvitem == -1 || !UseInvItem(MyPlayerId, pcursinvitem))
-				CheckPlrSpell();
+				CheckPlrSpell(isShiftHeld);
 		} else if (pcurs > CURSOR_HAND && pcurs < CURSOR_FIRSTITEM) {
 			NewCursor(CURSOR_HAND);
 		}
@@ -631,7 +631,7 @@ void GameEventHandler(uint32_t uMsg, int32_t wParam, int32_t lParam)
 		GetMousePos(lParam);
 		if (sgbMouseDown == CLICK_NONE) {
 			sgbMouseDown = CLICK_RIGHT;
-			RightMouseDown();
+			RightMouseDown((wParam & DVL_MK_SHIFT) != 0);
 		}
 		return;
 	case DVL_WM_RBUTTONUP:

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3433,7 +3433,7 @@ void CalcPlrStaff(Player &player)
 	}
 }
 
-void CheckPlrSpell()
+void CheckPlrSpell(bool isShiftHeld)
 {
 	bool addflag = false;
 	int sl;
@@ -3513,11 +3513,11 @@ void CheckPlrSpell()
 		Direction sd = GetDirection(myPlayer.position.tile, cursPosition);
 		sl = GetSpellLevel(MyPlayerId, myPlayer._pRSpell);
 		NetSendCmdLocParam4(true, CMD_SPELLXYD, cursPosition, myPlayer._pRSpell, myPlayer._pRSplType, static_cast<uint16_t>(sd), sl);
-	} else if (pcursmonst != -1) {
+	} else if (pcursmonst != -1 && !isShiftHeld) {
 		LastMouseButtonAction = MouseActionType::SpellMonsterTarget;
 		sl = GetSpellLevel(MyPlayerId, myPlayer._pRSpell);
 		NetSendCmdParam4(true, CMD_SPELLID, pcursmonst, myPlayer._pRSpell, myPlayer._pRSplType, sl);
-	} else if (pcursplr != -1) {
+	} else if (pcursplr != -1 && !isShiftHeld) {
 		LastMouseButtonAction = MouseActionType::SpellPlayerTarget;
 		sl = GetSpellLevel(MyPlayerId, myPlayer._pRSpell);
 		NetSendCmdParam4(true, CMD_SPELLPID, pcursplr, myPlayer._pRSpell, myPlayer._pRSplType, sl);

--- a/Source/player.h
+++ b/Source/player.h
@@ -631,7 +631,7 @@ void ClrPlrPath(Player &player);
 bool PosOkPlayer(const Player &player, Point position);
 void MakePlrPath(Player &player, Point targetPosition, bool endspace);
 void CalcPlrStaff(Player &player);
-void CheckPlrSpell();
+void CheckPlrSpell(bool isShiftHeld);
 void SyncPlrAnim(int pnum);
 void SyncInitPlrPos(int pnum);
 void SyncInitPlr(int pnum);

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -68,15 +68,15 @@ void RepeatMouseAction()
 			NetSendCmdParam1(true, rangedAttack ? CMD_RATTACKPID : CMD_ATTACKPID, pcursplr);
 		break;
 	case MouseActionType::Spell:
-		CheckPlrSpell();
+		CheckPlrSpell(true);
 		break;
 	case MouseActionType::SpellMonsterTarget:
 		if (pcursmonst != -1)
-			CheckPlrSpell();
+			CheckPlrSpell(false);
 		break;
 	case MouseActionType::SpellPlayerTarget:
 		if (pcursplr != -1 && !gbFriendlyMode)
-			CheckPlrSpell();
+			CheckPlrSpell(false);
 		break;
 	case MouseActionType::OperateObject:
 		if (pcursobj != -1) {


### PR DESCRIPTION
Fixes #2695
Fixes #2859

Notes:

- When the mouse is held cursor position only get updated if we previous didn't select an monster/object/item/... This was implemented to track a target. But this target tracking should activate if shift is pressed. So adjust the logic to only track if we want to.
- Shift+Spell needed more adjustment cause `CheckPlrSpell` sets `LastMouseButtonAction`. `CheckPlrSpell` is also used in initial mouse click (`RightMouseDown`) and for repeating mouse actions (`RepeatMouseAction`). Cause of this we must ensure that it regards shift/doesn't override `LastMouseButtonAction` when we are in `RepeatMouseAction`.
- The entire logic of this tracking target should only be performed if we have we want to track any target (is not `MouseActionType::None`). This fixes the inventory issue, where `CheckTrigForce` was called when mousebutton where held.
- Please test this. Tracking logic is ... special. 😉 

@FluffyQuack @AJenbo It would be nice if you both could take a look. 🙂 