### PR TITLE
Prevent Spell Targeting Players with Friendly Mode enabled

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3509,7 +3509,7 @@ void CheckPlrSpell(bool isShiftHeld)
 		LastMouseButtonAction = MouseActionType::SpellMonsterTarget;
 		sl = GetSpellLevel(MyPlayerId, myPlayer._pRSpell);
 		NetSendCmdParam4(true, CMD_SPELLID, pcursmonst, myPlayer._pRSpell, myPlayer._pRSplType, sl);
-	} else if (pcursplr != -1 && !isShiftHeld) {
+	} else if (pcursplr != -1 && !isShiftHeld && !gbFriendlyMode) {
 		LastMouseButtonAction = MouseActionType::SpellPlayerTarget;
 		sl = GetSpellLevel(MyPlayerId, myPlayer._pRSpell);
 		NetSendCmdParam4(true, CMD_SPELLPID, pcursplr, myPlayer._pRSpell, myPlayer._pRSplType, sl);


### PR DESCRIPTION
Prevents players from targeting each other with spells in the same way that players are prevented from targeting each other with weapons when Friendly Mode is enabled