### PR TITLE
Fix Hork Demon and Nakrul drops in multiplayer

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1094,7 +1094,7 @@ void SpawnLoot(Monster &monster, bool sendmsg)
 		if (sgGameInitInfo.bTheoQuest != 0) {
 			SpawnTheodore(monster.position.tile);
 		} else {
-			CreateAmulet(monster.position.tile, 13, false, true);
+			CreateAmulet(monster.position.tile, 13, sendmsg, false);
 		}
 	} else if (monster.MType->mtype == MT_HORKSPWN) {
 	} else if (monster.MType->mtype == MT_NAKRUL) {
@@ -1105,10 +1105,10 @@ void SpawnLoot(Monster &monster, bool sendmsg)
 			stream_stop();
 		Quests[Q_NAKRUL]._qlog = false;
 		UberDiabloMonsterIndex = -2;
-		CreateMagicWeapon(monster.position.tile, ItemType::Sword, ICURS_GREAT_SWORD, false, true);
-		CreateMagicWeapon(monster.position.tile, ItemType::Staff, ICURS_WAR_STAFF, false, true);
-		CreateMagicWeapon(monster.position.tile, ItemType::Bow, ICURS_LONG_WAR_BOW, false, true);
-		CreateSpellBook(monster.position.tile, SPL_APOCA, false, true);
+		CreateMagicWeapon(monster.position.tile, ItemType::Sword, ICURS_GREAT_SWORD, sendmsg, false);
+		CreateMagicWeapon(monster.position.tile, ItemType::Staff, ICURS_WAR_STAFF, sendmsg, false);
+		CreateMagicWeapon(monster.position.tile, ItemType::Bow, ICURS_LONG_WAR_BOW, sendmsg, false);
+		CreateSpellBook(monster.position.tile, SPL_APOCA, sendmsg, false);
 	} else if (monster.MType->mtype != MT_GOLEM) {
 		SpawnItem(monster, monster.position.tile, sendmsg);
 	}

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -600,6 +600,21 @@ struct TCmdPItem {
 	uint8_t bMinMag;
 	uint8_t bMinDex;
 	int16_t bAC;
+
+	/**
+	 * Items placed during dungeon generation
+	 */
+	static constexpr _cmd_id FloorItem = CMD_STAND;
+
+	/**
+	 * Floor items that have already been picked up
+	 */
+	static constexpr _cmd_id PickedUpItem = CMD_WALKXY;
+
+	/**
+	 * Items dropped by players, monsters, or objects and left on the floor of the dungeon
+	 */
+	static constexpr _cmd_id DroppedItem = CMD_ACK_PLRINFO;
 };
 
 struct TCmdChItem {

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2468,17 +2468,17 @@ void OperateSlainHero(int pnum, int i)
 	auto &player = Players[pnum];
 
 	if (player._pClass == HeroClass::Warrior) {
-		CreateMagicArmor(Objects[i].position, ItemType::HeavyArmor, ICURS_BREAST_PLATE, false, true);
+		CreateMagicArmor(Objects[i].position, ItemType::HeavyArmor, ICURS_BREAST_PLATE, true, false);
 	} else if (player._pClass == HeroClass::Rogue) {
-		CreateMagicWeapon(Objects[i].position, ItemType::Bow, ICURS_LONG_BATTLE_BOW, false, true);
+		CreateMagicWeapon(Objects[i].position, ItemType::Bow, ICURS_LONG_BATTLE_BOW, true, false);
 	} else if (player._pClass == HeroClass::Sorcerer) {
-		CreateSpellBook(Objects[i].position, SPL_LIGHTNING, false, true);
+		CreateSpellBook(Objects[i].position, SPL_LIGHTNING, true, false);
 	} else if (player._pClass == HeroClass::Monk) {
-		CreateMagicWeapon(Objects[i].position, ItemType::Staff, ICURS_WAR_STAFF, false, true);
+		CreateMagicWeapon(Objects[i].position, ItemType::Staff, ICURS_WAR_STAFF, true, false);
 	} else if (player._pClass == HeroClass::Bard) {
-		CreateMagicWeapon(Objects[i].position, ItemType::Sword, ICURS_BASTARD_SWORD, false, true);
+		CreateMagicWeapon(Objects[i].position, ItemType::Sword, ICURS_BASTARD_SWORD, true, false);
 	} else if (player._pClass == HeroClass::Barbarian) {
-		CreateMagicWeapon(Objects[i].position, ItemType::Axe, ICURS_BATTLE_AXE, false, true);
+		CreateMagicWeapon(Objects[i].position, ItemType::Axe, ICURS_BATTLE_AXE, true, false);
 	}
 	Players[MyPlayerId].Say(HeroSpeech::RestInPeaceMyFriend);
 	if (pnum == MyPlayerId)

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -728,7 +728,7 @@ void TalkToGirl(Player &player, Towner &girl)
 
 	if (quest._qactive != QUEST_DONE && player.TryRemoveInvItemById(IDI_THEODORE)) {
 		InitQTextMsg(TEXT_GIRL4);
-		CreateAmulet(girl.position, 13, false, true);
+		CreateAmulet(girl.position, 13, true, false);
 		quest._qlog = false;
 		quest._qactive = QUEST_DONE;
 		auto curFrame = girl._tAnimFrame;


### PR DESCRIPTION
This fixes an issue where the items dropped by Hork Demon and Nakrul will disappear from the floor if you exit the dungeon level without picking them up.

---

There are some really unintuitive things going on here so strap in while I try to explain them.

### Item deltas

There are three functions the game uses to manipulate item deltas.

* `DeltaAddItem()` is called when an item is placed on the floor by dungeon generation (aka "floor items")
* `DeltaPutItem()` is called when players drop items on the dungeon floor or when spawning loot from monsters or chests
* `DeltaGetItem()` is called when players pick up items from the dungeon floor

The intent here is to reconstruct level state when "warping" via stairs or portals. The dungeon gets regenerated from its seed, and then `DeltaLoadLevel()` uses the level deltas--which includes monster deltas, item deltas, and object deltas--to determine what's changed since initial generation. In the case of items, it will be necessary to know two things.

* Which floor items have already been picked up by players
* What items are on the floor that were not originally placed by dungeon generation

In addition to tracking these two pieces of information, item deltas also superfluously track all items which were originally placed by dungeon generation but were not already picked up by players. Presumably, this is done to detect errors or duplicates.

The game uses the `bCmd` parameter to indicate which of the three pieces of information is being tracked by each delta. This is extremely unintuitive because the `_cmd_id` enum is meant to represent something else entirely. To make this a bit more intuitive, I added aliases for the relevant enum values in the `TCmdPItem` struct.

### Slain Hero, Hork Demon, and Nakrul

The Slain Hero quest uses a special set of functions to generate specific types of items based on the player character's class. It seems the Hellfire devs reused these functions (and introduced one of their own) for Hork Demon and Nakrul so they could control the types of items that spawn from those two monsters. These functions each include a `sendmsg` argument and a `delta` argument that ultimately determine how the newly generated items will interact with the collection of item deltas.

The `sendmsg` flag indicates whether the `CMD_DROPITEM` command should be sent over the network when the item is generated. This network command triggers `OnDropItem()` when the command is processed which eventually calls `DeltaPutItem()` to add the item to the deltas. `DeltaPutItem()` sets the `bCmd` parameter of the item delta to `CMD_ACK_PLRINFO` to indicate that this represents an item that was not originally placed by dungeon generation.

The `delta` flag determines whether `DeltaAddItem()` gets called during item generation to add the item to the deltas. `DeltaAddItem()` sets the `bCmd` parameter of the item delta to `CMD_STAND` to indicate that this represents a floor item that was placed by dungeon generation.

Every call made to these functions was using `sendmsg=false` and `delta=true` indicating that all these items are floor items that were generated by the dungeon. Because `CMD_STAND` is meant to represent items that are placed by dungeon generation, `DeltaLoadLevel()` naturally ignores those deltas. This explains why those items disappear when warping. Ultimately, changing the value of the `sendmsg` and `delta` arguments in those function calls is the piece that resolves the error.

### SpawnLoot()

The `SpawnLoot()` function handles normal loot drops with special cases for Gharbad, Hork Demon, and Nakrul. The peculiar thing is how it handles the aforementioned `sendmsg` argument. It seems reasonable to assume that all spawned loot is, by definition, not a floor item generated by the dungeon and should therefore be synced with other clients via the `CMD_DROPITEM` network command. Instead, it receives its `sendmsg` value from `StartMonsterDeath()` which in turn receives it from `M_StartKill()` and `M_SyncStartKill()`.

`M_StartKill()` runs when a monster's HP is reduced to 0 on the local client and always passes `true` for `sendmsg`. `M_SyncStartKill()` runs when processing the `CMD_MONSTDEATH` command, takes no action if the monster was already reduced to 0 HP, and always passes `false` for `sendmsg`. I'm not entirely sure how to make sense of this logic. If the assumption is that `M_SyncStartKill()` will only spawn loot in response to a remote client's `M_StartKill()` and that the remote client will therefore spawn the loot and send the `CMD_DROPITEM` command, then it seems to me it would make more sense to simply wait for the `CMD_DROPITEM` command instead of having `M_SyncStartKill()` spawn desynced loot.

At this point, I decided this train of thought was taking me down a mostly irrelevant rabbit hole. Since I couldn't find any reason why Hork Demon or Nakrul should differ from normal loot drops in this respect, I decided it was okay to go ahead and use the same `sendmsg` value in all three places.

### Single Player vs Multiplayer

Single Player doesn't use deltas. Instead, level state is serialized in its entirety in the savegame, and all logic that would update or use deltas is skipped when playing Single Player. Therefore, this issue only affects multiplayer and doesn't really affect Slain Hero at all. I changed the flags in those function calls merely to maintain conceptual integrity.