### PR TITLE
Add zoom on start ini option

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -150,6 +150,11 @@ bool was_ui_init = false;
 void StartGame(interface_mode uMsg)
 {
 	zoomflag = true;
+	if (*sgOptions.Graphics.zoomStart) {
+		zoomflag = false;
+	} else {
+		zoomflag = true;
+	}
 	CalcViewportGeometry();
 	cineflag = false;
 	InitCursor();

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -746,6 +746,7 @@ GraphicsOptions::GraphicsOptions()
     , integerScaling("Integer Scaling", OptionEntryFlags::CantChangeInGame | OptionEntryFlags::RecreateUI, N_("Integer Scaling"), N_("Scales the image using whole number pixel ratio."), false)
     , vSync("Vertical Sync", OptionEntryFlags::RecreateUI, N_("Vertical Sync"), N_("Forces waiting for Vertical Sync. Prevents tearing effect when drawing a frame. Disabling it can help with mouse lag on some systems."), true)
 #endif
+    , zoomStart("Zoom on start", OptionEntryFlags::None, N_("Zoom on start"), N_("Zoom by default when a game starts."), false)
     , gammaCorrection("Gamma Correction", OptionEntryFlags::Invisible, "Gamma Correction", "Gamma correction level.", 100)
     , colorCycling("Color Cycling", OptionEntryFlags::None, N_("Color Cycling"), N_("Color cycling effect used for water, lava, and acid animation."), true)
     , alternateNestArt("Alternate nest art", OptionEntryFlags::OnlyHellfire | OptionEntryFlags::CantChangeInGame, N_("Alternate nest art"), N_("The game will use an alternative palette for Hellfire’s nest tileset."), false)
@@ -789,6 +790,7 @@ std::vector<OptionEntryBase *> GraphicsOptions::GetEntries()
 		&integerScaling,
 		&vSync,
 #endif
+		&zoomStart,
 		&gammaCorrection,
 		&limitFPS,
 		&showFPS,

--- a/Source/options.h
+++ b/Source/options.h
@@ -397,6 +397,8 @@ struct GraphicsOptions : OptionCategoryBase {
 	/** @brief Enable vsync on the output. */
 	OptionEntryBoolean vSync;
 #endif
+	/** @brief Zoom on start. */
+	OptionEntryBoolean zoomStart;
 	/** @brief Gamma correction level. */
 	OptionEntryInt<int> gammaCorrection;
 	/** @brief Enable color cycling animations. */


### PR DESCRIPTION
Adding in "zoom on start" option allows starting a game zoomed in without the need to press the Z button for the people that prefer to play this way.