### PR TITLE
Fix Stat Adjustment

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3601,12 +3601,7 @@ void ModifyPlrStr(int p, int l)
 	auto &player = Players[p];
 
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Strength);
-	if (player._pBaseStr + l > max) {
-		l = max - player._pBaseStr;
-	}
-	if (player._pBaseStr + l < 0) {
-		l = 0;
-	}
+	l = clamp(l, 0, max - player._pBaseStr);
 
 	player._pStrength += l;
 	player._pBaseStr += l;
@@ -3626,12 +3621,7 @@ void ModifyPlrMag(int p, int l)
 	auto &player = Players[p];
 
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Magic);
-	if (player._pBaseMag + l > max) {
-		l = max - player._pBaseMag;
-	}
-	if (player._pBaseMag + l < 0) {
-		l = 0;
-	}
+	l = clamp(l, 0, max - player._pBaseMag);
 
 	player._pMagic += l;
 	player._pBaseMag += l;
@@ -3665,12 +3655,7 @@ void ModifyPlrDex(int p, int l)
 	auto &player = Players[p];
 
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Dexterity);
-	if (player._pBaseDex + l > max) {
-		l = max - player._pBaseDex;
-	}
-	if (player._pBaseDex + l < 0) {
-		l = 0;
-	}
+	l = clamp(l, 0, max - player._pBaseDex);
 
 	player._pDexterity += l;
 	player._pBaseDex += l;
@@ -3689,12 +3674,7 @@ void ModifyPlrVit(int p, int l)
 	auto &player = Players[p];
 
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Vitality);
-	if (player._pBaseVit + l > max) {
-		l = max - player._pBaseVit;
-	}
-	if (player._pBaseVit + l < 0) {
-		l = 0;
-	}
+	l = clamp(l, 0, max - player._pBaseVit);
 
 	player._pVitality += l;
 	player._pBaseVit += l;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3603,7 +3603,8 @@ void ModifyPlrStr(int p, int l)
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Strength);
 	if (player._pBaseStr + l > max) {
 		l = max - player._pBaseStr;
-	} else if (player._pBaseStr + l < 0) {
+	}
+	if (player._pBaseStr + l < 0) {
 		l = 0;
 	}
 
@@ -3627,7 +3628,8 @@ void ModifyPlrMag(int p, int l)
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Magic);
 	if (player._pBaseMag + l > max) {
 		l = max - player._pBaseMag;
-	} else if (player._pBaseMag + l < 0) {
+	}
+	if (player._pBaseMag + l < 0) {
 		l = 0;
 	}
 
@@ -3665,7 +3667,8 @@ void ModifyPlrDex(int p, int l)
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Dexterity);
 	if (player._pBaseDex + l > max) {
 		l = max - player._pBaseDex;
-	} else if (player._pBaseDex + l < 0) {
+	}
+	if (player._pBaseDex + l < 0) {
 		l = 0;
 	}
 
@@ -3688,7 +3691,8 @@ void ModifyPlrVit(int p, int l)
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Vitality);
 	if (player._pBaseVit + l > max) {
 		l = max - player._pBaseVit;
-	} else if (player._pBaseVit + l < 0) {
+	}
+	if (player._pBaseVit + l < 0) {
 		l = 0;
 	}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3603,6 +3603,8 @@ void ModifyPlrStr(int p, int l)
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Strength);
 	if (player._pBaseStr + l > max) {
 		l = max - player._pBaseStr;
+	} else if (player._pBaseStr + l < 0) {
+		l = 0;
 	}
 
 	player._pStrength += l;
@@ -3625,6 +3627,8 @@ void ModifyPlrMag(int p, int l)
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Magic);
 	if (player._pBaseMag + l > max) {
 		l = max - player._pBaseMag;
+	} else if (player._pBaseMag + l < 0) {
+		l = 0;
 	}
 
 	player._pMagic += l;
@@ -3661,6 +3665,8 @@ void ModifyPlrDex(int p, int l)
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Dexterity);
 	if (player._pBaseDex + l > max) {
 		l = max - player._pBaseDex;
+	} else if (player._pBaseDex + l < 0) {
+		l = 0;
 	}
 
 	player._pDexterity += l;
@@ -3682,6 +3688,8 @@ void ModifyPlrVit(int p, int l)
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Vitality);
 	if (player._pBaseVit + l > max) {
 		l = max - player._pBaseVit;
+	} else if (player._pBaseVit + l < 0) {
+		l = 0;
 	}
 
 	player._pVitality += l;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3600,9 +3600,7 @@ void ModifyPlrStr(int p, int l)
 	}
 	auto &player = Players[p];
 
