### PR TITLE
OpenDingux: `strip` `.comment` and `.gnu.version`

### DIFF
--- a/Packaging/OpenDingux/build.sh
+++ b/Packaging/OpenDingux/build.sh
@@ -91,7 +91,7 @@ cmake_build() {
 }
 
 strip_bin() {
-	"${TOOLCHAIN}/usr/bin/"*-linux-strip "${BUILD_DIR}/devilutionx"
+	"${TOOLCHAIN}/usr/bin/"*-linux-strip -s -R .comment -R .gnu.version "${BUILD_DIR}/devilutionx"
 }
 
 build_debug() {


### PR DESCRIPTION
Saves 108 bytes in the binary size