### PR TITLE
Remove the use of HoldItem in AutoGetItem

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -372,7 +372,7 @@ void RemoveGold(Player &player, int goldIndex)
 	SetGoldSeed(player, player.HoldItem);
 	player.HoldItem._ivalue = dropGoldValue;
 	player.HoldItem._iStatFlag = true;
-	ControlSetGoldCurs(player);
+	ControlSetGoldCurs(player.HoldItem);
 	player._pGold = CalculateGold(player);
 	dropGoldValue = 0;
 }
@@ -397,10 +397,10 @@ bool IsLevelUpButtonVisible()
 
 } // namespace
 
-void ControlSetGoldCurs(Player &player)
+void ControlSetGoldCurs(Item &goldItem)
 {
-	SetPlrHandGoldCurs(player.HoldItem);
-	NewCursor(player.HoldItem._iCurs + CURSOR_FIRSTITEM);
+	SetPlrHandGoldCurs(goldItem);
+	NewCursor(goldItem._iCurs + CURSOR_FIRSTITEM);
 }
 
 void CalculatePanelAreas()

--- a/Source/control.h
+++ b/Source/control.h
@@ -68,7 +68,7 @@ inline bool CanPanelsCoverView()
 {
 	return GetScreenWidth() <= PANEL_WIDTH && GetScreenHeight() <= SPANEL_HEIGHT + PANEL_HEIGHT;
 }
-void ControlSetGoldCurs(Player &player);
+void ControlSetGoldCurs(Item &goldItem);
 
 void DrawSpellList(const Surface &out);
 void SetSpell();

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -867,7 +867,7 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 		}
 
 		CalcPlrInv(player, true);
-		CheckItemStats(player);
+		holdItem._iStatFlag = player.CanUseItem(holdItem);
 
 		if (pnum == MyPlayerId) {
 			if (automaticallyEquipped) {
@@ -1599,13 +1599,6 @@ void CheckInvScrn(bool isShiftHeld, bool isCtrlHeld)
 	}
 }
 
-void CheckItemStats(Player &player)
-{
-	Item &item = player.HoldItem;
-
-	item._iStatFlag = player.CanUseItem(item);
-}
-
 void InvGetItem(int pnum, int ii)
 {
 	auto &item = Items[ii];
@@ -1626,7 +1619,7 @@ void InvGetItem(int pnum, int ii)
 	player.HoldItem = item;
 	CheckQuestItem(player);
 	UpdateBookLevel(player, player.HoldItem);
-	CheckItemStats(player);
+	player.HoldItem._iStatFlag = player.CanUseItem(player.HoldItem);
 	bool cursorUpdated = false;
 	if (player.HoldItem._itype == ItemType::Gold && GoldAutoPlace(player, player.HoldItem))
 		cursorUpdated = true;
@@ -1659,7 +1652,7 @@ void AutoGetItem(int pnum, Item *item, int ii)
 	player.HoldItem = *item; /// BUGFIX: overwrites cursor item, allowing for belt dupe bug
 	CheckQuestItem(player);
 	UpdateBookLevel(player, player.HoldItem);
-	CheckItemStats(player);
+	player.HoldItem._iStatFlag = player.CanUseItem(player.HoldItem);
 	SetICursor(player.HoldItem._iCurs + CURSOR_FIRSTITEM);
 	if (player.HoldItem._itype == ItemType::Gold) {
 		done = GoldAutoPlace(player, player.HoldItem);

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1147,7 +1147,6 @@ bool GoldAutoPlaceInInventorySlot(Player &player, int slotIndex, Item &goldStack
 
 	goldStack._ivalue = 0;
 	player._pGold = CalculateGold(player);
-	NewCursor(CURSOR_HAND);
 
 	return true;
 }
@@ -1633,10 +1632,6 @@ void AutoGetItem(int pnum, Item *itemPointer, int ii)
 {
 	Item &item = *itemPointer;
 	auto &player = Players[pnum];
-
-	if (pcurs != CURSOR_HAND) {
-		return;
-	}
 
 	if (dropGoldFlag) {
 		CloseGoldDrop();

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -923,9 +923,9 @@ void UpdateBookLevel(Player &player, Item &book)
 	}
 }
 
-void CheckNaKrulNotes(Player &player)
+void TryCombineNaKrulNotes(Player &player, Item &noteItem)
 {
-	int idx = player.HoldItem.IDidx;
+	int idx = noteItem.IDidx;
 	_item_indexes notes[] = { IDI_NOTE1, IDI_NOTE2, IDI_NOTE3 };
 
 	if (IsNoneOf(idx, IDI_NOTE1, IDI_NOTE2, IDI_NOTE3)) {
@@ -946,9 +946,9 @@ void CheckNaKrulNotes(Player &player)
 		}
 	}
 
-	player.HoldItem = {};
-	GetItemAttrs(player.HoldItem, IDI_FULLNOTE, 16);
-	SetupItem(player.HoldItem);
+	noteItem = {};
+	GetItemAttrs(noteItem, IDI_FULLNOTE, 16);
+	SetupItem(noteItem);
 }
 
 void CheckQuestItem(Player &player)
@@ -999,7 +999,7 @@ void CheckQuestItem(Player &player)
 		}
 	}
 
