### PR TITLE
Clean up owned/unowned CelSprite ambiguity

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -121,11 +121,11 @@ namespace {
 
 std::optional<OwnedSurface> pLifeBuff;
 std::optional<OwnedSurface> pManaBuff;
-std::optional<CelSprite> talkButtons;
-std::optional<CelSprite> pDurIcons;
-std::optional<CelSprite> multiButtons;
-std::optional<CelSprite> pPanelButtons;
-std::optional<CelSprite> pGBoxBuff;
+std::optional<OwnedCelSprite> talkButtons;
+std::optional<OwnedCelSprite> pDurIcons;
+std::optional<OwnedCelSprite> multiButtons;
+std::optional<OwnedCelSprite> pPanelButtons;
+std::optional<OwnedCelSprite> pGBoxBuff;
 
 bool PanelButtons[8];
 int PanelButtonIndex;
@@ -517,7 +517,7 @@ void InitControlPan()
 	CelDrawUnsafeTo(*pBtmBuff, { 0, (PANEL_HEIGHT + 16) - 1 }, LoadCel("CtrlPan\\Panel8.CEL", PANEL_WIDTH), 1);
 	{
 		const Point bulbsPosition { 0, 87 };
-		const CelSprite statusPanel = LoadCel("CtrlPan\\P8Bulbs.CEL", 88);
+		const OwnedCelSprite statusPanel = LoadCel("CtrlPan\\P8Bulbs.CEL", 88);
 		CelDrawUnsafeTo(*pLifeBuff, bulbsPosition, statusPanel, 1);
 		CelDrawUnsafeTo(*pManaBuff, bulbsPosition, statusPanel, 2);
 	}

--- a/Source/controls/modifier_hints.cpp
+++ b/Source/controls/modifier_hints.cpp
@@ -14,7 +14,7 @@
 
 namespace devilution {
 
-extern std::optional<CelSprite> pSBkIconCels;
+extern std::optional<OwnedCelSprite> pSBkIconCels;
 
 namespace {
 

--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -139,7 +139,7 @@ void LoadPotionArt(Art *potionArt, SDL_Renderer *renderer)
 	Point position { 0, 0 };
 	for (item_cursor_graphic graphic : potionGraphics) {
 		const int frame = CURSOR_FIRSTITEM + graphic;
-		const CelSprite &potionSprite = GetInvItemSprite(frame);
+		const OwnedCelSprite &potionSprite = GetInvItemSprite(frame);
 		position.y += potionSize.height;
 		CelClippedDrawTo(Surface(surface.get()), position, potionSprite, frame);
 	}

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -29,10 +29,10 @@ namespace {
 /** Cursor images CEL */
 std::optional<OwnedCelSprite> pCursCels;
 std::optional<OwnedCelSprite> pCursCels2;
-constexpr int InvItems1Size = 180;
+constexpr uint16_t InvItems1Size = 180;
 
 /** Maps from objcurs.cel frame number to frame width. */
-const int InvItemWidth1[] = {
+const uint16_t InvItemWidth1[] = {
 	// clang-format off
 	// Cursors
 	0, 33, 32, 32, 32, 32, 32, 32, 32, 32, 32, 23,
@@ -55,7 +55,7 @@ const int InvItemWidth1[] = {
 	2 * 28, 2 * 28, 2 * 28, 2 * 28, 2 * 28, 2 * 28, 2 * 28, 2 * 28, 2 * 28, 2 * 28,
 	2 * 28, 2 * 28, 2 * 28, 2 * 28, 2 * 28, 2 * 28, 2 * 28, 2 * 28,
 };
-const int InvItemWidth2[] = {
+const uint16_t InvItemWidth2[] = {
 	0,
 	1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28,
 	1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28,
@@ -67,7 +67,7 @@ const int InvItemWidth2[] = {
 };
 
 /** Maps from objcurs.cel frame number to frame height. */
-const int InvItemHeight1[] = {
+const uint16_t InvItemHeight1[] = {
 	// clang-format off
 	// Cursors
 	0, 29, 32, 32, 32, 32, 32, 32, 32, 32, 32, 35,
@@ -90,7 +90,7 @@ const int InvItemHeight1[] = {
 	3 * 28, 3 * 28, 3 * 28, 3 * 28, 3 * 28, 3 * 28, 3 * 28, 3 * 28, 3 * 28, 3 * 28,
 	3 * 28, 3 * 28, 3 * 28, 3 * 28, 3 * 28, 3 * 28, 3 * 28, 3 * 28,
 };
-const int InvItemHeight2[] = {
+const uint16_t InvItemHeight2[] = {
 	0,
 	1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28,
 	1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28, 1 * 28,

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -27,8 +27,8 @@
 namespace devilution {
 namespace {
 /** Cursor images CEL */
-std::optional<CelSprite> pCursCels;
-std::optional<CelSprite> pCursCels2;
+std::optional<OwnedCelSprite> pCursCels;
+std::optional<OwnedCelSprite> pCursCels2;
 constexpr int InvItems1Size = 180;
 
 /** Maps from objcurs.cel frame number to frame width. */
@@ -143,7 +143,7 @@ void FreeCursor()
 	ClearCursor();
 }
 
-const CelSprite &GetInvItemSprite(int i)
+const OwnedCelSprite &GetInvItemSprite(int i)
 {
 	return i < InvItems1Size ? *pCursCels : *pCursCels2;
 }

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -61,7 +61,7 @@ inline bool IsItemSprite(int cursId)
 void CelDrawCursor(const Surface &out, Point position, int cursId);
 
 /** Returns the sprite for the given inventory index. */
-const CelSprite &GetInvItemSprite(int i);
+const OwnedCelSprite &GetInvItemSprite(int i);
 
 /** Returns the CEL frame index for the given inventory index. */
 int GetInvItemFrame(int i);

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -18,12 +18,10 @@ int8_t stonendx;
 namespace {
 void InitDeadAnimationFromMonster(Corpse &corpse, const CMonster &mon)
 {
-	int i = 0;
 	const auto &animData = mon.GetAnimData(MonsterGraphic::Death);
-	for (const auto &celSprite : animData.CelSpritesForDirections)
-		corpse.data[i++] = celSprite->Data();
+	memcpy(&corpse.data[0], &animData.CelSpritesForDirections[0], sizeof(animData.CelSpritesForDirections[0]) * animData.CelSpritesForDirections.size());
 	corpse.frame = animData.Frames;
-	corpse.width = animData.CelSpritesForDirections[0]->Width();
+	corpse.width = animData.Width;
 }
 } // namespace
 

--- a/Source/dead.h
+++ b/Source/dead.h
@@ -18,7 +18,7 @@ static constexpr unsigned MaxCorpses = 31;
 struct Corpse {
 	std::array<const byte *, 8> data;
 	int frame;
-	int width;
+	unsigned width;
 	uint8_t translationPaletteIndex;
 };
 

--- a/Source/dead.h
+++ b/Source/dead.h
@@ -18,7 +18,7 @@ static constexpr unsigned MaxCorpses = 31;
 struct Corpse {
 	std::array<const byte *, 8> data;
 	int frame;
-	unsigned width;
+	uint16_t width;
 	uint8_t translationPaletteIndex;
 };
 

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -32,7 +32,7 @@
 
 namespace devilution {
 
-std::optional<CelSprite> pSquareCel;
+std::optional<OwnedCelSprite> pSquareCel;
 bool DebugToggle = false;
 bool DebugGodMode = false;
 bool DebugVision = false;

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -15,7 +15,7 @@
 
 namespace devilution {
 
-extern std::optional<CelSprite> pSquareCel;
+extern std::optional<OwnedCelSprite> pSquareCel;
 extern bool DebugToggle;
 extern bool DebugGodMode;
 extern bool DebugVision;

--- a/Source/doom.cpp
+++ b/Source/doom.cpp
@@ -14,7 +14,7 @@
 
 namespace devilution {
 namespace {
-std::optional<CelSprite> DoomCel;
+std::optional<OwnedCelSprite> DoomCel;
 } // namespace
 
 bool DoomFlag;

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -75,7 +75,7 @@ float AnimationInfo::GetAnimationProgress() const
 	return animationFraction;
 }
 
-void AnimationInfo::SetNewAnimation(const CelSprite *celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/, float previewShownGameTickFragments /*= 0.F*/)
+void AnimationInfo::SetNewAnimation(std::optional<CelSprite> celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/, float previewShownGameTickFragments /*= 0.F*/)
 {
 	if ((flags & AnimationDistributionFlags::RepeatedAction) == AnimationDistributionFlags::RepeatedAction && distributeFramesBeforeFrame != 0 && NumberOfFrames == numberOfFrames && CurrentFrame >= distributeFramesBeforeFrame && CurrentFrame != NumberOfFrames) {
 		// We showed the same Animation (for example a melee attack) before but truncated the Animation.
@@ -90,7 +90,7 @@ void AnimationInfo::SetNewAnimation(const CelSprite *celSprite, int numberOfFram
 		ticksPerFrame = 1;
 	}
 
-	this->pCelSprite = celSprite;
+	this->celSprite = celSprite;
 	NumberOfFrames = numberOfFrames;
 	CurrentFrame = 1 + numSkippedFrames;
 	TickCounterOfCurrentFrame = 0;
@@ -168,7 +168,7 @@ void AnimationInfo::SetNewAnimation(const CelSprite *celSprite, int numberOfFram
 	}
 }
 
-void AnimationInfo::ChangeAnimationData(const CelSprite *celSprite, int numberOfFrames, int ticksPerFrame)
+void AnimationInfo::ChangeAnimationData(std::optional<CelSprite> celSprite, int numberOfFrames, int ticksPerFrame)
 {
 	if (numberOfFrames != NumberOfFrames || ticksPerFrame != TicksPerFrame) {
 		// Ensure that the CurrentFrame is still valid and that we disable ADL cause the calculcated values (for example TickModifier) could be wrong
@@ -183,7 +183,7 @@ void AnimationInfo::ChangeAnimationData(const CelSprite *celSprite, int numberOf
 		RelevantFramesForDistributing = 0;
 		TickModifier = 0.0F;
 	}
-	this->pCelSprite = celSprite;
+	this->celSprite = celSprite;
 }
 
 void AnimationInfo::ProcessAnimation(bool reverseAnimation /*= false*/, bool dontProgressAnimation /*= false*/)

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -5,10 +5,11 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <type_traits>
 
 #include "engine/cel_sprite.hpp"
+#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 
@@ -37,9 +38,9 @@ enum AnimationDistributionFlags : uint8_t {
 class AnimationInfo {
 public:
 	/**
-	 * @brief Pointer to Animation Sprite
+	 * @brief Animation sprite
 	 */
-	const CelSprite *pCelSprite;
+	std::optional<CelSprite> celSprite;
 	/**
 	 * @brief How many game ticks are needed to advance one Animation Frame
 	 */
@@ -82,7 +83,7 @@ public:
 	 * @param distributeFramesBeforeFrame Distribute the numSkippedFrames only before this frame
 	 * @param previewShownGameTickFragments Defines how long (in game ticks fraction) the preview animation was shown
 	 */
-	void SetNewAnimation(const CelSprite *celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0, float previewShownGameTickFragments = 0.F);
+	void SetNewAnimation(std::optional<CelSprite> celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0, float previewShownGameTickFragments = 0.F);
 
 	/**
 	 * @brief Changes the Animation Data on-the-fly. This is needed if a animation is currently in progress and the player changes his gear.
@@ -90,7 +91,7 @@ public:
 	 * @param numberOfFrames Number of Frames in Animation
 	 * @param ticksPerFrame How many game ticks are needed to advance one Animation Frame
 	 */
-	void ChangeAnimationData(const CelSprite *celSprite, int numberOfFrames, int ticksPerFrame);
+	void ChangeAnimationData(std::optional<CelSprite> celSprite, int numberOfFrames, int ticksPerFrame);
 
 	/**
 	 * @brief Process the Animation for a game tick (for example advances the frame)

--- a/Source/engine/cel_sprite.hpp
+++ b/Source/engine/cel_sprite.hpp
@@ -7,39 +7,31 @@
 
 namespace devilution {
 
+class OwnedCelSprite;
+
 /**
  * Stores a CEL or CL2 sprite and its width(s).
- *
- * The data may be unowned.
- * Eventually we'd like to remove the unowned version.
+ * Does not own the data.
  */
 class CelSprite {
 public:
-	CelSprite(std::unique_ptr<byte[]> data, int width)
-	    : data_(std::move(data))
-	    , data_ptr_(data_.get())
-	    , width_(width)
-	{
-	}
-
-	CelSprite(std::unique_ptr<byte[]> data, const int *widths)
-	    : data_(std::move(data))
-	    , data_ptr_(data_.get())
-	    , widths_(widths)
-	{
-	}
-
-	/**
-	 * Constructs an unowned sprite.
-	 * Ideally we'd like to remove all uses of this constructor.
-	 */
 	CelSprite(const byte *data, int width)
 	    : data_ptr_(data)
 	    , width_(width)
 	{
 	}
 
+	CelSprite(const byte *data, const int *widths)
+	    : data_ptr_(data)
+	    , widths_(widths)
+	{
+	}
+
+	explicit CelSprite(const OwnedCelSprite &owned);
+
+	CelSprite(const CelSprite &) = default;
 	CelSprite(CelSprite &&) noexcept = default;
+	CelSprite &operator=(const CelSprite &) = default;
 	CelSprite &operator=(CelSprite &&) noexcept = default;
 
 	[[nodiscard]] const byte *Data() const
@@ -52,11 +44,54 @@ public:
 		return widths_ == nullptr ? width_ : widths_[frame];
 	}
 
+	[[nodiscard]] bool operator==(CelSprite other) const
+	{
+		return data_ptr_ == other.data_ptr_;
+	}
+	[[nodiscard]] bool operator!=(CelSprite other) const
+	{
+		return data_ptr_ != other.data_ptr_;
+	}
+
 private:
-	std::unique_ptr<byte[]> data_;
 	const byte *data_ptr_;
 	int width_ = 0;
 	const int *widths_ = nullptr; // unowned
 };
+
+/**
+ * Stores a CEL or CL2 sprite and its width(s).
+ * Owns the data.
+ */
+class OwnedCelSprite : public CelSprite {
+public:
+	OwnedCelSprite(std::unique_ptr<byte[]> data, int width)
+	    : CelSprite(data.get(), width)
+	    , data_(std::move(data))
+	{
+	}
+
+	OwnedCelSprite(std::unique_ptr<byte[]> data, const int *widths)
+	    : CelSprite(data.get(), widths)
+	    , data_(std::move(data))
+	{
+	}
+
+	OwnedCelSprite(OwnedCelSprite &&) noexcept = default;
+	OwnedCelSprite &operator=(OwnedCelSprite &&) noexcept = default;
+
+	[[nodiscard]] CelSprite Unowned() const
+	{
+		return CelSprite(*this);
+	}
+
+private:
+	std::unique_ptr<byte[]> data_;
+};
+
+inline CelSprite::CelSprite(const OwnedCelSprite &owned)
+    : CelSprite(static_cast<const CelSprite &>(owned))
+{
+}
 
 } // namespace devilution

--- a/Source/engine/cel_sprite.hpp
+++ b/Source/engine/cel_sprite.hpp
@@ -15,13 +15,13 @@ class OwnedCelSprite;
  */
 class CelSprite {
 public:
-	CelSprite(const byte *data, int width)
+	CelSprite(const byte *data, uint16_t width)
 	    : data_ptr_(data)
 	    , width_(width)
 	{
 	}
 
-	CelSprite(const byte *data, const int *widths)
+	CelSprite(const byte *data, const uint16_t *widths)
 	    : data_ptr_(data)
 	    , widths_(widths)
 	{
@@ -39,7 +39,7 @@ public:
 		return data_ptr_;
 	}
 
-	[[nodiscard]] int Width(std::size_t frame = 1) const
+	[[nodiscard]] uint16_t Width(std::size_t frame = 1) const
 	{
 		return widths_ == nullptr ? width_ : widths_[frame];
 	}
@@ -55,8 +55,8 @@ public:
 
 private:
 	const byte *data_ptr_;
-	int width_ = 0;
-	const int *widths_ = nullptr; // unowned
+	uint16_t width_ = 0;
+	const uint16_t *widths_ = nullptr; // unowned
 };
 
 /**
@@ -65,13 +65,13 @@ private:
  */
 class OwnedCelSprite : public CelSprite {
 public:
-	OwnedCelSprite(std::unique_ptr<byte[]> data, int width)
+	OwnedCelSprite(std::unique_ptr<byte[]> data, uint16_t width)
 	    : CelSprite(data.get(), width)
 	    , data_(std::move(data))
 	{
 	}
 
-	OwnedCelSprite(std::unique_ptr<byte[]> data, const int *widths)
+	OwnedCelSprite(std::unique_ptr<byte[]> data, const uint16_t *widths)
 	    : CelSprite(data.get(), widths)
 	    , data_(std::move(data))
 	{

--- a/Source/engine/load_cel.cpp
+++ b/Source/engine/load_cel.cpp
@@ -4,12 +4,12 @@
 
 namespace devilution {
 
-OwnedCelSprite LoadCel(const char *pszName, int width)
+OwnedCelSprite LoadCel(const char *pszName, uint16_t width)
 {
 	return OwnedCelSprite(LoadFileInMem(pszName), width);
 }
 
-OwnedCelSprite LoadCel(const char *pszName, const int *widths)
+OwnedCelSprite LoadCel(const char *pszName, const uint16_t *widths)
 {
 	return OwnedCelSprite(LoadFileInMem(pszName), widths);
 }

--- a/Source/engine/load_cel.cpp
+++ b/Source/engine/load_cel.cpp
@@ -4,14 +4,14 @@
 
 namespace devilution {
 
-CelSprite LoadCel(const char *pszName, int width)
+OwnedCelSprite LoadCel(const char *pszName, int width)
 {
-	return CelSprite(LoadFileInMem(pszName), width);
+	return OwnedCelSprite(LoadFileInMem(pszName), width);
 }
 
-CelSprite LoadCel(const char *pszName, const int *widths)
+OwnedCelSprite LoadCel(const char *pszName, const int *widths)
 {
-	return CelSprite(LoadFileInMem(pszName), widths);
+	return OwnedCelSprite(LoadFileInMem(pszName), widths);
 }
 
 } // namespace devilution

--- a/Source/engine/load_cel.hpp
+++ b/Source/engine/load_cel.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "engine/cel_sprite.hpp"
 
 namespace devilution {
@@ -7,7 +9,7 @@ namespace devilution {
 /**
  * @brief Loads a Cel sprite and sets its width
  */
-OwnedCelSprite LoadCel(const char *pszName, int width);
-OwnedCelSprite LoadCel(const char *pszName, const int *widths);
+OwnedCelSprite LoadCel(const char *pszName, uint16_t width);
+OwnedCelSprite LoadCel(const char *pszName, const uint16_t *widths);
 
 } // namespace devilution

--- a/Source/engine/load_cel.hpp
+++ b/Source/engine/load_cel.hpp
@@ -7,7 +7,7 @@ namespace devilution {
 /**
  * @brief Loads a Cel sprite and sets its width
  */
-CelSprite LoadCel(const char *pszName, int width);
-CelSprite LoadCel(const char *pszName, const int *widths);
+OwnedCelSprite LoadCel(const char *pszName, int width);
+OwnedCelSprite LoadCel(const char *pszName, const int *widths);
 
 } // namespace devilution

--- a/Source/engine/render/cel_render.cpp
+++ b/Source/engine/render/cel_render.cpp
@@ -580,14 +580,14 @@ void CelBlitLightSafeTo(const Surface &out, Point position, const byte *pRLEByte
 
 } // namespace
 
-void CelDrawTo(const Surface &out, Point position, const CelSprite &cel, int frame)
+void CelDrawTo(const Surface &out, Point position, CelSprite cel, int frame)
 {
 	int nDataSize;
 	const auto *pRLEBytes = CelGetFrame(cel.Data(), frame, &nDataSize);
 	CelBlitSafeTo(out, position, pRLEBytes, nDataSize, cel.Width(frame));
 }
 
-void CelClippedDrawTo(const Surface &out, Point position, const CelSprite &cel, int frame)
+void CelClippedDrawTo(const Surface &out, Point position, CelSprite cel, int frame)
 {
 	int nDataSize;
 	const auto *pRLEBytes = CelGetFrameClipped(cel.Data(), frame, &nDataSize);
@@ -595,7 +595,7 @@ void CelClippedDrawTo(const Surface &out, Point position, const CelSprite &cel, 
 	CelBlitSafeTo(out, position, pRLEBytes, nDataSize, cel.Width(frame));
 }
 
-void CelDrawLightTo(const Surface &out, Point position, const CelSprite &cel, int frame, uint8_t *tbl)
+void CelDrawLightTo(const Surface &out, Point position, CelSprite cel, int frame, uint8_t *tbl)
 {
 	int nDataSize;
 	const auto *pRLEBytes = CelGetFrame(cel.Data(), frame, &nDataSize);
@@ -606,7 +606,7 @@ void CelDrawLightTo(const Surface &out, Point position, const CelSprite &cel, in
 		CelBlitSafeTo(out, position, pRLEBytes, nDataSize, cel.Width(frame));
 }
 
-void CelClippedDrawLightTo(const Surface &out, Point position, const CelSprite &cel, int frame)
+void CelClippedDrawLightTo(const Surface &out, Point position, CelSprite cel, int frame)
 {
 	int nDataSize;
 	const auto *pRLEBytes = CelGetFrameClipped(cel.Data(), frame, &nDataSize);
@@ -617,14 +617,14 @@ void CelClippedDrawLightTo(const Surface &out, Point position, const CelSprite &
 		CelBlitSafeTo(out, position, pRLEBytes, nDataSize, cel.Width(frame));
 }
 
-void CelDrawLightRedTo(const Surface &out, Point position, const CelSprite &cel, int frame)
+void CelDrawLightRedTo(const Surface &out, Point position, CelSprite cel, int frame)
 {
 	int nDataSize;
 	const auto *pRLEBytes = CelGetFrameClipped(cel.Data(), frame, &nDataSize);
 	RenderCelWithLightTable(out, position, pRLEBytes, nDataSize, cel.Width(frame), GetInfravisionTRN());
 }
 
-void CelDrawItem(const Item &item, const Surface &out, Point position, const CelSprite &cel, int frame)
+void CelDrawItem(const Item &item, const Surface &out, Point position, CelSprite cel, int frame)
 {
 	bool usable = item._iStatFlag;
 	if (!usable) {
@@ -634,7 +634,7 @@ void CelDrawItem(const Item &item, const Surface &out, Point position, const Cel
 	}
 }
 
-void CelClippedBlitLightTransTo(const Surface &out, Point position, const CelSprite &cel, int frame)
+void CelClippedBlitLightTransTo(const Surface &out, Point position, CelSprite cel, int frame)
 {
 	int nDataSize;
 	const byte *pRLEBytes = CelGetFrameClipped(cel.Data(), frame, &nDataSize);
@@ -647,14 +647,14 @@ void CelClippedBlitLightTransTo(const Surface &out, Point position, const CelSpr
 		CelBlitSafeTo(out, position, pRLEBytes, nDataSize, cel.Width(frame));
 }
 
-void CelDrawUnsafeTo(const Surface &out, Point position, const CelSprite &cel, int frame)
+void CelDrawUnsafeTo(const Surface &out, Point position, CelSprite cel, int frame)
 {
 	int nDataSize;
 	const auto *pRLEBytes = CelGetFrame(cel.Data(), frame, &nDataSize);
 	RenderCelClipY(out, position, pRLEBytes, nDataSize, cel.Width(frame), RenderLineMemcpy, NullLineEndFn);
 }
 
-void CelBlitOutlineTo(const Surface &out, uint8_t col, Point position, const CelSprite &cel, int frame, bool skipColorIndexZero)
+void CelBlitOutlineTo(const Surface &out, uint8_t col, Point position, CelSprite cel, int frame, bool skipColorIndexZero)
 {
 	int nDataSize;
 	const byte *src = CelGetFrameClipped(cel.Data(), frame, &nDataSize);
@@ -664,7 +664,7 @@ void CelBlitOutlineTo(const Surface &out, uint8_t col, Point position, const Cel
 		RenderCelOutline<false>(out, position, src, nDataSize, cel.Width(frame), col);
 }
 
-std::pair<int, int> MeasureSolidHorizontalBounds(const CelSprite &cel, int frame)
+std::pair<int, int> MeasureSolidHorizontalBounds(CelSprite cel, int frame)
 {
 	int nDataSize;
 	const byte *src = CelGetFrameClipped(cel.Data(), frame, &nDataSize);

--- a/Source/engine/render/cel_render.hpp
+++ b/Source/engine/render/cel_render.hpp
@@ -18,7 +18,7 @@ namespace devilution {
  * Returns a pair of X coordinates containing the start (inclusive) and end (exclusive)
  * of fully transparent columns in the sprite.
  */
-std::pair<int, int> MeasureSolidHorizontalBounds(const CelSprite &cel, int frame = 1);
+std::pair<int, int> MeasureSolidHorizontalBounds(CelSprite cel, int frame = 1);
 
 /**
  * @brief Blit CEL sprite to the back buffer at the given coordinates
@@ -27,7 +27,7 @@ std::pair<int, int> MeasureSolidHorizontalBounds(const CelSprite &cel, int frame
  * @param cel CEL sprite
  * @param frame CEL frame number
  */
-void CelDrawTo(const Surface &out, Point position, const CelSprite &cel, int frame);
+void CelDrawTo(const Surface &out, Point position, CelSprite cel, int frame);
 
 /**
  * @briefBlit CEL sprite to the given buffer, does not perform bounds-checking.
@@ -36,7 +36,7 @@ void CelDrawTo(const Surface &out, Point position, const CelSprite &cel, int fra
  * @param cel CEL sprite
  * @param frame CEL frame number
  */
-void CelDrawUnsafeTo(const Surface &out, Point position, const CelSprite &cel, int frame);
+void CelDrawUnsafeTo(const Surface &out, Point position, CelSprite cel, int frame);
 
 /**
  * @brief Same as CelDrawTo but with the option to skip parts of the top and bottom of the sprite
@@ -45,7 +45,7 @@ void CelDrawUnsafeTo(const Surface &out, Point position, const CelSprite &cel, i
  * @param cel CEL sprite
  * @param frame CEL frame number
  */
-void CelClippedDrawTo(const Surface &out, Point position, const CelSprite &cel, int frame);
+void CelClippedDrawTo(const Surface &out, Point position, CelSprite cel, int frame);
 
 /**
  * @brief Blit CEL sprite, and apply lighting, to the back buffer at the given coordinates
@@ -54,7 +54,7 @@ void CelClippedDrawTo(const Surface &out, Point position, const CelSprite &cel, 
  * @param cel CEL sprite
  * @param frame CEL frame number
  */
-void CelDrawLightTo(const Surface &out, Point position, const CelSprite &cel, int frame, uint8_t *tbl);
+void CelDrawLightTo(const Surface &out, Point position, CelSprite cel, int frame, uint8_t *tbl);
 
 /**
  * @brief Same as CelDrawLightTo but with the option to skip parts of the top and bottom of the sprite
@@ -63,7 +63,7 @@ void CelDrawLightTo(const Surface &out, Point position, const CelSprite &cel, in
  * @param cel CEL sprite
  * @param frame CEL frame number
  */
-void CelClippedDrawLightTo(const Surface &out, Point position, const CelSprite &cel, int frame);
+void CelClippedDrawLightTo(const Surface &out, Point position, CelSprite cel, int frame);
 
 /**
  * @brief Same as CelBlitLightSafeTo but with transparency applied
@@ -72,7 +72,7 @@ void CelClippedDrawLightTo(const Surface &out, Point position, const CelSprite &
  * @param cel CEL sprite
  * @param frame CEL frame number
  */
-void CelClippedBlitLightTransTo(const Surface &out, Point position, const CelSprite &cel, int frame);
+void CelClippedBlitLightTransTo(const Surface &out, Point position, CelSprite cel, int frame);
 
 /**
  * @brief Blit CEL sprite, and apply lighting, to the back buffer at the given coordinates, translated to a red hue
@@ -81,7 +81,7 @@ void CelClippedBlitLightTransTo(const Surface &out, Point position, const CelSpr
  * @param cel CEL sprite
  * @param frame CEL frame number
  */
-void CelDrawLightRedTo(const Surface &out, Point position, const CelSprite &cel, int frame);
+void CelDrawLightRedTo(const Surface &out, Point position, CelSprite cel, int frame);
 
 /**
  * @brief Blit item's CEL sprite recolored red if not usable, normal if usable
@@ -91,7 +91,7 @@ void CelDrawLightRedTo(const Surface &out, Point position, const CelSprite &cel,
  * @param cel CEL sprite
  * @param frame CEL frame number
  */
-void CelDrawItem(const Item &item, const Surface &out, Point position, const CelSprite &cel, int frame);
+void CelDrawItem(const Item &item, const Surface &out, Point position, CelSprite cel, int frame);
 
 /**
  * @brief Blit a solid colder shape one pixel larger than the given sprite shape, to the target buffer at the given coordianates
@@ -102,6 +102,6 @@ void CelDrawItem(const Item &item, const Surface &out, Point position, const Cel
  * @param frame CEL frame number
  * @param skipColorIndexZero If true, color in index 0 will be treated as transparent (these are typically used for shadows in sprites)
  */
-void CelBlitOutlineTo(const Surface &out, uint8_t col, Point position, const CelSprite &cel, int frame, bool skipColorIndexZero = true);
+void CelBlitOutlineTo(const Surface &out, uint8_t col, Point position, CelSprite cel, int frame, bool skipColorIndexZero = true);
 
 } // namespace devilution

--- a/Source/engine/render/cl2_render.cpp
+++ b/Source/engine/render/cl2_render.cpp
@@ -763,7 +763,7 @@ void Cl2ApplyTrans(byte *p, const std::array<uint8_t, 256> &ttbl, int nCel)
 	}
 }
 
-void Cl2Draw(const Surface &out, int sx, int sy, const CelSprite &cel, int frame)
+void Cl2Draw(const Surface &out, int sx, int sy, CelSprite cel, int frame)
 {
 	assert(frame > 0);
 
@@ -773,7 +773,7 @@ void Cl2Draw(const Surface &out, int sx, int sy, const CelSprite &cel, int frame
 	Cl2BlitSafe(out, sx, sy, pRLEBytes, nDataSize, cel.Width(frame));
 }
 
-void Cl2DrawOutline(const Surface &out, uint8_t col, int sx, int sy, const CelSprite &cel, int frame)
+void Cl2DrawOutline(const Surface &out, uint8_t col, int sx, int sy, CelSprite cel, int frame)
 {
 	assert(frame > 0);
 
@@ -783,7 +783,7 @@ void Cl2DrawOutline(const Surface &out, uint8_t col, int sx, int sy, const CelSp
 	RenderCl2Outline(out, { sx, sy }, pRLEBytes, nDataSize, cel.Width(frame), col);
 }
 
-void Cl2DrawTRN(const Surface &out, int sx, int sy, const CelSprite &cel, int frame, uint8_t *trn)
+void Cl2DrawTRN(const Surface &out, int sx, int sy, CelSprite cel, int frame, uint8_t *trn)
 {
 	assert(frame > 0);
 
@@ -792,7 +792,7 @@ void Cl2DrawTRN(const Surface &out, int sx, int sy, const CelSprite &cel, int fr
 	Cl2BlitLightSafe(out, sx, sy, pRLEBytes, nDataSize, cel.Width(frame), trn);
 }
 
-void Cl2DrawLight(const Surface &out, int sx, int sy, const CelSprite &cel, int frame)
+void Cl2DrawLight(const Surface &out, int sx, int sy, CelSprite cel, int frame)
 {
 	assert(frame > 0);
 

--- a/Source/engine/render/cl2_render.hpp
+++ b/Source/engine/render/cl2_render.hpp
@@ -30,7 +30,7 @@ void Cl2ApplyTrans(byte *p, const std::array<uint8_t, 256> &ttbl, int nCel);
  * @param pCelBuff CL2 buffer
  * @param nCel CL2 frame number
  */
-void Cl2Draw(const Surface &out, int sx, int sy, const CelSprite &cel, int frame);
+void Cl2Draw(const Surface &out, int sx, int sy, CelSprite cel, int frame);
 
 /**
  * @brief Blit a solid colder shape one pixel larger than the given sprite shape, to the given buffer at the given coordianates
@@ -41,7 +41,7 @@ void Cl2Draw(const Surface &out, int sx, int sy, const CelSprite &cel, int frame
  * @param pCelBuff CL2 buffer
  * @param nCel CL2 frame number
  */
-void Cl2DrawOutline(const Surface &out, uint8_t col, int sx, int sy, const CelSprite &cel, int frame);
+void Cl2DrawOutline(const Surface &out, uint8_t col, int sx, int sy, CelSprite cel, int frame);
 
 /**
  * @brief Blit CL2 sprite, and apply given TRN to the given buffer at the given coordinates
@@ -52,7 +52,7 @@ void Cl2DrawOutline(const Surface &out, uint8_t col, int sx, int sy, const CelSp
  * @param nCel CL2 frame number
  * @param TRN to use
  */
-void Cl2DrawTRN(const Surface &out, int sx, int sy, const CelSprite &cel, int frame, uint8_t *trn);
+void Cl2DrawTRN(const Surface &out, int sx, int sy, CelSprite cel, int frame, uint8_t *trn);
 
 /**
  * @brief Blit CL2 sprite, and apply lighting, to the given buffer at the given coordinates
@@ -62,6 +62,6 @@ void Cl2DrawTRN(const Surface &out, int sx, int sy, const CelSprite &cel, int fr
  * @param pCelBuff CL2 buffer
  * @param nCel CL2 frame number
  */
-void Cl2DrawLight(const Surface &out, int sx, int sy, const CelSprite &cel, int frame);
+void Cl2DrawLight(const Surface &out, int sx, int sy, CelSprite cel, int frame);
 
 } // namespace devilution

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -25,7 +25,7 @@
 
 namespace devilution {
 
-std::optional<CelSprite> pSPentSpn2Cels;
+std::optional<OwnedCelSprite> pSPentSpn2Cels;
 
 namespace {
 

--- a/Source/engine/render/text_render.hpp
+++ b/Source/engine/render/text_render.hpp
@@ -123,7 +123,7 @@ private:
  *
  * Also used in the stores and the quest log.
  */
-extern std::optional<CelSprite> pSPentSpn2Cels;
+extern std::optional<OwnedCelSprite> pSPentSpn2Cels;
 
 void LoadSmallSelectionSpinner();
 

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -24,7 +24,7 @@ int setpc_w;
 int setpc_h;
 std::unique_ptr<uint16_t[]> pSetPiece;
 bool setloadflag;
-std::optional<CelSprite> pSpecialCels;
+std::optional<OwnedCelSprite> pSpecialCels;
 std::unique_ptr<MegaTile[]> pMegaTiles;
 std::unique_ptr<uint16_t[]> pLevelPieces;
 std::unique_ptr<byte[]> pDungeonCels;

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -150,7 +150,7 @@ extern int setpc_h;
 extern std::unique_ptr<uint16_t[]> pSetPiece;
 /** Specifies whether a single player quest DUN has been loaded. */
 extern bool setloadflag;
-extern std::optional<CelSprite> pSpecialCels;
+extern std::optional<OwnedCelSprite> pSpecialCels;
 /** Specifies the tile definitions of the active dungeon type; (e.g. levels/l1data/l1.til). */
 extern std::unique_ptr<MegaTile[]> pMegaTiles;
 extern std::unique_ptr<uint16_t[]> pLevelPieces;

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -24,10 +24,10 @@ namespace devilution {
 
 namespace {
 
-std::optional<CelSprite> optbar_cel;
-std::optional<CelSprite> PentSpin_cel;
-std::optional<CelSprite> option_cel;
-std::optional<CelSprite> sgpLogo;
+std::optional<OwnedCelSprite> optbar_cel;
+std::optional<OwnedCelSprite> PentSpin_cel;
+std::optional<OwnedCelSprite> option_cel;
+std::optional<OwnedCelSprite> sgpLogo;
 bool mouseNavigation;
 TMenuItem *sgpCurrItem;
 int LogoAnim_tick;

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -26,7 +26,7 @@ namespace devilution {
 
 namespace {
 
-std::optional<CelSprite> sgpBackCel;
+std::optional<OwnedCelSprite> sgpBackCel;
 
 uint32_t sgdwProgress;
 int progress_id;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -134,7 +134,7 @@ const Point InvRect[] = {
 
 namespace {
 
-std::optional<CelSprite> pInvCels;
+std::optional<OwnedCelSprite> pInvCels;
 
 void InvDrawSlotBack(const Surface &out, Point targetPosition, Size size)
 {

--- a/Source/items.h
+++ b/Source/items.h
@@ -173,74 +173,74 @@ constexpr int ItemAnimWidth = 96;
 
 struct Item {
 	/** Randomly generated identifier */
-	int32_t _iSeed;
-	uint16_t _iCreateInfo;
-	enum ItemType _itype;
-	Point position;
-	bool _iAnimFlag;
+	int32_t _iSeed = 0;
+	uint16_t _iCreateInfo = 0;
+	enum ItemType _itype = ItemType::None;
+	Point position = { 0, 0 };
+	bool _iAnimFlag = false;
 	/*
 	 * @brief Contains Information for current Animation
 	 */
 	AnimationInfo AnimInfo;
-	bool _iDelFlag; // set when item is flagged for deletion, deprecated in 1.02
-	uint8_t _iSelFlag;
-	bool _iPostDraw;
-	bool _iIdentified;
-	item_quality _iMagical;
-	char _iName[64];
-	char _iIName[64];
-	enum item_equip_type _iLoc;
-	enum item_class _iClass;
-	uint8_t _iCurs;
-	int _ivalue;
-	int _iIvalue;
-	uint8_t _iMinDam;
-	uint8_t _iMaxDam;
-	int16_t _iAC;
-	uint32_t _iFlags; // item_special_effect
-	enum item_misc_id _iMiscId;
-	enum spell_id _iSpell;
-	int _iCharges;
-	int _iMaxCharges;
-	int _iDurability;
-	int _iMaxDur;
-	int16_t _iPLDam;
-	int16_t _iPLToHit;
-	int16_t _iPLAC;
-	int16_t _iPLStr;
-	int16_t _iPLMag;
-	int16_t _iPLDex;
-	int16_t _iPLVit;
-	int16_t _iPLFR;
-	int16_t _iPLLR;
-	int16_t _iPLMR;
-	int16_t _iPLMana;
-	int16_t _iPLHP;
-	int16_t _iPLDamMod;
-	int16_t _iPLGetHit;
-	int16_t _iPLLight;
-	int8_t _iSplLvlAdd;
-	bool _iRequest;
+	bool _iDelFlag = false; // set when item is flagged for deletion, deprecated in 1.02
+	uint8_t _iSelFlag = 0;
+	bool _iPostDraw = false;
+	bool _iIdentified = false;
+	item_quality _iMagical = ITEM_QUALITY_NORMAL;
+	char _iName[64] = {};
+	char _iIName[64] = {};
+	enum item_equip_type _iLoc = ILOC_NONE;
+	enum item_class _iClass = ICLASS_NONE;
+	uint8_t _iCurs = 0;
+	int _ivalue = 0;
+	int _iIvalue = 0;
+	uint8_t _iMinDam = 0;
+	uint8_t _iMaxDam = 0;
+	int16_t _iAC = 0;
+	uint32_t _iFlags = 0; // item_special_effect
+	enum item_misc_id _iMiscId = IMISC_NONE;
+	enum spell_id _iSpell = SPL_NULL;
+	int _iCharges = 0;
+	int _iMaxCharges = 0;
+	int _iDurability = 0;
+	int _iMaxDur = 0;
+	int16_t _iPLDam = 0;
+	int16_t _iPLToHit = 0;
+	int16_t _iPLAC = 0;
+	int16_t _iPLStr = 0;
+	int16_t _iPLMag = 0;
+	int16_t _iPLDex = 0;
+	int16_t _iPLVit = 0;
+	int16_t _iPLFR = 0;
+	int16_t _iPLLR = 0;
+	int16_t _iPLMR = 0;
+	int16_t _iPLMana = 0;
+	int16_t _iPLHP = 0;
+	int16_t _iPLDamMod = 0;
+	int16_t _iPLGetHit = 0;
+	int16_t _iPLLight = 0;
+	int8_t _iSplLvlAdd = 0;
+	bool _iRequest = false;
 	/** Unique item ID, used as an index into UniqueItemList */
-	int _iUid;
-	int16_t _iFMinDam;
-	int16_t _iFMaxDam;
-	int16_t _iLMinDam;
-	int16_t _iLMaxDam;
-	int16_t _iPLEnAc;
-	enum item_effect_type _iPrePower;
-	enum item_effect_type _iSufPower;
-	int _iVAdd1;
-	int _iVMult1;
-	int _iVAdd2;
-	int _iVMult2;
-	int8_t _iMinStr;
-	uint8_t _iMinMag;
-	int8_t _iMinDex;
-	bool _iStatFlag;
-	_item_indexes IDidx;
-	uint32_t dwBuff;
-	uint32_t _iDamAcFlags;
+	int _iUid = 0;
+	int16_t _iFMinDam = 0;
+	int16_t _iFMaxDam = 0;
+	int16_t _iLMinDam = 0;
+	int16_t _iLMaxDam = 0;
+	int16_t _iPLEnAc = 0;
+	enum item_effect_type _iPrePower = IPL_INVALID;
+	enum item_effect_type _iSufPower = IPL_INVALID;
+	int _iVAdd1 = 0;
+	int _iVMult1 = 0;
+	int _iVAdd2 = 0;
+	int _iVMult2 = 0;
+	int8_t _iMinStr = 0;
+	uint8_t _iMinMag = 0;
+	int8_t _iMinDex = 0;
+	bool _iStatFlag = false;
+	_item_indexes IDidx = IDI_NONE;
+	uint32_t dwBuff = 0;
+	uint32_t _iDamAcFlags = 0;
 
 	/**
 	 * @brief Checks whether this item is empty or not.

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -732,7 +732,7 @@ void LoadObject(LoadHelper &file, Object &object)
 	object._oAnimCnt = file.NextLE<int32_t>();
 	object._oAnimLen = file.NextLE<uint32_t>();
 	object._oAnimFrame = file.NextLE<uint32_t>();
-	object._oAnimWidth = file.NextLE<int32_t>();
+	object._oAnimWidth = static_cast<uint16_t>(file.NextLE<int32_t>());
 	file.Skip(4); // Skip _oAnimWidth2
 	object._oDelFlag = file.NextBool32();
 	object._oBreak = file.NextLE<int8_t>();
@@ -1403,7 +1403,7 @@ void SaveObject(SaveHelper &file, const Object &object)
 	file.WriteLE<uint32_t>(object._oAnimLen);
 	file.WriteLE<uint32_t>(object._oAnimFrame);
 	file.WriteLE<int32_t>(object._oAnimWidth);
-	file.WriteLE<int32_t>(CalculateWidth2(object._oAnimWidth)); // Write _oAnimWidth2 for vanilla compatibility
+	file.WriteLE<int32_t>(CalculateWidth2(static_cast<int>(object._oAnimWidth))); // Write _oAnimWidth2 for vanilla compatibility
 	file.WriteLE<uint32_t>(object._oDelFlag ? 1 : 0);
 	file.WriteLE<int8_t>(object._oBreak);
 	file.Skip(3); // Alignment

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1055,7 +1055,7 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.WriteLE<int32_t>(player.AnimInfo.NumberOfFrames);
 	file.WriteLE<int32_t>(player.AnimInfo.CurrentFrame);
 	// write _pAnimWidth for vanilla compatibility
-	int animWidth = player.AnimInfo.pCelSprite == nullptr ? 96 : player.AnimInfo.pCelSprite->Width();
+	int animWidth = player.AnimInfo.celSprite ? player.AnimInfo.celSprite->Width() : 96;
 	file.WriteLE<int32_t>(animWidth);
 	// write _pAnimWidth2 for vanilla compatibility
 	file.WriteLE<int32_t>(CalculateWidth2(animWidth));

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -31,7 +31,7 @@ int qtextSpd;
 /** Start time of scrolling */
 Uint32 ScrollStart;
 /** Graphics for the window border */
-std::optional<CelSprite> pTextBoxCels;
+std::optional<OwnedCelSprite> pTextBoxCels;
 
 /** Pixels for a line of text and the empty space under it. */
 const int LineHeight = 38;

--- a/Source/misdat.cpp
+++ b/Source/misdat.cpp
@@ -217,7 +217,7 @@ std::array<T, 16> maybeAutofill(std::initializer_list<T> list)
 
 MissileFileData::MissileFileData(string_view name, uint8_t animName, uint8_t animFAmt, MissileDataFlags flags,
     std::initializer_list<uint8_t> animDelay, std::initializer_list<uint8_t> animLen,
-    int16_t animWidth, int16_t animWidth2)
+    uint16_t animWidth, int16_t animWidth2)
     : name(name)
     , animName(animName)
     , animFAmt(animFAmt)

--- a/Source/misdat.h
+++ b/Source/misdat.h
@@ -10,6 +10,7 @@
 
 #include "effects.h"
 #include "engine.h"
+#include "engine/cel_sprite.hpp"
 #include "utils/stdcompat/cstddef.hpp"
 #include "utils/stdcompat/string_view.hpp"
 
@@ -141,14 +142,14 @@ struct MissileFileData {
 	MissileDataFlags flags;
 	std::array<uint8_t, 16> animDelay = {};
 	std::array<uint8_t, 16> animLen = {};
-	int16_t animWidth;
+	uint16_t animWidth;
 	int16_t animWidth2;
 	std::unique_ptr<byte[]> animData;
 	std::array<uint32_t, 16> frameOffsets;
 
 	MissileFileData(string_view name, uint8_t animName, uint8_t animFAmt, MissileDataFlags flags,
 	    std::initializer_list<uint8_t> animDelay, std::initializer_list<uint8_t> animLen,
-	    int16_t animWidth, int16_t animWidth2);
+	    uint16_t animWidth, int16_t animWidth2);
 
 	void LoadGFX();
 
@@ -162,6 +163,11 @@ struct MissileFileData {
 		// For a "null" missile, `frameOffsets[i]` is 0 and `animData` is nullptr
 		// `animData[frameOffsets[i]]` is UB, so we use get() instead.
 		return animData.get() + frameOffsets[i];
+	}
+
+	CelSprite Sprite() const
+	{
+		return CelSprite { GetFirstFrame(), animWidth };
 	}
 
 	void FreeGFX()

--- a/Source/misdat.h
+++ b/Source/misdat.h
@@ -159,7 +159,9 @@ struct MissileFileData {
 
 	[[nodiscard]] const byte *GetFrame(size_t i) const
 	{
-		return &animData[frameOffsets[i]];
+		// For a "null" missile, `frameOffsets[i]` is 0 and `animData` is nullptr
+		// `animData[frameOffsets[i]]` is UB, so we use get() instead.
+		return animData.get() + frameOffsets[i];
 	}
 
 	void FreeGFX()

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2160,7 +2160,7 @@ void InitMissileAnimationFromMonster(Missile &mis, Direction midir, const Monste
 	const AnimStruct &anim = mon.MType->GetAnimData(graphic);
 	mis._mimfnum = static_cast<int32_t>(midir);
 	mis._miAnimFlags = MissileDataFlags::None;
-	const auto &celSprite = *anim.CelSpritesForDirections[mis._mimfnum];
+	CelSprite celSprite = *anim.GetCelSpritesForDirection(midir);
 	mis._miAnimData = celSprite.Data();
 	mis._miAnimDelay = anim.Rate;
 	mis._miAnimLen = anim.Frames;
@@ -4184,7 +4184,7 @@ void missiles_process_charge()
 		} else {
 			graphic = MonsterGraphic::Walk;
 		}
-		missile._miAnimData = mon->GetAnimData(graphic).CelSpritesForDirections[missile._mimfnum]->Data();
+		missile._miAnimData = mon->GetAnimData(graphic).CelSpritesForDirections[missile._mimfnum];
 	}
 }
 

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -97,8 +97,8 @@ struct Missile {
 	const byte *_miAnimData;
 	int _miAnimDelay; // Tick length of each frame in the current animation
 	int _miAnimLen;   // Number of frames in current animation
-	int _miAnimWidth;
-	int _miAnimWidth2;
+	uint16_t _miAnimWidth;
+	int16_t _miAnimWidth2;
 	int _miAnimCnt; // Increases by one each game tick, counting how close we are to _pAnimDelay
 	int _miAnimAdd;
 	int _miAnimFrame; // Current frame of animation.

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -136,6 +136,11 @@ size_t GetNumAnims(const MonsterData &monsterData)
 	return monsterData.has_special ? 6 : 5;
 }
 
+bool IsDirectionalAnim(const CMonster &monster, size_t animIndex)
+{
+	return monster.mtype != MT_GOLEM || animIndex < 4;
+}
+
 void InitMonsterTRN(CMonster &monst)
 {
 	std::array<uint8_t, 256> colorTranslations;
@@ -149,11 +154,15 @@ void InitMonsterTRN(CMonster &monst)
 			continue;
 		}
 
-		for (int j = 0; j < 8; j++) {
-			Cl2ApplyTrans(
-			    CelGetFrame(monst.Anims[i].cl2Data, j),
-			    colorTranslations,
-			    monst.Anims[i].Frames);
+		AnimStruct &anim = monst.Anims[i];
+		if (IsDirectionalAnim(monst, i)) {
+			for (int j = 0; j < 8; j++) {
+				Cl2ApplyTrans(anim.CelSpritesForDirections[j], colorTranslations, anim.Frames);
+			}
+		} else {
+			for (int j = 0; j < 8; j++) {
+				Cl2ApplyTrans(CelGetFrame(anim.CelSpritesForDirections[0], j), colorTranslations, anim.Frames);
+			}
 		}
 	}
 }
@@ -680,8 +689,7 @@ void DeleteMonster(int i)
 void NewMonsterAnim(Monster &monster, MonsterGraphic graphic, Direction md, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0)
 {
 	const auto &animData = monster.MType->GetAnimData(graphic);
-	const auto *pCelSprite = &*animData.CelSpritesForDirections[static_cast<size_t>(md)];
-	monster.AnimInfo.SetNewAnimation(pCelSprite, animData.Frames, animData.Rate, flags, numSkippedFrames, distributeFramesBeforeFrame);
+	monster.AnimInfo.SetNewAnimation(animData.GetCelSpritesForDirection(md), animData.Frames, animData.Rate, flags, numSkippedFrames, distributeFramesBeforeFrame);
 	monster._mFlags &= ~(MFLAG_LOCK_ANIMATION | MFLAG_ALLOW_SPECIAL);
 	monster._mdir = md;
 }
@@ -3726,17 +3734,18 @@ void InitMonsterGFX(int monst)
 			continue;
 		}
 
-		anim.cl2Data = &monster.animData[animOffsets[animIndex]];
 		anim.Frames = monsterData.Frames[animIndex];
 		anim.Rate = monsterData.Rate[animIndex];
+		anim.Width = width;
 
-		if (monster.mtype != MT_GOLEM || (animletter[animIndex] != 's' && animletter[animIndex] != 'd')) {
+		byte *cl2Data = &monster.animData[animOffsets[animIndex]];
+		if (IsDirectionalAnim(monster, animIndex)) {
 			for (int i = 0; i < 8; i++) {
-				anim.CelSpritesForDirections[i].emplace(CelGetFrame(anim.cl2Data, i), width);
+				anim.CelSpritesForDirections[i] = CelGetFrame(cl2Data, i);
 			}
 		} else {
 			for (int i = 0; i < 8; i++) {
-				anim.CelSpritesForDirections[i].emplace(anim.cl2Data, width);
+				anim.CelSpritesForDirections[i] = cl2Data;
 			}
 		}
 	}

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -137,11 +137,11 @@ struct AnimStruct {
 		const byte *spriteData = CelSpritesForDirections[static_cast<size_t>(direction)];
 		if (spriteData == nullptr)
 			return std::nullopt;
-		return CelSprite(spriteData, static_cast<int>(Width));
+		return CelSprite(spriteData, Width);
 	}
 
 	std::array<byte *, 8> CelSpritesForDirections;
-	unsigned Width;
+	uint16_t Width;
 	int Frames;
 	int Rate;
 };

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -132,14 +132,16 @@ enum class LeaderRelation : uint8_t {
 };
 
 struct AnimStruct {
-	byte *cl2Data;
-	std::array<std::optional<CelSprite>, 8> CelSpritesForDirections;
-
-	inline const std::optional<CelSprite> &GetCelSpritesForDirection(Direction direction) const
+	[[nodiscard]] std::optional<CelSprite> GetCelSpritesForDirection(Direction direction) const
 	{
-		return CelSpritesForDirections[static_cast<size_t>(direction)];
+		const byte *spriteData = CelSpritesForDirections[static_cast<size_t>(direction)];
+		if (spriteData == nullptr)
+			return std::nullopt;
+		return CelSprite(spriteData, static_cast<int>(Width));
 	}
 
+	std::array<byte *, 8> CelSpritesForDirections;
+	unsigned Width;
 	int Frames;
 	int Rate;
 };
@@ -230,10 +232,9 @@ struct Monster { // note: missing field _mAFNum
 	void ChangeAnimationData(MonsterGraphic graphic, Direction direction)
 	{
 		auto &animationData = this->MType->GetAnimData(graphic);
-		auto &celSprite = animationData.GetCelSpritesForDirection(direction);
 
 		// Passing the Frames and Rate properties here is only relevant when initialising a monster, but doesn't cause any harm when switching animations.
-		this->AnimInfo.ChangeAnimationData(celSprite ? &*celSprite : nullptr, animationData.Frames, animationData.Rate);
+		this->AnimInfo.ChangeAnimationData(animationData.GetCelSpritesForDirection(direction), animationData.Frames, animationData.Rate);
 	}
 
 	/**

--- a/Source/objdat.h
+++ b/Source/objdat.h
@@ -234,7 +234,7 @@ struct ObjectData {
 	int oAnimFlag;  // TODO Create enum
 	int oAnimDelay; // Tick length of each frame in the current animation
 	int oAnimLen;   // Number of frames in current animation
-	int oAnimWidth;
+	uint16_t oAnimWidth;
 	bool oSolidFlag;
 	bool oMissFlag;
 	bool oLightFlag;

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -29,7 +29,7 @@ struct Object {
 	int _oAnimCnt;        // Increases by one each game tick, counting how close we are to _pAnimDelay
 	uint32_t _oAnimLen;   // Number of frames in current animation
 	uint32_t _oAnimFrame; // Current frame of animation.
-	int _oAnimWidth;
+	uint16_t _oAnimWidth;
 	bool _oDelFlag;
 	int8_t _oBreak;
 	bool _oSolidFlag;

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -16,7 +16,7 @@
 
 namespace devilution {
 
-std::optional<CelSprite> pChrButtons;
+std::optional<OwnedCelSprite> pChrButtons;
 
 /** Map of hero class names */
 const char *const ClassStrTbl[] = {

--- a/Source/panels/charpanel.hpp
+++ b/Source/panels/charpanel.hpp
@@ -6,7 +6,7 @@
 
 namespace devilution {
 
-extern std::optional<CelSprite> pChrButtons;
+extern std::optional<OwnedCelSprite> pChrButtons;
 extern const char *const ClassStrTbl[];
 
 void DrawChr(const Surface &);

--- a/Source/panels/info_box.cpp
+++ b/Source/panels/info_box.cpp
@@ -4,8 +4,8 @@
 
 namespace devilution {
 
-std::optional<CelSprite> pSTextBoxCels;
-std::optional<CelSprite> pSTextSlidCels;
+std::optional<OwnedCelSprite> pSTextBoxCels;
+std::optional<OwnedCelSprite> pSTextSlidCels;
 
 void InitInfoBoxGfx()
 {

--- a/Source/panels/info_box.hpp
+++ b/Source/panels/info_box.hpp
@@ -10,14 +10,14 @@ namespace devilution {
  *
  * Used in stores, the quest log, the help window, and the unique item info window.
  */
-extern std::optional<CelSprite> pSTextBoxCels;
+extern std::optional<OwnedCelSprite> pSTextBoxCels;
 
 /**
  * @brief Info box scrollbar graphics.
  *
  * Used in stores and `DrawDiabloMsg`.
  */
-extern std::optional<CelSprite> pSTextSlidCels;
+extern std::optional<OwnedCelSprite> pSTextSlidCels;
 
 void InitInfoBoxGfx();
 void FreeInfoBoxGfx();

--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -85,7 +85,7 @@ void InitSpellBook()
 	pSpellBkCel = LoadCel("Data\\SpellBk.CEL", SPANEL_WIDTH);
 
 	if (gbIsHellfire) {
-		static const int SBkBtnHellfireWidths[] = { 0, 61, 61, 61, 61, 61, 76 };
+		static const uint16_t SBkBtnHellfireWidths[] = { 0, 61, 61, 61, 61, 61, 76 };
 		pSBkBtnCel = LoadCel("Data\\SpellBkB.CEL", SBkBtnHellfireWidths);
 	} else {
 		pSBkBtnCel = LoadCel("Data\\SpellBkB.CEL", 76);

--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -21,12 +21,12 @@
 
 namespace devilution {
 
-std::optional<CelSprite> pSBkIconCels;
+std::optional<OwnedCelSprite> pSBkIconCels;
 
 namespace {
 
-std::optional<CelSprite> pSBkBtnCel;
-std::optional<CelSprite> pSpellBkCel;
+std::optional<OwnedCelSprite> pSBkBtnCel;
+std::optional<OwnedCelSprite> pSpellBkCel;
 
 /** Maps from spellbook page number and position to spell_id. */
 spell_id SpellPages[6][7] = {

--- a/Source/panels/spell_icons.cpp
+++ b/Source/panels/spell_icons.cpp
@@ -9,7 +9,7 @@
 namespace devilution {
 
 namespace {
-std::optional<CelSprite> pSpellCels;
+std::optional<OwnedCelSprite> pSpellCels;
 uint8_t SplTransTbl[256];
 } // namespace
 
@@ -87,7 +87,7 @@ void DrawSpellCel(const Surface &out, Point position, int nCel)
 	DrawSpellCel(out, position, *pSpellCels, nCel);
 }
 
-void DrawSpellCel(const Surface &out, Point position, const CelSprite &sprite, int nCel)
+void DrawSpellCel(const Surface &out, Point position, const OwnedCelSprite &sprite, int nCel)
 {
 	CelDrawLightTo(out, position, sprite, nCel, SplTransTbl);
 }

--- a/Source/panels/spell_icons.hpp
+++ b/Source/panels/spell_icons.hpp
@@ -27,7 +27,7 @@ void DrawSpellCel(const Surface &out, Point position, int nCel);
  * @param sprite Icons sprite sheet.
  * @param nCel Index of the cel frame to draw. 0 based.
  */
-void DrawSpellCel(const Surface &out, Point position, const CelSprite &sprite, int nCel);
+void DrawSpellCel(const Surface &out, Point position, const OwnedCelSprite &sprite, int nCel);
 
 void SetSpellTrans(spell_type t);
 

--- a/Source/player.h
+++ b/Source/player.h
@@ -190,7 +190,7 @@ struct PlayerAnimationData {
 	 */
 	std::unique_ptr<byte[]> RawData;
 
-	inline const std::optional<CelSprite> &GetCelSpritesForDirection(Direction direction) const
+	[[nodiscard]] std::optional<CelSprite> GetCelSpritesForDirection(Direction direction) const
 	{
 		return CelSpritesForDirections[static_cast<size_t>(direction)];
 	}
@@ -220,9 +220,9 @@ struct Player {
 	/**
 	 * @brief Contains a optional preview CelSprite that is displayed until the current command is handled by the game logic
 	 */
-	CelSprite *pPreviewCelSprite;
+	std::optional<CelSprite> previewCelSprite;
 	/**
-	 * @brief Contains the progress to next game tick when pPreviewCelSprite was set
+	 * @brief Contains the progress to next game tick when previewCelSprite was set
 	 */
 	float progressToNextGameTickWhenPreviewWasSet;
 	int _plid;
@@ -668,7 +668,7 @@ struct Player {
 	}
 
 	/**
-	 * @brief Updates pPreviewCelSprite according to new requested command
+	 * @brief Updates previewCelSprite according to new requested command
 	 * @param cmdId What command is requested
 	 * @param point Point for the command
 	 * @param wParam1 First Parameter

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -77,7 +77,7 @@ void AddItemToLabelQueue(int id, int x, int y)
 	nameWidth += MarginX * 2;
 	int index = ItemCAnimTbl[item._iCurs];
 	if (!labelCenterOffsets[index]) {
-		std::pair<int, int> itemBounds = MeasureSolidHorizontalBounds(*item.AnimInfo.pCelSprite, item.AnimInfo.CurrentFrame);
+		std::pair<int, int> itemBounds = MeasureSolidHorizontalBounds(*item.AnimInfo.celSprite, item.AnimInfo.CurrentFrame);
 		labelCenterOffsets[index].emplace((itemBounds.first + itemBounds.second) / 2);
 	}
 

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -29,7 +29,7 @@
 namespace devilution {
 
 bool QuestLogIsOpen;
-std::optional<CelSprite> pQLogCel;
+std::optional<OwnedCelSprite> pQLogCel;
 /** Contains the quests of the current game. */
 Quest Quests[MAXQUESTS];
 Point ReturnLvlPosition;

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -74,7 +74,7 @@ struct QuestData {
 };
 
 extern bool QuestLogIsOpen;
-extern std::optional<CelSprite> pQLogCel;
+extern std::optional<OwnedCelSprite> pQLogCel;
 extern DVL_API_FOR_TEST Quest Quests[MAXQUESTS];
 extern Point ReturnLvlPosition;
 extern dungeon_type ReturnLevelType;

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -454,12 +454,9 @@ void DrawMonster(const Surface &out, Point tilePosition, Point targetBufferPosit
  */
 void DrawPlayerIconHelper(const Surface &out, int pnum, missile_graphic_id missileGraphicId, Point position, bool lighting)
 {
-	position.x += CalculateWidth2(Players[pnum].AnimInfo.celSprite->Width()) - MissileSpriteData[missileGraphicId].animWidth2;
+	position.x += CalculateWidth2(static_cast<int>(Players[pnum].AnimInfo.celSprite->Width()) - MissileSpriteData[missileGraphicId].animWidth2);
 
-	int width = MissileSpriteData[missileGraphicId].animWidth;
-	const byte *pCelBuff = MissileSpriteData[missileGraphicId].GetFirstFrame();
-
-	CelSprite cel { pCelBuff, width };
+	const CelSprite cel = MissileSpriteData[missileGraphicId].Sprite();
 
 	if (pnum == MyPlayerId) {
 		Cl2Draw(out, position.x, position.y, cel, 1);
@@ -749,7 +746,7 @@ void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBuffe
 		auto &towner = Towners[mi];
 		int px = targetBufferPosition.x - CalculateWidth2(towner._tAnimWidth);
 		const Point position { px, targetBufferPosition.y };
-		CelSprite sprite { towner._tAnimData, towner._tAnimWidth };
+		const CelSprite sprite = towner.Sprite();
 		if (mi == pcursmonst) {
 			CelBlitOutlineTo(out, 166, position, sprite, towner._tAnimFrame);
 		}

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -43,7 +43,7 @@ struct Towner {
 	int16_t seed;
 	/** Tile position of NPC */
 	Point position;
-	int16_t _tAnimWidth;
+	uint16_t _tAnimWidth;
 	/** Tick length of each frame in the current animation */
 	int16_t _tAnimDelay;
 	/** Increases by one each game tick, counting how close we are to _pAnimDelay */
@@ -59,6 +59,11 @@ struct Towner {
 	std::size_t animOrderSize;
 	void (*talk)(Player &player, Towner &towner);
 	_talker_id _ttype;
+
+	CelSprite Sprite() const
+	{
+		return CelSprite { _tAnimData, _tAnimWidth };
+	}
 };
 
 extern Towner Towners[NUM_TOWNERS];

--- a/test/animationinfo_test.cpp
+++ b/test/animationinfo_test.cpp
@@ -75,7 +75,7 @@ void RunAnimationTest(const std::vector<TestData *> &vecTestData)
 	for (TestData *x : vecTestData) {
 		auto setNewAnimationData = dynamic_cast<SetNewAnimationData *>(x);
 		if (setNewAnimationData != nullptr) {
-			animInfo.SetNewAnimation(nullptr, setNewAnimationData->_NumberOfFrames, setNewAnimationData->_DelayLen, setNewAnimationData->_Params, setNewAnimationData->_NumSkippedFrames, setNewAnimationData->_DistributeFramesBeforeFrame);
+			animInfo.SetNewAnimation(std::nullopt, setNewAnimationData->_NumberOfFrames, setNewAnimationData->_DelayLen, setNewAnimationData->_Params, setNewAnimationData->_NumSkippedFrames, setNewAnimationData->_DistributeFramesBeforeFrame);
 		}
 
 		auto gameTickData = dynamic_cast<GameTickData *>(x);

--- a/test/inv_test.cpp
+++ b/test/inv_test.cpp
@@ -21,7 +21,7 @@ void set_up_scroll(Item &item, spell_id spell)
 void clear_inventory()
 {
 	for (int i = 0; i < NUM_INV_GRID_ELEM; i++) {
-		memset(&Players[MyPlayerId].InvList[i], 0, sizeof(Item));
+		Players[MyPlayerId].InvList[i] = {};
 		Players[MyPlayerId].InvGrid[i] = 0;
 	}
 	Players[MyPlayerId]._pNumInv = 0;


### PR DESCRIPTION
Makes `CelSprite` unowned and adds a new `OwnedCelSprite` class for owned sprites.

This clarifies ownership and makes the code cleaner in a number of places.

Additionally, because the `CelSprite` class is now tiny (1 less pointer), we can pass it by-value instead of by-reference, removing a pointer indirection in the rendering functions.

Based on top of #4031