### PR TITLE
Plr2PlrMHit and PlayerMhit refactoring

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -333,8 +333,13 @@ bool Plr2PlrMHit(int pnum, int p, int mindam, int maxdam, int dist, missile_id m
 		resper = 0;
 		break;
 	}
-	// BLOCK will be here
+	// BLOCK
 	*blocked = false;
+	if (resper <= 0 && blkper < blk) {
+		StartPlrBlock(p, GetDirection(target.position.tile, player.position.tile));
+		*blocked = true;
+		return true;
+	}
 	// DAMAGE calc
 	int dam;
 	if (mtype == MIS_BONESPIRIT) {
@@ -348,23 +353,15 @@ bool Plr2PlrMHit(int pnum, int p, int mindam, int maxdam, int dist, missile_id m
 	}
 	if (MissilesData[mtype].mType != 0)
 		dam /= 2;
-	// HIT (AND BLOCK temporary)
-	if (resper > 0) {
+	if (resper > 0)
 		dam -= (dam * resper) / 100;
-		if (pnum == MyPlayerId)
-			NetSendCmdDamage(true, p, dam);
+	// HIT
+	if (pnum == MyPlayerId)
+		NetSendCmdDamage(true, p, dam);
+	if (resper > 0)
 		target.Say(HeroSpeech::ArghClang);
-		return true;
-	}
-
-	if (blkper < blk) {
-		StartPlrBlock(p, GetDirection(target.position.tile, player.position.tile));
-		*blocked = true;
-	} else {
-		if (pnum == MyPlayerId)
-			NetSendCmdDamage(true, p, dam);
+	else
 		StartPlrHit(p, dam, false);
-	}
 
 	return true;
 }
@@ -1071,27 +1068,18 @@ bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, missil
 
 		dam = std::max(dam, 64);
 	}
-	// HIT
-	if (resper > 0) {
+	if (resper > 0)
 		dam -= dam * resper / 100;
-		if (pnum == MyPlayerId) {
-			ApplyPlrDamage(pnum, 0, 0, dam, earflag);
-		}
-
-		if (player._pHitPoints >> 6 > 0) {
-			player.Say(HeroSpeech::ArghClang);
-		}
-		return true;
-	}
-
-	if (pnum == MyPlayerId) {
+	// HIT
+	if (pnum == MyPlayerId)
 		ApplyPlrDamage(pnum, 0, 0, dam, earflag);
-	}
 
 	if (player._pHitPoints >> 6 > 0) {
-		StartPlrHit(pnum, dam, false);
+		if (resper > 0)
+			player.Say(HeroSpeech::ArghClang);
+		else
+			StartPlrHit(pnum, dam, false);
 	}
-
 	return true;
 }
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1364,7 +1364,7 @@ void MonsterAttackPlayer(int i, int pnum, int hit, int minDam, int maxDam)
 	if (player.isAbleToBlock()) {
 		blkper = GenerateRnd(100);
 	}
-	int blk = player.GetBlockChance() - (monster.mLevel * 2);
+	int blk = player.GetBlockChance(monster.mLevel);
 	blk = clamp(blk, 0, 100);
 	if (hper >= hit)
 		return;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1340,7 +1340,7 @@ void MonsterAttackPlayer(int i, int pnum, int hit, int minDam, int maxDam)
 
 	auto &player = Players[pnum];
 
-	if (player._pHitPoints >> 6 <= 0 || player._pInvincible || HasAnyOf(player._pSpellFlags, SpellFlag::Etherealize))
+	if (!player.isPossibleToHit() || HasAnyOf(player._pSpellFlags, SpellFlag::Etherealize))
 		return;
 	if (monster.position.tile.WalkingDistance(player.position.tile) >= 2)
 		return;
@@ -1358,16 +1358,10 @@ void MonsterAttackPlayer(int i, int pnum, int hit, int minDam, int maxDam)
 	hit += 2 * (monster.mLevel - player._pLevel)
 	    + 30
 	    - ac;
-	int minhit = 15;
-	if (currlevel == 14)
-		minhit = 20;
-	if (currlevel == 15)
-		minhit = 25;
-	if (currlevel == 16)
-		minhit = 30;
+	int minhit = getMonstersAndTrapsAutoHitAgainstPlayer(15);
 	hit = std::max(hit, minhit);
 	int blkper = 100;
