### PR TITLE
chatlog 2.0

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -95,6 +95,7 @@ set(libdevilutionx_SRCS
   mpq/mpq_sdl_rwops.cpp
   mpq/mpq_writer.cpp
   qol/autopickup.cpp
+  qol/chatlog.cpp
   qol/common.cpp
   qol/monhealthbar.cpp
   qol/xpbar.cpp

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -25,6 +25,7 @@
 #include "missiles.h"
 #include "panels/spell_list.hpp"
 #include "panels/ui_panels.hpp"
+#include "qol/chatlog.h"
 #include "stores.h"
 #include "towners.h"
 #include "trigs.h"
@@ -45,6 +46,7 @@ bool InGameMenu()
 {
 	return stextflag != STORE_NONE
 	    || HelpFlag
+	    || ChatLogFlag
 	    || talkflag
 	    || qtextflag
 	    || gmenu_is_active()

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -57,6 +57,7 @@
 #include "panels/spell_list.hpp"
 #include "pfile.h"
 #include "plrmsg.h"
+#include "qol/chatlog.h"
 #include "qol/common.h"
 #include "qol/itemlabels.h"
 #include "restrict.h"
@@ -490,6 +491,8 @@ void PressKey(int vkey)
 			QuestlogUp();
 		} else if (HelpFlag) {
 			HelpScrollUp();
+		} else if (ChatLogFlag) {
+			ChatLogScrollUp();
 		} else if (AutomapActive) {
 			AutomapUp();
 		}
@@ -500,16 +503,22 @@ void PressKey(int vkey)
 			QuestlogDown();
 		} else if (HelpFlag) {
 			HelpScrollDown();
+		} else if (ChatLogFlag) {
+			ChatLogScrollDown();
 		} else if (AutomapActive) {
 			AutomapDown();
 		}
 	} else if (vkey == DVL_VK_PRIOR) {
 		if (stextflag != STORE_NONE) {
 			StorePrior();
+		} else if (ChatLogFlag) {
+			ChatLogScrollTop();
 		}
 	} else if (vkey == DVL_VK_NEXT) {
 		if (stextflag != STORE_NONE) {
 			StoreNext();
+		} else if (ChatLogFlag) {
+			ChatLogScrollBottom();
 		}
 	} else if (vkey == DVL_VK_LEFT) {
 		if (AutomapActive && !talkflag) {
@@ -1549,6 +1558,7 @@ void InitKeymapActions()
 	    [] {
 		    ClosePanels();
 		    HelpFlag = false;
+		    ChatLogFlag = false;
 		    spselflag = false;
 		    if (qtextflag && leveltype == DTYPE_TOWN) {
 			    qtextflag = false;
@@ -1623,6 +1633,14 @@ void InitKeymapActions()
 	    },
 	    nullptr,
 	    CanPlayerTakeAction);
+	sgOptions.Keymapper.AddAction(
+	    "ChatLog",
+	    N_("Chat Log"),
+	    N_("Displays chat log."),
+	    'L',
+	    [] {
+		    ToggleChatLog();
+	    });
 #ifdef _DEBUG
 	sgOptions.Keymapper.AddAction(
 	    "DebugToggle",
@@ -1893,6 +1911,11 @@ bool PressEscKey()
 
 	if (HelpFlag) {
 		HelpFlag = false;
+		rv = true;
+	}
+
+	if (ChatLogFlag) {
+		ChatLogFlag = false;
 		rv = true;
 	}
 

--- a/Source/help.cpp
+++ b/Source/help.cpp
@@ -11,6 +11,7 @@
 #include "engine/render/text_render.hpp"
 #include "init.h"
 #include "minitext.h"
+#include "qol/chatlog.h"
 #include "stores.h"
 #include "utils/language.h"
 #include "utils/stdcompat/string_view.hpp"
@@ -218,6 +219,7 @@ void DisplayHelp()
 {
 	SkipLines = 0;
 	HelpFlag = true;
+	ChatLogFlag = false;
 }
 
 void HelpScrollUp()

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -19,6 +19,7 @@
 #include "options.h"
 #include "pfile.h"
 #include "plrmsg.h"
+#include "qol/chatlog.h"
 #include "storm/storm_net.hpp"
 #include "sync.h"
 #include "tmsg.h"
@@ -761,6 +762,11 @@ bool NetInit(bool bSinglePlayer)
 	if (!SNetGetGameInfo(GAMEINFO_PASSWORD, szPlayerDescript, 128))
 		nthread_terminate_game("SNetGetGameInfo2");
 	PublicGame = DvlNet_IsPublicGame();
+
+	auto &myPlayer = Players[MyPlayerId];
+	// separator for marking messages from a different game
+	AddMessageToChatLog(_("New Game"), nullptr, UiFlags::ColorRed);
+	AddMessageToChatLog(fmt::format(_("Player '{:s}' (level {:d}) just joined the game"), myPlayer._pName, myPlayer._pLevel));
 
 	return true;
 }

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -12,6 +12,7 @@
 #include "control.h"
 #include "engine/render/text_render.hpp"
 #include "inv.h"
+#include "qol/chatlog.h"
 #include "utils/language.h"
 #include "utils/utf8.hpp"
 
@@ -71,6 +72,7 @@ void EventPlrMsg(string_view text, UiFlags style)
 	message.text = std::string(text);
 	message.from = string_view(message.text.data(), 0);
 	message.lineHeight = GetLineHeight(message.text, GameFont12) + 3;
+	AddMessageToChatLog(std::string(text));
 }
 
 void SendPlrMsg(Player &player, string_view text)
@@ -84,6 +86,7 @@ void SendPlrMsg(Player &player, string_view text)
 	message.text = from + std::string(text);
 	message.from = string_view(message.text.data(), from.size());
 	message.lineHeight = GetLineHeight(message.text, GameFont12) + 3;
+	AddMessageToChatLog(std::string(text), &player);
 }
 
 void InitPlrMsg()
