### PR TITLE
Define sizes using Size type in control.cpp/stash.cpp

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -591,7 +591,7 @@ void InitControlPan()
 	sbookflag = false;
 
 	InitSpellBook();
-	pQLogCel = LoadCel("Data\\Quest.CEL", SidePanelSize.width);
+	pQLogCel = LoadCel("Data\\Quest.CEL", static_cast<uint16_t>(SidePanelSize.width));
 	pGBoxBuff = LoadCel("CtrlPan\\Golddrop.cel", 261);
 	CloseGoldDrop();
 	dropGoldValue = 0;

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -108,12 +108,13 @@ bool IsRightPanelOpen()
 	return invflag || sbookflag;
 }
 
+constexpr Size IncrementAttributeButtonSize { 41, 22 };
 /** Maps from attribute_id to the rectangle on screen used for attribute increment buttons. */
 Rectangle ChrBtnsRect[4] = {
-	{ { 137, 138 }, { 41, 22 } },
-	{ { 137, 166 }, { 41, 22 } },
-	{ { 137, 195 }, { 41, 22 } },
-	{ { 137, 223 }, { 41, 22 } }
+	{ { 137, 138 }, IncrementAttributeButtonSize },
+	{ { 137, 166 }, IncrementAttributeButtonSize },
+	{ { 137, 195 }, IncrementAttributeButtonSize },
+	{ { 137, 223 }, IncrementAttributeButtonSize }
 };
 
 /** Positions of panel buttons. */
