### PR TITLE
Add helper to clear/quick-init an item

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1809,7 +1809,7 @@ void UpdateSpellTarget(spell_id spell)
  */
 bool TryDropItem()
 {
-	const auto &myPlayer = Players[MyPlayerId];
+	auto &myPlayer = Players[MyPlayerId];
 
 	if (myPlayer.HoldItem.isEmpty()) {
 		return false;
@@ -1818,11 +1818,13 @@ bool TryDropItem()
 	if (currlevel == 0) {
 		if (UseItemOpensHive(myPlayer.HoldItem, myPlayer.position.tile)) {
 			NetSendCmdPItem(true, CMD_PUTITEM, { 79, 61 }, myPlayer.HoldItem);
+			myPlayer.HoldItem.Clear();
 			NewCursor(CURSOR_HAND);
 			return true;
 		}
 		if (UseItemOpensCrypt(myPlayer.HoldItem, myPlayer.position.tile)) {
 			NetSendCmdPItem(true, CMD_PUTITEM, { 35, 20 }, myPlayer.HoldItem);
+			myPlayer.HoldItem.Clear();
 			NewCursor(CURSOR_HAND);
 			return true;
 		}

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -177,7 +177,7 @@ void NewCursor(const Item &item)
 void NewCursor(int cursId)
 {
 	if (cursId < CURSOR_HOURGLASS && MyPlayer != nullptr) {
-		MyPlayer->HoldItem._itype = ItemType::None;
+		MyPlayer->HoldItem.Clear();
 	}
 	pcurs = cursId;
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -484,7 +484,7 @@ void CheckInvPaste(int pnum, Point cursorPosition)
 				RemoveEquipment(player, INVLOC_HAND_RIGHT, false);
 			} else {
 				// CMD_CHANGEPLRITEMS will eventually be sent for the left hand
-				player.InvBody[INVLOC_HAND_LEFT]._itype = ItemType::None;
+				player.InvBody[INVLOC_HAND_LEFT].Clear();
 			}
 		}
 
@@ -623,7 +623,7 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 	}
 
 	Item &holdItem = player.HoldItem;
-	holdItem._itype = ItemType::None;
+	holdItem.Clear();
 
 	bool automaticallyMoved = false;
 	bool automaticallyEquipped = false;
@@ -794,7 +794,7 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 					holdItem = player.InvBody[invloc];
 					if (player.InvBody[invloc]._itype != ItemType::None) {
 						if (invloc != NUM_INVLOC && AutoPlaceItemInInventory(player, holdItem, true)) {
-							player.InvBody[invloc]._itype = ItemType::None;
+							player.InvBody[invloc].Clear();
 						}
 					}
 					holdItem = player.InvList[iv - 1];
@@ -817,7 +817,7 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 			}
 
 			if (!automaticMove || automaticallyMoved) {
-				beltItem._itype = ItemType::None;
+				beltItem.Clear();
 				drawsbarflag = true;
 			}
 		}
@@ -847,7 +847,7 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 					}
 				}
 
