### PR TITLE
Fix: Don't track hidden monseters

### DIFF
--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -332,9 +332,12 @@ void CheckCursMove()
 	// While holding the button down we should retain target (but potentially lose it if it dies, goes out of view, etc)
 	if (sgbMouseDown != CLICK_NONE && IsNoneOf(LastMouseButtonAction, MouseActionType::None, MouseActionType::Attack, MouseActionType::Spell)) {
 		if (pcursmonst != -1) {
-			if (Monsters[pcursmonst]._mDelFlag || Monsters[pcursmonst]._mhitpoints >> 6 <= 0
-			    || ((dFlags[Monsters[pcursmonst].position.tile.x][Monsters[pcursmonst].position.tile.y] & BFLAG_VISIBLE) == 0))
+			const auto &monster = Monsters[pcursmonst];
+			if (monster._mDelFlag || monster._mhitpoints >> 6 <= 0
+			    || (monster._mFlags & MFLAG_HIDDEN) != 0
+			    || ((dFlags[monster.position.tile.x][monster.position.tile.y] & BFLAG_VISIBLE) == 0)) {
 				pcursmonst = -1;
+			}
 		} else if (pcursobj != -1) {
 			if (Objects[pcursobj]._oSelFlag < 1)
 				pcursobj = -1;

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -335,7 +335,7 @@ void CheckCursMove()
 			const auto &monster = Monsters[pcursmonst];
 			if (monster._mDelFlag || monster._mhitpoints >> 6 <= 0
 			    || (monster._mFlags & MFLAG_HIDDEN) != 0
-			    || ((dFlags[monster.position.tile.x][monster.position.tile.y] & BFLAG_VISIBLE) == 0)) {
+			    || ((dFlags[monster.position.tile.x][monster.position.tile.y] & BFLAG_LIT) == 0)) {
 				pcursmonst = -1;
 			}
 		} else if (pcursobj != -1) {
@@ -345,7 +345,7 @@ void CheckCursMove()
 			auto &targetPlayer = Players[pcursplr];
 			if (targetPlayer._pmode == PM_DEATH || targetPlayer._pmode == PM_QUIT || !targetPlayer.plractive
 			    || currlevel != targetPlayer.plrlevel || targetPlayer._pHitPoints >> 6 <= 0
-			    || ((dFlags[targetPlayer.position.tile.x][targetPlayer.position.tile.y] & BFLAG_VISIBLE) == 0))
+			    || ((dFlags[targetPlayer.position.tile.x][targetPlayer.position.tile.y] & BFLAG_LIT) == 0))
 				pcursplr = -1;
 		}
 


### PR DESCRIPTION
Fixes #2962

Also noticed that `BFLAG_VISIBLE` was used for checking a monster is visible.
But in [cursor](https://github.com/diasurgical/devilutionX/blob/2c4c277c87801ccbdeabcddafcd484ee7ac810f9/Source/cursor.cpp#L497) and [drawing](https://github.com/diasurgical/devilutionX/blob/2c4c277c87801ccbdeabcddafcd484ee7ac810f9/Source/scrollrt.cpp#L753) we use `BFLAG_LIT`.