### PR TITLE
Restrict dropping items to adjacent tiles

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1130,14 +1130,28 @@ bool PutItem(Player &player, Point &position)
 	if (CanPut(position))
 		return true;
 
-	std::optional<Point> itemPosition = FindClosestValidPosition(CanPut, player.position.tile, 1, 50);
-
-	if (itemPosition) {
-		position = *itemPosition;
+	position = player.position.tile + Left(Left(d));
+	if (CanPut(position))
 		return true;
-	}
 
-	return false;
+	position = player.position.tile + Right(Right(d));
+	if (CanPut(position))
+		return true;
+
+	position = player.position.tile + Left(Left(Left(d)));
+	if (CanPut(position))
+		return true;
+
+	position = player.position.tile + Right(Right(Right(d)));
+	if (CanPut(position))
+		return true;
+
+	position = player.position.tile + Opposite(d);
+	if (CanPut(position))
+		return true;
+
+	position = player.position.tile;
+	return CanPut(position);
 }
 
 bool CanUseStaff(Item &staff, spell_id spell)


### PR DESCRIPTION
This more closely matches vanilla behaviour until more intelligent dropping item behaviour is implemented (see #3489)

https://user-images.githubusercontent.com/357684/142081709-e36114d7-c309-48fe-8c64-868c615b215c.mp4


