### PR TITLE
Settings: Add Game Mode and Shareware and remove specials in settingsmenu

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -47,7 +47,6 @@ Art ArtBackgroundWidescreen;
 Art ArtBackground;
 Art ArtCursor;
 Art ArtHero;
-bool gbSpawned;
 
 void (*gfnSoundFunction)(const char *file);
 bool textInputActive = true;

--- a/Source/DiabloUI/diabloui.h
+++ b/Source/DiabloUI/diabloui.h
@@ -72,7 +72,6 @@ extern Art ArtBackground;
 extern Art ArtBackgroundWidescreen;
 extern Art ArtCursor;
 extern Art ArtHero;
-extern bool gbSpawned;
 
 extern void (*gfnSoundFunction)(const char *file);
 extern bool (*gfnHeroInfo)(bool (*fninfofunc)(_uiheroinfo *));
@@ -95,7 +94,6 @@ inline SDL_Surface *DiabloUiSurface()
 
 void UiDestroy();
 void UiTitleDialog();
-void UiSetSpawned(bool bSpawned);
 void UiInitialize();
 bool UiValidPlayerName(const char *name); /* check */
 void UiSelHeroMultDialog(bool (*fninfo)(bool (*fninfofunc)(_uiheroinfo *)), bool (*fncreate)(_uiheroinfo *), bool (*fnremove)(_uiheroinfo *), void (*fnstats)(unsigned int, _uidefaultstats *), _selhero_selections *dlgresult, uint32_t *saveNumber);

--- a/Source/DiabloUI/mainmenu.cpp
+++ b/Source/DiabloUI/mainmenu.cpp
@@ -40,7 +40,7 @@ void MainmenuLoad(const char *name, void (*fnSound)(const char *file))
 	vecMenuItems.push_back(std::make_unique<UiListItem>(_("Show Credits"), MAINMENU_SHOW_CREDITS));
 	vecMenuItems.push_back(std::make_unique<UiListItem>(gbIsHellfire ? _("Exit Hellfire") : _("Exit Diablo"), MAINMENU_EXIT_DIABLO));
 
