### PR TITLE
[Ios] load files from file browser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -548,6 +548,10 @@ set(libdevilutionx_SRCS
   Source/storm/storm_svid.cpp
   Source/miniwin/misc_msg.cpp)
 
+if(IOS)
+  list(APPEND libdevilutionx_SRCS Source/platform/ios/paths.m)
+endif()
+
 if(USE_SDL1)
   list(APPEND libdevilutionx_SRCS Source/utils/sdl2_to_1_2_backports.cpp)
 endif()

--- a/Packaging/apple/Info.plist
+++ b/Packaging/apple/Info.plist
@@ -44,5 +44,9 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 </dict>
 </plist>

--- a/Source/platform/ios/paths.h
+++ b/Source/platform/ios/paths.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern char *IOSGetPrefPath();
+
+#ifdef __cplusplus
+}
+#endif

--- a/Source/platform/ios/paths.m
+++ b/Source/platform/ios/paths.m
@@ -1,0 +1,30 @@
+#import <Foundation/Foundation.h>
+
+#include "paths.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+char *IOSGetPrefPath()
+{
+	@autoreleasepool {
+		NSArray *array = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+
+		if ([array count] > 0) {
+			NSString *str = [array objectAtIndex:0];
+			str = [str stringByAppendingString:@"/"];
+			const char *base = [str fileSystemRepresentation];
+
+			char *copy = malloc(strlen(base) + 1);
+			strcpy(copy, base);
+			return copy;
+		}
+
+		return "";
+	}
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/Source/utils/paths.cpp
+++ b/Source/utils/paths.cpp
@@ -6,6 +6,10 @@
 #include "utils/log.hpp"
 #include "utils/sdl_ptrs.h"
 
+#ifdef __IPHONEOS__
+#include "platform/ios/paths.h"
+#endif
+
 #ifdef USE_SDL1
 #include "utils/sdl2_to_1_2_backports.h"
 #endif
@@ -66,10 +70,14 @@ const std::string &BasePath()
 const std::string &PrefPath()
 {
 	if (!prefPath) {
+#ifndef __IPHONEOS__
 		prefPath = FromSDL(SDL_GetPrefPath("diasurgical", "devilution"));
 		if (FileExistsAndIsWriteable("diablo.ini")) {
 			prefPath = std::string("./");
 		}
+#else
+		prefPath = FromSDL(IOSGetPrefPath());
+#endif
 	}
 	return *prefPath;
 }
@@ -77,10 +85,14 @@ const std::string &PrefPath()
 const std::string &ConfigPath()
 {
 	if (!configPath) {
+#ifndef __IPHONEOS__
 		configPath = FromSDL(SDL_GetPrefPath("diasurgical", "devilution"));
 		if (FileExistsAndIsWriteable("diablo.ini")) {
 			configPath = std::string("./");
 		}
+#else
+		configPath = FromSDL(IOSGetPrefPath());
+#endif
 	}
 	return *configPath;
 }


### PR DESCRIPTION
My changes are to help people transfer their MPQ files to their iDevice so that they are able to run the game. These CLs allow 2 methods to achieve this.

The first step regardless of the method is to launch the app. For now, it will simply give you a messagebox saying it cannot find any MPQ file. This is fine though because it will have created diablo.ini and saved in the Document directory from the app's sandbox. Doing this will now expose the directory to the user.

- The first method is to copy the MPQ using the file browser app in the app's Document directory. There are a multitude of ways that the can get the MPQ file onto their iDevice (Cloud Storage such as iCloud, Dropbox, Google Drive, etc or using a shared network drive for example)

- The second method, is via iTunes on Windows or using Finder on MacOS. When viewing your iDevice's files through those, you can simply copy the MPQ file to the app's corresponding Document folder.
