### PR TITLE
[3DS] Use latest version of makerom

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,8 @@ jobs:
       - run: apt-get install -y ffmpeg gettext smpq
       - run: wget https://github.com/Steveice10/bannertool/releases/download/1.2.0/bannertool.zip
       - run: unzip -j "bannertool.zip" "linux-x86_64/bannertool" -d "/opt/devkitpro/tools/bin"
-      - run: wget https://github.com/jakcron/Project_CTR/releases/download/v0.16/makerom_016_ctrtool.zip
-      - run: unzip -j "makerom_016_ctrtool.zip" "Ubuntu/makerom" -d "/opt/devkitpro/tools/bin"
+      - run: wget https://github.com/3DSGuy/Project_CTR/releases/download/makerom-v0.18/makerom-v0.18-ubuntu_x86_64.zip
+      - run: unzip "makerom-v0.18-ubuntu_x86_64.zip" "makerom" -d "/opt/devkitpro/tools/bin"
       - run: sudo chmod +rx /opt/devkitpro/tools/bin/makerom
       - run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/3DS.cmake
       - run: cmake --build build -j 2


### PR DESCRIPTION
The recent CI build failure made me realize that our attempts to download makerom are being redirected because jakcron's repo for Project_CTR has been transferred to the 3DSGuy account. The issue that caused the build failure itself seems to have been transient, but I figured we may as well fix the URL and upgrade to the latest version while we're at it.