### PR TITLE
Perform item requirement check when entering vendors

### DIFF
--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -275,11 +275,6 @@ bool UnPackPlayer(const PlayerPack *pPack, Player &player, bool netSync)
 		UnPackItem(packedItem, player.SpdList[i], isHellfire);
 	}
 
-	if (&player == &Players[MyPlayerId]) {
-		for (int i = 0; i < 20; i++)
-			witchitem[i]._itype = ItemType::None;
-	}
-
 	CalcPlrInv(player, false);
 	player.wReflections = SDL_SwapLE16(pPack->wReflections);
 	player.pTownWarps = 0;

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -365,7 +365,11 @@ void StartSmithBuy()
 	AddItemListBackButton();
 
 	storenumh = 0;
-	for (int i = 0; !smithitem[i].isEmpty(); i++) {
+	for (Item &item : smithitem) {
+		if (item.isEmpty())
+			continue;
+
+		item._iStatFlag = MyPlayer->CanUseItem(item);
 		storenumh++;
 	}
 
@@ -402,9 +406,12 @@ void ScrollSmithPremiumBuy(int boughtitems)
 bool StartSmithPremiumBuy()
 {
 	storenumh = 0;
-	for (const auto &item : premiumitems) {
-		if (!item.isEmpty())
-			storenumh++;
+	for (Item &item : premiumitems) {
+		if (item.isEmpty())
+			continue;
+
+		item._iStatFlag = MyPlayer->CanUseItem(item);
+		storenumh++;
 	}
 	if (storenumh == 0) {
 		StartStore(STORE_SMITH);
@@ -703,6 +710,22 @@ void ScrollWitchBuy(int idx)
 		stextsel = stextdown;
 }
 
+void WitchBookLevel(Item &bookItem)
+{
+	if (bookItem._iMiscId != IMISC_BOOK)
+		return;
+	bookItem._iMinMag = spelldata[bookItem._iSpell].sMinInt;
+	int8_t spellLevel = Players[MyPlayerId]._pSplLvl[bookItem._iSpell];
+	while (spellLevel > 0) {
+		bookItem._iMinMag += 20 * bookItem._iMinMag / 100;
+		spellLevel--;
+		if (bookItem._iMinMag + 20 * bookItem._iMinMag / 100 > 255) {
+			bookItem._iMinMag = 255;
+			spellLevel = 0;
+		}
+	}
+}
+
 void StartWitchBuy()
 {
 	stextsize = true;
@@ -719,7 +742,12 @@ void StartWitchBuy()
 	AddItemListBackButton();
 
 	storenumh = 0;
-	for (int i = 0; !witchitem[i].isEmpty(); i++) {
+	for (Item &item : witchitem) {
+		if (item.isEmpty())
+			continue;
+
+		WitchBookLevel(item);
+		item._iStatFlag = MyPlayer->CanUseItem(item);
 		storenumh++;
 	}
 	stextsmax = std::max(storenumh - 4, 0);
@@ -1004,12 +1032,13 @@ void SStartBoyBuy()
 	stextscrl = false;
 
 	/* TRANSLATORS: This text is white space sensitive. Check for correct alignment! */
-	strcpy(tempstr, fmt::format(_("I have this item for sale:             Your gold: {:d}"), Players[MyPlayerId]._pGold).c_str());
+	strcpy(tempstr, fmt::format(_("I have this item for sale:             Your gold: {:d}"), MyPlayer->_pGold).c_str());
 
 	AddSText(0, 1, tempstr, UiFlags::ColorWhitegold | UiFlags::AlignCenter, false);
 	AddSLine(3);
 
 	UiFlags itemColor = boyitem.getTextColorWithStatCheck();
+	boyitem._iStatFlag = MyPlayer->CanUseItem(boyitem);
 
 	if (boyitem._iMagical != ITEM_QUALITY_NORMAL)
 		AddSText(20, 10, boyitem._iIName, itemColor, true);
@@ -1095,7 +1124,11 @@ void StartHealerBuy()
 	AddItemListBackButton();
 
 	storenumh = 0;
-	for (int i = 0; !healitem[i].isEmpty(); i++) {
+	for (Item &item : healitem) {
+		if (item.isEmpty())
+			continue;
+
+		item._iStatFlag = MyPlayer->CanUseItem(item);
 		storenumh++;
 	}
 


### PR DESCRIPTION
More prep work for rewriting stores.cpp

Vendor item stat checks were being performed at some really odd times:
- When reading a hero from a save game (select hero menu etc.)
- When generating the vendor items
- Reparing, identifying, recharging, applying oil, buying, resurrect, changing equipment
- Joining/starting a game, entering town
- Applying stats

Instead of all that craziness simply calculate it when opening the vendor item list.