### PR TITLE
Index Minis by tile instead of by coordinate

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1109,48 +1109,40 @@ void LoadLvlGFX()
 		if (gbIsHellfire) {
 			pDungeonCels = LoadFileInMem("NLevels\\TownData\\Town.CEL");
 			pMegaTiles = LoadFileInMem<MegaTile>("NLevels\\TownData\\Town.TIL");
-			pLevelPieces = LoadFileInMem<uint16_t>("NLevels\\TownData\\Town.MIN");
 		} else {
 			pDungeonCels = LoadFileInMem("Levels\\TownData\\Town.CEL");
 			pMegaTiles = LoadFileInMem<MegaTile>("Levels\\TownData\\Town.TIL");
-			pLevelPieces = LoadFileInMem<uint16_t>("Levels\\TownData\\Town.MIN");
 		}
 		pSpecialCels = LoadCel("Levels\\TownData\\TownS.CEL", SpecialCelWidth);
 		break;
 	case DTYPE_CATHEDRAL:
 		pDungeonCels = LoadFileInMem("Levels\\L1Data\\L1.CEL");
 		pMegaTiles = LoadFileInMem<MegaTile>("Levels\\L1Data\\L1.TIL");
-		pLevelPieces = LoadFileInMem<uint16_t>("Levels\\L1Data\\L1.MIN");
 		pSpecialCels = LoadCel("Levels\\L1Data\\L1S.CEL", SpecialCelWidth);
 		break;
 	case DTYPE_CATACOMBS:
 		pDungeonCels = LoadFileInMem("Levels\\L2Data\\L2.CEL");
 		pMegaTiles = LoadFileInMem<MegaTile>("Levels\\L2Data\\L2.TIL");
-		pLevelPieces = LoadFileInMem<uint16_t>("Levels\\L2Data\\L2.MIN");
 		pSpecialCels = LoadCel("Levels\\L2Data\\L2S.CEL", SpecialCelWidth);
 		break;
 	case DTYPE_CAVES:
 		pDungeonCels = LoadFileInMem("Levels\\L3Data\\L3.CEL");
 		pMegaTiles = LoadFileInMem<MegaTile>("Levels\\L3Data\\L3.TIL");
-		pLevelPieces = LoadFileInMem<uint16_t>("Levels\\L3Data\\L3.MIN");
 		pSpecialCels = LoadCel("Levels\\L1Data\\L1S.CEL", SpecialCelWidth);
 		break;
 	case DTYPE_HELL:
 		pDungeonCels = LoadFileInMem("Levels\\L4Data\\L4.CEL");
 		pMegaTiles = LoadFileInMem<MegaTile>("Levels\\L4Data\\L4.TIL");
-		pLevelPieces = LoadFileInMem<uint16_t>("Levels\\L4Data\\L4.MIN");
 		pSpecialCels = LoadCel("Levels\\L2Data\\L2S.CEL", SpecialCelWidth);
 		break;
 	case DTYPE_NEST:
 		pDungeonCels = LoadFileInMem("NLevels\\L6Data\\L6.CEL");
 		pMegaTiles = LoadFileInMem<MegaTile>("NLevels\\L6Data\\L6.TIL");
-		pLevelPieces = LoadFileInMem<uint16_t>("NLevels\\L6Data\\L6.MIN");
 		pSpecialCels = LoadCel("Levels\\L1Data\\L1S.CEL", SpecialCelWidth);
 		break;
 	case DTYPE_CRYPT:
 		pDungeonCels = LoadFileInMem("NLevels\\L5Data\\L5.CEL");
 		pMegaTiles = LoadFileInMem<MegaTile>("NLevels\\L5Data\\L5.TIL");
-		pLevelPieces = LoadFileInMem<uint16_t>("NLevels\\L5Data\\L5.MIN");
 		pSpecialCels = LoadCel("NLevels\\L5Data\\L5S.CEL", SpecialCelWidth);
 		break;
 	default:
