### PR TITLE
Fix snd_deinit called even if snd_init failed

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -146,7 +146,6 @@ bool was_archives_init = false;
 /** To know if surfaces have been initialized or not */
 bool was_window_init = false;
 bool was_ui_init = false;
-bool was_snd_init = false;
 
 void StartGame(interface_mode uMsg)
 {
@@ -1007,7 +1006,6 @@ void DiabloInit()
 	DiabloInitScreen();
 
 	snd_init();
-	was_snd_init = true;
 
 	ui_sound_init();
 
@@ -1047,7 +1045,7 @@ void DiabloDeinit()
 {
 	FreeItemGFX();
 
-	if (was_snd_init)
+	if (gbSndInited)
 		effects_cleanup_sfx();
 	snd_deinit();
 	if (was_ui_init)

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -1283,6 +1283,8 @@ void PlaySfxLoc(_sfx_id psfx, Point position, bool randomizeByCategory)
 
 void sound_stop()
 {
+	if (!gbSndInited)
+		return;
 	ClearDuplicateSounds();
 	for (auto &sfx : sgSFX) {
 		if (sfx.pSnd != nullptr) {


### PR DESCRIPTION
We were previously setting `was_sound_init` to true unconditionally after calling `snd_init`.

However, `snd_init` can fail. Use `gbSndInited` instead.