### PR TITLE
Move shared dungeon level code to common function

### DIFF
--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -926,17 +926,17 @@ void GenerateRoom(int x, int y, int w, int h, int dir)
 void FirstRoom()
 {
 	VerticalLayout = GenerateRnd(2) == 0;
+	HasChamber1 = (GenerateRnd(2) != 0);
+	HasChamber2 = (GenerateRnd(2) != 0);
+	HasChamber3 = (GenerateRnd(2) != 0);
+
+	if (!HasChamber1 || !HasChamber3)
+		HasChamber2 = true;
 
 	if (VerticalLayout) {
 		int ys = 1;
 		int ye = DMAXY - 1;
 
-		HasChamber1 = (GenerateRnd(2) != 0);
-		HasChamber2 = (GenerateRnd(2) != 0);
-		HasChamber3 = (GenerateRnd(2) != 0);
-
-		if (!HasChamber1 || !HasChamber3)
-			HasChamber2 = true;
 		if (HasChamber1)
 			MapRoom(15, 1, 10, 10);
 		else
@@ -968,12 +968,6 @@ void FirstRoom()
 		int xs = 1;
 		int xe = DMAXX - 1;
 
-		HasChamber1 = GenerateRnd(2) != 0;
-		HasChamber2 = GenerateRnd(2) != 0;
-		HasChamber3 = GenerateRnd(2) != 0;
-
-		if (!HasChamber1 || !HasChamber3)
-			HasChamber2 = true;
 		if (HasChamber1)
 			MapRoom(1, 15, 10, 10);
 		else
@@ -1521,16 +1515,12 @@ void FillChambers()
 		if (HasChamber1)
 			GenerateChamber(0, 14, false, false, false, true);
 
-		if (HasChamber2) {
-			if (HasChamber1 && !HasChamber3)
-				GenerateChamber(14, 14, false, false, true, false);
-			if (!HasChamber1 && HasChamber3)
-				GenerateChamber(14, 14, false, false, false, true);
-			if (HasChamber1 && HasChamber3)
-				GenerateChamber(14, 14, false, false, true, true);
-			if (!HasChamber1 && !HasChamber3)
-				GenerateChamber(14, 14, false, false, false, false);
-		}
+		if (!HasChamber3)
+			GenerateChamber(14, 14, false, false, true, false);
+		else if (!HasChamber1)
+			GenerateChamber(14, 14, false, false, false, true);
+		else if (HasChamber1 && HasChamber2 && HasChamber3)
+			GenerateChamber(14, 14, false, false, true, true);
 
 		if (HasChamber3)
 			GenerateChamber(28, 14, false, false, true, false);
@@ -1538,22 +1528,18 @@ void FillChambers()
 			GenerateHall(12, 18, 14, 18);
 		if (HasChamber2 && HasChamber3)
 			GenerateHall(26, 18, 28, 18);
-		if (HasChamber1 && !HasChamber2 && HasChamber3)
+		if (!HasChamber2)
 			GenerateHall(12, 18, 28, 18);
 	} else {
 		if (HasChamber1)
 			GenerateChamber(14, 0, false, true, false, false);
 
-		if (HasChamber2) {
-			if (HasChamber1 && !HasChamber3)
-				GenerateChamber(14, 14, true, false, false, false);
-			if (!HasChamber1 && HasChamber3)
-				GenerateChamber(14, 14, false, true, false, false);
-			if (HasChamber1 && HasChamber3)
-				GenerateChamber(14, 14, true, true, false, false);
-			if (!HasChamber1 && !HasChamber3)
-				GenerateChamber(14, 14, false, false, false, false);
-		}
+		if (!HasChamber3)
+			GenerateChamber(14, 14, true, false, false, false);
+		else if (!HasChamber1)
+			GenerateChamber(14, 14, false, true, false, false);
+		else if (HasChamber1 && HasChamber2 && HasChamber3)
+			GenerateChamber(14, 14, true, true, false, false);
 
 		if (HasChamber3)
 			GenerateChamber(14, 28, true, false, false, false);
@@ -1561,7 +1547,7 @@ void FillChambers()
 			GenerateHall(18, 12, 18, 14);
 		if (HasChamber2 && HasChamber3)
 			GenerateHall(18, 26, 18, 28);
-		if (HasChamber1 && !HasChamber2 && HasChamber3)
+		if (!HasChamber2)
 			GenerateHall(18, 12, 18, 28);
 	}
 

--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -2050,24 +2050,19 @@ void LoadPreL1Dungeon(const char *path)
 	memcpy(pdungeon, dungeon, sizeof(pdungeon));
 }
 
