### PR TITLE
Menu option text improvement

### DIFF
--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -36,7 +36,7 @@ TMenuItem sgSingleMenu[] = {
 	{ GMENU_ENABLED, N_("Options"),       &GamemenuOptions    },
 	{ GMENU_ENABLED, N_("New Game"),      &GamemenuNewGame   },
 	{ GMENU_ENABLED, N_("Load Game"),     &gamemenu_load_game  },
-	{ GMENU_ENABLED, N_("Quit Game"),     &gamemenu_quit_game  },
+	{ GMENU_ENABLED, N_("Quit Diablo"),   &gamemenu_quit_game  },
 	{ GMENU_ENABLED, nullptr,              nullptr             }
 	// clang-format on
 };
@@ -45,9 +45,9 @@ TMenuItem sgMultiMenu[] = {
 	// clang-format off
     // dwFlags,      pszStr,                fnMenu
 	{ GMENU_ENABLED, N_("Options"),         &GamemenuOptions      },
-	{ GMENU_ENABLED, N_("New Game"),        &GamemenuNewGame     },
-	{ GMENU_ENABLED, N_("Restart In Town"), &GamemenuRestartTown },
-	{ GMENU_ENABLED, N_("Quit Game"),       &gamemenu_quit_game    },
+	{ GMENU_ENABLED, N_("Leave Game"),      &GamemenuNewGame     },
+	{ GMENU_ENABLED, N_("Respawn In Town"), &GamemenuRestartTown },
+	{ GMENU_ENABLED, N_("Quit Diablo"),     &gamemenu_quit_game    },
 	{ GMENU_ENABLED, nullptr,                nullptr               },
 	// clang-format on
 };

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -33,9 +33,9 @@ TMenuItem sgSingleMenu[] = {
 	// clang-format off
     // dwFlags,      pszStr,              fnMenu
 	{ GMENU_ENABLED, N_("Save Game"),     &gamemenu_save_game  },
-	{ GMENU_ENABLED, N_("Options"),       &GamemenuOptions    },
-	{ GMENU_ENABLED, N_("New Game"),      &GamemenuNewGame   },
 	{ GMENU_ENABLED, N_("Load Game"),     &gamemenu_load_game  },
+	{ GMENU_ENABLED, N_("New Game"),      &GamemenuNewGame   },
+	{ GMENU_ENABLED, N_("Options"),       &GamemenuOptions    },
 	{ GMENU_ENABLED, N_("Quit Diablo"),   &gamemenu_quit_game  },
 	{ GMENU_ENABLED, nullptr,              nullptr             }
 	// clang-format on
@@ -44,9 +44,9 @@ TMenuItem sgSingleMenu[] = {
 TMenuItem sgMultiMenu[] = {
 	// clang-format off
     // dwFlags,      pszStr,                fnMenu
-	{ GMENU_ENABLED, N_("Options"),         &GamemenuOptions      },
-	{ GMENU_ENABLED, N_("Leave Game"),      &GamemenuNewGame     },
 	{ GMENU_ENABLED, N_("Respawn In Town"), &GamemenuRestartTown },
+	{ GMENU_ENABLED, N_("Leave Game"),      &GamemenuNewGame     },
+	{ GMENU_ENABLED, N_("Options"),         &GamemenuOptions      },
 	{ GMENU_ENABLED, N_("Quit Diablo"),     &gamemenu_quit_game    },
 	{ GMENU_ENABLED, nullptr,                nullptr               },
 	// clang-format on

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -84,7 +84,7 @@ void GamemenuUpdateSingle()
 
 void GamemenuUpdateMulti()
 {
-	gmenu_enable(&sgMultiMenu[2], MyPlayerIsDead);
+	gmenu_enable(&sgMultiMenu[0], MyPlayerIsDead);
 }
 
 void GamemenuPrevious(bool /*bActivate*/)


### PR DESCRIPTION
Revised menu text to more accurately represent the menu options to the player. Reorganizes each item for consistency between SP and MP (Bottom 3 items are identical between the two game modes)

![image](https://user-images.githubusercontent.com/68359262/148323058-3a5fa21a-9d77-4ed6-8ecf-fd5e6214840d.png)

![image](https://user-images.githubusercontent.com/68359262/148323212-2aca862b-4353-41b6-b08b-80b2e5900f51.png)