-	int max = player.GetMaximumAttributeValue(CharacterAttribute::Strength);
-
-	l = clamp(l, 0 - player._pBaseStr, max - player._pBaseStr);
+	l = clamp(l, 0 - player._pBaseStr, player.GetMaximumAttributeValue(CharacterAttribute::Strength) - player._pBaseStr);
 
 	player._pStrength += l;
 	player._pBaseStr += l;
@@ -3621,8 +3619,7 @@ void ModifyPlrMag(int p, int l)
 	}
 	auto &player = Players[p];
 
-	int max = player.GetMaximumAttributeValue(CharacterAttribute::Magic);
-	l = clamp(l, 0 - player._pBaseStr, max - player._pBaseMag);
+	l = clamp(l, 0 - player._pBaseStr, player.GetMaximumAttributeValue(CharacterAttribute::Magic) - player._pBaseMag);
 
 	player._pMagic += l;
 	player._pBaseMag += l;
@@ -3655,8 +3652,7 @@ void ModifyPlrDex(int p, int l)
 	}
 	auto &player = Players[p];
 
-	int max = player.GetMaximumAttributeValue(CharacterAttribute::Dexterity);
-	l = clamp(l, 0 - player._pBaseDex, max - player._pBaseDex);
+	l = clamp(l, 0 - player._pBaseDex, player.GetMaximumAttributeValue(CharacterAttribute::Dexterity) - player._pBaseDex);
 
 	player._pDexterity += l;
 	player._pBaseDex += l;
@@ -3675,7 +3671,7 @@ void ModifyPlrVit(int p, int l)
 	auto &player = Players[p];
 
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Vitality);
-	l = clamp(l, 0 - player._pBaseVit, max - player._pBaseVit);
+	l = clamp(l, 0 - player._pBaseVit, player.GetMaximumAttributeValue(CharacterAttribute::Vitality) - player._pBaseVit);
 
 	player._pVitality += l;
 	player._pBaseVit += l;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3670,7 +3670,6 @@ void ModifyPlrVit(int p, int l)
 	}
 	auto &player = Players[p];
 
-	int max = player.GetMaximumAttributeValue(CharacterAttribute::Vitality);
 	l = clamp(l, 0 - player._pBaseVit, player.GetMaximumAttributeValue(CharacterAttribute::Vitality) - player._pBaseVit);
 
 	player._pVitality += l;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3601,7 +3601,8 @@ void ModifyPlrStr(int p, int l)
 	auto &player = Players[p];
 
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Strength);
-	l = clamp(l, 0, max - player._pBaseStr);
+
+	l = clamp(l, 0 - player._pBaseStr, max - player._pBaseStr);
 
 	player._pStrength += l;
 	player._pBaseStr += l;
@@ -3621,7 +3622,7 @@ void ModifyPlrMag(int p, int l)
 	auto &player = Players[p];
 
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Magic);
-	l = clamp(l, 0, max - player._pBaseMag);
+	l = clamp(l, 0 - player._pBaseStr, max - player._pBaseMag);
 
 	player._pMagic += l;
 	player._pBaseMag += l;
@@ -3655,7 +3656,7 @@ void ModifyPlrDex(int p, int l)
 	auto &player = Players[p];
 
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Dexterity);
-	l = clamp(l, 0, max - player._pBaseDex);
+	l = clamp(l, 0 - player._pBaseDex, max - player._pBaseDex);
 
 	player._pDexterity += l;
 	player._pBaseDex += l;
@@ -3674,7 +3675,7 @@ void ModifyPlrVit(int p, int l)
 	auto &player = Players[p];
 
 	int max = player.GetMaximumAttributeValue(CharacterAttribute::Vitality);
-	l = clamp(l, 0, max - player._pBaseVit);
+	l = clamp(l, 0 - player._pBaseVit, max - player._pBaseVit);
 
 	player._pVitality += l;
 	player._pBaseVit += l;


### PR DESCRIPTION
This fixes a problem related to shrines. When a player with a base Magic or Vitality stat of 0 has their respective stat reduced below 0, they lose Mana/Life, and their stat is corrected to 0 without refunding them the lost Mana/Life. This will prevent stats from being modified to a value less than 0 in the first place.