### PR TITLE
Vanilla bug: Fix Lazarus quest level resetting

### DIFF
--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -392,7 +392,7 @@ void CheckQuests()
 		int rporty = quest.position.y;
 		AddMissile({ rportx, rporty }, { rportx, rporty }, Direction::South, MIS_RPORTAL, TARGET_MONSTERS, MyPlayerId, 0, 0);
 		quest._qvar2 = 1;
-		if (quest._qactive == QUEST_ACTIVE) {
+		if (quest._qactive == QUEST_ACTIVE && quest._qvar1 == 2) {
 			quest._qvar1 = 3;
 		}
 	}


### PR DESCRIPTION
This is a rather fun one: once you receive the Laz quest and go back down to level 15, the quest state is set to 3. When entering Laz's chamber it increases once you pop the seals and again after Laz finishes speaking. No problem right?

Well the devs didn't consider that you can portal out of Laz's chamber; and then walk back down to level 15 again, which sets the quest state back to 3. Going through the red portal would put you on the teleport pad thus fixing the quest state, but if you go back to town and through the original town portal instead, the dungeon will reset back to its initial state.