### PR TITLE
Restore randomization of stores for multiplayer games

### DIFF
--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2204,6 +2204,8 @@ void SetupTownStores()
 			if (myPlayer._pLvlVisited[i])
 				l = i;
 		}
+	} else {
+		SetRndSeed(glSeedTbl[currlevel] * SDL_GetTicks());
 	}
 
 	l = clamp(l + 2, 6, 16);


### PR DESCRIPTION
As pointed out by @StephenCWills, Diablo/Devilution included randomization of the store seed during setup, which may have  been removed to make the stores load the same items when loading a game in single player. This just adds randomization when setting up the stores only for multiplayer games.

Devilution code:
https://github.com/diasurgical/devilution/blob/f074a33cc13a87f2cd3e05ca3844ab3f659589c1/Source/stores.cpp#L108