### PR TITLE
Remove `OwnedCelSprite::Unowned` method

### DIFF
--- a/Source/engine/cel_sprite.hpp
+++ b/Source/engine/cel_sprite.hpp
@@ -80,11 +80,6 @@ public:
 	OwnedCelSprite(OwnedCelSprite &&) noexcept = default;
 	OwnedCelSprite &operator=(OwnedCelSprite &&) noexcept = default;
 
-	[[nodiscard]] CelSprite Unowned() const
-	{
-		return CelSprite(*this);
-	}
-
 private:
 	std::unique_ptr<byte[]> data_;
 };

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3427,7 +3427,7 @@ void FreeItemGFX()
 
 void GetItemFrm(Item &item)
 {
-	item.AnimInfo.celSprite = itemanims[ItemCAnimTbl[item._iCurs]]->Unowned();
+	item.AnimInfo.celSprite.emplace(*itemanims[ItemCAnimTbl[item._iCurs]]);
 }
 
 void GetItemStr(Item &item)
@@ -4564,7 +4564,7 @@ void Item::SetNewAnimation(bool showAnimation)
 {
 	int it = ItemCAnimTbl[_iCurs];
 	int numberOfFrames = ItemAnimLs[it];
-	auto celSprite = itemanims[it] ? std::optional<CelSprite> { itemanims[it]->Unowned() } : std::nullopt;
+	auto celSprite = itemanims[it] ? std::optional<CelSprite> { *itemanims[it] } : std::nullopt;
 	if (_iCurs != ICURS_MAGIC_ROCK)
 		AnimInfo.SetNewAnimation(celSprite, numberOfFrames, 1, AnimationDistributionFlags::ProcessAnimationPending, 0, numberOfFrames);
 	else


### PR DESCRIPTION
Conversion is already provided by the `CelSprite(const OwnedCelSprite &)` constructor.