### PR TITLE
Remove emoji from cmake output

### DIFF
--- a/CMake/functions/dependency_options.cmake
+++ b/CMake/functions/dependency_options.cmake
@@ -30,5 +30,5 @@ function(dependency_options LIB_NAME SYSTEM_OPTION_NAME DEFAULT_SYSTEM_VALUE STA
   else()
     set(_msg_source "library from source")
   endif()
-  message("-- 📚 ${LIB_NAME}: ${_msg_type} ${_msg_source}")
+  message("-- ${LIB_NAME}: ${_msg_type} ${_msg_source}")
 endfunction()


### PR DESCRIPTION
This requires advanced unicode support and compatible fonts, so it's likely that more people see it like garbage than as a library icon
![2022-05-17-172622_maim](https://user-images.githubusercontent.com/474217/168835631-6573a1a6-cde5-4126-9081-9c5128ae752a.png)
![2022-05-17-172839_maim](https://user-images.githubusercontent.com/474217/168835830-67c629ef-a4fb-47cd-ba40-da7173464fce.png)
![2022-05-17-172939_maim](https://user-images.githubusercontent.com/474217/168836045-8329e5a9-49a7-4bad-a88d-93c86d5b1028.png)
