### PR TITLE
Remove calls to NewCursor() from store functions

### DIFF
--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -1400,7 +1400,6 @@ void SmithBuyEnter()
 	}
 
 	myPlayer.HoldItem = smithitem[idx];
-	NewCursor(myPlayer.HoldItem._iCurs + CURSOR_FIRSTITEM);
 
 	bool done = AutoEquipEnabled(myPlayer, myPlayer.HoldItem) && AutoEquip(MyPlayerId, myPlayer.HoldItem, false);
 
@@ -1408,7 +1407,6 @@ void SmithBuyEnter()
 		StartStore(STORE_CONFIRM);
 	else
 		StartStore(STORE_NOROOM);
-	NewCursor(CURSOR_HAND);
 }
 
 /**
@@ -1468,15 +1466,13 @@ void SmithPremiumBuyEnter()
 	}
 
 	myPlayer.HoldItem = premiumitems[idx];
-	NewCursor(myPlayer.HoldItem._iCurs + CURSOR_FIRSTITEM);
+
 	bool done = AutoEquipEnabled(myPlayer, myPlayer.HoldItem) && AutoEquip(MyPlayerId, myPlayer.HoldItem, false);
 
 	if (done || AutoPlaceItemInInventory(myPlayer, myPlayer.HoldItem, false))
 		StartStore(STORE_CONFIRM);
 	else
 		StartStore(STORE_NOROOM);
-
-	NewCursor(CURSOR_HAND);
 }
 
 bool StoreGoldFit(int idx)
@@ -1670,15 +1666,13 @@ void WitchBuyEnter()
 	}
 
 	myPlayer.HoldItem = witchitem[idx];
-	NewCursor(myPlayer.HoldItem._iCurs + CURSOR_FIRSTITEM);
+
 	bool done = AutoEquipEnabled(myPlayer, myPlayer.HoldItem) && AutoEquip(MyPlayerId, myPlayer.HoldItem, false);
 
 	if (done || AutoPlaceItemInInventory(myPlayer, myPlayer.HoldItem, false) || AutoPlaceItemInBelt(myPlayer, myPlayer.HoldItem, false))
 		StartStore(STORE_CONFIRM);
 	else
 		StartStore(STORE_NOROOM);
-
-	NewCursor(CURSOR_HAND);
 }
 
 void WitchSellEnter()
@@ -1849,7 +1843,6 @@ void BoyBuyEnter()
 
 	myPlayer.HoldItem = boyitem;
 	myPlayer.HoldItem._iIvalue = price;
-	NewCursor(myPlayer.HoldItem._iCurs + CURSOR_FIRSTITEM);
 
 	bool done = false;
 	if (AutoEquipEnabled(myPlayer, myPlayer.HoldItem) && AutoEquip(MyPlayerId, myPlayer.HoldItem, false)) {
@@ -1861,8 +1854,6 @@ void BoyBuyEnter()
 	}
 
 	StartStore(done ? STORE_CONFIRM : STORE_NOROOM);
-
-	NewCursor(CURSOR_HAND);
 }
 
 void StorytellerIdentifyItem()
@@ -1986,7 +1977,6 @@ void HealerBuyEnter()
 	}
 
 	myPlayer.HoldItem = healitem[idx];
-	NewCursor(myPlayer.HoldItem._iCurs + CURSOR_FIRSTITEM);
 
 	bool done = AutoEquipEnabled(myPlayer, myPlayer.HoldItem) && AutoEquip(MyPlayerId, myPlayer.HoldItem, false);
 
@@ -1994,8 +1984,6 @@ void HealerBuyEnter()
 		StartStore(STORE_CONFIRM);
 	else
 		StartStore(STORE_NOROOM);
-
-	NewCursor(CURSOR_HAND);
 }
 
 void StorytellerEnter()


### PR DESCRIPTION
@ikonomov reported this issue on Discord.
> in Hellfire single player when I try to buy an item from Pepin the gold is spent, but no item is transferred to the inventory
> and at Gris and Adria when I buy an item it appears in the inventory, but when I try to interact with the newly bought item it disapears

The culprit here is the code introduced into `NewCursor()` by #4239. Or perhaps it would be more accurate to say it's the stores' abuse of the `Player::HoldItem` variable. Regardless, the calls to `NewCursor()` in each of the `*BuyEnter()` functions was clearing the item type of the hold item, causing the item to disappear after it was copied from there into the player's inventory.

I suspect that the reason the stores were setting the cursor in the first place was to populate the `icurseSize28` variable so it could be used to determine whether the player has room for the item in their inventory. Nowadays, the `AutoPlaceItemInInventory()` function uses the `GetInventorySize()` function which computes the size from the item's cursor data without having to actually update the cursor. Removing the `NewCursor()` calls resolves the bug and doesn't seem to have any adverse effects.