### PR TITLE
Sync quest items in multiplayer games

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1588,12 +1588,12 @@ bool TryDropItem()
 
 	if (currlevel == 0) {
 		if (UseItemOpensHive(myPlayer.HoldItem, myPlayer.position.tile)) {
-			NetSendCmdPItem(true, CMD_PUTITEM, { 79, 61 });
+			NetSendCmdPItem(true, CMD_PUTITEM, { 79, 61 }, myPlayer.HoldItem);
 			NewCursor(CURSOR_HAND);
 			return true;
 		}
 		if (UseItemOpensCrypt(myPlayer.HoldItem, myPlayer.position.tile)) {
-			NetSendCmdPItem(true, CMD_PUTITEM, { 35, 20 });
+			NetSendCmdPItem(true, CMD_PUTITEM, { 35, 20 }, myPlayer.HoldItem);
 			NewCursor(CURSOR_HAND);
 			return true;
 		}

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -331,7 +331,7 @@ void LeftMouseDown(int wParam)
 				CheckSBook();
 			} else if (pcurs >= CURSOR_FIRSTITEM) {
 				if (TryInvPut()) {
-					NetSendCmdPItem(true, CMD_PUTITEM, cursPosition);
+					NetSendCmdPItem(true, CMD_PUTITEM, cursPosition, Players[MyPlayerId].HoldItem);
 					NewCursor(CURSOR_HAND);
 				}
 			} else {

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1870,6 +1870,11 @@ int SyncPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, i
 
 	assert(CanPut(position));
 
+	return SyncDropItem(position, idx, icreateinfo, iseed, id, dur, mdur, ch, mch, ivalue, ibuff, toHit, maxDam, minStr, minMag, minDex, ac);
+}
+
+int SyncDropItem(Point position, int idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac)
+{
 	int ii = AllocateItem();
 	auto &item = Items[ii];
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1645,7 +1645,7 @@ void InvGetItem(int pnum, int ii)
 	auto &player = Players[pnum];
 
 	if (MyPlayerId == pnum && pcurs >= CURSOR_FIRSTITEM)
-		NetSendCmdPItem(true, CMD_SYNCPUTITEM, player.position.tile);
+		NetSendCmdPItem(true, CMD_SYNCPUTITEM, player.position.tile, player.HoldItem);
 
 	item._iCreateInfo &= ~CF_PREGEN;
 	player.HoldItem = item;
@@ -1720,7 +1720,7 @@ void AutoGetItem(int pnum, Item *item, int ii)
 	}
 	player.HoldItem = *item;
 	RespawnItem(item, true);
-	NetSendCmdPItem(true, CMD_RESPAWNITEM, item->position);
+	NetSendCmdPItem(true, CMD_RESPAWNITEM, item->position, player.HoldItem);
 	player.HoldItem._itype = ItemType::None;
 }
 
@@ -2211,7 +2211,7 @@ bool DropItemBeforeTrig()
 		return false;
 	}
 
-	NetSendCmdPItem(true, CMD_PUTITEM, cursPosition);
+	NetSendCmdPItem(true, CMD_PUTITEM, cursPosition, Players[MyPlayerId].HoldItem);
 	NewCursor(CURSOR_HAND);
 	return true;
 }

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -175,6 +175,7 @@ bool CanPut(Point position);
 bool TryInvPut();
 int InvPutItem(Player &player, Point position);
 int SyncPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
+int SyncDropItem(Point position, int idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
 int8_t CheckInvHLight();
 void RemoveScroll(Player &player);
 bool UseScroll();

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3552,6 +3552,10 @@ void SpawnRewardItem(int itemid, Point position)
 	item._iSelFlag = 2;
 	item._iPostDraw = true;
 	item._iIdentified = true;
+
+	if (gbIsMultiplayer) {
+		NetSendCmdPItem(false, CMD_DROPITEM, item.position, item);
+	}
 }
 
 void SpawnMapOfDoom(Point position)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1578,7 +1578,7 @@ void SetupBaseItem(Point position, int idx, bool onlygood, bool sendmsg, bool de
 	SetupAllItems(item, idx, AdvanceRndSeed(), 2 * curlv, 1, onlygood, false, delta);
 
 	if (sendmsg)
-		NetSendCmdDItem(false, ii);
+		NetSendCmdPItem(false, CMD_DROPITEM, item.position, item);
 	if (delta)
 		DeltaAddItem(ii);
 }
