### PR TITLE
[Android] Hide the Upscale option in the settings menu

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -66,6 +66,12 @@ namespace devilution {
 
 namespace {
 
+#ifdef __ANDROID__
+constexpr OptionEntryFlags InvisibleOnAndroid = OptionEntryFlags::Invisible;
+#else
+constexpr OptionEntryFlags InvisibleOnAndroid = OptionEntryFlags::None;
+#endif
+
 std::string GetIniPath()
 {
 	auto path = paths::ConfigPath() + std::string("diablo.ini");
@@ -667,7 +673,7 @@ GraphicsOptions::GraphicsOptions()
     , fitToScreen("Fit to Screen", OptionEntryFlags::CantChangeInGame | OptionEntryFlags::RecreateUI, N_("Fit to Screen"), N_("Automatically adjust the game window to your current desktop screen aspect ratio and resolution."), true)
 #endif
 #ifndef USE_SDL1
-    , upscale("Upscale", OptionEntryFlags::CantChangeInGame | OptionEntryFlags::RecreateUI, N_("Upscale"), N_("Enables image scaling from the game resolution to your monitor resolution. Prevents changing the monitor resolution and allows window resizing."), true)
+    , upscale("Upscale", InvisibleOnAndroid | OptionEntryFlags::CantChangeInGame | OptionEntryFlags::RecreateUI, N_("Upscale"), N_("Enables image scaling from the game resolution to your monitor resolution. Prevents changing the monitor resolution and allows window resizing."), true)
     , scaleQuality("Scaling Quality", OptionEntryFlags::None, N_("Scaling Quality"), N_("Enables optional filters to the output image when upscaling."), ScalingQuality::AnisotropicFiltering,
           {
               { ScalingQuality::NearestPixel, N_("Nearest Pixel") },


### PR DESCRIPTION
Likely a much better alternative to #3750.

This resolves #3708