### PR TITLE
Restructure test conditions to avoid tautology warnings

### DIFF
--- a/test/utf8_test.cpp
+++ b/test/utf8_test.cpp
@@ -42,22 +42,22 @@ TEST(Utf8CodeUnits, ValidCodePoints)
 		EXPECT_FALSE(IsTrailUtf8CodeUnit(x)) << "Basic Latin and ASCII Control characters are not trail code units";
 	}
 
-	for (char x = '\x80'; x >= '\x80' && x <= '\xBF'; x++) {
+	for (char x = '\x80'; x <= '\xBF'; x++) {
 		EXPECT_TRUE(IsTrailUtf8CodeUnit(x)) << "Bytes in the range 0x80 to 0xBF are potentially valid trail code units";
 	}
 
-	for (char x = '\xC2'; x >= '\xC2' && x <= '\xF4'; x++) {
+	for (char x = '\xC2'; x <= '\xF4'; x++) {
 		EXPECT_FALSE(IsTrailUtf8CodeUnit(x)) << "Bytes in the range 0xC2 to 0xF4 are never valid trail code units";
 	}
 }
 
 TEST(Utf8CodeUnits, InvalidCodePoints)
 {
-	for (char x = '\xC0'; x >= '\xC0' && x <= '\xC1'; x++) {
+	for (char x = '\xC0'; x <= '\xC1'; x++) {
 		EXPECT_FALSE(IsTrailUtf8CodeUnit(x)) << "Bytes in the range 0xC0 to oxC1 are not trail code units";
 	}
 
-	for (char x = '\xF5'; x >= '\xF5' && x <= '\xFF'; x++) {
+	for (char x = '\xFF'; x >= '\xF5'; x--) {
 		EXPECT_FALSE(IsTrailUtf8CodeUnit(x)) << "Bytes in the range 0xF5 to 0xFF are not trail code units";
 	}
 }


### PR DESCRIPTION
Most of the loops didn't risk overflow no matter what the underlying type of char is, the one that did is easy to reverse.