### PR TITLE
Revised Attack Speed power

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3881,7 +3881,7 @@ void DoOil(Player &player, int cii)
 		if ((item._iFlags & ISPL_FASTERATTACK) != 0)
 			return _("+30% increased attack speed");
 		if ((item._iFlags & ISPL_FASTESTATTACK) != 0)
-			return _("+40% increased attack speed");
+			return _("+30% increased attack speed");
 		return _("Another ability (NW)");
 	case IPL_FASTRECOVER:
 		if ((item._iFlags & ISPL_FASTRECOVER) != 0)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3875,13 +3875,13 @@ void DoOil(Player &player, int cii)
 		return _("penetrates target's armor");
 	case IPL_FASTATTACK:
 		if ((item._iFlags & ISPL_QUICKATTACK) != 0)
-			return _("quick attack");
+			return _("+10% increased attack speed");
 		if ((item._iFlags & ISPL_FASTATTACK) != 0)
-			return _("fast attack");
+			return _("+20% increased attack speed");
 		if ((item._iFlags & ISPL_FASTERATTACK) != 0)
-			return _("faster attack");
+			return _("+30% increased attack speed");
 		if ((item._iFlags & ISPL_FASTESTATTACK) != 0)
-			return _("fastest attack");
+			return _("+40% increased attack speed");
 		return _("Another ability (NW)");
 	case IPL_FASTRECOVER:
 		if ((item._iFlags & ISPL_FASTRECOVER) != 0)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -447,7 +447,7 @@ void StartAttack(int pnum, Direction d)
 		int increasePercent = 0;
 
 		if ((player._pIFlags & ISPL_FASTESTATTACK) != 0) {
-			increasePercent = 40;
+			increasePercent = 30;
 		} else if ((player._pIFlags & ISPL_FASTERATTACK) != 0) {
 			increasePercent = 30;
 		} else if ((player._pIFlags & ISPL_FASTATTACK) != 0) {
@@ -456,9 +456,7 @@ void StartAttack(int pnum, Direction d)
 			increasePercent = 10;
 		}
 
