### PR TITLE
fix light stealing in multi

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1546,7 +1546,6 @@ DWORD OnPlayerJoinLevel(TCmd *pCmd, int pnum)
 			}
 
 			player._pvid = AddVision(player.position.tile, player._pLightRad, pnum == MyPlayerId);
-			player._plid = NO_LIGHT;
 		}
 	}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3631,6 +3631,8 @@ void SyncInitPlr(int pnum)
 
 	SetPlrAnims(player);
 	SyncInitPlrPos(pnum);
+	if (pnum != MyPlayerId)
+		player._plid = NO_LIGHT;
 }
 
 void CheckStats(Player &player)


### PR DESCRIPTION
Resolves https://github.com/diasurgical/devilutionX/issues/2991
OnPlayerJoinLevel was setting light of other players to -1 too late, StartStand happened earlier and it updated light, which was 0 = light stealing.
