### PR TITLE
Fix missing punctuation in Help screen

### DIFF
--- a/Source/help.cpp
+++ b/Source/help.cpp
@@ -65,7 +65,7 @@ const char *const HelpText[] = {
 	   "number appears in that box. Items may be used by either pressing "
 	   "the corresponding number or right-clicking on the item."),
 	"",
-	N_("$Gold"),
+	N_("$Gold:"),
 	N_("You can select a specific amount of gold to drop by "
 	   "right-clicking on a pile of gold in your inventory."),
 	"",
@@ -81,7 +81,7 @@ const char *const HelpText[] = {
 	   "which allows you to select a skill or spell for immediate use. "
 	   "To use a readied skill or spell, simply right-click in the main play "
 	   "area."),
-	N_("Shift + Left-clicking on the 'select current spell' button will clear the readied spell"),
+	N_("Shift + Left-clicking on the 'select current spell' button will clear the readied spell."),
 	"",
 	N_("$Setting Spell Hotkeys"),
 	N_("You can assign up to four Hotkeys for skills, spells or scrolls. "

--- a/Source/help.cpp
+++ b/Source/help.cpp
@@ -76,20 +76,20 @@ const char *const HelpText[] = {
 	   "the spell you wish to cast will ready the spell. A readied spell "
 	   "may be cast by simply right-clicking in the play area."),
 	"",
-	N_("$Using the Speedbook for Spells"),
+	N_("$Using the Speedbook for Spells:"),
 	N_("Left-clicking on the 'readied spell' button will open the 'Speedbook' "
 	   "which allows you to select a skill or spell for immediate use. "
 	   "To use a readied skill or spell, simply right-click in the main play "
 	   "area."),
 	N_("Shift + Left-clicking on the 'select current spell' button will clear the readied spell."),
 	"",
-	N_("$Setting Spell Hotkeys"),
+	N_("$Setting Spell Hotkeys:"),
 	N_("You can assign up to four Hotkeys for skills, spells or scrolls. "
 	   "Start by opening the 'speedbook' as described in the section above. "
 	   "Press the F5, F6, F7 or F8 keys after highlighting the spell you "
 	   "wish to assign."),
 	"",
-	N_("$Spell Books"),
+	N_("$Spell Books:"),
 	N_("Reading more than one book increases your knowledge of that "
 	   "spell, allowing you to cast the spell more effectively."),
 };

--- a/Translations/devilutionx.pot
+++ b/Translations/devilutionx.pot
@@ -1594,7 +1594,7 @@ msgid "Useable items that are small in size, such as potions or scrolls, are aut
 msgstr ""
 
 #: Source/help.cpp:68
-msgid "$Gold"
+msgid "$Gold:"
 msgstr ""
 
 #: Source/help.cpp:69
@@ -1618,7 +1618,7 @@ msgid "Left-clicking on the 'readied spell' button will open the 'Speedbook' whi
 msgstr ""
 
 #: Source/help.cpp:84
-msgid "Shift + Left-clicking on the 'select current spell' button will clear the readied spell"
+msgid "Shift + Left-clicking on the 'select current spell' button will clear the readied spell."
 msgstr ""
 
 #: Source/help.cpp:86

--- a/Translations/devilutionx.pot
+++ b/Translations/devilutionx.pot
@@ -1610,7 +1610,7 @@ msgid "You can access your list of skills and spells by left-clicking on the 'SP
 msgstr ""
 
 #: Source/help.cpp:79
-msgid "$Using the Speedbook for Spells"
+msgid "$Using the Speedbook for Spells:"
 msgstr ""
 
 #: Source/help.cpp:80
@@ -1622,7 +1622,7 @@ msgid "Shift + Left-clicking on the 'select current spell' button will clear the
 msgstr ""
 
 #: Source/help.cpp:86
-msgid "$Setting Spell Hotkeys"
+msgid "$Setting Spell Hotkeys:"
 msgstr ""
 
 #: Source/help.cpp:87
@@ -1630,7 +1630,7 @@ msgid "You can assign up to four Hotkeys for skills, spells or scrolls. Start by
 msgstr ""
 
 #: Source/help.cpp:92
-msgid "$Spell Books"
+msgid "$Spell Books:"
 msgstr ""
 
 #: Source/help.cpp:93


### PR DESCRIPTION
Gold section name didn't end with a colon
https://github.com/diasurgical/devilutionX/blob/08e4e8c25400f09a7d7194a0cfb86e48550585ae/Source/help.cpp#L68

Speedbook sentence didn't end with a period
https://github.com/diasurgical/devilutionX/blob/08e4e8c25400f09a7d7194a0cfb86e48550585ae/Source/help.cpp#L84

Edit: `Using the Speedbook for Spells`, `Setting Spell Hotkeys` and `Spell Books` sections didn't end with colons either