### PR TITLE
Player's Character Statistics

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -102,6 +102,7 @@ set(libdevilutionx_SRCS
   qol/chatlog.cpp
   qol/monhealthbar.cpp
   qol/stash.cpp
+  qol/statistics.cpp
   qol/xpbar.cpp
   qol/itemlabels.cpp
   utils/console.cpp

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -149,7 +149,7 @@ char TalkMessage[MAX_SEND_STR_LEN];
 bool TalkButtonsDown[3];
 int sgbPlrTalkTbl;
 bool WhisperList[MAX_PLRS];
-char panelstr[4][64];
+char panelstr[5][64];
 
 enum panel_button_id {
 	PanelButtonCharinfo,
@@ -260,8 +260,8 @@ void PrintInfo(const Surface &out)
 	if (talkflag)
 		return;
 
-	const int LineStart[] = { 70, 58, 52, 48, 46 };
-	const int LineHeights[] = { 30, 24, 18, 15, 12 };
+	const int LineStart[] = { 70, 58, 52, 48, 46, 46 };
+	const int LineHeights[] = { 30, 24, 18, 15, 12, 12 };
 
 	Rectangle line { GetMainPanel().position + Displacement { 177, LineStart[pnumlines] }, { 288, 12 } };
 
@@ -462,7 +462,7 @@ void AddPanelString(string_view str)
 {
 	CopyUtf8(panelstr[pnumlines], str, sizeof(*panelstr));
 
-	if (pnumlines < 4)
+	if (pnumlines < 5)
 		pnumlines++;
 }
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -61,6 +61,7 @@
 #include "qol/itemlabels.h"
 #include "qol/monhealthbar.h"
 #include "qol/stash.h"
+#include "qol/statistics.h"
 #include "qol/xpbar.h"
 #include "restrict.h"
 #include "setmaps.h"
@@ -1913,11 +1914,13 @@ void diablo_pause_game()
 	if (!gbIsMultiplayer) {
 		if (PauseMode != 0) {
 			PauseMode = 0;
+			MyPlayerStatistics.ticksSubtrahend = SDL_GetTicks();
 		} else {
 			PauseMode = 2;
 			sound_stop();
 			qtextflag = false;
 			LastMouseButtonAction = MouseActionType::None;
+			CalculateInGameTime();
 		}
 
 		force_redraw = 255;
@@ -1949,6 +1952,7 @@ void diablo_focus_pause()
 		PauseMode = 2;
 		sound_stop();
 		LastMouseButtonAction = MouseActionType::None;
+		CalculateInGameTime();
 	}
 
 	SVidMute();
@@ -1961,6 +1965,7 @@ void diablo_focus_unpause()
 {
 	if (!GameWasAlreadyPaused) {
 		PauseMode = 0;
+		MyPlayerStatistics.ticksSubtrahend = SDL_GetTicks();
 	}
 
 	SVidUnmute();

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -150,6 +150,11 @@ public:
 	{
 		return Next<uint32_t>() != 0;
 	}
+
+	size_t getSize() const
+	{
+		return m_size_;
+	}
 };
 
 class SaveHelper {
@@ -1918,6 +1923,21 @@ void SaveHotkeys(MpqWriter &saveWriter)
 	// Write the selected spell last
 	file.WriteLE<int32_t>(myPlayer._pRSpell);
 	file.WriteLE<uint8_t>(myPlayer._pRSplType);
+}
+
+void LoadStatistics()
+{
+	LoadHelper file(OpenSaveArchive(gSaveNumber), "statistics");
+	if (!file.IsValid())
+		return;
+
+	MyPlayer->deathCount = file.NextLE<uint32_t>();
+}
+
+void SaveStatistics(MpqWriter &saveWriter)
+{
+	SaveHelper file(saveWriter, "statistics", sizeof(uint32_t));
+	file.WriteLE<uint32_t>(MyPlayer->deathCount);
 }
 
 void LoadHeroItems(Player &player)

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1929,7 +1929,7 @@ void SaveHotkeys(MpqWriter &saveWriter)
 
 void LoadStatistics()
 {
-	InitializePlayerStatistics(*MyPlayer);
+	InitializePlayerStatistics();
 	LoadHelper file(OpenSaveArchive(gSaveNumber), "statistics");
 	if (!file.IsValid())
 		return;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1941,7 +1941,7 @@ void LoadStatistics()
 	}
 
 	{
-		statisticsFile.clear();
+		StatisticsFile.clear();
 		std::stringstream ss(readString);
 		std::string line;
 		std::string del = "=";
@@ -1951,7 +1951,7 @@ void LoadStatistics()
 				continue;
 			std::string key = line.substr(0, delPos);
 			std::string value = line.substr(delPos + del.size());
-			statisticsFile[key] = value;
+			StatisticsFile[key] = value;
 		}
 	}
 
@@ -1963,7 +1963,7 @@ void SaveStatistics(MpqWriter &saveWriter)
 	CalculateInGameTime();
 	SaveStatisticsToMap();
 	std::string stringToSave;
-	for (const auto &s : statisticsFile) {
+	for (const auto &s : StatisticsFile) {
 		stringToSave += s.first + "=" + s.second + "\n";
 	}
 

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1936,7 +1936,7 @@ void LoadStatistics()
 
 	std::string readString;
 	size_t sizeFile = file.getSize();
-	for (int i = 0; i < sizeFile; i++) {
+	for (size_t i = 0; i < sizeFile; i++) {
 		readString += file.NextLE<char>();
 	}
 
@@ -1972,7 +1972,7 @@ void SaveStatistics(MpqWriter &saveWriter)
 	strcpy(charArrayToSave, stringToSave.c_str());
 
 	SaveHelper file(saveWriter, "statistics", stringToSaveLength);
-	for (int i = 0; i < stringToSaveLength; i++) {
+	for (size_t i = 0; i < stringToSaveLength; i++) {
 		char charToSave = *(charArrayToSave + i);
 		file.WriteLE<char>(charToSave);
 	}

--- a/Source/loadsave.h
+++ b/Source/loadsave.h
@@ -34,6 +34,8 @@ void RemoveEmptyInventory(Player &player);
  */
 void LoadGame(bool firstflag);
 void SaveHotkeys(MpqWriter &saveWriter);
+void SaveStatistics(MpqWriter &saveWriter);
+void LoadStatistics();
 void SaveHeroItems(MpqWriter &saveWriter, Player &player);
 void SaveGameData(MpqWriter &saveWriter);
 void SaveGame();

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1090,13 +1090,15 @@ void MonsterDeath(int mid, int pnum, Direction md, bool sendmsg)
 	assert(monster.MType != nullptr);
 
 	if (pnum < MAX_PLRS) {
-		if (pnum >= 0)
+		if (pnum >= 0) {
 			monster.mWhoHit |= 1 << pnum;
+			if (pnum == MyPlayerId)
+				MonsterKillCounts[monster.MType->mtype]++;
+		}
 		if (monster.MType->mtype != MT_GOLEM)
 			AddPlrMonstExper(monster.mLevel, monster.mExp, monster.mWhoHit);
 	}
 
-	MonsterKillCounts[monster.MType->mtype]++;
 	monster._mhitpoints = 0;
 	SetRndSeed(monster._mRndSeed);
 

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -271,6 +271,7 @@ void pfile_write_hero(MpqWriter &saveWriter, bool writeGameData)
 	EncodeHero(saveWriter, &pkplr);
 	if (!gbVanilla) {
 		SaveHotkeys(saveWriter);
+		SaveStatistics(saveWriter);
 		SaveHeroItems(saveWriter, myPlayer);
 	}
 }
@@ -431,6 +432,7 @@ bool pfile_ui_save_create(_uiheroinfo *heroinfo)
 	Game2UiPlayer(player, heroinfo, false);
 	if (!gbVanilla) {
 		SaveHotkeys(saveWriter);
+		SaveStatistics(saveWriter);
 		SaveHeroItems(saveWriter, player);
 	}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -28,6 +28,7 @@
 #include "player.h"
 #include "qol/autopickup.h"
 #include "qol/stash.h"
+#include "qol/statistics.h"
 #include "spells.h"
 #include "stores.h"
 #include "towners.h"
@@ -2627,7 +2628,7 @@ void CreatePlayer(int playerId, HeroClass c)
 
 	InitDungMsgs(player);
 	CreatePlrItems(playerId);
-	InitializePlayerStatistics(player);
+	InitializePlayerStatistics();
 	SetRndSeed(0);
 }
 
@@ -3145,7 +3146,7 @@ StartPlayerKill(int pnum, int earflag)
 		}
 	}
 	SetPlayerHitPoints(player, 0);
