### PR TITLE
Copy test fixtures to build dir (handle default VS2022 directory structure)

### DIFF
--- a/Source/engine/point.hpp
+++ b/Source/engine/point.hpp
@@ -16,6 +16,14 @@ struct Point {
 	int x;
 	int y;
 
+	Point() = default;
+
+	constexpr Point(int x, int y)
+	    : x(x)
+	    , y(y)
+	{
+	}
+
 	constexpr bool operator==(const Point &other) const
 	{
 		return x == other.x && y == other.y;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,8 @@ set(tests
   writehero_test
 )
 
+include(Fixtures.cmake)
+
 foreach(test_target ${tests})
   add_executable(${test_target} "${test_target}.cpp")
   gtest_discover_tests(${test_target})

--- a/test/Fixtures.cmake
+++ b/test/Fixtures.cmake
@@ -1,0 +1,37 @@
+if(NOT DEFINED DEVILUTIONX_TEST_FIXTURES_OUTPUT_DIRECTORY)
+  set(DEVILUTIONX_TEST_FIXTURES_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/fixtures")
+endif()
+
+set(devilutionx_fixtures
+  diablo/1-743271966.dun
+  diablo/2-1383137027.dun
+  diablo/3-844660068.dun
+  diablo/4-609325643.dun
+  diablo/5-1677631846.dun
+  diablo/6-2034738122.dun
+  diablo/7-680552750.dun
+  diablo/8-1999936419.dun
+  hellfire/1-401921334.dun
+  hellfire/2-128964898.dun
+  hellfire/3-1799396623.dun
+  hellfire/4-1190318991.dun
+  hellfire/21-2122696790.dun
+  hellfire/22-1191662129.dun
+  hellfire/23-97055268.dun
+  hellfire/24-1324803725.dun
+)
+
+foreach(fixture ${devilutionx_fixtures})
+  set(src "${CMAKE_CURRENT_SOURCE_DIR}/fixtures/${fixture}")
+  set(dst "${DEVILUTIONX_TEST_FIXTURES_OUTPUT_DIRECTORY}/${fixture}")
+  list(APPEND DEVILUTIONX_OUTPUT_TEST_FIXTURES_FILES "${dst}")
+  add_custom_command(
+    COMMENT "Copying ${fixture}"
+    OUTPUT "${dst}"
+    DEPENDS "${src}"
+    COMMAND ${CMAKE_COMMAND} -E copy "${src}" "${dst}"
+    VERBATIM)
+endforeach()
+
+add_custom_target(devilutionx_copied_fixtures DEPENDS ${DEVILUTIONX_OUTPUT_TEST_FIXTURES_FILES})
+add_dependencies(test_main devilutionx_copied_fixtures)

--- a/test/drlg_l1_test.cpp
+++ b/test/drlg_l1_test.cpp
@@ -47,12 +47,12 @@ void TestCreateL5Dungeon(bool hellfire, int level, uint32_t seed, lvl_entry entr
 	paths::SetPrefPath(path);
 	std::string dunPath;
 	if (hellfire)
-		dunPath = fmt::format("../test/fixtures/hellfire/{}-{}.dun", level, seed);
+		dunPath = fmt::format("test/fixtures/hellfire/{}-{}.dun", level, seed);
 	else
-		dunPath = fmt::format("../test/fixtures/diablo/{}-{}.dun", level, seed);
+		dunPath = fmt::format("test/fixtures/diablo/{}-{}.dun", level, seed);
 	auto dunData = LoadFileInMem<uint16_t>(dunPath.c_str());
-	ASSERT_EQ(DMAXX, dunData[0]);
-	ASSERT_EQ(DMAXY, dunData[1]);
+	ASSERT_NE(dunData, nullptr) << "Unable to load test fixture " << dunPath;
+	ASSERT_EQ(Size(DMAXX, DMAXY), Size(dunData[0], dunData[1]));
 
 	const uint16_t *tileLayer = &dunData[2];
 

--- a/test/drlg_l1_test.cpp
+++ b/test/drlg_l1_test.cpp
@@ -78,11 +78,9 @@ void TestCreateL5Dungeon(bool hellfire, int level, uint32_t seed, lvl_entry entr
 TEST(Drlg_l1, CreateL5Dungeon_diablo_1_743271966)
 {
 	TestCreateL5Dungeon(false, 1, 743271966, ENTRY_MAIN);
-	EXPECT_EQ(ViewPosition.x, 51);
-	EXPECT_EQ(ViewPosition.y, 82);
+	EXPECT_EQ(ViewPosition, Point(51, 82));
 	TestCreateL5Dungeon(false, 1, 743271966, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition.x, 81);
-	EXPECT_EQ(ViewPosition.y, 47);
+	EXPECT_EQ(ViewPosition, Point(81, 47));
 }
 
 TEST(Drlg_l1, CreateL5Dungeon_diablo_2_1383137027)
@@ -91,41 +89,33 @@ TEST(Drlg_l1, CreateL5Dungeon_diablo_2_1383137027)
 	Quests[Q_PWATER]._qactive = QUEST_INIT;
 
 	TestCreateL5Dungeon(false, 2, 1383137027, ENTRY_MAIN);
-	EXPECT_EQ(ViewPosition.x, 57);
-	EXPECT_EQ(ViewPosition.y, 74);
+	EXPECT_EQ(ViewPosition, Point(57, 74));
 	TestCreateL5Dungeon(false, 2, 1383137027, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition.x, 57);
-	EXPECT_EQ(ViewPosition.y, 79);
+	EXPECT_EQ(ViewPosition, Point(57, 79));
 }
 
 TEST(Drlg_l1, CreateL5Dungeon_diablo_3_844660068)
 {
 	TestCreateL5Dungeon(false, 3, 844660068, ENTRY_MAIN);
-	EXPECT_EQ(ViewPosition.x, 67);
-	EXPECT_EQ(ViewPosition.y, 52);
+	EXPECT_EQ(ViewPosition, Point(67, 52));
 	TestCreateL5Dungeon(false, 3, 844660068, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition.x, 85);
-	EXPECT_EQ(ViewPosition.y, 45);
+	EXPECT_EQ(ViewPosition, Point(85, 45));
 }
 
 TEST(Drlg_l1, CreateL5Dungeon_diablo_4_609325643)
 {
 	TestCreateL5Dungeon(false, 4, 609325643, ENTRY_MAIN);
-	EXPECT_EQ(ViewPosition.x, 85);
-	EXPECT_EQ(ViewPosition.y, 78);
+	EXPECT_EQ(ViewPosition, Point(85, 78));
 	TestCreateL5Dungeon(false, 4, 609325643, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition.x, 55);
-	EXPECT_EQ(ViewPosition.y, 47);
+	EXPECT_EQ(ViewPosition, Point(55, 47));
 }
 
 TEST(Drlg_l1, CreateL5Dungeon_hellfire_1_401921334)
 {
 	TestCreateL5Dungeon(true, 1, 401921334, ENTRY_MAIN);
-	EXPECT_EQ(ViewPosition.x, 79);
-	EXPECT_EQ(ViewPosition.y, 80);
+	EXPECT_EQ(ViewPosition, Point(79, 80));
 	TestCreateL5Dungeon(true, 1, 401921334, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition.x, 49);
-	EXPECT_EQ(ViewPosition.y, 63);
+	EXPECT_EQ(ViewPosition, Point(49, 63));
 }
 
 TEST(Drlg_l1, CreateL5Dungeon_hellfire_2_128964898)
@@ -133,41 +123,33 @@ TEST(Drlg_l1, CreateL5Dungeon_hellfire_2_128964898)
 	Quests[Q_PWATER]._qactive = QUEST_NOTAVAIL;
 
 	TestCreateL5Dungeon(true, 2, 128964898, ENTRY_MAIN);
-	EXPECT_EQ(ViewPosition.x, 55);
-	EXPECT_EQ(ViewPosition.y, 68);
+	EXPECT_EQ(ViewPosition, Point(55, 68));
 	TestCreateL5Dungeon(true, 2, 128964898, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition.x, 49);
-	EXPECT_EQ(ViewPosition.y, 63);
+	EXPECT_EQ(ViewPosition, Point(49, 63));
 }
 
 TEST(Drlg_l1, CreateL5Dungeon_hellfire_3_1799396623)
 {
 	TestCreateL5Dungeon(true, 3, 1799396623, ENTRY_MAIN);
-	EXPECT_EQ(ViewPosition.x, 59);
-	EXPECT_EQ(ViewPosition.y, 68);
+	EXPECT_EQ(ViewPosition, Point(59, 68));
 	TestCreateL5Dungeon(true, 3, 1799396623, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition.x, 47);
-	EXPECT_EQ(ViewPosition.y, 55);
+	EXPECT_EQ(ViewPosition, Point(47, 55));
 }
 
 TEST(Drlg_l1, CreateL5Dungeon_hellfire_4_1190318991)
 {
 	TestCreateL5Dungeon(true, 4, 1190318991, ENTRY_MAIN);
-	EXPECT_EQ(ViewPosition.x, 67);
-	EXPECT_EQ(ViewPosition.y, 80);
+	EXPECT_EQ(ViewPosition, Point(67, 80));
 	TestCreateL5Dungeon(true, 4, 1190318991, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition.x, 77);
-	EXPECT_EQ(ViewPosition.y, 45);
+	EXPECT_EQ(ViewPosition, Point(77, 45));
 }
 
 TEST(Drlg_l1, CreateL5Dungeon_crypt_1_2122696790)
 {
 	TestCreateL5Dungeon(true, 21, 2122696790, ENTRY_TWARPUP);
-	EXPECT_EQ(ViewPosition.x, 61);
-	EXPECT_EQ(ViewPosition.y, 80);
+	EXPECT_EQ(ViewPosition, Point(61, 80));
 	TestCreateL5Dungeon(true, 21, 2122696790, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition.x, 53);
-	EXPECT_EQ(ViewPosition.y, 67);
+	EXPECT_EQ(ViewPosition, Point(53, 67));
 }
 
 TEST(Drlg_l1, CreateL5Dungeon_crypt_2_1191662129)
@@ -175,28 +157,23 @@ TEST(Drlg_l1, CreateL5Dungeon_crypt_2_1191662129)
 	Quests[Q_PWATER]._qactive = QUEST_NOTAVAIL;
 
 	TestCreateL5Dungeon(true, 22, 1191662129, ENTRY_MAIN);
-	EXPECT_EQ(ViewPosition.x, 71);
-	EXPECT_EQ(ViewPosition.y, 47);
+	EXPECT_EQ(ViewPosition, Point(71, 47));
 	TestCreateL5Dungeon(true, 22, 1191662129, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition.x, 85);
-	EXPECT_EQ(ViewPosition.y, 71);
+	EXPECT_EQ(ViewPosition, Point(85, 71));
 }
 
 TEST(Drlg_l1, CreateL5Dungeon_crypt_3_97055268)
 {
 	TestCreateL5Dungeon(true, 23, 97055268, ENTRY_MAIN);
-	EXPECT_EQ(ViewPosition.x, 71);
-	EXPECT_EQ(ViewPosition.y, 57);
+	EXPECT_EQ(ViewPosition, Point(71, 57));
 	TestCreateL5Dungeon(true, 23, 97055268, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition.x, 81);
-	EXPECT_EQ(ViewPosition.y, 59);
+	EXPECT_EQ(ViewPosition, Point(81, 59));
 }
 
 TEST(Drlg_l1, CreateL5Dungeon_crypt_4_1324803725)
 {
 	TestCreateL5Dungeon(true, 24, 1324803725, ENTRY_MAIN);
-	EXPECT_EQ(ViewPosition.x, 79);
-	EXPECT_EQ(ViewPosition.y, 47);
+	EXPECT_EQ(ViewPosition, Point(79, 47));
 }
 
 } // namespace

--- a/test/drlg_l2_test.cpp
+++ b/test/drlg_l2_test.cpp
@@ -21,10 +21,10 @@ void TestCreateL2Dungeon(int level, uint32_t seed, lvl_entry entry)
 	std::string path = paths::BasePath();
 
 	paths::SetPrefPath(path);
-	std::string dunPath = fmt::format("../test/fixtures/diablo/{}-{}.dun", level, seed);
+	std::string dunPath = fmt::format("test/fixtures/diablo/{}-{}.dun", level, seed);
 	auto dunData = LoadFileInMem<uint16_t>(dunPath.c_str());
-	ASSERT_EQ(DMAXX, dunData[0]);
-	ASSERT_EQ(DMAXY, dunData[1]);
+	ASSERT_NE(dunData, nullptr) << "Unable to load test fixture " << dunPath;
+	ASSERT_EQ(Size(DMAXX, DMAXY), Size(dunData[0], dunData[1]));
 
 	const uint16_t *tileLayer = &dunData[2];
 

--- a/test/drlg_l2_test.cpp
+++ b/test/drlg_l2_test.cpp
@@ -50,41 +50,33 @@ void TestCreateL2Dungeon(int level, uint32_t seed, lvl_entry entry)
 TEST(Drlg_l1, CreateL2Dungeon_diablo_5_1677631846)
 {
 	TestCreateL2Dungeon(5, 1677631846, ENTRY_MAIN);
-	EXPECT_EQ(ViewPosition.x, 27);
-	EXPECT_EQ(ViewPosition.y, 28);
+	EXPECT_EQ(ViewPosition, Point(27, 28));
 	TestCreateL2Dungeon(5, 1677631846, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition.x, 26);
-	EXPECT_EQ(ViewPosition.y, 62);
+	EXPECT_EQ(ViewPosition, Point(26, 62));
 }
 
 TEST(Drlg_l1, CreateL2Dungeon_diablo_6_2034738122)
 {
 	TestCreateL2Dungeon(6, 2034738122, ENTRY_MAIN);
-	EXPECT_EQ(ViewPosition.x, 33);
-	EXPECT_EQ(ViewPosition.y, 26);
+	EXPECT_EQ(ViewPosition, Point(33, 26));
 	TestCreateL2Dungeon(6, 2034738122, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition.x, 34);
-	EXPECT_EQ(ViewPosition.y, 52);
+	EXPECT_EQ(ViewPosition, Point(34, 52));
 }
 
 TEST(Drlg_l1, CreateL2Dungeon_diablo_7_680552750)
 {
 	TestCreateL2Dungeon(7, 680552750, ENTRY_MAIN);
-	EXPECT_EQ(ViewPosition.x, 27);
-	EXPECT_EQ(ViewPosition.y, 26);
+	EXPECT_EQ(ViewPosition, Point(27, 26));
 	TestCreateL2Dungeon(7, 680552750, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition.x, 78);
-	EXPECT_EQ(ViewPosition.y, 52);
+	EXPECT_EQ(ViewPosition, Point(78, 52));
 }
 
 TEST(Drlg_l1, CreateL2Dungeon_diablo_8_1999936419)
 {
 	TestCreateL2Dungeon(8, 1999936419, ENTRY_MAIN);
-	EXPECT_EQ(ViewPosition.x, 39);
-	EXPECT_EQ(ViewPosition.y, 74);
+	EXPECT_EQ(ViewPosition, Point(39, 74));
 	TestCreateL2Dungeon(8, 1999936419, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition.x, 48);
-	EXPECT_EQ(ViewPosition.y, 46);
+	EXPECT_EQ(ViewPosition, Point(48, 46));
 }
 
 } // namespace


### PR DESCRIPTION
Tests were failing because visual studio uses an intermediate build directory for each configuration, going up one level wasn't enough to reference the test source directory.