### PR TITLE
update vision of other players

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2742,7 +2742,7 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 
 	lrad = clamp(lrad, 2, 15);
 
-	if (player._pLightRad != lrad && &player == &Players[MyPlayerId]) {
+	if (player._pLightRad != lrad) {
 		ChangeLightRadius(player._plid, lrad);
 		ChangeVisionRadius(player._pvid, lrad);
 		player._pLightRad = lrad;


### PR DESCRIPTION
With this change I was aware of light radius/vision of players that weren't even on my level : )
Calling ChangeLightRadius for other players won't do anything because 
```cpp
void ChangeLightRadius(int i, int r)
{
	if (DisableLighting || i == NO_LIGHT) {
		return;
	}
```
and their light index is NO_LIGHT