### PR TITLE
Allow identify/oil/repair/recharge on stash items

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1843,9 +1843,14 @@ bool TryIconCurs()
 	}
 
 	if (pcurs == CURSOR_OIL) {
+		bool changeCursor = true;
 		if (pcursinvitem != -1)
-			DoOil(myPlayer, pcursinvitem);
-		else
+			changeCursor = DoOil(myPlayer, pcursinvitem);
+		else if (pcursstashitem != uint16_t(-1)) {
+			Item &item = Stash.stashList[pcursstashitem];
+			changeCursor = ApplyOilToItem(item, myPlayer);
+		}
+		if (changeCursor)
 			NewCursor(CURSOR_HAND);
 		return true;
 	}

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1834,8 +1834,11 @@ bool TryIconCurs()
 	if (pcurs == CURSOR_RECHARGE) {
 		if (pcursinvitem != -1)
 			DoRecharge(myPlayer, pcursinvitem);
-		else
-			NewCursor(CURSOR_HAND);
+		else if (pcursstashitem != uint16_t(-1)) {
+			Item &item = Stash.stashList[pcursstashitem];
+			RechargeItem(item, myPlayer);
+		}
+		NewCursor(CURSOR_HAND);
 		return true;
 	}
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1823,8 +1823,11 @@ bool TryIconCurs()
 	if (pcurs == CURSOR_REPAIR) {
 		if (pcursinvitem != -1)
 			DoRepair(myPlayer, pcursinvitem);
-		else
-			NewCursor(CURSOR_HAND);
+		else if (pcursstashitem != uint16_t(-1)) {
+			Item &item = Stash.stashList[pcursstashitem];
+			RepairItem(item, myPlayer._pLevel);
+		}
+		NewCursor(CURSOR_HAND);
 		return true;
 	}
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1812,8 +1812,11 @@ bool TryIconCurs()
 	if (pcurs == CURSOR_IDENTIFY) {
 		if (pcursinvitem != -1)
 			CheckIdentify(myPlayer, pcursinvitem);
-		else
-			NewCursor(CURSOR_HAND);
+		else if (pcursstashitem != uint16_t(-1)) {
+			Item &item = Stash.stashList[pcursstashitem];
+			item._iIdentified = true;
+		}
+		NewCursor(CURSOR_HAND);
 		return true;
 	}
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3629,9 +3629,6 @@ void CheckIdentify(Player &player, int cii)
 
 	pi->_iIdentified = true;
 	CalcPlrInv(player, true);
-
-	if (&player == &Players[MyPlayerId])
-		NewCursor(CURSOR_HAND);
 }
 
 void DoRepair(Player &player, int cii)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1692,115 +1692,6 @@ void ItemDoppel()
 		idoppely = 16;
 }
 
