### PR TITLE
fix bounds checks

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3184,10 +3184,7 @@ void CreatePlrItems(int playerId)
 
 bool ItemSpaceOk(Point position)
 {
-	int oi;
-
-	// BUGFIX: Check `i + 1 >= MAXDUNX` and `j + 1 >= MAXDUNY` (applied)
-	if (position.x < 0 || position.x + 1 >= MAXDUNX || position.y < 0 || position.y + 1 >= MAXDUNY)
+	if (!InDungeonBounds(position))
 		return false;
 
 	if (dMonster[position.x][position.y] != 0)
@@ -3200,7 +3197,7 @@ bool ItemSpaceOk(Point position)
 		return false;
 
 	if (dObject[position.x][position.y] != 0) {
-		oi = dObject[position.x][position.y] > 0 ? dObject[position.x][position.y] - 1 : -(dObject[position.x][position.y] + 1);
+		int oi = dObject[position.x][position.y] > 0 ? dObject[position.x][position.y] - 1 : -(dObject[position.x][position.y] + 1);
 		if (Objects[oi]._oSolidFlag)
 			return false;
 	}

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -648,7 +648,7 @@ void DoUnVision(Point position, int nRadius)
 void DoVision(Point position, int nRadius, bool doautomap, bool visible)
 {
 
-	if (position.x >= 0 && position.x <= MAXDUNX && position.y >= 0 && position.y <= MAXDUNY) {
+	if (InDungeonBounds(position)) {
 		if (doautomap) {
 			if (dFlags[position.x][position.y] != 0) {
 				SetAutomapView(position);

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -253,8 +253,7 @@ bool CanPlaceMonster(int xp, int yp)
 {
 	char f;
 
-	if (xp < 0 || xp >= MAXDUNX
-	    || yp < 0 || yp >= MAXDUNY
+	if (!InDungeonBounds({ xp, yp })
 	    || dMonster[xp][yp] != 0
 	    || dPlayer[xp][yp] != 0) {
 		return false;
@@ -2479,8 +2478,8 @@ void ScavengerAi(int i)
 				if (GenerateRnd(2) != 0) {
 					for (y = -4; y <= 4 && !done; y++) {
 						for (x = -4; x <= 4 && !done; x++) {
-							// BUGFIX: incorrect check of offset against limits of the dungeon
-							if (y < 0 || y >= MAXDUNY || x < 0 || x >= MAXDUNX)
+							// BUGFIX: incorrect check of offset against limits of the dungeon (fixed)
+							if (!InDungeonBounds(monster.position.tile + Displacement { x, y }))
 								continue;
 							done = dCorpse[monster.position.tile.x + x][monster.position.tile.y + y] != 0
 							    && IsLineNotSolid(
@@ -2493,8 +2492,8 @@ void ScavengerAi(int i)
 				} else {
 					for (y = 4; y >= -4 && !done; y--) {
 						for (x = 4; x >= -4 && !done; x--) {
-							// BUGFIX: incorrect check of offset against limits of the dungeon
-							if (y < 0 || y >= MAXDUNY || x < 0 || x >= MAXDUNX)
+							// BUGFIX: incorrect check of offset against limits of the dungeon (fixed)
+							if (!InDungeonBounds(monster.position.tile + Displacement { x, y }))
 								continue;
 							done = dCorpse[monster.position.tile.x + x][monster.position.tile.y + y] != 0
 							    && IsLineNotSolid(
@@ -4404,7 +4403,7 @@ bool DirOK(int i, Direction mdir)
 	auto &monster = Monsters[i];
 	Point position = monster.position.tile;
 	Point futurePosition = position + mdir;
-	if (futurePosition.y < 0 || futurePosition.y >= MAXDUNY || futurePosition.x < 0 || futurePosition.x >= MAXDUNX || !IsTileAvailable(monster, futurePosition))
+	if (!InDungeonBounds(futurePosition) || !IsTileAvailable(monster, futurePosition))
 		return false;
 	if (mdir == Direction::East) {
 		if (IsTileSolid(position + Direction::SouthEast))
@@ -4426,7 +4425,7 @@ bool DirOK(int i, Direction mdir)
 	int mcount = 0;
 	for (int x = futurePosition.x - 3; x <= futurePosition.x + 3; x++) {
 		for (int y = futurePosition.y - 3; y <= futurePosition.y + 3; y++) {
-			if (y < 0 || y >= MAXDUNY || x < 0 || x >= MAXDUNX)
+			if (!InDungeonBounds({ x, y }))
 				continue;
 			int mi = dMonster[x][y];
 			if (mi == 0)

--- a/Source/path.cpp
+++ b/Source/path.cpp
@@ -285,7 +285,7 @@ bool GetPath(const std::function<bool(Point)> &posOk, PATHNODE *pPath, Point des
 
 bool IsTileNotSolid(Point position)
 {
-	if (position.x < 0 || position.y < 0 || position.x >= MAXDUNX || position.y >= MAXDUNY) {
+	if (!InDungeonBounds(position)) {
 		return false;
 	}
 
@@ -294,7 +294,7 @@ bool IsTileNotSolid(Point position)
 
 bool IsTileSolid(Point position)
 {
-	if (position.x < 0 || position.y < 0 || position.x >= MAXDUNX || position.y >= MAXDUNY) {
+	if (!InDungeonBounds(position)) {
 		return false;
 	}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3369,7 +3369,7 @@ void ClrPlrPath(Player &player)
  */
 bool PosOkPlayer(const Player &player, Point position)
 {
-	if (position.x < 0 || position.x >= MAXDUNX || position.y < 0 || position.y >= MAXDUNY)
+	if (!InDungeonBounds(position))
 		return false;
 	if (dPiece[position.x][position.y] == 0)
 		return false;

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -95,9 +95,7 @@ std::unordered_multimap<Point, Missile *, PointHash> MissilesAtRenderingTile;
  */
 bool CouldMissileCollide(Point tile, bool checkPlayerAndMonster)
 {
-	if (tile.x >= MAXDUNX || tile.x < 0)
-		return true;
-	if (tile.y >= MAXDUNY || tile.y < 0)
+	if (!InDungeonBounds(tile))
 		return true;
 	if (checkPlayerAndMonster) {
 		if (dMonster[tile.x][tile.y] > 0)
@@ -931,7 +929,7 @@ void DrawFloor(const Surface &out, Point tilePosition, Point targetBufferPositio
 {
 	for (int i = 0; i < rows; i++) {
 		for (int j = 0; j < columns; j++) {
-			if (tilePosition.x >= 0 && tilePosition.x < MAXDUNX && tilePosition.y >= 0 && tilePosition.y < MAXDUNY) {
+			if (InDungeonBounds(tilePosition)) {
 				level_piece_id = dPiece[tilePosition.x][tilePosition.y];
 				if (level_piece_id != 0) {
 					if (!nSolidTable[level_piece_id])

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -18,7 +18,7 @@ namespace {
 
 void RepeatWalk(Player &player)
 {
-	if (cursPosition.x < 0 || cursPosition.x >= MAXDUNX - 1 || cursPosition.y < 0 || cursPosition.y >= MAXDUNY - 1)
+	if (!InDungeonBounds(cursPosition))
 		return;
 
 	if (player._pmode != PM_STAND && !(player.IsWalking() && player.AnimInfo.GetFrameToUseForRendering() > 6))


### PR DESCRIPTION
1. Fixes OOB in DoVision
2. Fixes scavenger AI to search for corpse in all directions, earlier the search area looked like this because of a bug (bounds were checked for offset, so only positive one passed = south direction)
3. Applies dungeon bounds function
![image](https://user-images.githubusercontent.com/14297035/138598702-6fdd370b-028d-4c17-8179-706ee98bda2f.png)
