### PR TITLE
Prevent items from breaking

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -496,7 +496,8 @@ void CalcSelfItems(Player &player)
 
 			if (currstr >= equipment._iMinStr
 			    && currmag >= equipment._iMinMag
-			    && currdex >= equipment._iMinDex)
+			    && currdex >= equipment._iMinDex
+			    && ((equipment._iClass == ICLASS_MISC || equipment._iClass == ICLASS_GOLD || equipment._iClass == ICLASS_QUEST) || equipment._iDurability != 0))
 				continue;
 
 			changeflag = true;
@@ -512,7 +513,7 @@ void CalcSelfItems(Player &player)
 
 void CalcPlrItemMin(Player &player)
 {
-	for (Item &item : InventoryAndBeltPlayerItemsRange { player }) {
+	for (Item &item : PlayerItemsRange { player }) {
 		item._iStatFlag = player.CanUseItem(item);
 	}
 }

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1697,6 +1697,8 @@ void ItemDoppel()
 
 void RepairItem(Item &item, int lvl)
 {
+	auto &myPlayer = Players[MyPlayerId];
+
 	if (item._iDurability == item._iMaxDur) {
 		return;
 	}
@@ -1717,6 +1719,7 @@ void RepairItem(Item &item, int lvl)
 	} while (rep + item._iDurability < item._iMaxDur);
 
 	item._iDurability = std::min<int>(item._iDurability + rep, item._iMaxDur);
+	CalcPlrInv(myPlayer, true)
 }
 
 void RechargeItem(Item &item, int r)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1719,7 +1719,7 @@ void RepairItem(Item &item, int lvl)
 	} while (rep + item._iDurability < item._iMaxDur);
 
 	item._iDurability = std::min<int>(item._iDurability + rep, item._iMaxDur);
-	CalcPlrInv(myPlayer, true)
+	CalcPlrInv(myPlayer, true);
 }
 
 void RechargeItem(Item &item, int r)

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -839,6 +839,7 @@ GameplayOptions::GameplayOptions()
     , numFullManaPotionPickup("Full Mana Potion Pickup", OptionEntryFlags::None, N_("Full Mana Potion Pickup"), N_("Number of Full Mana potions to pick up automatically."), 0, { 0, 1, 2, 4, 8, 16 })
     , numRejuPotionPickup("Rejuvenation Potion Pickup", OptionEntryFlags::None, N_("Rejuvenation Potion Pickup"), N_("Number of Rejuvenation potions to pick up automatically."), 0, { 0, 1, 2, 4, 8, 16 })
     , numFullRejuPotionPickup("Full Rejuvenation Potion Pickup", OptionEntryFlags::None, N_("Full Rejuvenation Potion Pickup"), N_("Number of Full Rejuvenation potions to pick up automatically."), 0, { 0, 1, 2, 4, 8, 16 })
+    , allowZeroDurabilityItems("Prevent Item Destruction", OptionEntryFlags::None, N_("Prevent Item Destruction"), N_("Prevent items from breaking when reduced to 0 durability."), false)
 {
 	grabInput.SetValueChangedCallback(OptionGrabInputChanged);
 	experienceBar.SetValueChangedCallback(OptionExperienceBarChanged);
@@ -876,6 +877,7 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&numFullManaPotionPickup,
 		&numRejuPotionPickup,
 		&numFullRejuPotionPickup,
+		&allowZeroDurabilityItems,
 	};
 }
 

--- a/Source/options.h
+++ b/Source/options.h
@@ -474,6 +474,8 @@ struct GameplayOptions : OptionCategoryBase {
 	OptionEntryInt<int> numRejuPotionPickup;
 	/** @brief Number of Full Rejuvenating potions to pick up automatically */
 	OptionEntryInt<int> numFullRejuPotionPickup;
+	/** @brief Allow items to reach 0 Current Durability */
+	OptionEntryBoolean allowZeroDurabilityItems;
 };
 
 struct ControllerOptions : OptionCategoryBase {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -773,10 +773,9 @@ bool DamageWeapon(int pnum, int durrnd)
 			return false;
 		}
 
