### PR TITLE
Remove redundant "on Linux" from .desktop file comments

### DIFF
--- a/Packaging/nix/devilutionx-hellfire.desktop
+++ b/Packaging/nix/devilutionx-hellfire.desktop
@@ -1,10 +1,10 @@
 [Desktop Entry]
 Name=DevilutionX Hellfire
 GenericName=DevilutionX Hellfire
-Comment=Play Diablo: Hellfire on Linux
-Comment[da]=Spil Diablo: Hellfire på Linux
-Comment[hr]=Igrajte Diablo: Hellfire na Linuxu
-Comment[it]=Gioca a Diablo: Hellfire su Linux
+Comment=Play Diablo: Hellfire
+Comment[da]=Spil Diablo: Hellfire
+Comment[hr]=Igrajte Diablo: Hellfire
+Comment[it]=Gioca a Diablo: Hellfire
 Exec=devilutionx --hellfire
 Icon=devilutionx-hellfire
 Terminal=false

--- a/Packaging/nix/devilutionx.desktop
+++ b/Packaging/nix/devilutionx.desktop
@@ -1,10 +1,10 @@
 [Desktop Entry]
 Name=DevilutionX
 GenericName=DevilutionX
-Comment=Play Diablo I on Linux
-Comment[da]=Spil Diablo I på Linux
-Comment[hr]=Igrajte Diablo I na Linuxu
-Comment[it]=Gioca a Diablo I su Linux
+Comment=Play Diablo I
+Comment[da]=Spil Diablo I
+Comment[hr]=Igrajte Diablo I
+Comment[it]=Gioca a Diablo I
 Exec=devilutionx --diablo
 Icon=devilutionx
 Terminal=false


### PR DESCRIPTION
Not sure if it's the best solution. The thing is that I use these nix .desktop files for FreeBSD packaging where `on Linux` clause does not apply. I could copy .desktop files for e.g. Packaging/bsd, however IMO it would be better to avoid duplication, and just remove the clause, as even on Linux it's redundant.