### PR TITLE
Get user preferred languages on apple devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,12 @@ if(APPLE)
         COMPONENT Runtime)
   endif()
 
+  find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+  if(COREFOUNDATION_LIBRARY)
+    target_link_libraries(libdevilutionx PUBLIC "${COREFOUNDATION_LIBRARY}")
+    target_compile_definitions(libdevilutionx PRIVATE USE_COREFOUNDATION)
+  endif()
+
   set(MACOSX_BUNDLE_LONG_VERSION_STRING "Version ${PROJECT_VERSION}")
   set(CPACK On)
 endif()

--- a/Source/platform/locale.hpp
+++ b/Source/platform/locale.hpp
@@ -5,6 +5,10 @@
 
 namespace devilution {
 
+/**
+ * @brief Returns a list of preferred languages based on user/system configuration.
+ * @return 0 or more POSIX locale codes (language code with optional region identifier)
+ */
 std::vector<std::string> GetLocales();
 
 } // namespace devilution


### PR DESCRIPTION
Adapts the sample code provided by @bubio in #3641 so GetLocales() returns a list of POSIX language codes on apple devices (hopefully... I don't have an environment set up to cross-compile this, lets see if the build works).

Co-authored-by: Bubio <bubio66@gmail.com>