### PR TITLE
Remove pointless increments of life/mana on level up

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2581,9 +2581,7 @@ void NextPlrLevel(int pnum)
 	player._pNextExper = ExpLvlsTbl[player._pLevel];
 
 	int hp = player._pClass == HeroClass::Sorcerer ? 64 : 128;
-	if (!gbIsMultiplayer) {
-		hp++;
-	}
+
 	player._pMaxHP += hp;
 	player._pHitPoints = player._pMaxHP;
 	player._pMaxHPBase += hp;
@@ -2599,9 +2597,6 @@ void NextPlrLevel(int pnum)
 	else if (player._pClass == HeroClass::Barbarian)
 		mana = 0;
 
-	if (!gbIsMultiplayer) {
-		mana++;
-	}
 	player._pMaxMana += mana;
 	player._pMaxManaBase += mana;
 


### PR DESCRIPTION
fixes #3049

No visible impact on gameplay since this never leads to a full point difference in mana or hp, but this at least removes two references to the global `gbIsMultiplayer`