### PR TITLE
Add hint to avoid bugprone-use-after-move warnings

### DIFF
--- a/Source/cpp.hint
+++ b/Source/cpp.hint
@@ -1,0 +1,7 @@
+// Hint files help the Visual Studio IDE interpret Visual C++ identifiers
+// such as names of functions and macros.
+// For more information see https://go.microsoft.com/fwlink/?linkid=865984
+#define DVL_ALWAYS_INLINE
+#define DVL_ATTRIBUTE_HOT
+#define DVL_API_FOR_TEST
+#define DVL_REINITIALIZES

--- a/Source/items.h
+++ b/Source/items.h
@@ -245,7 +245,7 @@ struct Item {
 	/**
 	 * @brief Resets the item so isEmpty() returns true without needing to reinitialise the whole object
 	 */
-	void Clear()
+	DVL_REINITIALIZES void Clear()
 	{
 		this->_itype = ItemType::None;
 	}

--- a/Source/utils/attributes.h
+++ b/Source/utils/attributes.h
@@ -42,3 +42,11 @@
 #else
 #define DVL_API_FOR_TEST
 #endif
+
+#if defined(__clang__)
+#define DVL_REINITIALIZES [[clang::reinitializes]]
+#elif DVL_HAVE_ATTRIBUTE(reinitializes)
+#define DVL_REINITIALIZES __attribute__((reinitializes))
+#else
+#define DVL_REINITIALIZES
+#endif


### PR DESCRIPTION
Makes clang (and GCC) consider item.Clear() a reinitialisation of a moved variable - see https://clang.llvm.org/extra/clang-tidy/checks/bugprone-use-after-move.html#reinitialization

The cpp.hint file is something that MSVC/Visual Studio use to provide better intellisense hints. It needs to be in a parent directory of the file which uses the macro (not where it's defined). It only really needs to indicate whether a macro starts/ends a block, the contents of decorators like DVL_API_FOR_TEST doesn't actually matter in that file.