### PR TITLE
printInConsole: Add string_view support

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -817,32 +817,64 @@ void RunGameLoop(interface_mode uMsg)
 	}
 }
 
+void PrintWithRightPadding(string_view str, size_t width)
+{
+	printInConsole(str);
+	if (str.size() >= width)
+		return;
+	printInConsole(std::string(width - str.size(), ' '));
+}
+
+void PrintHelpOption(string_view flags, string_view description)
+{
+	printInConsole("    ");
+	PrintWithRightPadding(flags, 20);
+	printInConsole(" ");
+	PrintWithRightPadding(description, 30);
+	printNewlineInConsole();
+}
+
 [[noreturn]] void PrintHelpAndExit()
 {
-	printInConsole("%s", _(/* TRANSLATORS: Commandline Option */ "Options:\n").c_str());
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "-h, --help", _("Print this message and exit").c_str());
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--version", _("Print the version and exit").c_str());
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--data-dir", _("Specify the folder of diabdat.mpq").c_str());
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--save-dir", _("Specify the folder of save files").c_str());
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--config-dir", _("Specify the location of diablo.ini").c_str());
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "-n", _("Skip startup videos").c_str());
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "-f", _("Display frames per second").c_str());
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--verbose", _("Enable verbose logging").c_str());
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--record <#>", _("Record a demo file").c_str());
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--demo <#>", _("Play a demo file").c_str());
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--timedemo", _("Disable all frame limiting during demo playback").c_str());
-	printInConsole("%s", _(/* TRANSLATORS: Commandline Option */ "\nGame selection:\n").c_str());
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--spawn", _("Force Shareware mode").c_str());
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--diablo", _("Force Diablo mode").c_str());
-	printInConsole("    %-20s %-30s\n", /* TRANSLATORS: Commandline Option */ "--hellfire", _("Force Hellfire mode").c_str());
-	printInConsole("%s", _(/* TRANSLATORS: Commandline Option */ "\nHellfire options:\n").c_str());
+	printInConsole((/* TRANSLATORS: Commandline Option */ "Options:"));
+	printNewlineInConsole();
+	PrintHelpOption("-h, --help", _(/* TRANSLATORS: Commandline Option */ "Print this message and exit"));
+	PrintHelpOption("--version", _(/* TRANSLATORS: Commandline Option */ "Print the version and exit"));
+	PrintHelpOption("--data-dir", _(/* TRANSLATORS: Commandline Option */ "Specify the folder of diabdat.mpq"));
+	PrintHelpOption("--save-dir", _(/* TRANSLATORS: Commandline Option */ "Specify the folder of save files"));
+	PrintHelpOption("--config-dir", _(/* TRANSLATORS: Commandline Option */ "Specify the location of diablo.ini"));
+	PrintHelpOption("-n", _(/* TRANSLATORS: Commandline Option */ "Skip startup videos"));
+	PrintHelpOption("-f", _(/* TRANSLATORS: Commandline Option */ "Display frames per second"));
+	PrintHelpOption("--verbose", _(/* TRANSLATORS: Commandline Option */ "Enable verbose logging"));
+	PrintHelpOption("--record <#>", _(/* TRANSLATORS: Commandline Option */ "Record a demo file"));
+	PrintHelpOption("--demo <#>", _(/* TRANSLATORS: Commandline Option */ "Play a demo file"));
+	PrintHelpOption("--timedemo", _(/* TRANSLATORS: Commandline Option */ "Disable all frame limiting during demo playback"));
+	printNewlineInConsole();
+	printInConsole(_(/* TRANSLATORS: Commandline Option */ "Game selection:"));
+	printNewlineInConsole();
+	PrintHelpOption("--spawn", _(/* TRANSLATORS: Commandline Option */ "Force Shareware mode"));
+	PrintHelpOption("--diablo", _(/* TRANSLATORS: Commandline Option */ "Force Diablo mode"));
+	PrintHelpOption("--hellfire", _(/* TRANSLATORS: Commandline Option */ "Force Hellfire mode"));
+	printInConsole(_(/* TRANSLATORS: Commandline Option */ "Hellfire options:"));
+	printNewlineInConsole();
 #ifdef _DEBUG
