### PR TITLE
Fix item graphics on potion buttons for virtual gamepad

### DIFF
--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -138,8 +138,9 @@ void LoadPotionArt(Art *potionArt, SDL_Renderer *renderer)
 
 	Point position { 0, 0 };
 	for (item_cursor_graphic graphic : potionGraphics) {
-		const int frame = CURSOR_FIRSTITEM + graphic;
-		const OwnedCelSprite &potionSprite = GetInvItemSprite(frame);
+		const int cursorID = CURSOR_FIRSTITEM + graphic;
+		const int frame = GetInvItemFrame(cursorID);
+		const OwnedCelSprite &potionSprite = GetInvItemSprite(cursorID);
 		position.y += potionSize.height;
 		CelClippedDrawTo(Surface(surface.get()), position, potionSprite, frame);
 	}


### PR DESCRIPTION
Recent changes to frame indexes mixed up the graphics for the virtual gamepad a bit.

Before:
![image](https://user-images.githubusercontent.com/9203145/164981559-cd40b6a4-9893-4a1c-9ce9-9a6802220473.png)

After:
![image](https://user-images.githubusercontent.com/9203145/164981596-455561b5-9a1e-436e-a7b8-b1d6d934c7b1.png)