-	player.statistics->deathCount++;
+	myPlayerStatistics.deathCount++;
 }
 
 void StripTopGold(Player &player)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3146,7 +3146,7 @@ StartPlayerKill(int pnum, int earflag)
 		}
 	}
 	SetPlayerHitPoints(player, 0);
-	myPlayerStatistics.deathCount++;
+	MyPlayerStatistics.deathCount++;
 }
 
 void StripTopGold(Player &player)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2592,8 +2592,6 @@ void CreatePlayer(int playerId, HeroClass c)
 	// Initializing the hotkey bindings to no selection
 	std::fill(player._pSplHotKey, player._pSplHotKey + NumHotkeys, SPL_INVALID);
 
-	player.deathCount = 0;
-
 	PlayerWeaponGraphic animWeaponId = PlayerWeaponGraphic::Unarmed;
 	switch (c) {
 	case HeroClass::Warrior:
@@ -2629,6 +2627,7 @@ void CreatePlayer(int playerId, HeroClass c)
 
 	InitDungMsgs(player);
 	CreatePlrItems(playerId);
+	InitializePlayerStatistics(player);
 	SetRndSeed(0);
 }
 
@@ -3146,7 +3145,7 @@ StartPlayerKill(int pnum, int earflag)
 		}
 	}
 	SetPlayerHitPoints(player, 0);
