### PR TITLE
Remove missile/sprite limit

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -35,7 +35,7 @@ namespace devilution {
 
 ControlTypes ControlMode = ControlTypes::None;
 int pcurstrig = -1;
-int pcursmissile = -1;
+Missile *pcursmissile = nullptr;
 quest_id pcursquest = Q_INVALID;
 
 /**
@@ -405,26 +405,24 @@ void FindTrigger()
 	if (pcursitem != -1 || pcursobj != -1)
 		return; // Prefer showing items/objects over triggers (use of cursm* conflicts)
 
-	for (int i = 0; i < ActiveMissileCount; i++) {
-		int mi = ActiveMissiles[i];
-		auto &missile = Missiles[mi];
+	for (auto &missile : Missiles) {
 		if (missile._mitype == MIS_TOWN || missile._mitype == MIS_RPORTAL) {
 			const int newDistance = GetDistance(missile.position.tile, 2);
 			if (newDistance == 0)
 				continue;
-			if (pcursmissile != -1 && distance < newDistance)
+			if (pcursmissile != nullptr && distance < newDistance)
 				continue;
 			const int newRotations = GetRotaryDistance(missile.position.tile);
-			if (pcursmissile != -1 && distance == newDistance && rotations < newRotations)
+			if (pcursmissile != nullptr && distance == newDistance && rotations < newRotations)
 				continue;
 			cursPosition = missile.position.tile;
-			pcursmissile = mi;
+			pcursmissile = &missile;
 			distance = newDistance;
 			rotations = newRotations;
 		}
 	}
 
-	if (pcursmissile == -1) {
+	if (pcursmissile == nullptr) {
 		for (int i = 0; i < numtrigs; i++) {
 			int tx = trigs[i].position.x;
 			int ty = trigs[i].position.y;
@@ -1443,7 +1441,7 @@ void plrctrls_after_check_curs_move()
 	pcursmonst = -1;
 	pcursitem = -1;
 	pcursobj = -1;
-	pcursmissile = -1;
+	pcursmissile = nullptr;
 	pcurstrig = -1;
 	pcursquest = Q_INVALID;
 	cursPosition = { -1, -1 };
@@ -1710,8 +1708,8 @@ void PerformSecondaryAction()
 		NetSendCmdLocParam1(true, CMD_OPOBJXY, cursPosition, pcursobj);
 	} else {
 		auto &myPlayer = Players[MyPlayerId];
-		if (pcursmissile != -1) {
-			MakePlrPath(myPlayer, Missiles[pcursmissile].position.tile, true);
+		if (pcursmissile != nullptr) {
+			MakePlrPath(myPlayer, pcursmissile->position.tile, true);
 			myPlayer.destAction = ACTION_WALK;
 		} else if (pcurstrig != -1) {
 			MakePlrPath(myPlayer, trigs[pcurstrig].position, true);

--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -436,12 +436,12 @@ VirtualGamepadButtonType PrimaryActionButtonRenderer::GetInventoryButtonType()
 }
 
 extern int pcurstrig;
-extern int pcursmissile;
+extern Missile *pcursmissile;
 extern quest_id pcursquest;
 
 VirtualGamepadButtonType SecondaryActionButtonRenderer::GetButtonType()
 {
-	if (pcursmissile != -1 || pcurstrig != -1 || pcursquest != Q_INVALID) {
+	if (pcursmissile != nullptr || pcurstrig != -1 || pcursquest != Q_INVALID) {
 		return GetStairsButtonType(virtualPadButton->isHeld);
 	}
 	if (InGameMenu() || QuestLogIsOpen || sbookflag)

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -208,9 +208,7 @@ void InitLevelCursor()
 
 void CheckTown()
 {
-	for (int i = 0; i < ActiveMissileCount; i++) {
-		int mx = ActiveMissiles[i];
-		auto &missile = Missiles[mx];
+	for (auto &missile : Missiles) {
 		if (missile._mitype == MIS_TOWN) {
 			if (EntranceBoundaryContains(missile.position.tile, cursPosition)) {
 				trigflag = true;
@@ -226,9 +224,7 @@ void CheckTown()
 
 void CheckRportal()
 {
-	for (int i = 0; i < ActiveMissileCount; i++) {
-		int mx = ActiveMissiles[i];
-		auto &missile = Missiles[mx];
+	for (auto &missile : Missiles) {
 		if (missile._mitype == MIS_RPORTAL) {
 			if (EntranceBoundaryContains(missile.position.tile, cursPosition)) {
 				trigflag = true;

--- a/Source/misdat.h
+++ b/Source/misdat.h
@@ -110,9 +110,10 @@ enum class MissileMovementDistrubution {
 };
 
 struct Missile;
+struct AddMissileParameter;
 
 struct MissileData {
-	void (*mAddProc)(Missile &, Point, Direction);
+	void (*mAddProc)(Missile &, const AddMissileParameter &);
 	void (*mProc)(Missile &);
 	uint8_t mName;
 	bool mDraw;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -26,10 +26,7 @@
 
 namespace devilution {
 
-int ActiveMissiles[MAXMISSILES];
-int AvailableMissiles[MAXMISSILES];
-Missile Missiles[MAXMISSILES];
-int ActiveMissileCount;
+std::list<Missile> Missiles;
 bool MissilePreFlag;
 
 namespace {
@@ -956,14 +953,6 @@ Direction16 GetDirection16(Point p1, Point p2)
 	return ret;
 }
 
-void DeleteMissile(int i)
-{
-	AvailableMissiles[MAXMISSILES - ActiveMissileCount] = ActiveMissiles[i];
-	ActiveMissileCount--;
-	if (ActiveMissileCount > 0 && i != ActiveMissileCount)
-		ActiveMissiles[i] = ActiveMissiles[ActiveMissileCount];
-}
-
 bool MonsterTrapHit(int m, int mindam, int maxdam, int dist, missile_id t, bool shift)
 {
 	auto &monster = Monsters[m];
@@ -1191,9 +1180,7 @@ void InitMissiles()
 	AutoMapShowItems = false;
 	myPlayer._pSpellFlags &= ~0x1;
 	if (myPlayer._pInfraFlag) {
-		for (int i = 0; i < ActiveMissileCount; ++i) {
-			int mi = ActiveMissiles[i];
-			auto &missile = Missiles[mi];
+		for (auto &missile : Missiles) {
 			if (missile._mitype == MIS_INFRA) {
 				int src = missile._misource;
 				if (src == MyPlayerId)
@@ -1205,9 +1192,7 @@ void InitMissiles()
 	if ((myPlayer._pSpellFlags & 2) == 2 || (myPlayer._pSpellFlags & 4) == 4) {
 		myPlayer._pSpellFlags &= ~0x2;
 		myPlayer._pSpellFlags &= ~0x4;
-		for (int i = 0; i < ActiveMissileCount; ++i) {
-			int mi = ActiveMissiles[i];
-			auto &missile = Missiles[mi];
+		for (auto &missile : Missiles) {
 			if (missile._mitype == MIS_BLODBOIL) {
 				if (missile._misource == MyPlayerId) {
 					int missingHP = myPlayer._pMaxHP - myPlayer._pHitPoints;
@@ -1218,11 +1203,7 @@ void InitMissiles()
 		}
 	}
 
-	ActiveMissileCount = 0;
-	for (int i = 0; i < MAXMISSILES; i++) {
-		AvailableMissiles[i] = i;
-		ActiveMissiles[i] = 0;
-	}
+	Missiles.clear();
 	for (int j = 0; j < MAXDUNY; j++) {
 		for (int i = 0; i < MAXDUNX; i++) { // NOLINT(modernize-loop-convert)
 			dFlags[i][j] &= ~DungeonFlag::Missile;
@@ -1659,18 +1640,14 @@ void AddSearch(Missile &missile, const AddMissileParameter & /*parameter*/)
 	if (missile._micaster == TARGET_MONSTERS)
 		UseMana(missile._misource, SPL_SEARCH);
 
