### PR TITLE
Fix speedbook navigation on gamepad

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -618,65 +618,6 @@ void RemoveGold(Player &player, int goldIndex)
 	dropGoldValue = 0;
 }
 
-struct SpellListItem {
-	Point location;
-	spell_type type;
-	spell_id id;
-	bool isSelected;
-};
-
-std::vector<SpellListItem> GetSpellListItems()
-{
-	std::vector<SpellListItem> spellListItems;
-
-	uint64_t mask;
-
-	int x = PANEL_X + 12 + SPLICONLENGTH * SPLROWICONLS;
-	int y = PANEL_Y - 17;
-
-	for (int i = RSPLTYPE_SKILL; i < RSPLTYPE_INVALID; i++) {
-		auto &myPlayer = Players[MyPlayerId];
-		switch ((spell_type)i) {
-		case RSPLTYPE_SKILL:
-			mask = myPlayer._pAblSpells;
-			break;
-		case RSPLTYPE_SPELL:
-			mask = myPlayer._pMemSpells;
-			break;
-		case RSPLTYPE_SCROLL:
-			mask = myPlayer._pScrlSpells;
-			break;
-		case RSPLTYPE_CHARGES:
-			mask = myPlayer._pISpells;
-			break;
-		case RSPLTYPE_INVALID:
-			break;
-		}
-		int8_t j = SPL_FIREBOLT;
-		for (uint64_t spl = 1; j < MAX_SPELLS; spl <<= 1, j++) {
-			if ((mask & spl) == 0)
-				continue;
-			int lx = x;
-			int ly = y - SPLICONLENGTH;
-			bool isSelected = (MousePosition.x >= lx && MousePosition.x < lx + SPLICONLENGTH && MousePosition.y >= ly && MousePosition.y < ly + SPLICONLENGTH);
-			spellListItems.emplace_back(SpellListItem { { x, y }, (spell_type)i, (spell_id)j, isSelected });
-			x -= SPLICONLENGTH;
-			if (x == PANEL_X + 12 - SPLICONLENGTH) {
-				x = PANEL_X + 12 + SPLICONLENGTH * SPLROWICONLS;
-				y -= SPLICONLENGTH;
-			}
-		}
-		if (mask != 0 && x != PANEL_X + 12 + SPLICONLENGTH * SPLROWICONLS)
-			x -= SPLICONLENGTH;
-		if (x == PANEL_X + 12 - SPLICONLENGTH) {
-			x = PANEL_X + 12 + SPLICONLENGTH * SPLROWICONLS;
-			y -= SPLICONLENGTH;
-		}
-	}
-
-	return spellListItems;
-}
-
 bool GetSpellListSelection(spell_id &pSpell, spell_type &pSplType)
 {
 	pSpell = spell_id::SPL_INVALID;
@@ -815,6 +756,58 @@ void DrawSpellList(const Surface &out)
 			}
 		}
 	}
+}
+
+std::vector<SpellListItem> GetSpellListItems()
+{
+	std::vector<SpellListItem> spellListItems;
+
+	uint64_t mask;
+
+	int x = PANEL_X + 12 + SPLICONLENGTH * SPLROWICONLS;
+	int y = PANEL_Y - 17;
+
+	for (int i = RSPLTYPE_SKILL; i < RSPLTYPE_INVALID; i++) {
+		auto &myPlayer = Players[MyPlayerId];
+		switch ((spell_type)i) {
+		case RSPLTYPE_SKILL:
+			mask = myPlayer._pAblSpells;
+			break;
+		case RSPLTYPE_SPELL:
+			mask = myPlayer._pMemSpells;
+			break;
+		case RSPLTYPE_SCROLL:
+			mask = myPlayer._pScrlSpells;
+			break;
+		case RSPLTYPE_CHARGES:
+			mask = myPlayer._pISpells;
+			break;
+		case RSPLTYPE_INVALID:
+			break;
+		}
+		int8_t j = SPL_FIREBOLT;
+		for (uint64_t spl = 1; j < MAX_SPELLS; spl <<= 1, j++) {
+			if ((mask & spl) == 0)
+				continue;
+			int lx = x;
+			int ly = y - SPLICONLENGTH;
+			bool isSelected = (MousePosition.x >= lx && MousePosition.x < lx + SPLICONLENGTH && MousePosition.y >= ly && MousePosition.y < ly + SPLICONLENGTH);
+			spellListItems.emplace_back(SpellListItem { { x, y }, (spell_type)i, (spell_id)j, isSelected });
+			x -= SPLICONLENGTH;
+			if (x == PANEL_X + 12 - SPLICONLENGTH) {
+				x = PANEL_X + 12 + SPLICONLENGTH * SPLROWICONLS;
+				y -= SPLICONLENGTH;
+			}
+		}
+		if (mask != 0 && x != PANEL_X + 12 + SPLICONLENGTH * SPLROWICONLS)
+			x -= SPLICONLENGTH;
+		if (x == PANEL_X + 12 - SPLICONLENGTH) {
+			x = PANEL_X + 12 + SPLICONLENGTH * SPLROWICONLS;
+			y -= SPLICONLENGTH;
+		}
+	}
+
+	return spellListItems;
 }
 
 void SetSpell()

