### PR TITLE
Prevent erroneous diagonal traversal in span filling algorithm

### DIFF
--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -360,7 +360,8 @@ void FindTransparencyValues(Point floor, uint8_t floorID)
 			seedStack.push(std::make_tuple(scanLeft, scanRight - 1, y + dy, dy));
 			if (scanRight - 1 > scanEnd)
 				seedStack.push(std::make_tuple(scanEnd + 1, scanRight - 1, y - dy, -dy));
-			checkDiagonals({ scanRight - 1, y }, right);
+			if (scanLeft < scanRight)
+				checkDiagonals({ scanRight - 1, y }, right);
 
 			while (scanRight < scanEnd && !isInside(scanRight, y))
 				scanRight++;


### PR DESCRIPTION
After scrutinizing some of the code I added to this algorithm, I realized the scan-right isn't guaranteed to end on a point inside the shape if the scan starts on the edge of the shape. The diagonal check requires that the point that was passed in is on the inside of the shape to avoid false positives. Since the algorithm has already filled in that tile, I couldn't use `isInside()` to check, but this change should satisfy the precondition.