### PR TITLE
Fix crash in `WordWrapString`

### DIFF
--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -315,7 +315,9 @@ std::string WordWrapString(string_view text, size_t width, GameFontTables size, 
 		}
 		output.append(processedEnd, end);
 		output += '\n';
-		remaining.remove_prefix(lastBreakablePos + lastBreakableLen - (remaining.data() - begin));
+
+		// Restart from the beginning of the new line.
+		remaining = text.substr(lastBreakablePos + lastBreakableLen);
 		processedEnd = remaining.data();
 		lastBreakablePos = -1;
 		lineWidth = 0;


### PR DESCRIPTION
Fixes #3433