### PR TITLE
Rename `inv_iterators` methods to `camelCase`

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1948,13 +1948,10 @@ bool UseScroll(const spell_id spell)
 	if (pcurs != CURSOR_HAND)
 		return false;
 
-	Player &myPlayer = *MyPlayer;
-
 	if (leveltype == DTYPE_TOWN && !spelldata[spell].sTownSpell)
 		return false;
 
-	const InventoryAndBeltPlayerItemsRange items { myPlayer };
-	return std::any_of(items.begin(), items.end(), [spell](const Item &item) {
+	return HasInventoryOrBeltItem(*MyPlayer, [spell](const Item &item) {
 		return item.isScrollOf(spell);
 	});
 }

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -304,7 +304,7 @@ bool RemoveInventoryItem(Player &player, Predicate &&predicate)
 	const auto it = std::find_if(items.begin(), items.end(), std::forward<Predicate>(predicate));
 	if (it == items.end())
 		return false;
-	player.RemoveInvItem(static_cast<int>(it.Index()));
+	player.RemoveInvItem(static_cast<int>(it.index()));
 	return true;
 }
 
@@ -320,7 +320,7 @@ bool RemoveBeltItem(Player &player, Predicate &&predicate)
 	const auto it = std::find_if(items.begin(), items.end(), std::forward<Predicate>(predicate));
 	if (it == items.end())
 		return false;
