### PR TITLE
Implement virtual gamepad activation/deactivation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,10 @@ if(PIE)
   set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 endif()
 
+if(USE_SDL1)
+  set(VIRTUAL_GAMEPAD OFF)
+endif()
+
 if(NONET)
   # Fix dependent options if platform defs disable network
   set(DISABLE_TCP ON)

--- a/Source/controls/controller_motion.cpp
+++ b/Source/controls/controller_motion.cpp
@@ -160,7 +160,7 @@ AxisDirection GetLeftStickOrDpadDirection(bool allowDpad)
 	bool isLeftPressed = stickX <= -0.5 || (allowDpad && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_LEFT));
 	bool isRightPressed = stickX >= 0.5 || (allowDpad && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_RIGHT));
 
-#if defined(VIRTUAL_GAMEPAD) && !defined(USE_SDL1)
+#ifdef VIRTUAL_GAMEPAD
 	isUpPressed |= VirtualGamepadState.directionPad.isUpPressed;
 	isDownPressed |= VirtualGamepadState.directionPad.isDownPressed;
 	isLeftPressed |= VirtualGamepadState.directionPad.isLeftPressed;

--- a/Source/controls/controller_motion.cpp
+++ b/Source/controls/controller_motion.cpp
@@ -161,10 +161,10 @@ AxisDirection GetLeftStickOrDpadDirection(bool allowDpad)
 	bool isRightPressed = stickX >= 0.5 || (allowDpad && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_RIGHT));
 
 #ifdef VIRTUAL_GAMEPAD
