### PR TITLE
Fix OpenDingux/RetroFW builds

### DIFF
--- a/Source/controls/controller.cpp
+++ b/Source/controls/controller.cpp
@@ -36,8 +36,6 @@ ControllerButtonEvent ToControllerButtonEvent(const SDL_Event &event)
 	}
 #if HAS_KBCTRL == 1
 	result.button = KbCtrlToControllerButton(event);
-	result.state = event.key.state;
-
 	if (result.button != ControllerButton_NONE)
 		return result;
 #endif


### PR DESCRIPTION
Follow-up to https://github.com/diasurgical/devilutionX/pull/4414, which removed the `state` field.