@@ -93,6 +96,9 @@ void InitPlrMsg()
 
 void DrawPlrMsg(const Surface &out)
 {
+	if (ChatLogFlag)
+		return;
+
 	int x = 10;
 	int y = PANEL_TOP - 13;
 	int width = gnScreenWidth - 20;

--- a/Source/qol/chatlog.cpp
+++ b/Source/qol/chatlog.cpp
@@ -130,7 +130,7 @@ void AddMessageToChatLog(const std::string &message, Player *player, UiFlags fla
 		ChatLogLines.emplace_back(MultiColoredText { "{0} - {1}", { { timestamp, UiFlags::ColorRed }, { playerInfo, nameColor } } });
 	}
 
-	int diff = ChatLogLines.size() - oldSize;
+	unsigned int diff = ChatLogLines.size() - oldSize;
 	// only autoscroll when on top of the log
 	if (SkipLines != 0) {
 		SkipLines += diff;
@@ -158,7 +158,7 @@ void DrawChatLog(const Surface &out)
 
 	time_t tm = time(nullptr);
 	std::string timestamp = fmt::format("{:02}:{:02}:{:02}", localtime(&tm)->tm_hour, localtime(&tm)->tm_min, localtime(&tm)->tm_sec);
-	DrawString(out, timestamp, { { sx, sy + PaddingTop + blankLineHeight }, { ContentTextWidth, lineHeight } }, UiFlags::ColorRed);
+	DrawString(out, timestamp, { { sx, sy + PaddingTop + blankLineHeight }, { ContentTextWidth, lineHeight } }, UiFlags::ColorWhitegold);
 
 	const int titleBottom = sy + HeaderHeight();
 	DrawSLine(out, titleBottom);

--- a/Source/qol/chatlog.cpp
+++ b/Source/qol/chatlog.cpp
@@ -1,0 +1,209 @@
+/**
+ * @file chatlog.cpp
+ *
+ * Implementation of the in-game chat log.
+ */
+#include <fmt/format.h>
+#include <string>
+#include <vector>
+
+#include "DiabloUI/ui_flags.hpp"
+#include "automap.h"
+#include "chatlog.h"
+#include "control.h"
+#include "doom.h"
+#include "engine/render/text_render.hpp"
+#include "error.h"
+#include "gamemenu.h"
+#include "help.h"
+#include "init.h"
+#include "inv.h"
+#include "minitext.h"
+#include "stores.h"
+#include "utils/language.h"
+#include "utils/stdcompat/string_view.hpp"
+
+namespace devilution {
+
+namespace {
+
+struct ColoredText {
+	std::string text;
+	UiFlags color;
+};
+
+struct MultiColoredText {
+	std::string text;
+	std::vector<ColoredText> colors;
+	int offset = 0;
+};
+
+bool UnreadFlag = false;
+unsigned int SkipLines;
+unsigned int MessageCounter = 0;
+
+std::vector<MultiColoredText> ChatLogLines;
+
+constexpr int PaddingTop = 32;
+constexpr int PaddingLeft = 32;
+
+constexpr int PanelHeight = 297;
+constexpr int ContentTextWidth = 577;
+
+int LineHeight()
+{
+	return IsSmallFontTall() ? 18 : 14;
+}
+
+int BlankLineHeight()
+{
+	return 12;
+}
+
+int DividerLineMarginY()
+{
+	return BlankLineHeight() / 2;
+}
+
+int HeaderHeight()
+{
+	return PaddingTop + LineHeight() + 2 * BlankLineHeight() + DividerLineMarginY();
+}
+
+int ContentPaddingY()
+{
+	return BlankLineHeight();
+}
+
+int ContentsTextHeight()
+{
+	return PanelHeight - HeaderHeight() - DividerLineMarginY() - 2 * ContentPaddingY() - BlankLineHeight();
+}
+
+int NumVisibleLines()
+{
+	return (ContentsTextHeight() - 1) / LineHeight() + 1; // Ceil
+}
+
+} // namespace
+
+bool ChatLogFlag = false;
+
+void ToggleChatLog()
+{
+	if (ChatLogFlag) {
+		ChatLogFlag = false;
+	} else {
+		stextflag = STORE_NONE;
+		invflag = false;
+		chrflag = false;
+		sbookflag = false;
+		spselflag = false;
+		if (qtextflag && leveltype == DTYPE_TOWN) {
+			qtextflag = false;
+			stream_stop();
+		}
+		QuestLogIsOpen = false;
+		HelpFlag = false;
+		AutomapActive = false;
+		CancelCurrentDiabloMsg();
+		gamemenu_off();
+		SkipLines = 0;
+		ChatLogFlag = true;
+		doom_close();
+	}
+}
+
+void AddMessageToChatLog(const std::string &message, Player *player, UiFlags flags)
+{
+	MessageCounter++;
+	time_t tm = time(nullptr);
+	std::string timestamp = fmt::format("[#{:d}] {:02}:{:02}:{:02}", MessageCounter, localtime(&tm)->tm_hour, localtime(&tm)->tm_min, localtime(&tm)->tm_sec);
+	int oldSize = ChatLogLines.size();
+	ChatLogLines.emplace_back(MultiColoredText { "", { {} } });
+	if (player == nullptr) {
+		ChatLogLines.emplace_back(MultiColoredText { "{0} {1}", { { timestamp, UiFlags::ColorRed }, { message, flags } } });
+	} else {
+		std::string playerInfo = fmt::format(_("{:s} (lvl {:d}): {:s}"), player->_pName, player->_pLevel, "");
+		ChatLogLines.emplace_back(MultiColoredText { message, { {} }, 20 });
+		UiFlags nameColor = player == &Players[MyPlayerId] ? UiFlags::ColorWhitegold : UiFlags::ColorBlue;
+		ChatLogLines.emplace_back(MultiColoredText { "{0} - {1}", { { timestamp, UiFlags::ColorRed }, { playerInfo, nameColor } } });
+	}
+
+	int diff = ChatLogLines.size() - oldSize;
+	// only autoscroll when on top of the log
+	if (SkipLines != 0) {
+		SkipLines += diff;
+		UnreadFlag = true;
+	}
+}
+
+void DrawChatLog(const Surface &out)
+{
+	DrawSTextHelp();
+	DrawQTextBack(out);
+
+	if (SkipLines == 0) {
+		UnreadFlag = false;
+	}
+
+	const int lineHeight = LineHeight();
+	const int blankLineHeight = BlankLineHeight();
+	const int sx = PANEL_X + PaddingLeft;
+	const int sy = UI_OFFSET_Y;
+
+	DrawString(out, fmt::format(_("Chat History (Messages: {:d})"), MessageCounter),
+	    { { sx, sy + PaddingTop + blankLineHeight }, { ContentTextWidth, lineHeight } },
+	    (UnreadFlag ? UiFlags::ColorRed : UiFlags::ColorWhitegold) | UiFlags::AlignCenter);
+
+	char timestamp[64];
+	time_t tm = time(nullptr);
+	sprintf(timestamp, "%02d:%02d:%02d", localtime(&tm)->tm_hour, localtime(&tm)->tm_min, localtime(&tm)->tm_sec);
+	DrawString(out, timestamp, { { sx, sy + PaddingTop + blankLineHeight }, { ContentTextWidth, lineHeight } }, UiFlags::ColorRed);
+
+	const int titleBottom = sy + HeaderHeight();
+	DrawSLine(out, titleBottom);
+
+	const int numLines = NumVisibleLines();
+	const int contentY = titleBottom + DividerLineMarginY() + ContentPaddingY();
+	for (int i = 0; i < numLines; i++) {
+		if (i + SkipLines >= ChatLogLines.size())
+			break;
+		MultiColoredText &text = ChatLogLines[ChatLogLines.size() - (i + SkipLines + 1)];
+		const string_view line = text.text;
+
+		std::vector<DrawStringFormatArg> args;
+		for (auto &x : text.colors) {
+			args.emplace_back(DrawStringFormatArg { x.text, x.color });
+		}
+		DrawStringWithColors(out, line, args, { { (sx + text.offset), contentY + i * lineHeight }, { ContentTextWidth - text.offset, lineHeight } }, UiFlags::ColorWhite, /*spacing=*/1, lineHeight);
+	}
+
+	DrawString(out, _("Press ESC to end or the arrow keys to scroll."),
+	    { { sx, contentY + ContentsTextHeight() + ContentPaddingY() + blankLineHeight }, { ContentTextWidth, lineHeight } },
+	    UiFlags::ColorWhitegold | UiFlags::AlignCenter);
+}
+
+void ChatLogScrollUp()
+{
+	if (SkipLines > 0)
+		SkipLines--;
+}
+
+void ChatLogScrollDown()
+{
+	if (SkipLines + NumVisibleLines() < ChatLogLines.size())
+		SkipLines++;
+}
+
+void ChatLogScrollTop()
+{
+	SkipLines = 0;
+}
+
+void ChatLogScrollBottom()
+{
+	SkipLines = ChatLogLines.size() - NumVisibleLines();
+}
+
+} // namespace devilution

--- a/Source/qol/chatlog.cpp
+++ b/Source/qol/chatlog.cpp
@@ -156,9 +156,8 @@ void DrawChatLog(const Surface &out)
 	    { { sx, sy + PaddingTop + blankLineHeight }, { ContentTextWidth, lineHeight } },
 	    (UnreadFlag ? UiFlags::ColorRed : UiFlags::ColorWhitegold) | UiFlags::AlignCenter);
 
-	char timestamp[64];
 	time_t tm = time(nullptr);
-	sprintf(timestamp, "%02d:%02d:%02d", localtime(&tm)->tm_hour, localtime(&tm)->tm_min, localtime(&tm)->tm_sec);
+	std::string timestamp = fmt::format("{:02}:{:02}:{:02}", localtime(&tm)->tm_hour, localtime(&tm)->tm_min, localtime(&tm)->tm_sec);
 	DrawString(out, timestamp, { { sx, sy + PaddingTop + blankLineHeight }, { ContentTextWidth, lineHeight } }, UiFlags::ColorRed);
 
 	const int titleBottom = sy + HeaderHeight();
@@ -176,7 +175,7 @@ void DrawChatLog(const Surface &out)
 		for (auto &x : text.colors) {
 			args.emplace_back(DrawStringFormatArg { x.text, x.color });
 		}
-		DrawStringWithColors(out, line, args, { { (sx + text.offset), contentY + i * lineHeight }, { ContentTextWidth - text.offset, lineHeight } }, UiFlags::ColorWhite, /*spacing=*/1, lineHeight);
+		DrawStringWithColors(out, line, args, { { (sx + text.offset), contentY + i * lineHeight }, { ContentTextWidth - text.offset * 2, lineHeight } }, UiFlags::ColorWhite, /*spacing=*/1, lineHeight);
 	}
 
 	DrawString(out, _("Press ESC to end or the arrow keys to scroll."),

--- a/Source/qol/chatlog.h
+++ b/Source/qol/chatlog.h
@@ -1,0 +1,23 @@
+/**
+ * @file chatlog.h
+ *
+ * Adds Chat log QoL feature
+ */
+#pragma once
+
+#include "engine.h"
+#include "player.h"
+
+namespace devilution {
+
+extern bool ChatLogFlag;
+
+void ToggleChatLog();
+void AddMessageToChatLog(const std::string &message, Player *player = nullptr, UiFlags flags = UiFlags::ColorWhite);
+void DrawChatLog(const Surface &out);
+void ChatLogScrollUp();
+void ChatLogScrollDown();
+void ChatLogScrollTop();
+void ChatLogScrollBottom();
+
+} // namespace devilution

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -28,6 +28,7 @@
 #include "nthread.h"
 #include "panels/charpanel.hpp"
 #include "plrmsg.h"
+#include "qol/chatlog.h"
 #include "qol/itemlabels.h"
 #include "qol/monhealthbar.h"
 #include "qol/xpbar.h"
@@ -1292,6 +1293,9 @@ void DrawView(const Surface &out, Point startPosition)
 	}
 	if (HelpFlag) {
 		DrawHelp(out);
+	}
+	if (ChatLogFlag) {
+		DrawChatLog(out);
 	}
 	if (IsDiabloMsgAvailable()) {
 		DrawDiabloMsg(out);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14297035/154767699-af257793-d382-4772-b6f0-8df558927416.png)
After right margin change:
![image](https://user-images.githubusercontent.com/14297035/155201913-524b9bd2-39a9-4a7d-ab85-7b56aba7882c.png)

Disadvantages vs old ver:
No spinner
No scrollbar

Improvements:
`Chat History (Messages: {:d})` turns red if there's a new message and you haven't scrolled to top yet
page up / page down scroll to top / bottom of the chatlog
Clock in upper left corner - that's why I allow opening chat log in single player, it takes care of a request to have an ingame clock :D
