### PR TITLE
Disable shift-clicking of items you don't have stats to wear

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -829,7 +829,7 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 			if (automaticMove) {
 				if (CanBePlacedOnBelt(holdItem)) {
 					automaticallyMoved = AutoPlaceItemInBelt(player, holdItem, true);
-				} else if (CanEquip (holdItem)) {
+				} else if (CanEquip(holdItem)) {
 					/*
 					 * Move the respective InvBodyItem to inventory before moving the item from inventory
 					 * to InvBody with AutoEquip. AutoEquip requires the InvBody slot to be empty.

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -829,7 +829,7 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 			if (automaticMove) {
 				if (CanBePlacedOnBelt(holdItem)) {
 					automaticallyMoved = AutoPlaceItemInBelt(player, holdItem, true);
-				} else {
+				} else if (CanEquip (holdItem)) {
 					/*
 					 * Move the respective InvBodyItem to inventory before moving the item from inventory
 					 * to InvBody with AutoEquip. AutoEquip requires the InvBody slot to be empty.


### PR DESCRIPTION
Ensure people who shift-click items they don't have the stats for don't end up empty-handed.
