### PR TITLE
Use native script for translated language names

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -957,25 +957,25 @@ void OptionEntryLanguageCode::CheckLanguagesAreInitialized() const
 		return;
 
 	// Add well-known supported languages
-	languages.emplace_back("bg", "Bulgarian");
-	languages.emplace_back("cs", "Czech");
-	languages.emplace_back("da", "Danish");
-	languages.emplace_back("de", "German");
+	languages.emplace_back("bg", "Български - Bulgarian");
+	languages.emplace_back("cs", "Čeština - Czech");
+	languages.emplace_back("da", "Dansk - Danish");
+	languages.emplace_back("de", "Deutsch - German");
 	languages.emplace_back("en", "English");
-	languages.emplace_back("es", "Spanish");
-	languages.emplace_back("fr", "French");
-	languages.emplace_back("ja", "Japanese");
-	languages.emplace_back("hr", "Croatian");
-	languages.emplace_back("it", "Italian");
-	languages.emplace_back("ko_KR", "Korean");
-	languages.emplace_back("pl", "Polish");
-	languages.emplace_back("pt_BR", "Portuguese (Brazil)");
-	languages.emplace_back("ro_RO", "Romanian");
-	languages.emplace_back("ru", "Russian");
-	languages.emplace_back("sv", "Swedish");
-	languages.emplace_back("uk", "Ukrainian");
-	languages.emplace_back("zh_CN", "Simplified Chinese");
-	languages.emplace_back("zh_TW", "Traditional Chinese");
+	languages.emplace_back("es", "Español - Spanish");
+	languages.emplace_back("fr", "Français - French");
+	languages.emplace_back("ja", "日本語 - Japanese");
+	languages.emplace_back("hr", "Hrvatski - Croatian");
+	languages.emplace_back("it", "Italiano - Italian");
+	languages.emplace_back("ko_KR", "한국어 - Korean");
+	languages.emplace_back("pl", "Polski - Polish");
+	languages.emplace_back("pt_BR", "Português do Brasil - Portuguese (Brazil)");
+	languages.emplace_back("ro_RO", "Română - Romanian");
+	languages.emplace_back("ru", "Русский - Russian");
+	languages.emplace_back("sv", "Svenska - Swedish");
+	languages.emplace_back("uk", "Українська - Ukrainian");
+	languages.emplace_back("zh_CN", "汉语 - Simplified Chinese");
+	languages.emplace_back("zh_TW", "漢語 - Traditional Chinese");
 
 	// Ensures that the ini specified language is present in languages list even if unknown (for example if someone starts to translate a new language)
 	if (std::find_if(languages.begin(), languages.end(), [this](const auto &x) { return x.first == this->szCode; }) == languages.end()) {

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -957,23 +957,23 @@ void OptionEntryLanguageCode::CheckLanguagesAreInitialized() const
 		return;
 
 	// Add well-known supported languages
-	languages.emplace_back("bg", "Български - Bulgarian");
-	languages.emplace_back("cs", "Čeština - Czech");
-	languages.emplace_back("da", "Dansk - Danish");
-	languages.emplace_back("de", "Deutsch - German");
+	languages.emplace_back("bg", "Български");
+	languages.emplace_back("cs", "Čeština");
+	languages.emplace_back("da", "Dansk");
+	languages.emplace_back("de", "Deutsch");
 	languages.emplace_back("en", "English");
-	languages.emplace_back("es", "Español - Spanish");
-	languages.emplace_back("fr", "Français - French");
+	languages.emplace_back("es", "Español");
+	languages.emplace_back("fr", "Français");
 	languages.emplace_back("ja", "日本語 - Japanese");
-	languages.emplace_back("hr", "Hrvatski - Croatian");
-	languages.emplace_back("it", "Italiano - Italian");
+	languages.emplace_back("hr", "Hrvatski");
+	languages.emplace_back("it", "Italiano");
 	languages.emplace_back("ko_KR", "한국어 - Korean");
-	languages.emplace_back("pl", "Polski - Polish");
-	languages.emplace_back("pt_BR", "Português do Brasil - Portuguese (Brazil)");
-	languages.emplace_back("ro_RO", "Română - Romanian");
-	languages.emplace_back("ru", "Русский - Russian");
-	languages.emplace_back("sv", "Svenska - Swedish");
-	languages.emplace_back("uk", "Українська - Ukrainian");
+	languages.emplace_back("pl", "Polski");
+	languages.emplace_back("pt_BR", "Português do Brasil");
+	languages.emplace_back("ro_RO", "Română");
+	languages.emplace_back("ru", "Русский");
+	languages.emplace_back("sv", "Svenska");
+	languages.emplace_back("uk", "Українська");
 	languages.emplace_back("zh_CN", "汉语 - Simplified Chinese");
 	languages.emplace_back("zh_TW", "漢語 - Traditional Chinese");
 

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -964,18 +964,25 @@ void OptionEntryLanguageCode::CheckLanguagesAreInitialized() const
 	languages.emplace_back("en", "English");
 	languages.emplace_back("es", "Español");
 	languages.emplace_back("fr", "Français");
-	languages.emplace_back("ja", "日本語 - Japanese");
 	languages.emplace_back("hr", "Hrvatski");
 	languages.emplace_back("it", "Italiano");
-	languages.emplace_back("ko_KR", "한국어 - Korean");
+
+	if (font_mpq) {
+		languages.emplace_back("ja", "日本語");
+		languages.emplace_back("ko_KR", "한국어");
+	}
+
 	languages.emplace_back("pl", "Polski");
 	languages.emplace_back("pt_BR", "Português do Brasil");
 	languages.emplace_back("ro_RO", "Română");
 	languages.emplace_back("ru", "Русский");
 	languages.emplace_back("sv", "Svenska");
 	languages.emplace_back("uk", "Українська");
-	languages.emplace_back("zh_CN", "汉语 - Simplified Chinese");
-	languages.emplace_back("zh_TW", "漢語 - Traditional Chinese");
+
+	if (font_mpq) {
+		languages.emplace_back("zh_CN", "汉语");
+		languages.emplace_back("zh_TW", "漢語");
+	}
 
 	// Ensures that the ini specified language is present in languages list even if unknown (for example if someone starts to translate a new language)
 	if (std::find_if(languages.begin(), languages.end(), [this](const auto &x) { return x.first == this->szCode; }) == languages.end()) {


### PR DESCRIPTION
Without fonts.mpq:
![2022-01-02T205847_devilutionx](https://user-images.githubusercontent.com/357684/147872455-57a4ed79-158f-4e93-b513-ea19cdf401ac.png)

With fonts.mpq:
![2022-01-02T210050_devilutionx](https://user-images.githubusercontent.com/357684/147872461-4ed15b01-0156-4e80-b30d-9513fa603bc3.png)

Requires fonts.mpq in order to display options with extended scripts like korean/japanese/chinese. ~Also not sure the strings chosen are appropriate in all cases, e.g. I think "Limba română" literally translated means "language of romania"? "Român" might be better there.~

fixes #3881 

~Also note the line for Portugese (Brazil) is affected by the bug described in #3834. It's long enough that if wrapping was calculating the correct bounds it'd take up two lines. I'd rather fix that bug than shorten these lines as a workaround.~