### PR TITLE
Set clang-tidy config for MethodCase option

### DIFF
--- a/Source/.clang-tidy
+++ b/Source/.clang-tidy
@@ -59,6 +59,7 @@ CheckOptions:
   - { key: readability-identifier-naming.ClassCase,               value: CamelCase  }
   - { key: readability-identifier-naming.StructCase,              value: CamelCase  }
   - { key: readability-identifier-naming.TemplateParameterCase,   value: CamelCase  }
+  - { key: readability-identifier-naming.MethodCase,              value: camelBack  }
   - { key: readability-identifier-naming.FunctionCase,            value: CamelCase  }
   - { key: readability-identifier-naming.ParameterCase,           value: camelBack  }
   - { key: readability-identifier-naming.MemberCase,              value: camelBack  }

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -724,7 +724,7 @@ void CheckPanelInfo()
 				AddPanelString(fmt::format(_("Scroll of {:s}"), pgettext("spell", spelldata[spellId].sNameText)));
 				const InventoryAndBeltPlayerItemsRange items { myPlayer };
 				const int scrollCount = std::count_if(items.begin(), items.end(), [spellId](const Item &item) {
-					return item.IsScrollOf(spellId);
+					return item.isScrollOf(spellId);
 				});
 				AddPanelString(fmt::format(ngettext("{:d} Scroll", "{:d} Scrolls", scrollCount), scrollCount));
 			} break;

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1672,7 +1672,7 @@ void UseBeltItem(int type)
 		}
 
 		bool isRejuvenation = IsAnyOf(item._iMiscId, IMISC_REJUV, IMISC_FULLREJUV);
-		bool isHealing = isRejuvenation || IsAnyOf(item._iMiscId, IMISC_HEAL, IMISC_FULLHEAL) || item.IsScrollOf(SPL_HEAL);
+		bool isHealing = isRejuvenation || IsAnyOf(item._iMiscId, IMISC_HEAL, IMISC_FULLHEAL) || item.isScrollOf(SPL_HEAL);
 		bool isMana = isRejuvenation || IsAnyOf(item._iMiscId, IMISC_MANA, IMISC_FULLMANA);
 
 		if ((type == BLT_HEALING && isHealing) || (type == BLT_MANA && isMana)) {
@@ -1900,7 +1900,7 @@ void CtrlUseInvItem()
 
 	auto &myPlayer = Players[MyPlayerId];
 	Item &item = GetInventoryItem(myPlayer, pcursinvitem);
-	if (item.IsScroll()) {
+	if (item.isScroll()) {
 		if (TargetsMonster(item._iSpell)) {
 			return;
 		}
@@ -1927,7 +1927,7 @@ void CtrlUseStashItem()
 	}
 
 	const Item &item = Stash.stashList[pcursstashitem];
-	if (item.IsScroll()) {
+	if (item.isScroll()) {
 		if (TargetsMonster(item._iSpell)) {
 			return;
 		}

--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -369,7 +369,7 @@ std::optional<VirtualGamepadPotionType> PotionButtonRenderer::GetPotionType()
 				return GAMEPAD_HEALING;
 			if (item._iMiscId == IMISC_FULLHEAL)
 				return GAMEPAD_FULL_HEALING;
-			if (item.IsScrollOf(SPL_HEAL))
+			if (item.isScrollOf(SPL_HEAL))
 				return GAMEPAD_SCROLL_OF_HEALING;
 		}
 
@@ -453,7 +453,7 @@ VirtualGamepadButtonType SecondaryActionButtonRenderer::GetButtonType()
 
 		if (pcursinvitem != -1) {
 			Item &item = GetInventoryItem(*MyPlayer, pcursinvitem);
-			if (!item.IsScroll() || !spelldata[item._iSpell].sTargeted) {
+			if (!item.isScroll() || !spelldata[item._iSpell].sTargeted) {
 				if (!item.isEquipment()) {
 					return GetApplyButtonType(virtualPadButton->isHeld);
 				}

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -177,7 +177,7 @@ void NewCursor(const Item &item)
 void NewCursor(int cursId)
 {
 	if (cursId < CURSOR_HOURGLASS && MyPlayer != nullptr) {
-		MyPlayer->HoldItem.Clear();
+		MyPlayer->HoldItem.clear();
 	}
 	pcurs = cursId;
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -477,7 +477,7 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 				RemoveEquipment(player, INVLOC_HAND_RIGHT, false);
 			} else {
 				// CMD_CHANGEPLRITEMS will eventually be sent for the left hand
-				player.InvBody[INVLOC_HAND_LEFT].Clear();
+				player.InvBody[INVLOC_HAND_LEFT].clear();
 			}
 		}
 
@@ -505,7 +505,7 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 					player.InvList[invIndex]._ivalue = ig;
 					SetPlrHandGoldCurs(player.InvList[invIndex]);
 					player._pGold += player.HoldItem._ivalue;
-					player.HoldItem.Clear();
+					player.HoldItem.clear();
 				} else {
 					ig = MaxGold - gt;
 					player._pGold += ig;
@@ -612,7 +612,7 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 	}
 
 	Item &holdItem = player.HoldItem;
-	holdItem.Clear();
+	holdItem.clear();
 
 	bool automaticallyMoved = false;
 	bool automaticallyEquipped = false;
@@ -783,7 +783,7 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 					holdItem = player.InvBody[invloc];
 					if (player.InvBody[invloc]._itype != ItemType::None) {
 						if (invloc != NUM_INVLOC && AutoPlaceItemInInventory(player, holdItem, true)) {
-							player.InvBody[invloc].Clear();
+							player.InvBody[invloc].clear();
 						}
 					}
 					holdItem = player.InvList[iv - 1];
@@ -806,7 +806,7 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 			}
 
 			if (!automaticMove || automaticallyMoved) {
-				beltItem.Clear();
+				beltItem.clear();
 				drawsbarflag = true;
 			}
 		}
@@ -836,7 +836,7 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 					}
 				}
 
