### PR TITLE
Fix link with disabled sound

### DIFF
--- a/Source/sound.h
+++ b/Source/sound.h
@@ -51,7 +51,11 @@ struct TSnd {
 };
 
 extern bool gbSndInited;
+#ifndef NOSOUND
 extern _music_id sgnMusicTrack;
+#else
+inline const _music_id sgnMusicTrack = NUM_MUSIC;
+#endif
 
 void ClearDuplicateSounds();
 void snd_stop_snd(TSnd *pSnd);


### PR DESCRIPTION
sgnMusicTrack is used from diablo.cpp regardless of NOSOUND value, so provide a constant dummy value