### PR TITLE
AssetsPath: Default to exe dir

### DIFF
--- a/Source/utils/paths.cpp
+++ b/Source/utils/paths.cpp
@@ -91,7 +91,7 @@ const std::string &ConfigPath()
 const std::string &AssetsPath()
 {
 	if (!assetsPath)
-		assetsPath.emplace(BasePath() + "assets/");
+		assetsPath.emplace(FromSDL(SDL_GetBasePath()) + "assets/");
 	return *assetsPath;
 }
 
@@ -116,6 +116,12 @@ void SetConfigPath(const std::string &path)
 {
 	configPath = path;
 	AddTrailingSlash(*configPath);
+}
+
+void SetAssetsPath(const std::string &path)
+{
+	assetsPath = path;
+	AddTrailingSlash(*assetsPath);
 }
 
 void SetMpqDir(const std::string &path)

--- a/Source/utils/paths.h
+++ b/Source/utils/paths.h
@@ -17,6 +17,7 @@ const std::optional<std::string> &MpqDir();
 void SetBasePath(const std::string &path);
 void SetPrefPath(const std::string &path);
 void SetConfigPath(const std::string &path);
+void SetAssetsPath(const std::string &path);
 void SetMpqDir(const std::string &path);
 
 } // namespace paths


### PR DESCRIPTION
Also adds `SetAssetsPath`, for use by tests.

See discussion in #3770