### PR TITLE
Restore position of dropped note when recombining fragments

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -950,9 +950,11 @@ void TryCombineNaKrulNotes(Player &player, Item &noteItem)
 		}
 	}
 
+	Point position = noteItem.position; // copy the position to restore it after re-initialising the item
 	noteItem = {};
 	GetItemAttrs(noteItem, IDI_FULLNOTE, 16);
 	SetupItem(noteItem);
+	noteItem.position = position; // this ensures CleanupItem removes the entry in the dropped items lookup table
 }
 
 void CheckQuestItem(Player &player, Item &questItem)


### PR DESCRIPTION
I didn't realise that AutoGetItem runs for all pickup logic now? I thought that InvGetItem would be running in this case which still copied the note before combining fragments. This would've been an issue for auto-pickup anyway so this change preserves the position and sets it on the reconstructed note.

fixes #4240