### PR TITLE
Fix order of loop conditions when adding spell missiles

### DIFF
--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -240,7 +240,7 @@ void CastSpell(int id, spell_id spl, int sx, int sy, int dx, int dy, int spllvl)
 		dir = Players[id].tempDirection;
 	}
 
-	for (int i = 0; spelldata[spl].sMissiles[i] != MIS_NULL && i < 3; i++) {
+	for (int i = 0; i < 3 && spelldata[spl].sMissiles[i] != MIS_NULL; i++) {
 		AddMissile({ sx, sy }, { dx, dy }, dir, spelldata[spl].sMissiles[i], TARGET_MONSTERS, id, 0, spllvl);
 	}
 


### PR DESCRIPTION
Fixes an OOB memory access that occurs when a spell has three missiles associated with it.

If the situation occurs, the MinGW build would raise an access violation exception that crashes the game. This was discovered in the ME mod when players tried to cast the "Thunder" spell. DevilutionX doesn't have any spells that would trigger this exception, but the logic here is clearly backwards so it may as well be fixed.