### PR TITLE
Fix variable name in FindCITRO3D.cmake

### DIFF
--- a/CMake/platforms/ctr/modules/FindCITRO3D.cmake
+++ b/CMake/platforms/ctr/modules/FindCITRO3D.cmake
@@ -37,7 +37,7 @@ if(CITRO3D_ROOT)
 endif()
 
 # Search below ${DEVKITPRO}, ${DEVKITARM} etc.
-set(_CITRO3D_SEARCH_REROOTED
+set(_CITRO3D_SEARCH_CMAKE_REROOTED
   PATHS / /citro3d /libctru /ctrulib
   NO_DEFAULT_PATH
   ONLY_CMAKE_FIND_ROOT_PATH)


### PR DESCRIPTION
Reported by @pionere (https://github.com/diasurgical/devilutionX/commit/0976278fb44a6c8abb8506481a79d89e78c980e0#r70871345)

Fixes the variable name in `FindCITRO3D.cmake` so that build environments which use `CMAKE_FIND_ROOT_PATH` will be able to locate Citro3D.