### PR TITLE
Remove use of SetICursor and related globals from CheckStashPaste

### DIFF
--- a/Source/engine/size.hpp
+++ b/Source/engine/size.hpp
@@ -51,6 +51,12 @@ struct Size {
 		return *this;
 	}
 
+	constexpr friend Size operator*(Size a, const int factor)
+	{
+		a *= factor;
+		return a;
+	}
+
 	constexpr friend Size operator/(Size a, const int factor)
 	{
 		a /= factor;


### PR DESCRIPTION
Cleaned up the logic for `FindSlotUnderCursor` while I was at it, the code was difficult to read and ended up being simple to express entirely in `CheckStashPaste` instead.