### PR TITLE
IsValidLevelForMultiplayer: Fix last set level is wrongly assumed as invalid

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2378,7 +2378,7 @@ uint8_t GetLevelForMultiplayer(const Player &player)
 
 bool IsValidLevelForMultiplayer(uint8_t level)
 {
-	return level < MAX_MULTIPLAYERLEVELS;
+	return level <= MAX_MULTIPLAYERLEVELS;
 }
 
 bool IsValidLevel(uint8_t level, bool isSetLevel)


### PR DESCRIPTION
Found while testing singleplayer betrayer quest for multiplayer.