### PR TITLE
Address c4244 warning in PointerOrValue

### DIFF
--- a/Source/utils/pointer_value_union.hpp
+++ b/Source/utils/pointer_value_union.hpp
@@ -40,7 +40,7 @@ public:
 
 	[[nodiscard]] T AsValue() const
 	{
-		return repr_ >> 1;
+		return static_cast<T>(repr_ >> 1);
 	}
 
 private:


### PR DESCRIPTION
This triggers a bunch of warnings in MSVC because the conversion is potentially truncating, despite never being an issue in practice...