### PR TITLE
Remove MpqDir and use PrefPath instead.

### DIFF
--- a/Source/engine/assets.cpp
+++ b/Source/engine/assets.cpp
@@ -43,8 +43,8 @@ SDL_RWops *OpenAsset(const char *filename, bool threadsafe)
 
 	// Files next to the MPQ archives override MPQ contents.
 	SDL_RWops *rwops;
-	if (paths::MpqDir()) {
-		const std::string path = *paths::MpqDir() + relativePath;
+	{
+		const std::string path = paths::PrefPath() + relativePath;
 		// Avoid spamming DEBUG messages if the file does not exist.
 		if ((FileExists(path.c_str())) && (rwops = SDL_RWFromFile(path.c_str(), "rb")) != nullptr) {
 			LogVerbose("Loaded MPQ file override: {}", path);

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -69,7 +69,6 @@ std::optional<MpqArchive> LoadMPQ(const std::vector<std::string> &paths, string_
 		mpqAbsPath = path + mpqName.data();
 		if ((archive = MpqArchive::Open(mpqAbsPath.c_str(), error))) {
 			LogVerbose("  Found: {} in {}", mpqName, path);
-			paths::SetMpqDir(path);
 			return archive;
 		}
 		if (error != 0) {

--- a/Source/utils/paths.cpp
+++ b/Source/utils/paths.cpp
@@ -24,7 +24,6 @@ std::optional<std::string> basePath;
 std::optional<std::string> prefPath;
 std::optional<std::string> configPath;
 std::optional<std::string> assetsPath;
-std::optional<std::string> mpqDir;
 
 void AddTrailingSlash(std::string &path)
 {
@@ -99,11 +98,6 @@ const std::string &AssetsPath()
 	return *assetsPath;
 }
 
-const std::optional<std::string> &MpqDir()
-{
-	return mpqDir;
-}
-
 void SetBasePath(const std::string &path)
 {
 	basePath = path;
@@ -126,11 +120,6 @@ void SetAssetsPath(const std::string &path)
 {
 	assetsPath = path;
 	AddTrailingSlash(*assetsPath);
-}
-
-void SetMpqDir(const std::string &path)
-{
-	mpqDir = std::string(path);
 }
 
 } // namespace paths

--- a/Source/utils/paths.h
+++ b/Source/utils/paths.h
@@ -12,13 +12,11 @@ const std::string &BasePath();
 const std::string &PrefPath();
 const std::string &ConfigPath();
 const std::string &AssetsPath();
-const std::optional<std::string> &MpqDir();
 
 void SetBasePath(const std::string &path);
 void SetPrefPath(const std::string &path);
 void SetConfigPath(const std::string &path);
 void SetAssetsPath(const std::string &path);
-void SetMpqDir(const std::string &path);
 
 } // namespace paths
 


### PR DESCRIPTION
Fixes #4007

Removes `MpqDir` as it's not very reliable (see #4375) and always uses `PrefPath` instead.

Another alternative to discuss. 😉 