### PR TITLE
Fix hardware cursor gets white when switching game

### DIFF
--- a/Source/hwcursor.hpp
+++ b/Source/hwcursor.hpp
@@ -51,6 +51,11 @@ public:
 		return CursorInfo { CursorType::Game, gameSpriteId };
 	}
 
+	static CursorInfo UnknownCursor()
+	{
+		return CursorInfo { CursorType::Unknown };
+	}
+
 	[[nodiscard]] CursorType type() const
 	{
 		return type_;

--- a/Source/menu.cpp
+++ b/Source/menu.cpp
@@ -8,6 +8,7 @@
 #include "DiabloUI/extrasmenu.h"
 #include "DiabloUI/selok.h"
 #include "engine/demomode.h"
+#include "hwcursor.hpp"
 #include "init.h"
 #include "movie.h"
 #include "options.h"
@@ -193,6 +194,8 @@ void mainmenu_loop()
 			UiInitialize();
 			FreeItemGFX();
 			InitItemGFX();
+			if (IsHardwareCursor())
+				SetHardwareCursor(CursorInfo::UnknownCursor());
 			RefreshMusic();
 			menu = MAINMENU_NONE;
 			break;


### PR DESCRIPTION
Setting hardware cursor to `UnknownCursor` (is also the initial stat when loading the game) ensures that it's get reinitialized in `LoadBackgroundArt`.