### PR TITLE
Use apt-get instead of apt in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,9 @@ jobs:
     steps:
       - checkout
       - run: echo deb http://deb.debian.org/debian stretch-backports-sloppy main >> /etc/apt/sources.list.d/debian-backports.list
-      - run: apt update -y
-      - run: apt install -y g++ libsdl2-dev libbz2-dev git rpm wget smpq
-      - run: apt install -y -t 'stretch-backports*' cmake libsodium-dev libpng-dev
+      - run: apt-get update -y
+      - run: apt-get install -y g++ libsdl2-dev libbz2-dev git rpm wget smpq
+      - run: apt-get install -y -t 'stretch-backports*' cmake libsodium-dev libpng-dev
       - run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF -DCPACK=ON -DCMAKE_INSTALL_PREFIX=/usr
       - run: cmake --build build -j 2 --target package
       - store_artifacts: {path: ./build/devilutionx, destination: devilutionx_linux_x86_64}

--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install gettext
-      run: sudo apt update && sudo apt install -y gettext
+      run: sudo apt-get update && sudo apt-get install -y gettext
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/Linux_x86.yml
+++ b/.github/workflows/Linux_x86.yml
@@ -19,8 +19,8 @@ jobs:
     - name: Create Build Environment
       run: >
         sudo dpkg --add-architecture i386 &&
-        sudo apt update -y &&
-        sudo apt install -y cmake file g++-multilib git libfmt-dev:i386 libsdl2-dev:i386 libsodium-dev:i386 libpng-dev:i386 libbz2-dev:i386 rpm wget smpq
+        sudo apt-get update -y &&
+        sudo apt-get install -y cmake file g++-multilib git libfmt-dev:i386 libsdl2-dev:i386 libsodium-dev:i386 libpng-dev:i386 libbz2-dev:i386 rpm wget smpq
 
     - name: Cache CMake build folder
       uses: actions/cache@v2

--- a/.github/workflows/Linux_x86_64_SDL1.yml
+++ b/.github/workflows/Linux_x86_64_SDL1.yml
@@ -18,8 +18,8 @@ jobs:
 
     - name: Create Build Environment
       run: >
-        sudo apt update &&
-        sudo apt install -y cmake file g++ git libfmt-dev libsdl-dev libsodium-dev libpng-dev libbz2-dev rpm smpq
+        sudo apt-get update &&
+        sudo apt-get install -y cmake file g++ git libfmt-dev libsdl-dev libsodium-dev libpng-dev libbz2-dev rpm smpq
 
     - name: Cache CMake build folder
       uses: actions/cache@v2

--- a/.github/workflows/PS4.yml
+++ b/.github/workflows/PS4.yml
@@ -18,8 +18,8 @@ jobs:
 
     - name: Create Build Environment
       run: >
-        sudo apt update &&
-        sudo apt install -y wget cmake git gettext smpq &&
+        sudo apt-get update &&
+        sudo apt-get install -y wget cmake git gettext smpq &&
         wget https://github.com/PacBrew/pacbrew-pacman/releases/download/pacbrew-release-1.0/pacbrew-pacman-1.0.deb &&
         sudo dpkg -i pacbrew-pacman-1.0.deb && sudo pacbrew-pacman -Sy &&
         sudo pacbrew-pacman --noconfirm -S ps4-openorbis ps4-openorbis-portlibs &&

--- a/.github/workflows/Windows_x64.yml
+++ b/.github/workflows/Windows_x64.yml
@@ -18,8 +18,8 @@ jobs:
 
     - name: Create Build Environment
       run: >
-        sudo apt update &&
-        sudo apt install -y cmake gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 pkg-config-mingw-w64-x86-64 libz-mingw-w64-dev gettext dpkg-dev wget git sudo smpq &&
+        sudo apt-get update &&
+        sudo apt-get install -y cmake gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 pkg-config-mingw-w64-x86-64 libz-mingw-w64-dev gettext dpkg-dev wget git sudo smpq &&
         sudo rm /usr/x86_64-w64-mingw32/lib/libz.dll.a &&
         sudo Packaging/windows/mingw-prep64.sh
 

--- a/.github/workflows/opendingux_release.yml
+++ b/.github/workflows/opendingux_release.yml
@@ -16,8 +16,8 @@ jobs:
 
     - name: Create Build Environment
       run: >
-        sudo apt update &&
-        sudo apt install -y curl cmake git squashfs-tools &&
+        sudo apt-get update &&
+        sudo apt-get install -y curl cmake git squashfs-tools &&
         curl -L http://od.abstraction.se/opendingux/toolchain/opendingux-gcw0-toolchain.2021-10-22.tar.xz -o gcw0-toolchain.tar.xz &&
         sudo mkdir -p /opt/gcw0-toolchain && sudo chown -R "${USER}:" /opt/gcw0-toolchain &&
         tar -C /opt -xf gcw0-toolchain.tar.xz

--- a/.github/workflows/retrofw_release.yml
+++ b/.github/workflows/retrofw_release.yml
@@ -16,8 +16,8 @@ jobs:
 
     - name: Create Build Environment
       run: >
-        sudo apt update &&
-        sudo apt install -y curl cmake git squashfs-tools gettext &&
+        sudo apt-get update &&
+        sudo apt-get install -y curl cmake git squashfs-tools gettext &&
         curl -L https://github.com/Poligraf/retrofw_buildroot_gcc11/releases/download/2.3.2/host.tar.gz -o retrofw-toolchain.tar.gz &&
         sudo mkdir -p /opt/retrofw-toolchain && sudo chown -R "${USER}:" /opt/retrofw-toolchain &&
         tar -C /opt/retrofw-toolchain --strip-components=1 -xf retrofw-toolchain.tar.gz &&

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -17,7 +17,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install polib
-      run: sudo apt update && sudo apt install -y python3-polib
+      run: sudo apt-get update && sudo apt-get install -y python3-polib
 
     - name: Check
       working-directory: ${{github.workspace}}


### PR DESCRIPTION
Usage of `apt-get` instead of `apt` applied everywhere else.

For reasoning, see https://manpages.debian.org/buster/apt/apt.8#SCRIPT_USAGE_AND_DIFFERENCES_FROM_OTHER_APT_TOOLS