-void LoadL1Dungeon(const char *path, int vx, int vy)
+void LoadL1Dungeon(const char *path, Point spawn)
 {
-	ViewPosition = { vx, vy };
-
-	DRLG_Init_Globals();
-
-	memset(dungeon, 22, sizeof(dungeon));
-
-	auto dunData = LoadFileInMem<uint16_t>(path);
-	PlaceDunTiles(dunData.get(), { 0, 0 }, Tile::Floor);
+	LoadDungeonBase(path, spawn, Tile::Floor, 22);
 
 	if (leveltype == DTYPE_CATHEDRAL)
 		FillFloor();
 
 	Pass3();
 
-	SetMapMonsters(dunData.get(), Point(0, 0).megaToWorld());
-	SetMapObjects(dunData.get(), 0, 0);
+	if (leveltype == DTYPE_CRYPT)
+		AddCryptObjects(0, 0, MAXDUNX, MAXDUNY);
+	else
+		AddL1Objs(0, 0, MAXDUNX, MAXDUNY);
 }
 
 } // namespace devilution

--- a/Source/drlg_l1.h
+++ b/Source/drlg_l1.h
@@ -15,8 +15,8 @@ extern bool IsUberRoomOpened;
 extern bool IsUberLeverActivated;
 extern int UberDiabloMonsterIndex;
 
-void LoadL1Dungeon(const char *path, int vx, int vy);
-void LoadPreL1Dungeon(const char *path);
 void CreateL5Dungeon(uint32_t rseed, lvl_entry entry);
+void LoadPreL1Dungeon(const char *path);
+void LoadL1Dungeon(const char *path, Point spawn);
 
 } // namespace devilution

--- a/Source/drlg_l2.cpp
+++ b/Source/drlg_l2.cpp
@@ -2876,21 +2876,13 @@ void LoadPreL2Dungeon(const char *path)
 	memcpy(pdungeon, dungeon, sizeof(pdungeon));
 }
 
-void LoadL2Dungeon(const char *path, int vx, int vy)
+void LoadL2Dungeon(const char *path, Point spawn)
 {
-	ViewPosition = { vx, vy };
-
-	DRLG_Init_Globals();
-
-	memset(dungeon, 12, sizeof(dungeon));
-
-	auto dunData = LoadFileInMem<uint16_t>(path);
-	PlaceDunTiles(dunData.get(), { 0, 0 }, 3);
+	LoadDungeonBase(path, spawn, 3, 12);
 
 	Pass3();
 
-	SetMapMonsters(dunData.get(), Point(0, 0).megaToWorld());
-	SetMapObjects(dunData.get(), 0, 0);
+	AddL2Objs(0, 0, MAXDUNX, MAXDUNY);
 }
 
 } // namespace devilution

--- a/Source/drlg_l2.h
+++ b/Source/drlg_l2.h
@@ -26,8 +26,8 @@ struct ROOMNODE {
 
 extern BYTE predungeon[DMAXX][DMAXY];
 
-void LoadL2Dungeon(const char *path, int vx, int vy);
-void LoadPreL2Dungeon(const char *path);
 void CreateL2Dungeon(uint32_t rseed, lvl_entry entry);
+void LoadPreL2Dungeon(const char *path);
+void LoadL2Dungeon(const char *path, Point spawn);
 
 } // namespace devilution

--- a/Source/drlg_l3.cpp
+++ b/Source/drlg_l3.cpp
@@ -2250,22 +2250,15 @@ void LoadPreL3Dungeon(const char *path)
 	memcpy(pdungeon, dungeon, sizeof(pdungeon));
 }
 
