### PR TITLE
Consistently trigger menu/movie transitions on mouse up instead of down

### DIFF
--- a/Source/DiabloUI/credits.cpp
+++ b/Source/DiabloUI/credits.cpp
@@ -142,7 +142,7 @@ bool TextDialog(char const *const *text, std::size_t textLines)
 		while (PollEvent(&event) != 0) {
 			switch (event.type) {
 			case SDL_KEYDOWN:
-			case SDL_MOUSEBUTTONDOWN:
+			case SDL_MOUSEBUTTONUP:
 				endMenu = true;
 				break;
 			default:

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -907,7 +907,7 @@ void RenderItem(UiItemBase *item)
 
 bool HandleMouseEventArtTextButton(const SDL_Event &event, const UiArtTextButton *uiButton)
 {
-	if (event.type != SDL_MOUSEBUTTONDOWN || event.button.button != SDL_BUTTON_LEFT) {
+	if (event.type != SDL_MOUSEBUTTONUP || event.button.button != SDL_BUTTON_LEFT) {
 		return false;
 	}
 

--- a/Source/DiabloUI/title.cpp
+++ b/Source/DiabloUI/title.cpp
@@ -64,7 +64,7 @@ void UiTitleDialog()
 			}
 			switch (event.type) {
 			case SDL_KEYDOWN:
-			case SDL_MOUSEBUTTONDOWN:
+			case SDL_MOUSEBUTTONUP:
 				endMenu = true;
 				break;
 			}

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -40,8 +40,8 @@ void play_movie(const char *pszMovie, bool userCanClose)
 			while (movie_playing && FetchMessage(&msg)) {
 				switch (msg.message) {
 				case DVL_WM_KEYDOWN:
-				case DVL_WM_LBUTTONDOWN:
-				case DVL_WM_RBUTTONDOWN:
+				case DVL_WM_LBUTTONUP:
+				case DVL_WM_RBUTTONUP:
 					if (userCanClose || (msg.message == DVL_WM_KEYDOWN && msg.wParam == DVL_VK_ESCAPE))
 						movie_playing = false;
 					break;


### PR DESCRIPTION
Keypresses still occur on keydown to allow for repetition (e.g. when scrolling)

fixes #3850 