### PR TITLE
Add gamepad support for stash

### DIFF
--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -15,6 +15,7 @@
 #include "doom.h"
 #include "gmenu.h"
 #include "options.h"
+#include "qol/stash.h"
 #include "stores.h"
 
 namespace devilution {
@@ -164,6 +165,10 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, Game
 		}
 	}
 #endif
+	if (IsStashOpen && ctrlEvent.button == ControllerButton_BUTTON_BACK) {
+		StartGoldWithdraw();
+		return false;
+	}
 
 	if (HandleStartAndSelect(ctrlEvent, action))
 		return true;

--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -455,16 +455,9 @@ VirtualGamepadButtonType SecondaryActionButtonRenderer::GetButtonType()
 			return GetApplyButtonType(virtualPadButton->isHeld);
 
 		if (pcursinvitem != -1) {
-			Item *item;
-			if (pcursinvitem < INVITEM_INV_FIRST)
-				item = &MyPlayer->InvBody[pcursinvitem];
-			else if (pcursinvitem <= INVITEM_INV_LAST)
-				item = &MyPlayer->InvList[pcursinvitem - INVITEM_INV_FIRST];
-			else
-				item = &MyPlayer->SpdList[pcursinvitem - INVITEM_BELT_FIRST];
-
-			if (!item->IsScroll() || !spelldata[item->_iSpell].sTargeted) {
-				if (!item->isEquipment()) {
+			Item &item = GetInventoryItem(*MyPlayer, pcursinvitem);
+			if (!item.IsScroll() || !spelldata[item._iSpell].sTargeted) {
+				if (!item.isEquipment()) {
 					return GetApplyButtonType(virtualPadButton->isHeld);
 				}
 			}

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -177,6 +177,9 @@ void ResetCursor()
 
 void NewCursor(int cursId)
 {
+	if (cursId < CURSOR_FIRSTITEM && MyPlayer != nullptr) {
+		MyPlayer->HoldItem._itype = ItemType::None;
+	}
 	pcurs = cursId;
 	cursSize = GetInvItemSize(cursId);
 	SetICursor(cursId);

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -180,6 +180,7 @@ int AddGoldToInventory(Player &player, int value);
 bool GoldAutoPlace(Player &player, Item &goldStack);
 void CheckInvSwap(Player &player, inv_body_loc bLoc, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff);
 void inv_update_rem_item(Player &player, inv_body_loc iv);
+void TransferItemToStash(Player &player, int location);
 void CheckInvItem(bool isShiftHeld = false, bool isCtrlHeld = false);
 
 /**
@@ -208,6 +209,7 @@ void RemoveScroll(Player &player);
 bool UseScroll();
 void UseStaffCharge(Player &player);
 bool UseStaff();
+Item &GetInventoryItem(Player &player, int location);
 bool UseInvItem(int pnum, int cii);
 void DoTelekinesis();
 int CalculateGold(Player &player);

--- a/Source/miniwin/misc_msg.cpp
+++ b/Source/miniwin/misc_msg.cpp
@@ -319,10 +319,16 @@ void ProcessGamepadEvents(GameAction &action)
 	case GameActionType_SEND_KEY:
 		break;
 	case GameActionType_USE_HEALTH_POTION:
-		UseBeltItem(BLT_HEALING);
+		if (IsStashOpen)
+			Stash.SetPage(Stash.GetPage() - 1);
+		else
+			UseBeltItem(BLT_HEALING);
 		break;
 	case GameActionType_USE_MANA_POTION:
-		UseBeltItem(BLT_MANA);
+		if (IsStashOpen)
+			Stash.SetPage(Stash.GetPage() + 1);
+		else
+			UseBeltItem(BLT_MANA);
 		break;
 	case GameActionType_PRIMARY_ACTION:
 		PerformPrimaryAction();

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3136,7 +3136,6 @@ StartPlayerKill(int pnum, int earflag)
 
 			if (pcurs >= CURSOR_FIRSTITEM) {
 				DeadItem(player, std::move(player.HoldItem), { 0, 0 });
-				player.HoldItem._itype = ItemType::None;
 				NewCursor(CURSOR_HAND);
 			}
 

--- a/Source/qol/stash.h
+++ b/Source/qol/stash.h
@@ -47,6 +47,7 @@ extern int WithdrawGoldValue;
 Point GetStashSlotCoord(Point slot);
 void InitStash();
 void FreeStashGFX();
+void TransferItemToInventory(Player &player, uint16_t itemId);
 /**
  * @brief Render the inventory panel to the given buffer.
  */
@@ -57,6 +58,7 @@ uint16_t CheckStashHLight(Point mousePosition);
 void CheckStashButtonRelease(Point mousePosition);
 void CheckStashButtonPress(Point mousePosition);
 
+void StartGoldWithdraw();
 void WithdrawGoldKeyPress(char vkey);
 void DrawGoldWithdraw(const Surface &out, int amount);
 void CloseGoldWithdraw();


### PR DESCRIPTION
Resolves #4211 and an issue with the cursor not resetting correctly in the inventory (see `InvGetEquipSlotCoordFromInvSlot()`)

- [x] Cursor is misaligned when jumping from inventory stash (drops by one row)
- [x] Cursor is misaligned when jumping between stash and inventory (if there is an item larger then 1x1 at the destination)
- [x] Cannot jump between stash and inventory if edge item is 2 in width
- [x] Empty cursor is misaligned in stash grid (pointer is at upper left instead of center)
- [x] Miss aligned when jumping to belt from stash (lower left instead of center)
- [x] L1/L2 for changing page
- [x] SELECT for withdrawing gold
- [x] Secondary action should transfer items between stash and inventory

Optional:
- [ ] Center cursor when hovering items in stash (same as inventory)
- [ ] It's possible to move in to the wrong equipment slots when jumping from stash while holding an item