### PR TITLE
Restore default Windows audio driver (WASAPI)

### DIFF
--- a/Packaging/windows/mingw-prep.sh
+++ b/Packaging/windows/mingw-prep.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SDLDEV_VERS=2.0.18
+SDLDEV_VERS=2.0.20
 SODIUM_VERS=1.0.18
 
 # exit when any command fails

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -44,7 +44,7 @@ namespace devilution {
 #define DEFAULT_AUDIO_BUFFER_SIZE 2048
 #endif
 #ifndef DEFAULT_AUDIO_RESAMPLING_QUALITY
-#define DEFAULT_AUDIO_RESAMPLING_QUALITY 5
+#define DEFAULT_AUDIO_RESAMPLING_QUALITY 3
 #endif
 
 namespace {

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -192,12 +192,6 @@ bool SpawnWindow(const char *lpWindowName)
 	SDL_SetHint(SDL_HINT_ACCELEROMETER_AS_JOYSTICK, "0");
 #endif
 
-#if defined(_WIN32) && !defined(USE_SDL1) && !defined(__UWP__)
-	// The default WASAPI backend causes distortions
-	// https://github.com/diasurgical/devilutionX/issues/1434
-	SDL_setenv("SDL_AUDIODRIVER", "winmm", /*overwrite=*/false);
-#endif
-
 	int initFlags = SDL_INIT_VIDEO | SDL_INIT_JOYSTICK;
 #ifndef NOSOUND
 	initFlags |= SDL_INIT_AUDIO;


### PR DESCRIPTION
With the SDL 2.0.18 change to use the built-in WASAPI audio resampler (libsdl-org/SDL@ac32c52) and the recent vcpkg update to move from SDL 2.0.16 to SDL 2.0.20 (microsoft/vcpkg@9eb76eda), this seems like a pretty good time to reintroduce WASAPI.

While testing various audio settings, we found that resampling quality can have a pretty significant impact on game performance. Therefore, I'd also like to propose reducing the default resampling quality from 5 to 3 based on guidelines found in the Speex resampler documentation.

> https://speex.org/docs/manual/speex-manual/node7.html#SECTION00760000000000000000
> Usually, a quality of 3 is acceptable for most desktop uses and quality 10 is mostly recommended for pro audio work. Quality 0 usually has a decent sound (certainly better than using linear interpolation resampling), but artifacts may be heard.

See also:
#1434, #1435