### PR TITLE
Amiga: Cleanup build process

### DIFF
--- a/CMake/platforms/amiga.cmake
+++ b/CMake/platforms/amiga.cmake
@@ -15,3 +15,5 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-attributes")
 
 # `fseeko` fails to link on Amiga.
 add_definitions(-Dfseeko=fseek)
+
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/Packaging/amiga/devilutionx.info" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")

--- a/Packaging/amiga/Dockerfile
+++ b/Packaging/amiga/Dockerfile
@@ -4,8 +4,7 @@ RUN mkdir /devilutionx-deps-build
 COPY Packaging/amiga/prep.sh /devilutionx-deps-build/prep.sh
 RUN cd /devilutionx-deps-build && ./prep.sh
 
-CMD mkdir -p build-amiga && cd build-amiga && \
-	PKG_CONFIG_PATH=/opt/m68k-amigaos/lib/pkgconfig/:/opt/m68k-amigaos/share/pkgconfig/ \
-		cmake -DBINARY_RELEASE=ON -DM68K_CPU=68040 -DM68K_FPU=hard \
-		-DM68K_COMMON="-s -ffast-math -O3 -noixemul -D__BIG_ENDIAN__ -D__AMIGA__ -fpermissive" .. && \
-	cmake --build . -j $(nproc)
+CMD PKG_CONFIG_PATH=/opt/m68k-amigaos/usr/lib/pkgconfig/:/opt/m68k-amigaos/usr/share/pkgconfig/ \
+		cmake -S. -Bbuild-amiga -DBINARY_RELEASE=ON -DM68K_CPU=68040 -DM68K_FPU=hard \
+		-DM68K_COMMON="-s -ffast-math -O3 -noixemul -D__BIG_ENDIAN__ -D__AMIGA__ -fpermissive" && \
+	cmake --build build-amiga -j $(nproc)

--- a/Packaging/amiga/prep.sh
+++ b/Packaging/amiga/prep.sh
@@ -13,6 +13,17 @@ export M68K_COMMON="-s -ffast-math -fomit-frame-pointer"
 export M68K_CFLAGS="${M68K_CPU_FPU} ${M68K_COMMON}"
 export M68K_CXXFLAGS="${M68K_CPU_FPU} ${M68K_COMMON}"
 
+PARALLELISM="$(getconf _NPROCESSORS_ONLN)"
+
+declare -ra CMAKE_FLAGS=(
+  -DM68K_CPU="$M68K_CPU"
+  -DM68K_FPU="$M68K_FPU"
+  -DM68K_COMMON="$M68K_COMMON"
+  -DBUILD_SHARED_LIBS=OFF
+  -DCMAKE_BUILD_TYPE=Release
+  -DCMAKE_INSTALL_PREFIX="${SYSROOT}/usr"
+)
+
 mkdir -p deps
 mkdir -p ${SYSROOT}/usr/lib
 mkdir -p ${SYSROOT}/usr/include
@@ -22,16 +33,16 @@ cd deps
 wget https://www.zlib.net/zlib-1.2.11.tar.gz -O zlib-1.2.11.tar.gz
 tar -xvf zlib-1.2.11.tar.gz
 mkdir -p zlib-1.2.11/build
-cd zlib-1.2.11/build
-cmake .. -DM68K_CPU="$M68K_CPU" -DM68K_FPU="$M68K_FPU" -DM68K_COMMON="${M68K_COMMON} -O3 -fno-exceptions -w -noixemul -DBIG_ENDIAN -DAMIGA -fpermissive -std=c++14"
-cmake --build . --config Release --target install -- -j$(getconf _NPROCESSORS_ONLN)
-cd ../..
+cd zlib-1.2.11
+cmake -S. -Bbuild "${CMAKE_FLAGS[@]}" -DM68K_COMMON="${M68K_COMMON} -O3 -fno-exceptions -w -noixemul -DBIG_ENDIAN -DAMIGA -fpermissive -std=c++14"
+cmake --build build -j"$PARALLELISM" --config Release --target install
+cd ..
 
 # SDL1.2
 wget https://github.com/AmigaPorts/libSDL12/archive/master.tar.gz -O SDL-1.2.tar.gz
 tar -xvf SDL-1.2.tar.gz
 cd libSDL12-master
-make PREFX=${SYSROOT} PREF=${SYSROOT} -j$(getconf _NPROCESSORS_ONLN)
+make PREFX=${SYSROOT} PREF=${SYSROOT} -j"$PARALLELISM"
 mkdir -p ${SYSROOT}/usr/lib
 mkdir -p ${SYSROOT}/usr/include
 cp -fvr libSDL.a ${SYSROOT}/usr/lib/

--- a/docs/building.md
+++ b/docs/building.md
@@ -336,27 +336,17 @@ docker build -f Packaging/amiga/Dockerfile -t devilutionx-amiga .
 ### Build DevilutionX Amiga binary
 
 ~~~ bash
-docker run --rm -v "${PWD}:/work" devilutionx-amiga
-sudo chown -R "${USER}:" build-amiga
+docker run -u "$(id -u "$USER"):$(id -g "$USER")" --rm -v "${PWD}:/work" devilutionx-amiga
 ~~~
 
 The command above builds DevilutionX in release mode.
 For other build options, you can run the container interactively:
 
 ~~~ bash
-docker run -ti --rm -v "${PWD}:/work" devilutionx-amiga bash
+docker run -u "$(id -u "$USER"):$(id -g "$USER")" -ti --rm -v "${PWD}:/work" devilutionx-amiga bash
 ~~~
 
 See the `CMD` in `Packaging/amiga/Dockerfile` for reference.
-
-### Copy the necessary files
-
-Outside of the Docker container, from the DevilutionX directory, run:
-
-~~~ bash
-sudo chown -R "${USER}:" build-amiga
-cp Packaging/amiga/devilutionx.info build-amiga/
-~~~
 
 To actually start DevilutionX, increase the stack size to 50KiB in Amiga.
 You can do this by selecting the DevilutionX icon, then hold right mouse button and


### PR DESCRIPTION
1. Run Docker as the current user instead of root, removing the need to chown directories.
2. Copy `devilutionx.info` via CMake, removing the need to do it manually.
3. Cleanup `prep.sh` somewhat.