### PR TITLE
Throttle send player commands to avoid desyncs

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2337,6 +2337,7 @@ void game_loop(bool bStartup)
 		}
 		TimeoutCursor(false);
 		GameLogic();
+		ClearLastSendPlayerCmd();
 
 		if (!gbRunGame || !gbIsMultiplayer || demo::IsRunning() || demo::IsRecording() || !nthread_has_500ms_passed())
 			break;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -69,6 +69,57 @@ uint8_t sgbDeltaChunks;
 std::list<TMegaPkt> MegaPktList;
 Item ItemLimbo;
 
+/** @brief Last send player command for the local player. */
+TCmdLocParam4 lastSendPlayerCmd;
+
+/**
+ * @brief Throttles that a player command is only send once per game tick.
+ * This is a workaround for a desync that happens when a command is processed in different game ticks for different clients. See https://github.com/diasurgical/devilutionX/issues/2681 for details.
+ * When a proper fix is implemented this workaround can be removed.
+ */
+bool WasPlayerCmdAlreadyRequested(_cmd_id bCmd, Point position = {}, uint16_t wParam1 = 0, uint16_t wParam2 = 0, uint16_t wParam3 = 0, uint16_t wParam4 = 0)
+{
+	switch (bCmd) {
+	// All known commands that result in a changed player action (player.destAction)
+	case _cmd_id::CMD_RATTACKID:
+	case _cmd_id::CMD_SPELLID:
+	case _cmd_id::CMD_TSPELLID:
+	case _cmd_id::CMD_ATTACKID:
+	case _cmd_id::CMD_RATTACKPID:
+	case _cmd_id::CMD_SPELLPID:
+	case _cmd_id::CMD_TSPELLPID:
+	case _cmd_id::CMD_ATTACKPID:
+	case _cmd_id::CMD_ATTACKXY:
+	case _cmd_id::CMD_SATTACKXY:
+	case _cmd_id::CMD_RATTACKXY:
+	case _cmd_id::CMD_SPELLXY:
+	case _cmd_id::CMD_TSPELLXY:
+	case _cmd_id::CMD_SPELLXYD:
+	case _cmd_id::CMD_WALKXY:
+	case _cmd_id::CMD_TALKXY:
+	case _cmd_id::CMD_DISARMXY:
+	case _cmd_id::CMD_OPOBJXY:
+	case _cmd_id::CMD_GOTOGETITEM:
+	case _cmd_id::CMD_GOTOAGETITEM:
+		break;
+	default:
+		// None player actions should work normally
+		return false;
+	}
+
+	TCmdLocParam4 newSendParam = { bCmd, static_cast<uint8_t>(position.x), static_cast<uint8_t>(position.y), wParam1, wParam2, wParam3, wParam4 };
+
+	if (lastSendPlayerCmd.bCmd == newSendParam.bCmd && lastSendPlayerCmd.x == newSendParam.x && lastSendPlayerCmd.y == newSendParam.y
+	    && lastSendPlayerCmd.wParam1 == newSendParam.wParam1 && lastSendPlayerCmd.wParam2 == newSendParam.wParam2 && lastSendPlayerCmd.wParam3 == newSendParam.wParam3 && lastSendPlayerCmd.wParam4 == newSendParam.wParam4) {
+		// Command already send in this game tick => don't send again / throttle
+		return true;
+	}
+
+	lastSendPlayerCmd = newSendParam;
+
+	return false;
+}
+
 void GetNextPacket()
 {
 	MegaPktList.emplace_back();
@@ -1962,6 +2013,11 @@ DWORD OnOpenCrypt(const TCmd *pCmd)
 
 } // namespace
 
