### PR TITLE
Only query jbutton state for button events

### DIFF
--- a/Source/controls/controller.cpp
+++ b/Source/controls/controller.cpp
@@ -100,7 +100,9 @@ ControllerButtonEvent ToControllerButtonEvent(const SDL_Event &event)
 	const Joystick *joystick = Joystick::Get(event);
 	if (joystick != nullptr) {
 		result.button = devilution::Joystick::ToControllerButton(event);
-		result.state = event.jbutton.state;
+		result.state = ControllerButtonState_PRESSED;
+		if (IsAnyOf(event.type, SDL_JOYBUTTONUP, SDL_JOYBUTTONDOWN))
+			result.state = event.jbutton.state;
 	}
 
 	return result;


### PR DESCRIPTION
Hat state is a collection of flags indicating which combination of directions is currently pressed. We only receive events when the hat state changes and we only generate button events if the corresponding flag is set for the hat direction. Therefore, this change just assumes the event indicates the button was pressed. For a more complete solution, we'd have to save state from the previous hat event so we can detect transitions that would indicate d-pad buttons were released.

This resolves #4368