### PR TITLE
GetManaAmount - fix usage of pMaxManaBase

### DIFF
--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -146,7 +146,7 @@ int GetManaAmount(Player &player, spell_id sn)
 	if (sn == SPL_HEAL || sn == SPL_HEALOTHER) {
 		ma = (spelldata[SPL_HEAL].sManaCost + 2 * player._pLevel - adj);
 	} else if (spelldata[sn].sManaCost == 255) {
-		ma = ((BYTE)(player._pMaxManaBase >> 6) - adj);
+		ma = (player._pMaxManaBase >> 6) - adj;
 	} else {
 		ma = (spelldata[sn].sManaCost - adj);
 	}

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -146,7 +146,7 @@ int GetManaAmount(Player &player, spell_id sn)
 	if (sn == SPL_HEAL || sn == SPL_HEALOTHER) {
 		ma = (spelldata[SPL_HEAL].sManaCost + 2 * player._pLevel - adj);
 	} else if (spelldata[sn].sManaCost == 255) {
-		ma = ((BYTE)player._pMaxManaBase - adj);
+		ma = ((BYTE)(player._pMaxManaBase >> 6) - adj);
 	} else {
 		ma = (spelldata[sn].sManaCost - adj);
 	}


### PR DESCRIPTION
I don't think this ever comes up because no spells have an sManaCost of 255, however _pMaxManaBase is stored as fixed point, so it should be shifted before use.

But to be honest, I'm not even sure what it is trying to do here. Was sManaCost == 255 supposed to indicate that it was going to use all the player's mana? Why was it cast to a BYTE before using it? Did they intend to limit the manage usage to 255 and just screwed up? I originally saw this logic in Devilution, and found it because the Middle Earth mod had a slight change here, where it used pMana (maybe because they thought it was intended to be a spell that used all the player's mana?) Also, I saw that in 1.07, Ghidra saw `ma` as a byte, not an int as written in Devilution - I wonder if that's where the cast came from? In the ME Mod version, it sees `ma` as an int.