+void ClearLastSendPlayerCmd()
+{
+	lastSendPlayerCmd = {};
+}
+
 void msg_send_drop_pkt(int pnum, int reason)
 {
 	TFakeDropPlr cmd;
@@ -2366,6 +2422,9 @@ void NetSendCmdGolem(uint8_t mx, uint8_t my, Direction dir, uint8_t menemy, int 
 
 void NetSendCmdLoc(int playerId, bool bHiPri, _cmd_id bCmd, Point position)
 {
+	if (playerId == MyPlayerId && WasPlayerCmdAlreadyRequested(bCmd, position))
+		return;
+
 	TCmdLoc cmd;
 
 	cmd.bCmd = bCmd;
@@ -2382,6 +2441,9 @@ void NetSendCmdLoc(int playerId, bool bHiPri, _cmd_id bCmd, Point position)
 
 void NetSendCmdLocParam1(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1)
 {
+	if (WasPlayerCmdAlreadyRequested(bCmd, position, wParam1))
+		return;
+
 	TCmdLocParam1 cmd;
 
 	cmd.bCmd = bCmd;
@@ -2399,6 +2461,9 @@ void NetSendCmdLocParam1(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 
 void NetSendCmdLocParam2(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2)
 {
+	if (WasPlayerCmdAlreadyRequested(bCmd, position, wParam1, wParam2))
+		return;
+
 	TCmdLocParam2 cmd;
 
 	cmd.bCmd = bCmd;
@@ -2417,6 +2482,9 @@ void NetSendCmdLocParam2(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 
 void NetSendCmdLocParam3(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3)
 {
+	if (WasPlayerCmdAlreadyRequested(bCmd, position, wParam1, wParam2, wParam3))
+		return;
+
 	TCmdLocParam3 cmd;
 
 	cmd.bCmd = bCmd;
@@ -2436,6 +2504,9 @@ void NetSendCmdLocParam3(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 
 void NetSendCmdLocParam4(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4)
 {
+	if (WasPlayerCmdAlreadyRequested(bCmd, position, wParam1, wParam2, wParam3, wParam4))
+		return;
+
 	TCmdLocParam4 cmd;
 
 	cmd.bCmd = bCmd;
@@ -2453,6 +2524,9 @@ void NetSendCmdLocParam4(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 
 void NetSendCmdParam1(bool bHiPri, _cmd_id bCmd, uint16_t wParam1)
 {
+	if (WasPlayerCmdAlreadyRequested(bCmd, {}, wParam1))
+		return;
+
 	TCmdParam1 cmd;
 
 	cmd.bCmd = bCmd;
@@ -2481,6 +2555,9 @@ void NetSendCmdParam2(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wPar
 
 void NetSendCmdParam3(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3)
 {
+	if (WasPlayerCmdAlreadyRequested(bCmd, {}, wParam1, wParam2, wParam3))
+		return;
+
 	TCmdParam3 cmd;
 
 	cmd.bCmd = bCmd;
@@ -2495,6 +2572,9 @@ void NetSendCmdParam3(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wPar
 
 void NetSendCmdParam4(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4)
 {
+	if (WasPlayerCmdAlreadyRequested(bCmd, {}, wParam1, wParam2, wParam3, wParam4))
+		return;
+
 	TCmdParam4 cmd;
 
 	cmd.bCmd = bCmd;

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -790,6 +790,8 @@ void delta_sync_monster(const TSyncMonster &monsterSync, uint8_t level);
 void DeltaAddItem(int ii);
 void DeltaSaveLevel();
 void DeltaLoadLevel();
+/** @brief Clears last send player command for the local player. This is used when a game tick changes. */
+void ClearLastSendPlayerCmd();
 void NetSendCmd(bool bHiPri, _cmd_id bCmd);
 void NetSendCmdGolem(uint8_t mx, uint8_t my, Direction dir, uint8_t menemy, int hp, uint8_t cl);
 void NetSendCmdLoc(int playerId, bool bHiPri, _cmd_id bCmd, Point position);


### PR DESCRIPTION
Workaround for #2681

Notes:
- This implements the [mentioned](https://github.com/diasurgical/devilutionX/issues/2681#issuecomment-932789249) workaround:
   >Avoid sending multiple network messages in RepeatMouseAction (for one game tick).
- When the player should take a new action the logic checks if this command was the last sent action in this game ticks. If yes this is a redundant action and can be discarded. This helps to reduce the impact of #2681 significantly. For a detailed analysis see #2681.
- For local players this shouldn't make a difference, cause game ticks and network messages are always aligned.
- The logic is implemented in the `NetSendCmd` functions to work with normal clicks, repeated mouse actions, touch and gamepads.
- Hopefully this workaround can be removed in future version that's why it is implemented in a way that the code can be removed easily.