### PR TITLE
Use string_view for UiValidPlayerName

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -634,12 +634,10 @@ bool UiValidPlayerName(string_view name)
 	if (name.find_first_of(",<>%&\\\"?*#/: ") != name.npos)
 		return false;
 
-	constexpr auto isAsciiControlCharacter = [](char character) -> bool {
-		return (character >= 0x00 && character < 0x20) || character == 0x7F;
-	};
-	for (char letter : name)
-		if (isAsciiControlCharacter(letter) || !IsLeadUtf8CodeUnit(letter))
-			return false;
+	// Only basic latin alphabet is supported for multiplayer characters to avoid rendering issues for players who do
+	// not have fonts.mpq installed
+	if (!std::all_of(name.begin(), name.end(), IsBasicLatin))
+		return false;
 
 	string_view bannedNames[] = {
 		"gvdl",

--- a/Source/DiabloUI/diabloui.h
+++ b/Source/DiabloUI/diabloui.h
@@ -87,7 +87,7 @@ void UiDestroy();
 void UiTitleDialog();
 void UnloadUiGFX();
 void UiInitialize();
-bool UiValidPlayerName(const char *name); /* check */
+bool UiValidPlayerName(string_view name); /* check */
 void UiSelHeroMultDialog(bool (*fninfo)(bool (*fninfofunc)(_uiheroinfo *)), bool (*fncreate)(_uiheroinfo *), bool (*fnremove)(_uiheroinfo *), void (*fnstats)(unsigned int, _uidefaultstats *), _selhero_selections *dlgresult, uint32_t *saveNumber);
 void UiSelHeroSingDialog(bool (*fninfo)(bool (*fninfofunc)(_uiheroinfo *)), bool (*fncreate)(_uiheroinfo *), bool (*fnremove)(_uiheroinfo *), void (*fnstats)(unsigned int, _uidefaultstats *), _selhero_selections *dlgresult, uint32_t *saveNumber, _difficulty *difficulty);
 bool UiCreditsDialog();

--- a/Source/platform/locale.cpp
+++ b/Source/platform/locale.cpp
@@ -191,9 +191,8 @@ std::vector<std::string> GetLocales()
 		if (!languages.empty())
 			locales.emplace_back(languages.substr(0, languages.find_first_of(".")));
 	} else {
-		size_t separatorPos {};
 		do {
-			separatorPos = languages.find_first_of(":");
+			size_t separatorPos = languages.find_first_of(":");
 			if (separatorPos != 0)
 				locales.emplace_back(std::string(languages.substr(0, separatorPos)));
 

--- a/Source/utils/utf8.hpp
+++ b/Source/utils/utf8.hpp
@@ -32,11 +32,17 @@ inline char32_t ConsumeFirstUtf8CodePoint(string_view *input)
 /**
  * Returns true if this is a trailing byte in a UTF-8 code point encoding.
  *
- * A trailing byte is any byte that is not the heading byte.
+ * Trailing bytes all begin with 10 as the most significant bits, meaning they generally fall in the range 0x80 to
+ * 0xBF. Please note that certain 3 and 4 byte sequences use a narrower range for the second byte, this function is
+ * not intended to guarantee the character is valid within the sequence (or that the sequence is well-formed).
  */
 inline bool IsTrailUtf8CodeUnit(char x)
 {
-	return static_cast<signed char>(x) < -0x40;
+	// The following is equivalent to a bitmask test (x & 0xC0) == 0x80
+	// On x86_64 architectures it ends up being one instruction shorter
+	// This invokes implementation defined behaviour on platforms where the underlying type of char is unsigned char
+	// until C++20 makes unsigned to signed conversion well defined
+	return static_cast<signed char>(x) < static_cast<signed char>('\xC0');
 }
 
 /**

--- a/Source/utils/utf8.hpp
+++ b/Source/utils/utf8.hpp
@@ -44,6 +44,16 @@ constexpr bool IsLeadUtf8CodeUnit(char x)
 }
 
 /**
+ * Returns true if the character is part of the Basic Latin set.
+ *
+ * This includes ASCII punctuation, symbols, math operators, digits, and both uppercase/lowercase latin alphabets
+ */
+constexpr bool IsBasicLatin(char x)
+{
+	return x >= '\x20' && x <= '\x7E';
+}
+
+/**
  * Returns true if this is a trailing byte in a UTF-8 code point encoding.
  *
  * Trailing bytes all begin with 10 as the most significant bits, meaning they generally fall in the range 0x80 to

--- a/Source/utils/utf8.hpp
+++ b/Source/utils/utf8.hpp
@@ -30,6 +30,20 @@ inline char32_t ConsumeFirstUtf8CodePoint(string_view *input)
 }
 
 /**
+ * Returns true if this is a byte that potentially starts a valid UTF-8 sequence.
+ *
+ * Well-formed UTF-8 sequences are described in table 3-7 of S3.9 of the Unicode Standard
+ * see: https://www.unicode.org/versions/Unicode14.0.0/ch03.pdf#G7404
+ *
+ * This is not an inverse of IsTrailUtf8CodeUnit. Byte values C0-C1, F5-FF are not valid anywhere in a UTF-8 sequence.
+ */
+constexpr bool IsLeadUtf8CodeUnit(char x)
+{
+	// single byte character || multibyte character leader
+	return (x >= '\x00' && x <= '\x7F') || (x >= '\xC2' && x <= '\xF4');
+}
+
+/**
  * Returns true if this is a trailing byte in a UTF-8 code point encoding.
  *
  * Trailing bytes all begin with 10 as the most significant bits, meaning they generally fall in the range 0x80 to

--- a/test/utf8_test.cpp
+++ b/test/utf8_test.cpp
@@ -34,5 +34,33 @@ TEST(AppendUtf8Test, FourByteCodePoint)
 	EXPECT_EQ(s, "あ");
 }
 
+TEST(Utf8CodeUnits, ValidCodePoints)
+{
+	// Working backwards on this loop to avoid triggering signed integer overflow on platforms where char has an
+	// underlying type of signed char
+	for (char x = '\x7F'; x >= '\x00' && x <= '\x7F'; x--) {
+		EXPECT_FALSE(IsTrailUtf8CodeUnit(x)) << "Basic Latin and ASCII Control characters are not trail code units";
+	}
+
+	for (char x = '\x80'; x >= '\x80' && x <= '\xBF'; x++) {
+		EXPECT_TRUE(IsTrailUtf8CodeUnit(x)) << "Bytes in the range 0x80 to 0xBF are potentially valid trail code units";
+	}
+
+	for (char x = '\xC2'; x >= '\xC2' && x <= '\xF4'; x++) {
+		EXPECT_FALSE(IsTrailUtf8CodeUnit(x)) << "Bytes in the range 0xC2 to 0xF4 are never valid trail code units";
+	}
+}
+
+TEST(Utf8CodeUnits, InvalidCodePoints)
+{
+	for (char x = '\xC0'; x >= '\xC0' && x <= '\xC1'; x++) {
+		EXPECT_FALSE(IsTrailUtf8CodeUnit(x)) << "Bytes in the range 0xC0 to oxC1 are not trail code units";
+	}
+
+	for (char x = '\xF5'; x >= '\xF5' && x <= '\xFF'; x++) {
+		EXPECT_FALSE(IsTrailUtf8CodeUnit(x)) << "Bytes in the range 0xF5 to 0xFF are not trail code units";
+	}
+}
+
 } // namespace
 } // namespace devilution

--- a/test/utf8_test.cpp
+++ b/test/utf8_test.cpp
@@ -39,14 +39,17 @@ TEST(Utf8CodeUnits, ValidCodePoints)
 	// Working backwards on this loop to avoid triggering signed integer overflow on platforms where char has an
 	// underlying type of signed char
 	for (char x = '\x7F'; x >= '\x00' && x <= '\x7F'; x--) {
+		EXPECT_TRUE(IsLeadUtf8CodeUnit(x)) << "Basic Latin and ASCII Control characters are lead code units";
 		EXPECT_FALSE(IsTrailUtf8CodeUnit(x)) << "Basic Latin and ASCII Control characters are not trail code units";
 	}
 
 	for (char x = '\x80'; x >= '\x80' && x <= '\xBF'; x++) {
 		EXPECT_TRUE(IsTrailUtf8CodeUnit(x)) << "Bytes in the range 0x80 to 0xBF are potentially valid trail code units";
+		EXPECT_FALSE(IsLeadUtf8CodeUnit(x)) << "Trail code units are never valid lead code units";
 	}
 
 	for (char x = '\xC2'; x >= '\xC2' && x <= '\xF4'; x++) {
+		EXPECT_TRUE(IsLeadUtf8CodeUnit(x)) << "Bytes in the range 0xC2 to 0xF4 are lead code units";
 		EXPECT_FALSE(IsTrailUtf8CodeUnit(x)) << "Bytes in the range 0xC2 to 0xF4 are never valid trail code units";
 	}
 }
@@ -54,10 +57,12 @@ TEST(Utf8CodeUnits, ValidCodePoints)
 TEST(Utf8CodeUnits, InvalidCodePoints)
 {
 	for (char x = '\xC0'; x >= '\xC0' && x <= '\xC1'; x++) {
+		EXPECT_FALSE(IsLeadUtf8CodeUnit(x)) << "Bytes in the range 0xC0 to 0xC1 are not lead code units";
 		EXPECT_FALSE(IsTrailUtf8CodeUnit(x)) << "Bytes in the range 0xC0 to oxC1 are not trail code units";
 	}
 
 	for (char x = '\xF5'; x >= '\xF5' && x <= '\xFF'; x++) {
+		EXPECT_FALSE(IsLeadUtf8CodeUnit(x)) << "Bytes in the range 0xF5 to 0xFF are not lead code units";
 		EXPECT_FALSE(IsTrailUtf8CodeUnit(x)) << "Bytes in the range 0xF5 to 0xFF are not trail code units";
 	}
 }

--- a/test/utf8_test.cpp
+++ b/test/utf8_test.cpp
@@ -67,5 +67,22 @@ TEST(Utf8CodeUnits, InvalidCodePoints)
 	}
 }
 
+TEST(Utf8CodeUnits, BasicLatin)
+{
+	for (char x = '\x00'; x < '\x20'; x++) {
+		EXPECT_FALSE(IsBasicLatin(x)) << "ASCII Control characters are not Basic Latin symbols";
+	}
+
+	for (char x = '\x20'; x <= '\x7E'; x++) {
+		EXPECT_TRUE(IsBasicLatin(x)) << "Basic Latin symbols are denoted by the range 0x20 to 0x7E inclusive";
+	}
+
+	EXPECT_FALSE(IsBasicLatin('\x7F')) << "ASCII Control character DEL is not a Basic Latin symbol";
+
+	for (char x = '\x80'; x >= '\x80' && x <= '\xFF'; x++) {
+		EXPECT_FALSE(IsBasicLatin(x)) << "Multibyte Utf8 code units are not Basic Latin symbols";
+	}
+}
+
 } // namespace
 } // namespace devilution


### PR DESCRIPTION
Now that I've been able to confirm this isn't causing #4723 might as well get some eyes on it 😂 

The use of `std::string` for `tempName` isn't necessary, this could be reverted to use a char array and CopyUtf8 again with a bit of boilerplate to then wrap it in a string view. Didn't feel it was worth avoiding the heap allocation but I can change this if there's a strong preference to put it back on the stack.

Edit: Oh hey, thanks to GCC6 I have to wrap std::string in a string_view to be able to use `find(string_view)` anyway 🙃 