### PR TITLE
Validate CMD_SYNCDATA messages

### DIFF
--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -315,6 +315,11 @@ void FindTransparencyValues(int i, int j, int x, int y, int d, uint8_t floorID)
 
 } // namespace
 
+bool InDungeonBounds(Point position)
+{
+	return position.x >= 0 && position.x < MAXDUNX && position.y >= 0 && position.y < MAXDUNY;
+}
+
 void FillSolidBlockTbls()
 {
 	size_t tileCount;

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -222,6 +222,7 @@ extern char dSpecial[MAXDUNX][MAXDUNY];
 extern int themeCount;
 extern THEME_LOC themeLoc[MAXTHEMES];
 
+bool InDungeonBounds(Point position);
 void FillSolidBlockTbls();
 void SetDungeonMicros();
 void DRLG_InitTrans();

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -81,11 +81,6 @@ bool CheckBlock(Point from, Point to)
 	return false;
 }
 
-inline bool InDungeonBounds(Point position)
-{
-	return position.x > 0 && position.x < MAXDUNX && position.y > 0 && position.y < MAXDUNY;
-}
-
 Monster *FindClosest(Point source, int rad)
 {
 	if (rad > 19)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4960,17 +4960,17 @@ int encode_enemy(Monster &monster)
 	return monster._menemy;
 }
 
-void decode_enemy(Monster &monster, int enemy)
+void decode_enemy(Monster &monster, int enemyId)
 {
-	if (enemy < MAX_PLRS) {
+	if (enemyId < MAX_PLRS) {
 		monster._mFlags &= ~MFLAG_TARGETS_MONSTER;
-		monster._menemy = enemy;
-		monster.enemyPosition = Players[enemy].position.future;
+		monster._menemy = enemyId;
+		monster.enemyPosition = Players[enemyId].position.future;
 	} else {
 		monster._mFlags |= MFLAG_TARGETS_MONSTER;
-		enemy -= MAX_PLRS;
-		monster._menemy = enemy;
-		monster.enemyPosition = Monsters[enemy].position.future;
+		enemyId -= MAX_PLRS;
+		monster._menemy = enemyId;
+		monster.enemyPosition = Monsters[enemyId].position.future;
 	}
 }
 

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -315,6 +315,6 @@ void SpawnGolem(int i, Point position, Missile &missile);
 bool CanTalkToMonst(const Monster &monster);
 bool CheckMonsterHit(Monster &monster, bool *ret);
 int encode_enemy(Monster &monster);
-void decode_enemy(Monster &monster, int enemy);
+void decode_enemy(Monster &monster, int enemyId);
 
 } // namespace devilution

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -77,7 +77,7 @@ void FreePackets()
 
 void PrePacket()
 {
-	uint8_t playerId = -1;
+	uint8_t playerId = std::numeric_limits<uint8_t>::max();
 	for (TMegaPkt &pkt : MegaPktList) {
 		byte *data = pkt.data;
 		size_t spaceLeft = sizeof(pkt.data);
@@ -100,7 +100,17 @@ void PrePacket()
 				continue;
 			}
 
-			uint32_t pktSize = ParseCmd(playerId, (TCmd *)data);
+			if (playerId >= MAX_PLRS) {
+				Log("Missing source of network message");
+				return;
+			}
+
+			uint32_t size = ParseCmd(playerId, (TCmd *)data);
+			if (size == 0) {
+				Log("Discarding bad network message");
+				return;
+			}
+			uint32_t pktSize = size;
 			data += pktSize;
 			spaceLeft -= pktSize;
 		}
@@ -602,11 +612,6 @@ void NetSendCmdExtra(TCmdGItem *p)
 	cmd.dwTime = 0;
 	cmd.bCmd = CMD_ITEMEXTRA;
 	NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
-}
-
-DWORD OnSyncData(TCmd *pCmd, int pnum)
-{
-	return sync_update(pnum, (const byte *)pCmd);
 }
 
 DWORD OnWalk(TCmd *pCmd, Player &player)
@@ -1913,23 +1918,22 @@ void delta_monster_hp(int mi, int hp, BYTE bLevel)
 		pD->_mhitpoints = hp;
 }
 
