### PR TITLE
Leave healer

### DIFF
--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -1078,7 +1078,7 @@ void StartHealer()
 	AddSText(0, 9, _("Would you like to:"), UiFlags::ColorWhitegold | UiFlags::AlignCenter, false);
 	AddSText(0, 12, _("Talk to Pepin"), UiFlags::ColorBlue | UiFlags::AlignCenter, true);
 	AddSText(0, 14, _("Buy items"), UiFlags::ColorWhite | UiFlags::AlignCenter, true);
-	AddSText(0, 16, _("Leave Healer's home"), UiFlags::ColorWhite | UiFlags::AlignCenter, true);
+	AddSText(0, 18, _("Leave Healer's home"), UiFlags::ColorWhite | UiFlags::AlignCenter, true);
 	AddSLine(5);
 	storenumh = 20;
 }
@@ -2045,7 +2045,7 @@ void HealerEnter()
 	case 14:
 		StartStore(STORE_HBUY);
 		break;
-	case 16:
+	case 18:
 		stextflag = STORE_NONE;
 		break;
 	}

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2055,7 +2055,7 @@ void HealerBuyEnter()
 {
 	if (stextsel == BackButtonLine()) {
 		StartStore(STORE_HEALER);
-		stextsel = 16;
+		stextsel = 14;
 		return;
 	}
 
@@ -2596,7 +2596,7 @@ void StoreESC()
 		break;
 	case STORE_HBUY:
 		StartStore(STORE_HEALER);
-		stextsel = 16;
+		stextsel = 14;
 		break;
 	case STORE_SIDENTIFY:
 		StartStore(STORE_STORY);


### PR DESCRIPTION
When the healing option was removed from the menu the leave option was moved up. This is evidently not the right change since all stores have the leave option at at least the 18th position even when they have less options. It just happened that the healer had an option for all other lines.