### PR TITLE
Monks do not automatically equip shields

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1402,9 +1402,7 @@ bool AutoEquip(int playerId, const Item &item, bool persistItem)
 bool AutoEquipEnabled(const Player &player, const Item &item)
 {
 	if (item.isWeapon()) {
-		// Monk can use unarmed attack as an encouraged option, thus we do not automatically equip weapons on him so as to not
-		// annoy players who prefer that playstyle.
-		return player._pClass != HeroClass::Monk && *sgOptions.Gameplay.autoEquipWeapons;
+		return *sgOptions.Gameplay.autoEquipWeapons;
 	}
 
 	if (item.isArmor()) {
@@ -1416,9 +1414,7 @@ bool AutoEquipEnabled(const Player &player, const Item &item)
 	}
 
 	if (item.isShield()) {
-		// Monk can use unarmed attack as an encouraged option, thus we do not automatically equip shields on him so as to not
-		// annoy players who prefer that playstyle.
-		return player._pClass != HeroClass::Monk && *sgOptions.Gameplay.autoEquipShields;
+		return *sgOptions.Gameplay.autoEquipShields;
 	}
 
 	if (item.isJewelry()) {

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1416,7 +1416,9 @@ bool AutoEquipEnabled(const Player &player, const Item &item)
 	}
 
 	if (item.isShield()) {
-		return *sgOptions.Gameplay.autoEquipShields;
+		// Monk can use unarmed attack as an encouraged option, thus we do not automatically equip shields on him so as to not
+		// annoy players who prefer that playstyle.
+		return player._pClass != HeroClass::Monk && *sgOptions.Gameplay.autoEquipShields;
 	}
 
 	if (item.isJewelry()) {


### PR DESCRIPTION
Monks suffer a penalty to unarmed damage (1/2) whenever they have a shield or a weapon equipped so likely players that prefer this playstyle wouldn't want to have both weapons and shields automatically equipped.