-		player.InvBody[INVLOC_HAND_LEFT]._iDurability--;
-		if (player.InvBody[INVLOC_HAND_LEFT]._iDurability <= 0) {
-			NetSendCmdDelItem(true, INVLOC_HAND_LEFT);
-			player.InvBody[INVLOC_HAND_LEFT]._itype = ItemType::None;
+		if (player.InvBody[INVLOC_HAND_LEFT]._iDurability != 0)
+			player.InvBody[INVLOC_HAND_LEFT]._iDurability--;
+		if (player.InvBody[INVLOC_HAND_LEFT]._iDurability == 0) {
 			CalcPlrInv(player, true);
 			return true;
 		}
@@ -787,10 +786,9 @@ bool DamageWeapon(int pnum, int durrnd)
 			return false;
 		}
 
-		player.InvBody[INVLOC_HAND_RIGHT]._iDurability--;
+		if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability != 0)
+			player.InvBody[INVLOC_HAND_RIGHT]._iDurability--;
 		if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability == 0) {
-			NetSendCmdDelItem(true, INVLOC_HAND_RIGHT);
-			player.InvBody[INVLOC_HAND_RIGHT]._itype = ItemType::None;
 			CalcPlrInv(player, true);
 			return true;
 		}
@@ -801,10 +799,9 @@ bool DamageWeapon(int pnum, int durrnd)
 			return false;
 		}
 
-		player.InvBody[INVLOC_HAND_RIGHT]._iDurability--;
+		if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability != 0)
+			player.InvBody[INVLOC_HAND_RIGHT]._iDurability--;
 		if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability == 0) {
-			NetSendCmdDelItem(true, INVLOC_HAND_RIGHT);
-			player.InvBody[INVLOC_HAND_RIGHT]._itype = ItemType::None;
 			CalcPlrInv(player, true);
 			return true;
 		}
@@ -815,10 +812,9 @@ bool DamageWeapon(int pnum, int durrnd)
 			return false;
 		}
 
+		if (player.InvBody[INVLOC_HAND_LEFT]._iDurability != 0)
 		player.InvBody[INVLOC_HAND_LEFT]._iDurability--;
 		if (player.InvBody[INVLOC_HAND_LEFT]._iDurability == 0) {
-			NetSendCmdDelItem(true, INVLOC_HAND_LEFT);
-			player.InvBody[INVLOC_HAND_LEFT]._itype = ItemType::None;
 			CalcPlrInv(player, true);
 			return true;
 		}
@@ -1314,20 +1310,18 @@ void DamageParryItem(int pnum)
 			return;
 		}
 
-		player.InvBody[INVLOC_HAND_LEFT]._iDurability--;
+		if (player.InvBody[INVLOC_HAND_LEFT]._iDurability != 0)
+			player.InvBody[INVLOC_HAND_LEFT]._iDurability--;
 		if (player.InvBody[INVLOC_HAND_LEFT]._iDurability == 0) {
-			NetSendCmdDelItem(true, INVLOC_HAND_LEFT);
-			player.InvBody[INVLOC_HAND_LEFT]._itype = ItemType::None;
 			CalcPlrInv(player, true);
 		}
 	}
 
 	if (player.InvBody[INVLOC_HAND_RIGHT]._itype == ItemType::Shield) {
 		if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability != DUR_INDESTRUCTIBLE) {
-			player.InvBody[INVLOC_HAND_RIGHT]._iDurability--;
+			if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability != 0)
+				player.InvBody[INVLOC_HAND_RIGHT]._iDurability--;
 			if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability == 0) {
-				NetSendCmdDelItem(true, INVLOC_HAND_RIGHT);
-				player.InvBody[INVLOC_HAND_RIGHT]._itype = ItemType::None;
 				CalcPlrInv(player, true);
 			}
 		}
@@ -1389,17 +1383,11 @@ void DamageArmor(int pnum)
 		return;
 	}
 
