### PR TITLE
Call SyncPortals() only once for a level load

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2271,7 +2271,6 @@ void LoadLevel()
 		AutomapZoomReset();
 		ResyncQuests();
 		RedoMissileFlags();
-		SyncPortals();
 		UpdateLighting = true;
 	}
 


### PR DESCRIPTION
Fixes #3734

Notes:
- `SyncPortals` was called twice (once in `LoadLevel` and once in `LoadGameLevel`)
- That means `AddTown` was also called twice. The first call creates a town portal. The second call sees this town portal (`TileContainsMissile` is true) and places the second town portal near the first town portal. But a player is only allowed to have one town portal. That's why the first town portal gets deleted (in the video in the pr you can see it for a short period).
- Fix is to call `SyncPortals` only once.
- 9964bd9e495314e2d466eeb6a0c11d3c12c963ae only worked, cause the check for existing missiles/town portals was broken before this commit/bugfix.
- Alternative fix could be to check if new to place town portal is on the same location as a existing town portal from the same player and allow this special case.