### PR TITLE
Reduce stack size on 3DS

### DIFF
--- a/Source/platform/ctr/system.cpp
+++ b/Source/platform/ctr/system.cpp
@@ -9,13 +9,6 @@
 
 using namespace devilution;
 
-// Increase stack size for recursion in FindTransparencyValues()
-// 128 KB supports around 500 levels of recursion
-// Default stack size on 3DS is only 32 KB
-extern "C" {
-u32 __stacksize__ = 128 * 1024;
-}
-
 bool shouldDisableBacklight;
 
 aptHookCookie cookie;


### PR DESCRIPTION
With the resolution of #3543, the attached savegame no longer crashes on 3DS at the default stack size. For that matter, `FindTransparencyValues()` now requires very little stack space as there is no recursion, the stack is heap-allocated, and it only grows to a few dozen seeds at most. So long as there are no more instances of "extreme" recursion (~100 function calls deep) lurking in the codebase, we should be able to drop the stack size back down to its default on 3DS.