### PR TITLE
Update libsmackerdec

### DIFF
--- a/3rdParty/libsmackerdec/CMakeLists.txt
+++ b/3rdParty/libsmackerdec/CMakeLists.txt
@@ -2,8 +2,8 @@ include(FetchContent_MakeAvailableExcludeFromAll)
 
 include(FetchContent)
 FetchContent_Declare(libsmackerdec
-    URL https://github.com/diasurgical/libsmackerdec/archive/792527435722151aff1a5b11f0862b957563d10b.tar.gz
-    URL_HASH MD5=8e970b75c3c273be07c64addfa292522
+    URL https://github.com/diasurgical/libsmackerdec/archive/2997ee0e41e91bb723003bc09234be553b190e38.tar.gz
+    URL_HASH MD5=04d8ccd5bed0c78ee23e777c323d87ee
 )
 FetchContent_MakeAvailableExcludeFromAll(libsmackerdec)
 


### PR DESCRIPTION
This fixes a visual glitch in the Blizzard logo video when using the MPQ from the original CD release.

It seems the original version of the logo video doesn't fill the video buffer on the first frame, essentially making the assumption that the video decoder will fill it with something sane. However, libsmackerdec didn't explicitly initialize the data in the video buffer so the background before the logo sweeps in would display whatever garbage data existed in memory when the buffer was allocated. This change uses memset to initialize the buffer with zeros in `Smacker_Open()`.