### PR TITLE
Prefer when using VSync with no upscaling on Windows

### DIFF
--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -323,10 +323,10 @@ void ReinitializeRenderer()
 
 #ifdef _WIN32
 		// On Windows 11 the directx9 VSYNC timer doesn't get recreated properly, see https://github.com/libsdl-org/SDL/issues/5099
-		// Attempt to use the directx11 driver instead if we have vsync active.
+		// Attempt to use the opengl driver instead if we have vsync active.
 		const char *const renderHint = SDL_GetHint(SDL_HINT_RENDER_DRIVER);
-		if ((rendererFlags & SDL_RENDERER_PRESENTVSYNC) != 0 && SDL_SetHint(SDL_HINT_RENDER_DRIVER, "direct3d11") != SDL_TRUE) {
-			Log("Error when trying to set hint for direct3d11, using default render driver");
+		if ((rendererFlags & SDL_RENDERER_PRESENTVSYNC) != 0 && SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl") != SDL_TRUE) {
+			Log("Error when trying to set hint for opengl, using default render driver");
 		}
 #endif
 


### PR DESCRIPTION
Fixes #3806

@obligaron @StephenCWills Could I get one of you to test this since I don't have Windows :/

Regarding always using OpenGL on Windows, that might not be the best choice since we have the option of using higher quality upscaling when DirectX is being used.