### PR TITLE
Stop music on diablo exit

### DIFF
--- a/Source/menu.cpp
+++ b/Source/menu.cpp
@@ -180,6 +180,8 @@ void mainmenu_loop()
 			break;
 		}
 	} while (!done);
+
+	music_stop();
 }
 
 } // namespace devilution


### PR DESCRIPTION
Regression introduced by #4100

The main loop handler should close music, cause this also closes diablo.
If the music doesn't stop the destructor of `Aulib::Stream` would be called when memory is cleaned up and this can result in a deadlock.

Sorry for the inconvenience. 😞