### PR TITLE
Avoid recreating items in PutItem locally

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1837,14 +1837,14 @@ bool TryInvPut()
 	return CanPut(myPlayer.position.tile);
 }
 
-int InvPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac)
+int InvPutItem(Player &player, Point position, Item &item)
 {
 	if (player.plrlevel == 0) {
-		if (idx == IDI_RUNEBOMB && OpensHive(position)) {
+		if (item.IDidx == IDI_RUNEBOMB && OpensHive(position)) {
 			OpenHive();
 			return -1;
 		}
-		if (idx == IDI_MAPOFDOOM && OpensGrave(position)) {
+		if (item.IDidx == IDI_MAPOFDOOM && OpensGrave(position)) {
 			OpenCrypt();
 			return -1;
 		}
@@ -1854,8 +1854,21 @@ int InvPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, in
 		return -1;
 
 	assert(CanPut(position));
+	int ii = AllocateItem();
 
-	return SyncDropItem(position, idx, icreateinfo, iseed, id, dur, mdur, ch, mch, ivalue, ibuff, toHit, maxDam, minStr, minMag, minDex, ac);
+	dItem[position.x][position.y] = ii + 1;
+	Items[ii] = item;
+	Items[ii].position = position;
+	RespawnItem(Items[ii], true);
+
+	if (currlevel == 21 && position == CornerStone.position) {
+		CornerStone.item = Items[ii];
+		InitQTextMsg(TEXT_CORNSTN);
+		Quests[Q_CORNSTN]._qlog = false;
+		Quests[Q_CORNSTN]._qactive = QUEST_DONE;
+	}
+
+	return ii;
 }
 
 int SyncPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac)

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -201,7 +201,7 @@ int FindGetItem(int32_t iseed, _item_indexes idx, uint16_t ci);
 void SyncGetItem(Point position, int32_t iseed, _item_indexes idx, uint16_t ci);
 bool CanPut(Point position);
 bool TryInvPut();
-int InvPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
+int InvPutItem(Player &player, Point position, Item &item);
 int SyncPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
 int SyncDropItem(Point position, int idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
 int8_t CheckInvHLight();

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -67,6 +67,7 @@ DJunk sgJunk;
 bool sgbDeltaChanged;
 BYTE sgbDeltaChunks;
 std::list<TMegaPkt> MegaPktList;
+Item ItemLimbo;
 
 void GetNextPacket()
 {
@@ -857,7 +858,7 @@ DWORD OnPutItem(const TCmd *pCmd, int pnum)
 		if (currlevel == Players[pnum].plrlevel) {
 			int ii;
 			if (pnum == MyPlayerId)
-				ii = InvPutItem(Players[pnum], position, message.wIndx, message.wCI, message.dwSeed, message.bId, message.bDur, message.bMDur, message.bCh, message.bMCh, message.wValue, message.dwBuff, message.wToHit, message.wMaxDam, message.bMinStr, message.bMinMag, message.bMinDex, message.bAC);
+				ii = InvPutItem(Players[pnum], position, ItemLimbo);
 			else
 				ii = SyncPutItem(Players[pnum], position, message.wIndx, message.wCI, message.dwSeed, message.bId, message.bDur, message.bMDur, message.bCh, message.bMCh, message.wValue, message.dwBuff, message.wToHit, message.wMaxDam, message.bMinStr, message.bMinMag, message.bMinDex, message.bAC);
 			if (ii != -1) {
@@ -2607,6 +2608,8 @@ void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position, const Item &item
 		cmd.bAC = item._iAC;
 		cmd.dwBuff = item.dwBuff;
 	}
+
+	ItemLimbo = item;
 
 	if (bHiPri)
 		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));


### PR DESCRIPTION
This basically reverts #4276, but introduces a new variable to take the place of `Player::HoldItem` to be used when processing the message locally. This only requires space for one item if you assume that the player won't be able to drop multiple items in one frame. If we want to support dropping more than one item in one frame, we'd have to use something like `std::deque<Item>`.

This resolves #4386