### PR TITLE
Audio: Use SDL resampler where available

### DIFF
--- a/3rdParty/SDL_audiolib/CMakeLists.txt
+++ b/3rdParty/SDL_audiolib/CMakeLists.txt
@@ -31,6 +31,6 @@ set(USE_DEC_DRMP3 ON)
 
 include(FetchContent)
 FetchContent_Declare(SDL_audiolib
-  URL https://github.com/realnc/SDL_audiolib/archive/1a69135313c79817b38a3a99826d4ac28d627fdf.tar.gz
-  URL_HASH MD5=0bb189ccf8d26e01d10a97a24d298d2a)
+  URL https://github.com/realnc/SDL_audiolib/archive/e503dc0200d0833da4b2dd9fa1dbf1baf02ca591.tar.gz
+  URL_HASH MD5=9460b91b44caa7cbb7f713214d248307)
 FetchContent_MakeAvailableExcludeFromAll(SDL_audiolib)

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -21,6 +21,7 @@
 #include "platform/locale.hpp"
 #include "qol/monhealthbar.h"
 #include "qol/xpbar.h"
+#include "sound_defs.hpp"
 #include "utils/file_util.h"
 #include "utils/language.h"
 #include "utils/log.hpp"
@@ -611,7 +612,14 @@ AudioOptions::AudioOptions()
     , sampleRate("Sample Rate", OptionEntryFlags::CantChangeInGame, N_("Sample Rate"), N_("Output sample rate (Hz)."), DEFAULT_AUDIO_SAMPLE_RATE, { 22050, 44100, 48000 })
     , channels("Channels", OptionEntryFlags::CantChangeInGame, N_("Channels"), N_("Number of output channels."), DEFAULT_AUDIO_CHANNELS, { 1, 2 })
     , bufferSize("Buffer Size", OptionEntryFlags::CantChangeInGame, N_("Buffer Size"), N_("Buffer size (number of frames per channel)."), DEFAULT_AUDIO_BUFFER_SIZE, { 1024, 2048, 5120 })
-    , resamplingQuality("Resampling Quality", OptionEntryFlags::CantChangeInGame, N_("Resampling Quality"), N_("Quality of the resampler, from 0 (lowest) to 10 (highest)."), DEFAULT_AUDIO_RESAMPLING_QUALITY, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
+    , resamplingQuality("Resampling Quality",
+          OptionEntryFlags::CantChangeInGame |
+#ifdef DVL_AULIB_SUPPORTS_SDL_RESAMPLER
+              OptionEntryFlags::Invisible,
+#else
+              OptionEntryFlags::None,
+#endif
+          N_("Resampling Quality"), N_("Quality of the resampler, from 0 (lowest) to 10 (highest)."), DEFAULT_AUDIO_RESAMPLING_QUALITY, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
 {
 	sampleRate.SetValueChangedCallback(OptionAudioChanged);
 	channels.SetValueChangedCallback(OptionAudioChanged);

--- a/Source/sound_defs.hpp
+++ b/Source/sound_defs.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <SDL_version.h>
+
 #define VOLUME_MIN -1600
 #define VOLUME_MAX 0
 #define VOLUME_STEPS 64
@@ -9,3 +11,7 @@
 
 #define PAN_MIN -6400
 #define PAN_MAX 6400
+
+#if SDL_VERSION_ATLEAST(2, 0, 7)
+#define DVL_AULIB_SUPPORTS_SDL_RESAMPLER
+#endif

--- a/Source/storm/storm_svid.cpp
+++ b/Source/storm/storm_svid.cpp
@@ -7,9 +7,6 @@
 #include <SmackerDecoder.h>
 
 #ifndef NOSOUND
-#include <Aulib/ResamplerSpeex.h>
-#include <Aulib/Stream.h>
-
 #include "utils/push_aulib_decoder.h"
 #endif
 
@@ -17,6 +14,7 @@
 #include "engine/assets.hpp"
 #include "options.h"
 #include "palette.h"
+#include "utils/aulib.hpp"
 #include "utils/display.h"
 #include "utils/log.hpp"
 #include "utils/sdl_compat.h"
@@ -262,8 +260,7 @@ bool SVidPlayBegin(const char *filename, int flags)
 		SVidAudioBuffer = std::unique_ptr<int16_t[]> { new int16_t[audioInfo.idealBufferSize] };
 		auto decoder = std::make_unique<PushAulibDecoder>(audioInfo.nChannels, audioInfo.sampleRate);
 		SVidAudioDecoder = decoder.get();
-		SVidAudioStream.emplace(/*rwops=*/nullptr, std::move(decoder),
-		    std::make_unique<Aulib::ResamplerSpeex>(*sgOptions.Audio.resamplingQuality), /*closeRw=*/false);
+		SVidAudioStream.emplace(/*rwops=*/nullptr, std::move(decoder), CreateAulibResampler(), /*closeRw=*/false);
 		const float volume = static_cast<float>(*sgOptions.Audio.soundVolume - VOLUME_MIN) / -VOLUME_MIN;
 		SVidAudioStream->setVolume(volume);
 		if (!diablo_is_focused())

--- a/Source/utils/aulib.hpp
+++ b/Source/utils/aulib.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#ifndef NOSOUND
+
+#include <memory>
+
+#include <Aulib/Stream.h>
+
+#ifdef DVL_AULIB_SUPPORTS_SDL_RESAMPLER
+#include <Aulib/ResamplerSdl.h>
+#else
+#include <Aulib/ResamplerSpeex.h>
+#endif
+
+#include "options.h"
+
+namespace devilution {
+
+inline std::unique_ptr<Aulib::Resampler> CreateAulibResampler()
+{
+#ifdef DVL_AULIB_SUPPORTS_SDL_RESAMPLER
+	return std::make_unique<Aulib::ResamplerSdl>();
+#else
+	return std::make_unique<Aulib::ResamplerSpeex>(*sgOptions.Audio.resamplingQuality);
+#endif
+}
+
+} // namespace devilution
+
+#endif // !NOSOUND

--- a/Source/utils/soundsample.cpp
+++ b/Source/utils/soundsample.cpp
@@ -6,7 +6,6 @@
 
 #include <Aulib/DecoderDrmp3.h>
 #include <Aulib/DecoderDrwav.h>
-#include <Aulib/ResamplerSpeex.h>
 #include <SDL.h>
 #ifdef USE_SDL1
 #include "utils/sdl2_to_1_2_backports.h"
@@ -16,6 +15,7 @@
 
 #include "engine/assets.hpp"
 #include "options.h"
+#include "utils/aulib.hpp"
 #include "utils/log.hpp"
 #include "utils/math.h"
 #include "utils/stubs.h"
@@ -66,8 +66,7 @@ std::unique_ptr<Aulib::Decoder> CreateDecoder(bool isMp3)
 
 std::unique_ptr<Aulib::Stream> CreateStream(SDL_RWops *handle, bool isMp3)
 {
-	return std::make_unique<Aulib::Stream>(handle, CreateDecoder(isMp3),
-	    std::make_unique<Aulib::ResamplerSpeex>(*sgOptions.Audio.resamplingQuality), /*closeRw=*/true);
+	return std::make_unique<Aulib::Stream>(handle, CreateDecoder(isMp3), CreateAulibResampler(), /*closeRw=*/true);
 }
 
 /**


### PR DESCRIPTION
Speex resampler appears to have some issues (see the spectrograms in https://github.com/diasurgical/devilutionX/issues/1390#issuecomment-1100204992)

Use the new SDL_audiolib's native SDL resampler where available (SDL 2.0.7+).