-				holdItem._itype = ItemType::None;
+				holdItem.Clear();
 			} else {
 				NewCursor(holdItem);
 				if (!IsHardwareCursor() && !dropItem) {
@@ -986,7 +986,7 @@ void CleanupItems(int ii)
 	dItem[item.position.x][item.position.y] = 0;
 
 	if (currlevel == 21 && item.position == CornerStone.position) {
-		CornerStone.item._itype = ItemType::None;
+		CornerStone.item.Clear();
 		CornerStone.item._iSelFlag = 0;
 		CornerStone.item.position = { 0, 0 };
 		CornerStone.item._iAnimFlag = false;
@@ -1317,7 +1317,7 @@ void RemoveEquipment(Player &player, inv_body_loc bodyLocation, bool hiPri)
 		NetSendCmdDelItem(hiPri, bodyLocation);
 	}
 
-	player.InvBody[bodyLocation]._itype = ItemType::None;
+	player.InvBody[bodyLocation].Clear();
 }
 
 bool AutoPlaceItemInBelt(Player &player, const Item &item, bool persistItem)
@@ -1553,9 +1553,9 @@ void CheckInvSwap(Player &player, inv_body_loc bLoc, int idx, uint16_t wCI, int 
 	}
 
 	if (bLoc == INVLOC_HAND_LEFT && player.GetItemLocation(item) == ILOC_TWOHAND) {
-		player.InvBody[INVLOC_HAND_RIGHT]._itype = ItemType::None;
+		player.InvBody[INVLOC_HAND_RIGHT].Clear();
 	} else if (bLoc == INVLOC_HAND_RIGHT && player.GetItemLocation(item) == ILOC_TWOHAND) {
-		player.InvBody[INVLOC_HAND_LEFT]._itype = ItemType::None;
+		player.InvBody[INVLOC_HAND_LEFT].Clear();
 	}
 
 	CalcPlrInv(player, true);
@@ -1563,7 +1563,7 @@ void CheckInvSwap(Player &player, inv_body_loc bLoc, int idx, uint16_t wCI, int 
 
 void inv_update_rem_item(Player &player, inv_body_loc iv)
 {
-	player.InvBody[iv]._itype = ItemType::None;
+	player.InvBody[iv].Clear();
 
 	CalcPlrInv(player, player._pmode != PM_DEATH);
 }

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -93,7 +93,6 @@ void InvDrawSlotBack(const Surface &out, Point targetPosition, Size size);
  * @return 'True' in case the item can be placed on the belt and 'False' otherwise.
  */
 bool CanBePlacedOnBelt(const Item &item);
-int SwapItem(Item &a, Item &b);
 
 /**
  * @brief Function type which performs an operation on the given item.

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2344,7 +2344,7 @@ void InitItems()
 	memset(dItem, 0, sizeof(dItem));
 
 	for (auto &item : Items) {
-		item._itype = ItemType::None;
+		item.Clear();
 		item.position = { 0, 0 };
 		item._iAnimFlag = false;
 		item._iSelFlag = 0;
@@ -2824,7 +2824,7 @@ void CreatePlrItems(int playerId)
 	auto &player = Players[playerId];
 
 	for (auto &item : player.InvBody) {
-		item._itype = ItemType::None;
+		item.Clear();
 	}
 
 	// converting this to a for loop creates a `rep stosd` instruction,
@@ -2832,13 +2832,13 @@ void CreatePlrItems(int playerId)
 	memset(&player.InvGrid, 0, sizeof(player.InvGrid));
 
 	for (auto &item : player.InvList) {
-		item._itype = ItemType::None;
+		item.Clear();
 	}
 
 	player._pNumInv = 0;
 
 	for (auto &item : player.SpdList) {
-		item._itype = ItemType::None;
+		item.Clear();
 	}
 
 	switch (player._pClass) {
@@ -3290,7 +3290,7 @@ void CornerstoneLoad(Point position)
 		return;
 	}
 
-	CornerStone.item._itype = ItemType::None;
+	CornerStone.item.Clear();
 	CornerStone.activated = true;
 	if (dItem[position.x][position.y] != 0) {
 		int ii = dItem[position.x][position.y] - 1;
@@ -4098,7 +4098,7 @@ void SpawnSmith(int lvl)
 		newItem._iIdentified = true;
 	}
 	for (int i = iCnt; i < SMITH_ITEMS; i++)
-		smithitem[i]._itype = ItemType::None;
+		smithitem[i].Clear();
 
 	SortVendor(smithitem + PinnedItemCount);
 }
@@ -4177,7 +4177,7 @@ void SpawnWitch(int lvl)
 		}
 
 		if (i >= itemCount) {
-			item._itype = ItemType::None;
+			item.Clear();
 			continue;
 		}
 
@@ -4336,7 +4336,7 @@ void SpawnHealer(int lvl)
 		}
 
 		if (i >= itemCount) {
-			item._itype = ItemType::None;
+			item.Clear();
 			continue;
 		}
 
@@ -4639,7 +4639,7 @@ void RepairItem(Item &item, int lvl)
 	}
 
 	if (item._iMaxDur <= 0) {
-		item._itype = ItemType::None;
+		item.Clear();
 		return;
 	}
 
@@ -4648,7 +4648,7 @@ void RepairItem(Item &item, int lvl)
 		rep += lvl + GenerateRnd(lvl);
 		item._iMaxDur -= std::max(item._iMaxDur / (lvl + 9), 1);
 		if (item._iMaxDur == 0) {
-			item._itype = ItemType::None;
+			item.Clear();
 			return;
 		}
 	} while (rep + item._iDurability < item._iMaxDur);

--- a/Source/items.h
+++ b/Source/items.h
@@ -243,6 +243,14 @@ struct Item {
 	uint32_t _iDamAcFlags = 0;
 
 	/**
+	 * @brief Resets the item so isEmpty() returns true without needing to reinitialise the whole object
+	 */
+	void Clear()
+	{
+		this->_itype = ItemType::None;
+	}
+
+	/**
 	 * @brief Checks whether this item is empty or not.
 	 * @return 'True' in case the item is empty and 'False' otherwise.
 	 */

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1593,7 +1593,7 @@ void RemoveInvalidItem(Item &item)
 	}
 
 	if (isInvalid) {
-		item._itype = ItemType::None;
+		item.Clear();
 	}
 }
 

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -154,7 +154,7 @@ void UnPackItem(const ItemPack &packedItem, Item &item, bool isHellfire)
 	}
 
 	if (!IsItemAvailable(idx)) {
-		item._itype = ItemType::None;
+		item.Clear();
 		return;
 	}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1929,14 +1929,14 @@ void Player::RemoveInvItem(int iv, bool calcScrolls)
 		}
 	}
 
