### PR TITLE
Stop transmitting game info after leaving game

### DIFF
--- a/Source/dvlnet/base.cpp
+++ b/Source/dvlnet/base.cpp
@@ -397,6 +397,7 @@ bool base::SNetLeaveGame(int type)
 	auto pkt = pktfty->make_packet<PT_DISCONNECT>(plr_self, PLR_BROADCAST,
 	    plr_self, type);
 	send(*pkt);
+	plr_self = PLR_BROADCAST;
 	return true;
 }
 


### PR DESCRIPTION
ZeroTier code checks `plr_self != PLR_BROADCAST` when handling `PT_INFO_REQUEST` packets. Because `plr_self` isn't reset after leaving a game session, the client would continue sending `PT_INFO_REPLY` packets in response to requests so long as the player stayed in the ZeroTier menu. Game clients in this state would even handle `PT_JOIN_REQUEST` packets as normal, causing the remote player to end up in the progress dialog indefinitely while waiting for game data. If the remote client then cancels the progress dialog, it would trigger a `PT_DISCONNECT` packet which could either crash the game or cause the issue described in #4546.

This will likely help to resolve some of the crashes we've seen on Android.