### PR TITLE
Only spawn loot once

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1835,11 +1835,6 @@ int SyncPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, i
 
 	assert(CanPut(position));
 
-	return SyncDropItem(position, idx, icreateinfo, iseed, id, dur, mdur, ch, mch, ivalue, ibuff, toHit, maxDam, minStr, minMag, minDex, ac);
-}
-
-int SyncDropItem(Point position, int idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac)
-{
 	int ii = AllocateItem();
 	auto &item = Items[ii];
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1830,8 +1830,10 @@ int SyncPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, i
 			return -1;
 	}
 
-	if (!PutItem(player, position))
-		return -1;
+	if (IsNoneOf(idx, IDI_MAPOFDOOM, IDI_RUNEBOMB, IDI_THEODORE, IDI_AURIC)) {
+		if (!PutItem(player, position))
+			return -1;
+	}
 
 	assert(CanPut(position));
 

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -184,7 +184,6 @@ bool CanPut(Point position);
 bool TryInvPut();
 int InvPutItem(Player &player, Point position);
 int SyncPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
-int SyncDropItem(Point position, int idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
 int8_t CheckInvHLight();
 void RemoveScroll(Player &player);
 bool UseScroll();

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3346,7 +3346,7 @@ void SpawnQuestItem(int itemid, Point position, int randarea, int selflag)
 	}
 }
 