-	InvList[iv]._itype = ItemType::None;
+	InvList[iv].Clear();
 
 	_pNumInv--;
 
 	// If the item at the end of inventory array isn't the one we removed, we need to swap its position in the array with the removed item
 	if (_pNumInv > 0 && _pNumInv != iv) {
-		InvList[iv] = InvList[_pNumInv];
-		InvList[_pNumInv]._itype = ItemType::None;
+		InvList[iv] = std::move(InvList[_pNumInv]);
+		InvList[_pNumInv].Clear();
 
 		for (int8_t &itemIndex : InvGrid) {
 			if (itemIndex == _pNumInv + 1) {
@@ -1965,7 +1965,7 @@ bool Player::TryRemoveInvItemById(int item)
 
 void Player::RemoveSpdBarItem(int iv)
 {
-	SpdList[iv]._itype = ItemType::None;
+	SpdList[iv].Clear();
 
 	CalcScrolls();
 	force_redraw = 255;
@@ -3122,7 +3122,7 @@ StartPlayerKill(int pnum, int earflag)
 
 	if (pnum != MyPlayerId && earflag == 0 && !diablolevel) {
 		for (auto &item : player.InvBody) {
-			item._itype = ItemType::None;
+			item.Clear();
 		}
 		CalcPlrInv(player, false);
 	}
@@ -3175,7 +3175,7 @@ StartPlayerKill(int pnum, int earflag)
 						for (auto &item : player.InvBody) {
 							pdd = Left(pdd);
 							DeadItem(player, std::move(item), Displacement(pdd));
-							item._itype = ItemType::None;
+							item.Clear();
 						}
 
 						CalcPlrInv(player, false);

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -88,7 +88,7 @@ void CheckStashPaste(Point cursorPosition)
 
 	if (player.HoldItem._itype == ItemType::Gold) {
 		Stash.gold += player.HoldItem._ivalue;
-		player.HoldItem._itype == ItemType::None;
+		player.HoldItem.Clear();
 		PlaySFX(IS_GOLD);
 		Stash.dirty = true;
 		if (!IsHardwareCursor()) {
@@ -127,8 +127,8 @@ void CheckStashPaste(Point cursorPosition)
 	player.HoldItem.position = firstSlot + Displacement { 0, itemSize.height - 1 };
 
 	if (stashIndex == StashStruct::EmptyCell) {
-		Stash.stashList.push_back(player.HoldItem);
-		player.HoldItem._itype == ItemType::None;
+		Stash.stashList.emplace_back(std::move(player.HoldItem));
+		player.HoldItem.Clear();
 		// stashList will have at most 10 000 items, up to 65 535 are supported with uint16_t indexes
 		stashIndex = static_cast<uint16_t>(Stash.stashList.size() - 1);
 	} else {

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -182,7 +182,7 @@ void CheckStashCut(Point cursorPosition, bool automaticMove)
 	}
 
 	Item &holdItem = player.HoldItem;
-	holdItem._itype = ItemType::None;
+	holdItem.Clear();
 
 	bool automaticallyMoved = false;
 	bool automaticallyEquipped = false;
@@ -221,7 +221,7 @@ void CheckStashCut(Point cursorPosition, bool automaticMove)
 				}
 			}
 
-			holdItem._itype = ItemType::None;
+			holdItem.Clear();
 		} else {
 			NewCursor(holdItem);
 			if (!IsHardwareCursor()) {

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -510,7 +510,7 @@ void StartSmithSell()
 	storenumh = 0;
 
 	for (auto &item : storehold) {
-		item._itype = ItemType::None;
+		item.Clear();
 	}
 
 	const auto &myPlayer = Players[MyPlayerId];
@@ -593,7 +593,7 @@ void StartSmithRepair()
 	storenumh = 0;
 
 	for (auto &item : storehold) {
-		item._itype = ItemType::None;
+		item.Clear();
 	}
 
 	auto &myPlayer = Players[MyPlayerId];
@@ -784,7 +784,7 @@ void StartWitchSell()
 	storenumh = 0;
 
 	for (auto &item : storehold) {
-		item._itype = ItemType::None;
+		item.Clear();
 	}
 
 	const auto &myPlayer = Players[MyPlayerId];
@@ -877,7 +877,7 @@ void StartWitchRecharge()
 	storenumh = 0;
 
 	for (auto &item : storehold) {
-		item._itype = ItemType::None;
+		item.Clear();
 	}
 
 	const auto &myPlayer = Players[MyPlayerId];
@@ -1162,7 +1162,7 @@ void StartStorytellerIdentify()
 	storenumh = 0;
 
 	for (auto &item : storehold) {
-		item._itype = ItemType::None;
+		item.Clear();
 	}
 
 	auto &myPlayer = Players[MyPlayerId];
@@ -1376,12 +1376,12 @@ void SmithBuyItem(Item &item)
 	StoreAutoPlace(item, true);
 	int idx = stextvhold + ((stextlhold - stextup) / 4);
 	if (idx == SMITH_ITEMS - 1) {
-		smithitem[SMITH_ITEMS - 1]._itype = ItemType::None;
+		smithitem[SMITH_ITEMS - 1].Clear();
 	} else {
 		for (; !smithitem[idx + 1].isEmpty(); idx++) {
-			smithitem[idx] = smithitem[idx + 1];
+			smithitem[idx] = std::move(smithitem[idx + 1]);
 		}
-		smithitem[idx]._itype = ItemType::None;
+		smithitem[idx].Clear();
 	}
 	CalcPlrInv(*MyPlayer, true);
 }
@@ -1432,7 +1432,7 @@ void SmithBuyPItem(Item &item)
 		}
 	}
 
-	premiumitems[xx]._itype = ItemType::None;
+	premiumitems[xx].Clear();
 	numpremium--;
 	SpawnPremium(MyPlayerId);
 }
@@ -1630,12 +1630,12 @@ void WitchBuyItem(Item &item)
 
 	if (idx >= 3) {
 		if (idx == WITCH_ITEMS - 1) {
-			witchitem[WITCH_ITEMS - 1]._itype = ItemType::None;
+			witchitem[WITCH_ITEMS - 1].Clear();
 		} else {
 			for (; !witchitem[idx + 1].isEmpty(); idx++) {
-				witchitem[idx] = witchitem[idx + 1];
+				witchitem[idx] = std::move(witchitem[idx + 1]);
 			}
-			witchitem[idx]._itype = ItemType::None;
+			witchitem[idx].Clear();
 		}
 	}
 
@@ -1769,7 +1769,7 @@ void BoyBuyItem(Item &item)
 {
 	TakePlrsMoney(item._iIvalue);
 	StoreAutoPlace(item, true);
-	boyitem._itype = ItemType::None;
+	boyitem.Clear();
 	stextshold = STORE_BOY;
 	CalcPlrInv(*MyPlayer, true);
 	stextlhold = 12;
@@ -1803,12 +1803,12 @@ void HealerBuyItem(Item &item)
 	}
 	idx = stextvhold + ((stextlhold - stextup) / 4);
 	if (idx == 19) {
-		healitem[19]._itype = ItemType::None;
+		healitem[19].Clear();
 	} else {
 		for (; !healitem[idx + 1].isEmpty(); idx++) {
-			healitem[idx] = healitem[idx + 1];
+			healitem[idx] = std::move(healitem[idx + 1]);
 		}
-		healitem[idx]._itype = ItemType::None;
+		healitem[idx].Clear();
 	}
 	CalcPlrInv(*MyPlayer, true);
 }
