### PR TITLE
Fix Attack Speed Affix Panel Strings

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3586,7 +3586,7 @@ bool DoOil(Player &player, int cii)
 		}
 		if (HasAnyOf(item._iFlags, ItemSpecialEffect::FastAttack)) {
 			if (gbIsHellfire && item._itype == ItemType::Bow)
-				return _("fires fast speed arrows");
+				return _("fires fast arrows");
 			return _("fast attack");
 		}
 		if (HasAnyOf(item._iFlags, ItemSpecialEffect::FasterAttack))

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3580,8 +3580,12 @@ bool DoOil(Player &player, int cii)
 		return _("penetrates target's armor");
 	case IPL_FASTATTACK:
 		if (HasAnyOf(item._iFlags, ItemSpecialEffect::QuickAttack))
+			if (gbIsHellfire && item._itype == ItemType::Bow)
+				return _("fires quick speed arrows");
 			return _("quick attack");
 		if (HasAnyOf(item._iFlags, ItemSpecialEffect::FastAttack))
+			if (gbIsHellfire && item._itype == ItemType::Bow)
+				return _("fires fast speed arrows");
 			return _("fast attack");
 		if (HasAnyOf(item._iFlags, ItemSpecialEffect::FasterAttack))
 			return _("faster attack");

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3579,14 +3579,16 @@ bool DoOil(Player &player, int cii)
 	case IPL_TARGAC:
 		return _("penetrates target's armor");
 	case IPL_FASTATTACK:
-		if (HasAnyOf(item._iFlags, ItemSpecialEffect::QuickAttack))
+		if (HasAnyOf(item._iFlags, ItemSpecialEffect::QuickAttack)) {
 			if (gbIsHellfire && item._itype == ItemType::Bow)
 				return _("fires quick speed arrows");
 			return _("quick attack");
-		if (HasAnyOf(item._iFlags, ItemSpecialEffect::FastAttack))
+		}
+		if (HasAnyOf(item._iFlags, ItemSpecialEffect::FastAttack)) {
 			if (gbIsHellfire && item._itype == ItemType::Bow)
 				return _("fires fast speed arrows");
 			return _("fast attack");
+		}
 		if (HasAnyOf(item._iFlags, ItemSpecialEffect::FasterAttack))
 			return _("faster attack");
 		if (HasAnyOf(item._iFlags, ItemSpecialEffect::FastestAttack))

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3581,7 +3581,7 @@ bool DoOil(Player &player, int cii)
 	case IPL_FASTATTACK:
 		if (HasAnyOf(item._iFlags, ItemSpecialEffect::QuickAttack)) {
 			if (gbIsHellfire && item._itype == ItemType::Bow)
-				return _("fires quick speed arrows");
+				return _("fires quick arrows");
 			return _("quick attack");
 		}
 		if (HasAnyOf(item._iFlags, ItemSpecialEffect::FastAttack)) {


### PR DESCRIPTION

Changes Readiness & Swiftness to "fires quick speed arrows" & "fires fast speed arrows", on bow items in Hellfire.