### PR TITLE
Ensure Reflect + Thorn don't kill a monster twice

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1414,7 +1414,8 @@ void MonsterAttackPlayer(int i, int pnum, int hit, int minDam, int maxDam)
 			CheckReflect(i, pnum, dam);
 		ApplyPlrDamage(pnum, 0, 0, dam);
 	}
-	if ((player._pIFlags & ISPL_THORNS) != 0) {
+	// Reflect can also kill a monster, so make sure the monster is still alive
+	if ((player._pIFlags & ISPL_THORNS) != 0 && monster._mmode != MonsterMode::Death) {
 		int mdam = (GenerateRnd(3) + 1) << 6;
 		monster._mhitpoints -= mdam;
 		if (monster._mhitpoints >> 6 <= 0)


### PR DESCRIPTION
Fixes #3869

Notes
- When a monster hits (`MonsterAttackPlayer`) first reflect is calculated. Reflect can kill a monster (`CheckReflect` -> `M_StartKill` -> `StartMonsterDeath`).
- After this thorn (`Attacker takes x Damage`) is calculated. Thorn can also kill a monster (`M_StartKill` -> `StartMonsterDeath`).
- If reflect already killed the monster (and set it's hp to less then 1). Then thorn also adds damage, sees the monster has hp less then 1 and also triggers the kill. When this happens we have the double kill.
- This is not specific to Na-Krul. It can happen with any monster.