### PR TITLE
Use correct pointer arithmetic in OnLevelData

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -366,7 +366,7 @@ DWORD OnLevelData(int pnum, const TCmd *pCmd)
 	}
 
 	assert(message.wOffset == sgdwRecvOffset);
-	memcpy(&sgRecvBuf[message.wOffset], &message + sizeof(message), message.wBytes);
+	memcpy(&sgRecvBuf[message.wOffset], &message + 1, message.wBytes);
 	sgdwRecvOffset += message.wBytes;
 	return message.wBytes + sizeof(message);
 }


### PR DESCRIPTION
Previously was incrementing the pointer 5 places due to the way pointers to complete objects are handled.

see https://en.cppreference.com/w/cpp/language/operator_arithmetic#Additive_operators