### PR TITLE
Berserk light fix

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1228,6 +1228,12 @@ void UpdateMonsterLights()
 {
 	for (int i = 0; i < ActiveMonsterCount; i++) {
 		auto &monster = Monsters[ActiveMonsters[i]];
+
+		if ((monster._mFlags & MFLAG_BERSERK) != 0) {
+			int lightRadius = leveltype == DTYPE_NEST ? 9 : 3;
+			monster.mlid = AddLight(monster.position.tile, lightRadius);
+		}
+
 		if (monster.mlid != NO_LIGHT) {
 			if (monster.mlid == MyPlayer->_plid) { // Fix old saves where some monsters had 0 instead of NO_LIGHT
 				monster.mlid = NO_LIGHT;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -647,11 +647,6 @@ void LoadMonster(LoadHelper *file, Monster &monster)
 	if (monster.mlid == 0)
 		monster.mlid = NO_LIGHT; // Correct incorect values in old saves
 
-	if ((monster._mFlags & MFLAG_BERSERK) != 0) {
-		int lightRadius = leveltype == DTYPE_NEST ? 9 : 3;
-		monster.mlid = AddLight(monster.position.tile, lightRadius);
-	}
-
 	// Omit pointer mName;
 	// Omit pointer MType;
 	// Omit pointer MData;


### PR DESCRIPTION
This PR should

- fix delete player radius after kill berserked monster in singleplayer games. (fix https://github.com/diasurgical/devilutionX/issues/3166) 
- still fix https://github.com/diasurgical/devilutionX/issues/1588 

In the same time you may not be happy because it makes https://github.com/diasurgical/devilutionX/issues/1588 still occur (only 32 places for lights...)

Reproduce:

1. Save singleplayer dungeon level with berserked monster.
2. Quit Game
3. Run Game
4. Load SinglePlayer dungeon level with berserked monster.

There problem is already on load.
- It was introduced in https://github.com/diasurgical/devilutionX/pull/3121

To see it "in work":

5. Kill berserked monster (light id 0 will be deleted thanks to https://github.com/diasurgical/devilutionX/pull/3120 )
6. Wander around dungeon a bit (light radius of player is killed, all around pitch black).

call stack on load (step 4.)
```
 	devilutionx.exe!devilution::AddLight(devilution::Point position, int r) Line 917	C++
 	devilutionx.exe!devilution::`anonymous namespace'::LoadMonster(devilution::`anonymous-namespace'::LoadHelper * file, devilution::Monster & monster) Line 646	C++
 	devilutionx.exe!devilution::LoadGame(bool firstflag) Line 2033	C++
 	devilutionx.exe!devilution::ShowProgress(devilution::interface_mode uMsg) Line 247	C++
 	devilutionx.exe!devilution::`anonymous namespace'::StartGame(devilution::interface_mode uMsg) Line 162	C++
 	devilutionx.exe!devilution::`anonymous namespace'::RunGameLoop(devilution::interface_mode uMsg) Line 724	C++
 	devilutionx.exe!devilution::StartGame(bool bNewGame, bool bSinglePlayer) Line 1757	C++
	devilutionx.exe!devilution::`anonymous namespace'::InitMenu(devilution::_selhero_selections type) Line 57	C++
 	devilutionx.exe!devilution::`anonymous namespace'::InitSinglePlayerMenu() Line 68	C++
 	devilutionx.exe!devilution::mainmenu_loop() Line 160	C++
 	devilutionx.exe!devilution::DiabloMain(int argc, char * * argv) Line 1818	C++
 	devilutionx.exe!SDL_main(int argc, char * * argv) Line 46	C++
 	devilutionx.exe!main_getcmdline() Line 82	C
 	devilutionx.exe!WinMain(HINSTANCE__ * hInst, HINSTANCE__ * hPrev, char * szCmdLine, int sw) Line 115	C
 	[External Code]	
```

The problem:

`LoadMonster` calls `AddLight` and it returns 0.
So first berserked monster on list will get its `mlid` as `0`. And 0 is loaded from savegame as `Light` id for Player 0 Both during unpacking stage before choosing savegame, and later during load lights from savegame.
The reason why `Addlight` returns 0 is because `ActiveLights` array is not initialized at this moment. It is full of zeroes.
(So `AddLight` tries to get some free ID out of this array, but get always zero at this moment.)
This is because `ActiveLights` initialization in `InitLighting` is not called in `Load Game` - > `LoadGameLevel`, because of this line:
```c++
	if (leveltype != DTYPE_TOWN && lvldir != ENTRY_LOAD) {
		InitLighting();
		InitVision();
	}
```
and `lvldir == ENTRY_LOAD` because it is loading savegame.

Now the most weird part. It seems that in `ActiveLights` is not cleared during program run session. It will contain some garbage in next load game. Thus steps 2 and 3, and that's why it was not so simple to reproduce. Even with that garbage the monster will usually have his *own* lightsource :) but not on 1st load, and sometimes sharing it with something else than player... probably?

Because of that I thought it would be good to limit the condition only to `leveltype != DTYPE_TOWN`. But it was wrong solution, because during `LoadGameLevel`,  `PlayerInit` is also not called if `lvldir == ENTRY_LOAD`... And monster still got `mlid` as `0`.
Thus I thought to not worry about that garbage, since it should be properly cleared later in `LoadLighting`.

So I moved adding the light out of `LoadMonster`.
and placed it behind `LoadLighting`, so if there will be any of 32 places for lights left  - it will be added. If not - sorry, no banana.

But then I realized it is not needed at all - because savegame has saved lights from berserked monster...
And because of that, previous light ID is orphaned, and monster has assigned new light id...
So definetely not what I wanted.

I decided to remove it, because the light is already saved in savegame.
But still I was bothered what was wrong with https://github.com/diasurgical/devilutionX/issues/1588 
It seems that it is not about loading game (calling `LoadGame`) but `LoadGameLevel` after let's say trip to town via Town Portal.
Seems that after walking back from town to dungeon ActiveLightCount is back to zero... and then populated by `InitPlayer` and so on.
But near the end of `LoadGameLevel` there is `UpdateMonsterLights`!
It does its job.. but then `ProcessLightList` and guess what  `ActiveLightCount` was only set by `InitPlayer` and no counted for monsters... (maybe it is somewhere for unieques...)

So, finally I decided to just add this at the begining of `UpdateMonsterLights` which is called only from `LoadGameLevel`.

To clarify: `LoadGameLevel` is called in both situations - during trip from town to dungeon, and during `LoadGame` from savefile.
In both cases it calls `UpdateMonsterLights` but 
in 1st case - Monsters table has monsters with Berserk flag already - set during game session. 
In 2nd case - Monsters table has monsters without Berserk flag yet - it will be updated when processing `LoadGameLevel` will finish, and control will be back in `LoadGame` and will call `LoadMonster`. And Lights will be loaded in `LoadLighting`.
So all good. It will add Berserk lights when it is needed - on dungeon level change - where it was lost. Not on loading save game - where it was OK.

I think it does the job.

ouf, that was long. Is that make berserk better? Not necessary. Is light nicer? No. Does it fix the problem? Yes. It worked for me :)
