### PR TITLE
Don't hide the automap in Help and Chat Log

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1307,7 +1307,6 @@ void HelpKeyPressed()
 			stream_stop();
 		}
 		QuestLogIsOpen = false;
-		AutomapActive = false;
 		CancelCurrentDiabloMsg();
 		gamemenu_off();
 		DisplayHelp();

--- a/Source/qol/chatlog.cpp
+++ b/Source/qol/chatlog.cpp
@@ -105,7 +105,6 @@ void ToggleChatLog()
 		}
 		QuestLogIsOpen = false;
 		HelpFlag = false;
-		AutomapActive = false;
 		CancelCurrentDiabloMsg();
 		gamemenu_off();
 		SkipLines = 0;


### PR DESCRIPTION
This was necessary in the past due to stippled transparency but we use blended transparency now.

![screenshot](https://user-images.githubusercontent.com/216339/162614748-8898cce5-a13d-4a09-91d8-f3565b589d3c.png)

Fixes #4355