### PR TITLE
Use decimal separators for gold and XP

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -42,6 +42,7 @@
 #include "stores.h"
 #include "towners.h"
 #include "trigs.h"
+#include "utils/format_int.hpp"
 #include "utils/language.h"
 #include "utils/sdl_geometry.h"
 #include "utils/stdcompat/optional.hpp"
@@ -878,7 +879,7 @@ void DrawInfoBox(const Surface &out)
 	} else if (!myPlayer.HoldItem.isEmpty()) {
 		if (myPlayer.HoldItem._itype == ItemType::Gold) {
 			int nGold = myPlayer.HoldItem._ivalue;
-			InfoString = fmt::format(fmt::runtime(ngettext("{:d} gold piece", "{:d} gold pieces", nGold)), nGold);
+			InfoString = fmt::format(fmt::runtime(ngettext("{:s} gold piece", "{:s} gold pieces", nGold)), FormatInteger(nGold));
 		} else if (!myPlayer.CanUseItem(myPlayer.HoldItem)) {
 			InfoString = _("Requirements not met");
 		} else {
@@ -1057,10 +1058,10 @@ void DrawGoldSplit(const Surface &out, int amount)
 	const std::string description = fmt::format(
 	    fmt::runtime(ngettext(
 	        /* TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.*/
-	        "You have {:d} gold piece. How many do you want to remove?",
-	        "You have {:d} gold pieces. How many do you want to remove?",
+	        "You have {:s} gold piece. How many do you want to remove?",
+	        "You have {:s} gold pieces. How many do you want to remove?",
 	        initialDropGoldValue)),
-	    initialDropGoldValue);
+	    FormatInteger(initialDropGoldValue));
 
 	// Pre-wrap the string at spaces, otherwise DrawString would hard wrap in the middle of words
 	const std::string wrapped = WordWrapString(description, 200);

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1057,7 +1057,7 @@ void DrawGoldSplit(const Surface &out, int amount)
 
 	const std::string description = fmt::format(
 	    fmt::runtime(ngettext(
-	        /* TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.*/
+	        /* TRANSLATORS: {:s} is a number with separators. Dialog is shown when splitting a stash of Gold.*/
 	        "You have {:s} gold piece. How many do you want to remove?",
 	        "You have {:s} gold pieces. How many do you want to remove?",
 	        initialDropGoldValue)),

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -26,6 +26,7 @@
 #include "stores.h"
 #include "town.h"
 #include "towners.h"
+#include "utils/format_int.hpp"
 #include "utils/language.h"
 #include "utils/sdl_geometry.h"
 #include "utils/stdcompat/optional.hpp"
@@ -1928,7 +1929,7 @@ int8_t CheckInvHLight()
 
 	if (pi->_itype == ItemType::Gold) {
 		int nGold = pi->_ivalue;
-		InfoString = fmt::format(fmt::runtime(ngettext("{:d} gold piece", "{:d} gold pieces", nGold)), nGold);
+		InfoString = fmt::format(fmt::runtime(ngettext("{:s} gold piece", "{:s} gold pieces", nGold)), FormatInteger(nGold));
 	} else {
 		InfoColor = pi->getTextColor();
 		if (pi->_iIdentified) {

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -37,6 +37,7 @@
 #include "spells.h"
 #include "stores.h"
 #include "town.h"
+#include "utils/format_int.hpp"
 #include "utils/language.h"
 #include "utils/math.h"
 #include "utils/stdcompat/algorithm.hpp"
@@ -3452,7 +3453,7 @@ void GetItemStr(Item &item)
 		InfoColor = item.getTextColor();
 	} else {
 		int nGold = item._ivalue;
-		InfoString = fmt::format(fmt::runtime(ngettext("{:d} gold piece", "{:d} gold pieces", nGold)), nGold);
+		InfoString = fmt::format(fmt::runtime(ngettext("{:s} gold piece", "{:s} gold pieces", nGold)), FormatInteger(nGold));
 	}
 }
 

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -12,6 +12,7 @@
 #include "panels/ui_panels.hpp"
 #include "player.h"
 #include "utils/display.h"
+#include "utils/format_int.hpp"
 #include "utils/language.h"
 
 namespace devilution {
@@ -163,7 +164,7 @@ PanelEntry panelEntries[] = {
 
 	{ N_("Gold"), { TopRightLabelX, /* set dynamically */ 0 }, 0, 98 },
 	{ "", { TopRightLabelX, 127 }, 99, 0,
-	    []() { return StyledText { UiFlags::ColorWhite, fmt::format("{:d}", MyPlayer->_pGold) }; } },
+	    []() { return StyledText { UiFlags::ColorWhite, fmt::format("{:s}", FormatInteger(MyPlayer->_pGold)) }; } },
 
 	{ N_("Armor class"), { RightColumnLabelX, 163 }, 57, RightColumnLabelWidth,
 	    []() { return StyledText { GetValueColor(MyPlayer->_pIBonusAC), fmt::format("{:d}", MyPlayer->GetArmor()) }; } },

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -131,13 +131,17 @@ PanelEntry panelEntries[] = {
 	{ N_("Level"), { 57, 52 }, 57, 45,
 	    []() { return StyledText { UiFlags::ColorWhite, fmt::format("{:d}", MyPlayer->_pLevel) }; } },
 	{ N_("Experience"), { TopRightLabelX, 52 }, 99, 91,
-	    []() { return StyledText { UiFlags::ColorWhite, fmt::format("{:d}", MyPlayer->_pExperience) }; } },
+	    []() {
+	        int spacing = ((MyPlayer->_pExperience >= 1000000000) ? 0 : 1);
+	        return StyledText { UiFlags::ColorWhite, fmt::format("{:s}", FormatInteger(MyPlayer->_pExperience)), spacing };
+	    } },
 	{ N_("Next level"), { TopRightLabelX, 80 }, 99, 198,
 	    []() {
 	        if (MyPlayer->_pLevel == MAXCHARLEVEL) {
 		        return StyledText { UiFlags::ColorWhitegold, std::string(_("None")) };
 	        }
-	        return StyledText { UiFlags::ColorWhite, fmt::format("{:d}", MyPlayer->_pNextExper) };
+	        int spacing = ((MyPlayer->_pNextExper >= 1000000000) ? 0 : 1);
+	        return StyledText { UiFlags::ColorWhite, fmt::format("{:s}", FormatInteger(MyPlayer->_pNextExper)), spacing };
 	    } },
 
 	{ N_("Base"), { LeftColumnLabelX, /* set dynamically */ 0 }, 0, 44 },

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -14,6 +14,7 @@
 #include "inv.h"
 #include "itemlabels.h"
 #include "qol/stash.h"
+#include "utils/format_int.hpp"
 #include "utils/language.h"
 #include "utils/stdcompat/string_view.hpp"
 
@@ -70,7 +71,7 @@ void AddItemToLabelQueue(int id, int x, int y)
 
 	std::string textOnGround;
 	if (item._itype == ItemType::Gold) {
-		textOnGround = fmt::format(fmt::runtime(_("{:d} gold")), item._ivalue);
+		textOnGround = fmt::format(fmt::runtime(_("{:s} gold")), FormatInteger(item._ivalue));
 	} else {
 		textOnGround = item._iIdentified ? item._iIName : item._iName;
 	}

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -16,6 +16,7 @@
 #include "hwcursor.hpp"
 #include "minitext.h"
 #include "stores.h"
+#include "utils/format_int.hpp"
 #include "utils/language.h"
 #include "utils/utf8.hpp"
 
@@ -377,7 +378,7 @@ void DrawStash(const Surface &out)
 	UiFlags style = UiFlags::VerticalCenter | UiFlags::ColorWhite;
 
 	DrawString(out, fmt::format("{:d}", Stash.GetPage() + 1), { position + Displacement { 132, 0 }, { 57, 11 } }, UiFlags::AlignCenter | style);
-	DrawString(out, fmt::format("{:d}", Stash.gold), { position + Displacement { 122, 19 }, { 107, 13 } }, UiFlags::AlignRight | style);
+	DrawString(out, fmt::format("{:s}", FormatInteger(Stash.gold)), { position + Displacement { 122, 19 }, { 107, 13 } }, UiFlags::AlignRight | style);
 }
 
 void CheckStashItem(Point mousePosition, bool isShiftHeld, bool isCtrlHeld)

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -7,12 +7,11 @@
 
 #include <array>
 
-#include <fmt/format.h>
-
 #include "DiabloUI/art_draw.h"
 #include "control.h"
 #include "engine/point.hpp"
 #include "options.h"
+#include "utils/format_int.hpp"
 #include "utils/language.h"
 
 namespace devilution {
@@ -42,27 +41,6 @@ void DrawEndCap(const Surface &out, Point point, int idx, const ColorGradient &g
 	out.SetPixel({ point.x, point.y + 1 }, gradient[idx * 3 / 4]);
 	out.SetPixel({ point.x, point.y + 2 }, gradient[idx]);
 	out.SetPixel({ point.x, point.y + 3 }, gradient[idx / 2]);
-}
-
-/**
- * @brief Prints integer with thousands separator.
- */
-std::string PrintWithSeparator(int n)
-{
-	std::string number = fmt::format("{:d}", n);
-	std::string out = "";
-
-	int length = number.length();
-	int mlength = length % 3;
-	if (mlength == 0)
-		mlength = 3;
-	out.append(number.substr(0, mlength));
-	for (int i = mlength; i < length; i += 3) {
-		AppendStrView(out, _(/* TRANSLATORS: Thousands separator */ ","));
-		out.append(number.substr(i, 3));
-	}
-
-	return out;
 }
 
 } // namespace
@@ -150,7 +128,7 @@ bool CheckXPBarInfo()
 		// Show a maximum level indicator for max level players.
 		InfoColor = UiFlags::ColorWhitegold;
 
-		AddPanelString(fmt::format(fmt::runtime(_("Experience: {:s}")), PrintWithSeparator(ExpLvlsTbl[charLevel - 1])));
+		AddPanelString(fmt::format(fmt::runtime(_("Experience: {:s}")), FormatInteger(ExpLvlsTbl[charLevel - 1])));
 		AddPanelString(_("Maximum Level"));
 
 		return true;
@@ -158,9 +136,9 @@ bool CheckXPBarInfo()
 
 	InfoColor = UiFlags::ColorWhite;
 
-	AddPanelString(fmt::format(fmt::runtime(_("Experience: {:s}")), PrintWithSeparator(player._pExperience)));
-	AddPanelString(fmt::format(fmt::runtime(_("Next Level: {:s}")), PrintWithSeparator(ExpLvlsTbl[charLevel])));
-	AddPanelString(fmt::format(fmt::runtime(_("{:s} to Level {:d}")), PrintWithSeparator(ExpLvlsTbl[charLevel] - player._pExperience), charLevel + 1));
+	AddPanelString(fmt::format(fmt::runtime(_("Experience: {:s}")), FormatInteger(player._pExperience)));
+	AddPanelString(fmt::format(fmt::runtime(_("Next Level: {:s}")), FormatInteger(ExpLvlsTbl[charLevel])));
+	AddPanelString(fmt::format(fmt::runtime(_("{:s} to Level {:d}")), FormatInteger(ExpLvlsTbl[charLevel] - player._pExperience), charLevel + 1));
 
 	return true;
 }

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2236,11 +2236,8 @@ void PrintSString(const Surface &out, int margin, int line, const char *text, Ui
 
 	const Rectangle rect { { sx, sy }, { width, 0 } };
 	DrawString(out, text, rect, flags);
-	if (price > 0) {
-		char valstr[32];
-		sprintf(valstr, "%i", price);
-		DrawString(out, valstr, rect, flags | UiFlags::AlignRight);
-	}
+	if (price > 0)
+		DrawString(out, fmt::format("{:s}", FormatInteger(price)), rect, flags | UiFlags::AlignRight);
 
 	if (stextsel == line) {
 		DrawSelector(out, rect, text, flags);

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -21,6 +21,7 @@
 #include "panels/info_box.hpp"
 #include "qol/stash.h"
 #include "towners.h"
+#include "utils/format_int.hpp"
 #include "utils/language.h"
 #include "utils/stdcompat/string_view.hpp"
 #include "utils/utf8.hpp"
@@ -2437,7 +2438,7 @@ void DrawSText(const Surface &out)
 	}
 
 	if (RenderGold) {
-		PrintSString(out, 28, 1, fmt::format(fmt::runtime(_("Your gold: {:d}")), TotalPlayerGold()).c_str(), UiFlags::ColorWhitegold | UiFlags::AlignRight);
+		PrintSString(out, 28, 1, fmt::format(fmt::runtime(_("Your gold: {:s}")), FormatInteger(TotalPlayerGold())).c_str(), UiFlags::ColorWhitegold | UiFlags::AlignRight);
 	}
 
 	if (stextscrl)

--- a/Source/utils/format_int.hpp
+++ b/Source/utils/format_int.hpp
@@ -30,4 +30,4 @@ inline std::string FormatInteger(int n)
 	return out;
 }
 
-} //namespace devilution
+} // namespace devilution

