### PR TITLE
Load MPQ archives before reading options so translations can be detected

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -935,9 +935,6 @@ void DiabloInit()
 	init_create_window();
 	was_window_init = true;
 
-	init_archives();
-	was_archives_init = true;
-
 	if (forceSpawn || *sgOptions.StartUp.shareware)
 		gbIsSpawn = true;
 	if (forceDiablo || *sgOptions.StartUp.gameMode == StartUpGameMode::Diablo)
@@ -1618,6 +1615,10 @@ int DiabloMain(int argc, char **argv)
 
 	DiabloParseFlags(argc, argv);
 	InitKeymapActions();
+
+	init_archives();
+	was_archives_init = true;
+
 	LoadOptions();
 
 	DiabloInit();


### PR DESCRIPTION
This is a result of checking that the translation specified in diablo.ini actually exists:
https://github.com/diasurgical/devilutionX/blob/cacf55bb34c1c314d2b39868826f63f732cbfdf6/Source/options.cpp#L932-L937

I found the check useful when I was switching between branches with different translations available, but another fix for # 3821 could be to always assume the ini value is correct and bail early if the value exists (remove the HasTranslation call in that block).

For now I think it's safe to load the MPQs before the ini, there's no circular dependency (yet 😂 )

fixes #3821 