### PR TITLE
Remove `(un)lock_buf`

### DIFF
--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -169,7 +169,6 @@ void CaptureScreen()
 	PaletteGetEntries(256, palette);
 	RedPalette();
 
-	lock_buf(2);
 	const Surface &buf = GlobalBackBuffer();
 	success = CaptureHdr(buf.w(), buf.h(), &outStream);
 	if (success) {
@@ -178,7 +177,6 @@ void CaptureScreen()
 	if (success) {
 		success = CapturePal(palette, &outStream);
 	}
-	unlock_buf(2);
 	outStream.close();
 
 	if (!success) {

--- a/Source/dx.h
+++ b/Source/dx.h
@@ -15,8 +15,6 @@ extern bool RenderDirectlyToOutputSurface;
 Surface GlobalBackBuffer();
 
 void dx_init();
-void lock_buf(int idx);
-void unlock_buf(int idx);
 void dx_cleanup();
 void CreateBackBuffer();
 void InitPalette();

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -170,7 +170,6 @@ void InitCutscene(interface_mode uMsg)
 
 void DrawCutscene()
 {
-	lock_buf(1);
 	const Surface &out = GlobalBackBuffer();
 	DrawArt(out, { PANEL_X - (ArtCutsceneWidescreen.w() - PANEL_WIDTH) / 2, UI_OFFSET_Y }, &ArtCutsceneWidescreen);
 	CelDrawTo(out, { PANEL_X, 480 - 1 + UI_OFFSET_Y }, *sgpBackCel, 1);
@@ -182,8 +181,6 @@ void DrawCutscene()
 	    sgdwProgress,
 	    ProgressHeight);
 	SDL_FillRect(out.surface, &rect, BarColor[progress_id]);
-
-	unlock_buf(1);
 
 	BltFast(&rect, &rect);
 	RenderPresent();

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1564,12 +1564,8 @@ extern SDL_Surface *PalSurface;
 
 void ClearScreenBuffer()
 {
-	lock_buf(3);
-
 	assert(PalSurface != nullptr);
 	SDL_FillRect(PalSurface, nullptr, 0);
-
-	unlock_buf(3);
 }
 
 #ifdef _DEBUG
@@ -1670,9 +1666,7 @@ void scrollrt_draw_game_screen()
 	if (IsHardwareCursor()) {
 		SetHardwareCursorVisible(ShouldShowCursor());
 	} else {
-		lock_buf(0);
 		DrawCursor(GlobalBackBuffer());
-		unlock_buf(0);
 	}
 
 	DrawMain(hgt, false, false, false, false, false);
@@ -1680,9 +1674,7 @@ void scrollrt_draw_game_screen()
 	RenderPresent();
 
 	if (!IsHardwareCursor()) {
-		lock_buf(0);
 		UndrawCursor(GlobalBackBuffer());
-		unlock_buf(0);
 	}
 }
 
@@ -1712,7 +1704,6 @@ void DrawAndBlit()
 
 	force_redraw = 0;
 
-	lock_buf(0);
 	const Surface &out = GlobalBackBuffer();
 	UndrawCursor(out);
 
@@ -1753,8 +1744,6 @@ void DrawAndBlit()
 	}
 
 	DrawFPS(out);
-
-	unlock_buf(0);
 
 	DrawMain(hgt, ddsdesc, drawhpflag, drawmanaflag, drawsbarflag, drawbtnflag);
 


### PR DESCRIPTION
We do not seem to render from multiple threads, so these calls are unnecessary.