### PR TITLE
slide belt items down when consumed

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -2045,6 +2045,20 @@ bool UseInvItem(int pnum, int cii)
 				break;
 			}
 		}
+
+		// If speedlist item is not inventory, use same item at the end of the speedlist if exists.
+		if (speedlist && *sgOptions.Gameplay.autoRefillBelt) {
+			for (int i = INVITEM_BELT_LAST - INVITEM_BELT_FIRST; i > c; i--) {
+				Item &candidate = player.SpdList[i];
+
+				if (!candidate.isEmpty() && candidate._iMiscId == item->_iMiscId && candidate._iSpell == item->_iSpell) {
+					c = i;
+					item = &candidate;
+					break;
+				}
+			}
+		}
+
 	}
 
 	constexpr int SpeechDelay = 10;


### PR DESCRIPTION
If multiple items of the same type are on the belt and one is consumed, then the one further down the belt is used.  This change is in tandem with the AutoRefillBelt from inventory feature.  It's purpose is to reduce the amount of hunting for the correct hotkey on the belt so that items can be used hitting the same key.  It may help address the shock of no more potions available 
https://github.com/diasurgical/devilutionX/pull/983#issuecomment-765237425
Consider the case where the belt is full of full healing potion and the inventory is now out.  Player uses belt slot1, causing slot 8 to be used. Player can notice belt depleting, but can keep finger near the same hotkey, instead of hitting slot1 only to notice too late that it's empty.

![beltslide2](https://user-images.githubusercontent.com/24440637/168450442-140d92bd-d7d8-4952-a9e4-731ebe50c882.gif)
![beltslide3](https://user-images.githubusercontent.com/24440637/168450573-15042111-f268-4f66-aa59-5d92f817304a.gif)

