### PR TITLE
[Android] Clear memory on exit with System.exit(0)

### DIFF
--- a/android-project/app/src/main/java/org/diasurgical/devilutionx/DevilutionXSDLActivity.java
+++ b/android-project/app/src/main/java/org/diasurgical/devilutionx/DevilutionXSDLActivity.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 
 public class DevilutionXSDLActivity extends SDLActivity {
 	private String externalDir;
+	private boolean noExit;
 
 	protected void onCreate(Bundle savedInstanceState) {
 		// windowSoftInputMode=adjustPan stopped working
@@ -49,7 +50,20 @@ public class DevilutionXSDLActivity extends SDLActivity {
 		if (missingGameData()) {
 			Intent intent = new Intent(this, DataActivity.class);
 			startActivity(intent);
+			noExit = true;
 			this.finish();
+		}
+	}
+
+	/**
+	 * When the user exits the game, use System.exit(0)
+	 * to clear memory and prevent errors on restart
+	 */
+	protected void onDestroy() {
+		super.onDestroy();
+
+		if (!noExit) {
+			System.exit(0);
 		}
 	}
 


### PR DESCRIPTION
It turns out that #3329 and #3553 are the same issue.

I was completely unable to reproduce these errors on my Pixel 4, but the Pixel 2 AVD running Android 10 reproduced them quite easily.

As @AJenbo pointed out (https://github.com/diasurgical/devilutionX/issues/3553#issuecomment-974666734), `System.exit(0)` does not seem to do anything. The game still shows up in the task switcher and will restart when selected from there. However, it seems that under the covers the OS will reclaim heap data without reclaiming or reinitializing static data if you do not use it. This causes the static `controllers_` vector to maintain a reference to a deleted `GameController` instance on restart.

This change also has the nice added benefit of detaching the Android Studio debugger on exit.

This resolves #3553