### PR TITLE
Fix tests expecting unclean HoldItem uses

### DIFF
--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -88,7 +88,7 @@ static void AssertPlayer(Player &player)
 	ASSERT_EQ(CountItems(player.InvBody, NUM_INVLOC), 1);
 	ASSERT_EQ(CountItems(player.InvList, NUM_INV_GRID_ELEM), 1);
 	ASSERT_EQ(CountItems(player.SpdList, MAXBELTITEMS), 2);
-	ASSERT_EQ(CountItems(&player.HoldItem, 1), 1);
+	ASSERT_EQ(CountItems(&player.HoldItem, 1), 0);
 
 	ASSERT_EQ(player.position.tile.x, 0);
 	ASSERT_EQ(player.position.tile.y, 0);

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -221,7 +221,7 @@ static void AssertPlayer(Player &player)
 	ASSERT_EQ(CountItems(player.InvBody, NUM_INVLOC), 6);
 	ASSERT_EQ(CountItems(player.InvList, NUM_INV_GRID_ELEM), 2);
 	ASSERT_EQ(CountItems(player.SpdList, MAXBELTITEMS), 8);
-	ASSERT_EQ(CountItems(&player.HoldItem, 1), 1);
+	ASSERT_EQ(CountItems(&player.HoldItem, 1), 0);
 
 	ASSERT_EQ(player.position.tile.x, 75);
 	ASSERT_EQ(player.position.tile.y, 68);


### PR DESCRIPTION
These tests were asserting side-effects of the call to CreatePlayer leaving an initialised gold item in the held item slot.