### PR TITLE
Fix item label text with open stash

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -10,8 +10,6 @@
 #include "control.h"
 #include "engine/load_file.hpp"
 #include "engine/render/automap_render.hpp"
-#include "inv.h"
-#include "monster.h"
 #include "palette.h"
 #include "player.h"
 #include "setmaps.h"
@@ -376,9 +374,9 @@ void SearchAutomapItem(const Surface &out, const Displacement &myPlayerOffset)
 			};
 
 			if (CanPanelsCoverView()) {
-				if (invflag || sbookflag)
+				if (IsRightPanelOpen())
 					screen.x -= 160;
-				if (chrflag || QuestLogIsOpen)
+				if (IsLeftPanelOpen())
 					screen.x += 160;
 			}
 			screen.y -= AmLine8;
@@ -413,9 +411,9 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, int 
 	};
 
 	if (CanPanelsCoverView()) {
-		if (invflag || sbookflag)
+		if (IsRightPanelOpen())
 			base.x -= gnScreenWidth / 4;
-		if (chrflag || QuestLogIsOpen)
+		if (IsLeftPanelOpen())
 			base.x += gnScreenWidth / 4;
 	}
 	base.y -= AmLine16;
@@ -705,10 +703,10 @@ void DrawAutomap(const Surface &out)
 	screen.y += AutoMapScale * myPlayerOffset.deltaY / 100 / 2;
 
 	if (CanPanelsCoverView()) {
-		if (invflag || sbookflag) {
+		if (IsRightPanelOpen()) {
 			screen.x -= gnScreenWidth / 4;
 		}
-		if (chrflag || QuestLogIsOpen) {
+		if (IsLeftPanelOpen()) {
 			screen.x += gnScreenWidth / 4;
 		}
 	}

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -97,6 +97,14 @@ const Rectangle &GetRightPanel()
 {
 	return RightPanel;
 }
+bool IsLeftPanelOpen()
+{
+	return chrflag || QuestLogIsOpen || IsStashOpen;
+}
+bool IsRightPanelOpen()
+{
+	return invflag || sbookflag;
+}
 
 /** Maps from attribute_id to the rectangle on screen used for attribute increment buttons. */
 Rectangle ChrBtnsRect[4] = {
@@ -998,13 +1006,13 @@ void DrawDurIcon(const Surface &out)
 	bool hasRoomUnderPanels = MainPanel.position.y - (RightPanel.position.y + RightPanel.size.height) >= 16 + 32 + 16;
 
 	if (!hasRoomBetweenPanels && !hasRoomUnderPanels) {
-		if ((chrflag || QuestLogIsOpen || IsStashOpen) && (invflag || sbookflag))
+		if (IsLeftPanelOpen() && IsRightPanelOpen())
 			return;
 	}
 
 	int x = MainPanel.position.x + MainPanel.size.width - 32 - 16;
 	if (!hasRoomUnderPanels) {
-		if ((invflag || sbookflag) && MainPanel.position.x + MainPanel.size.width > RightPanel.position.x)
+		if (IsRightPanelOpen() && MainPanel.position.x + MainPanel.size.width > RightPanel.position.x)
 			x -= MainPanel.position.x + MainPanel.size.width - RightPanel.position.x;
 	}
 

--- a/Source/control.h
+++ b/Source/control.h
@@ -56,6 +56,8 @@ extern bool spselflag;
 const Rectangle &GetMainPanel();
 const Rectangle &GetLeftPanel();
 const Rectangle &GetRightPanel();
+bool IsLeftPanelOpen();
+bool IsRightPanelOpen();
 extern std::optional<OwnedSurface> pBtmBuff;
 extern std::optional<OwnedCelSprite> pGBoxBuff;
 extern SDL_Rect PanBtnPos[8];

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -258,9 +258,9 @@ void CheckCursMove()
 	int sy = MousePosition.y;
 
 	if (CanPanelsCoverView()) {
-		if (chrflag || QuestLogIsOpen || IsStashOpen) {
+		if (IsLeftPanelOpen()) {
 			sx -= GetScreenWidth() / 4;
-		} else if (invflag || sbookflag) {
+		} else if (IsRightPanelOpen()) {
 			sx += GetScreenWidth() / 4;
 		}
 	}
@@ -395,7 +395,7 @@ void CheckCursMove()
 	if (sbookflag && GetRightPanel().Contains(MousePosition)) {
 		return;
 	}
-	if ((chrflag || QuestLogIsOpen || IsStashOpen) && GetLeftPanel().Contains(MousePosition)) {
+	if (IsLeftPanelOpen() && GetLeftPanel().Contains(MousePosition)) {
 		return;
 	}
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -431,9 +431,9 @@ void ReleaseKey(int vkey)
 void ClosePanels()
 {
 	if (CanPanelsCoverView()) {
-		if (!chrflag && !QuestLogIsOpen && !IsStashOpen && (invflag || sbookflag) && MousePosition.x < 480 && MousePosition.y < PANEL_TOP) {
+		if (!IsLeftPanelOpen() && IsRightPanelOpen() && MousePosition.x < 480 && MousePosition.y < PANEL_TOP) {
 			SetCursorPos(MousePosition + Displacement { 160, 0 });
-		} else if (!invflag && !sbookflag && (chrflag || QuestLogIsOpen) && MousePosition.x > 160 && MousePosition.y < PANEL_TOP) {
+		} else if (!IsRightPanelOpen() && IsLeftPanelOpen() && MousePosition.x > 160 && MousePosition.y < PANEL_TOP) {
 			SetCursorPos(MousePosition - Displacement { 160, 0 });
 		}
 	}
@@ -1346,7 +1346,7 @@ void InventoryKeyPressed()
 	if (stextflag != STORE_NONE)
 		return;
 	invflag = !invflag;
-	if (!chrflag && !QuestLogIsOpen && !IsStashOpen && CanPanelsCoverView()) {
+	if (!IsLeftPanelOpen() && CanPanelsCoverView()) {
 		if (!invflag) { // We closed the invetory
 			if (MousePosition.x < 480 && MousePosition.y < GetMainPanel().position.y) {
 				SetCursorPos(MousePosition + Displacement { 160, 0 });
@@ -1367,7 +1367,7 @@ void CharacterSheetKeyPressed()
 	if (stextflag != STORE_NONE)
 		return;
 	chrflag = !chrflag;
-	if (!invflag && !sbookflag && CanPanelsCoverView()) {
+	if (!IsRightPanelOpen() && CanPanelsCoverView()) {
 		if (!chrflag) { // We closed the character sheet
 			if (MousePosition.x > 160 && MousePosition.y < GetMainPanel().position.y) {
 				SetCursorPos(MousePosition - Displacement { 160, 0 });
@@ -1392,7 +1392,7 @@ void QuestLogKeyPressed()
 	} else {
 		QuestLogIsOpen = false;
 	}
-	if (!invflag && !sbookflag && CanPanelsCoverView()) {
+	if (!IsRightPanelOpen() && CanPanelsCoverView()) {
 		if (!QuestLogIsOpen) { // We closed the quest log
 			if (MousePosition.x > 160 && MousePosition.y < PANEL_TOP) {
 				SetCursorPos(MousePosition - Displacement { 160, 0 });
@@ -1429,7 +1429,7 @@ void SpellBookKeyPressed()
 	if (stextflag != STORE_NONE)
 		return;
 	sbookflag = !sbookflag;
-	if (!chrflag && !QuestLogIsOpen && CanPanelsCoverView()) {
+	if (!IsLeftPanelOpen() && CanPanelsCoverView()) {
 		if (!sbookflag) { // We closed the invetory
 			if (MousePosition.x < 480 && MousePosition.y < GetMainPanel().position.y) {
 				SetCursorPos(MousePosition + Displacement { 160, 0 });
@@ -2032,7 +2032,7 @@ bool PressEscKey()
 		rv = true;
 	}
 
-	if (invflag || chrflag || sbookflag || QuestLogIsOpen) {
+	if (IsLeftPanelOpen() || IsRightPanelOpen()) {
 		ClosePanels();
 		rv = true;
 	}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3736,7 +3736,7 @@ bool DoOil(Player &player, int cii)
 void DrawUniqueInfo(const Surface &out)
 {
 	const Point position = GetRightPanel().position - Displacement { SPANEL_WIDTH, 0 };
-	if ((chrflag || QuestLogIsOpen || IsStashOpen) && GetLeftPanel().Contains(position)) {
+	if (IsLeftPanelOpen() && GetLeftPanel().Contains(position)) {
 		return;
 	}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3572,8 +3572,8 @@ void CheckPlrSpell(bool isShiftHeld, spell_id spellID, spell_type spellType)
 			return;
 
 		if (
-		    ((chrflag || QuestLogIsOpen || IsStashOpen) && GetLeftPanel().Contains(MousePosition)) // inside left panel
-		    || ((invflag || sbookflag) && GetRightPanel().Contains(MousePosition))                 // inside right panel
+		    (IsLeftPanelOpen() && GetLeftPanel().Contains(MousePosition))      // inside left panel
+		    || (IsRightPanelOpen() && GetRightPanel().Contains(MousePosition)) // inside right panel
 		) {
 			if (spellID != SPL_HEAL
 			    && spellID != SPL_IDENTIFY

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -104,11 +104,11 @@ void DrawPlrMsg(const Surface &out)
 	int y = PANEL_TOP - 13;
 	int width = gnScreenWidth - 20;
 
-	if (!talkflag && (chrflag || QuestLogIsOpen || IsStashOpen)) {
+	if (!talkflag && IsLeftPanelOpen()) {
 		x += GetLeftPanel().position.x + GetLeftPanel().size.width;
 		width -= GetLeftPanel().size.width;
 	}
-	if (!talkflag && (invflag || sbookflag))
+	if (!talkflag && IsRightPanelOpen())
 		width -= gnScreenWidth - GetRightPanel().position.x;
 
 	if (width < 300)

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -95,9 +95,9 @@ void AddItemToLabelQueue(int id, int x, int y)
 
 bool IsMouseOverGameArea()
 {
-	if ((invflag || sbookflag) && GetRightPanel().Contains(MousePosition))
+	if ((IsRightPanelOpen()) && GetRightPanel().Contains(MousePosition))
 		return false;
-	if ((chrflag || QuestLogIsOpen || IsStashOpen) && GetLeftPanel().Contains(MousePosition))
+	if ((IsLeftPanelOpen()) && GetLeftPanel().Contains(MousePosition))
 		return false;
 	if (GetMainPanel().Contains(MousePosition))
 		return false;

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -13,6 +13,7 @@
 #include "gmenu.h"
 #include "inv.h"
 #include "itemlabels.h"
+#include "qol/stash.h"
 #include "utils/language.h"
 #include "utils/stdcompat/string_view.hpp"
 
@@ -96,7 +97,7 @@ bool IsMouseOverGameArea()
 {
 	if ((invflag || sbookflag) && GetRightPanel().Contains(MousePosition))
 		return false;
-	if ((chrflag || QuestLogIsOpen) && GetLeftPanel().Contains(MousePosition))
+	if ((chrflag || QuestLogIsOpen || IsStashOpen) && GetLeftPanel().Contains(MousePosition))
 		return false;
 	if (GetMainPanel().Contains(MousePosition))
 		return false;

--- a/Source/qol/monhealthbar.cpp
+++ b/Source/qol/monhealthbar.cpp
@@ -79,9 +79,9 @@ void DrawMonsterHealthBar(const Surface &out)
 	Point position = { (gnScreenWidth - width) / 2, 18 };
 
 	if (CanPanelsCoverView()) {
-		if (invflag || sbookflag)
+		if (IsRightPanelOpen())
 			position.x -= SPANEL_WIDTH / 2;
-		if (chrflag || QuestLogIsOpen)
+		if (IsLeftPanelOpen())
 			position.x += SPANEL_WIDTH / 2;
 	}
 

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1026,10 +1026,10 @@ void Zoom(const Surface &out)
 	int viewportWidth = out.w();
 	int viewportOffsetX = 0;
 	if (CanPanelsCoverView()) {
-		if (chrflag || QuestLogIsOpen || IsStashOpen) {
+		if (IsLeftPanelOpen()) {
 			viewportWidth -= SPANEL_WIDTH;
 			viewportOffsetX = SPANEL_WIDTH;
-		} else if (invflag || sbookflag) {
+		} else if (IsRightPanelOpen()) {
 			viewportWidth -= SPANEL_WIDTH;
 		}
 	}
@@ -1106,23 +1106,23 @@ void DrawGame(const Surface &fullOut, Point position)
 	// Skip rendering parts covered by the panels
 	if (CanPanelsCoverView()) {
 		if (zoomflag) {
-			if (chrflag || QuestLogIsOpen || IsStashOpen) {
+			if (IsLeftPanelOpen()) {
 				position += Displacement(Direction::East) * 2;
 				columns -= 4;
 				sx += SPANEL_WIDTH - TILE_WIDTH / 2;
 			}
-			if (invflag || sbookflag) {
+			if (IsRightPanelOpen()) {
 				position += Displacement(Direction::East) * 2;
 				columns -= 4;
 				sx += -TILE_WIDTH / 2;
 			}
 		} else {
-			if (chrflag || QuestLogIsOpen || IsStashOpen) {
+			if (IsLeftPanelOpen()) {
 				position += Direction::East;
 				columns -= 2;
 				sx += -TILE_WIDTH / 2 / 2; // SPANEL_WIDTH accounted for in Zoom()
 			}
-			if (invflag || sbookflag) {
+			if (IsRightPanelOpen()) {
 				position += Direction::East;
 				columns -= 2;
 				sx += -TILE_WIDTH / 2 / 2;


### PR DESCRIPTION
First commit fixes #4584
Second commit is a refactoring that should make future panels (inspect player) more easy to add.
The refactoring doesn't include the `controls` folder (touch and gamepad), cause I didn't want to refactor something that I didn't test. If someone is willing to test it, I can also change this part.