### PR TITLE
CMake: Place tests where everything else is

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(GoogleTest)
 
 add_library(libdevilutionx_so SHARED)
+set_target_properties(libdevilutionx_so PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${DevilutionX_BINARY_DIR})
 target_link_libraries(libdevilutionx_so PUBLIC libdevilutionx)
 target_include_directories(libdevilutionx_so INTERFACE "${DevilutionX_SOURCE_DIR}/Source")
 set_target_properties(libdevilutionx_so PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
@@ -39,6 +40,7 @@ foreach(test_target ${tests})
   gtest_discover_tests(${test_target})
   target_link_libraries(${test_target} PRIVATE libdevilutionx_so ${GTEST_LIBRARIES} test_main)
   target_include_directories(${test_target} PRIVATE ${GTEST_INCLUDE_DIRS})
+  set_target_properties(${test_target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${DevilutionX_BINARY_DIR})
 endforeach()
 
 target_include_directories(writehero_test PRIVATE ../3rdParty/PicoSHA2)

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,16 +1,11 @@
 #include <gtest/gtest.h>
 
 #include "diablo.h"
-#include "utils/paths.h"
 
 int main(int argc, char **argv)
 {
 	// Disable error dialogs.
 	devilution::gbQuietMode = true;
-
-	// Let the tests find `devilutionx.mpq` or `assets/`.
-	devilution::paths::SetAssetsPath(devilution::paths::BasePath() + "../assets");
-	devilution::paths::SetBasePath(devilution::paths::BasePath() + "..");
 
 	testing::InitGoogleTest(&argc, argv);
 	return RUN_ALL_TESTS();


### PR DESCRIPTION
This should hopefully fix DLL lookup on Windows (#3778)

@tsunamistate @obligaron Can you please see if this resolves the issue?