-	isUpPressed |= VirtualGamepadState.directionPad.isUpPressed;
-	isDownPressed |= VirtualGamepadState.directionPad.isDownPressed;
-	isLeftPressed |= VirtualGamepadState.directionPad.isLeftPressed;
-	isRightPressed |= VirtualGamepadState.directionPad.isRightPressed;
+	isUpPressed |= VirtualGamepadState.isActive && VirtualGamepadState.directionPad.isUpPressed;
+	isDownPressed |= VirtualGamepadState.isActive && VirtualGamepadState.directionPad.isDownPressed;
+	isLeftPressed |= VirtualGamepadState.isActive && VirtualGamepadState.directionPad.isLeftPressed;
+	isRightPressed |= VirtualGamepadState.isActive && VirtualGamepadState.directionPad.isRightPressed;
 #endif
 
 	if (isUpPressed) {

--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -98,7 +98,7 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, Game
 {
 	const bool inGameMenu = InGameMenu();
 
-#if defined(VIRTUAL_GAMEPAD) && !defined(USE_SDL1)
+#ifdef VIRTUAL_GAMEPAD
 	if (event.type == SDL_FINGERDOWN) {
 		if (VirtualGamepadState.menuPanel.charButton.isHeld && VirtualGamepadState.menuPanel.charButton.didStateChange) {
 			*action = GameAction(GameActionType_TOGGLE_CHARACTER_INFO);

--- a/Source/controls/touch/event_handlers.cpp
+++ b/Source/controls/touch/event_handlers.cpp
@@ -119,7 +119,7 @@ void HandleTouchEvent(const SDL_Event &event)
 
 bool VirtualGamepadEventHandler::Handle(const SDL_Event &event)
 {
-	if (!IsAnyOf(event.type, SDL_FINGERDOWN, SDL_FINGERUP, SDL_FINGERMOTION)) {
+	if (!VirtualGamepadState.isActive || !IsAnyOf(event.type, SDL_FINGERDOWN, SDL_FINGERUP, SDL_FINGERMOTION)) {
 		VirtualGamepadState.primaryActionButton.didStateChange = false;
 		VirtualGamepadState.secondaryActionButton.didStateChange = false;
 		VirtualGamepadState.spellActionButton.didStateChange = false;

--- a/Source/controls/touch/event_handlers.h
+++ b/Source/controls/touch/event_handlers.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(VIRTUAL_GAMEPAD) && !defined(USE_SDL1)
+#ifdef VIRTUAL_GAMEPAD
 
 #include <SDL.h>
 

--- a/Source/controls/touch/gamepad.cpp
+++ b/Source/controls/touch/gamepad.cpp
@@ -166,6 +166,43 @@ void InitializeVirtualGamepad()
 	manaButtonArea.position.y = directionPad.area.position.y - (directionPadSize + padButtonSize + padButtonSpacing) / 2;
 	manaButtonArea.radius = padButtonSize / 2;
 	manaButton.isUsable = []() { return !chrflag && !QuestLogIsOpen; };
+
+	VirtualGamepadState.isActive = false;
+}
+
+void ActivateVirtualGamepad()
+{
+	VirtualGamepadState.isActive = true;
+}
+
+void DeactivateVirtualGamepad()
+{
+	VirtualGamepadState.Deactivate();
+}
+
+void VirtualGamepad::Deactivate()
+{
+	isActive = false;
+
+	menuPanel.Deactivate();
+	directionPad.Deactivate();
+	standButton.Deactivate();
+
+	primaryActionButton.Deactivate();
+	secondaryActionButton.Deactivate();
+	spellActionButton.Deactivate();
+	cancelButton.Deactivate();
+
+	healthButton.Deactivate();
+	manaButton.Deactivate();
+}
+
+void VirtualMenuPanel::Deactivate()
+{
+	charButton.Deactivate();
+	questsButton.Deactivate();
+	inventoryButton.Deactivate();
+	mapButton.Deactivate();
 }
 
 void VirtualDirectionPad::UpdatePosition(Point touchCoordinates)
@@ -197,6 +234,21 @@ void VirtualDirectionPad::UpdatePosition(Point touchCoordinates)
 	isDownPressed = PointsDown(angle);
 	isLeftPressed = PointsLeft(angle);
 	isRightPressed = PointsRight(angle);
+}
+
+void VirtualDirectionPad::Deactivate()
+{
+	position = area.position;
+	isUpPressed = false;
+	isDownPressed = false;
+	isLeftPressed = false;
+	isRightPressed = false;
+}
+
+void VirtualButton::Deactivate()
+{
+	isHeld = false;
+	didStateChange = false;
 }
 
 } // namespace devilution

--- a/Source/controls/touch/gamepad.h
+++ b/Source/controls/touch/gamepad.h
@@ -30,6 +30,7 @@ struct VirtualDirectionPad {
 	}
 
 	void UpdatePosition(Point touchCoordinates);
+	void Deactivate();
 };
 
 struct VirtualButton {
@@ -45,6 +46,7 @@ struct VirtualButton {
 	}
 
 	virtual bool Contains(Point point) = 0;
+	void Deactivate();
 };
 
 struct VirtualMenuButton : VirtualButton {
@@ -86,6 +88,8 @@ struct VirtualMenuPanel {
 	    : area({ { 0, 0 }, { 0, 0 } })
 	{
 	}
+
+	void Deactivate();
 };
 
 struct VirtualGamepad {
@@ -101,12 +105,18 @@ struct VirtualGamepad {
 	VirtualPadButton healthButton;
 	VirtualPadButton manaButton;
 
+	bool isActive;
+
 	VirtualGamepad()
 	{
 	}
+
+	void Deactivate();
 };
 
 void InitializeVirtualGamepad();
+void ActivateVirtualGamepad();
+void DeactivateVirtualGamepad();
 
 extern VirtualGamepad VirtualGamepadState;
 

--- a/Source/controls/touch/gamepad.h
+++ b/Source/controls/touch/gamepad.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(VIRTUAL_GAMEPAD) && !defined(USE_SDL1)
+#ifdef VIRTUAL_GAMEPAD
 
 #include <functional>
 

--- a/Source/controls/touch/renderers.h
+++ b/Source/controls/touch/renderers.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(VIRTUAL_GAMEPAD) && !defined(USE_SDL1)
+#ifdef VIRTUAL_GAMEPAD
 
 #include <SDL.h>
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -931,7 +931,7 @@ void DiabloInit()
 		strncpy(sgOptions.Chat.szHotKeyMsgs[i], _(QuickMessages[i].message), MAX_SEND_STR_LEN);
 	}
 
-#if defined(VIRTUAL_GAMEPAD) && !defined(USE_SDL1)
+#ifdef VIRTUAL_GAMEPAD
 	InitializeVirtualGamepad();
 #endif
 
@@ -1064,7 +1064,7 @@ void LoadLvlGFX()
 void LoadAllGFX()
 {
 	IncProgress();
-#if defined(VIRTUAL_GAMEPAD) && !defined(USE_SDL1)
+#ifdef VIRTUAL_GAMEPAD
 	InitVirtualGamepadGFX(renderer);
 #endif
 	IncProgress();
@@ -1520,7 +1520,7 @@ void FreeGameMem()
 	FreeObjectGFX();
 	FreeMonsterSnd();
 	FreeTownerGFX();
-#if defined(VIRTUAL_GAMEPAD) && !defined(USE_SDL1)
+#ifdef VIRTUAL_GAMEPAD
 	FreeVirtualGamepadGFX();
 #endif
 }
@@ -1860,7 +1860,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 			LoadAllGFX();
 		} else {
 			IncProgress();
-#if defined(VIRTUAL_GAMEPAD) && !defined(USE_SDL1)
+#ifdef VIRTUAL_GAMEPAD
 			InitVirtualGamepadGFX(renderer);
 #endif
 			IncProgress();
@@ -1963,7 +1963,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 		IncProgress();
 		InitMonsters();
 		IncProgress();
-#if defined(VIRTUAL_GAMEPAD) && !defined(USE_SDL1)
+#ifdef VIRTUAL_GAMEPAD
 		InitVirtualGamepadGFX(renderer);
 #endif
 		InitMissileGFX(gbIsHellfire);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1521,6 +1521,7 @@ void FreeGameMem()
 	FreeMonsterSnd();
 	FreeTownerGFX();
 #ifdef VIRTUAL_GAMEPAD
+	DeactivateVirtualGamepad();
 	FreeVirtualGamepadGFX();
 #endif
 }
@@ -2041,6 +2042,10 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 			SyncNakrulRoom();
 		}
 	}
+
+#ifdef VIRTUAL_GAMEPAD
+	ActivateVirtualGamepad();
+#endif
 
 	if (currlevel >= 17)
 		music_start(currlevel > 20 ? TMUSIC_L5 : TMUSIC_L6);

--- a/Source/miniwin/misc_msg.cpp
+++ b/Source/miniwin/misc_msg.cpp
@@ -334,7 +334,7 @@ bool FetchMessage_Real(tagMSG *lpMsg)
 	}
 #endif
 
-#if defined(VIRTUAL_GAMEPAD) && !defined(USE_SDL1)
+#ifdef VIRTUAL_GAMEPAD
 	HandleTouchEvent(e);
 #endif
 

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -53,7 +53,7 @@ namespace devilution {
 #define DEFAULT_AUDIO_RESAMPLING_QUALITY 5
 #endif
 
-#if defined(VIRTUAL_GAMEPAD) && !defined(USE_SDL1)
+#ifdef VIRTUAL_GAMEPAD
 #define AUTO_PICKUP_DEFAULT(bValue) true
 #else
 #define AUTO_PICKUP_DEFAULT(bValue) bValue


### PR DESCRIPTION
This PR explicitly activates and deactivates the virtual gamepad in the same functions that load and unload the gamepad art. The `isActive` Boolean value is used to determine whether the game should read virtual gamepad state. This prevents it from interfering in UI menus where you cannot see or interact with the gamepad. Deactivation also resets the state of the d-pad and buttons so they don't retain invalid state upon reactivation.

This resolves #3375