### PR TITLE
Char panel layout improvements

### DIFF
--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -114,7 +114,7 @@ uint16_t GetUnicodeRow(char32_t codePoint)
 
 bool IsCJK(uint16_t row)
 {
-	return row >= 0x4e && row <= 0x9f;
+	return row >= 0x30 && row <= 0x9f;
 }
 
 bool IsHangul(uint16_t row)

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -1,7 +1,8 @@
 #include "panels/charpanel.hpp"
 
-#include <fmt/format.h>
 #include <string>
+
+#include <fmt/format.h>
 
 #include "DiabloUI/art.h"
 #include "DiabloUI/art_draw.h"
@@ -111,6 +112,17 @@ StyledText GetResistInfo(int8_t resist)
 	};
 }
 
+constexpr int LeftColumnLabelX = 88;
+constexpr int TopRightLabelX = 211;
+constexpr int RightColumnLabelX = 253;
+
+constexpr int LeftColumnLabelWidth = 76;
+constexpr int RightColumnLabelWidth = 68;
+
+// Indices in `panelEntries`.
+constexpr unsigned AttributeHeaderEntryIndices[2] = { 5, 6 };
+constexpr unsigned GoldHeaderEntryIndex = 16;
+
 PanelEntry panelEntries[] = {
 	{ "", { 9, 14 }, 150, 0,
 	    []() { return StyledText { UiFlags::ColorWhite, MyPlayer->_pName }; } },
@@ -119,68 +131,67 @@ PanelEntry panelEntries[] = {
 
 	{ N_("Level"), { 57, 52 }, 57, 45,
 	    []() { return StyledText { UiFlags::ColorWhite, fmt::format("{:d}", MyPlayer->_pLevel) }; } },
-	{ N_("Experience"), { 211, 52 }, 99, 91,
+	{ N_("Experience"), { TopRightLabelX, 52 }, 99, 91,
 	    []() { return StyledText { UiFlags::ColorWhite, fmt::format("{:d}", MyPlayer->_pExperience) }; } },
-	{ N_("Next level"), { 211, 80 }, 99, 198,
+	{ N_("Next level"), { TopRightLabelX, 80 }, 99, 198,
 	    []() {
 	        if (MyPlayer->_pLevel == MAXCHARLEVEL - 1) {
 		        return StyledText { UiFlags::ColorWhitegold, _("None") };
-	        } else {
-		        return StyledText { UiFlags::ColorWhite, fmt::format("{:d}", MyPlayer->_pNextExper) };
 	        }
+	        return StyledText { UiFlags::ColorWhite, fmt::format("{:d}", MyPlayer->_pNextExper) };
 	    } },
 
-	{ N_("Base"), { 88, 115 }, 0, 44 },
-	{ N_("Now"), { 135, 115 }, 0, 44 },
-	{ N_("Strength"), { 88, 135 }, 45, 76,
+	{ N_("Base"), { LeftColumnLabelX, /* set dynamically */ 0 }, 0, 44 },
+	{ N_("Now"), { 135, /* set dynamically */ 0 }, 0, 44 },
+	{ N_("Strength"), { LeftColumnLabelX, 135 }, 45, LeftColumnLabelWidth,
 	    []() { return StyledText { GetBaseStatColor(CharacterAttribute::Strength), fmt::format("{:d}", MyPlayer->_pBaseStr) }; } },
 	{ "", { 135, 135 }, 45, 0,
 	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Strength), fmt::format("{:d}", MyPlayer->_pStrength) }; } },
-	{ N_("Magic"), { 88, 163 }, 45, 76,
+	{ N_("Magic"), { LeftColumnLabelX, 163 }, 45, LeftColumnLabelWidth,
 	    []() { return StyledText { GetBaseStatColor(CharacterAttribute::Magic), fmt::format("{:d}", MyPlayer->_pBaseMag) }; } },
 	{ "", { 135, 163 }, 45, 0,
 	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Magic), fmt::format("{:d}", MyPlayer->_pMagic) }; } },
-	{ N_("Dexterity"), { 88, 191 }, 45, 76, []() { return StyledText { GetBaseStatColor(CharacterAttribute::Dexterity), fmt::format("{:d}", MyPlayer->_pBaseDex) }; } },
+	{ N_("Dexterity"), { LeftColumnLabelX, 191 }, 45, LeftColumnLabelWidth, []() { return StyledText { GetBaseStatColor(CharacterAttribute::Dexterity), fmt::format("{:d}", MyPlayer->_pBaseDex) }; } },
 	{ "", { 135, 191 }, 45, 0,
 	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Dexterity), fmt::format("{:d}", MyPlayer->_pDexterity) }; } },
