### PR TITLE
Do not send CMD_REMSHIELD when another player runs out of mana

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3055,7 +3055,8 @@ void ApplyPlrDamage(int pnum, int dam, int minHP /*= 0*/, int frac /*= 0*/, int 
 			}
 			player._pMana = 0;
 			player._pManaBase = player._pMaxManaBase - player._pMaxMana;
-			NetSendCmd(true, CMD_REMSHIELD);
+			if (pnum == MyPlayerId)
+				NetSendCmd(true, CMD_REMSHIELD);
 		}
 	}
 


### PR DESCRIPTION
Solves the issue where a player can remove another's mana shield by taking damage.

https://user-images.githubusercontent.com/9203145/146689642-01c4e867-a01f-49d8-a398-aea6b72eb616.mp4