### PR TITLE
Update Gradle plugin version

### DIFF
--- a/android-project/build.gradle
+++ b/android-project/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 		google()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:7.1.0'
+		classpath 'com.android.tools.build:gradle:7.1.1'
 
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files


### PR DESCRIPTION
Another update to point release of Gradle plugin, 7.1.1 at the recommendation of Android Studio
Build play-tested, no issues found