### PR TITLE
Don't use HoldItem in CMD_PUTITEM handler

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1836,14 +1836,14 @@ bool TryInvPut()
 	return CanPut(myPlayer.position.tile);
 }
 
-int InvPutItem(Player &player, Point position)
+int InvPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac)
 {
 	if (player.plrlevel == 0) {
-		if (player.HoldItem.IDidx == IDI_RUNEBOMB && OpensHive(position)) {
+		if (idx == IDI_RUNEBOMB && OpensHive(position)) {
 			OpenHive();
 			return -1;
 		}
-		if (player.HoldItem.IDidx == IDI_MAPOFDOOM && OpensGrave(position)) {
+		if (idx == IDI_MAPOFDOOM && OpensGrave(position)) {
 			OpenCrypt();
 			return -1;
 		}
@@ -1854,22 +1854,7 @@ int InvPutItem(Player &player, Point position)
 
 	assert(CanPut(position));
 
-	int ii = AllocateItem();
-
-	dItem[position.x][position.y] = ii + 1;
-	Items[ii] = player.HoldItem;
-	Items[ii].position = position;
-	RespawnItem(Items[ii], true);
-
-	if (currlevel == 21 && position == CornerStone.position) {
-		CornerStone.item = Items[ii];
-		InitQTextMsg(TEXT_CORNSTN);
-		Quests[Q_CORNSTN]._qlog = false;
-		Quests[Q_CORNSTN]._qactive = QUEST_DONE;
-	}
-
-	NewCursor(CURSOR_HAND);
-	return ii;
+	return SyncDropItem(position, idx, icreateinfo, iseed, id, dur, mdur, ch, mch, ivalue, ibuff, toHit, maxDam, minStr, minMag, minDex, ac);
 }
 
 int SyncPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac)
@@ -1916,10 +1901,10 @@ int SyncDropItem(Point position, int idx, uint16_t icreateinfo, int iseed, int i
 	}
 
 	item.position = position;
-	RespawnItem(Items[ii], true);
+	RespawnItem(item, true);
 
 	if (currlevel == 21 && position == CornerStone.position) {
-		CornerStone.item = Items[ii];
+		CornerStone.item = item;
 		InitQTextMsg(TEXT_CORNSTN);
 		Quests[Q_CORNSTN]._qlog = false;
 		Quests[Q_CORNSTN]._qactive = QUEST_DONE;

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -201,7 +201,7 @@ int FindGetItem(int32_t iseed, _item_indexes idx, uint16_t ci);
 void SyncGetItem(Point position, int32_t iseed, _item_indexes idx, uint16_t ci);
 bool CanPut(Point position);
 bool TryInvPut();
-int InvPutItem(Player &player, Point position);
+int InvPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
 int SyncPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
 int SyncDropItem(Point position, int idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
 int8_t CheckInvHLight();

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -857,7 +857,7 @@ DWORD OnPutItem(const TCmd *pCmd, int pnum)
 		if (currlevel == Players[pnum].plrlevel) {
 			int ii;
 			if (pnum == MyPlayerId)
-				ii = InvPutItem(Players[pnum], position);
+				ii = InvPutItem(Players[pnum], position, message.wIndx, message.wCI, message.dwSeed, message.bId, message.bDur, message.bMDur, message.bCh, message.bMCh, message.wValue, message.dwBuff, message.wToHit, message.wMaxDam, message.bMinStr, message.bMinMag, message.bMinDex, message.bAC);
 			else
 				ii = SyncPutItem(Players[pnum], position, message.wIndx, message.wCI, message.dwSeed, message.bId, message.bDur, message.bMDur, message.bCh, message.bMCh, message.wValue, message.dwBuff, message.wToHit, message.wMaxDam, message.bMinStr, message.bMinMag, message.bMinDex, message.bAC);
 			if (ii != -1) {


### PR DESCRIPTION
Similar to the issue mentioned in #4274, dropping items on the ground causes the hold item to lose its item type. In this case, the game tries to use the hold item in the handler for the `CMD_PUTITEM` network message, but the cursor was cleared in the previous frame when generating the network message.

Of course, the game only uses the hold item on the local client because remote clients would not have access to that data. Instead, remote clients must recreate the item using the item information included in the network message, which was copied from the hold item when generating the network message. The idea behind this change is to go ahead and recreate the item on the local client as well instead of abusing the hold item as swap space.