-void LoadL3Dungeon(const char *path, int vx, int vy)
+void LoadL3Dungeon(const char *path, Point spawn)
 {
-	ViewPosition = { vx, vy };
-
-	DRLG_Init_Globals();
-
-	memset(dungeon, 8, sizeof(dungeon));
-
-	auto dunData = LoadFileInMem<uint16_t>(path);
-	PlaceDunTiles(dunData.get(), { 0, 0 }, 7);
+	LoadDungeonBase(path, spawn, 7, 8);
 
 	Pass3();
 	PlaceLights();
 
-	SetMapMonsters(dunData.get(), Point(0, 0).megaToWorld());
-	SetMapObjects(dunData.get(), 0, 0);
+	if (leveltype == DTYPE_CAVES)
+		AddL3Objs(0, 0, MAXDUNX, MAXDUNY);
 }
 
 } // namespace devilution

--- a/Source/drlg_l3.h
+++ b/Source/drlg_l3.h
@@ -10,7 +10,8 @@
 namespace devilution {
 
 void CreateL3Dungeon(uint32_t rseed, lvl_entry entry);
-void LoadL3Dungeon(const char *sFileName, int vx, int vy);
 void LoadPreL3Dungeon(const char *sFileName);
+void LoadL3Dungeon(const char *sFileName, Point spawn);
+;
 
 } // namespace devilution

--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -1293,21 +1293,11 @@ void LoadPreL4Dungeon(const char *path)
 	memcpy(pdungeon, dungeon, sizeof(pdungeon));
 }
 
-void LoadL4Dungeon(const char *path, int vx, int vy)
+void LoadL4Dungeon(const char *path, Point spawn)
 {
-	ViewPosition = { vx, vy };
-
-	DRLG_Init_Globals();
-
-	memset(dungeon, 30, sizeof(dungeon));
-
-	auto dunData = LoadFileInMem<uint16_t>(path);
-	PlaceDunTiles(dunData.get(), { 0, 0 }, 6);
+	LoadDungeonBase(path, spawn, 6, 30);
 
 	Pass3();
-
-	SetMapMonsters(dunData.get(), Point(0, 0).megaToWorld());
-	SetMapObjects(dunData.get(), 0, 0);
 }
 
 } // namespace devilution

--- a/Source/drlg_l4.h
+++ b/Source/drlg_l4.h
@@ -13,8 +13,9 @@ extern Point DiabloQuad1;
 extern Point DiabloQuad2;
 extern Point DiabloQuad3;
 extern Point DiabloQuad4;
+
 void CreateL4Dungeon(uint32_t rseed, lvl_entry entry);
-void LoadL4Dungeon(const char *path, int vx, int vy);
 void LoadPreL4Dungeon(const char *path);
+void LoadL4Dungeon(const char *path, Point spawn);
 
 } // namespace devilution

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -185,7 +185,7 @@ extern DVL_API_FOR_TEST int dPiece[MAXDUNX][MAXDUNY];
 extern MICROS dpiece_defs_map_2[MAXDUNX][MAXDUNY];
 /** Specifies the transparency at each coordinate of the map. */
 extern DVL_API_FOR_TEST int8_t dTransVal[MAXDUNX][MAXDUNY];
-extern DVL_API_FOR_TEST char dLight[MAXDUNX][MAXDUNY];
+extern char dLight[MAXDUNX][MAXDUNY];
 extern char dPreLight[MAXDUNX][MAXDUNY];
 /** Holds various information about dungeon tiles, @see DungeonFlag */
 extern DungeonFlag dFlags[MAXDUNX][MAXDUNY];
@@ -323,7 +323,8 @@ void DRLG_MRectTrans(Point origin, Point extent);
 void DRLG_MRectTrans(Rectangle area);
 void DRLG_RectTrans(Rectangle area);
 void DRLG_CopyTrans(int sx, int sy, int dx, int dy);
