### PR TITLE
3DS use homebrew logo

### DIFF
--- a/Packaging/ctr/template.rsf
+++ b/Packaging/ctr/template.rsf
@@ -1,7 +1,7 @@
 BasicInfo:
   Title                   : DevilutionX
   ProductCode             : CTR-P-DIABLO
-  Logo                    : Nintendo # Nintendo / Licensed / Distributed / iQue / iQueForSystem
+  Logo                    : Homebrew # Nintendo / Licensed / Distributed / iQue / iQueForSystem
 
 RomFs:
   # Specifies the root path of the read only file system to include in the ROM.


### PR DESCRIPTION
Would suggest on using 3DS homebrew logo instead to avoid copyright infringement.