### PR TITLE
DebugCmdLoadQuestMap: Don't load entry quest lvl if the hero is already on this level

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -240,8 +240,10 @@ std::string DebugCmdLoadQuestMap(const string_view parameter)
 		if (level != quest._qslvl)
 			continue;
 
-		StartNewLvl(MyPlayerId, (quest._qlevel != 21) ? interface_mode::WM_DIABNEXTLVL : interface_mode::WM_DIABTOWNWARP, quest._qlevel);
-		ProcessMessages();
+		if (!MyPlayer->isOnLevel(quest._qlevel)) {
+			StartNewLvl(MyPlayerId, (quest._qlevel != 21) ? interface_mode::WM_DIABNEXTLVL : interface_mode::WM_DIABTOWNWARP, quest._qlevel);
+			ProcessMessages();
+		}
 
 		setlvltype = quest._qlvltype;
 		StartNewLvl(MyPlayerId, WM_DIABSETLVL, level);


### PR DESCRIPTION
When accessing a quest map with debug commands, the level where the quest can be entered is loaded first (so ReturnPosition is set).
But this is not needed if we are already on the dungeon level.