### PR TITLE
Resize PalSurface when resizing the game window

### DIFF
--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -92,8 +92,6 @@ void CreateBackBuffer()
 	// time the global `palette` is changed. No need to do anything here as
 	// the global `palette` doesn't have any colors set yet.
 #endif
-
-	pal_surface_palette_version = 1;
 }
 
 void LockBufPriv()
@@ -144,6 +142,7 @@ void dx_init()
 
 	palette_init();
 	CreateBackBuffer();
+	pal_surface_palette_version = 1;
 }
 
 void lock_buf(int idx) // NOLINT(misc-unused-parameters)
@@ -216,6 +215,12 @@ void dx_reinit()
 		ErrSdl();
 	}
 #endif
+	force_redraw = 255;
+}
+
+void dx_resize()
+{
+	CreateBackBuffer();
 	force_redraw = 255;
 }
 

--- a/Source/dx.h
+++ b/Source/dx.h
@@ -19,6 +19,7 @@ void lock_buf(int idx);
 void unlock_buf(int idx);
 void dx_cleanup();
 void dx_reinit();
+void dx_resize();
 void InitPalette();
 void BltFast(SDL_Rect *srcRect, SDL_Rect *dstRect);
 void Blit(SDL_Surface *src, SDL_Rect *srcRect, SDL_Rect *dstRect);

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -17,6 +17,7 @@
 #include "controls/devices/joystick.h"
 #include "controls/devices/kbcontroller.h"
 #include "controls/game_controls.h"
+#include "dx.h"
 #include "options.h"
 #include "utils/log.hpp"
 #include "utils/sdl_wrap.h"
@@ -321,6 +322,7 @@ void ResizeWindow()
 #endif
 
 	ReinitializeRenderer();
+	dx_resize();
 }
 
 SDL_Surface *GetOutputSurface()


### PR DESCRIPTION
When the `PalSurface` is smaller than the game window, it causes graphical glitches and buffer overruns. This resolves the issue I found when fiddling with the resolution settings PR (https://github.com/diasurgical/devilutionX/pull/3688#issuecomment-987482770).