### PR TITLE
Allow to swap items with ctrl+click between inventory and stash

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -895,8 +895,13 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 		}
 	}
 
-	if (dropItem) {
-		TryDropItem();
+	if (dropItem && !holdItem.isEmpty()) {
+		if (IsStashOpen && AutoPlaceItemInStash(player, holdItem, true)) {
+			holdItem._itype = ItemType::None;
+			NewCursor(CURSOR_HAND);
+		} else {
+			TryDropItem();
+		}
 	}
 }
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -158,19 +158,6 @@ void AddItemToInvGrid(Player &player, int invGridIndex, int invListIndex, Size i
 }
 
 /**
- * @brief Gets the size, in inventory cells, of the given item.
- * @param item The item whose size is to be determined.
- * @return The size, in inventory cells, of the item.
- */
-Size GetInventorySize(const Item &item)
-{
-	int itemSizeIndex = item._iCurs + CURSOR_FIRSTITEM;
-	auto size = GetInvItemSize(itemSizeIndex);
-
-	return { size.width / InventorySlotSizeInPixels.width, size.height / InventorySlotSizeInPixels.height };
-}
-
-/**
  * @brief Checks whether the given item can fit in a belt slot (i.e. the item's size in inventory cells is 1x1).
  * @param item The item to be checked.
  * @return 'True' in case the item can fit a belt slot and 'False' otherwise.
@@ -2205,6 +2192,14 @@ bool DropItemBeforeTrig()
 	NetSendCmdPItem(true, CMD_PUTITEM, cursPosition, Players[MyPlayerId].HoldItem);
 	NewCursor(CURSOR_HAND);
 	return true;
+}
+
+Size GetInventorySize(const Item &item)
+{
+	int itemSizeIndex = item._iCurs + CURSOR_FIRSTITEM;
+	auto size = GetInvItemSize(itemSizeIndex);
+
+	return { size.width / InventorySlotSizeInPixels.width, size.height / InventorySlotSizeInPixels.height };
 }
 
 } // namespace devilution

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -196,6 +196,13 @@ void DoTelekinesis();
 int CalculateGold(Player &player);
 bool DropItemBeforeTrig();
 
+/**
+ * @brief Gets the size, in inventory cells, of the given item.
+ * @param item The item whose size is to be determined.
+ * @return The size, in inventory cells, of the item.
+ */
+Size GetInventorySize(const Item &item);
+
 /* data */
 
 } // namespace devilution

--- a/Source/qol/stash.h
+++ b/Source/qol/stash.h
@@ -50,4 +50,13 @@ void DrawGoldWithdraw(const Surface &out, int amount);
 void CloseGoldWithdraw();
 void GoldWithdrawNewText(string_view text);
 
+/**
+ * @brief Checks whether the given item can be placed on the specified player's stash.
+ * If 'persistItem' is 'True', the item is also placed in the inventory.
+ * @param item The item to be checked.
+ * @param persistItem Pass 'True' to actually place the item in the inventory. The default is 'False'.
+ * @return 'True' in case the item can be placed on the player's inventory and 'False' otherwise.
+ */
+bool AutoPlaceItemInStash(Player &player, const Item &item, bool persistItem);
+
 } // namespace devilution


### PR DESCRIPTION
With this pr we can fill the brand new stash faster. 😁

## Notes
- If inventory is full the item is still dropped on the ground.
- If stash (unlikely) is full the item is still dropped on the ground.
- If a stash page is full the item will be placed on the next stash page. If we are on the last stash page the algorithm starts with page 1 again.
- Needs to be rebased if #4172 is merged before (cause of the usage of `Stash.page`).

## Example Video
https://user-images.githubusercontent.com/25415264/159096311-ae1f41e4-8e8b-43c9-95eb-d3619f46b2c8.mp4


