### PR TITLE
change way to detect architecture/platform path for libsodium.

### DIFF
--- a/CMake/Findsodium.cmake
+++ b/CMake/Findsodium.cmake
@@ -121,15 +121,14 @@ elseif (WIN32)
     try_compile(_UNUSED_VAR "${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/arch.c"
             OUTPUT_VARIABLE _COMPILATION_LOG
         )
-        string(REGEX REPLACE ".*ARCH_VALUE ([a-zA-Z0-9_]+).*" "\\1" _TARGET_ARCH "${_COMPILATION_LOG}")
 
         # construct library path
-        if (_TARGET_ARCH STREQUAL "x86_32")
+        if (CMAKE_SIZEOF_VOID_P EQUAL 4)
             string(APPEND _PLATFORM_PATH "Win32")
-        elseif(_TARGET_ARCH STREQUAL "x86_64")
+        elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
             string(APPEND _PLATFORM_PATH "x64")
         else()
-            message(FATAL_ERROR "the ${_TARGET_ARCH} architecture is not supported by Findsodium.cmake.")
+            message(FATAL_ERROR "Can't find target architecture. CMAKE_SIZEOF_VOID_P not 4 or 8.")
         endif()
         string(APPEND _PLATFORM_PATH "/$$CONFIG$$")
 


### PR DESCRIPTION
Code was copied right from stackoverflow as @StephenCWills suggested: https://stackoverflow.com/a/39258832
I tried it with CLion and Visual Studio 2019 and was able to compile without any problems.
Without the change compiling with CLion was not possible.

Fixes #2558