### PR TITLE
Introduce template specialisation for Enum as flags

### DIFF
--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "DiabloUI/art.h"
+#include "utils/enum_traits.h"
 #include "utils/stubs.h"
 
 namespace devilution {
@@ -60,6 +61,7 @@ enum class UiFlags {
 	TextCursor         = 1 << 27,
 	// clang-format on
 };
+use_enum_as_flags(UiFlags);
 
 enum class UiPanels {
 	Main,
@@ -68,41 +70,6 @@ enum class UiPanels {
 	Spell,
 	Inventory,
 };
-
-inline UiFlags operator|(UiFlags lhs, UiFlags rhs)
-{
-	using T = std::underlying_type_t<UiFlags>;
-	return static_cast<UiFlags>(static_cast<T>(lhs) | static_cast<T>(rhs));
-}
-
-inline UiFlags operator|=(UiFlags &lhs, UiFlags rhs)
-{
-	lhs = lhs | rhs;
-	return lhs;
-}
-
-inline UiFlags operator&(UiFlags lhs, UiFlags rhs)
-{
-	using T = std::underlying_type_t<UiFlags>;
-	return static_cast<UiFlags>(static_cast<T>(lhs) & static_cast<T>(rhs));
-}
-
-inline UiFlags operator&=(UiFlags &lhs, UiFlags rhs)
-{
-	lhs = lhs & rhs;
-	return lhs;
-}
-
-inline UiFlags operator~(UiFlags value)
-{
-	using T = std::underlying_type_t<UiFlags>;
-	return static_cast<UiFlags>(~static_cast<T>(value));
-}
-
-inline bool HasAnyOf(UiFlags lhs, UiFlags test)
-{
-	return (lhs & test) != UiFlags::None;
-}
 
 class UiItemBase {
 public:

--- a/Source/utils/enum_traits.h
+++ b/Source/utils/enum_traits.h
@@ -55,4 +55,54 @@ typename enum_values<T>::Iterator end(enum_values<T>)
 	return typename enum_values<T>::Iterator(static_cast<typename std::underlying_type<T>::type>(T::LAST) + 1);
 }
 
+template <typename>
+struct is_flags_enum : std::false_type {
+};
+
+#define use_enum_as_flags(Type)                   \
+	template <>                                   \
+	struct is_flags_enum<Type> : std::true_type { \
+	};
+
+template <typename EnumType, std::enable_if_t<std::is_enum<EnumType>::value && is_flags_enum<EnumType>::value, bool> = true>
+constexpr EnumType operator|(EnumType lhs, EnumType rhs)
+{
+	using T = std::underlying_type_t<EnumType>;
+	return static_cast<EnumType>(static_cast<T>(lhs) | static_cast<T>(rhs));
+}
+
+template <typename EnumType, std::enable_if_t<std::is_enum<EnumType>::value && is_flags_enum<EnumType>::value, bool> = true>
+constexpr EnumType operator|=(EnumType &lhs, EnumType rhs)
+{
+	lhs = lhs | rhs;
+	return lhs;
+}
+
+template <typename EnumType, std::enable_if_t<std::is_enum<EnumType>::value && is_flags_enum<EnumType>::value, bool> = true>
+constexpr EnumType operator&(EnumType lhs, EnumType rhs)
+{
+	using T = std::underlying_type_t<EnumType>;
+	return static_cast<EnumType>(static_cast<T>(lhs) & static_cast<T>(rhs));
+}
+
+template <typename EnumType, std::enable_if_t<std::is_enum<EnumType>::value && is_flags_enum<EnumType>::value, bool> = true>
+constexpr EnumType operator&=(EnumType &lhs, EnumType rhs)
+{
+	lhs = lhs & rhs;
+	return lhs;
+}
+
+template <typename EnumType, std::enable_if_t<std::is_enum<EnumType>::value && is_flags_enum<EnumType>::value, bool> = true>
+constexpr EnumType operator~(EnumType value)
+{
+	using T = std::underlying_type_t<EnumType>;
+	return static_cast<EnumType>(~static_cast<T>(value));
+}
+
+template <typename EnumType, std::enable_if_t<std::is_enum<EnumType>::value && is_flags_enum<EnumType>::value, bool> = true>
+constexpr bool HasAnyOf(EnumType lhs, EnumType test)
+{
+	return (lhs & test) != static_cast<EnumType>(0); // Some flags enums may not use a None value outside this check so we don't require an EnumType::None definition here.
+}
+
 } // namespace devilution


### PR DESCRIPTION
This allows marking an enum as being a collection of flags and supporting basic bitwise combinations/tests to see if a flag is set.