### PR TITLE
Quick cast fixes

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -2017,8 +2017,14 @@ void PerformSecondaryAction()
 void QuickCast(int slot)
 {
 	auto &myPlayer = Players[MyPlayerId];
+	spell_id spell = myPlayer._pSplHotKey[slot];
+	spell_type spellType = myPlayer._pSplTHotKey[slot];
 
-	CheckPlrSpell(false, myPlayer._pSplHotKey[slot], myPlayer._pSplTHotKey[slot]);
+	if (ControlMode != ControlTypes::KeyboardAndMouse) {
+		UpdateSpellTarget(spell);
+	}
+
+	CheckPlrSpell(false, spell, spellType);
 }
 
 } // namespace devilution

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -2027,20 +2027,19 @@ void RemoveScroll(Player &player)
 	}
 }
 
-bool UseScroll()
+bool UseScroll(const spell_id spell)
 {
 	if (pcurs != CURSOR_HAND)
 		return false;
 
 	Player &myPlayer = Players[MyPlayerId];
-	const spell_id spellId = myPlayer._pRSpell;
 
-	if (leveltype == DTYPE_TOWN && !spelldata[spellId].sTownSpell)
+	if (leveltype == DTYPE_TOWN && !spelldata[spell].sTownSpell)
 		return false;
 
 	const InventoryAndBeltPlayerItemsRange items { myPlayer };
-	return std::any_of(items.begin(), items.end(), [spellId](const Item &item) {
-		return item.IsScrollOf(spellId);
+	return std::any_of(items.begin(), items.end(), [spell](const Item &item) {
+		return item.IsScrollOf(spell);
 	});
 }
 
@@ -2055,7 +2054,7 @@ void UseStaffCharge(Player &player)
 	CalcPlrStaff(player);
 }
 
-bool UseStaff()
+bool UseStaff(const spell_id spell)
 {
 	if (pcurs != CURSOR_HAND) {
 		return false;
@@ -2063,7 +2062,7 @@ bool UseStaff()
 
 	auto &myPlayer = Players[MyPlayerId];
 
-	return CanUseStaff(myPlayer.InvBody[INVLOC_HAND_LEFT], myPlayer._pRSpell);
+	return CanUseStaff(myPlayer.InvBody[INVLOC_HAND_LEFT], spell);
 }
 
 Item &GetInventoryItem(Player &player, int location)

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -206,9 +206,9 @@ int SyncPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, i
 int SyncDropItem(Point position, int idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
 int8_t CheckInvHLight();
 void RemoveScroll(Player &player);
-bool UseScroll();
+bool UseScroll(spell_id spell);
 void UseStaffCharge(Player &player);
-bool UseStaff();
+bool UseStaff(spell_id spell);
 Item &GetInventoryItem(Player &player, int location);
 bool UseInvItem(int pnum, int cii);
 void DoTelekinesis();

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3587,10 +3587,10 @@ void CheckPlrSpell(bool isShiftHeld, spell_id spellID, spell_type spellType)
 		addflag = spellcheck == SpellCheckResult::Success;
 		break;
 	case RSPLTYPE_SCROLL:
-		addflag = UseScroll();
+		addflag = UseScroll(spellID);
 		break;
 	case RSPLTYPE_CHARGES:
-		addflag = UseStaff();
+		addflag = UseStaff(spellID);
 		break;
 	case RSPLTYPE_INVALID:
 		return;

--- a/test/inv_test.cpp
+++ b/test/inv_test.cpp
@@ -32,14 +32,14 @@ TEST(Inv, UseScroll_from_inventory)
 {
 	set_up_scroll(Players[MyPlayerId].InvList[2], SPL_FIREBOLT);
 	Players[MyPlayerId]._pNumInv = 5;
-	EXPECT_TRUE(UseScroll());
+	EXPECT_TRUE(UseScroll(Players[MyPlayerId]._pRSpell));
 }
 
 // Test that the scroll is used in the belt in correct conditions
 TEST(Inv, UseScroll_from_belt)
 {
 	set_up_scroll(Players[MyPlayerId].SpdList[2], SPL_FIREBOLT);
-	EXPECT_TRUE(UseScroll());
+	EXPECT_TRUE(UseScroll(Players[MyPlayerId]._pRSpell));
 }
 
 // Test that the scroll is not used in the inventory for each invalid condition
@@ -52,23 +52,23 @@ TEST(Inv, UseScroll_from_inventory_invalid_conditions)
 
 	set_up_scroll(Players[MyPlayerId].InvList[2], SPL_FIREBOLT);
 	pcurs = CURSOR_IDENTIFY;
-	EXPECT_FALSE(UseScroll());
+	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 
 	set_up_scroll(Players[MyPlayerId].InvList[2], SPL_FIREBOLT);
 	leveltype = DTYPE_TOWN;
-	EXPECT_FALSE(UseScroll());
+	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 
 	set_up_scroll(Players[MyPlayerId].InvList[2], SPL_FIREBOLT);
 	Players[MyPlayerId]._pRSpell = static_cast<spell_id>(SPL_HEAL);
-	EXPECT_FALSE(UseScroll());
+	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 
 	set_up_scroll(Players[MyPlayerId].InvList[2], SPL_FIREBOLT);
 	Players[MyPlayerId].InvList[2]._iMiscId = IMISC_STAFF;
-	EXPECT_FALSE(UseScroll());
+	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 
 	set_up_scroll(Players[MyPlayerId].InvList[2], SPL_FIREBOLT);
 	Players[MyPlayerId].InvList[2]._itype = ItemType::None;
-	EXPECT_FALSE(UseScroll());
+	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 }
 
 // Test that the scroll is not used in the belt for each invalid condition
@@ -79,23 +79,23 @@ TEST(Inv, UseScroll_from_belt_invalid_conditions)
 
 	set_up_scroll(Players[MyPlayerId].SpdList[2], SPL_FIREBOLT);
 	pcurs = CURSOR_IDENTIFY;
-	EXPECT_FALSE(UseScroll());
+	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 
 	set_up_scroll(Players[MyPlayerId].SpdList[2], SPL_FIREBOLT);
 	leveltype = DTYPE_TOWN;
-	EXPECT_FALSE(UseScroll());
+	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 
 	set_up_scroll(Players[MyPlayerId].SpdList[2], SPL_FIREBOLT);
 	Players[MyPlayerId]._pRSpell = static_cast<spell_id>(SPL_HEAL);
-	EXPECT_FALSE(UseScroll());
+	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 
 	set_up_scroll(Players[MyPlayerId].SpdList[2], SPL_FIREBOLT);
 	Players[MyPlayerId].SpdList[2]._iMiscId = IMISC_STAFF;
-	EXPECT_FALSE(UseScroll());
+	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 
 	set_up_scroll(Players[MyPlayerId].SpdList[2], SPL_FIREBOLT);
 	Players[MyPlayerId].SpdList[2]._itype = ItemType::None;
-	EXPECT_FALSE(UseScroll());
+	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 }
 
 // Test gold calculation


### PR DESCRIPTION
When quick casting from gamepad, update the cursor position so the player can quick cast spells in front of them without targeting a player or monster.

When quick casting from staff charges and scrolls, these are now explicitly validated using the spell that was cast rather than `Player::_pRSpell`.

This resolves #4269