-				holdItem.Clear();
+				holdItem.clear();
 			} else {
 				NewCursor(holdItem);
 				if (!IsHardwareCursor() && !dropItem) {
@@ -975,7 +975,7 @@ void CleanupItems(int ii)
 	dItem[item.position.x][item.position.y] = 0;
 
 	if (currlevel == 21 && item.position == CornerStone.position) {
-		CornerStone.item.Clear();
+		CornerStone.item.clear();
 		CornerStone.item._iSelFlag = 0;
 		CornerStone.item.position = { 0, 0 };
 		CornerStone.item._iAnimFlag = false;
@@ -1299,7 +1299,7 @@ void RemoveEquipment(Player &player, inv_body_loc bodyLocation, bool hiPri)
 		NetSendCmdDelItem(hiPri, bodyLocation);
 	}
 
-	player.InvBody[bodyLocation].Clear();
+	player.InvBody[bodyLocation].clear();
 }
 
 bool AutoPlaceItemInBelt(Player &player, const Item &item, bool persistItem)
@@ -1535,9 +1535,9 @@ void CheckInvSwap(Player &player, inv_body_loc bLoc, int idx, uint16_t wCI, int 
 	}
 
 	if (bLoc == INVLOC_HAND_LEFT && player.GetItemLocation(item) == ILOC_TWOHAND) {
-		player.InvBody[INVLOC_HAND_RIGHT].Clear();
+		player.InvBody[INVLOC_HAND_RIGHT].clear();
 	} else if (bLoc == INVLOC_HAND_RIGHT && player.GetItemLocation(item) == ILOC_TWOHAND) {
-		player.InvBody[INVLOC_HAND_LEFT].Clear();
+		player.InvBody[INVLOC_HAND_LEFT].clear();
 	}
 
 	CalcPlrInv(player, true);
@@ -1545,7 +1545,7 @@ void CheckInvSwap(Player &player, inv_body_loc bLoc, int idx, uint16_t wCI, int 
 
 void inv_update_rem_item(Player &player, inv_body_loc iv)
 {
-	player.InvBody[iv].Clear();
+	player.InvBody[iv].clear();
 
 	CalcPlrInv(player, player._pmode != PM_DEATH);
 }
@@ -1686,7 +1686,7 @@ int FindGetItem(int32_t iseed, _item_indexes idx, uint16_t createInfo)
 {
 	for (uint8_t i = 0; i < ActiveItemCount; i++) {
 		auto &item = Items[ActiveItems[i]];
-		if (item.KeyAttributesMatch(iseed, idx, createInfo)) {
+		if (item.keyAttributesMatch(iseed, idx, createInfo)) {
 			return i;
 		}
 	}
@@ -1701,7 +1701,7 @@ void SyncGetItem(Point position, int32_t iseed, _item_indexes idx, uint16_t ci)
 
 	if (ii >= 0 && ii < MAXITEMS) {
 		// If there was an item there, check that it's the same item as the remote player has
-		if (!Items[ii].KeyAttributesMatch(iseed, idx, ci)) {
+		if (!Items[ii].keyAttributesMatch(iseed, idx, ci)) {
 			// Key attributes don't match so we must've desynced, ignore this index and try find a matching item via lookup
 			ii = -1;
 		}
@@ -1961,7 +1961,7 @@ void RemoveScroll(Player &player)
 {
 	const spell_id spellId = player._pSpell;
 	const auto isCurrentSpell = [spellId](const Item &item) {
-		return item.IsScrollOf(spellId);
+		return item.isScrollOf(spellId);
 	};
 	{
 		const InventoryPlayerItemsRange items { player };
@@ -1993,7 +1993,7 @@ bool UseScroll(const spell_id spell)
 
 	const InventoryAndBeltPlayerItemsRange items { myPlayer };
 	return std::any_of(items.begin(), items.end(), [spell](const Item &item) {
-		return item.IsScrollOf(spell);
+		return item.isScrollOf(spell);
 	});
 }
 
@@ -2112,7 +2112,7 @@ bool UseInvItem(int pnum, int cii)
 		dropGoldValue = 0;
 	}
 
-	if (item->IsScroll() && currlevel == 0 && !spelldata[item->_iSpell].sTownSpell) {
+	if (item->isScroll() && currlevel == 0 && !spelldata[item->_iSpell].sTownSpell) {
 		return true;
 	}
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2344,7 +2344,7 @@ void InitItems()
 	memset(dItem, 0, sizeof(dItem));
 
 	for (auto &item : Items) {
-		item.Clear();
+		item.clear();
 		item.position = { 0, 0 };
 		item._iAnimFlag = false;
 		item._iSelFlag = 0;
@@ -2824,7 +2824,7 @@ void CreatePlrItems(int playerId)
 	auto &player = Players[playerId];
 
 	for (auto &item : player.InvBody) {
-		item.Clear();
+		item.clear();
 	}
 
 	// converting this to a for loop creates a `rep stosd` instruction,
@@ -2832,13 +2832,13 @@ void CreatePlrItems(int playerId)
 	memset(&player.InvGrid, 0, sizeof(player.InvGrid));
 
 	for (auto &item : player.InvList) {
-		item.Clear();
+		item.clear();
 	}
 
 	player._pNumInv = 0;
 
 	for (auto &item : player.SpdList) {
-		item.Clear();
+		item.clear();
 	}
 
 	switch (player._pClass) {
@@ -3036,7 +3036,7 @@ void GetItemAttrs(Item &item, int itemData, int lvl)
 
 void SetupItem(Item &item)
 {
-	item.SetNewAnimation(Players[MyPlayerId].pLvlLoad == 0);
+	item.setNewAnimation(Players[MyPlayerId].pLvlLoad == 0);
 	item._iIdentified = false;
 }
 
@@ -3290,7 +3290,7 @@ void CornerstoneLoad(Point position)
 		return;
 	}
 
-	CornerStone.item.Clear();
+	CornerStone.item.clear();
 	CornerStone.activated = true;
 	if (dItem[position.x][position.y] != 0) {
 		int ii = dItem[position.x][position.y] - 1;
@@ -3378,7 +3378,7 @@ void SpawnRewardItem(int itemid, Point position, bool sendmsg)
 	dItem[position.x][position.y] = ii + 1;
 	int curlv = ItemsGetCurrlevel();
 	GetItemAttrs(item, itemid, curlv);
-	item.SetNewAnimation(true);
+	item.setNewAnimation(true);
 	item._iSelFlag = 2;
 	item._iPostDraw = true;
 	item._iIdentified = true;
@@ -3407,7 +3407,7 @@ void SpawnTheodore(Point position, bool sendmsg)
 void RespawnItem(Item &item, bool flipFlag)
 {
 	int it = ItemCAnimTbl[item._iCurs];
-	item.SetNewAnimation(flipFlag);
+	item.setNewAnimation(flipFlag);
 	item._iRequest = false;
 
 	if (IsAnyOf(item._iCurs, ICURS_MAGIC_ROCK, ICURS_TAVERN_SIGN, ICURS_ANVIL_OF_FURY))
@@ -4098,7 +4098,7 @@ void SpawnSmith(int lvl)
 		newItem._iIdentified = true;
 	}
 	for (int i = iCnt; i < SMITH_ITEMS; i++)
-		smithitem[i].Clear();
+		smithitem[i].clear();
 
 	SortVendor(smithitem + PinnedItemCount);
 }
@@ -4177,7 +4177,7 @@ void SpawnWitch(int lvl)
 		}
 
 		if (i >= itemCount) {
-			item.Clear();
+			item.clear();
 			continue;
 		}
 
@@ -4336,7 +4336,7 @@ void SpawnHealer(int lvl)
 		}
 
 		if (i >= itemCount) {
-			item.Clear();
+			item.clear();
 			continue;
 		}
 
@@ -4605,7 +4605,7 @@ std::string DebugSpawnUniqueItem(std::string itemName)
 }
 #endif
 
-void Item::SetNewAnimation(bool showAnimation)
+void Item::setNewAnimation(bool showAnimation)
 {
 	int it = ItemCAnimTbl[_iCurs];
 	int numberOfFrames = ItemAnimLs[it];
@@ -4639,7 +4639,7 @@ void RepairItem(Item &item, int lvl)
 	}
 
 	if (item._iMaxDur <= 0) {
-		item.Clear();
+		item.clear();
 		return;
 	}
 
@@ -4648,7 +4648,7 @@ void RepairItem(Item &item, int lvl)
 		rep += lvl + GenerateRnd(lvl);
 		item._iMaxDur -= std::max(item._iMaxDur / (lvl + 9), 1);
 		if (item._iMaxDur == 0) {
-			item.Clear();
+			item.clear();
 			return;
 		}
 	} while (rep + item._iDurability < item._iMaxDur);

--- a/Source/items.h
+++ b/Source/items.h
@@ -248,14 +248,14 @@ struct Item {
 	Item pop() &
 	{
 		Item temp = std::move(*this);
-		Clear();
+		clear();
 		return temp;
 	}
 
 	/**
 	 * @brief Resets the item so isEmpty() returns true without needing to reinitialise the whole object
 	 */
-	DVL_REINITIALIZES void Clear()
+	DVL_REINITIALIZES void clear()
 	{
 		this->_itype = ItemType::None;
 	}
@@ -375,17 +375,17 @@ struct Item {
 		}
 	}
 
-	[[nodiscard]] bool IsScroll() const
+	[[nodiscard]] bool isScroll() const
 	{
 		return _iMiscId == IMISC_SCROLL || _iMiscId == IMISC_SCROLLT;
 	}
 
-	[[nodiscard]] bool IsScrollOf(spell_id spellId) const
+	[[nodiscard]] bool isScrollOf(spell_id spellId) const
 	{
-		return IsScroll() && _iSpell == spellId;
+		return isScroll() && _iSpell == spellId;
 	}
 
-	[[nodiscard]] bool KeyAttributesMatch(int32_t seed, _item_indexes itemIndex, uint16_t createInfo) const
+	[[nodiscard]] bool keyAttributesMatch(int32_t seed, _item_indexes itemIndex, uint16_t createInfo) const
 	{
 		return _iSeed == seed && IDidx == itemIndex && _iCreateInfo == createInfo;
 	}
@@ -413,7 +413,7 @@ struct Item {
 	 * @brief Sets the current Animation for the Item
 	 * @param showAnimation Definies if the Animation (Flipping) is shown or if only the final Frame (item on the ground) is shown
 	 */
-	void SetNewAnimation(bool showAnimation);
+	void setNewAnimation(bool showAnimation);
 };
 
 struct ItemGetRecordStruct {

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1593,7 +1593,7 @@ void RemoveInvalidItem(Item &item)
 	}
 
 	if (isInvalid) {
-		item.Clear();
+		item.clear();
 	}
 }
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -701,7 +701,7 @@ DWORD OnRequestGetItem(const TCmd *pCmd, Player &player)
 			int ii = -1;
 			if (InDungeonBounds(position)) {
 				ii = abs(dItem[position.x][position.y]) - 1;
-				if (ii >= 0 && !Items[ii].KeyAttributesMatch(message.dwSeed, static_cast<_item_indexes>(message.wIndx), message.wCI)) {
+				if (ii >= 0 && !Items[ii].keyAttributesMatch(message.dwSeed, static_cast<_item_indexes>(message.wIndx), message.wCI)) {
 					ii = -1;
 				}
 			}

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -154,7 +154,7 @@ void UnPackItem(const ItemPack &packedItem, Item &item, bool isHellfire)
 	}
 
 	if (!IsItemAvailable(idx)) {
-		item.Clear();
+		item.clear();
 		return;
 	}
 

--- a/Source/panels/spell_list.cpp
+++ b/Source/panels/spell_list.cpp
@@ -184,7 +184,7 @@ void DrawSpellList(const Surface &out)
 			InfoString = fmt::format(_("Scroll of {:s}"), pgettext("spell", spellDataItem.sNameText));
 			const InventoryAndBeltPlayerItemsRange items { myPlayer };
 			const int scrollCount = std::count_if(items.begin(), items.end(), [spellId](const Item &item) {
-				return item.IsScrollOf(spellId);
+				return item.isScrollOf(spellId);
 			});
 			AddPanelString(fmt::format(ngettext("{:d} Scroll", "{:d} Scrolls", scrollCount), scrollCount));
 		} break;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1901,7 +1901,7 @@ void Player::CalcScrolls()
 {
 	_pScrlSpells = 0;
 	for (Item &item : InventoryAndBeltPlayerItemsRange { *this }) {
-		if (item.IsScroll() && item._iStatFlag) {
+		if (item.isScroll() && item._iStatFlag) {
 			_pScrlSpells |= GetSpellBitmask(item._iSpell);
 		}
 	}
@@ -1930,7 +1930,7 @@ void Player::RemoveInvItem(int iv, bool calcScrolls)
 		}
 	}
 
-	InvList[iv].Clear();
+	InvList[iv].clear();
 
 	_pNumInv--;
 
@@ -1965,7 +1965,7 @@ bool Player::TryRemoveInvItemById(int item)
 
 void Player::RemoveSpdBarItem(int iv)
 {
-	SpdList[iv].Clear();
+	SpdList[iv].clear();
 
 	CalcScrolls();
 	force_redraw = 255;
@@ -3122,7 +3122,7 @@ StartPlayerKill(int pnum, int earflag)
 
 	if (pnum != MyPlayerId && earflag == 0 && !diablolevel) {
 		for (auto &item : player.InvBody) {
-			item.Clear();
+			item.clear();
 		}
 		CalcPlrInv(player, false);
 	}

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -88,7 +88,7 @@ void CheckStashPaste(Point cursorPosition)
 
 	if (player.HoldItem._itype == ItemType::Gold) {
 		Stash.gold += player.HoldItem._ivalue;
-		player.HoldItem.Clear();
+		player.HoldItem.clear();
 		PlaySFX(IS_GOLD);
 		Stash.dirty = true;
 		if (!IsHardwareCursor()) {
@@ -181,7 +181,7 @@ void CheckStashCut(Point cursorPosition, bool automaticMove)
 	}
 
 	Item &holdItem = player.HoldItem;
-	holdItem.Clear();
+	holdItem.clear();
 
 	bool automaticallyMoved = false;
 	bool automaticallyEquipped = false;
@@ -220,7 +220,7 @@ void CheckStashCut(Point cursorPosition, bool automaticMove)
 				}
 			}
 
-			holdItem.Clear();
+			holdItem.clear();
 		} else {
 			NewCursor(holdItem);
 			if (!IsHardwareCursor()) {
@@ -470,7 +470,7 @@ bool UseStashItem(uint16_t c)
 		WithdrawGoldValue = 0;
 	}
 
-	if (item->IsScroll()) {
+	if (item->isScroll()) {
 		return true;
 	}
 

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -510,7 +510,7 @@ void StartSmithSell()
 	storenumh = 0;
 
 	for (auto &item : storehold) {
-		item.Clear();
+		item.clear();
 	}
 
 	const auto &myPlayer = Players[MyPlayerId];
@@ -593,7 +593,7 @@ void StartSmithRepair()
 	storenumh = 0;
 
 	for (auto &item : storehold) {
-		item.Clear();
+		item.clear();
 	}
 
 	auto &myPlayer = Players[MyPlayerId];
@@ -784,7 +784,7 @@ void StartWitchSell()
 	storenumh = 0;
 
 	for (auto &item : storehold) {
-		item.Clear();
+		item.clear();
 	}
 
 	const auto &myPlayer = Players[MyPlayerId];
@@ -877,7 +877,7 @@ void StartWitchRecharge()
 	storenumh = 0;
 
 	for (auto &item : storehold) {
-		item.Clear();
+		item.clear();
 	}
 
 	const auto &myPlayer = Players[MyPlayerId];
@@ -1162,7 +1162,7 @@ void StartStorytellerIdentify()
 	storenumh = 0;
 
 	for (auto &item : storehold) {
-		item.Clear();
+		item.clear();
 	}
 
 	auto &myPlayer = Players[MyPlayerId];
@@ -1376,12 +1376,12 @@ void SmithBuyItem(Item &item)
 	StoreAutoPlace(item, true);
 	int idx = stextvhold + ((stextlhold - stextup) / 4);
 	if (idx == SMITH_ITEMS - 1) {
-		smithitem[SMITH_ITEMS - 1].Clear();
+		smithitem[SMITH_ITEMS - 1].clear();
 	} else {
 		for (; !smithitem[idx + 1].isEmpty(); idx++) {
 			smithitem[idx] = std::move(smithitem[idx + 1]);
 		}
-		smithitem[idx].Clear();
+		smithitem[idx].clear();
 	}
 	CalcPlrInv(*MyPlayer, true);
 }
@@ -1432,7 +1432,7 @@ void SmithBuyPItem(Item &item)
 		}
 	}
 
