### PR TITLE
More QuickSpell Hotkeys

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1449,12 +1449,12 @@ void InitKeymapActions()
 		    CanPlayerTakeAction,
 		    i + 1);
 	}
-	for (int i = 0; i < 4; ++i) {
+	for (size_t i = 0; i < NumHotkeys; ++i) {
 		sgOptions.Keymapper.AddAction(
 		    "QuickSpell{}",
 		    N_("Quick spell {}"),
 		    N_("Hotkey for skill or spell."),
-		    DVL_VK_F5 + i,
+		    i < 4 ? DVL_VK_F5 + i : DVL_VK_INVALID,
 		    [i]() {
 			    if (spselflag) {
 				    SetSpeedSpell(i);

--- a/Source/panels/spell_list.cpp
+++ b/Source/panels/spell_list.cpp
@@ -85,7 +85,7 @@ bool GetSpellListSelection(spell_id &pSpell, spell_type &pSplType)
 std::optional<string_view> GetHotkeyName(spell_id spellId, spell_type spellType)
 {
 	auto &myPlayer = Players[MyPlayerId];
-	for (int t = 0; t < 4; t++) {
+	for (size_t t = 0; t < NumHotkeys; t++) {
 		if (myPlayer._pSplHotKey[t] != spellId || myPlayer._pSplTHotKey[t] != spellType)
 			continue;
 		auto quickSpellActionKey = fmt::format("QuickSpell{}", t + 1);
@@ -286,7 +286,7 @@ void SetSpeedSpell(int slot)
 		return;
 	}
 	auto &myPlayer = Players[MyPlayerId];
-	for (int i = 0; i < 4; ++i) {
+	for (size_t i = 0; i < NumHotkeys; ++i) {
 		if (myPlayer._pSplHotKey[i] == pSpell && myPlayer._pSplTHotKey[i] == pSplType)
 			myPlayer._pSplHotKey[i] = SPL_INVALID;
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2627,11 +2627,8 @@ void CreatePlayer(int playerId, HeroClass c)
 		player._pSplLvl[SPL_FIREBOLT] = 2;
 	}
 
-	// interestingly, only the first three hotkeys are reset
-	// TODO: BUGFIX: clear all 4 hotkeys instead of 3 (demo leftover)
-	for (int i = 0; i < 3; i++) {
-		player._pSplHotKey[i] = SPL_INVALID;
-	}
+	// Initializing the hotkey bindings to no selection
+	std::fill(player._pSplHotKey, player._pSplHotKey + NumHotkeys, SPL_INVALID);
 
 	PlayerWeaponGraphic animWeaponId = PlayerWeaponGraphic::Unarmed;
 	switch (c) {

--- a/Source/player.h
+++ b/Source/player.h
@@ -34,6 +34,7 @@ namespace devilution {
 #define MAX_SPELL_LEVEL 15
 #define PLR_NAME_LEN 32
 
+constexpr size_t NumHotkeys = 12;
 constexpr int BaseHitChance = 50;
 
 /** Walking directions */
@@ -251,8 +252,8 @@ struct Player {
 	uint64_t _pAblSpells;  // Bitmask of abilities
 	uint64_t _pScrlSpells; // Bitmask of spells available via scrolls
 	SpellFlag _pSpellFlags;
-	spell_id _pSplHotKey[4];
-	spell_type _pSplTHotKey[4];
+	spell_id _pSplHotKey[NumHotkeys];
+	spell_type _pSplTHotKey[NumHotkeys];
 	bool _pBlockFlag;
 	bool _pInvincible;
 	int8_t _pLightRad;


### PR DESCRIPTION
- Added 12 more QuickSpell hotkeys for a total of 16.
- Preserve compatibility with single player in LoadPlayer/SavePlayer by saving/loading only 4 hotkeys.
- The number of QuickSpells is hard coded now, but it's easy to change. The LoadHotkeys()/SaveHotkeys() functions already handles a different number of saved hotkeys by reading/writing the number of hotkeys at the beginning of the "hotkeys" file.

Note: when loading older save files, the LoadHotkeys() function will read offset data/garbage, in my tests this doesn't cause problems, but I might just have been lucky, this probably needs some more testing.