--- a/Source/utils/format_int.hpp
+++ b/Source/utils/format_int.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+
+#include <fmt/format.h>
+
+#include "utils/language.h"
+#include "utils/stdcompat/string_view.hpp"
+
+namespace devilution {
+
+/**
+ * @brief Formats integer with thousands separator.
+ */
+inline std::string FormatInteger(int n)
+{
+	std::string number = fmt::format("{:d}", n);
+	std::string out = "";
+
+	int length = number.length();
+	int mlength = length % 3;
+	if (mlength == 0)
+		mlength = 3;
+	out.append(number.substr(0, mlength));
+	for (int i = mlength; i < length; i += 3) {
+		AppendStrView(out, _(/* TRANSLATORS: Thousands separator */ ","));
+		out.append(number.substr(i, 3));
+	}
+
+	return out;
+}
+
+} //namespace devilution

--- a/Translations/bg.po
+++ b/Translations/bg.po
@@ -7434,8 +7434,8 @@ msgstr "Напуснете ателието"
 msgid "I have these items for sale:"
 msgstr "Продавам тези предмети."
 
-msgid "Your gold: {:d}"
-msgstr "Вашето злато: {:d}"
+msgid "Your gold: {:s}"
+msgstr "Вашето злато: {:s}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:425

--- a/Translations/bg.po
+++ b/Translations/bg.po
@@ -1048,10 +1048,10 @@ msgstr[0] "{:d} Заряд"
 msgstr[1] "{:d} Заряди"
 
 #: Source/control.cpp:860 Source/inv.cpp:1991 Source/items.cpp:3480
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "{:d} златна монета"
-msgstr[1] "{:d} златни монети"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s} златна монета"
+msgstr[1] "{:s} златни монети"
 
 #: Source/control.cpp:863
 msgid "Requirements not met"
@@ -1071,10 +1071,10 @@ msgstr "Ново ниво"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1040
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "Имате {:d} златна монета. Колко искате да отделите?"
-msgstr[1] "Имате {:d} златни монети. Колко искате да отделите?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "Имате {:s} златна монета. Колко искате да отделите?"
+msgstr[1] "Имате {:s} златни монети. Колко искате да отделите?"
 
 #: Source/controls/modifier_hints.cpp:176 Source/qol/monhealthbar.cpp:36
 #: Source/qol/xpbar.cpp:76
@@ -6920,8 +6920,8 @@ msgid "Chat History (Messages: {:d})"
 msgstr "История на Чата (Съобщения: {:d})"
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
-msgstr "{:d} злато"
+msgid "{:s} gold"
+msgstr "{:s} злато"
 
 #: Source/qol/stash.cpp:619
 msgid "How many gold pieces do you want to withdraw?"

--- a/Translations/cs.po
+++ b/Translations/cs.po
@@ -7399,8 +7399,8 @@ msgstr "Odejít z obchodu"
 msgid "I have these items for sale:"
 msgstr "Mám na prodej tyto věci:"
 
