### PR TITLE
Expand hot area of stash cell to include bottom-right border

### DIFF
--- a/Source/engine/size.hpp
+++ b/Source/engine/size.hpp
@@ -30,6 +30,13 @@ struct Size {
 		return !(*this == other);
 	}
 
+	constexpr Size &operator+=(const int factor)
+	{
+		width += factor;
+		height += factor;
+		return *this;
+	}
+
 	constexpr Size &operator*=(const int factor)
 	{
 		width *= factor;
@@ -49,6 +56,18 @@ struct Size {
 		width /= factor;
 		height /= factor;
 		return *this;
+	}
+
+	constexpr friend Size operator+(Size a, const int factor)
+	{
+		a += factor;
+		return a;
+	}
+
+	constexpr friend Size operator*(Size a, const int factor)
+	{
+		a *= factor;
+		return a;
 	}
 
 	constexpr friend Size operator/(Size a, const int factor)

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -69,7 +69,7 @@ Point FindSlotUnderCursor(Point cursorPosition)
 	for (auto point : PointsInRectangleRange({ { 0, 0 }, { 10, 10 } })) {
 		Rectangle cell {
 			GetStashSlotCoord(point),
-			InventorySlotSizeInPixels
+			InventorySlotSizeInPixels + 1
 		};
 
 		if (cell.Contains(cursorPosition)) {


### PR DESCRIPTION
This matches the behaviour of inventory cell hit logic. Previously it was possible to click exactly on a border and be unable to put an item in the stash.