### PR TITLE
Fix multiplayer equipment synchronization

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -801,10 +801,6 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 						invloc = INVLOC_AMULET;
 						break;
 					case ILOC_ONEHAND:
-						// Ensure shield is on the right, weapon on the left.
-						if (player.InvBody[INVLOC_HAND_LEFT]._itype == ItemType::Shield) {
-							SwapItem(player.InvBody[INVLOC_HAND_RIGHT], player.InvBody[INVLOC_HAND_LEFT]);
-						}
 						// User is attempting to move a weapon (left hand)
 						if (player.InvList[iv - 1]._iClass == player.InvBody[INVLOC_HAND_LEFT]._iClass
 						    && player.GetItemLocation(player.InvList[iv - 1]) == player.GetItemLocation(player.InvBody[INVLOC_HAND_LEFT])) {
@@ -835,7 +831,7 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 								player.RemoveInvItem(player._pNumInv - 1, false);
 								break;
 							}
-							player.InvBody[INVLOC_HAND_RIGHT]._itype = ItemType::None;
+							RemoveEquipment(player, INVLOC_HAND_RIGHT, false);
 							invloc = INVLOC_HAND_LEFT;
 						} else {
 							invloc = INVLOC_HAND_LEFT;

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -112,6 +112,14 @@ void DrawInv(const Surface &out);
 void DrawInvBelt(const Surface &out);
 
 /**
+ * @brief Removes equipment from the specified location on the player's body.
+ * @param player The player from which equipment will be removed.
+ * @param bodyLocation The location from which equipment will be removed.
+ * @param hiPri Priority of the network message to sync player equipment.
+ */
+void RemoveEquipment(Player &player, inv_body_loc bodyLocation, bool hiPri);
+
+/**
  * @brief Checks whether or not auto-equipping behavior is enabled for the given player and item.
  * @param player The player to check.
  * @param item The item to check.

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2615,15 +2615,16 @@ void NetSendCmdChItem(bool bHiPri, BYTE bLoc)
 {
 	TCmdChItem cmd;
 
-	auto &myPlayer = Players[MyPlayerId];
+	Player &myPlayer = Players[MyPlayerId];
+	Item &item = myPlayer.InvBody[bLoc];
 
 	cmd.bCmd = CMD_CHANGEPLRITEMS;
 	cmd.bLoc = bLoc;
-	cmd.wIndx = myPlayer.HoldItem.IDidx;
-	cmd.wCI = myPlayer.HoldItem._iCreateInfo;
-	cmd.dwSeed = myPlayer.HoldItem._iSeed;
-	cmd.bId = myPlayer.HoldItem._iIdentified ? 1 : 0;
-	cmd.dwBuff = myPlayer.HoldItem.dwBuff;
+	cmd.wIndx = item.IDidx;
+	cmd.wCI = item._iCreateInfo;
+	cmd.dwSeed = item._iSeed;
+	cmd.bId = item._iIdentified ? 1 : 0;
+	cmd.dwBuff = item.dwBuff;
 
 	if (bHiPri)
 		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -730,8 +730,7 @@ bool WeaponDecay(Player &player, int ii)
 	if (!player.InvBody[ii].isEmpty() && player.InvBody[ii]._iClass == ICLASS_WEAPON && (player.InvBody[ii]._iDamAcFlags & ISPLHF_DECAY) != 0) {
 		player.InvBody[ii]._iPLDam -= 5;
 		if (player.InvBody[ii]._iPLDam <= -100) {
-			NetSendCmdDelItem(true, ii);
-			player.InvBody[ii]._itype = ItemType::None;
+			RemoveEquipment(player, static_cast<inv_body_loc>(ii), true);
 			CalcPlrInv(player, true);
 			return true;
 		}
@@ -767,8 +766,7 @@ bool DamageWeapon(int pnum, int durrnd)
 
 		player.InvBody[INVLOC_HAND_LEFT]._iDurability--;
 		if (player.InvBody[INVLOC_HAND_LEFT]._iDurability <= 0) {
-			NetSendCmdDelItem(true, INVLOC_HAND_LEFT);
-			player.InvBody[INVLOC_HAND_LEFT]._itype = ItemType::None;
+			RemoveEquipment(player, INVLOC_HAND_LEFT, true);
 			CalcPlrInv(player, true);
 			return true;
 		}
@@ -781,8 +779,7 @@ bool DamageWeapon(int pnum, int durrnd)
 
 		player.InvBody[INVLOC_HAND_RIGHT]._iDurability--;
 		if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability == 0) {
-			NetSendCmdDelItem(true, INVLOC_HAND_RIGHT);
-			player.InvBody[INVLOC_HAND_RIGHT]._itype = ItemType::None;
+			RemoveEquipment(player, INVLOC_HAND_RIGHT, true);
 			CalcPlrInv(player, true);
 			return true;
 		}
@@ -795,8 +792,7 @@ bool DamageWeapon(int pnum, int durrnd)
 
 		player.InvBody[INVLOC_HAND_RIGHT]._iDurability--;
 		if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability == 0) {
-			NetSendCmdDelItem(true, INVLOC_HAND_RIGHT);
-			player.InvBody[INVLOC_HAND_RIGHT]._itype = ItemType::None;
+			RemoveEquipment(player, INVLOC_HAND_RIGHT, true);
 			CalcPlrInv(player, true);
 			return true;
 		}
@@ -809,8 +805,7 @@ bool DamageWeapon(int pnum, int durrnd)
 
 		player.InvBody[INVLOC_HAND_LEFT]._iDurability--;
 		if (player.InvBody[INVLOC_HAND_LEFT]._iDurability == 0) {
-			NetSendCmdDelItem(true, INVLOC_HAND_LEFT);
-			player.InvBody[INVLOC_HAND_LEFT]._itype = ItemType::None;
+			RemoveEquipment(player, INVLOC_HAND_LEFT, true);
 			CalcPlrInv(player, true);
 			return true;
 		}
@@ -1308,8 +1303,7 @@ void DamageParryItem(int pnum)
 
 		player.InvBody[INVLOC_HAND_LEFT]._iDurability--;
 		if (player.InvBody[INVLOC_HAND_LEFT]._iDurability == 0) {
-			NetSendCmdDelItem(true, INVLOC_HAND_LEFT);
-			player.InvBody[INVLOC_HAND_LEFT]._itype = ItemType::None;
+			RemoveEquipment(player, INVLOC_HAND_LEFT, true);
 			CalcPlrInv(player, true);
 		}
 	}
@@ -1318,8 +1312,7 @@ void DamageParryItem(int pnum)
 		if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability != DUR_INDESTRUCTIBLE) {
 			player.InvBody[INVLOC_HAND_RIGHT]._iDurability--;
 			if (player.InvBody[INVLOC_HAND_RIGHT]._iDurability == 0) {
-				NetSendCmdDelItem(true, INVLOC_HAND_RIGHT);
-				player.InvBody[INVLOC_HAND_RIGHT]._itype = ItemType::None;
+				RemoveEquipment(player, INVLOC_HAND_RIGHT, true);
 				CalcPlrInv(player, true);
 			}
 		}
@@ -1387,11 +1380,10 @@ void DamageArmor(int pnum)
 	}
 
 	if (a != 0) {
-		NetSendCmdDelItem(true, INVLOC_CHEST);
+		RemoveEquipment(player, INVLOC_CHEST, true);
 	} else {
-		NetSendCmdDelItem(true, INVLOC_HEAD);
+		RemoveEquipment(player, INVLOC_HEAD, true);
 	}
-	pi->_itype = ItemType::None;
 	CalcPlrInv(player, true);
 }
 


### PR DESCRIPTION
From #4182
> When auto equiping items the other player will sometimes not see that it has been equiped

This is caused by the fact that `NetSendCmdChItem()` uses `myPlayer.HoldItem` to populate the network message with item creation info. When auto-equipping items, the local client places the item in the appropriate equipment slot directly from the list of items on the ground. The network message ends up using whatever data is left over from the last item the player was holding.

The idea here is to change `NetSendCmdChItem()` to use data from `player.InvBody` instead. This means the item must be equipped locally before attempting to send the network message. The `ChangeEquipment()` function was introduced to ensure that the network message is only sent under the appropriate conditions. Since some of the equip logic also uses `NetSendCmdDelItem()` and those network messages are quite similar, I also introduced `RemoveEquipment()` as an additional cleanup.

---

I also found an unreported issue while testing. When using shift+click on one-handed weapons or shields in the player's inventory, the game would force the shield into the player's right hand before attempting to determine which hand the inventory item should be placed in. This swap wasn't being synchronized between clients, causing some confusion on the remote client. Based on how the logic was determining which hand the inventory item should be placed in, it doesn't appear that the swap was really necessary so I simply removed it.

I also went ahead and modified an edge case in the two-handed weapon logic to explicitly send `CMD_DELPLRITEMS` for the equipment in the player's right hand. It didn't seem like it was entirely necessary because the remote client would figure it out when receiving `CMD_CHANGEPLRITEMS` for the two-handed weapon, but this behavior matches the logic in `CheckInvPaste()`.