### PR TITLE
Don't destroy hold item when setting cursor to hourglass

### DIFF
--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -177,7 +177,7 @@ void ResetCursor()
 
 void NewCursor(int cursId)
 {
-	if (cursId < CURSOR_FIRSTITEM && MyPlayer != nullptr) {
+	if (cursId < CURSOR_HOURGLASS && MyPlayer != nullptr) {
 		MyPlayer->HoldItem._itype = ItemType::None;
 	}
 	pcurs = cursId;


### PR DESCRIPTION
The hourglass cursor should be an exception to the rule here. When the lag ends, the item cursor will be restored so the hold item is still valid.