### PR TITLE
Make 'quit game' return to the main menu when NOEXIT is set

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -94,6 +94,7 @@ dungeon_type gnLevelTypeTbl[NUMLEVELS];
 Point MousePosition;
 bool gbRunGame;
 bool gbRunGameResult;
+bool ReturnToMainMenu;
 bool zoomflag;
 /** Enable updating of player character, set to false once Diablo dies */
 bool gbProcessPlayers;
@@ -1700,6 +1701,7 @@ void FreeGameMem()
 bool StartGame(bool bNewGame, bool bSinglePlayer)
 {
 	gbSelectProvider = true;
+	ReturnToMainMenu = false;
 
 	do {
 		gbLoadGame = false;
@@ -1735,6 +1737,8 @@ bool StartGame(bool bNewGame, bool bSinglePlayer)
 		// initialize main menu resources.
 		if (gbRunGameResult)
 			UiInitialize();
+		if (ReturnToMainMenu)
+			return true;
 	} while (gbRunGameResult);
 
 	SNetDestroy();

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -64,6 +64,7 @@ extern dungeon_type gnLevelTypeTbl[NUMLEVELS];
 extern Point MousePosition;
 extern bool gbRunGame;
 extern bool gbRunGameResult;
+extern bool ReturnToMainMenu;
 extern DVL_API_FOR_TEST bool zoomflag;
 extern bool gbProcessPlayers;
 extern bool gbLoadGame;

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -31,39 +31,35 @@ void GamemenuSpeed(bool bActivate);
 /** Contains the game menu items of the single player menu. */
 TMenuItem sgSingleMenu[] = {
 	// clang-format off
-    // dwFlags,      pszStr,              fnMenu
-	{ GMENU_ENABLED, N_("Save Game"),     &gamemenu_save_game  },
-	{ GMENU_ENABLED, N_("Options"),       &GamemenuOptions    },
-	{ GMENU_ENABLED, N_("New Game"),      &GamemenuNewGame   },
-	{ GMENU_ENABLED, N_("Load Game"),     &gamemenu_load_game  },
-#ifndef NOEXIT
-	{ GMENU_ENABLED, N_("Quit Game"),     &gamemenu_quit_game  },
-#endif
-	{ GMENU_ENABLED, nullptr,              nullptr             }
+	// dwFlags,      pszStr,          fnMenu
+	{ GMENU_ENABLED, N_("Save Game"), &gamemenu_save_game },
+	{ GMENU_ENABLED, N_("Options"),   &GamemenuOptions    },
+	{ GMENU_ENABLED, N_("New Game"),  &GamemenuNewGame    },
+	{ GMENU_ENABLED, N_("Load Game"), &gamemenu_load_game },
+	{ GMENU_ENABLED, N_("Quit Game"), &gamemenu_quit_game },
+	{ GMENU_ENABLED, nullptr,         nullptr             }
 	// clang-format on
 };
 /** Contains the game menu items of the multi player menu. */
 TMenuItem sgMultiMenu[] = {
 	// clang-format off
-    // dwFlags,      pszStr,                fnMenu
-	{ GMENU_ENABLED, N_("Options"),         &GamemenuOptions      },
+	// dwFlags,      pszStr,                fnMenu
+	{ GMENU_ENABLED, N_("Options"),         &GamemenuOptions     },
 	{ GMENU_ENABLED, N_("New Game"),        &GamemenuNewGame     },
 	{ GMENU_ENABLED, N_("Restart In Town"), &GamemenuRestartTown },
-#ifndef NOEXIT
-	{ GMENU_ENABLED, N_("Quit Game"),       &gamemenu_quit_game    },
-#endif
-	{ GMENU_ENABLED, nullptr,                nullptr               },
+	{ GMENU_ENABLED, N_("Quit Game"),       &gamemenu_quit_game  },
+	{ GMENU_ENABLED, nullptr,               nullptr              },
 	// clang-format on
 };
 TMenuItem sgOptionsMenu[] = {
 	// clang-format off
-    // dwFlags,                     pszStr,              fnMenu
+	// dwFlags,                     pszStr,              fnMenu
 	{ GMENU_ENABLED | GMENU_SLIDER, nullptr,             &GamemenuMusicVolume  },
 	{ GMENU_ENABLED | GMENU_SLIDER, nullptr,             &GamemenuSoundVolume  },
-	{ GMENU_ENABLED | GMENU_SLIDER, N_("Gamma"),         &GamemenuGamma         },
-	{ GMENU_ENABLED | GMENU_SLIDER, N_("Speed"),         &GamemenuSpeed         },
-	{ GMENU_ENABLED               , N_("Previous Menu"), &GamemenuPrevious      },
-	{ GMENU_ENABLED               , nullptr,              nullptr                },
+	{ GMENU_ENABLED | GMENU_SLIDER, N_("Gamma"),         &GamemenuGamma        },
+	{ GMENU_ENABLED | GMENU_SLIDER, N_("Speed"),         &GamemenuSpeed        },
+	{ GMENU_ENABLED               , N_("Previous Menu"), &GamemenuPrevious     },
+	{ GMENU_ENABLED               , nullptr,             nullptr               },
 	// clang-format on
 };
 /** Specifies the menu names for music enabled and disabled. */
@@ -294,13 +290,15 @@ void GamemenuSpeed(bool bActivate)
 
 } // namespace
 
-#ifndef NOEXIT
 void gamemenu_quit_game(bool bActivate)
 {
 	GamemenuNewGame(bActivate);
+#ifndef NOEXIT
 	gbRunGameResult = false;
-}
+#else
+	ReturnToMainMenu = true;
 #endif
+}
 
 void gamemenu_load_game(bool /*bActivate*/)
 {

--- a/Source/gamemenu.h
+++ b/Source/gamemenu.h
@@ -10,9 +10,7 @@ namespace devilution {
 void gamemenu_on();
 void gamemenu_off();
 void gamemenu_handle_previous();
-#ifndef NOEXIT
 void gamemenu_quit_game(bool bActivate);
-#endif
 void gamemenu_load_game(bool bActivate);
 void gamemenu_save_game(bool bActivate);
 


### PR DESCRIPTION
This partially implements #4181 but only for systems where NOEXIT is set. This should avoid at least some confusion for users that are unsure how to get back to the main menu from the game menu.