### PR TITLE
Fix "Restart in Town" when dying on a quest/set map

### DIFF
--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -398,6 +398,7 @@ void ShowProgress(interface_mode uMsg)
 		}
 		IncProgress();
 		FreeGameMem();
+		setlevel = false;
 		currlevel = myPlayer.plrlevel;
 		leveltype = GetLevelType(currlevel);
 		IncProgress();


### PR DESCRIPTION
When dying in multiplayer quest/set maps and then using "Restart in town" the `setlevel` is not set correctly.
Discovered while working on quest and arena support.