### PR TITLE
Reduce reliance on `bool done` for control flow, part 2 of x

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -579,8 +579,6 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 		dropGoldValue = 0;
 	}
 
-	bool done = false;
-
 	uint32_t r = 0;
 	for (; r < NUM_XY_SLOTS; r++) {
 		int xo = GetRightPanel().position.x;
@@ -595,12 +593,11 @@ void CheckInvCut(int pnum, Point cursorPosition, bool automaticMove, bool dropIt
 		    && cursorPosition.x < InvRect[r].x + xo + (InventorySlotSizeInPixels.width + 1)
 		    && cursorPosition.y >= InvRect[r].y + yo - (InventorySlotSizeInPixels.height + 1)
 		    && cursorPosition.y < InvRect[r].y + yo) {
-			done = true;
 			break;
 		}
 	}
 
-	if (!done) {
+	if (r == NUM_XY_SLOTS) {
 		// not on an inventory slot rectangle
 		return;
 	}

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -482,15 +482,18 @@ void PlaceUniqueMonst(int uniqindex, int miniontype, int bosspacksize)
 	PrepareUniqueMonst(monster, uniqindex, miniontype, bosspacksize, uniqueMonsterData);
 }
 
+int GetMonsterTypeIndex(_monster_id type)
+{
+	for (int i = 0; i < LevelMonsterTypeCount; i++) {
+		if (LevelMonsterTypes[i].mtype == type)
+			return i;
+	}
+	return LevelMonsterTypeCount;
+}
+
 int AddMonsterType(_monster_id type, placeflag placeflag)
 {
-	int typeIndex = [&]() {
-		for (int i = 0; i < LevelMonsterTypeCount; i++) {
-			if (LevelMonsterTypes[i].mtype == type)
-				return i;
-		}
-		return LevelMonsterTypeCount;
-	}();
+	int typeIndex = GetMonsterTypeIndex(type);
 
 	if (typeIndex == LevelMonsterTypeCount) {
 		LevelMonsterTypeCount++;
@@ -541,13 +544,7 @@ void PlaceUniqueMonsters()
 		if (UniqueMonstersData[u].mlevel != currlevel)
 			continue;
 
-		int mt = [&]() {
-			for (int i = 0; i < LevelMonsterTypeCount; i++) {
-				if (LevelMonsterTypes[mt].mtype == UniqueMonstersData[u].mtype)
-					return i;
-			}
-			return LevelMonsterTypeCount;
-		}();
+		int mt = GetMonsterTypeIndex(UniqueMonstersData[u].mtype);
 		if (mt == LevelMonsterTypeCount)
 			continue;
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -541,12 +541,14 @@ void PlaceUniqueMonsters()
 		if (UniqueMonstersData[u].mlevel != currlevel)
 			continue;
 
-		int mt;
-		for (mt = 0; mt < LevelMonsterTypeCount; mt++) {
-			if (LevelMonsterTypes[mt].mtype == UniqueMonstersData[u].mtype)
-				break;
-		}
-		if (mt >= LevelMonsterTypeCount)
+		int mt = [&]() {
+			for (int i = 0; i < LevelMonsterTypeCount; i++) {
+				if (LevelMonsterTypes[mt].mtype == UniqueMonstersData[u].mtype)
+					return i;
+			}
+			return LevelMonsterTypeCount;
+		}();
+		if (mt == LevelMonsterTypeCount)
 			continue;
 
 		if (u == UMT_GARBUD && Quests[Q_GARBUD]._qactive == QUEST_NOTAVAIL)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -484,26 +484,24 @@ void PlaceUniqueMonst(int uniqindex, int miniontype, int bosspacksize)
 
 int AddMonsterType(_monster_id type, placeflag placeflag)
 {
-	bool done = false;
-	int i;
+	int typeIndex = [&]() {
+		for (int i = 0; i < LevelMonsterTypeCount; i++) {
+			if (LevelMonsterTypes[i].mtype == type)
+				return i;
+		}
+		return LevelMonsterTypeCount;
+	}();
 
-	for (i = 0; i < LevelMonsterTypeCount && !done; i++) {
-		done = LevelMonsterTypes[i].mtype == type;
-	}
-
-	i--;
-
-	if (!done) {
-		i = LevelMonsterTypeCount;
+	if (typeIndex == LevelMonsterTypeCount) {
 		LevelMonsterTypeCount++;
-		LevelMonsterTypes[i].mtype = type;
+		LevelMonsterTypes[typeIndex].mtype = type;
 		monstimgtot += MonstersData[type].mImage;
-		InitMonsterGFX(i);
-		InitMonsterSND(i);
+		InitMonsterGFX(typeIndex);
+		InitMonsterSND(typeIndex);
 	}
 
-	LevelMonsterTypes[i].mPlaceFlags |= placeflag;
-	return i;
+	LevelMonsterTypes[typeIndex].mPlaceFlags |= placeflag;
+	return typeIndex;
 }
 
 void ClearMVars(Monster &monster)


### PR DESCRIPTION
This also fixes a bug introduced in part 1, where `PlaceUniqueMonsters` uses a monster type that is off by 1.