### PR TITLE
Remove duplicate/undefined function

### DIFF
--- a/test/path_test.cpp
+++ b/test/path_test.cpp
@@ -8,7 +8,6 @@
 
 namespace devilution {
 
-extern int TestPathGetHCost(Point startPosition, Point destinationPosition);
 extern int TestPathGetHeuristicCost(Point startPosition, Point destinationPosition);
 
 TEST(PathTest, Heuristics)


### PR DESCRIPTION
Unused and no function definition under that name, the more descriptive name is used instead.