### PR TITLE
Hardware cursor: Simplify initialization

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -574,7 +574,15 @@ void LoadUiGFX()
 	LoadMaskedArt("ui_art\\focus16.pcx", &ArtFocus[FOCUS_SMALL], 8);
 	LoadMaskedArt("ui_art\\focus.pcx", &ArtFocus[FOCUS_MED], 8);
 	LoadMaskedArt("ui_art\\focus42.pcx", &ArtFocus[FOCUS_BIG], 8);
+
 	LoadMaskedArt("ui_art\\cursor.pcx", &ArtCursor, 1, 0);
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	// Set the palette because `ArtCursor` may be used as the hardware cursor.
+	if (ArtCursor.surface != nullptr) {
+		SDL_SetSurfacePalette(ArtCursor.surface.get(), Palette.get());
+	}
+#endif
 
 	LoadHeros();
 }

--- a/Source/hwcursor.cpp
+++ b/Source/hwcursor.cpp
@@ -144,13 +144,9 @@ void SetHardwareCursor(CursorInfo cursorInfo)
 	case CursorType::UserInterface:
 		// ArtCursor is null while loading the game on the progress screen,
 		// called via palette fade from ShowProgress.
-		if (ArtCursor.surface != nullptr) {
-			SDL_SetSurfacePalette(ArtCursor.surface.get(), Palette.get());
-			SDL_SetColorKey(ArtCursor.surface.get(), 1, 0);
-			CurrentCursorInfo.SetEnabled(
-			    IsCursorSizeAllowed(Size { ArtCursor.surface->w, ArtCursor.surface->h })
-			    && SetHardwareCursor(ArtCursor.surface.get(), HotpointPosition::TopLeft));
-		}
+		CurrentCursorInfo.SetEnabled(
+		    ArtCursor.surface != nullptr && IsCursorSizeAllowed(Size { ArtCursor.surface->w, ArtCursor.surface->h })
+		    && SetHardwareCursor(ArtCursor.surface.get(), HotpointPosition::TopLeft));
 		break;
 	case CursorType::Unknown:
 		CurrentCursorInfo.SetEnabled(false);


### PR DESCRIPTION
Set the palette at load time.

Since we only support hardware cursors in SDL2, we can take advantage of its reference-counted palettes.