### PR TITLE
Only load stash on New Game and Load Game

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2058,7 +2058,9 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 		FreeStoreMem();
 	}
 
-	LoadStash();
+	if (firstflag || lvldir == ENTRY_LOAD) {
+		LoadStash();
+	}
 
 	IncProgress();
 	InitAutomap();


### PR DESCRIPTION
This filters calls to `LoadStash()` so items get loaded from disk only on New Game and Load Game.

The game loads the stash from disk whenever the player changes levels, which causes some problems for Single Player. Kudos go to AJenbo for catching this so quick after merging.