### PR TITLE
Settings - Add language selection

### DIFF
--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -83,30 +83,7 @@ std::optional<MpqArchive> LoadMPQ(const std::vector<std::string> &paths, const c
 	return std::nullopt;
 }
 
-} // namespace
-
-void init_cleanup()
-{
-	if (gbIsMultiplayer && gbRunGame) {
-		pfile_write_hero(/*writeGameData=*/false, /*clearTables=*/true);
-	}
-
-	spawn_mpq = std::nullopt;
-	diabdat_mpq = std::nullopt;
-	hellfire_mpq = std::nullopt;
-	hfmonk_mpq = std::nullopt;
-	hfbard_mpq = std::nullopt;
-	hfbarb_mpq = std::nullopt;
-	hfmusic_mpq = std::nullopt;
-	hfvoice_mpq = std::nullopt;
-	lang_mpq = std::nullopt;
-	font_mpq = std::nullopt;
-	devilutionx_mpq = std::nullopt;
-
-	NetClose();
-}
-
-void init_archives()
+std::vector<std::string> GetMPQSearchPaths()
 {
 	std::vector<std::string> paths;
 	paths.push_back(paths::BasePath());
@@ -145,12 +122,11 @@ void init_archives()
 		LogVerbose("MPQ search paths:{}", message);
 	}
 
-#ifndef __ANDROID__
-	// Load devilutionx.mpq first to get the font file for error messages
-	devilutionx_mpq = LoadMPQ(paths, "devilutionx.mpq");
-#endif
-	font_mpq = LoadMPQ(paths, "fonts.mpq"); // Extra fonts
+	return paths;
+}
 
