### PR TITLE
Initialize options before first call to SaveOptions()

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1781,12 +1781,11 @@ int DiabloMain(int argc, char **argv)
 	// Finally load game data
 	LoadGameArchives();
 
-	SaveOptions();
 	DiabloInit();
-
 #ifdef __UWP__
 	onInitialized();
 #endif
+	SaveOptions();
 
 	DiabloSplash();
 	mainmenu_loop();


### PR DESCRIPTION
@ikonomov reported on Discord that quick messages in the INI do not populate at startup. It seems the `sgOptions.Chat.szHotKeyMsgs` options are populated by `DiabloInit()`. This moves the call to `SaveOptions()` after the initialization functions so that any options initialized by these functions will be captured in the INI at startup.