### PR TITLE
Fix application manifest in MinGW builds

### DIFF
--- a/Packaging/windows/devilutionx.exe.manifest
+++ b/Packaging/windows/devilutionx.exe.manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<assembly xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
 	<asmv3:application>
 		<asmv3:windowsSettings>
 			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>

--- a/Packaging/windows/devilutionx.rc
+++ b/Packaging/windows/devilutionx.rc
@@ -1,1 +1,7 @@
+#ifdef __MINGW32__
+#include "winuser.h"
+#define MANIFEST_RESOURCE_ID 1
+MANIFEST_RESOURCE_ID RT_MANIFEST "devilutionx.exe.manifest"
+#endif
+
 IDI_ICON1               ICON    DISCARDABLE     "icon.ico"


### PR DESCRIPTION
The resource file needs to reference the manifest file, and the manifest file had some errors.

This resolves #4358