### PR TITLE
Keymapper: Add more Actions

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -404,12 +404,6 @@ bool PressSysKey(int wParam)
 
 void ReleaseKey(int vkey)
 {
-	if (vkey == DVL_VK_SNAPSHOT)
-		CaptureScreen();
-	if (vkey == DVL_VK_MENU || vkey == DVL_VK_LMENU || vkey == DVL_VK_RMENU)
-		AltPressed(false);
-	if (vkey == DVL_VK_RCONTROL)
-		ToggleItemLabelHighlight();
 	if (sgnTimeoutCurs != CURSOR_NONE || dropGoldFlag)
 		return;
 	sgOptions.Keymapper.KeyReleased(vkey);
@@ -436,9 +430,6 @@ void PressKey(int vkey)
 		return;
 	}
 
-	if (vkey == DVL_VK_MENU || vkey == DVL_VK_LMENU || vkey == DVL_VK_RMENU)
-		AltPressed(true);
-
 	if (MyPlayerIsDead) {
 		if (sgnTimeoutCurs != CURSOR_NONE) {
 			return;
@@ -463,10 +454,6 @@ void PressKey(int vkey)
 	}
 
 	if (sgnTimeoutCurs != CURSOR_NONE || dropGoldFlag) {
-		return;
-	}
-	if (vkey == DVL_VK_PAUSE) {
-		diablo_pause_game();
 		return;
 	}
 
@@ -524,20 +511,6 @@ void PressKey(int vkey)
 		if (AutomapActive && !talkflag) {
 			AutomapRight();
 		}
-	} else if (vkey == DVL_VK_TAB) {
-		DoAutoMap();
-	} else if (vkey == DVL_VK_SPACE) {
-		ClosePanels();
-		HelpFlag = false;
-		spselflag = false;
-		if (qtextflag && leveltype == DTYPE_TOWN) {
-			qtextflag = false;
-			stream_stop();
-		}
-		AutomapActive = false;
-		CancelCurrentDiabloMsg();
-		gamemenu_off();
-		doom_close();
 	}
 }
 
@@ -1472,6 +1445,28 @@ void InitKeymapActions()
 	    [] { Players[MyPlayerId].Stop(); },
 	    nullptr,
 	    CanPlayerTakeAction);
+	sgOptions.Keymapper.AddAction(
+	    "Item Highlighting",
+	    N_("Item highlighting"),
+	    N_("Show/hide items on ground."),
+	    DVL_VK_LMENU,
+	    [] { AltPressed(true); },
+	    [] { AltPressed(false); });
+	sgOptions.Keymapper.AddAction(
+	    "Toggle Item Highlighting",
+	    N_("Toggle item highlighting"),
+	    N_("Permanent show/hide items on ground."),
+	    DVL_VK_RCONTROL,
+	    nullptr,
+	    [] { ToggleItemLabelHighlight(); });
+	sgOptions.Keymapper.AddAction(
+	    "Toggle Automap",
+	    N_("Toggle automap"),
+	    N_("Toggles if automap is displayed."),
+	    DVL_VK_TAB,
+	    DoAutoMap,
+	    nullptr,
+	    IsGameRunning);
 
 	sgOptions.Keymapper.AddAction(
 	    "Inventory",
@@ -1517,6 +1512,26 @@ void InitKeymapActions()
 		    i + 1);
 	}
 	sgOptions.Keymapper.AddAction(
+	    "Hide Info Screens",
+	    N_("Hide Info Screens"),
+	    N_("Hide all info screens."),
+	    DVL_VK_SPACE,
+	    [] {
+		    ClosePanels();
+		    HelpFlag = false;
+		    spselflag = false;
+		    if (qtextflag && leveltype == DTYPE_TOWN) {
+			    qtextflag = false;
+			    stream_stop();
+		    }
+		    AutomapActive = false;
+		    CancelCurrentDiabloMsg();
+		    gamemenu_off();
+		    doom_close();
+	    },
+	    nullptr,
+	    IsGameRunning);
+	sgOptions.Keymapper.AddAction(
 	    "Zoom",
 	    N_("Zoom"),
 	    N_("Zoom Game Screen."),
@@ -1527,6 +1542,12 @@ void InitKeymapActions()
 	    },
 	    nullptr,
 	    CanPlayerTakeAction);
