### PR TITLE
(Partially) deduplicate code used to check if a player can equip an item

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -832,7 +832,7 @@ void DrawInfoBox(const Surface &out)
 		if (myPlayer.HoldItem._itype == ItemType::Gold) {
 			int nGold = myPlayer.HoldItem._ivalue;
 			strcpy(infostr, fmt::format(ngettext("{:d} gold piece", "{:d} gold pieces", nGold), nGold).c_str());
-		} else if (!myPlayer.HoldItem._iStatFlag) {
+		} else if (!myPlayer.CanUseItem(myPlayer.HoldItem)) {
 			ClearPanel();
 			AddPanelString(_("Requirements not met"));
 		} else {

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -412,7 +412,7 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 			done = true;
 			if (!AllItemsList[player.HoldItem.IDidx].iUsable)
 				done = false;
-			if (!player.HoldItem._iStatFlag)
+			if (!player.CanUseItem(player.HoldItem))
 				done = false;
 			if (player.HoldItem._itype == ItemType::Gold)
 				done = false;
@@ -464,7 +464,7 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 	if (!done)
 		return;
 
-	if (IsNoneOf(il, ILOC_UNEQUIPABLE, ILOC_BELT) && !player.HoldItem._iStatFlag) {
+	if (IsNoneOf(il, ILOC_UNEQUIPABLE, ILOC_BELT) && !player.CanUseItem(player.HoldItem)) {
 		done = false;
 		player.Say(HeroSpeech::ICantUseThisYet);
 	}
@@ -1614,13 +1614,7 @@ void CheckItemStats(Player &player)
 {
 	Item &item = player.HoldItem;
 
-	item._iStatFlag = false;
-
-	if (player._pStrength >= item._iMinStr
-	    && player._pMagic >= item._iMinMag
-	    && player._pDexterity >= item._iMinDex) {
-		item._iStatFlag = true;
-	}
+	item._iStatFlag = player.CanUseItem(item);
 }
 
 void InvGetItem(int pnum, int ii)
@@ -2118,7 +2112,7 @@ bool UseInvItem(int pnum, int cii)
 	if (!AllItemsList[item->IDidx].iUsable)
 		return false;
 
-	if (!item->_iStatFlag) {
+	if (!player.CanUseItem(*item)) {
 		player.Say(HeroSpeech::ICantUseThisYet);
 		return true;
 	}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -510,24 +510,10 @@ void CalcSelfItems(Player &player)
 	} while (changeflag);
 }
 
-bool ItemMinStats(const Player &player, Item &x)
-{
-	if (player._pMagic < x._iMinMag)
-		return false;
-
-	if (player._pStrength < x._iMinStr)
-		return false;
-
-	if (player._pDexterity < x._iMinDex)
-		return false;
-
-	return true;
-}
-
 void CalcPlrItemMin(Player &player)
 {
 	for (Item &item : InventoryAndBeltPlayerItemsRange { player }) {
-		item._iStatFlag = ItemMinStats(player, item);
+		item._iStatFlag = player.CanUseItem(item);
 	}
 }
 
@@ -583,7 +569,7 @@ void CalcPlrBookVals(Player &player)
 					spellLevel = 0;
 				}
 			}
-			item._iStatFlag = ItemMinStats(player, item);
+			item._iStatFlag = player.CanUseItem(item);
 		}
 	}
 }

--- a/Source/player.h
+++ b/Source/player.h
@@ -299,6 +299,13 @@ struct Player {
 
 	void CalcScrolls();
 
+	bool CanUseItem(const Item &item) const
+	{
+		return _pStrength >= item._iMinStr
+		    && _pMagic >= item._iMinMag
+		    && _pDexterity >= item._iMinDex;
+	}
+
 	bool HasItem(int item, int *idx = nullptr) const;
 
 	/**


### PR DESCRIPTION
`CheckItemStats`, `ItemMinStats`, and `StoreStatsOk` all did effectively the same thing. The `item.statFlag` variable itself can be replaced by a check against the local player but with the way this check is used it's sometimes hard to define what is the local player (especially when building the save game list). I've done a very limited dedup/cleanup here to avoid breaking things by trying to remove runtime use of `statFlag` completely.