### PR TITLE
Correct DPI on devices that apply extra scaling

### DIFF
--- a/Source/controls/touch/gamepad.cpp
+++ b/Source/controls/touch/gamepad.cpp
@@ -62,7 +62,11 @@ void InitializeVirtualGamepad()
 	if (SDL_GetDisplayDPI(displayIndex, nullptr, &hdpi, &vdpi) == 0) {
 		int clientWidth;
 		int clientHeight;
-		SDL_GetRendererOutputSize(renderer, &clientWidth, &clientHeight);
+		if (renderer != nullptr)
+			SDL_GetRendererOutputSize(renderer, &clientWidth, &clientHeight);
+		else
+			SDL_GetWindowSize(ghMainWnd, &clientWidth, &clientHeight);
+
 		hdpi *= static_cast<float>(gnScreenWidth) / clientWidth;
 		vdpi *= static_cast<float>(gnScreenHeight) / clientHeight;
 

--- a/Source/controls/touch/gamepad.cpp
+++ b/Source/controls/touch/gamepad.cpp
@@ -62,7 +62,7 @@ void InitializeVirtualGamepad()
 	if (SDL_GetDisplayDPI(displayIndex, nullptr, &hdpi, &vdpi) == 0) {
 		int clientWidth;
 		int clientHeight;
-		SDL_GetWindowSize(ghMainWnd, &clientWidth, &clientHeight);
+		SDL_GetRendererOutputSize(renderer, &clientWidth, &clientHeight);
 		hdpi *= static_cast<float>(gnScreenWidth) / clientWidth;
 		vdpi *= static_cast<float>(gnScreenHeight) / clientHeight;
 


### PR DESCRIPTION
on iOS the windows size is reported in a size that matches the DPI of the original iPhone rather then the actual DPI. Getting the render size should give us the correct scale for all devices.

Hopefully this also works correctly on the iPhone 8+ which adds another layer of craziness by rendering at a higher resolution then the actually pixel count and then reports a fraction of that as it's windows size...
https://www.paintcodeapp.com/news/ultimate-guide-to-iphone-resolutions