### PR TITLE
Remove uses of `<locale>`

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -2,11 +2,6 @@
 
 #include <algorithm>
 #include <string>
-#ifdef USE_SDL1
-#include <cassert>
-#include <codecvt>
-#include <locale>
-#endif
 
 #include "DiabloUI/art_draw.h"
 #include "DiabloUI/button.h"
@@ -403,9 +398,8 @@ void UiFocusNavigation(SDL_Event *event)
 			}
 #ifdef USE_SDL1
 			if ((event->key.keysym.mod & KMOD_CTRL) == 0) {
-				Uint16 unicode = event->key.keysym.unicode;
-				std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> convert;
-				std::string utf8 = convert.to_bytes(unicode);
+				std::string utf8;
+				AppendUtf8(event->key.keysym.unicode, utf8);
 				SelheroCatToName(utf8.c_str(), UiTextInput, UiTextInputLen);
 			}
 #endif

--- a/Source/miniwin/misc_msg.cpp
+++ b/Source/miniwin/misc_msg.cpp
@@ -1,11 +1,6 @@
 #include <cstdint>
 #include <deque>
 #include <string>
-#ifdef USE_SDL1
-#include <cassert>
-#include <codecvt>
-#include <locale>
-#endif
 
 #include <SDL.h>
 
@@ -507,8 +502,8 @@ bool FetchMessage_Real(tagMSG *lpMsg)
 		if (gbRunGame && (IsTalkActive() || dropGoldFlag)) {
 			Uint16 unicode = e.key.keysym.unicode;
 			if (unicode >= ' ') {
-				std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> convert;
-				std::string utf8 = convert.to_bytes(unicode);
+				std::string utf8;
+				AppendUtf8(unicode, utf8);
 				if (IsTalkActive())
 					control_new_text(utf8);
 				if (dropGoldFlag)

--- a/Source/utils/utf8.cpp
+++ b/Source/utils/utf8.cpp
@@ -5,6 +5,8 @@
 
 #include <hoehrmann_utf8.h>
 
+#include "utils/attributes.h"
+
 namespace devilution {
 
 namespace {
@@ -47,6 +49,32 @@ void CopyUtf8(char *dest, string_view source, std::size_t bytes)
 	source = TruncateUtf8(source, bytes - 1);
 	std::memcpy(dest, source.data(), source.size());
 	dest[source.size()] = '\0';
+}
+
+void AppendUtf8(char32_t codepoint, std::string &out)
+{
+	if (codepoint <= 0x7F) {
+		out += static_cast<char>(codepoint);
+		return;
+	}
+
+	char buf[4];
+	if (codepoint <= 0x7FF) {
+		buf[0] = static_cast<char>(0xC0 | (codepoint >> 6 & 0x3F));
+		buf[1] = static_cast<char>(0x80 | (codepoint & 0x3F));
+		out.append(buf, 2);
+	} else if (codepoint <= 0xFFFF) {
+		buf[0] = static_cast<char>(0xE0 | (codepoint >> 12 & 0x3F));
+		buf[1] = static_cast<char>(0x80 | (codepoint >> 6 & 0x3F));
+		buf[2] = static_cast<char>(0x80 | (codepoint & 0x3F));
+		out.append(buf, 3);
+	} else {
+		buf[0] = static_cast<char>(0xF0 | (codepoint >> 18 & 0x3F));
+		buf[1] = static_cast<char>(0x80 | (codepoint >> 12 & 0x3F));
+		buf[2] = static_cast<char>(0x80 | (codepoint >> 6 & 0x3F));
+		buf[3] = static_cast<char>(0x80 | (codepoint & 0x3F));
+		out.append(buf, 4);
+	}
 }
 
 } // namespace devilution

--- a/Source/utils/utf8.hpp
+++ b/Source/utils/utf8.hpp
@@ -59,4 +59,6 @@ inline std::size_t FindLastUtf8Symbols(string_view input)
  */
 void CopyUtf8(char *dest, string_view source, std::size_t bytes);
 
+void AppendUtf8(char32_t codepoint, std::string &out);
+
 } // namespace devilution

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,7 @@ set(tests
   random_test
   scrollrt_test
   stores_test
+  utf8_test
   writehero_test
 )
 

--- a/test/utf8_test.cpp
+++ b/test/utf8_test.cpp
@@ -1,0 +1,38 @@
+
+#include <gtest/gtest.h>
+
+#include "utils/utf8.hpp"
+
+namespace devilution {
+namespace {
+
+TEST(AppendUtf8Test, OneByteCodePoint)
+{
+	std::string s = "x";
+	AppendUtf8(U'a', s);
+	EXPECT_EQ(s, "xa");
+}
+
+TEST(AppendUtf8Test, TwoByteCodePoint)
+{
+	std::string s = "x";
+	AppendUtf8(U'Á', s);
+	EXPECT_EQ(s, "xÁ");
+}
+
+TEST(AppendUtf8Test, ThreeByteCodePoint)
+{
+	std::string s;
+	AppendUtf8(U'€', s);
+	EXPECT_EQ(s, "€");
+}
+
+TEST(AppendUtf8Test, FourByteCodePoint)
+{
+	std::string s;
+	AppendUtf8(U'あ', s);
+	EXPECT_EQ(s, "あ");
+}
+
+} // namespace
+} // namespace devilution


### PR DESCRIPTION
1. The C++ `std::locale("")` constructor performs static initialization of all the facets on the first call.

    For example, this includes things like currency formatting.

    Avoid all of that by using the equivalent C locale call.

2. Replaces the deprecated `<codecvt>` machinery with a simple UTF-8 encoding function.