### PR TITLE
Clean up how DRLG_L1 quest elements are placed

### DIFF
--- a/Source/drlg_l2.cpp
+++ b/Source/drlg_l2.cpp
@@ -1604,17 +1604,12 @@ void PlaceMiniSetRandom1x1(uint8_t search, uint8_t replace, int rndper)
 
 void LoadQuestSetPieces()
 {
-	setloadflag = false;
-
 	if (Quests[Q_BLIND].IsAvailable()) {
 		pSetPiece = LoadFileInMem<uint16_t>("Levels\\L2Data\\Blind1.DUN");
-		setloadflag = true;
 	} else if (Quests[Q_BLOOD].IsAvailable()) {
 		pSetPiece = LoadFileInMem<uint16_t>("Levels\\L2Data\\Blood1.DUN");
-		setloadflag = true;
 	} else if (Quests[Q_SCHAMB].IsAvailable()) {
 		pSetPiece = LoadFileInMem<uint16_t>("Levels\\L2Data\\Bonestr2.DUN");
-		setloadflag = true;
 	}
 }
 
@@ -2726,7 +2721,7 @@ void GenerateLevel(lvl_entry entry)
 			continue;
 		}
 		FixTilesPatterns();
-		if (setloadflag) {
+		if (pSetPiece != nullptr) {
 			PlaceDunTiles(pSetPiece.get(), SetPieceRoom.position, 3);
 			SetPiece = { SetPieceRoom.position, { SDL_SwapLE16(pSetPiece[0]), SDL_SwapLE16(pSetPiece[1]) } };
 		}

--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -161,14 +161,10 @@ void ApplyShadowsPatterns()
 
 void LoadQuestSetPieces()
 {
-	setloadflag = false;
 	if (Quests[Q_WARLORD].IsAvailable()) {
 		pSetPiece = LoadFileInMem<uint16_t>("Levels\\L4Data\\Warlord.DUN");
-		setloadflag = true;
-	}
-	if (currlevel == 15 && gbIsMultiplayer) {
+	} else if (currlevel == 15 && gbIsMultiplayer) {
 		pSetPiece = LoadFileInMem<uint16_t>("Levels\\L4Data\\Vile1.DUN");
-		setloadflag = true;
 	}
 }
 
@@ -318,6 +314,9 @@ void FirstRoom()
 
 void SetSetPieceRoom(Point position)
 {
+	if (pSetPiece == nullptr)
+		return;
+
 	SetPiece = { position, { SDL_SwapLE16(pSetPiece[0]), SDL_SwapLE16(pSetPiece[1]) } };
 
 	PlaceDunTiles(pSetPiece.get(), position, 6);
@@ -1239,9 +1238,7 @@ void GenerateLevel(lvl_entry entry)
 		AddWall();
 		FloodTransparencyValues(6);
 		FixTransparency();
-		if (setloadflag) {
-			SetSetPieceRoom(SetPieceRoom.position);
-		}
+		SetSetPieceRoom(SetPieceRoom.position);
 		if (currlevel == 16) {
 			LoadDiabQuads(true);
 		}

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -397,6 +397,8 @@ dungeon_type GetLevelType(int level)
 
 void CreateDungeon(uint32_t rseed, lvl_entry entry)
 {
+	DRLG_Init_Globals();
+
 	switch (leveltype) {
 	case DTYPE_TOWN:
 		CreateTown(entry);
@@ -418,6 +420,8 @@ void CreateDungeon(uint32_t rseed, lvl_entry entry)
 	default:
 		app_fatal("Invalid level type");
 	}
+
+	Make_SetPC(SetPiece);
 }
 
 void FillSolidBlockTbls()
@@ -509,11 +513,6 @@ void DRLG_InitSetPC()
 {
 	SetPieceRoom = { { -1, -1 }, { -1, -1 } };
 	SetPiece = { { 0, 0 }, { 0, 0 } };
-}
-
-void DRLG_SetPC()
-{
-	Make_SetPC(SetPiece);
 }
 
 void Make_SetPC(Rectangle area)
@@ -641,6 +640,20 @@ void DRLG_HoldThemeRooms()
 	}
 }
 
