### PR TITLE
Fix character level up to 50

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -530,6 +530,14 @@ std::string DebugCmdLevelUp(const string_view parameter)
 	int levels = std::max(1, atoi(parameter.data()));
 	for (int i = 0; i < levels; i++)
 		NetSendCmd(true, CMD_CHEAT_EXPERIENCE);
+	return "Faster than FireIceTalon!";
+}
+
+std::string DebugCmdGiveExperience(const string_view parameter)
+{
+	int experience = std::max(1, atoi(parameter.data()));
+	Player &myPlayer = *MyPlayer;
+	AddPlrExperience(myPlayer, myPlayer._pLevel, experience);
 	return "New experience leads to new insights.";
 }
 
@@ -1009,7 +1017,8 @@ std::string DebugCmdChangeTRN(const string_view parameter)
 std::vector<DebugCmdItem> DebugCmdList = {
 	{ "help", "Prints help overview or help for a specific command.", "({command})", &DebugCmdHelp },
 	{ "givegold", "Fills the inventory with gold.", "", &DebugCmdGiveGoldCheat },
-	{ "givexp", "Levels the player up (min 1 level or {levels}).", "({levels})", &DebugCmdLevelUp },
+	{ "givelvl", "Levels the player up (min 1 level or {levels}).", "({levels})", &DebugCmdLevelUp },
+	{ "givexp", "Gives experience points (min 1 experience or {exp}).", "({exp})", &DebugCmdGiveExperience },
 	{ "maxstats", "Sets all stat values to maximum.", "", &DebugCmdMaxStats },
 	{ "minstats", "Sets all stat values to minimum.", "", &DebugCmdMinStats },
 	{ "setspells", "Set spell level to {level} for all spells.", "{level}", &DebugCmdSetSpellsLevel },

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -530,14 +530,6 @@ std::string DebugCmdLevelUp(const string_view parameter)
 	int levels = std::max(1, atoi(parameter.data()));
 	for (int i = 0; i < levels; i++)
 		NetSendCmd(true, CMD_CHEAT_EXPERIENCE);
-	return "Faster than FireIceTalon!";
-}
-
-std::string DebugCmdGiveExperience(const string_view parameter)
-{
-	int experience = std::max(1, atoi(parameter.data()));
-	Player &myPlayer = *MyPlayer;
-	AddPlrExperience(myPlayer, myPlayer._pLevel, experience);
 	return "New experience leads to new insights.";
 }
 
