### PR TITLE
Fix cow quest getting stuck in multiplayer

### DIFF
--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -658,12 +658,6 @@ void ResyncMPQuests()
 		nakrulQuest._qactive = QUEST_ACTIVE;
 		NetSendCmdQuest(true, nakrulQuest);
 	}
-
-	auto &cowQuest = Quests[Q_JERSEY];
-	if (cowQuest._qactive == QUEST_INIT && currlevel == cowQuest._qlevel - 1) {
-		cowQuest._qactive = QUEST_ACTIVE;
-		NetSendCmdQuest(true, cowQuest);
-	}
 }
 
 void ResyncQuests()

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -671,9 +671,6 @@ void TalkToCowFarmer(Player &player, Towner &cowFarmer)
 		if (gbIsMultiplayer)
 			NetSendCmdQuest(true, quest);
 		break;
-	case QUEST_ACTIVE:
-		InitQTextMsg(TEXT_JERSEY5);
-		break;
 	case QUEST_DONE:
 		InitQTextMsg(TEXT_JERSEY1);
 		break;


### PR DESCRIPTION
Fixes #4184

This turned out to be a vanilla hellfire bug. When loading level 8 the quest would be set as active, like for most other quests. But this quests should only be set active when the player is handed the rune bomb by the Nut in town. This would lead the logic to think the Nut had already given you the bomb and so the quest would be stuck in this state.

The solution is quite simple, simply do not enable this quest during loading of level 8.

Also I removed the specific dialog line for `QUEST_ACTIVE` as it is the same as the default dialog.