### PR TITLE
Fix blinking when position desyncs during E/W movement

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -606,7 +606,8 @@ void multi_process_network_packets()
 		if (pkt->wLen != dwMsgSize)
 			continue;
 		auto &player = Players[dwID];
-		player.position.last = { pkt->px, pkt->py };
+		Point syncPosition = { pkt->px, pkt->py };
+		player.position.last = syncPosition;
 		if (dwID != MyPlayerId) {
 			assert(gbBufferMsgs != 2);
 			player._pHitPoints = pkt->php;
@@ -623,8 +624,10 @@ void multi_process_network_packets()
 						FixPlrWalkTags(dwID);
 						player.position.old = player.position.tile;
 						FixPlrWalkTags(dwID);
-						player.position.tile = { pkt->px, pkt->py };
-						player.position.future = { pkt->px, pkt->py };
+						player.position.tile = syncPosition;
+						player.position.future = syncPosition;
+						if (player.IsWalking())
+							player.position.temp = syncPosition;
 						dPlayer[player.position.tile.x][player.position.tile.y] = dwID + 1;
 					}
 					dx = abs(player.position.future.x - player.position.tile.x);
@@ -634,8 +637,8 @@ void multi_process_network_packets()
 					}
 					MakePlrPath(player, { pkt->targx, pkt->targy }, true);
 				} else {
-					player.position.tile = { pkt->px, pkt->py };
-					player.position.future = { pkt->px, pkt->py };
+					player.position.tile = syncPosition;
+					player.position.future = syncPosition;
 				}
 			}
 		}


### PR DESCRIPTION
This fixes an issue where a remote player's sprite blinks back and forth after their position desyncs during east/west movement.

---

The following video demonstrates the issue. The remote player casts Teleport in the middle of walking eastward, but the local game client doesn't see the spell because the `CMD_SPELLXY` command is received while their sprite is in-between tiles. When their position inevitably desyncs the sprite begins to blink back and forth.

https://user-images.githubusercontent.com/9203145/150460171-15171ce7-6614-4aa2-aeb8-18ef34542f6a.mp4

 ---

If a remote player's position desyncs by more than 3 tiles, `multi_process_network_packets()` will use position data from packet headers to force the player into the correct position.

https://github.com/diasurgical/devilutionX/blob/c68eeb25cc2c83a42e4168b353af6347a2472f2f/Source/multi.cpp#L622-L629

When walking east or west, `DoWalk()` will update the player's position to the tile that they are moving into.

https://github.com/diasurgical/devilutionX/blob/c68eeb25cc2c83a42e4168b353af6347a2472f2f/Source/player.cpp#L703

Because the logic that syncs the player's position wasn't updating `player.position.temp` before this change, `player.position.temp` maintained the player's old coordinates. These two lines of code ended up in conflict, constantly warping the player back and forth between the two positions.