### PR TITLE
Update _iStatFlag for stash items

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -680,7 +680,7 @@ Point FindFirstStashSlotOnItem(uint16_t itemInvId)
 		return InvalidStashPoint;
 
 	for (auto point : PointsInRectangleRange({ { 0, 0 }, { 10, 10 } })) {
-		if (Stash.stashGrids[Stash.page][point.x][point.y] == itemInvId)
+		if (Stash.stashGrids[Stash.GetPage()][point.x][point.y] == itemInvId)
 			return point;
 	}
 
@@ -1574,7 +1574,7 @@ void PerformPrimaryAction()
 						Point slotUnderCursor = stashSlot + Displacement { x, y };
 						if (slotUnderCursor.x >= 10 || slotUnderCursor.y >= 10)
 							continue;
-						uint16_t itemId = Stash.stashGrids[Stash.page][slotUnderCursor.x][slotUnderCursor.y];
+						uint16_t itemId = Stash.stashGrids[Stash.GetPage()][slotUnderCursor.x][slotUnderCursor.y];
 						if (itemId != 0)
 							return itemId;
 					}

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -510,7 +510,7 @@ void PressKey(int vkey)
 		} else if (AutomapActive) {
 			AutomapUp();
 		} else if (IsStashOpen) {
-			Stash.page = clamp(Stash.page - 1, 0, 49);
+			Stash.SetPage(Stash.GetPage() - 1);
 		}
 	} else if (vkey == DVL_VK_DOWN) {
 		if (stextflag != STORE_NONE) {
@@ -524,7 +524,7 @@ void PressKey(int vkey)
 		} else if (AutomapActive) {
 			AutomapDown();
 		} else if (IsStashOpen) {
-			Stash.page = clamp(Stash.page + 1, 0, 49);
+			Stash.SetPage(Stash.GetPage() + 1);
 		}
 	} else if (vkey == DVL_VK_PRIOR) {
 		if (stextflag != STORE_NONE) {

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2712,6 +2712,10 @@ void CalcPlrInv(Player &player, bool loadgfx)
 		CalcPlrBookVals(player);
 		player.CalcScrolls();
 		CalcPlrStaff(player);
+		if (IsStashOpen) {
+			// If stash is open, ensure the items are displayed correctly
+			Stash.RefreshItemStatFlags();
+		}
 	}
 }
 

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -548,6 +548,13 @@ void StashStruct::SetPage(int newPage)
 	page = clamp(newPage, 0, CountStashPages - 1);
 }
 
