### PR TITLE
[Gamepad] Use secondary action button to apply oils

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1549,7 +1549,12 @@ void CtrlUseInvItem()
 void PerformSecondaryAction()
 {
 	if (invflag) {
-		CtrlUseInvItem();
+		if (pcurs > CURSOR_HAND && pcurs < CURSOR_FIRSTITEM) {
+			TryIconCurs();
+			NewCursor(CURSOR_HAND);
+		} else {
+			CtrlUseInvItem();
+		}
 		return;
 	}
 


### PR DESCRIPTION
After using an oil or the Repair/Staff Recharge skill, the secondary action is made to apply the oil or skill to the item under the cursor instead of attempting to use or auto-equip the item under the cursor.

Based on feedback from https://github.com/diasurgical/devilutionX/issues/2959#issuecomment-938949242

FYI, the spell action button already had this logic.