### PR TITLE
SDL1: Don't destroy surface in SDL_DestroyWindow

### DIFF
--- a/Source/utils/sdl2_to_1_2_backports.h
+++ b/Source/utils/sdl2_to_1_2_backports.h
@@ -163,7 +163,6 @@ inline void SDL_GetWindowSize(SDL_Window *window, int *w, int *h)
 
 inline void SDL_DestroyWindow(SDL_Window *window)
 {
-	SDL_FreeSurface(window);
 }
 
 inline void


### PR DESCRIPTION
As per the documentation (https://www.libsdl.org/release/SDL-1.2.15/docs/html/sdlsetvideomode.html), `SDL_Quit` does this for us.