+void SetSetPieceRoom(Point position, int floorId)
+{
+	if (pSetPiece == nullptr)
+		return;
+
+	PlaceDunTiles(pSetPiece.get(), position, floorId);
+	SetPiece = { position, { SDL_SwapLE16(pSetPiece[0]), SDL_SwapLE16(pSetPiece[1]) } };
+}
+
+void FreeQuestSetPieces()
+{
+	pSetPiece = nullptr;
+}
+
 void DRLG_LPass3(int lv)
 {
 	{
@@ -689,6 +702,9 @@ void DRLG_LPass3(int lv)
 
 void DRLG_Init_Globals()
 {
+	dminPosition = Point(0, 0).megaToWorld();
+	dmaxPosition = Point(40, 40).megaToWorld();
+	memset(dItem, 0, sizeof(dItem));
 	memset(dFlags, 0, sizeof(dFlags));
 	memset(dPlayer, 0, sizeof(dPlayer));
 	memset(dMonster, 0, sizeof(dMonster));
@@ -697,6 +713,8 @@ void DRLG_Init_Globals()
 	memset(dSpecial, 0, sizeof(dSpecial));
 	int8_t c = DisableLighting ? 0 : 15;
 	memset(dLight, c, sizeof(dLight));
+	DRLG_InitTrans();
+	DRLG_InitSetPC();
 }
 
 bool SkipThemeRoom(int x, int y)

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -26,7 +26,6 @@ bool Protected[DMAXX][DMAXY];
 Rectangle SetPieceRoom;
 Rectangle SetPiece;
 std::unique_ptr<uint16_t[]> pSetPiece;
-bool setloadflag;
 std::optional<OwnedCelSprite> pSpecialCels;
 std::unique_ptr<MegaTile[]> pMegaTiles;
 std::unique_ptr<uint16_t[]> pLevelPieces;

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -133,8 +133,6 @@ extern Rectangle SetPieceRoom;
 extern Rectangle SetPiece;
 /** Contains the contents of the single player quest DUN file. */
 extern std::unique_ptr<uint16_t[]> pSetPiece;
-/** Specifies whether a single player quest DUN has been loaded. */
-extern bool setloadflag;
 extern std::optional<OwnedCelSprite> pSpecialCels;
 /** Specifies the tile definitions of the active dungeon type; (e.g. levels/l1data/l1.til). */
 extern DVL_API_FOR_TEST std::unique_ptr<MegaTile[]> pMegaTiles;

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -324,7 +324,6 @@ void DRLG_MRectTrans(Rectangle area);
 void DRLG_RectTrans(Rectangle area);
 void DRLG_CopyTrans(int sx, int sy, int dx, int dy);
 void DRLG_InitSetPC();
-void DRLG_SetPC();
 void Make_SetPC(Rectangle area);
 /**
  * @param tries Tiles to try, 1600 will scan the full map
@@ -334,6 +333,8 @@ std::optional<Point> PlaceMiniSet(const Miniset &miniset, int tries = 199, bool 
 void PlaceDunTiles(const uint16_t *dunData, Point position, int floorId = 0);
 void DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int freq, bool rndSize);
 void DRLG_HoldThemeRooms();
+void SetSetPieceRoom(Point position, int floorId);
+void FreeQuestSetPieces();
 void DRLG_LPass3(int lv);
 void DRLG_Init_Globals();
 bool SkipThemeRoom(int x, int y);

--- a/Source/setmaps.cpp
+++ b/Source/setmaps.cpp
@@ -117,7 +117,6 @@ void LoadSetMap()
 	case SL_POISONWATER:
 		if (Quests[Q_PWATER]._qactive == QUEST_INIT)
 			Quests[Q_PWATER]._qactive = QUEST_ACTIVE;
-		LoadPreL3Dungeon("Levels\\L3Data\\Foulwatr.DUN");
 		LoadL3Dungeon("Levels\\L3Data\\Foulwatr.DUN", 31, 83);
 		LoadPalette("Levels\\L3Data\\L3pfoul.pal");
 		InitPWaterTriggers();

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -148,6 +148,46 @@ void TownCloseGrave()
 	SetDungeonMicros();
 }
 
+void InitTownPieces()
+{
+
+	for (int y = 0; y < MAXDUNY; y++) {
+		for (int x = 0; x < MAXDUNX; x++) {
+			if (dPiece[x][y] == 360) {
+				dSpecial[x][y] = 1;
+			} else if (dPiece[x][y] == 358) {
+				dSpecial[x][y] = 2;
+			} else if (dPiece[x][y] == 129) {
+				dSpecial[x][y] = 6;
+			} else if (dPiece[x][y] == 130) {
+				dSpecial[x][y] = 7;
+			} else if (dPiece[x][y] == 128) {
+				dSpecial[x][y] = 8;
+			} else if (dPiece[x][y] == 117) {
+				dSpecial[x][y] = 9;
+			} else if (dPiece[x][y] == 157) {
+				dSpecial[x][y] = 10;
+			} else if (dPiece[x][y] == 158) {
+				dSpecial[x][y] = 11;
+			} else if (dPiece[x][y] == 156) {
+				dSpecial[x][y] = 12;
+			} else if (dPiece[x][y] == 162) {
+				dSpecial[x][y] = 13;
+			} else if (dPiece[x][y] == 160) {
+				dSpecial[x][y] = 14;
+			} else if (dPiece[x][y] == 214) {
+				dSpecial[x][y] = 15;
+			} else if (dPiece[x][y] == 212) {
+				dSpecial[x][y] = 16;
+			} else if (dPiece[x][y] == 217) {
+				dSpecial[x][y] = 17;
+			} else if (dPiece[x][y] == 216) {
+				dSpecial[x][y] = 18;
+			}
+		}
+	}
+}
+
 /**
  * @brief Initialize all of the levels data
  */
@@ -196,6 +236,8 @@ void DrlgTPass3()
 	} else {
 		FillTile(60, 70, 71);
 	}
+
+	InitTownPieces();
 }
 
 } // namespace