-void delta_sync_monster(const TSyncMonster *pSync, BYTE bLevel)
+void delta_sync_monster(const TSyncMonster &monsterSync, uint8_t level)
 {
 	if (!gbIsMultiplayer)
 		return;
 
-	assert(pSync != nullptr);
-	assert(bLevel < NUMLEVELS);
+	assert(level < NUMLEVELS);
 	sgbDeltaChanged = true;
 
-	DMonsterStr *pD = &sgLevels[bLevel].monster[pSync->_mndx];
-	if (pD->_mhitpoints == 0)
+	DMonsterStr &monster = sgLevels[level].monster[monsterSync._mndx];
+	if (monster._mhitpoints == 0)
 		return;
 
-	pD->_mx = pSync->_mx;
-	pD->_my = pSync->_my;
-	pD->_mactive = UINT8_MAX;
-	pD->_menemy = pSync->_menemy;
+	monster._mx = monsterSync._mx;
+	monster._my = monsterSync._my;
+	monster._mactive = UINT8_MAX;
+	monster._menemy = monsterSync._menemy;
 }
 
 bool delta_portal_inited(int i)
@@ -2537,7 +2541,7 @@ void delta_close_portal(int pnum)
 	sgbDeltaChanged = true;
 }
 
-DWORD ParseCmd(int pnum, TCmd *pCmd)
+uint32_t ParseCmd(int pnum, TCmd *pCmd)
 {
 	sbLastCmd = pCmd->bCmd;
 	if (sgwPackPlrOffsetTbl[pnum] != 0 && sbLastCmd != CMD_ACK_PLRINFO && sbLastCmd != CMD_SEND_PLRINFO)

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -431,7 +431,7 @@ void DeltaExportData(int pnum);
 void delta_init();
 void delta_kill_monster(int mi, Point position, BYTE bLevel);
 void delta_monster_hp(int mi, int hp, BYTE bLevel);
-void delta_sync_monster(const TSyncMonster *pSync, BYTE bLevel);
+void delta_sync_monster(const TSyncMonster &monsterSync, uint8_t level);
 bool delta_portal_inited(int i);
 bool delta_quest_inited(int i);
 void DeltaAddItem(int ii);

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -33,20 +33,20 @@ void SyncOneMonster()
 	}
 }
 
-void SyncMonsterPos(TSyncMonster *p, int ndx)
+void SyncMonsterPos(TSyncMonster &monsterSync, int ndx)
 {
 	auto &monster = Monsters[ndx];
-	p->_mndx = ndx;
-	p->_mx = monster.position.tile.x;
-	p->_my = monster.position.tile.y;
-	p->_menemy = encode_enemy(monster);
-	p->_mdelta = sgnMonsterPriority[ndx] > 255 ? 255 : sgnMonsterPriority[ndx];
+	monsterSync._mndx = ndx;
+	monsterSync._mx = monster.position.tile.x;
+	monsterSync._my = monster.position.tile.y;
+	monsterSync._menemy = encode_enemy(monster);
+	monsterSync._mdelta = sgnMonsterPriority[ndx] > 255 ? 255 : sgnMonsterPriority[ndx];
 
 	sgnMonsterPriority[ndx] = 0xFFFF;
 	sgwLRU[ndx] = monster._msquelch == 0 ? 0xFFFF : 0xFFFE;
 }
 
-bool SyncMonsterActive(TSyncMonster *p)
+bool SyncMonsterActive(TSyncMonster &monsterSync)
 {
 	int ndx = -1;
 	uint32_t lru = 0xFFFFFFFF;
@@ -63,11 +63,11 @@ bool SyncMonsterActive(TSyncMonster *p)
 		return false;
 	}
 
-	SyncMonsterPos(p, ndx);
+	SyncMonsterPos(monsterSync, ndx);
 	return true;
 }
 
-bool SyncMonsterActive2(TSyncMonster *p)
+bool SyncMonsterActive2(TSyncMonster &monsterSync)
 {
 	int ndx = -1;
 	uint32_t lru = 0xFFFE;
@@ -88,7 +88,7 @@ bool SyncMonsterActive2(TSyncMonster *p)
 		return false;
 	}
 
-	SyncMonsterPos(p, ndx);
+	SyncMonsterPos(monsterSync, ndx);
 	return true;
 }
 
@@ -146,57 +146,102 @@ void SyncPlrInv(TSyncHeader *pHdr)
 	}
 }
 
