### PR TITLE
[gamepad] Reuse repeat logic from mouse

### DIFF
--- a/Source/controls/controller.h
+++ b/Source/controls/controller.h
@@ -6,16 +6,9 @@
 
 namespace devilution {
 
-enum ControllerButtonState : uint8_t {
-	ControllerButtonState_RELEASED = SDL_RELEASED,
-	ControllerButtonState_PRESSED = SDL_PRESSED,
-	ControllerButtonState_HELD = SDL_PRESSED + SDL_RELEASED + 1 // for making it sure that the value is different
-};
-
 struct ControllerButtonEvent {
 	ControllerButton button;
 	bool up;
-	uint8_t state;
 };
 
 // Must be called exactly once at the start of each SDL input event.
@@ -26,9 +19,5 @@ ControllerButtonEvent ToControllerButtonEvent(const SDL_Event &event);
 bool IsControllerButtonPressed(ControllerButton button);
 
 bool HandleControllerAddedOrRemovedEvent(const SDL_Event &event);
-
-void UnlockHeldControllerButtonEvents(const SDL_Event &event);
-
-int PollActionButtonPressed(SDL_Event *event);
 
 } // namespace devilution

--- a/Source/controls/devices/joystick.h
+++ b/Source/controls/devices/joystick.h
@@ -34,9 +34,9 @@ public:
 		return instance_id_;
 	}
 
+private:
 	static int ToSdlJoyButton(ControllerButton button);
 
-private:
 	bool IsHatButtonPressed(ControllerButton button) const;
 
 	SDL_Joystick *sdl_joystick_ = NULL;

--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -15,7 +15,6 @@
 #include "doom.h"
 #include "gmenu.h"
 #include "options.h"
-#include "plrctrls.h"
 #include "qol/stash.h"
 #include "stores.h"
 
@@ -23,8 +22,9 @@ namespace devilution {
 
 bool start_modifier_active = false;
 bool select_modifier_active = false;
-const ControllerButton ControllerButton_ATTACK = ControllerButton_BUTTON_B;
-const ControllerButton ControllerButton_CAST_SPELL = ControllerButton_BUTTON_X;
+const ControllerButton ControllerButtonPrimary = ControllerButton_BUTTON_B;
+const ControllerButton ControllerButtonSecondary = ControllerButton_BUTTON_Y;
+const ControllerButton ControllerButtonTertiary = ControllerButton_BUTTON_X;
 
 namespace {
 
@@ -195,23 +195,6 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, Game
 		return true;
 	default:
 		break;
-	}
-
-	if (ctrlEvent.state == ControllerButtonState_HELD) {
-		if (CanControlHero() && !chrflag && !select_modifier_active && !start_modifier_active) {
-			switch (ctrlEvent.button) {
-			case ControllerButton_ATTACK:
-				*action = GameAction(GameActionType_PRIMARY_ACTION);
-				break;
-			case ControllerButton_CAST_SPELL:
-				*action = GameAction(GameActionType_CAST_SPELL);
-				break;
-			default:
-				break;
-			}
-		}
-
-		return true;
 	}
 
 	if (!inGameMenu) {

--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -124,22 +124,32 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, Game
 				return true;
 			}
 			if (VirtualGamepadState.primaryActionButton.isHeld && VirtualGamepadState.primaryActionButton.didStateChange) {
-				if (!inGameMenu && !QuestLogIsOpen && !sbookflag)
+				if (!inGameMenu && !QuestLogIsOpen && !sbookflag) {
 					*action = GameAction(GameActionType_PRIMARY_ACTION);
-				else if (sgpCurrentMenu != nullptr || stextflag != STORE_NONE || QuestLogIsOpen)
+					if (ControllerButtonHeld == ControllerButton_NONE) {
+						ControllerButtonHeld = ControllerButtonPrimary;
+					}
+				} else if (sgpCurrentMenu != nullptr || stextflag != STORE_NONE || QuestLogIsOpen) {
 					*action = GameActionSendKey { DVL_VK_RETURN, false };
-				else
+				} else {
 					*action = GameActionSendKey { DVL_VK_SPACE, false };
+				}
 				return true;
 			}
 			if (VirtualGamepadState.secondaryActionButton.isHeld && VirtualGamepadState.secondaryActionButton.didStateChange) {
-				if (!inGameMenu && !QuestLogIsOpen && !sbookflag)
+				if (!inGameMenu && !QuestLogIsOpen && !sbookflag) {
 					*action = GameAction(GameActionType_SECONDARY_ACTION);
+					if (ControllerButtonHeld == ControllerButton_NONE)
+						ControllerButtonHeld = ControllerButtonSecondary;
+				}
 				return true;
 			}
 			if (VirtualGamepadState.spellActionButton.isHeld && VirtualGamepadState.spellActionButton.didStateChange) {
-				if (!inGameMenu && !QuestLogIsOpen && !sbookflag)
+				if (!inGameMenu && !QuestLogIsOpen && !sbookflag) {
 					*action = GameAction(GameActionType_CAST_SPELL);
+					if (ControllerButtonHeld == ControllerButton_NONE)
+						ControllerButtonHeld = ControllerButtonTertiary;
+				}
 				return true;
 			}
 			if (VirtualGamepadState.cancelButton.isHeld && VirtualGamepadState.cancelButton.didStateChange) {
@@ -164,6 +174,13 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, Game
 				if (!QuestLogIsOpen && !sbookflag && stextflag == STORE_NONE)
 					*action = GameAction(GameActionType_USE_MANA_POTION);
 				return true;
+			}
+		} else if (event.type == SDL_FINGERUP) {
+			if ((!VirtualGamepadState.primaryActionButton.isHeld && ControllerButtonHeld == ControllerButtonPrimary)
+			    || (!VirtualGamepadState.secondaryActionButton.isHeld && ControllerButtonHeld == ControllerButtonSecondary)
+			    || (!VirtualGamepadState.spellActionButton.isHeld && ControllerButtonHeld == ControllerButtonTertiary)) {
+				ControllerButtonHeld = ControllerButton_NONE;
+				LastMouseButtonAction = MouseActionType::None;
 			}
 		}
 	}