-	premiumitems[xx].Clear();
+	premiumitems[xx].clear();
 	numpremium--;
 	SpawnPremium(MyPlayerId);
 }
@@ -1630,12 +1630,12 @@ void WitchBuyItem(Item &item)
 
 	if (idx >= 3) {
 		if (idx == WITCH_ITEMS - 1) {
-			witchitem[WITCH_ITEMS - 1].Clear();
+			witchitem[WITCH_ITEMS - 1].clear();
 		} else {
 			for (; !witchitem[idx + 1].isEmpty(); idx++) {
 				witchitem[idx] = std::move(witchitem[idx + 1]);
 			}
-			witchitem[idx].Clear();
+			witchitem[idx].clear();
 		}
 	}
 
@@ -1769,7 +1769,7 @@ void BoyBuyItem(Item &item)
 {
 	TakePlrsMoney(item._iIvalue);
 	StoreAutoPlace(item, true);
-	boyitem.Clear();
+	boyitem.clear();
 	stextshold = STORE_BOY;
 	CalcPlrInv(*MyPlayer, true);
 	stextlhold = 12;
@@ -1803,12 +1803,12 @@ void HealerBuyItem(Item &item)
 	}
 	idx = stextvhold + ((stextlhold - stextup) / 4);
 	if (idx == 19) {
-		healitem[19].Clear();
+		healitem[19].clear();
 	} else {
 		for (; !healitem[idx + 1].isEmpty(); idx++) {
 			healitem[idx] = std::move(healitem[idx + 1]);
 		}
-		healitem[idx].Clear();
+		healitem[idx].clear();
 	}
 	CalcPlrInv(*MyPlayer, true);
 }
