### PR TITLE
Reintroduce c-str overload for SetIniValue()

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -197,14 +197,19 @@ void SetIniValue(const char *keyname, const char *valuename, float value)
 	GetIni().SetDoubleValue(keyname, valuename, value, nullptr, true);
 }
 
+void SetIniValue(const char *sectionName, const char *keyName, const char *value)
+{
+	IniChangedChecker changedChecker(sectionName, keyName);
+	auto &ini = GetIni();
+	ini.SetValue(sectionName, keyName, value, nullptr, true);
+}
+
 void SetIniValue(string_view sectionName, string_view keyName, string_view value)
 {
 	std::string sectionNameStr { sectionName };
 	std::string keyNameStr { keyName };
 	std::string valueStr { value };
-	IniChangedChecker changedChecker(sectionNameStr.c_str(), keyNameStr.c_str());
-	auto &ini = GetIni();
-	ini.SetValue(sectionNameStr.c_str(), keyNameStr.c_str(), valueStr.c_str(), nullptr, true);
+	SetIniValue(sectionNameStr.c_str(), keyNameStr.c_str(), valueStr.c_str());
 }
 
 void SetIniValue(const char *keyname, const char *valuename, const std::vector<std::string> &stringValues)


### PR DESCRIPTION
Resolves an issue (introduced by #4544) where all keymapper settings, as well as a handful of other settings in various categories, were selecting the Boolean overload for `SetIniValue()` because they were not explicitly using the `string_view` type to represent section name, key name, and value.

I'm not sure if this is the best approach, but modifying all overloads to use `string_view` instead of `const char *` didn't seem to solve the problem so this is the best I could come up with. I guess C++ considers `bool` a better match for `const char *` than `string_view`, at least in MSVC.