### PR TITLE
Address type conversion warnings in WordWrapString

### DIFF
--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -502,7 +502,7 @@ int AdjustSpacingToFitHorizontally(int &lineWidth, int maxSpacing, int character
 	return maxSpacing - spacingRedux;
 }
 
-std::string WordWrapString(string_view text, size_t width, GameFontTables size, int spacing)
+std::string WordWrapString(string_view text, unsigned width, GameFontTables size, int spacing)
 {
 	std::string output;
 	if (text.empty() || text[0] == '\0')
@@ -511,21 +511,21 @@ std::string WordWrapString(string_view text, size_t width, GameFontTables size, 
 	output.reserve(text.size());
 	const char *begin = text.data();
 	const char *processedEnd = text.data();
-	int lastBreakablePos = -1;
-	int lastBreakableLen;
+	std::size_t lastBreakablePos = -1;
+	std::size_t lastBreakableLen;
 	bool lastBreakableKeep = false;
 	uint32_t currentUnicodeRow = 0;
-	size_t lineWidth = 0;
+	unsigned lineWidth = 0;
 	std::array<uint8_t, 256> *kerning = nullptr;
 
 	char32_t codepoint = U'\0'; // the current codepoint
 	char32_t nextCodepoint;     // the next codepoint
-	uint8_t nextCodepointLen;
+	std::size_t nextCodepointLen;
 	string_view remaining = text;
 	nextCodepoint = DecodeFirstUtf8CodePoint(remaining, &nextCodepointLen);
 	do {
 		codepoint = nextCodepoint;
-		const uint8_t codepointLen = nextCodepointLen;
+		const std::size_t codepointLen = nextCodepointLen;
 		if (codepoint == Utf8DecodeError)
 			break;
 		remaining.remove_prefix(codepointLen);
@@ -551,7 +551,7 @@ std::string WordWrapString(string_view text, size_t width, GameFontTables size, 
 
 		const bool isWhitespace = IsWhitespace(codepoint);
 		if (isWhitespace || IsBreakAllowed(codepoint, nextCodepoint)) {
-			lastBreakablePos = static_cast<int>(remaining.data() - begin - codepointLen);
+			lastBreakablePos = remaining.data() - begin - codepointLen;
 			lastBreakableLen = codepointLen;
 			lastBreakableKeep = !isWhitespace;
 			continue;

--- a/Source/engine/render/text_render.hpp
+++ b/Source/engine/render/text_render.hpp
@@ -152,7 +152,19 @@ int GetLineWidth(string_view fmt, DrawStringFormatArg *args, std::size_t argsLen
 
 int GetLineHeight(string_view text, GameFontTables fontIndex);
 
-[[nodiscard]] std::string WordWrapString(string_view text, size_t width, GameFontTables size = GameFont12, int spacing = 1);
+/**
+ * @brief Builds a multi-line version of the given text so it'll fit within the given width.
+ *
+ * This function will not break words, if the given width is smaller than the width of the longest word in the given
+ * font then it will likely overflow the output region.
+ *
+ * @param text Source text
+ * @param width Width in pixels of the output region
+ * @param size Font size to use for the width calculation
+ * @param spacing Any adjustment to apply between each character
+ * @return A copy of the source text with newlines inserted where appropriate
+ */
+[[nodiscard]] std::string WordWrapString(string_view text, unsigned width, GameFontTables size = GameFont12, int spacing = 1);
 
 /**
  * @brief Draws a line of text within a clipping rectangle (positioned relative to the origin of the output buffer).

--- a/Source/utils/utf8.cpp
+++ b/Source/utils/utf8.cpp
@@ -22,7 +22,7 @@ string_view TruncateUtf8(string_view str, std::size_t len)
 
 } // namespace
 
-char32_t DecodeFirstUtf8CodePoint(string_view input, uint8_t *len)
+char32_t DecodeFirstUtf8CodePoint(string_view input, std::size_t *len)
 {
 	uint32_t codepoint = 0;
 	uint32_t state = UTF8_ACCEPT;

--- a/Source/utils/utf8.hpp
+++ b/Source/utils/utf8.hpp
@@ -16,14 +16,14 @@ constexpr char32_t Utf8DecodeError = 0xD83F;
  * Sets `len` to the length of the code point in bytes.
  * Returns `Utf8DecodeError` on error.
  */
-char32_t DecodeFirstUtf8CodePoint(string_view input, uint8_t *len);
+char32_t DecodeFirstUtf8CodePoint(string_view input, std::size_t *len);
 
 /**
  * Decodes and removes the first code point from UTF8-encoded input.
  */
 inline char32_t ConsumeFirstUtf8CodePoint(string_view *input)
 {
-	uint8_t len;
+	std::size_t len;
 	const char32_t result = DecodeFirstUtf8CodePoint(*input, &len);
 	input->remove_prefix(len);
 	return result;


### PR DESCRIPTION
A few warnings were being generated about potentially truncating conversions in this function and `DecodeFirstUtf8CodePoint()`. Consistently use `std::size_t` for calls relating to a string length or offset to address downcast warnings. Also changed the types for dealing with a pixel width to unsigned, given kerning is 8 bits and spacing is int this was giving potential overflow warnings.