### PR TITLE
Support unencrypted multiplayer games with no password

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,14 +27,12 @@ option(BINARY_RELEASE "Enable options for binary release" OFF)
 option(NIGHTLY_BUILD "Enable options for nightly build" OFF)
 option(USE_SDL1 "Use SDL1.2 instead of SDL2" OFF)
 option(NONET "Disable network support" OFF)
+cmake_dependent_option(DISABLE_TCP "Disable TCP multiplayer option" OFF "NOT NONET" ON)
+cmake_dependent_option(DISABLE_ZERO_TIER "Disable ZeroTier multiplayer option" OFF "NOT NONET" ON)
+cmake_dependent_option(PACKET_ENCRYPTION "Encrypt network packets" ON "NOT NONET" OFF)
 option(NOSOUND "Disable sound support" OFF)
 option(RUN_TESTS "Build and run tests" OFF)
 option(ENABLE_CODECOVERAGE "Instrument code for code coverage (only enabled with RUN_TESTS)" OFF)
-
-if(NOT NONET)
-  option(DISABLE_TCP "Disable TCP multiplayer option" OFF)
-  option(DISABLE_ZERO_TIER "Disable ZeroTier multiplayer option" OFF)
-endif()
 
 option(DISABLE_STREAMING_MUSIC "Disable streaming music (to work around broken platform implementations)" OFF)
 mark_as_advanced(DISABLE_STREAMING_MUSIC)
@@ -65,6 +63,9 @@ if(NIGHTLY_BUILD OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
   set(CPACK ON)
 endif()
 
+if(PACKET_ENCRYPTION)
+  list(APPEND VCPKG_MANIFEST_FEATURES "encryption")
+endif()
 if(USE_GETTEXT_FROM_VCPKG)
   list(APPEND VCPKG_MANIFEST_FEATURES "translations")
 endif()
@@ -78,7 +79,7 @@ if(NOT NOSOUND)
                         "DEVILUTIONX_SYSTEM_SDL_AUDIOLIB AND NOT DIST" ON)
 endif()
 
-if(NOT NONET)
+if(PACKET_ENCRYPTION)
   option(DEVILUTIONX_SYSTEM_LIBSODIUM "Use system-provided libsodium" ON)
   cmake_dependent_option(DEVILUTIONX_STATIC_LIBSODIUM "Link static libsodium" OFF
                         "DEVILUTIONX_SYSTEM_LIBSODIUM AND NOT DIST" ON)
@@ -216,6 +217,13 @@ if(PIE)
   set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 endif()
 
+if(NONET)
+  # Fix dependent options if platform defs disable network
+  set(DISABLE_TCP ON)
+  set(DISABLE_ZERO_TIER ON)
+  set(PACKET_ENCRYPTION OFF)
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -227,7 +235,7 @@ if(NOT NINTENDO_3DS)
   find_package(Threads REQUIRED)
 endif()
 
-if(NOT NONET)
+if(PACKET_ENCRYPTION)
   if(DEVILUTIONX_SYSTEM_LIBSODIUM)
     set(sodium_USE_STATIC_LIBS ${DEVILUTIONX_STATIC_LIBSODIUM})
     find_package(sodium REQUIRED)
@@ -531,18 +539,26 @@ if(NINTENDO_SWITCH)
     Source/platform/switch/network.cpp
     Source/platform/switch/keyboard.cpp
     Source/platform/switch/docking.cpp
-    Source/platform/switch/random.cpp
     Source/platform/switch/asio/pause.c
     Source/platform/switch/asio/net/if.c
     Source/platform/switch/asio/sys/signal.c)
+
+  if(PACKET_ENCRYPTION)
+    list(APPEND libdevilutionx_SRCS
+      Source/platform/switch/random.cpp)
+  endif()
 endif()
 
 if(VITA)
   list(APPEND libdevilutionx_SRCS
-    Source/platform/vita/random.cpp
     Source/platform/vita/network.cpp
     Source/platform/vita/keyboard.cpp
     Source/platform/vita/touch.cpp)
