### PR TITLE
Fix player level validation when joining ZT public games

### DIFF
--- a/Source/DiabloUI/selgame.cpp
+++ b/Source/DiabloUI/selgame.cpp
@@ -266,15 +266,15 @@ void selgame_GameSelection_Select(int value)
 	selgame_enteringGame = true;
 	selgame_selectedGame = value;
 
+	gfnHeroInfo(UpdateHeroLevel);
+
+	selgame_FreeVectors();
+
 	if (value > 2) {
 		CopyUtf8(selgame_Ip, Gamelist[value - 3].name, sizeof(selgame_Ip));
 		selgame_Password_Select(value);
 		return;
 	}
-
-	gfnHeroInfo(UpdateHeroLevel);
-
-	selgame_FreeVectors();
 
 	UiAddBackground(&vecSelGameDialog);
 	UiAddLogo(&vecSelGameDialog);


### PR DESCRIPTION
Selecting a public game would skip `gfnHeroInfo(UpdateHeroLevel)`, meaning that the game would sometimes mistakenly deny or permit entry into a Nightmare or Hell difficulty game based on whatever happened to be stored in that variable before.