### PR TITLE
Add vanilla trap bugfix

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -308,6 +308,8 @@ bool RndLocOk(int xp, int yp)
 
 bool CanPlaceWallTrap(int xp, int yp)
 {
+	if (dObject[xp][yp] != 0)
+		return false;
 	if (TileContainsSetPiece({ xp, yp }))
 		return false;
 


### PR DESCRIPTION
Have seen this bug for years but never knew it was a bug until looking into it. When the game places down wall traps, it doesn't consider whether an object is already there. Therefore it overwrites whatever is in the object map array, but not the existing object. The result is that multiple objects can exist in the same place the trap does.

In the screenshot below, you see how the trap was placed on top of a torch and therefore has lighting when it shouldn't. Traps may also spawn multiple times on top of each other. The fix is to skip placing the trap if an object already exists on the wall.

![img](https://user-images.githubusercontent.com/65138215/151070495-222c4316-8c03-43d0-a503-8b233b6e5275.png)