@@ -2413,7 +2413,7 @@ void CreateMagicItem(Point position, int lvl, ItemType itemType, int imid, int i
 	GetSuperItemSpace(position, ii);
 
 	if (sendmsg)
-		NetSendCmdDItem(false, ii);
+		NetSendCmdPItem(false, CMD_DROPITEM, item.position, item);
 	if (delta)
 		DeltaAddItem(ii);
 }
@@ -3319,7 +3319,7 @@ void SpawnItem(Monster &monster, Point position, bool sendmsg)
 	SetupAllItems(item, idx, AdvanceRndSeed(), mLevel, uper, onlygood, false, false);
 
 	if (sendmsg)
-		NetSendCmdDItem(false, ii);
+		NetSendCmdPItem(false, CMD_DROPITEM, item.position, item);
 }
 
 void CreateRndItem(Point position, bool onlygood, bool sendmsg, bool delta)
@@ -3341,7 +3341,7 @@ void CreateRndUseful(Point position, bool sendmsg)
 
 	SetupAllUseful(item, AdvanceRndSeed(), curlv);
 	if (sendmsg)
-		NetSendCmdDItem(false, ii);
+		NetSendCmdPItem(false, CMD_DROPITEM, item.position, item);
 }
 
 void CreateTypeItem(Point position, bool onlygood, ItemType itemType, int imisc, bool sendmsg, bool delta)
@@ -4584,7 +4584,7 @@ void CreateSpellBook(Point position, spell_id ispell, bool sendmsg, bool delta)
 	GetSuperItemSpace(position, ii);
 
 	if (sendmsg)
-		NetSendCmdDItem(false, ii);
+		NetSendCmdPItem(false, CMD_DROPITEM, item.position, item);
 	if (delta)
 		DeltaAddItem(ii);
 }
@@ -4710,7 +4710,7 @@ std::string DebugSpawnItem(std::string itemName)
 	}
 
 	item._iIdentified = true;
-	NetSendCmdDItem(false, ii);
+	NetSendCmdPItem(false, CMD_DROPITEM, item.position, item);
 	return fmt::format("Item generated successfully - iterations: {:d}", i);
 }
 
@@ -4787,7 +4787,7 @@ std::string DebugSpawnUniqueItem(std::string itemName)
 	}
 
 	item._iIdentified = true;
-	NetSendCmdDItem(false, ii);
+	NetSendCmdPItem(false, CMD_DROPITEM, item.position, item);
 	return fmt::format("Item generated successfully - iterations: {:d}", i);
 }
 #endif

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2547,42 +2547,41 @@ void NetSendCmdGItem(bool bHiPri, _cmd_id bCmd, BYTE mast, BYTE pnum, BYTE ii)
 		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
 }
 
