### PR TITLE
Allow to customize shown intro in diablo.ini

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -973,11 +973,15 @@ void DiabloSplash()
 	if (*sgOptions.StartUp.splash == StartUpSplash::LogoAndTitleDialog)
 		play_movie("gendata\\logo.smk", true);
 
-	if (gbIsHellfire && *sgOptions.Hellfire.intro) {
-		play_movie("gendata\\Hellfire.smk", true);
-	}
-	if (!gbIsHellfire && !gbIsSpawn && *sgOptions.Diablo.intro) {
-		play_movie("gendata\\diablo1.smk", true);
+	auto &intro = gbIsHellfire ? sgOptions.StartUp.hellfireIntro : sgOptions.StartUp.diabloIntro;
+
+	if (*intro != StartUpIntro::Off) {
+		if (gbIsHellfire)
+			play_movie("gendata\\Hellfire.smk", true);
+		else
+			play_movie("gendata\\diablo1.smk", true);
+		if (*intro == StartUpIntro::Once)
+			intro.SetValue(StartUpIntro::Off);
 	}
 
 	if (IsAnyOf(*sgOptions.StartUp.splash, StartUpSplash::TitleDialog, StartUpSplash::LogoAndTitleDialog))

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -970,7 +970,8 @@ void DiabloSplash()
 	if (!gbShowIntro)
 		return;
 
-	play_movie("gendata\\logo.smk", true);
+	if (*sgOptions.StartUp.splash == StartUpSplash::LogoAndTitleDialog)
+		play_movie("gendata\\logo.smk", true);
 
 	if (gbIsHellfire && *sgOptions.Hellfire.intro) {
 		play_movie("gendata\\Hellfire.smk", true);
@@ -979,7 +980,8 @@ void DiabloSplash()
 		play_movie("gendata\\diablo1.smk", true);
 	}
 
-	UiTitleDialog();
+	if (IsAnyOf(*sgOptions.StartUp.splash, StartUpSplash::TitleDialog, StartUpSplash::LogoAndTitleDialog))
+		UiTitleDialog();
 }
 
 void DiabloDeinit()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -565,6 +565,18 @@ string_view OptionCategoryBase::GetDescription() const
 
 StartUpOptions::StartUpOptions()
     : OptionCategoryBase("StartUp", N_("Start Up"), N_("Start Up Settings"))
