### PR TITLE
Fetch SDL_image from GitHub instead of libsdl.org

### DIFF
--- a/3rdParty/SDL_image/CMakeLists.txt
+++ b/3rdParty/SDL_image/CMakeLists.txt
@@ -3,13 +3,13 @@ include(FetchContent_MakeAvailableExcludeFromAll)
 include(FetchContent)
 if(USE_SDL1)
   FetchContent_Declare(SDL_image
-    URL https://www.libsdl.org/projects/SDL_image/release/SDL_image-1.2.12.tar.gz
-    URL_HASH MD5=a0f9098ebe5400f0bdc9b62e60797ecb
+    URL https://github.com/libsdl-org/SDL_image/archive/refs/tags/release-1.2.12.tar.gz
+    URL_HASH MD5=5d499e3cf6be00bfb0a7bff1cbdbd348
   )
 else()
   FetchContent_Declare(SDL_image
-    URL https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.5.tar.gz
-    URL_HASH MD5=f26f3a153360a8f09ed5220ef7b07aea
+    URL https://github.com/libsdl-org/SDL_image/archive/refs/tags/release-2.0.5.tar.gz
+    URL_HASH MD5=3446ed7ee3c700065dcb33426a9b0c6e
   )
 endif()
 FetchContent_MakeAvailableExcludeFromAll(SDL_image)


### PR DESCRIPTION
Lately libsdl.org appears to have some uptime issues, fetching the package from GitHub instead might be better.
Changed package link and corresponding md5.
Fixes #3033, also refer https://github.com/libsdl-org/SDL_image/issues/195.