### PR TITLE
Settings: Add graphic settings that resizes the window

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -22,6 +22,17 @@
       "enableClangTidyCodeAnalysis": true
     },
     {
+      "name": "x64-Debug-SDL1",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${workspaceRoot}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "inheritEnvironments": [ "msvc_x64" ],
+      "intelliSenseMode": "windows-msvc-x64",
+      "cmakeCommandArgs": "-DUSE_SDL1=ON",
+      "enableClangTidyCodeAnalysis": true
+    },
+    {
       "name": "x64-Release",
       "generator": "Ninja",
       "configurationType": "Release",

--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -190,7 +190,7 @@ void dx_cleanup()
 	RendererTextureSurface = nullptr;
 #ifndef USE_SDL1
 	texture = nullptr;
-	if (sgOptions.Graphics.bUpscale)
+	if (*sgOptions.Graphics.upscale)
 		SDL_DestroyRenderer(renderer);
 #endif
 	SDL_DestroyWindow(ghMainWnd);
@@ -312,7 +312,7 @@ void RenderPresent()
 #endif
 		SDL_RenderPresent(renderer);
 
-		if (!sgOptions.Graphics.bVSync) {
+		if (!*sgOptions.Graphics.vSync) {
 			LimitFrameRate();
 		}
 	} else {

--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -96,21 +96,6 @@ void CreateBackBuffer()
 	pal_surface_palette_version = 1;
 }
 
-void CreatePrimarySurface()
-{
-#ifndef USE_SDL1
-	if (renderer != nullptr) {
-		int width = 0;
-		int height = 0;
-		SDL_RenderGetLogicalSize(renderer, &width, &height);
-		Uint32 format;
-		if (SDL_QueryTexture(texture.get(), &format, nullptr, nullptr, nullptr) < 0)
-			ErrSdl();
-		RendererTextureSurface = SDLWrap::CreateRGBSurfaceWithFormat(0, width, height, SDL_BITSPERPIXEL(format), format);
-	}
-#endif
-}
-
 void LockBufPriv()
 {
 	MemCrit.lock();
@@ -157,7 +142,6 @@ void dx_init()
 	SDL_ShowWindow(ghMainWnd);
 #endif
 
-	CreatePrimarySurface();
 	palette_init();
 	CreateBackBuffer();
 }

--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -146,12 +146,16 @@ void OverrideOptions()
 {
 	sgOptions.Graphics.nWidth = DemoGraphicsWidth;
 	sgOptions.Graphics.nHeight = DemoGraphicsHeight;
-	sgOptions.Graphics.bFitToScreen = false;
+#ifndef USE_SDL1
+	sgOptions.Graphics.fitToScreen.SetValue(false);
+#endif
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	sgOptions.Graphics.bHardwareCursor = false;
 #endif
 	if (Timedemo) {
-		sgOptions.Graphics.bVSync = false;
+#ifndef USE_SDL1
+		sgOptions.Graphics.vSync.SetValue(false);
+#endif
 		sgOptions.Graphics.limitFPS.SetValue(false);
 	}
 }

--- a/Source/options.h
+++ b/Source/options.h
@@ -300,17 +300,21 @@ struct GraphicsOptions : OptionCategoryBase {
 	/** @brief Render height. */
 	int nHeight;
 	/** @brief Run in fullscreen or windowed mode. */
-	bool bFullscreen;
-	/** @brief Scale the image after rendering. */
-	bool bUpscale;
+	OptionEntryBoolean fullscreen;
+#if !defined(USE_SDL1) || defined(__3DS__)
 	/** @brief Expand the aspect ratio to match the screen. */
-	bool bFitToScreen;
+	OptionEntryBoolean fitToScreen;
+#endif
+#ifndef USE_SDL1
+	/** @brief Scale the image after rendering. */
+	OptionEntryBoolean upscale;
 	/** @brief See SDL_HINT_RENDER_SCALE_QUALITY. */
 	OptionEntryEnum<ScalingQuality> scaleQuality;
 	/** @brief Only scale by values divisible by the width and height. */
-	bool bIntegerScaling;
+	OptionEntryBoolean integerScaling;
 	/** @brief Enable vsync on the output. */
-	bool bVSync;
+	OptionEntryBoolean vSync;
+#endif
 	/** @brief Use blended transparency rather than stippled. */
 	OptionEntryBoolean blendedTransparancy;
 	/** @brief Gamma correction level. */

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -61,7 +61,7 @@ void CalculatePreferdWindowSize(int &width, int &height)
 		ErrSdl();
 	}
 
-	if (!sgOptions.Graphics.bIntegerScaling) {
+	if (!*sgOptions.Graphics.integerScaling) {
 		float wFactor = (float)mode.w / width;
 		float hFactor = (float)mode.h / height;
 
@@ -103,7 +103,7 @@ Size GetPreferedWindowSize()
 	Size windowSize = { sgOptions.Graphics.nWidth, sgOptions.Graphics.nHeight };
 
 #ifndef USE_SDL1
-	if (sgOptions.Graphics.bUpscale && sgOptions.Graphics.bFitToScreen) {
+	if (*sgOptions.Graphics.upscale && *sgOptions.Graphics.fitToScreen) {
 		CalculatePreferdWindowSize(windowSize.width, windowSize.height);
 	}
 #endif
@@ -132,7 +132,7 @@ void SetVideoModeToPrimary(bool fullscreen, int width, int height)
 		flags |= SDL_FULLSCREEN;
 #ifdef __3DS__
 	flags &= ~SDL_FULLSCREEN;
-	flags |= Get3DSScalingFlag(sgOptions.Graphics.bFitToScreen, width, height);
+	flags |= Get3DSScalingFlag(*sgOptions.Graphics.fitToScreen, width, height);
 #endif
 	SetVideoMode(width, height, SDL1_VIDEO_MODE_BPP, flags);
 	if (OutputRequiresScaling())
@@ -201,18 +201,18 @@ bool SpawnWindow(const char *lpWindowName)
 
 #ifdef USE_SDL1
 	SDL_WM_SetCaption(lpWindowName, WINDOW_ICON_NAME);
-	SetVideoModeToPrimary(!gbForceWindowed && sgOptions.Graphics.bFullscreen, windowSize.width, windowSize.height);
+	SetVideoModeToPrimary(!gbForceWindowed && *sgOptions.Graphics.fullscreen, windowSize.width, windowSize.height);
 	if (*sgOptions.Gameplay.grabInput)
 		SDL_WM_GrabInput(SDL_GRAB_ON);
 	atexit(SDL_VideoQuit); // Without this video mode is not restored after fullscreen.
 #else
 	int flags = 0;
-	if (sgOptions.Graphics.bUpscale) {
-		if (!gbForceWindowed && sgOptions.Graphics.bFullscreen) {
+	if (*sgOptions.Graphics.upscale) {
+		if (!gbForceWindowed && *sgOptions.Graphics.fullscreen) {
 			flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 		}
 		flags |= SDL_WINDOW_RESIZABLE;
-	} else if (!gbForceWindowed && sgOptions.Graphics.bFullscreen) {
+	} else if (!gbForceWindowed && *sgOptions.Graphics.fullscreen) {
 		flags |= SDL_WINDOW_FULLSCREEN;
 	}
 
@@ -259,10 +259,10 @@ void ReinitializeRenderer()
 		renderer = nullptr;
 	}
 
-	if (sgOptions.Graphics.bUpscale) {
+	if (*sgOptions.Graphics.upscale) {
 		Uint32 rendererFlags = SDL_RENDERER_ACCELERATED;
 
-		if (sgOptions.Graphics.bVSync) {
+		if (*sgOptions.Graphics.vSync) {
 			rendererFlags |= SDL_RENDERER_PRESENTVSYNC;
 		}
 
@@ -276,7 +276,7 @@ void ReinitializeRenderer()
 
 		texture = SDLWrap::CreateTexture(renderer, SDL_PIXELFORMAT_RGB888, SDL_TEXTUREACCESS_STREAMING, gnScreenWidth, gnScreenHeight);
 
-		if (sgOptions.Graphics.bIntegerScaling && SDL_RenderSetIntegerScale(renderer, SDL_TRUE) < 0) {
+		if (*sgOptions.Graphics.integerScaling && SDL_RenderSetIntegerScale(renderer, SDL_TRUE) < 0) {
 			ErrSdl();
 		}
 
@@ -304,15 +304,15 @@ void ResizeWindow()
 	Size windowSize = GetPreferedWindowSize();
 
 #ifdef USE_SDL1
-	SetVideoModeToPrimary(!gbForceWindowed && sgOptions.Graphics.bFullscreen, windowSize.width, windowSize.height);
+	SetVideoModeToPrimary(!gbForceWindowed && *sgOptions.Graphics.fullscreen, windowSize.width, windowSize.height);
 #else
 	int flags = 0;
-	if (sgOptions.Graphics.bUpscale) {
-		if (!gbForceWindowed && sgOptions.Graphics.bFullscreen) {
+	if (*sgOptions.Graphics.upscale) {
+		if (!gbForceWindowed && *sgOptions.Graphics.fullscreen) {
 			flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 		}
 		SDL_SetWindowResizable(ghMainWnd, SDL_TRUE);
-	} else if (!gbForceWindowed && sgOptions.Graphics.bFullscreen) {
+	} else if (!gbForceWindowed && *sgOptions.Graphics.fullscreen) {
 		flags |= SDL_WINDOW_FULLSCREEN;
 		SDL_SetWindowResizable(ghMainWnd, SDL_FALSE);
 	}

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -296,6 +296,34 @@ void ReinitializeRenderer()
 #endif
 }
 
+void ResizeWindow()
+{
+	if (ghMainWnd == nullptr)
+		return;
+
+	Size windowSize = GetPreferedWindowSize();
+
+#ifdef USE_SDL1
+	SetVideoModeToPrimary(!gbForceWindowed && sgOptions.Graphics.bFullscreen, windowSize.width, windowSize.height);
+#else
+	int flags = 0;
+	if (sgOptions.Graphics.bUpscale) {
+		if (!gbForceWindowed && sgOptions.Graphics.bFullscreen) {
+			flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+		}
+		SDL_SetWindowResizable(ghMainWnd, SDL_TRUE);
+	} else if (!gbForceWindowed && sgOptions.Graphics.bFullscreen) {
+		flags |= SDL_WINDOW_FULLSCREEN;
+		SDL_SetWindowResizable(ghMainWnd, SDL_FALSE);
+	}
+	SDL_SetWindowFullscreen(ghMainWnd, flags);
+
+	SDL_SetWindowSize(ghMainWnd, windowSize.width, windowSize.height);
+#endif
+
+	ReinitializeRenderer();
+}
+
 SDL_Surface *GetOutputSurface()
 {
 #ifdef USE_SDL1

--- a/Source/utils/ui_fwd.h
+++ b/Source/utils/ui_fwd.h
@@ -14,6 +14,7 @@ Uint16 GetViewportHeight();
 
 bool SpawnWindow(const char *lpWindowName);
 void ReinitializeRenderer();
+void ResizeWindow();
 void UiErrorOkDialog(const char *caption, const char *text, bool error = true);
 
 } // namespace devilution

--- a/Source/utils/ui_fwd.h
+++ b/Source/utils/ui_fwd.h
@@ -13,6 +13,7 @@ Uint16 GetScreenHeight();
 Uint16 GetViewportHeight();
 
 bool SpawnWindow(const char *lpWindowName);
+void ReinitializeRenderer();
 void UiErrorOkDialog(const char *caption, const char *text, bool error = true);
 
 } // namespace devilution


### PR DESCRIPTION
Notes:
- Add the possibility to resize the game and switch between window and fullscreen mode.
- Add the possibility to recreate upscale renderer (similar to #688 but not exactly the same).
- Added the follow settings to settings menu
  - Fullscreen
  - Fit to Screen
  - Upscale
  - Integer Scaling
  - Vertical Sync
- Fixed Scaling Quality doesn't instantly update when changed in settingsmenu,
- Settings are only active if supported (for example upscale is not supported in sdl 1).
- Added new VS configuration for SDL 1 on windows (based on the work done in #3392).
- Tested with SDL 2 and SDL 1 on windows.
- Is the groundwork for resolution changes,