-msgid "Your gold: {:d}"
-msgstr "Tvoje zlaťáky: {:d}"
+msgid "Your gold: {:s}"
+msgstr "Tvoje zlaťáky: {:s}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:425

--- a/Translations/cs.po
+++ b/Translations/cs.po
@@ -1044,11 +1044,11 @@ msgstr[1] "{:d} Použití"
 msgstr[2] "{:d} Použití"
 
 #: Source/control.cpp:860 Source/inv.cpp:1998 Source/items.cpp:3480
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "{:d} zlaťák"
-msgstr[1] "{:d} zlaťáky"
-msgstr[2] "{:d} zlaťáků"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s} zlaťák"
+msgstr[1] "{:s} zlaťáky"
+msgstr[2] "{:s} zlaťáků"
 
 #: Source/control.cpp:863
 msgid "Requirements not met"
@@ -1068,11 +1068,11 @@ msgstr "Nová úroveň"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1040
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "Máš {:d} zlaťák. Kolik jich chceš odebrat?"
-msgstr[1] "Máš {:d} zlaťáky. Kolik jich chceš odebrat?"
-msgstr[2] "Máš {:d} zlaťáků. Kolik jich chceš odebrat?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "Máš {:s} zlaťák. Kolik jich chceš odebrat?"
+msgstr[1] "Máš {:s} zlaťáky. Kolik jich chceš odebrat?"
+msgstr[2] "Máš {:s} zlaťáků. Kolik jich chceš odebrat?"
 
 #: Source/controls/modifier_hints.cpp:176 Source/qol/monhealthbar.cpp:36
 #: Source/qol/xpbar.cpp:76
@@ -6885,8 +6885,8 @@ msgid "Chat History (Messages: {:d})"
 msgstr "Historie Chatu (Zprávy: {:d})"
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
-msgstr "{:d} zlaťáků"
+msgid "{:s} gold"
+msgstr "{:s} zlaťáků"
 
 #: Source/qol/stash.cpp:586
 msgid "How many gold pieces do you want to withdraw?"

--- a/Translations/da.po
+++ b/Translations/da.po
@@ -7810,7 +7810,7 @@ msgstr "Køb varer"
 msgid "Leave the shop"
 msgstr "Forlad healers hjem"
 
-msgid "Your gold: {:d}"
+msgid "Your gold: {:s}"
 msgstr ""
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!

--- a/Translations/da.po
+++ b/Translations/da.po
@@ -1127,10 +1127,10 @@ msgstr[1] "Understøttede spillere: {:d}"
 
 #: Source/control.cpp:860 Source/inv.cpp:1998 Source/items.cpp:3480
 #, fuzzy
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "Understøttede spillere: {:d}"
-msgstr[1] "Understøttede spillere: {:d}"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "Understøttede spillere: {:s}"
+msgstr[1] "Understøttede spillere: {:s}"
 
 #: Source/control.cpp:863
 #, fuzzy
@@ -1156,8 +1156,8 @@ msgstr "Niveau:"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1040
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -7271,8 +7271,8 @@ msgstr ""
 
 #: Source/qol/itemlabels.cpp:72
 #, fuzzy
-msgid "{:d} gold"
-msgstr "Understøttede spillere: {:d}"
+msgid "{:s} gold"
+msgstr "Understøttede spillere: {:s}"
 
 #: Source/qol/stash.cpp:586
 msgid "How many gold pieces do you want to withdraw?"

--- a/Translations/de.po
+++ b/Translations/de.po
@@ -1053,10 +1053,10 @@ msgstr[0] "{:d}-Ladung"
 msgstr[1] "{:d}-Ladungen"
 
 #: Source/control.cpp:860 Source/inv.cpp:1998 Source/items.cpp:3480
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "{:d} Goldstück"
-msgstr[1] "{:d} Goldstücke"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s} Goldstück"
+msgstr[1] "{:s} Goldstücke"
 
 #: Source/control.cpp:863
 msgid "Requirements not met"
@@ -1076,10 +1076,10 @@ msgstr "Level-Up"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1040
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "Du hast {:d} Goldstück. Wieviele möchtest Du abheben?"
-msgstr[1] "Du hast {:d} Goldstücke. Wieviele möchtest Du abheben?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "Du hast {:s} Goldstück. Wieviele möchtest Du abheben?"
+msgstr[1] "Du hast {:s} Goldstücke. Wieviele möchtest Du abheben?"
 
 #: Source/controls/modifier_hints.cpp:176 Source/qol/monhealthbar.cpp:36
 #: Source/qol/xpbar.cpp:76
@@ -6907,8 +6907,8 @@ msgid "Chat History (Messages: {:d})"
 msgstr "Chatverlauf (Nachrichten: {:d})"
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
-msgstr "{:d} Gold"
+msgid "{:s} gold"
+msgstr "{:s} Gold"
 
 #: Source/qol/stash.cpp:586
 msgid "How many gold pieces do you want to withdraw?"

--- a/Translations/de.po
+++ b/Translations/de.po
@@ -7421,8 +7421,8 @@ msgstr "Schmiede verlassen"
 msgid "I have these items for sale:"
 msgstr "Hier meine Angebote:"
 
-msgid "Your gold: {:d}"
-msgstr "Euer Gold: {:d}"
+msgid "Your gold: {:s}"
+msgstr "Euer Gold: {:s}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:425

--- a/Translations/devilutionx.pot
+++ b/Translations/devilutionx.pot
@@ -956,8 +956,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: Source/control.cpp:860 Source/inv.cpp:2004 Source/items.cpp:3486
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -979,8 +979,8 @@ msgstr ""
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1039
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -6670,7 +6670,7 @@ msgid "Chat History (Messages: {:d})"
 msgstr ""
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
+msgid "{:s} gold"
 msgstr ""
 
 #: Source/qol/stash.cpp:619

--- a/Translations/devilutionx.pot
+++ b/Translations/devilutionx.pot
@@ -7397,7 +7397,7 @@ msgid "Say Goodbye"
 msgstr ""
 
 #: Source/stores.cpp:2458
-msgid "Your gold: {:d}"
+msgid "Your gold: {:s}"
 msgstr ""
 
 #. TRANSLATORS: Quest dialog spoken by Cain

--- a/Translations/el.po
+++ b/Translations/el.po
@@ -7462,8 +7462,8 @@ msgstr "Φύγεις από το Μαγαζί"
 msgid "I have these items for sale:"
 msgstr "Έχω τα παρακάτω για πώληση:"
 
-msgid "Your gold: {:d}"
-msgstr "Ο χρυσός σου: {:d}"
+msgid "Your gold: {:s}"
+msgstr "Ο χρυσός σου: {:s}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:425
@@ -7621,8 +7621,8 @@ msgstr "Δεν έχεις τίποτα για ταυτοποίηση."
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:1225
-msgid "Identify which item?             Your gold: {:d}"
-msgstr "Πιο αντικείμενο θέλεις να ταυτοποιήσω;   Ο χρυσός σου: {:d}"
+msgid "Identify which item?             Your gold: {:s}"
+msgstr "Πιο αντικείμενο θέλεις να ταυτοποιήσω;   Ο χρυσός σου: {:s}"
 
 #: Source/stores.cpp:1242
 msgid "This item is:"

--- a/Translations/el.po
+++ b/Translations/el.po
@@ -1071,10 +1071,10 @@ msgstr[0] "{:d} Φορτίο"
 msgstr[1] "{:d} Φορτία"
 
 #: Source/control.cpp:860 Source/inv.cpp:1991 Source/items.cpp:3471
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "{:d} χρυσό νόμισμα"
-msgstr[1] "{:d} χρυσά νομίσματα"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s} χρυσό νόμισμα"
+msgstr[1] "{:s} χρυσά νομίσματα"
 
 #: Source/control.cpp:862
 msgid "Requirements not met"
