### PR TITLE
Allow QuickMessages to contain multiple entries/lines 

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1237,12 +1237,16 @@ void DiabloHotkeyMsg(uint32_t dwMsg)
 
 	assert(dwMsg < QUICK_MESSAGE_OPTIONS);
 
-#ifdef _DEBUG
-	if (CheckDebugTextCommand(sgOptions.Chat.szHotKeyMsgs[dwMsg]))
-		return;
-#endif
+	for (auto &msg : sgOptions.Chat.szHotKeyMsgs[dwMsg]) {
 
-	NetSendCmdString(0xFFFFFF, sgOptions.Chat.szHotKeyMsgs[dwMsg]);
+#ifdef _DEBUG
+		if (CheckDebugTextCommand(msg))
+			continue;
+#endif
+		char charMsg[MAX_SEND_STR_LEN];
+		CopyUtf8(charMsg, msg, sizeof(charMsg));
+		NetSendCmdString(0xFFFFFF, charMsg);
+	}
 }
 
 void CloseGoldDrop()

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -929,10 +929,11 @@ void DiabloInit()
 	SetApplicationVersions();
 
 	for (size_t i = 0; i < QUICK_MESSAGE_OPTIONS; i++) {
-		if (strlen(sgOptions.Chat.szHotKeyMsgs[i]) != 0) {
+		auto &messages = sgOptions.Chat.szHotKeyMsgs[i];
+		if (messages.size() > 0) {
 			continue;
 		}
-		CopyUtf8(sgOptions.Chat.szHotKeyMsgs[i], _(QuickMessages[i].message), MAX_SEND_STR_LEN);
+		messages.emplace_back(_(QuickMessages[i].message));
 	}
 
 #ifdef VIRTUAL_GAMEPAD

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -348,7 +348,7 @@ void LoadOptions()
 	GetIniValue("Network", "Previous Host", sgOptions.Network.szPreviousHost, sizeof(sgOptions.Network.szPreviousHost), "");
 
 	for (size_t i = 0; i < QUICK_MESSAGE_OPTIONS; i++)
-		GetIniValue("NetMsg", QuickMessages[i].key, sgOptions.Chat.szHotKeyMsgs[i], MAX_SEND_STR_LEN, "");
+		GetIniStringVector("NetMsg", QuickMessages[i].key, sgOptions.Chat.szHotKeyMsgs[i]);
 
 	GetIniValue("Controller", "Mapping", sgOptions.Controller.szMapping, sizeof(sgOptions.Controller.szMapping), "");
 	sgOptions.Controller.bSwapShoulderButtonMode = GetIniBool("Controller", "Swap Shoulder Button Mode", false);

--- a/Source/options.h
+++ b/Source/options.h
@@ -420,7 +420,7 @@ struct ChatOptions : OptionCategoryBase {
 	std::vector<OptionEntryBase *> GetEntries() override;
 
 	/** @brief Quick chat messages. */
-	char szHotKeyMsgs[QUICK_MESSAGE_OPTIONS][MAX_SEND_STR_LEN];
+	std::vector<std::string> szHotKeyMsgs[QUICK_MESSAGE_OPTIONS];
 };
 
 struct LanguageOptions : OptionCategoryBase {


### PR DESCRIPTION
## Content
Allows QuickMessages to contain multiple lines that are executed as separated messages.

This is currently useful for two cases:

- Executes multiple debug commands in a batch (requested by @qndel)
- Show rules or other information in public server

## Example

```
[NetMsg]
QuickMessage1=Welcome to my server. There are rules you have to follow:
QuickMessage1=1. Be nice to each other.
QuickMessage1=2. Don't run the game in debug mode.
QuickMessage1=3. I'm the only one that is allowed to run debug commands!
QuickMessage2=god
QuickMessage2=changelevel 3
QuickMessage3=Here's something for you.
QuickMessage4=Now you DIE!
```

<details><summary>Video with example ini</summary>

First pressed F9/QuickMessage1 and after that F10/QuickMessage2.

https://user-images.githubusercontent.com/25415264/138610697-772e91b6-5089-429e-a1f5-c8076ca723dd.mp4

</details>

## Notes

- `SimpleIni` support `MultiKey` this is used for this feature. Enabling this feature requires passing `a_bForceReplace` if don't want multiple entries in the ini (normal settings). Enabling this feature could help for future improvements/pr (for example in keymapper, we could bind a action to multiple keys).
- Check for `MAX_SEND_STR_LEN` is moved from `LoadOptions` to `DiabloHotkeyMsg`.
- Tested:
   - default QuickMessages get generated
   - ensures `IniChangedChecker` still work
   - checked that `a_bForceReplace` works
   - checked that multiple QuickMessages works for multiple chat and debug commands (see video).