### PR TITLE
Fix network issues due to high-latency

### DIFF
--- a/Source/dvlnet/base.h
+++ b/Source/dvlnet/base.h
@@ -64,9 +64,9 @@ protected:
 
 	struct PlayerState {
 		bool isConnected = {};
-		bool waitForTurns = {};
 		std::deque<turn_t> turnQueue;
 		int32_t lastTurnValue = {};
+		uint32_t roundTripLatency = {};
 	};
 
 	seq_t next_turn = 0;
@@ -81,23 +81,28 @@ protected:
 	void Connect(plr_t player);
 	void RecvLocal(packet &pkt);
 	void RunEventHandler(_SNETEVENT &ev);
+	void SendEchoRequest(plr_t player);
 
 	[[nodiscard]] bool IsConnected(plr_t player) const;
 	virtual bool IsGameHost() = 0;
 
 private:
 	std::array<PlayerState, MAX_PLRS> playerStateTable_;
+	bool awaitingSequenceNumber_ = true;
 
 	plr_t GetOwner();
 	bool AllTurnsArrived();
 	void MakeReady(seq_t sequenceNumber);
 	void SendTurnIfReady(turn_t turn);
+	void SendFirstTurnIfReady(plr_t player);
 	void ClearMsg(plr_t plr);
 
 	void HandleAccept(packet &pkt);
 	void HandleConnect(packet &pkt);
 	void HandleTurn(packet &pkt);
 	void HandleDisconnect(packet &pkt);
+	void HandleEchoRequest(packet &pkt);
+	void HandleEchoReply(packet &pkt);
 };
 
 } // namespace net

--- a/Source/dvlnet/packet.cpp
+++ b/Source/dvlnet/packet.cpp
@@ -70,6 +70,10 @@ const char *packet_type_to_string(uint8_t packetType)
 		return "PT_INFO_REQUEST";
 	case PT_INFO_REPLY:
 		return "PT_INFO_REPLY";
+	case PT_ECHO_REQUEST:
+		return "PT_ECHO_REQUEST";
+	case PT_ECHO_REPLY:
+		return "PT_ECHO_REQUEST";
 	default:
 		return nullptr;
 	}
@@ -160,6 +164,13 @@ plr_t packet::NewPlayer()
 	assert(have_decrypted);
 	CheckPacketTypeOneOf({ PT_JOIN_ACCEPT, PT_CONNECT, PT_DISCONNECT }, m_type);
 	return m_newplr;
+}
+
+timestamp_t packet::Time()
+{
+	assert(have_decrypted);
+	CheckPacketTypeOneOf({ PT_ECHO_REQUEST, PT_ECHO_REPLY }, m_type);
+	return m_time;
 }
 
 const buffer_t &packet::Info()

--- a/Source/dvlnet/protocol_zt.cpp
+++ b/Source/dvlnet/protocol_zt.cpp
@@ -307,6 +307,11 @@ uint64_t protocol_zt::current_ms()
 	return 0;
 }
 
