### PR TITLE
Init monster TRN after monster load

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3464,6 +3464,13 @@ bool IsRelativeMoveOK(const Monster &monster, Point position, Direction mdir)
 
 } // namespace
 
+void InitTRNForUniqueMonster(Monster &monster)
+{
+	char filestr[64];
+	sprintf(filestr, "Monsters\\Monsters\\%s.TRN", UniqueMonstersData[monster._uniqtype - 1].mTrnName);
+	monster.uniqueTRN = LoadFileInMem<uint8_t>(filestr);
+}
+
 void PrepareUniqueMonst(Monster &monster, int uniqindex, int miniontype, int bosspacksize, const UniqueMonsterData &uniqueMonsterData)
 {
 	monster._uniqtype = uniqindex + 1;
@@ -3535,10 +3542,7 @@ void PrepareUniqueMonst(Monster &monster, int uniqindex, int miniontype, int bos
 		monster.mMaxDamage2 = 4 * monster.mMaxDamage2 + 6;
 	}
 
-	char filestr[64];
-	sprintf(filestr, "Monsters\\Monsters\\%s.TRN", uniqueMonsterData.mTrnName);
-	monster.uniqueTRN = LoadFileInMem<uint8_t>(filestr);
-
+	InitTRNForUniqueMonster(monster);
 	monster._uniqtrans = uniquetrans++;
 
 	if (uniqueMonsterData.customToHit != 0) {
@@ -4551,6 +4555,9 @@ void SyncMonsterAnim(Monster &monster)
 		monster.mName = pgettext("monster", UniqueMonstersData[monster._uniqtype - 1].mName);
 	else
 		monster.mName = pgettext("monster", monster.MData->mName);
+
+	if (monster._uniqtype != 0)
+		InitTRNForUniqueMonster(monster);
 
 	MonsterGraphic graphic = MonsterGraphic::Stand;
 


### PR DESCRIPTION
Fixes #4144

The TRN crash occurs cause `uniqueTRN` must be initialized if the monster is a unique (`monster._uniqtype != 0`).
`uniqueTRN` is only initialized in `InitMonsters`.
When we load a visited level all monsters that got generated by `InitMonsters` get removed and replaced by the monsters from the save.
But these new loaded monsters don't initialise `uniqueTRN`. That means they depend on the data set by `InitMonsters`.

This difference between generated and loaded monsters can cause the issue.
After #3744 this can happen much more often (cause when generating the level `InitMonsters` is called after `InitObjects`, but when loading a level `InitObjects` isn't called so we get different numbers).
But even without #3744 we don't generate always the exact same monsters for a dungeon across all versions (see [discussion](https://github.com/diasurgical/devilutionX/pull/3733#issuecomment-991707597)).
Note: In the future we could remove the call to `InitMonsters` entirely when loading a save game, cause it will be overridden by the loaded monsters anyway. This would reduce the needed calculations and clarify the logic.