### PR TITLE
VS Configuration: Rename WSL configuration, so that it doesn't get default selected

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -76,7 +76,7 @@
       "enableClangTidyCodeAnalysis": true
     },
     {
-      "name": "WSL-GCC-x64-Debug",
+      "name": "x64-Debug-WSL-GCC",
       "generator": "Ninja",
       "configurationType": "Debug",
       "buildRoot": "${workspaceRoot}\\build\\${name}",


### PR DESCRIPTION
It seams that visual studio default selected the first option in the combo-box.
And the combo-box is sorted by name.
That's why the WSL configuration is default selected.

With this PR now `x64-Debug` is now again the default.
I think that's a better default for most developers.

Noticed this cause visual studio switched sometimes to the default back.

Master | PR
-- | --
![grafik](https://user-images.githubusercontent.com/25415264/145611321-7b140772-4888-4f9d-b9a5-d91f71036a47.png) | ![grafik](https://user-images.githubusercontent.com/25415264/145611159-d4ff6073-421a-44ac-8a23-f2b924f3ae7a.png)