### PR TITLE
Load full width kerning programmatically

### DIFF
--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -29,7 +29,7 @@ namespace {
 std::unordered_map<uint32_t, Art> Fonts;
 std::unordered_map<uint32_t, std::array<uint8_t, 256>> FontKerns;
 std::array<int, 6> FontSizes = { 12, 24, 30, 42, 46, 22 };
-std::array<int, 6> FontFullwidth = { 16, 21, 29, 41, 43, 22 };
+std::array<uint8_t, 6> FontFullwidth = { 16, 21, 29, 41, 43, 22 };
 std::array<int, 6> LineHeights = { 12, 26, 38, 42, 50, 22 };
 std::array<int, 6> BaseLineOffset = { -3, -2, -3, -6, -7, 3 };
 


### PR DESCRIPTION
A lot of rows in Unicode uses full width for all symbols, generating the
data from code saves us almost 200kb of data files.