### PR TITLE
Fix OnSpellTile check

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -979,8 +979,6 @@ DWORD OnSpellTile(const TCmd *pCmd, Player &player)
 		return sizeof(message);
 	if (message.wParam2 > RSPLTYPE_INVALID)
 		return sizeof(message);
-	if (message.wParam3 > static_cast<int>(Direction::SouthEast))
-		return sizeof(message);
 
 	auto spell = static_cast<spell_id>(message.wParam1);
 	if (currlevel == 0 && !spelldata[spell].sTownSpell) {
@@ -992,7 +990,7 @@ DWORD OnSpellTile(const TCmd *pCmd, Player &player)
 	player.destAction = ACTION_SPELL;
 	player.destParam1 = position.x;
 	player.destParam2 = position.y;
-	player.destParam3 = static_cast<Direction>(message.wParam3);
+	player.destParam4 = message.wParam3;
 	player._pSpell = spell;
 	player._pSplType = static_cast<spell_type>(message.wParam2);
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1701,7 +1701,7 @@ void CheckNewPath(int pnum, bool pmWillBeCalled)
 		case ACTION_SPELL:
 			d = GetDirection(player.position.tile, { player.destParam1, player.destParam2 });
 			StartSpell(pnum, d, player.destParam1, player.destParam2);
-			player.spellLevel = static_cast<int>(player.destParam3);
+			player.spellLevel = player.destParam4;
 			break;
 		case ACTION_SPELLWALL:
 			StartSpell(pnum, player.destParam3, player.destParam1, player.destParam2);


### PR DESCRIPTION
`wParam3` is the spell level, not the direction (like in `CMD_SPELLXYD`).
What great network messages. 😛 