-	{ N_("Vitality"), { 88, 219 }, 45, 76, []() { return StyledText { GetBaseStatColor(CharacterAttribute::Vitality), fmt::format("{:d}", MyPlayer->_pBaseVit) }; } },
+	{ N_("Vitality"), { LeftColumnLabelX, 219 }, 45, LeftColumnLabelWidth, []() { return StyledText { GetBaseStatColor(CharacterAttribute::Vitality), fmt::format("{:d}", MyPlayer->_pBaseVit) }; } },
 	{ "", { 135, 219 }, 45, 0,
 	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Vitality), fmt::format("{:d}", MyPlayer->_pVitality) }; } },
-	{ N_("Points to distribute"), { 88, 248 }, 45, 76,
+	{ N_("Points to distribute"), { LeftColumnLabelX, 248 }, 45, LeftColumnLabelWidth,
 	    []() {
 	        MyPlayer->_pStatPts = std::min(CalcStatDiff(*MyPlayer), MyPlayer->_pStatPts);
 	        return StyledText { UiFlags::ColorRed, (MyPlayer->_pStatPts > 0 ? fmt::format("{:d}", MyPlayer->_pStatPts) : "") };
 	    } },
 
-	{ N_("Gold"), { 211, 107 }, 0, 98 },
-	{ "", { 211, 127 }, 99, 0,
+	{ N_("Gold"), { TopRightLabelX, /* set dynamically */ 0 }, 0, 98 },
+	{ "", { TopRightLabelX, 127 }, 99, 0,
 	    []() { return StyledText { UiFlags::ColorWhite, fmt::format("{:d}", MyPlayer->_pGold) }; } },
 
-	{ N_("Armor class"), { 253, 163 }, 57, 67,
+	{ N_("Armor class"), { RightColumnLabelX, 163 }, 57, RightColumnLabelWidth,
 	    []() { return StyledText { GetValueColor(MyPlayer->_pIBonusAC), fmt::format("{:d}", MyPlayer->GetArmor()) }; } },
-	{ N_("To hit"), { 253, 191 }, 57, 67,
+	{ N_("To hit"), { RightColumnLabelX, 191 }, 57, RightColumnLabelWidth,
 	    []() { return StyledText { GetValueColor(MyPlayer->_pIBonusToHit), fmt::format("{:d}%", (MyPlayer->InvBody[INVLOC_HAND_LEFT]._itype == ItemType::Bow ? MyPlayer->GetRangedToHit() : MyPlayer->GetMeleeToHit())) }; } },
-	{ N_("Damage"), { 253, 219 }, 57, 67,
+	{ N_("Damage"), { RightColumnLabelX, 219 }, 57, RightColumnLabelWidth,
 	    []() {
 	        std::pair<int, int> dmg = GetDamage();
 	        int spacing = ((dmg.first >= 100) ? -1 : 1);
 	        return StyledText { GetValueColor(MyPlayer->_pIBonusDam), fmt::format("{:d}-{:d}", dmg.first, dmg.second), spacing };
 	    } },
 
-	{ N_("Life"), { 88, 284 }, 45, 76,
+	{ N_("Life"), { LeftColumnLabelX, 284 }, 45, LeftColumnLabelWidth,
 	    []() { return StyledText { GetMaxHealthColor(), fmt::format("{:d}", MyPlayer->_pMaxHP >> 6) }; } },
 	{ "", { 135, 284 }, 45, 0,
 	    []() { return StyledText { (MyPlayer->_pHitPoints != MyPlayer->_pMaxHP ? UiFlags::ColorRed : GetMaxHealthColor()), fmt::format("{:d}", MyPlayer->_pHitPoints >> 6) }; } },
-	{ N_("Mana"), { 88, 312 }, 45, 76,
+	{ N_("Mana"), { LeftColumnLabelX, 312 }, 45, LeftColumnLabelWidth,
 	    []() { return StyledText { GetMaxManaColor(), fmt::format("{:d}", MyPlayer->_pMaxMana >> 6) }; } },
 	{ "", { 135, 312 }, 45, 0,
 	    []() { return StyledText { (MyPlayer->_pMana != MyPlayer->_pMaxMana ? UiFlags::ColorRed : GetMaxManaColor()), fmt::format("{:d}", MyPlayer->_pMana >> 6) }; } },
 
-	{ N_("Resist magic"), { 253, 256 }, 57, 67,
+	{ N_("Resist magic"), { RightColumnLabelX, 256 }, 57, RightColumnLabelWidth,
 	    []() { return GetResistInfo(MyPlayer->_pMagResist); } },
-	{ N_("Resist fire"), { 253, 284 }, 57, 67,
+	{ N_("Resist fire"), { RightColumnLabelX, 284 }, 57, RightColumnLabelWidth,
 	    []() { return GetResistInfo(MyPlayer->_pFireResist); } },
-	{ N_("Resist lightning"), { 253, 313 }, 57, 67,
+	{ N_("Resist lightning"), { RightColumnLabelX, 313 }, 57, RightColumnLabelWidth,
 	    []() { return GetResistInfo(MyPlayer->_pLghtResist); } },
 };
 
@@ -188,6 +199,11 @@ Art PanelBoxLeft;
 Art PanelBoxMiddle;
 Art PanelBoxRight;
 Art PanelFull;
+
+constexpr int PanelFieldHeight = 24;
+constexpr int PanelFieldPaddingTop = 3;
+constexpr int PanelFieldPaddingBottom = 3;
+constexpr int PanelFieldInnerHeight = PanelFieldHeight - PanelFieldPaddingTop - PanelFieldPaddingBottom;
 
 void DrawPanelField(const Surface &out, Point pos, int len)
 {
@@ -223,11 +239,11 @@ void DrawShadowString(const Surface &out, const PanelEntry &entry)
 		style |= UiFlags::AlignCenter;
 	} else {
 		style |= UiFlags::AlignRight;
-		labelPosition += Displacement { -entry.labelLength - 3, 0 };
+		labelPosition += Displacement { -entry.labelLength - (IsSmallFontTall() ? 2 : 3), 0 };
 	}
 
-	DrawString(out, text, { labelPosition + Displacement { -2, 2 }, { entry.labelLength, 20 } }, style | UiFlags::ColorBlack, Spacing, 10);
-	DrawString(out, text, { labelPosition, { entry.labelLength, 20 } }, style | UiFlags::ColorWhite, Spacing, 10);
+	DrawString(out, text, { labelPosition + Displacement { -2, 2 }, { entry.labelLength, PanelFieldHeight } }, style | UiFlags::ColorBlack, Spacing);
+	DrawString(out, text, { labelPosition, { entry.labelLength, PanelFieldHeight } }, style | UiFlags::ColorWhite, Spacing);
 }
 
 void DrawStatButtons(const Surface &out)
@@ -256,6 +272,13 @@ void LoadCharPanel()
 
 	const Surface out(PanelFull.surface.get());
 
+	const bool isSmallFontTall = IsSmallFontTall();
+	const int attributeHeadersY = isSmallFontTall ? 112 : 114;
+	for (unsigned i : AttributeHeaderEntryIndices) {
+		panelEntries[i].position.y = attributeHeadersY;
+	}
+	panelEntries[GoldHeaderEntryIndex].position.y = isSmallFontTall ? 105 : 106;
+
 	for (auto &entry : panelEntries) {
 		if (entry.statDisplayFunc != nullptr) {
 			DrawPanelField(out, entry.position, entry.length);
@@ -282,8 +305,8 @@ void DrawChr(const Surface &out)
 			StyledText tmp = entry.statDisplayFunc();
 			DrawString(
 			    out,
-			    tmp.text.c_str(),
-			    { entry.position + Displacement { pos.x, pos.y }, { entry.length, 27 } },
+			    tmp.text,
+			    { entry.position + Displacement { pos.x, pos.y + PanelFieldPaddingTop }, { entry.length, PanelFieldInnerHeight } },
 			    UiFlags::AlignCenter | UiFlags::VerticalCenter | tmp.style, tmp.spacing);
 		}
 	}


### PR DESCRIPTION
Improves char panel layout and fixes it for CJK

Chinese:

Before | After
---|---
![charpanel-zh-before](https://user-images.githubusercontent.com/216339/143676518-f3674c1a-1e0c-4b9a-8f83-e841e82efa77.png) | ![charpanel-zh-after](https://user-images.githubusercontent.com/216339/143676520-c966878c-15ee-4687-8df2-aa2a3f27deb5.png)

Japanese:

Before | After
---|---
![charpanel-ja-before](https://user-images.githubusercontent.com/216339/143676521-ad823a07-ff8a-4c66-80e9-b627760ceefd.png) | ![charpanel-ja-after](https://user-images.githubusercontent.com/216339/143676523-c7f9a34c-726d-43e4-8731-8921e3973225.png)

English:

Before | After
---|---
![charpanel-en-before](https://user-images.githubusercontent.com/216339/143676524-d96e19e3-fc6e-4cbc-b796-7a2232f003c6.png) | ![charpanel-en-after](https://user-images.githubusercontent.com/216339/143676837-1d1a6799-9846-44cd-9718-fe17b224906b.png)

Fixes #3621 

/cc @bubio @tytannia