@@ -1094,10 +1094,10 @@ msgstr "Νέο Επίπεδο"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1039
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "Έχεις {:d} χρυσό νόμισμα. Πόσα θέλεις να αφαιρέσεις;"
-msgstr[1] "Έχεις {:d} χρυσά νομίσματα. Πόσα θέλεις να αφαιρέσεις;"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "Έχεις {:s} χρυσό νόμισμα. Πόσα θέλεις να αφαιρέσεις;"
+msgstr[1] "Έχεις {:s} χρυσά νομίσματα. Πόσα θέλεις να αφαιρέσεις;"
 
 #: Source/controls/modifier_hints.cpp:177 Source/qol/monhealthbar.cpp:36
 #: Source/qol/xpbar.cpp:76
@@ -6946,14 +6946,14 @@ msgid "Chat History (Messages: {:d})"
 msgstr ""
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
-msgstr "{:d} χρυσά"
+msgid "{:s} gold"
+msgstr "{:s} χρυσά"
 
 #: Source/qol/stash.cpp:619
 #, fuzzy
-#| msgid "You have {:d} gold piece. How many do you want to remove?"
+#| msgid "You have {:s} gold piece. How many do you want to remove?"
 msgid "How many gold pieces do you want to withdraw?"
-msgstr "Έχεις {:d} χρυσό νόμισμα. Πόσα θέλεις να αφαιρέσεις;"
+msgstr "Έχεις {:s} χρυσό νόμισμα. Πόσα θέλεις να αφαιρέσεις;"
 
 #. TRANSLATORS: Thousands separator
 #: Source/qol/xpbar.cpp:61

--- a/Translations/es.po
+++ b/Translations/es.po
@@ -1053,10 +1053,10 @@ msgstr[0] "{:d} Carga"
 msgstr[1] "{:d} Cargas"
 
 #: Source/control.cpp:860 Source/inv.cpp:1990 Source/items.cpp:3480
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "{:d} pieza de oro"
-msgstr[1] "{:d} piezas de oro"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s} pieza de oro"
+msgstr[1] "{:s} piezas de oro"
 
 #: Source/control.cpp:863
 msgid "Requirements not met"
@@ -1076,10 +1076,10 @@ msgstr "Subir Nivel"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1040
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "Tiene {:d} moneda de oro. ¿Cuanto quiere eliminar?"
-msgstr[1] "Tiene {:d} monedas de oro. ¿Cuantas quiere eliminar?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "Tiene {:s} moneda de oro. ¿Cuanto quiere eliminar?"
+msgstr[1] "Tiene {:s} monedas de oro. ¿Cuantas quiere eliminar?"
 
 #: Source/controls/modifier_hints.cpp:176 Source/qol/monhealthbar.cpp:36
 #: Source/qol/xpbar.cpp:76
@@ -6940,8 +6940,8 @@ msgid "Chat History (Messages: {:d})"
 msgstr "Historia del Chat (Mensajes: {:d})"
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
-msgstr "{:d} oro"
+msgid "{:s} gold"
+msgstr "{:s} oro"
 
 #: Source/qol/stash.cpp:597
 msgid "How many gold pieces do you want to withdraw?"

--- a/Translations/es.po
+++ b/Translations/es.po
@@ -7454,8 +7454,8 @@ msgstr "Salir de la tienda"
 msgid "I have these items for sale:"
 msgstr "Tengo estos artículos a la venta:"
 
-msgid "Your gold: {:d}"
-msgstr "Tu oro: {:d}"
+msgid "Your gold: {:s}"
+msgstr "Tu oro: {:s}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:425

--- a/Translations/fr.po
+++ b/Translations/fr.po
@@ -1078,8 +1078,8 @@ msgstr "Niveau Supérieur"
 #: Source/control.cpp:1040
 msgid "You have {:d} gold piece. How many do you want to remove?"
 msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "Vous avez {:d} pièce d'or. Combien voulez-vous en supprimer ?"
-msgstr[1] "Vous avez {:d} pièces d'or. Combien voulez-vous en supprimer ?"
+msgstr[0] "Vous avez {:d} pièce d'or. Combien voulez-vous en supprimer ?"
+msgstr[1] "Vous avez {:d} pièces d'or. Combien voulez-vous en supprimer ?"
 
 #: Source/controls/modifier_hints.cpp:177 Source/qol/monhealthbar.cpp:36
 #: Source/qol/xpbar.cpp:76
@@ -5696,7 +5696,7 @@ msgstr "Quelques Immunités Magiques"
 
 #: Source/msg.cpp:537
 msgid "Trying to drop a floor item?"
-msgstr "Vous essayez de déposer un objet au sol ?"
+msgstr "Vous essayez de déposer un objet au sol ?"
 
 #: Source/msg.cpp:1039 Source/msg.cpp:1074 Source/msg.cpp:1105
 #: Source/msg.cpp:1232 Source/msg.cpp:1264 Source/msg.cpp:1296
@@ -6936,7 +6936,7 @@ msgstr "{:d} or"
 
 #: Source/qol/stash.cpp:619
 msgid "How many gold pieces do you want to withdraw?"
-msgstr "Combien de pièces d'or voulez-vous retirer ?"
+msgstr "Combien de pièces d'or voulez-vous retirer ?"
 
 #. TRANSLATORS: Thousands separator
 #: Source/qol/xpbar.cpp:61
@@ -7658,8 +7658,8 @@ msgid "Say Goodbye"
 msgstr "Dire Au Revoir"
 
 #: Source/stores.cpp:2439
-msgid "Your gold: {:d}"
-msgstr "Votre or: {:d}"
+msgid "Your gold: {:s}"
+msgstr "Votre or: {:s}"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:15
@@ -8851,9 +8851,9 @@ msgstr ""
 "On dit que toute arme fabriquée sur l'enclume ardente est dotée d'un grand "
 "pouvoir. Si cette Enclume est bien l'Enclume de Fureur, je pourrais peut-"
 "être vous fabriquer une arme capable de vaincre même le plus sombre des "
-"seigneurs de l'enfer !\n"
+"seigneurs de l'enfer !\n"
 " \n"
-"Trouvez l'Enclume pour moi et je me mettrai au travail !"
+"Trouvez l'Enclume pour moi et je me mettrai au travail !"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:188
@@ -9335,7 +9335,7 @@ msgid ""
 msgstr ""
 "Si Adria n'en a pas, vous pouvez parier que c'est une chose rare. Je ne peux "
 "pas vous offrir plus d'aide, mais cela ressemble à... un énorme champignon "
-"gargantuesque, gonflé et gonflé ! Eh bien, bonne chasse, je suppose."
+"gargantuesque, gonflé et gonflé ! Eh bien, bonne chasse, je suppose."
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:263
@@ -9344,7 +9344,7 @@ msgid ""
 "listen... here's the secret - moderation is the key!"
 msgstr ""
 "Ogden mélange un champignon noir, mais je tombe malade si je bois ça. "
-"Écoutez, écoutez... voici le secret - la modération est la clé !"
+"Écoutez, écoutez... voici le secret - la modération est la clé !"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:265
@@ -9620,7 +9620,7 @@ msgstr ""
 #. TRANSLATORS: Quest dialog spoken by Zhar the Mad (Hostile)
 #: Source/textdat.cpp:307
 msgid "Arrrrgh! Your curiosity will be the death of you!!!"
-msgstr "Arrrrgh ! Votre curiosité sera votre mort !!!"
+msgstr "Arrrrgh ! Votre curiosité sera votre mort !!!"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain
 #: Source/textdat.cpp:308
@@ -10976,7 +10976,7 @@ msgid ""
 " \n"
 "Perhaps I can tell you more if we speak again. Good luck."
 msgstr ""
-"Dieu merci, vous êtes de retour !\n"
+"Dieu merci, vous êtes de retour !\n"
 "Beaucoup de choses ont changé depuis que vous ne vivez plus ici, mon ami. "
 "Tout était paisible jusqu'à ce que les cavaliers noirs arrivent et "
 "détruisent notre village. Beaucoup ont été abattus sur place, et ceux qui "

--- a/Translations/fr.po
+++ b/Translations/fr.po
@@ -1053,10 +1053,10 @@ msgstr[0] "{:d} Charge"
 msgstr[1] "{:d} Charges"
 
 #: Source/control.cpp:861 Source/inv.cpp:1923 Source/items.cpp:3452
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "{:d} pièce d'or"
-msgstr[1] "{:d} pièces d'or"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s} pièce d'or"
+msgstr[1] "{:s} pièces d'or"
 
 #: Source/control.cpp:863
 msgid "Requirements not met"
