### PR TITLE
Fix PlaceUniqueMonsters when unique monster type is not active on the level

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -547,7 +547,7 @@ void PlaceUniqueMonsters()
 		int mt;
 		for (mt = 0; mt < LevelMonsterTypeCount && !done; mt++)
 			done = (LevelMonsterTypes[mt].mtype == UniqueMonstersData[u].mtype);
-		if (done)
+		if (!done)
 			continue;
 
 		if (u == UMT_GARBUD && Quests[Q_GARBUD]._qactive == QUEST_NOTAVAIL)


### PR DESCRIPTION
`PlaceUniqueMonsters` places unique monsters that are not active on the level (isnt preset in `LevelMonsterTypes`); and doesn't place unique monsters that are active on the level.
This results in a crash in `InitMonster` cause `MData` is not initialized.
Regressed with 4d6ff58c22b2195afc10e1072ec417b013241242