### PR TITLE
[Virtual Gamepad] Turn player when stand button is pressed

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1132,12 +1132,18 @@ void WalkInDir(int playerId, AxisDirection dir)
 		player._pdir = pdir;
 
 #ifdef VIRTUAL_GAMEPAD
-	if (VirtualGamepadState.standButton.isHeld)
+	if (VirtualGamepadState.standButton.isHeld) {
+		if (player._pmode == PM_STAND)
+			StartStand(playerId, pdir);
 		return;
+	}
 #endif
 
-	if (PosOkPlayer(player, delta) && IsPathBlocked(player.position.future, pdir))
+	if (PosOkPlayer(player, delta) && IsPathBlocked(player.position.future, pdir)) {
+		if (player._pmode == PM_STAND)
+			StartStand(playerId, pdir);
 		return; // Don't start backtrack around obstacles
+	}
 
 	NetSendCmdLoc(playerId, true, CMD_WALKXY, delta);
 }


### PR DESCRIPTION
This restarts the player's idle animation if they attempt to move while the stand button is pressed.