+	sgOptions.Keymapper.AddAction(
+	    "Pause Game",
+	    N_("Pause Game"),
+	    N_("Pauses the game."),
+	    DVL_VK_PAUSE,
+	    diablo_pause_game);
 	sgOptions.Keymapper.AddAction(
 	    "DecreaseGamma",
 	    N_("Decrease Gamma"),
@@ -1541,6 +1562,7 @@ void InitKeymapActions()
 	    N_("Increase screen brightness."),
 	    'F',
 	    IncreaseGamma,
+	    nullptr,
 	    CanPlayerTakeAction);
 	sgOptions.Keymapper.AddAction(
 	    "Help",
@@ -1550,6 +1572,13 @@ void InitKeymapActions()
 	    HelpKeyPressed,
 	    nullptr,
 	    CanPlayerTakeAction);
+	sgOptions.Keymapper.AddAction(
+	    "Screenshot",
+	    N_("Screenshot"),
+	    N_("Takes a screenshot."),
+	    DVL_VK_SNAPSHOT,
+	    nullptr,
+	    CaptureScreen);
 	sgOptions.Keymapper.AddAction(
 	    "GameInfo",
 	    N_("Game info"),

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -410,6 +410,9 @@ void ReleaseKey(int vkey)
 		AltPressed(false);
 	if (vkey == DVL_VK_RCONTROL)
 		ToggleItemLabelHighlight();
+	if (sgnTimeoutCurs != CURSOR_NONE || dropGoldFlag)
+		return;
+	sgOptions.Keymapper.KeyReleased(vkey);
 }
 
 void ClosePanels()
@@ -466,13 +469,14 @@ void PressKey(int vkey)
 		diablo_pause_game();
 		return;
 	}
+
+	sgOptions.Keymapper.KeyPressed(vkey);
+
 	if (PauseMode == 2) {
 		if (vkey == DVL_VK_RETURN && GetAsyncKeyState(DVL_VK_MENU))
 			sgOptions.Graphics.fullscreen.SetValue(!IsFullScreen());
 		return;
 	}
-
-	sgOptions.Keymapper.KeyPressed(vkey);
 
 	if (vkey == DVL_VK_RETURN) {
 		if (GetAsyncKeyState(DVL_VK_MENU)) {
@@ -1382,6 +1386,16 @@ bool IsPlayerDead()
 	return Players[MyPlayerId]._pmode == PM_DEATH || MyPlayerIsDead;
 }
 
+bool IsGameRunning()
+{
+	return PauseMode != 2;
+}
+
+bool CanPlayerTakeAction()
+{
+	return !IsPlayerDead() && IsGameRunning();
+}
+
 void InitKeymapActions()
 {
 	for (int i = 0; i < 8; ++i) {
@@ -1396,7 +1410,8 @@ void InitKeymapActions()
 				    UseInvItem(MyPlayerId, INVITEM_BELT_FIRST + i);
 			    }
 		    },
-		    [&]() { return !IsPlayerDead(); },
+		    nullptr,
+		    CanPlayerTakeAction,
 		    i + 1);
 	}
 	for (int i = 0; i < 4; ++i) {
@@ -1415,7 +1430,8 @@ void InitKeymapActions()
 			    else
 				    QuickCast(i);
 		    },
