### PR TITLE
Adjust gradle task dependencies to ensure assets are included in the APK

### DIFF
--- a/android-project/app/build.gradle
+++ b/android-project/app/build.gradle
@@ -29,6 +29,10 @@ android {
 			proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
 		}
 	}
+	applicationVariants.all { variant ->
+		tasks["merge${variant.name.capitalize()}Assets"]
+			.dependsOn("externalNativeBuild${variant.name.capitalize()}")
+	}
 	if (!project.hasProperty('EXCLUDE_NATIVE_LIBS')) {
 		sourceSets.main {
 			jniLibs.srcDir 'libs'


### PR DESCRIPTION
This resolves the issue with the Android test build that's been reported a handful of times on Discord.