+
+  if(PACKET_ENCRYPTION)
+    list(APPEND libdevilutionx_SRCS
+      Source/platform/vita/random.cpp)
+  endif()
 endif()
 
 if(NINTENDO_3DS)
@@ -551,13 +567,17 @@ if(NINTENDO_3DS)
     Source/platform/ctr/keyboard.cpp
     Source/platform/ctr/display.cpp
     Source/platform/ctr/messagebox.cpp
-    Source/platform/ctr/random.cpp
     Source/platform/ctr/sockets.cpp
     Source/platform/ctr/locale.cpp
     Source/platform/ctr/asio/net/if.c
     Source/platform/ctr/asio/sys/socket.c
     Source/platform/ctr/asio/sys/uio.c)
   set(BIN_TARGET ${BIN_TARGET}.elf)
+
+  if(PACKET_ENCRYPTION)
+    list(APPEND libdevilutionx_SRCS
+      Source/platform/ctr/random.cpp)
+  endif()
 endif()
 
 if(RUN_TESTS)
@@ -847,7 +867,9 @@ if(NOT NONET)
   if(NOT DISABLE_TCP)
     target_link_libraries(libdevilutionx PUBLIC asio)
   endif()
-  target_link_libraries(libdevilutionx PUBLIC sodium)
+  if(PACKET_ENCRYPTION)
+    target_link_libraries(libdevilutionx PUBLIC sodium)
+  endif()
 endif()
 
 target_link_libraries(libdevilutionx PUBLIC fmt::fmt)
@@ -874,6 +896,7 @@ foreach(
   GPERF_HEAP_MAIN
   GPERF_HEAP_FIRST_GAME_ITERATION
   STREAM_ALL_AUDIO
+  PACKET_ENCRYPTION
   VIRTUAL_GAMEPAD
 )
 if(${def_name})

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -64,6 +64,7 @@ bool UiItemsWraps;
 char *UiTextInput;
 int UiTextInputLen;
 bool textInputActive = true;
+bool allowEmptyTextInput = false;
 
 std::size_t SelectedItem = 0;
 
