### PR TITLE
Free dvlnet resources when game is shutting down

### DIFF
--- a/Source/storm/storm_net.cpp
+++ b/Source/storm/storm_net.cpp
@@ -93,6 +93,7 @@ bool SNetDestroy()
 #ifndef NONET
 	std::lock_guard<SdlMutex> lg(storm_net_mutex);
 #endif
+	dvlnet_inst = nullptr;
 	return true;
 }
 


### PR DESCRIPTION
This explicitly frees the currently active network implementation during application shutdown.

Leaving ZeroTier connections open during application shutdown invites errors related to locking mutexes that have already been freed. Selecting `Quit Game` from the in-game menu in a ZeroTier game with multiple players was enough to reproduce the error on my system.