@@ -1711,7 +1703,6 @@ void FreeGameMem()
 {
 	pDungeonCels = nullptr;
 	pMegaTiles = nullptr;
-	pLevelPieces = nullptr;
 	pSpecialCels = std::nullopt;
 
 	FreeMonsters();
@@ -2093,6 +2084,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 	SetRndSeed(glSeedTbl[currlevel]);
 	IncProgress();
 	MakeLightTable();
+	SetDungeonMicros();
 	LoadLvlGFX();
 	IncProgress();
 
@@ -2301,8 +2293,6 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 			}
 		}
 	}
-
-	SetDungeonMicros();
 
 	IncProgress();
 	IncProgress();

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -42,7 +42,7 @@ ScrollStruct ScrollInfo;
 int MicroTileLen;
 char TransVal;
 bool TransList[256];
-int dPiece[MAXDUNX][MAXDUNY];
+uint16_t dPiece[MAXDUNX][MAXDUNY];
 MICROS DPieceMicros[MAXTILES + 1];
 int8_t dTransVal[MAXDUNX][MAXDUNY];
 char dLight[MAXDUNX][MAXDUNY];

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -176,7 +176,7 @@ extern char TransVal;
 /** Specifies the active transparency indices. */
 extern bool TransList[256];
 /** Contains the piece IDs of each tile on the map. */
-extern DVL_API_FOR_TEST int dPiece[MAXDUNX][MAXDUNY];
+extern DVL_API_FOR_TEST uint16_t dPiece[MAXDUNX][MAXDUNY];
 /** Map of micros that comprises a full tile for any given dungeon piece. */
 extern MICROS DPieceMicros[MAXTILES + 1];
 /** Specifies the transparency at each coordinate of the map. */

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -150,7 +150,6 @@ extern std::unique_ptr<uint16_t[]> pSetPiece;
 extern std::optional<OwnedCelSprite> pSpecialCels;
 /** Specifies the tile definitions of the active dungeon type; (e.g. levels/l1data/l1.til). */
 extern DVL_API_FOR_TEST std::unique_ptr<MegaTile[]> pMegaTiles;
-extern std::unique_ptr<uint16_t[]> pLevelPieces;
 extern std::unique_ptr<byte[]> pDungeonCels;
 /**
  * List tile properties
@@ -178,8 +177,8 @@ extern char TransVal;
 extern bool TransList[256];
 /** Contains the piece IDs of each tile on the map. */
 extern DVL_API_FOR_TEST int dPiece[MAXDUNX][MAXDUNY];
-/** Specifies the dungeon piece information for a given coordinate and block number. */
-extern MICROS dpiece_defs_map_2[MAXDUNX][MAXDUNY];
+/** Map of micros that comprises a full tile for any given dungeon piece. */
+extern MICROS DPieceMicros[MAXTILES + 1];
 /** Specifies the transparency at each coordinate of the map. */
 extern DVL_API_FOR_TEST int8_t dTransVal[MAXDUNX][MAXDUNY];
 extern char dLight[MAXDUNX][MAXDUNY];

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1020,16 +1020,6 @@ void AddChest(int i, int t)
 void ObjSetMicro(Point position, int pn)
 {
 	dPiece[position.x][position.y] = pn;
-	pn--;
-
-	int blocks = leveltype != DTYPE_HELL ? 10 : 16;
-
-	uint16_t *piece = &pLevelPieces[blocks * pn];
-	MICROS &micros = dpiece_defs_map_2[position.x][position.y];
-
-	for (int i = 0; i < blocks; i++) {
-		micros.mt[i] = SDL_SwapLE16(piece[blocks - 2 + (i & 1) - (i & 0xE)]);
-	}
 }
 
 void InitializeL1Door(Object &door)
@@ -1614,16 +1604,6 @@ void ObjL2Special(int x1, int y1, int x2, int y2)
 	}
 }
 