-void SpawnRewardItem(int itemid, Point position)
+void SpawnRewardItem(int itemid, Point position, bool sendmsg)
 {
 	if (ActiveItemCount >= MAXITEMS)
 		return;
@@ -3362,25 +3362,26 @@ void SpawnRewardItem(int itemid, Point position)
 	item._iSelFlag = 2;
 	item._iPostDraw = true;
 	item._iIdentified = true;
+	GenerateNewSeed(item);
 
-	if (gbIsMultiplayer) {
-		NetSendCmdPItem(false, CMD_DROPITEM, item.position, item);
+	if (sendmsg) {
+		NetSendCmdPItem(true, CMD_RESPAWNITEM, item.position, item);
 	}
 }
 
-void SpawnMapOfDoom(Point position)
+void SpawnMapOfDoom(Point position, bool sendmsg)
 {
-	SpawnRewardItem(IDI_MAPOFDOOM, position);
+	SpawnRewardItem(IDI_MAPOFDOOM, position, sendmsg);
 }
 
-void SpawnRuneBomb(Point position)
+void SpawnRuneBomb(Point position, bool sendmsg)
 {
-	SpawnRewardItem(IDI_RUNEBOMB, position);
+	SpawnRewardItem(IDI_RUNEBOMB, position, sendmsg);
 }
 
-void SpawnTheodore(Point position)
+void SpawnTheodore(Point position, bool sendmsg)
 {
-	SpawnRewardItem(IDI_THEODORE, position);
+	SpawnRewardItem(IDI_THEODORE, position, sendmsg);
 }
 
 void RespawnItem(Item &item, bool flipFlag)
@@ -3389,14 +3390,14 @@ void RespawnItem(Item &item, bool flipFlag)
 	item.SetNewAnimation(flipFlag);
 	item._iRequest = false;
 
-	if (item._iCurs == ICURS_MAGIC_ROCK) {
+	if (IsAnyOf(item._iCurs, ICURS_MAGIC_ROCK, ICURS_TAVERN_SIGN, ICURS_ANVIL_OF_FURY))
 		item._iSelFlag = 1;
+	else if (IsAnyOf(item._iCurs, ICURS_MAP_OF_THE_STARS, ICURS_RUNE_BOMB, ICURS_THEODORE, ICURS_AURIC_AMULET))
+		item._iSelFlag = 2;
+
+	if (item._iCurs == ICURS_MAGIC_ROCK) {
 		PlaySfxLoc(ItemDropSnds[it], item.position);
 	}
-	if (item._iCurs == ICURS_TAVERN_SIGN)
-		item._iSelFlag = 1;
-	if (item._iCurs == ICURS_ANVIL_OF_FURY)
-		item._iSelFlag = 1;
 }
 
 void DeleteItem(int i)

--- a/Source/items.h
+++ b/Source/items.h
@@ -461,10 +461,10 @@ void RecreateEar(Item &item, uint16_t ic, int iseed, int Id, int dur, int mdur, 
 void CornerstoneSave();
 void CornerstoneLoad(Point position);
 void SpawnQuestItem(int itemid, Point position, int randarea, int selflag);
-void SpawnRewardItem(int itemid, Point position);
-void SpawnMapOfDoom(Point position);
-void SpawnRuneBomb(Point position);
-void SpawnTheodore(Point position);
+void SpawnRewardItem(int itemid, Point position, bool sendmsg);
+void SpawnMapOfDoom(Point position, bool sendmsg);
+void SpawnRuneBomb(Point position, bool sendmsg);
+void SpawnTheodore(Point position, bool sendmsg);
 void RespawnItem(Item &item, bool FlipFlag);
 void DeleteItem(int i);
 void ProcessItems();

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -986,15 +986,15 @@ void DiabloDeath(Monster &diablo, bool sendmsg)
 void SpawnLoot(Monster &monster, bool sendmsg)
 {
 	if (Quests[Q_GARBUD].IsAvailable() && monster._uniqtype - 1 == UMT_GARBUD) {
-		CreateTypeItem(monster.position.tile + Displacement { 1, 1 }, true, ItemType::Mace, IMISC_NONE, true, false);
+		CreateTypeItem(monster.position.tile + Displacement { 1, 1 }, true, ItemType::Mace, IMISC_NONE, sendmsg, false);
 	} else if (monster._uniqtype - 1 == UMT_DEFILER) {
 		if (effect_is_playing(USFX_DEFILER8))
 			stream_stop();
 		Quests[Q_DEFILER]._qlog = false;
-		SpawnMapOfDoom(monster.position.tile);
+		SpawnMapOfDoom(monster.position.tile, sendmsg);
 	} else if (monster._uniqtype - 1 == UMT_HORKDMN) {
 		if (sgGameInitInfo.bTheoQuest != 0) {
-			SpawnTheodore(monster.position.tile);
+			SpawnTheodore(monster.position.tile, sendmsg);
 		} else {
 			CreateAmulet(monster.position.tile, 13, sendmsg, false);
 		}

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1614,17 +1614,10 @@ DWORD OnDropItem(const TCmd *pCmd, int pnum)
 {
 	const auto &message = *reinterpret_cast<const TCmdPItem *>(pCmd);
 
-	if (gbBufferMsgs == 1) {
+	if (gbBufferMsgs == 1)
 		SendPacket(pnum, &message, sizeof(message));
-	} else if (IsPItemValid(message)) {
-		int playerLevel = Players[pnum].plrlevel;
-		Point position = { message.x, message.y };
-		if (currlevel == playerLevel && pnum != MyPlayerId) {
-			SyncDropItem(position, message.wIndx, message.wCI, message.dwSeed, message.bId, message.bDur, message.bMDur, message.bCh, message.bMCh, message.wValue, message.dwBuff, message.wToHit, message.wMaxDam, message.bMinStr, message.bMinMag, message.bMinDex, message.bAC);
-		}
-		PutItemRecord(message.dwSeed, message.wCI, message.wIndx);
-		DeltaPutItem(message, position, playerLevel);
-	}
+	else if (IsPItemValid(message))
+		DeltaPutItem(message, { message.x, message.y }, Players[pnum].plrlevel);
 
 	return sizeof(message);
 }

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -612,7 +612,7 @@ void TalkToFarmer(Player &player, Towner &farmer)
 		quest._qvar1 = 1;
 		quest._qlog = true;
 		quest._qmsg = TEXT_FARMER1;
-		SpawnRuneBomb(farmer.position + Displacement { 1, 0 });
+		SpawnRuneBomb(farmer.position + Displacement { 1, 0 }, true);
 		if (gbIsMultiplayer)
 			NetSendCmdQuest(true, quest);
 		break;
@@ -621,7 +621,7 @@ void TalkToFarmer(Player &player, Towner &farmer)
 		break;
 	case QUEST_DONE:
 		InitQTextMsg(TEXT_FARMER4);
-		SpawnRewardItem(IDI_AURIC, farmer.position + Displacement { 1, 0 });
+		SpawnRewardItem(IDI_AURIC, farmer.position + Displacement { 1, 0 }, true);
 		quest._qactive = QUEST_HIVE_DONE;
 		quest._qlog = false;
 		if (gbIsMultiplayer)
@@ -712,7 +712,7 @@ void TalkToCowFarmer(Player &player, Towner &cowFarmer)
 		quest._qvar1 = 1;
 		quest._qmsg = TEXT_JERSEY4;
 		quest._qlog = true;
-		SpawnRuneBomb(cowFarmer.position + Displacement { 1, 0 });
+		SpawnRuneBomb(cowFarmer.position + Displacement { 1, 0 }, true);
 		if (gbIsMultiplayer)
 			NetSendCmdQuest(true, quest);
 		break;


### PR DESCRIPTION
Alternate solution to #4187

1. https://github.com/diasurgical/devilutionX/commit/eeb9ac3303d890d77e122949280d990e1fe8644d turned out to cause loot to drop twice
2. Since quest items are not per-generated like other loot it has to be recreated on the other end, similar to inventory items
3. Quest items are not always dropped next to the player so skip `CanPut()`
4. `_iSelFlag` is `2` instead of `1` for quest items, so take that into account when re-spawning the item.

This does not solve Torn Notes as they use `SpawnQuestItem()` (also used by most single player quests), but it should be easy to make the same adjustments to it once we feel confident about how this works. As well the Torn Notes are not critical for accessing parts of the game.