### PR TITLE
Mouse/Gamepad fixes

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -666,11 +666,7 @@ void LoadBackgroundArt(const char *pszFile, int frames)
 	fadeTc = 0;
 	fadeValue = 0;
 
-	if (IsHardwareCursorEnabled() && ArtCursor.surface != nullptr && GetCurrentCursorInfo().type() != CursorType::UserInterface) {
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-		SDL_SetSurfacePalette(ArtCursor.surface.get(), Palette.get());
-		SDL_SetColorKey(ArtCursor.surface.get(), 1, 0);
-#endif
+	if (IsHardwareCursorEnabled() && ArtCursor.surface != nullptr && ControlDevice == ControlTypes::KeyboardAndMouse && GetCurrentCursorInfo().type() != CursorType::UserInterface) {
 		SetHardwareCursor(CursorInfo::UserInterfaceCursor());
 	}
 
@@ -757,7 +753,7 @@ void UiPollAndRender(std::function<bool(SDL_Event &)> eventHandler)
 
 	// Must happen after the very first UiFadeIn, which sets the cursor.
 	if (IsHardwareCursor())
-		SetHardwareCursorVisible(ControlMode == ControlTypes::KeyboardAndMouse);
+		SetHardwareCursorVisible(ControlDevice == ControlTypes::KeyboardAndMouse);
 
 #ifdef __3DS__
 	// Keyboard blocks until input is finished
@@ -1082,7 +1078,7 @@ bool UiItemMouseEvents(SDL_Event *event, const std::vector<std::unique_ptr<UiIte
 
 void DrawMouse()
 {
-	if (ControlMode != ControlTypes::KeyboardAndMouse || IsHardwareCursor())
+	if (ControlDevice != ControlTypes::KeyboardAndMouse || IsHardwareCursor())
 		return;
 
 	DrawArt(MousePosition, &ArtCursor);

--- a/Source/controls/plrctrls.h
+++ b/Source/controls/plrctrls.h
@@ -3,6 +3,8 @@
 
 #include <cstdint>
 
+#include <SDL.h>
+
 #include "controls/controller.h"
 #include "player.h"
 
@@ -20,7 +22,24 @@ enum class ControlTypes : uint8_t {
 	VirtualGamepad,
 };
 
+string_view ControlTypeToString(ControlTypes controlType);
+
+/**
+ * @brief Call this after sending a simulated mouse button click event.
+ */
+void NextMouseButtonClickEventIsSimulated();
+
 extern ControlTypes ControlMode;
+
+/**
+ * @brief Controlling device type.
+ *
+ * While simulating a mouse, `ControlMode` is set to `KeyboardAndMouse`,
+ * even though a gamepad is used to control it.
+ *
+ * This value is always set to the actual active device type.
+ */
+extern ControlTypes ControlDevice;
 
 // Runs every frame.
 // Handles menu movement.

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -7,6 +7,8 @@
 
 #include <fmt/format.h>
 
+#include "DiabloUI/art.h"
+#include "DiabloUI/diabloui.h"
 #include "control.h"
 #include "controls/plrctrls.h"
 #include "doom.h"
@@ -183,8 +185,16 @@ void NewCursor(int cursId)
 	pcurs = cursId;
 	cursSize = GetInvItemSize(cursId);
 	SetICursor(cursId);
-	if (IsHardwareCursorEnabled() && ControlMode == ControlTypes::KeyboardAndMouse && GetCurrentCursorInfo() != CursorInfo::GameCursor(cursId) && cursId != CURSOR_NONE) {
-		SetHardwareCursor(CursorInfo::GameCursor(cursId));
+
+	if (IsHardwareCursorEnabled() && ControlDevice == ControlTypes::KeyboardAndMouse) {
+		if (ArtCursor.surface == nullptr && cursId == CURSOR_NONE)
+			return;
+
+		const CursorInfo newCursor = ArtCursor.surface == nullptr
+		    ? CursorInfo::GameCursor(cursId)
+		    : CursorInfo::UserInterfaceCursor();
+		if (newCursor != GetCurrentCursorInfo())
+			SetHardwareCursor(newCursor);
 	}
 }
 

--- a/Source/hwcursor.cpp
+++ b/Source/hwcursor.cpp
@@ -145,6 +145,8 @@ void SetHardwareCursor(CursorInfo cursorInfo)
 		// ArtCursor is null while loading the game on the progress screen,
 		// called via palette fade from ShowProgress.
 		if (ArtCursor.surface != nullptr) {
+			SDL_SetSurfacePalette(ArtCursor.surface.get(), Palette.get());
+			SDL_SetColorKey(ArtCursor.surface.get(), 1, 0);
 			CurrentCursorInfo.SetEnabled(
 			    IsCursorSizeAllowed(Size { ArtCursor.surface->w, ArtCursor.surface->h })
 			    && SetHardwareCursor(ArtCursor.surface.get(), HotpointPosition::TopLeft));

--- a/Source/miniwin/misc_msg.cpp
+++ b/Source/miniwin/misc_msg.cpp
@@ -68,7 +68,7 @@ void SetMouseButtonEvent(SDL_Event &event, uint32_t type, uint8_t button, Point 
 
 void SetCursorPos(Point position)
 {
-	if (ControlMode != ControlTypes::KeyboardAndMouse) {
+	if (ControlDevice != ControlTypes::KeyboardAndMouse) {
 		MousePosition = position;
 		return;
 	}
@@ -398,6 +398,7 @@ void ProcessGamepadEvents(GameAction &action)
 		Uint8 simulatedButton = action.send_mouse_click.button == GameActionSendMouseClick::LEFT ? SDL_BUTTON_LEFT : SDL_BUTTON_RIGHT;
 		SDL_Event clickEvent;
 		SetMouseButtonEvent(clickEvent, action.send_mouse_click.up ? SDL_MOUSEBUTTONUP : SDL_MOUSEBUTTONDOWN, simulatedButton, MousePosition);
+		NextMouseButtonClickEventIsSimulated();
 		SDL_PushEvent(&clickEvent);
 		break;
 	}

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -31,7 +31,7 @@ void play_movie(const char *pszMovie, bool userCanClose)
 	stream_stop();
 	effects_play_sound("Sfx\\Misc\\blank.wav");
 
-	if (IsHardwareCursorEnabled() && ControlMode == ControlTypes::KeyboardAndMouse) {
+	if (IsHardwareCursorEnabled() && ControlDevice == ControlTypes::KeyboardAndMouse) {
 		SetHardwareCursorVisible(false);
 	}
 


### PR DESCRIPTION
Introduces a `ControlDevice` global which is distinct from `ControlMode` in that it is set to `Gamepad` even when simulating a mouse.

This allows us to avoid a number of edge cases related to mode changes.

Fixes #4242