-	printInConsole("\nDebug options:\n");
-	printInConsole("    %-20s %-30s\n", "-i", "Ignore network timeout");
-	printInConsole("    %-20s %-30s\n", "+<internal command>", "Pass commands to the engine");
+	printNewlineInConsole();
+	printInConsole("Debug options:");
+	printNewlineInConsole();
+	PrintHelpOption("-i", "Ignore network timeout");
+	PrintHelpOption("+<internal command>", "Pass commands to the engine");
 #endif
-	printInConsole("%s", _("\nReport bugs at https://github.com/diasurgical/devilutionX/\n").c_str());
+	printNewlineInConsole();
+	printInConsole(_("Report bugs at https://github.com/diasurgical/devilutionX/"));
+	printNewlineInConsole();
 	diablo_quit(0);
+}
+
+void PrintFlagsRequiresArgument(string_view flag)
+{
+	printInConsole(flag);
+	printInConsole("requires an argument");
+	printNewlineInConsole();
 }
 
 void DiabloParseFlags(int argc, char **argv)
@@ -859,29 +891,32 @@ void DiabloParseFlags(int argc, char **argv)
 		if (arg == "-h" || arg == "--help") {
 			PrintHelpAndExit();
 		} else if (arg == "--version") {
-			printInConsole("%s v%s\n", PROJECT_NAME, PROJECT_VERSION);
+			printInConsole(PROJECT_NAME);
+			printInConsole(" v");
+			printInConsole(PROJECT_VERSION);
+			printNewlineInConsole();
 			diablo_quit(0);
 		} else if (arg == "--data-dir") {
 			if (i + 1 == argc) {
-				printInConsole("%s requires an argument\n", "--data-dir");
+				PrintFlagsRequiresArgument("--data-dir");
 				diablo_quit(0);
 			}
 			paths::SetBasePath(argv[++i]);
 		} else if (arg == "--save-dir") {
 			if (i + 1 == argc) {
-				printInConsole("%s requires an argument\n", "--save-dir");
+				PrintFlagsRequiresArgument("--save-dir");
 				diablo_quit(0);
 			}
 			paths::SetPrefPath(argv[++i]);
 		} else if (arg == "--config-dir") {
 			if (i + 1 == argc) {
-				printInConsole("%s requires an argument\n", "--config-dir");
+				PrintFlagsRequiresArgument("--config-dir");
 				diablo_quit(0);
 			}
 			paths::SetConfigPath(argv[++i]);
 		} else if (arg == "--demo") {
 			if (i + 1 == argc) {
-				printInConsole("%s requires an argument\n", "--demo");
+				PrintFlagsRequiresArgument("--demo");
 				diablo_quit(0);
 			}
 			demoNumber = SDL_atoi(argv[++i]);
@@ -890,7 +925,7 @@ void DiabloParseFlags(int argc, char **argv)
 			timedemo = true;
 		} else if (arg == "--record") {
 			if (i + 1 == argc) {
-				printInConsole("%s requires an argument\n", "--record");
+				PrintFlagsRequiresArgument("--record");
 				diablo_quit(0);
 			}
 			recordNumber = SDL_atoi(argv[++i]);
@@ -922,7 +957,10 @@ void DiabloParseFlags(int argc, char **argv)
 			argumentIndexOfLastCommandPart = i;
 #endif
 		} else {
-			printInConsole("unrecognized option '%s'\n", argv[i]);
+			printInConsole("unrecognized option '");
+			printInConsole(argv[i]);
+			printInConsole("'");
+			printNewlineInConsole();
 			PrintHelpAndExit();
 		}
 	}

--- a/Source/utils/console.cpp
+++ b/Source/utils/console.cpp
@@ -3,6 +3,7 @@
 #if defined(_WIN64) || defined(_WIN32)
 #include <cstddef>
 #include <cstdio>
