### PR TITLE
Fix flash infinite casting: Add check for _pInvincible to RepeatMouseAction

### DIFF
--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -50,6 +50,8 @@ void RepeatMouseAction()
 	auto &myPlayer = Players[MyPlayerId];
 	if (myPlayer.destAction != ACTION_NONE)
 		return;
+	if (myPlayer._pInvincible)
+		return;
 	if (!myPlayer.CanChangeAction())
 		return;
 


### PR DESCRIPTION
Similar to [`RightMouseDown`](https://github.com/diasurgical/devilutionX/blob/db9a7c7cba1f957546b117b4cf1fd4bdb0317e66/Source/diablo.cpp#L374).