### PR TITLE
Check if dthread is running before locking mutex

### DIFF
--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -60,6 +60,9 @@ void DthreadHandler()
 
 void dthread_remove_player(uint8_t pnum)
 {
+	if (!DthreadRunning)
+		return;
+
 	std::lock_guard<SdlMutex> lock(*DthreadMutex);
 	InfoList.remove_if([&](auto &pkt) {
 		return pkt.pnum == pnum;
@@ -68,7 +71,7 @@ void dthread_remove_player(uint8_t pnum)
 
 void dthread_send_delta(int pnum, _cmd_id cmd, std::unique_ptr<byte[]> data, uint32_t len)
 {
-	if (!gbIsMultiplayer)
+	if (!gbIsMultiplayer || !DthreadRunning)
 		return;
 
 	DThreadPkt pkt { pnum, cmd, std::move(data), len };


### PR DESCRIPTION
Prevents crashes that can occur in the game's menus when receiving `PT_DISCONNECT` packets from other clients. This would be most commonly seen when receiving a late `PT_DISCONNECT` from a party member after defeating Diablo or in the situation described in #4626.