### PR TITLE
Pass object by reference to AddBarrel()

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1232,7 +1232,7 @@ void AddObjectLight(int i, int r)
 	}
 }
 
-void AddBarrel(Object barrel)
+void AddBarrel(Object &barrel)
 {
 	barrel._oVar1 = 0;
 	barrel._oRndSeed = AdvanceRndSeed();


### PR DESCRIPTION
Resolves an issue reported by FireIceTalon on Discord.

> In hell, every barrel im breaking drops a small red potion.
> It’s happened 2 games in a row.
> I think the game treats them as dupes, when i go to town and come back down all but one are gone.
> I assume u can recreate with any class, on any difficulty, on any dungeon level that has barrels.