### PR TITLE
Fix PlaceUniqueMonsters off by one monstertype

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -543,11 +543,12 @@ void PlaceUniqueMonsters()
 		if (UniqueMonstersData[u].mlevel != currlevel)
 			continue;
 
-		bool done = false;
 		int mt;
-		for (mt = 0; mt < LevelMonsterTypeCount && !done; mt++)
-			done = (LevelMonsterTypes[mt].mtype == UniqueMonstersData[u].mtype);
-		if (!done)
+		for (mt = 0; mt < LevelMonsterTypeCount; mt++) {
+			if (LevelMonsterTypes[mt].mtype == UniqueMonstersData[u].mtype)
+				break;
+		}
+		if (mt >= LevelMonsterTypeCount)
 			continue;
 
 		if (u == UMT_GARBUD && Quests[Q_GARBUD]._qactive == QUEST_NOTAVAIL)


### PR DESCRIPTION
Regressed with 4d6ff58c22b2195afc10e1072ec417b013241242
Didn't spot this one in #4729
Only results in a crash, if last monstertype on the level supports the uniques that is placed.

the `!done` condition was moved in the for-loop condition.
This is nicer but has a side-effect, cause the increment logic (`mt++`) of the for loop happens [before](https://en.cppreference.com/w/cpp/language/for) the for-condition is tested (`mt < LevelMonsterTypeCount && !done`).
That means's `mt` is increased one more time, even if `done` is true.
