### PR TITLE
Ignore leave requests if the player leaving is the local player

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -226,6 +226,10 @@ void ParseTurn(int pnum, uint32_t turn)
 
 void PlayerLeftMsg(int pnum, bool left)
 {
+	if (pnum == MyPlayerId) {
+		return;
+	}
+
 	auto &player = Players[pnum];
 
 	if (!player.plractive) {


### PR DESCRIPTION
Fixes the issue where the player character's name is erased upon entering a game.

Recent screenshots from Discord user myself600 have basically confirmed that the logic in `PlayerLeftMsg()` is the cause of this bug. You can see in the following screenshot where the game indicates that Eileen (myself600's character) left the game before stating that Hillstorm is already in the game, after which myself600's messages indicate that his character's name is now blank.

![image](https://user-images.githubusercontent.com/9203145/167259955-2249d98a-8202-4706-83e2-9e2801fd7b1d.png)

I am still completely unable to reproduce this issue, but this evidence strongly suggests that this change should resolve it.