### PR TITLE
Add inverse transformation to match Displacement::worldToScreen

### DIFF
--- a/Source/engine/displacement.hpp
+++ b/Source/engine/displacement.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <cmath>
+#ifdef BUILD_TESTING
+#include <ostream>
+#endif
 
 #include "direction.hpp"
 #include "size.hpp"
@@ -120,9 +123,21 @@ struct Displacement {
 	 *
 	 * @return A representation of the original displacement in screen coordinates.
 	 */
-	constexpr Displacement WorldToScreen() const
+	constexpr Displacement worldToScreen() const
 	{
 		return { (deltaY - deltaX) * 32, (deltaY + deltaX) * -16 };
+	}
+
+	/**
+	 * @brief Returns a new Displacement object in world coordinates.
+	 *
+	 * This is an inverse matrix of the worldToScreen transformation.
+	 *
+	 * @return A representation of the original displacement in world coordinates.
+	 */
+	constexpr Displacement screenToWorld() const
+	{
+		return { (2 * deltaY + deltaX) / -64, (2 * deltaY - deltaX) / -64 };
 	}
 
 	constexpr Displacement Rotate(int quadrants)
@@ -136,6 +151,19 @@ struct Displacement {
 
 		return Displacement { deltaX * cosine - deltaY * sine, deltaX * sine + deltaY * cosine };
 	}
+
+#ifdef BUILD_TESTING
+	/**
+	 * @brief Format displacements nicely in test failure messages
+	 * @param stream output stream, expected to have overloads for int and char*
+	 * @param offset Object to display
+	 * @return the stream, to allow chaining
+	 */
+	friend std::ostream &operator<<(std::ostream &stream, const Displacement &offset)
+	{
+		return stream << "(x: " << offset.deltaX << ", y: " << offset.deltaY << ")";
+	}
+#endif
 
 private:
 	static constexpr Displacement fromDirection(Direction direction)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -181,7 +181,7 @@ void MoveMissilePos(Missile &missile)
 	auto target = missile.position.tile + moveDirection;
 	if (IsTileAvailable(Monsters[missile._misource], target)) {
 		missile.position.tile = target;
-		missile.position.offset += Displacement(moveDirection).WorldToScreen();
+		missile.position.offset += Displacement(moveDirection).worldToScreen();
 	}
 }
 

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -616,8 +616,8 @@ void DrawObject(const Surface &out, Point tilePosition, Point targetBufferPositi
 	Point screenPosition = targetBufferPosition - Displacement { CalculateWidth2(objectToDraw._oAnimWidth), 0 };
 	if (objectToDraw.position != tilePosition) {
 		// drawing a large or offset object, calculate the correct position for the center of the sprite
-		Displacement screenOffset = objectToDraw.position - tilePosition;
-		screenPosition -= screenOffset.WorldToScreen();
+		Displacement worldOffset = objectToDraw.position - tilePosition;
+		screenPosition -= worldOffset.worldToScreen();
 	}
 
 	byte *pCelBuff = objectToDraw._oAnimData;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(tests
   file_util_test
   inv_test
   lighting_test
+  math_test
   missiles_test
   pack_test
   path_test

--- a/test/math_test.cpp
+++ b/test/math_test.cpp
@@ -1,0 +1,31 @@
+#include <gtest/gtest.h>
+
+#include "engine/displacement.hpp"
+
+namespace devilution {
+
+TEST(MathTest, WorldScreenTransformation)
+{
+	Displacement offset = { 5, 2 };
+	// Diablo renders tiles with the world origin translated to the top left of the screen, while the normal convention
+	// has the screen origin at the bottom left. This means that we end up with negative offsets in screen space for
+	// tiles in world space where x > y
+	EXPECT_EQ(offset.worldToScreen(), Displacement(-96, -112));
+
+	// Transformation should be reversable (as long as it's not truncating)
+	EXPECT_EQ(offset.worldToScreen().screenToWorld(), offset);
+
+	// Tiles with y >= x will still have a negative y coordinate in screen space
+	offset = { 2, 5 };
+	EXPECT_EQ(offset.worldToScreen(), Displacement(96, -112));
+
+	// Most screen to world transformations will have a further displacement applied, this is a simple case of
+	// selecting a tile on the edge of the world with the default origin
+	Displacement cursorPosition = { 342, -150 };
+	EXPECT_EQ(cursorPosition.screenToWorld(), Displacement(0, 10));
+
+	// Screen > World transforms lose information, so cannot be reversed exactly using ints
+	EXPECT_EQ(cursorPosition.screenToWorld().worldToScreen(), Displacement(320, -160));
+}
+
+} // namespace devilution


### PR DESCRIPTION
Was intending to use this for missiles but haven't got around to it yet. Hopefully this helps whoever picks up #4619