### PR TITLE
Use DrawStringWithColors in settingsmenu

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -15,7 +15,6 @@
 #include "controls/controller.h"
 #include "controls/menu_controls.h"
 #include "dx.h"
-#include "engine/render/text_render.hpp"
 #include "hwcursor.hpp"
 #include "palette.h"
 #include "utils/display.h"
@@ -802,7 +801,10 @@ void Render(const UiList *uiList)
 			DrawSelector(rect);
 
 		Rectangle rectangle { { rect.x, rect.y }, { rect.w, rect.h } };
-		DrawString(out, item->m_text, rectangle, uiList->m_iFlags | item->uiFlags, uiList->spacing());
+		if (item->args.size() == 0)
+			DrawString(out, item->m_text, rectangle, uiList->m_iFlags | item->uiFlags, uiList->spacing());
+		else
+			DrawStringWithColors(out, item->m_text, item->args, rectangle, uiList->m_iFlags | item->uiFlags, uiList->spacing());
 	}
 }
 

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -7,6 +7,7 @@
 
 #include "DiabloUI/art.h"
 #include "DiabloUI/ui_flags.hpp"
+#include "engine/render/text_render.hpp"
 #include "utils/enum_traits.h"
 #include "utils/stubs.h"
 
@@ -249,10 +250,19 @@ public:
 	{
 	}
 
+	UiListItem(const char *text, std::vector<DrawStringFormatArg> &args, int value = 0, UiFlags uiFlags = UiFlags::None)
+	    : m_text(text)
+	    , args(args)
+	    , m_value(value)
+	    , uiFlags(uiFlags)
+	{
+	}
+
 	~UiListItem() {};
 
 	// private:
 	const char *m_text;
+	std::vector<DrawStringFormatArg> args;
 	int m_value;
 	UiFlags uiFlags;
 };


### PR DESCRIPTION
Depends on #3576

Notes:
- Currently can't use `DrawStringFormatArg` directly in `ui_item.h`, cause it's defined in `text_render.hpp` and `text_render.hpp` includes `ui_item.h`. Currently resolved with forward declaration.
- With translations or longer new options the text could be too long and we need to split the entry in two lines. Do we need a new `GetLineWidth` and/or `WordWrapString` overload that supports `DrawStringFormatArg`?

<details><summary>Sample Video</summary>

https://user-images.githubusercontent.com/25415264/143327777-d77741ca-a0be-4400-ac4e-8ff4bc36b4fa.mp4

</details>