### PR TITLE
:bug: Fix unique scavenger ai getting stuck

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -643,6 +643,25 @@ void LoadMonster(LoadHelper *file, Monster &monster)
 	SyncMonsterAnim(monster);
 }
 
+/**
+ * @brief Recalculate the pack size of monster group that may have underflown
+ */
+void SyncPackSize(Monster &leader)
+{
+	if (leader._uniqtype == 0)
+		return;
+	if (leader._mAi != AI_SCAV)
+		return;
+
+	leader.packsize = 0;
+
+	for (int i = 0; i < ActiveMonsterCount; i++) {
+		auto &minion = Monsters[ActiveMonsters[i]];
+		if (minion.leaderRelation == LeaderRelation::Leashed && &Monsters[minion.leader] == &leader)
+			leader.packsize++;
+	}
+}
+
 void LoadMissile(LoadHelper *file, Missile &missile)
 {
 	missile._mitype = static_cast<missile_id>(file->NextLE<int32_t>());
@@ -1733,6 +1752,8 @@ void LoadGame(bool firstflag)
 			monsterId = file.NextBE<int32_t>();
 		for (int i = 0; i < ActiveMonsterCount; i++)
 			LoadMonster(&file, Monsters[ActiveMonsters[i]]);
+		for (int i = 0; i < ActiveMonsterCount; i++)
+			SyncPackSize(Monsters[ActiveMonsters[i]]);
 		for (int &missileId : ActiveMissiles)
 			missileId = file.NextLE<int8_t>();
 		for (int &missileId : AvailableMissiles)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -2440,7 +2440,8 @@ void ScavengerAi(int i)
 		return;
 	if (monster._mhitpoints < (monster._mmaxhp / 2) && monster._mgoal != MGOAL_HEALING) {
 		if (monster.leaderRelation != LeaderRelation::None) {
-			Monsters[monster.leader].packsize--;
+			if (monster.leaderRelation == LeaderRelation::Leashed)
+				Monsters[monster.leader].packsize--;
 			monster.leaderRelation = LeaderRelation::None;
 		}
 		monster._mgoal = MGOAL_HEALING;


### PR DESCRIPTION
This fixes the issue where Spineater and Pulsecrawler will get stuck after one of there minions goes for a snack.

See #2232 for details