### PR TITLE
Settingsmenu: Clean up UI-Resources before switching options that require RecreateUI

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -563,6 +563,8 @@ void LoadUiGFX()
 	LoadHeros();
 }
 
+} // namespace
+
 void UnloadUiGFX()
 {
 	ArtHero.Unload();
@@ -573,11 +575,8 @@ void UnloadUiGFX()
 		art.Unload();
 }
 
-} // namespace
-
 void UiInitialize()
 {
-	UnloadUiGFX();
 	LoadUiGFX();
 
 	if (ArtCursor.surface != nullptr) {

--- a/Source/DiabloUI/diabloui.h
+++ b/Source/DiabloUI/diabloui.h
@@ -94,6 +94,7 @@ inline SDL_Surface *DiabloUiSurface()
 
 void UiDestroy();
 void UiTitleDialog();
+void UnloadUiGFX();
 void UiInitialize();
 bool UiValidPlayerName(const char *name); /* check */
 void UiSelHeroMultDialog(bool (*fninfo)(bool (*fninfofunc)(_uiheroinfo *)), bool (*fncreate)(_uiheroinfo *), bool (*fnremove)(_uiheroinfo *), void (*fnstats)(unsigned int, _uidefaultstats *), _selhero_selections *dlgresult, uint32_t *saveNumber);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -947,6 +947,7 @@ void DiabloInit()
 		UiSelStartUpGameOption();
 		if (!gbIsHellfire) {
 			// Reinitalize the UI Elements cause we changed the game
+			UnloadUiGFX();
 			UiInitialize();
 			if (IsHardwareCursor())
 				SetHardwareCursor(CursorInfo::UnknownCursor());


### PR DESCRIPTION
Fixes #3668 (hopefully)

`UiPollAndRender` calls `UiHandleEvents`
`UiHandleEvents` calls `ItemSelected`. We change the language, mark the UI to be recreated.
But after that `UiPollAndRender` calls `UiRenderItems` once. And then we could access freed memory.

This pr avoid this by do the cleanup first (with `UiInitList_clear`), change settings and then recreates the UI and settingsmenu after that.

I don't own a mac, so can't verify it.
@bubio could you test this pr to verify if this fixes your crash on macOS?