@@ -1017,8 +1009,7 @@ std::string DebugCmdChangeTRN(const string_view parameter)
 std::vector<DebugCmdItem> DebugCmdList = {
 	{ "help", "Prints help overview or help for a specific command.", "({command})", &DebugCmdHelp },
 	{ "givegold", "Fills the inventory with gold.", "", &DebugCmdGiveGoldCheat },
-	{ "givelvl", "Levels the player up (min 1 level or {levels}).", "({levels})", &DebugCmdLevelUp },
-	{ "givexp", "Gives experience points (min 1 experience or {exp}).", "({exp})", &DebugCmdGiveExperience },
+	{ "givexp", "Levels the player up (min 1 level or {levels}).", "({levels})", &DebugCmdLevelUp },
 	{ "maxstats", "Sets all stat values to maximum.", "", &DebugCmdMaxStats },
 	{ "minstats", "Sets all stat values to minimum.", "", &DebugCmdMinStats },
 	{ "setspells", "Set spell level to {level} for all spells.", "{level}", &DebugCmdSetSpellsLevel },

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -135,6 +135,9 @@ PanelEntry panelEntries[] = {
 	{ N_("Experience"), { TopRightLabelX, 52 }, 99, 91,
 	    []() {
 	        int spacing = ((MyPlayer->_pExperience >= 1000000000) ? 0 : 1);
+	        if (MyPlayer->_pLevel == MaxCharacterLevel) {
+		        return StyledText { UiFlags::ColorWhitegold, FormatInteger(MyPlayer->_pExperience), spacing };
+	        }
 	        return StyledText { UiFlags::ColorWhite, FormatInteger(MyPlayer->_pExperience), spacing };
 	    } },
 	{ N_("Next level"), { TopRightLabelX, 80 }, 99, 198,

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -135,7 +135,7 @@ PanelEntry panelEntries[] = {
 	        if (MyPlayer->_pLevel == MaxCharacterLevel) {
 		        return StyledText { UiFlags::ColorWhitegold, StrCat(MyPlayer->_pLevel) };
 	        }
-			return StyledText { UiFlags::ColorWhite, StrCat(MyPlayer->_pLevel) }; 
+			return StyledText { UiFlags::ColorWhite, StrCat(MyPlayer->_pLevel) };
 		} },
 	{ N_("Experience"), { TopRightLabelX, 52 }, 99, 91,
 	    []() {

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -131,7 +131,12 @@ PanelEntry panelEntries[] = {
 	    []() { return StyledText { UiFlags::ColorWhite, std::string(_(ClassStrTbl[static_cast<std::size_t>(MyPlayer->_pClass)])) }; } },
 
 	{ N_("Level"), { 57, 52 }, 57, 45,
-	    []() { return StyledText { UiFlags::ColorWhite, StrCat(MyPlayer->_pLevel) }; } },
+	    []() {
+	        if (MyPlayer->_pLevel == MaxCharacterLevel) {
+		        return StyledText { UiFlags::ColorWhitegold, StrCat(MyPlayer->_pLevel) };
+	        }
+			return StyledText { UiFlags::ColorWhite, StrCat(MyPlayer->_pLevel) }; 
+		} },
 	{ N_("Experience"), { TopRightLabelX, 52 }, 99, 91,
 	    []() {
 	        int spacing = ((MyPlayer->_pExperience >= 1000000000) ? 0 : 1);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2718,7 +2718,7 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 
 	/* set player level to MaxCharacterLevel if the experience value for MaxCharacterLevel is reached, which exits the function early
 	and does not call NextPlrLevel(), which is responsible for giving Attribute points and Life/Mana on level up */
-	if (player._pExperience >= ExpLvlsTbl[MaxCharacterLevel - 1]) {
+	if (player._pExperience >= ExpLvlsTbl[MaxCharacterLevel]) {
 		player._pLevel = MaxCharacterLevel;
 		return;
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2715,11 +2715,9 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 	if (*sgOptions.Gameplay.experienceBar) {
 		RedrawEverything();
 	}
-
-	/* set player level to MaxCharacterLevel if the experience value for MaxCharacterLevel is reached, which exits the function early
-	and does not call NextPlrLevel(), which is responsible for giving Attribute points and Life/Mana on level up */
-	if (player._pExperience >= ExpLvlsTbl[MaxCharacterLevel]) {
-		player._pLevel = MaxCharacterLevel;
+	
+	// If player level is MaxCharacterLevel, exit the function early and do not call NextPlrLevel()
+	if (player._pLevel >= MaxCharacterLevel) {
 		return;
 	}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2687,7 +2687,7 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 		return;
 	}
 
-	// If player level is MaxCharacterLevel, exit the function early and do give experience points
+	// If player level is MaxCharacterLevel, exit the function early and do not give experience points
 	if (player._pLevel >= MaxCharacterLevel) {
 		player._pExperience = ExpLvlsTbl[MaxCharacterLevel - 1];
 		return;
@@ -2723,8 +2723,6 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 	while (newLvl < MaxCharacterLevel && player._pExperience >= ExpLvlsTbl[newLvl]) {
 		newLvl++;
 	}
-
-	// Level up player if necessary
 	if (newLvl > player._pLevel) {
 		NextPlrLevel(player, newLvl - player._pLevel);
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2715,7 +2715,7 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 	if (*sgOptions.Gameplay.experienceBar) {
 		RedrawEverything();
 	}
-	
+
 	// If player level is MaxCharacterLevel, exit the function early and do not call NextPlrLevel()
 	if (player._pLevel >= MaxCharacterLevel) {
 		return;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2685,9 +2685,8 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 		return;
 	}
 
-	// exit function early if player is unable to gain more experience by checking final index of ExpLvlsTbl
-	int expLvlsTblSize = sizeof(ExpLvlsTbl) / sizeof(ExpLvlsTbl[0]);
-	if (player._pExperience >= ExpLvlsTbl[expLvlsTblSize - 1]) {
+	// If player level is MaxCharacterLevel, exit the function early and do give experience points
+	if (player._pLevel >= MaxCharacterLevel) {
 		return;
 	}
 
@@ -2716,11 +2715,6 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 		RedrawEverything();
 	}
 
-	// If player level is MaxCharacterLevel, exit the function early and do not call NextPlrLevel()
-	if (player._pLevel >= MaxCharacterLevel) {
-		return;
-	}
-
 	// Increase player level if applicable
 	int newLvl = 0;
 	while (player._pExperience >= ExpLvlsTbl[newLvl]) {
@@ -2730,6 +2724,10 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 		for (int i = newLvl - player._pLevel; i > 0; i--) {
 			NextPlrLevel(player);
 		}
+	}
+
+	if (player._pLevel >= MaxCharacterLevel) {
+		player._pExperience = ExpLvlsTbl[MaxCharacterLevel - 1];
 	}
 
 	NetSendCmdParam1(false, CMD_PLRLEVEL, player._pLevel);

--- a/Source/player.h
+++ b/Source/player.h
@@ -789,7 +789,7 @@ void SetPlrAnims(Player &player);
 void CreatePlayer(Player &player, HeroClass c);
 int CalcStatDiff(Player &player);
 #ifdef _DEBUG
-void NextPlrLevel(Player &player);
+void NextPlrLevel(Player &player, int8_t numLvls = 1);
 #endif
 void AddPlrExperience(Player &player, int lvl, int exp);
 void AddPlrMonstExper(int lvl, int exp, char pmask);


### PR DESCRIPTION
The character does not receive life, mana, and skill points when leveling up to 50 because the NextPlrLevel function is skipped upon reached the needed experience to level up to 50. This change allows the player to receive the benefits of leveling up, but still prevents the player from leveling up to 51.