--- a/Source/controls/game_controls.h
+++ b/Source/controls/game_controls.h
@@ -77,7 +77,8 @@ AxisDirection GetMoveDirection();
 
 extern bool start_modifier_active;
 extern bool select_modifier_active;
-extern const ControllerButton ControllerButton_ATTACK;
-extern const ControllerButton ControllerButton_CAST_SPELL;
+extern const ControllerButton ControllerButtonPrimary;
+extern const ControllerButton ControllerButtonSecondary;
+extern const ControllerButton ControllerButtonTertiary;
 
 } // namespace devilution

--- a/Source/controls/input.h
+++ b/Source/controls/input.h
@@ -11,9 +11,6 @@ inline int PollEvent(SDL_Event *event)
 	int result = SDL_PollEvent(event);
 	if (result != 0) {
 		UnlockControllerState(*event);
-		UnlockHeldControllerButtonEvents(*event);
-	} else {
-		result = PollActionButtonPressed(event);
 	}
 
 	return result;

--- a/Source/controls/menu_controls.cpp
+++ b/Source/controls/menu_controls.cpp
@@ -34,20 +34,6 @@ MenuAction GetMenuAction(const SDL_Event &event)
 		return GetMenuHeldUpDownAction();
 	}
 
-	if (ctrlEvent.state == ControllerButtonState_HELD) {
-		bool processHeldEvent = IsAnyOf(ctrlEvent.button,
-		    ControllerButton_BUTTON_DPAD_UP,
-		    ControllerButton_BUTTON_DPAD_DOWN,
-		    ControllerButton_BUTTON_DPAD_LEFT,
-		    ControllerButton_BUTTON_DPAD_RIGHT,
-		    ControllerButton_BUTTON_LEFTSHOULDER,
-		    ControllerButton_BUTTON_RIGHTSHOULDER);
-
-		if (!processHeldEvent) {
-			return MenuAction_NONE;
-		}
-	}
-
 	if (!ctrlEvent.up) {
 		switch (ctrlEvent.button) {
 		case ControllerButton_IGNORE:

--- a/Source/controls/plrctrls.h
+++ b/Source/controls/plrctrls.h
@@ -36,6 +36,8 @@ extern ControlTypes ControlMode;
  */
 extern ControlTypes ControlDevice;
 
+extern ControllerButton ControllerButtonHeld;
+
 // Runs every frame.
 // Handles menu movement.
 void plrctrls_every_frame();
@@ -53,8 +55,6 @@ void HandleRightStickMotion();
 
 // Whether we're in a dialog menu that the game handles natively with keyboard controls.
 bool InGameMenu();
-
-bool CanControlHero();
 
 void SetPointAndClick(bool value);
 

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -348,24 +348,8 @@ void CheckCursMove()
 	const Point currentTile { mx, my };
 
 	// While holding the button down we should retain target (but potentially lose it if it dies, goes out of view, etc)
-	if (sgbMouseDown != CLICK_NONE && IsNoneOf(LastMouseButtonAction, MouseActionType::None, MouseActionType::Attack, MouseActionType::Spell)) {
-		if (pcursmonst != -1) {
-			const auto &monster = Monsters[pcursmonst];
-			if (monster._mDelFlag || monster._mhitpoints >> 6 <= 0
-			    || (monster._mFlags & MFLAG_HIDDEN) != 0
-			    || !IsTileLit(monster.position.tile)) {
-				pcursmonst = -1;
-			}
-		} else if (pcursobj != -1) {
-			if (Objects[pcursobj]._oSelFlag < 1)
-				pcursobj = -1;
-		} else if (pcursplr != -1) {
-			auto &targetPlayer = Players[pcursplr];
-			if (targetPlayer._pmode == PM_DEATH || targetPlayer._pmode == PM_QUIT || !targetPlayer.plractive
-			    || currlevel != targetPlayer.plrlevel || targetPlayer._pHitPoints >> 6 <= 0
-			    || !IsTileLit(targetPlayer.position.tile))
-				pcursplr = -1;
-		}
+	if ((sgbMouseDown != CLICK_NONE || ControllerButtonHeld != ControllerButton_NONE) && IsNoneOf(LastMouseButtonAction, MouseActionType::None, MouseActionType::Attack, MouseActionType::Spell)) {
+		InvalidateTargets();
 
 		if (pcursmonst == -1 && pcursobj == -1 && pcursitem == -1 && pcursinvitem == -1 && pcursstashitem == uint16_t(-1) && pcursplr == -1) {
 			cursPosition = { mx, my };

--- a/Source/miniwin/misc_msg.cpp
+++ b/Source/miniwin/misc_msg.cpp
@@ -466,6 +466,11 @@ bool FetchMessage_Real(tagMSG *lpMsg)
 		return true;
 	}
 
+	if (IsAnyOf(ctrlEvent.button, ControllerButtonPrimary, ControllerButtonSecondary, ControllerButtonTertiary) && IsAnyOf(ControllerButtonHeld, ctrlEvent.button, ControllerButton_NONE)) {
+		ControllerButtonHeld = ctrlEvent.up ? ControllerButton_NONE : ctrlEvent.button;
+		LastMouseButtonAction = MouseActionType::None;
+	}
+
 	GameAction action;
 	if (GetGameAction(e, ctrlEvent, &action)) {
 		if (movie_playing) {

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -7,6 +7,8 @@
 
 #include <SDL.h>
 
+#include "controls/game_controls.h"
+#include "controls/plrctrls.h"
 #include "cursor.h"
 #include "engine/point.hpp"
 #include "player.h"
@@ -33,12 +35,37 @@ void RepeatWalk(Player &player)
 
 } // namespace
 
+void InvalidateTargets()
+{
+	if (pcursmonst != -1) {
+		const Monster &monster = Monsters[pcursmonst];
+		if (monster._mDelFlag || monster._mhitpoints >> 6 <= 0
+		    || (monster._mFlags & MFLAG_HIDDEN) != 0
+		    || !IsTileLit(monster.position.tile)) {
+			pcursmonst = -1;
+		}
+	}
+
+	if (pcursobj != -1) {
+		if (Objects[pcursobj]._oSelFlag < 1)
+			pcursobj = -1;
+	}
+
+	if (pcursplr != -1) {
+		Player &targetPlayer = Players[pcursplr];
+		if (targetPlayer._pmode == PM_DEATH || targetPlayer._pmode == PM_QUIT || !targetPlayer.plractive
+		    || currlevel != targetPlayer.plrlevel || targetPlayer._pHitPoints >> 6 <= 0
+		    || !IsTileLit(targetPlayer.position.tile))
+			pcursplr = -1;
+	}
+}
+
 void RepeatMouseAction()
 {
 	if (pcurs != CURSOR_HAND)
 		return;
 
-	if (sgbMouseDown == CLICK_NONE)
+	if (sgbMouseDown == CLICK_NONE && ControllerButtonHeld == ControllerButton_NONE)
 		return;
 
 	if (stextflag != STORE_NONE)

--- a/Source/track.h
+++ b/Source/track.h
@@ -7,6 +7,7 @@
 
 namespace devilution {
 
+void InvalidateTargets();
 void RepeatMouseAction();
 bool track_isscrolling();
 


### PR DESCRIPTION
This reverts a large part of https://github.com/diasurgical/devilutionX/pull/4019 and instead reuses the mouse's logic for repeating the last action.

Fixes #4406

This still doesn't add the logic to the touch interface, but that should be relatively trivial at this point I think.