### PR TITLE
[Gamepad] Don't treat special cursors as items

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -655,7 +655,7 @@ void InvMove(AxisDirection dir)
 
 	Point mousePos = MousePosition;
 
-	const bool isHoldingItem = pcurs > 1;
+	const bool isHoldingItem = pcurs >= CURSOR_FIRSTITEM;
 
 	// normalize slots
 	if (Slot < 0)


### PR DESCRIPTION
Fixes the issue where gamepad users can't apply oils, repair skill, or recharge staff skill to equipped gear.

See: https://github.com/diasurgical/devilutionX/issues/2959#issuecomment-938949242