### PR TITLE
Refactor TryDropItem to reduce use of globals

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -343,7 +343,8 @@ void LeftMouseDown(int wParam)
 			} else if (sbookflag && GetRightPanel().Contains(MousePosition)) {
 				CheckSBook();
 			} else if (!MyPlayer->HoldItem.isEmpty()) {
-				if (TryInvPut()) {
+				Point currentPosition = MyPlayer->position.tile;
+				if (CanPut(currentPosition, GetDirection(currentPosition, cursPosition))) {
 					NetSendCmdPItem(true, CMD_PUTITEM, cursPosition, MyPlayer->HoldItem);
 					NewCursor(CURSOR_HAND);
 				}

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1763,27 +1763,24 @@ bool CanPut(Point position)
 	return true;
 }
 
-bool TryInvPut()
+bool CanPut(Point position, Direction dir)
 {
 	if (ActiveItemCount >= MAXITEMS)
 		return false;
 
-	auto &myPlayer = Players[MyPlayerId];
-
-	Direction dir = GetDirection(myPlayer.position.tile, cursPosition);
-	if (CanPut(myPlayer.position.tile + dir)) {
+	if (CanPut(position + dir)) {
 		return true;
 	}
 
-	if (CanPut(myPlayer.position.tile + Left(dir))) {
+	if (CanPut(position + Left(dir))) {
 		return true;
 	}
 
-	if (CanPut(myPlayer.position.tile + Right(dir))) {
+	if (CanPut(position + Right(dir))) {
 		return true;
 	}
 
-	return CanPut(myPlayer.position.tile);
+	return CanPut(position);
 }
 
 int InvPutItem(Player &player, Point position, Item &item)
@@ -2188,17 +2185,6 @@ int CalculateGold(Player &player)
 	}
 
 	return gold;
-}
-
-bool DropItemBeforeTrig()
-{
-	if (!TryInvPut()) {
-		return false;
-	}
-
-	NetSendCmdPItem(true, CMD_PUTITEM, cursPosition, Players[MyPlayerId].HoldItem);
-	NewCursor(CURSOR_HAND);
-	return true;
 }
 
 Size GetInventorySize(const Item &item)

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -198,8 +198,23 @@ void AutoGetItem(int pnum, Item *item, int ii);
  */
 int FindGetItem(int32_t iseed, _item_indexes idx, uint16_t ci);
 void SyncGetItem(Point position, int32_t iseed, _item_indexes idx, uint16_t ci);
+
+/**
+ * @brief Checks if the tile has room for an item
+ * @param position tile coordinates
+ * @return True if the space is free of obstructions, false if blocked
+ */
 bool CanPut(Point position);
-bool TryInvPut();
+
+/**
+ * @brief Checks for free spaces in the three "adjacent" tiles in the given direction and also the given position.
+ * @see CanPut
+ * @param position base tile coordinates
+ * @param facing direction to check, tiles "left" and "right" of this direction will also be checked.
+ * @return True if any of the four tiles checked can accept an item, false if all blocked
+ */
+bool CanPut(Point position, Direction facing);
+
 int InvPutItem(Player &player, Point position, Item &item);
 int SyncPutItem(Player &player, Point position, int idx, uint16_t icreateinfo, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
 int SyncDropItem(Point position, int idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
@@ -212,7 +227,6 @@ Item &GetInventoryItem(Player &player, int location);
 bool UseInvItem(int pnum, int cii);
 void DoTelekinesis();
 int CalculateGold(Player &player);
-bool DropItemBeforeTrig();
 
 /**
  * @brief Gets the size, in inventory cells, of the given item.


### PR DESCRIPTION
The way TryInvPut and DropItemBeforeTrig interacted was fragile, don't think this would've worked as expected at the best of times. Looks like it was added as part of controller support so guessing this isn't vanilla behaviour anyway.