@@ -284,8 +326,6 @@ void CreateTown(lvl_entry entry)
 {
 	dminPosition = { 10, 10 };
 	dmaxPosition = { 84, 84 };
-	DRLG_InitTrans();
-	DRLG_Init_Globals();
 
 	if (entry == ENTRY_MAIN) { // New game
 		ViewPosition = { 75, 68 };
@@ -310,50 +350,6 @@ void CreateTown(lvl_entry entry)
 	}
 
 	DrlgTPass3();
-	memset(dFlags, 0, sizeof(dFlags));
-	memset(dLight, 0, sizeof(dLight));
-	memset(dFlags, 0, sizeof(dFlags));
-	memset(dPlayer, 0, sizeof(dPlayer));
-	memset(dMonster, 0, sizeof(dMonster));
-	memset(dObject, 0, sizeof(dObject));
-	memset(dItem, 0, sizeof(dItem));
-	memset(dSpecial, 0, sizeof(dSpecial));
-
-	for (int y = 0; y < MAXDUNY; y++) {
-		for (int x = 0; x < MAXDUNX; x++) {
-			if (dPiece[x][y] == 360) {
-				dSpecial[x][y] = 1;
-			} else if (dPiece[x][y] == 358) {
-				dSpecial[x][y] = 2;
-			} else if (dPiece[x][y] == 129) {
-				dSpecial[x][y] = 6;
-			} else if (dPiece[x][y] == 130) {
-				dSpecial[x][y] = 7;
-			} else if (dPiece[x][y] == 128) {
-				dSpecial[x][y] = 8;
-			} else if (dPiece[x][y] == 117) {
-				dSpecial[x][y] = 9;
-			} else if (dPiece[x][y] == 157) {
-				dSpecial[x][y] = 10;
-			} else if (dPiece[x][y] == 158) {
-				dSpecial[x][y] = 11;
-			} else if (dPiece[x][y] == 156) {
-				dSpecial[x][y] = 12;
-			} else if (dPiece[x][y] == 162) {
-				dSpecial[x][y] = 13;
-			} else if (dPiece[x][y] == 160) {
-				dSpecial[x][y] = 14;
-			} else if (dPiece[x][y] == 214) {
-				dSpecial[x][y] = 15;
-			} else if (dPiece[x][y] == 212) {
-				dSpecial[x][y] = 16;
-			} else if (dPiece[x][y] == 217) {
-				dSpecial[x][y] = 17;
-			} else if (dPiece[x][y] == 216) {
-				dSpecial[x][y] = 18;
-			}
-		}
-	}
 }
 
 } // namespace devilution


### PR DESCRIPTION
I think I managed to keep the change set relatively clean this time :cold_sweat: 

This also saves 2K of ram during most of the level generation which I'm sure @glebm will appreciate :D

One possible down side here is that it will load the .dun file for each attempt at generating a valid level.