### PR TITLE
Reorder options in settingsmenu

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1384,13 +1384,21 @@ bool IsPlayerDead()
 
 void InitKeymapActions()
 {
-	sgOptions.Keymapper.AddAction(
-	    "Help",
-	    N_("Help"),
-	    N_("Open Help Screen."),
-	    DVL_VK_F1,
-	    HelpKeyPressed,
-	    [&]() { return !IsPlayerDead(); });
+	for (int i = 0; i < 8; ++i) {
+		sgOptions.Keymapper.AddAction(
+		    "BeltItem{}",
+		    N_("Belt item {}"),
+		    N_("Use Belt item."),
+		    '1' + i,
+		    [i] {
+			    auto &myPlayer = Players[MyPlayerId];
+			    if (!myPlayer.SpdList[i].isEmpty() && myPlayer.SpdList[i]._itype != ItemType::Gold) {
+				    UseInvItem(MyPlayerId, INVITEM_BELT_FIRST + i);
+			    }
+		    },
+		    [&]() { return !IsPlayerDead(); },
+		    i + 1);
+	}
 	for (int i = 0; i < 4; ++i) {
 		sgOptions.Keymapper.AddAction(
 		    "QuickSpell{}",
@@ -1410,61 +1418,6 @@ void InitKeymapActions()
 		    [&]() { return !IsPlayerDead(); },
 		    i + 1);
 	}
-	for (int i = 0; i < 4; ++i) {
-		sgOptions.Keymapper.AddAction(
-		    "QuickMessage{}",
-		    N_("Quick Message {}"),
-		    N_("Use Quick Message in chat."),
-		    DVL_VK_F9 + i,
-		    [i]() { DiabloHotkeyMsg(i); },
-		    [] { return true; },
-		    i + 1);
-	}
-	sgOptions.Keymapper.AddAction(
-	    "DecreaseGamma",
-	    N_("Decrease Gamma"),
-	    N_("Reduce screen brightness."),
-	    'G',
-	    DecreaseGamma,
-	    [&]() { return !IsPlayerDead(); });
-	sgOptions.Keymapper.AddAction(
-	    "IncreaseGamma",
-	    N_("Increase Gamma"),
-	    N_("Increase screen brightness."),
-	    'F',
-	    IncreaseGamma,
-	    [&]() { return !IsPlayerDead(); });
-	sgOptions.Keymapper.AddAction(
-	    "Inventory",
-	    N_("Inventory"),
-	    N_("Open Inventory screen."),
-	    'I',
-	    InventoryKeyPressed,
-	    [&]() { return !IsPlayerDead(); });
-	sgOptions.Keymapper.AddAction(
-	    "Character",
-	    N_("Character"),
-	    N_("Open Character screen."),
-	    'C',
-	    CharacterSheetKeyPressed,
-	    [&]() { return !IsPlayerDead(); });
-	sgOptions.Keymapper.AddAction(
-	    "QuestLog",
-	    N_("Quest log"),
-	    N_("Open Quest log."),
-	    'Q',
-	    QuestLogKeyPressed,
-	    [&]() { return !IsPlayerDead(); });
-	sgOptions.Keymapper.AddAction(
-	    "Zoom",
-	    N_("Zoom"),
-	    N_("Zoom Game Screen."),
-	    'Z',
-	    [] {
-		    zoomflag = !zoomflag;
-		    CalcViewportGeometry();
-	    },
-	    [&]() { return !IsPlayerDead(); });
 	sgOptions.Keymapper.AddAction(
 	    "DisplaySpells",
 	    N_("Speedbook"),
@@ -1472,41 +1425,6 @@ void InitKeymapActions()
 	    'S',
 	    DisplaySpellsKeyPressed,
 	    [&]() { return !IsPlayerDead(); });
-	sgOptions.Keymapper.AddAction(
-	    "SpellBook",
-	    N_("Spellbook"),
-	    N_("Open Spellbook."),
-	    'B',
-	    SpellBookKeyPressed,
-	    [&]() { return !IsPlayerDead(); });
-	sgOptions.Keymapper.AddAction(
-	    "GameInfo",
-	    N_("Game info"),
-	    N_("Displays game infos."),
-	    'V',
-	    [] {
-		    EventPlrMsg(fmt::format(
-		                    _(/* TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty. */ "{:s} {:s}"),
-		                    PROJECT_NAME,
-		                    PROJECT_VERSION),
-		        UiFlags::ColorWhite);
-	    },
-	    [&]() { return !IsPlayerDead(); });
-	for (int i = 0; i < 8; ++i) {
-		sgOptions.Keymapper.AddAction(
-		    "BeltItem{}",
-		    N_("Belt item {}"),
-		    N_("Use Belt item."),
-		    '1' + i,
-		    [i] {
-			    auto &myPlayer = Players[MyPlayerId];
-			    if (!myPlayer.SpdList[i].isEmpty() && myPlayer.SpdList[i]._itype != ItemType::Gold) {
-				    UseInvItem(MyPlayerId, INVITEM_BELT_FIRST + i);
-			    }
-		    },
-		    [&]() { return !IsPlayerDead(); },
-		    i + 1);
-	}
 	sgOptions.Keymapper.AddAction(
 	    "QuickSave",
 	    N_("Quick save"),
@@ -1533,6 +1451,89 @@ void InitKeymapActions()
 	    N_("Stops walking and cancel pending actions."),
 	    DVL_VK_INVALID,
 	    [] { Players[MyPlayerId].Stop(); },
+	    [&]() { return !IsPlayerDead(); });
+
+	sgOptions.Keymapper.AddAction(
+	    "Inventory",
+	    N_("Inventory"),
+	    N_("Open Inventory screen."),
+	    'I',
+	    InventoryKeyPressed,
+	    [&]() { return !IsPlayerDead(); });
+	sgOptions.Keymapper.AddAction(
+	    "Character",
+	    N_("Character"),
+	    N_("Open Character screen."),
+	    'C',
+	    CharacterSheetKeyPressed,
+	    [&]() { return !IsPlayerDead(); });
+	sgOptions.Keymapper.AddAction(
+	    "QuestLog",
+	    N_("Quest log"),
+	    N_("Open Quest log."),
+	    'Q',
+	    QuestLogKeyPressed,
+	    [&]() { return !IsPlayerDead(); });
+	sgOptions.Keymapper.AddAction(
+	    "SpellBook",
+	    N_("Spellbook"),
+	    N_("Open Spellbook."),
+	    'B',
+	    SpellBookKeyPressed,
+	    [&]() { return !IsPlayerDead(); });
+	for (int i = 0; i < 4; ++i) {
+		sgOptions.Keymapper.AddAction(
+		    "QuickMessage{}",
+		    N_("Quick Message {}"),
+		    N_("Use Quick Message in chat."),
+		    DVL_VK_F9 + i,
+		    [i]() { DiabloHotkeyMsg(i); },
+		    [] { return true; },
+		    i + 1);
+	}
+	sgOptions.Keymapper.AddAction(
+	    "Zoom",
+	    N_("Zoom"),
+	    N_("Zoom Game Screen."),
+	    'Z',
+	    [] {
+		    zoomflag = !zoomflag;
+		    CalcViewportGeometry();
+	    },
+	    [&]() { return !IsPlayerDead(); });
+	sgOptions.Keymapper.AddAction(
+	    "DecreaseGamma",
+	    N_("Decrease Gamma"),
+	    N_("Reduce screen brightness."),
+	    'G',
+	    DecreaseGamma,
+	    [&]() { return !IsPlayerDead(); });
+	sgOptions.Keymapper.AddAction(
+	    "IncreaseGamma",
+	    N_("Increase Gamma"),
+	    N_("Increase screen brightness."),
+	    'F',
+	    IncreaseGamma,
+	    [&]() { return !IsPlayerDead(); });
+	sgOptions.Keymapper.AddAction(
+	    "Help",
+	    N_("Help"),
+	    N_("Open Help Screen."),
+	    DVL_VK_F1,
+	    HelpKeyPressed,
+	    [&]() { return !IsPlayerDead(); });
+	sgOptions.Keymapper.AddAction(
+	    "GameInfo",
+	    N_("Game info"),
+	    N_("Displays game infos."),
+	    'V',
+	    [] {
+		    EventPlrMsg(fmt::format(
+		                    _(/* TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty. */ "{:s} {:s}"),
+		                    PROJECT_NAME,
+		                    PROJECT_VERSION),
+		        UiFlags::ColorWhite);
+	    },
 	    [&]() { return !IsPlayerDead(); });
 #ifdef _DEBUG
 	sgOptions.Keymapper.AddAction(

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -796,14 +796,14 @@ std::vector<OptionEntryBase *> GraphicsOptions::GetEntries()
 		&integerScaling,
 		&vSync,
 #endif
+		&limitFPS,
+		&showFPS,
 		&colorCycling,
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 		&hardwareCursor,
 		&hardwareCursorForItems,
 		&hardwareCursorMaxSize,
 #endif
-		&limitFPS,
-		&showFPS,
 	};
 	// clang-format on
 }
