### PR TITLE
Use GitHub Actions for Android test builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,16 +40,6 @@ jobs:
       - run: /opt/devkitpro/portlibs/switch/bin/aarch64-none-elf-cmake -S. -Bbuild .. -DNIGHTLY_BUILD=ON
       - run: cmake --build build -j 2
       - store_artifacts: {path: ./build/devilutionx.nro, destination: devilutionx.nro}
-  android:
-    docker:
-      - image: circleci/android:api-28-ndk
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - run: sudo apt update -y
-      - run: sudo apt install -y g++ cmake ninja-build smpq
-      - run: cd android-project && ./gradlew assembleDebug
-      - store_artifacts: {path: ./android-project/app/build/outputs/apk/debug/app-debug.apk, destination: devilutionx-debug.apk}
   3ds:
     docker:
       - image: devkitpro/devkitarm:latest
@@ -95,7 +85,6 @@ workflows:
       - linux_x86_64
       - linux_x86_64_test
       - switch
-      - android
       - 3ds
       - amigaos-m68k
       - vita

--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -1,0 +1,47 @@
+name: Android
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [ opened, synchronize ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    
+    - name: set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+        cache: gradle
+
+    # CMake version 3.21.3 causes gradle to throw a NullPointerException during the build
+    # Removing it will cause gradle to fall back on 3.18.1 installed by the Android SDK
+    - name: Create Build Environment
+      run: rm /usr/local/bin/cmake
+
+    - name: Cache CMake build folder
+      uses: actions/cache@v2
+      with:
+        path: android-project/app/.cxx
+        key: android-cmake-${{ github.sha }}
+        restore-keys: android-cmake-
+      
+    - name: Build
+      working-directory: ${{github.workspace}}
+      shell: bash
+      run: cd android-project && ./gradlew assembleDebug
+
+    - name: Upload-Package
+      uses: actions/upload-artifact@v2
+      with:
+        name: devilutionx-debug.apk
+        path: android-project/app/build/outputs/apk/debug/app-debug.apk

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ If you want to help test the latest state of the next version you can fetch the 
 [![MacOSX](https://github.com/diasurgical/devilutionX/actions/workflows/MacOSX.yml/badge.svg)](https://github.com/diasurgical/devilutionX/actions/workflows/MacOSX.yml?query=branch%3Amaster)
 [![Windows x64](https://github.com/diasurgical/devilutionX/actions/workflows/Windows_x64.yml/badge.svg)](https://github.com/diasurgical/devilutionX/actions/workflows/Windows_x64.yml?query=branch%3Amaster)
 [![Windows x86](https://github.com/diasurgical/devilutionX/actions/workflows/Windows_x86.yml/badge.svg)](https://github.com/diasurgical/devilutionX/actions/workflows/Windows_x86.yml?query=branch%3Amaster)
+[![Android](https://github.com/diasurgical/devilutionX/actions/workflows/Android.yml/badge.svg)](https://github.com/diasurgical/devilutionX/actions/workflows/Android.yml?query=branch%3Amaster)
 
-Linux x86-64, Switch, Vita, 3DS, Amiga, Android [![CircleCI](https://circleci.com/gh/diasurgical/devilutionX.svg?style=shield)](https://app.circleci.com/pipelines/github/diasurgical/devilutionX?branch=master)
+Linux x86-64, Switch, Vita, 3DS, Amiga, [![CircleCI](https://circleci.com/gh/diasurgical/devilutionX.svg?style=shield)](https://app.circleci.com/pipelines/github/diasurgical/devilutionX?branch=master)
 
 MSVC [![AppVeyor](https://ci.appveyor.com/api/projects/status/1a0jus2372qvksht/branch/master?svg=true)](https://ci.appveyor.com/project/AJenbo/devilutionx)
 


### PR DESCRIPTION
This replaces the CircleCI job for Android with a GitHub Actions workflow.

If the Docker image layers are not already cached by the CircleCI runner, the CircleCI Docker image we use for Android builds requires over 3 GB of downloads. The download by itself takes more than 20 minutes on those runners, which causes that job to fail intermittently due to timeouts. The GitHub Actions runner is prebuilt with the dependencies we need to run the Android build so this should provide more stable performance characteristics.

Based on my limited testing so far, the build takes about 10-12 minutes, which is on par with CircleCI. Caching the `.cxx` folder seems to have reduced that to under 7 minutes in my trial run.