### PR TITLE
Update installing.md

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -57,6 +57,16 @@ When the transfer is done you can disconnect your device and press "Check again"
 
 </details>
 
+<details><summary>FreeBSD</summary>
+
+- Copy the MPQ files to the folder containing the DevilutionX application, or to the data folder `~/.local/share/diasurgical/devilution/`
+- To install the port: `cd /usr/ports/games/devilutionX/ && make install clean`
+- To add the package, run one of these commands:
+  `pkg install games/devilutionX` || `pkg install devilutionX`
+- Run `devilutionx`
+  
+</details>
+
 <details><summary>iOS & iPadOS</summary>
 
 Certain sideloading applications exist which can let you install IPA packages to your device such as AltStore (https://altstore.io/) and Sideloadly (https://sideloadly.io/). Using such a sideloading application, install the .ipa file to your iDevice.


### PR DESCRIPTION
Add FreeBSD install instructions.

FreeBSD port has been reworked and updated to latest release, notable changes are:

    - Update to 1.4
    - Drop dependency on font, no longer needed
    - Drop unnecessary .desktop file patches (also upstream PR exists)
    - Install from the port (instead of patching CMakeLists.txt), to be
      more explicit and flexible
    - Convert to pkg-plist as there are more files now
    - The new version tries to fetch dependencies from the net, for some
      depenencies this is unconditional. Fetch these properly with
      GH_TUPLE and place in a directory where CMake expectes them.
    - Upstream code expects patch component in the version, so add an extra
      .0 to VERSION_NUM. This should not break on (future) X.Y.Z versions
      as the component will move to micropatch position and will be ignored
    - BINARY_RELEASE option is gone
    - Untie DEBUG (engine debug bode) from WITH_DEBUG knob (build debug
      binary), these are orthogonal
    - Properly support optional depends; zerotier is the only one
      broken as it conflicts with system header (see
      https://github.com/diasurgical/devilutionX/issues/4585)
    - Install devilutionx (own) data file
      - Since it's not versioned, use a little hack to add a tag to the
        filename to avoid clashes on the future updates; this seemed less
        evil than introducing DIST_SUBDIR
      - Use two-level datadir to be consistent with ~/.local/share path
    - Update pkg-message (Diablo data file doesn't have to be lowercase,
      works either way)

FreeBSD port url: https://www.freshports.org/games/devilutionX/

Thanks,

Nuno Eduardo Teixeira
eduardo@FreeBSD.org