+#include <string>
 
 // Suppress definitions of `min` and `max` macros by <windows.h>:
 #define NOMINMAX 1
@@ -24,34 +25,45 @@ HANDLE GetStderrHandle()
 	return handle;
 }
 
+void WriteToStderr(string_view str)
+{
+	HANDLE handle = GetStderrHandle();
+	if (handle == NULL)
+		return;
+	WriteConsole(handle, str.data(), str.size(), NULL, NULL);
+}
+
 } // namespace
 
-void printInConsole(const char *fmt, ...)
+void printInConsole(string_view str)
+{
+	OutputDebugString(std::string(str).c_str());
+	WriteToStderr(str);
+}
+
+void printNewlineInConsole()
+{
+	OutputDebugString("\r\n");
+	WriteToStderr("\r\n");
+}
+
+void printfInConsole(const char *fmt, ...)
 {
 	char message[4096];
 	va_list ap;
 	va_start(ap, fmt);
 	std::vsnprintf(message, sizeof(message), fmt, ap);
 	va_end(ap);
-
 	OutputDebugString(message);
-
-	HANDLE handle = GetStderrHandle();
-	if (handle == NULL)
-		return;
-	WriteConsole(handle, message, strlen(message), NULL, NULL);
+	WriteToStderr(message);
 }
 
-void printInConsoleV(const char *fmt, va_list ap)
+void vprintfInConsole(const char *fmt, va_list ap)
 {
 	char message[4096];
 	std::vsnprintf(message, sizeof(message), fmt, ap);
 	OutputDebugString(message);
-
-	HANDLE handle = GetStderrHandle();
-	if (handle == NULL)
-		return;
-	WriteConsole(handle, message, strlen(message), NULL, NULL);
+	WriteToStderr(message);
 }
 
 } // namespace devilution
