### PR TITLE
Refactor: Replace int mind, int maxd with struct DamageRange

### DIFF
--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -26,6 +26,11 @@ struct ChainStruct {
 	int _mirange;
 };
 
+struct DamageRange {
+	int min;
+	int max;
+};
+
 struct MissilePosition {
 	Point tile;
 	/** Sprite's pixel offset from tile. */
@@ -165,8 +170,8 @@ int GetSpellLevel(int playerId, spell_id sn);
  */
 Direction16 GetDirection16(Point p1, Point p2);
 void DeleteMissile(int i);
-bool MonsterTrapHit(int m, int mindam, int maxdam, int dist, missile_id t, bool shift);
-bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, missile_id mtype, bool shift, int earflag, bool *blocked);
+bool MonsterTrapHit(int m, DamageRange damrange, int dist, missile_id t, bool shift);
+bool PlayerMHit(int pnum, Monster *monster, int dist, DamageRange damrange, missile_id mtype, bool shift, int earflag, bool *blocked);
 
 /**
  * @brief Sets the missile sprite to the given sheet frame

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1570,10 +1570,10 @@ void UpdateFlameTrap(int i)
 		int x = Objects[i].position.x;
 		int y = Objects[i].position.y;
 		if (dMonster[x][y] > 0)
-			MonsterTrapHit(dMonster[x][y] - 1, mindam / 2, maxdam / 2, 0, MIS_FIREWALLC, false);
+			MonsterTrapHit(dMonster[x][y] - 1, DamageRange { mindam / 2, maxdam / 2 }, 0, MIS_FIREWALLC, false);
 		if (dPlayer[x][y] > 0) {
 			bool unused;
-			PlayerMHit(dPlayer[x][y] - 1, nullptr, 0, mindam, maxdam, MIS_FIREWALLC, false, 0, &unused);
+			PlayerMHit(dPlayer[x][y] - 1, nullptr, 0, DamageRange { mindam, maxdam }, MIS_FIREWALLC, false, 0, &unused);
 		}
 
 		if (Objects[i]._oAnimFrame == Objects[i]._oAnimLen)
@@ -4193,10 +4193,10 @@ void BreakBarrel(int pnum, int i, int dam, bool forcebreak, bool sendmsg)
 		for (int yp = Objects[i].position.y - 1; yp <= Objects[i].position.y + 1; yp++) {
 			for (int xp = Objects[i].position.x - 1; xp <= Objects[i].position.x + 1; xp++) {
 				if (dMonster[xp][yp] > 0)
-					MonsterTrapHit(dMonster[xp][yp] - 1, 1, 4, 0, MIS_FIREBOLT, false);
+					MonsterTrapHit(dMonster[xp][yp] - 1, DamageRange { 1, 4 }, 0, MIS_FIREBOLT, false);
 				bool unused;
 				if (dPlayer[xp][yp] > 0)
-					PlayerMHit(dPlayer[xp][yp] - 1, nullptr, 0, 8, 16, MIS_FIREBOLT, false, 0, &unused);
+					PlayerMHit(dPlayer[xp][yp] - 1, nullptr, 0, DamageRange { 8, 16 }, MIS_FIREBOLT, false, 0, &unused);
 				if (dObject[xp][yp] > 0) {
 					int oi = dObject[xp][yp] - 1;
 					if (Objects[oi]._otype == OBJ_BARRELEX && Objects[oi]._oBreak != -1)


### PR DESCRIPTION
Implemented `struct DamageRange`, to be used in place of pairs of `int mindam, int maxdam` and other such cases for better readability.
Partially fixes #2350.