@@ -1076,10 +1076,10 @@ msgstr "Niveau Supérieur"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1040
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "Vous avez {:d} pièce d'or. Combien voulez-vous en supprimer ?"
-msgstr[1] "Vous avez {:d} pièces d'or. Combien voulez-vous en supprimer ?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "Vous avez {:s} pièce d'or. Combien voulez-vous en supprimer ?"
+msgstr[1] "Vous avez {:s} pièces d'or. Combien voulez-vous en supprimer ?"
 
 #: Source/controls/modifier_hints.cpp:177 Source/qol/monhealthbar.cpp:36
 #: Source/qol/xpbar.cpp:76
@@ -5696,7 +5696,7 @@ msgstr "Quelques Immunités Magiques"
 
 #: Source/msg.cpp:537
 msgid "Trying to drop a floor item?"
-msgstr "Vous essayez de déposer un objet au sol ?"
+msgstr "Vous essayez de déposer un objet au sol ?"
 
 #: Source/msg.cpp:1039 Source/msg.cpp:1074 Source/msg.cpp:1105
 #: Source/msg.cpp:1232 Source/msg.cpp:1264 Source/msg.cpp:1296
@@ -6931,12 +6931,12 @@ msgid "Chat History (Messages: {:d})"
 msgstr "Historique des Messages (Messages: {:d})"
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
-msgstr "{:d} or"
+msgid "{:s} gold"
+msgstr "{:s} or"
 
 #: Source/qol/stash.cpp:619
 msgid "How many gold pieces do you want to withdraw?"
-msgstr "Combien de pièces d'or voulez-vous retirer ?"
+msgstr "Combien de pièces d'or voulez-vous retirer ?"
 
 #. TRANSLATORS: Thousands separator
 #: Source/qol/xpbar.cpp:61
@@ -8851,9 +8851,9 @@ msgstr ""
 "On dit que toute arme fabriquée sur l'enclume ardente est dotée d'un grand "
 "pouvoir. Si cette Enclume est bien l'Enclume de Fureur, je pourrais peut-"
 "être vous fabriquer une arme capable de vaincre même le plus sombre des "
-"seigneurs de l'enfer !\n"
+"seigneurs de l'enfer !\n"
 " \n"
-"Trouvez l'Enclume pour moi et je me mettrai au travail !"
+"Trouvez l'Enclume pour moi et je me mettrai au travail !"
 
 #. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:188
@@ -9335,7 +9335,7 @@ msgid ""
 msgstr ""
 "Si Adria n'en a pas, vous pouvez parier que c'est une chose rare. Je ne peux "
 "pas vous offrir plus d'aide, mais cela ressemble à... un énorme champignon "
-"gargantuesque, gonflé et gonflé ! Eh bien, bonne chasse, je suppose."
+"gargantuesque, gonflé et gonflé ! Eh bien, bonne chasse, je suppose."
 
 #. TRANSLATORS: Quest dialog spoken by Farnham
 #: Source/textdat.cpp:263
@@ -9344,7 +9344,7 @@ msgid ""
 "listen... here's the secret - moderation is the key!"
 msgstr ""
 "Ogden mélange un champignon noir, mais je tombe malade si je bois ça. "
-"Écoutez, écoutez... voici le secret - la modération est la clé !"
+"Écoutez, écoutez... voici le secret - la modération est la clé !"
 
 #. TRANSLATORS: Quest dialog spoken by Adria
 #: Source/textdat.cpp:265
@@ -9620,7 +9620,7 @@ msgstr ""
 #. TRANSLATORS: Quest dialog spoken by Zhar the Mad (Hostile)
 #: Source/textdat.cpp:307
 msgid "Arrrrgh! Your curiosity will be the death of you!!!"
-msgstr "Arrrrgh ! Votre curiosité sera votre mort !!!"
+msgstr "Arrrrgh ! Votre curiosité sera votre mort !!!"
 
 #. TRANSLATORS: Neutral dialog spoken by Cain
 #: Source/textdat.cpp:308
@@ -10976,7 +10976,7 @@ msgid ""
 " \n"
 "Perhaps I can tell you more if we speak again. Good luck."
 msgstr ""
-"Dieu merci, vous êtes de retour !\n"
+"Dieu merci, vous êtes de retour !\n"
 "Beaucoup de choses ont changé depuis que vous ne vivez plus ici, mon ami. "
 "Tout était paisible jusqu'à ce que les cavaliers noirs arrivent et "
 "détruisent notre village. Beaucoup ont été abattus sur place, et ceux qui "

--- a/Translations/hr.po
+++ b/Translations/hr.po
@@ -1068,11 +1068,11 @@ msgstr[1] "{:d} napunjena"
 msgstr[2] "{:d} napunjeno"
 
 #: Source/control.cpp:860 Source/inv.cpp:1991 Source/items.cpp:3480
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "{:d} zlatnik"
-msgstr[1] "{:d} zlatnika"
-msgstr[2] "{:d} zlatnika"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s} zlatnik"
+msgstr[1] "{:s} zlatnika"
+msgstr[2] "{:s} zlatnika"
 
 #: Source/control.cpp:863
 msgid "Requirements not met"
@@ -1092,11 +1092,11 @@ msgstr "Povećaj razinu"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1040
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "Imate {:d} zlatnik. Koliko ih želite izdvojiti?"
-msgstr[1] "Imate {:d} zlatnika. Koliko ih želite izdvojiti?"
-msgstr[2] "Imate {:d} zlatnika. Koliko ih želite izdvojiti?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "Imate {:s} zlatnik. Koliko ih želite izdvojiti?"
+msgstr[1] "Imate {:s} zlatnika. Koliko ih želite izdvojiti?"
+msgstr[2] "Imate {:s} zlatnika. Koliko ih želite izdvojiti?"
 
 #: Source/controls/modifier_hints.cpp:176 Source/qol/monhealthbar.cpp:36
 #: Source/qol/xpbar.cpp:76
@@ -6988,15 +6988,15 @@ msgid "Chat History (Messages: {:d})"
 msgstr ""
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
-msgstr "{:d} zlato"
+msgid "{:s} gold"
+msgstr "{:s} zlato"
 
 #: Source/qol/stash.cpp:619
 #, fuzzy
-#| msgid "You have {:d} gold piece. How many do you want to remove?"
-#| msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
+#| msgid "You have {:s} gold piece. How many do you want to remove?"
+#| msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
 msgid "How many gold pieces do you want to withdraw?"
-msgstr "Imate {:d} zlatnik. Koliko ih želite izdvojiti?"
+msgstr "Imate {:s} zlatnik. Koliko ih želite izdvojiti?"
 
 #. TRANSLATORS: Thousands separator
 #: Source/qol/xpbar.cpp:61

--- a/Translations/hr.po
+++ b/Translations/hr.po
@@ -7513,8 +7513,8 @@ msgstr "Napustiti kovačnicu"
 msgid "I have these items for sale:"
 msgstr "Imam ove predmete za prodaju:"
 
-msgid "Your gold: {:d}"
-msgstr "Vaše zlato: {:d}"
+msgid "Your gold: {:s}"
+msgstr "Vaše zlato: {:s}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:425

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -7432,8 +7432,8 @@ msgstr "Lascia bottega"
 msgid "I have these items for sale:"
 msgstr "Merce in vendita:"
 
-msgid "Your gold: {:d}"
-msgstr "Monete: {:d}"
+msgid "Your gold: {:s}"
+msgstr "Monete: {:s}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:425

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -1058,10 +1058,10 @@ msgstr[0] "{:d} Carica"
 msgstr[1] "{:d} Cariche"
 
 #: Source/control.cpp:860 Source/inv.cpp:1998 Source/items.cpp:3480
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "{:d} moneta"
-msgstr[1] "{:d} monete"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s} moneta"
+msgstr[1] "{:s} monete"
 
 #: Source/control.cpp:863
 msgid "Requirements not met"