-	for (int i = 0; i < ActiveMissileCount; i++) {
-		int mx = ActiveMissiles[i];
-		if (&Missiles[mx] != &missile) {
-			auto &other = Missiles[mx];
-			if (other._misource == missile._misource && other._mitype == MIS_SEARCH) {
-				int r1 = missile._mirange;
-				int r2 = other._mirange;
-				if (r2 < INT_MAX - r1)
-					other._mirange = r1 + r2;
-				missile._miDelFlag = true;
-				break;
-			}
+	for (auto &other : Missiles) {
+		if (&other != &missile && other._misource == missile._misource && other._mitype == MIS_SEARCH) {
+			int r1 = missile._mirange;
+			int r2 = other._mirange;
+			if (r2 < INT_MAX - r1)
+				other._mirange = r1 + r2;
+			missile._miDelFlag = true;
+			break;
 		}
 	}
 }
@@ -2038,9 +2015,7 @@ void AddTown(Missile &missile, const AddMissileParameter &parameter)
 
 	missile._mirange = 100;
 	missile.var1 = missile._mirange - missile._miAnimLen;
-	for (int i = 0; i < ActiveMissileCount; i++) {
-		int mx = ActiveMissiles[i];
-		auto &other = Missiles[mx];
+	for (auto &other : Missiles) {
 		if (other._mitype == MIS_TOWN && &other != &missile && other._misource == missile._misource)
 			other._mirange = 0;
 	}
@@ -2331,9 +2306,7 @@ void AddGolem(Missile &missile, const AddMissileParameter &parameter)
 
 	int playerId = missile._misource;
 
-	for (int i = 0; i < ActiveMissileCount; i++) {
-		int mx = ActiveMissiles[i];
-		auto &other = Missiles[mx];
+	for (auto &other : Missiles) {
 		if (other._mitype == MIS_GOLEM && &other != &missile && other._misource == playerId) {
 			return;
 		}
@@ -2719,17 +2692,12 @@ void AddDiabApoca(Missile &missile, const AddMissileParameter & /*parameter*/)
 	missile._miDelFlag = true;
 }
 
-int AddMissile(Point src, Point dst, Direction midir, missile_id mitype, mienemy_type micaster, int id, int midam, int spllvl, Missile *pParent /*= nullptr*/)
+Missile &AddMissile(Point src, Point dst, Direction midir, missile_id mitype, mienemy_type micaster, int id, int midam, int spllvl, Missile *pParent /*= nullptr*/)
 {
-	if (ActiveMissileCount >= MAXMISSILES - 1)
-		return -1;
+	constexpr int32_t MaxMissiles = std::numeric_limits<int32_t>::max();
 
-	int mi = AvailableMissiles[0];
-	auto &missile = Missiles[mi];
-
-	AvailableMissiles[0] = AvailableMissiles[MAXMISSILES - ActiveMissileCount - 1];
-	ActiveMissiles[ActiveMissileCount] = mi;
-	ActiveMissileCount++;
+	Missiles.emplace_back(Missile {});
+	auto &missile = Missiles.back();
 
 	memset(&missile, 0, sizeof(missile));
 
@@ -2760,7 +2728,7 @@ int AddMissile(Point src, Point dst, Direction midir, missile_id mitype, mienemy
 	AddMissileParameter parameter = { dst, midir, pParent };
 	missileData.mAddProc(missile, parameter);
 
-	return mi;
+	return missile;
 }
 
 void MI_LArrow(Missile &missile)
@@ -4144,13 +4112,7 @@ void MI_Rportal(Missile &missile)
 
 static void DeleteMissiles()
 {
-	for (int i = 0; i < ActiveMissileCount;) {
-		if (Missiles[ActiveMissiles[i]]._miDelFlag) {
-			DeleteMissile(i);
-		} else {
-			i++;
-		}
-	}
+	Missiles.remove_if([](Missile &missile) { return missile._miDelFlag; });
 }
 
 void ProcessManaShield()
@@ -4164,8 +4126,7 @@ void ProcessManaShield()
 
 void ProcessMissiles()
 {
-	for (int i = 0; i < ActiveMissileCount; i++) {
-		auto &missile = Missiles[ActiveMissiles[i]];
+	for (auto &missile : Missiles) {
 		const auto &position = missile.position.tile;
 		dFlags[position.x][position.y] &= ~DungeonFlag::Missile;
 		if (!InDungeonBounds(position))
@@ -4176,8 +4137,7 @@ void ProcessMissiles()
 
 	MissilePreFlag = false;
 
-	for (int i = 0; i < ActiveMissileCount; i++) {
-		auto &missile = Missiles[ActiveMissiles[i]];
+	for (auto &missile : Missiles) {
 		if (MissilesData[missile._mitype].mProc != nullptr)
 			MissilesData[missile._mitype].mProc(missile);
 		if (missile._miAnimFlags == MissileDataFlags::NotAnimated)
@@ -4201,10 +4161,7 @@ void ProcessMissiles()
 
 void missiles_process_charge()
 {
-	for (int i = 0; i < ActiveMissileCount; i++) {
-		int mi = ActiveMissiles[i];
-		auto &missile = Missiles[mi];
-
+	for (auto &missile : Missiles) {
 		missile._miAnimData = MissileSpriteData[missile._miAnimType].animData[missile._mimfnum].get();
 		if (missile._mitype != MIS_RHINO)
 			continue;
@@ -4225,8 +4182,7 @@ void missiles_process_charge()
 
 void RedoMissileFlags()
 {
-	for (int i = 0; i < ActiveMissileCount; i++) {
-		auto &missile = Missiles[ActiveMissiles[i]];
+	for (auto &missile : Missiles) {
 		PutMissile(missile);
 	}
 }

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -757,23 +757,6 @@ int FindParent(Missile &missile)
 	return -1;
 }
 
-/**
- * @brief Sync missile position with parent missile, by searching for self reference in all mssiles
- *
- * @todo It's unclear if this is actually neede is mostly dead code
- */
-void SyncPositionWithParent(Missile &missile)
-{
-	int mx = FindParent(missile);
-	if (mx == -1)
-		return;
-
-	auto &parent = Missiles[mx];
-
-	missile.position.offset = parent.position.offset;
-	missile.position.traveled = parent.position.traveled;
-}
-
 void SpawnLightning(Missile &missile, int dam)
 {
 	missile._mirange--;
@@ -1993,8 +1976,6 @@ void AddLightning(Missile &missile, Point dst, Direction /*midir*/)
 {
 	missile.position.start = dst;
 
-	SyncPositionWithParent(missile);
-
 	missile._miAnimFrame = GenerateRnd(8) + 1;
 
 	if (missile._micaster == TARGET_PLAYERS || missile._misource == -1) {
@@ -2634,8 +2615,6 @@ void AddFlame(Missile &missile, Point dst, Direction /*midir*/)
 {
 	missile.var2 = 5 * missile._midam;
 	missile.position.start = dst;
-
-	SyncPositionWithParent(missile);
 
 	missile._mirange = missile.var2 + 20;
 	missile._mlid = AddLight(missile.position.start, 1);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -34,9 +34,6 @@ bool MissilePreFlag;
 
 namespace {
 
-ChainStruct chain[MAXMISSILES];
-int numchains;
-
 int AddClassHealingBonus(int hp, HeroClass heroClass)
 {
 	switch (heroClass) {
@@ -1225,12 +1222,6 @@ void InitMissiles()
 	for (int i = 0; i < MAXMISSILES; i++) {
 		AvailableMissiles[i] = i;
 		ActiveMissiles[i] = 0;
-	}
-	numchains = 0;
-	for (auto &link : chain) {
-		link.idx = -1;
-		link._mitype = MIS_ARROW;
-		link._mirange = 0;
 	}
 	for (int j = 0; j < MAXDUNY; j++) {
 		for (int i = 0; i < MAXDUNX; i++) { // NOLINT(modernize-loop-convert)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1267,46 +1267,46 @@ void InitMissiles()
 	}
 }
 
-void AddHiveExplosion(Missile &missile, Point /*dst*/, Direction midir)
+void AddHiveExplosion(Missile &missile, const AddMissileParameter &parameter)
 {
 	for (int x : { 80, 81 }) {
 		for (int y : { 62, 63 }) {
-			AddMissile({ x, y }, { 80, 62 }, midir, MIS_HIVEEXP, missile._micaster, missile._misource, missile._midam, 0);
+			AddMissile({ x, y }, { 80, 62 }, parameter.midir, MIS_HIVEEXP, missile._micaster, missile._misource, missile._midam, 0);
 		}
 	}
 	missile._miDelFlag = true;
 }
 
-void AddFireRune(Missile &missile, Point dst, Direction /*midir*/)
+void AddFireRune(Missile &missile, const AddMissileParameter &parameter)
 {
-	AddRune(missile, dst, MIS_HIVEEXP);
+	AddRune(missile, parameter.dst, MIS_HIVEEXP);
 }
 
-void AddLightningRune(Missile &missile, Point dst, Direction /*midir*/)
+void AddLightningRune(Missile &missile, const AddMissileParameter &parameter)
 {
 	int id = missile._misource;
 	int lvl = (id > -1) ? Players[id]._pLevel : 0;
 	int dmg = 16 * (GenerateRndSum(10, 2) + lvl + 2);
 	missile._midam = dmg;
-	AddRune(missile, dst, MIS_LIGHTWALL);
+	AddRune(missile, parameter.dst, MIS_LIGHTWALL);
 }
 
-void AddGreatLightningRune(Missile &missile, Point dst, Direction /*midir*/)
+void AddGreatLightningRune(Missile &missile, const AddMissileParameter &parameter)
 {
-	AddRune(missile, dst, MIS_NOVA);
+	AddRune(missile, parameter.dst, MIS_NOVA);
 }
 
-void AddImmolationRune(Missile &missile, Point dst, Direction /*midir*/)
+void AddImmolationRune(Missile &missile, const AddMissileParameter &parameter)
 {
-	AddRune(missile, dst, MIS_IMMOLATION);
+	AddRune(missile, parameter.dst, MIS_IMMOLATION);
 }
 
-void AddStoneRune(Missile &missile, Point dst, Direction /*midir*/)
+void AddStoneRune(Missile &missile, const AddMissileParameter &parameter)
 {
-	AddRune(missile, dst, MIS_STONE);
+	AddRune(missile, parameter.dst, MIS_STONE);
 }
 
-void AddReflection(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddReflection(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	missile._miDelFlag = true;
 
@@ -1325,7 +1325,7 @@ void AddReflection(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	UseMana(missile._misource, SPL_REFLECT);
 }
 
-void AddBerserk(Missile &missile, Point dst, Direction /*midir*/)
+void AddBerserk(Missile &missile, const AddMissileParameter &parameter)
 {
 	missile._miDelFlag = true;
 
@@ -1358,7 +1358,7 @@ void AddBerserk(Missile &missile, Point dst, Direction /*midir*/)
 
 		    return true;
 	    },
-	    dst, 0, 5);
+	    parameter.dst, 0, 5);
 
 	if (targetMonsterPosition) {
 		auto &monster = Monsters[abs(dMonster[targetMonsterPosition->x][targetMonsterPosition->y]) - 1];
@@ -1374,15 +1374,15 @@ void AddBerserk(Missile &missile, Point dst, Direction /*midir*/)
 	}
 }
 
-void AddHorkSpawn(Missile &missile, Point dst, Direction midir)
+void AddHorkSpawn(Missile &missile, const AddMissileParameter &parameter)
 {
-	UpdateMissileVelocity(missile, dst, 8);
+	UpdateMissileVelocity(missile, parameter.dst, 8);
 	missile._mirange = 9;
-	missile.var1 = static_cast<int32_t>(midir);
+	missile.var1 = static_cast<int32_t>(parameter.midir);
 	PutMissile(missile);
 }
 
-void AddJester(Missile &missile, Point dst, Direction midir)
+void AddJester(Missile &missile, const AddMissileParameter &parameter)
 {
 	missile_id spell = MIS_FIREBOLT;
 	switch (GenerateRnd(10)) {
@@ -1416,11 +1416,11 @@ void AddJester(Missile &missile, Point dst, Direction midir)
 		spell = MIS_STONE;
 		break;
 	}
-	AddMissile(missile.position.start, dst, midir, spell, missile._micaster, missile._misource, 0, missile._mispllvl);
+	AddMissile(missile.position.start, parameter.dst, parameter.midir, spell, missile._micaster, missile._misource, 0, missile._mispllvl);
 	missile._miDelFlag = true;
 }
 
-void AddStealPotions(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddStealPotions(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	for (int i = 0; i < 3; i++) {
 		int k = CrawlNum[i];
@@ -1492,7 +1492,7 @@ void AddStealPotions(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	missile._miDelFlag = true;
 }
 
-void AddManaTrap(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddManaTrap(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	std::optional<Point> trappedPlayerPosition = FindClosestValidPosition(
 	    [](Point target) {
@@ -1513,7 +1513,7 @@ void AddManaTrap(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	missile._miDelFlag = true;
 }
 
-void AddSpecArrow(Missile &missile, Point dst, Direction /*midir*/)
+void AddSpecArrow(Missile &missile, const AddMissileParameter &parameter)
 {
 	int av = 0;
 
@@ -1536,12 +1536,12 @@ void AddSpecArrow(Missile &missile, Point dst, Direction /*midir*/)
 	}
 
 	missile._mirange = 1;
-	missile.var1 = dst.x;
-	missile.var2 = dst.y;
+	missile.var1 = parameter.dst.x;
+	missile.var2 = parameter.dst.y;
 	missile.var3 = av;
 }
 
-void AddWarp(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddWarp(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	int minDistanceSq = std::numeric_limits<int>::max();
 	Point src = missile.position.start;
@@ -1573,9 +1573,9 @@ void AddWarp(Missile &missile, Point /*dst*/, Direction /*midir*/)
 		UseMana(missile._misource, SPL_WARP);
 }
 
-void AddLightningWall(Missile &missile, Point dst, Direction /*midir*/)
+void AddLightningWall(Missile &missile, const AddMissileParameter &parameter)
 {
-	UpdateMissileVelocity(missile, dst, 16);
+	UpdateMissileVelocity(missile, parameter.dst, 16);
 	missile._miAnimFrame = GenerateRnd(8) + 1;
 	missile._mirange = 255 * (missile._mispllvl + 1);
 	if (missile._misource < 0) {
@@ -1587,7 +1587,7 @@ void AddLightningWall(Missile &missile, Point dst, Direction /*midir*/)
 	}
 }
 
-void AddRuneExplosion(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddRuneExplosion(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	if (IsAnyOf(missile._micaster, TARGET_MONSTERS, TARGET_BOTH)) {
 		int dmg = 2 * (Players[missile._misource]._pLevel + GenerateRndSum(10, 2)) + 4;
@@ -1604,10 +1604,11 @@ void AddRuneExplosion(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	missile._mirange = missile._miAnimLen - 1;
 }
 
-void AddFireNova(Missile &missile, Point dst, Direction midir)
+void AddFireNova(Missile &missile, const AddMissileParameter &parameter)
 {
-	if (missile.position.start == dst) {
-		dst += midir;
+	Point dst = parameter.dst;
+	if (missile.position.start == parameter.dst) {
+		dst += parameter.midir;
 	}
 	int sp = 16;
 	if (missile._micaster == TARGET_MONSTERS) {
@@ -1619,10 +1620,11 @@ void AddFireNova(Missile &missile, Point dst, Direction midir)
 	missile._mlid = AddLight(missile.position.start, 8);
 }
 
-void AddLightningArrow(Missile &missile, Point dst, Direction midir)
+void AddLightningArrow(Missile &missile, const AddMissileParameter &parameter)
 {
-	if (missile.position.start == dst) {
-		dst += midir;
+	Point dst = parameter.dst;
+	if (missile.position.start == parameter.dst) {
+		dst += parameter.midir;
 	}
 	UpdateMissileVelocity(missile, dst, 32);
 	missile._miAnimFrame = GenerateRnd(8) + 1;
@@ -1637,7 +1639,7 @@ void AddLightningArrow(Missile &missile, Point dst, Direction midir)
 	missile._midam <<= 6;
 }
 
-void AddMana(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddMana(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	auto &player = Players[missile._misource];
 
@@ -1663,7 +1665,7 @@ void AddMana(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	drawmanaflag = true;
 }
 
-void AddMagi(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddMagi(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	auto &player = Players[missile._misource];
 
@@ -1674,7 +1676,7 @@ void AddMagi(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	drawmanaflag = true;
 }
 
-void AddRing(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddRing(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	if (missile._micaster == TARGET_MONSTERS)
 		UseMana(missile._misource, SPL_FIRERING);
@@ -1683,7 +1685,7 @@ void AddRing(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	missile._mirange = 7;
 }
 
-void AddSearch(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddSearch(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	if (missile._misource == MyPlayerId)
 		AutoMapShowItems = true;
@@ -1710,28 +1712,30 @@ void AddSearch(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	}
 }
 
-void AddCboltArrow(Missile &missile, Point dst, Direction midir)
+void AddCboltArrow(Missile &missile, const AddMissileParameter &parameter)
 {
+	Point dst = parameter.dst;
 	missile._mirnd = GenerateRnd(15) + 1;
 	if (missile._micaster != TARGET_MONSTERS) {
 		missile._midam = 15;
 	}
 
 	if (missile.position.start == dst) {
-		dst += midir;
+		dst += parameter.midir;
 	}
 	missile._miAnimFrame = GenerateRnd(8) + 1;
 	missile._mlid = AddLight(missile.position.start, 5);
 	UpdateMissileVelocity(missile, dst, 8);
 	missile.var1 = 5;
-	missile.var2 = static_cast<int32_t>(midir);
+	missile.var2 = static_cast<int32_t>(parameter.midir);
 	missile._mirange = 256;
 }
 
-void AddLArrow(Missile &missile, Point dst, Direction midir)
+void AddLArrow(Missile &missile, const AddMissileParameter &parameter)
 {
+	Point dst = parameter.dst;
 	if (missile.position.start == dst) {
-		dst += midir;
+		dst += parameter.midir;
 	}
 	int av = 32;
 	if (missile._micaster == TARGET_MONSTERS) {
@@ -1764,10 +1768,11 @@ void AddLArrow(Missile &missile, Point dst, Direction midir)
 	missile._mlid = AddLight(missile.position.start, 5);
 }
 
-void AddArrow(Missile &missile, Point dst, Direction midir)
+void AddArrow(Missile &missile, const AddMissileParameter &parameter)
 {
+	Point dst = parameter.dst;
 	if (missile.position.start == dst) {
-		dst += midir;
+		dst += parameter.midir;
 	}
 	int av = 32;
 	if (missile._micaster == TARGET_MONSTERS) {
@@ -1813,16 +1818,16 @@ void UpdateVileMissPos(Missile &missile, Point dst)
 	}
 }
 
-void AddRndTeleport(Missile &missile, Point dst, Direction /*midir*/)
+void AddRndTeleport(Missile &missile, const AddMissileParameter &parameter)
 {
 	missile._mirange = 2;
 
 	auto &player = Players[missile._misource];
 
 	if (missile._micaster == TARGET_BOTH) {
-		missile.position.tile = dst;
-		if (!PosOkPlayer(player, dst))
-			UpdateVileMissPos(missile, dst);
+		missile.position.tile = parameter.dst;
+		if (!PosOkPlayer(player, parameter.dst))
+			UpdateVileMissPos(missile, parameter.dst);
 		return;
 	}
 
@@ -1854,10 +1859,11 @@ void AddRndTeleport(Missile &missile, Point dst, Direction /*midir*/)
 		UseMana(missile._misource, SPL_RNDTELEPORT);
 }
 
-void AddFirebolt(Missile &missile, Point dst, Direction midir)
+void AddFirebolt(Missile &missile, const AddMissileParameter &parameter)
 {
+	Point dst = parameter.dst;
 	if (missile.position.start == dst) {
-		dst += midir;
+		dst += parameter.midir;
 	}
 	int sp = 26;
 	if (missile._micaster == TARGET_MONSTERS) {
@@ -1878,9 +1884,9 @@ void AddFirebolt(Missile &missile, Point dst, Direction midir)
 	missile._mlid = AddLight(missile.position.start, 8);
 }
 
-void AddMagmaball(Missile &missile, Point dst, Direction /*midir*/)
+void AddMagmaball(Missile &missile, const AddMissileParameter &parameter)
 {
-	UpdateMissileVelocity(missile, dst, 16);
+	UpdateMissileVelocity(missile, parameter.dst, 16);
 	missile.position.traveled.deltaX += 3 * missile.position.velocity.deltaX;
 	missile.position.traveled.deltaY += 3 * missile.position.velocity.deltaY;
 	UpdateMissilePos(missile);
@@ -1893,13 +1899,13 @@ void AddMagmaball(Missile &missile, Point dst, Direction /*midir*/)
 	missile._mlid = AddLight(missile.position.start, 8);
 }
 
-void AddTeleport(Missile &missile, Point dst, Direction /*midir*/)
+void AddTeleport(Missile &missile, const AddMissileParameter &parameter)
 {
 	std::optional<Point> teleportDestination = FindClosestValidPosition(
 	    [&player = Players[missile._misource]](Point target) {
 		    return PosOkPlayer(player, target);
 	    },
-	    dst, 0, 5);
+	    parameter.dst, 0, 5);
 
 	if (teleportDestination) {
 		missile.position.tile = *teleportDestination;
@@ -1911,9 +1917,9 @@ void AddTeleport(Missile &missile, Point dst, Direction /*midir*/)
 	}
 }
 
-void AddLightball(Missile &missile, Point dst, Direction /*midir*/)
+void AddLightball(Missile &missile, const AddMissileParameter &parameter)
 {
-	UpdateMissileVelocity(missile, dst, 16);
+	UpdateMissileVelocity(missile, parameter.dst, 16);
 	missile._miAnimFrame = GenerateRnd(8) + 1;
 	missile._mirange = 255;
 	const Point position { missile._misource < 0 ? missile.position.start : Players[missile._misource].position.tile };
@@ -1921,12 +1927,12 @@ void AddLightball(Missile &missile, Point dst, Direction /*midir*/)
 	missile.var2 = position.y;
 }
 
-void AddFirewall(Missile &missile, Point dst, Direction /*midir*/)
+void AddFirewall(Missile &missile, const AddMissileParameter &parameter)
 {
 	missile._midam = GenerateRndSum(10, 2) + 2;
 	missile._midam += missile._misource >= 0 ? Players[missile._misource]._pLevel : currlevel; // BUGFIX: missing parenthesis around ternary (fixed)
 	missile._midam <<= 3;
-	UpdateMissileVelocity(missile, dst, 16);
+	UpdateMissileVelocity(missile, parameter.dst, 16);
 	int i = missile._mispllvl;
 	missile._mirange = 10;
 	if (i > 0)
@@ -1939,10 +1945,11 @@ void AddFirewall(Missile &missile, Point dst, Direction /*midir*/)
 	missile.var1 = missile._mirange - missile._miAnimLen;
 }
 
-void AddFireball(Missile &missile, Point dst, Direction midir)
+void AddFireball(Missile &missile, const AddMissileParameter &parameter)
 {
+	Point dst = parameter.dst;
 	if (missile.position.start == dst) {
-		dst += midir;
+		dst += parameter.midir;
 	}
 	int sp = 16;
 	if (missile._micaster == TARGET_MONSTERS) {
@@ -1961,20 +1968,20 @@ void AddFireball(Missile &missile, Point dst, Direction midir)
 	missile._mlid = AddLight(missile.position.start, 8);
 }
 
-void AddLightctrl(Missile &missile, Point dst, Direction /*midir*/)
+void AddLightctrl(Missile &missile, const AddMissileParameter &parameter)
 {
 	if (missile._midam == 0 && missile._micaster == TARGET_MONSTERS)
 		UseMana(missile._misource, SPL_LIGHTNING);
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
-	UpdateMissileVelocity(missile, dst, 32);
+	UpdateMissileVelocity(missile, parameter.dst, 32);
 	missile._miAnimFrame = GenerateRnd(8) + 1;
 	missile._mirange = 256;
 }
 
-void AddLightning(Missile &missile, Point dst, Direction /*midir*/)
+void AddLightning(Missile &missile, const AddMissileParameter &parameter)
 {
-	missile.position.start = dst;
+	missile.position.start = parameter.dst;
 
 	missile._miAnimFrame = GenerateRnd(8) + 1;
 
@@ -1989,7 +1996,7 @@ void AddLightning(Missile &missile, Point dst, Direction /*midir*/)
 	missile._mlid = AddLight(missile.position.tile, 4);
 }
 
-void AddMisexp(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddMisexp(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	if (missile._micaster != TARGET_MONSTERS && missile._misource >= 0) {
 		switch (Monsters[missile._misource].MType->mtype) {
@@ -2020,21 +2027,21 @@ void AddMisexp(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	missile._mirange = missile._miAnimLen;
 }
 
-void AddWeapexp(Missile &missile, Point dst, Direction /*midir*/)
+void AddWeapexp(Missile &missile, const AddMissileParameter &parameter)
 {
-	missile.var2 = dst.x;
-	if (dst.x == 1)
+	missile.var2 = parameter.dst.x;
+	if (parameter.dst.x == 1)
 		SetMissAnim(missile, MFILE_MAGBLOS);
 	else
 		SetMissAnim(missile, MFILE_MINILTNG);
 	missile._mirange = missile._miAnimLen - 1;
 }
 
-void AddTown(Missile &missile, Point dst, Direction /*midir*/)
+void AddTown(Missile &missile, const AddMissileParameter &parameter)
 {
 	if (currlevel == 0) {
-		missile.position.tile = dst;
-		missile.position.start = dst;
+		missile.position.tile = parameter.dst;
+		missile.position.start = parameter.dst;
 	} else {
 		std::optional<Point> targetPosition = FindClosestValidPosition(
 		    [](Point target) {
@@ -2057,7 +2064,7 @@ void AddTown(Missile &missile, Point dst, Direction /*midir*/)
 			    }
 			    return !CheckIfTrig(target);
 		    },
-		    dst, 0, 5);
+		    parameter.dst, 0, 5);
 
 		if (targetPosition) {
 			missile.position.tile = *targetPosition;
@@ -2086,7 +2093,7 @@ void AddTown(Missile &missile, Point dst, Direction /*midir*/)
 	}
 }
 
-void AddFlash(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddFlash(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	if (missile._misource != -1) {
 		if (missile._micaster == TARGET_MONSTERS) {
@@ -2103,7 +2110,7 @@ void AddFlash(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	missile._mirange = 19;
 }
 
-void AddFlash2(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddFlash2(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	if (missile._micaster == TARGET_MONSTERS) {
 		if (missile._misource != -1) {
@@ -2119,7 +2126,7 @@ void AddFlash2(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	missile._mirange = 19;
 }
 
-void AddManashield(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddManashield(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	missile._miDelFlag = true;
 
@@ -2139,16 +2146,16 @@ void AddManashield(Missile &missile, Point /*dst*/, Direction /*midir*/)
 		UseMana(missile._misource, SPL_MANASHIELD);
 }
 
-void AddFiremove(Missile &missile, Point dst, Direction /*midir*/)
+void AddFiremove(Missile &missile, const AddMissileParameter &parameter)
 {
 	missile._midam = GenerateRnd(10) + Players[missile._misource]._pLevel + 1;
-	UpdateMissileVelocity(missile, dst, 16);
+	UpdateMissileVelocity(missile, parameter.dst, 16);
 	missile._mirange = 255;
 	missile.position.tile += Displacement { 1, 1 };
 	missile.position.offset.deltaY -= 32;
 }
 
-void AddGuardian(Missile &missile, Point dst, Direction /*midir*/)
+void AddGuardian(Missile &missile, const AddMissileParameter &parameter)
 {
 	auto &player = Players[missile._misource];
 
@@ -2177,7 +2184,7 @@ void AddGuardian(Missile &missile, Point dst, Direction /*midir*/)
 
 		    return LineClearMissile(start, target);
 	    },
-	    dst, 0, 5);
+	    parameter.dst, 0, 5);
 
 	if (!spawnPosition) {
 		missile._miDelFlag = true;
@@ -2203,10 +2210,10 @@ void AddGuardian(Missile &missile, Point dst, Direction /*midir*/)
 	missile.var3 = 1;
 }
 
-void AddChain(Missile &missile, Point dst, Direction /*midir*/)
+void AddChain(Missile &missile, const AddMissileParameter &parameter)
 {
-	missile.var1 = dst.x;
-	missile.var2 = dst.y;
+	missile.var1 = parameter.dst.x;
+	missile.var2 = parameter.dst.y;
 	missile._mirange = 1;
 	UseMana(missile._misource, SPL_CHAIN);
 }
@@ -2231,7 +2238,7 @@ void InitMissileAnimationFromMonster(Missile &mis, Direction midir, const Monste
 }
 } // namespace
 
-void AddRhino(Missile &missile, Point dst, Direction midir)
+void AddRhino(Missile &missile, const AddMissileParameter &parameter)
 {
 	auto &monster = Monsters[missile._misource];
 
@@ -2243,8 +2250,8 @@ void AddRhino(Missile &missile, Point dst, Direction midir)
 			graphic = MonsterGraphic::Attack;
 		}
 	}
-	UpdateMissileVelocity(missile, dst, 18);
-	InitMissileAnimationFromMonster(missile, midir, monster, graphic);
+	UpdateMissileVelocity(missile, parameter.dst, 18);
+	InitMissileAnimationFromMonster(missile, parameter.midir, monster, graphic);
 	if (monster.MType->mtype >= MT_NSNAKE && monster.MType->mtype <= MT_GSNAKE)
 		missile._miAnimFrame = 7;
 	if (monster._uniqtype != 0) {
@@ -2254,10 +2261,11 @@ void AddRhino(Missile &missile, Point dst, Direction midir)
 	PutMissile(missile);
 }
 
-void AddFlare(Missile &missile, Point dst, Direction midir)
+void AddFlare(Missile &missile, const AddMissileParameter &parameter)
 {
+	Point dst = parameter.dst;
 	if (missile.position.start == dst) {
-		dst += midir;
+		dst += parameter.midir;
 	}
 	UpdateMissileVelocity(missile, dst, 16);
 	missile._mirange = 256;
@@ -2284,10 +2292,10 @@ void AddFlare(Missile &missile, Point dst, Direction midir)
 	}
 }
 
-void AddAcid(Missile &missile, Point dst, Direction /*midir*/)
+void AddAcid(Missile &missile, const AddMissileParameter &parameter)
 {
-	UpdateMissileVelocity(missile, dst, 16);
-	SetMissDir(missile, GetDirection16(missile.position.start, dst));
+	UpdateMissileVelocity(missile, parameter.dst, 16);
+	SetMissDir(missile, GetDirection16(missile.position.start, parameter.dst));
 	if (!gbIsHellfire || (missile.position.velocity.deltaX & 0xFFFF0000) != 0 || (missile.position.velocity.deltaY & 0xFFFF0000) != 0)
 		missile._mirange = 5 * (Monsters[missile._misource]._mint + 4);
 	else
@@ -2298,7 +2306,7 @@ void AddAcid(Missile &missile, Point dst, Direction /*midir*/)
 	PutMissile(missile);
 }
 
-void AddAcidpud(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddAcidpud(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	missile._miLightFlag = true;
 	int monst = missile._misource;
@@ -2306,7 +2314,7 @@ void AddAcidpud(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	missile._miPreFlag = true;
 }
 
-void AddStone(Missile &missile, Point dst, Direction /*midir*/)
+void AddStone(Missile &missile, const AddMissileParameter &parameter)
 {
 	std::optional<Point> targetMonsterPosition = FindClosestValidPosition(
 	    [](Point target) {
@@ -2330,7 +2338,7 @@ void AddStone(Missile &missile, Point dst, Direction /*midir*/)
 
 		    return true;
 	    },
-	    dst, 0, 5);
+	    parameter.dst, 0, 5);
 
 	if (!targetMonsterPosition) {
 		missile._miDelFlag = true;
@@ -2356,7 +2364,7 @@ void AddStone(Missile &missile, Point dst, Direction /*midir*/)
 	UseMana(missile._misource, SPL_STONE);
 }
 
-void AddGolem(Missile &missile, Point dst, Direction /*midir*/)
+void AddGolem(Missile &missile, const AddMissileParameter &parameter)
 {
 	missile._miDelFlag = true;
 
@@ -2379,7 +2387,7 @@ void AddGolem(Missile &missile, Point dst, Direction /*midir*/)
 		    [start = missile.position.start](Point target) {
 			    return !IsTileOccupied(target) && LineClearMissile(start, target);
 		    },
-		    dst, 0, 5);
+		    parameter.dst, 0, 5);
 
 		if (spawnPosition) {
 			SpawnGolem(playerId, *spawnPosition, missile);
@@ -2387,14 +2395,14 @@ void AddGolem(Missile &missile, Point dst, Direction /*midir*/)
 	}
 }
 
-void AddBoom(Missile &missile, Point dst, Direction /*midir*/)
+void AddBoom(Missile &missile, const AddMissileParameter &parameter)
 {
-	missile.position.tile = dst;
-	missile.position.start = dst;
+	missile.position.tile = parameter.dst;
+	missile.position.start = parameter.dst;
 	missile._mirange = missile._miAnimLen;
 }
 
-void AddHeal(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddHeal(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	auto &player = Players[missile._misource];
 
@@ -2420,7 +2428,7 @@ void AddHeal(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	drawhpflag = true;
 }
 
-void AddHealOther(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddHealOther(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	missile._miDelFlag = true;
 	UseMana(missile._misource, SPL_HEALOTHER);
@@ -2431,10 +2439,11 @@ void AddHealOther(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	}
 }
 
-void AddElement(Missile &missile, Point dst, Direction midir)
+void AddElement(Missile &missile, const AddMissileParameter &parameter)
 {
+	Point dst = parameter.dst;
 	if (missile.position.start == dst) {
-		dst += midir;
+		dst += parameter.midir;
 	}
 
 	int dmg = 2 * (Players[missile._misource]._pLevel + GenerateRndSum(10, 2)) + 4;
@@ -2453,7 +2462,7 @@ void AddElement(Missile &missile, Point dst, Direction midir)
 
 extern void FocusOnInventory();
 
-void AddIdentify(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddIdentify(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	missile._miDelFlag = true;
 	UseMana(missile._misource, SPL_IDENTIFY);
@@ -2469,13 +2478,13 @@ void AddIdentify(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	}
 }
 
-void AddFirewallC(Missile &missile, Point dst, Direction midir)
+void AddFirewallC(Missile &missile, const AddMissileParameter &parameter)
 {
 	std::optional<Point> spreadPosition = FindClosestValidPosition(
 	    [start = missile.position.start](Point target) {
 		    return start != target && IsTileNotSolid(target) && !IsObjectAtPosition(target) && LineClearMissile(start, target);
 	    },
-	    dst, 0, 5);
+	    parameter.dst, 0, 5);
 
 	if (!spreadPosition) {
 		missile._miDelFlag = true;
@@ -2487,13 +2496,13 @@ void AddFirewallC(Missile &missile, Point dst, Direction midir)
 	missile.var2 = spreadPosition->y;
 	missile.var5 = spreadPosition->x;
 	missile.var6 = spreadPosition->y;
-	missile.var3 = static_cast<int>(Left(Left(midir)));
-	missile.var4 = static_cast<int>(Right(Right(midir)));
+	missile.var3 = static_cast<int>(Left(Left(parameter.midir)));
+	missile.var4 = static_cast<int>(Right(Right(parameter.midir)));
 	missile._mirange = 7;
 	UseMana(missile._misource, SPL_FIREWALL);
 }
 
-void AddInfra(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddInfra(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	missile._mirange = ScaleSpellEffect(1584, missile._mispllvl);
 	missile._mirange += missile._mirange * Players[missile._misource]._pISplDur / 128;
@@ -2502,19 +2511,19 @@ void AddInfra(Missile &missile, Point /*dst*/, Direction /*midir*/)
 		UseMana(missile._misource, SPL_INFRA);
 }
 
-void AddWave(Missile &missile, Point dst, Direction /*midir*/)
+void AddWave(Missile &missile, const AddMissileParameter &parameter)
 {
-	missile.var1 = dst.x;
-	missile.var2 = dst.y;
+	missile.var1 = parameter.dst.x;
+	missile.var2 = parameter.dst.y;
 	missile._mirange = 1;
 	missile._miAnimFrame = 4;
 	UseMana(missile._misource, SPL_WAVE);
 }
 
-void AddNova(Missile &missile, Point dst, Direction /*midir*/)
+void AddNova(Missile &missile, const AddMissileParameter &parameter)
 {
-	missile.var1 = dst.x;
-	missile.var2 = dst.y;
+	missile.var1 = parameter.dst.x;
+	missile.var2 = parameter.dst.y;
 
 	if (missile._misource != -1) {
 		int dmg = GenerateRndSum(6, 5) + Players[missile._misource]._pLevel + 5;
@@ -2529,7 +2538,7 @@ void AddNova(Missile &missile, Point dst, Direction /*midir*/)
 	missile._mirange = 1;
 }
 
-void AddBlodboil(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddBlodboil(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	auto &player = Players[missile._misource];
 
@@ -2550,7 +2559,7 @@ void AddBlodboil(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	player.Say(HeroSpeech::Aaaaargh);
 }
 
-void AddRepair(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddRepair(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	missile._miDelFlag = true;
 	UseMana(missile._misource, SPL_REPAIR);
@@ -2566,7 +2575,7 @@ void AddRepair(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	}
 }
 
-void AddRecharge(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddRecharge(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	missile._miDelFlag = true;
 	UseMana(missile._misource, SPL_RECHARGE);
@@ -2582,7 +2591,7 @@ void AddRecharge(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	}
 }
 
-void AddDisarm(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddDisarm(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	missile._miDelFlag = true;
 	UseMana(missile._misource, SPL_DISARM);
@@ -2597,7 +2606,7 @@ void AddDisarm(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	}
 }
 
-void AddApoca(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddApoca(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	missile.var1 = 8;
 	missile.var2 = std::max(missile.position.start.y - 8, 1);
@@ -2611,10 +2620,10 @@ void AddApoca(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	UseMana(missile._misource, SPL_APOCA);
 }
 
-void AddFlame(Missile &missile, Point dst, Direction /*midir*/)
+void AddFlame(Missile &missile, const AddMissileParameter &parameter)
 {
 	missile.var2 = 5 * missile._midam;
-	missile.position.start = dst;
+	missile.position.start = parameter.dst;
 
 	missile._mirange = missile.var2 + 20;
 	missile._mlid = AddLight(missile.position.start, 1);
@@ -2627,10 +2636,11 @@ void AddFlame(Missile &missile, Point dst, Direction /*midir*/)
 	}
 }
 
-void AddFlamec(Missile &missile, Point dst, Direction midir)
+void AddFlamec(Missile &missile, const AddMissileParameter &parameter)
 {
-	if (missile.position.start == dst) {
-		dst += midir;
+	Point dst = parameter.dst;
+	if (missile.position.start == parameter.dst) {
+		dst += parameter.midir;
 	}
 	UpdateMissileVelocity(missile, dst, 32);
 	if (missile._micaster == TARGET_MONSTERS) {
@@ -2641,27 +2651,29 @@ void AddFlamec(Missile &missile, Point dst, Direction midir)
 	missile._mirange = 256;
 }
 
-void AddCbolt(Missile &missile, Point dst, Direction midir)
+void AddCbolt(Missile &missile, const AddMissileParameter &parameter)
 {
+	Point dst = parameter.dst;
 	missile._mirnd = GenerateRnd(15) + 1;
 	missile._midam = (missile._micaster == TARGET_MONSTERS) ? (GenerateRnd(Players[missile._misource]._pMagic / 4) + 1) : 15;
 
 	if (missile.position.start == dst) {
-		dst += midir;
+		dst += parameter.midir;
 	}
 	missile._miAnimFrame = GenerateRnd(8) + 1;
 	missile._mlid = AddLight(missile.position.start, 5);
 
 	UpdateMissileVelocity(missile, dst, 8);
 	missile.var1 = 5;
-	missile.var2 = static_cast<int>(midir);
+	missile.var2 = static_cast<int>(parameter.midir);
 	missile._mirange = 256;
 }
 
-void AddHbolt(Missile &missile, Point dst, Direction midir)
+void AddHbolt(Missile &missile, const AddMissileParameter &parameter)
 {
+	Point dst = parameter.dst;
 	if (missile.position.start == dst) {
-		dst += midir;
+		dst += parameter.midir;
 	}
 	int sp = 16;
 	if (missile._misource != -1) {
@@ -2678,7 +2690,7 @@ void AddHbolt(Missile &missile, Point dst, Direction midir)
 	UseMana(missile._misource, SPL_HBOLT);
 }
 
-void AddResurrect(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddResurrect(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	UseMana(missile._misource, SPL_RESURRECT);
 	if (missile._misource == MyPlayerId) {
@@ -2689,14 +2701,14 @@ void AddResurrect(Missile &missile, Point /*dst*/, Direction /*midir*/)
 	missile._miDelFlag = true;
 }
 
-void AddResurrectBeam(Missile &missile, Point dst, Direction /*midir*/)
+void AddResurrectBeam(Missile &missile, const AddMissileParameter &parameter)
 {
-	missile.position.tile = dst;
-	missile.position.start = dst;
+	missile.position.tile = parameter.dst;
+	missile.position.start = parameter.dst;
 	missile._mirange = MissileSpriteData[MFILE_RESSUR1].animLen[0];
 }
 
-void AddTelekinesis(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddTelekinesis(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	missile._miDelFlag = true;
 	UseMana(missile._misource, SPL_TELEKINESIS);
@@ -2704,10 +2716,11 @@ void AddTelekinesis(Missile &missile, Point /*dst*/, Direction /*midir*/)
 		NewCursor(CURSOR_TELEKINESIS);
 }
 
-void AddBoneSpirit(Missile &missile, Point dst, Direction midir)
+void AddBoneSpirit(Missile &missile, const AddMissileParameter &parameter)
 {
-	if (missile.position.start == dst) {
-		dst += midir;
+	Point dst = parameter.dst;
+	if (missile.position.start == parameter.dst) {
+		dst += parameter.midir;
 	}
 	UpdateMissileVelocity(missile, dst, 16);
 	SetMissDir(missile, GetDirection(missile.position.start, dst));
@@ -2723,14 +2736,14 @@ void AddBoneSpirit(Missile &missile, Point dst, Direction midir)
 	}
 }
 
-void AddRportal(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddRportal(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	missile._mirange = 100;
 	missile.var1 = 100 - missile._miAnimLen;
 	PutMissile(missile);
 }
 
-void AddDiabApoca(Missile &missile, Point /*dst*/, Direction /*midir*/)
+void AddDiabApoca(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	int players = gbIsMultiplayer ? MAX_PLRS : 1;
 	for (int pnum = 0; pnum < players; pnum++) {
@@ -2783,7 +2796,8 @@ int AddMissile(Point src, Point dst, Direction midir, missile_id mitype, mienemy
 		PlaySfxLoc(missileData.mlSFX, missile.position.start);
 	}
 
-	missileData.mAddProc(missile, dst, midir);
+	AddMissileParameter parameter = { dst, midir };
+	missileData.mAddProc(missile, parameter);
 
 	return mi;
 }

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -205,6 +205,7 @@ void InitMissiles();
 struct AddMissileParameter {
 	Point dst;
 	Direction midir;
+	Missile *pParent;
 };
 
 void AddHiveExplosion(Missile &missile, const AddMissileParameter &parameter);
@@ -351,7 +352,7 @@ void AddTelekinesis(Missile &missile, const AddMissileParameter &parameter);
 void AddBoneSpirit(Missile &missile, const AddMissileParameter &parameter);
 void AddRportal(Missile &missile, const AddMissileParameter &parameter);
 void AddDiabApoca(Missile &missile, const AddMissileParameter &parameter);
-int AddMissile(Point src, Point dst, Direction midir, missile_id mitype, mienemy_type micaster, int id, int midam, int spllvl);
+int AddMissile(Point src, Point dst, Direction midir, missile_id mitype, mienemy_type micaster, int id, int midam, int spllvl, Missile *pParent = nullptr);
 void MI_Golem(Missile &missile);
 void MI_Manashield(Missile &missile);
 void MI_LArrow(Missile &missile);

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -201,41 +201,47 @@ inline void SetMissDir(Missile &missile, Direction16 dir)
 }
 
 void InitMissiles();
-void AddHiveExplosion(Missile &missile, Point dst, Direction midir);
-void AddFireRune(Missile &missile, Point dst, Direction midir);
-void AddLightningRune(Missile &missile, Point dst, Direction midir);
-void AddGreatLightningRune(Missile &missile, Point dst, Direction midir);
-void AddImmolationRune(Missile &missile, Point dst, Direction midir);
-void AddStoneRune(Missile &missile, Point dst, Direction midir);
-void AddReflection(Missile &missile, Point dst, Direction midir);
-void AddBerserk(Missile &missile, Point dst, Direction midir);
+
+struct AddMissileParameter {
+	Point dst;
+	Direction midir;
+};
+
+void AddHiveExplosion(Missile &missile, const AddMissileParameter &parameter);
+void AddFireRune(Missile &missile, const AddMissileParameter &parameter);
+void AddLightningRune(Missile &missile, const AddMissileParameter &parameter);
+void AddGreatLightningRune(Missile &missile, const AddMissileParameter &parameter);
+void AddImmolationRune(Missile &missile, const AddMissileParameter &parameter);
+void AddStoneRune(Missile &missile, const AddMissileParameter &parameter);
+void AddReflection(Missile &missile, const AddMissileParameter &parameter);
+void AddBerserk(Missile &missile, const AddMissileParameter &parameter);
 
 /**
  * var1: Direction to place the spawn
  */
-void AddHorkSpawn(Missile &missile, Point dst, Direction midir);
-void AddJester(Missile &missile, Point dst, Direction midir);
-void AddStealPotions(Missile &missile, Point dst, Direction midir);
-void AddManaTrap(Missile &missile, Point dst, Direction midir);
-void AddSpecArrow(Missile &missile, Point dst, Direction midir);
-void AddWarp(Missile &missile, Point dst, Direction midir);
-void AddLightningWall(Missile &missile, Point dst, Direction midir);
-void AddRuneExplosion(Missile &missile, Point dst, Direction midir);
-void AddFireNova(Missile &missile, Point dst, Direction midir);
-void AddLightningArrow(Missile &missile, Point dst, Direction midir);
-void AddMana(Missile &missile, Point dst, Direction midir);
-void AddMagi(Missile &missile, Point dst, Direction midir);
-void AddRing(Missile &missile, Point dst, Direction midir);
-void AddSearch(Missile &missile, Point dst, Direction midir);
-void AddCboltArrow(Missile &missile, Point dst, Direction midir);
-void AddLArrow(Missile &missile, Point dst, Direction midir);
-void AddArrow(Missile &missile, Point dst, Direction midir);
-void AddRndTeleport(Missile &missile, Point dst, Direction midir);
-void AddFirebolt(Missile &missile, Point dst, Direction midir);
-void AddMagmaball(Missile &missile, Point dst, Direction midir);
-void AddTeleport(Missile &missile, Point dst, Direction midir);
-void AddLightball(Missile &missile, Point dst, Direction midir);
-void AddFirewall(Missile &missile, Point dst, Direction midir);
+void AddHorkSpawn(Missile &missile, const AddMissileParameter &parameter);
+void AddJester(Missile &missile, const AddMissileParameter &parameter);
+void AddStealPotions(Missile &missile, const AddMissileParameter &parameter);
+void AddManaTrap(Missile &missile, const AddMissileParameter &parameter);
+void AddSpecArrow(Missile &missile, const AddMissileParameter &parameter);
+void AddWarp(Missile &missile, const AddMissileParameter &parameter);
+void AddLightningWall(Missile &missile, const AddMissileParameter &parameter);
+void AddRuneExplosion(Missile &missile, const AddMissileParameter &parameter);
+void AddFireNova(Missile &missile, const AddMissileParameter &parameter);
+void AddLightningArrow(Missile &missile, const AddMissileParameter &parameter);
+void AddMana(Missile &missile, const AddMissileParameter &parameter);
+void AddMagi(Missile &missile, const AddMissileParameter &parameter);
+void AddRing(Missile &missile, const AddMissileParameter &parameter);
+void AddSearch(Missile &missile, const AddMissileParameter &parameter);
+void AddCboltArrow(Missile &missile, const AddMissileParameter &parameter);
+void AddLArrow(Missile &missile, const AddMissileParameter &parameter);
+void AddArrow(Missile &missile, const AddMissileParameter &parameter);
+void AddRndTeleport(Missile &missile, const AddMissileParameter &parameter);
+void AddFirebolt(Missile &missile, const AddMissileParameter &parameter);
+void AddMagmaball(Missile &missile, const AddMissileParameter &parameter);
+void AddTeleport(Missile &missile, const AddMissileParameter &parameter);
+void AddLightball(Missile &missile, const AddMissileParameter &parameter);
+void AddFirewall(Missile &missile, const AddMissileParameter &parameter);
 
 /**
  * var1: X coordinate of the missile-light
@@ -243,61 +249,61 @@ void AddFirewall(Missile &missile, Point dst, Direction midir);
  * var4: X coordinate of the missile-light
  * var5: Y coordinate of the missile-light
  */
-void AddFireball(Missile &missile, Point dst, Direction midir);
+void AddFireball(Missile &missile, const AddMissileParameter &parameter);
 
 /**
  * var1: X coordinate of the missile
  * var2: Y coordinate of the missile
  */
-void AddLightctrl(Missile &missile, Point dst, Direction midir);
-void AddLightning(Missile &missile, Point dst, Direction midir);
-void AddMisexp(Missile &missile, Point dst, Direction midir);
-void AddWeapexp(Missile &missile, Point dst, Direction midir);
+void AddLightctrl(Missile &missile, const AddMissileParameter &parameter);
+void AddLightning(Missile &missile, const AddMissileParameter &parameter);
+void AddMisexp(Missile &missile, const AddMissileParameter &parameter);
+void AddWeapexp(Missile &missile, const AddMissileParameter &parameter);
 
 /**
  * var1: Animation
  */
-void AddTown(Missile &missile, Point dst, Direction midir);
-void AddFlash(Missile &missile, Point dst, Direction midir);
-void AddFlash2(Missile &missile, Point dst, Direction midir);
-void AddManashield(Missile &missile, Point dst, Direction midir);
-void AddFiremove(Missile &missile, Point dst, Direction midir);
+void AddTown(Missile &missile, const AddMissileParameter &parameter);
+void AddFlash(Missile &missile, const AddMissileParameter &parameter);
+void AddFlash2(Missile &missile, const AddMissileParameter &parameter);
+void AddManashield(Missile &missile, const AddMissileParameter &parameter);
+void AddFiremove(Missile &missile, const AddMissileParameter &parameter);
 
 /**
  * var1: Animation
  * var3: Light strength
  */
-void AddGuardian(Missile &missile, Point dst, Direction midir);
+void AddGuardian(Missile &missile, const AddMissileParameter &parameter);
 
 /**
  * var1: X coordinate of the destination
  * var2: Y coordinate of the destination
  */
-void AddChain(Missile &missile, Point dst, Direction midir);
-void AddRhino(Missile &missile, Point dst, Direction midir);
+void AddChain(Missile &missile, const AddMissileParameter &parameter);
+void AddRhino(Missile &missile, const AddMissileParameter &parameter);
 
 /**
  * var1: X coordinate of the missile-light
  * var2: Y coordinate of the missile-light
  */
-void AddFlare(Missile &missile, Point dst, Direction midir);
+void AddFlare(Missile &missile, const AddMissileParameter &parameter);
 
 /**
  * var1: X coordinate of the missile-light
  * var2: Y coordinate of the missile-light
  */
-void AddAcid(Missile &missile, Point dst, Direction midir);
-void AddAcidpud(Missile &missile, Point dst, Direction midir);
+void AddAcid(Missile &missile, const AddMissileParameter &parameter);
+void AddAcidpud(Missile &missile, const AddMissileParameter &parameter);
 
 /**
  * var1: mmode of the monster
  * var2: mnum of the monster
  */
-void AddStone(Missile &missile, Point dst, Direction midir);
-void AddGolem(Missile &missile, Point dst, Direction midir);
-void AddBoom(Missile &missile, Point dst, Direction midir);
-void AddHeal(Missile &missile, Point dst, Direction midir);
-void AddHealOther(Missile &missile, Point dst, Direction midir);
+void AddStone(Missile &missile, const AddMissileParameter &parameter);
+void AddGolem(Missile &missile, const AddMissileParameter &parameter);
+void AddBoom(Missile &missile, const AddMissileParameter &parameter);
+void AddHeal(Missile &missile, const AddMissileParameter &parameter);
+void AddHealOther(Missile &missile, const AddMissileParameter &parameter);
 
 /**
  * var1: X coordinate of the missile-light
@@ -305,8 +311,8 @@ void AddHealOther(Missile &missile, Point dst, Direction midir);
  * var4: X coordinate of the destination
  * var5: Y coordinate of the destination
  */
-void AddElement(Missile &missile, Point dst, Direction midir);
-void AddIdentify(Missile &missile, Point dst, Direction midir);
+void AddElement(Missile &missile, const AddMissileParameter &parameter);
+void AddIdentify(Missile &missile, const AddMissileParameter &parameter);
 
 /**
  * var1: X coordinate of the first wave
@@ -316,35 +322,35 @@ void AddIdentify(Missile &missile, Point dst, Direction midir);
  * var5: X coordinate of the second wave
  * var6: Y coordinate of the second wave
  */
-void AddFirewallC(Missile &missile, Point dst, Direction midir);
-void AddInfra(Missile &missile, Point dst, Direction midir);
+void AddFirewallC(Missile &missile, const AddMissileParameter &parameter);
+void AddInfra(Missile &missile, const AddMissileParameter &parameter);
 
 /**
  * var1: X coordinate of the destination
  * var2: Y coordinate of the destination
  */
-void AddWave(Missile &missile, Point dst, Direction midir);
-void AddNova(Missile &missile, Point dst, Direction midir);
-void AddBlodboil(Missile &missile, Point dst, Direction midir);
-void AddRepair(Missile &missile, Point dst, Direction midir);
-void AddRecharge(Missile &missile, Point dst, Direction midir);
-void AddDisarm(Missile &missile, Point dst, Direction midir);
-void AddApoca(Missile &missile, Point dst, Direction midir);
-void AddFlame(Missile &missile, Point dst, Direction midir);
-void AddFlamec(Missile &missile, Point dst, Direction midir);
+void AddWave(Missile &missile, const AddMissileParameter &parameter);
+void AddNova(Missile &missile, const AddMissileParameter &parameter);
+void AddBlodboil(Missile &missile, const AddMissileParameter &parameter);
+void AddRepair(Missile &missile, const AddMissileParameter &parameter);
+void AddRecharge(Missile &missile, const AddMissileParameter &parameter);
+void AddDisarm(Missile &missile, const AddMissileParameter &parameter);
+void AddApoca(Missile &missile, const AddMissileParameter &parameter);
+void AddFlame(Missile &missile, const AddMissileParameter &parameter);
+void AddFlamec(Missile &missile, const AddMissileParameter &parameter);
 
 /**
  * var1: Light strength
  * var2: Base direction
  */
-void AddCbolt(Missile &missile, Point dst, Direction midir);
-void AddHbolt(Missile &missile, Point dst, Direction midir);
-void AddResurrect(Missile &missile, Point dst, Direction midir);
-void AddResurrectBeam(Missile &missile, Point dst, Direction midir);
-void AddTelekinesis(Missile &missile, Point dst, Direction midir);
-void AddBoneSpirit(Missile &missile, Point dst, Direction midir);
-void AddRportal(Missile &missile, Point dst, Direction midir);
-void AddDiabApoca(Missile &missile, Point dst, Direction midir);
+void AddCbolt(Missile &missile, const AddMissileParameter &parameter);
+void AddHbolt(Missile &missile, const AddMissileParameter &parameter);
+void AddResurrect(Missile &missile, const AddMissileParameter &parameter);
+void AddResurrectBeam(Missile &missile, const AddMissileParameter &parameter);
+void AddTelekinesis(Missile &missile, const AddMissileParameter &parameter);
+void AddBoneSpirit(Missile &missile, const AddMissileParameter &parameter);
+void AddRportal(Missile &missile, const AddMissileParameter &parameter);
+void AddDiabApoca(Missile &missile, const AddMissileParameter &parameter);
 int AddMissile(Point src, Point dst, Direction midir, missile_id mitype, mienemy_type micaster, int id, int midam, int spllvl);
 void MI_Golem(Missile &missile);
 void MI_Manashield(Missile &missile);

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstdint>
+#include <list>
 
 #include "engine.h"
 #include "engine/point.hpp"
@@ -15,8 +16,6 @@
 #include "spelldat.h"
 
 namespace devilution {
-
-#define MAXMISSILES 125
 
 constexpr Point GolemHoldingCell = Point { 1, 0 };
 
@@ -129,10 +128,7 @@ struct Missile {
 	int16_t lastCollisionTargetHash;
 };
 
-extern Missile Missiles[MAXMISSILES];
-extern int AvailableMissiles[MAXMISSILES];
-extern int ActiveMissiles[MAXMISSILES];
-extern int ActiveMissileCount;
+extern std::list<Missile> Missiles;
 extern bool MissilePreFlag;
 
 void GetDamageAmt(int i, int *mind, int *maxd);
@@ -158,7 +154,6 @@ int GetSpellLevel(int playerId, spell_id sn);
  * @return the direction of the p1->p2 vector
  */
 Direction16 GetDirection16(Point p1, Point p2);
-void DeleteMissile(int i);
 bool MonsterTrapHit(int m, int mindam, int maxdam, int dist, missile_id t, bool shift);
 bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, missile_id mtype, bool shift, int earflag, bool *blocked);
 
@@ -346,7 +341,7 @@ void AddTelekinesis(Missile &missile, const AddMissileParameter &parameter);
 void AddBoneSpirit(Missile &missile, const AddMissileParameter &parameter);
 void AddRportal(Missile &missile, const AddMissileParameter &parameter);
 void AddDiabApoca(Missile &missile, const AddMissileParameter &parameter);
-int AddMissile(Point src, Point dst, Direction midir, missile_id mitype, mienemy_type micaster, int id, int midam, int spllvl, Missile *pParent = nullptr);
+Missile &AddMissile(Point src, Point dst, Direction midir, missile_id mitype, mienemy_type micaster, int id, int midam, int spllvl, Missile *pParent = nullptr);
 void MI_Golem(Missile &missile);
 void MI_Manashield(Missile &missile);
 void MI_LArrow(Missile &missile);

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -20,12 +20,6 @@ namespace devilution {
 
 constexpr Point GolemHoldingCell = Point { 1, 0 };
 
-struct ChainStruct {
-	int idx;
-	missile_id _mitype;
-	int _mirange;
-};
-
 struct MissilePosition {
 	Point tile;
 	/** Sprite's pixel offset from tile. */

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -2001,9 +2001,7 @@ bool IsTileSafe(const Monster &monster, Point position)
 	bool fearsFire = (monster.mMagicRes & IMMUNE_FIRE) == 0 || monster.MType->mtype == MT_DIABLO;
 	bool fearsLightning = (monster.mMagicRes & IMMUNE_LIGHTNING) == 0 || monster.MType->mtype == MT_DIABLO;
 
-	for (int j = 0; j < ActiveMissileCount; j++) {
-		uint8_t mi = ActiveMissiles[j];
-		auto &missile = Missiles[mi];
+	for (auto &missile : Missiles) {
 		if (missile.position.tile == position) {
 			if (fearsFire && missile._mitype == MIS_FIREWALL) {
 				return false;
@@ -2558,12 +2556,11 @@ void RhinoAi(int i)
 		if (dist >= 5
 		    && v < 2 * monster._mint + 43
 		    && LineClear([&monster](Point position) { return IsTileAvailable(monster, position); }, monster.position.tile, { fx, fy })) {
-			if (AddMissile(monster.position.tile, { fx, fy }, md, MIS_RHINO, TARGET_PLAYERS, i, 0, 0) != -1) {
-				if (monster.MData->snd_special)
-					PlayEffect(monster, 3);
-				dMonster[monster.position.tile.x][monster.position.tile.y] = -(i + 1);
-				monster._mmode = MonsterMode::Charge;
-			}
+			AddMissile(monster.position.tile, { fx, fy }, md, MIS_RHINO, TARGET_PLAYERS, i, 0, 0);
+			if (monster.MData->snd_special)
+				PlayEffect(monster, 3);
+			dMonster[monster.position.tile.x][monster.position.tile.y] = -(i + 1);
+			monster._mmode = MonsterMode::Charge;
 		} else {
 			if (dist >= 2) {
 				v = GenerateRnd(100);
@@ -2761,10 +2758,9 @@ void BatAi(int i)
 	    && (abs(xd) >= 5 || abs(yd) >= 5)
 	    && v < 4 * monster._mint + 33
 	    && LineClear([&monster](Point position) { return IsTileAvailable(monster, position); }, monster.position.tile, { fx, fy })) {
-		if (AddMissile(monster.position.tile, { fx, fy }, md, MIS_RHINO, TARGET_PLAYERS, i, 0, 0) != -1) {
-			dMonster[monster.position.tile.x][monster.position.tile.y] = -(i + 1);
-			monster._mmode = MonsterMode::Charge;
-		}
+		AddMissile(monster.position.tile, { fx, fy }, md, MIS_RHINO, TARGET_PLAYERS, i, 0, 0);
+		dMonster[monster.position.tile.x][monster.position.tile.y] = -(i + 1);
+		monster._mmode = MonsterMode::Charge;
 	} else if (abs(xd) >= 2 || abs(yd) >= 2) {
 		if ((monster._mVar2 > 20 && v < monster._mint + 13)
 		    || (IsAnyOf(static_cast<MonsterMode>(monster._mVar1), MonsterMode::MoveNorthwards, MonsterMode::MoveSouthwards, MonsterMode::MoveSideways)
@@ -3030,11 +3026,10 @@ void SnakeAi(int i)
 	monster._mdir = md;
 	if (abs(mx) >= 2 || abs(my) >= 2) {
 		if (abs(mx) < 3 && abs(my) < 3 && LineClear([&monster](Point position) { return IsTileAvailable(monster, position); }, monster.position.tile, { fx, fy }) && static_cast<MonsterMode>(monster._mVar1) != MonsterMode::Charge) {
-			if (AddMissile(monster.position.tile, { fx, fy }, md, MIS_RHINO, TARGET_PLAYERS, i, 0, 0) != -1) {
-				PlayEffect(monster, 0);
-				dMonster[monster.position.tile.x][monster.position.tile.y] = -(i + 1);
-				monster._mmode = MonsterMode::Charge;
-			}
+			AddMissile(monster.position.tile, { fx, fy }, md, MIS_RHINO, TARGET_PLAYERS, i, 0, 0);
+			PlayEffect(monster, 0);
+			dMonster[monster.position.tile.x][monster.position.tile.y] = -(i + 1);
+			monster._mmode = MonsterMode::Charge;
 		} else if (static_cast<MonsterMode>(monster._mVar1) == MonsterMode::Delay || GenerateRnd(100) >= 35 - 2 * monster._mint) {
 			if (pattern[monster._mgoalvar1] == -1)
 				md = Left(md);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1421,9 +1421,7 @@ DWORD OnAwakeGolem(const TCmd *pCmd, int pnum)
 			DeltaSyncGolem(message, pnum, message._currlevel);
 		} else if (pnum != MyPlayerId) {
 			// Check if this player already has an active golem
-			for (int i = 0; i < ActiveMissileCount; i++) {
-				int mi = ActiveMissiles[i];
-				auto &missile = Missiles[mi];
+			for (auto &missile : Missiles) {
 				if (missile._mitype == MIS_GOLEM && missile._misource == pnum) {
 					return sizeof(message);
 				}
@@ -1702,9 +1700,7 @@ DWORD OnActivatePortal(const TCmd *pCmd, int pnum)
 				AddInTownPortal(pnum);
 			} else if (currlevel == Players[pnum].plrlevel) {
 				bool addPortal = true;
-				for (int i = 0; i < ActiveMissileCount; i++) {
-					int mi = ActiveMissiles[i];
-					auto &missile = Missiles[mi];
+				for (auto &missile : Missiles) {
 					if (missile._mitype == MIS_TOWN && missile._misource == pnum) {
 						addPortal = false;
 						break;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3302,9 +3302,7 @@ void RemovePlrMissiles(int pnum)
 		}
 	}
 
-	for (int i = 0; i < ActiveMissileCount; i++) {
-		int am = ActiveMissiles[i];
-		auto &missile = Missiles[am];
+	for (auto &missile : Missiles) {
 		if (missile._mitype == MIS_STONE && missile._misource == pnum) {
 			Monsters[missile.var2]._mmode = static_cast<MonsterMode>(missile.var1);
 		}

--- a/Source/portal.cpp
+++ b/Source/portal.cpp
@@ -51,11 +51,7 @@ void AddWarpMissile(int i, Point position)
 {
 	MissilesData[MIS_TOWN].mlSFX = SFX_NONE;
 
-	int mi = AddMissile({ 0, 0 }, position, Direction::South, MIS_TOWN, TARGET_MONSTERS, i, 0, 0);
-	if (mi == -1)
-		return;
-
-	auto &missile = Missiles[mi];
+	auto &missile = AddMissile({ 0, 0 }, position, Direction::South, MIS_TOWN, TARGET_MONSTERS, i, 0, 0);
 	SetMissDir(missile, 1);
 
 	if (currlevel != 0)
@@ -113,18 +109,17 @@ bool PortalOnLevel(int i)
 
 void RemovePortalMissile(int id)
 {
-	for (int i = 0; i < ActiveMissileCount; i++) {
-		int mi = ActiveMissiles[i];
-		auto &missile = Missiles[mi];
+	Missiles.remove_if([id](Missile &missile) {
 		if (missile._mitype == MIS_TOWN && missile._misource == id) {
 			dFlags[missile.position.tile.x][missile.position.tile.y] &= ~DungeonFlag::Missile;
 
 			if (Portals[id].level != 0)
 				AddUnLight(missile._mlid);
 
-			DeleteMissile(i);
+			return true;
 		}
-	}
+		return false;
+	});
 }
 
 void SetCurrentPortal(int p)

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -176,9 +176,7 @@ void UpdateMissilesRendererData()
 {
 	MissilesAtRenderingTile.clear();
 
-	for (int i = 0; i < ActiveMissileCount; i++) {
-		assert(ActiveMissiles[i] < MAXMISSILES);
-		Missile &m = Missiles[ActiveMissiles[i]];
+	for (auto &m : Missiles) {
 		UpdateMissileRendererData(m);
 		MissilesAtRenderingTile.insert(std::make_pair(m.position.tileForRendering, &m));
 	}


### PR DESCRIPTION
Fixes #768

<details><summary>Example Videos</summary>

## PR

https://user-images.githubusercontent.com/25415264/149675676-175df2c0-1ab8-498a-8c4b-4cdd78f2f2ae.mp4

## Vanilla

https://user-images.githubusercontent.com/25415264/149675685-49e35c77-0ee3-451d-95a5-25603c5bb16a.mp4

</details>

Notes:
- Technically the limit is not "removed" but only enhanced from 125 to 2147483648. But for the dungeon size this is the same as unlimited? 😜 
- Change is backwards-compatible (see Example Videos). This is achieved by adding the first 125 the normal way and the rest is added to a new `addtionalMissiles` "file" in the save game. Vanilla ignores `addtionalMissiles` and only loads the first 125 missiles.
- `AddMissile` checks from 0 upwards if a missile id is free. If we think this is performance wise not a good move, please state it.
- First 3 commits are needed refactorings for this pr. If we want we can split them from this pr.
- It would be nice if this could be tested by others also. 🙂