### PR TITLE
Resolve game crash when syncing Diablo items in Hellfire games

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3442,7 +3442,7 @@ void CornerstoneSave()
 		return;
 	if (!CornerStone.item.isEmpty()) {
 		ItemPack id;
-		PackItem(id, CornerStone.item);
+		PackItem(id, CornerStone.item, (CornerStone.item.dwBuff & CF_HELLFIRE) != 0);
 		const auto *buffer = reinterpret_cast<uint8_t *>(&id);
 		for (size_t i = 0; i < sizeof(ItemPack); i++) {
 			snprintf(&sgOptions.Hellfire.szItem[i * 2], 3, "%02hhX", buffer[i]);

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -320,7 +320,7 @@ void SendPlayerInfo(int pnum, _cmd_id cmd)
 	static_assert(alignof(PlayerPack) == 1, "Fix pkplr alignment");
 	std::unique_ptr<byte[]> pkplr { new byte[sizeof(PlayerPack)] };
 
-	PackPlayer(reinterpret_cast<PlayerPack *>(pkplr.get()), Players[MyPlayerId], true);
+	PackPlayer(reinterpret_cast<PlayerPack *>(pkplr.get()), Players[MyPlayerId], true, true);
 	dthread_send_delta(pnum, cmd, std::move(pkplr), sizeof(PlayerPack));
 }
 

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -35,14 +35,14 @@ void VerifyGoldSeeds(Player &player)
 
 } // namespace
 