-bool ApplyOilToItem(Item &item, Player &player)
-{
-	int r;
-
-	if (item._iClass == ICLASS_MISC) {
-		return false;
-	}
-	if (item._iClass == ICLASS_GOLD) {
-		return false;
-	}
-	if (item._iClass == ICLASS_QUEST) {
-		return false;
-	}
-
-	switch (player._pOilType) {
-	case IMISC_OILACC:
-	case IMISC_OILMAST:
-	case IMISC_OILSHARP:
-		if (item._iClass == ICLASS_ARMOR) {
-			return false;
-		}
-		break;
-	case IMISC_OILDEATH:
-		if (item._iClass == ICLASS_ARMOR) {
-			return false;
-		}
-		if (item._itype == ItemType::Bow) {
-			return false;
-		}
-		break;
-	case IMISC_OILHARD:
-	case IMISC_OILIMP:
-		if (item._iClass == ICLASS_WEAPON) {
-			return false;
-		}
-		break;
-	default:
-		break;
-	}
-
-	switch (player._pOilType) {
-	case IMISC_OILACC:
-		if (item._iPLToHit < 50) {
-			item._iPLToHit += GenerateRnd(2) + 1;
-		}
-		break;
-	case IMISC_OILMAST:
-		if (item._iPLToHit < 100) {
-			item._iPLToHit += GenerateRnd(3) + 3;
-		}
-		break;
-	case IMISC_OILSHARP:
-		if (item._iMaxDam - item._iMinDam < 30) {
-			item._iMaxDam = item._iMaxDam + 1;
-		}
-		break;
-	case IMISC_OILDEATH:
-		if (item._iMaxDam - item._iMinDam < 30) {
-			item._iMinDam = item._iMinDam + 1;
-			item._iMaxDam = item._iMaxDam + 2;
-		}
-		break;
-	case IMISC_OILSKILL:
-		r = GenerateRnd(6) + 5;
-		item._iMinStr = std::max(0, item._iMinStr - r);
-		item._iMinMag = std::max(0, item._iMinMag - r);
-		item._iMinDex = std::max(0, item._iMinDex - r);
-		break;
-	case IMISC_OILBSMTH:
-		if (item._iMaxDur == DUR_INDESTRUCTIBLE)
-			return true;
-		if (item._iDurability < item._iMaxDur) {
-			item._iDurability = (item._iMaxDur + 4) / 5 + item._iDurability;
-			item._iDurability = std::min<int>(item._iDurability, item._iMaxDur);
-		} else {
-			if (item._iMaxDur >= 100) {
-				return true;
-			}
-			item._iMaxDur++;
-			item._iDurability = item._iMaxDur;
-		}
-		break;
-	case IMISC_OILFORT:
-		if (item._iMaxDur != DUR_INDESTRUCTIBLE && item._iMaxDur < 200) {
-			r = GenerateRnd(41) + 10;
-			item._iMaxDur += r;
-			item._iDurability += r;
-		}
-		break;
-	case IMISC_OILPERM:
-		item._iDurability = DUR_INDESTRUCTIBLE;
-		item._iMaxDur = DUR_INDESTRUCTIBLE;
-		break;
-	case IMISC_OILHARD:
-		if (item._iAC < 60) {
-			item._iAC += GenerateRnd(2) + 1;
-		}
-		break;
-	case IMISC_OILIMP:
-		if (item._iAC < 120) {
-			item._iAC += GenerateRnd(3) + 3;
-		}
-		break;
-	default:
-		return false;
-	}
-	return true;
-}
-
 void PrintItemOil(char iDidx)
 {
 	switch (iDidx) {
@@ -3621,7 +3512,7 @@ void DoRecharge(Player &player, int cii)
 	CalcPlrInv(player, true);
 }
 
-void DoOil(Player &player, int cii)
+bool DoOil(Player &player, int cii)
 {
 	Item *pi;
 	if (cii >= NUM_INVLOC) {
@@ -3630,10 +3521,9 @@ void DoOil(Player &player, int cii)
 		pi = &player.InvBody[cii];
 	}
 	if (!ApplyOilToItem(*pi, player))
-		return;
+		return false;
 	CalcPlrInv(player, true);
-	if (&player == &Players[MyPlayerId])
-		NewCursor(CURSOR_HAND);
+	return true;
 }
 
 [[nodiscard]] std::string PrintItemPower(char plidx, const Item &item)
@@ -4763,6 +4653,115 @@ void RechargeItem(Item &item, Player &player)
 	} while (item._iCharges < item._iMaxCharges);
 
 	item._iCharges = std::min(item._iCharges, item._iMaxCharges);
