### PR TITLE
Add NewCursor(Item&) for setting the cursor based on a held item

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -372,7 +372,7 @@ void RemoveGold(Player &player, int goldIndex)
 		player.RemoveInvItem(gi);
 
 	MakeGoldStack(player.HoldItem, dropGoldValue);
-	NewCursor(player.HoldItem._iCurs + CURSOR_FIRSTITEM);
+	NewCursor(player.HoldItem);
 
 	player._pGold = CalculateGold(player);
 	dropGoldValue = 0;

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -165,6 +165,15 @@ void ResetCursor()
 	NewCursor(pcurs);
 }
 
+void NewCursor(const Item &item)
+{
+	if (item.isEmpty()) {
+		NewCursor(CURSOR_HAND);
+	} else {
+		NewCursor(item._iCurs + CURSOR_FIRSTITEM);
+	}
+}
+
 void NewCursor(int cursId)
 {
 	if (cursId < CURSOR_HOURGLASS && MyPlayer != nullptr) {

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -44,7 +44,15 @@ extern DVL_API_FOR_TEST int pcurs;
 void InitCursor();
 void FreeCursor();
 void ResetCursor();
+
+struct Item;
+/**
+ * @brief Use the item sprite as the cursor (or show the default hand cursor if the item isEmpty)
+ */
+void NewCursor(const Item &item);
+
 void NewCursor(int cursId);
+
 void InitLevelCursor();
 void CheckRportal();
 void CheckTown();

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -475,12 +475,8 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 				player.HoldItem = player.InvBody[INVLOC_HAND_RIGHT];
 			else
 				player.HoldItem = player.InvBody[INVLOC_HAND_LEFT];
-			if (pnum == MyPlayerId)
-				NewCursor(player.HoldItem._iCurs + CURSOR_FIRSTITEM);
 			bool done2h = AutoPlaceItemInInventory(player, player.HoldItem, true);
 			player.HoldItem = tempitem;
-			if (pnum == MyPlayerId)
-				NewCursor(player.HoldItem._iCurs + CURSOR_FIRSTITEM);
 			if (!done2h)
 				return;
 
@@ -853,7 +849,7 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 
 				holdItem._itype = ItemType::None;
 			} else {
-				NewCursor(holdItem._iCurs + CURSOR_FIRSTITEM);
+				NewCursor(holdItem);
 				if (!IsHardwareCursor() && !dropItem) {
 					// For a hardware cursor, we set the "hot point" to the center of the item instead.
 					Size cursSize = GetInvItemSize(holdItem._iCurs + CURSOR_FIRSTITEM);
@@ -1641,7 +1637,7 @@ void InvGetItem(int pnum, int ii)
 	CleanupItems(ii);
 	pcursitem = -1;
 	if (!player.HoldItem.isEmpty())
-		NewCursor(player.HoldItem._iCurs + CURSOR_FIRSTITEM);
+		NewCursor(player.HoldItem);
 }
 
 void AutoGetItem(int pnum, Item *itemPointer, int ii)

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -222,7 +222,7 @@ void CheckStashCut(Point cursorPosition, bool automaticMove)
 
 			holdItem._itype = ItemType::None;
 		} else {
-			NewCursor(holdItem._iCurs + CURSOR_FIRSTITEM);
+			NewCursor(holdItem);
 			if (!IsHardwareCursor()) {
 				// For a hardware cursor, we set the "hot point" to the center of the item instead.
 				Size cursSize = GetInvItemSize(holdItem._iCurs + CURSOR_FIRSTITEM);

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -88,6 +88,7 @@ void CheckStashPaste(Point cursorPosition)
 
 	if (player.HoldItem._itype == ItemType::Gold) {
 		Stash.gold += player.HoldItem._ivalue;
+		player.HoldItem._itype == ItemType::None;
 		PlaySFX(IS_GOLD);
 		Stash.dirty = true;
 		if (!IsHardwareCursor()) {
@@ -125,14 +126,14 @@ void CheckStashPaste(Point cursorPosition)
 
 	player.HoldItem.position = firstSlot + Displacement { 0, itemSize.height - 1 };
 
-	int cn = CURSOR_HAND;
 	if (stashIndex == StashStruct::EmptyCell) {
 		Stash.stashList.push_back(player.HoldItem);
+		player.HoldItem._itype == ItemType::None;
 		// stashList will have at most 10 000 items, up to 65 535 are supported with uint16_t indexes
 		stashIndex = static_cast<uint16_t>(Stash.stashList.size() - 1);
 	} else {
 		// remove item from stash grid
-		cn = SwapItem(Stash.stashList[stashIndex], player.HoldItem);
+		std::swap(Stash.stashList[stashIndex], player.HoldItem);
 		for (auto &row : Stash.GetCurrentGrid()) {
 			for (auto &itemId : row) {
 				if (itemId - 1 == stashIndex)
@@ -145,11 +146,11 @@ void CheckStashPaste(Point cursorPosition)
 
 	Stash.dirty = true;
 
-	if (cn == CURSOR_HAND && !IsHardwareCursor()) {
+	if (player.HoldItem.isEmpty() && !IsHardwareCursor()) {
 		// To make software cursors behave like hardware cursors we need to adjust the hand cursor position manually
 		SetCursorPos(cursorPosition + hotPixelOffset);
 	}
-	NewCursor(cn);
+	NewCursor(player.HoldItem);
 }
 
 void CheckStashCut(Point cursorPosition, bool automaticMove)


### PR DESCRIPTION
The motivation for this was to allow setting the cursor directly from the held item after doing actions which could either swap the held item with another item or leave the held item empty. Ends up letting CheckInvPaste get simplified a fair bit (but splitting that into a separate PR as it blows out the line count).