### PR TITLE
TRN rewrite + bugfix

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -91,6 +91,7 @@ set(libdevilutionx_SRCS
   engine/render/dun_render.cpp
   engine/render/text_render.cpp
   engine/surface.cpp
+  engine/trn.cpp
   mpq/mpq_reader.cpp
   mpq/mpq_sdl_rwops.cpp
   mpq/mpq_writer.cpp

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1002,7 +1002,7 @@ void DrawDurIcon(const Surface &out)
 void RedBack(const Surface &out)
 {
 	uint8_t *dst = out.begin();
-	uint8_t *tbl = &LightTables[4608];
+	uint8_t *tbl = &LightTables[16 * 256];
 	for (int h = gnViewportHeight; h != 0; h--, dst += out.pitch() - gnScreenWidth) {
 		for (int w = gnScreenWidth; w != 0; w--) {
 			if (leveltype != DTYPE_HELL || *dst >= 32)

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -20,6 +20,7 @@
 #include "engine/load_cel.hpp"
 #include "engine/render/cel_render.hpp"
 #include "engine/render/text_render.hpp"
+#include "engine/trn.hpp"
 #include "error.h"
 #include "gamemenu.h"
 #include "init.h"
@@ -1002,7 +1003,7 @@ void DrawDurIcon(const Surface &out)
 void RedBack(const Surface &out)
 {
 	uint8_t *dst = out.begin();
-	uint8_t *tbl = &LightTables[16 * 256];
+	uint8_t *tbl = GetPauseTRN();
 	for (int h = gnViewportHeight; h != 0; h--, dst += out.pitch() - gnScreenWidth) {
 		for (int w = gnScreenWidth; w != 0; w--) {
 			if (leveltype != DTYPE_HELL || *dst >= 32)

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -61,7 +61,7 @@ void InitCorpses()
 		auto &monster = Monsters[ActiveMonsters[i]];
 		if (monster._uniqtype != 0) {
 			InitDeadAnimationFromMonster(Corpses[nd], *monster.MType);
-			Corpses[nd].translationPaletteIndex = monster._uniqtrans + 4;
+			Corpses[nd].translationPaletteIndex = monster._uniqtype;
 			nd++;
 
 			monster._udeadval = nd;

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -61,7 +61,7 @@ void InitCorpses()
 		auto &monster = Monsters[ActiveMonsters[i]];
 		if (monster._uniqtype != 0) {
 			InitDeadAnimationFromMonster(Corpses[nd], *monster.MType);
-			Corpses[nd].translationPaletteIndex = monster._uniqtype;
+			Corpses[nd].translationPaletteIndex = ActiveMonsters[i] + 1;
 			nd++;
 
 			monster._udeadval = nd;

--- a/Source/engine/render/cel_render.cpp
+++ b/Source/engine/render/cel_render.cpp
@@ -10,6 +10,7 @@
 
 #include "engine/cel_header.hpp"
 #include "engine/render/common_impl.h"
+#include "engine/trn.hpp"
 #include "options.h"
 #include "palette.h"
 #include "scrollrt.h"
@@ -620,7 +621,7 @@ void CelDrawLightRedTo(const Surface &out, Point position, const CelSprite &cel,
 {
 	int nDataSize;
 	const auto *pRLEBytes = CelGetFrameClipped(cel.Data(), frame, &nDataSize);
-	RenderCelWithLightTable(out, position, pRLEBytes, nDataSize, cel.Width(frame), GetLightTable(1));
+	RenderCelWithLightTable(out, position, pRLEBytes, nDataSize, cel.Width(frame), GetInfravisionTRN());
 }
 
 void CelDrawItem(const Item &item, const Surface &out, Point position, const CelSprite &cel, int frame)

--- a/Source/engine/render/cl2_render.cpp
+++ b/Source/engine/render/cl2_render.cpp
@@ -783,13 +783,13 @@ void Cl2DrawOutline(const Surface &out, uint8_t col, int sx, int sy, const CelSp
 	RenderCl2Outline(out, { sx, sy }, pRLEBytes, nDataSize, cel.Width(frame), col);
 }
 
-void Cl2DrawLightTbl(const Surface &out, int sx, int sy, const CelSprite &cel, int frame, char light)
+void Cl2DrawTRN(const Surface &out, int sx, int sy, const CelSprite &cel, int frame, uint8_t *trn)
 {
 	assert(frame > 0);
 
 	int nDataSize;
 	const byte *pRLEBytes = CelGetFrameClipped(cel.Data(), frame, &nDataSize);
-	Cl2BlitLightSafe(out, sx, sy, pRLEBytes, nDataSize, cel.Width(frame), GetLightTable(light));
+	Cl2BlitLightSafe(out, sx, sy, pRLEBytes, nDataSize, cel.Width(frame), trn);
 }
 
 void Cl2DrawLight(const Surface &out, int sx, int sy, const CelSprite &cel, int frame)

--- a/Source/engine/render/cl2_render.hpp
+++ b/Source/engine/render/cl2_render.hpp
@@ -44,15 +44,15 @@ void Cl2Draw(const Surface &out, int sx, int sy, const CelSprite &cel, int frame
 void Cl2DrawOutline(const Surface &out, uint8_t col, int sx, int sy, const CelSprite &cel, int frame);
 
 /**
- * @brief Blit CL2 sprite, and apply a given lighting, to the given buffer at the given coordianates
+ * @brief Blit CL2 sprite, and apply given TRN to the given buffer at the given coordinates
  * @param out Output buffer
  * @param sx Output buffer coordinate
  * @param sy Output buffer coordinate
  * @param pCelBuff CL2 buffer
  * @param nCel CL2 frame number
- * @param light Light shade to use
+ * @param TRN to use
  */
-void Cl2DrawLightTbl(const Surface &out, int sx, int sy, const CelSprite &cel, int frame, char light);
+void Cl2DrawTRN(const Surface &out, int sx, int sy, const CelSprite &cel, int frame, uint8_t *trn);
 
 /**
  * @brief Blit CL2 sprite, and apply lighting, to the given buffer at the given coordinates

--- a/Source/engine/render/common_impl.h
+++ b/Source/engine/render/common_impl.h
@@ -13,16 +13,6 @@
 
 namespace devilution {
 
-inline std::uint8_t *GetLightTable(char light)
-{
-	int idx = 4096;
-	if (light == 2)
-		idx += 256; // gray colors
-	if (light >= 4)
-		idx += (light - 1) << 8;
-	return &LightTables[idx];
-}
-
 struct ClipX {
 	std::int_fast16_t left;
 	std::int_fast16_t right;

--- a/Source/engine/trn.cpp
+++ b/Source/engine/trn.cpp
@@ -3,36 +3,23 @@
 
 #include "engine/load_file.hpp"
 #include "engine/trn.hpp"
+#include "lighting.h"
 
 namespace devilution {
 
-namespace {
-
-std::unordered_map<std::string, uint8_t *> TRNMap;
-
-}
-
-uint8_t *GetTRN(const char *path)
-{
-	if (TRNMap[path] == nullptr) {
-		TRNMap[path] = LoadFileInMem<uint8_t>(path).release();
-	}
-	return TRNMap[path];
-}
-
-uint8_t *GetUniqueMonsterTRN(const char *path)
-{
-	return GetTRN(fmt::format(("Monsters\\Monsters\\{:s}.TRN"), path).c_str());
-}
-
 uint8_t *GetInfravisionTRN()
 {
-	return GetTRN("PlrGFX\\Infra.TRN");
+	return &LightTables[16 * 256];
 }
 
 uint8_t *GetStoneTRN()
 {
-	return GetTRN("PlrGFX\\Stone.TRN");
+	return &LightTables[17 * 256];
+}
+
+uint8_t *GetPauseTRN()
+{
+	return &LightTables[18 * 256];
 }
 
 } // namespace devilution

--- a/Source/engine/trn.cpp
+++ b/Source/engine/trn.cpp
@@ -1,0 +1,38 @@
+#include <fmt/format.h>
+#include <unordered_map>
+
+#include "engine/load_file.hpp"
+#include "engine/trn.hpp"
+
+namespace devilution {
+
+namespace {
+
+std::unordered_map<std::string, uint8_t *> TRNMap;
+
+}
+
+uint8_t *GetTRN(const char *path)
+{
+	if (TRNMap[path] == nullptr) {
+		TRNMap[path] = LoadFileInMem<uint8_t>(path).release();
+	}
+	return TRNMap[path];
+}
+
+uint8_t *GetUniqueMonsterTRN(const char *path)
+{
+	return GetTRN(fmt::format(("Monsters\\Monsters\\{:s}.TRN"), path).c_str());
+}
+
+uint8_t *GetInfravisionTRN()
+{
+	return GetTRN("PlrGFX\\Infra.TRN");
+}
+
+uint8_t *GetStoneTRN()
+{
+	return GetTRN("PlrGFX\\Stone.TRN");
+}
+
+} // namespace devilution

--- a/Source/engine/trn.hpp
+++ b/Source/engine/trn.hpp
@@ -1,0 +1,18 @@
+/**
+ * @file trn.h
+ *
+ * Contains most of trn logic
+ */
+#pragma once
+
+namespace devilution {
+
+uint8_t *GetTRN(const char *path);
+
+uint8_t *GetUniqueMonsterTRN(const char *path);
+
+uint8_t *GetInfravisionTRN();
+
+uint8_t *GetStoneTRN();
+
+} // namespace devilution

--- a/Source/engine/trn.hpp
+++ b/Source/engine/trn.hpp
@@ -7,12 +7,8 @@
 
 namespace devilution {
 
-uint8_t *GetTRN(const char *path);
-
-uint8_t *GetUniqueMonsterTRN(const char *path);
-
 uint8_t *GetInfravisionTRN();
-
 uint8_t *GetStoneTRN();
+uint8_t *GetPauseTRN();
 
 } // namespace devilution

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -848,6 +848,12 @@ void MakeLightTable()
 		tbl += 240;
 	}
 
+	LoadFileInMem("PlrGFX\\Infra.TRN", tbl, 256);
+	tbl += 256;
+
+	LoadFileInMem("PlrGFX\\Stone.TRN", tbl, 256);
+	tbl += 256;
+
 	for (int i = 0; i < 8; i++) {
 		for (uint8_t col = 226; col < 239; col++) {
 			if (i != 0 || col != 226) {

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -848,12 +848,6 @@ void MakeLightTable()
 		tbl += 240;
 	}
 
-	LoadFileInMem("PlrGFX\\Infra.TRN", tbl, 256);
-	tbl += 256;
-
-	LoadFileInMem("PlrGFX\\Stone.TRN", tbl, 256);
-	tbl += 256;
-
 	for (int i = 0; i < 8; i++) {
 		for (uint8_t col = 226; col < 239; col++) {
 			if (i != 0 || col != 226) {

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -17,7 +17,8 @@ namespace devilution {
 
 #define MAXLIGHTS 32
 #define MAXVISION 32
-#define LIGHTSIZE (27 * 256)
+/** 16 light levels + red for pause/death screen */
+#define LIGHTSIZE (17 * 256)
 #define NO_LIGHT -1
 
 struct LightPosition {

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -17,8 +17,8 @@ namespace devilution {
 
 #define MAXLIGHTS 32
 #define MAXVISION 32
-/** 16 light levels + red for pause/death screen */
-#define LIGHTSIZE (17 * 256)
+/** 16 light levels + infravision + stone curse + red for pause/death screen */
+#define LIGHTSIZE (19 * 256)
 #define NO_LIGHT -1
 
 struct LightPosition {

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2191,7 +2191,6 @@ void AddRhino(Missile &missile, const AddMissileParameter &parameter)
 	if (monster.MType->mtype >= MT_NSNAKE && monster.MType->mtype <= MT_GSNAKE)
 		missile._miAnimFrame = 7;
 	if (monster._uniqtype != 0) {
-		missile._miUniqTrans = monster._uniqtrans + 1;
 		missile._mlid = monster.mlid;
 	}
 	PutMissile(missile);
@@ -2715,6 +2714,13 @@ Missile *AddMissile(Point src, Point dst, Direction midir, missile_id mitype, mi
 	missile._miDrawFlag = missileData.mDraw;
 	missile._mlid = NO_LIGHT;
 	missile.lastCollisionTargetHash = 0;
+
+	if (micaster == TARGET_PLAYERS) {
+		Monster &monster = Monsters[id];
+		if (monster._uniqtype != 0) {
+			missile._miUniqTrans = monster._uniqtrans + 1;
+		}
+	}
 
 	if (missile._miAnimType == MFILE_NONE || MissileSpriteData[missile._miAnimType].animFAmt < 8)
 		SetMissDir(missile, 0);

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -540,6 +540,10 @@ void PlaceUniqueMonst(int uniqindex, int miniontype, int bosspacksize)
 		monster.mMaxDamage2 = 4 * monster.mMaxDamage2 + 6;
 	}
 
+	char filestr[64];
+	sprintf(filestr, "Monsters\\Monsters\\%s.TRN", uniqueMonsterData.mTrnName);
+	monster.uniqueTRN = LoadFileInMem<uint8_t>(filestr);
+
 	monster._uniqtrans = uniquetrans++;
 
 	if (uniqueMonsterData.customToHit != 0) {

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -370,10 +370,6 @@ void PlaceUniqueMonst(int uniqindex, int miniontype, int bosspacksize)
 	auto &monster = Monsters[ActiveMonsterCount];
 	const auto &uniqueMonsterData = UniqueMonstersData[uniqindex];
 
-	if ((uniquetrans + 19) * 256 >= LIGHTSIZE) {
-		return;
-	}
-
 	int uniqtype;
 	for (uniqtype = 0; uniqtype < LevelMonsterTypeCount; uniqtype++) {
 		if (LevelMonsterTypes[uniqtype].mtype == uniqueMonsterData.mtype) {
@@ -543,10 +539,6 @@ void PlaceUniqueMonst(int uniqindex, int miniontype, int bosspacksize)
 		monster.mMinDamage2 = 4 * monster.mMinDamage2 + 6;
 		monster.mMaxDamage2 = 4 * monster.mMaxDamage2 + 6;
 	}
-
-	char filestr[64];
-	sprintf(filestr, "Monsters\\Monsters\\%s.TRN", uniqueMonsterData.mTrnName);
-	LoadFileInMem(filestr, &LightTables[256 * (uniquetrans + 19)], 256);
 
 	monster._uniqtrans = uniquetrans++;
 

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -219,6 +219,7 @@ struct Monster { // note: missing field _mAFNum
 	const char *mName;
 	CMonster *MType;
 	const MonsterData *MData;
+	std::unique_ptr<uint8_t[]> uniqueTRN;
 
 	/**
 	 * @brief Sets the current cell sprite to match the desired direction and animation sequence

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -319,10 +319,9 @@ void DrawMissilePrivate(const Surface &out, const Missile &missile, Point target
 
 	const Point missileRenderPosition { targetBufferPosition + missile.position.offsetForRendering - Displacement { missile._miAnimWidth2, 0 } };
 	CelSprite cel { missile._miAnimData, missile._miAnimWidth };
-	if (missile._miUniqTrans != 0) {
-		uint8_t *trn = GetUniqueMonsterTRN(UniqueMonstersData[Monsters[missile._misource]._uniqtype - 1].mTrnName);
-		Cl2DrawTRN(out, missileRenderPosition.x, missileRenderPosition.y, cel, missile._miAnimFrame, trn);
-	} else if (missile._miLightFlag)
+	if (missile._miUniqTrans != 0)
+		Cl2DrawTRN(out, missileRenderPosition.x, missileRenderPosition.y, cel, missile._miAnimFrame, Monsters[missile._misource].uniqueTRN.get());
+	else if (missile._miLightFlag)
 		Cl2DrawLight(out, missileRenderPosition.x, missileRenderPosition.y, cel, missile._miAnimFrame);
 	else
 		Cl2Draw(out, missileRenderPosition.x, missileRenderPosition.y, cel, missile._miAnimFrame);
@@ -440,7 +439,7 @@ void DrawMonster(const Surface &out, Point tilePosition, Point targetBufferPosit
 	}
 	uint8_t *trn = nullptr;
 	if (monster._uniqtype != 0)
-		trn = GetUniqueMonsterTRN(UniqueMonstersData[monster._uniqtype - 1].mTrnName);
+		trn = monster.uniqueTRN.get();
 	if (monster._mmode == MonsterMode::Petrified)
 		trn = GetStoneTRN();
 	if (Players[MyPlayerId]._pInfraFlag && LightTableIndex > 8)
@@ -862,7 +861,7 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 				break;
 			}
 			if (pDeadGuy->translationPaletteIndex != 0) {
-				uint8_t *trn = GetUniqueMonsterTRN(UniqueMonstersData[pDeadGuy->translationPaletteIndex - 1].mTrnName);
+				uint8_t *trn = Monsters[pDeadGuy->translationPaletteIndex - 1].uniqueTRN.get();
 				Cl2DrawTRN(out, px, targetBufferPosition.y, CelSprite(pCelBuff, pDeadGuy->width), nCel, trn);
 			} else {
 				Cl2DrawLight(out, px, targetBufferPosition.y, CelSprite(pCelBuff, pDeadGuy->width), nCel);


### PR DESCRIPTION
Old TRN system was pretty poo - the game could only handle 8 unique monsters with it - now unlimited.
I've also noticed a bug while doing the rewrite - TRNs for missiles never worked, except for rhino.
I think they forgot to plug the system for the rest of the missiles.
![trnbeforefix](https://user-images.githubusercontent.com/14297035/153516258-93f3f473-c2ec-4b7a-9933-51ca0602de50.gif)
![trnafterfix](https://user-images.githubusercontent.com/14297035/153516265-e07d5a3c-439f-4d8d-942d-1e657e6e077a.gif)
Here's bloodlust before and after fix. (notice blue color baked into first frames of the animation)
The goal of this PR is to make future modding easier - adding custom TRNs to missiles etc.

Deathspit:
![deathspittrn](https://user-images.githubusercontent.com/14297035/154086668-d876ee83-d783-407d-98f0-ec1cc870d776.gif)

Plaguewrath:
![image](https://user-images.githubusercontent.com/14297035/154089611-e949f075-be7e-47c9-a1ee-8424762356cc.png)

![image](https://user-images.githubusercontent.com/14297035/154537581-60471f66-d555-4f89-9963-0fcaf2603820.png)


Screenshot from Crucible as a bonus:
![image](https://user-images.githubusercontent.com/14297035/154085110-bf4fe031-8f32-4ec4-aa39-e6cd2f6cc686.png)
