### PR TITLE
Fix broken link in the installation instructions

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -3,7 +3,7 @@
 First, you will need access to the game MPQ files.
 - First, locate `DIABDAT.MPQ` on your CD or in the GoG installation (or [extract it from the GoG installer](https://github.com/diasurgical/devilutionX/wiki/Extracting-the-.MPQs-from-the-GoG-installer)).
 - For the Diablo: Hellfire expansion you will also need `hellfire.mpq`, `hfmonk.mpq`, `hfmusic.mpq`, `hfvoice.mpq`.
-- Lastly, DevilutionX comes with [devilutionx.mpq](https://github.com/diasurgical/devilutionX/raw/master/Packaging/resources/devilutionx.mpq) which you will also need.
+- Lastly, DevilutionX comes with [devilutionx.mpq](https://github.com/diasurgical/devilutionX/raw/1.2.1/Packaging/resources/devilutionx.mpq) which you will also need.
 
 Download the latest [DevilutionX release](https://github.com/diasurgical/devilutionX/releases) for your system (if available) and extract the contents to a location of your choosing, or [build from source](building.md). Then follow the system-specific instructions below.
 


### PR DESCRIPTION
This just updates the URL in the installation instructions to use the 1.2.1 version of devilutionx.mpq as a stopgap before the v1.3.0 release.