### PR TITLE
Apply clang-tidy configuration to (some of) ui_item.h

### DIFF
--- a/Source/DiabloUI/button.cpp
+++ b/Source/DiabloUI/button.cpp
@@ -16,20 +16,15 @@ void LoadSmlButtonArt()
 
 void RenderButton(UiButton *button)
 {
-	int frame;
-	if (button->m_pressed) {
-		frame = UiButton::PRESSED;
-	} else {
-		frame = UiButton::DEFAULT;
-	}
-	DrawArt({ button->m_rect.x, button->m_rect.y }, button->m_art, frame, button->m_rect.w, button->m_rect.h);
+	DrawArt({ button->m_rect.x, button->m_rect.y }, button->GetArt(), button->GetFrame(), button->m_rect.w, button->m_rect.h);
 
 	Rectangle textRect { { button->m_rect.x, button->m_rect.y }, { button->m_rect.w, button->m_rect.h } };
-	if (!button->m_pressed)
+	if (!button->IsPressed()) {
 		--textRect.position.y;
+	}
 
 	const Surface &out = Surface(DiabloUiSurface());
-	DrawString(out, button->m_text, textRect, UiFlags::AlignCenter | UiFlags::FontSizeDialog | UiFlags::ColorDialogWhite);
+	DrawString(out, button->GetText(), textRect, UiFlags::AlignCenter | UiFlags::FontSizeDialog | UiFlags::ColorDialogWhite);
 }
 
 bool HandleMouseEventButton(const SDL_Event &event, UiButton *button)