@@ -2187,9 +2187,9 @@ void InitStores()
 	premiumlevel = 1;
 
 	for (auto &premiumitem : premiumitems)
-		premiumitem._itype = ItemType::None;
+		premiumitem.Clear();
 
-	boyitem._itype = ItemType::None;
+	boyitem.Clear();
 	boylevel = 0;
 }
 

--- a/test/inv_test.cpp
+++ b/test/inv_test.cpp
@@ -47,7 +47,7 @@ TEST(Inv, UseScroll_from_inventory_invalid_conditions)
 {
 	// Empty the belt to prevent using a scroll from the belt
 	for (int i = 0; i < MAXBELTITEMS; i++) {
-		Players[MyPlayerId].SpdList[i]._itype = ItemType::None;
+		Players[MyPlayerId].SpdList[i].Clear();
 	}
 
 	set_up_scroll(Players[MyPlayerId].InvList[2], SPL_FIREBOLT);
@@ -67,7 +67,7 @@ TEST(Inv, UseScroll_from_inventory_invalid_conditions)
 	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 
 	set_up_scroll(Players[MyPlayerId].InvList[2], SPL_FIREBOLT);
-	Players[MyPlayerId].InvList[2]._itype = ItemType::None;
+	Players[MyPlayerId].InvList[2].Clear();
 	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 }
 
