### PR TITLE
Remove no-op GCC pragma instructions

### DIFF
--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -1132,15 +1132,6 @@ void LoadDiabQuads(bool preflag)
 	}
 }
 
-#if defined(__3DS__)
-#pragma GCC push_options
-#pragma GCC optimize("O0")
-#endif
-
-#if defined(__3DS__)
-#pragma GCC pop_options
-#endif
-
 bool IsDURightWall(char d)
 {
 	if (d == 25) {


### PR DESCRIPTION
Pushing an option then immediately popping it doesn't do much :D