### PR TITLE
center automap arrow

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -355,9 +355,9 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, int 
 	} break;
 	case Direction::SouthEast: {
 		const Point point { base.x + AmLine16, base.y + AmLine8 };
+		DrawMapLineSteepNW(out, point, AmLine4, playerColor);
 		DrawMapLineSE(out, { point.x - 2 * AmLine8, point.y - AmLine8 }, AmLine8, playerColor);
 		DrawHorizontalLine(out, { point.x - (AmLine8 + 1), point.y }, AmLine8 + 1, playerColor);
-		DrawMapLineSteepNW(out, point, AmLine4, playerColor);
 	} break;
 	case Direction::South: {
 		const Point point { base.x, base.y + AmLine16 };

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -332,7 +332,7 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, int 
 		if (chrflag || QuestLogIsOpen)
 			base.x += gnScreenWidth / 4;
 	}
-	base.y -= AmLine8;
+	base.y -= AmLine16;
 
 	switch (player._pdir) {
 	case Direction::North: {


### PR DESCRIPTION
Resolves https://github.com/diasurgical/devilutionX/issues/292
![centerarrow](https://user-images.githubusercontent.com/14297035/135595317-63b63f4a-dbb4-4396-a747-93245c6c7221.gif)

Also  changed drawing order in southeast arrow
![betterarrow](https://user-images.githubusercontent.com/14297035/135597901-a554aefa-802c-44cb-a992-82a4c9088b1b.gif)
So shadow overwrites less
