### PR TITLE
Fix dungeon reroll - Initialize special Room coordinates

### DIFF
--- a/Source/drlg_l2.cpp
+++ b/Source/drlg_l2.cpp
@@ -2899,6 +2899,10 @@ void GenerateLevel(lvl_entry entry)
 	bool doneflag = false;
 	while (!doneflag) {
 		nRoomCnt = 0;
+		nSx1 = 0;
+		nSy1 = 0;
+		nSx2 = 0;
+		nSy2 = 0;
 		InitDungeonFlags();
 		DRLG_InitTrans();
 		if (!CreateDungeon()) {


### PR DESCRIPTION
Fixes #1506

`CreateRoom` [remembers](https://github.com/diasurgical/devilutionX/blob/2d6c602ef54cd84b6287a3b8af16bfc40183c761/Source/drlg_l2.cpp#L1990-L1995) the room coordinates in some variables.
This only happens if the room is [reserved for a quest](https://github.com/diasurgical/devilutionX/blob/2d6c602ef54cd84b6287a3b8af16bfc40183c761/Source/drlg_l2.cpp#L2688-L2714).
It doesn't happen if the level has no active quest.

The problem is that these variables are never reset when generating the level. They only get set when space is reserved for a quest set piece.
in issue #1506 Arkaine's Valor is not available, so level 5 has no quest set piece.
But level 6 has a quest room for Chamber of Bone.
That means level 6 sets these variables and when loading level 5 again you get another generated level, cause (in this case) [PlaceMiniSet](https://github.com/diasurgical/devilutionX/blob/2d6c602ef54cd84b6287a3b8af16bfc40183c761/Source/drlg_l2.cpp#L1698-L17009) behaves different when these variables are set.
That's also explains why the layout is also rerolled when you load the game again. But if you restart the game everything is fine (variables aren't set).

Side-note: When randomize quests is disabled this only happens on level 8, cause all other levels have a quest set pieces (zhar gets place in a normal theme room).