### PR TITLE
Add helpers to change stash pages

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -510,7 +510,7 @@ void PressKey(int vkey)
 		} else if (AutomapActive) {
 			AutomapUp();
 		} else if (IsStashOpen) {
-			Stash.SetPage(Stash.GetPage() - 1);
+			Stash.PreviousPage();
 		}
 	} else if (vkey == DVL_VK_DOWN) {
 		if (stextflag != STORE_NONE) {
@@ -524,7 +524,7 @@ void PressKey(int vkey)
 		} else if (AutomapActive) {
 			AutomapDown();
 		} else if (IsStashOpen) {
-			Stash.SetPage(Stash.GetPage() + 1);
+			Stash.NextPage();
 		}
 	} else if (vkey == DVL_VK_PRIOR) {
 		if (stextflag != STORE_NONE) {

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1809,6 +1809,8 @@ void LoadStash()
 	for (unsigned i = 0; i < itemCount; i++) {
 		LoadItemData(file, Stash.stashList[i]);
 	}
+
+	Stash.SetPage(file.NextLE<uint32_t>());
 }
 
 void RemoveEmptyInventory(Player &player)
@@ -2055,7 +2057,8 @@ void SaveStash()
 	        + sizeof(uint32_t)
 	        + (sizeof(uint32_t) + 10 * 10 * sizeof(uint16_t)) * Stash.stashGrids.size()
 	        + sizeof(uint32_t)
-	        + itemSize * Stash.stashList.size());
+	        + itemSize * Stash.stashList.size()
+	        + sizeof(uint32_t));
 
 	file.WriteLE<uint8_t>(StashVersion);
 
@@ -2077,6 +2080,8 @@ void SaveStash()
 	for (const Item &item : Stash.stashList) {
 		SaveItem(file, item);
 	}
+
+	file.WriteLE<uint32_t>(static_cast<uint32_t>(Stash.GetPage()));
 }
 
 void SaveGameData()

--- a/Source/miniwin/misc_msg.cpp
+++ b/Source/miniwin/misc_msg.cpp
@@ -320,13 +320,13 @@ void ProcessGamepadEvents(GameAction &action)
 		break;
 	case GameActionType_USE_HEALTH_POTION:
 		if (IsStashOpen)
-			Stash.SetPage(Stash.GetPage() - 1);
+			Stash.PreviousPage();
 		else
 			UseBeltItem(BLT_HEALING);
 		break;
 	case GameActionType_USE_MANA_POTION:
 		if (IsStashOpen)
-			Stash.SetPage(Stash.GetPage() + 1);
+			Stash.NextPage();
 		else
 			UseBeltItem(BLT_MANA);
 		break;

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -536,6 +536,7 @@ void StashStruct::RemoveStashItem(uint16_t iv)
 void StashStruct::SetPage(unsigned newPage)
 {
 	page = std::min(newPage, LastStashPage);
+	dirty = true;
 }
 
 void StashStruct::NextPage(unsigned offset)
@@ -545,6 +546,7 @@ void StashStruct::NextPage(unsigned offset)
 	} else {
 		page = LastStashPage;
 	}
+	dirty = true;
 }
 
 void StashStruct::PreviousPage(unsigned offset)
@@ -554,6 +556,7 @@ void StashStruct::PreviousPage(unsigned offset)
 	} else {
 		page = LastStashPage;
 	}
+	dirty = true;
 }
 
 void StashStruct::RefreshItemStatFlags()

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -29,6 +29,7 @@ int WithdrawGoldValue;
 namespace {
 
 constexpr unsigned CountStashPages = 50;
+constexpr unsigned LastStashPage = CountStashPages - 1;
 
 int InitialWithdrawGoldValue;
 
@@ -293,19 +294,19 @@ void CheckStashButtonRelease(Point mousePosition)
 	if (stashButton.Contains(mousePosition)) {
 		switch (StashButtonPressed) {
 		case 0:
-			Stash.SetPage(Stash.GetPage() - 10);
+			Stash.PreviousPage(10);
 			break;
 		case 1:
-			Stash.SetPage(Stash.GetPage() - 1);
+			Stash.PreviousPage();
 			break;
 		case 2:
 			StartGoldWithdraw();
 			break;
 		case 3:
-			Stash.SetPage(Stash.GetPage() + 1);
+			Stash.NextPage();
 			break;
 		case 4:
-			Stash.SetPage(Stash.GetPage() + 10);
+			Stash.NextPage(10);
 			break;
 		}
 	}
@@ -534,7 +535,25 @@ void StashStruct::RemoveStashItem(uint16_t iv)
 
 void StashStruct::SetPage(unsigned newPage)
 {
-	page = std::min(newPage, CountStashPages - 1);
+	page = std::min(newPage, LastStashPage);
+}
+
+void StashStruct::NextPage(unsigned offset)
+{
+	if (page <= LastStashPage) {
+		page += std::min(offset, LastStashPage - page);
+	} else {
+		page = LastStashPage;
+	}
+}
+
+void StashStruct::PreviousPage(unsigned offset)
+{
+	if (page <= LastStashPage) {
+		page -= std::min(offset, page);
+	} else {
+		page = LastStashPage;
+	}
 }
 
 void StashStruct::RefreshItemStatFlags()

--- a/Source/qol/stash.h
+++ b/Source/qol/stash.h
@@ -28,6 +28,9 @@ public:
 	}
 
 	void SetPage(unsigned newPage);
+	void NextPage(unsigned offset = 1);
+	void PreviousPage(unsigned offset = 1);
+
 	/** @brief Updates _iStatFlag for all stash items. */
 	void RefreshItemStatFlags();
 


### PR DESCRIPTION
The first commit addresses a bug I introduced in #4265 and #4281 where the stash page counter can underflow allowing navigation from page 1 directly to page 50. Splitting the other helpers to a separate PR since they're independent.