### PR TITLE
Fix: Disable lightning in town

### DIFF
--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -382,7 +382,7 @@ void InitGlobals()
 	memset(dItem, 0, sizeof(dItem));
 	memset(dObject, 0, sizeof(dObject));
 	memset(dSpecial, 0, sizeof(dSpecial));
-	memset(dLight, DisableLighting ? 0 : 15, sizeof(dLight));
+	memset(dLight, DisableLighting || leveltype == DTYPE_TOWN ? 0 : 15, sizeof(dLight));
 
 	DRLG_InitTrans();
 

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -150,7 +150,6 @@ void TownCloseGrave()
 
 void InitTownPieces()
 {
-
 	for (int y = 0; y < MAXDUNY; y++) {
 		for (int x = 0; x < MAXDUNX; x++) {
 			if (dPiece[x][y] == 360) {


### PR DESCRIPTION
Fixes wrong lightning with new created town level:

![grafik](https://user-images.githubusercontent.com/25415264/174388465-e8b5c2c6-26d7-4b70-9479-12237feb4b00.png)

Town doesn't support lightning.
Regressed with 6fa681e5675cdee7c8dbf34cc328d53c4a511cfb

Before `dLight` was initialized with 0 (in `CreateTown`):
`memset(dLight, 0, sizeof(dLight));`
In master `dLight` is initialized with 15 (in `InitGlobals`):
`memset(dLight, DisableLighting ? 0 : 15, sizeof(dLight));`