### PR TITLE
MonsterMHit and MonsterTrapHit refactoring

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -845,7 +845,7 @@ void StartHitMonsterByMissile(int m, int pnum, int dam)
 		monster.Petrify();
 }
 
-int PlayerMissile::CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster)
+int PlayerMissile::CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster) const
 {
 	int hper = 0;
 	if (pnum != -1) {
@@ -863,7 +863,7 @@ int PlayerMissile::CalculateCTHAgainstMonster(int pnum, devilution::Monster &mon
 	return hper;
 }
 
-void PlayerMissile::HitMonster(int pnum, int mindam, int maxdam, bool shift, int m)
+void PlayerMissile::HitMonster(int pnum, int mindam, int maxdam, bool shift, int m) const
 {
 	auto &monster = Monsters[m];
 	bool resist = monster.IsResistant(cm->_mitype);
@@ -909,12 +909,12 @@ void PlayerMissile::HitMonster(int pnum, int mindam, int maxdam, bool shift, int
 	}
 }
 
-int TrapMissile::CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster)
+int TrapMissile::CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster) const
 {
 	return 90 - (BYTE)monster.mArmorClass - cm->_midist;
 }
 
-void TrapMissile::HitMonster(int pnum, int mindam, int maxdam, bool shift, int m)
+void TrapMissile::HitMonster(int pnum, int mindam, int maxdam, bool shift, int m) const
 {
 	auto &monster = Monsters[m];
 	bool resist = monster.IsResistant(cm->_mitype);
@@ -939,7 +939,7 @@ void TrapMissile::HitMonster(int pnum, int mindam, int maxdam, bool shift, int m
 }
 
 template <typename Collidable>
-bool TryHitMonster(Collidable &col, int m, int mindam, int maxdam, bool shift)
+bool TryHitMonster(Collidable const &col, int m, int mindam, int maxdam, bool shift)
 {
 	auto &monster = Monsters[m];
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -317,7 +317,7 @@ void CheckMissileCol(Missile &missile, int mindam, int maxdam, bool shift, Point
 		if (missile._micaster == TARGET_MONSTERS) {
 			int mid = dMonster[mx][my];
 			if (mid != 0 && (mid > 0 || Monsters[abs(mid) - 1]._mmode == MonsterMode::Petrified)) {
-				if (TryHitMonster((PlayerMissile { &missile }), abs(mid) - 1, mindam, maxdam, shift)) {
+				if (TryHitMonster(PlayerMissile(missile), abs(mid) - 1, mindam, maxdam, shift)) {
 					if (!nodel)
 						missile._mirange = 0;
 					missile._miHitFlag = true;
@@ -346,7 +346,7 @@ void CheckMissileCol(Missile &missile, int mindam, int maxdam, bool shift, Point
 			if ((monster._mFlags & MFLAG_TARGETS_MONSTER) != 0
 			    && dMonster[mx][my] > 0
 			    && (Monsters[dMonster[mx][my] - 1]._mFlags & MFLAG_GOLEM) != 0
-			    && TryHitMonster((TrapMissile { &missile }), dMonster[mx][my] - 1, mindam, maxdam, shift)) {
+			    && TryHitMonster(TrapMissile(missile), dMonster[mx][my] - 1, mindam, maxdam, shift)) {
 				if (!nodel)
 					missile._mirange = 0;
 				missile._miHitFlag = true;
@@ -375,12 +375,12 @@ void CheckMissileCol(Missile &missile, int mindam, int maxdam, bool shift, Point
 		if (mid > 0) {
 			mid -= 1;
 			if (missile._micaster == TARGET_BOTH) {
-				if (TryHitMonster((PlayerMissile { &missile }), mid, mindam, maxdam, shift)) {
+				if (TryHitMonster(PlayerMissile(missile), mid, mindam, maxdam, shift)) {
 					if (!nodel)
 						missile._mirange = 0;
 					missile._miHitFlag = true;
 				}
-			} else if (TryHitMonster((TrapMissile { &missile }), mid, mindam, maxdam, shift)) {
+			} else if (TryHitMonster(TrapMissile(missile), mid, mindam, maxdam, shift)) {
 				if (!nodel)
 					missile._mirange = 0;
 				missile._miHitFlag = true;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -952,10 +952,8 @@ bool TryHitMonster(Collidable const &col, int m, int mindam, int maxdam, bool sh
 	int hper = col.CalculateCTHAgainstMonster(pnum, monster);
 	hper = clamp(hper, 5, 95);
 
-	bool ret;
-	if (LiftGargoylesOrIgnoreMages(monster, &ret)) {
-		return ret;
-	}
+	if (monster.TryLiftGargoyle())
+		return true;
 
 	if (hit >= hper && monster._mmode != MonsterMode::Petrified) {
 #ifdef _DEBUG

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -817,7 +817,7 @@ Direction16 GetDirection16(Point p1, Point p2)
 	return ret;
 }
 
-void StartHitMonsterByMissile(int m, int pnum, int dam)
+void StartHitMonsterByMissile(int m, int pnum, int dam, missile_id misName)
 {
 	auto &monster = Monsters[m];
 
@@ -829,12 +829,10 @@ void StartHitMonsterByMissile(int m, int pnum, int dam)
 	}
 
 	bool isPetrified = monster._mmode == MonsterMode::Petrified;
-	if (!isPetrified && hasKnockback)
+	if (!isPetrified && hasKnockback && MissilesData[misName].mType == 0)
 		M_GetKnockback(m);
 	if (m > MAX_PLRS - 1)
 		M_StartHit(m, pnum, dam);
-	if (isPetrified)
-		monster.Petrify();
 }
 
 int PlayerMissile::calculateCTHAgainstMonster(devilution::Monster &monster) const
@@ -893,7 +891,7 @@ void PlayerMissile::hitMonster(int m) const
 	else if (resist)
 		PlayEffect(monster, 1);
 	else
-		StartHitMonsterByMissile(m, pnum, dam);
+		StartHitMonsterByMissile(m, pnum, dam, cm->_mitype);
 
 	if (monster._msquelch == 0) {
 		monster._msquelch = UINT8_MAX;
@@ -928,7 +926,7 @@ void TrapMissile::hitMonster(int m) const
 	else if (resist)
 		PlayEffect(monster, 1);
 	else
-		StartHitMonsterByMissile(m, pnum, dam);
+		StartHitMonsterByMissile(m, pnum, dam, cm->_mitype);
 }
 
 template <typename Collidable>

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -817,14 +817,6 @@ Direction16 GetDirection16(Point p1, Point p2)
 	return ret;
 }
 
-void StartKillMonsterByMissile(int m, int pnum)
-{
-	auto &monster = Monsters[m];
-	M_StartKill(m, pnum);
-	if (monster._mmode == MonsterMode::Petrified)
-		monster.Petrify();
-}
-
 void StartHitMonsterByMissile(int m, int pnum, int dam)
 {
 	auto &monster = Monsters[m];
@@ -897,7 +889,7 @@ void PlayerMissile::hitMonster(int m) const
 		monster._mFlags |= MFLAG_NOHEAL;
 
 	if ((monster._mhitpoints >> 6) <= 0)
-		StartKillMonsterByMissile(m, pnum);
+		M_StartKill(m, pnum);
 	else if (resist)
 		PlayEffect(monster, 1);
 	else
@@ -932,7 +924,7 @@ void TrapMissile::hitMonster(int m) const
 		monster._mhitpoints = 0;
 #endif
 	if ((monster._mhitpoints >> 6) <= 0)
-		StartKillMonsterByMissile(m, pnum);
+		M_StartKill(m, pnum);
 	else if (resist)
 		PlayEffect(monster, 1);
 	else

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -29,6 +29,27 @@ namespace devilution {
 std::list<Missile> Missiles;
 bool MissilePreFlag;
 
+// placeholder for virtual
+int Missile::CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster)
+{
+	return 0;
+}
+// placeholder for virtual
+void Missile::HitMonster(int pnum, int mindam, int maxdam, bool shift, int m)
+{
+}
+
+class PlayerMissile : public Missile {
+
+public:
+	PlayerMissile(const Missile &M)
+	    : Missile(M) {};
+
+private:
+	int CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster) override;
+	void HitMonster(int pnum, int mindam, int maxdam, bool shift, int m) override;
+};
+
 namespace {
 
 int AddClassHealingBonus(int hp, HeroClass heroClass)
@@ -185,128 +206,6 @@ void MoveMissilePos(Missile &missile)
 	}
 }
 
-bool MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, missile_id t, bool shift)
-{
-	auto &monster = Monsters[m];
-
-	bool resist = false;
-	if (monster.mtalkmsg != TEXT_NONE
-	    || monster._mhitpoints >> 6 <= 0
-	    || (t == MIS_HBOLT && monster.MType->mtype != MT_DIABLO && monster.MData->mMonstClass != MonsterClass::Undead)) {
-		return false;
-	}
-	if (monster.MType->mtype == MT_ILLWEAV && monster._mgoal == MGOAL_RETREAT)
-		return false;
-	if (monster._mmode == MonsterMode::Charge)
-		return false;
-
-	uint8_t mor = monster.mMagicRes;
-	missile_resistance mir = MissilesData[t].mResist;
-
-	if (((mor & IMMUNE_MAGIC) != 0 && mir == MISR_MAGIC)
-	    || ((mor & IMMUNE_FIRE) != 0 && mir == MISR_FIRE)
-	    || ((mor & IMMUNE_LIGHTNING) != 0 && mir == MISR_LIGHTNING)
-	    || ((mor & IMMUNE_ACID) != 0 && mir == MISR_ACID))
-		return false;
-
-	if (((mor & RESIST_MAGIC) != 0 && mir == MISR_MAGIC)
-	    || ((mor & RESIST_FIRE) != 0 && mir == MISR_FIRE)
-	    || ((mor & RESIST_LIGHTNING) != 0 && mir == MISR_LIGHTNING))
-		resist = true;
-
-	if (gbIsHellfire && t == MIS_HBOLT && (monster.MType->mtype == MT_DIABLO || monster.MType->mtype == MT_BONEDEMN))
-		resist = true;
-
-	int hit = GenerateRnd(100);
-	int hper = 0;
-	if (pnum != -1) {
-		const auto &player = Players[pnum];
-		if (MissilesData[t].mType == 0) {
-			hper = player.GetRangedPiercingToHit();
-			hper -= player.CalculateArmorPierce(monster.mArmorClass, false);
-			hper -= (dist * dist) / 2;
-		} else {
-			hper = player.GetMagicToHit() - (monster.mLevel * 2) - dist;
-		}
-	} else {
-		hper = GenerateRnd(75) - monster.mLevel * 2;
-	}
-
-	hper = clamp(hper, 5, 95);
-
-	if (monster._mmode == MonsterMode::Petrified)
-		hit = 0;
-
-	bool ret = false;
-	if (CheckMonsterHit(monster, &ret))
-		return ret;
-
-	if (hit >= hper) {
-#ifdef _DEBUG
-		if (!DebugGodMode)
-#endif
-			return false;
-	}
-
-	int dam;
-	if (t == MIS_BONESPIRIT) {
-		dam = monster._mhitpoints / 3 >> 6;
-	} else {
-		dam = mindam + GenerateRnd(maxdam - mindam + 1);
-	}
-
-	const auto &player = Players[pnum];
-
-	if (MissilesData[t].mType == 0 && mir == MISR_NONE) {
-		dam = player._pIBonusDamMod + dam * player._pIBonusDam / 100 + dam;
-		if (player._pClass == HeroClass::Rogue)
-			dam += player._pDamageMod;
-		else
-			dam += player._pDamageMod / 2;
-	}
-
-	if (!shift)
-		dam <<= 6;
-	if (resist)
-		dam >>= 2;
-
-	if (pnum == MyPlayerId)
-		monster._mhitpoints -= dam;
-
-	if ((gbIsHellfire && HasAnyOf(player._pIFlags, ItemSpecialEffect::NoHealOnMonsters)) || (!gbIsHellfire && HasAnyOf(player._pIFlags, ItemSpecialEffect::FireArrows)))
-		monster._mFlags |= MFLAG_NOHEAL;
-
-	if (monster._mhitpoints >> 6 <= 0) {
-		if (monster._mmode == MonsterMode::Petrified) {
-			M_StartKill(m, pnum);
-			monster.Petrify();
-		} else {
-			M_StartKill(m, pnum);
-		}
-	} else {
-		if (resist) {
-			PlayEffect(monster, 1);
-		} else if (monster._mmode == MonsterMode::Petrified) {
-			if (m > MAX_PLRS - 1)
-				M_StartHit(m, pnum, dam);
-			monster.Petrify();
-		} else {
-			if (MissilesData[t].mType == 0 && HasAnyOf(player._pIFlags, ItemSpecialEffect::Knockback)) {
-				M_GetKnockback(m);
-			}
-			if (m > MAX_PLRS - 1)
-				M_StartHit(m, pnum, dam);
-		}
-	}
-
-	if (monster._msquelch == 0) {
-		monster._msquelch = UINT8_MAX;
-		monster.position.last = player.position.tile;
-	}
-
-	return true;
-}
-
 bool Plr2PlrMHit(int pnum, int p, int mindam, int maxdam, int dist, missile_id mtype, bool shift, bool *blocked)
 {
 	if (sgGameInitInfo.bFriendlyFire == 0 && gbFriendlyMode)
@@ -435,18 +334,14 @@ void CheckMissileCol(Missile &missile, int mindam, int maxdam, bool shift, Point
 	int mx = position.x;
 	int my = position.y;
 
+	//PlayerMissile pPlMis = missile;
+	//TrapMissile pTrapMis = missile;
+
 	if (missile._micaster != TARGET_BOTH && !missile.IsTrap()) {
 		if (missile._micaster == TARGET_MONSTERS) {
 			int mid = dMonster[mx][my];
 			if (mid != 0 && (mid > 0 || Monsters[abs(mid) - 1]._mmode == MonsterMode::Petrified)) {
-				if (MonsterMHit(
-				        missile._misource,
-				        abs(mid) - 1,
-				        mindam,
-				        maxdam,
-				        missile._midist,
-				        missile._mitype,
-				        shift)) {
+				if (((PlayerMissile)missile).TryHitMonster(abs(mid) - 1, mindam, maxdam, shift)) {
 					if (!nodel)
 						missile._mirange = 0;
 					missile._miHitFlag = true;
@@ -475,7 +370,7 @@ void CheckMissileCol(Missile &missile, int mindam, int maxdam, bool shift, Point
 			if ((monster._mFlags & MFLAG_TARGETS_MONSTER) != 0
 			    && dMonster[mx][my] > 0
 			    && (Monsters[dMonster[mx][my] - 1]._mFlags & MFLAG_GOLEM) != 0
-			    && MonsterTrapHit(dMonster[mx][my] - 1, mindam, maxdam, missile._midist, missile._mitype, shift)) {
+			    && ((TrapMissile)missile).TryHitMonster(dMonster[mx][my] - 1, mindam, maxdam, shift)) {
 				if (!nodel)
 					missile._mirange = 0;
 				missile._miHitFlag = true;
@@ -504,19 +399,12 @@ void CheckMissileCol(Missile &missile, int mindam, int maxdam, bool shift, Point
 		if (mid > 0) {
 			mid -= 1;
 			if (missile._micaster == TARGET_BOTH) {
-				if (MonsterMHit(
-				        missile._misource,
-				        mid,
-				        mindam,
-				        maxdam,
-				        missile._midist,
-				        missile._mitype,
-				        shift)) {
+				if (((PlayerMissile)missile).TryHitMonster(mid, mindam, maxdam, shift)) {
 					if (!nodel)
 						missile._mirange = 0;
 					missile._miHitFlag = true;
 				}
-			} else if (MonsterTrapHit(mid, mindam, maxdam, missile._midist, missile._mitype, shift)) {
+			} else if (((TrapMissile)missile).TryHitMonster(mid, mindam, maxdam, shift)) {
 				if (!nodel)
 					missile._mirange = 0;
 				missile._miHitFlag = true;
@@ -953,49 +841,74 @@ Direction16 GetDirection16(Point p1, Point p2)
 	return ret;
 }
 
-bool MonsterTrapHit(int m, int mindam, int maxdam, int dist, missile_id t, bool shift)
+int PlayerMissile::CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster)
+{
+	int hper = 0;
+	if (pnum != -1) {
+		const auto &player = Players[pnum];
+		if (MissilesData[_mitype].mType == 0) {
+			hper = player.GetRangedPiercingToHit();
+			hper -= player.CalculateArmorPierce(monster.mArmorClass, false);
+			hper -= (_midist * _midist) / 2;
+		} else {
+			hper = player.GetMagicToHit() - (monster.mLevel * 2) - _midist;
+		}
+	} else {
+		hper = GenerateRnd(75) - monster.mLevel * 2;
+	}
+	return hper;
+}
+
+void PlayerMissile::HitMonster(int pnum, int mindam, int maxdam, bool shift, int m)
 {
 	auto &monster = Monsters[m];
+	bool resist = monster.IsResistant(_mitype);
 
-	bool resist = false;
-	if (monster.mtalkmsg != TEXT_NONE) {
-		return false;
-	}
-	if (monster._mhitpoints >> 6 <= 0) {
-		return false;
-	}
-	if (monster.MType->mtype == MT_ILLWEAV && monster._mgoal == MGOAL_RETREAT)
-		return false;
-	if (monster._mmode == MonsterMode::Charge)
-		return false;
+	const auto &player = Players[pnum];
 
-	missile_resistance mir = MissilesData[t].mResist;
-	int mor = monster.mMagicRes;
-	if (((mor & IMMUNE_MAGIC) != 0 && mir == MISR_MAGIC)
-	    || ((mor & IMMUNE_FIRE) != 0 && mir == MISR_FIRE)
-	    || ((mor & IMMUNE_LIGHTNING) != 0 && mir == MISR_LIGHTNING)) {
-		return false;
-	}
+	int dam;
+	if (_mitype == MIS_BONESPIRIT) {
+		dam = monster._mhitpoints / 3 >> 6;
+	} else {
+		dam = mindam + GenerateRnd(maxdam - mindam + 1);
+		if (MissilesData[_mitype].mType == 0 && MissilesData[_mitype].mResist == MISR_NONE) {
+			dam = player._pIBonusDamMod + dam * player._pIBonusDam / 100 + dam;
+			if (player._pClass == HeroClass::Rogue)
+				dam += player._pDamageMod;
+			else
+				dam += player._pDamageMod / 2;
+		}
 
-	if (((mor & RESIST_MAGIC) != 0 && mir == MISR_MAGIC)
-	    || ((mor & RESIST_FIRE) != 0 && mir == MISR_FIRE)
-	    || ((mor & RESIST_LIGHTNING) != 0 && mir == MISR_LIGHTNING)) {
-		resist = true;
+		if (!shift)
+			dam <<= 6;
+		if (resist)
+			dam >>= 2;
 	}
 
-	int hit = GenerateRnd(100);
-	int hper = 90 - (BYTE)monster.mArmorClass - dist;
-	hper = clamp(hper, 5, 95);
-	bool ret;
-	if (CheckMonsterHit(monster, &ret)) {
-		return ret;
+	if (pnum == MyPlayerId)
+		monster._mhitpoints -= dam;
+
+	if ((gbIsHellfire && HasAnyOf(player._pIFlags, ItemSpecialEffect::NoHealOnMonsters))
+	    || (!gbIsHellfire && HasAnyOf(player._pIFlags, ItemSpecialEffect::FireArrows)))
+		monster._mFlags |= MFLAG_NOHEAL;
+
+	StartKillOrHitMonster(m, pnum, dam);
+
+	if (monster._msquelch == 0) {
+		monster._msquelch = UINT8_MAX;
+		monster.position.last = player.position.tile;
 	}
-	if (hit >= hper && monster._mmode != MonsterMode::Petrified) {
-#ifdef _DEBUG
-		if (!DebugGodMode)
-#endif
-			return false;
-	}
+}
+
+int TrapMissile::CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster)
+{
+	return 90 - (BYTE)monster.mArmorClass - _midist;
+}
+
+void TrapMissile::HitMonster(int pnum, int mindam, int maxdam, bool shift, int m)
+{
+	auto &monster = Monsters[m];
+	bool resist = monster.IsResistant(_mitype);
 
 	int dam = mindam + GenerateRnd(maxdam - mindam + 1);
 	if (!shift)
@@ -1008,25 +921,42 @@ bool MonsterTrapHit(int m, int mindam, int maxdam, int dist, missile_id t, bool 
 	if (DebugGodMode)
 		monster._mhitpoints = 0;
 #endif
-	if (monster._mhitpoints >> 6 <= 0) {
-		if (monster._mmode == MonsterMode::Petrified) {
-			M_StartKill(m, -1);
-			monster.Petrify();
-		} else {
-			M_StartKill(m, -1);
-		}
-	} else {
-		if (resist) {
-			PlayEffect(monster, 1);
-		} else if (monster._mmode == MonsterMode::Petrified) {
-			if (m > MAX_PLRS - 1)
-				M_StartHit(m, -1, dam);
-			monster.Petrify();
-		} else {
-			if (m > MAX_PLRS - 1)
-				M_StartHit(m, -1, dam);
-		}
+	StartKillOrHitMonster(m, pnum, dam);
+}
+
+
+bool Missile::TryHitMonster(int m, int mindam, int maxdam, bool shift)
+{
+	auto &monster = Monsters[m];
+
+	if (!IsMonsterPossibleToHit(monster))
+		return false;
+
+	int pnum = _misource;
+
+	int hit = GenerateRnd(100);
+	int hper = CalculateCTHAgainstMonster(pnum, monster);
+	hper = clamp(hper, 5, 95);
+
+	bool ret;
+	if (LiftGargoylesOrIgnoreMages(monster, &ret)) {
+		return ret;
 	}
+
+	if (hit >= hper && monster._mmode != MonsterMode::Petrified) {
+#ifdef _DEBUG
+		if (!DebugGodMode)
+#endif
+			return false;
+	}
+	HitMonster(pnum, mindam, maxdam, shift, m);
+	return true;
+}
+
+bool Missile::IsMonsterPossibleToHit(devilution::Monster &monster) const
+{
+	if (!monster.IsPossibleToHit() || monster.IsImmune(_mitype))
+		return false;
 	return true;
 }
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -947,8 +947,6 @@ bool TryHitMonster(Collidable const &col, int m)
 	if (!monster.IsPossibleToHit() || monster.IsImmune(col.cm->_mitype))
 		return false;
 
-	int pnum = col.cm->_misource;
-
 	int hit = GenerateRnd(100);
 	int hper = col.calculateCTHAgainstMonster(monster);
 	hper = clamp(hper, 5, 95);

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -137,33 +137,41 @@ struct Missile {
 class Collidable {
 public:
 	Missile *cm;
-	bool IsMonsterPossibleToHit(devilution::Monster &monster) const;
+	int m_minDam;
+	int m_maxDam;
+	bool m_shift;
 };
 
 class TrapMissile : public Collidable {
 
 public:
-	TrapMissile(Missile missile)
+	TrapMissile(Missile missile, int minDam, int maxDam, bool shift)
 	{
 		cm = &missile;
+		m_minDam = minDam;
+		m_maxDam = maxDam;
+		m_shift = shift;
 	}
-	int CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster) const;
-	void HitMonster(int pnum, int mindam, int maxdam, bool shift, int m) const ;
+	int calculateCTHAgainstMonster(devilution::Monster &monster) const;
+	void hitMonster(int m) const;
 };
 
 class PlayerMissile : public Collidable {
 
 public:
-	PlayerMissile(Missile missile)
+	PlayerMissile(Missile missile, int minDam, int maxDam, bool shift)
 	{
 		cm = &missile;
+		m_minDam = minDam;
+		m_maxDam = maxDam;
+		m_shift = shift;
 	}
-	int CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster) const;
-	void HitMonster(int pnum, int mindam, int maxdam, bool shift, int m) const;
+	int calculateCTHAgainstMonster(devilution::Monster &monster) const;
+	void hitMonster(int m) const;
 };
 
 template <typename Collidable>
-bool TryHitMonster(Collidable const &col, int m, int mindam, int maxdam, bool shift);
+bool TryHitMonster(Collidable const &col, int m);
 
 extern std::list<Missile> Missiles;
 extern bool MissilePreFlag;

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -132,27 +132,30 @@ struct Missile {
 	{
 		return _misource == -1;
 	}
-
-	bool TryHitMonster(int m, int mindam, int maxdam, bool shift);
-
-private:
-	bool IsMonsterPossibleToHit(devilution::Monster &monster) const;
-	virtual int CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster);
-	virtual void HitMonster(int pnum, int mindam, int maxdam, bool shift, int m);
 };
 
-class TrapMissile : public Missile {
+class Collidable {
+public:
+	Missile *cm;
+	bool IsMonsterPossibleToHit(devilution::Monster &monster) const;
+};
+
+class TrapMissile : public Collidable {
 
 public:
-	TrapMissile(const Missile &M)
-	    : Missile(M) {};
-	TrapMissile()
-	    : Missile() {};
-
-private:
-	int CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster) override;
-	void HitMonster(int pnum, int mindam, int maxdam, bool shift, int m) override;
+	int CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster);
+	void HitMonster(int pnum, int mindam, int maxdam, bool shift, int m);
 };
+
+class PlayerMissile : public Collidable {
+
+public:
+	int CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster);
+	void HitMonster(int pnum, int mindam, int maxdam, bool shift, int m);
+};
+
+template <typename Collidable>
+bool TryHitMonster(Collidable &col, int m, int mindam, int maxdam, bool shift);
 
 extern std::list<Missile> Missiles;
 extern bool MissilePreFlag;

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -143,19 +143,19 @@ public:
 class TrapMissile : public Collidable {
 
 public:
-	int CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster);
-	void HitMonster(int pnum, int mindam, int maxdam, bool shift, int m);
+	int CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster) const;
+	void HitMonster(int pnum, int mindam, int maxdam, bool shift, int m) const ;
 };
 
 class PlayerMissile : public Collidable {
 
 public:
-	int CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster);
-	void HitMonster(int pnum, int mindam, int maxdam, bool shift, int m);
+	int CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster) const;
+	void HitMonster(int pnum, int mindam, int maxdam, bool shift, int m) const;
 };
 
 template <typename Collidable>
-bool TryHitMonster(Collidable &col, int m, int mindam, int maxdam, bool shift);
+bool TryHitMonster(Collidable const &col, int m, int mindam, int maxdam, bool shift);
 
 extern std::list<Missile> Missiles;
 extern bool MissilePreFlag;

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -132,6 +132,26 @@ struct Missile {
 	{
 		return _misource == -1;
 	}
+
+	bool TryHitMonster(int m, int mindam, int maxdam, bool shift);
+
+private:
+	bool IsMonsterPossibleToHit(devilution::Monster &monster) const;
+	virtual int CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster);
+	virtual void HitMonster(int pnum, int mindam, int maxdam, bool shift, int m);
+};
+
+class TrapMissile : public Missile {
+
+public:
+	TrapMissile(const Missile &M)
+	    : Missile(M) {};
+	TrapMissile()
+	    : Missile() {};
+
+private:
+	int CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster) override;
+	void HitMonster(int pnum, int mindam, int maxdam, bool shift, int m) override;
 };
 
 extern std::list<Missile> Missiles;
@@ -160,7 +180,6 @@ int GetSpellLevel(int playerId, spell_id sn);
  * @return the direction of the p1->p2 vector
  */
 Direction16 GetDirection16(Point p1, Point p2);
-bool MonsterTrapHit(int m, int mindam, int maxdam, int dist, missile_id t, bool shift);
 bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, missile_id mtype, bool shift, int earflag, bool *blocked);
 
 /**

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -143,6 +143,10 @@ public:
 class TrapMissile : public Collidable {
 
 public:
+	TrapMissile(Missile missile)
+	{
+		cm = &missile;
+	}
 	int CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster) const;
 	void HitMonster(int pnum, int mindam, int maxdam, bool shift, int m) const ;
 };
@@ -150,6 +154,10 @@ public:
 class PlayerMissile : public Collidable {
 
 public:
+	PlayerMissile(Missile missile)
+	{
+		cm = &missile;
+	}
 	int CalculateCTHAgainstMonster(int pnum, devilution::Monster &monster) const;
 	void HitMonster(int pnum, int mindam, int maxdam, bool shift, int m) const;
 };

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1311,9 +1311,8 @@ void MonsterAttackMonster(int i, int mid, int hper, int mind, int maxd)
 					monster.Petrify();
 			} else {
 				MonsterHitMonster(mid, i, dam);
-				if (monster._mmode == MonsterMode::Petrified) {
+				if (monster._mmode == MonsterMode::Petrified)
 					monster.Petrify();
-				}
 			}
 		}
 	}

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1115,6 +1115,7 @@ void StartMonsterDeath(int i, int pnum, bool sendmsg)
 		PlayEffect(monster, 2);
 
 	Direction md = pnum >= 0 ? GetMonsterDirection(monster) : monster._mdir;
+	bool wasPetrified = (monster._mmode == MonsterMode::Petrified);
 	NewMonsterAnim(monster, MonsterGraphic::Death, md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
 	monster._mmode = MonsterMode::Death;
 	monster._mgoal = MGOAL_NONE;
@@ -1129,6 +1130,8 @@ void StartMonsterDeath(int i, int pnum, bool sendmsg)
 	if ((monster.MType->mtype >= MT_NACID && monster.MType->mtype <= MT_XACID) || monster.MType->mtype == MT_SPIDLORD)
 		AddMissile(monster.position.tile, { 0, 0 }, Direction::South, MIS_ACIDPUD, TARGET_PLAYERS, i, monster._mint + 1, 0);
 	if (monster._mmode == MonsterMode::Petrified)
+		monster.Petrify();
+	if (wasPetrified)
 		monster.Petrify();
 }
 
@@ -1163,7 +1166,7 @@ void StartDeathFromMonster(int i, int mid)
 	Direction md = Opposite(killer._mdir);
 	if (monster.MType->mtype == MT_GOLEM)
 		md = Direction::South;
-
+	bool wasPetrified = (monster._mmode == MonsterMode::Petrified);
 	NewMonsterAnim(monster, MonsterGraphic::Death, md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
 	monster._mmode = MonsterMode::Death;
 	monster.position.offset = { 0, 0 };
@@ -1178,6 +1181,8 @@ void StartDeathFromMonster(int i, int mid)
 
 	if (gbIsHellfire)
 		M_StartStand(killer, killer._mdir);
+	if (wasPetrified)
+		monster.Petrify();
 }
 
 void StartFadein(Monster &monster, Direction md, bool backwards)
@@ -1307,12 +1312,8 @@ void MonsterAttackMonster(int i, int mid, int hper, int mind, int maxd)
 			monster._mhitpoints -= dam;
 			if (monster._mhitpoints >> 6 <= 0) {
 				StartDeathFromMonster(i, mid);
-				if (monster._mmode == MonsterMode::Petrified)
-					monster.Petrify();
 			} else {
 				MonsterHitMonster(mid, i, dam);
-				if (monster._mmode == MonsterMode::Petrified)
-					monster.Petrify();
 			}
 		}
 	}

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1128,6 +1128,8 @@ void StartMonsterDeath(int i, int pnum, bool sendmsg)
 	M_FallenFear(monster.position.tile);
 	if ((monster.MType->mtype >= MT_NACID && monster.MType->mtype <= MT_XACID) || monster.MType->mtype == MT_SPIDLORD)
 		AddMissile(monster.position.tile, { 0, 0 }, Direction::South, MIS_ACIDPUD, TARGET_PLAYERS, i, monster._mint + 1, 0);
+	if (monster._mmode == MonsterMode::Petrified)
+		monster.Petrify();
 }
 
 void StartDeathFromMonster(int i, int mid)
@@ -4072,12 +4074,7 @@ void M_SyncStartKill(int i, Point position, int pnum)
 		monster.position.old = position;
 	}
 
-	if (monster._mmode == MonsterMode::Petrified) {
-		StartMonsterDeath(i, pnum, false);
-		monster.Petrify();
-	} else {
-		StartMonsterDeath(i, pnum, false);
-	}
+	StartMonsterDeath(i, pnum, false);
 }
 
 void M_UpdateLeader(int i)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1306,18 +1306,13 @@ void MonsterAttackMonster(int i, int mid, int hper, int mind, int maxd)
 			int dam = (mind + GenerateRnd(maxd - mind + 1)) << 6;
 			monster._mhitpoints -= dam;
 			if (monster._mhitpoints >> 6 <= 0) {
-				if (monster._mmode == MonsterMode::Petrified) {
-					StartDeathFromMonster(i, mid);
+				StartDeathFromMonster(i, mid);
+				if (monster._mmode == MonsterMode::Petrified)
 					monster.Petrify();
-				} else {
-					StartDeathFromMonster(i, mid);
-				}
 			} else {
+				MonsterHitMonster(mid, i, dam);
 				if (monster._mmode == MonsterMode::Petrified) {
-					MonsterHitMonster(mid, i, dam);
 					monster.Petrify();
-				} else {
-					MonsterHitMonster(mid, i, dam);
 				}
 			}
 		}

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4992,32 +4992,6 @@ void decode_enemy(Monster &monster, int enemyId)
 	}
 }
 
-void StartKillOrHitMonster(int m, int pnum, int dam)
-{
-	auto &monster = Monsters[m];
-
-	if ((monster._mhitpoints >> 6) <= 0) {
-		if (monster._mmode == MonsterMode::Petrified) {
-			M_StartKill(m, pnum);
-			monster.Petrify();
-		} else {
-			M_StartKill(m, pnum);
-		}
-	} else {
-		if (monster._mmode == MonsterMode::Petrified) {
-			M_StartHit(m, pnum, dam);
-			monster.Petrify();
-		} else {
-			if (pnum >= 0) {
-				const auto &player = Players[pnum];
-				if (HasAnyOf(player._pIFlags, ItemSpecialEffect::Knockback))
-					M_GetKnockback(m);
-			}
-			M_StartHit(m, pnum, dam);
-		}
-	}
-}
-
 void Monster::CheckStandAnimationIsLoaded(Direction mdir)
 {
 	if (IsAnyOf(_mmode, MonsterMode::Stand, MonsterMode::Talk)) {

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -258,6 +258,9 @@ struct Monster { // note: missing field _mAFNum
 	 * @brief Is the monster currently walking?
 	 */
 	bool IsWalking() const;
+	bool IsImmune(missile_id mitype) const;
+	bool IsResistant(missile_id mitype) const;
+	bool IsPossibleToHit() const;
 };
 
 extern CMonster LevelMonsterTypes[MAX_LVLMTYPES];
@@ -315,8 +318,9 @@ int PreSpawnSkeleton();
 void TalktoMonster(Monster &monster);
 void SpawnGolem(int i, Point position, Missile &missile);
 bool CanTalkToMonst(const Monster &monster);
-bool CheckMonsterHit(Monster &monster, bool *ret);
+bool LiftGargoylesOrIgnoreMages(Monster &monster, bool *ret);
 int encode_enemy(Monster &monster);
 void decode_enemy(Monster &monster, int enemyId);
+void StartKillOrHitMonster(int m, int pnum, int dam);
 
 } // namespace devilution

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -261,6 +261,7 @@ struct Monster { // note: missing field _mAFNum
 	bool IsImmune(missile_id mitype) const;
 	bool IsResistant(missile_id mitype) const;
 	bool IsPossibleToHit() const;
+	bool TryLiftGargoyle();
 };
 
 extern CMonster LevelMonsterTypes[MAX_LVLMTYPES];
@@ -318,7 +319,6 @@ int PreSpawnSkeleton();
 void TalktoMonster(Monster &monster);
 void SpawnGolem(int i, Point position, Missile &missile);
 bool CanTalkToMonst(const Monster &monster);
-bool LiftGargoylesOrIgnoreMages(Monster &monster, bool *ret);
 int encode_enemy(Monster &monster);
 void decode_enemy(Monster &monster, int enemyId);
 

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -321,6 +321,5 @@ bool CanTalkToMonst(const Monster &monster);
 bool LiftGargoylesOrIgnoreMages(Monster &monster, bool *ret);
 int encode_enemy(Monster &monster);
 void decode_enemy(Monster &monster, int enemyId);
-void StartKillOrHitMonster(int m, int pnum, int dam);
 
 } // namespace devilution

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1597,8 +1597,13 @@ void UpdateFlameTrap(Object &trap)
 
 		int x = trap.position.x;
 		int y = trap.position.y;
-		if (dMonster[x][y] > 0)
-			MonsterTrapHit(dMonster[x][y] - 1, mindam / 2, maxdam / 2, 0, MIS_FIREWALLC, false);
+		if (dMonster[x][y] > 0) {
+			TrapMissile trapDummyMissile = TrapMissile {};
+			trapDummyMissile._midist = 0;
+			trapDummyMissile._misource = -1;
+			trapDummyMissile._mitype = MIS_FIREWALLC;
+			trapDummyMissile.TryHitMonster(dMonster[x][y] - 1, mindam / 2, maxdam / 2, false);
+		}
 		if (dPlayer[x][y] > 0) {
 			bool unused;
 			PlayerMHit(dPlayer[x][y] - 1, nullptr, 0, mindam, maxdam, MIS_FIREWALLC, false, 0, &unused);
@@ -4281,7 +4286,11 @@ void BreakBarrel(int pnum, Object &barrel, int dam, bool forcebreak, bool sendms
 		for (int yp = barrel.position.y - 1; yp <= barrel.position.y + 1; yp++) {
 			for (int xp = barrel.position.x - 1; xp <= barrel.position.x + 1; xp++) {
 				if (dMonster[xp][yp] > 0) {
-					MonsterTrapHit(dMonster[xp][yp] - 1, 1, 4, 0, MIS_FIREBOLT, false);
+					TrapMissile trapDummyMissile = TrapMissile {};
+					trapDummyMissile._midist = 0;
+					trapDummyMissile._misource = -1;
+					trapDummyMissile._mitype = MIS_FIREBOLT;
+					trapDummyMissile.TryHitMonster(dMonster[xp][yp] - 1, 1, 4, false);
 				}
 				if (dPlayer[xp][yp] > 0) {
 					bool unused;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1598,7 +1598,7 @@ void UpdateFlameTrap(Object &trap)
 		int x = trap.position.x;
 		int y = trap.position.y;
 		if (dMonster[x][y] > 0) {
-			TrapMissile trapDummyMissile = TrapMissile { &(Missile {}) };
+			TrapMissile trapDummyMissile = TrapMissile(Missile {});
 			trapDummyMissile.cm->_midist = 0;
 			trapDummyMissile.cm->_misource = -1;
 			trapDummyMissile.cm->_mitype = MIS_FIREWALLC;
@@ -4286,7 +4286,7 @@ void BreakBarrel(int pnum, Object &barrel, int dam, bool forcebreak, bool sendms
 		for (int yp = barrel.position.y - 1; yp <= barrel.position.y + 1; yp++) {
 			for (int xp = barrel.position.x - 1; xp <= barrel.position.x + 1; xp++) {
 				if (dMonster[xp][yp] > 0) {
-					TrapMissile trapDummyMissile = TrapMissile { &(Missile {}) };
+					TrapMissile trapDummyMissile = TrapMissile(Missile {});
 					trapDummyMissile.cm->_midist = 0;
 					trapDummyMissile.cm->_misource = -1;
 					trapDummyMissile.cm->_mitype = MIS_FIREBOLT;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1598,11 +1598,11 @@ void UpdateFlameTrap(Object &trap)
 		int x = trap.position.x;
 		int y = trap.position.y;
 		if (dMonster[x][y] > 0) {
-			TrapMissile trapDummyMissile = TrapMissile {};
-			trapDummyMissile._midist = 0;
-			trapDummyMissile._misource = -1;
-			trapDummyMissile._mitype = MIS_FIREWALLC;
-			trapDummyMissile.TryHitMonster(dMonster[x][y] - 1, mindam / 2, maxdam / 2, false);
+			TrapMissile trapDummyMissile = TrapMissile { &(Missile {}) };
+			trapDummyMissile.cm->_midist = 0;
+			trapDummyMissile.cm->_misource = -1;
+			trapDummyMissile.cm->_mitype = MIS_FIREWALLC;
+			TryHitMonster(trapDummyMissile, dMonster[x][y] - 1, mindam / 2, maxdam / 2, false);
 		}
 		if (dPlayer[x][y] > 0) {
 			bool unused;
@@ -4286,11 +4286,11 @@ void BreakBarrel(int pnum, Object &barrel, int dam, bool forcebreak, bool sendms
 		for (int yp = barrel.position.y - 1; yp <= barrel.position.y + 1; yp++) {
 			for (int xp = barrel.position.x - 1; xp <= barrel.position.x + 1; xp++) {
 				if (dMonster[xp][yp] > 0) {
-					TrapMissile trapDummyMissile = TrapMissile {};
-					trapDummyMissile._midist = 0;
-					trapDummyMissile._misource = -1;
-					trapDummyMissile._mitype = MIS_FIREBOLT;
-					trapDummyMissile.TryHitMonster(dMonster[xp][yp] - 1, 1, 4, false);
+					TrapMissile trapDummyMissile = TrapMissile { &(Missile {}) };
+					trapDummyMissile.cm->_midist = 0;
+					trapDummyMissile.cm->_misource = -1;
+					trapDummyMissile.cm->_mitype = MIS_FIREBOLT;
+					TryHitMonster(trapDummyMissile, dMonster[xp][yp] - 1, 1, 4, false);
 				}
 				if (dPlayer[xp][yp] > 0) {
 					bool unused;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1598,11 +1598,11 @@ void UpdateFlameTrap(Object &trap)
 		int x = trap.position.x;
 		int y = trap.position.y;
 		if (dMonster[x][y] > 0) {
-			TrapMissile trapDummyMissile = TrapMissile(Missile {});
+			TrapMissile trapDummyMissile = TrapMissile((Missile {}), mindam / 2, maxdam / 2, false);
 			trapDummyMissile.cm->_midist = 0;
 			trapDummyMissile.cm->_misource = -1;
 			trapDummyMissile.cm->_mitype = MIS_FIREWALLC;
-			TryHitMonster(trapDummyMissile, dMonster[x][y] - 1, mindam / 2, maxdam / 2, false);
+			TryHitMonster(trapDummyMissile, dMonster[x][y] - 1);
 		}
 		if (dPlayer[x][y] > 0) {
 			bool unused;
@@ -4286,11 +4286,11 @@ void BreakBarrel(int pnum, Object &barrel, int dam, bool forcebreak, bool sendms
 		for (int yp = barrel.position.y - 1; yp <= barrel.position.y + 1; yp++) {
 			for (int xp = barrel.position.x - 1; xp <= barrel.position.x + 1; xp++) {
 				if (dMonster[xp][yp] > 0) {
-					TrapMissile trapDummyMissile = TrapMissile(Missile {});
+					TrapMissile trapDummyMissile = TrapMissile((Missile {}), 1, 4, false);
 					trapDummyMissile.cm->_midist = 0;
 					trapDummyMissile.cm->_misource = -1;
 					trapDummyMissile.cm->_mitype = MIS_FIREBOLT;
-					TryHitMonster(trapDummyMissile, dMonster[xp][yp] - 1, 1, 4, false);
+					TryHitMonster(trapDummyMissile, dMonster[xp][yp] - 1);
 				}
 				if (dPlayer[xp][yp] > 0) {
 					bool unused;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -823,17 +823,8 @@ bool PlrHitMonst(int pnum, int m, bool adjacentDamage = false)
 	}
 	auto &player = Players[pnum];
 
-	if ((monster._mhitpoints >> 6) <= 0) {
+	if (!monster.IsPossibleToHit())
 		return false;
-	}
-
-	if (monster.MType->mtype == MT_ILLWEAV && monster._mgoal == MGOAL_RETREAT) {
-		return false;
-	}
-
-	if (monster._mmode == MonsterMode::Charge) {
-		return false;
-	}
 
 	if (adjacentDamage) {
 		if (player._pLevel > 20)
@@ -851,7 +842,7 @@ bool PlrHitMonst(int pnum, int m, bool adjacentDamage = false)
 	hper = clamp(hper, 5, 95);
 
 	bool ret = false;
-	if (CheckMonsterHit(monster, &ret)) {
+	if (LiftGargoylesOrIgnoreMages(monster, &ret)) {
 		return ret;
 	}
 
@@ -994,24 +985,7 @@ bool PlrHitMonst(int pnum, int m, bool adjacentDamage = false)
 		monster._mhitpoints = 0; /* double check */
 	}
 #endif
-	if ((monster._mhitpoints >> 6) <= 0) {
-		if (monster._mmode == MonsterMode::Petrified) {
-			M_StartKill(m, pnum);
-			monster.Petrify();
-		} else {
-			M_StartKill(m, pnum);
-		}
-	} else {
-		if (monster._mmode == MonsterMode::Petrified) {
-			M_StartHit(m, pnum, dam);
-			monster.Petrify();
-		} else {
-			if (HasAnyOf(player._pIFlags, ItemSpecialEffect::Knockback)) {
-				M_GetKnockback(m);
-			}
-			M_StartHit(m, pnum, dam);
-		}
-	}
+	StartKillOrHitMonster(m, pnum, dam);
 
 	return true;
 }

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -985,7 +985,24 @@ bool PlrHitMonst(int pnum, int m, bool adjacentDamage = false)
 		monster._mhitpoints = 0; /* double check */
 	}
 #endif
-	StartKillOrHitMonster(m, pnum, dam);
+	if ((monster._mhitpoints >> 6) <= 0) {
+		if (monster._mmode == MonsterMode::Petrified) {
+			M_StartKill(m, pnum);
+			monster.Petrify();
+		} else {
+			M_StartKill(m, pnum);
+		}
+	} else {
+		if (monster._mmode == MonsterMode::Petrified) {
+			M_StartHit(m, pnum, dam);
+			monster.Petrify();
+		} else {
+			if (HasAnyOf(player._pIFlags, ItemSpecialEffect::Knockback)) {
+				M_GetKnockback(m);
+			}
+			M_StartHit(m, pnum, dam);
+		}
+	}
 
 	return true;
 }

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -989,8 +989,6 @@ bool PlrHitMonst(int pnum, int m, bool adjacentDamage = false)
 		if (!(monster._mmode == MonsterMode::Petrified) && HasAnyOf(player._pIFlags, ItemSpecialEffect::Knockback))
 			M_GetKnockback(m);
 		M_StartHit(m, pnum, dam);
-		if (monster._mmode == MonsterMode::Petrified)
-			monster.Petrify();
 	}
 
 	return true;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -986,22 +986,15 @@ bool PlrHitMonst(int pnum, int m, bool adjacentDamage = false)
 	}
 #endif
 	if ((monster._mhitpoints >> 6) <= 0) {
-		if (monster._mmode == MonsterMode::Petrified) {
-			M_StartKill(m, pnum);
+		M_StartKill(m, pnum);
+		if (monster._mmode == MonsterMode::Petrified)
 			monster.Petrify();
-		} else {
-			M_StartKill(m, pnum);
-		}
 	} else {
-		if (monster._mmode == MonsterMode::Petrified) {
-			M_StartHit(m, pnum, dam);
+		if (!(monster._mmode == MonsterMode::Petrified) && HasAnyOf(player._pIFlags, ItemSpecialEffect::Knockback))
+			M_GetKnockback(m);
+		M_StartHit(m, pnum, dam);
+		if (monster._mmode == MonsterMode::Petrified)
 			monster.Petrify();
-		} else {
-			if (HasAnyOf(player._pIFlags, ItemSpecialEffect::Knockback)) {
-				M_GetKnockback(m);
-			}
-			M_StartHit(m, pnum, dam);
-		}
 	}
 
 	return true;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -985,8 +985,6 @@ bool PlrHitMonst(int pnum, int m, bool adjacentDamage = false)
 #endif
 	if ((monster._mhitpoints >> 6) <= 0) {
 		M_StartKill(m, pnum);
-		if (monster._mmode == MonsterMode::Petrified)
-			monster.Petrify();
 	} else {
 		if (!(monster._mmode == MonsterMode::Petrified) && HasAnyOf(player._pIFlags, ItemSpecialEffect::Knockback))
 			M_GetKnockback(m);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -841,10 +841,8 @@ bool PlrHitMonst(int pnum, int m, bool adjacentDamage = false)
 	hper += player.GetMeleePiercingToHit() - player.CalculateArmorPierce(monster.mArmorClass, true);
 	hper = clamp(hper, 5, 95);
 
-	bool ret = false;
-	if (LiftGargoylesOrIgnoreMages(monster, &ret)) {
-		return ret;
-	}
+	if (monster.TryLiftGargoyle())
+		return true;
 
 	if (hit >= hper) {
 #ifdef _DEBUG


### PR DESCRIPTION
In this PR I have tried to refactor `MonsterMHit` function as a contrubution to Issue #2350.

While refactoring I noticed a lot of similiar code with `MonsterTrapHit` function.
Both functions are called twice in `CheckMissileCol` function, and trap called twice from object.cpp.
To get rid of duplicated code I used [Template Method](https://refactoring.guru/design-patterns/template-method) [pattern](https://sourcemaking.com/design_patterns/template_method).

Result: 2 functions `MonsterMHit` and `MonsterTrapHit` are now merged into `TryHitMonster`.
The number of parameters from 7 and 6 parameters has been reduced to 4 with the possibility of further reduction (read below).
The complexity of the function has been significantly reduced (from 120 + 75 to 26 lines) thanks to the function extraction. This makes it more legible and polite.
This PR should not make any changes to the game logic or fix any bugs. (I hope).

##### Details:
With Template Method as a method to solve the code duplication problem, I had to use some polymorphism.
I created 2 child classes, `PlayerMissile` and` TrapMissile`, for code that differs between them, and the rest of the code is part of `Missile` as its method.

In 2 additional places in `objects.cpp` in `BreakBarrel` and `UpdateFlameTrapthere` there are calls to `MonsterTrapHit`, without creating real missile. To unify this function calls with refactored code, I added dummy missiles without adding them to the Missiles array - just for calling method purpose. They should only live in scope of these methods. To make this possible I had to provide `TrapMissile` class accessible as part of header file `missiles.h`.

I found that some code were so closely related to monster, that I transferred them to monsters.cpp and made them as Monster methods. It simplified the code in terms of number of parameters, and aslo get rid of some duplicates (as in `player.cpp` 's `PlrHitMonst` ).


##### Further refactoring steps:
As you may guess from examining the code, this is not exactly how to implement Template Method pattern in perfect world. Actually the `Missile` should be abstract class with virtual methods declared as pure virtuals. But I couldn't do that, yet, because Missile is beeing initialized, not its child classes.
Therefore, I had to create converting costructors that I use in `CheckMissileCol` (can't downcast). For this reason, I had to put 2 placeholder definitions for `CalculateCTHAgainstMonster` and `HitMonster`. 
Probably further refactoring this domain would make `MonsterMissile` as well, and later initialize each missile the missile as child of `Missile` in `AddMissile`. Consequently, no placeholder would be needed, as `Missile` may be abstract, as it would have some pure virtual methods.

A further reduction in the number of parameterswould be draw mindam and maxdam into missile structure.
For now, missile struct has only single `_midam`, and damage is calculated in several places, often without even updating this member variable. I would do it maybe another time, but I am afraid that this would break savegames compatibility or something. Can someone confirm this? We could also get rid of "shift" here at least as a function parameter.

I really don't like what `CheckMonsterHit` function was, what it's called, how it's used, what it does and how, but I excluded it from the scope of this PR. It is used in several places. For sure extra caution has to be taken when dealing with it. 
Its name was so misleading that I changed it to more informative  `LiftGargoylesOrIgnoreMages`.
To make sure the game behaves exactly as vanilla (at least no changes in this PR to game logic), I left the calls to it in the same places, to ensure random number is generated when missile hit mage with goal different than normal. Normally I would check for that before calculating Chance To Hit (and split gargloyle logic from mages). 
Maybe another time.

I wish I could pass monster "as reference" to functions more times (mostly in `StartKillOrHitMonster` part), but there are so many places the index is needed, that I left this out of scope. 

###### Additional Notes:
All the changes do not change anything in the mechanics of  Diablo or Hellfire, but due to unification of code and getting rid of duplicates I decided as follows:
- traps now check if monster is immune to Holy Bolt (but there is no Holy Bolt trap).
- traps now checks for acid resistance (but there is no single acid element missile in entire game (acid spitters damage is magic type)

It makes more sense to me to leave this in code, and you can use it for mods as well.

##### Bottom line
This is my frist PR. I have no practical programming experience, especially in the field of C/C++.  (Usually I read code only). I am still learing. I am open to critique. And I hope you help me to get this merged.