### PR TITLE
Disallow to swap gear while not standing/walking.

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -470,6 +470,9 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 	if (!done)
 		return;
 
+	if (player._pmode > PM_WALK3 && IsNoneOf(il, ILOC_UNEQUIPABLE, ILOC_BELT))
+		return;
+
 	if (pnum == MyPlayerId)
 		PlaySFX(ItemInvSnds[ItemCAnimTbl[player.HoldItem._iCurs]]);
 


### PR DESCRIPTION
Fixes #3216

Notes:
- In `CheckInvCut` there is a [check](https://github.com/diasurgical/devilutionX/blob/eba6d827bfe942d7b466128f8f0259ab53489ef1/Source/inv.cpp#L679) that disallows to take items from inventory when not walking/standing. This pr adds a similar check when putting/swapping items to inventory (`CheckInvPaste`).
- Putting the item in normal inventory is still allowed.
- Tested with swapping armor.