-void SetDoorPiece(Point position)
-{
-	int pn = dPiece[position.x][position.y] - 1;
-
-	uint16_t *piece = &pLevelPieces[10 * pn + 8];
-
-	dpiece_defs_map_2[position.x][position.y].mt[0] = SDL_SwapLE16(piece[0]);
-	dpiece_defs_map_2[position.x][position.y].mt[1] = SDL_SwapLE16(piece[1]);
-}
-
 void DoorSet(Point position, bool isLeftDoor)
 {
 	int pn = dPiece[position.x][position.y];
@@ -1753,7 +1733,6 @@ void OperateL1RDoor(int pnum, int oi, bool sendflag)
 			PlaySfxLoc(IS_DOOROPEN, door.position);
 		ObjSetMicro(door.position, 395);
 		dSpecial[door.position.x][door.position.y] = 8;
-		SetDoorPiece(door.position + Direction::NorthEast);
 		door._oAnimFrame += 2;
 		door._oPreFlag = true;
 		DoorSet(door.position + Direction::NorthWest, false);
@@ -1808,7 +1787,6 @@ void OperateL1LDoor(int pnum, int oi, bool sendflag)
 		else
 			ObjSetMicro(door.position, 393);
 		dSpecial[door.position.x][door.position.y] = 7;
-		SetDoorPiece(door.position + Direction::NorthWest);
 		door._oAnimFrame += 2;
 		door._oPreFlag = true;
 		DoorSet(door.position + Direction::NorthEast, true);
@@ -2028,7 +2006,6 @@ void OperateL5RDoor(int pnum, int oi, bool sendflag)
 			PlaySfxLoc(IS_CROPEN, door.position);
 		ObjSetMicro(door.position, 209);
 		dSpecial[door.position.x][door.position.y] = 2;
-		SetDoorPiece(door.position + Direction::NorthEast);
 		door._oAnimFrame += 2;
 		door._oPreFlag = true;
 		CryptDoorSet(door.position + Direction::NorthWest, false);
@@ -2080,7 +2057,6 @@ void OperateL5LDoor(int pnum, int oi, bool sendflag)
 			PlaySfxLoc(IS_CROPEN, door.position);
 		ObjSetMicro(door.position, 206);
 		dSpecial[door.position.x][door.position.y] = 1;
-		SetDoorPiece(door.position + Direction::NorthWest);
 		door._oAnimFrame += 2;
 		door._oPreFlag = true;
 		CryptDoorSet(door.position + Direction::NorthEast, true);
@@ -4181,12 +4157,10 @@ void SyncL1Doors(Object &door)
 	if (isLeftDoor) {
 		ObjSetMicro(door.position, door._oVar1 == 214 ? 408 : 393);
 		dSpecial[door.position.x][door.position.y] = 7;
-		SetDoorPiece(door.position + Direction::NorthWest);
 		DoorSet(door.position + Direction::NorthEast, isLeftDoor);
 	} else {
 		ObjSetMicro(door.position, 395);
 		dSpecial[door.position.x][door.position.y] = 8;
-		SetDoorPiece(door.position + Direction::NorthEast);
 		DoorSet(door.position + Direction::NorthWest, isLeftDoor);
 	}
 }
@@ -4244,12 +4218,10 @@ void SyncL5Doors(Object &door)
 	if (isLeftDoor) {
 		ObjSetMicro(door.position, 206);
 		dSpecial[door.position.x][door.position.y] = 1;
-		SetDoorPiece(door.position + Direction::NorthWest);
 		CryptDoorSet(door.position + Direction::NorthEast, isLeftDoor);
 	} else {
 		ObjSetMicro(door.position, 209);
 		dSpecial[door.position.x][door.position.y] = 2;
-		SetDoorPiece(door.position + Direction::NorthEast);
 		CryptDoorSet(door.position + Direction::NorthWest, isLeftDoor);
 	}
 }
@@ -5566,8 +5538,6 @@ void SyncNakrulRoom()
 	dPiece[UberRow][UberCol - 1] = 301;
 	dPiece[UberRow][UberCol - 2] = 300;
 	dPiece[UberRow][UberCol + 1] = 299;
