### PR TITLE
Improve ZeroTier public game menu

### DIFF
--- a/Source/DiabloUI/selgame.cpp
+++ b/Source/DiabloUI/selgame.cpp
@@ -538,8 +538,7 @@ void RefreshGameList()
 
 	uint32_t currentTime = SDL_GetTicks();
 
-	if (lastRequest == 0 || currentTime - lastRequest > 30000) {
-		DvlNet_SendInfoRequest();
+	if ((lastRequest == 0 || currentTime - lastRequest > 30000) && DvlNet_SendInfoRequest()) {
 		lastRequest = currentTime;
 		lastUpdate = currentTime - 3000; // Give 2 sec for responses, but don't wait 5
 	}

--- a/Source/dvlnet/abstract_net.h
+++ b/Source/dvlnet/abstract_net.h
@@ -48,8 +48,9 @@ public:
 	{
 	}
 
-	virtual void send_info_request()
+	virtual bool send_info_request()
 	{
+		return true;
 	}
 
 	virtual void clear_gamelist()

--- a/Source/dvlnet/base_protocol.h
+++ b/Source/dvlnet/base_protocol.h
@@ -25,7 +25,7 @@ public:
 	virtual bool SNetLeaveGame(int type);
 
 	virtual std::string make_default_gamename();
-	virtual void send_info_request();
+	virtual bool send_info_request();
 	virtual void clear_gamelist();
 	virtual std::vector<std::string> get_gamelist();
 
@@ -97,12 +97,13 @@ bool base_protocol<P>::wait_firstpeer()
 }
 
 template <class P>
-void base_protocol<P>::send_info_request()
+bool base_protocol<P>::send_info_request()
 {
-	if (wait_network()) {
-		auto pkt = pktfty->make_packet<PT_INFO_REQUEST>(PLR_BROADCAST, PLR_MASTER);
-		proto.send_oob_mc(pkt->Data());
-	}
+	if (!proto.network_online())
+		return false;
+	auto pkt = pktfty->make_packet<PT_INFO_REQUEST>(PLR_BROADCAST, PLR_MASTER);
+	proto.send_oob_mc(pkt->Data());
+	return true;
 }
 
 template <class P>

--- a/Source/dvlnet/cdwrap.h
+++ b/Source/dvlnet/cdwrap.h
@@ -40,7 +40,7 @@ public:
 	virtual bool SNetGetTurnsInTransit(uint32_t *turns);
 	virtual void setup_gameinfo(buffer_t info);
 	virtual std::string make_default_gamename();
-	virtual void send_info_request();
+	virtual bool send_info_request();
 	virtual void clear_gamelist();
 	virtual std::vector<std::string> get_gamelist();
 	virtual void setup_password(std::string pw);
@@ -175,9 +175,9 @@ std::string cdwrap<T>::make_default_gamename()
 }
 
 template <class T>
-void cdwrap<T>::send_info_request()
+bool cdwrap<T>::send_info_request()
 {
-	dvlnet_wrap->send_info_request();
+	return dvlnet_wrap->send_info_request();
 }
 
 template <class T>

--- a/Source/storm/storm_net.cpp
+++ b/Source/storm/storm_net.cpp
@@ -234,9 +234,9 @@ bool SNetSetBasePlayer(int /*unused*/)
 	return true;
 }
 
-void DvlNet_SendInfoRequest()
+bool DvlNet_SendInfoRequest()
 {
-	dvlnet_inst->send_info_request();
+	return dvlnet_inst->send_info_request();
 }
 
 void DvlNet_ClearGamelist()

--- a/Source/storm/storm_net.hpp
+++ b/Source/storm/storm_net.hpp
@@ -165,7 +165,7 @@ bool SNetSetBasePlayer(int);
 bool SNetInitializeProvider(uint32_t provider, struct GameData *gameData);
 void SNetGetProviderCaps(struct _SNETCAPS *);
 
-void DvlNet_SendInfoRequest();
+bool DvlNet_SendInfoRequest();
 void DvlNet_ClearGamelist();
 std::vector<std::string> DvlNet_GetGamelist();
 void DvlNet_SetPassword(std::string pw);


### PR DESCRIPTION
Notes
- Make `DvlNet_SendInfoRequest` non blocking / doesn't wait for zero tier to be running. This allows to enter the multiplayer menu faster
- Adds "Public Games" category to UI, with "Loading... ", "None" or game list info.
- Would be nice if someone else could test this.

<details><summary>Example Video</summary>

https://user-images.githubusercontent.com/25415264/148372555-b2f5b638-a4a6-42b1-b5a2-ef3da2377887.mp4

</details>
