### PR TITLE
Disable RLE compression for PCX surfaces

### DIFF
--- a/Source/utils/sdl_compat.h
+++ b/Source/utils/sdl_compat.h
@@ -38,9 +38,8 @@ inline const Uint8 *SDLC_GetKeyState()
 inline int SDLC_SetColorKey(SDL_Surface *surface, Uint32 key)
 {
 #ifdef USE_SDL1
-	return SDL_SetColorKey(surface, SDL_SRCCOLORKEY | SDL_RLEACCEL, key);
+	return SDL_SetColorKey(surface, SDL_SRCCOLORKEY, key);
 #else
-	SDL_SetSurfaceRLE(surface, 1);
 	return SDL_SetColorKey(surface, SDL_TRUE, key);
 #endif
 }


### PR DESCRIPTION
With 1.3.0, we switched from CEL to PCX for fonts.

This resulted in significant performance drops when rendering lots of text, because SDL RLE implementation is not as optimized as our CEL implementation.

Disabling RLE significantly reduces the performance drop.

The font surfaces are fairly small, so we do not lose out much on RAM.
The menu surfaces are also PCX, so the RAM usage there is greater, but the game itself uses a lot more RAM than the menu anyway.

Thanks to @AJenbo for discovering the RLE flag as the root cause of font rendering performance issues!