### PR TITLE
[3DS] Adjust video flags to force hardware surface

### DIFF
--- a/CMake/platforms/n3ds.cmake
+++ b/CMake/platforms/n3ds.cmake
@@ -20,6 +20,8 @@ add_definitions(-D__3DS__)
 set(MO_LANG_DIR \"romfs:/\")
 
 #SDL video mode parameters
+set(SDL1_VIDEO_MODE_FLAGS SDL_DOUBLEBUF|SDL_HWSURFACE)
+set(SDL1_FORCE_SVID_VIDEO_MODE ON)
 set(SDL1_VIDEO_MODE_BPP 8)
 set(DEFAULT_WIDTH 800)
 set(DEFAULT_HEIGHT 480)


### PR DESCRIPTION
Apparently, the 3DS build of SDL always tries to return a double-buffered hardware surface, regardless of the flags you pass in.
https://github.com/devkitPro/SDL/blob/a9a6d223b4ceb1618053f9e1e6ef5afbbf4f7335/src/video/n3ds/SDL_n3dsvideo.c#L406

If you don't pass flags to explicitly ask for a hardware surface, SDL will return a "shadow surface" that can be used for double-buffering when the hardware doesn't support it.
https://github.com/devkitPro/SDL/blob/a9a6d223b4ceb1618053f9e1e6ef5afbbf4f7335/src/video/SDL_video.c#L904-L905

This commit bypasses the shadow surface middleman, which appears to speed up rendering on o3DS by a couple FPS.

---

Also, the `SDL1_FORCE_SVID_VIDEO_MODE` flag becomes necessary because the properties of the shadow surface were triggering logic that forced SVid video mode, whereas the hardware surface does not. However, we don't want to use the game surface for SVid because the Smacker videos play at a resolution that doesn't need to be scaled, whereas the game itself does not.