### PR TITLE
Do not disable backlight on o2DS

### DIFF
--- a/Source/platform/ctr/cfgu_service.hpp
+++ b/Source/platform/ctr/cfgu_service.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <3ds/result.h>
+#include <3ds/services/cfgu.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+namespace devilution {
+namespace n3ds {
+
+class CFGUService {
+public:
+	CFGUService()
+	{
+		Result res = cfguInit();
+		isInitialized = R_SUCCEEDED(res);
+	}
+
+	~CFGUService()
+	{
+		cfguExit();
+	}
+
+	bool IsInitialized()
+	{
+		return isInitialized;
+	}
+
+private:
+	bool isInitialized;
+};
+
+} // namespace n3ds
+} // namespace devilution

--- a/Source/platform/ctr/locale.cpp
+++ b/Source/platform/ctr/locale.cpp
@@ -1,34 +1,19 @@
-#include "platform/ctr/locale.hpp"
-
 #include <3ds.h>
+
+#include "platform/ctr/cfgu_service.hpp"
+#include "platform/ctr/locale.hpp"
 
 namespace devilution {
 namespace n3ds {
 
-namespace {
-
-class CFGUService {
-public:
-	CFGUService()
-	{
-		cfguInit();
-	}
-
-	~CFGUService()
-	{
-		cfguExit();
-	}
-};
-
-} // namespace
-
 std::string GetLocale()
 {
 	CFGUService cfguService;
+	if (!cfguService.IsInitialized())
+		return "";
 
 	u8 language;
 	Result res = CFGU_GetSystemLanguage(&language);
-
 	if (!R_SUCCEEDED(res))
 		return "";
 

--- a/Source/platform/ctr/system.cpp
+++ b/Source/platform/ctr/system.cpp
@@ -1,13 +1,15 @@
+#include <3ds.h>
 #include <cstdlib>
 #include <cstdio>
-#include <3ds.h>
-#include "platform/ctr/system.h"
+
+#include "platform/ctr/cfgu_service.hpp"
 #include "platform/ctr/random.hpp"
 #include "platform/ctr/sockets.hpp"
+#include "platform/ctr/system.h"
 
 using namespace devilution;
 
-bool isN3DS;
+bool shouldDisableBacklight;
 
 aptHookCookie cookie;
 
@@ -35,6 +37,8 @@ void aptHookFunc(APT_HookType hookType, void *param)
 
 void ctr_lcd_backlight_on()
 {
+	if (!shouldDisableBacklight)
+		return;
 	gspLcdInit();
 	GSPLCD_PowerOnBacklight(GSPLCD_SCREEN_BOTTOM);
 	gspLcdExit();
@@ -42,6 +46,8 @@ void ctr_lcd_backlight_on()
 
 void ctr_lcd_backlight_off()
 {
+	if (!shouldDisableBacklight)
+		return;
 	gspLcdInit();
 	GSPLCD_PowerOffBacklight(GSPLCD_SCREEN_BOTTOM);
 	gspLcdExit();
@@ -63,6 +69,27 @@ bool ctr_check_dsp()
 	return true;
 }
 
+bool ctr_is_n3ds()
+{
+	bool isN3DS;
+	Result res = APT_CheckNew3DS(&isN3DS);
+	return R_SUCCEEDED(res) && isN3DS;
+}
+
+bool ctr_should_disable_backlight()
+{
+	n3ds::CFGUService cfguService;
+	if (!cfguService.IsInitialized())
+		return false;
+
+	u8 model;
+	Result res = CFGU_GetSystemModel(&model);
+	if (!R_SUCCEEDED(res))
+		return false;
+
+	return model != CFG_MODEL_2DS;
+}
+
 void ctr_sys_init()
 {
 	if (ctr_check_dsp() == false)
@@ -70,9 +97,10 @@ void ctr_sys_init()
 
 	aptHook(&cookie, aptHookFunc, NULL);
 
-	APT_CheckNew3DS(&isN3DS);
-	if (isN3DS)
+	if (ctr_is_n3ds())
 		osSetSpeedupEnable(true);
+
+	shouldDisableBacklight = ctr_should_disable_backlight();
 
 	ctr_lcd_backlight_off();
 	atexit([]() { ctr_lcd_backlight_on(); });


### PR DESCRIPTION
I'm unable to test this on o2DS myself, but it should work okay based on the documentation. Eventually, it might be nice to enable toggling of the backlight, but it's probably best to wait until control remapping and/or bottom screen UI can be implemented.

This resolves #3444

*Note: If anyone chooses to attempt to test this build, it is highly recommended that you disable Sound and Music Volume in [diablo.ini](https://github.com/diasurgical/devilutionX/wiki/DevilutionX-diablo.ini-configuration-guide#audio) to avoid system crashes.*