-void PackItem(ItemPack &packedItem, const Item &item)
+void PackItem(ItemPack &packedItem, const Item &item, bool isHellfire)
 {
 	packedItem = {};
 	if (item.isEmpty()) {
 		packedItem.idx = 0xFFFF;
 	} else {
 		auto idx = item.IDidx;
-		if (!gbIsHellfire) {
+		if (!isHellfire) {
 			idx = RemapItemIdxToDiablo(idx);
 		}
 		if (gbIsSpawn) {
@@ -74,7 +74,7 @@ void PackItem(ItemPack &packedItem, const Item &item)
 	}
 }
 
-void PackPlayer(PlayerPack *pPack, const Player &player, bool manashield)
+void PackPlayer(PlayerPack *pPack, const Player &player, bool manashield, bool netSync)
 {
 	memset(pPack, 0, sizeof(*pPack));
 	pPack->destAction = player.destAction;
@@ -109,19 +109,25 @@ void PackPlayer(PlayerPack *pPack, const Player &player, bool manashield)
 		pPack->pSplLvl2[i - 37] = player._pSplLvl[i];
 
 	for (int i = 0; i < NUM_INVLOC; i++) {
-		PackItem(pPack->InvBody[i], player.InvBody[i]);
+		const Item &item = player.InvBody[i];
+		bool isHellfire = netSync ? ((item.dwBuff & CF_HELLFIRE) != 0) : gbIsHellfire;
+		PackItem(pPack->InvBody[i], item, isHellfire);
 	}
 
 	pPack->_pNumInv = player._pNumInv;
 	for (int i = 0; i < pPack->_pNumInv; i++) {
-		PackItem(pPack->InvList[i], player.InvList[i]);
+		const Item &item = player.InvList[i];
+		bool isHellfire = netSync ? ((item.dwBuff & CF_HELLFIRE) != 0) : gbIsHellfire;
+		PackItem(pPack->InvList[i], item, isHellfire);
 	}
 
 	for (int i = 0; i < NUM_INV_GRID_ELEM; i++)
 		pPack->InvGrid[i] = player.InvGrid[i];
 
 	for (int i = 0; i < MAXBELTITEMS; i++) {
-		PackItem(pPack->SpdList[i], player.SpdList[i]);
+		const Item &item = player.SpdList[i];
+		bool isHellfire = netSync ? ((item.dwBuff & CF_HELLFIRE) != 0) : gbIsHellfire;
+		PackItem(pPack->SpdList[i], item, isHellfire);
 	}
 
 	pPack->wReflections = SDL_SwapLE16(player.wReflections);

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -79,7 +79,7 @@ struct PlayerPack {
 };
 #pragma pack(pop)
 
-void PackPlayer(PlayerPack *pPack, const Player &player, bool manashield);
+void PackPlayer(PlayerPack *pPack, const Player &player, bool manashield, bool netSync);
 bool UnPackPlayer(const PlayerPack *pPack, Player &player, bool netSync);
 
 /**
@@ -88,7 +88,7 @@ bool UnPackPlayer(const PlayerPack *pPack, Player &player, bool netSync);
  * @param packedItem The destination packed struct
  * @param item The source item
  */
-void PackItem(ItemPack &packedItem, const Item &item);
+void PackItem(ItemPack &packedItem, const Item &item, bool isHellfire);
 
 /**
  * Expand a ItemPack in to a Item

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -262,7 +262,7 @@ void pfile_write_hero(bool writeGameData, bool clearTables)
 	PlayerPack pkplr;
 	auto &myPlayer = Players[MyPlayerId];
 
-	PackPlayer(&pkplr, myPlayer, !gbIsMultiplayer);
+	PackPlayer(&pkplr, myPlayer, !gbIsMultiplayer, false);
 	EncodeHero(&pkplr);
 	if (!gbVanilla) {
 		SaveHotkeys();
@@ -342,7 +342,7 @@ bool pfile_ui_save_create(_uiheroinfo *heroinfo)
 	auto &player = Players[0];
 	CreatePlayer(0, heroinfo->heroclass);
 	CopyUtf8(player._pName, heroinfo->name, PLR_NAME_LEN);
-	PackPlayer(&pkplr, player, true);
+	PackPlayer(&pkplr, player, true, false);
 	EncodeHero(&pkplr);
 	Game2UiPlayer(player, heroinfo, false);
 	if (!gbVanilla) {

--- a/test/pack_test.cpp
+++ b/test/pack_test.cpp
@@ -345,7 +345,7 @@ TEST(PackTest, UnPackItem_diablo)
 		UnPackItem(PackedDiabloItems[i], id, false);
 		CompareItems(id, DiabloItems[i]);
 
-		PackItem(is, id);
+		PackItem(is, id, gbIsHellfire);
 		ComparePackedItems(is, PackedDiabloItems[i]);
 	}
 }
@@ -380,7 +380,7 @@ TEST(PackTest, UnPackItem_diablo_unique_bug)
 	ASSERT_EQ(id.IDidx, IDI_STEELVEIL);
 
 	ItemPack is;
-	PackItem(is, id);
+	PackItem(is, id, gbIsHellfire);
 	ComparePackedItems(is, pkItem);
 }
 
@@ -416,7 +416,7 @@ TEST(PackTest, UnPackItem_spawn)
 		UnPackItem(PackedSpawnItems[i], id, false);
 		CompareItems(id, SpawnItems[i]);
 
-		PackItem(is, id);
+		PackItem(is, id, gbIsHellfire);
 		ComparePackedItems(is, PackedSpawnItems[i]);
 	}
 }
@@ -460,7 +460,7 @@ TEST(PackTest, UnPackItem_diablo_multiplayer)
 		UnPackItem(PackedDiabloMPItems[i], id, false);
 		CompareItems(id, DiabloMPItems[i]);
 
-		PackItem(is, id);
+		PackItem(is, id, gbIsHellfire);
 		ComparePackedItems(is, PackedDiabloMPItems[i]);
 	}
 }
@@ -669,7 +669,7 @@ TEST(PackTest, UnPackItem_hellfire)
 		UnPackItem(PackedHellfireItems[i], id, true);
 		CompareItems(id, HellfireItems[i]);
 
-		PackItem(is, id);
+		PackItem(is, id, gbIsHellfire);
 		is.dwBuff &= ~CF_HELLFIRE;
 		ComparePackedItems(is, PackedHellfireItems[i]);
 	}
@@ -706,7 +706,7 @@ TEST(PackTest, PackItem_empty)
 
 	id._itype = ItemType::None;
 
-	PackItem(is, id);
+	PackItem(is, id, gbIsHellfire);
 
 	// Copy the value out before comparing to avoid loading a misaligned address.
 	const auto idx = is.idx;
@@ -726,7 +726,7 @@ static void compareGold(const ItemPack &is, int iCurs)
 	ASSERT_EQ(id._iClass, ICLASS_GOLD);
 
 	ItemPack is2;
-	PackItem(is2, id);
+	PackItem(is2, id, gbIsHellfire);
 	ComparePackedItems(is, is2);
 }
 
@@ -758,7 +758,7 @@ TEST(PackTest, UnPackItem_ear)
 	ASSERT_EQ(id._ivalue, 3);
 
 	ItemPack is2;
-	PackItem(is2, id);
+	PackItem(is2, id, gbIsHellfire);
 	ComparePackedItems(is, is2);
 }
 


### PR DESCRIPTION
This fixes an error where converting Multiplayer save files from Diablo to Hellfire can cause a remote player's game to crash.

When converting save files from Diablo to Hellfire, the Diablo items are remapped to Hellfire item indexes in memory. When saving the file, the game leaves these indexes alone so they match the game type with which the save was generated. If there are any issues with the item when recreating it using the wrong index, the game resolves these by reading from the `heroitems` section of the file.

However, when transmitting the items over the network, there is no `heroitems` file the game can use to fix errors during item recreation. Therefore, the logic for `UnpackItem()` was changed to use the item's `dwBuff` value to tell the client where the item originated from so it can be properly recreated. The problem here is that `PackItem()` was never modified to remap item indexes back to Diablo so the host would send Hellfire item indexes for Diablo items. The remote client would then remap the Hellfire item indexes as if they were Diablo item indexes, which would cause item recreation to fail hard in some cases.

You can test this situation using the attached save files. `multi_0.sv` is the original vanilla Diablo save. `multi_0.hsv` has been converted to Hellfire by first loading the character into DevilutionX Diablo, renaming the file to hsv, and then loading the character into DevilutionX Hellfire.

[multi_0.zip](https://github.com/diasurgical/devilutionX/files/7877810/multi_0.zip)

