### PR TITLE
chatlog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,6 +469,7 @@ set(libdevilutionx_SRCS
   Source/qol/common.cpp
   Source/qol/monhealthbar.cpp
   Source/qol/xpbar.cpp
+  Source/qol/chatlog.cpp
   Source/qol/itemlabels.cpp
   Source/utils/console.cpp
   Source/utils/display.cpp

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -53,6 +53,7 @@
 #include "pfile.h"
 #include "plrmsg.h"
 #include "qol/common.h"
+#include "qol/chatlog.h"
 #include "qol/itemlabels.h"
 #include "restrict.h"
 #include "setmaps.h"
@@ -1491,6 +1492,12 @@ void InitKeymapActions()
 	    DVL_VK_INVALID,
 	    [] { Players[MyPlayerId].Stop(); },
 	    [&]() { return !IsPlayerDead(); },
+	});
+	keymapper.AddAction({
+	    "ChatLog",
+	    'L',
+	    [] { ToggleChatLog(); },
+	    [&]() { return gbIsMultiplayer; },
 	});
 #ifdef _DEBUG
 	keymapper.AddAction({

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1665,7 +1665,7 @@ DWORD OnPlayerJoinLevel(const TCmd *pCmd, int pnum)
 		ResetPlayerGFX(player);
 		player.plractive = true;
 		gbActivePlayers++;
-		EventPlrMsg(fmt::format(_("Player '{:s}' (level {:d}) just joined the game"), player._pName, player._pLevel).c_str());
+		EventPlrMsg(pnum, fmt::format(_("Player '{:s}' (level {:d}) just joined the game"), player._pName, player._pLevel).c_str());
 	}
 
 	if (player.plractive && MyPlayerId != pnum) {

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -19,6 +19,7 @@
 #include "options.h"
 #include "pfile.h"
 #include "plrmsg.h"
+#include "qol/chatlog.h"
 #include "storm/storm_net.hpp"
 #include "sync.h"
 #include "tmsg.h"
@@ -202,7 +203,7 @@ void PlayerLeftMsg(int pnum, bool left)
 			pszFmt = _("Player '{:s}' dropped due to timeout");
 			break;
 		}
-		EventPlrMsg(fmt::format(pszFmt, player._pName).c_str());
+		EventPlrMsg(pnum, fmt::format(pszFmt, player._pName).c_str());
 	}
 	player.plractive = false;
 	player._pName[0] = '\0';
@@ -754,6 +755,11 @@ bool NetInit(bool bSinglePlayer)
 		nthread_terminate_game("SNetGetGameInfo2");
 	PublicGame = DvlNet_IsPublicGame();
 
+	auto &myPlayer = Players[MyPlayerId];
+	// separator for marking messages from a different game
+	AddMessageToChatLog(MyPlayerId, "===========================================================================", true);
+	AddMessageToChatLog(MyPlayerId, fmt::format(_("Player '{:s}' (level {:d}) just joined the game"), myPlayer._pName, myPlayer._pLevel).c_str(), true);
+
 	return true;
 }
 
@@ -805,7 +811,7 @@ void recv_plrinfo(int pnum, const TCmdPlrInfoHdr &header, bool recv)
 	} else {
 		szEvent = _("Player '{:s}' (level {:d}) is already in the game");
 	}
-	EventPlrMsg(fmt::format(szEvent, player._pName, player._pLevel).c_str());
+	EventPlrMsg(pnum, fmt::format(szEvent, player._pName, player._pLevel).c_str());
 
 	SyncInitPlr(pnum);
 

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -10,6 +10,7 @@
 #include "control.h"
 #include "engine/render/text_render.hpp"
 #include "inv.h"
+#include "qol/chatlog.h"
 #include "utils/language.h"
 
 namespace devilution {
@@ -61,8 +62,9 @@ void ErrorPlrMsg(const char *pszMsg)
 	pMsg->str[sizeof(pMsg->str) - 1] = '\0';
 }
 
