### PR TITLE
Update libsmackerdec

### DIFF
--- a/3rdParty/libsmackerdec/CMakeLists.txt
+++ b/3rdParty/libsmackerdec/CMakeLists.txt
@@ -2,15 +2,14 @@ include(FetchContent_MakeAvailableExcludeFromAll)
 
 include(FetchContent)
 FetchContent_Declare(libsmackerdec
-    URL https://github.com/diasurgical/libsmackerdec/archive/f398721a3b2133b4054ca7e43e2201bdca58c1f0.tar.gz
-    URL_HASH MD5=888b9935a5ad232d3c3a3f2f72193075
+    URL https://github.com/diasurgical/libsmackerdec/archive/2b9247f2c72fea5e2992888f7f29cd7f6d790b35.tar.gz
+    URL_HASH MD5=a34396cfe21a166de331ae714c5449cb
 )
 FetchContent_MakeAvailableExcludeFromAll(libsmackerdec)
 
 add_library(libsmackerdec STATIC
   ${libsmackerdec_SOURCE_DIR}/src/BitReader.cpp
   ${libsmackerdec_SOURCE_DIR}/src/FileStream.cpp
-  ${libsmackerdec_SOURCE_DIR}/src/HuffmanVLC.cpp
   ${libsmackerdec_SOURCE_DIR}/src/LogError.cpp
   ${libsmackerdec_SOURCE_DIR}/src/SmackerDecoder.cpp)
 


### PR DESCRIPTION
This incorporates a couple optimizations that enable the o3DS to play the Hellfire logo and intro videos back. There is still a bit of stuttering when playing these videos so I will probably revisit this at some point, but for the moment I feel compelled to move on to other things.

Here are some timing results collected from playing the Hellfire logo on my o3DS to give an idea for how much performance improved. (The values are total number of milliseconds spent in each function, not an average.)

Before:
```
DEBUG: Profiler: Smacker_GetNextFrame 6805.248276674452 ms (count: 129)
DEBUG: Profiler: DecodeFrame 4422.610486870788 ms (count: 129)
DEBUG: Profiler: DecodeAudio 2376.4815682003878 ms (count: 114)
```

After:
```
DEBUG: Profiler: Smacker_GetNextFrame 4547.6864253253725 ms (count: 129)
DEBUG: Profiler: DecodeFrame 3694.7320748098286 ms (count: 129)
DEBUG: Profiler: DecodeAudio 844.9872727746838 ms (count: 114)
```