### PR TITLE
Fix walk stuttering with Preview Frame

### DIFF
--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -59,17 +59,17 @@ int AnimationInfo::GetFrameToUseForRendering() const
 
 float AnimationInfo::GetAnimationProgress() const
 {
-	int ticksSinceSequenceStarted = TicksSinceSequenceStarted;
+	float ticksSinceSequenceStarted = TicksSinceSequenceStarted;
 	float tickModifier = TickModifier;
 
 	if (RelevantFramesForDistributing <= 0) {
 		// This logic is used if animation distribution is not active (see GetFrameToUseForRendering).
 		// In this case the variables calculated with animation distribution are not initialized and we have to calculate them on the fly with the given information.
-		ticksSinceSequenceStarted = ((CurrentFrame - 1) * TicksPerFrame) + TickCounterOfCurrentFrame;
+		ticksSinceSequenceStarted = static_cast<float>(((CurrentFrame - 1) * TicksPerFrame) + TickCounterOfCurrentFrame);
 		tickModifier = 1.0F / static_cast<float>(TicksPerFrame);
 	}
 
-	float totalTicksForCurrentAnimationSequence = GetProgressToNextGameTick() + static_cast<float>(ticksSinceSequenceStarted);
+	float totalTicksForCurrentAnimationSequence = GetProgressToNextGameTick() + ticksSinceSequenceStarted;
 	float progressInAnimationFrames = totalTicksForCurrentAnimationSequence * tickModifier;
 	float animationFraction = progressInAnimationFrames / static_cast<float>(NumberOfFrames);
 	return animationFraction;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2409,7 +2409,7 @@ void NewPlrAnim(Player &player, player_graphic graphic, Direction dir, int numbe
 	CelSprite *pCelSprite = celSprite ? &*celSprite : nullptr;
 
 	float previewShownGameTickFragments = 0.F;
-	if (pCelSprite == player.pPreviewCelSprite)
+	if (pCelSprite == player.pPreviewCelSprite && !player.IsWalking())
 		previewShownGameTickFragments = clamp(1.F - player.progressToNextGameTickWhenPreviewWasSet, 0.F, 1.F);
 	player.AnimInfo.SetNewAnimation(pCelSprite, numberOfFrames, delayLen, flags, numSkippedFrames, distributeFramesBeforeFrame, previewShownGameTickFragments);
 }


### PR DESCRIPTION
Fixes a reported issue from @FitzRoyX

> Another issue is that obligaron's prediction algo thing is causing some slight wierd abruptness when coming to a stop walking horizontally. It feels like the camera is shifting, I don't know how to explain it

In #2457 (last commit) the time the preview frame was shown was added to the animation distribution to smooth the animation better. But this resulted in a small stuttering, cause `GetOffsetForWalking`/`GetAnimationProgress` is also based on this time.
Workaround is to not add preview frame time for the walking animation. Also fixes some casting warnings.