### PR TITLE
Load OFILE_CANDLE2 when the Poisoned Water Supply quest is available

### DIFF
--- a/Source/objdat.cpp
+++ b/Source/objdat.cpp
@@ -171,7 +171,7 @@ const ObjectData AllObjects[109] = {
 	{ OFILE_CHEST2,    1,      24, DTYPE_NONE,      THEME_NONE,              Q_INVALID,          0,          1,        0,         96, true,       true,      true,            0,        1, true      },
 	{ OFILE_CHEST3,    1,      24, DTYPE_NONE,      THEME_NONE,              Q_INVALID,          0,          1,        0,         96, true,       true,      true,            0,        1, true      },
 	{ OFILE_L1BRAZ,    0,       0, DTYPE_NONE,      THEME_NONE,              Q_INVALID,          0,          0,        0,          0, false,      false,     false,           0,        0, false     },
-	{ OFILE_CANDLE2,   0,       0, DTYPE_NONE,      THEME_SHRINE,            Q_INVALID,          1,          2,        4,         96, true,       true,      true,            0,        0, false     },
+	{ OFILE_CANDLE2,   0,       0, DTYPE_NONE,      THEME_SHRINE,            Q_PWATER,           1,          2,        4,         96, true,       true,      true,            0,        0, false     },
 	{ OFILE_L1BRAZ,    0,       0, DTYPE_NONE,      THEME_NONE,              Q_INVALID,          0,          0,        0,          0, false,      false,     false,           0,        0, false     },
 	{ OFILE_BANNER,    0,       0, DTYPE_NONE,      THEME_SKELROOM,          Q_INVALID,          0,          2,        0,         96, true,       true,      true,            0,        0, false     },
 	{ OFILE_BANNER,    0,       0, DTYPE_NONE,      THEME_SKELROOM,          Q_INVALID,          0,          1,        0,         96, true,       true,      true,            0,        0, false     },


### PR DESCRIPTION
Fixes an issue reported by Discord user ZeroContrast where the candles in front of Poisoned Water Supply had shown up as perpetually exploding barrels. Here is the savegame provided on Discord: [single_0.sv.zip](https://github.com/diasurgical/devilutionX/files/8873313/single_0.sv.zip). The following is a video they shared that showcases the perpetually exploding barrels.

https://user-images.githubusercontent.com/9203145/172928707-d9a8e327-5f8a-44ee-a61e-a0aa381cd369.mp4

FYI, if you load the savegame on master and go straight to dlvl 2 (`changelevel 2`), the game will attempt to render a null CEL buffer and the candles simply won't show up. If you go through dlvl 1 instead, you probably still will not see the exploding barrels, but the game may crash because it will load some garbage into memory and try to render that.

This will happen on any version of dlvl 2 that has Poisoned Water Supply and no shrines. Therefore, you can reproduce the issue easily enough on a new character by disabling randomized quests, using the following sequence of commands, and then teleporting through the wall to the northeast.

```
god
setspells 15
restart 2 1898487197
changelevel 2
```

The issue does not occur in 1.4.0. In case it matters, this was almost certainly introduced by 9872c7b.