### PR TITLE
Restore change to trigger position when advancing betrayer quest

### DIFF
--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -329,8 +329,9 @@ void CheckQuests()
 	    && quest._qvar1 >= 2
 	    && (quest._qactive == QUEST_ACTIVE || quest._qactive == QUEST_DONE)
 	    && (quest._qvar2 == 0 || quest._qvar2 == 2)) {
-		Point portalLocation = quest.position.megaToWorld();
-		AddMissile(portalLocation, portalLocation, Direction::South, MIS_RPORTAL, TARGET_MONSTERS, MyPlayerId, 0, 0);
+		// Move the quest trigger into world space, then spawn a portal at the same location
+		quest.position = quest.position.megaToWorld();
+		AddMissile(quest.position, quest.position, Direction::South, MIS_RPORTAL, TARGET_MONSTERS, MyPlayerId, 0, 0);
 		quest._qvar2 = 1;
 		if (quest._qactive == QUEST_ACTIVE && quest._qvar1 == 2) {
 			quest._qvar1 = 3;


### PR DESCRIPTION
Before https://github.com/diasurgical/devilutionX/pull/4698 the quest state was modified when spawning the portal to the unholy altar, I thought this was unused as the logic checking the triggers appeared to be looking at the portal position, but that was probably a wrong assumption 😂 

Haven't had time to test this actually works though, hoping Sieg can give it a shot? You'll need a save that hasn't advanced the quest to this stage yet.