-
-	SetDungeonMicros();
 }
 
 void AddNakrulLeaver()

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -654,8 +654,8 @@ static void DrawDungeon(const Surface & /*out*/, Point /*tilePosition*/, Point /
  */
 void DrawCell(const Surface &out, Point tilePosition, Point targetBufferPosition)
 {
-	MICROS *pMap = &dpiece_defs_map_2[tilePosition.x][tilePosition.y];
 	level_piece_id = dPiece[tilePosition.x][tilePosition.y];
+	MICROS *pMap = &DPieceMicros[level_piece_id];
 	cel_transparency_active = TileHasAny(level_piece_id, TileProperties::Transparent) && TransList[dTransVal[tilePosition.x][tilePosition.y]];
 	cel_foliage_active = !TileHasAny(level_piece_id, TileProperties::Solid);
 	for (int i = 0; i < (MicroTileLen / 2); i++) {
@@ -686,12 +686,13 @@ void DrawFloor(const Surface &out, Point tilePosition, Point targetBufferPositio
 	LightTableIndex = dLight[tilePosition.x][tilePosition.y];
 
 	arch_draw_type = 1; // Left
-	level_cel_block = dpiece_defs_map_2[tilePosition.x][tilePosition.y].mt[0];
+	int pn = dPiece[tilePosition.x][tilePosition.y];
+	level_cel_block = DPieceMicros[pn].mt[0];
 	if (level_cel_block != 0) {
 		RenderTile(out, targetBufferPosition);
 	}
 	arch_draw_type = 2; // Right
-	level_cel_block = dpiece_defs_map_2[tilePosition.x][tilePosition.y].mt[1];
+	level_cel_block = DPieceMicros[pn].mt[1];
 	if (level_cel_block != 0) {
 		RenderTile(out, targetBufferPosition + Displacement { TILE_WIDTH / 2, 0 });
 	}

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -345,6 +345,7 @@ void CreateTown(lvl_entry entry)
 	}
 
 	DrlgTPass3();
+	pMegaTiles = nullptr;
 }
 
 } // namespace devilution

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -127,7 +127,6 @@ void TownCloseHive()
 	dPiece[86][61] = 0x18;
 	dPiece[85][62] = 0x13;
 	dPiece[84][64] = 0x118;
-	SetDungeonMicros();
 }
 
 /**
@@ -145,7 +144,6 @@ void TownCloseGrave()
 	dPiece[37][24] = 0x532;
 	dPiece[35][21] = 0x53b;
 	dPiece[34][21] = 0x53c;
-	SetDungeonMicros();
 }
 
 void InitTownPieces()
@@ -303,7 +301,6 @@ void TownOpenHive()
 	dPiece[86][61] = 0x18;
 	dPiece[85][62] = 0x13;
 	dPiece[84][64] = 0x118;
-	SetDungeonMicros();
 }
 
 void TownOpenGrave()
@@ -318,7 +315,6 @@ void TownOpenGrave()
 	dPiece[37][24] = 0x53a;
 	dPiece[35][21] = 0x53b;
 	dPiece[34][21] = 0x53c;
-	SetDungeonMicros();
 }
 
 void CreateTown(lvl_entry entry)


### PR DESCRIPTION
So turned out that not only does reducing indexing MICROS by dPiece reduce the table size from 392KiB to 43KiB, it also means that the .min data is only needed at load time, saving an additional 9-44KiB (depending on the level). And as a bonus it remove the need to recompute the table as the level changes.

I also moved the call to `SetDungeonMicros()` before the call to `LoadLvlGFX()` to reduce peak memory usage.

DPieceMicros could be removed from runtime if SetDungeonMicros() instead computed a new CEL where the tiles are not split in to smaller chunks (see `DrawCell()`).

Doing so should also mean that we can drop much of the specialized render code and probably result in better CEL compression and render performance. But I feel this might be a bit more then I am able to do.

... also changed `dPiece` from int to `uint16_t` to gain 25KiB.

And unloaded `pMegaTiles` (3KiB) after loading town since it is not needed there. At run time it is only needed for dungeons that can change shape via `pdungeon`:
- SklKng2.DUN
- Bonecha1.DUN
- Vile2.DUN
- Level 4 + Banner
- Level 5 + Blood
- Level 6 + Bone
- Level 7 + Blind
- Level 16

I felt that unloading it for town made sens since town generally has a higher memory load then other levels. But it could also be unloaded for all Caves safely and from other levels by excluding the above list.

These levels are also the only ones where `pdungeon` (less then 1.6KiB) is needed, but this is currently static data.