### PR TITLE
Add helpers for creating/using Rectangles in UI contexts

### DIFF
--- a/Source/DiabloUI/button.cpp
+++ b/Source/DiabloUI/button.cpp
@@ -18,7 +18,7 @@ void RenderButton(UiButton *button)
 	const Surface &out = Surface(DiabloUiSurface());
 	RenderPcxSprite(out, ButtonSprite(button->IsPressed()), { button->m_rect.x, button->m_rect.y });
 
-	Rectangle textRect { { button->m_rect.x, button->m_rect.y }, { button->m_rect.w, button->m_rect.h } };
+	Rectangle textRect = MakeRectangle(button->m_rect);
 	if (!button->IsPressed()) {
 		--textRect.position.y;
 	}

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -802,18 +802,14 @@ namespace {
 
 void Render(const UiText *uiText)
 {
-	Rectangle rect { { uiText->m_rect.x, uiText->m_rect.y }, { uiText->m_rect.w, uiText->m_rect.h } };
-
 	const Surface &out = Surface(DiabloUiSurface());
-	DrawString(out, uiText->GetText(), rect, uiText->GetFlags() | UiFlags::FontSizeDialog);
+	DrawString(out, uiText->GetText(), MakeRectangle(uiText->m_rect), uiText->GetFlags() | UiFlags::FontSizeDialog);
 }
 
 void Render(const UiArtText *uiArtText)
 {
-	Rectangle rect { { uiArtText->m_rect.x, uiArtText->m_rect.y }, { uiArtText->m_rect.w, uiArtText->m_rect.h } };
-
 	const Surface &out = Surface(DiabloUiSurface());
-	DrawString(out, uiArtText->GetText(), rect, uiArtText->GetFlags(), uiArtText->GetSpacing(), uiArtText->GetLineHeight());
+	DrawString(out, uiArtText->GetText(), MakeRectangle(uiArtText->m_rect), uiArtText->GetFlags(), uiArtText->GetSpacing(), uiArtText->GetLineHeight());
 }
 
 void Render(const UiImage *uiImage)
@@ -865,10 +861,8 @@ void Render(const UiImageAnimatedPcx *uiImage)
 
 void Render(const UiArtTextButton *uiButton)
 {
-	Rectangle rect { { uiButton->m_rect.x, uiButton->m_rect.y }, { uiButton->m_rect.w, uiButton->m_rect.h } };
-
 	const Surface &out = Surface(DiabloUiSurface());
-	DrawString(out, uiButton->GetText(), rect, uiButton->GetFlags());
+	DrawString(out, uiButton->GetText(), MakeRectangle(uiButton->m_rect), uiButton->GetFlags());
 }
 
 void Render(const UiList *uiList)
@@ -881,7 +875,7 @@ void Render(const UiList *uiList)
 		if (i == SelectedItem)
 			DrawSelector(rect);
 
-		Rectangle rectangle { { rect.x, rect.y }, { rect.w, rect.h } };
+		Rectangle rectangle = MakeRectangle(rect);
 		if (item->args.empty())
 			DrawString(out, item->m_text, rectangle, uiList->GetFlags() | item->uiFlags, uiList->GetSpacing());
 		else

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -922,7 +922,8 @@ void Render(const UiEdit *uiEdit)
 {
 	DrawSelector(uiEdit->m_rect);
 
-	Rectangle rect { { uiEdit->m_rect.x + 43, uiEdit->m_rect.y + 1 }, { uiEdit->m_rect.w - 86, uiEdit->m_rect.h } };
+	// To simulate padding we inset the region used to draw text in an edit control
+	Rectangle rect = MakeRectangle(uiEdit->m_rect).inset({ 43, 1 });
 
 	const Surface &out = Surface(DiabloUiSurface());
 	DrawString(out, uiEdit->m_value, rect, uiEdit->GetFlags() | UiFlags::TextCursor);

--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -254,8 +254,8 @@ void UiSettingsMenu()
 
 		const Rectangle &uiRectangle = GetUIRectangle();
 
-		rectList = { { uiRectangle.position.x + 50, (uiRectangle.position.y + 204) }, { 540, 208 } };
-		rectDescription = { { uiRectangle.position.x + 24, rectList.position.y + rectList.size.height + 16 }, { 590, 35 } };
+		rectList = { uiRectangle.position + Displacement { 50, 204 }, Size { 540, 208 } };
+		rectDescription = { rectList.position + Displacement { -26, rectList.size.height + 16 }, Size { 590, 35 } };
 
 		optionDescription[0] = '\0';
 

--- a/Source/engine/rectangle.hpp
+++ b/Source/engine/rectangle.hpp
@@ -46,6 +46,19 @@ struct Rectangle {
 	{
 		return position + Displacement(size / 2);
 	}
+
+	/**
+	 * @brief Returns a rectangle with all sides shrunk according to the given displacement
+	 *
+	 * Effectively moves the left/right edges in by deltaX, and the top/bottom edges in by deltaY
+	 */
+	constexpr Rectangle inset(Displacement factor) const
+	{
+		return {
+			position + factor,
+			Size { size.width - factor.deltaX * 2, size.height - factor.deltaY * 2 }
+		};
+	}
 };
 
 } // namespace devilution

--- a/Source/utils/sdl_geometry.h
+++ b/Source/utils/sdl_geometry.h
@@ -31,4 +31,8 @@ inline SDL_Rect MakeSdlRect(Rectangle rect)
 	return MakeSdlRect(rect.position.x, rect.position.y, rect.size.width, rect.size.height);
 }
 
+constexpr Rectangle MakeRectangle(SDL_Rect sdlRect)
+{
+	return { Point { sdlRect.x, sdlRect.y }, Size { sdlRect.w, sdlRect.h } };
+}
 } // namespace devilution


### PR DESCRIPTION
Please note there are three behaviour differences included in this PR.

UiEdit text drawing regions now have their vertical dimension shrunk by 2 pixels. I don't think this matters in practice as when text overflows the clip region bounds it doesn't actually get clipped.

Similarly, spell book descriptions have a vertical dimension applied to their clip area now meaning they shouldn't overflow into the area for the next spell description. They still will because of clip regions not being true clip regions (unless the font size lines up reasonably well).

The last column of pixels of the last spell book tab buttons (for both Diablo and Hellfire) is now included in the hit area. The detection for buttons 3 and 4 in Diablo has been adjusted to match the alignment changes applied in DrawSpellBook. I'm not sure why there's a buffer page at the end of `SpellPages` since it shouldn't have been hit anyway but I've left removing that for a future PR.