### PR TITLE
Enable opening Hive and Crypt using gamepad

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -18,6 +18,7 @@
 #include "minitext.h"
 #include "missiles.h"
 #include "stores.h"
+#include "town.h"
 #include "towners.h"
 #include "trigs.h"
 
@@ -1396,6 +1397,28 @@ bool TryDropItem()
 
 	if (myPlayer.HoldItem.isEmpty()) {
 		return false;
+	}
+
+	if (myPlayer.HoldItem.IDidx == IDI_RUNEBOMB) {
+		for (auto dir : PathDirs) {
+			Point position = myPlayer.position.tile + dir;
+			if (OpensHive(position)) {
+				NetSendCmdPItem(true, CMD_PUTITEM, { 79, 61 });
+				NewCursor(CURSOR_HAND);
+				return true;
+			}
+		}
+	}
+
+	if (myPlayer.HoldItem.IDidx == IDI_MAPOFDOOM) {
+		for (auto dir : PathDirs) {
+			Point position = myPlayer.position.tile + dir;
+			if (OpensGrave(position)) {
+				NetSendCmdPItem(true, CMD_PUTITEM, { 35, 20 });
+				NewCursor(CURSOR_HAND);
+				return true;
+			}
+		}
 	}
 
 	cursPosition = myPlayer.position.future + Direction::SouthEast;

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -200,6 +200,20 @@ void DrlgTPass3()
 
 } // namespace
 
+bool OpensHive(Point position)
+{
+	int yp = position.y;
+	int xp = position.x;
+	return xp >= 79 && xp <= 82 && yp >= 61 && yp <= 64;
+}
+
+bool OpensGrave(Point position)
+{
+	int yp = position.y;
+	int xp = position.x;
+	return xp >= 35 && xp <= 38 && yp >= 20 && yp <= 24;
+}
+
 void TownOpenHive()
 {
 	dPiece[78][60] = 0x48a;

--- a/Source/town.h
+++ b/Source/town.h
@@ -11,6 +11,20 @@
 namespace devilution {
 
 /**
+ * @brief Check if hive can be opened by dropping rune bomb on a tile
+ * @param position The position of the tile
+ * @return True if the bomb would open hive
+*/
+bool OpensHive(Point position);
+
+/**
+ * @brief Check if grave can be opened by dropping cathedral map on a tile
+ * @param position The position of the tile
+ * @return True if the map would open the grave
+*/
+bool OpensGrave(Point position);
+
+/**
  * @brief Update the map to show the open hive
  */
 void TownOpenHive();


### PR DESCRIPTION
* Introduces `OpensHive(Point position)` and `OpensGrave(Point position)` functions in town.cpp
* Update logic in `InvPutItem()` to use these new functions
* Check for Rune Bomb using `IDI_RUNEBOMB` instead of `ICURS_RUNE_BOMB`
* Add additional logic to `SyncPutItem()` to prevent erroneous item drops in Multiplayer when Hive or Crypt are opened
* Add logic to plrctrls.cpp `TryDropItem()` to check if the player is next to Hive or Crypt when dropping the Rune Bomb or Cathedral Map respectively

This resolves #2540 (Assuming all players are in town when the item drops; otherwise, see #3103)