### PR TITLE
DrawArt: Fix bounds check

### DIFF
--- a/Source/DiabloUI/art_draw.cpp
+++ b/Source/DiabloUI/art_draw.cpp
@@ -26,14 +26,10 @@ void UpdatePalette(Art *art, const SDL_Surface *output)
 
 void DrawArt(Point screenPosition, Art *art, int nFrame, Uint16 srcW, Uint16 srcH)
 {
-	if (screenPosition.y >= gnScreenHeight || screenPosition.x >= gnScreenWidth || art->surface == nullptr)
+	if (art->surface == nullptr || screenPosition.y >= gnScreenHeight || screenPosition.x >= gnScreenWidth)
 		return;
 
-	SDL_Rect srcRect;
-	srcRect.x = 0;
-	srcRect.y = nFrame * art->h();
-	srcRect.w = art->w();
-	srcRect.h = art->h();
+	SDL_Rect srcRect = MakeSdlRect(0, nFrame * art->h(), art->w(), art->h());
 
 	ScaleOutputRect(&srcRect);
 
@@ -50,23 +46,19 @@ void DrawArt(Point screenPosition, Art *art, int nFrame, Uint16 srcW, Uint16 src
 		ErrSdl();
 }
 
-void DrawArt(const Surface &out, Point screenPosition, Art *art, int nFrame, Uint16 srcW, Uint16 srcH)
+void DrawArt(const Surface &out, Point position, Art *art, int nFrame, Uint16 srcW, Uint16 srcH)
 {
-	if (screenPosition.y >= gnScreenHeight || screenPosition.x >= gnScreenWidth || art->surface == nullptr)
+	if (art->surface == nullptr || position.y >= out.h() || position.x >= out.w())
 		return;
 
-	SDL_Rect srcRect;
-	srcRect.x = 0;
-	srcRect.y = nFrame * art->h();
-	srcRect.w = art->w();
-	srcRect.h = art->h();
-
+	SDL_Rect srcRect = MakeSdlRect(0, nFrame * art->h(), art->w(), art->h());
 	if (srcW != 0 && srcW < srcRect.w)
 		srcRect.w = srcW;
 	if (srcH != 0 && srcH < srcRect.h)
 		srcRect.h = srcH;
-	out.Clip(&srcRect, &screenPosition);
-	SDL_Rect dstRect { screenPosition.x + out.region.x, screenPosition.y + out.region.y, 0, 0 };
+
+	out.Clip(&srcRect, &position);
+	SDL_Rect dstRect = MakeSdlRect(position.x + out.region.x, position.y + out.region.y, 0, 0);
 
 	UpdatePalette(art, out.surface);
 

--- a/Source/DiabloUI/art_draw.h
+++ b/Source/DiabloUI/art_draw.h
@@ -9,7 +9,7 @@ void UpdatePalette(Art *art, const SDL_Surface *output = nullptr);
 
 void DrawArt(Point screenPosition, Art *art, int nFrame = 0, Uint16 srcW = 0, Uint16 srcH = 0);
 
-void DrawArt(const Surface &out, Point screenPosition, Art *art, int nFrame = 0, Uint16 srcW = 0, Uint16 srcH = 0);
+void DrawArt(const Surface &out, Point position, Art *art, int nFrame = 0, Uint16 srcW = 0, Uint16 srcH = 0);
 
 void DrawAnimatedArt(Art *art, Point screenPosition);
 

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -346,7 +346,7 @@ uint32_t DrawString(const Surface &out, string_view text, const Rectangle &rect,
 		characterPosition.x += rect.size.width - lineWidth;
 
 	int rightMargin = rect.position.x + rect.size.width;
-	int bottomMargin = rect.size.height != 0 ? rect.position.y + rect.size.height : out.h();
+	const int bottomMargin = rect.size.height != 0 ? std::min(rect.position.y + rect.size.height, out.h()) : out.h();
 
 	if (lineHeight == -1)
 		lineHeight = LineHeights[size];


### PR DESCRIPTION
The bounds checks were performed against the global screen dimensions instead of the output buffer dimensions.

Also includes some minor cleanup of DrawArt.

Fixes #3388