-void SyncMonster(int pnum, const TSyncMonster *p)
+void SyncMonster(int pnum, const TSyncMonster &monsterSync)
 {
-	int ndx = p->_mndx;
-
-	auto &monster = Monsters[ndx];
-
+	const int monsterId = monsterSync._mndx;
+	Monster &monster = Monsters[monsterId];
 	if (monster._mhitpoints <= 0) {
 		return;
 	}
+
+	const Point position { monsterSync._mx, monsterSync._my };
+	const int enemyId = monsterSync._menemy;
 
 	uint32_t delta = Players[MyPlayerId].position.tile.ManhattanDistance(monster.position.tile);
 	if (delta > 255) {
 		delta = 255;
 	}
 
-	if (delta < p->_mdelta || (delta == p->_mdelta && pnum > MyPlayerId)) {
+	if (delta < monsterSync._mdelta || (delta == monsterSync._mdelta && pnum > MyPlayerId)) {
 		return;
 	}
-	if (monster.position.future.x == p->_mx && monster.position.future.y == p->_my) {
+	if (monster.position.future == position) {
 		return;
 	}
 	if (IsAnyOf(monster._mmode, MonsterMode::Charge, MonsterMode::Petrified)) {
 		return;
 	}
 
-	if (monster.position.tile.WalkingDistance({ p->_mx, p->_my }) <= 2) {
+	if (monster.position.tile.WalkingDistance(position) <= 2) {
 		if (!monster.IsWalking()) {
-			Direction md = GetDirection(monster.position.tile, { p->_mx, p->_my });
-			if (DirOK(ndx, md)) {
-				M_ClearSquares(ndx);
-				dMonster[monster.position.tile.x][monster.position.tile.y] = ndx + 1;
-				M_WalkDir(ndx, md);
+			Direction md = GetDirection(monster.position.tile, position);
+			if (DirOK(monsterId, md)) {
+				M_ClearSquares(monsterId);
+				dMonster[monster.position.tile.x][monster.position.tile.y] = monsterId + 1;
+				M_WalkDir(monsterId, md);
 				monster._msquelch = UINT8_MAX;
 			}
 		}
-	} else if (dMonster[p->_mx][p->_my] == 0) {
-		M_ClearSquares(ndx);
-		dMonster[p->_mx][p->_my] = ndx + 1;
-		monster.position.tile = { p->_mx, p->_my };
-		decode_enemy(monster, p->_menemy);
-		Direction md = GetDirection({ p->_mx, p->_my }, monster.enemyPosition);
+	} else if (dMonster[position.x][position.y] == 0) {
+		M_ClearSquares(monsterId);
+		dMonster[position.x][position.y] = monsterId + 1;
+		monster.position.tile = position;
+		decode_enemy(monster, enemyId);
+		Direction md = GetDirection(position, monster.enemyPosition);
 		M_StartStand(monster, md);
 		monster._msquelch = UINT8_MAX;
 	}
 
-	decode_enemy(monster, p->_menemy);
+	decode_enemy(monster, enemyId);
+}
+
+bool IsEnemyIdValidate(const Monster &monster, int enemyId)
+{
+	if (enemyId < 0) {
+		return false;
+	}
+
+	if (enemyId < MAX_PLRS) {
+		return Players[enemyId].plractive;
+	}
+
+	enemyId -= MAX_PLRS;
+	if (enemyId >= MAXMONSTERS) {
+		return false;
+	}
+
+	const Monster &enemy = Monsters[enemyId];
+
+	if (&enemy == &monster) {
+		return false;
+	}
+
+	if (enemy._mhitpoints <= 0) {
+		return false;
+	}
+
+	return true;
+}
+
+bool IsTSyncMonsterValidate(const TSyncMonster &monsterSync)
+{
+	const int monsterId = monsterSync._mndx;
+
+	if (monsterId < 0 || monsterId >= MAXMONSTERS)
+		return false;
+
+	if (!InDungeonBounds({ monsterSync._mx, monsterSync._my }))
+		return false;
+
+	if (!IsEnemyIdValidate(Monsters[monsterId], monsterSync._menemy))
+		return false;
+
+	return true;
 }
 
 } // namespace
 
-uint32_t sync_all_monsters(const byte *pbBuf, uint32_t dwMaxLen)
+uint32_t sync_all_monsters(byte *pbBuf, uint32_t dwMaxLen)
 {
 	if (ActiveMonsterCount < 1) {
 		return dwMaxLen;
@@ -217,12 +262,13 @@ uint32_t sync_all_monsters(const byte *pbBuf, uint32_t dwMaxLen)
 	SyncOneMonster();
 
 	for (int i = 0; i < ActiveMonsterCount && dwMaxLen >= sizeof(TSyncMonster); i++) {
+		auto &monsterSync = *reinterpret_cast<TSyncMonster *>(pbBuf);
 		bool sync = false;
 		if (i < 2) {
-			sync = SyncMonsterActive2((TSyncMonster *)pbBuf);
+			sync = SyncMonsterActive2(monsterSync);
 		}
 		if (!sync) {
-			sync = SyncMonsterActive((TSyncMonster *)pbBuf);
+			sync = SyncMonsterActive(monsterSync);
 		}
 		if (!sync) {
 			break;
@@ -235,37 +281,40 @@ uint32_t sync_all_monsters(const byte *pbBuf, uint32_t dwMaxLen)
 	return dwMaxLen;
 }
 
-uint32_t sync_update(int pnum, const byte *pbBuf)
+uint32_t OnSyncData(const TCmd *pCmd, int pnum)
 {
-	uint16_t wLen;
-
-	auto *pHdr = (TSyncHeader *)pbBuf;
-	pbBuf += sizeof(*pHdr);
-
-	if (pHdr->bCmd != CMD_SYNCDATA) {
-		app_fatal("bad sync command");
-	}
+	const auto &header = *reinterpret_cast<const TSyncHeader *>(pCmd);
 
 	assert(gbBufferMsgs != 2);
 
 	if (gbBufferMsgs == 1) {
-		return pHdr->wLen + sizeof(*pHdr);
+		return header.wLen + sizeof(header);
 	}
 	if (pnum == MyPlayerId) {
-		return pHdr->wLen + sizeof(*pHdr);
+		return header.wLen + sizeof(header);
 	}
 
-	for (wLen = pHdr->wLen; wLen >= sizeof(TSyncMonster); wLen -= sizeof(TSyncMonster)) {
-		if (currlevel == pHdr->bLevel) {
-			SyncMonster(pnum, (TSyncMonster *)pbBuf);
+	assert(header.wLen % sizeof(TSyncMonster) == 0);
+	int monsterCount = header.wLen / sizeof(TSyncMonster);
+
+	uint8_t level = header.bLevel;
+
+	if (level < NUMLEVELS) {
+		const auto *monsterSyncs = reinterpret_cast<const TSyncMonster *>(pCmd + sizeof(header));
+
+		for (int i = 0; i < monsterCount; i++) {
+			if (!IsTSyncMonsterValidate(monsterSyncs[i]))
+				continue;
+
+			if (currlevel == level) {
+				SyncMonster(pnum, monsterSyncs[i]);
+			}
+
+			delta_sync_monster(monsterSyncs[i], level);
 		}
-		delta_sync_monster((TSyncMonster *)pbBuf, pHdr->bLevel);
-		pbBuf += sizeof(TSyncMonster);
 	}
 
-	assert(wLen == 0);
-
-	return pHdr->wLen + sizeof(*pHdr);
+	return header.wLen + sizeof(header);
 }
 
 void sync_init()

--- a/Source/sync.h
+++ b/Source/sync.h
@@ -11,8 +11,8 @@
 
 namespace devilution {
 
-uint32_t sync_all_monsters(const byte *pbBuf, uint32_t dwMaxLen);
-uint32_t sync_update(int pnum, const byte *pbBuf);
+uint32_t sync_all_monsters(byte *pbBuf, uint32_t dwMaxLen);
+uint32_t OnSyncData(const TCmd *pCmd, int pnum);
 void sync_init();
 
 } // namespace devilution


### PR DESCRIPTION
Checks that the CMD_SYNCDATA message won't cause OOB or CTD. CMD_SYNCDATA looks to be one of the more complicated messages and some of the changes here also lay the ground work for validating more messages so that we can more safely allow password-less games.

There are also some cleanups included since it helped me better understand the code and avoid the need for null pointer checks.