### PR TITLE
[Virtual Gamepad] Closing inventory drops item

### DIFF
--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -120,10 +120,16 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, Game
 			return true;
 		}
 		if (VirtualGamepadState.cancelButton.isHeld && VirtualGamepadState.cancelButton.didStateChange) {
-			if (inGameMenu || sbookflag)
+			if (inGameMenu || DoomFlag || spselflag)
 				*action = GameActionSendKey { DVL_VK_ESCAPE, false };
-			else if (DoomFlag || invflag || QuestLogIsOpen || chrflag || spselflag)
-				*action = GameActionSendKey { DVL_VK_SPACE, false };
+			else if (invflag)
+				*action = GameAction(GameActionType_TOGGLE_INVENTORY);
+			else if (sbookflag)
+				*action = GameAction(GameActionType_TOGGLE_SPELL_BOOK);
+			else if (QuestLogIsOpen)
+				*action = GameAction(GameActionType_TOGGLE_QUEST_LOG);
+			else if (chrflag)
+				*action = GameAction(GameActionType_TOGGLE_CHARACTER_INFO);
 			return true;
 		}
 		if (VirtualGamepadState.healthButton.isHeld && VirtualGamepadState.healthButton.didStateChange) {

--- a/Source/controls/touch/event_handlers.cpp
+++ b/Source/controls/touch/event_handlers.cpp
@@ -3,6 +3,7 @@
 #include "controls/touch/event_handlers.h"
 
 #include "control.h"
+#include "cursor.h"
 #include "diablo.h"
 #include "engine.h"
 #include "gmenu.h"
@@ -63,6 +64,9 @@ bool HandleSpeedbookInteraction(const SDL_Event &event)
 
 void HandleBottomPanelInteraction(const SDL_Event &event)
 {
+	if (pcurs >= CURSOR_FIRSTITEM)
+		return;
+
 	ClearPanBtn();
 
 	if (event.type != SDL_FINGERUP) {


### PR DESCRIPTION
This PR ensures that the player cannot close the inventory while holding an item.

* Prevents main panel interactions when an item is held
* Use `GameActionType_TOGGLE_INVENTORY` when pressing the gamepad's cancel button from the inventory so the item will automatically be dropped when the inventory is closed

---

Based on feedback from #2959
> It's possible to close the inventory while holding an item with out dropping it.