### PR TITLE
android_defs.cmake: Cleanup

### DIFF
--- a/CMake/android_defs.cmake
+++ b/CMake/android_defs.cmake
@@ -1,16 +1,25 @@
-#General compilation options
-set(ASAN OFF)
-set(UBSAN OFF)
-set(DEVILUTIONX_SYSTEM_SDL2 OFF)
-set(DEVILUTIONX_SYSTEM_LIBSODIUM OFF)
-set(DEVILUTIONX_SYSTEM_LIBPNG OFF)
-set(DEVILUTIONX_SYSTEM_BZIP2 OFF)
+# General build options.
 set(VIRTUAL_GAMEPAD ON)
 
+# Disable all system dependencies.
+# All of these will be fetched via FetchContent and linked statically.
+set(DEVILUTIONX_SYSTEM_SDL2 OFF)
+set(DEVILUTIONX_SYSTEM_SDL_IMAGE OFF)
+set(DEVILUTIONX_SYSTEM_SDL_AUDIOLIB OFF)
+set(DEVILUTIONX_SYSTEM_LIBSODIUM OFF)
+set(DEVILUTIONX_SYSTEM_LIBPNG OFF)
+set(DEVILUTIONX_SYSTEM_LIBFMT OFF)
+set(DEVILUTIONX_SYSTEM_BZIP2 OFF)
+
+# Package the assets with the APK.
+set(BUILD_ASSETS_MPQ OFF)
+set(DEVILUTIONX_ASSETS_OUTPUT_DIRECTORY "${DevilutionX_SOURCE_DIR}/android-project/app/src/main/assets")
+
+# Disable sanitizers. They're not supported out-of-the-box.
+set(ASAN OFF)
+set(UBSAN OFF)
+
 if(BINARY_RELEASE OR CMAKE_BUILD_TYPE STREQUAL "Release")
-  # Workaroudn linker bug in CLang: https://github.com/android/ndk/issues/721
+  # Work around a linker bug in clang: https://github.com/android/ndk/issues/721
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -flto=full")
 endif()
-
-set(DEVILUTIONX_ASSETS_OUTPUT_DIRECTORY "${DevilutionX_SOURCE_DIR}/android-project/app/src/main/assets")
-set(BUILD_ASSETS_MPQ OFF)


### PR DESCRIPTION
1. Organize and comment on various options that we set.
2. Disable all system dependencies explicitly instead of relying on auto-detection for some of them.