### PR TITLE
Add debug command for testing custom levels

### DIFF
--- a/Source/debug.h
+++ b/Source/debug.h
@@ -15,6 +15,7 @@
 
 namespace devilution {
 
+extern std::string TestMapPath;
 extern std::optional<OwnedCelSprite> pSquareCel;
 extern bool DebugToggle;
 extern bool DebugGodMode;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -537,32 +537,6 @@ void InitRndBarrels()
 	}
 }
 
-void AddCryptObjects(int x1, int y1, int x2, int y2)
-{
-	for (int j = y1; j < y2; j++) {
-		for (int i = x1; i < x2; i++) {
-			int pn = dPiece[i][j];
-			if (pn == 77)
-				AddObject(OBJ_L5LDOOR, { i, j });
-			if (pn == 80)
-				AddObject(OBJ_L5RDOOR, { i, j });
-		}
-	}
-}
-
-void AddL3Objs(int x1, int y1, int x2, int y2)
-{
-	for (int j = y1; j < y2; j++) {
-		for (int i = x1; i < x2; i++) {
-			int pn = dPiece[i][j];
-			if (pn == 531)
-				AddObject(OBJ_L3LDOOR, { i, j });
-			if (pn == 534)
-				AddObject(OBJ_L3RDOOR, { i, j });
-		}
-	}
-}
-
 void AddL2Torches()
 {
 	for (int j = 0; j < MAXDUNY; j++) {
@@ -4601,16 +4575,27 @@ void AddL2Objs(int x1, int y1, int x2, int y2)
 	}
 }
 
-void AddL5Objs(int x1, int y1, int x2, int y2)
+void AddL3Objs(int x1, int y1, int x2, int y2)
 {
 	for (int j = y1; j < y2; j++) {
 		for (int i = x1; i < x2; i++) {
 			int pn = dPiece[i][j];
-			if (pn == 270)
-				AddObject(OBJ_L1LIGHT, { i, j });
-			if (pn == 44 || pn == 51 || pn == 214)
+			if (pn == 531)
+				AddObject(OBJ_L3LDOOR, { i, j });
+			if (pn == 534)
+				AddObject(OBJ_L3RDOOR, { i, j });
+		}
+	}
+}
+
+void AddCryptObjects(int x1, int y1, int x2, int y2)
+{
+	for (int j = y1; j < y2; j++) {
+		for (int i = x1; i < x2; i++) {
+			int pn = dPiece[i][j];
+			if (pn == 77)
 				AddObject(OBJ_L5LDOOR, { i, j });
-			if (pn == 46 || pn == 56)
+			if (pn == 80)
 				AddObject(OBJ_L5RDOOR, { i, j });
 		}
 	}
@@ -5199,8 +5184,11 @@ void ObjChangeMap(int x1, int y1, int x2, int y2)
 		ObjL2Special(2 * x1 + 16, 2 * y1 + 16, 2 * x2 + 17, 2 * y2 + 17);
 		AddL2Objs(2 * x1 + 16, 2 * y1 + 16, 2 * x2 + 17, 2 * y2 + 17);
 	}
+	if (leveltype == DTYPE_CAVES) {
+		AddL3Objs(2 * x1 + 16, 2 * y1 + 16, 2 * x2 + 17, 2 * y2 + 17);
+	}
 	if (leveltype == DTYPE_CRYPT) {
-		AddL5Objs(2 * x1 + 16, 2 * y1 + 16, 2 * x2 + 17, 2 * y2 + 17);
+		AddCryptObjects(2 * x1 + 16, 2 * y1 + 16, 2 * x2 + 17, 2 * y2 + 17);
 	}
 }
 

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -288,7 +288,8 @@ void InitObjectGFX();
 void FreeObjectGFX();
 void AddL1Objs(int x1, int y1, int x2, int y2);
 void AddL2Objs(int x1, int y1, int x2, int y2);
-void AddL5Objs(int x1, int y1, int x2, int y2);
+void AddL3Objs(int x1, int y1, int x2, int y2);
+void AddCryptObjects(int x1, int y1, int x2, int y2);
 void InitObjects();
 void SetMapObjects(const uint16_t *dunData, int startx, int starty);
 /**

--- a/Source/setmaps.cpp
+++ b/Source/setmaps.cpp
@@ -5,9 +5,13 @@
  */
 #include "setmaps.h"
 