-	pi->_iDurability--;
 	if (pi->_iDurability != 0) {
+		pi->_iDurability--;
 		return;
 	}
 
-	if (a != 0) {
-		NetSendCmdDelItem(true, INVLOC_CHEST);
-	} else {
-		NetSendCmdDelItem(true, INVLOC_HEAD);
-	}
-	pi->_itype = ItemType::None;
 	CalcPlrInv(player, true);
 }
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -776,6 +776,10 @@ bool DamageWeapon(int pnum, int durrnd)
 		if (player.InvBody[INVLOC_HAND_LEFT]._iDurability != 0)
 			player.InvBody[INVLOC_HAND_LEFT]._iDurability--;
 		if (player.InvBody[INVLOC_HAND_LEFT]._iDurability == 0) {
+			if (!*sgOptions.Gameplay.allowZeroDurabilityItems) {
+				NetSendCmdDelItem(true, INVLOC_HAND_LEFT);
+				player.InvBody[INVLOC_HAND_LEFT]._itype = ItemType::None;
+			}
 			CalcPlrInv(player, true);
 			return true;
 		}
@@ -789,6 +793,10 @@ bool DamageWeapon(int pnum, int durrnd)
 		if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability != 0)
 			player.InvBody[INVLOC_HAND_RIGHT]._iDurability--;
 		if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability == 0) {
+			if (!*sgOptions.Gameplay.allowZeroDurabilityItems) {
+				NetSendCmdDelItem(true, INVLOC_HAND_RIGHT);
+				player.InvBody[INVLOC_HAND_RIGHT]._itype = ItemType::None;
+			}
 			CalcPlrInv(player, true);
 			return true;
 		}
@@ -802,6 +810,10 @@ bool DamageWeapon(int pnum, int durrnd)
 		if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability != 0)
 			player.InvBody[INVLOC_HAND_RIGHT]._iDurability--;
 		if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability == 0) {
+			if (!*sgOptions.Gameplay.allowZeroDurabilityItems) {
+				NetSendCmdDelItem(true, INVLOC_HAND_RIGHT);
+				player.InvBody[INVLOC_HAND_RIGHT]._itype = ItemType::None;
+			}
 			CalcPlrInv(player, true);
 			return true;
 		}
@@ -813,8 +825,12 @@ bool DamageWeapon(int pnum, int durrnd)
 		}
 
 		if (player.InvBody[INVLOC_HAND_LEFT]._iDurability != 0)
-		player.InvBody[INVLOC_HAND_LEFT]._iDurability--;
+			player.InvBody[INVLOC_HAND_LEFT]._iDurability--;
 		if (player.InvBody[INVLOC_HAND_LEFT]._iDurability == 0) {
+			if (!*sgOptions.Gameplay.allowZeroDurabilityItems) {
+				NetSendCmdDelItem(true, INVLOC_HAND_LEFT);
+				player.InvBody[INVLOC_HAND_LEFT]._itype = ItemType::None;
+			}
 			CalcPlrInv(player, true);
 			return true;
 		}
@@ -1313,6 +1329,10 @@ void DamageParryItem(int pnum)
 		if (player.InvBody[INVLOC_HAND_LEFT]._iDurability != 0)
 			player.InvBody[INVLOC_HAND_LEFT]._iDurability--;
 		if (player.InvBody[INVLOC_HAND_LEFT]._iDurability == 0) {
+			if (!*sgOptions.Gameplay.allowZeroDurabilityItems) {
+				NetSendCmdDelItem(true, INVLOC_HAND_LEFT);
+				player.InvBody[INVLOC_HAND_LEFT]._itype = ItemType::None;
+			}
 			CalcPlrInv(player, true);
 		}
 	}
