### PR TITLE
Do not process button held events in character panel

### DIFF
--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -198,7 +198,7 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, Game
 	}
 
 	if (ctrlEvent.state == ControllerButtonState_HELD) {
-		if (CanControlHero() && !select_modifier_active && !start_modifier_active) {
+		if (CanControlHero() && !chrflag && !select_modifier_active && !start_modifier_active) {
 			switch (ctrlEvent.button) {
 			case ControllerButton_ATTACK:
 				*action = GameAction(GameActionType_PRIMARY_ACTION);


### PR DESCRIPTION
Holding the `A` button down on a stat in the CHAR panel when leveling up will cause you to rapidly dump points into the stat. Rather, it's extremely difficult to avoid putting multiple points into a stat when pressing the button. This PR prevents that so you must press the button again each time you want to apply a stat point.