### PR TITLE
Accept all PT_MESSAGE packets when buffering messages

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -621,7 +621,7 @@ void multi_process_network_packets()
 		auto &player = Players[dwID];
 		if (!IsNetPlayerValid(player)) {
 			_cmd_id cmd = *(const _cmd_id *)(pkt + 1);
-			if (IsNoneOf(cmd, CMD_SEND_PLRINFO, CMD_ACK_PLRINFO)) {
+			if (gbBufferMsgs == 0 && IsNoneOf(cmd, CMD_SEND_PLRINFO, CMD_ACK_PLRINFO)) {
 				// Distrust all messages until
 				// player info is received
 				continue;


### PR DESCRIPTION
Follow-up to address comments in #4500.

When joining a game, the game sets `gbBufferMsgs = 1` to indicate that `PT_MESSAGE` packets which are not deltas should be placed in a buffer to be processed later once all deltas have been received. If `CMD_ACK_PLRINFO` ends up getting buffered, the remote player's info won't be processed until all deltas are received, but deltas will be rejected because the player's info is still invalid. This means the joining player will be stuck on the loading screen.

This PR assumes that a client which is buffering packets must be joining a game and waiting for deltas so it should be safe to implicitly trust all incoming `PT_MESSAGE` packets until buffering is complete.