### PR TITLE
The Sharp prefix bug from vanilla

### DIFF
--- a/Source/itemdat.cpp
+++ b/Source/itemdat.cpp
@@ -252,7 +252,7 @@ const PLStruct ItemPrefixes[] = {
 	{ N_("Merciless"),      { IPL_DAMP,                151,    175 },       60,                       PLT_WEAP |             PLT_BOW           , GOE_ANY,  true,     true,   15000,  20000,      20 },
 	{ N_("Clumsy"),         { IPL_TOHIT_DAMP_CURSE,     50,     75 },        5,                       PLT_WEAP | PLT_STAFF | PLT_BOW           , GOE_ANY,  true,     false,      0,      0,      -7 },
 	{ N_("Dull"),           { IPL_TOHIT_DAMP_CURSE,     25,     45 },        1,                       PLT_WEAP | PLT_STAFF | PLT_BOW           , GOE_ANY,  true,     false,      0,      0,      -5 },
-	{ N_("Sharp"),          { IPL_TOHIT_DAMP,           20,     35 },        1,                       PLT_WEAP | PLT_STAFF | PLT_BOW           , GOE_ANY,  true,     false,    350,    950,       5 },
+	{ N_("Sharp"),          { IPL_TOHIT_DAMP,           20,     35 },        1,                       PLT_WEAP | PLT_STAFF | PLT_BOW           , GOE_ANY,  true,     true,    350,    950,       5 },
 	{ N_("Fine"),           { IPL_TOHIT_DAMP,           36,     50 },        6,                       PLT_WEAP | PLT_STAFF | PLT_BOW           , GOE_ANY,  true,     true,    1100,   1700,       7 },
 	{ N_("Warrior's"),      { IPL_TOHIT_DAMP,           51,     65 },       10,                       PLT_WEAP | PLT_STAFF | PLT_BOW           , GOE_ANY,  true,     true,    1850,   2450,      13 },
 	{ N_("Soldier's"),      { IPL_TOHIT_DAMP,           66,     80 },       15,                       PLT_WEAP | PLT_STAFF                     , GOE_ANY,  true,     true,    2600,   3950,      17 },

--- a/Source/itemdat.cpp
+++ b/Source/itemdat.cpp
@@ -252,7 +252,7 @@ const PLStruct ItemPrefixes[] = {
 	{ N_("Merciless"),      { IPL_DAMP,                151,    175 },       60,                       PLT_WEAP |             PLT_BOW           , GOE_ANY,  true,     true,   15000,  20000,      20 },
 	{ N_("Clumsy"),         { IPL_TOHIT_DAMP_CURSE,     50,     75 },        5,                       PLT_WEAP | PLT_STAFF | PLT_BOW           , GOE_ANY,  true,     false,      0,      0,      -7 },
 	{ N_("Dull"),           { IPL_TOHIT_DAMP_CURSE,     25,     45 },        1,                       PLT_WEAP | PLT_STAFF | PLT_BOW           , GOE_ANY,  true,     false,      0,      0,      -5 },
-	{ N_("Sharp"),          { IPL_TOHIT_DAMP,           20,     35 },        1,                       PLT_WEAP | PLT_STAFF | PLT_BOW           , GOE_ANY,  true,     true,    350,    950,       5 },
+	{ N_("Sharp"),          { IPL_TOHIT_DAMP,           20,     35 },        1,                       PLT_WEAP | PLT_STAFF | PLT_BOW           , GOE_ANY,  true,     true,     350,    950,       5 },
 	{ N_("Fine"),           { IPL_TOHIT_DAMP,           36,     50 },        6,                       PLT_WEAP | PLT_STAFF | PLT_BOW           , GOE_ANY,  true,     true,    1100,   1700,       7 },
 	{ N_("Warrior's"),      { IPL_TOHIT_DAMP,           51,     65 },       10,                       PLT_WEAP | PLT_STAFF | PLT_BOW           , GOE_ANY,  true,     true,    1850,   2450,      13 },
 	{ N_("Soldier's"),      { IPL_TOHIT_DAMP,           66,     80 },       15,                       PLT_WEAP | PLT_STAFF                     , GOE_ANY,  true,     true,    2600,   3950,      17 },


### PR DESCRIPTION
The Sharp prefix has the wrong PLOk value set to false preventing it from being dropped.