### PR TITLE
Don't use holdItem as a temporary when auto-picking up gold

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1173,6 +1173,34 @@ void StartGoldDrop()
 	SDL_StartTextInput();
 }
 
+bool GoldAutoPlaceInInventorySlot(Player &player, int slotIndex, Item &goldStack)
+{
+	if (player.InvGrid[slotIndex] != 0) {
+		return false;
+	}
+
+	int ii = player._pNumInv;
+	player.InvList[ii] = goldStack;
+	player._pNumInv++;
+	player.InvGrid[slotIndex] = player._pNumInv;
+	GenerateNewSeed(player.InvList[ii]);
+
+	int gold = goldStack._ivalue;
+	if (gold > MaxGold) {
+		gold -= MaxGold;
+		goldStack._ivalue = gold;
+		GenerateNewSeed(goldStack);
+		player.InvList[ii]._ivalue = MaxGold;
+		return false;
+	}
+
+	goldStack._ivalue = 0;
+	player._pGold = CalculateGold(player);
+	NewCursor(CURSOR_HAND);
+
+	return true;
+}
+
 } // namespace
 
 void FreeInvGFX()
@@ -1499,8 +1527,6 @@ bool AutoPlaceItemInInventorySlot(Player &player, int slotIndex, const Item &ite
 	return true;
 }
 
-bool GoldAutoPlaceInInventorySlot(Player &, int, Item &);
-
 bool GoldAutoPlace(Player &player, Item &goldStack)
 {
 	bool done = false;
@@ -1537,34 +1563,6 @@ bool GoldAutoPlace(Player &player, Item &goldStack)
 
 	player._pGold = CalculateGold(player);
 	return done;
-}
-
-bool GoldAutoPlaceInInventorySlot(Player &player, int slotIndex, Item &goldStack)
-{
-	if (player.InvGrid[slotIndex] != 0) {
-		return false;
-	}
-
-	int ii = player._pNumInv;
-	player.InvList[ii] = goldStack;
-	player._pNumInv++;
-	player.InvGrid[slotIndex] = player._pNumInv;
-	GenerateNewSeed(player.InvList[ii]);
-
-	int gold = goldStack._ivalue;
-	if (gold > MaxGold) {
-		gold -= MaxGold;
-		goldStack._ivalue = gold;
-		GenerateNewSeed(goldStack);
-		player.InvList[ii]._ivalue = MaxGold;
-		return false;
-	}
-
-	goldStack._ivalue = 0;
-	player._pGold = CalculateGold(player);
-	NewCursor(CURSOR_HAND);
-
-	return true;
 }
 
 void CheckInvSwap(Player &player, inv_body_loc bLoc, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff)

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -148,8 +148,7 @@ bool AutoPlaceItemInInventorySlot(Player &player, int slotIndex, const Item &ite
  * @return 'True' in case the item can be placed on the player's belt and 'False' otherwise.
  */
 bool AutoPlaceItemInBelt(Player &player, const Item &item, bool persistItem = false);
-bool GoldAutoPlace(Player &player);
-bool GoldAutoPlaceInInventorySlot(Player &player, int slotIndex);
+bool GoldAutoPlace(Player &player, Item &goldStack);
 void CheckInvSwap(Player &player, inv_body_loc bLoc, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff);
 void inv_update_rem_item(Player &player, inv_body_loc iv);
 void CheckInvItem(bool isShiftHeld = false, bool isCtrlHeld = false);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3196,26 +3196,22 @@ StartPlayerKill(int pnum, int earflag)
 
 void StripTopGold(Player &player)
 {
-	Item tmpItem = player.HoldItem;
-
 	for (Item &item : InventoryPlayerItemsRange { player }) {
 		if (item._itype == ItemType::Gold) {
 			if (item._ivalue > MaxGold) {
-				int val = item._ivalue - MaxGold;
+				Item excessGold;
+				InitializeItem(excessGold, IDI_GOLD);
+				SetGoldSeed(player, excessGold);
+				excessGold._ivalue = item._ivalue - MaxGold;
+				SetPlrHandGoldCurs(excessGold);
 				item._ivalue = MaxGold;
-				InitializeItem(player.HoldItem, IDI_GOLD);
-				SetGoldSeed(player, player.HoldItem);
-				player.HoldItem._ivalue = val;
-				SetPlrHandGoldCurs(player.HoldItem);
-				if (!GoldAutoPlace(player)) {
-					DeadItem(player, player.HoldItem, { 0, 0 });
-					player.HoldItem._itype == ItemType::None;
+				if (!GoldAutoPlace(player, excessGold)) {
+					DeadItem(player, excessGold, { 0, 0 });
 				}
 			}
 		}
 	}
 	player._pGold = CalculateGold(player);
-	player.HoldItem = tmpItem;
 }
 
 void ApplyPlrDamage(int pnum, int dam, int minHP /*= 0*/, int frac /*= 0*/, int earflag /*= 0*/)

--- a/test/inv_test.cpp
+++ b/test/inv_test.cpp
@@ -131,7 +131,7 @@ TEST(Inv, GoldAutoPlace)
 	Players[MyPlayerId].HoldItem._itype = ItemType::Gold;
 	Players[MyPlayerId].HoldItem._ivalue = GOLD_MAX_LIMIT - 100;
 
-	GoldAutoPlace(Players[MyPlayerId]);
+	GoldAutoPlace(Players[MyPlayerId], Players[MyPlayerId].HoldItem);
 	// We expect the inventory:
 	// | 5000 | 900 | ...
 	EXPECT_EQ(Players[MyPlayerId].InvList[0]._ivalue, GOLD_MAX_LIMIT);


### PR DESCRIPTION
Split this into two commits so it's easier to see the changed variable reference.

The only reason GoldAutoPlaceInInventorySlot was forward declared (in the header) was due to the order those functions were defined, so I moved that into the anonymous namespace in the second commit.