### PR TITLE
Link `SDL2::SDLmain` correctly

### DIFF
--- a/.github/workflows/Windows_x64.yml
+++ b/.github/workflows/Windows_x64.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Create Build Environment
       run: >
         sudo apt update &&
-        sudo apt install -y cmake gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 pkg-config-mingw-w64-x86-64 wget git sudo smpq &&
+        sudo apt install -y cmake gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 pkg-config-mingw-w64-x86-64 dpkg-dev wget git sudo smpq &&
         sudo Packaging/windows/mingw-prep64.sh
 
     - name: Cache CMake build folder

--- a/.github/workflows/Windows_x86.yml
+++ b/.github/workflows/Windows_x86.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Create Build Environment
       run: >
         sudo apt update &&
-        sudo apt install -y cmake gcc-mingw-w64-i686 g++-mingw-w64-i686 pkg-config-mingw-w64-i686 wget git sudo smpq &&
+        sudo apt install -y cmake gcc-mingw-w64-i686 g++-mingw-w64-i686 pkg-config-mingw-w64-i686 dpkg-dev wget git sudo smpq &&
         sudo Packaging/windows/mingw-prep.sh
 
     - name: Cache CMake build folder

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1027,8 +1027,8 @@ if(USE_SDL1)
   target_compile_definitions(libdevilutionx PUBLIC USE_SDL1)
 else()
   target_link_libraries(libdevilutionx PUBLIC
-    SDL2::SDL2
     ${SDL2_MAIN}
+    SDL2::SDL2
     SDL2::SDL2_image)
 endif()
 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -1,4 +1,6 @@
 #include <SDL.h>
+#include <SDL_main.h>
+
 #ifdef __SWITCH__
 #include "platform/switch/network.h"
 #include "platform/switch/random.hpp"
@@ -23,11 +25,7 @@ extern "C" const char *__asan_default_options() // NOLINT(bugprone-reserved-iden
 }
 #endif
 
-#ifdef __ANDROID__
-int SDL_main(int argc, char **argv)
-#else
-int main(int argc, char **argv)
-#endif
+extern "C" int main(int argc, char **argv)
 {
 #ifdef __SWITCH__
 	switch_enable_network();


### PR DESCRIPTION
The `SDL_main.h` header defines `main` to be `SDL_main` *when needed by the target platform*. This header must be included before defining `main`.

The `SDL2::SDLmain` library should be linked only to the executable, not to `libdevilutionx`.