### PR TITLE
Return Utf8DecodeError when passed an incomplete code point

### DIFF
--- a/Source/utils/utf8.cpp
+++ b/Source/utils/utf8.cpp
@@ -21,7 +21,8 @@ char32_t DecodeFirstUtf8CodePoint(string_view input, uint8_t *len)
 			return Utf8DecodeError;
 		}
 	}
-	return codepoint;
+	*len = input.size();
+	return Utf8DecodeError;
 }
 
 } // namespace devilution


### PR DESCRIPTION
Also ensure that len is initialised and set properly, otherwise it leads to a call to remove_prefix with garbage.

It doesn't seem useful or valid to return an incomplete code point from this function. To match the behaviour of `mblen` we could have an "incomplete code point" return value, but this at least handles truncated strings better than before.