### PR TITLE
Ctrl+click stash item swap: if there is no room left, don't drop the item on the ground

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -902,7 +902,7 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 				holdItem._itype = ItemType::None;
 				NewCursor(CURSOR_HAND);
 			} else {
-				player.SaySpecific(HeroSpeech::IHaveNoRoom);
+				player.SaySpecific(HeroSpeech::WhereWouldIPutThis);
 			}
 		} else {
 			TryDropItem();

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -897,9 +897,13 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 	}
 
 	if (dropItem && !holdItem.isEmpty()) {
-		if (IsStashOpen && AutoPlaceItemInStash(player, holdItem, true)) {
-			holdItem._itype = ItemType::None;
-			NewCursor(CURSOR_HAND);
+		if (IsStashOpen) {
+			if (AutoPlaceItemInStash(player, holdItem, true)) {
+				holdItem._itype = ItemType::None;
+				NewCursor(CURSOR_HAND);
+			} else {
+				player.SaySpecific(HeroSpeech::IHaveNoRoom);
+			}
 		} else {
 			TryDropItem();
 		}

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -229,9 +229,13 @@ void CheckStashCut(Point cursorPosition, bool automaticMove, bool dropItem)
 	}
 
 	if (dropItem && !holdItem.isEmpty()) {
-		if (invflag && AutoPlaceItemInInventory(player, holdItem, true)) {
-			holdItem._itype = ItemType::None;
-			NewCursor(CURSOR_HAND);
+		if (invflag) {
+			if (AutoPlaceItemInInventory(player, holdItem, true)) {
+				holdItem._itype = ItemType::None;
+				NewCursor(CURSOR_HAND);
+			} else {
+				player.SaySpecific(HeroSpeech::IHaveNoRoom);
+			}
 		} else {
 			TryDropItem();
 		}


### PR DESCRIPTION
Instead play `HeroSpeech::IHaveNoRoom` and put the item in the hand/cursor.