### PR TITLE
Search assets next to mpq the same way we search for mpqs

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1725,6 +1725,9 @@ int DiabloMain(int argc, char **argv)
 	DiabloParseFlags(argc, argv);
 	InitKeymapActions();
 
+	// Initialize search paths for assets (mpq and relative files)
+	InitMPQSearchPaths();
+
 	// Need to ensure devilutionx.mpq (and fonts.mpq if available) are loaded before attempting to read translation settings
 	LoadCoreArchives();
 	was_archives_init = true;

--- a/Source/engine/assets.cpp
+++ b/Source/engine/assets.cpp
@@ -43,8 +43,9 @@ SDL_RWops *OpenAsset(const char *filename, bool threadsafe)
 
 	// Files next to the MPQ archives override MPQ contents.
 	SDL_RWops *rwops;
-	if (paths::MpqDir()) {
-		const std::string path = *paths::MpqDir() + relativePath;
+	const auto &searchPaths = paths::GetMPQSearchPaths();
+	for (const auto &mpqDir : searchPaths) {
+		const std::string path = mpqDir + relativePath;
 		// Avoid spamming DEBUG messages if the file does not exist.
 		if ((FileExists(path.c_str())) && (rwops = SDL_RWFromFile(path.c_str(), "rb")) != nullptr) {
 			LogVerbose("Loaded MPQ file override: {}", path);

--- a/Source/init.h
+++ b/Source/init.h
@@ -29,6 +29,7 @@ extern std::optional<MpqArchive> font_mpq;
 extern std::optional<MpqArchive> lang_mpq;
 extern std::optional<MpqArchive> devilutionx_mpq;
 
+void InitMPQSearchPaths();
 void init_cleanup();
 void LoadCoreArchives();
 void LoadLanguageArchive();

--- a/Source/utils/paths.cpp
+++ b/Source/utils/paths.cpp
@@ -24,7 +24,7 @@ std::optional<std::string> basePath;
 std::optional<std::string> prefPath;
 std::optional<std::string> configPath;
 std::optional<std::string> assetsPath;
-std::optional<std::string> mpqDir;
+std::vector<std::string> mpqSearchPaths;
 
 void AddTrailingSlash(std::string &path)
 {
@@ -99,9 +99,9 @@ const std::string &AssetsPath()
 	return *assetsPath;
 }
 
-const std::optional<std::string> &MpqDir()
+const std::vector<std::string> &GetMPQSearchPaths()
 {
-	return mpqDir;
+	return mpqSearchPaths;
 }
 
 void SetBasePath(const std::string &path)
@@ -128,9 +128,9 @@ void SetAssetsPath(const std::string &path)
 	AddTrailingSlash(*assetsPath);
 }
 
-void SetMpqDir(const std::string &path)
+void SetMPQSearchPaths(const std::vector<std::string> &paths)
 {
-	mpqDir = std::string(path);
+	mpqSearchPaths = paths;
 }
 
 } // namespace paths

--- a/Source/utils/paths.h
+++ b/Source/utils/paths.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "utils/stdcompat/optional.hpp"
 
@@ -12,13 +13,13 @@ const std::string &BasePath();
 const std::string &PrefPath();
 const std::string &ConfigPath();
 const std::string &AssetsPath();
-const std::optional<std::string> &MpqDir();
+const std::vector<std::string> &GetMPQSearchPaths();
 
 void SetBasePath(const std::string &path);
 void SetPrefPath(const std::string &path);
 void SetConfigPath(const std::string &path);
 void SetAssetsPath(const std::string &path);
-void SetMpqDir(const std::string &path);
+void SetMPQSearchPaths(const std::vector<std::string> &paths);
 
 } // namespace paths
 


### PR DESCRIPTION
Fixes #4007

## Notes
- Previous we searched for assets next to the mpq only for the **last** mpq we loaded
- On windows this was often the hf-mpqs that are found at the gog installation
- But for the language the case was special. The (language) settings are loaded after `devilutionx.mpq`. So if we didn't find `devilutionx.mpq` the old search path wasn't set. See @StephenCWills [good analysis](https://github.com/diasurgical/devilutionX/issues/4007#issuecomment-1048145649).
- With this change we search for overridden assets everywhere where we also search for mpqs.
- I think we should revisit our assets searching strategy. For example I would prefer loading /assets folder before mpqs and I wouldn't load from current working directory (mpqs and overridden files). But this is another topic.