### PR TITLE
Fix item cursor graphic for Rogue's Slain Hero reward

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2469,7 +2469,7 @@ void OperateSlainHero(int pnum, int i)
 	if (player._pClass == HeroClass::Warrior) {
 		CreateMagicArmor(Objects[i].position, ItemType::HeavyArmor, ICURS_BREAST_PLATE, false, true);
 	} else if (player._pClass == HeroClass::Rogue) {
-		CreateMagicWeapon(Objects[i].position, ItemType::Bow, ICURS_LONG_WAR_BOW, false, true);
+		CreateMagicWeapon(Objects[i].position, ItemType::Bow, ICURS_LONG_BATTLE_BOW, false, true);
 	} else if (player._pClass == HeroClass::Sorcerer) {
 		CreateSpellBook(Objects[i].position, SPL_LIGHTNING, false, true);
 	} else if (player._pClass == HeroClass::Monk) {


### PR DESCRIPTION
The item generation loops until the item cursor graphic matches what we pass in so the original logic would loop until it found an item that uses the Long War Bow graphic. Long War Bow drops from objects starting on dlvl 10 so this could only have dropped a Long Battle Bow, at least so long as it was using the Long War Bow graphic. However, the graphic was changed recently in bb9a20f.

Incidentally, this brings up another non-obvious side effect of changing the graphic. It seems Nakrul was scripted to always drop an item with the Long War Bow graphic which, prior to bb9a20f, probably could have produced a Long Battle Bow instead.

This resolves #826