### PR TITLE
Use romfs on Switch for devilutionx.mpq

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,8 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
+      - run: apt-get update -y
+      - run: apt-get install -y gettext smpq
       - run: /opt/devkitpro/portlibs/switch/bin/aarch64-none-elf-cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - run: cmake --build build -j 2
       - store_artifacts: {path: ./build/devilutionx.nro, destination: devilutionx.nro}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,21 @@ if(APPLE)
 endif()
 
 if(NINTENDO_SWITCH)
+  set(APP_ROMFS       "${CMAKE_BINARY_DIR}/romfs")
+
+  add_custom_target(romfs_directory
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${APP_ROMFS})
+
+  add_custom_target(romfs_files
+    COMMAND ${CMAKE_COMMAND} -E copy ${DEVILUTIONX_MPQ} ${APP_ROMFS}
+    DEPENDS ${DEVILUTIONX_MPQ})
+
+  # the romfs_directory target will create this directory at build time,
+  # but the nx_create_nro function requires it to also exist at configure time
+  file(MAKE_DIRECTORY ${APP_ROMFS})
+
+  add_dependencies(romfs_files romfs_directory devilutionx_mpq)
+
   nx_generate_nacp (${BIN_TARGET}.nacp
     NAME    "DevilutionX"
     AUTHOR  "Devilution Team"
@@ -307,9 +322,12 @@ if(NINTENDO_SWITCH)
   )
 
   nx_create_nro(${BIN_TARGET}
-    NACP ${BIN_TARGET}.nacp
-    ICON "${PROJECT_SOURCE_DIR}/Packaging/switch/icon.jpg"
+    NACP  ${BIN_TARGET}.nacp
+    ICON  "${PROJECT_SOURCE_DIR}/Packaging/switch/icon.jpg"
+    ROMFS ${APP_ROMFS}
   )
+
+  add_dependencies(${BIN_TARGET}_nro romfs_files)
 
 endif()
 

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -94,7 +94,7 @@ std::vector<std::string> GetMPQSearchPaths()
 #if defined(__linux__) && !defined(__ANDROID__)
 	paths.emplace_back("/usr/share/diasurgical/devilutionx/");
 	paths.emplace_back("/usr/local/share/diasurgical/devilutionx/");
-#elif defined(__3DS__)
+#elif defined(__3DS__) || defined(__SWITCH__)
 	paths.emplace_back("romfs:/");
 #elif (defined(_WIN64) || defined(_WIN32)) && !defined(__UWP__)
 	char gogpath[_FSG_PATH_MAX];

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -4,6 +4,7 @@
 #ifdef __SWITCH__
 #include "platform/switch/network.h"
 #include "platform/switch/random.hpp"
+#include "platform/switch/romfs.hpp"
 #endif
 #ifdef __3DS__
 #include "platform/ctr/system.h"
@@ -28,6 +29,7 @@ extern "C" const char *__asan_default_options() // NOLINT(bugprone-reserved-iden
 extern "C" int main(int argc, char **argv)
 {
 #ifdef __SWITCH__
+	switch_romfs_init();
 	switch_enable_network();
 	randombytes_switchrandom_init();
 #endif

--- a/Source/platform/switch/CMakeLists.txt
+++ b/Source/platform/switch/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(functions/devilutionx_library)
 
 add_devilutionx_object_library(libdevilutionx_switch
+  romfs.cpp
   network.cpp
   keyboard.cpp
   docking.cpp

--- a/Source/platform/switch/romfs.cpp
+++ b/Source/platform/switch/romfs.cpp
@@ -1,0 +1,14 @@
+#include "platform/switch/romfs.hpp"
+
+#include <cstdlib>
+
+extern "C" {
+#include <switch/runtime/devices/romfs_dev.h>
+}
+
+void switch_romfs_init()
+{
+	Result res = romfsInit();
+	if (R_SUCCEEDED(res))
+		atexit([]() { romfsExit(); });
+}

--- a/Source/platform/switch/romfs.hpp
+++ b/Source/platform/switch/romfs.hpp
@@ -1,0 +1,2 @@
+#pragma once
+void switch_romfs_init();


### PR DESCRIPTION
Packs devilutionx.mpq into the nro so it won't have to be distributed separately.

Tested with Ryujinx.

Note that we will probably encounter issues similar to 3DS and MacOSX if the user has a leftover version of devilutionx.mpq on their SD card.