### PR TITLE
Simplify loops in WillThemeRoomFit, rename to match use

### DIFF
--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -105,35 +105,45 @@ std::optional<Size> GetSizeForThemeRoom(int floor, Point origin, int minSize, in
 	int maxWidth = std::min(DMAXX - origin.x, maxSize);
 	int maxHeight = std::min(DMAXY - origin.y, maxSize);
 
-	// see if we can find a region at least as large as the minSize on each dimension
-	for (int yOffset = 0; yOffset < maxHeight; yOffset++) {
+	// Start out looking for the widest area at least as tall as minSize
+	for (int yOffset = 0; yOffset < minSize; yOffset++) {
 		for (int xOffset = 0; xOffset < maxWidth; xOffset++) {
-			// Start out looking for the widest area at least as tall as minSize
 			if (dungeon[origin.x + xOffset][origin.y + yOffset] == floor)
 				continue;
 
-			// found a floor tile earlier than the previous row, so the width has shrunk somewhat
+			// found a non-floor tile earlier than the previous max width
 
-			if (xOffset < minSize && yOffset < minSize) {
+			if (xOffset < minSize) {
 				// area is too small to hold a room of the desired size
 				return {};
 			}
 
-			if (yOffset >= minSize) {
-				// area is at least as high as necessary. If we wanted to find the largest rectangular area we should
-				// keep going and start checking for the largest total area we can find (could be either the current
-				// width and height, or maybe a narrower but taller region has a larger area). Instead to match
-				// vanilla Diablo logic we trigger a break from the outer loop and fall through to the other checks
-				maxHeight = yOffset;
-			}
+			// update the max width since we can't make a room larger than this
+			maxWidth = xOffset;
+		}
+	}
+
+	// area is at least as high as necessary. If we wanted to find the largest rectangular area we should keep going
+	// and start checking for the largest total area we can find (could be the tallest region that maintains current
+	// width, or maybe a narrower but taller region has a larger area). Instead to match vanilla Diablo logic we
+	// trigger a break as soon as the width shrinks again.
+	for (int yOffset = minSize; yOffset < maxHeight; yOffset++) {
+		for (int xOffset = 0; xOffset < maxWidth; xOffset++) {
+			if (dungeon[origin.x + xOffset][origin.y + yOffset] == floor)
+				continue;
+
+			// really should continue and check if using this xOffset as width gives a larger area than our current
+			// maxWidth and yOffset.
+			maxHeight = yOffset;
 
 			if (xOffset < minSize) {
-				// current row is too small to meet the minimum size, so just use the last rows dimension
+				// current row is too small to meet the minimum size, so we've reached the end of the search
 				break;
 			}
 
-			// otherwise we now have a new lower bound for how wide a row can be
-			maxWidth = xOffset; // soft break
+			// We should be checking the maxHeight/yOffset in combination with the xOffset to see if we've got a more
+			// suitable area, but instead we just update maxWidth and let the loops fall out.
+			maxWidth = xOffset;
 		}
 	}
 

--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -78,37 +78,52 @@ std::unique_ptr<uint16_t[]> LoadMinData(size_t &tileCount)
 	}
 }
 
-bool WillThemeRoomFit(int floor, int x, int y, int minSize, int maxSize, int *width, int *height)
+/**
+ * @brief Starting from the origin point determine how much floor space is available with the given bounds
+ *
+ * Essentially looks for the widest/tallest rectangular area of at least the minimum size, but due to a weird/buggy
+ * bounds check can return an area smaller than the available width/height.
+ *
+ * @param floor what value defines floor tiles within a dungeon
+ * @param origin starting point for the search
+ * @param minSize minimum allowable value for both dimensions
+ * @param maxSize maximum allowable value for both dimensions
+ * @return how much width/height is available for a theme room or an empty optional if there's not enough space
+ */
+std::optional<Size> GetSizeForThemeRoom(int floor, Point origin, int minSize, int maxSize)
 {
-	if (x + maxSize > DMAXX && y + maxSize > DMAXY) {
-		return false; // Original broken bounds check, avoids lower right corner
+	if (origin.x + maxSize > DMAXX && origin.y + maxSize > DMAXY) {
+		return {}; // Original broken bounds check, avoids lower right corner
 	}
-	if (x + minSize > DMAXX || y + minSize > DMAXY) {
-		return false; // Skip definit OOB cases
+	if (origin.x + minSize > DMAXX || origin.y + minSize > DMAXY) {
+		return {}; // Skip definit OOB cases
 	}
-	if (IsNearThemeRoom({ x, y })) {
-		return false;
+	if (IsNearThemeRoom(origin)) {
+		return {};
 	}
 
-	int maxWidth = std::min(DMAXX - x, maxSize);
-	int maxHeight = std::min(DMAXY - y, maxSize);
+	int maxWidth = std::min(DMAXX - origin.x, maxSize);
+	int maxHeight = std::min(DMAXY - origin.y, maxSize);
 
 	// see if we can find a region at least as large as the minSize on each dimension
 	for (int yOffset = 0; yOffset < maxHeight; yOffset++) {
 		for (int xOffset = 0; xOffset < maxWidth; xOffset++) {
 			// Start out looking for the widest area at least as tall as minSize
-			if (dungeon[x + xOffset][y + yOffset] == floor)
+			if (dungeon[origin.x + xOffset][origin.y + yOffset] == floor)
 				continue;
 
 			// found a floor tile earlier than the previous row, so the width has shrunk somewhat
 
 			if (xOffset < minSize && yOffset < minSize) {
 				// area is too small to hold a room of the desired size
-				return false;
+				return {};
 			}
 
 			if (yOffset >= minSize) {
-				// area is at least as high as necessary, this row now defines our max height (also breaks out of the outer loop)
+				// area is at least as high as necessary. If we wanted to find the largest rectangular area we should
+				// keep going and start checking for the largest total area we can find (could be either the current
+				// width and height, or maybe a narrower but taller region has a larger area). Instead to match
+				// vanilla Diablo logic we trigger a break from the outer loop and fall through to the other checks
 				maxHeight = yOffset;
 			}
 
@@ -122,10 +137,7 @@ bool WillThemeRoomFit(int floor, int x, int y, int minSize, int maxSize, int *wi
 		}
 	}
 
-	*width = maxWidth - 2;
-	*height = maxHeight - 2;
-
-	return true;
+	return Size { maxWidth, maxHeight } - 2;
 }
 
 void CreateThemeRoom(int themeIndex)
@@ -611,21 +623,25 @@ void DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int freq, bool rn
 	memset(themeLoc, 0, sizeof(*themeLoc));
 	for (int j = 0; j < DMAXY; j++) {
 		for (int i = 0; i < DMAXX; i++) {
-			int themeW = 0;
-			int themeH = 0;
-			if (dungeon[i][j] == floor && FlipCoin(freq) && WillThemeRoomFit(floor, i, j, minSize, maxSize, &themeW, &themeH)) {
+			if (dungeon[i][j] == floor && FlipCoin(freq)) {
+				std::optional<Size> themeSize = GetSizeForThemeRoom(floor, { i, j }, minSize, maxSize);
+
+				if (!themeSize)
+					continue;
+
 				if (rndSize) {
 					int min = minSize - 2;
 					int max = maxSize - 2;
-					themeW = min + GenerateRnd(GenerateRnd(themeW - min + 1));
-					if (themeW < min || themeW > max)
-						themeW = min;
-					themeH = min + GenerateRnd(GenerateRnd(themeH - min + 1));
-					if (themeH < min || themeH > max)
-						themeH = min;
+					themeSize->width = min + GenerateRnd(GenerateRnd(themeSize->width - min + 1));
+					if (themeSize->width < min || themeSize->width > max)
+						themeSize->width = min;
+					themeSize->height = min + GenerateRnd(GenerateRnd(themeSize->height - min + 1));
+					if (themeSize->height < min || themeSize->height > max)
+						themeSize->height = min;
 				}
+
 				THEME_LOC &theme = themeLoc[themeCount];
-				theme.room = { Point { i, j } + Direction::South, Size { themeW, themeH } };
+				theme.room = { Point { i, j } + Direction::South, *themeSize };
 				if (IsAnyOf(leveltype, DTYPE_CAVES, DTYPE_NEST)) {
 					DRLG_RectTrans({ (theme.room.position + Direction::South).megaToWorld(), theme.room.size * 2 - 5 });
 				} else {

--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -80,11 +80,6 @@ std::unique_ptr<uint16_t[]> LoadMinData(size_t &tileCount)
 
 bool WillThemeRoomFit(int floor, int x, int y, int minSize, int maxSize, int *width, int *height)
 {
-	bool yFlag = true;
-	bool xFlag = true;
-	int xCount = 0;
-	int yCount = 0;
-
 	if (x + maxSize > DMAXX && y + maxSize > DMAXY) {
 		return false; // Original broken bounds check, avoids lower right corner
 	}
@@ -95,67 +90,41 @@ bool WillThemeRoomFit(int floor, int x, int y, int minSize, int maxSize, int *wi
 		return false;
 	}
 
-	int xArray[20] = {};
-	int yArray[20] = {};
+	int maxWidth = std::min(DMAXX - x, maxSize);
+	int maxHeight = std::min(DMAXY - y, maxSize);
 
-	for (int ii = 0; ii < maxSize; ii++) {
-		if (xFlag && y + ii < DMAXY) {
-			for (int xx = x; xx < x + maxSize && xx < DMAXX; xx++) {
-				if (dungeon[xx][y + ii] != floor) {
-					if (xx >= minSize) {
-						break;
-					}
-					xFlag = false;
-				} else {
-					xCount++;
-				}
+	// see if we can find a region at least as large as the minSize on each dimension
+	for (int yOffset = 0; yOffset < maxHeight; yOffset++) {
+		for (int xOffset = 0; xOffset < maxWidth; xOffset++) {
+			// Start out looking for the widest area at least as tall as minSize
+			if (dungeon[x + xOffset][y + yOffset] == floor)
+				continue;
+
+			// found a floor tile earlier than the previous row, so the width has shrunk somewhat
+
+			if (xOffset < minSize && yOffset < minSize) {
+				// area is too small to hold a room of the desired size
+				return false;
 			}
-			if (xFlag) {
-				xArray[ii] = xCount;
-				xCount = 0;
+
+			if (yOffset >= minSize) {
+				// area is at least as high as necessary, this row now defines our max height (also breaks out of the outer loop)
+				maxHeight = yOffset;
 			}
-		}
-		if (yFlag && x + ii < DMAXX) {
-			for (int yy = y; yy < y + maxSize && yy < DMAXY; yy++) {
-				if (dungeon[x + ii][yy] != floor) {
-					if (yy >= minSize) {
-						break;
-					}
-					yFlag = false;
-				} else {
-					yCount++;
-				}
+
+			if (xOffset < minSize) {
+				// current row is too small to meet the minimum size, so just use the last rows dimension
+				break;
 			}
-			if (yFlag) {
-				yArray[ii] = yCount;
-				yCount = 0;
-			}
+
+			// otherwise we now have a new lower bound for how wide a row can be
+			maxWidth = xOffset; // soft break
 		}
 	}
 
-	for (int ii = 0; ii < minSize; ii++) {
-		if (xArray[ii] < minSize || yArray[ii] < minSize) {
-			return false;
-		}
-	}
+	*width = maxWidth - 2;
+	*height = maxHeight - 2;
 
-	int xSmallest = xArray[0];
-	int ySmallest = yArray[0];
-
-	for (int ii = 0; ii < maxSize; ii++) {
-		if (xArray[ii] < minSize || yArray[ii] < minSize) {
-			break;
-		}
-		if (xArray[ii] < xSmallest) {
-			xSmallest = xArray[ii];
-		}
-		if (yArray[ii] < ySmallest) {
-			ySmallest = yArray[ii];
-		}
-	}
-
-	*width = xSmallest - 2;
-	*height = ySmallest - 2;
 	return true;
 }
 


### PR DESCRIPTION
My brain is mush after looking at this code. It looks like it was intended to look for the largest/most balanced rectangular region within a given search area, but due to a weird way of picking when to use a particular bound it ended up getting smaller areas than strictly necessary if there were choices where both dimensions are over the minimum bound.

There's probably a way to make this even more straightforward but I have given up thought for today 😂 

The following are a few search spaces I dumped out so I could see what the old logic was doing and confirm this rewrite worked the same.
```
INFO: DebugCmd: changelevel 10 Result: Welcome to level 10.
DEBUG: +++++#####
DEBUG: +++++#####
DEBUG: +++++##-##
DEBUG: +++++--###
DEBUG: +++++--###
DEBUG: #-------##
DEBUG: ##------##
DEBUG: ##------##
DEBUG: ##-----###
DEBUG: -------###
DEBUG: found 5, 5
INFO: DebugCmd: changelevel 12 Result: Welcome to level 12.
DEBUG: +++++#####
DEBUG: +++++###-#
DEBUG: +++++----#
DEBUG: +++++---##
DEBUG: +++++--###
DEBUG: --###--###
DEBUG: -####----#
DEBUG: -#####--##
DEBUG: #-####--##
DEBUG: #####---##
DEBUG: found 5, 5
DEBUG: ++++++--##
DEBUG: ++++++-###
DEBUG: ++++++-###
DEBUG: ++++++-###
DEBUG: ++++++####
DEBUG: ++++++####
DEBUG: ----######
DEBUG: -#########
DEBUG: -#########
DEBUG: ##########
DEBUG: found 6, 6
The thread 0x66b8 has exited with code 0 (0x0).
INFO: DebugCmd: changelevel 7 Result: Welcome to level 7.
DEBUG: ++++++####
DEBUG: ++++++####
DEBUG: ++++++####
DEBUG: ++++++####
DEBUG: ++++++####
DEBUG: ++++++####
DEBUG: ++++++####
DEBUG: ++++++-###
DEBUG: ++++++-###
DEBUG: ++++++-###
DEBUG: found 6, 10
DEBUG: ++++++---# -- this should've been either a 6x9 or 9x6 area
DEBUG: ++++++---# -- since both width and height of both choices
DEBUG: ++++++---# -- were over the minSize value the original logic
DEBUG: ++++++---# -- ends up picking the intersection of both regions
DEBUG: ++++++---#
DEBUG: ++++++---#
DEBUG: ------####
DEBUG: ------####
DEBUG: ------####
DEBUG: #####-####
DEBUG: found 6, 6
DEBUG: +++++++++#
DEBUG: +++++++++#
DEBUG: +++++++++#
DEBUG: +++++++++#
DEBUG: +++++++++#
DEBUG: +++++++++#
DEBUG: +++++++++#
DEBUG: --###----#
DEBUG: --###-----
DEBUG: --###-----
DEBUG: found 9, 7
DEBUG: ++++++###-
DEBUG: ++++++###-
DEBUG: ++++++###-
DEBUG: ++++++###-
DEBUG: ++++++####
DEBUG: ++++++####
DEBUG: ++++++####
DEBUG: ++++++####
DEBUG: ++++++####
DEBUG: ++++++####
DEBUG: found 6, 10
DEBUG: +++++++++#
DEBUG: +++++++++#
DEBUG: +++++++++#
DEBUG: +++++++++#
DEBUG: +++++++++#
DEBUG: +++++++++#
DEBUG: #####----#
DEBUG: #####----#
DEBUG: #####----#
DEBUG: #####----#
DEBUG: found 9, 6
```