-	if (!gbSpawned || gbIsHellfire) {
+	if (!gbIsSpawn || gbIsHellfire) {
 		if (gbIsHellfire)
 			LoadArt("ui_art\\mainmenuw.pcx", &ArtBackgroundWidescreen);
 		LoadBackgroundArt("ui_art\\mainmenu.pcx");
@@ -51,7 +51,7 @@ void MainmenuLoad(const char *name, void (*fnSound)(const char *file))
 	UiAddBackground(&vecMainMenuDialog);
 	UiAddLogo(&vecMainMenuDialog);
 
-	if (gbSpawned && gbIsHellfire) {
+	if (gbIsSpawn && gbIsHellfire) {
 		SDL_Rect rect1 = { (Sint16)(PANEL_LEFT), (Sint16)(UI_OFFSET_Y + 145), 640, 30 };
 		vecMainMenuDialog.push_back(std::make_unique<UiArtText>(_("Shareware"), rect1, UiFlags::FontSize30 | UiFlags::ColorUiSilver | UiFlags::AlignCenter, 8));
 	}

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -224,7 +224,7 @@ bool ShouldPrefillHeroName()
 void SelheroClassSelectorSelect(int value)
 {
 	auto hClass = static_cast<HeroClass>(vecSelHeroDlgItems[value]->m_value);
-	if (gbSpawned && (hClass == HeroClass::Rogue || hClass == HeroClass::Sorcerer || (hClass == HeroClass::Bard && !hfbard_mpq))) {
+	if (gbIsSpawn && (hClass == HeroClass::Rogue || hClass == HeroClass::Sorcerer || (hClass == HeroClass::Bard && !hfbard_mpq))) {
 		ArtBackground.Unload();
 		UiSelOkDialog(nullptr, _("The Rogue and Sorcerer are only available in the full retail version of Diablo. Visit https://www.gog.com/game/diablo to purchase."), false);
 		LoadBackgroundArt("ui_art\\selhero.pcx");

--- a/Source/DiabloUI/selok.cpp
+++ b/Source/DiabloUI/selok.cpp
@@ -44,7 +44,7 @@ void UiSelOkDialog(const char *title, const char *body, bool background)
 	if (!background) {
 		LoadBackgroundArt("ui_art\\black.pcx");
 	} else {
-		if (!gbSpawned) {
+		if (!gbIsSpawn) {
 			LoadBackgroundArt("ui_art\\mainmenu.pcx");
 		} else {
 			LoadBackgroundArt("ui_art\\swmmenu.pcx");

--- a/Source/DiabloUI/selstart.cpp
+++ b/Source/DiabloUI/selstart.cpp
@@ -17,9 +17,8 @@ Art artLogo;
 
 void ItemSelected(int value)
 {
-	auto option = static_cast<StartUpGameOption>(vecDialogItems[value]->m_value);
-	sgOptions.Hellfire.startUpGameOption = option;
-	gbIsHellfire = option == StartUpGameOption::Hellfire;
+	auto option = static_cast<StartUpGameMode>(vecDialogItems[value]->m_value);
+	sgOptions.StartUp.gameMode.SetValue(option);
 	endMenu = true;
 }
 
@@ -40,8 +39,8 @@ void UiSelStartUpGameOption()
 	SDL_Rect rect = { 0, (Sint16)(UI_OFFSET_Y), 0, 0 };
 	vecDialog.push_back(std::make_unique<UiImage>(&artLogo, rect, UiFlags::AlignCenter, /*bAnimated=*/true));
 
-	vecDialogItems.push_back(std::make_unique<UiListItem>(_("Enter Hellfire"), static_cast<int>(StartUpGameOption::Hellfire)));
-	vecDialogItems.push_back(std::make_unique<UiListItem>(_("Switch to Diablo"), static_cast<int>(StartUpGameOption::Diablo)));
+	vecDialogItems.push_back(std::make_unique<UiListItem>(_("Enter Hellfire"), static_cast<int>(StartUpGameMode::Hellfire)));
+	vecDialogItems.push_back(std::make_unique<UiListItem>(_("Switch to Diablo"), static_cast<int>(StartUpGameMode::Diablo)));
 	vecDialog.push_back(std::make_unique<UiList>(vecDialogItems, vecDialogItems.size(), PANEL_LEFT + 64, (UI_OFFSET_Y + 240), 510, 43, UiFlags::AlignCenter | UiFlags::FontSize42 | UiFlags::ColorUiGold, 5));
 
 	UiInitList(nullptr, ItemSelected, EscPressed, vecDialog, true);

--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -26,7 +26,6 @@ Rectangle rectDescription;
 enum class SpecialMenuEntry {
 	None = -1,
 	PreviousMenu = -2,
-	SwitchGame = -3,
 	ToggleSpawn = -4,
 };
 
@@ -70,11 +69,6 @@ void ItemSelected(int value)
 			break;
 		case SpecialMenuEntry::PreviousMenu:
 			endMenu = true;
-			break;
-		case SpecialMenuEntry::SwitchGame:
-			gbIsHellfire = !gbIsHellfire;
-			endMenu = true;
-			recreateUI = true;
 			break;
 		case SpecialMenuEntry::ToggleSpawn:
 			gbIsSpawn = !gbIsSpawn;
@@ -137,8 +131,6 @@ void UiSettingsMenu()
 		vecDialog.push_back(std::make_unique<UiScrollbar>(&ArtScrollBarBackground, &ArtScrollBarThumb, &ArtScrollBarArrow, MakeSdlRect(rectList.position.x + rectList.size.width + 5, rectList.position.y, 25, rectList.size.height)));
 		vecDialog.push_back(std::make_unique<UiArtText>(optionDescription, MakeSdlRect(rectDescription), UiFlags::FontSize12 | UiFlags::ColorUiSilverDark | UiFlags::AlignCenter, 1, IsSmallFontTall() ? 22 : 18));
 
-		if (diabdat_mpq && hellfire_mpq)
-			vecDialogItems.push_back(std::make_unique<UiListItem>(gbIsHellfire ? _("Switch to Diablo") : _("Switch to Hellfire"), static_cast<int>(SpecialMenuEntry::SwitchGame), UiFlags::ColorUiGold));
 		if (diabdat_mpq)
 			vecDialogItems.push_back(std::make_unique<UiListItem>(gbIsSpawn ? _("Switch to Fullgame") : _("Switch to Shareware"), static_cast<int>(SpecialMenuEntry::ToggleSpawn), UiFlags::ColorUiGold));
 

--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -32,7 +32,12 @@ enum class SpecialMenuEntry {
 
 bool IsValidEntry(OptionEntryBase *pOptionEntry)
 {
-	return HasNoneOf(pOptionEntry->GetFlags(), OptionEntryFlags::Invisible | (gbIsHellfire ? OptionEntryFlags::OnlyDiablo : OptionEntryFlags::OnlyHellfire));
+	auto flags = pOptionEntry->GetFlags();
+	if (HasAnyOf(flags, OptionEntryFlags::NeedDiabloMpq) && !diabdat_mpq)
+		return false;
+	if (HasAnyOf(flags, OptionEntryFlags::NeedHellfireMpq) && !hellfire_mpq)
+		return false;
+	return HasNoneOf(flags, OptionEntryFlags::Invisible | (gbIsHellfire ? OptionEntryFlags::OnlyDiablo : OptionEntryFlags::OnlyHellfire));
 }
 
 std::vector<DrawStringFormatArg> CreateDrawStringFormatArgForEntry(OptionEntryBase *pEntry)

--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -72,7 +72,6 @@ void ItemSelected(int value)
 			break;
 		case SpecialMenuEntry::ToggleSpawn:
 			gbIsSpawn = !gbIsSpawn;
-			UiSetSpawned(gbIsSpawn);
 			endMenu = true;
 			recreateUI = true;
 			break;

--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -26,7 +26,6 @@ Rectangle rectDescription;
 enum class SpecialMenuEntry {
 	None = -1,
 	PreviousMenu = -2,
-	ToggleSpawn = -4,
 };
 
 bool IsValidEntry(OptionEntryBase *pOptionEntry)
@@ -69,11 +68,6 @@ void ItemSelected(int value)
 			break;
 		case SpecialMenuEntry::PreviousMenu:
 			endMenu = true;
-			break;
-		case SpecialMenuEntry::ToggleSpawn:
-			gbIsSpawn = !gbIsSpawn;
-			endMenu = true;
-			recreateUI = true;
 			break;
 		}
 		return;
@@ -130,13 +124,8 @@ void UiSettingsMenu()
 		vecDialog.push_back(std::make_unique<UiScrollbar>(&ArtScrollBarBackground, &ArtScrollBarThumb, &ArtScrollBarArrow, MakeSdlRect(rectList.position.x + rectList.size.width + 5, rectList.position.y, 25, rectList.size.height)));
 		vecDialog.push_back(std::make_unique<UiArtText>(optionDescription, MakeSdlRect(rectDescription), UiFlags::FontSize12 | UiFlags::ColorUiSilverDark | UiFlags::AlignCenter, 1, IsSmallFontTall() ? 22 : 18));
 
-		if (diabdat_mpq)
-			vecDialogItems.push_back(std::make_unique<UiListItem>(gbIsSpawn ? _("Switch to Fullgame") : _("Switch to Shareware"), static_cast<int>(SpecialMenuEntry::ToggleSpawn), UiFlags::ColorUiGold));
-
-		bool switchOptionExists = vecDialogItems.size() > 0;
-		int catCount = switchOptionExists ? 1 : 0;
-
-		size_t itemToSelect = switchOptionExists ? 0 : 1;
+		size_t catCount = 0;
+		size_t itemToSelect = 1;
 
 		for (auto *pCategory : sgOptions.GetCategories()) {
 			bool categoryCreated = false;

--- a/Source/DiabloUI/title.cpp
+++ b/Source/DiabloUI/title.cpp
@@ -71,9 +71,4 @@ void UiTitleDialog()
 	TitleFree();
 }
 
-void UiSetSpawned(bool bSpawned)
-{
-	gbSpawned = bSpawned;
-}
-
 } // namespace devilution

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -939,7 +939,6 @@ void DiabloInit()
 #endif
 
 	UiInitialize();
-	UiSetSpawned(gbIsSpawn);
 	was_ui_init = true;
 
 	ReadOnlyTest();

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -914,7 +914,7 @@ void DiabloInit()
 	init_archives();
 	was_archives_init = true;
 
-	if (forceSpawn)
+	if (forceSpawn || *sgOptions.StartUp.shareware)
 		gbIsSpawn = true;
 	if (forceDiablo || *sgOptions.StartUp.gameMode == StartUpGameMode::Diablo)
 		gbIsHellfire = false;

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -916,7 +916,7 @@ void DiabloInit()
 
 	if (forceSpawn)
 		gbIsSpawn = true;
-	if (forceDiablo || sgOptions.Hellfire.startUpGameOption == StartUpGameOption::Diablo)
+	if (forceDiablo || *sgOptions.StartUp.gameMode == StartUpGameMode::Diablo)
 		gbIsHellfire = false;
 	if (forceHellfire)
 		gbIsHellfire = true;
@@ -944,7 +944,7 @@ void DiabloInit()
 
 	ReadOnlyTest();
 
-	if (gbIsHellfire && !forceHellfire && sgOptions.Hellfire.startUpGameOption == StartUpGameOption::None) {
+	if (gbIsHellfire && !forceHellfire && *sgOptions.StartUp.gameMode == StartUpGameMode::Ask) {
 		UiSelStartUpGameOption();
 		if (!gbIsHellfire) {
 			// Reinitalize the UI Elements cause we changed the game

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -240,6 +240,11 @@ void OptionGameModeChanged()
 	gbIsHellfire = *sgOptions.StartUp.gameMode == StartUpGameMode::Hellfire;
 }
 
+void OptionSharewareChanged()
+{
+	gbIsSpawn = *sgOptions.StartUp.shareware;
+}
+
 } // namespace
 
 void SetIniValue(const char *sectionName, const char *keyName, const char *value, int len)
@@ -514,6 +519,7 @@ StartUpOptions::StartUpOptions()
               // Ask is missing, cause we want to hide it from UI-Settings.
               { StartUpGameMode::Hellfire, N_("Hellfire") },
           })
+    , shareware("Shareware", OptionEntryFlags::NeedDiabloMpq | OptionEntryFlags::RecreateUI, N_("Restrict to Shareware"), N_("Makes the game compatible with the demo. Enables multiplayer with friends who don't own a full copy of Diablo."), false)
     , diabloIntro("Diablo Intro", OptionEntryFlags::OnlyDiablo, N_("Intro"), N_("Shown Intro cinematic."), StartUpIntro::Once,
           {
               { StartUpIntro::Off, N_("OFF") },
@@ -534,11 +540,13 @@ StartUpOptions::StartUpOptions()
           })
 {
 	gameMode.SetValueChangedCallback(OptionGameModeChanged);
+	shareware.SetValueChangedCallback(OptionSharewareChanged);
 }
 std::vector<OptionEntryBase *> StartUpOptions::GetEntries()
 {
 	return {
 		&gameMode,
+		&shareware,
 		&diabloIntro,
 		&hellfireIntro,
 		&splash,

--- a/Source/options.h
+++ b/Source/options.h
@@ -10,10 +10,11 @@
 
 namespace devilution {
 
-enum class StartUpGameOption {
-	None,
-	Hellfire,
-	Diablo,
+enum class StartUpGameMode {
+	/** @brief If hellfire is present, asks the user what game he wants to start. */
+	Ask = 0,
+	Hellfire = 1,
+	Diablo = 2,
 };
 
 enum class StartUpIntro {
@@ -234,6 +235,7 @@ struct StartUpOptions : OptionCategoryBase {
 	StartUpOptions();
 	std::vector<OptionEntryBase *> GetEntries() override;
 
+	OptionEntryEnum<StartUpGameMode> gameMode;
 	/** @brief Play game intro video on diablo startup. */
 	OptionEntryEnum<StartUpIntro> diabloIntro;
 	/** @brief Play game intro video on hellfire startup. */
@@ -261,8 +263,6 @@ struct HellfireOptions : OptionCategoryBase {
 	std::uint32_t lastSinglePlayerHero;
 	/** @brief Remembers what multiplayer hero/save was last used. */
 	std::uint32_t lastMultiplayerHero;
-
-	StartUpGameOption startUpGameOption;
 };
 
 struct AudioOptions : OptionCategoryBase {

--- a/Source/options.h
+++ b/Source/options.h
@@ -236,6 +236,7 @@ struct StartUpOptions : OptionCategoryBase {
 	std::vector<OptionEntryBase *> GetEntries() override;
 
 	OptionEntryEnum<StartUpGameMode> gameMode;
+	OptionEntryBoolean shareware;
 	/** @brief Play game intro video on diablo startup. */
 	OptionEntryEnum<StartUpIntro> diabloIntro;
 	/** @brief Play game intro video on hellfire startup. */

--- a/Source/options.h
+++ b/Source/options.h
@@ -58,6 +58,10 @@ enum class OptionEntryFlags {
 	OnlyDiablo = 1 << 4,
 	/** @brief After option is changed the UI needs to be recreated. */
 	RecreateUI = 1 << 5,
+	/** @brief diablo.mpq must be present. */
+	NeedDiabloMpq = 1 << 6,
+	/** @brief hellfire.mpq must be present. */
+	NeedHellfireMpq = 1 << 7,
 };
 use_enum_as_flags(OptionEntryFlags);
 


### PR DESCRIPTION
## Content

- Add Game Mode to Settings
- Add Shareware to Settings
- Remove Special Actions `Switch to Diablo/Hellfire` and `Switch to Fullgame/Shareware`
- Unify `gbIsSpawn` and `gbSpawned`

## Screenshot

![grafik](https://user-images.githubusercontent.com/25415264/143781998-a3e603b2-27b1-4811-a849-f15dfd9e14fc.png)

