### PR TITLE
[Virtual Gamepad] Move potion buttons to the left side

### DIFF
--- a/Source/controls/touch/event_handlers.cpp
+++ b/Source/controls/touch/event_handlers.cpp
@@ -195,6 +195,12 @@ bool VirtualDirectionPadEventHandler::HandleFingerMotion(const SDL_TouchFingerEv
 
 bool VirtualPadButtonEventHandler::Handle(const SDL_Event &event)
 {
+	if (!virtualPadButton->isUsable()) {
+		virtualPadButton->didStateChange = virtualPadButton->isHeld;
+		virtualPadButton->isHeld = false;
+		return false;
+	}
+
 	virtualPadButton->didStateChange = false;
 
 	switch (event.type) {

--- a/Source/controls/touch/gamepad.cpp
+++ b/Source/controls/touch/gamepad.cpp
@@ -1,7 +1,9 @@
 #include <SDL.h>
 
+#include "control.h"
 #include "controls/touch/gamepad.h"
 #include "diablo.h"
+#include "quests.h"
 #include "utils/display.h"
 #include "utils/ui_fwd.h"
 
@@ -104,14 +106,16 @@ void InitializeVirtualGamepad()
 	cancelButton.area.radius = padButtonSize / 2;
 
 	VirtualPadButton &healthButton = VirtualGamepadState.healthButton;
-	healthButton.area.position.x = padButtonRight - padButtonSize - padButtonSpacing;
-	healthButton.area.position.y = padButtonTop - padButtonSize - padButtonSpacing;
+	healthButton.area.position.x = directionPad.area.position.x - (padButtonSize + padButtonSpacing) / 2;
+	healthButton.area.position.y = directionPad.area.position.y - (directionPadSize + padButtonSize + padButtonSpacing) / 2;
 	healthButton.area.radius = padButtonSize / 2;
+	healthButton.isUsable = []() { return !chrflag && !QuestLogIsOpen; };
 
 	VirtualPadButton &manaButton = VirtualGamepadState.manaButton;
-	manaButton.area.position.x = padButtonRight;
-	manaButton.area.position.y = padButtonTop - padButtonSize - padButtonSpacing;
+	manaButton.area.position.x = directionPad.area.position.x + (padButtonSize + padButtonSpacing) / 2;
+	manaButton.area.position.y = directionPad.area.position.y - (directionPadSize + padButtonSize + padButtonSpacing) / 2;
 	manaButton.area.radius = padButtonSize / 2;
+	manaButton.isUsable = []() { return !chrflag && !QuestLogIsOpen; };
 }
 
 void VirtualDirectionPad::UpdatePosition(Point touchCoordinates)

--- a/Source/controls/touch/gamepad.h
+++ b/Source/controls/touch/gamepad.h
@@ -2,6 +2,8 @@
 
 #if defined(VIRTUAL_GAMEPAD) && !defined(USE_SDL1)
 
+#include <functional>
+
 #include "controls/controller_buttons.h"
 #include "engine/circle.hpp"
 #include "engine/point.hpp"
@@ -33,11 +35,13 @@ struct VirtualPadButton {
 	Circle area;
 	bool isHeld;
 	bool didStateChange;
+	std::function<bool()> isUsable;
 
 	VirtualPadButton()
 	    : area({ { 0, 0 }, 0 })
 	    , isHeld(false)
 	    , didStateChange(false)
+	    , isUsable([]() { return true; })
 	{
 	}
 };

--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -233,6 +233,9 @@ void VirtualDirectionPadRenderer::RenderKnob(RenderFunction renderFunction)
 
 void VirtualPadButtonRenderer::Render(RenderFunction renderFunction, Art &buttonArt)
 {
+	if (!virtualPadButton->isUsable())
+		return;
+
 	VirtualGamepadButtonType buttonType = GetButtonType();
 	int frame = buttonType;
 	int offset = buttonArt.h() * frame;
@@ -253,6 +256,9 @@ void VirtualPadButtonRenderer::Render(RenderFunction renderFunction, Art &button
 
 void PotionButtonRenderer::RenderPotion(RenderFunction renderFunction, Art &potionArt)
 {
+	if (!virtualPadButton->isUsable())
+		return;
+
 	std::optional<VirtualGamepadPotionType> potionType = GetPotionType();
 	if (potionType == std::nullopt)
 		return;


### PR DESCRIPTION
Moves potion buttons to the left side of the screen instead of the right, based on feedback from #2959.
> Drinking potions on the right side might not be ideal, during fights you are already mashing the attack button on the right side, but you aren't really doing anything on the left side so maybe move the potion buttons there. Alternatively we could make the belt touch event "use" when the inventory isn't open.

![Screenshot_20211010-222423](https://user-images.githubusercontent.com/9203145/136724659-72840708-2d79-4dd2-b53f-0144bce5da4f.png)

I noticed this covers a significant portion of the character screen on my phone so I also added some code to hide the potion buttons when either the character panel or the quest panel are open.