@@ -2187,9 +2187,9 @@ void InitStores()
 	premiumlevel = 1;
 
 	for (auto &premiumitem : premiumitems)
-		premiumitem.Clear();
+		premiumitem.clear();
 
-	boyitem.Clear();
+	boyitem.clear();
 	boylevel = 0;
 }
 

--- a/test/inv_test.cpp
+++ b/test/inv_test.cpp
@@ -47,7 +47,7 @@ TEST(Inv, UseScroll_from_inventory_invalid_conditions)
 {
 	// Empty the belt to prevent using a scroll from the belt
 	for (int i = 0; i < MAXBELTITEMS; i++) {
-		Players[MyPlayerId].SpdList[i].Clear();
+		Players[MyPlayerId].SpdList[i].clear();
 	}
 
 	set_up_scroll(Players[MyPlayerId].InvList[2], SPL_FIREBOLT);
@@ -67,7 +67,7 @@ TEST(Inv, UseScroll_from_inventory_invalid_conditions)
 	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 
 	set_up_scroll(Players[MyPlayerId].InvList[2], SPL_FIREBOLT);
-	Players[MyPlayerId].InvList[2].Clear();
+	Players[MyPlayerId].InvList[2].clear();
 	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 }
 
@@ -94,7 +94,7 @@ TEST(Inv, UseScroll_from_belt_invalid_conditions)
 	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 
 	set_up_scroll(Players[MyPlayerId].SpdList[2], SPL_FIREBOLT);