@@ -1081,10 +1081,10 @@ msgstr "Su di Livello"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1040
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "Possiedi {:d} moneta d'oro. Quante ne vuoi rimuovere?"
-msgstr[1] "Possiedi {:d} monete d'oro. Quante ne vuoi rimuovere?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "Possiedi {:s} moneta d'oro. Quante ne vuoi rimuovere?"
+msgstr[1] "Possiedi {:s} monete d'oro. Quante ne vuoi rimuovere?"
 
 #: Source/controls/modifier_hints.cpp:176 Source/qol/monhealthbar.cpp:36
 #: Source/qol/xpbar.cpp:76
@@ -6918,8 +6918,8 @@ msgid "Chat History (Messages: {:d})"
 msgstr "Cronologia Chat (Messaggi: {:d})"
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
-msgstr "{:d} monete"
+msgid "{:s} gold"
+msgstr "{:s} monete"
 
 #: Source/qol/stash.cpp:586
 msgid "How many gold pieces do you want to withdraw?"

--- a/Translations/ja.po
+++ b/Translations/ja.po
@@ -1041,9 +1041,9 @@ msgid_plural "{:d} Charges"
 msgstr[0] "{:d}チャージ"
 
 #: Source/control.cpp:880 Source/inv.cpp:1931 Source/items.cpp:3452
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "{:d} 金魂"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s} 金魂"
 
 #: Source/control.cpp:882
 msgid "Requirements not met"
@@ -1063,9 +1063,9 @@ msgstr "レベルアップ"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1059
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "あなたは{:d}ゴールドを持っています。何枚削除しますか？"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "あなたは{:s}ゴールドを持っています。何枚削除しますか？"
 
 #: Source/controls/modifier_hints.cpp:179 Source/qol/monhealthbar.cpp:44
 #: Source/qol/xpbar.cpp:76
@@ -6883,8 +6883,8 @@ msgid "Chat History (Messages: {:d})"
 msgstr "チャット​履歴 (​メッセージ: {:d}​)"
 
 #: Source/qol/itemlabels.cpp:73
-msgid "{:d} gold"
-msgstr "{:d} ゴールド"
+msgid "{:s} gold"
+msgstr "{:s} ゴールド"
 
 #: Source/qol/stash.cpp:619
 msgid "How many gold pieces do you want to withdraw?"

--- a/Translations/ja.po
+++ b/Translations/ja.po
@@ -7610,8 +7610,8 @@ msgid "Say Goodbye"
 msgstr "立ち去る"
 
 #: Source/stores.cpp:2440
-msgid "Your gold: {:d}"
-msgstr "所持​金: {:d}"
+msgid "Your gold: {:s}"
+msgstr "所持​金: {:s}"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:15

--- a/Translations/ko.po
+++ b/Translations/ko.po
@@ -7592,8 +7592,8 @@ msgid "Say Goodbye"
 msgstr "작별한다"
 
 #: Source/stores.cpp:2458
-msgid "Your gold: {:d}"
-msgstr "소지금: {:d}"
+msgid "Your gold: {:s}"
+msgstr "소지금: {:s}"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:15
@@ -11305,20 +11305,20 @@ msgstr "디아블로에게 향한다"
 msgid "Back to Level {:d}"
 msgstr "지하 {:d} 층으로 돌아간다"
 
-#~ msgid "I have these items for sale:             Your gold: {:d}"
-#~ msgstr "이런 물품들이 구비되어 있습니다:             소지금: {:d}"
+#~ msgid "I have these items for sale:             Your gold: {:s}"
+#~ msgstr "이런 물품들이 구비되어 있습니다:             소지금: {:s}"
 
-#~ msgid "Repair which item?             Your gold: {:d}"
-#~ msgstr "무엇을 수리하겠습니까?             소지금: {:d}"
+#~ msgid "Repair which item?             Your gold: {:s}"
+#~ msgstr "무엇을 수리하겠습니까?             소지금: {:s}"
 
-#~ msgid "Recharge which item?             Your gold: {:d}"
-#~ msgstr "무엇을 충전하겠습니까?             소지금: {:d}"
+#~ msgid "Recharge which item?             Your gold: {:s}"
+#~ msgstr "무엇을 충전하겠습니까?             소지금: {:s}"
 
-#~ msgid "I have this item for sale:             Your gold: {:d}"
-#~ msgstr "이런 물품들이 구비되어 있습니다:             소지금: {:d}"
+#~ msgid "I have this item for sale:             Your gold: {:s}"
+#~ msgstr "이런 물품들이 구비되어 있습니다:             소지금: {:s}"
 
-#~ msgid "Identify which item?             Your gold: {:d}"
-#~ msgstr "어느 물품을 감별하겠습니까?             소지금: {:d}"
+#~ msgid "Identify which item?             Your gold: {:s}"
+#~ msgstr "어느 물품을 감별하겠습니까?             소지금: {:s}"
 
 #~ msgid "Right click to use"
 #~ msgstr "우클릭으로 사용"

--- a/Translations/ko.po
+++ b/Translations/ko.po
@@ -1034,9 +1034,9 @@ msgid_plural "{:d} Charges"
 msgstr[0] "{:d}회 충전"
 
 #: Source/control.cpp:860 Source/inv.cpp:2004 Source/items.cpp:3486
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "금화 {:d}개"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "금화 {:s}개"
 
 #: Source/control.cpp:862
 msgid "Requirements not met"
@@ -1056,9 +1056,9 @@ msgstr "레벨업"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1039
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "금화 {:d}개를 갖고 있습니다. 몇 개를 버리겠습니까?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "금화 {:s}개를 갖고 있습니다. 몇 개를 버리겠습니까?"
 
 #: Source/controls/modifier_hints.cpp:177 Source/qol/monhealthbar.cpp:36
 #: Source/qol/xpbar.cpp:76
@@ -6863,8 +6863,8 @@ msgid "Chat History (Messages: {:d})"
 msgstr "채팅 내역 (메시지: {:d})"
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
-msgstr "{:d} 금화"
+msgid "{:s} gold"
+msgstr "{:s} 금화"
 
 #: Source/qol/stash.cpp:619
 msgid "How many gold pieces do you want to withdraw?"

--- a/Translations/pl.po
+++ b/Translations/pl.po
@@ -7642,8 +7642,8 @@ msgid "Say Goodbye"
 msgstr "Wyjdź"
 
 #: Source/stores.cpp:2439
-msgid "Your gold: {:d}"
-msgstr "Twoje złoto: {:d}"
+msgid "Your gold: {:s}"
+msgstr "Twoje złoto: {:s}"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:15
@@ -11858,8 +11858,8 @@ msgstr "Staw czoła Diablo"
 msgid "Back to Level {:d}"
 msgstr "Wróć na poziom {:d}"
 
-#~ msgid "Which item is for sale?             Your gold: {:d}"
-#~ msgstr "Który przedmiot chcesz sprzedać?  Twoje złoto: {:d}"
+#~ msgid "Which item is for sale?             Your gold: {:s}"
+#~ msgstr "Który przedmiot chcesz sprzedać?  Twoje złoto: {:s}"
 
 #~ msgid "Right click to use"
 #~ msgstr "PPM by użyć"

--- a/Translations/pl.po
+++ b/Translations/pl.po
@@ -1051,11 +1051,11 @@ msgstr[1] "Ładunki: {:d}"
 msgstr[2] "Ładunki: {:d}"
 
 #: Source/control.cpp:861 Source/inv.cpp:1963 Source/items.cpp:3489
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "{:d} złota"
-msgstr[1] "{:d} złota"
-msgstr[2] "{:d} złota"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s} złota"
+msgstr[1] "{:s} złota"
+msgstr[2] "{:s} złota"
 
 #: Source/control.cpp:863
 msgid "Requirements not met"
