### PR TITLE
Fix order of operations when reading from Single Player save

### DIFF
--- a/Source/menu.cpp
+++ b/Source/menu.cpp
@@ -122,8 +122,6 @@ bool mainmenu_select_hero_dialog(GameData *gameData)
 	if (pSaveNumberFromOptions != nullptr)
 		pSaveNumberFromOptions->SetValue(gSaveNumber);
 
-	pfile_read_player_from_save(gSaveNumber, Players[MyPlayerId]);
-
 	return true;
 }
 

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -399,6 +399,8 @@ bool InitSingle(GameData *gameData)
 	MyPlayer = &Players[MyPlayerId];
 	gbIsMultiplayer = false;
 
+	pfile_read_player_from_save(gSaveNumber, *MyPlayer);
+
 	return true;
 }
 


### PR DESCRIPTION
When starting the game from scratch, going straight through the Single Player menus to play a new single player hero would cause potions in the player's belt to appear unusable.

![image](https://user-images.githubusercontent.com/9203145/164978406-18ea1e36-fb7e-4b53-8ae6-9522db5fd2b1.png)

More generally, the hero save data was being loaded into `Players[MyPlayerId]` before `InitSingle()` had the opportunity to set `MyPlayerId = 0` and `MyPlayer = Players[MyPlayerId]`. As a result, `CalcPlrInv()` was being called while `MyPlayer == nullptr` so it skips over the logic to set `_iStatFlag`. However, this issue actually causes an even more egregious error that requires a bit more setup, but could absolutely be stumbled on by accident.

1. Delete all single player heroes
2. Create two new single player heroes, making sure to remember which hero you created first
3. Join a multiplayer game in which you are not player 0
4. Select `New Game` to leave the multiplayer game
5. Navigate through the Single Player menus and select the hero you created first
6. You should now be playing the hero you created last
7. If you save the game, your first hero will morph into the last hero

This happens because the player number from your multiplayer game is used when `pfile_read_player_from_save()` is called from `mainmenu_select_hero_dialog()`, so the hero you selected is loaded into the wrong player index. The hero you get is determined by which has the highest save number because `pfile_ui_set_hero_infos()` loads each hero, in save number order, into `Players[0]` when navigating the menus.