### PR TITLE
Update libzt

### DIFF
--- a/3rdParty/libzt/CMakeLists.txt
+++ b/3rdParty/libzt/CMakeLists.txt
@@ -5,7 +5,7 @@ set(BUILD_HOST_SELFTEST OFF)
 include(FetchContent)
 FetchContent_Declare(libzt
   GIT_REPOSITORY https://github.com/diasurgical/libzt.git
-  GIT_TAG a9974991b031fd8f84c4bcfd93f129b3938ed8c8)
+  GIT_TAG fe2f8dcb0ce32b990c13d63c6217bbf35bbd547f)
 FetchContent_MakeAvailableExcludeFromAll(libzt)
 
 if(NOT ANDROID)


### PR DESCRIPTION
Fixes the MSVC release build issue described in https://github.com/diasurgical/devilutionX/pull/3935#issuecomment-1008853909.

> Also release builds that include zerotier are broken due to a gcc flag being passed in to MSVC in libzt: https://github.com/diasurgical/libzt/blob/a9974991b031fd8f84c4bcfd93f129b3938ed8c8/CMakeLists.txt#L286-L287
> 
> `-w` gets translated to `/w` to supress all warnings, but the `-wno-everything` flag is treated as `/W<int>` which fails to parse.