@@ -60,7 +72,17 @@ void printInConsoleV(const char *fmt, va_list ap)
 
 namespace devilution {
 
-void printInConsole(const char *fmt, ...)
+void printInConsole(string_view str)
+{
+	std::fwrite(str.data(), sizeof(char), str.size(), stderr);
+}
+
+void printNewlineInConsole()
+{
+	std::fputs("\n", stderr);
+}
+
+void printfInConsole(const char *fmt, ...)
 {
 	std::va_list ap;
 	va_start(ap, fmt);
@@ -68,7 +90,7 @@ void printInConsole(const char *fmt, ...)
 	va_end(ap);
 }
 
-void printInConsoleV(const char *fmt, std::va_list ap)
+void vprintfInConsole(const char *fmt, std::va_list ap)
 {
 	std::vfprintf(stderr, fmt, ap);
 }

--- a/Source/utils/console.h
+++ b/Source/utils/console.h
@@ -4,10 +4,13 @@
 #include <cstddef>
 
 #include "utils/attributes.h"
+#include "utils/stdcompat/string_view.hpp"
 
 namespace devilution {
 
-void printInConsole(const char *fmt, ...) DVL_PRINTF_ATTRIBUTE(1, 2);
-void printInConsoleV(const char *fmt, std::va_list ap) DVL_PRINTF_ATTRIBUTE(1, 0);
+void printInConsole(string_view str);
+void printNewlineInConsole();
+void printfInConsole(const char *fmt, ...) DVL_PRINTF_ATTRIBUTE(1, 2);
+void vprintfInConsole(const char *fmt, std::va_list ap) DVL_PRINTF_ATTRIBUTE(1, 0);
 
 } // namespace devilution

--- a/Source/utils/sdl2_to_1_2_backports.cpp
+++ b/Source/utils/sdl2_to_1_2_backports.cpp
@@ -165,9 +165,9 @@ void SDL_LogMessageV(int category, SDL_LogPriority priority, const char *fmt, va
 	if (static_cast<int>(priority) < 0 || priority >= SDL_NUM_LOG_PRIORITIES || priority < SDL_LogGetPriority(category))
 		return;
 
-	::devilution::printInConsole("%s: ", SDL_priority_prefixes[priority]);
-	::devilution::printInConsoleV(fmt, ap);
-	::devilution::printInConsole("\n");
+	::devilution::printfInConsole("%s: ", SDL_priority_prefixes[priority]);
+	::devilution::vprintfInConsole(fmt, ap);
+	::devilution::printNewlineInConsole();
 }
 
 namespace {

--- a/Translations/bg.po
+++ b/Translations/bg.po
@@ -1125,8 +1125,8 @@ msgstr "Сега ще УМРЕШ!"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:821
-msgid "Options:\n"
-msgstr "Настройки:\n"
+msgid "Options:"
+msgstr "Настройки:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
@@ -1185,12 +1185,8 @@ msgstr "Забраняване на всички лимити на кадри п
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:833
-msgid ""
-"\n"
-"Game selection:\n"
-msgstr ""
-"\n"
-"Избор на игра:\n"
+msgid "Game selection:"
+msgstr "Избор на игра:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
@@ -1209,20 +1205,12 @@ msgstr "Принудителен режим Hellfire"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:837
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"Настройки на Hellfire:\n"
+msgid "Hellfire options:"
+msgstr "Настройки на Hellfire:"
 
 #: Source/diablo.cpp:843
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"Докладвайте несъответствия на https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "Докладвайте несъответствия на https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:955
 msgid "version {:s}"

--- a/Translations/cs.po
+++ b/Translations/cs.po
@@ -1123,8 +1123,8 @@ msgstr "Teď chcípneš!"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:821
-msgid "Options:\n"
-msgstr "Nastavení:\n"
+msgid "Options:"
+msgstr "Nastavení:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
@@ -1183,12 +1183,8 @@ msgstr "Vypnout omezení snímků během přehrávání dema"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:833
-msgid ""
-"\n"
-"Game selection:\n"
-msgstr ""
-"\n"
-"Výběr hry:\n"
+msgid "Game selection:"
+msgstr "Výběr hry:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
@@ -1207,20 +1203,12 @@ msgstr "Vynutit Hellfire mód"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:837
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"Hellfire nastavení:\n"
+msgid "Hellfire options:"
+msgstr "Hellfire nastavení:"
 
 #: Source/diablo.cpp:843
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"Chyby hlašte na https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "Chyby hlašte na https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:955
 msgid "version {:s}"

--- a/Translations/da.po
+++ b/Translations/da.po
@@ -1216,7 +1216,7 @@ msgstr "Har du lyst til:"
 #: Source/diablo.cpp:821
 #, fuzzy
 #| msgid "Options"
-msgid "Options:\n"
+msgid "Options:"
 msgstr "Indstillinger"
 
 #. TRANSLATORS: Commandline Option
@@ -1283,9 +1283,7 @@ msgstr ""
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:833
-msgid ""
-"\n"
-"Game selection:\n"
+msgid "Game selection:"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
@@ -1308,15 +1306,11 @@ msgstr "Afslut Hellfire"
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:837
 #, fuzzy
-msgid ""
-"\n"
-"Hellfire options:\n"
+msgid "Hellfire options:"
 msgstr "Indstillinger"
 
 #: Source/diablo.cpp:843
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
 msgstr ""
 
 #: Source/diablo.cpp:955

--- a/Translations/de.po
+++ b/Translations/de.po
@@ -1131,8 +1131,8 @@ msgstr "Stirb!"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:821
-msgid "Options:\n"
-msgstr "Optionen:\n"
+msgid "Options:"
+msgstr "Optionen:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
@@ -1191,12 +1191,8 @@ msgstr "Alle Frame-Begrenzungen bei Demo-Wiedergabe ausschalten"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:833
-msgid ""
-"\n"
-"Game selection:\n"
-msgstr ""
-"\n"
-"Spielauswahl:\n"
+msgid "Game selection:"
+msgstr "Spielauswahl:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
@@ -1215,20 +1211,12 @@ msgstr "Hellfire erzwingen"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:837
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"Hellfire-Optionen:\n"
+msgid "Hellfire options:"
+msgstr "Hellfire-Optionen:"
 
 #: Source/diablo.cpp:843
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"Bugs melden unter https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "Bugs melden unter https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:955
 msgid "version {:s}"

--- a/Translations/devilutionx.pot
+++ b/Translations/devilutionx.pot
@@ -1030,7 +1030,7 @@ msgstr ""
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
-msgid "Options:\n"
+msgid "Options:"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
@@ -1090,9 +1090,7 @@ msgstr ""
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
-msgid ""
-"\n"
-"Game selection:\n"
+msgid "Game selection:"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
@@ -1112,15 +1110,11 @@ msgstr ""
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:838
-msgid ""
-"\n"
-"Hellfire options:\n"
+msgid "Hellfire options:"
 msgstr ""
 
 #: Source/diablo.cpp:844
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
 msgstr ""
 
 #: Source/diablo.cpp:956

--- a/Translations/el.po
+++ b/Translations/el.po
@@ -1150,8 +1150,8 @@ msgstr "Τώρα θα ΠΕΘΑΝΕΙΣ!"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
-msgid "Options:\n"
-msgstr "Επιλογές\n"
+msgid "Options:"
+msgstr "Επιλογές"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:823
@@ -1210,12 +1210,8 @@ msgstr "Απενεργοποίηση ορίων καρέ κατά την ανα�
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
-msgid ""
-"\n"
-"Game selection:\n"
-msgstr ""
-"\n"
-"Επιλογή παιχνιδιού:\n"
+msgid "Game selection:"
+msgstr "Επιλογή παιχνιδιού:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:835
@@ -1234,20 +1230,12 @@ msgstr "Εξαναγκαστική κατάστασή σε Hellfire"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:838
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"Επιλογές Χελφάϊερ:\n"
+msgid "Hellfire options:"
+msgstr "Επιλογές Χελφάϊερ:"
 
 #: Source/diablo.cpp:844
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"Αναφορά σφαλμάτων στην σελίδα https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "Αναφορά σφαλμάτων στην σελίδα https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:956
 msgid "version {:s}"

--- a/Translations/es.po
+++ b/Translations/es.po
@@ -1131,8 +1131,8 @@ msgstr "¡Ahora MUERES!"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:821
-msgid "Options:\n"
-msgstr "Opciones\n"
+msgid "Options:"
+msgstr "Opciones"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
@@ -1191,12 +1191,8 @@ msgstr "Desactivar la limitación de FPS durante la reproducción de la demo"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:833
-msgid ""
-"\n"
-"Game selection:\n"
-msgstr ""
-"\n"
-"Selección de juego:\n"
+msgid "Game selection:"
+msgstr "Selección de juego:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
@@ -1215,20 +1211,12 @@ msgstr "Forzar modo Hellfire"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:837
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"Opciones de Hellfire:\n"
+msgid "Hellfire options:"
+msgstr "Opciones de Hellfire:"
 
 #: Source/diablo.cpp:843
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"Reportar errores a https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "Reportar errores a https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:955
 msgid "version {:s}"

--- a/Translations/fr.po
+++ b/Translations/fr.po
@@ -1130,8 +1130,8 @@ msgstr "Maintenant tu MEURS!"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:821
-msgid "Options:\n"
-msgstr "Options:\n"
+msgid "Options:"
+msgstr "Options:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
@@ -1191,12 +1191,8 @@ msgstr ""
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:833
-msgid ""
-"\n"
-"Game selection:\n"
-msgstr ""
-"\n"
-"Selection de la Partie:\n"
+msgid "Game selection:"
+msgstr "Selection de la Partie:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
@@ -1215,20 +1211,12 @@ msgstr "Forcer le mode Hellfire"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:837
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"Options Hellfire:\n"
+msgid "Hellfire options:"
+msgstr "Options Hellfire:"
 
 #: Source/diablo.cpp:843
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"Signalez les bogues sur https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "Signalez les bogues sur https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:955
 msgid "version {:s}"

--- a/Translations/hr.po
+++ b/Translations/hr.po
@@ -1147,8 +1147,8 @@ msgstr "Sada UMRI!"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:821
-msgid "Options:\n"
-msgstr "Mogućnosti:\n"
+msgid "Options:"
+msgstr "Mogućnosti:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
@@ -1207,12 +1207,8 @@ msgstr "Onemogući sva ograničenja sličica tijekom demo reprodukcije"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:833
-msgid ""
-"\n"
-"Game selection:\n"
-msgstr ""
-"\n"
-"Odabir igre:\n"
+msgid "Game selection:"
+msgstr "Odabir igre:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
@@ -1231,20 +1227,12 @@ msgstr "Prisili Hellfire izdanje"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:837
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"Hellfire mogućnosti:\n"
+msgid "Hellfire options:"
+msgstr "Hellfire mogućnosti:"
 
 #: Source/diablo.cpp:843
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"Prijavite greške na https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "Prijavite greške na https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:955
 msgid "version {:s}"

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -1135,8 +1135,8 @@ msgstr "Ora MUORI!"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:821
-msgid "Options:\n"
-msgstr "Opzioni:\n"
+msgid "Options:"
+msgstr "Opzioni:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
@@ -1195,12 +1195,8 @@ msgstr "Disabilita limitazioni di frame in riproduzione demo"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:833
-msgid ""
-"\n"
-"Game selection:\n"
-msgstr ""
-"\n"
-"Selezione gioco:\n"
+msgid "Game selection:"
+msgstr "Selezione gioco:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
@@ -1219,20 +1215,12 @@ msgstr "Forza modalità Hellfire"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:837
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"Opzioni Hellfire:\n"
+msgid "Hellfire options:"
+msgstr "Opzioni Hellfire:"
 
 #: Source/diablo.cpp:843
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"Segnala gli errori a https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "Segnala gli errori a https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:955
 msgid "version {:s}"

--- a/Translations/ja.po
+++ b/Translations/ja.po
@@ -1117,8 +1117,8 @@ msgstr "さあ、死ぬ​ん​だ​!"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:821
-msgid "Options:\n"
-msgstr "オプション:\n"
+msgid "Options:"
+msgstr "オプション:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
@@ -1177,12 +1177,9 @@ msgstr "Disable all frame limiting during demo playback"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:833
-msgid ""
-"\n"
-"Game selection:\n"
+msgid "Game selection:"
 msgstr ""
-"\n"
-"Game selection:\n"
+"Game selection:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
@@ -1201,20 +1198,14 @@ msgstr "Force Hellfire mode"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:837
-msgid ""
-"\n"
-"Hellfire options:\n"
+msgid "Hellfire options:"
 msgstr ""
-"\n"
-"Hellfire options:\n"
+"Hellfire options:"
 
 #: Source/diablo.cpp:843
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
 msgstr ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
+"Report bugs at https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:955
 msgid "version {:s}"

--- a/Translations/ko.po
+++ b/Translations/ko.po
@@ -1110,8 +1110,8 @@ msgstr "그럼 이제 죽어!"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
-msgid "Options:\n"
-msgstr "선택 사항:\n"
+msgid "Options:"
+msgstr "선택 사항:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:823
@@ -1170,12 +1170,8 @@ msgstr "데모 플레이 프레임 제한 해제"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
-msgid ""
-"\n"
-"Game selection:\n"
-msgstr ""
-"\n"
-"게임 선택:\n"
+msgid "Game selection:"
+msgstr "게임 선택:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:835
@@ -1194,20 +1190,12 @@ msgstr "강제 헬파이어 모드"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:838
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"헬파이어 설정:\n"
+msgid "Hellfire options:"
+msgstr "헬파이어 설정:"
 
 #: Source/diablo.cpp:844
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"https://github.com/diasurgical/devilutionX/ 에 버그 리포트하기\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "https://github.com/diasurgical/devilutionX/ 에 버그 리포트하기"
 
 #: Source/diablo.cpp:956
 msgid "version {:s}"

--- a/Translations/pl.po
+++ b/Translations/pl.po
@@ -1131,8 +1131,8 @@ msgstr "Teraz ZGINIESZ!"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:821
-msgid "Options:\n"
-msgstr "Opcje\n"
+msgid "Options:"
+msgstr "Opcje"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
@@ -1191,12 +1191,8 @@ msgstr "Wyłącz limit klatek podczas odtwarzania demo"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:833
-msgid ""
-"\n"
-"Game selection:\n"
-msgstr ""
-"\n"
-"Wybór gry:\n"
+msgid "Game selection:"
+msgstr "Wybór gry:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
@@ -1215,20 +1211,12 @@ msgstr "Wymuś tryb Hellfire"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:837
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"Opcje Hellfire\n"
+msgid "Hellfire options:"
+msgstr "Opcje Hellfire"
 
 #: Source/diablo.cpp:843
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"Zgłoś błędy na https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "Zgłoś błędy na https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:955
 msgid "version {:s}"

--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -1129,8 +1129,8 @@ msgstr "Agora você MORRE!"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:821
-msgid "Options:\n"
-msgstr "Opções:\n"
+msgid "Options:"
+msgstr "Opções:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
@@ -1189,12 +1189,8 @@ msgstr "Desabilita todos os limites de frame durante a demonstração"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:833
-msgid ""
-"\n"
-"Game selection:\n"
-msgstr ""
-"\n"
-"Seleção do jogo:\n"
+msgid "Game selection:"
+msgstr "Seleção do jogo:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
@@ -1213,20 +1209,12 @@ msgstr "Forçar modo Hellfire"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:837
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"Opções do Hellfire:\n"
+msgid "Hellfire options:"
+msgstr "Opções do Hellfire:"
 
 #: Source/diablo.cpp:843
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"Reportar erros em https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "Reportar erros em https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:955
 msgid "version {:s}"

--- a/Translations/ro.po
+++ b/Translations/ro.po
@@ -1147,8 +1147,8 @@ msgstr "Acum MORI!"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:821
-msgid "Options:\n"
-msgstr "Opțiuni:\n"
+msgid "Options:"
+msgstr "Opțiuni:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
@@ -1207,9 +1207,7 @@ msgstr "Dezactivează limitările de cadre la rularea unui demo"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:833
-msgid ""
-"\n"
-"Game selection:\n"
+msgid "Game selection:"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
@@ -1229,20 +1227,12 @@ msgstr "Forțează modul Hellfire"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:837
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"Opțiuni Hellfire:\n"
+msgid "Hellfire options:"
+msgstr "Opțiuni Hellfire:"
 
 #: Source/diablo.cpp:843
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"Raportați problemele la https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "Raportați problemele la https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:955
 msgid "version {:s}"

--- a/Translations/ru.po
+++ b/Translations/ru.po
@@ -1148,8 +1148,8 @@ msgstr "А теперь УМРИ!"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:821
-msgid "Options:\n"
-msgstr "Параметры:\n"
+msgid "Options:"
+msgstr "Параметры:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
@@ -1208,12 +1208,8 @@ msgstr "Отключить лимит кадров во время проигр�
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:833
-msgid ""
-"\n"
-"Game selection:\n"
-msgstr ""
-"\n"
-"Выбор игры:\n"
+msgid "Game selection:"
+msgstr "Выбор игры:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
@@ -1232,20 +1228,12 @@ msgstr "Запустить в режиме Hellfire"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:837
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"Параметры Hellfire:\n"
+msgid "Hellfire options:"
+msgstr "Параметры Hellfire:"
 
 #: Source/diablo.cpp:843
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"Сообщайте об ошибках на https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "Сообщайте об ошибках на https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:955
 msgid "version {:s}"

--- a/Translations/sv.po
+++ b/Translations/sv.po
@@ -1122,8 +1122,8 @@ msgstr "Dags att DÖ!"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:821
-msgid "Options:\n"
-msgstr "Alternativ:\n"
+msgid "Options:"
+msgstr "Alternativ:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
@@ -1182,12 +1182,8 @@ msgstr "Stäng av alla framebegränsningar vid demouppspelning"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:833
-msgid ""
-"\n"
-"Game selection:\n"
-msgstr ""
-"\n"
-"Spelval:\n"
+msgid "Game selection:"
+msgstr "Spelval:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
@@ -1206,20 +1202,12 @@ msgstr "Tvinga Hellfireläge"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:837
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"Hellfire-alternativ:\n"
+msgid "Hellfire options:"
+msgstr "Hellfire-alternativ:"
 
 #: Source/diablo.cpp:843
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"Rapportera buggar på https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "Rapportera buggar på https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:955
 msgid "version {:s}"

--- a/Translations/uk.po
+++ b/Translations/uk.po
@@ -1124,8 +1124,8 @@ msgstr "А тепер ПОМРИ!"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
-msgid "Options:\n"
-msgstr "Опції:\n"
+msgid "Options:"
+msgstr "Опції:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:823
@@ -1184,12 +1184,8 @@ msgstr "Віключити ліміт кадрів під час програш�
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
-msgid ""
-"\n"
-"Game selection:\n"
-msgstr ""
-"\n"
-"Вибір гри:\n"
+msgid "Game selection:"
+msgstr "Вибір гри:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:835
@@ -1208,20 +1204,12 @@ msgstr "Примусити режим Hellfire"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:838
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"Опції Hellfire:\n"
+msgid "Hellfire options:"
+msgstr "Опції Hellfire:"
 
 #: Source/diablo.cpp:844
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"Пишіть про помилки на https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "Пишіть про помилки на https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:956
 msgid "version {:s}"

--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -1104,8 +1104,8 @@ msgstr "现在​你​死定​了！"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:821
-msgid "Options:\n"
-msgstr "选​项: \n"
+msgid "Options:"
+msgstr "选​项: "
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
@@ -1164,12 +1164,8 @@ msgstr "播放​录像​回放​时​禁​用​帧​数​限制"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:833
-msgid ""
-"\n"
-"Game selection:\n"
-msgstr ""
-"\n"
-"​游戏​选项​：​\n"
+msgid "Game selection:"
+msgstr "​游戏​选项​：​"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:834
@@ -1188,20 +1184,12 @@ msgstr "强制​地狱火​模式"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:837
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"​地​狱火​选项: \n"
+msgid "Hellfire options:"
+msgstr "​地​狱火​选项: "
 
 #: Source/diablo.cpp:843
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"​报告​错误​https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "​报告​错误​https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:955
 msgid "version {:s}"

--- a/Translations/zh_TW.po
+++ b/Translations/zh_TW.po
@@ -1154,8 +1154,8 @@ msgstr "現​在​你​死定​了！"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:821
-msgid "Options:\n"
-msgstr "選​項: \n"
+msgid "Options:"
+msgstr "選​項:"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:822
@@ -1216,9 +1216,7 @@ msgstr ""
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:833
-msgid ""
-"\n"
-"Game selection:\n"
+msgid "Game selection:"
 msgstr ""
 
 #. TRANSLATORS: Commandline Option
@@ -1240,20 +1238,12 @@ msgstr "地​獄火​幫助"
 
 #. TRANSLATORS: Commandline Option
 #: Source/diablo.cpp:837
-msgid ""
-"\n"
-"Hellfire options:\n"
-msgstr ""
-"\n"
-"地​獄火選項: \n"
+msgid "Hellfire options:"
+msgstr "地​獄火選項:"
 
 #: Source/diablo.cpp:843
-msgid ""
-"\n"
-"Report bugs at https://github.com/diasurgical/devilutionX/\n"
-msgstr ""
-"\n"
-"報​告錯​誤​https://github.com/diasurgical/devilutionX/\n"
+msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
+msgstr "報​告錯​誤​https://github.com/diasurgical/devilutionX/"
 
 #: Source/diablo.cpp:955
 msgid "version {:s}"


### PR DESCRIPTION
Also print `\r\n` instead of `\n` on Windows.

This paves the way forward for returning a `string_view` from `_(...)`.