+    , diabloIntro("Diablo Intro", OptionEntryFlags::OnlyDiablo, N_("Intro"), N_("Shown Intro cinematic."), StartUpIntro::Once,
+          {
+              { StartUpIntro::Off, N_("OFF") },
+              // Once is missing, cause we want to hide it from UI-Settings.
+              { StartUpIntro::On, N_("ON") },
+          })
+    , hellfireIntro("Hellfire Intro", OptionEntryFlags::OnlyHellfire, N_("Intro"), N_("Shown Intro cinematic."), StartUpIntro::Once,
+          {
+              { StartUpIntro::Off, N_("OFF") },
+              // Once is missing, cause we want to hide it from UI-Settings.
+              { StartUpIntro::On, N_("ON") },
+          })
     , splash("Splash", OptionEntryFlags::None, N_("Splash"), N_("Shown splash screen."), StartUpSplash::LogoAndTitleDialog,
           {
               { StartUpSplash::LogoAndTitleDialog, N_("Logo and Title Screen") },
@@ -576,32 +588,28 @@ StartUpOptions::StartUpOptions()
 std::vector<OptionEntryBase *> StartUpOptions::GetEntries()
 {
 	return {
+		&diabloIntro,
+		&hellfireIntro,
 		&splash,
 	};
 }
 
 DiabloOptions::DiabloOptions()
     : OptionCategoryBase("Diablo", N_("Diablo"), N_("Diablo specific Settings"))
-    , intro("Intro", OptionEntryFlags::OnlyDiablo, N_("Intro"), N_("Enable/disable Intro cinematic."), true)
 {
 }
 std::vector<OptionEntryBase *> DiabloOptions::GetEntries()
 {
-	return {
-		&intro,
-	};
+	return {};
 }
 
 HellfireOptions::HellfireOptions()
     : OptionCategoryBase("Hellfire", N_("Hellfire"), N_("Hellfire specific Settings"))
-    , intro("Intro", OptionEntryFlags::OnlyHellfire, N_("Intro"), N_("Enable/disable Intro cinematic."), true)
 {
 }
 std::vector<OptionEntryBase *> HellfireOptions::GetEntries()
 {
-	return {
-		&intro,
-	};
+	return {};
 }
 
 AudioOptions::AudioOptions()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -558,6 +558,23 @@ string_view OptionCategoryBase::GetDescription() const
 	return _(description.data());
 }
 
+StartUpOptions::StartUpOptions()
+    : OptionCategoryBase("StartUp", N_("Start Up"), N_("Start Up Settings"))
+    , splash("Splash", OptionEntryFlags::None, N_("Splash"), N_("Shown splash screen."), StartUpSplash::LogoAndTitleDialog,
+          {
+              { StartUpSplash::LogoAndTitleDialog, N_("Logo and Title Screen") },
+              { StartUpSplash::TitleDialog, N_("Title Screen") },
+              { StartUpSplash::None, N_("None") },
+          })
+{
+}
+std::vector<OptionEntryBase *> StartUpOptions::GetEntries()
+{
+	return {
+		&splash,
+	};
+}
+
 DiabloOptions::DiabloOptions()
     : OptionCategoryBase("Diablo", N_("Diablo"), N_("Diablo specific Settings"))
     , intro("Intro", OptionEntryFlags::OnlyDiablo, N_("Intro"), N_("Enable/disable Intro cinematic."), true)

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -513,6 +513,11 @@ void OptionEntryEnumBase::SaveToIni(string_view category) const
 {
 	SetIniValue(category.data(), key.data(), value);
 }
+void OptionEntryEnumBase::SetValueInternal(int value)
+{
+	this->value = value;
+	this->NotifyValueChanged();
+}
 void OptionEntryEnumBase::AddEntry(int value, string_view name)
 {
 	entryValues.push_back(value);

--- a/Source/options.h
+++ b/Source/options.h
@@ -16,6 +16,12 @@ enum class StartUpGameOption {
 	Diablo,
 };
 
+enum class StartUpIntro {
+	Off = 0,
+	Once = 1,
+	On = 2,
+};
+
 /** @brief Defines what splash screen should be shown at startup. */
 enum class StartUpSplash {
 	/** @brief Show no splash screen. */
@@ -197,6 +203,10 @@ struct StartUpOptions : OptionCategoryBase {
 	StartUpOptions();
 	std::vector<OptionEntryBase *> GetEntries() override;
 
+	/** @brief Play game intro video on diablo startup. */
+	OptionEntryEnum<StartUpIntro> diabloIntro;
+	/** @brief Play game intro video on hellfire startup. */
+	OptionEntryEnum<StartUpIntro> hellfireIntro;
 	OptionEntryEnum<StartUpSplash> splash;
 };
 
@@ -204,8 +214,6 @@ struct DiabloOptions : OptionCategoryBase {
 	DiabloOptions();
 	std::vector<OptionEntryBase *> GetEntries() override;
 
-	/** @brief Play game intro video on startup. */
-	OptionEntryBoolean intro;
 	/** @brief Remembers what singleplayer hero/save was last used. */
 	std::uint32_t lastSinglePlayerHero;
 	/** @brief Remembers what multiplayer hero/save was last used. */
@@ -216,8 +224,6 @@ struct HellfireOptions : OptionCategoryBase {
 	HellfireOptions();
 	std::vector<OptionEntryBase *> GetEntries() override;
 
-	/** @brief Play game intro video on startup. */
-	OptionEntryBoolean intro;
 	/** @brief Cornerstone of the world item. */
 	char szItem[sizeof(ItemPack) * 2 + 1];
 	/** @brief Remembers what singleplayer hero/save was last used. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -16,6 +16,16 @@ enum class StartUpGameOption {
 	Diablo,
 };
 
+/** @brief Defines what splash screen should be shown at startup. */
+enum class StartUpSplash {
+	/** @brief Show no splash screen. */
+	None = 0,
+	/** @brief Show only TitleDialog. */
+	TitleDialog = 1,
+	/** @brief Show Logo and TitleDialog. */
+	LogoAndTitleDialog = 2,
+};
+
 enum class ScalingQuality {
 	NearestPixel,
 	BilinearFiltering,
@@ -176,6 +186,13 @@ protected:
 	string_view key;
 	string_view name;
 	string_view description;
+};
+
+struct StartUpOptions : OptionCategoryBase {
+	StartUpOptions();
+	std::vector<OptionEntryBase *> GetEntries() override;
+
+	OptionEntryEnum<StartUpSplash> splash;
 };
 
 struct DiabloOptions : OptionCategoryBase {
@@ -366,6 +383,7 @@ struct LanguageOptions : OptionCategoryBase {
 };
 
 struct Options {
+	StartUpOptions StartUp;
 	DiabloOptions Diablo;
 	HellfireOptions Hellfire;
 	AudioOptions Audio;
@@ -379,6 +397,7 @@ struct Options {
 	[[nodiscard]] std::vector<OptionCategoryBase *> GetCategories()
 	{
 		return {
+			&StartUp,
 			&Diablo,
 			&Hellfire,
 			&Audio,

--- a/Source/options.h
+++ b/Source/options.h
@@ -147,6 +147,7 @@ protected:
 	{
 		return value;
 	}
+	void SetValueInternal(int value);
 
 	void AddEntry(int value, string_view name);
 
@@ -170,6 +171,10 @@ public:
 	[[nodiscard]] T operator*() const
 	{
 		return static_cast<T>(GetValueInternal());
+	}
+	void SetValue(T value)
+	{
+		SetValueInternal(static_cast<int>(value));
 	}
 };
 


### PR DESCRIPTION
Extend `Intro` option in `diablo.ini` with:

- **2**: No Intro  (equivalent to `-n` command line parameter)
- **3**: Show Title Dialog only (I like the title dialog 😉)

With this another alternative to command line arguments is present. This is relevant for platforms that don't support them (for example android).

Note: existing values (0 = no cinematic and 1 = initial show cinematic once (at first start)) stay the same for compatibility.