@@ -111,6 +112,7 @@ void UiInitList(int count, void (*fnFocus)(int value), void (*fnSelect)(int valu
 			auto *pItemUIEdit = static_cast<UiEdit *>(item.get());
 			SDL_SetTextInputRect(&item->m_rect);
 			textInputActive = true;
+			allowEmptyTextInput = pItemUIEdit->m_allowEmpty;
 #ifdef __SWITCH__
 			switch_start_text_input(pItemUIEdit->m_hint, pItemUIEdit->m_value, pItemUIEdit->m_max_length, /*multiline=*/0);
 #elif defined(__vita__)
@@ -425,7 +427,7 @@ void UiFocusNavigationSelect()
 {
 	UiPlaySelectSound();
 	if (textInputActive) {
-		if (strlen(UiTextInput) == 0) {
+		if (!allowEmptyTextInput && strlen(UiTextInput) == 0) {
 			return;
 		}
 #ifndef __SWITCH__

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -275,7 +275,7 @@ void SelheroClassSelectorSelect(int value)
 	vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Enter Name"), rect1, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
 	SDL_Rect rect2 = { (Sint16)(PANEL_LEFT + 265), (Sint16)(UI_OFFSET_Y + 317), 320, 33 };
-	vecSelDlgItems.push_back(std::make_unique<UiEdit>(_("Enter Name"), selhero_heroInfo.name, 15, rect2, UiFlags::FontSize24 | UiFlags::ColorUiGold));
+	vecSelDlgItems.push_back(std::make_unique<UiEdit>(_("Enter Name"), selhero_heroInfo.name, 15, false, rect2, UiFlags::FontSize24 | UiFlags::ColorUiGold));
 
 	SDL_Rect rect3 = { (Sint16)(PANEL_LEFT + 279), (Sint16)(UI_OFFSET_Y + 429), 140, 35 };
 	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect3, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -224,11 +224,12 @@ public:
 
 class UiEdit : public UiItemBase {
 public:
-	UiEdit(const char *hint, char *value, std::size_t max_length, SDL_Rect rect, UiFlags flags = UiFlags::None)
+	UiEdit(const char *hint, char *value, std::size_t max_length, bool allowEmpty, SDL_Rect rect, UiFlags flags = UiFlags::None)
 	    : UiItemBase(UiType::Edit, rect, flags)
 	    , m_hint(hint)
 	    , m_value(value)
 	    , m_max_length(max_length)
+	    , m_allowEmpty(allowEmpty)
 	{
 	}
 
@@ -236,6 +237,7 @@ public:
 	const char *m_hint;
 	char *m_value;
 	std::size_t m_max_length;
+	bool m_allowEmpty;
 };
 
 //=============================================================================

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -466,11 +466,12 @@ void DrawAutomapText(const Surface &out)
 			linePosition.y += 15;
 		}
 
-		if (szPlayerDescript[0] != '\0') {
+		if (!PublicGame)
 			strcat(strcpy(desc, _("password: ")), szPlayerDescript);
-			DrawString(out, desc, linePosition);
-			linePosition.y += 15;
-		}
+		else
+			strcpy(desc, _("Public Game"));
+		DrawString(out, desc, linePosition);
+		linePosition.y += 15;
 	}
 
 	if (setlevel) {

--- a/Source/dvlnet/abstract_net.h
+++ b/Source/dvlnet/abstract_net.h
@@ -22,8 +22,8 @@ public:
 
 class abstract_net {
 public:
-	virtual int create(std::string addrstr, std::string passwd) = 0;
-	virtual int join(std::string addrstr, std::string passwd) = 0;
+	virtual int create(std::string addrstr) = 0;
+	virtual int join(std::string addrstr) = 0;
 	virtual bool SNetReceiveMessage(int *sender, void **data, uint32_t *size) = 0;
 	virtual bool SNetSendMessage(int dest, void *data, unsigned int size) = 0;
 	virtual bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status) = 0;
@@ -41,6 +41,10 @@ public:
 	virtual std::string make_default_gamename() = 0;
 
 	virtual void setup_password(std::string passwd)
+	{
+	}
+
+	virtual void clear_password()
 	{
 	}
 

--- a/Source/dvlnet/base.cpp
+++ b/Source/dvlnet/base.cpp
@@ -17,6 +17,11 @@ void base::setup_password(std::string pw)
 	pktfty = std::make_unique<packet_factory>(pw);
 }
 
+void base::clear_password()
+{
+	pktfty = std::make_unique<packet_factory>();
+}
+
 void base::RunEventHandler(_SNETEVENT &ev)
 {
 	auto f = registered_handlers[static_cast<event_type>(ev.eventid)];

--- a/Source/dvlnet/base.h
+++ b/Source/dvlnet/base.h
@@ -14,8 +14,8 @@ namespace net {
 
 class base : public abstract_net {
 public:
-	virtual int create(std::string addrstr, std::string passwd) = 0;
-	virtual int join(std::string addrstr, std::string passwd) = 0;
+	virtual int create(std::string addrstr) = 0;
+	virtual int join(std::string addrstr) = 0;
 
 	virtual bool SNetReceiveMessage(int *sender, void **data, uint32_t *size);
 	virtual bool SNetSendMessage(int playerId, void *data, unsigned int size);
@@ -37,6 +37,7 @@ public:
 	void setup_gameinfo(buffer_t info);
 
 	virtual void setup_password(std::string pw);
+	virtual void clear_password();
 
 	virtual ~base() = default;
 

--- a/Source/dvlnet/base_protocol.h
+++ b/Source/dvlnet/base_protocol.h
@@ -16,8 +16,8 @@ namespace net {
 template <class P>
 class base_protocol : public base {
 public:
-	virtual int create(std::string addrstr, std::string passwd);
-	virtual int join(std::string addrstr, std::string passwd);
+	virtual int create(std::string addrstr);
+	virtual int join(std::string addrstr);
 	virtual void poll();
 	virtual void send(packet &pkt);
 	virtual void DisconnectNet(plr_t plr);
@@ -108,8 +108,7 @@ void base_protocol<P>::send_info_request()
 template <class P>
 void base_protocol<P>::wait_join()
 {
-	randombytes_buf(reinterpret_cast<unsigned char *>(&cookie_self),
-	    sizeof(cookie_t));
+	cookie_self = packet_out::GenerateCookie();
 	auto pkt = pktfty->make_packet<PT_JOIN_REQUEST>(PLR_BROADCAST,
 	    PLR_MASTER, cookie_self, game_init_info);
 	proto.send(firstpeer, pkt->Data());
@@ -122,9 +121,8 @@ void base_protocol<P>::wait_join()
 }
 
 template <class P>
-int base_protocol<P>::create(std::string addrstr, std::string passwd)
+int base_protocol<P>::create(std::string addrstr)
 {
-	setup_password(passwd);
 	gamename = addrstr;
 
 	if (wait_network()) {
@@ -136,10 +134,8 @@ int base_protocol<P>::create(std::string addrstr, std::string passwd)
 }
 
 template <class P>
-int base_protocol<P>::join(std::string addrstr, std::string passwd)
+int base_protocol<P>::join(std::string addrstr)
 {
-	//addrstr = "fd80:56c2:e21c:0:199:931d:b14:c4d2";
-	setup_password(passwd);
 	gamename = addrstr;
 	if (wait_network())
 		if (wait_firstpeer())

--- a/Source/dvlnet/loopback.cpp
+++ b/Source/dvlnet/loopback.cpp
@@ -5,12 +5,12 @@
 namespace devilution {
 namespace net {
 
-int loopback::create(std::string /*addrstr*/, std::string /*passwd*/)
+int loopback::create(std::string /*addrstr*/)
 {
 	return plr_single;
 }
 
-int loopback::join(std::string /*addrstr*/, std::string /*passwd*/)
+int loopback::join(std::string /*addrstr*/)
 {
 	ABORT();
 }

--- a/Source/dvlnet/loopback.h
+++ b/Source/dvlnet/loopback.h
@@ -20,8 +20,8 @@ public:
 		plr_single = 0;
 	};
 
-	virtual int create(std::string addrstr, std::string passwd);
-	virtual int join(std::string addrstr, std::string passwd);
+	virtual int create(std::string addrstr);
+	virtual int join(std::string addrstr);
 	virtual bool SNetReceiveMessage(int *sender, void **data, uint32_t *size);
 	virtual bool SNetSendMessage(int dest, void *data, unsigned int size);
 	virtual bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status);

--- a/Source/dvlnet/tcp_client.cpp
+++ b/Source/dvlnet/tcp_client.cpp
@@ -6,7 +6,6 @@
 #include <exception>
 #include <functional>
 #include <memory>
-#include <sodium.h>
 #include <sstream>
 #include <stdexcept>
 #include <system_error>
@@ -16,24 +15,23 @@
 namespace devilution {
 namespace net {
 
-int tcp_client::create(std::string addrstr, std::string passwd)
+int tcp_client::create(std::string addrstr)
 {
 	try {
 		auto port = sgOptions.Network.nPort;
-		local_server = std::make_unique<tcp_server>(ioc, addrstr, port, passwd);
-		return join(local_server->LocalhostSelf(), passwd);
+		local_server = std::make_unique<tcp_server>(ioc, addrstr, port, *pktfty);
+		return join(local_server->LocalhostSelf());
 	} catch (std::system_error &e) {
 		SDL_SetError("%s", e.what());
 		return -1;
 	}
 }
 
-int tcp_client::join(std::string addrstr, std::string passwd)
+int tcp_client::join(std::string addrstr)
 {
 	constexpr int MsSleep = 10;
 	constexpr int NoSleep = 250;
 
-	setup_password(passwd);
 	try {
 		std::stringstream port;
 		port << sgOptions.Network.nPort;
@@ -46,8 +44,7 @@ int tcp_client::join(std::string addrstr, std::string passwd)
 	}
 	StartReceive();
 	{
-		randombytes_buf(reinterpret_cast<unsigned char *>(&cookie_self),
-		    sizeof(cookie_t));
+		cookie_self = packet_out::GenerateCookie();
 		auto pkt = pktfty->make_packet<PT_JOIN_REQUEST>(PLR_BROADCAST,
 		    PLR_MASTER, cookie_self,
 		    game_init_info);

--- a/Source/dvlnet/tcp_client.h
+++ b/Source/dvlnet/tcp_client.h
@@ -17,8 +17,8 @@ namespace net {
 
 class tcp_client : public base {
 public:
-	int create(std::string addrstr, std::string passwd);
-	int join(std::string addrstr, std::string passwd);
+	int create(std::string addrstr);
+	int join(std::string addrstr);
 
 	virtual void poll();
 	virtual void send(packet &pkt);

--- a/Source/dvlnet/tcp_server.cpp
+++ b/Source/dvlnet/tcp_server.cpp
@@ -12,9 +12,9 @@ namespace devilution {
 namespace net {
 
 tcp_server::tcp_server(asio::io_context &ioc, const std::string &bindaddr,
-    unsigned short port, std::string pw)
+    unsigned short port, packet_factory &pktfty)
     : ioc(ioc)
-    , pktfty(std::move(pw))
+    , pktfty(pktfty)
 {
 	auto addr = asio::ip::address::from_string(bindaddr);
 	auto ep = asio::ip::tcp::endpoint(addr, port);

--- a/Source/dvlnet/tcp_server.h
+++ b/Source/dvlnet/tcp_server.h
@@ -26,7 +26,7 @@ public:
 class tcp_server {
 public:
 	tcp_server(asio::io_context &ioc, const std::string &bindaddr,
-	    unsigned short port, std::string pw);
+	    unsigned short port, packet_factory &pktfty);
 	std::string LocalhostSelf();
 	void Close();
 	virtual ~tcp_server();
@@ -52,7 +52,7 @@ private:
 	typedef std::shared_ptr<client_connection> scc;
 
 	asio::io_context &ioc;
-	packet_factory pktfty;
+	packet_factory &pktfty;
 	std::unique_ptr<asio::ip::tcp::acceptor> acceptor;
 	std::array<scc, MAX_PLRS> connections;
 	buffer_t game_init_info;

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -51,6 +51,7 @@ DWORD sgdwGameLoops;
 bool gbIsMultiplayer;
 bool sgbTimeout;
 char szPlayerName[128];
+bool PublicGame;
 BYTE gbDeltaSender;
 bool sgbNetInited;
 uint32_t player_state[MAX_PLRS];
@@ -752,6 +753,7 @@ bool NetInit(bool bSinglePlayer)
 		nthread_terminate_game("SNetGetGameInfo1");
 	if (!SNetGetGameInfo(GAMEINFO_PASSWORD, szPlayerDescript, 128))
 		nthread_terminate_game("SNetGetGameInfo2");
+	PublicGame = DvlNet_IsPublicGame();
 
 	return true;
 }

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -45,6 +45,7 @@ extern GameData sgGameInitInfo;
 extern bool gbSelectProvider;
 extern bool gbIsMultiplayer;
 extern char szPlayerName[128];
+extern bool PublicGame;
 extern BYTE gbDeltaSender;
 extern uint32_t player_state[MAX_PLRS];
 

--- a/Source/storm/storm.h
+++ b/Source/storm/storm.h
@@ -296,5 +296,7 @@ void DvlNet_SendInfoRequest();
 void DvlNet_ClearGamelist();
 std::vector<std::string> DvlNet_GetGamelist();
 void DvlNet_SetPassword(std::string pw);
+void DvlNet_ClearPassword();
+bool DvlNet_IsPublicGame();
 
 } // namespace devilution

--- a/Source/storm/storm_net.cpp
+++ b/Source/storm/storm_net.cpp
@@ -16,6 +16,7 @@ namespace devilution {
 static std::unique_ptr<net::abstract_net> dvlnet_inst;
 static char gpszGameName[128] = {};
 static char gpszGamePassword[128] = {};
+static bool GameIsPublic = {};
 
 #ifndef NONET
 static SdlMutex storm_net_mutex;
@@ -165,8 +166,10 @@ bool SNetCreateGame(const char *pszGameName, const char *pszGamePassword, char *
 
 	strncpy(gpszGameName, pszGameName, sizeof(gpszGameName) - 1);
 	if (pszGamePassword != nullptr)
-		strncpy(gpszGamePassword, pszGamePassword, sizeof(gpszGamePassword) - 1);
-	*playerID = dvlnet_inst->create(pszGameName, pszGamePassword);
+		DvlNet_SetPassword(pszGamePassword);
+	else
+		DvlNet_ClearPassword();
+	*playerID = dvlnet_inst->create(pszGameName);
 	return *playerID != -1;
 }
 
@@ -178,8 +181,10 @@ bool SNetJoinGame(char *pszGameName, char *pszGamePassword, int *playerID)
 	if (pszGameName != nullptr)
 		strncpy(gpszGameName, pszGameName, sizeof(gpszGameName) - 1);
 	if (pszGamePassword != nullptr)
-		strncpy(gpszGamePassword, pszGamePassword, sizeof(gpszGamePassword) - 1);
-	*playerID = dvlnet_inst->join(pszGameName, pszGamePassword);
+		DvlNet_SetPassword(pszGamePassword);
+	else
+		DvlNet_ClearPassword();
+	*playerID = dvlnet_inst->join(pszGameName);
 	return *playerID != -1;
 }
 
@@ -230,7 +235,21 @@ std::vector<std::string> DvlNet_GetGamelist()
 
 void DvlNet_SetPassword(std::string pw)
 {
+	GameIsPublic = false;
+	strncpy(gpszGamePassword, pw.c_str(), sizeof(gpszGamePassword) - 1);
 	dvlnet_inst->setup_password(std::move(pw));
+}
+
+void DvlNet_ClearPassword()
+{
+	GameIsPublic = true;
+	gpszGamePassword[0] = '\0';
+	dvlnet_inst->clear_password();
+}
+
+bool DvlNet_IsPublicGame()
+{
+	return GameIsPublic;
 }
 
 } // namespace devilution

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,10 +4,13 @@
     "dependencies": [
         "fmt",
         "libpng",
-        "libsodium",
         "sdl2"
     ],
     "features": {
+        "encryption": {
+            "description": "Build libsodium for packet encryption",
+            "dependencies": [ "libsodium" ]
+        },
         "translations": {
             "description": "Build translation files",
             "dependencies": [


### PR DESCRIPTION
There wasn't really a good way to break this into separate commits without leaving something broken so here's a general list of changes that will hopefully aid reviewers.

* Add "Create Public Game" option to the multiplayer menus
  * This skips password field entry
  * Only public games show up in the ZeroTier game list
* Add `m_allowEmpty` flag to `UiEdit`
  * To join a TCP public game (there is no game list), leave the password field blank
* Display "Public Game" instead of password in top-left corner when automap is enabled in a public game
* Don't use encryption for public games
* Add CMake option for `PACKET_ENCRYPTION` to enable builds that only support public games (Multiplayer without libsodium)
  * Add a `cookie_generator` class to be used in place of libsodium when packet encryption is disabled