+}
+
+bool ApplyOilToItem(Item &item, Player &player)
+{
+	int r;
+
+	if (item._iClass == ICLASS_MISC) {
+		return false;
+	}
+	if (item._iClass == ICLASS_GOLD) {
+		return false;
+	}
+	if (item._iClass == ICLASS_QUEST) {
+		return false;
+	}
+
+	switch (player._pOilType) {
+	case IMISC_OILACC:
+	case IMISC_OILMAST:
+	case IMISC_OILSHARP:
+		if (item._iClass == ICLASS_ARMOR) {
+			return false;
+		}
+		break;
+	case IMISC_OILDEATH:
+		if (item._iClass == ICLASS_ARMOR) {
+			return false;
+		}
+		if (item._itype == ItemType::Bow) {
+			return false;
+		}
+		break;
+	case IMISC_OILHARD:
+	case IMISC_OILIMP:
+		if (item._iClass == ICLASS_WEAPON) {
+			return false;
+		}
+		break;
+	default:
+		break;
+	}
+
+	switch (player._pOilType) {
+	case IMISC_OILACC:
+		if (item._iPLToHit < 50) {
+			item._iPLToHit += GenerateRnd(2) + 1;
+		}
+		break;
+	case IMISC_OILMAST:
+		if (item._iPLToHit < 100) {
+			item._iPLToHit += GenerateRnd(3) + 3;
+		}
+		break;
+	case IMISC_OILSHARP:
+		if (item._iMaxDam - item._iMinDam < 30) {
+			item._iMaxDam = item._iMaxDam + 1;
+		}
+		break;
+	case IMISC_OILDEATH:
+		if (item._iMaxDam - item._iMinDam < 30) {
+			item._iMinDam = item._iMinDam + 1;
+			item._iMaxDam = item._iMaxDam + 2;
+		}
+		break;
+	case IMISC_OILSKILL:
+		r = GenerateRnd(6) + 5;
+		item._iMinStr = std::max(0, item._iMinStr - r);
+		item._iMinMag = std::max(0, item._iMinMag - r);
+		item._iMinDex = std::max(0, item._iMinDex - r);
+		break;
+	case IMISC_OILBSMTH:
+		if (item._iMaxDur == DUR_INDESTRUCTIBLE)
+			return true;
+		if (item._iDurability < item._iMaxDur) {
+			item._iDurability = (item._iMaxDur + 4) / 5 + item._iDurability;
+			item._iDurability = std::min<int>(item._iDurability, item._iMaxDur);
+		} else {
+			if (item._iMaxDur >= 100) {
+				return true;
+			}
+			item._iMaxDur++;
+			item._iDurability = item._iMaxDur;
+		}
+		break;
+	case IMISC_OILFORT:
+		if (item._iMaxDur != DUR_INDESTRUCTIBLE && item._iMaxDur < 200) {
+			r = GenerateRnd(41) + 10;
+			item._iMaxDur += r;
+			item._iDurability += r;
+		}
+		break;
+	case IMISC_OILPERM:
+		item._iDurability = DUR_INDESTRUCTIBLE;
+		item._iMaxDur = DUR_INDESTRUCTIBLE;
+		break;
+	case IMISC_OILHARD:
+		if (item._iAC < 60) {
+			item._iAC += GenerateRnd(2) + 1;
+		}
+		break;
+	case IMISC_OILIMP:
+		if (item._iAC < 120) {
+			item._iAC += GenerateRnd(3) + 3;
+		}
+		break;
+	default:
+		return false;
+	}
+	return true;
 }
 
 } // namespace devilution

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1692,30 +1692,6 @@ void ItemDoppel()
 		idoppely = 16;
 }
 
-void RepairItem(Item &item, int lvl)
-{
-	if (item._iDurability == item._iMaxDur) {
-		return;
-	}
-
-	if (item._iMaxDur <= 0) {
-		item._itype = ItemType::None;
-		return;
-	}
-
-	int rep = 0;
-	do {
-		rep += lvl + GenerateRnd(lvl);
-		item._iMaxDur -= std::max(item._iMaxDur / (lvl + 9), 1);
-		if (item._iMaxDur == 0) {
-			item._itype = ItemType::None;
-			return;
-		}
-	} while (rep + item._iDurability < item._iMaxDur);
-
-	item._iDurability = std::min<int>(item._iDurability + rep, item._iMaxDur);
-}
-
 void RechargeItem(Item &item, int r)
 {
 	if (item._iCharges == item._iMaxCharges)
@@ -3645,9 +3621,6 @@ void DoRepair(Player &player, int cii)
 
 	RepairItem(*pi, player._pLevel);
 	CalcPlrInv(player, true);
-
-	if (&player == &Players[MyPlayerId])
-		NewCursor(CURSOR_HAND);
 }
 
 void DoRecharge(Player &player, int cii)
@@ -4766,6 +4739,30 @@ void initItemGetRecords()
 {
 	memset(itemrecord, 0, sizeof(itemrecord));
 	gnNumGetRecords = 0;
+}
+
+void RepairItem(Item &item, int lvl)
+{
+	if (item._iDurability == item._iMaxDur) {
+		return;
+	}
+
+	if (item._iMaxDur <= 0) {
+		item._itype = ItemType::None;
+		return;
+	}
+
+	int rep = 0;
+	do {
+		rep += lvl + GenerateRnd(lvl);
+		item._iMaxDur -= std::max(item._iMaxDur / (lvl + 9), 1);
+		if (item._iMaxDur == 0) {
+			item._itype = ItemType::None;
+			return;
+		}
+	} while (rep + item._iDurability < item._iMaxDur);
+
+	item._iDurability = std::min<int>(item._iDurability + rep, item._iMaxDur);
 }
 
 } // namespace devilution

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1692,22 +1692,6 @@ void ItemDoppel()
 		idoppely = 16;
 }
 