@@ -410,20 +411,19 @@ bool IsLevelUpButtonVisible()
 
 void CalculatePanelAreas()
 {
-	constexpr uint16_t PanelWidth = 640;
-	constexpr uint16_t PanelHeight = 128;
+	constexpr Size MainPanelSize { 640, 128 };
 
 	MainPanel = {
-		{ (gnScreenWidth - PanelWidth) / 2, gnScreenHeight - PanelHeight },
-		{ PanelWidth, PanelHeight }
+		{ (gnScreenWidth - MainPanelSize.width) / 2, gnScreenHeight - MainPanelSize.height },
+		MainPanelSize
 	};
 	LeftPanel = {
 		{ 0, 0 },
-		{ SPANEL_WIDTH, SPANEL_HEIGHT }
+		SidePanelSize
 	};
 	RightPanel = {
 		{ 0, 0 },
-		{ SPANEL_WIDTH, SPANEL_HEIGHT }
+		SidePanelSize
 	};
 
 	if (ControlMode == ControlTypes::VirtualGamepad) {
@@ -591,7 +591,7 @@ void InitControlPan()
 	sbookflag = false;
 
 	InitSpellBook();
-	pQLogCel = LoadCel("Data\\Quest.CEL", SPANEL_WIDTH);
+	pQLogCel = LoadCel("Data\\Quest.CEL", SidePanelSize.width);
 	pGBoxBuff = LoadCel("CtrlPan\\Golddrop.cel", 261);
 	CloseGoldDrop();
 	dropGoldValue = 0;

--- a/Source/control.h
+++ b/Source/control.h
@@ -24,8 +24,7 @@
 
 namespace devilution {
 
-#define SPANEL_WIDTH 320
-#define SPANEL_HEIGHT 352
+constexpr Size SidePanelSize { 320, 352 };
 
 extern bool drawhpflag;
 extern bool dropGoldFlag;
@@ -64,7 +63,7 @@ bool IsChatAvailable();
 inline bool CanPanelsCoverView()
 {
 	const Rectangle &mainPanel = GetMainPanel();
-	return GetScreenWidth() <= mainPanel.size.width && GetScreenHeight() <= SPANEL_HEIGHT + mainPanel.size.height;
+	return GetScreenWidth() <= mainPanel.size.width && GetScreenHeight() <= SidePanelSize.height + mainPanel.size.height;
 }
 void DrawSpellList(const Surface &out);
 void SetSpell();

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -689,7 +689,7 @@ Point FindFirstStashSlotOnItem(StashStruct::StashCell itemInvId)
 	if (itemInvId == StashStruct::EmptyCell)
 		return InvalidStashPoint;
 
-	for (auto point : PointsInRectangleRange({ { 0, 0 }, { 10, 10 } })) {
+	for (auto point : PointsInRectangleRange({ { 0, 0 }, Size { 10, 10 } })) {
 		if (Stash.GetItemIdAtPosition(point) == itemInvId)
 			return point;
 	}
@@ -758,7 +758,7 @@ Point FindClosestStashSlot(Point mousePos)
 	Point bestSlot = {};
 	mousePos += Displacement { -INV_SLOT_HALF_SIZE_PX, -INV_SLOT_HALF_SIZE_PX };
 
-	for (auto point : PointsInRectangleRange({ { 0, 0 }, { 10, 10 } })) {
+	for (auto point : PointsInRectangleRange({ { 0, 0 }, Size { 10, 10 } })) {
 		int distance = mousePos.ManhattanDistance(GetStashSlotCoord(point));
 		if (distance < shortestDistance) {
 			shortestDistance = distance;

--- a/Source/engine/points_in_rectangle_range.hpp
+++ b/Source/engine/points_in_rectangle_range.hpp
@@ -16,7 +16,7 @@ public:
 	using reference = value_type;
 
 protected:
-	PointsInRectangleIteratorBase(Point origin, int majorDimension, int majorIndex, int minorIndex)
+	constexpr PointsInRectangleIteratorBase(Point origin, int majorDimension, int majorIndex, int minorIndex)
 	    : origin(origin)
 	    , majorDimension(majorDimension)
 	    , majorIndex(majorIndex)
@@ -24,7 +24,7 @@ protected:
 	{
 	}
 
-	explicit PointsInRectangleIteratorBase(Point origin, int majorDimension, int index = 0)
+	explicit constexpr PointsInRectangleIteratorBase(Point origin, int majorDimension, int index = 0)
 	    : PointsInRectangleIteratorBase(origin, majorDimension, index / majorDimension, index % majorDimension)
 	{
 	}
@@ -71,7 +71,7 @@ public:
 	public:
 		PointsInRectangleIterator() = default;
 
-		PointsInRectangleIterator(Rectangle region, int index = 0)
+		constexpr PointsInRectangleIterator(Rectangle region, int index = 0)
 		    : PointsInRectangleIteratorBase(region.position, region.size.width, index)
 		{
 		}
@@ -182,7 +182,7 @@ public:
 		}
 	};
 
-	PointsInRectangleRange(Rectangle region)
+	constexpr PointsInRectangleRange(Rectangle region)
 	    : region(region)
 	{
 	}
@@ -239,7 +239,7 @@ public:
 	public:
 		PointsInRectangleIteratorColMajor() = default;
 
-		PointsInRectangleIteratorColMajor(Rectangle region, int index = 0)
+		constexpr PointsInRectangleIteratorColMajor(Rectangle region, int index = 0)
 		    : PointsInRectangleIteratorBase(region.position, region.size.height, index)
 		{
 		}
@@ -351,7 +351,7 @@ public:
 	};
 
 	// gcc6 needs a defined constructor?
-	PointsInRectangleRangeColMajor(Rectangle region)
+	constexpr PointsInRectangleRangeColMajor(Rectangle region)
 	    : region(region)
 	{
 	}

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1110,17 +1110,17 @@ void InitInv()
 	switch (MyPlayer->_pClass) {
 	case HeroClass::Warrior:
 	case HeroClass::Barbarian:
-		pInvCels = LoadCel("Data\\Inv\\Inv.CEL", SPANEL_WIDTH);
+		pInvCels = LoadCel("Data\\Inv\\Inv.CEL", static_cast<uint16_t>(SidePanelSize.width));
 		break;
 	case HeroClass::Rogue:
 	case HeroClass::Bard:
-		pInvCels = LoadCel("Data\\Inv\\Inv_rog.CEL", SPANEL_WIDTH);
+		pInvCels = LoadCel("Data\\Inv\\Inv_rog.CEL", static_cast<uint16_t>(SidePanelSize.width));
 		break;
 	case HeroClass::Sorcerer:
-		pInvCels = LoadCel("Data\\Inv\\Inv_Sor.CEL", SPANEL_WIDTH);
+		pInvCels = LoadCel("Data\\Inv\\Inv_Sor.CEL", static_cast<uint16_t>(SidePanelSize.width));
 		break;
 	case HeroClass::Monk:
-		pInvCels = LoadCel(!gbIsSpawn ? "Data\\Inv\\Inv_Sor.CEL" : "Data\\Inv\\Inv.CEL", SPANEL_WIDTH);
+		pInvCels = LoadCel(!gbIsSpawn ? "Data\\Inv\\Inv_Sor.CEL" : "Data\\Inv\\Inv.CEL", static_cast<uint16_t>(SidePanelSize.width));
 		break;
 	}
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1775,8 +1775,8 @@ void PrintItemOil(char iDidx)
 
 void DrawUniqueInfoWindow(const Surface &out)
 {
-	CelDrawTo(out, GetPanelPosition(UiPanels::Inventory, { 24 - SPANEL_WIDTH, 327 }), *pSTextBoxCels, 0);
-	DrawHalfTransparentRectTo(out, GetRightPanel().position.x - SPANEL_WIDTH + 27, GetRightPanel().position.y + 28, 265, 297);
+	CelDrawTo(out, GetPanelPosition(UiPanels::Inventory, { 24 - SidePanelSize.width, 327 }), *pSTextBoxCels, 0);
+	DrawHalfTransparentRectTo(out, GetRightPanel().position.x - SidePanelSize.width + 27, GetRightPanel().position.y + 28, 265, 297);
 }
 
 void PrintItemMisc(const Item &item)
@@ -3739,7 +3739,7 @@ bool DoOil(Player &player, int cii)
 
 void DrawUniqueInfo(const Surface &out)
 {
-	const Point position = GetRightPanel().position - Displacement { SPANEL_WIDTH, 0 };
+	const Point position = GetRightPanel().position - Displacement { SidePanelSize.width, 0 };
 	if (IsLeftPanelOpen() && GetLeftPanel().Contains(position)) {
 		return;
 	}

--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -82,7 +82,7 @@ spell_type GetSBookTrans(spell_id ii, bool townok)
 
 void InitSpellBook()
 {
-	pSpellBkCel = LoadCel("Data\\SpellBk.CEL", SPANEL_WIDTH);
+	pSpellBkCel = LoadCel("Data\\SpellBk.CEL", static_cast<uint16_t>(SidePanelSize.width));
 
 	if (gbIsHellfire) {
 		static const uint16_t SBkBtnHellfireWidths[] = { 61, 61, 61, 61, 61, 76 };

--- a/Source/qol/monhealthbar.cpp
+++ b/Source/qol/monhealthbar.cpp
@@ -79,9 +79,9 @@ void DrawMonsterHealthBar(const Surface &out)
 
 	if (CanPanelsCoverView()) {
 		if (IsRightPanelOpen())
-			position.x -= SPANEL_WIDTH / 2;
+			position.x -= SidePanelSize.width / 2;
 		if (IsLeftPanelOpen())
-			position.x += SPANEL_WIDTH / 2;
+			position.x += SidePanelSize.width / 2;
 	}
 
 	const int border = 3;

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -34,16 +34,19 @@ constexpr unsigned LastStashPage = CountStashPages - 1;
 
 int InitialWithdrawGoldValue;
 
+constexpr Size ButtonSize { 27, 16 };
 /** Contains mappings for the buttons in the stash (2 navigation buttons, withdraw gold buttons, 2 navigation buttons) */
 constexpr Rectangle StashButtonRect[] = {
 	// clang-format off
-	{ {  19, 19 }, { 27, 16 } }, // 10 left
-	{ {  56, 19 }, { 27, 16 } }, // 1 left
-	{ {  93, 19 }, { 27, 16 } }, // withdraw gold
-	{ { 242, 19 }, { 27, 16 } }, // 1 right
-	{ { 279, 19 }, { 27, 16 } }  // 10 right
+	{ {  19, 19 }, ButtonSize }, // 10 left
+	{ {  56, 19 }, ButtonSize }, // 1 left
+	{ {  93, 19 }, ButtonSize }, // withdraw gold
+	{ { 242, 19 }, ButtonSize }, // 1 right
+	{ { 279, 19 }, ButtonSize }  // 10 right
 	// clang-format on
 };
+
+constexpr PointsInRectangleRange StashGridRange { { { 0, 0 }, Size { 10, 10 } } };
 
 Art StashPanelArt;
 Art StashNavButtonArt;
@@ -61,7 +64,7 @@ void AddItemToStashGrid(unsigned page, Point position, uint16_t stashListIndex, 
 
 Point FindSlotUnderCursor(Point cursorPosition)
 {
-	for (auto point : PointsInRectangleRange({ { 0, 0 }, { 10, 10 } })) {
+	for (auto point : StashGridRange) {
 		Rectangle cell {
 			GetStashSlotCoord(point),
 			InventorySlotSizeInPixels + 1
@@ -164,10 +167,10 @@ void CheckStashCut(Point cursorPosition, bool automaticMove)
 
 	Point slot = InvalidStashPoint;
 
-	for (auto point : PointsInRectangleRange({ { 0, 0 }, { 10, 10 } })) {
+	for (auto point : StashGridRange) {
 		Rectangle cell {
 			GetStashSlotCoord(point),
-			{ InventorySlotSizeInPixels.width + 1, InventorySlotSizeInPixels.height + 1 }
+			InventorySlotSizeInPixels + 1
 		};
 
 		// check which inventory rectangle the mouse is in, if any
@@ -343,13 +346,13 @@ void DrawStash(const Surface &out)
 
 	constexpr Displacement offset { 0, INV_SLOT_SIZE_PX - 1 };
 
-	for (auto slot : PointsInRectangleRange({ { 0, 0 }, { 10, 10 } })) {
+	for (auto slot : StashGridRange) {
 		if (Stash.IsItemAtPosition(slot)) {
 			InvDrawSlotBack(out, GetStashSlotCoord(slot) + offset, InventorySlotSizeInPixels);
 		}
 	}
 
-	for (auto slot : PointsInRectangleRange({ { 0, 0 }, { 10, 10 } })) {
+	for (auto slot : StashGridRange) {
 		StashStruct::StashCell itemId = Stash.GetItemIdAtPosition(slot);
 		if (itemId == StashStruct::EmptyCell) {
 			continue; // No item in the given slot
@@ -395,10 +398,10 @@ void CheckStashItem(Point mousePosition, bool isShiftHeld, bool isCtrlHeld)
 uint16_t CheckStashHLight(Point mousePosition)
 {
 	Point slot = InvalidStashPoint;
-	for (auto point : PointsInRectangleRange({ { 0, 0 }, { 10, 10 } })) {
+	for (auto point : StashGridRange) {
 		Rectangle cell {
 			GetStashSlotCoord(point),
-			{ InventorySlotSizeInPixels.width + 1, InventorySlotSizeInPixels.height + 1 }
+			InventorySlotSizeInPixels + 1
 		};
 
 		if (cell.Contains({ mousePosition })) {
@@ -675,7 +678,7 @@ bool AutoPlaceItemInStash(Player &player, const Item &item, bool persistItem)
 		if (pageIndex >= CountStashPages)
 			pageIndex -= CountStashPages;
 		// Search all possible position in stash grid
-		for (auto stashPosition : PointsInRectangleRange({ { 0, 0 }, { 10 - (itemSize.width - 1), 10 - (itemSize.height - 1) } })) {
+		for (auto stashPosition : PointsInRectangleRange({ { 0, 0 }, Size { 10 - (itemSize.width - 1), 10 - (itemSize.height - 1) } })) {
 			// Check that all needed slots are free
 			bool isSpaceFree = true;
 			for (auto itemPoint : PointsInRectangleRange({ stashPosition, itemSize })) {

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1027,10 +1027,10 @@ void Zoom(const Surface &out)
 	int viewportOffsetX = 0;
 	if (CanPanelsCoverView()) {
 		if (IsLeftPanelOpen()) {
-			viewportWidth -= SPANEL_WIDTH;
-			viewportOffsetX = SPANEL_WIDTH;
+			viewportWidth -= SidePanelSize.width;
+			viewportOffsetX = SidePanelSize.width;
 		} else if (IsRightPanelOpen()) {
-			viewportWidth -= SPANEL_WIDTH;
+			viewportWidth -= SidePanelSize.width;
 		}
 	}
 
@@ -1109,7 +1109,7 @@ void DrawGame(const Surface &fullOut, Point position)
 			if (IsLeftPanelOpen()) {
 				position += Displacement(Direction::East) * 2;
 				columns -= 4;
-				sx += SPANEL_WIDTH - TILE_WIDTH / 2;
+				sx += SidePanelSize.width - TILE_WIDTH / 2;
 			}
 			if (IsRightPanelOpen()) {
 				position += Displacement(Direction::East) * 2;

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2251,8 +2251,8 @@ void DrawSLine(const Surface &out, int sy)
 	int width = 587;
 
 	if (!stextsize) {
-		sx += SPANEL_WIDTH;
-		width -= SPANEL_WIDTH;
+		sx += SidePanelSize.width;
+		width -= SidePanelSize.width;
 	}
 
 	BYTE *src = out.at(uiPosition.x + sx, uiPosition.y + 25);

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -140,11 +140,10 @@ void FreeRenderer()
 
 void CalculateUIRectangle()
 {
-	constexpr int UIWidth = 640;
-	constexpr int UIHeight = 480;
+	constexpr Size UISize { 640, 480 };
 	UIRectangle = {
-		{ (gnScreenWidth - UIWidth) / 2, (gnScreenHeight - UIHeight) / 2 },
-		{ UIWidth, UIHeight }
+		{ (gnScreenWidth - UISize.width) / 2, (gnScreenHeight - UISize.height) / 2 },
+		UISize
 	};
 }
 


### PR DESCRIPTION
Also extracted repeated redefinitions of the PointInRectangleRangeIterator to a common constexpr variable in stash.cpp. There are two uses in plrctrls.cpp that I didn't think were worth adding cruft to the stash.h header to support, maybe those functions can move into stash.cpp in the future?