### PR TITLE
clearTables when closing stash mpq

### DIFF
--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -309,7 +309,7 @@ void sfile_write_stash()
 
 	SaveStash();
 
-	StashWriter.Close(false);
+	StashWriter.Close();
 
 	Stash.dirty = false;
 }


### PR DESCRIPTION
Fixes #4356 for me.
Please verify again. I'm not mpq expert and perhaps I miss something 😉 

I could reproduce/test the issue with a empty data dir (no previous stash) and saving in singleplayer with the following modified code:
```cpp
void sfile_write_stash()
{
	//if (!Stash.dirty)
	//	return;
	for (int i = 0; i < 4; i++) {
		if (!StashWriter.Open(GetStashSavePath().c_str()))
			app_fatal("%s", _("Failed to open stash archive for writing.").c_str());
		SaveStash();
		StashWriter.Close(false);
		if (i % 2 != 0)
			gbIsMultiplayer = !gbIsMultiplayer;
		else
			gbIsHellfire = !gbIsHellfire;
	}
	Stash.dirty = false;
}
```