### PR TITLE
Clean up item name generation

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -234,13 +234,6 @@ void SelheroCatToName(const char *inBuf, char *outBuf, int cnt)
 	strncat(outBuf, inBuf, cnt - strlen(outBuf));
 }
 
-#ifdef __vita__
-void selhero_SetName(const char *in_buf, char *out_buf, int cnt)
-{
-	strncpy(out_buf, in_buf, cnt);
-}
-#endif
-
 bool HandleMenuAction(MenuAction menuAction)
 {
 	switch (menuAction) {
@@ -365,7 +358,7 @@ void UiFocusNavigation(SDL_Event *event)
 		case SDL_TEXTINPUT:
 			if (textInputActive) {
 #ifdef __vita__
-				selhero_SetName(event->text.text, UiTextInput, UiTextInputLen);
+				CopyUtf8(UiTextInput, event->text.text, UiTextInputLen);
 #else
 				SelheroCatToName(event->text.text, UiTextInput, UiTextInputLen);
 #endif
@@ -584,7 +577,7 @@ bool UiValidPlayerName(const char *name)
 	};
 
 	char tmpname[PLR_NAME_LEN];
-	strncpy(tmpname, name, PLR_NAME_LEN - 1);
+	CopyUtf8(tmpname, name, sizeof(tmpname));
 	for (size_t i = 0, n = strlen(tmpname); i < n; i++)
 		tmpname[i]++;
 

--- a/Source/DiabloUI/selconn.cpp
+++ b/Source/DiabloUI/selconn.cpp
@@ -4,6 +4,7 @@
 #include "stores.h"
 #include "storm/storm_net.hpp"
 #include "utils/language.h"
+#include "utils/utf8.hpp"
 
 namespace devilution {
 
@@ -104,22 +105,22 @@ void SelconnFocus(int value)
 	int players = MAX_PLRS;
 	switch (vecConnItems[value]->m_value) {
 	case SELCONN_TCP:
-		strncpy(selconn_Description, _("All computers must be connected to a TCP-compatible network."), sizeof(selconn_Description) - 1);
+		CopyUtf8(selconn_Description, _("All computers must be connected to a TCP-compatible network."), sizeof(selconn_Description));
 		players = MAX_PLRS;
 		break;
 	case SELCONN_ZT:
-		strncpy(selconn_Description, _("All computers must be connected to the internet."), sizeof(selconn_Description) - 1);
+		CopyUtf8(selconn_Description, _("All computers must be connected to the internet."), sizeof(selconn_Description));
 		players = MAX_PLRS;
 		break;
 	case SELCONN_LOOPBACK:
-		strncpy(selconn_Description, _("Play by yourself with no network exposure."), sizeof(selconn_Description) - 1);
+		CopyUtf8(selconn_Description, _("Play by yourself with no network exposure."), sizeof(selconn_Description));
 		players = 1;
 		break;
 	}
 
-	strncpy(selconn_MaxPlayers, fmt::format(_("Players Supported: {:d}"), players).c_str(), sizeof(selconn_MaxPlayers));
+	CopyUtf8(selconn_MaxPlayers, fmt::format(_("Players Supported: {:d}"), players), sizeof(selconn_MaxPlayers));
 	const std::string wrapped = WordWrapString(selconn_Description, DESCRIPTION_WIDTH);
-	strncpy(selconn_Description, wrapped.data(), sizeof(selconn_Description) - 1);
+	CopyUtf8(selconn_Description, wrapped, sizeof(selconn_Description));
 }
 
 void SelconnSelect(int value)

--- a/Source/DiabloUI/selgame.cpp
+++ b/Source/DiabloUI/selgame.cpp
@@ -12,6 +12,7 @@
 #include "options.h"
 #include "storm/storm_net.hpp"
 #include "utils/language.h"
+#include "utils/utf8.hpp"
 
 namespace devilution {
 
@@ -119,20 +120,20 @@ void selgame_GameSelection_Focus(int value)
 	HighlightedItem = value;
 	switch (vecSelGameDlgItems[value]->m_value) {
 	case 0:
-		strncpy(selgame_Description, _("Create a new game with a difficulty setting of your choice."), sizeof(selgame_Description) - 1);
+		CopyUtf8(selgame_Description, _("Create a new game with a difficulty setting of your choice."), sizeof(selgame_Description));
 		break;
 	case 1:
-		strncpy(selgame_Description, _("Create a new public game that anyone can join with a difficulty setting of your choice."), sizeof(selgame_Description) - 1);
+		CopyUtf8(selgame_Description, _("Create a new public game that anyone can join with a difficulty setting of your choice."), sizeof(selgame_Description));
 		break;
 	case 2:
-		strncpy(selgame_Description, _("Enter an IP or a hostname and join a game already in progress at that address."), sizeof(selgame_Description) - 1);
+		CopyUtf8(selgame_Description, _("Enter an IP or a hostname and join a game already in progress at that address."), sizeof(selgame_Description));
 		break;
 	default:
-		strncpy(selgame_Description, _("Join the public game already in progress at this address."), sizeof(selgame_Description) - 1);
+		CopyUtf8(selgame_Description, _("Join the public game already in progress at this address."), sizeof(selgame_Description));
 		break;
 	}
 	const std::string wrapped = WordWrapString(selgame_Description, DESCRIPTION_WIDTH);
-	strncpy(selgame_Description, wrapped.data(), sizeof(selgame_Description) - 1);
+	CopyUtf8(selgame_Description, wrapped.data(), sizeof(selgame_Description));
 }
 
 /**
@@ -236,20 +237,20 @@ void selgame_Diff_Focus(int value)
 {
 	switch (vecSelGameDlgItems[value]->m_value) {
 	case DIFF_NORMAL:
-		strncpy(selgame_Label, _("Normal"), sizeof(selgame_Label) - 1);
-		strncpy(selgame_Description, _("Normal Difficulty\nThis is where a starting character should begin the quest to defeat Diablo."), sizeof(selgame_Description) - 1);
+		CopyUtf8(selgame_Label, _("Normal"), sizeof(selgame_Label));
+		CopyUtf8(selgame_Description, _("Normal Difficulty\nThis is where a starting character should begin the quest to defeat Diablo."), sizeof(selgame_Description));
 		break;
 	case DIFF_NIGHTMARE:
-		strncpy(selgame_Label, _("Nightmare"), sizeof(selgame_Label) - 1);
-		strncpy(selgame_Description, _("Nightmare Difficulty\nThe denizens of the Labyrinth have been bolstered and will prove to be a greater challenge. This is recommended for experienced characters only."), sizeof(selgame_Description) - 1);
+		CopyUtf8(selgame_Label, _("Nightmare"), sizeof(selgame_Label));
+		CopyUtf8(selgame_Description, _("Nightmare Difficulty\nThe denizens of the Labyrinth have been bolstered and will prove to be a greater challenge. This is recommended for experienced characters only."), sizeof(selgame_Description));
 		break;
 	case DIFF_HELL:
-		strncpy(selgame_Label, _("Hell"), sizeof(selgame_Label) - 1);
-		strncpy(selgame_Description, _("Hell Difficulty\nThe most powerful of the underworld's creatures lurk at the gateway into Hell. Only the most experienced characters should venture in this realm."), sizeof(selgame_Description) - 1);
+		CopyUtf8(selgame_Label, _("Hell"), sizeof(selgame_Label));
+		CopyUtf8(selgame_Description, _("Hell Difficulty\nThe most powerful of the underworld's creatures lurk at the gateway into Hell. Only the most experienced characters should venture in this realm."), sizeof(selgame_Description));
 		break;
 	}
 	const std::string wrapped = WordWrapString(selgame_Description, DESCRIPTION_WIDTH);
-	strncpy(selgame_Description, wrapped.data(), sizeof(selgame_Description) - 1);
+	CopyUtf8(selgame_Description, wrapped, sizeof(selgame_Description));
 }
 
 bool IsDifficultyAllowed(int value)
@@ -361,24 +362,24 @@ void selgame_Speed_Focus(int value)
 {
 	switch (vecSelGameDlgItems[value]->m_value) {
 	case 20:
-		strncpy(selgame_Label, _("Normal"), sizeof(selgame_Label) - 1);
-		strncpy(selgame_Description, _("Normal Speed\nThis is where a starting character should begin the quest to defeat Diablo."), sizeof(selgame_Description) - 1);
+		CopyUtf8(selgame_Label, _("Normal"), sizeof(selgame_Label));
+		CopyUtf8(selgame_Description, _("Normal Speed\nThis is where a starting character should begin the quest to defeat Diablo."), sizeof(selgame_Description));
 		break;
 	case 30:
-		strncpy(selgame_Label, _("Fast"), sizeof(selgame_Label) - 1);
-		strncpy(selgame_Description, _("Fast Speed\nThe denizens of the Labyrinth have been hastened and will prove to be a greater challenge. This is recommended for experienced characters only."), sizeof(selgame_Description) - 1);
+		CopyUtf8(selgame_Label, _("Fast"), sizeof(selgame_Label));
+		CopyUtf8(selgame_Description, _("Fast Speed\nThe denizens of the Labyrinth have been hastened and will prove to be a greater challenge. This is recommended for experienced characters only."), sizeof(selgame_Description));
 		break;
 	case 40:
-		strncpy(selgame_Label, _("Faster"), sizeof(selgame_Label) - 1);
-		strncpy(selgame_Description, _("Faster Speed\nMost monsters of the dungeon will seek you out quicker than ever before. Only an experienced champion should try their luck at this speed."), sizeof(selgame_Description) - 1);
+		CopyUtf8(selgame_Label, _("Faster"), sizeof(selgame_Label));
+		CopyUtf8(selgame_Description, _("Faster Speed\nMost monsters of the dungeon will seek you out quicker than ever before. Only an experienced champion should try their luck at this speed."), sizeof(selgame_Description));
 		break;
 	case 50:
-		strncpy(selgame_Label, _("Fastest"), sizeof(selgame_Label) - 1);
-		strncpy(selgame_Description, _("Fastest Speed\nThe minions of the underworld will rush to attack without hesitation. Only a true speed demon should enter at this pace."), sizeof(selgame_Description) - 1);
+		CopyUtf8(selgame_Label, _("Fastest"), sizeof(selgame_Label));
+		CopyUtf8(selgame_Description, _("Fastest Speed\nThe minions of the underworld will rush to attack without hesitation. Only a true speed demon should enter at this pace."), sizeof(selgame_Description));
 		break;
 	}
 	const std::string wrapped = WordWrapString(selgame_Description, DESCRIPTION_WIDTH);
-	strncpy(selgame_Description, wrapped.data(), sizeof(selgame_Description) - 1);
+	CopyUtf8(selgame_Description, wrapped, sizeof(selgame_Description));
 }
 
 void selgame_Speed_Esc()

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -16,6 +16,7 @@
 #include "options.h"
 #include "pfile.h"
 #include "utils/language.h"
+#include "utils/utf8.hpp"
 #include <menu.h>
 
 namespace devilution {
@@ -138,12 +139,12 @@ void SelheroListFocus(int value)
 	}
 
 	SELHERO_DIALOG_HERO_IMG->m_frame = static_cast<int>(enum_size<HeroClass>::value);
-	strncpy(textStats[0], "--", sizeof(textStats[0]) - 1);
-	strncpy(textStats[1], "--", sizeof(textStats[1]) - 1);
-	strncpy(textStats[2], "--", sizeof(textStats[2]) - 1);
-	strncpy(textStats[3], "--", sizeof(textStats[3]) - 1);
-	strncpy(textStats[4], "--", sizeof(textStats[4]) - 1);
-	strncpy(textStats[5], "--", sizeof(textStats[5]) - 1);
+	CopyUtf8(textStats[0], "--", sizeof(textStats[0]));
+	CopyUtf8(textStats[1], "--", sizeof(textStats[1]));
+	CopyUtf8(textStats[2], "--", sizeof(textStats[2]));
+	CopyUtf8(textStats[3], "--", sizeof(textStats[3]));
+	CopyUtf8(textStats[4], "--", sizeof(textStats[4]));
+	CopyUtf8(textStats[5], "--", sizeof(textStats[5]));
 	SELLIST_DIALOG_DELETE_BUTTON->m_iFlags = baseFlags | UiFlags::ColorUiSilver | UiFlags::ElementDisabled;
 	selhero_deleteEnabled = false;
 }
@@ -269,7 +270,7 @@ void SelheroClassSelectorSelect(int value)
 	title = selhero_isMultiPlayer ? _("New Multi Player Hero") : _("New Single Player Hero");
 	memset(selhero_heroInfo.name, '\0', sizeof(selhero_heroInfo.name));
 	if (ShouldPrefillHeroName())
-		strncpy(selhero_heroInfo.name, SelheroGenerateName(selhero_heroInfo.heroclass), sizeof(selhero_heroInfo.name) - 1);
+		CopyUtf8(selhero_heroInfo.name, SelheroGenerateName(selhero_heroInfo.heroclass), sizeof(selhero_heroInfo.name));
 	vecSelDlgItems.clear();
 	SDL_Rect rect1 = { (Sint16)(PANEL_LEFT + 264), (Sint16)(UI_OFFSET_Y + 211), 320, 33 };
 	vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Enter Name"), rect1, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
@@ -596,11 +597,11 @@ static void UiSelHeroDialog(
 			char dialogTitle[128];
 			char dialogText[256];
 			if (selhero_isMultiPlayer) {
-				strncpy(dialogTitle, _("Delete Multi Player Hero"), sizeof(dialogTitle) - 1);
+				CopyUtf8(dialogTitle, _("Delete Multi Player Hero"), sizeof(dialogTitle));
 			} else {
-				strncpy(dialogTitle, _("Delete Single Player Hero"), sizeof(dialogTitle) - 1);
+				CopyUtf8(dialogTitle, _("Delete Single Player Hero"), sizeof(dialogTitle));
 			}
-			strncpy(dialogText, fmt::format(_("Are you sure you want to delete the character \"{:s}\"?"), selhero_heroInfo.name).c_str(), sizeof(dialogText));
+			CopyUtf8(dialogText, fmt::format(_("Are you sure you want to delete the character \"{:s}\"?"), selhero_heroInfo.name), sizeof(dialogText));
 
 			if (UiSelHeroYesNoDialog(dialogTitle, dialogText))
 				fnremove(&selhero_heroInfo);

--- a/Source/DiabloUI/selok.cpp
+++ b/Source/DiabloUI/selok.cpp
@@ -3,6 +3,7 @@
 #include "DiabloUI/diabloui.h"
 #include "control.h"
 #include "utils/language.h"
+#include "utils/utf8.hpp"
 #include "engine/render/text_render.hpp"
 
 namespace devilution {
@@ -69,7 +70,7 @@ void UiSelOkDialog(const char *title, const char *body, bool background)
 	vecSelOkDialog.push_back(std::make_unique<UiList>(vecSelOkDialogItems, PANEL_LEFT + 230, (UI_OFFSET_Y + 390), 180, 35, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
 	const std::string wrapped = WordWrapString(body, MESSAGE_WIDTH, GameFont24);
-	strncpy(dialogText, wrapped.data(), sizeof(dialogText) - 1);
+	CopyUtf8(dialogText, wrapped, sizeof(dialogText));
 
 	UiInitList(0, nullptr, selok_Select, selok_Esc, vecSelOkDialog, false, nullptr);
 

--- a/Source/DiabloUI/selyesno.cpp
+++ b/Source/DiabloUI/selyesno.cpp
@@ -3,6 +3,7 @@
 #include "DiabloUI/diabloui.h"
 #include "control.h"
 #include "utils/language.h"
+#include "utils/utf8.hpp"
 
 namespace devilution {
 namespace {
@@ -56,7 +57,7 @@ bool UiSelHeroYesNoDialog(const char *title, const char *body)
 	vecSelYesNoDialog.push_back(std::make_unique<UiList>(vecSelYesNoDialogItems, PANEL_LEFT + 230, (UI_OFFSET_Y + 390), 180, 35, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
 	const std::string wrapped = WordWrapString(body, MESSAGE_WIDTH, GameFont24);
-	strncpy(selyesno_confirmationMessage, wrapped.data(), sizeof(selyesno_confirmationMessage) - 1);
+	CopyUtf8(selyesno_confirmationMessage, wrapped, sizeof(selyesno_confirmationMessage));
 
 	UiInitList(vecSelYesNoDialogItems.size(), nullptr, SelyesnoSelect, SelyesnoEsc, vecSelYesNoDialog, true, nullptr);
 

--- a/Source/appfat.cpp
+++ b/Source/appfat.cpp
@@ -14,6 +14,7 @@
 #include "utils/language.h"
 #include "utils/sdl_thread.h"
 #include "utils/ui_fwd.h"
+#include "utils/utf8.hpp"
 
 namespace devilution {
 
@@ -99,7 +100,7 @@ void ErrDlg(const char *title, const char *error, const char *logFilePath, int l
 
 	FreeDlg();
 
-	strncpy(text, fmt::format(_(/* TRANSLATORS: Error message that displays relevant information for bug report */ "{:s}\n\nThe error occurred at: {:s} line {:d}"), error, logFilePath, logLineNr).c_str(), sizeof(text));
+	CopyUtf8(text, fmt::format(_(/* TRANSLATORS: Error message that displays relevant information for bug report */ "{:s}\n\nThe error occurred at: {:s} line {:d}"), error, logFilePath, logLineNr), sizeof(text));
 
 	UiErrorOkDialog(title, text);
 	app_fatal(nullptr);
@@ -128,7 +129,7 @@ void DirErrorDlg(const char *error)
 {
 	char text[1024];
 
-	strncpy(text, fmt::format(_(/* TRANSLATORS: Error when Program is not allowed to write data */ "Unable to write to location:\n{:s}"), error).c_str(), sizeof(text));
+	CopyUtf8(text, fmt::format(_(/* TRANSLATORS: Error when Program is not allowed to write data */ "Unable to write to location:\n{:s}"), error), sizeof(text));
 
 	UiErrorOkDialog(_("Read-Only Directory Error"), text);
 	app_fatal(nullptr);

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -895,8 +895,7 @@ void ToggleSpell(int slot)
 
 void AddPanelString(string_view str)
 {
-	strncpy(panelstr[pnumlines], str.data(), str.size());
-	panelstr[pnumlines][str.size()] = '\0';
+	CopyUtf8(panelstr[pnumlines], str, sizeof(*panelstr));
 
 	if (pnumlines < 4)
 		pnumlines++;
@@ -1413,9 +1412,7 @@ void DrawInfoBox(const Surface &out)
 					PrintMonstHistory(monster.MType->mtype);
 				}
 			} else if (pcursitem == -1) {
-				string_view townerName = Towners[pcursmonst].name;
-				strncpy(infostr, townerName.data(), townerName.length());
-				infostr[townerName.length()] = '\0';
+				CopyUtf8(infostr, Towners[pcursmonst].name, sizeof(infostr));
 			}
 		}
 		if (pcursplr != -1) {
@@ -1655,21 +1652,14 @@ void DrawGoldSplit(const Surface &out, int amount)
 
 	constexpr auto BufferSize = sizeof(tempstr) / sizeof(*tempstr);
 
-	// strncpy copies up to the maximum number of characters specified, it does not ensure that a null character is
-	// written to the end of the c-string. To be safe we specify a limit one character shorter than the buffer size and
-	// ensure that the buffer ends in a null character manually.
-	strncpy(
+	CopyUtf8(
 	    tempstr,
 	    fmt::format(ngettext(
 	                    /* TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.*/ "You have {:d} gold piece. How many do you want to remove?",
 	                    "You have {:d} gold pieces. How many do you want to remove?",
 	                    initialDropGoldValue),
-	        initialDropGoldValue)
-	        .c_str(),
-	    BufferSize - 1);
-	// Ensure the prompt shown to the player is terminated properly (in case the formatted/translated string ends up
-	// being longer than 255 characters)
-	tempstr[BufferSize - 1] = '\0';
+	        initialDropGoldValue),
+	    BufferSize);
 
 	// Pre-wrap the string at spaces, otherwise DrawString would hard wrap in the middle of words
 	const std::string wrapped = WordWrapString(tempstr, 200);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -67,6 +67,7 @@
 #include "utils/console.h"
 #include "utils/language.h"
 #include "utils/paths.h"
+#include "utils/utf8.hpp"
 
 #ifdef __vita__
 #include "platform/vita/touch.h"
@@ -897,7 +898,7 @@ void DiabloInitScreen()
 void SetApplicationVersions()
 {
 	snprintf(gszProductName, sizeof(gszProductName) / sizeof(char), "%s v%s", PROJECT_NAME, PROJECT_VERSION);
-	strncpy(gszVersionNumber, fmt::format(_("version {:s}"), PROJECT_VERSION).c_str(), sizeof(gszVersionNumber) / sizeof(char));
+	CopyUtf8(gszVersionNumber, fmt::format(_("version {:s}"), PROJECT_VERSION), sizeof(gszVersionNumber) / sizeof(char));
 }
 
 void DiabloInit()
@@ -928,7 +929,7 @@ void DiabloInit()
 		if (strlen(sgOptions.Chat.szHotKeyMsgs[i]) != 0) {
 			continue;
 		}
-		strncpy(sgOptions.Chat.szHotKeyMsgs[i], _(QuickMessages[i].message), MAX_SEND_STR_LEN);
+		CopyUtf8(sgOptions.Chat.szHotKeyMsgs[i], _(QuickMessages[i].message), MAX_SEND_STR_LEN);
 	}
 
 #ifdef VIRTUAL_GAMEPAD
@@ -1447,11 +1448,10 @@ void InitKeymapActions()
 			    _("Nightmare"),
 			    _("Hell"),
 		    };
-		    strncpy(pszStr, fmt::format(_(/* TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty. */
-		                                    "{:s}, version = {:s}, mode = {:s}"),
-		                        PROJECT_NAME, PROJECT_VERSION, difficulties[sgGameInitInfo.nDifficulty])
-		                        .c_str(),
-		        MAX_SEND_STR_LEN - 1);
+		    CopyUtf8(pszStr, fmt::format(_(/* TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty. */
+		                                     "{:s}, version = {:s}, mode = {:s}"),
+		                         PROJECT_NAME, PROJECT_VERSION, difficulties[sgGameInitInfo.nDifficulty]),
+		        sizeof(pszStr));
 		    NetSendCmdString(1 << MyPlayerId, pszStr);
 	    },
 	    [&]() { return !IsPlayerDead(); },

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -22,6 +22,7 @@
 #include "utils/log.hpp"
 #include "utils/paths.h"
 #include "utils/ui_fwd.h"
+#include "utils/utf8.hpp"
 
 #ifdef __vita__
 // increase default allowed heap size on Vita
@@ -152,7 +153,7 @@ void init_archives()
 
 	if (strcasecmp("en", sgOptions.Language.szCode) != 0 || strlen(sgOptions.Language.szCode) != 2) {
 		char langMpqName[10] = {};
-		strncpy(langMpqName, sgOptions.Language.szCode, sizeof(langMpqName) - strlen(langMpqName) - 1);
+		CopyUtf8(langMpqName, sgOptions.Language.szCode, sizeof(langMpqName));
 
 		strncat(langMpqName, ".mpq", sizeof(langMpqName) - strlen(langMpqName) - 1);
 		lang_mpq = LoadMPQ(paths, langMpqName);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1171,26 +1171,60 @@ void GetStaffPower(Item &item, int lvl, int bs, bool onlygood)
 		}
 		if (nl != 0) {
 			preidx = l[GenerateRnd(nl)];
-			strncpy(item._iIName, fmt::format(/* TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword */ _("{0} {1}"), _(ItemPrefixes[preidx].PLName), item._iIName).c_str(), sizeof(item._iIName) - 1);
-			item._iIName[sizeof(item._iIName) - 1] = '\0';
 			item._iMagical = ITEM_QUALITY_MAGIC;
 			SaveItemAffix(item, ItemPrefixes[preidx]);
 			item._iPrePower = ItemPrefixes[preidx].power.type;
 		}
 	}
-	if (!StringInPanel(item._iIName)) {
-		strcpy(item._iIName, _(AllItemsList[item.IDidx].iSName));
-		if (preidx != -1) {
-			strncpy(item._iIName, fmt::format(/* TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword */ _("{0} {1}"), _(ItemPrefixes[preidx].PLName), item._iIName).c_str(), sizeof(item._iIName) - 1);
+
+	const char *baseName = _(AllItemsList[item.IDidx].iName);
+	const char *shortName = _(AllItemsList[item.IDidx].iSName);
+	const char *spellName = pgettext("spell", spelldata[bs].sNameText);
+	const char *normalFmt = pgettext("spell", /* TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall */ "{0} of {1}");
+
+	strncpy(item._iName, fmt::format(normalFmt, baseName, spellName).c_str(), sizeof(item._iName) - 1);
+	item._iName[sizeof(item._iName) - 1] = '\0';
+	if (!StringInPanel(item._iName)) {
+		strncpy(item._iName, fmt::format(normalFmt, shortName, spellName).c_str(), sizeof(item._iName) - 1);
+		item._iName[sizeof(item._iName) - 1] = '\0';
+	}
+
+	if (preidx != -1) {
+		const char *magicFmt = pgettext("spell", /* TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall */ "{0} {1} of {2}");
+		const char *prefixName = _(ItemPrefixes[preidx].PLName);
+		strncpy(item._iIName, fmt::format(magicFmt, prefixName, baseName, spellName).c_str(), sizeof(item._iIName) - 1);
+		item._iIName[sizeof(item._iIName) - 1] = '\0';
+		if (!StringInPanel(item._iIName)) {
+			strncpy(item._iIName, fmt::format(magicFmt, prefixName, shortName, spellName).c_str(), sizeof(item._iIName) - 1);
 			item._iIName[sizeof(item._iIName) - 1] = '\0';
 		}
-		strncpy(item._iIName, fmt::format(_(/* TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's Staff of Firewall */ "{0} of {1}"), item._iIName, pgettext("spell", spelldata[bs].sNameText)).c_str(), sizeof(item._iIName) - 1);
-		item._iIName[sizeof(item._iIName) - 1] = '\0';
-		if (item._iMagical == ITEM_QUALITY_NORMAL)
-			strcpy(item._iName, item._iIName);
+	} else {
+		strncpy(item._iIName, item._iName, sizeof(item._iIName) - 1);
+		item._iName[sizeof(item._iName) - 1] = '\0';
 	}
+
 	CalcItemValue(item);
 }
+
+namespace {
+
+std::string GenerateMagicItemName(const string_view &baseNamel, int preidx, int sufidx)
+{
+	if (preidx != -1 && sufidx != -1) {
+		const char *fmt = _(/* TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale */ "{0} {1} of {2}");
+		return fmt::format(fmt, _(ItemPrefixes[preidx].PLName), baseNamel, _(ItemSuffixes[sufidx].PLName));
+	} else if (preidx != -1) {
+		const char *fmt = _(/* TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword */ "{0} {1}");
+		return fmt::format(fmt, _(ItemPrefixes[preidx].PLName), baseNamel);
+	} else if (sufidx != -1) {
+		const char *fmt = _(/* TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale */ "{0} of {1}");
+		return fmt::format(fmt, baseNamel, _(ItemSuffixes[sufidx].PLName));
+	}
+
+	return std::string(baseNamel);
+}
+
+} // namespace
 
 void GetItemPower(Item &item, int minlvl, int maxlvl, affix_item_type flgs, bool onlygood)
 {
@@ -1230,8 +1264,6 @@ void GetItemPower(Item &item, int minlvl, int maxlvl, affix_item_type flgs, bool
 		}
 		if (nt != 0) {
 			preidx = l[GenerateRnd(nt)];
-			strncpy(item._iIName, fmt::format(/* TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword */ _("{0} {1}"), _(ItemPrefixes[preidx].PLName), item._iIName).c_str(), sizeof(item._iIName) - 1);
-			item._iIName[sizeof(item._iIName) - 1] = '\0';
 			item._iMagical = ITEM_QUALITY_MAGIC;
 			SaveItemAffix(item, ItemPrefixes[preidx]);
 			item._iPrePower = ItemPrefixes[preidx].power.type;
@@ -1251,28 +1283,17 @@ void GetItemPower(Item &item, int minlvl, int maxlvl, affix_item_type flgs, bool
 		}
 		if (nl != 0) {
 			sufidx = l[GenerateRnd(nl)];
-			strncpy(item._iIName, fmt::format(_(/* TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Long Sword of the Whale */ "{0} of {1}"), item._iIName, _(ItemSuffixes[sufidx].PLName)).c_str(), sizeof(item._iIName) - 1);
-			item._iIName[sizeof(item._iIName) - 1] = '\0';
 			item._iMagical = ITEM_QUALITY_MAGIC;
 			SaveItemAffix(item, ItemSuffixes[sufidx]);
 			item._iSufPower = ItemSuffixes[sufidx].power.type;
 		}
 	}
-	if (!StringInPanel(item._iIName)) {
-		int aii = item.IDidx;
-		if (AllItemsList[aii].iSName != nullptr)
-			strcpy(item._iIName, _(AllItemsList[aii].iSName));
-		else
-			item._iName[0] = 0;
 
-		if (preidx != -1) {
-			strncpy(item._iIName, fmt::format(/* TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword */ _("{0} {1}"), _(ItemPrefixes[preidx].PLName), item._iIName).c_str(), sizeof(item._iIName) - 1);
-			item._iIName[sizeof(item._iIName) - 1] = '\0';
-		}
-		if (sufidx != -1) {
-			strncpy(item._iIName, fmt::format(_(/* TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Sword of the Whale */ "{0} of {1}"), item._iIName, _(ItemSuffixes[sufidx].PLName)).c_str(), sizeof(item._iIName) - 1);
-			item._iIName[sizeof(item._iIName) - 1] = '\0';
-		}
+	strncpy(item._iIName, GenerateMagicItemName(item._iName, preidx, sufidx).c_str(), sizeof(item._iIName) - 1);
+	item._iIName[sizeof(item._iIName) - 1] = '\0';
+	if (!StringInPanel(item._iIName)) {
+		strncpy(item._iIName, GenerateMagicItemName(_(AllItemsList[item.IDidx].iSName), preidx, sufidx).c_str(), sizeof(item._iIName) - 1);
+		item._iIName[sizeof(item._iIName) - 1] = '\0';
 	}
 	if (preidx != -1 || sufidx != -1)
 		CalcItemValue(item);
@@ -1310,13 +1331,6 @@ void GetStaffSpell(Item &item, int lvl, bool onlygood)
 		if (s == maxSpells)
 			s = SPL_FIREBOLT;
 	}
-
-	char istr[68] = {};
-	strncpy(istr, fmt::format(_(/* TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's War Staff of Firewall */ "{0} of {1}"), item._iName, pgettext("spell", spelldata[bs].sNameText)).c_str(), sizeof(istr) - 1);
-	if (!StringInPanel(istr))
-		strncpy(istr, fmt::format(_("Staff of {:s}"), pgettext("spell", spelldata[bs].sNameText)).c_str(), sizeof(istr) - 1);
-	strncpy(item._iName, istr, sizeof(item._iName) - 1);
-	strncpy(item._iIName, istr, sizeof(item._iIName) - 1);
 
 	int minc = spelldata[bs].sStaffMin;
 	int maxc = spelldata[bs].sStaffMax - minc + 1;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -34,6 +34,7 @@
 #include "utils/language.h"
 #include "utils/math.h"
 #include "utils/stdcompat/algorithm.hpp"
+#include "utils/utf8.hpp"
 
 namespace devilution {
 
@@ -1182,25 +1183,20 @@ void GetStaffPower(Item &item, int lvl, int bs, bool onlygood)
 	const char *spellName = pgettext("spell", spelldata[bs].sNameText);
 	const char *normalFmt = pgettext("spell", /* TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall */ "{0} of {1}");
 
-	strncpy(item._iName, fmt::format(normalFmt, baseName, spellName).c_str(), sizeof(item._iName) - 1);
-	item._iName[sizeof(item._iName) - 1] = '\0';
+	CopyUtf8(item._iName, fmt::format(normalFmt, baseName, spellName), sizeof(item._iName));
 	if (!StringInPanel(item._iName)) {
-		strncpy(item._iName, fmt::format(normalFmt, shortName, spellName).c_str(), sizeof(item._iName) - 1);
-		item._iName[sizeof(item._iName) - 1] = '\0';
+		CopyUtf8(item._iName, fmt::format(normalFmt, shortName, spellName), sizeof(item._iName));
 	}
 
 	if (preidx != -1) {
 		const char *magicFmt = pgettext("spell", /* TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall */ "{0} {1} of {2}");
 		const char *prefixName = _(ItemPrefixes[preidx].PLName);
-		strncpy(item._iIName, fmt::format(magicFmt, prefixName, baseName, spellName).c_str(), sizeof(item._iIName) - 1);
-		item._iIName[sizeof(item._iIName) - 1] = '\0';
+		CopyUtf8(item._iIName, fmt::format(magicFmt, prefixName, baseName, spellName), sizeof(item._iIName));
 		if (!StringInPanel(item._iIName)) {
-			strncpy(item._iIName, fmt::format(magicFmt, prefixName, shortName, spellName).c_str(), sizeof(item._iIName) - 1);
-			item._iIName[sizeof(item._iIName) - 1] = '\0';
+			CopyUtf8(item._iIName, fmt::format(magicFmt, prefixName, shortName, spellName), sizeof(item._iIName));
 		}
 	} else {
-		strncpy(item._iIName, item._iName, sizeof(item._iIName) - 1);
-		item._iName[sizeof(item._iName) - 1] = '\0';
+		CopyUtf8(item._iIName, item._iName, sizeof(item._iIName));
 	}
 
 	CalcItemValue(item);
@@ -1289,11 +1285,9 @@ void GetItemPower(Item &item, int minlvl, int maxlvl, affix_item_type flgs, bool
 		}
 	}
 
-	strncpy(item._iIName, GenerateMagicItemName(item._iName, preidx, sufidx).c_str(), sizeof(item._iIName) - 1);
-	item._iIName[sizeof(item._iIName) - 1] = '\0';
+	CopyUtf8(item._iIName, GenerateMagicItemName(item._iName, preidx, sufidx), sizeof(item._iIName));
 	if (!StringInPanel(item._iIName)) {
-		strncpy(item._iIName, GenerateMagicItemName(_(AllItemsList[item.IDidx].iSName), preidx, sufidx).c_str(), sizeof(item._iIName) - 1);
-		item._iIName[sizeof(item._iIName) - 1] = '\0';
+		CopyUtf8(item._iIName, GenerateMagicItemName(_(AllItemsList[item.IDidx].iSName), preidx, sufidx), sizeof(item._iIName));
 	}
 	if (preidx != -1 || sufidx != -1)
 		CalcItemValue(item);

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -31,6 +31,7 @@
 #include "utils/file_util.h"
 #include "utils/language.h"
 #include "utils/paths.h"
+#include "utils/utf8.hpp"
 
 namespace devilution {
 
@@ -201,11 +202,10 @@ bool GetIniValue(const char *sectionName, const char *keyName, char *string, int
 {
 	const char *value = GetIni().GetValue(sectionName, keyName);
 	if (value == nullptr) {
-		strncpy(string, defaultString, stringSize);
+		CopyUtf8(string, defaultString, stringSize);
 		return false;
 	}
-	strncpy(string, value, stringSize - 1);
-	string[stringSize - 1] = '\0';
+	CopyUtf8(string, value, stringSize);
 	return true;
 }
 

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -10,6 +10,7 @@
 #include "loadsave.h"
 #include "stores.h"
 #include "utils/endian.hpp"
+#include "utils/utf8.hpp"
 
 namespace devilution {
 
@@ -222,8 +223,7 @@ bool UnPackPlayer(const PlayerPack *pPack, Player &player, bool netSync)
 	ClrPlrPath(player);
 	player.destAction = ACTION_NONE;
 
-	strncpy(player._pName, pPack->pName, PLR_NAME_LEN - 1);
-	player._pName[PLR_NAME_LEN - 1] = '\0';
+	CopyUtf8(player._pName, pPack->pName, sizeof(player._pName));
 
 	InitPlayer(player, true);
 

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -18,6 +18,7 @@
 #include "utils/file_util.h"
 #include "utils/language.h"
 #include "utils/paths.h"
+#include "utils/utf8.hpp"
 
 namespace devilution {
 
@@ -173,8 +174,7 @@ std::optional<MpqArchive> OpenSaveArchive(uint32_t saveNum)
 
 void Game2UiPlayer(const Player &player, _uiheroinfo *heroinfo, bool bHasSaveFile)
 {
-	strncpy(heroinfo->name, player._pName, sizeof(heroinfo->name) - 1);
-	heroinfo->name[sizeof(heroinfo->name) - 1] = '\0';
+	CopyUtf8(heroinfo->name, player._pName, sizeof(heroinfo->name));
 	heroinfo->level = player._pLevel;
 	heroinfo->heroclass = player._pClass;
 	heroinfo->strength = player._pStrength;
@@ -337,13 +337,11 @@ bool pfile_ui_save_create(_uiheroinfo *heroinfo)
 	giNumberOfLevels = gbIsHellfire ? 25 : 17;
 
 	archive.RemoveHashEntries(GetFileName);
-	strncpy(hero_names[saveNum], heroinfo->name, PLR_NAME_LEN);
-	hero_names[saveNum][PLR_NAME_LEN - 1] = '\0';
+	CopyUtf8(hero_names[saveNum], heroinfo->name, sizeof(hero_names[saveNum]));
 
 	auto &player = Players[0];
 	CreatePlayer(0, heroinfo->heroclass);
-	strncpy(player._pName, heroinfo->name, PLR_NAME_LEN);
-	player._pName[PLR_NAME_LEN - 1] = '\0';
+	CopyUtf8(player._pName, heroinfo->name, PLR_NAME_LEN);
 	PackPlayer(&pkplr, player, true);
 	EncodeHero(&pkplr);
 	Game2UiPlayer(player, heroinfo, false);

--- a/Source/platform/ctr/keyboard.cpp
+++ b/Source/platform/ctr/keyboard.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 
 #include "platform/ctr/keyboard.h"
+#include "utils/utf8.hpp"
 
 constexpr size_t MAX_TEXT_LENGTH = 255;
 
@@ -44,11 +45,11 @@ void ctr_vkbdFlush()
 		SwkbdButton button = swkbdInputText(&swkbd, mybuf, sizeof(mybuf));
 
 		if (button == SWKBD_BUTTON_CONFIRM) {
-			strncpy(event.outText, mybuf, event.maxLength);
+			devilution::CopyUtf8(event.outText, mybuf, event.maxLength);
 			continue;
 		}
 
-		strncpy(event.outText, event.inText, event.maxLength);
+		devilution::CopyUtf8(event.outText, event.inText, event.maxLength);
 	}
 
 	eventCount = 0;

--- a/Source/platform/switch/keyboard.cpp
+++ b/Source/platform/switch/keyboard.cpp
@@ -2,6 +2,7 @@
 #include <switch.h>
 #include <SDL.h>
 #include "platform/switch/keyboard.h"
+#include "utils/utf8.hpp"
 
 static void switch_keyboard_get(const char *guide_text, char *initial_text, int max_len, int multiline, char *buf)
 {
@@ -59,8 +60,7 @@ void switch_start_text_input(const char *guide_text, char *initial_text, int max
 		switch_create_and_push_sdlkey_event(SDL_KEYUP, SDL_SCANCODE_DELETE, SDLK_DELETE);
 	}
 	if (text[0] == '\0') {
-		strncpy(text, initial_text, max_length - 1);
-		text[max_length] = { '\0' };
+		devilution::CopyUtf8(text, initial_text, max_length);
 	}
 	const uint8_t *utf8_text = (uint8_t *)text;
 	for (int i = 0; i < 599 && utf8_text[i];) {

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -11,6 +11,7 @@
 #include "engine/render/text_render.hpp"
 #include "inv.h"
 #include "utils/language.h"
+#include "utils/utf8.hpp"
 
 namespace devilution {
 
@@ -57,8 +58,7 @@ void ErrorPlrMsg(const char *pszMsg)
 	plr_msg_slot = (plr_msg_slot + 1) & (PMSG_COUNT - 1);
 	pMsg->player = MAX_PLRS;
 	pMsg->time = SDL_GetTicks();
-	strncpy(pMsg->str, pszMsg, sizeof(pMsg->str));
-	pMsg->str[sizeof(pMsg->str) - 1] = '\0';
+	CopyUtf8(pMsg->str, pszMsg, sizeof(pMsg->str));
 }
 
 size_t EventPlrMsg(const char *pszFmt, ...)

--- a/Source/storm/storm_net.cpp
+++ b/Source/storm/storm_net.cpp
@@ -12,6 +12,7 @@
 #include "menu.h"
 #include "options.h"
 #include "utils/stubs.h"
+#include "utils/utf8.hpp"
 
 namespace devilution {
 
@@ -127,10 +128,10 @@ bool SNetGetGameInfo(game_info type, void *dst, unsigned int length)
 #endif
 	switch (type) {
 	case GAMEINFO_NAME:
-		strncpy((char *)dst, gpszGameName, length);
+		CopyUtf8((char *)dst, gpszGameName, length);
 		break;
 	case GAMEINFO_PASSWORD:
-		strncpy((char *)dst, gpszGamePassword, length);
+		CopyUtf8((char *)dst, gpszGamePassword, length);
 		break;
 	}
 
@@ -179,7 +180,7 @@ bool SNetCreateGame(const char *pszGameName, const char *pszGamePassword, char *
 		pszGameName = defaultName.c_str();
 	}
 
-	strncpy(gpszGameName, pszGameName, sizeof(gpszGameName) - 1);
+	CopyUtf8(gpszGameName, pszGameName, sizeof(gpszGameName));
 	if (pszGamePassword != nullptr)
 		DvlNet_SetPassword(pszGamePassword);
 	else
@@ -194,7 +195,7 @@ bool SNetJoinGame(char *pszGameName, char *pszGamePassword, int *playerID)
 	std::lock_guard<SdlMutex> lg(storm_net_mutex);
 #endif
 	if (pszGameName != nullptr)
-		strncpy(gpszGameName, pszGameName, sizeof(gpszGameName) - 1);
+		CopyUtf8(gpszGameName, pszGameName, sizeof(gpszGameName));
 	if (pszGamePassword != nullptr)
 		DvlNet_SetPassword(pszGamePassword);
 	else
@@ -251,7 +252,7 @@ std::vector<std::string> DvlNet_GetGamelist()
 void DvlNet_SetPassword(std::string pw)
 {
 	GameIsPublic = false;
-	strncpy(gpszGamePassword, pw.c_str(), sizeof(gpszGamePassword) - 1);
+	CopyUtf8(gpszGamePassword, pw, sizeof(gpszGamePassword));
 	dvlnet_inst->setup_password(std::move(pw));
 }
 

--- a/Source/utils/utf8.cpp
+++ b/Source/utils/utf8.cpp
@@ -1,10 +1,26 @@
 #include "utils/utf8.hpp"
 
 #include <cstddef>
+#include <cstring>
 
 #include <hoehrmann_utf8.h>
 
 namespace devilution {
+
+namespace {
+
+/** Truncates `str` to at most `len` at a code point boundary. */
+string_view TruncateUtf8(string_view str, std::size_t len)
+{
+	if (str.size() > len) {
+		str.remove_suffix(str.size() - len);
+		while (!str.empty() && !IsTrailUtf8CodeUnit(str.back()))
+			str.remove_suffix(1);
+	}
+	return str;
+}
+
+} // namespace
 
 char32_t DecodeFirstUtf8CodePoint(string_view input, uint8_t *len)
 {
@@ -23,6 +39,13 @@ char32_t DecodeFirstUtf8CodePoint(string_view input, uint8_t *len)
 	}
 	*len = input.size();
 	return Utf8DecodeError;
+}
+
+void CopyUtf8(char *dest, string_view source, std::size_t bytes)
+{
+	source = TruncateUtf8(source, bytes - 1);
+	std::memcpy(dest, source.data(), source.size());
+	dest[source.size()] = '\0';
 }
 
 } // namespace devilution

--- a/Source/utils/utf8.hpp
+++ b/Source/utils/utf8.hpp
@@ -53,4 +53,10 @@ inline std::size_t FindLastUtf8Symbols(string_view input)
 	return pos;
 }
 
+/**
+ * @brief Copy up to a given number of bytes from a UTF8 string, and zero terminate string
+ * @param bytes Max number of bytes to copy
+ */
+void CopyUtf8(char *dest, string_view source, std::size_t bytes);
+
 } // namespace devilution

--- a/Translations/bg.po
+++ b/Translations/bg.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-11-15 22:07+0100\n"
+"POT-Creation-Date: 2021-11-21 05:44+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Nikolay Popov <nikolai.popovz@gmail.com>\n"
 "Language-Team: Nikolay Popov <nikolai.popovz@gmail.com>; Zakxaev68 / "
@@ -750,11 +750,11 @@ msgstr "Наистина ли искате да изтриете героя \"{:
 msgid "Enter Hellfire"
 msgstr "Режим Hellfire"
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr "Да"
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr "Не"
 
@@ -876,176 +876,176 @@ msgstr "Ниво: Свърталище {:d}"
 msgid "Level: Crypt {:d}"
 msgstr "Ниво: Гробница {:d}"
 
-#: Source/automap.cpp:508 Source/items.cpp:2076
+#: Source/automap.cpp:508 Source/items.cpp:2090
 msgid "Level: {:d}"
 msgstr "Ниво: {:d}"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr "Tab"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr "Esc"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Enter"
 msgstr "Enter"
 
-#: Source/control.cpp:202
+#: Source/control.cpp:215
 msgid "Character Information"
 msgstr "Информация за персонажа"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr "Приключенски дневник"
 
-#: Source/control.cpp:204
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr "Автоматична карта"
 
-#: Source/control.cpp:205
+#: Source/control.cpp:218
 msgid "Main Menu"
 msgstr "Главно меню"
 
-#: Source/control.cpp:206
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr "Инвентар"
 
-#: Source/control.cpp:207
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr "Книга за Заклинания"
 
-#: Source/control.cpp:208
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr "Изпрати съобщение"
 
-#: Source/control.cpp:705 Source/control.cpp:1566
+#: Source/control.cpp:718 Source/control.cpp:1587
 msgid "Skill"
 msgstr "Умение"
 
-#: Source/control.cpp:706 Source/control.cpp:1220
+#: Source/control.cpp:719 Source/control.cpp:1237
 msgid "{:s} Skill"
 msgstr "{:s} Умение"
 
-#: Source/control.cpp:712
+#: Source/control.cpp:725
 msgid "Spell"
 msgstr "Заклинание"
 
-#: Source/control.cpp:713 Source/control.cpp:1224
+#: Source/control.cpp:726 Source/control.cpp:1241
 msgid "{:s} Spell"
 msgstr "{:s} Заклинание"
 
-#: Source/control.cpp:715
+#: Source/control.cpp:728
 msgid "Damages undead only"
 msgstr "Поразява само немъртви"
 
-#: Source/control.cpp:719 Source/control.cpp:1228 Source/control.cpp:1590
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr "Заклинание Ниво 0 - Неизползваемо"
 
-#: Source/control.cpp:721 Source/control.cpp:1230 Source/control.cpp:1592
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 msgid "Spell Level {:d}"
 msgstr "Заклинание Ниво {:d}"
 
-#: Source/control.cpp:728
+#: Source/control.cpp:741
 msgid "Scroll"
 msgstr "{:d} Свитък"
 
-#: Source/control.cpp:729 Source/control.cpp:1234
+#: Source/control.cpp:742 Source/control.cpp:1251
 msgid "Scroll of {:s}"
 msgstr "Свитък на {:s}"
 
-#: Source/control.cpp:734 Source/control.cpp:1240
+#: Source/control.cpp:747 Source/control.cpp:1257
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "{:d} Свитък"
 msgstr[1] "{:d} Свитъци"
 
-#: Source/control.cpp:741 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
 #: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
 msgid "Staff"
 msgstr "Жезъл"
 
-#: Source/control.cpp:742 Source/control.cpp:1244 Source/items.cpp:1317
+#: Source/control.cpp:755 Source/control.cpp:1261
 msgid "Staff of {:s}"
 msgstr "Жезъл на {:s}"
 
-#: Source/control.cpp:744 Source/control.cpp:1246
+#: Source/control.cpp:757 Source/control.cpp:1263
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "{:d} Заряд"
 msgstr[1] "{:d} Заряди"
 
-#: Source/control.cpp:754
+#: Source/control.cpp:767
 msgid "Spell Hotkey {:s}"
 msgstr "Клавишна комбинация за заклинания {:s}"
 
-#: Source/control.cpp:1197
+#: Source/control.cpp:1214
 msgid "Player friendly"
 msgstr "Приятелска игра"
 
-#: Source/control.cpp:1199
+#: Source/control.cpp:1216
 msgid "Player attack"
 msgstr "Враждебна игра"
 
-#: Source/control.cpp:1202
+#: Source/control.cpp:1219
 msgid "Hotkey: {:s}"
 msgstr "Клавишна комбинация: {:s}"
 
-#: Source/control.cpp:1210
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr "Бутон за избор на текущо заклинание"
 
-#: Source/control.cpp:1213
+#: Source/control.cpp:1230
 msgid "Hotkey: 's'"
 msgstr "Клавишна комбинация: 's'"
 
-#: Source/control.cpp:1368 Source/inv.cpp:1979 Source/items.cpp:3729
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "{:d} златна монета"
 msgstr[1] "{:d} златни монети"
 
-#: Source/control.cpp:1371
+#: Source/control.cpp:1390
 msgid "Requirements not met"
 msgstr "Изискванията не са покрити"
 
-#: Source/control.cpp:1407
+#: Source/control.cpp:1426
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Ниво: {:d}"
 
-#: Source/control.cpp:1409
+#: Source/control.cpp:1428
 msgid "Hit Points {:d} of {:d}"
 msgstr "Точки живот {:d} от {:d}"
 
-#: Source/control.cpp:1436
+#: Source/control.cpp:1457
 msgid "Level Up"
 msgstr "Ново ниво"
 
-#: Source/control.cpp:1570
+#: Source/control.cpp:1591
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] "Жезъл ({:d} заряд)"
 msgstr[1] "Жезъл ({:d} заряди)"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1580
+#: Source/control.cpp:1601
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "Мана: {:d}  Щети: {:d} - {:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1582
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "Мана: {:d}  Щети: няма"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1585
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "Мана: {:d}  Щети: 1/3 ж.т.цел"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1643
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] "Имате {:d} златна монета. Колко искате да отделите?"
@@ -1800,23 +1800,23 @@ msgstr ""
 "Четенето на повече от една книга за едно и също заклинание, прави същото по-"
 "ефикасно."
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Shareware Hellfire Help"
 msgstr "Помощ за пробна версия на Hellfire"
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Hellfire Help"
 msgstr "Помощ за Hellfire"
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Shareware Diablo Help"
 msgstr "Помощ за пробна версия на Diablo"
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Diablo Help"
 msgstr "Помощ за Diablo"
 
-#: Source/help.cpp:161
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr ""
 "Наиснете ESC, за да прекъснете или клавишните стрелки за да превъртите."
@@ -3623,639 +3623,652 @@ msgstr "Масло на Втвърдяването"
 msgid "Oil of Imperviousness"
 msgstr "Масло на Непробиваемостта"
 
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#: Source/items.cpp:1174 Source/items.cpp:1184 Source/items.cpp:1233
-#: Source/items.cpp:1269
-msgid "{0} {1}"
-msgstr "{0} {1}"
-
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's Staff of Firewall
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Long Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1187 Source/items.cpp:1254 Source/items.cpp:1273
-#: Source/items.cpp:1315
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
+#, fuzzy
+#| msgid "{0} of {1}"
+msgctxt "spell"
 msgid "{0} of {1}"
 msgstr "{0} на {1}"
 
-#: Source/items.cpp:1892 Source/items.cpp:1904
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+#, fuzzy
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr "{0} {1} на {2}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+#, fuzzy
+msgid "{0} {1} of {2}"
+msgstr "{0} {1} на {2}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
+#: Source/items.cpp:1217
+msgid "{0} {1}"
+msgstr "{0} {1}"
+
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
+msgid "{0} of {1}"
+msgstr "{0} на {1}"
+
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr "увеличава"
 
-#: Source/items.cpp:1894
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr "шанса за попадение на оръжието"
 
-#: Source/items.cpp:1898
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr "значително увеличава шанса"
 
-#: Source/items.cpp:1900
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr "за попадение на оръжието"
 
-#: Source/items.cpp:1906
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr "потенциал за щети"
 
-#: Source/items.cpp:1910
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr "значително увеличава"
 
-#: Source/items.cpp:1912
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr "потенциала за щети - изкл. лъкове"
 
-#: Source/items.cpp:1916
+#: Source/items.cpp:1930
 msgid "reduces attributes needed"
 msgstr "намалява нужните атрибути"
 
-#: Source/items.cpp:1918
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr "използва се в/у брони и оръжия"
 
-#: Source/items.cpp:1922
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr "възстановява 20% от"
 
-#: Source/items.cpp:1924
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr "здравината на предмета"
 
-#: Source/items.cpp:1928
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr "увеличава"
 
-#: Source/items.cpp:1930
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr "текуща и макс здравина на предмета"
 
-#: Source/items.cpp:1934
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr "прави предмет неразрушим"
 
-#: Source/items.cpp:1938
+#: Source/items.cpp:1952
 msgid "increases the armor class"
 msgstr "увеличава клас на бронята"
 
-#: Source/items.cpp:1940
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr "на брони и щитове"
 
-#: Source/items.cpp:1944
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr "значително увеличава клас на бронята"
 
-#: Source/items.cpp:1946
+#: Source/items.cpp:1960
 msgid "class of armor and shields"
 msgstr "на брони и щитове"
 
-#: Source/items.cpp:1950 Source/items.cpp:1959
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr "залага огнена клопка"
 
-#: Source/items.cpp:1955
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr "залага мълниена клопка"
 
-#: Source/items.cpp:1963
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr "залага вкаменяваща клопка"
 
-#: Source/items.cpp:1967
+#: Source/items.cpp:1981
 msgid "restore all life"
 msgstr "напълно възстановява живот"
 
-#: Source/items.cpp:1971
+#: Source/items.cpp:1985
 msgid "restore some life"
 msgstr "частично възстановява живот"
 
-#: Source/items.cpp:1975
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr "възстановява живот"
 
-#: Source/items.cpp:1979
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr "смъртоносно изцеление"
 
-#: Source/items.cpp:1983
+#: Source/items.cpp:1997
 msgid "restore some mana"
 msgstr "частично възстановява мана"
 
-#: Source/items.cpp:1987
+#: Source/items.cpp:2001
 msgid "restore all mana"
 msgstr "напълно възстановява мана"
 
-#: Source/items.cpp:1991
+#: Source/items.cpp:2005
 msgid "increase strength"
 msgstr "увеличава сила"
 
-#: Source/items.cpp:1995
+#: Source/items.cpp:2009
 msgid "increase magic"
 msgstr "увеличава магия"
 
-#: Source/items.cpp:1999
+#: Source/items.cpp:2013
 msgid "increase dexterity"
 msgstr "увеличава сръчност"
 
-#: Source/items.cpp:2003
+#: Source/items.cpp:2017
 msgid "increase vitality"
 msgstr "увеличава жизненост"
 
-#: Source/items.cpp:2008
+#: Source/items.cpp:2022
 msgid "decrease strength"
 msgstr "намалява сила"
 
-#: Source/items.cpp:2012
+#: Source/items.cpp:2026
 msgid "decrease dexterity"
 msgstr "намалява сръчност"
 
-#: Source/items.cpp:2016
+#: Source/items.cpp:2030
 msgid "decrease vitality"
 msgstr "намалява жизненост"
 
-#: Source/items.cpp:2020
+#: Source/items.cpp:2034
 msgid "restore some life and mana"
 msgstr "частично възстановява живот и мана"
 
-#: Source/items.cpp:2024
+#: Source/items.cpp:2038
 msgid "restore all life and mana"
 msgstr "напълно възстановява живот и мана"
 
-#: Source/items.cpp:2039 Source/items.cpp:2064
+#: Source/items.cpp:2053 Source/items.cpp:2078
 msgid "Right-click to read"
 msgstr "Десен клик за прочитане"
 
-#: Source/items.cpp:2043
+#: Source/items.cpp:2057
 msgid "Right-click to read, then"
 msgstr "Десен клик за прочитане, "
 
-#: Source/items.cpp:2045
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr "следван от ляв клик върху цел"
 
-#: Source/items.cpp:2050
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr "Десен клик за използване"
 
-#: Source/items.cpp:2055 Source/items.cpp:2060
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr "Десен клик за използване"
 
-#: Source/items.cpp:2068
+#: Source/items.cpp:2082
 msgid "Right click to read"
 msgstr "Десен клик за прочитане"
 
-#: Source/items.cpp:2072
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr "Десен клик за поглед"
 
-#: Source/items.cpp:2080
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr "Удвоява лимит на златото"
 
-#: Source/items.cpp:2092 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 msgid "Required:"
 msgstr "Необходими:"
 
-#: Source/items.cpp:2094 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 msgid " {:d} Str"
 msgstr " {:d} Сила"
 
-#: Source/items.cpp:2096 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 msgid " {:d} Mag"
 msgstr " {:d} Маг"
 
-#: Source/items.cpp:2098 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 msgid " {:d} Dex"
 msgstr " {:d} Сръч"
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3513 Source/player.cpp:3018
+#: Source/items.cpp:3533 Source/player.cpp:3018
 msgid "Ear of {:s}"
 msgstr "Ухо на {:s}"
 
-#: Source/items.cpp:3808
+#: Source/items.cpp:3828
 msgid "chance to hit: {:+d}%"
 msgstr "шанс за удар: {:+d}%"
 
-#: Source/items.cpp:3812
+#: Source/items.cpp:3832
 #, no-c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% щети"
 
-#: Source/items.cpp:3816 Source/items.cpp:4072
+#: Source/items.cpp:3836 Source/items.cpp:4092
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "шанс удар: {:+d}%, {:+d}% щети"
 
-#: Source/items.cpp:3820
+#: Source/items.cpp:3840
 #, no-c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% броня"
 
-#: Source/items.cpp:3824
+#: Source/items.cpp:3844
 msgid "armor class: {:d}"
 msgstr "клас броня: {:d}"
 
-#: Source/items.cpp:3829 Source/items.cpp:4054
+#: Source/items.cpp:3849 Source/items.cpp:4074
 msgid "Resist Fire: {:+d}%"
 msgstr "Устойчивост Огън: {:+d}%"
 
-#: Source/items.cpp:3831
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr "Устойчивост Огън: 75% MAКС"
 
-#: Source/items.cpp:3836
+#: Source/items.cpp:3856
 msgid "Resist Lightning: {:+d}%"
 msgstr "Устойчивост Мълния: {:+d}%"
 
-#: Source/items.cpp:3838
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr "Устойчивост Мълния: 75% MAКС"
 
-#: Source/items.cpp:3843
+#: Source/items.cpp:3863
 msgid "Resist Magic: {:+d}%"
 msgstr "Устойчивост Магия: {:+d}%"
 
-#: Source/items.cpp:3845
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr "Устойчивост Магия: 75% MAX"
 
-#: Source/items.cpp:3850
+#: Source/items.cpp:3870
 msgid "Resist All: {:+d}%"
 msgstr "Устойчивост Всичко: {:+d}%"
 
-#: Source/items.cpp:3852
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr "Устойчивост Всичко: 75% MAX"
 
-#: Source/items.cpp:3856
+#: Source/items.cpp:3876
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] "заклинанията са увеличени с {:d} ниво"
 msgstr[1] "заклинанията са увеличени с {:d} нива"
 
-#: Source/items.cpp:3858
+#: Source/items.cpp:3878
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "заклинанията са намалени с {:d} ниво"
 msgstr[1] "заклинанията са намалени с {:d} нива"
 
-#: Source/items.cpp:3860
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr "нива на заклинания непроменени (?)"
 
-#: Source/items.cpp:3863
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr "Допълнителни заряди"
 
-#: Source/items.cpp:3866
+#: Source/items.cpp:3886
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:d} {:s} заряд"
 msgstr[1] "{:d} {:s} заряди"
 
-#: Source/items.cpp:3870
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr "Щети Огнен Удар: {:d}"
 
-#: Source/items.cpp:3872
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "Щети Огнен Удар: {:d}-{:d}"
 
-#: Source/items.cpp:3876
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr "Щети Мълниен Удар: {:d}"
 
-#: Source/items.cpp:3878
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "Щети Мълниен Удар: {:d}-{:d}"
 
-#: Source/items.cpp:3882
+#: Source/items.cpp:3902
 msgid "{:+d} to strength"
 msgstr "{:+d} към сила"
 
-#: Source/items.cpp:3886
+#: Source/items.cpp:3906
 msgid "{:+d} to magic"
 msgstr "{:+d} към магия"
 
-#: Source/items.cpp:3890
+#: Source/items.cpp:3910
 msgid "{:+d} to dexterity"
 msgstr "{:+d} към сръчност"
 
-#: Source/items.cpp:3894
+#: Source/items.cpp:3914
 msgid "{:+d} to vitality"
 msgstr "{:+d} към жизненост"
 
-#: Source/items.cpp:3898
+#: Source/items.cpp:3918
 msgid "{:+d} to all attributes"
 msgstr "{:+d} към всички атрибути"
 
-#: Source/items.cpp:3902
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} щети от врагове"
 
-#: Source/items.cpp:3906
+#: Source/items.cpp:3926
 msgid "Hit Points: {:+d}"
 msgstr "Живот: {:+d}"
 
-#: Source/items.cpp:3910
+#: Source/items.cpp:3930
 msgid "Mana: {:+d}"
 msgstr "Мана: {:+d}"
 
-#: Source/items.cpp:3913
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr "висока издържливост"
 
-#: Source/items.cpp:3916
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr "понижена издържливост"
 
-#: Source/items.cpp:3919
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr "неразрушими"
 
-#: Source/items.cpp:3922
+#: Source/items.cpp:3942
 #, no-c-format
 msgid "+{:d}% light radius"
 msgstr "+{:d}% светлинен радиус"
 
-#: Source/items.cpp:3925
+#: Source/items.cpp:3945
 #, no-c-format
 msgid "-{:d}% light radius"
 msgstr "-{:d}% светлинен радиус"
 
-#: Source/items.cpp:3928
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr "множество стрели при изстрел"
 
-#: Source/items.cpp:3932
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr "щети огнени стрели: {:d}"
 
-#: Source/items.cpp:3934
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "щети огнени стрели: {:d}-{:d}"
 
-#: Source/items.cpp:3938
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr "щети мълнийни стрели {:d}"
 
-#: Source/items.cpp:3940
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "щети мълнийни стрели {:d}-{:d}"
 
-#: Source/items.cpp:3944
+#: Source/items.cpp:3964
 msgid "fireball damage: {:d}"
 msgstr "щети огненo кълбо {:d}"
 
-#: Source/items.cpp:3946
+#: Source/items.cpp:3966
 msgid "fireball damage: {:d}-{:d}"
 msgstr "щети огнено кълбо {:d}-{:d}"
 
-#: Source/items.cpp:3949
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr "атакуващият получава 1-3 щети"
 
-#: Source/items.cpp:3952
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr "играчът губи всичката мана"
 
-#: Source/items.cpp:3955
+#: Source/items.cpp:3975
 msgid "you can't heal"
 msgstr "не може да се лекувате"
 
-#: Source/items.cpp:3958
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr "поглъща половината щети от капани"
 
-#: Source/items.cpp:3961
+#: Source/items.cpp:3981
 msgid "knocks target back"
 msgstr "избутва целта назад"
 
-#: Source/items.cpp:3964
+#: Source/items.cpp:3984
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr "+200% щети срещу демони"
 
-#: Source/items.cpp:3967
+#: Source/items.cpp:3987
 msgid "All Resistance equals 0"
 msgstr "Всички устойчивости са 0"
 
-#: Source/items.cpp:3970
+#: Source/items.cpp:3990
 msgid "hit monster doesn't heal"
 msgstr "поразен враг не може да се лекува"
 
-#: Source/items.cpp:3974
+#: Source/items.cpp:3994
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr "удар отнема 3% мана"
 
-#: Source/items.cpp:3976
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr "удар отнема 5% мана"
 
-#: Source/items.cpp:3980
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr "удар отнема 3% жизненост"
 
-#: Source/items.cpp:3982
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr "удар отнема 5% жизненост"
 
-#: Source/items.cpp:3985
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr "пробива бронята на врага"
 
-#: Source/items.cpp:3989
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr "ускорен замах"
 
-#: Source/items.cpp:3991
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr "бърз замах"
 
-#: Source/items.cpp:3993
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr "по-бърз замах"
 
-#: Source/items.cpp:3995
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr "най-бърз замах"
 
-#: Source/items.cpp:3999
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr "бързо възстановяване от удар"
 
-#: Source/items.cpp:4001
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr "по-бързо възстановяване от удар"
 
-#: Source/items.cpp:4003
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr "най-бързо възстановяване от удар"
 
-#: Source/items.cpp:4006
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr "бързо блокиране"
 
-#: Source/items.cpp:4009
+#: Source/items.cpp:4029
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] "добавя {:d} точка към щети"
 msgstr[1] "добавя {:d} точки към щети"
 
-#: Source/items.cpp:4012
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr "изстрелва стрели със случайна скорост"
 
-#: Source/items.cpp:4015
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr "необичайни щети за тип предмет"
 
-#: Source/items.cpp:4018
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr "променена издръжливост"
 
-#: Source/items.cpp:4021
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr "по-бърз удар с замах"
 
-#: Source/items.cpp:4024
+#: Source/items.cpp:4044
 msgid "one handed sword"
 msgstr "меч за една ръка"
 
-#: Source/items.cpp:4027
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr "постоянно губене на живот"
 
-#: Source/items.cpp:4030
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr "изсмукване на живот"
 
-#: Source/items.cpp:4033
+#: Source/items.cpp:4053
 msgid "no strength requirement"
 msgstr "няма изисквания за сила"
 
-#: Source/items.cpp:4036
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr "гледай с инфразрение"
 
-#: Source/items.cpp:4043
+#: Source/items.cpp:4063
 msgid "lightning damage: {:d}"
 msgstr "мълнийни щети: {:d}"
 
-#: Source/items.cpp:4045
+#: Source/items.cpp:4065
 msgid "lightning damage: {:d}-{:d}"
 msgstr "мълнийни щети: {:d}-{:d}"
 
-#: Source/items.cpp:4048
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr "светкавични заряди при удар"
 
-#: Source/items.cpp:4057
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr "случайни тройни щети"
 
-#: Source/items.cpp:4060
+#: Source/items.cpp:4080
 #, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr "разпадащи се {:+d}% щети"
 
-#: Source/items.cpp:4063
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr "2x щети за чуд., 1x за играч"
 
-#: Source/items.cpp:4066
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr "Произволни 0 - 500% щети"
 
-#: Source/items.cpp:4069
+#: Source/items.cpp:4089
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr "ниска изд., {:+d}% щети"
 
-#: Source/items.cpp:4075
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr "допълнително КБ с/у демони"
 
-#: Source/items.cpp:4078
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr "допълнително КБ с/у немъртви"
 
-#: Source/items.cpp:4081
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr "50% Мана пренесена в Живот"
 
-#: Source/items.cpp:4084
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr "40% Живот пренесен в Мана"
 
-#: Source/items.cpp:4087
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr "Друга способност (NW)"
 
-#: Source/items.cpp:4124 Source/items.cpp:4171
+#: Source/items.cpp:4144 Source/items.cpp:4191
 msgid "damage: {:d}  Indestructible"
 msgstr "щети: {:d}  Неразрушими"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4126 Source/items.cpp:4173
+#: Source/items.cpp:4146 Source/items.cpp:4193
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "щети: {:d}  Изд: {:d}/{:d}"
 
-#: Source/items.cpp:4129 Source/items.cpp:4176
+#: Source/items.cpp:4149 Source/items.cpp:4196
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "щети: {:d}-{:d}  Неразрушим"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4131 Source/items.cpp:4178
+#: Source/items.cpp:4151 Source/items.cpp:4198
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "щети: {:d}-{:d}  Изд: {:d}/{:d}"
 
-#: Source/items.cpp:4137 Source/items.cpp:4190
+#: Source/items.cpp:4157 Source/items.cpp:4210
 msgid "armor: {:d}  Indestructible"
 msgstr "броня: {:d}  Неразрушим"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4139 Source/items.cpp:4192
+#: Source/items.cpp:4159 Source/items.cpp:4212
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "броня: {:d}  Изд: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4144
+#: Source/items.cpp:4164
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "щети: {:d}  Изд: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4146
+#: Source/items.cpp:4166
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "щети: {:d}-{:d}  Изд: {:d}/{:d}"
 
-#: Source/items.cpp:4147 Source/items.cpp:4182 Source/items.cpp:4197
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 msgid "Charges: {:d}/{:d}"
 msgstr "Заряди: {:d}/{:d}"
 
-#: Source/items.cpp:4159
+#: Source/items.cpp:4179
 msgid "unique item"
 msgstr "уникат"
 
-#: Source/items.cpp:4186 Source/items.cpp:4195 Source/items.cpp:4202
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr "Неразпознат"
 
@@ -6473,7 +6486,7 @@ msgstr "Фарнам"
 msgid "Adria"
 msgstr "Адрия"
 
-#: Source/stores.cpp:98 Source/stores.cpp:1252
+#: Source/stores.cpp:98 Source/stores.cpp:1305
 msgid "Gillian"
 msgstr "Джилиън"
 
@@ -6481,298 +6494,293 @@ msgstr "Джилиън"
 msgid "Wirt"
 msgstr "Върт"
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr "Назад"
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ",  "
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 msgid "Damage: {:d}-{:d}  "
 msgstr "Щети: {:d}-{:d}  "
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 msgid "Armor: {:d}  "
 msgstr "Броня: {:d}  "
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 msgid "Dur: {:d}/{:d},  "
 msgstr "Издр.: {:d}/{:d},  "
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr "Неразрушими,  "
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr "Няма изисквани атрибути"
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr "Добре дошли в"
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr "Работилницата на Ковача"
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr "Искате ли да:"
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 msgid "Talk to Griswold"
 msgstr "Говорите с Грисволд"
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 msgid "Buy basic items"
 msgstr "Купите обикновени предмети"
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 msgid "Buy premium items"
 msgstr "Купите качествени предмети"
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 msgid "Sell items"
 msgstr "Продадете предмети"
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 msgid "Repair items"
 msgstr "Поправите предмети"
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 msgid "Leave the shop"
 msgstr "Напуснете ателието"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "Продавам тези предмети.             Вашето злато: {:d}"
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr "Назад"
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "Продавам тези изключителни предмети.    Вашето злато: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "Нямате нищо, което ми трябва.       Вашето злато: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "Кой предмет е за продажба?             Вашето злато: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "Нямате предмет за поправка.         Вашето злато: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "Кой предмет е за поправка?      Вашето злато: {:d}"
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr "Колибата на Вещицата"
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 msgid "Talk to Adria"
 msgstr "Говорите с Адрия"
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr "Купите магически предмети"
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr "Презаредите жезли"
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 msgid "Leave the shack"
 msgstr "Напуснете Колибата"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "Нямате предмет за презареждане.       Вашето злато: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "Кой предмет е за презареждане?             Вашето злато: {:d}"
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr "Нямате достатъчно злато"
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr "Нямате достатъчно място в инвентара"
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr "Договорихме ли се?"
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 msgid "Are you sure you want to identify this item?"
 msgstr "Наистина ли искате да разпознаете този предмет?"
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 msgid "Are you sure you want to buy this item?"
 msgstr "Наистина ли искате да купите този предмет?"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 msgid "Are you sure you want to recharge this item?"
 msgstr "Наистина ли искате да презаредите този предмет?"
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 msgid "Are you sure you want to sell this item?"
 msgstr "Наистина ли искате да продадете този предмет?"
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 msgid "Are you sure you want to repair this item?"
 msgstr "Наистина ли искате да поправите този предмет?"
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr "Върт, момчето с дървения крак"
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 msgid "Talk to Wirt"
 msgstr "Говорите с Върт"
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr "Имам нещо за продан,"
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr "но това ще ти струва 50 злато"
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr "само да погледнеш. "
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr "Какво имаш?"
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr "Кажете довиждане"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "Имам този предмет за продан:             Вашето злато: {:d}"
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 msgid "Leave"
 msgstr "Напуснете"
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr "Домът на Лечителя"
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr "Говорите с Пепин"
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr "Напуснете дома на Лечителя"
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 msgid "The Town Elder"
 msgstr "Градският старейшина"
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 msgid "Talk to Cain"
 msgstr "Говорите с Кайн"
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr "Разпознаване на предмет"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "Нямате нищо за разпознаване.             Вашето злато: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "Кой предмет е за разпознаване?             Вашето злато: {:d}"
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr "Този предмет е:"
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr "Готово"
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 msgid "Talk to {:s}"
 msgstr "Говорете с {:s}"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 msgid "Talking to {:s}"
 msgstr "Говори с {:s}"
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 msgid "is not available"
 msgstr "не е налично"
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 msgid "in the shareware"
 msgstr "в пробната"
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 msgid "version"
 msgstr "версия"
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr "Общи приказки"
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr "Изгряващото слънце"
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 msgid "Talk to Ogden"
 msgstr "Говорите с Огдън"
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 msgid "Leave the tavern"
 msgstr "Напуснете гостилницата"
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 msgid "Talk to Gillian"
 msgstr "Говорите с Джилиън"
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr "Пияницата Фарнам"
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 msgid "Talk to Farnham"
 msgstr "Говорите с Фарнам"
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr "Кажете довиждане"
 
@@ -6822,9 +6830,9 @@ msgstr ""
 "от половината от нас успяха да се спасят от неговото безумие.\n"
 "\n"
 "Рицарите му и придворните свещеници се опитаха да го усмирят, но той се "
-"обърна срещу тях и за жалост, те бяха принудени на цареубийство. С "
-"последния си дъх, Кралят отправи жестоко проклятие към бившите си слуги, "
-"кълнейки, се че те ще му служат вечно в мрака.\n"
+"обърна срещу тях и за жалост, те бяха принудени на цареубийство. С последния "
+"си дъх, Кралят отправи жестоко проклятие към бившите си слуги, кълнейки, се "
+"че те ще му служат вечно в мрака.\n"
 "\n"
 "Точно тогава, събитията придобиха още по-мрачен изглед, какъвто не съм и "
 "предполагал! Някогашният ни Крал се надигна от своя вечен сън и в момента "
@@ -10714,11 +10722,3 @@ msgstr "Надолу към Диабло"
 #: Source/trigs.cpp:710 Source/trigs.cpp:724 Source/trigs.cpp:738
 msgid "Back to Level {:d}"
 msgstr "Нагоре към Ниво {:d}"
-
-#~ msgid "Force spawn mode even if diabdat.mpq is found"
-#~ msgstr ""
-#~ "Принудително използване на режим spawn, дори когато diabdat.mpq е налице"
-
-#~ msgid "Force diablo mode even if hellfire.mpq is found"
-#~ msgstr ""
-#~ "Принудително използване на режим Diablo, дори когато hellfire.mpq е налице"

--- a/Translations/cs.po
+++ b/Translations/cs.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-10-08 21:56+0200\n"
+"POT-Creation-Date: 2021-11-21 05:44+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Psojed <realpsojed@gmail.com>\n"
 "Language-Team: Psojed (realpsojed@gmail.com)\n"
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.4.3\n"
+"X-Generator: Poedit 3.0\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-KeywordsList: _;N_;P_:1c,2\n"
 "X-Poedit-Basepath: ..\n"
@@ -310,15 +310,49 @@ msgstr "Kruh Jednoho Tisíce"
 msgid "\tNo souls were sold in the making of this game."
 msgstr "\tŽádné duše nebyly zaprodány při tvorbě této hry."
 
-#: Source/DiabloUI/dialogs.cpp:171 Source/DiabloUI/dialogs.cpp:183
-#: Source/DiabloUI/selconn.cpp:73 Source/DiabloUI/selgame.cpp:94
-#: Source/DiabloUI/selgame.cpp:164 Source/DiabloUI/selgame.cpp:182
-#: Source/DiabloUI/selgame.cpp:316 Source/DiabloUI/selgame.cpp:390
+#: Source/DiabloUI/dialogs.cpp:194 Source/DiabloUI/dialogs.cpp:206
+#: Source/DiabloUI/selconn.cpp:79 Source/DiabloUI/selgame.cpp:103
+#: Source/DiabloUI/selgame.cpp:193 Source/DiabloUI/selgame.cpp:211
+#: Source/DiabloUI/selgame.cpp:352 Source/DiabloUI/selgame.cpp:428
 #: Source/DiabloUI/selhero.cpp:186 Source/DiabloUI/selhero.cpp:211
 #: Source/DiabloUI/selhero.cpp:281 Source/DiabloUI/selhero.cpp:536
 #: Source/DiabloUI/selok.cpp:68
 msgid "OK"
 msgstr "OK"
+
+#: Source/DiabloUI/extrasmenu.cpp:41 Source/DiabloUI/selstart.cpp:44
+#, fuzzy
+#| msgid "Down to Diablo"
+msgid "Switch to Diablo"
+msgstr "Dolů do Hnízda úrovně {:d}"
+
+#: Source/DiabloUI/extrasmenu.cpp:41
+#, fuzzy
+#| msgid "Exit Hellfire"
+msgid "Switch to Hellfire"
+msgstr "Ukonči Hellfire"
+
+#: Source/DiabloUI/extrasmenu.cpp:43
+msgid "Switch to Fullgame"
+msgstr ""
+
+#: Source/DiabloUI/extrasmenu.cpp:43
+#, fuzzy
+#| msgid "in the shareware"
+msgid "Switch to Shareware"
+msgstr "v shareware"
+
+#: Source/DiabloUI/extrasmenu.cpp:44
+msgid "Replay Intro"
+msgstr "Přehraj Intro"
+
+#: Source/DiabloUI/extrasmenu.cpp:45
+msgid "Support"
+msgstr "Podpora"
+
+#: Source/DiabloUI/extrasmenu.cpp:46 Source/gamemenu.cpp:61
+msgid "Previous Menu"
+msgstr "Předchozí Menu"
 
 #: Source/DiabloUI/mainmenu.cpp:36
 msgid "Single Player"
@@ -329,148 +363,164 @@ msgid "Multi Player"
 msgstr "Hra Více Hráčů"
 
 #: Source/DiabloUI/mainmenu.cpp:38
-msgid "Replay Intro"
-msgstr "Přehraj Intro"
+#, fuzzy
+#| msgid "Extra charges"
+msgid "Extras"
+msgstr "Použití navíc"
 
 #: Source/DiabloUI/mainmenu.cpp:39
-msgid "Support"
-msgstr "Podpora"
-
-#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Show Credits"
 msgstr "Ukaž Autory"
 
-#: Source/DiabloUI/mainmenu.cpp:41
+#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Exit Hellfire"
 msgstr "Ukonči Hellfire"
 
-#: Source/DiabloUI/mainmenu.cpp:41
+#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Exit Diablo"
 msgstr "Ukonči Diablo"
 
-#. TRANSLATORS:  Error Message when a Shareware User clicks on "Replay Intro" in the Main Menu
-#: Source/DiabloUI/mainmenu.cpp:99
-msgid ""
-"The Diablo introduction cinematic is only available in the full retail "
-"version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
-msgstr ""
-"Úvodní filmová nahrávka pro Diablo je dostupná pouze v plné verzi hry "
-"Diablo. Pro koupi hry navštiv https://www.gog.com/game/diablo ."
+#: Source/DiabloUI/mainmenu.cpp:55
+#, fuzzy
+#| msgid "in the shareware"
+msgid "Shareware"
+msgstr "v shareware"
 
-#: Source/DiabloUI/progress.cpp:36 Source/DiabloUI/selconn.cpp:76
+#: Source/DiabloUI/progress.cpp:36 Source/DiabloUI/selconn.cpp:82
 #: Source/DiabloUI/selhero.cpp:189 Source/DiabloUI/selhero.cpp:214
 #: Source/DiabloUI/selhero.cpp:284 Source/DiabloUI/selhero.cpp:544
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: Source/DiabloUI/selconn.cpp:38 Source/DiabloUI/selgame.cpp:77
-#: Source/DiabloUI/selgame.cpp:375
+#: Source/DiabloUI/selconn.cpp:13
 msgid "Client-Server (TCP)"
 msgstr "Klient-Server (TCP)"
 
-#: Source/DiabloUI/selconn.cpp:41
+#: Source/DiabloUI/selconn.cpp:14
 msgid "Loopback"
 msgstr "Smyčka"
 
-#: Source/DiabloUI/selconn.cpp:47 Source/DiabloUI/selgame.cpp:437
-#: Source/DiabloUI/selgame.cpp:455
+#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:489
+#: Source/DiabloUI/selgame.cpp:510
 msgid "Multi Player Game"
 msgstr "Hra pro Více Hráčů"
 
-#: Source/DiabloUI/selconn.cpp:53
+#: Source/DiabloUI/selconn.cpp:59
 msgid "Requirements:"
 msgstr "Požadavky:"
 
-#: Source/DiabloUI/selconn.cpp:59
+#: Source/DiabloUI/selconn.cpp:65
 msgid "no gateway needed"
 msgstr "brána není potřeba"
 
-#: Source/DiabloUI/selconn.cpp:65
+#: Source/DiabloUI/selconn.cpp:71
 msgid "Select Connection"
 msgstr "Vyber typ připojení"
 
-#: Source/DiabloUI/selconn.cpp:68
+#: Source/DiabloUI/selconn.cpp:74
 msgid "Change Gateway"
 msgstr "Změň Bránu"
 
-#: Source/DiabloUI/selconn.cpp:101
+#: Source/DiabloUI/selconn.cpp:107
 msgid "All computers must be connected to a TCP-compatible network."
 msgstr "Všechny počítače musí být připojeny k TCP-kompatibilní síti."
 
-#: Source/DiabloUI/selconn.cpp:105
+#: Source/DiabloUI/selconn.cpp:111
 msgid "All computers must be connected to the internet."
 msgstr "Všechny počítače musí být připojeny k internetu."
 
-#: Source/DiabloUI/selconn.cpp:109
+#: Source/DiabloUI/selconn.cpp:115
 msgid "Play by yourself with no network exposure."
 msgstr "Hraj sám, bez jakéhokoli připojení do sítě."
 
-#: Source/DiabloUI/selconn.cpp:114
+#: Source/DiabloUI/selconn.cpp:120
 msgid "Players Supported: {:d}"
 msgstr "Možný Počet Hráčů: {:d}"
 
-#: Source/DiabloUI/selgame.cpp:80 Source/DiabloUI/selgame.cpp:378
+#: Source/DiabloUI/selgame.cpp:82 Source/DiabloUI/selgame.cpp:414
 msgid "Description:"
 msgstr "Popis:"
 
-#: Source/DiabloUI/selgame.cpp:86
+#: Source/DiabloUI/selgame.cpp:88
 msgid "Select Action"
 msgstr "Vyber Akci"
 
-#: Source/DiabloUI/selgame.cpp:88 Source/DiabloUI/selgame.cpp:152
-#: Source/DiabloUI/selgame.cpp:297
+#: Source/DiabloUI/selgame.cpp:91 Source/DiabloUI/selgame.cpp:181
+#: Source/DiabloUI/selgame.cpp:333
 msgid "Create Game"
 msgstr "Vytvoř Hru"
 
-#: Source/DiabloUI/selgame.cpp:89
+#: Source/DiabloUI/selgame.cpp:93
+#, fuzzy
+#| msgid "Create Game"
+msgid "Create Public Game"
+msgstr "Vytvoř Hru"
+
+#: Source/DiabloUI/selgame.cpp:94
 msgid "Join Game"
 msgstr "Připoj se ke Hře"
 
-#: Source/DiabloUI/selgame.cpp:97 Source/DiabloUI/selgame.cpp:167
-#: Source/DiabloUI/selgame.cpp:185 Source/DiabloUI/selgame.cpp:319
-#: Source/DiabloUI/selgame.cpp:393
+#: Source/DiabloUI/selgame.cpp:106 Source/DiabloUI/selgame.cpp:196
+#: Source/DiabloUI/selgame.cpp:214 Source/DiabloUI/selgame.cpp:355
+#: Source/DiabloUI/selgame.cpp:431
 msgid "CANCEL"
 msgstr "ZRUŠIT"
 
-#: Source/DiabloUI/selgame.cpp:106
+#: Source/DiabloUI/selgame.cpp:122
 msgid "Create a new game with a difficulty setting of your choice."
 msgstr "Vytvoří novou hru s obtížností jakou si zvolíš."
 
-#: Source/DiabloUI/selgame.cpp:109
+#: Source/DiabloUI/selgame.cpp:125
+#, fuzzy
+#| msgid "Create a new game with a difficulty setting of your choice."
+msgid ""
+"Create a new public game that anyone can join with a difficulty setting of "
+"your choice."
+msgstr "Vytvoří novou hru s obtížností jakou si zvolíš."
+
+#: Source/DiabloUI/selgame.cpp:128
 msgid ""
 "Enter an IP or a hostname and join a game already in progress at that "
 "address."
 msgstr "Zadej IP nebo název hry a připoj se ke hře vytvořené na dané adrese."
 
-#: Source/DiabloUI/selgame.cpp:155
+#: Source/DiabloUI/selgame.cpp:131
+#, fuzzy
+#| msgid ""
+#| "Enter an IP or a hostname and join a game already in progress at that "
+#| "address."
+msgid "Join the public game already in progress at this address."
+msgstr "Zadej IP nebo název hry a připoj se ke hře vytvořené na dané adrese."
+
+#: Source/DiabloUI/selgame.cpp:184
 msgid "Select Difficulty"
 msgstr "Vyber Obtížnost"
 
-#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
-#: Source/DiabloUI/selgame.cpp:308 Source/DiabloUI/selgame.cpp:328
-#: Source/diablo.cpp:1431
+#: Source/DiabloUI/selgame.cpp:186 Source/DiabloUI/selgame.cpp:239
+#: Source/DiabloUI/selgame.cpp:344 Source/DiabloUI/selgame.cpp:364
+#: Source/diablo.cpp:1446
 msgid "Normal"
 msgstr "Normal"
 
-#: Source/DiabloUI/selgame.cpp:158 Source/DiabloUI/selgame.cpp:208
-#: Source/diablo.cpp:1432
+#: Source/DiabloUI/selgame.cpp:187 Source/DiabloUI/selgame.cpp:243
+#: Source/diablo.cpp:1447
 msgid "Nightmare"
 msgstr "Nightmare"
 
-#: Source/DiabloUI/selgame.cpp:159 Source/DiabloUI/selgame.cpp:212
-#: Source/diablo.cpp:1433
+#: Source/DiabloUI/selgame.cpp:188 Source/DiabloUI/selgame.cpp:247
+#: Source/diablo.cpp:1448
 msgid "Hell"
 msgstr "Hell"
 
-#: Source/DiabloUI/selgame.cpp:173
+#: Source/DiabloUI/selgame.cpp:202
 msgid "Join TCP Games"
 msgstr "Připojit se k TCP Hrám"
 
-#: Source/DiabloUI/selgame.cpp:176 Source/DiabloUI/selgame.cpp:179
+#: Source/DiabloUI/selgame.cpp:205 Source/DiabloUI/selgame.cpp:208
 msgid "Enter address"
 msgstr "Zadej adresu"
 
-#: Source/DiabloUI/selgame.cpp:205
+#: Source/DiabloUI/selgame.cpp:240
 msgid ""
 "Normal Difficulty\n"
 "This is where a starting character should begin the quest to defeat Diablo."
@@ -478,7 +528,7 @@ msgstr ""
 "Obtížnost Normal\n"
 "Zde by měla začínající postava započít svoji výpravu k poražení Diabla."
 
-#: Source/DiabloUI/selgame.cpp:209
+#: Source/DiabloUI/selgame.cpp:244
 msgid ""
 "Nightmare Difficulty\n"
 "The denizens of the Labyrinth have been bolstered and will prove to be a "
@@ -488,7 +538,7 @@ msgstr ""
 "Obyvatelé Labyrintu byli posíleni a budou pro tebe opravdovou zkouškou. "
 "Doporučeno pouze pro zkušené postavy."
 
-#: Source/DiabloUI/selgame.cpp:213
+#: Source/DiabloUI/selgame.cpp:248
 msgid ""
 "Hell Difficulty\n"
 "The most powerful of the underworld's creatures lurk at the gateway into "
@@ -498,7 +548,7 @@ msgstr ""
 "Nejsilnější stvoření z podsvětí číhají u Pekelných bran. Pouze ty "
 "nejzkušenější postavy by měly vstoupit do tohoto světa."
 
-#: Source/DiabloUI/selgame.cpp:229
+#: Source/DiabloUI/selgame.cpp:264
 msgid ""
 "Your character must reach level 20 before you can enter a multiplayer game "
 "of Nightmare difficulty."
@@ -506,7 +556,7 @@ msgstr ""
 "Tvoje postava musí dosáhnout 20 úrovně než bude moci vstoupit do hry pro "
 "více hráčů na obtížnost Nightmare."
 
-#: Source/DiabloUI/selgame.cpp:231
+#: Source/DiabloUI/selgame.cpp:266
 msgid ""
 "Your character must reach level 30 before you can enter a multiplayer game "
 "of Hell difficulty."
@@ -514,23 +564,23 @@ msgstr ""
 "Tvoje postava musí dosáhnout 30 úrovně než bude moci vstoupit do hry pro "
 "více hráčů na obtížnost Hell."
 
-#: Source/DiabloUI/selgame.cpp:306
+#: Source/DiabloUI/selgame.cpp:342
 msgid "Select Game Speed"
 msgstr "Vyber Rychlost Hry"
 
-#: Source/DiabloUI/selgame.cpp:309 Source/DiabloUI/selgame.cpp:332
+#: Source/DiabloUI/selgame.cpp:345 Source/DiabloUI/selgame.cpp:368
 msgid "Fast"
 msgstr "Rychlá"
 
-#: Source/DiabloUI/selgame.cpp:310 Source/DiabloUI/selgame.cpp:336
+#: Source/DiabloUI/selgame.cpp:346 Source/DiabloUI/selgame.cpp:372
 msgid "Faster"
 msgstr "Rychlejší"
 
-#: Source/DiabloUI/selgame.cpp:311 Source/DiabloUI/selgame.cpp:340
+#: Source/DiabloUI/selgame.cpp:347 Source/DiabloUI/selgame.cpp:376
 msgid "Fastest"
 msgstr "Nejrychlejší"
 
-#: Source/DiabloUI/selgame.cpp:329
+#: Source/DiabloUI/selgame.cpp:365
 msgid ""
 "Normal Speed\n"
 "This is where a starting character should begin the quest to defeat Diablo."
@@ -538,7 +588,7 @@ msgstr ""
 "Běžná\n"
 "Zde by měla začínající postava započít svoji výpravu k poražení Diabla."
 
-#: Source/DiabloUI/selgame.cpp:333
+#: Source/DiabloUI/selgame.cpp:369
 msgid ""
 "Fast Speed\n"
 "The denizens of the Labyrinth have been hastened and will prove to be a "
@@ -548,7 +598,7 @@ msgstr ""
 "Obyvatelé Labyrintu byli zrychleni a budou pro tebe opravdovou zkouškou. "
 "Doporučeno pouze pro zkušené postavy."
 
-#: Source/DiabloUI/selgame.cpp:337
+#: Source/DiabloUI/selgame.cpp:373
 msgid ""
 "Faster Speed\n"
 "Most monsters of the dungeon will seek you out quicker than ever before. "
@@ -558,7 +608,7 @@ msgstr ""
 "Většina potvor v Labyrintu tě najde rychleji než kdykoli předtím. Pouze "
 "zkušený šampion by měl zkusit štěstí na této rychlosti."
 
-#: Source/DiabloUI/selgame.cpp:341
+#: Source/DiabloUI/selgame.cpp:377
 msgid ""
 "Fastest Speed\n"
 "The minions of the underworld will rush to attack without hesitation. Only a "
@@ -568,16 +618,16 @@ msgstr ""
 "Pohůnci z podsvětí budou spěchat do útoku bez sebemenšího zaváhání. Pouze "
 "pravý rychlostní démon by měl hrát s tímto nastavením."
 
-#: Source/DiabloUI/selgame.cpp:384 Source/DiabloUI/selgame.cpp:387
+#: Source/DiabloUI/selgame.cpp:420 Source/DiabloUI/selgame.cpp:425
 msgid "Enter Password"
 msgstr "Zadej Heslo"
 
-#: Source/DiabloUI/selgame.cpp:410
+#: Source/DiabloUI/selgame.cpp:448
 msgid "The host is running a different game than you."
 msgstr "Host má spuštěnou jinou hru než ty."
 
 #. TRANSLATORS: Error message when somebody tries to join a game running another version.
-#: Source/DiabloUI/selgame.cpp:413
+#: Source/DiabloUI/selgame.cpp:451
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr "Tvoje verze {:s} neodpovídá verzi hosta {:d}.{:d}.{:d}."
 
@@ -710,18 +760,24 @@ msgstr "Smazat Hrdinu Hry pro Jednoho Hráče"
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "Opravdu chceš smazat postavu \"{:s}\"?"
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selstart.cpp:43
+#, fuzzy
+#| msgid "Exit Hellfire"
+msgid "Enter Hellfire"
+msgstr "Ukonči Hellfire"
+
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr "Ano"
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr "Ne"
 
 #: Source/DiabloUI/support_lines.cpp:8
 msgid ""
-"We maintains a chat server at Discord.gg/YQKCAYQ Follow the links to join "
-"our community where we talk about things related to Diablo, and the Hellfire "
+"We maintain a chat server at Discord.gg/YQKCAYQ Follow the links to join our "
+"community where we talk about things related to Diablo, and the Hellfire "
 "expansion."
 msgstr ""
 
@@ -731,10 +787,11 @@ msgid ""
 "this address: https://github.com/diasurgical/devilutionX To help us better "
 "serve you, please be sure to include the version number, operating system, "
 "and the nature of the problem."
-msgstr "DevilutionX spravuje Diasurgical, problémy a chyby můžete hlásit "
-"na této adrese: https://github.com/diasurgical/devilutionX "
-"Abychom vám mohli lépe pomoci, prosím uveďte číslo verze hry, "
-"váš operační systém a popište váš problém."
+msgstr ""
+"DevilutionX spravuje Diasurgical, problémy a chyby můžete hlásit na této "
+"adrese: https://github.com/diasurgical/devilutionX Abychom vám mohli lépe "
+"pomoci, prosím uveďte číslo verze hry, váš operační systém a popište váš "
+"problém."
 
 #: Source/DiabloUI/support_lines.cpp:13
 msgid "Disclaimer:"
@@ -754,6 +811,7 @@ msgstr ""
 "ohledně DevilutionX by měly být směřovány k Diasurgical, nikoliv k Blizzard "
 "Entertainment nebo GOG.com."
 
+#: Source/DiabloUI/support_lines.cpp:17
 msgid ""
 "\tThis port makes use of CharisSILB, Unifont, and Noto which are licensed "
 "under the SIL Open Font License, as well as Twitmoji which is licensed under "
@@ -765,12 +823,12 @@ msgstr ""
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr "Copyright © 1996-2001 Blizzard Entertainment"
 
-#: Source/appfat.cpp:37
+#: Source/appfat.cpp:38
 msgid "Error"
 msgstr "Chyba"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:101
+#: Source/appfat.cpp:102
 msgid ""
 "{:s}\n"
 "\n"
@@ -780,7 +838,7 @@ msgstr ""
 "\n"
 "Chyba nastala v: {:s} řádek {:d}"
 
-#: Source/appfat.cpp:115
+#: Source/appfat.cpp:117
 msgid ""
 "Unable to open main data archive ({:s}).\n"
 "\n"
@@ -790,15 +848,12 @@ msgstr ""
 "\n"
 "Ujistěte se, že je výše uvedený soubor ve složce se hrou."
 
-msgid "diabdat.mpq or spawn.mpq"
-msgstr "diabdat.mpq nebo spawn.mpq"
-
-#: Source/appfat.cpp:119
+#: Source/appfat.cpp:123
 msgid "Data File Error"
 msgstr "Chyba Datového Souboru"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:127
+#: Source/appfat.cpp:131
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -806,177 +861,183 @@ msgstr ""
 "Nelze zapisovat do umístění:\n"
 "{:s}"
 
-#: Source/appfat.cpp:129
+#: Source/appfat.cpp:133
 msgid "Read-Only Directory Error"
 msgstr "Chyba - Adresář Pouze pro Čtení"
 
-#: Source/automap.cpp:464
+#: Source/automap.cpp:484
 msgid "game: "
 msgstr "hra: "
 
-#: Source/automap.cpp:470
+#: Source/automap.cpp:490
 msgid "password: "
 msgstr "heslo: "
 
-#: Source/automap.cpp:483
+#: Source/automap.cpp:492
+#, fuzzy
+#| msgid "Quit Game"
+msgid "Public Game"
+msgstr "Ukonči Hru"
+
+#: Source/automap.cpp:504
 msgid "Level: Nest {:d}"
 msgstr "Patro: Hnízdo {:d}"
 
-#: Source/automap.cpp:485
+#: Source/automap.cpp:506
 msgid "Level: Crypt {:d}"
 msgstr "Patro: Krypta {:d}"
 
-#: Source/automap.cpp:487 Source/items.cpp:2078
+#: Source/automap.cpp:508 Source/items.cpp:2090
 msgid "Level: {:d}"
 msgstr "Patro: {:d}"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr "Tab"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr "Esc"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Enter"
 msgstr "Zadej Jméno"
 
-#: Source/control.cpp:202
+#: Source/control.cpp:215
 msgid "Character Information"
 msgstr "Informace o Postavě"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr "Deník úkolů"
 
-#: Source/control.cpp:204
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr "Automapa"
 
-#: Source/control.cpp:205
+#: Source/control.cpp:218
 msgid "Main Menu"
 msgstr "Hlavní Menu"
 
-#: Source/control.cpp:206
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr "Inventář"
 
-#: Source/control.cpp:207
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr "Kniha kouzel"
 
-#: Source/control.cpp:208
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr "Odešli Zprávu"
 
-#: Source/control.cpp:750 Source/control.cpp:1557
+#: Source/control.cpp:718 Source/control.cpp:1587
 msgid "Skill"
 msgstr "Dovednost"
 
-#: Source/control.cpp:751 Source/control.cpp:1211
+#: Source/control.cpp:719 Source/control.cpp:1237
 msgid "{:s} Skill"
 msgstr "Dovednost {:s}"
 
-#: Source/control.cpp:757
+#: Source/control.cpp:725
 msgid "Spell"
 msgstr "Kouzlo"
 
-#: Source/control.cpp:758 Source/control.cpp:1215
+#: Source/control.cpp:726 Source/control.cpp:1241
 msgid "{:s} Spell"
 msgstr "Kouzlo {:s}"
 
-#: Source/control.cpp:760
+#: Source/control.cpp:728
 msgid "Damages undead only"
 msgstr "Zraňuje pouze nemrtvé"
 
-#: Source/control.cpp:764 Source/control.cpp:1219 Source/control.cpp:1581
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr "Kouzlo Úrovně 0 - Nefunguje"
 
-#: Source/control.cpp:766 Source/control.cpp:1221 Source/control.cpp:1583
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 msgid "Spell Level {:d}"
 msgstr "Kouzlo Úrovně {:d}"
 
-#: Source/control.cpp:773
+#: Source/control.cpp:741
 msgid "Scroll"
 msgstr "Svitek"
 
-#: Source/control.cpp:774 Source/control.cpp:1225
+#: Source/control.cpp:742 Source/control.cpp:1251
 msgid "Scroll of {:s}"
 msgstr "Svitek {:s}"
 
-#: Source/control.cpp:779 Source/control.cpp:1231
+#: Source/control.cpp:747 Source/control.cpp:1257
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "{:d} Svitek"
 msgstr[1] "{:d} Svitky"
 msgstr[2] "{:d} Svitků"
 
-#: Source/control.cpp:785 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
 #: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
 msgid "Staff"
 msgstr "Hůl"
 
-#: Source/control.cpp:786 Source/control.cpp:1235 Source/items.cpp:1319
+#: Source/control.cpp:755 Source/control.cpp:1261
 msgid "Staff of {:s}"
 msgstr "Hůl - {:s}"
 
-#: Source/control.cpp:788 Source/control.cpp:1237
+#: Source/control.cpp:757 Source/control.cpp:1263
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "{:d} Použití"
 msgstr[1] "{:d} Použití"
 msgstr[2] "{:d} Použití"
 
-#: Source/control.cpp:798
+#: Source/control.cpp:767
 msgid "Spell Hotkey {:s}"
 msgstr "Klávesová Zkratka Kouzla {:s}"
 
-#: Source/control.cpp:1188
+#: Source/control.cpp:1214
 msgid "Player friendly"
 msgstr "Neútočit na hráče"
 
-#: Source/control.cpp:1190
+#: Source/control.cpp:1216
 msgid "Player attack"
 msgstr "Útočit na hráče"
 
-#: Source/control.cpp:1193
+#: Source/control.cpp:1219
 msgid "Hotkey: {:s}"
 msgstr "Klávesová Zkratka: {:s}"
 
-#: Source/control.cpp:1201
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr "Tlačítko pro výběr kouzla"
 
-#: Source/control.cpp:1204
+#: Source/control.cpp:1230
 msgid "Hotkey: 's'"
 msgstr "Klávesová Zkratka: 's'"
 
-#: Source/control.cpp:1359 Source/inv.cpp:1892 Source/items.cpp:3746
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "{:d} zlaťák"
 msgstr[1] "{:d} zlaťáky"
 msgstr[2] "{:d} zlaťáků"
 
-#: Source/control.cpp:1362
+#: Source/control.cpp:1390
 msgid "Requirements not met"
 msgstr "Nesplňuješ požadavky"
 
-#: Source/control.cpp:1398
+#: Source/control.cpp:1426
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Úroveň: {:d}"
 
-#: Source/control.cpp:1400
+#: Source/control.cpp:1428
 msgid "Hit Points {:d} of {:d}"
 msgstr "Životy {:d} ze {:d}"
 
-#: Source/control.cpp:1427
+#: Source/control.cpp:1457
 msgid "Level Up"
 msgstr "Nová úroveň"
 
-#: Source/control.cpp:1561
+#: Source/control.cpp:1591
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] "Hůl ({:d} použití)"
@@ -984,22 +1045,22 @@ msgstr[1] "Hůl ({:d} použití)"
 msgstr[2] "Hůl ({:d} použití)"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1571
+#: Source/control.cpp:1601
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "Mana: {:d}  Poš: {:d} - {:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1573
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "Mana: {:d}  Poš: n/a"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1576
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "Mana: {:d}  Poš: 1/3 hp cíle"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1634
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] "Máš {:d} zlaťák. Kolik jich chceš odebrat?"
@@ -1050,94 +1111,113 @@ msgstr "Bezbožný Oltář"
 msgid "level 15"
 msgstr "15. patro"
 
-#: Source/diablo.cpp:112
+#: Source/diablo.cpp:114
 msgid "I need help! Come Here!"
 msgstr "Potřebuji pomoc! Pojď sem!"
 
-#: Source/diablo.cpp:113
+#: Source/diablo.cpp:115
 msgid "Follow me."
 msgstr "Následuj mě."
 
-#: Source/diablo.cpp:114
+#: Source/diablo.cpp:116
 msgid "Here's something for you."
 msgstr "Tady je něco pro tebe."
 
-#: Source/diablo.cpp:115
+#: Source/diablo.cpp:117
 msgid "Now you DIE!"
 msgstr "Teď chcípneš!"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:779
+#: Source/diablo.cpp:781
 msgid "Options:\n"
 msgstr "Nastavení:\n"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:780
+#: Source/diablo.cpp:782
 msgid "Print this message and exit"
 msgstr "Zobraz tuto zprávu a ukonči"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:781
+#: Source/diablo.cpp:783
 msgid "Print the version and exit"
 msgstr "Zobraz verzi a ukonči"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:782
+#: Source/diablo.cpp:784
 msgid "Specify the folder of diabdat.mpq"
 msgstr "Vyber složku se souborem diabdat.mpq"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:783
+#: Source/diablo.cpp:785
 msgid "Specify the folder of save files"
 msgstr "Vyber složku pro uložené hry"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:784
+#: Source/diablo.cpp:786
 msgid "Specify the location of diablo.ini"
 msgstr "Vyber složku pro soubor diablo.ini"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:785
+#: Source/diablo.cpp:787
 msgid "Skip startup videos"
 msgstr "Přeskoč startovní videa"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:786
+#: Source/diablo.cpp:788
 msgid "Display frames per second"
 msgstr "Zobraz smínky za vteřinu"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:787
+#: Source/diablo.cpp:789
 msgid "Run in windowed mode"
 msgstr "Spusť hru v okně"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:788
+#: Source/diablo.cpp:790
 msgid "Enable verbose logging"
 msgstr "Zapni důkladné logování"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:789
-msgid "Force spawn mode even if diabdat.mpq is found"
-msgstr "Spusť hru ve spawn módu i když bude diabdat.mpq nalezen"
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:790
+#: Source/diablo.cpp:791
 msgid "Record a demo file"
 msgstr "Nahrát demo soubor"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:791
+#: Source/diablo.cpp:792
 msgid "Play a demo file"
 msgstr "Přehrát demo soubor"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:792
+#: Source/diablo.cpp:793
 msgid "Disable all frame limiting during demo playback"
 msgstr "Vypnout omezení snímků během přehrávání dema"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:793
+#: Source/diablo.cpp:794
+msgid ""
+"\n"
+"Game selection:\n"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:795
+msgid "Force Shareware mode"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:796
+msgid "Force Diablo mode"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:797
+#, fuzzy
+#| msgid "Hellfire Help"
+msgid "Force Hellfire mode"
+msgstr "Nápověda k Hellfire"
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:798
 msgid ""
 "\n"
 "Hellfire options:\n"
@@ -1146,16 +1226,11 @@ msgstr ""
 "Hellfire nastavení:\n"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:794
-msgid "Force diablo mode even if hellfire.mpq is found"
-msgstr "Spusť hru v diablo módu i když bude hellfire.mpq nalezen"
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:795
+#: Source/diablo.cpp:799
 msgid "Use alternate nest palette"
 msgstr "Použij alternativní paletu pro hnízdo"
 
-#: Source/diablo.cpp:801
+#: Source/diablo.cpp:805
 msgid ""
 "\n"
 "Report bugs at https://github.com/diasurgical/devilutionX/\n"
@@ -1163,44 +1238,44 @@ msgstr ""
 "\n"
 "Chyby hlašte na https://github.com/diasurgical/devilutionX/\n"
 
-#: Source/diablo.cpp:865
+#: Source/diablo.cpp:869
 msgid "unrecognized option '{:s}'\n"
 msgstr "neznámá volba '{:s}'\n"
 
-#: Source/diablo.cpp:896
+#: Source/diablo.cpp:900
 msgid "version {:s}"
 msgstr "verze {:s}"
 
-#: Source/diablo.cpp:1203
+#: Source/diablo.cpp:1218
 msgid "-- Network timeout --"
 msgstr "-- Vypadlo spojení --"
 
-#: Source/diablo.cpp:1204
+#: Source/diablo.cpp:1219
 msgid "-- Waiting for players --"
 msgstr "-- Čekám na hráče --"
 
-#: Source/diablo.cpp:1223
+#: Source/diablo.cpp:1238
 msgid "No help available"
 msgstr "Žádná nápověda"
 
-#: Source/diablo.cpp:1224
+#: Source/diablo.cpp:1239
 msgid "while in stores"
 msgstr "v obchodech"
 
 #. TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty.
-#: Source/diablo.cpp:1436
+#: Source/diablo.cpp:1451
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr "{:s}, verze = {:s}, mód = {:s}"
 
-#: Source/dvlnet/loopback.cpp:111
+#: Source/dvlnet/loopback.cpp:113
 msgid "loopback"
 msgstr "zpětná vazba"
 
-#: Source/dvlnet/tcp_client.cpp:68
+#: Source/dvlnet/tcp_client.cpp:65
 msgid "Unable to connect"
 msgstr "Nelze se připojit"
 
-#: Source/dvlnet/tcp_client.cpp:89
+#: Source/dvlnet/tcp_client.cpp:86
 msgid "error: read 0 bytes from server"
 msgstr "chyba: přečteno 0 bytů ze serveru"
 
@@ -1484,10 +1559,6 @@ msgstr "Kontrast"
 msgid "Speed"
 msgstr "Rychlost Hry"
 
-#: Source/gamemenu.cpp:61
-msgid "Previous Menu"
-msgstr "Předchozí Menu"
-
 #: Source/gamemenu.cpp:68
 msgid "Music Disabled"
 msgstr "Hudba Vypnuta"
@@ -1661,7 +1732,9 @@ msgstr ""
 "klávesnici, nebo kliknutím na předmět pomocí pravého tlačítka myši."
 
 #: Source/help.cpp:68
-msgid "$Gold"
+#, fuzzy
+#| msgid "$Gold"
+msgid "$Gold:"
 msgstr "$Zlaťáky"
 
 #: Source/help.cpp:69
@@ -1691,7 +1764,9 @@ msgstr ""
 "tlačítkem myši do herní obrazovky."
 
 #: Source/help.cpp:79
-msgid "$Using the Speedbook for Spells"
+#, fuzzy
+#| msgid "$Using the Speedbook for Spells"
+msgid "$Using the Speedbook for Spells:"
 msgstr "$Používání Rychlé Volby pro Kouzla"
 
 #: Source/help.cpp:80
@@ -1706,15 +1781,21 @@ msgstr ""
 "obrazovky."
 
 #: Source/help.cpp:84
+#, fuzzy
+#| msgid ""
+#| "Shift + Left-clicking on the 'select current spell' button will clear the "
+#| "readied spell"
 msgid ""
 "Shift + Left-clicking on the 'select current spell' button will clear the "
-"readied spell"
+"readied spell."
 msgstr ""
 "Kliknutím Shift + Levé tlačítko myši na aktuální kouzlo můžeš odebrat "
 "vybrané kouzlo"
 
 #: Source/help.cpp:86
-msgid "$Setting Spell Hotkeys"
+#, fuzzy
+#| msgid "$Setting Spell Hotkeys"
+msgid "$Setting Spell Hotkeys:"
 msgstr "$Nastavení Klávesových Zkratek pro Kouzla"
 
 #: Source/help.cpp:87
@@ -1729,7 +1810,9 @@ msgstr ""
 "z kláves F5, F6, F7 nebo F8."
 
 #: Source/help.cpp:92
-msgid "$Spell Books"
+#, fuzzy
+#| msgid "$Spell Books"
+msgid "$Spell Books:"
 msgstr "$Knihy Kouzel"
 
 #: Source/help.cpp:93
@@ -1740,31 +1823,35 @@ msgstr ""
 "Čtením více než jedné knihy zvyšuješ svou znalost daného kouzla, což ti "
 "umožní čarovat dané kouzlo efektivněji."
 
-#: Source/help.cpp:129
+#: Source/help.cpp:181
 msgid "Shareware Hellfire Help"
 msgstr "Nápověda k Shareware Hellfire"
 
-#: Source/help.cpp:129
+#: Source/help.cpp:181
 msgid "Hellfire Help"
 msgstr "Nápověda k Hellfire"
 
-#: Source/help.cpp:131
+#: Source/help.cpp:183
 msgid "Shareware Diablo Help"
 msgstr "Nápověda k Shareware Diablu"
 
-#: Source/help.cpp:131
+#: Source/help.cpp:183
 msgid "Diablo Help"
 msgstr "Nápověda k Diablu"
 
-#: Source/help.cpp:155
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr "Stiskni ESC pro ukončení, šipky pro posun."
 
-#: Source/init.cpp:217
+#: Source/init.cpp:175
+msgid "diabdat.mpq or spawn.mpq"
+msgstr "diabdat.mpq nebo spawn.mpq"
+
+#: Source/init.cpp:196
 msgid "Some Hellfire MPQs are missing"
 msgstr "Některé Hellfire MPQ soubory chybí"
 
-#: Source/init.cpp:217
+#: Source/init.cpp:196
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
@@ -1772,11 +1859,11 @@ msgstr ""
 "Ne všechny Hellfire MPQ soubory nalezeny.\n"
 "Překopírujte všechny hf*.mpq soubory."
 
-#: Source/init.cpp:225
+#: Source/init.cpp:204
 msgid "Unable to create main window"
 msgstr "Nelze vytvořit hlavní okno"
 
-#: Source/itemdat.cpp:16 Source/itemdat.cpp:198 Source/panels/charpanel.cpp:154
+#: Source/itemdat.cpp:16 Source/itemdat.cpp:198 Source/panels/charpanel.cpp:155
 msgid "Gold"
 msgstr "Zlaťáky"
 
@@ -1916,7 +2003,7 @@ msgstr "Lazarusova Hůl"
 msgid "Scroll of Resurrect"
 msgstr "Svitek Oživení"
 
-#: Source/itemdat.cpp:51 Source/itemdat.cpp:99 Source/items.cpp:165
+#: Source/itemdat.cpp:51 Source/itemdat.cpp:99 Source/items.cpp:166
 msgid "Blacksmith Oil"
 msgstr "Kovářský Olej"
 
@@ -2016,7 +2103,7 @@ msgid "Quilted Armor"
 msgstr "Prošívané Brnění"
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
-#: Source/itemdat.cpp:77 Source/objects.cpp:5459
+#: Source/itemdat.cpp:77 Source/objects.cpp:5433
 msgid "Armor"
 msgstr "Brnění"
 
@@ -2111,11 +2198,11 @@ msgstr "Lektvar Omlazení"
 msgid "Potion of Full Rejuvenation"
 msgstr "Lektvar Plného Omlazení"
 
-#: Source/itemdat.cpp:100 Source/items.cpp:160
+#: Source/itemdat.cpp:100 Source/items.cpp:161
 msgid "Oil of Accuracy"
 msgstr "Olej Přesnosti"
 
-#: Source/itemdat.cpp:101 Source/items.cpp:162
+#: Source/itemdat.cpp:101 Source/items.cpp:163
 msgid "Oil of Sharpness"
 msgstr "Olej Ostrosti"
 
@@ -2433,7 +2520,7 @@ msgstr "Mithrilový"
 msgid "Meteoric"
 msgstr "Meteorický"
 
-#: Source/itemdat.cpp:202 Source/objects.cpp:104
+#: Source/itemdat.cpp:202 Source/objects.cpp:107
 msgid "Weird"
 msgstr "Divný"
 
@@ -2569,7 +2656,7 @@ msgstr "Posvátný"
 msgid "Awesome"
 msgstr "Úžasný"
 
-#: Source/itemdat.cpp:237 Source/objects.cpp:116
+#: Source/itemdat.cpp:237 Source/objects.cpp:119
 msgid "Holy"
 msgstr "Svatý"
 
@@ -3530,693 +3617,715 @@ msgstr "Amulet Ministranta"
 msgid "Gladiator's Ring"
 msgstr "Gladiátorův Prsten"
 
-#: Source/items.cpp:161
+#: Source/items.cpp:162
 msgid "Oil of Mastery"
 msgstr "Olej Mistrovství"
 
-#: Source/items.cpp:163
+#: Source/items.cpp:164
 msgid "Oil of Death"
 msgstr "Olej Smrti"
 
-#: Source/items.cpp:164
+#: Source/items.cpp:165
 msgid "Oil of Skill"
 msgstr "Olej Dovednosti"
 
-#: Source/items.cpp:166
+#: Source/items.cpp:167
 msgid "Oil of Fortitude"
 msgstr "Olej Statečnosti"
 
-#: Source/items.cpp:167
+#: Source/items.cpp:168
 msgid "Oil of Permanence"
 msgstr "Olej Stálosti"
 
-#: Source/items.cpp:168
+#: Source/items.cpp:169
 msgid "Oil of Hardening"
 msgstr "Olej Tvrdnutí"
 
-#: Source/items.cpp:169
+#: Source/items.cpp:170
 msgid "Oil of Imperviousness"
 msgstr "Olej Nepropustnosti"
 
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#: Source/items.cpp:1174 Source/items.cpp:1184 Source/items.cpp:1233
-#: Source/items.cpp:1269
-msgid "{0} {1}"
-msgstr ""
-
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's Staff of Firewall
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Long Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1187 Source/items.cpp:1254 Source/items.cpp:1273
-#: Source/items.cpp:1315
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
+#, fuzzy
+#| msgid "{0} of {1}"
+msgctxt "spell"
 msgid "{0} of {1}"
 msgstr "{:s} {:s}"
 
-#: Source/items.cpp:1894 Source/items.cpp:1906
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+#, fuzzy
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} {:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+#, fuzzy
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} {:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
+#: Source/items.cpp:1217
+msgid "{0} {1}"
+msgstr ""
+
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
+msgid "{0} of {1}"
+msgstr "{:s} {:s}"
+
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr "zvyšuje u zbraně"
 
-#: Source/items.cpp:1896
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr "šanci na zásah"
 
-#: Source/items.cpp:1900
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr "výrazně zvyšuje"
 
-#: Source/items.cpp:1902
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr "u zbraně šanci na zásah"
 
-#: Source/items.cpp:1908
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr "potenciál poškození"
 
-#: Source/items.cpp:1912
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr "výrazně zvyšuje u zbraně"
 
-#: Source/items.cpp:1914
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr "potenciál poškození - ne u luku"
 
-#: Source/items.cpp:1918
+#: Source/items.cpp:1930
 msgid "reduces attributes needed"
 msgstr "snižuje potřebné atributy"
 
-#: Source/items.cpp:1920
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr "pro používání zbroje a zbraní"
 
-#: Source/items.cpp:1924
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr "doplňuje 20% z"
 
-#: Source/items.cpp:1926
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr "výdrže předmětu"
 
-#: Source/items.cpp:1930
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr "zvyšuje současnou a"
 
-#: Source/items.cpp:1932
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr "maximální výdrž předmětu"
 
-#: Source/items.cpp:1936
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr "udělá předmět nezničitelným"
 
-#: Source/items.cpp:1940
+#: Source/items.cpp:1952
 msgid "increases the armor class"
 msgstr "zvýší obranné číslo"
 
-#: Source/items.cpp:1942
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr "zbroje nebo štítu"
 
-#: Source/items.cpp:1946
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr "výrazně zvýší obranné číslo"
 
-#: Source/items.cpp:1948
+#: Source/items.cpp:1960
 msgid "class of armor and shields"
 msgstr "zbroje nebo štítu"
 
-#: Source/items.cpp:1952 Source/items.cpp:1961
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr "nastraží ohnivou past"
 
-#: Source/items.cpp:1957
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr "nastraží bleskovou past"
 
-#: Source/items.cpp:1965
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr "nastraží past zkamenění"
 
-#: Source/items.cpp:1969
+#: Source/items.cpp:1981
 msgid "restore all life"
 msgstr "doplní všechny životy"
 
-#: Source/items.cpp:1973
+#: Source/items.cpp:1985
 msgid "restore some life"
 msgstr "doplní část životů"
 
-#: Source/items.cpp:1977
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr "doplní životy"
 
-#: Source/items.cpp:1981
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr "smrtící léčení"
 
-#: Source/items.cpp:1985
+#: Source/items.cpp:1997
 msgid "restore some mana"
 msgstr "doplní část many"
 
-#: Source/items.cpp:1989
+#: Source/items.cpp:2001
 msgid "restore all mana"
 msgstr "doplní všechnu manu"
 
-#: Source/items.cpp:1993
+#: Source/items.cpp:2005
 msgid "increase strength"
 msgstr "zvýší sílu"
 
-#: Source/items.cpp:1997
+#: Source/items.cpp:2009
 msgid "increase magic"
 msgstr "zvýší magii"
 
-#: Source/items.cpp:2001
+#: Source/items.cpp:2013
 msgid "increase dexterity"
 msgstr "zvýší obratnost"
 
-#: Source/items.cpp:2005
+#: Source/items.cpp:2017
 msgid "increase vitality"
 msgstr "zvýší vitalitu"
 
-#: Source/items.cpp:2010
+#: Source/items.cpp:2022
 msgid "decrease strength"
 msgstr "sníží sílu"
 
-#: Source/items.cpp:2014
+#: Source/items.cpp:2026
 msgid "decrease dexterity"
 msgstr "sníží obratnost"
 
-#: Source/items.cpp:2018
+#: Source/items.cpp:2030
 msgid "decrease vitality"
 msgstr "sníží vitalitu"
 
-#: Source/items.cpp:2022
+#: Source/items.cpp:2034
 msgid "restore some life and mana"
 msgstr "doplní část životů a many"
 
-#: Source/items.cpp:2026
+#: Source/items.cpp:2038
 msgid "restore all life and mana"
 msgstr "doplní všechny životy a manu"
 
-#: Source/items.cpp:2041 Source/items.cpp:2066
+#: Source/items.cpp:2053 Source/items.cpp:2078
 msgid "Right-click to read"
 msgstr "Přečtení - klikni Pravým"
 
-#: Source/items.cpp:2045
+#: Source/items.cpp:2057
 msgid "Right-click to read, then"
 msgstr "Přečtení - klikni Pravým, poté"
 
-#: Source/items.cpp:2047
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr "klikni Levým na cíl"
 
-#: Source/items.cpp:2052
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr "Použití - klikni Pravým"
 
-#: Source/items.cpp:2057 Source/items.cpp:2062
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr "Použití - klikni Pravým"
 
-#: Source/items.cpp:2070
+#: Source/items.cpp:2082
 msgid "Right click to read"
 msgstr "Přečtení - klikni Pravým"
 
-#: Source/items.cpp:2074
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr "Zobrazení - klikni Pravým"
 
-#: Source/items.cpp:2082
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr "Zdvojnásobí kapacitu hromádek zlata"
 
-#: Source/items.cpp:2094 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 msgid "Required:"
 msgstr "Požadavky:"
 
-#: Source/items.cpp:2096 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 msgid " {:d} Str"
 msgstr " {:d} Síla"
 
-#: Source/items.cpp:2098 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 msgid " {:d} Mag"
 msgstr " {:d} Magie"
 
-#: Source/items.cpp:2100 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 msgid " {:d} Dex"
 msgstr " {:d} Obrat"
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3530 Source/player.cpp:3027
+#: Source/items.cpp:3533 Source/player.cpp:3018
 msgid "Ear of {:s}"
 msgstr "Ucho od {:s}"
 
-#: Source/items.cpp:3825
+#: Source/items.cpp:3828
 msgid "chance to hit: {:+d}%"
 msgstr "šance na zásah: {:+d}%"
 
-#: Source/items.cpp:3829
+#: Source/items.cpp:3832
 #, no-c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% poškození"
 
-#: Source/items.cpp:3833 Source/items.cpp:4089
+#: Source/items.cpp:3836 Source/items.cpp:4092
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "na zásah: {:+d}%, {:+d}% poškození"
 
-#: Source/items.cpp:3837
+#: Source/items.cpp:3840
 #, no-c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% obrana"
 
-#: Source/items.cpp:3841
+#: Source/items.cpp:3844
 msgid "armor class: {:d}"
 msgstr "obranné číslo: {:d}"
 
-#: Source/items.cpp:3846 Source/items.cpp:4071
+#: Source/items.cpp:3849 Source/items.cpp:4074
 msgid "Resist Fire: {:+d}%"
 msgstr "Odolnost Oheň: {:+d}%"
 
-#: Source/items.cpp:3848
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr "Odolnost Oheň: 75% MAX"
 
-#: Source/items.cpp:3853
+#: Source/items.cpp:3856
 msgid "Resist Lightning: {:+d}%"
 msgstr "Odolnost Blesky: {:+d}%"
 
-#: Source/items.cpp:3855
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr "Odolnost Blesky: 75% MAX"
 
-#: Source/items.cpp:3860
+#: Source/items.cpp:3863
 msgid "Resist Magic: {:+d}%"
 msgstr "Odolnost Magie: {:+d}%"
 
-#: Source/items.cpp:3862
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr "Odolnost Magie: 75% MAX"
 
-#: Source/items.cpp:3867
+#: Source/items.cpp:3870
 msgid "Resist All: {:+d}%"
 msgstr "Odolnost Vše: {:+d}%"
 
-#: Source/items.cpp:3869
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr "Odolnost Vše: 75% MAX"
 
-#: Source/items.cpp:3873
+#: Source/items.cpp:3876
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] "kouzla navýšena o {:d} úroveň"
 msgstr[1] "kouzla navýšena o {:d} úrovně"
 msgstr[2] "kouzla navýšena o {:d} úrovní"
 
-#: Source/items.cpp:3875
+#: Source/items.cpp:3878
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "kouzla snížena o {:d} úroveň"
 msgstr[1] "kouzla snížena o {:d} úrovně"
 msgstr[2] "kouzla snížena o {:d} úrovní"
 
-#: Source/items.cpp:3877
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr "úroveň kouzel beze změn"
 
-#: Source/items.cpp:3880
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr "Použití navíc"
 
-#: Source/items.cpp:3883
+#: Source/items.cpp:3886
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:d} {:s} použití"
 msgstr[1] "{:d} {:s} použití"
 msgstr[2] "{:d} {:s} použití"
 
-#: Source/items.cpp:3887
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr "Poškození ohněm: {:d}"
 
-#: Source/items.cpp:3889
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "Poškození ohněm: {:d}-{:d}"
 
-#: Source/items.cpp:3893
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr "Poškození bleskem: {:d}"
 
-#: Source/items.cpp:3895
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "Poškození bleskem: {:d}-{:d}"
 
-#: Source/items.cpp:3899
+#: Source/items.cpp:3902
 msgid "{:+d} to strength"
 msgstr "{:+d} síla"
 
-#: Source/items.cpp:3903
+#: Source/items.cpp:3906
 msgid "{:+d} to magic"
 msgstr "{:+d} magie"
 
-#: Source/items.cpp:3907
+#: Source/items.cpp:3910
 msgid "{:+d} to dexterity"
 msgstr "{:+d} obratnost"
 
-#: Source/items.cpp:3911
+#: Source/items.cpp:3914
 msgid "{:+d} to vitality"
 msgstr "{:+d} vitalita"
 
-#: Source/items.cpp:3915
+#: Source/items.cpp:3918
 msgid "{:+d} to all attributes"
 msgstr "{:+d} ke všem statistikám"
 
-#: Source/items.cpp:3919
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} poškození od nepřátel"
 
-#: Source/items.cpp:3923
+#: Source/items.cpp:3926
 msgid "Hit Points: {:+d}"
 msgstr "Životy {:+d}"
 
-#: Source/items.cpp:3927
+#: Source/items.cpp:3930
 msgid "Mana: {:+d}"
 msgstr "Mana: {:+d}"
 
-#: Source/items.cpp:3930
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr "vysoká výdrž"
 
-#: Source/items.cpp:3933
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr "snížená výdrž"
 
-#: Source/items.cpp:3936
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr "nezničitelný"
 
-#: Source/items.cpp:3939
+#: Source/items.cpp:3942
 #, no-c-format
 msgid "+{:d}% light radius"
 msgstr "+{:d}% osvětlení"
 
-#: Source/items.cpp:3942
+#: Source/items.cpp:3945
 #, no-c-format
 msgid "-{:d}% light radius"
 msgstr "-{:d}% osvětlení"
 
-#: Source/items.cpp:3945
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr "střílí více šípů současně"
 
-#: Source/items.cpp:3949
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr "poškození ohnivým šípem: {:d}"
 
-#: Source/items.cpp:3951
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "poškození ohnivým šípem: {:d}-{:d}"
 
-#: Source/items.cpp:3955
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr "poškození bleskovým šípem: {:d}"
 
-#: Source/items.cpp:3957
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "poškození bleskovým šípem: {:d}-{:d}"
 
-#: Source/items.cpp:3961
+#: Source/items.cpp:3964
 msgid "fireball damage: {:d}"
 msgstr "poškození ohnivou koulí: {:d}"
 
-#: Source/items.cpp:3963
+#: Source/items.cpp:3966
 msgid "fireball damage: {:d}-{:d}"
 msgstr "poškození ohnivou koulí: {:d}-{:d}"
 
-#: Source/items.cpp:3966
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr "útočník je poškozen za 1-3"
 
-#: Source/items.cpp:3969
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr "uživatel ztratí všechnu manu"
 
-#: Source/items.cpp:3972
+#: Source/items.cpp:3975
 msgid "you can't heal"
 msgstr "nemůžeš se léčit"
 
-#: Source/items.cpp:3975
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr "pohlcuje polovinu poškození z pastí"
 
-#: Source/items.cpp:3978
+#: Source/items.cpp:3981
 msgid "knocks target back"
 msgstr "odhodí nepřítele dozadu"
 
-#: Source/items.cpp:3981
+#: Source/items.cpp:3984
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr "+200% poškození proti démonům"
 
-#: Source/items.cpp:3984
+#: Source/items.cpp:3987
 msgid "All Resistance equals 0"
 msgstr "Všechny Odolnosti jsou 0"
 
-#: Source/items.cpp:3987
+#: Source/items.cpp:3990
 msgid "hit monster doesn't heal"
 msgstr "zasažený nepřítel se nemůže léčit"
 
-#: Source/items.cpp:3991
+#: Source/items.cpp:3994
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr "zásah vysaje 3% many"
 
-#: Source/items.cpp:3993
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr "zásah vysaje 5% many"
 
-#: Source/items.cpp:3997
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr "zásah vysaje 3% životů"
 
-#: Source/items.cpp:3999
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr "zásah vysaje 5% životů"
 
-#: Source/items.cpp:4002
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr "prorazí obranu nepřítele"
 
-#: Source/items.cpp:4006
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr "hbitý útok"
 
-#: Source/items.cpp:4008
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr "rychlý útok"
 
-#: Source/items.cpp:4010
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr "rychlejší útok"
 
-#: Source/items.cpp:4012
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr "nejrychlejší útok"
 
-#: Source/items.cpp:4016
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr "rychlé vzpamatování ze zásahu"
 
-#: Source/items.cpp:4018
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr "rychlejší vzpamatování ze zásahu"
 
-#: Source/items.cpp:4020
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr "nejrychlejší vzpamatování ze zásahu"
 
-#: Source/items.cpp:4023
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr "rychlé blokování"
 
-#: Source/items.cpp:4026
+#: Source/items.cpp:4029
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] "přidá {:d} bod k poškození"
 msgstr[1] "přidá {:d} body k poškození"
 msgstr[2] "přidá {:d} bodů k poškození"
 
-#: Source/items.cpp:4029
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr "střílí šípy náhodnou rychlostí"
 
-#: Source/items.cpp:4032
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr "předmět má neobvyklé poškození"
 
-#: Source/items.cpp:4035
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr "upravená výdrž"
 
-#: Source/items.cpp:4038
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr "Rychlejší útočný švih"
 
-#: Source/items.cpp:4041
+#: Source/items.cpp:4044
 msgid "one handed sword"
 msgstr "jednoruční meč"
 
-#: Source/items.cpp:4044
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr "neustále budeš ztrácet životy"
 
-#: Source/items.cpp:4047
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr "vysátí životů"
 
-#: Source/items.cpp:4050
+#: Source/items.cpp:4053
 msgid "no strength requirement"
 msgstr "nepožaduje sílu"
 
-#: Source/items.cpp:4053
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr "máš infra vidění"
 
-#: Source/items.cpp:4060
+#: Source/items.cpp:4063
 msgid "lightning damage: {:d}"
 msgstr "poškození bleskem: {:d}"
 
-#: Source/items.cpp:4062
+#: Source/items.cpp:4065
 msgid "lightning damage: {:d}-{:d}"
 msgstr "poškození bleskem: {:d}-{:d}"
 
-#: Source/items.cpp:4065
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr "bleskové střely při zásahu"
 
-#: Source/items.cpp:4074
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr "občas ztrojnásobí poškození"
 
-#: Source/items.cpp:4077
+#: Source/items.cpp:4080
 #, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr "snižující se {:+d}% poškození"
 
-#: Source/items.cpp:4080
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr "2x poškození do nepřítele, 1x do tebe"
 
-#: Source/items.cpp:4083
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr "Náhodné 0 - 500% poškození"
 
-#: Source/items.cpp:4086
+#: Source/items.cpp:4089
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr "nízká výdrž, {:+d}% poškození"
 
-#: Source/items.cpp:4092
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr "extra OČ proti démonům"
 
-#: Source/items.cpp:4095
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr "extra OČ proti nemrtvým"
 
-#: Source/items.cpp:4098
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr "50% Many přesunuto do Životů"
 
-#: Source/items.cpp:4101
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr "40% Životů přesunuto do Many"
 
-#: Source/items.cpp:4104
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr "Další dovednost (NW)"
 
-#: Source/items.cpp:4141 Source/items.cpp:4188
+#: Source/items.cpp:4144 Source/items.cpp:4191
 msgid "damage: {:d}  Indestructible"
 msgstr "poškození: {:d}  Nezničitelný"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4143 Source/items.cpp:4190
+#: Source/items.cpp:4146 Source/items.cpp:4193
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "poškození: {:d}  Výdrž: {:d}/{:d}"
 
-#: Source/items.cpp:4146 Source/items.cpp:4193
+#: Source/items.cpp:4149 Source/items.cpp:4196
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "poškození: {:d}-{:d}  Nezničitelný"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4148 Source/items.cpp:4195
+#: Source/items.cpp:4151 Source/items.cpp:4198
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "poškození: {:d}-{:d}  Výdrž: {:d}/{:d}"
 
-#: Source/items.cpp:4154 Source/items.cpp:4207
+#: Source/items.cpp:4157 Source/items.cpp:4210
 msgid "armor: {:d}  Indestructible"
 msgstr "obrana: {:d}  Nezničitelný"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4156 Source/items.cpp:4209
+#: Source/items.cpp:4159 Source/items.cpp:4212
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "obrana: {:d}  Výdrž: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4161
+#: Source/items.cpp:4164
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "poš: {:d}  Výdrž: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4163
+#: Source/items.cpp:4166
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "poš: {:d}-{:d}  Výdrž: {:d}/{:d}"
 
-#: Source/items.cpp:4164 Source/items.cpp:4199 Source/items.cpp:4214
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 msgid "Charges: {:d}/{:d}"
 msgstr "Použití: {:d}/{:d}"
 
-#: Source/items.cpp:4176
+#: Source/items.cpp:4179
 msgid "unique item"
 msgstr "unikátní předmět"
 
-#: Source/items.cpp:4203 Source/items.cpp:4212 Source/items.cpp:4219
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr "Není Identifikován"
 
-#: Source/loadsave.cpp:1656 Source/loadsave.cpp:2122
+#: Source/loadsave.cpp:1683 Source/loadsave.cpp:2149
 msgid "Unable to open save file archive"
 msgstr "Nelze otevřít archiv souboru s uloženou hrou"
 
-#: Source/loadsave.cpp:1659
+#: Source/loadsave.cpp:1686
 msgid "Invalid save file"
 msgstr "Neplatný soubor s uloženou hrou"
 
-#: Source/loadsave.cpp:1688
+#: Source/loadsave.cpp:1717
 msgid "Player is on a Hellfire only level"
 msgstr "Hráč je v úrovni pouze pro Hellfire"
 
-#: Source/loadsave.cpp:1885
+#: Source/loadsave.cpp:1912
 msgid "Invalid game state"
 msgstr "Neplatný stav hry"
 
-#: Source/menu.cpp:144
+#: Source/menu.cpp:154
 msgid "Unable to display mainmenu"
 msgstr "Nelze zobrazit mainmenu"
+
+#. TRANSLATORS:  Error Message when a Shareware User clicks on "Replay Intro" in the Main Menu
+#: Source/menu.cpp:179
+msgid ""
+"The Diablo introduction cinematic is only available in the full retail "
+"version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
+msgstr ""
+"Úvodní filmová nahrávka pro Diablo je dostupná pouze v plné verzi hry "
+"Diablo. Pro koupi hry navštiv https://www.gog.com/game/diablo ."
 
 #. TRANSLATORS: Monster Block start
 #. MT_NZOMBIE
@@ -5339,97 +5448,97 @@ msgctxt "monster"
 msgid "Doomlock"
 msgstr "Zámek Záhuby"
 
-#: Source/monster.cpp:3474
+#: Source/monster.cpp:3479
 msgid "Animal"
 msgstr "Zvíře"
 
-#: Source/monster.cpp:3476
+#: Source/monster.cpp:3481
 msgid "Demon"
 msgstr "Démon"
 
-#: Source/monster.cpp:3478
+#: Source/monster.cpp:3483
 msgid "Undead"
 msgstr "Nemrtvý"
 
-#: Source/monster.cpp:4610
+#: Source/monster.cpp:4612
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "Typ: {:s}  Zabito: {:d}"
 
-#: Source/monster.cpp:4612
+#: Source/monster.cpp:4614
 msgid "Total kills: {:d}"
 msgstr "Celkem zabito: {:d}"
 
-#: Source/monster.cpp:4645
+#: Source/monster.cpp:4647
 msgid "Hit Points: {:d}-{:d}"
 msgstr "Životy: {:d}-{:d}"
 
-#: Source/monster.cpp:4651
+#: Source/monster.cpp:4653
 msgid "No magic resistance"
 msgstr "Žádná magická odolnost"
 
-#: Source/monster.cpp:4655
+#: Source/monster.cpp:4657
 msgid "Resists: "
 msgstr "Odolnosti: "
 
-#: Source/monster.cpp:4657 Source/monster.cpp:4668
+#: Source/monster.cpp:4659 Source/monster.cpp:4671
 msgid "Magic "
 msgstr "Magie "
 
-#: Source/monster.cpp:4659 Source/monster.cpp:4670
+#: Source/monster.cpp:4661 Source/monster.cpp:4673
 msgid "Fire "
 msgstr "Oheň "
 
-#: Source/monster.cpp:4661 Source/monster.cpp:4672
+#: Source/monster.cpp:4663 Source/monster.cpp:4675
 msgid "Lightning "
 msgstr "Blesky "
 
-#: Source/monster.cpp:4666
+#: Source/monster.cpp:4669
 msgid "Immune: "
 msgstr "Imunita: "
 
-#: Source/monster.cpp:4684
+#: Source/monster.cpp:4688
 msgid "Type: {:s}"
 msgstr "Typ: {:s}"
 
-#: Source/monster.cpp:4690 Source/monster.cpp:4697
+#: Source/monster.cpp:4694 Source/monster.cpp:4701
 msgid "No resistances"
 msgstr "Žádné odolnosti"
 
-#: Source/monster.cpp:4692 Source/monster.cpp:4702
+#: Source/monster.cpp:4696 Source/monster.cpp:4706
 msgid "No Immunities"
 msgstr "Žádné imunity"
 
-#: Source/monster.cpp:4695
+#: Source/monster.cpp:4699
 msgid "Some Magic Resistances"
 msgstr "Má nějaké Magické Odolnosti"
 
-#: Source/monster.cpp:4700
+#: Source/monster.cpp:4704
 msgid "Some Magic Immunities"
 msgstr "Má nějaké Magické Imunity"
 
-#: Source/msg.cpp:497
+#: Source/msg.cpp:495
 msgid "Trying to drop a floor item?"
 msgstr "Zkoušíš zahodit předmět na zemi?"
 
-#: Source/msg.cpp:950 Source/msg.cpp:985 Source/msg.cpp:1018
-#: Source/msg.cpp:1145 Source/msg.cpp:1177 Source/msg.cpp:1209
-#: Source/msg.cpp:1239
+#: Source/msg.cpp:994 Source/msg.cpp:1029 Source/msg.cpp:1060
+#: Source/msg.cpp:1187 Source/msg.cpp:1219 Source/msg.cpp:1251
+#: Source/msg.cpp:1281
 msgid "{:s} has cast an illegal spell."
 msgstr "{:s} vyčaroval nedovolené kouzlo."
 
-#: Source/msg.cpp:1621 Source/multi.cpp:799
+#: Source/msg.cpp:1668 Source/multi.cpp:804
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr "Hráč '{:s}' (úroveň {:d}) se připojil do hry"
 
-#: Source/msg.cpp:1925
+#: Source/msg.cpp:1972
 msgid "Waiting for game data..."
 msgstr "Čekám na herní data..."
 
-#: Source/msg.cpp:1933
+#: Source/msg.cpp:1980
 msgid "The game ended"
 msgstr "Hra byla ukončena"
 
-#: Source/msg.cpp:1939
+#: Source/msg.cpp:1986
 msgid "Unable to get level data"
 msgstr "Nelze získat data o patře"
 
@@ -5445,448 +5554,448 @@ msgstr "Hráč '{:s}' zabil Diabla a opustil hru!"
 msgid "Player '{:s}' dropped due to timeout"
 msgstr "Hráč '{:s}' byl odpojen (timeout)"
 
-#: Source/multi.cpp:801
+#: Source/multi.cpp:806
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr "Hráč '{:s}' (úroveň {:d}) už je připojen do hry"
 
 #. TRANSLATORS: Shrine Name Block
-#: Source/objects.cpp:101
+#: Source/objects.cpp:104
 msgid "Mysterious"
 msgstr "Tajemný"
 
-#: Source/objects.cpp:102
+#: Source/objects.cpp:105
 msgid "Hidden"
 msgstr "Skrytý"
 
-#: Source/objects.cpp:103
+#: Source/objects.cpp:106
 msgid "Gloomy"
 msgstr "Ponurý"
 
-#: Source/objects.cpp:105 Source/objects.cpp:112
+#: Source/objects.cpp:108 Source/objects.cpp:115
 msgid "Magical"
 msgstr "Kouzelný"
 
-#: Source/objects.cpp:106
+#: Source/objects.cpp:109
 msgid "Stone"
 msgstr "Kamenný"
 
-#: Source/objects.cpp:107
+#: Source/objects.cpp:110
 msgid "Religious"
 msgstr "Náboženský"
 
-#: Source/objects.cpp:108
+#: Source/objects.cpp:111
 msgid "Enchanted"
 msgstr "Očarovaný"
 
-#: Source/objects.cpp:109
+#: Source/objects.cpp:112
 msgid "Thaumaturgic"
 msgstr "Divotvorný"
 
-#: Source/objects.cpp:110
+#: Source/objects.cpp:113
 msgid "Fascinating"
 msgstr "Fascinující"
 
-#: Source/objects.cpp:111
+#: Source/objects.cpp:114
 msgid "Cryptic"
 msgstr "Záhadný"
 
-#: Source/objects.cpp:113
+#: Source/objects.cpp:116
 msgid "Eldritch"
 msgstr "Podivný"
 
-#: Source/objects.cpp:114
+#: Source/objects.cpp:117
 msgid "Eerie"
 msgstr "Tajuplný"
 
-#: Source/objects.cpp:115
+#: Source/objects.cpp:118
 msgid "Divine"
 msgstr "Božský"
 
-#: Source/objects.cpp:117
+#: Source/objects.cpp:120
 msgid "Sacred"
 msgstr "Posvátný"
 
-#: Source/objects.cpp:118
+#: Source/objects.cpp:121
 msgid "Spiritual"
 msgstr "Duchovní"
 
-#: Source/objects.cpp:119
+#: Source/objects.cpp:122
 msgid "Spooky"
 msgstr "Strašidelný"
 
-#: Source/objects.cpp:120
+#: Source/objects.cpp:123
 msgid "Abandoned"
 msgstr "Opuštěný"
 
-#: Source/objects.cpp:121
+#: Source/objects.cpp:124
 msgid "Creepy"
 msgstr "Strašidelný"
 
-#: Source/objects.cpp:122
+#: Source/objects.cpp:125
 msgid "Quiet"
 msgstr "Tichý"
 
-#: Source/objects.cpp:123
+#: Source/objects.cpp:126
 msgid "Secluded"
 msgstr "Odloučený"
 
-#: Source/objects.cpp:124
+#: Source/objects.cpp:127
 msgid "Ornate"
 msgstr "Ozdobený"
 
-#: Source/objects.cpp:125
+#: Source/objects.cpp:128
 msgid "Glimmering"
 msgstr "Mihotavý"
 
-#: Source/objects.cpp:126
+#: Source/objects.cpp:129
 msgid "Tainted"
 msgstr "Poskvrněný"
 
-#: Source/objects.cpp:127
+#: Source/objects.cpp:130
 msgid "Oily"
 msgstr "Mastný"
 
-#: Source/objects.cpp:128
+#: Source/objects.cpp:131
 msgid "Glowing"
 msgstr "Zařící"
 
-#: Source/objects.cpp:129
+#: Source/objects.cpp:132
 msgid "Mendicant's"
 msgstr "Žebrákův"
 
-#: Source/objects.cpp:130
+#: Source/objects.cpp:133
 msgid "Sparkling"
 msgstr "Jiskřivý"
 
-#: Source/objects.cpp:131
+#: Source/objects.cpp:134
 msgid "Town"
 msgstr "Městský"
 
-#: Source/objects.cpp:132
+#: Source/objects.cpp:135
 msgid "Shimmering"
 msgstr "Třpytivý"
 
-#: Source/objects.cpp:133
+#: Source/objects.cpp:136
 msgid "Solar"
 msgstr "Sluneční"
 
 #. TRANSLATORS: Shrine Name Block end
-#: Source/objects.cpp:135
+#: Source/objects.cpp:138
 msgid "Murphy's"
 msgstr "Murphyho"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:265
+#: Source/objects.cpp:268
 msgid "The Great Conflict"
 msgstr "Velký Konflikt"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:266
+#: Source/objects.cpp:269
 msgid "The Wages of Sin are War"
 msgstr "Mzdou Hříchu je Válka"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:267
+#: Source/objects.cpp:270
 msgid "The Tale of the Horadrim"
 msgstr "Příběh o Horadrimech"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:268
+#: Source/objects.cpp:271
 msgid "The Dark Exile"
 msgstr "Temný Exil"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:269
+#: Source/objects.cpp:272
 msgid "The Sin War"
 msgstr "Hříšná Válka"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:270
+#: Source/objects.cpp:273
 msgid "The Binding of the Three"
 msgstr "Spoutání Trojice"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:271
+#: Source/objects.cpp:274
 msgid "The Realms Beyond"
 msgstr "Sféry Mimo"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:272
+#: Source/objects.cpp:275
 msgid "Tale of the Three"
 msgstr "Příbeh o Třech"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:273
+#: Source/objects.cpp:276
 msgid "The Black King"
 msgstr "Černý Král"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:274
+#: Source/objects.cpp:277
 msgid "Journal: The Ensorcellment"
 msgstr "Deník: Očarování"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:275
+#: Source/objects.cpp:278
 msgid "Journal: The Meeting"
 msgstr "Deník: Setkání"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:276
+#: Source/objects.cpp:279
 msgid "Journal: The Tirade"
 msgstr "Deník: Tiráda"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:277
+#: Source/objects.cpp:280
 msgid "Journal: His Power Grows"
 msgstr "Deník: Jeho Síla Roste"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:278
+#: Source/objects.cpp:281
 msgid "Journal: NA-KRUL"
 msgstr "Deník: NA-KRUL"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:279
+#: Source/objects.cpp:282
 msgid "Journal: The End"
 msgstr "Deník: Konec"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:280
+#: Source/objects.cpp:283
 msgid "A Spellbook"
 msgstr "Kniha Kouzel"
 
-#: Source/objects.cpp:5365
+#: Source/objects.cpp:5339
 msgid "Crucified Skeleton"
 msgstr "Ukřižovaný Kostlivec"
 
-#: Source/objects.cpp:5369
+#: Source/objects.cpp:5343
 msgid "Lever"
 msgstr "Páka"
 
-#: Source/objects.cpp:5378
+#: Source/objects.cpp:5352
 msgid "Open Door"
 msgstr "Otevřené dveře"
 
-#: Source/objects.cpp:5380
+#: Source/objects.cpp:5354
 msgid "Closed Door"
 msgstr "Zavřené dveře"
 
-#: Source/objects.cpp:5382
+#: Source/objects.cpp:5356
 msgid "Blocked Door"
 msgstr "Zablokované dveře"
 
-#: Source/objects.cpp:5387
+#: Source/objects.cpp:5361
 msgid "Ancient Tome"
 msgstr "Prastará Kniha"
 
-#: Source/objects.cpp:5389
+#: Source/objects.cpp:5363
 msgid "Book of Vileness"
 msgstr "Kniha Ohavností"
 
-#: Source/objects.cpp:5394
+#: Source/objects.cpp:5368
 msgid "Skull Lever"
 msgstr "Páka s lebkou"
 
-#: Source/objects.cpp:5397
+#: Source/objects.cpp:5371
 msgid "Mythical Book"
 msgstr "Mýtická Kniha"
 
-#: Source/objects.cpp:5401
+#: Source/objects.cpp:5375
 msgid "Small Chest"
 msgstr "Malá Truhla"
 
-#: Source/objects.cpp:5405
+#: Source/objects.cpp:5379
 msgid "Chest"
 msgstr "Truhla"
 
-#: Source/objects.cpp:5410
+#: Source/objects.cpp:5384
 msgid "Large Chest"
 msgstr "Velká Truhla"
 
-#: Source/objects.cpp:5413
+#: Source/objects.cpp:5387
 msgid "Sarcophagus"
 msgstr "Sarkofág"
 
-#: Source/objects.cpp:5416
+#: Source/objects.cpp:5390
 msgid "Bookshelf"
 msgstr "Police na knihy"
 
-#: Source/objects.cpp:5420
+#: Source/objects.cpp:5394
 msgid "Bookcase"
 msgstr "Knihovna"
 
-#: Source/objects.cpp:5425
+#: Source/objects.cpp:5399
 msgid "Pod"
 msgstr "Zámotek"
 
-#: Source/objects.cpp:5427
+#: Source/objects.cpp:5401
 msgid "Urn"
 msgstr "Urna"
 
-#: Source/objects.cpp:5429
+#: Source/objects.cpp:5403
 msgid "Barrel"
 msgstr "Barel"
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:5433
+#: Source/objects.cpp:5407
 msgid "{:s} Shrine"
 msgstr "{:s} Oltář"
 
-#: Source/objects.cpp:5437
+#: Source/objects.cpp:5411
 msgid "Skeleton Tome"
 msgstr "Kostěná Kniha"
 
-#: Source/objects.cpp:5440
+#: Source/objects.cpp:5414
 msgid "Library Book"
 msgstr "Kniha v Knihovně"
 
-#: Source/objects.cpp:5443
+#: Source/objects.cpp:5417
 msgid "Blood Fountain"
 msgstr "Krvavá Fontána"
 
-#: Source/objects.cpp:5446
+#: Source/objects.cpp:5420
 msgid "Decapitated Body"
 msgstr "Setnuté Tělo"
 
-#: Source/objects.cpp:5449
+#: Source/objects.cpp:5423
 msgid "Book of the Blind"
 msgstr "Kniha Slepých"
 
-#: Source/objects.cpp:5452
+#: Source/objects.cpp:5426
 msgid "Book of Blood"
 msgstr "Kniha Krve"
 
-#: Source/objects.cpp:5455
+#: Source/objects.cpp:5429
 msgid "Purifying Spring"
 msgstr "Očišťující Pramen"
 
-#: Source/objects.cpp:5462 Source/objects.cpp:5486
+#: Source/objects.cpp:5436 Source/objects.cpp:5460
 msgid "Weapon Rack"
 msgstr "Stojan na Zbraně"
 
-#: Source/objects.cpp:5465
+#: Source/objects.cpp:5439
 msgid "Goat Shrine"
 msgstr "Oltář Kozlů"
 
-#: Source/objects.cpp:5468
+#: Source/objects.cpp:5442
 msgid "Cauldron"
 msgstr "Velký Kotel"
 
-#: Source/objects.cpp:5471
+#: Source/objects.cpp:5445
 msgid "Murky Pool"
 msgstr "Kalná Kaluž"
 
-#: Source/objects.cpp:5474
+#: Source/objects.cpp:5448
 msgid "Fountain of Tears"
 msgstr "Fontána Slz"
 
-#: Source/objects.cpp:5477
+#: Source/objects.cpp:5451
 msgid "Steel Tome"
 msgstr "Ocelová Kniha"
 
-#: Source/objects.cpp:5480
+#: Source/objects.cpp:5454
 msgid "Pedestal of Blood"
 msgstr "Podstavec Krve"
 
-#: Source/objects.cpp:5489
+#: Source/objects.cpp:5463
 msgid "Mushroom Patch"
 msgstr "Houbový Porost"
 
-#: Source/objects.cpp:5492
+#: Source/objects.cpp:5466
 msgid "Vile Stand"
 msgstr "Odporný Stojan"
 
-#: Source/objects.cpp:5495
+#: Source/objects.cpp:5469
 msgid "Slain Hero"
 msgstr "Zabitý Hrdina"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:5502
+#: Source/objects.cpp:5476
 msgid "Trapped {:s}"
 msgstr "{:s} s pastí"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
-#: Source/objects.cpp:5508
+#: Source/objects.cpp:5482
 msgid "{:s} (disabled)"
 msgstr "{:s} (deaktivováno)"
 
-#: Source/panels/charpanel.cpp:109
+#: Source/panels/charpanel.cpp:110
 msgid "MAX"
 msgstr "Maximum"
 
-#: Source/panels/charpanel.cpp:119
+#: Source/panels/charpanel.cpp:120
 msgid "Level"
 msgstr "Úroveň"
 
-#: Source/panels/charpanel.cpp:121
+#: Source/panels/charpanel.cpp:122
 msgid "Experience"
 msgstr "Zkušenosti"
 
-#: Source/panels/charpanel.cpp:123
+#: Source/panels/charpanel.cpp:124
 msgid "Next level"
 msgstr "Další úroveň"
 
-#: Source/panels/charpanel.cpp:126
+#: Source/panels/charpanel.cpp:127
 msgid "None"
 msgstr "Žádný"
 
-#: Source/panels/charpanel.cpp:132
+#: Source/panels/charpanel.cpp:133
 msgid "Base"
 msgstr "Základ"
 
-#: Source/panels/charpanel.cpp:133
+#: Source/panels/charpanel.cpp:134
 msgid "Now"
 msgstr "Nyní"
 
-#: Source/panels/charpanel.cpp:134
+#: Source/panels/charpanel.cpp:135
 msgid "Strength"
 msgstr "Síla"
 
-#: Source/panels/charpanel.cpp:138
+#: Source/panels/charpanel.cpp:139
 msgid "Magic"
 msgstr "Magie"
 
-#: Source/panels/charpanel.cpp:142
+#: Source/panels/charpanel.cpp:143
 msgid "Dexterity"
 msgstr "Obratnost"
 
-#: Source/panels/charpanel.cpp:145
+#: Source/panels/charpanel.cpp:146
 msgid "Vitality"
 msgstr "Vitalita"
 
-#: Source/panels/charpanel.cpp:148
+#: Source/panels/charpanel.cpp:149
 msgid "Points to distribute"
 msgstr "Body k distribuci"
 
-#: Source/panels/charpanel.cpp:158
+#: Source/panels/charpanel.cpp:159
 msgid "Armor class"
 msgstr "Obranné číslo"
 
-#: Source/panels/charpanel.cpp:160
+#: Source/panels/charpanel.cpp:161
 msgid "To hit"
 msgstr "Šance na zásah"
 
-#: Source/panels/charpanel.cpp:162
+#: Source/panels/charpanel.cpp:163
 msgid "Damage"
 msgstr "Poškození"
 
-#: Source/panels/charpanel.cpp:168
+#: Source/panels/charpanel.cpp:170
 msgid "Life"
 msgstr "Životy"
 
-#: Source/panels/charpanel.cpp:172
+#: Source/panels/charpanel.cpp:174
 msgid "Mana"
 msgstr "Mana"
 
-#: Source/panels/charpanel.cpp:177
+#: Source/panels/charpanel.cpp:179
 msgid "Resist magic"
 msgstr "Odolnost Magie"
 
-#: Source/panels/charpanel.cpp:179
+#: Source/panels/charpanel.cpp:181
 msgid "Resist fire"
 msgstr "Odolnost Oheň"
 
-#: Source/panels/charpanel.cpp:181
+#: Source/panels/charpanel.cpp:183
 msgid "Resist lightning"
 msgstr "Odolnost Blesky"
 
@@ -5924,27 +6033,26 @@ msgstr "kouzla"
 msgid "mute"
 msgstr "ztlumit"
 
-#: Source/pfile.cpp:260
+#: Source/pfile.cpp:242
 msgid "Failed to open player archive for writing."
 msgstr "Nepodařilo se otevřít archiv hráče k zápisu."
 
-#: Source/pfile.cpp:385
+#: Source/pfile.cpp:377
 msgid "Unable to open archive"
 msgstr "Nelze otevřít archiv"
 
-#: Source/pfile.cpp:387
+#: Source/pfile.cpp:379
 msgid "Unable to load character"
 msgstr "Nelze načíst postavu"
 
-#: Source/pfile.cpp:410 Source/pfile.cpp:430
+#: Source/pfile.cpp:403 Source/pfile.cpp:423
 msgid "Unable to read to save file archive"
 msgstr "Nelze přečíst z archivu uložené hry"
 
-#: Source/pfile.cpp:449
+#: Source/pfile.cpp:442
 msgid "Unable to write to save file archive"
 msgstr "Nelze zapsat do archivu uložené hry"
 
-#. TRANSLATORS: Shown if player presses "v" button. {:s} is player name, {:d} is level, {:s} is location
 #: Source/plrmsg.cpp:88
 msgid "{:s} (lvl {:d}): {:s}"
 msgstr "{:s} (úroveň {:d}): {:s}"
@@ -5960,7 +6068,7 @@ msgstr ",%03d"
 msgid "%i gold"
 msgstr "%i zlaťáků"
 
-#: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:56
+#: Source/qol/monhealthbar.cpp:37 Source/qol/xpbar.cpp:56
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
@@ -6373,298 +6481,331 @@ msgctxt "spell"
 msgid "Rune of Stone"
 msgstr "Runa Kamene"
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:91
+#, fuzzy
+#| msgid "Griswold's Edge"
+msgid "Griswold"
+msgstr "Griswoldovo Ostří"
+
+#: Source/stores.cpp:92
+msgid "Pepin"
+msgstr ""
+
+#: Source/stores.cpp:94
+msgid "Ogden"
+msgstr ""
+
+#: Source/stores.cpp:95
+msgid "Cain"
+msgstr ""
+
+#: Source/stores.cpp:96
+#, fuzzy
+#| msgid "Talk to Farnham"
+msgid "Farnham"
+msgstr "Mluvit s Farnhamem"
+
+#: Source/stores.cpp:97
+msgid "Adria"
+msgstr ""
+
+#: Source/stores.cpp:98 Source/stores.cpp:1305
+#, fuzzy
+#| msgid "brilliance"
+msgid "Gillian"
+msgstr "oslnivosti"
+
+#: Source/stores.cpp:99
+msgid "Wirt"
+msgstr ""
+
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr "Zpět"
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ",  "
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 msgid "Damage: {:d}-{:d}  "
 msgstr "Poškození: {:d}-{:d}  "
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 msgid "Armor: {:d}  "
 msgstr "Obrana: {:d}  "
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 msgid "Dur: {:d}/{:d},  "
 msgstr "Výdrž: {:d}/{:d},  "
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr "Nezničitelný,  "
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr "Požadavky: nic"
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr "Vítejte v mém"
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr "Kovářském obchodě"
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr "Co byste rádi:"
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 msgid "Talk to Griswold"
 msgstr "Mluvit s Griswoldem"
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 msgid "Buy basic items"
 msgstr "Koupit základní předměty"
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 msgid "Buy premium items"
 msgstr "Koupit prémiové předměty"
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 msgid "Sell items"
 msgstr "Prodat předměty"
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 msgid "Repair items"
 msgstr "Opravit předměty"
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 msgid "Leave the shop"
 msgstr "Odejít z obchodu"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "Mám na prodej tyto věci:             Tvoje zlaťáky: {:d}"
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr "Zpět"
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "Mám na prodej tyto prémiové věci:             Tvoje zlaťáky: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "Nemáš nic co bych odkoupil.             Tvoje zlaťáky: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "Které předměty jsou na prodej?             Tvoje zlaťáky: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "Nemáš nic k opravě.             Tvoje zlaťáky: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "Který předmět mám opravit?             Tvoje zlaťáky: {:d}"
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr "Čarodějná chalupa"
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 msgid "Talk to Adria"
 msgstr "Mluvit s Adrií"
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr "Koupit předměty"
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr "Nabít hole"
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 msgid "Leave the shack"
 msgstr "Odejít z chalupy"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "Nemáš žádné hole k nabití.             Tvoje zlaťáky: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "Kterou hůl chceš nabít?             Tvoje zlaťáky: {:d}"
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr "Nemáš dostatek zlaťáků"
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr "Nemáš dost místa v inventáři"
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr "Máme dohodu?"
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 msgid "Are you sure you want to identify this item?"
 msgstr "Opravdu chceš identifikovat tento předmět?"
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 msgid "Are you sure you want to buy this item?"
 msgstr "Opravdu chceš koupit tento předmět?"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 msgid "Are you sure you want to recharge this item?"
 msgstr "Opravdu chceš dobít tento předmět?"
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 msgid "Are you sure you want to sell this item?"
 msgstr "Opravdu chceš prodat tento předmět?"
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 msgid "Are you sure you want to repair this item?"
 msgstr "Opravdu chceš opravit tento předmět?"
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr "Wirt, kluk s protézou"
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 msgid "Talk to Wirt"
 msgstr "Mluvit s Wirtem"
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr "Mám něco na prodej,"
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr "ale bude tě stát 50 zlaťáků"
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr "aby ses mohl podívat. "
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr "Co máš za předmět?"
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr "Rozloučit se"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "Mám na prodej tento předmět:             Tvoje zlaťáky: {:d}"
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 msgid "Leave"
 msgstr "Odejít"
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr "Domě Léčitele"
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr "Mluvit s Pepinem"
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr "Odejít z Léčitelova domu"
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 msgid "The Town Elder"
 msgstr "Městský Stařešina"
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 msgid "Talk to Cain"
 msgstr "Mluvit s Cainem"
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr "Identifikovat předmět"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "Nemáš nic k identifikaci.             Tvoje zlaťáky: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "Který předmět chceš identifikovat?             Tvoje zlaťáky: {:d}"
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr "Tento předmět je:"
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr "Hotovo"
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 msgid "Talk to {:s}"
 msgstr "Mluvit s {:s}"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 msgid "Talking to {:s}"
 msgstr "Mluvení s {:s}"
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 msgid "is not available"
 msgstr "není dostupné"
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 msgid "in the shareware"
 msgstr "v shareware"
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 msgid "version"
 msgstr "verzi"
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr "Klábosit"
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr "Vycházející Slunce"
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 msgid "Talk to Ogden"
 msgstr "Mluvit s Ogdenem"
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 msgid "Leave the tavern"
 msgstr "Odejít z hospody"
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 msgid "Talk to Gillian"
 msgstr "Mluvit s Gillian"
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr "Opilec Farnham"
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 msgid "Talk to Farnham"
 msgstr "Mluvit s Farnhamem"
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr "Rozloučit se"
 
@@ -9404,17 +9545,17 @@ msgid "Down to Crypt"
 msgstr "Dolů do krypty"
 
 #: Source/trigs.cpp:412 Source/trigs.cpp:492 Source/trigs.cpp:539
-#: Source/trigs.cpp:630
+#: Source/trigs.cpp:634
 msgid "Up to level {:d}"
 msgstr "Nahoru do patra {:d}"
 
 #: Source/trigs.cpp:414 Source/trigs.cpp:469 Source/trigs.cpp:521
-#: Source/trigs.cpp:596 Source/trigs.cpp:613 Source/trigs.cpp:660
+#: Source/trigs.cpp:600 Source/trigs.cpp:617 Source/trigs.cpp:664
 msgid "Up to town"
 msgstr "Nahoru do města"
 
-#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:552
-#: Source/trigs.cpp:577 Source/trigs.cpp:642
+#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:556
+#: Source/trigs.cpp:581 Source/trigs.cpp:646
 msgid "Down to level {:d}"
 msgstr "Dolů do patra {:d}"
 
@@ -9426,14 +9567,14 @@ msgstr "Nahoru do Krypty úrovně {:d}"
 msgid "Down to Crypt level {:d}"
 msgstr "Dolů do Krypty úrovně {:d}"
 
-#: Source/trigs.cpp:564
+#: Source/trigs.cpp:568
 msgid "Up to Nest level {:d}"
 msgstr "Nahoru do Hnízda úrovně {:d}"
 
-#: Source/trigs.cpp:673
+#: Source/trigs.cpp:677
 msgid "Down to Diablo"
 msgstr "Dolů do Hnízda úrovně {:d}"
 
-#: Source/trigs.cpp:706 Source/trigs.cpp:720 Source/trigs.cpp:734
+#: Source/trigs.cpp:710 Source/trigs.cpp:724 Source/trigs.cpp:738
 msgid "Back to Level {:d}"
 msgstr "Zpět do Patra {:d}"

--- a/Translations/da.po
+++ b/Translations/da.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-09-20 04:34+0200\n"
-"PO-Revision-Date: 2021-09-20 04:34+0200\n"
+"POT-Creation-Date: 2021-11-21 05:44+0100\n"
+"PO-Revision-Date: 2021-11-21 05:44+0100\n"
 "Last-Translator: Anders Jenbo <anders@jenbo.dk>\n"
 "Language-Team: \n"
 "Language: da\n"
@@ -162,6 +162,7 @@ msgstr "QA-artilleristøtte (ekstra testere) "
 msgid "QA Counterintelligence"
 msgstr "QA-modintelligens"
 
+#. TRANSLATORS: A group of people
 #: Source/DiabloUI/credits_lines.cpp:130
 msgid "Order of Network Information Services"
 msgstr "Bestilling af netværksinformationstjenester"
@@ -339,15 +340,49 @@ msgstr "Ringen af et tusinde"
 msgid "\tNo souls were sold in the making of this game."
 msgstr "\tIngen sjæle blev solgt i fremstillingen af dette spil."
 
-#: Source/DiabloUI/dialogs.cpp:172 Source/DiabloUI/dialogs.cpp:185
-#: Source/DiabloUI/selconn.cpp:73 Source/DiabloUI/selgame.cpp:94
-#: Source/DiabloUI/selgame.cpp:163 Source/DiabloUI/selgame.cpp:181
-#: Source/DiabloUI/selgame.cpp:314 Source/DiabloUI/selgame.cpp:387
-#: Source/DiabloUI/selhero.cpp:185 Source/DiabloUI/selhero.cpp:210
-#: Source/DiabloUI/selhero.cpp:280 Source/DiabloUI/selhero.cpp:525
+#: Source/DiabloUI/dialogs.cpp:194 Source/DiabloUI/dialogs.cpp:206
+#: Source/DiabloUI/selconn.cpp:79 Source/DiabloUI/selgame.cpp:103
+#: Source/DiabloUI/selgame.cpp:193 Source/DiabloUI/selgame.cpp:211
+#: Source/DiabloUI/selgame.cpp:352 Source/DiabloUI/selgame.cpp:428
+#: Source/DiabloUI/selhero.cpp:186 Source/DiabloUI/selhero.cpp:211
+#: Source/DiabloUI/selhero.cpp:281 Source/DiabloUI/selhero.cpp:536
 #: Source/DiabloUI/selok.cpp:68
 msgid "OK"
 msgstr "OK"
+
+#: Source/DiabloUI/extrasmenu.cpp:41 Source/DiabloUI/selstart.cpp:44
+#, fuzzy
+#| msgid "Exit Diablo"
+msgid "Switch to Diablo"
+msgstr "Diablo Strike Team"
+
+#: Source/DiabloUI/extrasmenu.cpp:41
+#, fuzzy
+#| msgid "Exit Hellfire"
+msgid "Switch to Hellfire"
+msgstr "Afslut Hellfire"
+
+#: Source/DiabloUI/extrasmenu.cpp:43
+msgid "Switch to Fullgame"
+msgstr ""
+
+#: Source/DiabloUI/extrasmenu.cpp:43
+#, fuzzy
+#| msgid "Pepin the Healer"
+msgid "Switch to Shareware"
+msgstr "Healeren Pepin"
+
+#: Source/DiabloUI/extrasmenu.cpp:44
+msgid "Replay Intro"
+msgstr "Genspil intro"
+
+#: Source/DiabloUI/extrasmenu.cpp:45
+msgid "Support"
+msgstr "Support"
+
+#: Source/DiabloUI/extrasmenu.cpp:46 Source/gamemenu.cpp:61
+msgid "Previous Menu"
+msgstr "Forrige menu"
 
 #: Source/DiabloUI/mainmenu.cpp:36
 msgid "Single Player"
@@ -358,121 +393,126 @@ msgid "Multi Player"
 msgstr "Multiplayer"
 
 #: Source/DiabloUI/mainmenu.cpp:38
-msgid "Replay Intro"
-msgstr "Genspil intro"
+msgid "Extras"
+msgstr ""
 
 #: Source/DiabloUI/mainmenu.cpp:39
-msgid "Support"
-msgstr "Support"
-
-#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Show Credits"
 msgstr "Vis kredit"
 
-#: Source/DiabloUI/mainmenu.cpp:41
+#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Exit Hellfire"
 msgstr "Afslut Hellfire"
 
-#: Source/DiabloUI/mainmenu.cpp:41
+#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Exit Diablo"
 msgstr "Afslut Diablo"
 
-#. TRANSLATORS:  Error Message when a Shareware User clicks on "Replay Intro" in the Main Menu
-#: Source/DiabloUI/mainmenu.cpp:99
-msgid ""
-"The Diablo introduction cinematic is only available in the full retail "
-"version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
-msgstr ""
-"Introductionsekvensen til Diablo er kun tilgængelig i den fulde "
-"detailversion af Diablo. Besøg https://www.gog.com/game/diablo for at købe "
-"den."
+#: Source/DiabloUI/mainmenu.cpp:55
+#, fuzzy
+#| msgid "Pepin the Healer"
+msgid "Shareware"
+msgstr "Healeren Pepin"
 
-#: Source/DiabloUI/progress.cpp:48 Source/DiabloUI/selconn.cpp:76
-#: Source/DiabloUI/selhero.cpp:188 Source/DiabloUI/selhero.cpp:213
-#: Source/DiabloUI/selhero.cpp:283 Source/DiabloUI/selhero.cpp:533
+#: Source/DiabloUI/progress.cpp:36 Source/DiabloUI/selconn.cpp:82
+#: Source/DiabloUI/selhero.cpp:189 Source/DiabloUI/selhero.cpp:214
+#: Source/DiabloUI/selhero.cpp:284 Source/DiabloUI/selhero.cpp:544
 msgid "Cancel"
 msgstr "Annuller"
 
-#: Source/DiabloUI/selconn.cpp:38 Source/DiabloUI/selgame.cpp:77
-#: Source/DiabloUI/selgame.cpp:372
+#: Source/DiabloUI/selconn.cpp:13
 msgid "Client-Server (TCP)"
 msgstr "Klient-server (TCP)"
 
-#: Source/DiabloUI/selconn.cpp:41
+#: Source/DiabloUI/selconn.cpp:14
 msgid "Loopback"
 msgstr "Loopback"
 
-#: Source/DiabloUI/selconn.cpp:47 Source/DiabloUI/selgame.cpp:434
-#: Source/DiabloUI/selgame.cpp:452
+#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:489
+#: Source/DiabloUI/selgame.cpp:510
 msgid "Multi Player Game"
 msgstr "Multiplayer-spil"
 
-#: Source/DiabloUI/selconn.cpp:53
+#: Source/DiabloUI/selconn.cpp:59
 #, fuzzy
 #| msgid "Requirements:"
 msgid "Requirements:"
 msgstr "Krav:"
 
-#: Source/DiabloUI/selconn.cpp:59
+#: Source/DiabloUI/selconn.cpp:65
 msgid "no gateway needed"
 msgstr "ingen gateway"
 
-#: Source/DiabloUI/selconn.cpp:65
+#: Source/DiabloUI/selconn.cpp:71
 msgid "Select Connection"
 msgstr "Vælg forbindelse"
 
-#: Source/DiabloUI/selconn.cpp:68
+#: Source/DiabloUI/selconn.cpp:74
 msgid "Change Gateway"
 msgstr "Skift gateway"
 
-#: Source/DiabloUI/selconn.cpp:101
+#: Source/DiabloUI/selconn.cpp:107
 msgid "All computers must be connected to a TCP-compatible network."
 msgstr "Alle computere skal være tilsluttet et TCP-kompatibelt netværk."
 
-#: Source/DiabloUI/selconn.cpp:105
+#: Source/DiabloUI/selconn.cpp:111
 #, fuzzy
 #| msgid "All computers must be connected to a TCP-compatible network."
 msgid "All computers must be connected to the internet."
 msgstr "Alle computere skal være tilsluttet et TCP-kompatibelt netværk."
 
-#: Source/DiabloUI/selconn.cpp:109
+#: Source/DiabloUI/selconn.cpp:115
 msgid "Play by yourself with no network exposure."
 msgstr "Spil alene uden nogen netværkseksponering."
 
-#: Source/DiabloUI/selconn.cpp:114
+#: Source/DiabloUI/selconn.cpp:120
 msgid "Players Supported: {:d}"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/DiabloUI/selgame.cpp:80 Source/DiabloUI/selgame.cpp:375
+#: Source/DiabloUI/selgame.cpp:82 Source/DiabloUI/selgame.cpp:414
 msgid "Description:"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:86
+#: Source/DiabloUI/selgame.cpp:88
 msgid "Select Action"
 msgstr "Vælg handling"
 
-#: Source/DiabloUI/selgame.cpp:88 Source/DiabloUI/selgame.cpp:151
-#: Source/DiabloUI/selgame.cpp:295
+#: Source/DiabloUI/selgame.cpp:91 Source/DiabloUI/selgame.cpp:181
+#: Source/DiabloUI/selgame.cpp:333
 msgid "Create Game"
 msgstr "Opret spil"
 
-#: Source/DiabloUI/selgame.cpp:89
+#: Source/DiabloUI/selgame.cpp:93
+#, fuzzy
+#| msgid "Create Game"
+msgid "Create Public Game"
+msgstr "Opret spil"
+
+#: Source/DiabloUI/selgame.cpp:94
 #, fuzzy
 #| msgid "Join TCP Games"
 msgid "Join Game"
 msgstr "Spildesign"
 
-#: Source/DiabloUI/selgame.cpp:97 Source/DiabloUI/selgame.cpp:166
-#: Source/DiabloUI/selgame.cpp:184 Source/DiabloUI/selgame.cpp:317
-#: Source/DiabloUI/selgame.cpp:390
+#: Source/DiabloUI/selgame.cpp:106 Source/DiabloUI/selgame.cpp:196
+#: Source/DiabloUI/selgame.cpp:214 Source/DiabloUI/selgame.cpp:355
+#: Source/DiabloUI/selgame.cpp:431
 msgid "CANCEL"
 msgstr "ANNULLER"
 
-#: Source/DiabloUI/selgame.cpp:106
+#: Source/DiabloUI/selgame.cpp:122
 msgid "Create a new game with a difficulty setting of your choice."
 msgstr "Opret et nyt spil med sværhedsgrad efter eget valg."
 
-#: Source/DiabloUI/selgame.cpp:109
+#: Source/DiabloUI/selgame.cpp:125
+#, fuzzy
+#| msgid "Create a new game with a difficulty setting of your choice."
+msgid ""
+"Create a new public game that anyone can join with a difficulty setting of "
+"your choice."
+msgstr "Opret et nyt spil med sværhedsgrad efter eget valg."
+
+#: Source/DiabloUI/selgame.cpp:128
 #, fuzzy
 #| msgid "Enter an IP and join a game already in progress at that address."
 msgid ""
@@ -481,37 +521,44 @@ msgid ""
 msgstr ""
 "Indtast en IP og deltag i et spil, der allerede er i gang på den adresse."
 
-#: Source/DiabloUI/selgame.cpp:154
+#: Source/DiabloUI/selgame.cpp:131
+#, fuzzy
+#| msgid "Enter an IP and join a game already in progress at that address."
+msgid "Join the public game already in progress at this address."
+msgstr ""
+"Indtast en IP og deltag i et spil, der allerede er i gang på den adresse."
+
+#: Source/DiabloUI/selgame.cpp:184
 msgid "Select Difficulty"
 msgstr "Vælg sværhedsgrad"
 
-#: Source/DiabloUI/selgame.cpp:156 Source/DiabloUI/selgame.cpp:203
-#: Source/DiabloUI/selgame.cpp:306 Source/DiabloUI/selgame.cpp:326
-#: Source/diablo.cpp:1434
+#: Source/DiabloUI/selgame.cpp:186 Source/DiabloUI/selgame.cpp:239
+#: Source/DiabloUI/selgame.cpp:344 Source/DiabloUI/selgame.cpp:364
+#: Source/diablo.cpp:1446
 msgid "Normal"
 msgstr "Normal"
 
-#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:207
-#: Source/diablo.cpp:1435
+#: Source/DiabloUI/selgame.cpp:187 Source/DiabloUI/selgame.cpp:243
+#: Source/diablo.cpp:1447
 msgid "Nightmare"
 msgstr "Mareridt"
 
-#: Source/DiabloUI/selgame.cpp:158 Source/DiabloUI/selgame.cpp:211
-#: Source/diablo.cpp:1436
+#: Source/DiabloUI/selgame.cpp:188 Source/DiabloUI/selgame.cpp:247
+#: Source/diablo.cpp:1448
 msgid "Hell"
 msgstr "Helvede"
 
-#: Source/DiabloUI/selgame.cpp:172
+#: Source/DiabloUI/selgame.cpp:202
 msgid "Join TCP Games"
 msgstr "Deltag i et TCP-spil"
 
-#: Source/DiabloUI/selgame.cpp:175 Source/DiabloUI/selgame.cpp:178
+#: Source/DiabloUI/selgame.cpp:205 Source/DiabloUI/selgame.cpp:208
 #, fuzzy
 #| msgid "Enter Name"
 msgid "Enter address"
 msgstr "Indtast adgangskode"
 
-#: Source/DiabloUI/selgame.cpp:204
+#: Source/DiabloUI/selgame.cpp:240
 msgid ""
 "Normal Difficulty\n"
 "This is where a starting character should begin the quest to defeat Diablo."
@@ -519,7 +566,7 @@ msgstr ""
 "Normal sværhedsgrad\n"
 "Det er her en nybegynder skal starte sin stræben efter at besejre Diablo."
 
-#: Source/DiabloUI/selgame.cpp:208
+#: Source/DiabloUI/selgame.cpp:244
 msgid ""
 "Nightmare Difficulty\n"
 "The denizens of the Labyrinth have been bolstered and will prove to be a "
@@ -529,7 +576,7 @@ msgstr ""
 "Borgerne i labyrinten er styrket og vil vise sig at være en større "
 "udfordring. Dette anbefales kun til erfarne helte."
 
-#: Source/DiabloUI/selgame.cpp:212
+#: Source/DiabloUI/selgame.cpp:248
 msgid ""
 "Hell Difficulty\n"
 "The most powerful of the underworld's creatures lurk at the gateway into "
@@ -539,7 +586,7 @@ msgstr ""
 "De mest magtfulde af underverdenens væsener lurer ved indgangen til helvede. "
 "Kun de mest erfarne helte skal vove sig ind i denne verden."
 
-#: Source/DiabloUI/selgame.cpp:227
+#: Source/DiabloUI/selgame.cpp:264
 msgid ""
 "Your character must reach level 20 before you can enter a multiplayer game "
 "of Nightmare difficulty."
@@ -547,7 +594,7 @@ msgstr ""
 "Din karakter skal nå niveau 20, før du kan deltage i et multiplayer-spil med "
 "mareridt-sværhedsgrad."
 
-#: Source/DiabloUI/selgame.cpp:229
+#: Source/DiabloUI/selgame.cpp:266
 msgid ""
 "Your character must reach level 30 before you can enter a multiplayer game "
 "of Hell difficulty."
@@ -555,24 +602,24 @@ msgstr ""
 "Din karakter skal nå niveau 30, før du kan deltage i et multiplayer-spil med "
 "helvede-sværhedsgrad."
 
-#: Source/DiabloUI/selgame.cpp:304
+#: Source/DiabloUI/selgame.cpp:342
 #, fuzzy
 msgid "Select Game Speed"
 msgstr "Vælg forbindelse"
 
-#: Source/DiabloUI/selgame.cpp:307 Source/DiabloUI/selgame.cpp:330
+#: Source/DiabloUI/selgame.cpp:345 Source/DiabloUI/selgame.cpp:368
 msgid "Fast"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:308 Source/DiabloUI/selgame.cpp:334
+#: Source/DiabloUI/selgame.cpp:346 Source/DiabloUI/selgame.cpp:372
 msgid "Faster"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:309 Source/DiabloUI/selgame.cpp:338
+#: Source/DiabloUI/selgame.cpp:347 Source/DiabloUI/selgame.cpp:376
 msgid "Fastest"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:327
+#: Source/DiabloUI/selgame.cpp:365
 #, fuzzy
 #| msgid ""
 #| "Normal Difficulty\n"
@@ -585,7 +632,7 @@ msgstr ""
 "Normal sværhedsgrad\n"
 "Det er her en nybegynder skal starte sin stræben efter at besejre Diablo."
 
-#: Source/DiabloUI/selgame.cpp:331
+#: Source/DiabloUI/selgame.cpp:369
 #, fuzzy
 #| msgid ""
 #| "Nightmare Difficulty\n"
@@ -600,91 +647,91 @@ msgstr ""
 "Borgerne i labyrinten er styrket og vil vise sig at være en større "
 "udfordring. Dette anbefales kun til erfarne helte."
 
-#: Source/DiabloUI/selgame.cpp:335
+#: Source/DiabloUI/selgame.cpp:373
 msgid ""
 "Faster Speed\n"
 "Most monsters of the dungeon will seek you out quicker than ever before. "
 "Only an experienced champion should try their luck at this speed."
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:339
+#: Source/DiabloUI/selgame.cpp:377
 msgid ""
 "Fastest Speed\n"
 "The minions of the underworld will rush to attack without hesitation. Only a "
 "true speed demon should enter at this pace."
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:381 Source/DiabloUI/selgame.cpp:384
+#: Source/DiabloUI/selgame.cpp:420 Source/DiabloUI/selgame.cpp:425
 msgid "Enter Password"
 msgstr "Indtast adgangskode"
 
-#: Source/DiabloUI/selgame.cpp:407
+#: Source/DiabloUI/selgame.cpp:448
 msgid "The host is running a different game than you."
 msgstr ""
 
 #. TRANSLATORS: Error message when somebody tries to join a game running another version.
-#: Source/DiabloUI/selgame.cpp:410
+#: Source/DiabloUI/selgame.cpp:451
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr ""
 
-#: Source/DiabloUI/selhero.cpp:99
+#: Source/DiabloUI/selhero.cpp:100
 msgid "New Hero"
 msgstr "Ny helt"
 
-#: Source/DiabloUI/selhero.cpp:163
+#: Source/DiabloUI/selhero.cpp:164
 msgid "Choose Class"
 msgstr "Vælg klasse"
 
-#: Source/DiabloUI/selhero.cpp:167 Source/panels/charpanel.cpp:22
+#: Source/DiabloUI/selhero.cpp:168 Source/panels/charpanel.cpp:22
 msgid "Warrior"
 msgstr "Kriger"
 
-#: Source/DiabloUI/selhero.cpp:168 Source/panels/charpanel.cpp:23
+#: Source/DiabloUI/selhero.cpp:169 Source/panels/charpanel.cpp:23
 msgid "Rogue"
 msgstr "Skytte"
 
-#: Source/DiabloUI/selhero.cpp:169 Source/panels/charpanel.cpp:24
+#: Source/DiabloUI/selhero.cpp:170 Source/panels/charpanel.cpp:24
 msgid "Sorcerer"
 msgstr "Troldmand"
 
-#: Source/DiabloUI/selhero.cpp:171 Source/panels/charpanel.cpp:25
+#: Source/DiabloUI/selhero.cpp:172 Source/panels/charpanel.cpp:25
 msgid "Monk"
 msgstr ""
 
-#: Source/DiabloUI/selhero.cpp:174 Source/panels/charpanel.cpp:26
+#: Source/DiabloUI/selhero.cpp:175 Source/panels/charpanel.cpp:26
 msgid "Bard"
 msgstr ""
 
-#: Source/DiabloUI/selhero.cpp:177 Source/panels/charpanel.cpp:27
+#: Source/DiabloUI/selhero.cpp:178 Source/panels/charpanel.cpp:27
 msgid "Barbarian"
 msgstr ""
 
-#: Source/DiabloUI/selhero.cpp:194 Source/DiabloUI/selhero.cpp:268
+#: Source/DiabloUI/selhero.cpp:195 Source/DiabloUI/selhero.cpp:269
 msgid "New Multi Player Hero"
 msgstr "Ny multiplayer-helt"
 
-#: Source/DiabloUI/selhero.cpp:194 Source/DiabloUI/selhero.cpp:268
+#: Source/DiabloUI/selhero.cpp:195 Source/DiabloUI/selhero.cpp:269
 msgid "New Single Player Hero"
 msgstr "Ny singleplayer-helt"
 
-#: Source/DiabloUI/selhero.cpp:202
+#: Source/DiabloUI/selhero.cpp:203
 msgid "Save File Exists"
 msgstr "Gem filen findes"
 
-#: Source/DiabloUI/selhero.cpp:205 Source/gamemenu.cpp:38
+#: Source/DiabloUI/selhero.cpp:206 Source/gamemenu.cpp:38
 msgid "Load Game"
 msgstr "Indlæs spil"
 
-#: Source/DiabloUI/selhero.cpp:206 Source/gamemenu.cpp:37
+#: Source/DiabloUI/selhero.cpp:207 Source/gamemenu.cpp:37
 #: Source/gamemenu.cpp:48
 msgid "New Game"
 msgstr "Nyt spil"
 
-#: Source/DiabloUI/selhero.cpp:216 Source/DiabloUI/selhero.cpp:540
+#: Source/DiabloUI/selhero.cpp:217 Source/DiabloUI/selhero.cpp:551
 msgid "Single Player Characters"
 msgstr "Singleplayer-karakterer"
 
-#: Source/DiabloUI/selhero.cpp:262
+#: Source/DiabloUI/selhero.cpp:263
 msgid ""
 "The Rogue and Sorcerer are only available in the full retail version of "
 "Diablo. Visit https://www.gog.com/game/diablo to purchase."
@@ -692,11 +739,11 @@ msgstr ""
 "Skytten og Troldmanden er kun tilgængelige i den fulde detailversion af "
 "Diablo. Besøg https://www.gog.com/game/diablo for at købe den."
 
-#: Source/DiabloUI/selhero.cpp:274 Source/DiabloUI/selhero.cpp:277
+#: Source/DiabloUI/selhero.cpp:275 Source/DiabloUI/selhero.cpp:278
 msgid "Enter Name"
 msgstr "Indtast navn"
 
-#: Source/DiabloUI/selhero.cpp:306
+#: Source/DiabloUI/selhero.cpp:307
 msgid ""
 "Invalid name. A name cannot contain spaces, reserved characters, or reserved "
 "words.\n"
@@ -705,125 +752,110 @@ msgstr ""
 "reserverede ord.\n"
 
 #. TRANSLATORS: Error Message
-#: Source/DiabloUI/selhero.cpp:313
+#: Source/DiabloUI/selhero.cpp:314
 msgid "Unable to create character."
 msgstr "Kunne ikke oprette karakter."
 
-#: Source/DiabloUI/selhero.cpp:467 Source/DiabloUI/selhero.cpp:470
+#: Source/DiabloUI/selhero.cpp:468 Source/DiabloUI/selhero.cpp:471
 msgid "Level:"
 msgstr "Niveau:"
 
-#: Source/DiabloUI/selhero.cpp:475
+#: Source/DiabloUI/selhero.cpp:476
 msgid "Strength:"
 msgstr "Styrke:"
 
-#: Source/DiabloUI/selhero.cpp:480
+#: Source/DiabloUI/selhero.cpp:481
 msgid "Magic:"
 msgstr "Magi:"
 
-#: Source/DiabloUI/selhero.cpp:485
+#: Source/DiabloUI/selhero.cpp:486
 msgid "Dexterity:"
 msgstr "Smidighed:"
 
-#: Source/DiabloUI/selhero.cpp:490
+#: Source/DiabloUI/selhero.cpp:491
 msgid "Vitality:"
 msgstr "Vitalitet:"
 
-#: Source/DiabloUI/selhero.cpp:496
+#: Source/DiabloUI/selhero.cpp:497
 #, fuzzy
 #| msgid "Save Game"
 msgid "Savegame:"
 msgstr "Gem spil"
 
-#: Source/DiabloUI/selhero.cpp:508
+#: Source/DiabloUI/selhero.cpp:510
 msgid "Select Hero"
 msgstr "Vælg helt"
 
-#: Source/DiabloUI/selhero.cpp:528
+#: Source/DiabloUI/selhero.cpp:539
 msgid "Delete"
 msgstr "Slet"
 
-#: Source/DiabloUI/selhero.cpp:538
+#: Source/DiabloUI/selhero.cpp:549
 msgid "Multi Player Characters"
 msgstr "Multiplayer-karakteren"
 
-#: Source/DiabloUI/selhero.cpp:580
+#: Source/DiabloUI/selhero.cpp:599
 msgid "Delete Multi Player Hero"
 msgstr "Slet multiplayer-helt"
 
-#: Source/DiabloUI/selhero.cpp:582
+#: Source/DiabloUI/selhero.cpp:601
 msgid "Delete Single Player Hero"
 msgstr "Slet singleplayer-helt"
 
-#: Source/DiabloUI/selhero.cpp:584
+#: Source/DiabloUI/selhero.cpp:603
 #, fuzzy
 #| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "Er du sikker på, at du vil slette karakteren \"{:s}\"?"
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selstart.cpp:43
+#, fuzzy
+#| msgid "Exit Hellfire"
+msgid "Enter Hellfire"
+msgstr "Afslut Hellfire"
+
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr "Ja"
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr "Nej"
 
 #: Source/DiabloUI/support_lines.cpp:8
-msgid "GOG.com maintains a web site at https://www.gog.com/forum/diablo"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:9
-msgid "Follow the links to visit the discussion boards associated with Diablo."
+msgid ""
+"We maintain a chat server at Discord.gg/YQKCAYQ Follow the links to join our "
+"community where we talk about things related to Diablo, and the Hellfire "
+"expansion."
 msgstr ""
 
 #: Source/DiabloUI/support_lines.cpp:10
-#, fuzzy
-msgid "and the Hellfire expansion."
-msgstr "Afslut Hellfire"
-
-#: Source/DiabloUI/support_lines.cpp:12
 msgid ""
-"DevilutionX is maintained by Diasurgical, issues and bugs can be reported"
+"DevilutionX is maintained by Diasurgical, issues and bugs can be reported at "
+"this address: https://github.com/diasurgical/devilutionX To help us better "
+"serve you, please be sure to include the version number, operating system, "
+"and the nature of the problem."
 msgstr ""
 
 #: Source/DiabloUI/support_lines.cpp:13
-msgid "at this address: https://github.com/diasurgical/devilutionX"
+msgid "Disclaimer:"
 msgstr ""
 
 #: Source/DiabloUI/support_lines.cpp:14
 msgid ""
-"To help us better serve you, please be sure to include the version number,"
+"\tDevilutionX is not supported or maintained by Blizzard Entertainment, nor "
+"GOG.com. Neither Blizzard Entertainment nor GOG.com has tested or certified "
+"the quality or compatibility of DevilutionX. All inquiries regarding "
+"DevilutionX should be directed to Diasurgical, not to Blizzard Entertainment "
+"or GOG.com."
 msgstr ""
 
-#: Source/DiabloUI/support_lines.cpp:15
-msgid "operating system, and the nature of the problem."
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:18
-msgid "Disclaimer:"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:19
-msgid "  DevilutionX is not supported or maintained by Blizzard Entertainment,"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:20
-msgid "  nor GOG.com. Neither Blizzard Entertainment nor GOG.com has tested"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:21
+#: Source/DiabloUI/support_lines.cpp:17
 msgid ""
-"  or certified the quality or compatibility of DevilutionX. All inquiries"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:22
-msgid ""
-"  regarding DevilutionX should be directed to Diasurgical, not to Blizzard"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:23
-msgid "  Entertainment or GOG.com."
+"\tThis port makes use of CharisSILB, Unifont, and Noto which are licensed "
+"under the SIL Open Font License, as well as Twitmoji which is licensed under "
+"CC-BY 4.0. The port also makes use of SDL which is licensed under the zlib-"
+"license. See the ReadMe for further details."
 msgstr ""
 
 #: Source/DiabloUI/title.cpp:44
@@ -832,12 +864,12 @@ msgstr ""
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr "Copyright © 1996-2001 Blizzard Entertainment2"
 
-#: Source/appfat.cpp:37
+#: Source/appfat.cpp:38
 msgid "Error"
 msgstr "Fejl"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:101
+#: Source/appfat.cpp:102
 msgid ""
 "{:s}\n"
 "\n"
@@ -847,7 +879,7 @@ msgstr ""
 "\n"
 "Fejlen opstod ved: {:s} linje {:d}"
 
-#: Source/appfat.cpp:115
+#: Source/appfat.cpp:117
 #, fuzzy
 #| msgid ""
 #| "Unable to open {:s}.\n"
@@ -863,16 +895,13 @@ msgstr ""
 "\n"
 "Sørg for, at den findes i spilmappen, og at filnavnet er med små bogstaver."
 
-msgid "diabdat.mpq or spawn.mpq"
-msgstr "diabdat.mpq eller spawn.mpq"
-
-#: Source/appfat.cpp:119
+#: Source/appfat.cpp:123
 #, fuzzy
 msgid "Data File Error"
 msgstr "Skrivebeskyttet mappe fejl"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:127
+#: Source/appfat.cpp:131
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -880,109 +909,131 @@ msgstr ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#: Source/appfat.cpp:129
+#: Source/appfat.cpp:133
 msgid "Read-Only Directory Error"
 msgstr "Skrivebeskyttet mappe fejl"
 
-#: Source/automap.cpp:468
+#: Source/automap.cpp:484
 #, fuzzy
 msgid "game: "
 msgstr "Multiplayer-spil"
 
-#: Source/automap.cpp:474
+#: Source/automap.cpp:490
 #, fuzzy
 msgid "password: "
 msgstr "Indtast adgangskode"
 
-#: Source/automap.cpp:487
+#: Source/automap.cpp:492
+#, fuzzy
+#| msgid "Quit Diablo"
+msgid "Public Game"
+msgstr "Indlæs spil"
+
+#: Source/automap.cpp:504
 #, fuzzy
 msgid "Level: Nest {:d}"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/automap.cpp:489
+#: Source/automap.cpp:506
 #, fuzzy
 msgid "Level: Crypt {:d}"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/automap.cpp:491 Source/items.cpp:2086
+#: Source/automap.cpp:508 Source/items.cpp:2090
 #, fuzzy
 #| msgid "Level:"
 msgid "Level: {:d}"
 msgstr "Niveau:"
 
-#: Source/control.cpp:196
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr ""
 
-#: Source/control.cpp:196
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr ""
 
-#: Source/control.cpp:196
+#: Source/control.cpp:212
 #, fuzzy
 #| msgid "Enter Name"
 msgid "Enter"
 msgstr "Indtast navn"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:215
 #, fuzzy
 msgid "Character Information"
 msgstr "Kunne ikke oprette karakter."
 
-#: Source/control.cpp:200
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr ""
 
-#: Source/control.cpp:201
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr ""
 
-#: Source/control.cpp:202
+#: Source/control.cpp:218
 #, fuzzy
 msgid "Main Menu"
 msgstr "Forrige menu"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr ""
 
-#: Source/control.cpp:204
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr ""
 
-#: Source/control.cpp:205
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr ""
 
-#: Source/control.cpp:712 Source/control.cpp:1175
+#: Source/control.cpp:718 Source/control.cpp:1587
+msgid "Skill"
+msgstr ""
+
+#: Source/control.cpp:719 Source/control.cpp:1237
 #, fuzzy
 msgid "{:s} Skill"
 msgstr ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#: Source/control.cpp:716 Source/control.cpp:1179
+#: Source/control.cpp:725
+#, fuzzy
+msgid "Spell"
+msgstr ""
+"Kan ikke skrive til lokation:\n"
+"{:s}"
+
+#: Source/control.cpp:726 Source/control.cpp:1241
 #, fuzzy
 msgid "{:s} Spell"
 msgstr ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#: Source/control.cpp:718
+#: Source/control.cpp:728
 #, fuzzy
 msgid "Damages undead only"
 msgstr "Skrivebeskyttet mappe fejl"
 
-#: Source/control.cpp:722 Source/control.cpp:1183 Source/control.cpp:1554
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr ""
 
-#: Source/control.cpp:724 Source/control.cpp:1185 Source/control.cpp:1556
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 #, fuzzy
 msgid "Spell Level {:d}"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/control.cpp:729 Source/control.cpp:1189
+#: Source/control.cpp:741
+#, fuzzy
+msgid "Scroll"
+msgstr "Understøttede spillere: {:d}"
+
+#: Source/control.cpp:742 Source/control.cpp:1251
 #, fuzzy
 #| msgid "Talk to Pepin"
 msgid "Scroll of {:s}"
@@ -990,14 +1041,19 @@ msgstr ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#: Source/control.cpp:745 Source/control.cpp:1206
+#: Source/control.cpp:747 Source/control.cpp:1257
 #, fuzzy
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "Understøttede spillere: {:d}"
 msgstr[1] "Understøttede spillere: {:d}"
 
-#: Source/control.cpp:750 Source/control.cpp:1210 Source/items.cpp:1325
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
+msgid "Staff"
+msgstr ""
+
+#: Source/control.cpp:755 Source/control.cpp:1261
 #, fuzzy
 #| msgid "Talk to Pepin"
 msgid "Staff of {:s}"
@@ -1005,82 +1061,78 @@ msgstr ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#: Source/control.cpp:752 Source/control.cpp:1212
+#: Source/control.cpp:757 Source/control.cpp:1263
 #, fuzzy
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "Understøttede spillere: {:d}"
 msgstr[1] "Understøttede spillere: {:d}"
 
-#: Source/control.cpp:762
+#: Source/control.cpp:767
 #, fuzzy
 msgid "Spell Hotkey {:s}"
 msgstr ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#: Source/control.cpp:1152
+#: Source/control.cpp:1214
 #, fuzzy
 msgid "Player friendly"
 msgstr "Multiplayer-spil"
 
-#: Source/control.cpp:1154
+#: Source/control.cpp:1216
 #, fuzzy
 msgid "Player attack"
 msgstr "Singleplayer"
 
-#: Source/control.cpp:1157
+#: Source/control.cpp:1219
 #, fuzzy
 msgid "Hotkey: {:s}"
 msgstr ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#: Source/control.cpp:1165
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr ""
 
-#: Source/control.cpp:1168
+#: Source/control.cpp:1230
 #, fuzzy
 msgid "Hotkey: 's'"
 msgstr ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#: Source/control.cpp:1334 Source/inv.cpp:1893 Source/items.cpp:3751
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 #, fuzzy
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "Understøttede spillere: {:d}"
 msgstr[1] "Understøttede spillere: {:d}"
 
-#: Source/control.cpp:1337
+#: Source/control.cpp:1390
 #, fuzzy
 #| msgid "Requirements:"
 msgid "Requirements not met"
 msgstr "Krav:"
 
-#: Source/control.cpp:1373
+#: Source/control.cpp:1426
 #, fuzzy
 msgid "{:s}, Level: {:d}"
 msgstr "Niveau:"
 
-#: Source/control.cpp:1375
+#: Source/control.cpp:1428
 #, fuzzy
 msgid "Hit Points {:d} of {:d}"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/control.cpp:1402
+#: Source/control.cpp:1457
 #, fuzzy
 #| msgid "Level:"
 msgid "Level Up"
 msgstr "Niveau:"
 
-#: Source/control.cpp:1532
-msgid "Skill"
-msgstr ""
-
-#: Source/control.cpp:1536
+#: Source/control.cpp:1591
 #, fuzzy
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
@@ -1088,7 +1140,7 @@ msgstr[0] "Understøttede spillere: {:d}"
 msgstr[1] "Understøttede spillere: {:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1544
+#: Source/control.cpp:1601
 #, fuzzy
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr ""
@@ -1097,17 +1149,17 @@ msgstr ""
 "Fejlen opstod ved: {:s} linje {:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1546
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr ""
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1549
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr ""
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1606
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] ""
@@ -1163,55 +1215,55 @@ msgstr ""
 msgid "level 15"
 msgstr "Niveau:"
 
-#: Source/diablo.cpp:111
+#: Source/diablo.cpp:114
 msgid "I need help! Come Here!"
 msgstr ""
 
-#: Source/diablo.cpp:112
+#: Source/diablo.cpp:115
 msgid "Follow me."
 msgstr ""
 
-#: Source/diablo.cpp:113
+#: Source/diablo.cpp:116
 #, fuzzy
 msgid "Here's something for you."
 msgstr "Har du lyst til:"
 
-#: Source/diablo.cpp:114
+#: Source/diablo.cpp:117
 #, fuzzy
 msgid "Now you DIE!"
 msgstr "Har du lyst til:"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:777
+#: Source/diablo.cpp:781
 #, fuzzy
 #| msgid "Options"
 msgid "Options:\n"
 msgstr "Indstillinger"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:778
+#: Source/diablo.cpp:782
 #, fuzzy
 msgid "Print this message and exit"
 msgstr "Afslut Hellfire"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:779
+#: Source/diablo.cpp:783
 #, fuzzy
 msgid "Print the version and exit"
 msgstr "Afslut Hellfire"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:780
+#: Source/diablo.cpp:784
 msgid "Specify the folder of diabdat.mpq"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:781
+#: Source/diablo.cpp:785
 msgid "Specify the folder of save files"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:782
+#: Source/diablo.cpp:786
 #, fuzzy
 msgid "Specify the location of diablo.ini"
 msgstr ""
@@ -1219,59 +1271,68 @@ msgstr ""
 "{:s}"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:783
-msgid "Specify the location of the .ttf font"
-msgstr ""
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:784
-msgid "Specify the name of a custom .ttf font"
-msgstr ""
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:785
+#: Source/diablo.cpp:787
 msgid "Skip startup videos"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:786
+#: Source/diablo.cpp:788
 msgid "Display frames per second"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:787
+#: Source/diablo.cpp:789
 msgid "Run in windowed mode"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:788
+#: Source/diablo.cpp:790
 msgid "Enable verbose logging"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:789
-msgid "Force spawn mode even if diabdat.mpq is found"
-msgstr ""
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:790
+#: Source/diablo.cpp:791
 #, fuzzy
 msgid "Record a demo file"
 msgstr "Gem filen findes"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:791
+#: Source/diablo.cpp:792
 #, fuzzy
 msgid "Play a demo file"
 msgstr "Gem filen findes"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:792
+#: Source/diablo.cpp:793
 msgid "Disable all frame limiting during demo playback"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:793
+#: Source/diablo.cpp:794
+msgid ""
+"\n"
+"Game selection:\n"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:795
+msgid "Force Shareware mode"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:796
+msgid "Force Diablo mode"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:797
+#, fuzzy
+#| msgid "Exit Hellfire"
+msgid "Force Hellfire mode"
+msgstr "Afslut Hellfire"
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:798
 #, fuzzy
 msgid ""
 "\n"
@@ -1279,16 +1340,11 @@ msgid ""
 msgstr "Indstillinger"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:794
-msgid "Force diablo mode even if hellfire.mpq is found"
-msgstr ""
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:795
+#: Source/diablo.cpp:799
 msgid "Use alternate nest palette"
 msgstr ""
 
-#: Source/diablo.cpp:801
+#: Source/diablo.cpp:805
 msgid ""
 "\n"
 "Report bugs at https://github.com/diasurgical/devilutionX/\n"
@@ -1308,310 +1364,310 @@ msgstr ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#: Source/diablo.cpp:1206
+#: Source/diablo.cpp:1218
 #, fuzzy
 msgid "-- Network timeout --"
 msgstr "Bestilling af netværksinformationstjenester"
 
-#: Source/diablo.cpp:1207
+#: Source/diablo.cpp:1219
 #, fuzzy
 msgid "-- Waiting for players --"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/diablo.cpp:1226
+#: Source/diablo.cpp:1238
 msgid "No help available"
 msgstr ""
 
-#: Source/diablo.cpp:1227
+#: Source/diablo.cpp:1239
 msgid "while in stores"
 msgstr ""
 
 #. TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty.
-#: Source/diablo.cpp:1439
+#: Source/diablo.cpp:1451
 #, fuzzy
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#: Source/dvlnet/loopback.cpp:111
+#: Source/dvlnet/loopback.cpp:113
 #, fuzzy
 #| msgid "Loopback"
 msgid "loopback"
 msgstr "Loopback"
 
-#: Source/dvlnet/tcp_client.cpp:68
+#: Source/dvlnet/tcp_client.cpp:65
 #, fuzzy
 #| msgid "Unable to create character."
 msgid "Unable to connect"
 msgstr "Kunne ikke oprette karakter."
 
-#: Source/dvlnet/tcp_client.cpp:89
+#: Source/dvlnet/tcp_client.cpp:86
 msgid "error: read 0 bytes from server"
 msgstr ""
 
-#: Source/error.cpp:58
+#: Source/error.cpp:57
 #, fuzzy
 msgid "No automap available in town"
 msgstr "Genstart i byen"
 
-#: Source/error.cpp:59
+#: Source/error.cpp:58
 msgid "No multiplayer functions in demo"
 msgstr ""
 
-#: Source/error.cpp:60
+#: Source/error.cpp:59
 msgid "Direct Sound Creation Failed"
 msgstr ""
 
-#: Source/error.cpp:61
+#: Source/error.cpp:60
 msgid "Not available in shareware version"
 msgstr ""
 
-#: Source/error.cpp:62
+#: Source/error.cpp:61
 #, fuzzy
 msgid "Not enough space to save"
 msgstr "Gem filen findes"
 
-#: Source/error.cpp:63
+#: Source/error.cpp:62
 #, fuzzy
 msgid "No Pause in town"
 msgstr "Pause"
 
-#: Source/error.cpp:64
+#: Source/error.cpp:63
 msgid "Copying to a hard disk is recommended"
 msgstr ""
 
-#: Source/error.cpp:65
+#: Source/error.cpp:64
 msgid "Multiplayer sync problem"
 msgstr ""
 
-#: Source/error.cpp:66
+#: Source/error.cpp:65
 #, fuzzy
 msgid "No pause in multiplayer"
 msgstr "Pause"
 
-#: Source/error.cpp:67
+#: Source/error.cpp:66
 msgid "Loading..."
 msgstr ""
 
-#: Source/error.cpp:68
+#: Source/error.cpp:67
 msgid "Saving..."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:69
+#: Source/error.cpp:68
 msgid "Some are weakened as one grows strong"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:70
+#: Source/error.cpp:69
 msgid "New strength is forged through destruction"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:71
+#: Source/error.cpp:70
 msgid "Those who defend seldom attack"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:72
+#: Source/error.cpp:71
 msgid "The sword of justice is swift and sharp"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:73
+#: Source/error.cpp:72
 msgid "While the spirit is vigilant the body thrives"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:74
+#: Source/error.cpp:73
 msgid "The powers of mana refocused renews"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:75
+#: Source/error.cpp:74
 msgid "Time cannot diminish the power of steel"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:76
+#: Source/error.cpp:75
 msgid "Magic is not always what it seems to be"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:77
+#: Source/error.cpp:76
 msgid "What once was opened now is closed"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:78
+#: Source/error.cpp:77
 msgid "Intensity comes at the cost of wisdom"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:79
+#: Source/error.cpp:78
 msgid "Arcane power brings destruction"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:80
+#: Source/error.cpp:79
 msgid "That which cannot be held cannot be harmed"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:81
+#: Source/error.cpp:80
 msgid "Crimson and Azure become as the sun"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:82
+#: Source/error.cpp:81
 msgid "Knowledge and wisdom at the cost of self"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:83
+#: Source/error.cpp:82
 msgid "Drink and be refreshed"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:84
+#: Source/error.cpp:83
 #, fuzzy
 msgid "Wherever you go, there you are"
 msgstr "Har du lyst til:"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:85
+#: Source/error.cpp:84
 msgid "Energy comes at the cost of wisdom"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:86
+#: Source/error.cpp:85
 msgid "Riches abound when least expected"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:87
+#: Source/error.cpp:86
 msgid "Where avarice fails, patience gains reward"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:88
+#: Source/error.cpp:87
 msgid "Blessed by a benevolent companion!"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:89
+#: Source/error.cpp:88
 msgid "The hands of men may be guided by fate"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:90
+#: Source/error.cpp:89
 msgid "Strength is bolstered by heavenly faith"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:91
+#: Source/error.cpp:90
 msgid "The essence of life flows from within"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:92
+#: Source/error.cpp:91
 msgid "The way is made clear when viewed from above"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:93
+#: Source/error.cpp:92
 msgid "Salvation comes at the cost of wisdom"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:94
+#: Source/error.cpp:93
 msgid "Mysteries are revealed in the light of reason"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:95
+#: Source/error.cpp:94
 msgid "Those who are last may yet be first"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:96
+#: Source/error.cpp:95
 msgid "Generosity brings its own rewards"
 msgstr ""
 
-#: Source/error.cpp:97
+#: Source/error.cpp:96
 msgid "You must be at least level 8 to use this."
 msgstr ""
 
-#: Source/error.cpp:98
+#: Source/error.cpp:97
 msgid "You must be at least level 13 to use this."
 msgstr ""
 
-#: Source/error.cpp:99
+#: Source/error.cpp:98
 msgid "You must be at least level 17 to use this."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:100
+#: Source/error.cpp:99
 msgid "Arcane knowledge gained!"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:101
+#: Source/error.cpp:100
 msgid "That which does not kill you..."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:102
+#: Source/error.cpp:101
 msgid "Knowledge is power."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:103
+#: Source/error.cpp:102
 msgid "Give and you shall receive."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:104
+#: Source/error.cpp:103
 msgid "Some experience is gained by touch."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:105
+#: Source/error.cpp:104
 #, fuzzy
 msgid "There's no place like home."
 msgstr "Forlad healers hjem"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:106
+#: Source/error.cpp:105
 msgid "Spiritual energy is restored."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:107
+#: Source/error.cpp:106
 msgid "You feel more agile."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:108
+#: Source/error.cpp:107
 #, fuzzy
 msgid "You feel stronger."
 msgstr "Har du lyst til:"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:109
+#: Source/error.cpp:108
 #, fuzzy
 msgid "You feel wiser."
 msgstr "Har du lyst til:"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:110
+#: Source/error.cpp:109
 #, fuzzy
 msgid "You feel refreshed."
 msgstr "Har du lyst til:"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:111
+#: Source/error.cpp:110
 msgid "That which can break will."
 msgstr ""
 
@@ -1640,10 +1696,6 @@ msgstr "Gamma"
 #: Source/gamemenu.cpp:60 Source/gamemenu.cpp:167
 msgid "Speed"
 msgstr ""
-
-#: Source/gamemenu.cpp:61
-msgid "Previous Menu"
-msgstr "Forrige menu"
 
 #: Source/gamemenu.cpp:68
 msgid "Music Disabled"
@@ -1809,7 +1861,7 @@ msgid ""
 msgstr ""
 
 #: Source/help.cpp:68
-msgid "$Gold"
+msgid "$Gold:"
 msgstr ""
 
 #: Source/help.cpp:69
@@ -1832,7 +1884,7 @@ msgid ""
 msgstr ""
 
 #: Source/help.cpp:79
-msgid "$Using the Speedbook for Spells"
+msgid "$Using the Speedbook for Spells:"
 msgstr ""
 
 #: Source/help.cpp:80
@@ -1845,12 +1897,15 @@ msgstr ""
 #: Source/help.cpp:84
 msgid ""
 "Shift + Left-clicking on the 'select current spell' button will clear the "
-"readied spell"
+"readied spell."
 msgstr ""
 
 #: Source/help.cpp:86
-msgid "$Setting Spell Hotkeys"
+#, fuzzy
+msgid "$Setting Spell Hotkeys:"
 msgstr ""
+"Kan ikke skrive til lokation:\n"
+"{:s}"
 
 #: Source/help.cpp:87
 msgid ""
@@ -1860,8 +1915,11 @@ msgid ""
 msgstr ""
 
 #: Source/help.cpp:92
-msgid "$Spell Books"
+#, fuzzy
+msgid "$Spell Books:"
 msgstr ""
+"Kan ikke skrive til lokation:\n"
+"{:s}"
 
 #: Source/help.cpp:93
 msgid ""
@@ -1869,48 +1927,52 @@ msgid ""
 "you to cast the spell more effectively."
 msgstr ""
 
-#: Source/help.cpp:130
+#: Source/help.cpp:181
 #, fuzzy
 msgid "Shareware Hellfire Help"
 msgstr "Afslut Hellfire"
 
-#: Source/help.cpp:130
+#: Source/help.cpp:181
 #, fuzzy
 #| msgid "Exit Hellfire"
 msgid "Hellfire Help"
 msgstr "Afslut Hellfire"
 
-#: Source/help.cpp:132
+#: Source/help.cpp:183
 #, fuzzy
 msgid "Shareware Diablo Help"
 msgstr "Diablo Strike Team"
 
-#: Source/help.cpp:132
+#: Source/help.cpp:183
 #, fuzzy
 msgid "Diablo Help"
 msgstr "Afslut Diablo"
 
-#: Source/help.cpp:156
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr ""
 
-#: Source/init.cpp:214
+#: Source/init.cpp:175
+msgid "diabdat.mpq or spawn.mpq"
+msgstr "diabdat.mpq eller spawn.mpq"
+
+#: Source/init.cpp:196
 msgid "Some Hellfire MPQs are missing"
 msgstr ""
 
-#: Source/init.cpp:214
+#: Source/init.cpp:196
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
 msgstr ""
 
-#: Source/init.cpp:224
+#: Source/init.cpp:204
 #, fuzzy
 #| msgid "Unable to create character."
 msgid "Unable to create main window"
 msgstr "Kunne ikke oprette karakter."
 
-#: Source/itemdat.cpp:16 Source/itemdat.cpp:198 Source/panels/charpanel.cpp:154
+#: Source/itemdat.cpp:16 Source/itemdat.cpp:198 Source/panels/charpanel.cpp:155
 msgid "Gold"
 msgstr ""
 
@@ -2056,7 +2118,7 @@ msgstr ""
 msgid "Scroll of Resurrect"
 msgstr ""
 
-#: Source/itemdat.cpp:51 Source/itemdat.cpp:99 Source/items.cpp:164
+#: Source/itemdat.cpp:51 Source/itemdat.cpp:99 Source/items.cpp:166
 msgid "Blacksmith Oil"
 msgstr ""
 
@@ -2156,7 +2218,7 @@ msgid "Quilted Armor"
 msgstr ""
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
-#: Source/itemdat.cpp:77 Source/objects.cpp:5459
+#: Source/itemdat.cpp:77 Source/objects.cpp:5433
 msgid "Armor"
 msgstr ""
 
@@ -2252,11 +2314,11 @@ msgstr ""
 msgid "Potion of Full Rejuvenation"
 msgstr ""
 
-#: Source/itemdat.cpp:100 Source/items.cpp:159
+#: Source/itemdat.cpp:100 Source/items.cpp:161
 msgid "Oil of Accuracy"
 msgstr ""
 
-#: Source/itemdat.cpp:101 Source/items.cpp:161
+#: Source/itemdat.cpp:101 Source/items.cpp:163
 msgid "Oil of Sharpness"
 msgstr ""
 
@@ -2491,11 +2553,6 @@ msgstr ""
 msgid "Long War Bow"
 msgstr ""
 
-#: Source/itemdat.cpp:167 Source/itemdat.cpp:168 Source/itemdat.cpp:169
-#: Source/itemdat.cpp:170 Source/itemdat.cpp:171
-msgid "Staff"
-msgstr ""
-
 #: Source/itemdat.cpp:168
 msgid "Long Staff"
 msgstr ""
@@ -2587,7 +2644,7 @@ msgstr ""
 msgid "Meteoric"
 msgstr ""
 
-#: Source/itemdat.cpp:202 Source/objects.cpp:104
+#: Source/itemdat.cpp:202 Source/objects.cpp:107
 msgid "Weird"
 msgstr ""
 
@@ -2725,7 +2782,7 @@ msgstr ""
 msgid "Awesome"
 msgstr ""
 
-#: Source/itemdat.cpp:237 Source/objects.cpp:116
+#: Source/itemdat.cpp:237 Source/objects.cpp:119
 msgid "Holy"
 msgstr ""
 
@@ -3726,256 +3783,286 @@ msgstr ""
 msgid "Gladiator's Ring"
 msgstr "Ringen af et tusinde"
 
-#: Source/items.cpp:160
+#: Source/items.cpp:162
 msgid "Oil of Mastery"
 msgstr ""
 
-#: Source/items.cpp:162
+#: Source/items.cpp:164
 msgid "Oil of Death"
 msgstr ""
 
-#: Source/items.cpp:163
+#: Source/items.cpp:165
 msgid "Oil of Skill"
 msgstr ""
 
-#: Source/items.cpp:165
+#: Source/items.cpp:167
 msgid "Oil of Fortitude"
 msgstr ""
 
-#: Source/items.cpp:166
+#: Source/items.cpp:168
 msgid "Oil of Permanence"
 msgstr ""
 
-#: Source/items.cpp:167
+#: Source/items.cpp:169
 msgid "Oil of Hardening"
 msgstr ""
 
-#: Source/items.cpp:168
+#: Source/items.cpp:170
 msgid "Oil of Imperviousness"
 msgstr ""
 
-#. TRANSLATORS: Constructs item names. Format: <Prefix> <Item> of <Suffix>. Example: King's Long Sword of the Whale
-#: Source/items.cpp:1194 Source/items.cpp:1262 Source/items.cpp:1281
-#: Source/items.cpp:1324
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
 #, fuzzy
-msgid "{:s} of {:s}"
+msgctxt "spell"
+msgid "{0} of {1}"
 msgstr ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#: Source/items.cpp:1902 Source/items.cpp:1914
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+#, fuzzy
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr ""
+"Kan ikke skrive til lokation:\n"
+"{:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+#, fuzzy
+msgid "{0} {1} of {2}"
+msgstr ""
+"Kan ikke skrive til lokation:\n"
+"{:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
+#: Source/items.cpp:1217
+msgid "{0} {1}"
+msgstr ""
+
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
+#, fuzzy
+msgid "{0} of {1}"
+msgstr ""
+"Kan ikke skrive til lokation:\n"
+"{:s}"
+
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr ""
 
-#: Source/items.cpp:1904
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr ""
 
-#: Source/items.cpp:1908
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr ""
 
-#: Source/items.cpp:1910
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr ""
 
-#: Source/items.cpp:1916
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr ""
 
-#: Source/items.cpp:1920
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr ""
 
-#: Source/items.cpp:1922
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr ""
 
-#: Source/items.cpp:1926
+#: Source/items.cpp:1930
 #, fuzzy
 msgid "reduces attributes needed"
 msgstr "ingen gateway"
 
-#: Source/items.cpp:1928
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr ""
 
-#: Source/items.cpp:1932
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr ""
 
-#: Source/items.cpp:1934
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr ""
 
-#: Source/items.cpp:1938
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr ""
 
-#: Source/items.cpp:1940
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr ""
 
-#: Source/items.cpp:1944
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr ""
 
-#: Source/items.cpp:1948
+#: Source/items.cpp:1952
 #, fuzzy
 msgid "increases the armor class"
 msgstr "Vælg klasse"
 
-#: Source/items.cpp:1950
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr ""
 
-#: Source/items.cpp:1954
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr ""
 
-#: Source/items.cpp:1956
+#: Source/items.cpp:1960
 #, fuzzy
 msgid "class of armor and shields"
 msgstr "Vælg klasse"
 
-#: Source/items.cpp:1960 Source/items.cpp:1969
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr ""
 
-#: Source/items.cpp:1965
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr ""
 
-#: Source/items.cpp:1973
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr ""
 
-#: Source/items.cpp:1977
+#: Source/items.cpp:1981
 msgid "restore all life"
 msgstr ""
 
-#: Source/items.cpp:1981
+#: Source/items.cpp:1985
 msgid "restore some life"
 msgstr ""
 
-#: Source/items.cpp:1985
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr ""
 
-#: Source/items.cpp:1989
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr ""
 
-#: Source/items.cpp:1993
+#: Source/items.cpp:1997
 msgid "restore some mana"
 msgstr ""
 
-#: Source/items.cpp:1997
+#: Source/items.cpp:2001
 msgid "restore all mana"
 msgstr ""
 
-#: Source/items.cpp:2001
+#: Source/items.cpp:2005
 #, fuzzy
 msgid "increase strength"
 msgstr "Styrke:"
 
-#: Source/items.cpp:2005
+#: Source/items.cpp:2009
 #, fuzzy
 msgid "increase magic"
 msgstr "Magi:"
 
-#: Source/items.cpp:2009
+#: Source/items.cpp:2013
 #, fuzzy
 msgid "increase dexterity"
 msgstr "Smidighed:"
 
-#: Source/items.cpp:2013
+#: Source/items.cpp:2017
 #, fuzzy
 msgid "increase vitality"
 msgstr "Vitalitet:"
 
-#: Source/items.cpp:2018
+#: Source/items.cpp:2022
 #, fuzzy
 msgid "decrease strength"
 msgstr "Styrke:"
 
-#: Source/items.cpp:2022
+#: Source/items.cpp:2026
 #, fuzzy
 msgid "decrease dexterity"
 msgstr "Smidighed:"
 
-#: Source/items.cpp:2026
+#: Source/items.cpp:2030
 #, fuzzy
 msgid "decrease vitality"
 msgstr "Vitalitet:"
 
-#: Source/items.cpp:2030
+#: Source/items.cpp:2034
 msgid "restore some life and mana"
 msgstr ""
 
-#: Source/items.cpp:2034
+#: Source/items.cpp:2038
 msgid "restore all life and mana"
 msgstr ""
 
-#: Source/items.cpp:2049 Source/items.cpp:2074
+#: Source/items.cpp:2053 Source/items.cpp:2078
 #, fuzzy
 msgid "Right-click to read"
 msgstr "Skrivebeskyttet mappe fejl"
 
-#: Source/items.cpp:2053
+#: Source/items.cpp:2057
 #, fuzzy
 msgid "Right-click to read, then"
 msgstr "Skrivebeskyttet mappe fejl"
 
-#: Source/items.cpp:2055
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr ""
 
-#: Source/items.cpp:2060
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr ""
 
-#: Source/items.cpp:2065 Source/items.cpp:2070
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr ""
 
-#: Source/items.cpp:2078
+#: Source/items.cpp:2082
 #, fuzzy
 msgid "Right click to read"
 msgstr "Skrivebeskyttet mappe fejl"
 
-#: Source/items.cpp:2082
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr ""
 
-#: Source/items.cpp:2090
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr ""
 
-#: Source/items.cpp:2102 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 #, fuzzy
 #| msgid "Requirements:"
 msgid "Required:"
 msgstr "Krav:"
 
-#: Source/items.cpp:2104 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 #, fuzzy
 msgid " {:d} Str"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:2106 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 #, fuzzy
 msgid " {:d} Mag"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:2108 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 #, fuzzy
 msgid " {:d} Dex"
 msgstr "Understøttede spillere: {:d}"
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3535 Source/player.cpp:3042
+#: Source/items.cpp:3533 Source/player.cpp:3018
 #, fuzzy
 #| msgid "Talk to Pepin"
 msgid "Ear of {:s}"
@@ -3983,17 +4070,17 @@ msgstr ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#: Source/items.cpp:3830
+#: Source/items.cpp:3828
 #, fuzzy
 msgid "chance to hit: {:+d}%"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:3834
+#: Source/items.cpp:3832
 #, fuzzy, no-c-format
 msgid "{:+d}% damage"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:3838 Source/items.cpp:4094
+#: Source/items.cpp:3836 Source/items.cpp:4092
 #, fuzzy
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr ""
@@ -4001,77 +4088,77 @@ msgstr ""
 "\n"
 "Fejlen opstod ved: {:s} linje {:d}"
 
-#: Source/items.cpp:3842
+#: Source/items.cpp:3840
 #, fuzzy, no-c-format
 msgid "{:+d}% armor"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:3846
+#: Source/items.cpp:3844
 #, fuzzy
 msgid "armor class: {:d}"
 msgstr "Vælg klasse"
 
-#: Source/items.cpp:3851 Source/items.cpp:4076
+#: Source/items.cpp:3849 Source/items.cpp:4074
 #, fuzzy
 msgid "Resist Fire: {:+d}%"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:3853
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr ""
 
-#: Source/items.cpp:3858
+#: Source/items.cpp:3856
 #, fuzzy
 msgid "Resist Lightning: {:+d}%"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:3860
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr ""
 
-#: Source/items.cpp:3865
+#: Source/items.cpp:3863
 #, fuzzy
 msgid "Resist Magic: {:+d}%"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:3867
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr ""
 
-#: Source/items.cpp:3872
+#: Source/items.cpp:3870
 #, fuzzy
 msgid "Resist All: {:+d}%"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:3874
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr ""
 
-#: Source/items.cpp:3878
+#: Source/items.cpp:3876
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Source/items.cpp:3880
+#: Source/items.cpp:3878
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Source/items.cpp:3882
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr ""
 
-#: Source/items.cpp:3885
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr ""
 
-#: Source/items.cpp:3888
+#: Source/items.cpp:3886
 #, fuzzy
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
@@ -4082,109 +4169,109 @@ msgstr[1] ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#: Source/items.cpp:3892
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr ""
 
-#: Source/items.cpp:3894
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3898
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr ""
 
-#: Source/items.cpp:3900
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3904
+#: Source/items.cpp:3902
 #, fuzzy
 msgid "{:+d} to strength"
 msgstr "Styrke:"
 
-#: Source/items.cpp:3908
+#: Source/items.cpp:3906
 #, fuzzy
 msgid "{:+d} to magic"
 msgstr "Magi:"
 
-#: Source/items.cpp:3912
+#: Source/items.cpp:3910
 #, fuzzy
 msgid "{:+d} to dexterity"
 msgstr "Smidighed:"
 
-#: Source/items.cpp:3916
+#: Source/items.cpp:3914
 #, fuzzy
 msgid "{:+d} to vitality"
 msgstr "Vitalitet:"
 
-#: Source/items.cpp:3920
+#: Source/items.cpp:3918
 #, fuzzy
 msgid "{:+d} to all attributes"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:3924
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr ""
 
-#: Source/items.cpp:3928
+#: Source/items.cpp:3926
 #, fuzzy
 msgid "Hit Points: {:+d}"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:3932
+#: Source/items.cpp:3930
 #, fuzzy
 msgid "Mana: {:+d}"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:3935
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr ""
 
-#: Source/items.cpp:3938
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr ""
 
-#: Source/items.cpp:3941
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr ""
 
-#: Source/items.cpp:3944
+#: Source/items.cpp:3942
 #, fuzzy, no-c-format
 msgid "+{:d}% light radius"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:3947
+#: Source/items.cpp:3945
 #, fuzzy, no-c-format
 msgid "-{:d}% light radius"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:3950
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr ""
 
-#: Source/items.cpp:3954
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr ""
 
-#: Source/items.cpp:3956
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3960
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr ""
 
-#: Source/items.cpp:3962
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3966
+#: Source/items.cpp:3964
 #, fuzzy
 msgid "fireball damage: {:d}"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:3968
+#: Source/items.cpp:3966
 #, fuzzy
 msgid "fireball damage: {:d}-{:d}"
 msgstr ""
@@ -4192,147 +4279,147 @@ msgstr ""
 "\n"
 "Fejlen opstod ved: {:s} linje {:d}"
 
-#: Source/items.cpp:3971
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr ""
 
-#: Source/items.cpp:3974
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr ""
 
-#: Source/items.cpp:3977
+#: Source/items.cpp:3975
 #, fuzzy
 msgid "you can't heal"
 msgstr "Har du lyst til:"
 
-#: Source/items.cpp:3980
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr ""
 
-#: Source/items.cpp:3983
+#: Source/items.cpp:3981
 msgid "knocks target back"
 msgstr ""
 
-#: Source/items.cpp:3986
+#: Source/items.cpp:3984
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr ""
 
-#: Source/items.cpp:3989
+#: Source/items.cpp:3987
 msgid "All Resistance equals 0"
 msgstr ""
 
-#: Source/items.cpp:3992
+#: Source/items.cpp:3990
 msgid "hit monster doesn't heal"
 msgstr ""
 
-#: Source/items.cpp:3996
+#: Source/items.cpp:3994
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr ""
 
-#: Source/items.cpp:3998
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr ""
 
-#: Source/items.cpp:4002
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr ""
 
-#: Source/items.cpp:4004
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr ""
 
-#: Source/items.cpp:4007
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr ""
 
-#: Source/items.cpp:4011
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr ""
 
-#: Source/items.cpp:4013
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr ""
 
-#: Source/items.cpp:4015
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr ""
 
-#: Source/items.cpp:4017
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr ""
 
-#: Source/items.cpp:4021
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr ""
 
-#: Source/items.cpp:4023
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr ""
 
-#: Source/items.cpp:4025
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr ""
 
-#: Source/items.cpp:4028
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr ""
 
-#: Source/items.cpp:4031
+#: Source/items.cpp:4029
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Source/items.cpp:4034
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr ""
 
-#: Source/items.cpp:4037
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr ""
 
-#: Source/items.cpp:4040
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr ""
 
-#: Source/items.cpp:4043
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr ""
 
-#: Source/items.cpp:4046
+#: Source/items.cpp:4044
 #, fuzzy
 #| msgid "Enter Password"
 msgid "one handed sword"
 msgstr "Ringen af et tusinde"
 
-#: Source/items.cpp:4049
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr ""
 
-#: Source/items.cpp:4052
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr ""
 
-#: Source/items.cpp:4055
+#: Source/items.cpp:4053
 #, fuzzy
 msgid "no strength requirement"
 msgstr "Styrke:"
 
-#: Source/items.cpp:4058
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr ""
 
-#: Source/items.cpp:4065
+#: Source/items.cpp:4063
 #, fuzzy
 msgid "lightning damage: {:d}"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:4067
+#: Source/items.cpp:4065
 #, fuzzy
 msgid "lightning damage: {:d}-{:d}"
 msgstr ""
@@ -4340,62 +4427,62 @@ msgstr ""
 "\n"
 "Fejlen opstod ved: {:s} linje {:d}"
 
-#: Source/items.cpp:4070
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr ""
 
-#: Source/items.cpp:4079
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr ""
 
-#: Source/items.cpp:4082
+#: Source/items.cpp:4080
 #, fuzzy, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:4085
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr ""
 
-#: Source/items.cpp:4088
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr ""
 
-#: Source/items.cpp:4091
+#: Source/items.cpp:4089
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr ""
 
-#: Source/items.cpp:4097
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr ""
 
-#: Source/items.cpp:4100
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr ""
 
-#: Source/items.cpp:4103
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr ""
 
-#: Source/items.cpp:4106
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr ""
 
-#: Source/items.cpp:4109
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr ""
 
-#: Source/items.cpp:4146 Source/items.cpp:4193
+#: Source/items.cpp:4144 Source/items.cpp:4191
 #, fuzzy
 msgid "damage: {:d}  Indestructible"
 msgstr "Understøttede spillere: {:d}"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4148 Source/items.cpp:4195
+#: Source/items.cpp:4146 Source/items.cpp:4193
 #, fuzzy
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr ""
@@ -4403,7 +4490,7 @@ msgstr ""
 "\n"
 "Fejlen opstod ved: {:s} linje {:d}"
 
-#: Source/items.cpp:4151 Source/items.cpp:4198
+#: Source/items.cpp:4149 Source/items.cpp:4196
 #, fuzzy
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr ""
@@ -4412,7 +4499,7 @@ msgstr ""
 "Fejlen opstod ved: {:s} linje {:d}"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4153 Source/items.cpp:4200
+#: Source/items.cpp:4151 Source/items.cpp:4198
 #, fuzzy
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr ""
@@ -4420,13 +4507,13 @@ msgstr ""
 "\n"
 "Fejlen opstod ved: {:s} linje {:d}"
 
-#: Source/items.cpp:4159 Source/items.cpp:4212
+#: Source/items.cpp:4157 Source/items.cpp:4210
 #, fuzzy
 msgid "armor: {:d}  Indestructible"
 msgstr "Understøttede spillere: {:d}"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4161 Source/items.cpp:4214
+#: Source/items.cpp:4159 Source/items.cpp:4212
 #, fuzzy
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr ""
@@ -4435,13 +4522,13 @@ msgstr ""
 "Fejlen opstod ved: {:s} linje {:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4166
+#: Source/items.cpp:4164
 #, fuzzy
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "Understøttede spillere: {:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4168
+#: Source/items.cpp:4166
 #, fuzzy
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr ""
@@ -4449,46 +4536,56 @@ msgstr ""
 "\n"
 "Fejlen opstod ved: {:s} linje {:d}"
 
-#: Source/items.cpp:4169 Source/items.cpp:4204 Source/items.cpp:4219
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 #, fuzzy
 msgid "Charges: {:d}/{:d}"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/items.cpp:4181
+#: Source/items.cpp:4179
 #, fuzzy
 #| msgid "Buy items"
 msgid "unique item"
 msgstr "Køb varer"
 
-#: Source/items.cpp:4208 Source/items.cpp:4217 Source/items.cpp:4224
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr ""
 
-#: Source/loadsave.cpp:1656 Source/loadsave.cpp:2122
+#: Source/loadsave.cpp:1683 Source/loadsave.cpp:2149
 #, fuzzy
 #| msgid "Unable to create character."
 msgid "Unable to open save file archive"
 msgstr "Kunne ikke oprette karakter."
 
-#: Source/loadsave.cpp:1659
+#: Source/loadsave.cpp:1686
 #, fuzzy
 msgid "Invalid save file"
 msgstr "Gem filen findes"
 
-#: Source/loadsave.cpp:1688
+#: Source/loadsave.cpp:1717
 msgid "Player is on a Hellfire only level"
 msgstr ""
 
-#: Source/loadsave.cpp:1885
+#: Source/loadsave.cpp:1912
 #, fuzzy
 msgid "Invalid game state"
 msgstr "Spildesign"
 
-#: Source/menu.cpp:136
+#: Source/menu.cpp:154
 #, fuzzy
 msgid "Unable to display mainmenu"
 msgstr "Kunne ikke oprette karakter."
+
+#. TRANSLATORS:  Error Message when a Shareware User clicks on "Replay Intro" in the Main Menu
+#: Source/menu.cpp:179
+msgid ""
+"The Diablo introduction cinematic is only available in the full retail "
+"version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
+msgstr ""
+"Introductionsekvensen til Diablo er kun tilgængelig i den fulde "
+"detailversion af Diablo. Besøg https://www.gog.com/game/diablo for at købe "
+"den."
 
 #. TRANSLATORS: Monster Block start
 #. MT_NZOMBIE
@@ -5144,6 +5241,13 @@ msgctxt "monster"
 msgid "Reaper"
 msgstr ""
 
+#. TRANSLATORS: Monster Block end
+#. MT_NAKRUL
+#: Source/monstdat.cpp:158 Source/monstdat.cpp:485
+msgctxt "monster"
+msgid "Na-Krul"
+msgstr ""
+
 #. TRANSLATORS: Unique Monster Block start
 #: Source/monstdat.cpp:473
 msgctxt "monster"
@@ -5173,6 +5277,11 @@ msgstr ""
 #: Source/monstdat.cpp:479
 msgctxt "monster"
 msgid "Black Jade"
+msgstr ""
+
+#: Source/monstdat.cpp:480
+msgctxt "monster"
+msgid "Lachdanan"
 msgstr ""
 
 #: Source/monstdat.cpp:481
@@ -5227,6 +5336,11 @@ msgctxt "monster"
 msgid "Brokenhead Bangshield"
 msgstr ""
 
+#: Source/monstdat.cpp:494
+msgctxt "monster"
+msgid "Bongo"
+msgstr ""
+
 #: Source/monstdat.cpp:495
 msgctxt "monster"
 msgid "Rotcarnage"
@@ -5245,6 +5359,11 @@ msgstr ""
 #: Source/monstdat.cpp:498
 msgctxt "monster"
 msgid "Madeye the Dead"
+msgstr ""
+
+#: Source/monstdat.cpp:499
+msgctxt "monster"
+msgid "El Chupacabras"
 msgstr ""
 
 #: Source/monstdat.cpp:500
@@ -5586,9 +5705,19 @@ msgctxt "monster"
 msgid "The Vizier"
 msgstr ""
 
+#: Source/monstdat.cpp:567
+msgctxt "monster"
+msgid "Zamphir"
+msgstr ""
+
 #: Source/monstdat.cpp:568
 msgctxt "monster"
 msgid "Bloodlust"
+msgstr ""
+
+#: Source/monstdat.cpp:569
+msgctxt "monster"
+msgid "Webwidow"
 msgstr ""
 
 #: Source/monstdat.cpp:570
@@ -5607,19 +5736,19 @@ msgctxt "monster"
 msgid "Doomlock"
 msgstr ""
 
-#: Source/monster.cpp:3474
+#: Source/monster.cpp:3479
 msgid "Animal"
 msgstr ""
 
-#: Source/monster.cpp:3476
+#: Source/monster.cpp:3481
 msgid "Demon"
 msgstr ""
 
-#: Source/monster.cpp:3478
+#: Source/monster.cpp:3483
 msgid "Undead"
 msgstr ""
 
-#: Source/monster.cpp:4610
+#: Source/monster.cpp:4612
 #, fuzzy
 msgid "Type: {:s}  Kills: {:d}"
 msgstr ""
@@ -5627,12 +5756,12 @@ msgstr ""
 "\n"
 "Fejlen opstod ved: {:s} linje {:d}"
 
-#: Source/monster.cpp:4612
+#: Source/monster.cpp:4614
 #, fuzzy
 msgid "Total kills: {:d}"
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/monster.cpp:4645
+#: Source/monster.cpp:4647
 #, fuzzy
 msgid "Hit Points: {:d}-{:d}"
 msgstr ""
@@ -5640,82 +5769,83 @@ msgstr ""
 "\n"
 "Fejlen opstod ved: {:s} linje {:d}"
 
-#: Source/monster.cpp:4651
+#: Source/monster.cpp:4653
 #, fuzzy
 msgid "No magic resistance"
 msgstr "Magi:"
 
-#: Source/monster.cpp:4655
+#: Source/monster.cpp:4657
 msgid "Resists: "
 msgstr ""
 
-#: Source/monster.cpp:4657 Source/monster.cpp:4668
+#: Source/monster.cpp:4659 Source/monster.cpp:4671
 #, fuzzy
 #| msgid "Magic:"
 msgid "Magic "
 msgstr "Magi:"
 
-#: Source/monster.cpp:4659 Source/monster.cpp:4670
+#: Source/monster.cpp:4661 Source/monster.cpp:4673
 msgid "Fire "
 msgstr ""
 
-#: Source/monster.cpp:4661 Source/monster.cpp:4672
+#: Source/monster.cpp:4663 Source/monster.cpp:4675
 msgid "Lightning "
 msgstr ""
 
-#: Source/monster.cpp:4666
+#: Source/monster.cpp:4669
 msgid "Immune: "
 msgstr ""
 
-#: Source/monster.cpp:4684
+#: Source/monster.cpp:4688
 #, fuzzy
 msgid "Type: {:s}"
 msgstr ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#: Source/monster.cpp:4690 Source/monster.cpp:4697
+#: Source/monster.cpp:4694 Source/monster.cpp:4701
 msgid "No resistances"
 msgstr ""
 
-#: Source/monster.cpp:4692 Source/monster.cpp:4702
+#: Source/monster.cpp:4696 Source/monster.cpp:4706
 msgid "No Immunities"
 msgstr ""
 
-#: Source/monster.cpp:4695
+#: Source/monster.cpp:4699
 #, fuzzy
 msgid "Some Magic Resistances"
 msgstr "Magi:"
 
-#: Source/monster.cpp:4700
+#: Source/monster.cpp:4704
 #, fuzzy
 msgid "Some Magic Immunities"
 msgstr "Magi:"
 
-#: Source/msg.cpp:484
+#: Source/msg.cpp:495
 msgid "Trying to drop a floor item?"
 msgstr ""
 
-#: Source/msg.cpp:951 Source/msg.cpp:975 Source/msg.cpp:998 Source/msg.cpp:1113
-#: Source/msg.cpp:1136 Source/msg.cpp:1158 Source/msg.cpp:1180
+#: Source/msg.cpp:994 Source/msg.cpp:1029 Source/msg.cpp:1060
+#: Source/msg.cpp:1187 Source/msg.cpp:1219 Source/msg.cpp:1251
+#: Source/msg.cpp:1281
 msgid "{:s} has cast an illegal spell."
 msgstr ""
 
-#: Source/msg.cpp:1529 Source/multi.cpp:815
+#: Source/msg.cpp:1668 Source/multi.cpp:804
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr ""
 
-#: Source/msg.cpp:1826
+#: Source/msg.cpp:1972
 #, fuzzy
 msgid "Waiting for game data..."
 msgstr "Multiplayer-spil"
 
-#: Source/msg.cpp:1834
+#: Source/msg.cpp:1980
 #, fuzzy
 msgid "The game ended"
 msgstr "Multiplayer-spil"
 
-#: Source/msg.cpp:1840
+#: Source/msg.cpp:1986
 #, fuzzy
 #| msgid "Unable to create character."
 msgid "Unable to get level data"
@@ -5733,375 +5863,375 @@ msgstr ""
 msgid "Player '{:s}' dropped due to timeout"
 msgstr ""
 
-#: Source/multi.cpp:817
+#: Source/multi.cpp:806
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr ""
 
 #. TRANSLATORS: Shrine Name Block
-#: Source/objects.cpp:101
+#: Source/objects.cpp:104
 msgid "Mysterious"
 msgstr ""
 
-#: Source/objects.cpp:102
+#: Source/objects.cpp:105
 msgid "Hidden"
 msgstr ""
 
-#: Source/objects.cpp:103
+#: Source/objects.cpp:106
 msgid "Gloomy"
 msgstr ""
 
-#: Source/objects.cpp:105 Source/objects.cpp:112
+#: Source/objects.cpp:108 Source/objects.cpp:115
 #, fuzzy
 #| msgid "Magic:"
 msgid "Magical"
 msgstr "Magi:"
 
-#: Source/objects.cpp:106
+#: Source/objects.cpp:109
 msgid "Stone"
 msgstr ""
 
-#: Source/objects.cpp:107
+#: Source/objects.cpp:110
 msgid "Religious"
 msgstr ""
 
-#: Source/objects.cpp:108
+#: Source/objects.cpp:111
 msgid "Enchanted"
 msgstr ""
 
-#: Source/objects.cpp:109
+#: Source/objects.cpp:112
 msgid "Thaumaturgic"
 msgstr ""
 
-#: Source/objects.cpp:110
+#: Source/objects.cpp:113
 msgid "Fascinating"
 msgstr ""
 
-#: Source/objects.cpp:111
+#: Source/objects.cpp:114
 msgid "Cryptic"
 msgstr ""
 
-#: Source/objects.cpp:113
+#: Source/objects.cpp:116
 msgid "Eldritch"
 msgstr ""
 
-#: Source/objects.cpp:114
+#: Source/objects.cpp:117
 msgid "Eerie"
 msgstr ""
 
-#: Source/objects.cpp:115
+#: Source/objects.cpp:118
 msgid "Divine"
 msgstr ""
 
-#: Source/objects.cpp:117
+#: Source/objects.cpp:120
 msgid "Sacred"
 msgstr ""
 
-#: Source/objects.cpp:118
+#: Source/objects.cpp:121
 msgid "Spiritual"
 msgstr ""
 
-#: Source/objects.cpp:119
+#: Source/objects.cpp:122
 msgid "Spooky"
 msgstr ""
 
-#: Source/objects.cpp:120
+#: Source/objects.cpp:123
 msgid "Abandoned"
 msgstr ""
 
-#: Source/objects.cpp:121
+#: Source/objects.cpp:124
 msgid "Creepy"
 msgstr ""
 
-#: Source/objects.cpp:122
+#: Source/objects.cpp:125
 msgid "Quiet"
 msgstr ""
 
-#: Source/objects.cpp:123
+#: Source/objects.cpp:126
 msgid "Secluded"
 msgstr ""
 
-#: Source/objects.cpp:124
+#: Source/objects.cpp:127
 msgid "Ornate"
 msgstr ""
 
-#: Source/objects.cpp:125
+#: Source/objects.cpp:128
 msgid "Glimmering"
 msgstr ""
 
-#: Source/objects.cpp:126
+#: Source/objects.cpp:129
 msgid "Tainted"
 msgstr ""
 
-#: Source/objects.cpp:127
+#: Source/objects.cpp:130
 msgid "Oily"
 msgstr ""
 
-#: Source/objects.cpp:128
+#: Source/objects.cpp:131
 msgid "Glowing"
 msgstr ""
 
-#: Source/objects.cpp:129
+#: Source/objects.cpp:132
 msgid "Mendicant's"
 msgstr ""
 
-#: Source/objects.cpp:130
+#: Source/objects.cpp:133
 msgid "Sparkling"
 msgstr ""
 
-#: Source/objects.cpp:131
+#: Source/objects.cpp:134
 #, fuzzy
 msgid "Town"
 msgstr "Genstart i byen"
 
-#: Source/objects.cpp:132
+#: Source/objects.cpp:135
 msgid "Shimmering"
 msgstr ""
 
-#: Source/objects.cpp:133
+#: Source/objects.cpp:136
 msgid "Solar"
 msgstr ""
 
 #. TRANSLATORS: Shrine Name Block end
-#: Source/objects.cpp:135
+#: Source/objects.cpp:138
 msgid "Murphy's"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:265
+#: Source/objects.cpp:268
 msgid "The Great Conflict"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:266
+#: Source/objects.cpp:269
 msgid "The Wages of Sin are War"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:267
+#: Source/objects.cpp:270
 msgid "The Tale of the Horadrim"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:268
+#: Source/objects.cpp:271
 msgid "The Dark Exile"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:269
+#: Source/objects.cpp:272
 msgid "The Sin War"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:270
+#: Source/objects.cpp:273
 #, fuzzy
 #| msgid "The Ring of One Thousand"
 msgid "The Binding of the Three"
 msgstr "Ringen af et tusinde"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:271
+#: Source/objects.cpp:274
 msgid "The Realms Beyond"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:272
+#: Source/objects.cpp:275
 msgid "Tale of the Three"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:273
+#: Source/objects.cpp:276
 msgid "The Black King"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:274
+#: Source/objects.cpp:277
 msgid "Journal: The Ensorcellment"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:275
+#: Source/objects.cpp:278
 msgid "Journal: The Meeting"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:276
+#: Source/objects.cpp:279
 msgid "Journal: The Tirade"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:277
+#: Source/objects.cpp:280
 msgid "Journal: His Power Grows"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:278
+#: Source/objects.cpp:281
 msgid "Journal: NA-KRUL"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:279
+#: Source/objects.cpp:282
 msgid "Journal: The End"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:280
+#: Source/objects.cpp:283
 msgid "A Spellbook"
 msgstr ""
 
-#: Source/objects.cpp:5365
+#: Source/objects.cpp:5339
 msgid "Crucified Skeleton"
 msgstr ""
 
-#: Source/objects.cpp:5369
+#: Source/objects.cpp:5343
 #, fuzzy
 #| msgid "Level:"
 msgid "Lever"
 msgstr "Niveau:"
 
-#: Source/objects.cpp:5378
+#: Source/objects.cpp:5352
 msgid "Open Door"
 msgstr ""
 
-#: Source/objects.cpp:5380
+#: Source/objects.cpp:5354
 msgid "Closed Door"
 msgstr ""
 
-#: Source/objects.cpp:5382
+#: Source/objects.cpp:5356
 msgid "Blocked Door"
 msgstr ""
 
-#: Source/objects.cpp:5387
+#: Source/objects.cpp:5361
 msgid "Ancient Tome"
 msgstr ""
 
-#: Source/objects.cpp:5389
+#: Source/objects.cpp:5363
 msgid "Book of Vileness"
 msgstr ""
 
-#: Source/objects.cpp:5394
+#: Source/objects.cpp:5368
 msgid "Skull Lever"
 msgstr ""
 
-#: Source/objects.cpp:5397
+#: Source/objects.cpp:5371
 msgid "Mythical Book"
 msgstr ""
 
-#: Source/objects.cpp:5401
+#: Source/objects.cpp:5375
 msgid "Small Chest"
 msgstr ""
 
-#: Source/objects.cpp:5405
+#: Source/objects.cpp:5379
 msgid "Chest"
 msgstr ""
 
-#: Source/objects.cpp:5410
+#: Source/objects.cpp:5384
 msgid "Large Chest"
 msgstr ""
 
-#: Source/objects.cpp:5413
+#: Source/objects.cpp:5387
 msgid "Sarcophagus"
 msgstr ""
 
-#: Source/objects.cpp:5416
+#: Source/objects.cpp:5390
 msgid "Bookshelf"
 msgstr ""
 
-#: Source/objects.cpp:5420
+#: Source/objects.cpp:5394
 msgid "Bookcase"
 msgstr ""
 
-#: Source/objects.cpp:5425
+#: Source/objects.cpp:5399
 msgid "Pod"
 msgstr ""
 
-#: Source/objects.cpp:5427
+#: Source/objects.cpp:5401
 msgid "Urn"
 msgstr ""
 
-#: Source/objects.cpp:5429
+#: Source/objects.cpp:5403
 msgid "Barrel"
 msgstr ""
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:5433
+#: Source/objects.cpp:5407
 #, fuzzy
 msgid "{:s} Shrine"
 msgstr ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#: Source/objects.cpp:5437
+#: Source/objects.cpp:5411
 msgid "Skeleton Tome"
 msgstr ""
 
-#: Source/objects.cpp:5440
+#: Source/objects.cpp:5414
 msgid "Library Book"
 msgstr ""
 
-#: Source/objects.cpp:5443
+#: Source/objects.cpp:5417
 msgid "Blood Fountain"
 msgstr ""
 
-#: Source/objects.cpp:5446
+#: Source/objects.cpp:5420
 msgid "Decapitated Body"
 msgstr ""
 
-#: Source/objects.cpp:5449
+#: Source/objects.cpp:5423
 msgid "Book of the Blind"
 msgstr ""
 
-#: Source/objects.cpp:5452
+#: Source/objects.cpp:5426
 msgid "Book of Blood"
 msgstr ""
 
-#: Source/objects.cpp:5455
+#: Source/objects.cpp:5429
 msgid "Purifying Spring"
 msgstr ""
 
-#: Source/objects.cpp:5462 Source/objects.cpp:5486
+#: Source/objects.cpp:5436 Source/objects.cpp:5460
 msgid "Weapon Rack"
 msgstr ""
 
-#: Source/objects.cpp:5465
+#: Source/objects.cpp:5439
 msgid "Goat Shrine"
 msgstr ""
 
-#: Source/objects.cpp:5468
+#: Source/objects.cpp:5442
 msgid "Cauldron"
 msgstr ""
 
-#: Source/objects.cpp:5471
+#: Source/objects.cpp:5445
 msgid "Murky Pool"
 msgstr ""
 
-#: Source/objects.cpp:5474
+#: Source/objects.cpp:5448
 msgid "Fountain of Tears"
 msgstr ""
 
-#: Source/objects.cpp:5477
+#: Source/objects.cpp:5451
 msgid "Steel Tome"
 msgstr ""
 
-#: Source/objects.cpp:5480
+#: Source/objects.cpp:5454
 msgid "Pedestal of Blood"
 msgstr ""
 
-#: Source/objects.cpp:5489
+#: Source/objects.cpp:5463
 msgid "Mushroom Patch"
 msgstr ""
 
-#: Source/objects.cpp:5492
+#: Source/objects.cpp:5466
 msgid "Vile Stand"
 msgstr ""
 
-#: Source/objects.cpp:5495
+#: Source/objects.cpp:5469
 #, fuzzy
 #| msgid "Select Hero"
 msgid "Slain Hero"
 msgstr "Ny multiplayer-helt"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:5502
+#: Source/objects.cpp:5476
 #, fuzzy
 msgid "Trapped {:s}"
 msgstr ""
@@ -6109,167 +6239,167 @@ msgstr ""
 "{:s}"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
-#: Source/objects.cpp:5508
+#: Source/objects.cpp:5482
 #, fuzzy
 #| msgid "Music Disabled"
 msgid "{:s} (disabled)"
 msgstr "Musik deaktiveret"
 
-#: Source/panels/charpanel.cpp:109
+#: Source/panels/charpanel.cpp:110
 msgid "MAX"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:119
+#: Source/panels/charpanel.cpp:120
 #, fuzzy
 #| msgid "Level:"
 msgid "Level"
 msgstr "Niveau:"
 
-#: Source/panels/charpanel.cpp:121
+#: Source/panels/charpanel.cpp:122
 msgid "Experience"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:123
+#: Source/panels/charpanel.cpp:124
 #, fuzzy
 msgid "Next level"
 msgstr "Niveau:"
 
-#: Source/panels/charpanel.cpp:126
+#: Source/panels/charpanel.cpp:127
 msgid "None"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:132
+#: Source/panels/charpanel.cpp:133
 msgid "Base"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:133
+#: Source/panels/charpanel.cpp:134
 #, fuzzy
 #| msgid "No"
 msgid "Now"
 msgstr "Nej"
 
-#: Source/panels/charpanel.cpp:134
+#: Source/panels/charpanel.cpp:135
 #, fuzzy
 #| msgid "Strength:"
 msgid "Strength"
 msgstr "Styrke:"
 
-#: Source/panels/charpanel.cpp:138
+#: Source/panels/charpanel.cpp:139
 #, fuzzy
 #| msgid "Magic:"
 msgid "Magic"
 msgstr "Magi:"
 
-#: Source/panels/charpanel.cpp:142
+#: Source/panels/charpanel.cpp:143
 #, fuzzy
 #| msgid "Dexterity:"
 msgid "Dexterity"
 msgstr "Smidighed:"
 
-#: Source/panels/charpanel.cpp:145
+#: Source/panels/charpanel.cpp:146
 #, fuzzy
 #| msgid "Vitality:"
 msgid "Vitality"
 msgstr "Vitalitet:"
 
-#: Source/panels/charpanel.cpp:148
+#: Source/panels/charpanel.cpp:149
 msgid "Points to distribute"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:158
+#: Source/panels/charpanel.cpp:159
 #, fuzzy
 msgid "Armor class"
 msgstr "Vælg klasse"
 
-#: Source/panels/charpanel.cpp:160
+#: Source/panels/charpanel.cpp:161
 msgid "To hit"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:162
+#: Source/panels/charpanel.cpp:163
 msgid "Damage"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:168
+#: Source/panels/charpanel.cpp:170
 msgid "Life"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:172
+#: Source/panels/charpanel.cpp:174
 msgid "Mana"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:177
+#: Source/panels/charpanel.cpp:179
 #, fuzzy
 msgid "Resist magic"
 msgstr "Magi:"
 
-#: Source/panels/charpanel.cpp:179
+#: Source/panels/charpanel.cpp:181
 msgid "Resist fire"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:181
+#: Source/panels/charpanel.cpp:183
 msgid "Resist lightning"
 msgstr ""
 
-#: Source/panels/mainpanel.cpp:62 Source/panels/mainpanel.cpp:109
-#: Source/panels/mainpanel.cpp:111
+#: Source/panels/mainpanel.cpp:62 Source/panels/mainpanel.cpp:106
+#: Source/panels/mainpanel.cpp:108
 #, fuzzy
 #| msgid "Voices"
 msgid "voice"
 msgstr "Stemmeproduktion, retning og casting"
 
-#: Source/panels/mainpanel.cpp:87
+#: Source/panels/mainpanel.cpp:84
 msgid "char"
 msgstr ""
 
-#: Source/panels/mainpanel.cpp:88
+#: Source/panels/mainpanel.cpp:85
 msgid "quests"
 msgstr ""
 
-#: Source/panels/mainpanel.cpp:89
+#: Source/panels/mainpanel.cpp:86
 msgid "map"
 msgstr ""
 
-#: Source/panels/mainpanel.cpp:90
+#: Source/panels/mainpanel.cpp:87
 #, fuzzy
 msgid "menu"
 msgstr "Forrige menu"
 
-#: Source/panels/mainpanel.cpp:91
+#: Source/panels/mainpanel.cpp:88
 msgid "inv"
 msgstr ""
 
-#: Source/panels/mainpanel.cpp:92
+#: Source/panels/mainpanel.cpp:89
 msgid "spells"
 msgstr ""
 
-#: Source/panels/mainpanel.cpp:104 Source/panels/mainpanel.cpp:106
-#: Source/panels/mainpanel.cpp:108
+#: Source/panels/mainpanel.cpp:101 Source/panels/mainpanel.cpp:103
+#: Source/panels/mainpanel.cpp:105
 msgid "mute"
 msgstr ""
 
-#: Source/pfile.cpp:260
+#: Source/pfile.cpp:242
 msgid "Failed to open player archive for writing."
 msgstr ""
 
-#: Source/pfile.cpp:385
+#: Source/pfile.cpp:377
 #, fuzzy
 #| msgid "Unable to create character."
 msgid "Unable to open archive"
 msgstr "Kunne ikke oprette karakter."
 
-#: Source/pfile.cpp:387
+#: Source/pfile.cpp:379
 #, fuzzy
 #| msgid "Unable to create character."
 msgid "Unable to load character"
 msgstr "Kunne ikke oprette karakter."
 
-#: Source/pfile.cpp:410 Source/pfile.cpp:430
+#: Source/pfile.cpp:403 Source/pfile.cpp:423
 #, fuzzy
 #| msgid "Unable to create character."
 msgid "Unable to read to save file archive"
 msgstr "Kunne ikke oprette karakter."
 
-#: Source/pfile.cpp:449
+#: Source/pfile.cpp:442
 #, fuzzy
 #| msgid ""
 #| "Unable to write to location:\n"
@@ -6279,8 +6409,7 @@ msgstr ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#. TRANSLATORS: Shown if player presses "v" button. {:s} is player name, {:d} is level, {:s} is location
-#: Source/plrmsg.cpp:89
+#: Source/plrmsg.cpp:88
 #, fuzzy
 msgid "{:s} (lvl {:d}): {:s}"
 msgstr ""
@@ -6299,7 +6428,7 @@ msgstr ""
 msgid "%i gold"
 msgstr ""
 
-#: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:56
+#: Source/qol/monhealthbar.cpp:37 Source/qol/xpbar.cpp:56
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
@@ -6347,6 +6476,16 @@ msgstr ""
 msgid "Zhar the Mad"
 msgstr ""
 
+#: Source/quests.cpp:45
+msgid "Lachdanan"
+msgstr ""
+
+#: Source/quests.cpp:46
+#, fuzzy
+#| msgid "Exit Diablo"
+msgid "Diablo"
+msgstr "Afslut Diablo"
+
 #: Source/quests.cpp:47
 msgid "The Butcher"
 msgstr ""
@@ -6376,7 +6515,7 @@ msgid "Poisoned Water Supply"
 msgstr ""
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:55 Source/quests.cpp:90
+#: Source/quests.cpp:55 Source/quests.cpp:91
 msgid "The Chamber of Bone"
 msgstr ""
 
@@ -6404,6 +6543,10 @@ msgstr ""
 msgid "The Defiler"
 msgstr ""
 
+#: Source/quests.cpp:62
+msgid "Na-Krul"
+msgstr ""
+
 #: Source/quests.cpp:63 Source/trigs.cpp:447
 msgid "Cornerstone of the World"
 msgstr ""
@@ -6414,27 +6557,27 @@ msgid "The Jersey's Jersey"
 msgstr ""
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:89
+#: Source/quests.cpp:90
 msgid "King Leoric's Tomb"
 msgstr ""
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:91 Source/setmaps.cpp:26
+#: Source/quests.cpp:92 Source/setmaps.cpp:26
 msgid "Maze"
 msgstr ""
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:92
+#: Source/quests.cpp:93
 msgid "A Dark Passage"
 msgstr ""
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:93
+#: Source/quests.cpp:94
 msgid "Unholy Altar"
 msgstr ""
 
 #. TRANSLATORS: Used for Quest Portals. {:s} is a Map Name
-#: Source/quests.cpp:449
+#: Source/quests.cpp:450
 #, fuzzy
 #| msgid "Talk to Pepin"
 msgid "To {:s}"
@@ -6713,289 +6856,322 @@ msgctxt "spell"
 msgid "Rune of Stone"
 msgstr ""
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:91
+#, fuzzy
+#| msgid "Talk to Pepin"
+msgid "Griswold"
+msgstr "Tal med Pepin"
+
+#: Source/stores.cpp:92
+msgid "Pepin"
+msgstr ""
+
+#: Source/stores.cpp:94
+msgid "Ogden"
+msgstr ""
+
+#: Source/stores.cpp:95
+msgid "Cain"
+msgstr ""
+
+#: Source/stores.cpp:96
+#, fuzzy
+#| msgid "Talk to Pepin"
+msgid "Farnham"
+msgstr "Tal med Pepin"
+
+#: Source/stores.cpp:97
+msgid "Adria"
+msgstr ""
+
+#: Source/stores.cpp:98 Source/stores.cpp:1305
+#, fuzzy
+#| msgid "Talk to Pepin"
+msgid "Gillian"
+msgstr "Tal med Pepin"
+
+#: Source/stores.cpp:99
+msgid "Wirt"
+msgstr ""
+
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr ""
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ""
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 #, fuzzy
 msgid "Damage: {:d}-{:d}  "
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 #, fuzzy
 msgid "Armor: {:d}  "
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 #, fuzzy
 msgid "Dur: {:d}/{:d},  "
 msgstr "Understøttede spillere: {:d}"
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr ""
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr ""
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr "Velkommen til"
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr ""
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr "Har du lyst til:"
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 #, fuzzy
 #| msgid "Talk to Pepin"
 msgid "Talk to Griswold"
 msgstr "Tal med Pepin"
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 #, fuzzy
 #| msgid "Buy items"
 msgid "Buy basic items"
 msgstr "Køb varer"
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 #, fuzzy
 #| msgid "Buy items"
 msgid "Buy premium items"
 msgstr "Køb varer"
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 #, fuzzy
 #| msgid "Buy items"
 msgid "Sell items"
 msgstr "Køb varer"
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 #, fuzzy
 msgid "Repair items"
 msgstr "Køb varer"
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 #, fuzzy
 #| msgid "Leave Healer's home"
 msgid "Leave the shop"
 msgstr "Forlad healers hjem"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr ""
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr ""
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr ""
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr ""
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 #, fuzzy
 #| msgid "Talk to Pepin"
 msgid "Talk to Adria"
 msgstr "Tal med Pepin"
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr "Køb varer"
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr ""
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 #, fuzzy
 msgid "Leave the shack"
 msgstr "Forlad healers hjem"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr ""
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr ""
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr ""
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr ""
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 #, fuzzy
 #| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to identify this item?"
 msgstr "Er du sikker på, at du vil slette karakteren \"{:s}\"?"
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 #, fuzzy
 #| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to buy this item?"
 msgstr "Er du sikker på, at du vil slette karakteren \"{:s}\"?"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 #, fuzzy
 #| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to recharge this item?"
 msgstr "Er du sikker på, at du vil slette karakteren \"{:s}\"?"
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 #, fuzzy
 #| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to sell this item?"
 msgstr "Er du sikker på, at du vil slette karakteren \"{:s}\"?"
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 #, fuzzy
 #| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to repair this item?"
 msgstr "Er du sikker på, at du vil slette karakteren \"{:s}\"?"
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr ""
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 #, fuzzy
 #| msgid "Talk to Pepin"
 msgid "Talk to Wirt"
 msgstr "Tal med Pepin"
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr ""
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr ""
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr ""
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr ""
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr ""
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 #, fuzzy
 msgid "Leave"
 msgstr "Forlad healers hjem"
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr "Healers hjem"
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr "Tal med Pepin"
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr "Forlad healers hjem"
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 #, fuzzy
 msgid "The Town Elder"
 msgstr "Genstart i byen"
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 #, fuzzy
 #| msgid "Talk to Pepin"
 msgid "Talk to Cain"
 msgstr "Tal med Pepin"
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr ""
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr ""
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr ""
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 #, fuzzy
 #| msgid "Talk to Pepin"
 msgid "Talk to {:s}"
 msgstr "Tal med Pepin"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 #, fuzzy
 #| msgid "Talk to Pepin"
 msgid "Talking to {:s}"
@@ -7003,62 +7179,62 @@ msgstr ""
 "Kan ikke skrive til lokation:\n"
 "{:s}"
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 #, fuzzy
 msgid "is not available"
 msgstr ""
 "Skytten og Troldmanden er kun tilgængelige i den fulde detailversion af "
 "Diablo. Besøg https://www.gog.com/game/diablo for at købe den."
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 #, fuzzy
 #| msgid "Pepin the Healer"
 msgid "in the shareware"
 msgstr "Healeren Pepin"
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 #, fuzzy
 msgid "version"
 msgstr ""
 "Skytten og Troldmanden er kun tilgængelige i den fulde detailversion af "
 "Diablo. Besøg https://www.gog.com/game/diablo for at købe den."
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr ""
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr ""
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 #, fuzzy
 #| msgid "Talk to Pepin"
 msgid "Talk to Ogden"
 msgstr "Tal med Pepin"
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 #, fuzzy
 msgid "Leave the tavern"
 msgstr "Forlad healers hjem"
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 #, fuzzy
 #| msgid "Talk to Pepin"
 msgid "Talk to Gillian"
 msgstr "Tal med Pepin"
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr ""
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 #, fuzzy
 #| msgid "Talk to Pepin"
 msgid "Talk to Farnham"
 msgstr "Tal med Pepin"
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr ""
 
@@ -9768,6 +9944,10 @@ msgstr ""
 msgid "Complete Nut"
 msgstr ""
 
+#: Source/towners.cpp:266
+msgid "Celia"
+msgstr ""
+
 #: Source/towners.cpp:279
 msgid "Slain Townsman"
 msgstr ""
@@ -9798,19 +9978,19 @@ msgid "Down to Crypt"
 msgstr ""
 
 #: Source/trigs.cpp:412 Source/trigs.cpp:492 Source/trigs.cpp:539
-#: Source/trigs.cpp:630
+#: Source/trigs.cpp:634
 #, fuzzy
 msgid "Up to level {:d}"
 msgstr "Understøttede spillere: {:d}"
 
 #: Source/trigs.cpp:414 Source/trigs.cpp:469 Source/trigs.cpp:521
-#: Source/trigs.cpp:596 Source/trigs.cpp:613 Source/trigs.cpp:660
+#: Source/trigs.cpp:600 Source/trigs.cpp:617 Source/trigs.cpp:664
 #, fuzzy
 msgid "Up to town"
 msgstr "Genstart i byen"
 
-#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:552
-#: Source/trigs.cpp:577 Source/trigs.cpp:642
+#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:556
+#: Source/trigs.cpp:581 Source/trigs.cpp:646
 #, fuzzy
 msgid "Down to level {:d}"
 msgstr "Understøttede spillere: {:d}"
@@ -9823,17 +10003,17 @@ msgstr ""
 msgid "Down to Crypt level {:d}"
 msgstr ""
 
-#: Source/trigs.cpp:564
+#: Source/trigs.cpp:568
 msgid "Up to Nest level {:d}"
 msgstr ""
 
-#: Source/trigs.cpp:673
+#: Source/trigs.cpp:677
 #, fuzzy
 #| msgid "Exit Diablo"
 msgid "Down to Diablo"
 msgstr "Diablo Strike Team"
 
-#: Source/trigs.cpp:706 Source/trigs.cpp:720 Source/trigs.cpp:734
+#: Source/trigs.cpp:710 Source/trigs.cpp:724 Source/trigs.cpp:738
 #, fuzzy
 #| msgid "Talk to Pepin"
 msgid "Back to Level {:d}"

--- a/Translations/de.po
+++ b/Translations/de.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-10-25 23:11+0200\n"
+"POT-Creation-Date: 2021-11-21 05:44+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -320,7 +320,7 @@ msgstr "\tKeine Seelen wurden während der Entstehung dieses Spiels verkauft."
 msgid "OK"
 msgstr "OK"
 
-#: Source/DiabloUI/extrasmenu.cpp:41 Source/DiabloUI/selstart.cpp:61
+#: Source/DiabloUI/extrasmenu.cpp:41 Source/DiabloUI/selstart.cpp:44
 msgid "Switch to Diablo"
 msgstr "Zu Diablo wechseln"
 
@@ -390,8 +390,8 @@ msgstr "Client-Server (TCP)"
 msgid "Loopback"
 msgstr "Loopback"
 
-#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:481
-#: Source/DiabloUI/selgame.cpp:499
+#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:489
+#: Source/DiabloUI/selgame.cpp:510
 msgid "Multi Player Game"
 msgstr "Mehrspieler-Spiel"
 
@@ -752,22 +752,22 @@ msgstr "Einzelspielercharakter löschen"
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "Bist Du sicher, dass Du den Charakter \"{:s}\" löschen willst?"
 
-#: Source/DiabloUI/selstart.cpp:60
+#: Source/DiabloUI/selstart.cpp:43
 msgid "Enter Hellfire"
 msgstr "Hellfire betreten"
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr "Ja"
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr "Nein"
 
 #: Source/DiabloUI/support_lines.cpp:8
 msgid ""
-"We maintains a chat server at Discord.gg/YQKCAYQ Follow the links to join "
-"our community where we talk about things related to Diablo, and the Hellfire "
+"We maintain a chat server at Discord.gg/YQKCAYQ Follow the links to join our "
+"community where we talk about things related to Diablo, and the Hellfire "
 "expansion."
 msgstr ""
 
@@ -808,12 +808,12 @@ msgstr ""
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr "Urheberrecht © 1996-2001 Blizzard Entertainment"
 
-#: Source/appfat.cpp:37
+#: Source/appfat.cpp:38
 msgid "Error"
 msgstr "Fehler"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:101
+#: Source/appfat.cpp:102
 msgid ""
 "{:s}\n"
 "\n"
@@ -823,7 +823,7 @@ msgstr ""
 "\n"
 "Fehler an Position {:s} Zeile {:d}"
 
-#: Source/appfat.cpp:116
+#: Source/appfat.cpp:117
 msgid ""
 "Unable to open main data archive ({:s}).\n"
 "\n"
@@ -833,12 +833,12 @@ msgstr ""
 "\n"
 "Stelle sicher, dass es sich im Spielordner befindet."
 
-#: Source/appfat.cpp:122
+#: Source/appfat.cpp:123
 msgid "Data File Error"
 msgstr "Dateifehler"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:130
+#: Source/appfat.cpp:131
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -846,7 +846,7 @@ msgstr ""
 "An folgenden Speicherort kann nicht geschrieben werden:\n"
 "{:s}"
 
-#: Source/appfat.cpp:132
+#: Source/appfat.cpp:133
 msgid "Read-Only Directory Error"
 msgstr "Nur-Lesen-Verzeichnisfehler"
 
@@ -870,176 +870,176 @@ msgstr "Level: Stock {:d}"
 msgid "Level: Crypt {:d}"
 msgstr "Level: Krypta {:d}"
 
-#: Source/automap.cpp:508 Source/items.cpp:2079
+#: Source/automap.cpp:508 Source/items.cpp:2090
 msgid "Level: {:d}"
 msgstr "Level {:d}"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr "Tab"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr "Esc"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Enter"
 msgstr "Enter"
 
-#: Source/control.cpp:202
+#: Source/control.cpp:215
 msgid "Character Information"
 msgstr "Charakterinformation"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr "Questtagebuch"
 
-#: Source/control.cpp:204
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr "Automatische Karte"
 
-#: Source/control.cpp:205
+#: Source/control.cpp:218
 msgid "Main Menu"
 msgstr "Hauptmenü"
 
-#: Source/control.cpp:206
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr "Inventar"
 
-#: Source/control.cpp:207
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr "Zauberbuch"
 
-#: Source/control.cpp:208
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr "Nachricht senden"
 
-#: Source/control.cpp:764 Source/control.cpp:1572
+#: Source/control.cpp:718 Source/control.cpp:1587
 msgid "Skill"
 msgstr "Fähigkeit"
 
-#: Source/control.cpp:765 Source/control.cpp:1226
+#: Source/control.cpp:719 Source/control.cpp:1237
 msgid "{:s} Skill"
 msgstr "{:s}-Fertigkeit"
 
-#: Source/control.cpp:771
+#: Source/control.cpp:725
 msgid "Spell"
 msgstr "Zauber"
 
-#: Source/control.cpp:772 Source/control.cpp:1230
+#: Source/control.cpp:726 Source/control.cpp:1241
 msgid "{:s} Spell"
 msgstr "{:s}-Zauber"
 
-#: Source/control.cpp:774
+#: Source/control.cpp:728
 msgid "Damages undead only"
 msgstr "Nur Schaden an Untoten"
 
-#: Source/control.cpp:778 Source/control.cpp:1234 Source/control.cpp:1596
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr "Zauberlevel 0 - Unbrauchbar"
 
-#: Source/control.cpp:780 Source/control.cpp:1236 Source/control.cpp:1598
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 msgid "Spell Level {:d}"
 msgstr "Zauberlevel {:d}"
 
-#: Source/control.cpp:787
+#: Source/control.cpp:741
 msgid "Scroll"
 msgstr "Schriftrolle"
 
-#: Source/control.cpp:788 Source/control.cpp:1240
+#: Source/control.cpp:742 Source/control.cpp:1251
 msgid "Scroll of {:s}"
 msgstr "Schriftrolle mit {:s}"
 
-#: Source/control.cpp:793 Source/control.cpp:1246
+#: Source/control.cpp:747 Source/control.cpp:1257
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "{:d}-Schriftrolle"
 msgstr[1] "{:d}-Schriftrollen"
 
-#: Source/control.cpp:800 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
 #: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
 msgid "Staff"
 msgstr "Stab"
 
-#: Source/control.cpp:801 Source/control.cpp:1250 Source/items.cpp:1320
+#: Source/control.cpp:755 Source/control.cpp:1261
 msgid "Staff of {:s}"
 msgstr "Stab mit {:s}"
 
-#: Source/control.cpp:803 Source/control.cpp:1252
+#: Source/control.cpp:757 Source/control.cpp:1263
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "{:d}-Ladung"
 msgstr[1] "{:d}-Ladungen"
 
-#: Source/control.cpp:813
+#: Source/control.cpp:767
 msgid "Spell Hotkey {:s}"
 msgstr "Zauber-Schnelltaste {:s}"
 
-#: Source/control.cpp:1203
+#: Source/control.cpp:1214
 msgid "Player friendly"
 msgstr "Spieler ist freundlich"
 
-#: Source/control.cpp:1205
+#: Source/control.cpp:1216
 msgid "Player attack"
 msgstr "Spieler greift an"
 
-#: Source/control.cpp:1208
+#: Source/control.cpp:1219
 msgid "Hotkey: {:s}"
 msgstr "Schnelltaste: {:s}"
 
-#: Source/control.cpp:1216
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr "Zauberauswahlknopf"
 
-#: Source/control.cpp:1219
+#: Source/control.cpp:1230
 msgid "Hotkey: 's'"
 msgstr "Schnelltaste: 's'"
 
-#: Source/control.cpp:1374 Source/inv.cpp:1916 Source/items.cpp:3742
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "{:d} Goldstück"
 msgstr[1] "{:d} Goldstücke"
 
-#: Source/control.cpp:1377
+#: Source/control.cpp:1390
 msgid "Requirements not met"
 msgstr "Anforderungen nicht erfüllt"
 
-#: Source/control.cpp:1413
+#: Source/control.cpp:1426
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Level: {:d}"
 
-#: Source/control.cpp:1415
+#: Source/control.cpp:1428
 msgid "Hit Points {:d} of {:d}"
 msgstr "Trefferpunkte {:d} von {:d}"
 
-#: Source/control.cpp:1442
+#: Source/control.cpp:1457
 msgid "Level Up"
 msgstr "Level-Up"
 
-#: Source/control.cpp:1576
+#: Source/control.cpp:1591
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] "Stab ({:d} Ladung)"
 msgstr[1] "Stab ({:d} Ladungen)"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1586
+#: Source/control.cpp:1601
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "Mana: {:d}  Schaden: {:d}-{:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1588
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "Mana: {:d}   Schaden: n.V."
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1591
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "Mana: {:d}  Schaden: 1/3 TP"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1649
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] "Du hast {:d} Goldstück. Wieviele möchtest Du abheben?"
@@ -1245,7 +1245,7 @@ msgstr "während des Dialogs"
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr "{:s}, Version = {:s}, Modus = {:s}"
 
-#: Source/dvlnet/loopback.cpp:111
+#: Source/dvlnet/loopback.cpp:113
 msgid "loopback"
 msgstr "Loopback"
 
@@ -1709,7 +1709,9 @@ msgstr ""
 "Rechtsklick mit der Maus benutzt werden."
 
 #: Source/help.cpp:68
-msgid "$Gold"
+#, fuzzy
+#| msgid "$Gold"
+msgid "$Gold:"
 msgstr "$Gold"
 
 #: Source/help.cpp:69
@@ -1738,7 +1740,9 @@ msgstr ""
 "Spielfeld zum Auslösen des Zaubers."
 
 #: Source/help.cpp:79
-msgid "$Using the Speedbook for Spells"
+#, fuzzy
+#| msgid "$Using the Speedbook for Spells"
+msgid "$Using the Speedbook for Spells:"
 msgstr "$Verwendung der Schnellzauberleiste"
 
 #: Source/help.cpp:80
@@ -1753,15 +1757,21 @@ msgstr ""
 "Auslösen des Zaubers."
 
 #: Source/help.cpp:84
+#, fuzzy
+#| msgid ""
+#| "Shift + Left-clicking on the 'select current spell' button will clear the "
+#| "readied spell"
 msgid ""
 "Shift + Left-clicking on the 'select current spell' button will clear the "
-"readied spell"
+"readied spell."
 msgstr ""
 "Shift + Linksklick auf den Knopf mit dem ausgewählten Zauber hebt die "
 "Auswahl auf"
 
 #: Source/help.cpp:86
-msgid "$Setting Spell Hotkeys"
+#, fuzzy
+#| msgid "$Setting Spell Hotkeys"
+msgid "$Setting Spell Hotkeys:"
 msgstr "$Zauber-Schnelltasten festlegen"
 
 #: Source/help.cpp:87
@@ -1776,7 +1786,9 @@ msgstr ""
 "ihm mit F5, F6, F7 oder F8 eine Schnelltaste zu."
 
 #: Source/help.cpp:92
-msgid "$Spell Books"
+#, fuzzy
+#| msgid "$Spell Books"
+msgid "$Spell Books:"
 msgstr "$Zauberbücher"
 
 #: Source/help.cpp:93
@@ -1787,35 +1799,35 @@ msgstr ""
 "Je mehr Bücher eines bestimmten Zaubers Du liest, desto größer wird Dein "
 "Wissen und Deine Effektivität beim Anwenden des Zaubers."
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Shareware Hellfire Help"
 msgstr "Shareware-Hellfire-Hilfe"
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Hellfire Help"
 msgstr "Hellfire-Hilfe"
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Shareware Diablo Help"
 msgstr "Shareware-Diablo-Hilfe"
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Diablo Help"
 msgstr "Diablo-Hilfe"
 
-#: Source/help.cpp:161
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr "Escape zum Beenden oder Pfeiltasten um zu scrollen."
 
-#: Source/init.cpp:204
+#: Source/init.cpp:175
 msgid "diabdat.mpq or spawn.mpq"
 msgstr "diabdat.mpq oder spawn.mpq"
 
-#: Source/init.cpp:224
+#: Source/init.cpp:196
 msgid "Some Hellfire MPQs are missing"
 msgstr "Einige Hellfire-MPQs fehlen"
 
-#: Source/init.cpp:224
+#: Source/init.cpp:196
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
@@ -1823,7 +1835,7 @@ msgstr ""
 "Nicht alle Hellfire-MPQs vorhanden.\n"
 "Bitte besorge alle hf*.mpq-Dateien."
 
-#: Source/init.cpp:232
+#: Source/init.cpp:204
 msgid "Unable to create main window"
 msgstr "Hauptfenster kann nicht erstellt werden"
 
@@ -2067,7 +2079,7 @@ msgid "Quilted Armor"
 msgstr "Gesteppte Rüstung"
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
-#: Source/itemdat.cpp:77 Source/objects.cpp:5467
+#: Source/itemdat.cpp:77 Source/objects.cpp:5433
 msgid "Armor"
 msgstr "Rüstung"
 
@@ -3609,655 +3621,668 @@ msgstr "Öl des Härtens"
 msgid "Oil of Imperviousness"
 msgstr "Öl der Undurchlässigkeit"
 
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#: Source/items.cpp:1174 Source/items.cpp:1184 Source/items.cpp:1233
-#: Source/items.cpp:1269
-msgid "{0} {1}"
-msgstr ""
-
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's Staff of Firewall
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Long Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1187 Source/items.cpp:1254 Source/items.cpp:1273
-#: Source/items.cpp:1315
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
+#, fuzzy
+#| msgid "{0} of {1}"
+msgctxt "spell"
 msgid "{0} of {1}"
 msgstr "{:s} de{:s}"
 
-#: Source/items.cpp:1895 Source/items.cpp:1907
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+#, fuzzy
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} de{:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+#, fuzzy
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} de{:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
+#: Source/items.cpp:1217
+msgid "{0} {1}"
+msgstr ""
+
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
+msgid "{0} of {1}"
+msgstr "{:s} de{:s}"
+
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr "Erhöhung de"
 
-#: Source/items.cpp:1897
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr "r Trefferchance"
 
-#: Source/items.cpp:1901
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr "Starke Erhöhung de"
 
-#: Source/items.cpp:1903
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr "r Waffentrefferchance"
 
-#: Source/items.cpp:1909
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr "s Schadenspotentials"
 
-#: Source/items.cpp:1913
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr "Starke Erhöhung de"
 
-#: Source/items.cpp:1915
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr "s Schadenspotentials - außer Bögen"
 
-#: Source/items.cpp:1919
+#: Source/items.cpp:1930
 msgid "reduces attributes needed"
 msgstr "Verringerte Anforderungen"
 
-#: Source/items.cpp:1921
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr "für Rüstungen und Waffen"
 
-#: Source/items.cpp:1925
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr "Stellt 20% der"
 
-#: Source/items.cpp:1927
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr "Haltbarkeit wieder her"
 
-#: Source/items.cpp:1931
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr "Erhöht die aktuelle und"
 
-#: Source/items.cpp:1933
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr "maximale Haltbarkeit"
 
-#: Source/items.cpp:1937
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr "Macht einen Gegenstand unzerstörbar"
 
-#: Source/items.cpp:1941
+#: Source/items.cpp:1952
 msgid "increases the armor class"
 msgstr "Erhöhung des Rüstungswerts"
 
-#: Source/items.cpp:1943
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr "von Rüstungen und Schilden"
 
-#: Source/items.cpp:1947
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr "Große Erhöhung des Rüstungswerts"
 
-#: Source/items.cpp:1949
+#: Source/items.cpp:1960
 msgid "class of armor and shields"
 msgstr "von Rüstungen und Schilden"
 
-#: Source/items.cpp:1953 Source/items.cpp:1962
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr "legt eine Feuerfalle"
 
-#: Source/items.cpp:1958
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr "legt eine Blitzfalle"
 
-#: Source/items.cpp:1966
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr "legt eine Versteinerungsfalle"
 
-#: Source/items.cpp:1970
+#: Source/items.cpp:1981
 msgid "restore all life"
 msgstr "Volle Lebensaufladung"
 
-#: Source/items.cpp:1974
+#: Source/items.cpp:1985
 msgid "restore some life"
 msgstr "Partielle Lebensaufladung"
 
-#: Source/items.cpp:1978
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr "Lebensaufladung"
 
-#: Source/items.cpp:1982
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr "Tödliche Heilung"
 
-#: Source/items.cpp:1986
+#: Source/items.cpp:1997
 msgid "restore some mana"
 msgstr "Partielle Manaaufladung"
 
-#: Source/items.cpp:1990
+#: Source/items.cpp:2001
 msgid "restore all mana"
 msgstr "Volle Manaaufladung"
 
-#: Source/items.cpp:1994
+#: Source/items.cpp:2005
 msgid "increase strength"
 msgstr "Erhöht die Stärke"
 
-#: Source/items.cpp:1998
+#: Source/items.cpp:2009
 msgid "increase magic"
 msgstr "Erhöht die Magie"
 
-#: Source/items.cpp:2002
+#: Source/items.cpp:2013
 msgid "increase dexterity"
 msgstr "Erhöht die Agilität"
 
-#: Source/items.cpp:2006
+#: Source/items.cpp:2017
 msgid "increase vitality"
 msgstr "Erhöht die Vitalität"
 
-#: Source/items.cpp:2011
+#: Source/items.cpp:2022
 msgid "decrease strength"
 msgstr "Verringert die Stärke"
 
-#: Source/items.cpp:2015
+#: Source/items.cpp:2026
 msgid "decrease dexterity"
 msgstr "Verringert die Agilität"
 
-#: Source/items.cpp:2019
+#: Source/items.cpp:2030
 msgid "decrease vitality"
 msgstr "Verringert die Vitalität"
 
-#: Source/items.cpp:2023
+#: Source/items.cpp:2034
 msgid "restore some life and mana"
 msgstr "Lebens- und Manaaufladung"
 
-#: Source/items.cpp:2027
+#: Source/items.cpp:2038
 msgid "restore all life and mana"
 msgstr "Volles Leben und Mana"
 
-#: Source/items.cpp:2042 Source/items.cpp:2067
+#: Source/items.cpp:2053 Source/items.cpp:2078
 msgid "Right-click to read"
 msgstr "Rechtsklick zum Lesen"
 
-#: Source/items.cpp:2046
+#: Source/items.cpp:2057
 msgid "Right-click to read, then"
 msgstr "Rechtsklick zum Lesen, dann"
 
-#: Source/items.cpp:2048
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr "Linksklick zum Zielen"
 
-#: Source/items.cpp:2053
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr "Rechtsklick zum Benutzen"
 
-#: Source/items.cpp:2058 Source/items.cpp:2063
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr "Rechtsklick zum Benutzen"
 
-#: Source/items.cpp:2071
+#: Source/items.cpp:2082
 msgid "Right click to read"
 msgstr "Rechtsklick zum Lesen"
 
-#: Source/items.cpp:2075
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr "Rechtsklick zum Anschauen"
 
-#: Source/items.cpp:2083
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr "Verdoppelt die Goldkapazität"
 
-#: Source/items.cpp:2095 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 msgid "Required:"
 msgstr "Benötigt:"
 
-#: Source/items.cpp:2097 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 msgid " {:d} Str"
 msgstr " {:d} Str"
 
-#: Source/items.cpp:2099 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 msgid " {:d} Mag"
 msgstr " {:d} Mag"
 
-#: Source/items.cpp:2101 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 msgid " {:d} Dex"
 msgstr " {:d} Agil"
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3526 Source/player.cpp:3027
+#: Source/items.cpp:3533 Source/player.cpp:3018
 msgid "Ear of {:s}"
 msgstr "Ohr von {:s}"
 
-#: Source/items.cpp:3821
+#: Source/items.cpp:3828
 msgid "chance to hit: {:+d}%"
 msgstr "Trefferchance: {:+d}%"
 
-#: Source/items.cpp:3825
+#: Source/items.cpp:3832
 #, no-c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% Schaden"
 
-#: Source/items.cpp:3829 Source/items.cpp:4085
+#: Source/items.cpp:3836 Source/items.cpp:4092
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "Treff.: {:+d}%, {:+d}% Schaden"
 
-#: Source/items.cpp:3833
+#: Source/items.cpp:3840
 #, no-c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% Rüstung"
 
-#: Source/items.cpp:3837
+#: Source/items.cpp:3844
 msgid "armor class: {:d}"
 msgstr "Rüstungswert: {:d}"
 
-#: Source/items.cpp:3842 Source/items.cpp:4067
+#: Source/items.cpp:3849 Source/items.cpp:4074
 msgid "Resist Fire: {:+d}%"
 msgstr "Feuerresistenz: {:+d}%"
 
-#: Source/items.cpp:3844
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr "Feuerresistenz: 75% MAX"
 
-#: Source/items.cpp:3849
+#: Source/items.cpp:3856
 msgid "Resist Lightning: {:+d}%"
 msgstr "Blitzresistenz: {:+d}%"
 
-#: Source/items.cpp:3851
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr "Blitzresistenz: 75% MAX"
 
-#: Source/items.cpp:3856
+#: Source/items.cpp:3863
 msgid "Resist Magic: {:+d}%"
 msgstr "Magieresistenz: {:+d}%"
 
-#: Source/items.cpp:3858
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr "Magieresistenz: 75% MAX"
 
-#: Source/items.cpp:3863
+#: Source/items.cpp:3870
 msgid "Resist All: {:+d}%"
 msgstr "Resistenz gegen alles: {:+d}%"
 
-#: Source/items.cpp:3865
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr "Resistenz gegen alles: 75% MAX"
 
-#: Source/items.cpp:3869
+#: Source/items.cpp:3876
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] "+ {:d} auf alle Zauberlevel"
 msgstr[1] "+ {:d} auf alle Zauberlevel"
 
-#: Source/items.cpp:3871
+#: Source/items.cpp:3878
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "- {:d} auf alle Zauberlevel"
 msgstr[1] "- {:d} auf alle Zauberlevel"
 
-#: Source/items.cpp:3873
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr "Zauberlevel unverändert (?)"
 
-#: Source/items.cpp:3876
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr "Extraladungen"
 
-#: Source/items.cpp:3879
+#: Source/items.cpp:3886
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:d} {:s} Ladung"
 msgstr[1] "{:d} {:s} Ladungen"
 
-#: Source/items.cpp:3883
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr "Feuerschaden: {:d}"
 
-#: Source/items.cpp:3885
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "Feuerschaden: {:d}-{:d}"
 
-#: Source/items.cpp:3889
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr "Blitzschaden: {:d}"
 
-#: Source/items.cpp:3891
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "Blitzschaden: {:d}-{:d}"
 
-#: Source/items.cpp:3895
+#: Source/items.cpp:3902
 msgid "{:+d} to strength"
 msgstr "{:+d} zu Stärke"
 
-#: Source/items.cpp:3899
+#: Source/items.cpp:3906
 msgid "{:+d} to magic"
 msgstr "{:+d} zu Magie"
 
-#: Source/items.cpp:3903
+#: Source/items.cpp:3910
 msgid "{:+d} to dexterity"
 msgstr "{:+d} zu Agilität"
 
-#: Source/items.cpp:3907
+#: Source/items.cpp:3914
 msgid "{:+d} to vitality"
 msgstr "{:+d} zu Vitalität"
 
-#: Source/items.cpp:3911
+#: Source/items.cpp:3918
 msgid "{:+d} to all attributes"
 msgstr "{:+d} zu allen Attributen"
 
-#: Source/items.cpp:3915
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} Schaden von Feinden"
 
-#: Source/items.cpp:3919
+#: Source/items.cpp:3926
 msgid "Hit Points: {:+d}"
 msgstr "Leben: {:+d}"
 
-#: Source/items.cpp:3923
+#: Source/items.cpp:3930
 msgid "Mana: {:+d}"
 msgstr "Mana: {:+d}"
 
-#: Source/items.cpp:3926
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr "hohe Haltbarkeit"
 
-#: Source/items.cpp:3929
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr "verringerte Haltbarkeit"
 
-#: Source/items.cpp:3932
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr "Unzerstörbar"
 
-#: Source/items.cpp:3935
+#: Source/items.cpp:3942
 #, no-c-format
 msgid "+{:d}% light radius"
 msgstr "+{:d}% Lichtradius"
 
-#: Source/items.cpp:3938
+#: Source/items.cpp:3945
 #, no-c-format
 msgid "-{:d}% light radius"
 msgstr "-{:d}% Lichtradius"
 
-#: Source/items.cpp:3941
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr "Mehrere Pfeile pro Schuss"
 
-#: Source/items.cpp:3945
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr "Feuerpfeilschaden: {:d}"
 
-#: Source/items.cpp:3947
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "Feuerpfeilschaden: {:d}-{:d}"
 
-#: Source/items.cpp:3951
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr "Blitzpfeilschaden {:d}"
 
-#: Source/items.cpp:3953
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "Blitzpfeilschaden {:d}-{:d}"
 
-#: Source/items.cpp:3957
+#: Source/items.cpp:3964
 msgid "fireball damage: {:d}"
 msgstr "Feuerballschaden: {:d}"
 
-#: Source/items.cpp:3959
+#: Source/items.cpp:3966
 msgid "fireball damage: {:d}-{:d}"
 msgstr "Feuerballschaden: {:d}-{:d}"
 
-#: Source/items.cpp:3962
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr "Angreifer erleidet 1-3 Schaden"
 
-#: Source/items.cpp:3965
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr "Träger verliert gesamtes Mana"
 
-#: Source/items.cpp:3968
+#: Source/items.cpp:3975
 msgid "you can't heal"
 msgstr "Keine Heilung"
 
-#: Source/items.cpp:3971
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr "Halber Fallenschaden"
 
-#: Source/items.cpp:3974
+#: Source/items.cpp:3981
 msgid "knocks target back"
 msgstr "Zurückstoßung"
 
-#: Source/items.cpp:3977
+#: Source/items.cpp:3984
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr "+200% Schaden gegen Dämonen"
 
-#: Source/items.cpp:3980
+#: Source/items.cpp:3987
 msgid "All Resistance equals 0"
 msgstr "Träger verliert alle Resistenzen"
 
-#: Source/items.cpp:3983
+#: Source/items.cpp:3990
 msgid "hit monster doesn't heal"
 msgstr "Stoppt Monsterheilung"
 
-#: Source/items.cpp:3987
+#: Source/items.cpp:3994
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr "3% Manaabsaugung"
 
-#: Source/items.cpp:3989
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr "5% Manaabsaugung"
 
-#: Source/items.cpp:3993
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr "3% Lebensabsaugung"
 
-#: Source/items.cpp:3995
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr "3% Lebensabsaugung"
 
-#: Source/items.cpp:3998
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr "Durchschlägt gegnerische Rüstung"
 
-#: Source/items.cpp:4002
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr "Flinker Angriff"
 
-#: Source/items.cpp:4004
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr "schneller Angriff"
 
-#: Source/items.cpp:4006
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr "schnellerer Angriff"
 
-#: Source/items.cpp:4008
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr "schnellster Angriff"
 
-#: Source/items.cpp:4012
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr "schnelle Erholung"
 
-#: Source/items.cpp:4014
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr "schnellere Erholung"
 
-#: Source/items.cpp:4016
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr "schnellste Erholung"
 
-#: Source/items.cpp:4019
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr "schnelles Blocken"
 
-#: Source/items.cpp:4022
+#: Source/items.cpp:4029
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] "{:d} Schadenspunkt extra"
 msgstr[1] "{:d} Schadenspunkte extra"
 
-#: Source/items.cpp:4025
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr "Zufällige Pfeilgeschwindigkeit"
 
-#: Source/items.cpp:4028
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr "Ungewöhnlicher Schaden"
 
-#: Source/items.cpp:4031
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr "Veränderte Haltbarkeit"
 
-#: Source/items.cpp:4034
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr "Schnellerer Angriff"
 
-#: Source/items.cpp:4037
+#: Source/items.cpp:4044
 msgid "one handed sword"
 msgstr "Einhändig"
 
-#: Source/items.cpp:4040
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr "Kontinuierlicher LP-Verlust"
 
-#: Source/items.cpp:4043
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr "Lebensabsaugung"
 
-#: Source/items.cpp:4046
+#: Source/items.cpp:4053
 msgid "no strength requirement"
 msgstr "Keine Mindeststärke"
 
-#: Source/items.cpp:4049
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr "Mit Durchblick sehen"
 
-#: Source/items.cpp:4056
+#: Source/items.cpp:4063
 msgid "lightning damage: {:d}"
 msgstr "Blitzschaden: {:d}"
 
-#: Source/items.cpp:4058
+#: Source/items.cpp:4065
 msgid "lightning damage: {:d}-{:d}"
 msgstr "Blitzschaden: {:d}"
 
-#: Source/items.cpp:4061
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr "Geladene Blitze bei Treffer"
 
-#: Source/items.cpp:4070
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr "5% Chance auf 3-fachen Gesamtschaden"
 
-#: Source/items.cpp:4073
+#: Source/items.cpp:4080
 #, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr "{:+d}% Schaden, -5% pro Treffer"
 
-#: Source/items.cpp:4076
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr "2x Gegnerschaden, 1x Selbstschaden"
 
-#: Source/items.cpp:4079
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr "0- bis 6-facher Gesamtschaden"
 
-#: Source/items.cpp:4082
+#: Source/items.cpp:4089
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr "Geringe Haltb., {:+d}% Schaden"
 
-#: Source/items.cpp:4088
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr "Extra-Rüstung gegen Dämonen"
 
-#: Source/items.cpp:4091
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr "Extra-Rüstung gegen Untote"
 
-#: Source/items.cpp:4094
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr "50% Mana wird zu Leben"
 
-#: Source/items.cpp:4097
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr "40% Leben wird zu Mana"
 
-#: Source/items.cpp:4100
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr "Anderer Effekt (NW)"
 
-#: Source/items.cpp:4137 Source/items.cpp:4184
+#: Source/items.cpp:4144 Source/items.cpp:4191
 msgid "damage: {:d}  Indestructible"
 msgstr "Schaden: {:d}  Unzerstörbar"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4139 Source/items.cpp:4186
+#: Source/items.cpp:4146 Source/items.cpp:4193
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "Schaden: {:d}  Haltb.: {:d}/{:d}"
 
-#: Source/items.cpp:4142 Source/items.cpp:4189
+#: Source/items.cpp:4149 Source/items.cpp:4196
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "Schaden: {:d}  Unzerstörbar"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4144 Source/items.cpp:4191
+#: Source/items.cpp:4151 Source/items.cpp:4198
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "Schaden: {:d}-{:d}  Haltb.: {:d}/{:d}"
 
-#: Source/items.cpp:4150 Source/items.cpp:4203
+#: Source/items.cpp:4157 Source/items.cpp:4210
 msgid "armor: {:d}  Indestructible"
 msgstr "Rüstung: {:d}  Unzerstörbar"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4152 Source/items.cpp:4205
+#: Source/items.cpp:4159 Source/items.cpp:4212
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "Rüstung: {:d}  Haltb.: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4157
+#: Source/items.cpp:4164
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "Schaden: {:d}  Haltb.: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4159
+#: Source/items.cpp:4166
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "Schaden: {:d}-{:d}  Haltb.: {:d}/{:d}"
 
-#: Source/items.cpp:4160 Source/items.cpp:4195 Source/items.cpp:4210
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 msgid "Charges: {:d}/{:d}"
 msgstr "Ladungen: {:d}/{:d}"
 
-#: Source/items.cpp:4172
+#: Source/items.cpp:4179
 msgid "unique item"
 msgstr "Einzigartiger Gegenstand"
 
-#: Source/items.cpp:4199 Source/items.cpp:4208 Source/items.cpp:4215
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr "Nicht identifiziert"
 
-#: Source/loadsave.cpp:1680 Source/loadsave.cpp:2144
+#: Source/loadsave.cpp:1683 Source/loadsave.cpp:2149
 msgid "Unable to open save file archive"
 msgstr "Kann Spielstand nicht laden"
 
-#: Source/loadsave.cpp:1683
+#: Source/loadsave.cpp:1686
 msgid "Invalid save file"
 msgstr "Ungültiger Spielstand"
 
-#: Source/loadsave.cpp:1712
+#: Source/loadsave.cpp:1717
 msgid "Player is on a Hellfire only level"
 msgstr "Spieler befindet sich auf einem Hellfire-Level"
 
-#: Source/loadsave.cpp:1907
+#: Source/loadsave.cpp:1912
 msgid "Invalid game state"
 msgstr "Ungültiger Spielzustand"
 
@@ -5395,97 +5420,97 @@ msgctxt "monster"
 msgid "Doomlock"
 msgstr "Volux der Vergessene"
 
-#: Source/monster.cpp:3495
+#: Source/monster.cpp:3479
 msgid "Animal"
 msgstr "Tierisch"
 
-#: Source/monster.cpp:3497
+#: Source/monster.cpp:3481
 msgid "Demon"
 msgstr "Dämonisch"
 
-#: Source/monster.cpp:3499
+#: Source/monster.cpp:3483
 msgid "Undead"
 msgstr "Untot"
 
-#: Source/monster.cpp:4630
+#: Source/monster.cpp:4612
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "Typ: {:s}  Getötet: {:d}"
 
-#: Source/monster.cpp:4632
+#: Source/monster.cpp:4614
 msgid "Total kills: {:d}"
 msgstr "Insgesamt getötet: {:d}"
 
-#: Source/monster.cpp:4665
+#: Source/monster.cpp:4647
 msgid "Hit Points: {:d}-{:d}"
 msgstr "Trefferpunkte: {:d}-{:d}"
 
-#: Source/monster.cpp:4671
+#: Source/monster.cpp:4653
 msgid "No magic resistance"
 msgstr "Kein magischen Resistenzen"
 
-#: Source/monster.cpp:4675
+#: Source/monster.cpp:4657
 msgid "Resists: "
 msgstr "Resistenzen: "
 
-#: Source/monster.cpp:4677 Source/monster.cpp:4688
+#: Source/monster.cpp:4659 Source/monster.cpp:4671
 msgid "Magic "
 msgstr "Magie "
 
-#: Source/monster.cpp:4679 Source/monster.cpp:4690
+#: Source/monster.cpp:4661 Source/monster.cpp:4673
 msgid "Fire "
 msgstr "Feuer "
 
-#: Source/monster.cpp:4681 Source/monster.cpp:4692
+#: Source/monster.cpp:4663 Source/monster.cpp:4675
 msgid "Lightning "
 msgstr "Blitz "
 
-#: Source/monster.cpp:4686
+#: Source/monster.cpp:4669
 msgid "Immune: "
 msgstr "Immunitäten: "
 
-#: Source/monster.cpp:4704
+#: Source/monster.cpp:4688
 msgid "Type: {:s}"
 msgstr "Typ: {:s}"
 
-#: Source/monster.cpp:4710 Source/monster.cpp:4717
+#: Source/monster.cpp:4694 Source/monster.cpp:4701
 msgid "No resistances"
 msgstr "Keine Resistenzen"
 
-#: Source/monster.cpp:4712 Source/monster.cpp:4722
+#: Source/monster.cpp:4696 Source/monster.cpp:4706
 msgid "No Immunities"
 msgstr "Keine Immunitäten"
 
-#: Source/monster.cpp:4715
+#: Source/monster.cpp:4699
 msgid "Some Magic Resistances"
 msgstr "Einige magische Resistenzen"
 
-#: Source/monster.cpp:4720
+#: Source/monster.cpp:4704
 msgid "Some Magic Immunities"
 msgstr "Einige magische Immunitäten"
 
-#: Source/msg.cpp:494
+#: Source/msg.cpp:495
 msgid "Trying to drop a floor item?"
 msgstr "Versuchst Du, einen Bodengegenstand fallen zu lassen?"
 
-#: Source/msg.cpp:982 Source/msg.cpp:1017 Source/msg.cpp:1048
-#: Source/msg.cpp:1175 Source/msg.cpp:1207 Source/msg.cpp:1239
-#: Source/msg.cpp:1269
+#: Source/msg.cpp:994 Source/msg.cpp:1029 Source/msg.cpp:1060
+#: Source/msg.cpp:1187 Source/msg.cpp:1219 Source/msg.cpp:1251
+#: Source/msg.cpp:1281
 msgid "{:s} has cast an illegal spell."
 msgstr "Illegaler Zauber von {:s}"
 
-#: Source/msg.cpp:1655 Source/multi.cpp:805
+#: Source/msg.cpp:1668 Source/multi.cpp:804
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr "Spieler '{:s}' (Level {:d}) ist dem Spiel beigetreten"
 
-#: Source/msg.cpp:1959
+#: Source/msg.cpp:1972
 msgid "Waiting for game data..."
 msgstr "Warte auf Spieldaten..."
 
-#: Source/msg.cpp:1967
+#: Source/msg.cpp:1980
 msgid "The game ended"
 msgstr "Das Spiel ist zu Ende"
 
-#: Source/msg.cpp:1973
+#: Source/msg.cpp:1986
 msgid "Unable to get level data"
 msgstr "Leveldaten nicht verfügbar"
 
@@ -5501,7 +5526,7 @@ msgstr "Spieler '{:s}' hat Diablo getötet und das Spiel verlassen!"
 msgid "Player '{:s}' dropped due to timeout"
 msgstr "Spieler '{:s}' wurde wegen Timeout entfernt"
 
-#: Source/multi.cpp:807
+#: Source/multi.cpp:806
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr "Spieler '{:s}' (Level {:d}) ist bereits im Spiel"
 
@@ -5711,158 +5736,158 @@ msgstr "Tagebuch: Das Ende"
 msgid "A Spellbook"
 msgstr "Ein Zauberbuch"
 
-#: Source/objects.cpp:5373
+#: Source/objects.cpp:5339
 msgid "Crucified Skeleton"
 msgstr "Gekreuzigtes Skelett"
 
-#: Source/objects.cpp:5377
+#: Source/objects.cpp:5343
 msgid "Lever"
 msgstr "Hebel"
 
-#: Source/objects.cpp:5386
+#: Source/objects.cpp:5352
 msgid "Open Door"
 msgstr "Offene Tür"
 
-#: Source/objects.cpp:5388
+#: Source/objects.cpp:5354
 msgid "Closed Door"
 msgstr "Geschlossene Tür"
 
-#: Source/objects.cpp:5390
+#: Source/objects.cpp:5356
 msgid "Blocked Door"
 msgstr "Blockierte Tür"
 
-#: Source/objects.cpp:5395
+#: Source/objects.cpp:5361
 msgid "Ancient Tome"
 msgstr "Alter Wälzer"
 
-#: Source/objects.cpp:5397
+#: Source/objects.cpp:5363
 msgid "Book of Vileness"
 msgstr "Buch der Niedertracht"
 
-#: Source/objects.cpp:5402
+#: Source/objects.cpp:5368
 msgid "Skull Lever"
 msgstr "Schädel-Hebel"
 
-#: Source/objects.cpp:5405
+#: Source/objects.cpp:5371
 msgid "Mythical Book"
 msgstr "Mystisches Buch"
 
-#: Source/objects.cpp:5409
+#: Source/objects.cpp:5375
 msgid "Small Chest"
 msgstr "Kleine Truhe"
 
-#: Source/objects.cpp:5413
+#: Source/objects.cpp:5379
 msgid "Chest"
 msgstr "Truhe"
 
-#: Source/objects.cpp:5418
+#: Source/objects.cpp:5384
 msgid "Large Chest"
 msgstr "Große Truhe"
 
-#: Source/objects.cpp:5421
+#: Source/objects.cpp:5387
 msgid "Sarcophagus"
 msgstr "Sarkophag"
 
-#: Source/objects.cpp:5424
+#: Source/objects.cpp:5390
 msgid "Bookshelf"
 msgstr "Bücheregal"
 
-#: Source/objects.cpp:5428
+#: Source/objects.cpp:5394
 msgid "Bookcase"
 msgstr "Bücherschrank"
 
-#: Source/objects.cpp:5433
+#: Source/objects.cpp:5399
 msgid "Pod"
 msgstr "Exuvie"
 
-#: Source/objects.cpp:5435
+#: Source/objects.cpp:5401
 msgid "Urn"
 msgstr "Urne"
 
-#: Source/objects.cpp:5437
+#: Source/objects.cpp:5403
 msgid "Barrel"
 msgstr "Fass"
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:5441
+#: Source/objects.cpp:5407
 msgid "{:s} Shrine"
 msgstr "{:s} Schrein"
 
-#: Source/objects.cpp:5445
+#: Source/objects.cpp:5411
 msgid "Skeleton Tome"
 msgstr "Skelettbuch"
 
-#: Source/objects.cpp:5448
+#: Source/objects.cpp:5414
 msgid "Library Book"
 msgstr "Ledergebundenes Buch"
 
-#: Source/objects.cpp:5451
+#: Source/objects.cpp:5417
 msgid "Blood Fountain"
 msgstr "Blutbrunnen"
 
-#: Source/objects.cpp:5454
+#: Source/objects.cpp:5420
 msgid "Decapitated Body"
 msgstr "Enthauptete Leiche"
 
-#: Source/objects.cpp:5457
+#: Source/objects.cpp:5423
 msgid "Book of the Blind"
 msgstr "Buch der Blinden"
 
-#: Source/objects.cpp:5460
+#: Source/objects.cpp:5426
 msgid "Book of Blood"
 msgstr "Buch des Blutes"
 
-#: Source/objects.cpp:5463
+#: Source/objects.cpp:5429
 msgid "Purifying Spring"
 msgstr "Reinigende Quelle"
 
-#: Source/objects.cpp:5470 Source/objects.cpp:5494
+#: Source/objects.cpp:5436 Source/objects.cpp:5460
 msgid "Weapon Rack"
 msgstr "Waffenständer"
 
-#: Source/objects.cpp:5473
+#: Source/objects.cpp:5439
 msgid "Goat Shrine"
 msgstr "Ziegenschrein"
 
-#: Source/objects.cpp:5476
+#: Source/objects.cpp:5442
 msgid "Cauldron"
 msgstr "Kessel"
 
-#: Source/objects.cpp:5479
+#: Source/objects.cpp:5445
 msgid "Murky Pool"
 msgstr "Trübes Becken"
 
-#: Source/objects.cpp:5482
+#: Source/objects.cpp:5448
 msgid "Fountain of Tears"
 msgstr "Fontäne der Tränen"
 
-#: Source/objects.cpp:5485
+#: Source/objects.cpp:5451
 msgid "Steel Tome"
 msgstr "Stahlbuch"
 
-#: Source/objects.cpp:5488
+#: Source/objects.cpp:5454
 msgid "Pedestal of Blood"
 msgstr "Blutsockel"
 
-#: Source/objects.cpp:5497
+#: Source/objects.cpp:5463
 msgid "Mushroom Patch"
 msgstr "Pilzbeet"
 
-#: Source/objects.cpp:5500
+#: Source/objects.cpp:5466
 msgid "Vile Stand"
 msgstr "Abscheulicher Ständer"
 
-#: Source/objects.cpp:5503
+#: Source/objects.cpp:5469
 msgid "Slain Hero"
 msgstr "Getöteter Held"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:5510
+#: Source/objects.cpp:5476
 msgid "Trapped {:s}"
 msgstr "Gesicherte {:s}"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
-#: Source/objects.cpp:5516
+#: Source/objects.cpp:5482
 msgid "{:s} (disabled)"
 msgstr "{:s} (deaktiviert)"
 
@@ -5980,23 +6005,23 @@ msgstr "Zauber"
 msgid "mute"
 msgstr "Stumm"
 
-#: Source/pfile.cpp:260
+#: Source/pfile.cpp:242
 msgid "Failed to open player archive for writing."
 msgstr "Spielerarchiv kann nicht beschrieben werden, Fehler beim Öffnen."
 
-#: Source/pfile.cpp:389
+#: Source/pfile.cpp:377
 msgid "Unable to open archive"
 msgstr "Fehler beim Öffnen des Archivs"
 
-#: Source/pfile.cpp:391
+#: Source/pfile.cpp:379
 msgid "Unable to load character"
 msgstr "Fehler beim Laden des Charakters"
 
-#: Source/pfile.cpp:416 Source/pfile.cpp:436
+#: Source/pfile.cpp:403 Source/pfile.cpp:423
 msgid "Unable to read to save file archive"
 msgstr "Fehler beim Lesen vom Spielstandsarchiv"
 
-#: Source/pfile.cpp:455
+#: Source/pfile.cpp:442
 msgid "Unable to write to save file archive"
 msgstr "Fehler beim Schreiben ins Spielstandsarchiv"
 
@@ -6015,7 +6040,7 @@ msgstr ",%03d"
 msgid "%i gold"
 msgstr "%i Gold"
 
-#: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:56
+#: Source/qol/monhealthbar.cpp:37 Source/qol/xpbar.cpp:56
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
@@ -6429,298 +6454,331 @@ msgctxt "spell"
 msgid "Rune of Stone"
 msgstr "Steinrune"
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:91
+#, fuzzy
+#| msgid "Griswold's Edge"
+msgid "Griswold"
+msgstr "Griswolds Schneide"
+
+#: Source/stores.cpp:92
+msgid "Pepin"
+msgstr ""
+
+#: Source/stores.cpp:94
+msgid "Ogden"
+msgstr ""
+
+#: Source/stores.cpp:95
+msgid "Cain"
+msgstr ""
+
+#: Source/stores.cpp:96
+#, fuzzy
+#| msgid "Talk to Farnham"
+msgid "Farnham"
+msgstr "Mit Farnham sprechen"
+
+#: Source/stores.cpp:97
+msgid "Adria"
+msgstr ""
+
+#: Source/stores.cpp:98 Source/stores.cpp:1305
+#, fuzzy
+#| msgid "brilliance"
+msgid "Gillian"
+msgstr "r Brillanz"
+
+#: Source/stores.cpp:99
+msgid "Wirt"
+msgstr ""
+
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr "Zurück"
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ",  "
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 msgid "Damage: {:d}-{:d}  "
 msgstr "Schaden: {:d}-{:d}  "
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 msgid "Armor: {:d}  "
 msgstr "Rüstung: {:d}  "
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 msgid "Dur: {:d}/{:d},  "
 msgstr "Haltb.: {:d}/{:d},  "
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr "Unzerstörbar, "
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr "Ohne Anforderungen"
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr "Willkommen im"
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr "Laden des Schmieds"
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr "Was möchtet Ihr:"
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 msgid "Talk to Griswold"
 msgstr "Mit Griswold sprechen"
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 msgid "Buy basic items"
 msgstr "Gewöhnliches kaufen"
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 msgid "Buy premium items"
 msgstr "Besonderes kaufen"
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 msgid "Sell items"
 msgstr "Verkaufen"
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 msgid "Repair items"
 msgstr "Reparieren"
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 msgid "Leave the shop"
 msgstr "Schmiede verlassen"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "Hier meine Angebote:             Euer Gold: {:d}"
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr "Zurück"
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "Hier meine besonderen Angebote:             Euer Gold: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "Ihr habt nichts zu verkaufen.             Euer Gold: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "Was wollt Ihr verkaufen?             Euer Gold: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "Ihr habt nichts zu Reparieren.             Euer Gold: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "Was soll repariert werden?             Euer Gold: {:d}"
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr "Hütte der Hexe"
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 msgid "Talk to Adria"
 msgstr "Mit Adria sprechen"
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr "Etwas kaufen"
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr "Stäbe aufladen"
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 msgid "Leave the shack"
 msgstr "Hütte verlassen"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "Ihr habt nichts aufzuladen.             Euer Gold: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "Was soll ich aufladen?             Euer Gold: {:d}"
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr "Ihr habt nicht genug Gold"
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr "Ihr habt nicht genug Platz im Inventar"
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr "Abgemacht?"
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 msgid "Are you sure you want to identify this item?"
 msgstr "Seid Ihr sicher, dass ich das identifizieren soll?"
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 msgid "Are you sure you want to buy this item?"
 msgstr "Seid Ihr sicher, dass Ihr diesen Gegenstand kaufen wollt?"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 msgid "Are you sure you want to recharge this item?"
 msgstr "Seid Ihr sicher, dass ich diesen Stab aufladen soll?"
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 msgid "Are you sure you want to sell this item?"
 msgstr "Seid Ihr sicher, dass Ihr diesen Gegenstand verkaufen wollt?"
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 msgid "Are you sure you want to repair this item?"
 msgstr "Seid Ihr sicher, dass ich das reparieren soll?"
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr "Wirt mit dem Holzbein"
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 msgid "Talk to Wirt"
 msgstr "Mit Wirt sprechen"
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr "Ich habe etwas Besonderes zu"
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr "verkaufen. Für 50 Gold-"
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr "stücke zeige ich es Dir. "
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr "Was hast Du?"
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr "Auf Wiedersehen"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "Hier mein Angebot:             Dein Gold: {:d}"
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 msgid "Leave"
 msgstr "Verlassen"
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr "Haus des Heilers"
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr "Mit Pepin sprechen"
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr "Heiler verlassen"
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 msgid "The Town Elder"
 msgstr "Deckard Cain"
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 msgid "Talk to Cain"
 msgstr "Mit Cain sprechen"
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr "Gegenstand identifizieren"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "Ihr habt nichts zu identifizieren             Euer Gold: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "Was soll ich identifizieren?             Euer Gold: {:d}"
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr "Folgende Gegenstände habe ich identifiziert:"
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr "Erledigt"
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 msgid "Talk to {:s}"
 msgstr "Sprecht mit {:s}"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 msgid "Talking to {:s}"
 msgstr "Ihr sprecht mit {:s}"
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 msgid "is not available"
 msgstr "ist nicht verfügbar"
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 msgid "in the shareware"
 msgstr "in der Shareware"
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 msgid "version"
 msgstr "Version"
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr "Tratsch"
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr "Aufgehende Sonne"
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 msgid "Talk to Ogden"
 msgstr "Mit Ogden sprechen"
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 msgid "Leave the tavern"
 msgstr "Taverne verlassen"
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 msgid "Talk to Gillian"
 msgstr "Mit Gillian sprechen"
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr "Farnham der Säufer"
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 msgid "Talk to Farnham"
 msgstr "Mit Farnham sprechen"
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr "Auf Wiedersehen"
 
@@ -10813,17 +10871,17 @@ msgid "Down to Crypt"
 msgstr "Hinunter in die Krypta"
 
 #: Source/trigs.cpp:412 Source/trigs.cpp:492 Source/trigs.cpp:539
-#: Source/trigs.cpp:630
+#: Source/trigs.cpp:634
 msgid "Up to level {:d}"
 msgstr "Hinauf zu Level {:d}"
 
 #: Source/trigs.cpp:414 Source/trigs.cpp:469 Source/trigs.cpp:521
-#: Source/trigs.cpp:596 Source/trigs.cpp:613 Source/trigs.cpp:660
+#: Source/trigs.cpp:600 Source/trigs.cpp:617 Source/trigs.cpp:664
 msgid "Up to town"
 msgstr "Hinauf zur Stadt"
 
-#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:552
-#: Source/trigs.cpp:577 Source/trigs.cpp:642
+#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:556
+#: Source/trigs.cpp:581 Source/trigs.cpp:646
 msgid "Down to level {:d}"
 msgstr "Hinab zu Level {:d}"
 
@@ -10835,14 +10893,14 @@ msgstr "Hinauf zu Kryptalevel {:d}"
 msgid "Down to Crypt level {:d}"
 msgstr "Hinunter zu Kryptalevel {:d}"
 
-#: Source/trigs.cpp:564
+#: Source/trigs.cpp:568
 msgid "Up to Nest level {:d}"
 msgstr "Hinauf zu Stocklevel {:d}"
 
-#: Source/trigs.cpp:673
+#: Source/trigs.cpp:677
 msgid "Down to Diablo"
 msgstr "Hinunter zu Diablo"
 
-#: Source/trigs.cpp:706 Source/trigs.cpp:720 Source/trigs.cpp:734
+#: Source/trigs.cpp:710 Source/trigs.cpp:724 Source/trigs.cpp:738
 msgid "Back to Level {:d}"
 msgstr "Zurück zu Level {:d}"

--- a/Translations/devilutionx.pot
+++ b/Translations/devilutionx.pot
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-10-31 23:17+0100\n"
+"POT-Creation-Date: 2021-11-21 05:44+0100\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -389,8 +389,8 @@ msgstr ""
 msgid "Loopback"
 msgstr ""
 
-#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:484
-#: Source/DiabloUI/selgame.cpp:505
+#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:489
+#: Source/DiabloUI/selgame.cpp:510
 msgid "Multi Player Game"
 msgstr ""
 
@@ -702,11 +702,11 @@ msgstr ""
 msgid "Enter Hellfire"
 msgstr ""
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr ""
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr ""
 
@@ -734,37 +734,37 @@ msgstr ""
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr ""
 
-#: Source/appfat.cpp:37
+#: Source/appfat.cpp:38
 msgid "Error"
 msgstr ""
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:101
+#: Source/appfat.cpp:102
 msgid ""
 "{:s}\n"
 "\n"
 "The error occurred at: {:s} line {:d}"
 msgstr ""
 
-#: Source/appfat.cpp:116
+#: Source/appfat.cpp:117
 msgid ""
 "Unable to open main data archive ({:s}).\n"
 "\n"
 "Make sure that it is in the game folder."
 msgstr ""
 
-#: Source/appfat.cpp:122
+#: Source/appfat.cpp:123
 msgid "Data File Error"
 msgstr ""
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:130
+#: Source/appfat.cpp:131
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
 msgstr ""
 
-#: Source/appfat.cpp:132
+#: Source/appfat.cpp:133
 msgid "Read-Only Directory Error"
 msgstr ""
 
@@ -788,176 +788,176 @@ msgstr ""
 msgid "Level: Crypt {:d}"
 msgstr ""
 
-#: Source/automap.cpp:508 Source/items.cpp:2076
+#: Source/automap.cpp:508 Source/items.cpp:2090
 msgid "Level: {:d}"
 msgstr ""
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr ""
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr ""
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Enter"
 msgstr ""
 
-#: Source/control.cpp:202
+#: Source/control.cpp:215
 msgid "Character Information"
 msgstr ""
 
-#: Source/control.cpp:203
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr ""
 
-#: Source/control.cpp:204
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr ""
 
-#: Source/control.cpp:205
+#: Source/control.cpp:218
 msgid "Main Menu"
 msgstr ""
 
-#: Source/control.cpp:206
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr ""
 
-#: Source/control.cpp:207
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr ""
 
-#: Source/control.cpp:208
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr ""
 
-#: Source/control.cpp:764 Source/control.cpp:1572
+#: Source/control.cpp:718 Source/control.cpp:1587
 msgid "Skill"
 msgstr ""
 
-#: Source/control.cpp:765 Source/control.cpp:1226
+#: Source/control.cpp:719 Source/control.cpp:1237
 msgid "{:s} Skill"
 msgstr ""
 
-#: Source/control.cpp:771
+#: Source/control.cpp:725
 msgid "Spell"
 msgstr ""
 
-#: Source/control.cpp:772 Source/control.cpp:1230
+#: Source/control.cpp:726 Source/control.cpp:1241
 msgid "{:s} Spell"
 msgstr ""
 
-#: Source/control.cpp:774
+#: Source/control.cpp:728
 msgid "Damages undead only"
 msgstr ""
 
-#: Source/control.cpp:778 Source/control.cpp:1234 Source/control.cpp:1596
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr ""
 
-#: Source/control.cpp:780 Source/control.cpp:1236 Source/control.cpp:1598
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 msgid "Spell Level {:d}"
 msgstr ""
 
-#: Source/control.cpp:787
+#: Source/control.cpp:741
 msgid "Scroll"
 msgstr ""
 
-#: Source/control.cpp:788 Source/control.cpp:1240
+#: Source/control.cpp:742 Source/control.cpp:1251
 msgid "Scroll of {:s}"
 msgstr ""
 
-#: Source/control.cpp:793 Source/control.cpp:1246
+#: Source/control.cpp:747 Source/control.cpp:1257
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Source/control.cpp:800 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
 #: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
 msgid "Staff"
 msgstr ""
 
-#: Source/control.cpp:801 Source/control.cpp:1250 Source/items.cpp:1317
+#: Source/control.cpp:755 Source/control.cpp:1261
 msgid "Staff of {:s}"
 msgstr ""
 
-#: Source/control.cpp:803 Source/control.cpp:1252
+#: Source/control.cpp:757 Source/control.cpp:1263
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Source/control.cpp:813
+#: Source/control.cpp:767
 msgid "Spell Hotkey {:s}"
 msgstr ""
 
-#: Source/control.cpp:1203
+#: Source/control.cpp:1214
 msgid "Player friendly"
 msgstr ""
 
-#: Source/control.cpp:1205
+#: Source/control.cpp:1216
 msgid "Player attack"
 msgstr ""
 
-#: Source/control.cpp:1208
+#: Source/control.cpp:1219
 msgid "Hotkey: {:s}"
 msgstr ""
 
-#: Source/control.cpp:1216
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr ""
 
-#: Source/control.cpp:1219
+#: Source/control.cpp:1230
 msgid "Hotkey: 's'"
 msgstr ""
 
-#: Source/control.cpp:1374 Source/inv.cpp:1992 Source/items.cpp:3739
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Source/control.cpp:1377
+#: Source/control.cpp:1390
 msgid "Requirements not met"
 msgstr ""
 
-#: Source/control.cpp:1413
+#: Source/control.cpp:1426
 msgid "{:s}, Level: {:d}"
 msgstr ""
 
-#: Source/control.cpp:1415
+#: Source/control.cpp:1428
 msgid "Hit Points {:d} of {:d}"
 msgstr ""
 
-#: Source/control.cpp:1442
+#: Source/control.cpp:1457
 msgid "Level Up"
 msgstr ""
 
-#: Source/control.cpp:1576
+#: Source/control.cpp:1591
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] ""
 msgstr[1] ""
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1586
+#: Source/control.cpp:1601
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr ""
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1588
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr ""
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1591
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr ""
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1649
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] ""
@@ -1157,7 +1157,7 @@ msgstr ""
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr ""
 
-#: Source/dvlnet/loopback.cpp:111
+#: Source/dvlnet/loopback.cpp:113
 msgid "loopback"
 msgstr ""
 
@@ -1637,41 +1637,41 @@ msgstr ""
 msgid "Reading more than one book increases your knowledge of that spell, allowing you to cast the spell more effectively."
 msgstr ""
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Shareware Hellfire Help"
 msgstr ""
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Hellfire Help"
 msgstr ""
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Shareware Diablo Help"
 msgstr ""
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Diablo Help"
 msgstr ""
 
-#: Source/help.cpp:161
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr ""
 
-#: Source/init.cpp:206
+#: Source/init.cpp:175
 msgid "diabdat.mpq or spawn.mpq"
 msgstr ""
 
-#: Source/init.cpp:226
+#: Source/init.cpp:196
 msgid "Some Hellfire MPQs are missing"
 msgstr ""
 
-#: Source/init.cpp:226
+#: Source/init.cpp:196
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
 msgstr ""
 
-#: Source/init.cpp:234
+#: Source/init.cpp:204
 msgid "Unable to create main window"
 msgstr ""
 
@@ -1915,7 +1915,7 @@ msgid "Quilted Armor"
 msgstr ""
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
-#: Source/itemdat.cpp:77 Source/objects.cpp:5478
+#: Source/itemdat.cpp:77 Source/objects.cpp:5433
 msgid "Armor"
 msgstr ""
 
@@ -3457,639 +3457,648 @@ msgstr ""
 msgid "Oil of Imperviousness"
 msgstr ""
 
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#: Source/items.cpp:1174 Source/items.cpp:1184 Source/items.cpp:1233
-#: Source/items.cpp:1269
-msgid "{0} {1}"
-msgstr ""
-
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's Staff of Firewall
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Long Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1187 Source/items.cpp:1254 Source/items.cpp:1273
-#: Source/items.cpp:1315
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
+msgctxt "spell"
 msgid "{0} of {1}"
 msgstr ""
 
-#: Source/items.cpp:1892 Source/items.cpp:1904
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr ""
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+msgid "{0} {1} of {2}"
+msgstr ""
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
+#: Source/items.cpp:1217
+msgid "{0} {1}"
+msgstr ""
+
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
+msgid "{0} of {1}"
+msgstr ""
+
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr ""
 
-#: Source/items.cpp:1894
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr ""
 
-#: Source/items.cpp:1898
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr ""
 
-#: Source/items.cpp:1900
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr ""
 
-#: Source/items.cpp:1906
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr ""
 
-#: Source/items.cpp:1910
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr ""
 
-#: Source/items.cpp:1912
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr ""
 
-#: Source/items.cpp:1916
+#: Source/items.cpp:1930
 msgid "reduces attributes needed"
 msgstr ""
 
-#: Source/items.cpp:1918
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr ""
 
-#: Source/items.cpp:1922
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr ""
 
-#: Source/items.cpp:1924
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr ""
 
-#: Source/items.cpp:1928
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr ""
 
-#: Source/items.cpp:1930
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr ""
 
-#: Source/items.cpp:1934
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr ""
 
-#: Source/items.cpp:1938
+#: Source/items.cpp:1952
 msgid "increases the armor class"
 msgstr ""
 
-#: Source/items.cpp:1940
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr ""
 
-#: Source/items.cpp:1944
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr ""
 
-#: Source/items.cpp:1946
+#: Source/items.cpp:1960
 msgid "class of armor and shields"
 msgstr ""
 
-#: Source/items.cpp:1950 Source/items.cpp:1959
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr ""
 
-#: Source/items.cpp:1955
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr ""
 
-#: Source/items.cpp:1963
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr ""
 
-#: Source/items.cpp:1967
+#: Source/items.cpp:1981
 msgid "restore all life"
 msgstr ""
 
-#: Source/items.cpp:1971
+#: Source/items.cpp:1985
 msgid "restore some life"
 msgstr ""
 
-#: Source/items.cpp:1975
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr ""
 
-#: Source/items.cpp:1979
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr ""
 
-#: Source/items.cpp:1983
+#: Source/items.cpp:1997
 msgid "restore some mana"
 msgstr ""
 
-#: Source/items.cpp:1987
+#: Source/items.cpp:2001
 msgid "restore all mana"
 msgstr ""
 
-#: Source/items.cpp:1991
+#: Source/items.cpp:2005
 msgid "increase strength"
 msgstr ""
 
-#: Source/items.cpp:1995
+#: Source/items.cpp:2009
 msgid "increase magic"
 msgstr ""
 
-#: Source/items.cpp:1999
+#: Source/items.cpp:2013
 msgid "increase dexterity"
 msgstr ""
 
-#: Source/items.cpp:2003
+#: Source/items.cpp:2017
 msgid "increase vitality"
 msgstr ""
 
-#: Source/items.cpp:2008
+#: Source/items.cpp:2022
 msgid "decrease strength"
 msgstr ""
 
-#: Source/items.cpp:2012
+#: Source/items.cpp:2026
 msgid "decrease dexterity"
 msgstr ""
 
-#: Source/items.cpp:2016
+#: Source/items.cpp:2030
 msgid "decrease vitality"
 msgstr ""
 
-#: Source/items.cpp:2020
+#: Source/items.cpp:2034
 msgid "restore some life and mana"
 msgstr ""
 
-#: Source/items.cpp:2024
+#: Source/items.cpp:2038
 msgid "restore all life and mana"
 msgstr ""
 
-#: Source/items.cpp:2039 Source/items.cpp:2064
+#: Source/items.cpp:2053 Source/items.cpp:2078
 msgid "Right-click to read"
 msgstr ""
 
-#: Source/items.cpp:2043
+#: Source/items.cpp:2057
 msgid "Right-click to read, then"
 msgstr ""
 
-#: Source/items.cpp:2045
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr ""
 
-#: Source/items.cpp:2050
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr ""
 
-#: Source/items.cpp:2055 Source/items.cpp:2060
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr ""
 
-#: Source/items.cpp:2068
+#: Source/items.cpp:2082
 msgid "Right click to read"
 msgstr ""
 
-#: Source/items.cpp:2072
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr ""
 
-#: Source/items.cpp:2080
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr ""
 
-#: Source/items.cpp:2092 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 msgid "Required:"
 msgstr ""
 
-#: Source/items.cpp:2094 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 msgid " {:d} Str"
 msgstr ""
 
-#: Source/items.cpp:2096 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 msgid " {:d} Mag"
 msgstr ""
 
-#: Source/items.cpp:2098 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 msgid " {:d} Dex"
 msgstr ""
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3523 Source/player.cpp:3027
+#: Source/items.cpp:3533 Source/player.cpp:3018
 msgid "Ear of {:s}"
 msgstr ""
 
-#: Source/items.cpp:3818
+#: Source/items.cpp:3828
 msgid "chance to hit: {:+d}%"
 msgstr ""
 
-#: Source/items.cpp:3822
+#: Source/items.cpp:3832
 #, no-c-format
 msgid "{:+d}% damage"
 msgstr ""
 
-#: Source/items.cpp:3826 Source/items.cpp:4082
+#: Source/items.cpp:3836 Source/items.cpp:4092
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr ""
 
-#: Source/items.cpp:3830
+#: Source/items.cpp:3840
 #, no-c-format
 msgid "{:+d}% armor"
 msgstr ""
 
-#: Source/items.cpp:3834
+#: Source/items.cpp:3844
 msgid "armor class: {:d}"
 msgstr ""
 
-#: Source/items.cpp:3839 Source/items.cpp:4064
+#: Source/items.cpp:3849 Source/items.cpp:4074
 msgid "Resist Fire: {:+d}%"
 msgstr ""
 
-#: Source/items.cpp:3841
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr ""
 
-#: Source/items.cpp:3846
+#: Source/items.cpp:3856
 msgid "Resist Lightning: {:+d}%"
 msgstr ""
 
-#: Source/items.cpp:3848
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr ""
 
-#: Source/items.cpp:3853
+#: Source/items.cpp:3863
 msgid "Resist Magic: {:+d}%"
 msgstr ""
 
-#: Source/items.cpp:3855
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr ""
 
-#: Source/items.cpp:3860
+#: Source/items.cpp:3870
 msgid "Resist All: {:+d}%"
 msgstr ""
 
-#: Source/items.cpp:3862
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr ""
 
-#: Source/items.cpp:3866
+#: Source/items.cpp:3876
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Source/items.cpp:3868
+#: Source/items.cpp:3878
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Source/items.cpp:3870
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr ""
 
-#: Source/items.cpp:3873
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr ""
 
-#: Source/items.cpp:3876
+#: Source/items.cpp:3886
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Source/items.cpp:3880
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr ""
 
-#: Source/items.cpp:3882
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3886
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr ""
 
-#: Source/items.cpp:3888
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3892
+#: Source/items.cpp:3902
 msgid "{:+d} to strength"
 msgstr ""
 
-#: Source/items.cpp:3896
+#: Source/items.cpp:3906
 msgid "{:+d} to magic"
 msgstr ""
 
-#: Source/items.cpp:3900
+#: Source/items.cpp:3910
 msgid "{:+d} to dexterity"
 msgstr ""
 
-#: Source/items.cpp:3904
+#: Source/items.cpp:3914
 msgid "{:+d} to vitality"
 msgstr ""
 
-#: Source/items.cpp:3908
+#: Source/items.cpp:3918
 msgid "{:+d} to all attributes"
 msgstr ""
 
-#: Source/items.cpp:3912
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr ""
 
-#: Source/items.cpp:3916
+#: Source/items.cpp:3926
 msgid "Hit Points: {:+d}"
 msgstr ""
 
-#: Source/items.cpp:3920
+#: Source/items.cpp:3930
 msgid "Mana: {:+d}"
 msgstr ""
 
-#: Source/items.cpp:3923
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr ""
 
-#: Source/items.cpp:3926
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr ""
 
-#: Source/items.cpp:3929
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr ""
 
-#: Source/items.cpp:3932
+#: Source/items.cpp:3942
 #, no-c-format
 msgid "+{:d}% light radius"
 msgstr ""
 
-#: Source/items.cpp:3935
+#: Source/items.cpp:3945
 #, no-c-format
 msgid "-{:d}% light radius"
 msgstr ""
 
-#: Source/items.cpp:3938
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr ""
 
-#: Source/items.cpp:3942
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr ""
 
-#: Source/items.cpp:3944
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3948
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr ""
 
-#: Source/items.cpp:3950
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3954
+#: Source/items.cpp:3964
 msgid "fireball damage: {:d}"
 msgstr ""
 
-#: Source/items.cpp:3956
+#: Source/items.cpp:3966
 msgid "fireball damage: {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3959
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr ""
 
-#: Source/items.cpp:3962
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr ""
 
-#: Source/items.cpp:3965
+#: Source/items.cpp:3975
 msgid "you can't heal"
 msgstr ""
 
-#: Source/items.cpp:3968
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr ""
 
-#: Source/items.cpp:3971
+#: Source/items.cpp:3981
 msgid "knocks target back"
-msgstr ""
-
-#: Source/items.cpp:3974
-#, no-c-format
-msgid "+200% damage vs. demons"
-msgstr ""
-
-#: Source/items.cpp:3977
-msgid "All Resistance equals 0"
-msgstr ""
-
-#: Source/items.cpp:3980
-msgid "hit monster doesn't heal"
 msgstr ""
 
 #: Source/items.cpp:3984
 #, no-c-format
+msgid "+200% damage vs. demons"
+msgstr ""
+
+#: Source/items.cpp:3987
+msgid "All Resistance equals 0"
+msgstr ""
+
+#: Source/items.cpp:3990
+msgid "hit monster doesn't heal"
+msgstr ""
+
+#: Source/items.cpp:3994
+#, no-c-format
 msgid "hit steals 3% mana"
 msgstr ""
 
-#: Source/items.cpp:3986
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr ""
 
-#: Source/items.cpp:3990
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr ""
 
-#: Source/items.cpp:3992
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr ""
 
-#: Source/items.cpp:3995
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr ""
 
-#: Source/items.cpp:3999
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr ""
 
-#: Source/items.cpp:4001
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr ""
 
-#: Source/items.cpp:4003
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr ""
 
-#: Source/items.cpp:4005
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr ""
 
-#: Source/items.cpp:4009
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr ""
 
-#: Source/items.cpp:4011
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr ""
 
-#: Source/items.cpp:4013
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr ""
 
-#: Source/items.cpp:4016
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr ""
 
-#: Source/items.cpp:4019
+#: Source/items.cpp:4029
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] ""
 msgstr[1] ""
 
-#: Source/items.cpp:4022
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr ""
 
-#: Source/items.cpp:4025
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr ""
 
-#: Source/items.cpp:4028
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr ""
 
-#: Source/items.cpp:4031
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr ""
 
-#: Source/items.cpp:4034
+#: Source/items.cpp:4044
 msgid "one handed sword"
 msgstr ""
 
-#: Source/items.cpp:4037
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr ""
 
-#: Source/items.cpp:4040
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr ""
 
-#: Source/items.cpp:4043
+#: Source/items.cpp:4053
 msgid "no strength requirement"
 msgstr ""
 
-#: Source/items.cpp:4046
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr ""
 
-#: Source/items.cpp:4053
+#: Source/items.cpp:4063
 msgid "lightning damage: {:d}"
 msgstr ""
 
-#: Source/items.cpp:4055
+#: Source/items.cpp:4065
 msgid "lightning damage: {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:4058
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr ""
 
-#: Source/items.cpp:4067
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr ""
 
-#: Source/items.cpp:4070
+#: Source/items.cpp:4080
 #, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr ""
 
-#: Source/items.cpp:4073
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr ""
 
-#: Source/items.cpp:4076
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr ""
 
-#: Source/items.cpp:4079
+#: Source/items.cpp:4089
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr ""
 
-#: Source/items.cpp:4085
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr ""
 
-#: Source/items.cpp:4088
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr ""
 
-#: Source/items.cpp:4091
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr ""
 
-#: Source/items.cpp:4094
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr ""
 
-#: Source/items.cpp:4097
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr ""
 
-#: Source/items.cpp:4134 Source/items.cpp:4181
+#: Source/items.cpp:4144 Source/items.cpp:4191
 msgid "damage: {:d}  Indestructible"
 msgstr ""
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4136 Source/items.cpp:4183
+#: Source/items.cpp:4146 Source/items.cpp:4193
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr ""
 
-#: Source/items.cpp:4139 Source/items.cpp:4186
+#: Source/items.cpp:4149 Source/items.cpp:4196
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr ""
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4141 Source/items.cpp:4188
+#: Source/items.cpp:4151 Source/items.cpp:4198
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr ""
 
-#: Source/items.cpp:4147 Source/items.cpp:4200
+#: Source/items.cpp:4157 Source/items.cpp:4210
 msgid "armor: {:d}  Indestructible"
 msgstr ""
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4149 Source/items.cpp:4202
+#: Source/items.cpp:4159 Source/items.cpp:4212
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4154
+#: Source/items.cpp:4164
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr ""
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4156
+#: Source/items.cpp:4166
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr ""
 
-#: Source/items.cpp:4157 Source/items.cpp:4192 Source/items.cpp:4207
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 msgid "Charges: {:d}/{:d}"
 msgstr ""
 
-#: Source/items.cpp:4169
+#: Source/items.cpp:4179
 msgid "unique item"
 msgstr ""
 
-#: Source/items.cpp:4196 Source/items.cpp:4205 Source/items.cpp:4212
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr ""
 
@@ -5239,97 +5248,97 @@ msgctxt "monster"
 msgid "Doomlock"
 msgstr ""
 
-#: Source/monster.cpp:3497
+#: Source/monster.cpp:3479
 msgid "Animal"
 msgstr ""
 
-#: Source/monster.cpp:3499
+#: Source/monster.cpp:3481
 msgid "Demon"
 msgstr ""
 
-#: Source/monster.cpp:3501
+#: Source/monster.cpp:3483
 msgid "Undead"
 msgstr ""
 
-#: Source/monster.cpp:4632
+#: Source/monster.cpp:4612
 msgid "Type: {:s}  Kills: {:d}"
 msgstr ""
 
-#: Source/monster.cpp:4634
+#: Source/monster.cpp:4614
 msgid "Total kills: {:d}"
 msgstr ""
 
-#: Source/monster.cpp:4667
+#: Source/monster.cpp:4647
 msgid "Hit Points: {:d}-{:d}"
 msgstr ""
 
-#: Source/monster.cpp:4673
+#: Source/monster.cpp:4653
 msgid "No magic resistance"
 msgstr ""
 
-#: Source/monster.cpp:4677
+#: Source/monster.cpp:4657
 msgid "Resists: "
 msgstr ""
 
-#: Source/monster.cpp:4679 Source/monster.cpp:4690
+#: Source/monster.cpp:4659 Source/monster.cpp:4671
 msgid "Magic "
 msgstr ""
 
-#: Source/monster.cpp:4681 Source/monster.cpp:4692
+#: Source/monster.cpp:4661 Source/monster.cpp:4673
 msgid "Fire "
 msgstr ""
 
-#: Source/monster.cpp:4683 Source/monster.cpp:4694
+#: Source/monster.cpp:4663 Source/monster.cpp:4675
 msgid "Lightning "
 msgstr ""
 
-#: Source/monster.cpp:4688
+#: Source/monster.cpp:4669
 msgid "Immune: "
 msgstr ""
 
-#: Source/monster.cpp:4706
+#: Source/monster.cpp:4688
 msgid "Type: {:s}"
 msgstr ""
 
-#: Source/monster.cpp:4712 Source/monster.cpp:4719
+#: Source/monster.cpp:4694 Source/monster.cpp:4701
 msgid "No resistances"
 msgstr ""
 
-#: Source/monster.cpp:4714 Source/monster.cpp:4724
+#: Source/monster.cpp:4696 Source/monster.cpp:4706
 msgid "No Immunities"
 msgstr ""
 
-#: Source/monster.cpp:4717
+#: Source/monster.cpp:4699
 msgid "Some Magic Resistances"
 msgstr ""
 
-#: Source/monster.cpp:4722
+#: Source/monster.cpp:4704
 msgid "Some Magic Immunities"
 msgstr ""
 
-#: Source/msg.cpp:494
+#: Source/msg.cpp:495
 msgid "Trying to drop a floor item?"
 msgstr ""
 
-#: Source/msg.cpp:982 Source/msg.cpp:1017 Source/msg.cpp:1048
-#: Source/msg.cpp:1175 Source/msg.cpp:1207 Source/msg.cpp:1239
-#: Source/msg.cpp:1269
+#: Source/msg.cpp:994 Source/msg.cpp:1029 Source/msg.cpp:1060
+#: Source/msg.cpp:1187 Source/msg.cpp:1219 Source/msg.cpp:1251
+#: Source/msg.cpp:1281
 msgid "{:s} has cast an illegal spell."
 msgstr ""
 
-#: Source/msg.cpp:1655 Source/multi.cpp:805
+#: Source/msg.cpp:1668 Source/multi.cpp:804
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr ""
 
-#: Source/msg.cpp:1959
+#: Source/msg.cpp:1972
 msgid "Waiting for game data..."
 msgstr ""
 
-#: Source/msg.cpp:1967
+#: Source/msg.cpp:1980
 msgid "The game ended"
 msgstr ""
 
-#: Source/msg.cpp:1973
+#: Source/msg.cpp:1986
 msgid "Unable to get level data"
 msgstr ""
 
@@ -5345,7 +5354,7 @@ msgstr ""
 msgid "Player '{:s}' dropped due to timeout"
 msgstr ""
 
-#: Source/multi.cpp:807
+#: Source/multi.cpp:806
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr ""
 
@@ -5555,158 +5564,158 @@ msgstr ""
 msgid "A Spellbook"
 msgstr ""
 
-#: Source/objects.cpp:5384
+#: Source/objects.cpp:5339
 msgid "Crucified Skeleton"
 msgstr ""
 
-#: Source/objects.cpp:5388
+#: Source/objects.cpp:5343
 msgid "Lever"
 msgstr ""
 
-#: Source/objects.cpp:5397
+#: Source/objects.cpp:5352
 msgid "Open Door"
 msgstr ""
 
-#: Source/objects.cpp:5399
+#: Source/objects.cpp:5354
 msgid "Closed Door"
 msgstr ""
 
-#: Source/objects.cpp:5401
+#: Source/objects.cpp:5356
 msgid "Blocked Door"
 msgstr ""
 
-#: Source/objects.cpp:5406
+#: Source/objects.cpp:5361
 msgid "Ancient Tome"
 msgstr ""
 
-#: Source/objects.cpp:5408
+#: Source/objects.cpp:5363
 msgid "Book of Vileness"
 msgstr ""
 
-#: Source/objects.cpp:5413
+#: Source/objects.cpp:5368
 msgid "Skull Lever"
 msgstr ""
 
-#: Source/objects.cpp:5416
+#: Source/objects.cpp:5371
 msgid "Mythical Book"
 msgstr ""
 
-#: Source/objects.cpp:5420
+#: Source/objects.cpp:5375
 msgid "Small Chest"
 msgstr ""
 
-#: Source/objects.cpp:5424
+#: Source/objects.cpp:5379
 msgid "Chest"
 msgstr ""
 
-#: Source/objects.cpp:5429
+#: Source/objects.cpp:5384
 msgid "Large Chest"
 msgstr ""
 
-#: Source/objects.cpp:5432
+#: Source/objects.cpp:5387
 msgid "Sarcophagus"
 msgstr ""
 
-#: Source/objects.cpp:5435
+#: Source/objects.cpp:5390
 msgid "Bookshelf"
 msgstr ""
 
-#: Source/objects.cpp:5439
+#: Source/objects.cpp:5394
 msgid "Bookcase"
 msgstr ""
 
-#: Source/objects.cpp:5444
+#: Source/objects.cpp:5399
 msgid "Pod"
 msgstr ""
 
-#: Source/objects.cpp:5446
+#: Source/objects.cpp:5401
 msgid "Urn"
 msgstr ""
 
-#: Source/objects.cpp:5448
+#: Source/objects.cpp:5403
 msgid "Barrel"
 msgstr ""
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:5452
+#: Source/objects.cpp:5407
 msgid "{:s} Shrine"
 msgstr ""
 
-#: Source/objects.cpp:5456
+#: Source/objects.cpp:5411
 msgid "Skeleton Tome"
 msgstr ""
 
-#: Source/objects.cpp:5459
+#: Source/objects.cpp:5414
 msgid "Library Book"
 msgstr ""
 
-#: Source/objects.cpp:5462
+#: Source/objects.cpp:5417
 msgid "Blood Fountain"
 msgstr ""
 
-#: Source/objects.cpp:5465
+#: Source/objects.cpp:5420
 msgid "Decapitated Body"
 msgstr ""
 
-#: Source/objects.cpp:5468
+#: Source/objects.cpp:5423
 msgid "Book of the Blind"
 msgstr ""
 
-#: Source/objects.cpp:5471
+#: Source/objects.cpp:5426
 msgid "Book of Blood"
 msgstr ""
 
-#: Source/objects.cpp:5474
+#: Source/objects.cpp:5429
 msgid "Purifying Spring"
 msgstr ""
 
-#: Source/objects.cpp:5481 Source/objects.cpp:5505
+#: Source/objects.cpp:5436 Source/objects.cpp:5460
 msgid "Weapon Rack"
 msgstr ""
 
-#: Source/objects.cpp:5484
+#: Source/objects.cpp:5439
 msgid "Goat Shrine"
 msgstr ""
 
-#: Source/objects.cpp:5487
+#: Source/objects.cpp:5442
 msgid "Cauldron"
 msgstr ""
 
-#: Source/objects.cpp:5490
+#: Source/objects.cpp:5445
 msgid "Murky Pool"
 msgstr ""
 
-#: Source/objects.cpp:5493
+#: Source/objects.cpp:5448
 msgid "Fountain of Tears"
 msgstr ""
 
-#: Source/objects.cpp:5496
+#: Source/objects.cpp:5451
 msgid "Steel Tome"
 msgstr ""
 
-#: Source/objects.cpp:5499
+#: Source/objects.cpp:5454
 msgid "Pedestal of Blood"
 msgstr ""
 
-#: Source/objects.cpp:5508
+#: Source/objects.cpp:5463
 msgid "Mushroom Patch"
 msgstr ""
 
-#: Source/objects.cpp:5511
+#: Source/objects.cpp:5466
 msgid "Vile Stand"
 msgstr ""
 
-#: Source/objects.cpp:5514
+#: Source/objects.cpp:5469
 msgid "Slain Hero"
 msgstr ""
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:5521
+#: Source/objects.cpp:5476
 msgid "Trapped {:s}"
 msgstr ""
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
-#: Source/objects.cpp:5527
+#: Source/objects.cpp:5482
 msgid "{:s} (disabled)"
 msgstr ""
 
@@ -5824,23 +5833,23 @@ msgstr ""
 msgid "mute"
 msgstr ""
 
-#: Source/pfile.cpp:260
+#: Source/pfile.cpp:242
 msgid "Failed to open player archive for writing."
 msgstr ""
 
-#: Source/pfile.cpp:392
+#: Source/pfile.cpp:377
 msgid "Unable to open archive"
 msgstr ""
 
-#: Source/pfile.cpp:394
+#: Source/pfile.cpp:379
 msgid "Unable to load character"
 msgstr ""
 
-#: Source/pfile.cpp:419 Source/pfile.cpp:439
+#: Source/pfile.cpp:403 Source/pfile.cpp:423
 msgid "Unable to read to save file archive"
 msgstr ""
 
-#: Source/pfile.cpp:458
+#: Source/pfile.cpp:442
 msgid "Unable to write to save file archive"
 msgstr ""
 
@@ -5859,7 +5868,7 @@ msgstr ""
 msgid "%i gold"
 msgstr ""
 
-#: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:56
+#: Source/qol/monhealthbar.cpp:37 Source/qol/xpbar.cpp:56
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
@@ -6293,7 +6302,7 @@ msgstr ""
 msgid "Adria"
 msgstr ""
 
-#: Source/stores.cpp:98 Source/stores.cpp:1252
+#: Source/stores.cpp:98 Source/stores.cpp:1305
 msgid "Gillian"
 msgstr ""
 
@@ -6301,298 +6310,293 @@ msgstr ""
 msgid "Wirt"
 msgstr ""
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr ""
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ""
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 msgid "Damage: {:d}-{:d}  "
 msgstr ""
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 msgid "Armor: {:d}  "
 msgstr ""
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 msgid "Dur: {:d}/{:d},  "
 msgstr ""
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr ""
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr ""
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr ""
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr ""
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr ""
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 msgid "Talk to Griswold"
 msgstr ""
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 msgid "Buy basic items"
 msgstr ""
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 msgid "Buy premium items"
 msgstr ""
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 msgid "Sell items"
 msgstr ""
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 msgid "Repair items"
 msgstr ""
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 msgid "Leave the shop"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr ""
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr ""
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr ""
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr ""
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 msgid "Talk to Adria"
 msgstr ""
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr ""
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr ""
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 msgid "Leave the shack"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr ""
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr ""
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr ""
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr ""
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 msgid "Are you sure you want to identify this item?"
 msgstr ""
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 msgid "Are you sure you want to buy this item?"
 msgstr ""
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 msgid "Are you sure you want to recharge this item?"
 msgstr ""
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 msgid "Are you sure you want to sell this item?"
 msgstr ""
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 msgid "Are you sure you want to repair this item?"
 msgstr ""
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr ""
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 msgid "Talk to Wirt"
 msgstr ""
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr ""
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr ""
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr ""
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr ""
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr ""
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 msgid "Leave"
 msgstr ""
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr ""
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr ""
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr ""
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 msgid "The Town Elder"
 msgstr ""
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 msgid "Talk to Cain"
 msgstr ""
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr ""
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr ""
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr ""
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 msgid "Talk to {:s}"
 msgstr ""
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 msgid "Talking to {:s}"
 msgstr ""
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 msgid "is not available"
 msgstr ""
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 msgid "in the shareware"
 msgstr ""
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 msgid "version"
 msgstr ""
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr ""
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr ""
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 msgid "Talk to Ogden"
 msgstr ""
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 msgid "Leave the tavern"
 msgstr ""
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 msgid "Talk to Gillian"
 msgstr ""
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr ""
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 msgid "Talk to Farnham"
 msgstr ""
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr ""
 

--- a/Translations/es.po
+++ b/Translations/es.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-11-06 17:09+0100\n"
-"PO-Revision-Date: 2021-11-06 17:09+0100\n"
+"POT-Creation-Date: 2021-11-21 05:44+0100\n"
+"PO-Revision-Date: 2021-11-21 05:44+0100\n"
 "Last-Translator: Mad-Soft <mad.soft@gmail.com>\n"
 "Language-Team: Spanish\n"
 "Language: es\n"
@@ -397,8 +397,8 @@ msgstr "Cliente-Servidor (TCP)"
 msgid "Loopback"
 msgstr "Loopback"
 
-#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:484
-#: Source/DiabloUI/selgame.cpp:505
+#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:489
+#: Source/DiabloUI/selgame.cpp:510
 msgid "Multi Player Game"
 msgstr "Juego Multijugador"
 
@@ -762,11 +762,11 @@ msgstr "¿Está seguro de que desea borrar el personaje \"{:s}\"?"
 msgid "Enter Hellfire"
 msgstr "Entrar a Hellfire"
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr "Si"
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr "No"
 
@@ -826,12 +826,12 @@ msgstr ""
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr "Copyright © 1996-2001 Blizzard Entertainment"
 
-#: Source/appfat.cpp:37
+#: Source/appfat.cpp:38
 msgid "Error"
 msgstr "Error"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:101
+#: Source/appfat.cpp:102
 msgid ""
 "{:s}\n"
 "\n"
@@ -841,7 +841,7 @@ msgstr ""
 "\n"
 "El error ocurrió en: {:s} línea {:d}"
 
-#: Source/appfat.cpp:116
+#: Source/appfat.cpp:117
 msgid ""
 "Unable to open main data archive ({:s}).\n"
 "\n"
@@ -851,12 +851,12 @@ msgstr ""
 "\n"
 "Asegúrese de que esté en la carpeta del juego."
 
-#: Source/appfat.cpp:122
+#: Source/appfat.cpp:123
 msgid "Data File Error"
 msgstr "Error de Archivo de Datos"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:130
+#: Source/appfat.cpp:131
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -864,7 +864,7 @@ msgstr ""
 "No se puede escribir en la ubicación:\n"
 "{:s}"
 
-#: Source/appfat.cpp:132
+#: Source/appfat.cpp:133
 msgid "Read-Only Directory Error"
 msgstr "Error de Directorio de Solo Lectura"
 
@@ -888,176 +888,176 @@ msgstr "Nivel: Guarida {:d}"
 msgid "Level: Crypt {:d}"
 msgstr "Nivel: Cripta {:d}"
 
-#: Source/automap.cpp:508 Source/items.cpp:2076
+#: Source/automap.cpp:508 Source/items.cpp:2090
 msgid "Level: {:d}"
 msgstr "Nivel: {:d}"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr "Tab"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr "Esc"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Enter"
 msgstr "Intro"
 
-#: Source/control.cpp:202
+#: Source/control.cpp:215
 msgid "Character Information"
 msgstr "Información del Personaje"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr "Registro de Misiones"
 
-#: Source/control.cpp:204
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr "Automapa"
 
-#: Source/control.cpp:205
+#: Source/control.cpp:218
 msgid "Main Menu"
 msgstr "Menú Principal"
 
-#: Source/control.cpp:206
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr "Inventario"
 
-#: Source/control.cpp:207
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr "Libro de Hechizos"
 
-#: Source/control.cpp:208
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr "Enviar Mensaje"
 
-#: Source/control.cpp:705 Source/control.cpp:1565
+#: Source/control.cpp:718 Source/control.cpp:1587
 msgid "Skill"
 msgstr "Habilidad"
 
-#: Source/control.cpp:706 Source/control.cpp:1219
+#: Source/control.cpp:719 Source/control.cpp:1237
 msgid "{:s} Skill"
 msgstr "{:s} Habilidad"
 
-#: Source/control.cpp:712
+#: Source/control.cpp:725
 msgid "Spell"
 msgstr "Hechizo"
 
-#: Source/control.cpp:713 Source/control.cpp:1223
+#: Source/control.cpp:726 Source/control.cpp:1241
 msgid "{:s} Spell"
 msgstr "{:s} Hechizo"
 
-#: Source/control.cpp:715
+#: Source/control.cpp:728
 msgid "Damages undead only"
 msgstr "Solo daña muertos vivientes"
 
-#: Source/control.cpp:719 Source/control.cpp:1227 Source/control.cpp:1589
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr "Nivel de Hechizo 0: Inutilizable"
 
-#: Source/control.cpp:721 Source/control.cpp:1229 Source/control.cpp:1591
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 msgid "Spell Level {:d}"
 msgstr "Nivel de Hechizo {:d}"
 
-#: Source/control.cpp:728
+#: Source/control.cpp:741
 msgid "Scroll"
 msgstr "Pergamino"
 
-#: Source/control.cpp:729 Source/control.cpp:1233
+#: Source/control.cpp:742 Source/control.cpp:1251
 msgid "Scroll of {:s}"
 msgstr "Pergamino de {:s}"
 
-#: Source/control.cpp:734 Source/control.cpp:1239
+#: Source/control.cpp:747 Source/control.cpp:1257
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "{:d} Pergamino"
 msgstr[1] "{:d} Pergaminos"
 
-#: Source/control.cpp:741 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
 #: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
 msgid "Staff"
 msgstr "Vara"
 
-#: Source/control.cpp:742 Source/control.cpp:1243 Source/items.cpp:1317
+#: Source/control.cpp:755 Source/control.cpp:1261
 msgid "Staff of {:s}"
 msgstr "Vara de {:s}"
 
-#: Source/control.cpp:744 Source/control.cpp:1245
+#: Source/control.cpp:757 Source/control.cpp:1263
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "{:d} Carga"
 msgstr[1] "{:d} Cargas"
 
-#: Source/control.cpp:754
+#: Source/control.cpp:767
 msgid "Spell Hotkey {:s}"
 msgstr "Tecla de acceso rápido de Hechizo {:s}"
 
-#: Source/control.cpp:1196
+#: Source/control.cpp:1214
 msgid "Player friendly"
 msgstr "Amigable"
 
-#: Source/control.cpp:1198
+#: Source/control.cpp:1216
 msgid "Player attack"
 msgstr "Ataque del jugador"
 
-#: Source/control.cpp:1201
+#: Source/control.cpp:1219
 msgid "Hotkey: {:s}"
 msgstr "Tecla de acceso rápido: {:s}"
 
-#: Source/control.cpp:1209
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr "Seleccionar botón de hechizo actual"
 
-#: Source/control.cpp:1212
+#: Source/control.cpp:1230
 msgid "Hotkey: 's'"
 msgstr "Tecla de acceso rápido: 's'"
 
-#: Source/control.cpp:1367 Source/inv.cpp:1992 Source/items.cpp:3739
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "{:d} pieza de oro"
 msgstr[1] "{:d} piezas de oro"
 
-#: Source/control.cpp:1370
+#: Source/control.cpp:1390
 msgid "Requirements not met"
 msgstr "Requisitos no cumplidos"
 
-#: Source/control.cpp:1406
+#: Source/control.cpp:1426
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Nivel: {:d}"
 
-#: Source/control.cpp:1408
+#: Source/control.cpp:1428
 msgid "Hit Points {:d} of {:d}"
 msgstr "Vida {:d} de {:d}"
 
-#: Source/control.cpp:1435
+#: Source/control.cpp:1457
 msgid "Level Up"
 msgstr "Subir Nivel"
 
-#: Source/control.cpp:1569
+#: Source/control.cpp:1591
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] "Vara ({:d} carga)"
 msgstr[1] "Vara ({:d} cargas)"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1579
+#: Source/control.cpp:1601
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "Maná: {:d} Daño: {:d} - {:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1581
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "Maná: {:d} Daño: n/a"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1584
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "Maná: {:d} Daño: 1/3 tgt hp"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1642
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] "Tiene {:d} moneda de oro. ¿Cuanto quiere eliminar?"
@@ -1263,7 +1263,7 @@ msgstr "mientras que en las tiendas"
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr "{:s}, versión = {:s}, modo = {:s}"
 
-#: Source/dvlnet/loopback.cpp:111
+#: Source/dvlnet/loopback.cpp:113
 msgid "loopback"
 msgstr "loopback"
 
@@ -1733,7 +1733,9 @@ msgstr ""
 "presionando el número correspondiente o haciendo clic derecho en el objeto."
 
 #: Source/help.cpp:68
-msgid "$Gold"
+#, fuzzy
+#| msgid "$Gold"
+msgid "$Gold:"
 msgstr "$Oro"
 
 #: Source/help.cpp:69
@@ -1764,7 +1766,9 @@ msgstr ""
 "el botón derecho en el área de juego."
 
 #: Source/help.cpp:79
-msgid "$Using the Speedbook for Spells"
+#, fuzzy
+#| msgid "$Using the Speedbook for Spells"
+msgid "$Using the Speedbook for Spells:"
 msgstr "$Uso del Speedbook para Hechizos"
 
 #: Source/help.cpp:80
@@ -1779,15 +1783,21 @@ msgstr ""
 "el botón derecho en el área de juego principal."
 
 #: Source/help.cpp:84
+#, fuzzy
+#| msgid ""
+#| "Shift + Left-clicking on the 'select current spell' button will clear the "
+#| "readied spell"
 msgid ""
 "Shift + Left-clicking on the 'select current spell' button will clear the "
-"readied spell"
+"readied spell."
 msgstr ""
 "Shift + Click Izquierdo en el botón 'seleccionar hechizo actual' borrará el "
 "hechizo preparado"
 
 #: Source/help.cpp:86
-msgid "$Setting Spell Hotkeys"
+#, fuzzy
+#| msgid "$Setting Spell Hotkeys"
+msgid "$Setting Spell Hotkeys:"
 msgstr "$Configurar teclas de acceso rápido para Hechizos"
 
 #: Source/help.cpp:87
@@ -1802,7 +1812,9 @@ msgstr ""
 "el hechizo que desea asignar."
 
 #: Source/help.cpp:92
-msgid "$Spell Books"
+#, fuzzy
+#| msgid "$Spell Books"
+msgid "$Spell Books:"
 msgstr "$Libro de hechizos"
 
 #: Source/help.cpp:93
@@ -1813,35 +1825,35 @@ msgstr ""
 "Leer más de un libro aumenta su conocimiento de ese hechizo, lo que le "
 "permite lanzar el hechizo de manera más efectiva."
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Shareware Hellfire Help"
 msgstr "Ayuda de Hellfire Shareware"
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Hellfire Help"
 msgstr "Ayuda de Hellfire"
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Shareware Diablo Help"
 msgstr "Ayuda de Diablo Shareware"
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Diablo Help"
 msgstr "Ayuda de Diablo"
 
-#: Source/help.cpp:161
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr "Presione ESC para finalizar o las teclas de flecha para desplazarse."
 
-#: Source/init.cpp:206
+#: Source/init.cpp:175
 msgid "diabdat.mpq or spawn.mpq"
 msgstr "diabdat.mpq o spawn.mpq"
 
-#: Source/init.cpp:226
+#: Source/init.cpp:196
 msgid "Some Hellfire MPQs are missing"
 msgstr "Faltan algunos MPQ de Hellfire"
 
-#: Source/init.cpp:226
+#: Source/init.cpp:196
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
@@ -1849,7 +1861,7 @@ msgstr ""
 "No se encontraron todos los MPQ de Hellfire.\n"
 "Copie todos los archivos hf * .mpq."
 
-#: Source/init.cpp:234
+#: Source/init.cpp:204
 msgid "Unable to create main window"
 msgstr "No se pudo crear la ventana principal"
 
@@ -2093,7 +2105,7 @@ msgid "Quilted Armor"
 msgstr "Armadura Acolchada"
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
-#: Source/itemdat.cpp:77 Source/objects.cpp:5441
+#: Source/itemdat.cpp:77 Source/objects.cpp:5433
 msgid "Armor"
 msgstr "Armadura"
 
@@ -3635,639 +3647,652 @@ msgstr "Aceite de Endurecimiento"
 msgid "Oil of Imperviousness"
 msgstr "Aceite de Impermeabilidad"
 
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#: Source/items.cpp:1174 Source/items.cpp:1184 Source/items.cpp:1233
-#: Source/items.cpp:1269
-msgid "{0} {1}"
-msgstr "{0} {1}"
-
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's Staff of Firewall
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Long Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1187 Source/items.cpp:1254 Source/items.cpp:1273
-#: Source/items.cpp:1315
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
+#, fuzzy
+#| msgid "{0} of {1}"
+msgctxt "spell"
 msgid "{0} of {1}"
 msgstr "{0} de {1}"
 
-#: Source/items.cpp:1892 Source/items.cpp:1904
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+#, fuzzy
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr "{0} {1} de {2}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+#, fuzzy
+msgid "{0} {1} of {2}"
+msgstr "{0} {1} de {2}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
+#: Source/items.cpp:1217
+msgid "{0} {1}"
+msgstr "{0} {1}"
+
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
+msgid "{0} of {1}"
+msgstr "{0} de {1}"
+
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr "en el arma aumenta"
 
-#: Source/items.cpp:1894
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr "probabilidad de acertar"
 
-#: Source/items.cpp:1898
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr "aumenta enormemente un"
 
-#: Source/items.cpp:1900
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr "posibilidad de que el arma golpee"
 
-#: Source/items.cpp:1906
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr "daño potencial"
 
-#: Source/items.cpp:1910
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr "aumenta en gran medida la de un arma"
 
-#: Source/items.cpp:1912
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr "daño potencial - no arcos"
 
-#: Source/items.cpp:1916
+#: Source/items.cpp:1930
 msgid "reduces attributes needed"
 msgstr "reduce los atributos necesarios"
 
-#: Source/items.cpp:1918
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr "para usar armaduras o armas"
 
-#: Source/items.cpp:1922
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr "restaura el 20% de la"
 
-#: Source/items.cpp:1924
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr "durabilidad del artículo"
 
-#: Source/items.cpp:1928
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr "aumenta la de un artículo"
 
-#: Source/items.cpp:1930
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr "durabilidad actual y máxima"
 
-#: Source/items.cpp:1934
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr "hace que un artículo sea indestructible"
 
-#: Source/items.cpp:1938
+#: Source/items.cpp:1952
 msgid "increases the armor class"
 msgstr "aumenta la clase de armadura"
 
-#: Source/items.cpp:1940
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr "de armaduras y escudos"
 
-#: Source/items.cpp:1944
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr "aumenta enormemente la armadura"
 
-#: Source/items.cpp:1946
+#: Source/items.cpp:1960
 msgid "class of armor and shields"
 msgstr "clase de armaduras y escudos"
 
-#: Source/items.cpp:1950 Source/items.cpp:1959
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr "pone trampa de fuego"
 
-#: Source/items.cpp:1955
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr "establece trampa de rayos"
 
-#: Source/items.cpp:1963
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr "establece trampa de petrificación"
 
-#: Source/items.cpp:1967
+#: Source/items.cpp:1981
 msgid "restore all life"
 msgstr "recuperar toda la vida"
 
-#: Source/items.cpp:1971
+#: Source/items.cpp:1985
 msgid "restore some life"
 msgstr "recuperar algo de vida"
 
-#: Source/items.cpp:1975
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr "recuperar la vida"
 
-#: Source/items.cpp:1979
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr "curación mortal"
 
-#: Source/items.cpp:1983
+#: Source/items.cpp:1997
 msgid "restore some mana"
 msgstr "restaura algo de maná"
 
-#: Source/items.cpp:1987
+#: Source/items.cpp:2001
 msgid "restore all mana"
 msgstr "restaura todo el maná"
 
-#: Source/items.cpp:1991
+#: Source/items.cpp:2005
 msgid "increase strength"
 msgstr "aumenta la fuerza"
 
-#: Source/items.cpp:1995
+#: Source/items.cpp:2009
 msgid "increase magic"
 msgstr "aumenta la magia"
 
-#: Source/items.cpp:1999
+#: Source/items.cpp:2013
 msgid "increase dexterity"
 msgstr "aumenta la destreza"
 
-#: Source/items.cpp:2003
+#: Source/items.cpp:2017
 msgid "increase vitality"
 msgstr "aumenta la vitalidad"
 
-#: Source/items.cpp:2008
+#: Source/items.cpp:2022
 msgid "decrease strength"
 msgstr "disminuiye la fuerza"
 
-#: Source/items.cpp:2012
+#: Source/items.cpp:2026
 msgid "decrease dexterity"
 msgstr "disminuye la destreza"
 
-#: Source/items.cpp:2016
+#: Source/items.cpp:2030
 msgid "decrease vitality"
 msgstr "disminuye la vitalidad"
 
-#: Source/items.cpp:2020
+#: Source/items.cpp:2034
 msgid "restore some life and mana"
 msgstr "recupera algo de vida y maná"
 
-#: Source/items.cpp:2024
+#: Source/items.cpp:2038
 msgid "restore all life and mana"
 msgstr "recupera toda la vida y maná"
 
-#: Source/items.cpp:2039 Source/items.cpp:2064
+#: Source/items.cpp:2053 Source/items.cpp:2078
 msgid "Right-click to read"
 msgstr "Haga clic derecho para leer"
 
-#: Source/items.cpp:2043
+#: Source/items.cpp:2057
 msgid "Right-click to read, then"
 msgstr "Haga clic derecho para leer, luego"
 
-#: Source/items.cpp:2045
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr "clic izquierdo para apuntar"
 
-#: Source/items.cpp:2050
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr "Clic derecho para usar"
 
-#: Source/items.cpp:2055 Source/items.cpp:2060
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr "Clic derecho para usar"
 
-#: Source/items.cpp:2068
+#: Source/items.cpp:2082
 msgid "Right click to read"
 msgstr "Clic derecho para leer"
 
-#: Source/items.cpp:2072
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr "Clic derecho para ver"
 
-#: Source/items.cpp:2080
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr "Duplica la capacidad de oro"
 
-#: Source/items.cpp:2092 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 msgid "Required:"
 msgstr "Requerido:"
 
-#: Source/items.cpp:2094 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 msgid " {:d} Str"
 msgstr " {:d} Fuerza"
 
-#: Source/items.cpp:2096 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 msgid " {:d} Mag"
 msgstr " {:d} Magia"
 
-#: Source/items.cpp:2098 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 msgid " {:d} Dex"
 msgstr " {:d} Destreza"
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3523 Source/player.cpp:3027
+#: Source/items.cpp:3533 Source/player.cpp:3018
 msgid "Ear of {:s}"
 msgstr "Oído de {:s}"
 
-#: Source/items.cpp:3818
+#: Source/items.cpp:3828
 msgid "chance to hit: {:+d}%"
 msgstr "probabilidad de acertar: {:+d}%"
 
-#: Source/items.cpp:3822
+#: Source/items.cpp:3832
 #, no-c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% daño"
 
-#: Source/items.cpp:3826 Source/items.cpp:4082
+#: Source/items.cpp:3836 Source/items.cpp:4092
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "para golpear: {:+d}%,{:+d} {:d} daño"
 
-#: Source/items.cpp:3830
+#: Source/items.cpp:3840
 #, no-c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% armadura"
 
-#: Source/items.cpp:3834
+#: Source/items.cpp:3844
 msgid "armor class: {:d}"
 msgstr "clase de armadura: {:d}"
 
-#: Source/items.cpp:3839 Source/items.cpp:4064
+#: Source/items.cpp:3849 Source/items.cpp:4074
 msgid "Resist Fire: {:+d}%"
 msgstr "Resist al fuego: {:+d}%"
 
-#: Source/items.cpp:3841
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr "Resistencia al fuego: 75% MAX"
 
-#: Source/items.cpp:3846
+#: Source/items.cpp:3856
 msgid "Resist Lightning: {:+d}%"
 msgstr "Resistir Relámpagos: {:+d}%"
 
-#: Source/items.cpp:3848
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr "Resistir Relámpagos: 75% MAX"
 
-#: Source/items.cpp:3853
+#: Source/items.cpp:3863
 msgid "Resist Magic: {:+d}%"
 msgstr "Resistencia a la Magia: {:+d}%"
 
-#: Source/items.cpp:3855
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr "Resistencia a la Magia: 75% MAX"
 
-#: Source/items.cpp:3860
+#: Source/items.cpp:3870
 msgid "Resist All: {:+d}%"
 msgstr "Resistir Todo: {:+d}%"
 
-#: Source/items.cpp:3862
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr "Resistir Todo: 75% MAX"
 
-#: Source/items.cpp:3866
+#: Source/items.cpp:3876
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] "los hechizos aumentan {:d} nivel"
 msgstr[1] "los hechizos aumentan {:d} niveles"
 
-#: Source/items.cpp:3868
+#: Source/items.cpp:3878
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "los hechizos se reducen {:d} nivel"
 msgstr[1] "los hechizos se reducen {:d} niveles"
 
-#: Source/items.cpp:3870
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr "niveles de hechizo sin cambios (?)"
 
-#: Source/items.cpp:3873
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr "Cargas extras"
 
-#: Source/items.cpp:3876
+#: Source/items.cpp:3886
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:d} {:s} carga"
 msgstr[1] "{:d} {:s} cargas"
 
-#: Source/items.cpp:3880
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr "Daño por impacto de fuego: {:d}"
 
-#: Source/items.cpp:3882
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "Daño por impacto de fuego: {:d}- {:d}"
 
-#: Source/items.cpp:3886
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr "Daño por impacto de rayo: {:d}"
 
-#: Source/items.cpp:3888
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "Daño por impacto de rayo: {:d}- {:d}"
 
-#: Source/items.cpp:3892
+#: Source/items.cpp:3902
 msgid "{:+d} to strength"
 msgstr "{:+d} a la fuerza"
 
-#: Source/items.cpp:3896
+#: Source/items.cpp:3906
 msgid "{:+d} to magic"
 msgstr "{:+d} a la magia"
 
-#: Source/items.cpp:3900
+#: Source/items.cpp:3910
 msgid "{:+d} to dexterity"
 msgstr "{:+d} a la destreza"
 
-#: Source/items.cpp:3904
+#: Source/items.cpp:3914
 msgid "{:+d} to vitality"
 msgstr "{:+d} a la vitalidad"
 
-#: Source/items.cpp:3908
+#: Source/items.cpp:3918
 msgid "{:+d} to all attributes"
 msgstr "{:+d} a todos los atributos"
 
-#: Source/items.cpp:3912
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} de daño de enemigos"
 
-#: Source/items.cpp:3916
+#: Source/items.cpp:3926
 msgid "Hit Points: {:+d}"
 msgstr "Puntos de Vida: {:+d}"
 
-#: Source/items.cpp:3920
+#: Source/items.cpp:3930
 msgid "Mana: {:+d}"
 msgstr "Maná: {:+d}"
 
-#: Source/items.cpp:3923
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr "alta durabilidad"
 
-#: Source/items.cpp:3926
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr "durabilidad disminuida"
 
-#: Source/items.cpp:3929
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr "indestructible"
 
-#: Source/items.cpp:3932
+#: Source/items.cpp:3942
 #, no-c-format
 msgid "+{:d}% light radius"
 msgstr "+{:d}% radio de luz"
 
-#: Source/items.cpp:3935
+#: Source/items.cpp:3945
 #, no-c-format
 msgid "-{:d}% light radius"
 msgstr "-{:d}% radio de luz"
 
-#: Source/items.cpp:3938
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr "múltiples flechas por disparo"
 
-#: Source/items.cpp:3942
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr "daño de las flechas de fuego: {:d}"
 
-#: Source/items.cpp:3944
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "daño de las flechas de fuego: {:d}-{:d}"
 
-#: Source/items.cpp:3948
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr "daño de las flechas de rayo {:d}"
 
-#: Source/items.cpp:3950
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "daño de las flechas de rayo {:d}-{:d}"
 
-#: Source/items.cpp:3954
+#: Source/items.cpp:3964
 msgid "fireball damage: {:d}"
 msgstr "daño de bola de fuego: {:d}"
 
-#: Source/items.cpp:3956
+#: Source/items.cpp:3966
 msgid "fireball damage: {:d}-{:d}"
 msgstr "daño de bola de fuego: {:d}-{:d}"
 
-#: Source/items.cpp:3959
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr "el atacante recibe 1-3 daños"
 
-#: Source/items.cpp:3962
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr "el usuario pierde todo el maná"
 
-#: Source/items.cpp:3965
+#: Source/items.cpp:3975
 msgid "you can't heal"
 msgstr "no puedes curar"
 
-#: Source/items.cpp:3968
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr "absorbe la mitad del daño de la trampa"
 
-#: Source/items.cpp:3971
+#: Source/items.cpp:3981
 msgid "knocks target back"
 msgstr "hace retroceder al objetivo"
 
-#: Source/items.cpp:3974
+#: Source/items.cpp:3984
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr "+200% de daño contra demonios"
 
-#: Source/items.cpp:3977
+#: Source/items.cpp:3987
 msgid "All Resistance equals 0"
 msgstr "Toda la Resistencia es igual a 0"
 
-#: Source/items.cpp:3980
+#: Source/items.cpp:3990
 msgid "hit monster doesn't heal"
 msgstr "golpear al monstruo no cura"
 
-#: Source/items.cpp:3984
+#: Source/items.cpp:3994
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr "el golpe roba 3% de maná"
 
-#: Source/items.cpp:3986
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr "el golpe roba 5% de maná"
 
-#: Source/items.cpp:3990
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr "el golpe roba el 3% de la vida"
 
-#: Source/items.cpp:3992
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr "el golpe roba 5% de vida"
 
-#: Source/items.cpp:3995
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr "penetra la armadura del objetivo"
 
-#: Source/items.cpp:3999
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr "ataque rápido"
 
-#: Source/items.cpp:4001
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr "ataque rápido"
 
-#: Source/items.cpp:4003
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr "ataque más rápido"
 
-#: Source/items.cpp:4005
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr "ataque más rápido posible"
 
-#: Source/items.cpp:4009
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr "recuperación rápida de golpes"
 
-#: Source/items.cpp:4011
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr "recuperación de golpes más rápida"
 
-#: Source/items.cpp:4013
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr "recuperación de golpe más rápida posible"
 
-#: Source/items.cpp:4016
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr "bloqueo rapido"
 
-#: Source/items.cpp:4019
+#: Source/items.cpp:4029
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] "agrega {:d} punto al daño"
 msgstr[1] "agrega {:d} puntos al daño"
 
-#: Source/items.cpp:4022
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr "dispara flechas de velocidad aleatoria"
 
-#: Source/items.cpp:4025
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr "daño inusual del artículo"
 
-#: Source/items.cpp:4028
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr "durabilidad alterada"
 
-#: Source/items.cpp:4031
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr "Giro de ataque más rápido"
 
-#: Source/items.cpp:4034
+#: Source/items.cpp:4044
 msgid "one handed sword"
 msgstr "espada de una mano"
 
-#: Source/items.cpp:4037
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr "pierde puntos de vida constantemente"
 
-#: Source/items.cpp:4040
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr "robo de vida"
 
-#: Source/items.cpp:4043
+#: Source/items.cpp:4053
 msgid "no strength requirement"
 msgstr "sin requisito de fuerza"
 
-#: Source/items.cpp:4046
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr "ver con infravision"
 
-#: Source/items.cpp:4053
+#: Source/items.cpp:4063
 msgid "lightning damage: {:d}"
 msgstr "daño por rayo: {:d}"
 
-#: Source/items.cpp:4055
+#: Source/items.cpp:4065
 msgid "lightning damage: {:d}-{:d}"
 msgstr "daño por rayo: {:d}-{:d}"
 
-#: Source/items.cpp:4058
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr "rayos por cada golpe"
 
-#: Source/items.cpp:4067
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr "triple daño ocasional"
 
-#: Source/items.cpp:4070
+#: Source/items.cpp:4080
 #, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr "{:+d}% de daño de descomposición"
 
-#: Source/items.cpp:4073
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr "2x dañ al mes, 1x a ti"
 
-#: Source/items.cpp:4076
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr "Daño aleatorio 0 - 500%"
 
-#: Source/items.cpp:4079
+#: Source/items.cpp:4089
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr "baja dur, {:+d}% de daño"
 
-#: Source/items.cpp:4085
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr "extra CA contra demonios"
 
-#: Source/items.cpp:4088
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr "extra CA contra muertos vivientes"
 
-#: Source/items.cpp:4091
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr "50% de Maná se movió a Salud"
 
-#: Source/items.cpp:4094
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr "40% de Salud se movió a Maná"
 
-#: Source/items.cpp:4097
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr "Otra habilidad (NW)"
 
-#: Source/items.cpp:4134 Source/items.cpp:4181
+#: Source/items.cpp:4144 Source/items.cpp:4191
 msgid "damage: {:d}  Indestructible"
 msgstr "daño: {:d} Indestructible"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4136 Source/items.cpp:4183
+#: Source/items.cpp:4146 Source/items.cpp:4193
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "daño: {:d}  Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4139 Source/items.cpp:4186
+#: Source/items.cpp:4149 Source/items.cpp:4196
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "daño: {:d}-{:d} Indestructible"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4141 Source/items.cpp:4188
+#: Source/items.cpp:4151 Source/items.cpp:4198
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "daño: {:d}-{:d} Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4147 Source/items.cpp:4200
+#: Source/items.cpp:4157 Source/items.cpp:4210
 msgid "armor: {:d}  Indestructible"
 msgstr "armadura: {:d} Indestructible"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4149 Source/items.cpp:4202
+#: Source/items.cpp:4159 Source/items.cpp:4212
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "armadura: {:d} Dur: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4154
+#: Source/items.cpp:4164
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "dañ: {:d} Dur: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4156
+#: Source/items.cpp:4166
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "dañ: {:d}-{:d} Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4157 Source/items.cpp:4192 Source/items.cpp:4207
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 msgid "Charges: {:d}/{:d}"
 msgstr "Cargas: {:d}/{:d}"
 
-#: Source/items.cpp:4169
+#: Source/items.cpp:4179
 msgid "unique item"
 msgstr "artículo único"
 
-#: Source/items.cpp:4196 Source/items.cpp:4205 Source/items.cpp:4212
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr "No Identificado"
 
@@ -5422,97 +5447,97 @@ msgctxt "monster"
 msgid "Doomlock"
 msgstr "Cerradura de la Condenación"
 
-#: Source/monster.cpp:3497
+#: Source/monster.cpp:3479
 msgid "Animal"
 msgstr "Animal"
 
-#: Source/monster.cpp:3499
+#: Source/monster.cpp:3481
 msgid "Demon"
 msgstr "Demonio"
 
-#: Source/monster.cpp:3501
+#: Source/monster.cpp:3483
 msgid "Undead"
 msgstr "Muerto viviente"
 
-#: Source/monster.cpp:4632
+#: Source/monster.cpp:4612
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "Tipo: {:s}  Muertes: {:d}"
 
-#: Source/monster.cpp:4634
+#: Source/monster.cpp:4614
 msgid "Total kills: {:d}"
 msgstr "Muertes totales: {:d}"
 
-#: Source/monster.cpp:4667
+#: Source/monster.cpp:4647
 msgid "Hit Points: {:d}-{:d}"
 msgstr "Puntos de Golpe: {:d}- {:d}"
 
-#: Source/monster.cpp:4673
+#: Source/monster.cpp:4653
 msgid "No magic resistance"
 msgstr "Sin resistencia mágica"
 
-#: Source/monster.cpp:4677
+#: Source/monster.cpp:4657
 msgid "Resists: "
 msgstr "Resiste: "
 
-#: Source/monster.cpp:4679 Source/monster.cpp:4690
+#: Source/monster.cpp:4659 Source/monster.cpp:4671
 msgid "Magic "
 msgstr "Magia "
 
-#: Source/monster.cpp:4681 Source/monster.cpp:4692
+#: Source/monster.cpp:4661 Source/monster.cpp:4673
 msgid "Fire "
 msgstr "Fuego "
 
-#: Source/monster.cpp:4683 Source/monster.cpp:4694
+#: Source/monster.cpp:4663 Source/monster.cpp:4675
 msgid "Lightning "
 msgstr "Relámpago "
 
-#: Source/monster.cpp:4688
+#: Source/monster.cpp:4669
 msgid "Immune: "
 msgstr "Inmune: "
 
-#: Source/monster.cpp:4706
+#: Source/monster.cpp:4688
 msgid "Type: {:s}"
 msgstr "Tipo: {:s}"
 
-#: Source/monster.cpp:4712 Source/monster.cpp:4719
+#: Source/monster.cpp:4694 Source/monster.cpp:4701
 msgid "No resistances"
 msgstr "Sin resistencias"
 
-#: Source/monster.cpp:4714 Source/monster.cpp:4724
+#: Source/monster.cpp:4696 Source/monster.cpp:4706
 msgid "No Immunities"
 msgstr "Sin Inmunidades"
 
-#: Source/monster.cpp:4717
+#: Source/monster.cpp:4699
 msgid "Some Magic Resistances"
 msgstr "Algunas Resistencias Mágicas"
 
-#: Source/monster.cpp:4722
+#: Source/monster.cpp:4704
 msgid "Some Magic Immunities"
 msgstr "Algunas Inmunidades Mágicas"
 
-#: Source/msg.cpp:494
+#: Source/msg.cpp:495
 msgid "Trying to drop a floor item?"
 msgstr "¿Está intentando dejar caer un artículo del suelo?"
 
-#: Source/msg.cpp:982 Source/msg.cpp:1017 Source/msg.cpp:1048
-#: Source/msg.cpp:1175 Source/msg.cpp:1207 Source/msg.cpp:1239
-#: Source/msg.cpp:1269
+#: Source/msg.cpp:994 Source/msg.cpp:1029 Source/msg.cpp:1060
+#: Source/msg.cpp:1187 Source/msg.cpp:1219 Source/msg.cpp:1251
+#: Source/msg.cpp:1281
 msgid "{:s} has cast an illegal spell."
 msgstr "{:s} ha lanzado un hechizo ilegal."
 
-#: Source/msg.cpp:1655 Source/multi.cpp:805
+#: Source/msg.cpp:1668 Source/multi.cpp:804
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr "El jugador ' {:s}' (nivel {:d}) acaba de unirse al juego"
 
-#: Source/msg.cpp:1959
+#: Source/msg.cpp:1972
 msgid "Waiting for game data..."
 msgstr "Esperando datos del juego ..."
 
-#: Source/msg.cpp:1967
+#: Source/msg.cpp:1980
 msgid "The game ended"
 msgstr "El juego terminó"
 
-#: Source/msg.cpp:1973
+#: Source/msg.cpp:1986
 msgid "Unable to get level data"
 msgstr "No se pueden obtener datos del nivel"
 
@@ -5528,7 +5553,7 @@ msgstr "¡El jugador ' {:s}' mató a Diablo y abandonó el juego!"
 msgid "Player '{:s}' dropped due to timeout"
 msgstr "El jugador ' {:s}' desconectado debido al tiempo de espera"
 
-#: Source/multi.cpp:807
+#: Source/multi.cpp:806
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr "El jugador ' {:s}' (nivel {:d}) ya está en el juego"
 
@@ -5738,158 +5763,158 @@ msgstr "Diario: El Fin"
 msgid "A Spellbook"
 msgstr "Un libro de Hechizos"
 
-#: Source/objects.cpp:5347
+#: Source/objects.cpp:5339
 msgid "Crucified Skeleton"
 msgstr "Esqueleto Crucificado"
 
-#: Source/objects.cpp:5351
+#: Source/objects.cpp:5343
 msgid "Lever"
 msgstr "Palanca"
 
-#: Source/objects.cpp:5360
+#: Source/objects.cpp:5352
 msgid "Open Door"
 msgstr "Puerta Abierta"
 
-#: Source/objects.cpp:5362
+#: Source/objects.cpp:5354
 msgid "Closed Door"
 msgstr "Puerta Cerrada"
 
-#: Source/objects.cpp:5364
+#: Source/objects.cpp:5356
 msgid "Blocked Door"
 msgstr "Puerta Bloqueada"
 
-#: Source/objects.cpp:5369
+#: Source/objects.cpp:5361
 msgid "Ancient Tome"
 msgstr "Tomo Antiguo"
 
-#: Source/objects.cpp:5371
+#: Source/objects.cpp:5363
 msgid "Book of Vileness"
 msgstr "Libro de la Vileza"
 
-#: Source/objects.cpp:5376
+#: Source/objects.cpp:5368
 msgid "Skull Lever"
 msgstr "Palanca de Cráneo"
 
-#: Source/objects.cpp:5379
+#: Source/objects.cpp:5371
 msgid "Mythical Book"
 msgstr "Libro Mítico"
 
-#: Source/objects.cpp:5383
+#: Source/objects.cpp:5375
 msgid "Small Chest"
 msgstr "Cofre Pequeño"
 
-#: Source/objects.cpp:5387
+#: Source/objects.cpp:5379
 msgid "Chest"
 msgstr "Cofre"
 
-#: Source/objects.cpp:5392
+#: Source/objects.cpp:5384
 msgid "Large Chest"
 msgstr "Arcón"
 
-#: Source/objects.cpp:5395
+#: Source/objects.cpp:5387
 msgid "Sarcophagus"
 msgstr "Sarcófago"
 
-#: Source/objects.cpp:5398
+#: Source/objects.cpp:5390
 msgid "Bookshelf"
 msgstr "Estante para Libros"
 
-#: Source/objects.cpp:5402
+#: Source/objects.cpp:5394
 msgid "Bookcase"
 msgstr "Estantería"
 
-#: Source/objects.cpp:5407
+#: Source/objects.cpp:5399
 msgid "Pod"
 msgstr "Vaina"
 
-#: Source/objects.cpp:5409
+#: Source/objects.cpp:5401
 msgid "Urn"
 msgstr "Urna"
 
-#: Source/objects.cpp:5411
+#: Source/objects.cpp:5403
 msgid "Barrel"
 msgstr "Barril"
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:5415
+#: Source/objects.cpp:5407
 msgid "{:s} Shrine"
 msgstr "Santuario {:s}"
 
-#: Source/objects.cpp:5419
+#: Source/objects.cpp:5411
 msgid "Skeleton Tome"
 msgstr "Tomo de Esqueleto"
 
-#: Source/objects.cpp:5422
+#: Source/objects.cpp:5414
 msgid "Library Book"
 msgstr "Libro de la Biblioteca"
 
-#: Source/objects.cpp:5425
+#: Source/objects.cpp:5417
 msgid "Blood Fountain"
 msgstr "Fuente de Sangre"
 
-#: Source/objects.cpp:5428
+#: Source/objects.cpp:5420
 msgid "Decapitated Body"
 msgstr "Cuerpo Decapitado"
 
-#: Source/objects.cpp:5431
+#: Source/objects.cpp:5423
 msgid "Book of the Blind"
 msgstr "Libro de los Ciegos"
 
-#: Source/objects.cpp:5434
+#: Source/objects.cpp:5426
 msgid "Book of Blood"
 msgstr "Libro de Sangre"
 
-#: Source/objects.cpp:5437
+#: Source/objects.cpp:5429
 msgid "Purifying Spring"
 msgstr "Manantial Purificante"
 
-#: Source/objects.cpp:5444 Source/objects.cpp:5468
+#: Source/objects.cpp:5436 Source/objects.cpp:5460
 msgid "Weapon Rack"
 msgstr "Estante de Armas"
 
-#: Source/objects.cpp:5447
+#: Source/objects.cpp:5439
 msgid "Goat Shrine"
 msgstr "Santuario de las Cabras"
 
-#: Source/objects.cpp:5450
+#: Source/objects.cpp:5442
 msgid "Cauldron"
 msgstr "Caldero"
 
-#: Source/objects.cpp:5453
+#: Source/objects.cpp:5445
 msgid "Murky Pool"
 msgstr "Piscina Turbia"
 
-#: Source/objects.cpp:5456
+#: Source/objects.cpp:5448
 msgid "Fountain of Tears"
 msgstr "Fuente de las Lágrimas"
 
-#: Source/objects.cpp:5459
+#: Source/objects.cpp:5451
 msgid "Steel Tome"
 msgstr "Tomo de Acero"
 
-#: Source/objects.cpp:5462
+#: Source/objects.cpp:5454
 msgid "Pedestal of Blood"
 msgstr "Pedestal de Sangre"
 
-#: Source/objects.cpp:5471
+#: Source/objects.cpp:5463
 msgid "Mushroom Patch"
 msgstr "Parche de Hongos"
 
-#: Source/objects.cpp:5474
+#: Source/objects.cpp:5466
 msgid "Vile Stand"
 msgstr "Vil Estante"
 
-#: Source/objects.cpp:5477
+#: Source/objects.cpp:5469
 msgid "Slain Hero"
 msgstr "Héroe Asesinado"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:5484
+#: Source/objects.cpp:5476
 msgid "Trapped {:s}"
 msgstr "{:s} Atrapado"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
-#: Source/objects.cpp:5490
+#: Source/objects.cpp:5482
 msgid "{:s} (disabled)"
 msgstr "{:s} (deshabilitado)"
 
@@ -6007,23 +6032,23 @@ msgstr "hechizos"
 msgid "mute"
 msgstr "silenciar"
 
-#: Source/pfile.cpp:260
+#: Source/pfile.cpp:242
 msgid "Failed to open player archive for writing."
 msgstr "No se pudo abrir el archivo del reproductor para escribir."
 
-#: Source/pfile.cpp:392
+#: Source/pfile.cpp:377
 msgid "Unable to open archive"
 msgstr "No se puede abrir el archivo"
 
-#: Source/pfile.cpp:394
+#: Source/pfile.cpp:379
 msgid "Unable to load character"
 msgstr "No se puede cargar el personaje"
 
-#: Source/pfile.cpp:419 Source/pfile.cpp:439
+#: Source/pfile.cpp:403 Source/pfile.cpp:423
 msgid "Unable to read to save file archive"
 msgstr "No se puede leer para guardar el archivo de archivo"
 
-#: Source/pfile.cpp:458
+#: Source/pfile.cpp:442
 msgid "Unable to write to save file archive"
 msgstr "No se puede escribir para guardar el archivo"
 
@@ -6042,7 +6067,7 @@ msgstr ",%03d"
 msgid "%i gold"
 msgstr "%i oro"
 
-#: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:56
+#: Source/qol/monhealthbar.cpp:37 Source/qol/xpbar.cpp:56
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
@@ -6480,7 +6505,7 @@ msgstr "Farnham"
 msgid "Adria"
 msgstr "Adria"
 
-#: Source/stores.cpp:98 Source/stores.cpp:1252
+#: Source/stores.cpp:98 Source/stores.cpp:1305
 msgid "Gillian"
 msgstr "Gillian"
 
@@ -6488,298 +6513,293 @@ msgstr "Gillian"
 msgid "Wirt"
 msgstr "Wirt"
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr "Atrás"
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ",  "
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 msgid "Damage: {:d}-{:d}  "
 msgstr "Daño: {:d}-{:d} "
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 msgid "Armor: {:d}  "
 msgstr "Armadura:{:d} "
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 msgid "Dur: {:d}/{:d},  "
 msgstr "Dur:  {:d}/ {:d}, "
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr "Indestructible, "
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr "No requiere atributos"
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr "Bienvenido a la"
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr "Tienda de Herrería"
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr "Le gustaría:"
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 msgid "Talk to Griswold"
 msgstr "Hablar con Griswold"
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 msgid "Buy basic items"
 msgstr "Comprar artículos básicos"
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 msgid "Buy premium items"
 msgstr "Comprar artículos premium"
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 msgid "Sell items"
 msgstr "Vender artículos"
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 msgid "Repair items"
 msgstr "Reparar artículos"
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 msgid "Leave the shop"
 msgstr "Salir de la tienda"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "Tengo estos artículos a la venta:             Tu oro: {:d}"
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr "Atrás"
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "Tengo estos artículos premium a la venta:     Tu oro: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "No tienes nada que yo quiera.             Tu oro: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "¿Qué artículo está a la venta?             Tu oro: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "No tienes nada que reparar.             Tu oro: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "¿Reparar qué artículo?             Tu oro: {:d}"
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr "Choza de la Bruja"
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 msgid "Talk to Adria"
 msgstr "Hablar con Adria"
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr "Comprar artículos"
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr "Varas de Recarga"
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 msgid "Leave the shack"
 msgstr "Deja la choza"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "No tienes nada que recargar.             Tu oro: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "¿Recargar qué artículo?             Tu oro: {:d}"
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr "No tiene suficiente oro"
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr "No tienes suficiente espacio en el inventario"
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr "¿Tenemos un trato?"
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 msgid "Are you sure you want to identify this item?"
 msgstr "¿Estás seguro de que quieres identificar este artículo?"
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 msgid "Are you sure you want to buy this item?"
 msgstr "¿Estás seguro de que quieres comprar este artículo?"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 msgid "Are you sure you want to recharge this item?"
 msgstr "¿Estás seguro de que deseas recargar este artículo?"
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 msgid "Are you sure you want to sell this item?"
 msgstr "¿Estás seguro de que quieres vender este artículo?"
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 msgid "Are you sure you want to repair this item?"
 msgstr "¿Está seguro de que desea reparar este artículo?"
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr "Wirt el chico de la Pata de Palo"
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 msgid "Talk to Wirt"
 msgstr "Hablar con Wirt"
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr "Tengo algo en venta,"
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr "pero costará 50 de oro"
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr "solo para echar un vistazo. "
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr "¿Qué tienes?"
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr "Decir adiós"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "Tengo este artículo a la venta:             Tu oro: {:d}"
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 msgid "Leave"
 msgstr "Dejar"
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr "La casa del Sanador"
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr "Hablar con Pepin"
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr "Dejar la casa del Sanador"
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 msgid "The Town Elder"
 msgstr "El Anciano del Pueblo"
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 msgid "Talk to Cain"
 msgstr "Hablar con Cain"
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr "Identificar un artículo"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "No tienes nada que identificar.             Tu oro: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "¿Identificac cúal artículo?             Tu oro: {:d}"
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr "Este artículo es:"
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr "Hecho"
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 msgid "Talk to {:s}"
 msgstr "Habla con {:s}"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 msgid "Talking to {:s}"
 msgstr "Hablando con {:s}"
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 msgid "is not available"
 msgstr "no está disponible"
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 msgid "in the shareware"
 msgstr "en el shareware"
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 msgid "version"
 msgstr "versión"
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr "Chisme"
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr "Sol Naciente"
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 msgid "Talk to Ogden"
 msgstr "Hablar con Ogden"
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 msgid "Leave the tavern"
 msgstr "Dejar la taberna"
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 msgid "Talk to Gillian"
 msgstr "Hablar con Gillian"
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr "Farnham el Borracho"
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 msgid "Talk to Farnham"
 msgstr "Hablar con Farnham"
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr "Decir Adiós"
 

--- a/Translations/fr.po
+++ b/Translations/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-10-11 00:06+0200\n"
+"POT-Creation-Date: 2021-11-21 05:44+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Mathieu Maret <mathieu.maret@gmail.com>\n"
 "Language-Team: \n"
@@ -310,15 +310,49 @@ msgstr "L'Anneau des Mille"
 msgid "\tNo souls were sold in the making of this game."
 msgstr "\tAucunes âmes n'ont été vendue durant le développement de ce jeu."
 
-#: Source/DiabloUI/dialogs.cpp:171 Source/DiabloUI/dialogs.cpp:183
-#: Source/DiabloUI/selconn.cpp:73 Source/DiabloUI/selgame.cpp:94
-#: Source/DiabloUI/selgame.cpp:164 Source/DiabloUI/selgame.cpp:182
-#: Source/DiabloUI/selgame.cpp:316 Source/DiabloUI/selgame.cpp:390
+#: Source/DiabloUI/dialogs.cpp:194 Source/DiabloUI/dialogs.cpp:206
+#: Source/DiabloUI/selconn.cpp:79 Source/DiabloUI/selgame.cpp:103
+#: Source/DiabloUI/selgame.cpp:193 Source/DiabloUI/selgame.cpp:211
+#: Source/DiabloUI/selgame.cpp:352 Source/DiabloUI/selgame.cpp:428
 #: Source/DiabloUI/selhero.cpp:186 Source/DiabloUI/selhero.cpp:211
 #: Source/DiabloUI/selhero.cpp:281 Source/DiabloUI/selhero.cpp:536
 #: Source/DiabloUI/selok.cpp:68
 msgid "OK"
 msgstr "OK"
+
+#: Source/DiabloUI/extrasmenu.cpp:41 Source/DiabloUI/selstart.cpp:44
+#, fuzzy
+#| msgid "Down to Diablo"
+msgid "Switch to Diablo"
+msgstr "Descendre vers Diablo"
+
+#: Source/DiabloUI/extrasmenu.cpp:41
+#, fuzzy
+#| msgid "Exit Hellfire"
+msgid "Switch to Hellfire"
+msgstr "Quitter Hellfire"
+
+#: Source/DiabloUI/extrasmenu.cpp:43
+msgid "Switch to Fullgame"
+msgstr ""
+
+#: Source/DiabloUI/extrasmenu.cpp:43
+#, fuzzy
+#| msgid "in the shareware"
+msgid "Switch to Shareware"
+msgstr "dans le shareware"
+
+#: Source/DiabloUI/extrasmenu.cpp:44
+msgid "Replay Intro"
+msgstr "Rejouer l'intro"
+
+#: Source/DiabloUI/extrasmenu.cpp:45
+msgid "Support"
+msgstr "Support"
+
+#: Source/DiabloUI/extrasmenu.cpp:46 Source/gamemenu.cpp:61
+msgid "Previous Menu"
+msgstr "Menu Précédent"
 
 #: Source/DiabloUI/mainmenu.cpp:36
 msgid "Single Player"
@@ -329,116 +363,123 @@ msgid "Multi Player"
 msgstr "Multijoueur"
 
 #: Source/DiabloUI/mainmenu.cpp:38
-msgid "Replay Intro"
-msgstr "Rejouer l'intro"
+#, fuzzy
+#| msgid "Extra charges"
+msgid "Extras"
+msgstr "Charges supplémentaires"
 
 #: Source/DiabloUI/mainmenu.cpp:39
-msgid "Support"
-msgstr "Support"
-
-#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Show Credits"
 msgstr "Afficher les crédits"
 
-#: Source/DiabloUI/mainmenu.cpp:41
+#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Exit Hellfire"
 msgstr "Quitter Hellfire"
 
-#: Source/DiabloUI/mainmenu.cpp:41
+#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Exit Diablo"
 msgstr "Quitter Diablo"
 
-#. TRANSLATORS:  Error Message when a Shareware User clicks on "Replay Intro" in the Main Menu
-#: Source/DiabloUI/mainmenu.cpp:99
-msgid ""
-"The Diablo introduction cinematic is only available in the full retail "
-"version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
-msgstr ""
-"La cinématique d'introduction de Diablo n'est disponible que dans la version "
-"commerciale complète de Diablo. Visitez https://www.gog.com/game/diablo pour "
-"l'acheter."
+#: Source/DiabloUI/mainmenu.cpp:55
+#, fuzzy
+#| msgid "in the shareware"
+msgid "Shareware"
+msgstr "dans le shareware"
 
-#: Source/DiabloUI/progress.cpp:36 Source/DiabloUI/selconn.cpp:76
+#: Source/DiabloUI/progress.cpp:36 Source/DiabloUI/selconn.cpp:82
 #: Source/DiabloUI/selhero.cpp:189 Source/DiabloUI/selhero.cpp:214
 #: Source/DiabloUI/selhero.cpp:284 Source/DiabloUI/selhero.cpp:544
 msgid "Cancel"
 msgstr "Annuler"
 
-#: Source/DiabloUI/selconn.cpp:38 Source/DiabloUI/selgame.cpp:77
-#: Source/DiabloUI/selgame.cpp:375
+#: Source/DiabloUI/selconn.cpp:13
 msgid "Client-Server (TCP)"
 msgstr "Client-Serveur (TCP)"
 
-#: Source/DiabloUI/selconn.cpp:41
+#: Source/DiabloUI/selconn.cpp:14
 msgid "Loopback"
 msgstr "Rebouclage (Loopback)"
 
-#: Source/DiabloUI/selconn.cpp:47 Source/DiabloUI/selgame.cpp:437
-#: Source/DiabloUI/selgame.cpp:455
+#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:489
+#: Source/DiabloUI/selgame.cpp:510
 msgid "Multi Player Game"
 msgstr "Partie Multijoueur"
 
-#: Source/DiabloUI/selconn.cpp:53
+#: Source/DiabloUI/selconn.cpp:59
 msgid "Requirements:"
 msgstr "Prérequis:"
 
-#: Source/DiabloUI/selconn.cpp:59
+#: Source/DiabloUI/selconn.cpp:65
 msgid "no gateway needed"
 msgstr "sans passerelle"
 
-#: Source/DiabloUI/selconn.cpp:65
+#: Source/DiabloUI/selconn.cpp:71
 msgid "Select Connection"
 msgstr "Sélection Connexion"
 
-#: Source/DiabloUI/selconn.cpp:68
+#: Source/DiabloUI/selconn.cpp:74
 msgid "Change Gateway"
 msgstr "Changer de Passerelle"
 
-#: Source/DiabloUI/selconn.cpp:101
+#: Source/DiabloUI/selconn.cpp:107
 msgid "All computers must be connected to a TCP-compatible network."
 msgstr ""
 "Tous les ordinateurs doivent être connectées à un réseau compatible TCP."
 
-#: Source/DiabloUI/selconn.cpp:105
+#: Source/DiabloUI/selconn.cpp:111
 msgid "All computers must be connected to the internet."
 msgstr "Toutes les ordinateurs doivent être connectées à internet."
 
-#: Source/DiabloUI/selconn.cpp:109
+#: Source/DiabloUI/selconn.cpp:115
 msgid "Play by yourself with no network exposure."
 msgstr "Jouez seul sans connexion à internet."
 
-#: Source/DiabloUI/selconn.cpp:114
+#: Source/DiabloUI/selconn.cpp:120
 msgid "Players Supported: {:d}"
 msgstr "Joueurs Max: {:d}"
 
-#: Source/DiabloUI/selgame.cpp:80 Source/DiabloUI/selgame.cpp:378
+#: Source/DiabloUI/selgame.cpp:82 Source/DiabloUI/selgame.cpp:414
 msgid "Description:"
 msgstr "Description:"
 
-#: Source/DiabloUI/selgame.cpp:86
+#: Source/DiabloUI/selgame.cpp:88
 msgid "Select Action"
 msgstr "Sélectionner l'Action"
 
-#: Source/DiabloUI/selgame.cpp:88 Source/DiabloUI/selgame.cpp:152
-#: Source/DiabloUI/selgame.cpp:297
+#: Source/DiabloUI/selgame.cpp:91 Source/DiabloUI/selgame.cpp:181
+#: Source/DiabloUI/selgame.cpp:333
 msgid "Create Game"
 msgstr "Créer une Partie"
 
-#: Source/DiabloUI/selgame.cpp:89
+#: Source/DiabloUI/selgame.cpp:93
+#, fuzzy
+#| msgid "Create Game"
+msgid "Create Public Game"
+msgstr "Créer une Partie"
+
+#: Source/DiabloUI/selgame.cpp:94
 msgid "Join Game"
 msgstr "Rejoindre une Partie"
 
-#: Source/DiabloUI/selgame.cpp:97 Source/DiabloUI/selgame.cpp:167
-#: Source/DiabloUI/selgame.cpp:185 Source/DiabloUI/selgame.cpp:319
-#: Source/DiabloUI/selgame.cpp:393
+#: Source/DiabloUI/selgame.cpp:106 Source/DiabloUI/selgame.cpp:196
+#: Source/DiabloUI/selgame.cpp:214 Source/DiabloUI/selgame.cpp:355
+#: Source/DiabloUI/selgame.cpp:431
 msgid "CANCEL"
 msgstr "ANNULER"
 
-#: Source/DiabloUI/selgame.cpp:106
+#: Source/DiabloUI/selgame.cpp:122
 msgid "Create a new game with a difficulty setting of your choice."
 msgstr "Créer une nouvelle partie avec le niveau de difficulté de votre choix."
 
-#: Source/DiabloUI/selgame.cpp:109
+#: Source/DiabloUI/selgame.cpp:125
+#, fuzzy
+#| msgid "Create a new game with a difficulty setting of your choice."
+msgid ""
+"Create a new public game that anyone can join with a difficulty setting of "
+"your choice."
+msgstr "Créer une nouvelle partie avec le niveau de difficulté de votre choix."
+
+#: Source/DiabloUI/selgame.cpp:128
 msgid ""
 "Enter an IP or a hostname and join a game already in progress at that "
 "address."
@@ -446,35 +487,45 @@ msgstr ""
 "Entrez une adresse IP ou un nom d'hôte et rejoignez une partie déjà en cours "
 "à cette adresse."
 
-#: Source/DiabloUI/selgame.cpp:155
+#: Source/DiabloUI/selgame.cpp:131
+#, fuzzy
+#| msgid ""
+#| "Enter an IP or a hostname and join a game already in progress at that "
+#| "address."
+msgid "Join the public game already in progress at this address."
+msgstr ""
+"Entrez une adresse IP ou un nom d'hôte et rejoignez une partie déjà en cours "
+"à cette adresse."
+
+#: Source/DiabloUI/selgame.cpp:184
 msgid "Select Difficulty"
 msgstr "Sélection Difficulté"
 
-#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:204
-#: Source/DiabloUI/selgame.cpp:308 Source/DiabloUI/selgame.cpp:328
-#: Source/diablo.cpp:1431
+#: Source/DiabloUI/selgame.cpp:186 Source/DiabloUI/selgame.cpp:239
+#: Source/DiabloUI/selgame.cpp:344 Source/DiabloUI/selgame.cpp:364
+#: Source/diablo.cpp:1446
 msgid "Normal"
 msgstr "Normale"
 
-#: Source/DiabloUI/selgame.cpp:158 Source/DiabloUI/selgame.cpp:208
-#: Source/diablo.cpp:1432
+#: Source/DiabloUI/selgame.cpp:187 Source/DiabloUI/selgame.cpp:243
+#: Source/diablo.cpp:1447
 msgid "Nightmare"
 msgstr "Cauchemar"
 
-#: Source/DiabloUI/selgame.cpp:159 Source/DiabloUI/selgame.cpp:212
-#: Source/diablo.cpp:1433
+#: Source/DiabloUI/selgame.cpp:188 Source/DiabloUI/selgame.cpp:247
+#: Source/diablo.cpp:1448
 msgid "Hell"
 msgstr "Enfer"
 
-#: Source/DiabloUI/selgame.cpp:173
+#: Source/DiabloUI/selgame.cpp:202
 msgid "Join TCP Games"
 msgstr "Rejoignez une Partie TCP"
 
-#: Source/DiabloUI/selgame.cpp:176 Source/DiabloUI/selgame.cpp:179
+#: Source/DiabloUI/selgame.cpp:205 Source/DiabloUI/selgame.cpp:208
 msgid "Enter address"
 msgstr "Entrez l'adresse"
 
-#: Source/DiabloUI/selgame.cpp:205
+#: Source/DiabloUI/selgame.cpp:240
 msgid ""
 "Normal Difficulty\n"
 "This is where a starting character should begin the quest to defeat Diablo."
@@ -483,7 +534,7 @@ msgstr ""
 "C'est là qu'un personnage débutant devrait commencer sa quête pour vaincre "
 "Diablo."
 
-#: Source/DiabloUI/selgame.cpp:209
+#: Source/DiabloUI/selgame.cpp:244
 msgid ""
 "Nightmare Difficulty\n"
 "The denizens of the Labyrinth have been bolstered and will prove to be a "
@@ -493,7 +544,7 @@ msgstr ""
 "Les habitants du Labyrinthe ont été renforcés et se révéleront être un plus "
 "grand défi. Ceci est recommandé uniquement pour les personnages expérimentés."
 
-#: Source/DiabloUI/selgame.cpp:213
+#: Source/DiabloUI/selgame.cpp:248
 msgid ""
 "Hell Difficulty\n"
 "The most powerful of the underworld's creatures lurk at the gateway into "
@@ -504,7 +555,7 @@ msgstr ""
 "l'enfer. Seuls les personnages les plus expérimentés devraient s'aventurer "
 "dans ce domaine."
 
-#: Source/DiabloUI/selgame.cpp:229
+#: Source/DiabloUI/selgame.cpp:264
 msgid ""
 "Your character must reach level 20 before you can enter a multiplayer game "
 "of Nightmare difficulty."
@@ -512,7 +563,7 @@ msgstr ""
 "Votre personnage doit atteindre le niveau 20 avant de pouvoir entrer dans "
 "une partie multijoueur en difficulté Cauchemar."
 
-#: Source/DiabloUI/selgame.cpp:231
+#: Source/DiabloUI/selgame.cpp:266
 msgid ""
 "Your character must reach level 30 before you can enter a multiplayer game "
 "of Hell difficulty."
@@ -520,23 +571,23 @@ msgstr ""
 "Votre personnage doit atteindre le niveau 30 avant de pouvoir entrer dans "
 "une partie multijoueur en difficulté Enfer."
 
-#: Source/DiabloUI/selgame.cpp:306
+#: Source/DiabloUI/selgame.cpp:342
 msgid "Select Game Speed"
 msgstr "Sélection Vitesse du Jeu"
 
-#: Source/DiabloUI/selgame.cpp:309 Source/DiabloUI/selgame.cpp:332
+#: Source/DiabloUI/selgame.cpp:345 Source/DiabloUI/selgame.cpp:368
 msgid "Fast"
 msgstr "Rapide"
 
-#: Source/DiabloUI/selgame.cpp:310 Source/DiabloUI/selgame.cpp:336
+#: Source/DiabloUI/selgame.cpp:346 Source/DiabloUI/selgame.cpp:372
 msgid "Faster"
 msgstr "Plus Rapide"
 
-#: Source/DiabloUI/selgame.cpp:311 Source/DiabloUI/selgame.cpp:340
+#: Source/DiabloUI/selgame.cpp:347 Source/DiabloUI/selgame.cpp:376
 msgid "Fastest"
 msgstr "Le Plus Rapide"
 
-#: Source/DiabloUI/selgame.cpp:329
+#: Source/DiabloUI/selgame.cpp:365
 msgid ""
 "Normal Speed\n"
 "This is where a starting character should begin the quest to defeat Diablo."
@@ -545,7 +596,7 @@ msgstr ""
 "C'est là que le personnage débutant devrait commencer sa quête pour vaincre "
 "Diablo."
 
-#: Source/DiabloUI/selgame.cpp:333
+#: Source/DiabloUI/selgame.cpp:369
 msgid ""
 "Fast Speed\n"
 "The denizens of the Labyrinth have been hastened and will prove to be a "
@@ -555,7 +606,7 @@ msgstr ""
 "Les habitants du Labyrinthe ont été accélérés et s'avéreront être un plus "
 "grand défi. Ceci est recommandé uniquement pour les personnages expérimentés."
 
-#: Source/DiabloUI/selgame.cpp:337
+#: Source/DiabloUI/selgame.cpp:373
 msgid ""
 "Faster Speed\n"
 "Most monsters of the dungeon will seek you out quicker than ever before. "
@@ -565,7 +616,7 @@ msgstr ""
 "La plupart des monstres du donjon vous chercheront plus vite que jamais. "
 "Seul un champion expérimenté devrait tenter sa chance à cette vitesse."
 
-#: Source/DiabloUI/selgame.cpp:341
+#: Source/DiabloUI/selgame.cpp:377
 msgid ""
 "Fastest Speed\n"
 "The minions of the underworld will rush to attack without hesitation. Only a "
@@ -575,16 +626,16 @@ msgstr ""
 "Les sbires de la pègre se précipiteront pour attaquer sans hésitation. Seul "
 "un vrai démon de vitesse devrait utiliser cette vitesse."
 
-#: Source/DiabloUI/selgame.cpp:384 Source/DiabloUI/selgame.cpp:387
+#: Source/DiabloUI/selgame.cpp:420 Source/DiabloUI/selgame.cpp:425
 msgid "Enter Password"
 msgstr "Entrez le Mot de Passe"
 
-#: Source/DiabloUI/selgame.cpp:410
+#: Source/DiabloUI/selgame.cpp:448
 msgid "The host is running a different game than you."
 msgstr "L'hôte utilise un jeu différente du vôtre."
 
 #. TRANSLATORS: Error message when somebody tries to join a game running another version.
-#: Source/DiabloUI/selgame.cpp:413
+#: Source/DiabloUI/selgame.cpp:451
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr "Votre version {:s} ne correspond pas à celle de l'hôte {:d}.{:d}.{:d}."
 
@@ -718,18 +769,24 @@ msgstr "Effacer un Personnage Solo"
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "Voulez vous vraiment supprimer le personnage \"{:s}\"?"
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selstart.cpp:43
+#, fuzzy
+#| msgid "Exit Hellfire"
+msgid "Enter Hellfire"
+msgstr "Quitter Hellfire"
+
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr "Oui"
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr "Non"
 
 #: Source/DiabloUI/support_lines.cpp:8
 msgid ""
-"We maintains a chat server at Discord.gg/YQKCAYQ Follow the links to join "
-"our community where we talk about things related to Diablo, and the Hellfire "
+"We maintain a chat server at Discord.gg/YQKCAYQ Follow the links to join our "
+"community where we talk about things related to Diablo, and the Hellfire "
 "expansion."
 msgstr ""
 
@@ -739,9 +796,10 @@ msgid ""
 "this address: https://github.com/diasurgical/devilutionX To help us better "
 "serve you, please be sure to include the version number, operating system, "
 "and the nature of the problem."
-msgstr "DevilutionX est développé par Diasurgical. Les problèmes peuvent être "
-"signalés à cette adresse: https://github.com/diasurgical/devilutionX "
-"Merci de bien vouloir inclure le numéro de version ainsi que le système, "
+msgstr ""
+"DevilutionX est développé par Diasurgical. Les problèmes peuvent être "
+"signalés à cette adresse: https://github.com/diasurgical/devilutionX Merci "
+"de bien vouloir inclure le numéro de version ainsi que le système, "
 "d'exploitation utilisé afin que nous puissions mieux vous aider."
 
 #: Source/DiabloUI/support_lines.cpp:13
@@ -756,11 +814,11 @@ msgid ""
 "DevilutionX should be directed to Diasurgical, not to Blizzard Entertainment "
 "or GOG.com."
 msgstr ""
-"\tDevilutionX n'est pas supporté ni maintenu par Blizzard Entertainment,"
-" ou GOG.com. Ni Blizzard Entertainment ni GOG.com n'ont testé"
-" ou certifié la qualité ou la compatibilité de DevilutionX. Toutes demandes"
-" concernant DevilutionX doivent être adressées à Diasurgical et non à"
-" Blizzard Entertainment ou GOG.com."
+"\tDevilutionX n'est pas supporté ni maintenu par Blizzard Entertainment, ou "
+"GOG.com. Ni Blizzard Entertainment ni GOG.com n'ont testé ou certifié la "
+"qualité ou la compatibilité de DevilutionX. Toutes demandes concernant "
+"DevilutionX doivent être adressées à Diasurgical et non à Blizzard "
+"Entertainment ou GOG.com."
 
 #: Source/DiabloUI/support_lines.cpp:17
 msgid ""
@@ -774,12 +832,12 @@ msgstr ""
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr "Droits d'auteur © 1996-2001 Blizzard Entertainment"
 
-#: Source/appfat.cpp:37
+#: Source/appfat.cpp:38
 msgid "Error"
 msgstr "Erreur"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:101
+#: Source/appfat.cpp:102
 msgid ""
 "{:s}\n"
 "\n"
@@ -789,7 +847,7 @@ msgstr ""
 "\n"
 "Erreur dans : {:s} ligne {:d}"
 
-#: Source/appfat.cpp:115
+#: Source/appfat.cpp:117
 msgid ""
 "Unable to open main data archive ({:s}).\n"
 "\n"
@@ -799,15 +857,12 @@ msgstr ""
 "\n"
 "Assurez-vous qu'il se trouve dans le dossier du jeu."
 
-msgid "diabdat.mpq or spawn.mpq"
-msgstr "diabdat.mpq ou spawn.mpq"
-
-#: Source/appfat.cpp:119
+#: Source/appfat.cpp:123
 msgid "Data File Error"
 msgstr "Erreur de fichier de données"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:127
+#: Source/appfat.cpp:131
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -815,197 +870,203 @@ msgstr ""
 "Impossible d'écrire dans l'emplacement:\n"
 "{:s}"
 
-#: Source/appfat.cpp:129
+#: Source/appfat.cpp:133
 msgid "Read-Only Directory Error"
 msgstr "Erreur de répertoire en lecture seule"
 
-#: Source/automap.cpp:464
+#: Source/automap.cpp:484
 msgid "game: "
 msgstr "partie: "
 
-#: Source/automap.cpp:470
+#: Source/automap.cpp:490
 msgid "password: "
 msgstr "mot de passe: "
 
-#: Source/automap.cpp:483
+#: Source/automap.cpp:492
+#, fuzzy
+#| msgid "Quit Game"
+msgid "Public Game"
+msgstr "Quitter"
+
+#: Source/automap.cpp:504
 msgid "Level: Nest {:d}"
 msgstr "Niveau: Nid {:d}"
 
-#: Source/automap.cpp:485
+#: Source/automap.cpp:506
 msgid "Level: Crypt {:d}"
 msgstr "Niveau: Crypte {:d}"
 
-#: Source/automap.cpp:487 Source/items.cpp:2078
+#: Source/automap.cpp:508 Source/items.cpp:2090
 msgid "Level: {:d}"
 msgstr "Niveau: {:d}"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr "Tab"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr "ESC"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Enter"
 msgstr "Entrez"
 
-#: Source/control.cpp:202
+#: Source/control.cpp:215
 msgid "Character Information"
 msgstr "Profil du Personnage"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr "Journal des quêtes"
 
-#: Source/control.cpp:204
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr "Carte"
 
-#: Source/control.cpp:205
+#: Source/control.cpp:218
 msgid "Main Menu"
 msgstr "Menu Principal"
 
-#: Source/control.cpp:206
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr "Inventaire"
 
-#: Source/control.cpp:207
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr "Livre des sorts"
 
-#: Source/control.cpp:208
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr "Envoyer un Message"
 
-#: Source/control.cpp:750 Source/control.cpp:1558
+#: Source/control.cpp:718 Source/control.cpp:1587
 msgid "Skill"
 msgstr "Compétence"
 
-#: Source/control.cpp:751 Source/control.cpp:1212
+#: Source/control.cpp:719 Source/control.cpp:1237
 msgid "{:s} Skill"
 msgstr "{:s} Compétence"
 
-#: Source/control.cpp:757
+#: Source/control.cpp:725
 msgid "Spell"
 msgstr "Sort"
 
-#: Source/control.cpp:758 Source/control.cpp:1216
+#: Source/control.cpp:726 Source/control.cpp:1241
 msgid "{:s} Spell"
 msgstr "{:s} Sort"
 
-#: Source/control.cpp:760
+#: Source/control.cpp:728
 msgid "Damages undead only"
 msgstr "Dommages aux morts-vivants uniquement"
 
-#: Source/control.cpp:764 Source/control.cpp:1220 Source/control.cpp:1582
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr "Sort Niveau 0 - Inutilisable"
 
-#: Source/control.cpp:766 Source/control.cpp:1222 Source/control.cpp:1584
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 msgid "Spell Level {:d}"
 msgstr "Sort Niveau {:d}"
 
-#: Source/control.cpp:773
+#: Source/control.cpp:741
 msgid "Scroll"
 msgstr "Parchemin"
 
-#: Source/control.cpp:774 Source/control.cpp:1226
+#: Source/control.cpp:742 Source/control.cpp:1251
 msgid "Scroll of {:s}"
 msgstr "Parchemin de {:s}"
 
-#: Source/control.cpp:779 Source/control.cpp:1232
+#: Source/control.cpp:747 Source/control.cpp:1257
 #, fuzzy
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "Parchemin de {:s}"
 msgstr[1] "Parchemins de {:s}"
 
-#: Source/control.cpp:786 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
 #: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
 msgid "Staff"
 msgstr "Bâton"
 
-#: Source/control.cpp:787 Source/control.cpp:1236 Source/items.cpp:1319
+#: Source/control.cpp:755 Source/control.cpp:1261
 msgid "Staff of {:s}"
 msgstr "Baton de {:s}"
 
-#: Source/control.cpp:789 Source/control.cpp:1238
+#: Source/control.cpp:757 Source/control.cpp:1263
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "{:d} Charge"
 msgstr[1] "{:d} Charges"
 
-#: Source/control.cpp:799
+#: Source/control.cpp:767
 msgid "Spell Hotkey {:s}"
 msgstr "Raccourci Sort: {:s}"
 
-#: Source/control.cpp:1189
+#: Source/control.cpp:1214
 msgid "Player friendly"
 msgstr "Joueur Amical"
 
-#: Source/control.cpp:1191
+#: Source/control.cpp:1216
 msgid "Player attack"
 msgstr "Joueur hostile"
 
-#: Source/control.cpp:1194
+#: Source/control.cpp:1219
 msgid "Hotkey: {:s}"
 msgstr "Touche: {:s}"
 
-#: Source/control.cpp:1202
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr "Sélection du sort courant"
 
-#: Source/control.cpp:1205
+#: Source/control.cpp:1230
 msgid "Hotkey: 's'"
 msgstr "Touche: 's'"
 
-#: Source/control.cpp:1360 Source/inv.cpp:1891 Source/items.cpp:3744
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "{:d} pièce d'or"
 msgstr[1] "{:d} pièces d'or"
 
-#: Source/control.cpp:1363
+#: Source/control.cpp:1390
 msgid "Requirements not met"
 msgstr "Requis insuffisant"
 
-#: Source/control.cpp:1399
+#: Source/control.cpp:1426
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Niveau: {:d}"
 
-#: Source/control.cpp:1401
+#: Source/control.cpp:1428
 msgid "Hit Points {:d} of {:d}"
 msgstr "Dommages {:d} sur {:d}"
 
-#: Source/control.cpp:1428
+#: Source/control.cpp:1457
 msgid "Level Up"
 msgstr "Niveau Supérieur"
 
-#: Source/control.cpp:1562
+#: Source/control.cpp:1591
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] "Bâton ({:d} charge)"
 msgstr[1] "Bâton ({:d} charges)"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1572
+#: Source/control.cpp:1601
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "Mana: {:d}  Dom: {:d} - {:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1574
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "Mana: {:d}   Dom: n/a"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1577
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "Mana: {:d}  Dom: 1/3 tgt hp"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1635
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] "Vous avez {:d} pièce d'or. Combien voulez-vous en supprimer ?"
@@ -1055,95 +1116,114 @@ msgstr "L'Autel impie"
 msgid "level 15"
 msgstr "level 15"
 
-#: Source/diablo.cpp:112
+#: Source/diablo.cpp:114
 msgid "I need help! Come Here!"
 msgstr "J'ai besoin d'aide! Venez ici!"
 
-#: Source/diablo.cpp:113
+#: Source/diablo.cpp:115
 msgid "Follow me."
 msgstr "Suivez-moi."
 
-#: Source/diablo.cpp:114
+#: Source/diablo.cpp:116
 msgid "Here's something for you."
 msgstr "Voici quelque chose pour vous."
 
-#: Source/diablo.cpp:115
+#: Source/diablo.cpp:117
 msgid "Now you DIE!"
 msgstr "Maintenant tu meurs!"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:779
+#: Source/diablo.cpp:781
 msgid "Options:\n"
 msgstr "Maintenant tu meurs!\n"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:780
+#: Source/diablo.cpp:782
 msgid "Print this message and exit"
 msgstr "Affiche ce message et quitte"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:781
+#: Source/diablo.cpp:783
 msgid "Print the version and exit"
 msgstr "Affiche le numéro de version et quitte"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:782
+#: Source/diablo.cpp:784
 msgid "Specify the folder of diabdat.mpq"
 msgstr "Spécifie le dossier de diabdat.mpq"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:783
+#: Source/diablo.cpp:785
 msgid "Specify the folder of save files"
 msgstr "Spécifie le dossier des sauvegardes"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:784
+#: Source/diablo.cpp:786
 msgid "Specify the location of diablo.ini"
 msgstr "Spécifie l'emplacement de diablo.ini"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:785
+#: Source/diablo.cpp:787
 msgid "Skip startup videos"
 msgstr "Passe les vidéos d'intro"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:786
+#: Source/diablo.cpp:788
 msgid "Display frames per second"
 msgstr "Affiche le nombre de frame par seconde"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:787
+#: Source/diablo.cpp:789
 msgid "Run in windowed mode"
 msgstr "Mode fenêtré"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:788
+#: Source/diablo.cpp:790
 msgid "Enable verbose logging"
 msgstr "Active les logs détaillés"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:789
-msgid "Force spawn mode even if diabdat.mpq is found"
-msgstr "Force le mode spawn même si diabdat.mpq est trouvé"
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:790
+#: Source/diablo.cpp:791
 msgid "Record a demo file"
 msgstr "Enregistrer une démo"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:791
+#: Source/diablo.cpp:792
 msgid "Play a demo file"
 msgstr "Jouer une démo"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:792
+#: Source/diablo.cpp:793
 msgid "Disable all frame limiting during demo playback"
 msgstr ""
 "Désactiver toutes les limitations d'images pendant la lecture de la démo"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:793
+#: Source/diablo.cpp:794
+msgid ""
+"\n"
+"Game selection:\n"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:795
+msgid "Force Shareware mode"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:796
+msgid "Force Diablo mode"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:797
+#, fuzzy
+#| msgid "Hellfire Help"
+msgid "Force Hellfire mode"
+msgstr "Aide Hellfire"
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:798
 msgid ""
 "\n"
 "Hellfire options:\n"
@@ -1152,16 +1232,11 @@ msgstr ""
 "options Hellfire:\n"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:794
-msgid "Force diablo mode even if hellfire.mpq is found"
-msgstr "Force le mode diablo même si hellfire.mpq est trouvé"
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:795
+#: Source/diablo.cpp:799
 msgid "Use alternate nest palette"
 msgstr "Utilise une autre palette"
 
-#: Source/diablo.cpp:801
+#: Source/diablo.cpp:805
 msgid ""
 "\n"
 "Report bugs at https://github.com/diasurgical/devilutionX/\n"
@@ -1169,44 +1244,44 @@ msgstr ""
 "\n"
 "Signalez les bogues sur https://github.com/diasurgical/devilutionX/\n"
 
-#: Source/diablo.cpp:865
+#: Source/diablo.cpp:869
 msgid "unrecognized option '{:s}'\n"
 msgstr "option '{:s}' inconnue \n"
 
-#: Source/diablo.cpp:896
+#: Source/diablo.cpp:900
 msgid "version {:s}"
 msgstr "version {:s}"
 
-#: Source/diablo.cpp:1203
+#: Source/diablo.cpp:1218
 msgid "-- Network timeout --"
 msgstr "-- timeout réseau--"
 
-#: Source/diablo.cpp:1204
+#: Source/diablo.cpp:1219
 msgid "-- Waiting for players --"
 msgstr "-- En attente de joueurs --"
 
-#: Source/diablo.cpp:1223
+#: Source/diablo.cpp:1238
 msgid "No help available"
 msgstr "Pas d'aide disponible"
 
-#: Source/diablo.cpp:1224
+#: Source/diablo.cpp:1239
 msgid "while in stores"
 msgstr "dans les magasins"
 
 #. TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty.
-#: Source/diablo.cpp:1436
+#: Source/diablo.cpp:1451
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr "{:s},version = {:s}, mode = {:s}"
 
-#: Source/dvlnet/loopback.cpp:111
+#: Source/dvlnet/loopback.cpp:113
 msgid "loopback"
 msgstr "rebouclage (loopback)"
 
-#: Source/dvlnet/tcp_client.cpp:68
+#: Source/dvlnet/tcp_client.cpp:65
 msgid "Unable to connect"
 msgstr "Impossible de se connecter"
 
-#: Source/dvlnet/tcp_client.cpp:89
+#: Source/dvlnet/tcp_client.cpp:86
 msgid "error: read 0 bytes from server"
 msgstr "erreur: 0 bytes lu du serveur"
 
@@ -1490,10 +1565,6 @@ msgstr "Gamma"
 msgid "Speed"
 msgstr "Speed"
 
-#: Source/gamemenu.cpp:61
-msgid "Previous Menu"
-msgstr "Menu Précédent"
-
 #: Source/gamemenu.cpp:68
 msgid "Music Disabled"
 msgstr "Musique Désactivé"
@@ -1674,7 +1745,9 @@ msgstr ""
 "l'objet."
 
 #: Source/help.cpp:68
-msgid "$Gold"
+#, fuzzy
+#| msgid "$Gold"
+msgid "$Gold:"
 msgstr "$Or"
 
 #: Source/help.cpp:69
@@ -1704,7 +1777,9 @@ msgstr ""
 "être lancé par un simple clic droit dans la zone de jeu."
 
 #: Source/help.cpp:79
-msgid "$Using the Speedbook for Spells"
+#, fuzzy
+#| msgid "$Using the Speedbook for Spells"
+msgid "$Using the Speedbook for Spells:"
 msgstr "$Utiliser le Speedbook pour les sorts"
 
 #: Source/help.cpp:80
@@ -1719,15 +1794,21 @@ msgstr ""
 "simplement un clic droit dans la zone de jeu principale."
 
 #: Source/help.cpp:84
+#, fuzzy
+#| msgid ""
+#| "Shift + Left-clicking on the 'select current spell' button will clear the "
+#| "readied spell"
 msgid ""
 "Shift + Left-clicking on the 'select current spell' button will clear the "
-"readied spell"
+"readied spell."
 msgstr ""
 "Maj + clic gauche sur le bouton 'sélectionner le sort actuel' effacera le "
 "sort préparé"
 
 #: Source/help.cpp:86
-msgid "$Setting Spell Hotkeys"
+#, fuzzy
+#| msgid "$Setting Spell Hotkeys"
+msgid "$Setting Spell Hotkeys:"
 msgstr "$ Configurer le raccourci pour un sort"
 
 #: Source/help.cpp:87
@@ -1743,7 +1824,9 @@ msgstr ""
 "attribuer."
 
 #: Source/help.cpp:92
-msgid "$Spell Books"
+#, fuzzy
+#| msgid "$Spell Books"
+msgid "$Spell Books:"
 msgstr "$Livres de sort"
 
 #: Source/help.cpp:93
@@ -1754,31 +1837,35 @@ msgstr ""
 "Lire plus d'un livre augmente votre connaissance de ce sort, vous permettant "
 "de lancer le sort plus efficacement."
 
-#: Source/help.cpp:129
+#: Source/help.cpp:181
 msgid "Shareware Hellfire Help"
 msgstr "Aide Hellfire Shareware"
 
-#: Source/help.cpp:129
+#: Source/help.cpp:181
 msgid "Hellfire Help"
 msgstr "Aide Hellfire"
 
-#: Source/help.cpp:131
+#: Source/help.cpp:183
 msgid "Shareware Diablo Help"
 msgstr "Aide Diablo Shareware"
 
-#: Source/help.cpp:131
+#: Source/help.cpp:183
 msgid "Diablo Help"
 msgstr "Aide Diablo"
 
-#: Source/help.cpp:155
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr "Appuyez sur ESC pour terminer ou sur les flèches pour faire défiler."
 
-#: Source/init.cpp:217
+#: Source/init.cpp:175
+msgid "diabdat.mpq or spawn.mpq"
+msgstr "diabdat.mpq ou spawn.mpq"
+
+#: Source/init.cpp:196
 msgid "Some Hellfire MPQs are missing"
 msgstr "Certain MPQs Hellfire sont manquants"
 
-#: Source/init.cpp:217
+#: Source/init.cpp:196
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
@@ -1786,11 +1873,11 @@ msgstr ""
 "Tous les MPQ Hellfire n'ont pas été trouvés.\n"
 "Veuillez copier tous les fichiers hf*.mpq."
 
-#: Source/init.cpp:227
+#: Source/init.cpp:204
 msgid "Unable to create main window"
 msgstr "Impossible de créer la fenêtre principale"
 
-#: Source/itemdat.cpp:16 Source/itemdat.cpp:198 Source/panels/charpanel.cpp:154
+#: Source/itemdat.cpp:16 Source/itemdat.cpp:198 Source/panels/charpanel.cpp:155
 msgid "Gold"
 msgstr "Or"
 
@@ -1930,7 +2017,7 @@ msgstr "Bâton de Lazarus"
 msgid "Scroll of Resurrect"
 msgstr "Parchemin de Resurection"
 
-#: Source/itemdat.cpp:51 Source/itemdat.cpp:99 Source/items.cpp:165
+#: Source/itemdat.cpp:51 Source/itemdat.cpp:99 Source/items.cpp:166
 msgid "Blacksmith Oil"
 msgstr "Huile de forgeron"
 
@@ -2030,7 +2117,7 @@ msgid "Quilted Armor"
 msgstr "Armure Matelassée"
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
-#: Source/itemdat.cpp:77 Source/objects.cpp:5459
+#: Source/itemdat.cpp:77 Source/objects.cpp:5433
 msgid "Armor"
 msgstr "Armure"
 
@@ -2125,11 +2212,11 @@ msgstr "Potion de Rajeunissement"
 msgid "Potion of Full Rejuvenation"
 msgstr "Potion de Rajeunissement Total"
 
-#: Source/itemdat.cpp:100 Source/items.cpp:160
+#: Source/itemdat.cpp:100 Source/items.cpp:161
 msgid "Oil of Accuracy"
 msgstr "Huile de Précision"
 
-#: Source/itemdat.cpp:101 Source/items.cpp:162
+#: Source/itemdat.cpp:101 Source/items.cpp:163
 msgid "Oil of Sharpness"
 msgstr "Huilde d'Affutage"
 
@@ -2447,7 +2534,7 @@ msgstr "Mithril"
 msgid "Meteoric"
 msgstr "Météorique"
 
-#: Source/itemdat.cpp:202 Source/objects.cpp:104
+#: Source/itemdat.cpp:202 Source/objects.cpp:107
 msgid "Weird"
 msgstr "Bizarre"
 
@@ -2583,7 +2670,7 @@ msgstr "Saint"
 msgid "Awesome"
 msgstr "Impressionnant"
 
-#: Source/itemdat.cpp:237 Source/objects.cpp:116
+#: Source/itemdat.cpp:237 Source/objects.cpp:119
 msgid "Holy"
 msgstr "Sacré"
 
@@ -3544,689 +3631,712 @@ msgstr "Amulette d'Acolyte"
 msgid "Gladiator's Ring"
 msgstr "Anneau de Gladiateur"
 
-#: Source/items.cpp:161
+#: Source/items.cpp:162
 msgid "Oil of Mastery"
 msgstr "Huile de Maîtrise"
 
-#: Source/items.cpp:163
+#: Source/items.cpp:164
 msgid "Oil of Death"
 msgstr "Huile de Mort"
 
-#: Source/items.cpp:164
+#: Source/items.cpp:165
 msgid "Oil of Skill"
 msgstr "Huile de Compétence"
 
-#: Source/items.cpp:166
+#: Source/items.cpp:167
 msgid "Oil of Fortitude"
 msgstr "Huile de Courage"
 
-#: Source/items.cpp:167
+#: Source/items.cpp:168
 msgid "Oil of Permanence"
 msgstr "Huile de Durabilité"
 
-#: Source/items.cpp:168
+#: Source/items.cpp:169
 msgid "Oil of Hardening"
 msgstr "Huile de Durcissement"
 
-#: Source/items.cpp:169
+#: Source/items.cpp:170
 msgid "Oil of Imperviousness"
 msgstr "Huile d'Imperméabilité"
 
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#: Source/items.cpp:1174 Source/items.cpp:1184 Source/items.cpp:1233
-#: Source/items.cpp:1269
-msgid "{0} {1}"
-msgstr ""
-
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's Staff of Firewall
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Long Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1187 Source/items.cpp:1254 Source/items.cpp:1273
-#: Source/items.cpp:1315
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
+#, fuzzy
+#| msgid "{0} of {1}"
+msgctxt "spell"
 msgid "{0} of {1}"
 msgstr "{:s} de {:s}"
 
-#: Source/items.cpp:1894 Source/items.cpp:1906
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+#, fuzzy
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} de {:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+#, fuzzy
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} de {:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
+#: Source/items.cpp:1217
+msgid "{0} {1}"
+msgstr ""
+
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
+msgid "{0} of {1}"
+msgstr "{:s} de {:s}"
+
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr "augmente les"
 
-#: Source/items.cpp:1896
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr "chance de toucher"
 
-#: Source/items.cpp:1900
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr "augmente beaucoup"
 
-#: Source/items.cpp:1902
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr "les chances de toucher d'une arme"
 
-#: Source/items.cpp:1908
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr "dommage potentiel"
 
-#: Source/items.cpp:1912
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr "augmente beaucoup les"
 
-#: Source/items.cpp:1914
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr "dommage potentiel - pas les arcs"
 
-#: Source/items.cpp:1918
+#: Source/items.cpp:1930
 msgid "reduces attributes needed"
 msgstr "attributs nécessaire réduits"
 
-#: Source/items.cpp:1920
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr "pour utiliser des armes ou armures"
 
-#: Source/items.cpp:1924
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr "restaure 20% de"
 
-#: Source/items.cpp:1926
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr "la durabilité de l'objet"
 
-#: Source/items.cpp:1930
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr "augmente d'un objet"
 
-#: Source/items.cpp:1932
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr "durabilité courante et maximale"
 
-#: Source/items.cpp:1936
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr "rend un objet indestructible"
 
-#: Source/items.cpp:1940
+#: Source/items.cpp:1952
 msgid "increases the armor class"
 msgstr "augmente la classe d'une armure"
 
-#: Source/items.cpp:1942
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr "d'armure et de bouclier"
 
-#: Source/items.cpp:1946
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr "augmente beaucoup l'armure"
 
-#: Source/items.cpp:1948
+#: Source/items.cpp:1960
 msgid "class of armor and shields"
 msgstr "classe d'armure et de bouclier"
 
-#: Source/items.cpp:1952 Source/items.cpp:1961
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr "pose un piège à feu"
 
-#: Source/items.cpp:1957
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr "pose un piège à foudre"
 
-#: Source/items.cpp:1965
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr "pose un piège de pétrification"
 
-#: Source/items.cpp:1969
+#: Source/items.cpp:1981
 msgid "restore all life"
 msgstr "restaure toute la vie"
 
-#: Source/items.cpp:1973
+#: Source/items.cpp:1985
 msgid "restore some life"
 msgstr "restaure de la vie"
 
-#: Source/items.cpp:1977
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr "récupère de la vie"
 
-#: Source/items.cpp:1981
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr "guérison mortelle"
 
-#: Source/items.cpp:1985
+#: Source/items.cpp:1997
 msgid "restore some mana"
 msgstr "restaurer un peu de mana"
 
-#: Source/items.cpp:1989
+#: Source/items.cpp:2001
 msgid "restore all mana"
 msgstr "restaure tout le mana"
 
-#: Source/items.cpp:1993
+#: Source/items.cpp:2005
 msgid "increase strength"
 msgstr "augmente la force"
 
-#: Source/items.cpp:1997
+#: Source/items.cpp:2009
 msgid "increase magic"
 msgstr "augmente la magie"
 
-#: Source/items.cpp:2001
+#: Source/items.cpp:2013
 msgid "increase dexterity"
 msgstr "augmente la dextérité"
 
-#: Source/items.cpp:2005
+#: Source/items.cpp:2017
 msgid "increase vitality"
 msgstr "augmente la vitalité"
 
-#: Source/items.cpp:2010
+#: Source/items.cpp:2022
 msgid "decrease strength"
 msgstr "diminue la force"
 
-#: Source/items.cpp:2014
+#: Source/items.cpp:2026
 msgid "decrease dexterity"
 msgstr "diminue la dextérité"
 
-#: Source/items.cpp:2018
+#: Source/items.cpp:2030
 msgid "decrease vitality"
 msgstr "diminue la vitalité"
 
-#: Source/items.cpp:2022
+#: Source/items.cpp:2034
 msgid "restore some life and mana"
 msgstr "restaure de la vie et du mana"
 
-#: Source/items.cpp:2026
+#: Source/items.cpp:2038
 msgid "restore all life and mana"
 msgstr "restaure toute la vie et le mana"
 
-#: Source/items.cpp:2041 Source/items.cpp:2066
+#: Source/items.cpp:2053 Source/items.cpp:2078
 msgid "Right-click to read"
 msgstr "Clic-droit pour lire"
 
-#: Source/items.cpp:2045
+#: Source/items.cpp:2057
 msgid "Right-click to read, then"
 msgstr "Clic-droit pour lire, puis"
 
-#: Source/items.cpp:2047
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr "clic-gauche pour la cible"
 
-#: Source/items.cpp:2052
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr "Clic-droit pour utiliser"
 
-#: Source/items.cpp:2057 Source/items.cpp:2062
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr "Clic droit pour utiliser"
 
-#: Source/items.cpp:2070
+#: Source/items.cpp:2082
 msgid "Right click to read"
 msgstr "Clic droit pour lire"
 
-#: Source/items.cpp:2074
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr "Clic-droit pour voir"
 
-#: Source/items.cpp:2082
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr "Double la capacité en Or"
 
-#: Source/items.cpp:2094 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 msgid "Required:"
 msgstr "Requis:"
 
-#: Source/items.cpp:2096 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 msgid " {:d} Str"
 msgstr " {:d} For"
 
-#: Source/items.cpp:2098 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 msgid " {:d} Mag"
 msgstr " {:d} Mag"
 
-#: Source/items.cpp:2100 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 msgid " {:d} Dex"
 msgstr " {:d} Dex"
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3528 Source/player.cpp:3027
+#: Source/items.cpp:3533 Source/player.cpp:3018
 msgid "Ear of {:s}"
 msgstr "Oreille de {:s}"
 
-#: Source/items.cpp:3823
+#: Source/items.cpp:3828
 msgid "chance to hit: {:+d}%"
 msgstr "chance de toucher: {:+d} %"
 
-#: Source/items.cpp:3827
+#: Source/items.cpp:3832
 #, no-c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% dégats"
 
-#: Source/items.cpp:3831 Source/items.cpp:4087
+#: Source/items.cpp:3836 Source/items.cpp:4092
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "toucher: {:+d}%, {:+d}% dégats"
 
-#: Source/items.cpp:3835
+#: Source/items.cpp:3840
 #, no-c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% armure"
 
-#: Source/items.cpp:3839
+#: Source/items.cpp:3844
 msgid "armor class: {:d}"
 msgstr "classe d'armure: {:d}"
 
-#: Source/items.cpp:3844 Source/items.cpp:4069
+#: Source/items.cpp:3849 Source/items.cpp:4074
 msgid "Resist Fire: {:+d}%"
 msgstr "Résistance au Feu: {:+d}%"
 
-#: Source/items.cpp:3846
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr "Résistance au Feu: 75% MAX"
 
-#: Source/items.cpp:3851
+#: Source/items.cpp:3856
 msgid "Resist Lightning: {:+d}%"
 msgstr "Résistance à la Foudre: {:+d}%"
 
-#: Source/items.cpp:3853
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr "Résistance à la Foudre: 75% MAX"
 
-#: Source/items.cpp:3858
+#: Source/items.cpp:3863
 msgid "Resist Magic: {:+d}%"
 msgstr "Résistance à la Magie: {:+d}%"
 
-#: Source/items.cpp:3860
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr "Résistance à la Magie: 75% MAX"
 
-#: Source/items.cpp:3865
+#: Source/items.cpp:3870
 msgid "Resist All: {:+d}%"
 msgstr "Résistance à tout: {:+d}%"
 
-#: Source/items.cpp:3867
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr "Résistance à tout: 75% MAX"
 
-#: Source/items.cpp:3871
+#: Source/items.cpp:3876
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] "les sorts sont augmentés de {:d} niveau"
 msgstr[1] "les sorts sont augmentés de {:d} niveaux"
 
-#: Source/items.cpp:3873
+#: Source/items.cpp:3878
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "les sorts sont réduits de {:d} niveau"
 msgstr[1] "les sorts sont réduits de {:d} niveaux"
 
-#: Source/items.cpp:3875
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr "niveaux de sorts inchangés (?)"
 
-#: Source/items.cpp:3878
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr "Charges supplémentaires"
 
-#: Source/items.cpp:3881
+#: Source/items.cpp:3886
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:d} {:s} charge"
 msgstr[1] "{:d} {:s} charges"
 
-#: Source/items.cpp:3885
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr "Dégâts de Feu: {:d}"
 
-#: Source/items.cpp:3887
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "Dégâts de Feu: {:d}-{:d}"
 
-#: Source/items.cpp:3891
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr "Dégâts de Foudre: {:d}"
 
-#: Source/items.cpp:3893
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "Dégâts de Foudre: {:d}-{:d}"
 
-#: Source/items.cpp:3897
+#: Source/items.cpp:3902
 msgid "{:+d} to strength"
 msgstr "{:+d} en force"
 
-#: Source/items.cpp:3901
+#: Source/items.cpp:3906
 msgid "{:+d} to magic"
 msgstr "{:+d} en magie"
 
-#: Source/items.cpp:3905
+#: Source/items.cpp:3910
 msgid "{:+d} to dexterity"
 msgstr "{:+d} en dexterité"
 
-#: Source/items.cpp:3909
+#: Source/items.cpp:3914
 msgid "{:+d} to vitality"
 msgstr "{:+d} en vitalité"
 
-#: Source/items.cpp:3913
+#: Source/items.cpp:3918
 msgid "{:+d} to all attributes"
 msgstr "{:+d} à tous les attributs"
 
-#: Source/items.cpp:3917
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} dégâts des ennemis"
 
-#: Source/items.cpp:3921
+#: Source/items.cpp:3926
 msgid "Hit Points: {:+d}"
 msgstr "Points de vie:{:+d}"
 
-#: Source/items.cpp:3925
+#: Source/items.cpp:3930
 msgid "Mana: {:+d}"
 msgstr "Mana: {:+d}"
 
-#: Source/items.cpp:3928
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr "haute durabilité"
 
-#: Source/items.cpp:3931
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr "durabilité diminuée"
 
-#: Source/items.cpp:3934
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr "indestructible"
 
-#: Source/items.cpp:3937
+#: Source/items.cpp:3942
 #, no-c-format
 msgid "+{:d}% light radius"
 msgstr "+{:d}% portée lumineuse"
 
-#: Source/items.cpp:3940
+#: Source/items.cpp:3945
 #, no-c-format
 msgid "-{:d}% light radius"
 msgstr "-{:d}% portée lumineuse"
 
-#: Source/items.cpp:3943
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr "plusieurs flèches par tir"
 
-#: Source/items.cpp:3947
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr "dégâts de flèches de feu: {:d}"
 
-#: Source/items.cpp:3949
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "dégâts de flèches de feu: {:d}-{:d}"
 
-#: Source/items.cpp:3953
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr "dégâts de flèches de foudre: {:d}"
 
-#: Source/items.cpp:3955
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "dégâts de flèches de foudre: {:d}-{:d}"
 
-#: Source/items.cpp:3959
+#: Source/items.cpp:3964
 msgid "fireball damage: {:d}"
 msgstr "dégâts boule de feu: {:d}"
 
-#: Source/items.cpp:3961
+#: Source/items.cpp:3966
 msgid "fireball damage: {:d}-{:d}"
 msgstr "dégâts boule de feu: {:d}-{:d}"
 
-#: Source/items.cpp:3964
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr "l'attaquant subit 1 à 3 dégâts"
 
-#: Source/items.cpp:3967
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr "l'utilisateur perd tout son mana"
 
-#: Source/items.cpp:3970
+#: Source/items.cpp:3975
 msgid "you can't heal"
 msgstr "vous ne pouvez pas vous guérir"
 
-#: Source/items.cpp:3973
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr "absorbe la moitié des dégâts de piège"
 
-#: Source/items.cpp:3976
+#: Source/items.cpp:3981
 msgid "knocks target back"
 msgstr "repousse la cible"
 
-#: Source/items.cpp:3979
+#: Source/items.cpp:3984
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr "+200% dégâts vs. démons"
 
-#: Source/items.cpp:3982
+#: Source/items.cpp:3987
 msgid "All Resistance equals 0"
 msgstr "Toute résistance réduite à 0"
 
-#: Source/items.cpp:3985
+#: Source/items.cpp:3990
 msgid "hit monster doesn't heal"
 msgstr "le monstre touché ne guérit pas"
 
-#: Source/items.cpp:3989
+#: Source/items.cpp:3994
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr "frapper vole 3% de mana"
 
-#: Source/items.cpp:3991
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr "frapper vole 5% de mana"
 
-#: Source/items.cpp:3995
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr "frapper vole 3% de vie"
 
-#: Source/items.cpp:3997
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr "frapper vole 5% de vie"
 
-#: Source/items.cpp:4000
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr "pénètre l'armure de la cible"
 
-#: Source/items.cpp:4004
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr "attaque prompte"
 
-#: Source/items.cpp:4006
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr "attaque rapide"
 
-#: Source/items.cpp:4008
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr "attaque plus rapide"
 
-#: Source/items.cpp:4010
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr "attaque la plus rapide"
 
-#: Source/items.cpp:4014
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr "récupération rapide des coups"
 
-#: Source/items.cpp:4016
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr "récupération plus rapide des coups"
 
-#: Source/items.cpp:4018
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr "récupération la plus rapide des coups"
 
-#: Source/items.cpp:4021
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr "blocage rapide"
 
-#: Source/items.cpp:4024
+#: Source/items.cpp:4029
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] "ajoute {:d} point aux dégâts"
 msgstr[1] "ajoute {:d} points aux dégâts"
 
-#: Source/items.cpp:4027
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr "tire des flèches de vitesse aléatoires"
 
-#: Source/items.cpp:4030
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr "dommages inhabituels aux objets"
 
-#: Source/items.cpp:4033
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr "durabilité altérée"
 
-#: Source/items.cpp:4036
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr "Attaque plus rapide"
 
-#: Source/items.cpp:4039
+#: Source/items.cpp:4044
 msgid "one handed sword"
 msgstr "épée à une main"
 
-#: Source/items.cpp:4042
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr "perdre constamment des points de vie"
 
-#: Source/items.cpp:4045
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr "vole la vie"
 
-#: Source/items.cpp:4048
+#: Source/items.cpp:4053
 msgid "no strength requirement"
 msgstr "pas d'exigence de force"
 
-#: Source/items.cpp:4051
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr "voit avec infravision"
 
-#: Source/items.cpp:4058
+#: Source/items.cpp:4063
 msgid "lightning damage: {:d}"
 msgstr "dégâts de foudre: {:d}"
 
-#: Source/items.cpp:4060
+#: Source/items.cpp:4065
 msgid "lightning damage: {:d}-{:d}"
 msgstr "dégâts de foudre: {:d}-{:d}"
 
-#: Source/items.cpp:4063
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr "éclair chargé à l'impact"
 
-#: Source/items.cpp:4072
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr "triple dommage occasionnel"
 
-#: Source/items.cpp:4075
+#: Source/items.cpp:4080
 #, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr "putréfiant {:+d}% dommage"
 
-#: Source/items.cpp:4078
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr "2x dgt au monstre, 1x à vous"
 
-#: Source/items.cpp:4081
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr "Dégâts 0-500% aléatoire"
 
-#: Source/items.cpp:4084
+#: Source/items.cpp:4089
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr "faible dur, {:+d}% de dégât"
 
-#: Source/items.cpp:4090
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr "extra CA vs démons"
 
-#: Source/items.cpp:4093
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr "extra CA vs Morts-Vivants"
 
-#: Source/items.cpp:4096
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr "50% de mana transféré à la santé"
 
-#: Source/items.cpp:4099
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr "40% de santé transféré au Mana"
 
-#: Source/items.cpp:4102
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr "Une autre Capacité (NW)"
 
-#: Source/items.cpp:4139 Source/items.cpp:4186
+#: Source/items.cpp:4144 Source/items.cpp:4191
 msgid "damage: {:d}  Indestructible"
 msgstr "dégâts: {:d}  Indestructible"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4141 Source/items.cpp:4188
+#: Source/items.cpp:4146 Source/items.cpp:4193
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "dégâts: {:d}  Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4144 Source/items.cpp:4191
+#: Source/items.cpp:4149 Source/items.cpp:4196
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "dégâts: {:d}-{:d}  Indestructible"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4146 Source/items.cpp:4193
+#: Source/items.cpp:4151 Source/items.cpp:4198
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "dégâts: {:d}-{:d} Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4152 Source/items.cpp:4205
+#: Source/items.cpp:4157 Source/items.cpp:4210
 msgid "armor: {:d}  Indestructible"
 msgstr "armure: {:d} Indestructible"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4154 Source/items.cpp:4207
+#: Source/items.cpp:4159 Source/items.cpp:4212
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "armure: {:d}  Dur: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4159
+#: Source/items.cpp:4164
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "deg: {:d} Dur: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4161
+#: Source/items.cpp:4166
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "deg: {:d}-{:d} Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4162 Source/items.cpp:4197 Source/items.cpp:4212
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 msgid "Charges: {:d}/{:d}"
 msgstr "Charges: {:d}/{:d}"
 
-#: Source/items.cpp:4174
+#: Source/items.cpp:4179
 msgid "unique item"
 msgstr "objet unique"
 
-#: Source/items.cpp:4201 Source/items.cpp:4210 Source/items.cpp:4217
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr "Non identifié"
 
-#: Source/loadsave.cpp:1656 Source/loadsave.cpp:2122
+#: Source/loadsave.cpp:1683 Source/loadsave.cpp:2149
 msgid "Unable to open save file archive"
 msgstr "Impossible d'ouvrir l'archive de sauvegarde"
 
-#: Source/loadsave.cpp:1659
+#: Source/loadsave.cpp:1686
 msgid "Invalid save file"
 msgstr "Sauvegarde invalide"
 
-#: Source/loadsave.cpp:1688
+#: Source/loadsave.cpp:1717
 msgid "Player is on a Hellfire only level"
 msgstr "Le joueur est dans un niveau uniquement Hellfire"
 
-#: Source/loadsave.cpp:1885
+#: Source/loadsave.cpp:1912
 msgid "Invalid game state"
 msgstr "État du jeu invalide"
 
-#: Source/menu.cpp:144
+#: Source/menu.cpp:154
 msgid "Unable to display mainmenu"
 msgstr "Impossible d'afficher le menu principal"
+
+#. TRANSLATORS:  Error Message when a Shareware User clicks on "Replay Intro" in the Main Menu
+#: Source/menu.cpp:179
+msgid ""
+"The Diablo introduction cinematic is only available in the full retail "
+"version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
+msgstr ""
+"La cinématique d'introduction de Diablo n'est disponible que dans la version "
+"commerciale complète de Diablo. Visitez https://www.gog.com/game/diablo pour "
+"l'acheter."
 
 #. TRANSLATORS: Monster Block start
 #. MT_NZOMBIE
@@ -5349,97 +5459,97 @@ msgctxt "monster"
 msgid "Doomlock"
 msgstr "Serrure de la Fatalité"
 
-#: Source/monster.cpp:3474
+#: Source/monster.cpp:3479
 msgid "Animal"
 msgstr "Animal"
 
-#: Source/monster.cpp:3476
+#: Source/monster.cpp:3481
 msgid "Demon"
 msgstr "Démon"
 
-#: Source/monster.cpp:3478
+#: Source/monster.cpp:3483
 msgid "Undead"
 msgstr "Mort-vivant"
 
-#: Source/monster.cpp:4610
+#: Source/monster.cpp:4612
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "Type: {:s}  Tués: {:d}"
 
-#: Source/monster.cpp:4612
+#: Source/monster.cpp:4614
 msgid "Total kills: {:d}"
 msgstr "Total Victimes: {:d}"
 
-#: Source/monster.cpp:4645
+#: Source/monster.cpp:4647
 msgid "Hit Points: {:d}-{:d}"
 msgstr "Points de vie:{:d}-{:d}"
 
-#: Source/monster.cpp:4651
+#: Source/monster.cpp:4653
 msgid "No magic resistance"
 msgstr "Pas de résistance magique"
 
-#: Source/monster.cpp:4655
+#: Source/monster.cpp:4657
 msgid "Resists: "
 msgstr "Résiste: "
 
-#: Source/monster.cpp:4657 Source/monster.cpp:4668
+#: Source/monster.cpp:4659 Source/monster.cpp:4671
 msgid "Magic "
 msgstr "Magie "
 
-#: Source/monster.cpp:4659 Source/monster.cpp:4670
+#: Source/monster.cpp:4661 Source/monster.cpp:4673
 msgid "Fire "
 msgstr "Feu "
 
-#: Source/monster.cpp:4661 Source/monster.cpp:4672
+#: Source/monster.cpp:4663 Source/monster.cpp:4675
 msgid "Lightning "
 msgstr "Foudre "
 
-#: Source/monster.cpp:4666
+#: Source/monster.cpp:4669
 msgid "Immune: "
 msgstr "Immunisé: "
 
-#: Source/monster.cpp:4684
+#: Source/monster.cpp:4688
 msgid "Type: {:s}"
 msgstr "Type: {:s}"
 
-#: Source/monster.cpp:4690 Source/monster.cpp:4697
+#: Source/monster.cpp:4694 Source/monster.cpp:4701
 msgid "No resistances"
 msgstr "Pas de résistances"
 
-#: Source/monster.cpp:4692 Source/monster.cpp:4702
+#: Source/monster.cpp:4696 Source/monster.cpp:4706
 msgid "No Immunities"
 msgstr "Pas d'immunités"
 
-#: Source/monster.cpp:4695
+#: Source/monster.cpp:4699
 msgid "Some Magic Resistances"
 msgstr "Quelques Résistances Magiques"
 
-#: Source/monster.cpp:4700
+#: Source/monster.cpp:4704
 msgid "Some Magic Immunities"
 msgstr "Quelques Immunités Magiques"
 
-#: Source/msg.cpp:497
+#: Source/msg.cpp:495
 msgid "Trying to drop a floor item?"
 msgstr "Vous essayez de déposer un objet au sol ?"
 
-#: Source/msg.cpp:950 Source/msg.cpp:985 Source/msg.cpp:1018
-#: Source/msg.cpp:1145 Source/msg.cpp:1177 Source/msg.cpp:1209
-#: Source/msg.cpp:1239
+#: Source/msg.cpp:994 Source/msg.cpp:1029 Source/msg.cpp:1060
+#: Source/msg.cpp:1187 Source/msg.cpp:1219 Source/msg.cpp:1251
+#: Source/msg.cpp:1281
 msgid "{:s} has cast an illegal spell."
 msgstr "{:s} a lancé un sort interdit."
 
-#: Source/msg.cpp:1625 Source/multi.cpp:799
+#: Source/msg.cpp:1668 Source/multi.cpp:804
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr "Joueur '{:s}' (niveau  {:d}) a rejoint le jeu"
 
-#: Source/msg.cpp:1929
+#: Source/msg.cpp:1972
 msgid "Waiting for game data..."
 msgstr "En attente des données du jeu ..."
 
-#: Source/msg.cpp:1937
+#: Source/msg.cpp:1980
 msgid "The game ended"
 msgstr "Le jeu s'est terminé"
 
-#: Source/msg.cpp:1943
+#: Source/msg.cpp:1986
 msgid "Unable to get level data"
 msgstr "Impossible d'acquérir les données du niveau"
 
@@ -5455,448 +5565,448 @@ msgstr "Joueur '{:s}' a tué Diablo et quitté le jeu!"
 msgid "Player '{:s}' dropped due to timeout"
 msgstr "Joueur '{:s}' a été quitté de le jeu (timeout)"
 
-#: Source/multi.cpp:801
+#: Source/multi.cpp:806
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr "Joueur '{:s}' (niveau {:d}) est déjà en jeu"
 
 #. TRANSLATORS: Shrine Name Block
-#: Source/objects.cpp:101
+#: Source/objects.cpp:104
 msgid "Mysterious"
 msgstr "Mystérieux"
 
-#: Source/objects.cpp:102
+#: Source/objects.cpp:105
 msgid "Hidden"
 msgstr "Caché"
 
-#: Source/objects.cpp:103
+#: Source/objects.cpp:106
 msgid "Gloomy"
 msgstr "Cafardeux"
 
-#: Source/objects.cpp:105 Source/objects.cpp:112
+#: Source/objects.cpp:108 Source/objects.cpp:115
 msgid "Magical"
 msgstr "Magique"
 
-#: Source/objects.cpp:106
+#: Source/objects.cpp:109
 msgid "Stone"
 msgstr "Pierre"
 
-#: Source/objects.cpp:107
+#: Source/objects.cpp:110
 msgid "Religious"
 msgstr "Religieux"
 
-#: Source/objects.cpp:108
+#: Source/objects.cpp:111
 msgid "Enchanted"
 msgstr "Enchanté"
 
-#: Source/objects.cpp:109
+#: Source/objects.cpp:112
 msgid "Thaumaturgic"
 msgstr "Thaumaturgique"
 
-#: Source/objects.cpp:110
+#: Source/objects.cpp:113
 msgid "Fascinating"
 msgstr "Fascinant"
 
-#: Source/objects.cpp:111
+#: Source/objects.cpp:114
 msgid "Cryptic"
 msgstr "Cryptique"
 
-#: Source/objects.cpp:113
+#: Source/objects.cpp:116
 msgid "Eldritch"
 msgstr "Eldritch"
 
-#: Source/objects.cpp:114
+#: Source/objects.cpp:117
 msgid "Eerie"
 msgstr "Étrange"
 
-#: Source/objects.cpp:115
+#: Source/objects.cpp:118
 msgid "Divine"
 msgstr "Divin"
 
-#: Source/objects.cpp:117
+#: Source/objects.cpp:120
 msgid "Sacred"
 msgstr "Sacré"
 
-#: Source/objects.cpp:118
+#: Source/objects.cpp:121
 msgid "Spiritual"
 msgstr "Spirituelle"
 
-#: Source/objects.cpp:119
+#: Source/objects.cpp:122
 msgid "Spooky"
 msgstr "Sinistre"
 
-#: Source/objects.cpp:120
+#: Source/objects.cpp:123
 msgid "Abandoned"
 msgstr "Abandonné"
 
-#: Source/objects.cpp:121
+#: Source/objects.cpp:124
 msgid "Creepy"
 msgstr "Terrifiant"
 
-#: Source/objects.cpp:122
+#: Source/objects.cpp:125
 msgid "Quiet"
 msgstr "Calme"
 
-#: Source/objects.cpp:123
+#: Source/objects.cpp:126
 msgid "Secluded"
 msgstr "Isolé"
 
-#: Source/objects.cpp:124
+#: Source/objects.cpp:127
 msgid "Ornate"
 msgstr "Orné"
 
-#: Source/objects.cpp:125
+#: Source/objects.cpp:128
 msgid "Glimmering"
 msgstr "Scintillant"
 
-#: Source/objects.cpp:126
+#: Source/objects.cpp:129
 msgid "Tainted"
 msgstr "Entaché"
 
-#: Source/objects.cpp:127
+#: Source/objects.cpp:130
 msgid "Oily"
 msgstr "Huileux"
 
-#: Source/objects.cpp:128
+#: Source/objects.cpp:131
 msgid "Glowing"
 msgstr "Brillant"
 
-#: Source/objects.cpp:129
+#: Source/objects.cpp:132
 msgid "Mendicant's"
 msgstr "De Mendiant"
 
-#: Source/objects.cpp:130
+#: Source/objects.cpp:133
 msgid "Sparkling"
 msgstr "Pétillant"
 
-#: Source/objects.cpp:131
+#: Source/objects.cpp:134
 msgid "Town"
 msgstr "Ville"
 
-#: Source/objects.cpp:132
+#: Source/objects.cpp:135
 msgid "Shimmering"
 msgstr "Chatoyant"
 
-#: Source/objects.cpp:133
+#: Source/objects.cpp:136
 msgid "Solar"
 msgstr "Solaire"
 
 #. TRANSLATORS: Shrine Name Block end
-#: Source/objects.cpp:135
+#: Source/objects.cpp:138
 msgid "Murphy's"
 msgstr "De Murphy"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:265
+#: Source/objects.cpp:268
 msgid "The Great Conflict"
 msgstr "Le Grand Conflit"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:266
+#: Source/objects.cpp:269
 msgid "The Wages of Sin are War"
 msgstr "Le Salaire du Péché est la Guerre"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:267
+#: Source/objects.cpp:270
 msgid "The Tale of the Horadrim"
 msgstr "Le Conte des Horadrim"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:268
+#: Source/objects.cpp:271
 msgid "The Dark Exile"
 msgstr "Le Sombre Exile"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:269
+#: Source/objects.cpp:272
 msgid "The Sin War"
 msgstr "La Guerre du Péché"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:270
+#: Source/objects.cpp:273
 msgid "The Binding of the Three"
 msgstr "L'Emprisonnement des Trois"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:271
+#: Source/objects.cpp:274
 msgid "The Realms Beyond"
 msgstr "Les Royaumes Au-Delà"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:272
+#: Source/objects.cpp:275
 msgid "Tale of the Three"
 msgstr "Conte des Trois"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:273
+#: Source/objects.cpp:276
 msgid "The Black King"
 msgstr "Le Roi Noir"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:274
+#: Source/objects.cpp:277
 msgid "Journal: The Ensorcellment"
 msgstr "Journal: L'Ensorcellement"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:275
+#: Source/objects.cpp:278
 msgid "Journal: The Meeting"
 msgstr "Journal: La Réunion"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:276
+#: Source/objects.cpp:279
 msgid "Journal: The Tirade"
 msgstr "Journal: La Tirade"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:277
+#: Source/objects.cpp:280
 msgid "Journal: His Power Grows"
 msgstr "Journal: Ses Pouvoir Grandissent"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:278
+#: Source/objects.cpp:281
 msgid "Journal: NA-KRUL"
 msgstr "Journal: NA-KRUL"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:279
+#: Source/objects.cpp:282
 msgid "Journal: The End"
 msgstr "Journal: La Fin"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:280
+#: Source/objects.cpp:283
 msgid "A Spellbook"
 msgstr "Un Livre de Sort"
 
-#: Source/objects.cpp:5365
+#: Source/objects.cpp:5339
 msgid "Crucified Skeleton"
 msgstr "Squelette Crucifié"
 
-#: Source/objects.cpp:5369
+#: Source/objects.cpp:5343
 msgid "Lever"
 msgstr "Levier"
 
-#: Source/objects.cpp:5378
+#: Source/objects.cpp:5352
 msgid "Open Door"
 msgstr "Porte Ouverte"
 
-#: Source/objects.cpp:5380
+#: Source/objects.cpp:5354
 msgid "Closed Door"
 msgstr "Porte Fermée"
 
-#: Source/objects.cpp:5382
+#: Source/objects.cpp:5356
 msgid "Blocked Door"
 msgstr "Porte Bloqué"
 
-#: Source/objects.cpp:5387
+#: Source/objects.cpp:5361
 msgid "Ancient Tome"
 msgstr "Tome Ancien"
 
-#: Source/objects.cpp:5389
+#: Source/objects.cpp:5363
 msgid "Book of Vileness"
 msgstr "Livre de la Bassesse"
 
-#: Source/objects.cpp:5394
+#: Source/objects.cpp:5368
 msgid "Skull Lever"
 msgstr "Levier-Crâne"
 
-#: Source/objects.cpp:5397
+#: Source/objects.cpp:5371
 msgid "Mythical Book"
 msgstr "Livre Mythique"
 
-#: Source/objects.cpp:5401
+#: Source/objects.cpp:5375
 msgid "Small Chest"
 msgstr "Petit Coffre"
 
-#: Source/objects.cpp:5405
+#: Source/objects.cpp:5379
 msgid "Chest"
 msgstr "Coffre"
 
-#: Source/objects.cpp:5410
+#: Source/objects.cpp:5384
 msgid "Large Chest"
 msgstr "Coffre Large"
 
-#: Source/objects.cpp:5413
+#: Source/objects.cpp:5387
 msgid "Sarcophagus"
 msgstr "Sarcophage"
 
-#: Source/objects.cpp:5416
+#: Source/objects.cpp:5390
 msgid "Bookshelf"
 msgstr "Étagère à livres"
 
-#: Source/objects.cpp:5420
+#: Source/objects.cpp:5394
 msgid "Bookcase"
 msgstr "Bibliothèque"
 
-#: Source/objects.cpp:5425
+#: Source/objects.cpp:5399
 msgid "Pod"
 msgstr "Cosse"
 
-#: Source/objects.cpp:5427
+#: Source/objects.cpp:5401
 msgid "Urn"
 msgstr "Urne"
 
-#: Source/objects.cpp:5429
+#: Source/objects.cpp:5403
 msgid "Barrel"
 msgstr "Baril"
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:5433
+#: Source/objects.cpp:5407
 msgid "{:s} Shrine"
 msgstr "{:s} Sanctuaire"
 
-#: Source/objects.cpp:5437
+#: Source/objects.cpp:5411
 msgid "Skeleton Tome"
 msgstr "Tome du Squelette"
 
-#: Source/objects.cpp:5440
+#: Source/objects.cpp:5414
 msgid "Library Book"
 msgstr "Livre de la Bibliothèque"
 
-#: Source/objects.cpp:5443
+#: Source/objects.cpp:5417
 msgid "Blood Fountain"
 msgstr "Fontaine de Sang"
 
-#: Source/objects.cpp:5446
+#: Source/objects.cpp:5420
 msgid "Decapitated Body"
 msgstr "Corps Décapité"
 
-#: Source/objects.cpp:5449
+#: Source/objects.cpp:5423
 msgid "Book of the Blind"
 msgstr "Livre des Aveugles"
 
-#: Source/objects.cpp:5452
+#: Source/objects.cpp:5426
 msgid "Book of Blood"
 msgstr "Livre de Sang"
 
-#: Source/objects.cpp:5455
+#: Source/objects.cpp:5429
 msgid "Purifying Spring"
 msgstr "Printemps Purifiant"
 
-#: Source/objects.cpp:5462 Source/objects.cpp:5486
+#: Source/objects.cpp:5436 Source/objects.cpp:5460
 msgid "Weapon Rack"
 msgstr "Râtelier d'Armes"
 
-#: Source/objects.cpp:5465
+#: Source/objects.cpp:5439
 msgid "Goat Shrine"
 msgstr "Sanctuaire de la Chèvre"
 
-#: Source/objects.cpp:5468
+#: Source/objects.cpp:5442
 msgid "Cauldron"
 msgstr "Chaudron"
 
-#: Source/objects.cpp:5471
+#: Source/objects.cpp:5445
 msgid "Murky Pool"
 msgstr "Piscine Trouble"
 
-#: Source/objects.cpp:5474
+#: Source/objects.cpp:5448
 msgid "Fountain of Tears"
 msgstr "Fontaine des Larmes"
 
-#: Source/objects.cpp:5477
+#: Source/objects.cpp:5451
 msgid "Steel Tome"
 msgstr "Tome d'Acier"
 
-#: Source/objects.cpp:5480
+#: Source/objects.cpp:5454
 msgid "Pedestal of Blood"
 msgstr "Piédestal de Sang"
 
-#: Source/objects.cpp:5489
+#: Source/objects.cpp:5463
 msgid "Mushroom Patch"
 msgstr "Parcelle de Champignon"
 
-#: Source/objects.cpp:5492
+#: Source/objects.cpp:5466
 msgid "Vile Stand"
 msgstr "Support Ignoble"
 
-#: Source/objects.cpp:5495
+#: Source/objects.cpp:5469
 msgid "Slain Hero"
 msgstr "Héros Tué"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:5502
+#: Source/objects.cpp:5476
 msgid "Trapped {:s}"
 msgstr "Piégé {:s}"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
-#: Source/objects.cpp:5508
+#: Source/objects.cpp:5482
 msgid "{:s} (disabled)"
 msgstr "{:s} (désactivé)"
 
-#: Source/panels/charpanel.cpp:109
+#: Source/panels/charpanel.cpp:110
 msgid "MAX"
 msgstr "MAX"
 
-#: Source/panels/charpanel.cpp:119
+#: Source/panels/charpanel.cpp:120
 msgid "Level"
 msgstr "Niveau"
 
-#: Source/panels/charpanel.cpp:121
+#: Source/panels/charpanel.cpp:122
 msgid "Experience"
 msgstr "Expérience"
 
-#: Source/panels/charpanel.cpp:123
+#: Source/panels/charpanel.cpp:124
 msgid "Next level"
 msgstr "Prochain niveau"
 
-#: Source/panels/charpanel.cpp:126
+#: Source/panels/charpanel.cpp:127
 msgid "None"
 msgstr "Rien"
 
-#: Source/panels/charpanel.cpp:132
+#: Source/panels/charpanel.cpp:133
 msgid "Base"
 msgstr "Base"
 
-#: Source/panels/charpanel.cpp:133
+#: Source/panels/charpanel.cpp:134
 msgid "Now"
 msgstr "Actuel"
 
-#: Source/panels/charpanel.cpp:134
+#: Source/panels/charpanel.cpp:135
 msgid "Strength"
 msgstr "Force"
 
-#: Source/panels/charpanel.cpp:138
+#: Source/panels/charpanel.cpp:139
 msgid "Magic"
 msgstr "Magie"
 
-#: Source/panels/charpanel.cpp:142
+#: Source/panels/charpanel.cpp:143
 msgid "Dexterity"
 msgstr "Dextérité"
 
-#: Source/panels/charpanel.cpp:145
+#: Source/panels/charpanel.cpp:146
 msgid "Vitality"
 msgstr "Vitalité"
 
-#: Source/panels/charpanel.cpp:148
+#: Source/panels/charpanel.cpp:149
 msgid "Points to distribute"
 msgstr "Points à distribuer"
 
-#: Source/panels/charpanel.cpp:158
+#: Source/panels/charpanel.cpp:159
 msgid "Armor class"
 msgstr "Classe d'armure"
 
-#: Source/panels/charpanel.cpp:160
+#: Source/panels/charpanel.cpp:161
 msgid "To hit"
 msgstr "Chances de toucher"
 
-#: Source/panels/charpanel.cpp:162
+#: Source/panels/charpanel.cpp:163
 msgid "Damage"
 msgstr "Dommage"
 
-#: Source/panels/charpanel.cpp:168
+#: Source/panels/charpanel.cpp:170
 msgid "Life"
 msgstr "Vie"
 
-#: Source/panels/charpanel.cpp:172
+#: Source/panels/charpanel.cpp:174
 msgid "Mana"
 msgstr "Mana"
 
-#: Source/panels/charpanel.cpp:177
+#: Source/panels/charpanel.cpp:179
 msgid "Resist magic"
 msgstr "Résistance à la Magie"
 
-#: Source/panels/charpanel.cpp:179
+#: Source/panels/charpanel.cpp:181
 msgid "Resist fire"
 msgstr "Résistance au Feu"
 
-#: Source/panels/charpanel.cpp:181
+#: Source/panels/charpanel.cpp:183
 msgid "Resist lightning"
 msgstr "Résistance à la Foudre"
 
@@ -5934,27 +6044,26 @@ msgstr "sorts"
 msgid "mute"
 msgstr "rendre muet"
 
-#: Source/pfile.cpp:260
+#: Source/pfile.cpp:242
 msgid "Failed to open player archive for writing."
 msgstr "Échec de l'ouverture de l'archive du joueur (écriture)"
 
-#: Source/pfile.cpp:385
+#: Source/pfile.cpp:377
 msgid "Unable to open archive"
 msgstr "Impossible d'ouvrir l'archive"
 
-#: Source/pfile.cpp:387
+#: Source/pfile.cpp:379
 msgid "Unable to load character"
 msgstr "Impossible de charger le personnage"
 
-#: Source/pfile.cpp:410 Source/pfile.cpp:430
+#: Source/pfile.cpp:403 Source/pfile.cpp:423
 msgid "Unable to read to save file archive"
 msgstr "Impossible de lire l'archive de sauvegarde"
 
-#: Source/pfile.cpp:449
+#: Source/pfile.cpp:442
 msgid "Unable to write to save file archive"
 msgstr "Impossible d'écrire l'archive de sauvegarde"
 
-#. TRANSLATORS: Shown if player presses "v" button. {:s} is player name, {:d} is level, {:s} is location
 #: Source/plrmsg.cpp:88
 msgid "{:s} (lvl {:d}): {:s}"
 msgstr "{:s} (lvl {:d}): {:s}"
@@ -5970,7 +6079,7 @@ msgstr ",%03d"
 msgid "%i gold"
 msgstr "%i or"
 
-#: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:56
+#: Source/qol/monhealthbar.cpp:37 Source/qol/xpbar.cpp:56
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
@@ -6383,298 +6492,331 @@ msgctxt "spell"
 msgid "Rune of Stone"
 msgstr "Rune de Pierre"
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:91
+#, fuzzy
+#| msgid "Griswold's Edge"
+msgid "Griswold"
+msgstr "Epée de Griswold"
+
+#: Source/stores.cpp:92
+msgid "Pepin"
+msgstr ""
+
+#: Source/stores.cpp:94
+msgid "Ogden"
+msgstr ""
+
+#: Source/stores.cpp:95
+msgid "Cain"
+msgstr ""
+
+#: Source/stores.cpp:96
+#, fuzzy
+#| msgid "Talk to Farnham"
+msgid "Farnham"
+msgstr "Parler à Farnham"
+
+#: Source/stores.cpp:97
+msgid "Adria"
+msgstr ""
+
+#: Source/stores.cpp:98 Source/stores.cpp:1305
+#, fuzzy
+#| msgid "brilliance"
+msgid "Gillian"
+msgstr "éclat"
+
+#: Source/stores.cpp:99
+msgid "Wirt"
+msgstr ""
+
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr "Retour"
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ", "
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 msgid "Damage: {:d}-{:d}  "
 msgstr "Dégâts: {:d}-{:d} "
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 msgid "Armor: {:d}  "
 msgstr "Armure: {:d} "
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 msgid "Dur: {:d}/{:d},  "
 msgstr "Dur: {:d}/{:d},  "
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr "Indestructible, "
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr "Aucun attribut requis"
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr "Bienvenue dans la"
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr "Boutique du forgeron"
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr "Souhaitez-vous:"
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 msgid "Talk to Griswold"
 msgstr "Parler à Griswold"
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 msgid "Buy basic items"
 msgstr "Acheter des objets de base"
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 msgid "Buy premium items"
 msgstr "Acheter des objets premiums"
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 msgid "Sell items"
 msgstr "Vendre des objets"
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 msgid "Repair items"
 msgstr "Réparer des objets"
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 msgid "Leave the shop"
 msgstr "Quitter la boutique"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "J'ai ces objets à vendre:             Votre or: {:d}"
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr "Retour"
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "J'ai ces objets premim à vendre:             Votre or: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "Vous n'avez rien pour moi.             Votre or: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "Quel objet est à vendre?             Votre or: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "Vous n'avez rien à réparer.             Votre or: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "Réparer quel article?             Votre or: {:d}"
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr "Cabane de la sorcière"
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 msgid "Talk to Adria"
 msgstr "Parler à Adria"
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr "Acheter des articles"
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr "Recharger les bâtons"
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 msgid "Leave the shack"
 msgstr "Quitter la cabane"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "Vous n'avez rien à recharger.              Votre or: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "Recharger quel article?             Votre or: {:d}"
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr "Vous n'avez pas assez d'or"
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr "Tu n'as pas assez de place dans votre inventaire"
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr "Avons-nous un accord?"
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 msgid "Are you sure you want to identify this item?"
 msgstr "Êtes-vous sûr de vouloir identifier cet élément?"
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 msgid "Are you sure you want to buy this item?"
 msgstr "Êtes-vous sûr de vouloir acheter cet article?"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 msgid "Are you sure you want to recharge this item?"
 msgstr "Voulez-vous vraiment recharger cet article?"
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 msgid "Are you sure you want to sell this item?"
 msgstr "Êtes-vous sûr de vouloir vendre cet article?"
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 msgid "Are you sure you want to repair this item?"
 msgstr "Êtes-vous sûr de vouloir réparer cet article?"
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr "Wirt le Garçon à la prothese"
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 msgid "Talk to Wirt"
 msgstr "Parler à Wirt"
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr "J'ai quelque chose à vendre,"
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr "mais il en coûtera 50 pièces"
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr "rien que pour y jeter un oeil. "
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr "Qu'est-ce que tu as?"
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr "Dire aurevoir"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "J'ai cet objet à vendre:             Votre or: {:d}"
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 msgid "Leave"
 msgstr "Partir"
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr "Maison du Guérisseur"
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr "Parler à Pepin"
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr "Quitter le Guérisseur"
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 msgid "The Town Elder"
 msgstr "L'Ancien de la Ville"
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 msgid "Talk to Cain"
 msgstr "Parler à Cain"
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr "Identifier un objet"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "Vous n'avez rien à identifier.             Votre or: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "Identifier quel article?             Votre or: {:d}"
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr "Cet objet est:"
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr "Fait"
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 msgid "Talk to {:s}"
 msgstr "Parler à {:s}"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 msgid "Talking to {:s}"
 msgstr "Parler à {:s}"
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 msgid "is not available"
 msgstr "n'est pas possible"
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 msgid "in the shareware"
 msgstr "dans le shareware"
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 msgid "version"
 msgstr "version"
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr "Potins"
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr "Soleil Levant"
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 msgid "Talk to Ogden"
 msgstr "Parler à Ogden"
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 msgid "Leave the tavern"
 msgstr "Quitter la tarvene"
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 msgid "Talk to Gillian"
 msgstr "Parler à Gillian"
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr "Farnham l'Ivrogne"
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 msgid "Talk to Farnham"
 msgstr "Parler à Farnham"
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr "Dire Aurevoir"
 
@@ -10723,17 +10865,17 @@ msgid "Down to Crypt"
 msgstr "Descendre dans la Crypte"
 
 #: Source/trigs.cpp:412 Source/trigs.cpp:492 Source/trigs.cpp:539
-#: Source/trigs.cpp:630
+#: Source/trigs.cpp:634
 msgid "Up to level {:d}"
 msgstr "Monter au niveau {:d}"
 
 #: Source/trigs.cpp:414 Source/trigs.cpp:469 Source/trigs.cpp:521
-#: Source/trigs.cpp:596 Source/trigs.cpp:613 Source/trigs.cpp:660
+#: Source/trigs.cpp:600 Source/trigs.cpp:617 Source/trigs.cpp:664
 msgid "Up to town"
 msgstr "Monter en ville"
 
-#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:552
-#: Source/trigs.cpp:577 Source/trigs.cpp:642
+#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:556
+#: Source/trigs.cpp:581 Source/trigs.cpp:646
 msgid "Down to level {:d}"
 msgstr "Descendre au niveau {:d}"
 
@@ -10745,14 +10887,14 @@ msgstr "Monter vers la Crypte niveau {:d}"
 msgid "Down to Crypt level {:d}"
 msgstr "Descendre vers la crypte niveau {:d}"
 
-#: Source/trigs.cpp:564
+#: Source/trigs.cpp:568
 msgid "Up to Nest level {:d}"
 msgstr "Monter vers le Nid niveau {:d}"
 
-#: Source/trigs.cpp:673
+#: Source/trigs.cpp:677
 msgid "Down to Diablo"
 msgstr "Descendre vers Diablo"
 
-#: Source/trigs.cpp:706 Source/trigs.cpp:720 Source/trigs.cpp:734
+#: Source/trigs.cpp:710 Source/trigs.cpp:724 Source/trigs.cpp:738
 msgid "Back to Level {:d}"
 msgstr "Retourner au Niveau {:d}"

--- a/Translations/hr.po
+++ b/Translations/hr.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-09-20 04:34+0200\n"
-"PO-Revision-Date: 2021-09-20 04:34+0200\n"
+"POT-Creation-Date: 2021-11-21 05:45+0100\n"
+"PO-Revision-Date: 2021-11-21 05:45+0100\n"
 "Last-Translator: gogo <linux.hr@protonmail.com>\n"
 "Language-Team: \n"
 "Language: hr\n"
@@ -165,6 +165,7 @@ msgstr "Ispitivanje kvalitete - podrška artiljerije (Dodatni testiratelji) "
 msgid "QA Counterintelligence"
 msgstr "Ispitivanje kvalitete - kontraobavještajna služba"
 
+#. TRANSLATORS: A group of people
 #: Source/DiabloUI/credits_lines.cpp:130
 msgid "Order of Network Information Services"
 msgstr "Naručivanje mrežnih informacijskih usluga"
@@ -342,15 +343,48 @@ msgstr "Prsten od tisuće"
 msgid "\tNo souls were sold in the making of this game."
 msgstr "\tTijekom izrade ove igre nije bilo prodanih duša."
 
-#: Source/DiabloUI/dialogs.cpp:172 Source/DiabloUI/dialogs.cpp:185
-#: Source/DiabloUI/selconn.cpp:73 Source/DiabloUI/selgame.cpp:94
-#: Source/DiabloUI/selgame.cpp:163 Source/DiabloUI/selgame.cpp:181
-#: Source/DiabloUI/selgame.cpp:314 Source/DiabloUI/selgame.cpp:387
-#: Source/DiabloUI/selhero.cpp:185 Source/DiabloUI/selhero.cpp:210
-#: Source/DiabloUI/selhero.cpp:280 Source/DiabloUI/selhero.cpp:525
+#: Source/DiabloUI/dialogs.cpp:194 Source/DiabloUI/dialogs.cpp:206
+#: Source/DiabloUI/selconn.cpp:79 Source/DiabloUI/selgame.cpp:103
+#: Source/DiabloUI/selgame.cpp:193 Source/DiabloUI/selgame.cpp:211
+#: Source/DiabloUI/selgame.cpp:352 Source/DiabloUI/selgame.cpp:428
+#: Source/DiabloUI/selhero.cpp:186 Source/DiabloUI/selhero.cpp:211
+#: Source/DiabloUI/selhero.cpp:281 Source/DiabloUI/selhero.cpp:536
 #: Source/DiabloUI/selok.cpp:68
 msgid "OK"
 msgstr "U redu"
+
+#: Source/DiabloUI/extrasmenu.cpp:41 Source/DiabloUI/selstart.cpp:44
+#, fuzzy
+#| msgid "Exit Diablo"
+msgid "Switch to Diablo"
+msgstr "Diablo udarni tim"
+
+#: Source/DiabloUI/extrasmenu.cpp:41
+#, fuzzy
+msgid "Switch to Hellfire"
+msgstr "Zatvori Diablo"
+
+#: Source/DiabloUI/extrasmenu.cpp:43
+msgid "Switch to Fullgame"
+msgstr ""
+
+#: Source/DiabloUI/extrasmenu.cpp:43
+msgid "Switch to Shareware"
+msgstr ""
+
+#: Source/DiabloUI/extrasmenu.cpp:44
+msgid "Replay Intro"
+msgstr "Pogledaj uvod"
+
+#: Source/DiabloUI/extrasmenu.cpp:45
+#, fuzzy
+#| msgid "Customer Support"
+msgid "Support"
+msgstr "Ispitivanje kvalitete - podrška artiljerije (Dodatni testiratelji) "
+
+#: Source/DiabloUI/extrasmenu.cpp:46 Source/gamemenu.cpp:61
+msgid "Previous Menu"
+msgstr "Prijašnji izbornik"
 
 #: Source/DiabloUI/mainmenu.cpp:36
 msgid "Single Player"
@@ -361,123 +395,126 @@ msgid "Multi Player"
 msgstr "Više igrača"
 
 #: Source/DiabloUI/mainmenu.cpp:38
-msgid "Replay Intro"
-msgstr "Pogledaj uvod"
+msgid "Extras"
+msgstr ""
 
 #: Source/DiabloUI/mainmenu.cpp:39
-#, fuzzy
-#| msgid "Customer Support"
-msgid "Support"
-msgstr "Ispitivanje kvalitete - podrška artiljerije (Dodatni testiratelji) "
-
-#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Show Credits"
 msgstr "Pogledaj zasluge"
 
-#: Source/DiabloUI/mainmenu.cpp:41
+#: Source/DiabloUI/mainmenu.cpp:40
 #, fuzzy
 msgid "Exit Hellfire"
 msgstr "Zatvori Diablo"
 
-#: Source/DiabloUI/mainmenu.cpp:41
+#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Exit Diablo"
 msgstr "Zatvori Diablo"
 
-#. TRANSLATORS:  Error Message when a Shareware User clicks on "Replay Intro" in the Main Menu
-#: Source/DiabloUI/mainmenu.cpp:99
-msgid ""
-"The Diablo introduction cinematic is only available in the full retail "
-"version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
-msgstr ""
-"Diablo uvodni film je samo dostupan u cjelovitom maloprodajnom izdanju "
-"Diabla. Posjetite https://www.gog.com/game/diablo kako bi ga kupili."
+#: Source/DiabloUI/mainmenu.cpp:55
+#, fuzzy
+msgid "Shareware"
+msgstr "Diablo udarni tim"
 
-#: Source/DiabloUI/progress.cpp:48 Source/DiabloUI/selconn.cpp:76
-#: Source/DiabloUI/selhero.cpp:188 Source/DiabloUI/selhero.cpp:213
-#: Source/DiabloUI/selhero.cpp:283 Source/DiabloUI/selhero.cpp:533
+#: Source/DiabloUI/progress.cpp:36 Source/DiabloUI/selconn.cpp:82
+#: Source/DiabloUI/selhero.cpp:189 Source/DiabloUI/selhero.cpp:214
+#: Source/DiabloUI/selhero.cpp:284 Source/DiabloUI/selhero.cpp:544
 msgid "Cancel"
 msgstr "Odustani"
 
-#: Source/DiabloUI/selconn.cpp:38 Source/DiabloUI/selgame.cpp:77
-#: Source/DiabloUI/selgame.cpp:372
+#: Source/DiabloUI/selconn.cpp:13
 msgid "Client-Server (TCP)"
 msgstr "Klijent-Poslužitelj (TCP)"
 
-#: Source/DiabloUI/selconn.cpp:41
+#: Source/DiabloUI/selconn.cpp:14
 msgid "Loopback"
 msgstr "Izvanmrežno"
 
-#: Source/DiabloUI/selconn.cpp:47 Source/DiabloUI/selgame.cpp:434
-#: Source/DiabloUI/selgame.cpp:452
+#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:489
+#: Source/DiabloUI/selgame.cpp:510
 msgid "Multi Player Game"
 msgstr "Igra za više igrača"
 
-#: Source/DiabloUI/selconn.cpp:53
+#: Source/DiabloUI/selconn.cpp:59
 #, fuzzy
 #| msgid "Requirements:"
 msgid "Requirements:"
 msgstr "Zahtjevi:"
 
-#: Source/DiabloUI/selconn.cpp:59
+#: Source/DiabloUI/selconn.cpp:65
 msgid "no gateway needed"
 msgstr "pristupnik nije potreban"
 
-#: Source/DiabloUI/selconn.cpp:65
+#: Source/DiabloUI/selconn.cpp:71
 msgid "Select Connection"
 msgstr "Odaberi povezivanje"
 
-#: Source/DiabloUI/selconn.cpp:68
+#: Source/DiabloUI/selconn.cpp:74
 msgid "Change Gateway"
 msgstr "Promijeni pristupnika"
 
-#: Source/DiabloUI/selconn.cpp:101
+#: Source/DiabloUI/selconn.cpp:107
 msgid "All computers must be connected to a TCP-compatible network."
 msgstr "Sva računala moraju biti povezana u TCP kompatibilnu mrežu."
 
-#: Source/DiabloUI/selconn.cpp:105
+#: Source/DiabloUI/selconn.cpp:111
 #, fuzzy
 #| msgid "All computers must be connected to a TCP-compatible network."
 msgid "All computers must be connected to the internet."
 msgstr "Sva računala moraju biti povezana u TCP kompatibilnu mrežu."
 
-#: Source/DiabloUI/selconn.cpp:109
+#: Source/DiabloUI/selconn.cpp:115
 msgid "Play by yourself with no network exposure."
 msgstr "Igrajte sami sa sobom bez pristupa mreži."
 
-#: Source/DiabloUI/selconn.cpp:114
+#: Source/DiabloUI/selconn.cpp:120
 msgid "Players Supported: {:d}"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/DiabloUI/selgame.cpp:80 Source/DiabloUI/selgame.cpp:375
+#: Source/DiabloUI/selgame.cpp:82 Source/DiabloUI/selgame.cpp:414
 msgid "Description:"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:86
+#: Source/DiabloUI/selgame.cpp:88
 msgid "Select Action"
 msgstr "Odaberi radnju"
 
-#: Source/DiabloUI/selgame.cpp:88 Source/DiabloUI/selgame.cpp:151
-#: Source/DiabloUI/selgame.cpp:295
+#: Source/DiabloUI/selgame.cpp:91 Source/DiabloUI/selgame.cpp:181
+#: Source/DiabloUI/selgame.cpp:333
 msgid "Create Game"
 msgstr "Stvori igru"
 
-#: Source/DiabloUI/selgame.cpp:89
+#: Source/DiabloUI/selgame.cpp:93
+#, fuzzy
+#| msgid "Create Game"
+msgid "Create Public Game"
+msgstr "Stvori igru"
+
+#: Source/DiabloUI/selgame.cpp:94
 #, fuzzy
 #| msgid "Join TCP Games"
 msgid "Join Game"
 msgstr "Dizajn igre"
 
-#: Source/DiabloUI/selgame.cpp:97 Source/DiabloUI/selgame.cpp:166
-#: Source/DiabloUI/selgame.cpp:184 Source/DiabloUI/selgame.cpp:317
-#: Source/DiabloUI/selgame.cpp:390
+#: Source/DiabloUI/selgame.cpp:106 Source/DiabloUI/selgame.cpp:196
+#: Source/DiabloUI/selgame.cpp:214 Source/DiabloUI/selgame.cpp:355
+#: Source/DiabloUI/selgame.cpp:431
 msgid "CANCEL"
 msgstr "Odustani"
 
-#: Source/DiabloUI/selgame.cpp:106
+#: Source/DiabloUI/selgame.cpp:122
 msgid "Create a new game with a difficulty setting of your choice."
 msgstr "Stvorite novu igru s razinom po vašem izboru."
 
-#: Source/DiabloUI/selgame.cpp:109
+#: Source/DiabloUI/selgame.cpp:125
+#, fuzzy
+#| msgid "Create a new game with a difficulty setting of your choice."
+msgid ""
+"Create a new public game that anyone can join with a difficulty setting of "
+"your choice."
+msgstr "Stvorite novu igru s razinom po vašem izboru."
+
+#: Source/DiabloUI/selgame.cpp:128
 #, fuzzy
 #| msgid "Enter an IP and join a game already in progress at that address."
 msgid ""
@@ -486,37 +523,44 @@ msgid ""
 msgstr ""
 "Upišite IP adresu i pridružite se već pokrenutoj igri na dotičnoj adresi."
 
-#: Source/DiabloUI/selgame.cpp:154
+#: Source/DiabloUI/selgame.cpp:131
+#, fuzzy
+#| msgid "Enter an IP and join a game already in progress at that address."
+msgid "Join the public game already in progress at this address."
+msgstr ""
+"Upišite IP adresu i pridružite se već pokrenutoj igri na dotičnoj adresi."
+
+#: Source/DiabloUI/selgame.cpp:184
 msgid "Select Difficulty"
 msgstr "Odaberi razinu"
 
-#: Source/DiabloUI/selgame.cpp:156 Source/DiabloUI/selgame.cpp:203
-#: Source/DiabloUI/selgame.cpp:306 Source/DiabloUI/selgame.cpp:326
-#: Source/diablo.cpp:1434
+#: Source/DiabloUI/selgame.cpp:186 Source/DiabloUI/selgame.cpp:239
+#: Source/DiabloUI/selgame.cpp:344 Source/DiabloUI/selgame.cpp:364
+#: Source/diablo.cpp:1446
 msgid "Normal"
 msgstr "Normalna"
 
-#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:207
-#: Source/diablo.cpp:1435
+#: Source/DiabloUI/selgame.cpp:187 Source/DiabloUI/selgame.cpp:243
+#: Source/diablo.cpp:1447
 msgid "Nightmare"
 msgstr "Noćna mora"
 
-#: Source/DiabloUI/selgame.cpp:158 Source/DiabloUI/selgame.cpp:211
-#: Source/diablo.cpp:1436
+#: Source/DiabloUI/selgame.cpp:188 Source/DiabloUI/selgame.cpp:247
+#: Source/diablo.cpp:1448
 msgid "Hell"
 msgstr "Pakao"
 
-#: Source/DiabloUI/selgame.cpp:172
+#: Source/DiabloUI/selgame.cpp:202
 msgid "Join TCP Games"
 msgstr "Pridruži se TCP igrama"
 
-#: Source/DiabloUI/selgame.cpp:175 Source/DiabloUI/selgame.cpp:178
+#: Source/DiabloUI/selgame.cpp:205 Source/DiabloUI/selgame.cpp:208
 #, fuzzy
 #| msgid "Enter Name"
 msgid "Enter address"
 msgstr "Upiši lozinku"
 
-#: Source/DiabloUI/selgame.cpp:204
+#: Source/DiabloUI/selgame.cpp:240
 msgid ""
 "Normal Difficulty\n"
 "This is where a starting character should begin the quest to defeat Diablo."
@@ -524,7 +568,7 @@ msgstr ""
 "Normalna razina\n"
 "Ovdje bi novi lik trebao započeti potragu za porazom Diabla."
 
-#: Source/DiabloUI/selgame.cpp:208
+#: Source/DiabloUI/selgame.cpp:244
 msgid ""
 "Nightmare Difficulty\n"
 "The denizens of the Labyrinth have been bolstered and will prove to be a "
@@ -534,7 +578,7 @@ msgstr ""
 "Stanovnici Labirinta su ojačali i pokazat će se kao veći izazov. Ovo je "
 "preporučljivo samo za iskusne likove."
 
-#: Source/DiabloUI/selgame.cpp:212
+#: Source/DiabloUI/selgame.cpp:248
 msgid ""
 "Hell Difficulty\n"
 "The most powerful of the underworld's creatures lurk at the gateway into "
@@ -544,7 +588,7 @@ msgstr ""
 "Najmoćnija bića iz podzemlja vrebaju na ulazu u Pakao. U ovo bi carstvo "
 "trebali ući samo najiskusniji likovi."
 
-#: Source/DiabloUI/selgame.cpp:227
+#: Source/DiabloUI/selgame.cpp:264
 msgid ""
 "Your character must reach level 20 before you can enter a multiplayer game "
 "of Nightmare difficulty."
@@ -552,7 +596,7 @@ msgstr ""
 "Vaš lik mora prije dostići razinu 20 kako bi mogao ući u igru s više igrača "
 "ili u razinu noćne more."
 
-#: Source/DiabloUI/selgame.cpp:229
+#: Source/DiabloUI/selgame.cpp:266
 msgid ""
 "Your character must reach level 30 before you can enter a multiplayer game "
 "of Hell difficulty."
@@ -560,24 +604,24 @@ msgstr ""
 "Vaš lik mora prije dostići razinu 30 kako bi mogao ući u igru s više igrača "
 "ili u paklenu razinu."
 
-#: Source/DiabloUI/selgame.cpp:304
+#: Source/DiabloUI/selgame.cpp:342
 #, fuzzy
 msgid "Select Game Speed"
 msgstr "Odaberi povezivanje"
 
-#: Source/DiabloUI/selgame.cpp:307 Source/DiabloUI/selgame.cpp:330
+#: Source/DiabloUI/selgame.cpp:345 Source/DiabloUI/selgame.cpp:368
 msgid "Fast"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:308 Source/DiabloUI/selgame.cpp:334
+#: Source/DiabloUI/selgame.cpp:346 Source/DiabloUI/selgame.cpp:372
 msgid "Faster"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:309 Source/DiabloUI/selgame.cpp:338
+#: Source/DiabloUI/selgame.cpp:347 Source/DiabloUI/selgame.cpp:376
 msgid "Fastest"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:327
+#: Source/DiabloUI/selgame.cpp:365
 #, fuzzy
 #| msgid ""
 #| "Normal Difficulty\n"
@@ -590,7 +634,7 @@ msgstr ""
 "Normalna razina\n"
 "Ovdje bi novi lik trebao započeti potragu za porazom Diabla."
 
-#: Source/DiabloUI/selgame.cpp:331
+#: Source/DiabloUI/selgame.cpp:369
 #, fuzzy
 #| msgid ""
 #| "Nightmare Difficulty\n"
@@ -605,91 +649,91 @@ msgstr ""
 "Stanovnici Labirinta su ojačali i pokazat će se kao veći izazov. Ovo je "
 "preporučljivo samo za iskusne likove."
 
-#: Source/DiabloUI/selgame.cpp:335
+#: Source/DiabloUI/selgame.cpp:373
 msgid ""
 "Faster Speed\n"
 "Most monsters of the dungeon will seek you out quicker than ever before. "
 "Only an experienced champion should try their luck at this speed."
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:339
+#: Source/DiabloUI/selgame.cpp:377
 msgid ""
 "Fastest Speed\n"
 "The minions of the underworld will rush to attack without hesitation. Only a "
 "true speed demon should enter at this pace."
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:381 Source/DiabloUI/selgame.cpp:384
+#: Source/DiabloUI/selgame.cpp:420 Source/DiabloUI/selgame.cpp:425
 msgid "Enter Password"
 msgstr "Upiši lozinku"
 
-#: Source/DiabloUI/selgame.cpp:407
+#: Source/DiabloUI/selgame.cpp:448
 msgid "The host is running a different game than you."
 msgstr ""
 
 #. TRANSLATORS: Error message when somebody tries to join a game running another version.
-#: Source/DiabloUI/selgame.cpp:410
+#: Source/DiabloUI/selgame.cpp:451
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr ""
 
-#: Source/DiabloUI/selhero.cpp:99
+#: Source/DiabloUI/selhero.cpp:100
 msgid "New Hero"
 msgstr "Novi heroj"
 
-#: Source/DiabloUI/selhero.cpp:163
+#: Source/DiabloUI/selhero.cpp:164
 msgid "Choose Class"
 msgstr "Odaberi klasu"
 
-#: Source/DiabloUI/selhero.cpp:167 Source/panels/charpanel.cpp:22
+#: Source/DiabloUI/selhero.cpp:168 Source/panels/charpanel.cpp:22
 msgid "Warrior"
 msgstr "Ratnik"
 
-#: Source/DiabloUI/selhero.cpp:168 Source/panels/charpanel.cpp:23
+#: Source/DiabloUI/selhero.cpp:169 Source/panels/charpanel.cpp:23
 msgid "Rogue"
 msgstr "Lutalica"
 
-#: Source/DiabloUI/selhero.cpp:169 Source/panels/charpanel.cpp:24
+#: Source/DiabloUI/selhero.cpp:170 Source/panels/charpanel.cpp:24
 msgid "Sorcerer"
 msgstr "Čarobnjak"
 
-#: Source/DiabloUI/selhero.cpp:171 Source/panels/charpanel.cpp:25
+#: Source/DiabloUI/selhero.cpp:172 Source/panels/charpanel.cpp:25
 msgid "Monk"
 msgstr ""
 
-#: Source/DiabloUI/selhero.cpp:174 Source/panels/charpanel.cpp:26
+#: Source/DiabloUI/selhero.cpp:175 Source/panels/charpanel.cpp:26
 msgid "Bard"
 msgstr ""
 
-#: Source/DiabloUI/selhero.cpp:177 Source/panels/charpanel.cpp:27
+#: Source/DiabloUI/selhero.cpp:178 Source/panels/charpanel.cpp:27
 msgid "Barbarian"
 msgstr ""
 
-#: Source/DiabloUI/selhero.cpp:194 Source/DiabloUI/selhero.cpp:268
+#: Source/DiabloUI/selhero.cpp:195 Source/DiabloUI/selhero.cpp:269
 msgid "New Multi Player Hero"
 msgstr "Novi heroj među više igrača"
 
-#: Source/DiabloUI/selhero.cpp:194 Source/DiabloUI/selhero.cpp:268
+#: Source/DiabloUI/selhero.cpp:195 Source/DiabloUI/selhero.cpp:269
 msgid "New Single Player Hero"
 msgstr "Novi heroj jednog igrača"
 
-#: Source/DiabloUI/selhero.cpp:202
+#: Source/DiabloUI/selhero.cpp:203
 msgid "Save File Exists"
 msgstr "Datoteka spremanja postoji"
 
-#: Source/DiabloUI/selhero.cpp:205 Source/gamemenu.cpp:38
+#: Source/DiabloUI/selhero.cpp:206 Source/gamemenu.cpp:38
 msgid "Load Game"
 msgstr "Učitaj igru"
 
-#: Source/DiabloUI/selhero.cpp:206 Source/gamemenu.cpp:37
+#: Source/DiabloUI/selhero.cpp:207 Source/gamemenu.cpp:37
 #: Source/gamemenu.cpp:48
 msgid "New Game"
 msgstr "Nova igra"
 
-#: Source/DiabloUI/selhero.cpp:216 Source/DiabloUI/selhero.cpp:540
+#: Source/DiabloUI/selhero.cpp:217 Source/DiabloUI/selhero.cpp:551
 msgid "Single Player Characters"
 msgstr "Lik jednog igrača"
 
-#: Source/DiabloUI/selhero.cpp:262
+#: Source/DiabloUI/selhero.cpp:263
 msgid ""
 "The Rogue and Sorcerer are only available in the full retail version of "
 "Diablo. Visit https://www.gog.com/game/diablo to purchase."
@@ -697,11 +741,11 @@ msgstr ""
 "Čarobnjak i Lutalica samo su dostupni u cjelovitom maloprodajnom izdanju "
 "Diabla. Posjetite https://www.gog.com/game/diablo kako bi ga kupili."
 
-#: Source/DiabloUI/selhero.cpp:274 Source/DiabloUI/selhero.cpp:277
+#: Source/DiabloUI/selhero.cpp:275 Source/DiabloUI/selhero.cpp:278
 msgid "Enter Name"
 msgstr "Upiši ime"
 
-#: Source/DiabloUI/selhero.cpp:306
+#: Source/DiabloUI/selhero.cpp:307
 msgid ""
 "Invalid name. A name cannot contain spaces, reserved characters, or reserved "
 "words.\n"
@@ -710,124 +754,109 @@ msgstr ""
 "rezervirane riječi.\n"
 
 #. TRANSLATORS: Error Message
-#: Source/DiabloUI/selhero.cpp:313
+#: Source/DiabloUI/selhero.cpp:314
 msgid "Unable to create character."
 msgstr "Nemoguće stvaranje lika."
 
-#: Source/DiabloUI/selhero.cpp:467 Source/DiabloUI/selhero.cpp:470
+#: Source/DiabloUI/selhero.cpp:468 Source/DiabloUI/selhero.cpp:471
 msgid "Level:"
 msgstr "Razina:"
 
-#: Source/DiabloUI/selhero.cpp:475
+#: Source/DiabloUI/selhero.cpp:476
 msgid "Strength:"
 msgstr "Snaga:"
 
-#: Source/DiabloUI/selhero.cpp:480
+#: Source/DiabloUI/selhero.cpp:481
 msgid "Magic:"
 msgstr "Magija:"
 
-#: Source/DiabloUI/selhero.cpp:485
+#: Source/DiabloUI/selhero.cpp:486
 msgid "Dexterity:"
 msgstr "Vještina:"
 
-#: Source/DiabloUI/selhero.cpp:490
+#: Source/DiabloUI/selhero.cpp:491
 msgid "Vitality:"
 msgstr "Vitalnost:"
 
-#: Source/DiabloUI/selhero.cpp:496
+#: Source/DiabloUI/selhero.cpp:497
 #, fuzzy
 #| msgid "Save Game"
 msgid "Savegame:"
 msgstr "Spremi igru"
 
-#: Source/DiabloUI/selhero.cpp:508
+#: Source/DiabloUI/selhero.cpp:510
 msgid "Select Hero"
 msgstr "Odaberi heroja"
 
-#: Source/DiabloUI/selhero.cpp:528
+#: Source/DiabloUI/selhero.cpp:539
 msgid "Delete"
 msgstr "Obriši"
 
-#: Source/DiabloUI/selhero.cpp:538
+#: Source/DiabloUI/selhero.cpp:549
 msgid "Multi Player Characters"
 msgstr "Lik među više igrača"
 
-#: Source/DiabloUI/selhero.cpp:580
+#: Source/DiabloUI/selhero.cpp:599
 msgid "Delete Multi Player Hero"
 msgstr "Obriši heroja s više igrača"
 
-#: Source/DiabloUI/selhero.cpp:582
+#: Source/DiabloUI/selhero.cpp:601
 msgid "Delete Single Player Hero"
 msgstr "Obriši heroja jednog igrača"
 
-#: Source/DiabloUI/selhero.cpp:584
+#: Source/DiabloUI/selhero.cpp:603
 #, fuzzy
 #| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "Sigurno želite obrisati \"{:s}\" lik?"
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selstart.cpp:43
+#, fuzzy
+msgid "Enter Hellfire"
+msgstr "Zatvori Diablo"
+
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr "Da"
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr "Ne"
 
 #: Source/DiabloUI/support_lines.cpp:8
-msgid "GOG.com maintains a web site at https://www.gog.com/forum/diablo"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:9
-msgid "Follow the links to visit the discussion boards associated with Diablo."
+msgid ""
+"We maintain a chat server at Discord.gg/YQKCAYQ Follow the links to join our "
+"community where we talk about things related to Diablo, and the Hellfire "
+"expansion."
 msgstr ""
 
 #: Source/DiabloUI/support_lines.cpp:10
-msgid "and the Hellfire expansion."
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:12
 msgid ""
-"DevilutionX is maintained by Diasurgical, issues and bugs can be reported"
+"DevilutionX is maintained by Diasurgical, issues and bugs can be reported at "
+"this address: https://github.com/diasurgical/devilutionX To help us better "
+"serve you, please be sure to include the version number, operating system, "
+"and the nature of the problem."
 msgstr ""
 
 #: Source/DiabloUI/support_lines.cpp:13
-msgid "at this address: https://github.com/diasurgical/devilutionX"
+msgid "Disclaimer:"
 msgstr ""
 
 #: Source/DiabloUI/support_lines.cpp:14
 msgid ""
-"To help us better serve you, please be sure to include the version number,"
+"\tDevilutionX is not supported or maintained by Blizzard Entertainment, nor "
+"GOG.com. Neither Blizzard Entertainment nor GOG.com has tested or certified "
+"the quality or compatibility of DevilutionX. All inquiries regarding "
+"DevilutionX should be directed to Diasurgical, not to Blizzard Entertainment "
+"or GOG.com."
 msgstr ""
 
-#: Source/DiabloUI/support_lines.cpp:15
-msgid "operating system, and the nature of the problem."
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:18
-msgid "Disclaimer:"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:19
-msgid "  DevilutionX is not supported or maintained by Blizzard Entertainment,"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:20
-msgid "  nor GOG.com. Neither Blizzard Entertainment nor GOG.com has tested"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:21
+#: Source/DiabloUI/support_lines.cpp:17
 msgid ""
-"  or certified the quality or compatibility of DevilutionX. All inquiries"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:22
-msgid ""
-"  regarding DevilutionX should be directed to Diasurgical, not to Blizzard"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:23
-msgid "  Entertainment or GOG.com."
+"\tThis port makes use of CharisSILB, Unifont, and Noto which are licensed "
+"under the SIL Open Font License, as well as Twitmoji which is licensed under "
+"CC-BY 4.0. The port also makes use of SDL which is licensed under the zlib-"
+"license. See the ReadMe for further details."
 msgstr ""
 
 #: Source/DiabloUI/title.cpp:44
@@ -836,12 +865,12 @@ msgstr ""
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr "Autorsko pravo © 1996-2001 Blizzard Entertainment"
 
-#: Source/appfat.cpp:37
+#: Source/appfat.cpp:38
 msgid "Error"
 msgstr "Greška"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:101
+#: Source/appfat.cpp:102
 msgid ""
 "{:s}\n"
 "\n"
@@ -851,7 +880,7 @@ msgstr ""
 "\n"
 "Greška se dogodila na: {:s} redak {:d}"
 
-#: Source/appfat.cpp:115
+#: Source/appfat.cpp:117
 #, fuzzy
 #| msgid ""
 #| "Unable to open {:s}.\n"
@@ -867,16 +896,13 @@ msgstr ""
 "\n"
 "Provjerite nalazi li se u mapi igre i je li naziv datoteke u malim slovima."
 
-msgid "diabdat.mpq or spawn.mpq"
-msgstr "diabdat.mpq ili spawn.mpq"
-
-#: Source/appfat.cpp:119
+#: Source/appfat.cpp:123
 #, fuzzy
 msgid "Data File Error"
 msgstr "Greška, direktorij ima samo dozvolu čitanja"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:127
+#: Source/appfat.cpp:131
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -884,116 +910,138 @@ msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#: Source/appfat.cpp:129
+#: Source/appfat.cpp:133
 msgid "Read-Only Directory Error"
 msgstr "Greška, direktorij ima samo dozvolu čitanja"
 
-#: Source/automap.cpp:468
+#: Source/automap.cpp:484
 #, fuzzy
 msgid "game: "
 msgstr "Igra za više igrača"
 
-#: Source/automap.cpp:474
+#: Source/automap.cpp:490
 #, fuzzy
 msgid "password: "
 msgstr "Upiši lozinku"
 
-#: Source/automap.cpp:487
+#: Source/automap.cpp:492
+#, fuzzy
+#| msgid "Quit Diablo"
+msgid "Public Game"
+msgstr "Učitaj igru"
+
+#: Source/automap.cpp:504
 #, fuzzy
 msgid "Level: Nest {:d}"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/automap.cpp:489
+#: Source/automap.cpp:506
 #, fuzzy
 msgid "Level: Crypt {:d}"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/automap.cpp:491 Source/items.cpp:2086
+#: Source/automap.cpp:508 Source/items.cpp:2090
 #, fuzzy
 #| msgid "Level:"
 msgid "Level: {:d}"
 msgstr "Razina:"
 
-#: Source/control.cpp:196
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr ""
 
-#: Source/control.cpp:196
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr ""
 
-#: Source/control.cpp:196
+#: Source/control.cpp:212
 #, fuzzy
 #| msgid "Enter Name"
 msgid "Enter"
 msgstr "Upiši ime"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:215
 #, fuzzy
 msgid "Character Information"
 msgstr "Nemoguće stvaranje lika."
 
-#: Source/control.cpp:200
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr ""
 
-#: Source/control.cpp:201
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr ""
 
-#: Source/control.cpp:202
+#: Source/control.cpp:218
 #, fuzzy
 msgid "Main Menu"
 msgstr "Prijašnji izbornik"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr ""
 
-#: Source/control.cpp:204
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr ""
 
-#: Source/control.cpp:205
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr ""
 
-#: Source/control.cpp:712 Source/control.cpp:1175
+#: Source/control.cpp:718 Source/control.cpp:1587
+msgid "Skill"
+msgstr ""
+
+#: Source/control.cpp:719 Source/control.cpp:1237
 #, fuzzy
 msgid "{:s} Skill"
 msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#: Source/control.cpp:716 Source/control.cpp:1179
+#: Source/control.cpp:725
+#, fuzzy
+msgid "Spell"
+msgstr ""
+"Nemoguće zapisivanje lokacije:\n"
+"{:s}"
+
+#: Source/control.cpp:726 Source/control.cpp:1241
 #, fuzzy
 msgid "{:s} Spell"
 msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#: Source/control.cpp:718
+#: Source/control.cpp:728
 #, fuzzy
 msgid "Damages undead only"
 msgstr "Greška, direktorij ima samo dozvolu čitanja"
 
-#: Source/control.cpp:722 Source/control.cpp:1183 Source/control.cpp:1554
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr ""
 
-#: Source/control.cpp:724 Source/control.cpp:1185 Source/control.cpp:1556
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 #, fuzzy
 msgid "Spell Level {:d}"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/control.cpp:729 Source/control.cpp:1189
+#: Source/control.cpp:741
+#, fuzzy
+msgid "Scroll"
+msgstr "Podržano igrača: {:d}"
+
+#: Source/control.cpp:742 Source/control.cpp:1251
 #, fuzzy
 msgid "Scroll of {:s}"
 msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#: Source/control.cpp:745 Source/control.cpp:1206
+#: Source/control.cpp:747 Source/control.cpp:1257
 #, fuzzy
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
@@ -1001,14 +1049,19 @@ msgstr[0] "Podržano igrača: {:d}"
 msgstr[1] ""
 msgstr[2] ""
 
-#: Source/control.cpp:750 Source/control.cpp:1210 Source/items.cpp:1325
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
+msgid "Staff"
+msgstr ""
+
+#: Source/control.cpp:755 Source/control.cpp:1261
 #, fuzzy
 msgid "Staff of {:s}"
 msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#: Source/control.cpp:752 Source/control.cpp:1212
+#: Source/control.cpp:757 Source/control.cpp:1263
 #, fuzzy
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
@@ -1016,42 +1069,42 @@ msgstr[0] "Podržano igrača: {:d}"
 msgstr[1] ""
 msgstr[2] ""
 
-#: Source/control.cpp:762
+#: Source/control.cpp:767
 #, fuzzy
 msgid "Spell Hotkey {:s}"
 msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#: Source/control.cpp:1152
+#: Source/control.cpp:1214
 #, fuzzy
 msgid "Player friendly"
 msgstr "Igra za više igrača"
 
-#: Source/control.cpp:1154
+#: Source/control.cpp:1216
 #, fuzzy
 msgid "Player attack"
 msgstr "Jedan igrač"
 
-#: Source/control.cpp:1157
+#: Source/control.cpp:1219
 #, fuzzy
 msgid "Hotkey: {:s}"
 msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#: Source/control.cpp:1165
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr ""
 
-#: Source/control.cpp:1168
+#: Source/control.cpp:1230
 #, fuzzy
 msgid "Hotkey: 's'"
 msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#: Source/control.cpp:1334 Source/inv.cpp:1893 Source/items.cpp:3751
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 #, fuzzy
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
@@ -1059,33 +1112,29 @@ msgstr[0] "Podržano igrača: {:d}"
 msgstr[1] ""
 msgstr[2] ""
 
-#: Source/control.cpp:1337
+#: Source/control.cpp:1390
 #, fuzzy
 #| msgid "Requirements:"
 msgid "Requirements not met"
 msgstr "Zahtjevi:"
 
-#: Source/control.cpp:1373
+#: Source/control.cpp:1426
 #, fuzzy
 msgid "{:s}, Level: {:d}"
 msgstr "Razina:"
 
-#: Source/control.cpp:1375
+#: Source/control.cpp:1428
 #, fuzzy
 msgid "Hit Points {:d} of {:d}"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/control.cpp:1402
+#: Source/control.cpp:1457
 #, fuzzy
 #| msgid "Level:"
 msgid "Level Up"
 msgstr "Razina:"
 
-#: Source/control.cpp:1532
-msgid "Skill"
-msgstr ""
-
-#: Source/control.cpp:1536
+#: Source/control.cpp:1591
 #, fuzzy
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
@@ -1094,7 +1143,7 @@ msgstr[1] ""
 msgstr[2] ""
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1544
+#: Source/control.cpp:1601
 #, fuzzy
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr ""
@@ -1103,17 +1152,17 @@ msgstr ""
 "Greška se dogodila na: {:s} redak {:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1546
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr ""
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1549
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr ""
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1606
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] ""
@@ -1170,53 +1219,53 @@ msgstr ""
 msgid "level 15"
 msgstr "Razina:"
 
-#: Source/diablo.cpp:111
+#: Source/diablo.cpp:114
 msgid "I need help! Come Here!"
 msgstr ""
 
-#: Source/diablo.cpp:112
+#: Source/diablo.cpp:115
 msgid "Follow me."
 msgstr ""
 
-#: Source/diablo.cpp:113
+#: Source/diablo.cpp:116
 msgid "Here's something for you."
 msgstr ""
 
-#: Source/diablo.cpp:114
+#: Source/diablo.cpp:117
 msgid "Now you DIE!"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:777
+#: Source/diablo.cpp:781
 #, fuzzy
 #| msgid "Options"
 msgid "Options:\n"
 msgstr "Mogućnosti"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:778
+#: Source/diablo.cpp:782
 #, fuzzy
 msgid "Print this message and exit"
 msgstr "Zatvori Diablo"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:779
+#: Source/diablo.cpp:783
 #, fuzzy
 msgid "Print the version and exit"
 msgstr "Zatvori Diablo"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:780
+#: Source/diablo.cpp:784
 msgid "Specify the folder of diabdat.mpq"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:781
+#: Source/diablo.cpp:785
 msgid "Specify the folder of save files"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:782
+#: Source/diablo.cpp:786
 #, fuzzy
 msgid "Specify the location of diablo.ini"
 msgstr ""
@@ -1224,59 +1273,66 @@ msgstr ""
 "{:s}"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:783
-msgid "Specify the location of the .ttf font"
-msgstr ""
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:784
-msgid "Specify the name of a custom .ttf font"
-msgstr ""
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:785
+#: Source/diablo.cpp:787
 msgid "Skip startup videos"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:786
+#: Source/diablo.cpp:788
 msgid "Display frames per second"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:787
+#: Source/diablo.cpp:789
 msgid "Run in windowed mode"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:788
+#: Source/diablo.cpp:790
 msgid "Enable verbose logging"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:789
-msgid "Force spawn mode even if diabdat.mpq is found"
-msgstr ""
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:790
+#: Source/diablo.cpp:791
 #, fuzzy
 msgid "Record a demo file"
 msgstr "Datoteka spremanja postoji"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:791
+#: Source/diablo.cpp:792
 #, fuzzy
 msgid "Play a demo file"
 msgstr "Datoteka spremanja postoji"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:792
+#: Source/diablo.cpp:793
 msgid "Disable all frame limiting during demo playback"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:793
+#: Source/diablo.cpp:794
+msgid ""
+"\n"
+"Game selection:\n"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:795
+msgid "Force Shareware mode"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:796
+msgid "Force Diablo mode"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:797
+msgid "Force Hellfire mode"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:798
 #, fuzzy
 msgid ""
 "\n"
@@ -1284,16 +1340,11 @@ msgid ""
 msgstr "Mogućnosti"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:794
-msgid "Force diablo mode even if hellfire.mpq is found"
-msgstr ""
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:795
+#: Source/diablo.cpp:799
 msgid "Use alternate nest palette"
 msgstr ""
 
-#: Source/diablo.cpp:801
+#: Source/diablo.cpp:805
 msgid ""
 "\n"
 "Report bugs at https://github.com/diasurgical/devilutionX/\n"
@@ -1313,305 +1364,305 @@ msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#: Source/diablo.cpp:1206
+#: Source/diablo.cpp:1218
 #, fuzzy
 msgid "-- Network timeout --"
 msgstr "Naručivanje mrežnih informacijskih usluga"
 
-#: Source/diablo.cpp:1207
+#: Source/diablo.cpp:1219
 #, fuzzy
 msgid "-- Waiting for players --"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/diablo.cpp:1226
+#: Source/diablo.cpp:1238
 msgid "No help available"
 msgstr ""
 
-#: Source/diablo.cpp:1227
+#: Source/diablo.cpp:1239
 msgid "while in stores"
 msgstr ""
 
 #. TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty.
-#: Source/diablo.cpp:1439
+#: Source/diablo.cpp:1451
 #, fuzzy
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#: Source/dvlnet/loopback.cpp:111
+#: Source/dvlnet/loopback.cpp:113
 #, fuzzy
 #| msgid "Loopback"
 msgid "loopback"
 msgstr "Izvanmrežno"
 
-#: Source/dvlnet/tcp_client.cpp:68
+#: Source/dvlnet/tcp_client.cpp:65
 #, fuzzy
 #| msgid "Unable to create character."
 msgid "Unable to connect"
 msgstr "Nemoguće stvaranje lika."
 
-#: Source/dvlnet/tcp_client.cpp:89
+#: Source/dvlnet/tcp_client.cpp:86
 msgid "error: read 0 bytes from server"
 msgstr ""
 
-#: Source/error.cpp:58
+#: Source/error.cpp:57
 #, fuzzy
 msgid "No automap available in town"
 msgstr "Ponovno pokreni u gradu"
 
-#: Source/error.cpp:59
+#: Source/error.cpp:58
 msgid "No multiplayer functions in demo"
 msgstr ""
 
-#: Source/error.cpp:60
+#: Source/error.cpp:59
 msgid "Direct Sound Creation Failed"
 msgstr ""
 
-#: Source/error.cpp:61
+#: Source/error.cpp:60
 msgid "Not available in shareware version"
 msgstr ""
 
-#: Source/error.cpp:62
+#: Source/error.cpp:61
 #, fuzzy
 msgid "Not enough space to save"
 msgstr "Datoteka spremanja postoji"
 
-#: Source/error.cpp:63
+#: Source/error.cpp:62
 #, fuzzy
 msgid "No Pause in town"
 msgstr "Pauziraj"
 
-#: Source/error.cpp:64
+#: Source/error.cpp:63
 msgid "Copying to a hard disk is recommended"
 msgstr ""
 
-#: Source/error.cpp:65
+#: Source/error.cpp:64
 msgid "Multiplayer sync problem"
 msgstr ""
 
-#: Source/error.cpp:66
+#: Source/error.cpp:65
 #, fuzzy
 msgid "No pause in multiplayer"
 msgstr "Pauziraj"
 
-#: Source/error.cpp:67
+#: Source/error.cpp:66
 msgid "Loading..."
 msgstr ""
 
-#: Source/error.cpp:68
+#: Source/error.cpp:67
 msgid "Saving..."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:69
+#: Source/error.cpp:68
 msgid "Some are weakened as one grows strong"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:70
+#: Source/error.cpp:69
 msgid "New strength is forged through destruction"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:71
+#: Source/error.cpp:70
 msgid "Those who defend seldom attack"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:72
+#: Source/error.cpp:71
 msgid "The sword of justice is swift and sharp"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:73
+#: Source/error.cpp:72
 msgid "While the spirit is vigilant the body thrives"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:74
+#: Source/error.cpp:73
 msgid "The powers of mana refocused renews"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:75
+#: Source/error.cpp:74
 msgid "Time cannot diminish the power of steel"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:76
+#: Source/error.cpp:75
 msgid "Magic is not always what it seems to be"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:77
+#: Source/error.cpp:76
 msgid "What once was opened now is closed"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:78
+#: Source/error.cpp:77
 msgid "Intensity comes at the cost of wisdom"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:79
+#: Source/error.cpp:78
 msgid "Arcane power brings destruction"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:80
+#: Source/error.cpp:79
 msgid "That which cannot be held cannot be harmed"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:81
+#: Source/error.cpp:80
 msgid "Crimson and Azure become as the sun"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:82
+#: Source/error.cpp:81
 msgid "Knowledge and wisdom at the cost of self"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:83
+#: Source/error.cpp:82
 msgid "Drink and be refreshed"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:84
+#: Source/error.cpp:83
 msgid "Wherever you go, there you are"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:85
+#: Source/error.cpp:84
 msgid "Energy comes at the cost of wisdom"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:86
+#: Source/error.cpp:85
 msgid "Riches abound when least expected"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:87
+#: Source/error.cpp:86
 msgid "Where avarice fails, patience gains reward"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:88
+#: Source/error.cpp:87
 msgid "Blessed by a benevolent companion!"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:89
+#: Source/error.cpp:88
 msgid "The hands of men may be guided by fate"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:90
+#: Source/error.cpp:89
 msgid "Strength is bolstered by heavenly faith"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:91
+#: Source/error.cpp:90
 msgid "The essence of life flows from within"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:92
+#: Source/error.cpp:91
 msgid "The way is made clear when viewed from above"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:93
+#: Source/error.cpp:92
 msgid "Salvation comes at the cost of wisdom"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:94
+#: Source/error.cpp:93
 msgid "Mysteries are revealed in the light of reason"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:95
+#: Source/error.cpp:94
 msgid "Those who are last may yet be first"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:96
+#: Source/error.cpp:95
 msgid "Generosity brings its own rewards"
 msgstr ""
 
-#: Source/error.cpp:97
+#: Source/error.cpp:96
 msgid "You must be at least level 8 to use this."
 msgstr ""
 
-#: Source/error.cpp:98
+#: Source/error.cpp:97
 msgid "You must be at least level 13 to use this."
 msgstr ""
 
-#: Source/error.cpp:99
+#: Source/error.cpp:98
 msgid "You must be at least level 17 to use this."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:100
+#: Source/error.cpp:99
 msgid "Arcane knowledge gained!"
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:101
+#: Source/error.cpp:100
 msgid "That which does not kill you..."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:102
+#: Source/error.cpp:101
 msgid "Knowledge is power."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:103
+#: Source/error.cpp:102
 msgid "Give and you shall receive."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:104
+#: Source/error.cpp:103
 msgid "Some experience is gained by touch."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:105
+#: Source/error.cpp:104
 msgid "There's no place like home."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:106
+#: Source/error.cpp:105
 msgid "Spiritual energy is restored."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:107
+#: Source/error.cpp:106
 msgid "You feel more agile."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:108
+#: Source/error.cpp:107
 msgid "You feel stronger."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:109
+#: Source/error.cpp:108
 msgid "You feel wiser."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:110
+#: Source/error.cpp:109
 msgid "You feel refreshed."
 msgstr ""
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:111
+#: Source/error.cpp:110
 msgid "That which can break will."
 msgstr ""
 
@@ -1640,10 +1691,6 @@ msgstr "Gama"
 #: Source/gamemenu.cpp:60 Source/gamemenu.cpp:167
 msgid "Speed"
 msgstr ""
-
-#: Source/gamemenu.cpp:61
-msgid "Previous Menu"
-msgstr "Prijašnji izbornik"
 
 #: Source/gamemenu.cpp:68
 msgid "Music Disabled"
@@ -1809,7 +1856,7 @@ msgid ""
 msgstr ""
 
 #: Source/help.cpp:68
-msgid "$Gold"
+msgid "$Gold:"
 msgstr ""
 
 #: Source/help.cpp:69
@@ -1832,7 +1879,7 @@ msgid ""
 msgstr ""
 
 #: Source/help.cpp:79
-msgid "$Using the Speedbook for Spells"
+msgid "$Using the Speedbook for Spells:"
 msgstr ""
 
 #: Source/help.cpp:80
@@ -1845,12 +1892,15 @@ msgstr ""
 #: Source/help.cpp:84
 msgid ""
 "Shift + Left-clicking on the 'select current spell' button will clear the "
-"readied spell"
+"readied spell."
 msgstr ""
 
 #: Source/help.cpp:86
-msgid "$Setting Spell Hotkeys"
+#, fuzzy
+msgid "$Setting Spell Hotkeys:"
 msgstr ""
+"Nemoguće zapisivanje lokacije:\n"
+"{:s}"
 
 #: Source/help.cpp:87
 msgid ""
@@ -1860,8 +1910,11 @@ msgid ""
 msgstr ""
 
 #: Source/help.cpp:92
-msgid "$Spell Books"
+#, fuzzy
+msgid "$Spell Books:"
 msgstr ""
+"Nemoguće zapisivanje lokacije:\n"
+"{:s}"
 
 #: Source/help.cpp:93
 msgid ""
@@ -1869,45 +1922,49 @@ msgid ""
 "you to cast the spell more effectively."
 msgstr ""
 
-#: Source/help.cpp:130
+#: Source/help.cpp:181
 msgid "Shareware Hellfire Help"
 msgstr ""
 
-#: Source/help.cpp:130
+#: Source/help.cpp:181
 msgid "Hellfire Help"
 msgstr ""
 
-#: Source/help.cpp:132
+#: Source/help.cpp:183
 #, fuzzy
 msgid "Shareware Diablo Help"
 msgstr "Diablo udarni tim"
 
-#: Source/help.cpp:132
+#: Source/help.cpp:183
 #, fuzzy
 msgid "Diablo Help"
 msgstr "Zatvori Diablo"
 
-#: Source/help.cpp:156
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr ""
 
-#: Source/init.cpp:214
+#: Source/init.cpp:175
+msgid "diabdat.mpq or spawn.mpq"
+msgstr "diabdat.mpq ili spawn.mpq"
+
+#: Source/init.cpp:196
 msgid "Some Hellfire MPQs are missing"
 msgstr ""
 
-#: Source/init.cpp:214
+#: Source/init.cpp:196
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
 msgstr ""
 
-#: Source/init.cpp:224
+#: Source/init.cpp:204
 #, fuzzy
 #| msgid "Unable to create character."
 msgid "Unable to create main window"
 msgstr "Nemoguće stvaranje lika."
 
-#: Source/itemdat.cpp:16 Source/itemdat.cpp:198 Source/panels/charpanel.cpp:154
+#: Source/itemdat.cpp:16 Source/itemdat.cpp:198 Source/panels/charpanel.cpp:155
 msgid "Gold"
 msgstr ""
 
@@ -2053,7 +2110,7 @@ msgstr ""
 msgid "Scroll of Resurrect"
 msgstr ""
 
-#: Source/itemdat.cpp:51 Source/itemdat.cpp:99 Source/items.cpp:164
+#: Source/itemdat.cpp:51 Source/itemdat.cpp:99 Source/items.cpp:166
 msgid "Blacksmith Oil"
 msgstr ""
 
@@ -2153,7 +2210,7 @@ msgid "Quilted Armor"
 msgstr ""
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
-#: Source/itemdat.cpp:77 Source/objects.cpp:5459
+#: Source/itemdat.cpp:77 Source/objects.cpp:5433
 msgid "Armor"
 msgstr ""
 
@@ -2249,11 +2306,11 @@ msgstr ""
 msgid "Potion of Full Rejuvenation"
 msgstr ""
 
-#: Source/itemdat.cpp:100 Source/items.cpp:159
+#: Source/itemdat.cpp:100 Source/items.cpp:161
 msgid "Oil of Accuracy"
 msgstr ""
 
-#: Source/itemdat.cpp:101 Source/items.cpp:161
+#: Source/itemdat.cpp:101 Source/items.cpp:163
 msgid "Oil of Sharpness"
 msgstr ""
 
@@ -2488,11 +2545,6 @@ msgstr ""
 msgid "Long War Bow"
 msgstr ""
 
-#: Source/itemdat.cpp:167 Source/itemdat.cpp:168 Source/itemdat.cpp:169
-#: Source/itemdat.cpp:170 Source/itemdat.cpp:171
-msgid "Staff"
-msgstr ""
-
 #: Source/itemdat.cpp:168
 msgid "Long Staff"
 msgstr ""
@@ -2584,7 +2636,7 @@ msgstr ""
 msgid "Meteoric"
 msgstr ""
 
-#: Source/itemdat.cpp:202 Source/objects.cpp:104
+#: Source/itemdat.cpp:202 Source/objects.cpp:107
 msgid "Weird"
 msgstr ""
 
@@ -2722,7 +2774,7 @@ msgstr ""
 msgid "Awesome"
 msgstr ""
 
-#: Source/itemdat.cpp:237 Source/objects.cpp:116
+#: Source/itemdat.cpp:237 Source/objects.cpp:119
 msgid "Holy"
 msgstr ""
 
@@ -3721,273 +3773,303 @@ msgstr ""
 msgid "Gladiator's Ring"
 msgstr "Prsten od tisuće"
 
-#: Source/items.cpp:160
+#: Source/items.cpp:162
 msgid "Oil of Mastery"
 msgstr ""
 
-#: Source/items.cpp:162
+#: Source/items.cpp:164
 msgid "Oil of Death"
 msgstr ""
 
-#: Source/items.cpp:163
+#: Source/items.cpp:165
 msgid "Oil of Skill"
 msgstr ""
 
-#: Source/items.cpp:165
+#: Source/items.cpp:167
 msgid "Oil of Fortitude"
 msgstr ""
 
-#: Source/items.cpp:166
+#: Source/items.cpp:168
 msgid "Oil of Permanence"
 msgstr ""
 
-#: Source/items.cpp:167
+#: Source/items.cpp:169
 msgid "Oil of Hardening"
 msgstr ""
 
-#: Source/items.cpp:168
+#: Source/items.cpp:170
 msgid "Oil of Imperviousness"
 msgstr ""
 
-#. TRANSLATORS: Constructs item names. Format: <Prefix> <Item> of <Suffix>. Example: King's Long Sword of the Whale
-#: Source/items.cpp:1194 Source/items.cpp:1262 Source/items.cpp:1281
-#: Source/items.cpp:1324
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
 #, fuzzy
-msgid "{:s} of {:s}"
+msgctxt "spell"
+msgid "{0} of {1}"
 msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#: Source/items.cpp:1902 Source/items.cpp:1914
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+#, fuzzy
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr ""
+"Nemoguće zapisivanje lokacije:\n"
+"{:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+#, fuzzy
+msgid "{0} {1} of {2}"
+msgstr ""
+"Nemoguće zapisivanje lokacije:\n"
+"{:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
+#: Source/items.cpp:1217
+msgid "{0} {1}"
+msgstr ""
+
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
+#, fuzzy
+msgid "{0} of {1}"
+msgstr ""
+"Nemoguće zapisivanje lokacije:\n"
+"{:s}"
+
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr ""
 
-#: Source/items.cpp:1904
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr ""
 
-#: Source/items.cpp:1908
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr ""
 
-#: Source/items.cpp:1910
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr ""
 
-#: Source/items.cpp:1916
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr ""
 
-#: Source/items.cpp:1920
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr ""
 
-#: Source/items.cpp:1922
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr ""
 
-#: Source/items.cpp:1926
+#: Source/items.cpp:1930
 #, fuzzy
 msgid "reduces attributes needed"
 msgstr "pristupnik nije potreban"
 
-#: Source/items.cpp:1928
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr ""
 
-#: Source/items.cpp:1932
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr ""
 
-#: Source/items.cpp:1934
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr ""
 
-#: Source/items.cpp:1938
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr ""
 
-#: Source/items.cpp:1940
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr ""
 
-#: Source/items.cpp:1944
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr ""
 
-#: Source/items.cpp:1948
+#: Source/items.cpp:1952
 #, fuzzy
 msgid "increases the armor class"
 msgstr "Odaberi klasu"
 
-#: Source/items.cpp:1950
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr ""
 
-#: Source/items.cpp:1954
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr ""
 
-#: Source/items.cpp:1956
+#: Source/items.cpp:1960
 #, fuzzy
 msgid "class of armor and shields"
 msgstr "Odaberi klasu"
 
-#: Source/items.cpp:1960 Source/items.cpp:1969
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr ""
 
-#: Source/items.cpp:1965
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr ""
 
-#: Source/items.cpp:1973
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr ""
 
-#: Source/items.cpp:1977
+#: Source/items.cpp:1981
 msgid "restore all life"
 msgstr ""
 
-#: Source/items.cpp:1981
+#: Source/items.cpp:1985
 msgid "restore some life"
 msgstr ""
 
-#: Source/items.cpp:1985
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr ""
 
-#: Source/items.cpp:1989
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr ""
 
-#: Source/items.cpp:1993
+#: Source/items.cpp:1997
 msgid "restore some mana"
 msgstr ""
 
-#: Source/items.cpp:1997
+#: Source/items.cpp:2001
 msgid "restore all mana"
 msgstr ""
 
-#: Source/items.cpp:2001
+#: Source/items.cpp:2005
 #, fuzzy
 msgid "increase strength"
 msgstr "Snaga:"
 
-#: Source/items.cpp:2005
+#: Source/items.cpp:2009
 #, fuzzy
 msgid "increase magic"
 msgstr "Magija:"
 
-#: Source/items.cpp:2009
+#: Source/items.cpp:2013
 #, fuzzy
 msgid "increase dexterity"
 msgstr "Vještina:"
 
-#: Source/items.cpp:2013
+#: Source/items.cpp:2017
 #, fuzzy
 msgid "increase vitality"
 msgstr "Vitalnost:"
 
-#: Source/items.cpp:2018
+#: Source/items.cpp:2022
 #, fuzzy
 msgid "decrease strength"
 msgstr "Snaga:"
 
-#: Source/items.cpp:2022
+#: Source/items.cpp:2026
 #, fuzzy
 msgid "decrease dexterity"
 msgstr "Vještina:"
 
-#: Source/items.cpp:2026
+#: Source/items.cpp:2030
 #, fuzzy
 msgid "decrease vitality"
 msgstr "Vitalnost:"
 
-#: Source/items.cpp:2030
+#: Source/items.cpp:2034
 msgid "restore some life and mana"
 msgstr ""
 
-#: Source/items.cpp:2034
+#: Source/items.cpp:2038
 msgid "restore all life and mana"
 msgstr ""
 
-#: Source/items.cpp:2049 Source/items.cpp:2074
+#: Source/items.cpp:2053 Source/items.cpp:2078
 #, fuzzy
 msgid "Right-click to read"
 msgstr "Greška, direktorij ima samo dozvolu čitanja"
 
-#: Source/items.cpp:2053
+#: Source/items.cpp:2057
 #, fuzzy
 msgid "Right-click to read, then"
 msgstr "Greška, direktorij ima samo dozvolu čitanja"
 
-#: Source/items.cpp:2055
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr ""
 
-#: Source/items.cpp:2060
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr ""
 
-#: Source/items.cpp:2065 Source/items.cpp:2070
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr ""
 
-#: Source/items.cpp:2078
+#: Source/items.cpp:2082
 #, fuzzy
 msgid "Right click to read"
 msgstr "Greška, direktorij ima samo dozvolu čitanja"
 
-#: Source/items.cpp:2082
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr ""
 
-#: Source/items.cpp:2090
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr ""
 
-#: Source/items.cpp:2102 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 #, fuzzy
 #| msgid "Requirements:"
 msgid "Required:"
 msgstr "Zahtjevi:"
 
-#: Source/items.cpp:2104 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 #, fuzzy
 msgid " {:d} Str"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:2106 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 #, fuzzy
 msgid " {:d} Mag"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:2108 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 #, fuzzy
 msgid " {:d} Dex"
 msgstr "Podržano igrača: {:d}"
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3535 Source/player.cpp:3042
+#: Source/items.cpp:3533 Source/player.cpp:3018
 #, fuzzy
 msgid "Ear of {:s}"
 msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#: Source/items.cpp:3830
+#: Source/items.cpp:3828
 #, fuzzy
 msgid "chance to hit: {:+d}%"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:3834
+#: Source/items.cpp:3832
 #, fuzzy, no-c-format
 msgid "{:+d}% damage"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:3838 Source/items.cpp:4094
+#: Source/items.cpp:3836 Source/items.cpp:4092
 #, fuzzy
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr ""
@@ -3995,191 +4077,188 @@ msgstr ""
 "\n"
 "Greška se dogodila na: {:s} redak {:d}"
 
-#: Source/items.cpp:3842
+#: Source/items.cpp:3840
 #, fuzzy, no-c-format
 msgid "{:+d}% armor"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:3846
+#: Source/items.cpp:3844
 #, fuzzy
 msgid "armor class: {:d}"
 msgstr "Odaberi klasu"
 
-#: Source/items.cpp:3851 Source/items.cpp:4076
+#: Source/items.cpp:3849 Source/items.cpp:4074
 #, fuzzy
 msgid "Resist Fire: {:+d}%"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:3853
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr ""
 
-#: Source/items.cpp:3858
+#: Source/items.cpp:3856
 #, fuzzy
 msgid "Resist Lightning: {:+d}%"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:3860
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr ""
 
-#: Source/items.cpp:3865
+#: Source/items.cpp:3863
 #, fuzzy
 msgid "Resist Magic: {:+d}%"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:3867
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr ""
 
-#: Source/items.cpp:3872
+#: Source/items.cpp:3870
 #, fuzzy
 msgid "Resist All: {:+d}%"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:3874
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr ""
 
-#: Source/items.cpp:3878
+#: Source/items.cpp:3876
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: Source/items.cpp:3880
+#: Source/items.cpp:3878
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: Source/items.cpp:3882
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr ""
 
-#: Source/items.cpp:3885
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr ""
 
-#: Source/items.cpp:3888
-#, fuzzy
+#: Source/items.cpp:3886
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] ""
-"Nemoguće zapisivanje lokacije:\n"
-"{:s}"
 msgstr[1] ""
 msgstr[2] ""
 
-#: Source/items.cpp:3892
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr ""
 
-#: Source/items.cpp:3894
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3898
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr ""
 
-#: Source/items.cpp:3900
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3904
+#: Source/items.cpp:3902
 #, fuzzy
 msgid "{:+d} to strength"
 msgstr "Snaga:"
 
-#: Source/items.cpp:3908
+#: Source/items.cpp:3906
 #, fuzzy
 msgid "{:+d} to magic"
 msgstr "Magija:"
 
-#: Source/items.cpp:3912
+#: Source/items.cpp:3910
 #, fuzzy
 msgid "{:+d} to dexterity"
 msgstr "Vještina:"
 
-#: Source/items.cpp:3916
+#: Source/items.cpp:3914
 #, fuzzy
 msgid "{:+d} to vitality"
 msgstr "Vitalnost:"
 
-#: Source/items.cpp:3920
+#: Source/items.cpp:3918
 #, fuzzy
 msgid "{:+d} to all attributes"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:3924
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr ""
 
-#: Source/items.cpp:3928
+#: Source/items.cpp:3926
 #, fuzzy
 msgid "Hit Points: {:+d}"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:3932
+#: Source/items.cpp:3930
 #, fuzzy
 msgid "Mana: {:+d}"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:3935
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr ""
 
-#: Source/items.cpp:3938
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr ""
 
-#: Source/items.cpp:3941
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr ""
 
-#: Source/items.cpp:3944
+#: Source/items.cpp:3942
 #, fuzzy, no-c-format
 msgid "+{:d}% light radius"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:3947
+#: Source/items.cpp:3945
 #, fuzzy, no-c-format
 msgid "-{:d}% light radius"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:3950
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr ""
 
-#: Source/items.cpp:3954
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr ""
 
-#: Source/items.cpp:3956
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3960
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr ""
 
-#: Source/items.cpp:3962
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3966
+#: Source/items.cpp:3964
 #, fuzzy
 msgid "fireball damage: {:d}"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:3968
+#: Source/items.cpp:3966
 #, fuzzy
 msgid "fireball damage: {:d}-{:d}"
 msgstr ""
@@ -4187,147 +4266,147 @@ msgstr ""
 "\n"
 "Greška se dogodila na: {:s} redak {:d}"
 
-#: Source/items.cpp:3971
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr ""
 
-#: Source/items.cpp:3974
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr ""
 
-#: Source/items.cpp:3977
+#: Source/items.cpp:3975
 msgid "you can't heal"
 msgstr ""
 
-#: Source/items.cpp:3980
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr ""
 
-#: Source/items.cpp:3983
+#: Source/items.cpp:3981
 msgid "knocks target back"
 msgstr ""
 
-#: Source/items.cpp:3986
+#: Source/items.cpp:3984
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr ""
 
-#: Source/items.cpp:3989
+#: Source/items.cpp:3987
 msgid "All Resistance equals 0"
 msgstr ""
 
-#: Source/items.cpp:3992
+#: Source/items.cpp:3990
 msgid "hit monster doesn't heal"
 msgstr ""
 
-#: Source/items.cpp:3996
+#: Source/items.cpp:3994
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr ""
 
-#: Source/items.cpp:3998
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr ""
 
-#: Source/items.cpp:4002
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr ""
 
-#: Source/items.cpp:4004
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr ""
 
-#: Source/items.cpp:4007
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr ""
 
-#: Source/items.cpp:4011
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr ""
 
-#: Source/items.cpp:4013
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr ""
 
-#: Source/items.cpp:4015
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr ""
 
-#: Source/items.cpp:4017
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr ""
 
-#: Source/items.cpp:4021
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr ""
 
-#: Source/items.cpp:4023
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr ""
 
-#: Source/items.cpp:4025
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr ""
 
-#: Source/items.cpp:4028
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr ""
 
-#: Source/items.cpp:4031
+#: Source/items.cpp:4029
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: Source/items.cpp:4034
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr ""
 
-#: Source/items.cpp:4037
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr ""
 
-#: Source/items.cpp:4040
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr ""
 
-#: Source/items.cpp:4043
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr ""
 
-#: Source/items.cpp:4046
+#: Source/items.cpp:4044
 #, fuzzy
 #| msgid "Enter Password"
 msgid "one handed sword"
 msgstr "Prsten od tisuće"
 
-#: Source/items.cpp:4049
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr ""
 
-#: Source/items.cpp:4052
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr ""
 
-#: Source/items.cpp:4055
+#: Source/items.cpp:4053
 #, fuzzy
 msgid "no strength requirement"
 msgstr "Snaga:"
 
-#: Source/items.cpp:4058
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr ""
 
-#: Source/items.cpp:4065
+#: Source/items.cpp:4063
 #, fuzzy
 msgid "lightning damage: {:d}"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:4067
+#: Source/items.cpp:4065
 #, fuzzy
 msgid "lightning damage: {:d}-{:d}"
 msgstr ""
@@ -4335,62 +4414,62 @@ msgstr ""
 "\n"
 "Greška se dogodila na: {:s} redak {:d}"
 
-#: Source/items.cpp:4070
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr ""
 
-#: Source/items.cpp:4079
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr ""
 
-#: Source/items.cpp:4082
+#: Source/items.cpp:4080
 #, fuzzy, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:4085
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr ""
 
-#: Source/items.cpp:4088
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr ""
 
-#: Source/items.cpp:4091
+#: Source/items.cpp:4089
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr ""
 
-#: Source/items.cpp:4097
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr ""
 
-#: Source/items.cpp:4100
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr ""
 
-#: Source/items.cpp:4103
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr ""
 
-#: Source/items.cpp:4106
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr ""
 
-#: Source/items.cpp:4109
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr ""
 
-#: Source/items.cpp:4146 Source/items.cpp:4193
+#: Source/items.cpp:4144 Source/items.cpp:4191
 #, fuzzy
 msgid "damage: {:d}  Indestructible"
 msgstr "Podržano igrača: {:d}"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4148 Source/items.cpp:4195
+#: Source/items.cpp:4146 Source/items.cpp:4193
 #, fuzzy
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr ""
@@ -4398,7 +4477,7 @@ msgstr ""
 "\n"
 "Greška se dogodila na: {:s} redak {:d}"
 
-#: Source/items.cpp:4151 Source/items.cpp:4198
+#: Source/items.cpp:4149 Source/items.cpp:4196
 #, fuzzy
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr ""
@@ -4407,7 +4486,7 @@ msgstr ""
 "Greška se dogodila na: {:s} redak {:d}"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4153 Source/items.cpp:4200
+#: Source/items.cpp:4151 Source/items.cpp:4198
 #, fuzzy
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr ""
@@ -4415,13 +4494,13 @@ msgstr ""
 "\n"
 "Greška se dogodila na: {:s} redak {:d}"
 
-#: Source/items.cpp:4159 Source/items.cpp:4212
+#: Source/items.cpp:4157 Source/items.cpp:4210
 #, fuzzy
 msgid "armor: {:d}  Indestructible"
 msgstr "Podržano igrača: {:d}"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4161 Source/items.cpp:4214
+#: Source/items.cpp:4159 Source/items.cpp:4212
 #, fuzzy
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr ""
@@ -4430,13 +4509,13 @@ msgstr ""
 "Greška se dogodila na: {:s} redak {:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4166
+#: Source/items.cpp:4164
 #, fuzzy
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "Podržano igrača: {:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4168
+#: Source/items.cpp:4166
 #, fuzzy
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr ""
@@ -4444,44 +4523,53 @@ msgstr ""
 "\n"
 "Greška se dogodila na: {:s} redak {:d}"
 
-#: Source/items.cpp:4169 Source/items.cpp:4204 Source/items.cpp:4219
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 #, fuzzy
 msgid "Charges: {:d}/{:d}"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/items.cpp:4181
+#: Source/items.cpp:4179
 msgid "unique item"
 msgstr ""
 
-#: Source/items.cpp:4208 Source/items.cpp:4217 Source/items.cpp:4224
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr ""
 
-#: Source/loadsave.cpp:1656 Source/loadsave.cpp:2122
+#: Source/loadsave.cpp:1683 Source/loadsave.cpp:2149
 #, fuzzy
 #| msgid "Unable to create character."
 msgid "Unable to open save file archive"
 msgstr "Nemoguće stvaranje lika."
 
-#: Source/loadsave.cpp:1659
+#: Source/loadsave.cpp:1686
 #, fuzzy
 msgid "Invalid save file"
 msgstr "Datoteka spremanja postoji"
 
-#: Source/loadsave.cpp:1688
+#: Source/loadsave.cpp:1717
 msgid "Player is on a Hellfire only level"
 msgstr ""
 
-#: Source/loadsave.cpp:1885
+#: Source/loadsave.cpp:1912
 #, fuzzy
 msgid "Invalid game state"
 msgstr "Dizajn igre"
 
-#: Source/menu.cpp:136
+#: Source/menu.cpp:154
 #, fuzzy
 msgid "Unable to display mainmenu"
 msgstr "Nemoguće stvaranje lika."
+
+#. TRANSLATORS:  Error Message when a Shareware User clicks on "Replay Intro" in the Main Menu
+#: Source/menu.cpp:179
+msgid ""
+"The Diablo introduction cinematic is only available in the full retail "
+"version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
+msgstr ""
+"Diablo uvodni film je samo dostupan u cjelovitom maloprodajnom izdanju "
+"Diabla. Posjetite https://www.gog.com/game/diablo kako bi ga kupili."
 
 #. TRANSLATORS: Monster Block start
 #. MT_NZOMBIE
@@ -5134,6 +5222,13 @@ msgctxt "monster"
 msgid "Reaper"
 msgstr ""
 
+#. TRANSLATORS: Monster Block end
+#. MT_NAKRUL
+#: Source/monstdat.cpp:158 Source/monstdat.cpp:485
+msgctxt "monster"
+msgid "Na-Krul"
+msgstr ""
+
 #. TRANSLATORS: Unique Monster Block start
 #: Source/monstdat.cpp:473
 msgctxt "monster"
@@ -5163,6 +5258,11 @@ msgstr ""
 #: Source/monstdat.cpp:479
 msgctxt "monster"
 msgid "Black Jade"
+msgstr ""
+
+#: Source/monstdat.cpp:480
+msgctxt "monster"
+msgid "Lachdanan"
 msgstr ""
 
 #: Source/monstdat.cpp:481
@@ -5215,6 +5315,11 @@ msgctxt "monster"
 msgid "Brokenhead Bangshield"
 msgstr ""
 
+#: Source/monstdat.cpp:494
+msgctxt "monster"
+msgid "Bongo"
+msgstr ""
+
 #: Source/monstdat.cpp:495
 msgctxt "monster"
 msgid "Rotcarnage"
@@ -5233,6 +5338,11 @@ msgstr ""
 #: Source/monstdat.cpp:498
 msgctxt "monster"
 msgid "Madeye the Dead"
+msgstr ""
+
+#: Source/monstdat.cpp:499
+msgctxt "monster"
+msgid "El Chupacabras"
 msgstr ""
 
 #: Source/monstdat.cpp:500
@@ -5574,9 +5684,19 @@ msgctxt "monster"
 msgid "The Vizier"
 msgstr ""
 
+#: Source/monstdat.cpp:567
+msgctxt "monster"
+msgid "Zamphir"
+msgstr ""
+
 #: Source/monstdat.cpp:568
 msgctxt "monster"
 msgid "Bloodlust"
+msgstr ""
+
+#: Source/monstdat.cpp:569
+msgctxt "monster"
+msgid "Webwidow"
 msgstr ""
 
 #: Source/monstdat.cpp:570
@@ -5595,19 +5715,19 @@ msgctxt "monster"
 msgid "Doomlock"
 msgstr ""
 
-#: Source/monster.cpp:3474
+#: Source/monster.cpp:3479
 msgid "Animal"
 msgstr ""
 
-#: Source/monster.cpp:3476
+#: Source/monster.cpp:3481
 msgid "Demon"
 msgstr ""
 
-#: Source/monster.cpp:3478
+#: Source/monster.cpp:3483
 msgid "Undead"
 msgstr ""
 
-#: Source/monster.cpp:4610
+#: Source/monster.cpp:4612
 #, fuzzy
 msgid "Type: {:s}  Kills: {:d}"
 msgstr ""
@@ -5615,12 +5735,12 @@ msgstr ""
 "\n"
 "Greška se dogodila na: {:s} redak {:d}"
 
-#: Source/monster.cpp:4612
+#: Source/monster.cpp:4614
 #, fuzzy
 msgid "Total kills: {:d}"
 msgstr "Podržano igrača: {:d}"
 
-#: Source/monster.cpp:4645
+#: Source/monster.cpp:4647
 #, fuzzy
 msgid "Hit Points: {:d}-{:d}"
 msgstr ""
@@ -5628,82 +5748,83 @@ msgstr ""
 "\n"
 "Greška se dogodila na: {:s} redak {:d}"
 
-#: Source/monster.cpp:4651
+#: Source/monster.cpp:4653
 #, fuzzy
 msgid "No magic resistance"
 msgstr "Magija:"
 
-#: Source/monster.cpp:4655
+#: Source/monster.cpp:4657
 msgid "Resists: "
 msgstr ""
 
-#: Source/monster.cpp:4657 Source/monster.cpp:4668
+#: Source/monster.cpp:4659 Source/monster.cpp:4671
 #, fuzzy
 #| msgid "Magic:"
 msgid "Magic "
 msgstr "Magija:"
 
-#: Source/monster.cpp:4659 Source/monster.cpp:4670
+#: Source/monster.cpp:4661 Source/monster.cpp:4673
 msgid "Fire "
 msgstr ""
 
-#: Source/monster.cpp:4661 Source/monster.cpp:4672
+#: Source/monster.cpp:4663 Source/monster.cpp:4675
 msgid "Lightning "
 msgstr ""
 
-#: Source/monster.cpp:4666
+#: Source/monster.cpp:4669
 msgid "Immune: "
 msgstr ""
 
-#: Source/monster.cpp:4684
+#: Source/monster.cpp:4688
 #, fuzzy
 msgid "Type: {:s}"
 msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#: Source/monster.cpp:4690 Source/monster.cpp:4697
+#: Source/monster.cpp:4694 Source/monster.cpp:4701
 msgid "No resistances"
 msgstr ""
 
-#: Source/monster.cpp:4692 Source/monster.cpp:4702
+#: Source/monster.cpp:4696 Source/monster.cpp:4706
 msgid "No Immunities"
 msgstr ""
 
-#: Source/monster.cpp:4695
+#: Source/monster.cpp:4699
 #, fuzzy
 msgid "Some Magic Resistances"
 msgstr "Magija:"
 
-#: Source/monster.cpp:4700
+#: Source/monster.cpp:4704
 #, fuzzy
 msgid "Some Magic Immunities"
 msgstr "Magija:"
 
-#: Source/msg.cpp:484
+#: Source/msg.cpp:495
 msgid "Trying to drop a floor item?"
 msgstr ""
 
-#: Source/msg.cpp:951 Source/msg.cpp:975 Source/msg.cpp:998 Source/msg.cpp:1113
-#: Source/msg.cpp:1136 Source/msg.cpp:1158 Source/msg.cpp:1180
+#: Source/msg.cpp:994 Source/msg.cpp:1029 Source/msg.cpp:1060
+#: Source/msg.cpp:1187 Source/msg.cpp:1219 Source/msg.cpp:1251
+#: Source/msg.cpp:1281
 msgid "{:s} has cast an illegal spell."
 msgstr ""
 
-#: Source/msg.cpp:1529 Source/multi.cpp:815
+#: Source/msg.cpp:1668 Source/multi.cpp:804
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr ""
 
-#: Source/msg.cpp:1826
+#: Source/msg.cpp:1972
 #, fuzzy
 msgid "Waiting for game data..."
 msgstr "Igra za više igrača"
 
-#: Source/msg.cpp:1834
+#: Source/msg.cpp:1980
 #, fuzzy
 msgid "The game ended"
 msgstr "Igra za više igrača"
 
-#: Source/msg.cpp:1840
+#: Source/msg.cpp:1986
 #, fuzzy
 #| msgid "Unable to create character."
 msgid "Unable to get level data"
@@ -5721,375 +5842,375 @@ msgstr ""
 msgid "Player '{:s}' dropped due to timeout"
 msgstr ""
 
-#: Source/multi.cpp:817
+#: Source/multi.cpp:806
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr ""
 
 #. TRANSLATORS: Shrine Name Block
-#: Source/objects.cpp:101
+#: Source/objects.cpp:104
 msgid "Mysterious"
 msgstr ""
 
-#: Source/objects.cpp:102
+#: Source/objects.cpp:105
 msgid "Hidden"
 msgstr ""
 
-#: Source/objects.cpp:103
+#: Source/objects.cpp:106
 msgid "Gloomy"
 msgstr ""
 
-#: Source/objects.cpp:105 Source/objects.cpp:112
+#: Source/objects.cpp:108 Source/objects.cpp:115
 #, fuzzy
 #| msgid "Magic:"
 msgid "Magical"
 msgstr "Magija:"
 
-#: Source/objects.cpp:106
+#: Source/objects.cpp:109
 msgid "Stone"
 msgstr ""
 
-#: Source/objects.cpp:107
+#: Source/objects.cpp:110
 msgid "Religious"
 msgstr ""
 
-#: Source/objects.cpp:108
+#: Source/objects.cpp:111
 msgid "Enchanted"
 msgstr ""
 
-#: Source/objects.cpp:109
+#: Source/objects.cpp:112
 msgid "Thaumaturgic"
 msgstr ""
 
-#: Source/objects.cpp:110
+#: Source/objects.cpp:113
 msgid "Fascinating"
 msgstr ""
 
-#: Source/objects.cpp:111
+#: Source/objects.cpp:114
 msgid "Cryptic"
 msgstr ""
 
-#: Source/objects.cpp:113
+#: Source/objects.cpp:116
 msgid "Eldritch"
 msgstr ""
 
-#: Source/objects.cpp:114
+#: Source/objects.cpp:117
 msgid "Eerie"
 msgstr ""
 
-#: Source/objects.cpp:115
+#: Source/objects.cpp:118
 msgid "Divine"
 msgstr ""
 
-#: Source/objects.cpp:117
+#: Source/objects.cpp:120
 msgid "Sacred"
 msgstr ""
 
-#: Source/objects.cpp:118
+#: Source/objects.cpp:121
 msgid "Spiritual"
 msgstr ""
 
-#: Source/objects.cpp:119
+#: Source/objects.cpp:122
 msgid "Spooky"
 msgstr ""
 
-#: Source/objects.cpp:120
+#: Source/objects.cpp:123
 msgid "Abandoned"
 msgstr ""
 
-#: Source/objects.cpp:121
+#: Source/objects.cpp:124
 msgid "Creepy"
 msgstr ""
 
-#: Source/objects.cpp:122
+#: Source/objects.cpp:125
 msgid "Quiet"
 msgstr ""
 
-#: Source/objects.cpp:123
+#: Source/objects.cpp:126
 msgid "Secluded"
 msgstr ""
 
-#: Source/objects.cpp:124
+#: Source/objects.cpp:127
 msgid "Ornate"
 msgstr ""
 
-#: Source/objects.cpp:125
+#: Source/objects.cpp:128
 msgid "Glimmering"
 msgstr ""
 
-#: Source/objects.cpp:126
+#: Source/objects.cpp:129
 msgid "Tainted"
 msgstr ""
 
-#: Source/objects.cpp:127
+#: Source/objects.cpp:130
 msgid "Oily"
 msgstr ""
 
-#: Source/objects.cpp:128
+#: Source/objects.cpp:131
 msgid "Glowing"
 msgstr ""
 
-#: Source/objects.cpp:129
+#: Source/objects.cpp:132
 msgid "Mendicant's"
 msgstr ""
 
-#: Source/objects.cpp:130
+#: Source/objects.cpp:133
 msgid "Sparkling"
 msgstr ""
 
-#: Source/objects.cpp:131
+#: Source/objects.cpp:134
 #, fuzzy
 msgid "Town"
 msgstr "Ponovno pokreni u gradu"
 
-#: Source/objects.cpp:132
+#: Source/objects.cpp:135
 msgid "Shimmering"
 msgstr ""
 
-#: Source/objects.cpp:133
+#: Source/objects.cpp:136
 msgid "Solar"
 msgstr ""
 
 #. TRANSLATORS: Shrine Name Block end
-#: Source/objects.cpp:135
+#: Source/objects.cpp:138
 msgid "Murphy's"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:265
+#: Source/objects.cpp:268
 msgid "The Great Conflict"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:266
+#: Source/objects.cpp:269
 msgid "The Wages of Sin are War"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:267
+#: Source/objects.cpp:270
 msgid "The Tale of the Horadrim"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:268
+#: Source/objects.cpp:271
 msgid "The Dark Exile"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:269
+#: Source/objects.cpp:272
 msgid "The Sin War"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:270
+#: Source/objects.cpp:273
 #, fuzzy
 #| msgid "The Ring of One Thousand"
 msgid "The Binding of the Three"
 msgstr "Prsten od tisuće"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:271
+#: Source/objects.cpp:274
 msgid "The Realms Beyond"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:272
+#: Source/objects.cpp:275
 msgid "Tale of the Three"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:273
+#: Source/objects.cpp:276
 msgid "The Black King"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:274
+#: Source/objects.cpp:277
 msgid "Journal: The Ensorcellment"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:275
+#: Source/objects.cpp:278
 msgid "Journal: The Meeting"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:276
+#: Source/objects.cpp:279
 msgid "Journal: The Tirade"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:277
+#: Source/objects.cpp:280
 msgid "Journal: His Power Grows"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:278
+#: Source/objects.cpp:281
 msgid "Journal: NA-KRUL"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:279
+#: Source/objects.cpp:282
 msgid "Journal: The End"
 msgstr ""
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:280
+#: Source/objects.cpp:283
 msgid "A Spellbook"
 msgstr ""
 
-#: Source/objects.cpp:5365
+#: Source/objects.cpp:5339
 msgid "Crucified Skeleton"
 msgstr ""
 
-#: Source/objects.cpp:5369
+#: Source/objects.cpp:5343
 #, fuzzy
 #| msgid "Level:"
 msgid "Lever"
 msgstr "Razina:"
 
-#: Source/objects.cpp:5378
+#: Source/objects.cpp:5352
 msgid "Open Door"
 msgstr ""
 
-#: Source/objects.cpp:5380
+#: Source/objects.cpp:5354
 msgid "Closed Door"
 msgstr ""
 
-#: Source/objects.cpp:5382
+#: Source/objects.cpp:5356
 msgid "Blocked Door"
 msgstr ""
 
-#: Source/objects.cpp:5387
+#: Source/objects.cpp:5361
 msgid "Ancient Tome"
 msgstr ""
 
-#: Source/objects.cpp:5389
+#: Source/objects.cpp:5363
 msgid "Book of Vileness"
 msgstr ""
 
-#: Source/objects.cpp:5394
+#: Source/objects.cpp:5368
 msgid "Skull Lever"
 msgstr ""
 
-#: Source/objects.cpp:5397
+#: Source/objects.cpp:5371
 msgid "Mythical Book"
 msgstr ""
 
-#: Source/objects.cpp:5401
+#: Source/objects.cpp:5375
 msgid "Small Chest"
 msgstr ""
 
-#: Source/objects.cpp:5405
+#: Source/objects.cpp:5379
 msgid "Chest"
 msgstr ""
 
-#: Source/objects.cpp:5410
+#: Source/objects.cpp:5384
 msgid "Large Chest"
 msgstr ""
 
-#: Source/objects.cpp:5413
+#: Source/objects.cpp:5387
 msgid "Sarcophagus"
 msgstr ""
 
-#: Source/objects.cpp:5416
+#: Source/objects.cpp:5390
 msgid "Bookshelf"
 msgstr ""
 
-#: Source/objects.cpp:5420
+#: Source/objects.cpp:5394
 msgid "Bookcase"
 msgstr ""
 
-#: Source/objects.cpp:5425
+#: Source/objects.cpp:5399
 msgid "Pod"
 msgstr ""
 
-#: Source/objects.cpp:5427
+#: Source/objects.cpp:5401
 msgid "Urn"
 msgstr ""
 
-#: Source/objects.cpp:5429
+#: Source/objects.cpp:5403
 msgid "Barrel"
 msgstr ""
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:5433
+#: Source/objects.cpp:5407
 #, fuzzy
 msgid "{:s} Shrine"
 msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#: Source/objects.cpp:5437
+#: Source/objects.cpp:5411
 msgid "Skeleton Tome"
 msgstr ""
 
-#: Source/objects.cpp:5440
+#: Source/objects.cpp:5414
 msgid "Library Book"
 msgstr ""
 
-#: Source/objects.cpp:5443
+#: Source/objects.cpp:5417
 msgid "Blood Fountain"
 msgstr ""
 
-#: Source/objects.cpp:5446
+#: Source/objects.cpp:5420
 msgid "Decapitated Body"
 msgstr ""
 
-#: Source/objects.cpp:5449
+#: Source/objects.cpp:5423
 msgid "Book of the Blind"
 msgstr ""
 
-#: Source/objects.cpp:5452
+#: Source/objects.cpp:5426
 msgid "Book of Blood"
 msgstr ""
 
-#: Source/objects.cpp:5455
+#: Source/objects.cpp:5429
 msgid "Purifying Spring"
 msgstr ""
 
-#: Source/objects.cpp:5462 Source/objects.cpp:5486
+#: Source/objects.cpp:5436 Source/objects.cpp:5460
 msgid "Weapon Rack"
 msgstr ""
 
-#: Source/objects.cpp:5465
+#: Source/objects.cpp:5439
 msgid "Goat Shrine"
 msgstr ""
 
-#: Source/objects.cpp:5468
+#: Source/objects.cpp:5442
 msgid "Cauldron"
 msgstr ""
 
-#: Source/objects.cpp:5471
+#: Source/objects.cpp:5445
 msgid "Murky Pool"
 msgstr ""
 
-#: Source/objects.cpp:5474
+#: Source/objects.cpp:5448
 msgid "Fountain of Tears"
 msgstr ""
 
-#: Source/objects.cpp:5477
+#: Source/objects.cpp:5451
 msgid "Steel Tome"
 msgstr ""
 
-#: Source/objects.cpp:5480
+#: Source/objects.cpp:5454
 msgid "Pedestal of Blood"
 msgstr ""
 
-#: Source/objects.cpp:5489
+#: Source/objects.cpp:5463
 msgid "Mushroom Patch"
 msgstr ""
 
-#: Source/objects.cpp:5492
+#: Source/objects.cpp:5466
 msgid "Vile Stand"
 msgstr ""
 
-#: Source/objects.cpp:5495
+#: Source/objects.cpp:5469
 #, fuzzy
 #| msgid "Select Hero"
 msgid "Slain Hero"
 msgstr "Novi heroj među više igrača"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:5502
+#: Source/objects.cpp:5476
 #, fuzzy
 msgid "Trapped {:s}"
 msgstr ""
@@ -6097,167 +6218,167 @@ msgstr ""
 "{:s}"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
-#: Source/objects.cpp:5508
+#: Source/objects.cpp:5482
 #, fuzzy
 #| msgid "Music Disabled"
 msgid "{:s} (disabled)"
 msgstr "Glazba isključena"
 
-#: Source/panels/charpanel.cpp:109
+#: Source/panels/charpanel.cpp:110
 msgid "MAX"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:119
+#: Source/panels/charpanel.cpp:120
 #, fuzzy
 #| msgid "Level:"
 msgid "Level"
 msgstr "Razina:"
 
-#: Source/panels/charpanel.cpp:121
+#: Source/panels/charpanel.cpp:122
 msgid "Experience"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:123
+#: Source/panels/charpanel.cpp:124
 #, fuzzy
 msgid "Next level"
 msgstr "Razina:"
 
-#: Source/panels/charpanel.cpp:126
+#: Source/panels/charpanel.cpp:127
 msgid "None"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:132
+#: Source/panels/charpanel.cpp:133
 msgid "Base"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:133
+#: Source/panels/charpanel.cpp:134
 #, fuzzy
 #| msgid "No"
 msgid "Now"
 msgstr "Ne"
 
-#: Source/panels/charpanel.cpp:134
+#: Source/panels/charpanel.cpp:135
 #, fuzzy
 #| msgid "Strength:"
 msgid "Strength"
 msgstr "Snaga:"
 
-#: Source/panels/charpanel.cpp:138
+#: Source/panels/charpanel.cpp:139
 #, fuzzy
 #| msgid "Magic:"
 msgid "Magic"
 msgstr "Magija:"
 
-#: Source/panels/charpanel.cpp:142
+#: Source/panels/charpanel.cpp:143
 #, fuzzy
 #| msgid "Dexterity:"
 msgid "Dexterity"
 msgstr "Vještina:"
 
-#: Source/panels/charpanel.cpp:145
+#: Source/panels/charpanel.cpp:146
 #, fuzzy
 #| msgid "Vitality:"
 msgid "Vitality"
 msgstr "Vitalnost:"
 
-#: Source/panels/charpanel.cpp:148
+#: Source/panels/charpanel.cpp:149
 msgid "Points to distribute"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:158
+#: Source/panels/charpanel.cpp:159
 #, fuzzy
 msgid "Armor class"
 msgstr "Odaberi klasu"
 
-#: Source/panels/charpanel.cpp:160
+#: Source/panels/charpanel.cpp:161
 msgid "To hit"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:162
+#: Source/panels/charpanel.cpp:163
 msgid "Damage"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:168
+#: Source/panels/charpanel.cpp:170
 msgid "Life"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:172
+#: Source/panels/charpanel.cpp:174
 msgid "Mana"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:177
+#: Source/panels/charpanel.cpp:179
 #, fuzzy
 msgid "Resist magic"
 msgstr "Magija:"
 
-#: Source/panels/charpanel.cpp:179
+#: Source/panels/charpanel.cpp:181
 msgid "Resist fire"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:181
+#: Source/panels/charpanel.cpp:183
 msgid "Resist lightning"
 msgstr ""
 
-#: Source/panels/mainpanel.cpp:62 Source/panels/mainpanel.cpp:109
-#: Source/panels/mainpanel.cpp:111
+#: Source/panels/mainpanel.cpp:62 Source/panels/mainpanel.cpp:106
+#: Source/panels/mainpanel.cpp:108
 #, fuzzy
 #| msgid "Voices"
 msgid "voice"
 msgstr "Produkcija glasova, režija i raspoređivanje uloga"
 
-#: Source/panels/mainpanel.cpp:87
+#: Source/panels/mainpanel.cpp:84
 msgid "char"
 msgstr ""
 
-#: Source/panels/mainpanel.cpp:88
+#: Source/panels/mainpanel.cpp:85
 msgid "quests"
 msgstr ""
 
-#: Source/panels/mainpanel.cpp:89
+#: Source/panels/mainpanel.cpp:86
 msgid "map"
 msgstr ""
 
-#: Source/panels/mainpanel.cpp:90
+#: Source/panels/mainpanel.cpp:87
 #, fuzzy
 msgid "menu"
 msgstr "Prijašnji izbornik"
 
-#: Source/panels/mainpanel.cpp:91
+#: Source/panels/mainpanel.cpp:88
 msgid "inv"
 msgstr ""
 
-#: Source/panels/mainpanel.cpp:92
+#: Source/panels/mainpanel.cpp:89
 msgid "spells"
 msgstr ""
 
-#: Source/panels/mainpanel.cpp:104 Source/panels/mainpanel.cpp:106
-#: Source/panels/mainpanel.cpp:108
+#: Source/panels/mainpanel.cpp:101 Source/panels/mainpanel.cpp:103
+#: Source/panels/mainpanel.cpp:105
 msgid "mute"
 msgstr ""
 
-#: Source/pfile.cpp:260
+#: Source/pfile.cpp:242
 msgid "Failed to open player archive for writing."
 msgstr ""
 
-#: Source/pfile.cpp:385
+#: Source/pfile.cpp:377
 #, fuzzy
 #| msgid "Unable to create character."
 msgid "Unable to open archive"
 msgstr "Nemoguće stvaranje lika."
 
-#: Source/pfile.cpp:387
+#: Source/pfile.cpp:379
 #, fuzzy
 #| msgid "Unable to create character."
 msgid "Unable to load character"
 msgstr "Nemoguće stvaranje lika."
 
-#: Source/pfile.cpp:410 Source/pfile.cpp:430
+#: Source/pfile.cpp:403 Source/pfile.cpp:423
 #, fuzzy
 #| msgid "Unable to create character."
 msgid "Unable to read to save file archive"
 msgstr "Nemoguće stvaranje lika."
 
-#: Source/pfile.cpp:449
+#: Source/pfile.cpp:442
 #, fuzzy
 #| msgid ""
 #| "Unable to write to location:\n"
@@ -6267,8 +6388,7 @@ msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#. TRANSLATORS: Shown if player presses "v" button. {:s} is player name, {:d} is level, {:s} is location
-#: Source/plrmsg.cpp:89
+#: Source/plrmsg.cpp:88
 #, fuzzy
 msgid "{:s} (lvl {:d}): {:s}"
 msgstr ""
@@ -6286,7 +6406,7 @@ msgstr ""
 msgid "%i gold"
 msgstr ""
 
-#: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:56
+#: Source/qol/monhealthbar.cpp:37 Source/qol/xpbar.cpp:56
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
@@ -6334,6 +6454,16 @@ msgstr ""
 msgid "Zhar the Mad"
 msgstr ""
 
+#: Source/quests.cpp:45
+msgid "Lachdanan"
+msgstr ""
+
+#: Source/quests.cpp:46
+#, fuzzy
+#| msgid "Exit Diablo"
+msgid "Diablo"
+msgstr "Zatvori Diablo"
+
 #: Source/quests.cpp:47
 msgid "The Butcher"
 msgstr ""
@@ -6363,7 +6493,7 @@ msgid "Poisoned Water Supply"
 msgstr ""
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:55 Source/quests.cpp:90
+#: Source/quests.cpp:55 Source/quests.cpp:91
 msgid "The Chamber of Bone"
 msgstr ""
 
@@ -6391,6 +6521,10 @@ msgstr ""
 msgid "The Defiler"
 msgstr ""
 
+#: Source/quests.cpp:62
+msgid "Na-Krul"
+msgstr ""
+
 #: Source/quests.cpp:63 Source/trigs.cpp:447
 msgid "Cornerstone of the World"
 msgstr ""
@@ -6401,27 +6535,27 @@ msgid "The Jersey's Jersey"
 msgstr ""
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:89
+#: Source/quests.cpp:90
 msgid "King Leoric's Tomb"
 msgstr ""
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:91 Source/setmaps.cpp:26
+#: Source/quests.cpp:92 Source/setmaps.cpp:26
 msgid "Maze"
 msgstr ""
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:92
+#: Source/quests.cpp:93
 msgid "A Dark Passage"
 msgstr ""
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:93
+#: Source/quests.cpp:94
 msgid "Unholy Altar"
 msgstr ""
 
 #. TRANSLATORS: Used for Quest Portals. {:s} is a Map Name
-#: Source/quests.cpp:449
+#: Source/quests.cpp:450
 #, fuzzy
 msgid "To {:s}"
 msgstr ""
@@ -6697,324 +6831,351 @@ msgctxt "spell"
 msgid "Rune of Stone"
 msgstr ""
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:91
+msgid "Griswold"
+msgstr ""
+
+#: Source/stores.cpp:92
+msgid "Pepin"
+msgstr ""
+
+#: Source/stores.cpp:94
+msgid "Ogden"
+msgstr ""
+
+#: Source/stores.cpp:95
+msgid "Cain"
+msgstr ""
+
+#: Source/stores.cpp:96
+msgid "Farnham"
+msgstr ""
+
+#: Source/stores.cpp:97
+msgid "Adria"
+msgstr ""
+
+#: Source/stores.cpp:98 Source/stores.cpp:1305
+msgid "Gillian"
+msgstr ""
+
+#: Source/stores.cpp:99
+msgid "Wirt"
+msgstr ""
+
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr ""
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ""
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 #, fuzzy
 msgid "Damage: {:d}-{:d}  "
 msgstr "Podržano igrača: {:d}"
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 #, fuzzy
 msgid "Armor: {:d}  "
 msgstr "Podržano igrača: {:d}"
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 #, fuzzy
 msgid "Dur: {:d}/{:d},  "
 msgstr "Podržano igrača: {:d}"
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr ""
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr ""
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr ""
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr ""
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr ""
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 msgid "Talk to Griswold"
 msgstr ""
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 msgid "Buy basic items"
 msgstr ""
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 msgid "Buy premium items"
 msgstr ""
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 msgid "Sell items"
 msgstr ""
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 msgid "Repair items"
 msgstr ""
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 msgid "Leave the shop"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr ""
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr ""
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr ""
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr ""
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 msgid "Talk to Adria"
 msgstr ""
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr ""
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr ""
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 msgid "Leave the shack"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr ""
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr ""
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr ""
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr ""
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 #, fuzzy
 #| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to identify this item?"
 msgstr "Sigurno želite obrisati \"{:s}\" lik?"
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 #, fuzzy
 #| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to buy this item?"
 msgstr "Sigurno želite obrisati \"{:s}\" lik?"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 #, fuzzy
 #| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to recharge this item?"
 msgstr "Sigurno želite obrisati \"{:s}\" lik?"
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 #, fuzzy
 #| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to sell this item?"
 msgstr "Sigurno želite obrisati \"{:s}\" lik?"
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 #, fuzzy
 #| msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgid "Are you sure you want to repair this item?"
 msgstr "Sigurno želite obrisati \"{:s}\" lik?"
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr ""
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 msgid "Talk to Wirt"
 msgstr ""
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr ""
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr ""
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr ""
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr ""
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr ""
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 msgid "Leave"
 msgstr ""
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr ""
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr ""
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr ""
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 #, fuzzy
 msgid "The Town Elder"
 msgstr "Ponovno pokreni u gradu"
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 msgid "Talk to Cain"
 msgstr ""
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr ""
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr ""
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr ""
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 #, fuzzy
 msgid "Talk to {:s}"
 msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 #, fuzzy
 msgid "Talking to {:s}"
 msgstr ""
 "Nemoguće zapisivanje lokacije:\n"
 "{:s}"
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 #, fuzzy
 msgid "is not available"
 msgstr ""
 "Čarobnjak i Lutalica samo su dostupni u cjelovitom maloprodajnom izdanju "
 "Diabla. Posjetite https://www.gog.com/game/diablo kako bi ga kupili."
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 msgid "in the shareware"
 msgstr ""
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 #, fuzzy
 msgid "version"
 msgstr ""
 "Čarobnjak i Lutalica samo su dostupni u cjelovitom maloprodajnom izdanju "
 "Diabla. Posjetite https://www.gog.com/game/diablo kako bi ga kupili."
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr ""
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr ""
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 msgid "Talk to Ogden"
 msgstr ""
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 msgid "Leave the tavern"
 msgstr ""
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 msgid "Talk to Gillian"
 msgstr ""
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr ""
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 msgid "Talk to Farnham"
 msgstr ""
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr ""
 
@@ -9721,6 +9882,10 @@ msgstr ""
 msgid "Complete Nut"
 msgstr ""
 
+#: Source/towners.cpp:266
+msgid "Celia"
+msgstr ""
+
 #: Source/towners.cpp:279
 msgid "Slain Townsman"
 msgstr ""
@@ -9751,19 +9916,19 @@ msgid "Down to Crypt"
 msgstr ""
 
 #: Source/trigs.cpp:412 Source/trigs.cpp:492 Source/trigs.cpp:539
-#: Source/trigs.cpp:630
+#: Source/trigs.cpp:634
 #, fuzzy
 msgid "Up to level {:d}"
 msgstr "Podržano igrača: {:d}"
 
 #: Source/trigs.cpp:414 Source/trigs.cpp:469 Source/trigs.cpp:521
-#: Source/trigs.cpp:596 Source/trigs.cpp:613 Source/trigs.cpp:660
+#: Source/trigs.cpp:600 Source/trigs.cpp:617 Source/trigs.cpp:664
 #, fuzzy
 msgid "Up to town"
 msgstr "Ponovno pokreni u gradu"
 
-#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:552
-#: Source/trigs.cpp:577 Source/trigs.cpp:642
+#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:556
+#: Source/trigs.cpp:581 Source/trigs.cpp:646
 #, fuzzy
 msgid "Down to level {:d}"
 msgstr "Podržano igrača: {:d}"
@@ -9776,17 +9941,17 @@ msgstr ""
 msgid "Down to Crypt level {:d}"
 msgstr ""
 
-#: Source/trigs.cpp:564
+#: Source/trigs.cpp:568
 msgid "Up to Nest level {:d}"
 msgstr ""
 
-#: Source/trigs.cpp:673
+#: Source/trigs.cpp:677
 #, fuzzy
 #| msgid "Exit Diablo"
 msgid "Down to Diablo"
 msgstr "Diablo udarni tim"
 
-#: Source/trigs.cpp:706 Source/trigs.cpp:720 Source/trigs.cpp:734
+#: Source/trigs.cpp:710 Source/trigs.cpp:724 Source/trigs.cpp:738
 #, fuzzy
 msgid "Back to Level {:d}"
 msgstr "Podržano igrača: {:d}"

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-11-01 13:04+0100\n"
-"PO-Revision-Date: 2021-11-01 13:07+0100\n"
+"POT-Creation-Date: 2021-11-21 05:45+0100\n"
+"PO-Revision-Date: 2021-11-21 05:45+0100\n"
 "Last-Translator: Gianluca Boiano <morf3089@gmail.com>\n"
 "Language-Team: zuminator.altervista.org\n"
 "Language: it\n"
@@ -391,8 +391,8 @@ msgstr "Client-Server (TCP)"
 msgid "Loopback"
 msgstr "Loopback"
 
-#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:484
-#: Source/DiabloUI/selgame.cpp:505
+#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:489
+#: Source/DiabloUI/selgame.cpp:510
 msgid "Multi Player Game"
 msgstr "Multi Giocatore"
 
@@ -756,11 +756,11 @@ msgstr "Sei sicuro di voler eliminare il personaggio \"{:s}\"?"
 msgid "Enter Hellfire"
 msgstr "Entra in Hellfire"
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr "Si"
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr "No"
 
@@ -820,12 +820,12 @@ msgstr ""
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr "Copyright © 1996-2001 Blizzard Entertainment"
 
-#: Source/appfat.cpp:37
+#: Source/appfat.cpp:38
 msgid "Error"
 msgstr "Errore"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:101
+#: Source/appfat.cpp:102
 msgid ""
 "{:s}\n"
 "\n"
@@ -835,7 +835,7 @@ msgstr ""
 "\n"
 "L'errore si è verificato alla linea: {:s} {:d}"
 
-#: Source/appfat.cpp:116
+#: Source/appfat.cpp:117
 msgid ""
 "Unable to open main data archive ({:s}).\n"
 "\n"
@@ -845,12 +845,12 @@ msgstr ""
 "\n"
 "Assicurati che sia nella cartella del gioco."
 
-#: Source/appfat.cpp:122
+#: Source/appfat.cpp:123
 msgid "Data File Error"
 msgstr "Errore File Dati"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:130
+#: Source/appfat.cpp:131
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -858,7 +858,7 @@ msgstr ""
 "Impossibile scrivere nella posizione:\n"
 "{:s}"
 
-#: Source/appfat.cpp:132
+#: Source/appfat.cpp:133
 msgid "Read-Only Directory Error"
 msgstr "Errore di Cartella in Sola Lettura"
 
@@ -882,176 +882,176 @@ msgstr "Livello: Covo {:d}"
 msgid "Level: Crypt {:d}"
 msgstr "Livello: Cripta {:d}"
 
-#: Source/automap.cpp:508 Source/items.cpp:2076
+#: Source/automap.cpp:508 Source/items.cpp:2090
 msgid "Level: {:d}"
 msgstr "Liv. : {:d}"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr "Tab"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr "Esc"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Enter"
 msgstr "Invio"
 
-#: Source/control.cpp:202
+#: Source/control.cpp:215
 msgid "Character Information"
 msgstr "Dettagli Personaggio"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr "Missioni"
 
-#: Source/control.cpp:204
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr "Mappa"
 
-#: Source/control.cpp:205
+#: Source/control.cpp:218
 msgid "Main Menu"
 msgstr "Menu Principale"
 
-#: Source/control.cpp:206
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr "Inventario"
 
-#: Source/control.cpp:207
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr "Libro di magia"
 
-#: Source/control.cpp:208
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr "Invia Messaggio"
 
-#: Source/control.cpp:764 Source/control.cpp:1572
+#: Source/control.cpp:718 Source/control.cpp:1587
 msgid "Skill"
 msgstr "Abilità"
 
-#: Source/control.cpp:765 Source/control.cpp:1226
+#: Source/control.cpp:719 Source/control.cpp:1237
 msgid "{:s} Skill"
 msgstr "{:s} Abilità"
 
-#: Source/control.cpp:771
+#: Source/control.cpp:725
 msgid "Spell"
 msgstr "Magia"
 
-#: Source/control.cpp:772 Source/control.cpp:1230
+#: Source/control.cpp:726 Source/control.cpp:1241
 msgid "{:s} Spell"
 msgstr "{:s} Magia"
 
-#: Source/control.cpp:774
+#: Source/control.cpp:728
 msgid "Damages undead only"
 msgstr "Danneggia solo non morti"
 
-#: Source/control.cpp:778 Source/control.cpp:1234 Source/control.cpp:1596
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr "Liv. Magia 0 - Inusabile"
 
-#: Source/control.cpp:780 Source/control.cpp:1236 Source/control.cpp:1598
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 msgid "Spell Level {:d}"
 msgstr "Livello Magia {:d}"
 
-#: Source/control.cpp:787
+#: Source/control.cpp:741
 msgid "Scroll"
 msgstr "Pergamena"
 
-#: Source/control.cpp:788 Source/control.cpp:1240
+#: Source/control.cpp:742 Source/control.cpp:1251
 msgid "Scroll of {:s}"
 msgstr "Pergamena {:s}"
 
-#: Source/control.cpp:793 Source/control.cpp:1246
+#: Source/control.cpp:747 Source/control.cpp:1257
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "{:d} Pergamena"
 msgstr[1] "{:d} Pergamene"
 
-#: Source/control.cpp:800 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
 #: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
 msgid "Staff"
 msgstr "Verga"
 
-#: Source/control.cpp:801 Source/control.cpp:1250 Source/items.cpp:1317
+#: Source/control.cpp:755 Source/control.cpp:1261
 msgid "Staff of {:s}"
 msgstr "Verga di {:s}"
 
-#: Source/control.cpp:803 Source/control.cpp:1252
+#: Source/control.cpp:757 Source/control.cpp:1263
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "{:d} Carica"
 msgstr[1] "{:d} Cariche"
 
-#: Source/control.cpp:813
+#: Source/control.cpp:767
 msgid "Spell Hotkey {:s}"
 msgstr "Tasto Rapido {:s}"
 
-#: Source/control.cpp:1203
+#: Source/control.cpp:1214
 msgid "Player friendly"
 msgstr "Amichevole"
 
-#: Source/control.cpp:1205
+#: Source/control.cpp:1216
 msgid "Player attack"
 msgstr "Offensivo"
 
-#: Source/control.cpp:1208
+#: Source/control.cpp:1219
 msgid "Hotkey: {:s}"
 msgstr "Tasto: {:s}"
 
-#: Source/control.cpp:1216
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr "Seleziona magia corrente"
 
-#: Source/control.cpp:1219
+#: Source/control.cpp:1230
 msgid "Hotkey: 's'"
 msgstr "Tasto: 's'"
 
-#: Source/control.cpp:1374 Source/inv.cpp:1992 Source/items.cpp:3739
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "{:d} moneta"
 msgstr[1] "{:d} monete"
 
-#: Source/control.cpp:1377
+#: Source/control.cpp:1390
 msgid "Requirements not met"
 msgstr "Requisiti inadeguati"
 
-#: Source/control.cpp:1413
+#: Source/control.cpp:1426
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Livello: {:d}"
 
-#: Source/control.cpp:1415
+#: Source/control.cpp:1428
 msgid "Hit Points {:d} of {:d}"
 msgstr "Punti Ferita {:d} di {:d}"
 
-#: Source/control.cpp:1442
+#: Source/control.cpp:1457
 msgid "Level Up"
 msgstr "Su di Livello"
 
-#: Source/control.cpp:1576
+#: Source/control.cpp:1591
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] "Verga ({:d} carica)"
 msgstr[1] "Verga ({:d} cariche)"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1586
+#: Source/control.cpp:1601
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "Mana: {:d}  Dan: {:d} - {:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1588
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "Mana: {:d}   Dan: n/a"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1591
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "Mana: {:d}  Dan: 1/3 tgt hp"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1649
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] "Possiedi {:d} moneta d'oro. Quante ne vuoi rimuovere?"
@@ -1257,7 +1257,7 @@ msgstr "mentre nei negozi"
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr "{:s}, versione = {:s}, modalità = {:s}"
 
-#: Source/dvlnet/loopback.cpp:111
+#: Source/dvlnet/loopback.cpp:113
 msgid "loopback"
 msgstr "loopback"
 
@@ -1724,7 +1724,9 @@ msgstr ""
 "destro del mouse sull'oggetto."
 
 #: Source/help.cpp:68
-msgid "$Gold"
+#, fuzzy
+#| msgid "$Gold"
+msgid "$Gold:"
 msgstr "$Oro"
 
 #: Source/help.cpp:69
@@ -1755,7 +1757,9 @@ msgstr ""
 "nell'area di gioco."
 
 #: Source/help.cpp:79
-msgid "$Using the Speedbook for Spells"
+#, fuzzy
+#| msgid "$Using the Speedbook for Spells"
+msgid "$Using the Speedbook for Spells:"
 msgstr "$Uso dello Speedbook per le Magie"
 
 #: Source/help.cpp:80
@@ -1770,15 +1774,21 @@ msgstr ""
 "nell'area di gioco."
 
 #: Source/help.cpp:84
+#, fuzzy
+#| msgid ""
+#| "Shift + Left-clicking on the 'select current spell' button will clear the "
+#| "readied spell"
 msgid ""
 "Shift + Left-clicking on the 'select current spell' button will clear the "
-"readied spell"
+"readied spell."
 msgstr ""
 "Maiusc + Clic sinistro sul pulsante 'seleziona magia corrente' cancellerà la "
 "magia pronta"
 
 #: Source/help.cpp:86
-msgid "$Setting Spell Hotkeys"
+#, fuzzy
+#| msgid "$Setting Spell Hotkeys"
+msgid "$Setting Spell Hotkeys:"
 msgstr "$Impostazioni Tasti Magia"
 
 #: Source/help.cpp:87
@@ -1793,7 +1803,9 @@ msgstr ""
 "assegnare."
 
 #: Source/help.cpp:92
-msgid "$Spell Books"
+#, fuzzy
+#| msgid "$Spell Books"
+msgid "$Spell Books:"
 msgstr "$Libri di Magia"
 
 #: Source/help.cpp:93
@@ -1804,35 +1816,35 @@ msgstr ""
 "Leggere più di un libro aumenta la tua conoscenza di quella magia, "
 "permettendoti di lanciarla in modo più efficace."
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Shareware Hellfire Help"
 msgstr "Guida Hellfire Demo"
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Hellfire Help"
 msgstr "Guida Hellfire"
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Shareware Diablo Help"
 msgstr "Guida Diablo Demo"
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Diablo Help"
 msgstr "Guida Diablo"
 
-#: Source/help.cpp:161
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr "Premi ESC per uscire o le frecce per scorrere."
 
-#: Source/init.cpp:206
+#: Source/init.cpp:175
 msgid "diabdat.mpq or spawn.mpq"
 msgstr "diabdat.mpq o spawn.mpq"
 
-#: Source/init.cpp:226
+#: Source/init.cpp:196
 msgid "Some Hellfire MPQs are missing"
 msgstr "Mancano alcuni MPQ di Hellfire"
 
-#: Source/init.cpp:226
+#: Source/init.cpp:196
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
@@ -1840,7 +1852,7 @@ msgstr ""
 "Non tutti gli MPQ Hellfire sono stati trovati.\n"
 "Si prega di copiare tutti i file hf*.mpq."
 
-#: Source/init.cpp:234
+#: Source/init.cpp:204
 msgid "Unable to create main window"
 msgstr "Impossibile creare la finestra principale"
 
@@ -2084,7 +2096,7 @@ msgid "Quilted Armor"
 msgstr "Gambesone"
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
-#: Source/itemdat.cpp:77 Source/objects.cpp:5435
+#: Source/itemdat.cpp:77 Source/objects.cpp:5433
 msgid "Armor"
 msgstr "Armatura"
 
@@ -3626,639 +3638,652 @@ msgstr "Olio della Tempra"
 msgid "Oil of Imperviousness"
 msgstr "Olio dell'Impermeabilità"
 
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#: Source/items.cpp:1174 Source/items.cpp:1184 Source/items.cpp:1233
-#: Source/items.cpp:1269
-msgid "{0} {1}"
-msgstr "{1} {0}"
-
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's Staff of Firewall
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Long Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1187 Source/items.cpp:1254 Source/items.cpp:1273
-#: Source/items.cpp:1315
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
+#, fuzzy
+#| msgid "{0} of {1}"
+msgctxt "spell"
 msgid "{0} of {1}"
 msgstr "{:s} di {:s}"
 
-#: Source/items.cpp:1892 Source/items.cpp:1904
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+#, fuzzy
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} di {:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+#, fuzzy
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} di {:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
+#: Source/items.cpp:1217
+msgid "{0} {1}"
+msgstr "{1} {0}"
+
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
+msgid "{0} of {1}"
+msgstr "{:s} di {:s}"
+
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr "dell'arma, aumenta"
 
-#: Source/items.cpp:1894
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr "possibilità di colpire"
 
-#: Source/items.cpp:1898
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr "aumenta di molto"
 
-#: Source/items.cpp:1900
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr "possibilità di colpire dell'arma"
 
-#: Source/items.cpp:1906
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr "potenziale danno"
 
-#: Source/items.cpp:1910
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr "aumenta di molto dell'arma"
 
-#: Source/items.cpp:1912
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr "potenziale danno - archi esclusi"
 
-#: Source/items.cpp:1916
+#: Source/items.cpp:1930
 msgid "reduces attributes needed"
 msgstr "riduce attributi richiesti"
 
-#: Source/items.cpp:1918
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr "per usare armature o armi"
 
-#: Source/items.cpp:1922
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr "ripristina 20% di"
 
-#: Source/items.cpp:1924
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr "durabilità dell'oggetto"
 
-#: Source/items.cpp:1928
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr "dell'oggetto, aumenta"
 
-#: Source/items.cpp:1930
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr "durabilità corrente e massima"
 
-#: Source/items.cpp:1934
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr "rende indistruttibile un oggetto"
 
-#: Source/items.cpp:1938
+#: Source/items.cpp:1952
 msgid "increases the armor class"
 msgstr "aumenta la classe armatura"
 
-#: Source/items.cpp:1940
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr "di armatura e scudi"
 
-#: Source/items.cpp:1944
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr "aumenta di molto la classe"
 
-#: Source/items.cpp:1946
+#: Source/items.cpp:1960
 msgid "class of armor and shields"
 msgstr "armatura di armature e scudi"
 
-#: Source/items.cpp:1950 Source/items.cpp:1959
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr "imposta trappola fuoco"
 
-#: Source/items.cpp:1955
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr "imposta trappola fulmine"
 
-#: Source/items.cpp:1963
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr "imposta trappola pietrificazione"
 
-#: Source/items.cpp:1967
+#: Source/items.cpp:1981
 msgid "restore all life"
 msgstr "recupero totale vita"
 
-#: Source/items.cpp:1971
+#: Source/items.cpp:1985
 msgid "restore some life"
 msgstr "recupero paziale vita"
 
-#: Source/items.cpp:1975
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr "recupero vita"
 
-#: Source/items.cpp:1979
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr "resuscita"
 
-#: Source/items.cpp:1983
+#: Source/items.cpp:1997
 msgid "restore some mana"
 msgstr "recupero parziale mana"
 
-#: Source/items.cpp:1987
+#: Source/items.cpp:2001
 msgid "restore all mana"
 msgstr "recupero totale mana"
 
-#: Source/items.cpp:1991
+#: Source/items.cpp:2005
 msgid "increase strength"
 msgstr "aumenta forza"
 
-#: Source/items.cpp:1995
+#: Source/items.cpp:2009
 msgid "increase magic"
 msgstr "aumenta magia"
 
-#: Source/items.cpp:1999
+#: Source/items.cpp:2013
 msgid "increase dexterity"
 msgstr "aumenta destrezza"
 
-#: Source/items.cpp:2003
+#: Source/items.cpp:2017
 msgid "increase vitality"
 msgstr "aumenta vitalità"
 
-#: Source/items.cpp:2008
+#: Source/items.cpp:2022
 msgid "decrease strength"
 msgstr "riduci forza"
 
-#: Source/items.cpp:2012
+#: Source/items.cpp:2026
 msgid "decrease dexterity"
 msgstr "riduci destrezza"
 
-#: Source/items.cpp:2016
+#: Source/items.cpp:2030
 msgid "decrease vitality"
 msgstr "riduci vitalità"
 
-#: Source/items.cpp:2020
+#: Source/items.cpp:2034
 msgid "restore some life and mana"
 msgstr "recupero parziale vita e mana"
 
-#: Source/items.cpp:2024
+#: Source/items.cpp:2038
 msgid "restore all life and mana"
 msgstr "recupero totale vita e mana"
 
-#: Source/items.cpp:2039 Source/items.cpp:2064
+#: Source/items.cpp:2053 Source/items.cpp:2078
 msgid "Right-click to read"
 msgstr "Clic destro per leggere"
 
-#: Source/items.cpp:2043
+#: Source/items.cpp:2057
 msgid "Right-click to read, then"
 msgstr "Clic destro per leggere, poi"
 
-#: Source/items.cpp:2045
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr "clic sinistro per obiettivo"
 
-#: Source/items.cpp:2050
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr "Clic destro per usare"
 
-#: Source/items.cpp:2055 Source/items.cpp:2060
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr "Clic destro per usare"
 
-#: Source/items.cpp:2068
+#: Source/items.cpp:2082
 msgid "Right click to read"
 msgstr "Clic destro per leggere"
 
-#: Source/items.cpp:2072
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr "Clic destro per vedere"
 
-#: Source/items.cpp:2080
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr "Raddoppia le scorte d'oro"
 
-#: Source/items.cpp:2092 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 msgid "Required:"
 msgstr "Richiede:"
 
-#: Source/items.cpp:2094 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 msgid " {:d} Str"
 msgstr " {:d} Frz"
 
-#: Source/items.cpp:2096 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 msgid " {:d} Mag"
 msgstr " {:d} Mag"
 
-#: Source/items.cpp:2098 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 msgid " {:d} Dex"
 msgstr " {:d} Des"
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3523 Source/player.cpp:3027
+#: Source/items.cpp:3533 Source/player.cpp:3018
 msgid "Ear of {:s}"
 msgstr "Orecchio di {:s}"
 
-#: Source/items.cpp:3818
+#: Source/items.cpp:3828
 msgid "chance to hit: {:+d}%"
 msgstr "possibilità di colpire: {:+d}%"
 
-#: Source/items.cpp:3822
+#: Source/items.cpp:3832
 #, no-c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% danno"
 
-#: Source/items.cpp:3826 Source/items.cpp:4082
+#: Source/items.cpp:3836 Source/items.cpp:4092
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "colpo: {:+d}%, {:+d}% danno"
 
-#: Source/items.cpp:3830
+#: Source/items.cpp:3840
 #, no-c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% armatura"
 
-#: Source/items.cpp:3834
+#: Source/items.cpp:3844
 msgid "armor class: {:d}"
 msgstr "classe armatura: {:d}"
 
-#: Source/items.cpp:3839 Source/items.cpp:4064
+#: Source/items.cpp:3849 Source/items.cpp:4074
 msgid "Resist Fire: {:+d}%"
 msgstr "Resistenza Fuoco: {:+d}%"
 
-#: Source/items.cpp:3841
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr "Resistenza Fuoco: 75% MAX"
 
-#: Source/items.cpp:3846
+#: Source/items.cpp:3856
 msgid "Resist Lightning: {:+d}%"
 msgstr "Resistenza Fulmine: {:+d}%"
 
-#: Source/items.cpp:3848
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr "Resistenza Fulmine: 75% MAX"
 
-#: Source/items.cpp:3853
+#: Source/items.cpp:3863
 msgid "Resist Magic: {:+d}%"
 msgstr "Resistenza Magia: {:+d}%"
 
-#: Source/items.cpp:3855
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr "Resistenza Magia: 75% MAX"
 
-#: Source/items.cpp:3860
+#: Source/items.cpp:3870
 msgid "Resist All: {:+d}%"
 msgstr "Resistenza Tutto: {:+d}%"
 
-#: Source/items.cpp:3862
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr "Resistenza Tutto: 75% MAX"
 
-#: Source/items.cpp:3866
+#: Source/items.cpp:3876
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] "magie aumentate di {:d} livello"
 msgstr[1] "magie aumentate di {:d} livelli"
 
-#: Source/items.cpp:3868
+#: Source/items.cpp:3878
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "magie ridotte di {:d} livello"
 msgstr[1] "magie ridotte di {:d} livelli"
 
-#: Source/items.cpp:3870
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr "livelli magia invariati (?)"
 
-#: Source/items.cpp:3873
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr "Cariche extra"
 
-#: Source/items.cpp:3876
+#: Source/items.cpp:3886
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:d} {:s} carica"
 msgstr[1] "{:d} {:s} cariche"
 
-#: Source/items.cpp:3880
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr "Danno fuoco: {:d}"
 
-#: Source/items.cpp:3882
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "Danno Fuoco: {:d}-{:d}"
 
-#: Source/items.cpp:3886
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr "Danno Fulmine : {:d}"
 
-#: Source/items.cpp:3888
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "Danno Fulmine : {:d}-{:d}"
 
-#: Source/items.cpp:3892
+#: Source/items.cpp:3902
 msgid "{:+d} to strength"
 msgstr "{:+d} alla Forza"
 
-#: Source/items.cpp:3896
+#: Source/items.cpp:3906
 msgid "{:+d} to magic"
 msgstr "{:+d} di magia"
 
-#: Source/items.cpp:3900
+#: Source/items.cpp:3910
 msgid "{:+d} to dexterity"
 msgstr "{:+d} di destrezza"
 
-#: Source/items.cpp:3904
+#: Source/items.cpp:3914
 msgid "{:+d} to vitality"
 msgstr "{:+d} di vitalità"
 
-#: Source/items.cpp:3908
+#: Source/items.cpp:3918
 msgid "{:+d} to all attributes"
 msgstr "{:+d} a ogni attributo"
 
-#: Source/items.cpp:3912
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} danno dai nemici"
 
-#: Source/items.cpp:3916
+#: Source/items.cpp:3926
 msgid "Hit Points: {:+d}"
 msgstr "Punti Ferita: {:+d}"
 
-#: Source/items.cpp:3920
+#: Source/items.cpp:3930
 msgid "Mana: {:+d}"
 msgstr "Mana : {:+d}"
 
-#: Source/items.cpp:3923
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr "alta durabilità"
 
-#: Source/items.cpp:3926
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr "durabilità ridotta"
 
-#: Source/items.cpp:3929
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr "indistruttibile"
 
-#: Source/items.cpp:3932
+#: Source/items.cpp:3942
 #, no-c-format
 msgid "+{:d}% light radius"
 msgstr "+{:d}% bagliore"
 
-#: Source/items.cpp:3935
+#: Source/items.cpp:3945
 #, no-c-format
 msgid "-{:d}% light radius"
 msgstr "-{:d}% bagliore"
 
-#: Source/items.cpp:3938
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr "frecce multiple per tiro"
 
-#: Source/items.cpp:3942
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr "danno dardi infuocati: {:d}"
 
-#: Source/items.cpp:3944
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "danno dardi infuocati: {:d}-{:d}"
 
-#: Source/items.cpp:3948
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr "danno frecce fulminee: {:d}"
 
-#: Source/items.cpp:3950
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "danno frecce fulminee: {:d}-{:d}"
 
-#: Source/items.cpp:3954
+#: Source/items.cpp:3964
 msgid "fireball damage: {:d}"
 msgstr "danno sfera infuocata: {:d}"
 
-#: Source/items.cpp:3956
+#: Source/items.cpp:3966
 msgid "fireball damage: {:d}-{:d}"
 msgstr "danno sfera infuocata: {:d}-{:d}"
 
-#: Source/items.cpp:3959
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr "attaccante riceve1-3 danni"
 
-#: Source/items.cpp:3962
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr "l'utente perde tutto il mana"
 
-#: Source/items.cpp:3965
+#: Source/items.cpp:3975
 msgid "you can't heal"
 msgstr "non puoi guarire"
 
-#: Source/items.cpp:3968
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr "assorbe metà danni trappola"
 
-#: Source/items.cpp:3971
+#: Source/items.cpp:3981
 msgid "knocks target back"
 msgstr "respinge il bersaglio"
 
-#: Source/items.cpp:3974
+#: Source/items.cpp:3984
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr "+200% danno contro demoni"
 
-#: Source/items.cpp:3977
+#: Source/items.cpp:3987
 msgid "All Resistance equals 0"
 msgstr "Ogni Resistenza è 0"
 
-#: Source/items.cpp:3980
+#: Source/items.cpp:3990
 msgid "hit monster doesn't heal"
 msgstr "colpo al mostro non guarisce"
 
-#: Source/items.cpp:3984
+#: Source/items.cpp:3994
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr "colpo ruba 3% mana"
 
-#: Source/items.cpp:3986
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr "colpo ruba 5% mana"
 
-#: Source/items.cpp:3990
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr "colpo ruba 3% vita"
 
-#: Source/items.cpp:3992
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr "colpo ruba 5% vita"
 
-#: Source/items.cpp:3995
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr "penetra l'armatura dell'obiettivo"
 
-#: Source/items.cpp:3999
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr "attacco rapido"
 
-#: Source/items.cpp:4001
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr "attacco veloce"
 
-#: Source/items.cpp:4003
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr "attacco molto veloce"
 
-#: Source/items.cpp:4005
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr "attacco velocissimo"
 
-#: Source/items.cpp:4009
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr "recupero veloce"
 
-#: Source/items.cpp:4011
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr "recupero molto veloce"
 
-#: Source/items.cpp:4013
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr "recupero velocissimo"
 
-#: Source/items.cpp:4016
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr "blocco veloce"
 
-#: Source/items.cpp:4019
+#: Source/items.cpp:4029
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] "aggiunge {:d} punto al danno"
 msgstr[1] "aggiunge {:d} punti al danno"
 
-#: Source/items.cpp:4022
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr "velocità di gittata casuale"
 
-#: Source/items.cpp:4025
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr "danno non comune"
 
-#: Source/items.cpp:4028
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr "durabilità alterata"
 
-#: Source/items.cpp:4031
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr "Sferra attacco veloce"
 
-#: Source/items.cpp:4034
+#: Source/items.cpp:4044
 msgid "one handed sword"
 msgstr "spada a una mano"
 
-#: Source/items.cpp:4037
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr "perdita costante di punti ferita"
 
-#: Source/items.cpp:4040
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr "sottrae vita"
 
-#: Source/items.cpp:4043
+#: Source/items.cpp:4053
 msgid "no strength requirement"
 msgstr "nessun requisito di forza"
 
-#: Source/items.cpp:4046
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr "usa infravisione"
 
-#: Source/items.cpp:4053
+#: Source/items.cpp:4063
 msgid "lightning damage: {:d}"
 msgstr "danno fulmineo: {:d}"
 
-#: Source/items.cpp:4055
+#: Source/items.cpp:4065
 msgid "lightning damage: {:d}-{:d}"
 msgstr "danno fulmineo: {:d}-{:d}"
 
-#: Source/items.cpp:4058
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr "scariche fulminee al colpo"
 
-#: Source/items.cpp:4067
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr "danno triplo occasionale"
 
-#: Source/items.cpp:4070
+#: Source/items.cpp:4080
 #, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr "riduzione {:+d}% danno"
 
-#: Source/items.cpp:4073
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr "2x danni mostri, 1x a te"
 
-#: Source/items.cpp:4076
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr "Danno casuale 0 - 500%"
 
-#: Source/items.cpp:4079
+#: Source/items.cpp:4089
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr "dur ridotta, {:+d}% danno"
 
-#: Source/items.cpp:4085
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr "extra AC contro demoni"
 
-#: Source/items.cpp:4088
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr "extra AC contro non morti"
 
-#: Source/items.cpp:4091
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr "50% Mana spostato a Salute"
 
-#: Source/items.cpp:4094
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr "40% Salute spostato a Mana"
 
-#: Source/items.cpp:4097
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr "Altra abilità (NW)"
 
-#: Source/items.cpp:4134 Source/items.cpp:4181
+#: Source/items.cpp:4144 Source/items.cpp:4191
 msgid "damage: {:d}  Indestructible"
 msgstr "danno: {:d}  Invulnerabile"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4136 Source/items.cpp:4183
+#: Source/items.cpp:4146 Source/items.cpp:4193
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "danno: {:d}  Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4139 Source/items.cpp:4186
+#: Source/items.cpp:4149 Source/items.cpp:4196
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "danno: {:d}-{:d}  Indistruttibile"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4141 Source/items.cpp:4188
+#: Source/items.cpp:4151 Source/items.cpp:4198
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "danno: {:d}-{:d}  Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4147 Source/items.cpp:4200
+#: Source/items.cpp:4157 Source/items.cpp:4210
 msgid "armor: {:d}  Indestructible"
 msgstr "armatura: {:d}  Indistruttibile"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4149 Source/items.cpp:4202
+#: Source/items.cpp:4159 Source/items.cpp:4212
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "armatura: {:d}  Dur: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4154
+#: Source/items.cpp:4164
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "dan: {:d}  Dur: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4156
+#: Source/items.cpp:4166
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "dan: {:d}-{:d}  Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4157 Source/items.cpp:4192 Source/items.cpp:4207
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 msgid "Charges: {:d}/{:d}"
 msgstr "Cariche: {:d}/{:d}"
 
-#: Source/items.cpp:4169
+#: Source/items.cpp:4179
 msgid "unique item"
 msgstr "oggetto unico"
 
-#: Source/items.cpp:4196 Source/items.cpp:4205 Source/items.cpp:4212
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr "Sconosciuto"
 
@@ -5412,97 +5437,97 @@ msgctxt "monster"
 msgid "Doomlock"
 msgstr "Doomlock"
 
-#: Source/monster.cpp:3497
+#: Source/monster.cpp:3479
 msgid "Animal"
 msgstr "Bestia"
 
-#: Source/monster.cpp:3499
+#: Source/monster.cpp:3481
 msgid "Demon"
 msgstr "Demone"
 
-#: Source/monster.cpp:3501
+#: Source/monster.cpp:3483
 msgid "Undead"
 msgstr "Non morto"
 
-#: Source/monster.cpp:4632
+#: Source/monster.cpp:4612
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "Tipo: {:s}  Uccisioni: {:d}"
 
-#: Source/monster.cpp:4634
+#: Source/monster.cpp:4614
 msgid "Total kills: {:d}"
 msgstr "Tot. uccisioni : {:d}"
 
-#: Source/monster.cpp:4667
+#: Source/monster.cpp:4647
 msgid "Hit Points: {:d}-{:d}"
 msgstr "Punti Ferita: {:d}-{:d}"
 
-#: Source/monster.cpp:4673
+#: Source/monster.cpp:4653
 msgid "No magic resistance"
 msgstr "Nessuna Res. Magica"
 
-#: Source/monster.cpp:4677
+#: Source/monster.cpp:4657
 msgid "Resists: "
 msgstr "Resiste: "
 
-#: Source/monster.cpp:4679 Source/monster.cpp:4690
+#: Source/monster.cpp:4659 Source/monster.cpp:4671
 msgid "Magic "
 msgstr "Magia "
 
-#: Source/monster.cpp:4681 Source/monster.cpp:4692
+#: Source/monster.cpp:4661 Source/monster.cpp:4673
 msgid "Fire "
 msgstr "Fuoco "
 
-#: Source/monster.cpp:4683 Source/monster.cpp:4694
+#: Source/monster.cpp:4663 Source/monster.cpp:4675
 msgid "Lightning "
 msgstr "Fulmine "
 
-#: Source/monster.cpp:4688
+#: Source/monster.cpp:4669
 msgid "Immune: "
 msgstr "Immune: "
 
-#: Source/monster.cpp:4706
+#: Source/monster.cpp:4688
 msgid "Type: {:s}"
 msgstr "Tipo: {:s}"
 
-#: Source/monster.cpp:4712 Source/monster.cpp:4719
+#: Source/monster.cpp:4694 Source/monster.cpp:4701
 msgid "No resistances"
 msgstr "No resistenze"
 
-#: Source/monster.cpp:4714 Source/monster.cpp:4724
+#: Source/monster.cpp:4696 Source/monster.cpp:4706
 msgid "No Immunities"
 msgstr "No Immunità"
 
-#: Source/monster.cpp:4717
+#: Source/monster.cpp:4699
 msgid "Some Magic Resistances"
 msgstr "Alcune Resistenze Magiche"
 
-#: Source/monster.cpp:4722
+#: Source/monster.cpp:4704
 msgid "Some Magic Immunities"
 msgstr "Alcune Immunità Magiche"
 
-#: Source/msg.cpp:494
+#: Source/msg.cpp:495
 msgid "Trying to drop a floor item?"
 msgstr "Abbandonare un oggetto a terra?"
 
-#: Source/msg.cpp:982 Source/msg.cpp:1017 Source/msg.cpp:1048
-#: Source/msg.cpp:1175 Source/msg.cpp:1207 Source/msg.cpp:1239
-#: Source/msg.cpp:1269
+#: Source/msg.cpp:994 Source/msg.cpp:1029 Source/msg.cpp:1060
+#: Source/msg.cpp:1187 Source/msg.cpp:1219 Source/msg.cpp:1251
+#: Source/msg.cpp:1281
 msgid "{:s} has cast an illegal spell."
 msgstr "{:s} ha usato magia illegale."
 
-#: Source/msg.cpp:1655 Source/multi.cpp:805
+#: Source/msg.cpp:1668 Source/multi.cpp:804
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr "'{:s}' (livello {:d}) si è unito alla partita"
 
-#: Source/msg.cpp:1959
+#: Source/msg.cpp:1972
 msgid "Waiting for game data..."
 msgstr "In attesa di dati di gioco..."
 
-#: Source/msg.cpp:1967
+#: Source/msg.cpp:1980
 msgid "The game ended"
 msgstr "La partita è finita"
 
-#: Source/msg.cpp:1973
+#: Source/msg.cpp:1986
 msgid "Unable to get level data"
 msgstr "Impossibile ottenere dati di livello"
 
@@ -5518,7 +5543,7 @@ msgstr "'{:s}' ha ucciso Diablo e ha lasciato la partita!"
 msgid "Player '{:s}' dropped due to timeout"
 msgstr "'{:s}' disconnesso per timeout"
 
-#: Source/multi.cpp:807
+#: Source/multi.cpp:806
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr "'{:s}' (liv. {:d}) è già in partita"
 
@@ -5728,158 +5753,158 @@ msgstr "Diario: La Fine"
 msgid "A Spellbook"
 msgstr "Un Libro di Magia"
 
-#: Source/objects.cpp:5341
+#: Source/objects.cpp:5339
 msgid "Crucified Skeleton"
 msgstr "Scheletro Crocifisso"
 
-#: Source/objects.cpp:5345
+#: Source/objects.cpp:5343
 msgid "Lever"
 msgstr "Leva"
 
-#: Source/objects.cpp:5354
+#: Source/objects.cpp:5352
 msgid "Open Door"
 msgstr "Porta Aperta"
 
-#: Source/objects.cpp:5356
+#: Source/objects.cpp:5354
 msgid "Closed Door"
 msgstr "Porta Chiusa"
 
-#: Source/objects.cpp:5358
+#: Source/objects.cpp:5356
 msgid "Blocked Door"
 msgstr "Porta Bloccata"
 
-#: Source/objects.cpp:5363
+#: Source/objects.cpp:5361
 msgid "Ancient Tome"
 msgstr "Tomo Antico"
 
-#: Source/objects.cpp:5365
+#: Source/objects.cpp:5363
 msgid "Book of Vileness"
 msgstr "Libro della Viltà"
 
-#: Source/objects.cpp:5370
+#: Source/objects.cpp:5368
 msgid "Skull Lever"
 msgstr "Leva con Teschio"
 
-#: Source/objects.cpp:5373
+#: Source/objects.cpp:5371
 msgid "Mythical Book"
 msgstr "Libro Mitico"
 
-#: Source/objects.cpp:5377
+#: Source/objects.cpp:5375
 msgid "Small Chest"
 msgstr "Cofanetto"
 
-#: Source/objects.cpp:5381
+#: Source/objects.cpp:5379
 msgid "Chest"
 msgstr "Baule"
 
-#: Source/objects.cpp:5386
+#: Source/objects.cpp:5384
 msgid "Large Chest"
 msgstr "Scrigno"
 
-#: Source/objects.cpp:5389
+#: Source/objects.cpp:5387
 msgid "Sarcophagus"
 msgstr "Sarcofago"
 
-#: Source/objects.cpp:5392
+#: Source/objects.cpp:5390
 msgid "Bookshelf"
 msgstr "Scaffale"
 
-#: Source/objects.cpp:5396
+#: Source/objects.cpp:5394
 msgid "Bookcase"
 msgstr "Libreria"
 
-#: Source/objects.cpp:5401
+#: Source/objects.cpp:5399
 msgid "Pod"
 msgstr "Capsula"
 
-#: Source/objects.cpp:5403
+#: Source/objects.cpp:5401
 msgid "Urn"
 msgstr "Urna"
 
-#: Source/objects.cpp:5405
+#: Source/objects.cpp:5403
 msgid "Barrel"
 msgstr "Barile"
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:5409
+#: Source/objects.cpp:5407
 msgid "{:s} Shrine"
 msgstr "{:s} Santuario"
 
-#: Source/objects.cpp:5413
+#: Source/objects.cpp:5411
 msgid "Skeleton Tome"
 msgstr "Tomo dello Scheletro"
 
-#: Source/objects.cpp:5416
+#: Source/objects.cpp:5414
 msgid "Library Book"
 msgstr "Libro di Biblioteca"
 
-#: Source/objects.cpp:5419
+#: Source/objects.cpp:5417
 msgid "Blood Fountain"
 msgstr "Fonte del Sangue"
 
-#: Source/objects.cpp:5422
+#: Source/objects.cpp:5420
 msgid "Decapitated Body"
 msgstr "Corpo Decapitato"
 
-#: Source/objects.cpp:5425
+#: Source/objects.cpp:5423
 msgid "Book of the Blind"
 msgstr "Libro degli Orbi"
 
-#: Source/objects.cpp:5428
+#: Source/objects.cpp:5426
 msgid "Book of Blood"
 msgstr "Libro del Sangue"
 
-#: Source/objects.cpp:5431
+#: Source/objects.cpp:5429
 msgid "Purifying Spring"
 msgstr "Primavera Purificante"
 
-#: Source/objects.cpp:5438 Source/objects.cpp:5462
+#: Source/objects.cpp:5436 Source/objects.cpp:5460
 msgid "Weapon Rack"
 msgstr "Rastrelliera"
 
-#: Source/objects.cpp:5441
+#: Source/objects.cpp:5439
 msgid "Goat Shrine"
 msgstr "Santuario della Capra"
 
-#: Source/objects.cpp:5444
+#: Source/objects.cpp:5442
 msgid "Cauldron"
 msgstr "Calderone"
 
-#: Source/objects.cpp:5447
+#: Source/objects.cpp:5445
 msgid "Murky Pool"
 msgstr "Pozza Buia"
 
-#: Source/objects.cpp:5450
+#: Source/objects.cpp:5448
 msgid "Fountain of Tears"
 msgstr "Fonte del Pianto"
 
-#: Source/objects.cpp:5453
+#: Source/objects.cpp:5451
 msgid "Steel Tome"
 msgstr "Tomo d'Acciaio"
 
-#: Source/objects.cpp:5456
+#: Source/objects.cpp:5454
 msgid "Pedestal of Blood"
 msgstr "Colonna di Sangue"
 
-#: Source/objects.cpp:5465
+#: Source/objects.cpp:5463
 msgid "Mushroom Patch"
 msgstr "Pugno di Funghi"
 
-#: Source/objects.cpp:5468
+#: Source/objects.cpp:5466
 msgid "Vile Stand"
 msgstr "Stallo del Vile"
 
-#: Source/objects.cpp:5471
+#: Source/objects.cpp:5469
 msgid "Slain Hero"
 msgstr "Eroe Ucciso"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:5478
+#: Source/objects.cpp:5476
 msgid "Trapped {:s}"
 msgstr "Trappola {:s}"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
-#: Source/objects.cpp:5484
+#: Source/objects.cpp:5482
 msgid "{:s} (disabled)"
 msgstr "{:s} (disabilitato)"
 
@@ -5997,23 +6022,23 @@ msgstr "magie"
 msgid "mute"
 msgstr "silenzia"
 
-#: Source/pfile.cpp:260
+#: Source/pfile.cpp:242
 msgid "Failed to open player archive for writing."
 msgstr "Impossibile aprire archivio in scrittura."
 
-#: Source/pfile.cpp:392
+#: Source/pfile.cpp:377
 msgid "Unable to open archive"
 msgstr "Impossibile aprire archivio"
 
-#: Source/pfile.cpp:394
+#: Source/pfile.cpp:379
 msgid "Unable to load character"
 msgstr "Impossibile caricare personaggio"
 
-#: Source/pfile.cpp:419 Source/pfile.cpp:439
+#: Source/pfile.cpp:403 Source/pfile.cpp:423
 msgid "Unable to read to save file archive"
 msgstr "Impossibile leggere archivio di salvataggio"
 
-#: Source/pfile.cpp:458
+#: Source/pfile.cpp:442
 msgid "Unable to write to save file archive"
 msgstr "Impossibile scrivere archivio di salvataggio"
 
@@ -6032,7 +6057,7 @@ msgstr ",%03d"
 msgid "%i gold"
 msgstr "%i monete"
 
-#: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:56
+#: Source/qol/monhealthbar.cpp:37 Source/qol/xpbar.cpp:56
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
@@ -6469,7 +6494,7 @@ msgstr "Farnham"
 msgid "Adria"
 msgstr "Adria"
 
-#: Source/stores.cpp:98 Source/stores.cpp:1252
+#: Source/stores.cpp:98 Source/stores.cpp:1305
 msgid "Gillian"
 msgstr "Gillian"
 
@@ -6477,298 +6502,293 @@ msgstr "Gillian"
 msgid "Wirt"
 msgstr "Wirt"
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr "Indietro"
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ",  "
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 msgid "Damage: {:d}-{:d}  "
 msgstr "Danno : {:d}-{:d}  "
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 msgid "Armor: {:d}  "
 msgstr "Armat: {:d}  "
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 msgid "Dur: {:d}/{:d},  "
 msgstr "Dur: {:d}/{:d},  "
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr "Indistruttibile,  "
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr "Non richiede attributi"
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr "Benvenuti alla"
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr "Bottega del fabbro"
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr "Cosa intendi fare:"
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 msgid "Talk to Griswold"
 msgstr "Parla con Griswold"
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 msgid "Buy basic items"
 msgstr "Compra armi"
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 msgid "Buy premium items"
 msgstr "Compra armi speciali"
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 msgid "Sell items"
 msgstr "Vendi merce"
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 msgid "Repair items"
 msgstr "Ripara armi"
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 msgid "Leave the shop"
 msgstr "Lascia bottega"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "Merce in vendita:             Monete : {:d}"
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr "Indietro"
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "Armi speciali in vendita:     Monete : {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "Non mi interessa nulla.             Monete: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "Cosa proponi in vendita?             Monete: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "Nulla da riparare.             Monete: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "Cosa vuoi riparare?             Monete: {:d}"
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr "Baracca della strega"
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 msgid "Talk to Adria"
 msgstr "Parla con Adria"
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr "Compra merce"
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr "Ricarica verghe"
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 msgid "Leave the shack"
 msgstr "Lascia baracca"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "Nulla da ricaricare.             Monete: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "Cosa vuoi ricaricare?             Monete: {:d}"
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr "Non hai abbastanza oro"
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr "Non hai abbastanza spazio in inventario"
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr "Facciamo l'affare?"
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 msgid "Are you sure you want to identify this item?"
 msgstr "Sei sicuro di voler identificare l'oggetto?"
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 msgid "Are you sure you want to buy this item?"
 msgstr "Sei sicuro di voler comprare l'oggetto?"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 msgid "Are you sure you want to recharge this item?"
 msgstr "Sei sicuro di voler ricaricare l'oggetto?"
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 msgid "Are you sure you want to sell this item?"
 msgstr "Sei sicuro di voler vendere l'oggetto?"
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 msgid "Are you sure you want to repair this item?"
 msgstr "Sei sicuro di voler riparare l'oggetto?"
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr "Wirt Gamba di Legno"
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 msgid "Talk to Wirt"
 msgstr "Parla con Wirt"
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr "Ho qualcosa in vendita,"
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr "ma ti costerà 50 monete"
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr "solo sbirciare. "
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr "Di cosa si tratta?"
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr "Saluta"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "Oggetti in vendita:             Monete: {:d}"
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 msgid "Leave"
 msgstr "Lascia"
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr "Dimora del Guaritore"
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr "Parla con Pepin"
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr "Lascia dimora del Guaritore"
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 msgid "The Town Elder"
 msgstr "Il Saggio della Città"
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 msgid "Talk to Cain"
 msgstr "Parla con Cain"
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr "Identifica oggetti"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "Nulla da identificare.             Monete: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "Cosa vuoi identificare?             Monete: {:d}"
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr "Questo oggetto è:"
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr "Fatto"
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 msgid "Talk to {:s}"
 msgstr "Parla con {:s}"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 msgid "Talking to {:s}"
 msgstr "Parlare con {:s}"
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 msgid "is not available"
 msgstr "non è disponibile"
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 msgid "in the shareware"
 msgstr "nella demo"
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 msgid "version"
 msgstr "versione"
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr "Pettegolezzo"
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr "Il Sol Levante"
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 msgid "Talk to Ogden"
 msgstr "Parla con Ogden"
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 msgid "Leave the tavern"
 msgstr "Lascia taverna"
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 msgid "Talk to Gillian"
 msgstr "Parla con Gillian"
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr "Farnham l'Ubriaco"
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 msgid "Talk to Farnham"
 msgstr "Parla con Farnham"
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr "Saluta"
 

--- a/Translations/ja.po
+++ b/Translations/ja.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-11-19 03:42+0100\n"
+"POT-Creation-Date: 2021-11-21 05:45+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -750,11 +750,11 @@ msgstr "キャラクター​「​{:s}​」​を​削除​し​て​よ�
 msgid "Enter Hellfire"
 msgstr "ヘルファイア​へ"
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr "はい"
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr "いいえ"
 
@@ -876,172 +876,172 @@ msgstr "レベル: 巣 {:d}"
 msgid "Level: Crypt {:d}"
 msgstr "レベル: 地下​聖堂 {:d}"
 
-#: Source/automap.cpp:508 Source/items.cpp:2076
+#: Source/automap.cpp:508 Source/items.cpp:2090
 msgid "Level: {:d}"
 msgstr "レベル: {:d}"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr "Tab"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr "Esc"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Enter"
 msgstr "入力"
 
-#: Source/control.cpp:202
+#: Source/control.cpp:215
 msgid "Character Information"
 msgstr "キャラクター​情報"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr "クエスト​の​記録"
 
-#: Source/control.cpp:204
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr "オート​マップ"
 
-#: Source/control.cpp:205
+#: Source/control.cpp:218
 msgid "Main Menu"
 msgstr "メインメニュー"
 
-#: Source/control.cpp:206
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr "所持​品​の​一覧"
 
-#: Source/control.cpp:207
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr "スペル​ブック"
 
-#: Source/control.cpp:208
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr "メッセージ​送信"
 
-#: Source/control.cpp:705 Source/control.cpp:1566
+#: Source/control.cpp:718 Source/control.cpp:1587
 msgid "Skill"
 msgstr "スキル"
 
-#: Source/control.cpp:706 Source/control.cpp:1220
+#: Source/control.cpp:719 Source/control.cpp:1237
 msgid "{:s} Skill"
 msgstr "{:s} スキル"
 
-#: Source/control.cpp:712
+#: Source/control.cpp:725
 msgid "Spell"
 msgstr "スペル"
 
-#: Source/control.cpp:713 Source/control.cpp:1224
+#: Source/control.cpp:726 Source/control.cpp:1241
 msgid "{:s} Spell"
 msgstr "{:s} スペル"
 
-#: Source/control.cpp:715
+#: Source/control.cpp:728
 msgid "Damages undead only"
 msgstr "アンデッド​系​に​のみ​ダメージ"
 
-#: Source/control.cpp:719 Source/control.cpp:1228 Source/control.cpp:1590
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr "スペル​レベル 0 - 使え​ない"
 
-#: Source/control.cpp:721 Source/control.cpp:1230 Source/control.cpp:1592
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 msgid "Spell Level {:d}"
 msgstr "スペル​レベル {:d}"
 
-#: Source/control.cpp:728
+#: Source/control.cpp:741
 msgid "Scroll"
 msgstr "スクロール"
 
-#: Source/control.cpp:729 Source/control.cpp:1234
+#: Source/control.cpp:742 Source/control.cpp:1251
 msgid "Scroll of {:s}"
 msgstr "{:s}​の​スクロール"
 
-#: Source/control.cpp:734 Source/control.cpp:1240
+#: Source/control.cpp:747 Source/control.cpp:1257
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "{:d} スクロール"
 
-#: Source/control.cpp:741 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
 #: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
 msgid "Staff"
 msgstr "スタッフ"
 
-#: Source/control.cpp:742 Source/control.cpp:1244 Source/items.cpp:1317
+#: Source/control.cpp:755 Source/control.cpp:1261
 msgid "Staff of {:s}"
 msgstr "{:s}​・​スタッフ"
 
-#: Source/control.cpp:744 Source/control.cpp:1246
+#: Source/control.cpp:757 Source/control.cpp:1263
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "{:d}チャージ"
 
-#: Source/control.cpp:754
+#: Source/control.cpp:767
 msgid "Spell Hotkey {:s}"
 msgstr "スペルホットキー {:s}"
 
-#: Source/control.cpp:1197
+#: Source/control.cpp:1214
 msgid "Player friendly"
 msgstr "プレイヤー​は​味方"
 
-#: Source/control.cpp:1199
+#: Source/control.cpp:1216
 msgid "Player attack"
 msgstr "プレイヤー​の​攻撃"
 
-#: Source/control.cpp:1202
+#: Source/control.cpp:1219
 msgid "Hotkey: {:s}"
 msgstr "ホットキー: {:s}"
 
-#: Source/control.cpp:1210
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr "正しい​呪文​ボタン​を​選択​し​て​ください"
 
-#: Source/control.cpp:1213
+#: Source/control.cpp:1230
 msgid "Hotkey: 's'"
 msgstr "ホットキー: ’s’"
 
-#: Source/control.cpp:1368 Source/inv.cpp:1979 Source/items.cpp:3729
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "{:d} 金魂"
 
-#: Source/control.cpp:1371
+#: Source/control.cpp:1390
 msgid "Requirements not met"
 msgstr "能力​値​が​不足​し​て​い​ます"
 
-#: Source/control.cpp:1407
+#: Source/control.cpp:1426
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Level: {:d}"
 
-#: Source/control.cpp:1409
+#: Source/control.cpp:1428
 msgid "Hit Points {:d} of {:d}"
 msgstr "ヒット​ポイント: {:d}/{:d}"
 
-#: Source/control.cpp:1436
+#: Source/control.cpp:1457
 msgid "Level Up"
 msgstr "レベルアップ"
 
-#: Source/control.cpp:1570
+#: Source/control.cpp:1591
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] "スタッフ ({:d} チェージ)"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1580
+#: Source/control.cpp:1601
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "マナ: {:d}  ダメージ: {:d} - {:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1582
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "マナ: {:d}   ダメージ: -"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1585
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "マナ: {:d}  ダメージ: 1/3 ターゲット​HP"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1643
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] "あなたは{:d}ゴールドを持っています。何枚削除しますか？"
@@ -1788,23 +1788,23 @@ msgstr ""
 "2​冊​以上​の​本​を​読む​こと​で、その​呪文​の​知識​が​増え、より​効果的​に​呪文​を​唱える​こと​が​"
 "でき​ます。"
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Shareware Hellfire Help"
 msgstr "シェアウェア ヘルファイア ヘルプ"
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Hellfire Help"
 msgstr "ヘルファイア ヘルプ"
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Shareware Diablo Help"
 msgstr "シェアウェア ディアブロ ヘルプ"
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Diablo Help"
 msgstr "ディアブロ ヘルプ"
 
-#: Source/help.cpp:161
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr "ESC​を​押し​て​終了​する​か、矢印​キー​で​スクロール​し​ます。"
 
@@ -3610,635 +3610,649 @@ msgstr "ハーデニング​・​オイル"
 msgid "Oil of Imperviousness"
 msgstr "インプレビュスネス​・​オイル"
 
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#: Source/items.cpp:1174 Source/items.cpp:1184 Source/items.cpp:1233
-#: Source/items.cpp:1269
-msgid "{0} {1}"
-msgstr "{0} {1}"
-
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's Staff of Firewall
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Long Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1187 Source/items.cpp:1254 Source/items.cpp:1273
-#: Source/items.cpp:1315
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
+#, fuzzy
+#| msgid "{0} of {1}"
+msgctxt "spell"
 msgid "{0} of {1}"
 msgstr "{1}​の​{0}"
 
-#: Source/items.cpp:1892 Source/items.cpp:1904
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+#, fuzzy
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr "{2}​の{0}{1}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+#, fuzzy
+msgid "{0} {1} of {2}"
+msgstr "{2}​の{0}{1}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
+#: Source/items.cpp:1217
+#, fuzzy
+msgid "{0} {1}"
+msgstr "{0} {1}"
+
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
+msgid "{0} of {1}"
+msgstr "{1}​の​{0}"
+
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr "武器​の​命中​率​を"
 
-#: Source/items.cpp:1894
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr "上昇​さ​せる"
 
-#: Source/items.cpp:1898
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr "武器​の​命中​率​を"
 
-#: Source/items.cpp:1900
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr "大幅​に​上昇​さ​せる"
 
-#: Source/items.cpp:1906
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr "増大​さ​せる"
 
-#: Source/items.cpp:1910
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr "武器​の​ダメージ​を​大幅​に"
 
-#: Source/items.cpp:1912
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr "増大​さ​せる​-​ボウ​を​除く"
 
-#: Source/items.cpp:1916
+#: Source/items.cpp:1930
 msgid "reduces attributes needed"
 msgstr "防具​や​武器​の​必要​能力​値"
 
-#: Source/items.cpp:1918
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr "の​値​を​引き下げる"
 
-#: Source/items.cpp:1922
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr "を​20​%​回復"
 
-#: Source/items.cpp:1924
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr "アイテム​の​耐久​度"
 
-#: Source/items.cpp:1928
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr "次​の​もの​を​増大​さ​せ​ます:"
 
-#: Source/items.cpp:1930
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr "20​%​増大​さ​せる"
 
-#: Source/items.cpp:1934
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr "アイテム​を​壊れ​ない​よう​に​し​ます"
 
-#: Source/items.cpp:1938
+#: Source/items.cpp:1952
 msgid "increases the armor class"
 msgstr "防具​と​盾​の​防御​力​を"
 
-#: Source/items.cpp:1940
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr "増大​さ​せる"
 
-#: Source/items.cpp:1944
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr "防具​と​盾​の​防御​力​を"
 
-#: Source/items.cpp:1946
+#: Source/items.cpp:1960
 msgid "class of armor and shields"
 msgstr "大幅​に​増大​さ​せる"
 
-#: Source/items.cpp:1950 Source/items.cpp:1959
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr "ファイヤー​トラップ​を​設置"
 
-#: Source/items.cpp:1955
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr "ライトニング​トラップ​を​設置"
 
-#: Source/items.cpp:1963
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr "石化​トラップ​を​設置"
 
-#: Source/items.cpp:1967
+#: Source/items.cpp:1981
 msgid "restore all life"
 msgstr "ライフ​を​全​回復"
 
-#: Source/items.cpp:1971
+#: Source/items.cpp:1985
 msgid "restore some life"
 msgstr "ライフ​を​回復"
 
-#: Source/items.cpp:1975
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr "ライフ​の​回復"
 
-#: Source/items.cpp:1979
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr "デッドリー​ヒール"
 
-#: Source/items.cpp:1983
+#: Source/items.cpp:1997
 msgid "restore some mana"
 msgstr "マナ​を​回復"
 
-#: Source/items.cpp:1987
+#: Source/items.cpp:2001
 msgid "restore all mana"
 msgstr "マナ​を​全​回復"
 
-#: Source/items.cpp:1991
+#: Source/items.cpp:2005
 msgid "increase strength"
 msgstr "STR を​増大"
 
-#: Source/items.cpp:1995
+#: Source/items.cpp:2009
 msgid "increase magic"
 msgstr "MAG を​増大"
 
-#: Source/items.cpp:1999
+#: Source/items.cpp:2013
 msgid "increase dexterity"
 msgstr "DEX を​増大"
 
-#: Source/items.cpp:2003
+#: Source/items.cpp:2017
 msgid "increase vitality"
 msgstr "VIT を​増大"
 
-#: Source/items.cpp:2008
+#: Source/items.cpp:2022
 msgid "decrease strength"
 msgstr "STR を​減少"
 
-#: Source/items.cpp:2012
+#: Source/items.cpp:2026
 msgid "decrease dexterity"
 msgstr "DEX を​減少"
 
-#: Source/items.cpp:2016
+#: Source/items.cpp:2030
 msgid "decrease vitality"
 msgstr "VIT を​減少"
 
-#: Source/items.cpp:2020
+#: Source/items.cpp:2034
 msgid "restore some life and mana"
 msgstr "ライフ​と​マナ​を​回復"
 
-#: Source/items.cpp:2024
+#: Source/items.cpp:2038
 msgid "restore all life and mana"
 msgstr "ライフ​と​マナ​を​全​回復"
 
-#: Source/items.cpp:2039 Source/items.cpp:2064
+#: Source/items.cpp:2053 Source/items.cpp:2078
 msgid "Right-click to read"
 msgstr "右​クリック​で​読む"
 
-#: Source/items.cpp:2043
+#: Source/items.cpp:2057
 msgid "Right-click to read, then"
 msgstr "右​クリック​で​読み、次​に"
 
-#: Source/items.cpp:2045
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr "左​クリック​で​ターゲット"
 
-#: Source/items.cpp:2050
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr "右​クリック​で​使用"
 
-#: Source/items.cpp:2055 Source/items.cpp:2060
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr "右​クリック​で​使用"
 
-#: Source/items.cpp:2068
+#: Source/items.cpp:2082
 msgid "Right click to read"
 msgstr "右​クリック​で​読む"
 
-#: Source/items.cpp:2072
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr "右​クリック​で​表示"
 
-#: Source/items.cpp:2080
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr "ゴールド​の​容量​を​2​倍​に​する"
 
-#: Source/items.cpp:2092 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 msgid "Required:"
 msgstr "必要​能力:"
 
-#: Source/items.cpp:2094 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 msgid " {:d} Str"
 msgstr " {:d} Str"
 
-#: Source/items.cpp:2096 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 msgid " {:d} Mag"
 msgstr " {:d} Mag"
 
-#: Source/items.cpp:2098 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 msgid " {:d} Dex"
 msgstr " {:d} Dex"
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3513 Source/player.cpp:3018
+#: Source/items.cpp:3533 Source/player.cpp:3018
 msgid "Ear of {:s}"
 msgstr "{:s}​の​耳"
 
-#: Source/items.cpp:3808
+#: Source/items.cpp:3828
 msgid "chance to hit: {:+d}%"
 msgstr "命中​率: {:+d}​%"
 
-#: Source/items.cpp:3812
+#: Source/items.cpp:3832
 #, no-c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}​%​ダメージ"
 
-#: Source/items.cpp:3816 Source/items.cpp:4072
+#: Source/items.cpp:3836 Source/items.cpp:4092
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "命中​率:{:+d}​%​, {:+d}​% ダメージ"
 
-#: Source/items.cpp:3820
+#: Source/items.cpp:3840
 #, no-c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}​%​防護​力"
 
-#: Source/items.cpp:3824
+#: Source/items.cpp:3844
 msgid "armor class: {:d}"
 msgstr "防御​力: {:d}"
 
-#: Source/items.cpp:3829 Source/items.cpp:4054
+#: Source/items.cpp:3849 Source/items.cpp:4074
 msgid "Resist Fire: {:+d}%"
 msgstr "耐火​炎: {:+d}​%"
 
-#: Source/items.cpp:3831
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr "耐火​炎: 75​% MAX"
 
-#: Source/items.cpp:3836
+#: Source/items.cpp:3856
 msgid "Resist Lightning: {:+d}%"
 msgstr "耐​電撃: {:+d}​%"
 
-#: Source/items.cpp:3838
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr "耐​電撃: 75​% MAX"
 
-#: Source/items.cpp:3843
+#: Source/items.cpp:3863
 msgid "Resist Magic: {:+d}%"
 msgstr "耐​魔法: {:+d}​%"
 
-#: Source/items.cpp:3845
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr "耐​魔法: 75​% MAX"
 
-#: Source/items.cpp:3850
+#: Source/items.cpp:3870
 msgid "Resist All: {:+d}%"
 msgstr "全​耐性: {:+d}​%"
 
-#: Source/items.cpp:3852
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr "全​耐性: 75​% MAX"
 
-#: Source/items.cpp:3856
+#: Source/items.cpp:3876
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] "全呪文{:d} レベルアップ"
 
-#: Source/items.cpp:3858
+#: Source/items.cpp:3878
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "全呪文{:d}レベルダウン"
 
-#: Source/items.cpp:3860
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr "呪文​の​レベル​に​変化​なし​(​?​)"
 
-#: Source/items.cpp:3863
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr "追加​チャージ"
 
-#: Source/items.cpp:3866
+#: Source/items.cpp:3886
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:d} {:s}チャージ"
 
-#: Source/items.cpp:3870
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr "追加​火炎​ダメージ:{:d}"
 
-#: Source/items.cpp:3872
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "追加​火炎​ダメージ: {:d}-{:d}"
 
-#: Source/items.cpp:3876
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr "追加​電撃​ダメージ: {:d}"
 
-#: Source/items.cpp:3878
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "追加​電撃​ダメージ: {:d}-{:d}"
 
-#: Source/items.cpp:3882
+#: Source/items.cpp:3902
 msgid "{:+d} to strength"
 msgstr "STR{:+d}"
 
-#: Source/items.cpp:3886
+#: Source/items.cpp:3906
 msgid "{:+d} to magic"
 msgstr "MAG{:+d}"
 
-#: Source/items.cpp:3890
+#: Source/items.cpp:3910
 msgid "{:+d} to dexterity"
 msgstr "DEX{:+d}"
 
-#: Source/items.cpp:3894
+#: Source/items.cpp:3914
 msgid "{:+d} to vitality"
 msgstr "VIT{:+d}"
 
-#: Source/items.cpp:3898
+#: Source/items.cpp:3918
 msgid "{:+d} to all attributes"
 msgstr "全​能力​値​{:+d}"
 
-#: Source/items.cpp:3902
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr "敵​から​受ける​ダメージ​{:+d}"
 
-#: Source/items.cpp:3906
+#: Source/items.cpp:3926
 msgid "Hit Points: {:+d}"
 msgstr "ヒット​ポイント: {:+d}"
 
-#: Source/items.cpp:3910
+#: Source/items.cpp:3930
 msgid "Mana: {:+d}"
 msgstr "マナ: {:+d}"
 
-#: Source/items.cpp:3913
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr "高い​耐久​度"
 
-#: Source/items.cpp:3916
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr "低い​耐久​度"
 
-#: Source/items.cpp:3919
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr "壊れ​ない"
 
-#: Source/items.cpp:3922
+#: Source/items.cpp:3942
 #, no-c-format
 msgid "+{:d}% light radius"
 msgstr "視界​+{:d}​%"
 
-#: Source/items.cpp:3925
+#: Source/items.cpp:3945
 #, no-c-format
 msgid "-{:d}% light radius"
 msgstr "視界​-{:d}​%"
 
-#: Source/items.cpp:3928
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr "一回​の​射撃​で​複数​の​矢​を​放つ"
 
-#: Source/items.cpp:3932
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr "火炎​矢​の​ダメージ: {:d}"
 
-#: Source/items.cpp:3934
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "火炎​矢​の​ダメージ: {:d}-{:d}"
 
-#: Source/items.cpp:3938
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr "電撃​矢​の​ダメージ: {:d}"
 
-#: Source/items.cpp:3940
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "電撃​矢​の​ダメージ: {:d}-{:d}"
 
-#: Source/items.cpp:3944
+#: Source/items.cpp:3964
 msgid "fireball damage: {:d}"
 msgstr "ファイヤーボールダメージ: {:d}"
 
-#: Source/items.cpp:3946
+#: Source/items.cpp:3966
 msgid "fireball damage: {:d}-{:d}"
 msgstr "ファイヤーボールダメージ: {:d}-{:d}"
 
-#: Source/items.cpp:3949
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr "ダメージ​時​に​反撃:1-3"
 
-#: Source/items.cpp:3952
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr "全て​の​マナ​を​失う"
 
-#: Source/items.cpp:3955
+#: Source/items.cpp:3975
 msgid "you can't heal"
 msgstr "ライフ​を​回復​でき​ない"
 
-#: Source/items.cpp:3958
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr "罠​に​よる​ダメージ​半減"
 
-#: Source/items.cpp:3961
+#: Source/items.cpp:3981
 msgid "knocks target back"
 msgstr "ノック​バック​効果"
 
-#: Source/items.cpp:3964
+#: Source/items.cpp:3984
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr "対​悪魔​族​ダメージ​+200​%"
 
-#: Source/items.cpp:3967
+#: Source/items.cpp:3987
 msgid "All Resistance equals 0"
 msgstr "全て​の​耐性​を​失う"
 
-#: Source/items.cpp:3970
+#: Source/items.cpp:3990
 msgid "hit monster doesn't heal"
 msgstr "攻撃​を​受け​た​モンスター​は​回復​でき​ない"
 
-#: Source/items.cpp:3974
+#: Source/items.cpp:3994
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr "マナ​を​3​%​吸収"
 
-#: Source/items.cpp:3976
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr "マナ​を​5​%​吸収"
 
-#: Source/items.cpp:3980
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr "ライフ​を​3​%​吸収"
 
-#: Source/items.cpp:3982
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr "ライフ​を​5​%​吸収"
 
-#: Source/items.cpp:3985
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr "ターゲット​の​アーマー​を​貫通"
 
-#: Source/items.cpp:3989
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr "速い​攻撃"
 
-#: Source/items.cpp:3991
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr "高速​攻撃"
 
-#: Source/items.cpp:3993
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr "超​高速​攻撃"
 
-#: Source/items.cpp:3995
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr "神速​攻撃"
 
-#: Source/items.cpp:3999
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr "高速​体勢​回復"
 
-#: Source/items.cpp:4001
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr "早い​体勢​回復"
 
-#: Source/items.cpp:4003
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr "神速​体勢​回復"
 
-#: Source/items.cpp:4006
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr "早い​防御"
 
-#: Source/items.cpp:4009
+#: Source/items.cpp:4029
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] "追加ダメージ: {:d}"
 
-#: Source/items.cpp:4012
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr "発射​間隔​が​一定​で​ない"
 
-#: Source/items.cpp:4015
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr "魔法​の​アイテム​に​ダメージ"
 
-#: Source/items.cpp:4018
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr "特殊​な​耐久​度"
 
-#: Source/items.cpp:4021
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr "早い​攻撃​準備"
 
-#: Source/items.cpp:4024
+#: Source/items.cpp:4044
 msgid "one handed sword"
 msgstr "片手​持ち​ソード"
 
-#: Source/items.cpp:4027
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr "少し​ずつ​ライフ​を​失う"
 
-#: Source/items.cpp:4030
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr "直接​攻撃​で​ライフ​吸収"
 
-#: Source/items.cpp:4033
+#: Source/items.cpp:4053
 msgid "no strength requirement"
 msgstr "筋力​を​必要​と​し​ない"
 
-#: Source/items.cpp:4036
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr "インフラ​ビジョン​の​効果"
 
-#: Source/items.cpp:4043
+#: Source/items.cpp:4063
 msgid "lightning damage: {:d}"
 msgstr "電撃​ダメージ: {:d}"
 
-#: Source/items.cpp:4045
+#: Source/items.cpp:4065
 msgid "lightning damage: {:d}-{:d}"
 msgstr "電撃​ダメージ: {:d}-{:d}"
 
-#: Source/items.cpp:4048
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr "チャージド​ボルト"
 
-#: Source/items.cpp:4057
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr "たまに​3​倍​の​ダメージ"
 
-#: Source/items.cpp:4060
+#: Source/items.cpp:4080
 #, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr "崩壊​{:+d}​%​ダメージ"
 
-#: Source/items.cpp:4063
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr "モンスター​に​2​倍​の​ダメージ、自分​に​1​倍​の​ダメージ"
 
-#: Source/items.cpp:4066
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr "ランダム​に​0​～​500​％​の​ダメージ"
 
-#: Source/items.cpp:4069
+#: Source/items.cpp:4089
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr "低い​耐久性、{:+d}​%​の​ダメージ"
 
-#: Source/items.cpp:4075
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr "対​悪魔​族​の​追加​AC"
 
-#: Source/items.cpp:4078
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr "対​アンデッド​用​の​追加​AC"
 
-#: Source/items.cpp:4081
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr "50​%​の​マナ​を​ヘルス​に​移動"
 
-#: Source/items.cpp:4084
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr "40​%​の​ヘルス​を​マナ​に​移動"
 
-#: Source/items.cpp:4087
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr "別​の​能力​（​NW​）"
 
-#: Source/items.cpp:4124 Source/items.cpp:4171
+#: Source/items.cpp:4144 Source/items.cpp:4191
 msgid "damage: {:d}  Indestructible"
 msgstr "ダメージ:{:d}  壊れ​ない"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4126 Source/items.cpp:4173
+#: Source/items.cpp:4146 Source/items.cpp:4193
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "ダメージ:{:d}  耐久​度:{:d}/{:d}"
 
-#: Source/items.cpp:4129 Source/items.cpp:4176
+#: Source/items.cpp:4149 Source/items.cpp:4196
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "ダメージ: {:d}-{:d}  壊れ​ない"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4131 Source/items.cpp:4178
+#: Source/items.cpp:4151 Source/items.cpp:4198
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "ダメージ:{:d}  耐久​度:{:d}/{:d}"
 
-#: Source/items.cpp:4137 Source/items.cpp:4190
+#: Source/items.cpp:4157 Source/items.cpp:4210
 msgid "armor: {:d}  Indestructible"
 msgstr "防御​力:{:d}  壊れ​ない"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4139 Source/items.cpp:4192
+#: Source/items.cpp:4159 Source/items.cpp:4212
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "防御​力: {:d}  耐久​度: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4144
+#: Source/items.cpp:4164
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "ダメージ:{:d}  耐久​度:{:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4146
+#: Source/items.cpp:4166
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "ダメージ:{:d}-{:d}  耐久​度:{:d}/{:d}"
 
-#: Source/items.cpp:4147 Source/items.cpp:4182 Source/items.cpp:4197
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 msgid "Charges: {:d}/{:d}"
 msgstr "チャージ: {:d}/{:d}"
 
-#: Source/items.cpp:4159
+#: Source/items.cpp:4179
 msgid "unique item"
 msgstr "ユニーク​アイテム"
 
-#: Source/items.cpp:4186 Source/items.cpp:4195 Source/items.cpp:4202
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr "未​鑑定"
 
@@ -6450,7 +6464,7 @@ msgstr "ファーンハム"
 msgid "Adria"
 msgstr "エイドリア"
 
-#: Source/stores.cpp:98 Source/stores.cpp:1252
+#: Source/stores.cpp:98 Source/stores.cpp:1305
 msgid "Gillian"
 msgstr "ジリアン"
 
@@ -6458,298 +6472,293 @@ msgstr "ジリアン"
 msgid "Wirt"
 msgstr "ワート"
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr "戻る"
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ",  "
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 msgid "Damage: {:d}-{:d}  "
 msgstr "ダメージ: {:d}-{:d}  "
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 msgid "Armor: {:d}  "
 msgstr "防御​力: {:d}  "
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 msgid "Dur: {:d}/{:d},  "
 msgstr "耐久​度: {:d}/{:d},  "
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr "壊れ​ない​,  "
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr "必要​能力:​無し"
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr "ようこそ​!"
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr "グリズウォルド​の​鍛冶屋​へ"
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr "何​を​する​?"
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 msgid "Talk to Griswold"
 msgstr "グリズウォルド​と​話す"
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 msgid "Buy basic items"
 msgstr "ベーシック​アイテム​を​買う"
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 msgid "Buy premium items"
 msgstr "プレミアム​アイテム​を​買う"
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 msgid "Sell items"
 msgstr "アイテム​を​売る"
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 msgid "Repair items"
 msgstr "アイテム​の​修理"
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 msgid "Leave the shop"
 msgstr "店​を​出る"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "さて、何​が​欲しい​ん​だ​い​?​:             所持​金: {:d}"
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr "戻る"
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "どれ​も​珍しい​アイテム​だろう​?​:     所持​金 {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "何​も​買える​物​は​ない​よう​だ​が。             所持​金: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "何​を​売っ​て​くれる​ん​だ​い​?             所持​金: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "何​も​壊れ​ちゃ​い​ない​ぞ。             所持​金: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "どれ​を​直す​ん​だ​?             所持​金: {:d}"
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr "魔女​の​小屋"
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 msgid "Talk to Adria"
 msgstr "エイドリア​と​話す"
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr "アイテム​を​買う"
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr "リチャージ​する"
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 msgid "Leave the shack"
 msgstr "小屋​を​立ち去る"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "リチャージ​できる​もの​は​無い​よ。             所持​金: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "どれ​に​リチャージ​する​ん​だ​い​?             所持​金: {:d}"
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr "所持​金​が​足り​ませ​ん"
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr "置く​場所​が​あり​ませ​ん"
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr "よろしい​です​か​?"
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 msgid "Are you sure you want to identify this item?"
 msgstr "これ​を​鑑定​する​の​だ​ね​?"
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 msgid "Are you sure you want to buy this item?"
 msgstr "これ​を​買う​の​だ​ね​?"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 msgid "Are you sure you want to recharge this item?"
 msgstr "これ​に​リチャージ​する​ん​だ​ね​?"
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 msgid "Are you sure you want to sell this item?"
 msgstr "これ​を​売っ​て​くれる​ん​だ​ね​?"
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 msgid "Are you sure you want to repair this item?"
 msgstr "これ​を​直す​ん​だ​な​?"
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr "義足​の​少年​ワート"
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 msgid "Talk to Wirt"
 msgstr "ワート​と​話す"
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr "俺​は​いい​もの​を​持っ​て​いる。"
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr "で​も、50​ゴールド​払わ​なきゃ"
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr "見せ​て​やら​ない​ぜ。"
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr "払う​?"
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr "立ち去る"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "さて、何​が​欲しい​ん​だ​い​?​:             所持​金: {:d}"
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 msgid "Leave"
 msgstr "去る"
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr "治療​師​の​家"
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr "ペピン​と​話す"
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr "治療​師​の​家​を​去る"
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 msgid "The Town Elder"
 msgstr "町​の​語り部"
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 msgid "Talk to Cain"
 msgstr "ケイン​と​話す"
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr "鑑定​し​て​もらう"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "何​も​鑑定​する​もの​は​無い​よう​だ​が。             所持​金: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "何​を​鑑定​する​の​か​ね​?             所持​金: {:d}"
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr "何​を​する​?"
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr "終わる"
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 msgid "Talk to {:s}"
 msgstr "{:s}​と​話す"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 msgid "Talking to {:s}"
 msgstr "{:s}​と​話し​て​いる"
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 msgid "is not available"
 msgstr "使用​不能"
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 msgid "in the shareware"
 msgstr "シェアウェア​で"
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 msgid "version"
 msgstr "バージョン"
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr "噂話"
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr "日の出​亭"
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 msgid "Talk to Ogden"
 msgstr "オグデン​と​話す"
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 msgid "Leave the tavern"
 msgstr "宿屋​を​去る"
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 msgid "Talk to Gillian"
 msgstr "ジリアン​と​話す"
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr "よっぱらい​の​ファーンハム"
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 msgid "Talk to Farnham"
 msgstr "ファーンハム​と​話す"
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr "立ち去る"
 

--- a/Translations/ko_KR.po
+++ b/Translations/ko_KR.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-10-31 23:17+0100\n"
+"POT-Creation-Date: 2021-11-21 05:45+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: NSM53PROJECT <nsm53project@gmail.com>\n"
 "Language-Team: \n"
@@ -390,8 +390,8 @@ msgstr "클라이언트-서버 (TCP)"
 msgid "Loopback"
 msgstr "루프백"
 
-#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:484
-#: Source/DiabloUI/selgame.cpp:505
+#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:489
+#: Source/DiabloUI/selgame.cpp:510
 msgid "Multi Player Game"
 msgstr "멀티 플레이어 게임"
 
@@ -742,11 +742,11 @@ msgstr "\"{:s}\" 캐럭터를 정말로 삭제하겠습니까?"
 msgid "Enter Hellfire"
 msgstr "헬파이어 입장"
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr "예"
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr "아니요"
 
@@ -802,12 +802,12 @@ msgstr ""
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr "Copyright © 1996-2001 Blizzard Entertainment"
 
-#: Source/appfat.cpp:37
+#: Source/appfat.cpp:38
 msgid "Error"
 msgstr "에러"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:101
+#: Source/appfat.cpp:102
 msgid ""
 "{:s}\n"
 "\n"
@@ -817,7 +817,7 @@ msgstr ""
 "\n"
 "오류 발생: {:s} 줄 {:d}"
 
-#: Source/appfat.cpp:116
+#: Source/appfat.cpp:117
 msgid ""
 "Unable to open main data archive ({:s}).\n"
 "\n"
@@ -827,12 +827,12 @@ msgstr ""
 "\n"
 "게임 폴더 안에 있는지 확인해 주십시오."
 
-#: Source/appfat.cpp:122
+#: Source/appfat.cpp:123
 msgid "Data File Error"
 msgstr "데이터 파일 오류"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:130
+#: Source/appfat.cpp:131
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -840,7 +840,7 @@ msgstr ""
 "다음 위치에 기록할 수 없습니다:\n"
 "{:s}"
 
-#: Source/appfat.cpp:132
+#: Source/appfat.cpp:133
 msgid "Read-Only Directory Error"
 msgstr "읽기 전용 디렉토리 오류"
 
@@ -864,172 +864,172 @@ msgstr "둥지 지하 {:d}층"
 msgid "Level: Crypt {:d}"
 msgstr "지하묘소 지하 {:d}층"
 
-#: Source/automap.cpp:508 Source/items.cpp:2076
+#: Source/automap.cpp:508 Source/items.cpp:2090
 msgid "Level: {:d}"
 msgstr "지하 {:d}층"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr "탭"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr "ESC"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Enter"
 msgstr "엔터"
 
-#: Source/control.cpp:202
+#: Source/control.cpp:215
 msgid "Character Information"
 msgstr "캐릭터 정보"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr "퀘스트 로그"
 
-#: Source/control.cpp:204
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr "지도"
 
-#: Source/control.cpp:205
+#: Source/control.cpp:218
 msgid "Main Menu"
 msgstr "메인 메뉴"
 
-#: Source/control.cpp:206
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr "소지품"
 
-#: Source/control.cpp:207
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr "주문서"
 
-#: Source/control.cpp:208
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr "메시지 보내기"
 
-#: Source/control.cpp:764 Source/control.cpp:1572
+#: Source/control.cpp:718 Source/control.cpp:1587
 msgid "Skill"
 msgstr "기술"
 
-#: Source/control.cpp:765 Source/control.cpp:1226
+#: Source/control.cpp:719 Source/control.cpp:1237
 msgid "{:s} Skill"
 msgstr "{:s} 기술"
 
-#: Source/control.cpp:771
+#: Source/control.cpp:725
 msgid "Spell"
 msgstr "주문"
 
-#: Source/control.cpp:772 Source/control.cpp:1230
+#: Source/control.cpp:726 Source/control.cpp:1241
 msgid "{:s} Spell"
 msgstr "{:s} 주문"
 
-#: Source/control.cpp:774
+#: Source/control.cpp:728
 msgid "Damages undead only"
 msgstr "언데드에게만 피해"
 
-#: Source/control.cpp:778 Source/control.cpp:1234 Source/control.cpp:1596
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr "주문 레벨 0 - 사용 불가"
 
-#: Source/control.cpp:780 Source/control.cpp:1236 Source/control.cpp:1598
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 msgid "Spell Level {:d}"
 msgstr "주문 레벨 {:d}"
 
-#: Source/control.cpp:787
+#: Source/control.cpp:741
 msgid "Scroll"
 msgstr "두루마리"
 
-#: Source/control.cpp:788 Source/control.cpp:1240
+#: Source/control.cpp:742 Source/control.cpp:1251
 msgid "Scroll of {:s}"
 msgstr "{:s} 두루마리"
 
-#: Source/control.cpp:793 Source/control.cpp:1246
+#: Source/control.cpp:747 Source/control.cpp:1257
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "{:d} 두루마리"
 
-#: Source/control.cpp:800 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
 #: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
 msgid "Staff"
 msgstr "지팡이"
 
-#: Source/control.cpp:801 Source/control.cpp:1250 Source/items.cpp:1317
+#: Source/control.cpp:755 Source/control.cpp:1261
 msgid "Staff of {:s}"
 msgstr "{:s} 지팡이"
 
-#: Source/control.cpp:803 Source/control.cpp:1252
+#: Source/control.cpp:757 Source/control.cpp:1263
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "{:d}회 충전"
 
-#: Source/control.cpp:813
+#: Source/control.cpp:767
 msgid "Spell Hotkey {:s}"
 msgstr "주문 단축키 {:s}"
 
-#: Source/control.cpp:1203
+#: Source/control.cpp:1214
 msgid "Player friendly"
 msgstr "우호"
 
-#: Source/control.cpp:1205
+#: Source/control.cpp:1216
 msgid "Player attack"
 msgstr "적대"
 
-#: Source/control.cpp:1208
+#: Source/control.cpp:1219
 msgid "Hotkey: {:s}"
 msgstr "단축키: {:s}"
 
-#: Source/control.cpp:1216
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr "현재 주문 버튼 선택"
 
-#: Source/control.cpp:1219
+#: Source/control.cpp:1230
 msgid "Hotkey: 's'"
 msgstr "단축키: 's'"
 
-#: Source/control.cpp:1374 Source/inv.cpp:1992 Source/items.cpp:3739
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "금화 {:d}개"
 
-#: Source/control.cpp:1377
+#: Source/control.cpp:1390
 msgid "Requirements not met"
 msgstr "요구 사항 미충족"
 
-#: Source/control.cpp:1413
+#: Source/control.cpp:1426
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, 레벨: {:d}"
 
-#: Source/control.cpp:1415
+#: Source/control.cpp:1428
 msgid "Hit Points {:d} of {:d}"
 msgstr "히트 포인트 {:d} / {:d}"
 
-#: Source/control.cpp:1442
+#: Source/control.cpp:1457
 msgid "Level Up"
 msgstr "레벨업"
 
-#: Source/control.cpp:1576
+#: Source/control.cpp:1591
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] "지팡이 ({:d}회 충전)"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1586
+#: Source/control.cpp:1601
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "마나: {:d}  피해: {:d} - {:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1588
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "마나: {:d}   피해: 사용불가"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1591
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "마나: {:d}  피해: 대상 HP 1/3"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1649
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] "금화 {:d}개를 갖고 있습니다. 몇 개를 버리겠습니까?"
@@ -1235,7 +1235,7 @@ msgstr "받을 수 없습니다"
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr "{:s}, 버전 = {:s}, 모드 = {:s}"
 
-#: Source/dvlnet/loopback.cpp:111
+#: Source/dvlnet/loopback.cpp:113
 msgid "loopback"
 msgstr "루프백"
 
@@ -1770,35 +1770,35 @@ msgstr ""
 "책을 읽으면 해당 주문에 대한 지식이 늘어 주문을 더욱 효과적으로 시전할 수 있"
 "습니다."
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Shareware Hellfire Help"
 msgstr "체험판 헬파이어 도움말"
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Hellfire Help"
 msgstr "헬파이어 도움말"
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Shareware Diablo Help"
 msgstr "체혐판 디아블로 도움말"
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Diablo Help"
 msgstr "디아블로 도움말"
 
-#: Source/help.cpp:161
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr "ESC를 눌러 종료하거나 방향키를 이용해 스크롤해 주세요."
 
-#: Source/init.cpp:206
+#: Source/init.cpp:175
 msgid "diabdat.mpq or spawn.mpq"
 msgstr ""
 
-#: Source/init.cpp:226
+#: Source/init.cpp:196
 msgid "Some Hellfire MPQs are missing"
 msgstr "헬파이어 관련된 일부 MPQ 파일들이 존재하지 않습니다"
 
-#: Source/init.cpp:226
+#: Source/init.cpp:196
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
@@ -1806,7 +1806,7 @@ msgstr ""
 "헬파이어 관련 모든 MPQ 파일들을 찾을수 없습니다.\n"
 "hf*.mpq 파일들을 모두 복사해주세요."
 
-#: Source/init.cpp:234
+#: Source/init.cpp:204
 msgid "Unable to create main window"
 msgstr "메인 윈도우를 생성할 수 없습니다"
 
@@ -2050,7 +2050,7 @@ msgid "Quilted Armor"
 msgstr ""
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
-#: Source/itemdat.cpp:77 Source/objects.cpp:5478
+#: Source/itemdat.cpp:77 Source/objects.cpp:5433
 msgid "Armor"
 msgstr ""
 
@@ -3592,639 +3592,650 @@ msgstr ""
 msgid "Oil of Imperviousness"
 msgstr ""
 
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
+msgctxt "spell"
+msgid "{0} of {1}"
+msgstr ""
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+#, fuzzy
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr "{0} {2} of {1}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+#, fuzzy
+msgid "{0} {1} of {2}"
+msgstr "{0} {2} of {1}"
+
 #. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#: Source/items.cpp:1174 Source/items.cpp:1184 Source/items.cpp:1233
-#: Source/items.cpp:1269
+#: Source/items.cpp:1217
 msgid "{0} {1}"
 msgstr ""
 
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's Staff of Firewall
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Long Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1187 Source/items.cpp:1254 Source/items.cpp:1273
-#: Source/items.cpp:1315
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
 msgid "{0} of {1}"
 msgstr ""
 
 # 어순이 문제가 됨
-#: Source/items.cpp:1892 Source/items.cpp:1904
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr ""
 
-#: Source/items.cpp:1894
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr ""
 
-#: Source/items.cpp:1898
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr ""
 
-#: Source/items.cpp:1900
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr ""
 
-#: Source/items.cpp:1906
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr ""
 
-#: Source/items.cpp:1910
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr ""
 
-#: Source/items.cpp:1912
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr ""
 
-#: Source/items.cpp:1916
+#: Source/items.cpp:1930
 msgid "reduces attributes needed"
 msgstr ""
 
-#: Source/items.cpp:1918
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr ""
 
-#: Source/items.cpp:1922
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr ""
 
-#: Source/items.cpp:1924
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr ""
 
-#: Source/items.cpp:1928
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr ""
 
-#: Source/items.cpp:1930
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr ""
 
-#: Source/items.cpp:1934
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr ""
 
-#: Source/items.cpp:1938
+#: Source/items.cpp:1952
 msgid "increases the armor class"
 msgstr ""
 
-#: Source/items.cpp:1940
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr ""
 
-#: Source/items.cpp:1944
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr ""
 
-#: Source/items.cpp:1946
+#: Source/items.cpp:1960
 msgid "class of armor and shields"
 msgstr ""
 
-#: Source/items.cpp:1950 Source/items.cpp:1959
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr "화염 함정 설치"
 
-#: Source/items.cpp:1955
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr "번개 함정 설치"
 
-#: Source/items.cpp:1963
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr "석화 함정 설치"
 
-#: Source/items.cpp:1967
+#: Source/items.cpp:1981
 msgid "restore all life"
 msgstr "생명 전체 회복"
 
-#: Source/items.cpp:1971
+#: Source/items.cpp:1985
 msgid "restore some life"
 msgstr "생명 일부 회복"
 
-#: Source/items.cpp:1975
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr "생명 회복"
 
-#: Source/items.cpp:1979
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr "치명적 치료"
 
-#: Source/items.cpp:1983
+#: Source/items.cpp:1997
 msgid "restore some mana"
 msgstr "마나 일부 회복"
 
-#: Source/items.cpp:1987
+#: Source/items.cpp:2001
 msgid "restore all mana"
 msgstr "마나 전체 회복"
 
-#: Source/items.cpp:1991
+#: Source/items.cpp:2005
 msgid "increase strength"
 msgstr "힘 증가"
 
-#: Source/items.cpp:1995
+#: Source/items.cpp:2009
 msgid "increase magic"
 msgstr "마력 증가"
 
-#: Source/items.cpp:1999
+#: Source/items.cpp:2013
 msgid "increase dexterity"
 msgstr "민첩 증가"
 
-#: Source/items.cpp:2003
+#: Source/items.cpp:2017
 msgid "increase vitality"
 msgstr "생명력 증가"
 
-#: Source/items.cpp:2008
+#: Source/items.cpp:2022
 msgid "decrease strength"
 msgstr "힘 감소"
 
-#: Source/items.cpp:2012
+#: Source/items.cpp:2026
 msgid "decrease dexterity"
 msgstr "민첩 감소"
 
-#: Source/items.cpp:2016
+#: Source/items.cpp:2030
 msgid "decrease vitality"
 msgstr "생명력 감소"
 
-#: Source/items.cpp:2020
+#: Source/items.cpp:2034
 msgid "restore some life and mana"
 msgstr "생명과 마나 일부 회복"
 
-#: Source/items.cpp:2024
+#: Source/items.cpp:2038
 msgid "restore all life and mana"
 msgstr "생명과 마나 전부 회복"
 
-#: Source/items.cpp:2039 Source/items.cpp:2064
+#: Source/items.cpp:2053 Source/items.cpp:2078
 msgid "Right-click to read"
 msgstr "우클릭으로 읽기"
 
 # 조합 방식 확인 필요
-#: Source/items.cpp:2043
+#: Source/items.cpp:2057
 msgid "Right-click to read, then"
 msgstr "우클릭으로 읽고"
 
-#: Source/items.cpp:2045
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr "좌클릭으로 목표 지정"
 
-#: Source/items.cpp:2050
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr "우클릭으로 사용"
 
-#: Source/items.cpp:2055 Source/items.cpp:2060
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr "우클릭으로 사용"
 
-#: Source/items.cpp:2068
+#: Source/items.cpp:2082
 msgid "Right click to read"
 msgstr "우클릭으로 읽기"
 
-#: Source/items.cpp:2072
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr "우클릭으로 보기"
 
-#: Source/items.cpp:2080
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr "금화 수용력 두배"
 
-#: Source/items.cpp:2092 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 msgid "Required:"
 msgstr "요구치:"
 
-#: Source/items.cpp:2094 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 msgid " {:d} Str"
 msgstr " {:d} 힘"
 
-#: Source/items.cpp:2096 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 msgid " {:d} Mag"
 msgstr " {:d} 마력"
 
-#: Source/items.cpp:2098 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 msgid " {:d} Dex"
 msgstr " {:d} 민첩"
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3523 Source/player.cpp:3027
+#: Source/items.cpp:3533 Source/player.cpp:3018
 msgid "Ear of {:s}"
 msgstr "{:s}의 귀"
 
-#: Source/items.cpp:3818
+#: Source/items.cpp:3828
 msgid "chance to hit: {:+d}%"
 msgstr "명중률: {:+d}%"
 
-#: Source/items.cpp:3822
+#: Source/items.cpp:3832
 #, no-c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% 피해"
 
-#: Source/items.cpp:3826 Source/items.cpp:4082
+#: Source/items.cpp:3836 Source/items.cpp:4092
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "명중률: {:+d}%, {:+d}% 피해"
 
-#: Source/items.cpp:3830
+#: Source/items.cpp:3840
 #, no-c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% 방어력"
 
-#: Source/items.cpp:3834
+#: Source/items.cpp:3844
 msgid "armor class: {:d}"
 msgstr "방어력: {:d}"
 
-#: Source/items.cpp:3839 Source/items.cpp:4064
+#: Source/items.cpp:3849 Source/items.cpp:4074
 msgid "Resist Fire: {:+d}%"
 msgstr "화염 저항: {:+d}%"
 
-#: Source/items.cpp:3841
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr "화염 저항: 75% 최대치"
 
-#: Source/items.cpp:3846
+#: Source/items.cpp:3856
 msgid "Resist Lightning: {:+d}%"
 msgstr "번개 저항: {:+d}%"
 
-#: Source/items.cpp:3848
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr "번개 저항: 75% 최대치"
 
-#: Source/items.cpp:3853
+#: Source/items.cpp:3863
 msgid "Resist Magic: {:+d}%"
 msgstr "마법 저항: {:+d}%"
 
-#: Source/items.cpp:3855
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr "마법 저항: 75% 최대치"
 
-#: Source/items.cpp:3860
+#: Source/items.cpp:3870
 msgid "Resist All: {:+d}%"
 msgstr "전체 저항: {:+d}%"
 
-#: Source/items.cpp:3862
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr "전체 저항: 75% 최대치"
 
-#: Source/items.cpp:3866
+#: Source/items.cpp:3876
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] "주문이 {:d} 레벨로 상승했다"
 
-#: Source/items.cpp:3868
+#: Source/items.cpp:3878
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "주문이 {:d} 레벨로 하락했다"
 
 # 확인 필요
-#: Source/items.cpp:3870
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr "변동 없는 주문 레벨 (?)"
 
-#: Source/items.cpp:3873
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr "충전 추가분"
 
-#: Source/items.cpp:3876
+#: Source/items.cpp:3886
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:d} {:s} 충전"
 
-#: Source/items.cpp:3880
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr "화염 피해: {:d}"
 
-#: Source/items.cpp:3882
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "화염 피해: {:d}-{:d}"
 
-#: Source/items.cpp:3886
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr "번개 피해: {:d}"
 
-#: Source/items.cpp:3888
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "번개 피해: {:d}-{:d}"
 
-#: Source/items.cpp:3892
+#: Source/items.cpp:3902
 msgid "{:+d} to strength"
 msgstr "힘 {:+d}"
 
-#: Source/items.cpp:3896
+#: Source/items.cpp:3906
 msgid "{:+d} to magic"
 msgstr "마력 {:+d}"
 
-#: Source/items.cpp:3900
+#: Source/items.cpp:3910
 msgid "{:+d} to dexterity"
 msgstr "민첩 {:+d}"
 
-#: Source/items.cpp:3904
+#: Source/items.cpp:3914
 msgid "{:+d} to vitality"
 msgstr "생명력 {:+d}"
 
-#: Source/items.cpp:3908
+#: Source/items.cpp:3918
 msgid "{:+d} to all attributes"
 msgstr "모든 속성 {:+d}"
 
-#: Source/items.cpp:3912
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} 적에게서 받는 피해"
 
-#: Source/items.cpp:3916
+#: Source/items.cpp:3926
 msgid "Hit Points: {:+d}"
 msgstr "히트포인트: {:+d}"
 
-#: Source/items.cpp:3920
+#: Source/items.cpp:3930
 msgid "Mana: {:+d}"
 msgstr "마나: {:+d}"
 
-#: Source/items.cpp:3923
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr "높은 내구도"
 
-#: Source/items.cpp:3926
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr "내구도 감소"
 
-#: Source/items.cpp:3929
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr "영구적"
 
-#: Source/items.cpp:3932
+#: Source/items.cpp:3942
 #, no-c-format
 msgid "+{:d}% light radius"
 msgstr "+{:d}% 불빛 반경"
 
-#: Source/items.cpp:3935
+#: Source/items.cpp:3945
 #, no-c-format
 msgid "-{:d}% light radius"
 msgstr "-{:d}% 불빛 반경"
 
-#: Source/items.cpp:3938
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr "한 번에 여러 발의 화살 쏘기"
 
-#: Source/items.cpp:3942
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr "화염 화살 피해: {:d}"
 
-#: Source/items.cpp:3944
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "화염 화살 피해: {:d}-{:d}"
 
-#: Source/items.cpp:3948
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr "번개 화살 피해 {:d}"
 
-#: Source/items.cpp:3950
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "번개 화살 피해 {:d}-{:d}"
 
-#: Source/items.cpp:3954
+#: Source/items.cpp:3964
 msgid "fireball damage: {:d}"
 msgstr "화염구 피해: {:d}"
 
-#: Source/items.cpp:3956
+#: Source/items.cpp:3966
 msgid "fireball damage: {:d}-{:d}"
 msgstr "화염구 피해: {:d}-{:d}"
 
-#: Source/items.cpp:3959
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr "공격자가 피해를 1-3 받음"
 
-#: Source/items.cpp:3962
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr "사용자가 모든 마나를 잃음"
 
-#: Source/items.cpp:3965
+#: Source/items.cpp:3975
 msgid "you can't heal"
 msgstr "치료할 수 없음"
 
-#: Source/items.cpp:3968
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr "함정 피해 절반 흡수"
 
-#: Source/items.cpp:3971
+#: Source/items.cpp:3981
 msgid "knocks target back"
 msgstr "목표물을 뒤로 밀침"
 
-#: Source/items.cpp:3974
+#: Source/items.cpp:3984
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr "악마 상대 시 +200% 피해"
 
-#: Source/items.cpp:3977
+#: Source/items.cpp:3987
 msgid "All Resistance equals 0"
 msgstr "모든 저항 0"
 
-#: Source/items.cpp:3980
+#: Source/items.cpp:3990
 msgid "hit monster doesn't heal"
 msgstr "적중 시 괴물이 회복하지 않음"
 
-#: Source/items.cpp:3984
+#: Source/items.cpp:3994
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr "적중 시 마나 3% 흡수"
 
-#: Source/items.cpp:3986
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr "적중 시 마나 5% 흡수"
 
-#: Source/items.cpp:3990
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr "적중 시 생명 3% 흡수"
 
-#: Source/items.cpp:3992
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr "적중 시 생명 5% 흡수"
 
-#: Source/items.cpp:3995
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr "목표물의 갑옷을 관통"
 
-#: Source/items.cpp:3999
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr "민첩한 공격"
 
-#: Source/items.cpp:4001
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr "빠른 공격"
 
-#: Source/items.cpp:4003
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr "매우 빠른 공격"
 
-#: Source/items.cpp:4005
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr "가장 빠른 공격"
 
-#: Source/items.cpp:4009
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr "빠른 피해 회복"
 
-#: Source/items.cpp:4011
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr "매우 빠른 피해 회복"
 
-#: Source/items.cpp:4013
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr "가장 빠른 피해 회복"
 
-#: Source/items.cpp:4016
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr "빠른 막기"
 
-#: Source/items.cpp:4019
+#: Source/items.cpp:4029
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] "피해에 {:d} 포인트 추가"
 
-#: Source/items.cpp:4022
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr "무작위 속사"
 
-#: Source/items.cpp:4025
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr "비정상적 물품 손상"
 
-#: Source/items.cpp:4028
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr "내구도 변화"
 
-#: Source/items.cpp:4031
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr "매우 빠른 휘두르기 공격"
 
-#: Source/items.cpp:4034
+#: Source/items.cpp:4044
 msgid "one handed sword"
 msgstr "한손검"
 
-#: Source/items.cpp:4037
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr "지속적인 히트 포인트 상실"
 
-#: Source/items.cpp:4040
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr "생명 흡수"
 
-#: Source/items.cpp:4043
+#: Source/items.cpp:4053
 msgid "no strength requirement"
 msgstr "힘 요구치 없음"
 
-#: Source/items.cpp:4046
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr "초월 시야"
 
-#: Source/items.cpp:4053
+#: Source/items.cpp:4063
 msgid "lightning damage: {:d}"
 msgstr "번개 피해: {:d}"
 
-#: Source/items.cpp:4055
+#: Source/items.cpp:4065
 msgid "lightning damage: {:d}-{:d}"
 msgstr "번개 피해: {:d}-{:d}"
 
 # 마법명 미확정
-#: Source/items.cpp:4058
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr "적중 시 돌격탄"
 
-#: Source/items.cpp:4067
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr "가끔 3배의 피해"
 
-#: Source/items.cpp:4070
+#: Source/items.cpp:4080
 #, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr "{:+d}% 피해 감소"
 
-#: Source/items.cpp:4073
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr "괴물에게 2배, 본인에게 1배의 피해"
 
-#: Source/items.cpp:4076
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr "0 - 500% 무작위 피해"
 
-#: Source/items.cpp:4079
+#: Source/items.cpp:4089
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr "낮은 내구도, {:+d}% 피해"
 
-#: Source/items.cpp:4085
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr "악마 상대 시 추가 방어력"
 
-#: Source/items.cpp:4088
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr "언데드 상대 시 추가 방어력"
 
-#: Source/items.cpp:4091
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr "마나 50%를 생명으로 전환"
 
-#: Source/items.cpp:4094
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr "생명 40%를 마나로 전환"
 
-#: Source/items.cpp:4097
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr "또 다른 능력 (NW)"
 
-#: Source/items.cpp:4134 Source/items.cpp:4181
+#: Source/items.cpp:4144 Source/items.cpp:4191
 msgid "damage: {:d}  Indestructible"
 msgstr "피해: {:d}  영구적"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4136 Source/items.cpp:4183
+#: Source/items.cpp:4146 Source/items.cpp:4193
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "피해: {:d}  내구도: {:d}/{:d}"
 
-#: Source/items.cpp:4139 Source/items.cpp:4186
+#: Source/items.cpp:4149 Source/items.cpp:4196
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "피해: {:d}-{:d}  영구적"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4141 Source/items.cpp:4188
+#: Source/items.cpp:4151 Source/items.cpp:4198
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "피해: {:d}-{:d}  내구도: {:d}/{:d}"
 
-#: Source/items.cpp:4147 Source/items.cpp:4200
+#: Source/items.cpp:4157 Source/items.cpp:4210
 msgid "armor: {:d}  Indestructible"
 msgstr "방어력: {:d}  영구적"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4149 Source/items.cpp:4202
+#: Source/items.cpp:4159 Source/items.cpp:4212
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "방어력: {:d}  내구도: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4154
+#: Source/items.cpp:4164
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "피해: {:d}  내구도: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4156
+#: Source/items.cpp:4166
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "피해: {:d}-{:d}  내구도: {:d}/{:d}"
 
-#: Source/items.cpp:4157 Source/items.cpp:4192 Source/items.cpp:4207
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 msgid "Charges: {:d}/{:d}"
 msgstr "충전: {:d}/{:d}"
 
-#: Source/items.cpp:4169
+#: Source/items.cpp:4179
 msgid "unique item"
 msgstr "희귀 물품"
 
-#: Source/items.cpp:4196 Source/items.cpp:4205 Source/items.cpp:4212
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr "미식별"
 
@@ -5382,98 +5393,98 @@ msgctxt "monster"
 msgid "Doomlock"
 msgstr "파멸자물쇠"
 
-#: Source/monster.cpp:3497
+#: Source/monster.cpp:3479
 msgid "Animal"
 msgstr "짐승"
 
-#: Source/monster.cpp:3499
+#: Source/monster.cpp:3481
 msgid "Demon"
 msgstr "악마"
 
-#: Source/monster.cpp:3501
+#: Source/monster.cpp:3483
 msgid "Undead"
 msgstr "언데드"
 
-#: Source/monster.cpp:4632
+#: Source/monster.cpp:4612
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "종류: {:s}  토벌 수: {:d}"
 
-#: Source/monster.cpp:4634
+#: Source/monster.cpp:4614
 msgid "Total kills: {:d}"
 msgstr "총 토벌 수: {:d}"
 
-#: Source/monster.cpp:4667
+#: Source/monster.cpp:4647
 msgid "Hit Points: {:d}-{:d}"
 msgstr "히트 포인트: {:d}-{:d}"
 
-#: Source/monster.cpp:4673
+#: Source/monster.cpp:4653
 msgid "No magic resistance"
 msgstr "마법 저항 없음"
 
-#: Source/monster.cpp:4677
+#: Source/monster.cpp:4657
 msgid "Resists: "
 msgstr "저항: "
 
-#: Source/monster.cpp:4679 Source/monster.cpp:4690
+#: Source/monster.cpp:4659 Source/monster.cpp:4671
 msgid "Magic "
 msgstr "마법 "
 
-#: Source/monster.cpp:4681 Source/monster.cpp:4692
+#: Source/monster.cpp:4661 Source/monster.cpp:4673
 msgid "Fire "
 msgstr "화염 "
 
-#: Source/monster.cpp:4683 Source/monster.cpp:4694
+#: Source/monster.cpp:4663 Source/monster.cpp:4675
 msgid "Lightning "
 msgstr "번개 "
 
-#: Source/monster.cpp:4688
+#: Source/monster.cpp:4669
 msgid "Immune: "
 msgstr "면역: "
 
-#: Source/monster.cpp:4706
+#: Source/monster.cpp:4688
 msgid "Type: {:s}"
 msgstr "종류: {:s}"
 
-#: Source/monster.cpp:4712 Source/monster.cpp:4719
+#: Source/monster.cpp:4694 Source/monster.cpp:4701
 msgid "No resistances"
 msgstr "저항 없음"
 
-#: Source/monster.cpp:4714 Source/monster.cpp:4724
+#: Source/monster.cpp:4696 Source/monster.cpp:4706
 msgid "No Immunities"
 msgstr "면역 없음"
 
-#: Source/monster.cpp:4717
+#: Source/monster.cpp:4699
 msgid "Some Magic Resistances"
 msgstr "일부 마법 저항"
 
-#: Source/monster.cpp:4722
+#: Source/monster.cpp:4704
 msgid "Some Magic Immunities"
 msgstr "일부 면역 저항"
 
 # 언제 나오는 말인지 확인 필요
-#: Source/msg.cpp:494
+#: Source/msg.cpp:495
 msgid "Trying to drop a floor item?"
 msgstr "물품을 바닥에 떨구려 합니까?"
 
-#: Source/msg.cpp:982 Source/msg.cpp:1017 Source/msg.cpp:1048
-#: Source/msg.cpp:1175 Source/msg.cpp:1207 Source/msg.cpp:1239
-#: Source/msg.cpp:1269
+#: Source/msg.cpp:994 Source/msg.cpp:1029 Source/msg.cpp:1060
+#: Source/msg.cpp:1187 Source/msg.cpp:1219 Source/msg.cpp:1251
+#: Source/msg.cpp:1281
 msgid "{:s} has cast an illegal spell."
 msgstr "{:s}이(가) 불법 주문을 시전했습니다."
 
-#: Source/msg.cpp:1655 Source/multi.cpp:805
+#: Source/msg.cpp:1668 Source/multi.cpp:804
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr "플레이어 '{:s}' (레벨 {:d})이(가) 게임에 참가했습니다"
 
-#: Source/msg.cpp:1959
+#: Source/msg.cpp:1972
 msgid "Waiting for game data..."
 msgstr "게임 데이터 대기 중..."
 
-#: Source/msg.cpp:1967
+#: Source/msg.cpp:1980
 msgid "The game ended"
 msgstr "게임이 종료되었습니다"
 
-#: Source/msg.cpp:1973
+#: Source/msg.cpp:1986
 msgid "Unable to get level data"
 msgstr "레벨 데이터를 가져올 수 없습니다"
 
@@ -5489,7 +5500,7 @@ msgstr "플레이어 '{:s}'이(가) 디아블로를 물리치고 게임을 퇴�
 msgid "Player '{:s}' dropped due to timeout"
 msgstr "플레이어 '{:s}'이(가) 시간초과로 퇴장되었습니다"
 
-#: Source/multi.cpp:807
+#: Source/multi.cpp:806
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr "플레이어 '{:s}' (레벨 {:d})은(는) 이미 게임에 참여 중입니다"
 
@@ -5699,158 +5710,158 @@ msgstr "학술서: 종말"
 msgid "A Spellbook"
 msgstr "주문서"
 
-#: Source/objects.cpp:5384
+#: Source/objects.cpp:5339
 msgid "Crucified Skeleton"
 msgstr "못 박힌 해골"
 
-#: Source/objects.cpp:5388
+#: Source/objects.cpp:5343
 msgid "Lever"
 msgstr "지렛대"
 
-#: Source/objects.cpp:5397
+#: Source/objects.cpp:5352
 msgid "Open Door"
 msgstr "열린 문"
 
-#: Source/objects.cpp:5399
+#: Source/objects.cpp:5354
 msgid "Closed Door"
 msgstr "닫힌 문"
 
-#: Source/objects.cpp:5401
+#: Source/objects.cpp:5356
 msgid "Blocked Door"
 msgstr "잠긴 문"
 
-#: Source/objects.cpp:5406
+#: Source/objects.cpp:5361
 msgid "Ancient Tome"
 msgstr "고대서"
 
-#: Source/objects.cpp:5408
+#: Source/objects.cpp:5363
 msgid "Book of Vileness"
 msgstr "비열의 서"
 
-#: Source/objects.cpp:5413
+#: Source/objects.cpp:5368
 msgid "Skull Lever"
 msgstr "해골 지렛대"
 
-#: Source/objects.cpp:5416
+#: Source/objects.cpp:5371
 msgid "Mythical Book"
 msgstr "신화서"
 
-#: Source/objects.cpp:5420
+#: Source/objects.cpp:5375
 msgid "Small Chest"
 msgstr "작은 궤짝"
 
-#: Source/objects.cpp:5424
+#: Source/objects.cpp:5379
 msgid "Chest"
 msgstr "궤짝"
 
-#: Source/objects.cpp:5429
+#: Source/objects.cpp:5384
 msgid "Large Chest"
 msgstr "큰 궤짝"
 
-#: Source/objects.cpp:5432
+#: Source/objects.cpp:5387
 msgid "Sarcophagus"
 msgstr "석관"
 
-#: Source/objects.cpp:5435
+#: Source/objects.cpp:5390
 msgid "Bookshelf"
 msgstr "책장"
 
-#: Source/objects.cpp:5439
+#: Source/objects.cpp:5394
 msgid "Bookcase"
 msgstr "책장"
 
-#: Source/objects.cpp:5444
+#: Source/objects.cpp:5399
 msgid "Pod"
 msgstr "고치"
 
-#: Source/objects.cpp:5446
+#: Source/objects.cpp:5401
 msgid "Urn"
 msgstr "단지"
 
-#: Source/objects.cpp:5448
+#: Source/objects.cpp:5403
 msgid "Barrel"
 msgstr "나무통"
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:5452
+#: Source/objects.cpp:5407
 msgid "{:s} Shrine"
 msgstr "{:s} 신단"
 
-#: Source/objects.cpp:5456
+#: Source/objects.cpp:5411
 msgid "Skeleton Tome"
 msgstr "해골 고서"
 
-#: Source/objects.cpp:5459
+#: Source/objects.cpp:5414
 msgid "Library Book"
 msgstr "도서"
 
-#: Source/objects.cpp:5462
+#: Source/objects.cpp:5417
 msgid "Blood Fountain"
 msgstr "피의 분수"
 
-#: Source/objects.cpp:5465
+#: Source/objects.cpp:5420
 msgid "Decapitated Body"
 msgstr "참수된 시체"
 
-#: Source/objects.cpp:5468
+#: Source/objects.cpp:5423
 msgid "Book of the Blind"
 msgstr "눈먼 자의 서"
 
-#: Source/objects.cpp:5471
+#: Source/objects.cpp:5426
 msgid "Book of Blood"
 msgstr "피의 서"
 
-#: Source/objects.cpp:5474
+#: Source/objects.cpp:5429
 msgid "Purifying Spring"
 msgstr "정화의 활기"
 
-#: Source/objects.cpp:5481 Source/objects.cpp:5505
+#: Source/objects.cpp:5436 Source/objects.cpp:5460
 msgid "Weapon Rack"
 msgstr "무기 거치대"
 
-#: Source/objects.cpp:5484
+#: Source/objects.cpp:5439
 msgid "Goat Shrine"
 msgstr "염소 신단"
 
-#: Source/objects.cpp:5487
+#: Source/objects.cpp:5442
 msgid "Cauldron"
 msgstr "가마솥"
 
-#: Source/objects.cpp:5490
+#: Source/objects.cpp:5445
 msgid "Murky Pool"
 msgstr "탁한 웅덩이"
 
-#: Source/objects.cpp:5493
+#: Source/objects.cpp:5448
 msgid "Fountain of Tears"
 msgstr "눈물의 샘"
 
-#: Source/objects.cpp:5496
+#: Source/objects.cpp:5451
 msgid "Steel Tome"
 msgstr "강철 고서"
 
-#: Source/objects.cpp:5499
+#: Source/objects.cpp:5454
 msgid "Pedestal of Blood"
 msgstr "피의 받침대"
 
-#: Source/objects.cpp:5508
+#: Source/objects.cpp:5463
 msgid "Mushroom Patch"
 msgstr "버섯 군락"
 
-#: Source/objects.cpp:5511
+#: Source/objects.cpp:5466
 msgid "Vile Stand"
 msgstr "비열한 진열대"
 
-#: Source/objects.cpp:5514
+#: Source/objects.cpp:5469
 msgid "Slain Hero"
 msgstr "살해된 영웅"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:5521
+#: Source/objects.cpp:5476
 msgid "Trapped {:s}"
 msgstr "갇힌 {:s}"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
-#: Source/objects.cpp:5527
+#: Source/objects.cpp:5482
 msgid "{:s} (disabled)"
 msgstr "{:s} (끄기)"
 
@@ -5968,23 +5979,23 @@ msgstr "주문"
 msgid "mute"
 msgstr "음소거"
 
-#: Source/pfile.cpp:260
+#: Source/pfile.cpp:242
 msgid "Failed to open player archive for writing."
 msgstr "기록용 플레이어 아카이브를 열지 못했습니다."
 
-#: Source/pfile.cpp:392
+#: Source/pfile.cpp:377
 msgid "Unable to open archive"
 msgstr "아카이브를 열 수 없습니다"
 
-#: Source/pfile.cpp:394
+#: Source/pfile.cpp:379
 msgid "Unable to load character"
 msgstr "캐릭터를 불러올 수 없습니다"
 
-#: Source/pfile.cpp:419 Source/pfile.cpp:439
+#: Source/pfile.cpp:403 Source/pfile.cpp:423
 msgid "Unable to read to save file archive"
 msgstr "저장 파일을 읽을 수 없습니다"
 
-#: Source/pfile.cpp:458
+#: Source/pfile.cpp:442
 msgid "Unable to write to save file archive"
 msgstr "저장 파일을 기록할 수 없습니다"
 
@@ -6003,7 +6014,7 @@ msgstr ",%03d"
 msgid "%i gold"
 msgstr "%i 금화"
 
-#: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:56
+#: Source/qol/monhealthbar.cpp:37 Source/qol/xpbar.cpp:56
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
@@ -6442,7 +6453,7 @@ msgstr "파넘"
 msgid "Adria"
 msgstr "아드리아"
 
-#: Source/stores.cpp:98 Source/stores.cpp:1252
+#: Source/stores.cpp:98 Source/stores.cpp:1305
 msgid "Gillian"
 msgstr "질리언"
 
@@ -6450,298 +6461,293 @@ msgstr "질리언"
 msgid "Wirt"
 msgstr "워트"
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr "이전"
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ",  "
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 msgid "Damage: {:d}-{:d}  "
 msgstr "피해: {:d}-{:d}  "
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 msgid "Armor: {:d}  "
 msgstr "방어력: {:d}  "
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 msgid "Dur: {:d}/{:d},  "
 msgstr "내구도: {:d}/{:d},  "
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr "영구적, "
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr "요구치 없음"
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr "어서 오십시오"
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr "대장장이의 상점"
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr "무엇을 하겠습니까?:"
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 msgid "Talk to Griswold"
 msgstr "그리스월드와 대화"
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 msgid "Buy basic items"
 msgstr "기본 물품 구매"
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 msgid "Buy premium items"
 msgstr "고급 물품 구매"
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 msgid "Sell items"
 msgstr "물품 매각"
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 msgid "Repair items"
 msgstr "물품 수리"
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 msgid "Leave the shop"
 msgstr "상점을 떠난다"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "이런 물건들을 구비하고 있지:             소지금: {:d}"
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr "이전"
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "이런 특별품들을 구비하고 있지:     소지금: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "내가 원하는 물건이 없군.             소지금: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "무엇을 판매할 텐가?             소지금: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "수리할 것이 없군.             소지금: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "무엇을 수리할 텐가?             소지금: {:d}"
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr "마녀의 오두막"
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 msgid "Talk to Adria"
 msgstr "아드리아와 대화"
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr "풀품 구매"
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr "지팡이 충전"
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 msgid "Leave the shack"
 msgstr "오두막을 떠난다"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "충전할 것이 없군요.             소지금: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "무엇을 충전하겠습니까?             소지금: {:d}"
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr "소지금이 충분하지 않습니다"
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr "소지품 공간이 충분하지 않습니다"
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr "거래하겠습니까?"
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 msgid "Are you sure you want to identify this item?"
 msgstr "이 물품을 감별하겠습니까?"
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 msgid "Are you sure you want to buy this item?"
 msgstr "이 물품을 구매하겠습니까?"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 msgid "Are you sure you want to recharge this item?"
 msgstr "이 물품을 충전하겠습니까?"
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 msgid "Are you sure you want to sell this item?"
 msgstr "이 물품을 매각하겠습니까?"
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 msgid "Are you sure you want to repair this item?"
 msgstr "이 물품을 수리하겠습니까?"
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr "외다리 소년 워트"
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 msgid "Talk to Wirt"
 msgstr "워트와 대화"
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr "좋은 물건이 있는데,"
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr "금화 50 개만 내세요"
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr "보고 싶다면 말이죠. "
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr "뭘 갖고 있나요?"
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr "작별한다"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "이런 물건을 구비하고 있죠:             소지금: {:d}"
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 msgid "Leave"
 msgstr "떠난다"
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr "치료사의 집"
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr "페핀과 대화"
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr "치료사의 집을 떠난다"
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 msgid "The Town Elder"
 msgstr "마을 장로"
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 msgid "Talk to Cain"
 msgstr "케인과 대화"
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr "물품 감별"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "감별할 게 없군 그래.             소지금: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "어느 물건을 감별하겠나?             소지금: {:d}"
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr "이 물품은:"
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr "완료"
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 msgid "Talk to {:s}"
 msgstr "{:s}와(과) 대화"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 msgid "Talking to {:s}"
 msgstr "{:s}와(과) 대화 중"
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 msgid "is not available"
 msgstr "사용할 수 없습니다"
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 msgid "in the shareware"
 msgstr "체험판에서는"
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 msgid "version"
 msgstr "버전"
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr "가십"
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr "해오름 여관"
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 msgid "Talk to Ogden"
 msgstr "오그덴과 대화"
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 msgid "Leave the tavern"
 msgstr "여관을 떠난다"
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 msgid "Talk to Gillian"
 msgstr "질리언과 대화"
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr "주정뱅이 파넘"
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 msgid "Talk to Farnham"
 msgstr "파넘과 대화"
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr "작별한다"
 

--- a/Translations/pl.po
+++ b/Translations/pl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-10-25 22:11+0200\n"
+"POT-Creation-Date: 2021-11-21 05:45+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -321,7 +321,7 @@ msgstr "\tŻadne dusze nie zostały zaprzedane podczas tworzenia tej gry."
 msgid "OK"
 msgstr "OK"
 
-#: Source/DiabloUI/extrasmenu.cpp:41 Source/DiabloUI/selstart.cpp:61
+#: Source/DiabloUI/extrasmenu.cpp:41 Source/DiabloUI/selstart.cpp:44
 msgid "Switch to Diablo"
 msgstr "Przełącz na Diablo"
 
@@ -391,8 +391,8 @@ msgstr "Klient-Serwer (TCP)"
 msgid "Loopback"
 msgstr "Loopback"
 
-#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:481
-#: Source/DiabloUI/selgame.cpp:499
+#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:489
+#: Source/DiabloUI/selgame.cpp:510
 msgid "Multi Player Game"
 msgstr "Gra Wieloosobowa"
 
@@ -746,22 +746,22 @@ msgstr "Usuń Postać - Gra Jednoosobowa"
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "Czy na pewno chcesz usunąć postać \"{:s}\"?"
 
-#: Source/DiabloUI/selstart.cpp:60
+#: Source/DiabloUI/selstart.cpp:43
 msgid "Enter Hellfire"
 msgstr "Wejdź do Hellfire"
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr "Tak"
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr "Nie"
 
 #: Source/DiabloUI/support_lines.cpp:8
 msgid ""
-"We maintains a chat server at Discord.gg/YQKCAYQ Follow the links to join "
-"our community where we talk about things related to Diablo, and the Hellfire "
+"We maintain a chat server at Discord.gg/YQKCAYQ Follow the links to join our "
+"community where we talk about things related to Diablo, and the Hellfire "
 "expansion."
 msgstr ""
 
@@ -807,12 +807,12 @@ msgstr ""
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr "Copyright © 1996-2001 Blizzard Entertainment"
 
-#: Source/appfat.cpp:37
+#: Source/appfat.cpp:38
 msgid "Error"
 msgstr "Błąd"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:101
+#: Source/appfat.cpp:102
 msgid ""
 "{:s}\n"
 "\n"
@@ -822,7 +822,7 @@ msgstr ""
 "\n"
 "Nastąpił błąd w: {:s} linia {:d}"
 
-#: Source/appfat.cpp:116
+#: Source/appfat.cpp:117
 msgid ""
 "Unable to open main data archive ({:s}).\n"
 "\n"
@@ -832,12 +832,12 @@ msgstr ""
 "\n"
 "Upewnij się, że plik znajduje się w folderze."
 
-#: Source/appfat.cpp:122
+#: Source/appfat.cpp:123
 msgid "Data File Error"
 msgstr "Błąd Pliku z Danymi"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:130
+#: Source/appfat.cpp:131
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -845,7 +845,7 @@ msgstr ""
 "Nie da się zapisać do:\n"
 "{:s}"
 
-#: Source/appfat.cpp:132
+#: Source/appfat.cpp:133
 msgid "Read-Only Directory Error"
 msgstr "Błąd Folderu Tylko do Odczytu"
 
@@ -869,157 +869,157 @@ msgstr "Gniazdo - Poziom {:d}"
 msgid "Level: Crypt {:d}"
 msgstr "Krypta - Poziom {:d}"
 
-#: Source/automap.cpp:508 Source/items.cpp:2079
+#: Source/automap.cpp:508 Source/items.cpp:2090
 msgid "Level: {:d}"
 msgstr "Poziom: {:d}"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr "Tab"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr "Esc"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Enter"
 msgstr "Enter"
 
-#: Source/control.cpp:202
+#: Source/control.cpp:215
 msgid "Character Information"
 msgstr "Informacje o postaci"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr "Dziennik Zadań"
 
-#: Source/control.cpp:204
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr "Automapa"
 
-#: Source/control.cpp:205
+#: Source/control.cpp:218
 msgid "Main Menu"
 msgstr "Menu Główne"
 
-#: Source/control.cpp:206
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr "Inwentarz"
 
-#: Source/control.cpp:207
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr "Księga zaklęć"
 
-#: Source/control.cpp:208
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr "Wyślij Wiadomość"
 
-#: Source/control.cpp:764 Source/control.cpp:1572
+#: Source/control.cpp:718 Source/control.cpp:1587
 msgid "Skill"
 msgstr "Umiejętność"
 
-#: Source/control.cpp:765 Source/control.cpp:1226
+#: Source/control.cpp:719 Source/control.cpp:1237
 msgid "{:s} Skill"
 msgstr "Umiejętność: {:s}"
 
-#: Source/control.cpp:771
+#: Source/control.cpp:725
 msgid "Spell"
 msgstr "Czar"
 
-#: Source/control.cpp:772 Source/control.cpp:1230
+#: Source/control.cpp:726 Source/control.cpp:1241
 msgid "{:s} Spell"
 msgstr "Czar: {:s}"
 
-#: Source/control.cpp:774
+#: Source/control.cpp:728
 msgid "Damages undead only"
 msgstr "Rani tylko nieumarłych"
 
-#: Source/control.cpp:778 Source/control.cpp:1234 Source/control.cpp:1596
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr "Poziom Czaru: 0 - Bezużyteczny"
 
-#: Source/control.cpp:780 Source/control.cpp:1236 Source/control.cpp:1598
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 msgid "Spell Level {:d}"
 msgstr "Poziom Czaru: {:d}"
 
-#: Source/control.cpp:787
+#: Source/control.cpp:741
 msgid "Scroll"
 msgstr "Zwój"
 
-#: Source/control.cpp:788 Source/control.cpp:1240
+#: Source/control.cpp:742 Source/control.cpp:1251
 msgid "Scroll of {:s}"
 msgstr "Zwój: {:s}"
 
-#: Source/control.cpp:793 Source/control.cpp:1246
+#: Source/control.cpp:747 Source/control.cpp:1257
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "Zwój: {:d}"
 msgstr[1] "Zwoje: {:d}"
 msgstr[2] "Zwoje: {:d}"
 
-#: Source/control.cpp:800 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
 #: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
 msgid "Staff"
 msgstr "Kostur"
 
-#: Source/control.cpp:801 Source/control.cpp:1250 Source/items.cpp:1320
+#: Source/control.cpp:755 Source/control.cpp:1261
 msgid "Staff of {:s}"
 msgstr "Kostur: {:s}"
 
-#: Source/control.cpp:803 Source/control.cpp:1252
+#: Source/control.cpp:757 Source/control.cpp:1263
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "Ładunek: {:d}"
 msgstr[1] "Ładunki: {:d}"
 msgstr[2] "Ładunki: {:d}"
 
-#: Source/control.cpp:813
+#: Source/control.cpp:767
 msgid "Spell Hotkey {:s}"
 msgstr "Klawisz Czaru: {:s}"
 
-#: Source/control.cpp:1203
+#: Source/control.cpp:1214
 msgid "Player friendly"
 msgstr "Neutralność"
 
-#: Source/control.cpp:1205
+#: Source/control.cpp:1216
 msgid "Player attack"
 msgstr "Wrogość"
 
-#: Source/control.cpp:1208
+#: Source/control.cpp:1219
 msgid "Hotkey: {:s}"
 msgstr "Klawisz: {:s}"
 
-#: Source/control.cpp:1216
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr "Wybierz zaklęcie"
 
-#: Source/control.cpp:1219
+#: Source/control.cpp:1230
 msgid "Hotkey: 's'"
 msgstr "Klawisz: 's'"
 
-#: Source/control.cpp:1374 Source/inv.cpp:1916 Source/items.cpp:3742
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "{:d} złota"
 msgstr[1] "{:d} złota"
 msgstr[2] "{:d} złota"
 
-#: Source/control.cpp:1377
+#: Source/control.cpp:1390
 msgid "Requirements not met"
 msgstr "Nie spełniono wymagań"
 
-#: Source/control.cpp:1413
+#: Source/control.cpp:1426
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Poziom: {:d}"
 
-#: Source/control.cpp:1415
+#: Source/control.cpp:1428
 msgid "Hit Points {:d} of {:d}"
 msgstr "Punkty Życia {:d} / {:d}"
 
-#: Source/control.cpp:1442
+#: Source/control.cpp:1457
 msgid "Level Up"
 msgstr "Nowy Poziom"
 
-#: Source/control.cpp:1576
+#: Source/control.cpp:1591
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] "Kostur ({:d} ładunek)"
@@ -1027,22 +1027,22 @@ msgstr[1] "Kostur ({:d} ładunki)"
 msgstr[2] "Kostur ({:d} ładunków)"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1586
+#: Source/control.cpp:1601
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "Mana: {:d}  Obr: {:d} - {:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1588
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "Mana: {:d}   Obr: brak"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1591
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "Mana: {:d}  Obr: 1/3 PŻ celu"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1649
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] "Masz {:d} złota. Ile monet chcesz oddzielić?"
@@ -1249,7 +1249,7 @@ msgstr "podczas przebywania w sklepie"
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr "{:s}, wersja = {:s}, tryb = {:s}"
 
-#: Source/dvlnet/loopback.cpp:111
+#: Source/dvlnet/loopback.cpp:113
 msgid "loopback"
 msgstr "loopback"
 
@@ -1711,7 +1711,9 @@ msgstr ""
 "nie Prawym Przyciskiem Myszy."
 
 #: Source/help.cpp:68
-msgid "$Gold"
+#, fuzzy
+#| msgid "$Gold"
+msgid "$Gold:"
 msgstr "$Złota"
 
 #: Source/help.cpp:69
@@ -1738,7 +1740,9 @@ msgstr ""
 "umożliwia rzucenie go."
 
 #: Source/help.cpp:79
-msgid "$Using the Speedbook for Spells"
+#, fuzzy
+#| msgid "$Using the Speedbook for Spells"
+msgid "$Using the Speedbook for Spells:"
 msgstr "$Użycie podręcznej księgi czarów"
 
 #: Source/help.cpp:80
@@ -1751,13 +1755,19 @@ msgstr ""
 "wybrać umiejętność. By ją użyć wciśnij PPM na główne okno rozgrywki."
 
 #: Source/help.cpp:84
+#, fuzzy
+#| msgid ""
+#| "Shift + Left-clicking on the 'select current spell' button will clear the "
+#| "readied spell"
 msgid ""
 "Shift + Left-clicking on the 'select current spell' button will clear the "
-"readied spell"
+"readied spell."
 msgstr "Wciśnięcie Shift + LPM na wybrany czar usunie go"
 
 #: Source/help.cpp:86
-msgid "$Setting Spell Hotkeys"
+#, fuzzy
+#| msgid "$Setting Spell Hotkeys"
+msgid "$Setting Spell Hotkeys:"
 msgstr "$Ustawianie skrótów klawiszowych umiejętności"
 
 #: Source/help.cpp:87
@@ -1771,7 +1781,9 @@ msgstr ""
 "F6, F7 albo F8, aby przypisać go do wybranej umiejętności."
 
 #: Source/help.cpp:92
-msgid "$Spell Books"
+#, fuzzy
+#| msgid "$Spell Books"
+msgid "$Spell Books:"
 msgstr "$Księgi czarów"
 
 #: Source/help.cpp:93
@@ -1782,35 +1794,35 @@ msgstr ""
 "Czytanie wielu ksiąg zwiększa twą wiedzę o czarze, dzięki czemu może być ono "
 "jeszcze skuteczniejsze."
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Shareware Hellfire Help"
 msgstr "Pomoc Wersji Shareware Hellfire"
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Hellfire Help"
 msgstr "Pomoc Hellfire"
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Shareware Diablo Help"
 msgstr "Pomoc Wersji Shareware Diablo"
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Diablo Help"
 msgstr "Pomoc Diablo"
 
-#: Source/help.cpp:161
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr "ESC - wyjście, Strzałki - przewijanie"
 
-#: Source/init.cpp:204
+#: Source/init.cpp:175
 msgid "diabdat.mpq or spawn.mpq"
 msgstr "diabdat.mpq lub spawn.mpq"
 
-#: Source/init.cpp:224
+#: Source/init.cpp:196
 msgid "Some Hellfire MPQs are missing"
 msgstr "Brakuje części plików MPQ do Hellfire"
 
-#: Source/init.cpp:224
+#: Source/init.cpp:196
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
@@ -1818,7 +1830,7 @@ msgstr ""
 "Nie znaleziono wszystkich plików MPQ do Hellfire.\n"
 "Skopiuj wszystkie pliki hf*.mpq do folderu."
 
-#: Source/init.cpp:232
+#: Source/init.cpp:204
 msgid "Unable to create main window"
 msgstr "Nie udało się utworzyć głównego okna"
 
@@ -2062,7 +2074,7 @@ msgid "Quilted Armor"
 msgstr "Pikowana Zbroja"
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
-#: Source/itemdat.cpp:77 Source/objects.cpp:5467
+#: Source/itemdat.cpp:77 Source/objects.cpp:5433
 msgid "Armor"
 msgstr "Zbroja"
 
@@ -3604,659 +3616,672 @@ msgstr "Olej Wzmocnienia"
 msgid "Oil of Imperviousness"
 msgstr "Olej Nieprzenikalności"
 
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#: Source/items.cpp:1174 Source/items.cpp:1184 Source/items.cpp:1233
-#: Source/items.cpp:1269
-msgid "{0} {1}"
-msgstr ""
-
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's Staff of Firewall
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Long Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1187 Source/items.cpp:1254 Source/items.cpp:1273
-#: Source/items.cpp:1315
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
+#, fuzzy
+#| msgid "{0} of {1}"
+msgctxt "spell"
 msgid "{0} of {1}"
 msgstr "{:s} {:s}"
 
-#: Source/items.cpp:1895 Source/items.cpp:1907
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+#, fuzzy
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} {:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+#, fuzzy
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} {:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
+#: Source/items.cpp:1217
+msgid "{0} {1}"
+msgstr ""
+
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
+msgid "{0} of {1}"
+msgstr "{:s} {:s}"
+
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr "znacznie zwiększa"
 
-#: Source/items.cpp:1897
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr "celność broni"
 
-#: Source/items.cpp:1901
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr "znacznie zwiększa"
 
-#: Source/items.cpp:1903
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr "celność broni"
 
-#: Source/items.cpp:1909
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr "możliwe obrażenia"
 
-#: Source/items.cpp:1913
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr "znacznie zwiększa"
 
-#: Source/items.cpp:1915
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr "możliwe obrażenia (bez łuków)"
 
-#: Source/items.cpp:1919
+#: Source/items.cpp:1930
 msgid "reduces attributes needed"
 msgstr "zmniejsza wymagane atrybuty"
 
-#: Source/items.cpp:1921
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr "i pozwala używać przedmioty"
 
-#: Source/items.cpp:1925
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr "przywraca 20%"
 
-#: Source/items.cpp:1927
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr "wytrzymałości przedmiotu"
 
-#: Source/items.cpp:1931
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr "zwiększa"
 
-#: Source/items.cpp:1933
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr "bieżącą i maks. wytrzymałość"
 
-#: Source/items.cpp:1937
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr "czyni rzecz niezniszczalną"
 
-#: Source/items.cpp:1941
+#: Source/items.cpp:1952
 msgid "increases the armor class"
 msgstr "zwiększa klasę pancerza"
 
-#: Source/items.cpp:1943
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr "tarcz i zbroi"
 
-#: Source/items.cpp:1947
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr "znacznie zwiększa pancerz"
 
-#: Source/items.cpp:1949
+#: Source/items.cpp:1960
 msgid "class of armor and shields"
 msgstr "klasę tarcz i zbroi"
 
-#: Source/items.cpp:1953 Source/items.cpp:1962
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr "ustawia ognistą pułapkę"
 
-#: Source/items.cpp:1958
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr "ustawia pułapkę z błyskawic"
 
-#: Source/items.cpp:1966
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr "ustawia pułapkę Petryfikacji"
 
-#: Source/items.cpp:1970
+#: Source/items.cpp:1981
 msgid "restore all life"
 msgstr "odnawia całe życie"
 
-#: Source/items.cpp:1974
+#: Source/items.cpp:1985
 msgid "restore some life"
 msgstr "odnawia część życia"
 
-#: Source/items.cpp:1978
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr "przywraca życie"
 
-#: Source/items.cpp:1982
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr "śmiertelne leczenie"
 
-#: Source/items.cpp:1986
+#: Source/items.cpp:1997
 msgid "restore some mana"
 msgstr "odnawia część many"
 
-#: Source/items.cpp:1990
+#: Source/items.cpp:2001
 msgid "restore all mana"
 msgstr "odnawia całą manę"
 
-#: Source/items.cpp:1994
+#: Source/items.cpp:2005
 msgid "increase strength"
 msgstr "zwiększa siłę"
 
-#: Source/items.cpp:1998
+#: Source/items.cpp:2009
 msgid "increase magic"
 msgstr "zwiększa magię"
 
-#: Source/items.cpp:2002
+#: Source/items.cpp:2013
 msgid "increase dexterity"
 msgstr "zwiększa zręczność"
 
-#: Source/items.cpp:2006
+#: Source/items.cpp:2017
 msgid "increase vitality"
 msgstr "zwiększa żywotność"
 
-#: Source/items.cpp:2011
+#: Source/items.cpp:2022
 msgid "decrease strength"
 msgstr "zmniejsza siłę"
 
-#: Source/items.cpp:2015
+#: Source/items.cpp:2026
 msgid "decrease dexterity"
 msgstr "zmniejsza zręczność"
 
-#: Source/items.cpp:2019
+#: Source/items.cpp:2030
 msgid "decrease vitality"
 msgstr "zmniejsza żywotność"
 
-#: Source/items.cpp:2023
+#: Source/items.cpp:2034
 msgid "restore some life and mana"
 msgstr "odnawia część życia i many"
 
-#: Source/items.cpp:2027
+#: Source/items.cpp:2038
 msgid "restore all life and mana"
 msgstr "odnawia całe życie i manę"
 
-#: Source/items.cpp:2042 Source/items.cpp:2067
+#: Source/items.cpp:2053 Source/items.cpp:2078
 msgid "Right-click to read"
 msgstr "PPM by odczytać"
 
-#: Source/items.cpp:2046
+#: Source/items.cpp:2057
 msgid "Right-click to read, then"
 msgstr "PPM by odczytać, następnie"
 
-#: Source/items.cpp:2048
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr "LPM na cel"
 
-#: Source/items.cpp:2053
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr "PPM by użyć"
 
-#: Source/items.cpp:2058 Source/items.cpp:2063
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr "PPM by użyć"
 
-#: Source/items.cpp:2071
+#: Source/items.cpp:2082
 msgid "Right click to read"
 msgstr "PPM by odczytać"
 
-#: Source/items.cpp:2075
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr "PPM by wyświetlić"
 
-#: Source/items.cpp:2083
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr "Podwaja objętość sakwy"
 
-#: Source/items.cpp:2095 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 msgid "Required:"
 msgstr "Wymagania:"
 
-#: Source/items.cpp:2097 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 msgid " {:d} Str"
 msgstr " {:d} Siły"
 
-#: Source/items.cpp:2099 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 msgid " {:d} Mag"
 msgstr " {:d} Magii"
 
-#: Source/items.cpp:2101 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 msgid " {:d} Dex"
 msgstr " {:d} Zręcz."
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3526 Source/player.cpp:3027
+#: Source/items.cpp:3533 Source/player.cpp:3018
 msgid "Ear of {:s}"
 msgstr "Ucho ({:s})"
 
-#: Source/items.cpp:3821
+#: Source/items.cpp:3828
 msgid "chance to hit: {:+d}%"
 msgstr "celność: {:+d}%"
 
-#: Source/items.cpp:3825
+#: Source/items.cpp:3832
 #, no-c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% do obrażeń"
 
-#: Source/items.cpp:3829 Source/items.cpp:4085
+#: Source/items.cpp:3836 Source/items.cpp:4092
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "celność: {:+d}%, obrażenia: {:+d}%"
 
-#: Source/items.cpp:3833
+#: Source/items.cpp:3840
 #, no-c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% do obrony"
 
-#: Source/items.cpp:3837
+#: Source/items.cpp:3844
 msgid "armor class: {:d}"
 msgstr "klasa pancerza: {:d}"
 
-#: Source/items.cpp:3842 Source/items.cpp:4067
+#: Source/items.cpp:3849 Source/items.cpp:4074
 msgid "Resist Fire: {:+d}%"
 msgstr "Odporność na Ogień {:+d}%"
 
-#: Source/items.cpp:3844
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr "Odporność na Ogień 75% MAX"
 
-#: Source/items.cpp:3849
+#: Source/items.cpp:3856
 msgid "Resist Lightning: {:+d}%"
 msgstr "Odp. na Błyskawice {:+d}%"
 
-#: Source/items.cpp:3851
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr "Odp. na Błyskawice 75% MAX"
 
-#: Source/items.cpp:3856
+#: Source/items.cpp:3863
 msgid "Resist Magic: {:+d}%"
 msgstr "Odporność na Magię {:+d}%"
 
-#: Source/items.cpp:3858
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr "Odporność na Magię 75% MAX"
 
-#: Source/items.cpp:3863
+#: Source/items.cpp:3870
 msgid "Resist All: {:+d}%"
 msgstr "Odporność na wszystko: {:+d}%"
 
-#: Source/items.cpp:3865
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr "Odporność na wszystko 75% MAX"
 
-#: Source/items.cpp:3869
+#: Source/items.cpp:3876
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] "poziom czarów: {:d}"
 msgstr[1] "poziom czarów: {:d}"
 msgstr[2] "poziom czarów: {:d}"
 
-#: Source/items.cpp:3871
+#: Source/items.cpp:3878
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "poziom czarów: {:d}"
 msgstr[1] "poziom czarów: {:d}"
 msgstr[2] "poziom czarów: {:d}"
 
-#: Source/items.cpp:3873
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr "poziom czarów bez zmian (?)"
 
-#: Source/items.cpp:3876
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr "Dodatkowe ładunki"
 
-#: Source/items.cpp:3879
+#: Source/items.cpp:3886
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "Ładunki: {:d} {:s}"
 msgstr[1] "Ładunki: {:d} {:s}"
 msgstr[2] "Ładunki: {:d} {:s}"
 
-#: Source/items.cpp:3883
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr "Obr. od ognia: {:d}"
 
-#: Source/items.cpp:3885
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "Obr. od ognia: {:d}-{:d}"
 
-#: Source/items.cpp:3889
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr "Obr. od błyskawic: {:d}"
 
-#: Source/items.cpp:3891
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "Obr. od błyskawic: {:d}-{:d}"
 
-#: Source/items.cpp:3895
+#: Source/items.cpp:3902
 msgid "{:+d} to strength"
 msgstr "{:+d} do siły"
 
-#: Source/items.cpp:3899
+#: Source/items.cpp:3906
 msgid "{:+d} to magic"
 msgstr "{:+d} do magii"
 
-#: Source/items.cpp:3903
+#: Source/items.cpp:3910
 msgid "{:+d} to dexterity"
 msgstr "{:+d} do zręczności"
 
-#: Source/items.cpp:3907
+#: Source/items.cpp:3914
 msgid "{:+d} to vitality"
 msgstr "{:+d} do żywotności"
 
-#: Source/items.cpp:3911
+#: Source/items.cpp:3918
 msgid "{:+d} to all attributes"
 msgstr "{:+d} do wszystkich atrybutów"
 
-#: Source/items.cpp:3915
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} obrażeń od wrogów"
 
-#: Source/items.cpp:3919
+#: Source/items.cpp:3926
 msgid "Hit Points: {:+d}"
 msgstr "Punkty życia: {:+d}"
 
-#: Source/items.cpp:3923
+#: Source/items.cpp:3930
 msgid "Mana: {:+d}"
 msgstr "Mana: {:+d}"
 
-#: Source/items.cpp:3926
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr "wysoka wytrzymałość"
 
-#: Source/items.cpp:3929
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr "zmniejszona wytrzymałość"
 
-#: Source/items.cpp:3932
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr "niezniszczalność"
 
-#: Source/items.cpp:3935
+#: Source/items.cpp:3942
 #, no-c-format
 msgid "+{:d}% light radius"
 msgstr "+{:d}% do promienia światła"
 
-#: Source/items.cpp:3938
+#: Source/items.cpp:3945
 #, no-c-format
 msgid "-{:d}% light radius"
 msgstr "-{:d}% do promienia światła"
 
-#: Source/items.cpp:3941
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr "wielostrzał"
 
-#: Source/items.cpp:3945
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr "obr. płonących strzał {:d}"
 
-#: Source/items.cpp:3947
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "obr. płonących strzał: {:d}-{:d}"
 
-#: Source/items.cpp:3951
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr "obr. strzał błyskawic {:d}"
 
-#: Source/items.cpp:3953
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "obr. strzał błyskawic {:d}-{:d}"
 
-#: Source/items.cpp:3957
+#: Source/items.cpp:3964
 msgid "fireball damage: {:d}"
 msgstr "obr. ognistej kuli {:d}"
 
-#: Source/items.cpp:3959
+#: Source/items.cpp:3966
 msgid "fireball damage: {:d}-{:d}"
 msgstr "obr. ognistej kuli {:d}-{:d}"
 
-#: Source/items.cpp:3962
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr "atakujący otrzymuje 1-3 obrażeń"
 
-#: Source/items.cpp:3965
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr "gracz traci całą manę"
 
-#: Source/items.cpp:3968
+#: Source/items.cpp:3975
 msgid "you can't heal"
 msgstr "nie możesz się leczyć"
 
-#: Source/items.cpp:3971
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr "2x mniej obrażeń od pułapek"
 
-#: Source/items.cpp:3974
+#: Source/items.cpp:3981
 msgid "knocks target back"
 msgstr "odrzuca przeciwnika"
 
-#: Source/items.cpp:3977
+#: Source/items.cpp:3984
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr "+200% obrażeń wobec demonów"
 
-#: Source/items.cpp:3980
+#: Source/items.cpp:3987
 msgid "All Resistance equals 0"
 msgstr "Odporności spadają do 0"
 
-#: Source/items.cpp:3983
+#: Source/items.cpp:3990
 msgid "hit monster doesn't heal"
 msgstr "ranny potwór się nie ulecza"
 
-#: Source/items.cpp:3987
+#: Source/items.cpp:3994
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr "uderzenie kradnie 3% many"
 
-#: Source/items.cpp:3989
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr "uderzenie kradnie 5% many"
 
-#: Source/items.cpp:3993
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr "uderzenie kradnie 3% życia"
 
-#: Source/items.cpp:3995
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr "uderzenie kradnie 5% życia"
 
-#: Source/items.cpp:3998
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr "przebija pancerz wroga"
 
-#: Source/items.cpp:4002
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr "prędki atak"
 
-#: Source/items.cpp:4004
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr "szybki atak"
 
-#: Source/items.cpp:4006
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr "szybszy atak"
 
-#: Source/items.cpp:4008
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr "najszybszy atak"
 
-#: Source/items.cpp:4012
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr "szybko wznawia atak"
 
-#: Source/items.cpp:4014
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr "szybsze wznowienie ataku"
 
-#: Source/items.cpp:4016
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr "najszybsze wznowienie ataku"
 
-#: Source/items.cpp:4019
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr "szybki blok"
 
-#: Source/items.cpp:4022
+#: Source/items.cpp:4029
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] "+{:d} pkt. obrażeń"
 msgstr[1] "+{:d} pkt. obrażeń"
 msgstr[2] "+{:d} pkt. obrażeń"
 
-#: Source/items.cpp:4025
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr "losowe szybkie strzały"
 
-#: Source/items.cpp:4028
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr "nietypowe obrażenia"
 
-#: Source/items.cpp:4031
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr "zmieniona wytrzymałość"
 
-#: Source/items.cpp:4034
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr "Szybkie wykonanie ataku"
 
-#: Source/items.cpp:4037
+#: Source/items.cpp:4044
 msgid "one handed sword"
 msgstr "miecz jednoręczny"
 
-#: Source/items.cpp:4040
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr "stale tracisz punkty życia"
 
-#: Source/items.cpp:4043
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr "kradzież życia"
 
-#: Source/items.cpp:4046
+#: Source/items.cpp:4053
 msgid "no strength requirement"
 msgstr "brak wymogu siły"
 
-#: Source/items.cpp:4049
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr "widzenie z infrawizją"
 
-#: Source/items.cpp:4056
+#: Source/items.cpp:4063
 msgid "lightning damage: {:d}"
 msgstr "obrażenia błyskawic: {:d}"
 
-#: Source/items.cpp:4058
+#: Source/items.cpp:4065
 msgid "lightning damage: {:d}-{:d}"
 msgstr "obrażenia błyskawic: {:d}-{:d}"
 
-#: Source/items.cpp:4061
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr "rzuca Wiązkę Błyskawic"
 
-#: Source/items.cpp:4070
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr "okazyjnie potraja obrażenia"
 
-#: Source/items.cpp:4073
+#: Source/items.cpp:4080
 #, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr "rozkład {:+d}% obrażeń"
 
-#: Source/items.cpp:4076
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr "2x obr. dla potw, 1x dla cb"
 
-#: Source/items.cpp:4079
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr "Losowo 0 - 500% obrażeń"
 
-#: Source/items.cpp:4082
+#: Source/items.cpp:4089
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr "mała wyt, {:+d}% obrażeń"
 
-#: Source/items.cpp:4088
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr "ekstra pancerz przeciwko demonom"
 
-#: Source/items.cpp:4091
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr "ekstra pancerz przeciwko nieumarłym"
 
-#: Source/items.cpp:4094
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr "50% Many przechodzi do Życia"
 
-#: Source/items.cpp:4097
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr "40% Życia przechodzi do Many"
 
-#: Source/items.cpp:4100
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr "Inna zdolność"
 
-#: Source/items.cpp:4137 Source/items.cpp:4184
+#: Source/items.cpp:4144 Source/items.cpp:4191
 msgid "damage: {:d}  Indestructible"
 msgstr "obr: {:d}  Niezniszczalność"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4139 Source/items.cpp:4186
+#: Source/items.cpp:4146 Source/items.cpp:4193
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "obr: {:d}  Wyt: {:d}/{:d}"
 
-#: Source/items.cpp:4142 Source/items.cpp:4189
+#: Source/items.cpp:4149 Source/items.cpp:4196
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "obr: {:d}-{:d}  Niezniszczalność"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4144 Source/items.cpp:4191
+#: Source/items.cpp:4151 Source/items.cpp:4198
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "obr: {:d}-{:d}  Wyt: {:d}/{:d}"
 
-#: Source/items.cpp:4150 Source/items.cpp:4203
+#: Source/items.cpp:4157 Source/items.cpp:4210
 msgid "armor: {:d}  Indestructible"
 msgstr "pancerz: {:d}  Niezniszczalność"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4152 Source/items.cpp:4205
+#: Source/items.cpp:4159 Source/items.cpp:4212
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "pancerz: {:d}  Wyt: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4157
+#: Source/items.cpp:4164
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "obr: {:d}  Wyt: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4159
+#: Source/items.cpp:4166
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "obr: {:d}-{:d}  Wyt: {:d}/{:d}"
 
-#: Source/items.cpp:4160 Source/items.cpp:4195 Source/items.cpp:4210
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 msgid "Charges: {:d}/{:d}"
 msgstr "Ładunki: {:d}/{:d}"
 
-#: Source/items.cpp:4172
+#: Source/items.cpp:4179
 msgid "unique item"
 msgstr "unikat"
 
-#: Source/items.cpp:4199 Source/items.cpp:4208 Source/items.cpp:4215
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr "Nie zidentyfikowano"
 
-#: Source/loadsave.cpp:1680 Source/loadsave.cpp:2144
+#: Source/loadsave.cpp:1683 Source/loadsave.cpp:2149
 msgid "Unable to open save file archive"
 msgstr "Nie można otworzyć pliku zapisu"
 
-#: Source/loadsave.cpp:1683
+#: Source/loadsave.cpp:1686
 msgid "Invalid save file"
 msgstr "Nieprawidłowy plik zapisu"
 
-#: Source/loadsave.cpp:1712
+#: Source/loadsave.cpp:1717
 msgid "Player is on a Hellfire only level"
 msgstr "Gracz przebywa na poziomie z dodatku Hellfire"
 
-#: Source/loadsave.cpp:1907
+#: Source/loadsave.cpp:1912
 msgid "Invalid game state"
 msgstr "Nieprawidłowy stan gry"
 
@@ -5394,97 +5419,97 @@ msgctxt "monster"
 msgid "Doomlock"
 msgstr "Zaklęta Śmierć"
 
-#: Source/monster.cpp:3495
+#: Source/monster.cpp:3479
 msgid "Animal"
 msgstr "Zwierzę"
 
-#: Source/monster.cpp:3497
+#: Source/monster.cpp:3481
 msgid "Demon"
 msgstr "Demon"
 
-#: Source/monster.cpp:3499
+#: Source/monster.cpp:3483
 msgid "Undead"
 msgstr "Nieumarły"
 
-#: Source/monster.cpp:4630
+#: Source/monster.cpp:4612
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "Rodzaj: {:s}  Zabitych: {:d}"
 
-#: Source/monster.cpp:4632
+#: Source/monster.cpp:4614
 msgid "Total kills: {:d}"
 msgstr "Suma zabitych: {:d}"
 
-#: Source/monster.cpp:4665
+#: Source/monster.cpp:4647
 msgid "Hit Points: {:d}-{:d}"
 msgstr "Punkty życia: {:d}-{:d}"
 
-#: Source/monster.cpp:4671
+#: Source/monster.cpp:4653
 msgid "No magic resistance"
 msgstr "Brak odporności na magię"
 
-#: Source/monster.cpp:4675
+#: Source/monster.cpp:4657
 msgid "Resists: "
 msgstr "Odporność na: "
 
-#: Source/monster.cpp:4677 Source/monster.cpp:4688
+#: Source/monster.cpp:4659 Source/monster.cpp:4671
 msgid "Magic "
 msgstr "Magię "
 
-#: Source/monster.cpp:4679 Source/monster.cpp:4690
+#: Source/monster.cpp:4661 Source/monster.cpp:4673
 msgid "Fire "
 msgstr "Ogień "
 
-#: Source/monster.cpp:4681 Source/monster.cpp:4692
+#: Source/monster.cpp:4663 Source/monster.cpp:4675
 msgid "Lightning "
 msgstr "Błyskawice "
 
-#: Source/monster.cpp:4686
+#: Source/monster.cpp:4669
 msgid "Immune: "
 msgstr "Niewrażliwość na: "
 
-#: Source/monster.cpp:4704
+#: Source/monster.cpp:4688
 msgid "Type: {:s}"
 msgstr "Rodzaj: {:s}"
 
-#: Source/monster.cpp:4710 Source/monster.cpp:4717
+#: Source/monster.cpp:4694 Source/monster.cpp:4701
 msgid "No resistances"
 msgstr "Brak odporności"
 
-#: Source/monster.cpp:4712 Source/monster.cpp:4722
+#: Source/monster.cpp:4696 Source/monster.cpp:4706
 msgid "No Immunities"
 msgstr "Brak niewrażliwości"
 
-#: Source/monster.cpp:4715
+#: Source/monster.cpp:4699
 msgid "Some Magic Resistances"
 msgstr "Lekka odporność na magię"
 
-#: Source/monster.cpp:4720
+#: Source/monster.cpp:4704
 msgid "Some Magic Immunities"
 msgstr "Częściowa niewraż. na magię"
 
-#: Source/msg.cpp:494
+#: Source/msg.cpp:495
 msgid "Trying to drop a floor item?"
 msgstr "Próbujesz upuścić przedmiot leżący na ziemi?"
 
-#: Source/msg.cpp:982 Source/msg.cpp:1017 Source/msg.cpp:1048
-#: Source/msg.cpp:1175 Source/msg.cpp:1207 Source/msg.cpp:1239
-#: Source/msg.cpp:1269
+#: Source/msg.cpp:994 Source/msg.cpp:1029 Source/msg.cpp:1060
+#: Source/msg.cpp:1187 Source/msg.cpp:1219 Source/msg.cpp:1251
+#: Source/msg.cpp:1281
 msgid "{:s} has cast an illegal spell."
 msgstr "{:s} aktywował nielegalne zaklęcie."
 
-#: Source/msg.cpp:1655 Source/multi.cpp:805
+#: Source/msg.cpp:1668 Source/multi.cpp:804
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr "Gracz '{:s}' (poziom {:d}) dołączył do gry"
 
-#: Source/msg.cpp:1959
+#: Source/msg.cpp:1972
 msgid "Waiting for game data..."
 msgstr "Oczekiwanie na dane gry..."
 
-#: Source/msg.cpp:1967
+#: Source/msg.cpp:1980
 msgid "The game ended"
 msgstr "Gra została zakończona"
 
-#: Source/msg.cpp:1973
+#: Source/msg.cpp:1986
 msgid "Unable to get level data"
 msgstr "Nie można wczytać danych poziomu"
 
@@ -5500,7 +5525,7 @@ msgstr "Gracz '{:s}' pokonał Diablo i opuścił grę!"
 msgid "Player '{:s}' dropped due to timeout"
 msgstr "Gracz '{:s}' opuścił grę z powodu limitu czasu"
 
-#: Source/multi.cpp:807
+#: Source/multi.cpp:806
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr "Gracz '{:s}' (poziom {:d}) jest już w grze"
 
@@ -5710,158 +5735,158 @@ msgstr "Dziennik: Zakończenie"
 msgid "A Spellbook"
 msgstr "Księga Zaklęć"
 
-#: Source/objects.cpp:5373
+#: Source/objects.cpp:5339
 msgid "Crucified Skeleton"
 msgstr "Ukrzyżowany Szkielet"
 
-#: Source/objects.cpp:5377
+#: Source/objects.cpp:5343
 msgid "Lever"
 msgstr "Dźwignia"
 
-#: Source/objects.cpp:5386
+#: Source/objects.cpp:5352
 msgid "Open Door"
 msgstr "Otwarte Drzwi"
 
-#: Source/objects.cpp:5388
+#: Source/objects.cpp:5354
 msgid "Closed Door"
 msgstr "Zamknięte Drzwi"
 
-#: Source/objects.cpp:5390
+#: Source/objects.cpp:5356
 msgid "Blocked Door"
 msgstr "Zablokowane Drzwi"
 
-#: Source/objects.cpp:5395
+#: Source/objects.cpp:5361
 msgid "Ancient Tome"
 msgstr "Starożytna Księga"
 
-#: Source/objects.cpp:5397
+#: Source/objects.cpp:5363
 msgid "Book of Vileness"
 msgstr "Księga Obłudy"
 
-#: Source/objects.cpp:5402
+#: Source/objects.cpp:5368
 msgid "Skull Lever"
 msgstr "Kościana dźwignia"
 
-#: Source/objects.cpp:5405
+#: Source/objects.cpp:5371
 msgid "Mythical Book"
 msgstr "Mityczna Księga"
 
-#: Source/objects.cpp:5409
+#: Source/objects.cpp:5375
 msgid "Small Chest"
 msgstr "Mała Skrzynia"
 
-#: Source/objects.cpp:5413
+#: Source/objects.cpp:5379
 msgid "Chest"
 msgstr "Skrzynia"
 
-#: Source/objects.cpp:5418
+#: Source/objects.cpp:5384
 msgid "Large Chest"
 msgstr "Duża Skrzynia"
 
-#: Source/objects.cpp:5421
+#: Source/objects.cpp:5387
 msgid "Sarcophagus"
 msgstr "Sarkofag"
 
-#: Source/objects.cpp:5424
+#: Source/objects.cpp:5390
 msgid "Bookshelf"
 msgstr "Regał"
 
-#: Source/objects.cpp:5428
+#: Source/objects.cpp:5394
 msgid "Bookcase"
 msgstr "Biblioteczka"
 
-#: Source/objects.cpp:5433
+#: Source/objects.cpp:5399
 msgid "Pod"
 msgstr "Kokon"
 
-#: Source/objects.cpp:5435
+#: Source/objects.cpp:5401
 msgid "Urn"
 msgstr "Urna"
 
-#: Source/objects.cpp:5437
+#: Source/objects.cpp:5403
 msgid "Barrel"
 msgstr "Beczka"
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:5441
+#: Source/objects.cpp:5407
 msgid "{:s} Shrine"
 msgstr "{:s} Kapliczka"
 
-#: Source/objects.cpp:5445
+#: Source/objects.cpp:5411
 msgid "Skeleton Tome"
 msgstr "Kościana Księga"
 
-#: Source/objects.cpp:5448
+#: Source/objects.cpp:5414
 msgid "Library Book"
 msgstr "Księga Biblioteczna"
 
-#: Source/objects.cpp:5451
+#: Source/objects.cpp:5417
 msgid "Blood Fountain"
 msgstr "Fontanna Krwi"
 
-#: Source/objects.cpp:5454
+#: Source/objects.cpp:5420
 msgid "Decapitated Body"
 msgstr "Okaleczone Ciało"
 
-#: Source/objects.cpp:5457
+#: Source/objects.cpp:5423
 msgid "Book of the Blind"
 msgstr "Księga Ślepców"
 
-#: Source/objects.cpp:5460
+#: Source/objects.cpp:5426
 msgid "Book of Blood"
 msgstr "Księga Krwi"
 
-#: Source/objects.cpp:5463
+#: Source/objects.cpp:5429
 msgid "Purifying Spring"
 msgstr "Źródło Oczyszczenia"
 
-#: Source/objects.cpp:5470 Source/objects.cpp:5494
+#: Source/objects.cpp:5436 Source/objects.cpp:5460
 msgid "Weapon Rack"
 msgstr "Stojak na Broń"
 
-#: Source/objects.cpp:5473
+#: Source/objects.cpp:5439
 msgid "Goat Shrine"
 msgstr "Koźla Kapliczka"
 
-#: Source/objects.cpp:5476
+#: Source/objects.cpp:5442
 msgid "Cauldron"
 msgstr "Kocioł"
 
-#: Source/objects.cpp:5479
+#: Source/objects.cpp:5445
 msgid "Murky Pool"
 msgstr "Mętna Sadzawka"
 
-#: Source/objects.cpp:5482
+#: Source/objects.cpp:5448
 msgid "Fountain of Tears"
 msgstr "Fontanna Łez"
 
-#: Source/objects.cpp:5485
+#: Source/objects.cpp:5451
 msgid "Steel Tome"
 msgstr "Żelazna Księga"
 
-#: Source/objects.cpp:5488
+#: Source/objects.cpp:5454
 msgid "Pedestal of Blood"
 msgstr "Piedestał Krwi"
 
-#: Source/objects.cpp:5497
+#: Source/objects.cpp:5463
 msgid "Mushroom Patch"
 msgstr "Skupisko grzybów"
 
-#: Source/objects.cpp:5500
+#: Source/objects.cpp:5466
 msgid "Vile Stand"
 msgstr "Stojak Nikczemnego"
 
-#: Source/objects.cpp:5503
+#: Source/objects.cpp:5469
 msgid "Slain Hero"
 msgstr "Zabity Bohater"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:5510
+#: Source/objects.cpp:5476
 msgid "Trapped {:s}"
 msgstr "{:s} (pułapka)"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
-#: Source/objects.cpp:5516
+#: Source/objects.cpp:5482
 msgid "{:s} (disabled)"
 msgstr "{:s} (wył.)"
 
@@ -5983,23 +6008,23 @@ msgstr "czary"
 msgid "mute"
 msgstr "cisza"
 
-#: Source/pfile.cpp:260
+#: Source/pfile.cpp:242
 msgid "Failed to open player archive for writing."
 msgstr "Błąd podczas wczytywania danych postaci."
 
-#: Source/pfile.cpp:389
+#: Source/pfile.cpp:377
 msgid "Unable to open archive"
 msgstr "Nie udało się wczytać zawartości"
 
-#: Source/pfile.cpp:391
+#: Source/pfile.cpp:379
 msgid "Unable to load character"
 msgstr "Nie udało się wczytać postaci"
 
-#: Source/pfile.cpp:416 Source/pfile.cpp:436
+#: Source/pfile.cpp:403 Source/pfile.cpp:423
 msgid "Unable to read to save file archive"
 msgstr "Błąd podczas wczytywania pliku zapisu"
 
-#: Source/pfile.cpp:455
+#: Source/pfile.cpp:442
 msgid "Unable to write to save file archive"
 msgstr "Błąd podczas tworzenia pliku zapisu"
 
@@ -6018,7 +6043,7 @@ msgstr ",%03d"
 msgid "%i gold"
 msgstr "%i złota"
 
-#: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:56
+#: Source/qol/monhealthbar.cpp:37 Source/qol/xpbar.cpp:56
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
@@ -6432,298 +6457,331 @@ msgctxt "spell"
 msgid "Rune of Stone"
 msgstr "Runa Kamienia"
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:91
+#, fuzzy
+#| msgid "Griswold's Edge"
+msgid "Griswold"
+msgstr "Ostrze Griswolda"
+
+#: Source/stores.cpp:92
+msgid "Pepin"
+msgstr ""
+
+#: Source/stores.cpp:94
+msgid "Ogden"
+msgstr ""
+
+#: Source/stores.cpp:95
+msgid "Cain"
+msgstr ""
+
+#: Source/stores.cpp:96
+#, fuzzy
+#| msgid "Talk to Farnham"
+msgid "Farnham"
+msgstr "Rozmowa"
+
+#: Source/stores.cpp:97
+msgid "Adria"
+msgstr ""
+
+#: Source/stores.cpp:98 Source/stores.cpp:1305
+#, fuzzy
+#| msgid "brilliance"
+msgid "Gillian"
+msgstr "rozumu"
+
+#: Source/stores.cpp:99
+msgid "Wirt"
+msgstr ""
+
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr "Powrót"
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ",  "
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 msgid "Damage: {:d}-{:d}  "
 msgstr "Obrażenia: {:d}-{:d}  "
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 msgid "Armor: {:d}  "
 msgstr "Obrona: {:d}  "
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 msgid "Dur: {:d}/{:d},  "
 msgstr "Wyt: {:d}/{:d},  "
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr "Niezniszczalność,  "
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr "Brak wymagań atrybutów"
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr "Witaj"
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr "w kuźni Griswolda"
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr "Czynność:"
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 msgid "Talk to Griswold"
 msgstr "Rozmowa"
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 msgid "Buy basic items"
 msgstr "Kup zwykłe przedmioty"
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 msgid "Buy premium items"
 msgstr "Kup wyjątkowe przedmioty"
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 msgid "Sell items"
 msgstr "Sprzedaż"
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 msgid "Repair items"
 msgstr "Naprawa"
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 msgid "Leave the shop"
 msgstr "Wyjdź"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "Podstawowe przedmioty na sprzedaż:         Twoje złoto: {:d}"
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr "Powrót"
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "Wyjątkowe przedmioty na sprzedaż:           Twoje złoto: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "Nie masz rzeczy, których potrzebuję.     Twoje złoto: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "Który przedmiot chcesz sprzedać?  Twoje złoto: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "Nie masz nic do naprawy.          Twoje złoto: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "Który przedmiot naprawić?    Twoje złoto: {:d}"
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr "w Chacie Adrii"
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 msgid "Talk to Adria"
 msgstr "Rozmowa"
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr "Kup przedmioty"
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr "Naładowanie kosturów"
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 msgid "Leave the shack"
 msgstr "Wyjdź"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "Nie masz niczego do regeneracji.            Twoje złoto: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "Który przedmiot zregenerować?     Twoje złoto: {:d}"
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr "Brakuje ci złota"
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr "Nie masz miejsca w ekwipunku"
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr "Umowa stoi?"
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 msgid "Are you sure you want to identify this item?"
 msgstr "Czy na pewno chcesz zidentyfikować ten przedmiot?"
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 msgid "Are you sure you want to buy this item?"
 msgstr "Czy na pewno chcesz kupić ten przedmiot?"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 msgid "Are you sure you want to recharge this item?"
 msgstr "Czy na pewno chcesz zregenerować ten przedmiot?"
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 msgid "Are you sure you want to sell this item?"
 msgstr "Czy na pewno chcesz sprzedać ten przedmiot?"
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 msgid "Are you sure you want to repair this item?"
 msgstr "Czy na pewno chcesz naprawić ten przedmiot?"
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr "Wirt - kulejący chłopiec"
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 msgid "Talk to Wirt"
 msgstr "Rozmowa"
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr "Pokażę ci co oferuję,"
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr "jeśli dasz mi zaliczkę:"
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr "50 szt. złota. "
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr "Zgoda, co tam masz?"
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr "Wyjdź"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "Mogę ci to sprzedać:           Twoje złoto: {:d}"
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 msgid "Leave"
 msgstr "Wyjdź"
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr "w domu Pepina"
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr "Rozmowa"
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr "Wyjdź"
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 msgid "The Town Elder"
 msgstr "Miejski Kronikarz"
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 msgid "Talk to Cain"
 msgstr "Rozmowa"
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr "Identyfikacja"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "Nie masz nic do identyfikacji.       Twoje złoto: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "Który przedmiot zidentyfikować?         Twoje złoto: {:d}"
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr "Ten przedmiot to:"
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr "Akceptuj"
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 msgid "Talk to {:s}"
 msgstr "Rozmowa"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 msgid "Talking to {:s}"
 msgstr "Rozmowa"
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 msgid "is not available"
 msgstr "jest niedostępny"
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 msgid "in the shareware"
 msgstr "w wersji"
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 msgid "version"
 msgstr "shareware"
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr "Plotki"
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr "w Tawernie Ogdena"
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 msgid "Talk to Ogden"
 msgstr "Rozmowa"
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 msgid "Leave the tavern"
 msgstr "Wyjdź"
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 msgid "Talk to Gillian"
 msgstr "Rozmowa"
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr "Pijak Farnham"
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 msgid "Talk to Farnham"
 msgstr "Rozmowa"
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr "Wyjdź"
 
@@ -10906,17 +10964,17 @@ msgid "Down to Crypt"
 msgstr "Zejdź do Krypty"
 
 #: Source/trigs.cpp:412 Source/trigs.cpp:492 Source/trigs.cpp:539
-#: Source/trigs.cpp:630
+#: Source/trigs.cpp:634
 msgid "Up to level {:d}"
 msgstr "Wejdź na poziom {:d}"
 
 #: Source/trigs.cpp:414 Source/trigs.cpp:469 Source/trigs.cpp:521
-#: Source/trigs.cpp:596 Source/trigs.cpp:613 Source/trigs.cpp:660
+#: Source/trigs.cpp:600 Source/trigs.cpp:617 Source/trigs.cpp:664
 msgid "Up to town"
 msgstr "Wejdź do miasta"
 
-#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:552
-#: Source/trigs.cpp:577 Source/trigs.cpp:642
+#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:556
+#: Source/trigs.cpp:581 Source/trigs.cpp:646
 msgid "Down to level {:d}"
 msgstr "Zejdź na poziom {:d}"
 
@@ -10928,14 +10986,14 @@ msgstr "Do Krypty - poziom {:d}"
 msgid "Down to Crypt level {:d}"
 msgstr "Do Krypty - poziom {:d}"
 
-#: Source/trigs.cpp:564
+#: Source/trigs.cpp:568
 msgid "Up to Nest level {:d}"
 msgstr "Do Gniazda - poziom {:d}"
 
-#: Source/trigs.cpp:673
+#: Source/trigs.cpp:677
 msgid "Down to Diablo"
 msgstr "Staw czoła Diablo"
 
-#: Source/trigs.cpp:706 Source/trigs.cpp:720 Source/trigs.cpp:734
+#: Source/trigs.cpp:710 Source/trigs.cpp:724 Source/trigs.cpp:738
 msgid "Back to Level {:d}"
 msgstr "Wróć na poziom {:d}"

--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-09-20 04:33+0200\n"
-"PO-Revision-Date: 2021-09-24 00:25-0300\n"
+"POT-Creation-Date: 2021-11-21 05:46+0100\n"
+"PO-Revision-Date: 2021-11-21 05:46+0100\n"
 "Last-Translator: Altieres Lima da Silva <altieres.lima@gmail.com>\n"
 "Language-Team: \n"
 "Language: pt_BR\n"
@@ -159,6 +159,7 @@ msgstr ""
 msgid "QA Counterintelligence"
 msgstr "Contrainteligência do Controle de Qualidade"
 
+#. TRANSLATORS: A group of people
 #: Source/DiabloUI/credits_lines.cpp:130
 msgid "Order of Network Information Services"
 msgstr "Ordem dos Serviços de Informações de Rede"
@@ -311,15 +312,49 @@ msgstr "O Anel dos Mil"
 msgid "\tNo souls were sold in the making of this game."
 msgstr "\tNenhuma alma foi vendida na criação deste jogo."
 
-#: Source/DiabloUI/dialogs.cpp:172 Source/DiabloUI/dialogs.cpp:185
-#: Source/DiabloUI/selconn.cpp:73 Source/DiabloUI/selgame.cpp:94
-#: Source/DiabloUI/selgame.cpp:163 Source/DiabloUI/selgame.cpp:181
-#: Source/DiabloUI/selgame.cpp:314 Source/DiabloUI/selgame.cpp:387
-#: Source/DiabloUI/selhero.cpp:185 Source/DiabloUI/selhero.cpp:210
-#: Source/DiabloUI/selhero.cpp:280 Source/DiabloUI/selhero.cpp:525
+#: Source/DiabloUI/dialogs.cpp:194 Source/DiabloUI/dialogs.cpp:206
+#: Source/DiabloUI/selconn.cpp:79 Source/DiabloUI/selgame.cpp:103
+#: Source/DiabloUI/selgame.cpp:193 Source/DiabloUI/selgame.cpp:211
+#: Source/DiabloUI/selgame.cpp:352 Source/DiabloUI/selgame.cpp:428
+#: Source/DiabloUI/selhero.cpp:186 Source/DiabloUI/selhero.cpp:211
+#: Source/DiabloUI/selhero.cpp:281 Source/DiabloUI/selhero.cpp:536
 #: Source/DiabloUI/selok.cpp:68
 msgid "OK"
 msgstr "OK"
+
+#: Source/DiabloUI/extrasmenu.cpp:41 Source/DiabloUI/selstart.cpp:44
+#, fuzzy
+#| msgid "Down to Diablo"
+msgid "Switch to Diablo"
+msgstr "Descer para o Diablo"
+
+#: Source/DiabloUI/extrasmenu.cpp:41
+#, fuzzy
+#| msgid "Exit Hellfire"
+msgid "Switch to Hellfire"
+msgstr "Sair do Hellfire"
+
+#: Source/DiabloUI/extrasmenu.cpp:43
+msgid "Switch to Fullgame"
+msgstr ""
+
+#: Source/DiabloUI/extrasmenu.cpp:43
+#, fuzzy
+#| msgid "in the shareware"
+msgid "Switch to Shareware"
+msgstr "na versão"
+
+#: Source/DiabloUI/extrasmenu.cpp:44
+msgid "Replay Intro"
+msgstr "Repetir introdução"
+
+#: Source/DiabloUI/extrasmenu.cpp:45
+msgid "Support"
+msgstr "Suporte"
+
+#: Source/DiabloUI/extrasmenu.cpp:46 Source/gamemenu.cpp:61
+msgid "Previous Menu"
+msgstr "Menu anterior"
 
 #: Source/DiabloUI/mainmenu.cpp:36
 msgid "Single Player"
@@ -330,116 +365,123 @@ msgid "Multi Player"
 msgstr "Multijogador"
 
 #: Source/DiabloUI/mainmenu.cpp:38
-msgid "Replay Intro"
-msgstr "Repetir introdução"
+#, fuzzy
+#| msgid "Extra charges"
+msgid "Extras"
+msgstr "Cargas extra"
 
 #: Source/DiabloUI/mainmenu.cpp:39
-msgid "Support"
-msgstr "Suporte"
-
-#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Show Credits"
 msgstr "Exibir Créditos"
 
-#: Source/DiabloUI/mainmenu.cpp:41
+#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Exit Hellfire"
 msgstr "Sair do Hellfire"
 
-#: Source/DiabloUI/mainmenu.cpp:41
+#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Exit Diablo"
 msgstr "Sair do Diablo"
 
-#. TRANSLATORS:  Error Message when a Shareware User clicks on "Replay Intro" in the Main Menu
-#: Source/DiabloUI/mainmenu.cpp:99
-msgid ""
-"The Diablo introduction cinematic is only available in the full retail "
-"version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
-msgstr ""
-"A introdução cinematográfica da Diablo está disponível apenas na versão "
-"comercial completa do Diablo. Visite https://www.gog.com/game/diablo para "
-"comprar."
+#: Source/DiabloUI/mainmenu.cpp:55
+#, fuzzy
+#| msgid "in the shareware"
+msgid "Shareware"
+msgstr "na versão"
 
-#: Source/DiabloUI/progress.cpp:48 Source/DiabloUI/selconn.cpp:76
-#: Source/DiabloUI/selhero.cpp:188 Source/DiabloUI/selhero.cpp:213
-#: Source/DiabloUI/selhero.cpp:283 Source/DiabloUI/selhero.cpp:533
+#: Source/DiabloUI/progress.cpp:36 Source/DiabloUI/selconn.cpp:82
+#: Source/DiabloUI/selhero.cpp:189 Source/DiabloUI/selhero.cpp:214
+#: Source/DiabloUI/selhero.cpp:284 Source/DiabloUI/selhero.cpp:544
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: Source/DiabloUI/selconn.cpp:38 Source/DiabloUI/selgame.cpp:77
-#: Source/DiabloUI/selgame.cpp:372
+#: Source/DiabloUI/selconn.cpp:13
 msgid "Client-Server (TCP)"
 msgstr "Cliente-Servidor (TCP)"
 
-#: Source/DiabloUI/selconn.cpp:41
+#: Source/DiabloUI/selconn.cpp:14
 msgid "Loopback"
 msgstr "Loopback"
 
-#: Source/DiabloUI/selconn.cpp:47 Source/DiabloUI/selgame.cpp:434
-#: Source/DiabloUI/selgame.cpp:452
+#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:489
+#: Source/DiabloUI/selgame.cpp:510
 msgid "Multi Player Game"
 msgstr "Jogo Multijogador"
 
-#: Source/DiabloUI/selconn.cpp:53
+#: Source/DiabloUI/selconn.cpp:59
 msgid "Requirements:"
 msgstr "Requisitos:"
 
-#: Source/DiabloUI/selconn.cpp:59
+#: Source/DiabloUI/selconn.cpp:65
 msgid "no gateway needed"
 msgstr "sem gateway"
 
-#: Source/DiabloUI/selconn.cpp:65
+#: Source/DiabloUI/selconn.cpp:71
 msgid "Select Connection"
 msgstr "Selecione uma conexão"
 
-#: Source/DiabloUI/selconn.cpp:68
+#: Source/DiabloUI/selconn.cpp:74
 msgid "Change Gateway"
 msgstr "Mudar Gateway"
 
-#: Source/DiabloUI/selconn.cpp:101
+#: Source/DiabloUI/selconn.cpp:107
 msgid "All computers must be connected to a TCP-compatible network."
 msgstr ""
 "Todos os computadores devem estar conectados a uma rede compatível com TCP."
 
-#: Source/DiabloUI/selconn.cpp:105
+#: Source/DiabloUI/selconn.cpp:111
 msgid "All computers must be connected to the internet."
 msgstr "Todos os computadores devem estar conectados à internet."
 
-#: Source/DiabloUI/selconn.cpp:109
+#: Source/DiabloUI/selconn.cpp:115
 msgid "Play by yourself with no network exposure."
 msgstr "Jogue sozinho sem exposição na rede."
 
-#: Source/DiabloUI/selconn.cpp:114
+#: Source/DiabloUI/selconn.cpp:120
 msgid "Players Supported: {:d}"
 msgstr "Jogadores Suport.: {:d}"
 
-#: Source/DiabloUI/selgame.cpp:80 Source/DiabloUI/selgame.cpp:375
+#: Source/DiabloUI/selgame.cpp:82 Source/DiabloUI/selgame.cpp:414
 msgid "Description:"
 msgstr "Descrição:"
 
-#: Source/DiabloUI/selgame.cpp:86
+#: Source/DiabloUI/selgame.cpp:88
 msgid "Select Action"
 msgstr "Selecionar Ação"
 
-#: Source/DiabloUI/selgame.cpp:88 Source/DiabloUI/selgame.cpp:151
-#: Source/DiabloUI/selgame.cpp:295
+#: Source/DiabloUI/selgame.cpp:91 Source/DiabloUI/selgame.cpp:181
+#: Source/DiabloUI/selgame.cpp:333
 msgid "Create Game"
 msgstr "Criar jogo"
 
-#: Source/DiabloUI/selgame.cpp:89
+#: Source/DiabloUI/selgame.cpp:93
+#, fuzzy
+#| msgid "Create Game"
+msgid "Create Public Game"
+msgstr "Criar jogo"
+
+#: Source/DiabloUI/selgame.cpp:94
 msgid "Join Game"
 msgstr "Entrar no jogo"
 
-#: Source/DiabloUI/selgame.cpp:97 Source/DiabloUI/selgame.cpp:166
-#: Source/DiabloUI/selgame.cpp:184 Source/DiabloUI/selgame.cpp:317
-#: Source/DiabloUI/selgame.cpp:390
+#: Source/DiabloUI/selgame.cpp:106 Source/DiabloUI/selgame.cpp:196
+#: Source/DiabloUI/selgame.cpp:214 Source/DiabloUI/selgame.cpp:355
+#: Source/DiabloUI/selgame.cpp:431
 msgid "CANCEL"
 msgstr "CANCELAR"
 
-#: Source/DiabloUI/selgame.cpp:106
+#: Source/DiabloUI/selgame.cpp:122
 msgid "Create a new game with a difficulty setting of your choice."
 msgstr "Crie um novo jogo com uma dificuldade de sua escolha."
 
-#: Source/DiabloUI/selgame.cpp:109
+#: Source/DiabloUI/selgame.cpp:125
+#, fuzzy
+#| msgid "Create a new game with a difficulty setting of your choice."
+msgid ""
+"Create a new public game that anyone can join with a difficulty setting of "
+"your choice."
+msgstr "Crie um novo jogo com uma dificuldade de sua escolha."
+
+#: Source/DiabloUI/selgame.cpp:128
 msgid ""
 "Enter an IP or a hostname and join a game already in progress at that "
 "address."
@@ -447,35 +489,45 @@ msgstr ""
 "Insira um IP ou nome do servidor e entre em um jogo já em andamento nesse "
 "endereço."
 
-#: Source/DiabloUI/selgame.cpp:154
+#: Source/DiabloUI/selgame.cpp:131
+#, fuzzy
+#| msgid ""
+#| "Enter an IP or a hostname and join a game already in progress at that "
+#| "address."
+msgid "Join the public game already in progress at this address."
+msgstr ""
+"Insira um IP ou nome do servidor e entre em um jogo já em andamento nesse "
+"endereço."
+
+#: Source/DiabloUI/selgame.cpp:184
 msgid "Select Difficulty"
 msgstr "Dificuldade"
 
-#: Source/DiabloUI/selgame.cpp:156 Source/DiabloUI/selgame.cpp:203
-#: Source/DiabloUI/selgame.cpp:306 Source/DiabloUI/selgame.cpp:326
-#: Source/diablo.cpp:1434
+#: Source/DiabloUI/selgame.cpp:186 Source/DiabloUI/selgame.cpp:239
+#: Source/DiabloUI/selgame.cpp:344 Source/DiabloUI/selgame.cpp:364
+#: Source/diablo.cpp:1446
 msgid "Normal"
 msgstr "Normal"
 
-#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:207
-#: Source/diablo.cpp:1435
+#: Source/DiabloUI/selgame.cpp:187 Source/DiabloUI/selgame.cpp:243
+#: Source/diablo.cpp:1447
 msgid "Nightmare"
 msgstr "Pesadelo"
 
-#: Source/DiabloUI/selgame.cpp:158 Source/DiabloUI/selgame.cpp:211
-#: Source/diablo.cpp:1436
+#: Source/DiabloUI/selgame.cpp:188 Source/DiabloUI/selgame.cpp:247
+#: Source/diablo.cpp:1448
 msgid "Hell"
 msgstr "Inferno"
 
-#: Source/DiabloUI/selgame.cpp:172
+#: Source/DiabloUI/selgame.cpp:202
 msgid "Join TCP Games"
 msgstr "Entrar em jogos TCP"
 
-#: Source/DiabloUI/selgame.cpp:175 Source/DiabloUI/selgame.cpp:178
+#: Source/DiabloUI/selgame.cpp:205 Source/DiabloUI/selgame.cpp:208
 msgid "Enter address"
 msgstr "Inserir endereço"
 
-#: Source/DiabloUI/selgame.cpp:204
+#: Source/DiabloUI/selgame.cpp:240
 msgid ""
 "Normal Difficulty\n"
 "This is where a starting character should begin the quest to defeat Diablo."
@@ -483,7 +535,7 @@ msgstr ""
 "Dificuldade Normal\n"
 "É aqui que um personagem inicial deve começar a jornada para derrotar Diablo."
 
-#: Source/DiabloUI/selgame.cpp:208
+#: Source/DiabloUI/selgame.cpp:244
 msgid ""
 "Nightmare Difficulty\n"
 "The denizens of the Labyrinth have been bolstered and will prove to be a "
@@ -493,7 +545,7 @@ msgstr ""
 "Os habitantes do Labirinto foram reforçados e provarão ser um grande "
 "desafio. Recomendado apenas para personagens experientes."
 
-#: Source/DiabloUI/selgame.cpp:212
+#: Source/DiabloUI/selgame.cpp:248
 msgid ""
 "Hell Difficulty\n"
 "The most powerful of the underworld's creatures lurk at the gateway into "
@@ -504,7 +556,7 @@ msgstr ""
 "Inferno. Somente os personagens mais experientes devem se aventurar nesse "
 "reino."
 
-#: Source/DiabloUI/selgame.cpp:227
+#: Source/DiabloUI/selgame.cpp:264
 msgid ""
 "Your character must reach level 20 before you can enter a multiplayer game "
 "of Nightmare difficulty."
@@ -512,7 +564,7 @@ msgstr ""
 "Seu personagem deve atingir o nível 20 antes de poder entrar em um jogo "
 "multijogador na dificuldade Pesadelo."
 
-#: Source/DiabloUI/selgame.cpp:229
+#: Source/DiabloUI/selgame.cpp:266
 msgid ""
 "Your character must reach level 30 before you can enter a multiplayer game "
 "of Hell difficulty."
@@ -520,23 +572,23 @@ msgstr ""
 "Seu personagem deve atingir o nível 30 antes de poder entrar em um jogo "
 "multijogador na dificuldade Inferno."
 
-#: Source/DiabloUI/selgame.cpp:304
+#: Source/DiabloUI/selgame.cpp:342
 msgid "Select Game Speed"
 msgstr "Velocidade do jogo"
 
-#: Source/DiabloUI/selgame.cpp:307 Source/DiabloUI/selgame.cpp:330
+#: Source/DiabloUI/selgame.cpp:345 Source/DiabloUI/selgame.cpp:368
 msgid "Fast"
 msgstr "Rápido"
 
-#: Source/DiabloUI/selgame.cpp:308 Source/DiabloUI/selgame.cpp:334
+#: Source/DiabloUI/selgame.cpp:346 Source/DiabloUI/selgame.cpp:372
 msgid "Faster"
 msgstr "Muito Rápido"
 
-#: Source/DiabloUI/selgame.cpp:309 Source/DiabloUI/selgame.cpp:338
+#: Source/DiabloUI/selgame.cpp:347 Source/DiabloUI/selgame.cpp:376
 msgid "Fastest"
 msgstr "Super Rápido"
 
-#: Source/DiabloUI/selgame.cpp:327
+#: Source/DiabloUI/selgame.cpp:365
 msgid ""
 "Normal Speed\n"
 "This is where a starting character should begin the quest to defeat Diablo."
@@ -545,7 +597,7 @@ msgstr ""
 "É aqui que um personagem iniciante deve começar a jornada para derrotar "
 "Diablo."
 
-#: Source/DiabloUI/selgame.cpp:331
+#: Source/DiabloUI/selgame.cpp:369
 msgid ""
 "Fast Speed\n"
 "The denizens of the Labyrinth have been hastened and will prove to be a "
@@ -555,7 +607,7 @@ msgstr ""
 "Os habitantes do Labirinto foram acelerados e provarão ser um desafio maior. "
 "Isso é recomendado apenas para personagens experientes."
 
-#: Source/DiabloUI/selgame.cpp:335
+#: Source/DiabloUI/selgame.cpp:373
 msgid ""
 "Faster Speed\n"
 "Most monsters of the dungeon will seek you out quicker than ever before. "
@@ -565,7 +617,7 @@ msgstr ""
 "A maioria dos monstros da masmorra irão procurá-lo mais rápido do que nunca. "
 "Apenas um campeão experiente deve tentar a sorte nesta velocidade."
 
-#: Source/DiabloUI/selgame.cpp:339
+#: Source/DiabloUI/selgame.cpp:377
 msgid ""
 "Fastest Speed\n"
 "The minions of the underworld will rush to attack without hesitation. Only a "
@@ -575,77 +627,77 @@ msgstr ""
 "Os asseclas do submundo correrão para atacar sem hesitação. Apenas um "
 "verdadeiro demônio da velocidade deve entrar neste ritmo."
 
-#: Source/DiabloUI/selgame.cpp:381 Source/DiabloUI/selgame.cpp:384
+#: Source/DiabloUI/selgame.cpp:420 Source/DiabloUI/selgame.cpp:425
 msgid "Enter Password"
 msgstr "Inserir senha"
 
-#: Source/DiabloUI/selgame.cpp:407
+#: Source/DiabloUI/selgame.cpp:448
 msgid "The host is running a different game than you."
 msgstr "O anfitrião está executando um jogo diferente de você."
 
 #. TRANSLATORS: Error message when somebody tries to join a game running another version.
-#: Source/DiabloUI/selgame.cpp:410
+#: Source/DiabloUI/selgame.cpp:451
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr "Sua versão {:s} não corresponde com a do anfitrião {:d}.{:d}.{:d}."
 
-#: Source/DiabloUI/selhero.cpp:99
+#: Source/DiabloUI/selhero.cpp:100
 msgid "New Hero"
 msgstr "Novo herói"
 
-#: Source/DiabloUI/selhero.cpp:163
+#: Source/DiabloUI/selhero.cpp:164
 msgid "Choose Class"
 msgstr "Escolha uma Classe"
 
-#: Source/DiabloUI/selhero.cpp:167 Source/panels/charpanel.cpp:22
+#: Source/DiabloUI/selhero.cpp:168 Source/panels/charpanel.cpp:22
 msgid "Warrior"
 msgstr "Guerreiro"
 
-#: Source/DiabloUI/selhero.cpp:168 Source/panels/charpanel.cpp:23
+#: Source/DiabloUI/selhero.cpp:169 Source/panels/charpanel.cpp:23
 msgid "Rogue"
 msgstr "Ladina"
 
-#: Source/DiabloUI/selhero.cpp:169 Source/panels/charpanel.cpp:24
+#: Source/DiabloUI/selhero.cpp:170 Source/panels/charpanel.cpp:24
 msgid "Sorcerer"
 msgstr "Feiticeiro"
 
-#: Source/DiabloUI/selhero.cpp:171 Source/panels/charpanel.cpp:25
+#: Source/DiabloUI/selhero.cpp:172 Source/panels/charpanel.cpp:25
 msgid "Monk"
 msgstr "Monge"
 
-#: Source/DiabloUI/selhero.cpp:174 Source/panels/charpanel.cpp:26
+#: Source/DiabloUI/selhero.cpp:175 Source/panels/charpanel.cpp:26
 msgid "Bard"
 msgstr "Bardo"
 
-#: Source/DiabloUI/selhero.cpp:177 Source/panels/charpanel.cpp:27
+#: Source/DiabloUI/selhero.cpp:178 Source/panels/charpanel.cpp:27
 msgid "Barbarian"
 msgstr "Bárbaro"
 
-#: Source/DiabloUI/selhero.cpp:194 Source/DiabloUI/selhero.cpp:268
+#: Source/DiabloUI/selhero.cpp:195 Source/DiabloUI/selhero.cpp:269
 msgid "New Multi Player Hero"
 msgstr "Novo Herói Multijogador"
 
-#: Source/DiabloUI/selhero.cpp:194 Source/DiabloUI/selhero.cpp:268
+#: Source/DiabloUI/selhero.cpp:195 Source/DiabloUI/selhero.cpp:269
 msgid "New Single Player Hero"
 msgstr "Novo Herói"
 
-#: Source/DiabloUI/selhero.cpp:202
+#: Source/DiabloUI/selhero.cpp:203
 msgid "Save File Exists"
 msgstr "Jogo Salvo Existente"
 
-#: Source/DiabloUI/selhero.cpp:205 Source/gamemenu.cpp:38
+#: Source/DiabloUI/selhero.cpp:206 Source/gamemenu.cpp:38
 msgid "Load Game"
 msgstr "Carregar Jogo"
 
-#: Source/DiabloUI/selhero.cpp:206 Source/gamemenu.cpp:37
+#: Source/DiabloUI/selhero.cpp:207 Source/gamemenu.cpp:37
 #: Source/gamemenu.cpp:48
 msgid "New Game"
 msgstr "Novo Jogo"
 
-#: Source/DiabloUI/selhero.cpp:216 Source/DiabloUI/selhero.cpp:540
+#: Source/DiabloUI/selhero.cpp:217 Source/DiabloUI/selhero.cpp:551
 msgid "Single Player Characters"
 msgstr "Personagens"
 
-#: Source/DiabloUI/selhero.cpp:262
+#: Source/DiabloUI/selhero.cpp:263
 msgid ""
 "The Rogue and Sorcerer are only available in the full retail version of "
 "Diablo. Visit https://www.gog.com/game/diablo to purchase."
@@ -653,11 +705,11 @@ msgstr ""
 "A Ladina e o Feiticeiro estão disponíveis apenas na versão comercial "
 "completa do Diablo. Visite https://www.gog.com/game/diablo para comprar."
 
-#: Source/DiabloUI/selhero.cpp:274 Source/DiabloUI/selhero.cpp:277
+#: Source/DiabloUI/selhero.cpp:275 Source/DiabloUI/selhero.cpp:278
 msgid "Enter Name"
 msgstr "Inserir nome"
 
-#: Source/DiabloUI/selhero.cpp:306
+#: Source/DiabloUI/selhero.cpp:307
 msgid ""
 "Invalid name. A name cannot contain spaces, reserved characters, or reserved "
 "words.\n"
@@ -666,70 +718,76 @@ msgstr ""
 "palavras.\n"
 
 #. TRANSLATORS: Error Message
-#: Source/DiabloUI/selhero.cpp:313
+#: Source/DiabloUI/selhero.cpp:314
 msgid "Unable to create character."
 msgstr "Não foi possível criar o personagem."
 
-#: Source/DiabloUI/selhero.cpp:467 Source/DiabloUI/selhero.cpp:470
+#: Source/DiabloUI/selhero.cpp:468 Source/DiabloUI/selhero.cpp:471
 msgid "Level:"
 msgstr "Nível:"
 
-#: Source/DiabloUI/selhero.cpp:475
+#: Source/DiabloUI/selhero.cpp:476
 msgid "Strength:"
 msgstr "Força:"
 
-#: Source/DiabloUI/selhero.cpp:480
+#: Source/DiabloUI/selhero.cpp:481
 msgid "Magic:"
 msgstr "Magia:"
 
-#: Source/DiabloUI/selhero.cpp:485
+#: Source/DiabloUI/selhero.cpp:486
 msgid "Dexterity:"
 msgstr "Destreza:"
 
-#: Source/DiabloUI/selhero.cpp:490
+#: Source/DiabloUI/selhero.cpp:491
 msgid "Vitality:"
 msgstr "Vitalidade:"
 
-#: Source/DiabloUI/selhero.cpp:496
+#: Source/DiabloUI/selhero.cpp:497
 msgid "Savegame:"
 msgstr "Jogo Salvo:"
 
-#: Source/DiabloUI/selhero.cpp:508
+#: Source/DiabloUI/selhero.cpp:510
 msgid "Select Hero"
 msgstr "Selecione um Herói"
 
-#: Source/DiabloUI/selhero.cpp:528
+#: Source/DiabloUI/selhero.cpp:539
 msgid "Delete"
 msgstr "Apagar"
 
-#: Source/DiabloUI/selhero.cpp:538
+#: Source/DiabloUI/selhero.cpp:549
 msgid "Multi Player Characters"
 msgstr "Personagens Multijogador"
 
-#: Source/DiabloUI/selhero.cpp:580
+#: Source/DiabloUI/selhero.cpp:599
 msgid "Delete Multi Player Hero"
 msgstr "Apagar Herói Multijogador"
 
-#: Source/DiabloUI/selhero.cpp:582
+#: Source/DiabloUI/selhero.cpp:601
 msgid "Delete Single Player Hero"
 msgstr "Apagar Herói"
 
-#: Source/DiabloUI/selhero.cpp:584
+#: Source/DiabloUI/selhero.cpp:603
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "Tem certeza de que deseja apagar o personagem \"{:s}\"?"
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selstart.cpp:43
+#, fuzzy
+#| msgid "Exit Hellfire"
+msgid "Enter Hellfire"
+msgstr "Sair do Hellfire"
+
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr "Sim"
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr "Não"
 
 #: Source/DiabloUI/support_lines.cpp:8
 msgid ""
-"We maintains a chat server at Discord.gg/YQKCAYQ Follow the links to join "
-"our community where we talk about things related to Diablo, and the Hellfire "
+"We maintain a chat server at Discord.gg/YQKCAYQ Follow the links to join our "
+"community where we talk about things related to Diablo, and the Hellfire "
 "expansion."
 msgstr ""
 
@@ -775,12 +833,12 @@ msgstr ""
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr "Copyright © 1996-2001 Blizzard Entertainment"
 
-#: Source/appfat.cpp:37
+#: Source/appfat.cpp:38
 msgid "Error"
 msgstr "Erro"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:101
+#: Source/appfat.cpp:102
 msgid ""
 "{:s}\n"
 "\n"
@@ -790,7 +848,7 @@ msgstr ""
 "\n"
 "O erro ocorreu em: {:s} linha {:d}"
 
-#: Source/appfat.cpp:115
+#: Source/appfat.cpp:117
 msgid ""
 "Unable to open main data archive ({:s}).\n"
 "\n"
@@ -800,15 +858,12 @@ msgstr ""
 "\n"
 "Certifique-se de que ele esteja na pasta do jogo."
 
-msgid "diabdat.mpq or spawn.mpq"
-msgstr "diabdat.mpq ou spawn.mpq"
-
-#: Source/appfat.cpp:119
+#: Source/appfat.cpp:123
 msgid "Data File Error"
 msgstr "Erro de arquivo de dados"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:127
+#: Source/appfat.cpp:131
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -816,183 +871,207 @@ msgstr ""
 "Não foi possível gravar no local:\n"
 "{:s}"
 
-#: Source/appfat.cpp:129
+#: Source/appfat.cpp:133
 msgid "Read-Only Directory Error"
 msgstr "Erro de diretório, somente leitura"
 
-#: Source/automap.cpp:468
+#: Source/automap.cpp:484
 msgid "game: "
 msgstr "jogo: "
 
-#: Source/automap.cpp:474
+#: Source/automap.cpp:490
 msgid "password: "
 msgstr "senha: "
 
-#: Source/automap.cpp:487
+#: Source/automap.cpp:492
+#, fuzzy
+#| msgid "Quit Game"
+msgid "Public Game"
+msgstr "Sair do jogo"
+
+#: Source/automap.cpp:504
 msgid "Level: Nest {:d}"
 msgstr "Nível: Enxame {:d}"
 
-#: Source/automap.cpp:489
+#: Source/automap.cpp:506
 msgid "Level: Crypt {:d}"
 msgstr "Nível: Cripta {:d}"
 
-#: Source/automap.cpp:491 Source/items.cpp:2086
+#: Source/automap.cpp:508 Source/items.cpp:2090
 msgid "Level: {:d}"
 msgstr "Nível: {:d}"
 
-#: Source/control.cpp:196
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr "Tab"
 
-#: Source/control.cpp:196
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr "Esc"
 
-#: Source/control.cpp:196
+#: Source/control.cpp:212
 msgid "Enter"
 msgstr "Enter"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:215
 msgid "Character Information"
 msgstr "Informações do personagem"
 
-#: Source/control.cpp:200
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr "Registro de missões"
 
-#: Source/control.cpp:201
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr "Automapa"
 
-#: Source/control.cpp:202
+#: Source/control.cpp:218
 msgid "Main Menu"
 msgstr "Menu Principal"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr "Inventário"
 
-#: Source/control.cpp:204
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr "Livro de feitiços"
 
-#: Source/control.cpp:205
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr "Enviar Mensagem"
 
-#: Source/control.cpp:712 Source/control.cpp:1175
+#: Source/control.cpp:718 Source/control.cpp:1587
+msgid "Skill"
+msgstr "Habilidade"
+
+#: Source/control.cpp:719 Source/control.cpp:1237
 msgid "{:s} Skill"
 msgstr "Habilidade de {:s}"
 
-#: Source/control.cpp:716 Source/control.cpp:1179
+#: Source/control.cpp:725
+#, fuzzy
+#| msgid "Spells"
+msgid "Spell"
+msgstr "Feitiços"
+
+#: Source/control.cpp:726 Source/control.cpp:1241
 msgid "{:s} Spell"
 msgstr "Feitiço de {:s}"
 
-#: Source/control.cpp:718
+#: Source/control.cpp:728
 msgid "Damages undead only"
 msgstr "Atinge apenas mortos-vivos"
 
-#: Source/control.cpp:722 Source/control.cpp:1183 Source/control.cpp:1554
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr "Nível do feitiço 0 - Inutilizável"
 
-#: Source/control.cpp:724 Source/control.cpp:1185 Source/control.cpp:1556
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 msgid "Spell Level {:d}"
 msgstr "Nível do feitiço {:d}"
 
-#: Source/control.cpp:729 Source/control.cpp:1189
+#: Source/control.cpp:741
+#, fuzzy
+#| msgid "{:d} Scroll"
+#| msgid_plural "{:d} Scrolls"
+msgid "Scroll"
+msgstr "{:d} pergaminho"
+
+#: Source/control.cpp:742 Source/control.cpp:1251
 msgid "Scroll of {:s}"
 msgstr "Pergaminho de {:s}"
 
-#: Source/control.cpp:745 Source/control.cpp:1206
+#: Source/control.cpp:747 Source/control.cpp:1257
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "{:d} pergaminho"
 msgstr[1] "{:d} pergaminhos"
 
-#: Source/control.cpp:750 Source/control.cpp:1210 Source/items.cpp:1325
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
+msgid "Staff"
+msgstr "Cajado"
+
+#: Source/control.cpp:755 Source/control.cpp:1261
 msgid "Staff of {:s}"
 msgstr "Cajado de {:s}"
 
-#: Source/control.cpp:752 Source/control.cpp:1212
+#: Source/control.cpp:757 Source/control.cpp:1263
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "{:d} carga"
 msgstr[1] "{:d} cargas"
 
-#: Source/control.cpp:762
+#: Source/control.cpp:767
 msgid "Spell Hotkey {:s}"
 msgstr "Atalho de feitiço {:s}"
 
-#: Source/control.cpp:1152
+#: Source/control.cpp:1214
 msgid "Player friendly"
 msgstr "Amigável a jogadores"
 
-#: Source/control.cpp:1154
+#: Source/control.cpp:1216
 msgid "Player attack"
 msgstr "Hostil a jogadores"
 
-#: Source/control.cpp:1157
+#: Source/control.cpp:1219
 msgid "Hotkey: {:s}"
 msgstr "Tecla de atalho: {:s}"
 
-#: Source/control.cpp:1165
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr "Selecionar botão do feitiço atual"
 
-#: Source/control.cpp:1168
+#: Source/control.cpp:1230
 msgid "Hotkey: 's'"
 msgstr "Tecla de atalho: 's'"
 
-#: Source/control.cpp:1334 Source/inv.cpp:1893 Source/items.cpp:3751
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "{:d} peça de ouro"
 msgstr[1] "{:d} peças de ouro"
 
-#: Source/control.cpp:1337
+#: Source/control.cpp:1390
 msgid "Requirements not met"
 msgstr "Pré-requisitos não atendidos"
 
-#: Source/control.cpp:1373
+#: Source/control.cpp:1426
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Nível: {:d}"
 
-#: Source/control.cpp:1375
+#: Source/control.cpp:1428
 msgid "Hit Points {:d} of {:d}"
 msgstr "Pontos de vida {:d} de {:d}"
 
-#: Source/control.cpp:1402
+#: Source/control.cpp:1457
 msgid "Level Up"
 msgstr "Subiu de Nível"
 
-#: Source/control.cpp:1532
-msgid "Skill"
-msgstr "Habilidade"
-
-#: Source/control.cpp:1536
+#: Source/control.cpp:1591
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] "Cajado ({:d} carga)"
 msgstr[1] "Cajado ({:d} cargas)"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1544
+#: Source/control.cpp:1601
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "Mana: {:d}  Dano: {:d} - {:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1546
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "Mana: {:d}   Dano: NA"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1549
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "Mana: {:d}  Dano: 1/3 da vida do alvo"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1606
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] "Você tem {:d} peça de ouro. Quanto quer remover?"
@@ -1042,104 +1121,113 @@ msgstr "O Altar Profano"
 msgid "level 15"
 msgstr "o nível 15"
 
-#: Source/diablo.cpp:111
+#: Source/diablo.cpp:114
 msgid "I need help! Come Here!"
 msgstr "Preciso de ajuda! Venha aqui!"
 
-#: Source/diablo.cpp:112
+#: Source/diablo.cpp:115
 msgid "Follow me."
 msgstr "Siga-me."
 
-#: Source/diablo.cpp:113
+#: Source/diablo.cpp:116
 msgid "Here's something for you."
 msgstr "Tenho algo pra você."
 
-#: Source/diablo.cpp:114
+#: Source/diablo.cpp:117
 msgid "Now you DIE!"
 msgstr "Agora você MORRE!"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:777
+#: Source/diablo.cpp:781
 msgid "Options:\n"
 msgstr "Opções:\n"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:778
+#: Source/diablo.cpp:782
 msgid "Print this message and exit"
 msgstr "Imprime esta mensagem e sai"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:779
+#: Source/diablo.cpp:783
 msgid "Print the version and exit"
 msgstr "Imprime a versão e sai"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:780
+#: Source/diablo.cpp:784
 msgid "Specify the folder of diabdat.mpq"
 msgstr "Especifique a pasta de diabdat.mpq"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:781
+#: Source/diablo.cpp:785
 msgid "Specify the folder of save files"
 msgstr "Especifique a pasta dos arquivos salvos"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:782
+#: Source/diablo.cpp:786
 msgid "Specify the location of diablo.ini"
 msgstr "Especifique o local do diablo.ini"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:783
-msgid "Specify the location of the .ttf font"
-msgstr "Especifique o local da fonte .ttf"
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:784
-msgid "Specify the name of a custom .ttf font"
-msgstr "Especifique o nome de uma fonte .ttf personalizada"
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:785
+#: Source/diablo.cpp:787
 msgid "Skip startup videos"
 msgstr "Pular vídeos de abertura"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:786
+#: Source/diablo.cpp:788
 msgid "Display frames per second"
 msgstr "Exibir quadros por segundo"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:787
+#: Source/diablo.cpp:789
 msgid "Run in windowed mode"
 msgstr "Executar no modo janela"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:788
+#: Source/diablo.cpp:790
 msgid "Enable verbose logging"
 msgstr "Habilitar relatório detalhado"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:789
-msgid "Force spawn mode even if diabdat.mpq is found"
-msgstr "Forçar o modo spawn mesmo se diabdat.mpq for encontrado"
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:790
+#: Source/diablo.cpp:791
 msgid "Record a demo file"
 msgstr "Grava um arquivo de demonstração"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:791
+#: Source/diablo.cpp:792
 msgid "Play a demo file"
 msgstr "Toca um arquivo de demonstração"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:792
+#: Source/diablo.cpp:793
 msgid "Disable all frame limiting during demo playback"
 msgstr "Desabilita todos os limites de frame durante a demonstração"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:793
+#: Source/diablo.cpp:794
+msgid ""
+"\n"
+"Game selection:\n"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:795
+msgid "Force Shareware mode"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:796
+msgid "Force Diablo mode"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:797
+#, fuzzy
+#| msgid "Hellfire Help"
+msgid "Force Hellfire mode"
+msgstr "Ajuda do Hellfire"
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:798
 msgid ""
 "\n"
 "Hellfire options:\n"
@@ -1148,16 +1236,11 @@ msgstr ""
 "Opções do Hellfire:\n"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:794
-msgid "Force diablo mode even if hellfire.mpq is found"
-msgstr "Forçar o modo Diablo mesmo que o arquivo hellfire.mpq seja encontrado"
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:795
+#: Source/diablo.cpp:799
 msgid "Use alternate nest palette"
 msgstr "Usa paleta alternativa no enxame"
 
-#: Source/diablo.cpp:801
+#: Source/diablo.cpp:805
 msgid ""
 "\n"
 "Report bugs at https://github.com/diasurgical/devilutionX/\n"
@@ -1173,292 +1256,292 @@ msgstr "opção '{:s}' não reconhecida\n"
 msgid "version {:s}"
 msgstr "versão {:s}"
 
-#: Source/diablo.cpp:1206
+#: Source/diablo.cpp:1218
 msgid "-- Network timeout --"
 msgstr "-- Tempo limite da rede excedido --"
 
-#: Source/diablo.cpp:1207
+#: Source/diablo.cpp:1219
 msgid "-- Waiting for players --"
 msgstr "-- Aguardando jogadores --"
 
-#: Source/diablo.cpp:1226
+#: Source/diablo.cpp:1238
 msgid "No help available"
 msgstr "Nenhuma ajuda disponível"
 
-#: Source/diablo.cpp:1227
+#: Source/diablo.cpp:1239
 msgid "while in stores"
 msgstr "enquanto estiver em lojas"
 
 #. TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty.
-#: Source/diablo.cpp:1439
+#: Source/diablo.cpp:1451
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr "{:s}, versão = {:s}, modo = {:s}"
 
-#: Source/dvlnet/loopback.cpp:111
+#: Source/dvlnet/loopback.cpp:113
 msgid "loopback"
 msgstr "loopback"
 
-#: Source/dvlnet/tcp_client.cpp:68
+#: Source/dvlnet/tcp_client.cpp:65
 msgid "Unable to connect"
 msgstr "Não foi possível se conectar"
 
-#: Source/dvlnet/tcp_client.cpp:89
+#: Source/dvlnet/tcp_client.cpp:86
 msgid "error: read 0 bytes from server"
 msgstr "erro: 0 bytes lidos do servidor"
 
-#: Source/error.cpp:58
+#: Source/error.cpp:57
 msgid "No automap available in town"
 msgstr "Automapa indisponível na cidade"
 
-#: Source/error.cpp:59
+#: Source/error.cpp:58
 msgid "No multiplayer functions in demo"
 msgstr "Sem funções multijogador na demonstração"
 
-#: Source/error.cpp:60
+#: Source/error.cpp:59
 msgid "Direct Sound Creation Failed"
 msgstr "Falha na criação de Direct Sound"
 
-#: Source/error.cpp:61
+#: Source/error.cpp:60
 msgid "Not available in shareware version"
 msgstr "Indisponível na versão shareware"
 
-#: Source/error.cpp:62
+#: Source/error.cpp:61
 msgid "Not enough space to save"
 msgstr "Espaço insuficiente para salvar"
 
-#: Source/error.cpp:63
+#: Source/error.cpp:62
 msgid "No Pause in town"
 msgstr "Pausa não permitida na cidade"
 
-#: Source/error.cpp:64
+#: Source/error.cpp:63
 msgid "Copying to a hard disk is recommended"
 msgstr "É recomendado copiar para um disco rígido"
 
-#: Source/error.cpp:65
+#: Source/error.cpp:64
 msgid "Multiplayer sync problem"
 msgstr "Problema de sincronia do modo multijogador"
 
-#: Source/error.cpp:66
+#: Source/error.cpp:65
 msgid "No pause in multiplayer"
 msgstr "Não é permitido pausar no modo multijogador"
 
-#: Source/error.cpp:67
+#: Source/error.cpp:66
 msgid "Loading..."
 msgstr "Carregando..."
 
-#: Source/error.cpp:68
+#: Source/error.cpp:67
 msgid "Saving..."
 msgstr "Salvando..."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:69
+#: Source/error.cpp:68
 msgid "Some are weakened as one grows strong"
 msgstr "Uns são enfraquecidos enquanto um se torna mais forte"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:70
+#: Source/error.cpp:69
 msgid "New strength is forged through destruction"
 msgstr "Nova força é forjada pela destruição"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:71
+#: Source/error.cpp:70
 msgid "Those who defend seldom attack"
 msgstr "Aqueles que defendem raramente atacam"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:72
+#: Source/error.cpp:71
 msgid "The sword of justice is swift and sharp"
 msgstr "A espada da justiça é veloz e afiada"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:73
+#: Source/error.cpp:72
 msgid "While the spirit is vigilant the body thrives"
 msgstr "Enquanto o espírito é vigilante, o corpo prospera"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:74
+#: Source/error.cpp:73
 msgid "The powers of mana refocused renews"
 msgstr "Os poderes da mana reorientados se renovam"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:75
+#: Source/error.cpp:74
 msgid "Time cannot diminish the power of steel"
 msgstr "O tempo não pode diminuir o poder do aço"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:76
+#: Source/error.cpp:75
 msgid "Magic is not always what it seems to be"
 msgstr "A mágica nem sempre é o que parece ser"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:77
+#: Source/error.cpp:76
 msgid "What once was opened now is closed"
 msgstr "O que antes estava aberto, agora está fechado"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:78
+#: Source/error.cpp:77
 msgid "Intensity comes at the cost of wisdom"
 msgstr "A intensidade vem à custa de sabedoria"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:79
+#: Source/error.cpp:78
 msgid "Arcane power brings destruction"
 msgstr "O poder arcano traz destruição"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:80
+#: Source/error.cpp:79
 msgid "That which cannot be held cannot be harmed"
 msgstr "Aquilo que não pode ser agarrado não pode ser ferido"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:81
+#: Source/error.cpp:80
 msgid "Crimson and Azure become as the sun"
 msgstr "O Rubro e Anil se tornam como o sol"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:82
+#: Source/error.cpp:81
 msgid "Knowledge and wisdom at the cost of self"
 msgstr "Conhecimento e sabedoria à custa de seu próprio eu"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:83
+#: Source/error.cpp:82
 msgid "Drink and be refreshed"
 msgstr "Beba e refresque-se"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:84
+#: Source/error.cpp:83
 msgid "Wherever you go, there you are"
 msgstr "Aonde quer que você vá, lá está você"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:85
+#: Source/error.cpp:84
 msgid "Energy comes at the cost of wisdom"
 msgstr "A energia vem à custa de sabedoria"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:86
+#: Source/error.cpp:85
 msgid "Riches abound when least expected"
 msgstr "Riquezas abundam quando menos se espera"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:87
+#: Source/error.cpp:86
 msgid "Where avarice fails, patience gains reward"
 msgstr "Onde falha a avareza, a paciência é recompensada"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:88
+#: Source/error.cpp:87
 msgid "Blessed by a benevolent companion!"
 msgstr "Abençoado por uma companhia benevolente!"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:89
+#: Source/error.cpp:88
 msgid "The hands of men may be guided by fate"
 msgstr "As mãos dos homens podem ser guiadas pelo destino"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:90
+#: Source/error.cpp:89
 msgid "Strength is bolstered by heavenly faith"
 msgstr "A força é intensificada pela fé celestial"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:91
+#: Source/error.cpp:90
 msgid "The essence of life flows from within"
 msgstr "A essência da vida flui de dentro"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:92
+#: Source/error.cpp:91
 msgid "The way is made clear when viewed from above"
 msgstr "O caminho se faz claro quando visto de cima"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:93
+#: Source/error.cpp:92
 msgid "Salvation comes at the cost of wisdom"
 msgstr "A salvação vem à custa de sabedoria"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:94
+#: Source/error.cpp:93
 msgid "Mysteries are revealed in the light of reason"
 msgstr "Mistérios são revelados à luz da razão"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:95
+#: Source/error.cpp:94
 msgid "Those who are last may yet be first"
 msgstr "Aqueles que são últimos ainda poderão ser primeiros"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:96
+#: Source/error.cpp:95
 msgid "Generosity brings its own rewards"
 msgstr "A generosidade traz suas próprias recompensas"
 
-#: Source/error.cpp:97
+#: Source/error.cpp:96
 msgid "You must be at least level 8 to use this."
 msgstr "Você deve estar ao menos no nível 8 para usar isto."
 
-#: Source/error.cpp:98
+#: Source/error.cpp:97
 msgid "You must be at least level 13 to use this."
 msgstr "Você deve estar ao menos no nível 13 para usar isto."
 
-#: Source/error.cpp:99
+#: Source/error.cpp:98
 msgid "You must be at least level 17 to use this."
 msgstr "Você deve estar ao menos no nível 17 para usar isto."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:100
+#: Source/error.cpp:99
 msgid "Arcane knowledge gained!"
 msgstr "Conhecimento arcano obtido!"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:101
+#: Source/error.cpp:100
 msgid "That which does not kill you..."
 msgstr "Aquilo que não o mata..."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:102
+#: Source/error.cpp:101
 msgid "Knowledge is power."
 msgstr "Conhecimento é poder."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:103
+#: Source/error.cpp:102
 msgid "Give and you shall receive."
 msgstr "Doe e você receberá."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:104
+#: Source/error.cpp:103
 msgid "Some experience is gained by touch."
 msgstr "Um pouco de experiência é obtida através do toque."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:105
+#: Source/error.cpp:104
 msgid "There's no place like home."
 msgstr "Não há lugar como a nossa casa."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:106
+#: Source/error.cpp:105
 msgid "Spiritual energy is restored."
 msgstr "A energia espiritual é restaurada."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:107
+#: Source/error.cpp:106
 msgid "You feel more agile."
 msgstr "Você se sente mais ágil."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:108
+#: Source/error.cpp:107
 msgid "You feel stronger."
 msgstr "Você se sente mais forte."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:109
+#: Source/error.cpp:108
 msgid "You feel wiser."
 msgstr "Você se sente mais sábio."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:110
+#: Source/error.cpp:109
 msgid "You feel refreshed."
 msgstr "Você se sente revigorado."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:111
+#: Source/error.cpp:110
 msgid "That which can break will."
 msgstr "Aquilo que puder ser quebrado, assim o será."
 
@@ -1485,10 +1568,6 @@ msgstr "Gama"
 #: Source/gamemenu.cpp:60 Source/gamemenu.cpp:167
 msgid "Speed"
 msgstr "Veloc."
-
-#: Source/gamemenu.cpp:61
-msgid "Previous Menu"
-msgstr "Menu anterior"
 
 #: Source/gamemenu.cpp:68
 msgid "Music Disabled"
@@ -1665,7 +1744,9 @@ msgstr ""
 "correspondente ou dando um clique direito no item."
 
 #: Source/help.cpp:68
-msgid "$Gold"
+#, fuzzy
+#| msgid "$Gold"
+msgid "$Gold:"
 msgstr "$Ouro"
 
 #: Source/help.cpp:69
@@ -1696,7 +1777,9 @@ msgstr ""
 "área de jogo."
 
 #: Source/help.cpp:79
-msgid "$Using the Speedbook for Spells"
+#, fuzzy
+#| msgid "$Using the Speedbook for Spells"
+msgid "$Using the Speedbook for Spells:"
 msgstr "$Uso do Livro de acesso rápido para feitiços"
 
 #: Source/help.cpp:80
@@ -1711,15 +1794,21 @@ msgstr ""
 "simplesmente clique com o botão direito na área de jogo principal."
 
 #: Source/help.cpp:84
+#, fuzzy
+#| msgid ""
+#| "Shift + Left-clicking on the 'select current spell' button will clear the "
+#| "readied spell"
 msgid ""
 "Shift + Left-clicking on the 'select current spell' button will clear the "
-"readied spell"
+"readied spell."
 msgstr ""
 "Shift + clique esquerdo em 'Selecionar feitiço atual' irá limpar o feitiço "
 "preparado"
 
 #: Source/help.cpp:86
-msgid "$Setting Spell Hotkeys"
+#, fuzzy
+#| msgid "$Setting Spell Hotkeys"
+msgid "$Setting Spell Hotkeys:"
 msgstr "$Configuração de teclas de atalho para feitiços"
 
 #: Source/help.cpp:87
@@ -1734,7 +1823,9 @@ msgstr ""
 "feitiço que deseja designar."
 
 #: Source/help.cpp:92
-msgid "$Spell Books"
+#, fuzzy
+#| msgid "$Spell Books"
+msgid "$Spell Books:"
 msgstr "$Livros de feitiços"
 
 #: Source/help.cpp:93
@@ -1745,31 +1836,35 @@ msgstr ""
 "Ler mais de um livro aumenta seu conhecimento desse feitiço, o que lhe "
 "permite lançar o feitiço de maneira mais efetiva."
 
-#: Source/help.cpp:130
+#: Source/help.cpp:181
 msgid "Shareware Hellfire Help"
 msgstr "Ajuda do Hellfire Shareware"
 
-#: Source/help.cpp:130
+#: Source/help.cpp:181
 msgid "Hellfire Help"
 msgstr "Ajuda do Hellfire"
 
-#: Source/help.cpp:132
+#: Source/help.cpp:183
 msgid "Shareware Diablo Help"
 msgstr "Ajuda do Diablo Shareware"
 
-#: Source/help.cpp:132
+#: Source/help.cpp:183
 msgid "Diablo Help"
 msgstr "Ajuda do Diablo"
 
-#: Source/help.cpp:156
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr "Pressione ESC para encerrar ou setas direcionais para rolar."
 
-#: Source/init.cpp:214
+#: Source/init.cpp:175
+msgid "diabdat.mpq or spawn.mpq"
+msgstr "diabdat.mpq ou spawn.mpq"
+
+#: Source/init.cpp:196
 msgid "Some Hellfire MPQs are missing"
 msgstr "Alguns arquivos MPQs do Hellfire estão faltando"
 
-#: Source/init.cpp:214
+#: Source/init.cpp:196
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
@@ -1777,11 +1872,11 @@ msgstr ""
 "Nem todos os arquivos MPQs do Hellfire foram encontrados.\n"
 "Por favor, copie todos os arquivos hf*.mpq."
 
-#: Source/init.cpp:224
+#: Source/init.cpp:204
 msgid "Unable to create main window"
 msgstr "Não foi possível criar a janela principal"
 
-#: Source/itemdat.cpp:16 Source/itemdat.cpp:198 Source/panels/charpanel.cpp:154
+#: Source/itemdat.cpp:16 Source/itemdat.cpp:198 Source/panels/charpanel.cpp:155
 msgid "Gold"
 msgstr "Ouro"
 
@@ -1921,7 +2016,7 @@ msgstr "Cajado de Lázarus"
 msgid "Scroll of Resurrect"
 msgstr "Pergaminho de ressuscitar"
 
-#: Source/itemdat.cpp:51 Source/itemdat.cpp:99 Source/items.cpp:164
+#: Source/itemdat.cpp:51 Source/itemdat.cpp:99 Source/items.cpp:166
 msgid "Blacksmith Oil"
 msgstr "Óleo do ferreiro"
 
@@ -2021,7 +2116,7 @@ msgid "Quilted Armor"
 msgstr "Armadura acolchoada"
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
-#: Source/itemdat.cpp:77 Source/objects.cpp:5459
+#: Source/itemdat.cpp:77 Source/objects.cpp:5433
 msgid "Armor"
 msgstr "Armadura"
 
@@ -2116,11 +2211,11 @@ msgstr "Poção de rejuvenescimento"
 msgid "Potion of Full Rejuvenation"
 msgstr "Poção de rejuvenescimento completo"
 
-#: Source/itemdat.cpp:100 Source/items.cpp:159
+#: Source/itemdat.cpp:100 Source/items.cpp:161
 msgid "Oil of Accuracy"
 msgstr "Óleo da precisão"
 
-#: Source/itemdat.cpp:101 Source/items.cpp:161
+#: Source/itemdat.cpp:101 Source/items.cpp:163
 msgid "Oil of Sharpness"
 msgstr "Óleo da nitidez"
 
@@ -2348,11 +2443,6 @@ msgstr "Arco de Guerra Curto"
 msgid "Long War Bow"
 msgstr "Arco de Guerra Longo"
 
-#: Source/itemdat.cpp:167 Source/itemdat.cpp:168 Source/itemdat.cpp:169
-#: Source/itemdat.cpp:170 Source/itemdat.cpp:171
-msgid "Staff"
-msgstr "Cajado"
-
 #: Source/itemdat.cpp:168
 msgid "Long Staff"
 msgstr "Cajado longo"
@@ -2443,7 +2533,7 @@ msgstr "de mithril"
 msgid "Meteoric"
 msgstr "meteórico(a)"
 
-#: Source/itemdat.cpp:202 Source/objects.cpp:104
+#: Source/itemdat.cpp:202 Source/objects.cpp:107
 msgid "Weird"
 msgstr "esquisito(a)"
 
@@ -2579,7 +2669,7 @@ msgstr "santo(a)"
 msgid "Awesome"
 msgstr "impressionante"
 
-#: Source/itemdat.cpp:237 Source/objects.cpp:116
+#: Source/itemdat.cpp:237 Source/objects.cpp:119
 msgid "Holy"
 msgstr "sagrado(a)"
 
@@ -3188,7 +3278,9 @@ msgid "The Defender"
 msgstr "O defensor"
 
 #: Source/itemdat.cpp:418
-msgid "Gryphons Claw"
+#, fuzzy
+#| msgid "Gryphons Claw"
+msgid "Gryphon's Claw"
 msgstr "Garra de grifo"
 
 #: Source/itemdat.cpp:419
@@ -3352,7 +3444,9 @@ msgid "Rod of Onan"
 msgstr "Vara de Onan"
 
 #: Source/itemdat.cpp:459
-msgid "Helm of Sprits"
+#, fuzzy
+#| msgid "Helm of Sprits"
+msgid "Helm of Spirits"
 msgstr "Elmo dos espíritos"
 
 #: Source/itemdat.cpp:460
@@ -3540,689 +3634,712 @@ msgstr "Amuleto de acólito"
 msgid "Gladiator's Ring"
 msgstr "Anel do gladiador"
 
-#: Source/items.cpp:160
+#: Source/items.cpp:162
 msgid "Oil of Mastery"
 msgstr "Óleo da maestria"
 
-#: Source/items.cpp:162
+#: Source/items.cpp:164
 msgid "Oil of Death"
 msgstr "Óleo da morte"
 
-#: Source/items.cpp:163
+#: Source/items.cpp:165
 msgid "Oil of Skill"
 msgstr "Óleo de habilidade"
 
-#: Source/items.cpp:165
+#: Source/items.cpp:167
 msgid "Oil of Fortitude"
 msgstr "Óleo de fortitude"
 
-#: Source/items.cpp:166
+#: Source/items.cpp:168
 msgid "Oil of Permanence"
 msgstr "Óleo de permanência"
 
-#: Source/items.cpp:167
+#: Source/items.cpp:169
 msgid "Oil of Hardening"
 msgstr "Óleo de endurecimento"
 
-#: Source/items.cpp:168
+#: Source/items.cpp:170
 msgid "Oil of Imperviousness"
 msgstr "Óleo de impermeabilidade"
 
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#: Source/items.cpp:1174 Source/items.cpp:1184 Source/items.cpp:1233
-#: Source/items.cpp:1269
-msgid "{0} {1}"
-msgstr ""
-
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's Staff of Firewall
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Long Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1187 Source/items.cpp:1254 Source/items.cpp:1273
-#: Source/items.cpp:1315
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
+#, fuzzy
+#| msgid "{0} of {1}"
+msgctxt "spell"
 msgid "{0} of {1}"
 msgstr "{:s} {:s}"
 
-#: Source/items.cpp:1902 Source/items.cpp:1914
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+#, fuzzy
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} {:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+#, fuzzy
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} {:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
+#: Source/items.cpp:1217
+msgid "{0} {1}"
+msgstr ""
+
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
+msgid "{0} of {1}"
+msgstr "{:s} {:s}"
+
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr "aumenta"
 
-#: Source/items.cpp:1904
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr "chance de acerto"
 
-#: Source/items.cpp:1908
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr "aumenta enormemente um"
 
-#: Source/items.cpp:1910
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr "chance de acerto da arma"
 
-#: Source/items.cpp:1916
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr "potencial de dano"
 
-#: Source/items.cpp:1920
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr "aumenta enormemente"
 
-#: Source/items.cpp:1922
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr "potencial de dano - não arcos"
 
-#: Source/items.cpp:1926
+#: Source/items.cpp:1930
 msgid "reduces attributes needed"
 msgstr "reduz atributo requerido"
 
-#: Source/items.cpp:1928
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr "para usar armaduras ou armas"
 
-#: Source/items.cpp:1932
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr "restaura 20% de um"
 
-#: Source/items.cpp:1934
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr "durabilidade do item"
 
-#: Source/items.cpp:1938
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr "aumenta"
 
-#: Source/items.cpp:1940
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr "durabilidade atual e máxima"
 
-#: Source/items.cpp:1944
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr "faz com que um item seja indestrutível"
 
-#: Source/items.cpp:1948
+#: Source/items.cpp:1952
 msgid "increases the armor class"
 msgstr "aumenta a classe de armadura"
 
-#: Source/items.cpp:1950
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr "de armaduras e escudos"
 
-#: Source/items.cpp:1954
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr "aumenta enormemente a armadura"
 
-#: Source/items.cpp:1956
+#: Source/items.cpp:1960
 msgid "class of armor and shields"
 msgstr "classe de armaduras e escudos"
 
-#: Source/items.cpp:1960 Source/items.cpp:1969
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr "coloca armadilha de fogo"
 
-#: Source/items.cpp:1965
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr "coloca armadilha de relâmpagos"
 
-#: Source/items.cpp:1973
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr "coloca armadilha de petrificação"
 
-#: Source/items.cpp:1977
+#: Source/items.cpp:1981
 msgid "restore all life"
 msgstr "restaura toda a vida"
 
-#: Source/items.cpp:1981
+#: Source/items.cpp:1985
 msgid "restore some life"
 msgstr "restaura alguma vida"
 
-#: Source/items.cpp:1985
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr "recupera vida"
 
-#: Source/items.cpp:1989
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr "cura mortalmente"
 
-#: Source/items.cpp:1993
+#: Source/items.cpp:1997
 msgid "restore some mana"
 msgstr "restaura um pouco de mana"
 
-#: Source/items.cpp:1997
+#: Source/items.cpp:2001
 msgid "restore all mana"
 msgstr "restaura toda a mana"
 
-#: Source/items.cpp:2001
+#: Source/items.cpp:2005
 msgid "increase strength"
 msgstr "aumenta força"
 
-#: Source/items.cpp:2005
+#: Source/items.cpp:2009
 msgid "increase magic"
 msgstr "aumenta magia"
 
-#: Source/items.cpp:2009
+#: Source/items.cpp:2013
 msgid "increase dexterity"
 msgstr "aumenta destreza"
 
-#: Source/items.cpp:2013
+#: Source/items.cpp:2017
 msgid "increase vitality"
 msgstr "aumenta vitalidade"
 
-#: Source/items.cpp:2018
+#: Source/items.cpp:2022
 msgid "decrease strength"
 msgstr "diminui força"
 
-#: Source/items.cpp:2022
+#: Source/items.cpp:2026
 msgid "decrease dexterity"
 msgstr "diminui destreza"
 
-#: Source/items.cpp:2026
+#: Source/items.cpp:2030
 msgid "decrease vitality"
 msgstr "diminui vitalidade"
 
-#: Source/items.cpp:2030
+#: Source/items.cpp:2034
 msgid "restore some life and mana"
 msgstr "restaura um pouco de vida e mana"
 
-#: Source/items.cpp:2034
+#: Source/items.cpp:2038
 msgid "restore all life and mana"
 msgstr "restaura toda a vida e mana"
 
-#: Source/items.cpp:2049 Source/items.cpp:2074
+#: Source/items.cpp:2053 Source/items.cpp:2078
 msgid "Right-click to read"
 msgstr "Clique direito para ler"
 
-#: Source/items.cpp:2053
+#: Source/items.cpp:2057
 msgid "Right-click to read, then"
 msgstr "Clique direito para ler e então"
 
-#: Source/items.cpp:2055
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr "clique esquerdo para golpear"
 
-#: Source/items.cpp:2060
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr "Clique direito para usar"
 
-#: Source/items.cpp:2065 Source/items.cpp:2070
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr "Clique direito para usar"
 
-#: Source/items.cpp:2078
+#: Source/items.cpp:2082
 msgid "Right click to read"
 msgstr "Clique direito para ler"
 
-#: Source/items.cpp:2082
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr "Clique direito para visualizar"
 
-#: Source/items.cpp:2090
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr "Duplica a capacidade de ouro"
 
-#: Source/items.cpp:2102 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 msgid "Required:"
 msgstr "Requerido:"
 
-#: Source/items.cpp:2104 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 msgid " {:d} Str"
 msgstr " {:d} For."
 
-#: Source/items.cpp:2106 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 msgid " {:d} Mag"
 msgstr " {:d} Mag."
 
-#: Source/items.cpp:2108 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 msgid " {:d} Dex"
 msgstr " {:d} Des."
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3535 Source/player.cpp:3042
+#: Source/items.cpp:3533 Source/player.cpp:3018
 msgid "Ear of {:s}"
 msgstr "Orelha de {:s}"
 
-#: Source/items.cpp:3830
+#: Source/items.cpp:3828
 msgid "chance to hit: {:+d}%"
 msgstr "chance de acerto: {:+d}%"
 
-#: Source/items.cpp:3834
+#: Source/items.cpp:3832
 #, no-c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% de dano"
 
-#: Source/items.cpp:3838 Source/items.cpp:4094
+#: Source/items.cpp:3836 Source/items.cpp:4092
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "acerto: {:+d}%, {:+d}% de dano"
 
-#: Source/items.cpp:3842
+#: Source/items.cpp:3840
 #, no-c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% de armadura"
 
-#: Source/items.cpp:3846
+#: Source/items.cpp:3844
 msgid "armor class: {:d}"
 msgstr "classe de armadura: {:d}"
 
-#: Source/items.cpp:3851 Source/items.cpp:4076
+#: Source/items.cpp:3849 Source/items.cpp:4074
 msgid "Resist Fire: {:+d}%"
 msgstr "Resistência a fogo: {:+d}%"
 
-#: Source/items.cpp:3853
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr "Resistência a fogo: 75% MÁX"
 
-#: Source/items.cpp:3858
+#: Source/items.cpp:3856
 msgid "Resist Lightning: {:+d}%"
 msgstr "Resistência a raios: {:+d}%"
 
-#: Source/items.cpp:3860
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr "Resistência a raios: 75% MÁX"
 
-#: Source/items.cpp:3865
+#: Source/items.cpp:3863
 msgid "Resist Magic: {:+d}%"
 msgstr "Resistência à magia: {:+d}%"
 
-#: Source/items.cpp:3867
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr "Resistência à magia: 75% MÁX"
 
-#: Source/items.cpp:3872
+#: Source/items.cpp:3870
 msgid "Resist All: {:+d}%"
 msgstr "Resistência a tudo: {:+d}%"
 
-#: Source/items.cpp:3874
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr "Resistência a tudo: 75% MÁX"
 
-#: Source/items.cpp:3878
+#: Source/items.cpp:3876
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] "feitiços aumentam {:d} nível"
 msgstr[1] "feitiços aumentam {:d} níveis"
 
-#: Source/items.cpp:3880
+#: Source/items.cpp:3878
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "feitiços diminuem {:d} nível"
 msgstr[1] "feitiços diminuem {:d} níveis"
 
-#: Source/items.cpp:3882
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr "níveis de feitiço inalterados (?)"
 
-#: Source/items.cpp:3885
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr "Cargas extra"
 
-#: Source/items.cpp:3888
+#: Source/items.cpp:3886
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:d} {:s} carga"
 msgstr[1] "{:d} {:s} cargas"
 
-#: Source/items.cpp:3892
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr "Dano do acerto de fogo: {:d}"
 
-#: Source/items.cpp:3894
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "Dano do acerto de fogo: {:d}-{:d}"
 
-#: Source/items.cpp:3898
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr "Dano do acerto de raios: {:d}"
 
-#: Source/items.cpp:3900
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "Dano do acerto de raios: {:d}-{:d}"
 
-#: Source/items.cpp:3904
+#: Source/items.cpp:3902
 msgid "{:+d} to strength"
 msgstr "{:+d} para força"
 
-#: Source/items.cpp:3908
+#: Source/items.cpp:3906
 msgid "{:+d} to magic"
 msgstr "{:+d} para magia"
 
-#: Source/items.cpp:3912
+#: Source/items.cpp:3910
 msgid "{:+d} to dexterity"
 msgstr "{:+d} para destreza"
 
-#: Source/items.cpp:3916
+#: Source/items.cpp:3914
 msgid "{:+d} to vitality"
 msgstr "{:+d} para vitalidade"
 
-#: Source/items.cpp:3920
+#: Source/items.cpp:3918
 msgid "{:+d} to all attributes"
 msgstr "{:+d} a todos os atributos"
 
-#: Source/items.cpp:3924
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} de dano a inimigos"
 
-#: Source/items.cpp:3928
+#: Source/items.cpp:3926
 msgid "Hit Points: {:+d}"
 msgstr "Pontos de vida: {:+d}"
 
-#: Source/items.cpp:3932
+#: Source/items.cpp:3930
 msgid "Mana: {:+d}"
 msgstr "Mana: {:+d}"
 
-#: Source/items.cpp:3935
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr "alta durabilidade"
 
-#: Source/items.cpp:3938
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr "durabilidade diminuída"
 
-#: Source/items.cpp:3941
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr "indestrutível"
 
-#: Source/items.cpp:3944
+#: Source/items.cpp:3942
 #, no-c-format
 msgid "+{:d}% light radius"
 msgstr "+{:d}% de alcance de visão"
 
-#: Source/items.cpp:3947
+#: Source/items.cpp:3945
 #, no-c-format
 msgid "-{:d}% light radius"
 msgstr "-{:d}% de alcance de visão"
 
-#: Source/items.cpp:3950
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr "várias flechas por disparo"
 
-#: Source/items.cpp:3954
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr "dano das flechas de fogo: {:d}"
 
-#: Source/items.cpp:3956
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "dano das flechas de fogo: {:d}-{:d}"
 
-#: Source/items.cpp:3960
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr "dano das flechas de raios {:d}"
 
-#: Source/items.cpp:3962
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "dano das flechas de raios {:d}-{:d}"
 
-#: Source/items.cpp:3966
+#: Source/items.cpp:3964
 msgid "fireball damage: {:d}"
 msgstr "dano das bolas de fogo: {:d}"
 
-#: Source/items.cpp:3968
+#: Source/items.cpp:3966
 msgid "fireball damage: {:d}-{:d}"
 msgstr "dano das bolas de fogo: {:d}-{:d}"
 
-#: Source/items.cpp:3971
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr "atacante leva 1-3 de dano"
 
-#: Source/items.cpp:3974
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr "usuário perde toda a mana"
 
-#: Source/items.cpp:3977
+#: Source/items.cpp:3975
 msgid "you can't heal"
 msgstr "você não pode se curar"
 
-#: Source/items.cpp:3980
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr "enfraquece armadilhas 50%"
 
-#: Source/items.cpp:3983
+#: Source/items.cpp:3981
 msgid "knocks target back"
 msgstr "empurra alvo para trás"
 
-#: Source/items.cpp:3986
+#: Source/items.cpp:3984
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr "+200% de dano vs. demônios"
 
-#: Source/items.cpp:3989
+#: Source/items.cpp:3987
 msgid "All Resistance equals 0"
 msgstr "Todas Resistências viram 0"
 
-#: Source/items.cpp:3992
+#: Source/items.cpp:3990
 msgid "hit monster doesn't heal"
 msgstr "monstro acertado não cura"
 
-#: Source/items.cpp:3996
+#: Source/items.cpp:3994
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr "acerto rouba 3% de mana"
 
-#: Source/items.cpp:3998
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr "acerto rouba 5% de mana"
 
-#: Source/items.cpp:4002
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr "acerto rouba 3% de vida"
 
-#: Source/items.cpp:4004
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr "acerto rouba 5% de vida"
 
-#: Source/items.cpp:4007
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr "danifica armadura do alvo"
 
-#: Source/items.cpp:4011
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr "ataque breve"
 
-#: Source/items.cpp:4013
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr "ataque rápido"
 
-#: Source/items.cpp:4015
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr "ataque mais rápido"
 
-#: Source/items.cpp:4017
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr "ataque muito rápido"
 
-#: Source/items.cpp:4021
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr "recupera rápido de ataque"
 
-#: Source/items.cpp:4023
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr "rec. mais rápido de ataque"
 
-#: Source/items.cpp:4025
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr "rec. muito rápida de atq."
 
-#: Source/items.cpp:4028
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr "bloqueio rápido"
 
-#: Source/items.cpp:4031
+#: Source/items.cpp:4029
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] "adiciona {:d} ponto de dano"
 msgstr[1] "adiciona {:d} pontos de dano"
 
-#: Source/items.cpp:4034
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr "dá flechas de vel. variada"
 
-#: Source/items.cpp:4037
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr "dano de item incomum"
 
-#: Source/items.cpp:4040
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr "durabilidade alterada"
 
-#: Source/items.cpp:4043
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr "Movim. de atq. mais rápido"
 
-#: Source/items.cpp:4046
+#: Source/items.cpp:4044
 msgid "one handed sword"
 msgstr "espada de uma mão"
 
-#: Source/items.cpp:4049
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr "constantemente perde PV"
 
-#: Source/items.cpp:4052
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr "rouba vida"
 
-#: Source/items.cpp:4055
+#: Source/items.cpp:4053
 msgid "no strength requirement"
 msgstr "força não requerida"
 
-#: Source/items.cpp:4058
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr "enxerga com infravisão"
 
-#: Source/items.cpp:4065
+#: Source/items.cpp:4063
 msgid "lightning damage: {:d}"
 msgstr "dano de raio: {:d}"
 
-#: Source/items.cpp:4067
+#: Source/items.cpp:4065
 msgid "lightning damage: {:d}-{:d}"
 msgstr "dano de raio: {:d}-{:d}"
 
-#: Source/items.cpp:4070
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr "raios carregados nos golpes"
 
-#: Source/items.cpp:4079
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr "triplo dano ocasional"
 
-#: Source/items.cpp:4082
+#: Source/items.cpp:4080
 #, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr "declínio de {:+d}% de dano"
 
-#: Source/items.cpp:4085
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr "2x dano para monst, 1x a você"
 
-#: Source/items.cpp:4088
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr "Dano aleatório 0 - 500%"
 
-#: Source/items.cpp:4091
+#: Source/items.cpp:4089
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr "baixa dur, {:+d}% de dano"
 
-#: Source/items.cpp:4097
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr "AC extra vs demônios"
 
-#: Source/items.cpp:4100
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr "AC extra vs mortos vivos"
 
-#: Source/items.cpp:4103
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr "50% de Mana foi para a Vida"
 
-#: Source/items.cpp:4106
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr "40% de Mana foi para a Vida"
 
-#: Source/items.cpp:4109
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr "Outra habilidade (NW)"
 
-#: Source/items.cpp:4146 Source/items.cpp:4193
+#: Source/items.cpp:4144 Source/items.cpp:4191
 msgid "damage: {:d}  Indestructible"
 msgstr "dano: {:d}  Indestrutível"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4148 Source/items.cpp:4195
+#: Source/items.cpp:4146 Source/items.cpp:4193
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "dano: {:d}  Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4151 Source/items.cpp:4198
+#: Source/items.cpp:4149 Source/items.cpp:4196
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "dano: {:d}-{:d}  Indestrutível"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4153 Source/items.cpp:4200
+#: Source/items.cpp:4151 Source/items.cpp:4198
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "dano: {:d}-{:d}  Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4159 Source/items.cpp:4212
+#: Source/items.cpp:4157 Source/items.cpp:4210
 msgid "armor: {:d}  Indestructible"
 msgstr "armadura: {:d}  Indestrutível"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4161 Source/items.cpp:4214
+#: Source/items.cpp:4159 Source/items.cpp:4212
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "armadura: {:d}  Dur: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4166
+#: Source/items.cpp:4164
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "dano: {:d}  Dur: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4168
+#: Source/items.cpp:4166
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "dano: {:d}-{:d}  Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4169 Source/items.cpp:4204 Source/items.cpp:4219
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 msgid "Charges: {:d}/{:d}"
 msgstr "Cargas: {:d}/{:d}"
 
-#: Source/items.cpp:4181
+#: Source/items.cpp:4179
 msgid "unique item"
 msgstr "item único"
 
-#: Source/items.cpp:4208 Source/items.cpp:4217 Source/items.cpp:4224
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr "Não identificado"
 
-#: Source/loadsave.cpp:1656 Source/loadsave.cpp:2122
+#: Source/loadsave.cpp:1683 Source/loadsave.cpp:2149
 msgid "Unable to open save file archive"
 msgstr "Não foi possível abrir o arquivo salvo"
 
-#: Source/loadsave.cpp:1659
+#: Source/loadsave.cpp:1686
 msgid "Invalid save file"
 msgstr "Jogo salvo inválido"
 
-#: Source/loadsave.cpp:1688
+#: Source/loadsave.cpp:1717
 msgid "Player is on a Hellfire only level"
 msgstr "O jogador está em um nível somente Hellfire"
 
-#: Source/loadsave.cpp:1885
+#: Source/loadsave.cpp:1912
 msgid "Invalid game state"
 msgstr "Estado de jogo inválido"
 
-#: Source/menu.cpp:136
+#: Source/menu.cpp:154
 msgid "Unable to display mainmenu"
 msgstr "Não é possível mostrar o menu principal"
+
+#. TRANSLATORS:  Error Message when a Shareware User clicks on "Replay Intro" in the Main Menu
+#: Source/menu.cpp:179
+msgid ""
+"The Diablo introduction cinematic is only available in the full retail "
+"version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
+msgstr ""
+"A introdução cinematográfica da Diablo está disponível apenas na versão "
+"comercial completa do Diablo. Visite https://www.gog.com/game/diablo para "
+"comprar."
 
 #. TRANSLATORS: Monster Block start
 #. MT_NZOMBIE
@@ -5115,6 +5232,13 @@ msgctxt "monster"
 msgid "Reaper"
 msgstr "Ceifador"
 
+#. TRANSLATORS: Monster Block end
+#. MT_NAKRUL
+#: Source/monstdat.cpp:158 Source/monstdat.cpp:485
+msgctxt "monster"
+msgid "Na-Krul"
+msgstr ""
+
 #. TRANSLATORS: Unique Monster Block start
 #: Source/monstdat.cpp:473
 #, fuzzy
@@ -5155,6 +5279,11 @@ msgstr "vermelho(a)"
 msgctxt "monster"
 msgid "Black Jade"
 msgstr "de jade"
+
+#: Source/monstdat.cpp:480
+msgctxt "monster"
+msgid "Lachdanan"
+msgstr ""
 
 #: Source/monstdat.cpp:481
 msgctxt "monster"
@@ -5222,6 +5351,11 @@ msgctxt "monster"
 msgid "Brokenhead Bangshield"
 msgstr "Traumocéfalo Bate-Escudos"
 
+#: Source/monstdat.cpp:494
+msgctxt "monster"
+msgid "Bongo"
+msgstr ""
+
 #: Source/monstdat.cpp:495
 #, fuzzy
 #| msgid "Rotcarnage"
@@ -5249,6 +5383,11 @@ msgstr "Olho Morto"
 msgctxt "monster"
 msgid "Madeye the Dead"
 msgstr "Arco dos mortos"
+
+#: Source/monstdat.cpp:499
+msgctxt "monster"
+msgid "El Chupacabras"
+msgstr ""
 
 #: Source/monstdat.cpp:500
 #, fuzzy
@@ -5703,12 +5842,24 @@ msgctxt "monster"
 msgid "The Vizier"
 msgstr "O Vizir"
 
+#: Source/monstdat.cpp:567
+#, fuzzy
+#| msgid "Sapphire"
+msgctxt "monster"
+msgid "Zamphir"
+msgstr "safira"
+
 #: Source/monstdat.cpp:568
 #, fuzzy
 #| msgid "Bloodlust"
 msgctxt "monster"
 msgid "Bloodlust"
 msgstr "Sede de Sangue"
+
+#: Source/monstdat.cpp:569
+msgctxt "monster"
+msgid "Webwidow"
+msgstr ""
 
 #: Source/monstdat.cpp:570
 #, fuzzy
@@ -5732,96 +5883,97 @@ msgctxt "monster"
 msgid "Doomlock"
 msgstr "Perdentrave"
 
-#: Source/monster.cpp:3474
+#: Source/monster.cpp:3479
 msgid "Animal"
 msgstr "Animal"
 
-#: Source/monster.cpp:3476
+#: Source/monster.cpp:3481
 msgid "Demon"
 msgstr "Demônio"
 
-#: Source/monster.cpp:3478
+#: Source/monster.cpp:3483
 msgid "Undead"
 msgstr "Morto-vivo"
 
-#: Source/monster.cpp:4610
+#: Source/monster.cpp:4612
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "Tipo: {:s}  Mortos: {:d}"
 
-#: Source/monster.cpp:4612
+#: Source/monster.cpp:4614
 msgid "Total kills: {:d}"
 msgstr "Total de mortos: {:d}"
 
-#: Source/monster.cpp:4645
+#: Source/monster.cpp:4647
 msgid "Hit Points: {:d}-{:d}"
 msgstr "Pontos de vida: {:d}-{:d}"
 
-#: Source/monster.cpp:4651
+#: Source/monster.cpp:4653
 msgid "No magic resistance"
 msgstr "Nenhuma resistência a magia"
 
-#: Source/monster.cpp:4655
+#: Source/monster.cpp:4657
 msgid "Resists: "
 msgstr "Resiste a: "
 
-#: Source/monster.cpp:4657 Source/monster.cpp:4668
+#: Source/monster.cpp:4659 Source/monster.cpp:4671
 msgid "Magic "
 msgstr "Magia "
 
-#: Source/monster.cpp:4659 Source/monster.cpp:4670
+#: Source/monster.cpp:4661 Source/monster.cpp:4673
 msgid "Fire "
 msgstr "Fogo "
 
-#: Source/monster.cpp:4661 Source/monster.cpp:4672
+#: Source/monster.cpp:4663 Source/monster.cpp:4675
 msgid "Lightning "
 msgstr "Raios "
 
-#: Source/monster.cpp:4666
+#: Source/monster.cpp:4669
 msgid "Immune: "
 msgstr "Imune a: "
 
-#: Source/monster.cpp:4684
+#: Source/monster.cpp:4688
 msgid "Type: {:s}"
 msgstr "Tipo: {:s}"
 
-#: Source/monster.cpp:4690 Source/monster.cpp:4697
+#: Source/monster.cpp:4694 Source/monster.cpp:4701
 msgid "No resistances"
 msgstr "Sem resistências"
 
-#: Source/monster.cpp:4692 Source/monster.cpp:4702
+#: Source/monster.cpp:4696 Source/monster.cpp:4706
 msgid "No Immunities"
 msgstr "Sem imunidades"
 
-#: Source/monster.cpp:4695
+#: Source/monster.cpp:4699
 msgid "Some Magic Resistances"
 msgstr "Algumas Resistências à Magia"
 
-#: Source/monster.cpp:4700
+#: Source/monster.cpp:4704
 msgid "Some Magic Immunities"
 msgstr "Algumas Imunidades à Magia"
 
-#: Source/msg.cpp:484
+#: Source/msg.cpp:495
 msgid "Trying to drop a floor item?"
 msgstr "Gostaria de jogar um item do chão?"
 
-#: Source/msg.cpp:951 Source/msg.cpp:975 Source/msg.cpp:998 Source/msg.cpp:1113
-#: Source/msg.cpp:1136 Source/msg.cpp:1158 Source/msg.cpp:1180
+#: Source/msg.cpp:994 Source/msg.cpp:1029 Source/msg.cpp:1060
+#: Source/msg.cpp:1187 Source/msg.cpp:1219 Source/msg.cpp:1251
+#: Source/msg.cpp:1281
 msgid "{:s} has cast an illegal spell."
 msgstr "{:s} lançou um feitiço ilegal."
 
-#: Source/msg.cpp:1529 Source/multi.cpp:815
+#: Source/msg.cpp:1668 Source/multi.cpp:804
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr "O jogador '{:s}' (nível {:d}) acabou de entrar no jogo"
 
-#: Source/msg.cpp:1826
+#: Source/msg.cpp:1972
 msgid "Waiting for game data..."
 msgstr "Aguardando dados do jogo..."
 
-#: Source/msg.cpp:1834
+#: Source/msg.cpp:1980
 msgid "The game ended"
 msgstr "O jogo terminou"
 
-#: Source/msg.cpp:1840
+#: Source/msg.cpp:1986
 msgid "Unable to get level data"
 msgstr "Não é possível obter dados do nível"
 
@@ -5837,507 +5989,506 @@ msgstr "O jogador '{:s}' matou Diablo e saiu do jogo!"
 msgid "Player '{:s}' dropped due to timeout"
 msgstr "O jogador '{:s}' caiu devido a tempo esgotado"
 
-#: Source/multi.cpp:817
+#: Source/multi.cpp:806
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr "O jogador '{:s}' (nível {:d}) já está no jogo"
 
 #. TRANSLATORS: Shrine Name Block
-#: Source/objects.cpp:101
+#: Source/objects.cpp:104
 msgid "Mysterious"
 msgstr "Misterioso"
 
-#: Source/objects.cpp:102
+#: Source/objects.cpp:105
 msgid "Hidden"
 msgstr "Escondido"
 
-#: Source/objects.cpp:103
+#: Source/objects.cpp:106
 msgid "Gloomy"
 msgstr "Melancólico"
 
-#: Source/objects.cpp:105 Source/objects.cpp:112
+#: Source/objects.cpp:108 Source/objects.cpp:115
 msgid "Magical"
 msgstr "Mágico"
 
-#: Source/objects.cpp:106
+#: Source/objects.cpp:109
 msgid "Stone"
 msgstr "de pedra"
 
-#: Source/objects.cpp:107
+#: Source/objects.cpp:110
 msgid "Religious"
 msgstr "Religioso"
 
-#: Source/objects.cpp:108
+#: Source/objects.cpp:111
 msgid "Enchanted"
 msgstr "Encantado"
 
-#: Source/objects.cpp:109
+#: Source/objects.cpp:112
 msgid "Thaumaturgic"
 msgstr "Taumatúrgico"
 
-#: Source/objects.cpp:110
+#: Source/objects.cpp:113
 msgid "Fascinating"
 msgstr "Fascinante"
 
-#: Source/objects.cpp:111
+#: Source/objects.cpp:114
 msgid "Cryptic"
 msgstr "Críptico"
 
-#: Source/objects.cpp:113
+#: Source/objects.cpp:116
 msgid "Eldritch"
 msgstr "Insólito"
 
-#: Source/objects.cpp:114
+#: Source/objects.cpp:117
 msgid "Eerie"
 msgstr "Esquisito"
 
-#: Source/objects.cpp:115
+#: Source/objects.cpp:118
 msgid "Divine"
 msgstr "Divino"
 
-#: Source/objects.cpp:117
+#: Source/objects.cpp:120
 msgid "Sacred"
 msgstr "Sagrado"
 
-#: Source/objects.cpp:118
+#: Source/objects.cpp:121
 msgid "Spiritual"
 msgstr "Espiritual"
 
-#: Source/objects.cpp:119
+#: Source/objects.cpp:122
 msgid "Spooky"
 msgstr "Pavoroso"
 
-#: Source/objects.cpp:120
+#: Source/objects.cpp:123
 msgid "Abandoned"
 msgstr "Abandonado"
 
-#: Source/objects.cpp:121
+#: Source/objects.cpp:124
 msgid "Creepy"
 msgstr "Assustador"
 
-#: Source/objects.cpp:122
+#: Source/objects.cpp:125
 msgid "Quiet"
 msgstr "Quieto"
 
-#: Source/objects.cpp:123
+#: Source/objects.cpp:126
 msgid "Secluded"
 msgstr "Isolado"
 
-#: Source/objects.cpp:124
+#: Source/objects.cpp:127
 msgid "Ornate"
 msgstr "Ornado"
 
-#: Source/objects.cpp:125
+#: Source/objects.cpp:128
 msgid "Glimmering"
 msgstr "Vislumbrante"
 
-#: Source/objects.cpp:126
+#: Source/objects.cpp:129
 msgid "Tainted"
 msgstr "Maculado"
 
-#: Source/objects.cpp:127
+#: Source/objects.cpp:130
 msgid "Oily"
 msgstr "Oleoso"
 
-#: Source/objects.cpp:128
+#: Source/objects.cpp:131
 msgid "Glowing"
 msgstr "Brilhante"
 
-#: Source/objects.cpp:129
+#: Source/objects.cpp:132
 msgid "Mendicant's"
 msgstr "Do Mendicante"
 
-#: Source/objects.cpp:130
+#: Source/objects.cpp:133
 msgid "Sparkling"
 msgstr "Espumante"
 
-#: Source/objects.cpp:131
+#: Source/objects.cpp:134
 msgid "Town"
 msgstr "Cidade"
 
-#: Source/objects.cpp:132
+#: Source/objects.cpp:135
 msgid "Shimmering"
 msgstr "Cintilante"
 
-#: Source/objects.cpp:133
+#: Source/objects.cpp:136
 msgid "Solar"
 msgstr "Solar"
 
 #. TRANSLATORS: Shrine Name Block end
-#: Source/objects.cpp:135
+#: Source/objects.cpp:138
 msgid "Murphy's"
 msgstr "De Murphy"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:265
+#: Source/objects.cpp:268
 msgid "The Great Conflict"
 msgstr "O grande conflito"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:266
+#: Source/objects.cpp:269
 msgid "The Wages of Sin are War"
 msgstr "O salário do pecado é a guerra"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:267
+#: Source/objects.cpp:270
 msgid "The Tale of the Horadrim"
 msgstr "O conto dos Horadrim"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:268
+#: Source/objects.cpp:271
 msgid "The Dark Exile"
 msgstr "O exilo sombrio"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:269
+#: Source/objects.cpp:272
 msgid "The Sin War"
 msgstr "A guerra do pecado"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:270
+#: Source/objects.cpp:273
 msgid "The Binding of the Three"
 msgstr "O aprisionamento dos três"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:271
+#: Source/objects.cpp:274
 msgid "The Realms Beyond"
 msgstr "Os reinos além"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:272
+#: Source/objects.cpp:275
 msgid "Tale of the Three"
 msgstr "Conto dos três"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:273
+#: Source/objects.cpp:276
 msgid "The Black King"
 msgstr "O rei negro"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:274
+#: Source/objects.cpp:277
 msgid "Journal: The Ensorcellment"
 msgstr "Diário: O Enfeitiçado"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:275
+#: Source/objects.cpp:278
 msgid "Journal: The Meeting"
 msgstr "Diário: O Encontro"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:276
+#: Source/objects.cpp:279
 msgid "Journal: The Tirade"
 msgstr "Diário: A Desgraça"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:277
+#: Source/objects.cpp:280
 msgid "Journal: His Power Grows"
 msgstr "Diário: Seu Poder Cresce"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:278
+#: Source/objects.cpp:281
 msgid "Journal: NA-KRUL"
 msgstr "Diário: NA-KRUL"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:279
+#: Source/objects.cpp:282
 msgid "Journal: The End"
 msgstr "Diário: O Fim"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:280
+#: Source/objects.cpp:283
 msgid "A Spellbook"
 msgstr "Um livro de feitiços"
 
-#: Source/objects.cpp:5365
+#: Source/objects.cpp:5339
 msgid "Crucified Skeleton"
 msgstr "Esqueleto crucificado"
 
-#: Source/objects.cpp:5369
+#: Source/objects.cpp:5343
 msgid "Lever"
 msgstr "Alavanca"
 
-#: Source/objects.cpp:5378
+#: Source/objects.cpp:5352
 msgid "Open Door"
 msgstr "Porta aberta"
 
-#: Source/objects.cpp:5380
+#: Source/objects.cpp:5354
 msgid "Closed Door"
 msgstr "Porta fechada"
 
-#: Source/objects.cpp:5382
+#: Source/objects.cpp:5356
 msgid "Blocked Door"
 msgstr "Porta bloqueada"
 
-#: Source/objects.cpp:5387
+#: Source/objects.cpp:5361
 msgid "Ancient Tome"
 msgstr "Tomo antigo"
 
-#: Source/objects.cpp:5389
+#: Source/objects.cpp:5363
 msgid "Book of Vileness"
 msgstr "Livro da vileza"
 
-#: Source/objects.cpp:5394
+#: Source/objects.cpp:5368
 msgid "Skull Lever"
 msgstr "Alavanca de caveira"
 
-#: Source/objects.cpp:5397
+#: Source/objects.cpp:5371
 msgid "Mythical Book"
 msgstr "Livro mítico"
 
-#: Source/objects.cpp:5401
+#: Source/objects.cpp:5375
 msgid "Small Chest"
 msgstr "Baú pequeno"
 
-#: Source/objects.cpp:5405
+#: Source/objects.cpp:5379
 msgid "Chest"
 msgstr "Baú"
 
-#: Source/objects.cpp:5410
+#: Source/objects.cpp:5384
 msgid "Large Chest"
 msgstr "Baú grande"
 
-#: Source/objects.cpp:5413
+#: Source/objects.cpp:5387
 msgid "Sarcophagus"
 msgstr "Sarcófago"
 
-#: Source/objects.cpp:5416
+#: Source/objects.cpp:5390
 msgid "Bookshelf"
 msgstr "Estante de livros"
 
-#: Source/objects.cpp:5420
+#: Source/objects.cpp:5394
 msgid "Bookcase"
 msgstr "Estante"
 
-#: Source/objects.cpp:5425
+#: Source/objects.cpp:5399
 msgid "Pod"
 msgstr "Ovo"
 
-#: Source/objects.cpp:5427
+#: Source/objects.cpp:5401
 msgid "Urn"
 msgstr "Urna"
 
-#: Source/objects.cpp:5429
+#: Source/objects.cpp:5403
 msgid "Barrel"
 msgstr "Barril"
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:5433
+#: Source/objects.cpp:5407
 msgid "{:s} Shrine"
 msgstr "Altar {:s}"
 
-#: Source/objects.cpp:5437
+#: Source/objects.cpp:5411
 msgid "Skeleton Tome"
 msgstr "Tomo do esqueleto"
 
-#: Source/objects.cpp:5440
+#: Source/objects.cpp:5414
 msgid "Library Book"
 msgstr "Livro da biblioteca"
 
-#: Source/objects.cpp:5443
+#: Source/objects.cpp:5417
 msgid "Blood Fountain"
 msgstr "Fonte de sangue"
 
-#: Source/objects.cpp:5446
+#: Source/objects.cpp:5420
 msgid "Decapitated Body"
 msgstr "Corpo decapitado"
 
-#: Source/objects.cpp:5449
+#: Source/objects.cpp:5423
 msgid "Book of the Blind"
 msgstr "Livro dos cegos"
 
-#: Source/objects.cpp:5452
+#: Source/objects.cpp:5426
 msgid "Book of Blood"
 msgstr "Livro de sangue"
 
-#: Source/objects.cpp:5455
+#: Source/objects.cpp:5429
 msgid "Purifying Spring"
 msgstr "Fontícula purificante"
 
-#: Source/objects.cpp:5462 Source/objects.cpp:5486
+#: Source/objects.cpp:5436 Source/objects.cpp:5460
 msgid "Weapon Rack"
 msgstr "Estante de armas"
 
-#: Source/objects.cpp:5465
+#: Source/objects.cpp:5439
 msgid "Goat Shrine"
 msgstr "Altar caprino"
 
-#: Source/objects.cpp:5468
+#: Source/objects.cpp:5442
 msgid "Cauldron"
 msgstr "Caldeirão"
 
-#: Source/objects.cpp:5471
+#: Source/objects.cpp:5445
 msgid "Murky Pool"
 msgstr "Poça turva"
 
-#: Source/objects.cpp:5474
+#: Source/objects.cpp:5448
 msgid "Fountain of Tears"
 msgstr "Fonte de lágrimas"
 
-#: Source/objects.cpp:5477
+#: Source/objects.cpp:5451
 msgid "Steel Tome"
 msgstr "Tomo de aço"
 
-#: Source/objects.cpp:5480
+#: Source/objects.cpp:5454
 msgid "Pedestal of Blood"
 msgstr "Pedestal de sangue"
 
-#: Source/objects.cpp:5489
+#: Source/objects.cpp:5463
 msgid "Mushroom Patch"
 msgstr "Canteiro de cogumelos"
 
-#: Source/objects.cpp:5492
+#: Source/objects.cpp:5466
 msgid "Vile Stand"
 msgstr "Suporte Vil"
 
-#: Source/objects.cpp:5495
+#: Source/objects.cpp:5469
 msgid "Slain Hero"
 msgstr "Herói assassinado"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:5502
+#: Source/objects.cpp:5476
 msgid "Trapped {:s}"
 msgstr "{:s} aprisionado"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
-#: Source/objects.cpp:5508
+#: Source/objects.cpp:5482
 msgid "{:s} (disabled)"
 msgstr "{:s} (desativado)"
 
-#: Source/panels/charpanel.cpp:109
+#: Source/panels/charpanel.cpp:110
 msgid "MAX"
 msgstr "MÁX"
 
-#: Source/panels/charpanel.cpp:119
+#: Source/panels/charpanel.cpp:120
 msgid "Level"
 msgstr "Nível"
 
-#: Source/panels/charpanel.cpp:121
+#: Source/panels/charpanel.cpp:122
 msgid "Experience"
 msgstr "experiência"
 
-#: Source/panels/charpanel.cpp:123
+#: Source/panels/charpanel.cpp:124
 msgid "Next level"
 msgstr "próximo nível"
 
-#: Source/panels/charpanel.cpp:126
+#: Source/panels/charpanel.cpp:127
 msgid "None"
 msgstr "Nenhum"
 
-#: Source/panels/charpanel.cpp:132
+#: Source/panels/charpanel.cpp:133
 msgid "Base"
 msgstr "base"
 
-#: Source/panels/charpanel.cpp:133
+#: Source/panels/charpanel.cpp:134
 msgid "Now"
 msgstr "atual"
 
-#: Source/panels/charpanel.cpp:134
+#: Source/panels/charpanel.cpp:135
 msgid "Strength"
 msgstr "força"
 
-#: Source/panels/charpanel.cpp:138
+#: Source/panels/charpanel.cpp:139
 msgid "Magic"
 msgstr "magia"
 
-#: Source/panels/charpanel.cpp:142
+#: Source/panels/charpanel.cpp:143
 msgid "Dexterity"
 msgstr "destreza"
 
-#: Source/panels/charpanel.cpp:145
+#: Source/panels/charpanel.cpp:146
 msgid "Vitality"
 msgstr "vitalidade"
 
-#: Source/panels/charpanel.cpp:148
+#: Source/panels/charpanel.cpp:149
 msgid "Points to distribute"
 msgstr "pontos a distribuir"
 
-#: Source/panels/charpanel.cpp:158
+#: Source/panels/charpanel.cpp:159
 msgid "Armor class"
 msgstr "armadura"
 
-#: Source/panels/charpanel.cpp:160
+#: Source/panels/charpanel.cpp:161
 msgid "To hit"
 msgstr "chance de acerto"
 
-#: Source/panels/charpanel.cpp:162
+#: Source/panels/charpanel.cpp:163
 msgid "Damage"
 msgstr "dano"
 
-#: Source/panels/charpanel.cpp:168
+#: Source/panels/charpanel.cpp:170
 msgid "Life"
 msgstr "vida"
 
-#: Source/panels/charpanel.cpp:172
+#: Source/panels/charpanel.cpp:174
 msgid "Mana"
 msgstr "mana"
 
-#: Source/panels/charpanel.cpp:177
+#: Source/panels/charpanel.cpp:179
 msgid "Resist magic"
 msgstr "resist. à magia"
 
-#: Source/panels/charpanel.cpp:179
+#: Source/panels/charpanel.cpp:181
 msgid "Resist fire"
 msgstr "resist. a fogo"
 
-#: Source/panels/charpanel.cpp:181
+#: Source/panels/charpanel.cpp:183
 msgid "Resist lightning"
 msgstr "resist. a raios"
 
-#: Source/panels/mainpanel.cpp:62 Source/panels/mainpanel.cpp:109
-#: Source/panels/mainpanel.cpp:111
+#: Source/panels/mainpanel.cpp:62 Source/panels/mainpanel.cpp:106
+#: Source/panels/mainpanel.cpp:108
 msgid "voice"
 msgstr "voz"
 
-#: Source/panels/mainpanel.cpp:87
+#: Source/panels/mainpanel.cpp:84
 msgid "char"
 msgstr "person."
 
-#: Source/panels/mainpanel.cpp:88
+#: Source/panels/mainpanel.cpp:85
 msgid "quests"
 msgstr "missões"
 
-#: Source/panels/mainpanel.cpp:89
+#: Source/panels/mainpanel.cpp:86
 msgid "map"
 msgstr "mapa"
 
-#: Source/panels/mainpanel.cpp:90
+#: Source/panels/mainpanel.cpp:87
 msgid "menu"
 msgstr "menu"
 
-#: Source/panels/mainpanel.cpp:91
+#: Source/panels/mainpanel.cpp:88
 msgid "inv"
 msgstr "invent."
 
-#: Source/panels/mainpanel.cpp:92
+#: Source/panels/mainpanel.cpp:89
 msgid "spells"
 msgstr "feitiços"
 
-#: Source/panels/mainpanel.cpp:104 Source/panels/mainpanel.cpp:106
-#: Source/panels/mainpanel.cpp:108
+#: Source/panels/mainpanel.cpp:101 Source/panels/mainpanel.cpp:103
+#: Source/panels/mainpanel.cpp:105
 msgid "mute"
 msgstr "mudo"
 
-#: Source/pfile.cpp:260
+#: Source/pfile.cpp:242
 msgid "Failed to open player archive for writing."
 msgstr "Não foi possível abrir o arquivo do jogador para escrita."
 
-#: Source/pfile.cpp:385
+#: Source/pfile.cpp:377
 msgid "Unable to open archive"
 msgstr "Não é possível abrir o arquivo"
 
-#: Source/pfile.cpp:387
+#: Source/pfile.cpp:379
 msgid "Unable to load character"
 msgstr "Não é possível carregar o personagem"
 
-#: Source/pfile.cpp:410 Source/pfile.cpp:430
+#: Source/pfile.cpp:403 Source/pfile.cpp:423
 msgid "Unable to read to save file archive"
 msgstr "Não foi possível ler para salvar o arquivo"
 
-#: Source/pfile.cpp:449
+#: Source/pfile.cpp:442
 msgid "Unable to write to save file archive"
 msgstr "Não foi possível escrever para salvar o arquivo"
 
-#. TRANSLATORS: Shown if player presses "v" button. {:s} is player name, {:d} is level, {:s} is location
-#: Source/plrmsg.cpp:89
+#: Source/plrmsg.cpp:88
 msgid "{:s} (lvl {:d}): {:s}"
 msgstr "{:s} (nvl {:d}): {:s}"
 
@@ -6352,7 +6503,7 @@ msgstr ",%03d"
 msgid "%i gold"
 msgstr "%i de ouro"
 
-#: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:56
+#: Source/qol/monhealthbar.cpp:37 Source/qol/xpbar.cpp:56
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
@@ -6396,6 +6547,16 @@ msgstr "Gharbad, o Fraco"
 msgid "Zhar the Mad"
 msgstr "Zhar, o Louco"
 
+#: Source/quests.cpp:45
+msgid "Lachdanan"
+msgstr ""
+
+#: Source/quests.cpp:46
+#, fuzzy
+#| msgid "Exit Diablo"
+msgid "Diablo"
+msgstr "Sair do Diablo"
+
 #: Source/quests.cpp:47
 msgid "The Butcher"
 msgstr "O Açougueiro"
@@ -6425,7 +6586,7 @@ msgid "Poisoned Water Supply"
 msgstr "Reserv. de água envenenado"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:55 Source/quests.cpp:90
+#: Source/quests.cpp:55 Source/quests.cpp:91
 msgid "The Chamber of Bone"
 msgstr "A câmara de osso"
 
@@ -6453,6 +6614,10 @@ msgstr "Comerciante errante"
 msgid "The Defiler"
 msgstr "O Profanador"
 
+#: Source/quests.cpp:62
+msgid "Na-Krul"
+msgstr ""
+
 #: Source/quests.cpp:63 Source/trigs.cpp:447
 msgid "Cornerstone of the World"
 msgstr "Pedra angular do mundo"
@@ -6463,27 +6628,27 @@ msgid "The Jersey's Jersey"
 msgstr "A Fantasia de Jersey"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:89
+#: Source/quests.cpp:90
 msgid "King Leoric's Tomb"
 msgstr "A tumba do Rei Leoric"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:91 Source/setmaps.cpp:26
+#: Source/quests.cpp:92 Source/setmaps.cpp:26
 msgid "Maze"
 msgstr "Labirinto"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:92
+#: Source/quests.cpp:93
 msgid "A Dark Passage"
 msgstr "Uma passagem negra"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:93
+#: Source/quests.cpp:94
 msgid "Unholy Altar"
 msgstr "Altar profano"
 
 #. TRANSLATORS: Used for Quest Portals. {:s} is a Map Name
-#: Source/quests.cpp:449
+#: Source/quests.cpp:450
 msgid "To {:s}"
 msgstr "Para {:s}"
 
@@ -6772,298 +6937,331 @@ msgctxt "spell"
 msgid "Rune of Stone"
 msgstr "Runa de Pedra"
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:91
+#, fuzzy
+#| msgid "Griswold's Edge"
+msgid "Griswold"
+msgstr "Gume de Griswold"
+
+#: Source/stores.cpp:92
+msgid "Pepin"
+msgstr ""
+
+#: Source/stores.cpp:94
+msgid "Ogden"
+msgstr ""
+
+#: Source/stores.cpp:95
+msgid "Cain"
+msgstr ""
+
+#: Source/stores.cpp:96
+#, fuzzy
+#| msgid "Talk to Farnham"
+msgid "Farnham"
+msgstr "Falar com Farnham"
+
+#: Source/stores.cpp:97
+msgid "Adria"
+msgstr ""
+
+#: Source/stores.cpp:98 Source/stores.cpp:1305
+#, fuzzy
+#| msgid "brilliance"
+msgid "Gillian"
+msgstr "do brilhantismo"
+
+#: Source/stores.cpp:99
+msgid "Wirt"
+msgstr ""
+
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr "Voltar"
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ",  "
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 msgid "Damage: {:d}-{:d}  "
 msgstr "Dano: {:d}-{:d}  "
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 msgid "Armor: {:d}  "
 msgstr "Armadura: {:d}  "
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 msgid "Dur: {:d}/{:d},  "
 msgstr "Dur: {:d}/{:d},  "
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr "Indestrutível,  "
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr "Nenhum atributo requerido"
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr "Boas-vindas à"
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr "Loja do ferreiro"
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr "Você gostaria de:"
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 msgid "Talk to Griswold"
 msgstr "Falar com Griswold"
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 msgid "Buy basic items"
 msgstr "Comprar itens básicos"
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 msgid "Buy premium items"
 msgstr "Comprar itens especiais"
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 msgid "Sell items"
 msgstr "Vender itens"
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 msgid "Repair items"
 msgstr "Reparar itens"
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 msgid "Leave the shop"
 msgstr "Sair da loja"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "Eu tenho estes itens para vender:             Seu ouro: {:d}"
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr "Voltar"
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "Eu tenho estes itens especiais para vender:     Seu ouro: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "Você não tem nada que eu queira.             Seu ouro: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "Qual item está à venda?             Seu ouro: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "Você não tem nada para reparar.             Seu ouro: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "Reparar qual item?             Seu ouro: {:d}"
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr "Cabana da bruxa"
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 msgid "Talk to Adria"
 msgstr "Falar com Ádria"
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr "Comprar itens"
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr "Recarregar cajados"
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 msgid "Leave the shack"
 msgstr "Sair da cabana"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "Você não tem nada para recarregar.             Seu ouro: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "Recarregar qual item?             Seu ouro: {:d}"
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr "Você não tem ouro o suficiente"
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr "Você não tem espaço o suficiente em seu inventário"
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr "Negócio fechado?"
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 msgid "Are you sure you want to identify this item?"
 msgstr "Tem certeza de que quer identificar este item?"
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 msgid "Are you sure you want to buy this item?"
 msgstr "Tem certeza de que quer comprar este item?"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 msgid "Are you sure you want to recharge this item?"
 msgstr "Tem certeza de que quer recarregar este item?"
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 msgid "Are you sure you want to sell this item?"
 msgstr "Tem certeza de que quer vender este item?"
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 msgid "Are you sure you want to repair this item?"
 msgstr "Tem certeza de que quer reparar este item?"
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr "Wirt, garoto da Perna-de-Pau"
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 msgid "Talk to Wirt"
 msgstr "Falar com Wirt"
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr "Eu tenho algo para vender,"
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr "mas lhe custará 50 de ouro"
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr "só para dar uma olhada. "
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr "O que você tem aí?"
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr "Dizer adeus"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "Eu tenho este item para vender:             Seu ouro: {:d}"
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 msgid "Leave"
 msgstr "Sair"
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr "Casa do curandeiro"
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr "Falar com Pepin"
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr "Sair da casa do curandeiro"
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 msgid "The Town Elder"
 msgstr "O ancião da cidade"
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 msgid "Talk to Cain"
 msgstr "Falar com Cain"
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr "Identificar um item"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "Você não tem nada para identificar.             Seu ouro: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "Identificar qual item?             Seu ouro: {:d}"
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr "Este item é:"
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr "Pronto"
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 msgid "Talk to {:s}"
 msgstr "Falar com {:s}"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 msgid "Talking to {:s}"
 msgstr "Falar com {:s}"
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 msgid "is not available"
 msgstr "não está disponível"
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 msgid "in the shareware"
 msgstr "na versão"
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 msgid "version"
 msgstr "versão"
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr "Boatos"
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr "Sol Nascente"
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 msgid "Talk to Ogden"
 msgstr "Falar com Ogden"
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 msgid "Leave the tavern"
 msgstr "Sair da taverna"
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 msgid "Talk to Gillian"
 msgstr "Falar com Gillian"
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr "Farnham, o Bêbado"
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 msgid "Talk to Farnham"
 msgstr "Falar com Farnham"
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr "Dizer adeus"
 
@@ -11004,6 +11202,10 @@ msgstr "Lester, o fazendeiro"
 msgid "Complete Nut"
 msgstr "Completamente Louco"
 
+#: Source/towners.cpp:266
+msgid "Celia"
+msgstr ""
+
 #: Source/towners.cpp:279
 msgid "Slain Townsman"
 msgstr "Aldeão Assassinado"
@@ -11033,17 +11235,17 @@ msgid "Down to Crypt"
 msgstr "Descer para a Cripta"
 
 #: Source/trigs.cpp:412 Source/trigs.cpp:492 Source/trigs.cpp:539
-#: Source/trigs.cpp:630
+#: Source/trigs.cpp:634
 msgid "Up to level {:d}"
 msgstr "Subir para o nível {:d}"
 
 #: Source/trigs.cpp:414 Source/trigs.cpp:469 Source/trigs.cpp:521
-#: Source/trigs.cpp:596 Source/trigs.cpp:613 Source/trigs.cpp:660
+#: Source/trigs.cpp:600 Source/trigs.cpp:617 Source/trigs.cpp:664
 msgid "Up to town"
 msgstr "Subir para a cidade"
 
-#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:552
-#: Source/trigs.cpp:577 Source/trigs.cpp:642
+#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:556
+#: Source/trigs.cpp:581 Source/trigs.cpp:646
 msgid "Down to level {:d}"
 msgstr "Descer para o nível {:d}"
 
@@ -11055,14 +11257,14 @@ msgstr "Subir para o nível {:d} da Cripta"
 msgid "Down to Crypt level {:d}"
 msgstr "Descer para o nível {:d} da Cripta"
 
-#: Source/trigs.cpp:564
+#: Source/trigs.cpp:568
 msgid "Up to Nest level {:d}"
 msgstr "Subir para o nível {:d} do Ninho"
 
-#: Source/trigs.cpp:673
+#: Source/trigs.cpp:677
 msgid "Down to Diablo"
 msgstr "Descer para o Diablo"
 
-#: Source/trigs.cpp:706 Source/trigs.cpp:720 Source/trigs.cpp:734
+#: Source/trigs.cpp:710 Source/trigs.cpp:724 Source/trigs.cpp:738
 msgid "Back to Level {:d}"
 msgstr "Voltar ao Nível {:d}"

--- a/Translations/ro_RO.po
+++ b/Translations/ro_RO.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-10-25 22:19+0300\n"
+"POT-Creation-Date: 2021-11-21 05:45+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.4.2\n"
+"X-Generator: Poedit 3.0\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-KeywordsList: _;N_;P_:1c,2\n"
 "X-Poedit-Basepath: ..\n"
@@ -321,7 +321,7 @@ msgstr "\tNici un suflet nu a fost vândut în timpul producerii acestui joc."
 msgid "OK"
 msgstr "Bine"
 
-#: Source/DiabloUI/extrasmenu.cpp:41 Source/DiabloUI/selstart.cpp:61
+#: Source/DiabloUI/extrasmenu.cpp:41 Source/DiabloUI/selstart.cpp:44
 msgid "Switch to Diablo"
 msgstr "Schimbă la Diablo"
 
@@ -391,8 +391,8 @@ msgstr "Client-Server (TCP)"
 msgid "Loopback"
 msgstr "Local"
 
-#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:481
-#: Source/DiabloUI/selgame.cpp:499
+#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:489
+#: Source/DiabloUI/selgame.cpp:510
 msgid "Multi Player Game"
 msgstr "Joc multi-jucător"
 
@@ -753,85 +753,64 @@ msgstr "Șterge erou jucător"
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "Sigur doriți să ștergeți personajul \"{:s}\"?"
 
-#: Source/DiabloUI/selstart.cpp:60
+#: Source/DiabloUI/selstart.cpp:43
 msgid "Enter Hellfire"
 msgstr "Intră în Hellfire"
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr "Da"
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr "Nu"
 
 #: Source/DiabloUI/support_lines.cpp:8
-msgid "GOG.com maintains a web site at https://www.gog.com/forum/diablo"
-msgstr "GOG.com menține un sit web la https://www.gog.com/forum/diablo"
-
-#: Source/DiabloUI/support_lines.cpp:9
-msgid "Follow the links to visit the discussion boards associated with Diablo."
+msgid ""
+"We maintain a chat server at Discord.gg/YQKCAYQ Follow the links to join our "
+"community where we talk about things related to Diablo, and the Hellfire "
+"expansion."
 msgstr ""
-"Accesați aceste adrese pentru a vizita liste de discuții despre Diablo."
 
 #: Source/DiabloUI/support_lines.cpp:10
-msgid "and the Hellfire expansion."
-msgstr "și extinderea Hellfire."
-
-#: Source/DiabloUI/support_lines.cpp:12
 msgid ""
-"DevilutionX is maintained by Diasurgical, issues and bugs can be reported"
+"DevilutionX is maintained by Diasurgical, issues and bugs can be reported at "
+"this address: https://github.com/diasurgical/devilutionX To help us better "
+"serve you, please be sure to include the version number, operating system, "
+"and the nature of the problem."
 msgstr ""
 
 #: Source/DiabloUI/support_lines.cpp:13
-msgid "at this address: https://github.com/diasurgical/devilutionX"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:14
-msgid ""
-"To help us better serve you, please be sure to include the version number,"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:15
-msgid "operating system, and the nature of the problem."
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:18
 msgid "Disclaimer:"
 msgstr "Clauză exonerare de răspundere:"
 
-#: Source/DiabloUI/support_lines.cpp:19
-msgid "  DevilutionX is not supported or maintained by Blizzard Entertainment,"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:20
-msgid "  nor GOG.com. Neither Blizzard Entertainment nor GOG.com has tested"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:21
+#: Source/DiabloUI/support_lines.cpp:14
 msgid ""
-"  or certified the quality or compatibility of DevilutionX. All inquiries"
+"\tDevilutionX is not supported or maintained by Blizzard Entertainment, nor "
+"GOG.com. Neither Blizzard Entertainment nor GOG.com has tested or certified "
+"the quality or compatibility of DevilutionX. All inquiries regarding "
+"DevilutionX should be directed to Diasurgical, not to Blizzard Entertainment "
+"or GOG.com."
 msgstr ""
 
-#: Source/DiabloUI/support_lines.cpp:22
+#: Source/DiabloUI/support_lines.cpp:17
 msgid ""
-"  regarding DevilutionX should be directed to Diasurgical, not to Blizzard"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:23
-msgid "  Entertainment or GOG.com."
+"\tThis port makes use of CharisSILB, Unifont, and Noto which are licensed "
+"under the SIL Open Font License, as well as Twitmoji which is licensed under "
+"CC-BY 4.0. The port also makes use of SDL which is licensed under the zlib-"
+"license. See the ReadMe for further details."
 msgstr ""
 
 #: Source/DiabloUI/title.cpp:44
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr "Drepturi de auto © 1996-2001 Blizzard Entertainment"
 
-#: Source/appfat.cpp:37
+#: Source/appfat.cpp:38
 msgid "Error"
 msgstr "Eroare"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:101
+#: Source/appfat.cpp:102
 msgid ""
 "{:s}\n"
 "\n"
@@ -841,7 +820,7 @@ msgstr ""
 "\n"
 "Eroare s-a produs la: {:s} linia {:d}"
 
-#: Source/appfat.cpp:116
+#: Source/appfat.cpp:117
 msgid ""
 "Unable to open main data archive ({:s}).\n"
 "\n"
@@ -851,12 +830,12 @@ msgstr ""
 "\n"
 "Asigurați-vă că este în directorul jocului."
 
-#: Source/appfat.cpp:122
+#: Source/appfat.cpp:123
 msgid "Data File Error"
 msgstr "Eroare fișier de date"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:130
+#: Source/appfat.cpp:131
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -864,7 +843,7 @@ msgstr ""
 "Nu s-a putut scrie în locația:\n"
 "{:s}"
 
-#: Source/appfat.cpp:132
+#: Source/appfat.cpp:133
 msgid "Read-Only Directory Error"
 msgstr "Eroare de director doar-citire"
 
@@ -888,157 +867,157 @@ msgstr "Nivel: Cuibul {:d}"
 msgid "Level: Crypt {:d}"
 msgstr "Nivel: Criptă {:d}"
 
-#: Source/automap.cpp:508 Source/items.cpp:2079
+#: Source/automap.cpp:508 Source/items.cpp:2090
 msgid "Level: {:d}"
 msgstr "Nivel: {:d}"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr "Tab"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr "Esc"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Enter"
 msgstr "Enter"
 
-#: Source/control.cpp:202
+#: Source/control.cpp:215
 msgid "Character Information"
 msgstr "Informații personaj"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr "Jurnal misiuni"
 
-#: Source/control.cpp:204
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr "Hartă"
 
-#: Source/control.cpp:205
+#: Source/control.cpp:218
 msgid "Main Menu"
 msgstr "Meniu"
 
-#: Source/control.cpp:206
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr "Inventar"
 
-#: Source/control.cpp:207
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr "Carte vrăji"
 
-#: Source/control.cpp:208
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr "Trimite mesaj"
 
-#: Source/control.cpp:764 Source/control.cpp:1572
+#: Source/control.cpp:718 Source/control.cpp:1587
 msgid "Skill"
 msgstr "Abilitate"
 
-#: Source/control.cpp:765 Source/control.cpp:1226
+#: Source/control.cpp:719 Source/control.cpp:1237
 msgid "{:s} Skill"
 msgstr "{:s} Abilitate"
 
-#: Source/control.cpp:771
+#: Source/control.cpp:725
 msgid "Spell"
 msgstr "Vrajă"
 
-#: Source/control.cpp:772 Source/control.cpp:1230
+#: Source/control.cpp:726 Source/control.cpp:1241
 msgid "{:s} Spell"
 msgstr "{:s} Vrajă"
 
-#: Source/control.cpp:774
+#: Source/control.cpp:728
 msgid "Damages undead only"
 msgstr "Dăunează numai celor ne-morți"
 
-#: Source/control.cpp:778 Source/control.cpp:1234 Source/control.cpp:1596
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr "Nivel vrajă 0 - Inutilizabil"
 
-#: Source/control.cpp:780 Source/control.cpp:1236 Source/control.cpp:1598
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 msgid "Spell Level {:d}"
 msgstr "Nivel vrajă {:d}"
 
-#: Source/control.cpp:787
+#: Source/control.cpp:741
 msgid "Scroll"
 msgstr "Pergament"
 
-#: Source/control.cpp:788 Source/control.cpp:1240
+#: Source/control.cpp:742 Source/control.cpp:1251
 msgid "Scroll of {:s}"
 msgstr "Pergament de {:s}"
 
-#: Source/control.cpp:793 Source/control.cpp:1246
+#: Source/control.cpp:747 Source/control.cpp:1257
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "{:d} pergament"
 msgstr[1] "{:d} pergamente"
 msgstr[2] "{:d} de pergamente"
 
-#: Source/control.cpp:800 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
 #: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
 msgid "Staff"
 msgstr "Toiag"
 
-#: Source/control.cpp:801 Source/control.cpp:1250 Source/items.cpp:1320
+#: Source/control.cpp:755 Source/control.cpp:1261
 msgid "Staff of {:s}"
 msgstr "Toiag de {:s}"
 
-#: Source/control.cpp:803 Source/control.cpp:1252
+#: Source/control.cpp:757 Source/control.cpp:1263
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "{:d} încărcătură"
 msgstr[1] "{:d} încărcături"
 msgstr[2] "{:d} de încărcături"
 
-#: Source/control.cpp:813
+#: Source/control.cpp:767
 msgid "Spell Hotkey {:s}"
 msgstr "Tastă vrajă {:s}"
 
-#: Source/control.cpp:1203
+#: Source/control.cpp:1214
 msgid "Player friendly"
 msgstr "Jucător prietenos"
 
-#: Source/control.cpp:1205
+#: Source/control.cpp:1216
 msgid "Player attack"
 msgstr "Jucător agresiv"
 
-#: Source/control.cpp:1208
+#: Source/control.cpp:1219
 msgid "Hotkey: {:s}"
 msgstr "Tasta: {:s}"
 
-#: Source/control.cpp:1216
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr "Selectați buton curent de vrajă"
 
-#: Source/control.cpp:1219
+#: Source/control.cpp:1230
 msgid "Hotkey: 's'"
 msgstr "Tasta: 's'"
 
-#: Source/control.cpp:1374 Source/inv.cpp:1916 Source/items.cpp:3742
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "{:d} galben"
 msgstr[1] "{:d} galbeni"
 msgstr[2] "{:d} de galbeni"
 
-#: Source/control.cpp:1377
+#: Source/control.cpp:1390
 msgid "Requirements not met"
 msgstr "Cerințele nu au fost indeplinite"
 
-#: Source/control.cpp:1413
+#: Source/control.cpp:1426
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Nivel: {:d}"
 
-#: Source/control.cpp:1415
+#: Source/control.cpp:1428
 msgid "Hit Points {:d} of {:d}"
 msgstr "Puncte viață {:d} din {:d}"
 
-#: Source/control.cpp:1442
+#: Source/control.cpp:1457
 msgid "Level Up"
 msgstr "Creștere nivel"
 
-#: Source/control.cpp:1576
+#: Source/control.cpp:1591
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] "Toiag ({:d} încărcătură)"
@@ -1046,22 +1025,22 @@ msgstr[1] "Staff ({:d} încărcături)"
 msgstr[2] "Staff ({:d} de încărcături)"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1586
+#: Source/control.cpp:1601
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "Mana: {:d}  Daune: {:d} - {:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1588
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "Mana: {:d}   Daune: n/a"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1591
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "Mana: {:d}  Dam: 1/3 tgt hp"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1649
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] "Aveți {:d} galben. Câți doriți sa scoateți?"
@@ -1266,7 +1245,7 @@ msgstr ""
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr "{:s}, versiune = {:s}, mod = {:s}"
 
-#: Source/dvlnet/loopback.cpp:111
+#: Source/dvlnet/loopback.cpp:113
 msgid "loopback"
 msgstr "local"
 
@@ -1732,7 +1711,9 @@ msgstr ""
 "clic-dreapta pe obiect."
 
 #: Source/help.cpp:68
-msgid "$Gold"
+#, fuzzy
+#| msgid "$Gold"
+msgid "$Gold:"
 msgstr "$Galbeni"
 
 #: Source/help.cpp:69
@@ -1762,7 +1743,9 @@ msgstr ""
 "dreapta în zona de joc."
 
 #: Source/help.cpp:79
-msgid "$Using the Speedbook for Spells"
+#, fuzzy
+#| msgid "$Using the Speedbook for Spells"
+msgid "$Using the Speedbook for Spells:"
 msgstr "$Folosind Apelarea Rapidă pentru vrăji"
 
 #: Source/help.cpp:80
@@ -1777,15 +1760,21 @@ msgstr ""
 "dreapta în zona principală de joc."
 
 #: Source/help.cpp:84
+#, fuzzy
+#| msgid ""
+#| "Shift + Left-clicking on the 'select current spell' button will clear the "
+#| "readied spell"
 msgid ""
 "Shift + Left-clicking on the 'select current spell' button will clear the "
-"readied spell"
+"readied spell."
 msgstr ""
 "Shift + clic-stânga pe butonul 'selectare vrajă curentă' elimină vraja "
 "pregătită"
 
 #: Source/help.cpp:86
-msgid "$Setting Spell Hotkeys"
+#, fuzzy
+#| msgid "$Setting Spell Hotkeys"
+msgid "$Setting Spell Hotkeys:"
 msgstr "$Setare taste vrăji"
 
 #: Source/help.cpp:87
@@ -1800,7 +1789,9 @@ msgstr ""
 "alocați."
 
 #: Source/help.cpp:92
-msgid "$Spell Books"
+#, fuzzy
+#| msgid "$Spell Books"
+msgid "$Spell Books:"
 msgstr "$Cărți vrăji"
 
 #: Source/help.cpp:93
@@ -1811,35 +1802,35 @@ msgstr ""
 "Citind mai mult de o carte vă creșteți cunoștințele despre acea vrajă, "
 "permițându-vă să o folosiți mai eficient."
 
-#: Source/help.cpp:129
+#: Source/help.cpp:181
 msgid "Shareware Hellfire Help"
 msgstr "Ajutor Demo Hellfire"
 
-#: Source/help.cpp:129
+#: Source/help.cpp:181
 msgid "Hellfire Help"
 msgstr "Ajutor Hellfire"
 
-#: Source/help.cpp:131
+#: Source/help.cpp:183
 msgid "Shareware Diablo Help"
 msgstr "Ajutor Demo Diablo"
 
-#: Source/help.cpp:131
+#: Source/help.cpp:183
 msgid "Diablo Help"
 msgstr "Ajutor Diablo"
 
-#: Source/help.cpp:155
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr "Apăsați ESC pentru a încheia sau săgeți pentru a derula."
 
-#: Source/init.cpp:204
+#: Source/init.cpp:175
 msgid "diabdat.mpq or spawn.mpq"
 msgstr ""
 
-#: Source/init.cpp:224
+#: Source/init.cpp:196
 msgid "Some Hellfire MPQs are missing"
 msgstr "Niște fișiere MPQ Hellfire lipsesc"
 
-#: Source/init.cpp:224
+#: Source/init.cpp:196
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
@@ -1847,7 +1838,7 @@ msgstr ""
 "Nu toate fișierele Hellfire MPQ au fost găsite\n"
 "Vă rugăm să copiați fișierele hf*.mpq."
 
-#: Source/init.cpp:232
+#: Source/init.cpp:204
 msgid "Unable to create main window"
 msgstr "Nu s-a putut crea fereastra principală"
 
@@ -2091,7 +2082,7 @@ msgid "Quilted Armor"
 msgstr ""
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
-#: Source/itemdat.cpp:77 Source/objects.cpp:5467
+#: Source/itemdat.cpp:77 Source/objects.cpp:5433
 msgid "Armor"
 msgstr "Armură"
 
@@ -3633,659 +3624,672 @@ msgstr ""
 msgid "Oil of Imperviousness"
 msgstr ""
 
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#: Source/items.cpp:1174 Source/items.cpp:1184 Source/items.cpp:1233
-#: Source/items.cpp:1269
-msgid "{0} {1}"
-msgstr ""
-
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's Staff of Firewall
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Long Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1187 Source/items.cpp:1254 Source/items.cpp:1273
-#: Source/items.cpp:1315
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
+#, fuzzy
+#| msgid "{0} of {1}"
+msgctxt "spell"
 msgid "{0} of {1}"
 msgstr "{:s} de {:s}"
 
-#: Source/items.cpp:1895 Source/items.cpp:1907
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+#, fuzzy
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} de {:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+#, fuzzy
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} de {:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
+#: Source/items.cpp:1217
+msgid "{0} {1}"
+msgstr ""
+
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
+msgid "{0} of {1}"
+msgstr "{:s} de {:s}"
+
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr ""
 
-#: Source/items.cpp:1897
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr "șansă de lovitură"
 
-#: Source/items.cpp:1901
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr ""
 
-#: Source/items.cpp:1903
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr "șansele de lovitură ale armei"
 
-#: Source/items.cpp:1909
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr "potențial daune"
 
-#: Source/items.cpp:1913
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr ""
 
-#: Source/items.cpp:1915
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr ""
 
-#: Source/items.cpp:1919
+#: Source/items.cpp:1930
 msgid "reduces attributes needed"
 msgstr ""
 
-#: Source/items.cpp:1921
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr ""
 
-#: Source/items.cpp:1925
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr ""
 
-#: Source/items.cpp:1927
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr ""
 
-#: Source/items.cpp:1931
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr ""
 
-#: Source/items.cpp:1933
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr ""
 
-#: Source/items.cpp:1937
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr ""
 
-#: Source/items.cpp:1941
+#: Source/items.cpp:1952
 msgid "increases the armor class"
 msgstr ""
 
-#: Source/items.cpp:1943
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr ""
 
-#: Source/items.cpp:1947
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr ""
 
-#: Source/items.cpp:1949
+#: Source/items.cpp:1960
 msgid "class of armor and shields"
 msgstr ""
 
-#: Source/items.cpp:1953 Source/items.cpp:1962
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr ""
 
-#: Source/items.cpp:1958
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr ""
 
-#: Source/items.cpp:1966
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr ""
 
-#: Source/items.cpp:1970
+#: Source/items.cpp:1981
 msgid "restore all life"
 msgstr ""
 
-#: Source/items.cpp:1974
+#: Source/items.cpp:1985
 msgid "restore some life"
 msgstr ""
 
-#: Source/items.cpp:1978
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr ""
 
-#: Source/items.cpp:1982
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr ""
 
-#: Source/items.cpp:1986
+#: Source/items.cpp:1997
 msgid "restore some mana"
 msgstr ""
 
-#: Source/items.cpp:1990
+#: Source/items.cpp:2001
 msgid "restore all mana"
 msgstr ""
 
-#: Source/items.cpp:1994
+#: Source/items.cpp:2005
 msgid "increase strength"
 msgstr ""
 
-#: Source/items.cpp:1998
+#: Source/items.cpp:2009
 msgid "increase magic"
 msgstr ""
 
-#: Source/items.cpp:2002
+#: Source/items.cpp:2013
 msgid "increase dexterity"
 msgstr ""
 
-#: Source/items.cpp:2006
+#: Source/items.cpp:2017
 msgid "increase vitality"
 msgstr ""
 
-#: Source/items.cpp:2011
+#: Source/items.cpp:2022
 msgid "decrease strength"
 msgstr ""
 
-#: Source/items.cpp:2015
+#: Source/items.cpp:2026
 msgid "decrease dexterity"
 msgstr ""
 
-#: Source/items.cpp:2019
+#: Source/items.cpp:2030
 msgid "decrease vitality"
 msgstr ""
 
-#: Source/items.cpp:2023
+#: Source/items.cpp:2034
 msgid "restore some life and mana"
 msgstr ""
 
-#: Source/items.cpp:2027
+#: Source/items.cpp:2038
 msgid "restore all life and mana"
 msgstr ""
 
-#: Source/items.cpp:2042 Source/items.cpp:2067
+#: Source/items.cpp:2053 Source/items.cpp:2078
 msgid "Right-click to read"
 msgstr "Clic-dreapta citire"
 
-#: Source/items.cpp:2046
+#: Source/items.cpp:2057
 msgid "Right-click to read, then"
 msgstr "Clic-dreapta citire, și apoi"
 
-#: Source/items.cpp:2048
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr "clic-stânga țintire"
 
-#: Source/items.cpp:2053
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr "Clic-dreapta folosire"
 
-#: Source/items.cpp:2058 Source/items.cpp:2063
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr "Clic dreapta folosire"
 
-#: Source/items.cpp:2071
+#: Source/items.cpp:2082
 msgid "Right click to read"
 msgstr "Clic dreapta citire"
 
-#: Source/items.cpp:2075
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr "Clic-dreapta vizualizare"
 
-#: Source/items.cpp:2083
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr "Dublează capacitatea de galbeni"
 
-#: Source/items.cpp:2095 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 msgid "Required:"
 msgstr "Necesită:"
 
-#: Source/items.cpp:2097 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 msgid " {:d} Str"
 msgstr " {:d} Put"
 
-#: Source/items.cpp:2099 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 msgid " {:d} Mag"
 msgstr " {:d} Mag"
 
-#: Source/items.cpp:2101 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 msgid " {:d} Dex"
 msgstr " {:d} Dex"
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3526 Source/player.cpp:3027
+#: Source/items.cpp:3533 Source/player.cpp:3018
 msgid "Ear of {:s}"
 msgstr ""
 
-#: Source/items.cpp:3821
+#: Source/items.cpp:3828
 msgid "chance to hit: {:+d}%"
 msgstr "șansă de lovitură: {:+d}%"
 
-#: Source/items.cpp:3825
+#: Source/items.cpp:3832
 #, no-c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% daune"
 
-#: Source/items.cpp:3829 Source/items.cpp:4085
+#: Source/items.cpp:3836 Source/items.cpp:4092
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "lovitură: {:+d}%, daună {:+d}%"
 
-#: Source/items.cpp:3833
+#: Source/items.cpp:3840
 #, no-c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% armură"
 
-#: Source/items.cpp:3837
+#: Source/items.cpp:3844
 msgid "armor class: {:d}"
 msgstr "clasă armură: {:d}"
 
-#: Source/items.cpp:3842 Source/items.cpp:4067
+#: Source/items.cpp:3849 Source/items.cpp:4074
 msgid "Resist Fire: {:+d}%"
 msgstr "Rezistă la foc: {:+d}%"
 
-#: Source/items.cpp:3844
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr "Rezistă la foc: 75% MAX"
 
-#: Source/items.cpp:3849
+#: Source/items.cpp:3856
 msgid "Resist Lightning: {:+d}%"
 msgstr "Rezistă la fulger: {:+d}%"
 
-#: Source/items.cpp:3851
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr "Rezistă la fulger: 75% MAX"
 
-#: Source/items.cpp:3856
+#: Source/items.cpp:3863
 msgid "Resist Magic: {:+d}%"
 msgstr "Rezistă la magie: {:+d}%"
 
-#: Source/items.cpp:3858
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr "Rezistă la magie: 75% MAX"
 
-#: Source/items.cpp:3863
+#: Source/items.cpp:3870
 msgid "Resist All: {:+d}%"
 msgstr "Rezistă la toate: {:+d}%"
 
-#: Source/items.cpp:3865
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr "Rezistă la toate: 75% MAX"
 
-#: Source/items.cpp:3869
+#: Source/items.cpp:3876
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: Source/items.cpp:3871
+#: Source/items.cpp:3878
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: Source/items.cpp:3873
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr ""
 
-#: Source/items.cpp:3876
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr "Încărcături în plus"
 
-#: Source/items.cpp:3879
+#: Source/items.cpp:3886
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:d} {:s} încărcătură"
 msgstr[1] "{:d} {:s} încărcături"
 msgstr[2] "{:d} {:s} de încărcături"
 
-#: Source/items.cpp:3883
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr ""
 
-#: Source/items.cpp:3885
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3889
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr ""
 
-#: Source/items.cpp:3891
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3895
+#: Source/items.cpp:3902
 msgid "{:+d} to strength"
 msgstr "{:+d} la forță"
 
-#: Source/items.cpp:3899
+#: Source/items.cpp:3906
 msgid "{:+d} to magic"
 msgstr "{:+d} la magie"
 
-#: Source/items.cpp:3903
+#: Source/items.cpp:3910
 msgid "{:+d} to dexterity"
 msgstr "{:+d} la dexteritate"
 
-#: Source/items.cpp:3907
+#: Source/items.cpp:3914
 msgid "{:+d} to vitality"
 msgstr "{:+d} la vitalitate"
 
-#: Source/items.cpp:3911
+#: Source/items.cpp:3918
 msgid "{:+d} to all attributes"
 msgstr "{:+d} la toate atributele"
 
-#: Source/items.cpp:3915
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr ""
 
-#: Source/items.cpp:3919
+#: Source/items.cpp:3926
 msgid "Hit Points: {:+d}"
 msgstr ""
 
-#: Source/items.cpp:3923
+#: Source/items.cpp:3930
 msgid "Mana: {:+d}"
 msgstr ""
 
-#: Source/items.cpp:3926
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr ""
 
-#: Source/items.cpp:3929
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr ""
 
-#: Source/items.cpp:3932
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr ""
 
-#: Source/items.cpp:3935
+#: Source/items.cpp:3942
 #, no-c-format
 msgid "+{:d}% light radius"
 msgstr "+{:d}% rază lumină"
 
-#: Source/items.cpp:3938
+#: Source/items.cpp:3945
 #, no-c-format
 msgid "-{:d}% light radius"
 msgstr "-{:d}% rază lumină"
 
-#: Source/items.cpp:3941
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr ""
 
-#: Source/items.cpp:3945
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr ""
 
-#: Source/items.cpp:3947
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3951
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr ""
 
-#: Source/items.cpp:3953
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:3957
+#: Source/items.cpp:3964
 msgid "fireball damage: {:d}"
 msgstr "daune minge de foc: {:d}"
 
-#: Source/items.cpp:3959
+#: Source/items.cpp:3966
 msgid "fireball damage: {:d}-{:d}"
 msgstr "daune minge de foc: {:d}-{:d}"
 
-#: Source/items.cpp:3962
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr ""
 
-#: Source/items.cpp:3965
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr ""
 
-#: Source/items.cpp:3968
+#: Source/items.cpp:3975
 msgid "you can't heal"
 msgstr ""
 
-#: Source/items.cpp:3971
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr ""
 
-#: Source/items.cpp:3974
+#: Source/items.cpp:3981
 msgid "knocks target back"
 msgstr "lovește ținta inapoi"
 
-#: Source/items.cpp:3977
+#: Source/items.cpp:3984
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr ""
 
-#: Source/items.cpp:3980
+#: Source/items.cpp:3987
 msgid "All Resistance equals 0"
 msgstr ""
 
-#: Source/items.cpp:3983
+#: Source/items.cpp:3990
 msgid "hit monster doesn't heal"
 msgstr ""
 
-#: Source/items.cpp:3987
+#: Source/items.cpp:3994
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr ""
 
-#: Source/items.cpp:3989
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr ""
 
-#: Source/items.cpp:3993
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr ""
 
-#: Source/items.cpp:3995
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr ""
 
-#: Source/items.cpp:3998
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr ""
 
-#: Source/items.cpp:4002
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr ""
 
-#: Source/items.cpp:4004
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr ""
 
-#: Source/items.cpp:4006
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr ""
 
-#: Source/items.cpp:4008
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr ""
 
-#: Source/items.cpp:4012
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr ""
 
-#: Source/items.cpp:4014
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr ""
 
-#: Source/items.cpp:4016
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr ""
 
-#: Source/items.cpp:4019
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr ""
 
-#: Source/items.cpp:4022
+#: Source/items.cpp:4029
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: Source/items.cpp:4025
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr ""
 
-#: Source/items.cpp:4028
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr ""
 
-#: Source/items.cpp:4031
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr ""
 
-#: Source/items.cpp:4034
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr ""
 
-#: Source/items.cpp:4037
+#: Source/items.cpp:4044
 msgid "one handed sword"
 msgstr ""
 
-#: Source/items.cpp:4040
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr ""
 
-#: Source/items.cpp:4043
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr ""
 
-#: Source/items.cpp:4046
+#: Source/items.cpp:4053
 msgid "no strength requirement"
 msgstr ""
 
-#: Source/items.cpp:4049
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr ""
 
-#: Source/items.cpp:4056
+#: Source/items.cpp:4063
 msgid "lightning damage: {:d}"
 msgstr ""
 
-#: Source/items.cpp:4058
+#: Source/items.cpp:4065
 msgid "lightning damage: {:d}-{:d}"
 msgstr ""
 
-#: Source/items.cpp:4061
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr ""
 
-#: Source/items.cpp:4070
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr ""
 
-#: Source/items.cpp:4073
+#: Source/items.cpp:4080
 #, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr ""
 
-#: Source/items.cpp:4076
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr ""
 
-#: Source/items.cpp:4079
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr ""
 
-#: Source/items.cpp:4082
+#: Source/items.cpp:4089
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr ""
 
-#: Source/items.cpp:4088
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr ""
 
-#: Source/items.cpp:4091
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr ""
 
-#: Source/items.cpp:4094
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr ""
 
-#: Source/items.cpp:4097
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr ""
 
-#: Source/items.cpp:4100
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr ""
 
-#: Source/items.cpp:4137 Source/items.cpp:4184
+#: Source/items.cpp:4144 Source/items.cpp:4191
 msgid "damage: {:d}  Indestructible"
 msgstr "daune: {:d}  Indestructibil"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4139 Source/items.cpp:4186
+#: Source/items.cpp:4146 Source/items.cpp:4193
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "daune: {:d}  Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4142 Source/items.cpp:4189
+#: Source/items.cpp:4149 Source/items.cpp:4196
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "daune: {:d}-{:d}  Indestructibil"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4144 Source/items.cpp:4191
+#: Source/items.cpp:4151 Source/items.cpp:4198
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "daune: {:d}-{:d}  Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4150 Source/items.cpp:4203
+#: Source/items.cpp:4157 Source/items.cpp:4210
 msgid "armor: {:d}  Indestructible"
 msgstr "armură: {:d}-{:d}  Indestructibil"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4152 Source/items.cpp:4205
+#: Source/items.cpp:4159 Source/items.cpp:4212
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "armură: {:d}  Dur: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4157
+#: Source/items.cpp:4164
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "daune: {:d}  Dur: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4159
+#: Source/items.cpp:4166
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "daune: {:d}-{:d}  Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4160 Source/items.cpp:4195 Source/items.cpp:4210
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 msgid "Charges: {:d}/{:d}"
 msgstr "Încărcături: {:d}/{:d}"
 
-#: Source/items.cpp:4172
+#: Source/items.cpp:4179
 msgid "unique item"
 msgstr ""
 
-#: Source/items.cpp:4199 Source/items.cpp:4208 Source/items.cpp:4215
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr "Neidentificat"
 
-#: Source/loadsave.cpp:1680 Source/loadsave.cpp:2144
+#: Source/loadsave.cpp:1683 Source/loadsave.cpp:2149
 msgid "Unable to open save file archive"
 msgstr ""
 
-#: Source/loadsave.cpp:1683
+#: Source/loadsave.cpp:1686
 msgid "Invalid save file"
 msgstr "Fișier salvare invalid"
 
-#: Source/loadsave.cpp:1712
+#: Source/loadsave.cpp:1717
 msgid "Player is on a Hellfire only level"
 msgstr ""
 
-#: Source/loadsave.cpp:1907
+#: Source/loadsave.cpp:1912
 msgid "Invalid game state"
 msgstr ""
 
@@ -5423,97 +5427,97 @@ msgctxt "monster"
 msgid "Doomlock"
 msgstr ""
 
-#: Source/monster.cpp:3495
+#: Source/monster.cpp:3479
 msgid "Animal"
 msgstr ""
 
-#: Source/monster.cpp:3497
+#: Source/monster.cpp:3481
 msgid "Demon"
 msgstr ""
 
-#: Source/monster.cpp:3499
+#: Source/monster.cpp:3483
 msgid "Undead"
 msgstr ""
 
-#: Source/monster.cpp:4630
+#: Source/monster.cpp:4612
 msgid "Type: {:s}  Kills: {:d}"
 msgstr ""
 
-#: Source/monster.cpp:4632
+#: Source/monster.cpp:4614
 msgid "Total kills: {:d}"
 msgstr "Total uciși: {:d}"
 
-#: Source/monster.cpp:4665
+#: Source/monster.cpp:4647
 msgid "Hit Points: {:d}-{:d}"
 msgstr ""
 
-#: Source/monster.cpp:4671
+#: Source/monster.cpp:4653
 msgid "No magic resistance"
 msgstr ""
 
-#: Source/monster.cpp:4675
+#: Source/monster.cpp:4657
 msgid "Resists: "
 msgstr "Rezistă: "
 
-#: Source/monster.cpp:4677 Source/monster.cpp:4688
+#: Source/monster.cpp:4659 Source/monster.cpp:4671
 msgid "Magic "
 msgstr "Magie "
 
-#: Source/monster.cpp:4679 Source/monster.cpp:4690
+#: Source/monster.cpp:4661 Source/monster.cpp:4673
 msgid "Fire "
 msgstr ""
 
-#: Source/monster.cpp:4681 Source/monster.cpp:4692
+#: Source/monster.cpp:4663 Source/monster.cpp:4675
 msgid "Lightning "
 msgstr ""
 
-#: Source/monster.cpp:4686
+#: Source/monster.cpp:4669
 msgid "Immune: "
 msgstr ""
 
-#: Source/monster.cpp:4704
+#: Source/monster.cpp:4688
 msgid "Type: {:s}"
 msgstr ""
 
-#: Source/monster.cpp:4710 Source/monster.cpp:4717
+#: Source/monster.cpp:4694 Source/monster.cpp:4701
 msgid "No resistances"
 msgstr ""
 
-#: Source/monster.cpp:4712 Source/monster.cpp:4722
+#: Source/monster.cpp:4696 Source/monster.cpp:4706
 msgid "No Immunities"
 msgstr ""
 
-#: Source/monster.cpp:4715
+#: Source/monster.cpp:4699
 msgid "Some Magic Resistances"
 msgstr ""
 
-#: Source/monster.cpp:4720
+#: Source/monster.cpp:4704
 msgid "Some Magic Immunities"
 msgstr ""
 
-#: Source/msg.cpp:494
+#: Source/msg.cpp:495
 msgid "Trying to drop a floor item?"
 msgstr ""
 
-#: Source/msg.cpp:982 Source/msg.cpp:1017 Source/msg.cpp:1048
-#: Source/msg.cpp:1175 Source/msg.cpp:1207 Source/msg.cpp:1239
-#: Source/msg.cpp:1269
+#: Source/msg.cpp:994 Source/msg.cpp:1029 Source/msg.cpp:1060
+#: Source/msg.cpp:1187 Source/msg.cpp:1219 Source/msg.cpp:1251
+#: Source/msg.cpp:1281
 msgid "{:s} has cast an illegal spell."
 msgstr ""
 
-#: Source/msg.cpp:1655 Source/multi.cpp:805
+#: Source/msg.cpp:1668 Source/multi.cpp:804
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr ""
 
-#: Source/msg.cpp:1959
+#: Source/msg.cpp:1972
 msgid "Waiting for game data..."
 msgstr ""
 
-#: Source/msg.cpp:1967
+#: Source/msg.cpp:1980
 msgid "The game ended"
 msgstr ""
 
-#: Source/msg.cpp:1973
+#: Source/msg.cpp:1986
 msgid "Unable to get level data"
 msgstr ""
 
@@ -5529,7 +5533,7 @@ msgstr ""
 msgid "Player '{:s}' dropped due to timeout"
 msgstr ""
 
-#: Source/multi.cpp:807
+#: Source/multi.cpp:806
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr ""
 
@@ -5739,158 +5743,158 @@ msgstr ""
 msgid "A Spellbook"
 msgstr ""
 
-#: Source/objects.cpp:5373
+#: Source/objects.cpp:5339
 msgid "Crucified Skeleton"
 msgstr ""
 
-#: Source/objects.cpp:5377
+#: Source/objects.cpp:5343
 msgid "Lever"
 msgstr ""
 
-#: Source/objects.cpp:5386
+#: Source/objects.cpp:5352
 msgid "Open Door"
 msgstr "Ușă deschisă"
 
-#: Source/objects.cpp:5388
+#: Source/objects.cpp:5354
 msgid "Closed Door"
 msgstr "Ușă închisă"
 
-#: Source/objects.cpp:5390
+#: Source/objects.cpp:5356
 msgid "Blocked Door"
 msgstr "Ușă blocată"
 
-#: Source/objects.cpp:5395
+#: Source/objects.cpp:5361
 msgid "Ancient Tome"
 msgstr ""
 
-#: Source/objects.cpp:5397
+#: Source/objects.cpp:5363
 msgid "Book of Vileness"
 msgstr "Cartea Josnicei"
 
-#: Source/objects.cpp:5402
+#: Source/objects.cpp:5368
 msgid "Skull Lever"
 msgstr ""
 
-#: Source/objects.cpp:5405
+#: Source/objects.cpp:5371
 msgid "Mythical Book"
 msgstr ""
 
-#: Source/objects.cpp:5409
+#: Source/objects.cpp:5375
 msgid "Small Chest"
 msgstr ""
 
-#: Source/objects.cpp:5413
+#: Source/objects.cpp:5379
 msgid "Chest"
 msgstr ""
 
-#: Source/objects.cpp:5418
+#: Source/objects.cpp:5384
 msgid "Large Chest"
 msgstr ""
 
-#: Source/objects.cpp:5421
+#: Source/objects.cpp:5387
 msgid "Sarcophagus"
 msgstr ""
 
-#: Source/objects.cpp:5424
+#: Source/objects.cpp:5390
 msgid "Bookshelf"
 msgstr ""
 
-#: Source/objects.cpp:5428
+#: Source/objects.cpp:5394
 msgid "Bookcase"
 msgstr ""
 
-#: Source/objects.cpp:5433
+#: Source/objects.cpp:5399
 msgid "Pod"
 msgstr ""
 
-#: Source/objects.cpp:5435
+#: Source/objects.cpp:5401
 msgid "Urn"
 msgstr "Urnă"
 
-#: Source/objects.cpp:5437
+#: Source/objects.cpp:5403
 msgid "Barrel"
 msgstr "Butoi"
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:5441
+#: Source/objects.cpp:5407
 msgid "{:s} Shrine"
 msgstr ""
 
-#: Source/objects.cpp:5445
+#: Source/objects.cpp:5411
 msgid "Skeleton Tome"
 msgstr ""
 
-#: Source/objects.cpp:5448
+#: Source/objects.cpp:5414
 msgid "Library Book"
 msgstr ""
 
-#: Source/objects.cpp:5451
+#: Source/objects.cpp:5417
 msgid "Blood Fountain"
 msgstr ""
 
-#: Source/objects.cpp:5454
+#: Source/objects.cpp:5420
 msgid "Decapitated Body"
 msgstr ""
 
-#: Source/objects.cpp:5457
+#: Source/objects.cpp:5423
 msgid "Book of the Blind"
 msgstr "Cartea Oarbei"
 
-#: Source/objects.cpp:5460
+#: Source/objects.cpp:5426
 msgid "Book of Blood"
 msgstr "Cartea Insângeratei"
 
-#: Source/objects.cpp:5463
+#: Source/objects.cpp:5429
 msgid "Purifying Spring"
 msgstr ""
 
-#: Source/objects.cpp:5470 Source/objects.cpp:5494
+#: Source/objects.cpp:5436 Source/objects.cpp:5460
 msgid "Weapon Rack"
 msgstr ""
 
-#: Source/objects.cpp:5473
+#: Source/objects.cpp:5439
 msgid "Goat Shrine"
 msgstr ""
 
-#: Source/objects.cpp:5476
+#: Source/objects.cpp:5442
 msgid "Cauldron"
 msgstr ""
 
-#: Source/objects.cpp:5479
+#: Source/objects.cpp:5445
 msgid "Murky Pool"
 msgstr ""
 
-#: Source/objects.cpp:5482
+#: Source/objects.cpp:5448
 msgid "Fountain of Tears"
 msgstr ""
 
-#: Source/objects.cpp:5485
+#: Source/objects.cpp:5451
 msgid "Steel Tome"
 msgstr ""
 
-#: Source/objects.cpp:5488
+#: Source/objects.cpp:5454
 msgid "Pedestal of Blood"
 msgstr ""
 
-#: Source/objects.cpp:5497
+#: Source/objects.cpp:5463
 msgid "Mushroom Patch"
 msgstr ""
 
-#: Source/objects.cpp:5500
+#: Source/objects.cpp:5466
 msgid "Vile Stand"
 msgstr ""
 
-#: Source/objects.cpp:5503
+#: Source/objects.cpp:5469
 msgid "Slain Hero"
 msgstr ""
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:5510
+#: Source/objects.cpp:5476
 msgid "Trapped {:s}"
 msgstr ""
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
-#: Source/objects.cpp:5516
+#: Source/objects.cpp:5482
 msgid "{:s} (disabled)"
 msgstr "{:s} (dezactivat)"
 
@@ -6008,27 +6012,26 @@ msgstr "vrăji"
 msgid "mute"
 msgstr "amuțește"
 
-#: Source/pfile.cpp:260
+#: Source/pfile.cpp:242
 msgid "Failed to open player archive for writing."
 msgstr "Eroare la deschiderea pentru scriere a arhivei jucătorului."
 
-#: Source/pfile.cpp:389
+#: Source/pfile.cpp:377
 msgid "Unable to open archive"
 msgstr "Nu s-a putut deschide arhiva"
 
-#: Source/pfile.cpp:391
+#: Source/pfile.cpp:379
 msgid "Unable to load character"
 msgstr "Nu s-a putut încarcă personajul"
 
-#: Source/pfile.cpp:416 Source/pfile.cpp:436
+#: Source/pfile.cpp:403 Source/pfile.cpp:423
 msgid "Unable to read to save file archive"
 msgstr "Nu s-a putut citi arhiva fișierului salvat"
 
-#: Source/pfile.cpp:455
+#: Source/pfile.cpp:442
 msgid "Unable to write to save file archive"
 msgstr "Nu s-a putut scrie arhiva fișierului salvat"
 
-#. TRANSLATORS: Shown if player presses "v" button. {:s} is player name, {:d} is level, {:s} is location
 #: Source/plrmsg.cpp:88
 msgid "{:s} (lvl {:d}): {:s}"
 msgstr "{:s} (lvl {:d}): {:s}"
@@ -6044,7 +6047,7 @@ msgstr ",%03d"
 msgid "%i gold"
 msgstr "%i galbeni"
 
-#: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:56
+#: Source/qol/monhealthbar.cpp:37 Source/qol/xpbar.cpp:56
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
@@ -6457,298 +6460,331 @@ msgctxt "spell"
 msgid "Rune of Stone"
 msgstr ""
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:91
+#, fuzzy
+#| msgid "Talk to Griswold"
+msgid "Griswold"
+msgstr "Vorbiți cu Griswold"
+
+#: Source/stores.cpp:92
+msgid "Pepin"
+msgstr ""
+
+#: Source/stores.cpp:94
+msgid "Ogden"
+msgstr ""
+
+#: Source/stores.cpp:95
+msgid "Cain"
+msgstr ""
+
+#: Source/stores.cpp:96
+#, fuzzy
+#| msgid "Talk to Farnham"
+msgid "Farnham"
+msgstr "Vorbiți cu Farnham"
+
+#: Source/stores.cpp:97
+msgid "Adria"
+msgstr ""
+
+#: Source/stores.cpp:98 Source/stores.cpp:1305
+#, fuzzy
+#| msgid "Talk to Gillian"
+msgid "Gillian"
+msgstr "Vorbiți cu Gillian"
+
+#: Source/stores.cpp:99
+msgid "Wirt"
+msgstr ""
+
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr "Înapoi"
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ",  "
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 msgid "Damage: {:d}-{:d}  "
 msgstr "Daune: {:d}-{:d}  "
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 msgid "Armor: {:d}  "
 msgstr "Armură: {:d}  "
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 msgid "Dur: {:d}/{:d},  "
 msgstr "Dur: {:d}/{:d},  "
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr "Indestructibil,  "
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr "Fără atribute necesare"
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr "Bine ați venit la"
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr "Magazinul fierarului"
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr "Ați vrea să:"
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 msgid "Talk to Griswold"
 msgstr "Vorbiți cu Griswold"
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 msgid "Buy basic items"
 msgstr "Cumpărați obiecte comune"
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 msgid "Buy premium items"
 msgstr "Cumpărați obiecte de lux"
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 msgid "Sell items"
 msgstr "Vindeți obiecte"
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 msgid "Repair items"
 msgstr "Reparați obiecte"
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 msgid "Leave the shop"
 msgstr "Ieșiți din magazin"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "Am aceste obiecte de vânzare:             Galbeni: {:d}"
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr "Înapoi"
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "Am aceste obiecte de lux de vânzare:             Galbeni: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "Nu aveți nimic din ce aș vrea.             Galbeni: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "Care obiect e de vânzare?             Galbeni: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "Nu aveți nimic de reparat.             Galbeni: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "Repar care obiect?             Galbeni: {:d}"
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr "Coliba vrăjitoarei"
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 msgid "Talk to Adria"
 msgstr "Vorbiți cu Adria"
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr "Cumpărați obiecte"
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr "Reîncărcați toiege"
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 msgid "Leave the shack"
 msgstr "Ieșiți din colibă"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "Nu aveți nimic de reîncărcat.             Galbeni: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "Reîncărcați care obiect?             Galbeni: {:d}"
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr "Nu aveți destui galbeni"
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr "Nu aveți destul loc in inventar"
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr "Deci ne-am înțeles?"
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 msgid "Are you sure you want to identify this item?"
 msgstr "Sunteți siguri că vreți să identificați acest obiect?"
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 msgid "Are you sure you want to buy this item?"
 msgstr "Sunteți siguri că vreți să cumpărați acest obiect?"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 msgid "Are you sure you want to recharge this item?"
 msgstr "Sunteți siguri că vreți să reîncărcați acest obiect?"
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 msgid "Are you sure you want to sell this item?"
 msgstr "Sunteți siguri că vreți să vindeți acest obiect?"
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 msgid "Are you sure you want to repair this item?"
 msgstr "Sunteți siguri că vreți să reparați acest obiect?"
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr "Wirt băiatul cu picior de lemn"
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 msgid "Talk to Wirt"
 msgstr "Vorbiți cu Wirt"
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr "Am ceva de vânzare,"
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr "dar te va costa 50 de galbeni"
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr "doar ca să arunc o privire. "
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr "Și ce ai?"
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr "Spuneți la revedere"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "Am acest obiect de vânzare:             Galbeni: {:d}"
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 msgid "Leave"
 msgstr "Ieși"
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr "Casa vindecătorului"
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr "Vorbiți cu Pepin"
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr "Ieșiți din casa vindecătorului"
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 msgid "The Town Elder"
 msgstr "Bătrânul orașului"
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 msgid "Talk to Cain"
 msgstr "Vorbiți cu Cain"
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr "Identificați un obiect"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "Nu aveți nimic de identificat.             Galbeni: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "Identific care obiect?             Galbeni: {:d}"
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr "Acest obiect este:"
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr "Gata"
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 msgid "Talk to {:s}"
 msgstr "Vorbiți cu {:s}"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 msgid "Talking to {:s}"
 msgstr "Vorbiți cu {:s}"
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 msgid "is not available"
 msgstr "nu este disponibil"
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 msgid "in the shareware"
 msgstr "în versiunea Demo"
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 msgid "version"
 msgstr "versiune"
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr "Bârfă"
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr "Răsărit de Soare"
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 msgid "Talk to Ogden"
 msgstr "Vorbiți cu Ogden"
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 msgid "Leave the tavern"
 msgstr "Ieșiți din tavernă"
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 msgid "Talk to Gillian"
 msgstr "Vorbiți cu Gillian"
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr "Bețivul Farnham"
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 msgid "Talk to Farnham"
 msgstr "Vorbiți cu Farnham"
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr "Spuneți la revedere"
 
@@ -9488,17 +9524,17 @@ msgid "Down to Crypt"
 msgstr "Coboară în Criptă"
 
 #: Source/trigs.cpp:412 Source/trigs.cpp:492 Source/trigs.cpp:539
-#: Source/trigs.cpp:630
+#: Source/trigs.cpp:634
 msgid "Up to level {:d}"
 msgstr "Urcă la nivelul {:d}"
 
 #: Source/trigs.cpp:414 Source/trigs.cpp:469 Source/trigs.cpp:521
-#: Source/trigs.cpp:596 Source/trigs.cpp:613 Source/trigs.cpp:660
+#: Source/trigs.cpp:600 Source/trigs.cpp:617 Source/trigs.cpp:664
 msgid "Up to town"
 msgstr "Urcă în oraș"
 
-#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:552
-#: Source/trigs.cpp:577 Source/trigs.cpp:642
+#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:556
+#: Source/trigs.cpp:581 Source/trigs.cpp:646
 msgid "Down to level {:d}"
 msgstr "Coboară la nivelul {:d}"
 
@@ -9510,15 +9546,14 @@ msgstr "Urcă la nivelul {:d} în Criptă"
 msgid "Down to Crypt level {:d}"
 msgstr "Coboară la Nivelul {:d} în Criptă"
 
-#: Source/trigs.cpp:564
+#: Source/trigs.cpp:568
 msgid "Up to Nest level {:d}"
 msgstr "Urcă la nivelul {:d} în Cuib"
 
-#: Source/trigs.cpp:673
+#: Source/trigs.cpp:677
 msgid "Down to Diablo"
 msgstr "Coboară la Diablo"
 
-#: Source/trigs.cpp:706 Source/trigs.cpp:720 Source/trigs.cpp:734
+#: Source/trigs.cpp:710 Source/trigs.cpp:724 Source/trigs.cpp:738
 msgid "Back to Level {:d}"
 msgstr "Înapoi la Nivelul {:d}"
-

--- a/Translations/sv.po
+++ b/Translations/sv.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-09-20 04:34+0200\n"
+"POT-Creation-Date: 2021-11-21 05:45+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -157,6 +157,7 @@ msgstr ""
 msgid "QA Counterintelligence"
 msgstr ""
 
+#. TRANSLATORS: A group of people
 #: Source/DiabloUI/credits_lines.cpp:130
 msgid "Order of Network Information Services"
 msgstr ""
@@ -309,15 +310,49 @@ msgstr ""
 msgid "\tNo souls were sold in the making of this game."
 msgstr ""
 
-#: Source/DiabloUI/dialogs.cpp:172 Source/DiabloUI/dialogs.cpp:185
-#: Source/DiabloUI/selconn.cpp:73 Source/DiabloUI/selgame.cpp:94
-#: Source/DiabloUI/selgame.cpp:163 Source/DiabloUI/selgame.cpp:181
-#: Source/DiabloUI/selgame.cpp:314 Source/DiabloUI/selgame.cpp:387
-#: Source/DiabloUI/selhero.cpp:185 Source/DiabloUI/selhero.cpp:210
-#: Source/DiabloUI/selhero.cpp:280 Source/DiabloUI/selhero.cpp:525
+#: Source/DiabloUI/dialogs.cpp:194 Source/DiabloUI/dialogs.cpp:206
+#: Source/DiabloUI/selconn.cpp:79 Source/DiabloUI/selgame.cpp:103
+#: Source/DiabloUI/selgame.cpp:193 Source/DiabloUI/selgame.cpp:211
+#: Source/DiabloUI/selgame.cpp:352 Source/DiabloUI/selgame.cpp:428
+#: Source/DiabloUI/selhero.cpp:186 Source/DiabloUI/selhero.cpp:211
+#: Source/DiabloUI/selhero.cpp:281 Source/DiabloUI/selhero.cpp:536
 #: Source/DiabloUI/selok.cpp:68
 msgid "OK"
 msgstr ""
+
+#: Source/DiabloUI/extrasmenu.cpp:41 Source/DiabloUI/selstart.cpp:44
+#, fuzzy
+#| msgid "Down to Diablo"
+msgid "Switch to Diablo"
+msgstr "Ned till Diablo"
+
+#: Source/DiabloUI/extrasmenu.cpp:41
+#, fuzzy
+#| msgid "Exit Hellfire"
+msgid "Switch to Hellfire"
+msgstr "Avsluta Hellfire"
+
+#: Source/DiabloUI/extrasmenu.cpp:43
+msgid "Switch to Fullgame"
+msgstr ""
+
+#: Source/DiabloUI/extrasmenu.cpp:43
+#, fuzzy
+#| msgid "in the shareware"
+msgid "Switch to Shareware"
+msgstr "i shareware"
+
+#: Source/DiabloUI/extrasmenu.cpp:44
+msgid "Replay Intro"
+msgstr "Kör om Intro"
+
+#: Source/DiabloUI/extrasmenu.cpp:45
+msgid "Support"
+msgstr "Support"
+
+#: Source/DiabloUI/extrasmenu.cpp:46 Source/gamemenu.cpp:61
+msgid "Previous Menu"
+msgstr "Föregående Meny"
 
 #: Source/DiabloUI/mainmenu.cpp:36
 msgid "Single Player"
@@ -328,293 +363,301 @@ msgid "Multi Player"
 msgstr "Flera Spelare"
 
 #: Source/DiabloUI/mainmenu.cpp:38
-msgid "Replay Intro"
-msgstr "Kör om Intro"
+#, fuzzy
+#| msgid "Extra charges"
+msgid "Extras"
+msgstr "Extra laddningar"
 
 #: Source/DiabloUI/mainmenu.cpp:39
-msgid "Support"
-msgstr "Support"
-
-#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Show Credits"
 msgstr "Visa Spelskapare"
 
-#: Source/DiabloUI/mainmenu.cpp:41
+#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Exit Hellfire"
 msgstr "Avsluta Hellfire"
 
-#: Source/DiabloUI/mainmenu.cpp:41
+#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Exit Diablo"
 msgstr "Avsluta Diablo"
 
-#. TRANSLATORS:  Error Message when a Shareware User clicks on "Replay Intro" in the Main Menu
-#: Source/DiabloUI/mainmenu.cpp:99
-msgid ""
-"The Diablo introduction cinematic is only available in the full retail "
-"version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
-msgstr ""
-"Introduktionsvideon finns endast tillgänglig i den kompletta versionen av "
-"Diablo. Besök https://www.gog.com/game/diablo för att köpa."
+#: Source/DiabloUI/mainmenu.cpp:55
+#, fuzzy
+#| msgid "in the shareware"
+msgid "Shareware"
+msgstr "i shareware"
 
-#: Source/DiabloUI/progress.cpp:48 Source/DiabloUI/selconn.cpp:76
-#: Source/DiabloUI/selhero.cpp:188 Source/DiabloUI/selhero.cpp:213
-#: Source/DiabloUI/selhero.cpp:283 Source/DiabloUI/selhero.cpp:533
+#: Source/DiabloUI/progress.cpp:36 Source/DiabloUI/selconn.cpp:82
+#: Source/DiabloUI/selhero.cpp:189 Source/DiabloUI/selhero.cpp:214
+#: Source/DiabloUI/selhero.cpp:284 Source/DiabloUI/selhero.cpp:544
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: Source/DiabloUI/selconn.cpp:38 Source/DiabloUI/selgame.cpp:77
-#: Source/DiabloUI/selgame.cpp:372
+#: Source/DiabloUI/selconn.cpp:13
 msgid "Client-Server (TCP)"
 msgstr ""
 
-#: Source/DiabloUI/selconn.cpp:41
+#: Source/DiabloUI/selconn.cpp:14
 msgid "Loopback"
 msgstr ""
 
-#: Source/DiabloUI/selconn.cpp:47 Source/DiabloUI/selgame.cpp:434
-#: Source/DiabloUI/selgame.cpp:452
+#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:489
+#: Source/DiabloUI/selgame.cpp:510
 msgid "Multi Player Game"
 msgstr "Flerapelarsspel"
 
-#: Source/DiabloUI/selconn.cpp:53
+#: Source/DiabloUI/selconn.cpp:59
 msgid "Requirements:"
 msgstr ""
 
-#: Source/DiabloUI/selconn.cpp:59
+#: Source/DiabloUI/selconn.cpp:65
 msgid "no gateway needed"
 msgstr ""
 
-#: Source/DiabloUI/selconn.cpp:65
+#: Source/DiabloUI/selconn.cpp:71
 msgid "Select Connection"
 msgstr ""
 
-#: Source/DiabloUI/selconn.cpp:68
+#: Source/DiabloUI/selconn.cpp:74
 msgid "Change Gateway"
 msgstr ""
 
-#: Source/DiabloUI/selconn.cpp:101
+#: Source/DiabloUI/selconn.cpp:107
 msgid "All computers must be connected to a TCP-compatible network."
 msgstr ""
 
-#: Source/DiabloUI/selconn.cpp:105
+#: Source/DiabloUI/selconn.cpp:111
 msgid "All computers must be connected to the internet."
 msgstr ""
 
-#: Source/DiabloUI/selconn.cpp:109
+#: Source/DiabloUI/selconn.cpp:115
 msgid "Play by yourself with no network exposure."
 msgstr ""
 
-#: Source/DiabloUI/selconn.cpp:114
+#: Source/DiabloUI/selconn.cpp:120
 msgid "Players Supported: {:d}"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:80 Source/DiabloUI/selgame.cpp:375
+#: Source/DiabloUI/selgame.cpp:82 Source/DiabloUI/selgame.cpp:414
 msgid "Description:"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:86
+#: Source/DiabloUI/selgame.cpp:88
 msgid "Select Action"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:88 Source/DiabloUI/selgame.cpp:151
-#: Source/DiabloUI/selgame.cpp:295
+#: Source/DiabloUI/selgame.cpp:91 Source/DiabloUI/selgame.cpp:181
+#: Source/DiabloUI/selgame.cpp:333
 msgid "Create Game"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:89
+#: Source/DiabloUI/selgame.cpp:93
+msgid "Create Public Game"
+msgstr ""
+
+#: Source/DiabloUI/selgame.cpp:94
 msgid "Join Game"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:97 Source/DiabloUI/selgame.cpp:166
-#: Source/DiabloUI/selgame.cpp:184 Source/DiabloUI/selgame.cpp:317
-#: Source/DiabloUI/selgame.cpp:390
+#: Source/DiabloUI/selgame.cpp:106 Source/DiabloUI/selgame.cpp:196
+#: Source/DiabloUI/selgame.cpp:214 Source/DiabloUI/selgame.cpp:355
+#: Source/DiabloUI/selgame.cpp:431
 msgid "CANCEL"
 msgstr "AVBRYT"
 
-#: Source/DiabloUI/selgame.cpp:106
+#: Source/DiabloUI/selgame.cpp:122
 msgid "Create a new game with a difficulty setting of your choice."
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:109
+#: Source/DiabloUI/selgame.cpp:125
+msgid ""
+"Create a new public game that anyone can join with a difficulty setting of "
+"your choice."
+msgstr ""
+
+#: Source/DiabloUI/selgame.cpp:128
 msgid ""
 "Enter an IP or a hostname and join a game already in progress at that "
 "address."
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:154
+#: Source/DiabloUI/selgame.cpp:131
+msgid "Join the public game already in progress at this address."
+msgstr ""
+
+#: Source/DiabloUI/selgame.cpp:184
 msgid "Select Difficulty"
 msgstr "Välj Svårighetsgrad"
 
-#: Source/DiabloUI/selgame.cpp:156 Source/DiabloUI/selgame.cpp:203
-#: Source/DiabloUI/selgame.cpp:306 Source/DiabloUI/selgame.cpp:326
-#: Source/diablo.cpp:1434
+#: Source/DiabloUI/selgame.cpp:186 Source/DiabloUI/selgame.cpp:239
+#: Source/DiabloUI/selgame.cpp:344 Source/DiabloUI/selgame.cpp:364
+#: Source/diablo.cpp:1446
 msgid "Normal"
 msgstr "Normal"
 
-#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:207
-#: Source/diablo.cpp:1435
+#: Source/DiabloUI/selgame.cpp:187 Source/DiabloUI/selgame.cpp:243
+#: Source/diablo.cpp:1447
 msgid "Nightmare"
 msgstr "Mardröm"
 
-#: Source/DiabloUI/selgame.cpp:158 Source/DiabloUI/selgame.cpp:211
-#: Source/diablo.cpp:1436
+#: Source/DiabloUI/selgame.cpp:188 Source/DiabloUI/selgame.cpp:247
+#: Source/diablo.cpp:1448
 msgid "Hell"
 msgstr "Helvete"
 
-#: Source/DiabloUI/selgame.cpp:172
+#: Source/DiabloUI/selgame.cpp:202
 msgid "Join TCP Games"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:175 Source/DiabloUI/selgame.cpp:178
+#: Source/DiabloUI/selgame.cpp:205 Source/DiabloUI/selgame.cpp:208
 msgid "Enter address"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:204
+#: Source/DiabloUI/selgame.cpp:240
 msgid ""
 "Normal Difficulty\n"
 "This is where a starting character should begin the quest to defeat Diablo."
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:208
+#: Source/DiabloUI/selgame.cpp:244
 msgid ""
 "Nightmare Difficulty\n"
 "The denizens of the Labyrinth have been bolstered and will prove to be a "
 "greater challenge. This is recommended for experienced characters only."
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:212
+#: Source/DiabloUI/selgame.cpp:248
 msgid ""
 "Hell Difficulty\n"
 "The most powerful of the underworld's creatures lurk at the gateway into "
 "Hell. Only the most experienced characters should venture in this realm."
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:227
+#: Source/DiabloUI/selgame.cpp:264
 msgid ""
 "Your character must reach level 20 before you can enter a multiplayer game "
 "of Nightmare difficulty."
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:229
+#: Source/DiabloUI/selgame.cpp:266
 msgid ""
 "Your character must reach level 30 before you can enter a multiplayer game "
 "of Hell difficulty."
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:304
+#: Source/DiabloUI/selgame.cpp:342
 msgid "Select Game Speed"
 msgstr "Välj Spelhastighet"
 
-#: Source/DiabloUI/selgame.cpp:307 Source/DiabloUI/selgame.cpp:330
+#: Source/DiabloUI/selgame.cpp:345 Source/DiabloUI/selgame.cpp:368
 msgid "Fast"
 msgstr "Snabb"
 
-#: Source/DiabloUI/selgame.cpp:308 Source/DiabloUI/selgame.cpp:334
+#: Source/DiabloUI/selgame.cpp:346 Source/DiabloUI/selgame.cpp:372
 msgid "Faster"
 msgstr "Snabbare"
 
-#: Source/DiabloUI/selgame.cpp:309 Source/DiabloUI/selgame.cpp:338
+#: Source/DiabloUI/selgame.cpp:347 Source/DiabloUI/selgame.cpp:376
 msgid "Fastest"
 msgstr "Snabbast"
 
-#: Source/DiabloUI/selgame.cpp:327
+#: Source/DiabloUI/selgame.cpp:365
 msgid ""
 "Normal Speed\n"
 "This is where a starting character should begin the quest to defeat Diablo."
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:331
+#: Source/DiabloUI/selgame.cpp:369
 msgid ""
 "Fast Speed\n"
 "The denizens of the Labyrinth have been hastened and will prove to be a "
 "greater challenge. This is recommended for experienced characters only."
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:335
+#: Source/DiabloUI/selgame.cpp:373
 msgid ""
 "Faster Speed\n"
 "Most monsters of the dungeon will seek you out quicker than ever before. "
 "Only an experienced champion should try their luck at this speed."
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:339
+#: Source/DiabloUI/selgame.cpp:377
 msgid ""
 "Fastest Speed\n"
 "The minions of the underworld will rush to attack without hesitation. Only a "
 "true speed demon should enter at this pace."
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:381 Source/DiabloUI/selgame.cpp:384
+#: Source/DiabloUI/selgame.cpp:420 Source/DiabloUI/selgame.cpp:425
 msgid "Enter Password"
 msgstr ""
 
-#: Source/DiabloUI/selgame.cpp:407
+#: Source/DiabloUI/selgame.cpp:448
 msgid "The host is running a different game than you."
 msgstr ""
 
 #. TRANSLATORS: Error message when somebody tries to join a game running another version.
-#: Source/DiabloUI/selgame.cpp:410
+#: Source/DiabloUI/selgame.cpp:451
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr ""
 
-#: Source/DiabloUI/selhero.cpp:99
+#: Source/DiabloUI/selhero.cpp:100
 msgid "New Hero"
 msgstr "Ny Hjälte"
 
-#: Source/DiabloUI/selhero.cpp:163
+#: Source/DiabloUI/selhero.cpp:164
 msgid "Choose Class"
 msgstr "Välj Klass"
 
-#: Source/DiabloUI/selhero.cpp:167 Source/panels/charpanel.cpp:22
+#: Source/DiabloUI/selhero.cpp:168 Source/panels/charpanel.cpp:22
 msgid "Warrior"
 msgstr "Krigare"
 
-#: Source/DiabloUI/selhero.cpp:168 Source/panels/charpanel.cpp:23
+#: Source/DiabloUI/selhero.cpp:169 Source/panels/charpanel.cpp:23
 msgid "Rogue"
 msgstr "Rövare"
 
-#: Source/DiabloUI/selhero.cpp:169 Source/panels/charpanel.cpp:24
+#: Source/DiabloUI/selhero.cpp:170 Source/panels/charpanel.cpp:24
 msgid "Sorcerer"
 msgstr "Besvärjare"
 
-#: Source/DiabloUI/selhero.cpp:171 Source/panels/charpanel.cpp:25
+#: Source/DiabloUI/selhero.cpp:172 Source/panels/charpanel.cpp:25
 msgid "Monk"
 msgstr "Munk"
 
-#: Source/DiabloUI/selhero.cpp:174 Source/panels/charpanel.cpp:26
+#: Source/DiabloUI/selhero.cpp:175 Source/panels/charpanel.cpp:26
 msgid "Bard"
 msgstr "Skald"
 
-#: Source/DiabloUI/selhero.cpp:177 Source/panels/charpanel.cpp:27
+#: Source/DiabloUI/selhero.cpp:178 Source/panels/charpanel.cpp:27
 msgid "Barbarian"
 msgstr "Barbar"
 
-#: Source/DiabloUI/selhero.cpp:194 Source/DiabloUI/selhero.cpp:268
+#: Source/DiabloUI/selhero.cpp:195 Source/DiabloUI/selhero.cpp:269
 msgid "New Multi Player Hero"
 msgstr "Ny Flerspelarhjälte"
 
-#: Source/DiabloUI/selhero.cpp:194 Source/DiabloUI/selhero.cpp:268
+#: Source/DiabloUI/selhero.cpp:195 Source/DiabloUI/selhero.cpp:269
 msgid "New Single Player Hero"
 msgstr "Ny Enspelarhjälte"
 
-#: Source/DiabloUI/selhero.cpp:202
+#: Source/DiabloUI/selhero.cpp:203
 msgid "Save File Exists"
 msgstr "Sparad Fil Finns"
 
-#: Source/DiabloUI/selhero.cpp:205 Source/gamemenu.cpp:38
+#: Source/DiabloUI/selhero.cpp:206 Source/gamemenu.cpp:38
 msgid "Load Game"
 msgstr "Ladda Spel"
 
-#: Source/DiabloUI/selhero.cpp:206 Source/gamemenu.cpp:37
+#: Source/DiabloUI/selhero.cpp:207 Source/gamemenu.cpp:37
 #: Source/gamemenu.cpp:48
 msgid "New Game"
 msgstr "Nytt Spel"
 
-#: Source/DiabloUI/selhero.cpp:216 Source/DiabloUI/selhero.cpp:540
+#: Source/DiabloUI/selhero.cpp:217 Source/DiabloUI/selhero.cpp:551
 msgid "Single Player Characters"
 msgstr "Enspelarkaraktärer"
 
-#: Source/DiabloUI/selhero.cpp:262
+#: Source/DiabloUI/selhero.cpp:263
 msgid ""
 "The Rogue and Sorcerer are only available in the full retail version of "
 "Diablo. Visit https://www.gog.com/game/diablo to purchase."
@@ -622,11 +665,11 @@ msgstr ""
 "Rövaren och Besvärjaren finns endast tillgängliga i den kompletta versionen "
 "av Diablo. Besök https://www.gog.com/game/diablo för att köpa."
 
-#: Source/DiabloUI/selhero.cpp:274 Source/DiabloUI/selhero.cpp:277
+#: Source/DiabloUI/selhero.cpp:275 Source/DiabloUI/selhero.cpp:278
 msgid "Enter Name"
 msgstr "Skriv In Namn"
 
-#: Source/DiabloUI/selhero.cpp:306
+#: Source/DiabloUI/selhero.cpp:307
 msgid ""
 "Invalid name. A name cannot contain spaces, reserved characters, or reserved "
 "words.\n"
@@ -635,336 +678,343 @@ msgstr ""
 "eller reserverade ord.\n"
 
 #. TRANSLATORS: Error Message
-#: Source/DiabloUI/selhero.cpp:313
+#: Source/DiabloUI/selhero.cpp:314
 msgid "Unable to create character."
 msgstr "Kunde inte skapa karaktären."
 
-#: Source/DiabloUI/selhero.cpp:467 Source/DiabloUI/selhero.cpp:470
+#: Source/DiabloUI/selhero.cpp:468 Source/DiabloUI/selhero.cpp:471
 msgid "Level:"
 msgstr "Nivå:"
 
-#: Source/DiabloUI/selhero.cpp:475
+#: Source/DiabloUI/selhero.cpp:476
 msgid "Strength:"
 msgstr "Styrka:"
 
-#: Source/DiabloUI/selhero.cpp:480
+#: Source/DiabloUI/selhero.cpp:481
 msgid "Magic:"
 msgstr "Magi:"
 
-#: Source/DiabloUI/selhero.cpp:485
+#: Source/DiabloUI/selhero.cpp:486
 msgid "Dexterity:"
 msgstr "Smidighet:"
 
-#: Source/DiabloUI/selhero.cpp:490
+#: Source/DiabloUI/selhero.cpp:491
 msgid "Vitality:"
 msgstr "Kropp:"
 
-#: Source/DiabloUI/selhero.cpp:496
+#: Source/DiabloUI/selhero.cpp:497
 msgid "Savegame:"
 msgstr "Sparat spel:"
 
-#: Source/DiabloUI/selhero.cpp:508
+#: Source/DiabloUI/selhero.cpp:510
 msgid "Select Hero"
 msgstr "Välj Hjälte"
 
-#: Source/DiabloUI/selhero.cpp:528
+#: Source/DiabloUI/selhero.cpp:539
 msgid "Delete"
 msgstr "Ta Bort"
 
-#: Source/DiabloUI/selhero.cpp:538
+#: Source/DiabloUI/selhero.cpp:549
 msgid "Multi Player Characters"
 msgstr "Flerspelarkaraktärer"
 
-#: Source/DiabloUI/selhero.cpp:580
+#: Source/DiabloUI/selhero.cpp:599
 msgid "Delete Multi Player Hero"
 msgstr "Ta Bort Flerspelarhjälte"
 
-#: Source/DiabloUI/selhero.cpp:582
+#: Source/DiabloUI/selhero.cpp:601
 msgid "Delete Single Player Hero"
 msgstr "Ta Bort Enspelarhjälte"
 
-#: Source/DiabloUI/selhero.cpp:584
+#: Source/DiabloUI/selhero.cpp:603
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "Är du säker att du vill ta bort karaktären \"{:s}\"?"
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selstart.cpp:43
+#, fuzzy
+#| msgid "Exit Hellfire"
+msgid "Enter Hellfire"
+msgstr "Avsluta Hellfire"
+
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr "Ja"
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr "Nej"
 
 #: Source/DiabloUI/support_lines.cpp:8
-msgid "GOG.com maintains a web site at https://www.gog.com/forum/diablo"
-msgstr "GOG.com har en webbsida på https://www.gog.com/forum/diablo"
-
-#: Source/DiabloUI/support_lines.cpp:9
-msgid "Follow the links to visit the discussion boards associated with Diablo."
-msgstr "Följ länkarna för att besöka diskussionsforumen som rör Diablo."
+msgid ""
+"We maintain a chat server at Discord.gg/YQKCAYQ Follow the links to join our "
+"community where we talk about things related to Diablo, and the Hellfire "
+"expansion."
+msgstr ""
 
 #: Source/DiabloUI/support_lines.cpp:10
-msgid "and the Hellfire expansion."
-msgstr "och Hellfire-expansionen."
-
-#: Source/DiabloUI/support_lines.cpp:12
 msgid ""
-"DevilutionX is maintained by Diasurgical, issues and bugs can be reported"
+"DevilutionX is maintained by Diasurgical, issues and bugs can be reported at "
+"this address: https://github.com/diasurgical/devilutionX To help us better "
+"serve you, please be sure to include the version number, operating system, "
+"and the nature of the problem."
 msgstr ""
 
 #: Source/DiabloUI/support_lines.cpp:13
-msgid "at this address: https://github.com/diasurgical/devilutionX"
+msgid "Disclaimer:"
 msgstr ""
 
 #: Source/DiabloUI/support_lines.cpp:14
 msgid ""
-"To help us better serve you, please be sure to include the version number,"
+"\tDevilutionX is not supported or maintained by Blizzard Entertainment, nor "
+"GOG.com. Neither Blizzard Entertainment nor GOG.com has tested or certified "
+"the quality or compatibility of DevilutionX. All inquiries regarding "
+"DevilutionX should be directed to Diasurgical, not to Blizzard Entertainment "
+"or GOG.com."
 msgstr ""
 
-#: Source/DiabloUI/support_lines.cpp:15
-msgid "operating system, and the nature of the problem."
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:18
-msgid "Disclaimer:"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:19
-msgid "  DevilutionX is not supported or maintained by Blizzard Entertainment,"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:20
-msgid "  nor GOG.com. Neither Blizzard Entertainment nor GOG.com has tested"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:21
+#: Source/DiabloUI/support_lines.cpp:17
 msgid ""
-"  or certified the quality or compatibility of DevilutionX. All inquiries"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:22
-msgid ""
-"  regarding DevilutionX should be directed to Diasurgical, not to Blizzard"
-msgstr ""
-
-#: Source/DiabloUI/support_lines.cpp:23
-msgid "  Entertainment or GOG.com."
+"\tThis port makes use of CharisSILB, Unifont, and Noto which are licensed "
+"under the SIL Open Font License, as well as Twitmoji which is licensed under "
+"CC-BY 4.0. The port also makes use of SDL which is licensed under the zlib-"
+"license. See the ReadMe for further details."
 msgstr ""
 
 #: Source/DiabloUI/title.cpp:44
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr ""
 
-#: Source/appfat.cpp:37
+#: Source/appfat.cpp:38
 msgid "Error"
 msgstr ""
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:101
+#: Source/appfat.cpp:102
 msgid ""
 "{:s}\n"
 "\n"
 "The error occurred at: {:s} line {:d}"
 msgstr ""
 
-#: Source/appfat.cpp:115
+#: Source/appfat.cpp:117
 msgid ""
 "Unable to open main data archive ({:s}).\n"
 "\n"
 "Make sure that it is in the game folder."
 msgstr ""
 
-msgid "diabdat.mpq or spawn.mpq"
-msgstr "diabdat.mpq eller spawn.mpq"
-
-#: Source/appfat.cpp:119
+#: Source/appfat.cpp:123
 msgid "Data File Error"
 msgstr ""
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:127
+#: Source/appfat.cpp:131
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
 msgstr ""
 
-#: Source/appfat.cpp:129
+#: Source/appfat.cpp:133
 msgid "Read-Only Directory Error"
 msgstr ""
 
-#: Source/automap.cpp:468
+#: Source/automap.cpp:484
 msgid "game: "
 msgstr "spel: "
 
-#: Source/automap.cpp:474
+#: Source/automap.cpp:490
 msgid "password: "
 msgstr "lösenord: "
 
-#: Source/automap.cpp:487
+#: Source/automap.cpp:492
+#, fuzzy
+#| msgid "Quit Game"
+msgid "Public Game"
+msgstr "Avsluta Spel"
+
+#: Source/automap.cpp:504
 msgid "Level: Nest {:d}"
 msgstr "Nivå: Näste {:d}"
 
-#: Source/automap.cpp:489
+#: Source/automap.cpp:506
 msgid "Level: Crypt {:d}"
 msgstr "Nivå: Krypta {:d}"
 
-#: Source/automap.cpp:491 Source/items.cpp:2086
+#: Source/automap.cpp:508 Source/items.cpp:2090
 msgid "Level: {:d}"
 msgstr "Nivå: {:d}"
 
-#: Source/control.cpp:196
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr "Tab"
 
-#: Source/control.cpp:196
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr "Esc"
 
-#: Source/control.cpp:196
+#: Source/control.cpp:212
 msgid "Enter"
 msgstr "Enter"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:215
 msgid "Character Information"
 msgstr "Karaktärsinformation"
 
-#: Source/control.cpp:200
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr "Uppdragslogg"
 
-#: Source/control.cpp:201
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr "Autokarta"
 
-#: Source/control.cpp:202
+#: Source/control.cpp:218
 msgid "Main Menu"
 msgstr "Huvudmeny"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr "Ägodelar"
 
-#: Source/control.cpp:204
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr "Magibok"
 
-#: Source/control.cpp:205
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr "Skicka Meddelande"
 
-#: Source/control.cpp:712 Source/control.cpp:1175
+#: Source/control.cpp:718 Source/control.cpp:1587
+msgid "Skill"
+msgstr "Färdighet"
+
+#: Source/control.cpp:719 Source/control.cpp:1237
 msgid "{:s} Skill"
 msgstr "{:s} Färdighet"
 
-#: Source/control.cpp:716 Source/control.cpp:1179
+#: Source/control.cpp:725
+#, fuzzy
+#| msgid "Spells"
+msgid "Spell"
+msgstr "Magi"
+
+#: Source/control.cpp:726 Source/control.cpp:1241
 msgid "{:s} Spell"
 msgstr "{:s} Trollformel"
 
-#: Source/control.cpp:718
+#: Source/control.cpp:728
 msgid "Damages undead only"
 msgstr "Skadar endast vandöda"
 
-#: Source/control.cpp:722 Source/control.cpp:1183 Source/control.cpp:1554
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr "Trollformelsnivå 0 - Oanvändbar"
 
-#: Source/control.cpp:724 Source/control.cpp:1185 Source/control.cpp:1556
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 msgid "Spell Level {:d}"
 msgstr "Trollformelsnivå {:d}"
 
-#: Source/control.cpp:729 Source/control.cpp:1189
+#: Source/control.cpp:741
+#, fuzzy
+#| msgid "{:d} Scroll"
+#| msgid_plural "{:d} Scrolls"
+msgid "Scroll"
+msgstr "{:d}-Skriftrulle"
+
+#: Source/control.cpp:742 Source/control.cpp:1251
 msgid "Scroll of {:s}"
 msgstr "Skriftrulle med {:s}"
 
-#: Source/control.cpp:745 Source/control.cpp:1206
+#: Source/control.cpp:747 Source/control.cpp:1257
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "{:d}-Skriftrulle"
 msgstr[1] "{:d}-Skriftrullar"
 
-#: Source/control.cpp:750 Source/control.cpp:1210 Source/items.cpp:1325
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
+msgid "Staff"
+msgstr "Stav"
+
+#: Source/control.cpp:755 Source/control.cpp:1261
 msgid "Staff of {:s}"
 msgstr "Stav med {:s}"
 
-#: Source/control.cpp:752 Source/control.cpp:1212
+#: Source/control.cpp:757 Source/control.cpp:1263
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "{:d} Laddning"
 msgstr[1] "{:d} Laddningar"
 
-#: Source/control.cpp:762
+#: Source/control.cpp:767
 msgid "Spell Hotkey {:s}"
 msgstr "Trollformelsgenväg {:s}"
 
-#: Source/control.cpp:1152
+#: Source/control.cpp:1214
 msgid "Player friendly"
 msgstr "Spelarvänlig"
 
-#: Source/control.cpp:1154
+#: Source/control.cpp:1216
 msgid "Player attack"
 msgstr "Spelaranfall"
 
-#: Source/control.cpp:1157
+#: Source/control.cpp:1219
 msgid "Hotkey: {:s}"
 msgstr "Genväg: {:s}"
 
-#: Source/control.cpp:1165
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr "Välj nuvarande trollformelsknapp"
 
-#: Source/control.cpp:1168
+#: Source/control.cpp:1230
 msgid "Hotkey: 's'"
 msgstr "Genväg: 's'"
 
-#: Source/control.cpp:1334 Source/inv.cpp:1893 Source/items.cpp:3751
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "{:d} guldmynt"
 msgstr[1] "{:d} guldmynt"
 
-#: Source/control.cpp:1337
+#: Source/control.cpp:1390
 msgid "Requirements not met"
 msgstr "Kraven uppnås ej"
 
-#: Source/control.cpp:1373
+#: Source/control.cpp:1426
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Nivå: {:d}"
 
-#: Source/control.cpp:1375
+#: Source/control.cpp:1428
 msgid "Hit Points {:d} of {:d}"
 msgstr "Kroppspoäng {:d} av {:d}"
 
-#: Source/control.cpp:1402
+#: Source/control.cpp:1457
 msgid "Level Up"
 msgstr "Nivåökning"
 
-#: Source/control.cpp:1532
-msgid "Skill"
-msgstr "Färdighet"
-
-#: Source/control.cpp:1536
+#: Source/control.cpp:1591
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] "Stav ({:d} laddning)"
 msgstr[1] "Stav ({:d} laddningar)"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1544
+#: Source/control.cpp:1601
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "Mana: {:d}  Skada: {:d} - {:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1546
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "Mana: {:d}   Skada: ej aktuellt"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1549
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "Mana: {:d}  Skada: 1/3 målets KP"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1606
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] "Du har {:d} guldmynt. Hur många vill du dra ifrån?"
@@ -1014,104 +1064,113 @@ msgstr "Det Oheliga Altaret"
 msgid "level 15"
 msgstr "nivå 15"
 
-#: Source/diablo.cpp:111
+#: Source/diablo.cpp:114
 msgid "I need help! Come Here!"
 msgstr ""
 
-#: Source/diablo.cpp:112
+#: Source/diablo.cpp:115
 msgid "Follow me."
 msgstr ""
 
-#: Source/diablo.cpp:113
+#: Source/diablo.cpp:116
 msgid "Here's something for you."
 msgstr ""
 
-#: Source/diablo.cpp:114
+#: Source/diablo.cpp:117
 msgid "Now you DIE!"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:777
+#: Source/diablo.cpp:781
 msgid "Options:\n"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:778
+#: Source/diablo.cpp:782
 msgid "Print this message and exit"
 msgstr "Skriv detta meddelande och avsluta"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:779
+#: Source/diablo.cpp:783
 msgid "Print the version and exit"
 msgstr "Skriv ut version och avsluta"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:780
+#: Source/diablo.cpp:784
 msgid "Specify the folder of diabdat.mpq"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:781
+#: Source/diablo.cpp:785
 msgid "Specify the folder of save files"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:782
+#: Source/diablo.cpp:786
 msgid "Specify the location of diablo.ini"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:783
-msgid "Specify the location of the .ttf font"
-msgstr ""
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:784
-msgid "Specify the name of a custom .ttf font"
-msgstr ""
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:785
+#: Source/diablo.cpp:787
 msgid "Skip startup videos"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:786
+#: Source/diablo.cpp:788
 msgid "Display frames per second"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:787
+#: Source/diablo.cpp:789
 msgid "Run in windowed mode"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:788
+#: Source/diablo.cpp:790
 msgid "Enable verbose logging"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:789
-msgid "Force spawn mode even if diabdat.mpq is found"
-msgstr ""
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:790
+#: Source/diablo.cpp:791
 msgid "Record a demo file"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:791
+#: Source/diablo.cpp:792
 msgid "Play a demo file"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:792
+#: Source/diablo.cpp:793
 msgid "Disable all frame limiting during demo playback"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:793
+#: Source/diablo.cpp:794
+msgid ""
+"\n"
+"Game selection:\n"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:795
+msgid "Force Shareware mode"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:796
+msgid "Force Diablo mode"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:797
+#, fuzzy
+#| msgid "Hellfire Help"
+msgid "Force Hellfire mode"
+msgstr "Hellfire-Hjälp"
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:798
 msgid ""
 "\n"
 "Hellfire options:\n"
@@ -1120,16 +1179,11 @@ msgstr ""
 "Hellfire-alternativ:\n"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:794
-msgid "Force diablo mode even if hellfire.mpq is found"
-msgstr ""
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:795
+#: Source/diablo.cpp:799
 msgid "Use alternate nest palette"
 msgstr ""
 
-#: Source/diablo.cpp:801
+#: Source/diablo.cpp:805
 msgid ""
 "\n"
 "Report bugs at https://github.com/diasurgical/devilutionX/\n"
@@ -1143,292 +1197,292 @@ msgstr ""
 msgid "version {:s}"
 msgstr ""
 
-#: Source/diablo.cpp:1206
+#: Source/diablo.cpp:1218
 msgid "-- Network timeout --"
 msgstr ""
 
-#: Source/diablo.cpp:1207
+#: Source/diablo.cpp:1219
 msgid "-- Waiting for players --"
 msgstr ""
 
-#: Source/diablo.cpp:1226
+#: Source/diablo.cpp:1238
 msgid "No help available"
 msgstr ""
 
-#: Source/diablo.cpp:1227
+#: Source/diablo.cpp:1239
 msgid "while in stores"
 msgstr ""
 
 #. TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty.
-#: Source/diablo.cpp:1439
+#: Source/diablo.cpp:1451
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr ""
 
-#: Source/dvlnet/loopback.cpp:111
+#: Source/dvlnet/loopback.cpp:113
 msgid "loopback"
 msgstr ""
 
-#: Source/dvlnet/tcp_client.cpp:68
+#: Source/dvlnet/tcp_client.cpp:65
 msgid "Unable to connect"
 msgstr ""
 
-#: Source/dvlnet/tcp_client.cpp:89
+#: Source/dvlnet/tcp_client.cpp:86
 msgid "error: read 0 bytes from server"
 msgstr ""
 
-#: Source/error.cpp:58
+#: Source/error.cpp:57
 msgid "No automap available in town"
 msgstr ""
 
-#: Source/error.cpp:59
+#: Source/error.cpp:58
 msgid "No multiplayer functions in demo"
 msgstr ""
 
-#: Source/error.cpp:60
+#: Source/error.cpp:59
 msgid "Direct Sound Creation Failed"
 msgstr ""
 
-#: Source/error.cpp:61
+#: Source/error.cpp:60
 msgid "Not available in shareware version"
 msgstr ""
 
-#: Source/error.cpp:62
+#: Source/error.cpp:61
 msgid "Not enough space to save"
 msgstr ""
 
-#: Source/error.cpp:63
+#: Source/error.cpp:62
 msgid "No Pause in town"
 msgstr ""
 
-#: Source/error.cpp:64
+#: Source/error.cpp:63
 msgid "Copying to a hard disk is recommended"
 msgstr ""
 
-#: Source/error.cpp:65
+#: Source/error.cpp:64
 msgid "Multiplayer sync problem"
 msgstr ""
 
-#: Source/error.cpp:66
+#: Source/error.cpp:65
 msgid "No pause in multiplayer"
 msgstr ""
 
-#: Source/error.cpp:67
+#: Source/error.cpp:66
 msgid "Loading..."
 msgstr "Laddar..."
 
-#: Source/error.cpp:68
+#: Source/error.cpp:67
 msgid "Saving..."
 msgstr "Sparar..."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:69
+#: Source/error.cpp:68
 msgid "Some are weakened as one grows strong"
 msgstr "Vissa försvagas medan en stärks"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:70
+#: Source/error.cpp:69
 msgid "New strength is forged through destruction"
 msgstr "Ny styrka byggs genom förstörelse"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:71
+#: Source/error.cpp:70
 msgid "Those who defend seldom attack"
 msgstr "De som försvarar anfaller sällan"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:72
+#: Source/error.cpp:71
 msgid "The sword of justice is swift and sharp"
 msgstr "Rättvisans svärd är skarpt och kvickt"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:73
+#: Source/error.cpp:72
 msgid "While the spirit is vigilant the body thrives"
 msgstr "Medan själen vakar når kroppen välmående"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:74
+#: Source/error.cpp:73
 msgid "The powers of mana refocused renews"
 msgstr "Den refokuserade manans kraft förnyar"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:75
+#: Source/error.cpp:74
 msgid "Time cannot diminish the power of steel"
 msgstr "Tiden kan inte minska stålets kraft"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:76
+#: Source/error.cpp:75
 msgid "Magic is not always what it seems to be"
 msgstr "Trolldom är inte alltid som det verkar"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:77
+#: Source/error.cpp:76
 msgid "What once was opened now is closed"
 msgstr "Vad som en gång öppnats är nu stängt"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:78
+#: Source/error.cpp:77
 msgid "Intensity comes at the cost of wisdom"
 msgstr "Intensitet fås till priset av vishet"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:79
+#: Source/error.cpp:78
 msgid "Arcane power brings destruction"
 msgstr "Mystisk kraft förödar"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:80
+#: Source/error.cpp:79
 msgid "That which cannot be held cannot be harmed"
 msgstr "Det som inte kan hållas kan inte skadas"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:81
+#: Source/error.cpp:80
 msgid "Crimson and Azure become as the sun"
 msgstr "Blod och Himmel blir som solen"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:82
+#: Source/error.cpp:81
 msgid "Knowledge and wisdom at the cost of self"
 msgstr "Kunskap och vishet på ens egen bekostnad"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:83
+#: Source/error.cpp:82
 msgid "Drink and be refreshed"
 msgstr "Drick och bli vederkvickad"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:84
+#: Source/error.cpp:83
 msgid "Wherever you go, there you are"
 msgstr "Vart du än färdas, är var du befinner dig"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:85
+#: Source/error.cpp:84
 msgid "Energy comes at the cost of wisdom"
 msgstr "Energi fås till priset av vishet"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:86
+#: Source/error.cpp:85
 msgid "Riches abound when least expected"
 msgstr "Rikedomar möts när de är minst anade"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:87
+#: Source/error.cpp:86
 msgid "Where avarice fails, patience gains reward"
 msgstr "Där snålhet misslyckas, får tålmodigheten sin belöning"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:88
+#: Source/error.cpp:87
 msgid "Blessed by a benevolent companion!"
 msgstr "Välsignad av en välvillig följeslagare!"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:89
+#: Source/error.cpp:88
 msgid "The hands of men may be guided by fate"
 msgstr "Människornas händer kan styras av ödet"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:90
+#: Source/error.cpp:89
 msgid "Strength is bolstered by heavenly faith"
 msgstr "Styrkan stöds av himmelsk tro"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:91
+#: Source/error.cpp:90
 msgid "The essence of life flows from within"
 msgstr "Livets essens flödar inifrån"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:92
+#: Source/error.cpp:91
 msgid "The way is made clear when viewed from above"
 msgstr "Vägen är tydlig när man ser den från ovan"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:93
+#: Source/error.cpp:92
 msgid "Salvation comes at the cost of wisdom"
 msgstr "Frälsning fås till priset av vishet"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:94
+#: Source/error.cpp:93
 msgid "Mysteries are revealed in the light of reason"
 msgstr "Mysterier avslöjas i förnuftets ljus"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:95
+#: Source/error.cpp:94
 msgid "Those who are last may yet be first"
 msgstr "De sista kan ännu bli de första"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:96
+#: Source/error.cpp:95
 msgid "Generosity brings its own rewards"
 msgstr "Generositet ger sina egna belöningar"
 
-#: Source/error.cpp:97
+#: Source/error.cpp:96
 msgid "You must be at least level 8 to use this."
 msgstr "Du måste vara minst nivå 8 för att använda detta."
 
-#: Source/error.cpp:98
+#: Source/error.cpp:97
 msgid "You must be at least level 13 to use this."
 msgstr "Du måste vara minst nivå 13 för att använda detta."
 
-#: Source/error.cpp:99
+#: Source/error.cpp:98
 msgid "You must be at least level 17 to use this."
 msgstr "Du måste vara minst nivå 17 för att använda detta."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:100
+#: Source/error.cpp:99
 msgid "Arcane knowledge gained!"
 msgstr "Mystisk kunskap erhållen!"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:101
+#: Source/error.cpp:100
 msgid "That which does not kill you..."
 msgstr "Det som inte dödar..."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:102
+#: Source/error.cpp:101
 msgid "Knowledge is power."
 msgstr "Kunskap är makt."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:103
+#: Source/error.cpp:102
 msgid "Give and you shall receive."
 msgstr "Ge och du skall få."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:104
+#: Source/error.cpp:103
 msgid "Some experience is gained by touch."
 msgstr "En del erfarenhet fås genom beröring."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:105
+#: Source/error.cpp:104
 msgid "There's no place like home."
 msgstr "Hem ljuva hem."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:106
+#: Source/error.cpp:105
 msgid "Spiritual energy is restored."
 msgstr "Själens energi återhämtas."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:107
+#: Source/error.cpp:106
 msgid "You feel more agile."
 msgstr "Du känner dig spänstigare."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:108
+#: Source/error.cpp:107
 msgid "You feel stronger."
 msgstr "Du känner dig starkare."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:109
+#: Source/error.cpp:108
 msgid "You feel wiser."
 msgstr "Du känner dig visare."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:110
+#: Source/error.cpp:109
 msgid "You feel refreshed."
 msgstr "Du känner dig vederkvickt."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:111
+#: Source/error.cpp:110
 msgid "That which can break will."
 msgstr "Det som kan gå sönder kommer göra det."
 
@@ -1455,10 +1509,6 @@ msgstr "Gamma"
 #: Source/gamemenu.cpp:60 Source/gamemenu.cpp:167
 msgid "Speed"
 msgstr "Hastighet"
-
-#: Source/gamemenu.cpp:61
-msgid "Previous Menu"
-msgstr "Föregående Meny"
 
 #: Source/gamemenu.cpp:68
 msgid "Music Disabled"
@@ -1635,7 +1685,9 @@ msgstr ""
 "föremålet."
 
 #: Source/help.cpp:68
-msgid "$Gold"
+#, fuzzy
+#| msgid "$Gold"
+msgid "$Gold:"
 msgstr "$Guld"
 
 #: Source/help.cpp:69
@@ -1665,7 +1717,9 @@ msgstr ""
 "att högerklicka i spelområdet."
 
 #: Source/help.cpp:79
-msgid "$Using the Speedbook for Spells"
+#, fuzzy
+#| msgid "$Using the Speedbook for Spells"
+msgid "$Using the Speedbook for Spells:"
 msgstr "$Använda Snabboken för Trollformler"
 
 #: Source/help.cpp:80
@@ -1680,15 +1734,21 @@ msgstr ""
 "högerklicka i spelområdet."
 
 #: Source/help.cpp:84
+#, fuzzy
+#| msgid ""
+#| "Shift + Left-clicking on the 'select current spell' button will clear the "
+#| "readied spell"
 msgid ""
 "Shift + Left-clicking on the 'select current spell' button will clear the "
-"readied spell"
+"readied spell."
 msgstr ""
 "Genom att hålla in Shift + vänsterklicka 'förberedd trollformel'-knappen kan "
 "den förberedda trollformeln tas bort"
 
 #: Source/help.cpp:86
-msgid "$Setting Spell Hotkeys"
+#, fuzzy
+#| msgid "$Setting Spell Hotkeys"
+msgid "$Setting Spell Hotkeys:"
 msgstr "$Ställa in Trollformelsgenvägar"
 
 #: Source/help.cpp:87
@@ -1703,7 +1763,9 @@ msgstr ""
 "vill tilldela."
 
 #: Source/help.cpp:92
-msgid "$Spell Books"
+#, fuzzy
+#| msgid "$Spell Books"
+msgid "$Spell Books:"
 msgstr "$Magiböcker"
 
 #: Source/help.cpp:93
@@ -1714,42 +1776,45 @@ msgstr ""
 "Genom att läsa mer än en bok ökar du din kunskap om den trollformen, vilket "
 "låter dig använda den med större verkan."
 
-#: Source/help.cpp:130
+#: Source/help.cpp:181
 msgid "Shareware Hellfire Help"
 msgstr "Shareware Hellfire-Hjälp"
 
-#: Source/help.cpp:130
-#| msgid "Exit Hellfire"
+#: Source/help.cpp:181
 msgid "Hellfire Help"
 msgstr "Hellfire-Hjälp"
 
-#: Source/help.cpp:132
+#: Source/help.cpp:183
 msgid "Shareware Diablo Help"
 msgstr "Shareware Diablo-Hjälp"
 
-#: Source/help.cpp:132
+#: Source/help.cpp:183
 msgid "Diablo Help"
 msgstr "Diablo-Hjälp"
 
-#: Source/help.cpp:156
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr "Tryck ESC för att avsluta och piltangenterna för att flytta."
 
-#: Source/init.cpp:214
+#: Source/init.cpp:175
+msgid "diabdat.mpq or spawn.mpq"
+msgstr "diabdat.mpq eller spawn.mpq"
+
+#: Source/init.cpp:196
 msgid "Some Hellfire MPQs are missing"
 msgstr ""
 
-#: Source/init.cpp:214
+#: Source/init.cpp:196
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
 msgstr ""
 
-#: Source/init.cpp:224
+#: Source/init.cpp:204
 msgid "Unable to create main window"
 msgstr ""
 
-#: Source/itemdat.cpp:16 Source/itemdat.cpp:198 Source/panels/charpanel.cpp:154
+#: Source/itemdat.cpp:16 Source/itemdat.cpp:198 Source/panels/charpanel.cpp:155
 msgid "Gold"
 msgstr "Guld"
 
@@ -1889,7 +1954,7 @@ msgstr "Lazarus Stav"
 msgid "Scroll of Resurrect"
 msgstr "Återuppståndelse-Skriftrulle"
 
-#: Source/itemdat.cpp:51 Source/itemdat.cpp:99 Source/items.cpp:164
+#: Source/itemdat.cpp:51 Source/itemdat.cpp:99 Source/items.cpp:166
 msgid "Blacksmith Oil"
 msgstr "Smedsolja"
 
@@ -1989,7 +2054,7 @@ msgid "Quilted Armor"
 msgstr "Vadderat Pansar"
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
-#: Source/itemdat.cpp:77 Source/objects.cpp:5459
+#: Source/itemdat.cpp:77 Source/objects.cpp:5433
 msgid "Armor"
 msgstr "Pansar"
 
@@ -2084,11 +2149,11 @@ msgstr "Återhämtningsdryck"
 msgid "Potion of Full Rejuvenation"
 msgstr "Fullkomlig Återhämtningsdryck"
 
-#: Source/itemdat.cpp:100 Source/items.cpp:159
+#: Source/itemdat.cpp:100 Source/items.cpp:161
 msgid "Oil of Accuracy"
 msgstr "Träffsäkerhetsolja"
 
-#: Source/itemdat.cpp:101 Source/items.cpp:161
+#: Source/itemdat.cpp:101 Source/items.cpp:163
 msgid "Oil of Sharpness"
 msgstr "Skärpeolja"
 
@@ -2316,11 +2381,6 @@ msgstr "Kort Krigsbåge"
 msgid "Long War Bow"
 msgstr "Lång Krigsbåge"
 
-#: Source/itemdat.cpp:167 Source/itemdat.cpp:168 Source/itemdat.cpp:169
-#: Source/itemdat.cpp:170 Source/itemdat.cpp:171
-msgid "Staff"
-msgstr "Stav"
-
 #: Source/itemdat.cpp:168
 msgid "Long Staff"
 msgstr "Långstav"
@@ -2411,7 +2471,7 @@ msgstr "Mitril"
 msgid "Meteoric"
 msgstr "Meteorisk"
 
-#: Source/itemdat.cpp:202 Source/objects.cpp:104
+#: Source/itemdat.cpp:202 Source/objects.cpp:107
 msgid "Weird"
 msgstr "Konstig"
 
@@ -2547,7 +2607,7 @@ msgstr "Hegonaktig"
 msgid "Awesome"
 msgstr "Härlig"
 
-#: Source/itemdat.cpp:237 Source/objects.cpp:116
+#: Source/itemdat.cpp:237 Source/objects.cpp:119
 msgid "Holy"
 msgstr "Helig"
 
@@ -3508,677 +3568,713 @@ msgstr "Lärjungens Amulett"
 msgid "Gladiator's Ring"
 msgstr "Gladiatorns Ring"
 
-#: Source/items.cpp:160
+#: Source/items.cpp:162
 msgid "Oil of Mastery"
 msgstr "Mästerolja"
 
-#: Source/items.cpp:162
+#: Source/items.cpp:164
 msgid "Oil of Death"
 msgstr "Dödsolja"
 
-#: Source/items.cpp:163
+#: Source/items.cpp:165
 msgid "Oil of Skill"
 msgstr "Skicklighetsolja"
 
-#: Source/items.cpp:165
+#: Source/items.cpp:167
 msgid "Oil of Fortitude"
 msgstr "Ståndaktighetsolja"
 
-#: Source/items.cpp:166
+#: Source/items.cpp:168
 msgid "Oil of Permanence"
 msgstr "Permanensolja"
 
-#: Source/items.cpp:167
+#: Source/items.cpp:169
 msgid "Oil of Hardening"
 msgstr "Härdningsolja"
 
-#: Source/items.cpp:168
+#: Source/items.cpp:170
 msgid "Oil of Imperviousness"
 msgstr "Osårbarhetsolja"
 
-#. TRANSLATORS: Constructs item names. Format: <Prefix> <Item> of <Suffix>. Example: King's Long Sword of the Whale
-#: Source/items.cpp:1194 Source/items.cpp:1262 Source/items.cpp:1281
-#: Source/items.cpp:1324
-msgid "{:s} of {:s}"
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
+#, fuzzy
+#| msgid "{:s} of {:s}"
+msgctxt "spell"
+msgid "{0} of {1}"
 msgstr "{:s} av {:s}"
 
-#: Source/items.cpp:1902 Source/items.cpp:1914
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+#, fuzzy
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} av {:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+#, fuzzy
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} av {:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
+#: Source/items.cpp:1217
+msgid "{0} {1}"
+msgstr ""
+
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
+#, fuzzy
+#| msgid "{:s} of {:s}"
+msgid "{0} of {1}"
+msgstr "{:s} av {:s}"
+
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr "ökar ett vapens"
 
-#: Source/items.cpp:1904
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr "chans att träffa"
 
-#: Source/items.cpp:1908
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr "ökar betydligt ett"
 
-#: Source/items.cpp:1910
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr "vapens chans att träffa"
 
-#: Source/items.cpp:1916
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr "skadepotential"
 
-#: Source/items.cpp:1920
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr "ökar betydligt ett vapens"
 
-#: Source/items.cpp:1922
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr "skadepotential - inte bågar"
 
-#: Source/items.cpp:1926
+#: Source/items.cpp:1930
 msgid "reduces attributes needed"
 msgstr "minskar behövda attribut"
 
-#: Source/items.cpp:1928
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr "för att använda pansar eller vapen"
 
-#: Source/items.cpp:1932
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr "återställer 20% av ett"
 
-#: Source/items.cpp:1934
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr "föremåls tålighet"
 
-#: Source/items.cpp:1938
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr "ökar ett föremåls"
 
-#: Source/items.cpp:1940
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr "nuvarande och maximala tålighet"
 
-#: Source/items.cpp:1944
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr "gör ett föremål oförstörbart"
 
-#: Source/items.cpp:1948
+#: Source/items.cpp:1952
 msgid "increases the armor class"
 msgstr "ökar pansarklassen"
 
-#: Source/items.cpp:1950
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr "för pansar och sköldar"
 
-#: Source/items.cpp:1954
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr "ökar betydlgt pansar-"
 
-#: Source/items.cpp:1956
+#: Source/items.cpp:1960
 msgid "class of armor and shields"
 msgstr "klassen för vapen och sköldar"
 
-#: Source/items.cpp:1960 Source/items.cpp:1969
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr "sätter en eldfälla"
 
-#: Source/items.cpp:1965
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr "sätter en åskfälla"
 
-#: Source/items.cpp:1973
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr "sätter en försteningsfälla"
 
-#: Source/items.cpp:1977
+#: Source/items.cpp:1981
 msgid "restore all life"
 msgstr "återställ allt liv"
 
-#: Source/items.cpp:1981
+#: Source/items.cpp:1985
 msgid "restore some life"
 msgstr "återställ en del liv"
 
-#: Source/items.cpp:1985
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr "återhämta liv"
 
-#: Source/items.cpp:1989
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr "dödlig helning"
 
-#: Source/items.cpp:1993
+#: Source/items.cpp:1997
 msgid "restore some mana"
 msgstr "återställ en del mana"
 
-#: Source/items.cpp:1997
+#: Source/items.cpp:2001
 msgid "restore all mana"
 msgstr "återställ all mana"
 
-#: Source/items.cpp:2001
+#: Source/items.cpp:2005
 msgid "increase strength"
 msgstr "öka styrka"
 
-#: Source/items.cpp:2005
+#: Source/items.cpp:2009
 msgid "increase magic"
 msgstr "öka magi"
 
-#: Source/items.cpp:2009
+#: Source/items.cpp:2013
 msgid "increase dexterity"
 msgstr "öka smidighet"
 
-#: Source/items.cpp:2013
+#: Source/items.cpp:2017
 msgid "increase vitality"
 msgstr "öka kropp"
 
-#: Source/items.cpp:2018
+#: Source/items.cpp:2022
 msgid "decrease strength"
 msgstr "minska styrka"
 
-#: Source/items.cpp:2022
+#: Source/items.cpp:2026
 msgid "decrease dexterity"
 msgstr "minska smidighet"
 
-#: Source/items.cpp:2026
+#: Source/items.cpp:2030
 msgid "decrease vitality"
 msgstr "minska kropp"
 
-#: Source/items.cpp:2030
+#: Source/items.cpp:2034
 msgid "restore some life and mana"
 msgstr "återställ en del liv och mana"
 
-#: Source/items.cpp:2034
+#: Source/items.cpp:2038
 msgid "restore all life and mana"
 msgstr "återställ allt liv och mana"
 
-#: Source/items.cpp:2049 Source/items.cpp:2074
+#: Source/items.cpp:2053 Source/items.cpp:2078
 msgid "Right-click to read"
 msgstr "Högerklicka för att läsa"
 
-#: Source/items.cpp:2053
+#: Source/items.cpp:2057
 msgid "Right-click to read, then"
 msgstr "Högerklicka för att läsa, därefter"
 
-#: Source/items.cpp:2055
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr "vänsterklicka för att ange mål"
 
-#: Source/items.cpp:2060
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr "Högerklicka för att använda"
 
-#: Source/items.cpp:2065 Source/items.cpp:2070
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr "Högerklicka för att använda"
 
-#: Source/items.cpp:2078
+#: Source/items.cpp:2082
 msgid "Right click to read"
 msgstr "Högerklicka för att läsa"
 
-#: Source/items.cpp:2082
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr "Högerklicka för att visa"
 
-#: Source/items.cpp:2090
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr "Fördubblar guldkapacitet"
 
-#: Source/items.cpp:2102 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 msgid "Required:"
 msgstr "Krävs:"
 
-#: Source/items.cpp:2104 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 msgid " {:d} Str"
 msgstr " {:d} Sty"
 
-#: Source/items.cpp:2106 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 msgid " {:d} Mag"
 msgstr " {:d} Mag"
 
-#: Source/items.cpp:2108 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 msgid " {:d} Dex"
 msgstr " {:d} Smi"
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3535 Source/player.cpp:3042
+#: Source/items.cpp:3533 Source/player.cpp:3018
 msgid "Ear of {:s}"
 msgstr "{:s}s öra"
 
-#: Source/items.cpp:3830
+#: Source/items.cpp:3828
 msgid "chance to hit: {:+d}%"
 msgstr "träffchans: {:+d}%"
 
-#: Source/items.cpp:3834
+#: Source/items.cpp:3832
 #, no-c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% skada"
 
-#: Source/items.cpp:3838 Source/items.cpp:4094
+#: Source/items.cpp:3836 Source/items.cpp:4092
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "att träffa: {:+d}%, {:+d}% skada"
 
-#: Source/items.cpp:3842
+#: Source/items.cpp:3840
 #, no-c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% pansar"
 
-#: Source/items.cpp:3846
+#: Source/items.cpp:3844
 msgid "armor class: {:d}"
 msgstr "pansarklass: {:d}"
 
-#: Source/items.cpp:3851 Source/items.cpp:4076
+#: Source/items.cpp:3849 Source/items.cpp:4074
 msgid "Resist Fire: {:+d}%"
 msgstr "Motstå Eld: {:+d}%"
 
-#: Source/items.cpp:3853
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr "Motstå Eld: 75% MAX"
 
-#: Source/items.cpp:3858
+#: Source/items.cpp:3856
 msgid "Resist Lightning: {:+d}%"
 msgstr "Motstå Åska: {:+d}%"
 
-#: Source/items.cpp:3860
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr "Motstå Åska: 75% MAX"
 
-#: Source/items.cpp:3865
+#: Source/items.cpp:3863
 msgid "Resist Magic: {:+d}%"
 msgstr "Motstå Magi: {:+d}%"
 
-#: Source/items.cpp:3867
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr "Motstå Magi: 75% MAX"
 
-#: Source/items.cpp:3872
+#: Source/items.cpp:3870
 msgid "Resist All: {:+d}%"
 msgstr "Motstå Allt: {:+d}%"
 
-#: Source/items.cpp:3874
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr "Motstå Allt: 75% MAX"
 
-#: Source/items.cpp:3878
+#: Source/items.cpp:3876
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] "trollformler ökas {:d} nivå"
 msgstr[1] "Trollformler ökas {:d} nivåer"
 
-#: Source/items.cpp:3880
+#: Source/items.cpp:3878
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "trollformler minskas {:d} nivå"
 msgstr[1] "trollformler minskas {:d} nivåer"
 
-#: Source/items.cpp:3882
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr "trollformsnivåer oförändrade (?)"
 
-#: Source/items.cpp:3885
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr "Extra laddningar"
 
-#: Source/items.cpp:3888
+#: Source/items.cpp:3886
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:d} {:s} laddning"
 msgstr[1] "{:d} {:s} laddningar"
 
-#: Source/items.cpp:3892
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr "Eldträffskada: {:d}"
 
-#: Source/items.cpp:3894
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "Eldträffskada: {:d}-{:d}"
 
-#: Source/items.cpp:3898
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr "Åskträffskada: {:d}"
 
-#: Source/items.cpp:3900
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "Åskträffskada: {:d}-{:d}"
 
-#: Source/items.cpp:3904
+#: Source/items.cpp:3902
 msgid "{:+d} to strength"
 msgstr "{:+d} till styrka"
 
-#: Source/items.cpp:3908
+#: Source/items.cpp:3906
 msgid "{:+d} to magic"
 msgstr "{:+d} till magi"
 
-#: Source/items.cpp:3912
+#: Source/items.cpp:3910
 msgid "{:+d} to dexterity"
 msgstr "{:+d} till smidighet"
 
-#: Source/items.cpp:3916
+#: Source/items.cpp:3914
 msgid "{:+d} to vitality"
 msgstr "{:+d} till kropp"
 
-#: Source/items.cpp:3920
+#: Source/items.cpp:3918
 msgid "{:+d} to all attributes"
 msgstr "{:+d} till alla attribut"
 
-#: Source/items.cpp:3924
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} skada från fiender"
 
-#: Source/items.cpp:3928
+#: Source/items.cpp:3926
 msgid "Hit Points: {:+d}"
 msgstr "Kroppspoäng: {:+d}"
 
-#: Source/items.cpp:3932
+#: Source/items.cpp:3930
 msgid "Mana: {:+d}"
 msgstr "Mana: {:+d}"
 
-#: Source/items.cpp:3935
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr "hög tålighet"
 
-#: Source/items.cpp:3938
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr "minskad tålighet"
 
-#: Source/items.cpp:3941
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr "oförstörbar"
 
-#: Source/items.cpp:3944
+#: Source/items.cpp:3942
 #, no-c-format
 msgid "+{:d}% light radius"
 msgstr "+{:d}% ljusradie"
 
-#: Source/items.cpp:3947
+#: Source/items.cpp:3945
 #, no-c-format
 msgid "-{:d}% light radius"
 msgstr "-{:d}% ljusradie"
 
-#: Source/items.cpp:3950
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr "flera pilar per skott"
 
-#: Source/items.cpp:3954
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr "eldpilsskada: {:d}"
 
-#: Source/items.cpp:3956
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "eldpilsskada: {:d}-{:d}"
 
-#: Source/items.cpp:3960
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr "åskpilsskada {:d}"
 
-#: Source/items.cpp:3962
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "åskpilsskada {:d}-{:d}"
 
-#: Source/items.cpp:3966
+#: Source/items.cpp:3964
 msgid "fireball damage: {:d}"
 msgstr "eldklotsskada: {:d}"
 
-#: Source/items.cpp:3968
+#: Source/items.cpp:3966
 msgid "fireball damage: {:d}-{:d}"
 msgstr "eldklotsskada: {:d}-{:d}"
 
-#: Source/items.cpp:3971
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr "anfallare tar 1-3 skada"
 
-#: Source/items.cpp:3974
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr "användaren förlorar all mana"
 
-#: Source/items.cpp:3977
+#: Source/items.cpp:3975
 msgid "you can't heal"
 msgstr "du kan inte läka"
 
-#: Source/items.cpp:3980
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr "absorberar hälften av fällskada"
 
-#: Source/items.cpp:3983
+#: Source/items.cpp:3981
 msgid "knocks target back"
 msgstr "knuffar målet bakåt"
 
-#: Source/items.cpp:3986
+#: Source/items.cpp:3984
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr "+200% skada mot demoner"
 
-#: Source/items.cpp:3989
+#: Source/items.cpp:3987
 msgid "All Resistance equals 0"
 msgstr "Allt Motstånd lika med 0"
 
-#: Source/items.cpp:3992
+#: Source/items.cpp:3990
 msgid "hit monster doesn't heal"
 msgstr "träffade monster läker inte"
 
-#: Source/items.cpp:3996
+#: Source/items.cpp:3994
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr "träff stjäl 3% mana"
 
-#: Source/items.cpp:3998
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr "träff stjäl 5% mana"
 
-#: Source/items.cpp:4002
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr "träff stjäl 3% liv"
 
-#: Source/items.cpp:4004
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr "träff stjäl 5% liv"
 
-#: Source/items.cpp:4007
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr "går genom målets pansar"
 
-#: Source/items.cpp:4011
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr "kvick attack"
 
-#: Source/items.cpp:4013
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr "snabb attack"
 
-#: Source/items.cpp:4015
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr "snabbare attack"
 
-#: Source/items.cpp:4017
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr "snabbast attack"
 
-#: Source/items.cpp:4021
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr "snabb återhämtning efter träff"
 
-#: Source/items.cpp:4023
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr "snabbare återhämtning efter träff"
 
-#: Source/items.cpp:4025
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr "snabbast återhämtning efter träff"
 
-#: Source/items.cpp:4028
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr "snabb blockering"
 
-#: Source/items.cpp:4031
+#: Source/items.cpp:4029
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] "lägger till {:d} poäng till skada"
 msgstr[1] "lägger till {:d} poäng till skada"
 
-#: Source/items.cpp:4034
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr "avfyrar pilar med slumpmässig hastighet"
 
-#: Source/items.cpp:4037
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr "skada som ovanligt föremål"
 
-#: Source/items.cpp:4040
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr "ändrad tålighet"
 
-#: Source/items.cpp:4043
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr "Snabbare anfallssving"
 
-#: Source/items.cpp:4046
+#: Source/items.cpp:4044
 msgid "one handed sword"
 msgstr "enhänt svärd"
 
-#: Source/items.cpp:4049
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr "förlora kroppspoäng konstant"
 
-#: Source/items.cpp:4052
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr "livsstjälande"
 
-#: Source/items.cpp:4055
+#: Source/items.cpp:4053
 msgid "no strength requirement"
 msgstr "inget styrkekrav"
 
-#: Source/items.cpp:4058
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr "se med infraseende"
 
-#: Source/items.cpp:4065
+#: Source/items.cpp:4063
 msgid "lightning damage: {:d}"
 msgstr "åskskada: {:d}"
 
-#: Source/items.cpp:4067
+#: Source/items.cpp:4065
 msgid "lightning damage: {:d}-{:d}"
 msgstr "åskskada: {:d}-{:d}"
 
-#: Source/items.cpp:4070
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr "urladdning vid träff"
 
-#: Source/items.cpp:4079
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr "ibland trippel skada"
 
-#: Source/items.cpp:4082
+#: Source/items.cpp:4080
 #, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr "avtagande {:+d}% skada"
 
-#: Source/items.cpp:4085
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr "dubbel monsterskada, enkel till dig"
 
-#: Source/items.cpp:4088
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr "Slumpvis 0 - 500% skada"
 
-#: Source/items.cpp:4091
+#: Source/items.cpp:4089
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr "låg tål, {:+d}% skada"
 
-#: Source/items.cpp:4097
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr "extra PK mot demoner"
 
-#: Source/items.cpp:4100
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr "extra PK mot vandöda"
 
-#: Source/items.cpp:4103
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr "50% Mana flyttas till Liv"
 
-#: Source/items.cpp:4106
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr "40% Liv flyttas till Mana"
 
-#: Source/items.cpp:4109
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr "Annan förmåga (NW)"
 
-#: Source/items.cpp:4146 Source/items.cpp:4193
+#: Source/items.cpp:4144 Source/items.cpp:4191
 msgid "damage: {:d}  Indestructible"
 msgstr "skada: {:d}  Oförstörbar"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4148 Source/items.cpp:4195
+#: Source/items.cpp:4146 Source/items.cpp:4193
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "skada: {:d}  Tål: {:d}/{:d}"
 
-#: Source/items.cpp:4151 Source/items.cpp:4198
+#: Source/items.cpp:4149 Source/items.cpp:4196
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "skada: {:d}-{:d}  Oförstörbar"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4153 Source/items.cpp:4200
+#: Source/items.cpp:4151 Source/items.cpp:4198
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "skada: {:d}-{:d}  Tål: {:d}/{:d}"
 
-#: Source/items.cpp:4159 Source/items.cpp:4212
+#: Source/items.cpp:4157 Source/items.cpp:4210
 msgid "armor: {:d}  Indestructible"
 msgstr "pansar: {:d}  Oförstörbar"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4161 Source/items.cpp:4214
+#: Source/items.cpp:4159 Source/items.cpp:4212
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "pansar: {:d}  Tål: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4166
+#: Source/items.cpp:4164
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "skd: {:d}  Tål: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4168
+#: Source/items.cpp:4166
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "skd: {:d}-{:d}  Tål: {:d}/{:d}"
 
-#: Source/items.cpp:4169 Source/items.cpp:4204 Source/items.cpp:4219
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 msgid "Charges: {:d}/{:d}"
 msgstr "Laddningar: {:d}/{:d}"
 
-#: Source/items.cpp:4181
+#: Source/items.cpp:4179
 msgid "unique item"
 msgstr "unikt föremål"
 
-#: Source/items.cpp:4208 Source/items.cpp:4217 Source/items.cpp:4224
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr "Ej Identifierad"
 
-#: Source/loadsave.cpp:1656 Source/loadsave.cpp:2122
+#: Source/loadsave.cpp:1683 Source/loadsave.cpp:2149
 msgid "Unable to open save file archive"
 msgstr "Kunde inte öppna sparat arkiv"
 
-#: Source/loadsave.cpp:1659
+#: Source/loadsave.cpp:1686
 msgid "Invalid save file"
 msgstr "Ogiltig sparfil"
 
-#: Source/loadsave.cpp:1688
+#: Source/loadsave.cpp:1717
 msgid "Player is on a Hellfire only level"
 msgstr "Spelaren är på en nivå endast för Hellfire"
 
-#: Source/loadsave.cpp:1885
+#: Source/loadsave.cpp:1912
 msgid "Invalid game state"
 msgstr "Ogiltigt speltillstånd"
 
-#: Source/menu.cpp:136
+#: Source/menu.cpp:154
 msgid "Unable to display mainmenu"
 msgstr "Kunde inte visa huvudmeny"
+
+#. TRANSLATORS:  Error Message when a Shareware User clicks on "Replay Intro" in the Main Menu
+#: Source/menu.cpp:179
+msgid ""
+"The Diablo introduction cinematic is only available in the full retail "
+"version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
+msgstr ""
+"Introduktionsvideon finns endast tillgänglig i den kompletta versionen av "
+"Diablo. Besök https://www.gog.com/game/diablo för att köpa."
 
 #. TRANSLATORS: Monster Block start
 #. MT_NZOMBIE
@@ -4812,6 +4908,13 @@ msgctxt "monster"
 msgid "Reaper"
 msgstr "Skördare"
 
+#. TRANSLATORS: Monster Block end
+#. MT_NAKRUL
+#: Source/monstdat.cpp:158 Source/monstdat.cpp:485
+msgctxt "monster"
+msgid "Na-Krul"
+msgstr ""
+
 #. TRANSLATORS: Unique Monster Block start
 #: Source/monstdat.cpp:473
 msgctxt "monster"
@@ -4842,6 +4945,11 @@ msgstr "Röd Vex"
 msgctxt "monster"
 msgid "Black Jade"
 msgstr "Svart Jade"
+
+#: Source/monstdat.cpp:480
+msgctxt "monster"
+msgid "Lachdanan"
+msgstr ""
 
 #: Source/monstdat.cpp:481
 msgctxt "monster"
@@ -4893,6 +5001,11 @@ msgctxt "monster"
 msgid "Brokenhead Bangshield"
 msgstr "Sprickskalle Slagsköld"
 
+#: Source/monstdat.cpp:494
+msgctxt "monster"
+msgid "Bongo"
+msgstr ""
+
 #: Source/monstdat.cpp:495
 msgctxt "monster"
 msgid "Rotcarnage"
@@ -4912,6 +5025,11 @@ msgstr "Dödögat"
 msgctxt "monster"
 msgid "Madeye the Dead"
 msgstr "Villöga den Döde"
+
+#: Source/monstdat.cpp:499
+msgctxt "monster"
+msgid "El Chupacabras"
+msgstr ""
 
 #: Source/monstdat.cpp:500
 msgctxt "monster"
@@ -5248,10 +5366,22 @@ msgctxt "monster"
 msgid "The Vizier"
 msgstr "Visiren"
 
+#: Source/monstdat.cpp:567
+#, fuzzy
+#| msgid "Sapphire"
+msgctxt "monster"
+msgid "Zamphir"
+msgstr "Safirblå"
+
 #: Source/monstdat.cpp:568
 msgctxt "monster"
 msgid "Bloodlust"
 msgstr "Blodlust"
+
+#: Source/monstdat.cpp:569
+msgctxt "monster"
+msgid "Webwidow"
+msgstr ""
 
 #: Source/monstdat.cpp:570
 msgctxt "monster"
@@ -5269,96 +5399,97 @@ msgctxt "monster"
 msgid "Doomlock"
 msgstr "Domedagslockaren"
 
-#: Source/monster.cpp:3474
+#: Source/monster.cpp:3479
 msgid "Animal"
 msgstr "Djur"
 
-#: Source/monster.cpp:3476
+#: Source/monster.cpp:3481
 msgid "Demon"
 msgstr "Demon"
 
-#: Source/monster.cpp:3478
+#: Source/monster.cpp:3483
 msgid "Undead"
 msgstr "Vandöd"
 
-#: Source/monster.cpp:4610
+#: Source/monster.cpp:4612
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "Typ: {:s}  Dödat: {:d}"
 
-#: Source/monster.cpp:4612
+#: Source/monster.cpp:4614
 msgid "Total kills: {:d}"
 msgstr "Totalt dödade: {:d}"
 
-#: Source/monster.cpp:4645
+#: Source/monster.cpp:4647
 msgid "Hit Points: {:d}-{:d}"
 msgstr "Kroppspoäng: {:d}-{:d}"
 
-#: Source/monster.cpp:4651
+#: Source/monster.cpp:4653
 msgid "No magic resistance"
 msgstr "Inget magimotstånd"
 
-#: Source/monster.cpp:4655
+#: Source/monster.cpp:4657
 msgid "Resists: "
 msgstr "Står mot: "
 
-#: Source/monster.cpp:4657 Source/monster.cpp:4668
+#: Source/monster.cpp:4659 Source/monster.cpp:4671
 msgid "Magic "
 msgstr "Magi"
 
-#: Source/monster.cpp:4659 Source/monster.cpp:4670
+#: Source/monster.cpp:4661 Source/monster.cpp:4673
 msgid "Fire "
 msgstr "Eld"
 
-#: Source/monster.cpp:4661 Source/monster.cpp:4672
+#: Source/monster.cpp:4663 Source/monster.cpp:4675
 msgid "Lightning "
 msgstr "Åska"
 
-#: Source/monster.cpp:4666
+#: Source/monster.cpp:4669
 msgid "Immune: "
 msgstr "Immun: "
 
-#: Source/monster.cpp:4684
+#: Source/monster.cpp:4688
 msgid "Type: {:s}"
 msgstr "Typ: {:s}"
 
-#: Source/monster.cpp:4690 Source/monster.cpp:4697
+#: Source/monster.cpp:4694 Source/monster.cpp:4701
 msgid "No resistances"
 msgstr "Inga motståndskrafter"
 
-#: Source/monster.cpp:4692 Source/monster.cpp:4702
+#: Source/monster.cpp:4696 Source/monster.cpp:4706
 msgid "No Immunities"
 msgstr "Inga Immuniteter"
 
-#: Source/monster.cpp:4695
+#: Source/monster.cpp:4699
 msgid "Some Magic Resistances"
 msgstr "Vissa Magiska Motståndskrafter"
 
-#: Source/monster.cpp:4700
+#: Source/monster.cpp:4704
 msgid "Some Magic Immunities"
 msgstr "Vissa Magiska Immuniteter"
 
-#: Source/msg.cpp:484
+#: Source/msg.cpp:495
 msgid "Trying to drop a floor item?"
 msgstr ""
 
-#: Source/msg.cpp:951 Source/msg.cpp:975 Source/msg.cpp:998 Source/msg.cpp:1113
-#: Source/msg.cpp:1136 Source/msg.cpp:1158 Source/msg.cpp:1180
+#: Source/msg.cpp:994 Source/msg.cpp:1029 Source/msg.cpp:1060
+#: Source/msg.cpp:1187 Source/msg.cpp:1219 Source/msg.cpp:1251
+#: Source/msg.cpp:1281
 msgid "{:s} has cast an illegal spell."
 msgstr ""
 
-#: Source/msg.cpp:1529 Source/multi.cpp:815
+#: Source/msg.cpp:1668 Source/multi.cpp:804
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr ""
 
-#: Source/msg.cpp:1826
+#: Source/msg.cpp:1972
 msgid "Waiting for game data..."
 msgstr ""
 
-#: Source/msg.cpp:1834
+#: Source/msg.cpp:1980
 msgid "The game ended"
 msgstr ""
 
-#: Source/msg.cpp:1840
+#: Source/msg.cpp:1986
 msgid "Unable to get level data"
 msgstr ""
 
@@ -5374,507 +5505,506 @@ msgstr ""
 msgid "Player '{:s}' dropped due to timeout"
 msgstr ""
 
-#: Source/multi.cpp:817
+#: Source/multi.cpp:806
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr ""
 
 #. TRANSLATORS: Shrine Name Block
-#: Source/objects.cpp:101
+#: Source/objects.cpp:104
 msgid "Mysterious"
 msgstr "Mystisk"
 
-#: Source/objects.cpp:102
+#: Source/objects.cpp:105
 msgid "Hidden"
 msgstr "Gömd"
 
-#: Source/objects.cpp:103
+#: Source/objects.cpp:106
 msgid "Gloomy"
 msgstr "Dyster"
 
-#: Source/objects.cpp:105 Source/objects.cpp:112
+#: Source/objects.cpp:108 Source/objects.cpp:115
 msgid "Magical"
 msgstr "Magisk"
 
-#: Source/objects.cpp:106
+#: Source/objects.cpp:109
 msgid "Stone"
 msgstr "Stenig"
 
-#: Source/objects.cpp:107
+#: Source/objects.cpp:110
 msgid "Religious"
 msgstr "Religiös"
 
-#: Source/objects.cpp:108
+#: Source/objects.cpp:111
 msgid "Enchanted"
 msgstr "Förtrollad"
 
-#: Source/objects.cpp:109
+#: Source/objects.cpp:112
 msgid "Thaumaturgic"
 msgstr "Siande"
 
-#: Source/objects.cpp:110
+#: Source/objects.cpp:113
 msgid "Fascinating"
 msgstr "Fascinerande"
 
-#: Source/objects.cpp:111
+#: Source/objects.cpp:114
 msgid "Cryptic"
 msgstr "Kryptisk"
 
-#: Source/objects.cpp:113
+#: Source/objects.cpp:116
 msgid "Eldritch"
 msgstr "Uråldrig"
 
-#: Source/objects.cpp:114
+#: Source/objects.cpp:117
 msgid "Eerie"
 msgstr "Kuslig"
 
-#: Source/objects.cpp:115
+#: Source/objects.cpp:118
 msgid "Divine"
 msgstr "Gudomlig"
 
-#: Source/objects.cpp:117
+#: Source/objects.cpp:120
 msgid "Sacred"
 msgstr "Helig"
 
-#: Source/objects.cpp:118
+#: Source/objects.cpp:121
 msgid "Spiritual"
 msgstr "Spirituell"
 
-#: Source/objects.cpp:119
+#: Source/objects.cpp:122
 msgid "Spooky"
 msgstr "Spöklik"
 
-#: Source/objects.cpp:120
+#: Source/objects.cpp:123
 msgid "Abandoned"
 msgstr "Övergiven"
 
-#: Source/objects.cpp:121
+#: Source/objects.cpp:124
 msgid "Creepy"
 msgstr "Läskig"
 
-#: Source/objects.cpp:122
+#: Source/objects.cpp:125
 msgid "Quiet"
 msgstr "Tyst"
 
-#: Source/objects.cpp:123
+#: Source/objects.cpp:126
 msgid "Secluded"
 msgstr "Avskild"
 
-#: Source/objects.cpp:124
+#: Source/objects.cpp:127
 msgid "Ornate"
 msgstr "Sirlig"
 
-#: Source/objects.cpp:125
+#: Source/objects.cpp:128
 msgid "Glimmering"
 msgstr "Glittrande"
 
-#: Source/objects.cpp:126
+#: Source/objects.cpp:129
 msgid "Tainted"
 msgstr "Befläckad"
 
-#: Source/objects.cpp:127
+#: Source/objects.cpp:130
 msgid "Oily"
 msgstr "Oljig"
 
-#: Source/objects.cpp:128
+#: Source/objects.cpp:131
 msgid "Glowing"
 msgstr "Lysande"
 
-#: Source/objects.cpp:129
+#: Source/objects.cpp:132
 msgid "Mendicant's"
 msgstr "Botgörarens"
 
-#: Source/objects.cpp:130
+#: Source/objects.cpp:133
 msgid "Sparkling"
 msgstr "Gnistrande"
 
-#: Source/objects.cpp:131
+#: Source/objects.cpp:134
 msgid "Town"
 msgstr "Stadens"
 
-#: Source/objects.cpp:132
+#: Source/objects.cpp:135
 msgid "Shimmering"
 msgstr "Strålande"
 
-#: Source/objects.cpp:133
+#: Source/objects.cpp:136
 msgid "Solar"
 msgstr "Solens"
 
 #. TRANSLATORS: Shrine Name Block end
-#: Source/objects.cpp:135
+#: Source/objects.cpp:138
 msgid "Murphy's"
 msgstr "Murphys"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:265
+#: Source/objects.cpp:268
 msgid "The Great Conflict"
 msgstr "Det Stora Kriget"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:266
+#: Source/objects.cpp:269
 msgid "The Wages of Sin are War"
 msgstr "Krig är Syndens Lön"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:267
+#: Source/objects.cpp:270
 msgid "The Tale of the Horadrim"
 msgstr "Berättelsen om Horadrim"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:268
+#: Source/objects.cpp:271
 msgid "The Dark Exile"
 msgstr "Den Mörka Landsflykten"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:269
+#: Source/objects.cpp:272
 msgid "The Sin War"
 msgstr "Syndakriget"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:270
+#: Source/objects.cpp:273
 msgid "The Binding of the Three"
 msgstr "De Tre Binds Fast"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:271
+#: Source/objects.cpp:274
 msgid "The Realms Beyond"
 msgstr "Världarna Bortom"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:272
+#: Source/objects.cpp:275
 msgid "Tale of the Three"
 msgstr "Berättelsen om de Tre"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:273
+#: Source/objects.cpp:276
 msgid "The Black King"
 msgstr "Den Svarta Kungen"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:274
+#: Source/objects.cpp:277
 msgid "Journal: The Ensorcellment"
 msgstr "Dagbok: Trollbindelsen"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:275
+#: Source/objects.cpp:278
 msgid "Journal: The Meeting"
 msgstr "Dagbok: Mötet"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:276
+#: Source/objects.cpp:279
 msgid "Journal: The Tirade"
 msgstr "Dagbok: Utläggningen"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:277
+#: Source/objects.cpp:280
 msgid "Journal: His Power Grows"
 msgstr "Dagbok: Hans Kraft Växer"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:278
+#: Source/objects.cpp:281
 msgid "Journal: NA-KRUL"
 msgstr "Dagbok: NA-KRUL"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:279
+#: Source/objects.cpp:282
 msgid "Journal: The End"
 msgstr "Dagbok: Slutet"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:280
+#: Source/objects.cpp:283
 msgid "A Spellbook"
 msgstr "En Magibok"
 
-#: Source/objects.cpp:5365
+#: Source/objects.cpp:5339
 msgid "Crucified Skeleton"
 msgstr "Korsfäst Skelett"
 
-#: Source/objects.cpp:5369
+#: Source/objects.cpp:5343
 msgid "Lever"
 msgstr "Spak"
 
-#: Source/objects.cpp:5378
+#: Source/objects.cpp:5352
 msgid "Open Door"
 msgstr "Öppen Dörr"
 
-#: Source/objects.cpp:5380
+#: Source/objects.cpp:5354
 msgid "Closed Door"
 msgstr "Stängd Dörr"
 
-#: Source/objects.cpp:5382
+#: Source/objects.cpp:5356
 msgid "Blocked Door"
 msgstr "Spärrad Dörr"
 
-#: Source/objects.cpp:5387
+#: Source/objects.cpp:5361
 msgid "Ancient Tome"
 msgstr "Urgammal Volym"
 
-#: Source/objects.cpp:5389
+#: Source/objects.cpp:5363
 msgid "Book of Vileness"
 msgstr "Uselhetens Bok"
 
-#: Source/objects.cpp:5394
+#: Source/objects.cpp:5368
 msgid "Skull Lever"
 msgstr "Dödskallespak"
 
-#: Source/objects.cpp:5397
+#: Source/objects.cpp:5371
 msgid "Mythical Book"
 msgstr "Mytisk Bok"
 
-#: Source/objects.cpp:5401
+#: Source/objects.cpp:5375
 msgid "Small Chest"
 msgstr "Liten Kista"
 
-#: Source/objects.cpp:5405
+#: Source/objects.cpp:5379
 msgid "Chest"
 msgstr "Kista"
 
-#: Source/objects.cpp:5410
+#: Source/objects.cpp:5384
 msgid "Large Chest"
 msgstr "Stor Kista"
 
-#: Source/objects.cpp:5413
+#: Source/objects.cpp:5387
 msgid "Sarcophagus"
 msgstr "Sarkofag"
 
-#: Source/objects.cpp:5416
+#: Source/objects.cpp:5390
 msgid "Bookshelf"
 msgstr "Bokhylla"
 
-#: Source/objects.cpp:5420
+#: Source/objects.cpp:5394
 msgid "Bookcase"
 msgstr "Bokhyllor"
 
-#: Source/objects.cpp:5425
+#: Source/objects.cpp:5399
 msgid "Pod"
 msgstr "Behållare"
 
-#: Source/objects.cpp:5427
+#: Source/objects.cpp:5401
 msgid "Urn"
 msgstr "Urna"
 
-#: Source/objects.cpp:5429
+#: Source/objects.cpp:5403
 msgid "Barrel"
 msgstr "Tunna"
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:5433
+#: Source/objects.cpp:5407
 msgid "{:s} Shrine"
 msgstr "{:s} Helgedom"
 
-#: Source/objects.cpp:5437
+#: Source/objects.cpp:5411
 msgid "Skeleton Tome"
 msgstr "Skelettband"
 
-#: Source/objects.cpp:5440
+#: Source/objects.cpp:5414
 msgid "Library Book"
 msgstr "Biblioteksbok"
 
-#: Source/objects.cpp:5443
+#: Source/objects.cpp:5417
 msgid "Blood Fountain"
 msgstr "Blodfontän"
 
-#: Source/objects.cpp:5446
+#: Source/objects.cpp:5420
 msgid "Decapitated Body"
 msgstr "Halshuggen Kropp"
 
-#: Source/objects.cpp:5449
+#: Source/objects.cpp:5423
 msgid "Book of the Blind"
 msgstr "De Blindas Bok"
 
-#: Source/objects.cpp:5452
+#: Source/objects.cpp:5426
 msgid "Book of Blood"
 msgstr "Blodboken"
 
-#: Source/objects.cpp:5455
+#: Source/objects.cpp:5429
 msgid "Purifying Spring"
 msgstr "Rengörande Källa"
 
-#: Source/objects.cpp:5462 Source/objects.cpp:5486
+#: Source/objects.cpp:5436 Source/objects.cpp:5460
 msgid "Weapon Rack"
 msgstr "Vapenräcke"
 
-#: Source/objects.cpp:5465
+#: Source/objects.cpp:5439
 msgid "Goat Shrine"
 msgstr "Gethelgedom"
 
-#: Source/objects.cpp:5468
+#: Source/objects.cpp:5442
 msgid "Cauldron"
 msgstr "Kittel"
 
-#: Source/objects.cpp:5471
+#: Source/objects.cpp:5445
 msgid "Murky Pool"
 msgstr "Mörk Pöl"
 
-#: Source/objects.cpp:5474
+#: Source/objects.cpp:5448
 msgid "Fountain of Tears"
 msgstr "Tårfontän"
 
-#: Source/objects.cpp:5477
+#: Source/objects.cpp:5451
 msgid "Steel Tome"
 msgstr "Stålvolymen"
 
-#: Source/objects.cpp:5480
+#: Source/objects.cpp:5454
 msgid "Pedestal of Blood"
 msgstr "Blodpiedestal"
 
-#: Source/objects.cpp:5489
+#: Source/objects.cpp:5463
 msgid "Mushroom Patch"
 msgstr "Svampsamling"
 
-#: Source/objects.cpp:5492
+#: Source/objects.cpp:5466
 msgid "Vile Stand"
 msgstr "Uselt Stativ"
 
-#: Source/objects.cpp:5495
+#: Source/objects.cpp:5469
 msgid "Slain Hero"
 msgstr "Dräpt Hjälte"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:5502
+#: Source/objects.cpp:5476
 msgid "Trapped {:s}"
 msgstr "Fångad {:s}"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
-#: Source/objects.cpp:5508
+#: Source/objects.cpp:5482
 msgid "{:s} (disabled)"
 msgstr "{:s} (deaktiverad)"
 
-#: Source/panels/charpanel.cpp:109
+#: Source/panels/charpanel.cpp:110
 msgid "MAX"
 msgstr "MAX"
 
-#: Source/panels/charpanel.cpp:119
+#: Source/panels/charpanel.cpp:120
 msgid "Level"
 msgstr "Nivå"
 
-#: Source/panels/charpanel.cpp:121
+#: Source/panels/charpanel.cpp:122
 msgid "Experience"
 msgstr "Erfarenhet"
 
-#: Source/panels/charpanel.cpp:123
+#: Source/panels/charpanel.cpp:124
 msgid "Next level"
 msgstr "Nästa nivå"
 
-#: Source/panels/charpanel.cpp:126
+#: Source/panels/charpanel.cpp:127
 msgid "None"
 msgstr "Ingen"
 
-#: Source/panels/charpanel.cpp:132
+#: Source/panels/charpanel.cpp:133
 msgid "Base"
 msgstr "Grund"
 
-#: Source/panels/charpanel.cpp:133
+#: Source/panels/charpanel.cpp:134
 msgid "Now"
 msgstr "Nu"
 
-#: Source/panels/charpanel.cpp:134
+#: Source/panels/charpanel.cpp:135
 msgid "Strength"
 msgstr "Styrka"
 
-#: Source/panels/charpanel.cpp:138
+#: Source/panels/charpanel.cpp:139
 msgid "Magic"
 msgstr "Magi"
 
-#: Source/panels/charpanel.cpp:142
+#: Source/panels/charpanel.cpp:143
 msgid "Dexterity"
 msgstr "Smidighet"
 
-#: Source/panels/charpanel.cpp:145
+#: Source/panels/charpanel.cpp:146
 msgid "Vitality"
 msgstr "Kropp"
 
-#: Source/panels/charpanel.cpp:148
+#: Source/panels/charpanel.cpp:149
 msgid "Points to distribute"
 msgstr "Poäng att fördela"
 
-#: Source/panels/charpanel.cpp:158
+#: Source/panels/charpanel.cpp:159
 msgid "Armor class"
 msgstr "Pansarklass"
 
-#: Source/panels/charpanel.cpp:160
+#: Source/panels/charpanel.cpp:161
 msgid "To hit"
 msgstr "Träffchans"
 
-#: Source/panels/charpanel.cpp:162
+#: Source/panels/charpanel.cpp:163
 msgid "Damage"
 msgstr "Skada"
 
-#: Source/panels/charpanel.cpp:168
+#: Source/panels/charpanel.cpp:170
 msgid "Life"
 msgstr "Liv"
 
-#: Source/panels/charpanel.cpp:172
+#: Source/panels/charpanel.cpp:174
 msgid "Mana"
 msgstr "Mana"
 
-#: Source/panels/charpanel.cpp:177
+#: Source/panels/charpanel.cpp:179
 msgid "Resist magic"
 msgstr "Motstå magi"
 
-#: Source/panels/charpanel.cpp:179
+#: Source/panels/charpanel.cpp:181
 msgid "Resist fire"
 msgstr "Motstå eld"
 
-#: Source/panels/charpanel.cpp:181
+#: Source/panels/charpanel.cpp:183
 msgid "Resist lightning"
 msgstr "Motstå åska"
 
-#: Source/panels/mainpanel.cpp:62 Source/panels/mainpanel.cpp:109
-#: Source/panels/mainpanel.cpp:111
+#: Source/panels/mainpanel.cpp:62 Source/panels/mainpanel.cpp:106
+#: Source/panels/mainpanel.cpp:108
 msgid "voice"
 msgstr "röst"
 
-#: Source/panels/mainpanel.cpp:87
+#: Source/panels/mainpanel.cpp:84
 msgid "char"
 msgstr "karak"
 
-#: Source/panels/mainpanel.cpp:88
+#: Source/panels/mainpanel.cpp:85
 msgid "quests"
 msgstr "uppdr"
 
-#: Source/panels/mainpanel.cpp:89
+#: Source/panels/mainpanel.cpp:86
 msgid "map"
 msgstr "karta"
 
-#: Source/panels/mainpanel.cpp:90
+#: Source/panels/mainpanel.cpp:87
 msgid "menu"
 msgstr "meny"
 
-#: Source/panels/mainpanel.cpp:91
+#: Source/panels/mainpanel.cpp:88
 msgid "inv"
 msgstr "ägod"
 
-#: Source/panels/mainpanel.cpp:92
+#: Source/panels/mainpanel.cpp:89
 msgid "spells"
 msgstr "troll"
 
-#: Source/panels/mainpanel.cpp:104 Source/panels/mainpanel.cpp:106
-#: Source/panels/mainpanel.cpp:108
+#: Source/panels/mainpanel.cpp:101 Source/panels/mainpanel.cpp:103
+#: Source/panels/mainpanel.cpp:105
 msgid "mute"
 msgstr "tysta"
 
-#: Source/pfile.cpp:260
+#: Source/pfile.cpp:242
 msgid "Failed to open player archive for writing."
 msgstr ""
 
-#: Source/pfile.cpp:385
+#: Source/pfile.cpp:377
 msgid "Unable to open archive"
 msgstr ""
 
-#: Source/pfile.cpp:387
+#: Source/pfile.cpp:379
 msgid "Unable to load character"
 msgstr ""
 
-#: Source/pfile.cpp:410 Source/pfile.cpp:430
+#: Source/pfile.cpp:403 Source/pfile.cpp:423
 msgid "Unable to read to save file archive"
 msgstr ""
 
-#: Source/pfile.cpp:449
+#: Source/pfile.cpp:442
 msgid "Unable to write to save file archive"
 msgstr ""
 
-#. TRANSLATORS: Shown if player presses "v" button. {:s} is player name, {:d} is level, {:s} is location
-#: Source/plrmsg.cpp:89
+#: Source/plrmsg.cpp:88
 msgid "{:s} (lvl {:d}): {:s}"
 msgstr "{:s} (nivå {:d}): {:s}"
 
@@ -5889,7 +6019,7 @@ msgstr ""
 msgid "%i gold"
 msgstr "%i guld"
 
-#: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:56
+#: Source/qol/monhealthbar.cpp:37 Source/qol/xpbar.cpp:56
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
@@ -5929,6 +6059,16 @@ msgstr "Gharbad den Svage"
 msgid "Zhar the Mad"
 msgstr "Zhar den Galne"
 
+#: Source/quests.cpp:45
+msgid "Lachdanan"
+msgstr ""
+
+#: Source/quests.cpp:46
+#, fuzzy
+#| msgid "Exit Diablo"
+msgid "Diablo"
+msgstr "Avsluta Diablo"
+
 #: Source/quests.cpp:47
 msgid "The Butcher"
 msgstr "Slaktaren"
@@ -5958,7 +6098,7 @@ msgid "Poisoned Water Supply"
 msgstr "Förgiftad Vattenkälla"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:55 Source/quests.cpp:90
+#: Source/quests.cpp:55 Source/quests.cpp:91
 msgid "The Chamber of Bone"
 msgstr "Benkammaren"
 
@@ -5986,6 +6126,10 @@ msgstr "Vandrande Köpman"
 msgid "The Defiler"
 msgstr "Förpestaren"
 
+#: Source/quests.cpp:62
+msgid "Na-Krul"
+msgstr ""
+
 #: Source/quests.cpp:63 Source/trigs.cpp:447
 msgid "Cornerstone of the World"
 msgstr "Världens Hörnsten"
@@ -5996,27 +6140,27 @@ msgid "The Jersey's Jersey"
 msgstr "Jerseys Jersey"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:89
+#: Source/quests.cpp:90
 msgid "King Leoric's Tomb"
 msgstr "Kung Leorics Grift"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:91 Source/setmaps.cpp:26
+#: Source/quests.cpp:92 Source/setmaps.cpp:26
 msgid "Maze"
 msgstr "Labyrint"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:92
+#: Source/quests.cpp:93
 msgid "A Dark Passage"
 msgstr "En Mörk Tunnel"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:93
+#: Source/quests.cpp:94
 msgid "Unholy Altar"
 msgstr "Oheligt Altare"
 
 #. TRANSLATORS: Used for Quest Portals. {:s} is a Map Name
-#: Source/quests.cpp:449
+#: Source/quests.cpp:450
 msgid "To {:s}"
 msgstr "Till {:s}"
 
@@ -6287,298 +6431,331 @@ msgctxt "spell"
 msgid "Rune of Stone"
 msgstr "Stenruna"
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:91
+#, fuzzy
+#| msgid "Griswold's Edge"
+msgid "Griswold"
+msgstr "Griswolds Klinga"
+
+#: Source/stores.cpp:92
+msgid "Pepin"
+msgstr ""
+
+#: Source/stores.cpp:94
+msgid "Ogden"
+msgstr ""
+
+#: Source/stores.cpp:95
+msgid "Cain"
+msgstr ""
+
+#: Source/stores.cpp:96
+#, fuzzy
+#| msgid "Talk to Farnham"
+msgid "Farnham"
+msgstr "Tala med Farnham"
+
+#: Source/stores.cpp:97
+msgid "Adria"
+msgstr ""
+
+#: Source/stores.cpp:98 Source/stores.cpp:1305
+#, fuzzy
+#| msgid "brilliance"
+msgid "Gillian"
+msgstr "briljans"
+
+#: Source/stores.cpp:99
+msgid "Wirt"
+msgstr ""
+
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr "Tillbaka"
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ",  "
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 msgid "Damage: {:d}-{:d}  "
 msgstr "Skada: {:d}-{:d}  "
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 msgid "Armor: {:d}  "
 msgstr "Pansar: {:d}  "
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 msgid "Dur: {:d}/{:d},  "
 msgstr "Tål: {:d}/{:d},  "
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr "Oförstörbar,  "
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr "Inga krävda attribut"
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr "Välkommen till"
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr "Smedens butik"
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr "Vill du:"
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 msgid "Talk to Griswold"
 msgstr "Tala med Griswold"
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 msgid "Buy basic items"
 msgstr "Köpa enkla föremål"
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 msgid "Buy premium items"
 msgstr "Köpa exklusiva föremål"
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 msgid "Sell items"
 msgstr "Sälja föremål"
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 msgid "Repair items"
 msgstr "Laga föremål"
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 msgid "Leave the shop"
 msgstr "Lämna butiken"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "Jag har dessa föremål till salu:         Ditt guld: {:d}"
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr "Tillbaka"
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "Jag har dessa specialföremål till salu:  Ditt guld: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "Du har inget jag vill ha.            Ditt guld: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "Vad är till salu?                   Ditt guld: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "Du har inget att laga.                  Ditt guld: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "Laga vilket föremål?           Ditt guld: {:d}"
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr "Häxans hydda"
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 msgid "Talk to Adria"
 msgstr "Tala med Adria"
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr "Köpa föremål"
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr "Ladda om stavar"
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 msgid "Leave the shack"
 msgstr "Lämna hyddan"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "Du har inget att ladda om.                Ditt guld: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "Ladda om vilket föremål?         Ditt guld: {:d}"
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr "Du har inte tillräckligt med guld"
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr "Du har inte tillräckligt med utrymme i dina ägodelar"
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr "Är vi överens?"
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 msgid "Are you sure you want to identify this item?"
 msgstr "Är du säker på att du vill identifiera detta föremål?"
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 msgid "Are you sure you want to buy this item?"
 msgstr "Är du säker på att du vill köpa detta föremål?"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 msgid "Are you sure you want to recharge this item?"
 msgstr "Är du säker på att du vill ladda om detta föremål?"
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 msgid "Are you sure you want to sell this item?"
 msgstr "Är du säker på att du vill sälja detta föremål?"
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 msgid "Are you sure you want to repair this item?"
 msgstr "Är du säker på att du vill laga detta föremål?"
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr "Den Träbente pojken Wirt"
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 msgid "Talk to Wirt"
 msgstr "Tala med Wirt"
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr "Jag har något att sälja,"
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr "men det kostar 50 guld"
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr "bara för att se det. "
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr "Vad har du?"
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr "Säg hejdå"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "Jag säljer detta:                      Ditt guld: {:d}"
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 msgid "Leave"
 msgstr "Gå därifrån"
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr "Läkarens hus"
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr "Tala med Pepin"
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr "Lämna Läkarens hus"
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 msgid "The Town Elder"
 msgstr "Byäldsten"
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 msgid "Talk to Cain"
 msgstr "Tala med Cain"
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr "Identifiera ett föremål"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "Du har inget att identifiera.             Ditt guld: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "Identifiera vilket föremål?      Ditt guld: {:d}"
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr "Detta föremål är:"
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr "Klart"
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 msgid "Talk to {:s}"
 msgstr "Tala med {:s}"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 msgid "Talking to {:s}"
 msgstr "Talar med {:s}"
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 msgid "is not available"
 msgstr "är inte tillgänglig"
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 msgid "in the shareware"
 msgstr "i shareware"
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 msgid "version"
 msgstr "version"
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr "Skvaller"
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr "Soluppgången"
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 msgid "Talk to Ogden"
 msgstr "Tala med Ogden"
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 msgid "Leave the tavern"
 msgstr "Lämna Krogen"
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 msgid "Talk to Gillian"
 msgstr "Tala med Gillian"
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr "Fyllot Farnham"
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 msgid "Talk to Farnham"
 msgstr "Tala med Farnham"
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr "Säg Hejdå"
 
@@ -9285,6 +9462,10 @@ msgstr "Bonden Lester"
 msgid "Complete Nut"
 msgstr "Fullkomligt Nöt"
 
+#: Source/towners.cpp:266
+msgid "Celia"
+msgstr ""
+
 #: Source/towners.cpp:279
 msgid "Slain Townsman"
 msgstr "Dräpt Stadsbo"
@@ -9314,17 +9495,17 @@ msgid "Down to Crypt"
 msgstr "Ned till kryptan"
 
 #: Source/trigs.cpp:412 Source/trigs.cpp:492 Source/trigs.cpp:539
-#: Source/trigs.cpp:630
+#: Source/trigs.cpp:634
 msgid "Up to level {:d}"
 msgstr "Upp till nivå {:d}"
 
 #: Source/trigs.cpp:414 Source/trigs.cpp:469 Source/trigs.cpp:521
-#: Source/trigs.cpp:596 Source/trigs.cpp:613 Source/trigs.cpp:660
+#: Source/trigs.cpp:600 Source/trigs.cpp:617 Source/trigs.cpp:664
 msgid "Up to town"
 msgstr "Upp till staden"
 
-#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:552
-#: Source/trigs.cpp:577 Source/trigs.cpp:642
+#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:556
+#: Source/trigs.cpp:581 Source/trigs.cpp:646
 msgid "Down to level {:d}"
 msgstr "Ned till nivå {:d}"
 
@@ -9336,15 +9517,14 @@ msgstr "Upp till Kryptans nivå {:d}"
 msgid "Down to Crypt level {:d}"
 msgstr "Ned till Kryptans nivå {:d}"
 
-#: Source/trigs.cpp:564
+#: Source/trigs.cpp:568
 msgid "Up to Nest level {:d}"
 msgstr "Upp till Nästets nivå {:d}"
 
-#: Source/trigs.cpp:673
-#| msgid "Exit Diablo"
+#: Source/trigs.cpp:677
 msgid "Down to Diablo"
 msgstr "Ned till Diablo"
 
-#: Source/trigs.cpp:706 Source/trigs.cpp:720 Source/trigs.cpp:734
+#: Source/trigs.cpp:710 Source/trigs.cpp:724 Source/trigs.cpp:738
 msgid "Back to Level {:d}"
 msgstr "Tillbaka till nivå {:d}"

--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-11-01 15:00+0800\n"
+"POT-Creation-Date: 2021-11-21 05:46+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: muziling <pieceking@qq.com>\n"
 "Language-Team: Emiliano Augusto Gonzalez\n"
@@ -390,8 +390,8 @@ msgstr "客户​端​-​服务器​(​TCP)"
 msgid "Loopback"
 msgstr "回环"
 
-#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:484
-#: Source/DiabloUI/selgame.cpp:505
+#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:489
+#: Source/DiabloUI/selgame.cpp:510
 msgid "Multi Player Game"
 msgstr "多​人​游戏"
 
@@ -739,11 +739,11 @@ msgstr "是否​确实​要​删除​角色​“​{:s}​”？"
 msgid "Enter Hellfire"
 msgstr "进入​《​地狱火​》"
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr "是"
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr "否"
 
@@ -798,12 +798,12 @@ msgstr ""
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr "Copyright © 1996-2001 Blizzard Entertainment"
 
-#: Source/appfat.cpp:37
+#: Source/appfat.cpp:38
 msgid "Error"
 msgstr "错误"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:101
+#: Source/appfat.cpp:102
 msgid ""
 "{:s}\n"
 "\n"
@@ -813,7 +813,7 @@ msgstr ""
 "\n"
 "​错误​发生​在: {:s}，行{:d}"
 
-#: Source/appfat.cpp:116
+#: Source/appfat.cpp:117
 msgid ""
 "Unable to open main data archive ({:s}).\n"
 "\n"
@@ -823,12 +823,12 @@ msgstr ""
 "\n"
 "​确保​它​在​游戏​文件​夹​中，并且​文件​名​都​是​小​写​的。"
 
-#: Source/appfat.cpp:122
+#: Source/appfat.cpp:123
 msgid "Data File Error"
 msgstr "数据​文件​错误"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:130
+#: Source/appfat.cpp:131
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -836,7 +836,7 @@ msgstr ""
 "无法​写入​位置: \n"
 "{:s}"
 
-#: Source/appfat.cpp:132
+#: Source/appfat.cpp:133
 msgid "Read-Only Directory Error"
 msgstr "只​读​目录​错误"
 
@@ -860,172 +860,172 @@ msgstr "巢​穴: {:d} 层"
 msgid "Level: Crypt {:d}"
 msgstr "墓穴: {:d} 层"
 
-#: Source/automap.cpp:508 Source/items.cpp:2076
+#: Source/automap.cpp:508 Source/items.cpp:2090
 msgid "Level: {:d}"
 msgstr "等级: {:d}"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr "Tab"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr "Esc"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:212
 msgid "Enter"
 msgstr "Enter"
 
-#: Source/control.cpp:202
+#: Source/control.cpp:215
 msgid "Character Information"
 msgstr "角色​信息"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr "任务​日志"
 
-#: Source/control.cpp:204
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr "自动​地图"
 
-#: Source/control.cpp:205
+#: Source/control.cpp:218
 msgid "Main Menu"
 msgstr "主​菜​单"
 
-#: Source/control.cpp:206
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr "物品​栏"
 
-#: Source/control.cpp:207
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr "法术书"
 
-#: Source/control.cpp:208
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr "发送​消息"
 
-#: Source/control.cpp:764 Source/control.cpp:1572
+#: Source/control.cpp:718 Source/control.cpp:1587
 msgid "Skill"
 msgstr "技能"
 
-#: Source/control.cpp:765 Source/control.cpp:1226
+#: Source/control.cpp:719 Source/control.cpp:1237
 msgid "{:s} Skill"
 msgstr "技能​：​{:s}"
 
-#: Source/control.cpp:771
+#: Source/control.cpp:725
 msgid "Spell"
 msgstr "法术"
 
-#: Source/control.cpp:772 Source/control.cpp:1230
+#: Source/control.cpp:726 Source/control.cpp:1241
 msgid "{:s} Spell"
 msgstr "法术​：​{:s}"
 
-#: Source/control.cpp:774
+#: Source/control.cpp:728
 msgid "Damages undead only"
 msgstr "只​能​伤害​亡灵"
 
-#: Source/control.cpp:778 Source/control.cpp:1234 Source/control.cpp:1596
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr "法术​等级 0 - 无法​使用"
 
-#: Source/control.cpp:780 Source/control.cpp:1236 Source/control.cpp:1598
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 msgid "Spell Level {:d}"
 msgstr "法术​等级 {:d}"
 
-#: Source/control.cpp:787
+#: Source/control.cpp:741
 msgid "Scroll"
 msgstr "卷轴"
 
-#: Source/control.cpp:788 Source/control.cpp:1240
+#: Source/control.cpp:742 Source/control.cpp:1251
 msgid "Scroll of {:s}"
 msgstr "{:s}​卷轴"
 
-#: Source/control.cpp:793 Source/control.cpp:1246
+#: Source/control.cpp:747 Source/control.cpp:1257
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "{:d}卷轴"
 
-#: Source/control.cpp:800 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
 #: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
 msgid "Staff"
 msgstr "法​杖"
 
-#: Source/control.cpp:801 Source/control.cpp:1250 Source/items.cpp:1317
+#: Source/control.cpp:755 Source/control.cpp:1261
 msgid "Staff of {:s}"
 msgstr "{:s}​法​杖"
 
-#: Source/control.cpp:803 Source/control.cpp:1252
+#: Source/control.cpp:757 Source/control.cpp:1263
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "{:d}充能"
 
-#: Source/control.cpp:813
+#: Source/control.cpp:767
 msgid "Spell Hotkey {:s}"
 msgstr "法术​热键 {:d}"
 
-#: Source/control.cpp:1203
+#: Source/control.cpp:1214
 msgid "Player friendly"
 msgstr "对​玩家​友好"
 
-#: Source/control.cpp:1205
+#: Source/control.cpp:1216
 msgid "Player attack"
 msgstr "玩​家​攻击"
 
-#: Source/control.cpp:1208
+#: Source/control.cpp:1219
 msgid "Hotkey: {:s}"
 msgstr "热键: {:s}"
 
-#: Source/control.cpp:1216
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr "当前​选择​的​法术​按钮"
 
-#: Source/control.cpp:1219
+#: Source/control.cpp:1230
 msgid "Hotkey: 's'"
 msgstr "热键: “​s​”"
 
-#: Source/control.cpp:1374 Source/inv.cpp:1992 Source/items.cpp:3739
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "{:d}金币堆"
 
-#: Source/control.cpp:1377
+#: Source/control.cpp:1390
 msgid "Requirements not met"
 msgstr "未​满足​条件"
 
-#: Source/control.cpp:1413
+#: Source/control.cpp:1426
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}，层数: {:d}"
 
-#: Source/control.cpp:1415
+#: Source/control.cpp:1428
 msgid "Hit Points {:d} of {:d}"
 msgstr "生命值 {:d} 的 {:d}"
 
-#: Source/control.cpp:1442
+#: Source/control.cpp:1457
 msgid "Level Up"
 msgstr "升级"
 
-#: Source/control.cpp:1576
+#: Source/control.cpp:1591
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] "法杖 ({:d} 充能)"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1586
+#: Source/control.cpp:1601
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "法力: {:d} 伤害: {:d}-{:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1588
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "法力: {:d} 伤害: n/a"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1591
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "法力: {:d} 伤害: 1/3 目标​生命"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1649
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] "你有 {:d} 金币。你想要取出多少？"
@@ -1230,7 +1230,7 @@ msgstr "在​商店​里"
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr "{:s}, 版本 = {:s}, 模式 = {:s}"
 
-#: Source/dvlnet/loopback.cpp:111
+#: Source/dvlnet/loopback.cpp:113
 msgid "loopback"
 msgstr "环回"
 
@@ -1686,7 +1686,9 @@ msgstr ""
 "来​使用。"
 
 #: Source/help.cpp:68
-msgid "$Gold"
+#, fuzzy
+#| msgid "$Gold"
+msgid "$Gold:"
 msgstr "金币​(​$​G)"
 
 #: Source/help.cpp:69
@@ -1712,7 +1714,9 @@ msgstr ""
 "术​可以​通过​在​游戏​区域​中​单击​右键​来​施放。"
 
 #: Source/help.cpp:79
-msgid "$Using the Speedbook for Spells"
+#, fuzzy
+#| msgid "$Using the Speedbook for Spells"
+msgid "$Using the Speedbook for Spells:"
 msgstr "为​法术​使用​速度​书(​$​U)"
 
 #: Source/help.cpp:80
@@ -1725,13 +1729,19 @@ msgstr ""
 "使用​准备​好​的​技能​或​法术，只​需​在​主​游戏区​右键​单击​即​可。"
 
 #: Source/help.cpp:84
+#, fuzzy
+#| msgid ""
+#| "Shift + Left-clicking on the 'select current spell' button will clear the "
+#| "readied spell"
 msgid ""
 "Shift + Left-clicking on the 'select current spell' button will clear the "
-"readied spell"
+"readied spell."
 msgstr "Shift + 左键​单击​“​选择​当前​法术​”​按钮​将​清除​准备​好​的​法术"
 
 #: Source/help.cpp:86
-msgid "$Setting Spell Hotkeys"
+#, fuzzy
+#| msgid "$Setting Spell Hotkeys"
+msgid "$Setting Spell Hotkeys:"
 msgstr "设置​技能​热键(​$​S)"
 
 #: Source/help.cpp:87
@@ -1744,7 +1754,9 @@ msgstr ""
 "中​要​分配​的​法术​后，按 F5、F6、F7 或 F8 键。"
 
 #: Source/help.cpp:92
-msgid "$Spell Books"
+#, fuzzy
+#| msgid "$Spell Books"
+msgid "$Spell Books:"
 msgstr "法术书(​$​S)"
 
 #: Source/help.cpp:93
@@ -1753,35 +1765,35 @@ msgid ""
 "you to cast the spell more effectively."
 msgstr "阅读​不止​一​本​书​可以​增加​您​对​该​法术​的​了解，使​您​能够​更​有效​地​施展​该​法术。"
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Shareware Hellfire Help"
 msgstr "共​享​软件​地狱火​帮助"
 
-#: Source/help.cpp:135
+#: Source/help.cpp:181
 msgid "Hellfire Help"
 msgstr "地​狱火​帮助"
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Shareware Diablo Help"
 msgstr "共​享​软件​暗黑​破坏​神​帮助"
 
-#: Source/help.cpp:137
+#: Source/help.cpp:183
 msgid "Diablo Help"
 msgstr "暗​黑​破坏​神​帮助"
 
-#: Source/help.cpp:161
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr "按​ESC键​结束，或​按​方向​键​滚动。"
 
-#: Source/init.cpp:206
+#: Source/init.cpp:175
 msgid "diabdat.mpq or spawn.mpq"
 msgstr "diabdat.mpq或spawn.mpq"
 
-#: Source/init.cpp:226
+#: Source/init.cpp:196
 msgid "Some Hellfire MPQs are missing"
 msgstr "一些​地狱火​MPQ​无法​找到"
 
-#: Source/init.cpp:226
+#: Source/init.cpp:196
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
@@ -1789,7 +1801,7 @@ msgstr ""
 "地​狱火​MPQ​未​能​全部​找到。\n"
 "​请​复制​所有​hf​*​.mpq​文件。"
 
-#: Source/init.cpp:234
+#: Source/init.cpp:204
 msgid "Unable to create main window"
 msgstr "无法​创建主​窗口"
 
@@ -2033,7 +2045,7 @@ msgid "Quilted Armor"
 msgstr "内​衬甲"
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
-#: Source/itemdat.cpp:77 Source/objects.cpp:5435
+#: Source/itemdat.cpp:77 Source/objects.cpp:5433
 msgid "Armor"
 msgstr "护​甲"
 
@@ -3575,635 +3587,648 @@ msgstr "硬化​之​油"
 msgid "Oil of Imperviousness"
 msgstr "防水​之​油"
 
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#: Source/items.cpp:1174 Source/items.cpp:1184 Source/items.cpp:1233
-#: Source/items.cpp:1269
-msgid "{0} {1}"
-msgstr "{0}{1}"
-
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's Staff of Firewall
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Long Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1187 Source/items.cpp:1254 Source/items.cpp:1273
-#: Source/items.cpp:1315
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
+#, fuzzy
+#| msgid "{0} of {1}"
+msgctxt "spell"
 msgid "{0} of {1}"
 msgstr "{1}{0}"
 
-#: Source/items.cpp:1892 Source/items.cpp:1904
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+#, fuzzy
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr "{2}{0}{1}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+#, fuzzy
+msgid "{0} {1} of {2}"
+msgstr "{2}{0}{1}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
+#: Source/items.cpp:1217
+msgid "{0} {1}"
+msgstr "{0}{1}"
+
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
+msgid "{0} of {1}"
+msgstr "{1}{0}"
+
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr "增加​武器​的"
 
-#: Source/items.cpp:1894
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr "命​中​概率"
 
-#: Source/items.cpp:1898
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr "显著​增加​一​件"
 
-#: Source/items.cpp:1900
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr "武器​命​中​概率"
 
-#: Source/items.cpp:1906
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr "伤害​潜力"
 
-#: Source/items.cpp:1910
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr "大大​提高​非弓类​武器"
 
-#: Source/items.cpp:1912
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr "的​伤害​潜力"
 
-#: Source/items.cpp:1916
+#: Source/items.cpp:1930
 msgid "reduces attributes needed"
 msgstr "减少​护甲​或​武器"
 
-#: Source/items.cpp:1918
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr "使用​所​需​属性"
 
-#: Source/items.cpp:1922
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr "恢复​20​%​的"
 
-#: Source/items.cpp:1924
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr "物品​耐久度"
 
-#: Source/items.cpp:1928
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr "增加​一​件​物品​的"
 
-#: Source/items.cpp:1930
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr "当前​和​最​大​耐久度"
 
-#: Source/items.cpp:1934
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr "使​物品​坚​不​可​摧"
 
-#: Source/items.cpp:1938
+#: Source/items.cpp:1952
 msgid "increases the armor class"
 msgstr "增加​护甲​和​盾牌​的"
 
-#: Source/items.cpp:1940
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr "护甲​等级"
 
-#: Source/items.cpp:1944
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr "极​大​增加​护甲​和​盾牌"
 
-#: Source/items.cpp:1946
+#: Source/items.cpp:1960
 msgid "class of armor and shields"
 msgstr "的​护甲​等级"
 
-#: Source/items.cpp:1950 Source/items.cpp:1959
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr "设置​火焰​陷阱"
 
-#: Source/items.cpp:1955
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr "设置​闪电​陷阱"
 
-#: Source/items.cpp:1963
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr "设置​石化​陷阱"
 
-#: Source/items.cpp:1967
+#: Source/items.cpp:1981
 msgid "restore all life"
 msgstr "恢复​所有​生命​值"
 
-#: Source/items.cpp:1971
+#: Source/items.cpp:1985
 msgid "restore some life"
 msgstr "恢复​部分​生命​值"
 
-#: Source/items.cpp:1975
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr "恢复​生命​值"
 
-#: Source/items.cpp:1979
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr "治疗​致命​伤"
 
-#: Source/items.cpp:1983
+#: Source/items.cpp:1997
 msgid "restore some mana"
 msgstr "恢复​部分​法力"
 
-#: Source/items.cpp:1987
+#: Source/items.cpp:2001
 msgid "restore all mana"
 msgstr "恢复​所有​法力"
 
-#: Source/items.cpp:1991
+#: Source/items.cpp:2005
 msgid "increase strength"
 msgstr "增加​力量"
 
-#: Source/items.cpp:1995
+#: Source/items.cpp:2009
 msgid "increase magic"
 msgstr "增加​魔法"
 
-#: Source/items.cpp:1999
+#: Source/items.cpp:2013
 msgid "increase dexterity"
 msgstr "增加​敏捷"
 
-#: Source/items.cpp:2003
+#: Source/items.cpp:2017
 msgid "increase vitality"
 msgstr "增加​活力"
 
-#: Source/items.cpp:2008
+#: Source/items.cpp:2022
 msgid "decrease strength"
 msgstr "降低​力量"
 
-#: Source/items.cpp:2012
+#: Source/items.cpp:2026
 msgid "decrease dexterity"
 msgstr "降低​敏捷"
 
-#: Source/items.cpp:2016
+#: Source/items.cpp:2030
 msgid "decrease vitality"
 msgstr "降低​活力"
 
-#: Source/items.cpp:2020
+#: Source/items.cpp:2034
 msgid "restore some life and mana"
 msgstr "恢复​部分​生命​和​法力"
 
-#: Source/items.cpp:2024
+#: Source/items.cpp:2038
 msgid "restore all life and mana"
 msgstr "恢复​所有​生命​和​法力"
 
-#: Source/items.cpp:2039 Source/items.cpp:2064
+#: Source/items.cpp:2053 Source/items.cpp:2078
 msgid "Right-click to read"
 msgstr "右击​阅读"
 
-#: Source/items.cpp:2043
+#: Source/items.cpp:2057
 msgid "Right-click to read, then"
 msgstr "右击​阅读，然后"
 
-#: Source/items.cpp:2045
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr "左击​目标"
 
-#: Source/items.cpp:2050
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr "右击​使用"
 
-#: Source/items.cpp:2055 Source/items.cpp:2060
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr "右击​使用"
 
-#: Source/items.cpp:2068
+#: Source/items.cpp:2082
 msgid "Right click to read"
 msgstr "右击​阅读"
 
-#: Source/items.cpp:2072
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr "右击​查看"
 
-#: Source/items.cpp:2080
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr "金币​容量​翻倍"
 
-#: Source/items.cpp:2092 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 msgid "Required:"
 msgstr "需求:"
 
-#: Source/items.cpp:2094 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 msgid " {:d} Str"
 msgstr " {:d} 力量"
 
-#: Source/items.cpp:2096 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 msgid " {:d} Mag"
 msgstr " {:d} 魔法"
 
-#: Source/items.cpp:2098 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 msgid " {:d} Dex"
 msgstr " {:d} 敏捷"
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3523 Source/player.cpp:3027
+#: Source/items.cpp:3533 Source/player.cpp:3018
 msgid "Ear of {:s}"
 msgstr "{:s}​的​耳朵"
 
-#: Source/items.cpp:3818
+#: Source/items.cpp:3828
 msgid "chance to hit: {:+d}%"
 msgstr "命​中​几​率: {:+d}%"
 
-#: Source/items.cpp:3822
+#: Source/items.cpp:3832
 #, no-c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% 伤害"
 
-#: Source/items.cpp:3826 Source/items.cpp:4082
+#: Source/items.cpp:3836 Source/items.cpp:4092
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "命​中: {:+d}%​, {:+d}%​伤害"
 
-#: Source/items.cpp:3830
+#: Source/items.cpp:3840
 #, no-c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% 护甲"
 
-#: Source/items.cpp:3834
+#: Source/items.cpp:3844
 msgid "armor class: {:d}"
 msgstr "护甲​等级: {:d}"
 
-#: Source/items.cpp:3839 Source/items.cpp:4064
+#: Source/items.cpp:3849 Source/items.cpp:4074
 msgid "Resist Fire: {:+d}%"
 msgstr "火焰​抗性: {:+d}%"
 
-#: Source/items.cpp:3841
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr "火焰​抗性: 最​大​75%"
 
-#: Source/items.cpp:3846
+#: Source/items.cpp:3856
 msgid "Resist Lightning: {:+d}%"
 msgstr "闪电​抗性: {:+d}%"
 
-#: Source/items.cpp:3848
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr "闪电​抗性: 最​大​75%"
 
-#: Source/items.cpp:3853
+#: Source/items.cpp:3863
 msgid "Resist Magic: {:+d}%"
 msgstr "抵抗​魔法: {:+d}%"
 
-#: Source/items.cpp:3855
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr "抵抗​魔法: 最​大​75%"
 
-#: Source/items.cpp:3860
+#: Source/items.cpp:3870
 msgid "Resist All: {:+d}%"
 msgstr "所有​抗性: {:+d}%"
 
-#: Source/items.cpp:3862
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr "所有​抗性: 最​大​75%"
 
-#: Source/items.cpp:3866
+#: Source/items.cpp:3876
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] "法术增加{:d}级"
 
-#: Source/items.cpp:3868
+#: Source/items.cpp:3878
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "法术降低{:d}级"
 
-#: Source/items.cpp:3870
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr "法术​等级​不​变(?)"
 
-#: Source/items.cpp:3873
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr "额外​充能​次数"
 
-#: Source/items.cpp:3876
+#: Source/items.cpp:3886
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:d} {:s} 充能"
 
-#: Source/items.cpp:3880
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr "火焰​伤害: {:d}"
 
-#: Source/items.cpp:3882
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "火焰​伤害: {:d}-{:d}"
 
-#: Source/items.cpp:3886
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr "闪电​伤害: {:d}"
 
-#: Source/items.cpp:3888
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "闪电​伤害: {:d}-{:d}"
 
-#: Source/items.cpp:3892
+#: Source/items.cpp:3902
 msgid "{:+d} to strength"
 msgstr "{:+d} 力量"
 
-#: Source/items.cpp:3896
+#: Source/items.cpp:3906
 msgid "{:+d} to magic"
 msgstr "{:+d} 魔法"
 
-#: Source/items.cpp:3900
+#: Source/items.cpp:3910
 msgid "{:+d} to dexterity"
 msgstr "{:+d} 敏捷"
 
-#: Source/items.cpp:3904
+#: Source/items.cpp:3914
 msgid "{:+d} to vitality"
 msgstr "{:+d} 活力"
 
-#: Source/items.cpp:3908
+#: Source/items.cpp:3918
 msgid "{:+d} to all attributes"
 msgstr "{:+d} 所有​属性"
 
-#: Source/items.cpp:3912
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} 来自​敌人​的​伤害"
 
-#: Source/items.cpp:3916
+#: Source/items.cpp:3926
 msgid "Hit Points: {:+d}"
 msgstr "生命​值: {:+d}"
 
-#: Source/items.cpp:3920
+#: Source/items.cpp:3930
 msgid "Mana: {:+d}"
 msgstr "法力值: {:+d}"
 
-#: Source/items.cpp:3923
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr "高​耐​久度"
 
-#: Source/items.cpp:3926
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr "耐​久度​降低"
 
-#: Source/items.cpp:3929
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr "坚​不​可​摧"
 
-#: Source/items.cpp:3932
+#: Source/items.cpp:3942
 #, no-c-format
 msgid "+{:d}% light radius"
 msgstr "+{:d}% 照亮​范围"
 
-#: Source/items.cpp:3935
+#: Source/items.cpp:3945
 #, no-c-format
 msgid "-{:d}% light radius"
 msgstr "-{:d}% 照亮​范围"
 
-#: Source/items.cpp:3938
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr "多​重​射击"
 
-#: Source/items.cpp:3942
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr "火箭​伤害: {:d}"
 
-#: Source/items.cpp:3944
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "火箭​伤害: {:d}-{:d}"
 
-#: Source/items.cpp:3948
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr "闪​电箭​伤害​{:d}"
 
-#: Source/items.cpp:3950
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "闪​电箭​伤害​{:d}-{:d}"
 
-#: Source/items.cpp:3954
+#: Source/items.cpp:3964
 msgid "fireball damage: {:d}"
 msgstr "火球​伤害: {:d}"
 
-#: Source/items.cpp:3956
+#: Source/items.cpp:3966
 msgid "fireball damage: {:d}-{:d}"
 msgstr "火球​伤害: {:d}-{:d}"
 
-#: Source/items.cpp:3959
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr "攻击者​受到​1-3点​伤害"
 
-#: Source/items.cpp:3962
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr "使用者​失去​所有​法力值"
 
-#: Source/items.cpp:3965
+#: Source/items.cpp:3975
 msgid "you can't heal"
 msgstr "你​无法治​愈"
 
-#: Source/items.cpp:3968
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr "吸收​一半​陷阱​伤害"
 
-#: Source/items.cpp:3971
+#: Source/items.cpp:3981
 msgid "knocks target back"
 msgstr "击​退​目标"
 
-#: Source/items.cpp:3974
+#: Source/items.cpp:3984
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr "+200​% 对​恶魔​的​伤害"
 
-#: Source/items.cpp:3977
+#: Source/items.cpp:3987
 msgid "All Resistance equals 0"
 msgstr "所有​抗性​变为​0"
 
-#: Source/items.cpp:3980
+#: Source/items.cpp:3990
 msgid "hit monster doesn't heal"
 msgstr "命​中​怪物​无法​自愈"
 
-#: Source/items.cpp:3984
+#: Source/items.cpp:3994
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr "命​中时​3​%法力​偷取"
 
-#: Source/items.cpp:3986
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr "命​中时​5​%​法力​偷取"
 
-#: Source/items.cpp:3990
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr "命​中时​3​%​生命​偷取"
 
-#: Source/items.cpp:3992
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr "命​中时​5​%​生命​偷取"
 
-#: Source/items.cpp:3995
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr "穿透​目标​的​护甲"
 
-#: Source/items.cpp:3999
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr "快速​攻击"
 
-#: Source/items.cpp:4001
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr "更​快​攻击"
 
-#: Source/items.cpp:4003
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr "极​速​攻击"
 
-#: Source/items.cpp:4005
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr "最​快​攻击"
 
-#: Source/items.cpp:4009
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr "快速​打击​回复"
 
-#: Source/items.cpp:4011
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr "更​快​打击​回复"
 
-#: Source/items.cpp:4013
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr "最​快​打击​回复"
 
-#: Source/items.cpp:4016
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr "快速​格挡"
 
-#: Source/items.cpp:4019
+#: Source/items.cpp:4029
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] "增加{:d}点伤害"
 
-#: Source/items.cpp:4022
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr "发射​随机​速度​箭矢"
 
-#: Source/items.cpp:4025
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr "异常​的​物品​损坏"
 
-#: Source/items.cpp:4028
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr "改变​耐​久度"
 
-#: Source/items.cpp:4031
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr "更​快​的​挥动"
 
-#: Source/items.cpp:4034
+#: Source/items.cpp:4044
 msgid "one handed sword"
 msgstr "单手​剑"
 
-#: Source/items.cpp:4037
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr "持续​失去​生命值"
 
-#: Source/items.cpp:4040
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr "生命​偷取"
 
-#: Source/items.cpp:4043
+#: Source/items.cpp:4053
 msgid "no strength requirement"
 msgstr "无​力量​要求"
 
-#: Source/items.cpp:4046
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr "夜视​能力"
 
-#: Source/items.cpp:4053
+#: Source/items.cpp:4063
 msgid "lightning damage: {:d}"
 msgstr "闪电​伤害: {:d}"
 
-#: Source/items.cpp:4055
+#: Source/items.cpp:4065
 msgid "lightning damage: {:d}-{:d}"
 msgstr "闪电​伤害: {:d}-{:d}"
 
-#: Source/items.cpp:4058
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr "击​中时​触发电​荷弹"
 
-#: Source/items.cpp:4067
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr "有​概率​造成​三​倍​伤害"
 
-#: Source/items.cpp:4070
+#: Source/items.cpp:4080
 #, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr "减少​{:+d}%​伤害"
 
-#: Source/items.cpp:4073
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr "2x 对​怪物​伤害，1x 反噬​自身"
 
-#: Source/items.cpp:4076
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr "随机​0-500​%​伤害"
 
-#: Source/items.cpp:4079
+#: Source/items.cpp:4089
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr "低​耐久，{:+d}% d​伤害"
 
-#: Source/items.cpp:4085
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr "对抗​恶魔​的​额外​精准"
 
-#: Source/items.cpp:4088
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr "对抗​亡灵​的​额外​精准"
 
-#: Source/items.cpp:4091
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr "50​%​法​力值​转换​至​生命​值"
 
-#: Source/items.cpp:4094
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr "40​%​的​生命值​转换​至​法力值"
 
-#: Source/items.cpp:4097
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr "另​一​种​能力​(​NW)"
 
-#: Source/items.cpp:4134 Source/items.cpp:4181
+#: Source/items.cpp:4144 Source/items.cpp:4191
 msgid "damage: {:d}  Indestructible"
 msgstr "伤害: {:d}  坚不​可​摧"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4136 Source/items.cpp:4183
+#: Source/items.cpp:4146 Source/items.cpp:4193
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "伤害: {:d} 耐久: {:d}/{:d}"
 
-#: Source/items.cpp:4139 Source/items.cpp:4186
+#: Source/items.cpp:4149 Source/items.cpp:4196
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "伤害: {:d}-{:d} 坚不​可​摧"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4141 Source/items.cpp:4188
+#: Source/items.cpp:4151 Source/items.cpp:4198
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "伤害: {:d}-{:d} 耐久: {:d}/{:d}"
 
-#: Source/items.cpp:4147 Source/items.cpp:4200
+#: Source/items.cpp:4157 Source/items.cpp:4210
 msgid "armor: {:d}  Indestructible"
 msgstr "护​甲: {:d} 坚不​可​摧"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4149 Source/items.cpp:4202
+#: Source/items.cpp:4159 Source/items.cpp:4212
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "护​甲: {:d} 耐久: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4154
+#: Source/items.cpp:4164
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "伤害: {:d} 耐久: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4156
+#: Source/items.cpp:4166
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "伤害: {:d}-{:d} 耐久: {:d}/{:d}"
 
-#: Source/items.cpp:4157 Source/items.cpp:4192 Source/items.cpp:4207
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 msgid "Charges: {:d}/{:d}"
 msgstr "充能: {:d}/{:d}"
 
-#: Source/items.cpp:4169
+#: Source/items.cpp:4179
 msgid "unique item"
 msgstr "独特​装备"
 
-#: Source/items.cpp:4196 Source/items.cpp:4205 Source/items.cpp:4212
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr "未​鉴定"
 
@@ -5392,97 +5417,97 @@ msgctxt "monster"
 msgid "Doomlock"
 msgstr "杜姆洛克"
 
-#: Source/monster.cpp:3497
+#: Source/monster.cpp:3479
 msgid "Animal"
 msgstr "野兽"
 
-#: Source/monster.cpp:3499
+#: Source/monster.cpp:3481
 msgid "Demon"
 msgstr "恶魔"
 
-#: Source/monster.cpp:3501
+#: Source/monster.cpp:3483
 msgid "Undead"
 msgstr "亡灵"
 
-#: Source/monster.cpp:4632
+#: Source/monster.cpp:4612
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "类型: {:s} 击杀: {:d}"
 
-#: Source/monster.cpp:4634
+#: Source/monster.cpp:4614
 msgid "Total kills: {:d}"
 msgstr "击杀​总数: {:d}"
 
-#: Source/monster.cpp:4667
+#: Source/monster.cpp:4647
 msgid "Hit Points: {:d}-{:d}"
 msgstr "生命​值: {:d}-{:d}"
 
-#: Source/monster.cpp:4673
+#: Source/monster.cpp:4653
 msgid "No magic resistance"
 msgstr "没有​魔法​抗性"
 
-#: Source/monster.cpp:4677
+#: Source/monster.cpp:4657
 msgid "Resists: "
 msgstr "抗性: "
 
-#: Source/monster.cpp:4679 Source/monster.cpp:4690
+#: Source/monster.cpp:4659 Source/monster.cpp:4671
 msgid "Magic "
 msgstr "魔法 "
 
-#: Source/monster.cpp:4681 Source/monster.cpp:4692
+#: Source/monster.cpp:4661 Source/monster.cpp:4673
 msgid "Fire "
 msgstr "火焰 "
 
-#: Source/monster.cpp:4683 Source/monster.cpp:4694
+#: Source/monster.cpp:4663 Source/monster.cpp:4675
 msgid "Lightning "
 msgstr "闪电 "
 
-#: Source/monster.cpp:4688
+#: Source/monster.cpp:4669
 msgid "Immune: "
 msgstr "免疫: "
 
-#: Source/monster.cpp:4706
+#: Source/monster.cpp:4688
 msgid "Type: {:s}"
 msgstr "类型: {:s}"
 
-#: Source/monster.cpp:4712 Source/monster.cpp:4719
+#: Source/monster.cpp:4694 Source/monster.cpp:4701
 msgid "No resistances"
 msgstr "无​抗性"
 
-#: Source/monster.cpp:4714 Source/monster.cpp:4724
+#: Source/monster.cpp:4696 Source/monster.cpp:4706
 msgid "No Immunities"
 msgstr "无​免疫"
 
-#: Source/monster.cpp:4717
+#: Source/monster.cpp:4699
 msgid "Some Magic Resistances"
 msgstr "部分​魔法​抗性"
 
-#: Source/monster.cpp:4722
+#: Source/monster.cpp:4704
 msgid "Some Magic Immunities"
 msgstr "部分​魔法​免疫"
 
-#: Source/msg.cpp:494
+#: Source/msg.cpp:495
 msgid "Trying to drop a floor item?"
 msgstr "尝试​扔​掉​一些​物品​?"
 
-#: Source/msg.cpp:982 Source/msg.cpp:1017 Source/msg.cpp:1048
-#: Source/msg.cpp:1175 Source/msg.cpp:1207 Source/msg.cpp:1239
-#: Source/msg.cpp:1269
+#: Source/msg.cpp:994 Source/msg.cpp:1029 Source/msg.cpp:1060
+#: Source/msg.cpp:1187 Source/msg.cpp:1219 Source/msg.cpp:1251
+#: Source/msg.cpp:1281
 msgid "{:s} has cast an illegal spell."
 msgstr "{:s}​施放​了​非法​法术。"
 
-#: Source/msg.cpp:1655 Source/multi.cpp:805
+#: Source/msg.cpp:1668 Source/multi.cpp:804
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr "玩​家​{:s}(​等级​{:d}​)​刚​加入​了​游戏"
 
-#: Source/msg.cpp:1959
+#: Source/msg.cpp:1972
 msgid "Waiting for game data..."
 msgstr "正在​等待​游戏​数据​…​…"
 
-#: Source/msg.cpp:1967
+#: Source/msg.cpp:1980
 msgid "The game ended"
 msgstr "比赛​结束​了"
 
-#: Source/msg.cpp:1973
+#: Source/msg.cpp:1986
 msgid "Unable to get level data"
 msgstr "无法​获取​场景​数据"
 
@@ -5498,7 +5523,7 @@ msgstr "玩​家​{:s}​杀死​了​迪亚波罗​并​离开​了​�
 msgid "Player '{:s}' dropped due to timeout"
 msgstr "由于​超时，玩​家​{:s}​的​掉落物​被​删除"
 
-#: Source/multi.cpp:807
+#: Source/multi.cpp:806
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr "玩​家​{:s}(​等级​{:d})​已经​在​游戏​中"
 
@@ -5708,158 +5733,158 @@ msgstr "日记: 结束"
 msgid "A Spellbook"
 msgstr "一​本法术书"
 
-#: Source/objects.cpp:5341
+#: Source/objects.cpp:5339
 msgid "Crucified Skeleton"
 msgstr "钉死​的​骷髅"
 
-#: Source/objects.cpp:5345
+#: Source/objects.cpp:5343
 msgid "Lever"
 msgstr "控制​杆"
 
-#: Source/objects.cpp:5354
+#: Source/objects.cpp:5352
 msgid "Open Door"
 msgstr "打开​的​门"
 
-#: Source/objects.cpp:5356
+#: Source/objects.cpp:5354
 msgid "Closed Door"
 msgstr "关闭​的​门"
 
-#: Source/objects.cpp:5358
+#: Source/objects.cpp:5356
 msgid "Blocked Door"
 msgstr "封死​的​门"
 
-#: Source/objects.cpp:5363
+#: Source/objects.cpp:5361
 msgid "Ancient Tome"
 msgstr "古籍"
 
-#: Source/objects.cpp:5365
+#: Source/objects.cpp:5363
 msgid "Book of Vileness"
 msgstr "卑鄙​之​书"
 
-#: Source/objects.cpp:5370
+#: Source/objects.cpp:5368
 msgid "Skull Lever"
 msgstr "骸​骨​控制杆"
 
-#: Source/objects.cpp:5373
+#: Source/objects.cpp:5371
 msgid "Mythical Book"
 msgstr "神秘​之​书"
 
-#: Source/objects.cpp:5377
+#: Source/objects.cpp:5375
 msgid "Small Chest"
 msgstr "小​箱子"
 
-#: Source/objects.cpp:5381
+#: Source/objects.cpp:5379
 msgid "Chest"
 msgstr "箱子"
 
-#: Source/objects.cpp:5386
+#: Source/objects.cpp:5384
 msgid "Large Chest"
 msgstr "大​箱子"
 
-#: Source/objects.cpp:5389
+#: Source/objects.cpp:5387
 msgid "Sarcophagus"
 msgstr "石​棺"
 
-#: Source/objects.cpp:5392
+#: Source/objects.cpp:5390
 msgid "Bookshelf"
 msgstr "书架"
 
-#: Source/objects.cpp:5396
+#: Source/objects.cpp:5394
 msgid "Bookcase"
 msgstr "书柜"
 
-#: Source/objects.cpp:5401
+#: Source/objects.cpp:5399
 msgid "Pod"
 msgstr "茧"
 
-#: Source/objects.cpp:5403
+#: Source/objects.cpp:5401
 msgid "Urn"
 msgstr "罐子"
 
-#: Source/objects.cpp:5405
+#: Source/objects.cpp:5403
 msgid "Barrel"
 msgstr "木桶"
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:5409
+#: Source/objects.cpp:5407
 msgid "{:s} Shrine"
 msgstr "{:s}​圣坛"
 
-#: Source/objects.cpp:5413
+#: Source/objects.cpp:5411
 msgid "Skeleton Tome"
 msgstr "骸​骨堆"
 
-#: Source/objects.cpp:5416
+#: Source/objects.cpp:5414
 msgid "Library Book"
 msgstr "典籍"
 
-#: Source/objects.cpp:5419
+#: Source/objects.cpp:5417
 msgid "Blood Fountain"
 msgstr "血泉"
 
-#: Source/objects.cpp:5422
+#: Source/objects.cpp:5420
 msgid "Decapitated Body"
 msgstr "无​头​尸"
 
-#: Source/objects.cpp:5425
+#: Source/objects.cpp:5423
 msgid "Book of the Blind"
 msgstr "目盲​之​书"
 
-#: Source/objects.cpp:5428
+#: Source/objects.cpp:5426
 msgid "Book of Blood"
 msgstr "鲜血​之​书"
 
-#: Source/objects.cpp:5431
+#: Source/objects.cpp:5429
 msgid "Purifying Spring"
 msgstr "纯​净​之泉"
 
-#: Source/objects.cpp:5438 Source/objects.cpp:5462
+#: Source/objects.cpp:5436 Source/objects.cpp:5460
 msgid "Weapon Rack"
 msgstr "武器​架"
 
-#: Source/objects.cpp:5441
+#: Source/objects.cpp:5439
 msgid "Goat Shrine"
 msgstr "山​羊​神殿"
 
-#: Source/objects.cpp:5444
+#: Source/objects.cpp:5442
 msgid "Cauldron"
 msgstr "坩​埚"
 
-#: Source/objects.cpp:5447
+#: Source/objects.cpp:5445
 msgid "Murky Pool"
 msgstr "浑浊​的​水池"
 
-#: Source/objects.cpp:5450
+#: Source/objects.cpp:5448
 msgid "Fountain of Tears"
 msgstr "泪泉"
 
-#: Source/objects.cpp:5453
+#: Source/objects.cpp:5451
 msgid "Steel Tome"
 msgstr "钢铁​之​书"
 
-#: Source/objects.cpp:5456
+#: Source/objects.cpp:5454
 msgid "Pedestal of Blood"
 msgstr "鲜血​底​座"
 
-#: Source/objects.cpp:5465
+#: Source/objects.cpp:5463
 msgid "Mushroom Patch"
 msgstr "蘑菇​碎片"
 
-#: Source/objects.cpp:5468
+#: Source/objects.cpp:5466
 msgid "Vile Stand"
 msgstr "卑鄙​旗帜"
 
-#: Source/objects.cpp:5471
+#: Source/objects.cpp:5469
 msgid "Slain Hero"
 msgstr "被​杀​英雄"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:5478
+#: Source/objects.cpp:5476
 msgid "Trapped {:s}"
 msgstr "机关​{:s}"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
-#: Source/objects.cpp:5484
+#: Source/objects.cpp:5482
 msgid "{:s} (disabled)"
 msgstr "{:s}(​已​禁​用​)"
 
@@ -5977,23 +6002,23 @@ msgstr "法术"
 msgid "mute"
 msgstr "静​音"
 
-#: Source/pfile.cpp:260
+#: Source/pfile.cpp:242
 msgid "Failed to open player archive for writing."
 msgstr "无法​加载​玩​家​数据​进行​写入。"
 
-#: Source/pfile.cpp:392
+#: Source/pfile.cpp:377
 msgid "Unable to open archive"
 msgstr "无法​打开​存档"
 
-#: Source/pfile.cpp:394
+#: Source/pfile.cpp:379
 msgid "Unable to load character"
 msgstr "无法​加载​角色"
 
-#: Source/pfile.cpp:419 Source/pfile.cpp:439
+#: Source/pfile.cpp:403 Source/pfile.cpp:423
 msgid "Unable to read to save file archive"
 msgstr "因​无法​读取，无法​保存​存档"
 
-#: Source/pfile.cpp:458
+#: Source/pfile.cpp:442
 msgid "Unable to write to save file archive"
 msgstr "因​无法​写入，无法​保存​存档"
 
@@ -6012,7 +6037,7 @@ msgstr ",%03d"
 msgid "%i gold"
 msgstr "%i 金币"
 
-#: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:56
+#: Source/qol/monhealthbar.cpp:37 Source/qol/xpbar.cpp:56
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
@@ -6450,7 +6475,7 @@ msgstr "法恩汉"
 msgid "Adria"
 msgstr "艾德莉亚"
 
-#: Source/stores.cpp:98 Source/stores.cpp:1252
+#: Source/stores.cpp:98 Source/stores.cpp:1305
 #, fuzzy
 #| msgid "brilliance"
 msgid "Gillian"
@@ -6460,298 +6485,293 @@ msgstr "辉煌"
 msgid "Wirt"
 msgstr ""
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr "返回"
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ",  "
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 msgid "Damage: {:d}-{:d}  "
 msgstr "伤害: {:d}-{:d} "
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 msgid "Armor: {:d}  "
 msgstr "护​甲: {:d} "
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 msgid "Dur: {:d}/{:d},  "
 msgstr "耐久: {:d}/{:d}, "
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr "坚​不​可摧​,  "
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr "无​需​属性"
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr "欢迎​来到"
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr "铁匠​铺"
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr "您​想:"
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 msgid "Talk to Griswold"
 msgstr "与​格里斯沃尔德​交谈"
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 msgid "Buy basic items"
 msgstr "购买​基础​物品"
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 msgid "Buy premium items"
 msgstr "购买​高级​物品"
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 msgid "Sell items"
 msgstr "出售​物品"
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 msgid "Repair items"
 msgstr "修理​物品"
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 msgid "Leave the shop"
 msgstr "离开​商店"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "我​有​这些​东西​要​卖: 你​的​金币: {:d}"
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr "返回"
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "我​这​有些​高档品​出售: 你​的​金币: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "你​没有​我​想要​的​东西。你​的​金币: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "要​出售​哪​件​物品？你​的​金币: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "你​没有​需要​修理​的​物品。你​的​金币: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "哪​件​物品​需要​修理？你​的​金币: {:d}"
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr "女​巫小屋"
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 msgid "Talk to Adria"
 msgstr "与​艾德莉亚​交谈"
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr "购买​物品"
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr "给​魔杖​重新​充能"
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 msgid "Leave the shack"
 msgstr "离开​小​屋"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "你​没有​物品​需要​充能。你​的​金币: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "给​哪​件​物品​充能？你​的​金币: {:d}"
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr "你​没有​足够​的​金币"
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr "您​的​物品​栏​空间​不​足"
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr "我们​有​生意​往来​吗？"
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 msgid "Are you sure you want to identify this item?"
 msgstr "您​确定​要​鉴定​这​件​物品​吗？"
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 msgid "Are you sure you want to buy this item?"
 msgstr "您​确定​要​购买​这​件​物品​吗？"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 msgid "Are you sure you want to recharge this item?"
 msgstr "您​确定​要​为​该​物品​充能​吗？"
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 msgid "Are you sure you want to sell this item?"
 msgstr "您​确定​要​出售​这​件​物品​吗？"
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 msgid "Are you sure you want to repair this item?"
 msgstr "您​确定​要​修理​这​件​物品​吗？"
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr "假腿​男孩​怀​特"
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 msgid "Talk to Wirt"
 msgstr "和​怀特​谈​谈"
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr "我​有​东西​要​出售，"
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr "但​要​花 50 金币"
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr "才​能​看上​一​眼。"
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr "你​找到​了​什么​东西？"
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr "再见"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "我​有​这个​东西​要​卖: 你​的​金币: {:d}"
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 msgid "Leave"
 msgstr "离开"
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr "治疗者​的​家"
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr "与​佩金​交谈"
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr "离开​治疗者​的​家"
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 msgid "The Town Elder"
 msgstr "镇​上​的​长老"
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 msgid "Talk to Cain"
 msgstr "与​凯恩​交谈"
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr "鉴定​一​件​物品"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "你​没有​可以​鉴定​的​物品。你​的​金币: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "鉴定​哪​一​件​物品？你​的​金币: {:d}"
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr "这​件​物品​是:"
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr "完成"
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 msgid "Talk to {:s}"
 msgstr "与​{:s}​交谈"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 msgid "Talking to {:s}"
 msgstr "与​{:s}​交谈"
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 msgid "is not available"
 msgstr "不​可​用"
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 msgid "in the shareware"
 msgstr "在​共​享​软件​中"
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 msgid "version"
 msgstr "版本"
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr "闲聊"
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr "朝阳​旅店"
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 msgid "Talk to Ogden"
 msgstr "与​奥格登​交谈"
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 msgid "Leave the tavern"
 msgstr "离开​酒馆"
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 msgid "Talk to Gillian"
 msgstr "与​吉莉安​交谈"
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr "醉​汉法恩汉"
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 msgid "Talk to Farnham"
 msgstr "与​法恩汉​交谈"
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr "再见"
 

--- a/Translations/zh_TW.po
+++ b/Translations/zh_TW.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2021-09-20 04:34+0200\n"
+"POT-Creation-Date: 2021-11-21 05:46+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Aaron Sun <AaronSun.Test@gmail.com>\n"
 "Language-Team: \n"
@@ -157,6 +157,7 @@ msgstr "品​保​火力​支援​小組​（​附加​測試人員​）
 msgid "QA Counterintelligence"
 msgstr "品​保​反情​小​組"
 
+#. TRANSLATORS: A group of people
 #: Source/DiabloUI/credits_lines.cpp:130
 msgid "Order of Network Information Services"
 msgstr "NIS系統​維護​管理"
@@ -309,15 +310,49 @@ msgstr "最初​的​一千​名​Beta測試人員​（​The Ring of One T
 msgid "\tNo souls were sold in the making of this game."
 msgstr "\t​在​這個​遊戲​的​製作​過程​中​沒​有​任何​靈魂​被​出賣。"
 
-#: Source/DiabloUI/dialogs.cpp:172 Source/DiabloUI/dialogs.cpp:185
-#: Source/DiabloUI/selconn.cpp:73 Source/DiabloUI/selgame.cpp:94
-#: Source/DiabloUI/selgame.cpp:163 Source/DiabloUI/selgame.cpp:181
-#: Source/DiabloUI/selgame.cpp:314 Source/DiabloUI/selgame.cpp:387
-#: Source/DiabloUI/selhero.cpp:185 Source/DiabloUI/selhero.cpp:210
-#: Source/DiabloUI/selhero.cpp:280 Source/DiabloUI/selhero.cpp:525
+#: Source/DiabloUI/dialogs.cpp:194 Source/DiabloUI/dialogs.cpp:206
+#: Source/DiabloUI/selconn.cpp:79 Source/DiabloUI/selgame.cpp:103
+#: Source/DiabloUI/selgame.cpp:193 Source/DiabloUI/selgame.cpp:211
+#: Source/DiabloUI/selgame.cpp:352 Source/DiabloUI/selgame.cpp:428
+#: Source/DiabloUI/selhero.cpp:186 Source/DiabloUI/selhero.cpp:211
+#: Source/DiabloUI/selhero.cpp:281 Source/DiabloUI/selhero.cpp:536
 #: Source/DiabloUI/selok.cpp:68
 msgid "OK"
 msgstr "好"
+
+#: Source/DiabloUI/extrasmenu.cpp:41 Source/DiabloUI/selstart.cpp:44
+#, fuzzy
+#| msgid "Down to Diablo"
+msgid "Switch to Diablo"
+msgstr "下​到​迪亞波羅"
+
+#: Source/DiabloUI/extrasmenu.cpp:41
+#, fuzzy
+#| msgid "Exit Hellfire"
+msgid "Switch to Hellfire"
+msgstr "退出​地​獄火"
+
+#: Source/DiabloUI/extrasmenu.cpp:43
+msgid "Switch to Fullgame"
+msgstr ""
+
+#: Source/DiabloUI/extrasmenu.cpp:43
+#, fuzzy
+#| msgid "in the shareware"
+msgid "Switch to Shareware"
+msgstr "在​共​享軟​體​中"
+
+#: Source/DiabloUI/extrasmenu.cpp:44
+msgid "Replay Intro"
+msgstr "重​播動​畫"
+
+#: Source/DiabloUI/extrasmenu.cpp:45
+msgid "Support"
+msgstr "支援"
+
+#: Source/DiabloUI/extrasmenu.cpp:46 Source/gamemenu.cpp:61
+msgid "Previous Menu"
+msgstr "上​一​個​菜單"
 
 #: Source/DiabloUI/mainmenu.cpp:36
 msgid "Single Player"
@@ -328,148 +363,164 @@ msgid "Multi Player"
 msgstr "多​人"
 
 #: Source/DiabloUI/mainmenu.cpp:38
-msgid "Replay Intro"
-msgstr "重​播動​畫"
+#, fuzzy
+#| msgid "Extra charges"
+msgid "Extras"
+msgstr "額​外​充能"
 
 #: Source/DiabloUI/mainmenu.cpp:39
-msgid "Support"
-msgstr "支援"
-
-#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Show Credits"
 msgstr "顯示製​作​組"
 
-#: Source/DiabloUI/mainmenu.cpp:41
+#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Exit Hellfire"
 msgstr "退出​地​獄火"
 
-#: Source/DiabloUI/mainmenu.cpp:41
+#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Exit Diablo"
 msgstr "退出​暗​黑破壞神"
 
-#. TRANSLATORS:  Error Message when a Shareware User clicks on "Replay Intro" in the Main Menu
-#: Source/DiabloUI/mainmenu.cpp:99
-msgid ""
-"The Diablo introduction cinematic is only available in the full retail "
-"version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
-msgstr ""
-"暗​黑破壞​神介紹​電影版​只​提供​完整​的​零售版​暗​黑破壞神。前往 https://www.gog.com/"
-"game/diablo 購買。"
+#: Source/DiabloUI/mainmenu.cpp:55
+#, fuzzy
+#| msgid "in the shareware"
+msgid "Shareware"
+msgstr "在​共​享軟​體​中"
 
-#: Source/DiabloUI/progress.cpp:48 Source/DiabloUI/selconn.cpp:76
-#: Source/DiabloUI/selhero.cpp:188 Source/DiabloUI/selhero.cpp:213
-#: Source/DiabloUI/selhero.cpp:283 Source/DiabloUI/selhero.cpp:533
+#: Source/DiabloUI/progress.cpp:36 Source/DiabloUI/selconn.cpp:82
+#: Source/DiabloUI/selhero.cpp:189 Source/DiabloUI/selhero.cpp:214
+#: Source/DiabloUI/selhero.cpp:284 Source/DiabloUI/selhero.cpp:544
 msgid "Cancel"
 msgstr "取消"
 
-#: Source/DiabloUI/selconn.cpp:38 Source/DiabloUI/selgame.cpp:77
-#: Source/DiabloUI/selgame.cpp:372
+#: Source/DiabloUI/selconn.cpp:13
 msgid "Client-Server (TCP)"
 msgstr "客​戶端伺服器​（​TCP​）"
 
-#: Source/DiabloUI/selconn.cpp:41
+#: Source/DiabloUI/selconn.cpp:14
 msgid "Loopback"
 msgstr "環​回"
 
-#: Source/DiabloUI/selconn.cpp:47 Source/DiabloUI/selgame.cpp:434
-#: Source/DiabloUI/selgame.cpp:452
+#: Source/DiabloUI/selconn.cpp:53 Source/DiabloUI/selgame.cpp:489
+#: Source/DiabloUI/selgame.cpp:510
 msgid "Multi Player Game"
 msgstr "多​人​遊戲"
 
-#: Source/DiabloUI/selconn.cpp:53
+#: Source/DiabloUI/selconn.cpp:59
 msgid "Requirements:"
 msgstr "要求: "
 
-#: Source/DiabloUI/selconn.cpp:59
+#: Source/DiabloUI/selconn.cpp:65
 msgid "no gateway needed"
 msgstr "不​需要​閘道器"
 
-#: Source/DiabloUI/selconn.cpp:65
+#: Source/DiabloUI/selconn.cpp:71
 msgid "Select Connection"
 msgstr "選​擇連線"
 
-#: Source/DiabloUI/selconn.cpp:68
+#: Source/DiabloUI/selconn.cpp:74
 msgid "Change Gateway"
 msgstr "更改​閘​道器"
 
-#: Source/DiabloUI/selconn.cpp:101
+#: Source/DiabloUI/selconn.cpp:107
 msgid "All computers must be connected to a TCP-compatible network."
 msgstr "所有​計算​機​必須連線​到​與​TCP​相容​的​網路。"
 
-#: Source/DiabloUI/selconn.cpp:105
+#: Source/DiabloUI/selconn.cpp:111
 msgid "All computers must be connected to the internet."
 msgstr "所有​計算機​都​必須​連線​到​因特網。"
 
-#: Source/DiabloUI/selconn.cpp:109
+#: Source/DiabloUI/selconn.cpp:115
 msgid "Play by yourself with no network exposure."
 msgstr "自己​玩，沒​有​網路​曝光。"
 
-#: Source/DiabloUI/selconn.cpp:114
+#: Source/DiabloUI/selconn.cpp:120
 msgid "Players Supported: {:d}"
 msgstr "支援​的​玩家: {:d}"
 
-#: Source/DiabloUI/selgame.cpp:80 Source/DiabloUI/selgame.cpp:375
+#: Source/DiabloUI/selgame.cpp:82 Source/DiabloUI/selgame.cpp:414
 msgid "Description:"
 msgstr "說​明: "
 
-#: Source/DiabloUI/selgame.cpp:86
+#: Source/DiabloUI/selgame.cpp:88
 msgid "Select Action"
 msgstr "選​擇​操作"
 
-#: Source/DiabloUI/selgame.cpp:88 Source/DiabloUI/selgame.cpp:151
-#: Source/DiabloUI/selgame.cpp:295
+#: Source/DiabloUI/selgame.cpp:91 Source/DiabloUI/selgame.cpp:181
+#: Source/DiabloUI/selgame.cpp:333
 msgid "Create Game"
 msgstr "建立​遊戲"
 
-#: Source/DiabloUI/selgame.cpp:89
+#: Source/DiabloUI/selgame.cpp:93
+#, fuzzy
+#| msgid "Create Game"
+msgid "Create Public Game"
+msgstr "建立​遊戲"
+
+#: Source/DiabloUI/selgame.cpp:94
 msgid "Join Game"
 msgstr "加入​遊戲"
 
-#: Source/DiabloUI/selgame.cpp:97 Source/DiabloUI/selgame.cpp:166
-#: Source/DiabloUI/selgame.cpp:184 Source/DiabloUI/selgame.cpp:317
-#: Source/DiabloUI/selgame.cpp:390
+#: Source/DiabloUI/selgame.cpp:106 Source/DiabloUI/selgame.cpp:196
+#: Source/DiabloUI/selgame.cpp:214 Source/DiabloUI/selgame.cpp:355
+#: Source/DiabloUI/selgame.cpp:431
 msgid "CANCEL"
 msgstr "取消"
 
-#: Source/DiabloUI/selgame.cpp:106
+#: Source/DiabloUI/selgame.cpp:122
 msgid "Create a new game with a difficulty setting of your choice."
 msgstr "建立​一​個​新​遊戲​的​難度​設定​你​的​選擇。"
 
-#: Source/DiabloUI/selgame.cpp:109
+#: Source/DiabloUI/selgame.cpp:125
+#, fuzzy
+#| msgid "Create a new game with a difficulty setting of your choice."
+msgid ""
+"Create a new public game that anyone can join with a difficulty setting of "
+"your choice."
+msgstr "建立​一​個​新​遊戲​的​難度​設定​你​的​選擇。"
+
+#: Source/DiabloUI/selgame.cpp:128
 msgid ""
 "Enter an IP or a hostname and join a game already in progress at that "
 "address."
 msgstr "輸入​IP​或​主機名，然​後​在​該​地址​加入​正在​進行​的​遊戲。"
 
-#: Source/DiabloUI/selgame.cpp:154
+#: Source/DiabloUI/selgame.cpp:131
+#, fuzzy
+#| msgid ""
+#| "Enter an IP or a hostname and join a game already in progress at that "
+#| "address."
+msgid "Join the public game already in progress at this address."
+msgstr "輸入​IP​或​主機名，然​後​在​該​地址​加入​正在​進行​的​遊戲。"
+
+#: Source/DiabloUI/selgame.cpp:184
 msgid "Select Difficulty"
 msgstr "選​擇​難度"
 
-#: Source/DiabloUI/selgame.cpp:156 Source/DiabloUI/selgame.cpp:203
-#: Source/DiabloUI/selgame.cpp:306 Source/DiabloUI/selgame.cpp:326
-#: Source/diablo.cpp:1434
+#: Source/DiabloUI/selgame.cpp:186 Source/DiabloUI/selgame.cpp:239
+#: Source/DiabloUI/selgame.cpp:344 Source/DiabloUI/selgame.cpp:364
+#: Source/diablo.cpp:1446
 msgid "Normal"
 msgstr "正常"
 
-#: Source/DiabloUI/selgame.cpp:157 Source/DiabloUI/selgame.cpp:207
-#: Source/diablo.cpp:1435
+#: Source/DiabloUI/selgame.cpp:187 Source/DiabloUI/selgame.cpp:243
+#: Source/diablo.cpp:1447
 msgid "Nightmare"
 msgstr "噩夢"
 
-#: Source/DiabloUI/selgame.cpp:158 Source/DiabloUI/selgame.cpp:211
-#: Source/diablo.cpp:1436
+#: Source/DiabloUI/selgame.cpp:188 Source/DiabloUI/selgame.cpp:247
+#: Source/diablo.cpp:1448
 msgid "Hell"
 msgstr "地​獄"
 
-#: Source/DiabloUI/selgame.cpp:172
+#: Source/DiabloUI/selgame.cpp:202
 msgid "Join TCP Games"
 msgstr "加入​TCP遊​戲"
 
-#: Source/DiabloUI/selgame.cpp:175 Source/DiabloUI/selgame.cpp:178
+#: Source/DiabloUI/selgame.cpp:205 Source/DiabloUI/selgame.cpp:208
 msgid "Enter address"
 msgstr "輸入​地址"
 
-#: Source/DiabloUI/selgame.cpp:204
+#: Source/DiabloUI/selgame.cpp:240
 msgid ""
 "Normal Difficulty\n"
 "This is where a starting character should begin the quest to defeat Diablo."
@@ -477,7 +528,7 @@ msgstr ""
 "正常​難度​\n"
 "這​是​一​個​開始​的​角色​應該​開始尋求擊敗迪亞波羅。"
 
-#: Source/DiabloUI/selgame.cpp:208
+#: Source/DiabloUI/selgame.cpp:244
 msgid ""
 "Nightmare Difficulty\n"
 "The denizens of the Labyrinth have been bolstered and will prove to be a "
@@ -486,7 +537,7 @@ msgstr ""
 "噩夢​難度​\n"
 "迷宮裡​的​居民​得到​了​支援，這將​是​一​個​更​大​的​挑戰。這隻​建議​有​經驗​的​角色​使用。"
 
-#: Source/DiabloUI/selgame.cpp:212
+#: Source/DiabloUI/selgame.cpp:248
 msgid ""
 "Hell Difficulty\n"
 "The most powerful of the underworld's creatures lurk at the gateway into "
@@ -496,35 +547,35 @@ msgstr ""
 "​最​強​大​的​地下​世界​的​生物​潛伏在地獄​的​大門。只有​最​有​經驗​的​人物​才​能​在​這個​領域​冒"
 "險。"
 
-#: Source/DiabloUI/selgame.cpp:227
+#: Source/DiabloUI/selgame.cpp:264
 msgid ""
 "Your character must reach level 20 before you can enter a multiplayer game "
 "of Nightmare difficulty."
 msgstr "你​的​角色​必須達​到​20​級​才​能​進入​多​人​遊戲​的​噩夢​難度。"
 
-#: Source/DiabloUI/selgame.cpp:229
+#: Source/DiabloUI/selgame.cpp:266
 msgid ""
 "Your character must reach level 30 before you can enter a multiplayer game "
 "of Hell difficulty."
 msgstr "你​的​角色​必須達​到​30​級​才​能​進入​地獄​難度​的​多​人​遊戲。"
 
-#: Source/DiabloUI/selgame.cpp:304
+#: Source/DiabloUI/selgame.cpp:342
 msgid "Select Game Speed"
 msgstr "選​擇遊戲​速度"
 
-#: Source/DiabloUI/selgame.cpp:307 Source/DiabloUI/selgame.cpp:330
+#: Source/DiabloUI/selgame.cpp:345 Source/DiabloUI/selgame.cpp:368
 msgid "Fast"
 msgstr "快速​的"
 
-#: Source/DiabloUI/selgame.cpp:308 Source/DiabloUI/selgame.cpp:334
+#: Source/DiabloUI/selgame.cpp:346 Source/DiabloUI/selgame.cpp:372
 msgid "Faster"
 msgstr "更​快"
 
-#: Source/DiabloUI/selgame.cpp:309 Source/DiabloUI/selgame.cpp:338
+#: Source/DiabloUI/selgame.cpp:347 Source/DiabloUI/selgame.cpp:376
 msgid "Fastest"
 msgstr "最​快​的"
 
-#: Source/DiabloUI/selgame.cpp:327
+#: Source/DiabloUI/selgame.cpp:365
 msgid ""
 "Normal Speed\n"
 "This is where a starting character should begin the quest to defeat Diablo."
@@ -532,7 +583,7 @@ msgstr ""
 "正常​速度​\n"
 "這​是​一​個​開始​的​角色​應該​開始尋求擊敗迪亞波羅。"
 
-#: Source/DiabloUI/selgame.cpp:331
+#: Source/DiabloUI/selgame.cpp:369
 msgid ""
 "Fast Speed\n"
 "The denizens of the Labyrinth have been hastened and will prove to be a "
@@ -541,7 +592,7 @@ msgstr ""
 "快速​\n"
 "迷宮​的​居民​們​已​經​被​催促​了，這將​是​一​個​更​大​的​挑戰。這隻​建議​有​經驗​的​角色​使用。"
 
-#: Source/DiabloUI/selgame.cpp:335
+#: Source/DiabloUI/selgame.cpp:373
 msgid ""
 "Faster Speed\n"
 "Most monsters of the dungeon will seek you out quicker than ever before. "
@@ -551,7 +602,7 @@ msgstr ""
 "​地​牢里​的​大多​數​怪物會​比​以前​更​快​地​找到​你。只有​有​經驗​的​冠軍​才​能​在​這個​速度​下​碰碰"
 "運氣。"
 
-#: Source/DiabloUI/selgame.cpp:339
+#: Source/DiabloUI/selgame.cpp:377
 msgid ""
 "Fastest Speed\n"
 "The minions of the underworld will rush to attack without hesitation. Only a "
@@ -560,77 +611,77 @@ msgstr ""
 "最​快​速度​\n"
 "​黑社​會​的​僕從們會​毫​不​猶​豫​地​趕來​攻擊。只有​真正​的​速度​惡魔​才​能​以​這種​速度​進入。"
 
-#: Source/DiabloUI/selgame.cpp:381 Source/DiabloUI/selgame.cpp:384
+#: Source/DiabloUI/selgame.cpp:420 Source/DiabloUI/selgame.cpp:425
 msgid "Enter Password"
 msgstr "輸​入​密碼"
 
-#: Source/DiabloUI/selgame.cpp:407
+#: Source/DiabloUI/selgame.cpp:448
 msgid "The host is running a different game than you."
 msgstr "主機​執行​的​遊戲與​您​不同。"
 
 #. TRANSLATORS: Error message when somebody tries to join a game running another version.
-#: Source/DiabloUI/selgame.cpp:410
+#: Source/DiabloUI/selgame.cpp:451
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr "您​的​版本​{:s}​與​主機{:d}.{:d}.{:d}​不​匹配。"
 
-#: Source/DiabloUI/selhero.cpp:99
+#: Source/DiabloUI/selhero.cpp:100
 msgid "New Hero"
 msgstr "新​英雄"
 
-#: Source/DiabloUI/selhero.cpp:163
+#: Source/DiabloUI/selhero.cpp:164
 msgid "Choose Class"
 msgstr "選​擇職業"
 
-#: Source/DiabloUI/selhero.cpp:167 Source/panels/charpanel.cpp:22
+#: Source/DiabloUI/selhero.cpp:168 Source/panels/charpanel.cpp:22
 msgid "Warrior"
 msgstr "戰士"
 
-#: Source/DiabloUI/selhero.cpp:168 Source/panels/charpanel.cpp:23
+#: Source/DiabloUI/selhero.cpp:169 Source/panels/charpanel.cpp:23
 msgid "Rogue"
 msgstr "流亡者"
 
-#: Source/DiabloUI/selhero.cpp:169 Source/panels/charpanel.cpp:24
+#: Source/DiabloUI/selhero.cpp:170 Source/panels/charpanel.cpp:24
 msgid "Sorcerer"
 msgstr "巫師"
 
-#: Source/DiabloUI/selhero.cpp:171 Source/panels/charpanel.cpp:25
+#: Source/DiabloUI/selhero.cpp:172 Source/panels/charpanel.cpp:25
 msgid "Monk"
 msgstr "武僧"
 
-#: Source/DiabloUI/selhero.cpp:174 Source/panels/charpanel.cpp:26
+#: Source/DiabloUI/selhero.cpp:175 Source/panels/charpanel.cpp:26
 msgid "Bard"
 msgstr "吟遊​詩​人"
 
-#: Source/DiabloUI/selhero.cpp:177 Source/panels/charpanel.cpp:27
+#: Source/DiabloUI/selhero.cpp:178 Source/panels/charpanel.cpp:27
 msgid "Barbarian"
 msgstr "野​蠻​人"
 
-#: Source/DiabloUI/selhero.cpp:194 Source/DiabloUI/selhero.cpp:268
+#: Source/DiabloUI/selhero.cpp:195 Source/DiabloUI/selhero.cpp:269
 msgid "New Multi Player Hero"
 msgstr "新​的​多​人​英雄"
 
-#: Source/DiabloUI/selhero.cpp:194 Source/DiabloUI/selhero.cpp:268
+#: Source/DiabloUI/selhero.cpp:195 Source/DiabloUI/selhero.cpp:269
 msgid "New Single Player Hero"
 msgstr "新​單人​英雄"
 
-#: Source/DiabloUI/selhero.cpp:202
+#: Source/DiabloUI/selhero.cpp:203
 msgid "Save File Exists"
 msgstr "儲​存檔案​已​存在"
 
-#: Source/DiabloUI/selhero.cpp:205 Source/gamemenu.cpp:38
+#: Source/DiabloUI/selhero.cpp:206 Source/gamemenu.cpp:38
 msgid "Load Game"
 msgstr "載入​遊戲"
 
-#: Source/DiabloUI/selhero.cpp:206 Source/gamemenu.cpp:37
+#: Source/DiabloUI/selhero.cpp:207 Source/gamemenu.cpp:37
 #: Source/gamemenu.cpp:48
 msgid "New Game"
 msgstr "新​遊戲"
 
-#: Source/DiabloUI/selhero.cpp:216 Source/DiabloUI/selhero.cpp:540
+#: Source/DiabloUI/selhero.cpp:217 Source/DiabloUI/selhero.cpp:551
 msgid "Single Player Characters"
 msgstr "單​人​角色"
 
-#: Source/DiabloUI/selhero.cpp:262
+#: Source/DiabloUI/selhero.cpp:263
 msgid ""
 "The Rogue and Sorcerer are only available in the full retail version of "
 "Diablo. Visit https://www.gog.com/game/diablo to purchase."
@@ -638,83 +689,89 @@ msgstr ""
 "流亡者​和​巫師​只​在​暗​黑破​壞神​的​完整​零售版​中​提供。前往 https://www.gog.com/game/"
 "diablo 購買。"
 
-#: Source/DiabloUI/selhero.cpp:274 Source/DiabloUI/selhero.cpp:277
+#: Source/DiabloUI/selhero.cpp:275 Source/DiabloUI/selhero.cpp:278
 msgid "Enter Name"
 msgstr "輸​入名稱"
 
-#: Source/DiabloUI/selhero.cpp:306
+#: Source/DiabloUI/selhero.cpp:307
 msgid ""
 "Invalid name. A name cannot contain spaces, reserved characters, or reserved "
 "words.\n"
 msgstr "名稱​無效。名稱​不​能​包含​空格、保留​字元​或​保留​字。\n"
 
 #. TRANSLATORS: Error Message
-#: Source/DiabloUI/selhero.cpp:313
+#: Source/DiabloUI/selhero.cpp:314
 msgid "Unable to create character."
 msgstr "無​法​建立​角色。"
 
-#: Source/DiabloUI/selhero.cpp:467 Source/DiabloUI/selhero.cpp:470
+#: Source/DiabloUI/selhero.cpp:468 Source/DiabloUI/selhero.cpp:471
 msgid "Level:"
 msgstr "等​級: "
 
-#: Source/DiabloUI/selhero.cpp:475
+#: Source/DiabloUI/selhero.cpp:476
 msgid "Strength:"
 msgstr "強度: "
 
-#: Source/DiabloUI/selhero.cpp:480
+#: Source/DiabloUI/selhero.cpp:481
 msgid "Magic:"
 msgstr "魔術: "
 
-#: Source/DiabloUI/selhero.cpp:485
+#: Source/DiabloUI/selhero.cpp:486
 msgid "Dexterity:"
 msgstr "敏​捷: "
 
-#: Source/DiabloUI/selhero.cpp:490
+#: Source/DiabloUI/selhero.cpp:491
 msgid "Vitality:"
 msgstr "活力: "
 
-#: Source/DiabloUI/selhero.cpp:496
+#: Source/DiabloUI/selhero.cpp:497
 #, fuzzy
 #| msgid "Save Game"
 msgid "Savegame:"
 msgstr "儲​存遊​戲"
 
-#: Source/DiabloUI/selhero.cpp:508
+#: Source/DiabloUI/selhero.cpp:510
 msgid "Select Hero"
 msgstr "選​擇​英雄"
 
-#: Source/DiabloUI/selhero.cpp:528
+#: Source/DiabloUI/selhero.cpp:539
 msgid "Delete"
 msgstr "刪​除"
 
-#: Source/DiabloUI/selhero.cpp:538
+#: Source/DiabloUI/selhero.cpp:549
 msgid "Multi Player Characters"
 msgstr "多​人​遊戲​角色"
 
-#: Source/DiabloUI/selhero.cpp:580
+#: Source/DiabloUI/selhero.cpp:599
 msgid "Delete Multi Player Hero"
 msgstr "刪​除​多​人​遊戲​英雄"
 
-#: Source/DiabloUI/selhero.cpp:582
+#: Source/DiabloUI/selhero.cpp:601
 msgid "Delete Single Player Hero"
 msgstr "刪​除​單人​遊戲​英雄"
 
-#: Source/DiabloUI/selhero.cpp:584
+#: Source/DiabloUI/selhero.cpp:603
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "是否​確實​要​刪除​角色​「​{:s}​」？"
 
-#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:928
+#: Source/DiabloUI/selstart.cpp:43
+#, fuzzy
+#| msgid "Exit Hellfire"
+msgid "Enter Hellfire"
+msgstr "退出​地​獄火"
+
+#: Source/DiabloUI/selyesno.cpp:54 Source/stores.cpp:978
 msgid "Yes"
 msgstr "是"
 
-#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:929
+#: Source/DiabloUI/selyesno.cpp:55 Source/stores.cpp:979
 msgid "No"
 msgstr "否"
 
 #: Source/DiabloUI/support_lines.cpp:8
 msgid ""
-"We maintains a chat server at Discord.gg/YQKCAYQ Follow the links to join "
-"our community where we talk about things related to Diablo, and the Hellfire "
+"We maintain a chat server at Discord.gg/YQKCAYQ Follow the links to join our "
+"community where we talk about things related to Diablo, and the Hellfire "
 "expansion."
 msgstr ""
 
@@ -757,12 +814,12 @@ msgstr ""
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr "Copyright © 1996-2001 Blizzard Entertainment"
 
-#: Source/appfat.cpp:37
+#: Source/appfat.cpp:38
 msgid "Error"
 msgstr "錯​誤"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:101
+#: Source/appfat.cpp:102
 msgid ""
 "{:s}\n"
 "\n"
@@ -772,7 +829,7 @@ msgstr ""
 "\n"
 "錯誤​發生​在: {: s}，行{: d}"
 
-#: Source/appfat.cpp:115
+#: Source/appfat.cpp:117
 #, fuzzy
 #| msgid ""
 #| "Unable to open main data archive ({:s}).\n"
@@ -788,15 +845,12 @@ msgstr ""
 "\n"
 "確保​它​在​遊戲​資料夾​中，並且​檔名​都​是​小寫​的。"
 
-msgid "diabdat.mpq or spawn.mpq"
-msgstr "diabdat.mpq或spawn.mpq"
-
-#: Source/appfat.cpp:119
+#: Source/appfat.cpp:123
 msgid "Data File Error"
 msgstr "數​據​檔案​錯誤"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:127
+#: Source/appfat.cpp:131
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -804,166 +858,189 @@ msgstr ""
 "無​法​寫入​位置: \n"
 "{: s}"
 
-#: Source/appfat.cpp:129
+#: Source/appfat.cpp:133
 msgid "Read-Only Directory Error"
 msgstr "只​讀目錄​錯誤"
 
-#: Source/automap.cpp:468
+#: Source/automap.cpp:484
 msgid "game: "
 msgstr "遊​戲: "
 
-#: Source/automap.cpp:474
+#: Source/automap.cpp:490
 msgid "password: "
 msgstr "密碼: "
 
-#: Source/automap.cpp:487
+#: Source/automap.cpp:492
+#, fuzzy
+#| msgid "Quit Game"
+msgid "Public Game"
+msgstr "退出​遊戲"
+
+#: Source/automap.cpp:504
 msgid "Level: Nest {:d}"
 msgstr "層​數: {:d}​巢​穴"
 
-#: Source/automap.cpp:489
+#: Source/automap.cpp:506
 msgid "Level: Crypt {:d}"
 msgstr "層​數: {:d}​墓穴"
 
-#: Source/automap.cpp:491 Source/items.cpp:2086
+#: Source/automap.cpp:508 Source/items.cpp:2090
 msgid "Level: {:d}"
 msgstr "等​級: {:d}"
 
-#: Source/control.cpp:196
+#: Source/control.cpp:212
 msgid "Tab"
 msgstr "標​籤"
 
-#: Source/control.cpp:196
+#: Source/control.cpp:212
 msgid "Esc"
 msgstr "電子​穩定​控制​系統"
 
-#: Source/control.cpp:196
+#: Source/control.cpp:212
 msgid "Enter"
 msgstr "輸​入"
 
-#: Source/control.cpp:199
+#: Source/control.cpp:215
 msgid "Character Information"
 msgstr "角色​資訊"
 
-#: Source/control.cpp:200
+#: Source/control.cpp:216
 msgid "Quests log"
 msgstr "任​務日誌"
 
-#: Source/control.cpp:201
+#: Source/control.cpp:217
 msgid "Automap"
 msgstr "自動​對映"
 
-#: Source/control.cpp:202
+#: Source/control.cpp:218
 msgid "Main Menu"
 msgstr "主​菜單"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:219
 msgid "Inventory"
 msgstr "庫​存"
 
-#: Source/control.cpp:204
+#: Source/control.cpp:220
 msgid "Spell book"
 msgstr "咒​語書"
 
-#: Source/control.cpp:205
+#: Source/control.cpp:221
 msgid "Send Message"
 msgstr "發​送​訊​息"
 
-#: Source/control.cpp:712 Source/control.cpp:1175
+#: Source/control.cpp:718 Source/control.cpp:1587
+msgid "Skill"
+msgstr "技能"
+
+#: Source/control.cpp:719 Source/control.cpp:1237
 msgid "{:s} Skill"
 msgstr "{:s}​技能"
 
-#: Source/control.cpp:716 Source/control.cpp:1179
+#: Source/control.cpp:725
+#, fuzzy
+#| msgid "Spells"
+msgid "Spell"
+msgstr "法​術"
+
+#: Source/control.cpp:726 Source/control.cpp:1241
 msgid "{:s} Spell"
 msgstr "{:s}法術"
 
-#: Source/control.cpp:718
+#: Source/control.cpp:728
 msgid "Damages undead only"
 msgstr "只​傷害亡​靈"
 
-#: Source/control.cpp:722 Source/control.cpp:1183 Source/control.cpp:1554
+#: Source/control.cpp:732 Source/control.cpp:1245 Source/control.cpp:1611
 msgid "Spell Level 0 - Unusable"
 msgstr "法術​等​級​0-無法​使用"
 
-#: Source/control.cpp:724 Source/control.cpp:1185 Source/control.cpp:1556
+#: Source/control.cpp:734 Source/control.cpp:1247 Source/control.cpp:1613
 msgid "Spell Level {:d}"
 msgstr "法術​等​級{:d}"
 
-#: Source/control.cpp:729 Source/control.cpp:1189
+#: Source/control.cpp:741
+#, fuzzy
+#| msgid "{:d} Scroll"
+msgid "Scroll"
+msgstr "{:s}卷軸"
+
+#: Source/control.cpp:742 Source/control.cpp:1251
 msgid "Scroll of {:s}"
 msgstr "{:s}​卷​軸"
 
-#: Source/control.cpp:745 Source/control.cpp:1206
+#: Source/control.cpp:747 Source/control.cpp:1257
 #, fuzzy
 #| msgid "{:d} Scroll"
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "{:s}卷軸"
 
-#: Source/control.cpp:750 Source/control.cpp:1210 Source/items.cpp:1325
+#: Source/control.cpp:754 Source/itemdat.cpp:167 Source/itemdat.cpp:168
+#: Source/itemdat.cpp:169 Source/itemdat.cpp:170 Source/itemdat.cpp:171
+msgid "Staff"
+msgstr "工作人​員"
+
+#: Source/control.cpp:755 Source/control.cpp:1261
 msgid "Staff of {:s}"
 msgstr "{:s}​的​職員"
 
-#: Source/control.cpp:752 Source/control.cpp:1212
+#: Source/control.cpp:757 Source/control.cpp:1263
 #, fuzzy
 #| msgid "{:d} Charge"
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "生命點{:d}的{:d}"
 
-#: Source/control.cpp:762
+#: Source/control.cpp:767
 #, fuzzy
 #| msgid "Spell Hotkey #F{:d}"
 msgid "Spell Hotkey {:s}"
 msgstr "熱​鍵: {:s}"
 
-#: Source/control.cpp:1152
+#: Source/control.cpp:1214
 msgid "Player friendly"
 msgstr "對​玩​家​友好"
 
-#: Source/control.cpp:1154
+#: Source/control.cpp:1216
 msgid "Player attack"
 msgstr "玩​家​攻擊"
 
-#: Source/control.cpp:1157
+#: Source/control.cpp:1219
 msgid "Hotkey: {:s}"
 msgstr "熱​鍵: {:s}"
 
-#: Source/control.cpp:1165
+#: Source/control.cpp:1227
 msgid "Select current spell button"
 msgstr "選​擇​目前​法術​按​鈕"
 
-#: Source/control.cpp:1168
+#: Source/control.cpp:1230
 msgid "Hotkey: 's'"
 msgstr "熱​鍵: 「​s​」"
 
-#: Source/control.cpp:1334 Source/inv.cpp:1893 Source/items.cpp:3751
+#: Source/control.cpp:1387 Source/inv.cpp:1980 Source/items.cpp:3749
 #, fuzzy
 #| msgid "{:d} gold piece"
 msgid "{:d} gold piece"
 msgid_plural "{:d} gold pieces"
 msgstr[0] "金幣"
 
-#: Source/control.cpp:1337
+#: Source/control.cpp:1390
 msgid "Requirements not met"
 msgstr "未​滿足​條件"
 
-#: Source/control.cpp:1373
+#: Source/control.cpp:1426
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}，層數: {:d}"
 
-#: Source/control.cpp:1375
+#: Source/control.cpp:1428
 msgid "Hit Points {:d} of {:d}"
 msgstr "生命​點{:d}​的​{:d}"
 
-#: Source/control.cpp:1402
+#: Source/control.cpp:1457
 msgid "Level Up"
 msgstr "升級"
 
-#: Source/control.cpp:1532
-msgid "Skill"
-msgstr "技能"
-
-#: Source/control.cpp:1536
+#: Source/control.cpp:1591
 #, fuzzy
 #| msgid "Staff ({:d} charge)"
 msgid "Staff ({:d} charge)"
@@ -971,22 +1048,22 @@ msgid_plural "Staff ({:d} charges)"
 msgstr[0] "{:s}的職員"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1544
+#: Source/control.cpp:1601
 msgid "Mana: {:d}  Dam: {:d} - {:d}"
 msgstr "法力: {:d} 傷害: {:d}-{:d}"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1546
+#: Source/control.cpp:1603
 msgid "Mana: {:d}   Dam: n/a"
 msgstr "法力: {:d} 傷害: n/a"
 
 #. TRANSLATORS: Dam refers to damage. UI constrains, keep short please.
-#: Source/control.cpp:1549
+#: Source/control.cpp:1606
 msgid "Mana: {:d}  Dam: 1/3 tgt hp"
 msgstr "法力: {:d} 傷害: 1/3 tgt hp"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1606
+#: Source/control.cpp:1664
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
 msgstr[0] ""
@@ -1035,106 +1112,115 @@ msgstr "邪惡​的​祭壇"
 msgid "level 15"
 msgstr "15​級"
 
-#: Source/diablo.cpp:111
+#: Source/diablo.cpp:114
 msgid "I need help! Come Here!"
 msgstr "我​需要​幫助！過來！"
 
-#: Source/diablo.cpp:112
+#: Source/diablo.cpp:115
 msgid "Follow me."
 msgstr "跟​著​我。"
 
-#: Source/diablo.cpp:113
+#: Source/diablo.cpp:116
 msgid "Here's something for you."
 msgstr "這​是​給​你​的。"
 
-#: Source/diablo.cpp:114
+#: Source/diablo.cpp:117
 msgid "Now you DIE!"
 msgstr "現​在​你​死定​了！"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:777
+#: Source/diablo.cpp:781
 msgid "Options:\n"
 msgstr "選​項: \n"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:778
+#: Source/diablo.cpp:782
 msgid "Print this message and exit"
 msgstr "列​印此​訊息並​退出"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:779
+#: Source/diablo.cpp:783
 msgid "Print the version and exit"
 msgstr "列​印​版本​並​退出"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:780
+#: Source/diablo.cpp:784
 msgid "Specify the folder of diabdat.mpq"
 msgstr "指定​diabdat.mpq​的​資料​夾"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:781
+#: Source/diablo.cpp:785
 msgid "Specify the folder of save files"
 msgstr "指定​儲存​檔案​的​資料​夾"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:782
+#: Source/diablo.cpp:786
 msgid "Specify the location of diablo.ini"
 msgstr "指定​diablo.ini​的​位置"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:783
-msgid "Specify the location of the .ttf font"
-msgstr "指定​.ttf字型​的​位置"
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:784
-msgid "Specify the name of a custom .ttf font"
-msgstr "指定​自定義​.ttf字型​的​名稱"
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:785
+#: Source/diablo.cpp:787
 msgid "Skip startup videos"
 msgstr "跳過啟動視訊"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:786
+#: Source/diablo.cpp:788
 msgid "Display frames per second"
 msgstr "每​秒​顯示幀數"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:787
+#: Source/diablo.cpp:789
 msgid "Run in windowed mode"
 msgstr "在​視窗​模式​下執行"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:788
+#: Source/diablo.cpp:790
 msgid "Enable verbose logging"
 msgstr "啟​用​詳​細​日誌記錄"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:789
-msgid "Force spawn mode even if diabdat.mpq is found"
-msgstr "即使​找到​diabdat.mpq，也​強制產生​模式"
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:790
+#: Source/diablo.cpp:791
 #, fuzzy
 msgid "Record a demo file"
 msgstr "儲​存檔案​已​存在"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:791
+#: Source/diablo.cpp:792
 #, fuzzy
 msgid "Play a demo file"
 msgstr "自己​玩，沒​有​網路​曝光。"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:792
+#: Source/diablo.cpp:793
 msgid "Disable all frame limiting during demo playback"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:793
+#: Source/diablo.cpp:794
+msgid ""
+"\n"
+"Game selection:\n"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:795
+msgid "Force Shareware mode"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:796
+msgid "Force Diablo mode"
+msgstr ""
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:797
+#, fuzzy
+#| msgid "Hellfire Help"
+msgid "Force Hellfire mode"
+msgstr "地​獄火​幫助"
+
+#. TRANSLATORS: Commandline Option
+#: Source/diablo.cpp:798
 msgid ""
 "\n"
 "Hellfire options:\n"
@@ -1143,16 +1229,11 @@ msgstr ""
 "地​獄火選項: \n"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:794
-msgid "Force diablo mode even if hellfire.mpq is found"
-msgstr "即使​hellfire.mpq​存在，也​強制​使用​暗​黑破壞神​原版​模式"
-
-#. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:795
+#: Source/diablo.cpp:799
 msgid "Use alternate nest palette"
 msgstr "使用​備​用​巢狀​調色板"
 
-#: Source/diablo.cpp:801
+#: Source/diablo.cpp:805
 msgid ""
 "\n"
 "Report bugs at https://github.com/diasurgical/devilutionX/\n"
@@ -1168,294 +1249,294 @@ msgstr "無​法識別​的​選項​{: s}\n"
 msgid "version {:s}"
 msgstr "版本​{:s}"
 
-#: Source/diablo.cpp:1206
+#: Source/diablo.cpp:1218
 msgid "-- Network timeout --"
 msgstr "--網路​超時​--"
 
-#: Source/diablo.cpp:1207
+#: Source/diablo.cpp:1219
 msgid "-- Waiting for players --"
 msgstr "--​等待​玩​家​--"
 
-#: Source/diablo.cpp:1226
+#: Source/diablo.cpp:1238
 msgid "No help available"
 msgstr "沒​有​可用​的​幫助"
 
-#: Source/diablo.cpp:1227
+#: Source/diablo.cpp:1239
 msgid "while in stores"
 msgstr "在​商店​裡"
 
 #. TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty.
-#: Source/diablo.cpp:1439
+#: Source/diablo.cpp:1451
 #, fuzzy
 #| msgid "{:s}, mode = {:s}"
 msgid "{:s}, version = {:s}, mode = {:s}"
 msgstr "{:s}​（​等​級{:d}​）: {:s}"
 
-#: Source/dvlnet/loopback.cpp:111
+#: Source/dvlnet/loopback.cpp:113
 msgid "loopback"
 msgstr "環​回"
 
-#: Source/dvlnet/tcp_client.cpp:68
+#: Source/dvlnet/tcp_client.cpp:65
 msgid "Unable to connect"
 msgstr "無​法連線"
 
-#: Source/dvlnet/tcp_client.cpp:89
+#: Source/dvlnet/tcp_client.cpp:86
 msgid "error: read 0 bytes from server"
 msgstr "錯​誤: 從伺​服器​讀​取​0​位​元組"
 
-#: Source/error.cpp:58
+#: Source/error.cpp:57
 msgid "No automap available in town"
 msgstr "城裡沒​有​汽車​地​圖"
 
-#: Source/error.cpp:59
+#: Source/error.cpp:58
 msgid "No multiplayer functions in demo"
 msgstr "演示​中​沒​有​多​人​遊戲​功能"
 
-#: Source/error.cpp:60
+#: Source/error.cpp:59
 msgid "Direct Sound Creation Failed"
 msgstr "直接​聲音​建立​失敗"
 
-#: Source/error.cpp:61
+#: Source/error.cpp:60
 msgid "Not available in shareware version"
 msgstr "在​共​享軟​體​版本​中​不​可​用"
 
-#: Source/error.cpp:62
+#: Source/error.cpp:61
 msgid "Not enough space to save"
 msgstr "空間​不​夠​節省"
 
-#: Source/error.cpp:63
+#: Source/error.cpp:62
 msgid "No Pause in town"
 msgstr "不​要​在​城裡​停下​來"
 
-#: Source/error.cpp:64
+#: Source/error.cpp:63
 msgid "Copying to a hard disk is recommended"
 msgstr "建​議複製​到​硬碟"
 
-#: Source/error.cpp:65
+#: Source/error.cpp:64
 msgid "Multiplayer sync problem"
 msgstr "多​人​同步​問題"
 
-#: Source/error.cpp:66
+#: Source/error.cpp:65
 msgid "No pause in multiplayer"
 msgstr "多​人​遊戲​中​無暫​停"
 
-#: Source/error.cpp:67
+#: Source/error.cpp:66
 msgid "Loading..."
 msgstr "載入。。。"
 
-#: Source/error.cpp:68
+#: Source/error.cpp:67
 msgid "Saving..."
 msgstr "正在​儲存。。。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:69
+#: Source/error.cpp:68
 msgid "Some are weakened as one grows strong"
 msgstr "當​一​個​人​變​得​強壯時，有些​人​會​變​得​虛弱"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:70
+#: Source/error.cpp:69
 msgid "New strength is forged through destruction"
 msgstr "新​的​力量​是​通過​破壞鍛造出來​的"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:71
+#: Source/error.cpp:70
 msgid "Those who defend seldom attack"
 msgstr "防禦者​很​少​攻擊"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:72
+#: Source/error.cpp:71
 msgid "The sword of justice is swift and sharp"
 msgstr "正​義​之​劍​迅捷​而​鋒利"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:73
+#: Source/error.cpp:72
 msgid "While the spirit is vigilant the body thrives"
 msgstr "當​精神​保持​警惕時，身體​就​會茁壯​成長"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:74
+#: Source/error.cpp:73
 msgid "The powers of mana refocused renews"
 msgstr "法力​的​力量​重新​聚焦​更新"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:75
+#: Source/error.cpp:74
 msgid "Time cannot diminish the power of steel"
 msgstr "時​間​不​能​削弱​鋼鐵​的​力量"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:76
+#: Source/error.cpp:75
 msgid "Magic is not always what it seems to be"
 msgstr "魔術​並​不​總​是​看起來​的​那​樣"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:77
+#: Source/error.cpp:76
 msgid "What once was opened now is closed"
 msgstr "曾​經​打開​的​現​在​關閉​了"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:78
+#: Source/error.cpp:77
 msgid "Intensity comes at the cost of wisdom"
 msgstr "強度​是​以​智慧​為代價​的"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:79
+#: Source/error.cpp:78
 msgid "Arcane power brings destruction"
 msgstr "神秘​力量​帶來毀滅"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:80
+#: Source/error.cpp:79
 msgid "That which cannot be held cannot be harmed"
 msgstr "不​能​持有​的​東西​不​能​受到​傷害"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:81
+#: Source/error.cpp:80
 msgid "Crimson and Azure become as the sun"
 msgstr "深​紅湛藍​如​太​陽"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:82
+#: Source/error.cpp:81
 msgid "Knowledge and wisdom at the cost of self"
 msgstr "以​犧牲​自我​為代價​的​知識​和​智慧"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:83
+#: Source/error.cpp:82
 msgid "Drink and be refreshed"
 msgstr "喝​酒​提神"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:84
+#: Source/error.cpp:83
 msgid "Wherever you go, there you are"
 msgstr "無論​你​走到​哪​裡，你​都​在​那​裡"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:85
+#: Source/error.cpp:84
 msgid "Energy comes at the cost of wisdom"
 msgstr "能量​是​以​智慧​為代價​的"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:86
+#: Source/error.cpp:85
 msgid "Riches abound when least expected"
 msgstr "財富​在​最​不​經意​的​時候​大量​存在"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:87
+#: Source/error.cpp:86
 msgid "Where avarice fails, patience gains reward"
 msgstr "貪​婪失敗​了，耐心​就​會​得到​回報"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:88
+#: Source/error.cpp:87
 msgid "Blessed by a benevolent companion!"
 msgstr "被​仁慈​的​同伴​祝福！"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:89
+#: Source/error.cpp:88
 msgid "The hands of men may be guided by fate"
 msgstr "人​的​手可能​會​被​命運​所​指引"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:90
+#: Source/error.cpp:89
 msgid "Strength is bolstered by heavenly faith"
 msgstr "力量​是​由​天國​的​信仰​支撐​的"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:91
+#: Source/error.cpp:90
 msgid "The essence of life flows from within"
 msgstr "生命​的​本質來​自內​在"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:92
+#: Source/error.cpp:91
 msgid "The way is made clear when viewed from above"
 msgstr "從​上面​看​清楚​了"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:93
+#: Source/error.cpp:92
 msgid "Salvation comes at the cost of wisdom"
 msgstr "拯救​是​以​智慧​為代價​的"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:94
+#: Source/error.cpp:93
 msgid "Mysteries are revealed in the light of reason"
 msgstr "謎團​在​理性​的​光照​下​顯​露出​來"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:95
+#: Source/error.cpp:94
 msgid "Those who are last may yet be first"
 msgstr "最後​一​個​可能​還​是​第一​個"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:96
+#: Source/error.cpp:95
 msgid "Generosity brings its own rewards"
 msgstr "慷慨​自​有​回報"
 
-#: Source/error.cpp:97
+#: Source/error.cpp:96
 msgid "You must be at least level 8 to use this."
 msgstr "你​必須​至少​達​到​8​級​才​能​使用​這個。"
 
-#: Source/error.cpp:98
+#: Source/error.cpp:97
 msgid "You must be at least level 13 to use this."
 msgstr "你​必須​至少​達​到​13級​才​能​使用​這個。"
 
-#: Source/error.cpp:99
+#: Source/error.cpp:98
 msgid "You must be at least level 17 to use this."
 msgstr "你​必須​至少​達​到​17級​才​能​使用​這個。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:100
+#: Source/error.cpp:99
 msgid "Arcane knowledge gained!"
 msgstr "獲​得​奧術​知識！"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:101
+#: Source/error.cpp:100
 msgid "That which does not kill you..."
 msgstr "不​會殺死​你​的​東西。。。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:102
+#: Source/error.cpp:101
 msgid "Knowledge is power."
 msgstr "知識​就​是​力量。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:103
+#: Source/error.cpp:102
 msgid "Give and you shall receive."
 msgstr "付出​你​就​會​得到。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:104
+#: Source/error.cpp:103
 msgid "Some experience is gained by touch."
 msgstr "一些​經驗​是​通過​接觸​獲得​的。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:105
+#: Source/error.cpp:104
 msgid "There's no place like home."
 msgstr "沒​有​比家​更​好​的​地方​了。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:106
+#: Source/error.cpp:105
 msgid "Spiritual energy is restored."
 msgstr "精神​能量​被​恢復。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:107
+#: Source/error.cpp:106
 msgid "You feel more agile."
 msgstr "你​感覺​更​敏捷。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:108
+#: Source/error.cpp:107
 msgid "You feel stronger."
 msgstr "你​感覺​更​強壯。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:109
+#: Source/error.cpp:108
 msgid "You feel wiser."
 msgstr "你​覺得​自己​更​聰明。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:110
+#: Source/error.cpp:109
 msgid "You feel refreshed."
 msgstr "你​感覺​神清​氣爽。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:111
+#: Source/error.cpp:110
 msgid "That which can break will."
 msgstr "能​打破​意志​的​東西。"
 
@@ -1482,10 +1563,6 @@ msgstr "伽馬"
 #: Source/gamemenu.cpp:60 Source/gamemenu.cpp:167
 msgid "Speed"
 msgstr "速度"
-
-#: Source/gamemenu.cpp:61
-msgid "Previous Menu"
-msgstr "上​一​個​菜單"
 
 #: Source/gamemenu.cpp:68
 msgid "Music Disabled"
@@ -1661,7 +1738,7 @@ msgstr ""
 #: Source/help.cpp:68
 #, fuzzy
 #| msgid "Gold"
-msgid "$Gold"
+msgid "$Gold:"
 msgstr "金幣"
 
 #: Source/help.cpp:69
@@ -1686,7 +1763,7 @@ msgstr ""
 
 #: Source/help.cpp:79
 #, fuzzy
-msgid "$Using the Speedbook for Spells"
+msgid "$Using the Speedbook for Spells:"
 msgstr "法​術"
 
 #: Source/help.cpp:80
@@ -1699,12 +1776,12 @@ msgstr ""
 #: Source/help.cpp:84
 msgid ""
 "Shift + Left-clicking on the 'select current spell' button will clear the "
-"readied spell"
+"readied spell."
 msgstr ""
 
 #: Source/help.cpp:86
 #, fuzzy
-msgid "$Setting Spell Hotkeys"
+msgid "$Setting Spell Hotkeys:"
 msgstr "咒​語書"
 
 #: Source/help.cpp:87
@@ -1717,7 +1794,7 @@ msgstr ""
 #: Source/help.cpp:92
 #, fuzzy
 #| msgid "Spell book"
-msgid "$Spell Books"
+msgid "$Spell Books:"
 msgstr "法術​等​級​0-無法​使用"
 
 #: Source/help.cpp:93
@@ -1726,35 +1803,39 @@ msgid ""
 "you to cast the spell more effectively."
 msgstr ""
 
-#: Source/help.cpp:130
+#: Source/help.cpp:181
 #, fuzzy
 #| msgid "Hellfire Help"
 msgid "Shareware Hellfire Help"
 msgstr "地​獄火​幫助"
 
-#: Source/help.cpp:130
+#: Source/help.cpp:181
 msgid "Hellfire Help"
 msgstr "地​獄火​幫助"
 
-#: Source/help.cpp:132
+#: Source/help.cpp:183
 #, fuzzy
 #| msgid "Diablo Help"
 msgid "Shareware Diablo Help"
 msgstr "在​共​享軟​體​中"
 
-#: Source/help.cpp:132
+#: Source/help.cpp:183
 msgid "Diablo Help"
 msgstr "暗​黑破壞神​幫助"
 
-#: Source/help.cpp:156
+#: Source/help.cpp:213
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr "按​ESC鍵​結束，或​按箭頭鍵​滾動。"
 
-#: Source/init.cpp:214
+#: Source/init.cpp:175
+msgid "diabdat.mpq or spawn.mpq"
+msgstr "diabdat.mpq或spawn.mpq"
+
+#: Source/init.cpp:196
 msgid "Some Hellfire MPQs are missing"
 msgstr "一些​地​獄火​MPQ​無法​找到"
 
-#: Source/init.cpp:214
+#: Source/init.cpp:196
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
@@ -1762,11 +1843,11 @@ msgstr ""
 "地​獄火​MPQ​未​能​全部​找到。\n"
 "請​複製​所有​hf​*​.mpq檔案。"
 
-#: Source/init.cpp:224
+#: Source/init.cpp:204
 msgid "Unable to create main window"
 msgstr "無​法​建立​主視​窗"
 
-#: Source/itemdat.cpp:16 Source/itemdat.cpp:198 Source/panels/charpanel.cpp:154
+#: Source/itemdat.cpp:16 Source/itemdat.cpp:198 Source/panels/charpanel.cpp:155
 msgid "Gold"
 msgstr "金幣"
 
@@ -1906,7 +1987,7 @@ msgstr "拉撒雷茲​之​杖"
 msgid "Scroll of Resurrect"
 msgstr "復​活​卷軸"
 
-#: Source/itemdat.cpp:51 Source/itemdat.cpp:99 Source/items.cpp:164
+#: Source/itemdat.cpp:51 Source/itemdat.cpp:99 Source/items.cpp:166
 msgid "Blacksmith Oil"
 msgstr "鐵匠​之​油"
 
@@ -2006,7 +2087,7 @@ msgid "Quilted Armor"
 msgstr "內​襯​甲"
 
 #: Source/itemdat.cpp:74 Source/itemdat.cpp:75 Source/itemdat.cpp:76
-#: Source/itemdat.cpp:77 Source/objects.cpp:5459
+#: Source/itemdat.cpp:77 Source/objects.cpp:5433
 msgid "Armor"
 msgstr "護​甲"
 
@@ -2101,11 +2182,11 @@ msgstr "活力​恢復​藥​水"
 msgid "Potion of Full Rejuvenation"
 msgstr "完全​活力​恢復​藥​水"
 
-#: Source/itemdat.cpp:100 Source/items.cpp:159
+#: Source/itemdat.cpp:100 Source/items.cpp:161
 msgid "Oil of Accuracy"
 msgstr "精準​之​油"
 
-#: Source/itemdat.cpp:101 Source/items.cpp:161
+#: Source/itemdat.cpp:101 Source/items.cpp:163
 msgid "Oil of Sharpness"
 msgstr "銳利​之​油"
 
@@ -2333,11 +2414,6 @@ msgstr "短戰​爭弓"
 msgid "Long War Bow"
 msgstr "長​戰​爭弓"
 
-#: Source/itemdat.cpp:167 Source/itemdat.cpp:168 Source/itemdat.cpp:169
-#: Source/itemdat.cpp:170 Source/itemdat.cpp:171
-msgid "Staff"
-msgstr "工作人​員"
-
 #: Source/itemdat.cpp:168
 msgid "Long Staff"
 msgstr "長​杖"
@@ -2428,7 +2504,7 @@ msgstr "秘銀"
 msgid "Meteoric"
 msgstr "隕​鐵"
 
-#: Source/itemdat.cpp:202 Source/objects.cpp:104
+#: Source/itemdat.cpp:202 Source/objects.cpp:107
 msgid "Weird"
 msgstr "詭​異"
 
@@ -2564,7 +2640,7 @@ msgstr "聖者"
 msgid "Awesome"
 msgstr "真​棒"
 
-#: Source/itemdat.cpp:237 Source/objects.cpp:116
+#: Source/itemdat.cpp:237 Source/objects.cpp:119
 msgid "Holy"
 msgstr "聖佑"
 
@@ -3525,711 +3601,733 @@ msgstr "侍從​護​符"
 msgid "Gladiator's Ring"
 msgstr "角​鬥士​戒指"
 
-#: Source/items.cpp:160
+#: Source/items.cpp:162
 msgid "Oil of Mastery"
 msgstr "大​師​之​油"
 
-#: Source/items.cpp:162
+#: Source/items.cpp:164
 msgid "Oil of Death"
 msgstr "死亡​之​油"
 
-#: Source/items.cpp:163
+#: Source/items.cpp:165
 msgid "Oil of Skill"
 msgstr "技能​之​油"
 
-#: Source/items.cpp:165
+#: Source/items.cpp:167
 msgid "Oil of Fortitude"
 msgstr "堅​韌​之​油"
 
-#: Source/items.cpp:166
+#: Source/items.cpp:168
 msgid "Oil of Permanence"
 msgstr "永恒​之​油"
 
-#: Source/items.cpp:167
+#: Source/items.cpp:169
 msgid "Oil of Hardening"
 msgstr "硬化​之​油"
 
-#: Source/items.cpp:168
+#: Source/items.cpp:170
 msgid "Oil of Imperviousness"
 msgstr "防水​之​油"
 
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Sword
-#: Source/items.cpp:1174 Source/items.cpp:1184 Source/items.cpp:1233
-#: Source/items.cpp:1269
-msgid "{0} {1}"
-msgstr ""
-
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's Staff of Firewall
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Long Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Suffix}. Example: King's Sword of the Whale
-#. TRANSLATORS: Constructs item names. Format: {Prefix Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1187 Source/items.cpp:1254 Source/items.cpp:1273
-#: Source/items.cpp:1315
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
+#: Source/items.cpp:1183
+#, fuzzy
+#| msgid "{0} of {1}"
+msgctxt "spell"
 msgid "{0} of {1}"
 msgstr "{:s} / {:s}"
 
-#: Source/items.cpp:1902 Source/items.cpp:1914
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
+#: Source/items.cpp:1193
+#, fuzzy
+msgctxt "spell"
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} / {:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
+#: Source/items.cpp:1214
+#, fuzzy
+msgid "{0} {1} of {2}"
+msgstr "{:s} {:s} / {:s}"
+
+#. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
+#: Source/items.cpp:1217
+msgid "{0} {1}"
+msgstr ""
+
+#. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
+#: Source/items.cpp:1220
+msgid "{0} of {1}"
+msgstr "{:s} / {:s}"
+
+#: Source/items.cpp:1906 Source/items.cpp:1918
 msgid "increases a weapon's"
 msgstr "增加​武器​的"
 
-#: Source/items.cpp:1904
+#: Source/items.cpp:1908
 msgid "chance to hit"
 msgstr "擊​中​的​機會"
 
-#: Source/items.cpp:1908
+#: Source/items.cpp:1912
 msgid "greatly increases a"
 msgstr "大大​增加"
 
-#: Source/items.cpp:1910
+#: Source/items.cpp:1914
 msgid "weapon's chance to hit"
 msgstr "武器​擊​中​的​機會"
 
-#: Source/items.cpp:1916
+#: Source/items.cpp:1920
 msgid "damage potential"
 msgstr "潛​在​傷害"
 
-#: Source/items.cpp:1920
+#: Source/items.cpp:1924
 msgid "greatly increases a weapon's"
 msgstr "大大​提高​武器​的"
 
-#: Source/items.cpp:1922
+#: Source/items.cpp:1926
 msgid "damage potential - not bows"
 msgstr "潛​在​傷害​-​不​是​弓箭"
 
-#: Source/items.cpp:1926
+#: Source/items.cpp:1930
 msgid "reduces attributes needed"
 msgstr "減​少​所​需​屬性"
 
-#: Source/items.cpp:1928
+#: Source/items.cpp:1932
 msgid "to use armor or weapons"
 msgstr "使用​護甲​或​武器"
 
-#: Source/items.cpp:1932
+#: Source/items.cpp:1936
 #, no-c-format
 msgid "restores 20% of an"
 msgstr "恢復​20​%​的"
 
-#: Source/items.cpp:1934
+#: Source/items.cpp:1938
 msgid "item's durability"
 msgstr "物品​耐久度"
 
-#: Source/items.cpp:1938
+#: Source/items.cpp:1942
 msgid "increases an item's"
 msgstr "增加​物品​的"
 
-#: Source/items.cpp:1940
+#: Source/items.cpp:1944
 msgid "current and max durability"
 msgstr "目前​和​最​大​耐久度"
 
-#: Source/items.cpp:1944
+#: Source/items.cpp:1948
 msgid "makes an item indestructible"
 msgstr "使​物品​堅​不​可​摧"
 
-#: Source/items.cpp:1948
+#: Source/items.cpp:1952
 msgid "increases the armor class"
 msgstr "增加​護甲​等​級"
 
-#: Source/items.cpp:1950
+#: Source/items.cpp:1954
 msgid "of armor and shields"
 msgstr "護甲​和​盾牌"
 
-#: Source/items.cpp:1954
+#: Source/items.cpp:1958
 msgid "greatly increases the armor"
 msgstr "極​大地​增加​護甲"
 
-#: Source/items.cpp:1956
+#: Source/items.cpp:1960
 msgid "class of armor and shields"
 msgstr "護甲​和​盾牌​等​級"
 
-#: Source/items.cpp:1960 Source/items.cpp:1969
+#: Source/items.cpp:1964 Source/items.cpp:1973
 msgid "sets fire trap"
 msgstr "設​定​火焰​陷阱"
 
-#: Source/items.cpp:1965
+#: Source/items.cpp:1969
 msgid "sets lightning trap"
 msgstr "設​定閃電​陷阱"
 
-#: Source/items.cpp:1973
+#: Source/items.cpp:1977
 msgid "sets petrification trap"
 msgstr "設​定​石化​陷阱"
 
-#: Source/items.cpp:1977
+#: Source/items.cpp:1981
 #, fuzzy
 #| msgid "recover partial life"
 msgid "restore all life"
 msgstr "恢復​生命​值"
 
-#: Source/items.cpp:1981
+#: Source/items.cpp:1985
 #, fuzzy
 #| msgid "recover life"
 msgid "restore some life"
 msgstr "恢復​生命​值"
 
-#: Source/items.cpp:1985
+#: Source/items.cpp:1989
 msgid "recover life"
 msgstr "恢復​生命​值"
 
-#: Source/items.cpp:1989
+#: Source/items.cpp:1993
 msgid "deadly heal"
 msgstr "致命​的​治療"
 
-#: Source/items.cpp:1993
+#: Source/items.cpp:1997
 #, fuzzy
 #| msgid "restores 20% of an"
 msgid "restore some mana"
 msgstr "魔力​藥​水"
 
-#: Source/items.cpp:1997
+#: Source/items.cpp:2001
 #, fuzzy
 #| msgid "user loses all mana"
 msgid "restore all mana"
 msgstr "使用者​失去​所有​法力值"
 
-#: Source/items.cpp:2001
+#: Source/items.cpp:2005
 msgid "increase strength"
 msgstr "增強​力量"
 
-#: Source/items.cpp:2005
+#: Source/items.cpp:2009
 msgid "increase magic"
 msgstr "增加​魔法"
 
-#: Source/items.cpp:2009
+#: Source/items.cpp:2013
 msgid "increase dexterity"
 msgstr "增加​敏捷"
 
-#: Source/items.cpp:2013
+#: Source/items.cpp:2017
 msgid "increase vitality"
 msgstr "增加​活力"
 
-#: Source/items.cpp:2018
+#: Source/items.cpp:2022
 msgid "decrease strength"
 msgstr "降低​力量"
 
-#: Source/items.cpp:2022
+#: Source/items.cpp:2026
 msgid "decrease dexterity"
 msgstr "降低​敏捷"
 
-#: Source/items.cpp:2026
+#: Source/items.cpp:2030
 msgid "decrease vitality"
 msgstr "降低​活力"
 
-#: Source/items.cpp:2030
+#: Source/items.cpp:2034
 #, fuzzy
 #| msgid "recover life and mana"
 msgid "restore some life and mana"
 msgstr "恢復​生命值​和​法力值"
 
-#: Source/items.cpp:2034
+#: Source/items.cpp:2038
 #, fuzzy
 #| msgid "recover life and mana"
 msgid "restore all life and mana"
 msgstr "使用者​失去​所有​法力值"
 
-#: Source/items.cpp:2049 Source/items.cpp:2074
+#: Source/items.cpp:2053 Source/items.cpp:2078
 msgid "Right-click to read"
 msgstr "右​擊閱讀"
 
-#: Source/items.cpp:2053
+#: Source/items.cpp:2057
 msgid "Right-click to read, then"
 msgstr "右​擊​閱讀，然​後"
 
-#: Source/items.cpp:2055
+#: Source/items.cpp:2059
 msgid "left-click to target"
 msgstr "左​擊目標"
 
-#: Source/items.cpp:2060
+#: Source/items.cpp:2064
 msgid "Right-click to use"
 msgstr "右​擊​使用"
 
-#: Source/items.cpp:2065 Source/items.cpp:2070
+#: Source/items.cpp:2069 Source/items.cpp:2074
 msgid "Right click to use"
 msgstr "右​擊​使用"
 
-#: Source/items.cpp:2078
+#: Source/items.cpp:2082
 msgid "Right click to read"
 msgstr "右​擊閱讀"
 
-#: Source/items.cpp:2082
+#: Source/items.cpp:2086
 msgid "Right-click to view"
 msgstr "右​擊檢視"
 
-#: Source/items.cpp:2090
+#: Source/items.cpp:2094
 msgid "Doubles gold capacity"
 msgstr "金幣​容量​翻倍"
 
-#: Source/items.cpp:2102 Source/stores.cpp:212
+#: Source/items.cpp:2106 Source/stores.cpp:283
 msgid "Required:"
 msgstr "需求: "
 
-#: Source/items.cpp:2104 Source/stores.cpp:214
+#: Source/items.cpp:2108 Source/stores.cpp:285
 msgid " {:d} Str"
 msgstr "{:d}​力量"
 
-#: Source/items.cpp:2106 Source/stores.cpp:216
+#: Source/items.cpp:2110 Source/stores.cpp:287
 msgid " {:d} Mag"
 msgstr "{:d}​魔法"
 
-#: Source/items.cpp:2108 Source/stores.cpp:218
+#: Source/items.cpp:2112 Source/stores.cpp:289
 msgid " {:d} Dex"
 msgstr "{:d}​敏捷"
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:3535 Source/player.cpp:3042
+#: Source/items.cpp:3533 Source/player.cpp:3018
 msgid "Ear of {:s}"
 msgstr "{:s}​的​耳朵"
 
-#: Source/items.cpp:3830
+#: Source/items.cpp:3828
 msgid "chance to hit: {:+d}%"
 msgstr "命​中​機率: {:+d}%"
 
-#: Source/items.cpp:3834
+#: Source/items.cpp:3832
 #, fuzzy, no-c-format
 #| msgid "{:+d}% damage"
 msgid "{:+d}% damage"
 msgstr "{:+d}​敵人​傷害"
 
-#: Source/items.cpp:3838 Source/items.cpp:4094
+#: Source/items.cpp:3836 Source/items.cpp:4092
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "命​中: {:+d}%​, {:+d}%​傷害"
 
-#: Source/items.cpp:3842
+#: Source/items.cpp:3840
 #, fuzzy, no-c-format
 #| msgid "{:+d}% armor"
 msgid "{:+d}% armor"
 msgstr "護​甲: {:d}"
 
-#: Source/items.cpp:3846
+#: Source/items.cpp:3844
 msgid "armor class: {:d}"
 msgstr "護​甲​等​級: {:d}"
 
-#: Source/items.cpp:3851 Source/items.cpp:4076
+#: Source/items.cpp:3849 Source/items.cpp:4074
 msgid "Resist Fire: {:+d}%"
 msgstr "火焰​抗性: {:+d}%"
 
-#: Source/items.cpp:3853
+#: Source/items.cpp:3851
 #, no-c-format
 msgid "Resist Fire: 75% MAX"
 msgstr "火焰​抗性: 最​大​75%"
 
-#: Source/items.cpp:3858
+#: Source/items.cpp:3856
 msgid "Resist Lightning: {:+d}%"
 msgstr "閃​電​抗性: {:+d}%"
 
-#: Source/items.cpp:3860
+#: Source/items.cpp:3858
 #, no-c-format
 msgid "Resist Lightning: 75% MAX"
 msgstr "閃​電​抗性: 最​大​75%"
 
-#: Source/items.cpp:3865
+#: Source/items.cpp:3863
 msgid "Resist Magic: {:+d}%"
 msgstr "抵抗​魔法: {:+d}%"
 
-#: Source/items.cpp:3867
+#: Source/items.cpp:3865
 #, no-c-format
 msgid "Resist Magic: 75% MAX"
 msgstr "抵抗​魔法: 最​大​75%"
 
-#: Source/items.cpp:3872
+#: Source/items.cpp:3870
 msgid "Resist All: {:+d}%"
 msgstr "所有​抗性: {:+d}%"
 
-#: Source/items.cpp:3874
+#: Source/items.cpp:3872
 #, no-c-format
 msgid "Resist All: 75% MAX"
 msgstr "所有​抗性: 最​大​75%"
 
-#: Source/items.cpp:3878
+#: Source/items.cpp:3876
 #, fuzzy
 #| msgid "spells are increased {:d} level"
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] "層數: {:d}巢穴"
 
-#: Source/items.cpp:3880
+#: Source/items.cpp:3878
 #, fuzzy
 #| msgid "spells are decreased {:d} level"
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "層數: {:d}巢穴"
 
-#: Source/items.cpp:3882
+#: Source/items.cpp:3880
 msgid "spell levels unchanged (?)"
 msgstr "法術​等​級​不​變​（？）"
 
-#: Source/items.cpp:3885
+#: Source/items.cpp:3883
 msgid "Extra charges"
 msgstr "額​外​充能"
 
-#: Source/items.cpp:3888
+#: Source/items.cpp:3886
 #, fuzzy
 #| msgid "{:d} {:s} charge"
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:s}，層數: {:d}"
 
-#: Source/items.cpp:3892
+#: Source/items.cpp:3890
 msgid "Fire hit damage: {:d}"
 msgstr "火焰​傷害: {:d}"
 
-#: Source/items.cpp:3894
+#: Source/items.cpp:3892
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "火焰​傷害: {:d}-{:d}"
 
-#: Source/items.cpp:3898
+#: Source/items.cpp:3896
 msgid "Lightning hit damage: {:d}"
 msgstr "閃電​傷害: {:d}"
 
-#: Source/items.cpp:3900
+#: Source/items.cpp:3898
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "閃電​傷害: {:d}-{:d}"
 
-#: Source/items.cpp:3904
+#: Source/items.cpp:3902
 msgid "{:+d} to strength"
 msgstr "{:+d}​力量"
 
-#: Source/items.cpp:3908
+#: Source/items.cpp:3906
 msgid "{:+d} to magic"
 msgstr "{:+d}​魔法"
 
-#: Source/items.cpp:3912
+#: Source/items.cpp:3910
 msgid "{:+d} to dexterity"
 msgstr "{:+d}​敏捷"
 
-#: Source/items.cpp:3916
+#: Source/items.cpp:3914
 msgid "{:+d} to vitality"
 msgstr "{:+d}​活力"
 
-#: Source/items.cpp:3920
+#: Source/items.cpp:3918
 msgid "{:+d} to all attributes"
 msgstr "{:+d}​到​所有​屬性"
 
-#: Source/items.cpp:3924
+#: Source/items.cpp:3922
 msgid "{:+d} damage from enemies"
 msgstr "{:+d}​敵人​傷害"
 
-#: Source/items.cpp:3928
+#: Source/items.cpp:3926
 msgid "Hit Points: {:+d}"
 msgstr "生命​值: {:+d}"
 
-#: Source/items.cpp:3932
+#: Source/items.cpp:3930
 msgid "Mana: {:+d}"
 msgstr "法力值: {:+d}"
 
-#: Source/items.cpp:3935
+#: Source/items.cpp:3933
 msgid "high durability"
 msgstr "高​耐​久度"
 
-#: Source/items.cpp:3938
+#: Source/items.cpp:3936
 msgid "decreased durability"
 msgstr "耐​久度​降低"
 
-#: Source/items.cpp:3941
+#: Source/items.cpp:3939
 msgid "indestructible"
 msgstr "堅​不​可​摧"
 
-#: Source/items.cpp:3944
+#: Source/items.cpp:3942
 #, fuzzy, no-c-format
 #| msgid "+{:d}%% light radius"
 msgid "+{:d}% light radius"
 msgstr "謎團​在​理性​的​光照​下​顯​露出​來"
 
-#: Source/items.cpp:3947
+#: Source/items.cpp:3945
 #, fuzzy, no-c-format
 #| msgid "-{:d}%% light radius"
 msgid "-{:d}% light radius"
 msgstr "謎團​在​理性​的​光照​下​顯​露出​來"
 
-#: Source/items.cpp:3950
+#: Source/items.cpp:3948
 msgid "multiple arrows per shot"
 msgstr "射​出​多​重箭"
 
-#: Source/items.cpp:3954
+#: Source/items.cpp:3952
 msgid "fire arrows damage: {:d}"
 msgstr "火箭​傷害: {:d}"
 
-#: Source/items.cpp:3956
+#: Source/items.cpp:3954
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "火箭​傷害: {:d}-{:d}"
 
-#: Source/items.cpp:3960
+#: Source/items.cpp:3958
 msgid "lightning arrows damage {:d}"
 msgstr "閃​電箭​傷害{:d}"
 
-#: Source/items.cpp:3962
+#: Source/items.cpp:3960
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "閃​電箭​傷害{:d}-{:d}"
 
-#: Source/items.cpp:3966
+#: Source/items.cpp:3964
 msgid "fireball damage: {:d}"
 msgstr "火球​傷害: {:d}"
 
-#: Source/items.cpp:3968
+#: Source/items.cpp:3966
 msgid "fireball damage: {:d}-{:d}"
 msgstr "火球​傷害: {:d}-{:d}"
 
-#: Source/items.cpp:3971
+#: Source/items.cpp:3969
 msgid "attacker takes 1-3 damage"
 msgstr "攻擊者​受到​1-3​點​傷害"
 
-#: Source/items.cpp:3974
+#: Source/items.cpp:3972
 msgid "user loses all mana"
 msgstr "使用者​失去​所有​法力值"
 
-#: Source/items.cpp:3977
+#: Source/items.cpp:3975
 msgid "you can't heal"
 msgstr "你​無​法治​癒"
 
-#: Source/items.cpp:3980
+#: Source/items.cpp:3978
 msgid "absorbs half of trap damage"
 msgstr "吸收​一半​陷阱​傷害"
 
-#: Source/items.cpp:3983
+#: Source/items.cpp:3981
 msgid "knocks target back"
 msgstr "擊​退目標"
 
-#: Source/items.cpp:3986
+#: Source/items.cpp:3984
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr "+​對​惡​魔​造成​200​%​傷害"
 
-#: Source/items.cpp:3989
+#: Source/items.cpp:3987
 msgid "All Resistance equals 0"
 msgstr "所有​抗性​變​為​0"
 
-#: Source/items.cpp:3992
+#: Source/items.cpp:3990
 msgid "hit monster doesn't heal"
 msgstr "命​中​怪物無​法治​癒"
 
-#: Source/items.cpp:3996
+#: Source/items.cpp:3994
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr "命​中​竊取​3%​法力值"
 
-#: Source/items.cpp:3998
+#: Source/items.cpp:3996
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr "命​中​竊取​5%​法力值"
 
-#: Source/items.cpp:4002
+#: Source/items.cpp:4000
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr "命​中​時​竊​取​3%​生命​值"
 
-#: Source/items.cpp:4004
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr "命​中​時​竊​取​5​%​生命​值"
 
-#: Source/items.cpp:4007
+#: Source/items.cpp:4005
 msgid "penetrates target's armor"
 msgstr "穿透目標​的​護甲"
 
-#: Source/items.cpp:4011
+#: Source/items.cpp:4009
 msgid "quick attack"
 msgstr "加速​攻擊"
 
-#: Source/items.cpp:4013
+#: Source/items.cpp:4011
 msgid "fast attack"
 msgstr "快速​攻擊"
 
-#: Source/items.cpp:4015
+#: Source/items.cpp:4013
 msgid "faster attack"
 msgstr "極​速攻擊"
 
-#: Source/items.cpp:4017
+#: Source/items.cpp:4015
 msgid "fastest attack"
 msgstr "最​快​的​攻擊"
 
-#: Source/items.cpp:4021
+#: Source/items.cpp:4019
 msgid "fast hit recovery"
 msgstr "快速​打擊​回覆"
 
-#: Source/items.cpp:4023
+#: Source/items.cpp:4021
 msgid "faster hit recovery"
 msgstr "更​快​打擊​回覆"
 
-#: Source/items.cpp:4025
+#: Source/items.cpp:4023
 msgid "fastest hit recovery"
 msgstr "最​快​打擊​回覆"
 
-#: Source/items.cpp:4028
+#: Source/items.cpp:4026
 msgid "fast block"
 msgstr "快速​格擋"
 
-#: Source/items.cpp:4031
+#: Source/items.cpp:4029
 #, fuzzy
 #| msgid "adds {:d} point to damage"
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] "傷害: {:d} Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4034
+#: Source/items.cpp:4032
 msgid "fires random speed arrows"
 msgstr "發​射隨機​速度​箭頭"
 
-#: Source/items.cpp:4037
+#: Source/items.cpp:4035
 msgid "unusual item damage"
 msgstr "異​常​物品​損壞"
 
-#: Source/items.cpp:4040
+#: Source/items.cpp:4038
 msgid "altered durability"
 msgstr "改變​耐​久度"
 
-#: Source/items.cpp:4043
+#: Source/items.cpp:4041
 msgid "Faster attack swing"
 msgstr "更​快​的​揮動"
 
-#: Source/items.cpp:4046
+#: Source/items.cpp:4044
 msgid "one handed sword"
 msgstr "單​手劍"
 
-#: Source/items.cpp:4049
+#: Source/items.cpp:4047
 msgid "constantly lose hit points"
 msgstr "不​斷​失去​生命值"
 
-#: Source/items.cpp:4052
+#: Source/items.cpp:4050
 msgid "life stealing"
 msgstr "竊取​生命"
 
-#: Source/items.cpp:4055
+#: Source/items.cpp:4053
 msgid "no strength requirement"
 msgstr "無​力量​要求"
 
-#: Source/items.cpp:4058
+#: Source/items.cpp:4056
 msgid "see with infravision"
 msgstr "夜視​能力"
 
-#: Source/items.cpp:4065
+#: Source/items.cpp:4063
 msgid "lightning damage: {:d}"
 msgstr "閃電​傷害: {:d}"
 
-#: Source/items.cpp:4067
+#: Source/items.cpp:4065
 msgid "lightning damage: {:d}-{:d}"
 msgstr "閃電​傷害: {:d}-{:d}"
 
-#: Source/items.cpp:4070
+#: Source/items.cpp:4068
 msgid "charged bolts on hits"
 msgstr "擊​中​時觸發​電​荷彈"
 
-#: Source/items.cpp:4079
+#: Source/items.cpp:4077
 msgid "occasional triple damage"
 msgstr "有​概率​造成​三​倍​傷害"
 
-#: Source/items.cpp:4082
+#: Source/items.cpp:4080
 #, fuzzy, no-c-format
 #| msgid "decaying {:+d}% damage"
 msgid "decaying {:+d}% damage"
 msgstr "傷害: {:d} Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4085
+#: Source/items.cpp:4083
 msgid "2x dmg to monst, 1x to you"
 msgstr "2x 對​怪物​傷害，1x 反噬​自身"
 
-#: Source/items.cpp:4088
+#: Source/items.cpp:4086
 #, no-c-format
 msgid "Random 0 - 500% damage"
 msgstr "隨​機​0-500​%​傷害"
 
-#: Source/items.cpp:4091
+#: Source/items.cpp:4089
 #, fuzzy, no-c-format
 #| msgid "low dur, {:+d}% damage"
 msgid "low dur, {:+d}% damage"
 msgstr "傷害: {:d}-{:d} 耐久: {:d}/{:d}"
 
-#: Source/items.cpp:4097
+#: Source/items.cpp:4095
 msgid "extra AC vs demons"
 msgstr "對​抗​惡魔​的​額外​精準"
 
-#: Source/items.cpp:4100
+#: Source/items.cpp:4098
 msgid "extra AC vs undead"
 msgstr "對​抗亡靈​的​額外​精準"
 
-#: Source/items.cpp:4103
+#: Source/items.cpp:4101
 #, no-c-format
 msgid "50% Mana moved to Health"
 msgstr "50​%​法力值轉換​至​生命​值"
 
-#: Source/items.cpp:4106
+#: Source/items.cpp:4104
 #, no-c-format
 msgid "40% Health moved to Mana"
 msgstr "40​%​的​生命值轉換​至​法力值"
 
-#: Source/items.cpp:4109
+#: Source/items.cpp:4107
 msgid "Another ability (NW)"
 msgstr "另​一​種​能力​（​NW​）"
 
-#: Source/items.cpp:4146 Source/items.cpp:4193
+#: Source/items.cpp:4144 Source/items.cpp:4191
 msgid "damage: {:d}  Indestructible"
 msgstr "傷害: {:d} 堅​不​可​摧"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4148 Source/items.cpp:4195
+#: Source/items.cpp:4146 Source/items.cpp:4193
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "傷害: {:d} Dur: {:d}/{:d}"
 
-#: Source/items.cpp:4151 Source/items.cpp:4198
+#: Source/items.cpp:4149 Source/items.cpp:4196
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "傷害: {:d}-{:d} 堅​不​可​摧"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4153 Source/items.cpp:4200
+#: Source/items.cpp:4151 Source/items.cpp:4198
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "傷害: {:d}-{:d} 耐久: {:d}/{:d}"
 
-#: Source/items.cpp:4159 Source/items.cpp:4212
+#: Source/items.cpp:4157 Source/items.cpp:4210
 msgid "armor: {:d}  Indestructible"
 msgstr "護​甲: {:d} 堅​不​可​摧"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4161 Source/items.cpp:4214
+#: Source/items.cpp:4159 Source/items.cpp:4212
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "護​甲: {:d} 耐久: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4166
+#: Source/items.cpp:4164
 msgid "dam: {:d}  Dur: {:d}/{:d}"
 msgstr "傷害: {:d} 耐久: {:d}/{:d}"
 
 #. TRANSLATORS: dam: is damage Dur: is durability
-#: Source/items.cpp:4168
+#: Source/items.cpp:4166
 msgid "dam: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "傷害: {:d}-{:d} 耐久: {:d}/{:d}"
 
-#: Source/items.cpp:4169 Source/items.cpp:4204 Source/items.cpp:4219
-#: Source/stores.cpp:184
+#: Source/items.cpp:4167 Source/items.cpp:4202 Source/items.cpp:4217
+#: Source/stores.cpp:255
 msgid "Charges: {:d}/{:d}"
 msgstr "充能: {:d}/{:d}"
 
-#: Source/items.cpp:4181
+#: Source/items.cpp:4179
 msgid "unique item"
 msgstr "獨​特裝備"
 
-#: Source/items.cpp:4208 Source/items.cpp:4217 Source/items.cpp:4224
+#: Source/items.cpp:4206 Source/items.cpp:4215 Source/items.cpp:4222
 msgid "Not Identified"
 msgstr "未​鑑​定"
 
-#: Source/loadsave.cpp:1656 Source/loadsave.cpp:2122
+#: Source/loadsave.cpp:1683 Source/loadsave.cpp:2149
 msgid "Unable to open save file archive"
 msgstr "無​法​打開​儲​存檔​案​存檔"
 
-#: Source/loadsave.cpp:1659
+#: Source/loadsave.cpp:1686
 msgid "Invalid save file"
 msgstr "無效​的​儲存​檔案"
 
-#: Source/loadsave.cpp:1688
+#: Source/loadsave.cpp:1717
 msgid "Player is on a Hellfire only level"
 msgstr "玩​家處於​地​獄火​特有​地​圖"
 
-#: Source/loadsave.cpp:1885
+#: Source/loadsave.cpp:1912
 msgid "Invalid game state"
 msgstr "無效​的​遊戲狀態"
 
-#: Source/menu.cpp:136
+#: Source/menu.cpp:154
 msgid "Unable to display mainmenu"
 msgstr "無​法​顯示主菜單"
+
+#. TRANSLATORS:  Error Message when a Shareware User clicks on "Replay Intro" in the Main Menu
+#: Source/menu.cpp:179
+msgid ""
+"The Diablo introduction cinematic is only available in the full retail "
+"version of Diablo. Visit https://www.gog.com/game/diablo to purchase."
+msgstr ""
+"暗​黑破壞​神介紹​電影版​只​提供​完整​的​零售版​暗​黑破壞神。前往 https://www.gog.com/"
+"game/diablo 購買。"
 
 #. TRANSLATORS: Monster Block start
 #. MT_NZOMBIE
@@ -5136,6 +5234,13 @@ msgctxt "monster"
 msgid "Reaper"
 msgstr "收割者"
 
+#. TRANSLATORS: Monster Block end
+#. MT_NAKRUL
+#: Source/monstdat.cpp:158 Source/monstdat.cpp:485
+msgctxt "monster"
+msgid "Na-Krul"
+msgstr ""
+
 #. TRANSLATORS: Unique Monster Block start
 #: Source/monstdat.cpp:473
 #, fuzzy
@@ -5176,6 +5281,11 @@ msgstr "丹紅"
 msgctxt "monster"
 msgid "Black Jade"
 msgstr "碧玉"
+
+#: Source/monstdat.cpp:480
+msgctxt "monster"
+msgid "Lachdanan"
+msgstr ""
 
 #: Source/monstdat.cpp:481
 msgctxt "monster"
@@ -5243,6 +5353,11 @@ msgctxt "monster"
 msgid "Brokenhead Bangshield"
 msgstr "斷​頭盾"
 
+#: Source/monstdat.cpp:494
+msgctxt "monster"
+msgid "Bongo"
+msgstr ""
+
 #: Source/monstdat.cpp:495
 #, fuzzy
 #| msgid "Rotcarnage"
@@ -5270,6 +5385,11 @@ msgstr "死​神"
 msgctxt "monster"
 msgid "Madeye the Dead"
 msgstr "死者​之​弓"
+
+#: Source/monstdat.cpp:499
+msgctxt "monster"
+msgid "El Chupacabras"
+msgstr ""
 
 #: Source/monstdat.cpp:500
 #, fuzzy
@@ -5740,12 +5860,24 @@ msgctxt "monster"
 msgid "The Vizier"
 msgstr "維​齊爾"
 
+#: Source/monstdat.cpp:567
+#, fuzzy
+#| msgid "Sapphire"
+msgctxt "monster"
+msgid "Zamphir"
+msgstr "藍​寶石"
+
 #: Source/monstdat.cpp:568
 #, fuzzy
 #| msgid "Bloodlust"
 msgctxt "monster"
 msgid "Bloodlust"
 msgstr "嗜​血"
+
+#: Source/monstdat.cpp:569
+msgctxt "monster"
+msgid "Webwidow"
+msgstr ""
 
 #: Source/monstdat.cpp:570
 #, fuzzy
@@ -5769,96 +5901,97 @@ msgctxt "monster"
 msgid "Doomlock"
 msgstr "杜姆洛克"
 
-#: Source/monster.cpp:3474
+#: Source/monster.cpp:3479
 msgid "Animal"
 msgstr "動物"
 
-#: Source/monster.cpp:3476
+#: Source/monster.cpp:3481
 msgid "Demon"
 msgstr "惡​魔"
 
-#: Source/monster.cpp:3478
+#: Source/monster.cpp:3483
 msgid "Undead"
 msgstr "亡靈"
 
-#: Source/monster.cpp:4610
+#: Source/monster.cpp:4612
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "型​別: {:s} 擊殺: {:d}"
 
-#: Source/monster.cpp:4612
+#: Source/monster.cpp:4614
 msgid "Total kills: {:d}"
 msgstr "擊​殺總​數: {:d}"
 
-#: Source/monster.cpp:4645
+#: Source/monster.cpp:4647
 msgid "Hit Points: {:d}-{:d}"
 msgstr "生命​值: {:d}-{:d}"
 
-#: Source/monster.cpp:4651
+#: Source/monster.cpp:4653
 msgid "No magic resistance"
 msgstr "沒​有​魔法​抵抗"
 
-#: Source/monster.cpp:4655
+#: Source/monster.cpp:4657
 msgid "Resists: "
 msgstr "抗性: "
 
-#: Source/monster.cpp:4657 Source/monster.cpp:4668
+#: Source/monster.cpp:4659 Source/monster.cpp:4671
 msgid "Magic "
 msgstr "魔法"
 
-#: Source/monster.cpp:4659 Source/monster.cpp:4670
+#: Source/monster.cpp:4661 Source/monster.cpp:4673
 msgid "Fire "
 msgstr "火"
 
-#: Source/monster.cpp:4661 Source/monster.cpp:4672
+#: Source/monster.cpp:4663 Source/monster.cpp:4675
 msgid "Lightning "
 msgstr "閃​電"
 
-#: Source/monster.cpp:4666
+#: Source/monster.cpp:4669
 msgid "Immune: "
 msgstr "免疫: "
 
-#: Source/monster.cpp:4684
+#: Source/monster.cpp:4688
 msgid "Type: {:s}"
 msgstr "型​別: {:s}"
 
-#: Source/monster.cpp:4690 Source/monster.cpp:4697
+#: Source/monster.cpp:4694 Source/monster.cpp:4701
 msgid "No resistances"
 msgstr "無​抗性"
 
-#: Source/monster.cpp:4692 Source/monster.cpp:4702
+#: Source/monster.cpp:4696 Source/monster.cpp:4706
 msgid "No Immunities"
 msgstr "無​免疫"
 
-#: Source/monster.cpp:4695
+#: Source/monster.cpp:4699
 msgid "Some Magic Resistances"
 msgstr "一些​魔法​抵抗"
 
-#: Source/monster.cpp:4700
+#: Source/monster.cpp:4704
 msgid "Some Magic Immunities"
 msgstr "一些​魔法​免疫"
 
-#: Source/msg.cpp:484
+#: Source/msg.cpp:495
 msgid "Trying to drop a floor item?"
 msgstr "想​扔​地板嗎？"
 
-#: Source/msg.cpp:951 Source/msg.cpp:975 Source/msg.cpp:998 Source/msg.cpp:1113
-#: Source/msg.cpp:1136 Source/msg.cpp:1158 Source/msg.cpp:1180
+#: Source/msg.cpp:994 Source/msg.cpp:1029 Source/msg.cpp:1060
+#: Source/msg.cpp:1187 Source/msg.cpp:1219 Source/msg.cpp:1251
+#: Source/msg.cpp:1281
 msgid "{:s} has cast an illegal spell."
 msgstr "{:s}​施放​了​非法​法術。"
 
-#: Source/msg.cpp:1529 Source/multi.cpp:815
+#: Source/msg.cpp:1668 Source/multi.cpp:804
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr "玩​家​{:s}(​等​級{:d})剛​加入​了​遊戲"
 
-#: Source/msg.cpp:1826
+#: Source/msg.cpp:1972
 msgid "Waiting for game data..."
 msgstr "正在​等待​遊戲​數據。。。"
 
-#: Source/msg.cpp:1834
+#: Source/msg.cpp:1980
 msgid "The game ended"
 msgstr "比賽​結束​了"
 
-#: Source/msg.cpp:1840
+#: Source/msg.cpp:1986
 msgid "Unable to get level data"
 msgstr "無​法​獲取層數據"
 
@@ -5874,547 +6007,546 @@ msgstr "玩​家​{:s}​殺死​了​迪亞波羅並​離開​了​遊�
 msgid "Player '{:s}' dropped due to timeout"
 msgstr "由於​超時，玩家​{:s}​的​掉落物​被​刪除"
 
-#: Source/multi.cpp:817
+#: Source/multi.cpp:806
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr "玩​家​{:s}(​等​級{:d})​已​經​在​遊戲​中"
 
 #. TRANSLATORS: Shrine Name Block
-#: Source/objects.cpp:101
+#: Source/objects.cpp:104
 msgid "Mysterious"
 msgstr "神秘​的"
 
-#: Source/objects.cpp:102
+#: Source/objects.cpp:105
 msgid "Hidden"
 msgstr "隱​藏"
 
-#: Source/objects.cpp:103
+#: Source/objects.cpp:106
 msgid "Gloomy"
 msgstr "陰鬱​的"
 
-#: Source/objects.cpp:105 Source/objects.cpp:112
+#: Source/objects.cpp:108 Source/objects.cpp:115
 msgid "Magical"
 msgstr "神奇​的"
 
-#: Source/objects.cpp:106
+#: Source/objects.cpp:109
 msgid "Stone"
 msgstr "巖石"
 
-#: Source/objects.cpp:107
+#: Source/objects.cpp:110
 msgid "Religious"
 msgstr "宗教​的"
 
-#: Source/objects.cpp:108
+#: Source/objects.cpp:111
 msgid "Enchanted"
 msgstr "被​迷住​了"
 
-#: Source/objects.cpp:109
+#: Source/objects.cpp:112
 msgid "Thaumaturgic"
 msgstr "Thaumaturogic​公司"
 
-#: Source/objects.cpp:110
+#: Source/objects.cpp:113
 msgid "Fascinating"
 msgstr "炫​目"
 
-#: Source/objects.cpp:111
+#: Source/objects.cpp:114
 msgid "Cryptic"
 msgstr "神秘​的"
 
-#: Source/objects.cpp:113
+#: Source/objects.cpp:116
 msgid "Eldritch"
 msgstr "埃爾德里​奇"
 
-#: Source/objects.cpp:114
+#: Source/objects.cpp:117
 msgid "Eerie"
 msgstr "詭異​的"
 
-#: Source/objects.cpp:115
+#: Source/objects.cpp:118
 msgid "Divine"
 msgstr "至​聖"
 
-#: Source/objects.cpp:117
+#: Source/objects.cpp:120
 msgid "Sacred"
 msgstr "聖​潔"
 
-#: Source/objects.cpp:118
+#: Source/objects.cpp:121
 msgid "Spiritual"
 msgstr "靈性"
 
-#: Source/objects.cpp:119
+#: Source/objects.cpp:122
 msgid "Spooky"
 msgstr "幽靈​般​的"
 
-#: Source/objects.cpp:120
+#: Source/objects.cpp:123
 msgid "Abandoned"
 msgstr "被​遺棄​的"
 
-#: Source/objects.cpp:121
+#: Source/objects.cpp:124
 msgid "Creepy"
 msgstr "令​人​毛骨悚然"
 
-#: Source/objects.cpp:122
+#: Source/objects.cpp:125
 msgid "Quiet"
 msgstr "安靜​的"
 
-#: Source/objects.cpp:123
+#: Source/objects.cpp:126
 msgid "Secluded"
 msgstr "與​世隔絕"
 
-#: Source/objects.cpp:124
+#: Source/objects.cpp:127
 msgid "Ornate"
 msgstr "華麗​的"
 
-#: Source/objects.cpp:125
+#: Source/objects.cpp:128
 msgid "Glimmering"
 msgstr "微光"
 
-#: Source/objects.cpp:126
+#: Source/objects.cpp:129
 msgid "Tainted"
 msgstr "污染​魔"
 
-#: Source/objects.cpp:127
+#: Source/objects.cpp:130
 msgid "Oily"
 msgstr "油性"
 
-#: Source/objects.cpp:128
+#: Source/objects.cpp:131
 msgid "Glowing"
 msgstr "輝​光"
 
-#: Source/objects.cpp:129
+#: Source/objects.cpp:132
 msgid "Mendicant's"
 msgstr "乞丐​的"
 
-#: Source/objects.cpp:130
+#: Source/objects.cpp:133
 msgid "Sparkling"
 msgstr "閃​亮​的"
 
-#: Source/objects.cpp:131
+#: Source/objects.cpp:134
 msgid "Town"
 msgstr "城鎮"
 
-#: Source/objects.cpp:132
+#: Source/objects.cpp:135
 msgid "Shimmering"
 msgstr "光彩"
 
-#: Source/objects.cpp:133
+#: Source/objects.cpp:136
 msgid "Solar"
 msgstr "日光"
 
 #. TRANSLATORS: Shrine Name Block end
-#: Source/objects.cpp:135
+#: Source/objects.cpp:138
 msgid "Murphy's"
 msgstr "墨菲​的"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:265
+#: Source/objects.cpp:268
 msgid "The Great Conflict"
 msgstr "大​沖​突"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:266
+#: Source/objects.cpp:269
 msgid "The Wages of Sin are War"
 msgstr "罪惡​的​代價​是​戰爭"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:267
+#: Source/objects.cpp:270
 msgid "The Tale of the Horadrim"
 msgstr "赫拉迪姆​的​故事"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:268
+#: Source/objects.cpp:271
 msgid "The Dark Exile"
 msgstr "黑暗​的​流放"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:269
+#: Source/objects.cpp:272
 msgid "The Sin War"
 msgstr "原罪​之​戰"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:270
+#: Source/objects.cpp:273
 msgid "The Binding of the Three"
 msgstr "三者​的​結合"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:271
+#: Source/objects.cpp:274
 msgid "The Realms Beyond"
 msgstr "超越​的​王國"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:272
+#: Source/objects.cpp:275
 msgid "Tale of the Three"
 msgstr "三​部​曲"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:273
+#: Source/objects.cpp:276
 msgid "The Black King"
 msgstr "黑​王"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:274
+#: Source/objects.cpp:277
 msgid "Journal: The Ensorcellment"
 msgstr "期​刊: 感悟"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:275
+#: Source/objects.cpp:278
 msgid "Journal: The Meeting"
 msgstr "日​記: 會議"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:276
+#: Source/objects.cpp:279
 msgid "Journal: The Tirade"
 msgstr "日​記: 長篇​大論"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:277
+#: Source/objects.cpp:280
 msgid "Journal: His Power Grows"
 msgstr "日​記: 他​的​力量​在​增長"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:278
+#: Source/objects.cpp:281
 msgid "Journal: NA-KRUL"
 msgstr "期​刊: NA-KRUL"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:279
+#: Source/objects.cpp:282
 msgid "Journal: The End"
 msgstr "日​記: 結束"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:280
+#: Source/objects.cpp:283
 msgid "A Spellbook"
 msgstr "咒​語書"
 
-#: Source/objects.cpp:5365
+#: Source/objects.cpp:5339
 msgid "Crucified Skeleton"
 msgstr "十字​架​骷髏"
 
-#: Source/objects.cpp:5369
+#: Source/objects.cpp:5343
 msgid "Lever"
 msgstr "控制​桿"
 
-#: Source/objects.cpp:5378
+#: Source/objects.cpp:5352
 msgid "Open Door"
 msgstr "打開​的​門"
 
-#: Source/objects.cpp:5380
+#: Source/objects.cpp:5354
 msgid "Closed Door"
 msgstr "關閉​的​門"
 
-#: Source/objects.cpp:5382
+#: Source/objects.cpp:5356
 msgid "Blocked Door"
 msgstr "封死​的​門"
 
-#: Source/objects.cpp:5387
+#: Source/objects.cpp:5361
 msgid "Ancient Tome"
 msgstr "古籍"
 
-#: Source/objects.cpp:5389
+#: Source/objects.cpp:5363
 msgid "Book of Vileness"
 msgstr "卑鄙書"
 
-#: Source/objects.cpp:5394
+#: Source/objects.cpp:5368
 msgid "Skull Lever"
 msgstr "頭​骨槓​桿"
 
-#: Source/objects.cpp:5397
+#: Source/objects.cpp:5371
 msgid "Mythical Book"
 msgstr "神話書"
 
-#: Source/objects.cpp:5401
+#: Source/objects.cpp:5375
 msgid "Small Chest"
 msgstr "小​箱子"
 
-#: Source/objects.cpp:5405
+#: Source/objects.cpp:5379
 msgid "Chest"
 msgstr "箱子"
 
-#: Source/objects.cpp:5410
+#: Source/objects.cpp:5384
 msgid "Large Chest"
 msgstr "大​箱子"
 
-#: Source/objects.cpp:5413
+#: Source/objects.cpp:5387
 msgid "Sarcophagus"
 msgstr "石​棺"
 
-#: Source/objects.cpp:5416
+#: Source/objects.cpp:5390
 msgid "Bookshelf"
 msgstr "書架"
 
-#: Source/objects.cpp:5420
+#: Source/objects.cpp:5394
 msgid "Bookcase"
 msgstr "書​櫃"
 
-#: Source/objects.cpp:5425
+#: Source/objects.cpp:5399
 msgid "Pod"
 msgstr "豆莢"
 
-#: Source/objects.cpp:5427
+#: Source/objects.cpp:5401
 msgid "Urn"
 msgstr "罐子"
 
-#: Source/objects.cpp:5429
+#: Source/objects.cpp:5403
 msgid "Barrel"
 msgstr "桶"
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:5433
+#: Source/objects.cpp:5407
 msgid "{:s} Shrine"
 msgstr "{:s}​神殿"
 
-#: Source/objects.cpp:5437
+#: Source/objects.cpp:5411
 msgid "Skeleton Tome"
 msgstr "骷​髏​大部​頭"
 
-#: Source/objects.cpp:5440
+#: Source/objects.cpp:5414
 msgid "Library Book"
 msgstr "圖​書館圖書"
 
-#: Source/objects.cpp:5443
+#: Source/objects.cpp:5417
 msgid "Blood Fountain"
 msgstr "血泉"
 
-#: Source/objects.cpp:5446
+#: Source/objects.cpp:5420
 msgid "Decapitated Body"
 msgstr "斷​頭屍體"
 
-#: Source/objects.cpp:5449
+#: Source/objects.cpp:5423
 msgid "Book of the Blind"
 msgstr "盲人​書"
 
-#: Source/objects.cpp:5452
+#: Source/objects.cpp:5426
 msgid "Book of Blood"
 msgstr "血​書"
 
-#: Source/objects.cpp:5455
+#: Source/objects.cpp:5429
 msgid "Purifying Spring"
 msgstr "凈化彈簧"
 
-#: Source/objects.cpp:5462 Source/objects.cpp:5486
+#: Source/objects.cpp:5436 Source/objects.cpp:5460
 msgid "Weapon Rack"
 msgstr "武器​架"
 
-#: Source/objects.cpp:5465
+#: Source/objects.cpp:5439
 msgid "Goat Shrine"
 msgstr "山​羊​神殿"
 
-#: Source/objects.cpp:5468
+#: Source/objects.cpp:5442
 msgid "Cauldron"
 msgstr "大​鍋"
 
-#: Source/objects.cpp:5471
+#: Source/objects.cpp:5445
 msgid "Murky Pool"
 msgstr "渾濁​的​水池"
 
-#: Source/objects.cpp:5474
+#: Source/objects.cpp:5448
 msgid "Fountain of Tears"
 msgstr "淚泉"
 
-#: Source/objects.cpp:5477
+#: Source/objects.cpp:5451
 msgid "Steel Tome"
 msgstr "鋼​卷軸"
 
-#: Source/objects.cpp:5480
+#: Source/objects.cpp:5454
 msgid "Pedestal of Blood"
 msgstr "血座"
 
-#: Source/objects.cpp:5489
+#: Source/objects.cpp:5463
 msgid "Mushroom Patch"
 msgstr "蘑菇斑"
 
-#: Source/objects.cpp:5492
+#: Source/objects.cpp:5466
 msgid "Vile Stand"
 msgstr "卑鄙​的​立場"
 
-#: Source/objects.cpp:5495
+#: Source/objects.cpp:5469
 msgid "Slain Hero"
 msgstr "被​殺​英雄"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:5502
+#: Source/objects.cpp:5476
 msgid "Trapped {:s}"
 msgstr "陷阱​{:s}"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls leaver
-#: Source/objects.cpp:5508
+#: Source/objects.cpp:5482
 msgid "{:s} (disabled)"
 msgstr "{:s}​（​已​禁用​）"
 
-#: Source/panels/charpanel.cpp:109
+#: Source/panels/charpanel.cpp:110
 msgid "MAX"
 msgstr "馬​克斯"
 
-#: Source/panels/charpanel.cpp:119
+#: Source/panels/charpanel.cpp:120
 #, fuzzy
 #| msgid "Level:"
 msgid "Level"
 msgstr "等​級: "
 
-#: Source/panels/charpanel.cpp:121
+#: Source/panels/charpanel.cpp:122
 #, fuzzy
 #| msgid "Experience: "
 msgid "Experience"
 msgstr "經​驗: "
 
-#: Source/panels/charpanel.cpp:123
+#: Source/panels/charpanel.cpp:124
 #, fuzzy
 #| msgid "Next Level: "
 msgid "Next level"
 msgstr "下​一​級: "
 
-#: Source/panels/charpanel.cpp:126
+#: Source/panels/charpanel.cpp:127
 msgid "None"
 msgstr "沒​有​一​個"
 
-#: Source/panels/charpanel.cpp:132
+#: Source/panels/charpanel.cpp:133
 msgid "Base"
 msgstr ""
 
-#: Source/panels/charpanel.cpp:133
+#: Source/panels/charpanel.cpp:134
 #, fuzzy
 #| msgid "No"
 msgid "Now"
 msgstr "曾​經​打開​的​現​在​關閉​了"
 
-#: Source/panels/charpanel.cpp:134
+#: Source/panels/charpanel.cpp:135
 #, fuzzy
 #| msgid "Strength:"
 msgid "Strength"
 msgstr "力量"
 
-#: Source/panels/charpanel.cpp:138
+#: Source/panels/charpanel.cpp:139
 #, fuzzy
 #| msgid "Magic:"
 msgid "Magic"
 msgstr "魔術"
 
-#: Source/panels/charpanel.cpp:142
+#: Source/panels/charpanel.cpp:143
 #, fuzzy
 #| msgid "Dexterity:"
 msgid "Dexterity"
 msgstr "靈​巧"
 
-#: Source/panels/charpanel.cpp:145
+#: Source/panels/charpanel.cpp:146
 #, fuzzy
 #| msgid "Vitality:"
 msgid "Vitality"
 msgstr "活力"
 
-#: Source/panels/charpanel.cpp:148
+#: Source/panels/charpanel.cpp:149
 #, fuzzy
 msgid "Points to distribute"
 msgstr "生命​值: {:d}-{:d}"
 
-#: Source/panels/charpanel.cpp:158
+#: Source/panels/charpanel.cpp:159
 #, fuzzy
 #| msgid "armor class: {:d}"
 msgid "Armor class"
 msgstr "護​甲​等​級: {:d}"
 
-#: Source/panels/charpanel.cpp:160
+#: Source/panels/charpanel.cpp:161
 #, fuzzy
 msgid "To hit"
 msgstr "生命​點{:d}​的​{:d}"
 
-#: Source/panels/charpanel.cpp:162
+#: Source/panels/charpanel.cpp:163
 #, fuzzy
 msgid "Damage"
 msgstr "潛​在​傷害​-​不​是​弓箭"
 
-#: Source/panels/charpanel.cpp:168
+#: Source/panels/charpanel.cpp:170
 #, fuzzy
 msgid "Life"
 msgstr "生活"
 
-#: Source/panels/charpanel.cpp:172
+#: Source/panels/charpanel.cpp:174
 msgid "Mana"
 msgstr "法力"
 
-#: Source/panels/charpanel.cpp:177
+#: Source/panels/charpanel.cpp:179
 #, fuzzy
 #| msgid "Resist Magic: {:+d}%"
 msgid "Resist magic"
 msgstr "抵抗​魔法: {:+d}%"
 
-#: Source/panels/charpanel.cpp:179
+#: Source/panels/charpanel.cpp:181
 #, fuzzy
 #| msgid "Resists: "
 msgid "Resist fire"
 msgstr "火焰​抗性: {:+d}%"
 
-#: Source/panels/charpanel.cpp:181
+#: Source/panels/charpanel.cpp:183
 #, fuzzy
 #| msgid "Resist Lightning: {:+d}%"
 msgid "Resist lightning"
 msgstr "閃​電​抗性: {:+d}%"
 
-#: Source/panels/mainpanel.cpp:62 Source/panels/mainpanel.cpp:109
-#: Source/panels/mainpanel.cpp:111
+#: Source/panels/mainpanel.cpp:62 Source/panels/mainpanel.cpp:106
+#: Source/panels/mainpanel.cpp:108
 #, fuzzy
 #| msgid "Voices"
 msgid "voice"
 msgstr "語音​製作、導演​和​配音"
 
-#: Source/panels/mainpanel.cpp:87
+#: Source/panels/mainpanel.cpp:84
 #, fuzzy
 msgid "char"
 msgstr "角色"
 
-#: Source/panels/mainpanel.cpp:88
+#: Source/panels/mainpanel.cpp:85
 #, fuzzy
 #| msgid "Quests"
 msgid "quests"
 msgstr "任務"
 
-#: Source/panels/mainpanel.cpp:89
+#: Source/panels/mainpanel.cpp:86
 #, fuzzy
 #| msgid "Map"
 msgid "map"
 msgstr "地​圖"
 
-#: Source/panels/mainpanel.cpp:90
+#: Source/panels/mainpanel.cpp:87
 #, fuzzy
 msgid "menu"
 msgstr "菜單"
 
-#: Source/panels/mainpanel.cpp:91
+#: Source/panels/mainpanel.cpp:88
 #, fuzzy
 #| msgid "Inv"
 msgid "inv"
 msgstr "物品​欄"
 
-#: Source/panels/mainpanel.cpp:92
+#: Source/panels/mainpanel.cpp:89
 #, fuzzy
 #| msgid "Spells"
 msgid "spells"
 msgstr "法​術"
 
-#: Source/panels/mainpanel.cpp:104 Source/panels/mainpanel.cpp:106
-#: Source/panels/mainpanel.cpp:108
+#: Source/panels/mainpanel.cpp:101 Source/panels/mainpanel.cpp:103
+#: Source/panels/mainpanel.cpp:105
 msgid "mute"
 msgstr ""
 
-#: Source/pfile.cpp:260
+#: Source/pfile.cpp:242
 msgid "Failed to open player archive for writing."
 msgstr "無​法​打開​播放器​存檔​進行​寫入。"
 
-#: Source/pfile.cpp:385
+#: Source/pfile.cpp:377
 msgid "Unable to open archive"
 msgstr "無​法​打開​存檔"
 
-#: Source/pfile.cpp:387
+#: Source/pfile.cpp:379
 msgid "Unable to load character"
 msgstr "無​法​載入​角色"
 
-#: Source/pfile.cpp:410 Source/pfile.cpp:430
+#: Source/pfile.cpp:403 Source/pfile.cpp:423
 msgid "Unable to read to save file archive"
 msgstr "無​法​讀取​以​儲存檔​案​存檔"
 
-#: Source/pfile.cpp:449
+#: Source/pfile.cpp:442
 msgid "Unable to write to save file archive"
 msgstr "無​法寫​入​以​儲存檔​案​存檔"
 
-#. TRANSLATORS: Shown if player presses "v" button. {:s} is player name, {:d} is level, {:s} is location
-#: Source/plrmsg.cpp:89
+#: Source/plrmsg.cpp:88
 msgid "{:s} (lvl {:d}): {:s}"
 msgstr "{:s}​（​等​級{:d}​）: {:s}"
 
@@ -6429,7 +6561,7 @@ msgstr ""
 msgid "%i gold"
 msgstr "金幣"
 
-#: Source/qol/monhealthbar.cpp:35 Source/qol/xpbar.cpp:56
+#: Source/qol/monhealthbar.cpp:37 Source/qol/xpbar.cpp:56
 #, fuzzy
 #| msgid ""
 #| "Failed to load UI resources. Is devilutionx.mpq accessible and up to date?"
@@ -6472,6 +6604,16 @@ msgstr "加巴德弱者"
 msgid "Zhar the Mad"
 msgstr "瘋狂​的​扎爾"
 
+#: Source/quests.cpp:45
+msgid "Lachdanan"
+msgstr ""
+
+#: Source/quests.cpp:46
+#, fuzzy
+#| msgid "Exit Diablo"
+msgid "Diablo"
+msgstr "退出​暗​黑破壞神"
+
 #: Source/quests.cpp:47
 msgid "The Butcher"
 msgstr "屠夫"
@@ -6501,7 +6643,7 @@ msgid "Poisoned Water Supply"
 msgstr "中毒​供水"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:55 Source/quests.cpp:90
+#: Source/quests.cpp:55 Source/quests.cpp:91
 msgid "The Chamber of Bone"
 msgstr "骨腔"
 
@@ -6529,6 +6671,10 @@ msgstr "遊​蕩​交易者"
 msgid "The Defiler"
 msgstr "污染者"
 
+#: Source/quests.cpp:62
+msgid "Na-Krul"
+msgstr ""
+
 #: Source/quests.cpp:63 Source/trigs.cpp:447
 msgid "Cornerstone of the World"
 msgstr "世界​的​基石"
@@ -6539,27 +6685,27 @@ msgid "The Jersey's Jersey"
 msgstr "球衣​是​球衣"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:89
+#: Source/quests.cpp:90
 msgid "King Leoric's Tomb"
 msgstr "利奧里克國王​墓"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:91 Source/setmaps.cpp:26
+#: Source/quests.cpp:92 Source/setmaps.cpp:26
 msgid "Maze"
 msgstr "迷宮"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:92
+#: Source/quests.cpp:93
 msgid "A Dark Passage"
 msgstr "黑暗​的​通道"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:93
+#: Source/quests.cpp:94
 msgid "Unholy Altar"
 msgstr "邪惡​祭​壇"
 
 #. TRANSLATORS: Used for Quest Portals. {:s} is a Map Name
-#: Source/quests.cpp:449
+#: Source/quests.cpp:450
 msgid "To {:s}"
 msgstr "到​{:s}"
 
@@ -6944,298 +7090,331 @@ msgctxt "spell"
 msgid "Rune of Stone"
 msgstr "符文石"
 
-#: Source/stores.cpp:179 Source/stores.cpp:186
+#: Source/stores.cpp:91
+#, fuzzy
+#| msgid "Griswold's Edge"
+msgid "Griswold"
+msgstr "格里斯沃​爾德​之​鋒"
+
+#: Source/stores.cpp:92
+msgid "Pepin"
+msgstr ""
+
+#: Source/stores.cpp:94
+msgid "Ogden"
+msgstr ""
+
+#: Source/stores.cpp:95
+msgid "Cain"
+msgstr ""
+
+#: Source/stores.cpp:96
+#, fuzzy
+#| msgid "Talk to Farnham"
+msgid "Farnham"
+msgstr "和​法納姆談談"
+
+#: Source/stores.cpp:97
+msgid "Adria"
+msgstr ""
+
+#: Source/stores.cpp:98 Source/stores.cpp:1305
+#, fuzzy
+#| msgid "brilliance"
+msgid "Gillian"
+msgstr "輝煌"
+
+#: Source/stores.cpp:99
+msgid "Wirt"
+msgstr ""
+
+#: Source/stores.cpp:218 Source/stores.cpp:225
+msgid "Back"
+msgstr "返回"
+
+#: Source/stores.cpp:250 Source/stores.cpp:257
 msgid ",  "
 msgstr ","
 
-#: Source/stores.cpp:195
+#: Source/stores.cpp:266
 msgid "Damage: {:d}-{:d}  "
 msgstr "傷害: {:d}-{:d}"
 
-#: Source/stores.cpp:197
+#: Source/stores.cpp:268
 msgid "Armor: {:d}  "
 msgstr "護​甲: {:d}"
 
-#: Source/stores.cpp:199
+#: Source/stores.cpp:270
 msgid "Dur: {:d}/{:d},  "
 msgstr "杜爾: {:d}/{:d}，"
 
-#: Source/stores.cpp:202
+#: Source/stores.cpp:273
 msgid "Indestructible,  "
 msgstr "堅​不​可摧，"
 
-#: Source/stores.cpp:210
+#: Source/stores.cpp:281
 msgid "No required attributes"
 msgstr "沒​有​必需​的​屬性"
 
-#: Source/stores.cpp:243 Source/stores.cpp:995 Source/stores.cpp:1239
+#: Source/stores.cpp:314 Source/stores.cpp:1052 Source/stores.cpp:1292
 msgid "Welcome to the"
 msgstr "歡​迎來​到"
 
-#: Source/stores.cpp:244
+#: Source/stores.cpp:315
 msgid "Blacksmith's shop"
 msgstr "鐵匠​鋪"
 
-#: Source/stores.cpp:245 Source/stores.cpp:610 Source/stores.cpp:997
-#: Source/stores.cpp:1054 Source/stores.cpp:1241 Source/stores.cpp:1253
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:316 Source/stores.cpp:670 Source/stores.cpp:1054
+#: Source/stores.cpp:1110 Source/stores.cpp:1294 Source/stores.cpp:1306
+#: Source/stores.cpp:1318
 msgid "Would you like to:"
 msgstr "您​想: "
 
-#: Source/stores.cpp:246
+#: Source/stores.cpp:317
 msgid "Talk to Griswold"
 msgstr "和​格里斯沃​爾德談談"
 
-#: Source/stores.cpp:247
+#: Source/stores.cpp:318
 msgid "Buy basic items"
 msgstr "購​買​基本​物品"
 
-#: Source/stores.cpp:248
+#: Source/stores.cpp:319
 msgid "Buy premium items"
 msgstr "購​買​高檔​商品"
 
-#: Source/stores.cpp:249 Source/stores.cpp:613
+#: Source/stores.cpp:320 Source/stores.cpp:673
 msgid "Sell items"
 msgstr "出售​物品"
 
-#: Source/stores.cpp:250
+#: Source/stores.cpp:321
 msgid "Repair items"
 msgstr "修理​專案"
 
-#: Source/stores.cpp:251
+#: Source/stores.cpp:322
 msgid "Leave the shop"
 msgstr "離​開​商店"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:289 Source/stores.cpp:654 Source/stores.cpp:1032
+#: Source/stores.cpp:360 Source/stores.cpp:714 Source/stores.cpp:1089
 msgid "I have these items for sale:             Your gold: {:d}"
 msgstr "我​有​這​些​東西​要​賣: 你​的​金幣: {:d}"
 
-#: Source/stores.cpp:295 Source/stores.cpp:356 Source/stores.cpp:479
-#: Source/stores.cpp:495 Source/stores.cpp:569 Source/stores.cpp:585
-#: Source/stores.cpp:660 Source/stores.cpp:751 Source/stores.cpp:767
-#: Source/stores.cpp:832 Source/stores.cpp:848 Source/stores.cpp:1038
-#: Source/stores.cpp:1154 Source/stores.cpp:1170 Source/stores.cpp:1205
-#: Source/stores.cpp:1232
-msgid "Back"
-msgstr "返回"
-
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:351
+#: Source/stores.cpp:420
 msgid "I have these premium items for sale:     Your gold: {:d}"
 msgstr "我​有​這​些​高檔​商品​出售: 你​的​金幣: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:474 Source/stores.cpp:746
+#: Source/stores.cpp:541 Source/stores.cpp:804
 msgid "You have nothing I want.             Your gold: {:d}"
 msgstr "你​沒​有​我​想要​的​東西。你​的​金幣: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:489 Source/stores.cpp:761
+#: Source/stores.cpp:554 Source/stores.cpp:817
 msgid "Which item is for sale?             Your gold: {:d}"
 msgstr "哪​件​商品​在​出售？你​的​金幣: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:564
+#: Source/stores.cpp:627
 msgid "You have nothing to repair.             Your gold: {:d}"
 msgstr "你​沒什麼​可​修​的。你​的​金幣: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:579
+#: Source/stores.cpp:640
 msgid "Repair which item?             Your gold: {:d}"
 msgstr "修理​哪​個​專案？你​的​金幣: {:d}"
 
-#: Source/stores.cpp:609
+#: Source/stores.cpp:669
 msgid "Witch's shack"
 msgstr "女​巫小屋"
 
-#: Source/stores.cpp:611
+#: Source/stores.cpp:671
 msgid "Talk to Adria"
 msgstr "和​艾德里亞談​談"
 
-#: Source/stores.cpp:612 Source/stores.cpp:999
+#: Source/stores.cpp:672 Source/stores.cpp:1056
 msgid "Buy items"
 msgstr "購​買​物品"
 
-#: Source/stores.cpp:614
+#: Source/stores.cpp:674
 msgid "Recharge staves"
 msgstr "補​給棒"
 
-#: Source/stores.cpp:615
+#: Source/stores.cpp:675
 msgid "Leave the shack"
 msgstr "離​開​小​屋"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:827
+#: Source/stores.cpp:881
 msgid "You have nothing to recharge.             Your gold: {:d}"
 msgstr "你​沒什麼​好​充電​的。你​的​金幣: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:842
+#: Source/stores.cpp:894
 msgid "Recharge which item?             Your gold: {:d}"
 msgstr "給​哪​個​專案​充值？你​的​金幣: {:d}"
 
-#: Source/stores.cpp:858
+#: Source/stores.cpp:908
 msgid "You do not have enough gold"
 msgstr "你​沒​有​足夠​的​金幣"
 
-#: Source/stores.cpp:866
+#: Source/stores.cpp:916
 msgid "You do not have enough room in inventory"
 msgstr "您​的​庫存​空間​不足"
 
-#: Source/stores.cpp:903
+#: Source/stores.cpp:953
 msgid "Do we have a deal?"
 msgstr "我​們​有​協議嗎？"
 
-#: Source/stores.cpp:906
+#: Source/stores.cpp:956
 msgid "Are you sure you want to identify this item?"
 msgstr "確​定​要​標識​此​專案嗎？"
 
-#: Source/stores.cpp:912
+#: Source/stores.cpp:962
 msgid "Are you sure you want to buy this item?"
 msgstr "您​確定​要​購買​此​商品​嗎？"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:965
 msgid "Are you sure you want to recharge this item?"
 msgstr "您​確定​要​為該​物品​充值​嗎？"
 
-#: Source/stores.cpp:919
+#: Source/stores.cpp:969
 msgid "Are you sure you want to sell this item?"
 msgstr "你​確定​要​賣這個東​西嗎？"
 
-#: Source/stores.cpp:922
+#: Source/stores.cpp:972
 msgid "Are you sure you want to repair this item?"
 msgstr "確​定​要​修復​此​專案嗎？"
 
-#: Source/stores.cpp:936 Source/towners.cpp:157
+#: Source/stores.cpp:986 Source/towners.cpp:157
 msgid "Wirt the Peg-legged boy"
 msgstr "你​是​那​個​假腿​男孩​嗎"
 
-#: Source/stores.cpp:939 Source/stores.cpp:946
+#: Source/stores.cpp:989 Source/stores.cpp:996
 msgid "Talk to Wirt"
 msgstr "和​沃特談談"
 
-#: Source/stores.cpp:940
+#: Source/stores.cpp:990
 msgid "I have something for sale,"
 msgstr "我​有​東西​要​賣，"
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:991
 msgid "but it will cost 50 gold"
 msgstr "但​要​花​50​金"
 
-#: Source/stores.cpp:942
+#: Source/stores.cpp:992
 msgid "just to take a look. "
 msgstr "只​是​想​看看。"
 
-#: Source/stores.cpp:943
+#: Source/stores.cpp:993
 msgid "What have you got?"
 msgstr "你​有​什麼發現？"
 
-#: Source/stores.cpp:944 Source/stores.cpp:947 Source/stores.cpp:1057
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:994 Source/stores.cpp:997 Source/stores.cpp:1113
+#: Source/stores.cpp:1308
 msgid "Say goodbye"
 msgstr "說​再​見"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:957
+#: Source/stores.cpp:1007
 msgid "I have this item for sale:             Your gold: {:d}"
 msgstr "我​有​這個​東西​要​賣: 你​的​金幣: {:d}"
 
-#: Source/stores.cpp:974
+#: Source/stores.cpp:1030
 msgid "Leave"
 msgstr "離​開"
 
-#: Source/stores.cpp:996
+#: Source/stores.cpp:1053
 msgid "Healer's home"
 msgstr "療​養院"
 
-#: Source/stores.cpp:998
+#: Source/stores.cpp:1055
 msgid "Talk to Pepin"
 msgstr "和​佩平​談談"
 
-#: Source/stores.cpp:1000
+#: Source/stores.cpp:1057
 msgid "Leave Healer's home"
 msgstr "離​開療​養院"
 
-#: Source/stores.cpp:1053
+#: Source/stores.cpp:1109
 msgid "The Town Elder"
 msgstr "鎮​上​的​長​老"
 
-#: Source/stores.cpp:1055
+#: Source/stores.cpp:1111
 msgid "Talk to Cain"
 msgstr "和​凱恩談談"
 
-#: Source/stores.cpp:1056
+#: Source/stores.cpp:1112
 msgid "Identify an item"
 msgstr "標​識​專案"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1149
+#: Source/stores.cpp:1205
 msgid "You have nothing to identify.             Your gold: {:d}"
 msgstr "你​沒什麼​可​指認​的。你​的​金幣: {:d}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
-#: Source/stores.cpp:1164
+#: Source/stores.cpp:1218
 msgid "Identify which item?             Your gold: {:d}"
 msgstr "確定​哪​一​項？你​的​金幣: {:d}"
 
-#: Source/stores.cpp:1184
+#: Source/stores.cpp:1237
 msgid "This item is:"
 msgstr "此​專案​是: "
 
-#: Source/stores.cpp:1187
+#: Source/stores.cpp:1240
 msgid "Done"
 msgstr "多恩"
 
-#: Source/stores.cpp:1196
+#: Source/stores.cpp:1249
 msgid "Talk to {:s}"
 msgstr "與​{:s}​交談"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1253
 msgid "Talking to {:s}"
 msgstr "與​{:s}​交談"
 
-#: Source/stores.cpp:1202
+#: Source/stores.cpp:1255
 msgid "is not available"
 msgstr "不​可​用"
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1256
 msgid "in the shareware"
 msgstr "在​共​享軟​體​中"
 
-#: Source/stores.cpp:1204
+#: Source/stores.cpp:1257
 msgid "version"
 msgstr "版本"
 
-#: Source/stores.cpp:1231
+#: Source/stores.cpp:1284
 msgid "Gossip"
 msgstr "流言蜚語"
 
-#: Source/stores.cpp:1240
+#: Source/stores.cpp:1293
 msgid "Rising Sun"
 msgstr "日​出"
 
-#: Source/stores.cpp:1242
+#: Source/stores.cpp:1295
 msgid "Talk to Ogden"
 msgstr "與​奧​格登​交談"
 
-#: Source/stores.cpp:1243
+#: Source/stores.cpp:1296
 msgid "Leave the tavern"
 msgstr "離​開​酒館"
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1307
 msgid "Talk to Gillian"
 msgstr "和​阿嬌談​談"
 
-#: Source/stores.cpp:1264 Source/towners.cpp:212
+#: Source/stores.cpp:1317 Source/towners.cpp:212
 msgid "Farnham the Drunk"
 msgstr "醉​漢​法納​姆"
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1319
 msgid "Talk to Farnham"
 msgstr "和​法納姆談談"
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1320
 msgid "Say Goodbye"
 msgstr "說​再​見"
 
@@ -10698,6 +10877,10 @@ msgstr "農夫萊​斯特"
 msgid "Complete Nut"
 msgstr "全​套​螺母"
 
+#: Source/towners.cpp:266
+msgid "Celia"
+msgstr ""
+
 #: Source/towners.cpp:279
 msgid "Slain Townsman"
 msgstr "被​殺​的​老​鄉"
@@ -10727,17 +10910,17 @@ msgid "Down to Crypt"
 msgstr "去​地下室"
 
 #: Source/trigs.cpp:412 Source/trigs.cpp:492 Source/trigs.cpp:539
-#: Source/trigs.cpp:630
+#: Source/trigs.cpp:634
 msgid "Up to level {:d}"
 msgstr "達​到​{:d}​層"
 
 #: Source/trigs.cpp:414 Source/trigs.cpp:469 Source/trigs.cpp:521
-#: Source/trigs.cpp:596 Source/trigs.cpp:613 Source/trigs.cpp:660
+#: Source/trigs.cpp:600 Source/trigs.cpp:617 Source/trigs.cpp:664
 msgid "Up to town"
 msgstr "進​城"
 
-#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:552
-#: Source/trigs.cpp:577 Source/trigs.cpp:642
+#: Source/trigs.cpp:425 Source/trigs.cpp:503 Source/trigs.cpp:556
+#: Source/trigs.cpp:581 Source/trigs.cpp:646
 msgid "Down to level {:d}"
 msgstr "下​到​{:d}"
 
@@ -10749,14 +10932,14 @@ msgstr "上​到​墓穴​{:d}​層"
 msgid "Down to Crypt level {:d}"
 msgstr "下​到​墓穴​{:d}​層"
 
-#: Source/trigs.cpp:564
+#: Source/trigs.cpp:568
 msgid "Up to Nest level {:d}"
 msgstr "上​到​巢穴{:d}​層"
 
-#: Source/trigs.cpp:673
+#: Source/trigs.cpp:677
 msgid "Down to Diablo"
 msgstr "下​到​迪亞波羅"
 
-#: Source/trigs.cpp:706 Source/trigs.cpp:720 Source/trigs.cpp:734
+#: Source/trigs.cpp:710 Source/trigs.cpp:724 Source/trigs.cpp:738
 msgid "Back to Level {:d}"
 msgstr "返回​到​{:d}​層"


### PR DESCRIPTION
Resolves #2071

This allows translators to grater control over how item names are generated. It should also make the code easier to read and simpler to hook in to once/if we add scripting to the name generation.

@nsm53project has mentioned this being required for Korean to generate proper names since they need it to be `{prefix}{suffix}{item}`.

Most of the changes is just syncing the translation files ;) Note that Russian and Ukrainian have been left out as they are currently being edited in other PRs.