@@ -1322,6 +1342,10 @@ void DamageParryItem(int pnum)
 			if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability != 0)
 				player.InvBody[INVLOC_HAND_RIGHT]._iDurability--;
 			if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability == 0) {
+				if (!*sgOptions.Gameplay.allowZeroDurabilityItems) {
+					NetSendCmdDelItem(true, INVLOC_HAND_RIGHT);
+					player.InvBody[INVLOC_HAND_RIGHT]._itype = ItemType::None;
+				}
 				CalcPlrInv(player, true);
 			}
 		}
@@ -1385,7 +1409,20 @@ void DamageArmor(int pnum)
 
 	if (pi->_iDurability != 0) {
 		pi->_iDurability--;
+		if (*sgOptions.Gameplay.allowZeroDurabilityItems) {
+			if (pi->_iDurability == 0)
+				CalcPlrInv(player, true);
+		}
 		return;
+	}
+
+	if (!*sgOptions.Gameplay.allowZeroDurabilityItems) {
+		if (a != 0) {
+			NetSendCmdDelItem(true, INVLOC_CHEST);
+		} else {
+			NetSendCmdDelItem(true, INVLOC_HEAD);
+		}
+		pi->_itype = ItemType::None;
 	}
 
 	CalcPlrInv(player, true);

--- a/Source/player.h
+++ b/Source/player.h
@@ -334,7 +334,7 @@ struct Player {
 		return _pStrength >= item._iMinStr
 		    && _pMagic >= item._iMinMag
 		    && _pDexterity >= item._iMinDex
-		    && ((item._iClass == ICLASS_MISC || item._iClass == ICLASS_GOLD || item._iClass == ICLASS_QUEST) || item._iDurability != 0);
+		    && (IsAnyOf(item._iClass, ICLASS_MISC, ICLASS_GOLD, ICLASS_QUEST) || item._iDurability != 0);
 	}
 
 	bool HasItem(int item, int *idx = nullptr) const;

--- a/Source/player.h
+++ b/Source/player.h
@@ -333,7 +333,8 @@ struct Player {
 	{
 		return _pStrength >= item._iMinStr
 		    && _pMagic >= item._iMinMag
-		    && _pDexterity >= item._iMinDex;
+		    && _pDexterity >= item._iMinDex
+		    && ((item._iClass == ICLASS_MISC || item._iClass == ICLASS_GOLD || item._iClass == ICLASS_QUEST) || item._iDurability != 0);
 	}
 
 	bool HasItem(int item, int *idx = nullptr) const;

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -1658,6 +1658,7 @@ void SmithRepairItem()
 	}
 
 	myPlayer.InvList[i]._iDurability = myPlayer.InvList[i]._iMaxDur;
+	CalcPlrInv(myPlayer, true);
 }
 
 void SmithRepairEnter()

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -1654,6 +1654,7 @@ void SmithRepairItem()
 			myPlayer.InvBody[INVLOC_HAND_LEFT]._iDurability = myPlayer.InvBody[INVLOC_HAND_LEFT]._iMaxDur;
 		if (i == -4)
 			myPlayer.InvBody[INVLOC_HAND_RIGHT]._iDurability = myPlayer.InvBody[INVLOC_HAND_RIGHT]._iMaxDur;
+		CalcPlrInv(myPlayer, true);
 		return;
 	}
 


### PR DESCRIPTION
Prevents items from being deleted when they hit 0 durability. Keeps the item equipped, but turns it red and removes bonuses. Unable to be re-equipped until it is repaired. Item will not lose durability if already at 0 durability and the player continues to take damage. Toggleable in the settings menu/ini file. Logic for turning items red persists if toggled off in case the player already has a 0 durability item in their inventory when turning this feature off, or if another player drops such an item in a multiplayer game and the player with the option toggled off picks it up.

![image](https://user-images.githubusercontent.com/68359262/148669707-85b201df-c025-47c0-a8bf-db38fb0d6243.png)


![image](https://user-images.githubusercontent.com/68359262/148668090-905ef7a4-fc67-425b-9e45-4a1a89bb6c51.png)

![image](https://user-images.githubusercontent.com/68359262/148668098-b869a6aa-4e39-45ca-ab63-d66bda114ca1.png)