-	Players[MyPlayerId].SpdList[2].Clear();
+	Players[MyPlayerId].SpdList[2].clear();
 	EXPECT_FALSE(UseScroll(Players[MyPlayerId]._pRSpell));
 }
 
@@ -182,7 +182,7 @@ TEST(Inv, RemoveSpdBarItem)
 {
 	// Clear the belt
 	for (int i = 0; i < MAXBELTITEMS; i++) {
-		Players[MyPlayerId].SpdList[i].Clear();
+		Players[MyPlayerId].SpdList[i].clear();
 	}
 	// Put an item in the belt: | x | x | item | x | x | x | x | x |
 	Players[MyPlayerId].SpdList[3]._itype = ItemType::Misc;
@@ -213,7 +213,7 @@ TEST(Inv, RemoveScroll_belt)
 {
 	// Clear the belt
 	for (int i = 0; i < MAXBELTITEMS; i++) {
-		Players[MyPlayerId].SpdList[i].Clear();
+		Players[MyPlayerId].SpdList[i].clear();
 	}
 	// Put a firebolt scroll into the belt
 	Players[MyPlayerId]._pSpell = static_cast<spell_id>(SPL_FIREBOLT);


### PR DESCRIPTION
Previously this was falling back to FunctionCase, leading to inconsistent casing of class methods throughout the codebase. Applied to Item as an example.

Using camelCase from the discussion in #4493 - https://github.com/diasurgical/devilutionX/pull/4493#discussion_r853613509