### PR TITLE
Show correct death animation

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1681,7 +1681,7 @@ DWORD OnPlayerJoinLevel(const TCmd *pCmd, int pnum)
 			if ((player._pHitPoints >> 6) > 0) {
 				StartStand(pnum, Direction::South);
 			} else {
-				player._pgfxnum = 0;
+				player._pgfxnum &= 0xF0;
 				player._pmode = PM_DEATH;
 				NewPlrAnim(player, player_graphic::Death, Direction::South, player._pDFrames, 1);
 				player.AnimInfo.CurrentFrame = player.AnimInfo.NumberOfFrames - 1;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1681,7 +1681,7 @@ DWORD OnPlayerJoinLevel(const TCmd *pCmd, int pnum)
 			if ((player._pHitPoints >> 6) > 0) {
 				StartStand(pnum, Direction::South);
 			} else {
-				player._pgfxnum &= 0xF0;
+				player._pgfxnum &= ~0xF;
 				player._pmode = PM_DEATH;
 				NewPlrAnim(player, player_graphic::Death, Direction::South, player._pDFrames, 1);
 				player.AnimInfo.CurrentFrame = player.AnimInfo.NumberOfFrames - 1;

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -818,7 +818,7 @@ void recv_plrinfo(int pnum, const TCmdPlrInfoHdr &header, bool recv)
 		return;
 	}
 
-	player._pgfxnum &= 0xF0;
+	player._pgfxnum &= ~0xF;
 	player._pmode = PM_DEATH;
 	NewPlrAnim(player, player_graphic::Death, Direction::South, player._pDFrames, 1);
 	player.AnimInfo.CurrentFrame = player.AnimInfo.NumberOfFrames - 1;

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -818,7 +818,7 @@ void recv_plrinfo(int pnum, const TCmdPlrInfoHdr &header, bool recv)
 		return;
 	}
 
-	player._pgfxnum = 0;
+	player._pgfxnum &= 0xF0;
 	player._pmode = PM_DEATH;
 	NewPlrAnim(player, player_graphic::Death, Direction::South, player._pDFrames, 1);
 	player.AnimInfo.CurrentFrame = player.AnimInfo.NumberOfFrames - 1;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2204,7 +2204,7 @@ void LoadPlrGFX(Player &player, player_graphic graphic)
 void InitPlayerGFX(Player &player)
 {
 	if (player._pHitPoints >> 6 == 0) {
-		player._pgfxnum &= 0xF0;
+		player._pgfxnum &= ~0xF;
 		LoadPlrGFX(player, player_graphic::Death);
 		return;
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2204,7 +2204,7 @@ void LoadPlrGFX(Player &player, player_graphic graphic)
 void InitPlayerGFX(Player &player)
 {
 	if (player._pHitPoints >> 6 == 0) {
-		player._pgfxnum = 0;
+		player._pgfxnum &= 0xF0;
 		LoadPlrGFX(player, player_graphic::Death);
 		return;
 	}
@@ -2933,7 +2933,10 @@ StartPlayerKill(int pnum, int earflag)
 	player.Say(HeroSpeech::AuughUh);
 
 	if (player._pgfxnum != 0) {
-		player._pgfxnum = 0;
+		if (diablolevel || earflag != 0)
+			player._pgfxnum &= ~0xF;
+		else
+			player._pgfxnum = 0;
 		ResetPlayerGFX(player);
 		SetPlrAnims(player);
 	}


### PR DESCRIPTION
This fix revises the death animation, so that a death resulting in no equipped items being dropped will allow your death animation to match your current armor tier, instead of defaulting to light armor. If your equipped items are dropped, you will continue to use the light armor animation.