### PR TITLE
Refill smith premium items in a single pass

### DIFF
--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -35,8 +35,8 @@ Item storehold[48];
 
 Item smithitem[SMITH_ITEMS];
 int numpremium;
-int premiumlevel;
-Item premiumitems[SMITH_PREMIUM_ITEMS];
+int8_t premiumlevel;
+std::array<Item, SMITH_PREMIUM_ITEMS> premiumitems;
 
 Item healitem[20];
 

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -81,10 +81,10 @@ extern DVL_API_FOR_TEST Item storehold[48];
 extern Item smithitem[SMITH_ITEMS];
 /** Number of premium items for sale by Griswold */
 extern int numpremium;
-/** Base level of current premium items sold by Griswold */
-extern int premiumlevel;
+/** Character level used when Griswold last refreshed his premium item stock */
+extern int8_t premiumlevel;
 /** Premium items sold by Griswold */
-extern Item premiumitems[SMITH_PREMIUM_ITEMS];
+extern std::array<Item, SMITH_PREMIUM_ITEMS> premiumitems;
 
 /** Items sold by Pepin */
 extern Item healitem[20];


### PR DESCRIPTION
Got deadset on implementing this so here we go.

When loading a game from the main menu SmithPremium gets called with premiumlevel == 1 and numpremiums == 0. For a level 50 character in a Hellfire game it ended up running through the item generation code 15 + 3 * 49 times (to initialise the array then rolling 3 new items for every character level beyond the first). This code rolls at most 15 items.

Annoyingly loading a game from a save (i.e. load game, not new game) the premium items get overwritten by whatever was in the save file so this is still being performed unnecessarily in those cases.

~Also looks like there might've been a bug with the way items were generated in old saves? I have a level 7 character which has items of ilvl 5 in the premium items list. The lowest item level for that character level should be 6. This ends up causing more items than expected to get replaced when I buy something after loading that save file. It's 3am though so not gonna debug that more at the moment.~ edit: bitten by the dodgy reroll/level up code used by Hellfire logic, see Stephen's comment for details.