-size_t EventPlrMsg(const char *pszFmt, ...)
+size_t EventPlrMsg(int pnum, const char *pszFmt, ...)
 {
+	AddMessageToChatLog(pnum, pszFmt, true);
 	_plrmsg *pMsg;
 	va_list va;
 
@@ -86,6 +88,7 @@ void SendPlrMsg(int pnum, const char *pszStr)
 	assert(strlen(player._pName) < PLR_NAME_LEN);
 	assert(strlen(pszStr) < MAX_SEND_STR_LEN);
 	strcpy(pMsg->str, fmt::format(_("{:s} (lvl {:d}): {:s}"), player._pName, player._pLevel, pszStr).c_str());
+	AddMessageToChatLog(pnum, pszStr);
 }
 
 void ClearPlrMsg()
@@ -120,6 +123,9 @@ void DrawPlrMsg(const Surface &out)
 		width -= gnScreenWidth - RightPanel.position.x;
 
 	if (width < 300)
+		return;
+
+	if (IsChatLogEnabled())
 		return;
 
 	pMsg = plr_msgs;

--- a/Source/plrmsg.h
+++ b/Source/plrmsg.h
@@ -20,7 +20,7 @@ struct _plrmsg {
 
 void plrmsg_delay(bool delay);
 void ErrorPlrMsg(const char *pszMsg);
-size_t EventPlrMsg(const char *pszFmt, ...);
+size_t EventPlrMsg(int pnum, const char *pszFmt, ...);
 void SendPlrMsg(int pnum, const char *pszStr);
 void ClearPlrMsg();
 void InitPlrMsg();

--- a/Source/qol/chatlog.cpp
+++ b/Source/qol/chatlog.cpp
@@ -1,0 +1,39 @@
+#include "chatlog.h"
+
+#include <string>
+#include <vector>
+
+#include "stores.h"
+
+namespace devilution {
+
+std::vector<PlayerMessage> ChatLogMessages;
+
+bool IsChatLogEnabled()
+{
+	return stextflag == STORE_CHATLOG;
+}
+
+void ToggleChatLog()
+{
+	if (stextflag == STORE_CHATLOG) {
+		StoreESC();
+	} else if (!ChatLogMessages.empty())
+		StartStore(STORE_CHATLOG);
+}
+
+void AddMessageToChatLog(int pnum, const char *message, bool systemMessage)
+{
+	auto &player = Players[pnum];
+
+	PlayerMessage msg;
+	msg.sender = player._pName;
+	msg.text = message;
+	msg.level = player._pLevel;
+	msg.myMessage = pnum == MyPlayerId;
+	msg.timestamp = time(nullptr);
+	msg.systemMessage = systemMessage;
+	ChatLogMessages.push_back(msg);
+}
+
+} // namespace devilution

--- a/Source/qol/chatlog.h
+++ b/Source/qol/chatlog.h
@@ -1,0 +1,31 @@
+/**
+* @file chatlog.h
+*
+* Adds ChatLog QoL feature
+*/
+#pragma once
+#include <ctime>
+#include <string>
+#include <vector>
+
+#include "engine.h"
+#include "player.h"
+
+namespace devilution {
+
+struct PlayerMessage {
+	std::string sender;
+	std::string text;
+	int level;
+	bool myMessage;
+	time_t timestamp;
+	bool systemMessage;
+};
+
+extern std::vector<PlayerMessage> ChatLogMessages;
+
+bool IsChatLogEnabled();
+void ToggleChatLog();
+void AddMessageToChatLog(int pnum, const char *message, bool systemMessage = false);
+
+} // namespace devilution

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -42,6 +42,7 @@ enum talk_id : uint8_t {
 	STORE_TAVERN,
 	STORE_DRUNK,
 	STORE_BARMAID,
+	STORE_CHATLOG,
 };
 
 struct STextStruct {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14297035/138830910-004385a6-5ce4-46f2-b640-e2830ada0157.png)

Fully functional.
Disables showing standard chat on screen while active - otherwise messages could overlap and cause a mess.
Updates dynamically when someone writes something and you got chatlog open


![scrollchat](https://user-images.githubusercontent.com/14297035/138837093-f2b2af23-6cce-49a2-8c27-594c0729bd6c.gif)
Keeps messages between games - lets you read the chat later if you get booted out of the game for example, different games are separated with "============" message