+void init_language_archives(const std::vector<std::string> &paths)
+{
 	if (strcasecmp("en", sgOptions.Language.szCode) != 0 || strlen(sgOptions.Language.szCode) != 2) {
 		char langMpqName[10] = {};
 		CopyUtf8(langMpqName, sgOptions.Language.szCode, sizeof(langMpqName));
@@ -158,6 +134,42 @@ void init_archives()
 		strncat(langMpqName, ".mpq", sizeof(langMpqName) - strlen(langMpqName) - 1);
 		lang_mpq = LoadMPQ(paths, langMpqName);
 	}
+}
+
+} // namespace
+
+void init_cleanup()
+{
+	if (gbIsMultiplayer && gbRunGame) {
+		pfile_write_hero(/*writeGameData=*/false, /*clearTables=*/true);
+	}
+
+	spawn_mpq = std::nullopt;
+	diabdat_mpq = std::nullopt;
+	hellfire_mpq = std::nullopt;
+	hfmonk_mpq = std::nullopt;
+	hfbard_mpq = std::nullopt;
+	hfbarb_mpq = std::nullopt;
+	hfmusic_mpq = std::nullopt;
+	hfvoice_mpq = std::nullopt;
+	lang_mpq = std::nullopt;
+	font_mpq = std::nullopt;
+	devilutionx_mpq = std::nullopt;
+
+	NetClose();
+}
+
+void init_archives()
+{
+	auto paths = GetMPQSearchPaths();
+
+#ifndef __ANDROID__
+	// Load devilutionx.mpq first to get the font file for error messages
+	devilutionx_mpq = LoadMPQ(paths, "devilutionx.mpq");
+#endif
+	font_mpq = LoadMPQ(paths, "fonts.mpq"); // Extra fonts
+
+	init_language_archives(paths);
 
 	diabdat_mpq = LoadMPQ(paths, "DIABDAT.MPQ");
 	if (!diabdat_mpq) {
@@ -197,6 +209,12 @@ void init_archives()
 		UiErrorOkDialog(_("Some Hellfire MPQs are missing"), _("Not all Hellfire MPQs were found.\nPlease copy all the hf*.mpq files."));
 		app_fatal(nullptr);
 	}
+}
+
+void init_language_archives()
+{
+	lang_mpq = std::nullopt;
+	init_language_archives(GetMPQSearchPaths());
 }
 
 void init_create_window()

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -127,9 +127,10 @@ std::vector<std::string> GetMPQSearchPaths()
 
 void init_language_archives(const std::vector<std::string> &paths)
 {
-	if (strcasecmp("en", sgOptions.Language.szCode) != 0 || strlen(sgOptions.Language.szCode) != 2) {
+	string_view code = *sgOptions.Language.code;
+	if (code != "en") {
 		char langMpqName[10] = {};
-		CopyUtf8(langMpqName, sgOptions.Language.szCode, sizeof(langMpqName));
+		CopyUtf8(langMpqName, code.data(), sizeof(langMpqName));
 
 		strncat(langMpqName, ".mpq", sizeof(langMpqName) - strlen(langMpqName) - 1);
 		lang_mpq = LoadMPQ(paths, langMpqName);

--- a/Source/init.h
+++ b/Source/init.h
@@ -30,6 +30,7 @@ extern std::optional<MpqArchive> devilutionx_mpq;
 
 void init_cleanup();
 void init_archives();
+void init_language_archives();
 void init_create_window();
 void MainWndProc(uint32_t Msg);
 WNDPROC SetWindowProc(WNDPROC NewProc);

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -229,6 +229,12 @@ void OptionShowFPSChanged()
 		frameflag = false;
 }
 
+void OptionLanguageCodeChanged()
+{
+	LanguageInitialize();
+	init_language_archives();
+}
+
 } // namespace
 
 void SetIniValue(const char *sectionName, const char *keyName, const char *value, int len)
@@ -316,70 +322,6 @@ void LoadOptions()
 	sgOptions.Controller.bRearTouch = GetIniBool("Controller", "Enable Rear Touchpad", true);
 #endif
 
-#ifdef __ANDROID__
-	JNIEnv *env = (JNIEnv *)SDL_AndroidGetJNIEnv();
-	jobject activity = (jobject)SDL_AndroidGetActivity();
-	jclass clazz(env->GetObjectClass(activity));
-	jmethodID method_id = env->GetMethodID(clazz, "getLocale", "()Ljava/lang/String;");
-	jstring jLocale = (jstring)env->CallObjectMethod(activity, method_id);
-	const char *cLocale = env->GetStringUTFChars(jLocale, nullptr);
-	std::string locale = cLocale;
-	env->ReleaseStringUTFChars(jLocale, cLocale);
-	env->DeleteLocalRef(jLocale);
-	env->DeleteLocalRef(activity);
-	env->DeleteLocalRef(clazz);
-#elif defined(__vita__)
-	int32_t language = SCE_SYSTEM_PARAM_LANG_ENGLISH_US; // default to english
-	const char *vita_locales[] = {
-		"ja_JP",
-		"en_US",
-		"fr_FR",
-		"es_ES",
-		"de_DE",
-		"it_IT",
-		"nl_NL",
-		"pt_PT",
-		"ru_RU",
-		"ko_KR",
-		"zh_TW",
-		"zh_CN",
-		"fi_FI",
-		"sv_SE",
-		"da_DK",
-		"no_NO",
-		"pl_PL",
-		"pt_BR",
-		"en_GB",
-		"tr_TR",
-	};
-	SceAppUtilInitParam initParam;
-	SceAppUtilBootParam bootParam;
-	memset(&initParam, 0, sizeof(SceAppUtilInitParam));
-	memset(&bootParam, 0, sizeof(SceAppUtilBootParam));
-	sceAppUtilInit(&initParam, &bootParam);
-	sceAppUtilSystemParamGetInt(SCE_SYSTEM_PARAM_ID_LANG, &language);
-	if (language < 0 || language > SCE_SYSTEM_PARAM_LANG_TURKISH)
-		language = SCE_SYSTEM_PARAM_LANG_ENGLISH_US; // default to english
-	std::string locale = std::string(vita_locales[language]);
-	sceAppUtilShutdown();
-#elif defined(__3DS__)
-	std::string locale = n3ds::GetLocale();
-#else
-	std::string locale = std::locale("").name().substr(0, 5);
-#endif
-
-	locale = locale.substr(0, 5);
-	LogVerbose("Prefered locale: {}", locale);
-	if (!HasTranslation(locale)) {
-		locale = locale.substr(0, 2);
-		if (!HasTranslation(locale)) {
-			locale = "en";
-		}
-	}
-	LogVerbose("Best match locale: {}", locale);
-
-	GetIniValue("Language", "Code", sgOptions.Language.szCode, sizeof(sgOptions.Language.szCode), locale.c_str());
-
 	keymapper.Load();
 
 	if (demo::IsRunning())
@@ -444,8 +386,6 @@ void SaveOptions()
 #ifdef __vita__
 	SetIniValue("Controller", "Enable Rear Touchpad", sgOptions.Controller.bRearTouch);
 #endif
-
-	SetIniValue("Language", "Code", sgOptions.Language.szCode);
 
 	keymapper.Save();
 
@@ -712,13 +652,147 @@ std::vector<OptionEntryBase *> ChatOptions::GetEntries()
 	return {};
 }
 
