### PR TITLE
Use a temporary seed for RNG when operating fountains

### DIFF
--- a/Source/engine/random.cpp
+++ b/Source/engine/random.cpp
@@ -47,4 +47,15 @@ int32_t GenerateRnd(int32_t v)
 	return AdvanceRndSeed() % v;
 }
 
+TemporarySeed::TemporarySeed(uint32_t seed)
+{
+	OriginalSeed = sglGameSeed;
+	SetRndSeed(seed);
+}
+
+TemporarySeed::~TemporarySeed()
+{
+	SetRndSeed(OriginalSeed);
+}
+
 } // namespace devilution

--- a/Source/engine/random.hpp
+++ b/Source/engine/random.hpp
@@ -73,4 +73,16 @@ const T PickRandomlyAmong(const std::initializer_list<T> &values)
 	return *(values.begin() + index);
 }
 
+/**
+ * @brief Temporarily seeds the random number generator until the temporary seed goes out of scope.
+*/
+class TemporarySeed {
+public:
+	TemporarySeed(uint32_t seed);
+	~TemporarySeed();
+
+private:
+	uint32_t OriginalSeed;
+};
+
 } // namespace devilution

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3871,7 +3871,7 @@ bool OperateFountains(int pnum, int i)
 {
 	auto &player = Players[pnum];
 	bool applied = false;
-	SetRndSeed(Objects[i]._oRndSeed);
+	TemporarySeed temporarySeed(Objects[i]._oRndSeed);
 	switch (Objects[i]._otype) {
 	case OBJ_BLOODFTN:
 		if (deltaload)


### PR DESCRIPTION
* Based on @qndel's suggestion, implement a class for RAII to temporarily override the current seed
* Use a temporary seed in `OperateFountains()` so that using the fountain doesn't overwrite engine RNG

I noticed when testing #3219 that spamming the Blood Fountain caused all the randomness in monster attack frequency, hit rate, and block chance to go away. It seems that Fountain of Tears captures a seed to provide predictable behavior when used regardless of the current state of the engine's RNG, but the call to `SetRndSeed()` doesn't discriminate based on the type of fountain. Even if it did discriminate, using a Fountain of Tears would overwrite RNG state. It makes more sense to use a temporary seed here.