### PR TITLE
Remove debug assert after picking up an item

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1661,7 +1661,6 @@ void SyncGetItem(Point position, int idx, uint16_t ci, int iseed)
 		return;
 
 	CleanupItems(&Items[ii], ii);
-	assert(FindGetItem(idx, ci, iseed) == -1);
 }
 
 bool CanPut(Point position)


### PR DESCRIPTION
This check doesn't really do anything useful. It could be rewritten to check the position instead of doing an additional search, but that isn't useful either given if the target position doesn't contain an item on the local client the code looks for a matching dropped item and tries to pick that up instead. It doesn't really make sense to assert that an item exists at the target position or that it matches, a desync has already happened by this point if the checks on lines 1647 or 1649 are false.

fixes #3052