### PR TITLE
Enable gcov support in codecov uploader

### DIFF
--- a/.github/workflows/Linux_x86_64_test.yml
+++ b/.github/workflows/Linux_x86_64_test.yml
@@ -35,5 +35,6 @@ jobs:
       - name: Run tests
         run: cd build && ctest --output-on-failure
       - name: Upload results
-        uses: codecov/codecov-action@v2
-        # using default arguments, no token required for public repos
+        uses: codecov/codecov-action@v3
+        with:
+          gcov: true


### PR DESCRIPTION
Doesn't appear to be active by default? Maybe this is why the reports weren't being uploaded