### PR TITLE
Spell book: Fix "Level 0 - Unusable" overlap

### DIFF
--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -158,26 +158,26 @@ void DrawSpellBook(const Surface &out)
 			} break;
 			default: {
 				int mana = GetManaAmount(player, sn) >> 6;
-				if (sn != SPL_BONESPIRIT) {
-					int min;
-					int max;
-					GetDamageAmt(sn, &min, &max);
-					if (min != -1) {
-						if (sn == SPL_HEAL || sn == SPL_HEALOTHER) {
-							PrintSBookStr(out, line1, fmt::format(_(/* TRANSLATORS: UI constrains, keep short please.*/ "Heals: {:d} - {:d}"), min, max), UiFlags::AlignRight);
-						} else {
-							PrintSBookStr(out, line1, fmt::format(_(/* TRANSLATORS: UI constrains, keep short please.*/ "Damage: {:d} - {:d}"), min, max), UiFlags::AlignRight);
-						}
-					}
-				} else {
-					PrintSBookStr(out, line1, _(/* TRANSLATORS: UI constrains, keep short please.*/ "Dmg: 1/3 target hp"), UiFlags::AlignRight);
-				}
-				PrintSBookStr(out, line1, fmt::format(pgettext(/* TRANSLATORS: UI constrains, keep short please.*/ "spellbook", "Mana: {:d}"), mana));
 				int lvl = std::max(player._pSplLvl[sn] + player._pISplLvlAdd, 0);
+				PrintSBookStr(out, line0, fmt::format(pgettext(/* TRANSLATORS: UI constrains, keep short please.*/ "spellbook", "Level {:d}"), lvl), UiFlags::AlignRight);
 				if (lvl == 0) {
-					PrintSBookStr(out, line0, _("Level 0 - Unusable"), UiFlags::AlignRight);
+					PrintSBookStr(out, line1, _("Unusable"), UiFlags::AlignRight);
 				} else {
-					PrintSBookStr(out, line0, fmt::format(pgettext(/* TRANSLATORS: UI constrains, keep short please.*/ "spellbook", "Level {:d}"), lvl), UiFlags::AlignRight);
+					if (sn != SPL_BONESPIRIT) {
+						int min;
+						int max;
+						GetDamageAmt(sn, &min, &max);
+						if (min != -1) {
+							if (sn == SPL_HEAL || sn == SPL_HEALOTHER) {
+								PrintSBookStr(out, line1, fmt::format(_(/* TRANSLATORS: UI constrains, keep short please.*/ "Heals: {:d} - {:d}"), min, max), UiFlags::AlignRight);
+							} else {
+								PrintSBookStr(out, line1, fmt::format(_(/* TRANSLATORS: UI constrains, keep short please.*/ "Damage: {:d} - {:d}"), min, max), UiFlags::AlignRight);
+							}
+						}
+					} else {
+						PrintSBookStr(out, line1, _(/* TRANSLATORS: UI constrains, keep short please.*/ "Dmg: 1/3 target hp"), UiFlags::AlignRight);
+					}
+					PrintSBookStr(out, line1, fmt::format(pgettext(/* TRANSLATORS: UI constrains, keep short please.*/ "spellbook", "Mana: {:d}"), mana));
 				}
 			} break;
 			}

--- a/Translations/bg.po
+++ b/Translations/bg.po
@@ -6611,8 +6611,8 @@ msgid "Mana: {:d}"
 msgstr "Мана: {:d}"
 
 #: Source/panels/spell_book.cpp:178
-msgid "Level 0 - Unusable"
-msgstr "Ниво 0 - Неизползваемо"
+msgid "Unusable"
+msgstr "Неизползваемо"
 
 #. TRANSLATORS: UI constrains, keep short please.
 #: Source/panels/spell_book.cpp:180

--- a/Translations/es.po
+++ b/Translations/es.po
@@ -6791,8 +6791,8 @@ msgid "Mana: {:d}"
 msgstr "Maná: {:d}"
 
 #: Source/panels/spell_book.cpp:178
-msgid "Level 0 - Unusable"
-msgstr "Nivel0: Inutilizable"
+msgid "Unusable"
+msgstr "Inutilizable"
 
 #. TRANSLATORS: UI constrains, keep short please.
 #: Source/panels/spell_book.cpp:180

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -6763,8 +6763,8 @@ msgid "Mana: {:d}"
 msgstr "Mana: {:d}"
 
 #: Source/panels/spell_book.cpp:178
-msgid "Level 0 - Unusable"
-msgstr "Livello 0 - Inusabile"
+msgid "Unusable"
+msgstr "Inusabile"
 
 #. TRANSLATORS: UI constrains, keep short please.
 #: Source/panels/spell_book.cpp:180

--- a/Translations/ja.po
+++ b/Translations/ja.po
@@ -6369,8 +6369,8 @@ msgid "Mana: {:d}"
 msgstr "マナ {:d}"
 
 #: Source/panels/spell_book.cpp:178
-msgid "Level 0 - Unusable"
-msgstr "Lvl 0 - 使え​ない"
+msgid "Unusable"
+msgstr "使え​ない"
 
 #. TRANSLATORS: UI constrains, keep short please.
 #: Source/panels/spell_book.cpp:180

--- a/Translations/sv.po
+++ b/Translations/sv.po
@@ -6475,8 +6475,8 @@ msgid "Mana: {:d}"
 msgstr "Mana: {:d}"
 
 #: Source/panels/spell_book.cpp:178
-msgid "Level 0 - Unusable"
-msgstr "Nivå 0 - Oanvändbar"
+msgid "Unusable"
+msgstr "Oanvändbar"
 
 #. TRANSLATORS: UI constrains, keep short please.
 #: Source/panels/spell_book.cpp:180

--- a/Translations/uk.po
+++ b/Translations/uk.po
@@ -6436,8 +6436,8 @@ msgid "Mana: {:d}"
 msgstr "Мана: {:d}"
 
 #: Source/panels/spell_book.cpp:178
-msgid "Level 0 - Unusable"
-msgstr "0-вий Рівень Чар - Непридатні"
+msgid "Unusable"
+msgstr "Непридатні"
 
 #. TRANSLATORS: UI constrains, keep short please.
 #: Source/panels/spell_book.cpp:180

--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -1031,8 +1031,8 @@ msgid "Mana: {:d}"
 msgstr "法力 {:d}"
 
 #: Source/control.cpp:1623
-msgid "Level 0 - Unusable"
-msgstr "法术​等级 0 - 无法​使用"
+msgid "Unusable"
+msgstr "无法​使用"
 
 #. TRANSLATORS: UI constrains, keep short please.
 #: Source/control.cpp:1625


### PR DESCRIPTION
Removes the display of mana and damage for unusable spells and moves the "Unusable" text onto the second line, fixing the overlap.

Before | After
---|---
![image](https://user-images.githubusercontent.com/216339/147402416-07a6a1d3-3c19-4465-8e15-30c0c1a52294.png) | ![image](https://user-images.githubusercontent.com/216339/147402651-70f1eadd-87c9-4a1a-9444-bd8fc54ad2cc.png)
![image](https://user-images.githubusercontent.com/216339/147402453-5e94872e-1d91-4307-831b-8f43ca9ba3ac.png)  | ![image](https://user-images.githubusercontent.com/216339/147402637-4edd70ad-d992-4f6e-8de7-c464ef2dbe11.png)


Fixes #3846