### PR TITLE
Check player hitpoints in InGameMenu()

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -60,7 +60,7 @@ bool InGameMenu()
 	    || qtextflag
 	    || gmenu_is_active()
 	    || PauseMode == 2
-	    || MyPlayer->_pInvincible;
+	    || (MyPlayer->_pInvincible && MyPlayer->_pHitPoints == 0);
 }
 
 namespace {


### PR DESCRIPTION
I analyzed all the locations in the codebase where `_pInvincible` is assigned, and it seems like my theory in https://github.com/diasurgical/devilutionX/issues/4427#issuecomment-1099145676 was probably correct. Most places that need to determine whether the player is dead check both this flag as well as the player's hitpoints so I did the same thing here.

This resolves #4427

---

Here are my notes for all the places where `_pInvincible` is assigned.

```
LoadPlayer()
    Remember what it was when game was saved

MI_Flash()
MI_Flash2()
    I-frames

StartNewLvl()
RestartTownLvl()
StartWarpLvl()
    MyPlayerId invincible when warping

InitPlayer()
    No longer invincible after warping

StartPlayerKill()
    Invincible when dying/dead

DoResurrect()
RestartTownLvl()
    No longer invincible when revived

GamemenuNewGame()
PrepDoEnding()
    All players invincible before leaving game
```