### PR TITLE
Simplify logic when moving around the inventory with a controller

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -772,21 +772,17 @@ Point FindClosestStashSlot(Point mousePos)
 /**
  * @brief Figures out where on the body to move when on the first row
  */
-Point InventoryMoveToBody(int slot)
+inv_xy_slot InventoryMoveToBody(int slot)
 {
 	PreviousInventoryColumn = slot - SLOTXY_INV_ROW1_FIRST;
 	if (slot <= SLOTXY_INV_ROW1_FIRST + 2) { // first 3 general slots
-		Slot = SLOTXY_RING_LEFT;
-		return InvGetEquipSlotCoord(INVLOC_RING_LEFT);
-	} else if (slot <= SLOTXY_INV_ROW1_FIRST + 6) { // middle 4 general slots
-		Slot = SLOTXY_CHEST_FIRST;
-		return InvGetEquipSlotCoord(INVLOC_CHEST);
-	} else { // last 3 general slots
-		Slot = SLOTXY_RING_RIGHT;
-		return InvGetEquipSlotCoord(INVLOC_RING_RIGHT);
+		return SLOTXY_RING_LEFT;
 	}
-
-	return GetSlotCoord(0);
+	if (slot <= SLOTXY_INV_ROW1_FIRST + 6) { // middle 4 general slots
+		return SLOTXY_CHEST_FIRST;
+	}
+	// last 3 general slots
+	return SLOTXY_RING_RIGHT;
 }
 
 void InventoryMove(AxisDirection dir)
