### PR TITLE
Add item pickup sounds

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1610,6 +1610,14 @@ void AutoGetItem(int pnum, Item *item, int ii)
 	}
 
 	if (done) {
+		if (sgOptions.Audio.bItemPickupSound && pnum == MyPlayerId) {
+			if (player.HoldItem._itype == ItemType::Gold) {
+				PlaySFX(IS_IGRAB);
+			} else {
+				PlaySFX(ItemInvSnds[ItemCAnimTbl[item->_iCurs]]);
+			}
+		}
+
 		CleanupItems(&Items[ii], ii);
 		return;
 	}

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -216,6 +216,7 @@ void LoadOptions()
 	sgOptions.Audio.nMusicVolume = GetIniInt("Audio", "Music Volume", VOLUME_MAX);
 	sgOptions.Audio.bWalkingSound = GetIniBool("Audio", "Walking Sound", true);
 	sgOptions.Audio.bAutoEquipSound = GetIniBool("Audio", "Auto Equip Sound", false);
+	sgOptions.Audio.bItemPickupSound = GetIniBool("Audio", "Item Pickup Sound", false);
 
 	sgOptions.Audio.nSampleRate = GetIniInt("Audio", "Sample Rate", DEFAULT_AUDIO_SAMPLE_RATE);
 	sgOptions.Audio.nChannels = GetIniInt("Audio", "Channels", DEFAULT_AUDIO_CHANNELS);
@@ -366,6 +367,7 @@ void SaveOptions()
 	SetIniValue("Audio", "Music Volume", sgOptions.Audio.nMusicVolume);
 	SetIniValue("Audio", "Walking Sound", sgOptions.Audio.bWalkingSound);
 	SetIniValue("Audio", "Auto Equip Sound", sgOptions.Audio.bAutoEquipSound);
+	SetIniValue("Audio", "Item Pickup Sound", sgOptions.Audio.bItemPickupSound);
 
 	SetIniValue("Audio", "Sample Rate", sgOptions.Audio.nSampleRate);
 	SetIniValue("Audio", "Channels", sgOptions.Audio.nChannels);

--- a/Source/options.h
+++ b/Source/options.h
@@ -29,6 +29,8 @@ struct AudioOptions {
 	bool bWalkingSound;
 	/** @brief Automatically equipping items on pickup emits the equipment sound. */
 	bool bAutoEquipSound;
+	/** @brief Picking up items emits the items pickup sound. */
+	bool bItemPickupSound;
 
 	/** @brief Output sample rate (Hz) */
 	std::uint32_t nSampleRate;

--- a/Source/qol/autopickup.cpp
+++ b/Source/qol/autopickup.cpp
@@ -52,7 +52,6 @@ void AutoGoldPickup(int pnum)
 			if (item._itype == ItemType::Gold) {
 				NetSendCmdGItem(true, CMD_REQUESTAGITEM, pnum, pnum, itemIndex);
 				item._iRequest = true;
-				PlaySFX(IS_IGRAB);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/diasurgical/devilutionX/issues/1360

Should also fix https://github.com/diasurgical/devilutionX/issues/1467 and https://github.com/diasurgical/devilutionX/issues/1355 as the sound is now played when adding the item to the inventory.

One drawback is that when the new option 'Item Pickup Sound' is disabled, the gold pickup sound is not played anymore as it was playing before when auto gold pickup was enabled. If you don't like this change the previous behavior can also be kept with a slightly complex if statement.

I kept the previous sound for picking up gold, but we could also drop this special treatment and use the default chink sound for gold.