### PR TITLE
Revert "fix loot" for 1.3.0

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3408,11 +3408,9 @@ void SpawnItem(Monster &monster, Point position, bool sendmsg)
 	GetSuperItemSpace(position, ii);
 	int uper = monster._uniqtype != 0 ? 15 : 1;
 
-	int8_t mLevel = monster.mLevel;
+	int8_t mLevel = monster.MData->mLevel;
 	if (!gbIsHellfire && monster.MType->mtype == MT_DIABLO)
 		mLevel -= 15;
-	if (mLevel > CF_LEVEL)
-		mLevel = CF_LEVEL;
 
 	SetupAllItems(item, idx, AdvanceRndSeed(), mLevel, uper, onlygood, false, false);
 


### PR DESCRIPTION
This reverts commit e268ff9afa963142455fbaba84d3ed222c9da9f0.
This fix will be included in 1.4.0 along with https://github.com/diasurgical/devilutionX/pull/2930