### PR TITLE
Sync mana between clients

### DIFF
--- a/Source/msg.h
+++ b/Source/msg.h
@@ -711,6 +711,8 @@ struct TPktHdr {
 	uint8_t targy;
 	int32_t php;
 	int32_t pmhp;
+	int32_t mana;
+	int32_t maxmana;
 	uint8_t bstr;
 	uint8_t bmag;
 	uint8_t bdex;

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -126,6 +126,8 @@ void NetReceivePlayerData(TPkt *pkt)
 	pkt->hdr.targy = target.y;
 	pkt->hdr.php = myPlayer._pHitPoints;
 	pkt->hdr.pmhp = myPlayer._pMaxHP;
+	pkt->hdr.mana = myPlayer._pMana;
+	pkt->hdr.maxmana = myPlayer._pMaxMana;
 	pkt->hdr.bstr = myPlayer._pBaseStr;
 	pkt->hdr.bmag = myPlayer._pBaseMag;
 	pkt->hdr.bdex = myPlayer._pBaseDex;
@@ -613,6 +615,8 @@ void multi_process_network_packets()
 			assert(gbBufferMsgs != 2);
 			player._pHitPoints = pkt->php;
 			player._pMaxHP = pkt->pmhp;
+			player._pMana = pkt->mana;
+			player._pMaxMana = pkt->maxmana;
 			bool cond = gbBufferMsgs == 1;
 			player._pBaseStr = pkt->bstr;
 			player._pBaseMag = pkt->bmag;


### PR DESCRIPTION
With this change mana is synchronized between clients/players.
Should help to get #4074 along, see this [comment](https://github.com/diasurgical/devilutionX/pull/4074#discussion_r830529747).
Tested with modified `control.cpp` (when selecting another player mana is shown instead of hp; not included in this pr).
Works even with debug `fill` command. 😉 