### PR TITLE
Remove MAX from Char Panel Resists

### DIFF
--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -108,7 +108,7 @@ StyledText GetResistInfo(int8_t resist)
 		style = UiFlags::ColorWhitegold;
 
 	return {
-		style, (resist >= MAXRESIST ? _("MAX") : fmt::format("{:d}%", resist))
+		style, (fmt::format("{:d}%", resist))
 	};
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/68359262/155926843-134ea365-ef66-4fd9-bcf0-d8270f08ac3d.png)
Because no other stats show MAX instead of the actual number.