### PR TITLE
Introduce a replacement/abstraction for CrawlTable for single tile searches

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1130,18 +1130,11 @@ bool PutItem(Player &player, Point &position)
 	if (CanPut(position))
 		return true;
 
-	for (int l = 1; l < 50; l++) {
-		for (int j = -l; j <= l; j++) {
-			int yp = j + player.position.tile.y;
-			for (int i = -l; i <= l; i++) {
-				int xp = i + player.position.tile.x;
-				if (!CanPut({ xp, yp }))
-					continue;
+	std::optional<Point> itemPosition = FindClosestValidPosition(CanPut, player.position.tile, 1, 50);
 
-				position = { xp, yp };
-				return true;
-			}
-		}
+	if (itemPosition) {
+		position = *itemPosition;
+		return true;
 	}
 
 	return false;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3229,19 +3229,9 @@ int AllocateItem()
 
 Point GetSuperItemLoc(Point position)
 {
-	for (int k = 1; k < 50; k++) {
-		for (int j = -k; j <= k; j++) {
-			for (int i = -k; i <= k; i++) {
-				Displacement offset = { i, j };
-				Point positionToCheck = position + offset;
-				if (ItemSpaceOk(positionToCheck)) {
-					return positionToCheck;
-				}
-			}
-		}
-	}
+	std::optional<Point> itemPosition = FindClosestValidPosition(ItemSpaceOk, position, 1, 50);
 
-	return { 0, 0 }; // TODO handle no space for dropping items
+	return itemPosition.value_or(Point { 0, 0 }); // TODO handle no space for dropping items
 }
 
 void GetItemAttrs(Item &item, int itemData, int lvl)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3156,30 +3156,18 @@ void MI_HorkSpawn(Missile &missile)
 	CheckMissileCol(missile, 0, 0, false, missile.position.tile, false);
 	if (missile._mirange <= 0) {
 		missile._miDelFlag = true;
-		for (int i = 0; i < 2; i++) {
-			int k = CrawlNum[i];
-			int ck = k + 2;
-			for (auto j = static_cast<uint8_t>(CrawlTable[k]); j > 0; j--, ck += 2) {
-				Point target = missile.position.tile + Displacement { CrawlTable[ck - 1], CrawlTable[ck] };
-				if (!InDungeonBounds(target))
-					continue;
 
-				if (nSolidTable[dPiece[target.x][target.y]])
-					continue;
-				if (dMonster[target.x][target.y] != 0)
-					continue;
-				if (dPlayer[target.x][target.y] != 0)
-					continue;
-				if (dObject[target.x][target.y] != 0)
-					continue;
+		std::optional<Point> spawnPosition = FindClosestValidPosition(
+		    [](Point target) {
+			    return !IsTileOccupied(target);
+		    },
+		    missile.position.tile, 0, 1);
 
-				auto md = static_cast<Direction>(missile.var1);
-				int monsterId = AddMonster(target, md, 1, true);
-				if (monsterId != -1)
-					M_StartStand(Monsters[monsterId], md);
-
-				i = 6;
-				break;
+		if (spawnPosition) {
+			auto facing = static_cast<Direction>(missile.var1);
+			int monsterId = AddMonster(*spawnPosition, facing, 1, true);
+			if (monsterId != -1) {
+				M_StartStand(Monsters[monsterId], facing);
 			}
 		}
 	} else {

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1523,27 +1523,22 @@ void AddStealPotions(Missile &missile, Point /*dst*/, Direction /*midir*/)
 
 void AddManaTrap(Missile &missile, Point /*dst*/, Direction /*midir*/)
 {
-	for (int i = 0; i < 3; i++) {
-		int k = CrawlNum[i];
-		int ck = k + 2;
-		for (auto j = static_cast<uint8_t>(CrawlTable[k]); j > 0; j--, ck += 2) {
-			Point target = missile.position.start + Displacement { CrawlTable[ck - 1], CrawlTable[ck] };
-			if (!InDungeonBounds(target))
-				continue;
+	std::optional<Point> trappedPlayerPosition = FindClosestValidPosition(
+	    [](Point target) {
+		    return InDungeonBounds(target) && dPlayer[target.x][target.y] != 0;
+	    },
+	    missile.position.start, 0, 2);
 
-			int8_t pid = dPlayer[target.x][target.y];
-			if (pid == 0)
-				continue;
+	if (trappedPlayerPosition) {
+		auto &player = Players[abs(dPlayer[trappedPlayerPosition->x][trappedPlayerPosition->y]) - 1];
 
-			auto &player = Players[abs(pid) - 1];
-
-			player._pMana = 0;
-			player._pManaBase = player._pMana + player._pMaxManaBase - player._pMaxMana;
-			CalcPlrInv(player, false);
-			drawmanaflag = true;
-			PlaySfxLoc(TSFX_COW7, target);
-		}
+		player._pMana = 0;
+		player._pManaBase = player._pMana + player._pMaxManaBase - player._pMaxMana;
+		CalcPlrInv(player, false);
+		drawmanaflag = true;
+		PlaySfxLoc(TSFX_COW7, *trappedPlayerPosition);
 	}
+
 	missile._miDelFlag = true;
 }
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -693,23 +693,29 @@ void SetMissAnim(Missile &missile, int animtype)
 void AddRune(Missile &missile, Point dst, missile_id missileID)
 {
 	if (LineClearMissile(missile.position.start, dst)) {
-		for (int i = 0; i < 10; i++) {
-			int k = CrawlNum[i];
-			int ck = k + 2;
-			for (auto j = static_cast<uint8_t>(CrawlTable[k]); j > 0; j--, ck += 2) {
-				Point target = dst + Displacement { CrawlTable[ck - 1], CrawlTable[ck] };
-				if (!InDungeonBounds(target))
-					continue;
+		std::optional<Point> runePosition = FindClosestValidPosition(
+		    [](Point target) {
+			    if (!InDungeonBounds(target)) {
+				    return false;
+			    }
+			    if (dObject[target.x][target.y] != 0) {
+				    return false;
+			    }
+			    if (TileContainsMissile(target)) {
+				    return false;
+			    }
+			    if (nSolidTable[dPiece[target.x][target.y]]) {
+				    return false;
+			    }
+			    return true;
+		    },
+		    dst, 0, 9);
 
-				int dp = dPiece[target.x][target.y];
-				if (nSolidTable[dp] || dObject[target.x][target.y] != 0 || TileContainsMissile(target))
-					continue;
-
-				missile.position.tile = target;
-				missile.var1 = missileID;
-				missile._mlid = AddLight(target, 8);
-				return;
-			}
+		if (runePosition) {
+			missile.position.tile = *runePosition;
+			missile.var1 = missileID;
+			missile._mlid = AddLight(missile.position.tile, 8);
+			return;
 		}
 	}
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2397,24 +2397,14 @@ void AddGolem(Missile &missile, Point dst, Direction /*midir*/)
 	UseMana(playerId, SPL_GOLEM);
 
 	if (Monsters[playerId].position.tile == GolemHoldingCell) {
-		for (int i = 0; i < 6; i++) {
-			int k = CrawlNum[i];
-			int ck = k + 2;
-			for (auto j = static_cast<uint8_t>(CrawlTable[k]); j > 0; j--, ck += 2) {
-				Point target = dst + Displacement { CrawlTable[ck - 1], CrawlTable[ck] };
+		std::optional<Point> spawnPosition = FindClosestValidPosition(
+		    [start = missile.position.start](Point target) {
+			    return !IsTileOccupied(target) && LineClearMissile(start, target);
+		    },
+		    dst, 0, 5);
 
-				if (!InDungeonBounds(target))
-					continue;
-
-				if (!LineClearMissile(missile.position.start, target))
-					continue;
-
-				if (dMonster[target.x][target.y] != 0 || nSolidTable[dPiece[target.x][target.y]] || dObject[target.x][target.y] != 0 || dPlayer[target.x][target.y] != 0)
-					continue;
-
-				SpawnGolem(playerId, target, missile);
-				return;
-			}
+		if (spawnPosition) {
+			SpawnGolem(playerId, *spawnPosition, missile);
 		}
 	}
 }

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1929,23 +1929,20 @@ void AddMagmaball(Missile &missile, Point dst, Direction /*midir*/)
 
 void AddTeleport(Missile &missile, Point dst, Direction /*midir*/)
 {
-	for (int i = 0; i < 6; i++) {
-		int k = CrawlNum[i];
-		int ck = k + 2;
-		for (auto j = static_cast<uint8_t>(CrawlTable[k]); j > 0; j--, ck += 2) {
-			Point target = dst + Displacement { CrawlTable[ck - 1], CrawlTable[ck] };
-			if (!PosOkPlayer(Players[missile._misource], target))
-				continue;
+	std::optional<Point> teleportDestination = FindClosestValidPosition(
+	    [&player = Players[missile._misource]](Point target) {
+		    return PosOkPlayer(player, target);
+	    },
+	    dst, 0, 5);
 
-			missile.position.tile = target;
-			missile.position.start = target;
-			UseMana(missile._misource, SPL_TELEPORT);
-			missile._mirange = 2;
-			return;
-		}
+	if (teleportDestination) {
+		missile.position.tile = *teleportDestination;
+		missile.position.start = *teleportDestination;
+		UseMana(missile._misource, SPL_TELEPORT);
+		missile._mirange = 2;
+	} else {
+		missile._miDelFlag = true;
 	}
-
-	missile._miDelFlag = true;
 }
 
 void AddLightball(Missile &missile, Point dst, Direction /*midir*/)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -83,22 +83,18 @@ bool CheckBlock(Point from, Point to)
 
 Monster *FindClosest(Point source, int rad)
 {
-	if (rad > 19)
-		rad = 19;
+	std::optional<Point> monsterPosition = FindClosestValidPosition(
+	    [&source](Point target) {
+		    // search for a monster with clear line of sight
+		    return InDungeonBounds(target) && dMonster[target.x][target.y] > 0 && !CheckBlock(source, target);
+	    },
+	    source, 1, rad);
 
-	for (int i = 1; i < rad; i++) {
-		int k = CrawlNum[i];
-		int ck = k + 2;
-		for (auto j = static_cast<uint8_t>(CrawlTable[k]); j > 0; j--, ck += 2) {
-			Point target = source + Displacement { CrawlTable[ck - 1], CrawlTable[ck] };
-			if (!InDungeonBounds(target))
-				continue;
-
-			int mid = dMonster[target.x][target.y];
-			if (mid > 0 && !CheckBlock(source, target))
-				return &Monsters[mid - 1];
-		}
+	if (monsterPosition) {
+		int mid = dMonster[monsterPosition->x][monsterPosition->y];
+		return &Monsters[mid - 1];
 	}
+
 	return nullptr;
 }
 

--- a/Source/path.cpp
+++ b/Source/path.cpp
@@ -316,6 +316,28 @@ bool IsTileWalkable(Point position, bool ignoreDoors)
 	return !IsTileSolid(position);
 }
 
+bool IsTileOccupied(Point position)
+{
+	if (!InDungeonBounds(position)) {
+		return true; // OOB positions are considered occupied.
+	}
+
+	if (IsTileSolid(position)) {
+		return true;
+	}
+	if (dMonster[position.x][position.y] != 0) {
+		return true;
+	}
+	if (dPlayer[position.x][position.y] != 0) {
+		return true;
+	}
+	if (dObject[position.x][position.y] != 0) {
+		return true;
+	}
+
+	return false;
+}
+
 int FindPath(const std::function<bool(Point)> &posOk, Point startPosition, Point destinationPosition, int8_t path[MAX_PATH_LENGTH])
 {
 	/**

--- a/Source/path.h
+++ b/Source/path.h
@@ -11,6 +11,7 @@
 
 #include "engine/direction.hpp"
 #include "engine/point.hpp"
+#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 
@@ -65,5 +66,26 @@ const Displacement PathDirs[8] = {
 	{  0,  1 }, //Direction::SouthWest
 	// clang-format on
 };
+
+/**
+ * @brief Searches for the closest position that passes the check in expanding "rings".
+ *
+ * The search space is roughly equivalent to a square of tiles where the walking distance is equal to the radius except
+ * the corners are "rounded" (inset) by one tile. For example the following is a search space of radius 4:
+ * _XXXXXXX_
+ * XX_____XX
+ * X_______X
+ * < snip  >
+ * X_______X
+ * XX_____XX
+ * _XXXXXXX_
+ *
+ * @param posOk Used to check if a position is valid
+ * @param startingPosition dungeon tile location to start the search from
+ * @param minimumRadius A value from 0 to 50, allows skipping nearby tiles (e.g. specify radius 1 to skip checking the starting tile)
+ * @param maximumRadius The maximum distance to check, defaults to 18 for vanilla compatibility but supports values up to 50
+ * @return either the closest valid point or an empty optional
+ */
+std::optional<Point> FindClosestValidPosition(const std::function<bool(Point)> &posOk, Point startingPosition, unsigned int minimumRadius = 0, unsigned int maximumRadius = 18);
 
 } // namespace devilution

--- a/Source/path.h
+++ b/Source/path.h
@@ -36,6 +36,11 @@ bool IsTileSolid(Point position);
 bool IsTileWalkable(Point position, bool ignoreDoors = false);
 
 /**
+ * @brief Checks if the position contains an object, player, monster, or solid dungeon piece
+*/
+bool IsTileOccupied(Point position);
+
+/**
  * @brief Find the shortest path from startPosition to destinationPosition, using PosOk(Point) to check that each step is a valid position.
  * Store the step directions (corresponds to an index in PathDirs) in path, which must have room for 24 steps
  */

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3591,16 +3591,15 @@ void SyncInitPlrPos(int pnum)
 				return position;
 		}
 
-		for (int k : CrawlNum) {
-			int ck = k + 2;
-			for (auto j = static_cast<uint8_t>(CrawlTable[k]); j > 0; j--, ck += 2) {
-				Point position = player.position.tile + Displacement { CrawlTable[ck - 1], CrawlTable[ck] };
-				if (PosOkPlayer(player, position) && !PosOkPortal(currlevel, position.x, position.y))
-					return position;
-			}
-		}
+		std::optional<Point> nearPosition = FindClosestValidPosition(
+		    [&player](Point testPosition) {
+			    return PosOkPlayer(player, testPosition) && !PosOkPortal(currlevel, testPosition.x, testPosition.y);
+		    },
+		    player.position.tile,
+		    1, // skip the starting tile since that was checked in the previous loop
+		    50);
 
-		return Point { 0, 0 };
+		return nearPosition.value_or(Point { 0, 0 });
 	}();
 
 	player.position.tile = position;

--- a/test/path_test.cpp
+++ b/test/path_test.cpp
@@ -165,4 +165,111 @@ TEST(PathTest, Walkable)
 	EXPECT_FALSE(IsTileWalkable({ 5, 5 })) << "Solid tiles occupied by an open door remain unwalkable";
 	EXPECT_TRUE(IsTileWalkable({ 5, 5 }, true)) << "Solid tiles occupied by an open door become walkable when ignoring doors";
 }
+
+TEST(PathTest, FindClosest)
+{
+	{
+		std::array<std::array<int, 101>, 101> searchedTiles {};
+
+		std::optional<Point> nearPosition = FindClosestValidPosition(
+		    [&searchedTiles](Point testPosition) {
+			    searchedTiles[testPosition.x][testPosition.y]++;
+			    return false;
+		    },
+		    { 50, 50 }, 0, 50);
+
+		EXPECT_FALSE(nearPosition) << "Searching with no valid tiles should return an empty optional";
+
+		for (int x = 0; x < searchedTiles.size(); x++) {
+			for (int y = 0; y < searchedTiles[x].size(); y++) {
+				if (IsAnyOf(x, 0, 100) && IsAnyOf(y, 0, 100)) {
+					EXPECT_EQ(searchedTiles[x][y], 0) << "Extreme corners should be skipped due to the inset/rounded search space";
+				} else {
+					EXPECT_EQ(searchedTiles[x][y], 1) << "Position " << Point { x, y } << " should have been searched exactly once";
+				}
+			}
+		}
+	}
+	{
+		std::array<std::array<int, 5>, 5> searchedTiles {};
+
+		std::optional<Point> nearPosition = FindClosestValidPosition(
+		    [&searchedTiles](Point testPosition) {
+			    searchedTiles[testPosition.x][testPosition.y]++;
+			    return false;
+		    },
+		    { 2, 2 }, 1, 2);
+
+		EXPECT_FALSE(nearPosition) << "Still shouldn't find a valid position with no valid tiles";
+
+		for (int x = 0; x < searchedTiles.size(); x++) {
+			for (int y = 0; y < searchedTiles[x].size(); y++) {
+				if (Point { x, y } == Point { 2, 2 }) {
+					EXPECT_EQ(searchedTiles[x][y], 0) << "The starting tile should be skipped with a min radius of 1";
+				} else if (IsAnyOf(x, 0, 4) && IsAnyOf(y, 0, 4)) {
+					EXPECT_EQ(searchedTiles[x][y], 0) << "Corners should be skipped";
+				} else {
+					EXPECT_EQ(searchedTiles[x][y], 1) << "All tiles in range should be searched exactly once";
+				}
+			}
+		}
+	}
+	{
+		std::array<std::array<int, 3>, 3> searchedTiles {};
+
+		std::optional<Point> nearPosition = FindClosestValidPosition(
+		    [&searchedTiles](Point testPosition) {
+			    searchedTiles[testPosition.x][testPosition.y]++;
+			    return false;
+		    },
+		    { 1, 1 }, 0, 0);
+
+		EXPECT_FALSE(nearPosition) << "Searching with no valid tiles should return an empty optional";
+
+		for (int x = 0; x < searchedTiles.size(); x++) {
+			for (int y = 0; y < searchedTiles[x].size(); y++) {
+				if (Point { x, y } == Point { 1, 1 }) {
+					EXPECT_EQ(searchedTiles[x][y], 1) << "Only the starting tile should be searched with max radius 0";
+				} else {
+					EXPECT_EQ(searchedTiles[x][y], 0) << "Position " << Point { x, y } << " should not have been searched";
+				}
+			}
+		}
+	}
+
+	{
+		std::array<std::array<int, 7>, 7> searchedTiles {};
+
+		std::optional<Point> nearPosition = FindClosestValidPosition(
+		    [&searchedTiles](Point testPosition) {
+			    searchedTiles[testPosition.x][testPosition.y]++;
+			    return false;
+		    },
+		    { 3, 3 }, 3, 3);
+
+		EXPECT_FALSE(nearPosition) << "Searching with no valid tiles should return an empty optional";
+
+		for (int x = 0; x < searchedTiles.size(); x++) {
+			for (int y = 0; y < searchedTiles[x].size(); y++) {
+				if ((IsAnyOf(x, 1, 5) && IsAnyOf(y, 1, 5))     // inset corners
+				    || (IsAnyOf(x, 0, 6) && IsNoneOf(y, 0, 6)) // left/right sides
+				    || (IsNoneOf(x, 0, 6) && IsAnyOf(y, 0, 6)) // top/bottom sides
+				) {
+					EXPECT_EQ(searchedTiles[x][y], 1) << "Searching with a fixed radius should make a square with inset corners";
+				} else {
+					EXPECT_EQ(searchedTiles[x][y], 0) << "Position " << Point { x, y } << " should not have been searched";
+				}
+			}
+		}
+	}
+	{
+		std::optional<Point> nearPosition = FindClosestValidPosition(
+		    [](Point testPosition) {
+			    return true;
+		    },
+		    { 50, 50 }, 21, 50);
+
+		EXPECT_EQ(*nearPosition, (Point { 50, 50 } + Displacement { 0, 21 })) << "First candidate position with a minimum radius should be at {0, +y}";
+	}
+}
 } // namespace devilution


### PR DESCRIPTION
With the way CrawlTable and CrawlNum are defined callers needed to do some awkward iteration and manually construct displacements. This also meant that the logic performed when a valid target was found was mixed in with the actual search code since often there were two levels of loop to break out of.

I've added a function to abstract this table, using an interface similar to the pathfinding logic. I've also placed it in path.h/cpp as it seemed most appropriate given the existing use.

There are other functions which search for multiple tiles, this could be supported using a custom iterator but I wanted to focus on the simple case for now.