-void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position)
+void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position, const Item &item)
 {
-	TCmdPItem cmd;
+	TCmdPItem cmd {};
 
 	cmd.bCmd = bCmd;
 	cmd.x = position.x;
 	cmd.y = position.y;
-	auto &myPlayer = Players[MyPlayerId];
-	cmd.wIndx = myPlayer.HoldItem.IDidx;
+	cmd.wIndx = item.IDidx;
 
-	if (myPlayer.HoldItem.IDidx == IDI_EAR) {
-		cmd.wCI = myPlayer.HoldItem._iName[8] | (myPlayer.HoldItem._iName[7] << 8);
-		cmd.dwSeed = myPlayer.HoldItem._iName[12] | ((myPlayer.HoldItem._iName[11] | ((myPlayer.HoldItem._iName[10] | (myPlayer.HoldItem._iName[9] << 8)) << 8)) << 8);
-		cmd.bId = myPlayer.HoldItem._iName[13];
-		cmd.bDur = myPlayer.HoldItem._iName[14];
-		cmd.bMDur = myPlayer.HoldItem._iName[15];
-		cmd.bCh = myPlayer.HoldItem._iName[16];
-		cmd.bMCh = myPlayer.HoldItem._iName[17];
-		cmd.wValue = myPlayer.HoldItem._ivalue | (myPlayer.HoldItem._iName[18] << 8) | ((myPlayer.HoldItem._iCurs - ICURS_EAR_SORCERER) << 6);
-		cmd.dwBuff = myPlayer.HoldItem._iName[22] | ((myPlayer.HoldItem._iName[21] | ((myPlayer.HoldItem._iName[20] | (myPlayer.HoldItem._iName[19] << 8)) << 8)) << 8);
+	if (item.IDidx == IDI_EAR) {
+		cmd.wCI = item._iName[8] | (item._iName[7] << 8);
+		cmd.dwSeed = item._iName[12] | ((item._iName[11] | ((item._iName[10] | (item._iName[9] << 8)) << 8)) << 8);
+		cmd.bId = item._iName[13];
+		cmd.bDur = item._iName[14];
+		cmd.bMDur = item._iName[15];
+		cmd.bCh = item._iName[16];
+		cmd.bMCh = item._iName[17];
+		cmd.wValue = item._ivalue | (item._iName[18] << 8) | ((item._iCurs - ICURS_EAR_SORCERER) << 6);
+		cmd.dwBuff = item._iName[22] | ((item._iName[21] | ((item._iName[20] | (item._iName[19] << 8)) << 8)) << 8);
 	} else {
-		cmd.wCI = myPlayer.HoldItem._iCreateInfo;
-		cmd.dwSeed = myPlayer.HoldItem._iSeed;
-		cmd.bId = myPlayer.HoldItem._iIdentified ? 1 : 0;
-		cmd.bDur = myPlayer.HoldItem._iDurability;
-		cmd.bMDur = myPlayer.HoldItem._iMaxDur;
-		cmd.bCh = myPlayer.HoldItem._iCharges;
-		cmd.bMCh = myPlayer.HoldItem._iMaxCharges;
-		cmd.wValue = myPlayer.HoldItem._ivalue;
-		cmd.wToHit = myPlayer.HoldItem._iPLToHit;
-		cmd.wMaxDam = myPlayer.HoldItem._iMaxDam;
-		cmd.bMinStr = myPlayer.HoldItem._iMinStr;
-		cmd.bMinMag = myPlayer.HoldItem._iMinMag;
-		cmd.bMinDex = myPlayer.HoldItem._iMinDex;
-		cmd.bAC = myPlayer.HoldItem._iAC;
-		cmd.dwBuff = myPlayer.HoldItem.dwBuff;
+		cmd.wCI = item._iCreateInfo;
+		cmd.dwSeed = item._iSeed;
+		cmd.bId = item._iIdentified ? 1 : 0;
+		cmd.bDur = item._iDurability;
+		cmd.bMDur = item._iMaxDur;
+		cmd.bCh = item._iCharges;
+		cmd.bMCh = item._iMaxCharges;
+		cmd.wValue = item._ivalue;
+		cmd.wToHit = item._iPLToHit;
+		cmd.wMaxDam = item._iMaxDam;
+		cmd.bMinStr = item._iMinStr;
+		cmd.bMinMag = item._iMinMag;
+		cmd.bMinDex = item._iMinDex;
+		cmd.bAC = item._iAC;
+		cmd.dwBuff = item.dwBuff;
 	}
 
 	if (bHiPri)
@@ -2617,49 +2616,6 @@ void NetSendCmdDelItem(bool bHiPri, BYTE bLoc)
 
 	cmd.bLoc = bLoc;
 	cmd.bCmd = CMD_DELPLRITEMS;
-	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
-	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
-}
-
-void NetSendCmdDItem(bool bHiPri, int ii)
-{
-	TCmdPItem cmd;
-
-	cmd.bCmd = CMD_DROPITEM;
-	cmd.x = Items[ii].position.x;
-	cmd.y = Items[ii].position.y;
-	cmd.wIndx = Items[ii].IDidx;
-
-	if (Items[ii].IDidx == IDI_EAR) {
-		cmd.wCI = Items[ii]._iName[8] | (Items[ii]._iName[7] << 8);
-		cmd.dwSeed = Items[ii]._iName[12] | ((Items[ii]._iName[11] | ((Items[ii]._iName[10] | (Items[ii]._iName[9] << 8)) << 8)) << 8);
-		cmd.bId = Items[ii]._iName[13];
-		cmd.bDur = Items[ii]._iName[14];
-		cmd.bMDur = Items[ii]._iName[15];
-		cmd.bCh = Items[ii]._iName[16];
-		cmd.bMCh = Items[ii]._iName[17];
-		cmd.wValue = Items[ii]._ivalue | (Items[ii]._iName[18] << 8) | ((Items[ii]._iCurs - ICURS_EAR_SORCERER) << 6);
-		cmd.dwBuff = Items[ii]._iName[22] | ((Items[ii]._iName[21] | ((Items[ii]._iName[20] | (Items[ii]._iName[19] << 8)) << 8)) << 8);
-	} else {
-		cmd.wCI = Items[ii]._iCreateInfo;
-		cmd.dwSeed = Items[ii]._iSeed;
-		cmd.bId = Items[ii]._iIdentified ? 1 : 0;
-		cmd.bDur = Items[ii]._iDurability;
-		cmd.bMDur = Items[ii]._iMaxDur;
-		cmd.bCh = Items[ii]._iCharges;
-		cmd.bMCh = Items[ii]._iMaxCharges;
-		cmd.wValue = Items[ii]._ivalue;
-		cmd.wToHit = Items[ii]._iPLToHit;
-		cmd.wMaxDam = Items[ii]._iMaxDam;
-		cmd.bMinStr = Items[ii]._iMinStr;
-		cmd.bMinMag = Items[ii]._iMinMag;
-		cmd.bMinDex = Items[ii]._iMinDex;
-		cmd.bAC = Items[ii]._iAC;
-		cmd.dwBuff = Items[ii].dwBuff;
-	}
-
 	if (bHiPri)
 		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
 	else

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1614,10 +1614,17 @@ DWORD OnDropItem(const TCmd *pCmd, int pnum)
 {
 	const auto &message = *reinterpret_cast<const TCmdPItem *>(pCmd);
 
-	if (gbBufferMsgs == 1)
+	if (gbBufferMsgs == 1) {
 		SendPacket(pnum, &message, sizeof(message));
-	else if (IsPItemValid(message))
-		DeltaPutItem(message, { message.x, message.y }, Players[pnum].plrlevel);
+	} else if (IsPItemValid(message)) {
+		int playerLevel = Players[pnum].plrlevel;
+		Point position = { message.x, message.y };
+		if (currlevel == playerLevel && pnum != MyPlayerId) {
+			SyncDropItem(position, message.wIndx, message.wCI, message.dwSeed, message.bId, message.bDur, message.bMDur, message.bCh, message.bMCh, message.wValue, message.dwBuff, message.wToHit, message.wMaxDam, message.bMinStr, message.bMinMag, message.bMinDex, message.bAC);
+		}
+		PutItemRecord(message.dwSeed, message.wCI, message.wIndx);
+		DeltaPutItem(message, position, playerLevel);
+	}
 
 	return sizeof(message);
 }

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -782,10 +782,9 @@ void NetSendCmdParam3(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wPar
 void NetSendCmdParam4(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4);
 void NetSendCmdQuest(bool bHiPri, const Quest &quest);
 void NetSendCmdGItem(bool bHiPri, _cmd_id bCmd, BYTE mast, BYTE pnum, BYTE ii);
-void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position);
+void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position, const Item &item);
 void NetSendCmdChItem(bool bHiPri, BYTE bLoc);
 void NetSendCmdDelItem(bool bHiPri, BYTE bLoc);
-void NetSendCmdDItem(bool bHiPri, int ii);
 void NetSendCmdDamage(bool bHiPri, uint8_t bPlr, uint32_t dwDam);
 void NetSendCmdMonDmg(bool bHiPri, uint16_t wMon, uint32_t dwDam);
 void NetSendCmdString(uint32_t pmask, const char *pszStr);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -563,7 +563,7 @@ void DeadItem(Player &player, Item *itm, Displacement direction)
 	if (direction != Displacement { 0, 0 } && ItemSpaceOk(target)) {
 		RespawnDeadItem(itm, target);
 		player.HoldItem = *itm;
-		NetSendCmdPItem(false, CMD_RESPAWNITEM, target);
+		NetSendCmdPItem(false, CMD_RESPAWNITEM, target, player.HoldItem);
 		return;
 	}
 
@@ -574,7 +574,7 @@ void DeadItem(Player &player, Item *itm, Displacement direction)
 				if (ItemSpaceOk(next)) {
 					RespawnDeadItem(itm, next);
 					player.HoldItem = *itm;
-					NetSendCmdPItem(false, CMD_RESPAWNITEM, next);
+					NetSendCmdPItem(false, CMD_RESPAWNITEM, next, player.HoldItem);
 					return;
 				}
 			}


### PR DESCRIPTION
Fixes #1437

I think this is working acceptably, I was able to see quest items drop for all players in a multiplayer game no matter who triggered the item to spawn and also see the item if a player joined late. I didn't notice monster loot or chest loot getting duplicated, I was worried that might need more care to prevent. I would definitely appreciate more eyes to make sure I haven't missed anything.

Main thing was sending the DROPITEM message when quest rewards are spawned, and refactoring the Sync*Item code so it doesn't assume that a player is always dropping an item from hand.