-void RechargeItem(Item &item, int r)
-{
-	if (item._iCharges == item._iMaxCharges)
-		return;
-
-	do {
-		item._iMaxCharges--;
-		if (item._iMaxCharges == 0) {
-			return;
-		}
-		item._iCharges += r;
-	} while (item._iCharges < item._iMaxCharges);
-
-	item._iCharges = std::min(item._iCharges, item._iMaxCharges);
-}
-
 bool ApplyOilToItem(Item &item, Player &player)
 {
 	int r;
@@ -3632,15 +3616,9 @@ void DoRecharge(Player &player, int cii)
 	} else {
 		pi = &player.InvBody[cii];
 	}
-	if (pi->_itype == ItemType::Staff && pi->_iSpell != SPL_NULL) {
-		int r = GetSpellBookLevel(pi->_iSpell);
-		r = GenerateRnd(player._pLevel / r) + 1;
-		RechargeItem(*pi, r);
-		CalcPlrInv(player, true);
-	}
 
-	if (&player == &Players[MyPlayerId])
-		NewCursor(CURSOR_HAND);
+	RechargeItem(*pi, player);
+	CalcPlrInv(player, true);
 }
 
 void DoOil(Player &player, int cii)
@@ -4763,6 +4741,28 @@ void RepairItem(Item &item, int lvl)
 	} while (rep + item._iDurability < item._iMaxDur);
 
 	item._iDurability = std::min<int>(item._iDurability + rep, item._iMaxDur);
+}
+
+void RechargeItem(Item &item, Player &player)
+{
+	if (item._itype != ItemType::Staff || item._iSpell == SPL_NULL)
+		return;
+
+	if (item._iCharges == item._iMaxCharges)
+		return;
+
+	int r = GetSpellBookLevel(item._iSpell);
+	r = GenerateRnd(player._pLevel / r) + 1;
+
+	do {
+		item._iMaxCharges--;
+		if (item._iMaxCharges == 0) {
+			return;
+		}
+		item._iCharges += r;
+	} while (item._iCharges < item._iMaxCharges);
+
+	item._iCharges = std::min(item._iCharges, item._iMaxCharges);
 }
 
 } // namespace devilution

--- a/Source/items.h
+++ b/Source/items.h
@@ -474,7 +474,7 @@ void GetItemStr(Item &item);
 void CheckIdentify(Player &player, int cii);
 void DoRepair(Player &player, int cii);
 void DoRecharge(Player &player, int cii);
-void DoOil(Player &player, int cii);
+bool DoOil(Player &player, int cii);
 [[nodiscard]] std::string PrintItemPower(char plidx, const Item &item);
 void DrawUniqueInfo(const Surface &out);
 void PrintItemDetails(const Item &item);
@@ -504,6 +504,7 @@ void initItemGetRecords();
 
 void RepairItem(Item &item, int lvl);
 void RechargeItem(Item &item, Player &player);
+bool ApplyOilToItem(Item &item, Player &player);
 
 #ifdef _DEBUG
 std::string DebugSpawnItem(std::string itemName);

--- a/Source/items.h
+++ b/Source/items.h
@@ -502,6 +502,8 @@ void PutItemRecord(int nSeed, uint16_t wCI, int nIndex);
  */
 void initItemGetRecords();
 
+void RepairItem(Item &item, int lvl);
+
 #ifdef _DEBUG
 std::string DebugSpawnItem(std::string itemName);
 std::string DebugSpawnUniqueItem(std::string itemName);

--- a/Source/items.h
+++ b/Source/items.h
@@ -503,6 +503,7 @@ void PutItemRecord(int nSeed, uint16_t wCI, int nIndex);
 void initItemGetRecords();
 
 void RepairItem(Item &item, int lvl);
+void RechargeItem(Item &item, Player &player);
 
 #ifdef _DEBUG
 std::string DebugSpawnItem(std::string itemName);


### PR DESCRIPTION
Fixes a issue mentioned in stash pr #3853

> It's not possible to use or cast spells on items in the stash