### PR TITLE
Rename SkipThemeRoom, use theme room attributes in PlaceThemeRoom

### DIFF
--- a/Source/drlg_l3.cpp
+++ b/Source/drlg_l3.cpp
@@ -1714,7 +1714,7 @@ void Fence()
 
 	for (int j = 1; j < DMAXY; j++) {     // BUGFIX: Change '0' to '1' (fixed)
 		for (int i = 1; i < DMAXX; i++) { // BUGFIX: Change '0' to '1' (fixed)
-			if (dungeon[i][j] == 7 && GenerateRnd(1) == 0 && SkipThemeRoom(i, j)) {
+			if (dungeon[i][j] == 7 && GenerateRnd(1) == 0 && !IsNearThemeRoom({ i, j })) {
 				int rt = GenerateRnd(2);
 				if (rt == 0) {
 					int y1 = j;

--- a/Source/engine/size.hpp
+++ b/Source/engine/size.hpp
@@ -41,6 +41,11 @@ struct Size {
 		return *this;
 	}
 
+	constexpr Size &operator-=(const int factor)
+	{
+		return *this += -factor;
+	}
+
 	constexpr Size &operator*=(const int factor)
 	{
 		width *= factor;
@@ -65,6 +70,12 @@ struct Size {
 	constexpr friend Size operator+(Size a, const int factor)
 	{
 		a += factor;
+		return a;
+	}
+
+	constexpr friend Size operator-(Size a, const int factor)
+	{
+		a -= factor;
 		return a;
 	}
 

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -670,13 +670,14 @@ void DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int freq, bool rn
 					if (themeH < min || themeH > max)
 						themeH = min;
 				}
-				themeLoc[themeCount].room = { { i + 1, j + 1 }, { themeW, themeH } };
+				THEME_LOC &theme = themeLoc[themeCount];
+				theme.room = { Point { i, j } + Direction::South, Size { themeW, themeH } };
 				if (IsAnyOf(leveltype, DTYPE_CAVES, DTYPE_NEST)) {
-					DRLG_RectTrans({ Point(i + 2, j + 2).megaToWorld(), { themeW * 2 - 5, themeH * 2 - 5 } });
+					DRLG_RectTrans({ (theme.room.position + Direction::South).megaToWorld(), theme.room.size * 2 - 5 });
 				} else {
-					DRLG_MRectTrans({ { i + 1, j + 1 }, { themeW - 1, themeH - 1 } });
+					DRLG_MRectTrans({ theme.room.position, theme.room.size - 1 });
 				}
-				themeLoc[themeCount].ttval = TransVal - 1;
+				theme.ttval = TransVal - 1;
 				CreateThemeRoom(themeCount);
 				themeCount++;
 			}

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -752,11 +752,8 @@ void DRLG_LPass3(int lv)
 
 bool IsNearThemeRoom(Point testPosition)
 {
-	int x = testPosition.x;
-	int y = testPosition.y;
 	for (int i = 0; i < themeCount; i++) {
-		if (x >= themeLoc[i].room.position.x - 2 && x <= themeLoc[i].room.position.x + themeLoc[i].room.size.width + 2
-		    && y >= themeLoc[i].room.position.y - 2 && y <= themeLoc[i].room.position.y + themeLoc[i].room.size.height + 2)
+		if (Rectangle(themeLoc[i].room.position - Displacement { 2 }, themeLoc[i].room.size + 5).Contains(testPosition))
 			return true;
 	}
 

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -95,7 +95,7 @@ bool WillThemeRoomFit(int floor, int x, int y, int minSize, int maxSize, int *wi
 	if (x + minSize > DMAXX || y + minSize > DMAXY) {
 		return false; // Skip definit OOB cases
 	}
-	if (!SkipThemeRoom(x, y)) {
+	if (IsNearThemeRoom({ x, y })) {
 		return false;
 	}
 
@@ -750,15 +750,17 @@ void DRLG_LPass3(int lv)
 	}
 }
 
-bool SkipThemeRoom(int x, int y)
+bool IsNearThemeRoom(Point testPosition)
 {
+	int x = testPosition.x;
+	int y = testPosition.y;
 	for (int i = 0; i < themeCount; i++) {
 		if (x >= themeLoc[i].room.position.x - 2 && x <= themeLoc[i].room.position.x + themeLoc[i].room.size.width + 2
 		    && y >= themeLoc[i].room.position.y - 2 && y <= themeLoc[i].room.position.y + themeLoc[i].room.size.height + 2)
-			return false;
+			return true;
 	}
 
-	return true;
+	return false;
 }
 
 void InitLevels()

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -335,7 +335,13 @@ void DRLG_HoldThemeRooms();
 void SetSetPieceRoom(Point position, int floorId);
 void FreeQuestSetPieces();
 void DRLG_LPass3(int lv);
-bool SkipThemeRoom(int x, int y);
+
+/**
+ * @brief Checks if a theme room is located near the target point
+ * @param position Target location in dungeon coordinates
+ * @return True if a theme room is near (within 2 tiles of) this point, false if it is free.
+ */
+bool IsNearThemeRoom(Point position);
 void InitLevels();
 void FloodTransparencyValues(uint8_t floorID);
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -890,7 +890,7 @@ void AddHookedBodies(int freq)
 				continue;
 			if (GenerateRnd(freq) != 0)
 				continue;
-			if (!SkipThemeRoom(i, j))
+			if (IsNearThemeRoom({ i, j }))
 				continue;
 			if (dungeon[i][j] == 1 && dungeon[i + 1][j] == 6) {
 				switch (GenerateRnd(3)) {


### PR DESCRIPTION
This was part of an attempt at a wider cleanup of the way theme room dimensions are set, pulling this out to make the future PR(s) smaller.

There's a lot of places where a theme room dimension is adjusted by some amount, a lot of these seem to be compensating for/undoing previous adjustments. Hoping that can be simplified throughout.