### PR TITLE
:bug: Adjust save buffer to a safe value

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1865,13 +1865,9 @@ void SaveHeroItems(Player &player)
 		SaveItem(file, item);
 }
 
-// 256 kilobytes + 3 bytes (demo leftover) for file magic (262147)
-// final game uses 4-byte magic instead of 3
-#define FILEBUFF ((256 * 1024) + 3)
-
 void SaveGameData()
 {
-	SaveHelper file("game", FILEBUFF);
+	SaveHelper file("game", 320 * 1024);
 
 	if (gbIsSpawn && !gbIsHellfire)
 		file.WriteLE<uint32_t>(LoadLE32("SHAR"));
@@ -2041,7 +2037,7 @@ void SaveLevel()
 
 	char szName[MAX_PATH];
 	GetTempLevelNames(szName);
-	SaveHelper file(szName, FILEBUFF);
+	SaveHelper file(szName, 256 * 1024);
 
 	if (leveltype != DTYPE_TOWN) {
 		for (int j = 0; j < MAXDUNY; j++) {


### PR DESCRIPTION
Save game data can overflow the save buffer. The buffer size is 262147 bytes, but a save can take up to 322586 bytes. In Hellfire the issue is more likely to happen as the save game can reach 327218, mostly because of additional item data.

This is most likely to happen at the start of a new level as killing monsters and picking up items will decrease the data size.

Leve saves are not affected as they only take 229KB