### PR TITLE
[Original Hellfire bug] Fix for Berserked monsters hit don't wake up other meele monsters

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1309,6 +1309,12 @@ void MonsterAttackMonster(int i, int mid, int hper, int mind, int maxd)
 	} else {
 		MonsterHitMonster(mid, i, dam);
 	}
+
+	Monster &attackingMonster = Monsters[i];
+	if (monster._msquelch == 0) {
+		monster._msquelch = UINT8_MAX;
+		monster.position.last = attackingMonster.position.tile;
+	}
 }
 
 void CheckReflect(int mon, int pnum, int dam)


### PR DESCRIPTION
This PR is proposition to fix bug that makes berserked melee monsters attacking other melee monsters do not wake up when hit.
Bug is also in original Hellfire.

Consider situation: Player cast berserserk on hidden-type behind the wall (which is always active), and that hidden starts to kill every monster behind the wall without waking them up.
It can be abused even with non-hidden ones - just put them at the room door (like with stone curse) and open door with telekinesis - and he will clear all room :)
But for sure hidden ones are the easiest to abuse.

Only ranged monsters will see golems and berserked monsters from far away and react immediately.
Melee monsters won't even wake up.

Fix wakes up melee monsters that are succesful hit.
You may consider to change it to other moment - like on try to hit, or even at sight.
Golems have short activating distance only at presence:
https://github.com/diasurgical/devilutionX/blob/9c0ec048b42aa58e2acb177929e340d60954f332/Source/monster.cpp#L4206-L4209