### PR TITLE
3rdParty: Bump versions of libmpq and libsmacker dec

### DIFF
--- a/3rdParty/libmpq/CMakeLists.txt
+++ b/3rdParty/libmpq/CMakeLists.txt
@@ -8,8 +8,8 @@ include(FetchContent_MakeAvailableExcludeFromAll)
 
 include(FetchContent)
 FetchContent_Declare(libmpq
-    URL https://github.com/diasurgical/libmpq/archive/5f9187193b4c6ed01c8fb694d149b12429cb8b1b.tar.gz
-    URL_HASH MD5=689b123c3a3cb0b4a19e899fd86ac1bf
+    URL https://github.com/diasurgical/libmpq/archive/0f10bd1600f406b13932bf5351ba713361262184.tar.gz
+    URL_HASH MD5=c165f1a0c0ce13470e22d9cb5de62590
 )
 FetchContent_MakeAvailableExcludeFromAll(libmpq)
 

--- a/3rdParty/libsmackerdec/CMakeLists.txt
+++ b/3rdParty/libsmackerdec/CMakeLists.txt
@@ -2,8 +2,8 @@ include(FetchContent_MakeAvailableExcludeFromAll)
 
 include(FetchContent)
 FetchContent_Declare(libsmackerdec
-    URL https://github.com/diasurgical/libsmackerdec/archive/2b9247f2c72fea5e2992888f7f29cd7f6d790b35.tar.gz
-    URL_HASH MD5=a34396cfe21a166de331ae714c5449cb
+    URL https://github.com/diasurgical/libsmackerdec/archive/792527435722151aff1a5b11f0862b957563d10b.tar.gz
+    URL_HASH MD5=8e970b75c3c273be07c64addfa292522
 )
 FetchContent_MakeAvailableExcludeFromAll(libsmackerdec)
 


### PR DESCRIPTION
These are the only new commits:

https://github.com/diasurgical/libmpq/commit/0f10bd1600f406b13932bf5351ba713361262184
https://github.com/diasurgical/libsmackerdec/commit/792527435722151aff1a5b11f0862b957563d10b