-	if ((player._pmode == PM_STAND || player._pmode == PM_ATTACK) && player._pBlockFlag) {
+	if (player.isAbleToBlock()) {
 		blkper = GenerateRnd(100);
 	}
 	int blk = player.GetBlockChance() - (monster.mLevel * 2);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1020,7 +1020,7 @@ bool PlrHitPlr(int pnum, int8_t p)
 	hper = clamp(hper, 5, 95);
 
 	int blk = 100;
-	if ((target._pmode == PM_STAND || target._pmode == PM_ATTACK) && target._pBlockFlag) {
+	if (target.isAbleToBlock()) {
 		blk = GenerateRnd(100);
 	}
 
@@ -3949,6 +3949,17 @@ void PlayDungMsgs()
 	} else {
 		sfxdelay = 0;
 	}
+}
+
+int getMonstersAndTrapsAutoHitAgainstPlayer(int minHit)
+{
+	if (currlevel == 14)
+		minHit = 20;
+	if (currlevel == 15)
+		minHit = 25;
+	if (currlevel == 16)
+		minHit = 30;
+	return minHit;
 }
 
 #ifdef BUILD_TESTING

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1024,7 +1024,7 @@ bool PlrHitPlr(int pnum, int8_t p)
 		blk = GenerateRnd(100);
 	}
 
-	int blkper = target.GetBlockChance() - (attacker._pLevel * 2);
+	int blkper = target.GetBlockChance(attacker._pLevel);
 	blkper = clamp(blkper, 0, 100);
 
 	if (hit >= hper) {

--- a/Source/player.h
+++ b/Source/player.h
@@ -17,6 +17,7 @@
 #include "gendung.h"
 #include "interfac.h"
 #include "items.h"
+#include "misdat.h"
 #include "multi.h"
 #include "path.h"
 #include "spelldat.h"
@@ -706,6 +707,45 @@ struct Player {
 		return false;
 	}
 
+	bool isPossibleToHit() const
+	{
+		return ((_pHitPoints >> 6 > 0)
+		    && !_pInvincible);
+	}
+
+	bool isImmune(missile_id mName) const
+	{
+		return (MissilesData[mName].mType == 0 && HasAnyOf(_pSpellFlags, SpellFlag::Etherealize)
+		    || mName == MIS_HBOLT);
+	}
+
+	bool isAbleToBlock() const
+	{
+		return ((_pmode == PM_STAND || _pmode == PM_ATTACK)
+		    && _pBlockFlag);
+	}
+
+	int8_t getResistance(missile_resistance mResist) const
+	{
+		int8_t resPer;
+		switch (mResist) {
+		case MISR_FIRE:
+			resPer = _pFireResist;
+			break;
+		case MISR_LIGHTNING:
+			resPer = _pLghtResist;
+			break;
+		case MISR_MAGIC:
+		case MISR_ACID:
+			resPer = _pMagResist;
+			break;
+		default:
+			resPer = 0;
+			break;
+		}
+		return resPer;
+	}
+
 	/**
 	 * @brief Updates previewCelSprite according to new requested command
 	 * @param cmdId What command is requested
@@ -788,6 +828,7 @@ void SetPlrDex(Player &player, int v);
 void SetPlrVit(Player &player, int v);
 void InitDungMsgs(Player &player);
 void PlayDungMsgs();
+int getMonstersAndTrapsAutoHitAgainstPlayer(int minHit);
 
 /* data */
 

--- a/Source/player.h
+++ b/Source/player.h
@@ -543,14 +543,11 @@ struct Player {
 
 	/**
 	 * @brief Return block chance
-	 * @param useLevel - indicate if player's level should be added to block chance (the only case where it isn't is blocking a trap)
+	 * @param attackerLevel - to calculate doubled level difference between player and attacker. No difference for traps.
 	 */
-	int GetBlockChance(bool useLevel = true) const
+	int GetBlockChance(int attackerLevel) const
 	{
-		int blkper = _pDexterity + _pBaseToBlk;
-		if (useLevel)
-			blkper += _pLevel * 2;
-		return blkper;
+		return _pDexterity + _pBaseToBlk + 2 * (_pLevel - attackerLevel);
 	}
 
 	/**


### PR DESCRIPTION
As `Plr2PlrMHit` and `PlayerMhit` both has duplicate code. This PR focus mainly on clean that code and merge it together into one TryHitPlayer function without any important changing to how game mechanics works.

**It is highly recommended to review commit by commit, since many things are moved in files.**

Some small not important changes to mechanics will be noted here:
1. Some redundant RNG rolls are not done if not needed (thanks to unified reorder of functions internals)
2. Added check for player immunity for Holy Bolt missiles from monsters and trap.
3. Added check for positive player HP for missiles from player (could be redundant, but it is unified in extracted function)
4. Added check for `MIS_ACIDPUD` for Player missile while checking block possibility.