### PR TITLE
Do not exit game on network timeout

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -257,42 +257,7 @@ void BeginTimeout()
 		return;
 	}
 
-	int nLowestActive = -1;
-	int nLowestPlayer = -1;
-	uint8_t bGroupPlayers = 0;
-	uint8_t bGroupCount = 0;
-	for (int i = 0; i < MAX_PLRS; i++) {
-		uint32_t nState = player_state[i];
-		if ((nState & PS_CONNECTED) != 0) {
-			if (nLowestPlayer == -1) {
-				nLowestPlayer = i;
-			}
-			if ((nState & PS_ACTIVE) != 0) {
-				bGroupPlayers++;
-				if (nLowestActive == -1) {
-					nLowestActive = i;
-				}
-			} else {
-				bGroupCount++;
-			}
-		}
-	}
-
-	assert(bGroupPlayers);
-	assert(nLowestActive != -1);
-	assert(nLowestPlayer != -1);
-
-	if (bGroupPlayers < bGroupCount) {
-		gbGameDestroyed = true;
-	} else if (bGroupPlayers == bGroupCount) {
-		if (nLowestPlayer != nLowestActive) {
-			gbGameDestroyed = true;
-		} else if (nLowestActive == MyPlayerId) {
-			CheckDropPlayer();
-		}
-	} else if (nLowestActive == MyPlayerId) {
-		CheckDropPlayer();
-	}
+	CheckDropPlayer();
 }
 
 void HandleAllPackets(int pnum, const byte *data, size_t size)


### PR DESCRIPTION
This removes the logic that attempted to determine which multiplayer client should be the one to resume a game session in the event of a network interruption. Instead, every client will individually determine which players need to be kicked so that the game session can resume locally.

After a bunch of testing and brainstorming with @AJenbo, we came to the conclusion that there's no compelling reason to try so hard to make sure that only one game session remains active in the event of a network disruption. On the contrary, it's not difficult to imagine legitimate scenarios where doing so would be undesirable for the entire party.

For more context regarding what this is all about, see https://github.com/diasurgical/devilutionX/issues/4182#issuecomment-1073078627.