-	player.deathCount++;
+	player.statistics->deathCount++;
 }
 
 void StripTopGold(Player &player)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2592,6 +2592,8 @@ void CreatePlayer(int playerId, HeroClass c)
 	// Initializing the hotkey bindings to no selection
 	std::fill(player._pSplHotKey, player._pSplHotKey + NumHotkeys, SPL_INVALID);
 
+	player.deathCount = 0;
+
 	PlayerWeaponGraphic animWeaponId = PlayerWeaponGraphic::Unarmed;
 	switch (c) {
 	case HeroClass::Warrior:
@@ -2773,8 +2775,10 @@ void InitPlayer(Player &player, bool firstTime)
 	if (firstTime) {
 		player._pRSplType = RSPLTYPE_INVALID;
 		player._pRSpell = SPL_INVALID;
-		if (&player == &myPlayer)
+		if (&player == &myPlayer) {
 			LoadHotkeys();
+			LoadStatistics();
+		}
 		player._pSBkSpell = SPL_INVALID;
 		player._pSpell = player._pRSpell;
 		player._pSplType = player._pRSplType;
@@ -3142,6 +3146,7 @@ StartPlayerKill(int pnum, int earflag)
 		}
 	}
 	SetPlayerHitPoints(player, 0);
+	player.deathCount++;
 }
 
 void StripTopGold(Player &player)

--- a/Source/player.h
+++ b/Source/player.h
@@ -19,7 +19,6 @@
 #include "items.h"
 #include "multi.h"
 #include "path.h"
-#include "qol/statistics.h"
 #include "spelldat.h"
 #include "utils/attributes.h"
 #include "utils/enum_traits.h"
