### PR TITLE
Upgrade Android build tool and target SDK versions

### DIFF
--- a/android-project/app/build.gradle
+++ b/android-project/app/build.gradle
@@ -7,13 +7,13 @@ if (buildAsApplication) {
 }
 
 android {
-	compileSdkVersion 31
+	compileSdkVersion 32
 	defaultConfig {
 		if (buildAsApplication) {
 			applicationId "org.diasurgical.devilutionx"
 		}
 		minSdkVersion 18
-		targetSdkVersion 31
+		targetSdkVersion 32
 		versionCode 22
 		versionName "1.4.0"
 		externalNativeBuild {

--- a/android-project/build.gradle
+++ b/android-project/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 		google()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:7.1.3'
+		classpath 'com.android.tools.build:gradle:7.2.0'
 
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files

--- a/android-project/gradle/wrapper/gradle-wrapper.properties
+++ b/android-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Nov 11 18:20:34 PST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
All changes were at recommendation of Android Studio, and were playtested on Pixel 2, Android 10

* Upgrade Gradle plugin version to 7.2.0, release notes: https://developer.android.com/studio/releases/gradle-plugin#7-2-0
* Upgrade Gradle to 7.4.2, release notes: https://docs.gradle.org/7.4.2/release-notes.html
* Upgrade `compileSdkVersion` and `targetSdkVersion` to 32 to coincide with Android 12L feature drop: https://developer.android.com/about/versions/12/12L