### PR TITLE
Do not process held events for action buttons in main menu

### DIFF
--- a/Source/controls/menu_controls.cpp
+++ b/Source/controls/menu_controls.cpp
@@ -34,6 +34,20 @@ MenuAction GetMenuAction(const SDL_Event &event)
 		return GetMenuHeldUpDownAction();
 	}
 
+	if (ctrlEvent.state == ControllerButtonState_HELD) {
+		bool processHeldEvent = IsAnyOf(ctrlEvent.button,
+		    ControllerButton_BUTTON_DPAD_UP,
+		    ControllerButton_BUTTON_DPAD_DOWN,
+		    ControllerButton_BUTTON_DPAD_LEFT,
+		    ControllerButton_BUTTON_DPAD_RIGHT,
+		    ControllerButton_BUTTON_LEFTSHOULDER,
+		    ControllerButton_BUTTON_RIGHTSHOULDER);
+
+		if (!processHeldEvent) {
+			return MenuAction_NONE;
+		}
+	}
+
 	if (!ctrlEvent.up) {
 		switch (ctrlEvent.button) {
 		case ControllerButton_IGNORE:


### PR DESCRIPTION
Holding the `A` button down when skipping the intro video will skip straight to the character select screen for Single Player. I've often been inadvertently skipping the main menu on 3DS because of this. It also seemed like this was making it difficult to change the language selection on 3DS. This PR prevents all that behavior.