### PR TITLE
Add OptionEntry for alternative nest art

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -101,7 +101,6 @@ bool gbLoadGame;
 bool cineflag;
 int force_redraw;
 int PauseMode;
-bool gbNestArt;
 bool gbBard;
 bool gbBarbarian;
 bool gbQuietMode = false;
@@ -836,7 +835,6 @@ void RunGameLoop(interface_mode uMsg)
 	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--diablo", _("Force Diablo mode").c_str());
 	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--hellfire", _("Force Hellfire mode").c_str());
 	printInConsole("%s", _(/* TRANSLATORS: Commandline Option */ "\nHellfire options:\n").c_str());
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--nestart", _("Use alternate nest palette").c_str());
 #ifdef _DEBUG
 	printInConsole("\nDebug options:\n");
 	printInConsole("    %-20s %-30s\n", "-i", "Ignore network timeout");
@@ -905,8 +903,6 @@ void DiabloParseFlags(int argc, char **argv)
 			forceDiablo = true;
 		} else if (arg == "--hellfire") {
 			forceHellfire = true;
-		} else if (arg == "--nestart") {
-			gbNestArt = true;
 		} else if (arg == "--vanilla") {
 			gbVanilla = true;
 		} else if (arg == "--verbose") {

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -72,7 +72,6 @@ extern int force_redraw;
 /* These are defined in fonts.h */
 extern void FontsCleanup();
 extern DVL_API_FOR_TEST int PauseMode;
-extern bool gbNestArt;
 extern bool gbBard;
 extern bool gbBarbarian;
 /**

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -752,6 +752,7 @@ GraphicsOptions::GraphicsOptions()
 #endif
     , gammaCorrection("Gamma Correction", OptionEntryFlags::Invisible, "Gamma Correction", "Gamma correction level.", 100)
     , colorCycling("Color Cycling", OptionEntryFlags::None, N_("Color Cycling"), N_("Color cycling effect used for water, lava, and acid animation."), true)
+    , alternateNestArt("Alternate nest art", OptionEntryFlags::OnlyHellfire | OptionEntryFlags::CantChangeInGame, N_("Alternate nest art"), N_("The game will use an alternative palette for Hellfire’s nest tileset."), false)
 #if SDL_VERSION_ATLEAST(2, 0, 0)
     , hardwareCursor("Hardware Cursor", OptionEntryFlags::CantChangeInGame | OptionEntryFlags::RecreateUI | (HardwareCursorSupported() ? OptionEntryFlags::None : OptionEntryFlags::Invisible), N_("Hardware Cursor"), N_("Use a hardware cursor"), HardwareCursorDefault())
     , hardwareCursorForItems("Hardware Cursor For Items", OptionEntryFlags::CantChangeInGame | (HardwareCursorSupported() ? OptionEntryFlags::None : OptionEntryFlags::Invisible), N_("Hardware Cursor For Items"), N_("Use a hardware cursor for items."), false)
@@ -798,6 +799,7 @@ std::vector<OptionEntryBase *> GraphicsOptions::GetEntries()
 		&showHealthValues,
 		&showManaValues,
 		&colorCycling,
+		&alternateNestArt,
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 		&hardwareCursor,
 		&hardwareCursorForItems,

--- a/Source/options.h
+++ b/Source/options.h
@@ -400,6 +400,8 @@ struct GraphicsOptions : OptionCategoryBase {
 	OptionEntryInt<int> gammaCorrection;
 	/** @brief Enable color cycling animations. */
 	OptionEntryBoolean colorCycling;
+	/** @brief Use alternate nest palette. */
+	OptionEntryBoolean alternateNestArt;
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	/** @brief Use a hardware cursor (SDL2 only). */
 	OptionEntryBoolean hardwareCursor;

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -244,7 +244,7 @@ void LoadRndLvlPal(dungeon_type l)
 
 	char szFileName[27];
 	if (l == DTYPE_NEST) {
-		if (!gbNestArt) {
+		if (!*sgOptions.Graphics.alternateNestArt) {
 			rv++;
 		}
 		sprintf(szFileName, "NLevels\\L%iData\\L%iBase%i.PAL", 6, 6, rv);


### PR DESCRIPTION
… and remove command line parameter `--nestart`.

This enables platforms that can't use command line parameter (for example android) to use the alternative nest art.
It's also easier to access cause it's now part of the settings menu.