### PR TITLE
Use 0-based frame index for talk buttons

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1139,12 +1139,12 @@ void DrawTalkPan(const Surface &out)
 		const Point talkPanPosition = mainPanelPosition + Displacement { 172, 84 + 18 * talkBtn };
 		if (WhisperList[i]) {
 			if (TalkButtonsDown[talkBtn]) {
-				int nCel = talkBtn != 0 ? 4 : 3;
+				int nCel = talkBtn != 0 ? 3 : 2;
 				CelDrawTo(out, talkPanPosition, *talkButtons, nCel);
 				DrawArt(out, talkPanPosition + Displacement { 4, -15 }, &TalkButton, 2);
 			}
 		} else {
-			int nCel = talkBtn != 0 ? 2 : 1;
+			int nCel = talkBtn != 0 ? 1 : 0;
 			if (TalkButtonsDown[talkBtn])
 				nCel += 4;
 			CelDrawTo(out, talkPanPosition, *talkButtons, nCel);


### PR DESCRIPTION
Only the top button uses a different graphic because the demon statue's wing overlaps the button. So only the middle and bottom buttons would attempt to use the last frame of the CEL, which is the depressed mute button.

It's really hard to tell what's going on with the CEL because we draw over the buttons so they can be translated. It's easiest to see if you focus on the part of the button that overlaps with the wing.

This resolves #4608