### PR TITLE
Loading screen: Free the background early

### DIFF
--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -472,6 +472,15 @@ SDL_Surface *GetOutputSurface()
 #endif
 }
 
+bool IsDoubleBuffered()
+{
+#ifdef USE_SDL1
+	return (GetOutputSurface()->flags & SDL_DOUBLEBUF) == SDL_DOUBLEBUF;
+#else
+	return true;
+#endif
+}
+
 bool OutputRequiresScaling()
 {
 #ifdef USE_SDL1

--- a/Source/utils/display.h
+++ b/Source/utils/display.h
@@ -40,6 +40,8 @@ bool IsFullScreen();
 // SDL2, upscale: Renderer texture surface.
 SDL_Surface *GetOutputSurface();
 
+bool IsDoubleBuffered();
+
 // Whether the output surface requires software scaling.
 // Always returns false on SDL2.
 bool OutputRequiresScaling();


### PR DESCRIPTION
Frees the background after blitting it once in the loading screen.
This gives the game more RAM for the actual loading.