### PR TITLE
Add ProMotion support for iPhone 13 Pros

### DIFF
--- a/Packaging/apple/Info.plist
+++ b/Packaging/apple/Info.plist
@@ -48,5 +48,7 @@
 	<true/>
 	<key>UIFileSharingEnabled</key>
 	<true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
This key is required for over 60hz for the iPhone 13 Pros.