### PR TITLE
Additional helpers for converting between world/screen space for missiles

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -100,22 +100,18 @@ constexpr Direction16 Direction16Flip(Direction16 x, Direction16 pivot)
 	return static_cast<Direction16>(ret);
 }
 
-void UpdateMissileVelocity(Missile &missile, Point destination, int v)
+void UpdateMissileVelocity(Missile &missile, Point destination, int velocityInPixels)
 {
 	missile.position.velocity = { 0, 0 };
 
 	if (missile.position.tile == destination)
 		return;
 
-	// rotate so that +x leads to the right of screen and +y leads to the bottom (screen space but without the scaling factor)
-	double dxp = (destination.x + missile.position.tile.y - missile.position.tile.x - destination.y);
-	double dyp = (destination.y + destination.x - missile.position.tile.x - missile.position.tile.y);
-	double dr = sqrt(dxp * dxp + dyp * dyp);
-	// velocity is stored in screen coordinates so apply the scaling factor to the y axis while normalizing.
-	double normalizedX = dxp / dr;
-	double normalizedY = dyp / dr / 2;
-	missile.position.velocity.deltaX = static_cast<int>(normalizedX * (v << 16));
-	missile.position.velocity.deltaY = static_cast<int>(normalizedY * (v << 16));
+	// Get the normalized vector in isometric projection
+	Displacement fixed16NormalVector = (missile.position.tile - destination).worldToNormalScreen();
+
+	// Multiplying by the target velocity gives us a scaled velocity vector.
+	missile.position.velocity = fixed16NormalVector * velocityInPixels;
 }
 
 /**

--- a/test/math_test.cpp
+++ b/test/math_test.cpp
@@ -6,7 +6,7 @@ namespace devilution {
 
 TEST(MathTest, WorldScreenTransformation)
 {
-	Displacement offset = { 5, 2 };
+	Displacement offset { 5, 2 };
 	// Diablo renders tiles with the world origin translated to the top left of the screen, while the normal convention
 	// has the screen origin at the bottom left. This means that we end up with negative offsets in screen space for
 	// tiles in world space where x > y
@@ -26,6 +26,37 @@ TEST(MathTest, WorldScreenTransformation)
 
 	// Screen > World transforms lose information, so cannot be reversed exactly using ints
 	EXPECT_EQ(cursorPosition.screenToWorld().worldToScreen(), Displacement(320, -160));
+}
+
+TEST(MathTest, NormalizeDisplacement)
+{
+	// Normalizing displacements transforms the value into 16 bit fixed point representations
+	Displacement vector { 5, 0 };
+	EXPECT_FLOAT_EQ(vector.magnitude(), 5);
+	EXPECT_EQ(vector.normalized(), Displacement(1 << 16, 0)); // (1.0, 0.0)
+
+	vector = { 3, 4 };
+	EXPECT_FLOAT_EQ(vector.magnitude(), 5);
+	EXPECT_EQ(vector.normalized(), Displacement(39321, 52428)); // ~(0.6, 0.8)
+
+	vector = { -5, 2 };
+	EXPECT_FLOAT_EQ(vector.magnitude(), 5.3851647f);
+	EXPECT_EQ(vector.normalized(), Displacement(-60848, 24339)); // ~(-0.92, 0.37)
+}
+
+TEST(MathTest, MissileTransformation)
+{
+	// starting with a Displacement 2 world units West results in a vector pointing left of screen
+	EXPECT_EQ(Displacement(2, -2).worldToNormalScreen(), Displacement(-65536, 0));
+
+	// if it's not normalizing the vector then it's a problem :D
+	EXPECT_EQ(Displacement(4, -4).worldToNormalScreen(), Displacement(-65536, 0));
+
+	// Because of the isometric projection the y axis gets squashed
+	EXPECT_EQ(Displacement(8, 1).worldToNormalScreen(), Displacement(-40235, -25865)); // ~(0.6, 0.8/2)
+
+	// in elevation projection this would be a vector with x == y, isometric projection means y == x/2
+	EXPECT_EQ(Displacement(8, 0).worldToNormalScreen(), Displacement(-46340, -23170)); // ~(0.7, 0.7/2)
 }
 
 } // namespace devilution


### PR DESCRIPTION
The missile velocity calculation was bugging me, these helpers hopefully describe what the math is doing and also potentially allow changing the implementation (if we want to do it entirely in fixed point on platforms without an FPU for example).