--- a/Source/control.h
+++ b/Source/control.h
@@ -28,6 +28,13 @@ namespace devilution {
 #define SPANEL_WIDTH 320
 #define SPANEL_HEIGHT 352
 
+struct SpellListItem {
+	Point location;
+	spell_type type;
+	spell_id id;
+	bool isSelected;
+};
+
 extern bool drawhpflag;
 extern bool dropGoldFlag;
 extern bool chrbtn[4];
@@ -168,6 +175,7 @@ void ReleaseChrBtns(bool addAllStatPoints);
 void DrawDurIcon(const Surface &out);
 void RedBack(const Surface &out);
 void DrawSpellBook(const Surface &out);
+std::vector<SpellListItem> GetSpellListItems();
 void CheckSBook();
 void DrawGoldSplit(const Surface &out, int amount);
 void control_drop_gold(char vkey);

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1032,12 +1032,12 @@ void HotSpellMove(AxisDirection dir)
 		}
 	}
 
-	auto search = [&](AxisDirection dir, bool searchForward) {
+	const auto search = [&](AxisDirection dir, bool searchForward) {
 		if (dir.x == AxisDirectionX_NONE && dir.y == AxisDirectionY_NONE)
 			return;
 
 		for (size_t i = 0; i < spellListItems.size(); i++) {
-			auto index = i;
+			const size_t index = i;
 			if (searchForward)
 				index = spellListItems.size() - i - 1;
 

--- a/Source/controls/plrctrls.h
+++ b/Source/controls/plrctrls.h
@@ -45,7 +45,6 @@ bool TryDropItem();
 void InvalidateInventorySlot();
 void FocusOnInventory();
 void PerformSpellAction();
-void StoreSpellCoords();
 
 extern int speedspellcount;
 

--- a/Source/miniwin/misc_msg.cpp
+++ b/Source/miniwin/misc_msg.cpp
@@ -403,7 +403,6 @@ bool FetchMessage_Real(tagMSG *lpMsg)
 				chrflag = false;
 				QuestLogIsOpen = false;
 				sbookflag = false;
-				StoreSpellCoords();
 			}
 			break;
 		case GameActionType_TOGGLE_CHARACTER_INFO:


### PR DESCRIPTION
This fixes gamepad navigation after opening the speedbook with anything other than `GameActionType_TOGGLE_QUICK_SPELL_MENU`.

---

The gamepad code that toggles the speedbook called a function named `StoreSpellCoords()` in order to compute the location of each spell in the speedbook. However, if the speedbook was opened via any other method, such as the `S` key or by clicking on the spell icon in the main panel, the speedbook coordinates would not be updated and gamepad navigation would not work properly. This was most obvious when using touch controls which doesn't make use of `GameActionType_TOGGLE_QUICK_SPELL_MENU` to open the speedbook.

This PR rewrites the `HotSpellMove()` function to use `GetSpellListItems()` instead, which is the function that provides information for rendering the speedbook.