-	CheckNaKrulNotes(player);
+	TryCombineNaKrulNotes(player, player.HoldItem);
 }
 
 void OpenHive()

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -906,18 +906,18 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 	}
 }
 
-void CheckBookLevel(Player &player)
+void UpdateBookLevel(Player &player, Item &book)
 {
-	if (player.HoldItem._iMiscId != IMISC_BOOK)
+	if (book._iMiscId != IMISC_BOOK)
 		return;
 
-	player.HoldItem._iMinMag = spelldata[player.HoldItem._iSpell].sMinInt;
-	int8_t spellLevel = player._pSplLvl[player.HoldItem._iSpell];
+	book._iMinMag = spelldata[book._iSpell].sMinInt;
+	int8_t spellLevel = player._pSplLvl[book._iSpell];
 	while (spellLevel != 0) {
-		player.HoldItem._iMinMag += 20 * player.HoldItem._iMinMag / 100;
+		book._iMinMag += 20 * book._iMinMag / 100;
 		spellLevel--;
-		if (player.HoldItem._iMinMag + 20 * player.HoldItem._iMinMag / 100 > 255) {
-			player.HoldItem._iMinMag = -1;
+		if (book._iMinMag + 20 * book._iMinMag / 100 > 255) {
+			book._iMinMag = -1;
 			spellLevel = 0;
 		}
 	}
@@ -1625,7 +1625,7 @@ void InvGetItem(int pnum, int ii)
 	item._iCreateInfo &= ~CF_PREGEN;
 	player.HoldItem = item;
 	CheckQuestItem(player);
-	CheckBookLevel(player);
+	UpdateBookLevel(player, player.HoldItem);
 	CheckItemStats(player);
 	bool cursorUpdated = false;
 	if (player.HoldItem._itype == ItemType::Gold && GoldAutoPlace(player, player.HoldItem))
@@ -1658,7 +1658,7 @@ void AutoGetItem(int pnum, Item *item, int ii)
 	item->_iCreateInfo &= ~CF_PREGEN;
 	player.HoldItem = *item; /// BUGFIX: overwrites cursor item, allowing for belt dupe bug
 	CheckQuestItem(player);
-	CheckBookLevel(player);
+	UpdateBookLevel(player, player.HoldItem);
 	CheckItemStats(player);
 	SetICursor(player.HoldItem._iCurs + CURSOR_FIRSTITEM);
 	if (player.HoldItem._itype == ItemType::Gold) {

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -951,19 +951,19 @@ void TryCombineNaKrulNotes(Player &player, Item &noteItem)
 	SetupItem(noteItem);
 }
 
-void CheckQuestItem(Player &player)
+void CheckQuestItem(Player &player, Item &questItem)
 {
 	auto &myPlayer = Players[MyPlayerId];
 
-	if (player.HoldItem.IDidx == IDI_OPTAMULET && Quests[Q_BLIND]._qactive == QUEST_ACTIVE)
+	if (questItem.IDidx == IDI_OPTAMULET && Quests[Q_BLIND]._qactive == QUEST_ACTIVE)
 		Quests[Q_BLIND]._qactive = QUEST_DONE;
 
-	if (player.HoldItem.IDidx == IDI_MUSHROOM && Quests[Q_MUSHROOM]._qactive == QUEST_ACTIVE && Quests[Q_MUSHROOM]._qvar1 == QS_MUSHSPAWNED) {
+	if (questItem.IDidx == IDI_MUSHROOM && Quests[Q_MUSHROOM]._qactive == QUEST_ACTIVE && Quests[Q_MUSHROOM]._qvar1 == QS_MUSHSPAWNED) {
 		player.Say(HeroSpeech::NowThatsOneBigMushroom, 10); // BUGFIX: Voice for this quest might be wrong in MP
 		Quests[Q_MUSHROOM]._qvar1 = QS_MUSHPICKED;
 	}
 
-	if (player.HoldItem.IDidx == IDI_ANVIL && Quests[Q_ANVIL]._qactive != QUEST_NOTAVAIL) {
+	if (questItem.IDidx == IDI_ANVIL && Quests[Q_ANVIL]._qactive != QUEST_NOTAVAIL) {
 		if (Quests[Q_ANVIL]._qactive == QUEST_INIT) {
 			Quests[Q_ANVIL]._qactive = QUEST_ACTIVE;
 		}
@@ -972,11 +972,11 @@ void CheckQuestItem(Player &player)
 		}
 	}
 
-	if (player.HoldItem.IDidx == IDI_GLDNELIX && Quests[Q_VEIL]._qactive != QUEST_NOTAVAIL) {
+	if (questItem.IDidx == IDI_GLDNELIX && Quests[Q_VEIL]._qactive != QUEST_NOTAVAIL) {
 		myPlayer.Say(HeroSpeech::INeedToGetThisToLachdanan, 30);
 	}
 
-	if (player.HoldItem.IDidx == IDI_ROCK && Quests[Q_ROCK]._qactive != QUEST_NOTAVAIL) {
+	if (questItem.IDidx == IDI_ROCK && Quests[Q_ROCK]._qactive != QUEST_NOTAVAIL) {
 		if (Quests[Q_ROCK]._qactive == QUEST_INIT) {
 			Quests[Q_ROCK]._qactive = QUEST_ACTIVE;
 		}
@@ -985,12 +985,12 @@ void CheckQuestItem(Player &player)
 		}
 	}
 
-	if (player.HoldItem.IDidx == IDI_ARMOFVAL && Quests[Q_BLOOD]._qactive == QUEST_ACTIVE) {
+	if (questItem.IDidx == IDI_ARMOFVAL && Quests[Q_BLOOD]._qactive == QUEST_ACTIVE) {
 		Quests[Q_BLOOD]._qactive = QUEST_DONE;
 		myPlayer.Say(HeroSpeech::MayTheSpiritOfArkaineProtectMe, 20);
 	}
 
-	if (player.HoldItem.IDidx == IDI_MAPOFDOOM) {
+	if (questItem.IDidx == IDI_MAPOFDOOM) {
 		Quests[Q_GRAVE]._qlog = false;
 		Quests[Q_GRAVE]._qactive = QUEST_ACTIVE;
 		if (Quests[Q_GRAVE]._qvar1 != 1) {
@@ -999,7 +999,7 @@ void CheckQuestItem(Player &player)
 		}
 	}
 
-	TryCombineNaKrulNotes(player, player.HoldItem);
+	TryCombineNaKrulNotes(player, questItem);
 }
 
 void OpenHive()
@@ -1617,7 +1617,7 @@ void InvGetItem(int pnum, int ii)
 
 	item._iCreateInfo &= ~CF_PREGEN;
 	player.HoldItem = item;
-	CheckQuestItem(player);
+	CheckQuestItem(player, player.HoldItem);
 	UpdateBookLevel(player, player.HoldItem);
 	player.HoldItem._iStatFlag = player.CanUseItem(player.HoldItem);
 	bool cursorUpdated = false;
@@ -1650,7 +1650,7 @@ void AutoGetItem(int pnum, Item *item, int ii)
 
 	item->_iCreateInfo &= ~CF_PREGEN;
 	player.HoldItem = *item; /// BUGFIX: overwrites cursor item, allowing for belt dupe bug
-	CheckQuestItem(player);
+	CheckQuestItem(player, player.HoldItem);
 	UpdateBookLevel(player, player.HoldItem);
 	player.HoldItem._iStatFlag = player.CanUseItem(player.HoldItem);
 	SetICursor(player.HoldItem._iCurs + CURSOR_FIRSTITEM);

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -168,7 +168,6 @@ void CheckInvItem(bool isShiftHeld = false, bool isCtrlHeld = false);
  * Check for interactions with belt
  */
 void CheckInvScrn(bool isShiftHeld, bool isCtrlHeld);
-void CheckItemStats(Player &player);
 void InvGetItem(int pnum, int ii);
 void AutoGetItem(int pnum, Item *item, int ii);
 

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -202,7 +202,7 @@ void CheckStashCut(Point cursorPosition, bool automaticMove, bool dropItem)
 
 	if (!holdItem.isEmpty()) {
 		CalcPlrInv(player, true);
-		CheckItemStats(player);
+		holdItem._iStatFlag = player.CanUseItem(holdItem);
 		if (automaticallyEquipped) {
 			PlaySFX(ItemInvSnds[ItemCAnimTbl[holdItem._iCurs]]);
 		} else if (!automaticMove || automaticallyMoved) {

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -262,7 +262,7 @@ void WithdrawGold(Player &player, int amount)
 	SetGoldSeed(player, player.HoldItem);
 	player.HoldItem._ivalue = amount;
 	player.HoldItem._iStatFlag = true;
-	ControlSetGoldCurs(player);
+	ControlSetGoldCurs(player.HoldItem);
 	Stash.gold -= amount;
 	Stash.dirty = true;
 }


### PR DESCRIPTION
I also found a really stupid feature that can be supported with auto-pickup which was only prevented by a minor bug with the gold pickup code, so the last commit addresses that bug. Now you can pick up items while walking with the inventory open and a held item :D

https://user-images.githubusercontent.com/357684/159118640-2a7fb953-13ff-4ee1-861e-a4458e2ae8f9.mp4


