### PR TITLE
Fix issues with ears due to translation

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3222,6 +3222,7 @@ void RecreateEar(Item &item, uint16_t ic, int iseed, int id, int dur, int mdur, 
 	std::string itemName = fmt::format(_(/* TRANSLATORS: {:s} will be a Character Name */ "Ear of {:s}"), heroName);
 
 	CopyUtf8(item._iName, itemName, sizeof(item._iName));
+	CopyUtf8(item._iIName, heroName, sizeof(item._iIName));
 
 	item._iCurs = ((ivalue >> 6) & 3) + ICURS_EAR_SORCERER;
 	item._ivalue = ivalue & 0x3F;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -937,6 +937,8 @@ void LoadMatchingItems(LoadHelper &file, const int n, Item *pItem)
 			continue;
 		if (pItem[i]._iSeed != tempItem._iSeed)
 			continue;
+		if (tempItem.IDidx == IDI_EAR)
+			continue;
 		pItem[i] = tempItem;
 	}
 }

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2626,15 +2626,15 @@ void NetSendCmdGItem(bool bHiPri, _cmd_id bCmd, uint8_t mast, uint8_t pnum, uint
 	cmd.wIndx = Items[ii].IDidx;
 
 	if (Items[ii].IDidx == IDI_EAR) {
-		cmd.wCI = Items[ii]._iName[8] | (Items[ii]._iName[7] << 8);
-		cmd.dwSeed = Items[ii]._iName[12] | ((Items[ii]._iName[11] | ((Items[ii]._iName[10] | (Items[ii]._iName[9] << 8)) << 8)) << 8);
-		cmd.bId = Items[ii]._iName[13];
-		cmd.bDur = Items[ii]._iName[14];
-		cmd.bMDur = Items[ii]._iName[15];
-		cmd.bCh = Items[ii]._iName[16];
-		cmd.bMCh = Items[ii]._iName[17];
-		cmd.wValue = Items[ii]._ivalue | (Items[ii]._iName[18] << 8) | ((Items[ii]._iCurs - ICURS_EAR_SORCERER) << 6);
-		cmd.dwBuff = Items[ii]._iName[22] | ((Items[ii]._iName[21] | ((Items[ii]._iName[20] | (Items[ii]._iName[19] << 8)) << 8)) << 8);
+		cmd.wCI = Items[ii]._iIName[1] | (Items[ii]._iIName[0] << 8);
+		cmd.dwSeed = Items[ii]._iIName[5] | ((Items[ii]._iIName[4] | ((Items[ii]._iIName[3] | (Items[ii]._iIName[2] << 8)) << 8)) << 8);
+		cmd.bId = Items[ii]._iIName[6];
+		cmd.bDur = Items[ii]._iIName[7];
+		cmd.bMDur = Items[ii]._iIName[8];
+		cmd.bCh = Items[ii]._iIName[9];
+		cmd.bMCh = Items[ii]._iIName[10];
+		cmd.wValue = Items[ii]._ivalue | (Items[ii]._iIName[11] << 8) | ((Items[ii]._iCurs - ICURS_EAR_SORCERER) << 6);
+		cmd.dwBuff = Items[ii]._iIName[15] | ((Items[ii]._iIName[14] | ((Items[ii]._iIName[13] | (Items[ii]._iIName[12] << 8)) << 8)) << 8);
 	} else {
 		cmd.wCI = Items[ii]._iCreateInfo;
 		cmd.dwSeed = Items[ii]._iSeed;
@@ -2669,15 +2669,15 @@ void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position, const Item &item
 	cmd.wIndx = item.IDidx;
 
 	if (item.IDidx == IDI_EAR) {
-		cmd.wCI = item._iName[8] | (item._iName[7] << 8);
-		cmd.dwSeed = item._iName[12] | ((item._iName[11] | ((item._iName[10] | (item._iName[9] << 8)) << 8)) << 8);
-		cmd.bId = item._iName[13];
-		cmd.bDur = item._iName[14];
-		cmd.bMDur = item._iName[15];
-		cmd.bCh = item._iName[16];
-		cmd.bMCh = item._iName[17];
-		cmd.wValue = item._ivalue | (item._iName[18] << 8) | ((item._iCurs - ICURS_EAR_SORCERER) << 6);
-		cmd.dwBuff = item._iName[22] | ((item._iName[21] | ((item._iName[20] | (item._iName[19] << 8)) << 8)) << 8);
+		cmd.wCI = item._iIName[1] | (item._iIName[0] << 8);
+		cmd.dwSeed = item._iIName[5] | ((item._iIName[4] | ((item._iIName[3] | (item._iIName[2] << 8)) << 8)) << 8);
+		cmd.bId = item._iIName[6];
+		cmd.bDur = item._iIName[7];
+		cmd.bMDur = item._iIName[8];
+		cmd.bCh = item._iIName[9];
+		cmd.bMCh = item._iIName[10];
+		cmd.wValue = item._ivalue | (item._iIName[11] << 8) | ((item._iCurs - ICURS_EAR_SORCERER) << 6);
+		cmd.dwBuff = item._iIName[15] | ((item._iIName[14] | ((item._iIName[13] | (item._iIName[12] << 8)) << 8)) << 8);
 	} else {
 		cmd.wCI = item._iCreateInfo;
 		cmd.dwSeed = item._iSeed;

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -50,15 +50,15 @@ void PackItem(ItemPack &packedItem, const Item &item, bool isHellfire)
 		}
 		packedItem.idx = SDL_SwapLE16(idx);
 		if (item.IDidx == IDI_EAR) {
-			packedItem.iCreateInfo = item._iName[8] | (item._iName[7] << 8);
-			packedItem.iSeed = LoadBE32(&item._iName[9]);
-			packedItem.bId = item._iName[13];
-			packedItem.bDur = item._iName[14];
-			packedItem.bMDur = item._iName[15];
-			packedItem.bCh = item._iName[16];
-			packedItem.bMCh = item._iName[17];
-			packedItem.wValue = SDL_SwapLE16(item._ivalue | (item._iName[18] << 8) | ((item._iCurs - ICURS_EAR_SORCERER) << 6));
-			packedItem.dwBuff = LoadBE32(&item._iName[19]);
+			packedItem.iCreateInfo = item._iIName[1] | (item._iIName[0] << 8);
+			packedItem.iSeed = LoadBE32(&item._iIName[2]);
+			packedItem.bId = item._iIName[6];
+			packedItem.bDur = item._iIName[7];
+			packedItem.bMDur = item._iIName[8];
+			packedItem.bCh = item._iIName[9];
+			packedItem.bMCh = item._iIName[10];
+			packedItem.wValue = SDL_SwapLE16(item._ivalue | (item._iIName[11] << 8) | ((item._iCurs - ICURS_EAR_SORCERER) << 6));
+			packedItem.dwBuff = LoadBE32(&item._iIName[12]);
 		} else {
 			packedItem.iSeed = SDL_SwapLE32(item._iSeed);
 			packedItem.iCreateInfo = SDL_SwapLE16(item._iCreateInfo);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3103,6 +3103,7 @@ StartPlayerKill(int pnum, int earflag)
 						Item ear;
 						InitializeItem(ear, IDI_EAR);
 						CopyUtf8(ear._iName, fmt::format(_("Ear of {:s}"), player._pName), sizeof(ear._iName));
+						CopyUtf8(ear._iIName, player._pName, sizeof(ear._iIName));
 						switch (player._pClass) {
 						case HeroClass::Sorcerer:
 							ear._iCurs = ICURS_EAR_SORCERER;

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -108,15 +108,15 @@ void SyncPlrInv(TSyncHeader *pHdr)
 		pHdr->bItemY = item.position.y;
 		pHdr->wItemIndx = item.IDidx;
 		if (item.IDidx == IDI_EAR) {
-			pHdr->wItemCI = (item._iName[7] << 8) | item._iName[8];
-			pHdr->dwItemSeed = (item._iName[9] << 24) | (item._iName[10] << 16) | (item._iName[11] << 8) | item._iName[12];
-			pHdr->bItemId = item._iName[13];
-			pHdr->bItemDur = item._iName[14];
-			pHdr->bItemMDur = item._iName[15];
-			pHdr->bItemCh = item._iName[16];
-			pHdr->bItemMCh = item._iName[17];
-			pHdr->wItemVal = (item._iName[18] << 8) | ((item._iCurs - ICURS_EAR_SORCERER) << 6) | item._ivalue;
-			pHdr->dwItemBuff = (item._iName[19] << 24) | (item._iName[20] << 16) | (item._iName[21] << 8) | item._iName[22];
+			pHdr->wItemCI = (item._iIName[0] << 8) | item._iIName[1];
+			pHdr->dwItemSeed = (item._iIName[2] << 24) | (item._iIName[3] << 16) | (item._iIName[4] << 8) | item._iIName[5];
+			pHdr->bItemId = item._iIName[6];
+			pHdr->bItemDur = item._iIName[7];
+			pHdr->bItemMDur = item._iIName[8];
+			pHdr->bItemCh = item._iIName[9];
+			pHdr->bItemMCh = item._iIName[10];
+			pHdr->wItemVal = (item._iIName[11] << 8) | ((item._iCurs - ICURS_EAR_SORCERER) << 6) | item._ivalue;
+			pHdr->dwItemBuff = (item._iIName[12] << 24) | (item._iIName[13] << 16) | (item._iIName[14] << 8) | item._iIName[15];
 		} else {
 			pHdr->wItemCI = item._iCreateInfo;
 			pHdr->dwItemSeed = item._iSeed;


### PR DESCRIPTION
For ears, store the player's name in the `_iIName` field of the `Item` struct so that the name data can be reliably copied regardless of how translations modify the phrase "Ear of PlayerName".

This resolves #4641