### PR TITLE
Use the largest available area when placing theme rooms

### DIFF
--- a/Source/engine/size.hpp
+++ b/Source/engine/size.hpp
@@ -91,6 +91,11 @@ struct Size {
 		return a;
 	}
 
+	constexpr int area() const
+	{
+		return width * height;
+	}
+
 #ifdef BUILD_TESTING
 	/**
 	 * @brief Format sizes nicely in test failure messages


### PR DESCRIPTION
Splitting this into a separate PR from #4778 as this does change the boundaries of theme rooms. It could potentially put someone in a wall if they load a save made from an old version (though they can walk off it), and could lead to bodies/objects/items/monsters floating in the air/inside walls.

For example:
![cat_7](https://user-images.githubusercontent.com/357684/175546984-9786ba57-4949-4e77-afe3-25216b9b40c4.png)
![cat_7_fixed](https://user-images.githubusercontent.com/357684/175546992-3fd0d5cd-d6d3-489c-ae5c-5ae3fd435613.png)
![cat_8](https://user-images.githubusercontent.com/357684/175547002-db386f02-71a3-45aa-9fdf-b2a6b2c9847c.png)
![cat_8_fixed](https://user-images.githubusercontent.com/357684/175547018-25d78f78-d765-4f50-b8b7-82d8d0c58177.png)

But since it's one of the last phases of dungeon generation, it's relatively minor :D. Also got rid of the buggy bounds check since this changes behaviour anyway.