### PR TITLE
Blit UI surface to game surface when waiting for game data

### DIFF
--- a/Source/DiabloUI/progress.cpp
+++ b/Source/DiabloUI/progress.cpp
@@ -77,7 +77,7 @@ bool UiProgressDialog(int (*fnfunc)())
 		ProgressRender(progress);
 		UiRenderItems(vecProgress);
 		DrawMouse();
-		RenderPresent();
+		UiFadeIn();
 
 		while (PollEvent(&event) != 0) {
 			switch (event.type) {


### PR DESCRIPTION
Fixes an issue where the "Waiting for game data" dialog was not appearing when joining a game.

The issue was introduced by 52e0511. It seems we were (perhaps incorrectly) relying on the fact that this dialog was blitting directly to the output surface. This modifies the rendering loop to use `UiFadeIn()` instead of `RenderPresent()` like nearly all other UI rendering loops in the codebase.