### PR TITLE
Fix traps and monsters hitting monsters

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -418,7 +418,7 @@ void CheckMissileCol(Missile &missile, int minDamage, int maxDamage, bool isDama
 				isPlayerHit = PlayerMHit(pid - 1, &monster, missile._midist, minDamage, maxDamage, missile._mitype, isDamageShifted, 0, &blocked);
 			}
 		} else {
-			int earflag = (missile._miAnimType == MFILE_FIREWAL || missile._miAnimType == MFILE_LGHNING) ? 1 : 0;
+			int earflag = (!missile.IsTrap() && (missile._miAnimType == MFILE_FIREWAL || missile._miAnimType == MFILE_LGHNING)) ? 1 : 0;
 			isPlayerHit = PlayerMHit(pid - 1, nullptr, missile._midist, minDamage, maxDamage, missile._mitype, isDamageShifted, earflag, &blocked);
 		}
 	}

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -883,7 +883,7 @@ bool MonsterTrapHit(int m, int mindam, int maxdam, int dist, missile_id t, bool 
 		PlayEffect(monster, 1);
 	} else {
 		if (monster.MType->mtype != MT_GOLEM)
-			M_StartHit(m, -1, dam);
+			M_StartHit(m, dam);
 	}
 	return true;
 }

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -286,6 +286,7 @@ bool M_Talker(const Monster &monster);
 void M_StartStand(Monster &monster, Direction md);
 void M_ClearSquares(int i);
 void M_GetKnockback(int i);
+void M_StartHit(int i, int dam);
 void M_StartHit(int i, int pnum, int dam);
 void M_StartKill(int i, int pnum);
 void M_SyncStartKill(int i, Point position, int pnum);


### PR DESCRIPTION
I encountered an issue regarding when `pnum` can be `-1` in `MonsterMHit()`, turns out this can only happen the the case of the fire ring trap in Hellfire, because it's a trap but the logic in `CheckMissileCol()` assumes it to be fired by a player.

Solving allows us to remove the check for `-1` to determiner what should be triggered on hit, removing the need for some type juggling in #4754

In fixing this I also fixed a couple of other issues with missiles hitting monsters:
Monster unable to shoot a non-golem monster #4669
Monsters/traps can be unable to hit Petrified monsters (vanilla).
Ring of Fire traps do not damage monsters (hellfire).