### PR TITLE
Fix #4251 macOS mouse grab issue

### DIFF
--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -243,11 +243,11 @@ bool SpawnWindow(const char *lpWindowName)
 		flags |= SDL_WINDOW_FULLSCREEN;
 	}
 
-	if (*sgOptions.Gameplay.grabInput) {
-		flags |= SDL_WINDOW_INPUT_GRABBED;
-	}
-
 	ghMainWnd = SDL_CreateWindow(lpWindowName, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, windowSize.width, windowSize.height, flags);
+    
+    if (ghMainWnd != nullptr)
+        SDL_SetWindowGrab(ghMainWnd, *sgOptions.Gameplay.grabInput ? SDL_TRUE : SDL_FALSE);
+    
 #endif
 	if (ghMainWnd == nullptr) {
 		ErrSdl();

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -245,8 +245,9 @@ bool SpawnWindow(const char *lpWindowName)
 
 	ghMainWnd = SDL_CreateWindow(lpWindowName, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, windowSize.width, windowSize.height, flags);
 
-    // Note: https://github.com/libsdl-org/SDL/issues/962
-    // This is a solution to a problem related to SDL mouse grab.
+	// Note: https://github.com/libsdl-org/SDL/issues/962
+	// This is a solution to a problem related to SDL mouse grab.
+	// See https://github.com/diasurgical/devilutionX/issues/4251
 	if (ghMainWnd != nullptr)
 		SDL_SetWindowGrab(ghMainWnd, *sgOptions.Gameplay.grabInput ? SDL_TRUE : SDL_FALSE);
 

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -245,6 +245,8 @@ bool SpawnWindow(const char *lpWindowName)
 
 	ghMainWnd = SDL_CreateWindow(lpWindowName, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, windowSize.width, windowSize.height, flags);
 
+    // Note: https://github.com/libsdl-org/SDL/issues/962
+    // This is a solution to a problem related to SDL mouse grab.
 	if (ghMainWnd != nullptr)
 		SDL_SetWindowGrab(ghMainWnd, *sgOptions.Gameplay.grabInput ? SDL_TRUE : SDL_FALSE);
 

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -244,10 +244,10 @@ bool SpawnWindow(const char *lpWindowName)
 	}
 
 	ghMainWnd = SDL_CreateWindow(lpWindowName, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, windowSize.width, windowSize.height, flags);
-    
-    if (ghMainWnd != nullptr)
-        SDL_SetWindowGrab(ghMainWnd, *sgOptions.Gameplay.grabInput ? SDL_TRUE : SDL_FALSE);
-    
+
+	if (ghMainWnd != nullptr)
+		SDL_SetWindowGrab(ghMainWnd, *sgOptions.Gameplay.grabInput ? SDL_TRUE : SDL_FALSE);
+
 #endif
 	if (ghMainWnd == nullptr) {
 		ErrSdl();


### PR DESCRIPTION
I think this is fundamentally an SDL issue.
However, I think this is fine, since the problem can be avoided by making the process the same as the options menu.

Tested on:
MacBook Pro 2017 / macOS 12.3 / Retina
Note PC / Zorin OS / Non-Retina