### PR TITLE
:bug: Don't follow stuck leader

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1923,7 +1923,8 @@ void GroupUnity(Monster &monster)
 	assert(monster._uniqtype == 0);
 
 	auto &leader = Monsters[monster.leader];
-	if (IsLineNotSolid(monster.position.tile, leader.position.future)) {
+	bool leaderIsStuck = leader._mmode == MonsterMode::Stand && !DirOK(monster.leader, monster._mdir);
+	if (!leaderIsStuck && IsLineNotSolid(monster.position.tile, leader.position.future)) {
 		if (monster.leaderRelation == LeaderRelation::Separated
 		    && monster.position.tile.WalkingDistance(leader.position.future) < 4) {
 			// Reunite the separated monster with the pack
@@ -4368,7 +4369,7 @@ void ProcessMonsters()
 				raflag = MonsterTalk(monster);
 				break;
 			}
-			if (raflag) {
+			if (raflag || monster._mmode == MonsterMode::Stand) {
 				GroupUnity(monster);
 			}
 		} while (raflag);


### PR DESCRIPTION
Fixes #2232

This causes minions to evaluate if there leader is stuck before continuing to follow it blindly. It is not uncommon for the leader to be temporary stuck for a split second, meaning that this change will cause some slight behavioral changes to groups in general where they will now prefer to move forward if their leader has yet to make up his mind. So groups are more prone to splitting up, however usually they will almost instantly regroup as the leader is rarely far behind.

For that reason I would prefer if we can have some play testing of this PR before it is merged, @Chance4us do you have time to do so?

Before:
![stuck](https://user-images.githubusercontent.com/204594/137177677-8f36524d-b539-42de-9d16-14474e753c81.gif)

After:
![free](https://user-images.githubusercontent.com/204594/137177760-6c657e3d-e42e-4e2a-9d77-540172bc634e.gif)