### PR TITLE
Prevent ZeroTier race condition during application shutdown

### DIFF
--- a/Source/dvlnet/zerotier_native.cpp
+++ b/Source/dvlnet/zerotier_native.cpp
@@ -25,7 +25,6 @@ static constexpr uint64_t ZtNetwork = 0xaf78bf943649eb12;
 
 static std::atomic_bool zt_network_ready(false);
 static std::atomic_bool zt_node_online(false);
-static std::atomic_bool zt_started(false);
 static std::atomic_bool zt_joined(false);
 
 static void Callback(struct zts_callback_msg *msg)
@@ -55,18 +54,10 @@ bool zerotier_network_ready()
 	return zt_network_ready && zt_node_online;
 }
 
-void zerotier_network_stop()
-{
-	zts_stop();
-}
-
 void zerotier_network_start()
 {
-	if (zt_started)
-		return;
 	std::string ztpath = paths::PrefPath() + "zerotier";
 	zts_start(ztpath.c_str(), (void (*)(void *))Callback, 0);
-	std::atexit(zerotier_network_stop);
 }
 
 } // namespace net


### PR DESCRIPTION
Removes the call to `zts_stop()` based on this excerpt from the libzt project README.

> At the end of your program or when no more network activity is anticipated, the user application can shut down the service with `zts_stop()`. However, it is safe to leave the service running in the background indefinitely as it doesn't consume much memory or CPU while at idle. `zts_stop()` is a non-blocking call and will itself issue a series of events indicating that various aspects of the ZeroTier service have successfully shut down.

This resolves #2197