@@ -847,8 +847,10 @@ GameplayOptions::GameplayOptions()
 std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 {
 	return {
-		&runInTown,
 		&grabInput,
+		&runInTown,
+		&adriaRefillsMana,
+		&randomizeQuests,
 		&theoQuest,
 		&cowQuest,
 		&friendlyFire,
@@ -856,20 +858,18 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&testBarbarian,
 		&experienceBar,
 		&enemyHealthBar,
+		&showMonsterType,
+		&disableCripplingShrines,
+		&quickCast,
+		&autoRefillBelt,
+		&autoPickupInTown,
 		&autoGoldPickup,
 		&autoElixirPickup,
-		&autoPickupInTown,
-		&adriaRefillsMana,
 		&autoEquipWeapons,
 		&autoEquipArmor,
 		&autoEquipHelms,
 		&autoEquipShields,
 		&autoEquipJewelry,
-		&randomizeQuests,
-		&showMonsterType,
-		&autoRefillBelt,
-		&disableCripplingShrines,
-		&quickCast,
 		&numHealPotionPickup,
 		&numFullHealPotionPickup,
 		&numManaPotionPickup,

--- a/Source/options.h
+++ b/Source/options.h
@@ -587,16 +587,16 @@ struct Options {
 	[[nodiscard]] std::vector<OptionCategoryBase *> GetCategories()
 	{
 		return {
+			&Language,
 			&StartUp,
+			&Graphics,
+			&Audio,
 			&Diablo,
 			&Hellfire,
-			&Audio,
 			&Gameplay,
-			&Graphics,
 			&Controller,
 			&Network,
 			&Chat,
-			&Language,
 			&Keymapper,
 		};
 	}


### PR DESCRIPTION
Notes:
- This PR only reorder the options. No options are changed in anyway (Category, Key, Name, ...).
- Thoughts:
  - Language is first option, cause it's the most important if it's wrong. 😉 (see also [comment](https://github.com/diasurgical/devilutionX/pull/3634#issuecomment-981061793)).
  - Start Up is second, cause under it the game mode (diablo/hellfire) can be selected.
  - Graphics: VSync & FPS are grouped together,
  - Gameplay: Quests got grouped together and QoL Features. Autopickup options is last. They could be moved to it's own category (not part of this pr).
  - Keymapping: Keys for "normal" gaming are grouped first, then panel options (charachter, inventory, ...) and last everything else (Quick messages, zoom, help).
 - I don't have a strong opinion on the exact order, so I'm happy for any feedback.

<details><summary>Diff for hellfire settings</summary>

```diff
@@ -1,9 +1,27 @@
+Language
+   Language
+
 Start Up
    Game Mode
    Restrict to Shareware
    Intro
    Splash
 
+Graphics
+   Resolution
+   Fullscreen
+   Fit to Screen
+   Upscale
+   Scaling Quality
+   Integer Scaling
+   Vertical Sync
+   FPS Limiter
+   Show FPS
+   Color Cycling
+   Hardware Cursor
+   Hardware Cursor For Items
+   Hardware Cursor Maximum Size
+
 Audio
    Walking Sound
    Auto Equip Sound
@@ -14,8 +32,10 @@ Audio
    Resampling Quality
 
 Gameplay
-   Run in Town
    Grab Input
+   Run in Town
+   Adria Refills Mana
+   Randomize Quests
    Theo Quest
    Cow Quest
    Friendly Fire
@@ -23,20 +43,18 @@ Gameplay
    Test Barbarian
    Experience Bar
    Enemy Health Bar
+   Show Monster Type
+   Disable Crippling Shrines
+   Quick Cast
+   Auto Refill Belt
+   Auto Pickup in Town
    Auto Gold Pickup
    Auto Elixir Pickup
-   Auto Pickup in Town
-   Adria Refills Mana
    Auto Equip Weapons
    Auto Equip Armor
    Auto Equip Helms
    Auto Equip Shields
    Auto Equip Jewelry
-   Randomize Quests
-   Show Monster Type
-   Auto Refill Belt
-   Disable Crippling Shrines
-   Quick Cast
    Heal Potion Pickup
    Full Heal Potion Pickup
    Mana Potion Pickup
@@ -44,43 +62,7 @@ Gameplay
    Rejuvenation Potion Pickup
    Full Rejuvenation Potion Pickup
 
-Graphics
-   Resolution
-   Fullscreen
-   Fit to Screen
-   Upscale
-   Scaling Quality
-   Integer Scaling
-   Vertical Sync
-   Color Cycling
-   Hardware Cursor
-   Hardware Cursor For Items
-   Hardware Cursor Maximum Size
-   FPS Limiter
-   Show FPS
-
-Language
-   Language
-
 Keymapping
-   Help
-   Quick spell 1
-   Quick spell 2
-   Quick spell 3
-   Quick spell 4
-   Quick Message 1
-   Quick Message 2
-   Quick Message 3
-   Quick Message 4
-   Decrease Gamma
-   Increase Gamma
-   Inventory
-   Character
-   Quest log
-   Zoom
-   Speedbook
-   Spellbook
-   Game info
    Belt item 1
    Belt item 2
    Belt item 3
@@ -89,9 +71,27 @@ Keymapping
    Belt item 6
    Belt item 7
    Belt item 8
+   Quick spell 1
+   Quick spell 2
+   Quick spell 3
+   Quick spell 4
+   Speedbook
    Quick save
    Quick load
    Quit game
    Stop hero
+   Inventory
+   Character
+   Quest log
+   Spellbook
+   Quick Message 1
+   Quick Message 2
+   Quick Message 3
+   Quick Message 4
+   Zoom
+   Decrease Gamma
+   Increase Gamma
+   Help
+   Game info
    Debug toggle
 
```

</details>