### PR TITLE
Clean up window focus handlers

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -458,7 +458,7 @@ void UiHandleEvents(SDL_Event *event)
 		} else if (event->window.event == SDL_WINDOWEVENT_FOCUS_LOST) {
 			music_mute();
 		} else if (event->window.event == SDL_WINDOWEVENT_FOCUS_GAINED) {
-			music_unmute();
+			diablo_focus_unpause();
 		}
 	}
 #endif

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -461,6 +461,13 @@ void UiHandleEvents(SDL_Event *event)
 			diablo_focus_unpause();
 		}
 	}
+#else
+	if (event->type == SDL_ACTIVEEVENT && (event->active.state & SDL_APPINPUTFOCUS) != 0) {
+		if (event->active.gain == 0)
+			music_mute();
+		else
+			diablo_focus_unpause();
+	}
 #endif
 }
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1833,7 +1833,8 @@ bool diablo_is_focused()
 #ifndef USE_SDL1
 	return SDL_GetKeyboardFocus() == ghMainWnd;
 #else
-	return true;
+	Uint8 appState = SDL_GetAppState();
+	return (appState & SDL_APPINPUTFOCUS) != 0;
 #endif
 }
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1828,6 +1828,15 @@ void diablo_pause_game()
 bool GameWasAlreadyPaused = false;
 bool MinimizePaused = false;
 
+bool diablo_is_focused()
+{
+#ifndef USE_SDL1
+	return SDL_GetKeyboardFocus() == ghMainWnd;
+#else
+	return true;
+#endif
+}
+
 void diablo_focus_pause()
 {
 	if (!movie_playing && (gbIsMultiplayer || MinimizePaused)) {

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1848,10 +1848,6 @@ void diablo_focus_pause()
 
 void diablo_focus_unpause()
 {
-	if (gbIsMultiplayer || !MinimizePaused) {
-		return;
-	}
-
 	if (!GameWasAlreadyPaused) {
 		PauseMode = 0;
 	}

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -63,6 +63,7 @@
 #include "sound.h"
 #include "stores.h"
 #include "storm/storm_net.hpp"
+#include "storm/storm_svid.h"
 #include "themes.h"
 #include "town.h"
 #include "towners.h"
@@ -1829,7 +1830,7 @@ bool MinimizePaused = false;
 
 void diablo_focus_pause()
 {
-	if (gbIsMultiplayer || MinimizePaused) {
+	if (!movie_playing && (gbIsMultiplayer || MinimizePaused)) {
 		return;
 	}
 
@@ -1841,6 +1842,7 @@ void diablo_focus_pause()
 		LastMouseButtonAction = MouseActionType::None;
 	}
 
+	SVidMute();
 	music_mute();
 
 	MinimizePaused = true;
@@ -1852,6 +1854,7 @@ void diablo_focus_unpause()
 		PauseMode = 0;
 	}
 
+	SVidUnmute();
 	music_unmute();
 
 	MinimizePaused = false;

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -87,6 +87,7 @@ bool StartGame(bool bNewGame, bool bSinglePlayer);
 int DiabloMain(int argc, char **argv);
 bool TryIconCurs();
 void diablo_pause_game();
+bool diablo_is_focused();
 void diablo_focus_pause();
 void diablo_focus_unpause();
 bool PressEscKey();

--- a/Source/miniwin/misc_msg.cpp
+++ b/Source/miniwin/misc_msg.cpp
@@ -649,6 +649,15 @@ bool FetchMessage_Real(tagMSG *lpMsg)
 		}
 
 		break;
+#else
+	case SDL_ACTIVEEVENT:
+		if ((e.active.state & SDL_APPINPUTFOCUS) != 0) {
+			if (e.active.gain == 0)
+				diablo_focus_pause();
+			else
+				diablo_focus_unpause();
+		}
+		break;
 #endif
 	default:
 		return FalseAvail("unknown", e.type);

--- a/Source/sound.cpp
+++ b/Source/sound.cpp
@@ -301,13 +301,13 @@ int sound_get_or_set_sound_volume(int volume)
 void music_mute()
 {
 	if (music)
-		music->setVolume(VolumeLogToLinear(VOLUME_MIN, VOLUME_MIN, VOLUME_MAX));
+		music->mute();
 }
 
 void music_unmute()
 {
 	if (music)
-		music->setVolume(VolumeLogToLinear(sgOptions.Audio.nMusicVolume, VOLUME_MIN, VOLUME_MAX));
+		music->unmute();
 }
 
 } // namespace devilution

--- a/Source/sound.cpp
+++ b/Source/sound.cpp
@@ -255,6 +255,8 @@ void music_start(uint8_t nTrack)
 			}
 
 			music->setVolume(VolumeLogToLinear(sgOptions.Audio.nMusicVolume, VOLUME_MIN, VOLUME_MAX));
+			if (!diablo_is_focused())
+				music_mute();
 			if (!music->play(/*iterations=*/0)) {
 				LogError(LogCategory::Audio, "Aulib::Stream::play (from music_start): {}", SDL_GetError());
 				CleanupMusic();

--- a/Source/storm/storm_svid.cpp
+++ b/Source/storm/storm_svid.cpp
@@ -393,4 +393,20 @@ void SVidPlayEnd()
 #endif
 }
 
+void SVidMute()
+{
+#ifndef NOSOUND
+	if (SVidAudioStream)
+		SVidAudioStream->mute();
+#endif
+}
+
+void SVidUnmute()
+{
+#ifndef NOSOUND
+	if (SVidAudioStream)
+		SVidAudioStream->unmute();
+#endif
+}
+
 } // namespace devilution

--- a/Source/storm/storm_svid.cpp
+++ b/Source/storm/storm_svid.cpp
@@ -266,6 +266,8 @@ bool SVidPlayBegin(const char *filename, int flags)
 		    std::make_unique<Aulib::ResamplerSpeex>(*sgOptions.Audio.resamplingQuality), /*closeRw=*/false);
 		const float volume = static_cast<float>(sgOptions.Audio.nSoundVolume - VOLUME_MIN) / -VOLUME_MIN;
 		SVidAudioStream->setVolume(volume);
+		if (!diablo_is_focused())
+			SVidMute();
 		if (!SVidAudioStream->open()) {
 			LogError(LogCategory::Audio, "Aulib::Stream::open (from SVidPlayBegin): {}", SDL_GetError());
 			SVidAudioStream = std::nullopt;

--- a/Source/storm/storm_svid.h
+++ b/Source/storm/storm_svid.h
@@ -5,5 +5,7 @@ namespace devilution {
 bool SVidPlayBegin(const char *filename, int flags);
 bool SVidPlayContinue();
 void SVidPlayEnd();
+void SVidMute();
+void SVidUnmute();
 
 } // namespace devilution


### PR DESCRIPTION
* Mute cinematics when the window is not in focus
* Mute music/cinematic audio when menu state transitions while the window is not in focus
* Fix the error that causes multiplayer games to start paused
* Add SDL1 window focus logic

This resolves #3119