@@ -1075,11 +1075,11 @@ msgstr "Nowy Poziom"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1040
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "Masz {:d} złota. Ile monet chcesz oddzielić?"
-msgstr[1] "Masz {:d} złota. Ile monet chcesz oddzielić?"
-msgstr[2] "Masz {:d} złota. Ile monet chcesz oddzielić?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "Masz {:s} złota. Ile monet chcesz oddzielić?"
+msgstr[1] "Masz {:s} złota. Ile monet chcesz oddzielić?"
+msgstr[2] "Masz {:s} złota. Ile monet chcesz oddzielić?"
 
 #: Source/controls/modifier_hints.cpp:177 Source/qol/monhealthbar.cpp:36
 #: Source/qol/xpbar.cpp:76
@@ -6915,8 +6915,8 @@ msgid "Chat History (Messages: {:d})"
 msgstr "Historia czatu (Wiadomości: {:d})"
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
-msgstr "{:d} złota"
+msgid "{:s} gold"
+msgstr "{:s} złota"
 
 #: Source/qol/stash.cpp:618
 msgid "How many gold pieces do you want to withdraw?"

--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -7803,8 +7803,8 @@ msgstr "Sair da loja"
 msgid "I have these items for sale:"
 msgstr "Eu tenho estes itens para vender:"
 
-msgid "Your gold: {:d}"
-msgstr "Seu ouro: {:d}"
+msgid "Your gold: {:s}"
+msgstr "Seu ouro: {:s}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:425

--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -1051,10 +1051,10 @@ msgstr[0] "{:d} carga"
 msgstr[1] "{:d} cargas"
 
 #: Source/control.cpp:860 Source/inv.cpp:1998 Source/items.cpp:3480
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "{:d} peça de ouro"
-msgstr[1] "{:d} peças de ouro"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s} peça de ouro"
+msgstr[1] "{:s} peças de ouro"
 
 #: Source/control.cpp:863
 msgid "Requirements not met"
@@ -1074,10 +1074,10 @@ msgstr "Subiu de Nível"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1040
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "Você tem {:d} peça de ouro. Quanto quer remover?"
-msgstr[1] "Você tem {:d} peças de ouro. Quanto quer remover?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "Você tem {:s} peça de ouro. Quanto quer remover?"
+msgstr[1] "Você tem {:s} peças de ouro. Quanto quer remover?"
 
 #: Source/controls/modifier_hints.cpp:176 Source/qol/monhealthbar.cpp:36
 #: Source/qol/xpbar.cpp:76
@@ -7289,8 +7289,8 @@ msgid "Chat History (Messages: {:d})"
 msgstr "Histórico do Chat (Mensagens: {:d})"
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
-msgstr "{:d} de ouro"
+msgid "{:s} gold"
+msgstr "{:s} de ouro"
 
 #: Source/qol/stash.cpp:586
 msgid "How many gold pieces do you want to withdraw?"

--- a/Translations/ro.po
+++ b/Translations/ro.po
@@ -1068,11 +1068,11 @@ msgstr[1] "{:d} încărcături"
 msgstr[2] "{:d} de încărcături"
 
 #: Source/control.cpp:860 Source/inv.cpp:1998 Source/items.cpp:3480
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "{:d} galben"
-msgstr[1] "{:d} galbeni"
-msgstr[2] "{:d} de galbeni"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s} galben"
+msgstr[1] "{:s} galbeni"
+msgstr[2] "{:s} de galbeni"
 
 #: Source/control.cpp:863
 msgid "Requirements not met"
@@ -1092,11 +1092,11 @@ msgstr "Creștere nivel"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1040
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "Aveți {:d} galben. Câți doriți sa scoateți?"
-msgstr[1] "Aveți {:d} galbeni. Cați doriți sa scoateți?"
-msgstr[2] "Aveți {:d} de galbeni. Cați doriți sa scoateți?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "Aveți {:s} galben. Câți doriți sa scoateți?"
+msgstr[1] "Aveți {:s} galbeni. Cați doriți sa scoateți?"
+msgstr[2] "Aveți {:s} de galbeni. Cați doriți sa scoateți?"
 
 #: Source/controls/modifier_hints.cpp:176 Source/qol/monhealthbar.cpp:36
 #: Source/qol/xpbar.cpp:76
@@ -7008,15 +7008,15 @@ msgid "Chat History (Messages: {:d})"
 msgstr ""
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
-msgstr "{:d} galbeni"
+msgid "{:s} gold"
+msgstr "{:s} galbeni"
 
 #: Source/qol/stash.cpp:586
 #, fuzzy
-#| msgid "You have {:d} gold piece. How many do you want to remove?"
-#| msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
+#| msgid "You have {:s} gold piece. How many do you want to remove?"
+#| msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
 msgid "How many gold pieces do you want to withdraw?"
-msgstr "Aveți {:d} galben. Câți doriți sa scoateți?"
+msgstr "Aveți {:s} galben. Câți doriți sa scoateți?"
 
 #. TRANSLATORS: Thousands separator
 #: Source/qol/xpbar.cpp:61

--- a/Translations/ro.po
+++ b/Translations/ro.po
@@ -7531,8 +7531,8 @@ msgstr "Ieșiți din magazin"
 msgid "I have these items for sale:"
 msgstr "Am aceste obiecte de vânzare:"
 
-msgid "Your gold: {:d}"
-msgstr "Galbeni: {:d}"
+msgid "Your gold: {:s}"
+msgstr "Galbeni: {:s}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:425

--- a/Translations/ru.po
+++ b/Translations/ru.po
@@ -7541,8 +7541,8 @@ msgstr "Покинуть магазин"
 msgid "I have these items for sale:"
 msgstr "У меня есть на продажу:"
 
-msgid "Your gold: {:d}"
-msgstr "Ваше золото: {:d}"
+msgid "Your gold: {:s}"
+msgstr "Ваше золото: {:s}"
 
 # “премиальные прдеметы” не влезают в длину строки
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
@@ -7704,8 +7704,8 @@ msgstr "У вас нечего идентифицировать."
 # Нужно выровнять с остальными строками
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:1225
-msgid "Identify which item?             Your gold: {:d}"
-msgstr "Какой предмет идентифицировать? Ваше золото: {:d}"
+msgid "Identify which item?             Your gold: {:s}"
+msgstr "Какой предмет идентифицировать? Ваше золото: {:s}"
 
 #: Source/stores.cpp:1242
 msgid "This item is:"

--- a/Translations/ru.po
+++ b/Translations/ru.po
@@ -1069,11 +1069,11 @@ msgstr[1] "{:d} заряда"
 msgstr[2] "{:d} зарядов"
 
 #: Source/control.cpp:860 Source/inv.cpp:1998 Source/items.cpp:3480
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "{:d} золотой"
-msgstr[1] "{:d} золотых"
-msgstr[2] "{:d} золотых"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s} золотой"
+msgstr[1] "{:s} золотых"
+msgstr[2] "{:s} золотых"
 
 #: Source/control.cpp:863
 msgid "Requirements not met"
@@ -1093,11 +1093,11 @@ msgstr "Новый уровень"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1040
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "У вас {:d} золотой. Сколько вы хотите забрать?"
-msgstr[1] "У вас {:d} золотых. Сколько вы хотите забрать?"
-msgstr[2] "У вас {:d} золотых. Сколько вы хотите забрать?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "У вас {:s} золотой. Сколько вы хотите забрать?"
+msgstr[1] "У вас {:s} золотых. Сколько вы хотите забрать?"
+msgstr[2] "У вас {:s} золотых. Сколько вы хотите забрать?"
 
 #: Source/controls/modifier_hints.cpp:176 Source/qol/monhealthbar.cpp:36
 #: Source/qol/xpbar.cpp:76
@@ -7026,8 +7026,8 @@ msgid "Chat History (Messages: {:d})"
 msgstr "История чата (Сообщения: {:d})"
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
-msgstr "{:d} золота"
+msgid "{:s} gold"
+msgstr "{:s} золота"
 
 #: Source/qol/stash.cpp:586
 msgid "How many gold pieces do you want to withdraw?"

--- a/Translations/sv.po
+++ b/Translations/sv.po
@@ -7412,8 +7412,8 @@ msgstr "Lämna butiken"
 msgid "I have these items for sale:"
 msgstr "Jag har dessa föremål till salu:"
 
