### PR TITLE
`PrintMonstHistory`: Fix string manipulation

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -880,9 +880,10 @@ void ToggleSpell(int slot)
 	}
 }
 
-void AddPanelString(const char *str)
+void AddPanelString(string_view str)
 {
-	strcpy(panelstr[pnumlines], str);
+	strncpy(panelstr[pnumlines], str.data(), str.size());
+	panelstr[pnumlines][str.size()] = '\0';
 
 	if (pnumlines < 4)
 		pnumlines++;

--- a/Source/control.h
+++ b/Source/control.h
@@ -14,6 +14,7 @@
 #include "spelldat.h"
 #include "spells.h"
 #include "utils/stdcompat/optional.hpp"
+#include "utils/stdcompat/string_view.hpp"
 #include "utils/ui_fwd.h"
 
 namespace devilution {
@@ -76,7 +77,7 @@ void SetSpell();
 void SetSpeedSpell(int slot);
 void ToggleSpell(int slot);
 
-void AddPanelString(const char *str);
+void AddPanelString(string_view str);
 void ClearPanel();
 void DrawPanelBox(const Surface &out, SDL_Rect srcRect, Point targetPosition);
 Point GetPanelPosition(UiPanels panel, Point offset = { 0, 0 });

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -32,6 +32,7 @@
 #include "towners.h"
 #include "trigs.h"
 #include "utils/language.h"
+#include "utils/utf8.hpp"
 
 #ifdef _DEBUG
 #include "debug.h"
@@ -1340,7 +1341,7 @@ bool MonsterWalk(int i, MonsterMode variant)
 	auto &monster = Monsters[i];
 	assert(monster.MType != nullptr);
 
-	//Check if we reached new tile
+	// Check if we reached new tile
 	bool isAnimationEnd = monster.AnimInfo.CurrentFrame == monster.AnimInfo.NumberOfFrames;
 	if (isAnimationEnd) {
 		switch (variant) {
@@ -1365,7 +1366,7 @@ bool MonsterWalk(int i, MonsterMode variant)
 		if (monster.mlid != NO_LIGHT)
 			ChangeLightXY(monster.mlid, monster.position.tile);
 		M_StartStand(monster, monster._mdir);
-	} else { //We didn't reach new tile so update monster's "sub-tile" position
+	} else { // We didn't reach new tile so update monster's "sub-tile" position
 		if (monster.AnimInfo.TickCounterOfCurrentFrame == 0) {
 			if (monster.AnimInfo.CurrentFrame == 0 && monster.MType->mtype == MT_FLESTHNG)
 				PlayEffect(monster, 3);
@@ -1422,7 +1423,7 @@ void CheckReflect(int mon, int pnum, int dam)
 	player.wReflections--;
 	if (player.wReflections <= 0)
 		NetSendCmdParam1(true, CMD_SETREFLECT, 0);
-	//reflects 20-30% damage
+	// reflects 20-30% damage
 	int mdam = dam * (GenerateRnd(10) + 20L) / 100;
 	monster._mhitpoints -= mdam;
 	dam = std::max(dam - mdam, 0);
@@ -4660,8 +4661,9 @@ void PrintMonstHistory(int mt)
 					strcat(tempstr, _("Fire "));
 				if ((res & RESIST_LIGHTNING) != 0)
 					strcat(tempstr, _("Lightning "));
-				tempstr[strlen(tempstr) - 1] = '\0';
-				AddPanelString(tempstr);
+				string_view str { tempstr };
+				str.remove_suffix(str.size() - FindLastUtf8Symbols(str));
+				AddPanelString(str);
 			}
 			if ((res & (IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING)) != 0) {
 				strcpy(tempstr, _("Immune: "));
@@ -4671,8 +4673,9 @@ void PrintMonstHistory(int mt)
 					strcat(tempstr, _("Fire "));
 				if ((res & IMMUNE_LIGHTNING) != 0)
 					strcat(tempstr, _("Lightning "));
-				tempstr[strlen(tempstr) - 1] = '\0';
-				AddPanelString(tempstr);
+				string_view str { tempstr };
+				str.remove_suffix(str.size() - FindLastUtf8Symbols(str));
+				AddPanelString(str);
 			}
 		}
 	}

--- a/Translations/ja.po
+++ b/Translations/ja.po
@@ -5426,19 +5426,19 @@ msgstr "耐性: "
 
 #: Source/monster.cpp:4679 Source/monster.cpp:4690
 msgid "Magic "
-msgstr " 魔法"
+msgstr "魔法 "
 
 #: Source/monster.cpp:4681 Source/monster.cpp:4692
 msgid "Fire "
-msgstr "火炎"
+msgstr "火炎 "
 
 #: Source/monster.cpp:4683 Source/monster.cpp:4694
 msgid "Lightning "
-msgstr "ライトニング"
+msgstr "ライトニング "
 
 #: Source/monster.cpp:4688
 msgid "Immune: "
-msgstr "無効:"
+msgstr "無効: "
 
 #: Source/monster.cpp:4706
 msgid "Type: {:s}"


### PR DESCRIPTION
The code previously assumed that there is an ASCII separator after each resistance type.

Different languages may use something else entirely. Relaxes the assumption to any single code point to avoid producing malformed UTF-8.

Also fixes Japanese translations to use a space after the resistance (although I think it should be a fullwidth space or an ideographic comma, I'll leave that to the translators).

I'm not sure whether this is the cause of the crash in #3490 as I cannot reproduce it (hero dies too fast from the save).