### PR TITLE
Ensure SFileSetAssetsPath is called before InsertCDDlg is called

### DIFF
--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -174,6 +174,7 @@ void init_archives()
 	// Load devilutionx.mpq first to get the font file for error messages
 	devilutionx_mpq = LoadMPQ(paths, "devilutionx.mpq");
 	font_mpq = LoadMPQ(paths, "fonts.mpq"); // Extra fonts
+	SFileSetAssetsPath(paths::AppPath() + "assets/");
 
 	if (strcasecmp("en", sgOptions.Language.szCode) != 0 || strlen(sgOptions.Language.szCode) != 2) {
 		char langMpqName[9] = {};
@@ -216,8 +217,6 @@ void init_archives()
 		UiErrorOkDialog(_("Some Hellfire MPQs are missing"), _("Not all Hellfire MPQs were found.\nPlease copy all the hf*.mpq files."));
 		app_fatal(nullptr);
 	}
-
-	SFileSetAssetsPath(paths::AppPath() + "assets/");
 }
 
 void init_create_window()


### PR DESCRIPTION
`devilutionx.mpq` is loaded first to ensure the fonts are present.
If `devilutionx.mpq` is not present, we use raw assets.
So we should also initialize the path to raw assets after we try to load `devilutionx.mpq`.
Fixes No-CD/Data Dialog with raw assets.