### PR TITLE
show item labels toggle in menu

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -986,6 +986,7 @@ GameplayOptions::GameplayOptions()
     , autoEquipJewelry("Auto Equip Jewelry", OptionEntryFlags::None, N_("Auto Equip Jewelry"), N_("Jewelry will be automatically equipped on pickup or purchase if enabled."), false)
     , randomizeQuests("Randomize Quests", OptionEntryFlags::CantChangeInGame, N_("Randomize Quests"), N_("Randomly selecting available quests for new games."), true)
     , showMonsterType("Show Monster Type", OptionEntryFlags::None, N_("Show Monster Type"), N_("Hovering over a monster will display the type of monster in the description box in the UI."), false)
+    , showItemLabels("Show Item Labels", OptionEntryFlags::None, N_("Show Item Labels"), N_("Show labels for items on the ground when enabled."), false)
     , autoRefillBelt("Auto Refill Belt", OptionEntryFlags::None, N_("Auto Refill Belt"), N_("Refill belt from inventory when belt item is consumed."), false)
     , disableCripplingShrines("Disable Crippling Shrines", OptionEntryFlags::None, N_("Disable Crippling Shrines"), N_("When enabled Cauldrons, Fascinating Shrines, Goat Shrines, Ornate Shrines and Sacred Shrines are not able to be clicked on and labeled as disabled."), false)
     , quickCast("Quick Cast", OptionEntryFlags::None, N_("Quick Cast"), N_("Spell hotkeys instantly cast the spell, rather than switching the readied spell."), false)
@@ -1016,6 +1017,7 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&experienceBar,
 		&enemyHealthBar,
 		&showMonsterType,
+		&showItemLabels,
 		&disableCripplingShrines,
 		&quickCast,
 		&autoRefillBelt,

--- a/Source/options.h
+++ b/Source/options.h
@@ -537,6 +537,8 @@ struct GameplayOptions : OptionCategoryBase {
 	OptionEntryBoolean randomizeQuests;
 	/** @brief Indicates whether or not monster type (Animal, Demon, Undead) is shown along with other monster information. */
 	OptionEntryBoolean showMonsterType;
+	/** @brief Displays item labels for items on the ground.  */
+	OptionEntryBoolean showItemLabels;
 	/** @brief Refill belt from inventory, or rather, use potions/scrolls from inventory first when belt item is consumed.  */
 	OptionEntryBoolean autoRefillBelt;
 	/** @brief Locally disable clicking on shrines which permanently cripple character. */

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -13,6 +13,7 @@
 #include "gmenu.h"
 #include "inv.h"
 #include "itemlabels.h"
+#include "options.h"
 #include "qol/stash.h"
 #include "utils/format_int.hpp"
 #include "utils/language.h"
@@ -33,7 +34,6 @@ std::vector<ItemLabel> labelQueue;
 bool altPressed = false;
 bool isLabelHighlighted = false;
 std::array<std::optional<int>, ITEMTYPES> labelCenterOffsets;
-bool invertHighlightToggle = false;
 
 const int BorderX = 4;               // minimal horizontal space between labels
 const int BorderY = 2;               // minimal vertical space between labels
@@ -45,7 +45,7 @@ const int Height = 11 + MarginY * 2; // going above 13 scatters labels of items 
 
 void ToggleItemLabelHighlight()
 {
-	invertHighlightToggle = !invertHighlightToggle;
+	sgOptions.Gameplay.showItemLabels.SetValue(!*sgOptions.Gameplay.showItemLabels);
 }
 
 void AltPressed(bool pressed)
@@ -60,7 +60,7 @@ bool IsItemLabelHighlighted()
 
 bool IsHighlightingLabelsEnabled()
 {
-	return altPressed != invertHighlightToggle;
+	return altPressed != *sgOptions.Gameplay.showItemLabels;
 }
 
 void AddItemToLabelQueue(int id, int x, int y)


### PR DESCRIPTION
Makes it so controller and mobile can have item labels on. Also convenient for not having to press right control every time you start the game.

![image](https://user-images.githubusercontent.com/26759970/172020947-4a3d65f2-c068-499c-be77-0fe17e8c510e.png)
Screenshot on iPhone which previously was very annoying to enable