### PR TITLE
debug.cpp Fix `-Wswitch`

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -840,8 +840,9 @@ bool IsDebugGridInMegatiles()
 	case DebugGridTextItem::pdungeon:
 	case DebugGridTextItem::dflags:
 		return true;
+	default:
+		return false;
 	}
-	return false;
 }
 
 bool GetDebugGridText(Point dungeonCoords, char *debugGridTextBuffer)


### PR DESCRIPTION
```
../Source/debug.cpp: In function ‘bool devilution::IsDebugGridInMegatiles()’:
../Source/debug.cpp:837:16: warning: enumeration value ‘None’ not handled in switch [-Wswitch]
  837 |         switch (SelectedDebugGridTextItem) {
      |                ^
../Source/debug.cpp:837:16: warning: enumeration value ‘dPiece’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘dTransVal’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘dLight’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘dPreLight’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘dFlags’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘dPlayer’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘dMonster’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘dCorpse’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘dObject’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘dItem’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘dSpecial’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘coords’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘cursorcoords’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘objectindex’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘nBlockTable’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘nSolidTable’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘nTransTable’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘nMissileTable’ not handled in switch [-Wswitch]
../Source/debug.cpp:837:16: warning: enumeration value ‘nTrapTable’ not handled in switch [-Wswitch]
```