### PR TITLE
Controller mouse emulation fixes

### DIFF
--- a/Source/controls/controller_motion.cpp
+++ b/Source/controls/controller_motion.cpp
@@ -12,8 +12,11 @@
 #include "controls/plrctrls.h"
 #include "controls/touch/gamepad.h"
 #include "options.h"
+#include "utils/log.hpp"
 
 namespace devilution {
+
+bool SimulatingMouseWithSelectAndDPad;
 
 namespace {
 
@@ -63,38 +66,78 @@ void ScaleJoystickAxes(float *x, float *y, float deadzone)
 	}
 }
 
+void SetSimulatingMouseWithDpad(bool value)
+{
+	if (SimulatingMouseWithSelectAndDPad == value)
+		return;
+	SimulatingMouseWithSelectAndDPad = value;
+	if (value) {
+		LogDebug("Control: begin simulating mouse with D-Pad");
+	} else {
+		LogDebug("Control: end simulating mouse with D-Pad");
+	}
+}
+
 // SELECT + D-Pad to simulate right stick movement.
 bool SimulateRightStickWithDpad(ControllerButtonEvent ctrlEvent)
 {
 	if (sgOptions.Controller.bDpadHotkeys)
 		return false;
-	static bool simulating = false;
+	if (ctrlEvent.button == ControllerButton_NONE || ctrlEvent.button == ControllerButton_IGNORE)
+		return false;
 	if (ctrlEvent.button == ControllerButton_BUTTON_BACK) {
-		if (ctrlEvent.up && simulating) {
-			rightStickX = rightStickY = 0;
-			simulating = false;
+		if (SimulatingMouseWithSelectAndDPad) {
+			if (ctrlEvent.up) {
+				rightStickX = rightStickY = 0;
+			}
+			return true;
 		}
 		return false;
 	}
-	if (!IsControllerButtonPressed(ControllerButton_BUTTON_BACK))
-		return false;
-	switch (ctrlEvent.button) {
-	case ControllerButton_BUTTON_DPAD_LEFT:
-		rightStickX = ctrlEvent.up ? 0.F : -1.F;
-		break;
-	case ControllerButton_BUTTON_DPAD_RIGHT:
-		rightStickX = ctrlEvent.up ? 0.F : 1.F;
-		break;
-	case ControllerButton_BUTTON_DPAD_UP:
-		rightStickY = ctrlEvent.up ? 0.F : 1.F;
-		break;
-	case ControllerButton_BUTTON_DPAD_DOWN:
-		rightStickY = ctrlEvent.up ? 0.F : -1.F;
-		break;
-	default:
+
+	if (!IsControllerButtonPressed(ControllerButton_BUTTON_BACK)) {
+		SetSimulatingMouseWithDpad(false);
 		return false;
 	}
-	simulating = !(rightStickX == 0 && rightStickY == 0);
+	switch (ctrlEvent.button) {
+	case ControllerButton_BUTTON_DPAD_LEFT:
+		if (ctrlEvent.up) {
+			rightStickX = 0;
+		} else {
+			rightStickX = -1.F;
+			SetSimulatingMouseWithDpad(true);
+		}
+		break;
+	case ControllerButton_BUTTON_DPAD_RIGHT:
+		if (ctrlEvent.up) {
+			rightStickX = 0;
+		} else {
+			rightStickX = 1.F;
+			SetSimulatingMouseWithDpad(true);
+		}
+		break;
+	case ControllerButton_BUTTON_DPAD_UP:
+		if (ctrlEvent.up) {
+			rightStickY = 0;
+		} else {
+			rightStickY = 1.F;
+			SetSimulatingMouseWithDpad(true);
+		}
+		break;
+	case ControllerButton_BUTTON_DPAD_DOWN:
+		if (ctrlEvent.up) {
+			rightStickY = 0;
+		} else {
+			rightStickY = -1.F;
+			SetSimulatingMouseWithDpad(true);
+		}
+		break;
+	default:
+		if (!IsSimulatedMouseClickBinding(ctrlEvent)) {
+			SetSimulatingMouseWithDpad(false);
+		}
+		return false;
+	}
 
 	return true;
 }
@@ -136,17 +179,21 @@ bool ProcessControllerMotion(const SDL_Event &event, ControllerButtonEvent ctrlE
 	GameController *const controller = GameController::Get(event);
 	if (controller != nullptr && devilution::GameController::ProcessAxisMotion(event)) {
 		ScaleJoysticks();
+		SetSimulatingMouseWithDpad(false);
 		return true;
 	}
 #endif
 	Joystick *const joystick = Joystick::Get(event);
 	if (joystick != nullptr && devilution::Joystick::ProcessAxisMotion(event)) {
 		ScaleJoysticks();
+		SetSimulatingMouseWithDpad(false);
 		return true;
 	}
 #if HAS_KBCTRL == 1
-	if (ProcessKbCtrlAxisMotion(event))
+	if (ProcessKbCtrlAxisMotion(event)) {
+		SetSimulatingMouseWithDpad(false);
 		return true;
+	}
 #endif
 	return SimulateRightStickWithDpad(ctrlEvent);
 }

--- a/Source/controls/controller_motion.h
+++ b/Source/controls/controller_motion.h
@@ -9,6 +9,9 @@
 
 namespace devilution {
 
+// Whether we're currently simulating the mouse with SELECT + D-Pad.
+extern bool SimulatingMouseWithSelectAndDPad;
+
 // Raw axis values.
 extern float leftStickXUnscaled, leftStickYUnscaled, rightStickXUnscaled, rightStickYUnscaled;
 

--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -441,6 +441,20 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, Game
 	return false;
 }
 
+bool IsSimulatedMouseClickBinding(ControllerButtonEvent ctrlEvent)
+{
+	switch (ctrlEvent.button) {
+	case ControllerButton_BUTTON_LEFTSTICK:
+	case ControllerButton_BUTTON_LEFTSHOULDER:
+	case ControllerButton_BUTTON_RIGHTSHOULDER:
+		return select_modifier_active;
+	case ControllerButton_BUTTON_RIGHTSTICK:
+		return true;
+	default:
+		return false;
+	}
+}
+
 AxisDirection GetMoveDirection()
 {
 	return GetLeftStickOrDpadDirection(/*allowDpad=*/!sgOptions.Controller.bDpadHotkeys);

--- a/Source/controls/game_controls.h
+++ b/Source/controls/game_controls.h
@@ -71,6 +71,8 @@ struct GameAction {
 
 bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, GameAction *action);
 
+bool IsSimulatedMouseClickBinding(ControllerButtonEvent ctrlEvent);
+
 AxisDirection GetMoveDirection();
 
 extern bool start_modifier_active;

--- a/Source/controls/modifier_hints.cpp
+++ b/Source/controls/modifier_hints.cpp
@@ -5,8 +5,9 @@
 #include "DiabloUI/art_draw.h"
 #include "DiabloUI/ui_flags.hpp"
 #include "control.h"
-#include "controls/controller.h"
+#include "controls/controller_motion.h"
 #include "controls/game_controls.h"
+#include "controls/plrctrls.h"
 #include "engine/load_cel.hpp"
 #include "engine/render/text_render.hpp"
 #include "options.h"
@@ -155,7 +156,7 @@ void DrawStartModifierMenu(const Surface &out)
 
 void DrawSelectModifierMenu(const Surface &out)
 {
-	if (!select_modifier_active)
+	if (!select_modifier_active || SimulatingMouseWithSelectAndDPad)
 		return;
 
 	if (sgOptions.Controller.bDpadHotkeys) {

--- a/Source/controls/plrctrls.h
+++ b/Source/controls/plrctrls.h
@@ -24,11 +24,6 @@ enum class ControlTypes : uint8_t {
 
 string_view ControlTypeToString(ControlTypes controlType);
 
-/**
- * @brief Call this after sending a simulated mouse button click event.
- */
-void NextMouseButtonClickEventIsSimulated();
-
 extern ControlTypes ControlMode;
 
 /**

--- a/Source/miniwin/misc_msg.cpp
+++ b/Source/miniwin/misc_msg.cpp
@@ -394,13 +394,6 @@ void ProcessGamepadEvents(GameAction &action)
 			sbookflag = !sbookflag;
 		}
 		break;
-	case GameActionType_SEND_MOUSE_CLICK:
-		Uint8 simulatedButton = action.send_mouse_click.button == GameActionSendMouseClick::LEFT ? SDL_BUTTON_LEFT : SDL_BUTTON_RIGHT;
-		SDL_Event clickEvent;
-		SetMouseButtonEvent(clickEvent, action.send_mouse_click.up ? SDL_MOUSEBUTTONUP : SDL_MOUSEBUTTONDOWN, simulatedButton, MousePosition);
-		NextMouseButtonClickEventIsSimulated();
-		SDL_PushEvent(&clickEvent);
-		break;
 	}
 }
 
@@ -483,6 +476,12 @@ bool FetchMessage_Real(tagMSG *lpMsg)
 		} else if (action.type == GameActionType_SEND_KEY) {
 			lpMsg->message = action.send_key.up ? DVL_WM_KEYUP : DVL_WM_KEYDOWN;
 			lpMsg->wParam = action.send_key.vk_code;
+		} else if (action.type == GameActionType_SEND_MOUSE_CLICK) {
+			lpMsg->message = action.send_mouse_click.up
+			    ? (action.send_mouse_click.button == GameActionSendMouseClick::LEFT ? DVL_WM_LBUTTONUP : DVL_WM_RBUTTONUP)
+			    : (action.send_mouse_click.button == GameActionSendMouseClick::LEFT ? DVL_WM_LBUTTONDOWN : DVL_WM_RBUTTONDOWN);
+			lpMsg->wParam = 0;
+			lpMsg->lParam = (static_cast<int16_t>(MousePosition.y) << 16) | static_cast<int16_t>(MousePosition.x);
 		} else {
 			ProcessGamepadEvents(action);
 		}


### PR DESCRIPTION
1. Do not interrupt mouse mode on virtual clicks.
2. Handle virtual clicks directly instead of sending an SDL event.
3. Fix D-Pad mouse emulation state handling.
4. Hides the modifier hints during D-Pad mouse emulation.

Fixes #4369

@jimmiejoe, can you please check if this helps with #4368?