+bool protocol_zt::is_peer_connected(endpoint &peer)
+{
+	return peer_list.count(peer) != 0 && peer_list[peer].fd != -1;
+}
+
 std::string protocol_zt::make_default_gamename()
 {
 	std::string ret;

--- a/Source/dvlnet/protocol_zt.h
+++ b/Source/dvlnet/protocol_zt.h
@@ -73,6 +73,7 @@ public:
 	bool recv(endpoint &peer, buffer_t &data);
 	bool get_disconnected(endpoint &peer);
 	bool network_online();
+	bool is_peer_connected(endpoint &peer);
 	static std::string make_default_gamename();
 
 private:

--- a/Source/dvlnet/tcp_client.h
+++ b/Source/dvlnet/tcp_client.h
@@ -31,7 +31,7 @@ public:
 	virtual std::string make_default_gamename();
 
 protected:
-	virtual bool IsGameHost();
+	bool IsGameHost() override;
 
 private:
 	frame_queue recv_queue;

--- a/Source/dvlnet/tcp_server.h
+++ b/Source/dvlnet/tcp_server.h
@@ -68,7 +68,6 @@ private:
 	void HandleReceive(const scc &con, const asio::error_code &ec, size_t bytesRead);
 	void HandleReceiveNewPlayer(const scc &con, packet &pkt);
 	void HandleReceivePacket(packet &pkt);
-	void SendConnect(const scc &con);
 	void SendPacket(packet &pkt);
 	void StartSend(const scc &con, packet &pkt);
 	void HandleSend(const scc &con, const asio::error_code &ec, size_t bytesSent);


### PR DESCRIPTION
Summary of changes:
* Add packet types for echo request and echo reply to calculate round-trip latency
* Use echo packets in ZeroTier client to implement a two-way handshake between peers
* Queue packets in ZeroTier client until the first packet has been received from the remote player, indicating that packets will not be ignored
* Add `protocol_zt::is_peer_connected()` to prevent race conditions when establishing TCP connections between peers
* Fix turn interactions by replacing `waitForTurns` flag with `awaitingSequenceNumber_` and `SendFirstTurnIfReady()`
* Send `PT_CONNECT` from TCP server to all TCP clients when a new player joins

So.. I must admit that part of the reason this ended up being so complicated is because of the packet validation I added the other day (#4116). 😓 

Because of that validation, the client that handles `PT_JOIN_REQUEST` must send `PT_CONNECT` to all other clients to make sure that everyone is aware of each other and can therefore trust each other's packets. Unfortunately, this creates a rather complex race condition between the clients receiving those `PT_CONNECT` packets because none of them can be sure when the first packet is sent if the remote client will receive their `PT_CONNECT` packet first. If not, the aforementioned first packet would be ignored as an invalid packet.

My idea for fixing this involves a two-way handshake. Each client would send an echo request upon receipt of a `PT_CONNECT` packet. Since both clients will be sending echo requests, it doesn't matter if the first request is ignored because the client that receives their `PT_CONNECT` last will never be ignored. Any client that successfully processes an echo request will simply send an echo reply with the same content. Ultimately, both clients will have received a packet from the other and will each therefore be assured that their packets will not be ignored going forward. From there, all we need to do is queue up packets destined for a remote client until the remote client's first packet has been received.

Unfortunately, this ended up being a lot more complicated due to a couple factors. First, `PT_CONNECT` is sent before `PT_JOIN_ACCEPT` so that the new player will be made aware of all other players before entering the game logic. The new player's client doesn't know their player number until they receive `PT_JOIN_ACCEPT` and is therefore unable to form a valid echo request when the `PT_CONNECT` packets are received. Second, the TCP connection formed over the ZeroTier network is either initiated when the first packet is sent or accepted when the remote client initiates the connection, whichever comes first. If we allow both clients to send echo requests simultaneously, they may (and often do) initiate their TCP connections simultaneously as well. This will create two separate channels for communication between the two clients, and they will be unable to agree on which channel to use.

To solve the first, I handled edge cases for when the player doesn't yet know their player number and added logic to initiate handshakes after receiving `PT_JOIN_ACCEPT`. To solve the second, I added a function to detect when ZeroTier's TCP connection has already been established. The player with the smaller player number is the only one that will attempt to initiate the TCP connection. The player with the larger player number will only initiate the handshake if the TCP connection has already been established. Either the `PT_CONNECT` packet comes before the connection is established and we will eventually form the TCP connection to receive the remote's echo request or else the `PT_CONNECT` comes after at which point it's safe to send our own echo request. This still satisfies the requirements for the two-way handshake, which is to say that at least one of the echo requests will not be ignored.

Thankfully, I was able to work through both issues without too much trouble, but I'm sorry to say that the end result does feel a bit fragile. I guess the net code was already pretty fragile due to the fact that the game logic handles all the timing and the network providers are wrapped in a frankly absurd amount of templated classes and inheritance... but I digress. I suppose I'm trying to say that I wish I could have made the interactions less convoluted rather than piling on more of the same, but at least it didn't need a complete overhaul.

It's worth noting that none of this madness is necessary when playing over plain TCP. The TCP server can immediately route packets to all clients as soon as the new player's client has established their connection so there is no similar `PT_CONNECT` race condition. Honestly, the only reason `PT_CONNECT` is even necessary here is to ensure that all game clients are made aware of how many `PT_TURN` packets they need to wait for.