### PR TITLE
Use a viewport size of 1 when displaying a list of actions for the ok…

### DIFF
--- a/Source/DiabloUI/selok.cpp
+++ b/Source/DiabloUI/selok.cpp
@@ -66,7 +66,7 @@ void UiSelOkDialog(const char *title, const char *body, bool background)
 	}
 
 	vecSelOkDialogItems.push_back(std::make_unique<UiListItem>(_("OK"), 0));
-	vecSelOkDialog.push_back(std::make_unique<UiList>(vecSelOkDialogItems, 0, PANEL_LEFT + 230, (UI_OFFSET_Y + 390), 180, 35, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
+	vecSelOkDialog.push_back(std::make_unique<UiList>(vecSelOkDialogItems, 1, PANEL_LEFT + 230, (UI_OFFSET_Y + 390), 180, 35, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
 	strcpy(dialogText, WordWrapString(body, MESSAGE_WIDTH, GameFont24).c_str());
 


### PR DESCRIPTION
… dialog

Having a size 0 viewport made the action invisible, forcing the player to use the Esc action.

master
![2022-03-20T143147_devilutionx](https://user-images.githubusercontent.com/357684/159146869-39da56a9-0c07-44df-8f16-38681f52194a.png)

fixed
![2022-03-20T143243_devilutionx](https://user-images.githubusercontent.com/357684/159146876-f0dbb037-eaea-4d46-b156-fe4e4031e500.png)
