### PR TITLE
packet.h: Fix `-Wunused-variable`

### DIFF
--- a/Source/dvlnet/packet.h
+++ b/Source/dvlnet/packet.h
@@ -354,7 +354,6 @@ inline std::unique_ptr<packet> packet_factory::make_packet(buffer_t buf)
 	else
 		ret->Decrypt(std::move(buf));
 #endif
-	size_t size = ret->Data().size();
 	ret->process_data();
 	return ret;
 }


### PR DESCRIPTION
    ../Source/dvlnet/packet.h: In member function ‘std::unique_ptr<devilution::net::packet> devilution::net::packet_factory::make_packet(devilution::net::buffer_t)’:
    ../Source/dvlnet/packet.h:357:9: warning: unused variable ‘size’ [-Wunused-variable]
      357 |  size_t size = ret->Data().size();
          |         ^~~~