### PR TITLE
Allow only one gold input panel to be open

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1108,6 +1108,8 @@ bool CanUseStaff(Item &staff, spell_id spell)
 
 void StartGoldDrop()
 {
+	CloseGoldWithdraw();
+
 	initialDropGoldIndex = pcursinvitem;
 
 	auto &myPlayer = Players[MyPlayerId];

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -235,6 +235,8 @@ void CheckStashCut(Point cursorPosition, bool automaticMove, bool dropItem)
 
 void StartGoldWithdraw()
 {
+	CloseGoldDrop();
+
 	InitialWithdrawGoldValue = Stash.gold;
 
 	if (talkflag)


### PR DESCRIPTION
Fixes a issue mentioned in stash pr #3853

> It's possible to open both gold input panels at the same time