### PR TITLE
Android: Upgrade Gradle build tools

### DIFF
--- a/android-project/build.gradle
+++ b/android-project/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 		google()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:7.0.4'
+		classpath 'com.android.tools.build:gradle:7.1.0'
 
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files

--- a/android-project/gradle/wrapper/gradle-wrapper.properties
+++ b/android-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Nov 11 18:20:34 PST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
* Upgrades Gradle from 7.3 to 7.3.3. This includes patched log4j library and log4shell mitigations. [This is a recommended upgrade from Gradle team](https://docs.gradle.org/7.3.3/release-notes.html)
* Upgrades Gradle plugin to 7.1.0

Locally built and play tested, everything works