### PR TITLE
improve dropping items

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1601,12 +1601,8 @@ bool TryDropItem()
 		}
 	}
 
-	cursPosition = myPlayer.position.future + Direction::SouthEast;
-	if (!DropItemBeforeTrig()) {
-		// Try to drop on the other side
-		cursPosition = myPlayer.position.future + Direction::SouthWest;
-		DropItemBeforeTrig();
-	}
+	cursPosition = myPlayer.position.future;
+	DropItemBeforeTrig();
 
 	if (pcurs != CURSOR_HAND) {
 		myPlayer.Say(HeroSpeech::WhereWouldIPutThis);

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1139,23 +1139,25 @@ bool PutItem(Player &player, Point &position)
 	if (position.WalkingDistance(player.position.tile) > 1) {
 		position = player.position.tile + d;
 	}
-
-	std::optional<Point> itemPosition = FindClosestValidItemPosition(position);
-
-	position = player.position.tile + Left(Left(Left(d)));
 	if (CanPut(position))
 		return true;
 
-	position = player.position.tile + Right(Right(Right(d)));
+	position = player.position.tile + Left(d);
 	if (CanPut(position))
 		return true;
 
-	position = player.position.tile + Opposite(d);
+	position = player.position.tile + Right(d);
 	if (CanPut(position))
 		return true;
 
-	position = player.position.tile;
-	return CanPut(position);
+	std::optional<Point> itemPosition = FindClosestValidPosition(CanPut, player.position.tile, 1, 50);
+
+	if (itemPosition) {
+		position = itemPosition.value();
+		return true;
+	}
+
+	return false;
 }
 
 bool CanUseStaff(Item &staff, spell_id spell)

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1211,7 +1211,6 @@ std::optional<Point> FindClosestValidItemPosition(Point startingPosition)
 	return {};
 }
 
-
 void FreeInvGFX()
 {
 	pInvCels = std::nullopt;

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -90,6 +90,7 @@ extern const Point InvRect[73];
  */
 using ItemFunc = void (*)(Item &);
 
+std::optional<Point> FindClosestValidItemPosition(Point startingPosition);
 void FreeInvGFX();
 void InitInv();
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -557,21 +557,14 @@ void DeadItem(Player &player, Item &&itm, Displacement direction)
 		return;
 
 	Point target = player.position.tile + direction;
-	if (direction != Displacement { 0, 0 } && ItemSpaceOk(target)) {
+	if (direction != Displacement { 0, 0 } && CanPut(target)) {
 		RespawnDeadItem(std::move(itm), target);
 		return;
 	}
 
-	for (int k = 1; k < 50; k++) {
-		for (int j = -k; j <= k; j++) {
-			for (int i = -k; i <= k; i++) {
-				Point next = player.position.tile + Displacement { i, j };
-				if (ItemSpaceOk(next)) {
-					RespawnDeadItem(std::move(itm), next);
-					return;
-				}
-			}
-		}
+	std::optional<Point> itemPosition = FindClosestValidItemPosition(player.position.tile);
+	if (itemPosition) {
+		RespawnDeadItem(std::move(itm), itemPosition.value());
 	}
 }
 


### PR DESCRIPTION
Allows dropping items further than only tiles adjacent to the character and prevents them from dropping in unreachable places.
@Chance4us can you test? : P

Resolves https://github.com/diasurgical/devilutionX/issues/3514 in a super ugly way 🙃 
Fixes https://github.com/diasurgical/devilutionX/issues/4124
```cpp
bool CanPut(Point position)
{
	// TODO: remove after collision of houses has been fixed - see https://github.com/diasurgical/devilutionX/issues/3514
	// clang-format off
	if (IsAnyOf(position,
		Point { 53, 45 }, Point { 46, 45 }, Point { 46, 44 }, // house near portal location
		Point { 27, 16 }, Point { 29, 18 }, Point { 27, 27 }, // cathedral
		Point { 38, 67 }, Point { 38, 66 }, Point { 41, 67 }, Point { 41, 64 }, Point { 40, 64 }, // gillian's house
		Point { 71, 81 }, Point { 68, 81 }, Point { 68, 80 }, Point { 70, 78 }, Point { 71, 78 }, // house near farnham
		Point { 73, 71 }, // house near spawn
		Point { 60, 61 }, Point { 60, 60 }, Point { 62, 59 }, Point { 62, 58 }, // griswold's house
		Point { 9, 45 } // stones around wirt
	))
	// clang-format on
		return false;
```