### PR TITLE
Add helper for moving an item

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1817,14 +1817,12 @@ bool TryDropItem()
 
 	if (currlevel == 0) {
 		if (UseItemOpensHive(myPlayer.HoldItem, myPlayer.position.tile)) {
-			NetSendCmdPItem(true, CMD_PUTITEM, { 79, 61 }, myPlayer.HoldItem);
-			myPlayer.HoldItem.Clear();
+			NetSendCmdPItem(true, CMD_PUTITEM, { 79, 61 }, myPlayer.HoldItem.pop());
 			NewCursor(CURSOR_HAND);
 			return true;
 		}
 		if (UseItemOpensCrypt(myPlayer.HoldItem, myPlayer.position.tile)) {
-			NetSendCmdPItem(true, CMD_PUTITEM, { 35, 20 }, myPlayer.HoldItem);
-			myPlayer.HoldItem.Clear();
+			NetSendCmdPItem(true, CMD_PUTITEM, { 35, 20 }, myPlayer.HoldItem.pop());
 			NewCursor(CURSOR_HAND);
 			return true;
 		}

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -437,10 +437,8 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 		};
 		inv_body_loc slot = iLocToInvLoc(il);
 		Item previouslyEquippedItem = player.InvBody[slot];
-		ChangeEquipment(player, slot, player.HoldItem);
-		if (previouslyEquippedItem.isEmpty()) {
-			player.HoldItem.Clear();
-		} else {
+		ChangeEquipment(player, slot, player.HoldItem.pop());
+		if (!previouslyEquippedItem.isEmpty()) {
 			player.HoldItem = previouslyEquippedItem;
 		}
 		break;
@@ -459,10 +457,8 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 		if (dequipTwoHandedWeapon) {
 			RemoveEquipment(player, otherHand, false);
 		}
-		ChangeEquipment(player, pasteHand, player.HoldItem);
-		if (previouslyEquippedItem.isEmpty()) {
-			player.HoldItem.Clear();
-		} else {
+		ChangeEquipment(player, pasteHand, player.HoldItem.pop());
+		if (!previouslyEquippedItem.isEmpty()) {
 			player.HoldItem = previouslyEquippedItem;
 		}
 		break;
@@ -487,10 +483,8 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 
 		if (player.InvBody[INVLOC_HAND_RIGHT].isEmpty()) {
 			Item previouslyEquippedItem = player.InvBody[INVLOC_HAND_LEFT];
-			ChangeEquipment(player, INVLOC_HAND_LEFT, player.HoldItem);
-			if (previouslyEquippedItem.isEmpty()) {
-				player.HoldItem.Clear();
-			} else {
+			ChangeEquipment(player, INVLOC_HAND_LEFT, player.HoldItem.pop());
+			if (!previouslyEquippedItem.isEmpty()) {
 				player.HoldItem = previouslyEquippedItem;
 			}
 		} else {
@@ -523,15 +517,13 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 			} else {
 				int invIndex = player._pNumInv;
 				player._pGold += player.HoldItem._ivalue;
-				player.InvList[invIndex] = std::move(player.HoldItem);
-				player.HoldItem.Clear();
+				player.InvList[invIndex] = player.HoldItem.pop();
 				player._pNumInv++;
 				player.InvGrid[ii] = player._pNumInv;
 			}
 		} else {
 			if (it == 0) {
-				player.InvList[player._pNumInv] = std::move(player.HoldItem);
-				player.HoldItem.Clear();
+				player.InvList[player._pNumInv] = player.HoldItem.pop();
 				player._pNumInv++;
 				it = player._pNumInv;
 			} else {
@@ -560,8 +552,7 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 	case ILOC_BELT: {
 		int ii = r - SLOTXY_BELT_FIRST;
 		if (player.SpdList[ii].isEmpty()) {
-			player.SpdList[ii] = std::move(player.HoldItem);
-			player.HoldItem.Clear();
+			player.SpdList[ii] = player.HoldItem.pop();
 		} else {
 			std::swap(player.SpdList[ii], player.HoldItem);
 			if (player.HoldItem._itype == ItemType::Gold)

--- a/Source/items.h
+++ b/Source/items.h
@@ -243,6 +243,16 @@ struct Item {
 	ItemSpecialEffectHf _iDamAcFlags = ItemSpecialEffectHf::None;
 
 	/**
+	 * @brief Clears this item and returns the old value
+	 */
+	Item pop() &
+	{
+		Item temp = std::move(*this);
+		Clear();
+		return temp;
+	}
+
+	/**
 	 * @brief Resets the item so isEmpty() returns true without needing to reinitialise the whole object
 	 */
 	DVL_REINITIALIZES void Clear()

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1936,8 +1936,7 @@ void Player::RemoveInvItem(int iv, bool calcScrolls)
 
 	// If the item at the end of inventory array isn't the one we removed, we need to swap its position in the array with the removed item
 	if (_pNumInv > 0 && _pNumInv != iv) {
-		InvList[iv] = std::move(InvList[_pNumInv]);
-		InvList[_pNumInv].Clear();
+		InvList[iv] = InvList[_pNumInv].pop();
 
 		for (int8_t &itemIndex : InvGrid) {
 			if (itemIndex == _pNumInv + 1) {
@@ -3175,8 +3174,7 @@ StartPlayerKill(int pnum, int earflag)
 						Direction pdd = player._pdir;
 						for (auto &item : player.InvBody) {
 							pdd = Left(pdd);
-							DeadItem(player, std::move(item), Displacement(pdd));
-							item.Clear();
+							DeadItem(player, item.pop(), Displacement(pdd));
 						}
 
 						CalcPlrInv(player, false);

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -127,8 +127,7 @@ void CheckStashPaste(Point cursorPosition)
 	player.HoldItem.position = firstSlot + Displacement { 0, itemSize.height - 1 };
 
 	if (stashIndex == StashStruct::EmptyCell) {
-		Stash.stashList.emplace_back(std::move(player.HoldItem));
-		player.HoldItem.Clear();
+		Stash.stashList.emplace_back(player.HoldItem.pop());
 		// stashList will have at most 10 000 items, up to 65 535 are supported with uint16_t indexes
 		stashIndex = static_cast<uint16_t>(Stash.stashList.size() - 1);
 	} else {


### PR DESCRIPTION
Used when moving from one persistent variable to another where we want the old variable to be marked empty. Defining as a function instead of move constructor/assignment operator as we only really need to mark the source for xvalues. Detecting that in the constructor/assignment would be needlessly complicated.