### PR TITLE
Mana Shield 1.07 bugfix revision

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2104,6 +2104,12 @@ void Player::Reset()
 	*this = std::move(*emptyPlayer);
 }
 
+int Player::GetManaShieldDamageReduction()
+{
+	constexpr int8_t Max = 7;
+	return 24 - std::min(_pSplLvl[SPL_MANASHIELD], Max) * 3;
+}
+
 void Player::RestorePartialLife()
 {
 	int wholeHitpoints = _pMaxHP >> 6;
@@ -3229,7 +3235,7 @@ void ApplyPlrDamage(int pnum, int dam, int minHP /*= 0*/, int frac /*= 0*/, int 
 	if (totalDamage > 0 && player.pManaShield) {
 		int8_t manaShieldLevel = player._pSplLvl[SPL_MANASHIELD];
 		if (manaShieldLevel > 0) {
-			totalDamage += totalDamage / -3;
+			totalDamage += totalDamage / -player.GetManaShieldDamageReduction();
 		}
 		if (pnum == MyPlayerId)
 			drawmanaflag = true;
@@ -3240,7 +3246,7 @@ void ApplyPlrDamage(int pnum, int dam, int minHP /*= 0*/, int frac /*= 0*/, int 
 		} else {
 			totalDamage -= player._pMana;
 			if (manaShieldLevel > 0) {
-				totalDamage += totalDamage / 2;
+				totalDamage += totalDamage / (player.GetManaShieldDamageReduction() - 1);
 			}
 			player._pMana = 0;
 			player._pManaBase = player._pMaxManaBase - player._pMaxMana;

--- a/Source/player.h
+++ b/Source/player.h
@@ -528,6 +528,13 @@ struct Player {
 	}
 
 	/**
+	 * @brief Return reciprocal of the factor for calculating damage reduction due to Mana Shield.
+	 *
+	 * Valid only for players with Mana Shield spell level greater than zero.
+	 */
+	int GetManaShieldDamageReduction();
+
+	/**
 	 * @brief Return monster armor value after including player's armor piercing % (hellfire only)
 	 * @param monsterArmor - monster armor before applying % armor pierce
 	 * @param isMelee - indicates if it's melee or ranged combat


### PR DESCRIPTION
This is a bugfix for the vanilla 1.06 and earlier Mana Shield logic. In 1.07 Blizzard North "fixed" the Mana Shield logic since the damage reduction would decrease in effectiveness with increased spell level instead of increase. As a fix, they set the damage reduction to a flat value regardless of spell level. Originally, damage reduction started at 1/3 and capped at 1/21 at spell level 7. This fix reverses the order and gives 1/21 damage reduction at spell level 1, and caps at 1/3 damage reduction at spell level 7.

End result damage reduction values (based on 100 incoming damage):
SLvl 0 = 0
SLvl 1 = 4
SLvl 2 = 5
SLvl 3 = 6
SLvl 4 = 8
SLvl 5 = 11
SLvl 6 = 16
SLvl 7+ = 33