### PR TITLE
[3DS] Fix dependencies for romfs build targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1192,7 +1192,9 @@ if(NINTENDO_3DS)
 
   add_custom_target(romfs_files
     COMMAND ${CMAKE_COMMAND} -E copy ${APP_ROMFS_FILES} ${APP_ROMFS}
-    DEPENDS romfs_directory ${APP_ROMFS_FILES})
+    DEPENDS ${APP_ROMFS_FILES})
+    
+  add_dependencies(romfs_files romfs_directory devilutionx_mpq)
 
   include(Tools3DS)
   add_cia_target(${BIN_TARGET} ${APP_RSF} ${APP_BANNER} ${APP_AUDIO})


### PR DESCRIPTION
I think I finally figured out what was going on here. The `devilutionx_mpq` target was built after the `romfs_files` target. Also, it seems the `romfs_directory` target was being add as a file dependency of the `romfs_files` target which was probably confusing matters.