### PR TITLE
Filter out ZeroTier packets that do not come from an expected source

### DIFF
--- a/Source/dvlnet/base_protocol.h
+++ b/Source/dvlnet/base_protocol.h
@@ -288,6 +288,9 @@ void base_protocol<P>::recv_ingame(packet &pkt, endpoint sender)
 		// normal packets
 		LogDebug("Invalid packet: packet source ({}) >= MAX_PLRS", pkt.Source());
 		return;
+	} else if (sender != peers[pkt.Source()]) {
+		LogDebug("Invalid packet: packet source ({}) received from unrecognized endpoint", pkt.Source());
+		return;
 	}
 	connected_table[pkt.Source()] = true;
 	peers[pkt.Source()] = sender;


### PR DESCRIPTION
This change should reduce ZT errors due to erroneously interpreting random network traffic as an in-game packet. In cases where the player index is included as the packet source, this merely validates that the endpoint of the client who sent the packet matches the one that we would send packets to when communicating with the player at that index. FYI, this means that packets cannot be sent on behalf of another player, but that sort of delegation shouldn't be necessary since all players should have a direct channel to communicate between each other.

I believe this should help to address crashes similar to the one reported in #3263.