@@ -932,7 +928,8 @@ void InventoryMove(AxisDirection dir)
 			}
 		} else {
 			if (Slot >= SLOTXY_INV_ROW1_FIRST && Slot <= SLOTXY_INV_ROW1_LAST) {
-				mousePos = InventoryMoveToBody(Slot);
+				Slot = InventoryMoveToBody(Slot);
+				mousePos = InvGetEquipSlotCoordFromInvSlot(Slot);
 			} else if (Slot == SLOTXY_CHEST_FIRST || Slot == SLOTXY_HAND_LEFT_FIRST) {
 				Slot = SLOTXY_HEAD_FIRST;
 				mousePos = InvGetEquipSlotCoord(INVLOC_HEAD);
@@ -950,7 +947,8 @@ void InventoryMove(AxisDirection dir)
 				if (itemId != 0) {
 					for (int i = 1; i < 5; i++) {
 						if (Slot - i * INV_ROW_SLOT_SIZE < SLOTXY_INV_ROW1_FIRST) {
-							mousePos = InventoryMoveToBody(Slot - (i - 1) * INV_ROW_SLOT_SIZE);
+							Slot = InventoryMoveToBody(Slot - (i - 1) * INV_ROW_SLOT_SIZE);
+							mousePos = InvGetEquipSlotCoordFromInvSlot(Slot);
 							break;
 						}
 						if (itemId != GetItemIdOnSlot(Slot - i * INV_ROW_SLOT_SIZE)) {

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -564,7 +564,6 @@ void AttrIncBtnSnap(AxisDirection dir)
 Point InvGetEquipSlotCoord(const inv_body_loc invSlot)
 {
 	Point result = GetPanelPosition(UiPanels::Inventory);
-	result.x -= (icursSize28.width - 1) * (InventorySlotSizeInPixels.width / 2);
 	switch (invSlot) {
 	case INVLOC_HEAD:
 		result.x += ((InvRect[SLOTXY_HEAD_FIRST].x + InvRect[SLOTXY_HEAD_LAST].x) / 2);
@@ -996,10 +995,14 @@ void InventoryMove(AxisDirection dir)
 	}
 	// move cursor to the center of the slot if not holding anything or top left is holding an object
 	if (isHoldingItem) {
-		if (Slot >= SLOTXY_INV_FIRST)
-			mousePos.y -= InventorySlotSizeInPixels.height;
-		else
-			mousePos.y -= (int)((itemSize.height / 2.0) * InventorySlotSizeInPixels.height) + (InventorySlotSizeInPixels.height / 2);
+		if (Slot < SLOTXY_INV_FIRST) {
+			// The coordinates we get for body slots are based on the centre of the region relative to the hand cursor
+			// Need to adjust the position for items larger than 1x1 so they're aligned as expected
+			mousePos.x -= (itemSize.width - 1) * INV_SLOT_HALF_SIZE_PX;
+			mousePos.y -= (itemSize.height - 1) * INV_SLOT_HALF_SIZE_PX;
+		}
+		// Also the y position is off... so shift the mouse a cell up to compensate.
+		mousePos.y -= InventorySlotSizeInPixels.height;
 	} else {
 		// get item under new slot if navigating on the inventory
 		if (Slot >= SLOTXY_INV_FIRST && Slot <= SLOTXY_INV_LAST) {

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -815,28 +815,21 @@ void InventoryMove(AxisDirection dir)
 			if (Slot >= SLOTXY_INV_FIRST && Slot <= SLOTXY_BELT_LAST) {
 				if (IsNoneOf(Slot, SLOTXY_INV_ROW1_FIRST, SLOTXY_INV_ROW2_FIRST, SLOTXY_INV_ROW3_FIRST, SLOTXY_INV_ROW4_FIRST, SLOTXY_BELT_FIRST)) {
 					Slot -= 1;
-					mousePos = GetSlotCoord(Slot);
 				}
 			} else if (heldItem._itype == ItemType::Ring) {
 				Slot = SLOTXY_RING_LEFT;
-				mousePos = InvGetEquipSlotCoord(INVLOC_RING_LEFT);
 			} else if (heldItem.isWeapon() || heldItem.isShield()) {
 				Slot = SLOTXY_HAND_LEFT_FIRST;
-				mousePos = InvGetEquipSlotCoord(INVLOC_HAND_LEFT);
 			}
 		} else {
 			if (Slot == SLOTXY_HAND_RIGHT_FIRST) {
 				Slot = SLOTXY_CHEST_FIRST;
-				mousePos = InvGetEquipSlotCoord(INVLOC_CHEST);
 			} else if (Slot == SLOTXY_CHEST_FIRST) {
 				Slot = SLOTXY_HAND_LEFT_FIRST;
-				mousePos = InvGetEquipSlotCoord(INVLOC_HAND_LEFT);
 			} else if (Slot == SLOTXY_AMULET) {
 				Slot = SLOTXY_HEAD_FIRST;
-				mousePos = InvGetEquipSlotCoord(INVLOC_HEAD);
 			} else if (Slot == SLOTXY_RING_RIGHT) {
 				Slot = SLOTXY_RING_LEFT;
-				mousePos = InvGetEquipSlotCoord(INVLOC_RING_LEFT);
 			} else if (Slot >= SLOTXY_INV_FIRST && Slot <= SLOTXY_BELT_LAST) {
 				int8_t itemId = GetItemIdOnSlot(Slot);
 				if (itemId != 0) {
@@ -849,7 +842,6 @@ void InventoryMove(AxisDirection dir)
 				} else if (IsNoneOf(Slot, SLOTXY_INV_ROW1_FIRST, SLOTXY_INV_ROW2_FIRST, SLOTXY_INV_ROW3_FIRST, SLOTXY_INV_ROW4_FIRST, SLOTXY_BELT_FIRST)) {
 					Slot -= 1;
 				}
-				mousePos = GetSlotCoord(Slot);
 			}
 		}
 	} else if (dir.x == AxisDirectionX_RIGHT) {
@@ -857,28 +849,21 @@ void InventoryMove(AxisDirection dir)
 			if (Slot >= SLOTXY_INV_FIRST && Slot <= SLOTXY_BELT_LAST) {
 				if (IsNoneOf(Slot + itemSize.width - 1, SLOTXY_INV_ROW1_LAST, SLOTXY_INV_ROW2_LAST, SLOTXY_INV_ROW3_LAST, SLOTXY_INV_ROW4_LAST, SLOTXY_BELT_LAST)) {
 					Slot += 1;
-					mousePos = GetSlotCoord(Slot);
 				}
 			} else if (heldItem._itype == ItemType::Ring) {
 				Slot = SLOTXY_RING_RIGHT;
-				mousePos = InvGetEquipSlotCoord(INVLOC_RING_RIGHT);
 			} else if (heldItem.isWeapon() || heldItem.isShield()) {
 				Slot = SLOTXY_HAND_RIGHT_FIRST;
-				mousePos = InvGetEquipSlotCoord(INVLOC_HAND_RIGHT);
 			}
 		} else {
 			if (Slot == SLOTXY_RING_LEFT) {
 				Slot = SLOTXY_RING_RIGHT;
-				mousePos = InvGetEquipSlotCoord(INVLOC_RING_RIGHT);
 			} else if (Slot == SLOTXY_HAND_LEFT_FIRST) {
 				Slot = SLOTXY_CHEST_FIRST;
-				mousePos = InvGetEquipSlotCoord(INVLOC_CHEST);
 			} else if (Slot == SLOTXY_CHEST_FIRST) {
 				Slot = SLOTXY_HAND_RIGHT_FIRST;
-				mousePos = InvGetEquipSlotCoord(INVLOC_HAND_RIGHT);
 			} else if (Slot == SLOTXY_HEAD_FIRST) {
 				Slot = SLOTXY_AMULET;
-				mousePos = InvGetEquipSlotCoord(INVLOC_AMULET);
 			} else if (Slot >= SLOTXY_INV_FIRST && Slot <= SLOTXY_BELT_LAST) {
 				int8_t itemId = GetItemIdOnSlot(Slot);
 				if (itemId != 0) {
@@ -891,7 +876,6 @@ void InventoryMove(AxisDirection dir)
 				} else if (IsNoneOf(Slot, SLOTXY_INV_ROW1_LAST, SLOTXY_INV_ROW2_LAST, SLOTXY_INV_ROW3_LAST, SLOTXY_INV_ROW4_LAST, SLOTXY_BELT_LAST)) {
 					Slot += 1;
 				}
-				mousePos = GetSlotCoord(Slot);
 			}
 		}
 	}
@@ -899,67 +883,51 @@ void InventoryMove(AxisDirection dir)
 		if (isHoldingItem) {
 			if (Slot >= SLOTXY_INV_ROW2_FIRST) { // general inventory
 				Slot -= INV_ROW_SLOT_SIZE;
-				mousePos = GetSlotCoord(Slot);
 			} else if (Slot >= SLOTXY_INV_FIRST) {
 				if (heldItem._itype == ItemType::Ring) {
 					if (Slot >= SLOTXY_INV_ROW1_FIRST && Slot <= SLOTXY_INV_ROW1_FIRST + (INV_ROW_SLOT_SIZE / 2) - 1) {
 						Slot = SLOTXY_RING_LEFT;
-						mousePos = InvGetEquipSlotCoord(INVLOC_RING_LEFT);
 					} else {
 						Slot = SLOTXY_RING_RIGHT;
-						mousePos = InvGetEquipSlotCoord(INVLOC_RING_RIGHT);
 					}
 				} else if (heldItem.isWeapon()) {
 					Slot = SLOTXY_HAND_LEFT_FIRST;
-					mousePos = InvGetEquipSlotCoord(INVLOC_HAND_LEFT);
 				} else if (heldItem.isShield()) {
 					Slot = SLOTXY_HAND_RIGHT_FIRST;
-					mousePos = InvGetEquipSlotCoord(INVLOC_HAND_RIGHT);
 				} else if (heldItem.isHelm()) {
 					Slot = SLOTXY_HEAD_FIRST;
-					mousePos = InvGetEquipSlotCoord(INVLOC_HEAD);
 				} else if (heldItem.isArmor()) {
 					Slot = SLOTXY_CHEST_FIRST;
-					mousePos = InvGetEquipSlotCoord(INVLOC_CHEST);
 				} else if (heldItem._itype == ItemType::Amulet) {
 					Slot = SLOTXY_AMULET;
-					mousePos = InvGetEquipSlotCoord(INVLOC_AMULET);
 				}
 			}
 		} else {
 			if (Slot >= SLOTXY_INV_ROW1_FIRST && Slot <= SLOTXY_INV_ROW1_LAST) {
 				Slot = InventoryMoveToBody(Slot);
-				mousePos = InvGetEquipSlotCoordFromInvSlot(Slot);
 			} else if (Slot == SLOTXY_CHEST_FIRST || Slot == SLOTXY_HAND_LEFT_FIRST) {
 				Slot = SLOTXY_HEAD_FIRST;
-				mousePos = InvGetEquipSlotCoord(INVLOC_HEAD);
 			} else if (Slot == SLOTXY_RING_LEFT) {
 				Slot = SLOTXY_HAND_LEFT_FIRST;
-				mousePos = InvGetEquipSlotCoord(INVLOC_HAND_LEFT);
 			} else if (Slot == SLOTXY_RING_RIGHT) {
 				Slot = SLOTXY_HAND_RIGHT_FIRST;
-				mousePos = InvGetEquipSlotCoord(INVLOC_HAND_RIGHT);
 			} else if (Slot == SLOTXY_HAND_RIGHT_FIRST) {
 				Slot = SLOTXY_AMULET;
-				mousePos = InvGetEquipSlotCoord(INVLOC_AMULET);
 			} else if (Slot >= SLOTXY_INV_ROW2_FIRST) {
 				int8_t itemId = GetItemIdOnSlot(Slot);
 				if (itemId != 0) {
 					for (int i = 1; i < 5; i++) {
 						if (Slot - i * INV_ROW_SLOT_SIZE < SLOTXY_INV_ROW1_FIRST) {
 							Slot = InventoryMoveToBody(Slot - (i - 1) * INV_ROW_SLOT_SIZE);
-							mousePos = InvGetEquipSlotCoordFromInvSlot(Slot);
 							break;
 						}
 						if (itemId != GetItemIdOnSlot(Slot - i * INV_ROW_SLOT_SIZE)) {
 							Slot -= i * INV_ROW_SLOT_SIZE;
-							mousePos = GetSlotCoord(Slot);
 							break;
 						}
 					}
 				} else {
 					Slot -= INV_ROW_SLOT_SIZE;
-					mousePos = GetSlotCoord(Slot);
 				}
 			}
 		}
@@ -967,52 +935,40 @@ void InventoryMove(AxisDirection dir)
 		if (isHoldingItem) {
 			if (Slot == SLOTXY_HEAD_FIRST || Slot == SLOTXY_CHEST_FIRST) {
 				Slot = SLOTXY_INV_ROW1_FIRST + 4;
-				mousePos = GetSlotCoord(Slot);
 			} else if (Slot == SLOTXY_RING_LEFT || Slot == SLOTXY_HAND_LEFT_FIRST) {
 				Slot = SLOTXY_INV_ROW1_FIRST + 1;
-				mousePos = GetSlotCoord(Slot);
 			} else if (Slot == SLOTXY_RING_RIGHT || Slot == SLOTXY_HAND_RIGHT_FIRST || Slot == SLOTXY_AMULET) {
 				Slot = SLOTXY_INV_ROW1_LAST - 1;
-				mousePos = GetSlotCoord(Slot);
 			} else if (Slot <= (SLOTXY_INV_ROW4_LAST - (itemSize.height * INV_ROW_SLOT_SIZE))) {
 				Slot += INV_ROW_SLOT_SIZE;
-				mousePos = GetSlotCoord(Slot);
 			} else if (Slot <= SLOTXY_INV_LAST && heldItem._itype == ItemType::Misc && itemSize == Size { 1, 1 }) { // forcing only 1x1 misc items
 				if (Slot + INV_ROW_SLOT_SIZE <= SLOTXY_BELT_LAST)
 					Slot += INV_ROW_SLOT_SIZE;
-				mousePos = GetSlotCoord(Slot);
 			}
 		} else {
 			if (Slot == SLOTXY_HEAD_FIRST) {
 				Slot = SLOTXY_CHEST_FIRST;
-				mousePos = InvGetEquipSlotCoord(INVLOC_CHEST);
 			} else if (Slot == SLOTXY_CHEST_FIRST) {
 				if (PreviousInventoryColumn >= 3 && PreviousInventoryColumn <= 6)
 					Slot = SLOTXY_INV_ROW1_FIRST + PreviousInventoryColumn;
 				else
 					Slot = SLOTXY_INV_ROW1_FIRST + (INV_ROW_SLOT_SIZE / 2);
-				mousePos = GetSlotCoord(Slot);
 			} else if (Slot == SLOTXY_HAND_LEFT_FIRST) {
 				Slot = SLOTXY_RING_LEFT;
-				mousePos = InvGetEquipSlotCoord(INVLOC_RING_LEFT);
 			} else if (Slot == SLOTXY_RING_LEFT) {
 				if (PreviousInventoryColumn >= 0 && PreviousInventoryColumn <= 2)
 					Slot = SLOTXY_INV_ROW1_FIRST + PreviousInventoryColumn;
 				else
 					Slot = SLOTXY_INV_ROW1_FIRST + 1;
-				mousePos = GetSlotCoord(Slot);
 			} else if (Slot == SLOTXY_RING_RIGHT) {
 				if (PreviousInventoryColumn >= 7 && PreviousInventoryColumn <= 9)
 					Slot = SLOTXY_INV_ROW1_FIRST + PreviousInventoryColumn;
 				else
 					Slot = SLOTXY_INV_ROW1_LAST - 1;
-				mousePos = GetSlotCoord(Slot);
 			} else if (Slot == SLOTXY_AMULET) {
 				Slot = SLOTXY_HAND_RIGHT_FIRST;
-				mousePos = InvGetEquipSlotCoord(INVLOC_HAND_RIGHT);
 			} else if (Slot == SLOTXY_HAND_RIGHT_FIRST) {
 				Slot = SLOTXY_RING_RIGHT;
-				mousePos = InvGetEquipSlotCoord(INVLOC_RING_RIGHT);
 			} else if (Slot <= SLOTXY_INV_LAST) {
 				int8_t itemId = GetItemIdOnSlot(Slot);
 				if (itemId != 0) {
@@ -1025,7 +981,6 @@ void InventoryMove(AxisDirection dir)
 				} else if (Slot + INV_ROW_SLOT_SIZE <= SLOTXY_BELT_LAST) {
 					Slot += INV_ROW_SLOT_SIZE;
 				}
-				mousePos = GetSlotCoord(Slot);
 			}
 		}
 	}
@@ -1034,6 +989,11 @@ void InventoryMove(AxisDirection dir)
 	if (Slot == initialSlot)
 		return;
 
+	if (Slot < SLOTXY_INV_FIRST) {
+		mousePos = InvGetEquipSlotCoordFromInvSlot(static_cast<inv_xy_slot>(Slot));
+	} else {
+		mousePos = GetSlotCoord(Slot);
+	}
 	// move cursor to the center of the slot if not holding anything or top left is holding an object
 	if (isHoldingItem) {
 		if (Slot >= SLOTXY_INV_FIRST)

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -662,11 +662,7 @@ Size GetItemSizeOnSlot(int slot)
 		if (ii != 0) {
 			Item &item = MyPlayer->InvList[ii - 1];
 			if (!item.isEmpty()) {
-				auto size = GetInvItemSize(item._iCurs + CURSOR_FIRSTITEM);
-				size.width /= InventorySlotSizeInPixels.width;
-				size.height /= InventorySlotSizeInPixels.height;
-
-				return size;
+				return GetInventorySize(item);
 			}
 		}
 	}

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -109,15 +109,11 @@ const uint16_t InvItemHeight2[] = {
 Size cursSize;
 /** Current highlighted monster */
 int pcursmonst = -1;
-/** Size of current cursor in inventory cells */
-Size icursSize28;
 
 /** inv_item value */
 int8_t pcursinvitem;
 /** StashItem value */
 uint16_t pcursstashitem;
-/** Pixel size of the current cursor image */
-Size icursSize;
 /** Current highlighted item */
 int8_t pcursitem;
 /** Current highlighted object */
@@ -165,12 +161,6 @@ Size GetInvItemSize(int cursId)
 	return { InvItemWidth1[i], InvItemHeight1[i] };
 }
 
-void SetICursor(int cursId)
-{
-	icursSize = cursId == CURSOR_NONE ? Size { 0, 0 } : GetInvItemSize(cursId);
-	icursSize28 = icursSize / 28;
-}
-
 void ResetCursor()
 {
 	NewCursor(pcurs);
@@ -183,7 +173,6 @@ void NewCursor(int cursId)
 	}
 	pcurs = cursId;
 	cursSize = cursId == CURSOR_NONE ? Size { 0, 0 } : GetInvItemSize(cursId);
-	SetICursor(cursId);
 
 	if (IsHardwareCursorEnabled() && ControlDevice == ControlTypes::KeyboardAndMouse) {
 		if (ArtCursor.surface == nullptr && cursId == CURSOR_NONE)

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -34,8 +34,6 @@ enum cursor_id : uint8_t {
 
 extern DVL_API_FOR_TEST Size cursSize;
 extern int pcursmonst;
-extern DVL_API_FOR_TEST Size icursSize28;
-extern DVL_API_FOR_TEST Size icursSize;
 extern int8_t pcursinvitem;
 extern uint16_t pcursstashitem;
 extern int8_t pcursitem;
@@ -46,7 +44,6 @@ extern DVL_API_FOR_TEST int pcurs;
 
 void InitCursor();
 void FreeCursor();
-void SetICursor(int cursId);
 void ResetCursor();
 void NewCursor(int cursId);
 void InitLevelCursor();

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -477,14 +477,10 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 				player.HoldItem = player.InvBody[INVLOC_HAND_LEFT];
 			if (pnum == MyPlayerId)
 				NewCursor(player.HoldItem._iCurs + CURSOR_FIRSTITEM);
-			else
-				SetICursor(player.HoldItem._iCurs + CURSOR_FIRSTITEM);
 			bool done2h = AutoPlaceItemInInventory(player, player.HoldItem, true);
 			player.HoldItem = tempitem;
 			if (pnum == MyPlayerId)
 				NewCursor(player.HoldItem._iCurs + CURSOR_FIRSTITEM);
-			else
-				SetICursor(player.HoldItem._iCurs + CURSOR_FIRSTITEM);
 			if (!done2h)
 				return;
 
@@ -1665,7 +1661,6 @@ void AutoGetItem(int pnum, Item *itemPointer, int ii)
 	CheckQuestItem(player, item);
 	UpdateBookLevel(player, item);
 	item._iStatFlag = player.CanUseItem(item);
-	SetICursor(item._iCurs + CURSOR_FIRSTITEM);
 
 	bool done;
 	bool autoEquipped = false;

--- a/test/cursor_test.cpp
+++ b/test/cursor_test.cpp
@@ -12,8 +12,4 @@ TEST(Cursor, SetCursor)
 	EXPECT_EQ(pcurs, i);
 	EXPECT_EQ(cursSize.width, 1 * 28);
 	EXPECT_EQ(cursSize.height, 3 * 28);
-	EXPECT_EQ(icursSize.width, 1 * 28);
-	EXPECT_EQ(icursSize.height, 3 * 28);
-	EXPECT_EQ(icursSize28.width, 1);
-	EXPECT_EQ(icursSize28.height, 3);
 }


### PR DESCRIPTION
Removes the last uses of the icursSize variables, and removes a fair chunk of duplicated code. A lot of the cursor positioning stuff appears to be because InvRect points aren't quite aligned to the actual position of the grid in the panel? The multiple uses of that array make it hard to change at the moment so gonna leave that for later.