### PR TITLE
Fix condition for set pieces in AddL2Torches()

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -568,7 +568,7 @@ void AddL2Torches()
 	for (int j = 0; j < MAXDUNY; j++) {
 		for (int i = 0; i < MAXDUNX; i++) {
 			Point testPosition = { i, j };
-			if (!TileContainsSetPiece(testPosition))
+			if (TileContainsSetPiece(testPosition))
 				continue;
 
 			int pn = dPiece[i][j];


### PR DESCRIPTION
Fixes an issue reported by NickGavran on Discord.

> ![image](https://user-images.githubusercontent.com/9203145/168406641-3b70507b-dee8-426b-9d1c-b0e79999e707.png)
> Is it normal that the halls of the blind can spawn with torches on its walls? Asking about vanilla and about devilx (Screenshot 
> was taken from a random stream I stumbled upon playing Devilx) 
> These torches are not there in the .dun file
> Watching several vanilla playthroughs of this, they do not produce any torches whatsoever 

The condition seems to have been mistakenly flipped by 099fad5.