### PR TITLE
Replace uses of dObject with position-based lookup

### DIFF
--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -330,6 +330,8 @@ void CheckCursMove()
 	mx = clamp(mx, 0, MAXDUNX - 1);
 	my = clamp(my, 0, MAXDUNY - 1);
 
+	const Point currentTile { mx, my };
+
 	// While holding the button down we should retain target (but potentially lose it if it dies, goes out of view, etc)
 	if (sgbMouseDown != CLICK_NONE && IsNoneOf(LastMouseButtonAction, MouseActionType::None, MouseActionType::Attack, MouseActionType::Spell)) {
 		if (pcursmonst != -1) {
@@ -589,33 +591,32 @@ void CheckCursMove()
 		}
 	}
 	if (pcursmonst == -1 && pcursplr == -1) {
-		if (!flipflag && mx + 1 < MAXDUNX && dObject[mx + 1][my] != 0) {
-			int8_t bv = abs(dObject[mx + 1][my]) - 1;
-			if (Objects[bv]._oSelFlag >= 2) {
-				cursPosition = Point { mx, my } + Displacement { 1, 0 };
-				pcursobj = bv;
+		// No monsters or players under the cursor, try find an object starting with the tile below the current tile (tall
+		//  objects like doors)
+		Point testPosition = currentTile + Direction::South;
+		Object *object = ObjectAtPosition(testPosition);
+
+		if (object == nullptr || object->_oSelFlag < 2) {
+			// Either no object or can't interact from the test position, try the current tile
+			testPosition = currentTile;
+			object = ObjectAtPosition(testPosition);
+
+			if (object == nullptr || IsNoneOf(object->_oSelFlag, 1, 3)) {
+				// Still no object (that could be activated from this position), try the tile to the bottom left or right
+				//  (whichever is closest to the cursor as determined when we set flipflag earlier)
+				testPosition = currentTile + (flipflag ? Direction::SouthWest : Direction::SouthEast);
+				object = ObjectAtPosition(testPosition);
+
+				if (object != nullptr && object->_oSelFlag < 2) {
+					// Found an object but it's not in range, clear the pointer
+					object = nullptr;
+				}
 			}
 		}
-		if (flipflag && my + 1 < MAXDUNY && dObject[mx][my + 1] != 0) {
-			int8_t bv = abs(dObject[mx][my + 1]) - 1;
-			if (Objects[bv]._oSelFlag >= 2) {
-				cursPosition = Point { mx, my } + Displacement { 0, 1 };
-				pcursobj = bv;
-			}
-		}
-		if (dObject[mx][my] != 0) {
-			int8_t bv = abs(dObject[mx][my]) - 1;
-			if (Objects[bv]._oSelFlag == 1 || Objects[bv]._oSelFlag == 3) {
-				cursPosition = { mx, my };
-				pcursobj = bv;
-			}
-		}
-		if (mx + 1 < MAXDUNX && my + 1 < MAXDUNY && dObject[mx + 1][my + 1] != 0) {
-			int8_t bv = abs(dObject[mx + 1][my + 1]) - 1;
-			if (Objects[bv]._oSelFlag >= 2) {
-				cursPosition = Point { mx, my } + Displacement { 1, 1 };
-				pcursobj = bv;
-			}
+		if (object != nullptr) {
+			// found object that can be activated with the given cursor position
+			cursPosition = testPosition;
+			pcursobj = object->GetId();
 		}
 	}
 	if (pcursplr == -1 && pcursobj == -1 && pcursmonst == -1) {

--- a/Source/path.cpp
+++ b/Source/path.cpp
@@ -333,7 +333,7 @@ bool IsTileOccupied(Point position)
 	if (dPlayer[position.x][position.y] != 0) {
 		return true;
 	}
-	if (dObject[position.x][position.y] != 0) {
+	if (IsObjectAtPosition(position)) {
 		return true;
 	}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1151,9 +1151,9 @@ bool DoAttack(int pnum)
 
 		if ((player._pIFlags & ISPL_FIREDAM) == 0 || (player._pIFlags & ISPL_LIGHTDAM) == 0) {
 			if ((player._pIFlags & ISPL_FIREDAM) != 0) {
-				AddMissile({ dx, dy }, { 1, 0 }, Direction::South, MIS_WEAPEXP, TARGET_MONSTERS, pnum, 0, 0);
+				AddMissile(position, { 1, 0 }, Direction::South, MIS_WEAPEXP, TARGET_MONSTERS, pnum, 0, 0);
 			} else if ((player._pIFlags & ISPL_LIGHTDAM) != 0) {
-				AddMissile({ dx, dy }, { 2, 0 }, Direction::South, MIS_WEAPEXP, TARGET_MONSTERS, pnum, 0, 0);
+				AddMissile(position, { 2, 0 }, Direction::South, MIS_WEAPEXP, TARGET_MONSTERS, pnum, 0, 0);
 			}
 		}
 
@@ -1173,8 +1173,11 @@ bool DoAttack(int pnum)
 				p = -(dPlayer[dx][dy] + 1);
 			}
 			didhit = PlrHitPlr(pnum, p);
-		} else if (dObject[dx][dy] > 0) {
-			didhit = PlrHitObj(pnum, Objects[dObject[dx][dy] - 1]);
+		} else {
+			Object *object = ObjectAtPosition(position, false);
+			if (object != nullptr) {
+				didhit = PlrHitObj(pnum, *object);
+			}
 		}
 		if ((player._pClass == HeroClass::Monk
 		        && (player.InvBody[INVLOC_HAND_LEFT]._itype == ItemType::Staff || player.InvBody[INVLOC_HAND_RIGHT]._itype == ItemType::Staff))
@@ -1187,6 +1190,7 @@ bool DoAttack(int pnum)
 		                    || (player.InvBody[INVLOC_HAND_LEFT]._itype == ItemType::Sword && player.InvBody[INVLOC_HAND_LEFT]._iLoc == ILOC_TWOHAND)
 		                    || (player.InvBody[INVLOC_HAND_RIGHT]._itype == ItemType::Sword && player.InvBody[INVLOC_HAND_RIGHT]._iLoc == ILOC_TWOHAND))
 		                && !(player.InvBody[INVLOC_HAND_LEFT]._itype == ItemType::Shield || player.InvBody[INVLOC_HAND_RIGHT]._itype == ItemType::Shield))))) {
+			// playing as a class/weapon with cleave
 			position = player.position.tile + Right(player._pdir);
 			if (dMonster[position.x][position.y] != 0) {
 				int m = abs(dMonster[position.x][position.y]) - 1;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1476,6 +1476,17 @@ bool DoDeath(int pnum)
 	return false;
 }
 
+bool IsPlayerAdjacentToObject(Player &player, Object &object)
+{
+	int x = abs(player.position.tile.x - object.position.x);
+	int y = abs(player.position.tile.y - object.position.y);
+	if (y > 1 && ObjectAtPosition(object.position + Direction::NorthEast) == &object) {
+		// special case for activating a large object from the north-east side
+		y = abs(player.position.tile.y - object.position.y + 1);
+	}
+	return x <= 1 && y <= 1;
+}
+
 void CheckNewPath(int pnum, bool pmWillBeCalled)
 {
 	if ((DWORD)pnum >= MAX_PLRS) {
@@ -1673,12 +1684,7 @@ void CheckNewPath(int pnum, bool pmWillBeCalled)
 			player.spellLevel = player.destParam2;
 			break;
 		case ACTION_OPERATE:
-			x = abs(player.position.tile.x - object->position.x);
-			y = abs(player.position.tile.y - object->position.y);
-			if (y > 1 && dObject[object->position.x][object->position.y - 1] == -(targetId + 1)) {
-				y = abs(player.position.tile.y - object->position.y + 1);
-			}
-			if (x <= 1 && y <= 1) {
+			if (IsPlayerAdjacentToObject(player, *object)) {
 				if (object->_oBreak == 1) {
 					d = GetDirection(player.position.tile, object->position);
 					StartAttack(pnum, d);
@@ -1688,12 +1694,7 @@ void CheckNewPath(int pnum, bool pmWillBeCalled)
 			}
 			break;
 		case ACTION_DISARM:
-			x = abs(player.position.tile.x - object->position.x);
-			y = abs(player.position.tile.y - object->position.y);
-			if (y > 1 && dObject[object->position.x][object->position.y - 1] == -(targetId + 1)) {
-				y = abs(player.position.tile.y - object->position.y + 1);
-			}
-			if (x <= 1 && y <= 1) {
+			if (IsPlayerAdjacentToObject(player, *object)) {
 				if (object->_oBreak == 1) {
 					d = GetDirection(player.position.tile, object->position);
 					StartAttack(pnum, d);
@@ -1764,12 +1765,7 @@ void CheckNewPath(int pnum, bool pmWillBeCalled)
 			}
 			player.destAction = ACTION_NONE;
 		} else if (player.destAction == ACTION_OPERATE) {
-			x = abs(player.position.tile.x - object->position.x);
-			y = abs(player.position.tile.y - object->position.y);
-			if (y > 1 && dObject[object->position.x][object->position.y - 1] == -(targetId + 1)) {
-				y = abs(player.position.tile.y - object->position.y + 1);
-			}
-			if (x <= 1 && y <= 1) {
+			if (IsPlayerAdjacentToObject(player, *object)) {
 				if (object->_oBreak == 1) {
 					d = GetDirection(player.position.tile, object->position);
 					StartAttack(pnum, d);


### PR DESCRIPTION
Allows for a bit of a cleanup where it was previously used. The only remaining uses for lookup are internal to objects.cpp and the one in plrctrls.cpp which has been added to #3336

dObjects is referenced in debug.cpp, loadsave.cpp, gendung.cpp purely for setting/clearing/viewing indexes directly, that can be changed but I'll do it as part of the cleanup of how objects.cpp works internally.