### PR TITLE
Replace en_US code with en when searching for user preferred languages

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1032,22 +1032,7 @@ void OptionEntryLanguageCode::LoadFromIni(string_view category)
 
 	// So that the correct language is shown in the settings menu for users with US english set as a preferred language
 	//  we need to replace the "en_US" locale code with the neutral string "en" as expected by the available options
-	auto usEnglishLocale = std::find(locales.begin(), locales.end(), "en_US");
-	if (usEnglishLocale != locales.end()) {
-		auto neutralEnglishLocale = std::find(locales.begin(), locales.end(), "en");
-		if (usEnglishLocale < neutralEnglishLocale) {
-			// Neutral locale either isn't user-preferred or is after the us english variation in preferences, so we
-			//  can update this entry
-			*usEnglishLocale = "en";
-			if (neutralEnglishLocale != locales.end()) {
-				// And remove the now duplicate neutral variant (if it exists)
-				locales.erase(neutralEnglishLocale);
-			}
-		} else {
-			// somehow there's already a neutral locale earlier than the regional variation, remove the en_US entry
-			locales.erase(usEnglishLocale);
-		}
-	}
+	std::replace(locales.begin(), locales.end(), std::string { "en_US" }, std::string { "en" });
 
 	// Insert non-regional locale codes after the last regional variation so we fallback to neutral translations if no
 	//  regional translation exists that meets user preferences.

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -270,8 +270,9 @@ const std::string &LanguageTranslate(const char *key)
 
 bool HasTranslation(const std::string &locale)
 {
-	if (locale == "en" || locale == "en_US") {
-		// the base translation is en_US. No translation file will be present for these codes but we want the check to succeed to prevent further searches.
+	if (locale == "en") {
+		// the base translation is en (really en_US). No translation file will be present for this code but we want
+		//  the check to succeed to prevent further searches.
 		return true;
 	}
 


### PR DESCRIPTION
This allows the settings menu to display the expected value

fixes #3858 