### PR TITLE
Update action for source tarball

### DIFF
--- a/.github/workflows/src_dist_release.yml
+++ b/.github/workflows/src_dist_release.yml
@@ -16,8 +16,8 @@ jobs:
 
     - name: Create Build Environment
       run: >
-        sudo apt update &&
-        sudo apt install -y cmake curl libsdl2-dev libsdl2-image-dev libfmt-dev libsodium-dev libbz2-dev git smpq gettext python-is-python3
+        sudo apt-get update &&
+        sudo apt-get install -y cmake curl libsdl2-dev libsdl2-image-dev libfmt-dev libsodium-dev libbz2-dev libgtest-dev libgmock-dev git smpq gettext python-is-python3
 
     - name: Build
       working-directory: ${{github.workspace}}


### PR DESCRIPTION
* Use apt-get instead of apt, since apt has a warning
* Add Gtest dependency since it's now required

@glebm please review