### PR TITLE
Use Staff Spell level for Staff Recharge

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4536,7 +4536,7 @@ void RechargeItem(Item &item, Player &player)
 	if (item._iCharges == item._iMaxCharges)
 		return;
 
-	int r = GetSpellBookLevel(item._iSpell);
+	int r = GetSpellStaffLevel(item._iSpell);
 	r = GenerateRnd(player._pLevel / r) + 1;
 
 	do {


### PR DESCRIPTION
Uses the Staff Spell level instead of Book Level. Using Book level results in some spells using -1 in the RNG, resulting in staves losing 50% of charges when recharged at 0 charges consistently, when the spell does not have a book counterpart. Performed testing with a clvl 50 Sorcerer. The results were very similar between changed and unchanged, however recharging a Staff of Resurrect was far less penalizing, and recharging a Staff of Apocalypse was slightly less penalizing. Tests were done in Diablo not Hellfire.