### PR TITLE
fix for monster melee hit monster

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1299,14 +1299,15 @@ void MonsterAttackMonster(int i, int mid, int hper, int mind, int maxd)
 		hit = 0;
 	if (monster.TryLiftGargoyle())
 		return;
-	if (hit < hper) {
-		int dam = (mind + GenerateRnd(maxd - mind + 1)) << 6;
-		monster._mhitpoints -= dam;
-		if (monster._mhitpoints >> 6 <= 0) {
-			StartDeathFromMonster(i, mid);
-		} else {
-			MonsterHitMonster(mid, i, dam);
-		}
+	if (hit >= hper)
+		return;
+
+	int dam = (mind + GenerateRnd(maxd - mind + 1)) << 6;
+	monster._mhitpoints -= dam;
+	if (monster._mhitpoints >> 6 <= 0) {
+		StartDeathFromMonster(i, mid);
+	} else {
+		MonsterHitMonster(mid, i, dam);
 	}
 }
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1291,20 +1291,21 @@ void MonsterAttackMonster(int i, int mid, int hper, int mind, int maxd)
 	auto &monster = Monsters[mid];
 	assert(monster.MType != nullptr);
 
-	if (!monster.IsPossibleToHit()) {
-		int hit = GenerateRnd(100);
-		if (monster._mmode == MonsterMode::Petrified)
-			hit = 0;
-		if (monster.TryLiftGargoyle())
-			return;
-		if (hit < hper) {
-			int dam = (mind + GenerateRnd(maxd - mind + 1)) << 6;
-			monster._mhitpoints -= dam;
-			if (monster._mhitpoints >> 6 <= 0) {
-				StartDeathFromMonster(i, mid);
-			} else {
-				MonsterHitMonster(mid, i, dam);
-			}
+	if (!monster.IsPossibleToHit())
+		return;
+
+	int hit = GenerateRnd(100);
+	if (monster._mmode == MonsterMode::Petrified)
+		hit = 0;
+	if (monster.TryLiftGargoyle())
+		return;
+	if (hit < hper) {
+		int dam = (mind + GenerateRnd(maxd - mind + 1)) << 6;
+		monster._mhitpoints -= dam;
+		if (monster._mhitpoints >> 6 <= 0) {
+			StartDeathFromMonster(i, mid);
+		} else {
+			MonsterHitMonster(mid, i, dam);
 		}
 	}
 }


### PR DESCRIPTION
Fix for bug introduced in https://github.com/diasurgical/devilutionX/commit/417c4c9ce23e99475f366450b4274a9f0ab30b81
Sorry for that mistake.

Golems, and Berserkered monsters swing without hit.
Problem was negation (!) in `isPossibleToHit` , but I just returned early in this PR.