-msgid "Your gold: {:d}"
-msgstr "Ditt guld: {:d}"
+msgid "Your gold: {:s}"
+msgstr "Ditt guld: {:s}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:425

--- a/Translations/sv.po
+++ b/Translations/sv.po
@@ -1045,10 +1045,10 @@ msgstr[0] "{:d} Laddning"
 msgstr[1] "{:d} Laddningar"
 
 #: Source/control.cpp:860 Source/inv.cpp:1998 Source/items.cpp:3480
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "{:d} guldmynt"
-msgstr[1] "{:d} guldmynt"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s} guldmynt"
+msgstr[1] "{:s} guldmynt"
 
 #: Source/control.cpp:863
 msgid "Requirements not met"
@@ -1068,10 +1068,10 @@ msgstr "Nivåökning"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1040
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "Du har {:d} guldmynt. Hur många vill du dra ifrån?"
-msgstr[1] "Du har {:d} guldmynt. Hur många vill du dra ifrån?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "Du har {:s} guldmynt. Hur många vill du dra ifrån?"
+msgstr[1] "Du har {:s} guldmynt. Hur många vill du dra ifrån?"
 
 #: Source/controls/modifier_hints.cpp:176 Source/qol/monhealthbar.cpp:36
 #: Source/qol/xpbar.cpp:76
@@ -6898,8 +6898,8 @@ msgid "Chat History (Messages: {:d})"
 msgstr "Chatthistorik (Meddelanden: {:d})"
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
-msgstr "{:d} guld"
+msgid "{:s} gold"
+msgstr "{:s} guld"
 
 #: Source/qol/stash.cpp:586
 msgid "How many gold pieces do you want to withdraw?"

--- a/Translations/uk.po
+++ b/Translations/uk.po
@@ -7635,8 +7635,8 @@ msgid "Say Goodbye"
 msgstr "Попрощатися"
 
 #: Source/stores.cpp:2440
-msgid "Your gold: {:d}"
-msgstr "Ваше золото: {:d}"
+msgid "Your gold: {:s}"
+msgstr "Ваше золото: {:s}"
 
 #. TRANSLATORS: Quest dialog spoken by Cain
 #: Source/textdat.cpp:15

--- a/Translations/uk.po
+++ b/Translations/uk.po
@@ -1045,11 +1045,11 @@ msgstr[1] "{:d} Заряда"
 msgstr[2] "{:d} Зарядів"
 
 #: Source/control.cpp:880 Source/inv.cpp:1931 Source/items.cpp:3453
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "{:d} золота монета"
-msgstr[1] "{:d} золоті монети"
-msgstr[2] "{:d} золотих монет"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s} золота монета"
+msgstr[1] "{:s} золоті монети"
+msgstr[2] "{:s} золотих монет"
 
 #: Source/control.cpp:882
 msgid "Requirements not met"
@@ -1069,11 +1069,11 @@ msgstr "Новий Рівень"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1059
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "У тебе {:d} золота монета. Скільки ти хочеш забрати?"
-msgstr[1] "У тебе {:d} золоті монети. Скільки ти хочеш забрати?"
-msgstr[2] "У тебе {:d} золотих монет. Скільки ти хочеш забрати?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "У тебе {:s} золота монета. Скільки ти хочеш забрати?"
+msgstr[1] "У тебе {:s} золоті монети. Скільки ти хочеш забрати?"
+msgstr[2] "У тебе {:s} золотих монет. Скільки ти хочеш забрати?"
 
 #: Source/controls/modifier_hints.cpp:179 Source/qol/monhealthbar.cpp:44
 #: Source/qol/xpbar.cpp:76
@@ -6908,8 +6908,8 @@ msgid "Chat History (Messages: {:d})"
 msgstr "Історія Чату (Повідомлень: {:d})"
 
 #: Source/qol/itemlabels.cpp:73
-msgid "{:d} gold"
-msgstr "{:d} золота"
+msgid "{:s} gold"
+msgstr "{:s} золота"
 
 #: Source/qol/stash.cpp:619
 msgid "How many gold pieces do you want to withdraw?"

--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -7354,8 +7354,8 @@ msgstr "要​出售​哪​件​物品？"
 msgid "You have nothing to repair."
 msgstr "你​没有​需要​修理​的​物品。"
 
-msgid "Your gold: {:d}"
-msgstr "你​的​金币: {:d}"
+msgid "Your gold: {:s}"
+msgstr "你​的​金币: {:s}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:637

--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -1029,9 +1029,9 @@ msgid_plural "{:d} Charges"
 msgstr[0] "{:d}充能"
 
 #: Source/control.cpp:860 Source/inv.cpp:1998 Source/items.cpp:3480
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
-msgstr[0] "{:d}金币堆"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s}金币堆"
 
 #: Source/control.cpp:863
 msgid "Requirements not met"
@@ -1051,9 +1051,9 @@ msgstr "升级"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1040
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
-msgstr[0] "你有 {:d} 金币。你想要取出多少？"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
+msgstr[0] "你有 {:s} 金币。你想要取出多少？"
 
 #: Source/controls/modifier_hints.cpp:176 Source/qol/monhealthbar.cpp:36
 #: Source/qol/xpbar.cpp:76
@@ -6820,8 +6820,8 @@ msgid "Chat History (Messages: {:d})"
 msgstr "聊天​历史 (​消息: {:d}​)"
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
-msgstr "{:d} 金币"
+msgid "{:s} gold"
+msgstr "{:s} 金币"
 
 #: Source/qol/stash.cpp:586
 msgid "How many gold pieces do you want to withdraw?"

--- a/Translations/zh_TW.po
+++ b/Translations/zh_TW.po
@@ -8151,8 +8151,8 @@ msgstr "修理​專案"
 msgid "Leave the shop"
 msgstr "離​開​商店"
 
-msgid "Your gold: {:d}"
-msgstr "你​的​金幣: {:d}"
+msgid "Your gold: {:s}"
+msgstr "你​的​金幣: {:s}"
 
 #. TRANSLATORS: This text is white space sensitive. Check for correct alignment!
 #: Source/stores.cpp:360 Source/stores.cpp:725 Source/stores.cpp:1096

--- a/Translations/zh_TW.po
+++ b/Translations/zh_TW.po
@@ -1078,9 +1078,9 @@ msgstr[0] "生命點{:d}的{:d}"
 
 #: Source/control.cpp:860 Source/inv.cpp:1998 Source/items.cpp:3480
 #, fuzzy
-#| msgid "{:d} gold piece"
-msgid "{:d} gold piece"
-msgid_plural "{:d} gold pieces"
+#| msgid "{:s} gold piece"
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
 msgstr[0] "金幣"
 
 #: Source/control.cpp:863
@@ -1101,8 +1101,8 @@ msgstr "升級"
 
 #. TRANSLATORS: {:d} is a number. Dialog is shown when splitting a stash of Gold.
 #: Source/control.cpp:1040
-msgid "You have {:d} gold piece. How many do you want to remove?"
-msgid_plural "You have {:d} gold pieces. How many do you want to remove?"
+msgid "You have {:s} gold piece. How many do you want to remove?"
+msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
 msgstr[0] ""
 
 #: Source/controls/modifier_hints.cpp:176 Source/qol/monhealthbar.cpp:36
@@ -7522,7 +7522,7 @@ msgid "Chat History (Messages: {:d})"
 msgstr ""
 
 #: Source/qol/itemlabels.cpp:72
-msgid "{:d} gold"
+msgid "{:s} gold"
 msgstr ""
 
 #: Source/qol/stash.cpp:586


### PR DESCRIPTION
With the introduction of the stash, players can hoard huge amounts of gold. The total amount of gold can become illegible in the absence of decimal separators.
![Screenshot_20220617_140658](https://user-images.githubusercontent.com/3142367/174289521-f94fe28e-f63d-49a0-b0cb-83540a9af828.png)
![Screenshot_20220617_142352](https://user-images.githubusercontent.com/3142367/174289549-a58b2185-4b97-417f-b9eb-e62954bbc07f.png)

