### PR TITLE
Check that monsters aren't placed in doors V2

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1915,10 +1915,10 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 			if (firstflag || lvldir == ENTRY_LOAD || !myPlayer._pLvlVisited[currlevel] || gbIsMultiplayer) {
 				HoldThemeRooms();
 				[[maybe_unused]] uint32_t mid1Seed = GetLCGEngineState();
-				InitMonsters();
+				InitObjects();
 				[[maybe_unused]] uint32_t mid2Seed = GetLCGEngineState();
 				IncProgress();
-				InitObjects();
+				InitMonsters();
 				InitItems();
 				if (currlevel < 17)
 					CreateThemeRooms();

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -266,7 +266,7 @@ bool CanPlaceMonster(int xp, int yp)
 		return false;
 	}
 
-	return !IsTileSolid({ xp, yp });
+	return !IsTileOccupied({ xp, yp });
 }
 
 void PlaceMonster(int i, int mtype, int x, int y)


### PR DESCRIPTION
Fixes #2700

Alternative to #3733

Notes:
- See discussion in #3733 
- Checked both save games in #2700 and the monsters are not spawned in doors 😉