+OptionEntryLanguageCode::OptionEntryLanguageCode()
+    : OptionEntryListBase("Code", OptionEntryFlags::CantChangeInGame | OptionEntryFlags::RecreateUI, "Language", "Define what language to use in game")
+{
+}
+void OptionEntryLanguageCode::LoadFromIni(string_view category)
+{
+#ifdef __ANDROID__
+	JNIEnv *env = (JNIEnv *)SDL_AndroidGetJNIEnv();
+	jobject activity = (jobject)SDL_AndroidGetActivity();
+	jclass clazz(env->GetObjectClass(activity));
+	jmethodID method_id = env->GetMethodID(clazz, "getLocale", "()Ljava/lang/String;");
+	jstring jLocale = (jstring)env->CallObjectMethod(activity, method_id);
+	const char *cLocale = env->GetStringUTFChars(jLocale, nullptr);
+	std::string locale = cLocale;
+	env->ReleaseStringUTFChars(jLocale, cLocale);
+	env->DeleteLocalRef(jLocale);
+	env->DeleteLocalRef(activity);
+	env->DeleteLocalRef(clazz);
+#elif defined(__vita__)
+	int32_t language = SCE_SYSTEM_PARAM_LANG_ENGLISH_US; // default to english
+	const char *vita_locales[] = {
+		"ja_JP",
+		"en_US",
+		"fr_FR",
+		"es_ES",
+		"de_DE",
+		"it_IT",
+		"nl_NL",
+		"pt_PT",
+		"ru_RU",
+		"ko_KR",
+		"zh_TW",
+		"zh_CN",
+		"fi_FI",
+		"sv_SE",
+		"da_DK",
+		"no_NO",
+		"pl_PL",
+		"pt_BR",
+		"en_GB",
+		"tr_TR",
+	};
+	SceAppUtilInitParam initParam;
+	SceAppUtilBootParam bootParam;
+	memset(&initParam, 0, sizeof(SceAppUtilInitParam));
+	memset(&bootParam, 0, sizeof(SceAppUtilBootParam));
+	sceAppUtilInit(&initParam, &bootParam);
+	sceAppUtilSystemParamGetInt(SCE_SYSTEM_PARAM_ID_LANG, &language);
+	if (language < 0 || language > SCE_SYSTEM_PARAM_LANG_TURKISH)
+		language = SCE_SYSTEM_PARAM_LANG_ENGLISH_US; // default to english
+	std::string locale = std::string(vita_locales[language]);
+	sceAppUtilShutdown();
+#elif defined(__3DS__)
+	std::string locale = n3ds::GetLocale();
+#else
+	std::string locale = std::locale("").name().substr(0, 5);
+#endif
+
+	locale = locale.substr(0, 5);
+	LogVerbose("Preferred locale: {}", locale);
+	if (!HasTranslation(locale)) {
+		locale = locale.substr(0, 2);
+		if (!HasTranslation(locale)) {
+			locale = "en";
+		}
+	}
+	LogVerbose("Best match locale: {}", locale);
+
+	GetIniValue(category.data(), key.data(), szCode, sizeof(szCode), locale.c_str());
+}
+void OptionEntryLanguageCode::SaveToIni(string_view category) const
+{
+	SetIniValue(category.data(), key.data(), szCode);
+}
+
+void OptionEntryLanguageCode::CheckLanguagesAreInitialized() const
+{
+	if (!languages.empty())
+		return;
+
+	// Add well-known supported languages
+	languages.push_back({ "bg", "Bulgarian" });
+	languages.push_back({ "cs", "Czech" });
+	languages.push_back({ "da", "Danish" });
+	languages.push_back({ "de", "German" });
+	languages.push_back({ "en", "English" });
+	languages.push_back({ "es", "Spanish" });
+	languages.push_back({ "fr", "French" });
+	languages.push_back({ "ja", "Japanese" });
+	languages.push_back({ "hr", "Croatian" });
+	languages.push_back({ "it", "Italian" });
+	languages.push_back({ "ko_KR", "Korean" });
+	languages.push_back({ "pl", "Polish" });
+	languages.push_back({ "pt_BR", "Portuguese (Brazil)" });
+	languages.push_back({ "ro_RO", "Romansh" });
+	languages.push_back({ "ru", "Russian" });
+	languages.push_back({ "sv", "Swedish" });
+	languages.push_back({ "uk", "Ukrainian" });
+	languages.push_back({ "zh_CN", "Simplified Chinese" });
+	languages.push_back({ "zh_TW", "Traditional Chinese" });
+
+	// Ensures that the ini specified language is present in languages list even if unkown (for example if someone starts to translate a new language)
+	if (std::find_if(languages.begin(), languages.end(), [this](const auto &x) { return x.first == this->szCode; }) == languages.end()) {
+		languages.push_back({ szCode, szCode });
+	}
+}
+
+size_t OptionEntryLanguageCode::GetListSize() const
+{
+	CheckLanguagesAreInitialized();
+	return languages.size();
+}
+string_view OptionEntryLanguageCode::GetListDescription(size_t index) const
+{
+	CheckLanguagesAreInitialized();
+	return languages[index].second;
+}
+size_t OptionEntryLanguageCode::GetActiveListIndex() const
+{
+	CheckLanguagesAreInitialized();
+	auto found = std::find_if(languages.begin(), languages.end(), [this](const auto &x) { return x.first == this->szCode; });
+	if (found == languages.end())
+		return 0;
+	return std::distance(languages.begin(), found);
+}
+void OptionEntryLanguageCode::SetActiveListIndex(size_t index)
+{
+	strcpy(szCode, languages[index].first.c_str());
+	NotifyValueChanged();
+}
+
 LanguageOptions::LanguageOptions()
     : OptionCategoryBase("Language", N_("Language"), N_("Language Settings"))
 {
+	code.SetValueChangedCallback(OptionLanguageCodeChanged);
 }
 std::vector<OptionEntryBase *> LanguageOptions::GetEntries()
 {
-	return {};
+	return {
+		&code,
+	};
 }
 
 } // namespace devilution

