### PR TITLE
Reset game info after failing to join game

### DIFF
--- a/Source/DiabloUI/selgame.cpp
+++ b/Source/DiabloUI/selgame.cpp
@@ -494,6 +494,7 @@ void selgame_Password_Select(int /*value*/)
 		strcpy(sgOptions.Network.szPreviousHost, selgame_Ip);
 		if (SNetJoinGame(selgame_Ip, gamePassword, gdwPlayerId)) {
 			if (!IsGameCompatible(*m_game_data)) {
+				InitGameInfo();
 				selgame_GameSelection_Select(1);
 				return;
 			}
@@ -501,6 +502,7 @@ void selgame_Password_Select(int /*value*/)
 			UiInitList_clear();
 			selgame_endMenu = true;
 		} else {
+			InitGameInfo();
 			selgame_Free();
 			std::string error = SDL_GetError();
 			if (error.empty())

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -464,6 +464,21 @@ bool InitMulti(GameData *gameData)
 
 } // namespace
 
+void InitGameInfo()
+{
+	sgGameInitInfo.size = sizeof(sgGameInitInfo);
+	sgGameInitInfo.dwSeed = time(nullptr);
+	sgGameInitInfo.programid = GAME_ID;
+	sgGameInitInfo.versionMajor = PROJECT_VERSION_MAJOR;
+	sgGameInitInfo.versionMinor = PROJECT_VERSION_MINOR;
+	sgGameInitInfo.versionPatch = PROJECT_VERSION_PATCH;
+	sgGameInitInfo.nTickRate = sgOptions.Gameplay.nTickRate;
+	sgGameInitInfo.bRunInTown = *sgOptions.Gameplay.runInTown ? 1 : 0;
+	sgGameInitInfo.bTheoQuest = *sgOptions.Gameplay.theoQuest ? 1 : 0;
+	sgGameInitInfo.bCowQuest = *sgOptions.Gameplay.cowQuest ? 1 : 0;
+	sgGameInitInfo.bFriendlyFire = *sgOptions.Gameplay.friendlyFire ? 1 : 0;
+}
+
 void NetSendLoPri(int playerId, const byte *data, size_t size)
 {
 	if (data != nullptr && size != 0) {
@@ -684,17 +699,7 @@ bool NetInit(bool bSinglePlayer)
 {
 	while (true) {
 		SetRndSeed(0);
-		sgGameInitInfo.size = sizeof(sgGameInitInfo);
-		sgGameInitInfo.dwSeed = time(nullptr);
-		sgGameInitInfo.programid = GAME_ID;
-		sgGameInitInfo.versionMajor = PROJECT_VERSION_MAJOR;
-		sgGameInitInfo.versionMinor = PROJECT_VERSION_MINOR;
-		sgGameInitInfo.versionPatch = PROJECT_VERSION_PATCH;
-		sgGameInitInfo.nTickRate = sgOptions.Gameplay.nTickRate;
-		sgGameInitInfo.bRunInTown = *sgOptions.Gameplay.runInTown ? 1 : 0;
-		sgGameInitInfo.bTheoQuest = *sgOptions.Gameplay.theoQuest ? 1 : 0;
-		sgGameInitInfo.bCowQuest = *sgOptions.Gameplay.cowQuest ? 1 : 0;
-		sgGameInitInfo.bFriendlyFire = *sgOptions.Gameplay.friendlyFire ? 1 : 0;
+		InitGameInfo();
 		memset(sgbPlayerTurnBitTbl, 0, sizeof(sgbPlayerTurnBitTbl));
 		gbGameDestroyed = false;
 		memset(sgbPlayerLeftGameTbl, 0, sizeof(sgbPlayerLeftGameTbl));

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -44,6 +44,7 @@ extern bool PublicGame;
 extern BYTE gbDeltaSender;
 extern uint32_t player_state[MAX_PLRS];
 
+void InitGameInfo();
 void NetSendLoPri(int playerId, const byte *data, size_t size);
 void NetSendHiPri(int playerId, const byte *data, size_t size);
 void multi_send_msg_packet(uint32_t pmask, const byte *data, size_t size);


### PR DESCRIPTION
Prior to this change, game init info would only be initialized at the same time the multiplayer menu is initialized. Joining a game will overwrite game init info, but if you fail to join the game, you will never leave the multiplayer menu and so game init info would never be reinitialized. This can lead to some really unhappy situations if you create a new game right after failing to join one.