### PR TITLE
Automatically insert ZWSP between words in Chinese translation files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,9 @@ end_of_line = lf
 [*.po]
 end_of_line = lf
 
+[*.py]
+end_of_line = lf
+
 [*.yml]
 indent_style = space
 end_of_line = lf

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -327,6 +327,7 @@ std::string WordWrapString(string_view text, size_t width, GameFontTables size, 
 		processedEnd = remaining.data();
 		lastBreakablePos = -1;
 		lineWidth = 0;
+		nextCodepoint = !remaining.empty() ? DecodeFirstUtf8CodePoint(remaining, &nextCodepointLen) : U'\0';
 	} while (!remaining.empty() && remaining[0] != '\0');
 	output.append(processedEnd, remaining.data());
 	return output;

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -288,13 +288,15 @@ std::string WordWrapString(string_view text, size_t width, GameFontTables size, 
 			continue;
 		}
 
-		uint8_t frame = codepoint & 0xFF;
-		uint32_t unicodeRow = codepoint >> 8;
-		if (unicodeRow != currentUnicodeRow || kerning == nullptr) {
-			kerning = LoadFontKerning(size, unicodeRow);
-			currentUnicodeRow = unicodeRow;
+		if (codepoint != ZWSP) {
+			uint8_t frame = codepoint & 0xFF;
+			uint32_t unicodeRow = codepoint >> 8;
+			if (unicodeRow != currentUnicodeRow || kerning == nullptr) {
+				kerning = LoadFontKerning(size, unicodeRow);
+				currentUnicodeRow = unicodeRow;
+			}
+			lineWidth += (*kerning)[frame] + spacing;
 		}
-		lineWidth += (*kerning)[frame] + spacing;
 
 		const bool isWhitespace = IsWhitespace(codepoint);
 		if (isWhitespace || IsBreakAllowed(codepoint, nextCodepoint)) {

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -398,8 +398,8 @@ uint32_t DrawString(const Surface &out, string_view text, const Rectangle &rect,
 
 			if (HasAnyOf(flags, (UiFlags::AlignCenter | UiFlags::AlignRight))) {
 				lineWidth = (*kerning)[frame];
-				if (text[0] != '\0')
-					lineWidth += spacing + GetLineWidth(text, size, spacing);
+				if (!remaining.empty())
+					lineWidth += spacing + GetLineWidth(remaining, size, spacing);
 			}
 
 			if (HasAnyOf(flags, UiFlags::AlignCenter))

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -111,8 +111,8 @@ void DrawQTextContent(const Surface &out)
 			continue;
 		}
 
-		const char *line = TextLines[lineNumber].c_str();
-		if (line[0] == '\0') {
+		const std::string &line = TextLines[lineNumber];
+		if (line.empty()) {
 			continue;
 		}
 

--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -18,23 +18,23 @@ msgstr ""
 
 #: Source/DiabloUI/credits_lines.cpp:7
 msgid "Game Design"
-msgstr "游戏设计"
+msgstr "游戏​设计"
 
 #: Source/DiabloUI/credits_lines.cpp:10
 msgid "Senior Designers"
-msgstr "高级设计师"
+msgstr "高级​设计师"
 
 #: Source/DiabloUI/credits_lines.cpp:13 Source/DiabloUI/credits_lines.cpp:232
 msgid "Additional Design"
-msgstr "附加设计"
+msgstr "附加​设计"
 
 #: Source/DiabloUI/credits_lines.cpp:16 Source/DiabloUI/credits_lines.cpp:215
 msgid "Lead Programmer"
-msgstr "首席程序员"
+msgstr "首席​程序员"
 
 #: Source/DiabloUI/credits_lines.cpp:19
 msgid "Senior Programmers"
-msgstr "高级程序员"
+msgstr "高级​程序员"
 
 #: Source/DiabloUI/credits_lines.cpp:23
 msgid "Programming"
@@ -42,23 +42,23 @@ msgstr "编程"
 
 #: Source/DiabloUI/credits_lines.cpp:26
 msgid "Special Guest Programmers"
-msgstr "特邀程序员"
+msgstr "特​邀​程序员"
 
 #: Source/DiabloUI/credits_lines.cpp:29
 msgid "Battle.net Programming"
-msgstr "战网编程"
+msgstr "战网​编程"
 
 #: Source/DiabloUI/credits_lines.cpp:32
 msgid "Serial Communications Programming"
-msgstr "串行通信编程"
+msgstr "串行​通信​编程"
 
 #: Source/DiabloUI/credits_lines.cpp:35
 msgid "Installer Programming"
-msgstr "安装程序编程"
+msgstr "安装​程序​编程"
 
 #: Source/DiabloUI/credits_lines.cpp:38
 msgid "Art Directors"
-msgstr "艺术总监"
+msgstr "艺术​总监"
 
 #: Source/DiabloUI/credits_lines.cpp:41
 msgid "Artwork"
@@ -66,23 +66,23 @@ msgstr "艺术品"
 
 #: Source/DiabloUI/credits_lines.cpp:48
 msgid "Technical Artwork"
-msgstr "技术艺术品"
+msgstr "技术​艺术品"
 
 #: Source/DiabloUI/credits_lines.cpp:52
 msgid "Cinematic Art Directors"
-msgstr "电影艺术导演"
+msgstr "电影​艺术​导演"
 
 #: Source/DiabloUI/credits_lines.cpp:55
 msgid "3D Cinematic Artwork"
-msgstr "3D电影艺术品"
+msgstr "3D​电影​艺术品"
 
 #: Source/DiabloUI/credits_lines.cpp:61
 msgid "Cinematic Technical Artwork"
-msgstr "电影技术艺术品"
+msgstr "电影​技术​艺术品"
 
 #: Source/DiabloUI/credits_lines.cpp:64
 msgid "Executive Producer"
-msgstr "执行制片人"
+msgstr "执行​制片人"
 
 #: Source/DiabloUI/credits_lines.cpp:67
 msgid "Producer"
@@ -90,12 +90,12 @@ msgstr "制作人"
 
 #: Source/DiabloUI/credits_lines.cpp:70
 msgid "Associate Producer"
-msgstr "副制片人"
+msgstr "副​制片人"
 
 #. TRANSLATORS: Keep Strike Team as Name
 #: Source/DiabloUI/credits_lines.cpp:73
 msgid "Diablo Strike Team"
-msgstr "破坏神突击队"
+msgstr "破坏​神​突击队"
 
 #: Source/DiabloUI/credits_lines.cpp:77 Source/gamemenu.cpp:67
 msgid "Music"
@@ -103,23 +103,23 @@ msgstr "音乐"
 
 #: Source/DiabloUI/credits_lines.cpp:80
 msgid "Sound Design"
-msgstr "音响设计"
+msgstr "音响​设计"
 
 #: Source/DiabloUI/credits_lines.cpp:83
 msgid "Cinematic Music & Sound"
-msgstr "电影音乐与声音"
+msgstr "电影​音乐​与​声音"
 
 #: Source/DiabloUI/credits_lines.cpp:86
 msgid "Voice Production, Direction & Casting"
-msgstr "声音制作、导演和播音"
+msgstr "声音​制作​、​导演​和​播音"
 
 #: Source/DiabloUI/credits_lines.cpp:89
 msgid "Script & Story"
-msgstr "脚本和故事"
+msgstr "脚​本​和​故事"
 
 #: Source/DiabloUI/credits_lines.cpp:93
 msgid "Voice Editing"
-msgstr "语音编辑"
+msgstr "语音​编辑"
 
 #: Source/DiabloUI/credits_lines.cpp:96 Source/DiabloUI/credits_lines.cpp:250
 msgid "Voices"
@@ -127,44 +127,44 @@ msgstr "声音"
 
 #: Source/DiabloUI/credits_lines.cpp:101
 msgid "Recording Engineer"
-msgstr "录音工程师"
+msgstr "录音​工程师"
 
 #: Source/DiabloUI/credits_lines.cpp:104
 msgid "Manual Design & Layout"
-msgstr "手动设计和布局"
+msgstr "手动​设计​和​布局"
 
 #: Source/DiabloUI/credits_lines.cpp:108
 msgid "Manual Artwork"
-msgstr "手工艺术品"
+msgstr "手工​艺术品"
 
 #: Source/DiabloUI/credits_lines.cpp:112
 msgid "Provisional Director of QA (Lead Tester)"
-msgstr "QA临时总监（铅试验器）"
+msgstr "QA​临时​总监​（​铅​试验器​）"
 
 #: Source/DiabloUI/credits_lines.cpp:115
 msgid "QA Assault Team (Testers)"
-msgstr "QA突击队（测试人员）"
+msgstr "QA​突击队​（​测试​人员​）"
 
 #: Source/DiabloUI/credits_lines.cpp:120
 msgid "QA Special Ops Team (Compatibility Testers)"
-msgstr "QA特别行动小组（兼容性测试人员）"
+msgstr "QA​特别​行动​小组​（​兼容性​测试​人员​）"
 
 #: Source/DiabloUI/credits_lines.cpp:123
 msgid "QA Artillery Support (Additional Testers) "
-msgstr "QA火力支援（附加测试人员） "
+msgstr "QA​火力​支援​（​附加​测试​人员​） "
 
 #: Source/DiabloUI/credits_lines.cpp:127
 msgid "QA Counterintelligence"
-msgstr "QA反情报"
+msgstr "QA​反​情报"
 
 #. TRANSLATORS: A group of people
 #: Source/DiabloUI/credits_lines.cpp:130
 msgid "Order of Network Information Services"
-msgstr "网络信息服务秩序"
+msgstr "网络​信息​服务​秩序"
 
 #: Source/DiabloUI/credits_lines.cpp:134
 msgid "Customer Support"
-msgstr "客户支持"
+msgstr "客户​支持"
 
 #: Source/DiabloUI/credits_lines.cpp:139
 msgid "Sales"
@@ -176,11 +176,11 @@ msgstr "邓塞尔"
 
 #: Source/DiabloUI/credits_lines.cpp:145
 msgid "Mr. Dabiri's Background Vocalists"
-msgstr "达比里先生的背景歌手"
+msgstr "达​比​里​先生​的​背景​歌手"
 
 #: Source/DiabloUI/credits_lines.cpp:149
 msgid "Public Relations"
-msgstr "公共关系"
+msgstr "公共​关系"
 
 #: Source/DiabloUI/credits_lines.cpp:152
 msgid "Marketing"
@@ -188,11 +188,11 @@ msgstr "营销"
 
 #: Source/DiabloUI/credits_lines.cpp:155
 msgid "International Sales"
-msgstr "国际销售"
+msgstr "国际​销售"
 
 #: Source/DiabloUI/credits_lines.cpp:158
 msgid "U.S. Sales"
-msgstr "美国销售"
+msgstr "美国​销售"
 
 #: Source/DiabloUI/credits_lines.cpp:161
 msgid "Manufacturing"
@@ -200,11 +200,11 @@ msgstr "制造业"
 
 #: Source/DiabloUI/credits_lines.cpp:164
 msgid "Legal & Business"
-msgstr "法律与商业"
+msgstr "法律​与​商业"
 
 #: Source/DiabloUI/credits_lines.cpp:167
 msgid "Special Thanks To"
-msgstr "特别感谢"
+msgstr "特别​感谢"
 
 #: Source/DiabloUI/credits_lines.cpp:171
 msgid "Thanks To"
@@ -212,11 +212,11 @@ msgstr "感谢"
 
 #: Source/DiabloUI/credits_lines.cpp:200
 msgid "In memory of"
-msgstr "为了纪念"
+msgstr "为了​纪念"
 
 #: Source/DiabloUI/credits_lines.cpp:206
 msgid "Very Special Thanks to"
-msgstr "非常特别感谢"
+msgstr "非常​特别​感谢"
 
 #: Source/DiabloUI/credits_lines.cpp:212
 msgid "General Manager"
@@ -224,11 +224,11 @@ msgstr "总经理"
 
 #: Source/DiabloUI/credits_lines.cpp:218
 msgid "Software Engineering"
-msgstr "软件工程"
+msgstr "软件​工程"
 
 #: Source/DiabloUI/credits_lines.cpp:221
 msgid "Art Director"
-msgstr "艺术总监"
+msgstr "艺术​总监"
 
 #: Source/DiabloUI/credits_lines.cpp:224
 msgid "Artists"
@@ -240,15 +240,15 @@ msgstr "设计"
 
 #: Source/DiabloUI/credits_lines.cpp:235
 msgid "Sound Design, SFX & Audio Engineering"
-msgstr "声音设计、SFX和音频工程"
+msgstr "声音​设计​、​SFX​和​音频​工程"
 
 #: Source/DiabloUI/credits_lines.cpp:238
 msgid "Quality Assurance Lead"
-msgstr "质量保证负责人"
+msgstr "质量​保证​负责人"
 
 #: Source/DiabloUI/credits_lines.cpp:241
 msgid "Testers"
-msgstr "测试人员"
+msgstr "测试​人员"
 
 #: Source/DiabloUI/credits_lines.cpp:246
 msgid "Manual"
@@ -256,11 +256,11 @@ msgstr "手册"
 
 #: Source/DiabloUI/credits_lines.cpp:255
 msgid "\tAdditional Work"
-msgstr "\t附加工作"
+msgstr "\t​附加​工作"
 
 #: Source/DiabloUI/credits_lines.cpp:257
 msgid "Quest Text Writing"
-msgstr "任务文本写作"
+msgstr "任务​文本​写作"
 
 #: Source/DiabloUI/credits_lines.cpp:260 Source/DiabloUI/credits_lines.cpp:295
 msgid "Thanks to"
@@ -268,7 +268,7 @@ msgstr "感谢"
 
 #: Source/DiabloUI/credits_lines.cpp:265
 msgid "\t\t\tSpecial Thanks to Blizzard Entertainment"
-msgstr "\t\t\t特别感谢暴雪娱乐"
+msgstr "\t\t\t​特别​感谢​暴雪​娱乐"
 
 #: Source/DiabloUI/credits_lines.cpp:270
 msgid "\t\t\tSierra On-Line Inc. Northwest"
@@ -276,39 +276,39 @@ msgstr "\t\t\tSierra On-Line Inc. Northwest"
 
 #: Source/DiabloUI/credits_lines.cpp:272
 msgid "Quality Assurance Manager"
-msgstr "质量保证经理"
+msgstr "质量​保证​经理"
 
 #: Source/DiabloUI/credits_lines.cpp:275
 msgid "Quality Assurance Lead Tester"
-msgstr "质量保证铅测试仪"
+msgstr "质量​保证​铅​测试仪"
 
 #: Source/DiabloUI/credits_lines.cpp:278
 msgid "Main Testers"
-msgstr "主要测试人员"
+msgstr "主要​测试​人员"
 
 #: Source/DiabloUI/credits_lines.cpp:281
 msgid "Additional Testers"
-msgstr "附加测试人员"
+msgstr "附加​测试​人员"
 
 #: Source/DiabloUI/credits_lines.cpp:286
 msgid "Product Marketing Manager"
-msgstr "产品营销经理"
+msgstr "产品​营销​经理"
 
 #: Source/DiabloUI/credits_lines.cpp:289
 msgid "Public Relations Manager"
-msgstr "公共关系经理"
+msgstr "公共​关系​经理"
 
 #: Source/DiabloUI/credits_lines.cpp:292
 msgid "Associate Product Manager"
-msgstr "副产品经理"
+msgstr "副产品​经理"
 
 #: Source/DiabloUI/credits_lines.cpp:301
 msgid "The Ring of One Thousand"
-msgstr "千人之戒"
+msgstr "千​人​之​戒"
 
 #: Source/DiabloUI/credits_lines.cpp:547
 msgid "\tNo souls were sold in the making of this game."
-msgstr "\t在这个游戏的制作过程中没有灵魂被出卖。"
+msgstr "\t​在​这​个​游戏​的​制作​过程​中​没有​灵魂​被​出卖​。"
 
 #: Source/DiabloUI/dialogs.cpp:194 Source/DiabloUI/dialogs.cpp:206
 #: Source/DiabloUI/selconn.cpp:79 Source/DiabloUI/selgame.cpp:103
@@ -322,23 +322,23 @@ msgstr "确定"
 
 #: Source/DiabloUI/extrasmenu.cpp:41 Source/DiabloUI/selstart.cpp:44
 msgid "Switch to Diablo"
-msgstr "切换到原版"
+msgstr "切换​到​原版"
 
 #: Source/DiabloUI/extrasmenu.cpp:41
 msgid "Switch to Hellfire"
-msgstr "切换到地狱火"
+msgstr "切换​到​地狱火"
 
 #: Source/DiabloUI/extrasmenu.cpp:43
 msgid "Switch to Fullgame"
-msgstr "切换到完整版游戏"
+msgstr "切换​到​完整​版​游戏"
 
 #: Source/DiabloUI/extrasmenu.cpp:43
 msgid "Switch to Shareware"
-msgstr "切换到共享版"
+msgstr "切换​到​共​享版"
 
 #: Source/DiabloUI/extrasmenu.cpp:44
 msgid "Replay Intro"
-msgstr "重播动画"
+msgstr "重​播动画"
 
 #: Source/DiabloUI/extrasmenu.cpp:45
 msgid "Support"
@@ -346,35 +346,35 @@ msgstr "支持"
 
 #: Source/DiabloUI/extrasmenu.cpp:46 Source/gamemenu.cpp:61
 msgid "Previous Menu"
-msgstr "上一个菜单"
+msgstr "上​一​个​菜单"
 
 #: Source/DiabloUI/mainmenu.cpp:36
 msgid "Single Player"
-msgstr "单人游戏"
+msgstr "单人​游戏"
 
 #: Source/DiabloUI/mainmenu.cpp:37
 msgid "Multi Player"
-msgstr "多人游戏"
+msgstr "多​人​游戏"
 
 #: Source/DiabloUI/mainmenu.cpp:38
 msgid "Extras"
-msgstr "额外内容"
+msgstr "额外​内容"
 
 #: Source/DiabloUI/mainmenu.cpp:39
 msgid "Show Credits"
-msgstr "显示制作组"
+msgstr "显示​制作组"
 
 #: Source/DiabloUI/mainmenu.cpp:40
 msgid "Exit Hellfire"
-msgstr "退出地狱火"
+msgstr "退出​地狱火"
 
 #: Source/DiabloUI/mainmenu.cpp:40
 msgid "Exit Diablo"
-msgstr "退出暗黑破坏神"
+msgstr "退出​暗黑​破坏​神"
 
 #: Source/DiabloUI/mainmenu.cpp:55
 msgid "Shareware"
-msgstr "共享版"
+msgstr "共​享版"
 
 #: Source/DiabloUI/progress.cpp:36 Source/DiabloUI/selconn.cpp:82
 #: Source/DiabloUI/selhero.cpp:189 Source/DiabloUI/selhero.cpp:214
@@ -384,7 +384,7 @@ msgstr "取消"
 
 #: Source/DiabloUI/selconn.cpp:13
 msgid "Client-Server (TCP)"
-msgstr "客户端-服务器(TCP)"
+msgstr "客户​端​-​服务器​(​TCP)"
 
 #: Source/DiabloUI/selconn.cpp:14
 msgid "Loopback"
@@ -393,60 +393,60 @@ msgstr "回环"
 #: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:484
 #: Source/DiabloUI/selgame.cpp:505
 msgid "Multi Player Game"
-msgstr "多人游戏"
+msgstr "多​人​游戏"
 
 #: Source/DiabloUI/selconn.cpp:59
 msgid "Requirements:"
-msgstr "要求:"
+msgstr "要求​:"
 
 #: Source/DiabloUI/selconn.cpp:65
 msgid "no gateway needed"
-msgstr "不需要网关"
+msgstr "不​需要​网关"
 
 #: Source/DiabloUI/selconn.cpp:71
 msgid "Select Connection"
-msgstr "选择连接"
+msgstr "选择​连接"
 
 #: Source/DiabloUI/selconn.cpp:74
 msgid "Change Gateway"
-msgstr "更改网关"
+msgstr "更改​网关"
 
 #: Source/DiabloUI/selconn.cpp:107
 msgid "All computers must be connected to a TCP-compatible network."
-msgstr "所有计算机必须连接到与TCP兼容的网络。"
+msgstr "所有​计算机​必须​连接​到​与​TCP​兼容​的​网络​。"
 
 #: Source/DiabloUI/selconn.cpp:111
 msgid "All computers must be connected to the internet."
-msgstr "所有计算机都必须连接到因特网。"
+msgstr "所有​计算机​都​必须​连接​到​因特网​。"
 
 #: Source/DiabloUI/selconn.cpp:115
 msgid "Play by yourself with no network exposure."
-msgstr "在没有网络开放的情况下自己游玩。"
+msgstr "在​没有​网络​开放​的​情况​下​自己​游玩​。"
 
 #: Source/DiabloUI/selconn.cpp:120
 msgid "Players Supported: {:d}"
-msgstr "支持的玩家: {:d}"
+msgstr "支持​的​玩家​:​ {:d}"
 
 #: Source/DiabloUI/selgame.cpp:82 Source/DiabloUI/selgame.cpp:414
 msgid "Description:"
-msgstr "说明:"
+msgstr "说明​:"
 
 #: Source/DiabloUI/selgame.cpp:88
 msgid "Select Action"
-msgstr "选择操作"
+msgstr "选择​操作"
 
 #: Source/DiabloUI/selgame.cpp:91 Source/DiabloUI/selgame.cpp:181
 #: Source/DiabloUI/selgame.cpp:333
 msgid "Create Game"
-msgstr "创建游戏"
+msgstr "创建​游戏"
 
 #: Source/DiabloUI/selgame.cpp:93
 msgid "Create Public Game"
-msgstr "创建公开游戏"
+msgstr "创建​公开​游戏"
 
 #: Source/DiabloUI/selgame.cpp:94
 msgid "Join Game"
-msgstr "加入游戏"
+msgstr "加入​游戏"
 
 #: Source/DiabloUI/selgame.cpp:106 Source/DiabloUI/selgame.cpp:196
 #: Source/DiabloUI/selgame.cpp:214 Source/DiabloUI/selgame.cpp:355
@@ -456,27 +456,27 @@ msgstr "取消"
 
 #: Source/DiabloUI/selgame.cpp:122
 msgid "Create a new game with a difficulty setting of your choice."
-msgstr "从你选择的难度设置创建游戏。"
+msgstr "从​你​选择​的​难度​设置​创建​游戏​。"
 
 #: Source/DiabloUI/selgame.cpp:125
 msgid ""
 "Create a new public game that anyone can join with a difficulty setting of "
 "your choice."
-msgstr "创建一个公开游戏，任何人都可加入的，游戏难度将依据你的设定。"
+msgstr "创建​一​个​公开​游戏​，​任何​人​都​可​加入​的​，​游戏​难度​将​依据​你​的​设定​。"
 
 #: Source/DiabloUI/selgame.cpp:128
 msgid ""
 "Enter an IP or a hostname and join a game already in progress at that "
 "address."
-msgstr "输入IP或主机名，然后加入在该地址正在进行的游戏。"
+msgstr "输入​IP​或​主机名​，​然后​加入​在​该​地址​正在​进行​的​游戏​。"
 
 #: Source/DiabloUI/selgame.cpp:131
 msgid "Join the public game already in progress at this address."
-msgstr "加入该地址已经处于进行中的公开游戏。"
+msgstr "加入​该​地址​已经​处于​进行​中​的​公开​游戏​。"
 
 #: Source/DiabloUI/selgame.cpp:184
 msgid "Select Difficulty"
-msgstr "选择难度"
+msgstr "选择​难度"
 
 #: Source/DiabloUI/selgame.cpp:186 Source/DiabloUI/selgame.cpp:239
 #: Source/DiabloUI/selgame.cpp:344 Source/DiabloUI/selgame.cpp:364
@@ -487,7 +487,7 @@ msgstr "正常"
 #: Source/DiabloUI/selgame.cpp:187 Source/DiabloUI/selgame.cpp:243
 #: Source/diablo.cpp:1447
 msgid "Nightmare"
-msgstr "噩梦"
+msgstr "噩​梦"
 
 #: Source/DiabloUI/selgame.cpp:188 Source/DiabloUI/selgame.cpp:247
 #: Source/diablo.cpp:1448
@@ -496,19 +496,19 @@ msgstr "地狱"
 
 #: Source/DiabloUI/selgame.cpp:202
 msgid "Join TCP Games"
-msgstr "加入TCP游戏"
+msgstr "加入​TCP​游戏"
 
 #: Source/DiabloUI/selgame.cpp:205 Source/DiabloUI/selgame.cpp:208
 msgid "Enter address"
-msgstr "输入地址"
+msgstr "输入​地址"
 
 #: Source/DiabloUI/selgame.cpp:240
 msgid ""
 "Normal Difficulty\n"
 "This is where a starting character should begin the quest to defeat Diablo."
 msgstr ""
-"正常难度\n"
-"一个新角色应从此开始，最终击败迪亚波罗。"
+"正常​难度​\n"
+"​一​个​新​角色​应​从此​开始​，​最终​击败迪亚波罗​。"
 
 #: Source/DiabloUI/selgame.cpp:244
 msgid ""
@@ -516,8 +516,8 @@ msgid ""
 "The denizens of the Labyrinth have been bolstered and will prove to be a "
 "greater challenge. This is recommended for experienced characters only."
 msgstr ""
-"噩梦难度\n"
-"迷宫里的怪物将被强化，这将是一个更大的挑战。只建议经验丰富的角色进行挑战。"
+"噩​梦​难度​\n"
+"迷宫​里​的​怪物​将​被​强化​，​这​将​是​一​个​更​大​的​挑战​。​只​建议​经验​丰富​的​角色​进行​挑战​。"
 
 #: Source/DiabloUI/selgame.cpp:248
 msgid ""
@@ -525,25 +525,25 @@ msgid ""
 "The most powerful of the underworld's creatures lurk at the gateway into "
 "Hell. Only the most experienced characters should venture in this realm."
 msgstr ""
-"地狱困难\n"
-"最强大的地底世界的生物潜伏在地狱的大门。只有最有经验的角色才能在这个国度中冒"
-"险。"
+"地狱​困难​\n"
+"​最​强大​的​地底​世界​的​生物​潜伏​在地狱​的​大门​。​只​有​最​有​经验​的​角色​才​能​在​这个​国度​中​"
+"冒险​。"
 
 #: Source/DiabloUI/selgame.cpp:264
 msgid ""
 "Your character must reach level 20 before you can enter a multiplayer game "
 "of Nightmare difficulty."
-msgstr "你的角色必须达到20级才能进入噩梦难度的多人游戏。"
+msgstr "你​的​角色​必须​达到​20​级​才​能​进入​噩梦​难度​的​多​人​游戏​。"
 
 #: Source/DiabloUI/selgame.cpp:266
 msgid ""
 "Your character must reach level 30 before you can enter a multiplayer game "
 "of Hell difficulty."
-msgstr "你的角色必须达到30级才能进入地狱难度的多人游戏。"
+msgstr "你​的​角色​必须​达到​30​级​才​能​进入​地狱​难度​的​多​人​游戏​。"
 
 #: Source/DiabloUI/selgame.cpp:342
 msgid "Select Game Speed"
-msgstr "选择游戏速度"
+msgstr "选择​游戏​速度"
 
 #: Source/DiabloUI/selgame.cpp:345 Source/DiabloUI/selgame.cpp:368
 msgid "Fast"
@@ -551,19 +551,19 @@ msgstr "快速"
 
 #: Source/DiabloUI/selgame.cpp:346 Source/DiabloUI/selgame.cpp:372
 msgid "Faster"
-msgstr "更快"
+msgstr "更​快"
 
 #: Source/DiabloUI/selgame.cpp:347 Source/DiabloUI/selgame.cpp:376
 msgid "Fastest"
-msgstr "最快"
+msgstr "最​快"
 
 #: Source/DiabloUI/selgame.cpp:365
 msgid ""
 "Normal Speed\n"
 "This is where a starting character should begin the quest to defeat Diablo."
 msgstr ""
-"正常\n"
-"一个新角色应从此开始，最终击败迪亚波罗。"
+"正常​\n"
+"​一​个​新​角色​应​从此​开始​，​最终​击败迪亚波罗​。"
 
 #: Source/DiabloUI/selgame.cpp:369
 msgid ""
@@ -571,9 +571,9 @@ msgid ""
 "The denizens of the Labyrinth have been hastened and will prove to be a "
 "greater challenge. This is recommended for experienced characters only."
 msgstr ""
-"快速\n"
-"迷宫的居民们已经被催促了，这将是一个更大的挑战。只建议经验丰富的角色进行挑"
-"战。"
+"快速​\n"
+"迷宫​的​居民们​已经​被​催促​了​，​这​将​是​一​个​更​大​的​挑战​。​只​建议​经验​丰富​的​角色​进行​挑战"
+"​。"
 
 #: Source/DiabloUI/selgame.cpp:373
 msgid ""
@@ -581,9 +581,9 @@ msgid ""
 "Most monsters of the dungeon will seek you out quicker than ever before. "
 "Only an experienced champion should try their luck at this speed."
 msgstr ""
-"更快\n"
-"地牢里的大多数怪物会比以前更快地找到你。只有经验丰富的勇士才能在这个速度下砰"
-"砰运气。"
+"更​快​\n"
+"​地​牢里​的​大多数​怪物会​比​以前​更​快​地​找到​你​。​只有​经验​丰富​的​勇士​才​能​在​这个​速度​下​砰"
+"砰​运气​。"
 
 #: Source/DiabloUI/selgame.cpp:377
 msgid ""
@@ -591,29 +591,29 @@ msgid ""
 "The minions of the underworld will rush to attack without hesitation. Only a "
 "true speed demon should enter at this pace."
 msgstr ""
-"最快\n"
-"地下世界的仆从们会毫不犹豫地冲过来袭击。只有真正的速度恶魔才能赶得上脚步。"
+"最​快​\n"
+"​地下​世界​的​仆从们​会​毫​不​犹豫​地​冲​过​来​袭击​。​只有​真正​的​速度​恶魔​才​能​赶​得​上​脚步​。"
 
 #: Source/DiabloUI/selgame.cpp:420 Source/DiabloUI/selgame.cpp:425
 msgid "Enter Password"
-msgstr "输入密码"
+msgstr "输入​密码"
 
 #: Source/DiabloUI/selgame.cpp:448
 msgid "The host is running a different game than you."
-msgstr "主机运行的游戏与您不同。"
+msgstr "主机​运行​的​游戏​与​您​不同​。"
 
 #. TRANSLATORS: Error message when somebody tries to join a game running another version.
 #: Source/DiabloUI/selgame.cpp:451
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
-msgstr "您的版本{:s}与主机{:d}.{:d}.{:d}不匹配。"
+msgstr "您​的​版本​{:s}​与​主机{:d}.{:d}.{:d}​不​匹配​。"
 
 #: Source/DiabloUI/selhero.cpp:100
 msgid "New Hero"
-msgstr "新英雄"
+msgstr "新​英雄"
 
 #: Source/DiabloUI/selhero.cpp:164
 msgid "Choose Class"
-msgstr "选择职业"
+msgstr "选择​职业"
 
 #: Source/DiabloUI/selhero.cpp:168 Source/panels/charpanel.cpp:22
 msgid "Warrior"
@@ -633,111 +633,111 @@ msgstr "武僧"
 
 #: Source/DiabloUI/selhero.cpp:175 Source/panels/charpanel.cpp:26
 msgid "Bard"
-msgstr "吟游诗人"
+msgstr "吟游​诗人"
 
 #: Source/DiabloUI/selhero.cpp:178 Source/panels/charpanel.cpp:27
 msgid "Barbarian"
-msgstr "野蛮人"
+msgstr "野​蛮​人"
 
 #: Source/DiabloUI/selhero.cpp:195 Source/DiabloUI/selhero.cpp:269
 msgid "New Multi Player Hero"
-msgstr "新建多人游戏英雄"
+msgstr "新建​多​人​游戏​英雄"
 
 #: Source/DiabloUI/selhero.cpp:195 Source/DiabloUI/selhero.cpp:269
 msgid "New Single Player Hero"
-msgstr "新建单人游戏英雄"
+msgstr "新​建​单人​游戏​英雄"
 
 #: Source/DiabloUI/selhero.cpp:203
 msgid "Save File Exists"
-msgstr "保存文件已存在"
+msgstr "保存​文件​已​存在"
 
 #: Source/DiabloUI/selhero.cpp:206 Source/gamemenu.cpp:38
 msgid "Load Game"
-msgstr "加载游戏"
+msgstr "加载​游戏"
 
 #: Source/DiabloUI/selhero.cpp:207 Source/gamemenu.cpp:37
 #: Source/gamemenu.cpp:48
 msgid "New Game"
-msgstr "新游戏"
+msgstr "新​游戏"
 
 #: Source/DiabloUI/selhero.cpp:217 Source/DiabloUI/selhero.cpp:551
 msgid "Single Player Characters"
-msgstr "单人游戏角色"
+msgstr "单人​游戏​角色"
 
 #: Source/DiabloUI/selhero.cpp:263
 msgid ""
 "The Rogue and Sorcerer are only available in the full retail version of "
 "Diablo. Visit https://www.gog.com/game/diablo to purchase."
 msgstr ""
-"流亡者和巫师只在暗黑破坏神的完整零售版中提供。前往 https://www.gog.com/game/"
-"diablo 购买。"
+"流亡者​和​巫师​只​在​暗黑​破坏​神​的​完整​零售版​中​提供​。​前往​ https://www.gog.com/ga"
+"me/diablo ​购买​。"
 
 #: Source/DiabloUI/selhero.cpp:275 Source/DiabloUI/selhero.cpp:278
 msgid "Enter Name"
-msgstr "输入名称"
+msgstr "输入​名称"
 
 #: Source/DiabloUI/selhero.cpp:307
 msgid ""
 "Invalid name. A name cannot contain spaces, reserved characters, or reserved "
 "words.\n"
-msgstr "名称无效。名称不能包含空格、保留字符或保留词语。\n"
+msgstr "名称​无效​。​名称​不​能​包含​空格​、​保留​字符​或​保留​词语​。​\n"
 
 #. TRANSLATORS: Error Message
 #: Source/DiabloUI/selhero.cpp:314
 msgid "Unable to create character."
-msgstr "无法创建角色。"
+msgstr "无法​创建​角色​。"
 
 #: Source/DiabloUI/selhero.cpp:468 Source/DiabloUI/selhero.cpp:471
 msgid "Level:"
-msgstr "等级:"
+msgstr "等级​:"
 
 #: Source/DiabloUI/selhero.cpp:476
 msgid "Strength:"
-msgstr "力量:"
+msgstr "力量​:"
 
 #: Source/DiabloUI/selhero.cpp:481
 msgid "Magic:"
-msgstr "魔法:"
+msgstr "魔法​:"
 
 #: Source/DiabloUI/selhero.cpp:486
 msgid "Dexterity:"
-msgstr "敏捷:"
+msgstr "敏捷​:"
 
 #: Source/DiabloUI/selhero.cpp:491
 msgid "Vitality:"
-msgstr "活力:"
+msgstr "活力​:"
 
 #: Source/DiabloUI/selhero.cpp:497
 msgid "Savegame:"
-msgstr "保存游戏："
+msgstr "保存​游戏​："
 
 #: Source/DiabloUI/selhero.cpp:510
 msgid "Select Hero"
-msgstr "选择英雄"
+msgstr "选择​英雄"
 
 #: Source/DiabloUI/selhero.cpp:539
 msgid "Delete"
-msgstr "删除"
+msgstr "删​除"
 
 #: Source/DiabloUI/selhero.cpp:549
 msgid "Multi Player Characters"
-msgstr "多人游戏角色"
+msgstr "多​人​游戏​角色"
 
 #: Source/DiabloUI/selhero.cpp:599
 msgid "Delete Multi Player Hero"
-msgstr "删除多人游戏英雄"
+msgstr "删​除​多​人​游戏​英雄"
 
 #: Source/DiabloUI/selhero.cpp:601
 msgid "Delete Single Player Hero"
-msgstr "删除单人游戏英雄"
+msgstr "删​除​单人​游戏​英雄"
 
 #: Source/DiabloUI/selhero.cpp:603
 msgid "Are you sure you want to delete the character \"{:s}\"?"
-msgstr "是否确实要删除角色“{:s}”？"
+msgstr "是否​确实​要​删除​角色​“​{:s}​”​？"
 
 #: Source/DiabloUI/selstart.cpp:43
 msgid "Enter Hellfire"
-msgstr "进入《地狱火》"
+msgstr "进入​《​地狱火​》"
 
 #: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
 msgid "Yes"
@@ -753,8 +753,8 @@ msgid ""
 "community where we talk about things related to Diablo, and the Hellfire "
 "expansion."
 msgstr ""
-"我们维护的聊天服务器部署在 Discord.gg/YQKCAYQ ，点击连接加入我们的社群，我们"
-"在那里谈论有关暗黑破坏神以及地狱火资料片。"
+"我们​维护​的​聊天​服务器​部署​在​ Discord.gg/YQKCAYQ ​，​点击​连接​加入​我们​的​社群​，​我"
+"们​在​那里​谈论​有关​暗黑​破坏​神​以及​地狱火​资料片​。"
 
 #: Source/DiabloUI/support_lines.cpp:10
 msgid ""
@@ -763,13 +763,13 @@ msgid ""
 "serve you, please be sure to include the version number, operating system, "
 "and the nature of the problem."
 msgstr ""
-"DevilutionX由Diasurgical维护，可以报告问题和错误地址: https://github.com/"
-"diasurgical/devilutionX为了帮助我们更好地为您服务，请务必提供所使用的版本号，"
-"操作系统，以及问题的性质。"
+"DevilutionX​由​Diasurgical​维护​，​可以​报告​问题​和​错误​地址​:​ https://gith"
+"ub.com/diasurgical/devilutionX​为了​帮助​我们​更​好​地​为​您​服务​，​请​务必​提供​"
+"所​使用​的​版本​号​，​操作​系统​，​以及​问题​的​性质​。"
 
 #: Source/DiabloUI/support_lines.cpp:13
 msgid "Disclaimer:"
-msgstr "免责声明:"
+msgstr "免责​声明​:"
 
 #: Source/DiabloUI/support_lines.cpp:14
 msgid ""
@@ -779,9 +779,9 @@ msgid ""
 "DevilutionX should be directed to Diasurgical, not to Blizzard Entertainment "
 "or GOG.com."
 msgstr ""
-"\t暴雪娱乐和GOG.com不提供支持和维护DevilutionX，他们也没有对DevilutionX进行质"
-"量和兼容性测试。所有相关问题咨询，请直接联系Diasurgical，而不是暴雪娱乐或GOG."
-"com。"
+"\t​暴雪​娱乐​和​GOG.com​不​提供​支持​和​维护​DevilutionX​，​他们​也​没有​对​Devilut"
+"ionX​进行​质量​和​兼容性​测试​。​所有​相关​问题​咨询​，​请​直接​联系​Diasurgical​，​而​不​是"
+"​暴雪​娱乐​或​GOG.com​。"
 
 #: Source/DiabloUI/support_lines.cpp:17
 msgid ""
@@ -790,13 +790,13 @@ msgid ""
 "CC-BY 4.0. The port also makes use of SDL which is licensed under the zlib-"
 "license. See the ReadMe for further details."
 msgstr ""
-"\t这个移植使用了 CharisSILB、Unifont 和 Noto，它们处于SIL Open Font License、"
-"CC-BY 4.0和Twitmoji许可授权。该移植还使用了SDL，处于zlib-license许可。更多细"
-"节请参见ReadMe。"
+"\t​这个​移植​使用​了​ CharisSILB​、​Unifont ​和​ Noto​，​它们​处于​SIL Open F"
+"ont License​、​CC-BY 4.0​和​Twitmoji许可​授权​。​该​移植​还​使用​了​SDL​，​处于​"
+"zlib-license许可​。​更​多​细节​请​参见​ReadMe​。"
 
 #: Source/DiabloUI/title.cpp:44
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
-msgstr "Copyright © 1996-2001 Blizzard Entertainment"
+msgstr "Copyright ​©​ 1996-2001 Blizzard Entertainment"
 
 #: Source/appfat.cpp:37
 msgid "Error"
@@ -811,7 +811,7 @@ msgid ""
 msgstr ""
 "{:s}\n"
 "\n"
-"错误发生在: {:s}，行{:d}"
+"​错误​发生​在​:​ {:s}​，​行{:d}"
 
 #: Source/appfat.cpp:116
 msgid ""
@@ -819,13 +819,13 @@ msgid ""
 "\n"
 "Make sure that it is in the game folder."
 msgstr ""
-"无法打开主数据存档({:s})。\n"
+"无法​打开​主​数据​存档​({:s})​。​\n"
 "\n"
-"确保它在游戏文件夹中，并且文件名都是小写的。"
+"​确保​它​在​游戏​文件​夹​中​，​并且​文件​名​都​是​小​写​的​。"
 
 #: Source/appfat.cpp:122
 msgid "Data File Error"
-msgstr "数据文件错误"
+msgstr "数据​文件​错误"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
 #: Source/appfat.cpp:130
@@ -833,36 +833,36 @@ msgid ""
 "Unable to write to location:\n"
 "{:s}"
 msgstr ""
-"无法写入位置: \n"
+"无法​写入​位置​:​ \n"
 "{:s}"
 
 #: Source/appfat.cpp:132
 msgid "Read-Only Directory Error"
-msgstr "只读目录错误"
+msgstr "只​读​目录​错误"
 
 #: Source/automap.cpp:484
 msgid "game: "
-msgstr "游戏: "
+msgstr "游戏​: "
 
 #: Source/automap.cpp:490
 msgid "password: "
-msgstr "密码: "
+msgstr "密码​: "
 
 #: Source/automap.cpp:492
 msgid "Public Game"
-msgstr "公开游戏"
+msgstr "公开​游戏"
 
 #: Source/automap.cpp:504
 msgid "Level: Nest {:d}"
-msgstr "巢穴: {:d} 层"
+msgstr "巢​穴​:​ {:d} ​层"
 
 #: Source/automap.cpp:506
 msgid "Level: Crypt {:d}"
-msgstr "墓穴: {:d} 层"
+msgstr "墓穴​:​ {:d} ​层"
 
 #: Source/automap.cpp:508 Source/items.cpp:2076
 msgid "Level: {:d}"
-msgstr "等级: {:d}"
+msgstr "等级​:​ {:d}"
 
 #: Source/control.cpp:199
 msgid "Tab"
@@ -878,23 +878,23 @@ msgstr "Enter"
 
 #: Source/control.cpp:202
 msgid "Character Information"
-msgstr "角色信息"
+msgstr "角色​信息"
 
 #: Source/control.cpp:203
 msgid "Quests log"
-msgstr "任务日志"
+msgstr "任务​日志"
 
 #: Source/control.cpp:204
 msgid "Automap"
-msgstr "自动地图"
+msgstr "自动​地图"
 
 #: Source/control.cpp:205
 msgid "Main Menu"
-msgstr "主菜单"
+msgstr "主​菜​单"
 
 #: Source/control.cpp:206
 msgid "Inventory"
-msgstr "物品栏"
+msgstr "物品​栏"
 
 #: Source/control.cpp:207
 msgid "Spell book"
@@ -902,7 +902,7 @@ msgstr "法术书"
 
 #: Source/control.cpp:208
 msgid "Send Message"
-msgstr "发送消息"
+msgstr "发送​消息"
 
 #: Source/control.cpp:764 Source/control.cpp:1572
 msgid "Skill"
@@ -910,7 +910,7 @@ msgstr "技能"
 
 #: Source/control.cpp:765 Source/control.cpp:1226
 msgid "{:s} Skill"
-msgstr "技能：{:s}"
+msgstr "技能​：​{:s}"
 
 #: Source/control.cpp:771
 msgid "Spell"
@@ -918,19 +918,19 @@ msgstr "法术"
 
 #: Source/control.cpp:772 Source/control.cpp:1230
 msgid "{:s} Spell"
-msgstr "法术：{:s}"
+msgstr "法术​：​{:s}"
 
 #: Source/control.cpp:774
 msgid "Damages undead only"
-msgstr "只能伤害亡灵"
+msgstr "只​能​伤害​亡灵"
 
 #: Source/control.cpp:778 Source/control.cpp:1234 Source/control.cpp:1596
 msgid "Spell Level 0 - Unusable"
-msgstr "法术等级 0 - 无法使用"
+msgstr "法术​等级​ 0 - ​无法​使用"
 
 #: Source/control.cpp:780 Source/control.cpp:1236 Source/control.cpp:1598
 msgid "Spell Level {:d}"
-msgstr "法术等级 {:d}"
+msgstr "法术​等级​ {:d}"
 
 #: Source/control.cpp:787
 msgid "Scroll"
@@ -938,7 +938,7 @@ msgstr "卷轴"
 
 #: Source/control.cpp:788 Source/control.cpp:1240
 msgid "Scroll of {:s}"
-msgstr "{:s}卷轴"
+msgstr "{:s}​卷轴"
 
 #: Source/control.cpp:793 Source/control.cpp:1246
 msgid "{:d} Scroll"
@@ -948,11 +948,11 @@ msgstr[0] "{:d}卷轴"
 #: Source/control.cpp:800 Source/itemdat.cpp:167 Source/itemdat.cpp:168
 #: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
 msgid "Staff"
-msgstr "法杖"
+msgstr "法​杖"
 
 #: Source/control.cpp:801 Source/control.cpp:1250 Source/items.cpp:1317
 msgid "Staff of {:s}"
-msgstr "{:s}法杖"
+msgstr "{:s}​法​杖"
 
 #: Source/control.cpp:803 Source/control.cpp:1252
 msgid "{:d} Charge"
@@ -961,27 +961,27 @@ msgstr[0] "{:d}充能"
 
 #: Source/control.cpp:813
 msgid "Spell Hotkey {:s}"
-msgstr "法术热键 {:d}"
+msgstr "法术​热键​ {:d}"
 
 #: Source/control.cpp:1203
 msgid "Player friendly"
-msgstr "对玩家友好"
+msgstr "对​玩家​友好"
 
 #: Source/control.cpp:1205
 msgid "Player attack"
-msgstr "玩家攻击"
+msgstr "玩​家​攻击"
 
 #: Source/control.cpp:1208
 msgid "Hotkey: {:s}"
-msgstr "热键: {:s}"
+msgstr "热键​:​ {:s}"
 
 #: Source/control.cpp:1216
 msgid "Select current spell button"
-msgstr "当前选择的法术按钮"
+msgstr "当前​选择​的​法术​按钮"
 
 #: Source/control.cpp:1219
 msgid "Hotkey: 's'"
-msgstr "热键: “s”"
+msgstr "热键​: “​s​”"
 
 #: Source/control.cpp:1374 Source/inv.cpp:1992 Source/items.cpp:3739
 msgid "{:d} gold piece"
@@ -990,15 +990,15 @@ msgstr[0] "{:d}金币堆"
 
 #: Source/control.cpp:1377
 msgid "Requirements not met"
-msgstr "未满足条件"
+msgstr "未​满足​条件"
 
 #: Source/control.cpp:1413
 msgid "{:s}, Level: {:d}"
-msgstr "{:s}，层数: {:d}"
+msgstr "{:s}​，​层数​:​ {:d}"
 
 #: Source/control.cpp:1415
 msgid "Hit Points {:d} of {:d}"
-msgstr "生命值 {:d} 的 {:d}"
+msgstr "生命值​ {:d} ​的​ {:d}"
 
 #: Source/control.cpp:1442
 msgid "Level Up"
@@ -1012,17 +1012,17 @@ msgstr[0] "法杖 ({:d} 充能)"
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
 #: Source/control.cpp:1586
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
-msgstr "法力: {:d} 伤害: {:d}-{:d}"
+msgstr "法力​:​ {:d} ​伤害​:​ {:d}-{:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
 #: Source/control.cpp:1588
 msgid "Mana: {:d}   Dam: n/a"
-msgstr "法力: {:d} 伤害: n/a"
+msgstr "法力​:​ {:d} ​伤害​:​ n/a"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
 #: Source/control.cpp:1591
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
-msgstr "法力: {:d} 伤害: 1/3 目标生命"
+msgstr "法力​:​ {:d} ​伤害​:​ 1/3 ​目标​生命"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1649
@@ -1032,11 +1032,11 @@ msgstr[0] "你有 {:d} 金币。你想要取出多少？"
 
 #: Source/controls/modifier_hints.cpp:121
 msgid "Menu"
-msgstr "菜单"
+msgstr "菜​单"
 
 #: Source/controls/modifier_hints.cpp:121
 msgid "Inv"
-msgstr "物品栏"
+msgstr "物品​栏"
 
 #: Source/controls/modifier_hints.cpp:121
 msgid "Map"
@@ -1056,104 +1056,104 @@ msgstr "任务"
 
 #: Source/cursor.cpp:211
 msgid "Town Portal"
-msgstr "城镇传送门"
+msgstr "城镇​传送门"
 
 #: Source/cursor.cpp:212
 msgid "from {:s}"
-msgstr "从{:s}"
+msgstr "从​{:s}"
 
 #: Source/cursor.cpp:229
 msgid "Portal to"
-msgstr "通向"
+msgstr "通​向"
 
 #: Source/cursor.cpp:231
 msgid "The Unholy Altar"
-msgstr "不洁祭坛"
+msgstr "不​洁​祭坛"
 
 #: Source/cursor.cpp:233
 msgid "level 15"
-msgstr "15级"
+msgstr "15​级"
 
 #: Source/diablo.cpp:114
 msgid "I need help! Come Here!"
-msgstr "我需要帮助！过来！"
+msgstr "我​需要​帮助​！​过来​！"
 
 #: Source/diablo.cpp:115
 msgid "Follow me."
-msgstr "跟着我。"
+msgstr "跟​着​我​。"
 
 #: Source/diablo.cpp:116
 msgid "Here's something for you."
-msgstr "这是给你的。"
+msgstr "这​是​给​你​的​。"
 
 #: Source/diablo.cpp:117
 msgid "Now you DIE!"
-msgstr "现在你死定了！"
+msgstr "现在​你​死定​了​！"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:781
 msgid "Options:\n"
-msgstr "选项: \n"
+msgstr "选​项​:​ \n"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:782
 msgid "Print this message and exit"
-msgstr "打印此消息并退出"
+msgstr "打​印​此​消息​并​退出"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:783
 msgid "Print the version and exit"
-msgstr "打印版本并退出"
+msgstr "打​印​版本​并​退出"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:784
 msgid "Specify the folder of diabdat.mpq"
-msgstr "指定diabdat.mpq的文件夹"
+msgstr "指定​diabdat.mpq​的​文件​夹"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:785
 msgid "Specify the folder of save files"
-msgstr "指定保存文件的文件夹"
+msgstr "指定​保存​文件​的​文件​夹"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:786
 msgid "Specify the location of diablo.ini"
-msgstr "指定diablo.ini的位置"
+msgstr "指定​diablo.ini​的​位置"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:787
 msgid "Skip startup videos"
-msgstr "跳过启动视频"
+msgstr "跳​过​启动​视频"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:788
 msgid "Display frames per second"
-msgstr "每秒显示帧数"
+msgstr "每​秒​显示​帧数"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:789
 msgid "Run in windowed mode"
-msgstr "在窗口模式下运行"
+msgstr "在​窗口​模式​下​运行"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:790
 msgid "Enable verbose logging"
-msgstr "启用详细日志记录"
+msgstr "启用​详细​日志​记录"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:791
 msgid "Record a demo file"
-msgstr "记录一个录像文件"
+msgstr "记录​一​个​录像​文件"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:792
 msgid "Play a demo file"
-msgstr "播放录像文件"
+msgstr "播放​录像​文件"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:793
 msgid "Disable all frame limiting during demo playback"
-msgstr "播放录像回放时禁用帧数限制"
+msgstr "播放​录像​回放​时​禁​用​帧​数​限制"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:794
@@ -1162,22 +1162,22 @@ msgid ""
 "Game selection:\n"
 msgstr ""
 "\n"
-"游戏选项：\n"
+"​游戏​选项​：​\n"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:795
 msgid "Force Shareware mode"
-msgstr "强制共享版模式"
+msgstr "强制​共​享版​模式"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:796
 msgid "Force Diablo mode"
-msgstr "强制原版模式"
+msgstr "强制​原版​模式"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:797
 msgid "Force Hellfire mode"
-msgstr "强制地狱火模式"
+msgstr "强制​地狱火​模式"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:798
@@ -1186,12 +1186,12 @@ msgid ""
 "Hellfire options:\n"
 msgstr ""
 "\n"
-"地狱火选项: \n"
+"​地​狱火​选项​:​ \n"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:799
 msgid "Use alternate nest palette"
-msgstr "使用备用嵌套调色板"
+msgstr "使用​备用​嵌​套​调色板"
 
 #: Source/diablo.cpp:805
 msgid ""
@@ -1199,36 +1199,36 @@ msgid ""
 "Report bugs at https://github.com/diasurgical/devilutionX/\n"
 msgstr ""
 "\n"
-"报告错误https://github.com/diasurgical/devilutionX/\n"
+"​报告​错误​https://github.com/diasurgical/devilutionX/\n"
 
 #: Source/diablo.cpp:869
 msgid "unrecognized option '{:s}'\n"
-msgstr "无法识别的选项{:s}\n"
+msgstr "无法​识别​的​选项​{:s}\n"
 
 #: Source/diablo.cpp:900
 msgid "version {:s}"
-msgstr "版本{:s}"
+msgstr "版本​{:s}"
 
 #: Source/diablo.cpp:1218
 msgid "-- Network timeout --"
-msgstr "--网络超时--"
+msgstr "--​网络​超时--"
 
 #: Source/diablo.cpp:1219
 msgid "-- Waiting for players --"
-msgstr "--等待玩家--"
+msgstr "--​等待​玩​家​--"
 
 #: Source/diablo.cpp:1238
 msgid "No help available"
-msgstr "没有可用的帮助"
+msgstr "没有​可用​的​帮助"
 
 #: Source/diablo.cpp:1239
 msgid "while in stores"
-msgstr "在商店里"
+msgstr "在​商店​里"
 
 #. TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty.
 #: Source/diablo.cpp:1451
 msgid "{:s}, version = {:s}, mode = {:s}"
-msgstr "{:s}, 版本 = {:s}, 模式 = {:s}"
+msgstr "{:s}, ​版本​ = {:s}, ​模式​ = {:s}"
 
 #: Source/dvlnet/loopback.cpp:111
 msgid "loopback"
@@ -1236,283 +1236,283 @@ msgstr "环回"
 
 #: Source/dvlnet/tcp_client.cpp:65
 msgid "Unable to connect"
-msgstr "无法连接"
+msgstr "无法​连接"
 
 #: Source/dvlnet/tcp_client.cpp:86
 msgid "error: read 0 bytes from server"
-msgstr "错误: 从服务器读取了0个字节"
+msgstr "错误​: 从​服务器​读取​了​0​个​字节"
 
 #: Source/error.cpp:57
 msgid "No automap available in town"
-msgstr "城镇中没有自动地图"
+msgstr "城镇​中​没有​自动​地图"
 
 #: Source/error.cpp:58
 msgid "No multiplayer functions in demo"
-msgstr "演示版没有多人游戏功能"
+msgstr "演示版​没有​多​人​游戏​功能"
 
 #: Source/error.cpp:59
 msgid "Direct Sound Creation Failed"
-msgstr "Direct Sound 创建失败"
+msgstr "Direct Sound ​创建​失败"
 
 #: Source/error.cpp:60
 msgid "Not available in shareware version"
-msgstr "在共享软件版本中不可用"
+msgstr "在​共​享​软件​版本​中​不​可​用"
 
 #: Source/error.cpp:61
 msgid "Not enough space to save"
-msgstr "没有足够的空间保存游戏"
+msgstr "没有​足够​的​空间​保存​游戏"
 
 #: Source/error.cpp:62
 msgid "No Pause in town"
-msgstr "城镇中无法暂停"
+msgstr "城镇​中​无法​暂停"
 
 #: Source/error.cpp:63
 msgid "Copying to a hard disk is recommended"
-msgstr "建议复制到硬盘"
+msgstr "建议​复制​到​硬盘"
 
 #: Source/error.cpp:64
 msgid "Multiplayer sync problem"
-msgstr "多人同步问题"
+msgstr "多​人​同步​问题"
 
 #: Source/error.cpp:65
 msgid "No pause in multiplayer"
-msgstr "多人游戏中无法暂停"
+msgstr "多​人​游戏​中​无法​暂停"
 
 #: Source/error.cpp:66
 msgid "Loading..."
-msgstr "加载中……"
+msgstr "加载​中​…​…"
 
 #: Source/error.cpp:67
 msgid "Saving..."
-msgstr "保存中……"
+msgstr "保存​中​…​…"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:68
 msgid "Some are weakened as one grows strong"
-msgstr "一种力量变强的背后潜藏着其他力量的衰弱"
+msgstr "一​种​力量​变强​的​背后​潜藏​着​其他​力量​的​衰弱"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:69
 msgid "New strength is forged through destruction"
-msgstr "毁灭塑造了新的力量"
+msgstr "毁灭​塑造​了​新​的​力量"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:70
 msgid "Those who defend seldom attack"
-msgstr "专注防御意味着放弃进攻"
+msgstr "专注​防御​意味​着​放弃​进攻"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:71
 msgid "The sword of justice is swift and sharp"
-msgstr "正义之剑迅捷而锋利"
+msgstr "正义​之​剑​迅捷​而​锋利"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:72
 msgid "While the spirit is vigilant the body thrives"
-msgstr "君子终日乾乾夕惕若厉无咎"
+msgstr "君子​终日​乾乾夕惕若厉无咎"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:73
 msgid "The powers of mana refocused renews"
-msgstr "法力的能量奔流不息"
+msgstr "法力​的​能量​奔流​不息"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:74
 msgid "Time cannot diminish the power of steel"
-msgstr "时间也无法削弱钢铁之力"
+msgstr "时间​也​无法​削弱​钢铁​之​力"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:75
 msgid "Magic is not always what it seems to be"
-msgstr "魔法并不总是看起来的那样"
+msgstr "魔法​并不​总是​看​起来​的​那样"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:76
 msgid "What once was opened now is closed"
-msgstr "曾今开启的，如今却关上了"
+msgstr "曾​今​开启​的​，​如今​却​关上​了"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:77
 msgid "Intensity comes at the cost of wisdom"
-msgstr "无妄的力量，以智慧为代价"
+msgstr "无妄​的​力量​，​以​智慧​为​代价"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:78
 msgid "Arcane power brings destruction"
-msgstr "神秘力量带来毁灭"
+msgstr "神秘​力量​带来​毁灭"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:79
 msgid "That which cannot be held cannot be harmed"
-msgstr "不能持有的东西不能受到伤害"
+msgstr "不​能​持有​的​东西​不​能​受到​伤害"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:80
 msgid "Crimson and Azure become as the sun"
-msgstr "深红和湛蓝如太阳和天空"
+msgstr "深​红​和​湛蓝​如​太阳​和​天空"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:81
 msgid "Knowledge and wisdom at the cost of self"
-msgstr "以牺牲自我为代价的知识和智慧"
+msgstr "以​牺牲​自我​为​代价​的​知识​和​智慧"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:82
 msgid "Drink and be refreshed"
-msgstr "一饮而尽，酣畅淋漓"
+msgstr "一饮而尽​，​酣畅​淋漓"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:83
 msgid "Wherever you go, there you are"
-msgstr "身在，心在"
+msgstr "身​在​，​心​在"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:84
 msgid "Energy comes at the cost of wisdom"
-msgstr "能量是以智慧为代价的"
+msgstr "能量​是​以​智慧​为​代价​的"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:85
 msgid "Riches abound when least expected"
-msgstr "无心插柳柳成荫"
+msgstr "无​心​插柳柳​成荫"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:86
 msgid "Where avarice fails, patience gains reward"
-msgstr "贪婪导致失败，谦逊得到奖励"
+msgstr "贪​婪​导致​失败​，​谦逊​得到​奖励"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:87
 msgid "Blessed by a benevolent companion!"
-msgstr "被仁慈的同伴祝福！"
+msgstr "被​仁慈​的​同伴​祝福​！"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:88
 msgid "The hands of men may be guided by fate"
-msgstr "命运之手无形的操控一切"
+msgstr "命运​之​手​无形​的​操控​一切"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:89
 msgid "Strength is bolstered by heavenly faith"
-msgstr "天行健君子以自强不息"
+msgstr "天行健​君子​以​自强不息"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:90
 msgid "The essence of life flows from within"
-msgstr "生命的本质来自内在"
+msgstr "生命​的​本质​来自​内在"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:91
 msgid "The way is made clear when viewed from above"
-msgstr "当局者迷，旁观者清"
+msgstr "当局​者迷​，​旁观者​清"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:92
 msgid "Salvation comes at the cost of wisdom"
-msgstr "拯救是以智慧为代价的"
+msgstr "拯救​是​以​智慧​为​代价​的"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:93
 msgid "Mysteries are revealed in the light of reason"
-msgstr "神秘将在光芒中揭露"
+msgstr "神秘​将​在​光芒​中​揭露"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:94
 msgid "Those who are last may yet be first"
-msgstr "最后一个可能还是第一个"
+msgstr "最后​一​个​可能​还​是​第一​个"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:95
 msgid "Generosity brings its own rewards"
-msgstr "慷慨自有回报"
+msgstr "慷慨​自​有​回报"
 
 #: Source/error.cpp:96
 msgid "You must be at least level 8 to use this."
-msgstr "你必须至少达到8级才能使用这个。"
+msgstr "你​必须​至少​达到​8​级​才​能​使用​这个​。"
 
 #: Source/error.cpp:97
 msgid "You must be at least level 13 to use this."
-msgstr "你必须至少达到13级才能使用这个。"
+msgstr "你​必须​至少​达到​13级​才​能​使用​这个​。"
 
 #: Source/error.cpp:98
 msgid "You must be at least level 17 to use this."
-msgstr "你必须至少达到17级才能使用这个。"
+msgstr "你​必须​至少​达到​17级​才​能​使用​这个​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:99
 msgid "Arcane knowledge gained!"
-msgstr "获得奥术知识！"
+msgstr "获得​奥术​知识​！"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:100
 msgid "That which does not kill you..."
-msgstr "那不会杀掉你……"
+msgstr "那​不​会​杀掉​你​…​…"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:101
 msgid "Knowledge is power."
-msgstr "知识就是力量。"
+msgstr "知识​就​是​力量​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:102
 msgid "Give and you shall receive."
-msgstr "付出才有回报。"
+msgstr "付出​才​有​回报​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:103
 msgid "Some experience is gained by touch."
-msgstr "通过触碰获得了一些经验值。"
+msgstr "通过​触碰​获得​了​一些​经验值​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:104
 msgid "There's no place like home."
-msgstr "没有比家更好的地方了。"
+msgstr "没有​比家​更​好​的​地方​了​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:105
 msgid "Spiritual energy is restored."
-msgstr "精神能量被恢复。"
+msgstr "精神​能量​被​恢复​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:106
 msgid "You feel more agile."
-msgstr "你感觉更加敏捷。"
+msgstr "你​感觉​更加​敏捷​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:107
 msgid "You feel stronger."
-msgstr "你感觉更加强壮。"
+msgstr "你​感觉​更​加强​壮​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:108
 msgid "You feel wiser."
-msgstr "你觉得更加睿智。"
+msgstr "你​觉得​更加​睿智​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:109
 msgid "You feel refreshed."
-msgstr "你感觉神清气爽。"
+msgstr "你​感觉​神清气爽​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:110
 msgid "That which can break will."
-msgstr "这会让意志崩溃。"
+msgstr "这​会​让​意志​崩溃​。"
 
 #: Source/gamemenu.cpp:35
 msgid "Save Game"
-msgstr "保存游戏"
+msgstr "保存​游戏"
 
 #: Source/gamemenu.cpp:36 Source/gamemenu.cpp:47
 msgid "Options"
-msgstr "选项"
+msgstr "选​项"
 
 #: Source/gamemenu.cpp:39 Source/gamemenu.cpp:50
 msgid "Quit Game"
-msgstr "退出游戏"
+msgstr "退出​游戏"
 
 #: Source/gamemenu.cpp:49
 msgid "Restart In Town"
-msgstr "在城里重新开始"
+msgstr "在​城里​重新​开始"
 
 #: Source/gamemenu.cpp:59
 msgid "Gamma"
@@ -1524,7 +1524,7 @@ msgstr "速度"
 
 #: Source/gamemenu.cpp:68
 msgid "Music Disabled"
-msgstr "音乐已禁用"
+msgstr "音乐​已​禁​用"
 
 #: Source/gamemenu.cpp:72
 msgid "Sound"
@@ -1532,23 +1532,23 @@ msgstr "声音"
 
 #: Source/gamemenu.cpp:73
 msgid "Sound Disabled"
-msgstr "声音已禁用"
+msgstr "声音​已​禁​用"
 
 #: Source/gamemenu.cpp:155
 msgid "Speed: Fastest"
-msgstr "速度: 最快"
+msgstr "速度​: 最​快"
 
 #: Source/gamemenu.cpp:157
 msgid "Speed: Faster"
-msgstr "速度: 更快"
+msgstr "速度​: 更​快"
 
 #: Source/gamemenu.cpp:159
 msgid "Speed: Fast"
-msgstr "速度: 快速"
+msgstr "速度​: 快速"
 
 #: Source/gamemenu.cpp:161
 msgid "Speed: Normal"
-msgstr "速度: 正常"
+msgstr "速度​: 正常"
 
 #: Source/gmenu.cpp:166
 msgid "Pause"
@@ -1556,109 +1556,109 @@ msgstr "暂停"
 
 #: Source/help.cpp:26
 msgid "$Keyboard Shortcuts:"
-msgstr "快捷键($K):"
+msgstr "快​捷键​(​$​K)​:"
 
 #: Source/help.cpp:27
 msgid "F1:    Open Help Screen"
-msgstr "F1:    打开帮助屏幕"
+msgstr "F1:    ​打开​帮助​屏幕"
 
 #: Source/help.cpp:28
 msgid "Esc:   Display Main Menu"
-msgstr "Esc:   无法显示主菜单"
+msgstr "Esc:   ​无法​显示​主菜​单"
 
 #: Source/help.cpp:29
 msgid "Tab:   Display Auto-map"
-msgstr "Tab:   显示自动地图"
+msgstr "Tab:   ​显示​自动​地图"
 
 #: Source/help.cpp:30
 msgid "Space: Hide all info screens"
-msgstr "空格: 隐藏所有信息栏"
+msgstr "空​格: 隐藏​所有​信息​栏"
 
 #: Source/help.cpp:31
 msgid "S: Open Speedbook"
-msgstr "S: 打开速度书"
+msgstr "S: ​打开​速度​书"
 
 #: Source/help.cpp:32
 msgid "B: Open Spellbook"
-msgstr "B: 打开法术书"
+msgstr "B: ​打开​法术书"
 
 #: Source/help.cpp:33
 msgid "I: Open Inventory screen"
-msgstr "I: 打开物品栏"
+msgstr "I: ​打开​物品​栏"
 
 #: Source/help.cpp:34
 msgid "C: Open Character screen"
-msgstr "C: 打开角色栏"
+msgstr "C: ​打开​角色​栏"
 
 #: Source/help.cpp:35
 msgid "Q: Open Quest log"
-msgstr "Q: 任务日志"
+msgstr "Q: ​任务​日志"
 
 #: Source/help.cpp:36
 msgid "F: Reduce screen brightness"
-msgstr "F: 降低屏幕亮度"
+msgstr "F: ​降低​屏幕​亮度"
 
 #: Source/help.cpp:37
 msgid "G: Increase screen brightness"
-msgstr "G: 提高屏幕亮度"
+msgstr "G: ​提高​屏幕​亮度"
 
 #: Source/help.cpp:38
 msgid "Z: Zoom Game Screen"
-msgstr "Z: 缩放游戏屏幕"
+msgstr "Z: ​缩放​游戏​屏幕"
 
 #: Source/help.cpp:39
 msgid "+ / -: Zoom Automap"
-msgstr "+ / -: 缩放放自动映射"
+msgstr "+ / -: ​缩放​放​自动​映射"
 
 #: Source/help.cpp:40
 msgid "1 - 8: Use Belt item"
-msgstr "1 - 8: 使用腰带上的物品"
+msgstr "1 - 8: ​使用​腰带​上​的​物品"
 
 #: Source/help.cpp:41
 msgid "F5, F6, F7, F8:     Set hotkey for skill or spell"
-msgstr "F5, F6, F7, F8:     设置技能或法术热键"
+msgstr "F5, F6, F7, F8:     ​设置​技能​或​法术​热键"
 
 #: Source/help.cpp:42
 msgid "Shift + Left Mouse Button: Attack without moving"
-msgstr "Shift + 鼠标左键: 静止攻击"
+msgstr "Shift + ​鼠标​左​键​: 静止​攻击"
 
 #: Source/help.cpp:43
 msgid "Shift + Left Mouse Button (on character screen): Assign all stat points"
-msgstr "Shift + 鼠标左键(在角色栏): 分配所有统计点数"
+msgstr "Shift + ​鼠标​左​键(​在​角色​栏)​: 分配​所有​统计​点数"
 
 #: Source/help.cpp:44
 msgid ""
 "Shift + Left Mouse Button (on inventory): Move item to belt or equip/unequip "
 "item"
-msgstr "Shift + 鼠标左键(在物品栏): 移动物品到腰带或装备/卸下物品"
+msgstr "Shift + ​鼠标​左​键(​在​物品​栏)​: 移动​物品​到​腰带​或​装备​/​卸下​物品"
 
 #: Source/help.cpp:45
 msgid "Shift + Left Mouse Button (on belt): Move item to inventory"
-msgstr "Shift + 鼠标左键(在腰带栏): 移动物品到腰带"
+msgstr "Shift + ​鼠标​左​键(​在​腰带​栏​)​: 移动​物品​到​腰带"
 
 #: Source/help.cpp:47
 msgid "$Movement:"
-msgstr "移动($M)："
+msgstr "移动​(​$​M)​："
 
 #: Source/help.cpp:48
 msgid ""
 "If you hold the mouse button down while moving, the character will continue "
 "to move in that direction."
-msgstr "如果你按住鼠标键并且移动，角色会继续跟着鼠标移动。"
+msgstr "如果​你​按​住鼠​标键​并且​移动​，​角色​会​继续​跟着​鼠标​移动​。"
 
 #: Source/help.cpp:51
 msgid "$Combat:"
-msgstr "进攻($C)："
+msgstr "进攻​(​$​C)​："
 
 #: Source/help.cpp:52
 msgid ""
 "Holding down the shift key and then left-clicking allows the character to "
 "attack without moving."
-msgstr "按住shift键点击左键，可以让角色攻击时不移动。"
+msgstr "按​住​shift键​点击​左键​，​可以​让​角色​攻击​时​不​移动​。"
 
 #: Source/help.cpp:55
 msgid "$Auto-map:"
-msgstr "自动地图($A)："
+msgstr "自动​地图​(​$​A)​："
 
 #: Source/help.cpp:56
 msgid ""
@@ -1666,12 +1666,12 @@ msgid ""
 "press 'TAB' on the keyboard. Zooming in and out of the map is done with the "
 "+ and - keys. Scrolling the map uses the arrow keys."
 msgstr ""
-"要访问自动地图，点击信息栏的'MAP'按钮或按一下'TAB'键。使用 + 和 - 来放大或缩"
-"小。使用箭头键滚动动图。"
+"要​访问​自动​地图​，​点击​信息栏​的​'MAP'​按钮​或​按​一下​'​TAB​'键​。​使用​ + ​和​ - ​来"
+"​放大​或​缩小​。​使用​箭头键​滚动​动图​。"
 
 #: Source/help.cpp:61
 msgid "$Picking up Objects:"
-msgstr "拾起物品($P):"
+msgstr "拾​起​物品​(​$​P)​:"
 
 #: Source/help.cpp:62
 msgid ""
@@ -1681,23 +1681,23 @@ msgid ""
 "box. Items may be used by either pressing the corresponding number or right-"
 "clicking on the item."
 msgstr ""
-"常用的物品都比较小，比如药水和卷轴，会被自动放入面板上方的腰带栏。当一样物品"
-"放入腰带栏，一个小小的数字会显示在那一格。物品可以通过按对应的数字或右边点击"
-"来使用。"
+"常​用​的​物品​都​比较​小​，​比如​药水​和​卷轴​，​会​被​自动​放入​面板​上方​的​腰带栏​。​当​一样​物品​"
+"放入腰​带栏​，​一​个​小小​的​数字会​显示​在​那​一​格​。​物品​可以​通过​按​对应​的​数字​或​右边​点​击来"
+"​使用​。"
 
 #: Source/help.cpp:68
 msgid "$Gold"
-msgstr "金币($G)"
+msgstr "金币​(​$​G)"
 
 #: Source/help.cpp:69
 msgid ""
 "You can select a specific amount of gold to drop by right-clicking on a pile "
 "of gold in your inventory."
-msgstr "你可以在物品栏里的一堆金币上点击右键以移动指定的数量。"
+msgstr "你​可以​在​物品​栏​里​的​一​堆​金币​上​点击​右键​以​移动​指定​的​数量​。"
 
 #: Source/help.cpp:72
 msgid "$Skills & Spells:"
-msgstr "技能 & 法术($S):"
+msgstr "技能 & 法术​(​$​S)​:"
 
 #: Source/help.cpp:73
 msgid ""
@@ -1707,13 +1707,13 @@ msgid ""
 "will ready the spell. A readied spell may be cast by simply right-clicking "
 "in the play area."
 msgstr ""
-"你可以点击面板的'SPELLS'按钮来查看技能和法术列表。此处列出了记忆的法术和可通"
-"过法杖获得的法术。 左键单击您要施放的法术将使该法术准备就绪。 一个准备好的法"
-"术可以通过在游戏区域中单击右键来施放。"
+"你​可以​点击​面板​的​'​SPELLS'​按钮​来​查看​技能​和​法术​列表​。​此​处​列出​了​记忆​的​法术​和​"
+"可​通过​法杖​获得​的​法术​。 左键​单击​您​要​施放​的​法术​将​使​该​法术​准备​就绪​。 一​个​准备​好​的"
+"​法术​可以​通过​在​游戏​区域​中​单击​右键​来​施放​。"
 
 #: Source/help.cpp:79
 msgid "$Using the Speedbook for Spells"
-msgstr "为法术使用速度书($U)"
+msgstr "为​法术​使用​速度​书(​$​U)"
 
 #: Source/help.cpp:80
 msgid ""
@@ -1721,18 +1721,18 @@ msgid ""
 "allows you to select a skill or spell for immediate use. To use a readied "
 "skill or spell, simply right-click in the main play area."
 msgstr ""
-"左键单击“准备好的法术”按钮将打开“速度书”，您可以选择立即使用的技能或法术。 要"
-"使用准备好的技能或法术，只需在主游戏区右键单击即可。"
+"左键​单击​“​准备​好​的​法术​”​按钮​将​打开​“​速度​书​”​，​您​可以​选择​立即​使用​的​技能​或​法术​"
+"。 要​使用​准备​好​的​技能​或​法术​，​只​需​在​主​游戏区​右键​单击​即​可​。"
 
 #: Source/help.cpp:84
 msgid ""
 "Shift + Left-clicking on the 'select current spell' button will clear the "
 "readied spell"
-msgstr "Shift + 左键单击“选择当前法术”按钮将清除准备好的法术"
+msgstr "Shift + ​左键​单击​“​选择​当前​法术​”​按钮​将​清除​准备​好​的​法术"
 
 #: Source/help.cpp:86
 msgid "$Setting Spell Hotkeys"
-msgstr "设置技能热键($S)"
+msgstr "设置​技能​热键(​$​S)"
 
 #: Source/help.cpp:87
 msgid ""
@@ -1740,38 +1740,38 @@ msgid ""
 "opening the 'speedbook' as described in the section above. Press the F5, F6, "
 "F7 or F8 keys after highlighting the spell you wish to assign."
 msgstr ""
-"您最多可以为技能、法术或卷轴分配四个热键。 首先打开上一节所述的“速度书”。 选"
-"中要分配的法术后，按 F5、F6、F7 或 F8 键。"
+"您​最多​可以​为​技能​、​法术​或​卷轴​分配​四​个​热键​。 首先​打开​上​一​节​所述​的​“​速度​书​”​。 "
+"选​中​要​分配​的​法术​后​，​按​ F5​、​F6​、​F7 ​或​ F8 ​键​。"
 
 #: Source/help.cpp:92
 msgid "$Spell Books"
-msgstr "法术书($S)"
+msgstr "法术书(​$​S)"
 
 #: Source/help.cpp:93
 msgid ""
 "Reading more than one book increases your knowledge of that spell, allowing "
 "you to cast the spell more effectively."
-msgstr "阅读不止一本书可以增加您对该法术的了解，使您能够更有效地施展该法术。"
+msgstr "阅读​不止​一​本​书​可以​增加​您​对​该​法术​的​了解​，​使​您​能够​更​有效​地​施展​该​法术​。"
 
 #: Source/help.cpp:135
 msgid "Shareware Hellfire Help"
-msgstr "共享软件地狱火帮助"
+msgstr "共​享​软件​地狱火​帮助"
 
 #: Source/help.cpp:135
 msgid "Hellfire Help"
-msgstr "地狱火帮助"
+msgstr "地​狱火​帮助"
 
 #: Source/help.cpp:137
 msgid "Shareware Diablo Help"
-msgstr "共享软件暗黑破坏神帮助"
+msgstr "共​享​软件​暗黑​破坏​神​帮助"
 
 #: Source/help.cpp:137
 msgid "Diablo Help"
-msgstr "暗黑破坏神帮助"
+msgstr "暗​黑​破坏​神​帮助"
 
 #: Source/help.cpp:161
 msgid "Press ESC to end or the arrow keys to scroll."
-msgstr "按ESC键结束，或按方向键滚动。"
+msgstr "按​ESC键​结束​，​或​按​方向​键​滚动​。"
 
 #: Source/init.cpp:206
 msgid "diabdat.mpq or spawn.mpq"
@@ -1779,19 +1779,19 @@ msgstr "diabdat.mpq或spawn.mpq"
 
 #: Source/init.cpp:226
 msgid "Some Hellfire MPQs are missing"
-msgstr "一些地狱火MPQ无法找到"
+msgstr "一些​地狱火​MPQ​无法​找到"
 
 #: Source/init.cpp:226
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
 msgstr ""
-"地狱火MPQ未能全部找到。\n"
-"请复制所有hf*.mpq文件。"
+"地​狱火​MPQ​未​能​全部​找到​。​\n"
+"​请​复制​所有​hf​*​.mpq​文件​。"
 
 #: Source/init.cpp:234
 msgid "Unable to create main window"
-msgstr "无法创建主窗口"
+msgstr "无法​创建主​窗口"
 
 #: Source/itemdat.cpp:16 Source/itemdat.cpp:198 Source/panels/charpanel.cpp:155
 msgid "Gold"
@@ -1799,7 +1799,7 @@ msgstr "金币"
 
 #: Source/itemdat.cpp:17 Source/itemdat.cpp:135
 msgid "Short Sword"
-msgstr "短剑"
+msgstr "短​剑"
 
 #: Source/itemdat.cpp:18 Source/itemdat.cpp:87
 msgid "Buckler"
@@ -1815,7 +1815,7 @@ msgstr "短弓"
 
 #: Source/itemdat.cpp:21
 msgid "Short Staff of Mana"
-msgstr "法力短杖"
+msgstr "法力​短​杖"
 
 #: Source/itemdat.cpp:22
 msgid "Cleaver"
@@ -1823,11 +1823,11 @@ msgstr "切肉者"
 
 #: Source/itemdat.cpp:23 Source/itemdat.cpp:397
 msgid "The Undead Crown"
-msgstr "不死王冠"
+msgstr "不​死​王冠"
 
 #: Source/itemdat.cpp:24 Source/itemdat.cpp:398
 msgid "Empyrean Band"
-msgstr "碧空之戒"
+msgstr "碧空​之​戒"
 
 #: Source/itemdat.cpp:25
 msgid "Magic Rock"
@@ -1835,35 +1835,35 @@ msgstr "魔石"
 
 #: Source/itemdat.cpp:26 Source/itemdat.cpp:399
 msgid "Optic Amulet"
-msgstr "明眼护符"
+msgstr "明眼​护符"
 
 #: Source/itemdat.cpp:27 Source/itemdat.cpp:400
 msgid "Ring of Truth"
-msgstr "实相之戒"
+msgstr "实​相之戒"
 
 #: Source/itemdat.cpp:28
 msgid "Tavern Sign"
-msgstr "酒店招牌"
+msgstr "酒店​招牌"
 
 #: Source/itemdat.cpp:29 Source/itemdat.cpp:401
 msgid "Harlequin Crest"
-msgstr "谐角之冠"
+msgstr "谐​角​之​冠"
 
 #: Source/itemdat.cpp:30 Source/itemdat.cpp:402
 msgid "Veil of Steel"
-msgstr "钢铁面纱"
+msgstr "钢铁​面纱"
 
 #: Source/itemdat.cpp:31
 msgid "Golden Elixir"
-msgstr "金色药剂"
+msgstr "金色​药剂"
 
 #: Source/itemdat.cpp:32 Source/quests.cpp:51
 msgid "Anvil of Fury"
-msgstr "愤怒铁砧"
+msgstr "愤怒​铁砧"
 
 #: Source/itemdat.cpp:33 Source/quests.cpp:42
 msgid "Black Mushroom"
-msgstr "黑蘑菇"
+msgstr "黑​蘑菇"
 
 #: Source/itemdat.cpp:34
 msgid "Brain"
@@ -1871,19 +1871,19 @@ msgstr "大脑"
 
 #: Source/itemdat.cpp:35
 msgid "Fungal Tome"
-msgstr "长满真菌的书"
+msgstr "长满​真菌​的​书"
 
 #: Source/itemdat.cpp:36
 msgid "Spectral Elixir"
-msgstr "幽灵药剂"
+msgstr "幽灵​药剂"
 
 #: Source/itemdat.cpp:37
 msgid "Blood Stone"
-msgstr "鲜血石"
+msgstr "鲜​血石"
 
 #: Source/itemdat.cpp:38
 msgid "Cathedral Map"
-msgstr "大教堂地图"
+msgstr "大​教堂​地图"
 
 #: Source/itemdat.cpp:39
 msgid "Heart"
@@ -1891,35 +1891,35 @@ msgstr "心脏"
 
 #: Source/itemdat.cpp:40 Source/itemdat.cpp:93
 msgid "Potion of Healing"
-msgstr "治疗药水"
+msgstr "治疗​药​水"
 
 #: Source/itemdat.cpp:41 Source/itemdat.cpp:95
 msgid "Potion of Mana"
-msgstr "法力药水"
+msgstr "法力​药​水"
 
 #: Source/itemdat.cpp:42 Source/itemdat.cpp:110
 msgid "Scroll of Identify"
-msgstr "鉴定卷轴"
+msgstr "鉴定​卷轴"
 
 #: Source/itemdat.cpp:43 Source/itemdat.cpp:114
 msgid "Scroll of Town Portal"
-msgstr "城镇传送卷轴"
+msgstr "城镇​传送​卷轴"
 
 #: Source/itemdat.cpp:44 Source/itemdat.cpp:403
 msgid "Arkaine's Valor"
-msgstr "阿凯尼的荣耀"
+msgstr "阿凯尼​的​荣耀"
 
 #: Source/itemdat.cpp:45 Source/itemdat.cpp:94
 msgid "Potion of Full Healing"
-msgstr "完全治疗药剂"
+msgstr "完全​治疗​药剂"
 
 #: Source/itemdat.cpp:46 Source/itemdat.cpp:96
 msgid "Potion of Full Mana"
-msgstr "全法力药剂"
+msgstr "全​法力​药剂"
 
 #: Source/itemdat.cpp:47 Source/itemdat.cpp:404
 msgid "Griswold's Edge"
-msgstr "格里斯沃尔德的锐利"
+msgstr "格里斯沃尔德​的​锐利"
 
 #: Source/itemdat.cpp:48 Source/itemdat.cpp:405
 msgid "Bovine Plate"
@@ -1927,19 +1927,19 @@ msgstr "公牛板甲"
 
 #: Source/itemdat.cpp:49
 msgid "Staff of Lazarus"
-msgstr "拉扎鲁斯之杖"
+msgstr "拉扎鲁斯之​杖"
 
 #: Source/itemdat.cpp:50 Source/itemdat.cpp:111
 msgid "Scroll of Resurrect"
-msgstr "复活卷轴"
+msgstr "复活​卷轴"
 
 #: Source/itemdat.cpp:51 Source/itemdat.cpp:99 Source/items.cpp:166
 msgid "Blacksmith Oil"
-msgstr "铁匠之油"
+msgstr "铁匠​之​油"
 
 #: Source/itemdat.cpp:52 Source/itemdat.cpp:167
 msgid "Short Staff"
-msgstr "短法杖"
+msgstr "短​法​杖"
 
 #: Source/itemdat.cpp:53 Source/itemdat.cpp:135 Source/itemdat.cpp:136
 #: Source/itemdat.cpp:137 Source/itemdat.cpp:138 Source/itemdat.cpp:141
@@ -1950,11 +1950,11 @@ msgstr "剑"
 
 #: Source/itemdat.cpp:54 Source/itemdat.cpp:134
 msgid "Dagger"
-msgstr "长匕首"
+msgstr "长​匕首"
 
 #: Source/itemdat.cpp:55
 msgid "Rune Bomb"
-msgstr "符文炸弹"
+msgstr "符文​炸弹"
 
 #: Source/itemdat.cpp:56
 msgid "Theodore"
@@ -1962,31 +1962,31 @@ msgstr "西奥多"
 
 #: Source/itemdat.cpp:57
 msgid "Auric Amulet"
-msgstr "金项链"
+msgstr "金​项链"
 
 #: Source/itemdat.cpp:58
 msgid "Torn Note 1"
-msgstr "残破的日记1"
+msgstr "残破​的​日记​1"
 
 #: Source/itemdat.cpp:59
 msgid "Torn Note 2"
-msgstr "残破的日记2"
+msgstr "残破​的​日记​2"
 
 #: Source/itemdat.cpp:60
 msgid "Torn Note 3"
-msgstr "残破的日记3"
+msgstr "残破​的​日记​3"
 
 #: Source/itemdat.cpp:61
 msgid "Reconstructed Note"
-msgstr "重新拼凑的日记"
+msgstr "重新​拼凑​的​日记"
 
 #: Source/itemdat.cpp:62
 msgid "Brown Suit"
-msgstr "棕色大衣"
+msgstr "棕色​大​衣"
 
 #: Source/itemdat.cpp:63
 msgid "Grey Suit"
-msgstr "灰色大衣"
+msgstr "灰色​大衣"
 
 #: Source/itemdat.cpp:64 Source/itemdat.cpp:65
 msgid "Cap"
@@ -1994,7 +1994,7 @@ msgstr "软帽"
 
 #: Source/itemdat.cpp:65
 msgid "Skull Cap"
-msgstr "骷髅帽"
+msgstr "骷​髅​帽"
 
 #: Source/itemdat.cpp:66 Source/itemdat.cpp:67 Source/itemdat.cpp:69
 msgid "Helm"
@@ -2002,15 +2002,15 @@ msgstr "头盔"
 
 #: Source/itemdat.cpp:67
 msgid "Full Helm"
-msgstr "全护盔"
+msgstr "全​护盔"
 
 #: Source/itemdat.cpp:68
 msgid "Crown"
-msgstr "皇冠"
+msgstr "皇​冠"
 
 #: Source/itemdat.cpp:69
 msgid "Great Helm"
-msgstr "巨型战盔"
+msgstr "巨型​战盔"
 
 #: Source/itemdat.cpp:70
 msgid "Cape"
@@ -2018,7 +2018,7 @@ msgstr "斗篷"
 
 #: Source/itemdat.cpp:71
 msgid "Rags"
-msgstr "短披风"
+msgstr "短​披风"
 
 #: Source/itemdat.cpp:72
 msgid "Cloak"
@@ -2026,16 +2026,16 @@ msgstr "披风"
 
 #: Source/itemdat.cpp:73
 msgid "Robe"
-msgstr "长袍"
+msgstr "长​袍"
 
 #: Source/itemdat.cpp:74
 msgid "Quilted Armor"
-msgstr "内衬甲"
+msgstr "内​衬甲"
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
 #: Source/itemdat.cpp:77 Source/objects.cpp:5435
 msgid "Armor"
-msgstr "护甲"
+msgstr "护​甲"
 
 #: Source/itemdat.cpp:75
 msgid "Leather Armor"
@@ -2043,24 +2043,24 @@ msgstr "皮甲"
 
 #: Source/itemdat.cpp:76
 msgid "Hard Leather Armor"
-msgstr "硬皮甲"
+msgstr "硬​皮甲"
 
 #: Source/itemdat.cpp:77
 msgid "Studded Leather Armor"
-msgstr "钉皮甲"
+msgstr "钉​皮甲"
 
 #: Source/itemdat.cpp:78
 msgid "Ring Mail"
-msgstr "环甲"
+msgstr "环​甲"
 
 #: Source/itemdat.cpp:78 Source/itemdat.cpp:79 Source/itemdat.cpp:80
 #: Source/itemdat.cpp:82
 msgid "Mail"
-msgstr "锁甲"
+msgstr "锁​甲"
 
 #: Source/itemdat.cpp:79
 msgid "Chain Mail"
-msgstr "锁子甲"
+msgstr "锁子​甲"
 
 #: Source/itemdat.cpp:80
 msgid "Scale Mail"
@@ -2068,45 +2068,45 @@ msgstr "鱼鳞甲"
 
 #: Source/itemdat.cpp:81
 msgid "Breast Plate"
-msgstr "胸片甲"
+msgstr "胸片​甲"
 
 #: Source/itemdat.cpp:81 Source/itemdat.cpp:83 Source/itemdat.cpp:84
 #: Source/itemdat.cpp:85 Source/itemdat.cpp:86
 msgid "Plate"
-msgstr "板甲"
+msgstr "板​甲"
 
 #: Source/itemdat.cpp:82
 msgid "Splint Mail"
-msgstr "板条甲"
+msgstr "板条​甲"
 
 #: Source/itemdat.cpp:83
 msgid "Plate Mail"
-msgstr "板条锁甲"
+msgstr "板条​锁甲"
 
 #: Source/itemdat.cpp:84
 msgid "Field Plate"
-msgstr "全身板甲"
+msgstr "全身​板​甲"
 
 #: Source/itemdat.cpp:85
 msgid "Gothic Plate"
-msgstr "哥特甲"
+msgstr "哥特​甲"
 
 #: Source/itemdat.cpp:86
 msgid "Full Plate Mail"
-msgstr "全身板链甲"
+msgstr "全身​板链甲"
 
 #: Source/itemdat.cpp:87 Source/itemdat.cpp:88 Source/itemdat.cpp:89
 #: Source/itemdat.cpp:90 Source/itemdat.cpp:91 Source/itemdat.cpp:92
 msgid "Shield"
-msgstr "之盾"
+msgstr "之​盾"
 
 #: Source/itemdat.cpp:88
 msgid "Small Shield"
-msgstr "小盾"
+msgstr "小​盾"
 
 #: Source/itemdat.cpp:89
 msgid "Large Shield"
-msgstr "大盾牌"
+msgstr "大​盾​牌"
 
 #: Source/itemdat.cpp:90
 msgid "Kite Shield"
@@ -2122,19 +2122,19 @@ msgstr "哥特盾"
 
 #: Source/itemdat.cpp:97
 msgid "Potion of Rejuvenation"
-msgstr "活力恢复药水"
+msgstr "活力​恢复​药​水"
 
 #: Source/itemdat.cpp:98
 msgid "Potion of Full Rejuvenation"
-msgstr "完全活力恢复药水"
+msgstr "完全​活力​恢复​药​水"
 
 #: Source/itemdat.cpp:100 Source/items.cpp:161
 msgid "Oil of Accuracy"
-msgstr "精准之油"
+msgstr "精准​之​油"
 
 #: Source/itemdat.cpp:101 Source/items.cpp:163
 msgid "Oil of Sharpness"
-msgstr "锐利之油"
+msgstr "锐利​之​油"
 
 #: Source/itemdat.cpp:102
 msgid "Oil"
@@ -2142,108 +2142,108 @@ msgstr "油"
 
 #: Source/itemdat.cpp:103
 msgid "Elixir of Strength"
-msgstr "力量药剂"
+msgstr "力量​药剂"
 
 #: Source/itemdat.cpp:104
 msgid "Elixir of Magic"
-msgstr "魔法药剂"
+msgstr "魔法​药剂"
 
 #: Source/itemdat.cpp:105
 msgid "Elixir of Dexterity"
-msgstr "敏捷药剂"
+msgstr "敏捷​药剂"
 
 #: Source/itemdat.cpp:106
 msgid "Elixir of Vitality"
-msgstr "活力药剂"
+msgstr "活力​药剂"
 
 #: Source/itemdat.cpp:107
 msgid "Scroll of Healing"
-msgstr "治疗卷轴"
+msgstr "治疗​卷轴"
 
 #: Source/itemdat.cpp:108
 msgid "Scroll of Search"
-msgstr "搜索卷轴"
+msgstr "搜索​卷轴"
 
 #: Source/itemdat.cpp:109
 msgid "Scroll of Lightning"
-msgstr "闪电卷轴"
+msgstr "闪​电​卷轴"
 
 #: Source/itemdat.cpp:112
 msgid "Scroll of Fire Wall"
-msgstr "火焰墙卷轴"
+msgstr "火焰​墙​卷轴"
 
 #: Source/itemdat.cpp:113
 msgid "Scroll of Inferno"
-msgstr "地狱火卷轴"
+msgstr "地​狱火​卷轴"
 
 #: Source/itemdat.cpp:115
 msgid "Scroll of Flash"
-msgstr "闪光卷轴"
+msgstr "闪光​卷轴"
 
 #: Source/itemdat.cpp:116
 msgid "Scroll of Infravision"
-msgstr "夜视卷轴"
+msgstr "夜视​卷轴"
 
 #: Source/itemdat.cpp:117
 msgid "Scroll of Phasing"
-msgstr "相位调整卷轴"
+msgstr "相位​调整​卷轴"
 
 #: Source/itemdat.cpp:118
 msgid "Scroll of Mana Shield"
-msgstr "法力护盾卷轴"
+msgstr "法力​护盾​卷轴"
 
 #: Source/itemdat.cpp:119
 msgid "Scroll of Flame Wave"
-msgstr "火焰波卷轴"
+msgstr "火焰​波​卷轴"
 
 #: Source/itemdat.cpp:120
 msgid "Scroll of Fireball"
-msgstr "火球卷轴"
+msgstr "火球​卷轴"
 
 #: Source/itemdat.cpp:121
 msgid "Scroll of Stone Curse"
-msgstr "石化诅咒卷轴"
+msgstr "石化​诅咒​卷轴"
 
 #: Source/itemdat.cpp:122
 msgid "Scroll of Chain Lightning"
-msgstr "连锁闪电卷轴"
+msgstr "连锁​闪电​卷轴"
 
 #: Source/itemdat.cpp:123
 msgid "Scroll of Guardian"
-msgstr "召唤守护者卷轴"
+msgstr "召唤​守护者​卷轴"
 
 #: Source/itemdat.cpp:125
 msgid "Scroll of Nova"
-msgstr "闪电新星卷轴"
+msgstr "闪电​新​星​卷轴"
 
 #: Source/itemdat.cpp:126
 msgid "Scroll of Golem"
-msgstr "召唤魔像卷轴"
+msgstr "召唤​魔像​卷轴"
 
 #: Source/itemdat.cpp:128
 msgid "Scroll of Teleport"
-msgstr "传送术卷轴"
+msgstr "传​送术​卷轴"
 
 #: Source/itemdat.cpp:129
 msgid "Scroll of Apocalypse"
-msgstr "天启卷轴"
+msgstr "天​启卷​轴"
 
 #: Source/itemdat.cpp:130 Source/itemdat.cpp:131 Source/itemdat.cpp:132
 #: Source/itemdat.cpp:133
 msgid "Book of "
-msgstr "法术书： "
+msgstr "法术​书​： "
 
 #: Source/itemdat.cpp:136
 msgid "Falchion"
-msgstr "弯刃剑"
+msgstr "弯​刃剑"
 
 #: Source/itemdat.cpp:137
 msgid "Scimitar"
-msgstr "西米塔弯刀"
+msgstr "西​米塔​弯刀"
 
 #: Source/itemdat.cpp:138
 msgid "Claymore"
-msgstr "双刃大剑"
+msgstr "双​刃​大​剑"
 
 #: Source/itemdat.cpp:139
 msgid "Blade"
@@ -2255,27 +2255,27 @@ msgstr "军刀"
 
 #: Source/itemdat.cpp:141
 msgid "Long Sword"
-msgstr "长剑"
+msgstr "长​剑"
 
 #: Source/itemdat.cpp:142
 msgid "Broad Sword"
-msgstr "阔剑"
+msgstr "阔​剑"
 
 #: Source/itemdat.cpp:143
 msgid "Bastard Sword"
-msgstr "重剑"
+msgstr "重​剑"
 
 #: Source/itemdat.cpp:144
 msgid "Two-Handed Sword"
-msgstr "双手剑"
+msgstr "双​手​剑"
 
 #: Source/itemdat.cpp:145
 msgid "Great Sword"
-msgstr "双手巨剑"
+msgstr "双​手​巨剑"
 
 #: Source/itemdat.cpp:146
 msgid "Small Axe"
-msgstr "小斧"
+msgstr "小​斧"
 
 #: Source/itemdat.cpp:146 Source/itemdat.cpp:147 Source/itemdat.cpp:148
 #: Source/itemdat.cpp:149 Source/itemdat.cpp:150 Source/itemdat.cpp:151
@@ -2292,7 +2292,7 @@ msgstr "阔斧"
 
 #: Source/itemdat.cpp:150
 msgid "Battle Axe"
-msgstr "战斗斧"
+msgstr "战斗​斧"
 
 #: Source/itemdat.cpp:151
 msgid "Great Axe"
@@ -2300,15 +2300,15 @@ msgstr "大斧"
 
 #: Source/itemdat.cpp:152 Source/itemdat.cpp:153
 msgid "Mace"
-msgstr "钉锤"
+msgstr "钉​锤"
 
 #: Source/itemdat.cpp:153
 msgid "Morning Star"
-msgstr "流星锤"
+msgstr "流​星锤"
 
 #: Source/itemdat.cpp:154
 msgid "War Hammer"
-msgstr "战锤"
+msgstr "战​锤"
 
 #: Source/itemdat.cpp:154
 msgid "Hammer"
@@ -2316,15 +2316,15 @@ msgstr "锤"
 
 #: Source/itemdat.cpp:155
 msgid "Spiked Club"
-msgstr "狼牙棒"
+msgstr "狼​牙棒"
 
 #: Source/itemdat.cpp:157
 msgid "Flail"
-msgstr "连枷"
+msgstr "连​枷"
 
 #: Source/itemdat.cpp:158
 msgid "Maul"
-msgstr "大头锤"
+msgstr "大​头​锤"
 
 #: Source/itemdat.cpp:159 Source/itemdat.cpp:160 Source/itemdat.cpp:161
 #: Source/itemdat.cpp:162 Source/itemdat.cpp:163 Source/itemdat.cpp:164
@@ -2338,7 +2338,7 @@ msgstr "猎弓"
 
 #: Source/itemdat.cpp:161
 msgid "Long Bow"
-msgstr "长弓"
+msgstr "长​弓"
 
 #: Source/itemdat.cpp:162
 msgid "Composite Bow"
@@ -2346,35 +2346,35 @@ msgstr "复合弓"
 
 #: Source/itemdat.cpp:163
 msgid "Short Battle Bow"
-msgstr "短战弓"
+msgstr "短​战弓"
 
 #: Source/itemdat.cpp:164
 msgid "Long Battle Bow"
-msgstr "长战弓"
+msgstr "长​战弓"
 
 #: Source/itemdat.cpp:165
 msgid "Short War Bow"
-msgstr "短战争弓"
+msgstr "短​战争​弓"
 
 #: Source/itemdat.cpp:166
 msgid "Long War Bow"
-msgstr "长战争弓"
+msgstr "长​战争​弓"
 
 #: Source/itemdat.cpp:168
 msgid "Long Staff"
-msgstr "长法杖"
+msgstr "长​法​杖"
 
 #: Source/itemdat.cpp:169
 msgid "Composite Staff"
-msgstr "复合法杖"
+msgstr "复​合法​杖"
 
 #: Source/itemdat.cpp:170
 msgid "Quarter Staff"
-msgstr "弦月法杖"
+msgstr "弦月​法杖"
 
 #: Source/itemdat.cpp:171
 msgid "War Staff"
-msgstr "战争法杖"
+msgstr "战争​法​杖"
 
 #: Source/itemdat.cpp:172 Source/itemdat.cpp:173 Source/itemdat.cpp:174
 msgid "Ring"
@@ -2386,7 +2386,7 @@ msgstr "护符"
 
 #: Source/itemdat.cpp:177
 msgid "Rune of Fire"
-msgstr "火焰符文"
+msgstr "火焰​符文"
 
 #: Source/itemdat.cpp:177 Source/itemdat.cpp:178 Source/itemdat.cpp:179
 #: Source/itemdat.cpp:180 Source/itemdat.cpp:181
@@ -2399,11 +2399,11 @@ msgstr "闪电符文"
 
 #: Source/itemdat.cpp:179
 msgid "Greater Rune of Fire"
-msgstr "强效火焰符文"
+msgstr "强效​火焰​符文"
 
 #: Source/itemdat.cpp:180
 msgid "Greater Rune of Lightning"
-msgstr "强效闪电符文"
+msgstr "强​效​闪电符文"
 
 #: Source/itemdat.cpp:181
 msgid "Rune of Stone"
@@ -2411,7 +2411,7 @@ msgstr "符文石"
 
 #: Source/itemdat.cpp:182
 msgid "Short Staff of Charged Bolt"
-msgstr "电荷弹短杖"
+msgstr "电​荷弹​短​杖"
 
 #. TRANSLATORS: Item prefix section.
 #: Source/itemdat.cpp:192
@@ -2420,7 +2420,7 @@ msgstr "锡"
 
 #: Source/itemdat.cpp:193
 msgid "Brass"
-msgstr "黄铜"
+msgstr "黄​铜"
 
 #: Source/itemdat.cpp:194
 msgid "Bronze"
@@ -2440,7 +2440,7 @@ msgstr "白银"
 
 #: Source/itemdat.cpp:199
 msgid "Platinum"
-msgstr "铂金"
+msgstr "铂​金"
 
 #: Source/itemdat.cpp:200
 msgid "Mithril"
@@ -2448,19 +2448,19 @@ msgstr "秘银"
 
 #: Source/itemdat.cpp:201
 msgid "Meteoric"
-msgstr "陨铁"
+msgstr "陨​铁"
 
 #: Source/itemdat.cpp:202 Source/objects.cpp:107
 msgid "Weird"
-msgstr "诡异"
+msgstr "诡​异"
 
 #: Source/itemdat.cpp:203
 msgid "Strange"
-msgstr "奇异"
+msgstr "奇​异"
 
 #: Source/itemdat.cpp:204
 msgid "Useless"
-msgstr "无用的"
+msgstr "无​用​的"
 
 #: Source/itemdat.cpp:205
 msgid "Bent"
@@ -2468,7 +2468,7 @@ msgstr "弯曲"
 
 #: Source/itemdat.cpp:206
 msgid "Weak"
-msgstr "软弱的"
+msgstr "软弱​的"
 
 #: Source/itemdat.cpp:207
 msgid "Jagged"
@@ -2480,7 +2480,7 @@ msgstr "致命"
 
 #: Source/itemdat.cpp:209
 msgid "Heavy"
-msgstr "沉重的"
+msgstr "沉重​的"
 
 #: Source/itemdat.cpp:210
 msgid "Vicious"
@@ -2492,15 +2492,15 @@ msgstr "残忍"
 
 #: Source/itemdat.cpp:212
 msgid "Massive"
-msgstr "蛮横"
+msgstr "蛮​横"
 
 #: Source/itemdat.cpp:213
 msgid "Savage"
-msgstr "野蛮"
+msgstr "野​蛮"
 
 #: Source/itemdat.cpp:214
 msgid "Ruthless"
-msgstr "无情的"
+msgstr "无情​的"
 
 #: Source/itemdat.cpp:215
 msgid "Merciless"
@@ -2508,11 +2508,11 @@ msgstr "无情"
 
 #: Source/itemdat.cpp:216
 msgid "Clumsy"
-msgstr "笨拙的"
+msgstr "笨拙​的"
 
 #: Source/itemdat.cpp:217
 msgid "Dull"
-msgstr "迟钝的"
+msgstr "迟钝​的"
 
 #: Source/itemdat.cpp:218
 msgid "Sharp"
@@ -2524,31 +2524,31 @@ msgstr "优良"
 
 #: Source/itemdat.cpp:220
 msgid "Warrior's"
-msgstr "战士的"
+msgstr "战士​的"
 
 #: Source/itemdat.cpp:221
 msgid "Soldier's"
-msgstr "士兵的"
+msgstr "士兵​的"
 
 #: Source/itemdat.cpp:222
 msgid "Lord's"
-msgstr "勋爵的"
+msgstr "勋爵​的"
 
 #: Source/itemdat.cpp:223
 msgid "Knight's"
-msgstr "骑士的"
+msgstr "骑士​的"
 
 #: Source/itemdat.cpp:224
 msgid "Master's"
-msgstr "大师的"
+msgstr "大师​的"
 
 #: Source/itemdat.cpp:225
 msgid "Champion's"
-msgstr "勇士的"
+msgstr "勇士​的"
 
 #: Source/itemdat.cpp:226
 msgid "King's"
-msgstr "国王的"
+msgstr "国王​的"
 
 #: Source/itemdat.cpp:227
 msgid "Vulnerable"
@@ -2560,7 +2560,7 @@ msgstr "生锈"
 
 #: Source/itemdat.cpp:230
 msgid "Strong"
-msgstr "强壮"
+msgstr "强​壮"
 
 #: Source/itemdat.cpp:231
 msgid "Grand"
@@ -2600,7 +2600,7 @@ msgstr "丹红"
 
 #: Source/itemdat.cpp:240 Source/itemdat.cpp:241
 msgid "Crimson"
-msgstr "猩红"
+msgstr "猩​红"
 
 #: Source/itemdat.cpp:242
 msgid "Garnet"
@@ -2608,7 +2608,7 @@ msgstr "石榴"
 
 #: Source/itemdat.cpp:243
 msgid "Ruby"
-msgstr "红宝石"
+msgstr "红​宝石"
 
 #: Source/itemdat.cpp:244
 msgid "Blue"
@@ -2620,11 +2620,11 @@ msgstr "碧空"
 
 #: Source/itemdat.cpp:246
 msgid "Lapis"
-msgstr "青金石"
+msgstr "青​金石"
 
 #: Source/itemdat.cpp:247
 msgid "Cobalt"
-msgstr "钴蓝"
+msgstr "钴​蓝"
 
 #: Source/itemdat.cpp:248
 msgid "Sapphire"
@@ -2656,7 +2656,7 @@ msgstr "黄宝石"
 
 #: Source/itemdat.cpp:255
 msgid "Amber"
-msgstr "琥珀"
+msgstr "琥​珀"
 
 #: Source/itemdat.cpp:256
 msgid "Jade"
@@ -2664,59 +2664,59 @@ msgstr "碧玉"
 
 #: Source/itemdat.cpp:257
 msgid "Obsidian"
-msgstr "黑曜石"
+msgstr "黑​曜石"
 
 #: Source/itemdat.cpp:258
 msgid "Emerald"
-msgstr "绿宝石"
+msgstr "绿​宝石"
 
 #: Source/itemdat.cpp:259
 msgid "Hyena's"
-msgstr "土狼"
+msgstr "土​狼"
 
 #: Source/itemdat.cpp:260
 msgid "Frog's"
-msgstr "青蛙的"
+msgstr "青蛙​的"
 
 #: Source/itemdat.cpp:261
 msgid "Spider's"
-msgstr "蜘蛛的"
+msgstr "蜘蛛​的"
 
 #: Source/itemdat.cpp:262
 msgid "Raven's"
-msgstr "乌鸦的"
+msgstr "乌鸦​的"
 
 #: Source/itemdat.cpp:263
 msgid "Snake's"
-msgstr "毒蛇的"
+msgstr "毒​蛇​的"
 
 #: Source/itemdat.cpp:264
 msgid "Serpent's"
-msgstr "巨蛇的"
+msgstr "巨蛇​的"
 
 #: Source/itemdat.cpp:265
 msgid "Drake's"
-msgstr "幼龙的"
+msgstr "幼龙​的"
 
 #: Source/itemdat.cpp:266
 msgid "Dragon's"
-msgstr "翼龙的"
+msgstr "翼龙​的"
 
 #: Source/itemdat.cpp:267
 msgid "Wyrm's"
-msgstr "游龙的"
+msgstr "游龙​的"
 
 #: Source/itemdat.cpp:268
 msgid "Hydra's"
-msgstr "九头蛇的"
+msgstr "九头蛇​的"
 
 #: Source/itemdat.cpp:269
 msgid "Angel's"
-msgstr "天使的"
+msgstr "天使​的"
 
 #: Source/itemdat.cpp:270
 msgid "Arch-Angel's"
-msgstr "大天使的"
+msgstr "大​天使​的"
 
 #: Source/itemdat.cpp:271
 msgid "Plentiful"
@@ -2728,15 +2728,15 @@ msgstr "慷慨"
 
 #: Source/itemdat.cpp:273
 msgid "Flaming"
-msgstr "烈焰"
+msgstr "烈​焰"
 
 #: Source/itemdat.cpp:274
 msgid "Lightning"
-msgstr "闪电"
+msgstr "闪​电"
 
 #: Source/itemdat.cpp:275
 msgid "Jester's"
-msgstr "愚弄法术的"
+msgstr "愚弄​法术​的"
 
 #: Source/itemdat.cpp:276
 msgid "Crystalline"
@@ -2745,7 +2745,7 @@ msgstr "晶状"
 #. TRANSLATORS: Item prefix section end.
 #: Source/itemdat.cpp:278
 msgid "Doppelganger's"
-msgstr "双生的"
+msgstr "双​生​的"
 
 #. TRANSLATORS: Item suffix section. All items will have a word binding word. (Format: {:s} of {:s} - e.g. Rags of Valor)
 #: Source/itemdat.cpp:288
@@ -2758,7 +2758,7 @@ msgstr "残废"
 
 #: Source/itemdat.cpp:290
 msgid "slaying"
-msgstr "杀戮"
+msgstr "杀​戮"
 
 #: Source/itemdat.cpp:291
 msgid "gore"
@@ -2802,7 +2802,7 @@ msgstr "渗透"
 
 #: Source/itemdat.cpp:301
 msgid "frailty"
-msgstr "虚弱"
+msgstr "虚​弱"
 
 #: Source/itemdat.cpp:302
 msgid "weakness"
@@ -2862,7 +2862,7 @@ msgstr "傻瓜"
 
 #: Source/itemdat.cpp:316
 msgid "dyslexia"
-msgstr "文盲"
+msgstr "文​盲"
 
 #: Source/itemdat.cpp:317
 msgid "magic"
@@ -2918,7 +2918,7 @@ msgstr "麻烦"
 
 #: Source/itemdat.cpp:330
 msgid "the pit"
-msgstr "坑洞"
+msgstr "坑​洞"
 
 #: Source/itemdat.cpp:331
 msgid "the sky"
@@ -2942,11 +2942,11 @@ msgstr "星象"
 
 #: Source/itemdat.cpp:336
 msgid "the vulture"
-msgstr "秃鹫"
+msgstr "秃​鹫"
 
 #: Source/itemdat.cpp:337
 msgid "the jackal"
-msgstr "豺狼"
+msgstr "豺​狼"
 
 #: Source/itemdat.cpp:338
 msgid "the fox"
@@ -2962,7 +2962,7 @@ msgstr "老鹰"
 
 #: Source/itemdat.cpp:341
 msgid "the wolf"
-msgstr "野狼"
+msgstr "野​狼"
 
 #: Source/itemdat.cpp:342
 msgid "the tiger"
@@ -2978,11 +2978,11 @@ msgstr "猛犸"
 
 #: Source/itemdat.cpp:345
 msgid "the whale"
-msgstr "鲸鱼"
+msgstr "鲸​鱼"
 
 #: Source/itemdat.cpp:346
 msgid "fragility"
-msgstr "易损"
+msgstr "易​损"
 
 #: Source/itemdat.cpp:347
 msgid "brittleness"
@@ -3038,11 +3038,11 @@ msgstr "闪光"
 
 #: Source/itemdat.cpp:360
 msgid "lightning"
-msgstr "闪电"
+msgstr "闪​电"
 
 #: Source/itemdat.cpp:361
 msgid "thunder"
-msgstr "雷电"
+msgstr "雷​电"
 
 #: Source/itemdat.cpp:362
 msgid "many"
@@ -3062,19 +3062,19 @@ msgstr "腐败"
 
 #: Source/itemdat.cpp:366
 msgid "thieves"
-msgstr "窃贼"
+msgstr "窃​贼"
 
 #: Source/itemdat.cpp:367
 msgid "the bear"
-msgstr "野熊"
+msgstr "野​熊"
 
 #: Source/itemdat.cpp:368
 msgid "the bat"
-msgstr "蝙蝠"
+msgstr "蝙​蝠"
 
 #: Source/itemdat.cpp:369
 msgid "vampires"
-msgstr "吸血鬼"
+msgstr "吸血​鬼"
 
 #: Source/itemdat.cpp:370
 msgid "the leech"
@@ -3086,7 +3086,7 @@ msgstr "鲜血"
 
 #: Source/itemdat.cpp:372
 msgid "piercing"
-msgstr "穿刺"
+msgstr "穿​刺"
 
 #: Source/itemdat.cpp:373
 msgid "puncturing"
@@ -3126,7 +3126,7 @@ msgstr "和谐"
 
 #: Source/itemdat.cpp:382
 msgid "blocking"
-msgstr "格挡"
+msgstr "格​挡"
 
 #: Source/itemdat.cpp:383
 msgid "devastation"
@@ -3144,15 +3144,15 @@ msgstr "危险"
 #. TRANSLATORS: Unique Item section
 #: Source/itemdat.cpp:396
 msgid "The Butcher's Cleaver"
-msgstr "屠夫的剁肉刀"
+msgstr "屠夫​的​剁肉刀"
 
 #: Source/itemdat.cpp:406
 msgid "The Rift Bow"
-msgstr "裂缝弓"
+msgstr "裂缝​弓"
 
 #: Source/itemdat.cpp:407
 msgid "The Needler"
-msgstr "缝纫工"
+msgstr "缝纫​工"
 
 #: Source/itemdat.cpp:408
 msgid "The Celestial Bow"
@@ -3160,35 +3160,35 @@ msgstr "天堂弓"
 
 #: Source/itemdat.cpp:409
 msgid "Deadly Hunter"
-msgstr "致命猎手"
+msgstr "致命​猎手"
 
 #: Source/itemdat.cpp:410
 msgid "Bow of the Dead"
-msgstr "死者之弓"
+msgstr "死者​之​弓"
 
 #: Source/itemdat.cpp:411
 msgid "The Blackoak Bow"
-msgstr "黑色橡木弓"
+msgstr "黑色​橡木弓"
 
 #: Source/itemdat.cpp:412
 msgid "Flamedart"
-msgstr "火焰镖"
+msgstr "火焰​镖"
 
 #: Source/itemdat.cpp:413
 msgid "Fleshstinger"
-msgstr "肉刺"
+msgstr "肉​刺"
 
 #: Source/itemdat.cpp:414
 msgid "Windforce"
-msgstr "风之力"
+msgstr "风​之​力"
 
 #: Source/itemdat.cpp:415
 msgid "Eaglehorn"
-msgstr "鹰之号角"
+msgstr "鹰​之​号​角"
 
 #: Source/itemdat.cpp:416
 msgid "Gonnagal's Dirk"
-msgstr "贡纳加尔的匕首"
+msgstr "贡纳加尔​的​匕首"
 
 #: Source/itemdat.cpp:417
 msgid "The Defender"
@@ -3196,11 +3196,11 @@ msgstr "防守者"
 
 #: Source/itemdat.cpp:418
 msgid "Gryphon's Claw"
-msgstr "狮鹫之爪"
+msgstr "狮​鹫​之​爪"
 
 #: Source/itemdat.cpp:419
 msgid "Black Razor"
-msgstr "黑色剃刀"
+msgstr "黑色​剃刀"
 
 #: Source/itemdat.cpp:420
 msgid "Gibbous Moon"
@@ -3212,7 +3212,7 @@ msgstr "冰柄"
 
 #: Source/itemdat.cpp:422
 msgid "The Executioner's Blade"
-msgstr "刽子手的利刃"
+msgstr "刽子手​的​利刃"
 
 #: Source/itemdat.cpp:423
 msgid "The Bonesaw"
@@ -3224,23 +3224,23 @@ msgstr "影鹰"
 
 #: Source/itemdat.cpp:425
 msgid "Wizardspike"
-msgstr "巫师之刺"
+msgstr "巫师​之​刺"
 
 #: Source/itemdat.cpp:426
 msgid "Lightsabre"
-msgstr "光之军刀"
+msgstr "光​之​军刀"
 
 #: Source/itemdat.cpp:427
 msgid "The Falcon's Talon"
-msgstr "鹰隼之爪"
+msgstr "鹰隼​之​爪"
 
 #: Source/itemdat.cpp:428
 msgid "Inferno"
-msgstr "地狱火"
+msgstr "地​狱火"
 
 #: Source/itemdat.cpp:429
 msgid "Doombringer"
-msgstr "末日使者"
+msgstr "末​日​使者"
 
 #: Source/itemdat.cpp:430
 msgid "The Grizzly"
@@ -3260,7 +3260,7 @@ msgstr "锐喙"
 
 #: Source/itemdat.cpp:434
 msgid "BloodSlayer"
-msgstr "血腥杀戮者"
+msgstr "血腥​杀戮者"
 
 #: Source/itemdat.cpp:435
 msgid "The Celestial Axe"
@@ -3280,11 +3280,11 @@ msgstr "阿吉纳拉斧头"
 
 #: Source/itemdat.cpp:439
 msgid "Hellslayer"
-msgstr "地狱屠戮者"
+msgstr "地狱​屠​戮者"
 
 #: Source/itemdat.cpp:440
 msgid "Messerschmidt's Reaver"
-msgstr "梅塞施密特的劫掠者"
+msgstr "梅​塞施密特​的​劫掠者"
 
 #: Source/itemdat.cpp:441
 msgid "Crackrust"
@@ -3292,39 +3292,39 @@ msgstr "裂纹"
 
 #: Source/itemdat.cpp:442
 msgid "Hammer of Jholm"
-msgstr "霍尔姆之锤"
+msgstr "霍尔姆​之​锤"
 
 #: Source/itemdat.cpp:443
 msgid "Civerb's Cudgel"
-msgstr "希弗柏的短棍"
+msgstr "希弗柏​的​短棍"
 
 #: Source/itemdat.cpp:444
 msgid "The Celestial Star"
-msgstr "天堂之星"
+msgstr "天堂​之​星"
 
 #: Source/itemdat.cpp:445
 msgid "Baranar's Star"
-msgstr "巴拉纳之星"
+msgstr "巴拉纳​之​星"
 
 #: Source/itemdat.cpp:446
 msgid "Gnarled Root"
-msgstr "多节根"
+msgstr "多​节根"
 
 #: Source/itemdat.cpp:447
 msgid "The Cranium Basher"
-msgstr "碎颅"
+msgstr "碎​颅"
 
 #: Source/itemdat.cpp:448
 msgid "Schaefer's Hammer"
-msgstr "舍费尔之锤"
+msgstr "舍费尔​之​锤"
 
 #: Source/itemdat.cpp:449
 msgid "Dreamflange"
-msgstr "梦幻法兰"
+msgstr "梦​幻法兰"
 
 #: Source/itemdat.cpp:450
 msgid "Staff of Shadows"
-msgstr "暗影之杖"
+msgstr "暗影​之​杖"
 
 #: Source/itemdat.cpp:451
 msgid "Immolator"
@@ -3332,15 +3332,15 @@ msgstr "献祭者"
 
 #: Source/itemdat.cpp:452
 msgid "Storm Spire"
-msgstr "风暴尖刺"
+msgstr "风暴​尖刺"
 
 #: Source/itemdat.cpp:453
 msgid "Gleamsong"
-msgstr "闪光之歌"
+msgstr "闪光​之​歌"
 
 #: Source/itemdat.cpp:454
 msgid "Thundercall"
-msgstr "风暴召唤"
+msgstr "风暴​召唤"
 
 #: Source/itemdat.cpp:455
 msgid "The Protector"
@@ -3348,7 +3348,7 @@ msgstr "保护者"
 
 #: Source/itemdat.cpp:456
 msgid "Naj's Puzzler"
-msgstr "诺吉的解密棒"
+msgstr "诺吉​的​解密棒"
 
 #: Source/itemdat.cpp:457
 msgid "Mindcry"
@@ -3356,11 +3356,11 @@ msgstr "心声"
 
 #: Source/itemdat.cpp:458
 msgid "Rod of Onan"
-msgstr "奥南之棒"
+msgstr "奥南​之​棒"
 
 #: Source/itemdat.cpp:459
 msgid "Helm of Spirits"
-msgstr "精魂头盔"
+msgstr "精魂​头盔"
 
 #: Source/itemdat.cpp:460
 msgid "Thinking Cap"
@@ -3368,11 +3368,11 @@ msgstr "思考帽"
 
 #: Source/itemdat.cpp:461
 msgid "OverLord's Helm"
-msgstr "霸王的头盔"
+msgstr "霸王​的​头盔"
 
 #: Source/itemdat.cpp:462
 msgid "Fool's Crest"
-msgstr "愚人奖章"
+msgstr "愚人​奖章"
 
 #: Source/itemdat.cpp:463
 msgid "Gotterdamerung"
@@ -3380,35 +3380,35 @@ msgstr "暮光"
 
 #: Source/itemdat.cpp:464
 msgid "Royal Circlet"
-msgstr "贵族头环"
+msgstr "贵族​头环"
 
 #: Source/itemdat.cpp:465
 msgid "Torn Flesh of Souls"
-msgstr "魂飞魄散"
+msgstr "魂​飞魄​散"
 
 #: Source/itemdat.cpp:466
 msgid "The Gladiator's Bane"
-msgstr "角斗士之祸"
+msgstr "角​斗士​之​祸"
 
 #: Source/itemdat.cpp:467
 msgid "The Rainbow Cloak"
-msgstr "彩虹斗篷"
+msgstr "彩虹​斗篷"
 
 #: Source/itemdat.cpp:468
 msgid "Leather of Aut"
-msgstr "奥特之皮"
+msgstr "奥特​之​皮"
 
 #: Source/itemdat.cpp:469
 msgid "Wisdom's Wrap"
-msgstr "智慧束带"
+msgstr "智慧​束带"
 
 #: Source/itemdat.cpp:470
 msgid "Sparking Mail"
-msgstr "电光锁甲"
+msgstr "电光锁​甲"
 
 #: Source/itemdat.cpp:471
 msgid "Scavenger Carapace"
-msgstr "食腐甲壳"
+msgstr "食​腐甲壳"
 
 #: Source/itemdat.cpp:472
 msgid "Nightscape"
@@ -3416,11 +3416,11 @@ msgstr "夜色"
 
 #: Source/itemdat.cpp:473
 msgid "Naj's Light Plate"
-msgstr "诺吉的轻铠甲"
+msgstr "诺吉​的​轻铠​甲"
 
 #: Source/itemdat.cpp:474
 msgid "Demonspike Coat"
-msgstr "恶魔长钉外套"
+msgstr "恶​魔长​钉​外套"
 
 #: Source/itemdat.cpp:475
 msgid "The Deflector"
@@ -3428,23 +3428,23 @@ msgstr "偏转者"
 
 #: Source/itemdat.cpp:476
 msgid "Split Skull Shield"
-msgstr "裂颅护盾"
+msgstr "裂颅​护盾"
 
 #: Source/itemdat.cpp:477
 msgid "Dragon's Breach"
-msgstr "巨龙吐息"
+msgstr "巨​龙吐息"
 
 #: Source/itemdat.cpp:478
 msgid "Blackoak Shield"
-msgstr "黑橡木盾"
+msgstr "黑​橡木盾"
 
 #: Source/itemdat.cpp:479
 msgid "Holy Defender"
-msgstr "神圣卫士"
+msgstr "神圣​卫士"
 
 #: Source/itemdat.cpp:480
 msgid "Stormshield"
-msgstr "暴风之盾"
+msgstr "暴风​之​盾"
 
 #: Source/itemdat.cpp:481
 msgid "Bramble"
@@ -3452,31 +3452,31 @@ msgstr "刺棘"
 
 #: Source/itemdat.cpp:482
 msgid "Ring of Regha"
-msgstr "雷加之戒"
+msgstr "雷加之​戒"
 
 #: Source/itemdat.cpp:483
 msgid "The Bleeder"
-msgstr "放血者"
+msgstr "放​血者"
 
 #: Source/itemdat.cpp:484
 msgid "Constricting Ring"
-msgstr "紧缩之戒"
+msgstr "紧缩​之​戒"
 
 #: Source/itemdat.cpp:485
 msgid "Ring of Engagement"
-msgstr "订婚戒指"
+msgstr "订​婚​戒指"
 
 #: Source/itemdat.cpp:486
 msgid "Giant's Knuckle"
-msgstr "巨人的指节"
+msgstr "巨人​的​指节"
 
 #: Source/itemdat.cpp:487
 msgid "Mercurial Ring"
-msgstr "水银戒指"
+msgstr "水​银戒指"
 
 #: Source/itemdat.cpp:488
 msgid "Xorine's Ring"
-msgstr "克索林的戒指"
+msgstr "克索林​的​戒指"
 
 #: Source/itemdat.cpp:489
 msgid "Karik's Ring"
@@ -3484,39 +3484,39 @@ msgstr "卡里克戒指"
 
 #: Source/itemdat.cpp:490
 msgid "Ring of Magma"
-msgstr "熔岩指环"
+msgstr "熔岩​指环"
 
 #: Source/itemdat.cpp:491
 msgid "Ring of the Mystics"
-msgstr "神秘指环"
+msgstr "神秘​指环"
 
 #: Source/itemdat.cpp:492
 msgid "Ring of Thunder"
-msgstr "雷电指环"
+msgstr "雷电​指环"
 
 #: Source/itemdat.cpp:493
 msgid "Amulet of Warding"
-msgstr "闪避护符"
+msgstr "闪避​护符"
 
 #: Source/itemdat.cpp:494
 msgid "Gnat Sting"
-msgstr "虫咬"
+msgstr "虫​咬"
 
 #: Source/itemdat.cpp:495
 msgid "Flambeau"
-msgstr "烛台"
+msgstr "烛​台"
 
 #: Source/itemdat.cpp:496
 msgid "Armor of Gloom"
-msgstr "阴沉护甲"
+msgstr "阴​沉护​甲"
 
 #: Source/itemdat.cpp:497
 msgid "Blitzen"
-msgstr "闪电迅捷"
+msgstr "闪​电​迅捷"
 
 #: Source/itemdat.cpp:498
 msgid "Thunderclap"
-msgstr "霹雳"
+msgstr "霹​雳"
 
 #: Source/itemdat.cpp:499
 msgid "Shirotachi"
@@ -3524,7 +3524,7 @@ msgstr "白池"
 
 #: Source/itemdat.cpp:500
 msgid "Eater of Souls"
-msgstr "灵魂吞噬者"
+msgstr "灵魂​吞噬者"
 
 #: Source/itemdat.cpp:501
 msgid "Diamondedge"
@@ -3532,48 +3532,48 @@ msgstr "钻石利刃"
 
 #: Source/itemdat.cpp:502
 msgid "Bone Chain Armor"
-msgstr "骨链甲"
+msgstr "骨链​甲"
 
 #: Source/itemdat.cpp:503
 msgid "Demon Plate Armor"
-msgstr "恶魔板甲"
+msgstr "恶​魔板​甲"
 
 #: Source/itemdat.cpp:504
 msgid "Acolyte's Amulet"
-msgstr "侍从护符"
+msgstr "侍​从​护符"
 
 #. TRANSLATORS: Unique Item section end.
 #: Source/itemdat.cpp:506
 msgid "Gladiator's Ring"
-msgstr "角斗士戒指"
+msgstr "角​斗士​戒指"
 
 #: Source/items.cpp:162
 msgid "Oil of Mastery"
-msgstr "掌控之油"
+msgstr "掌控​之​油"
 
 #: Source/items.cpp:164
 msgid "Oil of Death"
-msgstr "死亡之油"
+msgstr "死亡​之​油"
 
 #: Source/items.cpp:165
 msgid "Oil of Skill"
-msgstr "技能之油"
+msgstr "技能​之​油"
 
 #: Source/items.cpp:167
 msgid "Oil of Fortitude"
-msgstr "坚韧之油"
+msgstr "坚韧​之​油"
 
 #: Source/items.cpp:168
 msgid "Oil of Permanence"
-msgstr "永恒之油"
+msgstr "永恒​之​油"
 
 #: Source/items.cpp:169
 msgid "Oil of Hardening"
-msgstr "硬化之油"
+msgstr "硬化​之​油"
 
 #: Source/items.cpp:170
 msgid "Oil of Imperviousness"
-msgstr "防水之油"
+msgstr "防水​之​油"
 
 #. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
 #. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
@@ -3595,205 +3595,205 @@ msgstr "{1}{0}"
 
 #: Source/items.cpp:1892 Source/items.cpp:1904
 msgid "increases a weapon's"
-msgstr "增加武器的"
+msgstr "增加​武器​的"
 
 #: Source/items.cpp:1894
 msgid "chance to hit"
-msgstr "命中概率"
+msgstr "命​中​概率"
 
 #: Source/items.cpp:1898
 msgid "greatly increases a"
-msgstr "显著增加一件"
+msgstr "显著​增加​一​件"
 
 #: Source/items.cpp:1900
 msgid "weapon's chance to hit"
-msgstr "武器命中概率"
+msgstr "武器​命​中​概率"
 
 #: Source/items.cpp:1906
 msgid "damage potential"
-msgstr "伤害潜力"
+msgstr "伤害​潜力"
 
 #: Source/items.cpp:1910
 msgid "greatly increases a weapon's"
-msgstr "大大提高非弓类武器"
+msgstr "大大​提高​非弓类​武器"
 
 #: Source/items.cpp:1912
 msgid "damage potential - not bows"
-msgstr "的伤害潜力"
+msgstr "的​伤害​潜力"
 
 #: Source/items.cpp:1916
 msgid "reduces attributes needed"
-msgstr "减少护甲或武器"
+msgstr "减少​护甲​或​武器"
 
 #: Source/items.cpp:1918
 msgid "to use armor or weapons"
-msgstr "使用所需属性"
+msgstr "使用​所​需​属性"
 
 #: Source/items.cpp:1922
 #, no-c-format
 msgid "restores 20% of an"
-msgstr "恢复20%的"
+msgstr "恢复​20​%​的"
 
 #: Source/items.cpp:1924
 msgid "item's durability"
-msgstr "物品耐久度"
+msgstr "物品​耐久度"
 
 #: Source/items.cpp:1928
 msgid "increases an item's"
-msgstr "增加一件物品的"
+msgstr "增加​一​件​物品​的"
 
 #: Source/items.cpp:1930
 msgid "current and max durability"
-msgstr "当前和最大耐久度"
+msgstr "当前​和​最​大​耐久度"
 
 #: Source/items.cpp:1934
 msgid "makes an item indestructible"
-msgstr "使物品坚不可摧"
+msgstr "使​物品​坚​不​可​摧"
 
 #: Source/items.cpp:1938
 msgid "increases the armor class"
-msgstr "增加护甲和盾牌的"
+msgstr "增加​护甲​和​盾牌​的"
 
 #: Source/items.cpp:1940
 msgid "of armor and shields"
-msgstr "护甲等级"
+msgstr "护甲​等级"
 
 #: Source/items.cpp:1944
 msgid "greatly increases the armor"
-msgstr "极大增加护甲和盾牌"
+msgstr "极​大​增加​护甲​和​盾牌"
 
 #: Source/items.cpp:1946
 msgid "class of armor and shields"
-msgstr "的护甲等级"
+msgstr "的​护甲​等级"
 
 #: Source/items.cpp:1950 Source/items.cpp:1959
 msgid "sets fire trap"
-msgstr "设置火焰陷阱"
+msgstr "设置​火焰​陷阱"
 
 #: Source/items.cpp:1955
 msgid "sets lightning trap"
-msgstr "设置闪电陷阱"
+msgstr "设置​闪电​陷阱"
 
 #: Source/items.cpp:1963
 msgid "sets petrification trap"
-msgstr "设置石化陷阱"
+msgstr "设置​石化​陷阱"
 
 #: Source/items.cpp:1967
 msgid "restore all life"
-msgstr "恢复所有生命值"
+msgstr "恢复​所有​生命​值"
 
 #: Source/items.cpp:1971
 msgid "restore some life"
-msgstr "恢复部分生命值"
+msgstr "恢复​部分​生命​值"
 
 #: Source/items.cpp:1975
 msgid "recover life"
-msgstr "恢复生命值"
+msgstr "恢复​生命​值"
 
 #: Source/items.cpp:1979
 msgid "deadly heal"
-msgstr "治疗致命伤"
+msgstr "治疗​致命​伤"
 
 #: Source/items.cpp:1983
 msgid "restore some mana"
-msgstr "恢复部分法力"
+msgstr "恢复​部分​法力"
 
 #: Source/items.cpp:1987
 msgid "restore all mana"
-msgstr "恢复所有法力"
+msgstr "恢复​所有​法力"
 
 #: Source/items.cpp:1991
 msgid "increase strength"
-msgstr "增加力量"
+msgstr "增加​力量"
 
 #: Source/items.cpp:1995
 msgid "increase magic"
-msgstr "增加魔法"
+msgstr "增加​魔法"
 
 #: Source/items.cpp:1999
 msgid "increase dexterity"
-msgstr "增加敏捷"
+msgstr "增加​敏捷"
 
 #: Source/items.cpp:2003
 msgid "increase vitality"
-msgstr "增加活力"
+msgstr "增加​活力"
 
 #: Source/items.cpp:2008
 msgid "decrease strength"
-msgstr "降低力量"
+msgstr "降低​力量"
 
 #: Source/items.cpp:2012
 msgid "decrease dexterity"
-msgstr "降低敏捷"
+msgstr "降低​敏捷"
 
 #: Source/items.cpp:2016
 msgid "decrease vitality"
-msgstr "降低活力"
+msgstr "降低​活力"
 
 #: Source/items.cpp:2020
 msgid "restore some life and mana"
-msgstr "恢复部分生命和法力"
+msgstr "恢复​部分​生命​和​法力"
 
 #: Source/items.cpp:2024
 msgid "restore all life and mana"
-msgstr "恢复所有生命和法力"
+msgstr "恢复​所有​生命​和​法力"
 
 #: Source/items.cpp:2039 Source/items.cpp:2064
 msgid "Right-click to read"
-msgstr "右击阅读"
+msgstr "右击​阅读"
 
 #: Source/items.cpp:2043
 msgid "Right-click to read, then"
-msgstr "右击阅读，然后"
+msgstr "右击​阅读​，​然后"
 
 #: Source/items.cpp:2045
 msgid "left-click to target"
-msgstr "左击目标"
+msgstr "左击​目标"
 
 #: Source/items.cpp:2050
 msgid "Right-click to use"
-msgstr "右击使用"
+msgstr "右击​使用"
 
 #: Source/items.cpp:2055 Source/items.cpp:2060
 msgid "Right click to use"
-msgstr "右击使用"
+msgstr "右击​使用"
 
 #: Source/items.cpp:2068
 msgid "Right click to read"
-msgstr "右击阅读"
+msgstr "右击​阅读"
 
 #: Source/items.cpp:2072
 msgid "Right-click to view"
-msgstr "右击查看"
+msgstr "右击​查看"
 
 #: Source/items.cpp:2080
 msgid "Doubles gold capacity"
-msgstr "金币容量翻倍"
+msgstr "金币​容量​翻倍"
 
 #: Source/items.cpp:2092 Source/stores.cpp:212
 msgid "Required:"
-msgstr "需求:"
+msgstr "需求​:"
 
 #: Source/items.cpp:2094 Source/stores.cpp:214
 msgid " {:d} Str"
-msgstr " {:d} 力量"
+msgstr " {:d} ​力量"
 
 #: Source/items.cpp:2096 Source/stores.cpp:216
 msgid " {:d} Mag"
-msgstr " {:d} 魔法"
+msgstr " {:d} ​魔法"
 
 #: Source/items.cpp:2098 Source/stores.cpp:218
 msgid " {:d} Dex"
-msgstr " {:d} 敏捷"
+msgstr " {:d} ​敏捷"
 
 #. TRANSLATORS: {:s} will be a Character Name
 #: Source/items.cpp:3523 Source/player.cpp:3027
 msgid "Ear of {:s}"
-msgstr "{:s}的耳朵"
+msgstr "{:s}​的​耳朵"
 
 #: Source/items.cpp:3818
 msgid "chance to hit: {:+d}%"
-msgstr "命中几率: {:+d}%"
+msgstr "命​中​几​率​:​ {:+d}%"
 
 #: Source/items.cpp:3822
 #, no-c-format
@@ -3802,7 +3802,7 @@ msgstr "{:+d}% 伤害"
 
 #: Source/items.cpp:3826 Source/items.cpp:4082
 msgid "to hit: {:+d}%, {:+d}% damage"
-msgstr "命中: {:+d}%, {:+d}%伤害"
+msgstr "命​中​:​ {:+d}%​, {:+d}%​伤害"
 
 #: Source/items.cpp:3830
 #, no-c-format
@@ -3811,43 +3811,43 @@ msgstr "{:+d}% 护甲"
 
 #: Source/items.cpp:3834
 msgid "armor class: {:d}"
-msgstr "护甲等级: {:d}"
+msgstr "护甲​等级​:​ {:d}"
 
 #: Source/items.cpp:3839 Source/items.cpp:4064
 msgid "Resist Fire: {:+d}%"
-msgstr "火焰抗性: {:+d}%"
+msgstr "火焰​抗性​:​ {:+d}%"
 
 #: Source/items.cpp:3841
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
-msgstr "火焰抗性: 最大75%"
+msgstr "火焰​抗性​: 最​大​75%"
 
 #: Source/items.cpp:3846
 msgid "Resist Lightning: {:+d}%"
-msgstr "闪电抗性: {:+d}%"
+msgstr "闪电​抗性​:​ {:+d}%"
 
 #: Source/items.cpp:3848
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
-msgstr "闪电抗性: 最大75%"
+msgstr "闪电​抗性​: 最​大​75%"
 
 #: Source/items.cpp:3853
 msgid "Resist Magic: {:+d}%"
-msgstr "抵抗魔法: {:+d}%"
+msgstr "抵抗​魔法​:​ {:+d}%"
 
 #: Source/items.cpp:3855
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
-msgstr "抵抗魔法: 最大75%"
+msgstr "抵抗​魔法​: 最​大​75%"
 
 #: Source/items.cpp:3860
 msgid "Resist All: {:+d}%"
-msgstr "所有抗性: {:+d}%"
+msgstr "所有​抗性​:​ {:+d}%"
 
 #: Source/items.cpp:3862
 #, no-c-format
 msgid "Resist All: 75% MAX"
-msgstr "所有抗性: 最大75%"
+msgstr "所有​抗性​: 最​大​75%"
 
 #: Source/items.cpp:3866
 msgid "spells are increased {:d} level"
@@ -3861,11 +3861,11 @@ msgstr[0] "法术降低{:d}级"
 
 #: Source/items.cpp:3870
 msgid "spell levels unchanged (?)"
-msgstr "法术等级不变(?)"
+msgstr "法术​等级​不​变(?)"
 
 #: Source/items.cpp:3873
 msgid "Extra charges"
-msgstr "额外充能次数"
+msgstr "额外​充能​次数"
 
 #: Source/items.cpp:3876
 msgid "{:d} {:s} charge"
@@ -3874,190 +3874,190 @@ msgstr[0] "{:d} {:s} 充能"
 
 #: Source/items.cpp:3880
 msgid "Fire hit damage: {:d}"
-msgstr "火焰伤害: {:d}"
+msgstr "火焰​伤害​:​ {:d}"
 
 #: Source/items.cpp:3882
 msgid "Fire hit damage: {:d}-{:d}"
-msgstr "火焰伤害: {:d}-{:d}"
+msgstr "火焰​伤害​:​ {:d}-{:d}"
 
 #: Source/items.cpp:3886
 msgid "Lightning hit damage: {:d}"
-msgstr "闪电伤害: {:d}"
+msgstr "闪电​伤害​:​ {:d}"
 
 #: Source/items.cpp:3888
 msgid "Lightning hit damage: {:d}-{:d}"
-msgstr "闪电伤害: {:d}-{:d}"
+msgstr "闪电​伤害​:​ {:d}-{:d}"
 
 #: Source/items.cpp:3892
 msgid "{:+d} to strength"
-msgstr "{:+d} 力量"
+msgstr "{:+d} ​力量"
 
 #: Source/items.cpp:3896
 msgid "{:+d} to magic"
-msgstr "{:+d} 魔法"
+msgstr "{:+d} ​魔法"
 
 #: Source/items.cpp:3900
 msgid "{:+d} to dexterity"
-msgstr "{:+d} 敏捷"
+msgstr "{:+d} ​敏捷"
 
 #: Source/items.cpp:3904
 msgid "{:+d} to vitality"
-msgstr "{:+d} 活力"
+msgstr "{:+d} ​活力"
 
 #: Source/items.cpp:3908
 msgid "{:+d} to all attributes"
-msgstr "{:+d} 所有属性"
+msgstr "{:+d} ​所有​属性"
 
 #: Source/items.cpp:3912
 msgid "{:+d} damage from enemies"
-msgstr "{:+d} 来自敌人的伤害"
+msgstr "{:+d} ​来自​敌人​的​伤害"
 
 #: Source/items.cpp:3916
 msgid "Hit Points: {:+d}"
-msgstr "生命值: {:+d}"
+msgstr "生命​值​:​ {:+d}"
 
 #: Source/items.cpp:3920
 msgid "Mana: {:+d}"
-msgstr "法力值: {:+d}"
+msgstr "法力值​:​ {:+d}"
 
 #: Source/items.cpp:3923
 msgid "high durability"
-msgstr "高耐久度"
+msgstr "高​耐​久度"
 
 #: Source/items.cpp:3926
 msgid "decreased durability"
-msgstr "耐久度降低"
+msgstr "耐​久度​降低"
 
 #: Source/items.cpp:3929
 msgid "indestructible"
-msgstr "坚不可摧"
+msgstr "坚​不​可​摧"
 
 #: Source/items.cpp:3932
 #, no-c-format
 msgid "+{:d}% light radius"
-msgstr "+{:d}% 照亮范围"
+msgstr "+{:d}% 照亮​范围"
 
 #: Source/items.cpp:3935
 #, no-c-format
 msgid "-{:d}% light radius"
-msgstr "-{:d}% 照亮范围"
+msgstr "-{:d}% 照亮​范围"
 
 #: Source/items.cpp:3938
 msgid "multiple arrows per shot"
-msgstr "多重射击"
+msgstr "多​重​射击"
 
 #: Source/items.cpp:3942
 msgid "fire arrows damage: {:d}"
-msgstr "火箭伤害: {:d}"
+msgstr "火箭​伤害​:​ {:d}"
 
 #: Source/items.cpp:3944
 msgid "fire arrows damage: {:d}-{:d}"
-msgstr "火箭伤害: {:d}-{:d}"
+msgstr "火箭​伤害​:​ {:d}-{:d}"
 
 #: Source/items.cpp:3948
 msgid "lightning arrows damage {:d}"
-msgstr "闪电箭伤害{:d}"
+msgstr "闪​电箭​伤害​{:d}"
 
 #: Source/items.cpp:3950
 msgid "lightning arrows damage {:d}-{:d}"
-msgstr "闪电箭伤害{:d}-{:d}"
+msgstr "闪​电箭​伤害​{:d}-{:d}"
 
 #: Source/items.cpp:3954
 msgid "fireball damage: {:d}"
-msgstr "火球伤害: {:d}"
+msgstr "火球​伤害​:​ {:d}"
 
 #: Source/items.cpp:3956
 msgid "fireball damage: {:d}-{:d}"
-msgstr "火球伤害: {:d}-{:d}"
+msgstr "火球​伤害​:​ {:d}-{:d}"
 
 #: Source/items.cpp:3959
 msgid "attacker takes 1-3 damage"
-msgstr "攻击者受到1-3点伤害"
+msgstr "攻击者​受到​1-3点​伤害"
 
 #: Source/items.cpp:3962
 msgid "user loses all mana"
-msgstr "使用者失去所有法力值"
+msgstr "使用者​失去​所有​法力值"
 
 #: Source/items.cpp:3965
 msgid "you can't heal"
-msgstr "你无法治愈"
+msgstr "你​无法治​愈"
 
 #: Source/items.cpp:3968
 msgid "absorbs half of trap damage"
-msgstr "吸收一半陷阱伤害"
+msgstr "吸收​一半​陷阱​伤害"
 
 #: Source/items.cpp:3971
 msgid "knocks target back"
-msgstr "击退目标"
+msgstr "击​退​目标"
 
 #: Source/items.cpp:3974
 #, no-c-format
 msgid "+200% damage vs. demons"
-msgstr "+200% 对恶魔的伤害"
+msgstr "+200​% 对​恶魔​的​伤害"
 
 #: Source/items.cpp:3977
 msgid "All Resistance equals 0"
-msgstr "所有抗性变为0"
+msgstr "所有​抗性​变为​0"
 
 #: Source/items.cpp:3980
 msgid "hit monster doesn't heal"
-msgstr "命中怪物无法自愈"
+msgstr "命​中​怪物​无法​自愈"
 
 #: Source/items.cpp:3984
 #, no-c-format
 msgid "hit steals 3% mana"
-msgstr "命中时3%法力偷取"
+msgstr "命​中时​3​%法力​偷取"
 
 #: Source/items.cpp:3986
 #, no-c-format
 msgid "hit steals 5% mana"
-msgstr "命中时5%法力偷取"
+msgstr "命​中时​5​%​法力​偷取"
 
 #: Source/items.cpp:3990
 #, no-c-format
 msgid "hit steals 3% life"
-msgstr "命中时3%生命偷取"
+msgstr "命​中时​3​%​生命​偷取"
 
 #: Source/items.cpp:3992
 #, no-c-format
 msgid "hit steals 5% life"
-msgstr "命中时5%生命偷取"
+msgstr "命​中时​5​%​生命​偷取"
 
 #: Source/items.cpp:3995
 msgid "penetrates target's armor"
-msgstr "穿透目标的护甲"
+msgstr "穿透​目标​的​护甲"
 
 #: Source/items.cpp:3999
 msgid "quick attack"
-msgstr "快速攻击"
+msgstr "快速​攻击"
 
 #: Source/items.cpp:4001
 msgid "fast attack"
-msgstr "更快攻击"
+msgstr "更​快​攻击"
 
 #: Source/items.cpp:4003
 msgid "faster attack"
-msgstr "极速攻击"
+msgstr "极​速​攻击"
 
 #: Source/items.cpp:4005
 msgid "fastest attack"
-msgstr "最快攻击"
+msgstr "最​快​攻击"
 
 #: Source/items.cpp:4009
 msgid "fast hit recovery"
-msgstr "快速打击回复"
+msgstr "快速​打击​回复"
 
 #: Source/items.cpp:4011
 msgid "faster hit recovery"
-msgstr "更快打击回复"
+msgstr "更​快​打击​回复"
 
 #: Source/items.cpp:4013
 msgid "fastest hit recovery"
-msgstr "最快打击回复"
+msgstr "最​快​打击​回复"
 
 #: Source/items.cpp:4016
 msgid "fast block"
-msgstr "快速格挡"
+msgstr "快速​格挡"
 
 #: Source/items.cpp:4019
 msgid "adds {:d} point to damage"
@@ -4066,166 +4066,166 @@ msgstr[0] "增加{:d}点伤害"
 
 #: Source/items.cpp:4022
 msgid "fires random speed arrows"
-msgstr "发射随机速度箭矢"
+msgstr "发射​随机​速度​箭矢"
 
 #: Source/items.cpp:4025
 msgid "unusual item damage"
-msgstr "异常的物品损坏"
+msgstr "异常​的​物品​损坏"
 
 #: Source/items.cpp:4028
 msgid "altered durability"
-msgstr "改变耐久度"
+msgstr "改变​耐​久度"
 
 #: Source/items.cpp:4031
 msgid "Faster attack swing"
-msgstr "更快的挥动"
+msgstr "更​快​的​挥动"
 
 #: Source/items.cpp:4034
 msgid "one handed sword"
-msgstr "单手剑"
+msgstr "单手​剑"
 
 #: Source/items.cpp:4037
 msgid "constantly lose hit points"
-msgstr "持续失去生命值"
+msgstr "持续​失去​生命值"
 
 #: Source/items.cpp:4040
 msgid "life stealing"
-msgstr "生命偷取"
+msgstr "生命​偷取"
 
 #: Source/items.cpp:4043
 msgid "no strength requirement"
-msgstr "无力量要求"
+msgstr "无​力量​要求"
 
 #: Source/items.cpp:4046
 msgid "see with infravision"
-msgstr "夜视能力"
+msgstr "夜视​能力"
 
 #: Source/items.cpp:4053
 msgid "lightning damage: {:d}"
-msgstr "闪电伤害: {:d}"
+msgstr "闪电​伤害​:​ {:d}"
 
 #: Source/items.cpp:4055
 msgid "lightning damage: {:d}-{:d}"
-msgstr "闪电伤害: {:d}-{:d}"
+msgstr "闪电​伤害​:​ {:d}-{:d}"
 
 #: Source/items.cpp:4058
 msgid "charged bolts on hits"
-msgstr "击中时触发电荷弹"
+msgstr "击​中时​触发电​荷弹"
 
 #: Source/items.cpp:4067
 msgid "occasional triple damage"
-msgstr "有概率造成三倍伤害"
+msgstr "有​概率​造成​三​倍​伤害"
 
 #: Source/items.cpp:4070
 #, no-c-format
 msgid "decaying {:+d}% damage"
-msgstr "减少{:+d}%伤害"
+msgstr "减少​{:+d}%​伤害"
 
 #: Source/items.cpp:4073
 msgid "2x dmg to monst, 1x to you"
-msgstr "2x 对怪物伤害，1x 反噬自身"
+msgstr "2x ​对​怪物​伤害​，​1x ​反噬​自身"
 
 #: Source/items.cpp:4076
 #, no-c-format
 msgid "Random 0 - 500% damage"
-msgstr "随机0-500%伤害"
+msgstr "随机​0-500​%​伤害"
 
 #: Source/items.cpp:4079
 #, no-c-format
 msgid "low dur, {:+d}% damage"
-msgstr "低耐久，{:+d}% d伤害"
+msgstr "低​耐久​，​{:+d}%​ d​伤害"
 
 #: Source/items.cpp:4085
 msgid "extra AC vs demons"
-msgstr "对抗恶魔的额外精准"
+msgstr "对抗​恶魔​的​额外​精准"
 
 #: Source/items.cpp:4088
 msgid "extra AC vs undead"
-msgstr "对抗亡灵的额外精准"
+msgstr "对抗​亡灵​的​额外​精准"
 
 #: Source/items.cpp:4091
 #, no-c-format
 msgid "50% Mana moved to Health"
-msgstr "50%法力值转换至生命值"
+msgstr "50​%​法​力值​转换​至​生命​值"
 
 #: Source/items.cpp:4094
 #, no-c-format
 msgid "40% Health moved to Mana"
-msgstr "40%的生命值转换至法力值"
+msgstr "40​%​的​生命值​转换​至​法力值"
 
 #: Source/items.cpp:4097
 msgid "Another ability (NW)"
-msgstr "另一种能力(NW)"
+msgstr "另​一​种​能力​(​NW)"
 
 #: Source/items.cpp:4134 Source/items.cpp:4181
 msgid "damage: {:d}  Indestructible"
-msgstr "伤害: {:d}  坚不可摧"
+msgstr "伤害​:​ {:d}  ​坚不​可​摧"
 
 #. TRANSLATORS: Dur: is durability
 #: Source/items.cpp:4136 Source/items.cpp:4183
 msgid "damage: {:d}  Dur: {:d}/{:d}"
-msgstr "伤害: {:d} 耐久: {:d}/{:d}"
+msgstr "伤害​:​ {:d} ​耐久​:​ {:d}/{:d}"
 
 #: Source/items.cpp:4139 Source/items.cpp:4186
 msgid "damage: {:d}-{:d}  Indestructible"
-msgstr "伤害: {:d}-{:d} 坚不可摧"
+msgstr "伤害​:​ {:d}-{:d} ​坚不​可​摧"
 
 #. TRANSLATORS: Dur: is durability
 #: Source/items.cpp:4141 Source/items.cpp:4188
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
-msgstr "伤害: {:d}-{:d} 耐久: {:d}/{:d}"
+msgstr "伤害​:​ {:d}-{:d} ​耐久​:​ {:d}/{:d}"
 
 #: Source/items.cpp:4147 Source/items.cpp:4200
 msgid "armor: {:d}  Indestructible"
-msgstr "护甲: {:d} 坚不可摧"
+msgstr "护​甲​:​ {:d} ​坚不​可​摧"
 
 #. TRANSLATORS: Dur: is durability
 #: Source/items.cpp:4149 Source/items.cpp:4202
 msgid "armor: {:d}  Dur: {:d}/{:d}"
-msgstr "护甲: {:d} 耐久: {:d}/{:d}"
+msgstr "护​甲​:​ {:d} ​耐久​:​ {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
 #: Source/items.cpp:4154
 msgid "dam: {:d}  Dur: {:d}/{:d}"
-msgstr "伤害: {:d} 耐久: {:d}/{:d}"
+msgstr "伤害​:​ {:d} ​耐久​:​ {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
 #: Source/items.cpp:4156
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
-msgstr "伤害: {:d}-{:d} 耐久: {:d}/{:d}"
+msgstr "伤害​:​ {:d}-{:d} ​耐久​:​ {:d}/{:d}"
 
 #: Source/items.cpp:4157 Source/items.cpp:4192 Source/items.cpp:4207
 #: Source/stores.cpp:184
 msgid "Charges: {:d}/{:d}"
-msgstr "充能: {:d}/{:d}"
+msgstr "充能​:​ {:d}/{:d}"
 
 #: Source/items.cpp:4169
 msgid "unique item"
-msgstr "独特装备"
+msgstr "独特​装备"
 
 #: Source/items.cpp:4196 Source/items.cpp:4205 Source/items.cpp:4212
 msgid "Not Identified"
-msgstr "未鉴定"
+msgstr "未​鉴定"
 
 #: Source/loadsave.cpp:1683 Source/loadsave.cpp:2149
 msgid "Unable to open save file archive"
-msgstr "无法打开保存文件存档"
+msgstr "无法​打开​保存​文件​存档"
 
 #: Source/loadsave.cpp:1686
 msgid "Invalid save file"
-msgstr "无效的保存文件"
+msgstr "无效​的​保存​文件"
 
 #: Source/loadsave.cpp:1717
 msgid "Player is on a Hellfire only level"
-msgstr "玩家处于地狱火特有地图"
+msgstr "玩​家​处于​地狱火​特有​地图"
 
 #: Source/loadsave.cpp:1912
 msgid "Invalid game state"
-msgstr "无效的游戏状态"
+msgstr "无效​的​游戏​状态"
 
 #: Source/menu.cpp:154
 msgid "Unable to display mainmenu"
-msgstr "无法显示主菜单"
+msgstr "无法​显示​主菜​单"
 
 #. TRANSLATORS:  Error Message when a Shareware User clicks on "Replay Intro" in the Main Menu
 #: Source/menu.cpp:179
@@ -4233,8 +4233,8 @@ msgid ""
 "The Diablo introduction cinematic is only available in the full retail "
 "version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
 msgstr ""
-"暗黑破坏神介绍影片只在完整的零售版暗黑破坏神提供。请前往 https://www.gog.com/"
-"game/diablo 购买。"
+"暗​黑​破坏​神​介绍​影片​只​在​完整​的​零售版​暗​黑​破坏​神​提供​。​请​前往​ https://www.gog"
+".com/game/diablo ​购买​。"
 
 #. TRANSLATORS: Monster Block start
 #. MT_NZOMBIE
@@ -4256,7 +4256,7 @@ msgstr "腐尸"
 #: Source/monstdat.cpp:23
 msgctxt "monster"
 msgid "Black Death"
-msgstr "黑死病躯"
+msgstr "黑​死​病躯"
 
 #: Source/monstdat.cpp:24 Source/monstdat.cpp:32
 msgctxt "monster"
@@ -4266,7 +4266,7 @@ msgstr "堕落者"
 #: Source/monstdat.cpp:25 Source/monstdat.cpp:33
 msgctxt "monster"
 msgid "Carver"
-msgstr "剁肉魔"
+msgstr "剁​肉​魔"
 
 #: Source/monstdat.cpp:26 Source/monstdat.cpp:34
 msgctxt "monster"
@@ -4276,42 +4276,42 @@ msgstr "魔皮"
 #: Source/monstdat.cpp:27 Source/monstdat.cpp:35
 msgctxt "monster"
 msgid "Dark One"
-msgstr "暗魔"
+msgstr "暗​魔"
 
 #: Source/monstdat.cpp:28 Source/monstdat.cpp:40
 msgctxt "monster"
 msgid "Skeleton"
-msgstr "骷髅"
+msgstr "骷​髅"
 
 #: Source/monstdat.cpp:29
 msgctxt "monster"
 msgid "Corpse Axe"
-msgstr "尸骸斧兵"
+msgstr "尸骸​斧兵"
 
 #: Source/monstdat.cpp:30 Source/monstdat.cpp:42
 msgctxt "monster"
 msgid "Burning Dead"
-msgstr "烈焰亡灵"
+msgstr "烈​焰​亡灵"
 
 #: Source/monstdat.cpp:31 Source/monstdat.cpp:43
 msgctxt "monster"
 msgid "Horror"
-msgstr "骇魔"
+msgstr "骇​魔"
 
 #: Source/monstdat.cpp:36
 msgctxt "monster"
 msgid "Scavenger"
-msgstr "食腐魔"
+msgstr "食​腐魔"
 
 #: Source/monstdat.cpp:37
 msgctxt "monster"
 msgid "Plague Eater"
-msgstr "食疫魔"
+msgstr "食疫​魔"
 
 #: Source/monstdat.cpp:38
 msgctxt "monster"
 msgid "Shadow Beast"
-msgstr "暗影兽"
+msgstr "暗​影兽"
 
 #: Source/monstdat.cpp:39
 msgctxt "monster"
@@ -4321,52 +4321,52 @@ msgstr "噬骨魔"
 #: Source/monstdat.cpp:41
 msgctxt "monster"
 msgid "Corpse Bow"
-msgstr "尸骸弓兵"
+msgstr "尸骸​弓兵"
 
 #: Source/monstdat.cpp:44
 msgctxt "monster"
 msgid "Skeleton Captain"
-msgstr "骷髅队长"
+msgstr "骷​髅​队长"
 
 #: Source/monstdat.cpp:45
 msgctxt "monster"
 msgid "Corpse Captain"
-msgstr "尸骸队长"
+msgstr "尸骸​队长"
 
 #: Source/monstdat.cpp:46
 msgctxt "monster"
 msgid "Burning Dead Captain"
-msgstr "烈焰亡灵队长"
+msgstr "烈​焰​亡灵​队长"
 
 #: Source/monstdat.cpp:47
 msgctxt "monster"
 msgid "Horror Captain"
-msgstr "骇魔队长"
+msgstr "骇魔队​长"
 
 #: Source/monstdat.cpp:48
 msgctxt "monster"
 msgid "Invisible Lord"
-msgstr "无形领主"
+msgstr "无形​领主"
 
 #: Source/monstdat.cpp:49
 msgctxt "monster"
 msgid "Hidden"
-msgstr "潜行魔"
+msgstr "潜行​魔"
 
 #: Source/monstdat.cpp:50
 msgctxt "monster"
 msgid "Stalker"
-msgstr "追踪魔"
+msgstr "追踪​魔"
 
 #: Source/monstdat.cpp:51
 msgctxt "monster"
 msgid "Unseen"
-msgstr "隐形魔"
+msgstr "隐形​魔"
 
 #: Source/monstdat.cpp:52
 msgctxt "monster"
 msgid "Illusion Weaver"
-msgstr "幻像编织者"
+msgstr "幻像​编织者"
 
 #: Source/monstdat.cpp:53
 msgctxt "monster"
@@ -4376,7 +4376,7 @@ msgstr "萨特领主"
 #: Source/monstdat.cpp:54 Source/monstdat.cpp:62
 msgctxt "monster"
 msgid "Flesh Clan"
-msgstr "血肉氏族"
+msgstr "血​肉氏族"
 
 #: Source/monstdat.cpp:55 Source/monstdat.cpp:63
 msgctxt "monster"
@@ -4391,7 +4391,7 @@ msgstr "火焰氏族"
 #: Source/monstdat.cpp:57 Source/monstdat.cpp:65
 msgctxt "monster"
 msgid "Night Clan"
-msgstr "暗夜氏族"
+msgstr "暗​夜氏族"
 
 #: Source/monstdat.cpp:58
 msgctxt "monster"
@@ -4416,27 +4416,27 @@ msgstr "雷翼"
 #: Source/monstdat.cpp:66
 msgctxt "monster"
 msgid "Acid Beast"
-msgstr "酸液兽"
+msgstr "酸​液​兽"
 
 #: Source/monstdat.cpp:67
 msgctxt "monster"
 msgid "Poison Spitter"
-msgstr "喷毒兽"
+msgstr "喷毒​兽"
 
 #: Source/monstdat.cpp:68
 msgctxt "monster"
 msgid "Pit Beast"
-msgstr "深渊兽"
+msgstr "深​渊兽"
 
 #: Source/monstdat.cpp:69
 msgctxt "monster"
 msgid "Lava Maw"
-msgstr "岩浆喉"
+msgstr "岩​浆喉"
 
 #: Source/monstdat.cpp:70 Source/monstdat.cpp:474
 msgctxt "monster"
 msgid "Skeleton King"
-msgstr "骷髅王"
+msgstr "骷​髅​王"
 
 #: Source/monstdat.cpp:71 Source/monstdat.cpp:482
 msgctxt "monster"
@@ -4451,17 +4451,17 @@ msgstr "领主"
 #: Source/monstdat.cpp:73
 msgctxt "monster"
 msgid "Mud Man"
-msgstr "污泥魔"
+msgstr "污泥​魔"
 
 #: Source/monstdat.cpp:74
 msgctxt "monster"
 msgid "Toad Demon"
-msgstr "蟾魔"
+msgstr "蟾​魔"
 
 #: Source/monstdat.cpp:75
 msgctxt "monster"
 msgid "Flayed One"
-msgstr "剥皮魔"
+msgstr "剥​皮魔"
 
 #: Source/monstdat.cpp:76
 #, fuzzy
@@ -4474,7 +4474,7 @@ msgstr "游龙"
 #| msgid "Cave Slug"
 msgctxt "monster"
 msgid "Cave Slug"
-msgstr "洞穴蛞蝓"
+msgstr "洞​穴蛞蝓"
 
 #: Source/monstdat.cpp:78
 #, fuzzy
@@ -4487,68 +4487,68 @@ msgstr "邪恶游龙"
 #| msgid "Devourer"
 msgctxt "monster"
 msgid "Devourer"
-msgstr "吞食虫"
+msgstr "吞食​虫"
 
 #: Source/monstdat.cpp:80
 msgctxt "monster"
 msgid "Magma Demon"
-msgstr "岩浆魔"
+msgstr "岩浆​魔"
 
 #: Source/monstdat.cpp:81
 msgctxt "monster"
 msgid "Blood Stone"
-msgstr "鲜血石"
+msgstr "鲜​血石"
 
 #: Source/monstdat.cpp:82
 msgctxt "monster"
 msgid "Hell Stone"
-msgstr "地狱石"
+msgstr "地​狱石"
 
 #: Source/monstdat.cpp:83
 msgctxt "monster"
 msgid "Lava Lord"
-msgstr "岩浆领主"
+msgstr "岩浆​领主"
 
 #: Source/monstdat.cpp:84
 msgctxt "monster"
 msgid "Horned Demon"
-msgstr "长角魔"
+msgstr "长​角​魔"
 
 #: Source/monstdat.cpp:85
 msgctxt "monster"
 msgid "Mud Runner"
-msgstr "污泥奔行魔"
+msgstr "污泥​奔行​魔"
 
 #: Source/monstdat.cpp:86
 msgctxt "monster"
 msgid "Frost Charger"
-msgstr "冰霜冲锋魔"
+msgstr "冰霜​冲锋​魔"
 
 #: Source/monstdat.cpp:87
 msgctxt "monster"
 msgid "Obsidian Lord"
-msgstr "黑曜石领主"
+msgstr "黑​曜​石领主"
 
 #: Source/monstdat.cpp:88
 msgctxt "monster"
 msgid "oldboned"
-msgstr "老骨头"
+msgstr "老​骨头"
 
 #: Source/monstdat.cpp:89
 #, fuzzy
 msgctxt "monster"
 msgid "Red Death"
-msgstr "红色死神"
+msgstr "红色​死神"
 
 #: Source/monstdat.cpp:90
 msgctxt "monster"
 msgid "Litch Demon"
-msgstr "尸妖恶魔"
+msgstr "尸妖​恶魔"
 
 #: Source/monstdat.cpp:91
 msgctxt "monster"
 msgid "Undead Balrog"
-msgstr "不死炎魔"
+msgstr "不​死炎​魔"
 
 #: Source/monstdat.cpp:92
 msgctxt "monster"
@@ -4558,57 +4558,57 @@ msgstr "焚化者"
 #: Source/monstdat.cpp:93
 msgctxt "monster"
 msgid "Flame Lord"
-msgstr "火焰领主"
+msgstr "火焰​领主"
 
 #: Source/monstdat.cpp:94
 msgctxt "monster"
 msgid "Doom Fire"
-msgstr "末日火焰"
+msgstr "末​日​火焰"
 
 #: Source/monstdat.cpp:95
 msgctxt "monster"
 msgid "Hell Burner"
-msgstr "地狱燃烧者"
+msgstr "地狱​燃烧者"
 
 #: Source/monstdat.cpp:96
 msgctxt "monster"
 msgid "Red Storm"
-msgstr "红色风暴"
+msgstr "红色​风暴"
 
 #: Source/monstdat.cpp:97
 msgctxt "monster"
 msgid "Storm Rider"
-msgstr "风暴骑手"
+msgstr "风暴​骑手"
 
 #: Source/monstdat.cpp:98
 msgctxt "monster"
 msgid "Storm Lord"
-msgstr "风暴领主"
+msgstr "风暴​领主"
 
 #: Source/monstdat.cpp:99
 msgctxt "monster"
 msgid "Maelstrom"
-msgstr "漩涡魔"
+msgstr "漩涡​魔"
 
 #: Source/monstdat.cpp:100
 msgctxt "monster"
 msgid "Devil Kin Brute"
-msgstr "魔族凶兽"
+msgstr "魔族​凶兽"
 
 #: Source/monstdat.cpp:101
 msgctxt "monster"
 msgid "Winged-Demon"
-msgstr "翼魔"
+msgstr "翼​魔"
 
 #: Source/monstdat.cpp:102
 msgctxt "monster"
 msgid "Gargoyle"
-msgstr "石像鬼"
+msgstr "石​像​鬼"
 
 #: Source/monstdat.cpp:103
 msgctxt "monster"
 msgid "Blood Claw"
-msgstr "血爪"
+msgstr "血​爪"
 
 #: Source/monstdat.cpp:104
 msgctxt "monster"
@@ -4628,95 +4628,95 @@ msgstr "守护者"
 #: Source/monstdat.cpp:107
 msgctxt "monster"
 msgid "Vortex Lord"
-msgstr "漩涡王"
+msgstr "漩涡​王"
 
 #: Source/monstdat.cpp:108
 msgctxt "monster"
 msgid "Balrog"
-msgstr "炎魔"
+msgstr "炎​魔"
 
 #: Source/monstdat.cpp:109
 msgctxt "monster"
 msgid "Cave Viper"
-msgstr "洞穴虺蛇"
+msgstr "洞​穴虺​蛇"
 
 #: Source/monstdat.cpp:110
 msgctxt "monster"
 msgid "Fire Drake"
-msgstr "火焰蛟蛇"
+msgstr "火焰​蛟​蛇"
 
 #: Source/monstdat.cpp:111
 msgctxt "monster"
 msgid "Gold Viper"
-msgstr "金色虺蛇"
+msgstr "金色​虺​蛇"
 
 #: Source/monstdat.cpp:112
 msgctxt "monster"
 msgid "Azure Drake"
-msgstr "碧蓝蛟蛇"
+msgstr "碧蓝蛟​蛇"
 
 #: Source/monstdat.cpp:113
 msgctxt "monster"
 msgid "Black Knight"
-msgstr "黑骑士"
+msgstr "黑​骑士"
 
 #: Source/monstdat.cpp:114
 msgctxt "monster"
 msgid "Doom Guard"
-msgstr "末日守卫"
+msgstr "末​日守卫"
 
 #: Source/monstdat.cpp:115
 msgctxt "monster"
 msgid "Steel Lord"
-msgstr "钢铁领主"
+msgstr "钢铁​领主"
 
 #: Source/monstdat.cpp:116
 msgctxt "monster"
 msgid "Blood Knight"
-msgstr "血骑士"
+msgstr "血​骑士"
 
 #: Source/monstdat.cpp:117
 #, fuzzy
 msgctxt "monster"
 msgid "The Shredded"
-msgstr "撕裂者"
+msgstr "撕​裂者"
 
 #: Source/monstdat.cpp:118
 msgctxt "monster"
 msgid "Hollow One"
-msgstr "空壳尸魔"
+msgstr "空壳​尸魔"
 
 #: Source/monstdat.cpp:119
 msgctxt "monster"
 msgid "Pain Master"
-msgstr "痛楚大师"
+msgstr "痛楚​大师"
 
 #: Source/monstdat.cpp:120
 #, fuzzy
 #| msgid "Reality Weaver"
 msgctxt "monster"
 msgid "Reality Weaver"
-msgstr "现实编织者"
+msgstr "现实​编织者"
 
 #: Source/monstdat.cpp:121
 msgctxt "monster"
 msgid "Succubus"
-msgstr "魅魔"
+msgstr "魅​魔"
 
 #: Source/monstdat.cpp:122
 msgctxt "monster"
 msgid "Snow Witch"
-msgstr "冰雪妖女"
+msgstr "冰雪妖​女"
 
 #: Source/monstdat.cpp:123
 msgctxt "monster"
 msgid "Hell Spawn"
-msgstr "地狱妖女"
+msgstr "地​狱妖​女"
 
 #: Source/monstdat.cpp:124
 msgctxt "monster"
 msgid "Soul Burner"
-msgstr "燃魂妖女"
+msgstr "燃魂妖​女"
 
 #: Source/monstdat.cpp:125
 msgctxt "monster"
@@ -4731,7 +4731,7 @@ msgstr "执法官"
 #: Source/monstdat.cpp:127
 msgctxt "monster"
 msgid "Cabalist"
-msgstr "秘法师"
+msgstr "秘​法师"
 
 #: Source/monstdat.cpp:128
 msgctxt "monster"
@@ -4746,12 +4746,12 @@ msgstr "魔像"
 #: Source/monstdat.cpp:130
 msgctxt "monster"
 msgid "The Dark Lord"
-msgstr "黑暗之王"
+msgstr "黑暗​之​王"
 
 #: Source/monstdat.cpp:131
 msgctxt "monster"
 msgid "The Arch-Litch Malignus"
-msgstr "高阶巫妖马利葛奴斯"
+msgstr "高​阶​巫妖马利葛奴斯"
 
 #: Source/monstdat.cpp:132
 msgctxt "monster"
@@ -4761,33 +4761,33 @@ msgstr "地狱猪"
 #: Source/monstdat.cpp:133
 msgctxt "monster"
 msgid "Stinger"
-msgstr "钉刺者"
+msgstr "钉​刺者"
 
 #: Source/monstdat.cpp:134
 #, fuzzy
 #| msgid "Psychorb"
 msgctxt "monster"
 msgid "Psychorb"
-msgstr "精神失控者"
+msgstr "精神​失控者"
 
 #: Source/monstdat.cpp:135
 #, fuzzy
 #| msgid "Arachnon"
 msgctxt "monster"
 msgid "Arachnon"
-msgstr "蛛网魔"
+msgstr "蛛​网​魔"
 
 #: Source/monstdat.cpp:136
 #, fuzzy
 #| msgid "Felltwin"
 msgctxt "monster"
 msgid "Felltwin"
-msgstr "孪生者"
+msgstr "孪​生者"
 
 #: Source/monstdat.cpp:137
 msgctxt "monster"
 msgid "Hork Spawn"
-msgstr "腐尸诞生者"
+msgstr "腐尸​诞生者"
 
 #: Source/monstdat.cpp:138
 #, fuzzy
@@ -4801,24 +4801,24 @@ msgstr "毒尾"
 #| msgid "Necromorb"
 msgctxt "monster"
 msgid "Necromorb"
-msgstr "死尸"
+msgstr "死​尸"
 
 #: Source/monstdat.cpp:140
 msgctxt "monster"
 msgid "Spider Lord"
-msgstr "蜘蛛领主"
+msgstr "蜘蛛​领主"
 
 #: Source/monstdat.cpp:141
 #, fuzzy
 msgctxt "monster"
 msgid "Lashworm"
-msgstr "鞭状蠕虫"
+msgstr "鞭状蠕​虫"
 
 #: Source/monstdat.cpp:142
 #, fuzzy
 msgctxt "monster"
 msgid "Torchant"
-msgstr "火蚂蚁"
+msgstr "火​蚂蚁"
 
 #: Source/monstdat.cpp:143 Source/monstdat.cpp:483
 msgctxt "monster"
@@ -4828,27 +4828,27 @@ msgstr "腐尸恶魔"
 #: Source/monstdat.cpp:144
 msgctxt "monster"
 msgid "Hell Bug"
-msgstr "地狱恶虫"
+msgstr "地​狱恶​虫"
 
 #: Source/monstdat.cpp:145
 msgctxt "monster"
 msgid "Gravedigger"
-msgstr "掘墓者"
+msgstr "掘​墓者"
 
 #: Source/monstdat.cpp:146
 msgctxt "monster"
 msgid "Tomb Rat"
-msgstr "墓穴蝙蝠"
+msgstr "墓穴​蝙蝠"
 
 #: Source/monstdat.cpp:147
 msgctxt "monster"
 msgid "Firebat"
-msgstr "火焰蝙"
+msgstr "火焰​蝙"
 
 #: Source/monstdat.cpp:148
 msgctxt "monster"
 msgid "Skullwing"
-msgstr "头骨之翼"
+msgstr "头骨​之翼"
 
 #: Source/monstdat.cpp:149
 msgctxt "monster"
@@ -4858,34 +4858,34 @@ msgstr "巫妖"
 #: Source/monstdat.cpp:150
 msgctxt "monster"
 msgid "Crypt Demon"
-msgstr "地穴恶魔"
+msgstr "地​穴恶魔"
 
 #: Source/monstdat.cpp:151
 msgctxt "monster"
 msgid "Hellbat"
-msgstr "地狱蝙蝠"
+msgstr "地狱蝙​蝠"
 
 #: Source/monstdat.cpp:152
 msgctxt "monster"
 msgid "Bone Demon"
-msgstr "白骨恶魔"
+msgstr "白​骨恶魔"
 
 #: Source/monstdat.cpp:153
 msgctxt "monster"
 msgid "Arch Lich"
-msgstr "高阶巫妖"
+msgstr "高​阶​巫妖"
 
 #: Source/monstdat.cpp:154
 #, fuzzy
 #| msgid "Biclops"
 msgctxt "monster"
 msgid "Biclops"
-msgstr "双钩"
+msgstr "双​钩"
 
 #: Source/monstdat.cpp:155
 msgctxt "monster"
 msgid "Flesh Thing"
-msgstr "血肉造物"
+msgstr "血​肉​造物"
 
 #: Source/monstdat.cpp:156
 msgctxt "monster"
@@ -4903,12 +4903,12 @@ msgstr "纳·库尔"
 #: Source/monstdat.cpp:473
 msgctxt "monster"
 msgid "Gharbad the Weak"
-msgstr "虚弱的贾巴德"
+msgstr "虚弱​的​贾巴德"
 
 #: Source/monstdat.cpp:475
 msgctxt "monster"
 msgid "Zhar the Mad"
-msgstr "疯狂的扎尔"
+msgstr "疯狂​的​扎尔"
 
 #: Source/monstdat.cpp:476
 msgctxt "monster"
@@ -4918,12 +4918,12 @@ msgstr "鼻屎"
 #: Source/monstdat.cpp:477
 msgctxt "monster"
 msgid "Arch-Bishop Lazarus"
-msgstr "大主教拉扎鲁斯"
+msgstr "大​主教​拉扎鲁斯"
 
 #: Source/monstdat.cpp:478
 msgctxt "monster"
 msgid "Red Vex"
-msgstr "红色暴戾"
+msgstr "红色​暴戾"
 
 #: Source/monstdat.cpp:479
 msgctxt "monster"
@@ -4933,12 +4933,12 @@ msgstr "黑玉"
 #: Source/monstdat.cpp:480
 msgctxt "monster"
 msgid "Lachdanan"
-msgstr "拉齐达南"
+msgstr "拉齐达​南"
 
 #: Source/monstdat.cpp:481
 msgctxt "monster"
 msgid "Warlord of Blood"
-msgstr "鲜血战神"
+msgstr "鲜血​战神"
 
 #: Source/monstdat.cpp:484
 msgctxt "monster"
@@ -4948,20 +4948,20 @@ msgstr "污染者"
 #: Source/monstdat.cpp:486
 msgctxt "monster"
 msgid "Bonehead Keenaxe"
-msgstr "骷髅头基纳克斯"
+msgstr "骷​髅头​基纳克斯"
 
 #: Source/monstdat.cpp:487
 #, fuzzy
 msgctxt "monster"
 msgid "Bladeskin the Slasher"
-msgstr "刀刃皮肤·鞭笞者"
+msgstr "刀​刃皮肤·鞭​笞者"
 
 #: Source/monstdat.cpp:488
 #, fuzzy
 #| msgid "Soulpus"
 msgctxt "monster"
 msgid "Soulpus"
-msgstr "放逐之魂"
+msgstr "放逐​之魂"
 
 #: Source/monstdat.cpp:489
 msgctxt "monster"
@@ -4971,34 +4971,34 @@ msgstr "普克拉特·肮脏者"
 #: Source/monstdat.cpp:490
 msgctxt "monster"
 msgid "Boneripper"
-msgstr "剥骨者"
+msgstr "剥​骨者"
 
 #: Source/monstdat.cpp:491
 msgctxt "monster"
 msgid "Rotfeast the Hungry"
-msgstr "饥饿的食腐狂"
+msgstr "饥饿​的​食腐狂"
 
 #: Source/monstdat.cpp:492
 #, fuzzy
 msgctxt "monster"
 msgid "Gutshank the Quick"
-msgstr "迅捷的古特申克"
+msgstr "迅捷​的​古特申克"
 
 #: Source/monstdat.cpp:493
 msgctxt "monster"
 msgid "Brokenhead Bangshield"
-msgstr "碎颅·猛盾"
+msgstr "碎​颅​·猛盾"
 
 #: Source/monstdat.cpp:494
 msgctxt "monster"
 msgid "Bongo"
-msgstr "邦戈"
+msgstr "邦​戈"
 
 #: Source/monstdat.cpp:495
 #, fuzzy
 msgctxt "monster"
 msgid "Rotcarnage"
-msgstr "腐肉搅碎者"
+msgstr "腐肉​搅​碎者"
 
 #: Source/monstdat.cpp:496
 msgctxt "monster"
@@ -5008,12 +5008,12 @@ msgstr "影咬"
 #: Source/monstdat.cpp:497
 msgctxt "monster"
 msgid "Deadeye"
-msgstr "死眼"
+msgstr "死​眼"
 
 #: Source/monstdat.cpp:498
 msgctxt "monster"
 msgid "Madeye the Dead"
-msgstr "疯眼·亡魂"
+msgstr "疯眼​·亡魂"
 
 #: Source/monstdat.cpp:499
 msgctxt "monster"
@@ -5028,28 +5028,28 @@ msgstr "火骷髅"
 #: Source/monstdat.cpp:501
 msgctxt "monster"
 msgid "Warpskull"
-msgstr "扭曲颅骨"
+msgstr "扭曲​颅骨"
 
 #: Source/monstdat.cpp:502
 msgctxt "monster"
 msgid "Goretongue"
-msgstr "血肉舌"
+msgstr "血​肉舌"
 
 #: Source/monstdat.cpp:503
 #, fuzzy
 msgctxt "monster"
 msgid "Pulsecrawler"
-msgstr "脉冲爬行者"
+msgstr "脉​冲​爬行者"
 
 #: Source/monstdat.cpp:504
 msgctxt "monster"
 msgid "Moonbender"
-msgstr "月亮狂欢者"
+msgstr "月亮​狂欢者"
 
 #: Source/monstdat.cpp:505
 msgctxt "monster"
 msgid "Wrathraven"
-msgstr "饥渴怨魂"
+msgstr "饥​渴​怨魂"
 
 #: Source/monstdat.cpp:506
 msgctxt "monster"
@@ -5059,7 +5059,7 @@ msgstr "刺食者"
 #: Source/monstdat.cpp:507
 msgctxt "monster"
 msgid "Blackash the Burning"
-msgstr "燃烧的黑色余烬"
+msgstr "燃烧​的​黑色​余烬"
 
 #: Source/monstdat.cpp:508
 msgctxt "monster"
@@ -5069,17 +5069,17 @@ msgstr "影鸦"
 #: Source/monstdat.cpp:509
 msgctxt "monster"
 msgid "Blightstone the Weak"
-msgstr "虚弱的亮石"
+msgstr "虚弱​的​亮石"
 
 #: Source/monstdat.cpp:510
 msgctxt "monster"
 msgid "Bilefroth the Pit Master"
-msgstr "拜弗洛斯·深渊领主"
+msgstr "拜弗洛斯·深渊​领主"
 
 #: Source/monstdat.cpp:511
 msgctxt "monster"
 msgid "Bloodskin Darkbow"
-msgstr "血皮·暗弓"
+msgstr "血​皮·暗弓"
 
 #: Source/monstdat.cpp:512
 msgctxt "monster"
@@ -5089,12 +5089,12 @@ msgstr "邪翼"
 #: Source/monstdat.cpp:513
 msgctxt "monster"
 msgid "Shadowdrinker"
-msgstr "暗饮者"
+msgstr "暗​饮者"
 
 #: Source/monstdat.cpp:514
 msgctxt "monster"
 msgid "Hazeshifter"
-msgstr "迷雾移形怪"
+msgstr "迷​雾​移形​怪"
 
 #: Source/monstdat.cpp:515
 msgctxt "monster"
@@ -5109,43 +5109,43 @@ msgstr "刨脏"
 #: Source/monstdat.cpp:517
 msgctxt "monster"
 msgid "Deathshade Fleshmaul"
-msgstr "死亡之影·肉锤"
+msgstr "死亡​之​影·肉锤"
 
 #: Source/monstdat.cpp:518
 msgctxt "monster"
 msgid "Warmaggot the Mad"
-msgstr "疯狂的战斗蛆虫"
+msgstr "疯狂​的​战斗蛆​虫"
 
 #: Source/monstdat.cpp:519
 #, fuzzy
 msgctxt "monster"
 msgid "Glasskull the Jagged"
-msgstr "玻璃颅·锯齿"
+msgstr "玻璃​颅​·锯齿"
 
 #: Source/monstdat.cpp:520
 msgctxt "monster"
 msgid "Blightfire"
-msgstr "死疫之火"
+msgstr "死疫​之​火"
 
 #: Source/monstdat.cpp:521
 msgctxt "monster"
 msgid "Nightwing the Cold"
-msgstr "冰之夜翼"
+msgstr "冰​之​夜翼"
 
 #: Source/monstdat.cpp:522
 msgctxt "monster"
 msgid "Gorestone"
-msgstr "血肉石"
+msgstr "血​肉石"
 
 #: Source/monstdat.cpp:523
 msgctxt "monster"
 msgid "Bronzefist Firestone"
-msgstr "青铜拳·火石"
+msgstr "青铜​拳​·火石"
 
 #: Source/monstdat.cpp:524
 msgctxt "monster"
 msgid "Wrathfire the Doomed"
-msgstr "怒火·末日"
+msgstr "怒火​·末日"
 
 #: Source/monstdat.cpp:525
 msgctxt "monster"
@@ -5155,12 +5155,12 @@ msgstr "火伤·凶魔"
 #: Source/monstdat.cpp:526
 msgctxt "monster"
 msgid "Baron Sludge"
-msgstr "污泥男爵"
+msgstr "污泥​男​爵"
 
 #: Source/monstdat.cpp:527
 msgctxt "monster"
 msgid "Blighthorn Steelmace"
-msgstr "病角·钢锤"
+msgstr "病​角·钢锤"
 
 #: Source/monstdat.cpp:528
 msgctxt "monster"
@@ -5170,7 +5170,7 @@ msgstr "疯嚎"
 #: Source/monstdat.cpp:529
 msgctxt "monster"
 msgid "Doomgrin the Rotting"
-msgstr "末日微笑·腐烂者"
+msgstr "末​日微笑·腐烂者"
 
 #: Source/monstdat.cpp:530
 msgctxt "monster"
@@ -5180,7 +5180,7 @@ msgstr "疯燃者"
 #: Source/monstdat.cpp:531
 msgctxt "monster"
 msgid "Bonesaw the Litch"
-msgstr "骨锯·巫妖"
+msgstr "骨锯​·巫妖"
 
 #: Source/monstdat.cpp:532
 msgctxt "monster"
@@ -5190,32 +5190,32 @@ msgstr "断脊"
 #: Source/monstdat.cpp:533
 msgctxt "monster"
 msgid "Devilskull Sharpbone"
-msgstr "鬼颅锐骨"
+msgstr "鬼​颅​锐骨"
 
 #: Source/monstdat.cpp:534
 msgctxt "monster"
 msgid "Brokenstorm"
-msgstr "破碎风暴"
+msgstr "破碎​风暴"
 
 #: Source/monstdat.cpp:535
 msgctxt "monster"
 msgid "Stormbane"
-msgstr "风暴灾星"
+msgstr "风暴​灾​星"
 
 #: Source/monstdat.cpp:536
 msgctxt "monster"
 msgid "Oozedrool"
-msgstr "渗脓"
+msgstr "渗​脓"
 
 #: Source/monstdat.cpp:537
 msgctxt "monster"
 msgid "Goldblight of the Flame"
-msgstr "火之金翼"
+msgstr "火​之​金翼"
 
 #: Source/monstdat.cpp:538
 msgctxt "monster"
 msgid "Blackstorm"
-msgstr "黑色风暴"
+msgstr "黑色​风暴"
 
 #: Source/monstdat.cpp:539
 msgctxt "monster"
@@ -5225,7 +5225,7 @@ msgstr "怒疫"
 #: Source/monstdat.cpp:540
 msgctxt "monster"
 msgid "The Flayer"
-msgstr "扒皮"
+msgstr "扒​皮"
 
 #: Source/monstdat.cpp:541
 msgctxt "monster"
@@ -5236,22 +5236,22 @@ msgstr "蓝角"
 #, fuzzy
 msgctxt "monster"
 msgid "Warpfire Hellspawn"
-msgstr "地狱诞生的扭曲烈焰"
+msgstr "地狱​诞生​的​扭曲​烈​焰"
 
 #: Source/monstdat.cpp:543
 msgctxt "monster"
 msgid "Fangspeir"
-msgstr "蟠蛇牙"
+msgstr "蟠​蛇​牙"
 
 #: Source/monstdat.cpp:544
 msgctxt "monster"
 msgid "Festerskull"
-msgstr "快颅"
+msgstr "快​颅"
 
 #: Source/monstdat.cpp:545
 msgctxt "monster"
 msgid "Lionskull the Bent"
-msgstr "扭曲的狮颅"
+msgstr "扭曲​的​狮颅"
 
 #: Source/monstdat.cpp:546
 msgctxt "monster"
@@ -5266,12 +5266,12 @@ msgstr "邪触"
 #: Source/monstdat.cpp:548
 msgctxt "monster"
 msgid "Viperflame"
-msgstr "毒焰"
+msgstr "毒​焰"
 
 #: Source/monstdat.cpp:549
 msgctxt "monster"
 msgid "Fangskin"
-msgstr "牙皮"
+msgstr "牙​皮"
 
 #: Source/monstdat.cpp:550
 msgctxt "monster"
@@ -5281,42 +5281,42 @@ msgstr "巫火·不洁者"
 #: Source/monstdat.cpp:551
 msgctxt "monster"
 msgid "Blackskull"
-msgstr "黑颅"
+msgstr "黑​颅"
 
 #: Source/monstdat.cpp:552
 msgctxt "monster"
 msgid "Soulslash"
-msgstr "灵魂撕裂者"
+msgstr "灵魂​撕​裂者"
 
 #: Source/monstdat.cpp:553
 msgctxt "monster"
 msgid "Windspawn"
-msgstr "风生"
+msgstr "风​生"
 
 #: Source/monstdat.cpp:554
 msgctxt "monster"
 msgid "Lord of the Pit"
-msgstr "地坑领主"
+msgstr "地​坑领主"
 
 #: Source/monstdat.cpp:555
 msgctxt "monster"
 msgid "Rustweaver"
-msgstr "骨锈编织者"
+msgstr "骨锈​编织者"
 
 #: Source/monstdat.cpp:556
 msgctxt "monster"
 msgid "Howlingire the Shade"
-msgstr "哀嚎的阴魂"
+msgstr "哀嚎​的​阴魂"
 
 #: Source/monstdat.cpp:557
 msgctxt "monster"
 msgid "Doomcloud"
-msgstr "末日阴云"
+msgstr "末​日阴云"
 
 #: Source/monstdat.cpp:558
 msgctxt "monster"
 msgid "Bloodmoon Soulfire"
-msgstr "血月魂火"
+msgstr "血​月​魂火"
 
 #: Source/monstdat.cpp:559
 msgctxt "monster"
@@ -5326,7 +5326,7 @@ msgstr "巫月"
 #: Source/monstdat.cpp:560
 msgctxt "monster"
 msgid "Gorefeast"
-msgstr "血肉盛宴"
+msgstr "血​肉盛宴"
 
 #: Source/monstdat.cpp:561
 msgctxt "monster"
@@ -5336,7 +5336,7 @@ msgstr "格雷沃·屠杀者"
 #: Source/monstdat.cpp:562
 msgctxt "monster"
 msgid "Dreadjudge"
-msgstr "恐惧法官"
+msgstr "恐惧​法官"
 
 #: Source/monstdat.cpp:563
 msgctxt "monster"
@@ -5346,12 +5346,12 @@ msgstr "星眼·女魔"
 #: Source/monstdat.cpp:564
 msgctxt "monster"
 msgid "Steelskull the Hunter"
-msgstr "钢颅·猎杀者"
+msgstr "钢颅·​猎杀者"
 
 #: Source/monstdat.cpp:565
 msgctxt "monster"
 msgid "Sir Gorash"
-msgstr "格拉什爵士"
+msgstr "格拉什​爵士"
 
 #: Source/monstdat.cpp:566
 msgctxt "monster"
@@ -5367,22 +5367,22 @@ msgstr "赞菲尔"
 #: Source/monstdat.cpp:568
 msgctxt "monster"
 msgid "Bloodlust"
-msgstr "嗜血者"
+msgstr "嗜​血​者"
 
 #: Source/monstdat.cpp:569
 msgctxt "monster"
 msgid "Webwidow"
-msgstr "织网黑寡妇"
+msgstr "织网​黑​寡妇"
 
 #: Source/monstdat.cpp:570
 msgctxt "monster"
 msgid "Fleshdancer"
-msgstr "血肉舞者"
+msgstr "血​肉​舞者"
 
 #: Source/monstdat.cpp:571
 msgctxt "monster"
 msgid "Grimspike"
-msgstr "恐惧之钉"
+msgstr "恐惧​之​钉"
 
 #. TRANSLATORS: Unique Monster Block end
 #: Source/monstdat.cpp:573
@@ -5406,23 +5406,23 @@ msgstr "亡灵"
 
 #: Source/monster.cpp:4632
 msgid "Type: {:s}  Kills: {:d}"
-msgstr "类型: {:s} 击杀: {:d}"
+msgstr "类型​:​ {:s} ​击杀​:​ {:d}"
 
 #: Source/monster.cpp:4634
 msgid "Total kills: {:d}"
-msgstr "击杀总数: {:d}"
+msgstr "击杀​总数​:​ {:d}"
 
 #: Source/monster.cpp:4667
 msgid "Hit Points: {:d}-{:d}"
-msgstr "生命值: {:d}-{:d}"
+msgstr "生命​值​:​ {:d}-{:d}"
 
 #: Source/monster.cpp:4673
 msgid "No magic resistance"
-msgstr "没有魔法抗性"
+msgstr "没有​魔法​抗性"
 
 #: Source/monster.cpp:4677
 msgid "Resists: "
-msgstr "抗性: "
+msgstr "抗性​: "
 
 #: Source/monster.cpp:4679 Source/monster.cpp:4690
 msgid "Magic "
@@ -5438,69 +5438,69 @@ msgstr "闪电 "
 
 #: Source/monster.cpp:4688
 msgid "Immune: "
-msgstr "免疫: "
+msgstr "免疫​: "
 
 #: Source/monster.cpp:4706
 msgid "Type: {:s}"
-msgstr "类型: {:s}"
+msgstr "类型​:​ {:s}"
 
 #: Source/monster.cpp:4712 Source/monster.cpp:4719
 msgid "No resistances"
-msgstr "无抗性"
+msgstr "无​抗性"
 
 #: Source/monster.cpp:4714 Source/monster.cpp:4724
 msgid "No Immunities"
-msgstr "无免疫"
+msgstr "无​免疫"
 
 #: Source/monster.cpp:4717
 msgid "Some Magic Resistances"
-msgstr "部分魔法抗性"
+msgstr "部分​魔法​抗性"
 
 #: Source/monster.cpp:4722
 msgid "Some Magic Immunities"
-msgstr "部分魔法免疫"
+msgstr "部分​魔法​免疫"
 
 #: Source/msg.cpp:494
 msgid "Trying to drop a floor item?"
-msgstr "尝试扔掉一些物品?"
+msgstr "尝试​扔​掉​一些​物品​?"
 
 #: Source/msg.cpp:982 Source/msg.cpp:1017 Source/msg.cpp:1048
 #: Source/msg.cpp:1175 Source/msg.cpp:1207 Source/msg.cpp:1239
 #: Source/msg.cpp:1269
 msgid "{:s} has cast an illegal spell."
-msgstr "{:s}施放了非法法术。"
+msgstr "{:s}​施放​了​非法​法术​。"
 
 #: Source/msg.cpp:1655 Source/multi.cpp:805
 msgid "Player '{:s}' (level {:d}) just joined the game"
-msgstr "玩家{:s}(等级{:d})刚加入了游戏"
+msgstr "玩​家​{:s}(​等级​{:d}​)​刚​加入​了​游戏"
 
 #: Source/msg.cpp:1959
 msgid "Waiting for game data..."
-msgstr "正在等待游戏数据……"
+msgstr "正在​等待​游戏​数据​…​…"
 
 #: Source/msg.cpp:1967
 msgid "The game ended"
-msgstr "比赛结束了"
+msgstr "比赛​结束​了"
 
 #: Source/msg.cpp:1973
 msgid "Unable to get level data"
-msgstr "无法获取场景数据"
+msgstr "无法​获取​场景​数据"
 
 #: Source/multi.cpp:195
 msgid "Player '{:s}' just left the game"
-msgstr "玩家{:s}刚刚离开了游戏"
+msgstr "玩​家​{:s}​刚刚​离开​了​游戏"
 
 #: Source/multi.cpp:198
 msgid "Player '{:s}' killed Diablo and left the game!"
-msgstr "玩家{:s}杀死了迪亚波罗并离开了游戏！"
+msgstr "玩​家​{:s}​杀死​了​迪亚波罗​并​离开​了​游戏​！"
 
 #: Source/multi.cpp:202
 msgid "Player '{:s}' dropped due to timeout"
-msgstr "由于超时，玩家{:s}的掉落物被删除"
+msgstr "由于​超时​，​玩​家​{:s}​的​掉落物​被​删除"
 
 #: Source/multi.cpp:807
 msgid "Player '{:s}' (level {:d}) is already in the game"
-msgstr "玩家{:s}(等级{:d})已经在游戏中"
+msgstr "玩​家​{:s}(​等级​{:d})​已经​在​游戏​中"
 
 #. TRANSLATORS: Shrine Name Block
 #: Source/objects.cpp:104
@@ -5525,7 +5525,7 @@ msgstr "岩石"
 
 #: Source/objects.cpp:110
 msgid "Religious"
-msgstr "教法"
+msgstr "教​法"
 
 #: Source/objects.cpp:111
 msgid "Enchanted"
@@ -5537,7 +5537,7 @@ msgstr "奇幻"
 
 #: Source/objects.cpp:113
 msgid "Fascinating"
-msgstr "炫目"
+msgstr "炫​目"
 
 #: Source/objects.cpp:114
 msgid "Cryptic"
@@ -5545,7 +5545,7 @@ msgstr "奥秘"
 
 #: Source/objects.cpp:116
 msgid "Eldritch"
-msgstr "奇异"
+msgstr "奇​异"
 
 #: Source/objects.cpp:117
 msgid "Eerie"
@@ -5581,7 +5581,7 @@ msgstr "静谧"
 
 #: Source/objects.cpp:126
 msgid "Secluded"
-msgstr "隔世"
+msgstr "隔​世"
 
 #: Source/objects.cpp:127
 msgid "Ornate"
@@ -5601,7 +5601,7 @@ msgstr "油腻"
 
 #: Source/objects.cpp:131
 msgid "Glowing"
-msgstr "辉光"
+msgstr "辉​光"
 
 #: Source/objects.cpp:132
 msgid "Mendicant's"
@@ -5631,102 +5631,102 @@ msgstr "浑浊"
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:268
 msgid "The Great Conflict"
-msgstr "大分歧"
+msgstr "大​分歧"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:269
 msgid "The Wages of Sin are War"
-msgstr "原罪的代价即是战争"
+msgstr "原罪​的​代价​即​是​战争"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:270
 msgid "The Tale of the Horadrim"
-msgstr "赫拉迪姆的故事"
+msgstr "赫拉迪姆​的​故事"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:271
 msgid "The Dark Exile"
-msgstr "黑暗的流放"
+msgstr "黑暗​的​流放"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:272
 msgid "The Sin War"
-msgstr "原罪之战"
+msgstr "原罪​之​战"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:273
 msgid "The Binding of the Three"
-msgstr "三位一体"
+msgstr "三​位​一体"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:274
 msgid "The Realms Beyond"
-msgstr "超越的王国"
+msgstr "超越​的​王国"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:275
 msgid "Tale of the Three"
-msgstr "三部曲"
+msgstr "三​部​曲"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:276
 msgid "The Black King"
-msgstr "黑色国王"
+msgstr "黑色​国王"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:277
 msgid "Journal: The Ensorcellment"
-msgstr "日记: 感悟"
+msgstr "日记​: 感悟"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:278
 msgid "Journal: The Meeting"
-msgstr "日记: 会议"
+msgstr "日记​: 会议"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:279
 msgid "Journal: The Tirade"
-msgstr "日记: 长篇大论"
+msgstr "日记​: 长篇​大论"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:280
 msgid "Journal: His Power Grows"
-msgstr "日记: 他的力量在增长"
+msgstr "日记​: 他​的​力量​在​增长"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:281
 msgid "Journal: NA-KRUL"
-msgstr "日志: 纳·克鲁"
+msgstr "日志​: 纳·克鲁"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:282
 msgid "Journal: The End"
-msgstr "日记: 结束"
+msgstr "日记​: 结束"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:283
 msgid "A Spellbook"
-msgstr "一本法术书"
+msgstr "一​本法术书"
 
 #: Source/objects.cpp:5341
 msgid "Crucified Skeleton"
-msgstr "钉死的骷髅"
+msgstr "钉死​的​骷髅"
 
 #: Source/objects.cpp:5345
 msgid "Lever"
-msgstr "控制杆"
+msgstr "控制​杆"
 
 #: Source/objects.cpp:5354
 msgid "Open Door"
-msgstr "打开的门"
+msgstr "打开​的​门"
 
 #: Source/objects.cpp:5356
 msgid "Closed Door"
-msgstr "关闭的门"
+msgstr "关闭​的​门"
 
 #: Source/objects.cpp:5358
 msgid "Blocked Door"
-msgstr "封死的门"
+msgstr "封死​的​门"
 
 #: Source/objects.cpp:5363
 msgid "Ancient Tome"
@@ -5734,19 +5734,19 @@ msgstr "古籍"
 
 #: Source/objects.cpp:5365
 msgid "Book of Vileness"
-msgstr "卑鄙之书"
+msgstr "卑鄙​之​书"
 
 #: Source/objects.cpp:5370
 msgid "Skull Lever"
-msgstr "骸骨控制杆"
+msgstr "骸​骨​控制杆"
 
 #: Source/objects.cpp:5373
 msgid "Mythical Book"
-msgstr "神秘之书"
+msgstr "神秘​之​书"
 
 #: Source/objects.cpp:5377
 msgid "Small Chest"
-msgstr "小箱子"
+msgstr "小​箱子"
 
 #: Source/objects.cpp:5381
 msgid "Chest"
@@ -5754,11 +5754,11 @@ msgstr "箱子"
 
 #: Source/objects.cpp:5386
 msgid "Large Chest"
-msgstr "大箱子"
+msgstr "大​箱子"
 
 #: Source/objects.cpp:5389
 msgid "Sarcophagus"
-msgstr "石棺"
+msgstr "石​棺"
 
 #: Source/objects.cpp:5392
 msgid "Bookshelf"
@@ -5783,11 +5783,11 @@ msgstr "木桶"
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
 #: Source/objects.cpp:5409
 msgid "{:s} Shrine"
-msgstr "{:s}圣坛"
+msgstr "{:s}​圣坛"
 
 #: Source/objects.cpp:5413
 msgid "Skeleton Tome"
-msgstr "骸骨堆"
+msgstr "骸​骨堆"
 
 #: Source/objects.cpp:5416
 msgid "Library Book"
@@ -5799,35 +5799,35 @@ msgstr "血泉"
 
 #: Source/objects.cpp:5422
 msgid "Decapitated Body"
-msgstr "无头尸"
+msgstr "无​头​尸"
 
 #: Source/objects.cpp:5425
 msgid "Book of the Blind"
-msgstr "目盲之书"
+msgstr "目盲​之​书"
 
 #: Source/objects.cpp:5428
 msgid "Book of Blood"
-msgstr "鲜血之书"
+msgstr "鲜血​之​书"
 
 #: Source/objects.cpp:5431
 msgid "Purifying Spring"
-msgstr "纯净之泉"
+msgstr "纯​净​之泉"
 
 #: Source/objects.cpp:5438 Source/objects.cpp:5462
 msgid "Weapon Rack"
-msgstr "武器架"
+msgstr "武器​架"
 
 #: Source/objects.cpp:5441
 msgid "Goat Shrine"
-msgstr "山羊神殿"
+msgstr "山​羊​神殿"
 
 #: Source/objects.cpp:5444
 msgid "Cauldron"
-msgstr "坩埚"
+msgstr "坩​埚"
 
 #: Source/objects.cpp:5447
 msgid "Murky Pool"
-msgstr "浑浊的水池"
+msgstr "浑浊​的​水池"
 
 #: Source/objects.cpp:5450
 msgid "Fountain of Tears"
@@ -5835,37 +5835,37 @@ msgstr "泪泉"
 
 #: Source/objects.cpp:5453
 msgid "Steel Tome"
-msgstr "钢铁之书"
+msgstr "钢铁​之​书"
 
 #: Source/objects.cpp:5456
 msgid "Pedestal of Blood"
-msgstr "鲜血底座"
+msgstr "鲜血​底​座"
 
 #: Source/objects.cpp:5465
 msgid "Mushroom Patch"
-msgstr "蘑菇碎片"
+msgstr "蘑菇​碎片"
 
 #: Source/objects.cpp:5468
 msgid "Vile Stand"
-msgstr "卑鄙旗帜"
+msgstr "卑鄙​旗帜"
 
 #: Source/objects.cpp:5471
 msgid "Slain Hero"
-msgstr "被杀英雄"
+msgstr "被​杀​英雄"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
 #: Source/objects.cpp:5478
 msgid "Trapped {:s}"
-msgstr "机关{:s}"
+msgstr "机关​{:s}"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
 #: Source/objects.cpp:5484
 msgid "{:s} (disabled)"
-msgstr "{:s}(已禁用)"
+msgstr "{:s}(​已​禁​用​)"
 
 #: Source/panels/charpanel.cpp:110
 msgid "MAX"
-msgstr "最大"
+msgstr "最​大"
 
 #: Source/panels/charpanel.cpp:120
 msgid "Level"
@@ -5877,11 +5877,11 @@ msgstr "经验"
 
 #: Source/panels/charpanel.cpp:124
 msgid "Next level"
-msgstr "下一级"
+msgstr "下​一​级"
 
 #: Source/panels/charpanel.cpp:127
 msgid "None"
-msgstr "没有一个"
+msgstr "没有​一​个"
 
 #: Source/panels/charpanel.cpp:133
 msgid "Base"
@@ -5909,15 +5909,15 @@ msgstr "活力"
 
 #: Source/panels/charpanel.cpp:149
 msgid "Points to distribute"
-msgstr "可分配点数"
+msgstr "可​分配​点​数"
 
 #: Source/panels/charpanel.cpp:159
 msgid "Armor class"
-msgstr "护甲等级"
+msgstr "护甲​等级"
 
 #: Source/panels/charpanel.cpp:161
 msgid "To hit"
-msgstr "命中"
+msgstr "命​中"
 
 #: Source/panels/charpanel.cpp:163
 msgid "Damage"
@@ -5933,15 +5933,15 @@ msgstr "法力"
 
 #: Source/panels/charpanel.cpp:179
 msgid "Resist magic"
-msgstr "魔法抗性"
+msgstr "魔法​抗性"
 
 #: Source/panels/charpanel.cpp:181
 msgid "Resist fire"
-msgstr "火焰抗性"
+msgstr "火焰​抗性"
 
 #: Source/panels/charpanel.cpp:183
 msgid "Resist lightning"
-msgstr "闪电抗性"
+msgstr "闪电​抗性"
 
 #: Source/panels/mainpanel.cpp:62 Source/panels/mainpanel.cpp:106
 #: Source/panels/mainpanel.cpp:108
@@ -5962,11 +5962,11 @@ msgstr "地图"
 
 #: Source/panels/mainpanel.cpp:87
 msgid "menu"
-msgstr "菜单"
+msgstr "菜​单"
 
 #: Source/panels/mainpanel.cpp:88
 msgid "inv"
-msgstr "物品栏"
+msgstr "物品​栏"
 
 #: Source/panels/mainpanel.cpp:89
 msgid "spells"
@@ -5975,42 +5975,42 @@ msgstr "法术"
 #: Source/panels/mainpanel.cpp:101 Source/panels/mainpanel.cpp:103
 #: Source/panels/mainpanel.cpp:105
 msgid "mute"
-msgstr "静音"
+msgstr "静​音"
 
 #: Source/pfile.cpp:260
 msgid "Failed to open player archive for writing."
-msgstr "无法加载玩家数据进行写入。"
+msgstr "无法​加载​玩​家​数据​进行​写入​。"
 
 #: Source/pfile.cpp:392
 msgid "Unable to open archive"
-msgstr "无法打开存档"
+msgstr "无法​打开​存档"
 
 #: Source/pfile.cpp:394
 msgid "Unable to load character"
-msgstr "无法加载角色"
+msgstr "无法​加载​角色"
 
 #: Source/pfile.cpp:419 Source/pfile.cpp:439
 msgid "Unable to read to save file archive"
-msgstr "因无法读取，无法保存存档"
+msgstr "因​无法​读取​，​无法​保存​存档"
 
 #: Source/pfile.cpp:458
 msgid "Unable to write to save file archive"
-msgstr "因无法写入，无法保存存档"
+msgstr "因​无法​写入​，​无法​保存​存档"
 
 #: Source/plrmsg.cpp:88
 msgid "{:s} (lvl {:d}): {:s}"
-msgstr "{:s} (等级 {:d}): {:s}"
+msgstr "{:s} ​(​等级​ {:d}​)​:​ {:s}"
 
 #. TRANSLATORS: Decimal separator
 #: Source/qol/common.cpp:25
 #, c-format
 msgid ",%03d"
-msgstr ",%03d"
+msgstr ",​%​03d"
 
 #: Source/qol/itemlabels.cpp:70
 #, c-format
 msgid "%i gold"
-msgstr "%i 金币"
+msgstr "%i ​金币"
 
 #: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:56
 msgid ""
@@ -6018,29 +6018,29 @@ msgid ""
 "\n"
 "Make sure devilutionx.mpq is in the game folder and that it is up to date."
 msgstr ""
-"无法加载UI资源。\n"
+"无法​加载​UI​资源​。​\n"
 "\n"
-"请检查DevilutionX.mpq是否在游戏目录为最新版本。"
+"​请​检查​DevilutionX.mpq​是否​在​游戏​目录​为​最新​版本​。"
 
 #: Source/qol/xpbar.cpp:125
 msgid "Level {:d}"
-msgstr "等级{:d}"
+msgstr "等级​{:d}"
 
 #: Source/qol/xpbar.cpp:132 Source/qol/xpbar.cpp:143
 msgid "Experience: "
-msgstr "经验: "
+msgstr "经验​: "
 
 #: Source/qol/xpbar.cpp:136
 msgid "Maximum Level"
-msgstr "最大等级"
+msgstr "最​大​等级"
 
 #: Source/qol/xpbar.cpp:147
 msgid "Next Level: "
-msgstr "下一级: "
+msgstr "下​一​级​: "
 
 #: Source/qol/xpbar.cpp:151
 msgid " to Level {:d}"
-msgstr " 到 {:d} 级"
+msgstr " ​到​ {:d} ​级"
 
 #. TRANSLATORS: Quest Name Block
 #: Source/quests.cpp:41
@@ -6049,15 +6049,15 @@ msgstr "魔石"
 
 #: Source/quests.cpp:43
 msgid "Gharbad The Weak"
-msgstr "虚弱的贾巴德"
+msgstr "虚弱​的​贾巴德"
 
 #: Source/quests.cpp:44
 msgid "Zhar the Mad"
-msgstr "疯狂的扎尔"
+msgstr "疯狂​的​扎尔"
 
 #: Source/quests.cpp:45
 msgid "Lachdanan"
-msgstr "拉齐达南"
+msgstr "拉齐达​南"
 
 #: Source/quests.cpp:46
 msgid "Diablo"
@@ -6069,11 +6069,11 @@ msgstr "屠夫"
 
 #: Source/quests.cpp:48
 msgid "Ogden's Sign"
-msgstr "奥格登之征"
+msgstr "奥格登​之​征"
 
 #: Source/quests.cpp:49
 msgid "Halls of the Blind"
-msgstr "目盲之厅"
+msgstr "目盲​之厅"
 
 #: Source/quests.cpp:50
 msgid "Valor"
@@ -6081,15 +6081,15 @@ msgstr "荣耀"
 
 #: Source/quests.cpp:52
 msgid "Warlord of Blood"
-msgstr "鲜血战神"
+msgstr "鲜血​战神"
 
 #: Source/quests.cpp:53
 msgid "The Curse of King Leoric"
-msgstr "国王李奥瑞克的诅咒"
+msgstr "国王​李奥瑞克​的​诅咒"
 
 #: Source/quests.cpp:54 Source/setmaps.cpp:27
 msgid "Poisoned Water Supply"
-msgstr "有毒的水源补给"
+msgstr "有毒​的​水源​补给"
 
 #. TRANSLATORS: Quest Map
 #: Source/quests.cpp:55 Source/quests.cpp:91
@@ -6098,23 +6098,23 @@ msgstr "白骨密室"
 
 #: Source/quests.cpp:56
 msgid "Archbishop Lazarus"
-msgstr "大主教拉扎鲁斯"
+msgstr "大​主教​拉扎鲁斯"
 
 #: Source/quests.cpp:57
 msgid "Grave Matters"
-msgstr "大墓地大问题"
+msgstr "大​墓​地​大​问题"
 
 #: Source/quests.cpp:58
 msgid "Farmer's Orchard"
-msgstr "农夫的果园"
+msgstr "农夫​的​果园"
 
 #: Source/quests.cpp:59
 msgid "Little Girl"
-msgstr "小女孩"
+msgstr "小​女孩"
 
 #: Source/quests.cpp:60
 msgid "Wandering Trader"
-msgstr "旅行商人"
+msgstr "旅行​商人"
 
 #: Source/quests.cpp:61
 msgid "The Defiler"
@@ -6126,17 +6126,17 @@ msgstr "纳·库尔"
 
 #: Source/quests.cpp:63 Source/trigs.cpp:447
 msgid "Cornerstone of the World"
-msgstr "世界的基石"
+msgstr "世界​的​基石"
 
 #. TRANSLATORS: Quest Name Block end
 #: Source/quests.cpp:64
 msgid "The Jersey's Jersey"
-msgstr "小丑的愚弄"
+msgstr "小丑​的​愚弄"
 
 #. TRANSLATORS: Quest Map
 #: Source/quests.cpp:90
 msgid "King Leoric's Tomb"
-msgstr "国王李奥瑞克的陵寝"
+msgstr "国王​李奥瑞克​的​陵寝"
 
 #. TRANSLATORS: Quest Map
 #: Source/quests.cpp:92 Source/setmaps.cpp:26
@@ -6146,21 +6146,21 @@ msgstr "迷宫"
 #. TRANSLATORS: Quest Map
 #: Source/quests.cpp:93
 msgid "A Dark Passage"
-msgstr "黑暗的通道"
+msgstr "黑暗​的​通道"
 
 #. TRANSLATORS: Quest Map
 #: Source/quests.cpp:94
 msgid "Unholy Altar"
-msgstr "邪恶祭坛"
+msgstr "邪恶​祭坛"
 
 #. TRANSLATORS: Used for Quest Portals. {:s} is a Map Name
 #: Source/quests.cpp:450
 msgid "To {:s}"
-msgstr "到{:s}"
+msgstr "到​{:s}"
 
 #: Source/setmaps.cpp:24
 msgid "Skeleton King's Lair"
-msgstr "骷髅王的巢穴"
+msgstr "骷​髅王​的​巢穴"
 
 #: Source/setmaps.cpp:25
 msgid "Chamber of Bone"
@@ -6168,7 +6168,7 @@ msgstr "白骨密室"
 
 #: Source/setmaps.cpp:28
 msgid "Archbishop Lazarus' Lair"
-msgstr "大主教拉扎鲁斯的巢穴"
+msgstr "大​主教​拉扎鲁斯​的​巢穴"
 
 #: Source/spelldat.cpp:16
 msgctxt "spell"
@@ -6178,12 +6178,12 @@ msgstr "火焰弹"
 #: Source/spelldat.cpp:17
 msgctxt "spell"
 msgid "Healing"
-msgstr "治疗术"
+msgstr "治疗​术"
 
 #: Source/spelldat.cpp:18
 msgctxt "spell"
 msgid "Lightning"
-msgstr "闪电术"
+msgstr "闪​电术"
 
 #: Source/spelldat.cpp:19
 msgctxt "spell"
@@ -6198,82 +6198,82 @@ msgstr "鉴定"
 #: Source/spelldat.cpp:21
 msgctxt "spell"
 msgid "Fire Wall"
-msgstr "火焰墙"
+msgstr "火焰​墙"
 
 #: Source/spelldat.cpp:22
 msgctxt "spell"
 msgid "Town Portal"
-msgstr "城镇传送门"
+msgstr "城镇​传送门"
 
 #: Source/spelldat.cpp:23
 msgctxt "spell"
 msgid "Stone Curse"
-msgstr "石化诅咒"
+msgstr "石化​诅咒"
 
 #: Source/spelldat.cpp:24
 msgctxt "spell"
 msgid "Infravision"
-msgstr "夜视术"
+msgstr "夜​视术"
 
 #: Source/spelldat.cpp:25
 msgctxt "spell"
 msgid "Phasing"
-msgstr "相位术"
+msgstr "相​位术"
 
 #: Source/spelldat.cpp:26
 msgctxt "spell"
 msgid "Mana Shield"
-msgstr "法力护盾"
+msgstr "法力​护盾"
 
 #: Source/spelldat.cpp:27
 msgctxt "spell"
 msgid "Fireball"
-msgstr "火球术"
+msgstr "火​球术"
 
 #: Source/spelldat.cpp:28
 msgctxt "spell"
 msgid "Guardian"
-msgstr "召唤守护者"
+msgstr "召唤​守护者"
 
 #: Source/spelldat.cpp:29
 msgctxt "spell"
 msgid "Chain Lightning"
-msgstr "连锁闪电"
+msgstr "连锁​闪​电"
 
 #: Source/spelldat.cpp:30
 msgctxt "spell"
 msgid "Flame Wave"
-msgstr "烈焰波"
+msgstr "烈​焰​波"
 
 #: Source/spelldat.cpp:31
 msgctxt "spell"
 msgid "Doom Serpents"
-msgstr "多头蛇"
+msgstr "多​头​蛇"
 
 #: Source/spelldat.cpp:32
 msgctxt "spell"
 msgid "Blood Ritual"
-msgstr "鲜血仪式"
+msgstr "鲜血​仪式"
 
 #: Source/spelldat.cpp:33
 msgctxt "spell"
 msgid "Nova"
-msgstr "闪电新星"
+msgstr "闪电​新​星"
 
 #: Source/spelldat.cpp:34
 msgctxt "spell"
 msgid "Invisibility"
-msgstr "隐形术"
+msgstr "隐形​术"
 
 #: Source/spelldat.cpp:35
 msgctxt "spell"
 msgid "Inferno"
-msgstr "地狱火"
+msgstr "地​狱火"
 
 #: Source/spelldat.cpp:36
 msgctxt "spell"
 msgid "Golem"
-msgstr "召唤魔像"
+msgstr "召唤​魔像"
 
 #: Source/spelldat.cpp:37
 msgctxt "spell"
@@ -6283,12 +6283,12 @@ msgstr "狂暴"
 #: Source/spelldat.cpp:38
 msgctxt "spell"
 msgid "Teleport"
-msgstr "传送术"
+msgstr "传​送术"
 
 #: Source/spelldat.cpp:39
 msgctxt "spell"
 msgid "Apocalypse"
-msgstr "天启"
+msgstr "天​启"
 
 #: Source/spelldat.cpp:40
 #, fuzzy
@@ -6299,27 +6299,27 @@ msgstr "灵化术"
 #: Source/spelldat.cpp:41
 msgctxt "spell"
 msgid "Item Repair"
-msgstr "物品修理"
+msgstr "物品​修理"
 
 #: Source/spelldat.cpp:42
 msgctxt "spell"
 msgid "Staff Recharge"
-msgstr "魔杖充能"
+msgstr "魔杖​充能"
 
 #: Source/spelldat.cpp:43
 msgctxt "spell"
 msgid "Trap Disarm"
-msgstr "解除陷阱"
+msgstr "解除​陷阱"
 
 #: Source/spelldat.cpp:44
 msgctxt "spell"
 msgid "Elemental"
-msgstr "召唤元素"
+msgstr "召唤​元素"
 
 #: Source/spelldat.cpp:45
 msgctxt "spell"
 msgid "Charged Bolt"
-msgstr "电荷弹"
+msgstr "电​荷弹"
 
 #: Source/spelldat.cpp:46
 msgctxt "spell"
@@ -6334,17 +6334,17 @@ msgstr "复活术"
 #: Source/spelldat.cpp:48
 msgctxt "spell"
 msgid "Telekinesis"
-msgstr "心灵传动"
+msgstr "心灵​传动"
 
 #: Source/spelldat.cpp:49
 msgctxt "spell"
 msgid "Heal Other"
-msgstr "治疗他人"
+msgstr "治疗​他​人"
 
 #: Source/spelldat.cpp:50
 msgctxt "spell"
 msgid "Blood Star"
-msgstr "血星"
+msgstr "血​星"
 
 #: Source/spelldat.cpp:51
 msgctxt "spell"
@@ -6359,12 +6359,12 @@ msgstr "法力"
 #: Source/spelldat.cpp:53
 msgctxt "spell"
 msgid "the Magi"
-msgstr "大法师之力"
+msgstr "大​法师​之​力"
 
 #: Source/spelldat.cpp:54
 msgctxt "spell"
 msgid "the Jester"
-msgstr "小丑的愚弄"
+msgstr "小丑​的​愚弄"
 
 #: Source/spelldat.cpp:55
 msgctxt "spell"
@@ -6389,12 +6389,12 @@ msgstr "反射"
 #: Source/spelldat.cpp:59
 msgctxt "spell"
 msgid "Berserk"
-msgstr "狂战士"
+msgstr "狂​战士"
 
 #: Source/spelldat.cpp:60
 msgctxt "spell"
 msgid "Ring of Fire"
-msgstr "火焰环"
+msgstr "火焰​环"
 
 #: Source/spelldat.cpp:61
 msgctxt "spell"
@@ -6404,7 +6404,7 @@ msgstr "搜索"
 #: Source/spelldat.cpp:62
 msgctxt "spell"
 msgid "Rune of Fire"
-msgstr "火焰符文"
+msgstr "火焰​符文"
 
 #: Source/spelldat.cpp:63
 msgctxt "spell"
@@ -6414,12 +6414,12 @@ msgstr "闪电符文"
 #: Source/spelldat.cpp:64
 msgctxt "spell"
 msgid "Rune of Nova"
-msgstr "新星符文"
+msgstr "新​星符文"
 
 #: Source/spelldat.cpp:65
 msgctxt "spell"
 msgid "Rune of Immolation"
-msgstr "献祭符文"
+msgstr "献祭​符文"
 
 #: Source/spelldat.cpp:66
 msgctxt "spell"
@@ -6430,7 +6430,7 @@ msgstr "符文石"
 #, fuzzy
 #| msgid "Griswold's Edge"
 msgid "Griswold"
-msgstr "格里斯沃尔德的锐利"
+msgstr "格里斯沃尔德​的​锐利"
 
 #: Source/stores.cpp:92
 msgid "Pepin"
@@ -6448,7 +6448,7 @@ msgstr ""
 #, fuzzy
 #| msgid "Talk to Farnham"
 msgid "Farnham"
-msgstr "与法恩汉交谈"
+msgstr "与​法恩汉​交谈"
 
 #: Source/stores.cpp:97
 msgid "Adria"
@@ -6470,66 +6470,66 @@ msgstr ",  "
 
 #: Source/stores.cpp:195
 msgid "Damage: {:d}-{:d}  "
-msgstr "伤害: {:d}-{:d} "
+msgstr "伤害​:​ {:d}-{:d} "
 
 #: Source/stores.cpp:197
 msgid "Armor: {:d}  "
-msgstr "护甲: {:d} "
+msgstr "护​甲​:​ {:d} "
 
 #: Source/stores.cpp:199
 msgid "Dur: {:d}/{:d},  "
-msgstr "耐久: {:d}/{:d}, "
+msgstr "耐久​:​ {:d}/{:d}, "
 
 #: Source/stores.cpp:202
 msgid "Indestructible,  "
-msgstr "坚不可摧,  "
+msgstr "坚​不​可摧​,  "
 
 #: Source/stores.cpp:210
 msgid "No required attributes"
-msgstr "无需属性"
+msgstr "无​需​属性"
 
 #: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
 msgid "Welcome to the"
-msgstr "欢迎来到"
+msgstr "欢迎​来到"
 
 #: Source/stores.cpp:244
 msgid "Blacksmith's shop"
-msgstr "铁匠铺"
+msgstr "铁匠​铺"
 
 #: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
 #: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
 #: Source/stores.cpp:1265
 msgid "Would you like to:"
-msgstr "您想:"
+msgstr "您​想​:"
 
 #: Source/stores.cpp:246
 msgid "Talk to Griswold"
-msgstr "与格里斯沃尔德交谈"
+msgstr "与​格里斯沃尔德​交谈"
 
 #: Source/stores.cpp:247
 msgid "Buy basic items"
-msgstr "购买基础物品"
+msgstr "购买​基础​物品"
 
 #: Source/stores.cpp:248
 msgid "Buy premium items"
-msgstr "购买高级物品"
+msgstr "购买​高级​物品"
 
 #: Source/stores.cpp:249 Source/stores.cpp:613
 msgid "Sell items"
-msgstr "出售物品"
+msgstr "出售​物品"
 
 #: Source/stores.cpp:250
 msgid "Repair items"
-msgstr "修理物品"
+msgstr "修理​物品"
 
 #: Source/stores.cpp:251
 msgid "Leave the shop"
-msgstr "离开商店"
+msgstr "离开​商店"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
 msgid "I have these items for sale:             Your gold: {:d}"
-msgstr "我有这些东西要卖: 你的金币: {:d}"
+msgstr "我​有​这些​东西​要​卖​: 你​的​金币​:​ {:d}"
 
 #: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
 #: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
@@ -6543,113 +6543,113 @@ msgstr "返回"
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:351
 msgid "I have these premium items for sale:     Your gold: {:d}"
-msgstr "我这有些高档品出售: 你的金币: {:d}"
+msgstr "我​这​有些​高档品​出售​: 你​的​金币​:​ {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:474 Source/stores.cpp:746
 msgid "You have nothing I want.             Your gold: {:d}"
-msgstr "你没有我想要的东西。你的金币: {:d}"
+msgstr "你​没有​我​想要​的​东西​。​你​的​金币​:​ {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:489 Source/stores.cpp:761
 msgid "Which item is for sale?             Your gold: {:d}"
-msgstr "要出售哪件物品？你的金币: {:d}"
+msgstr "要​出售​哪​件​物品​？​你​的​金币​:​ {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:564
 msgid "You have nothing to repair.             Your gold: {:d}"
-msgstr "你没有需要修理的物品。你的金币: {:d}"
+msgstr "你​没有​需要​修理​的​物品​。​你​的​金币​:​ {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:579
 msgid "Repair which item?             Your gold: {:d}"
-msgstr "哪件物品需要修理？你的金币: {:d}"
+msgstr "哪​件​物品​需要​修理​？​你​的​金币​:​ {:d}"
 
 #: Source/stores.cpp:609
 msgid "Witch's shack"
-msgstr "女巫小屋"
+msgstr "女​巫小屋"
 
 #: Source/stores.cpp:611
 msgid "Talk to Adria"
-msgstr "与艾德莉亚交谈"
+msgstr "与​艾德莉亚​交谈"
 
 #: Source/stores.cpp:612 Source/stores.cpp:999
 msgid "Buy items"
-msgstr "购买物品"
+msgstr "购买​物品"
 
 #: Source/stores.cpp:614
 msgid "Recharge staves"
-msgstr "给魔杖重新充能"
+msgstr "给​魔杖​重新​充能"
 
 #: Source/stores.cpp:615
 msgid "Leave the shack"
-msgstr "离开小屋"
+msgstr "离开​小​屋"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:827
 msgid "You have nothing to recharge.             Your gold: {:d}"
-msgstr "你没有物品需要充能。你的金币: {:d}"
+msgstr "你​没有​物品​需要​充能​。​你​的​金币​:​ {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:842
 msgid "Recharge which item?             Your gold: {:d}"
-msgstr "给哪件物品充能？你的金币: {:d}"
+msgstr "给​哪​件​物品​充能​？​你​的​金币​:​ {:d}"
 
 #: Source/stores.cpp:858
 msgid "You do not have enough gold"
-msgstr "你没有足够的金币"
+msgstr "你​没有​足够​的​金币"
 
 #: Source/stores.cpp:866
 msgid "You do not have enough room in inventory"
-msgstr "您的物品栏空间不足"
+msgstr "您​的​物品​栏​空间​不​足"
 
 #: Source/stores.cpp:903
 msgid "Do we have a deal?"
-msgstr "我们有生意往来吗？"
+msgstr "我们​有​生意​往来​吗​？"
 
 #: Source/stores.cpp:906
 msgid "Are you sure you want to identify this item?"
-msgstr "您确定要鉴定这件物品吗？"
+msgstr "您​确定​要​鉴定​这​件​物品​吗​？"
 
 #: Source/stores.cpp:912
 msgid "Are you sure you want to buy this item?"
-msgstr "您确定要购买这件物品吗？"
+msgstr "您​确定​要​购买​这​件​物品​吗​？"
 
 #: Source/stores.cpp:915
 msgid "Are you sure you want to recharge this item?"
-msgstr "您确定要为该物品充能吗？"
+msgstr "您​确定​要​为​该​物品​充能​吗​？"
 
 #: Source/stores.cpp:919
 msgid "Are you sure you want to sell this item?"
-msgstr "您确定要出售这件物品吗？"
+msgstr "您​确定​要​出售​这​件​物品​吗​？"
 
 #: Source/stores.cpp:922
 msgid "Are you sure you want to repair this item?"
-msgstr "您确定要修理这件物品吗？"
+msgstr "您​确定​要​修理​这​件​物品​吗​？"
 
 #: Source/stores.cpp:936 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
-msgstr "假腿男孩怀特"
+msgstr "假腿​男孩​怀​特"
 
 #: Source/stores.cpp:939 Source/stores.cpp:946
 msgid "Talk to Wirt"
-msgstr "和怀特谈谈"
+msgstr "和​怀特​谈​谈"
 
 #: Source/stores.cpp:940
 msgid "I have something for sale,"
-msgstr "我有东西要出售，"
+msgstr "我​有​东西​要​出售​，"
 
 #: Source/stores.cpp:941
 msgid "but it will cost 50 gold"
-msgstr "但要花 50 金币"
+msgstr "但​要​花​ 50 ​金币"
 
 #: Source/stores.cpp:942
 msgid "just to take a look. "
-msgstr "才能看上一眼。"
+msgstr "才​能​看上​一​眼​。"
 
 #: Source/stores.cpp:943
 msgid "What have you got?"
-msgstr "你找到了什么东西？"
+msgstr "你​找到​了​什么​东西​？"
 
 #: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
 #: Source/stores.cpp:1255
@@ -6659,7 +6659,7 @@ msgstr "再见"
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:957
 msgid "I have this item for sale:             Your gold: {:d}"
-msgstr "我有这个东西要卖: 你的金币: {:d}"
+msgstr "我​有​这个​东西​要​卖​: 你​的​金币​:​ {:d}"
 
 #: Source/stores.cpp:974
 msgid "Leave"
@@ -6667,41 +6667,41 @@ msgstr "离开"
 
 #: Source/stores.cpp:996
 msgid "Healer's home"
-msgstr "治疗者的家"
+msgstr "治疗者​的​家"
 
 #: Source/stores.cpp:998
 msgid "Talk to Pepin"
-msgstr "与佩金交谈"
+msgstr "与​佩金​交谈"
 
 #: Source/stores.cpp:1000
 msgid "Leave Healer's home"
-msgstr "离开治疗者的家"
+msgstr "离开​治疗者​的​家"
 
 #: Source/stores.cpp:1053
 msgid "The Town Elder"
-msgstr "镇上的长老"
+msgstr "镇​上​的​长老"
 
 #: Source/stores.cpp:1055
 msgid "Talk to Cain"
-msgstr "与凯恩交谈"
+msgstr "与​凯恩​交谈"
 
 #: Source/stores.cpp:1056
 msgid "Identify an item"
-msgstr "鉴定一件物品"
+msgstr "鉴定​一​件​物品"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:1149
 msgid "You have nothing to identify.             Your gold: {:d}"
-msgstr "你没有可以鉴定的物品。你的金币: {:d}"
+msgstr "你​没有​可以​鉴定​的​物品​。​你​的​金币​:​ {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:1164
 msgid "Identify which item?             Your gold: {:d}"
-msgstr "鉴定哪一件物品？你的金币: {:d}"
+msgstr "鉴定​哪​一​件​物品​？​你​的​金币​:​ {:d}"
 
 #: Source/stores.cpp:1184
 msgid "This item is:"
-msgstr "这件物品是:"
+msgstr "这​件​物品​是​:"
 
 #: Source/stores.cpp:1187
 msgid "Done"
@@ -6709,19 +6709,19 @@ msgstr "完成"
 
 #: Source/stores.cpp:1196
 msgid "Talk to {:s}"
-msgstr "与{:s}交谈"
+msgstr "与​{:s}​交谈"
 
 #: Source/stores.cpp:1200
 msgid "Talking to {:s}"
-msgstr "与{:s}交谈"
+msgstr "与​{:s}​交谈"
 
 #: Source/stores.cpp:1202
 msgid "is not available"
-msgstr "不可用"
+msgstr "不​可​用"
 
 #: Source/stores.cpp:1203
 msgid "in the shareware"
-msgstr "在共享软件中"
+msgstr "在​共​享​软件​中"
 
 #: Source/stores.cpp:1204
 msgid "version"
@@ -6733,27 +6733,27 @@ msgstr "闲聊"
 
 #: Source/stores.cpp:1240
 msgid "Rising Sun"
-msgstr "朝阳旅店"
+msgstr "朝阳​旅店"
 
 #: Source/stores.cpp:1242
 msgid "Talk to Ogden"
-msgstr "与奥格登交谈"
+msgstr "与​奥格登​交谈"
 
 #: Source/stores.cpp:1243
 msgid "Leave the tavern"
-msgstr "离开酒馆"
+msgstr "离开​酒馆"
 
 #: Source/stores.cpp:1254
 msgid "Talk to Gillian"
-msgstr "与吉莉安交谈"
+msgstr "与​吉莉安​交谈"
 
 #: Source/stores.cpp:1264 Source/towners.cpp:212
 msgid "Farnham the Drunk"
-msgstr "醉汉法恩汉"
+msgstr "醉​汉法恩汉"
 
 #: Source/stores.cpp:1266
 msgid "Talk to Farnham"
-msgstr "与法恩汉交谈"
+msgstr "与​法恩汉​交谈"
 
 #: Source/stores.cpp:1267
 msgid "Say Goodbye"
@@ -6769,10 +6769,10 @@ msgid ""
 "men. Only the vilest powers of Hell could so utterly destroy a man from "
 "within..."
 msgstr ""
-"啊，关于我们国王的故事，是吧？李奥瑞克国王的堕落对于这王国来说是一场悲剧。人"
-"民一直热爱着国王，但是从此人们反而生活在对他的恐惧之中。我一直反思，他原来是"
-"如此虔诚，如何堕落到离光明如此遥远。只有，来自地狱最邪恶的力量才能如此彻底的"
-"从内心摧毁他。"
+"啊​，​关于​我们​国王​的​故事​，​是​吧​？​李奥瑞克​国王​的​堕落​对于​这​王国​来​说​是​一​场​悲剧​。​人"
+"民​一直​热爱​着​国王​，​但是​从此​人们​反而​生活​在​对​他​的​恐惧​之中​。​我​一直​反思​，​他​原来​是​"
+"如此​虔诚​，​如何​堕落​到​离​光明​如此​遥远​。​只有​，​来自​地狱​最​邪恶​的​力量​才​能​如此​彻底​的​从"
+"​内心​摧毁​他​。"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:17
@@ -6795,16 +6795,16 @@ msgid ""
 "levels beneath the Cathedral. Please, good master, put his soul at ease by "
 "destroying his now cursed form..."
 msgstr ""
-"村子需要你的帮助，好心人！几个月前，李奥瑞克的儿子，艾伯莱希特王子被绑架了。"
-"国王勃然大怒，在村子中到处寻找他失踪的孩子。日子一天天过去，李奥瑞克开始逐渐"
-"陷入疯狂。他把儿子的失踪，归咎于无辜的村民，残忍的处决了他们。只有不到一半的"
-"人从他的疯狂举动中幸存……\n"
-"宫里的骑士和祭司试图安慰他，国王反到认为他们是想谋反。在国王即将咽气的时候，"
-"对他的追随者们降下了可怕的诅咒。他发誓要让他们在黑暗中永远的效忠自己。\n"
-"但是实时上发生的事情比我想象中的还要黑暗和扭曲！现在，我们的前任国王已经从长"
-"眠中复活了，并在地下回廊中指挥着一只不死军团。他的身体已经被火化，埋葬在大教"
-"堂的地下墓室的第三层。求你了，好心人，摧毁它那现在被诅咒的身体，让他的灵魂得"
-"到解放。"
+"村子​需要​你​的​帮助​，​好心​人​！​几​个​月​前​，​李奥瑞克​的​儿子​，​艾伯莱希特​王子​被​绑架​了​。​国"
+"王​勃然大怒​，​在​村子​中​到处​寻找​他​失踪​的​孩子​。​日子​一​天天​过去​，​李奥瑞克​开始​逐渐​陷入​疯狂"
+"​。​他​把​儿子​的​失踪​，​归咎于​无辜​的​村民​，​残忍​的​处决​了​他们​。​只​有​不到​一半​的​人​从​他"
+"​的​疯狂​举动​中​幸存​…​…​\n"
+"宫​里​的​骑士​和​祭司​试图​安慰​他​，​国王​反​到​认为​他们​是​想​谋反​。​在​国王​即将​咽气​的​时候​，"
+"​对​他​的​追随者们​降下​了​可怕​的​诅咒​。​他​发誓​要​让​他们​在​黑暗中​永远​的​效忠​自己​。​\n"
+"​但是​实时​上​发生​的​事情​比​我​想​象​中​的​还​要​黑暗​和​扭曲​！​现在​，​我们​的​前任​国王​已经​从"
+"​长眠​中​复活​了​，​并​在​地下​回廊​中​指挥​着​一​只​不​死​军团​。​他​的​身体​已经​被​火化​，​埋葬​"
+"在​大​教堂​的​地下​墓室​的​第三​层​。​求​你​了​，​好心人​，​摧毁​它​那​现在​被​诅咒​的​身体​，​让​他"
+"​的​灵魂​得到​解放​。"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:19
@@ -6813,8 +6813,8 @@ msgid ""
 "down there, waiting in the putrid darkness for his chance to destroy this "
 "land..."
 msgstr ""
-"正如之前我告诉你的，好心人，国王被埋葬在地下墓穴第三层。他就在那下面，在那腐"
-"朽的黑暗中等待着摧毁这片土地的机会。"
+"正​如​之前​我​告诉​你​的​，​好心人​，​国王​被​埋葬​在​地下​墓穴​第三​层​。​他​就​在​那​下面​，​在​那"
+"​腐朽​的​黑暗​中​等待​着​摧毁​这​片​土地​的​机会​。"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden (Quest End)
 #: Source/textdat.cpp:21
@@ -6824,9 +6824,9 @@ msgid ""
 "consumes our land, for your victory is a good omen. May Light guide you on "
 "your way, good master."
 msgstr ""
-"我们国王的诅咒已经解除，但我担心那只是巨大邪恶的冰山一角。然而，正因为你的胜"
-"利，我们还有在被邪恶席卷这片土地前被救赎的机会。希望光明指引你的旅途，好心"
-"人。"
+"我们​国王​的​诅咒​已经​解除​，​但​我​担心​那​只是​巨大​邪恶​的​冰山​一​角​。​然而​，​正​因为​你​的​胜"
+"利​，​我们​还​有​在​被​邪恶​席卷​这​片​土地​前​被​救赎​的​机会​。​希望​光明​指引​你​的​旅途​，​好心人"
+"​。"
 
 #. TRANSLATORS: Quest dialog spoken by Pepin
 #: Source/textdat.cpp:23
@@ -6836,9 +6836,9 @@ msgid ""
 "this kingdom from that day forward, but perhaps if you were to free his "
 "spirit from his earthly prison, the curse would be lifted..."
 msgstr ""
-"失去儿子，对于李奥瑞克国王来说是个沉痛的打击。我尽我所能的减轻他的疯狂，但是"
-"终究邪恶还是占据了他。从那天起，黑色的诅咒笼罩着王国，要是你也许能让他的灵魂"
-"从人间解脱，诅咒便会就此解除。"
+"失去​儿子​，​对于​李奥瑞克​国王​来​说​是​个​沉痛​的​打击​。​我​尽​我​所能​的​减轻​他​的​疯狂​，​但是​"
+"终究​邪恶​还是​占据​了​他​。​从​那​天​起​，​黑色​的​诅咒​笼罩​着​王国​，​要是​你​也许​能​让​他​的​灵"
+"魂​从​人间​解脱​，​诅咒​便​会​就此​解除​。"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:25
@@ -6847,8 +6847,8 @@ msgid ""
 "the kind and just ruler that he was. His death was so sad and seemed very "
 "wrong, somehow."
 msgstr ""
-"我不想去回忆国王的驾崩。我印象中他是一位仁慈且公正的统治者。不止为何，他的死"
-"是如此的悲痛，就像是一场悲剧。"
+"我​不​想​去​回忆​国王​的​驾崩​。​我​印象中​他​是​一​位​仁慈​且​公正​的​统治者​。​不止​为​何​，​他​的"
+"​死​是​如此​的​悲痛​，​就​像是​一​场​悲剧​。"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:27
@@ -6858,9 +6858,9 @@ msgid ""
 "mithril for him, as well as a field crown to match. I still cannot believe "
 "how he died, but it must have been some sinister force that drove him insane!"
 msgstr ""
-"我打造的武器和盔甲大部分被李奥瑞克国王武装他的骑士。我还为他本人锻造了一把趁"
-"手的秘银双手大剑和一顶与之相配的王冠。我始终无法接受他的驾崩，一定是某种强大"
-"的邪恶把他逼疯了！"
+"我​打造​的​武器​和​盔甲​大部分​被​李奥瑞克​国王​武装​他​的​骑士​。​我​还​为​他​本人​锻造​了​一​把​趁手"
+"​的​秘银​双​手​大剑​和​一​顶​与​之​相配​的​王冠​。​我​始终​无法​接受​他​的​驾崩​，​一定​是​某​种​强"
+"大​的​邪恶​把​他​逼疯​了​！"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:29
@@ -6868,8 +6868,8 @@ msgid ""
 "I don't care about that. Listen, no skeleton is gonna be MY king. Leoric is "
 "King. King, so you hear me? HAIL TO THE KING!"
 msgstr ""
-"我才不在乎呢。听着，我的国王才不会是一具骨架子。李奥瑞克才是国王。什么是国"
-"王，懂吗？向国王致敬！"
+"我​才​不​在乎​呢​。​听​着​，​我​的​国王​才​不​会​是​一​具​骨​架子​。​李奥瑞克​才​是​国王​。​什么​是"
+"​国王​，​懂​吗​？​向​国王​致敬​！"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:31
@@ -6879,8 +6879,8 @@ msgid ""
 "you do not stop his reign, he will surely march across this land and slay "
 "all who still live here."
 msgstr ""
-"在人间活跃的亡灵跟随着被诅咒的国王。他它拥有着复生无尽亡者大军的力量。如果你"
-"不能阻止他的统治，他一定会率领大军杀穿这片土地，屠杀所有生者。"
+"在​人间​活跃​的​亡灵​跟​随​着​被​诅咒​的​国王​。​他​它​拥有​着​复生无​尽亡者​大军​的​力量​。​如果​你​"
+"不​能​阻止​他​的​统治​，​他​一定​会​率领​大军​杀​穿​这​片​土地​，​屠杀​所有​生者​。"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:33
@@ -6890,15 +6890,15 @@ msgid ""
 "need something to use against this King of the undead, then I can help you "
 "out..."
 msgstr ""
-"瞧，我就是来做生意的。我不卖情报，也不关心那死的比我活的还长的国王。如果你需"
-"要些东西对付这死不了的国王，那我倒是可以帮帮你。"
+"瞧​，​我​就​是​来​做​生意​的​。​我​不​卖​情报​，​也​不​关心​那死​的​比​我​活​的​还​长​的​国王​。​"
+"如果​你​需要​些​东西​对付​这​死不​了​的​国王​，​那​我​倒​是​可以​帮​帮​你​。"
 
 #. TRANSLATORS: Quest dialog spoken by The Skeleton King (Hostile)
 #: Source/textdat.cpp:35
 msgid ""
 "The warmth of life has entered my tomb. Prepare yourself, mortal, to serve "
 "my Master for eternity!"
-msgstr "温暖是生命气息来到了我的墓穴。那就来吧，凡人，为我主效命终生吧！"
+msgstr "温暖​是​生命​气息​来到​了​我​的​墓穴​。​那​就​来​吧​，​凡​人​，​为​我​主效命​终生​吧​！"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:37
@@ -6909,9 +6909,9 @@ msgid ""
 "led them to believe that it too holds some arcane powers. Hmm, perhaps they "
 "are not all as smart as we had feared..."
 msgstr ""
-"我知道这种奇怪的行为也让你困惑。我猜想，既然许多恶魔害怕太阳光，相信它拥有巨"
-"大的力量，那可能是你所说的星座上描绘的旭日让他们相信它也拥有一些神秘的力量。"
-"嗯，也许他们并不像我们担心的那么聪明"
+"我​知道​这​种​奇怪​的​行为​也​让​你​困惑​。​我​猜想​，​既然​许多​恶魔​害怕​太阳光​，​相信​它​拥有​巨大"
+"​的​力量​，​那​可能​是​你​所​说​的​星座​上​描绘​的​旭日​让​他们​相信​它​也​拥有​一些​神秘​的​力量​。"
+"​嗯​，​也许​他们​并不​像​我们​担心​的​那么​聪明"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:39
@@ -6925,11 +6925,11 @@ msgid ""
 "the sign to my inn. I don't know why the demons would steal my sign but "
 "leave my family in peace... 'tis strange, no?"
 msgstr ""
-"师父，我有一个奇怪的经历。我知道你对迷宫里的怪物很了解，这是我一生都无法理解"
-"的。。。我在晚上被酒店外面的刮擦声吵醒了。当我从卧室往外看的时候，我看到客栈"
-"院子里有一些像魔鬼一样的小动物。过了一会儿，他们跑掉了，但还没来得及把牌子偷"
-"到我的客栈。我不知道为什么恶魔会偷走我的标志，却让我的家人安然无恙……”很奇怪，"
-"不是吗"
+"师父​，​我​有​一​个​奇怪​的​经历​。​我​知道​你​对​迷宫​里​的​怪物​很​了解​，​这​是​我​一​生​都​无法"
+"​理解​的​。​。​。​我​在​晚上​被​酒店​外面​的​刮擦声​吵醒​了​。​当​我​从​卧室​往外​看​的​时候​，​我​"
+"看到​客栈院子​里​有​一些​像​魔鬼​一样​的​小​动物​。​过​了​一会儿​，​他们​跑掉​了​，​但​还​没​来​得​及"
+"​把​牌子​偷​到​我​的​客栈​。​我​不​知道​为什么​恶魔会​偷走​我​的​标志​，​却​让​我​的​家人​安然​无恙​"
+"…​…​”​很​奇怪​，​不​是​吗"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden (Quest End)
 #: Source/textdat.cpp:41
@@ -6940,9 +6940,10 @@ msgid ""
 "cap was left in one of the rooms by a magician who stayed here some time "
 "ago. Perhaps it may be of some value to you."
 msgstr ""
-"哦，你不必把我的牌子拿回来，但我想它确实可以帮我省下再做一个牌子的费用。好"
-"吧，让我想想，我能给你什么作为找到它的费用？嗯，我们这里有什么。。。啊，是"
-"的！这顶帽子是一个魔法师不久前留下来的，他把它放在一个房间里。也许对你有价值"
+"哦​，​你​不​必​把​我​的​牌子​拿​回来​，​但​我​想​它​确实​可以​帮​我​省下​再​做​一​个​牌子​的​费用​"
+"。​好​吧​，​让​我​想想​，​我​能​给​你​什么​作为​找到​它​的​费用​？​嗯​，​我们​这里​有​什么​。​。​。"
+"​啊​，​是​的​！​这​顶​帽子​是​一​个​魔法师​不久​前​留​下来​的​，​他​把​它​放​在​一​个​房间​里​。​"
+"也许​对​你​有​价值"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:43
@@ -6951,8 +6952,8 @@ msgid ""
 "- is nothing sacred? I hope that Ogden and Garda are all right. I suppose "
 "that they would come to see me if they were hurt..."
 msgstr ""
-"我的天哪，恶魔们晚上在村子里到处乱跑，掠夺我们的家园——难道没有什么神圣的东西"
-"吗？我希望奥格登和加尔达没事。我想如果他们受伤了他们会来看我的"
+"我​的​天哪​，​恶魔们​晚上​在​村子​里​到处​乱​跑​，​掠夺​我们​的​家园​——​难道​没有​什么​神圣​的​东西​"
+"吗​？​我​希望​奥格登​和​加尔达​没​事​。​我​想​如果​他们​受伤​了​他们​会​来​看​我​的"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:45
@@ -6960,8 +6961,7 @@ msgid ""
 "Oh my! Is that where the sign went? My Grandmother and I must have slept "
 "right through the whole thing. Thank the Light that those monsters didn't "
 "attack the inn."
-msgstr ""
-"天哪！标志就在那里吗？我祖母和我一定一直都在睡觉。感谢那些怪物没有攻击客栈"
+msgstr "天​哪​！​标志​就​在​那里​吗​？​我​祖母​和​我​一定​一直​都​在​睡觉​。​感谢​那些​怪物​没有​攻击​客栈"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:47
@@ -6971,9 +6971,9 @@ msgid ""
 " \n"
 "Demons are concerned with ripping out your heart, not your signpost."
 msgstr ""
-"你说恶魔偷了奥格登的招牌？这听起来不像我听说过或见过的暴行。\n"
+"你​说​恶魔​偷​了​奥格登​的​招牌​？​这​听​起来​不​像​我​听​说​过​或​见​过​的​暴行​。​\n"
 " \n"
-"恶魔关心的是撕碎你的心，而不是你的路标"
+"​恶魔​关心​的​是​撕碎​你​的​心​，​而​不​是​你​的​路标"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:49
@@ -6983,9 +6983,9 @@ msgid ""
 "new sign with some pretty drawing on it. Maybe a nice mug of ale or a piece "
 "of cheese..."
 msgstr ""
-"你知道我怎么想吗？有人拿了那个牌子，他们会想要很多钱的。如果我是奥格登。。。"
-"我不是，但如果我是。。。我想买一个新牌子，上面画些漂亮的图案。也许是一杯啤酒"
-"或者一块奶酪"
+"你​知道​我​怎么​想​吗​？​有​人​拿​了​那个​牌子​，​他们​会​想要​很多​钱​的​。​如果​我​是​奥格登​。​。"
+"​。​我​不​是​，​但​如果​我​是​。​。​。​我​想​买​一​个​新​牌子​，​上面​画​些​漂亮​的​图案​。​也许​"
+"是​一​杯​啤酒​或者​一​块​奶酪"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:51
@@ -6994,9 +6994,9 @@ msgid ""
 " \n"
 "Never let their erratic actions confuse you, as that too may be their plan."
 msgstr ""
-"没有人能真正理解恶魔的思想。\n"
+"没有​人​能​真正​理解​恶魔​的​思想​。​\n"
 " \n"
-"永远不要让他们不稳定的行为迷惑你，因为那也可能是他们的计划"
+"​永远​不​要​让​他们​不​稳定​的​行为​迷惑​你​，​因为​那​也​可能​是​他们​的​计划"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:53
@@ -7007,9 +7007,9 @@ msgid ""
 "Look, I got over simple sign stealing months ago. You can't turn a profit on "
 "a piece of wood."
 msgstr ""
-"他是说我拿了那个？我想格里斯沃尔德也站在他这边。\n"
+"他​是​说​我​拿​了​那个​？​我​想​格里斯沃尔德​也​站​在​他​这​边​。​\n"
 " \n"
-"听着，我几个月前就忘了偷牌子了。你不能靠一块木头赚钱"
+"​听​着​，​我​几​个​月​前​就​忘​了​偷牌子​了​。​你​不​能​靠​一​块​木头​赚​钱"
 
 #. TRANSLATORS: Quest dialog spoken by Snotspill (Hostile)
 #: Source/textdat.cpp:55
@@ -7018,18 +7018,18 @@ msgid ""
 "no leave with life! You kill big uglies and give back Magic. Go past corner "
 "and door, find uglies. You give, you go!"
 msgstr ""
-"嘿-你就是那个杀人狂！你给我拿魔旗否则我们就进攻！你不能离开生命！你杀了大丑八"
-"怪还了魔法。穿过街角和门，找到丑陋的东西。你给，你走"
+"嘿​-​你​就​是​那个​杀人​狂​！​你​给​我​拿​魔旗​否则​我们​就​进攻​！​你​不​能​离开​生命​！​你​杀​了"
+"​大丑八怪​还​了​魔法​。​穿过​街角​和​门​，​找到​丑陋​的​东西​。​你​给​，​你​走"
 
 #. TRANSLATORS: Quest dialog spoken by Snotspill (Hostile)
 #: Source/textdat.cpp:57
 msgid "You kill uglies, get banner. You bring to me, or else..."
-msgstr "你杀了丑八怪，得到横幅。你给我带来，否则"
+msgstr "你​杀​了​丑八怪​，​得到​横幅​。​你​给​我​带来​，​否则"
 
 #. TRANSLATORS: Quest dialog spoken by Snotspill (Hostile)
 #: Source/textdat.cpp:59
 msgid "You give! Yes, good! Go now, we strong. We kill all with big Magic!"
-msgstr "你给我！是的，很好！走吧，我们坚强。我们用大魔法杀人"
+msgstr "你​给​我​！​是​的​，​很​好​！​走​吧​，​我们​坚强​。​我们​用​大​魔法​杀人"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:61
@@ -7058,30 +7058,29 @@ msgid ""
 "You must hurry and save the prince from the sacrificial blade of this "
 "demented fiend!"
 msgstr ""
-"这不是好兆头，因为它证实了我最黑暗的恐惧。虽然我不允许自己相信古老的传说，但"
-"我现在不能否认它们。也许是时候揭露我是谁了。\n"
+"这​不​是​好​兆头​，​因为​它​证实​了​我​最​黑暗​的​恐惧​。​虽然​我​不​允许​自己​相信​古老​的​传说​，​"
+"但​我​现在​不​能​否认​它们​。​也许​是​时候​揭露​我​是​谁​了​。​\n"
 " \n"
-"我的真名是老凯恩，我是一个古老兄弟会的最后一个后代，这个兄弟会致力于保护一个"
-"永恒邪恶的秘密。一个很明显已经被释放的恶魔。\n"
+"​我​的​真名​是​老凯恩​，​我​是​一​个​古老​兄弟会​的​最后​一​个​后代​，​这​个​兄弟​会​致力于​保护​一​"
+"个​永恒​邪恶​的​秘密​。​一​个​很​明显​已经​被​释放​的​恶魔​。​\n"
 " \n"
-"拉扎鲁斯大主教曾经是李奥瑞克国王最信任的顾问，他带领一队普通的市民进入迷宫，"
-"寻找国王失踪的儿子艾伯莱希特。过了很长一段时间他们才回来，只有少数人带着生命"
-"逃走了。\n"
+"拉扎鲁斯大​主教​曾经​是​李奥瑞克​国王​最​信任​的​顾问​，​他​带领​一​队​普通​的​市民​进入​迷宫​，​寻找​国"
+"王​失踪​的​儿子​艾伯莱希特​。​过​了​很​长​一​段​时间​他们​才​回来​，​只有​少数​人​带​着​生命​逃走​了​"
+"。​\n"
 " \n"
-"诅咒我是个傻瓜！我当时应该怀疑他暗中的背叛。一定是拉扎鲁斯自己绑架了艾伯莱希"
-"特，然后把他藏在迷宫里。我不明白大主教为什么转向黑暗，或者他对这个孩子有什么"
-"兴趣，除非他打算把他献给他的黑暗主人！\n"
+"诅咒​我​是​个​傻瓜​！​我​当时​应该​怀疑​他​暗中​的​背叛​。​一定​是​拉扎鲁斯​自己​绑架​了​艾伯莱希特​，​"
+"然后​把​他​藏​在​迷宫​里​。​我​不​明白​大主教​为什么​转向​黑暗​，​或者​他​对​这​个​孩子​有​什么​兴趣​"
+"，​除非​他​打算​把​他​献给​他​的​黑暗​主人​！​\n"
 " \n"
-"那一定是他的计划！他的“救援队”的幸存者说，拉扎鲁斯最后一次被看到跑进迷宫最深"
-"处。你必须赶快把王子从这个疯狂恶魔的祭剑中救出来"
+"​那​一定​是​他​的​计划​！​他​的​“​救援队​”​的​幸存者​说​，​拉扎鲁斯​最后​一​次​被​看到​跑进​迷宫​最"
+"​深​处​。​你​必须​赶快​把​王子​从​这​个​疯狂​恶魔​的​祭剑​中​救​出来"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:63
 msgid ""
 "You must hurry and rescue Albrecht from the hands of Lazarus. The prince and "
 "the people of this kingdom are counting on you!"
-msgstr ""
-"你必须赶快把艾伯莱希特从拉扎鲁斯手中救出来。王子和这个王国的人民都指望着你"
+msgstr "你​必须​赶快​把​艾伯莱希特​从​拉扎鲁斯​手​中​救​出来​。​王子​和​这个​王国​的​人民​都​指望​着​你"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:65
@@ -7097,13 +7096,13 @@ msgid ""
 "again sow chaos in the realm of mankind. You must venture through the portal "
 "and destroy Diablo before it is too late!"
 msgstr ""
-"你的故事很残酷，我的朋友。拉扎鲁斯一定会因为他那可怕的行为在地狱里被烧死。你"
-"描述的那个男孩不是我们的王子，但我相信艾伯莱希特可能还处在危险之中。你所说的"
-"权力的象征一定是迷宫中心的一个入口。\n"
+"你​的​故事​很​残酷​，​我​的​朋友​。​拉扎鲁斯​一定​会​因为​他​那​可怕​的​行为​在​地狱里​被​烧死​。​你​"
+"描述​的​那​个​男孩​不​是​我们​的​王子​，​但​我​相信​艾伯莱希特​可能​还​处在​危险​之中​。​你​所​说​的​"
+"权力​的​象征​一定​是​迷宫​中心​的​一​个​入口​。​\n"
 " \n"
-"你要知道，我的朋友，你所反对的邪恶是恐怖的黑魔王。他被世人称为迪亚波罗。几个"
-"世纪前，正是他被囚禁在迷宫里，我担心他又一次企图在人类的王国里制造混乱。你必"
-"须冒险穿过传送门，在一切还不到时候摧毁迪亚波罗"
+"​你​要​知道​，​我​的​朋友​，​你​所​反对​的​邪恶​是​恐怖​的​黑魔王​。​他​被​世人​称为​迪亚波罗​。​几​"
+"个​世纪​前​，​正​是​他​被​囚禁​在​迷宫​里​，​我​担心​他​又​一​次​企图​在​人类​的​王国​里​制造​混乱​"
+"。​你​必须​冒险​穿过​传送门​，​在​一切​还​不​到​时候​摧毁迪亚波罗"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:67
@@ -7113,9 +7112,9 @@ msgid ""
 "suppose he was killed along with most of the others. If you would do me a "
 "favor, good master - please do not talk to Farnham about that day."
 msgstr ""
-"拉扎鲁斯是大主教，他带领许多市民进入迷宫。那天我失去了很多好朋友，拉扎鲁斯再"
-"也没有回来。我想他是和其他大多数人一起被杀的。如果你能帮我一个忙，好主人-请不"
-"要和法恩汉谈论那一天"
+"拉扎鲁斯​是​大主教​，​他​带领​许多​市民​进入​迷宫​。​那天​我​失去​了​很多​好​朋友​，​拉扎鲁斯​再​也​没有"
+"​回来​。​我​想​他​是​和​其他​大多数​人​一起​被​杀​的​。​如果​你​能​帮​我​一​个​忙​，​好​主人​-​请"
+"​不​要​和​法恩汉​谈论​那​一​天"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:71
@@ -7125,9 +7124,9 @@ msgid ""
 "that. He was an Archbishop, and always seemed to care so much for the "
 "townsfolk of Tristram. So many were injured, I could not save them all..."
 msgstr ""
-"当我听说镇上的人那天晚上打算干什么时，我很震惊。我想在所有人中，拉扎鲁斯应该"
-"更有理智。他是一位大主教，似乎总是那么关心崔斯特姆的市民。这么多人受伤，我救"
-"不了他们"
+"当​我​听说​镇​上​的​人​那天​晚上​打算​干​什么​时​，​我​很​震惊​。​我​想​在​所有​人​中​，​拉扎鲁斯​应"
+"该​更​有​理智​。​他​是​一​位​大主教​，​似乎​总是​那么​关心​崔斯特姆​的​市民​。​这么​多​人​受伤​，​我​"
+"救​不​了​他们"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:73
@@ -7136,8 +7135,9 @@ msgid ""
 "mother's funeral, and was supportive of my grandmother and myself in a very "
 "troubled time. I pray every night that somehow, he is still alive and safe."
 msgstr ""
-"我记得拉扎鲁斯是一个非常和善和乐于奉献的人。他在我母亲的葬礼上发表了讲话，在"
-"非常困难的时候支持我和我的祖母。我每晚都祈祷，不知何故，他还活着，安然无恙"
+"我​记得​拉扎鲁斯​是​一​个​非常​和​善​和​乐于​奉献​的​人​。​他​在​我​母亲​的​葬礼​上​发表​了​讲话​，​"
+"在​非常​困难​的​时候​支持​我​和​我​的​祖母​。​我​每​晚​都​祈祷​，​不​知​何故​，​他​还​活​着​，​安然"
+"​无恙"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:75
@@ -7147,9 +7147,9 @@ msgid ""
 "much as lift his mace against them. He just ran deeper into the dim, endless "
 "chambers that were filled with the servants of darkness!"
 msgstr ""
-"拉扎鲁斯领我们进迷宫的时候，我在那里。他谈到了神圣的报应，但当我们开始与那些"
-"地狱之子战斗时，他甚至没有举起他的狼牙棒来对付他们。他只不过是往黑暗的仆人们"
-"所住的昏暗无边的房间里跑得更深"
+"拉扎鲁斯领​我们​进迷宫​的​时候​，​我​在​那里​。​他​谈到​了​神圣​的​报应​，​但​当​我们​开始​与​那些​地狱"
+"​之​子​战斗​时​，​他​甚至​没有​举起​他​的​狼牙棒​来​对付​他们​。​他​只不过​是​往​黑暗​的​仆人们​所​住"
+"​的​昏暗​无​边​的​房间​里​跑​得​更​深"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:77
@@ -7158,8 +7158,8 @@ msgid ""
 "dead! Dead! Do you hear me? They just keep falling and falling... their "
 "blood spilling out all over the floor... all his fault..."
 msgstr ""
-"它们刺，然后咬，然后它们就在你周围。说谎者！说谎者！他们都死了！死去的你听见"
-"了吗？他们只是不断地跌倒。。。他们的血洒得满地都是。。。全是他的错"
+"它们​刺​，​然后​咬​，​然后​它们​就​在​你​周围​。​说谎者​！​说​谎者​！​他们​都​死​了​！​死去​的​你​听"
+"见​了​吗​？​他们​只​是​不断​地​跌倒​。​。​。​他们​的​血洒​得​满​地​都​是​。​。​。​全​是​他​的​错"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:79
@@ -7168,8 +7168,8 @@ msgid ""
 "conflict within his being. He poses a great danger, and will stop at nothing "
 "to serve the powers of darkness which have claimed him as theirs."
 msgstr ""
-"我不认识你们所说的拉扎鲁斯，但我确实感觉到他内心有很大的矛盾。他带来了巨大的"
-"危险，他将不择手段地为黑暗势力服务，黑暗势力将他视为他们的"
+"我​不​认识​你们​所​说​的​拉扎鲁斯​，​但​我​确实​感觉​到​他​内心​有​很​大​的​矛盾​。​他​带来​了​巨大​"
+"的​危险​，​他​将​不​择​手段​地​为​黑暗​势力​服务​，​黑暗​势力​将​他​视为​他们​的"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:81
@@ -7178,8 +7178,8 @@ msgid ""
 "down there. Didn't help save my leg, did it? Look, I'll give you a free "
 "piece of advice. Ask Farnham, he was there."
 msgstr ""
-"是的，正义的拉扎鲁斯，他对那里的怪物非常有效。没救我的腿，是吗？听着，我给你"
-"一个免费的建议。问问法恩汉，他在那儿"
+"是​的​，​正义​的​拉扎鲁斯​，​他​对​那里​的​怪物​非常​有效​。​没​救​我​的​腿​，​是​吗​？​听​着​，​我"
+"​给​你​一​个​免费​的​建议​。​问问​法恩汉​，​他​在​那儿"
 
 #. TRANSLATORS: Quest dialog spoken by Lazarus (Hostile)
 #: Source/textdat.cpp:83
@@ -7187,8 +7187,8 @@ msgid ""
 "Abandon your foolish quest. All that awaits you is the wrath of my Master! "
 "You are too late to save the child. Now you will join him in Hell!"
 msgstr ""
-"放弃你愚蠢的追求。等待你的只有我主人的愤怒！你来不及救孩子了。现在你要和他一"
-"起下地狱了"
+"放弃​你​愚蠢​的​追求​。​等待​你​的​只​有​我​主人​的​愤怒​！​你​来​不​及​救​孩子​了​。​现在​你​要​和"
+"​他​一起​下​地狱​了"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:86
@@ -7199,9 +7199,9 @@ msgid ""
 "the same. Unfortunately, I do not know what would cause our water supply to "
 "be tainted."
 msgstr ""
-"嗯，我不知道我能告诉你些什么对你有帮助。充满我们水井的水来自地下泉水。我听说"
-"过一条通往大湖的隧道——也许它们是同一条。不幸的是，我不知道什么会导致我们的供"
-"水受到污染"
+"嗯​，​我​不​知道​我​能​告诉​你​些​什么​对​你​有​帮助​。​充满​我们​水井​的​水​来自​地下泉水​。​我​听说"
+"​过​一​条​通往​大​湖​的​隧道​——​也许​它们​是​同​一​条​。​不幸​的​是​，​我​不​知道​什么​会​导致​我"
+"们​的​供水​受到​污染"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:88
@@ -7212,10 +7212,10 @@ msgid ""
 " \n"
 "Please, do what you can or I don't know what we will do."
 msgstr ""
-"我一直试图在我们的储藏室里储存大量的食品和饮料，但由于全镇没有淡水供应，即使"
-"是我们的商店也很快就会干涸。\n"
+"我​一直​试图​在​我们​的​储藏室​里​储存​大量​的​食品​和​饮料​，​但​由于​全​镇​没有​淡水​供应​，​即使​是"
+"​我们​的​商店​也​很​快​就​会​干涸​。​\n"
 " \n"
-"拜托，做你能做的，否则我不知道我们会做什么"
+"​拜托​，​做​你​能​做​的​，​否则​我​不​知道​我们​会​做​什么"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:90
@@ -7226,9 +7226,9 @@ msgid ""
 "passage that leads to the springs that serve our town. Please find what has "
 "caused this calamity, or we all will surely perish."
 msgstr ""
-"很高兴我及时赶上了你！我们的水井变得微咸、死气沉沉，一些城里人喝得不好。我们"
-"储备的淡水很快就干涸了。我相信有一条通道通向为我们城镇服务的泉水。请找出造成"
-"这场灾难的原因，否则我们都将灭亡"
+"很​高兴​我​及时​赶上​了​你​！​我们​的​水井​变​得​微咸​、​死气​沉沉​，​一些​城里人​喝​得​不​好​。​我们"
+"​储备​的​淡水​很​快​就​干涸​了​。​我​相信​有​一​条​通道​通​向​为​我们​城镇​服务​的​泉水​。​请​找出​"
+"造成​这​场​灾难​的​原因​，​否则​我们​都​将​灭亡"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:92
@@ -7238,9 +7238,9 @@ msgid ""
 " \n"
 "We cannot survive for long without your help."
 msgstr ""
-"拜托，你必须快点。每过一个小时，我们就更接近没有水喝了。\n"
+"拜托​，​你​必须​快点​。​每​过​一​个​小时​，​我们​就​更​接近​没有​水​喝​了​。​\n"
 " \n"
-"没有你的帮助，我们活不了多久"
+"​没有​你​的​帮助​，​我们​活​不​了​多久"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:94
@@ -7250,16 +7250,16 @@ msgid ""
 "perseverance and courage gives us hope. Please take this ring - perhaps it "
 "will aid you in the destruction of such vile creatures."
 msgstr ""
-"你说什么？仅仅是恶魔的存在就导致了水被污染了？哦，我们镇下确实隐藏着一个巨大"
-"的恶魔，但你的毅力和勇气给了我们希望。请收下这枚戒指——也许它能帮助你消灭这些"
-"邪恶的生物"
+"你​说​什么​？​仅仅​是​恶魔​的​存在​就​导致​了​水​被​污染​了​？​哦​，​我们​镇下​确实​隐藏​着​一​个​巨"
+"大​的​恶魔​，​但​你​的​毅力​和​勇气​给​了​我们​希望​。​请​收​下​这​枚​戒指​——​也许​它​能​帮助​你​"
+"消灭​这些​邪恶​的​生物"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:96
 msgid ""
 "My grandmother is very weak, and Garda says that we cannot drink the water "
 "from the wells. Please, can you do something to help us?"
-msgstr "我祖母很虚弱，嘉达说我们不能喝井水。拜托，你能帮点忙吗"
+msgstr "我​祖母​很​虚​弱​，​嘉达​说​我们​不​能​喝​井​水​。​拜托​，​你​能​帮​点​忙​吗"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:98
@@ -7268,13 +7268,13 @@ msgid ""
 "have tried to clear one of the smaller wells, but it reeks of stagnant "
 "filth. It must be getting clogged at the source."
 msgstr ""
-"佩金告诉了你真相。我们很快就会急需淡水。我试过清理其中一口小井，但它散发着死"
-"水的臭味。一定是源头堵塞了"
+"佩金​告诉​了​你​真相​。​我们​很​快​就​会​急​需​淡水​。​我​试​过​清理​其中​一​口​小​井​，​但​它​散发"
+"​着​死水​的​臭味​。​一定​是​源头​堵塞​了"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:100
 msgid "You drink water?"
-msgstr "你想喝水吗？"
+msgstr "你​想​喝​水​吗​？"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:101
@@ -7285,9 +7285,9 @@ msgid ""
 "Know this - demons are at the heart of this matter, but they remain ignorant "
 "of what they have spawned."
 msgstr ""
-"如果你不能恢复井中的淡水，崔斯特姆人就会死。\n"
+"如果​你​不​能​恢复​井​中​的​淡水​，​崔斯特姆人​就​会​死​。​\n"
 " \n"
-"知道这一点-恶魔是这件事的核心，但他们仍然不知道他们产生了什么"
+"​知道​这​一点​-​恶魔​是​这​件​事​的​核心​，​但​他们​仍然​不​知道​他们​产生​了​什么"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:103
@@ -7295,8 +7295,8 @@ msgid ""
 "For once, I'm with you. My business runs dry - so to speak - if I have no "
 "market to sell to. You better find out what is going on, and soon!"
 msgstr ""
-"这一次，我和你在一起。可以说，如果我没有销路的话，我的生意就完了。你最好尽快"
-"弄清楚发生了什么事"
+"这​一​次​，​我​和​你​在一起​。​可以​说​，​如果​我​没有​销路​的话​，​我​的​生意​就​完​了​。​你​最好​"
+"尽快​弄清楚​发生​了​什么​事"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:105
@@ -7308,31 +7308,31 @@ msgid ""
 "the attempt to steal that treasure would be forever bound to defend it. A "
 "twisted, but strangely fitting, end?"
 msgstr ""
-"一本书提到了一间满是人类骸骨的密室？嗯，在我曾经研究学习的东方图书馆，馆藏的"
-"一些古籍中提到了白骨密室。这些书籍推断，当下界领主想要保护大量宝藏时，他们会"
-"创建一些结界。在结界中，那些试图偷窃宝藏时死亡的人，将永远被束缚。一个扭曲"
-"的，既在情理之中，又在意料之外的结局。"
+"一​本​书​提到​了​一​间​满​是​人类​骸骨​的​密室​？​嗯​，​在​我​曾经​研究​学习​的​东方​图书馆​，​馆藏​"
+"的​一些​古籍​中​提到​了​白骨密室​。​这些​书籍​推断​，​当下界​领主​想要​保护​大量​宝藏​时​，​他们​会​创建"
+"​一些​结界​。​在​结界​中​，​那些​试图​偷窃​宝藏​时​死亡​的​人​，​将​永远​被​束缚​。​一​个​扭曲​的​，"
+"​既​在​情理​之​中​，​又​在​意料​之外​的​结局​。"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:107
 msgid ""
 "I am afraid that I don't know anything about that, good master. Cain has "
 "many books that may be of some help."
-msgstr "我恐怕对此一无所知，好心人。凯恩读过很多书，他也许能提供帮助。"
+msgstr "我​恐怕​对​此​一无所知​，​好心​人​。​凯恩​读​过​很多​书​，​他​也许​能​提供​帮助​。"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:109
 msgid ""
 "This sounds like a very dangerous place. If you venture there, please take "
 "great care."
-msgstr "这听起来是个非常危险的地方。如果你在那里冒险，请小心。"
+msgstr "这​听​起来​是​个​非常​危险​的​地方​。​如果​你​在​那里​冒险​，​请​小心​。"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:111
 msgid ""
 "I am afraid that I haven't heard anything about that. Perhaps Cain the "
 "Storyteller could be of some help."
-msgstr "恐怕我什么也没听说过。说书人凯恩也许能帮上忙。"
+msgstr "恐怕​我​什么​也​没​听​说​过​。​说​书人凯恩​也许​能​帮​上​忙​。"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:113
@@ -7341,8 +7341,8 @@ msgid ""
 "many things, and it would not surprise me if he had some answers to your "
 "question."
 msgstr ""
-"我对这地方一无所知，不过你可以问问凯恩。他知道很多事情，知道你问题的答案也不"
-"奇怪。"
+"我​对​这​地方​一无所知​，​不过​你​可以​问问​凯恩​。​他​知道​很多​事情​，​知道​你​问题​的​答案​也​不​奇"
+"怪​。"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:115
@@ -7351,8 +7351,9 @@ msgid ""
 "her - tells the tree... cause you gotta wait. Then I says, that might work "
 "against him, but if you think I'm gonna PAY for this... you... uh... yeah."
 msgstr ""
-"看，有这样一个木屋。你知道他的妻子，她告诉那棵树……因为你必须等着。然后我说，"
-"这可能对他不利，但如果你认为我会为此付出代价……你……呃……对。"
+"看​，​有​这样​一​个​木屋​。​你​知道​他​的​妻子​，​她​告诉​那​棵​树​…​…​因为​你​必须​等​着​。​然后"
+"​我​说​，​这​可能​对​他​不利​，​但​如果​你​认为​我​会​为​此​付出​代价​…​…​你​…​…​呃​…​…​对​"
+"。"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:117
@@ -7362,9 +7363,9 @@ msgid ""
 " \n"
 "Enter the Chamber of Bone at your own peril."
 msgstr ""
-"倘若你死在这个被诅咒的结界里，你将成为黑暗领主永恒的仆人。\n"
+"倘​若​你​死​在​这个​被​诅咒​的​结界​里​，​你​将​成为​黑暗​领主​永恒​的​仆人​。​\n"
 "\n"
-"进入白骨密室的风险由你自行承担。"
+"​进入​白骨密室​的​风险​由​你​自行​承担​。"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:119
@@ -7373,8 +7374,8 @@ msgid ""
 "picking up a few things from you... or better yet, don't you need some rare "
 "and expensive supplies to get you through this ordeal?"
 msgstr ""
-"你是说一个巨大且神秘的宝藏？或许我有兴趣从你那里拿走些东西……或者更好的。你难"
-"道不需要些稀有且昂贵的物资来度过这场折磨吗？"
+"你​是​说​一​个​巨大​且​神秘​的​宝藏​？​或许​我​有​兴趣​从​你​那里​拿走​些​东西​…​…​或者​更​好​的​"
+"。​你​难道​不​需要​些​稀有​且​昂贵​的​物资​来​度过​这​场​折磨​吗​？"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:121
@@ -7385,9 +7386,9 @@ msgid ""
 "for what lay within the cold earth... Lazarus abandoned them down there - "
 "left in the clutches of unspeakable horrors - to die."
 msgstr ""
-"大主教拉扎鲁斯似乎怂恿过很多镇民冒险进入迷宫，去寻找国王失踪的儿子。他以镇民"
-"的恐惧为乐，鞭打他们使其成为疯狂的暴徒。没有人对倒在冰冷地面有所准备……拉扎鲁"
-"斯抛弃了他们，使留在难以言喻的恐怖中，等死。"
+"大​主教​拉扎鲁斯​似乎​怂恿​过​很多​镇民​冒险​进入​迷宫​，​去​寻找​国王​失踪​的​儿子​。​他​以​镇民​的​恐"
+"惧​为乐​，​鞭打​他们​使​其​成为​疯狂​的​暴徒​。​没有​人​对​倒​在​冰冷​地面​有所​准备​…​…​拉扎鲁斯​抛"
+"弃​了​他们​，​使​留​在​难以​言喻​的​恐怖​中​，​等死​。"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:123
@@ -7395,8 +7396,8 @@ msgid ""
 "Yes, Farnham has mumbled something about a hulking brute who wielded a "
 "fierce weapon. I believe he called him a butcher."
 msgstr ""
-"是的，法恩汉含糊的地说到一些关于一个笨重的畜生挥舞着恐怖武器的事。我确定他称"
-"他为屠夫。"
+"是​的​，​法恩汉​含糊​的​地​说到​一些​关于​一​个​笨重​的​畜生​挥舞​着​恐怖​武器​的​事​。​我​确定​他​称"
+"​他​为​屠夫​。"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:125
@@ -7408,18 +7409,17 @@ msgid ""
 "festering with disease and even I found them almost impossible to treat. "
 "Beware if you plan to battle this fiend..."
 msgstr ""
-"圣光在上，我知道这恶魔一些事情。当拉扎鲁斯带领少数幸存者从大教堂中逃出来时，"
-"很多人身上都有着恐怖的伤口。我清楚，他用什么玩意儿在受害者身上割出这样的伤口"
-"的，但绝对不是来自这个世界。它留下的伤口全是溃烂与恶疾，即便是我也毫无办法去"
-"治疗。如果你打算跟这个恶魔战斗，当心……"
+"圣光​在​上​，​我​知道​这​恶魔​一些​事情​。​当拉扎鲁斯​带领​少数​幸存者​从​大​教堂​中​逃​出来​时​，​很多"
+"​人​身​上​都​有​着​恐怖​的​伤口​。​我​清楚​，​他​用​什么​玩意儿​在​受害者​身​上​割出​这样​的​伤口​的"
+"​，​但​绝对​不​是​来自​这​个​世界​。​它​留下​的​伤口​全​是​溃烂​与​恶疾​，​即便​是​我​也​毫​无​办法"
+"​去​治疗​。​如果​你​打算​跟​这​个​恶魔​战斗​，​当心​…​…"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:127
 msgid ""
 "When Farnham said something about a butcher killing people, I immediately "
 "discounted it. But since you brought it up, maybe it is true."
-msgstr ""
-"当法恩汉说起屠夫杀人的事时，我根本不信他。然而你的再次提到，那也许是真的。"
+msgstr "当​法恩汉​说起​屠夫​杀人​的​事​时​，​我​根本​不​信​他​。​然而​你​的​再次​提到​，​那​也许​是​真的​。"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:129
@@ -7431,10 +7431,10 @@ msgid ""
 "I never saw that hideous beast again, but his blood-stained visage haunts me "
 "to this day."
 msgstr ""
-"我亲眼看到法恩汉所说的“屠夫”，我那些被他杀死朋友，尸体铺成了路。他手中挥舞的"
-"切肉刀大的就像一把斧子，胆敢面对他的勇士都被剁成了尸块。在打斗中我被另一群尖"
-"啸的恶魔拦住，还好我碰巧找到了逃离的楼梯。之后我再也没见过那可怕的怪物，但他"
-"那血迹斑斑的面容让我至今心有余悸。"
+"我​亲眼​看到​法恩汉​所​说​的​“​屠夫​”​，​我​那些​被​他​杀死​朋友​，​尸体​铺成​了​路​。​他​手​中​挥"
+"舞​的​切肉刀​大​的​就​像​一​把​斧子​，​胆​敢​面对​他​的​勇士​都​被​剁成​了​尸块​。​在​打斗​中​我​被"
+"​另​一​群​尖啸​的​恶魔​拦​住​，​还好​我​碰巧​找到​了​逃离​的​楼梯​。​之后​我​再​也​没​见​过​那​可怕"
+"​的​怪物​，​但​他​那​血迹​斑斑​的​面容​让​我​至今​心有余悸​。"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham (*sad face*)
 #: Source/textdat.cpp:131
@@ -7443,8 +7443,8 @@ msgid ""
 "couldn't save them. Trapped in a room with so many bodies... so many "
 "friends... NOOOOOOOOOO!"
 msgstr ""
-"大！大砍刀杀了我所有的伙伴。没法阻止他，必须逃跑，救不了他们。被关在一间全是"
-"尸体的房间……那么多的朋友……不，不！"
+"大​！​大​砍​刀​杀​了​我​所有​的​伙伴​。​没​法​阻止​他​，​必须​逃跑​，​救​不​了​他们​。​被​关​在​一"
+"​间​全​是​尸体​的​房间​…​…​那么​多​的​朋友​…​…​不​，​不​！"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:133
@@ -7453,8 +7453,8 @@ msgid ""
 "others. You have seen his handiwork in the drunkard Farnham. His destruction "
 "will do much to ensure the safety of this village."
 msgstr ""
-"“屠夫”是个彻彻底底的虐待狂，以别人的痛苦和折磨为乐。你已经看到他的杰作，让法"
-"恩汉一蹶不振就此成了醉鬼。消灭他能有效的确保村子安全。"
+"“​屠夫​”​是​个​彻彻底​底​的​虐待​狂​，​以​别人​的​痛苦​和​折磨​为​乐​。​你​已经​看到​他​的​杰作​，"
+"​让​法恩汉​一蹶不振​就此​成​了​醉鬼​。​消灭​他​能​有效​的​确保​村子​安全​。"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:135
@@ -7466,10 +7466,10 @@ msgid ""
 "I'll put it bluntly - kill him before he kills you and adds your corpse to "
 "his collection."
 msgstr ""
-"关于那个狰狞的恶魔，我知道的远比你想象的多。他的小伙伴抓到了我，在格里斯沃尔"
-"德赶来成功帮我逃出魔窟前，成功的卸掉了我的腿。\n"
+"关于​那​个​狰狞​的​恶魔​，​我​知道​的​远比​你​想象​的​多​。​他​的​小​伙伴​抓到​了​我​，​在​格里斯沃尔"
+"德​赶来​成功​帮​我​逃出​魔窟​前​，​成功​的​卸掉​了​我​的​腿​。​\n"
 "\n"
-"我就直话直说了，在他杀了你，让你的尸体成为他收藏品前杀了他。"
+"​我​就​直​话​直​说​了​，​在​他杀​了​你​，​让​你​的​尸体​成为​他​收藏品​前杀​了​他​。"
 
 #. TRANSLATORS: Quest dialog spoken by Wounded Townsman (Dying)
 #: Source/textdat.cpp:137
@@ -7479,9 +7479,9 @@ msgid ""
 "killed by a demon he called the Butcher. Avenge us! Find this Butcher and "
 "slay him so that our souls may finally rest..."
 msgstr ""
-"请听我说。大主教拉扎鲁斯，是他带领我们来这里寻找失踪的王子。结果那混蛋把我们"
-"引入了陷阱！现在所有人都死了……被一个叫做“屠夫”的恶魔杀死。为我们报仇！找到这"
-"个“屠夫”，杀了他，让我们的灵魂最终得到安息。"
+"请​听​我​说​。​大主教​拉扎鲁斯​，​是​他​带领​我们​来​这里​寻找​失踪​的​王子​。​结果​那​混蛋​把​我们​引"
+"入​了​陷阱​！​现在​所有​人​都​死​了​…​…​被​一​个​叫做​“​屠夫​”​的​恶魔​杀死​。​为​我们​报仇​！​"
+"找到​这​个​“​屠夫​”​，​杀​了​他​，​让​我们​的​灵魂​最终​得到​安息​。"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:140
@@ -7494,10 +7494,10 @@ msgid ""
 "sightless for all eternity. The prison for those so damned is named the "
 "Halls of the Blind..."
 msgstr ""
-"你朗诵了一首有趣的诗句，它的风格让我想起了另一个作品。让我好好想想。\n"
+"你​朗诵​了​一​首​有趣​的​诗句​，​它​的​风格​让​我​想起​了​另​一​个​作品​。​让​我​好好​想想​。​\n"
 " \n"
-"…黑暗遮蔽的隐秘。那些可怜的灵魂双目发光但却无法看见，只有被利爪急促的挂磨声永"
-"远的折磨。一座为被诅咒的人所建立的监狱，盲目之厅……"
+"​…​黑暗​遮蔽​的​隐秘​。​那些​可怜​的​灵魂​双目​发光​但​却​无法​看见​，​只有​被​利爪急促​的​挂磨声​永远"
+"​的​折磨​。​一​座​为​被​诅咒​的​人​所​建立​的​监狱​，​盲目​之​厅​…​…"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:142
@@ -7507,10 +7507,10 @@ msgid ""
 " \n"
 "What? Oh, yes... uh, well, I suppose you could see what someone else knows."
 msgstr ""
-"我从来就不喜欢诗词。偶尔，旅店生意好的时候，我会雇上吟游诗人。但那似乎是很久"
-"以前的事情了。\n"
+"我​从来​就​不​喜欢​诗词​。​偶尔​，​旅店​生意​好​的​时候​，​我​会​雇上​吟游​诗人​。​但​那​似乎​是​很​"
+"久​以前​的​事情​了​。​\n"
 "\n"
-"什么？啊，好吧……呃，我认为你可以问问别人知道什么。"
+"​什么​？​啊​，​好​吧​…​…​呃​，​我​认为​你​可以​问问​别人​知道​什么​。"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:144
@@ -7519,8 +7519,8 @@ msgid ""
 "much like that poem while researching the history of demonic afflictions. It "
 "spoke of a place of great evil that... wait - you're not going there are you?"
 msgstr ""
-"不知为何，这听起来挺熟悉的。我似乎回想起以前研究恶魔痛楚历史时读到类似的诗"
-"句，它讲述了一个非常邪恶的地方……等下，你是不会去那儿的对吧？"
+"不​知​为何​，​这​听​起来​挺​熟悉​的​。​我​似乎​回想​起​以前​研究​恶魔​痛楚​历史​时​读到​类似​的​诗句​"
+"，​它​讲述​了​一​个​非常​邪恶​的​地方​…​…​等​下​，​你​是​不​会​去​那儿​的​对​吧​？"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:146
@@ -7529,8 +7529,8 @@ msgid ""
 "he gave my grandmother a potion that helped clear her vision, so maybe he "
 "can help you, too."
 msgstr ""
-"如果你对失明有疑问，你应该和佩金谈谈。我只知道它给了我祖母一瓶药水，使得她能"
-"清晰的看到东西，或许他也能帮助你。"
+"如果​你​对​失明​有​疑问​，​你​应该​和​佩金谈谈​。​我​只​知道​它​给​了​我​祖母​一​瓶​药水​，​使得​她​"
+"能​清晰​的​看到​东西​，​或许​他​也​能​帮助​你​。"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:148
@@ -7539,13 +7539,13 @@ msgid ""
 "vivid description, my friend. Perhaps Cain the Storyteller could be of some "
 "help."
 msgstr ""
-"我恐怕从来没听过和见过一个地方与你生动的描述相符，朋友。也许说书人凯恩能提供"
-"些帮助。"
+"我​恐怕​从来​没​听​过​和​见​过​一​个​地方​与​你​生动​的​描述​相符​，​朋友​。​也许​说​书人凯恩能​提供​"
+"些​帮助​。"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:150
 msgid "Look here... that's pretty funny, huh? Get it? Blind - look here?"
-msgstr "看这里……好玩吧？明白？瞎子，看这？"
+msgstr "看​这里​…​…​好玩​吧​？​明白​？​瞎子​，​看​这​？"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:152
@@ -7556,9 +7556,9 @@ msgid ""
 "Tread carefully or you may yourself be staying much longer than you had "
 "anticipated."
 msgstr ""
-"这是一个极度折磨和恐惧的地方，为它的主人很好的服务。\n"
+"这​是​一​个​极度​折磨​和​恐惧​的​地方​，​为​它​的​主人​很​好​的​服务​。​\n"
 "\n"
-"小心点，不然你将被困在那儿，时间超乎你的想象。"
+"​小心点​，​不然​你​将​被困​在​那儿​，​时间​超乎​你​的​想象​。"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:154
@@ -7567,8 +7567,8 @@ msgid ""
 "you about this? No. Are you now leaving and going to talk to the storyteller "
 "who lives for this kind of thing? Yes."
 msgstr ""
-"我想想，我卖给你东西了？没有。你给钱让我告诉你这事情了吗？没有。你该离开去找"
-"那个活着就是为了跟你说话的说书人了吗？是的。"
+"我​想想​，​我​卖给​你​东西​了​？​没有​。​你​给​钱​让​我​告诉​你​这​事情​了​吗​？​没有​。​你​该​离开"
+"​去​找​那​个​活​着​就​是​为了​跟​你​说话​的​说书人​了​吗​？​是​的​。"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:156
@@ -7582,19 +7582,18 @@ msgid ""
 "suppose that your story could be true. If I were in your place, my friend, I "
 "would find a way to release him from his torture."
 msgstr ""
-"你声称和拉齐达南谈过？他一生是个伟大的英雄。拉齐达南是一个光荣而公正的人，多"
-"年来一直忠实地为国王服务。当然，你已经知道了。\n"
+"你​声称​和​拉齐达​南​谈​过​？​他​一生​是​个​伟大​的​英雄​。​拉齐​达​南​是​一​个​光荣​而​公正​的​人​"
+"，​多​年​来​一直​忠实​地​为​国王​服务​。​当然​，​你​已经​知道​了​。​\n"
 " \n"
-"在那些被国王诅咒的人中，拉齐达南最不可能不战而屈身于黑暗，所以我想你的故事可"
-"能是真的。如果我在你的位置，我的朋友，我会想办法把他从折磨中释放出来"
+"​在​那些​被​国王​诅咒​的​人​中​，​拉齐​达南​最​不​可能​不​战​而​屈身​于​黑暗​，​所以​我​想​你​的​故"
+"事​可能​是​真的​。​如果​我​在​你​的​位置​，​我​的​朋友​，​我​会​想​办法​把​他​从​折磨​中​释放​出来"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:158
 msgid ""
 "You speak of a brave warrior long dead! I'll have no such talk of speaking "
 "with departed souls in my inn yard, thank you very much."
-msgstr ""
-"你说的是一个死了很久的勇士！我不想在客栈院子里和死去的灵魂说话，非常感谢"
+msgstr "你​说​的​是​一​个​死​了​很​久​的​勇士​！​我​不​想​在​客栈​院子​里​和​死去​的​灵魂​说话​，​非常​感谢"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:160
@@ -7604,16 +7603,16 @@ msgid ""
 "drink it. As your healer, I strongly advise that should you find such an "
 "elixir, do as Lachdanan asks and DO NOT try to use it."
 msgstr ""
-"你是说一种金色的药剂。我从未调制过那种颜色的药水，所以我没办法告诉你如果你喝"
-"了它会怎样。作为一个治疗者，我强烈建议你去寻找那种药剂，照着拉齐达南要求的"
-"做，但你绝对不要喝了它。"
+"你​是​说​一​种​金色​的​药剂​。​我​从​未​调制​过​那​种​颜色​的​药水​，​所以​我​没​办法​告诉​你​如果​"
+"你​喝​了​它​会​怎样​。​作为​一​个​治疗者​，​我​强烈​建议​你​去​寻找​那​种​药剂​，​照着​拉齐达南​要求​"
+"的​做​，​但​你​绝对​不​要​喝​了​它​。"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:162
 msgid ""
 "I've never heard of a Lachdanan before. I'm sorry, but I don't think that I "
 "can be of much help to you."
-msgstr "我从来没听说过拉齐达南，抱歉我帮不了你。"
+msgstr "我​从来​没​听​说​过​拉齐达南​，​抱歉​我​帮​不​了​你​。"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:164
@@ -7623,15 +7622,15 @@ msgid ""
 "and loyal in nature. The curse that fell upon the followers of King Leoric "
 "would fall especially hard upon him."
 msgstr ""
-"如果你真的遇到了拉齐达南，我希望你帮帮他。我和他打过几次交道，发现他生性诚实"
-"且富有荣誉感。李奥瑞克国王的追随者遭受的诅咒，在他身上会更加糟糕。"
+"如果​你​真的​遇到​了​拉齐达南​，​我​希望​你​帮​帮​他​。​我​和​他​打​过​几​次​交道​，​发现​他​生性​诚"
+"实​且​富有​荣誉感​。​李奥瑞克​国王​的​追随者​遭受​的​诅咒​，​在​他​身​上​会​更加​糟糕​。"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:166
 msgid ""
 " Lachdanan is dead. Everybody knows that, and you can't fool me into "
 "thinking any other way. You can't talk to the dead. I know!"
-msgstr "拉齐达南已经死了。所有人都知道，你没法骗我。你不能和死人说话。我知道！"
+msgstr "拉齐达南​已经​死​了​。​所有​人​都​知道​，​你​没​法骗​我​。​你​不​能​和​死人​说话​。​我​知道​！"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:168
@@ -7641,9 +7640,9 @@ msgid ""
 " \n"
 "I sense in him honor and great guilt. Aid him, and you aid all of Tristram."
 msgstr ""
-"你也许能遇到被困在迷宫里的人，拉齐达南只是其中之一。\n"
+"你​也许​能​遇到​被困​在​迷宫​里​的​人​，​拉齐​达南​只​是​其中​之一​。​\n"
 "\n"
-"我从他身上感受到荣誉和巨大的内疚。帮助他就是帮助崔斯特姆。"
+"​我​从​他​身​上​感受​到​荣誉​和​巨大​的​内疚​。​帮助​他​就​是​帮助​崔斯特姆​。"
 
 #. TRANSLATORS: Quest dialog spoken by  Wirt
 #: Source/textdat.cpp:170
@@ -7653,9 +7652,9 @@ msgid ""
 "questions anymore. Oh, that isn't what happened? Then I guess you'll be "
 "buying something or you'll be on your way."
 msgstr ""
-"等等，让我猜猜。一条巨大裂缝出现在凯恩脚下将他吞噬，地狱烈焰把他烧得个精光，"
-"以至于没法回答你问题了。哦，不是那样么？那我就只能认为你是想买点东西或是该上"
-"路了。"
+"等等​，​让​我​猜猜​。​一​条​巨大​裂缝​出现​在​凯恩脚​下​将​他​吞噬​，​地狱烈​焰​把​他​烧​得​个​精光​"
+"，​以至于​没​法​回答​你​问题​了​。​哦​，​不​是​那样么​？​那​我​就​只​能​认为​你​是​想​买​点​东西​或"
+"是​该​上路​了​。"
 
 #. TRANSLATORS: Quest dialog spoken by Lachdanan (in despair)
 #: Source/textdat.cpp:172
@@ -7672,21 +7671,21 @@ msgid ""
 "it the last of my humanity as well. Please aid me and find the Elixir. I "
 "will repay your efforts - I swear upon my honor."
 msgstr ""
-"手下留情，别杀我，请听我把话说完。我曾经是李奥瑞克国王的骑士队长，以正义和荣"
-"誉捍卫着这王国的律法。后来他的黑暗诅咒降临在我们身上，只因我们在他的悲剧死亡"
-"中扮演的角色。当我的其他骑士同伴屈服于他们扭曲命运的时，我逃出了国王的墓室，"
-"寻找某种能解除我身上诅咒的方法。我……失败了……\n"
+"手​下​留情​，​别​杀​我​，​请​听​我​把​话​说完​。​我​曾经​是​李奥瑞克​国王​的​骑士​队长​，​以​正义​和"
+"​荣誉​捍卫​着​这​王国​的​律法​。​后来​他​的​黑暗​诅咒​降临​在​我们​身​上​，​只​因​我们​在​他​的​悲剧"
+"​死亡​中​扮演​的​角色​。​当​我​的​其他​骑士​同伴​屈服​于​他们​扭曲​命运​的​时​，​我​逃出​了​国王​的​"
+"墓室​，​寻找​某​种​能​解除​我​身​上​诅咒​的​方法​。​我​…​…​失败​了​…​…​\n"
 "\n"
-"我听说有一种“金色药剂”可以解除诅咒，让我的灵魂安息，可惜我无法找到它。我的意"
-"志逐渐衰弱，我也会因此最终失去人性。请帮帮我，找到药剂。我以荣耀发誓一定会报"
-"答你的帮助。"
+"​我​听说​有​一​种​“​金色​药剂​”​可以​解除​诅咒​，​让​我​的​灵魂​安息​，​可惜​我​无法​找到​它​。​我"
+"​的​意志​逐渐​衰弱​，​我​也​会​因此​最终​失去​人性​。​请​帮​帮​我​，​找到​药剂​。​我​以​荣耀​发誓​一"
+"定​会​报答​你​的​帮助​。"
 
 #. TRANSLATORS: Quest dialog spoken by Lachdanan (in despair)
 #: Source/textdat.cpp:174
 msgid ""
 "You have not found the Golden Elixir. I fear that I am doomed for eternity. "
 "Please, keep trying..."
-msgstr "如果你还没找到“金色药剂”，我就将承受永恒的诅咒了。求你，继续寻找吧……"
+msgstr "如果​你​还​没​找到​“​金色​药剂​”​，​我​就​将​承受​永恒​的​诅咒​了​。​求​你​，​继续​寻找​吧​…​…"
 
 #. TRANSLATORS: Quest dialog spoken by Lachdanan (Quest End)
 #: Source/textdat.cpp:176
@@ -7697,9 +7696,9 @@ msgid ""
 "have little use for it. May it protect you against the dark powers below. Go "
 "with the Light, my friend..."
 msgstr ""
-"你把我的灵魂从诅咒中拯救出来，为此我欠你一个人情。如果有办法让死后的我报答"
-"你，我一定会去做，但现在能做的——拿走我的头盔吧。我今后的旅途里，用不到它了。"
-"愿它能保护你免受地底黑暗力量的侵扰。圣光伴你同行，我的朋友……"
+"你​把​我​的​灵魂​从​诅咒​中​拯救​出来​，​为​此​我​欠​你​一​个​人情​。​如果​有​办法​让​死后​的​我​报"
+"​答​你​，​我​一定​会​去​做​，​但​现在​能​做​的​——​拿走​我​的​头盔​吧​。​我​今后​的​旅途​里​，​用"
+"​不​到​它​了​。​愿​它​能​保护​你​免​受​地底​黑暗​力量​的​侵扰​。​圣光伴​你​同行​，​我​的​朋友​…​…"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:178
@@ -7713,18 +7712,18 @@ msgid ""
 "unpredictable nature of Chaos makes it difficult to know what the outcome of "
 "this smithing will be..."
 msgstr ""
-"格里斯沃尔德谈到了“愤怒铁砧”——一件传说中的神器，人们一直在寻找，但一直没有找"
-"到。愤怒铁砧是用剃刀坑恶魔的金属骨头制作而成的，熔铸在五个最强大的冥界法师的"
-"头骨周围。刻有力量和混乱符文，任何在这个铁砧上锻造的武器或护甲都将被浸入混乱"
-"的领域，并将其嵌入魔法属性。据说，混沌的不可预测性使人们很难知道这场锻造会有"
-"什么结果"
+"格里斯沃尔德​谈到​了​“​愤怒铁砧​”​——​一​件​传说​中​的​神器​，​人们​一直​在​寻找​，​但​一直​没有​找到"
+"​。​愤怒​铁砧​是​用​剃刀​坑​恶魔​的​金属​骨头​制作​而​成​的​，​熔铸​在​五​个​最​强大​的​冥界​法师​的"
+"​头骨​周围​。​刻有​力量​和​混乱​符文​，​任何​在​这个​铁砧​上​锻造​的​武器​或​护甲​都​将​被​浸入​混乱​"
+"的​领域​，​并​将​其​嵌​入​魔法​属性​。​据说​，​混沌​的​不​可​预测性​使​人们​很​难​知道​这​场​锻造​会"
+"​有​什么​结果"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:180
 msgid ""
 "Don't you think that Griswold would be a better person to ask about this? "
 "He's quite handy, you know."
-msgstr "你不觉得格里斯沃尔德会是一个更好的人问这个问题吗？你知道，他很能干"
+msgstr "你​不​觉得​格里斯沃尔德会​是​一​个​更​好​的​人问​这​个​问题​吗​？​你​知道​，​他​很​能干"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:182
@@ -7734,8 +7733,8 @@ msgid ""
 "However, in this matter, you would be better served to speak to either "
 "Griswold or Cain."
 msgstr ""
-"如果你一直在寻找治疗杵或净化银圣杯的信息，我可以帮助你，我的朋友。不过，在这"
-"件事上，你最好和格里斯沃尔德或凯恩谈谈"
+"如果​你​一直​在​寻找​治疗​杵​或​净化​银圣杯​的​信息​，​我​可以​帮助​你​，​我​的​朋友​。​不过​，​在​这"
+"​件​事​上​，​你​最好​和​格里斯沃尔德​或​凯恩​谈​谈"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:184
@@ -7745,9 +7744,9 @@ msgid ""
 "was struck upon this anvil, the ground would shake with a great fury. "
 "Whenever the earth moves, I always remember that story."
 msgstr ""
-"格里斯沃尔德的父亲曾经告诉我们中的一些人，当我们成长的时候，一个巨大的铁砧是"
-"用来制造强大的武器。他说，当一把锤子敲在这个铁砧上时，地面会剧烈地震动。每当"
-"地球移动时，我总是记得那个故事"
+"格里斯沃尔德​的​父亲​曾经​告诉​我们​中​的​一些​人​，​当​我们​成长​的​时候​，​一​个​巨大​的​铁砧​是​用来"
+"​制造​强大​的​武器​。​他​说​，​当​一​把​锤子​敲​在​这个​铁砧​上​时​，​地面​会​剧烈​地震动​。​每​当​"
+"地球​移动​时​，​我​总是​记得​那​个​故事"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:186
@@ -7769,17 +7768,17 @@ msgid ""
 " \n"
 "Find the Anvil for me, and I'll get to work!"
 msgstr ""
-"问候语！很高兴见到我最好的客户之一！我知道你一直在冒险深入迷宫，有一个故事告"
-"诉我，你可能觉得值得花时间听。。。\n"
+"问候语​！​很​高兴​见到​我​最​好​的​客户​之一​！​我​知道​你​一直​在​冒险​深入​迷宫​，​有​一​个​故事​告"
+"诉​我​，​你​可能​觉得​值得​花​时间​听​。​。​。​\n"
 " \n"
-"一个从迷宫里回来的人告诉我他逃跑时遇到的一个神秘的铁砧。他的描述让我想起了我"
-"年轻时听到的关于燃烧的地狱炉的传说，那里有强大的魔法武器。传说在地狱熔炉的深"
-"处安放着“愤怒铁砧”！这个铁砧里面包含着恶魔世界的精髓。。。\n"
+"​一​个​从​迷宫​里​回来​的​人​告诉​我​他​逃跑​时​遇到​的​一​个​神秘​的​铁砧​。​他​的​描述​让​我​想起"
+"​了​我​年轻​时​听到​的​关于​燃烧​的​地狱炉​的​传说​，​那里​有​强大​的​魔法​武器​。​传说​在​地狱​熔炉​"
+"的​深处​安放​着​“​愤怒铁砧​”​！​这个​铁砧​里面​包含​着​恶魔​世界​的​精髓​。​。​。​\n"
 " \n"
-"据说任何在燃烧的铁砧上制作的武器都充满了巨大的力量。如果这铁砧真的就是“愤怒铁"
-"砧”，我也许能让你成为一件武器，甚至可以打败最黑暗的地狱之主！\n"
+"​据说​任何​在​燃烧​的​铁砧​上​制作​的​武器​都​充满​了​巨大​的​力量​。​如果​这​铁砧​真的​就​是​“​愤怒"
+"铁砧​”​，​我​也许​能​让​你​成为​一​件​武器​，​甚至​可以​打败​最​黑暗​的​地狱​之​主​！​\n"
 " \n"
-"帮我找铁砧，我就去干活"
+"帮​我​找​铁砧​，​我​就​去​干活"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:188
@@ -7788,8 +7787,8 @@ msgid ""
 "be your best hope, and I am sure that I can make you one of legendary "
 "proportions."
 msgstr ""
-"还没有，嗯？好吧，继续找。铁砧上锻造的武器可能是你最大的希望，我相信我能让你"
-"成为传奇般的人物之一"
+"还​没有​，​嗯​？​好​吧​，​继续​找​。​铁砧​上​锻造​的​武器​可能​是​你​最​大​的​希望​，​我​相信​我​能"
+"​让​你​成为​传奇​般​的​人物​之一"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:190
@@ -7798,16 +7797,15 @@ msgid ""
 "Now we'll show those bastards that there are no weapons in Hell more deadly "
 "than those made by men! Take this and may Light protect you."
 msgstr ""
-"我简直不敢相信！这是“愤怒铁砧”。干得好，我的朋友。现在我们要告诉那些混蛋，地"
-"狱里没有比人类制造的武器更致命的武器了！拿着这个，光会保护你的"
+"我​简直​不​敢​相信​！​这​是​“​愤怒铁砧​”​。​干​得​好​，​我​的​朋友​。​现在​我们​要​告诉​那些​混蛋​"
+"，​地狱​里​没有​比​人类​制造​的​武器​更​致命​的​武器​了​！​拿​着​这个​，​光​会​保护​你​的"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:192
 msgid ""
 "Griswold can't sell his anvil. What will he do then? And I'd be angry too if "
 "someone took my anvil!"
-msgstr ""
-"格里斯沃尔德卖不出他的铁砧。那他会怎么做？如果有人拿了我的铁砧我也会生气的"
+msgstr "格里斯沃尔德​卖​不​出​他​的​铁砧​。​那​他​会​怎么​做​？​如果​有​人​拿​了​我​的​铁砧​我​也​会​生气​的"
 
 #. TRANSLATORS: Quest dialog spoken by
 #: Source/textdat.cpp:194
@@ -7817,8 +7815,8 @@ msgid ""
 "used by either the Light or the Darkness. Securing the Anvil from below "
 "could shift the course of the Sin War towards the Light."
 msgstr ""
-"迷宫里有许多神器，拥有着凡人无法理解的力量。其中一些拥有神奇的力量，可以被光"
-"明或黑暗所利用。从下面固定铁砧可以将原罪之战的进程转向光明"
+"迷宫​里​有​许多​神器​，​拥有​着​凡​人​无法​理解​的​力量​。​其中​一些​拥有​神奇​的​力量​，​可以​被​光明"
+"​或​黑暗​所​利用​。​从​下面​固定​铁砧​可以​将​原罪之战​的​进程​转向​光明"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:196
@@ -7826,8 +7824,8 @@ msgid ""
 "If you were to find this artifact for Griswold, it could put a serious "
 "damper on my business here. Awwww, you'll never find it."
 msgstr ""
-"如果你为格里斯沃尔德找到这件艺术品，它会严重影响我在这里的生意。啊，你永远找"
-"不到它"
+"如果​你​为​格里斯沃尔德​找到​这​件​艺术品​，​它​会​严重​影响​我​在​这里​的​生意​。​啊​，​你​永远​找​不"
+"​到​它"
 
 #. TRANSLATORS: Quest dialog spoken by
 #: Source/textdat.cpp:198
@@ -7850,18 +7848,18 @@ msgid ""
 "said that when this holy armor is again needed, a hero will arise to don "
 "Valor once more. Perhaps you are that hero..."
 msgstr ""
-"鲜血之门与火焰大厅都是神秘起源的地标。在你读到这本书的地方，一定充盈着强大力"
-"量。\n"
+"鲜血​之​门​与​火焰​大厅​都​是​神秘​起源​的​地标​。​在​你​读到​这​本​书​的​地方​，​一定​充盈​着​强大​"
+"力量​。​\n"
 "\n"
-"传说有一个用黑曜石雕刻的底座，装满了漂浮着骨屑的沸腾鲜血。传说还提到了鲜血"
-"石，它能开起一道守护远古财宝的大门……\n"
+"​传说​有​一​个​用​黑曜​石​雕刻​的​底座​，​装满​了​漂浮​着​骨屑​的​沸腾​鲜血​。​传说​还​提到​了​鲜血石"
+"​，​它​能​开起​一​道​守护​远古​财宝​的​大门​…​…​\n"
 "\n"
-"这件宝物的本质到底是什么众说纷纭，疑团重重，我的朋友。但据说古代的英雄阿凯尼"
-"把它的圣甲“荣耀”放置在一个秘密的地方。他是第一个扭转原罪之战的浪潮，将黑暗军"
-"团赶回烈焰地狱的凡人。\n"
+"​这​件​宝物​的​本质​到底​是​什么​众说纷纭​，​疑团​重重​，​我​的​朋友​。​但​据说​古代​的​英雄​阿凯尼​把"
+"​它​的​圣甲​“​荣耀​”​放置​在​一​个​秘密​的​地方​。​他​是​第一​个​扭转​原罪之战​的​浪潮​，​将​黑暗​"
+"军团​赶回​烈​焰​地狱​的​凡​人​。​\n"
 "\n"
-"阿凯尼临死前，他的铠甲就被秘密地藏进了一处密室中。相传等到这副圣甲需要再一次"
-"现世时，一位英雄将会挺身而出，并且再度荣耀加身。也许你就是那个英雄……"
+"阿凯尼​临死​前​，​他​的​铠甲​就​被​秘密​地​藏进​了​一​处​密室​中​。​相传​等到​这​副圣甲​需要​再​一​次"
+"​现世​时​，​一​位​英雄​将​会​挺身而出​，​并且​再度​荣耀​加身​。​也许​你​就​是​那​个​英雄​…​…"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:200
@@ -7870,8 +7868,8 @@ msgid ""
 "known as Valor. If you could find its resting place, you would be well "
 "protected against the evil in the Labyrinth."
 msgstr ""
-"每个孩子听过战士阿凯尼和他被称作“荣耀”的传奇盔甲的故事。如果你能找到它沉睡的"
-"地方，你就能更好的保护自己对抗迷宫里的邪恶。"
+"每​个​孩子​听​过​战士​阿凯尼​和​他​被​称作​“​荣耀​”​的​传奇​盔甲​的​故事​。​如果​你​能​找到​它​沉睡"
+"​的​地方​，​你​就​能​更​好​的​保护​自己​对抗​迷宫​里​的​邪恶​。"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:202
@@ -7880,15 +7878,15 @@ msgid ""
 "learning new cures and creating better elixirs that I must have forgotten. "
 "Sorry..."
 msgstr ""
-"嗯……这听起来根本就记不住，因为我一直忙于学习新的治疗方法和制作更好的药剂，我"
-"必须忘掉这些事，抱歉……"
+"嗯​…​…​这​听​起来​根本​就​记​不​住​，​因为​我​一直​忙于​学习​新​的​治疗​方法​和​制作​更​好​的​药剂"
+"​，​我​必须​忘掉​这些​事​，​抱歉​…​…"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:204
 msgid ""
 "The story of the magic armor called Valor is something I often heard the "
 "boys talk about. You had better ask one of the men in the village."
-msgstr "我经常听到男孩们讨论关于魔法铠甲“荣耀”的故事。你最好问问村里的男人们。"
+msgstr "我​经常​听到​男孩们​讨论​关于​魔法​铠甲​“​荣耀​”​的​故事​。​你​最好​问问​村​里​的​男人们​。"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:206
@@ -7898,9 +7896,9 @@ msgid ""
 "well, my friend, and it will take more than a bit of luck to unlock the "
 "secrets that have kept it concealed oh, lo these many years."
 msgstr ""
-"被称作“荣耀”的盔甲，也许将让天平向你倾斜。我想说的是，包括我在内的许多人曾经"
-"都尝试寻找它。阿凯尼把它藏得很好，我的朋友，得需要点运气去揭开隐藏它的秘密，"
-"哎，尽管这么多年过去了。"
+"被​称作​“​荣耀​”​的​盔甲​，​也许​将​让​天平​向​你​倾斜​。​我​想​说​的​是​，​包括​我​在内​的​许多​"
+"人​曾经​都​尝试​寻找​它​。​阿凯尼​把​它​藏得​很​好​，​我​的​朋友​，​得​需要​点​运气​去​揭开​隐藏​它​"
+"的​秘密​，​哎​，​尽管​这么​多​年​过去​了​。"
 
 #. TRANSLATORS: Quest dialog "spoken" by Farnham
 #: Source/textdat.cpp:208
@@ -7915,9 +7913,9 @@ msgid ""
 "The way is fraught with danger and your only hope rests within your self "
 "trust."
 msgstr ""
-"一旦你发现了鲜血石，请小心谨慎的使用它。\n"
+"一旦​你​发现​了​鲜血石​，​请​小心​谨慎​的​使用​它​。​\n"
 "\n"
-"道路充满了危险，你唯一的希望源自于你的自信。"
+"​道路​充满​了​危险​，​你​唯一​的​希望​源自于​你​的​自信​。"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:211
@@ -7927,10 +7925,10 @@ msgid ""
 "No one has ever figured out where Arkaine stashed the stuff, and if my "
 "contacts couldn't find it, I seriously doubt you ever will either."
 msgstr ""
-"你想要找到那件被称作“荣耀”的盔甲？\n"
+"你​想要​找到​那件​被​称作​“​荣耀​”​的​盔甲​？​\n"
 "\n"
-"没人知道阿凯尼把东西藏在哪里，如果我联系的人都找不到，我很怀疑你怎么可能会找"
-"到。"
+"​没​人​知道​阿凯尼​把​东​西藏​在​哪里​，​如果​我​联系​的​人​都​找​不​到​，​我​很​怀疑​你​怎么​可能​"
+"会​找到​。"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:213
@@ -7947,14 +7945,14 @@ msgid ""
 "Legion of Darkness during the Sin War, he lost his humanity to his "
 "insatiable hunger for blood."
 msgstr ""
-"据我所知，只有一种传说提到过你描述的那个战士。他的故事记录在在古老的《原罪之"
-"战编年史》中……\n"
+"据​我​所​知​，​只有​一​种​传说​提到​过​你​描述​的​那​个​战士​。​他​的​故事​记录​在​在​古老​的​《​原"
+"罪​之​战编年史​》​中​…​…​\n"
 "\n"
-"持续千年的战争，鲜血与死亡，鲜血战神的受害者残肢断臂堆积如山。他的黑暗之刃向"
-"生者尖啸，散发黑色的诅咒；任何挡在地狱刽子手面前的人都将受到酷刑的邀请。\n"
+"​持续​千​年​的​战争​，​鲜血​与​死亡​，​鲜血​战神​的​受害者​残肢​断臂​堆积如山​。​他​的​黑暗​之​刃​向​"
+"生者​尖啸​，​散发​黑色​的​诅咒​；​任何​挡​在​地狱​刽子​手​面前​的​人​都​将​受到​酷刑​的​邀请​。​\n"
 " \n"
-"书中还写到，尽管他只是一个在原罪之战中与黑暗军团并肩作战凡人，但嗜血的欲望使"
-"得他失去了人性。"
+"书​中​还​写到​，​尽管​他​只​是​一​个​在​原罪​之​战​中​与​黑暗​军团​并肩​作战​凡​人​，​但​嗜​血​的​"
+"欲望​使得​他​失去​了​人性​。"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:215
@@ -7963,22 +7961,22 @@ msgid ""
 "master. I hope that you do not have to fight him, for he sounds extremely "
 "dangerous."
 msgstr ""
-"如此歹毒的战士我从未听说，好心人。我希望你不用跟他战斗，他听上去是极其的危"
-"险。"
+"如此​歹毒​的​战士​我​从​未​听说​，​好心​人​。​我​希望​你​不​用​跟​他​战斗​，​他​听​上去​是​极其​的​"
+"危险​。"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:217
 msgid ""
 "Cain would be able to tell you much more about something like this than I "
 "would ever wish to know."
-msgstr "凯恩能告诉你更多有关的事情，这些事真是我从来愿意知道的。"
+msgstr "凯恩​能​告诉​你​更​多​有关​的​事情​，​这些​事​真​是​我​从来​愿意​知道​的​。"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:219
 msgid ""
 "If you are to battle such a fierce opponent, may Light be your guide and "
 "your defender. I will keep you in my thoughts."
-msgstr "如果你要与如此凶猛的对手战斗，那愿圣光指引和保佑你。我会一直惦记着你。"
+msgstr "如果​你​要​与​如此​凶猛​的​对手​战斗​，​那​愿​圣光​指引​和​保佑​你​。​我​会​一直​惦记​着​你​。"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:221
@@ -7986,8 +7984,8 @@ msgid ""
 "Dark and wicked legends surrounds the one Warlord of Blood. Be well "
 "prepared, my friend, for he shows no mercy or quarter."
 msgstr ""
-"“鲜血战神”被黑暗邪恶的传说笼罩。做好准备我的朋友，因为他既不仁慈，也不讲情"
-"面。"
+"“​鲜血​战神​”​被​黑暗​邪恶​的​传说​笼罩​。​做好​准备​我​的​朋友​，​因为​他​既​不​仁慈​，​也​不​讲​"
+"情面​。"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:223
@@ -7996,8 +7994,8 @@ msgid ""
 "that pretty girl that brings the drinks. Listen here, friend - you're "
 "obsessive, you know that?"
 msgstr ""
-"你总是不停的提到血么？不如说点鲜花、阳光和送饮料的漂亮女孩。听着，朋友，你真"
-"是执迷不悟，你知道么？"
+"你​总是​不​停​的​提到​血么​？​不如说​点​鲜花​、​阳光​和​送​饮料​的​漂亮​女孩​。​听​着​，​朋友​，​你​"
+"真​是​执迷不悟​，​你​知道么​？"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:225
@@ -8006,8 +8004,8 @@ msgid ""
 "years knowing only warfare. I am sorry... I can not see if you will defeat "
 "him."
 msgstr ""
-"他的剑术令人惊叹，千年的岁月对他而言只有战斗。我很抱歉……我也不好判断你能不否"
-"打败他。"
+"他​的​剑术​令​人​惊叹​，​千​年​的​岁月​对​他​而​言​只​有​战斗​。​我​很​抱歉​…​…​我​也​不​好​判断"
+"​你​能​不​否​打败​他​。"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:227
@@ -8015,15 +8013,15 @@ msgid ""
 "I haven't ever dealt with this Warlord you speak of, but he sounds like he's "
 "going through a lot of swords. Wouldn't mind supplying his armies..."
 msgstr ""
-"我从没跟那个什么战神进行过买卖，但是我听说他用坏过很多剑。你不介意我卖点武器"
-"装备给他吧……"
+"我​从​没​跟​那​个​什么​战神​进行​过​买卖​，​但是​我​听说​他​用​坏​过​很多​剑​。​你​不​介意​我​卖点​"
+"武器​装备​给​他​吧​…​…"
 
 #. TRANSLATORS: Quest dialog spoken by Warlord of Blood (Hostile)
 #: Source/textdat.cpp:229
 msgid ""
 "My blade sings for your blood, mortal, and by my dark masters it shall not "
 "be denied."
-msgstr "我的刀刃正在为你的血歌唱，凡人。我的黑暗主人也会很高兴听到这歌声。"
+msgstr "我​的​刀刃​正在​为​你​的​血​歌唱​，​凡​人​。​我​的​黑暗​主人​也​会​很​高兴​听到​这​歌声​。"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:231
@@ -8034,9 +8032,9 @@ msgid ""
 "man could possess. I do not know what secrets it holds, my friend, but "
 "finding this stone would certainly prove most valuable."
 msgstr ""
-"格里斯沃尔德谈到了天石，它是注定要飞地位于东部。它被带到那里作进一步研究。这"
-"块石头闪耀着一种能量，它以某种方式赋予了一个普通人无法拥有的视觉。我不知道它"
-"有什么秘密，我的朋友，但找到这块石头肯定是最有价值的"
+"格里斯沃尔德​谈到​了​天石​，​它​是​注定​要​飞​地位​于​东部​。​它​被​带到​那里​作​进一步​研究​。​这​块​"
+"石头​闪耀​着​一​种​能量​，​它​以​某​种​方式​赋予​了​一​个​普通​人​无法​拥有​的​视觉​。​我​不​知道​它"
+"​有​什么​秘密​，​我​的​朋友​，​但​找到​这​块​石头​肯定​是​最​有​价值​的"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:233
@@ -8046,8 +8044,8 @@ msgid ""
 "sweetbreads that Garda has just finished baking. Shame what happened to "
 "them..."
 msgstr ""
-"商队在这里停了下来，为他们向东旅行带去一些补给。我卖给他们不少新鲜水果和一些"
-"佳达刚刚烤好的上等甜面包。可惜他们发生了什么"
+"商队​在​这里​停​了​下来​，​为​他们​向东​旅行​带​去​一些​补给​。​我​卖给​他们​不少​新鲜​水果​和​一些​佳"
+"达​刚刚​烤好​的​上​等​甜​面包​。​可惜​他们​发生​了​什么"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:235
@@ -8056,8 +8054,8 @@ msgid ""
 "I will say this. If rocks are falling from the sky, you had better be "
 "careful!"
 msgstr ""
-"我不知道他们以为用那块石头能看到什么，但我要说的是。如果岩石从天而降，你最好"
-"小心"
+"我​不​知道​他们​以为​用​那​块​石头​能​看到​什么​，​但​我​要​说​的​是​。​如果​岩石​从天而降​，​你​最好"
+"​小心"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:237
@@ -8069,10 +8067,10 @@ msgid ""
 "I don't see how you could hope to find anything that they would have been "
 "carrying."
 msgstr ""
-"好吧，一队重要人物停在这里，但那是很久以前的事了。我记得，他们的口音很奇怪，"
-"正开始长途旅行。\n"
+"好​吧​，​一​队​重要​人物​停​在​这里​，​但​那​是​很​久​以前​的​事​了​。​我​记得​，​他们​的​口音​很​"
+"奇怪​，​正​开始​长途​旅行​。​\n"
 " \n"
-"我不明白你怎么能指望找到他们会带的东西"
+"​我​不​明白​你​怎么​能​指望​找到​他们​会​带​的​东西"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:239
@@ -8085,17 +8083,17 @@ msgid ""
 "found. If you should find it, I believe that I can fashion something useful "
 "from it."
 msgstr ""
-"呆一会儿-我有个故事你可能会觉得有趣。一辆开往东方王国的大篷车前段时间经过这"
-"里。据说它带着一片落在地上的天空！大篷车就在这北边的公路上被披着斗篷的骑手伏"
-"击了。我在残骸中搜寻这块岩石，但找不到。如果你能找到它，我相信我能从中找到有"
-"用的东西"
+"呆​一会儿​-​我​有​个​故事​你​可能​会​觉得​有趣​。​一​辆​开往​东方​王国​的​大篷​车​前​段​时间​经过​这"
+"里​。​据说​它​带​着​一​片​落​在​地上​的​天空​！​大篷车​就​在​这​北​边​的​公路​上​被​披着​斗篷​的​骑"
+"手​伏击​了​。​我​在​残骸​中​搜寻​这​块​岩石​，​但​找​不​到​。​如果​你​能​找到​它​，​我​相信​我​能​"
+"从中​找到​有用​的​东西"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:241
 msgid ""
 "I am still waiting for you to bring me that stone from the heavens. I know "
 "that I can make something powerful out of it."
-msgstr "我还在等你从天上把那块石头带给我。我知道我能从中制造出强大的东西"
+msgstr "我​还​在​等​你​从天​上​把​那​块​石头​带给​我​。​我​知道​我​能​从中​制造​出​强大​的​东西"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold(Quest End)
 #: Source/textdat.cpp:243
@@ -8105,9 +8103,9 @@ msgid ""
 "Ah, Here you are. I arranged pieces of the stone within a silver ring that "
 "my father left me. I hope it serves you well."
 msgstr ""
-"让我看看-是的。。。是的，正如我所相信的。给我一点时间。。。\n"
+"让​我​看看​-​是​的​。​。​。​是​的​，​正​如​我​所​相信​的​。​给​我​一点​时间​。​。​。​\n"
 " \n"
-"啊，给你。我把几块石头放在父亲留给我的银戒指里。希望对你有好处"
+"​啊​，​给​你​。​我​把​几​块​石头​放​在​父亲​留给​我​的​银戒指里​。​希望​对​你​有​好处"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:245
@@ -8116,8 +8114,8 @@ msgid ""
 "green and red and silver. Don't remember what happened to it, though. I "
 "really miss that ring..."
 msgstr ""
-"我曾经有一个漂亮的戒指；这是一个非常昂贵的，蓝色，绿色，红色和银色。不过，我"
-"不记得发生了什么。我真的很想念那个戒指"
+"我​曾经​有​一​个​漂亮​的​戒指​；​这​是​一​个​非常​昂贵​的​，​蓝色​，​绿色​，​红色​和​银色​。​不过​，"
+"​我​不​记得​发生​了​什么​。​我​真的​很​想​念​那​个​戒指"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:247
@@ -8126,8 +8124,8 @@ msgid ""
 "find it, I would prevent it. He will harness its powers and its use will be "
 "for the good of us all."
 msgstr ""
-"天石是非常强大的，如果是任何人，但格里斯沃尔德谁叫你找到它，我会阻止它。他将"
-"利用它的力量，它的使用将造福于我们所有人"
+"天石​是​非常​强大​的​，​如果​是​任何​人​，​但​格里斯沃尔德​谁​叫​你​找到​它​，​我​会​阻止​它​。​他​将"
+"​利用​它​的​力量​，​它​的​使用​将​造福于​我们​所有​人"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:249
@@ -8136,8 +8134,8 @@ msgid ""
 "he is doing, and as much as I try to steal his customers, I respect the "
 "quality of his work."
 msgstr ""
-"如果有人能用那块石头做点什么，格里斯沃尔德也能。他知道自己在做什么，尽管我试"
-"图窃取他的客户，但我尊重他的工作质量"
+"如果​有​人​能​用​那​块​石头​做​点​什么​，​格里斯沃尔德​也​能​。​他​知道​自己​在​做​什么​，​尽管​我​试"
+"图​窃取​他​的​客户​，​但​我​尊重​他​的​工作​质量"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:251
@@ -8146,8 +8144,8 @@ msgid ""
 "as I do about Red Herrings. Perhaps Pepin the Healer could tell you more, "
 "but this is something that cannot be found in any of my stories or books."
 msgstr ""
-"女巫艾德莉亚想要一个黑蘑菇？我对黑蘑菇的了解和对红鲱鱼的了解一样多。也许治疗"
-"者佩金可以告诉你更多，但这是我的任何故事或书籍中都找不到的"
+"女​巫艾德莉亚​想要​一​个​黑​蘑菇​？​我​对​黑​蘑菇​的​了解​和​对​红鲱​鱼​的​了解​一样​多​。​也许​治疗者"
+"​佩金​可以​告诉​你​更​多​，​但​这​是​我​的​任何​故事​或​书籍​中​都​找​不​到​的"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:253
@@ -8157,8 +8155,8 @@ msgid ""
 "then that is her business, but I can't help you find any. Black mushrooms... "
 "disgusting!"
 msgstr ""
-"我就这么说吧。我和嘉达永远不会给我们的贵宾提供黑蘑菇。如果艾德莉亚想在炖菜里"
-"放些蘑菇，那是她的事，但我帮不了你。黑蘑菇。。。恶心"
+"我​就​这么​说​吧​。​我​和​嘉达​永远​不​会​给​我们​的​贵宾​提供​黑蘑菇​。​如果​艾德莉亚​想​在​炖菜​里​"
+"放些​蘑菇​，​那​是​她​的​事​，​但​我​帮​不​了​你​。​黑​蘑菇​。​。​。​恶心"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:255
@@ -8169,10 +8167,10 @@ msgid ""
 "that its alchemy holds. If you can remove the brain of a demon when you kill "
 "it, I would be grateful if you could bring it to me."
 msgstr ""
-"巫婆告诉我你在寻找一个恶魔的大脑来帮助我制造长生不老药。如果我能解开我怀疑它"
-"的炼金术所掌握的秘密，它对许多被这些邪恶野兽伤害的人来说应该是非常有价值的。"
-"如果你能在杀死一个恶魔的时候把它的大脑取出来，如果你能把它带给我，我将不胜感"
-"激"
+"巫婆​告诉​我​你​在​寻找​一​个​恶魔​的​大脑​来​帮助​我​制造​长生​不​老药​。​如果​我​能​解开​我​怀疑​它"
+"​的​炼金术​所​掌握​的​秘密​，​它​对​许多​被​这些​邪恶​野兽​伤害​的​人​来说​应该​是​非常​有​价值​的​。"
+"​如果​你​能​在​杀死​一​个​恶魔​的​时候​把​它​的​大脑取​出来​，​如果​你​能​把​它​带给​我​，​我​将​不"
+"胜​感激"
 
 #. TRANSLATORS: Quest dialog spoken by Pepin
 #: Source/textdat.cpp:257
@@ -8181,15 +8179,15 @@ msgid ""
 "without this, but it can't hurt to have this to study. Would you please "
 "carry this to the witch? I believe that she is expecting it."
 msgstr ""
-"太好了，这正是我想要的。没有这个我就可以完成长生不老药，但是有这个来学习也没"
-"什么坏处。请你把这个带给女巫好吗？我相信她在等着呢"
+"太​好​了​，​这​正​是​我​想要​的​。​没有​这个​我​就​可以​完成​长生不​老药​，​但是​有​这个​来​学习​也​"
+"没​什么​坏处​。​请​你​把​这个​带给​女​巫好​吗​？​我​相信​她​在​等​着​呢"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:259
 msgid ""
 "I think Ogden might have some mushrooms in the storage cellar. Why don't you "
 "ask him?"
-msgstr "我想奥格登的地窖里可能有蘑菇。你为什么不问问他"
+msgstr "我​想​奥格登​的​地窖​里​可能​有​蘑菇​。​你​为什么​不​问问​他"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:261
@@ -8198,9 +8196,9 @@ msgid ""
 "I can offer you no more help than that, but it sounds like... a huge, "
 "gargantuan, swollen, bloated mushroom! Well, good hunting, I suppose."
 msgstr ""
-"如果阿德里娅没有这些，你可以打赌这确实是一件罕见的事情。我不能给你更多的帮"
-"助，但是听起来。。。一个巨大的，巨大的，肿胀的，膨胀的蘑菇！嗯，我想打猎不错"
-"吧"
+"如果​阿德里娅​没有​这些​，​你​可以​打​赌​这​确实​是​一​件​罕见​的​事情​。​我​不​能​给​你​更​多​的​帮"
+"助​，​但是​听​起来​。​。​。​一​个​巨大​的​，​巨大​的​，​肿胀​的​，​膨胀​的​蘑菇​！​嗯​，​我​想​打猎"
+"​不错​吧"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:263
@@ -8208,8 +8206,8 @@ msgid ""
 "Ogden mixes a MEAN black mushroom, but I get sick if I drink that. Listen, "
 "listen... here's the secret - moderation is the key!"
 msgstr ""
-"奥格登混合了一种难吃的黑蘑菇，但如果我喝了它我会生病的。听着，听着。。。秘诀"
-"就在这里——适度才是关键"
+"奥格登​混合​了​一​种​难​吃​的​黑蘑菇​，​但​如果​我​喝​了​它​我​会​生病​的​。​听​着​，​听​着​。​。​"
+"。​秘诀​就​在​这里​——​适度​才​是​关键"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:265
@@ -8218,8 +8216,8 @@ msgid ""
 "your eyes open for a black mushroom. It should be fairly large and easy to "
 "identify. If you find it, bring it to me, won't you?"
 msgstr ""
-"我们这里有什么？有趣的是，它看起来像一本试剂书。睁大眼睛看黑蘑菇。它应该相当"
-"大，并且易于识别。如果你找到了，把它带给我，好吗"
+"我们​这里​有​什么​？​有趣​的​是​，​它​看​起来​像​一​本​试剂​书​。​睁大​眼睛​看黑​蘑菇​。​它​应该​相当"
+"​大​，​并且​易​于​识别​。​如果​你​找到​了​，​把​它​带给​我​，​好​吗"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:267
@@ -8227,8 +8225,8 @@ msgid ""
 "It's a big, black mushroom that I need. Now run off and get it for me so "
 "that I can use it for a special concoction that I am working on."
 msgstr ""
-"我需要一个又大又黑的蘑菇。现在跑去给我拿，这样我就可以用它做我正在做的一种特"
-"殊的调味品了"
+"我​需要​一​个​又​大​又​黑​的​蘑菇​。​现在​跑​去​给​我​拿​，​这样​我​就​可以​用​它​做​我​正在​做​的"
+"​一​种​特殊​的​调味品​了"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:269
@@ -8239,9 +8237,9 @@ msgid ""
 "intends to make an elixir from it. If you help him find what he needs, "
 "please see if you can get a sample of the elixir for me."
 msgstr ""
-"是的，这将是完美的酿造，我正在创建。顺便说一句，治疗者正在寻找某种恶魔的大"
-"脑，这样他就可以治疗那些被他们的毒液折磨的人。我相信他打算用它做长生不老药。"
-"如果你帮他找到他需要的东西，请你帮我拿一个长生不老药的样品"
+"是​的​，​这​将​是​完美​的​酿造​，​我​正在​创建​。​顺便​说​一​句​，​治疗者​正​在​寻找​某​种​恶魔​的​"
+"大脑​，​这样​他​就​可以​治疗​那些​被​他们​的​毒液​折磨​的​人​。​我​相信​他​打算​用​它​做​长生​不​老药"
+"​。​如果​你​帮​他​找到​他​需要​的​东西​，​请​你​帮​我​拿​一​个​长生​不​老药​的​样品"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:271
@@ -8251,9 +8249,9 @@ msgid ""
 "that grotesque organ that you are holding, and then bring me the elixir. "
 "Simple when you think about it, isn't it?"
 msgstr ""
-"你为什么把它带到这里来？我现在不需要恶魔的大脑。我确实需要一些治疗者正在研制"
-"的长生不老药。他需要你拿着的奇怪的器官，然后给我拿长生不老药。想起来很简单，"
-"不是吗"
+"你​为什么​把​它​带到​这里​来​？​我​现在​不​需要​恶魔​的​大脑​。​我​确实​需要​一些​治疗者​正​在​研制​的"
+"​长生​不​老药​。​他​需要​你​拿​着​的​奇怪​的​器官​，​然后​给​我​拿​长生​不​老药​。​想​起来​很​简单​"
+"，​不​是​吗"
 
 #. TRANSLATORS: Quest dialog spoken by Adria (Quest End)
 #: Source/textdat.cpp:273
@@ -8261,15 +8259,15 @@ msgid ""
 "What? Now you bring me that elixir from the healer? I was able to finish my "
 "brew without it. Why don't you just keep it..."
 msgstr ""
-"什么？现在你把医治者的长生不老药带给我？不用它我就能喝完我的啤酒。你为什么不"
-"留着它"
+"什么​？​现在​你​把​医治者​的​长生​不​老​药​带给​我​？​不用​它​我​就​能​喝​完​我​的​啤酒​。​你​为什么"
+"​不​留​着​它"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:275
 msgid ""
 "I don't have any mushrooms of any size or color for sale. How about "
 "something a bit more useful?"
-msgstr "我没有任何大小和颜色的蘑菇出售。再来点有用的怎么样"
+msgstr "我​没有​任何​大小​和​颜色​的​蘑菇​出售​。​再​来​点​有用​的​怎么样"
 
 #. TRANSLATORS: Quest dialog spoken by Cain (currently unused)
 #: Source/textdat.cpp:277
@@ -8294,27 +8292,26 @@ msgid ""
 "before the stars align, for we may never have a chance to rid the world of "
 "his evil again!"
 msgstr ""
-"所以，地图上的传说是真实的。连我都不相信！我想是时候告诉你我是谁了，我的朋"
-"友。你看，我并不像我看起来那样。。。\n"
+"所以​，​地图​上​的​传说​是​真实​的​。​连​我​都​不​相信​！​我​想​是​时候​告诉​你​我​是​谁​了​，​我​"
+"的​朋友​。​你​看​，​我​并不​像​我​看​起来​那样​。​。​。​\n"
 " \n"
-"我的真名是老凯恩，我是一个古老兄弟会的最后一个后代，这个兄弟会致力于保守和保"
-"护一个永恒邪恶的秘密。一个很明显已经被释放的恶魔。。。\n"
+"​我​的​真名​是​老凯恩​，​我​是​一​个​古老​兄弟会​的​最后​一​个​后代​，​这​个​兄弟​会​致力于​保守​和​"
+"保护​一​个​永恒​邪恶​的​秘密​。​一​个​很​明显​已经​被​释放​的​恶魔​。​。​。​\n"
 " \n"
-"你要对付的恶魔是恐怖的黑魔王——凡人都知道的迪亚波罗。几个世纪前被囚禁在迷宫里"
-"的正是他。你现在持有的地图是很久以前创造的，用来标记迪亚波罗从监禁中复活的时"
-"间。当那张地图上的两颗星星对齐时，迪亚波罗将达到他的能量顶峰。他将所向无"
-"敌。。。\n"
+"​你​要​对付​的​恶魔​是​恐怖​的​黑魔王​——​凡​人​都​知道​的​迪亚波罗​。​几​个​世纪​前​被​囚禁​在​迷宫"
+"​里​的​正​是​他​。​你​现在​持有​的​地图​是​很​久​以前​创造​的​，​用来​标记迪亚波罗​从​监禁​中​复活​的"
+"​时间​。​当​那​张​地图​上​的​两​颗​星星​对​齐​时​，​迪亚波罗​将​达到​他​的​能量​顶峰​。​他​将​所​向"
+"​无敌​。​。​。​\n"
 " \n"
-"你现在在和时间赛跑，我的朋友！找到迪亚波罗，在众星云集之前消灭他，因为我们可"
-"能再也没有机会摆脱他的邪恶了"
+"​你​现在​在​和​时间​赛跑​，​我​的​朋友​！​找到​迪亚波罗​，​在​众​星云集​之前​消灭​他​，​因为​我们​可能"
+"​再​也​没有​机会​摆脱​他​的​邪恶​了"
 
 #. TRANSLATORS: Quest dialog spoken by Cain (currently unused)
 #: Source/textdat.cpp:279
 msgid ""
 "Our time is running short! I sense his dark power building and only you can "
 "stop him from attaining his full might."
-msgstr ""
-"我们的时间不多了！我感觉到了他的黑暗力量，只有你才能阻止他达到他的全部力量"
+msgstr "我们​的​时间​不​多​了​！​我​感觉​到​了​他​的​黑暗​力量​，​只有​你​才​能​阻止​他​达到​他​的​全部​力量"
 
 #. TRANSLATORS: Quest dialog spoken by Cain (currently unused)
 #: Source/textdat.cpp:281
@@ -8324,9 +8321,9 @@ msgid ""
 "and you will need all your courage and strength to defeat him. May the Light "
 "protect and guide you, my friend. I will help in any way that I am able."
 msgstr ""
-"我相信你已经尽力了，但我担心你的力量和意志都不够。迪亚波罗现在正处于他尘世力"
-"量的顶峰，你将需要你所有的勇气和力量来打败他。愿光明保护和指引你，我的朋友。"
-"我将尽我所能提供帮助。"
+"我​相信​你​已经​尽力​了​，​但​我​担心​你​的​力量​和​意志​都​不​够​。​迪亚波罗​现在​正​处于​他​尘世​力"
+"量​的​顶峰​，​你​将​需要​你​所有​的​勇气​和​力量​来​打败​他​。​愿​光明​保护​和​指引​你​，​我​的​朋友"
+"​。​我​将​尽​我​所​能​提供​帮助​。"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden (currently unused)
 #: Source/textdat.cpp:283
@@ -8335,8 +8332,8 @@ msgid ""
 "that I would know anything? It sounds like this is a very serious matter. "
 "You should hurry along and see the storyteller as Adria suggests."
 msgstr ""
-"如果女巫帮不了你，建议你去见凯恩，你凭什么认为我什么都知道？听起来这是一件非"
-"常严重的事情。你应该像艾德莉亚建议的那样，赶快去见讲故事的人"
+"如果​女​巫帮​不​了​你​，​建议​你​去见凯恩​，​你​凭​什么​认为​我​什么​都​知道​？​听​起来​这​是​一​件​"
+"非常​严重​的​事情​。​你​应该​像​艾德莉亚​建议​的​那样​，​赶快​去​见​讲​故事​的​人"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin (currently unused)
 #: Source/textdat.cpp:285
@@ -8347,9 +8344,9 @@ msgid ""
 "I can see that it is a map of the stars in our sky, but any more than that "
 "is beyond my talents."
 msgstr ""
-"我对这张地图上的文字不太了解，但也许艾德莉亚或凯恩能帮你破译这是指什么。\n"
+"我​对​这​张​地图​上​的​文字​不​太​了解​，​但​也许​艾德莉亚​或​凯恩​能​帮​你​破译​这​是​指​什么​。​\n"
 " \n"
-"我可以看到这是一张我们天空中星星的地图，但比这更是超出我的能力"
+"​我​可以​看到​这​是​一​张​我们​天空​中​星星​的​地图​，​但​比​这​更​是​超出​我​的​能力"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian (currently unused)
 #: Source/textdat.cpp:287
@@ -8359,9 +8356,9 @@ msgid ""
 "Cain is very knowledgeable about ancient writings, and that is easily the "
 "oldest looking piece of paper that I have ever seen."
 msgstr ""
-"问这类事情的最佳人选是我们的说书人。\n"
+"问​这​类​事情​的​最​佳​人选​是​我们​的​说书​人​。​\n"
 " \n"
-"凯恩对古代著作非常了解，这是我见过的最古老的一张纸"
+"凯恩​对​古代​著作​非常​了解​，​这​是​我​见​过​的​最​古老​的​一​张​纸"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold (currently unused)
 #: Source/textdat.cpp:289
@@ -8370,8 +8367,8 @@ msgid ""
 "have no idea how to read this, Cain or Adria may be able to provide the "
 "answers that you seek."
 msgstr ""
-"我以前从未见过这样的地图。你从哪儿弄来的？虽然我不知道该怎么读这篇文章，但凯"
-"恩或艾德莉亚也许能提供你所寻求的答案"
+"我​以前​从​未​见​过​这样​的​地图​。​你​从​哪儿​弄来​的​？​虽然​我​不​知道​该​怎么​读​这​篇​文章​，​"
+"但​凯恩​或​艾德莉亚​也许​能​提供​你​所​寻求​的​答案"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham (currently unused)
 #: Source/textdat.cpp:291
@@ -8379,8 +8376,8 @@ msgid ""
 "Listen here, come close. I don't know if you know what I know, but you have "
 "really got somethin' here. That's a map."
 msgstr ""
-"听着，靠近点。我不知道你是否知道我所知道的，但你真的有些东西在这里。那是一张"
-"地图"
+"听​着​，​靠近点​。​我​不​知道​你​是否​知道​我​所​知道​的​，​但​你​真的​有些​东西​在​这里​。​那​是​一"
+"​张​地图"
 
 #. TRANSLATORS: Quest dialog spoken by Adria (currently unused)
 #: Source/textdat.cpp:293
@@ -8389,8 +8386,8 @@ msgid ""
 "portends great disaster, but its secrets are not mine to tell. The time has "
 "come for you to have a very serious conversation with the Storyteller..."
 msgstr ""
-"哦，恐怕这一点都不是好兆头。这张星图预示着巨大的灾难，但它的秘密不是我说的。"
-"是时候让你和讲故事的人好好谈谈了"
+"哦​，​恐怕​这​一点​都​不​是​好​兆头​。​这​张​星图​预示​着​巨大​的​灾难​，​但​它​的​秘密不​是​我​说​"
+"的​。​是​时候​让​你​和​讲​故事​的​人​好好​谈​谈​了"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt (currently unused)
 #: Source/textdat.cpp:295
@@ -8399,14 +8396,14 @@ msgid ""
 "that to Adria - she can probably tell you what it is. I'll say one thing; it "
 "looks old, and old usually means valuable."
 msgstr ""
-"我一直在找地图，但那肯定不是。你应该把这个给艾德莉亚看-她可能会告诉你是什么。"
-"我要说一件事；它看起来很老，而且老通常意味着有价值"
+"我​一直​在​找​地图​，​但​那​肯定​不是​。​你​应该​把​这个​给​艾德莉亚​看-​她​可能​会​告诉​你​是​什么​"
+"。​我​要​说​一​件​事​；​它​看​起来​很​老​，​而且​老​通常​意味​着​有​价值"
 
 #. TRANSLATORS: Quest dialog spoken by Gharbad the Weak
 #: Source/textdat.cpp:297
 msgid ""
 "Pleeeease, no hurt. No Kill. Keep alive and next time good bring to you."
-msgstr "请放心，不要受伤。不杀人。保持活力，下次给你带来好东西"
+msgstr "请​放心​，​不​要​受伤​。​不​杀人​。​保持​活力​，​下​次​给​你​带来​好​东西"
 
 #. TRANSLATORS: Quest dialog spoken by Gharbad the Weak
 #: Source/textdat.cpp:299
@@ -8416,9 +8413,9 @@ msgid ""
 " \n"
 "You take this as proof I keep word..."
 msgstr ""
-"我正在为你做些东西。再说一遍，别杀了加尔巴德。活得好好的。\n"
+"我​正在​为​你​做​些​东西​。​再说​一​遍​，​别​杀​了​加尔巴德​。​活​得​好好​的​。​\n"
 " \n"
-"你把这当作我遵守诺言的证据"
+"​你​把​这​当作​我​遵守​诺言​的​证据"
 
 #. TRANSLATORS: Quest dialog spoken by Gharbad the Weak
 #: Source/textdat.cpp:301
@@ -8429,16 +8426,16 @@ msgid ""
 " \n"
 "No pain and promise I keep!"
 msgstr ""
-"还没有！差不多了。\n"
+"还​没有​！​差不​多​了​。​\n"
 " \n"
-"非常强大，非常强大。居住居住\n"
+"​非常​强大​，​非常​强大​。​居住​居住​\n"
 " \n"
-"没有痛苦，我信守诺言"
+"​没有​痛苦​，​我​信守​诺言"
 
 #. TRANSLATORS: Quest dialog spoken by Gharbad the Weak (Hostile)
 #: Source/textdat.cpp:303
 msgid "This too good for you. Very Powerful! You want - you take!"
-msgstr "这对你来说太好了。非常强大！你想要-你拿"
+msgstr "这​对​你​来说​太​好​了​。​非常​强大​！​你​想要​-​你​拿"
 
 #. TRANSLATORS: Quest dialog spoken by Zhar the Mad (annoyed / Hostile)
 #: Source/textdat.cpp:305
@@ -8446,18 +8443,18 @@ msgid ""
 "What?! Why are you here? All these interruptions are enough to make one "
 "insane. Here, take this and leave me to my work. Trouble me no more!"
 msgstr ""
-"什么？！你为什么在这里？所有这些干扰都足以让人发疯。来，拿着这个，让我继续工"
-"作。别再烦我了"
+"什么​？​！​你​为什么​在​这里​？​所有​这些​干扰​都​足以​让​人​发疯​。​来​，​拿​着​这个​，​让​我​继续​"
+"工作​。​别​再​烦​我​了"
 
 #. TRANSLATORS: Quest dialog spoken by Zhar the Mad (Hostile)
 #: Source/textdat.cpp:307
 msgid "Arrrrgh! Your curiosity will be the death of you!!!"
-msgstr "啊！你的好奇心将是你的死亡"
+msgstr "啊​！​你​的​好奇心​将​是​你​的​死亡"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain
 #: Source/textdat.cpp:308
 msgid "Hello, my friend. Stay awhile and listen..."
-msgstr "你好，我的朋友。呆一会儿听我说"
+msgstr "你​好​，​我​的​朋友​。​呆​一会儿​听​我​说"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:309
@@ -8467,9 +8464,9 @@ msgid ""
 " \n"
 "Read them carefully for they can tell you things that even I cannot."
 msgstr ""
-"当你冒险深入迷宫时，你可能会发现那里藏着大量的知识。\n"
+"当​你​冒险​深入​迷宫​时​，​你​可能​会​发现​那里​藏​着​大量​的​知识​。​\n"
 " \n"
-"仔细阅读它们，因为它们能告诉你即使是我也不能告诉你的事情"
+"​仔细​阅读​它们​，​因为​它们​能​告诉​你​即使​是​我​也​不​能​告诉​你​的​事情"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:311
@@ -8479,8 +8476,8 @@ msgid ""
 "and questions to which you seek knowledge, seek me out and I will tell you "
 "what I can."
 msgstr ""
-"我知道许多神话和传说，其中可能包含对你在迷宫之旅中可能出现的问题的答案。如果"
-"你遇到挑战和问题，你寻求知识，寻找我出来，我会告诉你我能做什么"
+"我​知道​许多​神话​和​传说​，​其中​可能​包含​对​你​在​迷宫​之​旅​中​可能​出现​的​问题​的​答案​。​如果​"
+"你​遇到​挑战​和​问题​，​你​寻求​知识​，​寻找​我​出来​，​我​会​告诉​你​我​能​做​什么"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:313
@@ -8491,9 +8488,9 @@ msgid ""
 "is a skilled craftsman, and if he claims to be able to help you in any way, "
 "you can count on his honesty and his skill."
 msgstr ""
-"格里斯沃尔德——一个行动力和勇气都很强的人。我打赌他从没告诉过你他进迷宫救怀特"
-"的事，是吗？他知道在那里会有很多危险，但话说回来，你也是。他是一个技艺高超的"
-"工匠，如果他声称能以任何方式帮助你，你可以指望他的诚实和他的技能"
+"格里斯沃尔德​——​一​个​行动力​和​勇气​都​很​强​的​人​。​我​打​赌​他​从​没​告诉​过​你​他​进迷宫​救怀特"
+"​的​事​，​是​吗​？​他​知道​在​那里​会​有​很多​危险​，​但​话​说​回来​，​你​也是​。​他​是​一​个​技艺"
+"​高超​的​工匠​，​如果​他​声称​能​以​任何​方式​帮助​你​，​你​可以​指望​他​的​诚实​和​他​的​技能"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:315
@@ -8504,9 +8501,9 @@ msgid ""
 "all they had in making a life for themselves here. He is a good man with a "
 "deep sense of responsibility."
 msgstr ""
-"奥格登已经拥有和经营旭日酒店近四年了。他买了它就在几个月前，这里的一切都变成"
-"了地狱。他和他的妻子加尔达没有钱离开，因为他们把所有的钱都投资在这里为自己创"
-"造生活。他是一个很有责任感的好人"
+"奥格登​已经​拥有​和​经营​旭日​酒店​近​四​年​了​。​他​买​了​它​就​在​几​个​月​前​，​这里​的​一切​都​"
+"变成​了​地狱​。​他​和​他​的​妻子​加尔达​没有​钱​离开​，​因为​他们​把​所有​的​钱​都​投资​在​这里​为​自"
+"己​创造​生活​。​他​是​一​个​很​有​责任感​的​好​人"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:317
@@ -8517,10 +8514,10 @@ msgid ""
 "He finds comfort only at the bottom of his tankard nowadays, but there are "
 "occasional bits of truth buried within his constant ramblings."
 msgstr ""
-"可怜的法恩汉。他令人不安地提醒人们，在那黑暗的一天，注定要与拉扎鲁斯一起进入"
-"大教堂的集会。他带着生命逃走了，但他的勇气和大部分的理智都留在了某个黑暗的坑"
-"里。如今，他只在酒馆的最底层找到安慰，但在他不断的闲谈中，偶尔也隐藏着一些真"
-"相"
+"可怜​的​法恩汉​。​他​令​人​不安​地​提醒​人们​，​在​那​黑暗​的​一​天​，​注定​要​与​拉扎鲁斯一起​进入​大"
+"​教堂​的​集会​。​他​带​着​生命​逃走​了​，​但​他​的​勇气​和​大部分​的​理智​都​留​在​了​某​个​黑暗​的"
+"​坑​里​。​如今​，​他​只​在​酒馆​的​最​底​层​找到​安慰​，​但​在​他​不断​的​闲谈​中​，​偶尔​也​隐藏​"
+"着​一些​真相"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:319
@@ -8531,9 +8528,9 @@ msgid ""
 "access to many strange and arcane artifacts and tomes of knowledge that even "
 "I have never seen before."
 msgstr ""
-"女巫艾德莉亚是崔斯特姆的一个异类。她是在大教堂被亵渎后不久到达的，而大多数人"
-"都在逃离。她在城镇边缘建了一间小屋，似乎是一夜之间建成的，她能接触到许多奇怪"
-"而神秘的文物和知识的大部头，连我都从未见过"
+"女​巫艾德莉亚​是​崔斯特姆​的​一​个​异类​。​她​是​在​大​教堂​被​亵渎​后​不久​到达​的​，​而​大多数​人​都"
+"​在​逃离​。​她​在​城镇​边缘​建​了​一​间​小​屋​，​似乎​是​一​夜​之间​建成​的​，​她​能​接触​到​许多​"
+"奇怪​而​神秘​的​文物​和​知识​的​大部头​，​连​我​都​从​未​见​过"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:321
@@ -8545,10 +8542,10 @@ msgid ""
 "never returned. The Blacksmith found the boy, but only after the foul beasts "
 "had begun to torture him for their sadistic pleasures."
 msgstr ""
-"怀特的故事是一个可怕而悲惨的故事。他从他母亲的怀抱中被带到迷宫里，被那些挥舞"
-"邪恶长矛的邪恶小恶魔们拖进了迷宫。那天还有许多孩子被带走，包括李奥瑞克国王的"
-"儿子。宫殿的骑士们下楼去了，但再也没有回来。铁匠找到了那个男孩，但那是在那些"
-"邪恶的野兽开始折磨他以获取他们的虐待狂般的快乐之后"
+"怀特​的​故事​是​一​个​可怕​而​悲惨​的​故事​。​他​从​他​母亲​的​怀抱​中​被​带到​迷宫​里​，​被​那些​挥"
+"舞​邪恶​长矛​的​邪恶​小​恶魔们​拖进​了​迷宫​。​那​天​还​有​许多​孩子​被​带走​，​包括​李奥瑞克​国王​的​"
+"儿子​。​宫殿​的​骑士们​下楼​去​了​，​但​再​也​没有​回来​。​铁匠​找到​了​那个​男孩​，​但​那​是​在​那些"
+"​邪恶​的​野兽​开始​折磨​他​以​获取​他们​的​虐待​狂般​的​快乐​之后"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:323
@@ -8558,9 +8555,9 @@ msgid ""
 "existed. His knowledge and skills are equaled by few, and his door is always "
 "open."
 msgstr ""
-"啊，佩金。我把他视为真正的朋友——也许是我在这里最亲密的朋友。他有时有点烦躁不"
-"安，但从来没有一个更关心和体贴的灵魂存在过。他的知识和技能为数不多，他的大门"
-"总是敞开的"
+"啊​，​佩金​。​我​把​他​视为​真正​的​朋友​——​也许​是​我​在​这里​最​亲密​的​朋友​。​他​有时​有点​烦躁"
+"不安​，​但​从来​没有​一​个​更​关心​和​体贴​的​灵魂​存在​过​。​他​的​知识​和​技能​为数​不​多​，​他​的"
+"​大门​总是​敞开​的"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:325
@@ -8571,14 +8568,14 @@ msgid ""
 "for her safety, but I know that any man in the village would rather die than "
 "see her harmed."
 msgstr ""
-"吉莉安是个好女人。她因兴高采烈和爽朗的笑声而备受崇拜，在我心中占有特殊的地"
-"位。她留在酒馆里养活年迈的祖母，因为她病得不能旅行了。我有时担心她的安全，但"
-"我知道村里的任何男人都宁愿死也不愿看到她受到伤害"
+"吉莉安​是​个​好​女人​。​她​因兴​高采烈​和​爽朗​的​笑声​而​备受​崇拜​，​在​我​心​中​占有​特殊​的​地位​"
+"。​她​留​在​酒馆​里​养活​年迈​的​祖母​，​因为​她​病得​不​能​旅行​了​。​我​有时​担心​她​的​安全​，​但"
+"​我​知道​村​里​的​任何​男人​都​宁愿​死​也​不​愿​看到​她​受到​伤害"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden
 #: Source/textdat.cpp:327
 msgid "Greetings, good master. Welcome to the Tavern of the Rising Sun!"
-msgstr "你好，好师父。欢迎来到朝阳酒馆"
+msgstr "你​好​，​好​师父​。​欢迎​来到​朝阳​酒馆"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden (Gossip)
 #: Source/textdat.cpp:329
@@ -8588,8 +8585,8 @@ msgid ""
 "any of them agree on was this old axiom. Perhaps it will help you. You can "
 "cut the flesh, but you must crush the bone."
 msgstr ""
-"我的酒馆里有许多冒险家，讲的故事是喝啤酒的十倍。我唯一听到他们一致同意的就是"
-"这条古老的公理。也许这对你有帮助。你可以割肉，但必须压碎骨头"
+"我​的​酒馆​里​有​许多​冒险家​，​讲​的​故事​是​喝​啤酒​的​十​倍​。​我​唯一​听到​他们​一致​同意​的​就​"
+"是​这​条​古老​的​公理​。​也许​这​对​你​有​帮助​。​你​可以​割肉​，​但​必须​压碎​骨头"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden (Gossip)
 #: Source/textdat.cpp:331
@@ -8597,8 +8594,8 @@ msgid ""
 "Griswold the blacksmith is extremely knowledgeable about weapons and armor. "
 "If you ever need work done on your gear, he is definitely the man to see."
 msgstr ""
-"铁匠格里斯沃尔德对武器和护甲非常了解。如果你需要修理你的装备，他绝对是你要找"
-"的人"
+"铁匠​格里斯沃尔德​对​武器​和​护甲​非常​了解​。​如果​你​需要​修理​你​的​装备​，​他​绝对​是​你​要​找​的​"
+"人"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden (Gossip)
 #: Source/textdat.cpp:333
@@ -8606,8 +8603,8 @@ msgid ""
 "Farnham spends far too much time here, drowning his sorrows in cheap ale. I "
 "would make him leave, but he did suffer so during his time in the Labyrinth."
 msgstr ""
-"法恩汉在这里待的时间太长了，他用廉价的啤酒来消愁。我想让他离开，但他在迷宫里"
-"的时候确实很痛苦"
+"法恩汉​在​这里​待​的​时间​太​长​了​，​他​用​廉价​的​啤酒​来​消愁​。​我​想​让​他​离开​，​但​他​在​迷"
+"宫​里​的​时候​确实​很​痛苦"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden (Gossip)
 #: Source/textdat.cpp:335
@@ -8618,16 +8615,16 @@ msgid ""
 "Well, no matter. If you ever have need to trade in items of sorcery, she "
 "maintains a strangely well-stocked hut just across the river."
 msgstr ""
-"艾德莉亚的智慧超过了她的年龄，但我必须承认——她有点吓到我了。\n"
+"艾德莉亚​的​智慧​超过​了​她​的​年龄​，​但​我​必须​承认​——​她​有点​吓​到​我​了​。​\n"
 " \n"
-"好吧，没关系。如果你需要交易巫术物品，她在河对岸有一个奇怪的仓库"
+"​好​吧​，​没​关系​。​如果​你​需要​交易​巫术​物品​，​她​在​河​对岸​有​一​个​奇怪​的​仓库"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden (Gossip)
 #: Source/textdat.cpp:337
 msgid ""
 "If you want to know more about the history of our village, the storyteller "
 "Cain knows quite a bit about the past."
-msgstr "如果你想更多地了解我们村子的历史，讲故事的凯恩对过去的事相当了解"
+msgstr "如果​你​想​更​多​地​了解​我们​村子​的​历史​，​讲​故事​的​凯恩​对​过去​的​事​相当​了解"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden (Gossip)
 #: Source/textdat.cpp:339
@@ -8638,9 +8635,9 @@ msgid ""
 "He probably went fooling about someplace that he shouldn't have been. I feel "
 "sorry for the boy, but I don't abide the company that he keeps."
 msgstr ""
-"怀特是个说唱歌手和小流氓。他总是惹麻烦，发生在他身上的事也就不足为奇了。\n"
+"怀特​是​个​说​唱​歌手​和​小​流氓​。​他​总是​惹​麻烦​，​发生​在​他​身​上​的​事​也​就​不足为奇​了​。​\n"
 " \n"
-"他可能去了一个他不该去的地方。我为那个男孩感到难过，但我不愿意和他作伴"
+"​他​可能​去​了​一​个​他​不​该​去​的​地方​。​我​为​那个​男孩​感到​难过​，​但​我​不​愿意​和​他​作伴"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden (Gossip)
 #: Source/textdat.cpp:341
@@ -8649,8 +8646,8 @@ msgid ""
 "always attending to the needs of others, but trouble of some sort or another "
 "does seem to follow him wherever he goes..."
 msgstr ""
-"佩金是个好人，当然也是村里最慷慨的人。他总是关心别人的需要，但无论他走到哪"
-"里，总有一些麻烦跟着他"
+"佩金​是​个​好​人​，​当然​也​是​村​里​最​慷慨​的​人​。​他​总是​关心​别人​的​需要​，​但​无论​他​走到​"
+"哪里​，​总​有​一些​麻烦​跟着​他"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden (Gossip)
 #: Source/textdat.cpp:343
@@ -8661,14 +8658,14 @@ msgid ""
 "Goodness knows I begged her to leave, telling her that I would watch after "
 "the old woman, but she is too sweet and caring to have done so."
 msgstr ""
-"吉莉安，我的酒吧女招待？如果不是因为她对大坝的责任感，她早就从这里逃走了。\n"
+"吉莉安​，​我​的​酒吧​女​招待​？​如果​不​是​因为​她​对​大坝​的​责任感​，​她​早​就​从​这里​逃走​了​。​\n"
 " \n"
-"天知道我求她离开，告诉她我会照顾那个老妇人，但她太可爱了，太体贴了"
+"天​知道​我​求​她​离开​，​告诉​她​我​会​照顾​那​个​老​妇人​，​但​她​太​可爱​了​，​太​体贴​了"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin
 #: Source/textdat.cpp:345
 msgid "What ails you, my friend?"
-msgstr "你怎么了，我的朋友？"
+msgstr "你​怎么​了​，​我​的​朋友​？"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:346
@@ -8678,8 +8675,8 @@ msgid ""
 "hurt one of the monsters, make sure it is dead or it very well may "
 "regenerate itself."
 msgstr ""
-"我有一个非常有趣的发现。与我们不同的是，迷宫中的生物不用药水或魔法就能自愈。"
-"如果你伤害了其中一个怪物，确保它已经死了，否则它很可能会自己再生"
+"我​有​一​个​非常​有趣​的​发现​。​与​我们​不同​的​是​，​迷宫​中​的​生物​不​用药​水​或​魔法​就​能​自愈"
+"​。​如果​你​伤害​了​其中​一​个​怪物​，​确保​它​已经​死​了​，​否则​它​很​可能​会​自己​再生"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:348
@@ -8689,8 +8686,8 @@ msgid ""
 "any, you should read them all, for some may hold secrets to the workings of "
 "the Labyrinth."
 msgstr ""
-"在它被下面隐藏的东西接管之前，大教堂是一个非常有学问的地方。那里有许多书可以"
-"找到。如果你发现了什么，你应该把它们全部读一遍，因为有些可能掌握着迷宫运作的"
+"在​它​被​下面​隐藏​的​东西​接管​之前​，​大​教堂​是​一​个​非常​有​学问​的​地方​。​那里​有​许多书​可以​"
+"找到​。​如果​你​发现​了​什么​，​你​应该​把​它们​全部​读​一​遍​，​因为​有些​可能​掌握​着​迷宫​运作​的​"
 "秘密"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
@@ -8700,8 +8697,8 @@ msgid ""
 "healing. He is a shrewd merchant, but his work is second to none. Oh, I "
 "suppose that may be because he is the only blacksmith left here."
 msgstr ""
-"格里斯沃尔德对战争艺术的了解和我对治疗艺术的了解一样多。他是个精明的商人，但"
-"他的工作是首屈一指的。哦，我想那可能是因为他是这里唯一的铁匠"
+"格里斯沃尔德​对​战争​艺术​的​了解​和​我​对​治疗​艺术​的​了解​一样​多​。​他​是​个​精明​的​商人​，​但​他"
+"​的​工作​是​首屈一指​的​。​哦​，​我​想​那​可能​是​因为​他​是​这里​唯一​的​铁匠"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:352
@@ -8710,8 +8707,8 @@ msgid ""
 "an innate ability to discern the true nature of many things. If you ever "
 "have any questions, he is the person to go to."
 msgstr ""
-"凯恩是一个真正的朋友和智慧的圣人。他拥有一个庞大的图书馆，有一种与生俱来的能"
-"力来辨别许多事物的本质。如果你有任何问题，他就是你要找的人"
+"凯恩​是​一​个​真正​的​朋友​和​智慧​的​圣人​。​他​拥有​一​个​庞大​的​图书馆​，​有​一​种​与生俱来​的​能"
+"力​来​辨别​许多​事物​的​本质​。​如果​你​有​任何​问题​，​他​就​是​你​要​找​的​人"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:354
@@ -8719,8 +8716,8 @@ msgid ""
 "Even my skills have been unable to fully heal Farnham. Oh, I have been able "
 "to mend his body, but his mind and spirit are beyond anything I can do."
 msgstr ""
-"就连我的技能也无法完全治愈法恩汉。哦，我已经能修好他的身体了，但是他的精神和"
-"精神我无能为力"
+"就​连​我​的​技能​也​无法​完全​治​愈法恩汉​。​哦​，​我​已经​能​修好​他​的​身体​了​，​但是​他​的​精神​"
+"和​精神​我​无​能​为力"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:356
@@ -8731,9 +8728,9 @@ msgid ""
 "be much more than the hovel it appears to be, but I can never seem to get "
 "inside the place."
 msgstr ""
-"当我使用一些有限的魔法来创造我储存在这里的药剂和长生不老药时，艾德莉亚是一个"
-"真正的女巫。她似乎从不睡觉，她总是能接触到许多神秘的大部头和文物。我相信她的"
-"小屋可能比看上去的小屋要大得多，但我似乎永远也进不了这个地方"
+"当​我​使用​一些​有限​的​魔法​来​创造​我​储​存​在​这里​的​药剂​和​长生​不​老药​时​，​艾德莉亚​是​一​个"
+"​真正​的​女巫​。​她​似乎​从​不​睡觉​，​她​总是​能​接触​到​许多​神秘​的​大部头​和​文物​。​我​相信​她​"
+"的​小屋​可能​比​看​上去​的​小屋​要​大​得​多​，​但​我​似乎​永远​也​进​不​了​这个​地方"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:358
@@ -8743,8 +8740,8 @@ msgid ""
 "hideous. No one - and especially such a young child - should have to suffer "
 "the way he did."
 msgstr ""
-"可怜的怀特。我为那孩子做了一切可能的事，但我知道他看不起我被迫绑在他腿上的木"
-"钉。他的伤口很难看。没有人——尤其是这么小的孩子——应该像他那样受苦"
+"可怜​的​怀特​。​我​为​那​孩子​做​了​一切​可能​的​事​，​但​我​知道​他​看​不​起​我​被迫​绑​在​他​腿上"
+"​的​木钉​。​他​的​伤口​很​难​看​。​没有​人​——​尤其是​这么​小​的​孩子​——​应该​像​他​那样​受​苦"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:360
@@ -8755,9 +8752,9 @@ msgid ""
 "many murders that happen in the surrounding countryside, or perhaps the "
 "wishes of his wife that keep him and his family where they are."
 msgstr ""
-"我真不明白奥格登为什么留在崔斯特姆。他有点紧张，但他是一个聪明而勤奋的人，无"
-"论他去哪里都会做得很好。我想可能是因为害怕周围农村发生的许多谋杀案，也可能是"
-"因为他妻子的愿望，他和他的家人一直呆在那里"
+"我​真​不​明白​奥格登​为什么​留​在​崔斯特姆​。​他​有点​紧张​，​但​他​是​一​个​聪明​而​勤奋​的​人​，​无"
+"论​他​去​哪里​都​会​做​得​很​好​。​我​想​可能​是​因为​害怕​周围​农村​发生​的​许多​谋杀案​，​也​可能​"
+"是​因为​他​妻子​的​愿望​，​他​和​他​的​家人​一直​呆​在​那里"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:362
@@ -8768,21 +8765,21 @@ msgid ""
 "She claims that they are visions, but I have no proof of that one way or the "
 "other."
 msgstr ""
-"奥格登的酒吧女招待是个可爱的女孩。她祖母病得很重，有妄想症。\n"
+"奥格登​的​酒吧​女​招待​是​个​可爱​的​女孩​。​她​祖母​病​得​很​重​，​有​妄想症​。​\n"
 " \n"
-"她声称那是幻觉，但我没有证据证明这一点"
+"​她​声称​那​是​幻觉​，​但​我​没有​证据​证明​这​一​点"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian
 #: Source/textdat.cpp:364
 msgid "Good day! How may I serve you?"
-msgstr "你好！有什么我能为您效劳吗？"
+msgstr "你​好​！​有​什么​我​能​为​您​效劳​吗​？"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian (Gossip)
 #: Source/textdat.cpp:365
 msgid ""
 "My grandmother had a dream that you would come and talk to me. She has "
 "visions, you know and can see into the future."
-msgstr "我祖母梦见你来和我说话。她有远见卓识，你知道，而且能预见未来"
+msgstr "我​祖母​梦​见​你​来​和​我​说话​。​她​有​远见​卓识​，​你​知道​，​而且​能​预见​未来"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian (Gossip)
 #: Source/textdat.cpp:367
@@ -8793,10 +8790,10 @@ msgid ""
 "It would take someone quite brave, like you, to see what she is doing out "
 "there."
 msgstr ""
-"镇边的那个女人是个女巫！她看起来很好，她的名字叫艾德莉亚，很讨人喜欢，但我很"
-"害怕她。\n"
+"镇​边​的​那​个​女人​是​个​女巫​！​她​看​起来​很​好​，​她​的​名字​叫​艾德莉亚​，​很​讨人​喜欢​，​但​"
+"我​很​害怕​她​。​\n"
 " \n"
-"像你这样勇敢的人才能看到她在外面干什么"
+"像​你​这样​勇敢​的​人才​能​看到​她​在​外面​干​什么"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian (Gossip)
 #: Source/textdat.cpp:369
@@ -8806,17 +8803,16 @@ msgid ""
 "received praises from our King Leoric himself - may his soul rest in peace. "
 "Griswold is also a great hero; just ask Cain."
 msgstr ""
-"我们的铁匠是崔斯特姆人民的骄傲。他不仅是一个手艺大师，在他的行会中赢得了许多"
-"比赛，而且他还得到了我们国王李奥瑞克本人的赞扬——愿他的灵魂安息。格里斯沃尔德"
-"也是一位伟大的英雄；问问凯恩"
+"我们​的​铁匠​是​崔斯特姆​人民​的​骄傲​。​他​不仅​是​一​个​手艺​大师​，​在​他​的​行会​中​赢得​了​许多​"
+"比赛​，​而且​他​还​得到​了​我们​国王​李奥瑞克​本人​的​赞扬​——​愿​他​的​灵魂​安息​。​格里斯沃尔德​也​是"
+"​一​位​伟大​的​英雄​；​问问​凯恩"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian (Gossip)
 #: Source/textdat.cpp:371
 msgid ""
 "Cain has been the storyteller of Tristram for as long as I can remember. He "
 "knows so much, and can tell you just about anything about almost everything."
-msgstr ""
-"从我记事起，凯恩一直是崔斯特姆的说书人。他知道的太多了，几乎什么都能告诉你"
+msgstr "从​我​记事​起​，​凯恩​一直​是​崔斯特姆​的​说​书​人​。​他​知道​的​太​多​了​，​几乎​什么​都​能​告诉​你"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian (Gossip)
 #: Source/textdat.cpp:373
@@ -8828,9 +8824,9 @@ msgid ""
 "frustrated watching him slip farther and farther into a befuddled stupor "
 "every night."
 msgstr ""
-"法恩汉是个酒鬼，他的肚子里装满了啤酒，其他人的耳朵里全是废话。\n"
+"法恩汉​是​个​酒鬼​，​他​的​肚子​里​装满​了​啤酒​，​其他​人​的​耳朵​里​全​是​废话​。​\n"
 " \n"
-"我知道佩金和奥格登都同情他，但每天晚上看着他越来越昏迷不醒，我感到非常沮丧"
+"​我​知道​佩金​和​奥格登​都​同情​他​，​但​每​天​晚上​看​着​他​越来越​昏迷​不​醒​，​我​感到​非常​沮丧"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian (Gossip)
 #: Source/textdat.cpp:375
@@ -8840,8 +8836,8 @@ msgid ""
 "sword and more mysterious than any spell you can name. If you ever are in "
 "need of healing, Pepin can help you."
 msgstr ""
-"佩金救了我祖母的命，我知道我永远也报答不了他。他治愈任何疾病的能力比最强大的"
-"剑更强大，比你能说出的任何法术都更神秘。如果你需要治疗，佩金可以帮助你"
+"佩金救​了​我​祖母​的​命​，​我​知道​我​永远​也​报答​不​了​他​。​他​治愈​任何​疾病​的​能力​比​最​强大​"
+"的​剑​更​强大​，​比​你​能​说出​的​任何​法术​都​更​神秘​。​如果​你​需要​治疗​，​佩金​可以​帮助​你"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian (Gossip)
 #: Source/textdat.cpp:377
@@ -8853,10 +8849,10 @@ msgid ""
 "seen horrors that I cannot even imagine, but some of that darkness hangs "
 "over him still."
 msgstr ""
-"我和怀特的母亲，加那斯一起长大。虽然当那些可怕的生物偷走他时，她只是受到了轻"
-"微的伤害，但她始终没有康复。我想她死于心碎。怀特成了一个小气鬼，只想从别人的"
-"汗水中获利。我知道他受苦受难，经历过我无法想象的恐惧，但他身上仍然笼罩着一些"
-"黑暗"
+"我​和​怀特​的​母亲​，​加那斯​一​起​长大​。​虽然​当​那些​可怕​的​生物​偷走​他​时​，​她​只​是​受到​了​"
+"轻微​的​伤害​，​但​她​始终​没有​康复​。​我​想​她​死​于​心碎​。​怀特​成​了​一​个​小气鬼​，​只​想​从​"
+"别人​的​汗水​中​获利​。​我​知道​他​受苦受难​，​经历​过​我​无法​想象​的​恐惧​，​但​他​身​上​仍然​笼罩​"
+"着​一些​黑暗"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian (Gossip)
 #: Source/textdat.cpp:379
@@ -8866,13 +8862,13 @@ msgid ""
 "them, and hope one day to leave this place and help them start a grand hotel "
 "in the east."
 msgstr ""
-"奥格登和他的妻子把我和我的祖母带到他们家里，甚至让我在旅馆工作挣了几块金币。"
-"我欠他们太多了，希望有一天离开这个地方，帮助他们在东方开一家大酒店"
+"奥格登​和​他​的​妻子​把​我​和​我​的​祖母​带到​他们​家​里​，​甚至​让​我​在​旅馆​工作​挣​了​几​块​金币"
+"​。​我​欠​他们​太​多​了​，​希望​有​一​天​离开​这个​地方​，​帮助​他们​在​东方​开​一​家​大​酒店"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold
 #: Source/textdat.cpp:381
 msgid "Well, what can I do for ya?"
-msgstr "你好，我能为你做些什么？"
+msgstr "你​好​，​我​能​为​你​做​些​什么​？"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:382
@@ -8882,8 +8878,8 @@ msgid ""
 "undying horrors down there, and there's nothing better to shatter skinny "
 "little skeletons!"
 msgstr ""
-"如果你想找一件好武器，让我给你看看。带上你最基本的钝器，比如狼牙棒。像一个魅"
-"力对抗那些不朽的恐惧在那里，没有什么比粉碎瘦小的骨架更好"
+"如果​你​想​找​一​件​好​武器​，​让​我​给​你​看看​。​带上​你​最​基本​的​钝器​，​比如​狼牙棒​。​像​一​"
+"个​魅力​对抗​那些​不朽​的​恐惧​在​那里​，​没有​什么​比​粉碎​瘦小​的​骨架​更​好"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:384
@@ -8893,9 +8889,9 @@ msgid ""
 "mind, however, that it is slow to swing - but talk about dealing a heavy "
 "blow!"
 msgstr ""
-"斧头？是的，这是一个很好的武器，可以对付任何敌人。看看它是如何劈开空气的，然"
-"后想象一个漂亮的胖魔鬼头在它的路径上。但是，请记住，摇摆是很慢的，但是谈论如"
-"何处理一个沉重的打击"
+"斧头​？​是​的​，​这​是​一​个​很​好​的​武器​，​可以​对付​任何​敌人​。​看看​它​是​如何​劈​开​空气​的​"
+"，​然后​想象​一​个​漂亮​的​胖魔鬼​头​在​它​的​路径​上​。​但是​，​请​记住​，​摇摆​是​很​慢​的​，​但是"
+"​谈论​如何​处理​一​个​沉重​的​打击"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:386
@@ -8905,9 +8901,9 @@ msgid ""
 "or pierce on the undead, but against a living, breathing enemy, a sword will "
 "better slice their flesh!"
 msgstr ""
-"看看那个边缘，那个平衡。右手中的剑，和对的敌人，是一切武器的主人。它锐利的刀"
-"锋在不死生物身上几乎找不到可砍或可刺的东西，但对于一个活生生的、会呼吸的敌"
-"人，一把剑会更好地切开他们的肉"
+"看看​那​个​边缘​，​那个​平衡​。​右​手​中​的​剑​，​和​对​的​敌人​，​是​一切​武器​的​主人​。​它​锐利​"
+"的​刀锋​在​不​死​生物​身上​几乎​找​不​到​可​砍​或​可​刺​的​东西​，​但​对于​一​个​活生生​的​、​会​呼"
+"吸​的​敌人​，​一​把​剑会​更​好​地​切开​他们​的​肉"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:388
@@ -8916,8 +8912,8 @@ msgid ""
 "Darkness. If you bring them to me, with a bit of work and a hot forge, I can "
 "restore them to top fighting form."
 msgstr ""
-"你的武器和护甲将显示你与黑暗斗争的迹象。如果你把它们带到我这里来，稍加改造和"
-"热锻，我就能把它们恢复到最佳战斗状态"
+"你​的​武器​和​护甲​将​显示​你​与​黑暗​斗争​的​迹象​。​如果​你​把​它们​带到​我​这里​来​，​稍加​改造​和"
+"​热锻​，​我​就​能​把​它们​恢复​到​最佳​战斗​状态"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:390
@@ -8927,9 +8923,9 @@ msgid ""
 "seems to get whatever she needs. If I knew even the smallest bit about how "
 "to harness magic as she did, I could make some truly incredible things."
 msgstr ""
-"当我不得不从我们该死的小镇边缘的商队里偷运我所需要的金属和工具时，那个女巫艾"
-"德里亚似乎总能得到她所需要的一切。如果我像她那样懂得如何运用魔法，我就能做出"
-"一些真正不可思议的事情"
+"当​我​不​得不​从​我们​该​死​的​小​镇​边缘​的​商队​里​偷运​我​所​需要​的​金属​和​工具​时​，​那​个​女"
+"​巫艾德里亚​似乎​总​能​得到​她​所​需要​的​一切​。​如果​我​像​她​那样​懂得​如何​运用​魔法​，​我​就​能​"
+"做出​一些​真正​不可​思议​的​事情"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:392
@@ -8937,8 +8933,8 @@ msgid ""
 "Gillian is a nice lass. Shame that her gammer is in such poor health or I "
 "would arrange to get both of them out of here on one of the trading caravans."
 msgstr ""
-"吉莉安是个好姑娘。可惜她的男朋友身体这么差，否则我会安排他们两个都乘商队离开"
-"这里"
+"吉莉安​是​个​好​姑娘​。​可惜​她​的​男朋友​身体​这么​差​，​否则​我​会​安排​他们​两​个​都​乘商队​离开​这"
+"里"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:394
@@ -8947,8 +8943,8 @@ msgid ""
 "in life. If I could bend steel as well as he can bend your ear, I could make "
 "a suit of court plate good enough for an Emperor!"
 msgstr ""
-"有时我觉得凯恩说得太多了，但我想这是他一生的使命。如果我能像他能弯曲你的耳朵"
-"一样弯曲钢铁，我就能做一套足够好的皇帝用的宫廷盘子"
+"有时​我​觉得​凯恩​说​得​太​多​了​，​但​我​想​这​是​他​一​生​的​使命​。​如果​我​能​像​他​能​弯曲​你"
+"​的​耳朵​一样​弯曲​钢铁​，​我​就​能​做​一​套​足够​好​的​皇帝​用​的​宫廷​盘子"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:396
@@ -8958,9 +8954,9 @@ msgid ""
 "my side. I fear that the attack left his soul as crippled as, well, another "
 "did my leg. I cannot fight this battle for him now, but I would if I could."
 msgstr ""
-"那天晚上我和法恩汉在一起，拉扎鲁斯把我们领进了迷宫。我再也见不到大主教了，如"
-"果法恩汉不在我身边，我可能就活不下去了。我担心这次袭击使他的灵魂像另一次袭击"
-"我的腿一样残废。我现在不能为他而战，但如果可以的话我会的"
+"那​天​晚上​我​和​法恩汉​在一起​，​拉扎鲁斯​把​我们​领进​了​迷宫​。​我​再​也​见不到​大主教​了​，​如果​法"
+"恩汉​不​在​我​身边​，​我​可能​就​活​不​下去​了​。​我​担心​这​次​袭击​使​他​的​灵魂​像​另​一​次​袭击"
+"​我​的​腿​一样​残废​。​我​现在​不​能​为​他​而​战​，​但​如果​可以​的​话​我​会​的"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:398
@@ -8969,8 +8965,8 @@ msgid ""
 "left in Tristram - or anywhere else for that matter - who has a bad thing to "
 "say about the healer."
 msgstr ""
-"把别人的需要放在自己的需要之上的好人。你不会发现任何人留在崔斯特姆-或任何其他"
-"地方的问题-谁有一个坏东西说的治疗者"
+"把​别人​的​需要​放​在​自己​的​需要​之上​的​好​人​。​你​不​会​发现​任何​人​留​在​崔斯特姆-​或​任何​其"
+"他​地方​的​问题​-​谁​有​一​个​坏​东西​说​的​治疗者"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:400
@@ -8981,9 +8977,9 @@ msgid ""
 "origin. I cannot hold that against him after what happened to him, but I do "
 "wish he would at least be careful."
 msgstr ""
-"那小子会惹上大麻烦的。。。或者我想我应该再说一遍。我试着让他对在这里工作和学"
-"习诚实的贸易感兴趣，但他更喜欢经营来源可疑的货物的高额利润。我不能在他出事后"
-"再对他说这话，但我真希望他至少要小心点"
+"那​小子​会​惹​上​大​麻烦​的​。​。​。​或者​我​想​我​应该​再​说​一​遍​。​我​试​着​让​他​对​在​这里​"
+"工作​和​学习​诚实​的​贸易感​兴趣​，​但​他​更​喜欢​经营​来源​可疑​的​货物​的​高额​利润​。​我​不​能​在​"
+"他​出​事​后​再​对​他​说​这话​，​但​我​真​希望​他​至少​要​小心点"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:402
@@ -8996,21 +8992,21 @@ msgid ""
 "starved during that first year when the entire countryside was overrun by "
 "demons."
 msgstr ""
-"客栈老板没有什么生意，也没有真正的盈利途径。他设法维持生计，为那些偶尔在村子"
-"里漂泊的人提供食物和住宿，但他们很可能会偷偷溜进夜空，就像他们付钱给他一样。"
-"如果不是因为他在地窖里储存了大量的谷物和干肉，为什么，我们大多数人会在第一年"
-"饿死，那时整个乡村都被恶魔蹂躏"
+"客栈​老板​没有​什么​生意​，​也​没有​真正​的​盈利​途径​。​他​设法​维持​生计​，​为​那些​偶尔​在​村子​里​"
+"漂泊​的​人​提供​食物​和​住宿​，​但​他们​很​可能​会​偷偷​溜进​夜空​，​就​像​他们​付​钱​给​他​一样​。​"
+"如果​不​是​因为​他​在​地窖里​储存​了​大量​的​谷物​和​干肉​，​为什么​，​我们​大多数​人​会​在​第一​年​饿"
+"死​，​那时​整​个​乡村​都​被​恶魔​蹂​躏"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham
 #: Source/textdat.cpp:404
 msgid "Can't a fella drink in peace?"
-msgstr "你个家伙就不能安静地喝酒吗？"
+msgstr "你​个​家伙​就​不​能​安静​地​喝​酒​吗​？"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:405
 msgid ""
 "The gal who brings the drinks? Oh, yeah, what a pretty lady. So nice, too."
-msgstr "送饮料的那个女孩？哦，是啊，多漂亮的女人啊。太好了"
+msgstr "送​饮料​的​那​个​女孩​？​哦​，​是​啊​，​多​漂亮​的​女人​啊​。​太​好​了"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:407
@@ -9019,8 +9015,8 @@ msgid ""
 "stuff, but you listen to me... she's unnatural. I ain't never seen her eat "
 "or drink - and you can't trust somebody who doesn't drink at least a little."
 msgstr ""
-"为什么那个老太婆不改变一下。当然，当然，她有东西，但你听我说。。。她很不自"
-"然。我从来没见过她吃喝——你也不能相信一个不喝酒的人"
+"为什么​那个​老太​婆​不​改变​一下​。​当然​，​当然​，​她​有​东西​，​但​你​听​我​说​。​。​。​她​很​不​"
+"自然​。​我​从来​没​见​过​她​吃喝​——​你​也​不​能​相信​一​个​不​喝​酒​的​人"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:409
@@ -9029,8 +9025,8 @@ msgid ""
 "'em are real scary or funny... but I think he knows more than he knows he "
 "knows."
 msgstr ""
-"凯恩不是他说的那样。当然，当然，他讲了一个好故事。。。有些真的很吓人或者很有"
-"趣。。。但我想他知道的比他知道的还多"
+"凯恩​不​是​他​说​的​那样​。​当然​，​当然​，​他​讲​了​一​个​好​故事​。​。​。​有些​真的​很​吓人​或者​"
+"很​有趣​。​。​。​但​我​想​他​知道​的​比​他​知道​的​还​多"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:411
@@ -9038,8 +9034,8 @@ msgid ""
 "Griswold? Good old Griswold. I love him like a brother! We fought together, "
 "you know, back when... we... Lazarus...  Lazarus... Lazarus!!!"
 msgstr ""
-"格里斯沃尔德？善良的老格里斯沃尔德。我像兄弟一样爱他！我们一起战斗，你知道，"
-"当。。。我们。。。拉扎鲁斯。。。拉扎鲁斯。。。拉扎鲁斯"
+"格里斯沃尔德​？​善良​的​老格里斯沃尔德​。​我​像​兄弟​一样​爱​他​！​我们​一起​战斗​，​你​知道​，​当​。​。"
+"​。​我们​。​。​。​拉扎鲁斯​。​。​。​拉扎鲁斯​。​。​。​拉扎鲁斯"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:413
@@ -9049,8 +9045,8 @@ msgid ""
 "wantin' help. Hey, I guess that would be kinda like you, huh hero? I was a "
 "hero too..."
 msgstr ""
-"呵呵，我喜欢佩金。他真的很努力，你知道的。听着，你应该了解他。像这样的好人总"
-"是有人想帮忙。嘿，我想那会有点像你，英雄？我也是个英雄"
+"呵呵​，​我​喜欢​佩金​。​他​真的​很​努力​，​你​知道​的​。​听​着​，​你​应该​了解​他​。​像​这样​的​好​"
+"人​总是​有​人​想​帮忙​。​嘿​，​我​想​那​会​有点​像​你​，​英雄​？​我​也​是​个​英雄"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:415
@@ -9059,8 +9055,9 @@ msgid ""
 "problems. Listen here - that kid is gotta sweet deal, but he's been there, "
 "you know? Lost a leg! Gotta walk around on a piece of wood. So sad, so sad..."
 msgstr ""
-"怀特是个问题比我还多的孩子，我知道所有的问题。听着-那孩子一定是个好人，但他去"
-"过那里，你知道吗？丢了一条腿！得在一块木头上走来走去。太伤心了，太伤心了"
+"怀特​是​个​问题​比​我​还​多​的​孩子​，​我​知道​所有​的​问题​。​听​着​-​那​孩子​一定​是​个​好​人​，"
+"​但​他​去​过​那里​，​你​知道​吗​？​丢​了​一​条​腿​！​得​在​一​块​木头​上​走​来​走去​。​太​伤心​了"
+"​，​太​伤心​了"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:417
@@ -9069,8 +9066,8 @@ msgid ""
 "long as she keeps tappin' kegs, I'll like her just fine. Seems like I been "
 "spendin' more time with Ogden than most, but he's so good to me..."
 msgstr ""
-"奥格登是镇上最好的男人。我觉得他妻子不太喜欢我，但只要她不停地敲桶，我就很喜"
-"欢她。似乎我和奥格登在一起的时间比大多数人都多，但他对我很好"
+"奥格登​是​镇​上​最​好​的​男人​。​我​觉得​他​妻子​不​太​喜欢​我​，​但​只要​她​不​停​地​敲桶​，​我​就"
+"​很​喜欢​她​。​似乎​我​和​奥格登​在一起​的​时间​比​大多数​人​都​多​，​但​他​对​我​很​好"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:419
@@ -9079,8 +9076,8 @@ msgid ""
 "specialty. This here is the best... theeeee best! That other ale ain't no "
 "good since those stupid dogs..."
 msgstr ""
-"我想告诉你，因为我知道这一切。这是我的专长。这是最好的。。。最好的！其他的啤"
-"酒不好，因为那些蠢狗"
+"我​想​告诉​你​，​因为​我​知道​这​一切​。​这​是​我​的​专长​。​这​是​最​好​的​。​。​。​最​好​的​！​"
+"其他​的​啤酒​不​好​，​因为​那些​蠢​狗"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:421
@@ -9089,8 +9086,8 @@ msgid ""
 "somewhere under the church is a whole pile o' gold. Gleamin' and shinin' and "
 "just waitin' for someone to get it."
 msgstr ""
-"从来没有人。。。听我说。在某个地方-我不太确定-但是在教堂下面的某个地方有一堆"
-"金子。闪闪发光，只是等待有人得到它"
+"从来​没有​人​。​。​。​听​我​说​。​在​某​个​地方​-​我​不​太​确定​-​但是​在​教堂​下面​的​某​个​地方"
+"​有​一​堆​金子​。​闪闪​发光​，​只是​等待​有​人​得到​它"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:423
@@ -9100,8 +9097,8 @@ msgid ""
 "brutes! Oh, I don't care what Griswold says, they can't make anything like "
 "they used to in the old days..."
 msgstr ""
-"我知道你有自己的想法，我知道你不会相信的，但你的武器，你在那里-它只是不好对付"
-"那些大畜生！哦，我不管格里斯沃尔德怎么说，他们不能像以前那样做任何东西"
+"我​知道​你​有​自己​的​想法​，​我​知道​你​不​会​相信​的​，​但​你​的​武器​，​你​在​那里​-​它​只​是​"
+"不​好​对付​那些​大​畜生​！​哦​，​我​不管​格里斯沃尔德​怎么​说​，​他们​不​能​像​以前​那样​做​任何​东西"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:425
@@ -9110,13 +9107,14 @@ msgid ""
 "and get out of here. That boy out there... He's always got somethin good, "
 "but you gotta give him some gold or he won't even show you what he's got."
 msgstr ""
-"如果我是你。。。我不是。。。但如果我是，我会卖掉你所有的东西然后离开这里。外"
-"面那个男孩。。。他总是有好东西，但你得给他点金子，否则他连他的东西都不给你看"
+"如果​我​是​你​。​。​。​我​不​是​。​。​。​但​如果​我​是​，​我​会​卖掉​你​所有​的​东西​然后​离开​这里"
+"​。​外面​那​个​男孩​。​。​。​他​总是​有​好​东西​，​但​你​得​给​他​点金子​，​否则​他​连​他​的​东西​"
+"都​不​给​你​看"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria
 #: Source/textdat.cpp:427
 msgid "I sense a soul in search of answers..."
-msgstr "我感觉到一个灵魂在寻找答案"
+msgstr "我​感觉​到​一​个​灵魂​在​寻找​答案"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:428
@@ -9125,8 +9123,8 @@ msgid ""
 "words. Should you already have knowledge of the arcane mysteries scribed "
 "within a book, remember - that level of mastery can always increase."
 msgstr ""
-"智慧是应得的，而不是给予的。如果你发现了一本知识的大部头，就要吞没它的文字。"
-"如果你已经掌握了书中描述的神秘事物的知识，记住-掌握的水平总是可以提高的"
+"智慧​是​应​得​的​，​而​不​是​给予​的​。​如果​你​发现​了​一​本​知识​的​大部头​，​就​要​吞没​它​的​文"
+"字​。​如果​你​已经​掌握​了​书​中​描述​的​神秘​事物​的​知识​，​记住​-​掌握​的​水平​总是​可以​提高​的"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:430
@@ -9138,9 +9136,9 @@ msgid ""
 "be kept at the ready in your mind. Know also that these scrolls can be read "
 "but once, so use them with care."
 msgstr ""
-"最强大的力量往往是最短命的。你可以在羊皮纸的卷轴上找到古老的权力话语。这些卷"
-"轴的力量在于学徒或熟练的施展能力。他们的弱点是，他们必须首先大声朗读，永远不"
-"能随时准备在你的脑海中。还要知道这些卷轴只能读一次，所以要小心使用"
+"最​强大​的​力量​往往​是​最​短命​的​。​你​可以​在​羊​皮纸​的​卷轴​上​找到​古老​的​权力​话语​。​这些​卷"
+"轴​的​力量​在于​学徒​或​熟练​的​施展​能力​。​他们​的​弱点​是​，​他们​必须​首先​大声​朗读​，​永远​不​能"
+"​随时​准备​在​你​的​脑海​中​。​还​要​知道​这些​卷轴​只​能​读​一​次​，​所以​要​小心​使用"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:432
@@ -9151,9 +9149,9 @@ msgid ""
 "magical energies many times over. I have the ability to restore their power "
 "- but know that nothing is done without a price."
 msgstr ""
-"尽管太阳的热量无法估量，但光是蜡烛的火焰就更危险。没有适当的聚焦，任何能量，"
-"无论多大，都不能被使用。对于许多法术来说，被赋予灵能的杖可以被多次充满魔法能"
-"量。我有能力恢复他们的力量，但我知道没有代价是做不到的"
+"尽管​太阳​的​热量​无法​估量​，​但​光是​蜡烛​的​火焰​就​更​危险​。​没有​适当​的​聚焦​，​任何​能量​，​无"
+"论​多​大​，​都​不​能​被​使用​。​对于​许多​法术​来说​，​被​赋予​灵能​的​杖​可以​被​多​次​充满​魔法​能"
+"量​。​我​有​能力​恢复​他们​的​力量​，​但​我​知道​没有​代价​是​做​不​到​的"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:434
@@ -9162,8 +9160,8 @@ msgid ""
 "or scroll that you cannot decipher, do not hesitate to bring it to me. If I "
 "can make sense of it I will share what I find."
 msgstr ""
-"我们知识的总和就是它的人民的总和。如果你发现一本书或卷轴，你不能破译，不要犹"
-"豫，把它给我。如果我能理解的话，我会分享我的发现"
+"我们​知识​的​总和​就​是​它​的​人民​的​总和​。​如果​你​发现​一​本​书​或​卷轴​，​你​不​能​破译​，​不​"
+"要​犹豫​，​把​它​给​我​。​如果​我​能​理解​的话​，​我​会​分享​我​的​发现"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:436
@@ -9172,8 +9170,8 @@ msgid ""
 "blacksmith Griswold is more of a sorcerer than he knows. His ability to meld "
 "fire and metal is unequaled in this land."
 msgstr ""
-"对一个只懂钢铁的人来说，没有什么比钢铁更神奇了。铁匠格里斯沃尔德比他所知道的"
-"更像个巫师。他融火与金属的能力在这片土地上是无与伦比的"
+"对​一​个​只​懂​钢铁​的​人​来​说​，​没有​什么​比​钢铁​更​神奇​了​。​铁匠​格里斯沃尔德比​他​所​知道​的​"
+"更​像​个​巫师​。​他​融火​与​金属​的​能力​在​这​片​土地​上​是​无与伦比​的"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:438
@@ -9183,8 +9181,8 @@ msgid ""
 "matriarch over her own. She fears me, but it is only because she does not "
 "understand me."
 msgstr ""
-"腐败有欺骗的力量，而清白有纯洁的力量。年轻的吉莉安有一颗纯洁的心，把女家长的"
-"需要凌驾于自己的需要之上。她害怕我，但那只是因为她不了解我"
+"腐败​有​欺骗​的​力量​，​而​清白​有​纯洁​的​力量​。​年轻​的​吉莉安​有​一​颗​纯洁​的​心​，​把​女​家长​"
+"的​需要​凌驾于​自己​的​需要​之上​。​她​害怕​我​，​但​那​只​是​因为​她​不​了解​我"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:440
@@ -9194,8 +9192,8 @@ msgid ""
 "not look. His knowledge of what lies beneath the cathedral is far greater "
 "than even he allows himself to realize."
 msgstr ""
-"在黑暗中打开的箱子所装的财宝，并不比在光明中打开的箱子更大。讲故事的凯恩是一"
-"个谜，但只有那些谁不看。他对大教堂下面的东西的了解远远超过了他自己的想象"
+"在​黑暗中​打开​的​箱子​所​装​的​财宝​，​并不​比​在​光明​中​打开​的​箱子​更​大​。​讲​故事​的​凯恩​是​"
+"一​个​谜​，​但​只有​那些​谁​不​看​。​他​对​大​教堂​下面​的​东西​的​了解​远远​超过​了​他​自己​的​想象"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:442
@@ -9205,9 +9203,9 @@ msgid ""
 "fellow townspeople betrayed by the Archbishop Lazarus. He has knowledge to "
 "be gleaned, but you must separate fact from fantasy."
 msgstr ""
-"你对一个人的信心越高，他就越会堕落。法恩汉已经失去了他的灵魂，但不是任何恶"
-"魔。当他看到他的同乡们被拉扎鲁斯大主教出卖时，他失去了理智。他有知识可以收"
-"集，但你必须把事实和幻想分开"
+"你​对​一​个​人​的​信心​越​高​，​他​就​越​会​堕落​。​法恩汉​已经​失去​了​他​的​灵魂​，​但​不​是​任何"
+"​恶魔​。​当​他​看到​他​的​同乡们​被​拉扎鲁斯大​主教​出​卖​时​，​他​失去​了​理智​。​他​有​知识​可以​收"
+"集​，​但​你​必须​把​事实​和​幻想​分开"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:444
@@ -9218,9 +9216,9 @@ msgid ""
 "understanding of the creation of elixirs and potions. He is as great an ally "
 "as you have in Tristram."
 msgstr ""
-"手、心和心在完美的和谐中就能创造奇迹。治疗者佩金以一种连我都看不到的方式观察"
-"身体。他对长生不老药和药水的理解使他恢复病人和伤者的能力得到了放大。他和你在"
-"崔斯特姆一样是个伟大的盟友"
+"手​、​心​和心​在​完美​的​和谐​中​就​能​创造​奇迹​。​治疗者​佩金​以​一​种​连​我​都​看​不​到​的​方式​"
+"观察​身体​。​他​对​长生​不​老药​和​药水​的​理解​使​他​恢复​病人​和​伤者​的​能力​得到​了​放大​。​他​和"
+"​你​在​崔斯特姆​一样​是​个​伟大​的​盟友"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:446
@@ -9233,10 +9231,10 @@ msgid ""
 "reproachful, Wirt can provide assistance for your battle against the "
 "encroaching Darkness."
 msgstr ""
-"未来有很多我们看不到的，但当它来临时，将是孩子们掌握着它。这个男孩的灵魂是黑"
-"暗的，但他对这个城镇和它的人民没有威胁。他与附近城镇的顽童和不为人知的行会的"
-"秘密交易使他能够接触到许多在崔斯特姆很难找到的设备。虽然他的方法可能会受到指"
-"责，但怀特可以为你对抗日益逼近的黑暗提供帮助"
+"未来​有​很多​我们​看​不​到​的​，​但​当​它​来​临​时​，​将​是​孩子们​掌握​着​它​。​这个​男孩​的​灵魂​"
+"是​黑暗​的​，​但​他​对​这个​城镇​和​它​的​人民​没有​威胁​。​他​与​附近​城镇​的​顽童​和​不​为​人知​的"
+"​行会​的​秘密​交易​使​他​能够​接触​到​许多​在​崔斯特姆​很​难​找到​的​设备​。​虽然​他​的​方法​可能​会​"
+"受到​指责​，​但​怀特​可以​为​你​对抗​日益​逼近​的​黑暗​提供​帮助"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:448
@@ -9249,16 +9247,16 @@ msgid ""
 "found there, provide a glimpse of a life that the people here remember. It "
 "is that memory that continues to feed their hopes for your success."
 msgstr ""
-"土墙和茅草屋顶不是一个家。旅馆老板奥格登在这个镇上的作用比许多人所理解的要大"
-"得多。他为吉莉安和她的女族长提供庇护所，维持法恩汉留给他的生活，并为留在镇上"
-"的所有人提供一个锚，让他们回到崔斯特姆曾经的样子。他的小酒馆，以及在那里仍然"
-"可以找到的简单的乐趣，让我们看到了这里的人们所记得的生活。正是这段记忆，让他"
-"们对你的成功充满了希望"
+"土墙​和​茅草​屋顶​不​是​一​个​家​。​旅馆​老板​奥格登​在​这个​镇​上​的​作用​比​许多​人​所​理解​的​要​"
+"大​得​多​。​他​为​吉莉安​和​她​的​女族​长​提供​庇护所​，​维持​法恩汉​留给​他​的​生活​，​并​为​留​在​"
+"镇​上​的​所有人​提供​一​个​锚​，​让​他们​回到​崔斯特姆​曾经​的​样子​。​他​的​小酒馆​，​以及​在​那里​仍"
+"然​可以​找到​的​简单​的​乐趣​，​让​我们​看到​了​这里​的​人们​所​记得​的​生活​。​正​是​这​段​记忆​，​"
+"让​他们​对​你​的​成功​充满​了​希望"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt
 #: Source/textdat.cpp:450
 msgid "Pssst... over here..."
-msgstr "嘿……过来这儿……"
+msgstr "嘿​…​…​过来​这儿​…​…"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:451
@@ -9268,17 +9266,17 @@ msgid ""
 " \n"
 "Sometimes, only you will be able to find a purpose for some things."
 msgstr ""
-"并不是所有在崔斯特姆的人都有一个用途-或市场-你会发现在迷宫中的一切。连我都不"
-"相信。\n"
+"并​不​是​所有​在​崔斯特姆​的​人​都​有​一​个​用途​-​或​市场​-​你​会​发现​在​迷宫​中​的​一切​。​连​"
+"我​都​不​相信​。​\n"
 " \n"
-"有时候，只有你才能为某些事情找到目标"
+"​有时候​，​只有​你​才​能​为​某些​事情​找到​目标"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:453
 msgid ""
 "Don't trust everything the drunk says. Too many ales have fogged his vision "
 "and his good sense."
-msgstr "别相信醉汉说的每一句话。太多的啤酒模糊了他的视力和判断力"
+msgstr "别​相信​醉汉​说​的​每​一​句​话​。​太​多​的​啤酒​模糊​了​他​的​视力​和​判断力"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:455
@@ -9288,9 +9286,9 @@ msgid ""
 "Griswold, Pepin or that witch, Adria. I'm sure that they will snap up "
 "whatever you can bring them..."
 msgstr ""
-"如果你没注意到，我不会从崔斯特姆买任何东西。我是一个进口优质商品的进口商。如"
-"果你想兜售垃圾，你得去看看格里斯沃尔德，佩金或那个女巫，艾德莉亚。我相信他们"
-"会抢购你能带给他们的任何东西"
+"如果​你​没​注意​到​，​我​不​会​从​崔斯特姆​买​任何​东西​。​我​是​一​个​进口​优质​商品​的​进口商​。​如"
+"果​你​想​兜售​垃圾​，​你​得​去​看看​格里斯沃尔德​，​佩金​或​那​个​女巫​，​艾德莉亚​。​我​相信​他们​会​"
+"抢购​你​能​带给​他们​的​任何​东西"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:457
@@ -9300,9 +9298,9 @@ msgid ""
 "I'll never get enough money to... well, let's just say that I have definite "
 "plans that require a large amount of gold."
 msgstr ""
-"我想我欠铁匠一条命——这是怎么回事。当然，格里斯沃尔德让我在铁匠铺当学徒，他是"
-"个很好的人，但我永远拿不到足够的钱。。。好吧，就说我有明确的计划，需要大量的"
-"黄金"
+"我​想​我​欠铁匠​一​条​命​——​这​是​怎么回​事​。​当然​，​格里斯沃尔德​让​我​在​铁匠​铺当​学徒​，​他​是"
+"​个​很​好​的​人​，​但​我​永远​拿​不​到​足够​的​钱​。​。​。​好​吧​，​就​说​我​有​明确​的​计划​，​"
+"需要​大量​的​黄金"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:459
@@ -9312,9 +9310,9 @@ msgid ""
 "Gillian is a beautiful girl who should get out of Tristram as soon as it is "
 "safe. Hmmm... maybe I'll take her with me when I go..."
 msgstr ""
-"如果我再大几岁，我会尽我所能给她带来财富，让我向你保证，我可以得到一些非常好"
-"的东西。吉莉安是一个美丽的女孩，她应该尽快离开崔斯特姆，只要它是安全的。"
-"嗯。。。也许我去的时候会带她一起去"
+"如果​我​再​大​几​岁​，​我​会​尽​我​所​能​给​她​带来​财富​，​让​我​向​你​保证​，​我​可以​得到​一些​"
+"非常​好​的​东西​。​吉莉安​是​一​个​美丽​的​女孩​，​她​应该​尽快​离开​崔斯特姆​，​只要​它​是​安全​的​。"
+"​嗯​。​。​。​也许​我​去​的​时候​会​带​她​一起​去"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:461
@@ -9323,8 +9321,8 @@ msgid ""
 "woman across the river. He keeps telling me about how lucky I am to be "
 "alive, and how my story is foretold in legend. I think he's off his crock."
 msgstr ""
-"凯恩知道的太多了。他把我吓死了，甚至比河对岸的那个女人还可怕。他不停地告诉"
-"我，我活着是多么幸运，我的故事是如何在传说中被预言的。我想他是疯了"
+"凯恩​知道​的​太​多​了​。​他​把​我​吓死​了​，​甚至​比河​对岸​的​那​个​女人​还​可怕​。​他​不​停​地​告"
+"诉​我​，​我​活​着​是​多么​幸运​，​我​的​故事​是​如何​在​传说​中​被​预言​的​。​我​想​他​是​疯​了"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:463
@@ -9335,9 +9333,9 @@ msgid ""
 "down there, so don't even start telling me about your plans to destroy the "
 "evil that dwells in that Labyrinth. Just watch your legs..."
 msgstr ""
-"法恩汉-现在有一个男人有严重的问题，我知道所有的严重问题可以。他过于相信一个人"
-"的正直，拉扎鲁斯就把他带进了死亡的深渊。哦，我知道下面是什么样的，所以别告诉"
-"我你打算消灭迷宫里的恶魔。小心你的腿"
+"法恩汉-​现在​有​一​个​男人​有​严重​的​问题​，​我​知道​所有​的​严重​问题​可以​。​他​过于​相信​一​个​人"
+"​的​正直​，​拉扎鲁斯​就​把​他​带进​了​死亡​的​深渊​。​哦​，​我​知道​下面​是​什么样​的​，​所以​别​告诉"
+"​我​你​打算​消灭​迷宫​里​的​恶魔​。​小心​你​的​腿"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:465
@@ -9347,9 +9345,9 @@ msgid ""
 " \n"
 "If I'd have had some of those potions he brews, I might still have my leg..."
 msgstr ""
-"只要你不需要任何东西复位，老佩金是一样好，他们来了。\n"
+"只要​你​不​需要​任何​东西​复位​，​老佩金​是​一样​好​，​他们​来​了​。​\n"
 " \n"
-"如果我有一些他酿造的药水，我可能还有腿"
+"​如果​我​有​一些​他​酿造​的​药水​，​我​可能​还​有​腿"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:467
@@ -9359,9 +9357,9 @@ msgid ""
 "get whatever she needs, too. Adria gets her hands on more merchandise than "
 "I've seen pass through the gates of the King's Bazaar during High Festival."
 msgstr ""
-"艾德莉亚真让我烦恼。当然，凯恩对你说的关于过去的事是令人毛骨悚然的，但那个女"
-"巫能看透你的过去。她也总有办法得到她需要的东西。阿德里娅拿到的商品比我在节日"
-"期间穿过国王集市的大门看到的还要多"
+"艾德莉亚真​让​我​烦恼​。​当然​，​凯恩​对​你​说​的​关于​过去​的​事​是​令​人​毛骨悚然​的​，​但​那​个​女"
+"​巫能​看​透​你​的​过去​。​她​也​总​有​办法​得到​她​需要​的​东西​。​阿德里娅​拿到​的​商品​比​我​在​节"
+"日​期间​穿过​国王​集市​的​大门​看到​的​还​要​多"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:469
@@ -9371,9 +9369,9 @@ msgid ""
 "stupid tavern. I guess at the least he gives Gillian a place to work, and "
 "his wife Garda does make a superb Shepherd's pie..."
 msgstr ""
-"奥格登呆在这里真是个傻瓜。我可以以一个非常合理的价格把他弄到城外去，但他坚持"
-"要和那家愚蠢的酒馆混过去。我想至少他给了吉莉安一个工作的地方，他的妻子嘉达做"
-"了一个很棒的牧羊派"
+"奥格登呆​在​这里​真​是​个​傻瓜​。​我​可以​以​一​个​非常​合理​的​价格​把​他​弄​到​城外​去​，​但​他​坚"
+"持​要​和​那家​愚蠢​的​酒馆​混​过去​。​我​想​至少​他​给​了​吉莉安​一​个​工作​的​地方​，​他​的​妻子​嘉"
+"达​做​了​一​个​很​棒​的​牧羊派"
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:471 Source/textdat.cpp:479 Source/textdat.cpp:487
@@ -9382,8 +9380,8 @@ msgid ""
 "who would seek to steal the treasures secured within this room. So speaks "
 "the Lord of Terror, and so it is written."
 msgstr ""
-"在英雄走廊的另一端藏匿着白骨密室。任何胆敢盗取此地财宝的人，都将遭受永恒的死"
-"亡。恐惧之王如是说，本书也如实写。"
+"在​英雄​走廊​的​另​一​端​藏匿​着​白骨密室​。​任何​胆​敢​盗取​此​地​财宝​的​人​，​都​将​遭受​永恒​的​"
+"死亡​。​恐惧​之​王​如是​说​，​本​书​也​如实​写​。"
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:473 Source/textdat.cpp:481 Source/textdat.cpp:489
@@ -9391,7 +9389,7 @@ msgstr ""
 msgid ""
 "...and so, locked beyond the Gateway of Blood and past the Hall of Fire, "
 "Valor awaits for the Hero of Light to awaken..."
-msgstr "……于是，打开鲜血之门，穿过火焰大厅，荣耀等待着光明的英雄去唤醒……"
+msgstr "…​…​于是​，​打开​鲜血​之​门​，​穿过​火焰​大厅​，​荣耀​等待​着​光明​的​英雄​去​唤醒​…​…"
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:475 Source/textdat.cpp:483 Source/textdat.cpp:491
@@ -9406,14 +9404,14 @@ msgid ""
 "Out of darkness, out of mind,\n"
 "Cast down into the Halls of the Blind."
 msgstr ""
-"我能见你所不能见\n"
-"鬼影缭绕腐蚀肉眼\n"
-"方一转身全数消散\n"
-"耳边响起招魂童谣\n"
-"无形之物即现眼前\n"
-"光影交叠怨气弥漫\n"
-"撕裂心灵冲破黑暗\n"
-"目盲之厅不见彼岸"
+"我​能见​你​所​不​能​见​\n"
+"​鬼影缭绕​腐蚀​肉眼​\n"
+"方​一​转身​全数​消散​\n"
+"​耳边​响起​招魂​童谣\n"
+"​无形​之​物​即​现眼前​\n"
+"光影​交叠​怨气弥漫\n"
+"​撕裂​心灵​冲破​黑暗​\n"
+"​目盲​之厅​不​见​彼岸"
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:477 Source/textdat.cpp:485 Source/textdat.cpp:493
@@ -9423,8 +9421,8 @@ msgid ""
 "fulfill his endless sacrifices to the Dark ones who scream for one thing - "
 "blood."
 msgstr ""
-"地狱的军械库如同鲜血战神的私宅。其所到之处，无不留下成千上万的残肢断臂。无论"
-"是天使还是人类都将遭到残杀，只为了能够呈上邪魔们最渴望的东西——鲜血。"
+"地狱​的​军械库​如同​鲜血​战神​的​私宅​。​其​所​到​之​处​，​无​不​留下​成千上万​的​残肢断臂​。​无论​是​"
+"天使​还是​人类​都​将​遭到​残杀​，​只​为了​能够​呈上​邪魔们​最​渴望​的​东西​——​鲜血​。"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:505
@@ -9437,10 +9435,10 @@ msgid ""
 "sky. Neither side ever gains sway for long as the forces of Light and "
 "Darkness constantly vie for control over all creation."
 msgstr ""
-"注意并见证这里的真理，因为它们是赫拉迪姆最后的遗产。甚至在现在，在我们所知的"
-"领域之外，在天堂的乌托邦王国和燃烧地狱的混乱深渊之间，仍有一场战争在肆虐。这"
-"场战争被称为大冲突，它的肆虐和燃烧时间比天空中任何一颗星星都要长。只要光明和"
-"黑暗的力量不断争夺对所有造物的控制权，任何一方都不会获得支配权"
+"注意​并​见证​这里​的​真理​，​因为​它们​是​赫拉迪姆​最后​的​遗产​。​甚至​在​现在​，​在​我们​所​知​的​领"
+"域​之外​，​在​天堂​的​乌托邦​王国​和​燃烧​地狱​的​混乱​深渊​之间​，​仍​有​一​场​战争​在​肆虐​。​这​场"
+"​战争​被​称为​大​冲突​，​它​的​肆虐​和​燃烧​时间​比​天空​中​任何​一​颗​星星​都​要​长​。​只要​光明​和"
+"​黑暗​的​力量​不断​争夺​对​所有​造物​的​控制权​，​任何​一​方​都​不​会​获得​支配权"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:507
@@ -9453,10 +9451,10 @@ msgid ""
 "have even allied themselves with either side, and helped to dictate the "
 "course of the Sin War."
 msgstr ""
-"注意并见证这里的真理，因为它们是赫拉迪姆最后的遗产。当天堂和地狱之间永恒的冲"
-"突落在凡人的土地上，这就是原罪之战。天使和恶魔伪装着行走在人类之中，秘密地战"
-"斗，远离凡人窥探的眼睛。一些勇敢、强大的凡人甚至与任何一方结盟，并帮助指挥罪"
-"恶战争的进程"
+"注意​并​见证​这里​的​真理​，​因为​它们​是​赫拉迪姆​最后​的​遗产​。​当天堂​和​地狱​之间​永恒​的​冲突​落​"
+"在​凡人​的​土地​上​，​这​就​是​原罪之战​。​天使​和​恶魔​伪​装​着​行走​在​人类​之中​，​秘密​地​战斗​，"
+"​远离​凡人​窥探​的​眼睛​。​一些​勇敢​、​强大​的​凡人​甚至​与​任何​一​方​结盟​，​并​帮助​指挥​罪恶​战争"
+"​的​进程"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:509
@@ -9480,18 +9478,18 @@ msgid ""
 "faith. If Diablo were to be released, he would seek a body that is easily "
 "controlled as he would be very weak - perhaps that of an old man or a child."
 msgstr ""
-"注意并见证这里的真理，因为它们是赫拉迪姆最后的遗产。近三百年前，人们知道燃烧"
-"地狱的三大恶魔神秘地来到了我们的世界。兄弟三人蹂躏东方的土地数十年，而人类却"
-"在他们身后战栗。我们的骑士团——赫拉迪姆——是由一群神秘的法师建立的，目的是一劳"
-"永逸地追捕和俘虏这三个恶魔。\n"
+"注意​并​见证​这里​的​真理​，​因为​它们​是​赫拉迪姆​最后​的​遗产​。​近​三百​年​前​，​人们​知道​燃烧​地狱"
+"​的​三​大​恶魔​神秘​地​来到​了​我们​的​世界​。​兄弟​三​人​蹂躏​东方​的​土地​数十​年​，​而​人类​却​在"
+"​他们​身​后​战栗​。​我们​的​骑士团​——​赫拉迪姆​——​是​由​一​群​神秘​的​法师​建立​的​，​目的​是​一​"
+"劳永逸​地​追捕​和​俘虏​这​三​个​恶魔​。​\n"
 " \n"
-"最初的赫拉迪姆在被称为“灵魂石”的强大文物中捕获了其中两个，并将它们深埋在荒凉"
-"的东部沙漠之下。第三个恶魔逃脱了追捕，逃到了西部，许多赫拉迪姆人都在追捕。第"
-"三个恶魔-被称为迪亚波罗，恐惧之王-最终被俘虏，他的灵魂石和埋在这个迷宫的本"
-"质。\n"
+"​最初​的​赫拉迪姆​在​被​称为​“​灵魂​石​”​的​强大​文物​中​捕获​了​其中​两​个​，​并​将​它们​深​埋​在"
+"​荒凉​的​东部​沙漠​之下​。​第三​个​恶魔​逃脱​了​追捕​，​逃到​了​西部​，​许多​赫拉迪姆人​都​在​追捕​。​"
+"第三​个​恶魔-​被​称为​迪亚波罗​，​恐惧​之​王​-​最终​被​俘虏​，​他​的​灵魂石​和​埋​在​这​个​迷宫​的​"
+"本质​。​\n"
 " \n"
-"要被警告，灵魂之石必须防止被那些不信的人发现。如果迪亚波罗被释放，他会寻找一"
-"个身体很容易控制，因为他会非常虚弱-也许是一个老人或儿童"
+"​要​被​警告​，​灵魂​之石​必须​防止​被​那些​不​信​的​人​发现​。​如果​迪亚波罗​被​释放​，​他​会​寻找​一"
+"​个​身体​很​容易​控制​，​因为​他​会​非常​虚弱-​也许​是​一​个​老人​或​儿童"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:511
@@ -9504,10 +9502,10 @@ msgid ""
 "the factions of Belial and Azmodan while the forces of the High Heavens "
 "continually battered upon the very Gates of Hell."
 msgstr ""
-"因此，在燃烧的地狱里发生了一场被称为黑暗放逐的伟大革命。较小的邪恶推翻了三个"
-"主要的邪恶，并将他们的精神形式放逐到凡人的领域。恶魔彼列尔（谎言之王）和阿兹"
-"莫丹（罪恶之王）在兄弟三人不在的时候争夺地狱的统治权。所有的地狱恶魔都在彼列"
-"尔和阿兹莫丹两个派系之间分化，而天堂的力量不断地冲击着地狱的大门。"
+"因此​，​在​燃烧​的​地狱​里​发生​了​一​场​被​称为​黑暗​放逐​的​伟大​革命​。​较​小​的​邪恶​推翻​了​三​"
+"个​主要​的​邪恶​，​并​将​他们​的​精神​形式​放逐​到​凡人​的​领域​。​恶魔彼​列尔​（​谎言之王​）​和​阿兹莫"
+"丹​（​罪恶​之​王​）​在​兄弟​三​人​不​在​的​时候​争夺​地狱​的​统治权​。​所有​的​地狱​恶魔​都​在​彼列尔"
+"​和​阿兹莫丹​两​个​派系​之间​分化​，​而​天堂​的​力量​不断​地​冲击​着​地狱​的​大门​。"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:513
@@ -9518,9 +9516,9 @@ msgid ""
 "secretive Order of mortal magi named the Horadrim, who quickly became adept "
 "at hunting demons. They also made many dark enemies in the underworlds."
 msgstr ""
-"许多恶魔为了寻找三兄弟来到了凡间。这些恶魔被天使们带到了凡间，他们在东方的广"
-"大城市里猎杀他们。天使们与一个隐秘的名为赫拉迪姆法师教团结盟，他很快就变得善"
-"于猎杀恶魔。他们也在阴间制造了许多黑暗的敌人。"
+"许多​恶魔​为了​寻找​三​兄弟​来到​了​凡间​。​这些​恶魔​被​天使们​带到​了​凡​间​，​他们​在​东方​的​广大​"
+"城市​里​猎杀​他们​。​天使们​与​一​个​隐秘​的​名​为​赫拉迪姆​法师​教团​结盟​，​他​很​快​就​变得​善于​猎"
+"杀​恶魔​。​他们​也​在​阴间​制造​了​许多​黑暗​的​敌人​。"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:515
@@ -9539,15 +9537,15 @@ msgid ""
 "He will then arise to free his Brothers and once more fan the flames of the "
 "Sin War..."
 msgstr ""
-"因此，这三个主要的恶魔以灵魂的形式被放逐到凡人的领域，在东方缝了几十年的混乱"
-"之后，他们被凡人赫拉迪姆的诅咒的秩序所追捕。赫拉迪姆使用了被称为“灵魂石”的人"
-"工制品来容纳仇恨之主墨菲斯托和他的兄弟毁灭之主巴力的精髓。最小的弟弟——恐惧之"
-"王迪亚波罗——逃到了西方。\n"
+"因此​，​这​三​个​主要​的​恶魔​以​灵魂​的​形式​被​放逐​到​凡人​的​领域​，​在​东方​缝​了​几十​年​的​混"
+"乱​之后​，​他们​被​凡人​赫拉迪姆​的​诅咒​的​秩序​所​追捕​。​赫拉迪姆​使用​了​被​称为​“​灵魂​石​”​的​"
+"人工​制品​来​容纳​仇恨​之​主​墨菲斯托​和​他​的​兄弟​毁灭​之​主巴力​的​精髓​。​最​小​的​弟弟​——​恐惧​"
+"之​王迪亚波罗​——​逃到​了​西方​。​\n"
 " \n"
-"最终，赫拉迪姆也在一块灵魂石中俘获了迪亚波罗，并将他埋葬在一座被遗忘的古老大"
-"教堂下。在那里，恐怖之主沉睡着，等待着他的重生。你们要知道，他要寻求一个充满"
-"青春和力量的身体来占有，一个清白和容易控制的身体。然后他会起来解救他的兄弟"
-"们，再一次煽起原罪之战的火焰"
+"​最终​，​赫拉迪姆​也​在​一​块​灵魂石中​俘​获​了​迪亚波罗​，​并​将​他​埋葬​在​一​座​被​遗忘​的​古老大​"
+"教堂​下​。​在​那里​，​恐怖​之​主​沉睡​着​，​等待​着​他​的​重生​。​你们​要​知道​，​他​要​寻求​一​个​"
+"充满​青春​和​力量​的​身体​来​占有​，​一​个​清白​和​容易​控制​的​身体​。​然后​他​会​起来​解救​他​的​兄"
+"弟们​，​再​一​次​煽起​原罪之战​的​火焰"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:517
@@ -9559,10 +9557,10 @@ msgid ""
 "that have brought this discord to the realms of man. My lord has named the "
 "battle for this world and all who exist here the Sin War."
 msgstr ""
-"所有赞扬迪亚波罗-恐惧之王和黑暗流放的幸存者。当他从沉睡中醒来时，我的主人和主"
-"人对我说了一些很少有人知道的秘密。他告诉我，天上的王国和燃烧的地狱的深坑正在"
-"进行一场永恒的战争。他揭示了将这种不和谐带到人类领域的力量。我主已将这场为世"
-"界而战的战争和所有在这里生存的人命名为原罪之战。"
+"所有​赞扬迪亚波罗-恐惧​之​王​和​黑暗​流放​的​幸存者​。​当​他​从​沉睡​中醒​来​时​，​我​的​主人​和​主人​"
+"对​我​说​了​一些​很​少​有​人​知道​的​秘密​。​他​告诉​我​，​天上​的​王国​和​燃烧​的​地狱​的​深坑​正在"
+"​进行​一​场​永恒​的​战争​。​他​揭示​了​将​这​种​不​和谐​带到​人类​领域​的​力量​。​我​主​已​将​这​场"
+"​为​世界​而​战​的​战争​和​所有​在​这里​生存​的​人​命名​为​原罪之战​。"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:519
@@ -9574,10 +9572,10 @@ msgid ""
 "beneath the sands of the east. Once my Lord releases his Brothers, the Sin "
 "War will once again know the fury of the Three."
 msgstr ""
-"荣耀和赞许给迪亚波罗-恐惧之王和三人之首。我主对我谈到他的两个兄弟，墨菲斯托和"
-"巴尔，他们很久以前被放逐到这个世界上。我的主希望等待时机，利用他令人敬畏的能"
-"力，以便将他被俘的兄弟们从东方沙漠下的坟墓中解救出来。一旦我主释放了他的兄"
-"弟，原罪之战将再次知道三人的愤怒"
+"荣耀​和​赞许​给​迪亚波罗-恐惧​之​王​和​三​人​之​首​。​我​主​对​我​谈到​他​的​两​个​兄弟​，​墨菲斯托​"
+"和​巴尔​，​他们​很​久​以前​被​放逐​到​这个​世界​上​。​我​的​主​希望​等待​时机​，​利用​他​令​人​敬畏​"
+"的​能力​，​以便​将​他​被​俘​的​兄弟们​从​东方​沙漠下​的​坟墓​中​解救​出来​。​一旦​我​主​释放​了​他​的"
+"​兄弟​，​原罪​之​战​将​再次​知道​三​人​的​愤怒"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:521
@@ -9592,12 +9590,12 @@ msgid ""
 "Diablo's call and pray that I will be rewarded when he at last emerges as "
 "the Lord of this world."
 msgstr ""
-"向迪亚波罗致敬和献祭-恐惧之王和灵魂的毁灭者。当我从睡梦中唤醒我的主人时，他试"
-"图拥有一个凡人的形体。迪亚波罗试图夺走李奥瑞克国王的尸体，但我的主人被囚禁后"
-"太虚弱了。我的主人需要一个简单和无辜的锚到这个世界上，所以发现男孩艾伯莱希特"
-"特是完美的任务。当善良的国王李奥瑞克被迪亚波罗的失败激怒时，我绑架了他的儿子"
-"艾伯莱希特，把他带到我的主人面前。我现在等待着迪亚波罗的召唤，祈祷当他最终成"
-"为这个世界的主时，我会得到回报"
+"向​迪亚波​罗致敬​和​献祭​-​恐惧​之​王​和​灵魂​的​毁灭者​。​当​我​从​睡梦​中​唤醒​我​的​主人​时​，​他"
+"​试图​拥有​一​个​凡人​的​形体​。​迪亚波罗​试图​夺走​李奥瑞克​国王​的​尸体​，​但​我​的​主人​被​囚禁​后​"
+"太​虚​弱​了​。​我​的​主人​需要​一​个​简单​和​无辜​的​锚​到​这个​世界​上​，​所以​发现​男孩​艾伯莱希特特"
+"​是​完美​的​任务​。​当善良​的​国王​李奥瑞克​被​迪亚波罗的​失败​激怒​时​，​我​绑架​了​他​的​儿子​艾伯莱希"
+"特​，​把​他​带到​我​的​主人​面​前​。​我​现在​等待​着​迪亚波罗的​召唤​，​祈祷​当​他​最终​成为​这​个​世"
+"界​的​主​时​，​我​会​得到​回报"
 
 #. TRANSLATORS: Neutral Text spoken by Ogden
 #: Source/textdat.cpp:523
@@ -9613,14 +9611,14 @@ msgid ""
 " \n"
 "Perhaps I can tell you more if we speak again. Good luck."
 msgstr ""
-"谢天谢地，你终于回来了！\n"
-"我的朋友，你居住过的这里发生了巨大的变化。一切都很平静，直到黑暗骑士到来，摧"
-"毁了我们的村子。很多没有抵抗的人直接被砍杀，而那些拿起武器反抗的人也被屠杀或"
-"是被抓走成为奴隶，甚至更糟。城镇边的教堂已经被亵渎，用作黑暗仪式。回荡在叫声"
-"夜晚不是人可以忍受的，也许一些镇民还活着。这条我的旅店和这铁匠铺之间的路通向"
-"教堂，去拯救那些人吧。\n"
+"谢天谢地​，​你​终于​回来​了​！​\n"
+"​我​的​朋友​，​你​居住​过​的​这里​发生​了​巨大​的​变化​。​一切​都​很​平静​，​直​到​黑暗​骑士​到来​，"
+"​摧毁​了​我们​的​村子​。​很多​没有​抵抗​的​人​直接​被​砍杀​，​而​那些​拿起​武器​反抗​的​人​也​被​屠杀"
+"​或是​被​抓​走​成为​奴隶​，​甚至​更​糟​。​城镇​边​的​教堂​已经​被​亵渎​，​用​作​黑暗​仪式​。​回荡​在"
+"​叫声​夜晚​不​是​人​可以​忍受​的​，​也许​一些​镇民​还​活​着​。​这​条​我​的​旅店​和​这​铁​匠铺​之间​"
+"的​路​通​向​教堂​，​去​拯救​那些​人​吧​。​\n"
 "\n"
-"如果你想要知道更多事，就再和我谈谈，我也许能告诉你。祝你好运。"
+"​如果​你​想要​知道​更​多​事​，​就​再​和​我​谈谈​，​我​也许​能​告诉​你​。​祝​你​好运​。"
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:525 Source/textdat.cpp:533
@@ -9629,8 +9627,8 @@ msgid ""
 "any who would seek to steal the treasures secured within this room.  So "
 "speaks the Lord of Terror, and so it is written."
 msgstr ""
-"在英雄走廊的另一端藏匿着白骨密室。任何胆敢盗取此地财宝的人，都将遭受永恒的死"
-"亡。恐惧之王如是说，本书也如实写。"
+"在​英雄​走廊​的​另​一​端​藏匿​着​白骨密室​。​任何​胆​敢​盗取​此​地​财宝​的​人​，​都​将​遭受​永恒​的​"
+"死亡​。​恐惧​之​王​如是​说​，​本​书​也​如实​写​。"
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:531 Source/textdat.cpp:539
@@ -9640,8 +9638,8 @@ msgid ""
 "fulfill his endless sacrifices to the Dark ones who scream for one thing - "
 "blood."
 msgstr ""
-"地狱的军械库如同鲜血战神的私宅。其所到之处，无不留下成千上万的残肢断臂。无论"
-"是天使还是人类都将遭到残杀，只为了能够呈上邪魔们最渴望的东西——鲜血。"
+"地狱​的​军械库​如同​鲜血​战神​的​私宅​。​其​所​到​之​处​，​无​不​留下​成千上万​的​残肢断臂​。​无论​是​"
+"天使​还是​人类​都​将​遭到​残杀​，​只​为了​能够​呈上​邪魔们​最​渴望​的​东西​——​鲜血​。"
 
 #. TRANSLATORS: Quest text spoken by Adria
 #: Source/textdat.cpp:541
@@ -9650,8 +9648,8 @@ msgid ""
 "a treasure that is hidden less so.  I will leave you with this.  Do not let "
 "the sands of time confuse your search."
 msgstr ""
-"继续你的任务。找到丢失的宝藏并不容易。找到一个藏得不那么深的宝藏。我把这个留"
-"给你。不要让时间的沙子迷惑了你的寻找"
+"继续​你​的​任务​。​找到​丢失​的​宝藏​并不​容易​。​找到​一​个​藏得​不​那么​深​的​宝藏​。​我​把​这个​留"
+"给​你​。​不​要​让​时间​的​沙子​迷惑​了​你​的​寻找"
 
 #. TRANSLATORS: Quest text spoken by Griswold
 #: Source/textdat.cpp:543
@@ -9661,15 +9659,15 @@ msgid ""
 "don't match our town at all.  I'd keep my mind on what lies below the "
 "cathedral and not what lies below our topsoil."
 msgstr ""
-"什么？！这是愚蠢的。崔斯特姆这里没有宝藏。让我看看！！啊，看这些画不准确。他"
-"们根本不符合我们的城市。我会把心思放在大教堂下面，而不是我们的表土下面"
+"什么​？​！​这​是​愚蠢​的​。​崔斯特姆​这里​没有​宝藏​。​让​我​看看​！​！​啊​，​看​这些​画​不​准确​。​"
+"他们​根本​不​符合​我们​的​城市​。​我​会​把​心思放​在​大​教堂​下面​，​而​不​是​我们​的​表土​下面"
 
 #. TRANSLATORS: Quest text spoken by Pipin
 #: Source/textdat.cpp:545
 msgid ""
 "I really don't have time to discuss some map you are looking for.  I have "
 "many sick people that require my help and yours as well."
-msgstr "我真的没有时间讨论你要找的地图。我有许多病人需要我和你的帮助"
+msgstr "我​真的​没有​时间​讨论​你​要​找​的​地图​。​我​有​许多​病人​需要​我​和​你​的​帮助"
 
 #. TRANSLATORS: Quest text spoken by Adria
 #: Source/textdat.cpp:547 Source/textdat.cpp:559
@@ -9678,8 +9676,8 @@ msgid ""
 "His honor stripped and his visage altered.  He is trapped in immortal "
 "torment.  Charged to conceal the very thing that could free him."
 msgstr ""
-"曾经引以为傲的Iswall深陷在这个世界的表面之下。他的荣誉被剥夺了，面容也变了。"
-"他被困在不朽的折磨之中。被指控隐瞒能让他自由的事情"
+"曾经​引​以为​傲​的​Iswall​深陷​在​这个​世界​的​表面​之下​。​他​的​荣誉​被​剥夺​了​，​面容​也​变​"
+"了​。​他​被困​在​不朽​的​折磨​之中​。​被​指控​隐瞒​能​让​他​自由​的​事情"
 
 #. TRANSLATORS: Quest text spoken by Ogden
 #: Source/textdat.cpp:549
@@ -9688,8 +9686,8 @@ msgid ""
 "at you later when you were running around the town with your nose in the "
 "dirt.  I'd ignore it."
 msgstr ""
-"我敢打赌，怀特看见你来了，就装出一副样子，这样他就可以在你鼻子埋在泥土里在城"
-"里跑的时候嘲笑你了。我会忽略它"
+"我​敢​打赌​，​怀特​看见​你​来​了​，​就​装​出​一​副样子​，​这样​他​就​可以​在​你​鼻子​埋​在​泥土​里​"
+"在​城里​跑​的​时候​嘲笑​你​了​。​我​会​忽略​它"
 
 #. TRANSLATORS: Quest text spoken by Cain
 #: Source/textdat.cpp:551
@@ -9699,17 +9697,16 @@ msgid ""
 "treasure are common fantasies of any child.  Wirt seldom indulges in "
 "youthful games.  So it may just be his imagination."
 msgstr ""
-"曾经有一段时间，这个城镇是远道而来的旅行者的常去之地。从那以后发生了很大的变"
-"化。但隐藏的洞穴和埋藏的宝藏是任何孩子的共同幻想。怀特很少沉迷于年轻人的游"
-"戏。所以这可能只是他的想象"
+"曾经​有​一​段​时间​，​这​个​城镇​是​远道而​来​的​旅行者​的​常去之​地​。​从​那​以后​发生​了​很​大​的​"
+"变化​。​但​隐藏​的​洞穴​和​埋藏​的​宝藏​是​任何​孩子​的​共同​幻想​。​怀特​很少​沉迷​于​年轻​人​的​游戏"
+"​。​所以​这​可​能​只​是​他​的​想象"
 
 #. TRANSLATORS: Quest text spoken by Farnham
 #: Source/textdat.cpp:553
 msgid ""
 "Listen here.  Come close.  I don't know if you know what I know, but you've "
 "have really got something here.  That's a map."
-msgstr ""
-"听着。靠近点。我不知道你是否知道我所知道的，但你真的有所收获。那是一张地图"
+msgstr "听​着​。​靠近点​。​我​不​知道​你​是否​知道​我​所​知道​的​，​但​你​真的​有所​收获​。​那​是​一​张​地图"
 
 #. TRANSLATORS: Quest text spoken by Gillian
 #: Source/textdat.cpp:555
@@ -9721,10 +9718,10 @@ msgid ""
 "offering would be altered in some strange way.  I don't know if this is just "
 "the talk of an old sick woman, but anything seems possible these days."
 msgstr ""
-"我祖母经常给我讲一些关于居住在教堂外墓地的奇怪势力的故事。你可能会对其中一个"
-"很感兴趣。她说，如果你把合适的祭品留在墓地，进入大教堂为死者祈祷，然后再回"
-"来，祭品会以某种奇怪的方式改变。我不知道这是不是一个老病妇的谈话，但最近似乎"
-"什么都有可能"
+"我​祖母​经常​给​我​讲​一些​关于​居住​在​教堂​外​墓地​的​奇怪​势力​的​故事​。​你​可能​会​对​其中​一​个"
+"​很​感​兴趣​。​她​说​，​如果​你​把​合适​的​祭品​留​在​墓地​，​进入​大​教堂​为​死者​祈祷​，​然后​再​"
+"回来​，​祭品​会​以​某​种​奇怪​的​方式​改变​。​我​不​知道​这​是​不​是​一​个​老​病妇​的​谈话​，​但​最"
+"近​似乎​什么​都​有​可能"
 
 #. TRANSLATORS: Quest text spoken by Wirt
 #: Source/textdat.cpp:557
@@ -9733,8 +9730,8 @@ msgid ""
 "interested in picking up a few things from you.  Or better yet, don't you "
 "need some rare and expensive supplies to get you through this ordeal?"
 msgstr ""
-"嗯。你说的是一个巨大而神秘的宝藏。嗯。也许我有兴趣从你那里得到一些东西。或者"
-"更好的是，你不需要一些稀有而昂贵的物资来度过这场磨难吗"
+"嗯​。​你​说​的​是​一​个​巨大​而​神秘​的​宝藏​。​嗯​。​也许​我​有​兴趣​从​你​那里​得到​一些​东西​。​"
+"或者​更​好​的​是​，​你​不​需要​一些​稀有​而​昂贵​的​物资​来​度过​这​场​磨难​吗"
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
 #: Source/textdat.cpp:561
@@ -9747,10 +9744,11 @@ msgid ""
 "you could destroy it, I would be forever grateful. I'd do it myself, but "
 "someone has to stay here with the cows..."
 msgstr ""
-"所以，你是每个人都在谈论的英雄。也许你能帮助一个贫穷的农民摆脱困境？在我的果"
-"园的边缘，就在这里的南边，有一个可怕的东西从地里冒出来！我不能得到我的庄稼或"
-"我的捆干草，我可怜的奶牛会饿死。巫婆把这个给了我，说它会把那东西从我的地里炸"
-"出来。如果你能毁掉它，我将永远感激。我自己会做的，但总得有人留下来陪奶牛"
+"所以​，​你​是​每​个​人​都​在​谈论​的​英雄​。​也许​你​能​帮助​一​个​贫穷​的​农民​摆脱​困境​？​在​我​"
+"的​果园​的​边缘​，​就​在​这里​的​南边​，​有​一​个​可怕​的​东西​从​地​里​冒​出来​！​我​不​能​得到​我"
+"​的​庄稼​或​我​的​捆干草​，​我​可怜​的​奶牛会​饿死​。​巫婆​把​这个​给​了​我​，​说​它​会​把​那​东西​"
+"从​我​的​地​里​炸​出来​。​如果​你​能​毁掉​它​，​我​将​永远​感激​。​我​自己​会​做​的​，​但​总​得​有"
+"​人​留​下来​陪奶牛"
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
 #: Source/textdat.cpp:563
@@ -9758,8 +9756,8 @@ msgid ""
 "I knew that it couldn't be as simple as that witch made it sound. It's a sad "
 "world when you can't even trust your neighbors."
 msgstr ""
-"我知道事情不会像巫婆说的那么简单。当你连邻居都不能信任的时候，这是一个悲哀的"
-"世界"
+"我​知道​事情​不​会​像​巫婆​说​的​那么​简单​。​当​你​连​邻居​都​不​能​信任​的​时候​，​这​是​一​个​悲"
+"哀​的​世界"
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
 #: Source/textdat.cpp:565
@@ -9768,8 +9766,8 @@ msgid ""
 "it? You what? Oh, don't tell me you lost it! Those things don't come cheap, "
 "you know. You've got to find it, and then blast that horror out of our town."
 msgstr ""
-"它不见了吗？你把它送回了孕育它的阴间吗？你什么？哦，别告诉我你丢了！你知道，"
-"那些东西不便宜。你一定要找到它，然后把那恐惧的东西轰出去"
+"它​不见​了​吗​？​你​把​它​送回​了​孕育​它​的​阴间​吗​？​你​什么​？​哦​，​别​告诉​我​你​丢​了​！​你"
+"​知道​，​那些​东西​不便宜​。​你​一定​要​找到​它​，​然后​把​那​恐惧​的​东西​轰​出去"
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
 #: Source/textdat.cpp:567
@@ -9779,9 +9777,9 @@ msgid ""
 "church, and so forth, these are trying times. I am but a poor farmer, but "
 "here -- take this with my great thanks."
 msgstr ""
-"我听到爆炸声了！多谢你，善良的陌生人。随着所有这些东西从地下冒出来，怪物占领"
-"了教堂，等等，这些都是艰难的时刻。我只是一个贫穷的农民，但在这里——请接受我的"
-"谢意"
+"我​听到​爆炸声​了​！​多谢​你​，​善良​的​陌生人​。​随着​所有​这些​东西​从​地下​冒​出来​，​怪物​占领​了​"
+"教堂​，​等等​，​这些​都​是​艰难​的​时刻​。​我​只​是​一​个​贫穷​的​农民​，​但​在​这里​——​请​接受​我"
+"​的​谢意"
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
 #: Source/textdat.cpp:569
@@ -9791,13 +9789,13 @@ msgid ""
 "those creatures you could come back... and spare a little time to help a "
 "poor farmer?"
 msgstr ""
-"哦，我有这么大的麻烦…也许…不，我不能强加给你，还有其他的麻烦。也许在你清除了"
-"教堂里的一些生物之后你可以回来。。。抽出一点时间去帮助一个贫穷的农民"
+"哦​，​我​有​这么​大​的​麻烦​…​也许​…​不​，​我​不​能​强加​给​你​，​还​有​其他​的​麻烦​。​也许​在​"
+"你​清除​了​教堂​里​的​一些​生物​之后​你​可以​回来​。​。​。​抽出​一点​时间​去​帮助​一​个​贫穷​的​农民"
 
 #. TRANSLATORS: Quest text spoken by Little Girl
 #: Source/textdat.cpp:571
 msgid "Waaaah! (sniff) Waaaah! (sniff)"
-msgstr "哇啊(嗅）哇啊(嗅嗅）"
+msgstr "哇​啊​(​嗅​）​哇​啊​(嗅嗅​）"
 
 #. TRANSLATORS: Quest text spoken by Little Girl
 #: Source/textdat.cpp:572
@@ -9807,9 +9805,9 @@ msgid ""
 "but we snuck over there, and then suddenly this BUG came out!  We ran away "
 "but Theo fell down and the bug GRABBED him and took him away!"
 msgstr ""
-"我失去了西奥！我失去了我最好的朋友！我们在河边玩，西奥说他想去看看绿色的东"
-"西。我说我们不应该，但我们偷偷溜过去，然后突然这个虫子出来了！我们逃跑了，但"
-"西奥摔倒了，虫子抓住他，把他带走了"
+"我​失去​了​西奥​！​我​失去​了​我​最​好​的​朋友​！​我们​在​河​边​玩​，​西奥​说​他​想​去​看看​绿色​的"
+"​东西​。​我​说​我们​不​应该​，​但​我们​偷偷​溜​过去​，​然后​突然​这个​虫子​出来​了​！​我们​逃跑​了​，"
+"​但​西奥​摔倒​了​，​虫子​抓住​他​，​把​他​带走​了"
 
 #. TRANSLATORS: Quest text spoken by Little Girl
 #: Source/textdat.cpp:574
@@ -9817,7 +9815,8 @@ msgid ""
 "Didja find him?  You gotta find Theodore, please!  He's just little.  He "
 "can't take care of himself!  Please!"
 msgstr ""
-"你找到他了吗？你得找到西奥多，求你了！他只是个小孩子。他不能照顾自己！求你了"
+"你​找到​他​了​吗​？​你​得​找到​西奥多​，​求​你​了​！​他​只​是​个​小​孩子​。​他​不​能​照顾​自己​！​"
+"求​你​了"
 
 #. TRANSLATORS: Quest text spoken by Little Girl (Quest End)
 #: Source/textdat.cpp:576
@@ -9826,8 +9825,8 @@ msgid ""
 "scare you?  Hey!  Ugh!  There's something stuck to your fur!  Ick!  Come on, "
 "Theo, let's go home!  Thanks again, hero person!"
 msgstr ""
-"你找到他了！你找到他了！非常感谢。哦，西奥，那些讨厌的虫子吓到你了吗？嘿啊！"
-"有东西粘在你的毛上了！哎呀！来吧，西奥，我们回家吧！再次感谢，英雄人物"
+"你​找到​他​了​！​你​找到​他​了​！​非常​感谢​。​哦​，​西奥​，​那些​讨厌​的​虫子吓到​你​了​吗​？​嘿​啊"
+"​！​有​东西粘​在​你​的​毛上​了​！​哎呀​！​来​吧​，​西奥​，​我们​回家​吧​！​再次​感谢​，​英雄​人物"
 
 #. TRANSLATORS: Quest text spoken by Defiler (Hostile)
 #: Source/textdat.cpp:578
@@ -9835,15 +9834,15 @@ msgid ""
 "We have long lain dormant, and the time to awaken has come.  After our long "
 "sleep, we are filled with great hunger.  Soon, now, we shall feed..."
 msgstr ""
-"我们早已沉睡，觉醒的时刻已经到来。长眠之后，我们感到非常饥饿。很快，现在，我"
-"们将喂养"
+"我们​早​已​沉睡​，​觉醒​的​时刻​已经​到来​。​长眠​之后​，​我们​感到​非常​饥饿​。​很​快​，​现在​，​我们"
+"​将​喂养"
 
 #. TRANSLATORS: Quest text spoken by Defiler (Hostile)
 #: Source/textdat.cpp:580
 msgid ""
 "Have you been enjoying yourself, little mammal?  How pathetic. Your little "
 "world will be no challenge at all."
-msgstr "你玩得开心吗，小哺乳动物？真可怜。你的小世界不会是什么挑战"
+msgstr "你​玩​得​开心​吗​，​小​哺​乳​动物​？​真​可怜​。​你​的​小​世界​不​会​是​什么​挑战"
 
 #. TRANSLATORS: Quest text spoken by Defiler (Hostile)
 #: Source/textdat.cpp:582
@@ -9852,15 +9851,15 @@ msgid ""
 "men call home.  Our tendrils shall envelop this world, and we will feast on "
 "the flesh of its denizens.  Man shall become our chattel and sustenance."
 msgstr ""
-"这些地必被玷污，我们的后裔必漫过人们称为家的田地。我们的卷须要包裹这世界，我"
-"们要以其居民的肉为食。人类将成为我们的动产和食物"
+"这些​地必​被​玷污​，​我们​的​后裔​必漫​过​人们​称为​家​的​田地​。​我们​的​卷须​要​包裹​这​世界​，​我们"
+"​要​以​其​居民​的​肉为食​。​人类​将​成为​我们​的​动产​和​食物"
 
 #. TRANSLATORS: Quest text spoken by Defiler (Hostile)
 #: Source/textdat.cpp:584
 msgid ""
 "Ah, I can smell you...you are close! Close! Ssss...the scent of blood and "
 "fear...how enticing..."
-msgstr "啊，我能闻到你…你就在附近！接近！血和恐惧的味道…多么诱人"
+msgstr "啊​，​我​能​闻到​你​…​你​就​在​附近​！​接近​！​血​和​恐惧​的​味道​…​多么​诱​人"
 
 #. TRANSLATORS: Quest text spoken by Narrator
 #: Source/textdat.cpp:592
@@ -9879,30 +9878,30 @@ msgid ""
 "within all things and beyond all things. Light and unity are the products of "
 "this holy foundation, a unity of purpose and a unity of possession."
 msgstr ""
-"在金光之年，一座大教堂被立了起来。这个圣地的基石是用半透明的安提拉石雕刻而成"
-"的，安提拉石是以与赫拉迪姆分享力量的天使命名的。\n"
+"在​金光​之​年​，​一​座​大​教堂​被​立​了​起来​。​这个​圣地​的​基石​是​用半​透明​的​安提拉​石​雕刻​而​"
+"成​的​，​安提拉石​是​以​与​赫拉迪姆​分享​力量​的​天使​命名​的​。​\n"
 " \n"
-"在画影子的那一年，大地震动，大教堂粉碎倒塌。随着地下墓穴和城堡的建造开始，人"
-"们开始抵抗原罪之战的蹂躏，废墟被清理出来寻找石头。就这样，基石从人们的眼中消"
-"失了。\n"
+"​在​画影子​的​那​一​年​，​大​地​震动​，​大​教堂​粉碎​倒塌​。​随着​地下​墓穴​和​城堡​的​建造​开始​，​"
+"人们​开始​抵抗​原罪之战​的​蹂躏​，​废墟​被​清理​出来​寻找​石头​。​就​这样​，​基石​从​人们​的​眼​中​消失"
+"​了​。​\n"
 " \n"
-"石头属于这个世界，也属于所有的世界，就像光既存在于万物之中，也存在于万物之"
-"外。光明与统一是这个神圣基础的产物，是目的的统一和占有的统一。"
+"​石头​属于​这个​世界​，​也​属于​所有​的​世界​，​就​像​光​既​存在​于​万物​之​中​，​也​存在​于​万物​之"
+"外​。​光明​与​统一​是​这​个​神圣​基础​的​产物​，​是​目的​的​统一​和​占有​的​统一​。"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:594
 msgid "Moo."
-msgstr "哞。"
+msgstr "哞​。"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:595
 msgid "I said, Moo."
-msgstr "我说了，哞。"
+msgstr "我​说​了​，​哞​。"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:596
 msgid "Look I'm just a cow, OK?"
-msgstr "听着，我只是一头牛，好吗？"
+msgstr "听​着​，​我​只​是​一​头​牛​，​好​吗​？"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:597
@@ -9918,26 +9917,27 @@ msgid ""
 "my house, it's just south of the fork in the river... you know... the one "
 "with the overgrown vegetable garden."
 msgstr ""
-"好吧，好吧。我不是一头牛。我一般不会这样到处走；但是，当时我正坐在家里处理自"
-"己的事情，突然这些虫子、藤蔓、球茎之类的东西开始从地板上冒出来。。。太可怕"
-"了！如果我有正常的衣服穿，就不会那么糟糕了。嘿你能回我家帮我拿衣服吗？棕色"
-"的，不是灰色的，那是晚装的。我会自己做的，但我不想让任何人看到我这样。给，拿"
-"着这个，你可能需要它。。。杀死那些长满一切的东西。你不会错过我家的，就在河的"
-"岔口南边。。。你知道的。。。有杂草丛生的菜园的那个"
+"好​吧​，​好​吧​。​我​不​是​一​头​牛​。​我​一般​不​会​这样​到处​走​；​但是​，​当时​我​正​坐​在​家​"
+"里​处理​自己​的​事情​，​突然​这些​虫​子​、​藤蔓​、​球茎​之类​的​东西​开始​从​地板​上​冒​出来​。​。​。"
+"​太​可怕​了​！​如果​我​有​正常​的​衣服​穿​，​就​不​会​那么​糟糕​了​。​嘿​你​能回​我​家​帮​我​拿​衣"
+"服​吗​？​棕色​的​，​不​是​灰色​的​，​那​是​晚装​的​。​我​会​自己​做​的​，​但​我​不​想​让​任何​人​"
+"看到​我​这样​。​给​，​拿​着​这个​，​你​可能​需要​它​。​。​。​杀死​那些​长满​一切​的​东西​。​你​不​会"
+"​错过​我​家​的​，​就​在​河​的​岔口​南​边​。​。​。​你​知道​的​。​。​。​有​杂草​丛生​的​菜园​的​那​"
+"个"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:599
 msgid ""
 "What are you wasting time for?  Go get my suit!  And hurry!  That Holstein "
 "over there keeps winking at me!"
-msgstr "你在浪费时间干什么？去拿我的衣服！快点！那边那个荷斯坦人一直对我眨眼"
+msgstr "你​在​浪费​时间​干​什么​？​去​拿​我​的​衣服​！​快点​！​那边​那​个​荷斯坦人​一直​对​我​眨眼"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:601
 msgid ""
 "Hey, have you got my suit there?  Quick, pass it over!  These ears itch like "
 "you wouldn't believe!"
-msgstr "嘿，你有我的西装吗？快，传过来！这些耳朵痒得你都不敢相信"
+msgstr "嘿​，​你​有​我​的​西装​吗​？​快​，​传​过来​！​这些​耳朵​痒​得​你​都​不​敢​相信"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:603
@@ -9946,8 +9946,8 @@ msgid ""
 "occasions!  I can't wear THIS.  What are you, some kind of weirdo?  I need "
 "the BROWN suit."
 msgstr ""
-"不不不！这是我的灰色西装！这是晚装！正式场合！我不能穿这个。你是什么怪人？我"
-"需要那套棕色的西装"
+"不​不​不​！​这​是​我​的​灰色​西装​！​这​是​晚装​！​正式​场合​！​我​不​能​穿​这个​。​你​是​什么​怪人"
+"​？​我​需要​那​套​棕色​的​西装"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:605
@@ -9958,18 +9958,17 @@ msgid ""
 "you could use a new... yknowwhatImean?  The whole adventurer motif is just "
 "so... retro.  Just a word of advice, eh?  Ciao."
 msgstr ""
-"啊，好多了。呼！终于有尊严了！我的鹿角是直的吗？很好。听着，非常感谢你帮我。"
-"来，把这个当作礼物；而且，你知道。。。一点时尚提示。。。你可以用一点。。。你"
-"可以用一个新的。。。你知道什么时候？整个冒险家的主题就是。。。复古的。只是一"
-"句忠告，嗯？再见"
+"啊​，​好多​了​。​呼​！​终于​有​尊严​了​！​我​的​鹿角​是​直​的​吗​？​很​好​。​听​着​，​非常​感谢​你"
+"​帮​我​。​来​，​把​这个​当作​礼物​；​而且​，​你​知道​。​。​。​一点​时尚​提示​。​。​。​你​可以​用​一"
+"点​。​。​。​你​可以​用​一​个​新​的​。​。​。​你​知道​什么​时候​？​整个​冒险家​的​主题​就​是​。​。​。"
+"​复古​的​。​只​是​一​句​忠告​，​嗯​？​再见"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:607
 msgid ""
 "Look.  I'm a cow.  And you, you're monster bait. Get some experience under "
 "your belt!  We'll talk..."
-msgstr ""
-"你看。我是一头牛。而你，你是怪物诱饵。在你的腰带下获得一些经验！我们谈谈"
+msgstr "你​看​。​我​是​一​头​牛​。​而​你​，​你​是​怪物诱饵​。​在​你​的​腰带​下​获得​一些​经验​！​我们​谈​谈"
 
 #. TRANSLATORS: Quest text spoken by Farmer
 #: Source/textdat.cpp:610
@@ -9977,15 +9976,15 @@ msgid ""
 "It must truly be a fearsome task I've set before you. If there was just some "
 "way that I could... would a flagon of some nice, fresh milk help?"
 msgstr ""
-"这一定是我摆在你面前的一项可怕的任务。如果有什么办法我可以。。。喝一大杯新鲜"
-"的牛奶好吗"
+"这​一定​是​我​摆​在​你​面前​的​一​项​可怕​的​任务​。​如果​有​什么​办法​我​可以​。​。​。​喝​一​大杯​"
+"新鲜​的​牛奶​好​吗"
 
 #. TRANSLATORS: Quest text spoken by Farmer
 #: Source/textdat.cpp:612
 msgid ""
 "Oh, I could use your help, but perhaps after you've saved the catacombs from "
 "the desecration of those beasts."
-msgstr "哦，我需要你的帮助，但也许在你从那些野兽的亵渎中拯救了地下墓穴之后"
+msgstr "哦​，​我​需要​你​的​帮助​，​但​也许​在​你​从​那些​野兽​的​亵渎​中​拯救​了​地下​墓穴​之后"
 
 #. TRANSLATORS: Quest text spoken by Farmer
 #: Source/textdat.cpp:614
@@ -9993,8 +9992,8 @@ msgid ""
 "I need something done, but I couldn't impose on a perfect stranger. Perhaps "
 "after you've been here a while I might feel more comfortable asking a favor."
 msgstr ""
-"我需要做点什么，但我不能强加给一个完全陌生的人。也许在你来了一段时间之后，我"
-"会更乐意请你帮个忙"
+"我​需要​做​点​什么​，​但​我​不​能​强加​给​一​个​完全​陌生​的​人​。​也许​在​你​来​了​一​段​时间​之后"
+"​，​我​会​更​乐意​请​你​帮​个​忙"
 
 #. TRANSLATORS: Quest text spoken by Farmer
 #: Source/textdat.cpp:616
@@ -10002,8 +10001,8 @@ msgid ""
 "I see in you the potential for greatness.  Perhaps sometime while you are "
 "fulfilling your destiny, you could stop by and do a little favor for me?"
 msgstr ""
-"我从你身上看到了伟大的潜力。也许某个时候你正在完成你的命运，你可以停下来帮我"
-"一个小忙"
+"我​从​你​身​上​看到​了​伟大​的​潜力​。​也许​某​个​时候​你​正在​完成​你​的​命运​，​你​可以​停​下来​帮"
+"​我​一​个​小​忙"
 
 #. TRANSLATORS: Quest text spoken by Farmer
 #: Source/textdat.cpp:618
@@ -10012,14 +10011,14 @@ msgid ""
 "more powerful. I wouldn't want to injure the village's only chance to "
 "destroy the menace in the church!"
 msgstr ""
-"我想你也许可以帮我，但也许在你变得更有力量之后。我可不想破坏村子里摧毁教堂威"
-"胁的唯一机会"
+"我​想​你​也许​可以​帮​我​，​但​也许​在​你​变得​更​有​力量​之后​。​我​可​不​想​破坏​村子​里​摧毁​教堂"
+"​威胁​的​唯一​机会"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:620
 msgid ""
 "Me, I'm a self-made cow.  Make something of yourself, and... then we'll talk."
-msgstr "我，我是一头白手起家的母牛。做点自己，然后。。。那我们谈谈"
+msgstr "我​，​我​是​一​头​白手​起家​的​母牛​。​做点​自己​，​然后​。​。​。​那​我们​谈​谈"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:622
@@ -10027,8 +10026,8 @@ msgid ""
 "I don't have to explain myself to every tourist that walks by!  Don't you "
 "have some monsters to kill?  Maybe we'll talk later.  If you live..."
 msgstr ""
-"我不必向每一个路过的游客解释我自己！你不是有怪物要杀吗？也许我们以后再谈。如"
-"果你活着"
+"我​不​必​向​每​一​个​路​过​的​游客​解释​我​自己​！​你​不​是​有​怪物​要​杀​吗​？​也许​我们​以后​再​"
+"谈​。​如果​你​活​着"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:624
@@ -10037,8 +10036,8 @@ msgid ""
 "it.  I can't trust you, you're going to get eaten by monsters any day now... "
 "I need someone who's an experienced hero."
 msgstr ""
-"别烦我了。我在找一个真正的英雄。但你不是。我不能相信你，你随时都会被怪物吃掉"
-"的。。。我需要一个有经验的英雄"
+"别烦​我​了​。​我​在​找​一​个​真正​的​英雄​。​但​你​不是​。​我​不​能​相信​你​，​你​随时​都​会​被​怪"
+"物​吃掉​的​。​。​。​我​需要​一​个​有​经验​的​英雄"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:626
@@ -10055,12 +10054,13 @@ msgid ""
 "it's just south of the fork in the river... you know... the one with the "
 "overgrown vegetable garden."
 msgstr ""
-"好吧，我来切公牛。我不是故意误导你的。我坐在家里，心情很不好，这时情况变得很"
-"不稳定；一大群怪物从地板上跑了出来！我只是吓了一跳。我跑出家门的时候正好穿着"
-"这件球衣，现在我看起来很可笑。如果我有正常的衣服穿，就不会那么糟糕了。嘿你能"
-"回我家帮我拿衣服吗？棕色的，不是灰色的，那是晚装的。我会自己做的，但我不想让"
-"任何人看到我这样。给，拿着这个，你可能需要它。。。杀死那些长满一切的东西。你"
-"不会错过我家的，就在河的岔口南边。。。你知道的。。。有杂草丛生的菜园的那个"
+"好​吧​，​我​来​切​公牛​。​我​不​是​故意​误导​你​的​。​我​坐​在​家​里​，​心情​很​不​好​，​这时​情况"
+"​变得​很​不​稳定​；​一​大​群​怪物​从​地板​上​跑​了​出来​！​我​只​是​吓​了​一​跳​。​我​跑出​家门​的"
+"​时候​正好​穿​着​这​件​球衣​，​现在​我​看​起来​很​可笑​。​如果​我​有​正常​的​衣服​穿​，​就​不​会​那"
+"么​糟糕​了​。​嘿​你​能回​我​家​帮​我​拿​衣服​吗​？​棕色​的​，​不​是​灰色​的​，​那​是​晚装​的​。​我"
+"​会​自己​做​的​，​但​我​不​想​让​任何​人​看到​我​这样​。​给​，​拿​着​这个​，​你​可能​需要​它​。​。"
+"​。​杀死​那些​长满​一切​的​东西​。​你​不​会​错过​我​家​的​，​就​在​河​的​岔口​南​边​。​。​。​你​知"
+"道​的​。​。​。​有​杂草​丛生​的​菜园​的​那​个"
 
 #. TRANSLATORS: Quest text spoken by Unknown, Maybe Farmer
 #: Source/textdat.cpp:628
@@ -10070,8 +10070,8 @@ msgid ""
 "remember to order some more bat guano and black candles from Adria; I'm "
 "running a bit low."
 msgstr ""
-"今天多云凉爽。将亡灵之网撒向虚空，降落了两个新的飞行恐惧亚种；一天的好工作。"
-"一定要记得从艾德莉亚订购更多的蝙蝠粪和黑蜡烛；我的血压有点低"
+"今天​多云​凉爽​。​将​亡灵​之​网​撒向​虚空​，​降落​了​两​个​新​的​飞行​恐惧​亚种​；​一​天​的​好​工作​"
+"。​一定​要​记得​从​艾德莉亚​订购​更​多​的​蝙蝠​粪​和​黑​蜡烛​；​我​的​血压​有点​低"
 
 #. TRANSLATORS: Quest text read aloud from book
 #: Source/textdat.cpp:630
@@ -10080,8 +10080,8 @@ msgid ""
 "creature -- to no avail.  My methods of enslaving lesser demons seem to have "
 "no effect on this fearsome beast."
 msgstr ""
-"我试过法术，威胁，放弃和这个肮脏的生物讨价还价——都没有用。我奴役小恶魔的方法"
-"似乎对这个可怕的野兽没有效果"
+"我​试​过​法术​，​威胁​，​放弃​和​这个​肮脏​的​生物​讨价​还价​——​都​没有用​。​我​奴役​小​恶魔​的​方法"
+"​似乎​对​这​个​可怕​的​野兽​没有​效果"
 
 #. TRANSLATORS: Quest text read aloud from book
 #: Source/textdat.cpp:632
@@ -10091,8 +10091,8 @@ msgid ""
 "of my vision.  The faint scrabble of claws dances at the edges of my "
 "hearing. They are searching, I think, for this journal."
 msgstr ""
-"我的家正慢慢被这个不受欢迎的囚犯的卑鄙行径所腐蚀。地窖里到处都是影子，它们就"
-"在我视线的角落之外。我耳边隐约传来爪子的拼字声。我想，他们在找这本杂志"
+"我​的​家正​慢慢​被​这个​不​受​欢迎​的​囚犯​的​卑鄙​行径​所​腐蚀​。​地窖​里​到处​都​是​影子​，​它们​就"
+"​在​我​视线​的​角落​之外​。​我​耳边​隐约​传来​爪子​的​拼字声​。​我​想​，​他们​在​找​这​本​杂志"
 
 #. TRANSLATORS: Quest text read aloud from book
 #: Source/textdat.cpp:634
@@ -10102,9 +10102,9 @@ msgid ""
 "destroyed my library.  Na-Krul... The name fills me with a cold dread.  I "
 "prefer to think of it only as The Creature rather than ponder its true name."
 msgstr ""
-"在咆哮中，这个生物漏了自己的名字——纳克鲁尔。我曾试图研究这个名字，但小恶魔不"
-"知何故毁了我的图书馆。纳克鲁尔。。。我对这个名字充满了恐惧。我宁愿把它当作一"
-"种生物，而不愿考虑它的真名"
+"在​咆哮​中​，​这​个​生物​漏​了​自己​的​名字​——​纳克鲁尔​。​我​曾​试图​研究​这个​名字​，​但​小​恶魔​"
+"不​知​何​故毁​了​我​的​图书馆​。​纳克鲁尔​。​。​。​我​对​这个​名字​充满​了​恐惧​。​我​宁愿​把​它​当作"
+"​一​种​生物​，​而​不​愿​考虑​它​的​真名"
 
 #. TRANSLATORS: Quest text read aloud from book
 #: Source/textdat.cpp:636
@@ -10114,8 +10114,9 @@ msgid ""
 "curses upon me for trapping it here.  Its words fill my heart with terror, "
 "and yet I cannot block out its voice."
 msgstr ""
-"那被困住的生物狂怒的嚎叫使我无法获得急需的睡眠。它向那把它送到虚空的人发怒，"
-"因我把它困在这里，就咒诅我。它的话语使我的心充满恐惧，然而我无法阻挡它的声音"
+"那​被​困住​的​生物​狂怒​的​嚎叫​使​我​无法​获得​急​需​的​睡眠​。​它​向​那​把​它​送到​虚空​的​人​发怒"
+"​，​因​我​把​它​困​在​这里​，​就​咒诅​我​。​它​的​话语​使​我​的​心​充满​恐惧​，​然而​我​无法​阻挡​"
+"它​的​声音"
 
 #. TRANSLATORS: Quest text read aloud from book
 #: Source/textdat.cpp:638
@@ -10125,8 +10126,8 @@ msgid ""
 "knowledge to free their lord.  I hope that whoever finds this journal will "
 "seek the knowledge."
 msgstr ""
-"我的时间快用完了。我必须记录下削弱恶魔的方法，然后隐藏这段文字，以免他的爪牙"
-"们想办法利用我的知识来解放他们的主。我希望找到这本日记的人都能找到知识"
+"我​的​时间​快​用完​了​。​我​必须​记录​下​削弱​恶魔​的​方法​，​然后​隐藏​这​段​文字​，​以免​他​的​爪牙"
+"们​想​办法​利用​我​的​知识​来​解放​他们​的​主​。​我​希望​找到​这​本​日记​的​人​都​能​找到​知识"
 
 #. TRANSLATORS: Quest text read aloud from book
 #: Source/textdat.cpp:640
@@ -10144,14 +10145,14 @@ msgid ""
 "only these spells to gain entry or his power may be too great for you to "
 "defeat."
 msgstr ""
-"无论谁找到这卷卷轴，都将负责阻止这些墙内的恶魔生物。我的时间到了。即使是现"
-"在，它的地狱般的爪子在脆弱的门，我躲在后面爪。\n"
+"无论​谁​找到​这​卷​卷轴​，​都​将​负责​阻止​这些​墙内​的​恶魔​生物​。​我​的​时间​到​了​。​即使​是​现在"
+"​，​它​的​地狱​般​的​爪子​在​脆弱​的​门​，​我​躲​在​后面​爪​。​\n"
 " \n"
-"我已经用神秘的魔法把恶魔束缚住，把它包裹在长城里，但我担心这还不够。\n"
+"​我​已经​用​神秘​的​魔法​把​恶魔​束​缚​住​，​把​它​包裹​在​长城​里​，​但​我​担心​这​还​不​够​。​\n"
 " \n"
-"在我的三个幽灵身上找到的法术将为你提供进入他的领地的保护，但前提是必须按正确"
-"的顺序施放。入口的杠杆会移除障碍物，释放恶魔；别碰他们！只使用这些法术进入，"
-"否则他的力量可能太大，你无法击败"
+"​在​我​的​三​个​幽灵​身​上​找到​的​法术​将​为​你​提供​进入​他​的​领地​的​保护​，​但​前提​是​必须​按"
+"​正确​的​顺序​施放​。​入口​的​杠杆​会​移除​障碍物​，​释放​恶魔​；​别碰​他们​！​只​使用​这些​法术​进入​"
+"，​否则​他​的​力量​可能​太​大​，​你​无法​击败"
 
 #. TRANSLATORS: Quest text read aloud from book by player
 #: Source/textdat.cpp:642 Source/textdat.cpp:645 Source/textdat.cpp:648
@@ -10173,31 +10174,31 @@ msgstr "Efficio Obitus Ut Inimicus."
 
 #: Source/towners.cpp:86
 msgid "Griswold the Blacksmith"
-msgstr "铁匠格里斯沃尔德"
+msgstr "铁匠​格里斯沃尔德"
 
 #: Source/towners.cpp:108
 msgid "Ogden the Tavern owner"
-msgstr "酒馆老板奥格登"
+msgstr "酒馆​老板​奥格登"
 
 #: Source/towners.cpp:117
 msgid "Wounded Townsman"
-msgstr "受伤的镇民"
+msgstr "受伤​的​镇民"
 
 #: Source/towners.cpp:139
 msgid "Adria the Witch"
-msgstr "女巫艾德莉亚"
+msgstr "女​巫艾德莉亚"
 
 #: Source/towners.cpp:148
 msgid "Gillian the Barmaid"
-msgstr "酒吧女招待吉莉安"
+msgstr "酒吧​女​招待​吉莉安"
 
 #: Source/towners.cpp:179
 msgid "Pepin the Healer"
-msgstr "医治者佩金"
+msgstr "医治者​佩​金"
 
 #: Source/towners.cpp:196
 msgid "Cain the Elder"
-msgstr "长者凯恩"
+msgstr "长者​凯恩"
 
 #: Source/towners.cpp:225
 msgid "Cow"
@@ -10205,11 +10206,11 @@ msgstr "奶牛"
 
 #: Source/towners.cpp:244
 msgid "Lester the farmer"
-msgstr "农夫莱斯特"
+msgstr "农夫​莱斯特"
 
 #: Source/towners.cpp:257
 msgid "Complete Nut"
-msgstr "完整的纳特"
+msgstr "完整​的​纳特"
 
 #: Source/towners.cpp:266
 msgid "Celia"
@@ -10217,63 +10218,63 @@ msgstr "西莉亚"
 
 #: Source/towners.cpp:279
 msgid "Slain Townsman"
-msgstr "被杀的镇民"
+msgstr "被​杀​的​镇民"
 
 #: Source/trigs.cpp:341
 msgid "Down to dungeon"
-msgstr "下到地牢"
+msgstr "下​到​地​牢"
 
 #: Source/trigs.cpp:352
 msgid "Down to catacombs"
-msgstr "下到墓穴"
+msgstr "下​到​墓穴"
 
 #: Source/trigs.cpp:362
 msgid "Down to caves"
-msgstr "下到洞窟"
+msgstr "下​到​洞窟"
 
 #: Source/trigs.cpp:372
 msgid "Down to hell"
-msgstr "下到地狱"
+msgstr "下​到​地狱"
 
 #: Source/trigs.cpp:384
 msgid "Down to Hive"
-msgstr "下到巢穴"
+msgstr "下​到​巢穴"
 
 #: Source/trigs.cpp:396
 msgid "Down to Crypt"
-msgstr "下到地穴"
+msgstr "下​到​地​穴"
 
 #: Source/trigs.cpp:412 Source/trigs.cpp:492 Source/trigs.cpp:539
 #: Source/trigs.cpp:634
 msgid "Up to level {:d}"
-msgstr "上到 {:d} 层"
+msgstr "上​到​ {:d} ​层"
 
 #: Source/trigs.cpp:414 Source/trigs.cpp:469 Source/trigs.cpp:521
 #: Source/trigs.cpp:600 Source/trigs.cpp:617 Source/trigs.cpp:664
 msgid "Up to town"
-msgstr "上到城镇"
+msgstr "上​到​城镇"
 
 #: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:556
 #: Source/trigs.cpp:581 Source/trigs.cpp:646
 msgid "Down to level {:d}"
-msgstr "下到 {:d} 层"
+msgstr "下​到​ {:d} ​层"
 
 #: Source/trigs.cpp:437
 msgid "Up to Crypt level {:d}"
-msgstr "上到墓穴 {:d} 层"
+msgstr "上​到​墓穴​ {:d} ​层"
 
 #: Source/trigs.cpp:452
 msgid "Down to Crypt level {:d}"
-msgstr "下到墓穴 {:d} 层"
+msgstr "下​到​墓穴​ {:d} ​层"
 
 #: Source/trigs.cpp:568
 msgid "Up to Nest level {:d}"
-msgstr "上到巢穴 {:d} 层"
+msgstr "上​到​巢穴​ {:d} ​层"
 
 #: Source/trigs.cpp:677
 msgid "Down to Diablo"
-msgstr "下到迪亚波罗"
+msgstr "下​到​迪亚波罗"
 
 #: Source/trigs.cpp:710 Source/trigs.cpp:724 Source/trigs.cpp:738
 msgid "Back to Level {:d}"
-msgstr "返回到 {:d} 层"
+msgstr "返回​到​ {:d} ​层"

--- a/Translations/zh_TW.po
+++ b/Translations/zh_TW.po
@@ -18,104 +18,104 @@ msgstr ""
 
 #: Source/DiabloUI/credits_lines.cpp:7
 msgid "Game Design"
-msgstr "遊戲設計"
+msgstr "遊​戲設計"
 
 #: Source/DiabloUI/credits_lines.cpp:10
 msgid "Senior Designers"
-msgstr "資深設計師"
+msgstr "資​深​設計​師"
 
 #: Source/DiabloUI/credits_lines.cpp:13 Source/DiabloUI/credits_lines.cpp:232
 msgid "Additional Design"
-msgstr "附加設計"
+msgstr "附加​設計"
 
 #: Source/DiabloUI/credits_lines.cpp:16 Source/DiabloUI/credits_lines.cpp:215
 msgid "Lead Programmer"
-msgstr "首席程式設計師"
+msgstr "首席​程式​設計師"
 
 #: Source/DiabloUI/credits_lines.cpp:19
 msgid "Senior Programmers"
-msgstr "資深程式設計師"
+msgstr "資​深​程式​設計師"
 
 #: Source/DiabloUI/credits_lines.cpp:23
 msgid "Programming"
-msgstr "程式設計"
+msgstr "程式​設計"
 
 #: Source/DiabloUI/credits_lines.cpp:26
 msgid "Special Guest Programmers"
-msgstr "特約程式設計師"
+msgstr "特約​程式​設計師"
 
 #: Source/DiabloUI/credits_lines.cpp:29
 msgid "Battle.net Programming"
-msgstr "Battle.net程式設計"
+msgstr "Battle.net​程式​設計"
 
 #: Source/DiabloUI/credits_lines.cpp:32
 msgid "Serial Communications Programming"
-msgstr "序列通訊程式設計"
+msgstr "序​列通訊​程式​設計"
 
 #: Source/DiabloUI/credits_lines.cpp:35
 msgid "Installer Programming"
-msgstr "安裝程式程式設計"
+msgstr "安裝​程式​程式​設計"
 
 #: Source/DiabloUI/credits_lines.cpp:38
 msgid "Art Directors"
-msgstr "美術總監"
+msgstr "美​術總監"
 
 #: Source/DiabloUI/credits_lines.cpp:41
 msgid "Artwork"
-msgstr "美術設計"
+msgstr "美​術設計"
 
 #: Source/DiabloUI/credits_lines.cpp:48
 msgid "Technical Artwork"
-msgstr "技術美術設計"
+msgstr "技​術​美術設計"
 
 #: Source/DiabloUI/credits_lines.cpp:52
 msgid "Cinematic Art Directors"
-msgstr "影片美術總監"
+msgstr "影片​美術總監"
 
 #: Source/DiabloUI/credits_lines.cpp:55
 msgid "3D Cinematic Artwork"
-msgstr "3D影片美術設計"
+msgstr "3D​影片​美術設計"
 
 #: Source/DiabloUI/credits_lines.cpp:61
 msgid "Cinematic Technical Artwork"
-msgstr "影片技術美術設計"
+msgstr "影片​技術​美術設計"
 
 #: Source/DiabloUI/credits_lines.cpp:64
 msgid "Executive Producer"
-msgstr "執行製作人"
+msgstr "執​行製​作人"
 
 #: Source/DiabloUI/credits_lines.cpp:67
 msgid "Producer"
-msgstr "製作人"
+msgstr "製​作人"
 
 #: Source/DiabloUI/credits_lines.cpp:70
 msgid "Associate Producer"
-msgstr "助理製作人"
+msgstr "助理​製作人"
 
 #. TRANSLATORS: Keep Strike Team as Name
 #: Source/DiabloUI/credits_lines.cpp:73
 msgid "Diablo Strike Team"
-msgstr "暗黑破壞神突擊小組"
+msgstr "暗​黑破壞​神突擊​小​組"
 
 #: Source/DiabloUI/credits_lines.cpp:77 Source/gamemenu.cpp:67
 msgid "Music"
-msgstr "音樂"
+msgstr "音​樂"
 
 #: Source/DiabloUI/credits_lines.cpp:80
 msgid "Sound Design"
-msgstr "音效設計"
+msgstr "音效​設​計"
 
 #: Source/DiabloUI/credits_lines.cpp:83
 msgid "Cinematic Music & Sound"
-msgstr "影片音樂和音效"
+msgstr "影片​音樂​和​音效"
 
 #: Source/DiabloUI/credits_lines.cpp:86
 msgid "Voice Production, Direction & Casting"
-msgstr "語音製作、導演和配音"
+msgstr "語音​製作​、​導演​和​配音"
 
 #: Source/DiabloUI/credits_lines.cpp:89
 msgid "Script & Story"
-msgstr "劇本和故事"
+msgstr "劇​本​和​故事"
 
 #: Source/DiabloUI/credits_lines.cpp:93
 msgid "Voice Editing"
@@ -123,7 +123,7 @@ msgstr "語音編輯"
 
 #: Source/DiabloUI/credits_lines.cpp:96 Source/DiabloUI/credits_lines.cpp:250
 msgid "Voices"
-msgstr "語音"
+msgstr "語​音"
 
 #: Source/DiabloUI/credits_lines.cpp:101
 msgid "Recording Engineer"
@@ -131,43 +131,43 @@ msgstr "錄音師"
 
 #: Source/DiabloUI/credits_lines.cpp:104
 msgid "Manual Design & Layout"
-msgstr "使用手冊設計和編排"
+msgstr "使用​手冊設計​和​編排"
 
 #: Source/DiabloUI/credits_lines.cpp:108
 msgid "Manual Artwork"
-msgstr "使用手冊美術設計"
+msgstr "使用​手冊​美術設計"
 
 #: Source/DiabloUI/credits_lines.cpp:112
 msgid "Provisional Director of QA (Lead Tester)"
-msgstr "短期品保總監（測試主管）"
+msgstr "短期​品保總監​（​測試​主管​）"
 
 #: Source/DiabloUI/credits_lines.cpp:115
 msgid "QA Assault Team (Testers)"
-msgstr "品保突擊小組（測試人員）"
+msgstr "品​保突擊​小​組​（​測試人員​）"
 
 #: Source/DiabloUI/credits_lines.cpp:120
 msgid "QA Special Ops Team (Compatibility Testers)"
-msgstr "品保特別行動小組（相容性測試人員）"
+msgstr "品​保特​別行動​小組​（​相容性測試人員​）"
 
 #: Source/DiabloUI/credits_lines.cpp:123
 msgid "QA Artillery Support (Additional Testers) "
-msgstr "品保火力支援小組（附加測試人員）"
+msgstr "品​保​火力​支援​小組​（​附加​測試人員​）"
 
 #: Source/DiabloUI/credits_lines.cpp:127
 msgid "QA Counterintelligence"
-msgstr "品保反情小組"
+msgstr "品​保​反情​小​組"
 
 #: Source/DiabloUI/credits_lines.cpp:130
 msgid "Order of Network Information Services"
-msgstr "NIS系統維護管理"
+msgstr "NIS系統​維護​管理"
 
 #: Source/DiabloUI/credits_lines.cpp:134
 msgid "Customer Support"
-msgstr "客服人員"
+msgstr "客​服人​員"
 
 #: Source/DiabloUI/credits_lines.cpp:139
 msgid "Sales"
-msgstr "銷售人員"
+msgstr "銷​售人​員"
 
 #: Source/DiabloUI/credits_lines.cpp:142
 msgid "Dunsel"
@@ -175,31 +175,31 @@ msgstr "Dunsel"
 
 #: Source/DiabloUI/credits_lines.cpp:145
 msgid "Mr. Dabiri's Background Vocalists"
-msgstr "Dabiri先生的和聲"
+msgstr "Dabiri​先生​的​和​聲"
 
 #: Source/DiabloUI/credits_lines.cpp:149
 msgid "Public Relations"
-msgstr "公關人員"
+msgstr "公關人​員"
 
 #: Source/DiabloUI/credits_lines.cpp:152
 msgid "Marketing"
-msgstr "行銷人員"
+msgstr "行​銷人​員"
 
 #: Source/DiabloUI/credits_lines.cpp:155
 msgid "International Sales"
-msgstr "國際銷售人員"
+msgstr "國​際​銷​售人​員"
 
 #: Source/DiabloUI/credits_lines.cpp:158
 msgid "U.S. Sales"
-msgstr "美國銷售人員"
+msgstr "美​國​銷​售人​員"
 
 #: Source/DiabloUI/credits_lines.cpp:161
 msgid "Manufacturing"
-msgstr "製造商"
+msgstr "製​造商"
 
 #: Source/DiabloUI/credits_lines.cpp:164
 msgid "Legal & Business"
-msgstr "法律和商業"
+msgstr "法律​和​商業"
 
 #: Source/DiabloUI/credits_lines.cpp:167
 msgid "Special Thanks To"
@@ -211,55 +211,55 @@ msgstr "感謝"
 
 #: Source/DiabloUI/credits_lines.cpp:200
 msgid "In memory of"
-msgstr "以玆紀念"
+msgstr "以​玆紀​念"
 
 #: Source/DiabloUI/credits_lines.cpp:206
 msgid "Very Special Thanks to"
-msgstr "非常特別感謝"
+msgstr "非常​特別感謝"
 
 #: Source/DiabloUI/credits_lines.cpp:212
 msgid "General Manager"
-msgstr "總經理"
+msgstr "總​經理"
 
 #: Source/DiabloUI/credits_lines.cpp:218
 msgid "Software Engineering"
-msgstr "軟體工程"
+msgstr "軟​體​工程"
 
 #: Source/DiabloUI/credits_lines.cpp:221
 msgid "Art Director"
-msgstr "美術總監"
+msgstr "美​術總監"
 
 #: Source/DiabloUI/credits_lines.cpp:224
 msgid "Artists"
-msgstr "美術"
+msgstr "美​術"
 
 #: Source/DiabloUI/credits_lines.cpp:228
 msgid "Design"
-msgstr "設計"
+msgstr "設​計"
 
 #: Source/DiabloUI/credits_lines.cpp:235
 msgid "Sound Design, SFX & Audio Engineering"
-msgstr "音效設計、混音和音訊工程"
+msgstr "音效​設計​、​混音​和​音訊​工程"
 
 #: Source/DiabloUI/credits_lines.cpp:238
 msgid "Quality Assurance Lead"
-msgstr "品保主管"
+msgstr "品​保​主管"
 
 #: Source/DiabloUI/credits_lines.cpp:241
 msgid "Testers"
-msgstr "測試人員"
+msgstr "測​試人​員"
 
 #: Source/DiabloUI/credits_lines.cpp:246
 msgid "Manual"
-msgstr "使用手冊"
+msgstr "使用​手冊"
 
 #: Source/DiabloUI/credits_lines.cpp:255
 msgid "\tAdditional Work"
-msgstr "\t附加工作"
+msgstr "\t​附加​工作"
 
 #: Source/DiabloUI/credits_lines.cpp:257
 msgid "Quest Text Writing"
-msgstr "任務文字撰寫"
+msgstr "任務​文字​撰寫"
 
 #: Source/DiabloUI/credits_lines.cpp:260 Source/DiabloUI/credits_lines.cpp:295
 msgid "Thanks to"
@@ -267,47 +267,47 @@ msgstr "感謝"
 
 #: Source/DiabloUI/credits_lines.cpp:265
 msgid "\t\t\tSpecial Thanks to Blizzard Entertainment"
-msgstr "\t\t\t特別感謝暴雪娛樂"
+msgstr "\t\t\t​特別感謝​暴雪娛樂"
 
 #: Source/DiabloUI/credits_lines.cpp:270
 msgid "\t\t\tSierra On-Line Inc. Northwest"
-msgstr "\t\t\t雪樂山線上"
+msgstr "\t\t\t雪樂山線​上"
 
 #: Source/DiabloUI/credits_lines.cpp:272
 msgid "Quality Assurance Manager"
-msgstr "品保經理"
+msgstr "品​保經理"
 
 #: Source/DiabloUI/credits_lines.cpp:275
 msgid "Quality Assurance Lead Tester"
-msgstr "品保測試主管"
+msgstr "品​保測試​主管"
 
 #: Source/DiabloUI/credits_lines.cpp:278
 msgid "Main Testers"
-msgstr "主要測試人員"
+msgstr "主要​測試人​員"
 
 #: Source/DiabloUI/credits_lines.cpp:281
 msgid "Additional Testers"
-msgstr "附加測試人員"
+msgstr "附加​測試人​員"
 
 #: Source/DiabloUI/credits_lines.cpp:286
 msgid "Product Marketing Manager"
-msgstr "產品行銷經理"
+msgstr "產​品行​銷​經理"
 
 #: Source/DiabloUI/credits_lines.cpp:289
 msgid "Public Relations Manager"
-msgstr "公關經理"
+msgstr "公關​經理"
 
 #: Source/DiabloUI/credits_lines.cpp:292
 msgid "Associate Product Manager"
-msgstr "助理產品經理"
+msgstr "助理​產品​經理"
 
 #: Source/DiabloUI/credits_lines.cpp:301
 msgid "The Ring of One Thousand"
-msgstr "最初的一千名Beta測試人員（The Ring of One Thousand）"
+msgstr "最初​的​一千​名​Beta測試人員​（​The Ring of One Thousand​）"
 
 #: Source/DiabloUI/credits_lines.cpp:547
 msgid "\tNo souls were sold in the making of this game."
-msgstr "\t在這個遊戲的製作過程中沒有任何靈魂被出賣。"
+msgstr "\t​在​這個​遊戲​的​製作​過程​中​沒​有​任何​靈魂​被​出賣​。"
 
 #: Source/DiabloUI/dialogs.cpp:172 Source/DiabloUI/dialogs.cpp:185
 #: Source/DiabloUI/selconn.cpp:73 Source/DiabloUI/selgame.cpp:94
@@ -321,15 +321,15 @@ msgstr "好"
 
 #: Source/DiabloUI/mainmenu.cpp:36
 msgid "Single Player"
-msgstr "單人"
+msgstr "單​人"
 
 #: Source/DiabloUI/mainmenu.cpp:37
 msgid "Multi Player"
-msgstr "多人"
+msgstr "多​人"
 
 #: Source/DiabloUI/mainmenu.cpp:38
 msgid "Replay Intro"
-msgstr "重播動畫"
+msgstr "重​播動​畫"
 
 #: Source/DiabloUI/mainmenu.cpp:39
 msgid "Support"
@@ -337,15 +337,15 @@ msgstr "支援"
 
 #: Source/DiabloUI/mainmenu.cpp:40
 msgid "Show Credits"
-msgstr "顯示製作組"
+msgstr "顯示製​作​組"
 
 #: Source/DiabloUI/mainmenu.cpp:41
 msgid "Exit Hellfire"
-msgstr "退出地獄火"
+msgstr "退出​地​獄火"
 
 #: Source/DiabloUI/mainmenu.cpp:41
 msgid "Exit Diablo"
-msgstr "退出暗黑破壞神"
+msgstr "退出​暗​黑破壞神"
 
 #. TRANSLATORS:  Error Message when a Shareware User clicks on "Replay Intro" in the Main Menu
 #: Source/DiabloUI/mainmenu.cpp:99
@@ -353,8 +353,8 @@ msgid ""
 "The Diablo introduction cinematic is only available in the full retail "
 "version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
 msgstr ""
-"暗黑破壞神介紹電影版只提供完整的零售版暗黑破壞神。前往 https://www.gog.com/"
-"game/diablo 購買。"
+"暗​黑破壞​神介紹​電影版​只​提供​完整​的​零售版​暗​黑破壞神​。​前往​ https://www.gog.com/ga"
+"me/diablo ​購買​。"
 
 #: Source/DiabloUI/progress.cpp:48 Source/DiabloUI/selconn.cpp:76
 #: Source/DiabloUI/selhero.cpp:188 Source/DiabloUI/selhero.cpp:213
@@ -365,65 +365,65 @@ msgstr "取消"
 #: Source/DiabloUI/selconn.cpp:38 Source/DiabloUI/selgame.cpp:77
 #: Source/DiabloUI/selgame.cpp:372
 msgid "Client-Server (TCP)"
-msgstr "客戶端伺服器（TCP）"
+msgstr "客​戶端伺服器​（​TCP​）"
 
 #: Source/DiabloUI/selconn.cpp:41
 msgid "Loopback"
-msgstr "環回"
+msgstr "環​回"
 
 #: Source/DiabloUI/selconn.cpp:47 Source/DiabloUI/selgame.cpp:434
 #: Source/DiabloUI/selgame.cpp:452
 msgid "Multi Player Game"
-msgstr "多人遊戲"
+msgstr "多​人​遊戲"
 
 #: Source/DiabloUI/selconn.cpp:53
 msgid "Requirements:"
-msgstr "要求: "
+msgstr "要求​: "
 
 #: Source/DiabloUI/selconn.cpp:59
 msgid "no gateway needed"
-msgstr "不需要閘道器"
+msgstr "不​需要​閘道器"
 
 #: Source/DiabloUI/selconn.cpp:65
 msgid "Select Connection"
-msgstr "選擇連線"
+msgstr "選​擇連線"
 
 #: Source/DiabloUI/selconn.cpp:68
 msgid "Change Gateway"
-msgstr "更改閘道器"
+msgstr "更改​閘​道器"
 
 #: Source/DiabloUI/selconn.cpp:101
 msgid "All computers must be connected to a TCP-compatible network."
-msgstr "所有計算機必須連線到與TCP相容的網路。"
+msgstr "所有​計算​機​必須連線​到​與​TCP​相容​的​網路​。"
 
 #: Source/DiabloUI/selconn.cpp:105
 msgid "All computers must be connected to the internet."
-msgstr "所有計算機都必須連線到因特網。"
+msgstr "所有​計算機​都​必須​連線​到​因特網​。"
 
 #: Source/DiabloUI/selconn.cpp:109
 msgid "Play by yourself with no network exposure."
-msgstr "自己玩，沒有網路曝光。"
+msgstr "自己​玩​，​沒​有​網路​曝光​。"
 
 #: Source/DiabloUI/selconn.cpp:114
 msgid "Players Supported: {:d}"
-msgstr "支援的玩家: {:d}"
+msgstr "支援​的​玩家​:​ {:d}"
 
 #: Source/DiabloUI/selgame.cpp:80 Source/DiabloUI/selgame.cpp:375
 msgid "Description:"
-msgstr "說明: "
+msgstr "說​明​: "
 
 #: Source/DiabloUI/selgame.cpp:86
 msgid "Select Action"
-msgstr "選擇操作"
+msgstr "選​擇​操作"
 
 #: Source/DiabloUI/selgame.cpp:88 Source/DiabloUI/selgame.cpp:151
 #: Source/DiabloUI/selgame.cpp:295
 msgid "Create Game"
-msgstr "建立遊戲"
+msgstr "建立​遊戲"
 
 #: Source/DiabloUI/selgame.cpp:89
 msgid "Join Game"
-msgstr "加入遊戲"
+msgstr "加入​遊戲"
 
 #: Source/DiabloUI/selgame.cpp:97 Source/DiabloUI/selgame.cpp:166
 #: Source/DiabloUI/selgame.cpp:184 Source/DiabloUI/selgame.cpp:317
@@ -433,17 +433,17 @@ msgstr "取消"
 
 #: Source/DiabloUI/selgame.cpp:106
 msgid "Create a new game with a difficulty setting of your choice."
-msgstr "建立一個新遊戲的難度設定你的選擇。"
+msgstr "建立​一​個​新​遊戲​的​難度​設定​你​的​選擇​。"
 
 #: Source/DiabloUI/selgame.cpp:109
 msgid ""
 "Enter an IP or a hostname and join a game already in progress at that "
 "address."
-msgstr "輸入IP或主機名，然後在該地址加入正在進行的遊戲。"
+msgstr "輸入​IP​或​主機名​，​然​後​在​該​地址​加入​正在​進行​的​遊戲​。"
 
 #: Source/DiabloUI/selgame.cpp:154
 msgid "Select Difficulty"
-msgstr "選擇難度"
+msgstr "選​擇​難度"
 
 #: Source/DiabloUI/selgame.cpp:156 Source/DiabloUI/selgame.cpp:203
 #: Source/DiabloUI/selgame.cpp:306 Source/DiabloUI/selgame.cpp:326
@@ -459,23 +459,23 @@ msgstr "噩夢"
 #: Source/DiabloUI/selgame.cpp:158 Source/DiabloUI/selgame.cpp:211
 #: Source/diablo.cpp:1436
 msgid "Hell"
-msgstr "地獄"
+msgstr "地​獄"
 
 #: Source/DiabloUI/selgame.cpp:172
 msgid "Join TCP Games"
-msgstr "加入TCP遊戲"
+msgstr "加入​TCP遊​戲"
 
 #: Source/DiabloUI/selgame.cpp:175 Source/DiabloUI/selgame.cpp:178
 msgid "Enter address"
-msgstr "輸入地址"
+msgstr "輸入​地址"
 
 #: Source/DiabloUI/selgame.cpp:204
 msgid ""
 "Normal Difficulty\n"
 "This is where a starting character should begin the quest to defeat Diablo."
 msgstr ""
-"正常難度\n"
-"這是一個開始的角色應該開始尋求擊敗迪亞波羅。"
+"正常​難度​\n"
+"這​是​一​個​開始​的​角色​應該​開始尋求擊敗迪亞波羅​。"
 
 #: Source/DiabloUI/selgame.cpp:208
 msgid ""
@@ -483,8 +483,8 @@ msgid ""
 "The denizens of the Labyrinth have been bolstered and will prove to be a "
 "greater challenge. This is recommended for experienced characters only."
 msgstr ""
-"噩夢難度\n"
-"迷宮裡的居民得到了支援，這將是一個更大的挑戰。這隻建議有經驗的角色使用。"
+"噩夢​難度​\n"
+"迷宮裡​的​居民​得到​了​支援​，​這將​是​一​個​更​大​的​挑戰​。​這隻​建議​有​經驗​的​角色​使用​。"
 
 #: Source/DiabloUI/selgame.cpp:212
 msgid ""
@@ -492,45 +492,45 @@ msgid ""
 "The most powerful of the underworld's creatures lurk at the gateway into "
 "Hell. Only the most experienced characters should venture in this realm."
 msgstr ""
-"地獄般的困難\n"
-"最強大的地下世界的生物潛伏在地獄的大門。只有最有經驗的人物才能在這個領域冒"
-"險。"
+"地​獄​般​的​困難​\n"
+"​最​強​大​的​地下​世界​的​生物​潛伏在地獄​的​大門​。​只有​最​有​經驗​的​人物​才​能​在​這個​領域​冒險​"
+"。"
 
 #: Source/DiabloUI/selgame.cpp:227
 msgid ""
 "Your character must reach level 20 before you can enter a multiplayer game "
 "of Nightmare difficulty."
-msgstr "你的角色必須達到20級才能進入多人遊戲的噩夢難度。"
+msgstr "你​的​角色​必須達​到​20​級​才​能​進入​多​人​遊戲​的​噩夢​難度​。"
 
 #: Source/DiabloUI/selgame.cpp:229
 msgid ""
 "Your character must reach level 30 before you can enter a multiplayer game "
 "of Hell difficulty."
-msgstr "你的角色必須達到30級才能進入地獄難度的多人遊戲。"
+msgstr "你​的​角色​必須達​到​30​級​才​能​進入​地獄​難度​的​多​人​遊戲​。"
 
 #: Source/DiabloUI/selgame.cpp:304
 msgid "Select Game Speed"
-msgstr "選擇遊戲速度"
+msgstr "選​擇遊戲​速度"
 
 #: Source/DiabloUI/selgame.cpp:307 Source/DiabloUI/selgame.cpp:330
 msgid "Fast"
-msgstr "快速的"
+msgstr "快速​的"
 
 #: Source/DiabloUI/selgame.cpp:308 Source/DiabloUI/selgame.cpp:334
 msgid "Faster"
-msgstr "更快"
+msgstr "更​快"
 
 #: Source/DiabloUI/selgame.cpp:309 Source/DiabloUI/selgame.cpp:338
 msgid "Fastest"
-msgstr "最快的"
+msgstr "最​快​的"
 
 #: Source/DiabloUI/selgame.cpp:327
 msgid ""
 "Normal Speed\n"
 "This is where a starting character should begin the quest to defeat Diablo."
 msgstr ""
-"正常速度\n"
-"這是一個開始的角色應該開始尋求擊敗迪亞波羅。"
+"正常​速度​\n"
+"這​是​一​個​開始​的​角色​應該​開始尋求擊敗迪亞波羅​。"
 
 #: Source/DiabloUI/selgame.cpp:331
 msgid ""
@@ -538,8 +538,8 @@ msgid ""
 "The denizens of the Labyrinth have been hastened and will prove to be a "
 "greater challenge. This is recommended for experienced characters only."
 msgstr ""
-"快速\n"
-"迷宮的居民們已經被催促了，這將是一個更大的挑戰。這隻建議有經驗的角色使用。"
+"快速​\n"
+"迷宮​的​居民​們​已​經​被​催促​了​，​這將​是​一​個​更​大​的​挑戰​。​這隻​建議​有​經驗​的​角色​使用​。"
 
 #: Source/DiabloUI/selgame.cpp:335
 msgid ""
@@ -547,9 +547,9 @@ msgid ""
 "Most monsters of the dungeon will seek you out quicker than ever before. "
 "Only an experienced champion should try their luck at this speed."
 msgstr ""
-"更快的速度\n"
-"地牢里的大多數怪物會比以前更快地找到你。只有有經驗的冠軍才能在這個速度下碰碰"
-"運氣。"
+"更​快​的​速度​\n"
+"​地​牢里​的​大多​數​怪物會​比​以前​更​快​地​找到​你​。​只有​有​經驗​的​冠軍​才​能​在​這個​速度​下​碰"
+"碰運氣​。"
 
 #: Source/DiabloUI/selgame.cpp:339
 msgid ""
@@ -557,29 +557,29 @@ msgid ""
 "The minions of the underworld will rush to attack without hesitation. Only a "
 "true speed demon should enter at this pace."
 msgstr ""
-"最快速度\n"
-"黑社會的僕從們會毫不猶豫地趕來攻擊。只有真正的速度惡魔才能以這種速度進入。"
+"最​快​速度​\n"
+"​黑社​會​的​僕從們會​毫​不​猶​豫​地​趕來​攻擊​。​只有​真正​的​速度​惡魔​才​能​以​這種​速度​進入​。"
 
 #: Source/DiabloUI/selgame.cpp:381 Source/DiabloUI/selgame.cpp:384
 msgid "Enter Password"
-msgstr "輸入密碼"
+msgstr "輸​入​密碼"
 
 #: Source/DiabloUI/selgame.cpp:407
 msgid "The host is running a different game than you."
-msgstr "主機執行的遊戲與您不同。"
+msgstr "主機​執行​的​遊戲與​您​不同​。"
 
 #. TRANSLATORS: Error message when somebody tries to join a game running another version.
 #: Source/DiabloUI/selgame.cpp:410
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
-msgstr "您的版本{:s}與主機{:d}.{:d}.{:d}不匹配。"
+msgstr "您​的​版本​{:s}​與​主機{:d}.{:d}.{:d}​不​匹配​。"
 
 #: Source/DiabloUI/selhero.cpp:99
 msgid "New Hero"
-msgstr "新英雄"
+msgstr "新​英雄"
 
 #: Source/DiabloUI/selhero.cpp:163
 msgid "Choose Class"
-msgstr "選擇職業"
+msgstr "選​擇職業"
 
 #: Source/DiabloUI/selhero.cpp:167 Source/panels/charpanel.cpp:22
 msgid "Warrior"
@@ -599,109 +599,109 @@ msgstr "武僧"
 
 #: Source/DiabloUI/selhero.cpp:174 Source/panels/charpanel.cpp:26
 msgid "Bard"
-msgstr "吟遊詩人"
+msgstr "吟遊​詩​人"
 
 #: Source/DiabloUI/selhero.cpp:177 Source/panels/charpanel.cpp:27
 msgid "Barbarian"
-msgstr "野蠻人"
+msgstr "野​蠻​人"
 
 #: Source/DiabloUI/selhero.cpp:194 Source/DiabloUI/selhero.cpp:268
 msgid "New Multi Player Hero"
-msgstr "新的多人英雄"
+msgstr "新​的​多​人​英雄"
 
 #: Source/DiabloUI/selhero.cpp:194 Source/DiabloUI/selhero.cpp:268
 msgid "New Single Player Hero"
-msgstr "新單人英雄"
+msgstr "新​單人​英雄"
 
 #: Source/DiabloUI/selhero.cpp:202
 msgid "Save File Exists"
-msgstr "儲存檔案已存在"
+msgstr "儲​存檔案​已​存在"
 
 #: Source/DiabloUI/selhero.cpp:205 Source/gamemenu.cpp:38
 msgid "Load Game"
-msgstr "載入遊戲"
+msgstr "載入​遊戲"
 
 #: Source/DiabloUI/selhero.cpp:206 Source/gamemenu.cpp:37
 #: Source/gamemenu.cpp:48
 msgid "New Game"
-msgstr "新遊戲"
+msgstr "新​遊戲"
 
 #: Source/DiabloUI/selhero.cpp:216 Source/DiabloUI/selhero.cpp:540
 msgid "Single Player Characters"
-msgstr "單人角色"
+msgstr "單​人​角色"
 
 #: Source/DiabloUI/selhero.cpp:262
 msgid ""
 "The Rogue and Sorcerer are only available in the full retail version of "
 "Diablo. Visit https://www.gog.com/game/diablo to purchase."
 msgstr ""
-"流亡者和巫師只在暗黑破壞神的完整零售版中提供。前往 https://www.gog.com/game/"
-"diablo 購買。"
+"流亡者​和​巫師​只​在​暗​黑破​壞神​的​完整​零售版​中​提供​。​前往​ https://www.gog.com/ga"
+"me/diablo ​購買​。"
 
 #: Source/DiabloUI/selhero.cpp:274 Source/DiabloUI/selhero.cpp:277
 msgid "Enter Name"
-msgstr "輸入名稱"
+msgstr "輸​入名稱"
 
 #: Source/DiabloUI/selhero.cpp:306
 msgid ""
 "Invalid name. A name cannot contain spaces, reserved characters, or reserved "
 "words.\n"
-msgstr "名稱無效。名稱不能包含空格、保留字元或保留字。\n"
+msgstr "名稱​無效​。​名稱​不​能​包含​空格​、​保留​字元​或​保留​字​。​\n"
 
 #. TRANSLATORS: Error Message
 #: Source/DiabloUI/selhero.cpp:313
 msgid "Unable to create character."
-msgstr "無法建立角色。"
+msgstr "無​法​建立​角色​。"
 
 #: Source/DiabloUI/selhero.cpp:467 Source/DiabloUI/selhero.cpp:470
 msgid "Level:"
-msgstr "等級: "
+msgstr "等​級​: "
 
 #: Source/DiabloUI/selhero.cpp:475
 msgid "Strength:"
-msgstr "強度: "
+msgstr "強度​: "
 
 #: Source/DiabloUI/selhero.cpp:480
 msgid "Magic:"
-msgstr "魔術: "
+msgstr "魔術​: "
 
 #: Source/DiabloUI/selhero.cpp:485
 msgid "Dexterity:"
-msgstr "敏捷: "
+msgstr "敏​捷​: "
 
 #: Source/DiabloUI/selhero.cpp:490
 msgid "Vitality:"
-msgstr "活力: "
+msgstr "活力​: "
 
 #: Source/DiabloUI/selhero.cpp:496
 #, fuzzy
 #| msgid "Save Game"
 msgid "Savegame:"
-msgstr "儲存遊戲"
+msgstr "儲​存遊​戲"
 
 #: Source/DiabloUI/selhero.cpp:508
 msgid "Select Hero"
-msgstr "選擇英雄"
+msgstr "選​擇​英雄"
 
 #: Source/DiabloUI/selhero.cpp:528
 msgid "Delete"
-msgstr "刪除"
+msgstr "刪​除"
 
 #: Source/DiabloUI/selhero.cpp:538
 msgid "Multi Player Characters"
-msgstr "多人遊戲角色"
+msgstr "多​人​遊戲​角色"
 
 #: Source/DiabloUI/selhero.cpp:580
 msgid "Delete Multi Player Hero"
-msgstr "刪除多人遊戲英雄"
+msgstr "刪​除​多​人​遊戲​英雄"
 
 #: Source/DiabloUI/selhero.cpp:582
 msgid "Delete Single Player Hero"
-msgstr "刪除單人遊戲英雄"
+msgstr "刪​除​單人​遊戲​英雄"
 
 #: Source/DiabloUI/selhero.cpp:584
 msgid "Are you sure you want to delete the character \"{:s}\"?"
-msgstr "是否確實要刪除角色「{:s}」？"
+msgstr "是否​確實​要​刪除​角色​「​{:s}​」​？"
 
 #: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
 msgid "Yes"
@@ -725,13 +725,13 @@ msgid ""
 "serve you, please be sure to include the version number, operating system, "
 "and the nature of the problem."
 msgstr ""
-"DevilutionX由Diasurgical維護，可以報告問題和錯誤地址: https://github.com/"
-"diasurgical/devilutionX爲了幫助我們更好地為您服務，請務必包括版本號，操作系"
-"統，以及問題的性質。"
+"DevilutionX​由​Diasurgical​維護​，​可以​報告問題​和​錯誤​地址​:​ https://githu"
+"b.com/diasurgical/devilutionX爲​了​幫助​我​們​更​好​地​為​您​服務​，​請務​必​包括​"
+"版本​號​，​操作系統​，​以及​問題​的​性質​。"
 
 #: Source/DiabloUI/support_lines.cpp:13
 msgid "Disclaimer:"
-msgstr "免責聲明: "
+msgstr "免​責​聲​明​: "
 
 #: Source/DiabloUI/support_lines.cpp:14
 msgid ""
@@ -741,9 +741,9 @@ msgid ""
 "DevilutionX should be directed to Diasurgical, not to Blizzard Entertainment "
 "or GOG.com."
 msgstr ""
-"\t暴雪娛樂不支援或維護DevilutionX，也不是GOG.com。暴雪娛樂和GOG.com都沒有進行"
-"測試或者證明了DevilutionX的質量或相容性。所有查詢關於DevilutionX，應直接向"
-"Diasurgical，而不是暴雪娛樂或GOG.com。"
+"\t​暴雪​娛樂​不​支援​或​維護​DevilutionX​，​也​不​是​GOG.com​。​暴雪娛樂​和​GOG.com"
+"​都​沒​有​進行測試​或者​證明​了​DevilutionX​的​質量​或​相容性​。​所有​查詢關​於​Devilutio"
+"nX​，​應​直接​向​Diasurgical​，​而​不​是​暴雪娛樂​或​GOG.com​。"
 
 #: Source/DiabloUI/support_lines.cpp:17
 msgid ""
@@ -755,11 +755,11 @@ msgstr ""
 
 #: Source/DiabloUI/title.cpp:44
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
-msgstr "Copyright © 1996-2001 Blizzard Entertainment"
+msgstr "Copyright ​©​ 1996-2001 Blizzard Entertainment"
 
 #: Source/appfat.cpp:37
 msgid "Error"
-msgstr "錯誤"
+msgstr "錯​誤"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
 #: Source/appfat.cpp:101
@@ -770,7 +770,7 @@ msgid ""
 msgstr ""
 "{: s}\n"
 "\n"
-"錯誤發生在: {: s}，行{: d}"
+"錯誤​發生​在​:​ {: s}​，​行{: d}"
 
 #: Source/appfat.cpp:115
 #, fuzzy
@@ -784,16 +784,16 @@ msgid ""
 "\n"
 "Make sure that it is in the game folder."
 msgstr ""
-"無法打開主數據存檔（{:s}）。\n"
+"無​法​打開主數據​存檔​（​{:s}​）​。​\n"
 "\n"
-"確保它在遊戲資料夾中，並且檔名都是小寫的。"
+"確保​它​在​遊戲​資料夾​中​，​並且​檔名​都​是​小寫​的​。"
 
 msgid "diabdat.mpq or spawn.mpq"
 msgstr "diabdat.mpq或spawn.mpq"
 
 #: Source/appfat.cpp:119
 msgid "Data File Error"
-msgstr "數據檔案錯誤"
+msgstr "數​據​檔案​錯誤"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
 #: Source/appfat.cpp:127
@@ -801,76 +801,76 @@ msgid ""
 "Unable to write to location:\n"
 "{:s}"
 msgstr ""
-"無法寫入位置: \n"
+"無​法​寫入​位置​:​ \n"
 "{: s}"
 
 #: Source/appfat.cpp:129
 msgid "Read-Only Directory Error"
-msgstr "只讀目錄錯誤"
+msgstr "只​讀目錄​錯誤"
 
 #: Source/automap.cpp:468
 msgid "game: "
-msgstr "遊戲: "
+msgstr "遊​戲​: "
 
 #: Source/automap.cpp:474
 msgid "password: "
-msgstr "密碼: "
+msgstr "密碼​: "
 
 #: Source/automap.cpp:487
 msgid "Level: Nest {:d}"
-msgstr "層數: {:d}巢穴"
+msgstr "層​數​:​ {:d}​巢​穴"
 
 #: Source/automap.cpp:489
 msgid "Level: Crypt {:d}"
-msgstr "層數: {:d}墓穴"
+msgstr "層​數​:​ {:d}​墓穴"
 
 #: Source/automap.cpp:491 Source/items.cpp:2086
 msgid "Level: {:d}"
-msgstr "等級: {:d}"
+msgstr "等​級​:​ {:d}"
 
 #: Source/control.cpp:196
 msgid "Tab"
-msgstr "標籤"
+msgstr "標​籤"
 
 #: Source/control.cpp:196
 msgid "Esc"
-msgstr "電子穩定控制系統"
+msgstr "電子​穩定​控制​系統"
 
 #: Source/control.cpp:196
 msgid "Enter"
-msgstr "輸入"
+msgstr "輸​入"
 
 #: Source/control.cpp:199
 msgid "Character Information"
-msgstr "角色資訊"
+msgstr "角色​資訊"
 
 #: Source/control.cpp:200
 msgid "Quests log"
-msgstr "任務日誌"
+msgstr "任​務日誌"
 
 #: Source/control.cpp:201
 msgid "Automap"
-msgstr "自動對映"
+msgstr "自動​對映"
 
 #: Source/control.cpp:202
 msgid "Main Menu"
-msgstr "主菜單"
+msgstr "主​菜單"
 
 #: Source/control.cpp:203
 msgid "Inventory"
-msgstr "庫存"
+msgstr "庫​存"
 
 #: Source/control.cpp:204
 msgid "Spell book"
-msgstr "咒語書"
+msgstr "咒​語書"
 
 #: Source/control.cpp:205
 msgid "Send Message"
-msgstr "發送訊息"
+msgstr "發​送​訊​息"
 
 #: Source/control.cpp:712 Source/control.cpp:1175
 msgid "{:s} Skill"
-msgstr "{:s}技能"
+msgstr "{:s}​技能"
 
 #: Source/control.cpp:716 Source/control.cpp:1179
 msgid "{:s} Spell"
@@ -878,19 +878,19 @@ msgstr "{:s}法術"
 
 #: Source/control.cpp:718
 msgid "Damages undead only"
-msgstr "只傷害亡靈"
+msgstr "只​傷害亡​靈"
 
 #: Source/control.cpp:722 Source/control.cpp:1183 Source/control.cpp:1554
 msgid "Spell Level 0 - Unusable"
-msgstr "法術等級0-無法使用"
+msgstr "法術​等​級​0-無法​使用"
 
 #: Source/control.cpp:724 Source/control.cpp:1185 Source/control.cpp:1556
 msgid "Spell Level {:d}"
-msgstr "法術等級{:d}"
+msgstr "法術​等​級{:d}"
 
 #: Source/control.cpp:729 Source/control.cpp:1189
 msgid "Scroll of {:s}"
-msgstr "{:s}卷軸"
+msgstr "{:s}​卷​軸"
 
 #: Source/control.cpp:745 Source/control.cpp:1206
 #, fuzzy
@@ -901,7 +901,7 @@ msgstr[0] "{:s}卷軸"
 
 #: Source/control.cpp:750 Source/control.cpp:1210 Source/items.cpp:1325
 msgid "Staff of {:s}"
-msgstr "{:s}的職員"
+msgstr "{:s}​的​職員"
 
 #: Source/control.cpp:752 Source/control.cpp:1212
 #, fuzzy
@@ -914,27 +914,27 @@ msgstr[0] "生命點{:d}的{:d}"
 #, fuzzy
 #| msgid "Spell Hotkey #F{:d}"
 msgid "Spell Hotkey {:s}"
-msgstr "熱鍵: {:s}"
+msgstr "熱​鍵​:​ {:s}"
 
 #: Source/control.cpp:1152
 msgid "Player friendly"
-msgstr "對玩家友好"
+msgstr "對​玩​家​友好"
 
 #: Source/control.cpp:1154
 msgid "Player attack"
-msgstr "玩家攻擊"
+msgstr "玩​家​攻擊"
 
 #: Source/control.cpp:1157
 msgid "Hotkey: {:s}"
-msgstr "熱鍵: {:s}"
+msgstr "熱​鍵​:​ {:s}"
 
 #: Source/control.cpp:1165
 msgid "Select current spell button"
-msgstr "選擇目前法術按鈕"
+msgstr "選​擇​目前​法術​按​鈕"
 
 #: Source/control.cpp:1168
 msgid "Hotkey: 's'"
-msgstr "熱鍵: 「s」"
+msgstr "熱​鍵​: 「​s​」"
 
 #: Source/control.cpp:1334 Source/inv.cpp:1893 Source/items.cpp:3751
 #, fuzzy
@@ -945,15 +945,15 @@ msgstr[0] "金幣"
 
 #: Source/control.cpp:1337
 msgid "Requirements not met"
-msgstr "未滿足條件"
+msgstr "未​滿足​條件"
 
 #: Source/control.cpp:1373
 msgid "{:s}, Level: {:d}"
-msgstr "{:s}，層數: {:d}"
+msgstr "{:s}​，​層數​:​ {:d}"
 
 #: Source/control.cpp:1375
 msgid "Hit Points {:d} of {:d}"
-msgstr "生命點{:d}的{:d}"
+msgstr "生命​點{:d}​的​{:d}"
 
 #: Source/control.cpp:1402
 msgid "Level Up"
@@ -973,17 +973,17 @@ msgstr[0] "{:s}的職員"
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
 #: Source/control.cpp:1544
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
-msgstr "法力: {:d} 傷害: {:d}-{:d}"
+msgstr "法力​:​ {:d} ​傷害​:​ {:d}-{:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
 #: Source/control.cpp:1546
 msgid "Mana: {:d}   Dam: n/a"
-msgstr "法力: {:d} 傷害: n/a"
+msgstr "法力​:​ {:d} ​傷害​:​ n/a"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
 #: Source/control.cpp:1549
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
-msgstr "法力: {:d} 傷害: 1/3 tgt hp"
+msgstr "法力​:​ {:d} ​傷害​:​ 1/3 tgt hp"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1606
@@ -997,11 +997,11 @@ msgstr "菜單"
 
 #: Source/controls/modifier_hints.cpp:121
 msgid "Inv"
-msgstr "物品欄"
+msgstr "物品​欄"
 
 #: Source/controls/modifier_hints.cpp:121
 msgid "Map"
-msgstr "地圖"
+msgstr "地​圖"
 
 #: Source/controls/modifier_hints.cpp:121
 msgid "Char"
@@ -1009,7 +1009,7 @@ msgstr "角色"
 
 #: Source/controls/modifier_hints.cpp:122
 msgid "Spells"
-msgstr "法術"
+msgstr "法​術"
 
 #: Source/controls/modifier_hints.cpp:122
 msgid "Quests"
@@ -1017,79 +1017,79 @@ msgstr "任務"
 
 #: Source/cursor.cpp:211
 msgid "Town Portal"
-msgstr "城鎮傳送門"
+msgstr "城鎮​傳​送門"
 
 #: Source/cursor.cpp:212
 msgid "from {:s}"
-msgstr "從{:s}"
+msgstr "從​{:s}"
 
 #: Source/cursor.cpp:229
 msgid "Portal to"
-msgstr "通向"
+msgstr "通​向"
 
 #: Source/cursor.cpp:231
 msgid "The Unholy Altar"
-msgstr "邪惡的祭壇"
+msgstr "邪惡​的​祭壇"
 
 #: Source/cursor.cpp:233
 msgid "level 15"
-msgstr "15級"
+msgstr "15​級"
 
 #: Source/diablo.cpp:111
 msgid "I need help! Come Here!"
-msgstr "我需要幫助！過來！"
+msgstr "我​需要​幫助​！​過來​！"
 
 #: Source/diablo.cpp:112
 msgid "Follow me."
-msgstr "跟著我。"
+msgstr "跟​著​我​。"
 
 #: Source/diablo.cpp:113
 msgid "Here's something for you."
-msgstr "這是給你的。"
+msgstr "這​是​給​你​的​。"
 
 #: Source/diablo.cpp:114
 msgid "Now you DIE!"
-msgstr "現在你死定了！"
+msgstr "現​在​你​死定​了​！"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:777
 msgid "Options:\n"
-msgstr "選項: \n"
+msgstr "選​項​:​ \n"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:778
 msgid "Print this message and exit"
-msgstr "列印此訊息並退出"
+msgstr "列​印此​訊息並​退出"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:779
 msgid "Print the version and exit"
-msgstr "列印版本並退出"
+msgstr "列​印​版本​並​退出"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:780
 msgid "Specify the folder of diabdat.mpq"
-msgstr "指定diabdat.mpq的資料夾"
+msgstr "指定​diabdat.mpq​的​資料​夾"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:781
 msgid "Specify the folder of save files"
-msgstr "指定儲存檔案的資料夾"
+msgstr "指定​儲存​檔案​的​資料​夾"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:782
 msgid "Specify the location of diablo.ini"
-msgstr "指定diablo.ini的位置"
+msgstr "指定​diablo.ini​的​位置"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:783
 msgid "Specify the location of the .ttf font"
-msgstr "指定.ttf字型的位置"
+msgstr "指定​.ttf字型​的​位置"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:784
 msgid "Specify the name of a custom .ttf font"
-msgstr "指定自定義.ttf字型的名稱"
+msgstr "指定​自定義​.ttf字型​的​名稱"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:785
@@ -1099,34 +1099,34 @@ msgstr "跳過啟動視訊"
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:786
 msgid "Display frames per second"
-msgstr "每秒顯示幀數"
+msgstr "每​秒​顯示幀數"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:787
 msgid "Run in windowed mode"
-msgstr "在視窗模式下執行"
+msgstr "在​視窗​模式​下執行"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:788
 msgid "Enable verbose logging"
-msgstr "啟用詳細日誌記錄"
+msgstr "啟​用​詳​細​日誌記錄"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:789
 msgid "Force spawn mode even if diabdat.mpq is found"
-msgstr "即使找到diabdat.mpq，也強制產生模式"
+msgstr "即使​找到​diabdat.mpq​，​也​強制產生​模式"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:790
 #, fuzzy
 msgid "Record a demo file"
-msgstr "儲存檔案已存在"
+msgstr "儲​存檔案​已​存在"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:791
 #, fuzzy
 msgid "Play a demo file"
-msgstr "自己玩，沒有網路曝光。"
+msgstr "自己​玩​，​沒​有​網路​曝光​。"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:792
@@ -1140,17 +1140,17 @@ msgid ""
 "Hellfire options:\n"
 msgstr ""
 "\n"
-"地獄火選項: \n"
+"地​獄火選項​:​ \n"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:794
 msgid "Force diablo mode even if hellfire.mpq is found"
-msgstr "即使hellfire.mpq存在，也強制使用暗黑破壞神原版模式"
+msgstr "即使​hellfire.mpq​存在​，​也​強制​使用​暗​黑破壞神​原版​模式"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:795
 msgid "Use alternate nest palette"
-msgstr "使用備用巢狀調色板"
+msgstr "使用​備​用​巢狀​調色板"
 
 #: Source/diablo.cpp:801
 msgid ""
@@ -1158,322 +1158,322 @@ msgid ""
 "Report bugs at https://github.com/diasurgical/devilutionX/\n"
 msgstr ""
 "\n"
-"報告錯誤https://github.com/diasurgical/devilutionX/\n"
+"報​告錯​誤​https://github.com/diasurgical/devilutionX/\n"
 
 #: Source/diablo.cpp:869
 msgid "unrecognized option '{:s}'\n"
-msgstr "無法識別的選項{: s}\n"
+msgstr "無​法識別​的​選項​{: s}\n"
 
 #: Source/diablo.cpp:900
 msgid "version {:s}"
-msgstr "版本{:s}"
+msgstr "版本​{:s}"
 
 #: Source/diablo.cpp:1206
 msgid "-- Network timeout --"
-msgstr "--網路超時--"
+msgstr "--網路​超時​--"
 
 #: Source/diablo.cpp:1207
 msgid "-- Waiting for players --"
-msgstr "--等待玩家--"
+msgstr "--​等待​玩​家​--"
 
 #: Source/diablo.cpp:1226
 msgid "No help available"
-msgstr "沒有可用的幫助"
+msgstr "沒​有​可用​的​幫助"
 
 #: Source/diablo.cpp:1227
 msgid "while in stores"
-msgstr "在商店裡"
+msgstr "在​商店​裡"
 
 #. TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty.
 #: Source/diablo.cpp:1439
 #, fuzzy
 #| msgid "{:s}, mode = {:s}"
 msgid "{:s}, version = {:s}, mode = {:s}"
-msgstr "{:s}（等級{:d}）: {:s}"
+msgstr "{:s}​（​等​級{:d}​）​:​ {:s}"
 
 #: Source/dvlnet/loopback.cpp:111
 msgid "loopback"
-msgstr "環回"
+msgstr "環​回"
 
 #: Source/dvlnet/tcp_client.cpp:68
 msgid "Unable to connect"
-msgstr "無法連線"
+msgstr "無​法連線"
 
 #: Source/dvlnet/tcp_client.cpp:89
 msgid "error: read 0 bytes from server"
-msgstr "錯誤: 從伺服器讀取0位元組"
+msgstr "錯​誤​: 從伺​服器​讀​取​0​位​元組"
 
 #: Source/error.cpp:58
 msgid "No automap available in town"
-msgstr "城裡沒有汽車地圖"
+msgstr "城裡沒​有​汽車​地​圖"
 
 #: Source/error.cpp:59
 msgid "No multiplayer functions in demo"
-msgstr "演示中沒有多人遊戲功能"
+msgstr "演示​中​沒​有​多​人​遊戲​功能"
 
 #: Source/error.cpp:60
 msgid "Direct Sound Creation Failed"
-msgstr "直接聲音建立失敗"
+msgstr "直接​聲音​建立​失敗"
 
 #: Source/error.cpp:61
 msgid "Not available in shareware version"
-msgstr "在共享軟體版本中不可用"
+msgstr "在​共​享軟​體​版本​中​不​可​用"
 
 #: Source/error.cpp:62
 msgid "Not enough space to save"
-msgstr "空間不夠節省"
+msgstr "空間​不​夠​節省"
 
 #: Source/error.cpp:63
 msgid "No Pause in town"
-msgstr "不要在城裡停下來"
+msgstr "不​要​在​城裡​停下​來"
 
 #: Source/error.cpp:64
 msgid "Copying to a hard disk is recommended"
-msgstr "建議複製到硬碟"
+msgstr "建​議複製​到​硬碟"
 
 #: Source/error.cpp:65
 msgid "Multiplayer sync problem"
-msgstr "多人同步問題"
+msgstr "多​人​同步​問題"
 
 #: Source/error.cpp:66
 msgid "No pause in multiplayer"
-msgstr "多人遊戲中無暫停"
+msgstr "多​人​遊戲​中​無暫​停"
 
 #: Source/error.cpp:67
 msgid "Loading..."
-msgstr "載入。。。"
+msgstr "載入​。​。​。"
 
 #: Source/error.cpp:68
 msgid "Saving..."
-msgstr "正在儲存。。。"
+msgstr "正在​儲存​。​。​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:69
 msgid "Some are weakened as one grows strong"
-msgstr "當一個人變得強壯時，有些人會變得虛弱"
+msgstr "當​一​個​人​變​得​強壯時​，​有些​人​會​變​得​虛弱"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:70
 msgid "New strength is forged through destruction"
-msgstr "新的力量是通過破壞鍛造出來的"
+msgstr "新​的​力量​是​通過​破壞鍛造出來​的"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:71
 msgid "Those who defend seldom attack"
-msgstr "防禦者很少攻擊"
+msgstr "防禦者​很​少​攻擊"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:72
 msgid "The sword of justice is swift and sharp"
-msgstr "正義之劍迅捷而鋒利"
+msgstr "正​義​之​劍​迅捷​而​鋒利"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:73
 msgid "While the spirit is vigilant the body thrives"
-msgstr "當精神保持警惕時，身體就會茁壯成長"
+msgstr "當​精神​保持​警惕時​，​身體​就​會茁壯​成長"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:74
 msgid "The powers of mana refocused renews"
-msgstr "法力的力量重新聚焦更新"
+msgstr "法力​的​力量​重新​聚焦​更新"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:75
 msgid "Time cannot diminish the power of steel"
-msgstr "時間不能削弱鋼鐵的力量"
+msgstr "時​間​不​能​削弱​鋼鐵​的​力量"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:76
 msgid "Magic is not always what it seems to be"
-msgstr "魔術並不總是看起來的那樣"
+msgstr "魔術​並​不​總​是​看起來​的​那​樣"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:77
 msgid "What once was opened now is closed"
-msgstr "曾經打開的現在關閉了"
+msgstr "曾​經​打開​的​現​在​關閉​了"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:78
 msgid "Intensity comes at the cost of wisdom"
-msgstr "強度是以智慧為代價的"
+msgstr "強度​是​以​智慧​為代價​的"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:79
 msgid "Arcane power brings destruction"
-msgstr "神秘力量帶來毀滅"
+msgstr "神秘​力量​帶來毀滅"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:80
 msgid "That which cannot be held cannot be harmed"
-msgstr "不能持有的東西不能受到傷害"
+msgstr "不​能​持有​的​東西​不​能​受到​傷害"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:81
 msgid "Crimson and Azure become as the sun"
-msgstr "深紅湛藍如太陽"
+msgstr "深​紅湛藍​如​太​陽"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:82
 msgid "Knowledge and wisdom at the cost of self"
-msgstr "以犧牲自我為代價的知識和智慧"
+msgstr "以​犧牲​自我​為代價​的​知識​和​智慧"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:83
 msgid "Drink and be refreshed"
-msgstr "喝酒提神"
+msgstr "喝​酒​提神"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:84
 msgid "Wherever you go, there you are"
-msgstr "無論你走到哪裡，你都在那裡"
+msgstr "無論​你​走到​哪​裡​，​你​都​在​那​裡"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:85
 msgid "Energy comes at the cost of wisdom"
-msgstr "能量是以智慧為代價的"
+msgstr "能量​是​以​智慧​為代價​的"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:86
 msgid "Riches abound when least expected"
-msgstr "財富在最不經意的時候大量存在"
+msgstr "財富​在​最​不​經意​的​時候​大量​存在"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:87
 msgid "Where avarice fails, patience gains reward"
-msgstr "貪婪失敗了，耐心就會得到回報"
+msgstr "貪​婪失敗​了​，​耐心​就​會​得到​回報"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:88
 msgid "Blessed by a benevolent companion!"
-msgstr "被仁慈的同伴祝福！"
+msgstr "被​仁慈​的​同伴​祝福​！"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:89
 msgid "The hands of men may be guided by fate"
-msgstr "人的手可能會被命運所指引"
+msgstr "人​的​手可能​會​被​命運​所​指引"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:90
 msgid "Strength is bolstered by heavenly faith"
-msgstr "力量是由天國的信仰支撐的"
+msgstr "力量​是​由​天國​的​信仰​支撐​的"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:91
 msgid "The essence of life flows from within"
-msgstr "生命的本質來自內在"
+msgstr "生命​的​本質來​自內​在"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:92
 msgid "The way is made clear when viewed from above"
-msgstr "從上面看清楚了"
+msgstr "從​上面​看​清楚​了"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:93
 msgid "Salvation comes at the cost of wisdom"
-msgstr "拯救是以智慧為代價的"
+msgstr "拯救​是​以​智慧​為代價​的"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:94
 msgid "Mysteries are revealed in the light of reason"
-msgstr "謎團在理性的光照下顯露出來"
+msgstr "謎團​在​理性​的​光照​下​顯​露出​來"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:95
 msgid "Those who are last may yet be first"
-msgstr "最後一個可能還是第一個"
+msgstr "最後​一​個​可能​還​是​第一​個"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:96
 msgid "Generosity brings its own rewards"
-msgstr "慷慨自有回報"
+msgstr "慷慨​自​有​回報"
 
 #: Source/error.cpp:97
 msgid "You must be at least level 8 to use this."
-msgstr "你必須至少達到8級才能使用這個。"
+msgstr "你​必須​至少​達​到​8​級​才​能​使用​這個​。"
 
 #: Source/error.cpp:98
 msgid "You must be at least level 13 to use this."
-msgstr "你必須至少達到13級才能使用這個。"
+msgstr "你​必須​至少​達​到​13級​才​能​使用​這個​。"
 
 #: Source/error.cpp:99
 msgid "You must be at least level 17 to use this."
-msgstr "你必須至少達到17級才能使用這個。"
+msgstr "你​必須​至少​達​到​17級​才​能​使用​這個​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:100
 msgid "Arcane knowledge gained!"
-msgstr "獲得奧術知識！"
+msgstr "獲​得​奧術​知識​！"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:101
 msgid "That which does not kill you..."
-msgstr "不會殺死你的東西。。。"
+msgstr "不​會殺死​你​的​東西​。​。​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:102
 msgid "Knowledge is power."
-msgstr "知識就是力量。"
+msgstr "知識​就​是​力量​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:103
 msgid "Give and you shall receive."
-msgstr "付出你就會得到。"
+msgstr "付出​你​就​會​得到​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:104
 msgid "Some experience is gained by touch."
-msgstr "一些經驗是通過接觸獲得的。"
+msgstr "一些​經驗​是​通過​接觸​獲得​的​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:105
 msgid "There's no place like home."
-msgstr "沒有比家更好的地方了。"
+msgstr "沒​有​比家​更​好​的​地方​了​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:106
 msgid "Spiritual energy is restored."
-msgstr "精神能量被恢復。"
+msgstr "精神​能量​被​恢復​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:107
 msgid "You feel more agile."
-msgstr "你感覺更敏捷。"
+msgstr "你​感覺​更​敏捷​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:108
 msgid "You feel stronger."
-msgstr "你感覺更強壯。"
+msgstr "你​感覺​更​強壯​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:109
 msgid "You feel wiser."
-msgstr "你覺得自己更聰明。"
+msgstr "你​覺得​自己​更​聰明​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:110
 msgid "You feel refreshed."
-msgstr "你感覺神清氣爽。"
+msgstr "你​感覺​神清​氣爽​。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/error.cpp:111
 msgid "That which can break will."
-msgstr "能打破意志的東西。"
+msgstr "能​打破​意志​的​東西​。"
 
 #: Source/gamemenu.cpp:35
 msgid "Save Game"
-msgstr "儲存遊戲"
+msgstr "儲​存遊​戲"
 
 #: Source/gamemenu.cpp:36 Source/gamemenu.cpp:47
 msgid "Options"
-msgstr "選項"
+msgstr "選​項"
 
 #: Source/gamemenu.cpp:39 Source/gamemenu.cpp:50
 msgid "Quit Game"
-msgstr "退出遊戲"
+msgstr "退出​遊戲"
 
 #: Source/gamemenu.cpp:49
 msgid "Restart In Town"
-msgstr "在城裡重新開始"
+msgstr "在​城裡​重新​開始"
 
 #: Source/gamemenu.cpp:59
 msgid "Gamma"
@@ -1485,39 +1485,39 @@ msgstr "速度"
 
 #: Source/gamemenu.cpp:61
 msgid "Previous Menu"
-msgstr "上一個菜單"
+msgstr "上​一​個​菜單"
 
 #: Source/gamemenu.cpp:68
 msgid "Music Disabled"
-msgstr "音樂已禁用"
+msgstr "音樂​已​禁​用"
 
 #: Source/gamemenu.cpp:72
 msgid "Sound"
-msgstr "聲音"
+msgstr "聲​音"
 
 #: Source/gamemenu.cpp:73
 msgid "Sound Disabled"
-msgstr "聲音已禁用"
+msgstr "聲音​已​禁​用"
 
 #: Source/gamemenu.cpp:155
 msgid "Speed: Fastest"
-msgstr "速度: 最快"
+msgstr "速度​: 最​快"
 
 #: Source/gamemenu.cpp:157
 msgid "Speed: Faster"
-msgstr "速度: 更快"
+msgstr "速度​: 更​快"
 
 #: Source/gamemenu.cpp:159
 msgid "Speed: Fast"
-msgstr "速度: 快"
+msgstr "速度​: 快"
 
 #: Source/gamemenu.cpp:161
 msgid "Speed: Normal"
-msgstr "速度: 正常"
+msgstr "速度​: 正常"
 
 #: Source/gmenu.cpp:166
 msgid "Pause"
-msgstr "暫停"
+msgstr "暫​停"
 
 #: Source/help.cpp:26
 msgid "$Keyboard Shortcuts:"
@@ -1531,7 +1531,7 @@ msgstr ""
 #, fuzzy
 #| msgid "Unable to display mainmenu"
 msgid "Esc:   Display Main Menu"
-msgstr "主菜單"
+msgstr "主​菜單"
 
 #: Source/help.cpp:29
 msgid "Tab:   Display Auto-map"
@@ -1550,7 +1550,7 @@ msgstr "{:s} / {:s}"
 #, fuzzy
 #| msgid "A Spellbook"
 msgid "B: Open Spellbook"
-msgstr "咒語書"
+msgstr "咒​語書"
 
 #: Source/help.cpp:33
 msgid "I: Open Inventory screen"
@@ -1564,7 +1564,7 @@ msgstr ""
 #, fuzzy
 #| msgid "Quests log"
 msgid "Q: Open Quest log"
-msgstr "任務日誌"
+msgstr "任​務日誌"
 
 #: Source/help.cpp:36
 msgid "F: Reduce screen brightness"
@@ -1574,7 +1574,7 @@ msgstr ""
 #, fuzzy
 #| msgid "increase strength"
 msgid "G: Increase screen brightness"
-msgstr "增強力量"
+msgstr "增強​力量"
 
 #: Source/help.cpp:38
 msgid "Z: Zoom Game Screen"
@@ -1583,7 +1583,7 @@ msgstr ""
 #: Source/help.cpp:39
 #, fuzzy
 msgid "+ / -: Zoom Automap"
-msgstr "自動對映"
+msgstr "自動​對映"
 
 #: Source/help.cpp:40
 msgid "1 - 8: Use Belt item"
@@ -1635,7 +1635,7 @@ msgstr ""
 #, fuzzy
 #| msgid "Automap"
 msgid "$Auto-map:"
-msgstr "大教堂地圖"
+msgstr "大​教堂​地​圖"
 
 #: Source/help.cpp:56
 msgid ""
@@ -1673,7 +1673,7 @@ msgstr ""
 #: Source/help.cpp:72
 #, fuzzy
 msgid "$Skills & Spells:"
-msgstr "法術"
+msgstr "法​術"
 
 #: Source/help.cpp:73
 msgid ""
@@ -1687,7 +1687,7 @@ msgstr ""
 #: Source/help.cpp:79
 #, fuzzy
 msgid "$Using the Speedbook for Spells"
-msgstr "法術"
+msgstr "法​術"
 
 #: Source/help.cpp:80
 msgid ""
@@ -1705,7 +1705,7 @@ msgstr ""
 #: Source/help.cpp:86
 #, fuzzy
 msgid "$Setting Spell Hotkeys"
-msgstr "咒語書"
+msgstr "咒​語書"
 
 #: Source/help.cpp:87
 msgid ""
@@ -1718,7 +1718,7 @@ msgstr ""
 #, fuzzy
 #| msgid "Spell book"
 msgid "$Spell Books"
-msgstr "法術等級0-無法使用"
+msgstr "法術​等​級​0-無法​使用"
 
 #: Source/help.cpp:93
 msgid ""
@@ -1730,41 +1730,41 @@ msgstr ""
 #, fuzzy
 #| msgid "Hellfire Help"
 msgid "Shareware Hellfire Help"
-msgstr "地獄火幫助"
+msgstr "地​獄火​幫助"
 
 #: Source/help.cpp:130
 msgid "Hellfire Help"
-msgstr "地獄火幫助"
+msgstr "地​獄火​幫助"
 
 #: Source/help.cpp:132
 #, fuzzy
 #| msgid "Diablo Help"
 msgid "Shareware Diablo Help"
-msgstr "在共享軟體中"
+msgstr "在​共​享軟​體​中"
 
 #: Source/help.cpp:132
 msgid "Diablo Help"
-msgstr "暗黑破壞神幫助"
+msgstr "暗​黑破壞神​幫助"
 
 #: Source/help.cpp:156
 msgid "Press ESC to end or the arrow keys to scroll."
-msgstr "按ESC鍵結束，或按箭頭鍵滾動。"
+msgstr "按​ESC鍵​結束​，​或​按箭頭鍵​滾動​。"
 
 #: Source/init.cpp:214
 msgid "Some Hellfire MPQs are missing"
-msgstr "一些地獄火MPQ無法找到"
+msgstr "一些​地​獄火​MPQ​無法​找到"
 
 #: Source/init.cpp:214
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
 msgstr ""
-"地獄火MPQ未能全部找到。\n"
-"請複製所有hf*.mpq檔案。"
+"地​獄火​MPQ​未​能​全部​找到​。​\n"
+"請​複製​所有​hf​*​.mpq檔案​。"
 
 #: Source/init.cpp:224
 msgid "Unable to create main window"
-msgstr "無法建立主視窗"
+msgstr "無​法​建立​主視​窗"
 
 #: Source/itemdat.cpp:16 Source/itemdat.cpp:198 Source/panels/charpanel.cpp:154
 msgid "Gold"
@@ -1772,11 +1772,11 @@ msgstr "金幣"
 
 #: Source/itemdat.cpp:17 Source/itemdat.cpp:135
 msgid "Short Sword"
-msgstr "短劍"
+msgstr "短​劍"
 
 #: Source/itemdat.cpp:18 Source/itemdat.cpp:87
 msgid "Buckler"
-msgstr "小圓盾"
+msgstr "小​圓盾"
 
 #: Source/itemdat.cpp:19 Source/itemdat.cpp:155 Source/itemdat.cpp:156
 msgid "Club"
@@ -1788,7 +1788,7 @@ msgstr "短弓"
 
 #: Source/itemdat.cpp:21
 msgid "Short Staff of Mana"
-msgstr "法力不足"
+msgstr "法力​不足"
 
 #: Source/itemdat.cpp:22
 msgid "Cleaver"
@@ -1796,11 +1796,11 @@ msgstr "切肉者"
 
 #: Source/itemdat.cpp:23 Source/itemdat.cpp:397
 msgid "The Undead Crown"
-msgstr "不死之冠"
+msgstr "不​死​之​冠"
 
 #: Source/itemdat.cpp:24 Source/itemdat.cpp:398
 msgid "Empyrean Band"
-msgstr "太陽帶"
+msgstr "太​陽帶"
 
 #: Source/itemdat.cpp:25
 msgid "Magic Rock"
@@ -1808,23 +1808,23 @@ msgstr "魔石"
 
 #: Source/itemdat.cpp:26 Source/itemdat.cpp:399
 msgid "Optic Amulet"
-msgstr "神聖護符"
+msgstr "神聖護​符"
 
 #: Source/itemdat.cpp:27 Source/itemdat.cpp:400
 msgid "Ring of Truth"
-msgstr "真理之環"
+msgstr "真理​之​環"
 
 #: Source/itemdat.cpp:28
 msgid "Tavern Sign"
-msgstr "酒店招牌"
+msgstr "酒店​招牌"
 
 #: Source/itemdat.cpp:29 Source/itemdat.cpp:401
 msgid "Harlequin Crest"
-msgstr "諧角之冠"
+msgstr "諧角​之​冠"
 
 #: Source/itemdat.cpp:30 Source/itemdat.cpp:402
 msgid "Veil of Steel"
-msgstr "鋼鐵面紗"
+msgstr "鋼​鐵面紗"
 
 #: Source/itemdat.cpp:31
 msgid "Golden Elixir"
@@ -1832,23 +1832,23 @@ msgstr "金丹"
 
 #: Source/itemdat.cpp:32 Source/quests.cpp:51
 msgid "Anvil of Fury"
-msgstr "憤怒的鐵砧"
+msgstr "憤怒​的​鐵砧"
 
 #: Source/itemdat.cpp:33 Source/quests.cpp:42
 msgid "Black Mushroom"
-msgstr "黑蘑菇"
+msgstr "黑​蘑菇"
 
 #: Source/itemdat.cpp:34
 msgid "Brain"
-msgstr "大腦"
+msgstr "大​腦"
 
 #: Source/itemdat.cpp:35
 msgid "Fungal Tome"
-msgstr "真菌切片機"
+msgstr "真​菌​切片​機"
 
 #: Source/itemdat.cpp:36
 msgid "Spectral Elixir"
-msgstr "光譜藥劑"
+msgstr "光​譜藥劑"
 
 #: Source/itemdat.cpp:37
 msgid "Blood Stone"
@@ -1856,43 +1856,43 @@ msgstr "血石"
 
 #: Source/itemdat.cpp:38
 msgid "Cathedral Map"
-msgstr "大教堂地圖"
+msgstr "大​教堂​地​圖"
 
 #: Source/itemdat.cpp:39
 msgid "Heart"
-msgstr "心臟"
+msgstr "心​臟"
 
 #: Source/itemdat.cpp:40 Source/itemdat.cpp:93
 msgid "Potion of Healing"
-msgstr "治療藥劑"
+msgstr "治​療藥劑"
 
 #: Source/itemdat.cpp:41 Source/itemdat.cpp:95
 msgid "Potion of Mana"
-msgstr "魔力藥水"
+msgstr "魔力​藥​水"
 
 #: Source/itemdat.cpp:42 Source/itemdat.cpp:110
 msgid "Scroll of Identify"
-msgstr "鑑定卷軸"
+msgstr "鑑​定​卷軸"
 
 #: Source/itemdat.cpp:43 Source/itemdat.cpp:114
 msgid "Scroll of Town Portal"
-msgstr "城鎮傳送卷軸"
+msgstr "城鎮傳​送​卷軸"
 
 #: Source/itemdat.cpp:44 Source/itemdat.cpp:403
 msgid "Arkaine's Valor"
-msgstr "阿凱尼的榮耀"
+msgstr "阿凱尼​的​榮耀"
 
 #: Source/itemdat.cpp:45 Source/itemdat.cpp:94
 msgid "Potion of Full Healing"
-msgstr "完全治癒藥劑"
+msgstr "完全​治癒藥劑"
 
 #: Source/itemdat.cpp:46 Source/itemdat.cpp:96
 msgid "Potion of Full Mana"
-msgstr "全法力藥劑"
+msgstr "全​法力​藥​劑"
 
 #: Source/itemdat.cpp:47 Source/itemdat.cpp:404
 msgid "Griswold's Edge"
-msgstr "格里斯沃爾德之鋒"
+msgstr "格里斯沃​爾德​之​鋒"
 
 #: Source/itemdat.cpp:48 Source/itemdat.cpp:405
 msgid "Bovine Plate"
@@ -1900,19 +1900,19 @@ msgstr "牛板"
 
 #: Source/itemdat.cpp:49
 msgid "Staff of Lazarus"
-msgstr "拉撒雷茲之杖"
+msgstr "拉撒雷茲​之​杖"
 
 #: Source/itemdat.cpp:50 Source/itemdat.cpp:111
 msgid "Scroll of Resurrect"
-msgstr "復活卷軸"
+msgstr "復​活​卷軸"
 
 #: Source/itemdat.cpp:51 Source/itemdat.cpp:99 Source/items.cpp:164
 msgid "Blacksmith Oil"
-msgstr "鐵匠之油"
+msgstr "鐵匠​之​油"
 
 #: Source/itemdat.cpp:52 Source/itemdat.cpp:167
 msgid "Short Staff"
-msgstr "短杖"
+msgstr "短​杖"
 
 #: Source/itemdat.cpp:53 Source/itemdat.cpp:135 Source/itemdat.cpp:136
 #: Source/itemdat.cpp:137 Source/itemdat.cpp:138 Source/itemdat.cpp:141
@@ -1927,11 +1927,11 @@ msgstr "匕首"
 
 #: Source/itemdat.cpp:55
 msgid "Rune Bomb"
-msgstr "符文炸彈"
+msgstr "符文​炸彈"
 
 #: Source/itemdat.cpp:56
 msgid "Theodore"
-msgstr "西奧多"
+msgstr "西奧​多"
 
 #: Source/itemdat.cpp:57
 msgid "Auric Amulet"
@@ -1939,19 +1939,19 @@ msgstr "金護符"
 
 #: Source/itemdat.cpp:58
 msgid "Torn Note 1"
-msgstr "殘破的日記1"
+msgstr "殘破​的​日記​1"
 
 #: Source/itemdat.cpp:59
 msgid "Torn Note 2"
-msgstr "殘破的日記2"
+msgstr "殘破​的​日記​2"
 
 #: Source/itemdat.cpp:60
 msgid "Torn Note 3"
-msgstr "殘破的日記3"
+msgstr "殘破​的​日記​3"
 
 #: Source/itemdat.cpp:61
 msgid "Reconstructed Note"
-msgstr "重構日記"
+msgstr "重​構​日記"
 
 #: Source/itemdat.cpp:62
 msgid "Brown Suit"
@@ -1959,15 +1959,15 @@ msgstr "棕色套裝"
 
 #: Source/itemdat.cpp:63
 msgid "Grey Suit"
-msgstr "灰色套裝"
+msgstr "灰色​套裝"
 
 #: Source/itemdat.cpp:64 Source/itemdat.cpp:65
 msgid "Cap"
-msgstr "軟帽"
+msgstr "軟​帽"
 
 #: Source/itemdat.cpp:65
 msgid "Skull Cap"
-msgstr "骷髏帽"
+msgstr "骷​髏​帽"
 
 #: Source/itemdat.cpp:66 Source/itemdat.cpp:67 Source/itemdat.cpp:69
 msgid "Helm"
@@ -1975,7 +1975,7 @@ msgstr "頭盔"
 
 #: Source/itemdat.cpp:67
 msgid "Full Helm"
-msgstr "全護盔"
+msgstr "全​護盔"
 
 #: Source/itemdat.cpp:68
 msgid "Crown"
@@ -1991,7 +1991,7 @@ msgstr "披肩"
 
 #: Source/itemdat.cpp:71
 msgid "Rags"
-msgstr "短披風"
+msgstr "短​披風"
 
 #: Source/itemdat.cpp:72
 msgid "Cloak"
@@ -1999,16 +1999,16 @@ msgstr "披風"
 
 #: Source/itemdat.cpp:73
 msgid "Robe"
-msgstr "長袍"
+msgstr "長​袍"
 
 #: Source/itemdat.cpp:74
 msgid "Quilted Armor"
-msgstr "內襯甲"
+msgstr "內​襯​甲"
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
 #: Source/itemdat.cpp:77 Source/objects.cpp:5459
 msgid "Armor"
-msgstr "護甲"
+msgstr "護​甲"
 
 #: Source/itemdat.cpp:75
 msgid "Leather Armor"
@@ -2016,70 +2016,70 @@ msgstr "皮甲"
 
 #: Source/itemdat.cpp:76
 msgid "Hard Leather Armor"
-msgstr "硬皮甲"
+msgstr "硬​皮甲"
 
 #: Source/itemdat.cpp:77
 msgid "Studded Leather Armor"
-msgstr "釘皮甲"
+msgstr "釘​皮甲"
 
 #: Source/itemdat.cpp:78
 msgid "Ring Mail"
-msgstr "環甲"
+msgstr "環​甲"
 
 #: Source/itemdat.cpp:78 Source/itemdat.cpp:79 Source/itemdat.cpp:80
 #: Source/itemdat.cpp:82
 msgid "Mail"
-msgstr "鎖甲"
+msgstr "鎖​甲"
 
 #: Source/itemdat.cpp:79
 msgid "Chain Mail"
-msgstr "鎖子甲"
+msgstr "鎖子​甲"
 
 #: Source/itemdat.cpp:80
 msgid "Scale Mail"
-msgstr "魚鱗甲"
+msgstr "魚​鱗​甲"
 
 #: Source/itemdat.cpp:81
 msgid "Breast Plate"
-msgstr "胸片甲"
+msgstr "胸片​甲"
 
 #: Source/itemdat.cpp:81 Source/itemdat.cpp:83 Source/itemdat.cpp:84
 #: Source/itemdat.cpp:85 Source/itemdat.cpp:86
 msgid "Plate"
-msgstr "板甲"
+msgstr "板​甲"
 
 #: Source/itemdat.cpp:82
 msgid "Splint Mail"
-msgstr "板條甲"
+msgstr "板​條​甲"
 
 #: Source/itemdat.cpp:83
 msgid "Plate Mail"
-msgstr "板鍊甲"
+msgstr "板​鍊​甲"
 
 #: Source/itemdat.cpp:84
 msgid "Field Plate"
-msgstr "全身板甲"
+msgstr "全身​板​甲"
 
 #: Source/itemdat.cpp:85
 msgid "Gothic Plate"
-msgstr "哥特甲"
+msgstr "哥特​甲"
 
 #: Source/itemdat.cpp:86
 msgid "Full Plate Mail"
-msgstr "全身板鍊甲"
+msgstr "全身​板鍊​甲"
 
 #: Source/itemdat.cpp:87 Source/itemdat.cpp:88 Source/itemdat.cpp:89
 #: Source/itemdat.cpp:90 Source/itemdat.cpp:91 Source/itemdat.cpp:92
 msgid "Shield"
-msgstr "之盾"
+msgstr "之​盾"
 
 #: Source/itemdat.cpp:88
 msgid "Small Shield"
-msgstr "小盾"
+msgstr "小​盾"
 
 #: Source/itemdat.cpp:89
 msgid "Large Shield"
-msgstr "大盾"
+msgstr "大​盾"
 
 #: Source/itemdat.cpp:90
 msgid "Kite Shield"
@@ -2095,19 +2095,19 @@ msgstr "哥特盾"
 
 #: Source/itemdat.cpp:97
 msgid "Potion of Rejuvenation"
-msgstr "活力恢復藥水"
+msgstr "活力​恢復​藥​水"
 
 #: Source/itemdat.cpp:98
 msgid "Potion of Full Rejuvenation"
-msgstr "完全活力恢復藥水"
+msgstr "完全​活力​恢復​藥​水"
 
 #: Source/itemdat.cpp:100 Source/items.cpp:159
 msgid "Oil of Accuracy"
-msgstr "精準之油"
+msgstr "精準​之​油"
 
 #: Source/itemdat.cpp:101 Source/items.cpp:161
 msgid "Oil of Sharpness"
-msgstr "銳利之油"
+msgstr "銳利​之​油"
 
 #: Source/itemdat.cpp:102
 msgid "Oil"
@@ -2115,108 +2115,108 @@ msgstr "油"
 
 #: Source/itemdat.cpp:103
 msgid "Elixir of Strength"
-msgstr "力量藥劑"
+msgstr "力量​藥劑"
 
 #: Source/itemdat.cpp:104
 msgid "Elixir of Magic"
-msgstr "魔法藥劑"
+msgstr "魔法​藥劑"
 
 #: Source/itemdat.cpp:105
 msgid "Elixir of Dexterity"
-msgstr "敏捷藥劑"
+msgstr "敏捷藥​劑"
 
 #: Source/itemdat.cpp:106
 msgid "Elixir of Vitality"
-msgstr "活力藥劑"
+msgstr "活力​藥劑"
 
 #: Source/itemdat.cpp:107
 msgid "Scroll of Healing"
-msgstr "治療卷軸"
+msgstr "治​療​卷軸"
 
 #: Source/itemdat.cpp:108
 msgid "Scroll of Search"
-msgstr "搜索卷軸"
+msgstr "搜索​卷軸"
 
 #: Source/itemdat.cpp:109
 msgid "Scroll of Lightning"
-msgstr "閃電卷軸"
+msgstr "閃​電​卷軸"
 
 #: Source/itemdat.cpp:112
 msgid "Scroll of Fire Wall"
-msgstr "火焰墻卷軸"
+msgstr "火焰​墻​卷軸"
 
 #: Source/itemdat.cpp:113
 msgid "Scroll of Inferno"
-msgstr "地獄火卷軸"
+msgstr "地​獄​火卷軸"
 
 #: Source/itemdat.cpp:115
 msgid "Scroll of Flash"
-msgstr "閃光卷軸"
+msgstr "閃​光​卷軸"
 
 #: Source/itemdat.cpp:116
 msgid "Scroll of Infravision"
-msgstr "夜視卷軸"
+msgstr "夜​視​卷軸"
 
 #: Source/itemdat.cpp:117
 msgid "Scroll of Phasing"
-msgstr "相位調整卷軸"
+msgstr "相位​調​整​卷​軸"
 
 #: Source/itemdat.cpp:118
 msgid "Scroll of Mana Shield"
-msgstr "法力盾卷軸"
+msgstr "法力​盾​卷軸"
 
 #: Source/itemdat.cpp:119
 msgid "Scroll of Flame Wave"
-msgstr "火焰波卷軸"
+msgstr "火焰​波卷軸"
 
 #: Source/itemdat.cpp:120
 msgid "Scroll of Fireball"
-msgstr "火球卷軸"
+msgstr "火球卷​軸"
 
 #: Source/itemdat.cpp:121
 msgid "Scroll of Stone Curse"
-msgstr "石咒卷軸"
+msgstr "石咒​卷軸"
 
 #: Source/itemdat.cpp:122
 msgid "Scroll of Chain Lightning"
-msgstr "連環閃電卷軸"
+msgstr "連​環閃​電​卷軸"
 
 #: Source/itemdat.cpp:123
 msgid "Scroll of Guardian"
-msgstr "守護者卷軸"
+msgstr "守​護者​卷軸"
 
 #: Source/itemdat.cpp:125
 msgid "Scroll of Nova"
-msgstr "閃電新星卷軸"
+msgstr "閃​電​新​星卷軸"
 
 #: Source/itemdat.cpp:126
 msgid "Scroll of Golem"
-msgstr "傀儡卷軸"
+msgstr "傀儡​卷軸"
 
 #: Source/itemdat.cpp:128
 msgid "Scroll of Teleport"
-msgstr "傳送卷軸"
+msgstr "傳​送​卷軸"
 
 #: Source/itemdat.cpp:129
 msgid "Scroll of Apocalypse"
-msgstr "啓示錄卷軸"
+msgstr "啓示錄​卷軸"
 
 #: Source/itemdat.cpp:130 Source/itemdat.cpp:131 Source/itemdat.cpp:132
 #: Source/itemdat.cpp:133
 msgid "Book of "
-msgstr "之書"
+msgstr "之​書"
 
 #: Source/itemdat.cpp:136
 msgid "Falchion"
-msgstr "彎刃劍"
+msgstr "彎​刃劍"
 
 #: Source/itemdat.cpp:137
 msgid "Scimitar"
-msgstr "彎刀"
+msgstr "彎​刀"
 
 #: Source/itemdat.cpp:138
 msgid "Claymore"
-msgstr "雙手大劍"
+msgstr "雙​手​大劍"
 
 #: Source/itemdat.cpp:139
 msgid "Blade"
@@ -2224,31 +2224,31 @@ msgstr "利刃"
 
 #: Source/itemdat.cpp:140
 msgid "Sabre"
-msgstr "軍刀"
+msgstr "軍​刀"
 
 #: Source/itemdat.cpp:141
 msgid "Long Sword"
-msgstr "長劍"
+msgstr "長​劍"
 
 #: Source/itemdat.cpp:142
 msgid "Broad Sword"
-msgstr "闊劍"
+msgstr "闊​劍"
 
 #: Source/itemdat.cpp:143
 msgid "Bastard Sword"
-msgstr "手半劍"
+msgstr "手​半​劍"
 
 #: Source/itemdat.cpp:144
 msgid "Two-Handed Sword"
-msgstr "雙手劍"
+msgstr "雙​手劍"
 
 #: Source/itemdat.cpp:145
 msgid "Great Sword"
-msgstr "重劍"
+msgstr "重​劍"
 
 #: Source/itemdat.cpp:146
 msgid "Small Axe"
-msgstr "小斧"
+msgstr "小​斧"
 
 #: Source/itemdat.cpp:146 Source/itemdat.cpp:147 Source/itemdat.cpp:148
 #: Source/itemdat.cpp:149 Source/itemdat.cpp:150 Source/itemdat.cpp:151
@@ -2273,7 +2273,7 @@ msgstr "重斧"
 
 #: Source/itemdat.cpp:152 Source/itemdat.cpp:153
 msgid "Mace"
-msgstr "釘錘"
+msgstr "釘​錘"
 
 #: Source/itemdat.cpp:153
 msgid "Morning Star"
@@ -2281,7 +2281,7 @@ msgstr "流星錘"
 
 #: Source/itemdat.cpp:154
 msgid "War Hammer"
-msgstr "戰錘"
+msgstr "戰​錘"
 
 #: Source/itemdat.cpp:154
 msgid "Hammer"
@@ -2289,7 +2289,7 @@ msgstr "錘"
 
 #: Source/itemdat.cpp:155
 msgid "Spiked Club"
-msgstr "狼牙棒"
+msgstr "狼​牙棒"
 
 #: Source/itemdat.cpp:157
 msgid "Flail"
@@ -2297,7 +2297,7 @@ msgstr "連枷"
 
 #: Source/itemdat.cpp:158
 msgid "Maul"
-msgstr "大錘"
+msgstr "大​錘"
 
 #: Source/itemdat.cpp:159 Source/itemdat.cpp:160 Source/itemdat.cpp:161
 #: Source/itemdat.cpp:162 Source/itemdat.cpp:163 Source/itemdat.cpp:164
@@ -2307,52 +2307,52 @@ msgstr "弓"
 
 #: Source/itemdat.cpp:160
 msgid "Hunter's Bow"
-msgstr "獵弓"
+msgstr "獵​弓"
 
 #: Source/itemdat.cpp:161
 msgid "Long Bow"
-msgstr "長弓"
+msgstr "長​弓"
 
 #: Source/itemdat.cpp:162
 msgid "Composite Bow"
-msgstr "複合弓"
+msgstr "複​合弓"
 
 #: Source/itemdat.cpp:163
 msgid "Short Battle Bow"
-msgstr "短戰弓"
+msgstr "短​戰弓"
 
 #: Source/itemdat.cpp:164
 msgid "Long Battle Bow"
-msgstr "長戰弓"
+msgstr "長​戰弓"
 
 #: Source/itemdat.cpp:165
 msgid "Short War Bow"
-msgstr "短戰爭弓"
+msgstr "短戰​爭弓"
 
 #: Source/itemdat.cpp:166
 msgid "Long War Bow"
-msgstr "長戰爭弓"
+msgstr "長​戰​爭弓"
 
 #: Source/itemdat.cpp:167 Source/itemdat.cpp:168 Source/itemdat.cpp:169
 #: Source/itemdat.cpp:170 Source/itemdat.cpp:171
 msgid "Staff"
-msgstr "工作人員"
+msgstr "工作人​員"
 
 #: Source/itemdat.cpp:168
 msgid "Long Staff"
-msgstr "長杖"
+msgstr "長​杖"
 
 #: Source/itemdat.cpp:169
 msgid "Composite Staff"
-msgstr "綜合工作人員"
+msgstr "綜​合​工作人​員"
 
 #: Source/itemdat.cpp:170
 msgid "Quarter Staff"
-msgstr "季度員工"
+msgstr "季度​員工"
 
 #: Source/itemdat.cpp:171
 msgid "War Staff"
-msgstr "戰杖"
+msgstr "戰​杖"
 
 #: Source/itemdat.cpp:172 Source/itemdat.cpp:173 Source/itemdat.cpp:174
 msgid "Ring"
@@ -2360,7 +2360,7 @@ msgstr "戒指"
 
 #: Source/itemdat.cpp:175 Source/itemdat.cpp:176
 msgid "Amulet"
-msgstr "護符"
+msgstr "護​符"
 
 #: Source/itemdat.cpp:177
 msgid "Rune of Fire"
@@ -2373,7 +2373,7 @@ msgstr "符文"
 
 #: Source/itemdat.cpp:178
 msgid "Rune of Lightning"
-msgstr "閃電符文"
+msgstr "閃​電​符文"
 
 #: Source/itemdat.cpp:179
 msgid "Greater Rune of Fire"
@@ -2381,7 +2381,7 @@ msgstr "大火符文"
 
 #: Source/itemdat.cpp:180
 msgid "Greater Rune of Lightning"
-msgstr "大閃電符文"
+msgstr "大​閃​電​符文"
 
 #: Source/itemdat.cpp:181
 msgid "Rune of Stone"
@@ -2389,16 +2389,16 @@ msgstr "符文石"
 
 #: Source/itemdat.cpp:182
 msgid "Short Staff of Charged Bolt"
-msgstr "電荷彈短杖"
+msgstr "電​荷彈​短​杖"
 
 #. TRANSLATORS: Item prefix section.
 #: Source/itemdat.cpp:192
 msgid "Tin"
-msgstr "錫金"
+msgstr "錫​金"
 
 #: Source/itemdat.cpp:193
 msgid "Brass"
-msgstr "黃銅"
+msgstr "黃​銅"
 
 #: Source/itemdat.cpp:194
 msgid "Bronze"
@@ -2406,11 +2406,11 @@ msgstr "青銅"
 
 #: Source/itemdat.cpp:195
 msgid "Iron"
-msgstr "黑鐵"
+msgstr "黑​鐵"
 
 #: Source/itemdat.cpp:196
 msgid "Steel"
-msgstr "鋼鐵"
+msgstr "鋼​鐵"
 
 #: Source/itemdat.cpp:197
 msgid "Silver"
@@ -2426,11 +2426,11 @@ msgstr "秘銀"
 
 #: Source/itemdat.cpp:201
 msgid "Meteoric"
-msgstr "隕鐵"
+msgstr "隕​鐵"
 
 #: Source/itemdat.cpp:202 Source/objects.cpp:104
 msgid "Weird"
-msgstr "詭異"
+msgstr "詭​異"
 
 #: Source/itemdat.cpp:203
 msgid "Strange"
@@ -2438,19 +2438,19 @@ msgstr "奇異"
 
 #: Source/itemdat.cpp:204
 msgid "Useless"
-msgstr "無用的"
+msgstr "無​用​的"
 
 #: Source/itemdat.cpp:205
 msgid "Bent"
-msgstr "彎曲"
+msgstr "彎​曲"
 
 #: Source/itemdat.cpp:206
 msgid "Weak"
-msgstr "軟弱的"
+msgstr "軟弱​的"
 
 #: Source/itemdat.cpp:207
 msgid "Jagged"
-msgstr "參差"
+msgstr "參​差"
 
 #: Source/itemdat.cpp:208
 msgid "Deadly"
@@ -2458,39 +2458,39 @@ msgstr "致命"
 
 #: Source/itemdat.cpp:209
 msgid "Heavy"
-msgstr "沉重的"
+msgstr "沉重​的"
 
 #: Source/itemdat.cpp:210
 msgid "Vicious"
-msgstr "兇惡"
+msgstr "兇​惡"
 
 #: Source/itemdat.cpp:211
 msgid "Brutal"
-msgstr "殘忍"
+msgstr "殘​忍"
 
 #: Source/itemdat.cpp:212
 msgid "Massive"
-msgstr "蠻橫"
+msgstr "蠻​橫"
 
 #: Source/itemdat.cpp:213
 msgid "Savage"
-msgstr "野蠻"
+msgstr "野​蠻"
 
 #: Source/itemdat.cpp:214
 msgid "Ruthless"
-msgstr "無情的"
+msgstr "無情​的"
 
 #: Source/itemdat.cpp:215
 msgid "Merciless"
-msgstr "無情"
+msgstr "無​情"
 
 #: Source/itemdat.cpp:216
 msgid "Clumsy"
-msgstr "笨拙的"
+msgstr "笨拙​的"
 
 #: Source/itemdat.cpp:217
 msgid "Dull"
-msgstr "遲鈍的"
+msgstr "遲鈍​的"
 
 #: Source/itemdat.cpp:218
 msgid "Sharp"
@@ -2498,47 +2498,47 @@ msgstr "鋒利"
 
 #: Source/itemdat.cpp:219 Source/itemdat.cpp:229
 msgid "Fine"
-msgstr "優良"
+msgstr "優​良"
 
 #: Source/itemdat.cpp:220
 msgid "Warrior's"
-msgstr "戰士的"
+msgstr "戰士​的"
 
 #: Source/itemdat.cpp:221
 msgid "Soldier's"
-msgstr "士兵的"
+msgstr "士兵​的"
 
 #: Source/itemdat.cpp:222
 msgid "Lord's"
-msgstr "勛爵的"
+msgstr "勛​爵​的"
 
 #: Source/itemdat.cpp:223
 msgid "Knight's"
-msgstr "騎士的"
+msgstr "騎士​的"
 
 #: Source/itemdat.cpp:224
 msgid "Master's"
-msgstr "大師的"
+msgstr "大師​的"
 
 #: Source/itemdat.cpp:225
 msgid "Champion's"
-msgstr "冠軍的"
+msgstr "冠軍​的"
 
 #: Source/itemdat.cpp:226
 msgid "King's"
-msgstr "國王的"
+msgstr "國王​的"
 
 #: Source/itemdat.cpp:227
 msgid "Vulnerable"
-msgstr "脆弱的"
+msgstr "脆弱​的"
 
 #: Source/itemdat.cpp:228
 msgid "Rusted"
-msgstr "生鏽的"
+msgstr "生鏽​的"
 
 #: Source/itemdat.cpp:230
 msgid "Strong"
-msgstr "強壯"
+msgstr "強​壯"
 
 #: Source/itemdat.cpp:231
 msgid "Grand"
@@ -2546,11 +2546,11 @@ msgstr "大"
 
 #: Source/itemdat.cpp:232
 msgid "Valiant"
-msgstr "勇敢的"
+msgstr "勇敢​的"
 
 #: Source/itemdat.cpp:233
 msgid "Glorious"
-msgstr "光輝"
+msgstr "光​輝"
 
 #: Source/itemdat.cpp:234
 msgid "Blessed"
@@ -2562,7 +2562,7 @@ msgstr "聖者"
 
 #: Source/itemdat.cpp:236
 msgid "Awesome"
-msgstr "真棒"
+msgstr "真​棒"
 
 #: Source/itemdat.cpp:237 Source/objects.cpp:116
 msgid "Holy"
@@ -2578,7 +2578,7 @@ msgstr "丹紅"
 
 #: Source/itemdat.cpp:240 Source/itemdat.cpp:241
 msgid "Crimson"
-msgstr "猩紅"
+msgstr "猩​紅"
 
 #: Source/itemdat.cpp:242
 msgid "Garnet"
@@ -2586,7 +2586,7 @@ msgstr "石榴"
 
 #: Source/itemdat.cpp:243
 msgid "Ruby"
-msgstr "紅寶石"
+msgstr "紅​寶石"
 
 #: Source/itemdat.cpp:244
 msgid "Blue"
@@ -2598,15 +2598,15 @@ msgstr "碧空"
 
 #: Source/itemdat.cpp:246
 msgid "Lapis"
-msgstr "青金石"
+msgstr "青​金石"
 
 #: Source/itemdat.cpp:247
 msgid "Cobalt"
-msgstr "鈷藍"
+msgstr "鈷​藍"
 
 #: Source/itemdat.cpp:248
 msgid "Sapphire"
-msgstr "藍寶石"
+msgstr "藍​寶石"
 
 #: Source/itemdat.cpp:249
 msgid "White"
@@ -2630,11 +2630,11 @@ msgstr "鑽石"
 
 #: Source/itemdat.cpp:254
 msgid "Topaz"
-msgstr "黃寶石"
+msgstr "黃​寶石"
 
 #: Source/itemdat.cpp:255
 msgid "Amber"
-msgstr "琥珀"
+msgstr "琥​珀"
 
 #: Source/itemdat.cpp:256
 msgid "Jade"
@@ -2642,88 +2642,88 @@ msgstr "碧玉"
 
 #: Source/itemdat.cpp:257
 msgid "Obsidian"
-msgstr "黑曜石"
+msgstr "黑​曜石"
 
 #: Source/itemdat.cpp:258
 msgid "Emerald"
-msgstr "綠寶石"
+msgstr "綠​寶石"
 
 #: Source/itemdat.cpp:259
 msgid "Hyena's"
-msgstr "土狼"
+msgstr "土​狼"
 
 #: Source/itemdat.cpp:260
 msgid "Frog's"
-msgstr "青蛙的"
+msgstr "青蛙​的"
 
 #: Source/itemdat.cpp:261
 msgid "Spider's"
-msgstr "蜘蛛的"
+msgstr "蜘蛛​的"
 
 #: Source/itemdat.cpp:262
 msgid "Raven's"
-msgstr "烏鴉的"
+msgstr "烏鴉​的"
 
 #: Source/itemdat.cpp:263
 msgid "Snake's"
-msgstr "毒蛇的"
+msgstr "毒​蛇​的"
 
 #: Source/itemdat.cpp:264
 msgid "Serpent's"
-msgstr "巨蛇的"
+msgstr "巨蛇​的"
 
 #: Source/itemdat.cpp:265
 msgid "Drake's"
-msgstr "幼龍的"
+msgstr "幼龍​的"
 
 #: Source/itemdat.cpp:266
 msgid "Dragon's"
-msgstr "翼龍的"
+msgstr "翼龍​的"
 
 #: Source/itemdat.cpp:267
 msgid "Wyrm's"
-msgstr "游龍的"
+msgstr "游龍​的"
 
 #: Source/itemdat.cpp:268
 msgid "Hydra's"
-msgstr "海德拉的"
+msgstr "海德拉​的"
 
 #: Source/itemdat.cpp:269
 msgid "Angel's"
-msgstr "天使的"
+msgstr "天使​的"
 
 #: Source/itemdat.cpp:270
 msgid "Arch-Angel's"
-msgstr "大天使的"
+msgstr "大​天使​的"
 
 #: Source/itemdat.cpp:271
 msgid "Plentiful"
-msgstr "豐富"
+msgstr "豐​富"
 
 #: Source/itemdat.cpp:272
 msgid "Bountiful"
-msgstr "慷慨的"
+msgstr "慷慨​的"
 
 #: Source/itemdat.cpp:273
 msgid "Flaming"
-msgstr "烈焰"
+msgstr "烈​焰"
 
 #: Source/itemdat.cpp:274
 msgid "Lightning"
-msgstr "閃電術"
+msgstr "閃​電術"
 
 #: Source/itemdat.cpp:275
 msgid "Jester's"
-msgstr "弄臣的"
+msgstr "弄臣​的"
 
 #: Source/itemdat.cpp:276
 msgid "Crystalline"
-msgstr "結晶的"
+msgstr "結晶​的"
 
 #. TRANSLATORS: Item prefix section end.
 #: Source/itemdat.cpp:278
 msgid "Doppelganger's"
-msgstr "雙通道"
+msgstr "雙​通道"
 
 #. TRANSLATORS: Item suffix section. All items will have a word binding word. (Format: {:s} of {:s} - e.g. Rags of Valor)
 #: Source/itemdat.cpp:288
@@ -2732,11 +2732,11 @@ msgstr "質量"
 
 #: Source/itemdat.cpp:289
 msgid "maiming"
-msgstr "殘廢"
+msgstr "殘​廢"
 
 #: Source/itemdat.cpp:290
 msgid "slaying"
-msgstr "殺戮"
+msgstr "殺​戮"
 
 #: Source/itemdat.cpp:291
 msgid "gore"
@@ -2744,7 +2744,7 @@ msgstr "戈爾"
 
 #: Source/itemdat.cpp:292
 msgid "carnage"
-msgstr "大屠殺"
+msgstr "大​屠​殺"
 
 #: Source/itemdat.cpp:293
 msgid "slaughter"
@@ -2756,7 +2756,7 @@ msgstr "疼痛"
 
 #: Source/itemdat.cpp:295
 msgid "tears"
-msgstr "眼淚"
+msgstr "眼​淚"
 
 #: Source/itemdat.cpp:296
 msgid "health"
@@ -2776,7 +2776,7 @@ msgstr "偏轉"
 
 #: Source/itemdat.cpp:300
 msgid "osmosis"
-msgstr "滲透作用"
+msgstr "滲​透​作用"
 
 #: Source/itemdat.cpp:301
 msgid "frailty"
@@ -2784,7 +2784,7 @@ msgstr "虛弱"
 
 #: Source/itemdat.cpp:302
 msgid "weakness"
-msgstr "弱點"
+msgstr "弱​點"
 
 #: Source/itemdat.cpp:303
 msgid "strength"
@@ -2816,7 +2816,7 @@ msgstr "萎縮"
 
 #: Source/itemdat.cpp:310
 msgid "dexterity"
-msgstr "靈巧"
+msgstr "靈​巧"
 
 #: Source/itemdat.cpp:311
 msgid "skill"
@@ -2840,7 +2840,7 @@ msgstr "傻瓜"
 
 #: Source/itemdat.cpp:316
 msgid "dyslexia"
-msgstr "誦讀困難"
+msgstr "誦​讀困難"
 
 #: Source/itemdat.cpp:317
 msgid "magic"
@@ -2848,7 +2848,7 @@ msgstr "魔術"
 
 #: Source/itemdat.cpp:318
 msgid "the mind"
-msgstr "頭腦"
+msgstr "頭​腦"
 
 #: Source/itemdat.cpp:319
 msgid "brilliance"
@@ -2876,11 +2876,11 @@ msgstr "活力"
 
 #: Source/itemdat.cpp:325
 msgid "zest"
-msgstr "熱情"
+msgstr "熱​情"
 
 #: Source/itemdat.cpp:326
 msgid "vim"
-msgstr "維姆"
+msgstr "維​姆"
 
 #: Source/itemdat.cpp:327
 msgid "vigor"
@@ -2916,15 +2916,15 @@ msgstr "天堂"
 
 #: Source/itemdat.cpp:335
 msgid "the zodiac"
-msgstr "十二宮"
+msgstr "十二​宮"
 
 #: Source/itemdat.cpp:336
 msgid "the vulture"
-msgstr "禿鷲"
+msgstr "禿​鷲"
 
 #: Source/itemdat.cpp:337
 msgid "the jackal"
-msgstr "豺狼"
+msgstr "豺​狼"
 
 #: Source/itemdat.cpp:338
 msgid "the fox"
@@ -2936,7 +2936,7 @@ msgstr "捷豹"
 
 #: Source/itemdat.cpp:340
 msgid "the eagle"
-msgstr "老鷹"
+msgstr "老​鷹"
 
 #: Source/itemdat.cpp:341
 msgid "the wolf"
@@ -2952,11 +2952,11 @@ msgstr "獅子"
 
 #: Source/itemdat.cpp:344
 msgid "the mammoth"
-msgstr "猛犸象"
+msgstr "猛​犸​象"
 
 #: Source/itemdat.cpp:345
 msgid "the whale"
-msgstr "鯨魚"
+msgstr "鯨​魚"
 
 #: Source/itemdat.cpp:346
 msgid "fragility"
@@ -2968,7 +2968,7 @@ msgstr "脆性"
 
 #: Source/itemdat.cpp:348
 msgid "sturdiness"
-msgstr "堅固性"
+msgstr "堅​固性"
 
 #: Source/itemdat.cpp:349
 msgid "craftsmanship"
@@ -2976,7 +2976,7 @@ msgstr "工藝"
 
 #: Source/itemdat.cpp:350
 msgid "structure"
-msgstr "結構"
+msgstr "結​構"
 
 #: Source/itemdat.cpp:351
 msgid "the ages"
@@ -2996,7 +2996,7 @@ msgstr "光"
 
 #: Source/itemdat.cpp:355
 msgid "radiance"
-msgstr "光輝"
+msgstr "光​輝"
 
 #: Source/itemdat.cpp:356
 msgid "flame"
@@ -3016,15 +3016,15 @@ msgstr "震驚"
 
 #: Source/itemdat.cpp:360
 msgid "lightning"
-msgstr "閃電"
+msgstr "閃​電"
 
 #: Source/itemdat.cpp:361
 msgid "thunder"
-msgstr "打雷"
+msgstr "打​雷"
 
 #: Source/itemdat.cpp:362
 msgid "many"
-msgstr "許多的"
+msgstr "許​多​的"
 
 #: Source/itemdat.cpp:363
 msgid "plenty"
@@ -3032,7 +3032,7 @@ msgstr "大量"
 
 #: Source/itemdat.cpp:364
 msgid "thorns"
-msgstr "荊棘"
+msgstr "荊​棘"
 
 #: Source/itemdat.cpp:365
 msgid "corruption"
@@ -3048,11 +3048,11 @@ msgstr "熊"
 
 #: Source/itemdat.cpp:368
 msgid "the bat"
-msgstr "蝙蝠"
+msgstr "蝙​蝠"
 
 #: Source/itemdat.cpp:369
 msgid "vampires"
-msgstr "吸血鬼"
+msgstr "吸血​鬼"
 
 #: Source/itemdat.cpp:370
 msgid "the leech"
@@ -3064,11 +3064,11 @@ msgstr "血"
 
 #: Source/itemdat.cpp:372
 msgid "piercing"
-msgstr "刺骨的"
+msgstr "刺骨​的"
 
 #: Source/itemdat.cpp:373
 msgid "puncturing"
-msgstr "穿刺"
+msgstr "穿​刺"
 
 #: Source/itemdat.cpp:374
 msgid "bashing"
@@ -3076,7 +3076,7 @@ msgstr "猛擊"
 
 #: Source/itemdat.cpp:375
 msgid "readiness"
-msgstr "準備就緒"
+msgstr "準備​就​緒"
 
 #: Source/itemdat.cpp:376
 msgid "swiftness"
@@ -3100,15 +3100,15 @@ msgstr "穩定性"
 
 #: Source/itemdat.cpp:381
 msgid "harmony"
-msgstr "和諧"
+msgstr "和​諧"
 
 #: Source/itemdat.cpp:382
 msgid "blocking"
-msgstr "舞臺排程"
+msgstr "舞臺​排程"
 
 #: Source/itemdat.cpp:383
 msgid "devastation"
-msgstr "毀滅"
+msgstr "毀​滅"
 
 #: Source/itemdat.cpp:384
 msgid "decay"
@@ -3122,15 +3122,15 @@ msgstr "危險"
 #. TRANSLATORS: Unique Item section
 #: Source/itemdat.cpp:396
 msgid "The Butcher's Cleaver"
-msgstr "屠夫的切肉刀"
+msgstr "屠夫​的​切肉刀"
 
 #: Source/itemdat.cpp:406
 msgid "The Rift Bow"
-msgstr "裂谷弓"
+msgstr "裂谷​弓"
 
 #: Source/itemdat.cpp:407
 msgid "The Needler"
-msgstr "縫紉工"
+msgstr "縫​紉​工"
 
 #: Source/itemdat.cpp:408
 msgid "The Celestial Bow"
@@ -3138,35 +3138,35 @@ msgstr "天弓"
 
 #: Source/itemdat.cpp:409
 msgid "Deadly Hunter"
-msgstr "致命的獵人"
+msgstr "致命​的​獵人"
 
 #: Source/itemdat.cpp:410
 msgid "Bow of the Dead"
-msgstr "死者之弓"
+msgstr "死者​之​弓"
 
 #: Source/itemdat.cpp:411
 msgid "The Blackoak Bow"
-msgstr "黑橡樹蝴蝶結"
+msgstr "黑​橡樹​蝴蝶​結"
 
 #: Source/itemdat.cpp:412
 msgid "Flamedart"
-msgstr "火焰鏢"
+msgstr "火焰​鏢"
 
 #: Source/itemdat.cpp:413
 msgid "Fleshstinger"
-msgstr "肉刺"
+msgstr "肉​刺"
 
 #: Source/itemdat.cpp:414
 msgid "Windforce"
-msgstr "風之力"
+msgstr "風​之​力"
 
 #: Source/itemdat.cpp:415
 msgid "Eaglehorn"
-msgstr "鷹之號角"
+msgstr "鷹​之​號​角"
 
 #: Source/itemdat.cpp:416
 msgid "Gonnagal's Dirk"
-msgstr "貢納加爾的德克"
+msgstr "貢​納​加爾​的​德克"
 
 #: Source/itemdat.cpp:417
 msgid "The Defender"
@@ -3174,11 +3174,11 @@ msgstr "防守者"
 
 #: Source/itemdat.cpp:418
 msgid "Gryphon's Claw"
-msgstr "鷹頭獅爪"
+msgstr "鷹​頭​獅​爪"
 
 #: Source/itemdat.cpp:419
 msgid "Black Razor"
-msgstr "黑色剃刀"
+msgstr "黑色​剃刀"
 
 #: Source/itemdat.cpp:420
 msgid "Gibbous Moon"
@@ -3190,11 +3190,11 @@ msgstr "冰柄"
 
 #: Source/itemdat.cpp:422
 msgid "The Executioner's Blade"
-msgstr "劊子手之刃"
+msgstr "劊子​手​之​刃"
 
 #: Source/itemdat.cpp:423
 msgid "The Bonesaw"
-msgstr "骨頭鋸"
+msgstr "骨頭​鋸"
 
 #: Source/itemdat.cpp:424
 msgid "Shadowhawk"
@@ -3202,23 +3202,23 @@ msgstr "暗鷹"
 
 #: Source/itemdat.cpp:425
 msgid "Wizardspike"
-msgstr "巫師之刺"
+msgstr "巫師​之​刺"
 
 #: Source/itemdat.cpp:426
 msgid "Lightsabre"
-msgstr "光劍"
+msgstr "光​劍"
 
 #: Source/itemdat.cpp:427
 msgid "The Falcon's Talon"
-msgstr "獵鷹的爪子"
+msgstr "獵鷹​的​爪子"
 
 #: Source/itemdat.cpp:428
 msgid "Inferno"
-msgstr "地獄火"
+msgstr "地​獄火"
 
 #: Source/itemdat.cpp:429
 msgid "Doombringer"
-msgstr "末日使者"
+msgstr "末​日​使者"
 
 #: Source/itemdat.cpp:430
 msgid "The Grizzly"
@@ -3230,7 +3230,7 @@ msgstr "祖父"
 
 #: Source/itemdat.cpp:432
 msgid "The Mangler"
-msgstr "馬槽工"
+msgstr "馬​槽工"
 
 #: Source/itemdat.cpp:433
 msgid "Sharp Beak"
@@ -3238,7 +3238,7 @@ msgstr "銳利鳥嘴"
 
 #: Source/itemdat.cpp:434
 msgid "BloodSlayer"
-msgstr "吸血鬼"
+msgstr "吸血​鬼"
 
 #: Source/itemdat.cpp:435
 msgid "The Celestial Axe"
@@ -3246,7 +3246,7 @@ msgstr "天斧"
 
 #: Source/itemdat.cpp:436
 msgid "Wicked Axe"
-msgstr "邪惡的斧頭"
+msgstr "邪惡​的​斧頭"
 
 #: Source/itemdat.cpp:437
 msgid "Stonecleaver"
@@ -3258,11 +3258,11 @@ msgstr "阿吉納拉斧頭"
 
 #: Source/itemdat.cpp:439
 msgid "Hellslayer"
-msgstr "地獄屠戮者"
+msgstr "地​獄​屠戮者"
 
 #: Source/itemdat.cpp:440
 msgid "Messerschmidt's Reaver"
-msgstr "梅塞施密特的劫掠者"
+msgstr "梅​塞施密特​的​劫掠者"
 
 #: Source/itemdat.cpp:441
 msgid "Crackrust"
@@ -3270,39 +3270,39 @@ msgstr "裂紋"
 
 #: Source/itemdat.cpp:442
 msgid "Hammer of Jholm"
-msgstr "霍爾姆之錘"
+msgstr "霍爾姆​之錘"
 
 #: Source/itemdat.cpp:443
 msgid "Civerb's Cudgel"
-msgstr "希弗柏的短棍"
+msgstr "希弗柏​的​短棍"
 
 #: Source/itemdat.cpp:444
 msgid "The Celestial Star"
-msgstr "天上的星星"
+msgstr "天​上​的​星星"
 
 #: Source/itemdat.cpp:445
 msgid "Baranar's Star"
-msgstr "巴拉納之星"
+msgstr "巴拉納​之​星"
 
 #: Source/itemdat.cpp:446
 msgid "Gnarled Root"
-msgstr "多節根"
+msgstr "多​節根"
 
 #: Source/itemdat.cpp:447
 msgid "The Cranium Basher"
-msgstr "碎顱"
+msgstr "碎​顱"
 
 #: Source/itemdat.cpp:448
 msgid "Schaefer's Hammer"
-msgstr "舍費爾之錘"
+msgstr "舍​費爾​之​錘"
 
 #: Source/itemdat.cpp:449
 msgid "Dreamflange"
-msgstr "夢幻法蘭"
+msgstr "夢​幻法蘭"
 
 #: Source/itemdat.cpp:450
 msgid "Staff of Shadows"
-msgstr "暗影之杖"
+msgstr "暗影​之​杖"
 
 #: Source/itemdat.cpp:451
 msgid "Immolator"
@@ -3310,7 +3310,7 @@ msgstr "固定器"
 
 #: Source/itemdat.cpp:452
 msgid "Storm Spire"
-msgstr "風暴尖塔"
+msgstr "風​暴尖​塔"
 
 #: Source/itemdat.cpp:453
 msgid "Gleamsong"
@@ -3318,7 +3318,7 @@ msgstr "格里姆松"
 
 #: Source/itemdat.cpp:454
 msgid "Thundercall"
-msgstr "雷鳴呼叫"
+msgstr "雷鳴​呼叫"
 
 #: Source/itemdat.cpp:455
 msgid "The Protector"
@@ -3326,19 +3326,19 @@ msgstr "保護者"
 
 #: Source/itemdat.cpp:456
 msgid "Naj's Puzzler"
-msgstr "諾吉的解密棒"
+msgstr "諾吉​的​解密棒"
 
 #: Source/itemdat.cpp:457
 msgid "Mindcry"
-msgstr "心聲"
+msgstr "心​聲"
 
 #: Source/itemdat.cpp:458
 msgid "Rod of Onan"
-msgstr "奧南之棒"
+msgstr "奧​南​之​棒"
 
 #: Source/itemdat.cpp:459
 msgid "Helm of Spirits"
-msgstr "精靈之舵"
+msgstr "精靈​之​舵"
 
 #: Source/itemdat.cpp:460
 msgid "Thinking Cap"
@@ -3350,7 +3350,7 @@ msgstr "霸王舵"
 
 #: Source/itemdat.cpp:462
 msgid "Fool's Crest"
-msgstr "傻瓜的徽章"
+msgstr "傻瓜​的​徽章"
 
 #: Source/itemdat.cpp:463
 msgid "Gotterdamerung"
@@ -3358,35 +3358,35 @@ msgstr "戈特達梅隆"
 
 #: Source/itemdat.cpp:464
 msgid "Royal Circlet"
-msgstr "皇家環"
+msgstr "皇家​環"
 
 #: Source/itemdat.cpp:465
 msgid "Torn Flesh of Souls"
-msgstr "撕裂的靈魂之肉"
+msgstr "撕裂​的​靈魂​之​肉"
 
 #: Source/itemdat.cpp:466
 msgid "The Gladiator's Bane"
-msgstr "角鬥士之禍"
+msgstr "角​鬥士​之​禍"
 
 #: Source/itemdat.cpp:467
 msgid "The Rainbow Cloak"
-msgstr "彩虹斗篷"
+msgstr "彩虹​斗篷"
 
 #: Source/itemdat.cpp:468
 msgid "Leather of Aut"
-msgstr "Aut皮革"
+msgstr "Aut​皮革"
 
 #: Source/itemdat.cpp:469
 msgid "Wisdom's Wrap"
-msgstr "智慧的包裹"
+msgstr "智慧​的​包裹"
 
 #: Source/itemdat.cpp:470
 msgid "Sparking Mail"
-msgstr "電光鎖甲"
+msgstr "電​光鎖​甲"
 
 #: Source/itemdat.cpp:471
 msgid "Scavenger Carapace"
-msgstr "食腐甲殼"
+msgstr "食​腐甲殼"
 
 #: Source/itemdat.cpp:472
 msgid "Nightscape"
@@ -3394,11 +3394,11 @@ msgstr "夜景"
 
 #: Source/itemdat.cpp:473
 msgid "Naj's Light Plate"
-msgstr "諾吉的輕鎧甲"
+msgstr "諾吉​的​輕鎧​甲"
 
 #: Source/itemdat.cpp:474
 msgid "Demonspike Coat"
-msgstr "魔鬼長矛大衣"
+msgstr "魔鬼​長矛​大衣"
 
 #: Source/itemdat.cpp:475
 msgid "The Deflector"
@@ -3406,23 +3406,23 @@ msgstr "偏轉器"
 
 #: Source/itemdat.cpp:476
 msgid "Split Skull Shield"
-msgstr "裂顱護盾"
+msgstr "裂顱​護盾"
 
 #: Source/itemdat.cpp:477
 msgid "Dragon's Breach"
-msgstr "龍穴"
+msgstr "龍​穴"
 
 #: Source/itemdat.cpp:478
 msgid "Blackoak Shield"
-msgstr "黑橡樹盾"
+msgstr "黑​橡樹盾"
 
 #: Source/itemdat.cpp:479
 msgid "Holy Defender"
-msgstr "神聖衛士"
+msgstr "神聖​衛士"
 
 #: Source/itemdat.cpp:480
 msgid "Stormshield"
-msgstr "暴風之盾"
+msgstr "暴風​之​盾"
 
 #: Source/itemdat.cpp:481
 msgid "Bramble"
@@ -3430,31 +3430,31 @@ msgstr "刺棘"
 
 #: Source/itemdat.cpp:482
 msgid "Ring of Regha"
-msgstr "雷加之戒"
+msgstr "雷加之​戒"
 
 #: Source/itemdat.cpp:483
 msgid "The Bleeder"
-msgstr "出血點"
+msgstr "出血​點"
 
 #: Source/itemdat.cpp:484
 msgid "Constricting Ring"
-msgstr "緊縮之戒"
+msgstr "緊縮​之​戒"
 
 #: Source/itemdat.cpp:485
 msgid "Ring of Engagement"
-msgstr "訂婚戒指"
+msgstr "訂​婚戒指"
 
 #: Source/itemdat.cpp:486
 msgid "Giant's Knuckle"
-msgstr "巨人的指節"
+msgstr "巨人​的​指節"
 
 #: Source/itemdat.cpp:487
 msgid "Mercurial Ring"
-msgstr "汞環"
+msgstr "汞​環"
 
 #: Source/itemdat.cpp:488
 msgid "Xorine's Ring"
-msgstr "克索林的戒指"
+msgstr "克索林​的​戒指"
 
 #: Source/itemdat.cpp:489
 msgid "Karik's Ring"
@@ -3462,11 +3462,11 @@ msgstr "卡里克戒指"
 
 #: Source/itemdat.cpp:490
 msgid "Ring of Magma"
-msgstr "巖漿環"
+msgstr "巖​漿環"
 
 #: Source/itemdat.cpp:491
 msgid "Ring of the Mystics"
-msgstr "神秘之戒"
+msgstr "神秘​之​戒"
 
 #: Source/itemdat.cpp:492
 msgid "Ring of Thunder"
@@ -3474,27 +3474,27 @@ msgstr "雷鳴"
 
 #: Source/itemdat.cpp:493
 msgid "Amulet of Warding"
-msgstr "閃避護符"
+msgstr "閃​避護符"
 
 #: Source/itemdat.cpp:494
 msgid "Gnat Sting"
-msgstr "蚊蟲叮咬"
+msgstr "蚊蟲​叮咬"
 
 #: Source/itemdat.cpp:495
 msgid "Flambeau"
-msgstr "弗拉姆博"
+msgstr "弗拉姆​博"
 
 #: Source/itemdat.cpp:496
 msgid "Armor of Gloom"
-msgstr "陰沉的護甲"
+msgstr "陰沉​的​護甲"
 
 #: Source/itemdat.cpp:497
 msgid "Blitzen"
-msgstr "閃電"
+msgstr "閃​電"
 
 #: Source/itemdat.cpp:498
 msgid "Thunderclap"
-msgstr "霹靂"
+msgstr "霹​靂"
 
 #: Source/itemdat.cpp:499
 msgid "Shirotachi"
@@ -3502,56 +3502,56 @@ msgstr "白池"
 
 #: Source/itemdat.cpp:500
 msgid "Eater of Souls"
-msgstr "靈魂吞噬者"
+msgstr "靈魂​吞噬者"
 
 #: Source/itemdat.cpp:501
 msgid "Diamondedge"
-msgstr "鑽石邊"
+msgstr "鑽​石邊"
 
 #: Source/itemdat.cpp:502
 msgid "Bone Chain Armor"
-msgstr "骨鍊甲"
+msgstr "骨鍊​甲"
 
 #: Source/itemdat.cpp:503
 msgid "Demon Plate Armor"
-msgstr "惡魔板甲"
+msgstr "惡​魔板​甲"
 
 #: Source/itemdat.cpp:504
 msgid "Acolyte's Amulet"
-msgstr "侍從護符"
+msgstr "侍從​護​符"
 
 #. TRANSLATORS: Unique Item section end.
 #: Source/itemdat.cpp:506
 msgid "Gladiator's Ring"
-msgstr "角鬥士戒指"
+msgstr "角​鬥士​戒指"
 
 #: Source/items.cpp:160
 msgid "Oil of Mastery"
-msgstr "大師之油"
+msgstr "大​師​之​油"
 
 #: Source/items.cpp:162
 msgid "Oil of Death"
-msgstr "死亡之油"
+msgstr "死亡​之​油"
 
 #: Source/items.cpp:163
 msgid "Oil of Skill"
-msgstr "技能之油"
+msgstr "技能​之​油"
 
 #: Source/items.cpp:165
 msgid "Oil of Fortitude"
-msgstr "堅韌之油"
+msgstr "堅​韌​之​油"
 
 #: Source/items.cpp:166
 msgid "Oil of Permanence"
-msgstr "永恒之油"
+msgstr "永恒​之​油"
 
 #: Source/items.cpp:167
 msgid "Oil of Hardening"
-msgstr "硬化之油"
+msgstr "硬化​之​油"
 
 #: Source/items.cpp:168
 msgid "Oil of Imperviousness"
-msgstr "防水之油"
+msgstr "防水​之​油"
 
 #. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
 #. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
@@ -3573,273 +3573,273 @@ msgstr "{:s} / {:s}"
 
 #: Source/items.cpp:1902 Source/items.cpp:1914
 msgid "increases a weapon's"
-msgstr "增加武器的"
+msgstr "增加​武器​的"
 
 #: Source/items.cpp:1904
 msgid "chance to hit"
-msgstr "擊中的機會"
+msgstr "擊​中​的​機會"
 
 #: Source/items.cpp:1908
 msgid "greatly increases a"
-msgstr "大大增加"
+msgstr "大大​增加"
 
 #: Source/items.cpp:1910
 msgid "weapon's chance to hit"
-msgstr "武器擊中的機會"
+msgstr "武器​擊​中​的​機會"
 
 #: Source/items.cpp:1916
 msgid "damage potential"
-msgstr "潛在傷害"
+msgstr "潛​在​傷害"
 
 #: Source/items.cpp:1920
 msgid "greatly increases a weapon's"
-msgstr "大大提高武器的"
+msgstr "大大​提高​武器​的"
 
 #: Source/items.cpp:1922
 msgid "damage potential - not bows"
-msgstr "潛在傷害-不是弓箭"
+msgstr "潛​在​傷害​-​不​是​弓箭"
 
 #: Source/items.cpp:1926
 msgid "reduces attributes needed"
-msgstr "減少所需屬性"
+msgstr "減​少​所​需​屬性"
 
 #: Source/items.cpp:1928
 msgid "to use armor or weapons"
-msgstr "使用護甲或武器"
+msgstr "使用​護甲​或​武器"
 
 #: Source/items.cpp:1932
 #, no-c-format
 msgid "restores 20% of an"
-msgstr "恢復20%的"
+msgstr "恢復​20​%​的"
 
 #: Source/items.cpp:1934
 msgid "item's durability"
-msgstr "物品耐久度"
+msgstr "物品​耐久度"
 
 #: Source/items.cpp:1938
 msgid "increases an item's"
-msgstr "增加物品的"
+msgstr "增加​物品​的"
 
 #: Source/items.cpp:1940
 msgid "current and max durability"
-msgstr "目前和最大耐久度"
+msgstr "目前​和​最​大​耐久度"
 
 #: Source/items.cpp:1944
 msgid "makes an item indestructible"
-msgstr "使物品堅不可摧"
+msgstr "使​物品​堅​不​可​摧"
 
 #: Source/items.cpp:1948
 msgid "increases the armor class"
-msgstr "增加護甲等級"
+msgstr "增加​護甲​等​級"
 
 #: Source/items.cpp:1950
 msgid "of armor and shields"
-msgstr "護甲和盾牌"
+msgstr "護甲​和​盾牌"
 
 #: Source/items.cpp:1954
 msgid "greatly increases the armor"
-msgstr "極大地增加護甲"
+msgstr "極​大地​增加​護甲"
 
 #: Source/items.cpp:1956
 msgid "class of armor and shields"
-msgstr "護甲和盾牌等級"
+msgstr "護甲​和​盾牌​等​級"
 
 #: Source/items.cpp:1960 Source/items.cpp:1969
 msgid "sets fire trap"
-msgstr "設定火焰陷阱"
+msgstr "設​定​火焰​陷阱"
 
 #: Source/items.cpp:1965
 msgid "sets lightning trap"
-msgstr "設定閃電陷阱"
+msgstr "設​定閃電​陷阱"
 
 #: Source/items.cpp:1973
 msgid "sets petrification trap"
-msgstr "設定石化陷阱"
+msgstr "設​定​石化​陷阱"
 
 #: Source/items.cpp:1977
 #, fuzzy
 #| msgid "recover partial life"
 msgid "restore all life"
-msgstr "恢復生命值"
+msgstr "恢復​生命​值"
 
 #: Source/items.cpp:1981
 #, fuzzy
 #| msgid "recover life"
 msgid "restore some life"
-msgstr "恢復生命值"
+msgstr "恢復​生命​值"
 
 #: Source/items.cpp:1985
 msgid "recover life"
-msgstr "恢復生命值"
+msgstr "恢復​生命​值"
 
 #: Source/items.cpp:1989
 msgid "deadly heal"
-msgstr "致命的治療"
+msgstr "致命​的​治療"
 
 #: Source/items.cpp:1993
 #, fuzzy
 #| msgid "restores 20% of an"
 msgid "restore some mana"
-msgstr "魔力藥水"
+msgstr "魔力​藥​水"
 
 #: Source/items.cpp:1997
 #, fuzzy
 #| msgid "user loses all mana"
 msgid "restore all mana"
-msgstr "使用者失去所有法力值"
+msgstr "使用者​失去​所有​法力值"
 
 #: Source/items.cpp:2001
 msgid "increase strength"
-msgstr "增強力量"
+msgstr "增強​力量"
 
 #: Source/items.cpp:2005
 msgid "increase magic"
-msgstr "增加魔法"
+msgstr "增加​魔法"
 
 #: Source/items.cpp:2009
 msgid "increase dexterity"
-msgstr "增加敏捷"
+msgstr "增加​敏捷"
 
 #: Source/items.cpp:2013
 msgid "increase vitality"
-msgstr "增加活力"
+msgstr "增加​活力"
 
 #: Source/items.cpp:2018
 msgid "decrease strength"
-msgstr "降低力量"
+msgstr "降低​力量"
 
 #: Source/items.cpp:2022
 msgid "decrease dexterity"
-msgstr "降低敏捷"
+msgstr "降低​敏捷"
 
 #: Source/items.cpp:2026
 msgid "decrease vitality"
-msgstr "降低活力"
+msgstr "降低​活力"
 
 #: Source/items.cpp:2030
 #, fuzzy
 #| msgid "recover life and mana"
 msgid "restore some life and mana"
-msgstr "恢復生命值和法力值"
+msgstr "恢復​生命值​和​法力值"
 
 #: Source/items.cpp:2034
 #, fuzzy
 #| msgid "recover life and mana"
 msgid "restore all life and mana"
-msgstr "使用者失去所有法力值"
+msgstr "使用者​失去​所有​法力值"
 
 #: Source/items.cpp:2049 Source/items.cpp:2074
 msgid "Right-click to read"
-msgstr "右擊閱讀"
+msgstr "右​擊閱讀"
 
 #: Source/items.cpp:2053
 msgid "Right-click to read, then"
-msgstr "右擊閱讀，然後"
+msgstr "右​擊​閱讀​，​然​後"
 
 #: Source/items.cpp:2055
 msgid "left-click to target"
-msgstr "左擊目標"
+msgstr "左​擊目標"
 
 #: Source/items.cpp:2060
 msgid "Right-click to use"
-msgstr "右擊使用"
+msgstr "右​擊​使用"
 
 #: Source/items.cpp:2065 Source/items.cpp:2070
 msgid "Right click to use"
-msgstr "右擊使用"
+msgstr "右​擊​使用"
 
 #: Source/items.cpp:2078
 msgid "Right click to read"
-msgstr "右擊閱讀"
+msgstr "右​擊閱讀"
 
 #: Source/items.cpp:2082
 msgid "Right-click to view"
-msgstr "右擊檢視"
+msgstr "右​擊檢視"
 
 #: Source/items.cpp:2090
 msgid "Doubles gold capacity"
-msgstr "金幣容量翻倍"
+msgstr "金幣​容量​翻倍"
 
 #: Source/items.cpp:2102 Source/stores.cpp:212
 msgid "Required:"
-msgstr "需求: "
+msgstr "需求​: "
 
 #: Source/items.cpp:2104 Source/stores.cpp:214
 msgid " {:d} Str"
-msgstr "{:d}力量"
+msgstr "{:d}​力量"
 
 #: Source/items.cpp:2106 Source/stores.cpp:216
 msgid " {:d} Mag"
-msgstr "{:d}魔法"
+msgstr "{:d}​魔法"
 
 #: Source/items.cpp:2108 Source/stores.cpp:218
 msgid " {:d} Dex"
-msgstr "{:d}敏捷"
+msgstr "{:d}​敏捷"
 
 #. TRANSLATORS: {:s} will be a Character Name
 #: Source/items.cpp:3535 Source/player.cpp:3042
 msgid "Ear of {:s}"
-msgstr "{:s}的耳朵"
+msgstr "{:s}​的​耳朵"
 
 #: Source/items.cpp:3830
 msgid "chance to hit: {:+d}%"
-msgstr "命中機率: {:+d}%"
+msgstr "命​中​機率​:​ {:+d}%"
 
 #: Source/items.cpp:3834
 #, fuzzy, no-c-format
 #| msgid "{:+d}% damage"
 msgid "{:+d}% damage"
-msgstr "{:+d}敵人傷害"
+msgstr "{:+d}​敵人​傷害"
 
 #: Source/items.cpp:3838 Source/items.cpp:4094
 msgid "to hit: {:+d}%, {:+d}% damage"
-msgstr "命中: {:+d}%, {:+d}%傷害"
+msgstr "命​中​:​ {:+d}%​, {:+d}%​傷害"
 
 #: Source/items.cpp:3842
 #, fuzzy, no-c-format
 #| msgid "{:+d}% armor"
 msgid "{:+d}% armor"
-msgstr "護甲: {:d}"
+msgstr "護​甲​:​ {:d}"
 
 #: Source/items.cpp:3846
 msgid "armor class: {:d}"
-msgstr "護甲等級: {:d}"
+msgstr "護​甲​等​級​:​ {:d}"
 
 #: Source/items.cpp:3851 Source/items.cpp:4076
 msgid "Resist Fire: {:+d}%"
-msgstr "火焰抗性: {:+d}%"
+msgstr "火焰​抗性​:​ {:+d}%"
 
 #: Source/items.cpp:3853
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
-msgstr "火焰抗性: 最大75%"
+msgstr "火焰​抗性​: 最​大​75%"
 
 #: Source/items.cpp:3858
 msgid "Resist Lightning: {:+d}%"
-msgstr "閃電抗性: {:+d}%"
+msgstr "閃​電​抗性​:​ {:+d}%"
 
 #: Source/items.cpp:3860
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
-msgstr "閃電抗性: 最大75%"
+msgstr "閃​電​抗性​: 最​大​75%"
 
 #: Source/items.cpp:3865
 msgid "Resist Magic: {:+d}%"
-msgstr "抵抗魔法: {:+d}%"
+msgstr "抵抗​魔法​:​ {:+d}%"
 
 #: Source/items.cpp:3867
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
-msgstr "抵抗魔法: 最大75%"
+msgstr "抵抗​魔法​: 最​大​75%"
 
 #: Source/items.cpp:3872
 msgid "Resist All: {:+d}%"
-msgstr "所有抗性: {:+d}%"
+msgstr "所有​抗性​:​ {:+d}%"
 
 #: Source/items.cpp:3874
 #, no-c-format
 msgid "Resist All: 75% MAX"
-msgstr "所有抗性: 最大75%"
+msgstr "所有​抗性​: 最​大​75%"
 
 #: Source/items.cpp:3878
 #, fuzzy
@@ -3857,11 +3857,11 @@ msgstr[0] "層數: {:d}巢穴"
 
 #: Source/items.cpp:3882
 msgid "spell levels unchanged (?)"
-msgstr "法術等級不變（？）"
+msgstr "法術​等​級​不​變​（​？​）"
 
 #: Source/items.cpp:3885
 msgid "Extra charges"
-msgstr "額外充能"
+msgstr "額​外​充能"
 
 #: Source/items.cpp:3888
 #, fuzzy
@@ -3872,192 +3872,192 @@ msgstr[0] "{:s}，層數: {:d}"
 
 #: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}"
-msgstr "火焰傷害: {:d}"
+msgstr "火焰​傷害​:​ {:d}"
 
 #: Source/items.cpp:3894
 msgid "Fire hit damage: {:d}-{:d}"
-msgstr "火焰傷害: {:d}-{:d}"
+msgstr "火焰​傷害​:​ {:d}-{:d}"
 
 #: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}"
-msgstr "閃電傷害: {:d}"
+msgstr "閃電​傷害​:​ {:d}"
 
 #: Source/items.cpp:3900
 msgid "Lightning hit damage: {:d}-{:d}"
-msgstr "閃電傷害: {:d}-{:d}"
+msgstr "閃電​傷害​:​ {:d}-{:d}"
 
 #: Source/items.cpp:3904
 msgid "{:+d} to strength"
-msgstr "{:+d}力量"
+msgstr "{:+d}​力量"
 
 #: Source/items.cpp:3908
 msgid "{:+d} to magic"
-msgstr "{:+d}魔法"
+msgstr "{:+d}​魔法"
 
 #: Source/items.cpp:3912
 msgid "{:+d} to dexterity"
-msgstr "{:+d}敏捷"
+msgstr "{:+d}​敏捷"
 
 #: Source/items.cpp:3916
 msgid "{:+d} to vitality"
-msgstr "{:+d}活力"
+msgstr "{:+d}​活力"
 
 #: Source/items.cpp:3920
 msgid "{:+d} to all attributes"
-msgstr "{:+d}到所有屬性"
+msgstr "{:+d}​到​所有​屬性"
 
 #: Source/items.cpp:3924
 msgid "{:+d} damage from enemies"
-msgstr "{:+d}敵人傷害"
+msgstr "{:+d}​敵人​傷害"
 
 #: Source/items.cpp:3928
 msgid "Hit Points: {:+d}"
-msgstr "生命值: {:+d}"
+msgstr "生命​值​:​ {:+d}"
 
 #: Source/items.cpp:3932
 msgid "Mana: {:+d}"
-msgstr "法力值: {:+d}"
+msgstr "法力值​:​ {:+d}"
 
 #: Source/items.cpp:3935
 msgid "high durability"
-msgstr "高耐久度"
+msgstr "高​耐​久度"
 
 #: Source/items.cpp:3938
 msgid "decreased durability"
-msgstr "耐久度降低"
+msgstr "耐​久度​降低"
 
 #: Source/items.cpp:3941
 msgid "indestructible"
-msgstr "堅不可摧"
+msgstr "堅​不​可​摧"
 
 #: Source/items.cpp:3944
 #, fuzzy, no-c-format
 #| msgid "+{:d}%% light radius"
 msgid "+{:d}% light radius"
-msgstr "謎團在理性的光照下顯露出來"
+msgstr "謎團​在​理性​的​光照​下​顯​露出​來"
 
 #: Source/items.cpp:3947
 #, fuzzy, no-c-format
 #| msgid "-{:d}%% light radius"
 msgid "-{:d}% light radius"
-msgstr "謎團在理性的光照下顯露出來"
+msgstr "謎團​在​理性​的​光照​下​顯​露出​來"
 
 #: Source/items.cpp:3950
 msgid "multiple arrows per shot"
-msgstr "射出多重箭"
+msgstr "射​出​多​重箭"
 
 #: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}"
-msgstr "火箭傷害: {:d}"
+msgstr "火箭​傷害​:​ {:d}"
 
 #: Source/items.cpp:3956
 msgid "fire arrows damage: {:d}-{:d}"
-msgstr "火箭傷害: {:d}-{:d}"
+msgstr "火箭​傷害​:​ {:d}-{:d}"
 
 #: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}"
-msgstr "閃電箭傷害{:d}"
+msgstr "閃​電箭​傷害{:d}"
 
 #: Source/items.cpp:3962
 msgid "lightning arrows damage {:d}-{:d}"
-msgstr "閃電箭傷害{:d}-{:d}"
+msgstr "閃​電箭​傷害{:d}-{:d}"
 
 #: Source/items.cpp:3966
 msgid "fireball damage: {:d}"
-msgstr "火球傷害: {:d}"
+msgstr "火球​傷害​:​ {:d}"
 
 #: Source/items.cpp:3968
 msgid "fireball damage: {:d}-{:d}"
-msgstr "火球傷害: {:d}-{:d}"
+msgstr "火球​傷害​:​ {:d}-{:d}"
 
 #: Source/items.cpp:3971
 msgid "attacker takes 1-3 damage"
-msgstr "攻擊者受到1-3點傷害"
+msgstr "攻擊者​受到​1-3​點​傷害"
 
 #: Source/items.cpp:3974
 msgid "user loses all mana"
-msgstr "使用者失去所有法力值"
+msgstr "使用者​失去​所有​法力值"
 
 #: Source/items.cpp:3977
 msgid "you can't heal"
-msgstr "你無法治癒"
+msgstr "你​無​法治​癒"
 
 #: Source/items.cpp:3980
 msgid "absorbs half of trap damage"
-msgstr "吸收一半陷阱傷害"
+msgstr "吸收​一半​陷阱​傷害"
 
 #: Source/items.cpp:3983
 msgid "knocks target back"
-msgstr "擊退目標"
+msgstr "擊​退目標"
 
 #: Source/items.cpp:3986
 #, no-c-format
 msgid "+200% damage vs. demons"
-msgstr "+對惡魔造成200%傷害"
+msgstr "+​對​惡​魔​造成​200​%​傷害"
 
 #: Source/items.cpp:3989
 msgid "All Resistance equals 0"
-msgstr "所有抗性變為0"
+msgstr "所有​抗性​變​為​0"
 
 #: Source/items.cpp:3992
 msgid "hit monster doesn't heal"
-msgstr "命中怪物無法治癒"
+msgstr "命​中​怪物無​法治​癒"
 
 #: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 3% mana"
-msgstr "命中竊取3%法力值"
+msgstr "命​中​竊取​3%​法力值"
 
 #: Source/items.cpp:3998
 #, no-c-format
 msgid "hit steals 5% mana"
-msgstr "命中竊取5%法力值"
+msgstr "命​中​竊取​5%​法力值"
 
 #: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 3% life"
-msgstr "命中時竊取3%生命值"
+msgstr "命​中​時​竊​取​3%​生命​值"
 
 #: Source/items.cpp:4004
 #, no-c-format
 msgid "hit steals 5% life"
-msgstr "命中時竊取5%生命值"
+msgstr "命​中​時​竊​取​5​%​生命​值"
 
 #: Source/items.cpp:4007
 msgid "penetrates target's armor"
-msgstr "穿透目標的護甲"
+msgstr "穿透目標​的​護甲"
 
 #: Source/items.cpp:4011
 msgid "quick attack"
-msgstr "加速攻擊"
+msgstr "加速​攻擊"
 
 #: Source/items.cpp:4013
 msgid "fast attack"
-msgstr "快速攻擊"
+msgstr "快速​攻擊"
 
 #: Source/items.cpp:4015
 msgid "faster attack"
-msgstr "極速攻擊"
+msgstr "極​速攻擊"
 
 #: Source/items.cpp:4017
 msgid "fastest attack"
-msgstr "最快的攻擊"
+msgstr "最​快​的​攻擊"
 
 #: Source/items.cpp:4021
 msgid "fast hit recovery"
-msgstr "快速打擊回覆"
+msgstr "快速​打擊​回覆"
 
 #: Source/items.cpp:4023
 msgid "faster hit recovery"
-msgstr "更快打擊回覆"
+msgstr "更​快​打擊​回覆"
 
 #: Source/items.cpp:4025
 msgid "fastest hit recovery"
-msgstr "最快打擊回覆"
+msgstr "最​快​打擊​回覆"
 
 #: Source/items.cpp:4028
 msgid "fast block"
-msgstr "快速格擋"
+msgstr "快速​格擋"
 
 #: Source/items.cpp:4031
 #, fuzzy
@@ -4068,168 +4068,168 @@ msgstr[0] "傷害: {:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:4034
 msgid "fires random speed arrows"
-msgstr "發射隨機速度箭頭"
+msgstr "發​射隨機​速度​箭頭"
 
 #: Source/items.cpp:4037
 msgid "unusual item damage"
-msgstr "異常物品損壞"
+msgstr "異​常​物品​損壞"
 
 #: Source/items.cpp:4040
 msgid "altered durability"
-msgstr "改變耐久度"
+msgstr "改變​耐​久度"
 
 #: Source/items.cpp:4043
 msgid "Faster attack swing"
-msgstr "更快的揮動"
+msgstr "更​快​的​揮動"
 
 #: Source/items.cpp:4046
 msgid "one handed sword"
-msgstr "單手劍"
+msgstr "單​手劍"
 
 #: Source/items.cpp:4049
 msgid "constantly lose hit points"
-msgstr "不斷失去生命值"
+msgstr "不​斷​失去​生命值"
 
 #: Source/items.cpp:4052
 msgid "life stealing"
-msgstr "竊取生命"
+msgstr "竊取​生命"
 
 #: Source/items.cpp:4055
 msgid "no strength requirement"
-msgstr "無力量要求"
+msgstr "無​力量​要求"
 
 #: Source/items.cpp:4058
 msgid "see with infravision"
-msgstr "夜視能力"
+msgstr "夜視​能力"
 
 #: Source/items.cpp:4065
 msgid "lightning damage: {:d}"
-msgstr "閃電傷害: {:d}"
+msgstr "閃電​傷害​:​ {:d}"
 
 #: Source/items.cpp:4067
 msgid "lightning damage: {:d}-{:d}"
-msgstr "閃電傷害: {:d}-{:d}"
+msgstr "閃電​傷害​:​ {:d}-{:d}"
 
 #: Source/items.cpp:4070
 msgid "charged bolts on hits"
-msgstr "擊中時觸發電荷彈"
+msgstr "擊​中​時觸發​電​荷彈"
 
 #: Source/items.cpp:4079
 msgid "occasional triple damage"
-msgstr "有概率造成三倍傷害"
+msgstr "有​概率​造成​三​倍​傷害"
 
 #: Source/items.cpp:4082
 #, fuzzy, no-c-format
 #| msgid "decaying {:+d}% damage"
 msgid "decaying {:+d}% damage"
-msgstr "傷害: {:d} Dur: {:d}/{:d}"
+msgstr "傷害​:​ {:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:4085
 msgid "2x dmg to monst, 1x to you"
-msgstr "2x 對怪物傷害，1x 反噬自身"
+msgstr "2x ​對​怪物​傷害​，​1x ​反噬​自身"
 
 #: Source/items.cpp:4088
 #, no-c-format
 msgid "Random 0 - 500% damage"
-msgstr "隨機0-500%傷害"
+msgstr "隨​機​0-500​%​傷害"
 
 #: Source/items.cpp:4091
 #, fuzzy, no-c-format
 #| msgid "low dur, {:+d}% damage"
 msgid "low dur, {:+d}% damage"
-msgstr "傷害: {:d}-{:d} 耐久: {:d}/{:d}"
+msgstr "傷害​:​ {:d}-{:d} ​耐久​:​ {:d}/{:d}"
 
 #: Source/items.cpp:4097
 msgid "extra AC vs demons"
-msgstr "對抗惡魔的額外精準"
+msgstr "對​抗​惡魔​的​額外​精準"
 
 #: Source/items.cpp:4100
 msgid "extra AC vs undead"
-msgstr "對抗亡靈的額外精準"
+msgstr "對​抗亡靈​的​額外​精準"
 
 #: Source/items.cpp:4103
 #, no-c-format
 msgid "50% Mana moved to Health"
-msgstr "50%法力值轉換至生命值"
+msgstr "50​%​法力值轉換​至​生命​值"
 
 #: Source/items.cpp:4106
 #, no-c-format
 msgid "40% Health moved to Mana"
-msgstr "40%的生命值轉換至法力值"
+msgstr "40​%​的​生命值轉換​至​法力值"
 
 #: Source/items.cpp:4109
 msgid "Another ability (NW)"
-msgstr "另一種能力（NW）"
+msgstr "另​一​種​能力​（​NW​）"
 
 #: Source/items.cpp:4146 Source/items.cpp:4193
 msgid "damage: {:d}  Indestructible"
-msgstr "傷害: {:d} 堅不可摧"
+msgstr "傷害​:​ {:d} ​堅​不​可​摧"
 
 #. TRANSLATORS: Dur: is durability
 #: Source/items.cpp:4148 Source/items.cpp:4195
 msgid "damage: {:d}  Dur: {:d}/{:d}"
-msgstr "傷害: {:d} Dur: {:d}/{:d}"
+msgstr "傷害​:​ {:d} Dur: {:d}/{:d}"
 
 #: Source/items.cpp:4151 Source/items.cpp:4198
 msgid "damage: {:d}-{:d}  Indestructible"
-msgstr "傷害: {:d}-{:d} 堅不可摧"
+msgstr "傷害​:​ {:d}-{:d} ​堅​不​可​摧"
 
 #. TRANSLATORS: Dur: is durability
 #: Source/items.cpp:4153 Source/items.cpp:4200
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
-msgstr "傷害: {:d}-{:d} 耐久: {:d}/{:d}"
+msgstr "傷害​:​ {:d}-{:d} ​耐久​:​ {:d}/{:d}"
 
 #: Source/items.cpp:4159 Source/items.cpp:4212
 msgid "armor: {:d}  Indestructible"
-msgstr "護甲: {:d} 堅不可摧"
+msgstr "護​甲​:​ {:d} ​堅​不​可​摧"
 
 #. TRANSLATORS: Dur: is durability
 #: Source/items.cpp:4161 Source/items.cpp:4214
 msgid "armor: {:d}  Dur: {:d}/{:d}"
-msgstr "護甲: {:d} 耐久: {:d}/{:d}"
+msgstr "護​甲​:​ {:d} ​耐久​:​ {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
 #: Source/items.cpp:4166
 msgid "dam: {:d}  Dur: {:d}/{:d}"
-msgstr "傷害: {:d} 耐久: {:d}/{:d}"
+msgstr "傷害​:​ {:d} ​耐久​:​ {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
 #: Source/items.cpp:4168
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
-msgstr "傷害: {:d}-{:d} 耐久: {:d}/{:d}"
+msgstr "傷害​:​ {:d}-{:d} ​耐久​:​ {:d}/{:d}"
 
 #: Source/items.cpp:4169 Source/items.cpp:4204 Source/items.cpp:4219
 #: Source/stores.cpp:184
 msgid "Charges: {:d}/{:d}"
-msgstr "充能: {:d}/{:d}"
+msgstr "充能​:​ {:d}/{:d}"
 
 #: Source/items.cpp:4181
 msgid "unique item"
-msgstr "獨特裝備"
+msgstr "獨​特裝備"
 
 #: Source/items.cpp:4208 Source/items.cpp:4217 Source/items.cpp:4224
 msgid "Not Identified"
-msgstr "未鑑定"
+msgstr "未​鑑​定"
 
 #: Source/loadsave.cpp:1656 Source/loadsave.cpp:2122
 msgid "Unable to open save file archive"
-msgstr "無法打開儲存檔案存檔"
+msgstr "無​法​打開​儲​存檔​案​存檔"
 
 #: Source/loadsave.cpp:1659
 msgid "Invalid save file"
-msgstr "無效的儲存檔案"
+msgstr "無效​的​儲存​檔案"
 
 #: Source/loadsave.cpp:1688
 msgid "Player is on a Hellfire only level"
-msgstr "玩家處於地獄火特有地圖"
+msgstr "玩​家處於​地​獄火​特有​地​圖"
 
 #: Source/loadsave.cpp:1885
 msgid "Invalid game state"
-msgstr "無效的遊戲狀態"
+msgstr "無效​的​遊戲狀態"
 
 #: Source/menu.cpp:136
 msgid "Unable to display mainmenu"
-msgstr "無法顯示主菜單"
+msgstr "無​法​顯示主菜單"
 
 #. TRANSLATORS: Monster Block start
 #. MT_NZOMBIE
@@ -4238,49 +4238,49 @@ msgstr "無法顯示主菜單"
 #| msgid "Zombie"
 msgctxt "monster"
 msgid "Zombie"
-msgstr "殭屍"
+msgstr "殭​屍"
 
 #: Source/monstdat.cpp:21
 #, fuzzy
 #| msgid "Ghoul"
 msgctxt "monster"
 msgid "Ghoul"
-msgstr "食尸鬼"
+msgstr "食​尸鬼"
 
 #: Source/monstdat.cpp:22
 #, fuzzy
 #| msgid "Rotting Carcass"
 msgctxt "monster"
 msgid "Rotting Carcass"
-msgstr "腐爛的屍體"
+msgstr "腐爛​的​屍體"
 
 #: Source/monstdat.cpp:23
 #, fuzzy
 #| msgid "Black Death"
 msgctxt "monster"
 msgid "Black Death"
-msgstr "黑蘑菇"
+msgstr "黑​蘑菇"
 
 #: Source/monstdat.cpp:24 Source/monstdat.cpp:32
 #, fuzzy
 #| msgid "Fallen One"
 msgctxt "monster"
 msgid "Fallen One"
-msgstr "單手劍"
+msgstr "單​手劍"
 
 #: Source/monstdat.cpp:25 Source/monstdat.cpp:33
 #, fuzzy
 #| msgid "Carver"
 msgctxt "monster"
 msgid "Carver"
-msgstr "利刃魔"
+msgstr "利刃​魔"
 
 #: Source/monstdat.cpp:26 Source/monstdat.cpp:34
 #, fuzzy
 #| msgid "Devil Kin"
 msgctxt "monster"
 msgid "Devil Kin"
-msgstr "魔鬼親戚"
+msgstr "魔鬼​親戚"
 
 #: Source/monstdat.cpp:27 Source/monstdat.cpp:35
 #, fuzzy
@@ -4294,14 +4294,14 @@ msgstr "黑暗"
 #| msgid "Skeleton"
 msgctxt "monster"
 msgid "Skeleton"
-msgstr "骷髏王的巢穴"
+msgstr "骷​髏王​的​巢穴"
 
 #: Source/monstdat.cpp:29
 #, fuzzy
 #| msgid "Corpse Axe"
 msgctxt "monster"
 msgid "Corpse Axe"
-msgstr "小斧"
+msgstr "小​斧"
 
 #: Source/monstdat.cpp:30 Source/monstdat.cpp:42
 #, fuzzy
@@ -4316,22 +4316,22 @@ msgstr "燃燒"
 msgctxt "monster"
 msgid "Horror"
 msgstr ""
-"它不見了嗎？你把它送回了孕育它的陰間嗎？你什麼？哦，別告訴我你丟了！你知道，"
-"那些東西不便宜。你一定要找到它，然後把那恐懼的東西轟出去"
+"它​不​見​了​嗎​？​你​把​它​送回​了​孕育​它​的​陰間嗎​？​你​什麼​？​哦​，​別告訴​我​你​丟​了​！​你​"
+"知道​，​那些​東西不便宜​。​你​一定​要​找到​它​，​然​後​把​那​恐懼​的​東西轟​出去"
 
 #: Source/monstdat.cpp:36
 #, fuzzy
 #| msgid "Scavenger"
 msgctxt "monster"
 msgid "Scavenger"
-msgstr "食腐甲殼"
+msgstr "食​腐甲殼"
 
 #: Source/monstdat.cpp:37
 #, fuzzy
 #| msgid "Plague Eater"
 msgctxt "monster"
 msgid "Plague Eater"
-msgstr "靈魂吞噬者"
+msgstr "靈魂​吞噬者"
 
 #: Source/monstdat.cpp:38
 #, fuzzy
@@ -4345,7 +4345,7 @@ msgstr "影獸"
 #| msgid "Bone Gasher"
 msgctxt "monster"
 msgid "Bone Gasher"
-msgstr "骨鍊甲"
+msgstr "骨鍊​甲"
 
 #: Source/monstdat.cpp:41
 #, fuzzy
@@ -4359,21 +4359,21 @@ msgstr "短弓"
 #| msgid "Skeleton Captain"
 msgctxt "monster"
 msgid "Skeleton Captain"
-msgstr "十字架骷髏"
+msgstr "十字​架​骷髏"
 
 #: Source/monstdat.cpp:45
 #, fuzzy
 #| msgid "Corpse Captain"
 msgctxt "monster"
 msgid "Corpse Captain"
-msgstr "殭屍隊長"
+msgstr "殭​屍隊長"
 
 #: Source/monstdat.cpp:46
 #, fuzzy
 #| msgid "Burning Dead Captain"
 msgctxt "monster"
 msgid "Burning Dead Captain"
-msgstr "死者之弓"
+msgstr "死者​之​弓"
 
 #: Source/monstdat.cpp:47
 #, fuzzy
@@ -4387,12 +4387,12 @@ msgstr "恐懼隊長"
 #| msgid "Invisible Lord"
 msgctxt "monster"
 msgid "Invisible Lord"
-msgstr "勛爵的"
+msgstr "勛​爵​的"
 
 #: Source/monstdat.cpp:49
 msgctxt "monster"
 msgid "Hidden"
-msgstr "隱藏"
+msgstr "隱​藏"
 
 #: Source/monstdat.cpp:50
 #, fuzzy
@@ -4407,12 +4407,12 @@ msgstr "追蹤者"
 msgctxt "monster"
 msgid "Unseen"
 msgstr ""
-"你背誦了一首有趣的韻文，它的風格讓我想起了其他的作品。現在讓我想想-那是什"
-"么？\n"
+"你​背誦​了​一​首​有趣​的​韻文​，​它​的​風格讓​我​想起​了​其他​的​作品​。​現​在​讓​我​想想​-​那​是​"
+"什么​？​\n"
 " \n"
-"…黑暗籠罩著隱藏的世界。眼睛在看不見的地方閃閃發光，只有剃刀爪子的聲音在短暫地"
-"刮來刮去，折磨那些永遠失明的可憐的靈魂。為那些該死的人而設的監獄被命名為盲人"
-"的大廳"
+"​…​黑暗​籠罩​著​隱藏​的​世界​。​眼睛​在​看​不​見​的​地方​閃閃​發光​，​只有​剃刀​爪子​的​聲音​在​短暫"
+"​地​刮來​刮去​，​折磨​那些​永遠失明​的​可憐​的​靈魂​。​為​那些​該死​的​人​而​設​的​監獄​被​命名​為盲人"
+"​的​大廳"
 
 #: Source/monstdat.cpp:52
 #, fuzzy
@@ -4426,14 +4426,14 @@ msgstr "幻覺編織者"
 #| msgid "Satyr Lord"
 msgctxt "monster"
 msgid "Satyr Lord"
-msgstr "勛爵的"
+msgstr "勛​爵​的"
 
 #: Source/monstdat.cpp:54 Source/monstdat.cpp:62
 #, fuzzy
 #| msgid "Flesh Clan"
 msgctxt "monster"
 msgid "Flesh Clan"
-msgstr "撕裂的靈魂之肉"
+msgstr "撕裂​的​靈魂​之​肉"
 
 #: Source/monstdat.cpp:55 Source/monstdat.cpp:63
 #, fuzzy
@@ -4462,10 +4462,10 @@ msgstr "夜晚"
 msgctxt "monster"
 msgid "Fiend"
 msgstr ""
-"藉著光明，我知道這個邪惡的惡魔。當拉撒路率領的少數幾名衝鋒倖存者從大教堂爬出"
-"來時，許多人身上留下了他憤怒的傷疤。我不知道他以前是怎麼切開受害者的，但這不"
-"可能是這個世界的。它留下的傷口潰爛與疾病，甚至我發現他們幾乎不可能治療。如果"
-"你打算和這個惡魔戰鬥，要小心"
+"藉​著​光明​，​我​知道​這個​邪惡​的​惡魔​。​當拉撒路率領​的​少數​幾名衝鋒倖​存者​從大​教堂​爬出來時​，​許多"
+"​人​身​上​留下​了​他​憤怒​的​傷疤​。​我​不​知道​他​以前​是​怎麼​切開​受害者​的​，​但​這​不​可能​是​"
+"這個​世界​的​。​它​留下​的​傷口潰爛與​疾病​，​甚至​我​發現​他​們​幾乎​不​可能​治療​。​如果​你​打算​和​"
+"這個​惡​魔戰​鬥​，​要​小心"
 
 #: Source/monstdat.cpp:59
 #, fuzzy
@@ -4479,7 +4479,7 @@ msgstr "眨眼"
 #| msgid "Gloom"
 msgctxt "monster"
 msgid "Gloom"
-msgstr "陰沉的護甲"
+msgstr "陰沉​的​護甲"
 
 #: Source/monstdat.cpp:61
 #, fuzzy
@@ -4487,15 +4487,15 @@ msgstr "陰沉的護甲"
 msgctxt "monster"
 msgid "Familiar"
 msgstr ""
-"不知怎麼的，這似乎很熟悉。我似乎記得在研究惡魔痛苦的歷史時讀過類似這首詩的東"
-"西。它講述了一個邪惡的地方。。。等等-你不會去的，是嗎"
+"不​知​怎麼​的​，​這​似乎​很​熟悉​。​我​似乎​記​得​在​研究​惡魔​痛苦​的​歷史時讀過​類​似​這​首​詩​的​"
+"東西​。​它​講述​了​一​個​邪惡​的​地方​。​。​。​等等​-​你​不​會去​的​，​是​嗎"
 
 #: Source/monstdat.cpp:66
 #, fuzzy
 #| msgid "Acid Beast"
 msgctxt "monster"
 msgid "Acid Beast"
-msgstr "酸獸"
+msgstr "酸​獸"
 
 #: Source/monstdat.cpp:67
 #, fuzzy
@@ -4516,14 +4516,14 @@ msgstr "坑"
 #| msgid "Lava Maw"
 msgctxt "monster"
 msgid "Lava Maw"
-msgstr "熔巖肚"
+msgstr "熔​巖​肚"
 
 #: Source/monstdat.cpp:70 Source/monstdat.cpp:474
 #, fuzzy
 #| msgid "Skeleton King"
 msgctxt "monster"
 msgid "Skeleton King"
-msgstr "骷髏王的巢穴"
+msgstr "骷​髏王​的​巢穴"
 
 #: Source/monstdat.cpp:71 Source/monstdat.cpp:482
 msgctxt "monster"
@@ -4542,42 +4542,42 @@ msgstr "霸王舵"
 #| msgid "Mud Man"
 msgctxt "monster"
 msgid "Mud Man"
-msgstr "泥人"
+msgstr "泥​人"
 
 #: Source/monstdat.cpp:74
 #, fuzzy
 #| msgid "Toad Demon"
 msgctxt "monster"
 msgid "Toad Demon"
-msgstr "惡魔"
+msgstr "惡​魔"
 
 #: Source/monstdat.cpp:75
 #, fuzzy
 #| msgid "Flayed One"
 msgctxt "monster"
 msgid "Flayed One"
-msgstr "單手劍"
+msgstr "單​手劍"
 
 #: Source/monstdat.cpp:76
 #, fuzzy
 #| msgid "Wyrm"
 msgctxt "monster"
 msgid "Wyrm"
-msgstr "游龍的"
+msgstr "游龍​的"
 
 #: Source/monstdat.cpp:77
 #, fuzzy
 #| msgid "Cave Slug"
 msgctxt "monster"
 msgid "Cave Slug"
-msgstr "洞穴蛞蝓"
+msgstr "洞​穴蛞蝓"
 
 #: Source/monstdat.cpp:78
 #, fuzzy
 #| msgid "Devil Wyrm"
 msgctxt "monster"
 msgid "Devil Wyrm"
-msgstr "游龍的"
+msgstr "游龍​的"
 
 #: Source/monstdat.cpp:79
 #, fuzzy
@@ -4591,7 +4591,7 @@ msgstr "吞食蟲"
 #| msgid "Magma Demon"
 msgctxt "monster"
 msgid "Magma Demon"
-msgstr "巖漿環"
+msgstr "巖​漿環"
 
 #: Source/monstdat.cpp:81
 msgctxt "monster"
@@ -4603,49 +4603,49 @@ msgstr "血石"
 #| msgid "Hell Stone"
 msgctxt "monster"
 msgid "Hell Stone"
-msgstr "地獄"
+msgstr "地​獄"
 
 #: Source/monstdat.cpp:83
 #, fuzzy
 #| msgid "Lava Lord"
 msgctxt "monster"
 msgid "Lava Lord"
-msgstr "勛爵的"
+msgstr "勛​爵​的"
 
 #: Source/monstdat.cpp:84
 #, fuzzy
 #| msgid "Horned Demon"
 msgctxt "monster"
 msgid "Horned Demon"
-msgstr "惡魔"
+msgstr "惡​魔"
 
 #: Source/monstdat.cpp:85
 #, fuzzy
 #| msgid "Mud Runner"
 msgctxt "monster"
 msgid "Mud Runner"
-msgstr "泥漿泵"
+msgstr "泥​漿泵"
 
 #: Source/monstdat.cpp:86
 #, fuzzy
 #| msgid "Frost Charger"
 msgctxt "monster"
 msgid "Frost Charger"
-msgstr "霜凍加料機"
+msgstr "霜凍​加料​機"
 
 #: Source/monstdat.cpp:87
 #, fuzzy
 #| msgid "Obsidian Lord"
 msgctxt "monster"
 msgid "Obsidian Lord"
-msgstr "黑曜石"
+msgstr "黑​曜石"
 
 #: Source/monstdat.cpp:88
 #, fuzzy
 #| msgid "oldboned"
 msgctxt "monster"
 msgid "oldboned"
-msgstr "老骨頭"
+msgstr "老​骨頭"
 
 #: Source/monstdat.cpp:89
 #, fuzzy
@@ -4659,7 +4659,7 @@ msgstr "丹紅"
 #| msgid "Litch Demon"
 msgctxt "monster"
 msgid "Litch Demon"
-msgstr "惡魔"
+msgstr "惡​魔"
 
 #: Source/monstdat.cpp:91
 #, fuzzy
@@ -4673,7 +4673,7 @@ msgstr "亡靈"
 #| msgid "Incinerator"
 msgctxt "monster"
 msgid "Incinerator"
-msgstr "焚化爐"
+msgstr "焚化​爐"
 
 #: Source/monstdat.cpp:93
 #, fuzzy
@@ -4694,56 +4694,56 @@ msgstr "火"
 #| msgid "Hell Burner"
 msgctxt "monster"
 msgid "Hell Burner"
-msgstr "下到地獄"
+msgstr "下​到​地獄"
 
 #: Source/monstdat.cpp:96
 #, fuzzy
 #| msgid "Red Storm"
 msgctxt "monster"
 msgid "Red Storm"
-msgstr "風暴尖塔"
+msgstr "風​暴尖​塔"
 
 #: Source/monstdat.cpp:97
 #, fuzzy
 #| msgid "Storm Rider"
 msgctxt "monster"
 msgid "Storm Rider"
-msgstr "風暴尖塔"
+msgstr "風​暴尖​塔"
 
 #: Source/monstdat.cpp:98
 #, fuzzy
 #| msgid "Storm Lord"
 msgctxt "monster"
 msgid "Storm Lord"
-msgstr "風暴尖塔"
+msgstr "風​暴尖​塔"
 
 #: Source/monstdat.cpp:99
 #, fuzzy
 #| msgid "Maelstorm"
 msgctxt "monster"
 msgid "Maelstrom"
-msgstr "大漩渦"
+msgstr "大​漩​渦"
 
 #: Source/monstdat.cpp:100
 #, fuzzy
 #| msgid "Devil Kin Brute"
 msgctxt "monster"
 msgid "Devil Kin Brute"
-msgstr "惡魔族畜生"
+msgstr "惡​魔族​畜​生"
 
 #: Source/monstdat.cpp:101
 #, fuzzy
 #| msgid "Winged-Demon"
 msgctxt "monster"
 msgid "Winged-Demon"
-msgstr "惡魔"
+msgstr "惡​魔"
 
 #: Source/monstdat.cpp:102
 #, fuzzy
 #| msgid "Gargoyle"
 msgctxt "monster"
 msgid "Gargoyle"
-msgstr "滴水嘴"
+msgstr "滴​水嘴"
 
 #: Source/monstdat.cpp:103
 #, fuzzy
@@ -4757,49 +4757,49 @@ msgstr "血"
 #| msgid "Death Wing"
 msgctxt "monster"
 msgid "Death Wing"
-msgstr "死亡之油"
+msgstr "死亡​之​油"
 
 #: Source/monstdat.cpp:105
 #, fuzzy
 #| msgid "Slayer"
 msgctxt "monster"
 msgid "Slayer"
-msgstr "屠殺者"
+msgstr "屠​殺者"
 
 #: Source/monstdat.cpp:106
 #, fuzzy
 #| msgid "Guardian"
 msgctxt "monster"
 msgid "Guardian"
-msgstr "守護者卷軸"
+msgstr "守​護者​卷軸"
 
 #: Source/monstdat.cpp:107
 #, fuzzy
 #| msgid "Vortex Lord"
 msgctxt "monster"
 msgid "Vortex Lord"
-msgstr "勛爵的"
+msgstr "勛​爵​的"
 
 #: Source/monstdat.cpp:108
 #, fuzzy
 #| msgid "Balrog"
 msgctxt "monster"
 msgid "Balrog"
-msgstr "炎魔"
+msgstr "炎​魔"
 
 #: Source/monstdat.cpp:109
 #, fuzzy
 #| msgid "Cave Viper"
 msgctxt "monster"
 msgid "Cave Viper"
-msgstr "洞穴毒蛇"
+msgstr "洞​穴毒​蛇"
 
 #: Source/monstdat.cpp:110
 #, fuzzy
 #| msgid "Fire Drake"
 msgctxt "monster"
 msgid "Fire Drake"
-msgstr "幼龍的"
+msgstr "幼龍​的"
 
 #: Source/monstdat.cpp:111
 #, fuzzy
@@ -4820,42 +4820,42 @@ msgstr "碧空"
 #| msgid "Black Knight"
 msgctxt "monster"
 msgid "Black Knight"
-msgstr "騎士的"
+msgstr "騎士​的"
 
 #: Source/monstdat.cpp:114
 #, fuzzy
 #| msgid "Doom Guard"
 msgctxt "monster"
 msgid "Doom Guard"
-msgstr "毀滅守衛"
+msgstr "毀​滅守衛"
 
 #: Source/monstdat.cpp:115
 #, fuzzy
 #| msgid "Steel Lord"
 msgctxt "monster"
 msgid "Steel Lord"
-msgstr "勛爵的"
+msgstr "勛​爵​的"
 
 #: Source/monstdat.cpp:116
 #, fuzzy
 #| msgid "Blood Knight"
 msgctxt "monster"
 msgid "Blood Knight"
-msgstr "騎士的"
+msgstr "騎士​的"
 
 #: Source/monstdat.cpp:117
 #, fuzzy
 #| msgid "The Shredded"
 msgctxt "monster"
 msgid "The Shredded"
-msgstr "碎紙"
+msgstr "碎​紙"
 
 #: Source/monstdat.cpp:118
 #, fuzzy
 #| msgid "Hollow One"
 msgctxt "monster"
 msgid "Hollow One"
-msgstr "單手劍"
+msgstr "單​手劍"
 
 #: Source/monstdat.cpp:119
 #, fuzzy
@@ -4869,28 +4869,28 @@ msgstr "疼痛"
 #| msgid "Reality Weaver"
 msgctxt "monster"
 msgid "Reality Weaver"
-msgstr "現實編織者"
+msgstr "現​實編​織者"
 
 #: Source/monstdat.cpp:121
 #, fuzzy
 #| msgid "Succubus"
 msgctxt "monster"
 msgid "Succubus"
-msgstr "魅魔"
+msgstr "魅​魔"
 
 #: Source/monstdat.cpp:122
 #, fuzzy
 #| msgid "Snow Witch"
 msgctxt "monster"
 msgid "Snow Witch"
-msgstr "女巫小屋"
+msgstr "女​巫小屋"
 
 #: Source/monstdat.cpp:123
 #, fuzzy
 #| msgid "Hell Spawn"
 msgctxt "monster"
 msgid "Hell Spawn"
-msgstr "下到地獄"
+msgstr "下​到​地獄"
 
 #: Source/monstdat.cpp:124
 #, fuzzy
@@ -4904,21 +4904,21 @@ msgstr "燃魂"
 #| msgid "Counselor"
 msgctxt "monster"
 msgid "Counselor"
-msgstr "顧問"
+msgstr "顧​問"
 
 #: Source/monstdat.cpp:126
 #, fuzzy
 #| msgid "Magistrate"
 msgctxt "monster"
 msgid "Magistrate"
-msgstr "地方執法官"
+msgstr "地方​執​法官"
 
 #: Source/monstdat.cpp:127
 #, fuzzy
 #| msgid "Cabalist"
 msgctxt "monster"
 msgid "Cabalist"
-msgstr "陰謀家"
+msgstr "陰​謀家"
 
 #: Source/monstdat.cpp:128
 #, fuzzy
@@ -4932,7 +4932,7 @@ msgstr "提倡"
 #| msgid "Golem"
 msgctxt "monster"
 msgid "Golem"
-msgstr "傀儡卷軸"
+msgstr "傀儡​卷軸"
 
 #: Source/monstdat.cpp:130
 #, fuzzy
@@ -4940,40 +4940,40 @@ msgstr "傀儡卷軸"
 msgctxt "monster"
 msgid "The Dark Lord"
 msgstr ""
-"所以，地圖上的傳說是真實的。連我都不相信！我想是時候告訴你我是誰了，我的朋"
-"友。你看，我並不像我看起來那樣。。。\n"
+"所以​，​地圖​上​的​傳說​是​真實​的​。​連​我​都​不​相信​！​我​想​是​時候​告訴​你​我​是​誰​了​，​我​"
+"的​朋友​。​你​看​，​我​並​不​像​我​看​起來​那​樣​。​。​。​\n"
 " \n"
-"我的真名是老凱恩，我是一個古老兄弟會的最後一個後代，這個兄弟會致力於保守和保"
-"護一個永恒邪惡的秘密。一個很明顯已經被釋放的惡魔。。。\n"
+"​我​的​真名​是​老凱恩​，​我​是​一​個​古老​兄弟會​的​最後​一個​後​代​，​這個​兄弟​會​致力​於​保守​和​"
+"保護​一​個​永恒​邪惡​的​秘密​。​一​個​很​明顯​已​經​被​釋放​的​惡魔​。​。​。​\n"
 " \n"
-"你要對付的惡魔是恐怖的黑魔王——凡人都知道的迪亞波羅。幾個世紀前被囚禁在迷宮裡"
-"的正是他。你現在持有的地圖是很久以前創造的，用來標記迪亞波羅從監禁中復活的時"
-"間。當那張地圖上的兩顆星星對齊時，迪亞波羅將達到他的能量頂峰。他將所向無"
-"敵。。。\n"
+"​你​要​對付​的​惡魔​是​恐怖​的​黑魔王​——​凡​人​都​知道​的​迪亞波羅​。​幾個世紀​前​被​囚禁​在​迷宮裡​"
+"的​正​是​他​。​你​現​在​持有​的​地圖​是​很​久​以前​創造​的​，​用來標​記​迪亞波羅從​監​禁​中​復活​的​"
+"時間​。​當​那​張​地圖​上​的​兩顆​星星對​齊時​，​迪亞波羅將達​到​他​的​能量​頂峰​。​他​將​所​向​無敵​。"
+"​。​。​\n"
 " \n"
-"你現在在和時間賽跑，我的朋友！找到迪亞波羅，在眾星雲集之前消滅他，因為我們可"
-"能再也沒有機會擺脫他的邪惡了"
+"​你​現​在在​和​時間​賽​跑​，​我​的​朋友​！​找到​迪亞波羅​，​在​眾星​雲集​之前​消滅​他​，​因​為​我​們"
+"​可能​再​也​沒​有​機會擺脫​他​的​邪惡​了"
 
 #: Source/monstdat.cpp:131
 #, fuzzy
 #| msgid "The Arch-Litch Malignus"
 msgctxt "monster"
 msgid "The Arch-Litch Malignus"
-msgstr "大天使的"
+msgstr "大​天使​的"
 
 #: Source/monstdat.cpp:132
 #, fuzzy
 #| msgid "Hellboar"
 msgctxt "monster"
 msgid "Hellboar"
-msgstr "地獄豬"
+msgstr "地​獄豬"
 
 #: Source/monstdat.cpp:133
 #, fuzzy
 #| msgid "Stinger"
 msgctxt "monster"
 msgid "Stinger"
-msgstr "釘刺者"
+msgstr "釘​刺者"
 
 #: Source/monstdat.cpp:134
 #, fuzzy
@@ -4987,21 +4987,21 @@ msgstr "精神病"
 #| msgid "Arachnon"
 msgctxt "monster"
 msgid "Arachnon"
-msgstr "蛛網膜"
+msgstr "蛛​網膜"
 
 #: Source/monstdat.cpp:136
 #, fuzzy
 #| msgid "Felltwin"
 msgctxt "monster"
 msgid "Felltwin"
-msgstr "孿生兄弟"
+msgstr "孿生​兄弟"
 
 #: Source/monstdat.cpp:137
 #, fuzzy
 #| msgid "Hork Spawn"
 msgctxt "monster"
 msgid "Hork Spawn"
-msgstr "霍克產卵"
+msgstr "霍克產​卵"
 
 #: Source/monstdat.cpp:138
 #, fuzzy
@@ -5015,14 +5015,14 @@ msgstr "毒尾"
 #| msgid "Necromorb"
 msgctxt "monster"
 msgid "Necromorb"
-msgstr "死屍"
+msgstr "死​屍"
 
 #: Source/monstdat.cpp:140
 #, fuzzy
 #| msgid "Spider Lord"
 msgctxt "monster"
 msgid "Spider Lord"
-msgstr "蜘蛛的"
+msgstr "蜘蛛​的"
 
 #: Source/monstdat.cpp:141
 #, fuzzy
@@ -5043,42 +5043,42 @@ msgstr "托爾昌特"
 #| msgid "Hork Demon"
 msgctxt "monster"
 msgid "Hork Demon"
-msgstr "惡魔"
+msgstr "惡​魔"
 
 #: Source/monstdat.cpp:144
 #, fuzzy
 #| msgid "Hell Bug"
 msgctxt "monster"
 msgid "Hell Bug"
-msgstr "地獄"
+msgstr "地​獄"
 
 #: Source/monstdat.cpp:145
 #, fuzzy
 #| msgid "Gravedigger"
 msgctxt "monster"
 msgid "Gravedigger"
-msgstr "掘墓人"
+msgstr "掘​墓​人"
 
 #: Source/monstdat.cpp:146
 #, fuzzy
 #| msgid "Tomb Rat"
 msgctxt "monster"
 msgid "Tomb Rat"
-msgstr "利奧里克國王墓"
+msgstr "利奧里克國王​墓"
 
 #: Source/monstdat.cpp:147
 #, fuzzy
 #| msgid "Firebat"
 msgctxt "monster"
 msgid "Firebat"
-msgstr "火焰兵"
+msgstr "火焰​兵"
 
 #: Source/monstdat.cpp:148
 #, fuzzy
 #| msgid "Skullwing"
 msgctxt "monster"
 msgid "Skullwing"
-msgstr "骷髏"
+msgstr "骷​髏"
 
 #: Source/monstdat.cpp:149
 #, fuzzy
@@ -5092,14 +5092,14 @@ msgstr "巫妖"
 #| msgid "Crypt Demon"
 msgctxt "monster"
 msgid "Crypt Demon"
-msgstr "去地下室"
+msgstr "去​地下室"
 
 #: Source/monstdat.cpp:151
 #, fuzzy
 #| msgid "Hellbat"
 msgctxt "monster"
 msgid "Hellbat"
-msgstr "藍蝙蝠"
+msgstr "藍​蝙蝠"
 
 #: Source/monstdat.cpp:152
 #, fuzzy
@@ -5113,7 +5113,7 @@ msgstr "骨腔"
 #| msgid "Arch Lich"
 msgctxt "monster"
 msgid "Arch Lich"
-msgstr "大天使的"
+msgstr "大​天使​的"
 
 #: Source/monstdat.cpp:154
 #, fuzzy
@@ -5127,7 +5127,7 @@ msgstr "雙色"
 #| msgid "Flesh Thing"
 msgctxt "monster"
 msgid "Flesh Thing"
-msgstr "撕裂的靈魂之肉"
+msgstr "撕裂​的​靈魂​之​肉"
 
 #: Source/monstdat.cpp:156
 #, fuzzy
@@ -5147,21 +5147,21 @@ msgstr "加巴德弱者"
 #: Source/monstdat.cpp:475
 msgctxt "monster"
 msgid "Zhar the Mad"
-msgstr "瘋狂的扎爾"
+msgstr "瘋狂​的​扎爾"
 
 #: Source/monstdat.cpp:476
 #, fuzzy
 #| msgid "Snotspill"
 msgctxt "monster"
 msgid "Snotspill"
-msgstr "鼻涕丸"
+msgstr "鼻涕​丸"
 
 #: Source/monstdat.cpp:477
 #, fuzzy
 #| msgid "Arch-Bishop Lazarus"
 msgctxt "monster"
 msgid "Arch-Bishop Lazarus"
-msgstr "大天使的"
+msgstr "大​天使​的"
 
 #: Source/monstdat.cpp:478
 #, fuzzy
@@ -5180,7 +5180,7 @@ msgstr "碧玉"
 #: Source/monstdat.cpp:481
 msgctxt "monster"
 msgid "Warlord of Blood"
-msgstr "鮮血督軍"
+msgstr "鮮​血督軍"
 
 #: Source/monstdat.cpp:484
 msgctxt "monster"
@@ -5192,63 +5192,63 @@ msgstr "污染者"
 #| msgid "Bonehead Keenaxe"
 msgctxt "monster"
 msgid "Bonehead Keenaxe"
-msgstr "骷髏頭"
+msgstr "骷​髏頭"
 
 #: Source/monstdat.cpp:487
 #, fuzzy
 #| msgid "Bladeskin the Slasher"
 msgctxt "monster"
 msgid "Bladeskin the Slasher"
-msgstr "刀砍機中的刀鋒"
+msgstr "刀​砍​機​中​的​刀鋒"
 
 #: Source/monstdat.cpp:488
 #, fuzzy
 #| msgid "Soulpus"
 msgctxt "monster"
 msgid "Soulpus"
-msgstr "靈魂"
+msgstr "靈​魂"
 
 #: Source/monstdat.cpp:489
 #, fuzzy
 #| msgid "Pukerat the Unclean"
 msgctxt "monster"
 msgid "Pukerat the Unclean"
-msgstr "吐在不乾淨的地方"
+msgstr "吐​在​不​乾淨​的​地方"
 
 #: Source/monstdat.cpp:490
 #, fuzzy
 #| msgid "Boneripper"
 msgctxt "monster"
 msgid "Boneripper"
-msgstr "博內里珀"
+msgstr "博內​里​珀"
 
 #: Source/monstdat.cpp:491
 #, fuzzy
 #| msgid "Rotfeast the Hungry"
 msgctxt "monster"
 msgid "Rotfeast the Hungry"
-msgstr "讓飢餓的人飽餐一頓"
+msgstr "讓​飢餓​的​人​飽餐​一​頓"
 
 #: Source/monstdat.cpp:492
 #, fuzzy
 #| msgid "Gutshank the Quick"
 msgctxt "monster"
 msgid "Gutshank the Quick"
-msgstr "加速攻擊"
+msgstr "加速​攻擊"
 
 #: Source/monstdat.cpp:493
 #, fuzzy
 #| msgid "Brokenhead Bangshield"
 msgctxt "monster"
 msgid "Brokenhead Bangshield"
-msgstr "斷頭盾"
+msgstr "斷​頭盾"
 
 #: Source/monstdat.cpp:495
 #, fuzzy
 #| msgid "Rotcarnage"
 msgctxt "monster"
 msgid "Rotcarnage"
-msgstr "輪迴屠殺"
+msgstr "輪​迴​屠殺"
 
 #: Source/monstdat.cpp:496
 #, fuzzy
@@ -5262,28 +5262,28 @@ msgstr "暗影"
 #| msgid "Deadeye"
 msgctxt "monster"
 msgid "Deadeye"
-msgstr "死神"
+msgstr "死​神"
 
 #: Source/monstdat.cpp:498
 #, fuzzy
 #| msgid "Madeye the Dead"
 msgctxt "monster"
 msgid "Madeye the Dead"
-msgstr "死者之弓"
+msgstr "死者​之​弓"
 
 #: Source/monstdat.cpp:500
 #, fuzzy
 #| msgid "Skullfire"
 msgctxt "monster"
 msgid "Skullfire"
-msgstr "頭骨火"
+msgstr "頭​骨火"
 
 #: Source/monstdat.cpp:501
 #, fuzzy
 #| msgid "Warpskull"
 msgctxt "monster"
 msgid "Warpskull"
-msgstr "頭骨翹曲"
+msgstr "頭​骨翹曲"
 
 #: Source/monstdat.cpp:502
 #, fuzzy
@@ -5297,7 +5297,7 @@ msgstr "戈雷通古"
 #| msgid "Pulsecrawler"
 msgctxt "monster"
 msgid "Pulsecrawler"
-msgstr "脈衝發生器"
+msgstr "脈​衝​發生器"
 
 #: Source/monstdat.cpp:504
 #, fuzzy
@@ -5332,7 +5332,7 @@ msgstr "燃燒"
 #| msgid "Shadowcrow"
 msgctxt "monster"
 msgid "Shadowcrow"
-msgstr "暗影烏鴉"
+msgstr "暗影烏​鴉"
 
 #: Source/monstdat.cpp:509
 #, fuzzy
@@ -5346,14 +5346,14 @@ msgstr "加巴德弱者"
 #| msgid "Bilefroth the Pit Master"
 msgctxt "monster"
 msgid "Bilefroth the Pit Master"
-msgstr "大師的"
+msgstr "大師​的"
 
 #: Source/monstdat.cpp:511
 #, fuzzy
 #| msgid "Bloodskin Darkbow"
 msgctxt "monster"
 msgid "Bloodskin Darkbow"
-msgstr "血色暗影"
+msgstr "血色​暗影"
 
 #: Source/monstdat.cpp:512
 #, fuzzy
@@ -5374,42 +5374,42 @@ msgstr "暗飲者"
 #| msgid "Hazeshifter"
 msgctxt "monster"
 msgid "Hazeshifter"
-msgstr "危險品搬運工"
+msgstr "危險品​搬運​工"
 
 #: Source/monstdat.cpp:515
 #, fuzzy
 #| msgid "Deathspit"
 msgctxt "monster"
 msgid "Deathspit"
-msgstr "臨終遺言"
+msgstr "臨​終遺​言"
 
 #: Source/monstdat.cpp:516
 #, fuzzy
 #| msgid "Bloodgutter"
 msgctxt "monster"
 msgid "Bloodgutter"
-msgstr "血溝"
+msgstr "血​溝"
 
 #: Source/monstdat.cpp:517
 #, fuzzy
 #| msgid "Deathshade Fleshmaul"
 msgctxt "monster"
 msgid "Deathshade Fleshmaul"
-msgstr "死蔭肉搏"
+msgstr "死​蔭​肉搏"
 
 #: Source/monstdat.cpp:518
 #, fuzzy
 #| msgid "Warmaggot the Mad"
 msgctxt "monster"
 msgid "Warmaggot the Mad"
-msgstr "瘋狂的扎爾"
+msgstr "瘋狂​的​扎爾"
 
 #: Source/monstdat.cpp:519
 #, fuzzy
 #| msgid "Glasskull the Jagged"
 msgctxt "monster"
 msgid "Glasskull the Jagged"
-msgstr "參差"
+msgstr "參​差"
 
 #: Source/monstdat.cpp:520
 #, fuzzy
@@ -5423,7 +5423,7 @@ msgstr "疫病"
 #| msgid "Nightwing the Cold"
 msgctxt "monster"
 msgid "Nightwing the Cold"
-msgstr "寒冷的夜晚"
+msgstr "寒冷​的​夜晚"
 
 #: Source/monstdat.cpp:522
 #, fuzzy
@@ -5437,49 +5437,49 @@ msgstr "金石"
 #| msgid "Bronzefist Firestone"
 msgctxt "monster"
 msgid "Bronzefist Firestone"
-msgstr "青銅火石"
+msgstr "青銅​火石"
 
 #: Source/monstdat.cpp:524
 #, fuzzy
 #| msgid "Wrathfire the Doomed"
 msgctxt "monster"
 msgid "Wrathfire the Doomed"
-msgstr "憤怒之火註定"
+msgstr "憤​怒​之​火註​定"
 
 #: Source/monstdat.cpp:525
 #, fuzzy
 #| msgid "Firewound the Grim"
 msgctxt "monster"
 msgid "Firewound the Grim"
-msgstr "陰森的森林被火燒得團團轉"
+msgstr "陰森​的​森林​被​火燒​得​團團轉"
 
 #: Source/monstdat.cpp:526
 #, fuzzy
 #| msgid "Baron Sludge"
 msgctxt "monster"
 msgid "Baron Sludge"
-msgstr "男爵污泥"
+msgstr "男​爵​污泥"
 
 #: Source/monstdat.cpp:527
 #, fuzzy
 #| msgid "Blighthorn Steelmace"
 msgctxt "monster"
 msgid "Blighthorn Steelmace"
-msgstr "白頭蒼蠅"
+msgstr "白頭蒼​蠅"
 
 #: Source/monstdat.cpp:528
 #, fuzzy
 #| msgid "Chaoshowler"
 msgctxt "monster"
 msgid "Chaoshowler"
-msgstr "朝紹勒"
+msgstr "朝​紹勒"
 
 #: Source/monstdat.cpp:529
 #, fuzzy
 #| msgid "Doomgrin the Rotting"
 msgctxt "monster"
 msgid "Doomgrin the Rotting"
-msgstr "腐爛中的惡作劇"
+msgstr "腐爛​中​的​惡作​劇"
 
 #: Source/monstdat.cpp:530
 #, fuzzy
@@ -5493,7 +5493,7 @@ msgstr "瘋子"
 #| msgid "Bonesaw the Litch"
 msgctxt "monster"
 msgid "Bonesaw the Litch"
-msgstr "骨頭鋸"
+msgstr "骨頭​鋸"
 
 #: Source/monstdat.cpp:532
 #, fuzzy
@@ -5514,21 +5514,21 @@ msgstr "魔骨"
 #| msgid "Brokenstorm"
 msgctxt "monster"
 msgid "Brokenstorm"
-msgstr "破壞者"
+msgstr "破​壞者"
 
 #: Source/monstdat.cpp:535
 #, fuzzy
 #| msgid "Stormbane"
 msgctxt "monster"
 msgid "Stormbane"
-msgstr "風暴軌跡"
+msgstr "風​暴軌​跡"
 
 #: Source/monstdat.cpp:536
 #, fuzzy
 #| msgid "Oozedrool"
 msgctxt "monster"
 msgid "Oozedrool"
-msgstr "蛋黃"
+msgstr "蛋​黃"
 
 #: Source/monstdat.cpp:537
 #, fuzzy
@@ -5542,14 +5542,14 @@ msgstr "火焰"
 #| msgid "Blackstorm"
 msgctxt "monster"
 msgid "Blackstorm"
-msgstr "黑色風暴"
+msgstr "黑色​風​暴"
 
 #: Source/monstdat.cpp:539
 #, fuzzy
 #| msgid "Plaguewrath"
 msgctxt "monster"
 msgid "Plaguewrath"
-msgstr "瘟疫之怒"
+msgstr "瘟疫​之​怒"
 
 #: Source/monstdat.cpp:540
 #, fuzzy
@@ -5563,35 +5563,35 @@ msgstr "鞭子"
 #| msgid "Bluehorn"
 msgctxt "monster"
 msgid "Bluehorn"
-msgstr "藍喇叭"
+msgstr "藍​喇叭"
 
 #: Source/monstdat.cpp:542
 #, fuzzy
 #| msgid "Warpfire Hellspawn"
 msgctxt "monster"
 msgid "Warpfire Hellspawn"
-msgstr "戰火地獄產卵"
+msgstr "戰​火地獄產​卵"
 
 #: Source/monstdat.cpp:543
 #, fuzzy
 #| msgid "Fangspeir"
 msgctxt "monster"
 msgid "Fangspeir"
-msgstr "方斯皮爾"
+msgstr "方​斯皮爾"
 
 #: Source/monstdat.cpp:544
 #, fuzzy
 #| msgid "Festerskull"
 msgctxt "monster"
 msgid "Festerskull"
-msgstr "費斯特斯庫爾"
+msgstr "費​斯特斯庫爾"
 
 #: Source/monstdat.cpp:545
 #, fuzzy
 #| msgid "Lionskull the Bent"
 msgctxt "monster"
 msgid "Lionskull the Bent"
-msgstr "彎曲"
+msgstr "彎​曲"
 
 #: Source/monstdat.cpp:546
 #, fuzzy
@@ -5612,28 +5612,28 @@ msgstr "Viletouch村"
 #| msgid "Viperflame"
 msgctxt "monster"
 msgid "Viperflame"
-msgstr "毒蛇"
+msgstr "毒​蛇"
 
 #: Source/monstdat.cpp:549
 #, fuzzy
 #| msgid "Fangskin"
 msgctxt "monster"
 msgid "Fangskin"
-msgstr "牙皮"
+msgstr "牙​皮"
 
 #: Source/monstdat.cpp:550
 #, fuzzy
 #| msgid "Witchfire the Unholy"
 msgctxt "monster"
 msgid "Witchfire the Unholy"
-msgstr "邪惡的祭壇"
+msgstr "邪惡​的​祭壇"
 
 #: Source/monstdat.cpp:551
 #, fuzzy
 #| msgid "Blackskull"
 msgctxt "monster"
 msgid "Blackskull"
-msgstr "黑頭骨"
+msgstr "黑​頭​骨"
 
 #: Source/monstdat.cpp:552
 #, fuzzy
@@ -5647,7 +5647,7 @@ msgstr "靈魂衝擊"
 #| msgid "Windspawn"
 msgctxt "monster"
 msgid "Windspawn"
-msgstr "風擋"
+msgstr "風​擋"
 
 #: Source/monstdat.cpp:554
 #, fuzzy
@@ -5661,35 +5661,35 @@ msgstr "坑"
 #| msgid "Rustweaver"
 msgctxt "monster"
 msgid "Rustweaver"
-msgstr "銹織工"
+msgstr "銹​織​工"
 
 #: Source/monstdat.cpp:556
 #, fuzzy
 #| msgid "Howlingire the Shade"
 msgctxt "monster"
 msgid "Howlingire the Shade"
-msgstr "在陰涼處嚎叫"
+msgstr "在​陰涼​處嚎叫"
 
 #: Source/monstdat.cpp:557
 #, fuzzy
 #| msgid "Doomcloud"
 msgctxt "monster"
 msgid "Doomcloud"
-msgstr "末日之聲"
+msgstr "末​日​之​聲"
 
 #: Source/monstdat.cpp:558
 #, fuzzy
 #| msgid "Bloodmoon Soulfire"
 msgctxt "monster"
 msgid "Bloodmoon Soulfire"
-msgstr "血月靈魂之火"
+msgstr "血月​靈魂​之​火"
 
 #: Source/monstdat.cpp:559
 #, fuzzy
 #| msgid "Witchmoon"
 msgctxt "monster"
 msgid "Witchmoon"
-msgstr "女巫月亮"
+msgstr "女​巫​月亮"
 
 #: Source/monstdat.cpp:560
 #, fuzzy
@@ -5703,56 +5703,56 @@ msgstr "戈雷弗特"
 #| msgid "Graywar the Slayer"
 msgctxt "monster"
 msgid "Graywar the Slayer"
-msgstr "格雷瓦爾殺手"
+msgstr "格雷瓦爾​殺手"
 
 #: Source/monstdat.cpp:562
 #, fuzzy
 #| msgid "Dreadjudge"
 msgctxt "monster"
 msgid "Dreadjudge"
-msgstr "恐懼法官"
+msgstr "恐懼​法官"
 
 #: Source/monstdat.cpp:563
 #, fuzzy
 #| msgid "Stareye the Witch"
 msgctxt "monster"
 msgid "Stareye the Witch"
-msgstr "女巫艾德里亞"
+msgstr "女​巫艾德里亞"
 
 #: Source/monstdat.cpp:564
 #, fuzzy
 #| msgid "Steelskull the Hunter"
 msgctxt "monster"
 msgid "Steelskull the Hunter"
-msgstr "致命的獵人"
+msgstr "致命​的​獵人"
 
 #: Source/monstdat.cpp:565
 #, fuzzy
 #| msgid "Sir Gorash"
 msgctxt "monster"
 msgid "Sir Gorash"
-msgstr "戈拉什爵士"
+msgstr "戈拉什​爵士"
 
 #: Source/monstdat.cpp:566
 #, fuzzy
 #| msgid "The Vizier"
 msgctxt "monster"
 msgid "The Vizier"
-msgstr "維齊爾"
+msgstr "維​齊爾"
 
 #: Source/monstdat.cpp:568
 #, fuzzy
 #| msgid "Bloodlust"
 msgctxt "monster"
 msgid "Bloodlust"
-msgstr "嗜血"
+msgstr "嗜​血"
 
 #: Source/monstdat.cpp:570
 #, fuzzy
 #| msgid "Fleshdancer"
 msgctxt "monster"
 msgid "Fleshdancer"
-msgstr "肉身舞者"
+msgstr "肉身​舞者"
 
 #: Source/monstdat.cpp:571
 #, fuzzy
@@ -5775,7 +5775,7 @@ msgstr "動物"
 
 #: Source/monster.cpp:3476
 msgid "Demon"
-msgstr "惡魔"
+msgstr "惡​魔"
 
 #: Source/monster.cpp:3478
 msgid "Undead"
@@ -5783,23 +5783,23 @@ msgstr "亡靈"
 
 #: Source/monster.cpp:4610
 msgid "Type: {:s}  Kills: {:d}"
-msgstr "型別: {:s} 擊殺: {:d}"
+msgstr "型​別​:​ {:s} ​擊殺​:​ {:d}"
 
 #: Source/monster.cpp:4612
 msgid "Total kills: {:d}"
-msgstr "擊殺總數: {:d}"
+msgstr "擊​殺總​數​:​ {:d}"
 
 #: Source/monster.cpp:4645
 msgid "Hit Points: {:d}-{:d}"
-msgstr "生命值: {:d}-{:d}"
+msgstr "生命​值​:​ {:d}-{:d}"
 
 #: Source/monster.cpp:4651
 msgid "No magic resistance"
-msgstr "沒有魔法抵抗"
+msgstr "沒​有​魔法​抵抗"
 
 #: Source/monster.cpp:4655
 msgid "Resists: "
-msgstr "抗性: "
+msgstr "抗性​: "
 
 #: Source/monster.cpp:4657 Source/monster.cpp:4668
 msgid "Magic "
@@ -5811,89 +5811,89 @@ msgstr "火"
 
 #: Source/monster.cpp:4661 Source/monster.cpp:4672
 msgid "Lightning "
-msgstr "閃電"
+msgstr "閃​電"
 
 #: Source/monster.cpp:4666
 msgid "Immune: "
-msgstr "免疫: "
+msgstr "免疫​: "
 
 #: Source/monster.cpp:4684
 msgid "Type: {:s}"
-msgstr "型別: {:s}"
+msgstr "型​別​:​ {:s}"
 
 #: Source/monster.cpp:4690 Source/monster.cpp:4697
 msgid "No resistances"
-msgstr "無抗性"
+msgstr "無​抗性"
 
 #: Source/monster.cpp:4692 Source/monster.cpp:4702
 msgid "No Immunities"
-msgstr "無免疫"
+msgstr "無​免疫"
 
 #: Source/monster.cpp:4695
 msgid "Some Magic Resistances"
-msgstr "一些魔法抵抗"
+msgstr "一些​魔法​抵抗"
 
 #: Source/monster.cpp:4700
 msgid "Some Magic Immunities"
-msgstr "一些魔法免疫"
+msgstr "一些​魔法​免疫"
 
 #: Source/msg.cpp:484
 msgid "Trying to drop a floor item?"
-msgstr "想扔地板嗎？"
+msgstr "想​扔​地板嗎​？"
 
 #: Source/msg.cpp:951 Source/msg.cpp:975 Source/msg.cpp:998 Source/msg.cpp:1113
 #: Source/msg.cpp:1136 Source/msg.cpp:1158 Source/msg.cpp:1180
 msgid "{:s} has cast an illegal spell."
-msgstr "{:s}施放了非法法術。"
+msgstr "{:s}​施放​了​非法​法術​。"
 
 #: Source/msg.cpp:1529 Source/multi.cpp:815
 msgid "Player '{:s}' (level {:d}) just joined the game"
-msgstr "玩家{:s}(等級{:d})剛加入了遊戲"
+msgstr "玩​家​{:s}(​等​級{:d})剛​加入​了​遊戲"
 
 #: Source/msg.cpp:1826
 msgid "Waiting for game data..."
-msgstr "正在等待遊戲數據。。。"
+msgstr "正在​等待​遊戲​數據​。​。​。"
 
 #: Source/msg.cpp:1834
 msgid "The game ended"
-msgstr "比賽結束了"
+msgstr "比賽​結束​了"
 
 #: Source/msg.cpp:1840
 msgid "Unable to get level data"
-msgstr "無法獲取層數據"
+msgstr "無​法​獲取層數據"
 
 #: Source/multi.cpp:195
 msgid "Player '{:s}' just left the game"
-msgstr "玩家{:s}剛剛離開了遊戲"
+msgstr "玩​家​{:s}​剛剛離開​了​遊戲"
 
 #: Source/multi.cpp:198
 msgid "Player '{:s}' killed Diablo and left the game!"
-msgstr "玩家{:s}殺死了迪亞波羅並離開了遊戲！"
+msgstr "玩​家​{:s}​殺死​了​迪亞波羅並​離開​了​遊戲​！"
 
 #: Source/multi.cpp:202
 msgid "Player '{:s}' dropped due to timeout"
-msgstr "由於超時，玩家{:s}的掉落物被刪除"
+msgstr "由於​超時​，​玩家​{:s}​的​掉落物​被​刪除"
 
 #: Source/multi.cpp:817
 msgid "Player '{:s}' (level {:d}) is already in the game"
-msgstr "玩家{:s}(等級{:d})已經在遊戲中"
+msgstr "玩​家​{:s}(​等​級{:d})​已​經​在​遊戲​中"
 
 #. TRANSLATORS: Shrine Name Block
 #: Source/objects.cpp:101
 msgid "Mysterious"
-msgstr "神秘的"
+msgstr "神秘​的"
 
 #: Source/objects.cpp:102
 msgid "Hidden"
-msgstr "隱藏"
+msgstr "隱​藏"
 
 #: Source/objects.cpp:103
 msgid "Gloomy"
-msgstr "陰鬱的"
+msgstr "陰鬱​的"
 
 #: Source/objects.cpp:105 Source/objects.cpp:112
 msgid "Magical"
-msgstr "神奇的"
+msgstr "神奇​的"
 
 #: Source/objects.cpp:106
 msgid "Stone"
@@ -5901,39 +5901,39 @@ msgstr "巖石"
 
 #: Source/objects.cpp:107
 msgid "Religious"
-msgstr "宗教的"
+msgstr "宗教​的"
 
 #: Source/objects.cpp:108
 msgid "Enchanted"
-msgstr "被迷住了"
+msgstr "被​迷住​了"
 
 #: Source/objects.cpp:109
 msgid "Thaumaturgic"
-msgstr "Thaumaturogic公司"
+msgstr "Thaumaturogic​公司"
 
 #: Source/objects.cpp:110
 msgid "Fascinating"
-msgstr "炫目"
+msgstr "炫​目"
 
 #: Source/objects.cpp:111
 msgid "Cryptic"
-msgstr "神秘的"
+msgstr "神秘​的"
 
 #: Source/objects.cpp:113
 msgid "Eldritch"
-msgstr "埃爾德里奇"
+msgstr "埃爾德里​奇"
 
 #: Source/objects.cpp:114
 msgid "Eerie"
-msgstr "詭異的"
+msgstr "詭異​的"
 
 #: Source/objects.cpp:115
 msgid "Divine"
-msgstr "至聖"
+msgstr "至​聖"
 
 #: Source/objects.cpp:117
 msgid "Sacred"
-msgstr "聖潔"
+msgstr "聖​潔"
 
 #: Source/objects.cpp:118
 msgid "Spiritual"
@@ -5941,27 +5941,27 @@ msgstr "靈性"
 
 #: Source/objects.cpp:119
 msgid "Spooky"
-msgstr "幽靈般的"
+msgstr "幽靈​般​的"
 
 #: Source/objects.cpp:120
 msgid "Abandoned"
-msgstr "被遺棄的"
+msgstr "被​遺棄​的"
 
 #: Source/objects.cpp:121
 msgid "Creepy"
-msgstr "令人毛骨悚然"
+msgstr "令​人​毛骨悚然"
 
 #: Source/objects.cpp:122
 msgid "Quiet"
-msgstr "安靜的"
+msgstr "安靜​的"
 
 #: Source/objects.cpp:123
 msgid "Secluded"
-msgstr "與世隔絕"
+msgstr "與​世隔絕"
 
 #: Source/objects.cpp:124
 msgid "Ornate"
-msgstr "華麗的"
+msgstr "華麗​的"
 
 #: Source/objects.cpp:125
 msgid "Glimmering"
@@ -5969,7 +5969,7 @@ msgstr "微光"
 
 #: Source/objects.cpp:126
 msgid "Tainted"
-msgstr "污染魔"
+msgstr "污染​魔"
 
 #: Source/objects.cpp:127
 msgid "Oily"
@@ -5977,15 +5977,15 @@ msgstr "油性"
 
 #: Source/objects.cpp:128
 msgid "Glowing"
-msgstr "輝光"
+msgstr "輝​光"
 
 #: Source/objects.cpp:129
 msgid "Mendicant's"
-msgstr "乞丐的"
+msgstr "乞丐​的"
 
 #: Source/objects.cpp:130
 msgid "Sparkling"
-msgstr "閃亮的"
+msgstr "閃​亮​的"
 
 #: Source/objects.cpp:131
 msgid "Town"
@@ -6002,107 +6002,107 @@ msgstr "日光"
 #. TRANSLATORS: Shrine Name Block end
 #: Source/objects.cpp:135
 msgid "Murphy's"
-msgstr "墨菲的"
+msgstr "墨菲​的"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:265
 msgid "The Great Conflict"
-msgstr "大沖突"
+msgstr "大​沖​突"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:266
 msgid "The Wages of Sin are War"
-msgstr "罪惡的代價是戰爭"
+msgstr "罪惡​的​代價​是​戰爭"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:267
 msgid "The Tale of the Horadrim"
-msgstr "赫拉迪姆的故事"
+msgstr "赫拉迪姆​的​故事"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:268
 msgid "The Dark Exile"
-msgstr "黑暗的流放"
+msgstr "黑暗​的​流放"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:269
 msgid "The Sin War"
-msgstr "原罪之戰"
+msgstr "原罪​之​戰"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:270
 msgid "The Binding of the Three"
-msgstr "三者的結合"
+msgstr "三者​的​結合"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:271
 msgid "The Realms Beyond"
-msgstr "超越的王國"
+msgstr "超越​的​王國"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:272
 msgid "Tale of the Three"
-msgstr "三部曲"
+msgstr "三​部​曲"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:273
 msgid "The Black King"
-msgstr "黑王"
+msgstr "黑​王"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:274
 msgid "Journal: The Ensorcellment"
-msgstr "期刊: 感悟"
+msgstr "期​刊​: 感悟"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:275
 msgid "Journal: The Meeting"
-msgstr "日記: 會議"
+msgstr "日​記​: 會議"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:276
 msgid "Journal: The Tirade"
-msgstr "日記: 長篇大論"
+msgstr "日​記​: 長篇​大論"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:277
 msgid "Journal: His Power Grows"
-msgstr "日記: 他的力量在增長"
+msgstr "日​記​: 他​的​力量​在​增長"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:278
 msgid "Journal: NA-KRUL"
-msgstr "期刊: NA-KRUL"
+msgstr "期​刊​:​ NA-KRUL"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:279
 msgid "Journal: The End"
-msgstr "日記: 結束"
+msgstr "日​記​: 結束"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:280
 msgid "A Spellbook"
-msgstr "咒語書"
+msgstr "咒​語書"
 
 #: Source/objects.cpp:5365
 msgid "Crucified Skeleton"
-msgstr "十字架骷髏"
+msgstr "十字​架​骷髏"
 
 #: Source/objects.cpp:5369
 msgid "Lever"
-msgstr "控制桿"
+msgstr "控制​桿"
 
 #: Source/objects.cpp:5378
 msgid "Open Door"
-msgstr "打開的門"
+msgstr "打開​的​門"
 
 #: Source/objects.cpp:5380
 msgid "Closed Door"
-msgstr "關閉的門"
+msgstr "關閉​的​門"
 
 #: Source/objects.cpp:5382
 msgid "Blocked Door"
-msgstr "封死的門"
+msgstr "封死​的​門"
 
 #: Source/objects.cpp:5387
 msgid "Ancient Tome"
@@ -6114,7 +6114,7 @@ msgstr "卑鄙書"
 
 #: Source/objects.cpp:5394
 msgid "Skull Lever"
-msgstr "頭骨槓桿"
+msgstr "頭​骨槓​桿"
 
 #: Source/objects.cpp:5397
 msgid "Mythical Book"
@@ -6122,7 +6122,7 @@ msgstr "神話書"
 
 #: Source/objects.cpp:5401
 msgid "Small Chest"
-msgstr "小箱子"
+msgstr "小​箱子"
 
 #: Source/objects.cpp:5405
 msgid "Chest"
@@ -6130,11 +6130,11 @@ msgstr "箱子"
 
 #: Source/objects.cpp:5410
 msgid "Large Chest"
-msgstr "大箱子"
+msgstr "大​箱子"
 
 #: Source/objects.cpp:5413
 msgid "Sarcophagus"
-msgstr "石棺"
+msgstr "石​棺"
 
 #: Source/objects.cpp:5416
 msgid "Bookshelf"
@@ -6142,7 +6142,7 @@ msgstr "書架"
 
 #: Source/objects.cpp:5420
 msgid "Bookcase"
-msgstr "書櫃"
+msgstr "書​櫃"
 
 #: Source/objects.cpp:5425
 msgid "Pod"
@@ -6159,15 +6159,15 @@ msgstr "桶"
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
 #: Source/objects.cpp:5433
 msgid "{:s} Shrine"
-msgstr "{:s}神殿"
+msgstr "{:s}​神殿"
 
 #: Source/objects.cpp:5437
 msgid "Skeleton Tome"
-msgstr "骷髏大部頭"
+msgstr "骷​髏​大部​頭"
 
 #: Source/objects.cpp:5440
 msgid "Library Book"
-msgstr "圖書館圖書"
+msgstr "圖​書館圖書"
 
 #: Source/objects.cpp:5443
 msgid "Blood Fountain"
@@ -6175,15 +6175,15 @@ msgstr "血泉"
 
 #: Source/objects.cpp:5446
 msgid "Decapitated Body"
-msgstr "斷頭屍體"
+msgstr "斷​頭屍體"
 
 #: Source/objects.cpp:5449
 msgid "Book of the Blind"
-msgstr "盲人書"
+msgstr "盲人​書"
 
 #: Source/objects.cpp:5452
 msgid "Book of Blood"
-msgstr "血書"
+msgstr "血​書"
 
 #: Source/objects.cpp:5455
 msgid "Purifying Spring"
@@ -6191,19 +6191,19 @@ msgstr "凈化彈簧"
 
 #: Source/objects.cpp:5462 Source/objects.cpp:5486
 msgid "Weapon Rack"
-msgstr "武器架"
+msgstr "武器​架"
 
 #: Source/objects.cpp:5465
 msgid "Goat Shrine"
-msgstr "山羊神殿"
+msgstr "山​羊​神殿"
 
 #: Source/objects.cpp:5468
 msgid "Cauldron"
-msgstr "大鍋"
+msgstr "大​鍋"
 
 #: Source/objects.cpp:5471
 msgid "Murky Pool"
-msgstr "渾濁的水池"
+msgstr "渾濁​的​水池"
 
 #: Source/objects.cpp:5474
 msgid "Fountain of Tears"
@@ -6211,7 +6211,7 @@ msgstr "淚泉"
 
 #: Source/objects.cpp:5477
 msgid "Steel Tome"
-msgstr "鋼卷軸"
+msgstr "鋼​卷軸"
 
 #: Source/objects.cpp:5480
 msgid "Pedestal of Blood"
@@ -6223,47 +6223,47 @@ msgstr "蘑菇斑"
 
 #: Source/objects.cpp:5492
 msgid "Vile Stand"
-msgstr "卑鄙的立場"
+msgstr "卑鄙​的​立場"
 
 #: Source/objects.cpp:5495
 msgid "Slain Hero"
-msgstr "被殺英雄"
+msgstr "被​殺​英雄"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
 #: Source/objects.cpp:5502
 msgid "Trapped {:s}"
-msgstr "陷阱{:s}"
+msgstr "陷阱​{:s}"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
 #: Source/objects.cpp:5508
 msgid "{:s} (disabled)"
-msgstr "{:s}（已禁用）"
+msgstr "{:s}​（​已​禁用​）"
 
 #: Source/panels/charpanel.cpp:109
 msgid "MAX"
-msgstr "馬克斯"
+msgstr "馬​克斯"
 
 #: Source/panels/charpanel.cpp:119
 #, fuzzy
 #| msgid "Level:"
 msgid "Level"
-msgstr "等級: "
+msgstr "等​級​: "
 
 #: Source/panels/charpanel.cpp:121
 #, fuzzy
 #| msgid "Experience: "
 msgid "Experience"
-msgstr "經驗: "
+msgstr "經​驗​: "
 
 #: Source/panels/charpanel.cpp:123
 #, fuzzy
 #| msgid "Next Level: "
 msgid "Next level"
-msgstr "下一級: "
+msgstr "下​一​級​: "
 
 #: Source/panels/charpanel.cpp:126
 msgid "None"
-msgstr "沒有一個"
+msgstr "沒​有​一​個"
 
 #: Source/panels/charpanel.cpp:132
 msgid "Base"
@@ -6273,7 +6273,7 @@ msgstr ""
 #, fuzzy
 #| msgid "No"
 msgid "Now"
-msgstr "曾經打開的現在關閉了"
+msgstr "曾​經​打開​的​現​在​關閉​了"
 
 #: Source/panels/charpanel.cpp:134
 #, fuzzy
@@ -6291,7 +6291,7 @@ msgstr "魔術"
 #, fuzzy
 #| msgid "Dexterity:"
 msgid "Dexterity"
-msgstr "靈巧"
+msgstr "靈​巧"
 
 #: Source/panels/charpanel.cpp:145
 #, fuzzy
@@ -6302,23 +6302,23 @@ msgstr "活力"
 #: Source/panels/charpanel.cpp:148
 #, fuzzy
 msgid "Points to distribute"
-msgstr "生命值: {:d}-{:d}"
+msgstr "生命​值​:​ {:d}-{:d}"
 
 #: Source/panels/charpanel.cpp:158
 #, fuzzy
 #| msgid "armor class: {:d}"
 msgid "Armor class"
-msgstr "護甲等級: {:d}"
+msgstr "護​甲​等​級​:​ {:d}"
 
 #: Source/panels/charpanel.cpp:160
 #, fuzzy
 msgid "To hit"
-msgstr "生命點{:d}的{:d}"
+msgstr "生命​點{:d}​的​{:d}"
 
 #: Source/panels/charpanel.cpp:162
 #, fuzzy
 msgid "Damage"
-msgstr "潛在傷害-不是弓箭"
+msgstr "潛​在​傷害​-​不​是​弓箭"
 
 #: Source/panels/charpanel.cpp:168
 #, fuzzy
@@ -6333,26 +6333,26 @@ msgstr "法力"
 #, fuzzy
 #| msgid "Resist Magic: {:+d}%"
 msgid "Resist magic"
-msgstr "抵抗魔法: {:+d}%"
+msgstr "抵抗​魔法​:​ {:+d}%"
 
 #: Source/panels/charpanel.cpp:179
 #, fuzzy
 #| msgid "Resists: "
 msgid "Resist fire"
-msgstr "火焰抗性: {:+d}%"
+msgstr "火焰​抗性​:​ {:+d}%"
 
 #: Source/panels/charpanel.cpp:181
 #, fuzzy
 #| msgid "Resist Lightning: {:+d}%"
 msgid "Resist lightning"
-msgstr "閃電抗性: {:+d}%"
+msgstr "閃​電​抗性​:​ {:+d}%"
 
 #: Source/panels/mainpanel.cpp:62 Source/panels/mainpanel.cpp:109
 #: Source/panels/mainpanel.cpp:111
 #, fuzzy
 #| msgid "Voices"
 msgid "voice"
-msgstr "語音製作、導演和配音"
+msgstr "語音​製作​、​導演​和​配音"
 
 #: Source/panels/mainpanel.cpp:87
 #, fuzzy
@@ -6369,7 +6369,7 @@ msgstr "任務"
 #, fuzzy
 #| msgid "Map"
 msgid "map"
-msgstr "地圖"
+msgstr "地​圖"
 
 #: Source/panels/mainpanel.cpp:90
 #, fuzzy
@@ -6380,13 +6380,13 @@ msgstr "菜單"
 #, fuzzy
 #| msgid "Inv"
 msgid "inv"
-msgstr "物品欄"
+msgstr "物品​欄"
 
 #: Source/panels/mainpanel.cpp:92
 #, fuzzy
 #| msgid "Spells"
 msgid "spells"
-msgstr "法術"
+msgstr "法​術"
 
 #: Source/panels/mainpanel.cpp:104 Source/panels/mainpanel.cpp:106
 #: Source/panels/mainpanel.cpp:108
@@ -6395,28 +6395,28 @@ msgstr ""
 
 #: Source/pfile.cpp:260
 msgid "Failed to open player archive for writing."
-msgstr "無法打開播放器存檔進行寫入。"
+msgstr "無​法​打開​播放器​存檔​進行​寫入​。"
 
 #: Source/pfile.cpp:385
 msgid "Unable to open archive"
-msgstr "無法打開存檔"
+msgstr "無​法​打開​存檔"
 
 #: Source/pfile.cpp:387
 msgid "Unable to load character"
-msgstr "無法載入角色"
+msgstr "無​法​載入​角色"
 
 #: Source/pfile.cpp:410 Source/pfile.cpp:430
 msgid "Unable to read to save file archive"
-msgstr "無法讀取以儲存檔案存檔"
+msgstr "無​法​讀取​以​儲存檔​案​存檔"
 
 #: Source/pfile.cpp:449
 msgid "Unable to write to save file archive"
-msgstr "無法寫入以儲存檔案存檔"
+msgstr "無​法寫​入​以​儲存檔​案​存檔"
 
 #. TRANSLATORS: Shown if player presses "v" button. {:s} is player name, {:d} is level, {:s} is location
 #: Source/plrmsg.cpp:89
 msgid "{:s} (lvl {:d}): {:s}"
-msgstr "{:s}（等級{:d}）: {:s}"
+msgstr "{:s}​（​等​級{:d}​）​:​ {:s}"
 
 #. TRANSLATORS: Decimal separator
 #: Source/qol/common.cpp:25
@@ -6437,27 +6437,27 @@ msgid ""
 "Failed to load UI resources.\n"
 "\n"
 "Make sure devilutionx.mpq is in the game folder and that it is up to date."
-msgstr "無法載入UI資源。devilutionx.mpq是否可訪問且是最新的？"
+msgstr "無​法載入​UI資源​。​devilutionx.mpq​是否​可​訪問且​是​最​新​的​？"
 
 #: Source/qol/xpbar.cpp:125
 msgid "Level {:d}"
-msgstr "等級{:d}"
+msgstr "等​級{:d}"
 
 #: Source/qol/xpbar.cpp:132 Source/qol/xpbar.cpp:143
 msgid "Experience: "
-msgstr "經驗: "
+msgstr "經​驗​: "
 
 #: Source/qol/xpbar.cpp:136
 msgid "Maximum Level"
-msgstr "最高水位"
+msgstr "最高​水位"
 
 #: Source/qol/xpbar.cpp:147
 msgid "Next Level: "
-msgstr "下一級: "
+msgstr "下​一​級​: "
 
 #: Source/qol/xpbar.cpp:151
 msgid " to Level {:d}"
-msgstr "到{:d}級"
+msgstr "到​{:d}​級"
 
 #. TRANSLATORS: Quest Name Block
 #: Source/quests.cpp:41
@@ -6470,7 +6470,7 @@ msgstr "加巴德弱者"
 
 #: Source/quests.cpp:44
 msgid "Zhar the Mad"
-msgstr "瘋狂的扎爾"
+msgstr "瘋狂​的​扎爾"
 
 #: Source/quests.cpp:47
 msgid "The Butcher"
@@ -6478,11 +6478,11 @@ msgstr "屠夫"
 
 #: Source/quests.cpp:48
 msgid "Ogden's Sign"
-msgstr "奧格登征"
+msgstr "奧​格​登征"
 
 #: Source/quests.cpp:49
 msgid "Halls of the Blind"
-msgstr "盲人大廳"
+msgstr "盲​人大​廳"
 
 #: Source/quests.cpp:50
 msgid "Valor"
@@ -6490,15 +6490,15 @@ msgstr "英勇"
 
 #: Source/quests.cpp:52
 msgid "Warlord of Blood"
-msgstr "鮮血督軍"
+msgstr "鮮​血督軍"
 
 #: Source/quests.cpp:53
 msgid "The Curse of King Leoric"
-msgstr "李奧瑞克國王的詛咒"
+msgstr "李奧瑞克國王​的​詛咒"
 
 #: Source/quests.cpp:54 Source/setmaps.cpp:27
 msgid "Poisoned Water Supply"
-msgstr "中毒供水"
+msgstr "中毒​供水"
 
 #. TRANSLATORS: Quest Map
 #: Source/quests.cpp:55 Source/quests.cpp:90
@@ -6507,23 +6507,23 @@ msgstr "骨腔"
 
 #: Source/quests.cpp:56
 msgid "Archbishop Lazarus"
-msgstr "大主教拉撒雷茲"
+msgstr "大​主教​拉撒雷茲"
 
 #: Source/quests.cpp:57
 msgid "Grave Matters"
-msgstr "重大事項"
+msgstr "重大​事​項"
 
 #: Source/quests.cpp:58
 msgid "Farmer's Orchard"
-msgstr "農家果園"
+msgstr "農​家果園"
 
 #: Source/quests.cpp:59
 msgid "Little Girl"
-msgstr "小女孩"
+msgstr "小​女孩"
 
 #: Source/quests.cpp:60
 msgid "Wandering Trader"
-msgstr "遊蕩交易者"
+msgstr "遊​蕩​交易者"
 
 #: Source/quests.cpp:61
 msgid "The Defiler"
@@ -6531,17 +6531,17 @@ msgstr "污染者"
 
 #: Source/quests.cpp:63 Source/trigs.cpp:447
 msgid "Cornerstone of the World"
-msgstr "世界的基石"
+msgstr "世界​的​基石"
 
 #. TRANSLATORS: Quest Name Block end
 #: Source/quests.cpp:64
 msgid "The Jersey's Jersey"
-msgstr "球衣是球衣"
+msgstr "球衣​是​球衣"
 
 #. TRANSLATORS: Quest Map
 #: Source/quests.cpp:89
 msgid "King Leoric's Tomb"
-msgstr "利奧里克國王墓"
+msgstr "利奧里克國王​墓"
 
 #. TRANSLATORS: Quest Map
 #: Source/quests.cpp:91 Source/setmaps.cpp:26
@@ -6551,21 +6551,21 @@ msgstr "迷宮"
 #. TRANSLATORS: Quest Map
 #: Source/quests.cpp:92
 msgid "A Dark Passage"
-msgstr "黑暗的通道"
+msgstr "黑暗​的​通道"
 
 #. TRANSLATORS: Quest Map
 #: Source/quests.cpp:93
 msgid "Unholy Altar"
-msgstr "邪惡祭壇"
+msgstr "邪惡​祭​壇"
 
 #. TRANSLATORS: Used for Quest Portals. {:s} is a Map Name
 #: Source/quests.cpp:449
 msgid "To {:s}"
-msgstr "到{:s}"
+msgstr "到​{:s}"
 
 #: Source/setmaps.cpp:24
 msgid "Skeleton King's Lair"
-msgstr "骷髏王的巢穴"
+msgstr "骷​髏王​的​巢穴"
 
 #: Source/setmaps.cpp:25
 msgid "Chamber of Bone"
@@ -6573,115 +6573,115 @@ msgstr "骨腔"
 
 #: Source/setmaps.cpp:28
 msgid "Archbishop Lazarus' Lair"
-msgstr "拉撒雷茲大主教的巢穴"
+msgstr "拉撒雷茲​大​主教​的​巢穴"
 
 #: Source/spelldat.cpp:16
 #, fuzzy
 #| msgid "Firebolt"
 msgctxt "spell"
 msgid "Firebolt"
-msgstr "火栓"
+msgstr "火​栓"
 
 #: Source/spelldat.cpp:17
 #, fuzzy
 #| msgid "Healing"
 msgctxt "spell"
 msgid "Healing"
-msgstr "完全治癒藥劑"
+msgstr "完全​治癒藥劑"
 
 #: Source/spelldat.cpp:18
 msgctxt "spell"
 msgid "Lightning"
-msgstr "閃電術"
+msgstr "閃​電術"
 
 #: Source/spelldat.cpp:19
 #, fuzzy
 #| msgid "Flash"
 msgctxt "spell"
 msgid "Flash"
-msgstr "閃光卷軸"
+msgstr "閃​光​卷軸"
 
 #: Source/spelldat.cpp:20
 #, fuzzy
 #| msgid "Identify"
 msgctxt "spell"
 msgid "Identify"
-msgstr "標識專案"
+msgstr "標​識​專案"
 
 #: Source/spelldat.cpp:21
 #, fuzzy
 #| msgid "Fire Wall"
 msgctxt "spell"
 msgid "Fire Wall"
-msgstr "火焰墻卷軸"
+msgstr "火焰​墻​卷軸"
 
 #: Source/spelldat.cpp:22
 msgctxt "spell"
 msgid "Town Portal"
-msgstr "城鎮傳送門"
+msgstr "城鎮​傳​送門"
 
 #: Source/spelldat.cpp:23
 #, fuzzy
 #| msgid "Stone Curse"
 msgctxt "spell"
 msgid "Stone Curse"
-msgstr "石咒卷軸"
+msgstr "石咒​卷軸"
 
 #: Source/spelldat.cpp:24
 #, fuzzy
 #| msgid "Infravision"
 msgctxt "spell"
 msgid "Infravision"
-msgstr "夜視能力"
+msgstr "夜視​能力"
 
 #: Source/spelldat.cpp:25
 #, fuzzy
 #| msgid "Phasing"
 msgctxt "spell"
 msgid "Phasing"
-msgstr "相位調整卷軸"
+msgstr "相位​調​整​卷​軸"
 
 #: Source/spelldat.cpp:26
 #, fuzzy
 #| msgid "Mana Shield"
 msgctxt "spell"
 msgid "Mana Shield"
-msgstr "法力盾卷軸"
+msgstr "法力​盾​卷軸"
 
 #: Source/spelldat.cpp:27
 #, fuzzy
 #| msgid "Fireball"
 msgctxt "spell"
 msgid "Fireball"
-msgstr "火球傷害: {:d}"
+msgstr "火球​傷害​:​ {:d}"
 
 #: Source/spelldat.cpp:28
 #, fuzzy
 #| msgid "Guardian"
 msgctxt "spell"
 msgid "Guardian"
-msgstr "守護者卷軸"
+msgstr "守​護者​卷軸"
 
 #: Source/spelldat.cpp:29
 #, fuzzy
 #| msgid "Chain Lightning"
 msgctxt "spell"
 msgid "Chain Lightning"
-msgstr "連環閃電卷軸"
+msgstr "連​環閃​電​卷軸"
 
 #: Source/spelldat.cpp:30
 #, fuzzy
 #| msgid "Flame Wave"
 msgctxt "spell"
 msgid "Flame Wave"
-msgstr "火焰波卷軸"
+msgstr "火焰​波卷軸"
 
 #: Source/spelldat.cpp:31
 #, fuzzy
 #| msgid "Doom Serpents"
 msgctxt "spell"
 msgid "Doom Serpents"
-msgstr "末日之蛇"
+msgstr "末​日​之​蛇"
 
 #: Source/spelldat.cpp:32
 #, fuzzy
@@ -6695,7 +6695,7 @@ msgstr "血石"
 #| msgid "Nova"
 msgctxt "spell"
 msgid "Nova"
-msgstr "閃電新星卷軸"
+msgstr "閃​電​新​星卷軸"
 
 #: Source/spelldat.cpp:34
 #, fuzzy
@@ -6707,14 +6707,14 @@ msgstr "隱形"
 #: Source/spelldat.cpp:35
 msgctxt "spell"
 msgid "Inferno"
-msgstr "地獄火"
+msgstr "地​獄火"
 
 #: Source/spelldat.cpp:36
 #, fuzzy
 #| msgid "Golem"
 msgctxt "spell"
 msgid "Golem"
-msgstr "傀儡卷軸"
+msgstr "傀儡​卷軸"
 
 #: Source/spelldat.cpp:37
 #, fuzzy
@@ -6722,60 +6722,60 @@ msgstr "傀儡卷軸"
 msgctxt "spell"
 msgid "Rage"
 msgstr ""
-"村裡需要你的幫助，好師傅！幾個月前，萊奧里克國王的兒子阿爾布雷希特王子被綁"
-"架。國王勃然大怒，在村子裡到處尋找他失蹤的孩子。日復一日，萊奧里克似乎陷入了"
-"更深的瘋狂之中。他試圖把男孩的失蹤歸咎於無辜的市民，並殘忍地處決了他們。只有"
-"不到一半的人從他的瘋狂中倖存下來。。。\n"
+"村​裡​需要​你​的​幫助​，​好師傅​！​幾​個​月​前​，​萊奧​里克國王​的​兒子​阿爾布雷希特​王子​被​綁架​。​國"
+"王勃然大怒​，​在​村子​裡​到​處尋​找​他​失蹤​的​孩子​。​日復​一​日​，​萊奧​里克​似乎​陷入​了​更​深​的​"
+"瘋狂​之中​。​他​試圖​把​男孩​的​失蹤歸咎於​無辜​的​市民​，​並殘​忍地處決​了​他​們​。​只​有​不到​一半​的"
+"​人從​他​的​瘋狂​中​倖存​下來​。​。​。​\n"
 " \n"
-"國王的騎士和牧師試圖安撫他，但他轉而反對他們，不幸的是，他們被迫殺了他。國王"
-"臨終前一口氣對他以前的追隨者下了一個可怕的詛咒。他發誓他們會永遠在黑暗中為他"
-"服務。。。\n"
+"國王​的​騎士​和​牧師試​圖安撫​他​，​但​他​轉​而​反對​他​們​，​不幸​的​是​，​他​們​被迫殺​了​他​。​國"
+"王臨終​前​一​口​氣對​他​以前​的​追隨者​下​了​一​個​可怕​的​詛咒​。​他​發誓​他​們會​永遠​在​黑暗中​為​"
+"他​服務​。​。​。​\n"
 " \n"
-"這是事情發生了比我想像的更黑暗的轉折！我們的前國王已經從永恒的睡眠中醒來，現"
-"在在迷宮中指揮著一支不死僕從軍團。他的屍體被埋在大教堂下面三層的墳墓里。求你"
-"了，好主人，通過摧毀他現在被詛咒的身體來讓他的靈魂放鬆"
+"這​是​事情​發生​了​比​我​想像​的​更​黑暗​的​轉折​！​我​們​的​前​國​王​已​經從​永恒​的​睡眠​中​醒來​"
+"，​現​在在​迷宮​中​指揮​著​一​支​不​死​僕從​軍團​。​他​的​屍體​被​埋​在​大​教堂​下面​三​層​的​墳​墓"
+"​里​。​求​你​了​，​好​主人​，​通過摧毀​他​現​在​被​詛咒​的​身體來讓​他​的​靈魂​放鬆"
 
 #: Source/spelldat.cpp:38
 #, fuzzy
 #| msgid "Teleport"
 msgctxt "spell"
 msgid "Teleport"
-msgstr "傳送卷軸"
+msgstr "傳​送​卷軸"
 
 #: Source/spelldat.cpp:39
 #, fuzzy
 #| msgid "Apocalypse"
 msgctxt "spell"
 msgid "Apocalypse"
-msgstr "啓示錄卷軸"
+msgstr "啓示錄​卷軸"
 
 #: Source/spelldat.cpp:40
 #, fuzzy
 #| msgid "Etherealize"
 msgctxt "spell"
 msgid "Etherealize"
-msgstr "以太化"
+msgstr "以​太化"
 
 #: Source/spelldat.cpp:41
 #, fuzzy
 #| msgid "Item Repair"
 msgctxt "spell"
 msgid "Item Repair"
-msgstr "修理專案"
+msgstr "修理​專案"
 
 #: Source/spelldat.cpp:42
 #, fuzzy
 #| msgid "Staff Recharge"
 msgctxt "spell"
 msgid "Staff Recharge"
-msgstr "補給棒"
+msgstr "補​給棒"
 
 #: Source/spelldat.cpp:43
 #, fuzzy
 #| msgid "Trap Disarm"
 msgctxt "spell"
 msgid "Trap Disarm"
-msgstr "設定火焰陷阱"
+msgstr "設​定​火焰​陷阱"
 
 #: Source/spelldat.cpp:44
 #, fuzzy
@@ -6789,35 +6789,35 @@ msgstr "元素"
 #| msgid "Charged Bolt"
 msgctxt "spell"
 msgid "Charged Bolt"
-msgstr "電荷彈短杖"
+msgstr "電​荷彈​短​杖"
 
 #: Source/spelldat.cpp:46
 #, fuzzy
 #| msgid "Holy Bolt"
 msgctxt "spell"
 msgid "Holy Bolt"
-msgstr "電荷彈短杖"
+msgstr "電​荷彈​短​杖"
 
 #: Source/spelldat.cpp:47
 #, fuzzy
 #| msgid "Resurrect"
 msgctxt "spell"
 msgid "Resurrect"
-msgstr "復活卷軸"
+msgstr "復​活​卷軸"
 
 #: Source/spelldat.cpp:48
 #, fuzzy
 #| msgid "Telekinesis"
 msgctxt "spell"
 msgid "Telekinesis"
-msgstr "心靈傳動"
+msgstr "心​靈傳​動"
 
 #: Source/spelldat.cpp:49
 #, fuzzy
 #| msgid "Heal Other"
 msgctxt "spell"
 msgid "Heal Other"
-msgstr "致命的治療"
+msgstr "致命​的​治療"
 
 #: Source/spelldat.cpp:50
 #, fuzzy
@@ -6831,7 +6831,7 @@ msgstr "血"
 #| msgid "Bone Spirit"
 msgctxt "spell"
 msgid "Bone Spirit"
-msgstr "骨鍊甲"
+msgstr "骨鍊​甲"
 
 #: Source/spelldat.cpp:52
 msgctxt "spell"
@@ -6844,39 +6844,39 @@ msgstr "法力"
 msgctxt "spell"
 msgid "the Magi"
 msgstr ""
-"注意並見證這裡的真理，因為它們是赫拉迪姆最後的遺產。近三百年前，人們知道燃燒"
-"地獄的三大惡魔神秘地來到了我們的世界。兄弟三人蹂躪東方的土地數十年，而人類卻"
-"在他們身後戰慄。我們的騎士團——赫拉迪姆——是由一群神秘的法師建立的，目的是一勞"
-"永逸地追捕和俘虜這三個惡魔。\n"
+"注意​並見​證這裡​的​真理​，​因​為​它​們​是​赫拉迪姆​最後​的​遺產​。​近​三百​年​前​，​人們​知道​燃燒​地"
+"獄​的​三​大​惡魔​神秘​地來​到​了​我​們​的​世界​。​兄弟​三​人​蹂躪​東方​的​土地​數​十​年​，​而​人類卻"
+"​在​他​們身​後​戰慄​。​我​們​的​騎士團​——​赫拉迪姆​——​是​由​一​群​神秘​的​法師​建立​的​，​目的​是"
+"​一​勞​永逸​地​追捕​和​俘虜​這​三​個​惡魔​。​\n"
 " \n"
-"最初的赫拉德里姆在被稱為「靈魂石」的強大文物中捕獲了其中兩個，並將它們深埋在"
-"荒涼的東部沙漠之下。第三個惡魔逃脫了追捕，逃到了西部，許多赫拉迪姆人都在追"
-"捕。第三個惡魔-被稱為迪亞波羅，恐懼之王-最終被俘虜，他的靈魂石和埋在這個迷宮"
-"的本質。\n"
+"​最初​的​赫拉德里姆​在​被​稱為​「​靈魂石​」​的​強大​文物​中​捕獲​了​其中​兩個​，​並將​它​們​深​埋​在​"
+"荒涼​的​東部​沙漠​之下​。​第三​個​惡​魔逃脫​了​追捕​，​逃到​了​西部​，​許多赫拉迪姆人​都​在​追捕​。​第三"
+"​個​惡​魔-​被​稱為迪亞波羅​，​恐懼​之​王-​最​終​被​俘虜​，​他​的​靈魂石​和​埋​在​這個​迷宮​的​本質​"
+"。​\n"
 " \n"
-"要被警告，靈魂之石必須防止被那些不信的人發現。如果迪亞波羅被釋放，他會尋找一"
-"個身體很容易控制，因為他會非常虛弱-也許是一個老人或兒童"
+"​要​被​警告​，​靈魂​之石必須​防止​被​那些​不​信​的​人​發現​。​如果​迪亞波羅​被​釋放​，​他​會尋​找​一​"
+"個身體​很​容易​控制​，​因​為​他​會​非常​虛弱​-​也​許​是​一​個​老人​或​兒童"
 
 #: Source/spelldat.cpp:54
 #, fuzzy
 #| msgid "the Jester"
 msgctxt "spell"
 msgid "the Jester"
-msgstr "弄臣的"
+msgstr "弄臣​的"
 
 #: Source/spelldat.cpp:55
 #, fuzzy
 #| msgid "Lightning Wall"
 msgctxt "spell"
 msgid "Lightning Wall"
-msgstr "閃電術"
+msgstr "閃​電術"
 
 #: Source/spelldat.cpp:56
 #, fuzzy
 #| msgid "Immolation"
 msgctxt "spell"
 msgid "Immolation"
-msgstr "獻祭"
+msgstr "獻​祭"
 
 #: Source/spelldat.cpp:57
 #, fuzzy
@@ -6897,7 +6897,7 @@ msgstr "反映"
 #| msgid "Berserk"
 msgctxt "spell"
 msgid "Berserk"
-msgstr "狂戰士"
+msgstr "狂​戰士"
 
 #: Source/spelldat.cpp:60
 #, fuzzy
@@ -6911,7 +6911,7 @@ msgstr "戒指"
 #| msgid "Search"
 msgctxt "spell"
 msgid "Search"
-msgstr "我感覺到一個靈魂在尋找答案"
+msgstr "我​感覺​到​一​個​靈魂​在​尋​找​答案"
 
 #: Source/spelldat.cpp:62
 msgctxt "spell"
@@ -6937,7 +6937,7 @@ msgstr "符文"
 #| msgid "Rune of Immolation"
 msgctxt "spell"
 msgid "Rune of Immolation"
-msgstr "符文炸彈"
+msgstr "符文​炸彈"
 
 #: Source/spelldat.cpp:66
 msgctxt "spell"
@@ -6950,66 +6950,66 @@ msgstr ","
 
 #: Source/stores.cpp:195
 msgid "Damage: {:d}-{:d}  "
-msgstr "傷害: {:d}-{:d}"
+msgstr "傷害​:​ {:d}-{:d}"
 
 #: Source/stores.cpp:197
 msgid "Armor: {:d}  "
-msgstr "護甲: {:d}"
+msgstr "護​甲​:​ {:d}"
 
 #: Source/stores.cpp:199
 msgid "Dur: {:d}/{:d},  "
-msgstr "杜爾: {:d}/{:d}，"
+msgstr "杜爾​:​ {:d}/{:d}​，"
 
 #: Source/stores.cpp:202
 msgid "Indestructible,  "
-msgstr "堅不可摧，"
+msgstr "堅​不​可摧​，"
 
 #: Source/stores.cpp:210
 msgid "No required attributes"
-msgstr "沒有必需的屬性"
+msgstr "沒​有​必需​的​屬性"
 
 #: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
 msgid "Welcome to the"
-msgstr "歡迎來到"
+msgstr "歡​迎來​到"
 
 #: Source/stores.cpp:244
 msgid "Blacksmith's shop"
-msgstr "鐵匠鋪"
+msgstr "鐵匠​鋪"
 
 #: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
 #: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
 #: Source/stores.cpp:1265
 msgid "Would you like to:"
-msgstr "您想: "
+msgstr "您​想​: "
 
 #: Source/stores.cpp:246
 msgid "Talk to Griswold"
-msgstr "和格里斯沃爾德談談"
+msgstr "和​格里斯沃​爾德談談"
 
 #: Source/stores.cpp:247
 msgid "Buy basic items"
-msgstr "購買基本物品"
+msgstr "購​買​基本​物品"
 
 #: Source/stores.cpp:248
 msgid "Buy premium items"
-msgstr "購買高檔商品"
+msgstr "購​買​高檔​商品"
 
 #: Source/stores.cpp:249 Source/stores.cpp:613
 msgid "Sell items"
-msgstr "出售物品"
+msgstr "出售​物品"
 
 #: Source/stores.cpp:250
 msgid "Repair items"
-msgstr "修理專案"
+msgstr "修理​專案"
 
 #: Source/stores.cpp:251
 msgid "Leave the shop"
-msgstr "離開商店"
+msgstr "離​開​商店"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
 msgid "I have these items for sale:             Your gold: {:d}"
-msgstr "我有這些東西要賣: 你的金幣: {:d}"
+msgstr "我​有​這​些​東西​要​賣​: 你​的​金幣​:​ {:d}"
 
 #: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
 #: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
@@ -7023,165 +7023,165 @@ msgstr "返回"
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:351
 msgid "I have these premium items for sale:     Your gold: {:d}"
-msgstr "我有這些高檔商品出售: 你的金幣: {:d}"
+msgstr "我​有​這​些​高檔​商品​出售​: 你​的​金幣​:​ {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:474 Source/stores.cpp:746
 msgid "You have nothing I want.             Your gold: {:d}"
-msgstr "你沒有我想要的東西。你的金幣: {:d}"
+msgstr "你​沒​有​我​想要​的​東西​。​你​的​金幣​:​ {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:489 Source/stores.cpp:761
 msgid "Which item is for sale?             Your gold: {:d}"
-msgstr "哪件商品在出售？你的金幣: {:d}"
+msgstr "哪​件​商品​在​出售​？​你​的​金幣​:​ {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:564
 msgid "You have nothing to repair.             Your gold: {:d}"
-msgstr "你沒什麼可修的。你的金幣: {:d}"
+msgstr "你​沒什麼​可​修​的​。​你​的​金幣​:​ {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:579
 msgid "Repair which item?             Your gold: {:d}"
-msgstr "修理哪個專案？你的金幣: {:d}"
+msgstr "修理​哪​個​專案​？​你​的​金幣​:​ {:d}"
 
 #: Source/stores.cpp:609
 msgid "Witch's shack"
-msgstr "女巫小屋"
+msgstr "女​巫小屋"
 
 #: Source/stores.cpp:611
 msgid "Talk to Adria"
-msgstr "和艾德里亞談談"
+msgstr "和​艾德里亞談​談"
 
 #: Source/stores.cpp:612 Source/stores.cpp:999
 msgid "Buy items"
-msgstr "購買物品"
+msgstr "購​買​物品"
 
 #: Source/stores.cpp:614
 msgid "Recharge staves"
-msgstr "補給棒"
+msgstr "補​給棒"
 
 #: Source/stores.cpp:615
 msgid "Leave the shack"
-msgstr "離開小屋"
+msgstr "離​開​小​屋"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:827
 msgid "You have nothing to recharge.             Your gold: {:d}"
-msgstr "你沒什麼好充電的。你的金幣: {:d}"
+msgstr "你​沒什麼​好​充電​的​。​你​的​金幣​:​ {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:842
 msgid "Recharge which item?             Your gold: {:d}"
-msgstr "給哪個專案充值？你的金幣: {:d}"
+msgstr "給​哪​個​專案​充值​？​你​的​金幣​:​ {:d}"
 
 #: Source/stores.cpp:858
 msgid "You do not have enough gold"
-msgstr "你沒有足夠的金幣"
+msgstr "你​沒​有​足夠​的​金幣"
 
 #: Source/stores.cpp:866
 msgid "You do not have enough room in inventory"
-msgstr "您的庫存空間不足"
+msgstr "您​的​庫存​空間​不足"
 
 #: Source/stores.cpp:903
 msgid "Do we have a deal?"
-msgstr "我們有協議嗎？"
+msgstr "我​們​有​協議嗎​？"
 
 #: Source/stores.cpp:906
 msgid "Are you sure you want to identify this item?"
-msgstr "確定要標識此專案嗎？"
+msgstr "確​定​要​標識​此​專案嗎​？"
 
 #: Source/stores.cpp:912
 msgid "Are you sure you want to buy this item?"
-msgstr "您確定要購買此商品嗎？"
+msgstr "您​確定​要​購買​此​商品​嗎​？"
 
 #: Source/stores.cpp:915
 msgid "Are you sure you want to recharge this item?"
-msgstr "您確定要為該物品充值嗎？"
+msgstr "您​確定​要​為該​物品​充值​嗎​？"
 
 #: Source/stores.cpp:919
 msgid "Are you sure you want to sell this item?"
-msgstr "你確定要賣這個東西嗎？"
+msgstr "你​確定​要​賣這個東​西嗎​？"
 
 #: Source/stores.cpp:922
 msgid "Are you sure you want to repair this item?"
-msgstr "確定要修復此專案嗎？"
+msgstr "確​定​要​修復​此​專案嗎​？"
 
 #: Source/stores.cpp:936 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
-msgstr "你是那個假腿男孩嗎"
+msgstr "你​是​那​個​假腿​男孩​嗎"
 
 #: Source/stores.cpp:939 Source/stores.cpp:946
 msgid "Talk to Wirt"
-msgstr "和沃特談談"
+msgstr "和​沃特談談"
 
 #: Source/stores.cpp:940
 msgid "I have something for sale,"
-msgstr "我有東西要賣，"
+msgstr "我​有​東西​要​賣​，"
 
 #: Source/stores.cpp:941
 msgid "but it will cost 50 gold"
-msgstr "但要花50金"
+msgstr "但​要​花​50​金"
 
 #: Source/stores.cpp:942
 msgid "just to take a look. "
-msgstr "只是想看看。"
+msgstr "只​是​想​看看​。"
 
 #: Source/stores.cpp:943
 msgid "What have you got?"
-msgstr "你有什麼發現？"
+msgstr "你​有​什麼發現​？"
 
 #: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
 #: Source/stores.cpp:1255
 msgid "Say goodbye"
-msgstr "說再見"
+msgstr "說​再​見"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:957
 msgid "I have this item for sale:             Your gold: {:d}"
-msgstr "我有這個東西要賣: 你的金幣: {:d}"
+msgstr "我​有​這個​東西​要​賣​: 你​的​金幣​:​ {:d}"
 
 #: Source/stores.cpp:974
 msgid "Leave"
-msgstr "離開"
+msgstr "離​開"
 
 #: Source/stores.cpp:996
 msgid "Healer's home"
-msgstr "療養院"
+msgstr "療​養院"
 
 #: Source/stores.cpp:998
 msgid "Talk to Pepin"
-msgstr "和佩平談談"
+msgstr "和​佩平​談談"
 
 #: Source/stores.cpp:1000
 msgid "Leave Healer's home"
-msgstr "離開療養院"
+msgstr "離​開療​養院"
 
 #: Source/stores.cpp:1053
 msgid "The Town Elder"
-msgstr "鎮上的長老"
+msgstr "鎮​上​的​長​老"
 
 #: Source/stores.cpp:1055
 msgid "Talk to Cain"
-msgstr "和凱恩談談"
+msgstr "和​凱恩談談"
 
 #: Source/stores.cpp:1056
 msgid "Identify an item"
-msgstr "標識專案"
+msgstr "標​識​專案"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:1149
 msgid "You have nothing to identify.             Your gold: {:d}"
-msgstr "你沒什麼可指認的。你的金幣: {:d}"
+msgstr "你​沒什麼​可​指認​的​。​你​的​金幣​:​ {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:1164
 msgid "Identify which item?             Your gold: {:d}"
-msgstr "確定哪一項？你的金幣: {:d}"
+msgstr "確定​哪​一​項​？​你​的​金幣​:​ {:d}"
 
 #: Source/stores.cpp:1184
 msgid "This item is:"
-msgstr "此專案是: "
+msgstr "此​專案​是​: "
 
 #: Source/stores.cpp:1187
 msgid "Done"
@@ -7189,19 +7189,19 @@ msgstr "多恩"
 
 #: Source/stores.cpp:1196
 msgid "Talk to {:s}"
-msgstr "與{:s}交談"
+msgstr "與​{:s}​交談"
 
 #: Source/stores.cpp:1200
 msgid "Talking to {:s}"
-msgstr "與{:s}交談"
+msgstr "與​{:s}​交談"
 
 #: Source/stores.cpp:1202
 msgid "is not available"
-msgstr "不可用"
+msgstr "不​可​用"
 
 #: Source/stores.cpp:1203
 msgid "in the shareware"
-msgstr "在共享軟體中"
+msgstr "在​共​享軟​體​中"
 
 #: Source/stores.cpp:1204
 msgid "version"
@@ -7213,31 +7213,31 @@ msgstr "流言蜚語"
 
 #: Source/stores.cpp:1240
 msgid "Rising Sun"
-msgstr "日出"
+msgstr "日​出"
 
 #: Source/stores.cpp:1242
 msgid "Talk to Ogden"
-msgstr "與奧格登交談"
+msgstr "與​奧​格登​交談"
 
 #: Source/stores.cpp:1243
 msgid "Leave the tavern"
-msgstr "離開酒館"
+msgstr "離​開​酒館"
 
 #: Source/stores.cpp:1254
 msgid "Talk to Gillian"
-msgstr "和阿嬌談談"
+msgstr "和​阿嬌談​談"
 
 #: Source/stores.cpp:1264 Source/towners.cpp:212
 msgid "Farnham the Drunk"
-msgstr "醉漢法納姆"
+msgstr "醉​漢​法納​姆"
 
 #: Source/stores.cpp:1266
 msgid "Talk to Farnham"
-msgstr "和法納姆談談"
+msgstr "和​法納姆談談"
 
 #: Source/stores.cpp:1267
 msgid "Say Goodbye"
-msgstr "說再見"
+msgstr "說​再​見"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:15
@@ -7249,10 +7249,10 @@ msgid ""
 "men. Only the vilest powers of Hell could so utterly destroy a man from "
 "within..."
 msgstr ""
-"啊，我們國王的故事，是嗎？李奧瑞克的悲慘淪陷對這片土地是一個沉重的打擊。人民"
-"一直愛著國王，現在他們生活在對他的極度恐懼之中。我一直在問自己的問題是，他怎"
-"么會落在離光這麼遠的地方，因為李奧瑞克一直是最神聖的人。只有地獄中最邪惡的力"
-"量才能如此徹底地摧毀一個人"
+"啊​，​我​們​國王​的​故事​，​是​嗎​？​李奧瑞克​的​悲慘​淪​陷對​這片​土地​是​一​個​沉重​的​打擊​。​人民"
+"​一直​愛​著​國王​，​現​在​他​們​生活​在​對​他​的​極度​恐懼​之中​。​我​一直​在​問​自己​的​問題​是​，"
+"​他​怎么​會落​在​離光這​麼遠​的​地方​，​因​為​李奧瑞克​一直​是​最​神聖​的​人​。​只有​地​獄​中​最​邪惡"
+"​的​力量​才​能​如此​徹底​地摧毀​一​個​人"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:17
@@ -7275,18 +7275,18 @@ msgid ""
 "levels beneath the Cathedral. Please, good master, put his soul at ease by "
 "destroying his now cursed form..."
 msgstr ""
-"村裡需要你的幫助，好師傅！幾個月前，萊奧里克國王的兒子阿爾布雷希特王子被綁"
-"架。國王勃然大怒，在村子裡到處尋找他失蹤的孩子。日復一日，萊奧里克似乎陷入了"
-"更深的瘋狂之中。他試圖把男孩的失蹤歸咎於無辜的市民，並殘忍地處決了他們。只有"
-"不到一半的人從他的瘋狂中倖存下來。。。\n"
+"村​裡​需要​你​的​幫助​，​好師傅​！​幾​個​月​前​，​萊奧​里克國王​的​兒子​阿爾布雷希特​王子​被​綁架​。​國"
+"王勃然大怒​，​在​村子​裡​到​處尋​找​他​失蹤​的​孩子​。​日復​一​日​，​萊奧​里克​似乎​陷入​了​更​深​的​"
+"瘋狂​之中​。​他​試圖​把​男孩​的​失蹤歸咎於​無辜​的​市民​，​並殘​忍地處決​了​他​們​。​只​有​不到​一半​的"
+"​人從​他​的​瘋狂​中​倖存​下來​。​。​。​\n"
 " \n"
-"國王的騎士和牧師試圖安撫他，但他轉而反對他們，不幸的是，他們被迫殺了他。國王"
-"臨終前一口氣對他以前的追隨者下了一個可怕的詛咒。他發誓他們會永遠在黑暗中為他"
-"服務。。。\n"
+"國王​的​騎士​和​牧師試​圖安撫​他​，​但​他​轉​而​反對​他​們​，​不幸​的​是​，​他​們​被迫殺​了​他​。​國"
+"王臨終​前​一​口​氣對​他​以前​的​追隨者​下​了​一​個​可怕​的​詛咒​。​他​發誓​他​們會​永遠​在​黑暗中​為​"
+"他​服務​。​。​。​\n"
 " \n"
-"這是事情發生了比我想像的更黑暗的轉折！我們的前國王已經從永恒的睡眠中醒來，現"
-"在在迷宮中指揮著一支不死僕從軍團。他的屍體被埋在大教堂下面三層的墳墓里。求你"
-"了，好主人，通過摧毀他現在被詛咒的身體來讓他的靈魂放鬆"
+"這​是​事情​發生​了​比​我​想像​的​更​黑暗​的​轉折​！​我​們​的​前​國​王​已​經從​永恒​的​睡眠​中​醒來​"
+"，​現​在在​迷宮​中​指揮​著​一​支​不​死​僕從​軍團​。​他​的​屍體​被​埋​在​大​教堂​下面​三​層​的​墳​墓"
+"​里​。​求​你​了​，​好​主人​，​通過摧毀​他​現​在​被​詛咒​的​身體來讓​他​的​靈魂​放鬆"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:19
@@ -7295,8 +7295,8 @@ msgid ""
 "down there, waiting in the putrid darkness for his chance to destroy this "
 "land..."
 msgstr ""
-"正如我告訴你的，好主人，國王被埋葬在下面三層。他在下面，在腐朽的黑暗中等待著"
-"毀滅這片土地的機會"
+"正​如​我​告訴​你​的​，​好​主人​，​國王​被​埋葬​在​下面​三​層​。​他​在​下面​，​在​腐朽​的​黑暗​中​等"
+"待​著​毀滅​這片​土地​的​機會"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden (Quest End)
 #: Source/textdat.cpp:21
@@ -7306,9 +7306,9 @@ msgid ""
 "consumes our land, for your victory is a good omen. May Light guide you on "
 "your way, good master."
 msgstr ""
-"我們國王的詛咒已經過去了，但我擔心這只是更大的罪惡的一部分。然而，我們仍有可"
-"能從吞滅我們土地的黑暗中得救，因為你們的勝利是個好兆頭。愿光明指引你前進，好"
-"主人"
+"我​們​國王​的​詛咒​已​經過​去​了​，​但​我​擔心這​只是​更​大​的​罪惡​的​一​部分​。​然而​，​我​們​仍​"
+"有​可能​從吞滅​我​們​土地​的​黑暗中​得救​，​因​為​你​們​的​勝利​是​個好​兆頭​。​愿​光明​指引​你​前進​"
+"，​好​主人"
 
 #. TRANSLATORS: Quest dialog spoken by Pepin
 #: Source/textdat.cpp:23
@@ -7318,9 +7318,9 @@ msgid ""
 "this kingdom from that day forward, but perhaps if you were to free his "
 "spirit from his earthly prison, the curse would be lifted..."
 msgstr ""
-"失去兒子對李奧瑞克國王來說是太多了。我盡我所能減輕他的瘋狂，但最終還是戰勝了"
-"他。從那一天起，一個黑色的詛咒就籠罩著這個王國，但是如果你把他的靈魂從塵世的"
-"牢獄中釋放出來，詛咒就會解除"
+"失去​兒子對​李奧瑞克國王來說​是​太​多​了​。​我​盡​我​所​能​減輕​他​的​瘋狂​，​但​最​終還​是​戰勝​了​他"
+"​。​從​那​一​天​起​，​一​個​黑色​的​詛咒​就​籠罩​著​這個​王國​，​但是​如果​你​把​他​的​靈魂從​塵世​"
+"的​牢獄​中​釋​放出來​，​詛咒​就​會​解除"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:25
@@ -7329,8 +7329,8 @@ msgid ""
 "the kind and just ruler that he was. His death was so sad and seemed very "
 "wrong, somehow."
 msgstr ""
-"我不想去想國王是怎麼死的。我喜歡記住他的善良和公正的統治者，他是。他的死是如"
-"此悲傷，似乎非常錯誤，不知何故"
+"我​不​想​去​想​國​王​是​怎麼死​的​。​我​喜歡記​住​他​的​善良​和​公正​的​統治者​，​他​是​。​他​的​死"
+"​是​如此​悲傷​，​似乎​非常​錯誤​，​不​知​何​故"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:27
@@ -7340,9 +7340,9 @@ msgid ""
 "mithril for him, as well as a field crown to match. I still cannot believe "
 "how he died, but it must have been some sinister force that drove him insane!"
 msgstr ""
-"我做了很多武器和大部分護甲，國王李奧瑞克用來裝備他的騎士。我甚至為他製作了一"
-"把巨大的雙手劍，是最好的秘銀劍，還有一頂與之相配的戰地王冠。我仍然無法相信他"
-"是怎麼死的，但一定是某種邪惡的力量把他逼瘋了"
+"我​做​了​很多​武器​和​大部分​護甲​，​國王李奧瑞克​用​來裝備​他​的​騎士​。​我​甚至​為​他​製​作​了​一​把"
+"​巨大​的​雙手劍​，​是​最​好​的​秘銀劍​，​還​有​一​頂​與​之​相配​的​戰地​王冠​。​我​仍然​無法​相信​他"
+"​是​怎麼死​的​，​但​一定​是​某​種​邪惡​的​力量​把​他​逼瘋​了"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:29
@@ -7350,8 +7350,8 @@ msgid ""
 "I don't care about that. Listen, no skeleton is gonna be MY king. Leoric is "
 "King. King, so you hear me? HAIL TO THE KING!"
 msgstr ""
-"我才不管呢。聽著，沒有骷髏會是我的國王。利奧里克是國王。國王，你聽見了嗎？向"
-"國王致敬"
+"我​才​不管​呢​。​聽著​，​沒​有​骷髏會​是​我​的​國王​。​利奧里克​是​國王​。​國王​，​你​聽見​了​嗎​？​"
+"向​國王​致敬"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:31
@@ -7361,9 +7361,9 @@ msgid ""
 "you do not stop his reign, he will surely march across this land and slay "
 "all who still live here."
 msgstr ""
-"行在活人中間的死人，都跟隨被咒詛的王。他有能力為一支不斷壯大的不死軍團培養更"
-"多的戰士。如果你不停止他的統治，他一定會穿過這片土地，殺死所有仍然住在這裡的"
-"人"
+"行​在​活​人​中間​的​死人​，​都​跟​隨​被​咒詛​的​王​。​他​有​能力​為​一​支​不​斷壯​大​的​不​死軍​團"
+"​培養​更​多​的​戰士​。​如果​你​不​停止​他​的​統治​，​他​一定​會​穿過​這片​土地​，​殺死​所有​仍然​住​"
+"在​這裡​的​人"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:33
@@ -7373,15 +7373,15 @@ msgid ""
 "need something to use against this King of the undead, then I can help you "
 "out..."
 msgstr ""
-"聽著，我在這裡做生意。我不賣情報，我也不關心那些死得比我還久的國王。如果你需"
-"要什麼東西來對付不死之王，那麼我可以幫你"
+"聽​著​，​我​在​這裡​做​生意​。​我​不​賣情報​，​我​也​不​關心​那些​死得​比​我​還久​的​國王​。​如果​你"
+"​需要​什麼東​西來​對​付​不​死​之​王​，​那​麼​我​可以​幫​你"
 
 #. TRANSLATORS: Quest dialog spoken by The Skeleton King (Hostile)
 #: Source/textdat.cpp:35
 msgid ""
 "The warmth of life has entered my tomb. Prepare yourself, mortal, to serve "
 "my Master for eternity!"
-msgstr "生命的溫暖已經進入我的墳墓。準備好你自己，凡人，為我的主人服務到永遠"
+msgstr "生命​的​溫暖​已​經進入​我​的​墳​墓​。​準備​好​你​自己​，​凡​人​，​為​我​的​主人服務​到​永遠"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:37
@@ -7392,9 +7392,9 @@ msgid ""
 "led them to believe that it too holds some arcane powers. Hmm, perhaps they "
 "are not all as smart as we had feared..."
 msgstr ""
-"我知道這種奇怪的行為也讓你困惑。我猜想，既然許多惡魔害怕太陽光，相信它擁有巨"
-"大的力量，那可能是你所說的星座上描繪的旭日讓他們相信它也擁有一些神秘的力量。"
-"嗯，也許他們並不像我們擔心的那麼聰明"
+"我​知道​這種​奇怪​的​行為​也​讓​你​困惑​。​我​猜想​，​既然​許​多​惡​魔​害怕​太​陽光​，​相信​它​擁​有"
+"​巨大​的​力量​，​那​可能​是​你​所​說​的​星座​上​描繪​的​旭日​讓​他​們​相信​它​也​擁​有​一些​神秘​的"
+"​力量​。​嗯​，​也​許​他​們並​不​像​我​們​擔心​的​那​麼​聰明"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:39
@@ -7408,11 +7408,11 @@ msgid ""
 "the sign to my inn. I don't know why the demons would steal my sign but "
 "leave my family in peace... 'tis strange, no?"
 msgstr ""
-"師父，我有一個奇怪的經歷。我知道你對迷宮裡的怪物很瞭解，這是我一生都無法理解"
-"的。。。我在晚上被酒店外面的刮擦聲吵醒了。當我從臥室往外看的時候，我看到客棧"
-"院子里有一些像魔鬼一樣的小動物。過了一會兒，他們跑掉了，但還沒來得及把牌子偷"
-"到我的客棧。我不知道為什麼惡魔會偷走我的標誌，卻讓我的家人安然無恙……」很奇"
-"怪，不是嗎"
+"師父​，​我​有​一​個​奇怪​的​經歷​。​我​知道​你​對迷宮裡​的​怪物​很​瞭解​，​這​是​我​一​生​都​無法​理"
+"解​的​。​。​。​我​在​晚上​被​酒店​外面​的​刮擦聲​吵醒​了​。​當​我​從​臥室​往外​看​的​時候​，​我​看到"
+"​客棧​院子​里​有​一些​像​魔鬼​一​樣​的​小​動物​。​過​了​一​會兒​，​他​們​跑掉​了​，​但​還沒來​得​及"
+"​把​牌子​偷​到​我​的​客棧​。​我​不​知道​為​什麼​惡​魔會​偷走​我​的​標誌​，​卻讓​我​的​家人​安然​無恙"
+"​…​…​」​很​奇怪​，​不​是​嗎"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden (Quest End)
 #: Source/textdat.cpp:41
@@ -7423,9 +7423,10 @@ msgid ""
 "cap was left in one of the rooms by a magician who stayed here some time "
 "ago. Perhaps it may be of some value to you."
 msgstr ""
-"哦，你不必把我的牌子拿回來，但我想它確實可以幫我省下再做一個牌子的費用。好"
-"吧，讓我想想，我能給你什麼作為找到它的費用？嗯，我們這裡有什麼。。。啊，是"
-"的！這頂帽子是一個魔術師不久前留下來的，他把它放在一個房間里。也許對你有價值"
+"哦​，​你​不​必​把​我​的​牌子​拿回來​，​但​我​想​它​確實​可以​幫​我​省下​再​做​一​個​牌子​的​費用​。"
+"​好​吧​，​讓​我​想想​，​我​能​給​你​什麼​作​為​找到​它​的​費用​？​嗯​，​我​們這裡​有​什麼​。​。​。"
+"​啊​，​是​的​！​這頂​帽子​是​一​個​魔術​師​不久​前​留下​來​的​，​他​把​它​放​在​一​個​房間​里​。​"
+"也​許對​你​有​價值"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:43
@@ -7434,8 +7435,8 @@ msgid ""
 "- is nothing sacred? I hope that Ogden and Garda are all right. I suppose "
 "that they would come to see me if they were hurt..."
 msgstr ""
-"我的天哪，惡魔們晚上在村子裡到處亂跑，掠奪我們的家園——難道沒有什麼神聖的東西"
-"嗎？我希望奧格登和加爾達沒事。我想如果他們受傷了他們會來看我的"
+"我​的​天哪​，​惡魔們​晚上​在​村子​裡​到​處亂​跑​，​掠奪​我​們​的​家園​——​難道沒​有​什麼神聖​的​東西嗎"
+"​？​我​希望​奧格登​和​加爾達​沒​事​。​我​想​如果​他​們受傷​了​他​們會來​看​我​的"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:45
@@ -7443,8 +7444,7 @@ msgid ""
 "Oh my! Is that where the sign went? My Grandmother and I must have slept "
 "right through the whole thing. Thank the Light that those monsters didn't "
 "attack the inn."
-msgstr ""
-"天哪！標誌就在那裡嗎？我祖母和我一定一直都在睡覺。感謝那些怪物沒有攻擊客棧"
+msgstr "天​哪​！​標誌​就​在​那​裡嗎​？​我​祖母​和​我​一定​一直​都​在​睡覺​。​感謝​那些​怪物沒​有​攻擊客棧"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:47
@@ -7454,9 +7454,9 @@ msgid ""
 " \n"
 "Demons are concerned with ripping out your heart, not your signpost."
 msgstr ""
-"你說惡魔偷了奧格登的招牌？這聽起來不像我聽說過或見過的暴行。\n"
+"你​說惡​魔偷​了​奧格登​的​招牌​？​這聽​起來​不​像​我​聽說過​或​見過​的​暴行​。​\n"
 " \n"
-"惡魔關心的是撕碎你的心，而不是你的路標"
+"惡​魔關​心​的​是​撕碎​你​的​心​，​而​不​是​你​的​路標"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:49
@@ -7466,9 +7466,9 @@ msgid ""
 "new sign with some pretty drawing on it. Maybe a nice mug of ale or a piece "
 "of cheese..."
 msgstr ""
-"你知道我怎麼想嗎？有人拿了那個牌子，他們會想要很多錢的。如果我是奧格登。。。"
-"我不是，但如果我是。。。我想買一個新牌子，上面畫些漂亮的圖案。也許是一杯啤酒"
-"或者一塊奶酪"
+"你​知道​我​怎​麼​想​嗎​？​有​人​拿​了​那個​牌子​，​他​們會​想要​很多​錢​的​。​如果​我​是​奧格登​。​"
+"。​。​我​不​是​，​但​如果​我​是​。​。​。​我​想​買​一​個​新​牌子​，​上面​畫​些​漂亮​的​圖案​。​也​"
+"許​是​一​杯​啤酒​或者​一​塊​奶酪"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:51
@@ -7477,9 +7477,9 @@ msgid ""
 " \n"
 "Never let their erratic actions confuse you, as that too may be their plan."
 msgstr ""
-"沒有人能真正理解惡魔的思想。\n"
+"沒​有​人​能​真正​理解​惡魔​的​思想​。​\n"
 " \n"
-"永遠不要讓他們不穩定的行為迷惑你，因為那也可能是他們的計劃"
+"永遠​不​要​讓​他​們​不​穩定​的​行為​迷惑​你​，​因​為​那​也​可能​是​他​們​的​計劃"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:53
@@ -7490,9 +7490,9 @@ msgid ""
 "Look, I got over simple sign stealing months ago. You can't turn a profit on "
 "a piece of wood."
 msgstr ""
-"他是說我拿了那個？我想格里斯沃爾德也站在他這邊。\n"
+"他​是​說​我​拿​了​那個​？​我​想​格里斯沃​爾德​也​站​在​他​這邊​。​\n"
 " \n"
-"聽著，我幾個月前就忘了偷牌子了。你不能靠一塊木頭賺錢"
+"​聽​著​，​我​幾​個​月​前​就​忘​了​偷牌子​了​。​你​不​能​靠​一​塊木頭​賺錢"
 
 #. TRANSLATORS: Quest dialog spoken by Snotspill (Hostile)
 #: Source/textdat.cpp:55
@@ -7501,18 +7501,18 @@ msgid ""
 "no leave with life! You kill big uglies and give back Magic. Go past corner "
 "and door, find uglies. You give, you go!"
 msgstr ""
-"嘿-你就是那個殺人狂！你給我拿魔旗否則我們就進攻！你不能離開生命！你殺了大醜八"
-"怪還了魔法。穿過街角和門，找到醜陋的東西。你給，你走"
+"嘿​-​你​就​是​那​個殺​人狂​！​你​給​我​拿​魔旗​否則​我​們​就​進攻​！​你​不​能​離開​生命​！​你​殺​"
+"了​大醜​八怪還​了​魔法​。​穿過​街角​和​門​，​找到​醜陋​的​東西​。​你​給​，​你​走"
 
 #. TRANSLATORS: Quest dialog spoken by Snotspill (Hostile)
 #: Source/textdat.cpp:57
 msgid "You kill uglies, get banner. You bring to me, or else..."
-msgstr "你殺了醜八怪，得到橫幅。你給我帶來，否則"
+msgstr "你​殺​了​醜​八怪​，​得到​橫幅​。​你​給​我​帶來​，​否則"
 
 #. TRANSLATORS: Quest dialog spoken by Snotspill (Hostile)
 #: Source/textdat.cpp:59
 msgid "You give! Yes, good! Go now, we strong. We kill all with big Magic!"
-msgstr "你給我！是的，很好！走吧，我們堅強。我們用大魔法殺人"
+msgstr "你​給​我​！​是​的​，​很​好​！​走​吧​，​我​們​堅強​。​我​們​用​大​魔法​殺​人"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:61
@@ -7541,30 +7541,29 @@ msgid ""
 "You must hurry and save the prince from the sacrificial blade of this "
 "demented fiend!"
 msgstr ""
-"這不是好兆頭，因為它證實了我最黑暗的恐懼。雖然我不允許自己相信古老的傳說，但"
-"我現在不能否認它們。也許是時候揭露我是誰了。\n"
+"這​不​是​好​兆頭​，​因​為​它​證實​了​我​最​黑暗​的​恐懼​。​雖然​我​不​允許​自己​相信​古老​的​傳說​，"
+"​但​我​現​在​不​能否​認​它​們​。​也​許​是​時候​揭露​我​是​誰​了​。​\n"
 " \n"
-"我的真名是老凱恩，我是一個古老兄弟會的最後一個後代，這個兄弟會致力於保護一個"
-"永恒邪惡的秘密。一個很明顯已經被釋放的惡魔。\n"
+"​我​的​真名​是​老凱恩​，​我​是​一​個​古老​兄弟會​的​最後​一個​後​代​，​這個​兄弟​會​致力​於​保護​一​"
+"個​永恒​邪惡​的​秘密​。​一​個​很​明顯​已​經​被​釋放​的​惡魔​。​\n"
 " \n"
-"拉撒雷茲大主教曾經是萊奧里克國王最信任的顧問，他帶領一隊普通的市民進入迷宮，"
-"尋找國王失蹤的兒子阿爾布雷希特。過了很長一段時間他們才回來，只有少數人帶著生"
-"命逃走了。\n"
+"拉撒雷茲​大​主教​曾​經​是​萊奧​里克國王​最​信任​的​顧問​，​他​帶領​一​隊​普通​的​市民​進入​迷宮​，​尋​"
+"找​國​王失蹤​的​兒子​阿爾布雷希特​。​過​了​很​長​一​段​時間​他​們​才​回來​，​只有​少​數人​帶​著​生命​"
+"逃走​了​。​\n"
 " \n"
-"詛咒我是個傻瓜！我當時應該懷疑他暗中的背叛。一定是拉撒路自己綁架了阿爾佈雷希"
-"特，然後把他藏在迷宮裡。我不明白大主教為什麼轉向黑暗，或者他對這個孩子有什麼"
-"興趣，除非他打算把他獻給他的黑暗主人！\n"
+"​詛咒​我​是​個​傻瓜​！​我​當時應該​懷疑​他​暗中​的​背叛​。​一定​是​拉撒路​自己​綁架​了​阿爾佈​雷希特​，"
+"​然​後​把​他​藏​在​迷宮裡​。​我​不​明白​大​主教​為什麼轉​向​黑暗​，​或者​他​對這個​孩子​有​什麼​興趣​"
+"，​除非​他​打算​把​他​獻給​他​的​黑暗​主人​！​\n"
 " \n"
-"那一定是他的計劃！他的「救援隊」的倖存者說，拉撒路最後一次被看到跑進迷宮最深"
-"處。你必須趕快把王子從這個瘋狂惡魔的祭劍中救出來"
+"​那​一定​是​他​的​計劃​！​他​的​「​救援隊​」​的​倖存者​說​，​拉撒路​最後​一​次​被​看到​跑進迷宮​最​深"
+"​處​。​你​必須​趕​快​把​王子從​這個​瘋狂​惡魔​的​祭劍​中​救出​來"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:63
 msgid ""
 "You must hurry and rescue Albrecht from the hands of Lazarus. The prince and "
 "the people of this kingdom are counting on you!"
-msgstr ""
-"你必須趕快把阿爾布雷希特從拉撒路手中救出來。王子和這個王國的人民都指望著你"
+msgstr "你​必須​趕​快​把​阿爾布雷希特從拉撒路​手​中​救出來​。​王子​和​這個​王國​的​人民​都​指望​著​你"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:65
@@ -7580,13 +7579,13 @@ msgid ""
 "again sow chaos in the realm of mankind. You must venture through the portal "
 "and destroy Diablo before it is too late!"
 msgstr ""
-"你的故事很殘酷，我的朋友。拉撒路一定會因為他那可怕的行為在地獄裡被燒死。你描"
-"述的那個男孩不是我們的王子，但我相信阿爾布雷希特可能還處在危險之中。你所說的"
-"權力的象徵一定是迷宮中心的一個入口。\n"
+"你​的​故事​很​殘​酷​，​我​的​朋友​。​拉撒路​一定​會​因​為​他​那​可怕​的​行為​在地​獄裡​被​燒死​。​你"
+"​描述​的​那​個​男孩​不​是​我​們​的​王子​，​但​我​相信​阿爾布雷希特​可能​還處​在​危險​之中​。​你​所​說"
+"​的​權力​的​象徵​一定​是​迷宮​中心​的​一​個​入口​。​\n"
 " \n"
-"你要知道，我的朋友，你所反對的邪惡是恐怖的黑魔王。他被世人稱為迪亞波羅。幾個"
-"世紀前，正是他被囚禁在迷宮裡，我擔心他又一次企圖在人類的王國里製造混亂。你必"
-"須冒險穿過傳送門，在一切還不到時候摧毀迪亞波羅"
+"​你​要​知道​，​我​的​朋友​，​你​所​反對​的​邪惡​是​恐怖​的​黑魔王​。​他​被​世人​稱為​迪亞波羅​。​幾個"
+"世紀​前​，​正​是​他​被​囚禁​在​迷宮裡​，​我​擔心​他​又​一​次​企圖​在​人類​的​王國里​製造​混亂​。​你​"
+"必​須​冒險​穿過傳​送門​，​在​一切​還​不​到​時候摧毀迪亞波羅"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:67
@@ -7596,9 +7595,9 @@ msgid ""
 "suppose he was killed along with most of the others. If you would do me a "
 "favor, good master - please do not talk to Farnham about that day."
 msgstr ""
-"拉撒路是大主教，他帶領許多市民進入迷宮。那天我失去了很多好朋友，拉撒路再也沒"
-"有回來。我想他是和其他大多數人一起被殺的。如果你能幫我一個忙，好主人-請不要和"
-"法納姆談論那一天"
+"拉撒路​是​大主教​，​他​帶領​許​多​市民​進入​迷宮​。​那天​我​失去​了​很多​好​朋友​，​拉撒路​再​也​沒​有"
+"​回來​。​我​想​他​是​和​其他​大多​數​人​一起​被​殺​的​。​如果​你​能幫​我​一​個​忙​，​好​主人​-​請"
+"​不​要​和​法納​姆談論​那​一​天"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:71
@@ -7608,9 +7607,9 @@ msgid ""
 "that. He was an Archbishop, and always seemed to care so much for the "
 "townsfolk of Tristram. So many were injured, I could not save them all..."
 msgstr ""
-"當我聽說鎮上的人那天晚上打算幹什麼時，我很震驚。我想在所有人中，拉撒路應該更"
-"有理智。他是一位大主教，似乎總是那麼關心特里斯特拉姆的市民。這麼多人受傷，我"
-"救不了他們"
+"當​我​聽說鎮​上​的​人​那天​晚上​打算​幹什麼時​，​我​很​震驚​。​我​想​在​所有​人​中​，​拉撒路​應該​更​"
+"有​理智​。​他​是​一​位​大主教​，​似乎​總​是​那​麼​關​心​特里斯特拉姆​的​市民​。​這麼​多​人​受傷​，​我"
+"​救​不​了​他​們"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:73
@@ -7619,8 +7618,9 @@ msgid ""
 "mother's funeral, and was supportive of my grandmother and myself in a very "
 "troubled time. I pray every night that somehow, he is still alive and safe."
 msgstr ""
-"我記得拉撒路是一個非常和善和樂於奉獻的人。他在我母親的葬禮上發表了講話，在非"
-"常困難的時候支援我和我的祖母。我每晚都祈禱，不知何故，他還活著，安然無恙"
+"我​記​得​拉撒路​是​一​個​非常​和​善​和​樂於​奉獻​的​人​。​他​在​我​母親​的​葬禮​上​發表​了​講話​，​"
+"在​非常​困難​的​時候​支援​我​和​我​的​祖母​。​我​每​晚​都​祈禱​，​不​知​何故​，​他​還活著​，​安然​無"
+"恙"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:75
@@ -7630,9 +7630,9 @@ msgid ""
 "much as lift his mace against them. He just ran deeper into the dim, endless "
 "chambers that were filled with the servants of darkness!"
 msgstr ""
-"拉撒路領我們進迷宮的時候，我在那裡。他談到了神聖的報應，但當我們開始與那些地"
-"獄之子戰鬥時，他甚至沒有舉起他的狼牙棒來對付他們。他只不過是往黑暗的僕人們所"
-"住的昏暗無邊的房間里跑得更深"
+"拉撒路領​我​們​進迷宮​的​時候​，​我​在​那裡​。​他​談​到​了​神聖​的​報應​，​但​當​我​們開​始與​那些​地"
+"獄​之​子​戰鬥時​，​他​甚至​沒​有​舉起​他​的​狼牙棒來​對付​他​們​。​他​只不​過​是​往​黑暗​的​僕人們​所"
+"​住​的​昏暗​無邊​的​房間​里​跑​得​更​深"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:77
@@ -7641,8 +7641,9 @@ msgid ""
 "dead! Dead! Do you hear me? They just keep falling and falling... their "
 "blood spilling out all over the floor... all his fault..."
 msgstr ""
-"它們刺，然後咬，然後它們就在你周圍。說謊者！說謊者！他們都死了！死去的你聽見"
-"了嗎？他們只是不斷地跌倒。。。他們的血灑得滿地都是。。。全是他的錯"
+"它​們刺​，​然​後​咬​，​然​後​它​們​就​在​你​周圍​。​說謊者​！​說謊者​！​他​們​都​死​了​！​死去​的​"
+"你​聽見​了​嗎​？​他​們​只​是​不​斷​地​跌倒​。​。​。​他​們​的​血灑​得​滿​地​都​是​。​。​。​全​是​"
+"他​的​錯"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:79
@@ -7651,8 +7652,8 @@ msgid ""
 "conflict within his being. He poses a great danger, and will stop at nothing "
 "to serve the powers of darkness which have claimed him as theirs."
 msgstr ""
-"我不認識你們所說的拉撒路，但我確實感覺到他內心有很大的矛盾。他帶來了巨大的危"
-"險，他將不擇手段地為黑暗勢力服務，黑暗勢力將他視為他們的"
+"我​不​認識​你​們​所​說​的​拉撒路​，​但​我​確​實感覺​到​他​內​心有​很​大​的​矛盾​。​他​帶來​了​巨大​"
+"的​危險​，​他​將​不​擇​手段​地為​黑暗​勢力服務​，​黑暗​勢力將​他​視為​他​們​的"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:81
@@ -7661,8 +7662,8 @@ msgid ""
 "down there. Didn't help save my leg, did it? Look, I'll give you a free "
 "piece of advice. Ask Farnham, he was there."
 msgstr ""
-"是的，正義的拉撒路，他對那裡的怪物非常有效。沒救我的腿，是嗎？聽著，我給你一"
-"個免費的建議。問問法納姆，他在那兒"
+"是​的​，​正義​的​拉撒路​，​他​對​那​裡​的​怪物​非常​有效​。​沒救​我​的​腿​，​是​嗎​？​聽著​，​我​給"
+"​你​一​個​免費​的​建議​。​問問法納姆​，​他​在​那​兒"
 
 #. TRANSLATORS: Quest dialog spoken by Lazarus (Hostile)
 #: Source/textdat.cpp:83
@@ -7670,8 +7671,8 @@ msgid ""
 "Abandon your foolish quest. All that awaits you is the wrath of my Master! "
 "You are too late to save the child. Now you will join him in Hell!"
 msgstr ""
-"放棄你愚蠢的追求。等待你的只有我主人的憤怒！你來不及救孩子了。現在你要和他一"
-"起下地獄了"
+"放棄​你​愚蠢​的​追求​。​等待​你​的​只​有​我​主人​的​憤怒​！​你​來​不​及​救​孩子​了​。​現​在​你​要​"
+"和​他​一起​下地獄​了"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:86
@@ -7682,9 +7683,9 @@ msgid ""
 "the same. Unfortunately, I do not know what would cause our water supply to "
 "be tainted."
 msgstr ""
-"嗯，我不知道我能告訴你些什麼對你有幫助。充滿我們水井的水來自地下泉水。我聽說"
-"過一條通往大湖的隧道——也許它們是同一條。不幸的是，我不知道什麼會導致我們的供"
-"水受到污染"
+"嗯​，​我​不​知道​我​能​告訴​你​些​什麼對​你​有​幫助​。​充滿​我​們​水​井​的​水來​自​地下泉水​。​我​聽"
+"說​過​一​條​通往​大​湖​的​隧道​——​也​許​它​們​是​同​一​條​。​不幸​的​是​，​我​不​知道​什麼會​導致"
+"​我​們​的​供水​受到​污染"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:88
@@ -7695,10 +7696,10 @@ msgid ""
 " \n"
 "Please, do what you can or I don't know what we will do."
 msgstr ""
-"我一直試圖在我們的儲藏室裡儲存大量的食品和飲料，但由於全鎮沒有淡水供應，即使"
-"是我們的商店也很快就會乾涸。\n"
+"我​一直​試圖​在​我​們​的​儲藏室​裡​儲存​大量​的​食品​和​飲料​，​但​由於​全​鎮沒​有​淡水​供應​，​即使​"
+"是​我​們​的​商店​也​很​快​就​會​乾涸​。​\n"
 " \n"
-"拜託，做你能做的，否則我不知道我們會做什麼"
+"拜託​，​做​你​能​做​的​，​否則​我​不​知道​我​們會​做​什麼"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:90
@@ -7709,9 +7710,9 @@ msgid ""
 "passage that leads to the springs that serve our town. Please find what has "
 "caused this calamity, or we all will surely perish."
 msgstr ""
-"很高興我及時趕上了你！我們的水井變得微咸、死氣沉沉，一些城裡人喝得不好。我們"
-"儲備的淡水很快就乾涸了。我相信有一條通道通向為我們城鎮服務的泉水。請找出造成"
-"這場災難的原因，否則我們都將滅亡"
+"很​高​興​我​及​時趕​上​了​你​！​我​們​的​水井變​得​微咸​、​死氣​沉沉​，​一些​城裡人​喝​得​不​好​。​"
+"我​們​儲備​的​淡水​很​快​就​乾涸​了​。​我​相信​有​一​條​通道​通向​為​我​們城鎮服務​的​泉水​。​請​找出"
+"​造成​這場​災難​的​原因​，​否則​我​們​都​將滅亡"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:92
@@ -7721,9 +7722,9 @@ msgid ""
 " \n"
 "We cannot survive for long without your help."
 msgstr ""
-"拜託，你必須快點。每過一個小時，我們就更接近沒有水喝了。\n"
+"拜託​，​你​必須​快點​。​每​過​一​個​小​時​，​我​們​就​更​接近​沒​有​水​喝​了​。​\n"
 " \n"
-"沒有你的幫助，我們活不了多久"
+"沒​有​你​的​幫助​，​我​們​活​不​了​多久"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:94
@@ -7733,16 +7734,16 @@ msgid ""
 "perseverance and courage gives us hope. Please take this ring - perhaps it "
 "will aid you in the destruction of such vile creatures."
 msgstr ""
-"你說什麼？僅僅是惡魔的存在就導致了水被污染了？哦，我們鎮下確實隱藏著一個巨大"
-"的惡魔，但你的毅力和勇氣給了我們希望。請收下這枚戒指——也許它能幫助你消滅這些"
-"邪惡的生物"
+"你​說什麼​？​僅僅​是​惡魔​的​存在​就​導致​了​水​被​污染​了​？​哦​，​我​們鎮​下​確實​隱​藏​著​一​個​"
+"巨大​的​惡魔​，​但​你​的​毅力​和​勇氣給​了​我​們​希望​。​請收​下​這​枚​戒指​——​也​許​它​能​幫助​你"
+"​消滅​這​些​邪惡​的​生物"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:96
 msgid ""
 "My grandmother is very weak, and Garda says that we cannot drink the water "
 "from the wells. Please, can you do something to help us?"
-msgstr "我祖母很虛弱，嘉達說我們不能喝井水。拜託，你能幫點忙嗎"
+msgstr "我​祖母​很​虛弱​，​嘉達說​我​們​不​能​喝​井​水​。​拜託​，​你​能幫​點​忙嗎"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:98
@@ -7751,13 +7752,13 @@ msgid ""
 "have tried to clear one of the smaller wells, but it reeks of stagnant "
 "filth. It must be getting clogged at the source."
 msgstr ""
-"佩平告訴了你真相。我們很快就會急需淡水。我試過清理其中一口小井，但它散發著死"
-"水的臭味。一定是源頭堵塞了"
+"佩平告訴​了​你​真相​。​我​們​很​快​就​會​急​需​淡水​。​我​試過​清理​其中​一​口​小​井​，​但​它​散發​"
+"著​死​水​的​臭味​。​一定​是​源頭​堵塞​了"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:100
 msgid "You drink water?"
-msgstr "你喝水嗎"
+msgstr "你​喝​水嗎"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:101
@@ -7768,9 +7769,9 @@ msgid ""
 "Know this - demons are at the heart of this matter, but they remain ignorant "
 "of what they have spawned."
 msgstr ""
-"如果你不能恢復井中的淡水，崔斯特瑞姆人就會死。\n"
+"如果​你​不​能​恢復​井​中​的​淡水​，​崔斯特瑞姆人​就​會死​。​\n"
 " \n"
-"知道這一點-惡魔是這件事的核心，但他們仍然不知道他們產生了什麼"
+"​知道​這​一​點​-​惡魔​是​這件​事​的​核心​，​但​他​們​仍然​不​知道​他​們產生​了​什麼"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:103
@@ -7778,8 +7779,8 @@ msgid ""
 "For once, I'm with you. My business runs dry - so to speak - if I have no "
 "market to sell to. You better find out what is going on, and soon!"
 msgstr ""
-"這一次，我和你在一起。可以說，如果我沒有銷路的話，我的生意就完了。你最好儘快"
-"弄清楚發生了什麼事"
+"這​一​次​，​我​和​你​在一起​。​可以​說​，​如果​我​沒​有​銷路​的​話​，​我​的​生意​就​完​了​。​你​最"
+"好​儘快​弄清楚​發生​了​什麼​事"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:105
@@ -7791,30 +7792,30 @@ msgid ""
 "the attempt to steal that treasure would be forever bound to defend it. A "
 "twisted, but strangely fitting, end?"
 msgstr ""
-"一本關於藏骨密室的書？嗯，我在東方圖書館研究過的一些古代著作中提到了骨室。這"
-"些大部頭書推斷，當地下世界的領主想要保護巨大的寶藏時，他們會建立領地，讓那些"
-"在試圖竊取寶藏時死去的人永遠有義務保衛寶藏。一個扭曲的，但奇怪的適合，結束"
+"一​本​關於​藏骨密室​的​書​？​嗯​，​我​在​東方圖書館​研究過​的​一些​古代​著作​中​提到​了​骨室​。​這​些​"
+"大部​頭書​推斷​，​當​地下​世界​的​領主​想要​保護​巨大​的​寶藏時​，​他​們會​建立​領地​，​讓​那些​在​試圖"
+"​竊取寶​藏時死去​的​人永遠​有​義務​保衛​寶藏​。​一​個​扭曲​的​，​但​奇怪​的​適合​，​結束"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:107
 msgid ""
 "I am afraid that I don't know anything about that, good master. Cain has "
 "many books that may be of some help."
-msgstr "恐怕我對此一無所知，好師傅。凱恩有許多書可能對他有所幫助"
+msgstr "恐怕​我​對​此​一​無​所​知​，​好​師傅​。​凱恩​有​許​多​書​可能​對​他​有所​幫助"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:109
 msgid ""
 "This sounds like a very dangerous place. If you venture there, please take "
 "great care."
-msgstr "這聽起來是個非常危險的地方。如果你在那裡冒險，請小心"
+msgstr "這​聽起來​是​個​非常​危險​的​地方​。​如果​你​在​那裡​冒險​，​請​小心"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:111
 msgid ""
 "I am afraid that I haven't heard anything about that. Perhaps Cain the "
 "Storyteller could be of some help."
-msgstr "恐怕我什麼也沒聽說過。說書人凱恩也許能幫上忙"
+msgstr "恐怕​我​什麼​也​沒聽​說過​。​說書人​凱恩​也​許能​幫​上​忙"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:113
@@ -7823,8 +7824,8 @@ msgid ""
 "many things, and it would not surprise me if he had some answers to your "
 "question."
 msgstr ""
-"我對這地方一無所知，不過你可以問問凱恩。他談了很多事情，如果他能回答你的問"
-"題，我也不會感到驚訝"
+"我​對這​地方​一​無​所​知​，​不​過​你​可以​問問​凱恩​。​他​談​了​很多​事情​，​如果​他​能​回答​你​的​"
+"問題​，​我​也​不​會​感到​驚訝"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:115
@@ -7833,8 +7834,8 @@ msgid ""
 "her - tells the tree... cause you gotta wait. Then I says, that might work "
 "against him, but if you think I'm gonna PAY for this... you... uh... yeah."
 msgstr ""
-"好吧，聽著。有一間木屋，你看。他的妻子告訴樹。。。因為你得等。然後我說，這可"
-"能對他不利，但如果你認為我會為此付出代價。。。你。。。UH是的"
+"好​吧​，​聽著​。​有​一​間​木屋​，​你​看​。​他​的​妻子​告訴樹​。​。​。​因為​你​得​等​。​然​後​我​說"
+"​，​這​可能​對​他​不利​，​但​如果​你​認為​我​會​為​此​付出​代價​。​。​。​你​。​。​。​UH​是​的"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:117
@@ -7844,9 +7845,9 @@ msgid ""
 " \n"
 "Enter the Chamber of Bone at your own peril."
 msgstr ""
-"如果你死在這個被詛咒的領域裡，你將成為黑暗領主的永恒僕人。\n"
+"如果​你​死​在​這個​被​詛咒​的​領域裡​，​你​將成為​黑暗​領主​的​永恒​僕​人​。​\n"
 " \n"
-"進入骨室的風險由你自己承擔"
+"​進入骨室​的​風險​由​你​自己​承擔"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:119
@@ -7855,8 +7856,8 @@ msgid ""
 "picking up a few things from you... or better yet, don't you need some rare "
 "and expensive supplies to get you through this ordeal?"
 msgstr ""
-"你說是一個巨大而神秘的寶藏？也許我有興趣從你那裡得到一些東西。。。或者更好的"
-"是，你不需要一些稀有而昂貴的物資來度過這場磨難嗎"
+"你​說​是​一​個​巨大​而​神秘​的​寶藏​？​也​許​我​有​興趣從​你​那​裡​得到​一些​東西​。​。​。​或者​更​"
+"好​的​是​，​你​不​需要​一些​稀有​而​昂貴​的​物資​來度​過這​場​磨難嗎"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:121
@@ -7867,17 +7868,16 @@ msgid ""
 "for what lay within the cold earth... Lazarus abandoned them down there - "
 "left in the clutches of unspeakable horrors - to die."
 msgstr ""
-"似乎拉撒路大主教慫恿許多市民冒險進入迷宮尋找國王失蹤的兒子。他利用他們的恐"
-"懼，把他們鞭打成一群瘋狂的暴徒。他們中沒有一個人準備好面對冰冷的地球上的一"
-"切。。。拉撒路把他們丟在那裡，丟在難以形容的恐懼魔爪里，等死"
+"似乎​拉撒路​大​主教​慫恿許​多​市民​冒險進​入​迷宮尋​找​國​王失蹤​的​兒子​。​他​利用​他​們​的​恐懼​，​把"
+"​他​們鞭​打​成​一​群​瘋狂​的​暴徒​。​他​們​中​沒​有​一​個人準備​好​面對​冰冷​的​地球​上​的​一切​。​"
+"。​。​拉撒路​把​他​們丟​在​那裡​，​丟​在​難​以​形容​的​恐懼​魔爪​里​，​等​死"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:123
 msgid ""
 "Yes, Farnham has mumbled something about a hulking brute who wielded a "
 "fierce weapon. I believe he called him a butcher."
-msgstr ""
-"是的，法納姆喃喃地說了一些關於一個笨重的畜生揮舞著兇器的事。我相信他叫他屠夫"
+msgstr "是​的​，​法納姆喃喃​地說​了​一些​關​於​一​個​笨重​的​畜生​揮​舞著​兇器​的​事​。​我​相信​他​叫​他​屠夫"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:125
@@ -7889,10 +7889,10 @@ msgid ""
 "festering with disease and even I found them almost impossible to treat. "
 "Beware if you plan to battle this fiend..."
 msgstr ""
-"藉著光明，我知道這個邪惡的惡魔。當拉撒路率領的少數幾名衝鋒倖存者從大教堂爬出"
-"來時，許多人身上留下了他憤怒的傷疤。我不知道他以前是怎麼切開受害者的，但這不"
-"可能是這個世界的。它留下的傷口潰爛與疾病，甚至我發現他們幾乎不可能治療。如果"
-"你打算和這個惡魔戰鬥，要小心"
+"藉​著​光明​，​我​知道​這個​邪惡​的​惡魔​。​當拉撒路率領​的​少數​幾名衝鋒倖​存者​從大​教堂​爬出來時​，​許多"
+"​人​身​上​留下​了​他​憤怒​的​傷疤​。​我​不​知道​他​以前​是​怎麼​切開​受害者​的​，​但​這​不​可能​是​"
+"這個​世界​的​。​它​留下​的​傷口潰爛與​疾病​，​甚至​我​發現​他​們​幾乎​不​可能​治療​。​如果​你​打算​和​"
+"這個​惡​魔戰​鬥​，​要​小心"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:127
@@ -7900,7 +7900,7 @@ msgid ""
 "When Farnham said something about a butcher killing people, I immediately "
 "discounted it. But since you brought it up, maybe it is true."
 msgstr ""
-"當法納姆說起屠夫殺人的事時，我立刻打消了這個念頭。但既然是你提出來的，也許是"
+"當​法納姆說​起​屠夫殺人​的​事時​，​我​立刻​打消​了​這個​念頭​。​但​既然​是​你​提出​來​的​，​也​許​是​"
 "真的"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
@@ -7913,10 +7913,10 @@ msgid ""
 "I never saw that hideous beast again, but his blood-stained visage haunts me "
 "to this day."
 msgstr ""
-"我看到法納姆所說的屠夫在我朋友的屍體上劃出一條小路。他揮舞著一把斧頭般大的砍"
-"刀，砍斷四肢，砍倒站在那裡的勇士。我被一群尖叫著的小惡魔從紛爭中分離出來，不"
-"知怎的我找到了通向外面的樓梯。我再也沒見過那可怕的野獸，但他那血跡斑斑的面容"
-"至今縈繞在我心頭"
+"我​看到​法納姆所說​的​屠夫​在​我​朋友​的​屍體​上​劃​出​一​條​小​路​。​他​揮​舞​著​一​把​斧頭​般​大​"
+"的​砍​刀​，​砍​斷​四肢​，​砍​倒​站​在​那裡​的​勇士​。​我​被​一​群​尖叫​著​的​小​惡​魔從​紛爭​中​分"
+"離出來​，​不​知​怎​的​我​找到​了​通向​外面​的​樓梯​。​我​再​也​沒見​過​那​可怕​的​野獸​，​但​他​那​"
+"血跡​斑斑​的​面容​至今​縈繞​在​我​心頭"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham (*sad face*)
 #: Source/textdat.cpp:131
@@ -7925,8 +7925,8 @@ msgid ""
 "couldn't save them. Trapped in a room with so many bodies... so many "
 "friends... NOOOOOOOOOO!"
 msgstr ""
-"大的大砍刀殺了我所有的朋友。阻止不了他，不得不逃跑，救不了他們。被困在一個有"
-"這麼多屍體的房間里。。。這麼多朋友。。。不，不"
+"大​的​大​砍​刀​殺​了​我​所有​的​朋友​。​阻止​不​了​他​，​不得不​逃跑​，​救​不​了​他​們​。​被困​在​"
+"一​個​有​這麼​多​屍體​的​房間​里​。​。​。​這麼​多​朋友​。​。​。​不​，​不"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:133
@@ -7935,8 +7935,8 @@ msgid ""
 "others. You have seen his handiwork in the drunkard Farnham. His destruction "
 "will do much to ensure the safety of this village."
 msgstr ""
-"屠夫是個虐待狂，喜歡別人的折磨和痛苦。你見過他在酒鬼法納姆的作品。他的毀滅將"
-"對確保這個村莊的安全大有幫助"
+"屠夫​是​個虐待​狂​，​喜​歡​別​人​的​折磨​和​痛苦​。​你​見過​他​在​酒​鬼法納姆​的​作品​。​他​的​毀滅將"
+"對​確​保這個​村莊​的​安全​大​有​幫助"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:135
@@ -7948,10 +7948,10 @@ msgid ""
 "I'll put it bluntly - kill him before he kills you and adds your corpse to "
 "his collection."
 msgstr ""
-"我知道的比你想的還要多。他的小朋友們抓住了我，設法在格里斯沃爾德把我從洞里拉"
-"出來之前抓住了我的腿。\n"
+"我​知道​的​比​你​想​的​還​要​多​。​他​的​小朋友​們​抓住​了​我​，​設法​在​格里斯沃​爾德​把​我​從洞​里"
+"拉​出來​之前​抓住​了​我​的​腿​。​\n"
 " \n"
-"我直截了當地說——在他殺了你並把你的屍體加入他的收藏之前殺了他"
+"​我​直截​了​當​地說​——​在​他​殺​了​你​並​把​你​的​屍體​加入​他​的​收藏​之前​殺​了​他"
 
 #. TRANSLATORS: Quest dialog spoken by Wounded Townsman (Dying)
 #: Source/textdat.cpp:137
@@ -7961,9 +7961,9 @@ msgid ""
 "killed by a demon he called the Butcher. Avenge us! Find this Butcher and "
 "slay him so that our souls may finally rest..."
 msgstr ""
-"請聽我說。拉撒路大主教，他帶我們到這裡來尋找失蹤的王子。那混蛋把我們引入陷"
-"阱！現在每個人都死了。。。被一個叫屠夫的惡魔殺死。為我們報仇！找到這個屠夫，"
-"殺了他，讓我們的靈魂最終安息"
+"請聽​我​說​。​拉撒路​大​主教​，​他​帶​我​們​到​這裡​來尋​找​失蹤​的​王子​。​那​混蛋​把​我​們​引入​陷"
+"阱​！​現​在​每​個​人​都​死​了​。​。​。​被​一​個​叫​屠夫​的​惡魔​殺死​。​為​我​們報仇​！​找到​這個​"
+"屠夫​，​殺​了​他​，​讓​我​們​的​靈魂​最​終​安息"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:140
@@ -7976,12 +7976,12 @@ msgid ""
 "sightless for all eternity. The prison for those so damned is named the "
 "Halls of the Blind..."
 msgstr ""
-"你背誦了一首有趣的韻文，它的風格讓我想起了其他的作品。現在讓我想想-那是什"
-"么？\n"
+"你​背誦​了​一​首​有趣​的​韻文​，​它​的​風格讓​我​想起​了​其他​的​作品​。​現​在​讓​我​想想​-​那​是​"
+"什么​？​\n"
 " \n"
-"…黑暗籠罩著隱藏的世界。眼睛在看不見的地方閃閃發光，只有剃刀爪子的聲音在短暫地"
-"刮來刮去，折磨那些永遠失明的可憐的靈魂。為那些該死的人而設的監獄被命名為盲人"
-"的大廳"
+"​…​黑暗​籠罩​著​隱藏​的​世界​。​眼睛​在​看​不​見​的​地方​閃閃​發光​，​只有​剃刀​爪子​的​聲音​在​短暫"
+"​地​刮來​刮去​，​折磨​那些​永遠失明​的​可憐​的​靈魂​。​為​那些​該死​的​人​而​設​的​監獄​被​命名​為盲人"
+"​的​大廳"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:142
@@ -7991,10 +7991,10 @@ msgid ""
 " \n"
 "What? Oh, yes... uh, well, I suppose you could see what someone else knows."
 msgstr ""
-"我從不太喜歡詩歌。偶爾，當旅店經營得很好的時候，我有理由僱傭吟遊詩人，但那似"
-"乎是很久以前的事了。\n"
+"我​從​不​太​喜​歡​詩歌​。​偶爾​，​當​旅店​經​營​得​很​好​的​時候​，​我​有​理由​僱​傭吟遊​詩人​，​但"
+"​那​似乎​是​很​久​以前​的​事​了​。​\n"
 " \n"
-"什麼？哦，是的。。。呃，好吧，我想你可以看看別人知道什麼"
+"什麼​？​哦​，​是​的​。​。​。​呃​，​好​吧​，​我​想​你​可以​看看​別人​知道​什麼"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:144
@@ -8003,8 +8003,8 @@ msgid ""
 "much like that poem while researching the history of demonic afflictions. It "
 "spoke of a place of great evil that... wait - you're not going there are you?"
 msgstr ""
-"不知怎麼的，這似乎很熟悉。我似乎記得在研究惡魔痛苦的歷史時讀過類似這首詩的東"
-"西。它講述了一個邪惡的地方。。。等等-你不會去的，是嗎"
+"不​知​怎麼​的​，​這​似乎​很​熟悉​。​我​似乎​記​得​在​研究​惡魔​痛苦​的​歷史時讀過​類​似​這​首​詩​的​"
+"東西​。​它​講述​了​一​個​邪惡​的​地方​。​。​。​等等​-​你​不​會去​的​，​是​嗎"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:146
@@ -8013,8 +8013,8 @@ msgid ""
 "he gave my grandmother a potion that helped clear her vision, so maybe he "
 "can help you, too."
 msgstr ""
-"如果你對失明有疑問，你應該和佩平談談。我知道他給了我祖母一種藥水，幫助她消除"
-"視力，所以也許他也能幫你"
+"如果​你​對失明有​疑問​，​你​應該​和​佩平談談​。​我​知道​他​給​了​我​祖母​一​種​藥​水​，​幫助​她​消除​"
+"視力​，​所以​也​許​他​也​能​幫​你"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:148
@@ -8023,13 +8023,13 @@ msgid ""
 "vivid description, my friend. Perhaps Cain the Storyteller could be of some "
 "help."
 msgstr ""
-"恐怕我既沒聽說過也沒見過一個地方與你生動的描述相符，我的朋友。說書人凱恩也許"
-"能幫上忙"
+"恐怕​我​既​沒​聽說過​也​沒見過​一​個​地方​與​你​生動​的​描述​相符​，​我​的​朋友​。​說書人​凱恩​也​許能"
+"​幫​上​忙"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:150
 msgid "Look here... that's pretty funny, huh? Get it? Blind - look here?"
-msgstr "看這裡。。。很有趣吧？瞭解了？瞎子-看這裡"
+msgstr "看​這裡​。​。​。​很​有趣​吧​？​瞭解​了​？​瞎子​-​看這裡"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:152
@@ -8040,9 +8040,9 @@ msgid ""
 "Tread carefully or you may yourself be staying much longer than you had "
 "anticipated."
 msgstr ""
-"這是一個極度痛苦和恐怖的地方，因此很好地為主人服務。\n"
+"這​是​一​個​極度​痛苦​和​恐怖​的​地方​，​因此​很​好​地​為​主人​服務​。​\n"
 " \n"
-"小心踩，否則你可能會比你預期的呆得久"
+"​小心​踩​，​否則​你​可能​會​比​你​預期​的​呆​得​久"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:154
@@ -8051,8 +8051,8 @@ msgid ""
 "you about this? No. Are you now leaving and going to talk to the storyteller "
 "who lives for this kind of thing? Yes."
 msgstr ""
-"讓我想想，我是不是在賣東西給你？不，你是在給我錢告訴你這件事嗎？不，你現在要"
-"走了，去和為這種事活著的說書人談談嗎？是的"
+"讓​我​想想​，​我​是​不​是​在​賣東​西給​你​？​不​，​你​是​在​給​我​錢告訴​你​這件​事​嗎​？​不​，​你"
+"​現​在​要​走​了​，​去​和​為這​種​事活​著​的​說書人談談嗎​？​是​的"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:156
@@ -8066,19 +8066,18 @@ msgid ""
 "suppose that your story could be true. If I were in your place, my friend, I "
 "would find a way to release him from his torture."
 msgstr ""
-"你聲稱和拉赫達南談過？他一生是個偉大的英雄。拉赫達南是一個光榮而公正的人，多"
-"年來一直忠實地為國王服務。當然，你已經知道了。\n"
+"你​聲稱​和​拉赫​達南談過​？​他​一生​是​個偉​大​的​英雄​。​拉赫​達​南​是​一​個光榮​而​公正​的​人​，​多"
+"​年​來​一直​忠實​地​為國​王服務​。​當然​，​你​已​經​知道​了​。​\n"
 " \n"
-"在那些被國王詛咒的人中，拉赫達南最不可能不戰而屈身於黑暗，所以我想你的故事可"
-"能是真的。如果我在你的位置，我的朋友，我會想辦法把他從折磨中釋放出來"
+"​在​那些​被​國王詛咒​的​人​中​，​拉赫​達南​最​不​可能​不​戰​而​屈身​於​黑暗​，​所以​我​想​你​的​故事"
+"​可能​是​真的​。​如果​我​在​你​的​位置​，​我​的​朋友​，​我​會​想​辦法​把​他​從折磨​中​釋​放出​來"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:158
 msgid ""
 "You speak of a brave warrior long dead! I'll have no such talk of speaking "
 "with departed souls in my inn yard, thank you very much."
-msgstr ""
-"你說的是一個死了很久的勇士！我不想在客棧院子里和死去的靈魂說話，非常感謝"
+msgstr "你​說​的​是​一​個​死​了​很​久​的​勇士​！​我​不​想​在​客棧​院子​里​和​死去​的​靈魂​說話​，​非常​感謝"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:160
@@ -8088,16 +8087,16 @@ msgid ""
 "drink it. As your healer, I strongly advise that should you find such an "
 "elixir, do as Lachdanan asks and DO NOT try to use it."
 msgstr ""
-"你說是金丹。我從來沒有調製過那種顏色的藥水，所以我不能告訴你如果你試著喝它會"
-"有什麼影響。作為你的治療者，我強烈建議，如果你找到這樣一種長生不老藥，按照拉"
-"赫達南的要求去做，不要試圖使用它"
+"你​說​是​金丹​。​我​從來沒​有​調製過​那​種​顏色​的​藥水​，​所以​我​不​能​告訴​你​如果​你​試​著​喝​它"
+"​會​有​什麼​影響​。​作為​你​的​治療​者​，​我​強烈​建議​，​如果​你​找到​這樣​一​種​長生不老藥​，​按照​"
+"拉赫​達南​的​要求​去​做​，​不​要​試圖​使用​它"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:162
 msgid ""
 "I've never heard of a Lachdanan before. I'm sorry, but I don't think that I "
 "can be of much help to you."
-msgstr "我以前從沒聽說過拉赫達南。對不起，我想我幫不了你什麼忙"
+msgstr "我​以前​從沒聽說過​拉赫​達南​。​對​不​起​，​我​想​我​幫​不​了​你​什麼​忙"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:164
@@ -8107,8 +8106,8 @@ msgid ""
 "and loyal in nature. The curse that fell upon the followers of King Leoric "
 "would fall especially hard upon him."
 msgstr ""
-"如果你遇到的是拉赫達南，那麼我建議你幫助他。我和他打過幾次交道，發現他生性誠"
-"實忠誠。落在國王李奧瑞克的追隨者身上的詛咒尤其會落在他身上"
+"如果​你​遇到​的​是​拉赫​達南​，​那​麼​我​建​議​你​幫助​他​。​我​和​他​打過​幾​次​交道​，​發現​他​生"
+"性​誠實忠誠​。​落​在​國王李奧瑞克​的​追隨者​身​上​的​詛咒​尤其​會落​在​他​身​上"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:166
@@ -8116,8 +8115,8 @@ msgid ""
 " Lachdanan is dead. Everybody knows that, and you can't fool me into "
 "thinking any other way. You can't talk to the dead. I know!"
 msgstr ""
-"拉赫達南死了。每個人都知道這一點，你不能騙我去想別的。你不能和死人說話。我知"
-"道"
+"拉赫達​南死​了​。​每​個​人​都​知道​這​一​點​，​你​不​能​騙​我​去​想​別​的​。​你​不​能​和​死人​說話"
+"​。​我​知道"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:168
@@ -8127,9 +8126,9 @@ msgid ""
 " \n"
 "I sense in him honor and great guilt. Aid him, and you aid all of Tristram."
 msgstr ""
-"你可能會遇到被困在迷宮裡的人，比如拉赫達南。\n"
+"你​可能​會​遇到​被困​在​迷宮裡​的​人​，​比如​拉赫​達南​。​\n"
 " \n"
-"我從他身上感受到榮譽和巨大的內疚。幫幫他，你就幫幫崔斯特瑞姆"
+"​我​從​他​身​上​感受​到​榮譽​和​巨大​的​內疚​。​幫幫​他​，​你​就​幫幫​崔斯特瑞姆"
 
 #. TRANSLATORS: Quest dialog spoken by  Wirt
 #: Source/textdat.cpp:170
@@ -8139,9 +8138,9 @@ msgid ""
 "questions anymore. Oh, that isn't what happened? Then I guess you'll be "
 "buying something or you'll be on your way."
 msgstr ""
-"等等，讓我猜猜。凱恩被一條巨大的裂縫吞沒了，裂縫在他下面張開。他在地獄之火中"
-"被燒死了，再也回答不了你的問題了。哦，不是這樣嗎？那我猜你要買點東西了，要不"
-"就上路了"
+"等等​，​讓​我​猜猜​。​凱恩​被​一​條​巨大​的​裂縫​吞沒​了​，​裂縫​在​他​下面​張開​。​他​在​地獄​之​火"
+"​中​被​燒死​了​，​再​也​回答​不​了​你​的​問題​了​。​哦​，​不​是​這樣嗎​？​那​我​猜​你​要​買點​東西"
+"​了​，​要​不​就​上路​了"
 
 #. TRANSLATORS: Quest dialog spoken by Lachdanan (in despair)
 #: Source/textdat.cpp:172
@@ -8158,21 +8157,21 @@ msgid ""
 "it the last of my humanity as well. Please aid me and find the Elixir. I "
 "will repay your efforts - I swear upon my honor."
 msgstr ""
-"拜託，別殺我，聽我說完。我曾經是萊奧里克國王騎士團的隊長，以正義和榮譽維護這"
-"片土地的法律。然後他的黑暗詛咒降臨在我們身上，因為我們在他悲慘的死亡中扮演了"
-"角色。當我的騎士同伴們屈服於他們扭曲的命運時，我逃離了國王的墓室，尋找某種方"
-"法來擺脫詛咒。我失敗了。。。\n"
+"拜託​，​別殺​我​，​聽​我​說​完​。​我​曾​經​是​萊奧​里克國王騎士團​的​隊長​，​以​正義​和​榮譽維護​這片​"
+"土地​的​法律​。​然​後​他​的​黑暗​詛咒​降臨​在​我​們​身​上​，​因​為​我​們​在​他​悲慘​的​死亡​中​扮演"
+"​了​角色​。​當​我​的​騎士​同伴​們​屈服​於​他​們​扭曲​的​命運時​，​我​逃離​了​國王​的​墓室​，​尋​找​"
+"某​種​方法​來擺脫​詛咒​。​我​失敗​了​。​。​。​\n"
 " \n"
-"我聽說有一種金丹可以解除詛咒，讓我的靈魂安息，但我一直找不到它。我的力量正在"
-"衰退，伴隨著它，我最後的人性也在衰退。請幫助我找到長生不老藥。我會報答你的努"
-"力-我以我的名譽起誓"
+"​我​聽說​有​一​種​金丹​可以​解除​詛咒​，​讓​我​的​靈魂​安息​，​但​我​一直​找​不​到​它​。​我​的​力量"
+"​正在​衰退​，​伴隨​著​它​，​我​最後​的​人性​也​在​衰退​。​請​幫助​我​找到​長生不老藥​。​我​會​報​答​"
+"你​的​努力​-​我​以​我​的​名譽​起​誓"
 
 #. TRANSLATORS: Quest dialog spoken by Lachdanan (in despair)
 #: Source/textdat.cpp:174
 msgid ""
 "You have not found the Golden Elixir. I fear that I am doomed for eternity. "
 "Please, keep trying..."
-msgstr "你還沒有找到金丹。我害怕我註定要永生。請繼續努力"
+msgstr "你​還沒​有​找到​金丹​。​我​害怕​我​註定​要​永生​。​請繼續​努力"
 
 #. TRANSLATORS: Quest dialog spoken by Lachdanan (Quest End)
 #: Source/textdat.cpp:176
@@ -8183,9 +8182,9 @@ msgid ""
 "have little use for it. May it protect you against the dark powers below. Go "
 "with the Light, my friend..."
 msgstr ""
-"你救了我的靈魂脫離了詛咒，為此我欠你的債。如果有什麼方法可以讓我從墳墓那邊回"
-"報你的話，我會找到的，但是現在，請你掌舵。在我即將踏上的旅途中，我對它毫無用"
-"處。愿它保護你不受黑暗勢力的傷害。跟著光走，我的朋友"
+"你​救​了​我​的​靈魂​脫離​了​詛咒​，​為​此​我​欠​你​的​債​。​如果​有​什麼​方法​可以​讓​我​從墳​墓​那"
+"​邊回報​你​的​話​，​我​會​找到​的​，​但是​現​在​，​請​你​掌舵​。​在​我​即​將踏​上​的​旅途​中​，​我"
+"​對​它​毫​無​用處​。​愿​它​保護​你​不​受​黑暗​勢力​的​傷害​。​跟​著​光​走​，​我​的​朋友"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:178
@@ -8199,18 +8198,18 @@ msgid ""
 "unpredictable nature of Chaos makes it difficult to know what the outcome of "
 "this smithing will be..."
 msgstr ""
-"格里斯沃爾德談到了《憤怒的鐵砧》——一件傳說中的神器，人們一直在尋找，但一直沒"
-"有找到。憤怒的鐵砧是用剃刀坑惡魔的金屬骨頭製作而成的，熔鑄在五個最強大的冥界"
-"法師的頭骨周圍。刻有力量和混亂符文，任何在這個鐵砧上鍛造的武器或護甲都將被浸"
-"入混亂的領域，並將其嵌入魔法屬性。據說，混沌的不可預測性使人們很難知道這場鍛"
-"造會有什麼結果"
+"格里斯沃​爾德談​到​了​《​憤怒​的​鐵砧​》​——​一​件​傳說​中​的​神器​，​人們​一直​在​尋找​，​但​一直​沒"
+"​有​找到​。​憤怒​的​鐵砧​是​用​剃刀​坑​惡魔​的​金屬骨頭製​作​而​成​的​，​熔鑄​在​五​個​最​強​大​的​"
+"冥界​法師​的​頭骨​周圍​。​刻有​力量​和​混亂​符文​，​任何​在​這個鐵砧​上​鍛造​的​武器​或​護甲​都​將​被​"
+"浸入​混亂​的​領域​，​並將​其​嵌​入​魔法​屬性​。​據說​，​混沌​的​不​可​預測性​使​人們​很​難​知道​這場​"
+"鍛​造會​有​什麼​結​果"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:180
 msgid ""
 "Don't you think that Griswold would be a better person to ask about this? "
 "He's quite handy, you know."
-msgstr "你不覺得格里斯沃爾德會是一個更好的人問這個問題嗎？你知道，他很能幹"
+msgstr "你​不​覺​得​格里斯沃​爾德會​是​一​個​更​好​的​人問這個問題嗎​？​你​知道​，​他​很​能​幹"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:182
@@ -8220,8 +8219,8 @@ msgid ""
 "However, in this matter, you would be better served to speak to either "
 "Griswold or Cain."
 msgstr ""
-"如果你一直在尋找治療杵或凈化銀聖盃的資訊，我可以幫助你，我的朋友。不過，在這"
-"件事上，你最好和格里斯沃爾德或凱恩談談"
+"如果​你​一直​在​尋​找​治​療杵​或​凈化銀聖盃​的​資訊​，​我​可以​幫助​你​，​我​的​朋友​。​不​過​，​在​"
+"這件​事​上​，​你​最好​和​格里斯沃​爾德​或​凱恩談談"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:184
@@ -8231,9 +8230,9 @@ msgid ""
 "was struck upon this anvil, the ground would shake with a great fury. "
 "Whenever the earth moves, I always remember that story."
 msgstr ""
-"格里斯沃爾德的父親曾經告訴我們中的一些人，當我們成長的時候，一個巨大的鐵砧是"
-"用來製造強大的武器。他說，當一把錘子敲在這個鐵砧上時，地面會劇烈地震動。每當"
-"地球移動時，我總是記得那個故事"
+"格里斯沃​爾德​的​父親​曾​經告訴​我​們​中​的​一些​人​，​當​我​們​成長​的​時候​，​一​個​巨大​的​鐵砧​是"
+"​用來​製造強​大​的​武器​。​他​說​，​當​一​把​錘子​敲​在​這個鐵砧​上時​，​地面​會​劇烈​地震​動​。​每​"
+"當​地球​移動時​，​我​總​是​記​得​那​個​故事"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:186
@@ -8255,17 +8254,17 @@ msgid ""
 " \n"
 "Find the Anvil for me, and I'll get to work!"
 msgstr ""
-"問候語！很高興見到我最好的客戶之一！我知道你一直在冒險深入迷宮，有一個故事告"
-"訴我，你可能覺得值得花時間聽。。。\n"
+"問候語​！​很​高​興見​到​我​最​好​的​客戶​之一​！​我​知道​你​一直​在​冒險​深入​迷宮​，​有​一​個​故事​"
+"告訴​我​，​你​可能​覺​得​值得​花時間聽​。​。​。​\n"
 " \n"
-"一個從迷宮裡回來的人告訴我他逃跑時遇到的一個神秘的鐵砧。他的描述讓我想起了我"
-"年輕時聽到的關於燃燒的地獄爐的傳說，那裡有強大的魔法武器。傳說在地獄熔爐的深"
-"處安放著憤怒的鐵砧！這個鐵砧裡面包含著惡魔世界的精髓。。。\n"
+"​一​個​從迷宮裡​回來​的​人​告訴​我​他​逃跑​時​遇到​的​一​個​神秘​的​鐵砧​。​他​的​描述​讓​我​想起​了"
+"​我​年輕時​聽到​的​關於​燃燒​的​地​獄爐​的​傳說​，​那​裡​有​強​大​的​魔法​武器​。​傳說​在地​獄​熔爐​"
+"的​深處​安放​著​憤怒​的​鐵砧​！​這個鐵砧裡​面​包含​著​惡魔​世界​的​精髓​。​。​。​\n"
 " \n"
-"據說任何在燃燒的鐵砧上製作的武器都充滿了巨大的力量。如果這鐵砧真的是憤怒的鐵"
-"砧，我也許能讓你成為一件武器，甚至可以打敗最黑暗的地獄之主！\n"
+"據說​任何​在​燃燒​的​鐵砧​上​製作​的​武器​都​充滿​了​巨大​的​力量​。​如果​這鐵​砧​真的​是​憤怒​的​鐵砧"
+"​，​我​也​許​能​讓​你​成為​一​件​武器​，​甚至​可以​打敗​最​黑暗​的​地獄​之​主​！​\n"
 " \n"
-"幫我找鐵砧，我就去幹活"
+"幫​我​找​鐵砧​，​我​就​去​幹活"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:188
@@ -8274,8 +8273,8 @@ msgid ""
 "be your best hope, and I am sure that I can make you one of legendary "
 "proportions."
 msgstr ""
-"還沒有，嗯？好吧，繼續找。鐵砧上鍛造的武器可能是你最大的希望，我相信我能讓你"
-"成為傳奇般的人物之一"
+"還​沒​有​，​嗯​？​好​吧​，​繼續​找​。​鐵砧​上​鍛造​的​武器​可能​是​你​最​大​的​希望​，​我​相信​我​"
+"能​讓​你​成為傳奇​般​的​人物​之一"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:190
@@ -8284,16 +8283,15 @@ msgid ""
 "Now we'll show those bastards that there are no weapons in Hell more deadly "
 "than those made by men! Take this and may Light protect you."
 msgstr ""
-"我簡直不敢相信！這是憤怒的鐵砧-幹得好，我的朋友。現在我們要告訴那些混蛋，地獄"
-"里沒有比人類製造的武器更致命的武器了！拿著這個，光會保護你的"
+"我​簡​直​不​敢​相信​！​這​是​憤怒​的​鐵砧​-​幹​得​好​，​我​的​朋友​。​現​在​我​們​要​告訴​那些​混"
+"蛋​，​地獄​里​沒​有​比​人類​製造​的​武器​更​致命​的​武器​了​！​拿​著​這個​，​光​會​保護​你​的"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:192
 msgid ""
 "Griswold can't sell his anvil. What will he do then? And I'd be angry too if "
 "someone took my anvil!"
-msgstr ""
-"格里斯沃爾德賣不出他的鐵砧。那他會怎麼做？如果有人拿了我的鐵砧我也會生氣的"
+msgstr "格里斯沃​爾德賣​不​出​他​的​鐵砧​。​那​他​會​怎麼​做​？​如果​有​人​拿​了​我​的​鐵砧​我​也​會生氣​的"
 
 #. TRANSLATORS: Quest dialog spoken by
 #: Source/textdat.cpp:194
@@ -8303,8 +8301,8 @@ msgid ""
 "used by either the Light or the Darkness. Securing the Anvil from below "
 "could shift the course of the Sin War towards the Light."
 msgstr ""
-"迷宮裡有許多神器，擁有著凡人無法理解的力量。其中一些擁有神奇的力量，可以被光"
-"明或黑暗所利用。從下面固定鐵砧可以將罪惡戰爭的程序轉向光明"
+"迷宮裡​有​許多神器​，​擁​有​著​凡​人​無法​理解​的​力量​。​其中​一些​擁​有​神奇​的​力量​，​可以​被​光明"
+"​或​黑暗​所​利用​。​從​下面​固定​鐵砧​可以​將罪惡​戰爭​的​程序轉​向​光明"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:196
@@ -8312,8 +8310,8 @@ msgid ""
 "If you were to find this artifact for Griswold, it could put a serious "
 "damper on my business here. Awwww, you'll never find it."
 msgstr ""
-"如果你為格里斯沃爾德找到這件藝術品，它會嚴重影響我在這裡的生意。啊，你永遠找"
-"不到它"
+"如果​你​為​格里斯沃​爾德​找到​這件藝​術品​，​它​會嚴​重影響​我​在​這裡​的​生意​。​啊​，​你​永遠​找​不​"
+"到​它"
 
 #. TRANSLATORS: Quest dialog spoken by
 #: Source/textdat.cpp:198
@@ -8336,18 +8334,18 @@ msgid ""
 "said that when this holy armor is again needed, a hero will arise to don "
 "Valor once more. Perhaps you are that hero..."
 msgstr ""
-"血之門和火之殿是神秘起源的地標。無論你從哪裡讀到這本書，它都是一個充滿力量的"
-"地方。\n"
+"血​之​門​和​火之殿​是​神秘​起源​的​地標​。​無論​你​從​哪​裡​讀​到​這​本​書​，​它​都​是​一​個​充滿​"
+"力量​的​地方​。​\n"
 " \n"
-"傳說中有一個底座是用黑曜石雕刻而成的，上面有一灘沸騰的血。也有典故提到血石會"
-"打開一扇門，守護著一個古老的寶藏。。。\n"
+"傳說​中​有​一​個​底​座​是​用​黑曜​石​雕刻​而​成​的​，​上面​有​一​灘​沸騰​的​血​。​也​有​典故​提到​"
+"血石會​打開​一​扇​門​，​守護​著​一​個​古老​的​寶藏​。​。​。​\n"
 " \n"
-"我的朋友，這件寶藏的性質被猜測所掩蓋，但據說古代英雄阿卡因把神聖的護甲英勇放"
-"置在一個秘密的地下室裡。阿肯是第一個扭轉罪惡戰爭潮流，將黑暗軍團趕回燃燒地獄"
-"的凡人。\n"
+"​我​的​朋友​，​這件​寶藏​的​性質​被​猜測​所​掩蓋​，​但​據說​古代​英雄​阿卡因​把​神聖​的​護甲​英勇​放置"
+"​在​一​個​秘密​的​地下室​裡​。​阿肯​是​第一​個​扭轉​罪惡戰爭​潮流​，​將​黑暗​軍團趕​回燃燒​地獄​的​凡​"
+"人​。​\n"
 " \n"
-"就在阿凱死前，他的護甲藏在一個秘密的地下室裡。據說，當這種神聖的護甲再次被需"
-"要時，一個英雄將再次出現在勇氣堂。也許你就是那個英雄"
+"​就​在​阿凱死​前​，​他​的​護甲​藏​在​一​個​秘密​的​地下室​裡​。​據說​，​當這種​神聖​的​護甲​再次​被​"
+"需要​時​，​一​個​英雄​將​再次​出現​在​勇氣堂​。​也​許​你​就​是​那​個​英雄"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:200
@@ -8356,8 +8354,8 @@ msgid ""
 "known as Valor. If you could find its resting place, you would be well "
 "protected against the evil in the Labyrinth."
 msgstr ""
-"每個孩子都會聽到戰士阿卡因和他那被稱為英勇的神秘護甲的故事。如果你能找到它的"
-"安息之地，你就可以在迷宮裡很好地抵禦邪惡"
+"每​個​孩子​都​會聽​到​戰士​阿卡因​和​他​那​被​稱為​英勇​的​神秘​護甲​的​故事​。​如果​你​能​找到​它​的"
+"​安息​之​地​，​你​就​可以​在​迷宮裡​很​好​地​抵禦​邪惡"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:202
@@ -8366,16 +8364,15 @@ msgid ""
 "learning new cures and creating better elixirs that I must have forgotten. "
 "Sorry..."
 msgstr ""
-"隱馬爾可夫模型。。。這聽起來像是我應該記住的，但我一直忙於學習新的治療方法和"
-"創造更好的長生不老藥，我一定忘記了。對不起"
+"隱​馬爾​可​夫​模型​。​。​。​這聽​起來​像​是​我​應該記​住​的​，​但​我​一直​忙於​學習​新​的​治療​方法​"
+"和​創造​更​好​的​長生不老藥​，​我​一定​忘記​了​。​對​不​起"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:204
 msgid ""
 "The story of the magic armor called Valor is something I often heard the "
 "boys talk about. You had better ask one of the men in the village."
-msgstr ""
-"我經常聽到男孩們談論的關於魔法護甲的故事叫做英勇。你最好問問村裡的一個人"
+msgstr "我​經​常聽​到​男孩​們​談論​的​關於​魔法​護甲​的​故事​叫做​英勇​。​你​最好​問問​村裡​的​一​個​人"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:206
@@ -8385,8 +8382,9 @@ msgid ""
 "well, my friend, and it will take more than a bit of luck to unlock the "
 "secrets that have kept it concealed oh, lo these many years."
 msgstr ""
-"被稱為英勇的護甲可能會使天平對你有利。我要告訴你，很多人都找過，包括我自己。"
-"阿肯把它藏得很好，我的朋友，要解開隱藏了這麼多年的秘密還需要一點運氣哦，瞧"
+"被​稱為​英勇​的​護甲​可能​會​使​天平對​你​有利​。​我​要​告訴​你​，​很多​人​都​找過​，​包括​我​自己​。"
+"​阿肯​把​它​藏得​很​好​，​我​的​朋友​，​要​解開​隱藏​了​這麼​多​年​的​秘密還​需要​一​點​運氣​哦​，​"
+"瞧"
 
 #. TRANSLATORS: Quest dialog "spoken" by Farnham
 #: Source/textdat.cpp:208
@@ -8401,9 +8399,9 @@ msgid ""
 "The way is fraught with danger and your only hope rests within your self "
 "trust."
 msgstr ""
-"如果你發現了這些血石，小心使用。\n"
+"如果​你​發現​了​這​些​血石​，​小心​使用​。​\n"
 " \n"
-"道路充滿危險，你唯一的希望在於你的自信"
+"​道路​充滿​危險​，​你​唯一​的​希望​在​於​你​的​自信"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:211
@@ -8413,9 +8411,9 @@ msgid ""
 "No one has ever figured out where Arkaine stashed the stuff, and if my "
 "contacts couldn't find it, I seriously doubt you ever will either."
 msgstr ""
-"你想找到被稱為英勇的護甲嗎？\n"
+"你​想​找到​被​稱為​英勇​的​護甲嗎​？​\n"
 " \n"
-"沒人知道阿凱把東西藏在哪裡，如果我的聯繫人找不到，我很懷疑你也會"
+"​沒人​知道​阿凱​把​東​西藏​在​哪​裡​，​如果​我​的​聯繫​人​找​不​到​，​我​很​懷疑​你​也​會"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:213
@@ -8432,15 +8430,15 @@ msgid ""
 "Legion of Darkness during the Sin War, he lost his humanity to his "
 "insatiable hunger for blood."
 msgstr ""
-"我只知道一個傳說像你描述的那樣提到一個戰士。他的故事可以在罪惡戰爭的古代編年"
-"史中找到。。。\n"
+"我​只​知道​一​個傳說像​你​描述​的​那​樣​提到​一​個​戰士​。​他​的​故事​可以​在​罪惡戰爭​的​古代​編​年史"
+"​中​找到​。​。​。​\n"
 " \n"
-"被一千年的戰爭，鮮血和死亡所玷污，血的軍閥站在他破舊的受害者的山上。他的黑暗"
-"之刃向活人發出了黑色的詛咒；對任何站在這個地獄劊子手面前的人的一個嚴刑拷打的"
-"邀請。\n"
+"​被​一千​年​的​戰爭​，​鮮血​和​死亡​所​玷污​，​血​的​軍閥​站​在​他​破舊​的​受害者​的​山​上​。​他​的"
+"​黑暗​之​刃​向​活人​發出​了​黑色​的​詛咒​；​對​任何​站​在​這個​地獄​劊子​手​面前​的​人​的​一​個​嚴​"
+"刑拷打​的​邀請​。​\n"
 " \n"
-"書中還寫到，雖然他曾經是一個凡人，在罪惡戰爭中與黑暗軍團並肩作戰，但他因對鮮"
-"血的貪得無厭而失去了人性"
+"書​中​還寫​到​，​雖然​他​曾​經​是​一​個​凡​人​，​在​罪惡戰爭​中​與​黑暗​軍團​並肩作戰​，​但​他​因對​"
+"鮮​血​的​貪​得​無厭​而​失去​了​人性"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:215
@@ -8449,23 +8447,22 @@ msgid ""
 "master. I hope that you do not have to fight him, for he sounds extremely "
 "dangerous."
 msgstr ""
-"恐怕我還沒聽說過這麼惡毒的戰士，好師傅。我希望你不用和他打架，因為他聽起來非"
-"常危險"
+"恐怕​我​還沒聽說過這麼​惡毒​的​戰士​，​好​師傅​。​我​希望​你​不用​和​他​打架​，​因​為​他​聽起來​非常​危"
+"險"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:217
 msgid ""
 "Cain would be able to tell you much more about something like this than I "
 "would ever wish to know."
-msgstr "凱恩會告訴你比我想知道的更多的事情"
+msgstr "凱恩會告訴​你​比​我​想​知道​的​更​多​的​事情"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:219
 msgid ""
 "If you are to battle such a fierce opponent, may Light be your guide and "
 "your defender. I will keep you in my thoughts."
-msgstr ""
-"如果你要與如此兇猛的對手作戰，愿光明成為你的嚮導和衛士。我會一直惦記著你"
+msgstr "如果​你​要​與​如此​兇猛​的​對手​作戰​，​愿​光明​成為​你​的​嚮導​和​衛士​。​我​會​一直​惦​記​著​你"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:221
@@ -8473,8 +8470,8 @@ msgid ""
 "Dark and wicked legends surrounds the one Warlord of Blood. Be well "
 "prepared, my friend, for he shows no mercy or quarter."
 msgstr ""
-"黑暗邪惡的傳說圍繞著一個血的軍閥。我的朋友，請做好準備，因為他既不仁慈也不吝"
-"嗇"
+"黑暗​邪惡​的​傳說圍​繞​著​一​個​血​的​軍閥​。​我​的​朋友​，​請​做好​準備​，​因​為​他​既​不​仁慈​也​"
+"不​吝嗇"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:223
@@ -8483,8 +8480,8 @@ msgid ""
 "that pretty girl that brings the drinks. Listen here, friend - you're "
 "obsessive, you know that?"
 msgstr ""
-"你總是說血？鮮花，陽光，還有那個送飲料的漂亮女孩呢。聽著，朋友-你很癡迷，知道"
-"嗎"
+"你​總​是​說血​？​鮮花​，​陽光​，​還​有​那​個​送​飲料​的​漂亮​女孩​呢​。​聽著​，​朋友​-​你​很​癡迷​"
+"，​知道​嗎"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:225
@@ -8493,8 +8490,8 @@ msgid ""
 "years knowing only warfare. I am sorry... I can not see if you will defeat "
 "him."
 msgstr ""
-"他的劍術令人敬畏，他已經活了幾千年，只知道戰爭。我很抱歉。。。我看不出你是否"
-"能打敗他"
+"他​的​劍術​令​人​敬畏​，​他​已​經活​了​幾​千​年​，​只​知道​戰爭​。​我​很​抱歉​。​。​。​我​看​不​出"
+"​你​是否​能​打敗​他"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:227
@@ -8502,15 +8499,15 @@ msgid ""
 "I haven't ever dealt with this Warlord you speak of, but he sounds like he's "
 "going through a lot of swords. Wouldn't mind supplying his armies..."
 msgstr ""
-"我從來沒有和你說的那個軍閥打過交道，但他聽起來好像經歷了很多磨難。不介意為他"
-"的軍隊提供補給"
+"我​從來沒​有​和​你​說​的​那​個軍閥​打過​交道​，​但​他​聽起來​好像​經歷​了​很多​磨難​。​不​介意為​他​的"
+"​軍隊​提供​補給"
 
 #. TRANSLATORS: Quest dialog spoken by Warlord of Blood (Hostile)
 #: Source/textdat.cpp:229
 msgid ""
 "My blade sings for your blood, mortal, and by my dark masters it shall not "
 "be denied."
-msgstr "我的刀鋒為你的鮮血歌唱，凡人，我的黑暗主人不會否認它"
+msgstr "我​的​刀鋒為​你​的​鮮血​歌唱​，​凡​人​，​我​的​黑暗​主人​不​會否認​它"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:231
@@ -8521,9 +8518,9 @@ msgid ""
 "man could possess. I do not know what secrets it holds, my friend, but "
 "finding this stone would certainly prove most valuable."
 msgstr ""
-"格里斯沃爾德談到了天石，它是註定要飛地位於東部。它被帶到那裡作進一步研究。這"
-"塊石頭閃耀著一種能量，它以某種方式賦予了一個普通人無法擁有的視覺。我不知道它"
-"有什麼秘密，我的朋友，但找到這塊石頭肯定是最有價值的"
+"格里斯沃​爾德談​到​了​天石​，​它​是​註定​要​飛​地位​於​東​部​。​它​被​帶​到​那​裡​作​進​一​步​研究​"
+"。​這塊石頭​閃耀​著​一​種​能量​，​它​以​某​種​方式​賦予​了​一​個​普通​人無​法擁​有的​視覺​。​我​不​知"
+"道​它​有​什麼​秘密​，​我​的​朋友​，​但​找到​這塊​石頭​肯定​是​最​有​價值​的"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:233
@@ -8533,8 +8530,8 @@ msgid ""
 "sweetbreads that Garda has just finished baking. Shame what happened to "
 "them..."
 msgstr ""
-"商隊在這裡停了下來，為他們向東旅行帶去一些補給。我賣給他們不少新鮮水果和一些"
-"佳達剛剛烤好的上等甜麵包。可惜他們發生了什麼"
+"商隊​在​這裡​停​了​下來​，​為​他​們​向​東​旅行​帶​去​一些​補給​。​我​賣給​他​們​不少​新​鮮​水果​和​"
+"一些​佳達剛剛​烤好​的​上​等​甜麵包​。​可惜​他​們發生​了​什麼"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:235
@@ -8543,8 +8540,8 @@ msgid ""
 "I will say this. If rocks are falling from the sky, you had better be "
 "careful!"
 msgstr ""
-"我不知道他們以為用那塊石頭能看到什麼，但我要說的是。如果巖石從天而降，你最好"
-"小心"
+"我​不​知道​他​們​以​為​用​那​塊石頭​能​看到​什麼​，​但​我​要​說​的​是​。​如果​巖石從天而降​，​你​最好"
+"​小心"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian
 #: Source/textdat.cpp:237
@@ -8556,10 +8553,10 @@ msgid ""
 "I don't see how you could hope to find anything that they would have been "
 "carrying."
 msgstr ""
-"好吧，一隊重要人物停在這裡，但那是很久以前的事了。我記得，他們的口音很奇怪，"
-"正開始長途旅行。\n"
+"好​吧​，​一​隊​重要​人物​停​在​這裡​，​但​那​是​很​久​以前​的​事​了​。​我​記得​，​他​們​的​口音​很"
+"​奇怪​，​正​開始​長途​旅行​。​\n"
 " \n"
-"我不明白你怎麼能指望找到他們會帶的東西"
+"​我​不​明白​你​怎麼​能​指望​找到​他​們會帶​的​東西"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:239
@@ -8572,17 +8569,17 @@ msgid ""
 "found. If you should find it, I believe that I can fashion something useful "
 "from it."
 msgstr ""
-"呆一會兒-我有個故事你可能會覺得有趣。一輛開往東方王國的大篷車前段時間經過這"
-"里。據說它帶著一片落在地上的天空！大篷車就在這北邊的公路上被披著斗篷的騎手伏"
-"擊了。我在殘骸中搜尋這塊巖石，但找不到。如果你能找到它，我相信我能從中找到有"
-"用的東西"
+"呆​一​會​兒​-​我​有​個​故事​你​可能​會​覺​得​有趣​。​一​輛​開往​東方​王國​的​大篷車​前​段​時間經過這"
+"​里​。​據說​它​帶著​一​片​落​在​地上​的​天空​！​大篷車​就​在​這北邊​的​公路​上​被​披著​斗篷​的​騎手​"
+"伏擊​了​。​我​在​殘骸​中​搜尋​這塊​巖石​，​但​找​不​到​。​如果​你​能​找到​它​，​我​相信​我​能​從​中"
+"​找到​有用​的​東西"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:241
 msgid ""
 "I am still waiting for you to bring me that stone from the heavens. I know "
 "that I can make something powerful out of it."
-msgstr "我還在等你從天上把那塊石頭帶給我。我知道我能從中製造出強大的東西"
+msgstr "我​還​在​等​你​從天​上​把​那​塊石頭帶給​我​。​我​知道​我​能​從​中​製​造出​強​大​的​東西"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold(Quest End)
 #: Source/textdat.cpp:243
@@ -8592,9 +8589,9 @@ msgid ""
 "Ah, Here you are. I arranged pieces of the stone within a silver ring that "
 "my father left me. I hope it serves you well."
 msgstr ""
-"讓我看看-是的。。。是的，正如我所相信的。給我一點時間。。。\n"
+"讓​我​看看​-​是​的​。​。​。​是​的​，​正​如​我​所​相信​的​。​給​我​一​點​時間​。​。​。​\n"
 " \n"
-"啊，給你。我把幾塊石頭放在父親留給我的銀戒指里。希望對你有好處"
+"​啊​，​給​你​。​我​把​幾塊石頭​放​在​父親​留給​我​的​銀戒指里​。​希望​對​你​有​好​處"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:245
@@ -8603,8 +8600,8 @@ msgid ""
 "green and red and silver. Don't remember what happened to it, though. I "
 "really miss that ring..."
 msgstr ""
-"我曾經有一個漂亮的戒指；這是一個非常昂貴的，藍色，綠色，紅色和銀色。不過，我"
-"不記得發生了什麼。我真的很想念那個戒指"
+"我​曾​經​有​一​個​漂亮​的​戒指​；​這​是​一​個​非常​昂貴​的​，​藍色​，​綠色​，​紅色​和​銀色​。​不​過"
+"​，​我​不​記得​發生​了​什麼​。​我​真的​很​想​念​那​個​戒指"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:247
@@ -8613,8 +8610,8 @@ msgid ""
 "find it, I would prevent it. He will harness its powers and its use will be "
 "for the good of us all."
 msgstr ""
-"天石是非常強大的，如果是任何人，但格里斯沃爾德誰叫你找到它，我會阻止它。他將"
-"利用它的力量，它的使用將造福於我們所有人"
+"天石​是​非常​強​大​的​，​如果​是​任何​人​，​但​格里斯沃​爾德誰​叫​你​找到​它​，​我​會​阻止​它​。​他​"
+"將​利用​它​的​力量​，​它​的​使用​將​造福​於​我​們​所有​人"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:249
@@ -8623,8 +8620,8 @@ msgid ""
 "he is doing, and as much as I try to steal his customers, I respect the "
 "quality of his work."
 msgstr ""
-"如果有人能用那塊石頭做點什麼，格里斯沃爾德也能。他知道自己在做什麼，儘管我試"
-"圖竊取他的客戶，但我尊重他的工作質量"
+"如果​有​人​能​用​那塊石頭​做​點什麼​，​格里斯沃​爾德​也​能​。​他​知道​自己​在​做​什麼​，​儘管​我​試圖竊"
+"取​他​的​客戶​，​但​我​尊重​他​的​工作​質量"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:251
@@ -8633,8 +8630,8 @@ msgid ""
 "as I do about Red Herrings. Perhaps Pepin the Healer could tell you more, "
 "but this is something that cannot be found in any of my stories or books."
 msgstr ""
-"女巫艾德里亞想要一個黑蘑菇？我對黑蘑菇的瞭解和對紅鯡魚的瞭解一樣多。也許治療"
-"者佩平可以告訴你更多，但這是我的任何故事或書籍中都找不到的"
+"女​巫艾德里亞​想要​一​個​黑​蘑菇​？​我​對​黑​蘑菇​的​瞭解​和​對紅​鯡魚​的​瞭解​一​樣​多​。​也​許治療者"
+"​佩平​可以​告訴​你​更​多​，​但​這​是​我​的​任何​故事​或​書籍​中​都​找​不​到​的"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:253
@@ -8644,8 +8641,8 @@ msgid ""
 "then that is her business, but I can't help you find any. Black mushrooms... "
 "disgusting!"
 msgstr ""
-"我就這麼說吧。我和嘉達永遠不會給我們的貴賓提供黑蘑菇。如果艾德里亞想在燉菜里"
-"放些蘑菇，那是她的事，但我幫不了你。黑蘑菇。。。噁心"
+"我​就​這麼​說​吧​。​我​和​嘉達​永遠​不​會給​我​們​的​貴賓​提供​黑蘑菇​。​如果​艾德里亞​想​在​燉菜​里​"
+"放些​蘑菇​，​那​是​她​的​事​，​但​我​幫​不​了​你​。​黑​蘑菇​。​。​。​噁心"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin
 #: Source/textdat.cpp:255
@@ -8656,9 +8653,9 @@ msgid ""
 "that its alchemy holds. If you can remove the brain of a demon when you kill "
 "it, I would be grateful if you could bring it to me."
 msgstr ""
-"巫婆告訴我你在尋找一個惡魔的大腦來幫助我製造長生不老藥。如果我能解開我懷疑它"
-"的鍊金術所掌握的秘密，它對許多被這些邪惡野獸傷害的人來說應該是非常有價值的。"
-"如果你能在殺死一個惡魔的時候把它的大腦取出來，如果你能把它帶給我，我將不勝感"
+"巫婆​告訴​我​你​在​尋​找​一​個​惡魔​的​大​腦來​幫助​我​製造​長生不老藥​。​如果​我​能解開​我​懷疑​它​的"
+"​鍊金術​所​掌握​的​秘密​，​它​對許​多​被​這​些​邪惡野獸​傷害​的​人來說應該​是​非常​有​價值​的​。​如果​"
+"你​能​在​殺死​一​個​惡魔​的​時候​把​它​的​大腦​取出來​，​如果​你​能​把​它​帶給​我​，​我​將​不​勝​感"
 "激"
 
 #. TRANSLATORS: Quest dialog spoken by Pepin
@@ -8668,15 +8665,15 @@ msgid ""
 "without this, but it can't hurt to have this to study. Would you please "
 "carry this to the witch? I believe that she is expecting it."
 msgstr ""
-"太好了，這正是我想要的。沒有這個我就可以完成長生不老藥，但是有這個來學習也沒"
-"什麼壞處。請你把這個帶給女巫好嗎？我相信她在等著呢"
+"太​好​了​，​這​正​是​我​想要​的​。​沒​有​這個​我​就​可以​完成​長生不老藥​，​但是​有​這個來學習​也​沒什"
+"麼壞處​。​請​你​把​這個帶給​女​巫好嗎​？​我​相信​她​在​等著​呢"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:259
 msgid ""
 "I think Ogden might have some mushrooms in the storage cellar. Why don't you "
 "ask him?"
-msgstr "我想奧格登的地窖里可能有蘑菇。你為什麼不問問他"
+msgstr "我​想​奧格登​的​地窖​里​可能​有​蘑菇​。​你​為什麼​不​問問​他"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:261
@@ -8685,9 +8682,9 @@ msgid ""
 "I can offer you no more help than that, but it sounds like... a huge, "
 "gargantuan, swollen, bloated mushroom! Well, good hunting, I suppose."
 msgstr ""
-"如果阿德里婭沒有這些，你可以打賭這確實是一件罕見的事情。我不能給你更多的幫"
-"助，但是聽起來。。。一個巨大的，巨大的，腫脹的，膨脹的蘑菇！嗯，我想打獵不錯"
-"吧"
+"如果​阿德里婭沒​有​這​些​，​你​可以​打賭這確實​是​一​件​罕見​的​事情​。​我​不​能​給​你​更​多​的​幫助​"
+"，​但是​聽起來​。​。​。​一​個​巨大​的​，​巨大​的​，​腫脹​的​，​膨脹​的​蘑菇​！​嗯​，​我​想​打獵​不​"
+"錯​吧"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:263
@@ -8695,8 +8692,8 @@ msgid ""
 "Ogden mixes a MEAN black mushroom, but I get sick if I drink that. Listen, "
 "listen... here's the secret - moderation is the key!"
 msgstr ""
-"奧格登混合了一種難吃的黑蘑菇，但如果我喝了它我會生病的。聽著，聽著。。。秘訣"
-"就在這裡——適度才是關鍵"
+"奧​格登​混合​了​一​種​難​吃​的​黑蘑菇​，​但​如果​我​喝​了​它​我​會​生病​的​。​聽著​，​聽著​。​。​。"
+"​秘訣​就​在​這裡​——​適度​才​是​關鍵"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:265
@@ -8705,8 +8702,8 @@ msgid ""
 "your eyes open for a black mushroom. It should be fairly large and easy to "
 "identify. If you find it, bring it to me, won't you?"
 msgstr ""
-"我們這裡有什麼？有趣的是，它看起來像一本試劑書。睜大眼睛看黑蘑菇。它應該相當"
-"大，並且易於識別。如果你找到了，把它帶給我，好嗎"
+"我​們這裡​有​什麼​？​有趣​的​是​，​它​看起​來像​一​本​試劑書​。​睜大​眼睛​看黑​蘑菇​。​它​應該​相當​大"
+"​，​並且​易於​識別​。​如果​你​找到​了​，​把​它​帶給​我​，​好嗎"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:267
@@ -8714,8 +8711,8 @@ msgid ""
 "It's a big, black mushroom that I need. Now run off and get it for me so "
 "that I can use it for a special concoction that I am working on."
 msgstr ""
-"我需要一個又大又黑的蘑菇。現在跑去給我拿，這樣我就可以用它做我正在做的一種特"
-"殊的調味品了"
+"我​需要​一​個​又​大​又​黑​的​蘑菇​。​現​在​跑去給​我​拿​，​這樣​我​就​可以​用​它​做​我​正在​做​的​"
+"一​種​特殊​的​調味品​了"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:269
@@ -8726,9 +8723,9 @@ msgid ""
 "intends to make an elixir from it. If you help him find what he needs, "
 "please see if you can get a sample of the elixir for me."
 msgstr ""
-"是的，這將是完美的釀造，我正在建立。順便說一句，治療者正在尋找某種惡魔的大"
-"腦，這樣他就可以治療那些被他們的毒液折磨的人。我相信他打算用它做長生不老藥。"
-"如果你幫他找到他需要的東西，請你幫我拿一個長生不老藥的樣品"
+"是​的​，​這將​是​完美​的​釀造​，​我​正在​建立​。​順便​說​一​句​，​治療者​正​在​尋​找​某​種​惡魔​的​"
+"大腦​，​這樣​他​就​可以​治療​那些​被​他​們​的​毒液​折磨​的​人​。​我​相信​他​打算​用​它​做​長生不老藥​"
+"。​如果​你​幫​他​找到​他​需要​的​東西​，​請​你​幫​我​拿​一​個​長生不老藥​的​樣品"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:271
@@ -8738,9 +8735,9 @@ msgid ""
 "that grotesque organ that you are holding, and then bring me the elixir. "
 "Simple when you think about it, isn't it?"
 msgstr ""
-"你為什麼把它帶到這裡來？我現在不需要惡魔的大腦。我確實需要一些治療者正在研製"
-"的長生不老藥。他需要你拿著的奇怪的器官，然後給我拿長生不老藥。想起來很簡單，"
-"不是嗎"
+"你​為什麼​把​它​帶​到​這裡來​？​我​現​在​不​需要​惡魔​的​大腦​。​我​確實​需要​一些​治療者​正​在​研製​"
+"的​長生不老藥​。​他​需要​你​拿著​的​奇怪​的​器官​，​然​後​給​我​拿​長生不老藥​。​想起來​很​簡單​，​不​"
+"是​嗎"
 
 #. TRANSLATORS: Quest dialog spoken by Adria (Quest End)
 #: Source/textdat.cpp:273
@@ -8748,15 +8745,15 @@ msgid ""
 "What? Now you bring me that elixir from the healer? I was able to finish my "
 "brew without it. Why don't you just keep it..."
 msgstr ""
-"什麼？現在你把醫治者的長生不老藥帶給我？不用它我就能喝完我的啤酒。你為什麼不"
-"留著它"
+"什麼​？​現​在​你​把​醫​治者​的​長生不​老​藥帶給​我​？​不用​它​我​就​能​喝​完​我​的​啤酒​。​你​為什麼"
+"​不​留著​它"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt
 #: Source/textdat.cpp:275
 msgid ""
 "I don't have any mushrooms of any size or color for sale. How about "
 "something a bit more useful?"
-msgstr "我沒有任何大小和顏色的蘑菇出售。再來點有用的怎麼樣"
+msgstr "我​沒​有​任何​大小​和​顏色​的​蘑菇​出售​。​再​來點​有用​的​怎​麼​樣"
 
 #. TRANSLATORS: Quest dialog spoken by Cain (currently unused)
 #: Source/textdat.cpp:277
@@ -8781,19 +8778,19 @@ msgid ""
 "before the stars align, for we may never have a chance to rid the world of "
 "his evil again!"
 msgstr ""
-"所以，地圖上的傳說是真實的。連我都不相信！我想是時候告訴你我是誰了，我的朋"
-"友。你看，我並不像我看起來那樣。。。\n"
+"所以​，​地圖​上​的​傳說​是​真實​的​。​連​我​都​不​相信​！​我​想​是​時候​告訴​你​我​是​誰​了​，​我​"
+"的​朋友​。​你​看​，​我​並​不​像​我​看​起來​那​樣​。​。​。​\n"
 " \n"
-"我的真名是老凱恩，我是一個古老兄弟會的最後一個後代，這個兄弟會致力於保守和保"
-"護一個永恒邪惡的秘密。一個很明顯已經被釋放的惡魔。。。\n"
+"​我​的​真名​是​老凱恩​，​我​是​一​個​古老​兄弟會​的​最後​一個​後​代​，​這個​兄弟​會​致力​於​保守​和​"
+"保護​一​個​永恒​邪惡​的​秘密​。​一​個​很​明顯​已​經​被​釋放​的​惡魔​。​。​。​\n"
 " \n"
-"你要對付的惡魔是恐怖的黑魔王——凡人都知道的迪亞波羅。幾個世紀前被囚禁在迷宮裡"
-"的正是他。你現在持有的地圖是很久以前創造的，用來標記迪亞波羅從監禁中復活的時"
-"間。當那張地圖上的兩顆星星對齊時，迪亞波羅將達到他的能量頂峰。他將所向無"
-"敵。。。\n"
+"​你​要​對付​的​惡魔​是​恐怖​的​黑魔王​——​凡​人​都​知道​的​迪亞波羅​。​幾個世紀​前​被​囚禁​在​迷宮裡​"
+"的​正​是​他​。​你​現​在​持有​的​地圖​是​很​久​以前​創造​的​，​用來標​記​迪亞波羅從​監​禁​中​復活​的​"
+"時間​。​當​那​張​地圖​上​的​兩顆​星星對​齊時​，​迪亞波羅將達​到​他​的​能量​頂峰​。​他​將​所​向​無敵​。"
+"​。​。​\n"
 " \n"
-"你現在在和時間賽跑，我的朋友！找到迪亞波羅，在眾星雲集之前消滅他，因為我們可"
-"能再也沒有機會擺脫他的邪惡了"
+"​你​現​在在​和​時間​賽​跑​，​我​的​朋友​！​找到​迪亞波羅​，​在​眾星​雲集​之前​消滅​他​，​因​為​我​們"
+"​可能​再​也​沒​有​機會擺脫​他​的​邪惡​了"
 
 #. TRANSLATORS: Quest dialog spoken by Cain (currently unused)
 #: Source/textdat.cpp:279
@@ -8801,7 +8798,8 @@ msgid ""
 "Our time is running short! I sense his dark power building and only you can "
 "stop him from attaining his full might."
 msgstr ""
-"我們的時間不多了！我感覺到了他的黑暗力量，只有你才能阻止他達到他的全部力量"
+"我​們​的​時間​不​多​了​！​我​感覺​到​了​他​的​黑暗​力量​，​只有​你​才​能​阻止​他​達​到​他​的​全部​"
+"力量"
 
 #. TRANSLATORS: Quest dialog spoken by Cain (currently unused)
 #: Source/textdat.cpp:281
@@ -8811,9 +8809,9 @@ msgid ""
 "and you will need all your courage and strength to defeat him. May the Light "
 "protect and guide you, my friend. I will help in any way that I am able."
 msgstr ""
-"我相信你已經盡力了，但我擔心你的力量和意志都不夠。迪亞波羅現在正處於他塵世力"
-"量的頂峰，你將需要你所有的勇氣和力量來打敗他。愿光明保護和指引你，我的朋友。"
-"我將盡我所能提供幫助。"
+"我​相信​你​已​經​盡力​了​，​但​我​擔心​你​的​力量​和​意志​都​不​夠​。​迪亞波羅現​在​正處於​他​塵世​力"
+"量​的​頂峰​，​你​將​需要​你​所有​的​勇氣​和​力量​來打敗​他​。​愿光明​保護​和​指引​你​，​我​的​朋友​。"
+"​我​將盡​我​所​能​提供​幫助​。"
 
 #. TRANSLATORS: Quest dialog spoken by Ogden (currently unused)
 #: Source/textdat.cpp:283
@@ -8822,8 +8820,8 @@ msgid ""
 "that I would know anything? It sounds like this is a very serious matter. "
 "You should hurry along and see the storyteller as Adria suggests."
 msgstr ""
-"如果女巫幫不了你，建議你去見凱恩，你憑什麼認為我什麼都知道？聽起來這是一件非"
-"常嚴重的事情。你應該像阿德里亞建議的那樣，趕快去見講故事的人"
+"如果​女​巫幫​不​了​你​，​建議​你​去見凱恩​，​你​憑什麼​認為​我​什麼​都​知道​？​聽起​來這​是​一​件​非常"
+"​嚴重​的​事情​。​你​應該​像​阿德里​亞建議​的​那樣​，​趕快​去​見講​故事​的​人"
 
 #. TRANSLATORS: Quest dialog spoken by Pipin (currently unused)
 #: Source/textdat.cpp:285
@@ -8834,9 +8832,9 @@ msgid ""
 "I can see that it is a map of the stars in our sky, but any more than that "
 "is beyond my talents."
 msgstr ""
-"我對這張地圖上的文字不太瞭解，但也許艾德里亞或凱恩能幫你破譯這是指什麼。\n"
+"我​對這張​地​圖​上​的​文字​不​太​瞭解​，​但​也​許​艾德里亞​或​凱恩​能​幫​你​破譯這​是​指什麼​。​\n"
 " \n"
-"我可以看到這是一張我們天空中星星的地圖，但比這更是超出我的能力"
+"​我​可以​看到​這​是​一​張​我​們​天空​中​星星​的​地圖​，​但​比這​更​是​超出​我​的​能力"
 
 #. TRANSLATORS: Quest dialog spoken by Gillian (currently unused)
 #: Source/textdat.cpp:287
@@ -8846,9 +8844,9 @@ msgid ""
 "Cain is very knowledgeable about ancient writings, and that is easily the "
 "oldest looking piece of paper that I have ever seen."
 msgstr ""
-"問這類事情的最佳人選是我們的說書人。\n"
+"問​這類​事情​的​最​佳​人選​是​我​們​的​說書​人​。​\n"
 " \n"
-"凱恩對古代著作非常瞭解，這是我見過的最古老的一張紙"
+"凱恩對​古代​著作​非常​瞭解​，​這​是​我​見過​的​最​古老​的​一​張​紙"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold (currently unused)
 #: Source/textdat.cpp:289
@@ -8857,8 +8855,8 @@ msgid ""
 "have no idea how to read this, Cain or Adria may be able to provide the "
 "answers that you seek."
 msgstr ""
-"我以前從未見過這樣的地圖。你從哪兒弄來的？雖然我不知道該怎麼讀這篇文章，但凱"
-"恩或阿德里亞也許能提供你所尋求的答案"
+"我​以前​從​未​見過​這樣​的​地圖​。​你​從​哪​兒​弄來​的​？​雖然​我​不​知道​該​怎​麼讀​這篇​文章​，​但"
+"​凱恩​或​阿德里亞​也​許能​提供​你​所​尋求​的​答案"
 
 #. TRANSLATORS: Quest dialog spoken by Farnham (currently unused)
 #: Source/textdat.cpp:291
@@ -8866,8 +8864,8 @@ msgid ""
 "Listen here, come close. I don't know if you know what I know, but you have "
 "really got somethin' here. That's a map."
 msgstr ""
-"聽著，靠近點。我不知道你是否知道我所知道的，但你真的有些東西在這裡。那是一張"
-"地圖"
+"聽​著​，​靠近點​。​我​不​知道​你​是否​知道​我​所​知道​的​，​但​你​真的​有些​東西​在​這裡​。​那​是​一"
+"​張​地​圖"
 
 #. TRANSLATORS: Quest dialog spoken by Adria (currently unused)
 #: Source/textdat.cpp:293
@@ -8876,8 +8874,8 @@ msgid ""
 "portends great disaster, but its secrets are not mine to tell. The time has "
 "come for you to have a very serious conversation with the Storyteller..."
 msgstr ""
-"哦，恐怕這一點都不是好兆頭。這張星圖預示著巨大的災難，但它的秘密不是我說的。"
-"是時候讓你和講故事的人好好談談了"
+"哦​，​恐怕​這​一​點​都​不​是​好​兆頭​。​這張​星圖​預​示著​巨大​的​災難​，​但​它​的​秘密不​是​我​說​"
+"的​。​是​時候讓​你​和​講​故事​的​人​好好​談談​了"
 
 #. TRANSLATORS: Quest dialog spoken by Wirt (currently unused)
 #: Source/textdat.cpp:295
@@ -8886,14 +8884,14 @@ msgid ""
 "that to Adria - she can probably tell you what it is. I'll say one thing; it "
 "looks old, and old usually means valuable."
 msgstr ""
-"我一直在找地圖，但那肯定不是。你應該把這個給艾德里亞看-她可能會告訴你是什麼。"
-"我要說一件事；它看起來很老，而且老通常意味著有價值"
+"我​一直​在​找​地圖​，​但​那​肯定​不​是​。​你​應該​把​這個給​艾德里亞​看-​她​可能​會告訴​你​是​什麼​。"
+"​我​要​說​一​件​事​；​它​看​起​來​很​老​，​而且​老​通常​意味​著​有​價值"
 
 #. TRANSLATORS: Quest dialog spoken by Gharbad the Weak
 #: Source/textdat.cpp:297
 msgid ""
 "Pleeeease, no hurt. No Kill. Keep alive and next time good bring to you."
-msgstr "請放心，不要受傷。不殺人。保持活力，下次給你帶來好東西"
+msgstr "請​放心​，​不​要​受傷​。​不​殺​人​。​保持​活力​，​下​次​給​你​帶來​好​東​西"
 
 #. TRANSLATORS: Quest dialog spoken by Gharbad the Weak
 #: Source/textdat.cpp:299
@@ -8903,9 +8901,9 @@ msgid ""
 " \n"
 "You take this as proof I keep word..."
 msgstr ""
-"我正在為你做些東西。再說一遍，別殺了加爾巴德。活得好好的。\n"
+"我​正在​為​你​做​些​東西​。​再​說​一​遍​，​別殺​了​加爾巴德​。​活​得​好好​的​。​\n"
 " \n"
-"你把這當作我遵守諾言的證據"
+"​你​把​這當作​我​遵守​諾言​的​證據"
 
 #. TRANSLATORS: Quest dialog spoken by Gharbad the Weak
 #: Source/textdat.cpp:301
@@ -8916,16 +8914,16 @@ msgid ""
 " \n"
 "No pain and promise I keep!"
 msgstr ""
-"還沒有！差不多了。\n"
+"還​沒​有​！​差不​多​了​。​\n"
 " \n"
-"非常強大，非常強大。居住居住\n"
+"​非常​強​大​，​非常​強​大​。​居住​居住​\n"
 " \n"
-"沒有痛苦，我信守諾言"
+"沒​有​痛苦​，​我​信守​諾言"
 
 #. TRANSLATORS: Quest dialog spoken by Gharbad the Weak (Hostile)
 #: Source/textdat.cpp:303
 msgid "This too good for you. Very Powerful! You want - you take!"
-msgstr "這對你來說太好了。非常強大！你想要-你拿"
+msgstr "這對​你​來說​太​好​了​。​非常​強​大​！​你​想要​-​你​拿"
 
 #. TRANSLATORS: Quest dialog spoken by Zhar the Mad (annoyed / Hostile)
 #: Source/textdat.cpp:305
@@ -8933,18 +8931,18 @@ msgid ""
 "What?! Why are you here? All these interruptions are enough to make one "
 "insane. Here, take this and leave me to my work. Trouble me no more!"
 msgstr ""
-"什麼？！你為什麼在這裡？所有這些干擾都足以讓人發瘋。來，拿著這個，讓我繼續工"
-"作。別再煩我了"
+"什麼​？​！​你​為什麼​在​這裡​？​所有​這​些​干擾​都​足以​讓人​發瘋​。​來​，​拿​著​這個​，​讓​我​繼續​"
+"工作​。​別​再​煩​我​了"
 
 #. TRANSLATORS: Quest dialog spoken by Zhar the Mad (Hostile)
 #: Source/textdat.cpp:307
 msgid "Arrrrgh! Your curiosity will be the death of you!!!"
-msgstr "啊！你的好奇心將是你的死亡"
+msgstr "啊​！​你​的​好奇​心將​是​你​的​死亡"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain
 #: Source/textdat.cpp:308
 msgid "Hello, my friend. Stay awhile and listen..."
-msgstr "你好，我的朋友。呆一會兒聽我說"
+msgstr "你​好​，​我​的​朋友​。​呆​一​會​兒聽​我​說"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:309
@@ -8954,9 +8952,9 @@ msgid ""
 " \n"
 "Read them carefully for they can tell you things that even I cannot."
 msgstr ""
-"當你冒險深入迷宮時，你可能會發現那裡藏著大量的知識。\n"
+"當​你​冒險​深入​迷宮時​，​你​可能​會發現​那​裡​藏著​大量​的​知識​。​\n"
 " \n"
-"仔細閱讀它們，因為它們能告訴你即使是我也不能告訴你的事情"
+"仔細閱讀​它​們​，​因​為​它​們​能​告訴​你​即使​是​我​也​不​能​告訴​你​的​事情"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:311
@@ -8966,8 +8964,8 @@ msgid ""
 "and questions to which you seek knowledge, seek me out and I will tell you "
 "what I can."
 msgstr ""
-"我知道許多神話和傳說，其中可能包含對你在迷宮之旅中可能出現的問題的答案。如果"
-"你遇到挑戰和問題，你尋求知識，尋找我出來，我會告訴你我能做什麼"
+"我​知道​許​多​神話​和​傳說​，​其中​可能​包含​對​你​在​迷宮​之​旅​中​可​能​出現​的​問題​的​答案​。​如"
+"果​你​遇到​挑戰​和​問題​，​你​尋求​知識​，​尋​找​我​出來​，​我​會​告訴​你​我​能​做​什麼"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:313
@@ -8978,9 +8976,9 @@ msgid ""
 "is a skilled craftsman, and if he claims to be able to help you in any way, "
 "you can count on his honesty and his skill."
 msgstr ""
-"格里斯沃爾德——一個行動力和勇氣都很強的人。我打賭他從沒告訴過你他進迷宮救沃特"
-"的事，是嗎？他知道在那裡會有很多危險，但話說回來，你也是。他是一個技藝高超的"
-"工匠，如果他聲稱能以任何方式幫助你，你可以指望他的誠實和他的技能"
+"格里斯沃​爾德​——​一​個行動力​和​勇氣​都​很​強​的​人​。​我​打賭​他​從沒​告訴過​你​他​進迷宮救​沃特​的​"
+"事​，​是​嗎​？​他​知道​在​那​裡會​有​很多​危險​，​但​話說​回來​，​你​也是​。​他​是​一​個​技藝​高超​"
+"的​工匠​，​如果​他​聲稱​能​以​任何​方式​幫助​你​，​你​可以​指望​他​的​誠實​和​他​的​技能"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:315
@@ -8991,9 +8989,9 @@ msgid ""
 "all they had in making a life for themselves here. He is a good man with a "
 "deep sense of responsibility."
 msgstr ""
-"奧格登已經擁有和經營旭日酒店近四年了。他買了它就在幾個月前，這裡的一切都變成"
-"了地獄。他和他的妻子加爾達沒有錢離開，因為他們把所有的錢都投資在這裡為自己創"
-"造生活。他是一個很有責任感的好人"
+"奧​格登​已​經擁​有​和​經營​旭日​酒店​近​四​年​了​。​他​買​了​它​就​在​幾個​月​前​，​這裡​的​一切​都"
+"​變成​了​地獄​。​他​和​他​的​妻子​加爾達沒​有​錢離開​，​因​為​他​們​把​所有​的​錢​都​投資​在​這裡為​"
+"自己​創造​生活​。​他​是​一​個​很​有​責​任感​的​好​人"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:317
@@ -9004,10 +9002,10 @@ msgid ""
 "He finds comfort only at the bottom of his tankard nowadays, but there are "
 "occasional bits of truth buried within his constant ramblings."
 msgstr ""
-"可憐的法納姆。他令人不安地提醒人們，在那黑暗的一天，註定要與拉撒路一起進入大"
-"教堂的集會。他帶著生命逃走了，但他的勇氣和大部分的理智都留在了某個黑暗的坑"
-"里。如今，他只在酒館的最底層找到安慰，但在他不斷的閑談中，偶爾也隱藏著一些真"
-"相"
+"可​憐​的​法納姆​。​他​令​人​不安​地​提醒​人們​，​在​那​黑暗​的​一​天​，​註定​要​與​拉撒路​一起​進入​"
+"大​教堂​的​集會​。​他​帶​著​生命​逃走​了​，​但​他​的​勇氣​和​大部分​的​理智​都​留​在​了​某​個​黑暗​"
+"的​坑​里​。​如今​，​他​只​在​酒館​的​最​底​層​找到​安慰​，​但​在​他​不​斷​的​閑談​中​，​偶爾​也​隱"
+"​藏​著​一些​真相"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:319
@@ -9018,9 +9016,9 @@ msgid ""
 "access to many strange and arcane artifacts and tomes of knowledge that even "
 "I have never seen before."
 msgstr ""
-"女巫艾德里亞是特里斯特拉姆的一個異類。她是在大教堂被褻瀆后不久到達的，而大多"
-"數人都在逃離。她在城鎮邊緣建了一間小屋，似乎是一夜之間建成的，她能接觸到許多"
-"奇怪而神秘的文物和知識的大部頭，連我都從未見過"
+"女​巫艾德里亞​是​特里斯特拉姆​的​一​個​異類​。​她​是​在​大​教堂​被​褻瀆​后​不久​到達​的​，​而​大多​數​"
+"人​都​在逃離​。​她​在​城鎮邊​緣​建​了​一​間​小屋​，​似乎​是​一​夜​之​間​建成​的​，​她​能​接觸​到​許"
+"多​奇怪​而​神秘​的​文物​和​知識​的​大部頭​，​連​我​都​從​未​見過"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:321
@@ -9032,10 +9030,10 @@ msgid ""
 "never returned. The Blacksmith found the boy, but only after the foul beasts "
 "had begun to torture him for their sadistic pleasures."
 msgstr ""
-"維特的故事是一個可怕而悲慘的故事。他從他母親的懷抱中被帶到迷宮裡，被那些揮舞"
-"邪惡長矛的邪惡小惡魔們拖進了迷宮。那天還有許多孩子被帶走，包括利奧里克國王的"
-"兒子。宮殿的騎士們下樓去了，但再也沒有回來。鐵匠找到了那個男孩，但那是在那些"
-"邪惡的野獸開始折磨他以獲取他們的虐待狂般的快樂之後"
+"維特​的​故事​是​一​個​可怕​而​悲慘​的​故事​。​他​從​他​母親​的​懷抱​中​被​帶​到​迷宮裡​，​被​那些​揮"
+"舞邪惡​長矛​的​邪惡​小​惡​魔們​拖進​了​迷宮​。​那​天還​有​許​多​孩子​被​帶走​，​包括​利奧里克國王​的​兒"
+"子​。​宮殿​的​騎士​們​下樓去​了​，​但​再​也​沒​有​回來​。​鐵匠​找到​了​那個​男孩​，​但​那​是​在​那些"
+"​邪惡​的​野獸開​始​折磨​他​以​獲取​他​們​的​虐待​狂​般​的​快樂​之後"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:323
@@ -9045,9 +9043,9 @@ msgid ""
 "existed. His knowledge and skills are equaled by few, and his door is always "
 "open."
 msgstr ""
-"啊，佩平。我把他視為真正的朋友——也許是我在這裡最親密的朋友。他有時有點煩躁不"
-"安，但從來沒有一個更關心和體貼的靈魂存在過。他的知識和技能為數不多，他的大門"
-"總是敞開的"
+"啊​，​佩平​。​我​把​他​視為​真正​的​朋友​——​也​許​是​我​在​這裡​最​親密​的​朋友​。​他​有​時​有​點"
+"​煩躁不安​，​但​從來沒​有​一​個​更​關心​和​體貼​的​靈魂​存在​過​。​他​的​知識​和​技能​為數​不​多​，​"
+"他​的​大門總​是​敞開​的"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain (Gossip)
 #: Source/textdat.cpp:325
@@ -9058,14 +9056,14 @@ msgid ""
 "for her safety, but I know that any man in the village would rather die than "
 "see her harmed."
 msgstr ""
-"阿嬌是個好女人。她因興高采烈和爽朗的笑聲而備受崇拜，在我心中佔有特殊的地位。"
-"她留在酒館裡養活年邁的祖母，因為她病得不能旅行了。我有時擔心她的安全，但我知"
-"道村裡的任何男人都寧願死也不願看到她受到傷害"
+"阿嬌​是​個好​女人​。​她​因興​高​采烈​和​爽朗​的​笑聲​而​備受​崇拜​，​在​我​心​中​佔​有​特殊​的​地位​"
+"。​她​留​在​酒館裡​養活​年邁​的​祖母​，​因​為​她​病​得​不​能​旅行​了​。​我​有​時擔心​她​的​安全​，​"
+"但​我​知道​村裡​的​任何​男人​都​寧願死​也​不​願​看到​她​受到​傷害"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden
 #: Source/textdat.cpp:327
 msgid "Greetings, good master. Welcome to the Tavern of the Rising Sun!"
-msgstr "你好，好師父。歡迎來到朝陽酒館"
+msgstr "你​好​，​好​師父​。​歡​迎來​到​朝陽​酒館"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden (Gossip)
 #: Source/textdat.cpp:329
@@ -9075,8 +9073,8 @@ msgid ""
 "any of them agree on was this old axiom. Perhaps it will help you. You can "
 "cut the flesh, but you must crush the bone."
 msgstr ""
-"我的酒館裡有許多冒險家，講的故事是喝啤酒的十倍。我唯一聽到他們一致同意的就是"
-"這條古老的公理。也許這對你有幫助。你可以割肉，但必須壓碎骨頭"
+"我​的​酒館裡​有​許​多​冒​險家​，​講​的​故事​是​喝​啤酒​的​十​倍​。​我​唯一​聽​到​他​們​一致​同意​的"
+"​就​是​這條​古老​的​公理​。​也​許這對​你​有​幫助​。​你​可以​割肉​，​但​必須​壓​碎骨頭"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden (Gossip)
 #: Source/textdat.cpp:331
@@ -9084,8 +9082,8 @@ msgid ""
 "Griswold the blacksmith is extremely knowledgeable about weapons and armor. "
 "If you ever need work done on your gear, he is definitely the man to see."
 msgstr ""
-"鐵匠格里斯沃爾德對武器和護甲非常瞭解。如果你需要修理你的裝備，他絕對是你要找"
-"的人"
+"鐵​匠​格里斯沃​爾德對​武器​和​護甲​非常​瞭解​。​如果​你​需要​修理​你​的​裝備​，​他​絕對​是​你​要​找​的"
+"​人"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden (Gossip)
 #: Source/textdat.cpp:333
@@ -9093,8 +9091,8 @@ msgid ""
 "Farnham spends far too much time here, drowning his sorrows in cheap ale. I "
 "would make him leave, but he did suffer so during his time in the Labyrinth."
 msgstr ""
-"法納姆在這裡待的時間太長了，他用廉價的啤酒來消愁。我想讓他離開，但他在迷宮裡"
-"的時候確實很痛苦"
+"法納姆​在​這裡待​的​時間​太​長​了​，​他​用​廉價​的​啤酒來​消愁​。​我​想​讓​他​離開​，​但​他​在​迷宮裡"
+"​的​時候​確實​很​痛苦"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden (Gossip)
 #: Source/textdat.cpp:335
@@ -9105,16 +9103,16 @@ msgid ""
 "Well, no matter. If you ever have need to trade in items of sorcery, she "
 "maintains a strangely well-stocked hut just across the river."
 msgstr ""
-"艾德里亞的智慧超過了她的年齡，但我必須承認——她有點嚇到我了。\n"
+"艾德里亞​的​智慧​超過​了​她​的​年齡​，​但​我​必​須​承認​——​她​有​點嚇​到​我​了​。​\n"
 " \n"
-"好吧，沒關係。如果你需要交易巫術物品，她在河對岸有一個奇怪的倉庫"
+"​好​吧​，​沒關係​。​如果​你​需要​交易​巫術​物品​，​她​在​河​對岸​有​一​個​奇怪​的​倉庫"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden (Gossip)
 #: Source/textdat.cpp:337
 msgid ""
 "If you want to know more about the history of our village, the storyteller "
 "Cain knows quite a bit about the past."
-msgstr "如果你想更多地瞭解我們村子的歷史，講故事的凱恩對過去的事相當瞭解"
+msgstr "如果​你​想​更​多​地​瞭解​我​們​村子​的​歷史​，​講​故事​的​凱恩對過去​的​事​相當​瞭解"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden (Gossip)
 #: Source/textdat.cpp:339
@@ -9125,9 +9123,9 @@ msgid ""
 "He probably went fooling about someplace that he shouldn't have been. I feel "
 "sorry for the boy, but I don't abide the company that he keeps."
 msgstr ""
-"維特是個說唱歌手和小流氓。他總是惹麻煩，發生在他身上的事也就不足為奇了。\n"
+"維特​是​個說​唱​歌手​和​小​流氓​。​他​總​是​惹麻煩​，​發生​在​他​身​上​的​事​也​就​不足為奇​了​。​\n"
 " \n"
-"他可能去了一個他不該去的地方。我為那個男孩感到難過，但我不願意和他作伴"
+"​他​可能​去​了​一​個​他​不​該去​的​地方​。​我​為​那​個​男孩​感到​難過​，​但​我​不​願意​和​他​作伴"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden (Gossip)
 #: Source/textdat.cpp:341
@@ -9136,8 +9134,8 @@ msgid ""
 "always attending to the needs of others, but trouble of some sort or another "
 "does seem to follow him wherever he goes..."
 msgstr ""
-"佩平是個好人，當然也是村裡最慷慨的人。他總是關心別人的需要，但無論他走到哪"
-"里，總有一些麻煩跟著他"
+"佩平​是​個好​人​，​當然​也​是​村裡​最​慷慨​的​人​。​他​總​是​關心​別人​的​需要​，​但​無論​他​走到​哪"
+"里​，​總​有​一些​麻煩​跟​著​他"
 
 #. TRANSLATORS: Neutral dialog spoken by Ogden (Gossip)
 #: Source/textdat.cpp:343
@@ -9148,14 +9146,14 @@ msgid ""
 "Goodness knows I begged her to leave, telling her that I would watch after "
 "the old woman, but she is too sweet and caring to have done so."
 msgstr ""
-"阿嬌，我的酒吧女招待？如果不是因為她對大壩的責任感，她早就從這裡逃走了。\n"
+"阿嬌​，​我​的​酒吧​女​招待​？​如果​不​是​因為​她​對​大壩​的​責任感​，​她​早​就​從這裡​逃走​了​。​\n"
 " \n"
-"天知道我求她離開，告訴她我會照顧那個老婦人，但她太可愛了，太體貼了"
+"天​知道​我​求​她​離開​，​告訴​她​我​會照顧​那​個​老​婦人​，​但​她​太​可​愛​了​，​太​體貼​了"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin
 #: Source/textdat.cpp:345
 msgid "What ails you, my friend?"
-msgstr "你怎麼了，我的朋友"
+msgstr "你​怎麼​了​，​我​的​朋友"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:346
@@ -9165,8 +9163,8 @@ msgid ""
 "hurt one of the monsters, make sure it is dead or it very well may "
 "regenerate itself."
 msgstr ""
-"我有一個非常有趣的發現。與我們不同的是，迷宮中的生物不用藥水或魔法就能自愈。"
-"如果你傷害了其中一個怪物，確保它已經死了，否則它很可能會自己再生"
+"我​有​一​個​非常​有趣​的​發現​。​與​我​們​不同​的​是​，​迷宮​中​的​生物​不​用​藥水​或​魔法​就​能​自"
+"愈​。​如果​你​傷害​了​其中​一​個​怪物​，​確保​它​已​經死​了​，​否則​它​很​可能​會​自己​再生"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:348
@@ -9176,9 +9174,9 @@ msgid ""
 "any, you should read them all, for some may hold secrets to the workings of "
 "the Labyrinth."
 msgstr ""
-"在它被下面隱藏的東西接管之前，大教堂是一個非常有學問的地方。那裡有許多書可以"
-"找到。如果你發現了什麼，你應該把它們全部讀一遍，因為有些可能掌握著迷宮運作的"
-"秘密"
+"在​它​被​下面​隱藏​的​東西​接管​之前​，​大​教堂​是​一​個​非常​有​學問​的​地方​。​那裡​有​許​多​書​可"
+"以​找到​。​如果​你​發現​了​什麼​，​你​應該​把​它​們​全部​讀​一​遍​，​因​為​有些​可能​掌握​著迷宮​運​"
+"作​的​秘密"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:350
@@ -9187,8 +9185,8 @@ msgid ""
 "healing. He is a shrewd merchant, but his work is second to none. Oh, I "
 "suppose that may be because he is the only blacksmith left here."
 msgstr ""
-"格里斯沃爾德對戰爭藝術的瞭解和我對治療藝術的瞭解一樣多。他是個精明的商人，但"
-"他的工作是首屈一指的。哦，我想那可能是因為他是這裡唯一的鐵匠"
+"格里斯沃​爾德對戰爭​藝術​的​瞭解​和​我​對治療藝術​的​瞭解​一​樣​多​。​他​是​個​精明​的​商人​，​但​他​的"
+"​工作​是​首屈一指​的​。​哦​，​我​想​那​可能​是​因為​他​是​這裡​唯一​的​鐵匠"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:352
@@ -9197,8 +9195,8 @@ msgid ""
 "an innate ability to discern the true nature of many things. If you ever "
 "have any questions, he is the person to go to."
 msgstr ""
-"凱恩是一個真正的朋友和智慧的聖人。他擁有一個龐大的圖書館，有一種與生俱來的能"
-"力來辨別許多事物的本質。如果你有任何問題，他就是你要找的人"
+"凱恩​是​一​個​真正​的​朋友​和​智慧​的​聖人​。​他​擁​有​一​個​龐​大​的​圖書館​，​有​一​種​與生俱來​的"
+"​能力​來辨別​許​多​事物​的​本質​。​如果​你​有​任何​問題​，​他​就​是​你​要​找​的​人"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:354
@@ -9206,8 +9204,8 @@ msgid ""
 "Even my skills have been unable to fully heal Farnham. Oh, I have been able "
 "to mend his body, but his mind and spirit are beyond anything I can do."
 msgstr ""
-"就連我的技能也無法完全治癒法納姆。哦，我已經能修好他的身體了，但是他的精神和"
-"精神我無能為力"
+"就​連​我​的​技能​也​無法​完全​治癒法納姆​。​哦​，​我​已​經​能​修好​他​的​身體​了​，​但是​他​的​精神​"
+"和​精神​我​無​能​為力"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:356
@@ -9218,9 +9216,9 @@ msgid ""
 "be much more than the hovel it appears to be, but I can never seem to get "
 "inside the place."
 msgstr ""
-"當我使用一些有限的魔法來創造我儲存在這裡的藥劑和長生不老藥時，阿德里亞是一個"
-"真正的女巫。她似乎從不睡覺，她總是能接觸到許多神秘的大部頭和文物。我相信她的"
-"小屋可能比看上去的小屋要大得多，但我似乎永遠也進不了這個地方"
+"當​我​使用​一些​有限​的​魔法​來​創造​我​儲​存在​這裡​的​藥劑​和​長生不​老​藥時​，​阿德里亞​是​一​個​真"
+"正​的​女巫​。​她​似乎​從​不​睡覺​，​她​總​是​能​接觸​到​許多​神秘​的​大部頭​和​文物​。​我​相信​她​的"
+"​小屋​可能​比​看​上去​的​小屋​要​大​得​多​，​但​我​似乎​永遠​也​進​不​了​這個​地方"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:358
@@ -9230,8 +9228,8 @@ msgid ""
 "hideous. No one - and especially such a young child - should have to suffer "
 "the way he did."
 msgstr ""
-"可憐的懷特。我為那孩子做了一切可能的事，但我知道他看不起我被迫綁在他腿上的木"
-"釘。他的傷口很難看。沒有人——尤其是這麼小的孩子——應該像他那樣受苦"
+"可​憐​的​懷特​。​我​為​那​孩子​做​了​一切​可能​的​事​，​但​我​知道​他​看​不​起​我​被迫綁​在​他​腿上"
+"​的​木釘​。​他​的​傷口​很​難​看​。​沒​有​人​——​尤其是​這麼​小​的​孩子​——​應該​像​他​那​樣​受​苦"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:360
@@ -9242,9 +9240,9 @@ msgid ""
 "many murders that happen in the surrounding countryside, or perhaps the "
 "wishes of his wife that keep him and his family where they are."
 msgstr ""
-"我真不明白奧格登為什麼留在特里斯特拉姆。他有點緊張，但他是一個聰明而勤奮的"
-"人，無論他去哪裡都會做得很好。我想可能是因為害怕周圍農村發生的許多謀殺案，也"
-"可能是因為他妻子的願望，他和他的家人一直呆在那裡"
+"我​真​不​明白​奧格登​為什麼​留​在​特里斯特拉姆​。​他​有​點緊張​，​但​他​是​一​個​聰明​而​勤奮​的​人​，"
+"​無論​他​去​哪​裡​都​會​做​得​很​好​。​我​想​可能​是​因​為​害怕​周圍農​村​發生​的​許多​謀​殺案​，​"
+"也​可能​是​因​為​他​妻子​的​願望​，​他​和​他​的​家人​一直​呆​在​那​裡"
 
 #. TRANSLATORS: Neutral dialog spoken by Pipin (Gossip)
 #: Source/textdat.cpp:362
@@ -9255,21 +9253,21 @@ msgid ""
 "She claims that they are visions, but I have no proof of that one way or the "
 "other."
 msgstr ""
-"奧格登的酒吧女招待是個可愛的女孩。她祖母病得很重，有妄想癥。\n"
+"奧​格登​的​酒吧​女​招待​是​個​可​愛​的​女孩​。​她​祖母​病​得​很​重​，​有​妄想癥​。​\n"
 " \n"
-"她聲稱那是幻覺，但我沒有證據證明這一點"
+"​她​聲稱​那​是​幻覺​，​但​我​沒​有​證據​證明這​一​點"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian
 #: Source/textdat.cpp:364
 msgid "Good day! How may I serve you?"
-msgstr "很好的一天！我能為您效勞嗎"
+msgstr "很​好​的​一​天​！​我​能​為​您​效勞​嗎"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian (Gossip)
 #: Source/textdat.cpp:365
 msgid ""
 "My grandmother had a dream that you would come and talk to me. She has "
 "visions, you know and can see into the future."
-msgstr "我祖母夢見你來和我說話。她有遠見卓識，你知道，而且能預見未來"
+msgstr "我​祖母​夢​見​你​來​和​我​說話​。​她​有​遠見卓識​，​你​知道​，​而且​能​預見​未​來"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian (Gossip)
 #: Source/textdat.cpp:367
@@ -9280,10 +9278,10 @@ msgid ""
 "It would take someone quite brave, like you, to see what she is doing out "
 "there."
 msgstr ""
-"鎮邊的那個女人是個女巫！她看起來很好，她的名字叫艾德里亞，很討人喜歡，但我很"
-"害怕她。\n"
+"鎮邊​的​那個​女人​是​個女​巫​！​她​看起來​很​好​，​她​的​名字​叫​艾德里亞​，​很​討人​喜歡​，​但​我​很"
+"​害怕​她​。​\n"
 " \n"
-"像你這樣勇敢的人才能看到她在外面幹什麼"
+"像​你​這樣​勇敢​的​人才​能​看到​她​在​外面​幹什麼"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian (Gossip)
 #: Source/textdat.cpp:369
@@ -9293,9 +9291,9 @@ msgid ""
 "received praises from our King Leoric himself - may his soul rest in peace. "
 "Griswold is also a great hero; just ask Cain."
 msgstr ""
-"我們的鐵匠是特里斯特拉姆人民的驕傲。他不僅是一個手藝大師，在他的行會中贏得了"
-"許多比賽，而且他還得到了我們國王李奧瑞克本人的讚揚——愿他的靈魂安息。格里斯沃"
-"爾德也是一位偉大的英雄；問問凱恩"
+"我​們​的​鐵匠​是​特里斯特拉姆​人民​的​驕傲​。​他​不僅​是​一​個手藝大師​，​在​他​的​行會​中​贏​得了​許多"
+"​比賽​，​而且​他​還​得到​了​我​們國​王李奧瑞克​本人​的​讚揚​——​愿​他​的​靈魂​安息​。​格里斯沃​爾德​也"
+"​是​一​位​偉​大​的​英雄​；​問問​凱恩"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian (Gossip)
 #: Source/textdat.cpp:371
@@ -9303,7 +9301,8 @@ msgid ""
 "Cain has been the storyteller of Tristram for as long as I can remember. He "
 "knows so much, and can tell you just about anything about almost everything."
 msgstr ""
-"從我記事起，凱恩一直是崔斯特瑞姆的說書人。他知道的太多了，幾乎什麼都能告訴你"
+"從​我​記​事​起​，​凱恩​一直​是​崔斯特瑞姆​的​說書​人​。​他​知道​的​太​多​了​，​幾乎​什麼​都​能​告訴​"
+"你"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian (Gossip)
 #: Source/textdat.cpp:373
@@ -9315,9 +9314,10 @@ msgid ""
 "frustrated watching him slip farther and farther into a befuddled stupor "
 "every night."
 msgstr ""
-"法納姆是個酒鬼，他的肚子里裝滿了啤酒，其他人的耳朵里全是廢話。\n"
+"法納姆​是​個​酒鬼​，​他​的​肚子​里​裝滿​了​啤酒​，​其他​人​的​耳朵​里​全​是​廢話​。​\n"
 " \n"
-"我知道佩平和奧格登都同情他，但每天晚上看著他越來越昏迷不醒，我感到非常沮喪"
+"​我​知道​佩平​和​奧格登​都​同情​他​，​但​每​天​晚上​看​著​他​越​來​越​昏迷​不​醒​，​我​感到​非常​沮"
+"喪"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian (Gossip)
 #: Source/textdat.cpp:375
@@ -9327,8 +9327,9 @@ msgid ""
 "sword and more mysterious than any spell you can name. If you ever are in "
 "need of healing, Pepin can help you."
 msgstr ""
-"佩平救了我祖母的命，我知道我永遠也報答不了他。他治癒任何疾病的能力比最強大的"
-"劍更強大，比你能說出的任何咒語都更神秘。如果你需要治療，Pepin可以幫助你"
+"佩平救​了​我​祖母​的​命​，​我​知道​我​永遠​也​報​答​不​了​他​。​他​治癒​任何​疾病​的​能力​比​最​強​"
+"大​的​劍​更​強​大​，​比​你​能​說出​的​任何​咒語​都​更​神秘​。​如果​你​需要​治療​，​Pepin​可以​幫"
+"助​你"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian (Gossip)
 #: Source/textdat.cpp:377
@@ -9340,10 +9341,10 @@ msgid ""
 "seen horrors that I cannot even imagine, but some of that darkness hangs "
 "over him still."
 msgstr ""
-"我和沃特的母親，加那斯一起長大。雖然當那些可怕的生物偷走他時，她只是受到了輕"
-"微的傷害，但她始終沒有康復。我想她死於心碎。維特成了一個小氣鬼，只想從別人的"
-"汗水中獲利。我知道他受苦受難，經歷過我無法想像的恐懼，但他身上仍然籠罩著一些"
-"黑暗"
+"我​和​沃特​的​母親​，​加那斯​一起​長​大​。​雖然當​那些​可怕​的​生物​偷走​他​時​，​她​只​是​受到​了​輕"
+"微​的​傷害​，​但​她​始終沒​有​康復​。​我​想​她​死於​心碎​。​維特​成​了​一​個​小​氣鬼​，​只​想​從別​"
+"人​的​汗水​中​獲利​。​我​知道​他​受苦受難​，​經歷過​我​無法​想像​的​恐懼​，​但​他​身​上​仍然​籠罩​著​"
+"一些​黑暗"
 
 #. TRANSLATORS: Neutral dialog spoken by Gillian (Gossip)
 #: Source/textdat.cpp:379
@@ -9353,13 +9354,13 @@ msgid ""
 "them, and hope one day to leave this place and help them start a grand hotel "
 "in the east."
 msgstr ""
-"奧格登和他的妻子把我和我的祖母帶到他們家裡，甚至讓我在旅館工作掙了幾塊金幣。"
-"我欠他們太多了，希望有一天離開這個地方，幫助他們在東方開一家大酒店"
+"奧​格登​和​他​的​妻子​把​我​和​我​的​祖母​帶​到​他​們家裡​，​甚至​讓​我​在​旅館​工作​掙​了​幾塊​金幣"
+"​。​我​欠​他​們​太​多​了​，​希望​有​一​天​離開​這個​地方​，​幫助​他​們​在​東方​開​一​家​大​酒店"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold
 #: Source/textdat.cpp:381
 msgid "Well, what can I do for ya?"
-msgstr "我能為你做些什麼"
+msgstr "我​能​為​你​做​些​什麼"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:382
@@ -9369,8 +9370,8 @@ msgid ""
 "undying horrors down there, and there's nothing better to shatter skinny "
 "little skeletons!"
 msgstr ""
-"如果你想找一件好武器，讓我給你看看。帶上你最基本的鈍器，比如狼牙棒。像一個魅"
-"力對抗那些不朽的恐懼在那裡，沒有什麼比粉碎瘦小的骨架更好"
+"如果​你​想​找​一​件​好​武器​，​讓​我​給​你​看看​。​帶上​你​最​基本​的​鈍器​，​比如​狼牙棒​。​像​一​"
+"個​魅力​對抗​那些​不朽​的​恐懼​在​那裡​，​沒​有​什麼​比​粉碎​瘦小​的​骨架​更​好"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:384
@@ -9380,9 +9381,9 @@ msgid ""
 "mind, however, that it is slow to swing - but talk about dealing a heavy "
 "blow!"
 msgstr ""
-"斧頭？是的，這是一個很好的武器，可以對付任何敵人。看看它是如何劈開空氣的，然"
-"后想像一個漂亮的胖魔鬼頭在它的路徑上。但是，請記住，搖擺是很慢的，但是談論如"
-"何處理一個沉重的打擊"
+"斧頭​？​是​的​，​這​是​一​個​很​好​的​武器​，​可以​對付​任何​敵人​。​看看​它​是​如何​劈​開​空氣​的​"
+"，​然后​想像​一​個​漂亮​的​胖魔鬼​頭​在​它​的​路徑​上​。​但是​，​請記​住​，​搖擺​是​很​慢​的​，​但是"
+"​談論​如何​處理​一​個​沉重​的​打擊"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:386
@@ -9392,9 +9393,9 @@ msgid ""
 "or pierce on the undead, but against a living, breathing enemy, a sword will "
 "better slice their flesh!"
 msgstr ""
-"看看那個邊緣，那個平衡。右手中的劍，和對的敵人，是一切武器的主人。它銳利的刀"
-"鋒在不死生物身上幾乎找不到可砍或可刺的東西，但對於一個活生生的、會呼吸的敵"
-"人，一把劍會更好地切開他們的肉"
+"看看​那​個​邊緣​，​那​個​平衡​。​右​手​中​的​劍​，​和​對​的​敵人​，​是​一切​武器​的​主人​。​它​銳利"
+"​的​刀鋒​在​不​死​生物​身上​幾乎​找​不​到​可​砍​或​可​刺​的​東西​，​但​對​於​一​個​活生生​的​、​會"
+"​呼吸​的​敵人​，​一​把​劍會​更​好​地​切開​他​們​的​肉"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:388
@@ -9403,8 +9404,8 @@ msgid ""
 "Darkness. If you bring them to me, with a bit of work and a hot forge, I can "
 "restore them to top fighting form."
 msgstr ""
-"你的武器和護甲將顯示你與黑暗鬥爭的跡象。如果你把它們帶到我這裡來，稍加改造和"
-"熱鍛，我就能把它們恢復到最佳戰鬥狀態"
+"你​的​武器​和​護甲將​顯示​你​與​黑暗​鬥爭​的​跡象​。​如果​你​把​它​們帶​到​我​這裡來​，​稍加​改造​和​"
+"熱鍛​，​我​就​能​把​它​們​恢復​到​最​佳​戰鬥狀態"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:390
@@ -9414,18 +9415,16 @@ msgid ""
 "seems to get whatever she needs. If I knew even the smallest bit about how "
 "to harness magic as she did, I could make some truly incredible things."
 msgstr ""
-"當我不得不從我們該死的小鎮邊緣的商隊里偷運我所需要的金屬和工具時，那個女巫艾"
-"德里亞似乎總能得到她所需要的一切。如果我像她那樣懂得如何運用魔法，我就能做出"
-"一些真正不可思議的事情"
+"當​我​不​得不​從​我​們​該死​的​小​鎮​邊緣​的​商隊​里​偷運​我​所​需要​的​金屬​和​工具時​，​那​個​女​"
+"巫艾德里亞​似乎​總​能​得到​她​所​需要​的​一切​。​如果​我​像​她​那​樣​懂得​如何​運用​魔法​，​我​就​能​"
+"做出​一些​真正​不​可思議​的​事情"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:392
 msgid ""
 "Gillian is a nice lass. Shame that her gammer is in such poor health or I "
 "would arrange to get both of them out of here on one of the trading caravans."
-msgstr ""
-"阿嬌是個好姑娘。可惜她的男朋友身體這麼差，否則我會安排他們兩個都乘商隊離開這"
-"里"
+msgstr "阿嬌​是​個好​姑娘​。​可惜​她​的​男朋友​身體這​麼​差​，​否則​我​會​安排​他​們兩個​都​乘商隊離開這​里"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:394
@@ -9434,8 +9433,8 @@ msgid ""
 "in life. If I could bend steel as well as he can bend your ear, I could make "
 "a suit of court plate good enough for an Emperor!"
 msgstr ""
-"有時我覺得凱恩說得太多了，但我想這是他一生的使命。如果我能像他能彎曲你的耳朵"
-"一樣彎曲鋼鐵，我就能做一套足夠好的皇帝用的宮廷盤子"
+"有​時​我​覺​得​凱恩說​得​太​多​了​，​但​我​想​這​是​他​一​生​的​使命​。​如果​我​能​像​他​能​彎曲​"
+"你​的​耳朵​一​樣​彎曲​鋼鐵​，​我​就​能​做​一​套足夠​好​的​皇帝​用​的​宮廷​盤子"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:396
@@ -9445,9 +9444,9 @@ msgid ""
 "my side. I fear that the attack left his soul as crippled as, well, another "
 "did my leg. I cannot fight this battle for him now, but I would if I could."
 msgstr ""
-"那天晚上我和法納姆在一起，拉撒路把我們領進了迷宮。我再也見不到大主教了，如果"
-"法納姆不在我身邊，我可能就活不下去了。我擔心這次襲擊使他的靈魂像另一次襲擊我"
-"的腿一樣殘廢。我現在不能為他而戰，但如果可以的話我會的"
+"那​天​晚上​我​和​法納姆​在一起​，​拉撒路​把​我​們領進​了​迷宮​。​我​再​也​見​不​到​大主教​了​，​如果​"
+"法納姆​不​在​我​身邊​，​我​可能​就​活​不​下去​了​。​我​擔心​這次​襲擊​使​他​的​靈魂​像​另​一​次​襲擊"
+"​我​的​腿一樣​殘廢​。​我​現​在​不​能​為​他​而​戰​，​但​如果​可以​的​話​我​會​的"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:398
@@ -9456,8 +9455,8 @@ msgid ""
 "left in Tristram - or anywhere else for that matter - who has a bad thing to "
 "say about the healer."
 msgstr ""
-"把別人的需要放在自己的需要之上的好人。你不會發現任何人留在崔斯特瑞姆-或任何其"
-"他地方的問題-誰有一個壞東西說的治療者"
+"把​別人​的​需要​放​在​自己​的​需要​之上​的​好​人​。​你​不​會​發現​任何​人​留​在​崔斯特瑞姆-​或​任何​"
+"其他​地方​的​問題​-​誰​有​一​個壞東​西說​的​治療者"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:400
@@ -9468,9 +9467,9 @@ msgid ""
 "origin. I cannot hold that against him after what happened to him, but I do "
 "wish he would at least be careful."
 msgstr ""
-"那小子會惹上大麻煩的。。。或者我想我應該再說一遍。我試著讓他對在這裡工作和學"
-"習誠實的貿易感興趣，但他更喜歡經營來源可疑的貨物的高額利潤。我不能在他出事後"
-"再對他說這話，但我真希望他至少要小心點"
+"那​小子​會​惹​上​大麻煩​的​。​。​。​或者​我​想​我​應該​再​說​一​遍​。​我​試​著​讓​他​對​在​這裡​工"
+"作​和​學習​誠實​的​貿易感​興趣​，​但​他​更​喜歡經營​來源​可疑​的​貨物​的​高額利潤​。​我​不​能​在​他​出"
+"事​後​再​對​他​說這話​，​但​我​真​希望​他​至少​要​小心​點"
 
 #. TRANSLATORS: Neutral dialog spoken by Griswold (Gossip)
 #: Source/textdat.cpp:402
@@ -9483,21 +9482,21 @@ msgid ""
 "starved during that first year when the entire countryside was overrun by "
 "demons."
 msgstr ""
-"客棧老闆沒有什麼生意，也沒有真正的盈利途徑。他設法維持生計，為那些偶爾在村子"
-"里漂泊的人提供食物和住宿，但他們很可能會偷偷溜進夜空，就像他們付錢給他一樣。"
-"如果不是因為他在地窖里儲存了大量的穀物和乾肉，為什麼，我們大多數人會在第一年"
-"餓死，那時整個鄉村都被惡魔蹂躪"
+"客棧​老​闆沒​有​什麼​生意​，​也​沒​有​真正​的​盈利​途徑​。​他​設法維​持生計​，​為​那些​偶爾​在​村子​里"
+"​漂泊​的​人​提供​食物​和​住宿​，​但​他​們​很​可能​會​偷偷​溜進​夜空​，​就​像​他​們付錢給​他​一​樣​。"
+"​如果​不​是​因為​他​在​地窖里​儲存​了​大量​的​穀物​和​乾肉​，​為什麼​，​我​們​大多​數人會​在​第一​年​"
+"餓死​，​那​時​整​個​鄉​村​都​被​惡​魔蹂​躪"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham
 #: Source/textdat.cpp:404
 msgid "Can't a fella drink in peace?"
-msgstr "一個人不能安靜地喝酒嗎"
+msgstr "一​個​人​不​能​安靜​地​喝​酒​嗎"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:405
 msgid ""
 "The gal who brings the drinks? Oh, yeah, what a pretty lady. So nice, too."
-msgstr "送飲料的那個女孩？哦，是啊，多漂亮的女人啊。太好了"
+msgstr "送​飲料​的​那個​女孩​？​哦​，​是​啊​，​多​漂亮​的​女人​啊​。​太​好​了"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:407
@@ -9506,8 +9505,8 @@ msgid ""
 "stuff, but you listen to me... she's unnatural. I ain't never seen her eat "
 "or drink - and you can't trust somebody who doesn't drink at least a little."
 msgstr ""
-"為什麼那個老太婆不改變一下。當然，當然，她有東西，但你聽我說。。。她很不自"
-"然。我從來沒見過她吃喝——你也不能相信一個不喝酒的人"
+"為​什麼​那​個​老太​婆​不​改​變​一下​。​當然​，​當然​，​她​有​東西​，​但​你​聽​我​說​。​。​。​她​很"
+"​不​自然​。​我​從來沒見過​她​吃喝​——​你​也​不​能​相信​一​個​不​喝​酒​的​人"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:409
@@ -9516,8 +9515,8 @@ msgid ""
 "'em are real scary or funny... but I think he knows more than he knows he "
 "knows."
 msgstr ""
-"凱恩不是他說的那樣。當然，當然，他講了一個好故事。。。有些真的很嚇人或者很有"
-"趣。。。但我想他知道的比他知道的還多"
+"凱恩​不​是​他​說​的​那樣​。​當然​，​當然​，​他​講​了​一​個​好​故事​。​。​。​有些​真的​很​嚇人​或者​"
+"很​有趣​。​。​。​但​我​想​他​知道​的​比​他​知道​的​還​多"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:411
@@ -9525,8 +9524,8 @@ msgid ""
 "Griswold? Good old Griswold. I love him like a brother! We fought together, "
 "you know, back when... we... Lazarus...  Lazarus... Lazarus!!!"
 msgstr ""
-"格里斯沃爾德？善良的老格里斯沃爾德。我像兄弟一樣愛他！我們一起戰鬥，你知道，"
-"當。。。我們。。。拉撒路。。。拉撒路。。。拉撒路"
+"格里斯沃​爾德​？​善良​的​老格里斯沃​爾德​。​我​像​兄弟​一​樣愛​他​！​我​們​一起​戰鬥​，​你​知道​，​當​"
+"。​。​。​我​們​。​。​。​拉撒路​。​。​。​拉撒路​。​。​。​拉撒​路"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:413
@@ -9536,8 +9535,8 @@ msgid ""
 "wantin' help. Hey, I guess that would be kinda like you, huh hero? I was a "
 "hero too..."
 msgstr ""
-"呵呵，我喜歡佩平。他真的很努力，你知道的。聽著，你應該瞭解他。像這樣的好人總"
-"是有人想幫忙。嘿，我想那會有點像你，英雄？我也是個英雄"
+"呵呵​，​我​喜歡佩平​。​他​真的​很​努力​，​你​知道​的​。​聽著​，​你​應該​瞭解​他​。​像​這樣​的​好​人總"
+"​是​有​人​想​幫​忙​。​嘿​，​我​想​那​會​有​點像​你​，​英雄​？​我​也​是​個​英雄"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:415
@@ -9546,8 +9545,9 @@ msgid ""
 "problems. Listen here - that kid is gotta sweet deal, but he's been there, "
 "you know? Lost a leg! Gotta walk around on a piece of wood. So sad, so sad..."
 msgstr ""
-"維特是個問題比我還多的孩子，我知道所有的問題。聽著-那孩子一定是個好人，但他去"
-"過那裡，你知道嗎？丟了一條腿！得在一塊木頭上走來走去。太傷心了，太傷心了"
+"維特​是​個問題​比​我​還​多​的​孩子​，​我​知道​所有​的​問題​。​聽著​-​那​孩子​一定​是​個好​人​，​但​"
+"他​去​過​那​裡​，​你​知道​嗎​？​丟​了​一​條腿​！​得​在​一​塊木頭​上​走​來​走​去​。​太​傷心​了​，​"
+"太​傷心​了"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:417
@@ -9556,8 +9556,8 @@ msgid ""
 "long as she keeps tappin' kegs, I'll like her just fine. Seems like I been "
 "spendin' more time with Ogden than most, but he's so good to me..."
 msgstr ""
-"奧格登是鎮上最好的男人。我覺得他妻子不太喜歡我，但只要她不停地敲桶，我就很喜"
-"歡她。似乎我和奧格登在一起的時間比大多數人都多，但他對我很好"
+"奧​格登​是​鎮​上​最​好​的​男人​。​我​覺​得​他​妻子​不​太​喜歡​我​，​但​只要​她​不​停​地​敲桶​，​我"
+"​就​很​喜歡​她​。​似乎​我​和​奧格登​在一起​的​時間​比​大多​數​人​都​多​，​但​他​對​我​很​好"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:419
@@ -9566,8 +9566,8 @@ msgid ""
 "specialty. This here is the best... theeeee best! That other ale ain't no "
 "good since those stupid dogs..."
 msgstr ""
-"我想告訴你，因為我知道這一切。這是我的專長。這是最好的。。。最好的！其他的啤"
-"酒不好，因為那些蠢狗"
+"我​想​告訴​你​，​因​為​我​知道​這​一切​。​這​是​我​的​專長​。​這​是​最​好​的​。​。​。​最​好​的​！"
+"​其他​的​啤酒​不​好​，​因​為​那些​蠢​狗"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:421
@@ -9576,8 +9576,8 @@ msgid ""
 "somewhere under the church is a whole pile o' gold. Gleamin' and shinin' and "
 "just waitin' for someone to get it."
 msgstr ""
-"從來沒有人。。。聽我說。在某個地方-我不太確定-但是在教堂下面的某個地方有一堆"
-"金子。閃閃發光，只是等待有人得到它"
+"從​來沒​有​人​。​。​。​聽​我​說​。​在​某​個​地方​-​我​不​太​確定​-​但是​在​教堂​下面​的​某​個​地"
+"方​有​一​堆​金子​。​閃閃​發光​，​只是​等待​有​人​得到​它"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:423
@@ -9587,8 +9587,9 @@ msgid ""
 "brutes! Oh, I don't care what Griswold says, they can't make anything like "
 "they used to in the old days..."
 msgstr ""
-"我知道你有自己的想法，我知道你不會相信的，但你的武器，你在那裡-它只是不好對付"
-"那些大畜生！哦，我不管格里斯沃爾德怎麼說，他們不能像以前那樣做任何東西"
+"我​知道​你​有​自己​的​想法​，​我​知道​你​不​會​相信​的​，​但​你​的​武器​，​你​在​那​裡​-​它​只​是"
+"​不​好​對付​那些​大​畜生​！​哦​，​我​不管​格里斯沃​爾德​怎​麼說​，​他​們​不​能​像​以前​那​樣​做​任何"
+"​東西"
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:425
@@ -9597,13 +9598,14 @@ msgid ""
 "and get out of here. That boy out there... He's always got somethin good, "
 "but you gotta give him some gold or he won't even show you what he's got."
 msgstr ""
-"如果我是你。。。我不是。。。但如果我是，我會賣掉你所有的東西然後離開這裡。外"
-"面那個男孩。。。他總是有好東西，但你得給他點金子，否則他連他的東西都不給你看"
+"如果​我​是​你​。​。​。​我​不​是​。​。​。​但​如果​我​是​，​我​會​賣掉​你​所有​的​東西然​後​離開​這裡"
+"​。​外面​那​個​男孩​。​。​。​他​總​是​有​好​東西​，​但​你​得給​他​點金子​，​否則​他​連​他​的​東西​"
+"都​不​給​你​看"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria
 #: Source/textdat.cpp:427
 msgid "I sense a soul in search of answers..."
-msgstr "我感覺到一個靈魂在尋找答案"
+msgstr "我​感覺​到​一​個​靈魂​在​尋​找​答案"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:428
@@ -9612,8 +9614,8 @@ msgid ""
 "words. Should you already have knowledge of the arcane mysteries scribed "
 "within a book, remember - that level of mastery can always increase."
 msgstr ""
-"智慧是應得的，而不是給予的。如果你發現了一本知識的大部頭，就要吞沒它的文字。"
-"如果你已經掌握了書中描述的神秘事物的知識，記住-掌握的水平總是可以提高的"
+"智慧​是​應得​的​，​而​不​是​給予​的​。​如果​你​發現​了​一​本​知識​的​大部頭​，​就​要​吞沒​它​的​文字"
+"​。​如果​你​已​經​掌握​了​書中​描述​的​神秘​事物​的​知識​，​記住​-​掌握​的​水平​總​是​可以​提高​的"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:430
@@ -9625,9 +9627,9 @@ msgid ""
 "be kept at the ready in your mind. Know also that these scrolls can be read "
 "but once, so use them with care."
 msgstr ""
-"最強大的力量往往是最短命的。你可以在羊皮紙的卷軸上找到古老的權力話語。這些卷"
-"軸的力量在於學徒或熟練的施展能力。他們的弱點是，他們必須首先大聲朗讀，永遠不"
-"能隨時準備在你的腦海中。還要知道這些卷軸只能讀一次，所以要小心使用"
+"最​強​大​的​力量​往往​是​最​短命​的​。​你​可以​在​羊皮紙​的​卷軸​上​找到​古老​的​權力​話語​。​這​些​"
+"卷軸​的​力量​在​於​學徒​或​熟練​的​施展​能力​。​他​們​的​弱點​是​，​他​們必​須​首先​大聲朗讀​，​永遠​"
+"不​能​隨時​準備​在​你​的​腦海​中​。​還​要​知道​這​些​卷軸​只​能​讀​一​次​，​所以​要​小心​使用"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:432
@@ -9638,9 +9640,9 @@ msgid ""
 "magical energies many times over. I have the ability to restore their power "
 "- but know that nothing is done without a price."
 msgstr ""
-"儘管太陽的熱量無法估量，但光是蠟燭的火焰就更危險。沒有適當的聚焦，任何能量，"
-"無論多大，都不能被使用。對於許多咒語來說，被賦予靈能的杖可以被多次充滿魔法能"
-"量。我有能力恢復他們的力量，但我知道沒有代價是做不到的"
+"儘​管​太​陽​的​熱量​無​法​估量​，​但​光是​蠟燭​的​火焰​就​更​危險​。​沒​有​適當​的​聚焦​，​任何​能量"
+"​，​無論​多​大​，​都​不​能​被​使用​。​對於​許​多​咒​語來說​，​被​賦予​靈能​的​杖​可以​被​多​次​充滿"
+"​魔法​能量​。​我​有​能力​恢復​他​們​的​力量​，​但​我​知道​沒​有​代價​是​做​不​到​的"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:434
@@ -9649,8 +9651,8 @@ msgid ""
 "or scroll that you cannot decipher, do not hesitate to bring it to me. If I "
 "can make sense of it I will share what I find."
 msgstr ""
-"我們知識的總和就是它的人民的總和。如果你發現一本書或卷軸，你不能破譯，不要猶"
-"豫，把它給我。如果我能理解的話，我會分享我的發現"
+"我​們​知識​的​總​和​就​是​它​的​人民​的​總和​。​如果​你​發現​一​本​書​或​卷軸​，​你​不​能​破譯​，​"
+"不​要​猶豫​，​把​它​給​我​。​如果​我​能​理解​的​話​，​我​會​分享​我​的​發現"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:436
@@ -9659,8 +9661,8 @@ msgid ""
 "blacksmith Griswold is more of a sorcerer than he knows. His ability to meld "
 "fire and metal is unequaled in this land."
 msgstr ""
-"對一個只懂鋼鐵的人來說，沒有什麼比鋼鐵更神奇了。鐵匠格里斯沃爾德比他所知道的"
-"更像個巫師。他融火與金屬的能力在這片土地上是無與倫比的"
+"對​一​個​只​懂​鋼鐵​的​人​來說​，​沒​有​什麼​比鋼鐵​更​神奇​了​。​鐵匠​格里斯沃​爾德比​他​所​知道​的​"
+"更​像​個​巫師​。​他​融火​與金屬​的​能力​在​這片​土地​上​是​無與倫​比​的"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:438
@@ -9670,8 +9672,8 @@ msgid ""
 "matriarch over her own. She fears me, but it is only because she does not "
 "understand me."
 msgstr ""
-"腐敗有欺騙的力量，而清白有純潔的力量。年輕的阿嬌有一顆純潔的心，把女家長的需"
-"要凌駕于自己的需要之上。她害怕我，但那只是因為她不瞭解我"
+"腐敗​有​欺騙​的​力量​，​而​清白​有​純潔​的​力量​。​年輕​的​阿嬌​有​一​顆​純潔​的​心​，​把​女​家長​的"
+"​需要​凌駕于​自己​的​需要​之上​。​她​害怕​我​，​但​那​只​是​因為​她​不​瞭解​我"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:440
@@ -9681,8 +9683,8 @@ msgid ""
 "not look. His knowledge of what lies beneath the cathedral is far greater "
 "than even he allows himself to realize."
 msgstr ""
-"在黑暗中打開的箱子所裝的財寶，並不比在光明中打開的箱子更大。講故事的凱恩是一"
-"個謎，但只有那些誰不看。他對大教堂下面的東西的瞭解遠遠超過了他自己的想像"
+"在​黑暗中​打開​的​箱子​所​裝​的​財寶​，​並​不​比​在​光明​中​打開​的​箱子​更​大​。​講​故事​的​凱恩​是"
+"​一​個謎​，​但​只有​那些​誰​不​看​。​他​對大​教堂​下面​的​東西​的​瞭解遠遠​超過​了​他​自己​的​想像"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:442
@@ -9692,9 +9694,9 @@ msgid ""
 "fellow townspeople betrayed by the Archbishop Lazarus. He has knowledge to "
 "be gleaned, but you must separate fact from fantasy."
 msgstr ""
-"你對一個人的信心越高，他就越會墮落。法納姆已經失去了他的靈魂，但不是任何惡"
-"魔。當他看到他的同鄉們被拉撒路大主教出賣時，他失去了理智。他有知識可以收集，"
-"但你必須把事實和幻想分開"
+"你​對​一​個​人​的​信心​越​高​，​他​就​越​會​墮​落​。​法納姆​已​經​失去​了​他​的​靈魂​，​但​不​是​"
+"任何​惡魔​。​當​他​看到​他​的​同鄉們​被​拉撒路​大​主教​出賣時​，​他​失去​了​理智​。​他​有​知識​可以​收"
+"集​，​但​你​必須​把​事實​和​幻想分開"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:444
@@ -9705,9 +9707,9 @@ msgid ""
 "understanding of the creation of elixirs and potions. He is as great an ally "
 "as you have in Tristram."
 msgstr ""
-"手、心和心在完美的和諧中就能創造奇蹟。治療者佩平以一種連我都看不到的方式觀察"
-"身體。他對長生不老藥和藥水的理解使他恢復病人和傷者的能力得到了放大。他和你在"
-"特里斯特拉姆一樣是個偉大的盟友"
+"手​、​心​和心​在​完美​的​和​諧​中​就​能​創造奇蹟​。​治療者​佩平​以​一​種連​我​都​看​不​到​的​方式​觀"
+"察身體​。​他​對​長生不​老藥​和​藥水​的​理解​使​他​恢復​病人​和​傷者​的​能力​得到​了​放大​。​他​和​你​"
+"在​特里斯特拉姆​一樣​是​個偉​大​的​盟友"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:446
@@ -9720,10 +9722,10 @@ msgid ""
 "reproachful, Wirt can provide assistance for your battle against the "
 "encroaching Darkness."
 msgstr ""
-"未來有很多我們看不到的，但當它來臨時，將是孩子們掌握著它。這個男孩的靈魂是黑"
-"暗的，但他對這個城鎮和它的人民沒有威脅。他與附近城鎮的頑童和不為人知的行會的"
-"秘密交易使他能夠接觸到許多在特里斯特拉姆很難找到的裝置。雖然他的方法可能會受"
-"到指責，但Wirt可以為你對抗日益逼近的黑暗提供幫助"
+"未​來​有​很多​我​們​看​不​到​的​，​但​當​它​來臨時​，​將​是​孩子​們​掌握​著​它​。​這個​男孩​的​靈魂"
+"​是​黑暗​的​，​但​他​對這​個城鎮​和​它​的​人民​沒​有​威脅​。​他​與​附近​城鎮​的​頑童​和​不​為​人​知"
+"​的​行會​的​秘密​交易​使​他​能​夠​接觸​到​許多​在​特里斯特拉姆​很​難​找到​的​裝置​。​雖然​他​的​方法​"
+"可能​會​受到​指責​，​但​Wirt​可以​為​你​對抗​日益​逼近​的​黑暗​提供​幫助"
 
 #. TRANSLATORS: Neutral dialog spoken by Adria (Gossip)
 #: Source/textdat.cpp:448
@@ -9736,16 +9738,16 @@ msgid ""
 "found there, provide a glimpse of a life that the people here remember. It "
 "is that memory that continues to feed their hopes for your success."
 msgstr ""
-"土墻和茅草屋頂不是一個家。旅館老闆奧格登在這個鎮上的作用比許多人所理解的要大"
-"得多。他為阿嬌和她的女族長提供庇護所，維持法納姆留給他的生活，併爲留在鎮上的"
-"所有人提供一個錨，讓他們回到特里斯特拉姆曾經的樣子。他的小酒館，以及在那裡仍"
-"然可以找到的簡單的樂趣，讓我們看到了這裡的人們所記得的生活。正是這段記憶，讓"
-"他們對你的成功充滿了希望"
+"土墻​和​茅草屋​頂​不​是​一​個​家​。​旅館​老​闆​奧​格登​在​這個鎮​上​的​作用​比​許​多​人​所​理解​的​"
+"要​大​得​多​。​他​為​阿嬌​和​她​的​女族長​提供​庇護所​，​維持​法納姆留給​他​的​生活​，​併爲​留​在​鎮上"
+"​的​所有人​提供​一​個錨​，​讓​他​們​回到​特里斯特拉姆​曾經​的​樣子​。​他​的​小酒館​，​以及​在​那裡​仍然"
+"​可以​找到​的​簡單​的​樂趣​，​讓​我​們​看到​了​這裡​的​人們​所​記得​的​生活​。​正​是​這段​記憶​，​讓"
+"​他​們對​你​的​成功​充滿​了​希望"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt
 #: Source/textdat.cpp:450
 msgid "Pssst... over here..."
-msgstr "PSST。。。在這裡"
+msgstr "PSST​。​。​。​在​這裡"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:451
@@ -9755,17 +9757,17 @@ msgid ""
 " \n"
 "Sometimes, only you will be able to find a purpose for some things."
 msgstr ""
-"並不是所有在特里斯特拉姆的人都有一個用途-或市場-你會發現在迷宮中的一切。連我"
-"都不相信。\n"
+"並​不​是​所有​在​特里斯特拉姆​的​人​都​有​一​個​用途​-​或​市場​-​你​會發現​在​迷宮​中​的​一切​。​連"
+"​我​都​不​相信​。​\n"
 " \n"
-"有時候，只有你才能為某些事情找到目標"
+"​有​時候​，​只有​你​才​能​為​某些​事情​找到​目標"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:453
 msgid ""
 "Don't trust everything the drunk says. Too many ales have fogged his vision "
 "and his good sense."
-msgstr "別相信醉漢說的每一句話。太多的啤酒模糊了他的視力和判斷力"
+msgstr "別​相信​醉漢說​的​每​一​句​話​。​太​多​的​啤酒​模糊​了​他​的​視力​和​判斷力"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:455
@@ -9775,9 +9777,9 @@ msgid ""
 "Griswold, Pepin or that witch, Adria. I'm sure that they will snap up "
 "whatever you can bring them..."
 msgstr ""
-"如果你沒注意到，我不會從崔斯特瑞買任何東西。我是一個進口優質商品的進口商。如"
-"果你想兜售垃圾，你得去看看格里斯沃爾德，佩平或那個女巫，阿德里亞。我相信他們"
-"會搶購你能帶給他們的任何東西"
+"如果​你​沒​注意​到​，​我​不​會從​崔斯特瑞買​任何​東西​。​我​是​一​個​進口​優質​商品​的​進口商​。​如果​"
+"你​想​兜售​垃圾​，​你​得​去​看看​格里斯沃​爾德​，​佩平​或​那個女巫​，​阿德里亞​。​我​相信​他​們會​搶購​"
+"你​能​帶給​他​們​的​任何​東西"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:457
@@ -9787,9 +9789,9 @@ msgid ""
 "I'll never get enough money to... well, let's just say that I have definite "
 "plans that require a large amount of gold."
 msgstr ""
-"我想我欠鐵匠一條命——這是怎麼回事。當然，格里斯沃爾德讓我在鐵匠鋪當學徒，他是"
-"個很好的人，但我永遠拿不到足夠的錢。。。好吧，就說我有明確的計劃，需要大量的"
-"黃金"
+"我​想​我​欠鐵匠​一​條命​——​這​是​怎麼​回​事​。​當然​，​格里斯沃​爾德讓​我​在​鐵匠​鋪當​學徒​，​他​是"
+"​個​很​好​的​人​，​但​我​永遠​拿​不​到​足夠​的​錢​。​。​。​好​吧​，​就​說​我​有​明確​的​計劃​，​"
+"需要​大量​的​黃​金"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:459
@@ -9799,9 +9801,9 @@ msgid ""
 "Gillian is a beautiful girl who should get out of Tristram as soon as it is "
 "safe. Hmmm... maybe I'll take her with me when I go..."
 msgstr ""
-"如果我再大幾歲，我會盡我所能給她帶來財富，讓我向你保證，我可以得到一些非常好"
-"的東西。阿嬌是一個美麗的女孩，她應該儘快離開特里斯特拉姆，只要它是安全的。六"
-"羥甲基三聚氰胺六甲醚。。。也許我去的時候會帶她一起去"
+"如果​我​再​大​幾歲​，​我​會盡​我​所​能給​她​帶來​財富​，​讓​我​向​你​保證​，​我​可以​得到​一些​非常​"
+"好​的​東西​。​阿嬌​是​一​個​美麗​的​女孩​，​她​應該​儘​快離​開​特里斯特拉姆​，​只要​它​是​安全​的​。​"
+"六​羥​甲​基​三​聚氰​胺六甲醚​。​。​。​也​許​我​去​的​時候會帶​她​一起​去"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:461
@@ -9810,8 +9812,8 @@ msgid ""
 "woman across the river. He keeps telling me about how lucky I am to be "
 "alive, and how my story is foretold in legend. I think he's off his crock."
 msgstr ""
-"凱恩知道的太多了。他把我嚇死了，甚至比河對岸的那個女人還可怕。他不停地告訴"
-"我，我活著是多麼幸運，我的故事是如何在傳說中被預言的。我想他是瘋了"
+"凱恩​知道​的​太​多​了​。​他​把​我​嚇死​了​，​甚至​比河對岸​的​那​個​女人​還​可怕​。​他​不​停​地​告訴"
+"​我​，​我​活​著​是​多麼幸運​，​我​的​故事​是​如何​在​傳說​中​被​預言​的​。​我​想​他​是​瘋​了"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:463
@@ -9822,9 +9824,9 @@ msgid ""
 "down there, so don't even start telling me about your plans to destroy the "
 "evil that dwells in that Labyrinth. Just watch your legs..."
 msgstr ""
-"法納姆-現在有一個男人有嚴重的問題，我知道所有的嚴重問題可以。他過於相信一個人"
-"的正直，拉撒路就把他帶進了死亡的深淵。哦，我知道下面是什麼樣的，所以別告訴我"
-"你打算消滅迷宮裡的惡魔。小心你的腿"
+"法​納姆-現​在​有​一​個​男人​有​嚴重​的​問題​，​我​知道​所有​的​嚴重​問題​可以​。​他​過於​相信​一​個​"
+"人​的​正直​，​拉撒路​就​把​他​帶進​了​死亡​的​深淵​。​哦​，​我​知道​下面​是​什麼樣​的​，​所以​別告訴​"
+"我​你​打算​消滅迷宮裡​的​惡魔​。​小心​你​的​腿"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:465
@@ -9834,9 +9836,9 @@ msgid ""
 " \n"
 "If I'd have had some of those potions he brews, I might still have my leg..."
 msgstr ""
-"只要你不需要任何東西復位，老佩平是一樣好，他們來了。\n"
+"只要​你​不​需要​任何​東西​復位​，​老佩平​是​一​樣​好​，​他​們來​了​。​\n"
 " \n"
-"如果我有一些他釀造的藥水，我可能還有腿"
+"​如果​我​有​一些​他​釀造​的​藥水​，​我​可能​還​有​腿"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:467
@@ -9846,9 +9848,9 @@ msgid ""
 "get whatever she needs, too. Adria gets her hands on more merchandise than "
 "I've seen pass through the gates of the King's Bazaar during High Festival."
 msgstr ""
-"阿德里亞真讓我煩惱。當然，凱恩對你說的關於過去的事是令人毛骨悚然的，但那個女"
-"巫能看透你的過去。她也總有辦法得到她需要的東西。阿德里婭拿到的商品比我在節日"
-"期間穿過國王集市的大門看到的還要多"
+"阿德里亞​真​讓​我​煩惱​。​當然​，​凱恩對​你​說​的​關於​過去​的​事​是​令​人​毛骨悚然​的​，​但​那​個​女"
+"​巫能​看​透​你​的​過去​。​她​也​總​有​辦法​得到​她​需要​的​東西​。​阿德里婭​拿到​的​商品​比​我​在​節"
+"​日期​間​穿過國​王集市​的​大門​看到​的​還​要​多"
 
 #. TRANSLATORS: Neutral dialog spoken by Wirt (Gossip)
 #: Source/textdat.cpp:469
@@ -9858,9 +9860,9 @@ msgid ""
 "stupid tavern. I guess at the least he gives Gillian a place to work, and "
 "his wife Garda does make a superb Shepherd's pie..."
 msgstr ""
-"奧格登呆在這裡真是個傻瓜。我可以以一個非常合理的價格把他弄到城外去，但他堅持"
-"要和那家愚蠢的酒館混過去。我想至少他給了阿嬌一個工作的地方，他的妻子嘉達做了"
-"一個很棒的牧羊派"
+"奧​格登呆​在​這裡​真​是​個​傻瓜​。​我​可以​以​一​個​非常​合理​的​價格​把​他​弄​到​城外​去​，​但​他​"
+"堅持​要​和​那家​愚蠢​的​酒館​混過​去​。​我​想​至少​他​給​了​阿嬌​一​個​工作​的​地方​，​他​的​妻子​嘉"
+"達​做​了​一​個​很​棒​的​牧羊派"
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:471 Source/textdat.cpp:479 Source/textdat.cpp:487
@@ -9869,8 +9871,8 @@ msgid ""
 "who would seek to steal the treasures secured within this room. So speaks "
 "the Lord of Terror, and so it is written."
 msgstr ""
-"英雄殿後是藏骨密室。永恒的死亡等待著任何想要偷走這間屋子裡珍寶的人。恐懼之王"
-"如此說，經上如此記著"
+"英雄​殿後​是​藏骨密室​。​永恒​的​死亡​等待​著​任何​想要​偷​走​這間​屋子​裡珍寶​的​人​。​恐懼​之​王​如此"
+"​說​，​經​上​如此​記​著"
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:473 Source/textdat.cpp:481 Source/textdat.cpp:489
@@ -9878,7 +9880,7 @@ msgstr ""
 msgid ""
 "...and so, locked beyond the Gateway of Blood and past the Hall of Fire, "
 "Valor awaits for the Hero of Light to awaken..."
-msgstr "……所以，在血之門的外面，在火之殿的前面，勇敢的等待著光之英雄的覺醒"
+msgstr "…​…​所以​，​在​血​之門​的​外面​，​在​火之殿​的​前面​，​勇敢​的​等待​著光​之​英雄​的​覺醒"
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:475 Source/textdat.cpp:483 Source/textdat.cpp:491
@@ -9893,14 +9895,14 @@ msgid ""
 "Out of darkness, out of mind,\n"
 "Cast down into the Halls of the Blind."
 msgstr ""
-"我能看到你看不到的東西。\n"
-"視力乳白色，然後眼睛腐爛。\n"
-"當你轉過身，他們就不見了，\n"
-"低語著他們隱藏的歌聲。\n"
-"然後你看到什麼是不可能的，\n"
-"陰影在光線應該在的地方移動。\n"
-"走出黑暗，走出心靈，\n"
-"扔到盲人的大廳里"
+"我​能​看到​你​看​不​到​的​東西​。​\n"
+"​視力​乳白色​，​然​後​眼睛​腐爛​。​\n"
+"當​你​轉​過身​，​他​們​就​不​見​了​，​\n"
+"​低​語​著​他​們​隱藏​的​歌聲​。​\n"
+"然​後​你​看到​什麼​是​不​可能​的​，​\n"
+"​陰影​在​光線應該​在​的​地方​移動​。​\n"
+"​走出​黑暗​，​走出​心靈​，​\n"
+"​扔​到​盲人​的​大廳​里"
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:477 Source/textdat.cpp:485 Source/textdat.cpp:493
@@ -9910,8 +9912,8 @@ msgid ""
 "fulfill his endless sacrifices to the Dark ones who scream for one thing - "
 "blood."
 msgstr ""
-"地獄的軍械庫是血之軍閥的家。他身後躺著成千上萬具殘缺的屍體。天使和人類都被砍"
-"掉了，來完成他對黑暗勢力無盡的犧牲，他們只為一件事而尖叫——鮮血"
+"地獄​的​軍械庫​是​血​之​軍閥​的​家​。​他​身​後​躺著​成千上​萬具殘缺​的​屍體​。​天使​和​人類​都​被​砍掉"
+"​了​，​來​完成​他​對​黑暗​勢力無盡​的​犧牲​，​他​們​只​為​一​件​事​而​尖叫​——​鮮​血"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:505
@@ -9924,10 +9926,10 @@ msgid ""
 "sky. Neither side ever gains sway for long as the forces of Light and "
 "Darkness constantly vie for control over all creation."
 msgstr ""
-"注意並見證這裡的真理，因為它們是赫拉迪姆最後的遺產。甚至在現在，在我們所知的"
-"領域之外，在天堂的烏托邦王國和燃燒地獄的混亂深淵之間，仍有一場戰爭在肆虐。這"
-"場戰爭被稱為大沖突，它的肆虐和燃燒時間比天空中任何一顆星星都要長。只要光明和"
-"黑暗的力量不斷爭奪對所有造物的控制權，任何一方都不會獲得支配權"
+"注意​並見​證這裡​的​真理​，​因​為​它​們​是​赫拉迪姆​最後​的​遺產​。​甚至​在​現在​，​在​我​們​所​知​的"
+"​領域​之外​，​在​天堂​的​烏托邦王國​和​燃燒​地獄​的​混亂​深​淵​之​間​，​仍​有​一​場​戰爭​在​肆虐​。​"
+"這場戰爭​被​稱為​大​沖突​，​它​的​肆虐​和​燃燒時間​比​天空​中​任何​一​顆​星星​都​要​長​。​只要​光明​和"
+"​黑暗​的​力量​不​斷爭奪對​所有​造物​的​控制​權​，​任何​一​方​都​不​會獲​得​支​配權"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:507
@@ -9940,10 +9942,10 @@ msgid ""
 "have even allied themselves with either side, and helped to dictate the "
 "course of the Sin War."
 msgstr ""
-"注意並見證這裡的真理，因為它們是赫拉迪姆最後的遺產。當天堂和地獄之間永恒的沖"
-"突落在凡人的土地上，這就是原罪之戰。天使和惡魔偽裝著行走在人類之中，秘密地戰"
-"鬥，遠離凡人窺探的眼睛。一些勇敢、強大的凡人甚至與任何一方結盟，並幫助指揮罪"
-"惡戰爭的程序"
+"注意​並見​證這裡​的​真理​，​因​為​它​們​是​赫拉迪姆​最後​的​遺產​。​當天堂​和​地獄​之​間​永恒​的​沖​突"
+"落​在​凡人​的​土地​上​，​這​就​是​原罪之戰​。​天使​和​惡魔偽​裝​著​行走​在​人類​之​中​，​秘密​地​戰鬥"
+"​，​遠離​凡​人​窺探​的​眼睛​。​一些​勇敢​、​強大​的​凡人​甚至​與​任何​一​方​結盟​，​並幫助​指揮罪惡​戰"
+"爭​的​程序"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:509
@@ -9967,18 +9969,18 @@ msgid ""
 "faith. If Diablo were to be released, he would seek a body that is easily "
 "controlled as he would be very weak - perhaps that of an old man or a child."
 msgstr ""
-"注意並見證這裡的真理，因為它們是赫拉迪姆最後的遺產。近三百年前，人們知道燃燒"
-"地獄的三大惡魔神秘地來到了我們的世界。兄弟三人蹂躪東方的土地數十年，而人類卻"
-"在他們身後戰慄。我們的騎士團——赫拉迪姆——是由一群神秘的法師建立的，目的是一勞"
-"永逸地追捕和俘虜這三個惡魔。\n"
+"注意​並見​證這裡​的​真理​，​因​為​它​們​是​赫拉迪姆​最後​的​遺產​。​近​三百​年​前​，​人們​知道​燃燒​地"
+"獄​的​三​大​惡魔​神秘​地來​到​了​我​們​的​世界​。​兄弟​三​人​蹂躪​東方​的​土地​數​十​年​，​而​人類卻"
+"​在​他​們身​後​戰慄​。​我​們​的​騎士團​——​赫拉迪姆​——​是​由​一​群​神秘​的​法師​建立​的​，​目的​是"
+"​一​勞​永逸​地​追捕​和​俘虜​這​三​個​惡魔​。​\n"
 " \n"
-"最初的赫拉德里姆在被稱為「靈魂石」的強大文物中捕獲了其中兩個，並將它們深埋在"
-"荒涼的東部沙漠之下。第三個惡魔逃脫了追捕，逃到了西部，許多赫拉迪姆人都在追"
-"捕。第三個惡魔-被稱為迪亞波羅，恐懼之王-最終被俘虜，他的靈魂石和埋在這個迷宮"
-"的本質。\n"
+"​最初​的​赫拉德里姆​在​被​稱為​「​靈魂石​」​的​強大​文物​中​捕獲​了​其中​兩個​，​並將​它​們​深​埋​在​"
+"荒涼​的​東部​沙漠​之下​。​第三​個​惡​魔逃脫​了​追捕​，​逃到​了​西部​，​許多赫拉迪姆人​都​在​追捕​。​第三"
+"​個​惡​魔-​被​稱為迪亞波羅​，​恐懼​之​王-​最​終​被​俘虜​，​他​的​靈魂石​和​埋​在​這個​迷宮​的​本質​"
+"。​\n"
 " \n"
-"要被警告，靈魂之石必須防止被那些不信的人發現。如果迪亞波羅被釋放，他會尋找一"
-"個身體很容易控制，因為他會非常虛弱-也許是一個老人或兒童"
+"​要​被​警告​，​靈魂​之石必須​防止​被​那些​不​信​的​人​發現​。​如果​迪亞波羅​被​釋放​，​他​會尋​找​一​"
+"個身體​很​容易​控制​，​因​為​他​會​非常​虛弱​-​也​許​是​一​個​老人​或​兒童"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:511
@@ -9991,10 +9993,10 @@ msgid ""
 "the factions of Belial and Azmodan while the forces of the High Heavens "
 "continually battered upon the very Gates of Hell."
 msgstr ""
-"因此，在燃燒的地獄裡發生了一場被稱為黑暗放逐的偉大革命。較小的邪惡推翻了三個"
-"主要的邪惡，並將他們的精神形式放逐到凡人的領域。惡魔彼列爾（謊言之王）和阿茲"
-"莫丹（罪惡之王）在兄弟三人不在的時候爭奪地獄的統治權。所有的地獄惡魔都在彼列"
-"爾和阿茲莫丹兩個派系之間分化，而天堂的力量不斷地衝擊著地獄的大門。"
+"因此​，​在​燃燒​的​地獄裡​發生​了​一​場​被​稱為​黑暗​放逐​的​偉大​革命​。​較​小​的​邪惡​推翻​了​三​個"
+"​主要​的​邪惡​，​並將​他​們​的​精神​形式​放逐​到​凡人​的​領域​。​惡魔彼​列​爾​（​謊言之​王​）​和​阿茲"
+"莫丹​（​罪惡​之​王​）​在​兄弟​三​人​不​在​的​時候爭奪​地獄​的​統治權​。​所有​的​地獄惡​魔​都​在​彼列爾"
+"​和​阿茲​莫丹兩​個​派系​之​間​分化​，​而​天堂​的​力量​不​斷​地衝擊​著​地獄​的​大門​。"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:513
@@ -10005,9 +10007,9 @@ msgid ""
 "secretive Order of mortal magi named the Horadrim, who quickly became adept "
 "at hunting demons. They also made many dark enemies in the underworlds."
 msgstr ""
-"許多惡魔爲了尋找三兄弟來到了凡間。這些惡魔被天使們帶到了凡間，他們在東方的廣"
-"大城市裡獵殺他們。天使們與一個隱秘的名為赫拉迪姆法師教團結盟，他很快就變得善"
-"于獵殺惡魔。他們也在陰間製造了許多黑暗的敵人。"
+"許​多​惡​魔爲​了​尋​找​三​兄弟​來​到​了​凡間​。​這​些​惡魔​被​天使​們帶​到​了​凡間​，​他​們​在​東方"
+"​的​廣大​城市​裡獵殺​他​們​。​天使​們與​一​個​隱秘​的​名為​赫拉迪姆法師​教團​結盟​，​他​很​快​就​變​得"
+"​善于​獵殺​惡魔​。​他​們​也​在​陰間​製造​了​許多​黑暗​的​敵人​。"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:515
@@ -10026,15 +10028,15 @@ msgid ""
 "He will then arise to free his Brothers and once more fan the flames of the "
 "Sin War..."
 msgstr ""
-"因此，這三個主要的惡魔以靈魂的形式被放逐到凡人的領域，在東方縫了幾十年的混亂"
-"之後，他們被凡人赫拉迪姆的詛咒的秩序所追捕。赫拉德里姆使用了被稱為「靈魂石」"
-"的人工製品來容納仇恨之主墨菲斯托和他的兄弟毀滅之主巴力的精髓。最小的弟弟——恐"
-"懼之王迪亞波羅——逃到了西方。\n"
+"因此​，​這​三​個​主要​的​惡魔​以​靈魂​的​形式​被​放逐​到​凡人​的​領域​，​在​東方縫​了​幾​十​年​的​混"
+"亂​之後​，​他​們​被​凡人​赫拉迪姆​的​詛咒​的​秩序​所​追捕​。​赫拉德里姆​使用​了​被​稱為​「​靈魂石​」​的"
+"​人工​製品來容納​仇恨​之​主​墨菲斯托​和​他​的​兄弟​毀滅​之​主巴力​的​精髓​。​最​小​的​弟弟​——​恐懼​之"
+"​王迪亞波羅​——​逃到​了​西方​。​\n"
 " \n"
-"最終，赫拉德里姆也在一塊靈魂石中俘獲了迪亞波羅，並將他埋葬在一座被遺忘的古老"
-"大教堂下。在那裡，恐怖之主沉睡著，等待著他的重生。你們要知道，他要尋求一個充"
-"滿青春和力量的身體來佔有，一個清白和容易控制的身體。然後他會起來解救他的兄弟"
-"們，再一次煽起罪惡戰爭的火焰"
+"​最​終​，​赫拉德里姆​也​在​一​塊​靈魂石​中​俘獲​了​迪亞波羅​，​並將​他​埋葬​在​一​座​被​遺忘​的​古老大"
+"​教堂​下​。​在​那裡​，​恐怖​之​主​沉​睡​著​，​等待​著​他​的​重生​。​你​們​要​知道​，​他​要​尋求​一"
+"​個​充滿​青春​和​力量​的​身體來佔​有​，​一​個​清白​和​容易​控制​的​身體​。​然後​他​會起​來​解救​他​的"
+"​兄弟們​，​再​一​次​煽起罪惡戰爭​的​火焰"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:517
@@ -10046,10 +10048,10 @@ msgid ""
 "that have brought this discord to the realms of man. My lord has named the "
 "battle for this world and all who exist here the Sin War."
 msgstr ""
-"所有讚揚迪亞波羅-恐懼之王和黑暗流放的倖存者。當他從沉睡中醒來時，我的主人和主"
-"人對我說了一些很少有人知道的秘密。他告訴我，天上的王國和燃燒的地獄的深坑正在"
-"進行一場永恒的戰爭。他揭示了將這種不和諧帶到人類領域的力量。我主已將這場為世"
-"界而戰的戰爭和所有在這裡生存的人命名為原罪之戰。"
+"所有​讚揚​迪亞波羅​-​恐懼​之​王​和​黑暗​流放​的​倖​存者​。​當​他​從​沉睡​中​醒來時​，​我​的​主人​和​"
+"主人​對​我​說​了​一些​很​少​有​人​知道​的​秘密​。​他​告訴​我​，​天​上​的​王國​和​燃燒​的​地獄​的​深"
+"坑​正在​進行​一​場​永恒​的​戰爭​。​他​揭示​了​將這種​不和​諧帶​到​人類​領域​的​力量​。​我​主​已​將這場"
+"為​世界​而​戰​的​戰爭​和​所有​在​這裡​生存​的​人​命名​為原罪之戰​。"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:519
@@ -10061,10 +10063,10 @@ msgid ""
 "beneath the sands of the east. Once my Lord releases his Brothers, the Sin "
 "War will once again know the fury of the Three."
 msgstr ""
-"榮耀和讚許給迪亞波羅-恐懼之王和三人之首。我主對我談到他的兩個兄弟，墨菲斯托和"
-"巴爾，他們很久以前被放逐到這個世界上。我的主希望等待時機，利用他令人敬畏的能"
-"力，以便將他被俘的兄弟們從東方沙漠下的墳墓中解救出來。一旦我主釋放了他的兄"
-"弟，原罪之戰將再次知道三人的憤怒"
+"榮耀​和​讚許​給​迪亞波羅​-​恐懼​之​王​和​三​人​之​首​。​我​主對​我​談​到​他​的​兩個​兄弟​，​墨菲斯托"
+"​和​巴爾​，​他​們​很​久​以前​被​放逐​到​這個​世界​上​。​我​的​主​希望​等待​時機​，​利用​他​令​人​敬"
+"畏​的​能力​，​以便​將​他​被​俘​的​兄弟​們從​東方​沙漠​下​的​墳​墓​中​解救​出來​。​一旦​我​主釋放​了​"
+"他​的​兄弟​，​原罪​之​戰將​再次​知道​三​人​的​憤怒"
 
 #. TRANSLATORS: Book read aloud
 #: Source/textdat.cpp:521
@@ -10079,12 +10081,12 @@ msgid ""
 "Diablo's call and pray that I will be rewarded when he at last emerges as "
 "the Lord of this world."
 msgstr ""
-"向迪亞波羅致敬和獻祭-恐懼之王和靈魂的毀滅者。當我從睡夢中喚醒我的主人時，他試"
-"圖擁有一個凡人的形體。迪亞波羅試圖奪走李奧瑞克國王的屍體，但我的主人被囚禁后"
-"太虛弱了。我的主人需要一個簡單和無辜的錨到這個世界上，所以發現男孩阿爾佈雷希"
-"特是完美的任務。當善良的國王李奧瑞克被迪亞波羅的失敗激怒時，我綁架了他的兒子"
-"阿爾布雷希特，把他帶到我的主人面前。我現在等待著迪亞波羅的召喚，祈禱當他最終"
-"成為這個世界的主時，我會得到回報"
+"向​迪亞波羅​致敬​和​獻祭​-​恐懼​之​王​和​靈魂​的​毀滅​者​。​當​我​從​睡​夢​中​喚醒​我​的​主人時​，​"
+"他​試圖擁​有​一​個​凡​人​的​形體​。​迪亞波羅試圖奪​走​李奧瑞克國王​的​屍體​，​但​我​的​主人​被​囚禁​后​"
+"太​虛弱​了​。​我​的​主人​需要​一​個​簡單​和​無辜​的​錨​到​這個​世界​上​，​所以​發現​男孩​阿爾佈​雷希特"
+"​是​完美​的​任務​。​當善良​的​國王李奧瑞克​被​迪亞波羅​的​失敗​激怒​時​，​我​綁架​了​他​的​兒子​阿爾布雷"
+"希特​，​把​他​帶​到​我​的​主人​面​前​。​我​現​在​等待​著​迪亞波羅​的​召喚​，​祈禱當​他​最​終​成為這個"
+"​世界​的​主時​，​我​會​得到​回報"
 
 #. TRANSLATORS: Neutral Text spoken by Ogden
 #: Source/textdat.cpp:523
@@ -10100,14 +10102,14 @@ msgid ""
 " \n"
 "Perhaps I can tell you more if we speak again. Good luck."
 msgstr ""
-"謝天謝地你回來了\n"
-"自從你住在這裡，我的朋友，一切都變了。一切都很平靜，直到黑暗騎士來摧毀我們的"
-"村莊。許多人在原地被砍倒，拿起武器的人被殺或被拖走成為奴隸，甚至更糟。城市邊"
-"緣的教堂被褻瀆，被用來舉行黑暗的儀式。夜晚迴響的尖叫聲是不人道的，但我們的一"
-"些市民可能還活著。沿著我的小酒館和鐵匠鋪之間的小路去尋找教堂，拯救你能拯救的"
-"人。\n"
+"謝​天謝​地​你​回來​了​\n"
+"自從​你​住​在​這裡​，​我​的​朋友​，​一切​都​變​了​。​一切​都​很​平靜​，​直​到​黑暗​騎士​來摧毀​我​們"
+"​的​村莊​。​許多​人​在​原地​被​砍倒​，​拿起​武器​的​人​被​殺​或​被​拖走​成​為奴隸​，​甚至​更​糟​。​"
+"城市​邊緣​的​教堂​被​褻瀆​，​被​用來​舉行​黑暗​的​儀式​。​夜晚​迴響​的​尖叫​聲​是​不​人道​的​，​但​我"
+"​們​的​一些​市民​可能​還活著​。​沿​著​我​的​小酒館​和​鐵匠​鋪​之​間​的​小​路​去​尋​找​教堂​，​拯救​"
+"你​能​拯救​的​人​。​\n"
 " \n"
-"如果我們再談的話，也許我可以告訴你更多。祝你好運"
+"​如果​我​們​再​談​的​話​，​也​許​我​可以​告訴​你​更​多​。​祝​你​好運"
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:525 Source/textdat.cpp:533
@@ -10116,8 +10118,8 @@ msgid ""
 "any who would seek to steal the treasures secured within this room.  So "
 "speaks the Lord of Terror, and so it is written."
 msgstr ""
-"英雄殿後是藏骨密室。永恒的死亡等待著任何想要偷走這間屋子裡珍寶的人。恐懼之耶"
-"和華如此說，經上如此記著"
+"英雄​殿後​是​藏骨密室​。​永恒​的​死亡​等待​著​任何​想要​偷​走​這間​屋子​裡珍寶​的​人​。​恐懼​之​耶​和華"
+"​如此​說​，​經​上​如此​記​著"
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:531 Source/textdat.cpp:539
@@ -10127,8 +10129,8 @@ msgid ""
 "fulfill his endless sacrifices to the Dark ones who scream for one thing - "
 "blood."
 msgstr ""
-"地獄的軍械庫是血之軍閥的家。他身後躺著成千上萬具殘缺的屍體。天使和人類都被砍"
-"掉了，來完成他對黑暗勢力無盡的犧牲，他們只為一件事而尖叫——血"
+"地獄​的​軍械庫​是​血​之​軍閥​的​家​。​他​身​後​躺著​成千上​萬具殘缺​的​屍體​。​天使​和​人類​都​被​砍掉"
+"​了​，​來​完成​他​對​黑暗​勢力無盡​的​犧牲​，​他​們​只​為​一​件​事​而​尖叫​——​血"
 
 #. TRANSLATORS: Quest text spoken by Adria
 #: Source/textdat.cpp:541
@@ -10137,8 +10139,8 @@ msgid ""
 "a treasure that is hidden less so.  I will leave you with this.  Do not let "
 "the sands of time confuse your search."
 msgstr ""
-"繼續你的任務。找到丟失的寶藏並不容易。找到一個藏得不那麼深的寶藏。我把這個留"
-"給你。不要讓時間的沙子迷惑了你的尋找"
+"繼續​你​的​任務​。​找到​丟失​的​寶藏並​不​容易​。​找到​一​個​藏得​不​那​麼​深​的​寶藏​。​我​把​這個​"
+"留給​你​。​不​要​讓時間​的​沙子​迷惑​了​你​的​尋​找"
 
 #. TRANSLATORS: Quest text spoken by Griswold
 #: Source/textdat.cpp:543
@@ -10148,15 +10150,16 @@ msgid ""
 "don't match our town at all.  I'd keep my mind on what lies below the "
 "cathedral and not what lies below our topsoil."
 msgstr ""
-"什麼？！這是愚蠢的。特里斯特拉姆這裡沒有寶藏。讓我看看！！啊，看這些畫不準"
-"確。他們根本不符合我們的城市。我會把心思放在大教堂下面，而不是我們的表土下面"
+"什麼​？​！​這​是​愚蠢​的​。​特里斯特拉姆​這裡沒​有​寶藏​。​讓​我​看看​！​！​啊​，​看這​些​畫​不​準確​"
+"。​他​們​根本​不​符合​我​們​的​城市​。​我​會​把​心思放​在​大​教堂​下面​，​而​不​是​我​們​的​表土​下"
+"面"
 
 #. TRANSLATORS: Quest text spoken by Pipin
 #: Source/textdat.cpp:545
 msgid ""
 "I really don't have time to discuss some map you are looking for.  I have "
 "many sick people that require my help and yours as well."
-msgstr "我真的沒有時間討論你要找的地圖。我有許多病人需要我和你的幫助"
+msgstr "我​真的​沒​有​時間討論​你​要​找​的​地圖​。​我​有​許​多​病人​需要​我​和​你​的​幫助"
 
 #. TRANSLATORS: Quest text spoken by Adria
 #: Source/textdat.cpp:547 Source/textdat.cpp:559
@@ -10165,8 +10168,8 @@ msgid ""
 "His honor stripped and his visage altered.  He is trapped in immortal "
 "torment.  Charged to conceal the very thing that could free him."
 msgstr ""
-"曾經引以為傲的Iswall深陷在這個世界的表面之下。他的榮譽被剝奪了，面容也變了。"
-"他被困在不朽的折磨之中。被指控隱瞞能讓他自由的事情"
+"曾​經引​以​為傲​的​Iswall​深陷​在​這個​世界​的​表面​之下​。​他​的​榮譽​被​剝奪​了​，​面容​也​變​"
+"了​。​他​被困​在​不朽​的​折磨​之中​。​被​指控​隱瞞​能​讓​他​自由​的​事情"
 
 #. TRANSLATORS: Quest text spoken by Ogden
 #: Source/textdat.cpp:549
@@ -10175,8 +10178,8 @@ msgid ""
 "at you later when you were running around the town with your nose in the "
 "dirt.  I'd ignore it."
 msgstr ""
-"我敢打賭，沃特看見你來了，就裝出一副樣子，這樣他就可以在你鼻子埋在泥土裡在城"
-"里跑的時候嘲笑你了。我會忽略它"
+"我​敢​打賭​，​沃特​看見​你​來​了​，​就​裝​出​一​副樣子​，​這樣​他​就​可以​在​你​鼻子​埋​在​泥土裡​在"
+"​城里​跑​的​時候​嘲笑​你​了​。​我​會​忽略​它"
 
 #. TRANSLATORS: Quest text spoken by Cain
 #: Source/textdat.cpp:551
@@ -10186,9 +10189,9 @@ msgid ""
 "treasure are common fantasies of any child.  Wirt seldom indulges in "
 "youthful games.  So it may just be his imagination."
 msgstr ""
-"曾經有一段時間，這個城鎮是遠道而來的旅行者的常去之地。從那以後發生了很大的變"
-"化。但隱藏的洞穴和埋藏的寶藏是任何孩子的共同幻想。懷特很少沉迷於年輕人的游"
-"戲。所以這可能只是他的想像"
+"曾​經​有​一​段​時間​，​這個城鎮​是​遠道​而來​的​旅行者​的​常去之​地​。​從​那​以​後​發生​了​很​大​的​"
+"變化​。​但​隱藏​的​洞穴​和​埋藏​的​寶藏​是​任何​孩子​的​共同​幻想​。​懷特​很少​沉迷​於​年輕人​的​游戲​"
+"。​所以​這​可能​只​是​他​的​想像"
 
 #. TRANSLATORS: Quest text spoken by Farnham
 #: Source/textdat.cpp:553
@@ -10196,7 +10199,8 @@ msgid ""
 "Listen here.  Come close.  I don't know if you know what I know, but you've "
 "have really got something here.  That's a map."
 msgstr ""
-"聽著。靠近點。我不知道你是否知道我所知道的，但你真的有所收穫。那是一張地圖"
+"聽​著​。​靠近​點​。​我​不​知道​你​是否​知道​我​所​知道​的​，​但​你​真的​有所​收穫​。​那​是​一​張​地"
+"​圖"
 
 #. TRANSLATORS: Quest text spoken by Gillian
 #: Source/textdat.cpp:555
@@ -10208,10 +10212,10 @@ msgid ""
 "offering would be altered in some strange way.  I don't know if this is just "
 "the talk of an old sick woman, but anything seems possible these days."
 msgstr ""
-"我祖母經常給我講一些關於居住在教堂外墓地的奇怪勢力的故事。你可能會對其中一個"
-"很感興趣。她說，如果你把合適的祭品留在墓地，進入大教堂為死者祈禱，然後再回"
-"來，祭品會以某種奇怪的方式改變。我不知道這是不是一個老病婦的談話，但最近似乎"
-"什麼都有可能"
+"我​祖母​經​常給​我​講​一些​關於​居住​在​教堂​外​墓地​的​奇怪​勢力​的​故事​。​你​可能​會對​其中​一​個​"
+"很​感​興趣​。​她​說​，​如果​你​把​合適​的​祭品​留​在​墓地​，​進入​大​教堂​為​死者​祈禱​，​然​後​再​"
+"回來​，​祭品會​以​某​種​奇怪​的​方式​改變​。​我​不​知道​這​是​不​是​一​個​老​病婦​的​談話​，​但​最近"
+"​似乎​什麼​都​有​可能"
 
 #. TRANSLATORS: Quest text spoken by Wirt
 #: Source/textdat.cpp:557
@@ -10220,8 +10224,8 @@ msgid ""
 "interested in picking up a few things from you.  Or better yet, don't you "
 "need some rare and expensive supplies to get you through this ordeal?"
 msgstr ""
-"嗯。你說的是一個巨大而神秘的寶藏。嗯。也許我有興趣從你那裡得到一些東西。或者"
-"更好的是，你不需要一些稀有而昂貴的物資來度過這場磨難嗎"
+"嗯​。​你​說​的​是​一​個​巨大​而​神秘​的​寶藏​。​嗯​。​也​許​我​有​興趣從​你​那​裡​得到​一些​東西​。"
+"​或者​更​好​的​是​，​你​不​需要​一些​稀有​而​昂貴​的​物資​來度​過這​場​磨難嗎"
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
 #: Source/textdat.cpp:561
@@ -10234,10 +10238,11 @@ msgid ""
 "you could destroy it, I would be forever grateful. I'd do it myself, but "
 "someone has to stay here with the cows..."
 msgstr ""
-"所以，你是每個人都在談論的英雄。也許你能幫助一個貧窮的農民擺脫困境？在我的果"
-"園的邊緣，就在這裡的南邊，有一個可怕的東西從地裡冒出來！我不能得到我的莊稼或"
-"我的捆乾草，我可憐的奶牛會餓死。巫婆把這個給了我，說它會把那東西從我的地裡炸"
-"出來。如果你能毀掉它，我將永遠感激。我自己會做的，但總得有人留下來陪奶牛"
+"所以​，​你​是​每​個​人​都​在​談論​的​英雄​。​也​許​你​能​幫助​一​個​貧窮​的​農民擺脫​困境​？​在​我​"
+"的​果園​的​邊緣​，​就​在​這裡​的​南邊​，​有​一​個​可怕​的​東西從​地​裡​冒出​來​！​我​不​能​得到​我​"
+"的​莊稼​或​我​的​捆乾草​，​我​可​憐​的​奶牛會​餓死​。​巫婆​把​這個給​了​我​，​說​它​會​把​那​東​西從"
+"​我​的​地裡​炸​出來​。​如果​你​能​毀掉​它​，​我​將​永遠​感激​。​我​自己​會​做​的​，​但​總​得​有​人"
+"​留下​來​陪​奶牛"
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
 #: Source/textdat.cpp:563
@@ -10245,8 +10250,8 @@ msgid ""
 "I knew that it couldn't be as simple as that witch made it sound. It's a sad "
 "world when you can't even trust your neighbors."
 msgstr ""
-"我知道事情不會像巫婆說的那麼簡單。當你連鄰居都不能信任的時候，這是一個悲哀的"
-"世界"
+"我​知道​事情​不​會​像​巫婆說​的​那​麼​簡單​。​當​你​連鄰居​都​不​能​信任​的​時候​，​這​是​一​個​悲哀"
+"​的​世界"
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
 #: Source/textdat.cpp:565
@@ -10255,8 +10260,8 @@ msgid ""
 "it? You what? Oh, don't tell me you lost it! Those things don't come cheap, "
 "you know. You've got to find it, and then blast that horror out of our town."
 msgstr ""
-"它不見了嗎？你把它送回了孕育它的陰間嗎？你什麼？哦，別告訴我你丟了！你知道，"
-"那些東西不便宜。你一定要找到它，然後把那恐懼的東西轟出去"
+"它​不​見​了​嗎​？​你​把​它​送回​了​孕育​它​的​陰間嗎​？​你​什麼​？​哦​，​別告訴​我​你​丟​了​！​你​"
+"知道​，​那些​東西不便宜​。​你​一定​要​找到​它​，​然​後​把​那​恐懼​的​東西轟​出去"
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
 #: Source/textdat.cpp:567
@@ -10266,9 +10271,9 @@ msgid ""
 "church, and so forth, these are trying times. I am but a poor farmer, but "
 "here -- take this with my great thanks."
 msgstr ""
-"我聽到爆炸聲了！多謝你，善良的陌生人。隨著所有這些東西從地下冒出來，怪物佔領"
-"了教堂，等等，這些都是艱難的時刻。我只是一個貧窮的農民，但在這裡——請接受我的"
-"謝意"
+"我​聽​到​爆炸聲​了​！​多​謝​你​，​善良​的​陌生人​。​隨著​所有​這​些​東西從​地下​冒出來​，​怪物佔領​了​"
+"教堂​，​等等​，​這​些​都​是​艱難​的​時刻​。​我​只​是​一​個​貧窮​的​農民​，​但​在​這裡​——​請​接受​"
+"我​的​謝意"
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
 #: Source/textdat.cpp:569
@@ -10278,13 +10283,14 @@ msgid ""
 "those creatures you could come back... and spare a little time to help a "
 "poor farmer?"
 msgstr ""
-"哦，我有這麼大的麻煩…也許…不，我不能強加給你，還有其他的麻煩。也許在你清除了"
-"教堂里的一些生物之後你可以回來。。。抽出一點時間去幫助一個貧窮的農民"
+"哦​，​我​有​這麼​大​的​麻煩​…​也​許​…​不​，​我​不​能​強加給​你​，​還​有​其他​的​麻煩​。​也​許​在"
+"​你​清除​了​教堂​里​的​一些​生物​之後​你​可以​回來​。​。​。​抽出​一​點​時間​去​幫助​一​個​貧窮​的​農"
+"民"
 
 #. TRANSLATORS: Quest text spoken by Little Girl
 #: Source/textdat.cpp:571
 msgid "Waaaah! (sniff) Waaaah! (sniff)"
-msgstr "哇啊(嗅）哇啊(嗅嗅）"
+msgstr "哇​啊​(​嗅​）​哇​啊​(嗅嗅​）"
 
 #. TRANSLATORS: Quest text spoken by Little Girl
 #: Source/textdat.cpp:572
@@ -10294,9 +10300,9 @@ msgid ""
 "but we snuck over there, and then suddenly this BUG came out!  We ran away "
 "but Theo fell down and the bug GRABBED him and took him away!"
 msgstr ""
-"我失去了西奧！我失去了我最好的朋友！我們在河邊玩，西奧說他想去看看綠色的東"
-"西。我說我們不應該，但我們偷偷溜過去，然後突然這個蟲子出來了！我們逃跑了，但"
-"西奧摔倒了，蟲子抓住他，把他帶走了"
+"我​失去​了​西奧​！​我​失去​了​我​最​好​的​朋友​！​我​們​在​河邊​玩​，​西奧說​他​想​去​看看​綠色​的​"
+"東西​。​我​說​我​們​不​應該​，​但​我​們​偷偷​溜過​去​，​然後​突然​這個​蟲子​出來​了​！​我​們​逃跑​了"
+"​，​但​西奧​摔倒​了​，​蟲子​抓住​他​，​把​他​帶​走​了"
 
 #. TRANSLATORS: Quest text spoken by Little Girl
 #: Source/textdat.cpp:574
@@ -10304,7 +10310,8 @@ msgid ""
 "Didja find him?  You gotta find Theodore, please!  He's just little.  He "
 "can't take care of himself!  Please!"
 msgstr ""
-"你找到他了嗎？你得找到西奧多，求你了！他只是個小孩子。他不能照顧自己！求你了"
+"你​找到​他​了​嗎​？​你​得​找到​西奧​多​，​求​你​了​！​他​只是​個​小​孩子​。​他​不​能​照顧​自己​！​"
+"求​你​了"
 
 #. TRANSLATORS: Quest text spoken by Little Girl (Quest End)
 #: Source/textdat.cpp:576
@@ -10313,8 +10320,9 @@ msgid ""
 "scare you?  Hey!  Ugh!  There's something stuck to your fur!  Ick!  Come on, "
 "Theo, let's go home!  Thanks again, hero person!"
 msgstr ""
-"你找到他了！你找到他了！非常感謝。哦，西奧，那些討厭的蟲子嚇到你了嗎？嘿啊！"
-"有東西粘在你的毛上了！哎呀！來吧，西奧，我們回家吧！再次感謝，英雄人物"
+"你​找到​他​了​！​你​找到​他​了​！​非常​感謝​。​哦​，​西奧​，​那些​討厭​的​蟲子嚇​到​你​了​嗎​？​嘿​"
+"啊​！​有​東​西粘​在​你​的​毛上​了​！​哎呀​！​來​吧​，​西奧​，​我​們​回家​吧​！​再次​感謝​，​英雄​人"
+"物"
 
 #. TRANSLATORS: Quest text spoken by Defiler (Hostile)
 #: Source/textdat.cpp:578
@@ -10322,15 +10330,15 @@ msgid ""
 "We have long lain dormant, and the time to awaken has come.  After our long "
 "sleep, we are filled with great hunger.  Soon, now, we shall feed..."
 msgstr ""
-"我們早已沉睡，覺醒的時刻已經到來。長眠之後，我們感到非常飢餓。很快，現在，我"
-"們將餵養"
+"我​們​早​已​沉睡​，​覺醒​的​時刻​已​經​到​來​。​長眠​之後​，​我​們​感到​非常​飢餓​。​很​快​，​現​在"
+"​，​我​們將餵養"
 
 #. TRANSLATORS: Quest text spoken by Defiler (Hostile)
 #: Source/textdat.cpp:580
 msgid ""
 "Have you been enjoying yourself, little mammal?  How pathetic. Your little "
 "world will be no challenge at all."
-msgstr "你玩得開心嗎，小哺乳動物？真可憐。你的小世界不會是什麼挑戰"
+msgstr "你​玩​得​開心嗎​，​小​哺​乳動物​？​真​可​憐​。​你​的​小​世界​不​會​是​什麼​挑戰"
 
 #. TRANSLATORS: Quest text spoken by Defiler (Hostile)
 #: Source/textdat.cpp:582
@@ -10339,15 +10347,15 @@ msgid ""
 "men call home.  Our tendrils shall envelop this world, and we will feast on "
 "the flesh of its denizens.  Man shall become our chattel and sustenance."
 msgstr ""
-"這些地必被玷污，我們的後裔必漫過人們稱為家的田地。我們的捲鬚要包裹這世界，我"
-"們要以其居民的肉為食。人類將成為我們的動產和食物"
+"這​些​地​必​被​玷污​，​我​們​的​後​裔​必​漫過人​們稱​為家​的​田地​。​我​們​的​捲鬚​要​包裹這​世界​，"
+"​我​們​要​以​其​居民​的​肉為食​。​人類將​成為​我​們​的​動產​和​食物"
 
 #. TRANSLATORS: Quest text spoken by Defiler (Hostile)
 #: Source/textdat.cpp:584
 msgid ""
 "Ah, I can smell you...you are close! Close! Ssss...the scent of blood and "
 "fear...how enticing..."
-msgstr "啊，我能聞到你…你就在附近！接近！血和恐懼的味道…多麼誘人"
+msgstr "啊​，​我​能​聞​到​你​…​你​就​在​附近​！​接近​！​血​和​恐懼​的​味道​…​多​麼​誘​人"
 
 #. TRANSLATORS: Quest text spoken by Narrator
 #: Source/textdat.cpp:592
@@ -10366,30 +10374,30 @@ msgid ""
 "within all things and beyond all things. Light and unity are the products of "
 "this holy foundation, a unity of purpose and a unity of possession."
 msgstr ""
-"在金光之年，一座大教堂被立了起來。這個聖地的基石是用半透明的安提拉石雕刻而成"
-"的，安提拉石是以與赫拉迪姆分享力量的天使命名的。\n"
+"在​金光​之​年​，​一​座​大​教堂​被​立​了​起來​。​這個​聖地​的​基石​是​用半​透明​的​安提拉​石​雕刻​而​"
+"成​的​，​安提拉石​是​以​與​赫拉迪姆​分享​力量​的​天使​命名​的​。​\n"
 " \n"
-"在畫影子的那一年，大地震動，大教堂粉碎倒塌。隨著地下墓穴和城堡的建造開始，人"
-"們開始抵抗罪惡戰爭的蹂躪，廢墟被清理出來尋找石頭。就這樣，基石從人們的眼中消"
-"失了。\n"
+"​在​畫​影子​的​那​一​年​，​大​地震​動​，​大​教堂​粉碎​倒塌​。​隨​著​地下​墓穴​和​城堡​的​建造​開始​"
+"，​人們​開始​抵抗​罪惡戰爭​的​蹂躪​，​廢墟​被​清理​出來尋​找​石頭​。​就​這樣​，​基石​從人們​的​眼​中​消"
+"失​了​。​\n"
 " \n"
-"石頭屬於這個世界，也屬於所有的世界，就像光既存在於萬物之中，也存在於萬物之"
-"外。光明與統一是這個神聖基礎的產物，是目的的統一和佔有的統一。"
+"石頭屬​於​這個​世界​，​也​屬於​所有​的​世界​，​就​像​光​既​存在​於​萬物​之​中​，​也​存在​於​萬物​之外"
+"​。​光明​與​統​一​是​這個神聖基礎​的​產物​，​是​目的​的​統​一​和​佔有的​統​一​。"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:594
 msgid "Moo."
-msgstr "嗚嗚"
+msgstr "嗚​嗚"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:595
 msgid "I said, Moo."
-msgstr "我說，穆"
+msgstr "我​說​，​穆"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:596
 msgid "Look I'm just a cow, OK?"
-msgstr "聽著，我只是一頭牛，好嗎"
+msgstr "聽​著​，​我​只​是​一​頭牛​，​好嗎"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:597
@@ -10405,26 +10413,26 @@ msgid ""
 "my house, it's just south of the fork in the river... you know... the one "
 "with the overgrown vegetable garden."
 msgstr ""
-"好吧，好吧。我不是一頭牛。我一般不會這樣到處走；但是，當時我正坐在家裡處理自"
-"己的事情，突然這些蟲子、藤蔓、球莖之類的東西開始從地板上冒出來。。。太可怕"
-"了！如果我有正常的衣服穿，就不會那麼糟糕了。嘿你能回我家幫我拿衣服嗎？棕色"
-"的，不是灰色的，那是晚裝的。我會自己做的，但我不想讓任何人看到我這樣。給，拿"
-"著這個，你可能需要它。。。殺死那些長滿一切的東西。你不會錯過我家的，就在河的"
-"岔口南邊。。。你知道的。。。有雜草叢生的菜園的那個"
+"好​吧​，​好​吧​。​我​不​是​一​頭​牛​。​我​一般​不​會這樣​到​處走​；​但是​，​當時​我​正​坐​在​家裡​"
+"處理​自己​的​事情​，​突然​這​些​蟲子​、​藤蔓​、​球莖​之​類​的​東西開始從​地板​上​冒出來​。​。​。​太​可"
+"怕​了​！​如果​我​有​正常​的​衣服​穿​，​就​不​會​那麼​糟糕​了​。​嘿​你​能回​我​家​幫​我​拿​衣服​嗎​"
+"？​棕色​的​，​不​是​灰色​的​，​那​是​晚裝​的​。​我​會​自己​做​的​，​但​我​不​想​讓​任何​人​看到​我"
+"​這樣​。​給​，​拿​著​這個​，​你​可能​需要​它​。​。​。​殺死​那些​長滿​一切​的​東西​。​你​不​會​錯過​"
+"我​家​的​，​就​在​河​的​岔口​南邊​。​。​。​你​知道​的​。​。​。​有​雜草​叢生​的​菜園​的​那​個"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:599
 msgid ""
 "What are you wasting time for?  Go get my suit!  And hurry!  That Holstein "
 "over there keeps winking at me!"
-msgstr "你在浪費時間幹什麼？去拿我的衣服！快點！那邊那個荷斯坦人一直對我眨眼"
+msgstr "你​在​浪費​時間​幹​什麼​？​去​拿​我​的​衣服​！​快點​！​那​邊​那​個​荷斯坦人​一直​對​我​眨眼"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:601
 msgid ""
 "Hey, have you got my suit there?  Quick, pass it over!  These ears itch like "
 "you wouldn't believe!"
-msgstr "嘿，你有我的西裝嗎？快，傳過來！這些耳朵癢得你都不敢相信"
+msgstr "嘿​，​你​有​我​的​西裝嗎​？​快​，​傳過來​！​這​些​耳朵​癢​得​你​都​不​敢​相信"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:603
@@ -10433,8 +10441,8 @@ msgid ""
 "occasions!  I can't wear THIS.  What are you, some kind of weirdo?  I need "
 "the BROWN suit."
 msgstr ""
-"不不不！這是我的灰色西裝！這是晚裝！正式場合！我不能穿這個。你是什麼怪人？我"
-"需要那套棕色的西裝"
+"不​不​不​！​這​是​我​的​灰色​西裝​！​這​是​晚裝​！​正式​場合​！​我​不​能​穿這個​。​你​是​什麼​怪人​"
+"？​我​需要​那​套​棕色​的​西裝"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:605
@@ -10445,18 +10453,17 @@ msgid ""
 "you could use a new... yknowwhatImean?  The whole adventurer motif is just "
 "so... retro.  Just a word of advice, eh?  Ciao."
 msgstr ""
-"啊，好多了。呼！終於有尊嚴了！我的鹿角是直的嗎？很好。聽著，非常感謝你幫我。"
-"來，把這個當作禮物；而且，你知道。。。一點時尚提示。。。你可以用一點。。。你"
-"可以用一個新的。。。你知道什麼時候？整個冒險家的主題就是。。。復古的。只是一"
-"句忠告，嗯？再見"
+"啊​，​好多​了​。​呼​！​終於​有​尊嚴​了​！​我​的​鹿角​是​直​的​嗎​？​很​好​。​聽著​，​非常​感謝​你​"
+"幫​我​。​來​，​把​這個​當作​禮物​；​而且​，​你​知道​。​。​。​一​點​時​尚​提示​。​。​。​你​可以​用​"
+"一​點​。​。​。​你​可以​用​一​個​新​的​。​。​。​你​知道​什麼​時候​？​整​個​冒險家​的​主題​就是​。​。"
+"​。​復古​的​。​只​是​一​句​忠告​，​嗯​？​再​見"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:607
 msgid ""
 "Look.  I'm a cow.  And you, you're monster bait. Get some experience under "
 "your belt!  We'll talk..."
-msgstr ""
-"你看。我是一頭牛。而你，你是怪物誘餌。在你的腰帶下獲得一些經驗！我們談談"
+msgstr "你​看​。​我​是​一​頭​牛​。​而​你​，​你​是​怪物誘餌​。​在​你​的​腰帶​下獲​得​一些​經驗​！​我​們談談"
 
 #. TRANSLATORS: Quest text spoken by Farmer
 #: Source/textdat.cpp:610
@@ -10464,15 +10471,15 @@ msgid ""
 "It must truly be a fearsome task I've set before you. If there was just some "
 "way that I could... would a flagon of some nice, fresh milk help?"
 msgstr ""
-"這一定是我擺在你面前的一項可怕的任務。如果有什麼辦法我可以。。。喝一大杯新鮮"
-"的牛奶好嗎"
+"這​一定​是​我​擺​在​你​面前​的​一​項​可怕​的​任務​。​如果​有​什麼辦法​我​可以​。​。​。​喝​一​大杯​新"
+"鮮​的​牛奶​好​嗎"
 
 #. TRANSLATORS: Quest text spoken by Farmer
 #: Source/textdat.cpp:612
 msgid ""
 "Oh, I could use your help, but perhaps after you've saved the catacombs from "
 "the desecration of those beasts."
-msgstr "哦，我需要你的幫助，但也許在你從那些野獸的褻瀆中拯救了地下墓穴之後"
+msgstr "哦​，​我​需要​你​的​幫助​，​但​也​許​在​你​從​那些​野獸​的​褻瀆​中​拯救​了​地下​墓穴​之後"
 
 #. TRANSLATORS: Quest text spoken by Farmer
 #: Source/textdat.cpp:614
@@ -10480,8 +10487,8 @@ msgid ""
 "I need something done, but I couldn't impose on a perfect stranger. Perhaps "
 "after you've been here a while I might feel more comfortable asking a favor."
 msgstr ""
-"我需要做點什麼，但我不能強加給一個完全陌生的人。也許在你來了一段時間之後，我"
-"會更樂意請你幫個忙"
+"我​需要​做​點什麼​，​但​我​不​能​強​加給​一​個​完全​陌生​的​人​。​也​許​在​你​來​了​一​段​時間​之後"
+"​，​我​會​更​樂意請​你​幫個​忙"
 
 #. TRANSLATORS: Quest text spoken by Farmer
 #: Source/textdat.cpp:616
@@ -10489,8 +10496,8 @@ msgid ""
 "I see in you the potential for greatness.  Perhaps sometime while you are "
 "fulfilling your destiny, you could stop by and do a little favor for me?"
 msgstr ""
-"我從你身上看到了偉大的潛力。也許某個時候你正在完成你的命運，你可以停下來幫我"
-"一個小忙"
+"我​從​你​身​上​看到​了​偉大​的​潛力​。​也​許​某​個​時候​你​正在​完成​你​的​命運​，​你​可以​停下​來幫"
+"​我​一​個​小​忙"
 
 #. TRANSLATORS: Quest text spoken by Farmer
 #: Source/textdat.cpp:618
@@ -10499,14 +10506,14 @@ msgid ""
 "more powerful. I wouldn't want to injure the village's only chance to "
 "destroy the menace in the church!"
 msgstr ""
-"我想你也許可以幫我，但也許在你變得更有力量之後。我可不想破壞村子裡摧毀教堂威"
-"脅的唯一機會"
+"我​想​你​也​許​可以​幫​我​，​但​也​許​在​你​變​得​更​有​力量​之後​。​我​可​不​想​破壞​村子​裡摧毀​"
+"教堂​威脅​的​唯一​機會"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:620
 msgid ""
 "Me, I'm a self-made cow.  Make something of yourself, and... then we'll talk."
-msgstr "我，我是一頭白手起家的母牛。做點自己，然後。。。那我們談談"
+msgstr "我​，​我​是​一​頭​白手​起家​的​母牛​。​做點​自己​，​然​後​。​。​。​那​我​們談談"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:622
@@ -10514,8 +10521,8 @@ msgid ""
 "I don't have to explain myself to every tourist that walks by!  Don't you "
 "have some monsters to kill?  Maybe we'll talk later.  If you live..."
 msgstr ""
-"我不必向每一個路過的遊客解釋我自己！你不是有怪物要殺嗎？也許我們以後再談。如"
-"果你活著"
+"我​不​必​向​每​一​個​路過​的​遊客解釋​我​自己​！​你​不​是​有​怪物​要​殺嗎​？​也​許​我​們​以​後​再​"
+"談​。​如果​你​活​著"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:624
@@ -10524,8 +10531,8 @@ msgid ""
 "it.  I can't trust you, you're going to get eaten by monsters any day now... "
 "I need someone who's an experienced hero."
 msgstr ""
-"別煩我了。我在找一個真正的英雄。但你不是。我不能相信你，你隨時都會被怪物吃掉"
-"的。。。我需要一個有經驗的英雄"
+"別煩​我​了​。​我​在​找​一​個​真正​的​英雄​。​但​你​不是​。​我​不​能​相信​你​，​你​隨時​都​會​被​怪"
+"物​吃掉​的​。​。​。​我​需要​一​個​有​經驗​的​英雄"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
 #: Source/textdat.cpp:626
@@ -10542,12 +10549,13 @@ msgid ""
 "it's just south of the fork in the river... you know... the one with the "
 "overgrown vegetable garden."
 msgstr ""
-"好吧，我來切公牛。我不是故意誤導你的。我坐在家裡，心情很不好，這時情況變得很"
-"不穩定；一大群怪物從地板上跑了出來！我只是嚇了一跳。我跑出家門的時候正好穿著"
-"這件球衣，現在我看起來很可笑。如果我有正常的衣服穿，就不會那麼糟糕了。嘿你能"
-"回我家幫我拿衣服嗎？棕色的，不是灰色的，那是晚裝的。我會自己做的，但我不想讓"
-"任何人看到我這樣。給，拿著這個，你可能需要它。。。殺死那些長滿一切的東西。你"
-"不會錯過我家的，就在河的岔口南邊。。。你知道的。。。有雜草叢生的菜園的那個"
+"好​吧​，​我​來切​公牛​。​我​不​是​故意​誤導​你​的​。​我​坐​在​家裡​，​心情​很​不​好​，​這時​情況變​"
+"得​很​不​穩定​；​一​大​群​怪物從​地板​上​跑​了​出來​！​我​只​是​嚇​了​一​跳​。​我​跑出家門​的​時候​"
+"正好​穿​著​這件​球衣​，​現​在​我​看​起來​很​可​笑​。​如果​我​有​正常​的​衣服​穿​，​就​不​會​那麼​糟"
+"糕​了​。​嘿​你​能回​我​家​幫​我​拿​衣服​嗎​？​棕色​的​，​不​是​灰色​的​，​那​是​晚裝​的​。​我​會​"
+"自己​做​的​，​但​我​不​想​讓​任何​人​看到​我​這樣​。​給​，​拿​著​這個​，​你​可能​需要​它​。​。​。​"
+"殺死​那些​長滿​一切​的​東西​。​你​不​會​錯過​我​家​的​，​就​在​河​的​岔口​南邊​。​。​。​你​知道​的​"
+"。​。​。​有​雜草​叢生​的​菜園​的​那​個"
 
 #. TRANSLATORS: Quest text spoken by Unknown, Maybe Farmer
 #: Source/textdat.cpp:628
@@ -10557,8 +10565,8 @@ msgid ""
 "remember to order some more bat guano and black candles from Adria; I'm "
 "running a bit low."
 msgstr ""
-"今天多雲涼爽。將亡靈之網撒向虛空，降落了兩個新的飛行恐懼亞種；一天的好工作。"
-"一定要記得從阿德里亞訂購更多的蝙蝠糞和黑蠟燭；我的血壓有點低"
+"今天​多​雲​涼爽​。​將亡靈​之​網​撒向虛空​，​降落​了​兩個​新​的​飛行​恐懼​亞種​；​一​天​的​好​工作​。​"
+"一定​要​記​得​從​阿德里亞訂購​更​多​的​蝙蝠糞​和​黑蠟燭​；​我​的​血壓​有​點​低"
 
 #. TRANSLATORS: Quest text read aloud from book
 #: Source/textdat.cpp:630
@@ -10567,8 +10575,8 @@ msgid ""
 "creature -- to no avail.  My methods of enslaving lesser demons seem to have "
 "no effect on this fearsome beast."
 msgstr ""
-"我試過咒語，威脅，放棄和這個骯髒的生物討價還價——都沒有用。我奴役小惡魔的方法"
-"似乎對這個可怕的野獸沒有效果"
+"我​試過咒​語​，​威脅​，​放棄​和​這個​骯髒​的​生物​討價​還價​——​都​沒​有用​。​我​奴役​小惡魔​的​方法​"
+"似乎​對這個​可怕​的​野獸沒​有​效果"
 
 #. TRANSLATORS: Quest text read aloud from book
 #: Source/textdat.cpp:632
@@ -10578,8 +10586,8 @@ msgid ""
 "of my vision.  The faint scrabble of claws dances at the edges of my "
 "hearing. They are searching, I think, for this journal."
 msgstr ""
-"我的家正慢慢被這個不受歡迎的囚犯的卑鄙行徑所腐蝕。地窖里到處都是影子，它們就"
-"在我視線的角落之外。我耳邊隱約傳來爪子的拼字聲。我想，他們在找這本雜誌"
+"我​的​家正​慢慢​被​這個​不​受​歡迎​的​囚犯​的​卑鄙行徑​所​腐蝕​。​地窖里​到​處​都​是​影子​，​它​們​就"
+"​在​我​視線​的​角落​之外​。​我​耳邊隱約傳​來​爪子​的​拼字聲​。​我​想​，​他​們​在​找這​本​雜誌"
 
 #. TRANSLATORS: Quest text read aloud from book
 #: Source/textdat.cpp:634
@@ -10589,9 +10597,9 @@ msgid ""
 "destroyed my library.  Na-Krul... The name fills me with a cold dread.  I "
 "prefer to think of it only as The Creature rather than ponder its true name."
 msgstr ""
-"在咆哮中，這個生物漏了自己的名字——納克魯爾。我曾試圖研究這個名字，但小惡魔不"
-"知何故毀了我的圖書館。納克魯爾。。。我對這個名字充滿了恐懼。我寧願把它當作一"
-"種生物，而不願考慮它的真名"
+"在​咆哮​中​，​這個​生物​漏​了​自己​的​名字​——​納克魯爾​。​我​曾​試圖​研究​這個​名字​，​但​小​惡​魔​"
+"不​知​何故毀​了​我​的​圖書館​。​納克魯爾​。​。​。​我​對這個​名字​充滿​了​恐懼​。​我​寧願​把​它​當​作​"
+"一​種​生物​，​而​不​願考慮​它​的​真名"
 
 #. TRANSLATORS: Quest text read aloud from book
 #: Source/textdat.cpp:636
@@ -10601,8 +10609,9 @@ msgid ""
 "curses upon me for trapping it here.  Its words fill my heart with terror, "
 "and yet I cannot block out its voice."
 msgstr ""
-"那被困住的生物狂怒的嚎叫使我無法獲得急需的睡眠。它向那把它送到虛空的人發怒，"
-"因我把它困在這裡，就咒詛我。它的話語使我的心充滿恐懼，然而我無法阻擋它的聲音"
+"那​被​困住​的​生物​狂怒​的​嚎叫​使​我​無法獲​得​急​需​的​睡眠​。​它​向​那​把​它​送到​虛空​的​人​發怒"
+"​，​因​我​把​它​困​在​這裡​，​就​咒​詛​我​。​它​的​話語​使​我​的​心充滿​恐懼​，​然而​我​無​法​阻擋"
+"​它​的​聲音"
 
 #. TRANSLATORS: Quest text read aloud from book
 #: Source/textdat.cpp:638
@@ -10612,8 +10621,8 @@ msgid ""
 "knowledge to free their lord.  I hope that whoever finds this journal will "
 "seek the knowledge."
 msgstr ""
-"我的時間快用完了。我必須記錄下削弱惡魔的方法，然後隱藏這段文字，以免他的爪牙"
-"們想辦法利用我的知識來解放他們的主。我希望找到這本日記的人都能找到知識"
+"我​的​時間​快​用完​了​。​我​必​須記錄​下​削弱​惡魔​的​方法​，​然​後​隱​藏這​段​文字​，​以免​他​的​爪"
+"牙們​想​辦法​利用​我​的​知識來​解放​他​們​的​主​。​我​希望​找到​這本​日記​的​人​都​能​找到​知識"
 
 #. TRANSLATORS: Quest text read aloud from book
 #: Source/textdat.cpp:640
@@ -10631,60 +10640,60 @@ msgid ""
 "only these spells to gain entry or his power may be too great for you to "
 "defeat."
 msgstr ""
-"無論誰找到這卷卷軸，都將負責阻止這些墻內的惡魔生物。我的時間到了。即使是現"
-"在，它的地獄般的爪子在脆弱的門，我躲在後面爪。\n"
+"無​論誰​找到​這卷​卷軸​，​都​將負責​阻止​這​些​墻內​的​惡魔​生物​。​我​的​時間​到​了​。​即使​是​現​在"
+"​，​它​的​地獄​般​的​爪子​在​脆弱​的​門​，​我​躲​在​後面​爪​。​\n"
 " \n"
-"我已經用神秘的魔法把惡魔束縛住，把它包裹在長城裡，但我擔心這還不夠。\n"
+"​我​已​經用​神秘​的​魔法​把​惡​魔束​縛住​，​把​它​包裹​在​長城裡​，​但​我​擔心這還​不​夠​。​\n"
 " \n"
-"在我的三個幽靈身上找到的法術將為你提供進入他的領地的保護，但前提是必須按正確"
-"的順序施放。入口的槓桿會移除障礙物，釋放惡魔；別碰他們！只使用這些法術進入，"
-"否則他的力量可能太大，你無法擊敗"
+"​在​我​的​三​個​幽靈​身​上​找到​的​法術將為​你​提供​進入​他​的​領地​的​保護​，​但​前提​是​必須​按​正"
+"確​的​順序​施放​。​入口​的​槓桿​會​移​除障​礙物​，​釋放​惡魔​；​別碰​他​們​！​只​使用​這​些​法術​進入"
+"​，​否則​他​的​力量​可能​太​大​，​你​無法擊敗"
 
 #. TRANSLATORS: Quest text read aloud from book by player
 #: Source/textdat.cpp:642 Source/textdat.cpp:645 Source/textdat.cpp:648
 #: Source/textdat.cpp:651 Source/textdat.cpp:654
 msgid "In Spiritu Sanctum."
-msgstr "在靈堂"
+msgstr "在​靈堂"
 
 #. TRANSLATORS: Quest text read aloud from book by player
 #: Source/textdat.cpp:643 Source/textdat.cpp:646 Source/textdat.cpp:649
 #: Source/textdat.cpp:652 Source/textdat.cpp:655
 msgid "Praedictum Otium."
-msgstr "中耳前庭"
+msgstr "中​耳前庭"
 
 #. TRANSLATORS: Quest text read aloud from book by player
 #: Source/textdat.cpp:644 Source/textdat.cpp:647 Source/textdat.cpp:650
 #: Source/textdat.cpp:653 Source/textdat.cpp:656
 msgid "Efficio Obitus Ut Inimicus."
-msgstr "有效的懲罰"
+msgstr "有效​的​懲罰"
 
 #: Source/towners.cpp:86
 msgid "Griswold the Blacksmith"
-msgstr "鐵匠格里斯沃爾德"
+msgstr "鐵​匠​格里斯沃​爾德"
 
 #: Source/towners.cpp:108
 msgid "Ogden the Tavern owner"
-msgstr "酒館老闆奧格登"
+msgstr "酒​館​老​闆​奧​格登"
 
 #: Source/towners.cpp:117
 msgid "Wounded Townsman"
-msgstr "受傷的市民"
+msgstr "受傷​的​市民"
 
 #: Source/towners.cpp:139
 msgid "Adria the Witch"
-msgstr "女巫艾德里亞"
+msgstr "女​巫艾德里亞"
 
 #: Source/towners.cpp:148
 msgid "Gillian the Barmaid"
-msgstr "酒吧女招待阿嬌"
+msgstr "酒吧​女​招待​阿嬌"
 
 #: Source/towners.cpp:179
 msgid "Pepin the Healer"
-msgstr "醫治者"
+msgstr "醫​治者"
 
 #: Source/towners.cpp:196
 msgid "Cain the Elder"
-msgstr "長者凱恩"
+msgstr "長者​凱恩"
 
 #: Source/towners.cpp:225
 msgid "Cow"
@@ -10692,71 +10701,71 @@ msgstr "奶牛"
 
 #: Source/towners.cpp:244
 msgid "Lester the farmer"
-msgstr "農夫萊斯特"
+msgstr "農夫萊​斯特"
 
 #: Source/towners.cpp:257
 msgid "Complete Nut"
-msgstr "全套螺母"
+msgstr "全​套​螺母"
 
 #: Source/towners.cpp:279
 msgid "Slain Townsman"
-msgstr "被殺的老鄉"
+msgstr "被​殺​的​老​鄉"
 
 #: Source/trigs.cpp:341
 msgid "Down to dungeon"
-msgstr "下到地牢"
+msgstr "下​到​地​牢"
 
 #: Source/trigs.cpp:352
 msgid "Down to catacombs"
-msgstr "下到地下墓穴"
+msgstr "下​到​地下​墓穴"
 
 #: Source/trigs.cpp:362
 msgid "Down to caves"
-msgstr "下到山洞"
+msgstr "下​到​山洞"
 
 #: Source/trigs.cpp:372
 msgid "Down to hell"
-msgstr "下到地獄"
+msgstr "下​到​地獄"
 
 #: Source/trigs.cpp:384
 msgid "Down to Hive"
-msgstr "下到巢穴"
+msgstr "下​到​巢穴"
 
 #: Source/trigs.cpp:396
 msgid "Down to Crypt"
-msgstr "去地下室"
+msgstr "去​地下室"
 
 #: Source/trigs.cpp:412 Source/trigs.cpp:492 Source/trigs.cpp:539
 #: Source/trigs.cpp:630
 msgid "Up to level {:d}"
-msgstr "達到{:d}層"
+msgstr "達​到​{:d}​層"
 
 #: Source/trigs.cpp:414 Source/trigs.cpp:469 Source/trigs.cpp:521
 #: Source/trigs.cpp:596 Source/trigs.cpp:613 Source/trigs.cpp:660
 msgid "Up to town"
-msgstr "進城"
+msgstr "進​城"
 
 #: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:552
 #: Source/trigs.cpp:577 Source/trigs.cpp:642
 msgid "Down to level {:d}"
-msgstr "下到{:d}"
+msgstr "下​到​{:d}"
 
 #: Source/trigs.cpp:437
 msgid "Up to Crypt level {:d}"
-msgstr "上到墓穴{:d}層"
+msgstr "上​到​墓穴​{:d}​層"
 
 #: Source/trigs.cpp:452
 msgid "Down to Crypt level {:d}"
-msgstr "下到墓穴{:d}層"
+msgstr "下​到​墓穴​{:d}​層"
 
 #: Source/trigs.cpp:564
 msgid "Up to Nest level {:d}"
-msgstr "上到巢穴{:d}層"
+msgstr "上​到​巢穴{:d}​層"
 
 #: Source/trigs.cpp:673
 msgid "Down to Diablo"
-msgstr "下到迪亞波羅"
+msgstr "下​到​迪亞波羅"
 
 #: Source/trigs.cpp:706 Source/trigs.cpp:720 Source/trigs.cpp:734
 msgid "Back to Level {:d}"
-msgstr "返回到{:d}層"
+msgstr "返回​到​{:d}​層"

--- a/tools/zh_segmenter/README.md
+++ b/tools/zh_segmenter/README.md
@@ -1,0 +1,37 @@
+# Chinese segmenter for gettext (.po) translation files
+
+Inserts [ZWSP] between the segments of Chinese text.
+
+Uses a high quality `zh_segmentation` model from Google: <https://tfhub.dev/google/zh_segmentation/1>.
+
+## Pre-requisites
+
+1. Python. The easiest way to install Python on any Linux system is <https://github.com/asdf-vm/asdf>.
+
+2. ```bash
+   pip install 'tensorflow_text>=2.4.0b0'
+   ```
+
+## Usage
+
+To re-segment the current translation files:
+
+```shell
+tools/zh_segmenter/segment.py --input_path Translations/zh_CN.po
+tools/zh_segmenter/segment.py --input_path Translations/zh_TW.po
+```
+
+Additionaly, you can provide a different separator, such as `--separator='|'`, for debugging.
+
+This tool performs a number of replacements to make sure interpolations are not affected etc.
+
+You can also see the segmenter output for a given string like this:
+
+```console
+tools/zh_segmenter/segment.py --debug '返回到 {:d} 层'
+```
+```
+返回|到| |{|:d}| |层
+```
+
+[ZWSP]: https://en.wikipedia.org/wiki/Zero-width_space

--- a/tools/zh_segmenter/segment.py
+++ b/tools/zh_segmenter/segment.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+import argparse
+import pathlib
+import os
+import re
+import sys
+
+import tensorflow_text
+
+_DISALLOW_SEGMENTATION = re.compile(
+	r'(?:\{[^\}]*\}|\\[a-z]|[\w/-](?::[\w/-]?)?|[.,;?!=+/#]|\s)+'.encode())
+
+_ZWSP = "\u200B"
+
+_MODEL_HANDLE = "https://tfhub.dev/google/zh_segmentation/1"
+
+default_input_path = pathlib.Path(__file__).resolve(
+).parent.parent.parent.joinpath("Translations/zh_CN.po")
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--input_path", default=default_input_path,
+                    help="Path to the input .po file")
+parser.add_argument("--output_path", help="Output path (default: in-place)")
+parser.add_argument("--separator", default=_ZWSP,
+                    help="Separator to use between segments")
+parser.add_argument("--debug",
+                    help="If this flag is given, segments the given string, joins with \"|\", and prints it.")
+args = parser.parse_args()
+
+_SEPARATOR = args.separator.encode()
+_SEGMENTER = tensorflow_text.HubModuleTokenizer(_MODEL_HANDLE)
+
+
+def _RunSegmenter(text, separator):
+	"""Runs the segmenter and produces a separator-joined string."""
+	if not text:
+		return []
+	text = _RemoveAllMarkers(text)
+	_tokens, starts, ends = _SEGMENTER.tokenize_with_offsets(text)
+	starts, ends = starts.numpy(), ends.numpy()
+	starts, ends = _RecoverGaps(text, starts, ends)
+	starts, ends = _MergeDisallowedPositions(text, starts, ends)
+	output = separator.join([text[i:j] for i, j in zip(starts, ends)])
+	return _RemoveRedundantMarkers(output)
+
+
+def _RecoverGaps(text, starts, ends):
+	"""Recovers gaps from the segmenter-produced start and end indices.
+
+	The segmenter may produce gaps around spaces, e.g. segment("hello world") => "hello|world"
+	"""
+	out_starts = []
+	out_ends = []
+	prev_end = 0
+	for start, end in zip(starts, ends):
+		if start != prev_end:
+			out_starts.append(prev_end)
+			out_ends.append(start)
+		out_starts.append(start)
+		out_ends.append(end)
+		prev_end = end
+	if out_ends[-1] != len(text):
+		out_ends[-1] = len(text)
+	return out_starts, out_ends
+
+
+def _MergeDisallowedPositions(text, starts, ends):
+	"""Merges segments disallowed by _DISALLOW_SEGMENTATION."""
+	disallowed = set()
+	for m in re.finditer(_DISALLOW_SEGMENTATION, text):
+		for i in range(m.start() + 1, m.end()):
+			disallowed.add(i)
+
+	out_starts = [starts[0]]
+	out_ends = [ends[0]]
+	for start, end in zip(starts[1:], ends[1:]):
+		if start in disallowed:
+			out_ends[-1] = end
+		else:
+			out_starts.append(start)
+			out_ends.append(end)
+	return out_starts, out_ends
+
+
+_REMOVE_REDUNDANT_MARKERS = re.compile(b''.join(
+	[re.escape(_SEPARATOR), '?([ 　，、。？！])'.encode(), re.escape(_SEPARATOR), b'?']))
+
+
+def _RemoveRedundantMarkers(text):
+	"""Removes segmentation markers for cases that are handled at runtime anyway."""
+	return re.sub(_REMOVE_REDUNDANT_MARKERS, r'\1', text)
+
+
+_SEGMENTATION_MARKERS = re.compile(b''.join(
+	[b'(?:', re.escape(_SEPARATOR), b'|', re.escape(_ZWSP.encode()), b')+']))
+
+
+def _RemoveAllMarkers(text):
+	"""Remove the existing segmentation markers to allow for re-segmenting."""
+	return re.sub(_SEGMENTATION_MARKERS, b'', text)
+
+
+def _QuoteLine(line):
+	return f'"{line}"\n'
+
+
+def _SplitEveryN(input, n):
+	return [input[i:i + n] for i in range(0, len(input), n)]
+
+
+def _FormatMsgStr(text_bytes):
+	"""A rough approximation of poedit formatting and wrapping."""
+	if not text_bytes:
+		return b'""\n'
+
+	text = text_bytes.decode()
+	output_lines = []
+	lines_with_newline = text.split('\\n')
+	for line_i, line_with_newline in enumerate(lines_with_newline):
+		if not line_with_newline and line_i != len(lines_with_newline) - 1:
+			output_lines.append('"\\n"\n')
+			continue
+		lines = _SplitEveryN(line_with_newline, 63)
+		if line_i == len(lines_with_newline) - 1:
+			lines = map(_QuoteLine, lines)
+		else:
+			lines[0:-1] = map(_QuoteLine, lines[0:-1])
+			lines[-1] = f'"{lines[-1]}\\n"\n'
+		output_lines.extend(lines)
+
+	if len(output_lines) > 1:
+		output_lines.insert(0, '""\n')
+	return ''.join(output_lines).encode()
+
+
+if args.debug:
+	with os.fdopen(sys.stdout.fileno(), "wb", closefd=False) as f:
+		f.write(_RunSegmenter(args.debug.encode(), separator=b'|'))
+		f.write(b'\n')
+	exit()
+
+if not args.output_path:
+	args.output_path = args.input_path
+
+with open(args.input_path, 'rb') as f:
+    input = f.readlines()
+
+_MSGSTR_PREFIX = b'msgstr '
+
+output = []
+
+# Skip poedit header
+header_end = input.index(b'\n') + 1
+output.extend(input[:header_end])
+input = input[header_end:]
+
+in_msgstr = False
+msgstr_prefix = ""
+msgstr = []
+
+
+def _ProcessMsgStr():
+	text = _RunSegmenter(b''.join(msgstr), separator=_SEPARATOR)
+	output.append(msgstr_prefix + _FormatMsgStr(text))
+
+
+for line in input:
+	if line.startswith(_MSGSTR_PREFIX):
+		msgstr_prefix, line = line.split(b'"', maxsplit=1)
+		msgstr.append(line[:-2])
+		in_msgstr = True
+	elif in_msgstr and line.startswith(b'"'):
+		msgstr.append(line[1:-2])
+	else:
+		if msgstr:
+			_ProcessMsgStr()
+			msgstr.clear()
+			msgstr_prefix = ""
+		output.append(line)
+		in_msgstr = False
+
+if msgstr:
+	_ProcessMsgStr()
+
+with open(args.output_path, 'wb') if args.output_path != "/dev/stdout" else os.fdopen(sys.stdout.fileno(), "wb", closefd=False) as f:
+	f.write(b''.join(output))


### PR DESCRIPTION
Adds a tool can insert ZWSP between words in Chinese .po files using this model: https://tfhub.dev/google/zh_segmentation/1

We will use this tool to be able to word wrap Chinese translations at runtime without bundling a segmenter.

Doing this offline also allows us to use a segmenter that would otherwise be too slow for runtime.

The tool takes ~15s to run and depends on Python, TensorFlow, and downloads a model file as needed.
It is too heavy to run automatically at build time, so it will only be run manually for now:

    tools/zh_segmenter/segment.py --input_path Translations/zh_CN.po
    tools/zh_segmenter/segment.py --input_path Translations/zh_TW.po

![image](https://user-images.githubusercontent.com/216339/141028317-4eb90ef9-8eef-4b38-a40e-771dd4f97859.png)


Refs #3162
/cc @tytannial