### PR TITLE
Save options when settings change instead of at exit

### DIFF
--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -354,6 +354,9 @@ void UiSettingsMenu()
 
 		CleanUpSettingsUI();
 	} while (!backToMain);
+
+	// Save options when leaving the settings menu so that changes are persisted immediately
+	SaveOptions();
 }
 
 } // namespace devilution

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -943,10 +943,9 @@ void DiabloInit()
 
 	for (size_t i = 0; i < QUICK_MESSAGE_OPTIONS; i++) {
 		auto &messages = sgOptions.Chat.szHotKeyMsgs[i];
-		if (messages.size() > 0) {
-			continue;
+		if (messages.empty()) {
+			messages.emplace_back(_(QuickMessages[i].message));
 		}
-		messages.emplace_back(_(QuickMessages[i].message));
 	}
 
 #ifndef USE_SDL1
@@ -960,6 +959,7 @@ void DiabloInit()
 
 	if (gbIsHellfire && !forceHellfire && *sgOptions.StartUp.gameMode == StartUpGameMode::Ask) {
 		UiSelStartUpGameOption();
+		SaveOptions(); // save the selection so we don't ask again
 		if (!gbIsHellfire) {
 			// Reinitalize the UI Elements cause we changed the game
 			UnloadUiGFX();
@@ -1007,8 +1007,6 @@ void DiabloDeinit()
 {
 	FreeItemGFX();
 
-	if (sbWasOptionsLoaded && !demo::IsRunning())
-		SaveOptions();
 	if (was_snd_init)
 		effects_cleanup_sfx();
 	snd_deinit();

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -302,7 +302,6 @@ void OptionAudioChanged()
 
 /** Game options */
 Options sgOptions;
-bool sbWasOptionsLoaded = false;
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 bool HardwareCursorSupported()
@@ -352,10 +351,13 @@ void LoadOptions()
 	sgOptions.Controller.bRearTouch = GetIniBool("Controller", "Enable Rear Touchpad", true);
 #endif
 
-	if (demo::IsRunning())
+	if (demo::IsRunning()) {
 		demo::OverrideOptions();
-
-	sbWasOptionsLoaded = true;
+	} else {
+		// Immediately attempt to save new options in case the player is upgrading from an old version of DevilutionX
+		//  or if this is a first run
+		SaveOptions();
+	}
 }
 
 void SaveOptions()
@@ -411,7 +413,7 @@ OptionEntryFlags OptionEntryBase::GetFlags() const
 }
 void OptionEntryBase::SetValueChangedCallback(std::function<void()> callback)
 {
-	this->callback = callback;
+	this->callback = std::move(callback);
 }
 void OptionEntryBase::NotifyValueChanged()
 {

--- a/Source/options.h
+++ b/Source/options.h
@@ -12,7 +12,7 @@
 namespace devilution {
 
 enum class StartUpGameMode {
-	/** @brief If hellfire is present, asks the user what game he wants to start. */
+	/** @brief If hellfire is present, asks the user what game they want to start. */
 	Ask = 0,
 	Hellfire = 1,
 	Diablo = 2,
@@ -605,7 +605,6 @@ struct Options {
 };
 
 extern DVL_API_FOR_TEST Options sgOptions;
-extern bool sbWasOptionsLoaded;
 
 bool HardwareCursorSupported();
 


### PR DESCRIPTION
This allows settings to persist on systems where the game is killed by the OS instead of quitting gracefully (vita, android maybe?)

Raised by sarcastic cat in discord. This implementation mostly works but I'm sure there's improvements that can be made :D