### PR TITLE
HP bar tweaks and fixes

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4311,6 +4311,7 @@ void ProcessMonsters()
 			} else {
 				monster._mhitpoints += monster.mLevel;
 			}
+			monster._mhitpoints = std::min(monster._mhitpoints, monster._mmaxhp); // prevent going over max HP with part of a single regen tick
 		}
 
 		if (IsTileVisible(monster.position.tile) && monster._msquelch == 0) {

--- a/Source/qol/monhealthbar.cpp
+++ b/Source/qol/monhealthbar.cpp
@@ -18,6 +18,7 @@ namespace {
 Art healthBox;
 Art resistance;
 Art health;
+Art healthBlue;
 Art playerExpTags;
 
 } // namespace
@@ -29,6 +30,11 @@ void InitMonsterHealthBar()
 
 	LoadMaskedArt("data\\healthbox.pcx", &healthBox, 1, 1);
 	LoadArt("data\\health.pcx", &health);
+	std::array<uint8_t, 256> data;
+	data[234] = 185;
+	data[235] = 186;
+	data[236] = 187;
+	LoadMaskedArt("data\\health.pcx", &healthBlue, 1, 1, &data);
 	LoadMaskedArt("data\\resistance.pcx", &resistance, 6, 1);
 	LoadMaskedArt("data\\monstertags.pcx", &playerExpTags, 5, 1);
 
@@ -46,6 +52,7 @@ void FreeMonsterHealthBar()
 {
 	healthBox.Unload();
 	health.Unload();
+	healthBlue.Unload();
 	resistance.Unload();
 }
 
@@ -56,6 +63,7 @@ void DrawMonsterHealthBar(const Surface &out)
 
 	assert(healthBox.surface != nullptr);
 	assert(health.surface != nullptr);
+	assert(healthBlue.surface != nullptr);
 	assert(resistance.surface != nullptr);
 
 	if (currlevel == 0)
@@ -95,7 +103,7 @@ void DrawMonsterHealthBar(const Surface &out)
 	DrawHalfTransparentRectTo(out, position.x + border, position.y + border, width - (border * 2), height - (border * 2));
 	int barProgress = (barWidth * currLife) / monster._mmaxhp;
 	if (barProgress != 0) {
-		DrawArt(out, position + Displacement { border + 1, border + 1 }, &health, 0, barProgress, height - (border * 2) - 2);
+		DrawArt(out, position + Displacement { border + 1, border + 1 }, multiplier > 0 ? &healthBlue : &health, 0, barProgress, height - (border * 2) - 2);
 	}
 
 	constexpr auto getBorderColor = [](MonsterClass monsterClass) {


### PR DESCRIPTION
![leosteal](https://user-images.githubusercontent.com/14297035/165788945-e9c93060-a7a9-49c8-a2cb-f51288c77c9a.gif)

This handles some hp/hp bar stuff
1. fixes vanilla bug where monsters could reach HP within a single regen tick above their max (was necessary because monsters regenerating over their max would show as having more than 1 health bar with this PR which was obviously not the goal)
2. fixes devx hp bar - it was inaccurate earlier because of using wrong width - was showing full bar when monster actually had 95% HP
3. People usually thought something was broken when Leo stole hp from them and they damaged him and his HP bar didn't budge - this solves the issue by borrowing the "boss hp bar" mechanic from some games - a number appears saying how many hp bars the boss actually has.

Recolored extra health bars blue 
![image](https://user-images.githubusercontent.com/14297035/165847524-828f2882-7e9b-43f6-b195-b6fb3675ac9e.png)
