### PR TITLE
Github CI: Fixup release actions

### DIFF
--- a/.github/workflows/opendingux_release.yml
+++ b/.github/workflows/opendingux_release.yml
@@ -37,7 +37,7 @@ jobs:
         path: build-rg350/devilutionx-rg350.opk
 
     - name: Update Release
-      if: github.event_name == 'release' && github.event.action == 'created' && ${{ !env.ACT }}
+      if: ${{ github.event_name == 'release' && github.event.action == 'created' && !env.ACT }}
       uses: ncipollo/release-action@v1
       with:
         artifacts: "build-rg350/devilutionx-rg350.opk"
@@ -78,7 +78,7 @@ jobs:
         path: build-lepus/devilutionx-lepus.opk
 
     - name: Update Release
-      if: startsWith(github.ref, 'refs/tags/') && ${{ !env.ACT }}
+      if: ${{ github.event_name == 'release' && github.event.action == 'created' && !env.ACT }}
       uses: ncipollo/release-action@v1
       with:
         artifacts: "build-lepus/devilutionx-lepus.opk"

--- a/.github/workflows/retrofw_release.yml
+++ b/.github/workflows/retrofw_release.yml
@@ -38,7 +38,7 @@ jobs:
         path: build-retrofw/devilutionx-retrofw.opk
 
     - name: Update Release
-      if: github.event_name == 'release' && github.event.action == 'created' && ${{ !env.ACT }}
+      if: ${{ github.event_name == 'release' && github.event.action == 'created' && !env.ACT }}
       uses: ncipollo/release-action@v1
       with:
         artifacts: "build-retrofw/devilutionx-retrofw.opk"

--- a/.github/workflows/src_dist_release.yml
+++ b/.github/workflows/src_dist_release.yml
@@ -31,7 +31,7 @@ jobs:
         path: devilutionx-src.tar.xz
 
     - name: Update Release
-      if: github.event_name == 'release' && github.event.action == 'created' && ${{ !env.ACT }}
+      if: ${{ github.event_name == 'release' && github.event.action == 'created' && !env.ACT }}
       uses: ncipollo/release-action@v1
       with:
         artifacts: "devilutionx-src.tar.xz"


### PR DESCRIPTION
1. Use `${{ }}` consistently. It is technically not required in `if` conditions but GitHub CI docs use it and it avoid certain pitfalls,  such as when the value starts with `!` (making it a YAML type declaration).
2. Fixes one of the `if`s.