### PR TITLE
Avoid resetting monster health and mWhoHit

### DIFF
--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -197,8 +197,7 @@ void SyncMonster(int pnum, const TSyncMonster &monsterSync)
 	}
 
 	decode_enemy(monster, enemyId);
-	monster.mWhoHit = monsterSync.mWhoHit;
-	monster._mhitpoints = monsterSync._mhitpoints;
+	monster.mWhoHit |= monsterSync.mWhoHit;
 }
 
 bool IsEnemyIdValid(const Monster &monster, int enemyId)


### PR DESCRIPTION
As observed in https://github.com/diasurgical/devilutionX/issues/4182 monsters health appears to get stuck and jitter in current master. This is probably caused by https://github.com/diasurgical/devilutionX/commit/b00feb4c3d85fca3fa7cf2cf1975a1629744b35a where monsters health is synced on every tick, which may well cancel out most damage dealt to the monster by a ranged player (since the closest player's data will overwrite the more distant one).

It also appeared that mWhoHit has not taking the ranged player in to account which would again be explained by `mWhoHit` being taken from the melee player. Instead this is now ored on to the local state.