+void StashStruct::RefreshItemStatFlags()
+{
+	for (auto &item : Stash.stashList) {
+		item._iStatFlag = MyPlayer->CanUseItem(item);
+	}
+}
+
 void WithdrawGoldKeyPress(char vkey)
 {
 	auto &myPlayer = Players[MyPlayerId];

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -28,6 +28,8 @@ int WithdrawGoldValue;
 
 namespace {
 
+constexpr int CountStashPages = 50;
+
 int InitialWithdrawGoldValue;
 
 /** Contains mappings for the buttons in the stash (2 navigation buttons, withdraw gold buttons, 2 navigation buttons) */
@@ -109,7 +111,7 @@ void CheckStashPaste(Point cursorPosition)
 	// Check that no more then 1 item is replaced by the move
 	uint16_t it = 0;
 	for (auto point : PointsInRectangleRange({ { 0, 0 }, itemSize })) {
-		uint16_t iv = Stash.stashGrids[Stash.page][firstSlot.x + point.x][firstSlot.y + point.y];
+		uint16_t iv = Stash.stashGrids[Stash.GetPage()][firstSlot.x + point.x][firstSlot.y + point.y];
 		if (iv == 0 || it == iv)
 			continue;
 		if (it == 0) {
@@ -131,7 +133,7 @@ void CheckStashPaste(Point cursorPosition)
 	} else {
 		stashIndex = it - 1;
 		cn = SwapItem(Stash.stashList[stashIndex], player.HoldItem);
-		for (auto &row : Stash.stashGrids[Stash.page]) {
+		for (auto &row : Stash.stashGrids[Stash.GetPage()]) {
 			for (auto &itemId : row) {
 				if (itemId == it)
 					itemId = 0;
@@ -139,7 +141,7 @@ void CheckStashPaste(Point cursorPosition)
 		}
 	}
 
-	AddItemToStashGrid(Stash.page, firstSlot, stashIndex, itemSize);
+	AddItemToStashGrid(Stash.GetPage(), firstSlot, stashIndex, itemSize);
 
 	Stash.dirty = true;
 
@@ -182,7 +184,7 @@ void CheckStashCut(Point cursorPosition, bool automaticMove, bool dropItem)
 	bool automaticallyMoved = false;
 	bool automaticallyEquipped = false;
 
-	uint16_t ii = Stash.stashGrids[Stash.page][slot.x][slot.y];
+	uint16_t ii = Stash.stashGrids[Stash.GetPage()][slot.x][slot.y];
 	if (ii != 0) {
 		uint16_t iv = ii - 1;
 
@@ -306,25 +308,24 @@ void CheckStashButtonRelease(Point mousePosition)
 	if (stashButton.Contains(mousePosition)) {
 		switch (StashButtonPressed) {
 		case 0:
-			Stash.page -= 10;
+			Stash.SetPage(Stash.GetPage() - 10);
 			break;
 		case 1:
-			Stash.page -= 1;
+			Stash.SetPage(Stash.GetPage() - 1);
 			break;
 		case 2:
 			StartGoldWithdraw();
 			break;
 		case 3:
-			Stash.page += 1;
+			Stash.SetPage(Stash.GetPage() + 1);
 			break;
 		case 4:
-			Stash.page += 10;
+			Stash.SetPage(Stash.GetPage() + 10);
 			break;
 		}
 	}
 
 	StashButtonPressed = -1;
-	Stash.page = clamp(Stash.page, 0, 49);
 }
 
 void CheckStashButtonPress(Point mousePosition)
@@ -355,17 +356,17 @@ void DrawStash(const Surface &out)
 	constexpr Displacement offset { 0, INV_SLOT_SIZE_PX - 1 };
 
 	for (auto slot : PointsInRectangleRange({ { 0, 0 }, { 10, 10 } })) {
-		if (Stash.stashGrids[Stash.page][slot.x][slot.y] != 0) {
+		if (Stash.stashGrids[Stash.GetPage()][slot.x][slot.y] != 0) {
 			InvDrawSlotBack(out, GetStashSlotCoord(slot) + offset, InventorySlotSizeInPixels);
 		}
 	}
 
 	for (auto slot : PointsInRectangleRange({ { 0, 0 }, { 10, 10 } })) {
-		if (Stash.stashGrids[Stash.page][slot.x][slot.y] == 0) {
+		if (Stash.stashGrids[Stash.GetPage()][slot.x][slot.y] == 0) {
 			continue; // No item in the given slot
 		}
 
-		uint16_t itemId = Stash.stashGrids[Stash.page][slot.x][slot.y] - 1;
+		uint16_t itemId = Stash.stashGrids[Stash.GetPage()][slot.x][slot.y] - 1;
 		if (Stash.stashList[itemId].position != slot) {
 			continue; // Not the first slot of the item
 		}
@@ -388,7 +389,7 @@ void DrawStash(const Surface &out)
 	Point position = GetPanelPosition(UiPanels::Stash);
 	UiFlags style = UiFlags::VerticalCenter | UiFlags::ColorWhite;
 
-	DrawString(out, fmt::format("{:d}", Stash.page + 1), { position + Displacement { 132, 0 }, { 57, 11 } }, UiFlags::AlignCenter | style);
+	DrawString(out, fmt::format("{:d}", Stash.GetPage() + 1), { position + Displacement { 132, 0 }, { 57, 11 } }, UiFlags::AlignCenter | style);
 	DrawString(out, fmt::format("{:d}", Stash.gold), { position + Displacement { 122, 19 }, { 107, 13 } }, UiFlags::AlignRight | style);
 }
 
@@ -423,7 +424,7 @@ uint16_t CheckStashHLight(Point mousePosition)
 
 	ClearPanel();
 
-	uint16_t itemId = abs(Stash.stashGrids[Stash.page][slot.x][slot.y]);
+	uint16_t itemId = abs(Stash.stashGrids[Stash.GetPage()][slot.x][slot.y]);
 	if (itemId == 0)
 		return -1;
 
@@ -510,7 +511,7 @@ bool UseStashItem(uint16_t c)
 void StashStruct::RemoveStashItem(uint16_t iv)
 {
 	// Iterate through stashGrid and remove every reference to item
-	for (auto &row : Stash.stashGrids[Stash.page]) {
+	for (auto &row : Stash.stashGrids[Stash.GetPage()]) {
 		for (uint16_t &itemId : row) {
 			if (itemId - 1 == iv) {
 				itemId = 0;
@@ -540,6 +541,11 @@ void StashStruct::RemoveStashItem(uint16_t iv)
 	}
 	stashList.pop_back();
 	Stash.dirty = true;
+}
+
+void StashStruct::SetPage(int newPage)
+{
+	page = clamp(newPage, 0, CountStashPages - 1);
 }
 
 void WithdrawGoldKeyPress(char vkey)
@@ -625,11 +631,9 @@ bool AutoPlaceItemInStash(Player &player, const Item &item, bool persistItem)
 
 	Size itemSize = GetInventorySize(item);
 
-	constexpr int CountStashPages = 50;
-
 	// Try to add the item to the current active page and if it's not possible move forward
 	for (int pageCounter = 0; pageCounter < CountStashPages; pageCounter++) {
-		int pageIndex = Stash.page + pageCounter;
+		int pageIndex = Stash.GetPage() + pageCounter;
 		// Wrap around if needed
 		if (pageIndex >= CountStashPages)
 			pageIndex -= CountStashPages;

--- a/Source/qol/stash.h
+++ b/Source/qol/stash.h
@@ -14,14 +14,24 @@
 
 namespace devilution {
 
-struct StashStruct {
+class StashStruct {
+public:
 	void RemoveStashItem(uint16_t iv);
 	std::map<int, std::array<std::array<uint16_t, 10>, 10>> stashGrids;
 	std::vector<Item> stashList;
 	int gold;
+	bool dirty = false;
+
+	int GetPage() const
+	{
+		return page;
+	}
+
+	void SetPage(int newPage);
+
+private:
 	/** Current Page */
 	int page;
-	bool dirty = false;
 };
 
 constexpr Point InvalidStashPoint { -1, -1 };

--- a/Source/qol/stash.h
+++ b/Source/qol/stash.h
@@ -28,6 +28,8 @@ public:
 	}
 
 	void SetPage(int newPage);
+	/** @brief Updates _iStatFlag for all stash items. */
+	void RefreshItemStatFlags();
 
 private:
 	/** Current Page */

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2169,6 +2169,7 @@ void BarmaidEnter()
 	case 14:
 		stextflag = STORE_NONE;
 		IsStashOpen = true;
+		Stash.RefreshItemStatFlags();
 		invflag = true;
 		if (ControlMode != ControlTypes::KeyboardAndMouse) {
 			if (pcurs == CURSOR_DISARM)


### PR DESCRIPTION
Fixes a issue mentioned in stash pr #3853

> If a player doesn't have the requirements of an item it is placed on the stash tinted as red, if another player opens the stash it will be still red. The opposite is also true, items show colored even if the player doesn't have the requirements

This pr updates `_iStatFlag` for the active page when opening the stash or changing the active page.
This pr also reduces the number of places where max stash pages are defined.