### PR TITLE
Remove libpng from vcpkg dependencies

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,6 @@
     "version-string": "1.2.1",
     "dependencies": [
         "fmt",
-        "libpng",
         "sdl2",
         "sdl2-image"
     ],


### PR DESCRIPTION
Thanks to @glebm's tip (#3387), I surmised that Windows does not need both libpng and sdl2-image.