### PR TITLE
Cleanup Diablo-SHA and codec.cpp

### DIFF
--- a/Source/sha.h
+++ b/Source/sha.h
@@ -11,12 +11,15 @@
 
 namespace devilution {
 
-constexpr size_t BlockSize = 64;
-constexpr size_t SHA1HashSize = 20;
+constexpr size_t BlockSize = 16;
+constexpr size_t SHA1HashSize = 5;
 
-void SHA1Clear();
-void SHA1Result(int n, byte messageDigest[SHA1HashSize]);
-void SHA1Calculate(int n, const byte data[BlockSize], byte messageDigest[SHA1HashSize]);
-void SHA1Reset(int n);
+struct SHA1Context {
+	uint32_t state[SHA1HashSize] = { 0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0 };
+	uint32_t buffer[BlockSize];
+};
+
+void SHA1Result(SHA1Context &context, uint32_t messageDigest[SHA1HashSize]);
+void SHA1Calculate(SHA1Context &context, const uint32_t data[BlockSize]);
 
 } // namespace devilution


### PR DESCRIPTION
1. Switches to 32-bit based calculation throughout. This is faster and less error-prone as we only byte-swap once when reading and writing.
2. Removes global state from Diablo-SHA implementation.