--- a/Source/options.h
+++ b/Source/options.h
@@ -159,6 +159,31 @@ public:
 	}
 };
 
+class OptionEntryLanguageCode : public OptionEntryListBase {
+public:
+	OptionEntryLanguageCode();
+
+	void LoadFromIni(string_view category) override;
+	void SaveToIni(string_view category) const override;
+
+	[[nodiscard]] virtual size_t GetListSize() const override;
+	[[nodiscard]] virtual string_view GetListDescription(size_t index) const override;
+	[[nodiscard]] virtual size_t GetActiveListIndex() const override;
+	virtual void SetActiveListIndex(size_t index) override;
+
+	string_view operator*() const
+	{
+		return szCode;
+	}
+
+private:
+	/** @brief Language code (IETF) for text. */
+	char szCode[6];
+	mutable std::vector<std::pair<std::string, std::string>> languages;
+
+	void CheckLanguagesAreInitialized() const;
+};
+
 struct OptionCategoryBase {
 	OptionCategoryBase(string_view key, string_view name, string_view description);
 
@@ -357,8 +382,7 @@ struct LanguageOptions : OptionCategoryBase {
 	LanguageOptions();
 	std::vector<OptionEntryBase *> GetEntries() override;
 
-	/** @brief Language code (IETF) for text. */
-	char szCode[6];
+	OptionEntryLanguageCode code;
 };
 
 struct Options {

--- a/Source/options.h
+++ b/Source/options.h
@@ -40,6 +40,8 @@ enum class OptionEntryFlags {
 	OnlyHellfire = 1 << 3,
 	/** @brief Option is only relevant for Diablo. */
 	OnlyDiablo = 1 << 4,
+	/** @brief After option is changed the UI needs to be recreated. */
+	RecreateUI = 1 << 5,
 };
 use_enum_as_flags(OptionEntryFlags);
 

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -289,6 +289,8 @@ bool IsSmallFontTall()
 
 void LanguageInitialize()
 {
+	translation = { {}, {} };
+
 	const std::string lang = sgOptions.Language.szCode;
 	SDL_RWops *rw;
 

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -283,7 +283,7 @@ bool HasTranslation(const std::string &locale)
 
 bool IsSmallFontTall()
 {
-	string_view code(sgOptions.Language.szCode, 2);
+	string_view code = (*sgOptions.Language.code).substr(0, 2);
 	return code == "zh" || code == "ja" || code == "ko";
 }
 
@@ -291,7 +291,7 @@ void LanguageInitialize()
 {
 	translation = { {}, {} };
 
-	const std::string lang = sgOptions.Language.szCode;
+	const std::string lang(*sgOptions.Language.code);
 	SDL_RWops *rw;
 
 	// Translations normally come in ".gmo" files.


### PR DESCRIPTION
## Notes

- Language list is at the moment hard coded. This could be improved in the future (searching for  *.mo/gmo files).
- No validation is currently applied (could be added later; for example check if language files really exists)
- UI needs to be recreated, cause we need to reload all texts (this will also be needed if we change resolution)
- I'm unsure if the language setting ("Languages") and the languages list ("English", "Spanish", ...) should be translatable. At the moment they aren't
- Didn't test polish voice pack
- UI could be improved (not part of this pr; for example we could show a sub-menu with the list entries)

## Sample Video

https://user-images.githubusercontent.com/25415264/143745625-a7269988-b7c7-4a15-ad5f-98d7567d8fee.mp4

