### PR TITLE
Don't sync position on dead monsters

### DIFF
--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -152,7 +152,7 @@ void SyncMonster(int pnum, const TSyncMonster &monsterSync)
 {
 	const int monsterId = monsterSync._mndx;
 	Monster &monster = Monsters[monsterId];
-	if (monster._mhitpoints <= 0) {
+	if (monster._mhitpoints <= 0 || monster._mmode == MonsterMode::Death) {
 		return;
 	}
 


### PR DESCRIPTION
From @kphoenix137 on Discord...
> I had a rogue outside diablos room, the warrior killed diablo, and all monsters died on warrior side 
> Rogue teleported in, and there were blood knights attacking the warrior

Testing reveals this is a vanilla issue, and it's caused by the `CMD_SYNCDATA` network message trying to fix positions for monsters despite them having already entered the death animation state.

I suspect this could help fix some more general desync edge cases as well, considering `M_SyncStartKill()` is already using effectively the same conditional.

https://github.com/diasurgical/devilutionX/blob/3bc2eb8471dba8693c6c7f83f83057f33ab0604e/Source/monster.cpp#L4042-L4049