@@ -94,7 +94,7 @@ TEST(Inv, UseScroll_from_belt_invalid_conditions)
 	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 
 	set_up_scroll(Players[MyPlayerId].SpdList[2], SPL_FIREBOLT);
-	Players[MyPlayerId].SpdList[2]._itype = ItemType::None;
+	Players[MyPlayerId].SpdList[2].Clear();
 	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 }
 
@@ -182,13 +182,13 @@ TEST(Inv, RemoveSpdBarItem)
 {
 	// Clear the belt
 	for (int i = 0; i < MAXBELTITEMS; i++) {
-		Players[MyPlayerId].SpdList[i]._itype = ItemType::None;
+		Players[MyPlayerId].SpdList[i].Clear();
 	}
 	// Put an item in the belt: | x | x | item | x | x | x | x | x |
 	Players[MyPlayerId].SpdList[3]._itype = ItemType::Misc;
 
 	Players[MyPlayerId].RemoveSpdBarItem(3);
-	EXPECT_EQ(Players[MyPlayerId].SpdList[3]._itype, ItemType::None);
+	EXPECT_TRUE(Players[MyPlayerId].SpdList[3].isEmpty());
 }
 
 // Test removing a scroll from the inventory
@@ -213,7 +213,7 @@ TEST(Inv, RemoveScroll_belt)
 {
 	// Clear the belt
 	for (int i = 0; i < MAXBELTITEMS; i++) {
-		Players[MyPlayerId].SpdList[i]._itype = ItemType::None;
+		Players[MyPlayerId].SpdList[i].Clear();
 	}
 	// Put a firebolt scroll into the belt
 	Players[MyPlayerId]._pSpell = static_cast<spell_id>(SPL_FIREBOLT);
@@ -222,7 +222,7 @@ TEST(Inv, RemoveScroll_belt)
 	Players[MyPlayerId].SpdList[3]._iSpell = SPL_FIREBOLT;
 
 	RemoveScroll(Players[MyPlayerId]);
-	EXPECT_EQ(Players[MyPlayerId].SpdList[3]._itype, ItemType::None);
+	EXPECT_TRUE(Players[MyPlayerId].SpdList[3].isEmpty());
 }
 
 TEST(Inv, ItemSize)


### PR DESCRIPTION
Adds "shorthand" for resetting item when the space is going to be reused in the future. It does end up being a function call but every compiler should be able to inline this... I hope. If the amiga builds move to a more modern gcc this could use `constexpr` to be sure.

This becomes more useful with #4482. The `cn` variable can be removed from CheckInvPaste, then `SwapItem` can be fully inlined so it's just a call to `std::swap`.