### PR TITLE
Monster death

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4999,13 +4999,11 @@ bool Monster::IsResistant(missile_id mName) const
 
 bool Monster::IsPossibleToHit() const
 {
-	if (_mhitpoints >> 6 <= 0
+	return !(_mhitpoints >> 6 <= 0
 	    || mtalkmsg != TEXT_NONE
-	    || MType->mtype == MT_ILLWEAV && _mgoal == MGOAL_RETREAT
+	    || (MType->mtype == MT_ILLWEAV && _mgoal == MGOAL_RETREAT)
 	    || _mmode == MonsterMode::Charge
-	    || MType->mtype >= MT_COUNSLR && MType->mtype <= MT_ADVOCATE && _mgoal != MGOAL_NORMAL)
-		return false;
-	return true;
+	    || (MType->mtype >= MT_COUNSLR && MType->mtype <= MT_ADVOCATE && _mgoal != MGOAL_NORMAL));
 }
 
 bool Monster::TryLiftGargoyle()

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1174,9 +1174,8 @@ void StartDeathFromMonster(int i, int mid)
 	dMonster[monster.position.tile.x][monster.position.tile.y] = mid + 1;
 	CheckQuestKill(monster, true);
 	M_FallenFear(monster.position.tile);
-	if (monster.MType->mtype >= MT_NACID && monster.MType->mtype <= MT_XACID)
+	if ((monster.MType->mtype >= MT_NACID && monster.MType->mtype <= MT_XACID) || monster.MType->mtype == MT_SPIDLORD)
 		AddMissile(monster.position.tile, { 0, 0 }, Direction::South, MIS_ACIDPUD, TARGET_PLAYERS, mid, monster._mint + 1, 0);
-
 	if (gbIsHellfire)
 		M_StartStand(killer, killer._mdir);
 }

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1115,9 +1115,10 @@ void StartMonsterDeath(int i, int pnum, bool sendmsg)
 		PlayEffect(monster, 2);
 
 	Direction md = pnum >= 0 ? GetMonsterDirection(monster) : monster._mdir;
-	bool wasPetrified = (monster._mmode == MonsterMode::Petrified);
-	NewMonsterAnim(monster, MonsterGraphic::Death, md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
-	monster._mmode = MonsterMode::Death;
+	if (monster._mmode != MonsterMode::Petrified) {
+		NewMonsterAnim(monster, MonsterGraphic::Death, md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
+		monster._mmode = MonsterMode::Death;
+	}
 	monster._mgoal = MGOAL_NONE;
 	monster.position.offset = { 0, 0 };
 	monster._mVar1 = 0;
@@ -1129,8 +1130,6 @@ void StartMonsterDeath(int i, int pnum, bool sendmsg)
 	M_FallenFear(monster.position.tile);
 	if ((monster.MType->mtype >= MT_NACID && monster.MType->mtype <= MT_XACID) || monster.MType->mtype == MT_SPIDLORD)
 		AddMissile(monster.position.tile, { 0, 0 }, Direction::South, MIS_ACIDPUD, TARGET_PLAYERS, i, monster._mint + 1, 0);
-	if (wasPetrified)
-		monster.Petrify();
 }
 
 void StartDeathFromMonster(int i, int mid)
@@ -1164,9 +1163,10 @@ void StartDeathFromMonster(int i, int mid)
 	Direction md = Opposite(killer._mdir);
 	if (monster.MType->mtype == MT_GOLEM)
 		md = Direction::South;
-	bool wasPetrified = (monster._mmode == MonsterMode::Petrified);
-	NewMonsterAnim(monster, MonsterGraphic::Death, md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
-	monster._mmode = MonsterMode::Death;
+	if (monster._mmode != MonsterMode::Petrified) {
+		NewMonsterAnim(monster, MonsterGraphic::Death, md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
+		monster._mmode = MonsterMode::Death;
+	}
 	monster.position.offset = { 0, 0 };
 	monster.position.tile = monster.position.old;
 	monster.position.future = monster.position.old;
@@ -1179,8 +1179,6 @@ void StartDeathFromMonster(int i, int mid)
 
 	if (gbIsHellfire)
 		M_StartStand(killer, killer._mdir);
-	if (wasPetrified)
-		monster.Petrify();
 }
 
 void StartFadein(Monster &monster, Direction md, bool backwards)


### PR DESCRIPTION
- This fixes a bug where Spiderlords would not leave behind an acid puddle when killed by monsters.
- Cleans up redundant logic by moving it to a shared function.
- Don't take short cuts when calculating the proper heading for the death animation