### PR TITLE
Allow to consume items from stash

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -397,15 +397,16 @@ void RightMouseDown(bool isShiftHeld)
 		SetSpell();
 		return;
 	}
-	if ((!sbookflag || !GetRightPanel().Contains(MousePosition))
-	    && !TryIconCurs()
-	    && (pcursinvitem == -1 || !UseInvItem(MyPlayerId, pcursinvitem))) {
-		if (pcurs == CURSOR_HAND) {
-			if (pcursinvitem == -1 || !UseInvItem(MyPlayerId, pcursinvitem))
-				CheckPlrSpell(isShiftHeld);
-		} else if (pcurs > CURSOR_HAND && pcurs < CURSOR_FIRSTITEM) {
-			NewCursor(CURSOR_HAND);
-		}
+	if (sbookflag && GetRightPanel().Contains(MousePosition))
+		return;
+	if (TryIconCurs())
+		return;
+	if (pcursinvitem != -1 && UseInvItem(MyPlayerId, pcursinvitem))
+		return;
+	if (pcurs == CURSOR_HAND) {
+		CheckPlrSpell(isShiftHeld);
+	} else if (pcurs > CURSOR_HAND && pcurs < CURSOR_FIRSTITEM) {
+		NewCursor(CURSOR_HAND);
 	}
 }
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -403,6 +403,8 @@ void RightMouseDown(bool isShiftHeld)
 		return;
 	if (pcursinvitem != -1 && UseInvItem(MyPlayerId, pcursinvitem))
 		return;
+	if (pcursstashitem != uint16_t(-1) && UseStashItem(pcursstashitem))
+		return;
 	if (pcurs == CURSOR_HAND) {
 		CheckPlrSpell(isShiftHeld);
 	} else if (pcurs > CURSOR_HAND && pcurs < CURSOR_FIRSTITEM) {

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -476,7 +476,7 @@ bool UseStashItem(uint16_t c)
 		WithdrawGoldValue = 0;
 	}
 
-	if (item->IsScroll() && currlevel == 0 && !spelldata[item->_iSpell].sTownSpell) {
+	if (item->IsScroll()) {
 		return true;
 	}
 


### PR DESCRIPTION
With this pr it is possible to use/consume items from stash (for example a potion).

Notes
- I tried to simplify `RightMouseDown` and removed a redundant call to `UseInvItem`. i would appreciate if someone could double check this.
- For now i disabled the use/consume of scrolls from stash. This would make fixing double cast bug harder. For more details see this [discussion](https://github.com/diasurgical/devilutionX/pull/3853#issuecomment-1072957281).