### PR TITLE
Don't restart music if the same track is played

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -184,6 +184,7 @@ void FreeGame()
 	FreeDebugGFX();
 #endif
 	FreeGameMem();
+	music_stop();
 }
 
 bool ProcessInput()
@@ -666,7 +667,6 @@ void GameEventHandler(uint32_t uMsg, int32_t wParam, int32_t lParam)
 		nthread_ignore_mutex(true);
 		PaletteFadeOut(8);
 		sound_stop();
-		music_stop();
 		LastMouseButtonAction = MouseActionType::None;
 		sgbMouseDown = CLICK_NONE;
 		ShowProgress((interface_mode)uMsg);
@@ -1638,8 +1638,6 @@ void InitKeymapActions()
 
 void FreeGameMem()
 {
-	music_stop();
-
 	pDungeonCels = nullptr;
 	pMegaTiles = nullptr;
 	pLevelPieces = nullptr;
@@ -1703,6 +1701,7 @@ bool StartGame(bool bNewGame, bool bSinglePlayer)
 void diablo_quit(int exitStatus)
 {
 	FreeGameMem();
+	music_stop();
 	DiabloDeinit();
 	exit(exitStatus);
 }
@@ -1977,7 +1976,14 @@ void DisableInputWndProc(uint32_t uMsg, int32_t /*wParam*/, int32_t lParam)
 
 void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 {
-	music_stop();
+	_music_id neededTrack;
+	if (currlevel >= 17)
+		neededTrack = currlevel > 20 ? TMUSIC_L5 : TMUSIC_L6;
+	else
+		neededTrack = static_cast<_music_id>(leveltype);
+
+	if (neededTrack != sgnMusicTrack)
+		music_stop();
 	if (pcurs > CURSOR_HAND && pcurs < CURSOR_FIRSTITEM) {
 		NewCursor(CURSOR_HAND);
 	}
@@ -2216,10 +2222,8 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 	ActivateVirtualGamepad();
 #endif
 
-	if (currlevel >= 17)
-		music_start(currlevel > 20 ? TMUSIC_L5 : TMUSIC_L6);
-	else
-		music_start(leveltype);
+	if (sgnMusicTrack != neededTrack)
+		music_start(neededTrack);
 
 	if (MinimizePaused) {
 		music_mute();

--- a/Source/menu.cpp
+++ b/Source/menu.cpp
@@ -47,8 +47,6 @@ bool InitMenu(_selhero_selections type)
 	if (type == SELHERO_PREVIOUS)
 		return true;
 
-	music_stop();
-
 	success = StartGame(type != SELHERO_CONTINUE, type != SELHERO_CONNECT);
 	if (success)
 		RefreshMusic();
@@ -182,8 +180,6 @@ void mainmenu_loop()
 			break;
 		}
 	} while (!done);
-
-	music_stop();
 }
 
 } // namespace devilution

--- a/Source/sound.h
+++ b/Source/sound.h
@@ -60,6 +60,8 @@ struct TSnd {
 };
 
 extern bool gbSndInited;
+extern _music_id sgnMusicTrack;
+
 void ClearDuplicateSounds();
 void snd_stop_snd(TSnd *pSnd);
 void snd_play_snd(TSnd *pSnd, int lVolume, int lPan);


### PR DESCRIPTION
Fixes #799

## Notes
- When the same track is played on both levels the music isn't restarted.
- When a different track is needed the music will change when the loading screen is shown (the music will stop after 20% finished). This feels a little bit like fade out / in.
- The music will not stop when quick-loading (if the saved level uses the same track).
- Music in menus continues playing.