### PR TITLE
Handle multiple language preferences on windows

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -911,6 +911,25 @@ void OptionEntryLanguageCode::LoadFromIni(string_view category)
 		}
 	}
 
+	std::vector<std::string> fallbackLocales;
+	fallbackLocales.reserve(locales.size());
+
+	for (const auto &locale : locales) {
+		std::string neutralLocale = locale.substr(0, locale.find('_'));
+		if (std::find(fallbackLocales.cbegin(), fallbackLocales.cend(), neutralLocale) == fallbackLocales.cend()) {
+			fallbackLocales.push_back(neutralLocale);
+		}
+	}
+
+	for (const auto &fallbackLocale : fallbackLocales) {
+		LogVerbose("Trying to load fallback translation: {}", fallbackLocale);
+		if (HasTranslation(fallbackLocale)) {
+			LogVerbose("Found matching fallback locale: {}", fallbackLocale);
+			CopyUtf8(szCode, fallbackLocale, sizeof(szCode));
+			return;
+		}
+	}
+
 	LogVerbose("No suitable translation found");
 	strcpy(szCode, "en");
 }

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -270,7 +270,8 @@ const std::string &LanguageTranslate(const char *key)
 
 bool HasTranslation(const std::string &locale)
 {
-	if (locale == "en") {
+	if (locale == "en" || locale == "en_US") {
+		// the base translation is en_US. No translation file will be present for these codes but we want the check to succeed to prevent further searches.
 		return true;
 	}
 

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -270,15 +270,19 @@ const std::string &LanguageTranslate(const char *key)
 
 bool HasTranslation(const std::string &locale)
 {
-	for (const char *ext : { ".mo", ".gmo" }) {
-		SDL_RWops *rw = OpenAsset((locale + ext).c_str());
+	if (locale == "en") {
+		return true;
+	}
+
+	constexpr std::array<char *, 2> Extensions { ".mo", ".gmo" };
+	return std::any_of(Extensions.cbegin(), Extensions.cend(), [locale](const std::string &extension) {
+		SDL_RWops *rw = OpenAsset((locale + extension).c_str());
 		if (rw != nullptr) {
 			SDL_RWclose(rw);
 			return true;
 		}
-	}
-
-	return false;
+		return false;
+	});
 }
 
 bool IsSmallFontTall()


### PR DESCRIPTION
This PR looks for all region-specific locales according to user preferences to find a matching translation. The last commit updates the fallback behaviour to look for non-regional translations after the last regional variation of a given language.

For example, a user preference of `en_AU, fr_FR, en_US` will search for translations in the order `en_AU, fr_FR, fr, en_US, en`. `en_AU` is the first preference so will be checked first, but because another english regional variation is in the list to be checked in the future we do not look for non-regional translations yet. `fr_FR` is immediately followed by a check for a non-regional `fr` translation as no other regional variations were specified. Finally `en_US` then `en` are checked being the last regional variation of english in the list of languages.

To ensure that cases where `en_US` or `en` are higher in the user preferences than other languages with translation files `HasTranslation` includes an explicit check for these codes. Without this these languages would never be picked over another existing translation since there should never be a .mo/.gmo file for those codes.