-void DRLG_InitSetPC();
+void LoadTransparency(const uint16_t *dunData);
+void LoadDungeonBase(const char *path, Point spawn, int floorId, int dirtId);
 void Make_SetPC(Rectangle area);
 /**
  * @param tries Tiles to try, 1600 will scan the full map
@@ -336,7 +337,6 @@ void DRLG_HoldThemeRooms();
 void SetSetPieceRoom(Point position, int floorId);
 void FreeQuestSetPieces();
 void DRLG_LPass3(int lv);
-void DRLG_Init_Globals();
 bool SkipThemeRoom(int x, int y);
 void InitLevels();
 void FloodTransparencyValues(uint8_t floorID);

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -47,7 +47,7 @@ extern uint8_t ActiveLights[MAXLIGHTS];
 extern int ActiveLightCount;
 constexpr char LightsMax = 15;
 extern std::array<uint8_t, LIGHTSIZE> LightTables;
-extern DVL_API_FOR_TEST bool DisableLighting;
+extern bool DisableLighting;
 extern bool UpdateLighting;
 
 void DoLighting(Point position, int nRadius, int Lnum);

--- a/Source/setmaps.cpp
+++ b/Source/setmaps.cpp
@@ -13,6 +13,7 @@
 #include "drlg_l3.h"
 #include "drlg_l4.h"
 #include "engine/load_file.hpp"
+#include "gendung.h"
 #include "objdat.h"
 #include "objects.h"
 #include "palette.h"
@@ -65,24 +66,7 @@ void AddVileObjs()
 void SetMapTransparency(const char *path)
 {
 	auto dunData = LoadFileInMem<uint16_t>(path);
-
-	int width = SDL_SwapLE16(dunData[0]);
-	int height = SDL_SwapLE16(dunData[1]);
-
-	int layer2Offset = 2 + width * height;
-
-	// The rest of the layers are at dPiece scale
-	width *= 2;
-	height *= 2;
-
-	const uint16_t *transparentLayer = &dunData[layer2Offset + width * height * 3];
-
-	for (int j = 0; j < height; j++) {
-		for (int i = 0; i < width; i++) {
-			dTransVal[16 + i][16 + j] = SDL_SwapLE16(*transparentLayer);
-			transparentLayer++;
-		}
-	}
+	LoadTransparency(dunData.get());
 }
 
 } // namespace
@@ -96,19 +80,17 @@ void LoadSetMap()
 			Quests[Q_SKELKING]._qvar1 = 1;
 		}
 		LoadPreL1Dungeon("Levels\\L1Data\\SklKng1.DUN");
-		LoadL1Dungeon("Levels\\L1Data\\SklKng2.DUN", 83, 45);
-		LoadPalette("Levels\\L1Data\\L1_2.pal");
+		LoadL1Dungeon("Levels\\L1Data\\SklKng2.DUN", { 83, 45 });
 		SetMapTransparency("Levels\\L1Data\\SklKngT.dun");
-		AddL1Objs(0, 0, MAXDUNX, MAXDUNY);
+		LoadPalette("Levels\\L1Data\\L1_2.pal");
 		AddSKingObjs();
 		InitSKingTriggers();
 		break;
 	case SL_BONECHAMB:
 		LoadPreL2Dungeon("Levels\\L2Data\\Bonecha2.DUN");
-		LoadL2Dungeon("Levels\\L2Data\\Bonecha1.DUN", 69, 39);
-		LoadPalette("Levels\\L2Data\\L2_2.pal");
+		LoadL2Dungeon("Levels\\L2Data\\Bonecha1.DUN", { 69, 39 });
 		SetMapTransparency("Levels\\L2Data\\BonechaT.dun");
-		AddL2Objs(0, 0, MAXDUNX, MAXDUNY);
+		LoadPalette("Levels\\L2Data\\L2_2.pal");
 		AddSChamObjs();
 		InitSChambTriggers();
 		break;
@@ -117,7 +99,7 @@ void LoadSetMap()
 	case SL_POISONWATER:
 		if (Quests[Q_PWATER]._qactive == QUEST_INIT)
 			Quests[Q_PWATER]._qactive = QUEST_ACTIVE;
-		LoadL3Dungeon("Levels\\L3Data\\Foulwatr.DUN", 31, 83);
+		LoadL3Dungeon("Levels\\L3Data\\Foulwatr.DUN", { 31, 83 });
 		LoadPalette("Levels\\L3Data\\L3pfoul.pal");
 		InitPWaterTriggers();
 		break;
@@ -128,50 +110,34 @@ void LoadSetMap()
 			Quests[Q_BETRAYER]._qvar2 = 3;
 		}
 		LoadPreL1Dungeon("Levels\\L1Data\\Vile1.DUN");
-		LoadL1Dungeon("Levels\\L1Data\\Vile2.DUN", 35, 36);
-		LoadPalette("Levels\\L1Data\\L1_2.pal");
-		AddL1Objs(0, 0, MAXDUNX, MAXDUNY);
-		AddVileObjs();
+		LoadL1Dungeon("Levels\\L1Data\\Vile2.DUN", { 35, 36 });
 		SetMapTransparency("Levels\\L1Data\\Vile1.DUN");
+		LoadPalette("Levels\\L1Data\\L1_2.pal");
+		AddVileObjs();
 		InitNoTriggers();
 		break;
 	case SL_NONE:
 #ifdef _DEBUG
 		switch (setlvltype) {
 		case DTYPE_CATHEDRAL:
-			LoadPreL1Dungeon(TestMapPath.c_str());
-			LoadL1Dungeon(TestMapPath.c_str(), ViewPosition.x, ViewPosition.y);
-			AddL1Objs(0, 0, MAXDUNX, MAXDUNY);
+		case DTYPE_CRYPT:
+			LoadL1Dungeon(TestMapPath.c_str(), ViewPosition);
 			break;
 		case DTYPE_CATACOMBS:
-			LoadPreL2Dungeon(TestMapPath.c_str());
-			LoadL2Dungeon(TestMapPath.c_str(), ViewPosition.x, ViewPosition.y);
-			AddL2Objs(0, 0, MAXDUNX, MAXDUNY);
+			LoadL2Dungeon(TestMapPath.c_str(), ViewPosition);
 			break;
 		case DTYPE_CAVES:
-			LoadPreL3Dungeon(TestMapPath.c_str());
-			LoadL3Dungeon(TestMapPath.c_str(), ViewPosition.x, ViewPosition.y);
-			AddL3Objs(0, 0, MAXDUNX, MAXDUNY);
+		case DTYPE_NEST:
+			LoadL3Dungeon(TestMapPath.c_str(), ViewPosition);
 			break;
 		case DTYPE_HELL:
-			LoadPreL4Dungeon(TestMapPath.c_str());
-			LoadL4Dungeon(TestMapPath.c_str(), ViewPosition.x, ViewPosition.y);
-			break;
-		case DTYPE_NEST:
-			LoadPreL3Dungeon(TestMapPath.c_str());
-			LoadL3Dungeon(TestMapPath.c_str(), ViewPosition.x, ViewPosition.y);
-			break;
-		case DTYPE_CRYPT:
-			LoadPreL1Dungeon(TestMapPath.c_str());
-			LoadL1Dungeon(TestMapPath.c_str(), ViewPosition.x, ViewPosition.y);
-			AddCryptObjects(0, 0, MAXDUNX, MAXDUNY);
+			LoadL4Dungeon(TestMapPath.c_str(), ViewPosition);
 			break;
 		case DTYPE_TOWN:
 		case DTYPE_NONE:
 			break;
 		}
 		LoadRndLvlPal(setlvltype);
-		SetMapTransparency(TestMapPath.c_str());
 		InitNoTriggers();
 #endif
 		break;

--- a/test/drlg_l1_test.cpp
+++ b/test/drlg_l1_test.cpp
@@ -1,28 +1,12 @@
 #include <gtest/gtest.h>
 
 #include "drlg_test.hpp"
-#include "gendung.h"
-#include "lighting.h"
 #include "player.h"
 #include "quests.h"
 
 using namespace devilution;
 
 namespace {
-
-TEST(Drlg_l1, DRLG_Init_Globals_noflag)
-{
-	DisableLighting = false;
-	DRLG_Init_Globals();
-	EXPECT_EQ(dLight[0][0], 15);
-}
-
-TEST(Drlg_l1, DRLG_Init_Globals)
-{
-	DisableLighting = true;
-	DRLG_Init_Globals();
-	EXPECT_EQ(dLight[0][0], 0);
-}
 
 TEST(Drlg_l1, CreateL5Dungeon_diablo_1_2588)
 {


### PR DESCRIPTION
I'm not super happy about the relation of `LoadDungeonBase()` here, but it is still well worth it for the the amount of duplicate code that it replaces.

Fun fact, none of the original levels have the transparency info in the correct file, which is why `SetMapTransparency()` still exists.