-		if (increasePercent >= ((1000 / (player._pAFNum - 4)) * player._pAFNum - 1000) / 10) {
-			skippedAnimationFrames = 4;
-		} else if (increasePercent >= ((1000 / (player._pAFNum - 3)) * player._pAFNum - 1000) / 10) {
+		if (increasePercent >= ((1000 / (player._pAFNum - 3)) * player._pAFNum - 1000) / 10) {
 			skippedAnimationFrames = 3;
 		} else if (increasePercent >= ((1000 / (player._pAFNum - 2)) * player._pAFNum - 1000) / 10) {
 			skippedAnimationFrames = 2;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -442,18 +442,19 @@ void StartAttack(int pnum, Direction d)
 	}
 
 	int skippedAnimationFrames = 0;
-	int increasePercent = 0;
-	if ((player._pIFlags & ISPL_FASTESTATTACK) != 0) {
-		increasePercent = 40;
-	} else if ((player._pIFlags & ISPL_FASTERATTACK) != 0) {
-		increasePercent = 30;
-	} else if ((player._pIFlags & ISPL_FASTATTACK) != 0) {
-		increasePercent = 20;
-	} else if ((player._pIFlags & ISPL_QUICKATTACK) != 0) {
-		increasePercent = 10;
-	}
 
 	if ((player._pIFlags & ISPL_QUICKATTACK) != 0 || (player._pIFlags & ISPL_FASTATTACK) != 0 || (player._pIFlags & ISPL_FASTERATTACK) != 0 || (player._pIFlags & ISPL_FASTESTATTACK) != 0) {
+		int increasePercent = 0;
+
+		if ((player._pIFlags & ISPL_FASTESTATTACK) != 0) {
+			increasePercent = 40;
+		} else if ((player._pIFlags & ISPL_FASTERATTACK) != 0) {
+			increasePercent = 30;
+		} else if ((player._pIFlags & ISPL_FASTATTACK) != 0) {
+			increasePercent = 20;
+		} else if ((player._pIFlags & ISPL_QUICKATTACK) != 0) {
+			increasePercent = 10;
+		}
 
 		if (increasePercent >= ((1000 / (player._pAFNum - 4)) * player._pAFNum - 1000) / 10) {
 			skippedAnimationFrames = 4;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -442,14 +442,28 @@ void StartAttack(int pnum, Direction d)
 	}
 
 	int skippedAnimationFrames = 0;
-	if ((player._pIFlags & ISPL_FASTERATTACK) != 0) {
-		// The combination of Faster and Fast Attack doesn't result in more skipped skipped frames, cause the secound frame skip of Faster Attack is not triggered.
-		skippedAnimationFrames = 2;
+	int increasePercent = 0;
+	if ((player._pIFlags & ISPL_FASTESTATTACK) != 0) {
+		increasePercent = 40;
+	} else if ((player._pIFlags & ISPL_FASTERATTACK) != 0) {
+		increasePercent = 30;
 	} else if ((player._pIFlags & ISPL_FASTATTACK) != 0) {
-		skippedAnimationFrames = 1;
-	} else if ((player._pIFlags & ISPL_FASTESTATTACK) != 0) {
-		// Fastest Attack is skipped if Fast or Faster Attack is also specified, cause both skip the frame that triggers fastest attack skipping
-		skippedAnimationFrames = 2;
+		increasePercent = 20;
+	} else if ((player._pIFlags & ISPL_QUICKATTACK) != 0) {
+		increasePercent = 10;
+	}
+
+	if ((player._pIFlags & ISPL_QUICKATTACK) != 0 || (player._pIFlags & ISPL_FASTATTACK) != 0 || (player._pIFlags & ISPL_FASTERATTACK) != 0 || (player._pIFlags & ISPL_FASTESTATTACK) != 0) {
+
+		if (increasePercent >= ((1000 / (player._pAFNum - 4)) * player._pAFNum - 1000) / 10) {
+			skippedAnimationFrames = 4;
+		} else if (increasePercent >= ((1000 / (player._pAFNum - 3)) * player._pAFNum - 1000) / 10) {
+			skippedAnimationFrames = 3;
+		} else if (increasePercent >= ((1000 / (player._pAFNum - 2)) * player._pAFNum - 1000) / 10) {
+			skippedAnimationFrames = 2;
+		} else if (increasePercent >= ((1000 / (player._pAFNum - 1)) * player._pAFNum - 1000) / 10) {
+			skippedAnimationFrames = 1;
+		}
 	}
 
 	auto animationFlags = AnimationDistributionFlags::ProcessAnimationPending;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/68359262/153806491-4c2f346b-3cfc-4383-8f98-d70d9324a3e2.png)

This changes the affix power for attack speed modifiers. Instead of set frame reductions for each affix, instead they increase attack speed by adding 10%, 20%, 30% and 30% (Haste). This is intended to be a solution to the original issue with attack speed modifiers that could not be reimplemented (would cause up to 4 reduces attack frames which would end up completely unbalanced on classes using weapons they are already fast with). This solution increases attack speed more fairly for all classes. Fast attacks such as Sword of Haste on Warrior and Bow of swiftness on Rogue are unable to become faster than they are in vanilla. This mainly affects the slowest animations, such as axe on Sorcerer.

The main takeaway is that this will affect early gameplay by giving you Readiness which will actually do something, if you have a low base speed for that weapon type.

Warrior:
melee = unchanged behavior from vanilla
axe = unchanged from vanilla
bow = readiness reduces 1 frame, swiftness reduces 1 frame
staff = readiness reduces 1 frame, swiftness reduces 1 frame, speed reduces 2 frames, haste reduces 2 frames

Rogue:
melee = unchanged from vanilla
axe = readiness reduces 1 frame, swiftness reduces 2 frames, speed reduces 3 frames, haste reduces 3 frames
bow = unchanged from vanilla
staff = readiness reduces 1 frame, swiftness reduces 1 frame, speed reduces 2 frames, haste reduces 2 frames

Sorcerer:
melee = readiness reduces 1 frame, swiftness reduces 2 frames, speed reduces 2 frames, haste reduces 3 frames
axe = readiness reduces 1 frame, swiftness reduces 2 frames, speed reduces 3 frames, haste reduces 4 frames
bow = readiness reduces 1 frame, swiftness reduces 2 frames
staff = readiness reduces 1 frame, swiftness reduces 2 frames, speed reduces 3 frames, haste reduces 3 frames

Hellfire Characters:
Bard:
melee = unchanged from vanilla
axe = readiness reduces 1 frame, swiftness reduces 2 frames, speed reduces 3 frames, haste reduces 3 frames
bow = readiness reduces 1 frame, swiftness reduces 1 frame
staff = readiness reduces 1 frame, swiftness reduces 1 frame, speed reduces 2 frames, haste reduces 2 frames

Barbarian:
melee = swiftness reduces 1 frame, haste reduces 2 frames
axe = swiftness reduces 1 frame, haste reduces 2 frames
bow = readiness reduces 1 frame, swiftness reduces 1 frame
staff = readiness reduces 1 frame, swiftness reduces 1 frame, speed reduces 2 frames, haste reduces 2 frames