-		    [&]() { return !IsPlayerDead(); },
+		    nullptr,
+		    CanPlayerTakeAction,
 		    i + 1);
 	}
 	sgOptions.Keymapper.AddAction(
@@ -1424,21 +1440,24 @@ void InitKeymapActions()
 	    N_("Open Speedbook."),
 	    'S',
 	    DisplaySpellsKeyPressed,
-	    [&]() { return !IsPlayerDead(); });
+	    nullptr,
+	    CanPlayerTakeAction);
 	sgOptions.Keymapper.AddAction(
 	    "QuickSave",
 	    N_("Quick save"),
 	    N_("Saves the game."),
 	    DVL_VK_F2,
 	    [] { gamemenu_save_game(false); },
-	    [&]() { return !gbIsMultiplayer && !IsPlayerDead(); });
+	    nullptr,
+	    [&]() { return !gbIsMultiplayer && CanPlayerTakeAction(); });
 	sgOptions.Keymapper.AddAction(
 	    "QuickLoad",
 	    N_("Quick load"),
 	    N_("Loads the game."),
 	    DVL_VK_F3,
 	    [] { gamemenu_load_game(false); },
-	    [&]() { return !gbIsMultiplayer && gbValidSaveFile && stextflag == STORE_NONE; });
+	    nullptr,
+	    [&]() { return !gbIsMultiplayer && gbValidSaveFile && stextflag == STORE_NONE && IsGameRunning(); });
 	sgOptions.Keymapper.AddAction(
 	    "QuitGame",
 	    N_("Quit game"),
@@ -1451,7 +1470,8 @@ void InitKeymapActions()
 	    N_("Stops walking and cancel pending actions."),
 	    DVL_VK_INVALID,
 	    [] { Players[MyPlayerId].Stop(); },
-	    [&]() { return !IsPlayerDead(); });
+	    nullptr,
+	    CanPlayerTakeAction);
 
 	sgOptions.Keymapper.AddAction(
 	    "Inventory",
@@ -1459,28 +1479,32 @@ void InitKeymapActions()
 	    N_("Open Inventory screen."),
 	    'I',
 	    InventoryKeyPressed,
-	    [&]() { return !IsPlayerDead(); });
+	    nullptr,
+	    CanPlayerTakeAction);
 	sgOptions.Keymapper.AddAction(
 	    "Character",
 	    N_("Character"),
 	    N_("Open Character screen."),
 	    'C',
 	    CharacterSheetKeyPressed,
-	    [&]() { return !IsPlayerDead(); });
+	    nullptr,
+	    CanPlayerTakeAction);
 	sgOptions.Keymapper.AddAction(
 	    "QuestLog",
 	    N_("Quest log"),
 	    N_("Open Quest log."),
 	    'Q',
 	    QuestLogKeyPressed,
-	    [&]() { return !IsPlayerDead(); });
+	    nullptr,
+	    CanPlayerTakeAction);
 	sgOptions.Keymapper.AddAction(
 	    "SpellBook",
 	    N_("Spellbook"),
 	    N_("Open Spellbook."),
 	    'B',
 	    SpellBookKeyPressed,
-	    [&]() { return !IsPlayerDead(); });
+	    nullptr,
+	    CanPlayerTakeAction);
 	for (int i = 0; i < 4; ++i) {
 		sgOptions.Keymapper.AddAction(
 		    "QuickMessage{}",
@@ -1488,7 +1512,8 @@ void InitKeymapActions()
 		    N_("Use Quick Message in chat."),
 		    DVL_VK_F9 + i,
 		    [i]() { DiabloHotkeyMsg(i); },
-		    [] { return true; },
+		    nullptr,
+		    nullptr,
 		    i + 1);
 	}
 	sgOptions.Keymapper.AddAction(
@@ -1500,28 +1525,31 @@ void InitKeymapActions()
 		    zoomflag = !zoomflag;
 		    CalcViewportGeometry();
 	    },
-	    [&]() { return !IsPlayerDead(); });
+	    nullptr,
+	    CanPlayerTakeAction);
 	sgOptions.Keymapper.AddAction(
 	    "DecreaseGamma",
 	    N_("Decrease Gamma"),
 	    N_("Reduce screen brightness."),
 	    'G',
 	    DecreaseGamma,
-	    [&]() { return !IsPlayerDead(); });
+	    nullptr,
+	    CanPlayerTakeAction);
 	sgOptions.Keymapper.AddAction(
 	    "IncreaseGamma",
 	    N_("Increase Gamma"),
 	    N_("Increase screen brightness."),
 	    'F',
 	    IncreaseGamma,
-	    [&]() { return !IsPlayerDead(); });
+	    CanPlayerTakeAction);
 	sgOptions.Keymapper.AddAction(
 	    "Help",
 	    N_("Help"),
 	    N_("Open Help Screen."),
 	    DVL_VK_F1,
 	    HelpKeyPressed,
-	    [&]() { return !IsPlayerDead(); });
+	    nullptr,
+	    CanPlayerTakeAction);
 	sgOptions.Keymapper.AddAction(
 	    "GameInfo",
 	    N_("Game info"),
@@ -1534,7 +1562,8 @@ void InitKeymapActions()
 		                    PROJECT_VERSION),
 		        UiFlags::ColorWhite);
 	    },
