### PR TITLE
Fix Diablo's HP

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -175,11 +175,12 @@ void InitMonster(Monster &monster, Direction rd, int mtype, Point position)
 	monster.AnimInfo.CurrentFrame = GenerateRnd(monster.AnimInfo.NumberOfFrames - 1) + 1;
 
 	monster.mLevel = monster.MData->mLevel;
-	monster._mmaxhp = (monster.MType->mMinHP + GenerateRnd(monster.MType->mMaxHP - monster.MType->mMinHP + 1)) << 6;
+	int maxhp = monster.MData->mMinHP + GenerateRnd(monster.MData->mMaxHP - monster.MData->mMinHP + 1);
 	if (monster.MType->mtype == MT_DIABLO && !gbIsHellfire) {
-		monster._mmaxhp /= 2;
+		maxhp /= 2;
 		monster.mLevel -= 15;
 	}
+	monster._mmaxhp = maxhp << 6;
 
 	if (!gbIsMultiplayer)
 		monster._mmaxhp = std::max(monster._mmaxhp / 2, 64);
@@ -3736,13 +3737,6 @@ void InitMonsterGFX(int monst)
 		}
 	}
 
-	monster.mMinHP = monsterData.mMinHP;
-	monster.mMaxHP = monsterData.mMaxHP;
-	if (!gbIsHellfire && mtype == MT_DIABLO) {
-		monster.mMinHP -= 2000;
-		monster.mMaxHP -= 2000;
-	}
-	monster.mAFNum = monsterData.mAFNum;
 	monster.MData = &monsterData;
 
 	if (monsterData.has_trans) {
@@ -4633,8 +4627,8 @@ void PrintMonstHistory(int mt)
 		int minHP = MonstersData[mt].mMinHP;
 		int maxHP = MonstersData[mt].mMaxHP;
 		if (!gbIsHellfire && mt == MT_DIABLO) {
-			minHP -= 2000;
-			maxHP -= 2000;
+			minHP /= 2;
+			maxHP /= 2;
 		}
 		if (!gbIsMultiplayer) {
 			minHP /= 2;

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -158,9 +158,6 @@ struct CMonster {
 		return Anims[static_cast<int>(graphic)];
 	}
 	std::unique_ptr<TSnd> Snds[4][2];
-	uint16_t mMinHP;
-	uint16_t mMaxHP;
-	uint8_t mAFNum;
 	int8_t mdeadval;
 	const MonsterData *MData;
 };


### PR DESCRIPTION
This restores Diablo to his original HP values of 833 for single player and 1666 for multiplayer in non-Hellfire games.

This resolves #4043

---

It was discovered by @ikonomov and reported on Discord that there are a couple places in the code where Diablo's HP is arbitrarily reduced by 2000 when it seemingly should have instead been reduced by half in `InitMonsterGFX()` and `PrintMonstHistory()`. These code blocks can be traced back to f05ae4c which doesn't really provide much context about where they came from. From what I can tell, it seems like a math error so that was my assumption when making these changes.

Note that the error by itself didn't actually modify Diablo's HP, which was still hardcoded in `InitMonster()` at the time. Eventually, the hardcoded logic was replaced in #1486. The HP value was adjusted as though it was working from the full Hellfire HP value of 3333, but it was actually working from 1333, granting Diablo a measly 333.25 HP in single player and 666.5 HP in multiplayer.