-	player.RemoveSpdBarItem(static_cast<int>(it.Index()));
+	player.RemoveSpdBarItem(static_cast<int>(it.index()));
 	return true;
 }
 

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -354,7 +354,7 @@ inline bool RemoveInventoryItemById(Player &player, _item_indexes id)
  */
 inline bool RemoveBeltItemById(Player &player, _item_indexes id)
 {
-	return RemoveInventoryItem(player, [id](const Item &item) {
+	return RemoveBeltItem(player, [id](const Item &item) {
 		return item.IDidx == id;
 	});
 }

--- a/Source/inv_iterators.hpp
+++ b/Source/inv_iterators.hpp
@@ -30,7 +30,7 @@ public:
 		    , count_(count)
 		    , index_(index)
 		{
-			AdvancePastEmpty();
+			advancePastEmpty();
 		}
 
 		pointer operator->() const
@@ -46,7 +46,7 @@ public:
 		Iterator &operator++()
 		{
 			++index_;
-			AdvancePastEmpty();
+			advancePastEmpty();
 			return *this;
 		}
 
@@ -67,18 +67,18 @@ public:
 			return !(*this == other);
 		}
 
-		[[nodiscard]] bool AtEnd() const
+		[[nodiscard]] bool atEnd() const
 		{
 			return index_ == count_;
 		}
 
-		[[nodiscard]] std::size_t Index() const
+		[[nodiscard]] std::size_t index() const
 		{
 			return index_;
 		}
 
 	private:
-		void AdvancePastEmpty()
+		void advancePastEmpty()
 		{
 			while (index_ < count_ && items_[index_].isEmpty()) {
 				++index_;
@@ -96,12 +96,12 @@ public:
 	{
 	}
 
-	[[nodiscard]] Iterator begin() const // NOLINT(readability-identifier-naming)
+	[[nodiscard]] Iterator begin() const
 	{
 		return Iterator { items_, count_, 0 };
 	}
 
-	[[nodiscard]] Iterator end() const // NOLINT(readability-identifier-naming)
+	[[nodiscard]] Iterator end() const
 	{
 		return Iterator { nullptr, count_, count_ };
 	}
@@ -129,7 +129,7 @@ public:
 		explicit Iterator(std::vector<ItemsContainerRange::Iterator> iterators)
 		    : iterators_(std::move(iterators))
 		{
-			AdvancePastEmpty();
+			advancePastEmpty();
 		}
 
 		pointer operator->() const
@@ -145,7 +145,7 @@ public:
 		Iterator &operator++()
 		{
 			++iterators_[current_];
-			AdvancePastEmpty();
+			advancePastEmpty();
 			return *this;
 		}
 
@@ -166,9 +166,9 @@ public:
 		}
 
 	private:
-		void AdvancePastEmpty()
+		void advancePastEmpty()
 		{
-			while (current_ + 1 < iterators_.size() && iterators_[current_].AtEnd()) {
+			while (current_ + 1 < iterators_.size() && iterators_[current_].atEnd()) {
 				++current_;
 			}
 		}
@@ -188,18 +188,18 @@ public:
 	{
 	}
 
-	[[nodiscard]] ItemsContainerRange::Iterator begin() const // NOLINT(readability-identifier-naming)
+	[[nodiscard]] ItemsContainerRange::Iterator begin() const
 	{
-		return ItemsContainerRange::Iterator { &player_->InvBody[0], ContainerSize(), 0 };
+		return ItemsContainerRange::Iterator { &player_->InvBody[0], containerSize(), 0 };
 	}
 
-	[[nodiscard]] ItemsContainerRange::Iterator end() const // NOLINT(readability-identifier-naming)
+	[[nodiscard]] ItemsContainerRange::Iterator end() const
 	{
-		return ItemsContainerRange::Iterator { nullptr, ContainerSize(), ContainerSize() };
+		return ItemsContainerRange::Iterator { nullptr, containerSize(), containerSize() };
 	}
 
 private:
-	[[nodiscard]] std::size_t ContainerSize() const
+	[[nodiscard]] std::size_t containerSize() const
 	{
 		return sizeof(player_->InvBody) / sizeof(player_->InvBody[0]);
 	}
@@ -217,18 +217,18 @@ public:
 	{
 	}
 
-	[[nodiscard]] ItemsContainerRange::Iterator begin() const // NOLINT(readability-identifier-naming)
+	[[nodiscard]] ItemsContainerRange::Iterator begin() const
 	{
-		return ItemsContainerRange::Iterator { &player_->InvList[0], ContainerSize(), 0 };
+		return ItemsContainerRange::Iterator { &player_->InvList[0], containerSize(), 0 };
 	}
 
-	[[nodiscard]] ItemsContainerRange::Iterator end() const // NOLINT(readability-identifier-naming)
+	[[nodiscard]] ItemsContainerRange::Iterator end() const
 	{
-		return ItemsContainerRange::Iterator { nullptr, ContainerSize(), ContainerSize() };
+		return ItemsContainerRange::Iterator { nullptr, containerSize(), containerSize() };
 	}
 
 private:
-	[[nodiscard]] std::size_t ContainerSize() const
+	[[nodiscard]] std::size_t containerSize() const
 	{
 		return static_cast<std::size_t>(player_->_pNumInv);
 	}
@@ -246,18 +246,18 @@ public:
 	{
 	}
 
-	[[nodiscard]] ItemsContainerRange::Iterator begin() const // NOLINT(readability-identifier-naming)
+	[[nodiscard]] ItemsContainerRange::Iterator begin() const
 	{
-		return ItemsContainerRange::Iterator { &player_->SpdList[0], ContainerSize(), 0 };
+		return ItemsContainerRange::Iterator { &player_->SpdList[0], containerSize(), 0 };
 	}
 
-	[[nodiscard]] ItemsContainerRange::Iterator end() const // NOLINT(readability-identifier-naming)
+	[[nodiscard]] ItemsContainerRange::Iterator end() const
 	{
-		return ItemsContainerRange::Iterator { nullptr, ContainerSize(), ContainerSize() };
+		return ItemsContainerRange::Iterator { nullptr, containerSize(), containerSize() };
 	}
 
 private:
-	[[nodiscard]] std::size_t ContainerSize() const
+	[[nodiscard]] std::size_t containerSize() const
 	{
 		return sizeof(player_->SpdList) / sizeof(player_->SpdList[0]);
 	}
@@ -275,7 +275,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] ItemsContainerListRange::Iterator begin() const // NOLINT(readability-identifier-naming)
+	[[nodiscard]] ItemsContainerListRange::Iterator begin() const
 	{
 		return ItemsContainerListRange::Iterator({
 		    InventoryPlayerItemsRange(*player_).begin(),
@@ -283,7 +283,7 @@ public:
 		});
 	}
 
-	[[nodiscard]] ItemsContainerListRange::Iterator end() const // NOLINT(readability-identifier-naming)
+	[[nodiscard]] ItemsContainerListRange::Iterator end() const
 	{
 		return ItemsContainerListRange::Iterator({
 		    InventoryPlayerItemsRange(*player_).end(),
@@ -305,7 +305,7 @@ public:
 	{
 	}
 
-	[[nodiscard]] ItemsContainerListRange::Iterator begin() const // NOLINT(readability-identifier-naming)
+	[[nodiscard]] ItemsContainerListRange::Iterator begin() const
 	{
 		return ItemsContainerListRange::Iterator({
 		    EquippedPlayerItemsRange(*player_).begin(),
@@ -314,7 +314,7 @@ public:
 		});
 	}
 
-	[[nodiscard]] ItemsContainerListRange::Iterator end() const // NOLINT(readability-identifier-naming)
+	[[nodiscard]] ItemsContainerListRange::Iterator end() const
 	{
 		return ItemsContainerListRange::Iterator({
 		    EquippedPlayerItemsRange(*player_).end(),


### PR DESCRIPTION
Per clang-tidy config

Also fixes `RemoveBeltItemById` (follow-up to #4661)