### PR TITLE
.github/workflows/src_dist_release.yml: Fix python

### DIFF
--- a/.github/workflows/src_dist_release.yml
+++ b/.github/workflows/src_dist_release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Create Build Environment
       run: >
         sudo apt update &&
-        sudo apt install -y cmake curl libsdl2-dev libsdl2-image-dev libfmt-dev libsodium-dev libbz2-dev git smpq gettext python
+        sudo apt install -y cmake curl libsdl2-dev libsdl2-image-dev libfmt-dev libsodium-dev libbz2-dev git smpq gettext python-is-python3
 
     - name: Build
       working-directory: ${{github.workspace}}


### PR DESCRIPTION
Seems to default to Python 2 on Ubuntu 20.04, whereas we use Python 3

(previously failed at https://github.com/diasurgical/devilutionX/runs/4337688960?check_suite_focus=true)