### PR TITLE
Move definition of ghMainWnd to utils/display.cpp

### DIFF
--- a/Source/controls/touch/gamepad.cpp
+++ b/Source/controls/touch/gamepad.cpp
@@ -2,7 +2,6 @@
 
 #include "control.h"
 #include "controls/touch/gamepad.h"
-#include "diablo.h"
 #include "quests.h"
 #include "utils/display.h"
 #include "utils/ui_fwd.h"

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -73,6 +73,7 @@
 #include "track.h"
 #include "trigs.h"
 #include "utils/console.h"
+#include "utils/display.h"
 #include "utils/language.h"
 #include "utils/paths.h"
 #include "utils/stdcompat/string_view.hpp"
@@ -88,7 +89,6 @@
 
 namespace devilution {
 
-SDL_Window *ghMainWnd;
 uint32_t glSeedTbl[NUMLEVELS];
 dungeon_type gnLevelTypeTbl[NUMLEVELS];
 Point MousePosition;

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -58,7 +58,6 @@ enum class MouseActionType : int {
 	OperateObject,
 };
 
-extern SDL_Window *ghMainWnd;
 extern uint32_t glSeedTbl[NUMLEVELS];
 extern dungeon_type gnLevelTypeTbl[NUMLEVELS];
 extern Point MousePosition;

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -13,7 +13,6 @@
 #include <SimpleIni.h>
 
 #include "control.h"
-#include "diablo.h"
 #include "discord/discord.h"
 #include "engine/demomode.h"
 #include "hwcursor.hpp"
@@ -22,6 +21,7 @@
 #include "qol/monhealthbar.h"
 #include "qol/xpbar.h"
 #include "sound_defs.hpp"
+#include "utils/display.h"
 #include "utils/file_util.h"
 #include "utils/language.h"
 #include "utils/log.hpp"

--- a/Source/platform/switch/docking.cpp
+++ b/Source/platform/switch/docking.cpp
@@ -3,7 +3,6 @@
 #include <SDL.h>
 #include <switch.h>
 
-#include "diablo.h"
 #include "utils/display.h"
 
 namespace devilution {

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -37,6 +37,7 @@
 namespace devilution {
 
 extern SDLSurfaceUniquePtr RendererTextureSurface; /** defined in dx.cpp */
+SDL_Window *ghMainWnd;
 
 Uint16 gnScreenWidth;
 Uint16 gnScreenHeight;

--- a/Source/utils/display.h
+++ b/Source/utils/display.h
@@ -17,6 +17,7 @@ namespace devilution {
 
 extern int refreshDelay; // Screen refresh rate in nanoseconds
 extern SDL_Window *window;
+extern SDL_Window *ghMainWnd;
 extern SDL_Renderer *renderer;
 #ifndef USE_SDL1
 extern SDLTextureUniquePtr texture;


### PR DESCRIPTION
This variable is controlled/set by the code in that file, this also lets other files have more specific/relevant includes instead of the monolith that is diablo.h