### PR TITLE
Correctly indicate when scroll can be used on virtual gamepad

### DIFF
--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -454,7 +454,7 @@ VirtualGamepadButtonType SecondaryActionButtonRenderer::GetButtonType()
 
 		if (pcursinvitem != -1) {
 			Item &item = GetInventoryItem(*MyPlayer, pcursinvitem);
-			if (!item.isScroll() || !spelldata[item._iSpell].sTargeted) {
+			if (!item.isScroll() || !TargetsMonster(item._iSpell)) {
 				if (!item.isEquipment()) {
 					return GetApplyButtonType(virtualPadButton->isHeld);
 				}


### PR DESCRIPTION
Fixes the icon on the secondary action button when hovering over scrolls of Town Portal, Teleport, and Guardian.

This resolves #4505