### PR TITLE
url to the vcpkg quickstart guide for windows has (slightly) changed

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -132,13 +132,10 @@ of the `(i686|x86_64)-w64-mingw32` directory.
 Make sure to install the `C++ CMake tools for Windows` and `Windows SDK` component for Visual Studio.
 *Note: `Windows SDK` component should match your Windows build version.*
 
-Install vcpkg following the instructions from https://github.com/microsoft/vcpkg#quick-start-windows. Don't forget to
-perform _user-wide integration_ step for additional convenience.
+Install vcpkg following the instructions from https://github.com/microsoft/vcpkg#quick-start-windows. Don't forget to perform _user-wide integration_ step for additional convenience.
 
 In order to build devilutionx.mpq, install smpq from https://launchpad.net/smpq/trunk/1.6/+download/SMPQ-1.6-x86_64.exe.
-The location of this tool will need to
-be [added to the system's PATH environment variable](https://docs.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/ee537574(v=office.14))
-.
+The location of this tool will need to be [added to the system's PATH environment variable](https://docs.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/ee537574(v=office.14)).
 
 ### Compiling
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -132,7 +132,8 @@ of the `(i686|x86_64)-w64-mingw32` directory.
 Make sure to install the `C++ CMake tools for Windows` and `Windows SDK` component for Visual Studio.
 *Note: `Windows SDK` component should match your Windows build version.*
 
-Install vcpkg following the instructions from https://github.com/microsoft/vcpkg#quick-start-windows. Don't forget to perform _user-wide integration_ step for additional convenience.
+Install vcpkg following the instructions from https://github.com/microsoft/vcpkg#quick-start-windows.
+Don't forget to perform _user-wide integration_ step for additional convenience.
 
 In order to build devilutionx.mpq, install smpq from https://launchpad.net/smpq/trunk/1.6/+download/SMPQ-1.6-x86_64.exe.
 The location of this tool will need to be [added to the system's PATH environment variable](https://docs.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/ee537574(v=office.14)).

--- a/docs/building.md
+++ b/docs/building.md
@@ -132,11 +132,13 @@ of the `(i686|x86_64)-w64-mingw32` directory.
 Make sure to install the `C++ CMake tools for Windows` and `Windows SDK` component for Visual Studio.
 *Note: `Windows SDK` component should match your Windows build version.*
 
-Install vcpkg following the instructions from https://github.com/microsoft/vcpkg#quick-start.
-Don't forget to perform _user-wide integration_ step for additional convenience.
+Install vcpkg following the instructions from https://github.com/microsoft/vcpkg#quick-start-windows. Don't forget to
+perform _user-wide integration_ step for additional convenience.
 
 In order to build devilutionx.mpq, install smpq from https://launchpad.net/smpq/trunk/1.6/+download/SMPQ-1.6-x86_64.exe.
-The location of this tool will need to be [added to the system's PATH environment variable](https://docs.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/ee537574(v=office.14)).
+The location of this tool will need to
+be [added to the system's PATH environment variable](https://docs.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/ee537574(v=office.14))
+.
 
 ### Compiling
 


### PR DESCRIPTION
I also have in my personal notes the following:
```
# For 64Bit
vcpkg install fmt:x64-windows sdl2:x64-windows sdl2-mixer:x64-windows sdl2-ttf:x64-windows libsodium:x64-windows gtest:x64-windows

vcpkg integrate install
```
But I'm not sure if these commands are still needed, so I didn't add them in the markdown.