### PR TITLE
Add VS configuration for building in WSL using GCC

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -48,7 +48,7 @@ end_of_line = crlf
 [AppRun]
 end_of_line = lf
 
-[CMakeLists.txt]
+[{CMakeLists.txt,CMakeSettings.json}]
 indent_style = space
 indent_size = 2
 end_of_line = crlf

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,68 +1,82 @@
 {
-	"configurations": [
-		{
-			"name": "x64-Debug",
-			"generator": "Ninja",
-			"configurationType": "Debug",
-			"buildRoot": "${workspaceRoot}\\build\\${name}",
-			"installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-			"inheritEnvironments": [ "msvc_x64" ],
-			"intelliSenseMode": "windows-msvc-x64",
-			"enableClangTidyCodeAnalysis": true
-		},
-		{
-			"name": "x64-Debug-UnitTests",
-			"generator": "Ninja",
-			"configurationType": "Debug",
-			"buildRoot": "${workspaceRoot}\\build\\${name}",
-			"installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-			"inheritEnvironments": [ "msvc_x64" ],
-			"intelliSenseMode": "windows-msvc-x64",
-			"cmakeCommandArgs": "-DRUN_TESTS=ON",
-			"enableClangTidyCodeAnalysis": true
-		},
-		{
-			"name": "x64-Release",
-			"generator": "Ninja",
-			"configurationType": "Release",
-			"buildRoot": "${workspaceRoot}\\build\\${name}",
-			"installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-			"cmakeCommandArgs": "-DBINARY_RELEASE=ON",
-			"inheritEnvironments": [ "msvc_x64" ],
-			"intelliSenseMode": "windows-msvc-x64",
-			"enableClangTidyCodeAnalysis": true
-		},
-		{
-			"name": "x86-Debug",
-			"generator": "Ninja",
-			"configurationType": "Debug",
-			"buildRoot": "${workspaceRoot}\\build\\${name}",
-			"installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-			"inheritEnvironments": [ "msvc_x86" ],
-			"intelliSenseMode": "windows-msvc-x86",
-			"enableClangTidyCodeAnalysis": true
-		},
-		{
-			"name": "x86-Debug-UnitTests",
-			"generator": "Ninja",
-			"configurationType": "Debug",
-			"buildRoot": "${workspaceRoot}\\build\\${name}",
-			"installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-			"inheritEnvironments": [ "msvc_x86" ],
-			"intelliSenseMode": "windows-msvc-x86",
-			"cmakeCommandArgs": "-DRUN_TESTS=ON",
-			"enableClangTidyCodeAnalysis": true
-		},
-		{
-			"name": "x86-Release",
-			"generator": "Ninja",
-			"configurationType": "Release",
-			"buildRoot": "${workspaceRoot}\\build\\${name}",
-			"installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-			"cmakeCommandArgs": "-DBINARY_RELEASE=ON",
-			"inheritEnvironments": [ "msvc_x86" ],
-			"intelliSenseMode": "windows-msvc-x86",
-			"enableClangTidyCodeAnalysis": true
-		}
-	]
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${workspaceRoot}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "inheritEnvironments": [ "msvc_x64" ],
+      "intelliSenseMode": "windows-msvc-x64",
+      "enableClangTidyCodeAnalysis": true
+    },
+    {
+      "name": "x64-Debug-UnitTests",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${workspaceRoot}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "inheritEnvironments": [ "msvc_x64" ],
+      "intelliSenseMode": "windows-msvc-x64",
+      "cmakeCommandArgs": "-DRUN_TESTS=ON",
+      "enableClangTidyCodeAnalysis": true
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "buildRoot": "${workspaceRoot}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "cmakeCommandArgs": "-DBINARY_RELEASE=ON",
+      "inheritEnvironments": [ "msvc_x64" ],
+      "intelliSenseMode": "windows-msvc-x64",
+      "enableClangTidyCodeAnalysis": true
+    },
+    {
+      "name": "x86-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${workspaceRoot}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "inheritEnvironments": [ "msvc_x86" ],
+      "intelliSenseMode": "windows-msvc-x86",
+      "enableClangTidyCodeAnalysis": true
+    },
+    {
+      "name": "x86-Debug-UnitTests",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${workspaceRoot}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "inheritEnvironments": [ "msvc_x86" ],
+      "intelliSenseMode": "windows-msvc-x86",
+      "cmakeCommandArgs": "-DRUN_TESTS=ON",
+      "enableClangTidyCodeAnalysis": true
+    },
+    {
+      "name": "x86-Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "buildRoot": "${workspaceRoot}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "cmakeCommandArgs": "-DBINARY_RELEASE=ON",
+      "inheritEnvironments": [ "msvc_x86" ],
+      "intelliSenseMode": "windows-msvc-x86",
+      "enableClangTidyCodeAnalysis": true
+    },
+    {
+      "name": "WSL-GCC-x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${workspaceRoot}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "cmakeExecutable": "cmake",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "linux_x64" ],
+      "wslPath": "${defaultWSLPath}",
+      "variables": []
+    }
+  ]
 }

--- a/docs/building.md
+++ b/docs/building.md
@@ -143,7 +143,13 @@ The location of this tool will need to be [added to the system's PATH environmen
 
 * **Through Open->CMake in Visual Studio**
 1. Go to `File -> Open -> CMake`, select `CMakeLists.txt` from the project root.
-2. Select `Build devilution.exe` from the `Build` menu.
+2. Select the `x64-Release` configuration (or `x86` for 32 bit builds, `-Debug` for debug builds).
+3. Select `Build devilution.exe` from the `Build` menu.
+
+* **Through GCC/WSL in Visual Studio**
+1. Ensure the WSL environment has the build pre-requisites for both devilutionX (see "Installing Dependencies on Debian and Ubuntu" under the "Linux" section above) and [WSL remote development](https://docs.microsoft.com/en-us/cpp/linux/connect-to-your-remote-linux-computer?view=msvc-160#connect-to-wsl).
+2. Select the `WSL-GCC-x64-Debug` configuration.
+3. Select `Build devilution` from the `Build` menu.
 
 * **Through cmake-gui**
 


### PR DESCRIPTION
This is mainly to help me test code builds under GCC faster than pushing to the remote and letting the build server do it. If someone without WSL installed selects the build target they'll get an error in their IDE, but no harmful impact other than that. The variables should be populated for any WSL2 installation. No idea about WSL1.

The whitespace in this file is showing significant changes because visual studio regenerates the whole file when a change is made, I didn't think it was worth reverting since it'll happen again next time someone makes a change (seems it defaults to spaces...)