### PR TITLE
Fix distributing stat points using gamepad

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1394,7 +1394,9 @@ void PerformPrimaryAction()
 	if (chrflag && !chrbtnactive && Players[MyPlayerId]._pStatPts > 0) {
 		CheckChrBtns();
 		for (int i = 0; i < 4; i++) {
-			if (ChrBtnsRect[i].Contains(MousePosition)) {
+			Rectangle button = ChrBtnsRect[i];
+			button.position = GetPanelPosition(UiPanels::Character, button.position);
+			if (button.Contains(MousePosition)) {
 				chrbtn[i] = true;
 				chrbtnactive = true;
 				ReleaseChrBtns(false);


### PR DESCRIPTION
Gamepad controls needed to call `GetPanelPosition()` to determine the actual location of char panel buttons. I guess this error wasn't apparent before #3152.