### PR TITLE
Apocrypha fixes

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1177,7 +1177,7 @@ bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, missil
 		dam = player._pHitPoints / 3;
 	} else {
 		if (!shift) {
-			dam = (mind << 6) + GenerateRnd((maxd - mind + 1) << 6);
+			dam = (mind << 6) + GenerateRnd(((maxd - mind) << 6) + 1);
 			if (monster == nullptr)
 				if ((player._pIFlags & ISPL_ABSHALFTRAP) != 0)
 					dam /= 2;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3093,7 +3093,8 @@ void MI_Fireball(Missile &missile)
 			AddUnLight(missile._mlid);
 		}
 	} else {
-		int dam = missile._midam;
+		auto &monster = Monsters[id];
+		int dam = (missile._micaster == TARGET_MONSTERS) ? missile._midam : monster.mMinDamage + GenerateRnd(monster.mMaxDamage - monster.mMinDamage + 1);
 		MoveMissileAndCheckMissileCol(missile, dam, dam, true, false);
 		if (missile._mirange == 0) {
 			Point m = missile.position.tile;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3093,9 +3093,15 @@ void MI_Fireball(Missile &missile)
 			AddUnLight(missile._mlid);
 		}
 	} else {
-		auto &monster = Monsters[id];
-		int dam = (missile._micaster == TARGET_MONSTERS) ? missile._midam : monster.mMinDamage + GenerateRnd(monster.mMaxDamage - monster.mMinDamage + 1);
-		MoveMissileAndCheckMissileCol(missile, dam, dam, true, false);
+		int minDam = missile._midam;
+		int maxDam = missile._midam;
+
+		if (missile._micaster != TARGET_MONSTERS) {
+			auto &monster = Monsters[id];
+			minDam = monster.mMinDamage;
+			maxDam = monster.mMaxDamage;
+		}
+		MoveMissileAndCheckMissileCol(missile, minDam, maxDam, true, false);
 		if (missile._mirange == 0) {
 			Point m = missile.position.tile;
 			ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame);
@@ -3103,7 +3109,7 @@ void MI_Fireball(Missile &missile)
 			constexpr Displacement Pattern[] = { { 0, 0 }, { 0, 1 }, { 0, -1 }, { 1, 0 }, { 1, -1 }, { 1, 1 }, { -1, 0 }, { -1, 1 }, { -1, -1 } };
 			for (auto shift : Pattern) {
 				if (!CheckBlock(p, m + shift))
-					CheckMissileCol(missile, dam, dam, false, m + shift, true);
+					CheckMissileCol(missile, minDam, maxDam, false, m + shift, true);
 			}
 
 			if (!TransList[dTransVal[m.x][m.y]]

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1484,7 +1484,7 @@ void MonsterAttackPlayer(int i, int pnum, int hit, int minDam, int maxDam)
 		Direction dir = GetDirection(player.position.tile, monster.position.tile);
 		StartPlrBlock(pnum, dir);
 		if (pnum == MyPlayerId && player.wReflections > 0) {
-			int dam = GenerateRnd((maxDam - minDam + 1) << 6) + (minDam << 6);
+			int dam = GenerateRnd(((maxDam - minDam) << 6) + 1) + (minDam << 6);
 			dam = std::max(dam + (player._pIGetHit << 6), 64);
 			CheckReflect(i, pnum, dam);
 		}
@@ -1504,7 +1504,7 @@ void MonsterAttackPlayer(int i, int pnum, int hit, int minDam, int maxDam)
 			}
 		}
 	}
-	int dam = (minDam << 6) + GenerateRnd((maxDam - minDam + 1) << 6);
+	int dam = (minDam << 6) + GenerateRnd(((maxDam - minDam) << 6) + 1);
 	dam = std::max(dam + (player._pIGetHit << 6), 64);
 	if (pnum == MyPlayerId) {
 		if (player.wReflections > 0)


### PR DESCRIPTION
For review/discussion. Fixes from @SoundChaser83's Apocrypha mod.

> ... it looks like Hellbats and Torchants do absurdly low damage because their fireballs aren't reading damage from the monster data table, and also all monster melee/missile hits do up to + or - 63/64ths points of damage over and above their usual damage range because of a parentheses/order of operations issue.

> Regarding that Torchant/Hellbat fireball fix, those things will hit like an absolute truck if you go through with that fix, so it may be surprising to people.