### PR TITLE
Demomode: Init ControlMode to KeyboardAndMouse

### DIFF
--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "controls/plrctrls.h"
 #include "demomode.h"
 #include "menu.h"
 #include "nthread.h"
@@ -126,6 +127,7 @@ void InitPlayBack(int demoNumber, bool timedemo)
 {
 	DemoNumber = demoNumber;
 	Timedemo = timedemo;
+	ControlMode = ControlTypes::KeyboardAndMouse;
 
 	if (!LoadDemoMessages(demoNumber)) {
 		SDL_Log("Unable to load demo file");


### PR DESCRIPTION
Found (while rebasing #2526) that the current (later replaced) demomode doesn't work anymore.
The reason is that `ControlMode` is never set, cause the demomode has a special message handling (`demo::FetchMessage` vs `FetchMessage_Real`).
Note: `ControlMode` can't change while playing the current format and the current format only supports mouse+keyboard. The new format hopefully doesn't even have to bother about this sort of difference. 😉