### PR TITLE
Use distro zlib package for MinGW instead of SDL-ttf zlib dll

### DIFF
--- a/.github/workflows/Windows_x64.yml
+++ b/.github/workflows/Windows_x64.yml
@@ -22,13 +22,6 @@ jobs:
         sudo apt install -y cmake gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 pkg-config-mingw-w64-x86-64 libz-mingw-w64-dev dpkg-dev wget git sudo smpq &&
         sudo Packaging/windows/mingw-prep64.sh
 
-    - name: Cache CMake build folder
-      uses: actions/cache@v2
-      with:
-        path: build
-        key: windows-x86_64-cmake-v2-${{ github.sha }}
-        restore-keys: windows-x86_64-cmake-v2-
-
     - name: Configure CMake
       shell: bash
       working-directory: ${{github.workspace}}

--- a/.github/workflows/Windows_x64.yml
+++ b/.github/workflows/Windows_x64.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Create Build Environment
       run: >
         sudo apt update &&
-        sudo apt install -y cmake gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 pkg-config-mingw-w64-x86-64 dpkg-dev wget git sudo smpq &&
+        sudo apt install -y cmake gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 pkg-config-mingw-w64-x86-64 libz-mingw-w64-dev dpkg-dev wget git sudo smpq &&
         sudo Packaging/windows/mingw-prep64.sh
 
     - name: Cache CMake build folder

--- a/.github/workflows/Windows_x86.yml
+++ b/.github/workflows/Windows_x86.yml
@@ -22,13 +22,6 @@ jobs:
         sudo apt install -y cmake gcc-mingw-w64-i686 g++-mingw-w64-i686 pkg-config-mingw-w64-i686 libz-mingw-w64-dev dpkg-dev wget git sudo smpq &&
         sudo Packaging/windows/mingw-prep.sh
 
-    - name: Cache CMake build folder
-      uses: actions/cache@v2
-      with:
-        path: build
-        key: windows-x86-cmake-v2-${{ github.sha }}
-        restore-keys: windows-x86-cmake-v2-
-
     - name: Configure CMake
       shell: bash
       working-directory: ${{github.workspace}}

--- a/.github/workflows/Windows_x86.yml
+++ b/.github/workflows/Windows_x86.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Create Build Environment
       run: >
         sudo apt update &&
-        sudo apt install -y cmake gcc-mingw-w64-i686 g++-mingw-w64-i686 pkg-config-mingw-w64-i686 dpkg-dev wget git sudo smpq &&
+        sudo apt install -y cmake gcc-mingw-w64-i686 g++-mingw-w64-i686 pkg-config-mingw-w64-i686 libz-mingw-w64-dev dpkg-dev wget git sudo smpq &&
         sudo Packaging/windows/mingw-prep.sh
 
     - name: Cache CMake build folder

--- a/Packaging/windows/mingw-prep.sh
+++ b/Packaging/windows/mingw-prep.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
 SDLDEV_VERS=2.0.18
-SDLTTF_VERS=2.0.15
 SODIUM_VERS=1.0.18
-ZLIB_VERS=1.2.11
 
 # exit when any command fails
 set -euo pipefail
@@ -35,19 +33,11 @@ fi
 
 wget -q https://www.libsdl.org/release/SDL2-devel-${SDLDEV_VERS}-mingw.tar.gz -OSDL2-devel-${SDLDEV_VERS}-mingw.tar.gz
 tar -xzf SDL2-devel-${SDLDEV_VERS}-mingw.tar.gz
