### PR TITLE
Remove unnecessary string copies in error.cpp

### DIFF
--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -29,11 +29,9 @@ const int LineWidth = 418;
 void InitNextLines()
 {
 	msgdelay = SDL_GetTicks();
-	auto message = DiabloMessages.front();
-
 	TextLines.clear();
 
-	const std::string paragraphs = WordWrapString(message, LineWidth, GameFont12, 1);
+	const std::string paragraphs = WordWrapString(DiabloMessages.front(), LineWidth, GameFont12, 1);
 
 	size_t previous = 0;
 	while (true) {
@@ -165,7 +163,6 @@ void DrawDiabloMsg(const Surface &out)
 
 	DrawHalfTransparentRectTo(out, PANEL_X + 104, dialogStartY - 8, 432, ErrorWindowHeight);
 
-	auto message = DiabloMessages.front();
 	int lineNumber = 0;
 	for (auto &line : TextLines) {
 		DrawString(out, line, { { PANEL_X + 109, dialogStartY + 12 + lineNumber * LineHeight }, { LineWidth, LineHeight } }, UiFlags::AlignCenter, 1, LineHeight);


### PR DESCRIPTION
`message` was unused in `DrawDiabloMsg()`, only one use in `InitNextLines()` so inlined the call there.