### PR TITLE
Update Fedora build dependencies

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -28,7 +28,7 @@ sudo apt-get install smpq
 ```
 ### Installing dependencies on Fedora
 ```
-sudo dnf install cmake gcc-c++ glibc-devel SDL2-devel libsodium-devel libpng-devel bzip2-devel gtest-devel libasan libubsan
+sudo dnf install cmake gcc-c++ glibc-devel libstdc++-static SDL2-devel libsodium-devel libpng-devel bzip2-devel gmock-devel gtest-devel libasan libubsan
 ```
 ### Compiling
 ```bash


### PR DESCRIPTION
Add gmock and cpp-static libraries to Fedora build instructions. Otherwise, building on FC35 will not work.