### PR TITLE
Fix modifier + D-Pad triggering a D-Pad event

### DIFF
--- a/Source/controls/controller_motion.cpp
+++ b/Source/controls/controller_motion.cpp
@@ -158,6 +158,8 @@ AxisDirection GetLeftStickOrDpadDirection(bool allowDpad)
 
 	AxisDirection result { AxisDirectionX_NONE, AxisDirectionY_NONE };
 
+	allowDpad = allowDpad && !IsControllerButtonPressed(ControllerButton_BUTTON_START);
+
 	bool isUpPressed = stickY >= 0.5 || (allowDpad && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_UP));
 	bool isDownPressed = stickY <= -0.5 || (allowDpad && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_DOWN));
 	bool isLeftPressed = stickX <= -0.5 || (allowDpad && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_LEFT));

--- a/Source/controls/devices/kbcontroller.cpp
+++ b/Source/controls/devices/kbcontroller.cpp
@@ -90,9 +90,7 @@ ControllerButton KbCtrlToControllerButton(const SDL_Event &event)
 	}
 }
 
-namespace {
-
-int ControllerButtonToKbCtrlKeyCode(ControllerButton button)
+SDL_Keycode ControllerButtonToKbCtrlKeyCode(ControllerButton button)
 {
 	switch (button) {
 #ifdef KBCTRL_BUTTON_A
@@ -160,16 +158,14 @@ int ControllerButtonToKbCtrlKeyCode(ControllerButton button)
 		return KBCTRL_BUTTON_DPAD_RIGHT;
 #endif
 	default:
-		return -1;
+		return SDLK_UNKNOWN;
 	}
 }
 
-} // namespace
-
 bool IsKbCtrlButtonPressed(ControllerButton button)
 {
-	int key_code = ControllerButtonToKbCtrlKeyCode(button);
-	if (key_code == -1)
+	SDL_Keycode key_code = ControllerButtonToKbCtrlKeyCode(button);
+	if (key_code == SDLK_UNKNOWN)
 		return false;
 #ifndef USE_SDL1
 	return SDL_GetKeyboardState(NULL)[SDL_GetScancodeFromKey(key_code)];

--- a/Source/controls/devices/kbcontroller.h
+++ b/Source/controls/devices/kbcontroller.h
@@ -9,9 +9,15 @@
 #include "controls/controller_buttons.h"
 #include <SDL.h>
 
+#ifdef USE_SDL1
+#include "utils/sdl2_to_1_2_backports.h"
+#endif
+
 namespace devilution {
 
 ControllerButton KbCtrlToControllerButton(const SDL_Event &event);
+
+SDL_Keycode ControllerButtonToKbCtrlKeyCode(ControllerButton button);
 
 bool IsKbCtrlButtonPressed(ControllerButton button);
 

--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -206,6 +206,8 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, Game
 			case ControllerButton_CAST_SPELL:
 				*action = GameAction(GameActionType_CAST_SPELL);
 				break;
+			default:
+				break;
 			}
 		}
 


### PR DESCRIPTION
Also fixes build with `HAS_KBCTRL=1`

Fixes #1977