### PR TITLE
Increase stack size on 3DS

### DIFF
--- a/Source/platform/ctr/system.cpp
+++ b/Source/platform/ctr/system.cpp
@@ -9,6 +9,13 @@
 
 using namespace devilution;
 
+// Increase stack size for recursion in FindTransparencyValues()
+// 128 KB supports around 500 levels of recursion
+// Default stack size on 3DS is only 32 KB
+extern "C" {
+u32 __stacksize__ = 128 * 1024;
+}
+
 bool shouldDisableBacklight;
 
 aptHookCookie cookie;


### PR DESCRIPTION
[single_0.hsv.zip](https://github.com/diasurgical/devilutionX/files/7568499/single_0.hsv.zip) causes the game to crash on 3DS when entering dungeon level 13, due to the amount of recursion in `FindTransparencyValues()`.

If you're not familiar with the function, it seems to be using a flood fill algorithm to mark contiguous regions of floor, as well as the adjacent and surrounding non-floor spaces, with the same "transparency value". Based on the name of it, I would guess this is used to determine which walls should be rendered transparent when the player enters a room. However, it also seems to be used in a few other places, such as when determining whether a monster is in the same room as another entity.

My testing reveals that the function reached about 470 levels of recursion. If my estimate is right, 128 KB should barely cover this. I guess the big question is whether this savegame represents an extreme or whether we should expect to encounter even deeper recursion in another dungeon layout.

Here are some thoughts I had while messing with this.
* Add some additional stack space to be safe, but I'm not sure how much.
* Rewrite the function to use heap space instead.
* Select a different algorithm with lower memory overhead.
  * https://en.wikipedia.org/wiki/Flood_fill