### PR TITLE
Revise power leveling cap

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2583,15 +2583,9 @@ void AddPlrExperience(int pnum, int lvl, int exp)
 
 	// Adjust xp based on difference in level between player and monster
 	uint32_t clampedExp = std::max(static_cast<int>(exp * (1 + (lvl - player._pLevel) / 10.0)), 0);
-
-	// Prevent power leveling
-	if (gbIsMultiplayer) {
-		const uint32_t clampedPlayerLevel = clamp(static_cast<int>(player._pLevel), 0, 50);
-
-		// for low level characters experience gain is capped to 1/20 of current levels xp
-		// for high level characters experience gain is capped to 200 * current level - this is a smaller value than 1/20 of the exp needed for the next level after level 5.
-		clampedExp = std::min({ clampedExp, /* level 0-5: */ ExpLvlsTbl[clampedPlayerLevel] / 20U, /* level 6-50: */ 200U * clampedPlayerLevel });
-	}
+	// Prevent power leveling (caps the exp gain per monster at 1x the monster's exp instead of capping exp gain at 200*clvl)
+	if (gbIsMultiplayer)
+		clampedExp = std::min(static_cast<int>(clampedExp), exp);
 
 	constexpr uint32_t MaxExperience = 2000000000U;
 


### PR DESCRIPTION
This change revises the power level cap to function differently from vanilla in Multiplayer. Normally, the cap will severely limit the experience gains from monsters of equivalent or greater level between ~0.3x and ~0.8x the monster's exp yield, where in Single Player, players can potentially enjoy exp yields up to around 5x the monster's exp yield. This will change the range of possible exp gained from 0x to 1x the monster's exp yield based on mlvl to clvl difference. The end result is that monsters at the same level or greater as the player's level will net the full exp found in monstdat.cpp.