### PR TITLE
Move Betrayer bugfix out of PlaceMiniSet

### DIFF
--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -194,9 +194,6 @@ bool PlaceMiniSet(const Miniset &miniset, bool setview)
 
 	miniset.place({ sx, sy }, true);
 
-	if (currlevel == 15 && Quests[Q_BETRAYER]._qactive >= QUEST_ACTIVE) { /// Lazarus staff skip bug fixed
-		Quests[Q_BETRAYER].position = { sx + 1, sy + 1 };
-	}
 	if (setview) {
 		ViewPosition = Point { 21, 22 } + Displacement { sx, sy } * 2;
 	}
@@ -1341,11 +1338,12 @@ void GenerateLevel(lvl_entry entry)
 	if (currlevel == 15) {
 		for (int j = 0; j < DMAXY; j++) {
 			for (int i = 0; i < DMAXX; i++) {
-				if (dungeon[i][j] == 98) {
+				if (IsAnyOf(dungeon[i][j], 98, 107)) {
 					Make_SetPC(i - 1, j - 1, 5, 5);
-				}
-				if (dungeon[i][j] == 107) {
-					Make_SetPC(i - 1, j - 1, 5, 5);
+					if (Quests[Q_BETRAYER]._qactive >= QUEST_ACTIVE) { /// Lazarus staff skip bug fixed
+						// Set the portal position to the location of the northmost pentagram tile.
+						Quests[Q_BETRAYER].position = { i, j };
+					}
 				}
 			}
 		}

--- a/test/drlg_l4_test.cpp
+++ b/test/drlg_l4_test.cpp
@@ -63,14 +63,22 @@ TEST(Drlg_l4, CreateL4Dungeon_diablo_15_1583642716)
 	TestCreateDungeon(15, 1583642716, ENTRY_PREV);
 	EXPECT_EQ(ViewPosition, Point(87, 69));
 
+	Quests[Q_BETRAYER]._qactive = QUEST_ACTIVE;
+	TestCreateDungeon(15, 1583642716, ENTRY_MAIN); // Betrayer quest does not change level gen
+	EXPECT_EQ(ViewPosition, Point(44, 26));
+	EXPECT_EQ(Quests[Q_BETRAYER].position, Point(34, 24)) << "Ensure the portal to lazarus has a spawn position if the player has activated the quest";
+
 	LoadExpectedLevelData("diablo/15-1583642716-changed.dun");
 
+	Quests[Q_BETRAYER]._qactive = QUEST_DONE;
 	Quests[Q_DIABLO]._qactive = QUEST_ACTIVE;
 
 	TestCreateDungeon(15, 1583642716, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(44, 26));
+	EXPECT_EQ(Quests[Q_BETRAYER].position, Point(34, 24)) << "Not really required? current bugfix sets this position anyway";
 	TestCreateDungeon(15, 1583642716, ENTRY_PREV);
 	EXPECT_EQ(ViewPosition, Point(87, 69));
+	EXPECT_EQ(Quests[Q_BETRAYER].position, Point(34, 24)) << "Not really required? current bugfix sets this position anyway";
 }
 
 TEST(Drlg_l4, CreateL4Dungeon_diablo_15_1256511996)


### PR DESCRIPTION
So that the function is more similar to other dungeon generation versions, and so that it's not doing unnecessary work.

This only applies to singleplayer so I didn't add to the multiplayer dlvl15 test.