-	    [&]() { return !IsPlayerDead(); });
+	    nullptr,
+	    CanPlayerTakeAction);
 #ifdef _DEBUG
 	sgOptions.Keymapper.AddAction(
 	    "DebugToggle",
@@ -1543,11 +1572,9 @@ void InitKeymapActions()
 	    'X',
 	    [] {
 		    DebugToggle = !DebugToggle;
-	    },
-	    [&]() { return true; });
+	    });
 #endif
 }
-
 } // namespace
 
 void FreeGameMem()

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1048,6 +1048,15 @@ KeymapperOptions::KeymapperOptions()
 		keyIDToKeyName.emplace(DVL_VK_F1 + i, fmt::format("F{}", i + 1));
 	}
 
+	keyIDToKeyName.emplace(DVL_VK_LMENU, "LALT");
+	keyIDToKeyName.emplace(DVL_VK_RMENU, "RALT");
+	keyIDToKeyName.emplace(DVL_VK_SPACE, "SPACE");
+	keyIDToKeyName.emplace(DVL_VK_RCONTROL, "RCONTROL");
+	keyIDToKeyName.emplace(DVL_VK_LCONTROL, "LCONTROL");
+	keyIDToKeyName.emplace(DVL_VK_SNAPSHOT, "PRINT");
+	keyIDToKeyName.emplace(DVL_VK_PAUSE, "PAUSE");
+	keyIDToKeyName.emplace(DVL_VK_TAB, "TAB");
+
 	keyNameToKeyID.reserve(keyIDToKeyName.size());
 	for (const auto &kv : keyIDToKeyName) {
 		keyNameToKeyID.emplace(kv.second, kv.first);

--- a/Source/options.h
+++ b/Source/options.h
@@ -543,9 +543,10 @@ struct KeymapperOptions : OptionCategoryBase {
 		bool SetValue(int value);
 
 	private:
-		Action(string_view key, string_view name, string_view description, int defaultKey, std::function<void()> action, std::function<bool()> enable, int index);
+		Action(string_view key, string_view name, string_view description, int defaultKey, std::function<void()> actionPressed, std::function<void()> actionReleased, std::function<bool()> enable, int index);
 		int defaultKey;
-		std::function<void()> action;
+		std::function<void()> actionPressed;
+		std::function<void()> actionReleased;
 		std::function<bool()> enable;
 		int boundKey = DVL_VK_INVALID;
 		int dynamicIndex;
@@ -560,8 +561,9 @@ struct KeymapperOptions : OptionCategoryBase {
 
 	void AddAction(
 	    string_view key, string_view name, string_view description, int defaultKey,
-	    std::function<void()> action, std::function<bool()> enable = [] { return true; }, int index = -1);
+	    std::function<void()> actionPressed, std::function<void()> actionReleased = nullptr, std::function<bool()> enable = nullptr, int index = -1);
 	void KeyPressed(int key) const;
+	void KeyReleased(int key) const;
 	string_view KeyNameForAction(string_view actionName) const;
 
 private:


### PR DESCRIPTION
Fixes #2832

Notes:
- Adds Item Highlighting (Default key ALT & RCONTROL)
- Adds Screenshot (Default key PRINT)
- Adds Pause (Default key PAUSE)
- Adds Automap Toggle (Default key TAB)
- Adds Hide info Screen (Default key SPACE)
- With this PR all "normal" actions are mappable. Only menu and store Interactions, Automap movement and "ESC" is still hard coded. But imho these are fine.
- Still missing is mapping the mouse based actions. But this is another topic/issue.
- Also not implemented are modifier keys `SHIFT` or `ALT`.

Open question: currently left and right control are different keys for the keymapper, cause Item Highlighting only used right control. But the alt keys are combined, cause Item Highlighting also used to do this. Should we stay with this old logic or separate all keys or combine all?