### PR TITLE
Switch to release for Android test builds

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -44,4 +44,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: devilutionx.apk
-        path: android-project/app/build/outputs/apk/release/app.apk
+        path: android-project/app/build/outputs/apk/release/app-release-unsigned.apk


### PR DESCRIPTION
Phones will not always allow the user to install a debug package, this should make it a lot easier to install the latest test build