### PR TITLE
Fix melee friendly fire when sgOptions.Gameplay.bFriendlyFire is set

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1210,7 +1210,7 @@ bool DoAttack(int pnum)
 				m = -(dMonster[dx][dy] + 1);
 			}
 			didhit = PlrHitMonst(pnum, m);
-		} else if (dPlayer[dx][dy] != 0 && (!gbFriendlyMode || sgGameInitInfo.bFriendlyFire != 0)) {
+		} else if (dPlayer[dx][dy] != 0 && !gbFriendlyMode) {
 			BYTE p = dPlayer[dx][dy];
 			if (dPlayer[dx][dy] > 0) {
 				p = dPlayer[dx][dy] - 1;


### PR DESCRIPTION
Fixes #2772

Notes:

- `gbFriendlyMode` toggles friendly mode (the UI button)
- `sgGameInitInfo.bFriendlyFire` added the possibility to also disable missile friendly fire when `gbFriendlyMode` is active.
- This was introduced with #1104 but the check was also (incorrectly) applied to melee attacks. For melee we don't need to check `sgGameInitInfo.bFriendlyFire` cause it's not a missile.