### PR TITLE
ps4: avoid using std::locale to detect language, and fallback to en

### DIFF
--- a/Source/platform/locale.cpp
+++ b/Source/platform/locale.cpp
@@ -103,6 +103,9 @@ std::vector<std::string> GetLocales()
 		language = SCE_SYSTEM_PARAM_LANG_ENGLISH_US; // default to english
 	locales.emplace_back(vita_locales[language]);
 	sceAppUtilShutdown();
+
+#elif defined(__ORBIS__)
+	// use default
 #elif defined(__3DS__)
 	locales.push_back(n3ds::GetLocale());
 #elif defined(_WIN32)


### PR DESCRIPTION
Subsumes https://github.com/diasurgical/devilutionX/pull/4485/

Upon next release, install instructions can be simplified since the is no longer a need to create diablo.ini with preferred language before first lunch.