### PR TITLE
Correctly center panel text when holding red item

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -859,8 +859,7 @@ void DrawInfoBox(const Surface &out)
 			int nGold = myPlayer.HoldItem._ivalue;
 			InfoString = fmt::format(ngettext("{:d} gold piece", "{:d} gold pieces", nGold), nGold);
 		} else if (!myPlayer.CanUseItem(myPlayer.HoldItem)) {
-			ClearPanel();
-			AddPanelString(_("Requirements not met"));
+			InfoString = _("Requirements not met");
 		} else {
 			if (myPlayer.HoldItem._iIdentified)
 				InfoString = myPlayer.HoldItem._iIName;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/204594/161406626-0c24b3b9-3a00-408d-8215-3d13b2d899e6.png)

After:
![image](https://user-images.githubusercontent.com/204594/161406638-24468452-a396-44ad-b6a0-df8ed2b51d12.png)
