### PR TITLE
Fix build with NONET and no exceptions

### DIFF
--- a/Source/dvlnet/packet.cpp
+++ b/Source/dvlnet/packet.cpp
@@ -107,7 +107,11 @@ void CheckPacketTypeOneOf(std::initializer_list<packet_type> expectedTypes, std:
 	for (std::uint8_t packetType : expectedTypes)
 		if (actualType == packetType)
 			return;
+#if DVL_EXCEPTIONS
 	throw wrong_packet_type_exception(expectedTypes, actualType);
+#else
+	app_fatal("wrong packet type");
+#endif
 }
 
 } // namespace
@@ -191,7 +195,11 @@ void packet_in::Create(buffer_t buf)
 {
 	assert(!have_encrypted && !have_decrypted);
 	if (buf.size() < sizeof(packet_type) + 2 * sizeof(plr_t))
+#if DVL_EXCEPTIONS
 		throw packet_exception();
+#else
+		app_fatal("invalid packet");
+#endif
 
 	decrypted_buffer = std::move(buf);
 	have_decrypted = true;

--- a/Source/dvlnet/packet.h
+++ b/Source/dvlnet/packet.h
@@ -10,7 +10,9 @@
 #include <sodium.h>
 #endif
 
+#include "appfat.h"
 #include "dvlnet/abstract_net.h"
+#include "utils/attributes.h"
 #include "utils/stubs.h"
 
 namespace devilution {
@@ -201,7 +203,11 @@ template <class T>
 void packet_in::process_element(T &x)
 {
 	if (decrypted_buffer.size() < sizeof(T))
+#if DVL_EXCEPTIONS
 		throw packet_exception();
+#else
+		app_fatal("invalid packet");
+#endif
 	std::memcpy(&x, decrypted_buffer.data(), sizeof(T));
 	decrypted_buffer.erase(decrypted_buffer.begin(),
 	    decrypted_buffer.begin() + sizeof(T));

--- a/Source/utils/attributes.h
+++ b/Source/utils/attributes.h
@@ -50,3 +50,9 @@
 #else
 #define DVL_REINITIALIZES
 #endif
+
+#if (defined(__GNUC__) && !defined(__EXCEPTIONS)) || FMT_MSC_VER && !_HAS_EXCEPTIONS
+#define DVL_EXCEPTIONS 0
+#else
+#define DVL_EXCEPTIONS 1
+#endif

--- a/Source/utils/log.hpp
+++ b/Source/utils/log.hpp
@@ -49,9 +49,13 @@ std::string format(string_view fmt, Args &&...args)
 	}
 	FMT_CATCH(const fmt::format_error &e)
 	{
+#if FMT_EXCEPTIONS
+		// e.what() is undefined if exceptions are disabled, so we wrap the whole block
+		// with an `FMT_EXCEPTIONS` check.
 		std::string error = fmt::format("Format error, fmt: {}, error: {}", fmt, e.what());
 		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "%s", error.c_str());
 		app_fatal(error);
+#endif
 	}
 }
 


### PR DESCRIPTION
Fixes the build with `-fno-rtti` and `-fno-exceptions`.

Building with these flags reduces the binary size by more than 200 KiB.