+#ifdef _DEBUG
+#include "debug.h"
+#endif
 #include "drlg_l1.h"
 #include "drlg_l2.h"
 #include "drlg_l3.h"
+#include "drlg_l4.h"
 #include "engine/load_file.hpp"
 #include "objdat.h"
 #include "objects.h"
@@ -197,6 +201,41 @@ void LoadSetMap()
 		InitNoTriggers();
 		break;
 	case SL_NONE:
+#ifdef _DEBUG
+		switch (setlvltype) {
+		case DTYPE_CATHEDRAL:
+			LoadPreL1Dungeon(TestMapPath.c_str());
+			LoadL1Dungeon(TestMapPath.c_str(), ViewPosition.x, ViewPosition.y);
+			AddL1Objs(0, 0, MAXDUNX, MAXDUNY);
+			break;
+		case DTYPE_CATACOMBS:
+			LoadPreL2Dungeon(TestMapPath.c_str());
+			LoadL2Dungeon(TestMapPath.c_str(), ViewPosition.x, ViewPosition.y);
+			AddL2Objs(0, 0, MAXDUNX, MAXDUNY);
+			break;
+		case DTYPE_CAVES:
+			LoadPreL3Dungeon(TestMapPath.c_str());
+			LoadL3Dungeon(TestMapPath.c_str(), ViewPosition.x, ViewPosition.y);
+			AddL3Objs(0, 0, MAXDUNX, MAXDUNY);
+			break;
+		case DTYPE_HELL:
+			LoadPreL4Dungeon(TestMapPath.c_str());
+			LoadL4Dungeon(TestMapPath.c_str(), ViewPosition.x, ViewPosition.y);
+			break;
+		case DTYPE_NEST:
+			LoadPreL3Dungeon(TestMapPath.c_str());
+			LoadL3Dungeon(TestMapPath.c_str(), ViewPosition.x, ViewPosition.y);
+			break;
+		case DTYPE_CRYPT:
+			LoadPreL1Dungeon(TestMapPath.c_str());
+			LoadL1Dungeon(TestMapPath.c_str(), ViewPosition.x, ViewPosition.y);
+			AddCryptObjects(0, 0, MAXDUNX, MAXDUNY);
+			break;
+		}
+		LoadRndLvlPal(setlvltype);
+		SetMapTransparency(TestMapPath.c_str());
+		InitNoTriggers();
+#endif
 		break;
 	}
 }


### PR DESCRIPTION
Load a custom level `map path type x y`. Example `map Levels\L3Data\Foulwatr 3 31 83` will load the poison water level with the cave tiles and spawn position of 31x83
![image](https://user-images.githubusercontent.com/204594/168164015-c122115a-02ff-4ab0-b451-7ca738318de2.png)

`map levels\l1data\vile1 6 35 36` will load you in to Lazarus' chamber but using the Crypt theme (partially compatible as it is based on Cathedral)
![image](https://user-images.githubusercontent.com/204594/168164585-5ac20656-3b5a-42a0-a0d5-4ccca3a8532d.png)

`map levels\l1data\vile1 4 35 36` also just for fun, Lazarus' chamber with Hell tiles
![image](https://user-images.githubusercontent.com/204594/168165095-2573815e-dd1f-4e63-a9f8-f9ebfd487e10.png)

`map Levels\L3Data\Foulwatr 5 31 83` Poison water with the Hive tiles:
![image](https://user-images.githubusercontent.com/204594/168165839-cb6efc34-e217-452b-bc86-f738916604bd.png)
(note that loading a level with the incorrect theme is likely to result in crashes)

`map Levels\L1Data\Lv1MazeB 1 20 50` loads the unused maze level:
![image](https://user-images.githubusercontent.com/204594/168166130-155638b2-f5a6-41ea-93fa-5b6bd7e9f0d0.png)

Be aware that you need to start a new/reload game between loading each level as else the game will try to transfer object and monster states from the previous level you had loaded as the test level.

A handy way to use this is to bind it to one of the quick messages so that you can load your test level with the press of a button.

Note that level palette will be a random one based on the selected tileset and no triggers will be setup.