### PR TITLE
MonsterMHit and MonsterTrapHit Split 2

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -194,23 +194,25 @@ void MoveMissilePos(Missile &missile)
 
 bool MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, missile_id t, bool shift)
 {
-	auto &monster = Monsters[m];
+	Monster &monster = Monsters[m];
 
 	if (!monster.IsPossibleToHit() || monster.IsImmune(t))
 		return false;
 
-	int hit = GenerateRnd(100);
-	int hper = PlayerMissileCalculateCTHAgainstMonster(pnum, t, dist, monster);
-	hper = clamp(hper, 5, 95);
-
 	if (monster.TryLiftGargoyle())
 		return true;
 
-	if (hit >= hper && monster._mmode != MonsterMode::Petrified) {
+	if (monster._mmode != MonsterMode::Petrified) {
+		int hit = GenerateRnd(100);
+		int hper = PlayerMissileCalculateCTHAgainstMonster(pnum, t, dist, monster);
+		hper = clamp(hper, 5, 95);
+
+		if (hit >= hper) {
 #ifdef _DEBUG
-		if (!DebugGodMode)
+			if (!DebugGodMode)
 #endif
-			return false;
+				return false;
+		}
 	}
 
 	int dam = PlayerMissileCalculateDamageAgainstMonster(pnum, mindam, maxdam, t, monster);
@@ -822,8 +824,7 @@ Direction16 GetDirection16(Point p1, Point p2)
 
 void MissileHitMonsterConsequences(int mid, int pnum, int dam, missile_id mName)
 {
-	auto &monster = Monsters[mid];
-	const auto &player = Players[pnum];
+	Monster &monster = Monsters[mid];
 
 	bool hasKnockback = false;
 	if (pnum >= 0 && pnum < MAX_PLRS) {
@@ -848,18 +849,17 @@ void MissileHitMonsterConsequences(int mid, int pnum, int dam, missile_id mName)
 
 int PlayerMissileCalculateCTHAgainstMonster(int pnum, missile_id mName, int dist, Monster &monster)
 {
+	if (pnum == -1)
+		return GenerateRnd(75) - monster.mLevel * 2;
+
 	int hper = 0;
-	if (pnum != -1) {
-		const Player &player = Players[pnum];
-		if (MissilesData[mName].mType == 0) {
-			hper = player.GetRangedPiercingToHit();
-			hper -= player.CalculateArmorPierce(monster.mArmorClass, false);
-			hper -= (dist * dist) / 2;
-		} else {
-			hper = player.GetMagicToHit() - (monster.mLevel * 2) - dist;
-		}
+	const Player &player = Players[pnum];
+	if (MissilesData[mName].mType == 0) {
+		hper = player.GetRangedPiercingToHit();
+		hper -= player.CalculateArmorPierce(monster.mArmorClass, false);
+		hper -= (dist * dist) / 2;
 	} else {
-		hper = GenerateRnd(75) - monster.mLevel * 2;
+		hper = player.GetMagicToHit() - (monster.mLevel * 2) - dist;
 	}
 	return hper;
 }
@@ -885,7 +885,7 @@ int PlayerMissileCalculateDamageAgainstMonster(int pnum, int minDam, int maxDam,
 
 void PlayerMissileHitMonster(int pnum, int dam, int m, missile_id mName)
 {
-	auto &monster = Monsters[m];
+	Monster &monster = Monsters[m];
 	if (pnum == MyPlayerId)
 		monster._mhitpoints -= dam;
 
@@ -903,7 +903,7 @@ void PlayerMissileHitMonster(int pnum, int dam, int m, missile_id mName)
 
 int TrapMissileCalculateCTHAgainstMonster(int dist, Monster &monster)
 {
-	return 90 - (BYTE)monster.mArmorClass - dist;
+	return 90 - monster.mArmorClass - dist;
 }
 
 int TrapMissileCalculateDamageAgainstMonster(int minDam, int maxDam, int mName, Monster &monster)
@@ -915,7 +915,7 @@ int TrapMissileCalculateDamageAgainstMonster(int minDam, int maxDam, int mName, 
 
 void TrapMissileHitMonster(int mid, int dam, missile_id mName)
 {
-	auto &monster = Monsters[mid];
+	Monster &monster = Monsters[mid];
 	monster._mhitpoints -= dam;
 #ifdef _DEBUG
 	if (DebugGodMode)
@@ -926,23 +926,25 @@ void TrapMissileHitMonster(int mid, int dam, missile_id mName)
 
 bool MonsterTrapHit(int m, int mindam, int maxdam, int dist, missile_id t, bool shift)
 {
-	auto &monster = Monsters[m];
+	Monster &monster = Monsters[m];
 
 	if (!monster.IsPossibleToHit() || monster.IsImmune(t))
 		return false;
 
-	int hit = GenerateRnd(100);
-	int hper = TrapMissileCalculateCTHAgainstMonster(dist, monster);
-	hper = clamp(hper, 5, 95);
-
 	if (monster.TryLiftGargoyle())
 		return true;
 
-	if (hit >= hper && monster._mmode != MonsterMode::Petrified) {
+	if (monster._mmode != MonsterMode::Petrified) {
+		int hit = GenerateRnd(100);
+		int hper = TrapMissileCalculateCTHAgainstMonster(dist, monster);
+		hper = clamp(hper, 5, 95);
+
+		if (hit >= hper) {
 #ifdef _DEBUG
-		if (!DebugGodMode)
+			if (!DebugGodMode)
 #endif
-			return false;
+				return false;
+		}
 	}
 
 	int dam;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -807,7 +807,7 @@ void MissileHitMonsterConsequences(int mid, int pnum, int dam, missile_id mName)
 	}
 }
 
-int PlayerMissile::CalculateCTH(Monster &monster) const
+int PlayerMissile::calculateCTH(Monster &monster) const
 {
 	if (colMissile->_misource == -1)
 		return GenerateRnd(75) - monster.mLevel * 2;
@@ -824,12 +824,12 @@ int PlayerMissile::CalculateCTH(Monster &monster) const
 	return hper;
 }
 
-int PlayerMissile::CalculateDamage(Monster &monster) const
+int PlayerMissile::calculateDamage(Monster &monster) const
 {
 	if (colMissile->_mitype == MIS_BONESPIRIT)
 		return monster._mhitpoints / 3 >> 6;
 
-	int dam = m_minDamage + GenerateRnd(m_maxDamage - m_minDamage + 1);
+	int dam = minDamage + GenerateRnd(maxDamage - minDamage + 1);
 	const Player &player = Players[colMissile->_misource];
 	if (MissilesData[colMissile->_mitype].mType == 0 && MissilesData[colMissile->_mitype].mResist == MISR_NONE) {
 		dam += (dam * player._pIBonusDam / 100) + player._pIBonusDamMod;
@@ -843,13 +843,13 @@ int PlayerMissile::CalculateDamage(Monster &monster) const
 	return dam;
 }
 
-void PlayerMissile::HitMonster(int mid, int dam) const
+void PlayerMissile::hitMonster(int mid, int dam) const
 {
 	Monster &monster = Monsters[mid];
 	if (colMissile->_misource == MyPlayerId)
 		monster._mhitpoints -= dam;
 
-	const auto &player = Players[colMissile->_misource];
+	const Player &player = Players[colMissile->_misource];
 	if ((gbIsHellfire && HasAnyOf(player._pIFlags, ItemSpecialEffect::NoHealOnMonsters)) || (!gbIsHellfire && HasAnyOf(player._pIFlags, ItemSpecialEffect::FireArrows)))
 		monster._mFlags |= MFLAG_NOHEAL;
 
@@ -861,19 +861,19 @@ void PlayerMissile::HitMonster(int mid, int dam) const
 	}
 }
 
-int TrapMissile::CalculateCTH(Monster &monster) const
+int TrapMissile::calculateCTH(Monster &monster) const
 {
 	return 90 - monster.mArmorClass - colMissile->_midist;
 }
 
-int TrapMissile::CalculateDamage(Monster &monster) const
+int TrapMissile::calculateDamage(Monster &monster) const
 {
 	return (colMissile->_mitype == MIS_BONESPIRIT)
 	    ? monster._mhitpoints / 3 >> 6
-	    : m_minDamage + GenerateRnd(m_maxDamage - m_minDamage + 1);
+	    : minDamage + GenerateRnd(maxDamage - minDamage + 1);
 }
 
-void TrapMissile::HitMonster(int mid, int dam) const
+void TrapMissile::hitMonster(int mid, int dam) const
 {
 	Monster &monster = Monsters[mid];
 	monster._mhitpoints -= dam;
@@ -897,7 +897,7 @@ bool TryHitMonster(TCollidable const &col, int mid)
 
 	if (monster._mmode != MonsterMode::Petrified) {
 		int hit = GenerateRnd(100);
-		int hper = col.CalculateCTH(monster);
+		int hper = col.calculateCTH(monster);
 		hper = clamp(hper, 5, 95);
 
 		if (hit >= hper) {
@@ -908,13 +908,13 @@ bool TryHitMonster(TCollidable const &col, int mid)
 		}
 	}
 
-	int dam = col.CalculateDamage(monster);
-	if (!col.m_isDamageShifted)
+	int dam = col.calculateDamage(monster);
+	if (!col.isDamageShifted)
 		dam <<= 6;
 	if (monster.IsResistant(col.colMissile->_mitype))
 		dam >>= 2;
 
-	col.HitMonster(mid, dam);
+	col.hitMonster(mid, dam);
 
 	return true;
 }

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -813,13 +813,12 @@ int PlayerMissile::calculateCTH(Monster &monster) const
 		return GenerateRnd(75) - monster.mLevel * 2;
 
 	int hper = 0;
-	const Player &player = Players[colMissile->_misource];
 	if (MissilesData[colMissile->_mitype].mType == 0) {
-		hper = player.GetRangedPiercingToHit();
-		hper -= player.CalculateArmorPierce(monster.mArmorClass, false);
+		hper = attacker_->GetRangedPiercingToHit();
+		hper -= attacker_->CalculateArmorPierce(monster.mArmorClass, false);
 		hper -= (colMissile->_midist * colMissile->_midist) / 2;
 	} else {
-		hper = player.GetMagicToHit() - (monster.mLevel * 2) - colMissile->_midist;
+		hper = attacker_->GetMagicToHit() - (monster.mLevel * 2) - colMissile->_midist;
 	}
 	return hper;
 }
@@ -830,14 +829,13 @@ int PlayerMissile::calculateDamage(Monster &monster) const
 		return monster._mhitpoints / 3 >> 6;
 
 	int dam = minDamage + GenerateRnd(maxDamage - minDamage + 1);
-	const Player &player = Players[colMissile->_misource];
 	if (MissilesData[colMissile->_mitype].mType == 0 && MissilesData[colMissile->_mitype].mResist == MISR_NONE) {
-		dam += (dam * player._pIBonusDam / 100) + player._pIBonusDamMod;
-		if (player._pClass == HeroClass::Rogue)
-			dam += player._pDamageMod;
+		dam += (dam * attacker_->_pIBonusDamMod / 100) + attacker_->_pIBonusDam;
+		if (attacker_->_pClass == HeroClass::Rogue)
+			dam += attacker_->_pDamageMod;
 		else
-			dam += player._pDamageMod / 2;
-		if (monster.MData->mMonstClass == MonsterClass::Demon && HasAnyOf(player._pIFlags, ItemSpecialEffect::TripleDemonDamage))
+			dam += attacker_->_pDamageMod / 2;
+		if (monster.MData->mMonstClass == MonsterClass::Demon && HasAnyOf(attacker_->_pIFlags, ItemSpecialEffect::TripleDemonDamage))
 			dam *= 3;
 	}
 	return dam;
@@ -849,15 +847,15 @@ void PlayerMissile::hitMonster(int mid, int dam) const
 	if (colMissile->_misource == MyPlayerId)
 		monster._mhitpoints -= dam;
 
-	const Player &player = Players[colMissile->_misource];
-	if ((gbIsHellfire && HasAnyOf(player._pIFlags, ItemSpecialEffect::NoHealOnMonsters)) || (!gbIsHellfire && HasAnyOf(player._pIFlags, ItemSpecialEffect::FireArrows)))
+	if ((gbIsHellfire && HasAnyOf(attacker_->_pIFlags, ItemSpecialEffect::NoHealOnMonsters))
+	    || (!gbIsHellfire && HasAnyOf(attacker_->_pIFlags, ItemSpecialEffect::FireArrows)))
 		monster._mFlags |= MFLAG_NOHEAL;
 
 	MissileHitMonsterConsequences(mid, colMissile->_misource, dam, colMissile->_mitype);
 
 	if (monster._msquelch == 0) {
 		monster._msquelch = UINT8_MAX;
-		monster.position.last = player.position.tile;
+		monster.position.last = attacker_->position.tile;
 	}
 }
 

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -13,6 +13,7 @@
 #include "miniwin/miniwin.h"
 #include "misdat.h"
 #include "monster.h"
+#include "player.h"
 #include "spelldat.h"
 
 namespace devilution {
@@ -173,10 +174,14 @@ public:
 		this->minDamage = minDamage;
 		this->maxDamage = maxDamage;
 		this->isDamageShifted = isDamageShifted;
+		attacker_ = &Players[colMissile->_misource];
 	}
 	int calculateCTH(Monster &monster) const;
 	int calculateDamage(Monster &monster) const;
 	void hitMonster(int mid, int dam) const;
+
+private:
+	const Player *attacker_;
 };
 
 template <typename TCollidable>

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -134,6 +134,47 @@ struct Missile {
 	}
 };
 
+class Collidable {
+public:
+	Missile *colMissile;
+	int m_minDamage;
+	int m_maxDamage;
+	bool m_isDamageShifted;
+};
+
+class TrapMissile : public Collidable {
+
+public:
+	TrapMissile(Missile missile, int minDamage, int maxDamage, bool isDamageShifted)
+	{
+		colMissile = &missile;
+		m_minDamage = minDamage;
+		m_maxDamage = maxDamage;
+		m_isDamageShifted = isDamageShifted;
+	}
+	int CalculateCTH(Monster &monster) const;
+	int CalculateDamage(Monster &monster) const;
+	void HitMonster(int mid, int dam) const;
+};
+
+class PlayerMissile : public Collidable {
+
+public:
+	PlayerMissile(Missile missile, int minDamage, int maxDamage, bool isDamageShifted)
+	{
+		colMissile = &missile;
+		m_minDamage = minDamage;
+		m_maxDamage = maxDamage;
+		m_isDamageShifted = isDamageShifted;
+	}
+	int CalculateCTH(Monster &monster) const;
+	int CalculateDamage(Monster &monster) const;
+	void HitMonster(int mid, int dam) const;
+};
+
+template <typename TCollidable>
+bool TryHitMonster(TCollidable const &col, int mid);
+
 extern std::list<Missile> Missiles;
 extern bool MissilePreFlag;
 
@@ -160,7 +201,6 @@ int GetSpellLevel(int playerId, spell_id sn);
  * @return the direction of the p1->p2 vector
  */
 Direction16 GetDirection16(Point p1, Point p2);
-bool MonsterTrapHit(int m, int mindam, int maxdam, int dist, missile_id t, bool shift);
 bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, missile_id mtype, bool shift, int earflag, bool *blocked);
 
 /**

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -137,9 +137,9 @@ struct Missile {
 class Collidable {
 public:
 	Missile *colMissile;
-	int m_minDamage;
-	int m_maxDamage;
-	bool m_isDamageShifted;
+	int minDamage;
+	int maxDamage;
+	bool isDamageShifted;
 };
 
 class TrapMissile : public Collidable {
@@ -148,13 +148,20 @@ public:
 	TrapMissile(Missile missile, int minDamage, int maxDamage, bool isDamageShifted)
 	{
 		colMissile = &missile;
-		m_minDamage = minDamage;
-		m_maxDamage = maxDamage;
-		m_isDamageShifted = isDamageShifted;
+		this->minDamage = minDamage;
+		this->maxDamage = maxDamage;
+		this->isDamageShifted = isDamageShifted;
 	}
-	int CalculateCTH(Monster &monster) const;
-	int CalculateDamage(Monster &monster) const;
-	void HitMonster(int mid, int dam) const;
+	TrapMissile(Missile missile, int minDamage, int maxDamage, bool isDamageShifted, int distance, int miSource, missile_id mName)
+	    : TrapMissile(missile, minDamage, maxDamage, isDamageShifted)
+	{
+		colMissile->_midist = distance;
+		colMissile->_misource = miSource;
+		colMissile->_mitype = mName;
+	}
+	int calculateCTH(Monster &monster) const;
+	int calculateDamage(Monster &monster) const;
+	void hitMonster(int mid, int dam) const;
 };
 
 class PlayerMissile : public Collidable {
@@ -163,13 +170,13 @@ public:
 	PlayerMissile(Missile missile, int minDamage, int maxDamage, bool isDamageShifted)
 	{
 		colMissile = &missile;
-		m_minDamage = minDamage;
-		m_maxDamage = maxDamage;
-		m_isDamageShifted = isDamageShifted;
+		this->minDamage = minDamage;
+		this->maxDamage = maxDamage;
+		this->isDamageShifted = isDamageShifted;
 	}
-	int CalculateCTH(Monster &monster) const;
-	int CalculateDamage(Monster &monster) const;
-	void HitMonster(int mid, int dam) const;
+	int calculateCTH(Monster &monster) const;
+	int calculateDamage(Monster &monster) const;
+	void hitMonster(int mid, int dam) const;
 };
 
 template <typename TCollidable>

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1571,8 +1571,13 @@ void UpdateFlameTrap(Object &trap)
 
 		int x = trap.position.x;
 		int y = trap.position.y;
-		if (dMonster[x][y] > 0)
-			MonsterTrapHit(dMonster[x][y] - 1, mindam / 2, maxdam / 2, 0, MIS_FIREWALLC, false);
+		if (dMonster[x][y] > 0) {
+			TrapMissile trapDummyMissile = TrapMissile((Missile {}), mindam / 2, maxdam / 2, false);
+			trapDummyMissile.colMissile->_midist = 0;
+			trapDummyMissile.colMissile->_misource = -1;
+			trapDummyMissile.colMissile->_mitype = MIS_FIREWALLC;
+			TryHitMonster(trapDummyMissile, dMonster[x][y] - 1);
+		}
 		if (dPlayer[x][y] > 0) {
 			bool unused;
 			PlayerMHit(dPlayer[x][y] - 1, nullptr, 0, mindam, maxdam, MIS_FIREWALLC, false, 0, &unused);
@@ -4182,7 +4187,11 @@ void BreakBarrel(int pnum, Object &barrel, int dam, bool forcebreak, bool sendms
 		for (int yp = barrel.position.y - 1; yp <= barrel.position.y + 1; yp++) {
 			for (int xp = barrel.position.x - 1; xp <= barrel.position.x + 1; xp++) {
 				if (dMonster[xp][yp] > 0) {
-					MonsterTrapHit(dMonster[xp][yp] - 1, 1, 4, 0, MIS_FIREBOLT, false);
+					TrapMissile trapDummyMissile = TrapMissile((Missile {}), 1, 4, false);
+					trapDummyMissile.colMissile->_midist = 0;
+					trapDummyMissile.colMissile->_misource = -1;
+					trapDummyMissile.colMissile->_mitype = MIS_FIREBOLT;
+					TryHitMonster(trapDummyMissile, dMonster[xp][yp] - 1);
 				}
 				if (dPlayer[xp][yp] > 0) {
 					bool unused;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1572,11 +1572,8 @@ void UpdateFlameTrap(Object &trap)
 		int x = trap.position.x;
 		int y = trap.position.y;
 		if (dMonster[x][y] > 0) {
-			TrapMissile trapDummyMissile = TrapMissile((Missile {}), mindam / 2, maxdam / 2, false);
-			trapDummyMissile.colMissile->_midist = 0;
-			trapDummyMissile.colMissile->_misource = -1;
-			trapDummyMissile.colMissile->_mitype = MIS_FIREWALLC;
-			TryHitMonster(trapDummyMissile, dMonster[x][y] - 1);
+			TrapMissile dummyMissile = TrapMissile((Missile {}), mindam / 2, maxdam / 2, false, 0, -1, MIS_FIREWALLC);
+			TryHitMonster(dummyMissile, dMonster[x][y] - 1);
 		}
 		if (dPlayer[x][y] > 0) {
 			bool unused;
@@ -4187,11 +4184,8 @@ void BreakBarrel(int pnum, Object &barrel, int dam, bool forcebreak, bool sendms
 		for (int yp = barrel.position.y - 1; yp <= barrel.position.y + 1; yp++) {
 			for (int xp = barrel.position.x - 1; xp <= barrel.position.x + 1; xp++) {
 				if (dMonster[xp][yp] > 0) {
-					TrapMissile trapDummyMissile = TrapMissile((Missile {}), 1, 4, false);
-					trapDummyMissile.colMissile->_midist = 0;
-					trapDummyMissile.colMissile->_misource = -1;
-					trapDummyMissile.colMissile->_mitype = MIS_FIREBOLT;
-					TryHitMonster(trapDummyMissile, dMonster[xp][yp] - 1);
+					TrapMissile dummyMissile = TrapMissile((Missile {}), 1, 4, false, 0, -1, MIS_FIREBOLT);
+					TryHitMonster(dummyMissile, dMonster[xp][yp] - 1);
 				}
 				if (dPlayer[xp][yp] > 0) {
 					bool unused;


### PR DESCRIPTION
Please review this PR - as 2nd part of split of #4570.

This second part of MonsterMhit and MonsterTrapHit refactor I finally merged both function into TryHitMonster using template method pattern.
To do so I used function template to still achieve proper inheritance. 
Player specific code went to `PlayerMissile` class and Trap specific code went to `TrapMissile`.
Both classes are derived from abstract class `Collidable`, which I have plans for in the future :)

It is strongly recommended to view changes commit by commit, because there are many movings of code.

I am also looking forward for permission to merge [already implemented](https://github.com/k-bar/devilutionX/commit/cb92aec7ef0509f375514d063a0c0bf9246ed7d3) solution based on abstract class and pure virtual functions. If not now, then maybe in the future.


This PR should not change game mechanics.
Minor changes: 
- enabled damage calculations for Bone Spirit as viable trap missile.
- fixed Hellfire bug related to Ring of Fire trap vs monsters.
- firewall originating from Oily shrine calculates CTH the same as trap Ring of Fire.

<details>
  <summary>outdated</summary>
This PR will focus on 2 things

1st commit will extract Player and Trap specific code from MonsterMHit and MonsterTrapHit.

It won't be ready to merge yet!

After some review remarks I will commit 2nd commit in which I will merge those 2 almost identical right now functions.

Please note that number of parameters will drasticall change, and names will go shorter, as all function names starting with `PlayerMissileSomething` or `TrapMissileSomething` will be `PlayerMissile::Something` and `TrapMissile::Something`.
So you do not have to focus on that right now.
</details>