### PR TITLE
Settingsmenu: Handle long text

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -142,6 +142,8 @@ void UiInitList(void (*fnFocus)(int value), void (*fnSelect)(int value), void (*
 			SelectedItemMax = std::max(uiList->m_vecItems.size() - 1, static_cast<size_t>(0));
 			ListViewportSize = uiList->viewportSize;
 			gUiList = uiList;
+			if (selectedItem <= SelectedItemMax && HasAnyOf(uiList->GetItem(selectedItem)->uiFlags, UiFlags::NeedsNextElement))
+				AdjustListOffset(selectedItem + 1);
 		} else if (item->IsType(UiType::Scrollbar)) {
 			uiScrollbar = static_cast<UiScrollbar *>(item.get());
 		}
@@ -214,11 +216,9 @@ void UiFocus(std::size_t itemIndex, bool checkUp, bool ignoreItemsWraps = false)
 		pItem = gUiList->GetItem(itemIndex);
 	}
 
-	if (HasAnyOf(pItem->uiFlags, UiFlags::NeedsNextElement)) {
+	if (HasAnyOf(pItem->uiFlags, UiFlags::NeedsNextElement))
 		AdjustListOffset(itemIndex + 1);
-	} else {
-		AdjustListOffset(itemIndex);
-	}
+	AdjustListOffset(itemIndex);
 
 	SelectedItem = itemIndex;
 

--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -32,6 +32,7 @@ ShownMenuType shownMenu;
 
 char optionDescription[512];
 
+Rectangle rectList;
 Rectangle rectDescription;
 
 enum class SpecialMenuEntry {
@@ -56,6 +57,12 @@ std::vector<DrawStringFormatArg> CreateDrawStringFormatArgForEntry(OptionEntryBa
 		{ pEntry->GetName().data(), UiFlags::ColorUiGold },
 		{ pEntry->GetValueDescription().data(), UiFlags::ColorUiSilver }
 	};
+}
+
+/** @brief Check if the option text can't fit in one list line (list width minus drawn selector) */
+bool NeedsTwoLinesToDisplayOption(std::vector<DrawStringFormatArg> &formatArgs)
+{
+	return GetLineWidth("{}: {}", formatArgs.data(), formatArgs.size(), GameFontTables::GameFont24, 1) >= (rectList.size.width - 90);
 }
 
 void CleanUpSettingsUI()
@@ -177,9 +184,19 @@ void ItemSelected(int value)
 			updateValueDescription = ChangeOptionValue(pOption, 0);
 		}
 		if (updateValueDescription) {
-			vecItem->args.clear();
-			for (auto &arg : CreateDrawStringFormatArgForEntry(pOption))
-				vecItem->args.push_back(arg);
+			auto args = CreateDrawStringFormatArgForEntry(pOption);
+			bool optionUsesTwoLines = ((value + 1) < vecDialogItems.size() && vecDialogItems[value]->m_value == vecDialogItems[value + 1]->m_value);
+			if (NeedsTwoLinesToDisplayOption(args) != optionUsesTwoLines) {
+				selectedOption = pOption;
+				endMenu = true;
+			} else {
+				vecItem->args.clear();
+				for (auto &arg : args)
+					vecItem->args.push_back(arg);
+				if (optionUsesTwoLines) {
+					vecDialogItems[value + 1]->m_text = pOption->GetValueDescription().data();
+				}
+			}
 		}
 	} break;
 	case ShownMenuType::ListOption: {
@@ -230,7 +247,7 @@ void UiSettingsMenu()
 		UiAddBackground(&vecDialog);
 		UiAddLogo(&vecDialog);
 
-		Rectangle rectList = { { PANEL_LEFT + 50, (UI_OFFSET_Y + 204) }, { 540, 208 } };
+		rectList = { { PANEL_LEFT + 50, (UI_OFFSET_Y + 204) }, { 540, 208 } };
 		rectDescription = { { PANEL_LEFT + 24, rectList.position.y + rectList.size.height + 16 }, { 590, 35 } };
 
 		optionDescription[0] = '\0';
@@ -258,10 +275,15 @@ void UiSettingsMenu()
 						vecDialogItems.push_back(std::make_unique<UiListItem>(pCategory->GetName().data(), static_cast<int>(SpecialMenuEntry::None), UiFlags::ColorWhitegold | UiFlags::ElementDisabled));
 						categoryCreated = true;
 					}
-					auto formatArgs = CreateDrawStringFormatArgForEntry(pEntry);
 					if (selectedOption == pEntry)
 						itemToSelect = vecDialogItems.size();
-					vecDialogItems.push_back(std::make_unique<UiListItem>("{}: {}", formatArgs, vecOptions.size(), UiFlags::ColorUiGold));
+					auto formatArgs = CreateDrawStringFormatArgForEntry(pEntry);
+					if (NeedsTwoLinesToDisplayOption(formatArgs)) {
+						vecDialogItems.push_back(std::make_unique<UiListItem>("{}:", formatArgs, vecOptions.size(), UiFlags::ColorUiGold | UiFlags::NeedsNextElement));
+						vecDialogItems.push_back(std::make_unique<UiListItem>(pEntry->GetValueDescription().data(), vecOptions.size(), UiFlags::ColorUiSilver | UiFlags::ElementDisabled));
+					} else {
+						vecDialogItems.push_back(std::make_unique<UiListItem>("{}: {}", formatArgs, vecOptions.size(), UiFlags::ColorUiGold));
+					}
 					vecOptions.push_back(pEntry);
 				}
 			}


### PR DESCRIPTION
Fixes #3834

Notes:
- If an option is too long to display, it will be manually separated in two lines. Similar how the first version of the settings menu handled this.
- After each change to a option this need to be rechecked, cause the value description text can be longer or shorter.
- `UiFlags::NeedsNextElement` didn't work correctly when a item is preselected or with the changed up/down logic. Didn't occur in master, cause in master no one uses `UiFlags::NeedsNextElement`

<details><summary>Sample Video</summary>

https://user-images.githubusercontent.com/25415264/148422581-ba118c30-65a4-40b7-a792-006a3e49ddef.mp4

</details>