-wget -q https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${SDLTTF_VERS}-mingw.tar.gz -OSDL2_ttf-devel-${SDLTTF_VERS}-mingw.tar.gz
-tar -xzf SDL2_ttf-devel-${SDLTTF_VERS}-mingw.tar.gz
 $SUDO cp -r SDL2*/${MINGW_ARCH}/* ${MINGW_PREFIX}
 
 wget -q https://github.com/jedisct1/libsodium/releases/download/${SODIUM_VERS}-RELEASE/libsodium-${SODIUM_VERS}-mingw.tar.gz -Olibsodium-${SODIUM_VERS}-mingw.tar.gz
 tar -xzf libsodium-${SODIUM_VERS}-mingw.tar.gz --no-same-owner
 $SUDO cp -r libsodium-${SODIUM_ARCH}/* ${MINGW_PREFIX}
-
-wget -q https://zlib.net/zlib-${ZLIB_VERS}.tar.gz -Ozlib-${ZLIB_VERS}.tar.gz
-tar -xzf zlib-${ZLIB_VERS}.tar.gz
-$SUDO cp zlib-${ZLIB_VERS}/zconf.h ${MINGW_PREFIX}/include
-$SUDO cp zlib-${ZLIB_VERS}/zlib.h ${MINGW_PREFIX}/include
-$SUDO ln -sf ../bin/zlib1.dll ${MINGW_PREFIX}/lib/libzlib1.dll.a
 
 # Fixup pkgconfig prefix:
 find "${MINGW_PREFIX}/lib/pkgconfig/" -name '*.pc' -exec \

--- a/docs/building.md
+++ b/docs/building.md
@@ -117,7 +117,7 @@ cmake --build build -j $(sysctl -n hw.ncpuonline)
 Download the 32bit MinGW Development Libraries of [SDL2](https://www.libsdl.org/download-2.0.php) and [Libsodium](https://github.com/jedisct1/libsodium/releases) as well as headers for [zlib](https://zlib.net/zlib-1.2.11.tar.gz) and place them in `/usr/i686-w64-mingw32`. This can be done automatically by running `Packaging/windows/mingw-prep.sh`.
 
 ```
-sudo apt-get install cmake gcc-mingw-w64-i686 g++-mingw-w64-i686 pkg-config-mingw-w64-i686
+sudo apt-get install cmake gcc-mingw-w64-i686 g++-mingw-w64-i686 pkg-config-mingw-w64-i686 libz-mingw-w64-dev
 ```
 
 ### 64-bit
@@ -125,21 +125,21 @@ sudo apt-get install cmake gcc-mingw-w64-i686 g++-mingw-w64-i686 pkg-config-ming
 Download the 64bit MinGW Development Libraries of [SDL2](https://www.libsdl.org/download-2.0.php) and [Libsodium](https://github.com/jedisct1/libsodium/releases) as well as headers for [zlib](https://zlib.net/zlib-1.2.11.tar.gz) and place them in `/usr/x86_64-w64-mingw32`. This can be done automatically by running `Packaging/windows/mingw-prep64.sh`.
 
 ```
-sudo apt-get install cmake gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 pkg-config-mingw-w64-x86-64
+sudo apt-get install cmake gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 pkg-config-mingw-w64-x86-64 libz-mingw-w64-dev
 ```
 ### Compiling
 
 ### 32-bit
 
 ```bash
-cmake -S. -Bbuild -DCMAKE_TOOLCHAIN_FILE=../CMake/platforms/mingwcc.toolchain.cmake -DCMAKE_BUILD_TYPE=Release
+cmake -S. -Bbuild -DCMAKE_TOOLCHAIN_FILE=../CMake/platforms/mingwcc.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DDEVILUTIONX_SYSTEM_BZIP2=OFF
 cmake --build build -j $(getconf _NPROCESSORS_ONLN)
 ```
 
 ### 64-bit
 
 ```bash
-cmake -S. -Bbuild -DCMAKE_TOOLCHAIN_FILE=../CMake/mingwcc64.toolchain.cmake -DCMAKE_BUILD_TYPE=Release
+cmake -S. -Bbuild -DCMAKE_TOOLCHAIN_FILE=../CMake/mingwcc64.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DDEVILUTIONX_SYSTEM_BZIP2=OFF
 cmake --build build -j $(getconf _NPROCESSORS_ONLN)
 ```
 


### PR DESCRIPTION
Modifies the MinGW build scripts and instructions to use the `libz-mingw-w64-dev` package instead of the zlib dll provided by SDL-ttf. I also added `-DDEVILUTIONX_SYSTEM_BZIP2=OFF` to the build instructions since I couldn't find a package for it.

This resolves #3037