### PR TITLE
Cleanup block_lvid checks

### DIFF
--- a/Source/engine/render/dun_render.cpp
+++ b/Source/engine/render/dun_render.cpp
@@ -1131,14 +1131,12 @@ const std::uint32_t *GetMask(TileType tile)
 			return &WallMaskFullyTrasparent[TILE_HEIGHT - 1];
 		}
 		if (arch_draw_type == 1 && tile != TileType::LeftTriangle) {
-			const auto c = block_lvid[level_piece_id];
-			if (c == 1 || c == 3) {
+			if ((block_lvid[level_piece_id] & 0x01) != 0) {
 				return &LeftMaskTransparent[TILE_HEIGHT - 1];
 			}
 		}
 		if (arch_draw_type == 2 && tile != TileType::RightTriangle) {
-			const auto c = block_lvid[level_piece_id];
-			if (c == 2 || c == 3) {
+			if ((block_lvid[level_piece_id] & 0x02) != 0) {
 				return &RightMaskTransparent[TILE_HEIGHT - 1];
 			}
 		}

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -385,7 +385,7 @@ void FillSolidBlockTbls()
 		nMissileTable[i + 1] = (bv & 0x04) != 0;
 		nTransTable[i + 1] = (bv & 0x08) != 0;
 		nTrapTable[i + 1] = (bv & 0x80) != 0;
-		block_lvid[i + 1] = (bv & 0x70) >> 4;
+		block_lvid[i + 1] = (bv & 0x30) >> 4;
 	}
 }
 


### PR DESCRIPTION
Only consider the relevant flags for block_lvid, and use it as a flag instead of integer values.