@@ -351,7 +350,6 @@ struct Player {
 	ItemSpecialEffectHf pDamAcFlags;
 	/** @brief Specifies whether players are in non-PvP mode. */
 	bool friendlyMode = true;
-	struct Statistics *statistics;
 
 	void CalcScrolls();
 

--- a/Source/player.h
+++ b/Source/player.h
@@ -350,6 +350,7 @@ struct Player {
 	ItemSpecialEffectHf pDamAcFlags;
 	/** @brief Specifies whether players are in non-PvP mode. */
 	bool friendlyMode = true;
+	uint32_t deathCount;
 
 	void CalcScrolls();
 

--- a/Source/player.h
+++ b/Source/player.h
@@ -19,6 +19,7 @@
 #include "items.h"
 #include "multi.h"
 #include "path.h"
+#include "qol/statistics.h"
 #include "spelldat.h"
 #include "utils/attributes.h"
 #include "utils/enum_traits.h"
@@ -350,7 +351,7 @@ struct Player {
 	ItemSpecialEffectHf pDamAcFlags;
 	/** @brief Specifies whether players are in non-PvP mode. */
 	bool friendlyMode = true;
-	uint32_t deathCount;
+	struct Statistics *statistics;
 
 	void CalcScrolls();
 

--- a/Source/qol/statistics.cpp
+++ b/Source/qol/statistics.cpp
@@ -2,50 +2,51 @@
 
 namespace devilution {
 
-Statistics myPlayerStatistics;
-std::map<std::string, std::string> statisticsFile;
+Statistics MyPlayerStatistics;
+std::map<std::string, std::string> StatisticsFile;
 
-void SaveMonsterKillCount();
 void LoadMonsterKillCount();
+void SaveMonsterKillCount();
 std::string GetMonsterName(uint16_t monsterID);
 void AddMonsterWeapon(std::string &monsterName, uint16_t monsterID);
 
 void InitializePlayerStatistics()
 {
-	myPlayerStatistics = {};
+	MyPlayerStatistics = {};
 	std::fill_n(MonsterKillCounts, MAXMONSTERS, 0);
+	StatisticsFile.clear();
 }
 
 void LoadStatisticsFromMap()
 {
-	if (statisticsFile.find("deathCount") != statisticsFile.end())
-		myPlayerStatistics.deathCount = std::stoul(statisticsFile.at("deathCount"));
+	if (StatisticsFile.find("deathCount") != StatisticsFile.end())
+		MyPlayerStatistics.deathCount = std::stoul(StatisticsFile.at("deathCount"));
 
-	if (statisticsFile.find("ingameTime") != statisticsFile.end())
-		myPlayerStatistics.ingameTime = std::stoul(statisticsFile.at("ingameTime"));
+	if (StatisticsFile.find("ingameTime") != StatisticsFile.end())
+		MyPlayerStatistics.ingameTime = std::stoul(StatisticsFile.at("ingameTime"));
 	LoadMonsterKillCount();
 }
 
 void SaveStatisticsToMap()
 {
-	statisticsFile["deathCount"] = std::to_string(myPlayerStatistics.deathCount);
-	statisticsFile["ingameTime"] = std::to_string(myPlayerStatistics.ingameTime);
+	StatisticsFile["deathCount"] = std::to_string(MyPlayerStatistics.deathCount);
+	StatisticsFile["ingameTime"] = std::to_string(MyPlayerStatistics.ingameTime);
 	SaveMonsterKillCount();
 }
 
 void CalculateInGameTime()
 {
 	uint32_t ticksNow = SDL_GetTicks();
-	myPlayerStatistics.ingameTime += (ticksNow - myPlayerStatistics.ticksSubstrahend);
-	myPlayerStatistics.ticksSubstrahend = ticksNow;
+	MyPlayerStatistics.ingameTime += (ticksNow - MyPlayerStatistics.ticksSubtrahend);
+	MyPlayerStatistics.ticksSubtrahend = ticksNow;
 }
 
 void LoadMonsterKillCount()
 {
 	for (uint16_t monsterID = 0; monsterID < _monster_id::NUM_MTYPES; monsterID++) {
 		std::string monsterName = GetMonsterName(monsterID);
-		if (statisticsFile.find("killed." + monsterName) != statisticsFile.end())
-			MonsterKillCounts[monsterID] = std::stoi(statisticsFile.at("killed." + monsterName));
+		if (StatisticsFile.find("killed." + monsterName) != StatisticsFile.end())
+			MonsterKillCounts[monsterID] = std::stoi(StatisticsFile.at("killed." + monsterName));
 	}
 }
 
@@ -53,14 +54,15 @@ void SaveMonsterKillCount()
 {
 	for (uint16_t monsterID = 0; monsterID < _monster_id::NUM_MTYPES; monsterID++) {
 		std::string monsterName = GetMonsterName(monsterID);
-		statisticsFile["killed." + monsterName] = std::to_string(MonsterKillCounts[monsterID]);
+		StatisticsFile["killed." + monsterName] = std::to_string(MonsterKillCounts[monsterID]);
 	}
 }
 
 std::string GetMonsterName(uint16_t monsterID)
 {
 	std::string monsterName = MonstersData[monsterID].mName;
-	monsterName.erase(std::remove_if(monsterName.begin(), monsterName.end(), [](unsigned char x) { return std::isspace(x); }), monsterName.end());
+	std::string remChars = "- ";
+	monsterName.erase(std::remove_if(monsterName.begin(), monsterName.end(), [remChars](const std::string::value_type &x) { return remChars.find(x) != std::string::npos; }), monsterName.end());
 	AddMonsterWeapon(monsterName, monsterID);
 	return monsterName;
 }

--- a/Source/qol/statistics.cpp
+++ b/Source/qol/statistics.cpp
@@ -10,38 +10,34 @@ void LoadMonsterKillCount();
 std::string GetMonsterName(uint16_t monsterID);
 void AddMonsterWeapon(std::string &monsterName, uint16_t monsterID);
 
-void InitializePlayerStatistics(Player &player)
+void InitializePlayerStatistics()
 {
 	myPlayerStatistics = {};
-	player.statistics = &myPlayerStatistics;
 	std::fill_n(MonsterKillCounts, MAXMONSTERS, 0);
 }
 
 void LoadStatisticsFromMap()
 {
-	Player &myPlayer = *MyPlayer;
 	if (statisticsFile.find("deathCount") != statisticsFile.end())
-		myPlayer.statistics->deathCount = std::stoul(statisticsFile.at("deathCount"));
+		myPlayerStatistics.deathCount = std::stoul(statisticsFile.at("deathCount"));
 
 	if (statisticsFile.find("ingameTime") != statisticsFile.end())
-		myPlayer.statistics->ingameTime = std::stoul(statisticsFile.at("ingameTime"));
+		myPlayerStatistics.ingameTime = std::stoul(statisticsFile.at("ingameTime"));
 	LoadMonsterKillCount();
 }
 
 void SaveStatisticsToMap()
 {
-	Player &myPlayer = *MyPlayer;
-	statisticsFile["deathCount"] = std::to_string(myPlayer.statistics->deathCount);
-	statisticsFile["ingameTime"] = std::to_string(myPlayer.statistics->ingameTime);
+	statisticsFile["deathCount"] = std::to_string(myPlayerStatistics.deathCount);
+	statisticsFile["ingameTime"] = std::to_string(myPlayerStatistics.ingameTime);
 	SaveMonsterKillCount();
 }
 
 void CalculateInGameTime()
 {
-	Statistics *stats = MyPlayer->statistics;
 	uint64_t ticksNow = SDL_GetTicks64();
-	stats->ingameTime += (ticksNow - stats->ticksSubstrahend);
-	stats->ticksSubstrahend = ticksNow;
+	myPlayerStatistics.ingameTime += (ticksNow - myPlayerStatistics.ticksSubstrahend);
+	myPlayerStatistics.ticksSubstrahend = ticksNow;
 }
 
 void LoadMonsterKillCount()

--- a/Source/qol/statistics.cpp
+++ b/Source/qol/statistics.cpp
@@ -5,10 +5,16 @@ namespace devilution {
 Statistics myPlayerStatistics;
 std::map<std::string, std::string> statisticsFile;
 
+void SaveMonsterKillCount();
+void LoadMonsterKillCount();
+std::string GetMonsterName(uint16_t monsterID);
+void AddMonsterWeapon(std::string &monsterName, uint16_t monsterID);
+
 void InitializePlayerStatistics(Player &player)
 {
 	myPlayerStatistics = {};
 	player.statistics = &myPlayerStatistics;
+	std::fill_n(MonsterKillCounts, MAXMONSTERS, 0);
 }
 
 void LoadStatisticsFromMap()
@@ -19,6 +25,7 @@ void LoadStatisticsFromMap()
 
 	if (statisticsFile.find("ingameTime") != statisticsFile.end())
 		myPlayer.statistics->ingameTime = std::stoul(statisticsFile.at("ingameTime"));
+	LoadMonsterKillCount();
 }
 
 void SaveStatisticsToMap()
@@ -26,6 +33,7 @@ void SaveStatisticsToMap()
 	Player &myPlayer = *MyPlayer;
 	statisticsFile["deathCount"] = std::to_string(myPlayer.statistics->deathCount);
 	statisticsFile["ingameTime"] = std::to_string(myPlayer.statistics->ingameTime);
+	SaveMonsterKillCount();
 }
 
 void CalculateInGameTime()
@@ -34,6 +42,60 @@ void CalculateInGameTime()
 	uint64_t ticksNow = SDL_GetTicks64();
 	stats->ingameTime += (ticksNow - stats->ticksSubstrahend);
 	stats->ticksSubstrahend = ticksNow;
+}
+
+void LoadMonsterKillCount()
+{
+	for (uint16_t monsterID = 0; monsterID < _monster_id::NUM_MTYPES; monsterID++) {
+		std::string monsterName = GetMonsterName(monsterID);
+		if (statisticsFile.find("killed." + monsterName) != statisticsFile.end())
+			MonsterKillCounts[monsterID] = std::stoi(statisticsFile.at("killed." + monsterName));
+	}
+}
+
+void SaveMonsterKillCount()
+{
+	for (uint16_t monsterID = 0; monsterID < _monster_id::NUM_MTYPES; monsterID++) {
+		std::string monsterName = GetMonsterName(monsterID);
+		statisticsFile["killed." + monsterName] = std::to_string(MonsterKillCounts[monsterID]);
+	}
+}
+
+std::string GetMonsterName(uint16_t monsterID)
+{
+	std::string monsterName = MonstersData[monsterID].mName;
+	monsterName.erase(std::remove_if(monsterName.begin(), monsterName.end(), [](unsigned char x) { return std::isspace(x); }), monsterName.end());
+	AddMonsterWeapon(monsterName, monsterID);
+	return monsterName;
+}
+
+void AddMonsterWeapon(std::string &monsterName, uint16_t monsterID)
+{
+	switch (monsterID) {
+	case MT_WSKELBW:
+	case MT_RSKELBW:
+	case MT_XSKELBW:
+	case MT_NGOATBW:
+	case MT_BGOATBW:
+	case MT_RGOATBW:
+	case MT_GGOATBW:
+		monsterName += "Archer";
+		break;
+	case MT_RFALLSP:
+	case MT_DFALLSP:
+	case MT_YFALLSP:
+	case MT_BFALLSP:
+		monsterName += "WithSpear";
+		break;
+	case MT_RFALLSD:
+	case MT_DFALLSD:
+	case MT_YFALLSD:
+	case MT_BFALLSD:
+		monsterName += "WithSword";
+		break;
+	default: // do nothing;
+		break;
+	}
 }
 
 } // namespace devilution

--- a/Source/qol/statistics.cpp
+++ b/Source/qol/statistics.cpp
@@ -1,0 +1,39 @@
+#include "qol/statistics.h"
+
+namespace devilution {
+
+Statistics myPlayerStatistics;
+std::map<std::string, std::string> statisticsFile;
+
+void InitializePlayerStatistics(Player &player)
+{
+	myPlayerStatistics = {};
+	player.statistics = &myPlayerStatistics;
+}
+
+void LoadStatisticsFromMap()
+{
+	Player &myPlayer = *MyPlayer;
+	if (statisticsFile.find("deathCount") != statisticsFile.end())
+		myPlayer.statistics->deathCount = std::stoul(statisticsFile.at("deathCount"));
+
+	if (statisticsFile.find("ingameTime") != statisticsFile.end())
+		myPlayer.statistics->ingameTime = std::stoul(statisticsFile.at("ingameTime"));
+}
+
+void SaveStatisticsToMap()
+{
+	Player &myPlayer = *MyPlayer;
+	statisticsFile["deathCount"] = std::to_string(myPlayer.statistics->deathCount);
+	statisticsFile["ingameTime"] = std::to_string(myPlayer.statistics->ingameTime);
+}
+
+void CalculateInGameTime()
+{
+	Statistics *stats = MyPlayer->statistics;
+	uint64_t ticksNow = SDL_GetTicks64();
+	stats->ingameTime += (ticksNow - stats->ticksSubstrahend);
+	stats->ticksSubstrahend = ticksNow;
+}
+
+} // namespace devilution

--- a/Source/qol/statistics.cpp
+++ b/Source/qol/statistics.cpp
@@ -35,7 +35,7 @@ void SaveStatisticsToMap()
 
 void CalculateInGameTime()
 {
-	uint64_t ticksNow = SDL_GetTicks64();
+	uint32_t ticksNow = SDL_GetTicks();
 	myPlayerStatistics.ingameTime += (ticksNow - myPlayerStatistics.ticksSubstrahend);
 	myPlayerStatistics.ticksSubstrahend = ticksNow;
 }

--- a/Source/qol/statistics.h
+++ b/Source/qol/statistics.h
@@ -10,11 +10,11 @@ namespace devilution {
 struct Statistics {
 	uint32_t deathCount = 0;
 	uint64_t ingameTime = 0;
-	uint32_t ticksSubstrahend = SDL_GetTicks();
+	uint32_t ticksSubtrahend = SDL_GetTicks();
 };
 
-extern std::map<std::string, std::string> statisticsFile;
-extern Statistics myPlayerStatistics;
+extern std::map<std::string, std::string> StatisticsFile;
+extern Statistics MyPlayerStatistics;
 
 void InitializePlayerStatistics();
 void LoadStatisticsFromMap();

--- a/Source/qol/statistics.h
+++ b/Source/qol/statistics.h
@@ -10,7 +10,7 @@ namespace devilution {
 struct Statistics {
 	uint32_t deathCount = 0;
 	uint64_t ingameTime = 0;
-	uint64_t ticksSubstrahend = SDL_GetTicks64();
+	uint32_t ticksSubstrahend = SDL_GetTicks();
 };
 
 extern std::map<std::string, std::string> statisticsFile;

--- a/Source/qol/statistics.h
+++ b/Source/qol/statistics.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+#include "player.h"
+
+namespace devilution {
+
+struct Statistics {
+	uint32_t deathCount = 0;
+	uint64_t ingameTime = 0;
+	uint64_t ticksSubstrahend = SDL_GetTicks64();
+};
+
+extern std::map<std::string, std::string> statisticsFile;
+
+void InitializePlayerStatistics(Player &player);
+void LoadStatisticsFromMap();
+void SaveStatisticsToMap();
+void CalculateInGameTime();
+
+} // namespace devilution

--- a/Source/qol/statistics.h
+++ b/Source/qol/statistics.h
@@ -14,8 +14,9 @@ struct Statistics {
 };
 
 extern std::map<std::string, std::string> statisticsFile;
+extern Statistics myPlayerStatistics;
 
-void InitializePlayerStatistics(Player &player);
+void InitializePlayerStatistics();
 void LoadStatisticsFromMap();
 void SaveStatisticsToMap();
 void CalculateInGameTime();

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -142,7 +142,8 @@ bool CheckXPBarInfo()
 	AddPanelString(fmt::format(fmt::runtime(_("Experience: {:s}")), FormatInteger(player._pExperience)));
 	AddPanelString(fmt::format(fmt::runtime(_("Next Level: {:s}")), FormatInteger(ExpLvlsTbl[charLevel])));
 	AddPanelString(fmt::format(fmt::runtime(_("{:s} to Level {:d}")), FormatInteger(ExpLvlsTbl[charLevel] - player._pExperience), charLevel + 1));
-	AddPanelString(fmt::format(fmt::runtime(_("Deaths: {:d}")), myPlayerStatistics.deathCount));
+	if (gbIsMultiplayer)
+		AddPanelString(fmt::format(fmt::runtime(_("Deaths: {:d}")), MyPlayerStatistics.deathCount));
 
 	return true;
 }

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -124,7 +124,7 @@ bool CheckXPBarInfo()
 
 	const int8_t charLevel = player._pLevel;
 
-	AddPanelString(fmt::format(fmt::runtime(_("Level {:d}  Deaths: {:d}")), charLevel, player.statistics->deathCount));
+	AddPanelString(fmt::format(fmt::runtime(_("Level {:d}")), charLevel));
 
 	if (charLevel == MAXCHARLEVEL) {
 		// Show a maximum level indicator for max level players.
@@ -141,6 +141,7 @@ bool CheckXPBarInfo()
 	AddPanelString(fmt::format(fmt::runtime(_("Experience: {:s}")), FormatInteger(player._pExperience)));
 	AddPanelString(fmt::format(fmt::runtime(_("Next Level: {:s}")), FormatInteger(ExpLvlsTbl[charLevel])));
 	AddPanelString(fmt::format(fmt::runtime(_("{:s} to Level {:d}")), FormatInteger(ExpLvlsTbl[charLevel] - player._pExperience), charLevel + 1));
+	AddPanelString(fmt::format(fmt::runtime(_("Deaths: {:d}")), player.statistics->deathCount));
 
 	return true;
 }

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -124,7 +124,7 @@ bool CheckXPBarInfo()
 
 	const int8_t charLevel = player._pLevel;
 
-	AddPanelString(fmt::format(fmt::runtime(_("Level {:d}  Deaths: {:d}")), charLevel, player.deathCount));
+	AddPanelString(fmt::format(fmt::runtime(_("Level {:d}  Deaths: {:d}")), charLevel, player.statistics->deathCount));
 
 	if (charLevel == MAXCHARLEVEL) {
 		// Show a maximum level indicator for max level players.

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -124,7 +124,7 @@ bool CheckXPBarInfo()
 
 	const int8_t charLevel = player._pLevel;
 
-	AddPanelString(fmt::format(fmt::runtime(_("Level {:d}")), charLevel));
+	AddPanelString(fmt::format(fmt::runtime(_("Level {:d}  Deaths: {:d}")), charLevel, player.deathCount));
 
 	if (charLevel == MAXCHARLEVEL) {
 		// Show a maximum level indicator for max level players.

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -13,6 +13,7 @@
 #include "control.h"
 #include "engine/point.hpp"
 #include "options.h"
+#include "qol/statistics.h"
 #include "utils/format_int.hpp"
 #include "utils/language.h"
 
@@ -141,7 +142,7 @@ bool CheckXPBarInfo()
 	AddPanelString(fmt::format(fmt::runtime(_("Experience: {:s}")), FormatInteger(player._pExperience)));
 	AddPanelString(fmt::format(fmt::runtime(_("Next Level: {:s}")), FormatInteger(ExpLvlsTbl[charLevel])));
 	AddPanelString(fmt::format(fmt::runtime(_("{:s} to Level {:d}")), FormatInteger(ExpLvlsTbl[charLevel] - player._pExperience), charLevel + 1));
-	AddPanelString(fmt::format(fmt::runtime(_("Deaths: {:d}")), player.statistics->deathCount));
+	AddPanelString(fmt::format(fmt::runtime(_("Deaths: {:d}")), myPlayerStatistics.deathCount));
 
 	return true;
 }


### PR DESCRIPTION
This PR introduces Player's Character Statistics to the game as a structure ready to expand.

Statistics are saved to savegame mpq as separate statistics file. Thus don't break compatibility with vanilla that will just ignore it.

**Ready to expand.** Currently only few statistisc are added. But the structure is ready to add as many as you like.
Just implement new ones in the game logic, and add in `statistics.cpp` in `LoadStatisticsFromMap()` and `SaveStatisticsToMap()` - by analogy to the currently added ones. Add to `Statistics` struct if needed.

**Forward and backward compatible.**
Thanks to saving as key->value map it is totally safe to load savegame originating from newer version of game that introcuded more statistics.
If savegame is loaded by older version of game that will not support particular statistics - not supported statistics will survive and just be saved without any changes. Game will modifiy only statistics known to it. The rest will stay untouched.

Currently implemented statistics:
- Player (character) Death Count
- Ingame time
- Monster Kill Count support in MP games.

Only Player Death Count is displayed right now (hover exp bar). For more statistics some statistics panel is needed as UI part - yet to be done. But nothing prevents you from adding statistics that will be gathered and displayed layer.
Monster Kill Count is displayed as always - but this time also saved per MP character as well.
(small modification by me here is count only kills done by My Player - as bug fix).


I experimented with few only, but as you can imagine sky is the limit. You can count and store everything.
some ideas:
How many times character asked Farnham for gossip, how many arrows she shooted. How many times he blocked. What was highest damage he dealt, or maybe received. What was his priciest buy. How many stairs he took, or town portals from other players. What was his farthest teleport distance. How many games he created or joined. How many messages he typed in a chat, or maybe used debug commands? How many times he said "#$%^&". What is his favourite spell or gear? Which shrines did he took how many times? Or hit by trap. How many items he too from stash, and how many placed in? How many small yellow potion he quaffed. How many times he killed or resurrected other players.
How many meters character walked, swim or jump :wink:
This also enables achievments (like kill 6666 goats).
Take note that it is possible to use it not only as counters. You can let's say store previous character names as coma separated list in one of map position (when change-name feature will be implemented). And many more.
At some point maybe save to txt could be added, to print and plant on a fridge. Or even display on some statistics website hosted on server connected to DevilutionX.

If you want more ideas - go take a look at statistics in World of Warcraft (it's free to play as trial with character level limitations). There are literally hundreds if not thousands.
It is even better as you can inspect other player statistics there too (as all is stored on server).