### PR TITLE
Don't set RNG seed when operating fountains

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3871,7 +3871,6 @@ bool OperateFountains(int pnum, int i)
 {
 	auto &player = Players[pnum];
 	bool applied = false;
-	SetRndSeed(Objects[i]._oRndSeed);
 	switch (Objects[i]._otype) {
 	case OBJ_BLOODFTN:
 		if (deltaload)
@@ -3943,12 +3942,13 @@ bool OperateFountains(int pnum, int i)
 		if (pnum != MyPlayerId)
 			return false;
 
-		int fromStat = GenerateRnd(4);
-		int toStat = abs(GenerateRnd(3));
+		unsigned randomValue = (Objects[i]._oRndSeed >> 16) % 12;
+		unsigned fromStat = randomValue / 3;
+		unsigned toStat = randomValue % 3;
 		if (toStat >= fromStat)
 			toStat++;
 
-		std::pair<int, int> alterations[] = { { fromStat, -1 }, { toStat, 1 } };
+		std::pair<unsigned, int> alterations[] = { { fromStat, -1 }, { toStat, 1 } };
 		for (auto alteration : alterations) {
 			switch (alteration.first) {
 			case 0:


### PR DESCRIPTION
This change removes the need for `SetRndSeed()` by simply calculating the from/to stats for Fountain of Tears from the seed value itself.

I'm submitting this for discussion as a potentially less controversial alternative to #3296.

> I noticed when testing #3219 that spamming the Blood Fountain caused all the randomness in monster attack frequency, hit rate, and block chance to go away. It seems that Fountain of Tears captures a seed to provide predictable behavior when used regardless of the current state of the engine's RNG, but the call to `SetRndSeed()` doesn't discriminate based on the type of fountain.