@@ -38,10 +33,13 @@ bool HandleMouseEventButton(const SDL_Event &event, UiButton *button)
 		return false;
 	switch (event.type) {
 	case SDL_MOUSEBUTTONUP:
-		button->m_action();
-		return true;
+		if (button->IsPressed()) {
+			button->Activate();
+			return true;
+		}
+		return false;
 	case SDL_MOUSEBUTTONDOWN:
-		button->m_pressed = true;
+		button->Press();
 		return true;
 	default:
 		return false;
@@ -50,7 +48,7 @@ bool HandleMouseEventButton(const SDL_Event &event, UiButton *button)
 
 void HandleGlobalMouseUpButton(UiButton *button)
 {
-	button->m_pressed = false;
+	button->Release();
 }
 
 } // namespace devilution

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -116,7 +116,7 @@ void UiInitList(void (*fnFocus)(int value), void (*fnSelect)(int value), void (*
 	textInputActive = false;
 	UiScrollbar *uiScrollbar = nullptr;
 	for (const auto &item : items) {
-		if (item->m_type == UiType::Edit) {
+		if (item->IsType(UiType::Edit)) {
 			auto *pItemUIEdit = static_cast<UiEdit *>(item.get());
 			SDL_SetTextInputRect(&item->m_rect);
 			textInputActive = true;
@@ -132,12 +132,12 @@ void UiInitList(void (*fnFocus)(int value), void (*fnSelect)(int value), void (*
 #endif
 			UiTextInput = pItemUIEdit->m_value;
 			UiTextInputLen = pItemUIEdit->m_max_length;
-		} else if (item->m_type == UiType::List) {
+		} else if (item->IsType(UiType::List)) {
 			auto *uiList = static_cast<UiList *>(item.get());
 			SelectedItemMax = std::max(uiList->m_vecItems.size() - 1, static_cast<size_t>(0));
 			ListViewportSize = uiList->viewportSize;
 			gUiList = uiList;
-		} else if (item->m_type == UiType::Scrollbar) {
+		} else if (item->IsType(UiType::Scrollbar)) {
 			uiScrollbar = static_cast<UiScrollbar *>(item.get());
 		}
 	}
@@ -852,7 +852,7 @@ void RenderItem(UiItemBase *item)
 {
 	if (item->IsHidden())
 		return;
-	switch (item->m_type) {
+	switch (item->GetType()) {
 	case UiType::Text:
 		Render(static_cast<UiText *>(item));
 		break;
@@ -961,7 +961,7 @@ bool HandleMouseEvent(const SDL_Event &event, UiItemBase *item)
 {
 	if (item->IsNotInteractive() || !IsInsideRect(event, item->m_rect))
 		return false;
-	switch (item->m_type) {
+	switch (item->GetType()) {
 	case UiType::ArtTextButton:
 		return HandleMouseEventArtTextButton(event, static_cast<UiArtTextButton *>(item));
 	case UiType::Button:
@@ -1018,8 +1018,9 @@ bool UiItemMouseEvents(SDL_Event *event, const std::vector<UiItemBase *> &items)
 	if (event->type == SDL_MOUSEBUTTONUP && event->button.button == SDL_BUTTON_LEFT) {
 		scrollBarState.downArrowPressed = scrollBarState.upArrowPressed = false;
 		for (const auto &item : items) {
-			if (item->m_type == UiType::Button)
+			if (item->IsType(UiType::Button)) {
 				HandleGlobalMouseUpButton(static_cast<UiButton *>(item));
+			}
 		}
 	}
 
@@ -1048,8 +1049,9 @@ bool UiItemMouseEvents(SDL_Event *event, const std::vector<std::unique_ptr<UiIte
 	if (event->type == SDL_MOUSEBUTTONUP && event->button.button == SDL_BUTTON_LEFT) {
 		scrollBarState.downArrowPressed = scrollBarState.upArrowPressed = false;
 		for (const auto &item : items) {
-			if (item->m_type == UiType::Button)
+			if (item->IsType(UiType::Button)) {
 				HandleGlobalMouseUpButton(static_cast<UiButton *>(item.get()));
+			}
 		}
 	}
 

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -769,14 +769,14 @@ void Render(const UiArtText *uiArtText)
 void Render(const UiImage *uiImage)
 {
 	int x = uiImage->m_rect.x;
-	if (uiImage->IsCentered() && uiImage->m_art != nullptr) {
-		const int xOffset = GetCenterOffset(uiImage->m_art->w(), uiImage->m_rect.w);
+	if (uiImage->IsCentered() && uiImage->GetArt() != nullptr) {
+		const int xOffset = GetCenterOffset(uiImage->GetArt()->w(), uiImage->m_rect.w);
 		x += xOffset;
 	}
-	if (uiImage->m_animated) {
-		DrawAnimatedArt(uiImage->m_art, { x, uiImage->m_rect.y });
+	if (uiImage->IsAnimated()) {
+		DrawAnimatedArt(uiImage->GetArt(), { x, uiImage->m_rect.y });
 	} else {
-		DrawArt({ x, uiImage->m_rect.y }, uiImage->m_art, uiImage->m_frame, uiImage->m_rect.w);
+		DrawArt({ x, uiImage->m_rect.y }, uiImage->GetArt(), uiImage->GetFrame(), uiImage->m_rect.w);
 	}
 }
 

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -146,9 +146,9 @@ void UiInitList(void (*fnFocus)(int value), void (*fnSelect)(int value), void (*
 
 	if (uiScrollbar != nullptr) {
 		if (ListViewportSize >= static_cast<std::size_t>(SelectedItemMax + 1)) {
-			uiScrollbar->add_flag(UiFlags::ElementHidden);
+			uiScrollbar->Hide();
 		} else {
-			uiScrollbar->remove_flag(UiFlags::ElementHidden);
+			uiScrollbar->Show();
 		}
 	}
 }
@@ -755,7 +755,7 @@ void Render(UiText *uiText)
 	Rectangle rect { { uiText->m_rect.x, uiText->m_rect.y }, { uiText->m_rect.w, uiText->m_rect.h } };
 
 	const Surface &out = Surface(DiabloUiSurface());
-	DrawString(out, uiText->m_text, rect, uiText->m_iFlags | UiFlags::FontSizeDialog);
+	DrawString(out, uiText->m_text, rect, uiText->GetFlags() | UiFlags::FontSizeDialog);
 }
 
 void Render(const UiArtText *uiArtText)
@@ -763,13 +763,13 @@ void Render(const UiArtText *uiArtText)
 	Rectangle rect { { uiArtText->m_rect.x, uiArtText->m_rect.y }, { uiArtText->m_rect.w, uiArtText->m_rect.h } };
 
 	const Surface &out = Surface(DiabloUiSurface());
-	DrawString(out, uiArtText->text(), rect, uiArtText->m_iFlags, uiArtText->spacing(), uiArtText->lineHeight());
+	DrawString(out, uiArtText->text(), rect, uiArtText->GetFlags(), uiArtText->spacing(), uiArtText->lineHeight());
 }
 
 void Render(const UiImage *uiImage)
 {
 	int x = uiImage->m_rect.x;
-	if (HasAnyOf(uiImage->m_iFlags, UiFlags::AlignCenter) && uiImage->m_art != nullptr) {
+	if (uiImage->IsCentered() && uiImage->m_art != nullptr) {
 		const int xOffset = GetCenterOffset(uiImage->m_art->w(), uiImage->m_rect.w);
 		x += xOffset;
 	}
@@ -785,7 +785,7 @@ void Render(const UiArtTextButton *uiButton)
 	Rectangle rect { { uiButton->m_rect.x, uiButton->m_rect.y }, { uiButton->m_rect.w, uiButton->m_rect.h } };
 
 	const Surface &out = Surface(DiabloUiSurface());
-	DrawString(out, uiButton->m_text, rect, uiButton->m_iFlags);
+	DrawString(out, uiButton->m_text, rect, uiButton->GetFlags());
 }
 
 void Render(const UiList *uiList)
@@ -799,10 +799,10 @@ void Render(const UiList *uiList)
 			DrawSelector(rect);
 
 		Rectangle rectangle { { rect.x, rect.y }, { rect.w, rect.h } };
-		if (item->args.size() == 0)
-			DrawString(out, item->m_text, rectangle, uiList->m_iFlags | item->uiFlags, uiList->spacing());
+		if (item->args.empty())
+			DrawString(out, item->m_text, rectangle, uiList->GetFlags() | item->uiFlags, uiList->spacing());
 		else
-			DrawStringWithColors(out, item->m_text, item->args, rectangle, uiList->m_iFlags | item->uiFlags, uiList->spacing());
+			DrawStringWithColors(out, item->m_text, item->args, rectangle, uiList->GetFlags() | item->uiFlags, uiList->spacing());
 	}
 }
 
@@ -845,12 +845,12 @@ void Render(const UiEdit *uiEdit)
 	Rectangle rect { { uiEdit->m_rect.x + 43, uiEdit->m_rect.y + 1 }, { uiEdit->m_rect.w - 86, uiEdit->m_rect.h } };
 
 	const Surface &out = Surface(DiabloUiSurface());
-	DrawString(out, uiEdit->m_value, rect, uiEdit->m_iFlags | UiFlags::TextCursor);
+	DrawString(out, uiEdit->m_value, rect, uiEdit->GetFlags() | UiFlags::TextCursor);
 }
 
 void RenderItem(UiItemBase *item)
 {
-	if (item->has_flag(UiFlags::ElementHidden))
+	if (item->IsHidden())
 		return;
 	switch (item->m_type) {
 	case UiType::Text:
@@ -959,7 +959,7 @@ bool HandleMouseEventScrollBar(const SDL_Event &event, const UiScrollbar *uiSb)
 
 bool HandleMouseEvent(const SDL_Event &event, UiItemBase *item)
 {
-	if (item->has_any_flag(UiFlags::ElementHidden | UiFlags::ElementDisabled) || !IsInsideRect(event, item->m_rect))
+	if (item->IsNotInteractive() || !IsInsideRect(event, item->m_rect))
 		return false;
 	switch (item->m_type) {
 	case UiType::ArtTextButton:

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -763,7 +763,7 @@ void Render(const UiArtText *uiArtText)
 	Rectangle rect { { uiArtText->m_rect.x, uiArtText->m_rect.y }, { uiArtText->m_rect.w, uiArtText->m_rect.h } };
 
 	const Surface &out = Surface(DiabloUiSurface());
-	DrawString(out, uiArtText->text(), rect, uiArtText->GetFlags(), uiArtText->spacing(), uiArtText->lineHeight());
+	DrawString(out, uiArtText->GetText(), rect, uiArtText->GetFlags(), uiArtText->GetSpacing(), uiArtText->GetLineHeight());
 }
 
 void Render(const UiImage *uiImage)
@@ -800,9 +800,9 @@ void Render(const UiList *uiList)
 
 		Rectangle rectangle { { rect.x, rect.y }, { rect.w, rect.h } };
 		if (item->args.empty())
-			DrawString(out, item->m_text, rectangle, uiList->GetFlags() | item->uiFlags, uiList->spacing());
+			DrawString(out, item->m_text, rectangle, uiList->GetFlags() | item->uiFlags, uiList->GetSpacing());
 		else
-			DrawStringWithColors(out, item->m_text, item->args, rectangle, uiList->GetFlags() | item->uiFlags, uiList->spacing());
+			DrawStringWithColors(out, item->m_text, item->args, rectangle, uiList->GetFlags() | item->uiFlags, uiList->GetSpacing());
 	}
 }
 

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -750,12 +750,12 @@ void UiPollAndRender()
 
 namespace {
 
-void Render(UiText *uiText)
+void Render(const UiText *uiText)
 {
 	Rectangle rect { { uiText->m_rect.x, uiText->m_rect.y }, { uiText->m_rect.w, uiText->m_rect.h } };
 
 	const Surface &out = Surface(DiabloUiSurface());
-	DrawString(out, uiText->m_text, rect, uiText->GetFlags() | UiFlags::FontSizeDialog);
+	DrawString(out, uiText->GetText(), rect, uiText->GetFlags() | UiFlags::FontSizeDialog);
 }
 
 void Render(const UiArtText *uiArtText)

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -785,7 +785,7 @@ void Render(const UiArtTextButton *uiButton)
 	Rectangle rect { { uiButton->m_rect.x, uiButton->m_rect.y }, { uiButton->m_rect.w, uiButton->m_rect.h } };
 
 	const Surface &out = Surface(DiabloUiSurface());
-	DrawString(out, uiButton->m_text, rect, uiButton->GetFlags());
+	DrawString(out, uiButton->GetText(), rect, uiButton->GetFlags());
 }
 
 void Render(const UiList *uiList)
@@ -882,9 +882,11 @@ void RenderItem(UiItemBase *item)
 
 bool HandleMouseEventArtTextButton(const SDL_Event &event, const UiArtTextButton *uiButton)
 {
-	if (event.type != SDL_MOUSEBUTTONDOWN || event.button.button != SDL_BUTTON_LEFT)
+	if (event.type != SDL_MOUSEBUTTONDOWN || event.button.button != SDL_BUTTON_LEFT) {
 		return false;
-	uiButton->m_action();
+	}
+
+	uiButton->Activate();
 	return true;
 }
 

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -75,7 +75,7 @@ void SelheroFree()
 
 void SelheroSetStats()
 {
-	SELHERO_DIALOG_HERO_IMG->m_frame = static_cast<int>(selhero_heroInfo.heroclass);
+	SELHERO_DIALOG_HERO_IMG->SetFrame(static_cast<int>(selhero_heroInfo.heroclass));
 	snprintf(textStats[0], sizeof(textStats[0]), "%i", selhero_heroInfo.level);
 	snprintf(textStats[1], sizeof(textStats[1]), "%i", selhero_heroInfo.strength);
 	snprintf(textStats[2], sizeof(textStats[2]), "%i", selhero_heroInfo.magic);
@@ -107,7 +107,7 @@ void SelheroListFocus(int value)
 		return;
 	}
 
-	SELHERO_DIALOG_HERO_IMG->m_frame = static_cast<int>(enum_size<HeroClass>::value);
+	SELHERO_DIALOG_HERO_IMG->SetFrame(static_cast<int>(enum_size<HeroClass>::value));
 	for (char *textStat : textStats)
 		strcpy(textStat, "--");
 	SELLIST_DIALOG_DELETE_BUTTON->SetFlags(baseFlags | UiFlags::ColorUiSilver | UiFlags::ElementDisabled);

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -102,7 +102,7 @@ void SelheroListFocus(int value)
 	if (selhero_SaveCount != 0 && index < selhero_SaveCount) {
 		memcpy(&selhero_heroInfo, &selhero_heros[index], sizeof(selhero_heroInfo));
 		SelheroSetStats();
-		SELLIST_DIALOG_DELETE_BUTTON->m_iFlags = baseFlags | UiFlags::ColorUiGold;
+		SELLIST_DIALOG_DELETE_BUTTON->SetFlags(baseFlags | UiFlags::ColorUiGold);
 		selhero_deleteEnabled = true;
 		return;
 	}
@@ -110,7 +110,7 @@ void SelheroListFocus(int value)
 	SELHERO_DIALOG_HERO_IMG->m_frame = static_cast<int>(enum_size<HeroClass>::value);
 	for (char *textStat : textStats)
 		strcpy(textStat, "--");
-	SELLIST_DIALOG_DELETE_BUTTON->m_iFlags = baseFlags | UiFlags::ColorUiSilver | UiFlags::ElementDisabled;
+	SELLIST_DIALOG_DELETE_BUTTON->SetFlags(baseFlags | UiFlags::ColorUiSilver | UiFlags::ElementDisabled);
 	selhero_deleteEnabled = false;
 }
 

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -45,7 +45,7 @@ public:
 
 	[[nodiscard]] bool IsHidden() const
 	{
-		return (uiFlags_ & UiFlags::ElementHidden) == UiFlags::ElementHidden;
+		return HasAnyOf(uiFlags_, UiFlags::ElementHidden);
 	}
 
 	[[nodiscard]] bool IsNotInteractive() const

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -92,9 +92,9 @@ class UiImage : public UiItemBase {
 public:
 	UiImage(Art *art, SDL_Rect rect, UiFlags flags = UiFlags::None, bool animated = false, int frame = 0)
 	    : UiItemBase(UiType::Image, rect, flags)
-	    , m_art(art)
-	    , m_animated(animated)
-	    , m_frame(frame)
+	    , art_(art)
+	    , animated_(animated)
+	    , frame_(frame)
 	{
 	}
 
@@ -105,10 +105,30 @@ public:
 		return HasAnyOf(GetFlags(), UiFlags::AlignCenter);
 	}
 
-	// private:
-	Art *m_art;
-	bool m_animated;
-	int m_frame;
+	[[nodiscard]] constexpr Art *GetArt() const
+	{
+		return art_;
+	}
+
+	[[nodiscard]] constexpr bool IsAnimated() const
+	{
+		return animated_;
+	}
+
+	[[nodiscard]] constexpr int GetFrame() const
+	{
+		return frame_;
+	}
+
+	void SetFrame(int frame)
+	{
+		frame_ = frame;
+	}
+
+private:
+	Art *art_;
+	bool animated_;
+	int frame_;
 };
 
 //=============================================================================
@@ -224,11 +244,11 @@ private:
 
 class UiEdit : public UiItemBase {
 public:
-	UiEdit(const char *hint, char *value, std::size_t max_length, bool allowEmpty, SDL_Rect rect, UiFlags flags = UiFlags::None)
+	UiEdit(const char *hint, char *value, std::size_t maxLength, bool allowEmpty, SDL_Rect rect, UiFlags flags = UiFlags::None)
 	    : UiItemBase(UiType::Edit, rect, flags)
 	    , m_hint(hint)
 	    , m_value(value)
-	    , m_max_length(max_length)
+	    , m_max_length(maxLength)
 	    , m_allowEmpty(allowEmpty)
 	{
 	}

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -191,7 +191,7 @@ public:
 
 class UiArtTextButton : public UiItemBase {
 public:
-	using Callback = void (*) ();
+	using Callback = void (*)();
 
 	UiArtTextButton(const char *text, Callback action, SDL_Rect rect, UiFlags flags = UiFlags::None)
 	    : UiItemBase(UiType::ArtTextButton, rect, flags)
@@ -262,30 +262,61 @@ public:
 
 class UiButton : public UiItemBase {
 public:
-	using Callback = void (*) ();
+	using Callback = void (*)();
 
 	UiButton(Art *art, const char *text, Callback action, SDL_Rect rect, UiFlags flags = UiFlags::None)
 	    : UiItemBase(UiType::Button, rect, flags)
-	    , m_art(art)
-	    , m_text(text)
-	    , m_action(action)
-	    , m_pressed(false)
+	    , art_(art)
+	    , text_(text)
+	    , action_(action)
+	    , pressed_(false)
 	{
 	}
 
-	enum FrameKey : uint8_t {
-		DEFAULT,
-		PRESSED,
-	};
+	[[nodiscard]] constexpr int GetFrame() const
+	{
+		// Frame 1 is a held button sprite, frame 0 is the default
+		return IsPressed() ? 1 : 0;
+	}
 
-	// private:
-	Art *m_art;
+	[[nodiscard]] constexpr Art *GetArt() const
+	{
+		return art_;
+	}
 
-	const char *m_text;
-	Callback m_action;
+	[[nodiscard]] constexpr string_view GetText() const
+	{
+		return text_;
+	}
+
+	constexpr void Activate() const
+	{
+		action_();
+	}
+
+	[[nodiscard]] constexpr bool IsPressed() const
+	{
+		return pressed_;
+	}
+
+	constexpr void Press()
+	{
+		pressed_ = true;
+	}
+
+	constexpr void Release()
+	{
+		pressed_ = false;
+	}
+
+private:
+	Art *art_;
+
+	const char *text_;
+	Callback action_;
 
 	// State
-	bool m_pressed;
+	bool pressed_;
 };
 
 //=============================================================================

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -145,7 +145,7 @@ public:
 
 	~UiArtText() override = default;
 
-	[[nodiscard]] constexpr const char *GetText() const
+	[[nodiscard]] constexpr string_view GetText() const
 	{
 		if (text_ != nullptr)
 			return text_;
@@ -191,10 +191,12 @@ public:
 
 class UiArtTextButton : public UiItemBase {
 public:
-	UiArtTextButton(const char *text, void (*action)(), SDL_Rect rect, UiFlags flags = UiFlags::None)
+	using Callback = void (*) ();
+
+	UiArtTextButton(const char *text, Callback action, SDL_Rect rect, UiFlags flags = UiFlags::None)
 	    : UiItemBase(UiType::ArtTextButton, rect, flags)
-	    , m_text(text)
-	    , m_action(action)
+	    , text_(text)
+	    , action_(action)
 	{
 	}
 
@@ -203,9 +205,19 @@ public:
 		UiItemBase::SetFlags(flags);
 	}
 
-	// private:
-	const char *m_text;
-	void (*m_action)();
+	[[nodiscard]] constexpr string_view GetText() const
+	{
+		return text_;
+	}
+
+	constexpr void Activate() const
+	{
+		action_();
+	}
+
+private:
+	const char *text_;
+	Callback action_;
 };
 
 //=============================================================================
@@ -250,7 +262,9 @@ public:
 
 class UiButton : public UiItemBase {
 public:
-	UiButton(Art *art, const char *text, void (*action)(), SDL_Rect rect, UiFlags flags = UiFlags::None)
+	using Callback = void (*) ();
+
+	UiButton(Art *art, const char *text, Callback action, SDL_Rect rect, UiFlags flags = UiFlags::None)
 	    : UiItemBase(UiType::Button, rect, flags)
 	    , m_art(art)
 	    , m_text(text)
@@ -268,7 +282,7 @@ public:
 	Art *m_art;
 
 	const char *m_text;
-	void (*m_action)();
+	Callback m_action;
 
 	// State
 	bool m_pressed;

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -26,39 +26,52 @@ enum class UiType {
 
 class UiItemBase {
 public:
+	virtual ~UiItemBase() = default;
+
+	[[nodiscard]] constexpr UiFlags GetFlags() const
+	{
+		return uiFlags_;
+	}
+
+	[[nodiscard]] constexpr bool IsHidden() const
+	{
+		return (uiFlags_ & UiFlags::ElementHidden) == UiFlags::ElementHidden;
+	}
+
+	[[nodiscard]] constexpr bool IsNotInteractive() const
+	{
+		return HasAnyOf(uiFlags_, UiFlags::ElementHidden | UiFlags::ElementDisabled);
+	}
+
+	constexpr void Hide()
+	{
+		uiFlags_ |= UiFlags::ElementHidden;
+	}
+
+	constexpr void Show()
+	{
+		uiFlags_ &= ~UiFlags::ElementHidden;
+	}
+
+protected:
 	UiItemBase(UiType type, SDL_Rect rect, UiFlags flags)
 	    : m_type(type)
 	    , m_rect(rect)
-	    , m_iFlags(flags)
+	    , uiFlags_(flags)
 	{
 	}
 
-	virtual ~UiItemBase() {};
-
-	bool has_flag(UiFlags flag) const
+	void SetFlags(UiFlags flags)
 	{
-		return (m_iFlags & flag) == flag;
+		uiFlags_ = flags;
 	}
 
-	bool has_any_flag(UiFlags flags) const
-	{
-		return HasAnyOf(m_iFlags, flags);
-	}
-
-	void add_flag(UiFlags flag)
-	{
-		m_iFlags |= flag;
-	}
-
-	void remove_flag(UiFlags flag)
-	{
-		m_iFlags &= ~flag;
-	}
-
-	// protected:
+public:
 	UiType m_type;
 	SDL_Rect m_rect;
-	UiFlags m_iFlags;
+
+private:
+	UiFlags uiFlags_;
 };
 
 //=============================================================================
@@ -73,7 +86,12 @@ public:
 	{
 	}
 
-	~UiImage() {};
+	~UiImage() override = default;
+
+	[[nodiscard]] constexpr bool IsCentered() const
+	{
+		return HasAnyOf(GetFlags(), UiFlags::AlignCenter);
+	}
 
 	// private:
 	Art *m_art;
@@ -166,6 +184,11 @@ public:
 	    , m_text(text)
 	    , m_action(action)
 	{
+	}
+
+	void SetFlags(UiFlags flags)
+	{
+		UiItemBase::SetFlags(flags);
 	}
 
 	// private:

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -123,9 +123,9 @@ public:
 	 */
 	UiArtText(const char *text, SDL_Rect rect, UiFlags flags = UiFlags::None, int spacing = 1, int lineHeight = -1)
 	    : UiItemBase(UiType::ArtText, rect, flags)
-	    , m_text(text)
-	    , m_spacing(spacing)
-	    , m_lineHeight(lineHeight)
+	    , text_(text)
+	    , spacing_(spacing)
+	    , lineHeight_(lineHeight)
 	{
 	}
 
@@ -137,36 +137,36 @@ public:
 	 */
 	UiArtText(const char **ptext, SDL_Rect rect, UiFlags flags = UiFlags::None, int spacing = 1, int lineHeight = -1)
 	    : UiItemBase(UiType::ArtText, rect, flags)
-	    , m_ptext(ptext)
-	    , m_spacing(spacing)
-	    , m_lineHeight(lineHeight)
+	    , textPointer_(ptext)
+	    , spacing_(spacing)
+	    , lineHeight_(lineHeight)
 	{
 	}
 
-	const char *text() const
+	~UiArtText() override = default;
+
+	[[nodiscard]] constexpr const char *GetText() const
 	{
-		if (m_text != nullptr)
-			return m_text;
-		return *m_ptext;
+		if (text_ != nullptr)
+			return text_;
+		return *textPointer_;
 	}
 
-	int spacing() const
+	[[nodiscard]] constexpr int GetSpacing() const
 	{
-		return m_spacing;
+		return spacing_;
 	}
 
-	int lineHeight() const
+	[[nodiscard]] constexpr int GetLineHeight() const
 	{
-		return m_lineHeight;
+		return lineHeight_;
 	}
-
-	~UiArtText() {};
 
 private:
-	const char *m_text = nullptr;
-	const char **m_ptext = nullptr;
-	int m_spacing = 1;
-	int m_lineHeight = -1;
+	const char *text_ = nullptr;
+	const char **textPointer_ = nullptr;
+	int spacing_;
+	int lineHeight_;
 };
 
 //=============================================================================
@@ -293,7 +293,7 @@ public:
 	{
 	}
 
-	~UiListItem() {};
+	~UiListItem() = default;
 
 	// private:
 	const char *m_text;
@@ -302,10 +302,10 @@ public:
 	UiFlags uiFlags;
 };
 
-typedef std::vector<std::unique_ptr<UiListItem>> vUiListItem;
-
 class UiList : public UiItemBase {
 public:
+	using vUiListItem = std::vector<std::unique_ptr<UiListItem>>;
+
 	UiList(const vUiListItem &vItems, size_t viewportSize, Sint16 x, Sint16 y, Uint16 item_width, Uint16 item_height, UiFlags flags = UiFlags::None, int spacing = 1)
 	    : UiItemBase(UiType::List, { x, y, item_width, static_cast<Uint16>(item_height * viewportSize) }, flags)
 	    , viewportSize(viewportSize)
@@ -313,15 +313,15 @@ public:
 	    , m_y(y)
 	    , m_width(item_width)
 	    , m_height(item_height)
-	    , m_spacing(spacing)
+	    , spacing_(spacing)
 	{
-		for (auto &item : vItems)
+		for (const auto &item : vItems)
 			m_vecItems.push_back(item.get());
 	}
 
-	~UiList() {};
+	~UiList() override = default;
 
-	SDL_Rect itemRect(int i) const
+	[[nodiscard]] SDL_Rect itemRect(int i) const
 	{
 		SDL_Rect tmp;
 		tmp.x = m_x;
@@ -340,14 +340,14 @@ public:
 		return index;
 	}
 
-	UiListItem *GetItem(int i) const
+	[[nodiscard]] UiListItem *GetItem(std::size_t i) const
 	{
 		return m_vecItems[i];
 	}
 
-	int spacing() const
+	[[nodiscard]] constexpr int GetSpacing() const
 	{
-		return m_spacing;
+		return spacing_;
 	}
 
 	// private:
@@ -355,6 +355,8 @@ public:
 	Sint16 m_x, m_y;
 	Uint16 m_width, m_height;
 	std::vector<UiListItem *> m_vecItems;
-	int m_spacing;
+
+private:
+	int spacing_;
 };
 } // namespace devilution

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -28,6 +28,16 @@ class UiItemBase {
 public:
 	virtual ~UiItemBase() = default;
 
+	[[nodiscard]] constexpr UiType GetType() const
+	{
+		return type_;
+	}
+
+	[[nodiscard]] constexpr bool IsType(UiType testType) const
+	{
+		return type_ == testType;
+	}
+
 	[[nodiscard]] constexpr UiFlags GetFlags() const
 	{
 		return uiFlags_;
@@ -55,7 +65,7 @@ public:
 
 protected:
 	UiItemBase(UiType type, SDL_Rect rect, UiFlags flags)
-	    : m_type(type)
+	    : type_(type)
 	    , m_rect(rect)
 	    , uiFlags_(flags)
 	{
@@ -66,8 +76,10 @@ protected:
 		uiFlags_ = flags;
 	}
 
+private:
+	UiType type_;
+
 public:
-	UiType m_type;
 	SDL_Rect m_rect;
 
 private:

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -248,12 +248,17 @@ class UiText : public UiItemBase {
 public:
 	UiText(const char *text, SDL_Rect rect, UiFlags flags = UiFlags::ColorDialogWhite)
 	    : UiItemBase(UiType::Text, rect, flags)
-	    , m_text(text)
+	    , text_(text)
 	{
 	}
 
-	// private:
-	const char *m_text;
+	[[nodiscard]] constexpr string_view GetText() const
+	{
+		return text_;
+	}
+
+private:
+	const char *text_;
 };
 
 //=============================================================================

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -28,37 +28,37 @@ class UiItemBase {
 public:
 	virtual ~UiItemBase() = default;
 
-	[[nodiscard]] constexpr UiType GetType() const
+	[[nodiscard]] UiType GetType() const
 	{
 		return type_;
 	}
 
-	[[nodiscard]] constexpr bool IsType(UiType testType) const
+	[[nodiscard]] bool IsType(UiType testType) const
 	{
 		return type_ == testType;
 	}
 
-	[[nodiscard]] constexpr UiFlags GetFlags() const
+	[[nodiscard]] UiFlags GetFlags() const
 	{
 		return uiFlags_;
 	}
 
-	[[nodiscard]] constexpr bool IsHidden() const
+	[[nodiscard]] bool IsHidden() const
 	{
 		return (uiFlags_ & UiFlags::ElementHidden) == UiFlags::ElementHidden;
 	}
 
-	[[nodiscard]] constexpr bool IsNotInteractive() const
+	[[nodiscard]] bool IsNotInteractive() const
 	{
 		return HasAnyOf(uiFlags_, UiFlags::ElementHidden | UiFlags::ElementDisabled);
 	}
 
-	constexpr void Hide()
+	void Hide()
 	{
 		uiFlags_ |= UiFlags::ElementHidden;
 	}
 
-	constexpr void Show()
+	void Show()
 	{
 		uiFlags_ &= ~UiFlags::ElementHidden;
 	}
@@ -98,24 +98,22 @@ public:
 	{
 	}
 
-	~UiImage() override = default;
-
-	[[nodiscard]] constexpr bool IsCentered() const
+	[[nodiscard]] bool IsCentered() const
 	{
 		return HasAnyOf(GetFlags(), UiFlags::AlignCenter);
 	}
 
-	[[nodiscard]] constexpr Art *GetArt() const
+	[[nodiscard]] Art *GetArt() const
 	{
 		return art_;
 	}
 
-	[[nodiscard]] constexpr bool IsAnimated() const
+	[[nodiscard]] bool IsAnimated() const
 	{
 		return animated_;
 	}
 
-	[[nodiscard]] constexpr int GetFrame() const
+	[[nodiscard]] int GetFrame() const
 	{
 		return frame_;
 	}
@@ -163,21 +161,19 @@ public:
 	{
 	}
 
-	~UiArtText() override = default;
-
-	[[nodiscard]] constexpr string_view GetText() const
+	[[nodiscard]] string_view GetText() const
 	{
 		if (text_ != nullptr)
 			return text_;
 		return *textPointer_;
 	}
 
-	[[nodiscard]] constexpr int GetSpacing() const
+	[[nodiscard]] int GetSpacing() const
 	{
 		return spacing_;
 	}
 
-	[[nodiscard]] constexpr int GetLineHeight() const
+	[[nodiscard]] int GetLineHeight() const
 	{
 		return lineHeight_;
 	}
@@ -225,12 +221,12 @@ public:
 		UiItemBase::SetFlags(flags);
 	}
 
-	[[nodiscard]] constexpr string_view GetText() const
+	[[nodiscard]] string_view GetText() const
 	{
 		return text_;
 	}
 
-	constexpr void Activate() const
+	void Activate() const
 	{
 		action_();
 	}
@@ -272,7 +268,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] constexpr string_view GetText() const
+	[[nodiscard]] string_view GetText() const
 	{
 		return text_;
 	}
@@ -298,38 +294,38 @@ public:
 	{
 	}
 
-	[[nodiscard]] constexpr int GetFrame() const
+	[[nodiscard]] int GetFrame() const
 	{
 		// Frame 1 is a held button sprite, frame 0 is the default
 		return IsPressed() ? 1 : 0;
 	}
 
-	[[nodiscard]] constexpr Art *GetArt() const
+	[[nodiscard]] Art *GetArt() const
 	{
 		return art_;
 	}
 
-	[[nodiscard]] constexpr string_view GetText() const
+	[[nodiscard]] string_view GetText() const
 	{
 		return text_;
 	}
 
-	constexpr void Activate() const
+	void Activate() const
 	{
 		action_();
 	}
 
-	[[nodiscard]] constexpr bool IsPressed() const
+	[[nodiscard]] bool IsPressed() const
 	{
 		return pressed_;
 	}
 
-	constexpr void Press()
+	void Press()
 	{
 		pressed_ = true;
 	}
 
-	constexpr void Release()
+	void Release()
 	{
 		pressed_ = false;
 	}
@@ -363,8 +359,6 @@ public:
 	{
 	}
 
-	~UiListItem() = default;
-
 	// private:
 	const char *m_text;
 	std::vector<DrawStringFormatArg> args;
@@ -388,8 +382,6 @@ public:
 		for (const auto &item : vItems)
 			m_vecItems.push_back(item.get());
 	}
-
-	~UiList() override = default;
 
 	[[nodiscard]] SDL_Rect itemRect(int i) const
 	{
@@ -415,7 +407,7 @@ public:
 		return m_vecItems[i];
 	}
 
-	[[nodiscard]] constexpr int GetSpacing() const
+	[[nodiscard]] int GetSpacing() const
 	{
 		return spacing_;
 	}


### PR DESCRIPTION
Makes me feel like I'm writing Java code with all these getters and setters 😂 . Most of the members are constant/write once so it makes sense to define only a getter. This allows defining these members as private to address `misc-non-private-member-variables-in-classes`. Then the few members which actually need to be modified get wrappers with (hopefully) more descriptive names where possible.

The classes I haven't fully cleaned up either have platform specific handling or make heavy use of `SDL_Rect`. I'll do those as a separate PR since that'll be another large diff.