### PR TITLE
Settings: add resolution option

### DIFF
--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -144,8 +144,6 @@ void InitRecording(int recordNumber)
 }
 void OverrideOptions()
 {
-	sgOptions.Graphics.nWidth = DemoGraphicsWidth;
-	sgOptions.Graphics.nHeight = DemoGraphicsHeight;
 #ifndef USE_SDL1
 	sgOptions.Graphics.fitToScreen.SetValue(false);
 #endif

--- a/Source/options.h
+++ b/Source/options.h
@@ -216,6 +216,31 @@ private:
 	void CheckLanguagesAreInitialized() const;
 };
 
+class OptionEntryResolution : public OptionEntryListBase {
+public:
+	OptionEntryResolution();
+
+	void LoadFromIni(string_view category) override;
+	void SaveToIni(string_view category) const override;
+
+	[[nodiscard]] size_t GetListSize() const override;
+	[[nodiscard]] string_view GetListDescription(size_t index) const override;
+	[[nodiscard]] size_t GetActiveListIndex() const override;
+	void SetActiveListIndex(size_t index) override;
+
+	Size operator*() const
+	{
+		return size;
+	}
+
+private:
+	/** @brief View size. */
+	Size size;
+	mutable std::vector<std::pair<Size, std::string>> resolutions;
+
+	void CheckResolutionsAreInitialized() const;
+};
+
 struct OptionCategoryBase {
 	OptionCategoryBase(string_view key, string_view name, string_view description);
 
@@ -295,10 +320,7 @@ struct GraphicsOptions : OptionCategoryBase {
 	GraphicsOptions();
 	std::vector<OptionEntryBase *> GetEntries() override;
 
-	/** @brief Render width. */
-	int nWidth;
-	/** @brief Render height. */
-	int nHeight;
+	OptionEntryResolution resolution;
 	/** @brief Run in fullscreen or windowed mode. */
 	OptionEntryBoolean fullscreen;
 #if !defined(USE_SDL1) || defined(__3DS__)

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -100,7 +100,7 @@ void AdjustToScreenGeometry(Size windowSize)
 
 Size GetPreferredWindowSize()
 {
-	Size windowSize = { sgOptions.Graphics.nWidth, sgOptions.Graphics.nHeight };
+	Size windowSize = *sgOptions.Graphics.resolution;
 
 #ifndef USE_SDL1
 	if (*sgOptions.Graphics.upscale && *sgOptions.Graphics.fitToScreen) {


### PR DESCRIPTION
This pr allows to change the resolution ingame.

Notes:
- List with resolutions if populated by monitor resolutions (`SDL_ListModes` / `SDL_GetDisplayMode`).
- if `ini` contains a resolution that is not part of the monitor resolutions it is preserved.
- Default resolution (640x480) is always added explicitly.
- Tested with SDL 2 and SDL 1 on windows.

![grafik](https://user-images.githubusercontent.com/25415264/144895545-95d8715f-8ce8-43d6-a752-0ea307b4daa1.png)