### PR TITLE
Fix viewport size of UiList on settings menu

### DIFF
--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -347,7 +347,8 @@ void UiSettingsMenu()
 		vecDialogItems.push_back(std::make_unique<UiListItem>("", static_cast<int>(SpecialMenuEntry::None), UiFlags::ElementDisabled));
 		vecDialogItems.push_back(std::make_unique<UiListItem>(_("Previous Menu"), static_cast<int>(SpecialMenuEntry::PreviousMenu), UiFlags::ColorUiGold));
 
-		vecDialog.push_back(std::make_unique<UiList>(vecDialogItems, rectList.size.height / 26, rectList.position.x, rectList.position.y, rectList.size.width, 26, UiFlags::FontSize24 | UiFlags::AlignCenter));
+		size_t maxViewportSize = rectList.size.height / 26;
+		vecDialog.push_back(std::make_unique<UiList>(vecDialogItems, std::min<size_t>(maxViewportSize, vecDialogItems.size()), rectList.position.x, rectList.position.y, rectList.size.width, 26, UiFlags::FontSize24 | UiFlags::AlignCenter));
 
 		UiInitList(ItemFocused, ItemSelected, EscPressed, vecDialog, true, FullscreenChanged, nullptr, itemToSelect);
 


### PR DESCRIPTION
Fixes a crash when clicking in a specific region on certain submenus within the settings menu.

The viewport size for the `UiList` was hardcoded to 8 (`rectList.size.height / 26`), meaning that the calculated size of that list was too large for the actual number of entries when viewing submenus with fewer than 6 options.

This resolves #4476