### PR TITLE
dont allow opening gold withdraw with item in cursor

### DIFF
--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -246,6 +246,9 @@ void StartGoldWithdraw()
 {
 	CloseGoldDrop();
 
+	if (pcurs != CURSOR_HAND)
+		return;
+
 	InitialWithdrawGoldValue = Stash.gold;
 
 	if (talkflag)


### PR DESCRIPTION
Earlier withdrawing gold while having an item in cursor would destroy the item.