### PR TITLE
Cancel heal other/resurrect on right-click

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1796,15 +1796,23 @@ int DiabloMain(int argc, char **argv)
 bool TryIconCurs()
 {
 	if (pcurs == CURSOR_RESURRECT) {
-		NetSendCmdParam1(true, CMD_RESURRECT, pcursplr);
-		NewCursor(CURSOR_HAND);
-		return true;
+		if (pcursplr != -1) {
+			NetSendCmdParam1(true, CMD_RESURRECT, pcursplr);
+			NewCursor(CURSOR_HAND);
+			return true;
+		}
+
+		return false;
 	}
 
 	if (pcurs == CURSOR_HEALOTHER) {
-		NetSendCmdParam1(true, CMD_HEALOTHER, pcursplr);
-		NewCursor(CURSOR_HAND);
-		return true;
+		if (pcursplr != -1) {
+			NetSendCmdParam1(true, CMD_HEALOTHER, pcursplr);
+			NewCursor(CURSOR_HAND);
+			return true;
+		}
+
+		return false;
 	}
 
 	if (pcurs == CURSOR_TELEKINESIS) {

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1797,11 +1797,13 @@ bool TryIconCurs()
 {
 	if (pcurs == CURSOR_RESURRECT) {
 		NetSendCmdParam1(true, CMD_RESURRECT, pcursplr);
+		NewCursor(CURSOR_HAND);
 		return true;
 	}
 
 	if (pcurs == CURSOR_HEALOTHER) {
 		NetSendCmdParam1(true, CMD_HEALOTHER, pcursplr);
+		NewCursor(CURSOR_HAND);
 		return true;
 	}
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1313,12 +1313,15 @@ DWORD OnResurrect(const TCmd *pCmd, int pnum)
 	return sizeof(message);
 }
 
-DWORD OnHealOther(const TCmd *pCmd, int pnum)
+DWORD OnHealOther(const TCmd *pCmd, const Player &caster)
 {
 	const auto &message = *reinterpret_cast<const TCmdParam1 *>(pCmd);
 
-	if (gbBufferMsgs != 1 && currlevel == Players[pnum].plrlevel && message.wParam1 < MAX_PLRS)
-		DoHealOther(pnum, message.wParam1);
+	if (gbBufferMsgs != 1) {
+		if (currlevel == caster.plrlevel && message.wParam1 < MAX_PLRS) {
+			DoHealOther(caster, Players[message.wParam1]);
+		}
+	}
 
 	return sizeof(message);
 }
@@ -2767,7 +2770,7 @@ uint32_t ParseCmd(int pnum, const TCmd *pCmd)
 	case CMD_RESURRECT:
 		return OnResurrect(pCmd, pnum);
 	case CMD_HEALOTHER:
-		return OnHealOther(pCmd, pnum);
+		return OnHealOther(pCmd, player);
 	case CMD_TALKXY:
 		return OnTalkXY(pCmd, player);
 	case CMD_DEBUG:

--- a/Source/player.h
+++ b/Source/player.h
@@ -22,6 +22,7 @@
 #include "spelldat.h"
 #include "utils/attributes.h"
 #include "utils/enum_traits.h"
+#include "utils/stdcompat/algorithm.hpp"
 
 namespace devilution {
 
@@ -554,6 +555,20 @@ struct Player {
 	 * Valid only for players with Mana Shield spell level greater than zero.
 	 */
 	int GetManaShieldDamageReduction();
+
+	/**
+	 * @brief Gets the effective spell level for the player, considering item bonuses
+	 * @param spell spell_id enum member identifying the spell
+	 * @return effective spell level
+	 */
+	int GetSpellLevel(spell_id spell) const
+	{
+		if (spell == SPL_INVALID || static_cast<std::size_t>(spell) >= sizeof(_pSplLvl)) {
+			return 0;
+		}
+
+		return std::max<int8_t>(_pISplLvlAdd + _pSplLvl[static_cast<std::size_t>(spell)], 0);
+	}
 
 	/**
 	 * @brief Return monster armor value after including player's armor piercing % (hellfire only)

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -247,10 +247,6 @@ void CastSpell(int id, spell_id spl, int sx, int sy, int dx, int dy, int spllvl)
 
 void DoResurrect(int pnum, uint16_t rid)
 {
-	if (pnum == MyPlayerId) {
-		NewCursor(CURSOR_HAND);
-	}
-
 	if ((DWORD)pnum >= MAX_PLRS || rid >= MAX_PLRS) {
 		return;
 	}
@@ -295,10 +291,6 @@ void DoResurrect(int pnum, uint16_t rid)
 
 void DoHealOther(int pnum, uint16_t rid)
 {
-	if (pnum == MyPlayerId) {
-		NewCursor(CURSOR_HAND);
-	}
-
 	if ((DWORD)pnum >= MAX_PLRS || rid >= MAX_PLRS) {
 		return;
 	}

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -289,38 +289,32 @@ void DoResurrect(int pnum, uint16_t rid)
 	}
 }
 
-void DoHealOther(int pnum, uint16_t rid)
+void DoHealOther(const Player &caster, Player &target)
 {
-	if ((DWORD)pnum >= MAX_PLRS || rid >= MAX_PLRS) {
-		return;
-	}
-	auto &player = Players[pnum];
-	auto &target = Players[rid];
-
 	if ((target._pHitPoints >> 6) <= 0) {
 		return;
 	}
 
 	int hp = (GenerateRnd(10) + 1) << 6;
-	for (int i = 0; i < player._pLevel; i++) {
+	for (int i = 0; i < caster._pLevel; i++) {
 		hp += (GenerateRnd(4) + 1) << 6;
 	}
-	for (int i = 0; i < GetSpellLevel(pnum, SPL_HEALOTHER); i++) {
+	for (int i = 0; i < caster.GetSpellLevel(SPL_HEALOTHER); i++) {
 		hp += (GenerateRnd(6) + 1) << 6;
 	}
 
-	if (player._pClass == HeroClass::Warrior || player._pClass == HeroClass::Barbarian) {
+	if (caster._pClass == HeroClass::Warrior || caster._pClass == HeroClass::Barbarian) {
 		hp *= 2;
-	} else if (player._pClass == HeroClass::Rogue || player._pClass == HeroClass::Bard) {
+	} else if (caster._pClass == HeroClass::Rogue || caster._pClass == HeroClass::Bard) {
 		hp += hp / 2;
-	} else if (player._pClass == HeroClass::Monk) {
+	} else if (caster._pClass == HeroClass::Monk) {
 		hp *= 3;
 	}
 
 	target._pHitPoints = std::min(target._pHitPoints + hp, target._pMaxHP);
 	target._pHPBase = std::min(target._pHPBase + hp, target._pMaxHPBase);
 
-	if (rid == MyPlayerId) {
+	if (&target == MyPlayer) {
 		drawhpflag = true;
 	}
 }

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -36,7 +36,7 @@ void CastSpell(int id, spell_id spl, int sx, int sy, int dx, int dy, int spllvl)
  * @param rid target player index
  */
 void DoResurrect(int pnum, uint16_t rid);
-void DoHealOther(int pnum, uint16_t rid);
+void DoHealOther(const Player &caster, Player &target);
 int GetSpellBookLevel(spell_id s);
 int GetSpellStaffLevel(spell_id s);
 


### PR DESCRIPTION
fixes #4252

> We have made changes that makes heal other/resurrect only trigger when a player is targeted (to avoid wasting the spell).

The cast spell code fires in `TryIconCurs()` for both left and right clicks (and cursor driven gamepad actions with the inventory open). In the current code these spells are "cast" with no target, then when the local client receives the message the cursor is changed back to the hand only if there was a valid target. In a roundabout way this leaves the spell readied unless the user does something else which triggers a cursor change (like interacting with an inventory cell).

This change restricts casting resurrect/heal other only with a valid target. This ends up making left mouse clicks progress through the fallback cases that allow moving with a readied spell, right clicks eventually fall through to reset the cursor and "unready" the spell. The mana is spent (or the scroll is consumed) as soon as the spell is readied which makes it harder to restore the source, so I haven't bothered to try track and undo that state change.