### PR TITLE
Check for null spells

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1220,7 +1220,7 @@ void CheckPanelInfo()
 		AddPanelString(tempstr);
 		auto &myPlayer = Players[MyPlayerId];
 		const spell_id spellId = myPlayer._pRSpell;
-		if (spellId != SPL_INVALID) {
+		if (spellId != SPL_INVALID && spellId != SPL_NULL) {
 			switch (myPlayer._pRSplType) {
 			case RSPLTYPE_SKILL:
 				strcpy(tempstr, fmt::format(_("{:s} Skill"), pgettext("spell", spelldata[spellId].sSkillText)).c_str());


### PR DESCRIPTION
Fixes #3304

This situation should not really happen. The save that triggered it was created using debug commands, so it could have created an unusual situation. Let me know if you feel this should be better researched or more care should be done to not let the situation happen in the first place.