### PR TITLE
Optimize `DrawHalfTransparentBlendedRectTo`

### DIFF
--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -19,6 +19,8 @@ SDL_Color system_palette[256];
 SDL_Color orig_palette[256];
 Uint8 paletteTransparencyLookup[256][256];
 
+uint16_t paletteTransparencyLookupBlack16[65536];
+
 namespace {
 
 /** Specifies whether the palette has max brightness. */
@@ -86,6 +88,17 @@ void GenerateBlendedLookupTable(SDL_Color *palette, int skipFrom, int skipTo, in
 			blendedColor.b = ((int)palette[i].b + (int)palette[j].b) / 2;
 			Uint8 best = FindBestMatchForColor(palette, blendedColor, skipFrom, skipTo);
 			paletteTransparencyLookup[i][j] = best;
+		}
+	}
+
+	for (unsigned i = 0; i < 256; ++i) {
+		for (unsigned j = 0; j < 256; ++j) {
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+			const std::uint16_t index = i | (j << 8);
+#else
+			const std::uint16_t index = j | (i << 8);
+#endif
+			paletteTransparencyLookupBlack16[index] = paletteTransparencyLookup[0][i] | (paletteTransparencyLookup[0][j] << 8);
 		}
 	}
 }

--- a/Source/palette.h
+++ b/Source/palette.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #include "gendung.h"
 
 namespace devilution {
@@ -34,6 +36,17 @@ extern SDL_Color system_palette[256];
 extern SDL_Color orig_palette[256];
 /** Lookup table for transparency */
 extern Uint8 paletteTransparencyLookup[256][256];
+
+/**
+ * A lookup table from black for a pair of colors.
+ *
+ * For a pair of colors i and j, the index `i | (j << 8)` contains
+ * `paletteTransparencyLookup[0][i] | (paletteTransparencyLookup[0][j] << 8)`.
+ *
+ * On big-endian platforms, the indices are encoded as `j | (i << 8)`, while the
+ * value order remains the same.
+ */
+extern uint16_t paletteTransparencyLookupBlack16[65536];
 
 void palette_update(int first = 0, int ncolor = 256);
 void palette_init();


### PR DESCRIPTION
`DrawHalfTransparentBlendedRectTo` takes up a significant chunk of time when rendering store and quest dialogs.

Optimizes the function to read 2 blendings at a time and write 4 pixels at a time.

It is a bit of work to measure the exact performance impact of this correctly but it does seem consistently faster on my PC in both debug and release builds.

Example

before
![fast-rect-before](https://user-images.githubusercontent.com/216339/140628822-6d3206b7-b950-437a-8d59-060c88372017.png)

after
![fast-rect-after](https://user-images.githubusercontent.com/216339/140628823-532d005d-8c47-45e5-8219-4abd43a62fd2.png)

Refs #3405
