### PR TITLE
Correct polish translation for thorns

### DIFF
--- a/Translations/pl.po
+++ b/Translations/pl.po
@@ -4007,7 +4007,7 @@ msgstr "obr. ognistej kuli {:d}-{:d}"
 
 #: Source/items.cpp:3962
 msgid "attacker takes 1-3 damage"
-msgstr "1-3 obrażeń wraca do ciebie"
+msgstr "atakujący otrzymuje 1-3 obrażeń"
 
 #: Source/items.cpp:3965
 msgid "user loses all mana"


### PR DESCRIPTION
Previous pl string literally translated to english would say:
"1-3 damage returns to you"

Considering that it is thorns affix, I am guessing
the attacker means the enemy of the player, NOT the player him/herself.

The corrected pl string is equal to english one
and it is almost the same as thorns affix
translation from diablo 2.