### PR TITLE
Add 3dsx back to the 3DS build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
       - run: sudo chmod +rx /opt/devkitpro/tools/bin/makerom
       - run: cmake -S. -Bbuild -DNIGHTLY_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/3DS.cmake
       - run: cmake --build build -j 2
+      - store_artifacts: {path: ./build/devilutionx.3dsx, destination: devilutionx.3dsx}
       - store_artifacts: {path: ./build/devilutionx.cia, destination: devilutionx.cia}
   amigaos-m68k:
     docker:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1228,9 +1228,11 @@ if(NINTENDO_3DS)
   add_dependencies(romfs_files romfs_directory devilutionx_mpq)
 
   include(Tools3DS)
+  add_3dsx_target(${BIN_TARGET})
   add_cia_target(${BIN_TARGET} ${APP_RSF} ${APP_BANNER} ${APP_AUDIO})
 
   get_filename_component(APP_TARGET_PREFIX ${BIN_TARGET} NAME_WE)
+  add_dependencies(${APP_TARGET_PREFIX}_3dsx romfs_files)
   add_dependencies(${APP_TARGET_PREFIX}_cia romfs_files)
 endif()
 


### PR DESCRIPTION
Based on comments from @MrHuu (https://github.com/diasurgical/devilutionX/pull/3458#issuecomment-973223677), it seems the 3dsx build can be used on a 3DS console without CFW if it is first loaded onto a flashcart.

Now that Smacker videos are being streamed from the SD card, o3DS consoles should be able to make it through the intro video with only 64 MB of RAM available. However, additional testing reveals that sometimes dungeon levels may require close to 64 MB of RAM. The game may run out of memory and exit unexpectedly during a loading screen when played for a prolonged period of time. Therefore, o3DS users should be cautious and save their game often if they choose to play using the 3dsx build.