### PR TITLE
Use object reference (and self-id lookup) for BreakBarrel

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -548,10 +548,11 @@ void CheckMissileCol(Missile &missile, int mindam, int maxdam, bool shift, Point
 		}
 	}
 	if (dObject[mx][my] != 0) {
-		int oi = abs(dObject[mx][my]) - 1;
-		if (!Objects[oi]._oMissFlag) {
-			if (Objects[oi]._oBreak == 1)
-				BreakObject(-1, oi);
+		Object &object = Objects[abs(dObject[mx][my]) - 1];
+		if (!object._oMissFlag) {
+			if (object.IsBreakable()) {
+				BreakObject(-1, object);
+			}
 			if (!nodel)
 				missile._mirange = 0;
 			missile._miHitFlag = false;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1554,8 +1554,9 @@ DWORD OnBreakObject(const TCmd *pCmd, int pnum)
 		SendPacket(pnum, &message, sizeof(message));
 	} else if (message.wParam1 < MAX_PLRS && message.wParam2 < MAXOBJECTS) {
 		int playerLevel = Players[pnum].plrlevel;
-		if (currlevel == playerLevel)
-			SyncBreakObj(message.wParam1, message.wParam2);
+		if (currlevel == playerLevel) {
+			SyncBreakObj(message.wParam1, Objects[message.wParam2]);
+		}
 		DeltaSyncObject(message.wParam2, CMD_BREAKOBJ, playerLevel);
 	}
 
@@ -2277,7 +2278,7 @@ void DeltaLoadLevel()
 				SyncOpObject(-1, sgLevels[currlevel].object[i].bCmd, i);
 				break;
 			case CMD_BREAKOBJ:
-				SyncBreakObj(-1, i);
+				SyncBreakObj(-1, Objects[i]);
 				break;
 			default:
 				break;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4125,81 +4125,86 @@ void BreakCrux(Object &crux)
 	ObjChangeMap(crux._oVar1, crux._oVar2, crux._oVar3, crux._oVar4);
 }
 
-void BreakBarrel(int pnum, int i, int dam, bool forcebreak, bool sendmsg)
+void BreakBarrel(int pnum, Object &barrel, int dam, bool forcebreak, bool sendmsg)
 {
-	if (Objects[i]._oSelFlag == 0)
+	if (barrel._oSelFlag == 0)
 		return;
 	if (forcebreak) {
-		Objects[i]._oVar1 = 0;
+		barrel._oVar1 = 0;
 	} else {
-		Objects[i]._oVar1 -= dam;
-		if (pnum != MyPlayerId && Objects[i]._oVar1 <= 0)
-			Objects[i]._oVar1 = 1;
+		barrel._oVar1 -= dam;
+		if (pnum != MyPlayerId && barrel._oVar1 <= 0)
+			barrel._oVar1 = 1;
 	}
-	if (Objects[i]._oVar1 > 0) {
+	if (barrel._oVar1 > 0) {
 		if (deltaload)
 			return;
 
-		PlaySfxLoc(IS_IBOW, Objects[i].position);
+		PlaySfxLoc(IS_IBOW, barrel.position);
 		return;
 	}
 
-	Objects[i]._oVar1 = 0;
-	Objects[i]._oAnimFlag = 1;
-	Objects[i]._oAnimFrame = 1;
-	Objects[i]._oAnimDelay = 1;
-	Objects[i]._oSolidFlag = false;
-	Objects[i]._oMissFlag = true;
-	Objects[i]._oBreak = -1;
-	Objects[i]._oSelFlag = 0;
-	Objects[i]._oPreFlag = true;
+	barrel._oVar1 = 0;
+	barrel._oAnimFlag = 1;
+	barrel._oAnimFrame = 1;
+	barrel._oAnimDelay = 1;
+	barrel._oSolidFlag = false;
+	barrel._oMissFlag = true;
+	barrel._oBreak = -1;
+	barrel._oSelFlag = 0;
+	barrel._oPreFlag = true;
 	if (deltaload) {
-		Objects[i]._oAnimFrame = Objects[i]._oAnimLen;
-		Objects[i]._oAnimCnt = 0;
-		Objects[i]._oAnimDelay = 1000;
+		barrel._oAnimFrame = barrel._oAnimLen;
+		barrel._oAnimCnt = 0;
+		barrel._oAnimDelay = 1000;
 		return;
 	}
 
-	if (Objects[i]._otype == OBJ_BARRELEX) {
+	if (barrel._otype == OBJ_BARRELEX) {
 		if (currlevel >= 21 && currlevel <= 24)
-			PlaySfxLoc(IS_POPPOP3, Objects[i].position);
+			PlaySfxLoc(IS_POPPOP3, barrel.position);
 		else if (currlevel >= 17 && currlevel <= 20)
-			PlaySfxLoc(IS_POPPOP8, Objects[i].position);
+			PlaySfxLoc(IS_POPPOP8, barrel.position);
 		else
-			PlaySfxLoc(IS_BARLFIRE, Objects[i].position);
-		for (int yp = Objects[i].position.y - 1; yp <= Objects[i].position.y + 1; yp++) {
-			for (int xp = Objects[i].position.x - 1; xp <= Objects[i].position.x + 1; xp++) {
-				if (dMonster[xp][yp] > 0)
+			PlaySfxLoc(IS_BARLFIRE, barrel.position);
+		for (int yp = barrel.position.y - 1; yp <= barrel.position.y + 1; yp++) {
+			for (int xp = barrel.position.x - 1; xp <= barrel.position.x + 1; xp++) {
+				if (dMonster[xp][yp] > 0) {
 					MonsterTrapHit(dMonster[xp][yp] - 1, 1, 4, 0, MIS_FIREBOLT, false);
-				bool unused;
-				if (dPlayer[xp][yp] > 0)
+				}
+				if (dPlayer[xp][yp] > 0) {
+					bool unused;
 					PlayerMHit(dPlayer[xp][yp] - 1, nullptr, 0, 8, 16, MIS_FIREBOLT, false, 0, &unused);
-				if (dObject[xp][yp] > 0) {
-					int oi = dObject[xp][yp] - 1;
-					if (Objects[oi]._otype == OBJ_BARRELEX && Objects[oi]._oBreak != -1)
-						BreakBarrel(pnum, oi, dam, true, sendmsg);
+				}
+				int oi = dObject[xp][yp] - 1;
+				if (oi >= 0) {
+					Object &adjacentObject = Objects[oi];
+					if (adjacentObject._otype == _object_id::OBJ_BARRELEX && !adjacentObject.IsBroken()) {
+						BreakBarrel(pnum, adjacentObject, dam, true, sendmsg);
+					}
 				}
 			}
 		}
 	} else {
 		if (currlevel >= 21 && currlevel <= 24)
-			PlaySfxLoc(IS_POPPOP2, Objects[i].position);
+			PlaySfxLoc(IS_POPPOP2, barrel.position);
 		else if (currlevel >= 17 && currlevel <= 20)
-			PlaySfxLoc(IS_POPPOP5, Objects[i].position);
+			PlaySfxLoc(IS_POPPOP5, barrel.position);
 		else
-			PlaySfxLoc(IS_BARREL, Objects[i].position);
-		SetRndSeed(Objects[i]._oRndSeed);
-		if (Objects[i]._oVar2 <= 1) {
-			if (Objects[i]._oVar3 == 0)
-				CreateRndUseful(Objects[i].position, sendmsg);
+			PlaySfxLoc(IS_BARREL, barrel.position);
+		SetRndSeed(barrel._oRndSeed);
+		if (barrel._oVar2 <= 1) {
+			if (barrel._oVar3 == 0)
+				CreateRndUseful(barrel.position, sendmsg);
 			else
-				CreateRndItem(Objects[i].position, false, sendmsg, false);
+				CreateRndItem(barrel.position, false, sendmsg, false);
 		}
-		if (Objects[i]._oVar2 >= 8)
-			SpawnSkeleton(Objects[i]._oVar4, Objects[i].position);
+		if (barrel._oVar2 >= 8)
+			SpawnSkeleton(barrel._oVar4, barrel.position);
 	}
-	if (pnum == MyPlayerId)
-		NetSendCmdParam2(false, CMD_BREAKOBJ, pnum, i);
+	if (pnum == MyPlayerId) {
+		NetSendCmdParam2(false, CMD_BREAKOBJ, pnum, static_cast<uint16_t>(barrel.GetId()));
+	}
 }
 
 void SyncCrux(const Object &crux)
@@ -4324,6 +4329,11 @@ void SyncL3Doors(Object &door)
 }
 
 } // namespace
+
+unsigned int Object::GetId() const
+{
+	return abs(dObject[position.x][position.y]) - 1;
+}
 
 bool Object::IsDisabled() const
 {
@@ -5246,7 +5256,7 @@ void SyncOpObject(int pnum, int cmd, int i)
 	}
 }
 
-void BreakObject(int pnum, int oi)
+void BreakObject(int pnum, Object &object)
 {
 	int objdam = 10;
 	if (pnum != -1) {
@@ -5257,17 +5267,18 @@ void BreakObject(int pnum, int oi)
 		objdam += player._pDamageMod + player._pIBonusDamMod + objdam * player._pIBonusDam / 100;
 	}
 
-	if (Objects[oi].IsBarrel()) {
-		BreakBarrel(pnum, oi, objdam, false, true);
-	} else if (Objects[oi].IsCrux()) {
-		BreakCrux(Objects[oi]);
+	if (object.IsBarrel()) {
+		BreakBarrel(pnum, object, objdam, false, true);
+	} else if (object.IsCrux()) {
+		BreakCrux(object);
 	}
 }
 
 void SyncBreakObj(int pnum, int oi)
 {
-	if (Objects[oi].IsBarrel()) {
-		BreakBarrel(pnum, oi, 0, true, false);
+	Object &object = Objects[oi];
+	if (object.IsBarrel()) {
+		BreakBarrel(pnum, object, 0, true, false);
 	}
 }
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5274,9 +5274,8 @@ void BreakObject(int pnum, Object &object)
 	}
 }
 
-void SyncBreakObj(int pnum, int oi)
+void SyncBreakObj(int pnum, Object &object)
 {
-	Object &object = Objects[oi];
 	if (object.IsBarrel()) {
 		BreakBarrel(pnum, object, 0, true, false);
 	}

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -260,7 +260,7 @@ int ItemMiscIdIdx(item_misc_id imiscid);
 void OperateObject(int pnum, int i, bool TeleFlag);
 void SyncOpObject(int pnum, int cmd, int i);
 void BreakObject(int pnum, Object &object);
-void SyncBreakObj(int pnum, int oi);
+void SyncBreakObj(int pnum, Object &object);
 void SyncObjectAnim(Object &object);
 /**
  * @brief Updates the text drawn in the info box to describe the given object

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -58,6 +58,13 @@ struct Object {
 	int _oVar8;
 
 	/**
+	 * @brief Returns the network identifier for this object
+	 *
+	 * This is currently the index into the Objects array, but may change in the future.
+	 */
+	unsigned int GetId() const;
+
+	/**
 	 * @brief Marks the map region to be refreshed when the player interacts with the object.
 	 *
 	 * Some objects will cause a map region to change when a player interacts with them (e.g. Skeleton King
@@ -120,6 +127,24 @@ struct Object {
 	{
 		SetMapRange(mapRange);
 		_oVar8 = leverID;
+	}
+
+	/**
+	 * @brief Check if the object can be broken (is an intact barrel or crux)
+	 * @return True if the object is intact and breakable, false if already broken or not a breakable object.
+	 */
+	[[nodiscard]] constexpr bool IsBreakable() const
+	{
+		return _oBreak == 1;
+	}
+
+	/**
+	 * @brief Check if the object has been broken
+	 * @return True if the object is breakable and has been broken, false if unbroken or not a breakable object.
+	 */
+	[[nodiscard]] constexpr bool IsBroken() const
+	{
+		return _oBreak == -1;
 	}
 
 	/**
@@ -234,7 +259,7 @@ void TryDisarm(int pnum, int i);
 int ItemMiscIdIdx(item_misc_id imiscid);
 void OperateObject(int pnum, int i, bool TeleFlag);
 void SyncOpObject(int pnum, int cmd, int i);
-void BreakObject(int pnum, int oi);
+void BreakObject(int pnum, Object &object);
 void SyncBreakObj(int pnum, int oi);
 void SyncObjectAnim(Object &object);
 /**

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1143,16 +1143,15 @@ bool PlrHitPlr(int pnum, int8_t p)
 
 bool PlrHitObj(int pnum, int mx, int my)
 {
-	int oi;
-
-	if (dObject[mx][my] > 0) {
-		oi = dObject[mx][my] - 1;
-	} else {
-		oi = -dObject[mx][my] - 1;
+	int oi = abs(dObject[mx][my]) - 1;
+	if (oi < 0) {
+		return false;
 	}
 
-	if (Objects[oi]._oBreak == 1) {
-		BreakObject(pnum, oi);
+	Object &targetObject = Objects[oi];
+
+	if (targetObject.IsBreakable()) {
+		BreakObject(pnum, targetObject);
 		return true;
 	}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1141,15 +1141,8 @@ bool PlrHitPlr(int pnum, int8_t p)
 	return true;
 }
 
-bool PlrHitObj(int pnum, int mx, int my)
+bool PlrHitObj(int pnum, Object &targetObject)
 {
-	int oi = abs(dObject[mx][my]) - 1;
-	if (oi < 0) {
-		return false;
-	}
-
-	Object &targetObject = Objects[oi];
-
 	if (targetObject.IsBreakable()) {
 		BreakObject(pnum, targetObject);
 		return true;
@@ -1214,7 +1207,7 @@ bool DoAttack(int pnum)
 			}
 			didhit = PlrHitPlr(pnum, p);
 		} else if (dObject[dx][dy] > 0) {
-			didhit = PlrHitObj(pnum, dx, dy);
+			didhit = PlrHitObj(pnum, Objects[dObject[dx][dy] - 1]);
 		}
 		if ((player._pClass == HeroClass::Monk
 		        && (player.InvBody[INVLOC_HAND_LEFT]._itype == ItemType::Staff || player.InvBody[INVLOC_HAND_RIGHT]._itype == ItemType::Staff))


### PR DESCRIPTION
Theoretically we can set the ID as an attribute when the object is spawned but I haven't checked how the Objects array is used yet to confirm it's not getting memset at some point after allocation. The GetId method just uses the index (from the dObject cell value) for now.