### PR TITLE
Persist the placed item in AutoPlaceItemInInventorySlot()

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1503,7 +1503,7 @@ bool AutoPlaceItemInInventorySlot(Player &player, int slotIndex, const Item &ite
 	}
 
 	if (persistItem) {
-		player.InvList[player._pNumInv] = player.HoldItem;
+		player.InvList[player._pNumInv] = item;
 		player._pNumInv++;
 
 		AddItemToInvGrid(player, slotIndex, player._pNumInv, itemSize);


### PR DESCRIPTION
From a practical standpoint, this change should be both pointless and benign. The only place where `player.HoldItem` is not passed as the `item` parameter is `DoPickup()` in `autopickup.cpp`, which passes `false` for `persistItem`.

https://github.com/diasurgical/devilutionX/blob/d3995736b97fd97dfa2ce5744fca2b691b9eca06/Source/qol/autopickup.cpp#L47

However, there are at least a couple good reasons to make the change. It seems to me that this assignment is only correct under the assumption that `item` and `player.HoldItem` are the same, which will cause issues if the function is called with `persistItem == true && item != player.HoldItem`. Furthermore, it already caused me plenty of confusion when reading the code.