### PR TITLE
Fix item morphing on Cornerstone of the World

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3540,9 +3540,9 @@ void CornerstoneSave()
 	if (!CornerStone.item.isEmpty()) {
 		ItemPack id;
 		PackItem(&id, &CornerStone.item);
-		const auto *buffer = reinterpret_cast<char *>(&id);
+		const auto *buffer = reinterpret_cast<uint8_t *>(&id);
 		for (size_t i = 0; i < sizeof(ItemPack); i++) {
-			sprintf(&sgOptions.Hellfire.szItem[i * 2], "%02X", buffer[i]);
+			snprintf(&sgOptions.Hellfire.szItem[i * 2], 3, "%02hhX", buffer[i]);
 		}
 	} else {
 		sgOptions.Hellfire.szItem[0] = '\0';


### PR DESCRIPTION
Item seed was getting corrupted when saving Cornerstone items due to the signed char data type.

For example, `0xB4` produces `-76` as a signed char. `sprintf()` with the `%02X` format specifier sign extends to produce `FFFFFFB4`. The additional characters after the first two were overwritten by subsequent bytes in the for loop so, presumably, every negative signed char value was ultimately encoded as `0xFF` instead of the intended value.