### PR TITLE
Add helpers to anim info

### DIFF
--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -12,92 +12,92 @@
 
 namespace devilution {
 
-int AnimationInfo::GetFrameToUseForRendering() const
+int AnimationInfo::getFrameToUseForRendering() const
 {
 	// Normal logic is used,
 	// - if no frame-skipping is required and so we have exactly one Animationframe per game tick
 	// or
 	// - if we load from a savegame where the new variables are not stored (we don't want to break savegame compatiblity because of smoother rendering of one animation)
-	if (RelevantFramesForDistributing <= 0)
-		return std::max(0, CurrentFrame);
+	if (relevantFramesForDistributing_ <= 0)
+		return std::max(0, currentFrame_);
 
-	if (CurrentFrame >= RelevantFramesForDistributing)
-		return CurrentFrame;
+	if (currentFrame_ >= relevantFramesForDistributing_)
+		return currentFrame_;
 
-	float ticksSinceSequenceStarted = TicksSinceSequenceStarted;
-	if (TicksSinceSequenceStarted < 0) {
+	float ticksSinceSequenceStarted = ticksSinceSequenceStarted_;
+	if (ticksSinceSequenceStarted_ < 0) {
 		ticksSinceSequenceStarted = 0.0F;
-		Log("GetFrameToUseForRendering: Invalid TicksSinceSequenceStarted {}", TicksSinceSequenceStarted);
+		Log("getFrameToUseForRendering: Invalid ticksSinceSequenceStarted_ {}", ticksSinceSequenceStarted_);
 	}
 
 	// we don't use the processed game ticks alone but also the fraction of the next game tick (if a rendering happens between game ticks). This helps to smooth the animations.
-	float totalTicksForCurrentAnimationSequence = GetProgressToNextGameTick() + ticksSinceSequenceStarted;
+	float totalTicksForCurrentAnimationSequence = getProgressToNextGameTick() + ticksSinceSequenceStarted;
 
-	int absoluteAnimationFrame = static_cast<int>(totalTicksForCurrentAnimationSequence * TickModifier);
-	if (SkippedFramesFromPreviousAnimation > 0) {
+	int absoluteAnimationFrame = static_cast<int>(totalTicksForCurrentAnimationSequence * tickModifier_);
+	if (skippedFramesFromPreviousAnimation_ > 0) {
 		// absoluteAnimationFrames contains also the Frames from the previous Animation, so if we want to get the current Frame we have to remove them
-		absoluteAnimationFrame -= SkippedFramesFromPreviousAnimation;
+		absoluteAnimationFrame -= skippedFramesFromPreviousAnimation_;
 		if (absoluteAnimationFrame < 0) {
 			// We still display the remains of the previous Animation
-			absoluteAnimationFrame = NumberOfFrames + absoluteAnimationFrame;
+			absoluteAnimationFrame = numberOfFrames_ + absoluteAnimationFrame;
 		}
-	} else if (absoluteAnimationFrame >= RelevantFramesForDistributing) {
+	} else if (absoluteAnimationFrame >= relevantFramesForDistributing_) {
 		// this can happen if we are at the last frame and the next game tick is due (gfProgressToNextGameTick >= 1.0f)
-		if (absoluteAnimationFrame >= (RelevantFramesForDistributing + 1)) {
+		if (absoluteAnimationFrame >= (relevantFramesForDistributing_ + 1)) {
 			// we should never have +2 frames even if next game tick is due
-			Log("GetFrameToUseForRendering: Calculated an invalid Animation Frame (Calculated {} MaxFrame {})", absoluteAnimationFrame, RelevantFramesForDistributing);
+			Log("getFrameToUseForRendering: Calculated an invalid Animation Frame (Calculated {} MaxFrame {})", absoluteAnimationFrame, relevantFramesForDistributing_);
 		}
-		return RelevantFramesForDistributing - 1;
+		return relevantFramesForDistributing_ - 1;
 	}
 	if (absoluteAnimationFrame < 0) {
-		Log("GetFrameToUseForRendering: Calculated an invalid Animation Frame (Calculated {})", absoluteAnimationFrame);
+		Log("getFrameToUseForRendering: Calculated an invalid Animation Frame (Calculated {})", absoluteAnimationFrame);
 		return 0;
 	}
 	return absoluteAnimationFrame;
 }
 
-float AnimationInfo::GetAnimationProgress() const
+float AnimationInfo::getAnimationProgress() const
 {
-	float ticksSinceSequenceStarted = TicksSinceSequenceStarted;
-	float tickModifier = TickModifier;
+	float ticksSinceSequenceStarted = ticksSinceSequenceStarted_;
+	float tickModifier = tickModifier_;
 
-	if (RelevantFramesForDistributing <= 0) {
-		// This logic is used if animation distribution is not active (see GetFrameToUseForRendering).
+	if (relevantFramesForDistributing_ <= 0) {
+		// This logic is used if animation distribution is not active (see getFrameToUseForRendering).
 		// In this case the variables calculated with animation distribution are not initialized and we have to calculate them on the fly with the given information.
-		ticksSinceSequenceStarted = static_cast<float>((CurrentFrame * TicksPerFrame) + TickCounterOfCurrentFrame);
-		tickModifier = 1.0F / static_cast<float>(TicksPerFrame);
+		ticksSinceSequenceStarted = static_cast<float>((currentFrame_ * ticksPerFrame_) + tickCounterOfCurrentFrame_);
+		tickModifier = 1.0F / static_cast<float>(ticksPerFrame_);
 	}
 
-	float totalTicksForCurrentAnimationSequence = GetProgressToNextGameTick() + ticksSinceSequenceStarted;
+	float totalTicksForCurrentAnimationSequence = getProgressToNextGameTick() + ticksSinceSequenceStarted;
 	float progressInAnimationFrames = totalTicksForCurrentAnimationSequence * tickModifier;
-	float animationFraction = progressInAnimationFrames / static_cast<float>(NumberOfFrames);
+	float animationFraction = progressInAnimationFrames / static_cast<float>(numberOfFrames_);
 	return animationFraction;
 }
 
-void AnimationInfo::SetNewAnimation(std::optional<CelSprite> celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/, float previewShownGameTickFragments /*= 0.F*/)
+void AnimationInfo::setNewAnimation(std::optional<CelSprite> celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/, float previewShownGameTickFragments /*= 0.F*/)
 {
-	if ((flags & AnimationDistributionFlags::RepeatedAction) == AnimationDistributionFlags::RepeatedAction && distributeFramesBeforeFrame != 0 && NumberOfFrames == numberOfFrames && CurrentFrame + 1 >= distributeFramesBeforeFrame && CurrentFrame != NumberOfFrames - 1) {
+	if ((flags & AnimationDistributionFlags::RepeatedAction) == AnimationDistributionFlags::RepeatedAction && distributeFramesBeforeFrame != 0 && numberOfFrames_ == numberOfFrames && currentFrame_ + 1 >= distributeFramesBeforeFrame && currentFrame_ != numberOfFrames_ - 1) {
 		// We showed the same Animation (for example a melee attack) before but truncated the Animation.
 		// So now we should add them back to the new Animation. This increases the speed of the current Animation but the game logic/ticks isn't affected.
-		SkippedFramesFromPreviousAnimation = NumberOfFrames - CurrentFrame - 1;
+		skippedFramesFromPreviousAnimation_ = numberOfFrames_ - currentFrame_ - 1;
 	} else {
-		SkippedFramesFromPreviousAnimation = 0;
+		skippedFramesFromPreviousAnimation_ = 0;
 	}
 
 	if (ticksPerFrame <= 0) {
-		Log("SetNewAnimation: Invalid ticksPerFrame {}", ticksPerFrame);
+		Log("setNewAnimation: Invalid ticksPerFrame {}", ticksPerFrame);
 		ticksPerFrame = 1;
 	}
 
-	this->celSprite = celSprite;
-	NumberOfFrames = numberOfFrames;
-	CurrentFrame = numSkippedFrames;
-	TickCounterOfCurrentFrame = 0;
-	TicksPerFrame = ticksPerFrame;
-	TicksSinceSequenceStarted = 0.F;
-	RelevantFramesForDistributing = 0;
-	TickModifier = 0.0F;
-	IsPetrified = false;
+	celSprite_ = celSprite;
+	numberOfFrames_ = numberOfFrames;
+	currentFrame_ = numSkippedFrames;
+	tickCounterOfCurrentFrame_ = 0;
+	ticksPerFrame_ = ticksPerFrame;
+	ticksSinceSequenceStarted_ = 0.F;
+	relevantFramesForDistributing_ = 0;
+	tickModifier_ = 0.0F;
+	isPetrified_ = false;
 
 	if (numSkippedFrames != 0 || flags != AnimationDistributionFlags::None) {
 		// Animation Frames that will be adjusted for the skipped Frames/game ticks
@@ -114,27 +114,27 @@ void AnimationInfo::SetNewAnimation(std::optional<CelSprite> celSprite, int numb
 		int relevantAnimationTicksForDistribution = relevantAnimationFramesForDistributing * ticksPerFrame;
 
 		// How many game ticks will the Animation be really shown (skipped Frames and game ticks removed)
-		float relevantAnimationTicksWithSkipping = relevantAnimationTicksForDistribution - (numSkippedFrames * ticksPerFrame);
+		auto relevantAnimationTicksWithSkipping = static_cast<float>(relevantAnimationTicksForDistribution - (numSkippedFrames * ticksPerFrame));
 
 		if ((flags & AnimationDistributionFlags::ProcessAnimationPending) == AnimationDistributionFlags::ProcessAnimationPending) {
-			// If ProcessAnimation will be called after SetNewAnimation (in same game tick as SetNewAnimation), we increment the Animation-Counter.
-			// If no delay is specified, this will result in complete skipped frame (see ProcessAnimation).
+			// If processAnimation will be called after setNewAnimation (in same game tick as setNewAnimation), we increment the Animation-Counter.
+			// If no delay is specified, this will result in complete skipped frame (see processAnimation).
 			// But if we have a delay specified, this would only result in a reduced time the first frame is shown (one skipped delay).
 			// Because of that, we only the remove one game tick from the time the Animation is shown
 			relevantAnimationTicksWithSkipping -= 1.F;
 			// The Animation Distribution Logic needs to account how many game ticks passed since the Animation started.
-			// Because ProcessAnimation will increase this later (in same game tick as SetNewAnimation), we correct this upfront.
-			// This also means Rendering should never hapen with TicksSinceSequenceStarted < 0.
-			TicksSinceSequenceStarted = -1.F;
+			// Because processAnimation will increase this later (in same game tick as setNewAnimation), we correct this upfront.
+			// This also means Rendering should never hapen with ticksSinceSequenceStarted_ < 0.
+			ticksSinceSequenceStarted_ = -1.F;
 		}
 
 		// The preview animation was shown some times (less then one game tick)
 		// So we overall have a longer time the animation is shown
-		TicksSinceSequenceStarted += previewShownGameTickFragments;
+		ticksSinceSequenceStarted_ += previewShownGameTickFragments;
 		relevantAnimationTicksWithSkipping += previewShownGameTickFragments;
 
 		if ((flags & AnimationDistributionFlags::SkipsDelayOfLastFrame) == AnimationDistributionFlags::SkipsDelayOfLastFrame) {
-			// The logic for player/monster/... (not ProcessAnimation) only checks the frame not the delay.
+			// The logic for player/monster/... (not processAnimation) only checks the frame not the delay.
 			// That means if a delay is specified, the last-frame is shown less than the other frames
 			// Example:
 			// If we have a animation with 3 frames and with a delay of 1 (ticksPerFrame = 2).
@@ -150,11 +150,11 @@ void AnimationInfo::SetNewAnimation(std::optional<CelSprite> celSprite, int numb
 			// in game tick 5 ProcessPlayer sees Frame = 3 and stops the animation.
 			// But Frame 3 is only shown 1 game tick and all other Frames are shown 2 game ticks.
 			// Thats why we need to remove the Delay of the last Frame from the time (game ticks) the Animation is shown
-			relevantAnimationTicksWithSkipping -= (ticksPerFrame - 1);
+			relevantAnimationTicksWithSkipping -= static_cast<float>(ticksPerFrame - 1);
 		}
 
 		// The truncated Frames from previous Animation will also be shown, so we also have to distribute them for the given time (game ticks)
-		relevantAnimationTicksForDistribution += (SkippedFramesFromPreviousAnimation * ticksPerFrame);
+		relevantAnimationTicksForDistribution += (skippedFramesFromPreviousAnimation_ * ticksPerFrame);
 
 		// if we skipped Frames we need to expand the game ticks to make one game tick for this Animation "faster"
 		float tickModifier = static_cast<float>(relevantAnimationTicksForDistribution) / relevantAnimationTicksWithSkipping;
@@ -162,56 +162,56 @@ void AnimationInfo::SetNewAnimation(std::optional<CelSprite> celSprite, int numb
 		// tickModifier specifies the Animation fraction per game tick, so we have to remove the delay from the variable
 		tickModifier /= static_cast<float>(ticksPerFrame);
 
-		RelevantFramesForDistributing = relevantAnimationFramesForDistributing;
-		TickModifier = tickModifier;
+		relevantFramesForDistributing_ = relevantAnimationFramesForDistributing;
+		tickModifier_ = tickModifier;
 	}
 }
 
-void AnimationInfo::ChangeAnimationData(std::optional<CelSprite> celSprite, int numberOfFrames, int ticksPerFrame)
+void AnimationInfo::changeAnimationData(std::optional<CelSprite> celSprite, int numberOfFrames, int ticksPerFrame)
 {
-	if (numberOfFrames != NumberOfFrames || ticksPerFrame != TicksPerFrame) {
-		// Ensure that the CurrentFrame is still valid and that we disable ADL cause the calculcated values (for example TickModifier) could be wrong
+	if (numberOfFrames != numberOfFrames_ || ticksPerFrame != ticksPerFrame_) {
+		// Ensure that the currentFrame_ is still valid and that we disable ADL cause the calculcated values (for example tickModifier_) could be wrong
 		if (numberOfFrames >= 1)
-			CurrentFrame = clamp(CurrentFrame, 0, numberOfFrames - 1);
+			currentFrame_ = clamp(currentFrame_, 0, numberOfFrames - 1);
 		else
-			CurrentFrame = -1;
+			currentFrame_ = -1;
 
-		NumberOfFrames = numberOfFrames;
-		TicksPerFrame = ticksPerFrame;
-		TicksSinceSequenceStarted = 0.F;
-		RelevantFramesForDistributing = 0;
-		TickModifier = 0.0F;
+		numberOfFrames_ = numberOfFrames;
+		ticksPerFrame_ = ticksPerFrame;
+		ticksSinceSequenceStarted_ = 0.F;
+		relevantFramesForDistributing_ = 0;
+		tickModifier_ = 0.0F;
 	}
-	this->celSprite = celSprite;
+	celSprite_ = celSprite;
 }
 
-void AnimationInfo::ProcessAnimation(bool reverseAnimation /*= false*/, bool dontProgressAnimation /*= false*/)
+void AnimationInfo::processAnimation(bool reverseAnimation /*= false*/, bool dontProgressAnimation /*= false*/)
 {
-	TickCounterOfCurrentFrame++;
+	tickCounterOfCurrentFrame_++;
 	if (dontProgressAnimation)
 		return;
-	TicksSinceSequenceStarted++;
-	if (TickCounterOfCurrentFrame >= TicksPerFrame) {
-		TickCounterOfCurrentFrame = 0;
+	ticksSinceSequenceStarted_++;
+	if (tickCounterOfCurrentFrame_ >= ticksPerFrame_) {
+		tickCounterOfCurrentFrame_ = 0;
 		if (reverseAnimation) {
-			--CurrentFrame;
-			if (CurrentFrame == -1) {
-				CurrentFrame = NumberOfFrames - 1;
-				TicksSinceSequenceStarted = 0.F;
+			--currentFrame_;
+			if (currentFrame_ == -1) {
+				currentFrame_ = numberOfFrames_ - 1;
+				ticksSinceSequenceStarted_ = 0.F;
 			}
 		} else {
-			++CurrentFrame;
-			if (CurrentFrame >= NumberOfFrames) {
-				CurrentFrame = 0;
-				TicksSinceSequenceStarted = 0.F;
+			++currentFrame_;
+			if (currentFrame_ >= numberOfFrames_) {
+				currentFrame_ = 0;
+				ticksSinceSequenceStarted_ = 0.F;
 			}
 		}
 	}
 }
 
-float AnimationInfo::GetProgressToNextGameTick() const
+float AnimationInfo::getProgressToNextGameTick() const
 {
-	if (IsPetrified)
+	if (isPetrified_)
 		return 0.0F;
 	return gfProgressToNextGameTick;
 }

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -363,7 +363,7 @@ void DrawMissile(const Surface &out, Point tilePosition, Point targetBufferPosit
  */
 void DrawMonster(const Surface &out, Point tilePosition, Point targetBufferPosition, const Monster &monster)
 {
-	if (!monster.AnimInfo.celSprite) {
+	if (!monster.AnimInfo.getCelSprite()) {
 		Log("Draw Monster \"{}\": NULL Cel Buffer", monster.mName);
 		return;
 	}
@@ -429,8 +429,8 @@ void DrawMonster(const Surface &out, Point tilePosition, Point targetBufferPosit
 		}
 	};
 
-	int nCel = monster.AnimInfo.GetFrameToUseForRendering();
-	const uint32_t frames = LoadLE32(monster.AnimInfo.celSprite->Data());
+	int nCel = monster.AnimInfo.getFrameToUseForRendering();
+	const uint32_t frames = LoadLE32(monster.AnimInfo.getCelSprite()->Data());
 	if (nCel < 0 || frames > 50 || nCel >= static_cast<int>(frames)) {
 		Log(
 		    "Draw Monster \"{}\" {}: facing {}, frame {} of {}",
@@ -442,7 +442,7 @@ void DrawMonster(const Surface &out, Point tilePosition, Point targetBufferPosit
 		return;
 	}
 
-	const auto &cel = *monster.AnimInfo.celSprite;
+	const auto &cel = *monster.AnimInfo.getCelSprite();
 
 	if (!IsTileLit(tilePosition)) {
 		Cl2DrawTRN(out, targetBufferPosition.x, targetBufferPosition.y, cel, nCel, GetInfravisionTRN());
@@ -515,8 +515,8 @@ void DrawPlayer(const Surface &out, int pnum, Point tilePosition, Point targetBu
 
 	Player &player = Players[pnum];
 
-	std::optional<CelSprite> sprite = player.AnimInfo.celSprite;
-	int nCel = player.AnimInfo.GetFrameToUseForRendering();
+	std::optional<CelSprite> sprite = player.AnimInfo.getCelSprite();
+	int nCel = player.AnimInfo.getFrameToUseForRendering();
 
 	if (player.previewCelSprite) {
 		sprite = player.previewCelSprite;
@@ -719,13 +719,13 @@ void DrawItem(const Surface &out, Point tilePosition, Point targetBufferPosition
 	if (item._iPostDraw == pre)
 		return;
 
-	std::optional<CelSprite> cel = item.AnimInfo.celSprite;
+	std::optional<CelSprite> cel = item.AnimInfo.getCelSprite();
 	if (!cel) {
 		Log("Draw Item \"{}\" 1: NULL CelSprite", item._iIName);
 		return;
 	}
 
-	int nCel = item.AnimInfo.GetFrameToUseForRendering();
+	int nCel = item.AnimInfo.getFrameToUseForRendering();
 	const uint32_t frames = LoadLE32(cel->Data());
 	if (nCel < 0 || frames > 50 || nCel >= static_cast<int>(frames)) {
 		Log("Draw \"{}\" Item 1: frame {} of {}, item type=={}", item._iIName, nCel, frames, ItemTypeToString(item._itype));
@@ -738,7 +738,7 @@ void DrawItem(const Surface &out, Point tilePosition, Point targetBufferPosition
 		CelBlitOutlineTo(out, GetOutlineColor(item, false), position, *cel, nCel);
 	}
 	CelClippedDrawLightTo(out, position, *cel, nCel);
-	if (item.AnimInfo.CurrentFrame == item.AnimInfo.NumberOfFrames - 1 || item._iCurs == ICURS_MAGIC_ROCK)
+	if (item.AnimInfo.isLastFrame() || item._iCurs == ICURS_MAGIC_ROCK)
 		AddItemToLabelQueue(bItem - 1, px, targetBufferPosition.y);
 }
 
@@ -783,7 +783,7 @@ void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBuffe
 		return;
 	}
 
-	CelSprite cel = *monster.AnimInfo.celSprite;
+	CelSprite cel = *monster.AnimInfo.getCelSprite();
 
 	Displacement offset = monster.position.offset;
 	if (monster.IsWalking()) {
@@ -792,7 +792,7 @@ void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBuffe
 
 	const Point monsterRenderPosition { targetBufferPosition + offset - Displacement { CalculateWidth2(cel.Width()), 0 } };
 	if (mi == pcursmonst) {
-		Cl2DrawOutline(out, 233, monsterRenderPosition.x, monsterRenderPosition.y, cel, monster.AnimInfo.GetFrameToUseForRendering());
+		Cl2DrawOutline(out, 233, monsterRenderPosition.x, monsterRenderPosition.y, cel, monster.AnimInfo.getFrameToUseForRendering());
 	}
 	DrawMonster(out, tilePosition, monsterRenderPosition, monster);
 }
@@ -1425,7 +1425,7 @@ Displacement GetOffsetForWalking(const AnimationInfo &animationInfo, const Direc
 	constexpr Displacement MovingOffset[8]   = { {   0,  32 }, { -32,  16 }, { -64,   0 }, { -32, -16 }, {   0, -32 }, {  32, -16 },  {  64,   0 }, {  32,  16 } };
 	// clang-format on
 
-	float fAnimationProgress = animationInfo.GetAnimationProgress();
+	float fAnimationProgress = animationInfo.getAnimationProgress();
 	Displacement offset = MovingOffset[static_cast<size_t>(dir)];
 	offset *= fAnimationProgress;
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -445,7 +445,7 @@ void AddInitItems()
 
 		item._iCreateInfo = curlv | CF_PREGEN;
 		SetupItem(item);
-		item.AnimInfo.CurrentFrame = item.AnimInfo.NumberOfFrames - 1;
+		item.AnimInfo.setCurrentFrameAsLast();
 		item._iAnimFlag = false;
 		item._iSelFlag = 1;
 		DeltaAddItem(ii);
@@ -1647,7 +1647,7 @@ void SpawnRock()
 	SetupItem(item);
 	item._iSelFlag = 2;
 	item._iPostDraw = true;
-	item.AnimInfo.CurrentFrame = 10;
+	item.AnimInfo.setCurrentFrame(10);
 }
 
 void ItemDoppel()
@@ -2678,10 +2678,10 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 		player.previewCelSprite = std::nullopt;
 		if (player._pmode == PM_STAND) {
 			LoadPlrGFX(player, player_graphic::Stand);
-			player.AnimInfo.ChangeAnimationData(player.AnimationData[static_cast<size_t>(player_graphic::Stand)].GetCelSpritesForDirection(player._pdir), player._pNFrames, 4);
+			player.AnimInfo.changeAnimationData(player.AnimationData[static_cast<size_t>(player_graphic::Stand)].GetCelSpritesForDirection(player._pdir), player._pNFrames, 4);
 		} else {
 			LoadPlrGFX(player, player_graphic::Walk);
-			player.AnimInfo.ChangeAnimationData(player.AnimationData[static_cast<size_t>(player_graphic::Walk)].GetCelSpritesForDirection(player._pdir), player._pWFrames, 1);
+			player.AnimInfo.changeAnimationData(player.AnimationData[static_cast<size_t>(player_graphic::Walk)].GetCelSpritesForDirection(player._pdir), player._pWFrames, 1);
 		}
 	} else {
 		player._pgfxnum = gfxNum;
@@ -3328,7 +3328,7 @@ void SpawnQuestItem(int itemid, Point position, int randarea, int selflag)
 	item._iPostDraw = true;
 	if (selflag != 0) {
 		item._iSelFlag = selflag;
-		item.AnimInfo.CurrentFrame = item.AnimInfo.NumberOfFrames - 1;
+		item.AnimInfo.setCurrentFrameAsLast();
 		item._iAnimFlag = false;
 	}
 }
@@ -3410,18 +3410,18 @@ void ProcessItems()
 		auto &item = Items[ii];
 		if (!item._iAnimFlag)
 			continue;
-		item.AnimInfo.ProcessAnimation();
+		item.AnimInfo.processAnimation();
 		if (item._iCurs == ICURS_MAGIC_ROCK) {
-			if (item._iSelFlag == 1 && item.AnimInfo.CurrentFrame == 10)
-				item.AnimInfo.CurrentFrame = 0;
-			if (item._iSelFlag == 2 && item.AnimInfo.CurrentFrame == 20)
-				item.AnimInfo.CurrentFrame = 10;
+			if (item._iSelFlag == 1 && item.AnimInfo.getCurrentFrame() == 10)
+				item.AnimInfo.setCurrentFrame(0);
+			if (item._iSelFlag == 2 && item.AnimInfo.getCurrentFrame() == 20)
+				item.AnimInfo.setCurrentFrame(10);
 		} else {
-			if (item.AnimInfo.CurrentFrame == (item.AnimInfo.NumberOfFrames - 1) / 2)
+			if (item.AnimInfo.getCurrentFrame() == (item.AnimInfo.getNumberOfFrames() - 1) / 2)
 				PlaySfxLoc(ItemDropSnds[ItemCAnimTbl[item._iCurs]], item.position);
 
-			if (item.AnimInfo.CurrentFrame >= item.AnimInfo.NumberOfFrames - 1) {
-				item.AnimInfo.CurrentFrame = item.AnimInfo.NumberOfFrames - 1;
+			if (item.AnimInfo.isOver()) {
+				item.AnimInfo.setCurrentFrameAsLast();
 				item._iAnimFlag = false;
 				item._iSelFlag = 1;
 			}
@@ -3439,7 +3439,7 @@ void FreeItemGFX()
 
 void GetItemFrm(Item &item)
 {
-	item.AnimInfo.celSprite.emplace(*itemanims[ItemCAnimTbl[item._iCurs]]);
+	item.AnimInfo.emplaceCelSprite(*itemanims[ItemCAnimTbl[item._iCurs]]);
 }
 
 void GetItemStr(Item &item)
@@ -4336,7 +4336,7 @@ void MakeGoldStack(Item &goldItem, int value)
 int ItemNoFlippy()
 {
 	int r = ActiveItems[ActiveItemCount - 1];
-	Items[r].AnimInfo.CurrentFrame = Items[r].AnimInfo.NumberOfFrames - 1;
+	Items[r].AnimInfo.setCurrentFrameAsLast();
 	Items[r]._iAnimFlag = false;
 	Items[r]._iSelFlag = 1;
 
@@ -4584,16 +4584,16 @@ void Item::setNewAnimation(bool showAnimation)
 	int numberOfFrames = ItemAnimLs[it];
 	auto celSprite = itemanims[it] ? std::optional<CelSprite> { *itemanims[it] } : std::nullopt;
 	if (_iCurs != ICURS_MAGIC_ROCK)
-		AnimInfo.SetNewAnimation(celSprite, numberOfFrames, 1, AnimationDistributionFlags::ProcessAnimationPending, 0, numberOfFrames);
+		AnimInfo.setNewAnimation(celSprite, numberOfFrames, 1, AnimationDistributionFlags::ProcessAnimationPending, 0, numberOfFrames);
 	else
-		AnimInfo.SetNewAnimation(celSprite, numberOfFrames, 1);
+		AnimInfo.setNewAnimation(celSprite, numberOfFrames, 1);
 	_iPostDraw = false;
 	_iRequest = false;
 	if (showAnimation) {
 		_iAnimFlag = true;
 		_iSelFlag = 0;
 	} else {
-		AnimInfo.CurrentFrame = AnimInfo.NumberOfFrames - 1;
+		AnimInfo.setCurrentFrameAsLast();
 		_iAnimFlag = false;
 		_iSelFlag = 1;
 	}

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -230,8 +230,8 @@ void LoadItemData(LoadHelper &file, Item &item)
 	item._iAnimFlag = file.NextBool32();
 	file.Skip(4); // Skip pointer _iAnimData
 	item.AnimInfo = {};
-	item.AnimInfo.NumberOfFrames = file.NextLE<int32_t>();
-	item.AnimInfo.CurrentFrame = file.NextLE<int32_t>() - 1;
+	item.AnimInfo.setNumberOfFrames(file.NextLE<int32_t>());
+	item.AnimInfo.setCurrentFrame(file.NextLE<int32_t>() - 1);
 	file.Skip(8); // Skip _iAnimWidth and _iAnimWidth2
 	file.Skip(4); // Unused since 1.02
 	item._iSelFlag = file.NextLE<uint8_t>();
@@ -342,10 +342,10 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	player._pgfxnum = file.NextLE<int32_t>();
 	file.Skip<uint32_t>(); // Skip pointer pData
 	player.AnimInfo = {};
-	player.AnimInfo.TicksPerFrame = file.NextLE<int32_t>() + 1;
-	player.AnimInfo.TickCounterOfCurrentFrame = file.NextLE<int32_t>();
-	player.AnimInfo.NumberOfFrames = file.NextLE<int32_t>();
-	player.AnimInfo.CurrentFrame = file.NextLE<int32_t>() - 1;
+	player.AnimInfo.setTicksPerFrame(file.NextLE<int32_t>() + 1);
+	player.AnimInfo.setTickCounterOfCurrentFrame(file.NextLE<int32_t>());
+	player.AnimInfo.setNumberOfFrames(file.NextLE<int32_t>());
+	player.AnimInfo.setCurrentFrame(file.NextLE<int32_t>() - 1);
 	file.Skip<uint32_t>(3); // Skip _pAnimWidth, _pAnimWidth2, _peflag
 	player._plid = file.NextLE<int32_t>();
 	player._pvid = file.NextLE<int32_t>();
@@ -467,6 +467,11 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	player._pBFrames = file.NextLE<int32_t>();
 	file.Skip<uint32_t>(); // skip _pBWidth
 
+	if (player._pmode == PM_SPELL)
+		player.AnimInfo.setTriggerFrame(player._pSFNum - 1);
+	if (player._pmode == PM_ATTACK || player._pmode == PM_RATTACK)
+		player.AnimInfo.setTriggerFrame(player._pAFNum - 1);
+
 	for (Item &item : player.InvBody)
 		LoadItemData(file, item);
 
@@ -583,10 +588,10 @@ void LoadMonster(LoadHelper *file, Monster &monster)
 
 	file->Skip(4); // Skip pointer _mAnimData
 	monster.AnimInfo = {};
-	monster.AnimInfo.TicksPerFrame = file->NextLE<int32_t>();
-	monster.AnimInfo.TickCounterOfCurrentFrame = file->NextLE<int32_t>();
-	monster.AnimInfo.NumberOfFrames = file->NextLE<int32_t>();
-	monster.AnimInfo.CurrentFrame = file->NextLE<int32_t>() - 1;
+	monster.AnimInfo.setTicksPerFrame(file->NextLE<int32_t>());
+	monster.AnimInfo.setTickCounterOfCurrentFrame(file->NextLE<int32_t>());
+	monster.AnimInfo.setNumberOfFrames(file->NextLE<int32_t>());
+	monster.AnimInfo.setCurrentFrame(file->NextLE<int32_t>() - 1);
 	file->Skip(4); // Skip _meflag
 	monster._mDelFlag = file->NextBool32();
 	monster._mVar1 = file->NextLE<int32_t>();
@@ -990,8 +995,8 @@ void SaveItem(SaveHelper &file, const Item &item)
 	file.WriteLE<int32_t>(item.position.y);
 	file.WriteLE<uint32_t>(item._iAnimFlag ? 1 : 0);
 	file.Skip(4); // Skip pointer _iAnimData
-	file.WriteLE<int32_t>(item.AnimInfo.NumberOfFrames);
-	file.WriteLE<int32_t>(item.AnimInfo.CurrentFrame + 1);
+	file.WriteLE<int32_t>(item.AnimInfo.getNumberOfFrames());
+	file.WriteLE<int32_t>(item.AnimInfo.getCurrentFrame() + 1);
 	// write _iAnimWidth for vanilla compatibility
 	file.WriteLE<int32_t>(ItemAnimWidth);
 	// write _iAnimWidth2 for vanilla compatibility
@@ -1097,12 +1102,12 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.Skip(4); // Unused
 	file.WriteLE<int32_t>(player._pgfxnum);
 	file.Skip(4); // Skip pointer _pAnimData
-	file.WriteLE<int32_t>(std::max(0, player.AnimInfo.TicksPerFrame - 1));
-	file.WriteLE<int32_t>(player.AnimInfo.TickCounterOfCurrentFrame);
-	file.WriteLE<int32_t>(player.AnimInfo.NumberOfFrames);
-	file.WriteLE<int32_t>(player.AnimInfo.CurrentFrame + 1);
+	file.WriteLE<int32_t>(std::max(0, player.AnimInfo.getTicksPerFrame() - 1));
+	file.WriteLE<int32_t>(player.AnimInfo.getTickCounterOfCurrentFrame());
+	file.WriteLE<int32_t>(player.AnimInfo.getNumberOfFrames());
+	file.WriteLE<int32_t>(player.AnimInfo.getCurrentFrame() + 1);
 	// write _pAnimWidth for vanilla compatibility
-	int animWidth = player.AnimInfo.celSprite ? player.AnimInfo.celSprite->Width() : 96;
+	int animWidth = player.AnimInfo.getCelSprite() ? player.AnimInfo.getCelSprite()->Width() : 96;
 	file.WriteLE<int32_t>(animWidth);
 	// write _pAnimWidth2 for vanilla compatibility
 	file.WriteLE<int32_t>(CalculateWidth2(animWidth));
@@ -1325,10 +1330,10 @@ void SaveMonster(SaveHelper *file, Monster &monster)
 	file->Skip(2); // Unused
 
 	file->Skip(4); // Skip pointer _mAnimData
-	file->WriteLE<int32_t>(monster.AnimInfo.TicksPerFrame);
-	file->WriteLE<int32_t>(monster.AnimInfo.TickCounterOfCurrentFrame);
-	file->WriteLE<int32_t>(monster.AnimInfo.NumberOfFrames);
-	file->WriteLE<int32_t>(monster.AnimInfo.CurrentFrame + 1);
+	file->WriteLE<int32_t>(monster.AnimInfo.getTicksPerFrame());
+	file->WriteLE<int32_t>(monster.AnimInfo.getTickCounterOfCurrentFrame());
+	file->WriteLE<int32_t>(monster.AnimInfo.getNumberOfFrames());
+	file->WriteLE<int32_t>(monster.AnimInfo.getCurrentFrame() + 1);
 	file->Skip<uint32_t>(); // Skip _meflag
 	file->WriteLE<uint32_t>(monster._mDelFlag ? 1 : 0);
 	file->WriteLE<int32_t>(monster._mVar1);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3479,7 +3479,7 @@ void MI_Stone(Missile &missile)
 		missile._miDelFlag = true;
 		if (monster._mhitpoints > 0) {
 			monster._mmode = static_cast<MonsterMode>(missile.var1);
-			monster.AnimInfo.IsPetrified = false;
+			monster.AnimInfo.unpetrify();
 		} else {
 			AddCorpse(monster.position.tile, stonendx, monster._mdir);
 		}

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -237,7 +237,7 @@ struct Monster { // note: missing field _mAFNum
 		auto &animationData = this->MType->getAnimData(graphic);
 
 		// Passing the Frames and rate properties here is only relevant when initialising a monster, but doesn't cause any harm when switching animations.
-		this->AnimInfo.ChangeAnimationData(animationData.getCelSpritesForDirection(direction), animationData.frames, animationData.rate);
+		this->AnimInfo.changeAnimationData(animationData.getCelSpritesForDirection(direction), animationData.frames, animationData.rate);
 	}
 
 	/**

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1838,7 +1838,7 @@ DWORD OnPlayerJoinLevel(const TCmd *pCmd, int pnum)
 				player._pgfxnum &= ~0xF;
 				player._pmode = PM_DEATH;
 				NewPlrAnim(player, player_graphic::Death, Direction::South, player._pDFrames, 1);
-				player.AnimInfo.CurrentFrame = player.AnimInfo.NumberOfFrames - 2;
+				player.AnimInfo.setCurrentFrame(player.AnimInfo.getNumberOfFrames() - 2);
 				dFlags[player.position.tile.x][player.position.tile.y] |= DungeonFlag::DeadPlayer;
 			}
 

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -845,7 +845,7 @@ void recv_plrinfo(int pnum, const TCmdPlrInfoHdr &header, bool recv)
 	player._pgfxnum &= ~0xF;
 	player._pmode = PM_DEATH;
 	NewPlrAnim(player, player_graphic::Death, Direction::South, player._pDFrames, 1);
-	player.AnimInfo.CurrentFrame = player.AnimInfo.NumberOfFrames - 2;
+	player.AnimInfo.setCurrentFrame(player.AnimInfo.getNumberOfFrames() - 2);
 	dFlags[player.position.tile.x][player.position.tile.y] |= DungeonFlag::DeadPlayer;
 }
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -460,6 +460,7 @@ void StartAttack(int pnum, Direction d)
 	if (player._pmode == PM_ATTACK)
 		animationFlags = static_cast<AnimationDistributionFlags>(animationFlags | AnimationDistributionFlags::RepeatedAction);
 	NewPlrAnim(player, player_graphic::Attack, d, player._pAFrames, 1, animationFlags, skippedAnimationFrames, player._pAFNum);
+	player.AnimInfo.setTriggerFrame(player._pAFNum - 1);
 	player._pmode = PM_ATTACK;
 	FixPlayerLocation(player, d);
 	SetPlayerOld(player);
@@ -488,6 +489,7 @@ void StartRangeAttack(int pnum, Direction d, WorldTileCoord cx, WorldTileCoord c
 	if (player._pmode == PM_RATTACK)
 		animationFlags = static_cast<AnimationDistributionFlags>(animationFlags | AnimationDistributionFlags::RepeatedAction);
 	NewPlrAnim(player, player_graphic::Attack, d, player._pAFrames, 1, animationFlags, skippedAnimationFrames, player._pAFNum);
+	player.AnimInfo.setTriggerFrame(player._pAFNum - 1);
 
 	player._pmode = PM_RATTACK;
 	FixPlayerLocation(player, d);
@@ -522,6 +524,7 @@ void StartSpell(int pnum, Direction d, WorldTileCoord cx, WorldTileCoord cy)
 	if (player._pmode == PM_SPELL)
 		animationFlags = static_cast<AnimationDistributionFlags>(animationFlags | AnimationDistributionFlags::RepeatedAction);
 	NewPlrAnim(player, GetPlayerGraphicForSpell(player._pSpell), d, player._pSFrames, 1, animationFlags, 0, player._pSFNum);
+	player.AnimInfo.setTriggerFrame(player._pSFNum - 1);
 
 	PlaySfxLoc(spelldata[player._pSpell].sSFX, player.position.tile);
 
@@ -658,14 +661,14 @@ bool DoWalk(int pnum, int variant)
 
 	// Play walking sound effect on certain animation frames
 	if (*sgOptions.Audio.walkingSound && (leveltype != DTYPE_TOWN || sgGameInitInfo.bRunInTown == 0)) {
-		if (player.AnimInfo.CurrentFrame == 0
-		    || player.AnimInfo.CurrentFrame == 4) {
+		if (player.AnimInfo.getCurrentFrame() == 0
+		    || player.AnimInfo.getCurrentFrame() == 4) {
 			PlaySfxLoc(PS_WALK1, player.position.tile);
 		}
 	}
 
 	// Check if we reached new tile
-	if (player.AnimInfo.CurrentFrame >= player._pWFrames - 1) {
+	if (player.AnimInfo.isOver()) {
 
 		// Update the player's tile position
 		switch (variant) {
@@ -1072,13 +1075,13 @@ bool DoAttack(int pnum)
 	}
 	Player &player = Players[pnum];
 
-	if (player.AnimInfo.CurrentFrame == player._pAFNum - 2) {
+	if (player.AnimInfo.getCurrentFrame() == player.AnimInfo.getTriggerFrame() - 1) {
 		PlaySfxLoc(PS_SWING, player.position.tile);
 	}
 
 	bool didhit = false;
 
-	if (player.AnimInfo.CurrentFrame == player._pAFNum - 1) {
+	if (player.AnimInfo.isTriggerFrame()) {
 		Point position = player.position.tile + player._pdir;
 		int dx = position.x;
 		int dy = position.y;
@@ -1165,7 +1168,7 @@ bool DoAttack(int pnum)
 		}
 	}
 
-	if (player.AnimInfo.CurrentFrame == player._pAFrames - 1) {
+	if (player.AnimInfo.isLastFrame()) {
 		StartStand(pnum, player._pdir);
 		ClearStateVariables(player);
 		return true;
@@ -1182,11 +1185,12 @@ bool DoRangeAttack(int pnum)
 	Player &player = Players[pnum];
 
 	int arrows = 0;
-	if (player.AnimInfo.CurrentFrame == player._pAFNum - 1) {
+	if (player.AnimInfo.isTriggerFrame()) {
 		arrows = 1;
 	}
 
-	if (HasAnyOf(player._pIFlags, ItemSpecialEffect::MultipleArrows) && player.AnimInfo.CurrentFrame == player._pAFNum + 1) {
+	if (HasAnyOf(player._pIFlags, ItemSpecialEffect::MultipleArrows)
+	    && player.AnimInfo.getCurrentFrame() == player.AnimInfo.getTriggerFrame() + 2) {
 		arrows = 2;
 	}
 
@@ -1237,7 +1241,7 @@ bool DoRangeAttack(int pnum)
 		}
 	}
 
-	if (player.AnimInfo.CurrentFrame >= player._pAFrames - 1) {
+	if (player.AnimInfo.isOver()) {
 		StartStand(pnum, player._pdir);
 		ClearStateVariables(player);
 		return true;
@@ -1281,7 +1285,7 @@ bool DoBlock(int pnum)
 	}
 	Player &player = Players[pnum];
 
-	if (player.AnimInfo.CurrentFrame >= player._pBFrames - 1) {
+	if (player.AnimInfo.isOver()) {
 		StartStand(pnum, player._pdir);
 		ClearStateVariables(player);
 
@@ -1342,7 +1346,7 @@ bool DoSpell(int pnum)
 	}
 	Player &player = Players[pnum];
 
-	if (player.AnimInfo.CurrentFrame == player._pSFNum) {
+	if (player.AnimInfo.getCurrentFrame() == player.AnimInfo.getTriggerFrame() + 1) {
 		CastSpell(
 		    pnum,
 		    player._pSpell,
@@ -1357,7 +1361,7 @@ bool DoSpell(int pnum)
 		}
 	}
 
-	if (player.AnimInfo.CurrentFrame >= player._pSFrames - 1) {
+	if (player.AnimInfo.isOver()) {
 		StartStand(pnum, player._pdir);
 		ClearStateVariables(player);
 		return true;
@@ -1373,7 +1377,7 @@ bool DoGotHit(int pnum)
 	}
 	Player &player = Players[pnum];
 
-	if (player.AnimInfo.CurrentFrame >= player._pHFrames - 1) {
+	if (player.AnimInfo.isOver()) {
 		StartStand(pnum, player._pdir);
 		ClearStateVariables(player);
 		if (GenerateRnd(4) != 0) {
@@ -1388,11 +1392,11 @@ bool DoGotHit(int pnum)
 
 bool DoDeath(Player &player)
 {
-	if (player.AnimInfo.CurrentFrame == player.AnimInfo.NumberOfFrames - 1) {
-		if (player.AnimInfo.TickCounterOfCurrentFrame == 0) {
-			player.AnimInfo.TicksPerFrame = 1000000000;
+	if (player.AnimInfo.isLastFrame()) {
+		if (player.AnimInfo.getTickCounterOfCurrentFrame() == 0) {
+			player.AnimInfo.setTicksPerFrame(1000000000);
 			dFlags[player.position.tile.x][player.position.tile.y] |= DungeonFlag::DeadPlayer;
-		} else if (&player == MyPlayer && player.AnimInfo.TickCounterOfCurrentFrame == 30) {
+		} else if (&player == MyPlayer && player.AnimInfo.getTickCounterOfCurrentFrame() == 30) {
 			MyPlayerIsDead = true;
 			if (!gbIsMultiplayer) {
 				gamemenu_on();
@@ -1670,7 +1674,7 @@ void CheckNewPath(int pnum, bool pmWillBeCalled)
 		return;
 	}
 
-	if (player._pmode == PM_ATTACK && player.AnimInfo.CurrentFrame >= player._pAFNum) {
+	if (player._pmode == PM_ATTACK && player.AnimInfo.isAfterTriggerFrame()) {
 		if (player.destAction == ACTION_ATTACK) {
 			d = GetDirection(player.position.future, { player.destParam1, player.destParam2 });
 			StartAttack(pnum, d);
@@ -1701,7 +1705,7 @@ void CheckNewPath(int pnum, bool pmWillBeCalled)
 		}
 	}
 
-	if (player._pmode == PM_RATTACK && player.AnimInfo.CurrentFrame >= player._pAFNum) {
+	if (player._pmode == PM_RATTACK && player.AnimInfo.isAfterTriggerFrame()) {
 		if (player.destAction == ACTION_RATTACK) {
 			d = GetDirection(player.position.tile, { player.destParam1, player.destParam2 });
 			StartRangeAttack(pnum, d, player.destParam1, player.destParam2);
@@ -1717,7 +1721,7 @@ void CheckNewPath(int pnum, bool pmWillBeCalled)
 		}
 	}
 
-	if (player._pmode == PM_SPELL && player.AnimInfo.CurrentFrame >= player._pSFNum) {
+	if (player._pmode == PM_SPELL && player.AnimInfo.isAfterTriggerFrame()) {
 		if (player.destAction == ACTION_SPELL) {
 			d = GetDirection(player.position.tile, { player.destParam1, player.destParam2 });
 			StartSpell(pnum, d, player.destParam1, player.destParam2);
@@ -2307,7 +2311,7 @@ void InitPlayerGFX(Player &player)
 
 void ResetPlayerGFX(Player &player)
 {
-	player.AnimInfo.celSprite = std::nullopt;
+	player.AnimInfo.setCelSprite(std::nullopt);
 	for (auto &animData : player.AnimationData) {
 		for (auto &celSprite : animData.CelSpritesForDirections)
 			celSprite = std::nullopt;
@@ -2324,7 +2328,7 @@ void NewPlrAnim(Player &player, player_graphic graphic, Direction dir, int numbe
 	float previewShownGameTickFragments = 0.F;
 	if (celSprite == player.previewCelSprite && !player.IsWalking())
 		previewShownGameTickFragments = clamp(1.F - player.progressToNextGameTickWhenPreviewWasSet, 0.F, 1.F);
-	player.AnimInfo.SetNewAnimation(celSprite, numberOfFrames, delayLen, flags, numSkippedFrames, distributeFramesBeforeFrame, previewShownGameTickFragments);
+	player.AnimInfo.setNewAnimation(celSprite, numberOfFrames, delayLen, flags, numSkippedFrames, distributeFramesBeforeFrame, previewShownGameTickFragments);
 }
 
 void SetPlrAnims(Player &player)
@@ -2740,12 +2744,12 @@ void InitPlayer(Player &player, bool firstTime)
 		if (player._pHitPoints >> 6 > 0) {
 			player._pmode = PM_STAND;
 			NewPlrAnim(player, player_graphic::Stand, Direction::South, player._pNFrames, 4);
-			player.AnimInfo.CurrentFrame = GenerateRnd(player._pNFrames - 1);
-			player.AnimInfo.TickCounterOfCurrentFrame = GenerateRnd(3);
+			player.AnimInfo.setCurrentFrame(GenerateRnd(player._pNFrames - 1));
+			player.AnimInfo.setTickCounterOfCurrentFrame(GenerateRnd(3));
 		} else {
 			player._pmode = PM_DEATH;
 			NewPlrAnim(player, player_graphic::Death, Direction::South, player._pDFrames, 2);
-			player.AnimInfo.CurrentFrame = player.AnimInfo.NumberOfFrames - 2;
+			player.AnimInfo.setCurrentFrame(player.AnimInfo.getNumberOfFrames() - 2);
 		}
 
 		player._pdir = Direction::South;
@@ -3371,7 +3375,7 @@ void ProcessPlayers()
 			} while (tplayer);
 
 			player.previewCelSprite = std::nullopt;
-			player.AnimInfo.ProcessAnimation();
+			player.AnimInfo.processAnimation();
 		}
 	}
 }
@@ -3587,7 +3591,7 @@ void SyncPlrAnim(Player &player)
 		app_fatal("SyncPlrAnim");
 	}
 
-	player.AnimInfo.celSprite = player.AnimationData[static_cast<size_t>(graphic)].GetCelSpritesForDirection(player._pdir);
+	player.AnimInfo.setCelSprite(player.AnimationData[static_cast<size_t>(graphic)].GetCelSpritesForDirection(player._pdir));
 	// Ensure ScrollInfo is initialized correctly
 	ScrollViewPort(player, WalkSettings[static_cast<size_t>(player._pdir)].scrollDir);
 }

--- a/Source/player.h
+++ b/Source/player.h
@@ -686,17 +686,9 @@ struct Player {
 
 	bool CanChangeAction()
 	{
-		if (_pmode == PM_STAND)
-			return true;
-		if (_pmode == PM_ATTACK && AnimInfo.CurrentFrame >= _pAFNum)
-			return true;
-		if (_pmode == PM_RATTACK && AnimInfo.CurrentFrame >= _pAFNum)
-			return true;
-		if (_pmode == PM_SPELL && AnimInfo.CurrentFrame >= _pSFNum)
-			return true;
-		if (IsWalking() && AnimInfo.CurrentFrame == AnimInfo.NumberOfFrames - 1)
-			return true;
-		return false;
+		return (_pmode == PM_STAND
+		    || IsAnyOf(_pmode, PM_ATTACK, PM_RATTACK, PM_SPELL) && AnimInfo.isAfterTriggerFrame()
+		    || (IsWalking() && AnimInfo.isLastFrame()));
 	}
 
 	/**

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -80,7 +80,7 @@ void AddItemToLabelQueue(int id, int x, int y)
 	nameWidth += MarginX * 2;
 	int index = ItemCAnimTbl[item._iCurs];
 	if (!labelCenterOffsets[index]) {
-		std::pair<int, int> itemBounds = MeasureSolidHorizontalBounds(*item.AnimInfo.celSprite, item.AnimInfo.CurrentFrame);
+		std::pair<int, int> itemBounds = MeasureSolidHorizontalBounds(*item.AnimInfo.getCelSprite(), item.AnimInfo.getCurrentFrame());
 		labelCenterOffsets[index].emplace((itemBounds.first + itemBounds.second) / 2);
 	}
 

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -23,7 +23,7 @@ void RepeatWalk(Player &player)
 	if (!InDungeonBounds(cursPosition))
 		return;
 
-	if (player._pmode != PM_STAND && !(player.IsWalking() && player.AnimInfo.GetFrameToUseForRendering() > 6))
+	if (player._pmode != PM_STAND && !(player.IsWalking() && player.AnimInfo.getFrameToUseForRendering() > 6))
 		return;
 
 	const Point target = player.GetTargetPosition();

--- a/test/animationinfo_test.cpp
+++ b/test/animationinfo_test.cpp
@@ -20,7 +20,7 @@ struct TestData {
 };
 
 /**
- * @brief Represents a call to SetNewAnimation
+ * @brief Represents a call to setNewAnimation
  */
 struct SetNewAnimationData : public TestData {
 	SetNewAnimationData(int numberOfFrames, int delayLen, AnimationDistributionFlags params = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0)
@@ -45,7 +45,7 @@ struct SetNewAnimationData : public TestData {
 };
 
 /**
- * @brief Represents a GameTick, this includes skipping of Frames (for example because of Fastest Attack Modifier) and ProcessAnimation (which also updates Animation Frame/Count).
+ * @brief Represents a GameTick, this includes skipping of Frames (for example because of Fastest Attack Modifier) and processAnimation (which also updates Animation Frame/Count).
  */
 struct GameTickData : TestData {
 	int _ExpectedAnimationFrame;
@@ -99,23 +99,23 @@ void RunAnimationTest(const std::vector<TestData *> &vecTestData)
 		switch (x->type()) {
 		case TestDataType::SetNewAnimation: {
 			auto setNewAnimationData = static_cast<SetNewAnimationData *>(x);
-			animInfo.SetNewAnimation(std::nullopt, setNewAnimationData->_NumberOfFrames, setNewAnimationData->_DelayLen, setNewAnimationData->_Params, setNewAnimationData->_NumSkippedFrames, setNewAnimationData->_DistributeFramesBeforeFrame);
+			animInfo.setNewAnimation(std::nullopt, setNewAnimationData->_NumberOfFrames, setNewAnimationData->_DelayLen, setNewAnimationData->_Params, setNewAnimationData->_NumSkippedFrames, setNewAnimationData->_DistributeFramesBeforeFrame);
 		} break;
 		case TestDataType::GameTick: {
 			auto gameTickData = static_cast<GameTickData *>(x);
 			currentGameTick += 1;
-			animInfo.ProcessAnimation();
-			EXPECT_EQ(animInfo.CurrentFrame, gameTickData->_ExpectedAnimationFrame);
-			EXPECT_EQ(animInfo.TickCounterOfCurrentFrame, gameTickData->_ExpectedAnimationCnt);
+			animInfo.processAnimation();
+			EXPECT_EQ(animInfo.getCurrentFrame(), gameTickData->_ExpectedAnimationFrame);
+			EXPECT_EQ(animInfo.getTickCounterOfCurrentFrame(), gameTickData->_ExpectedAnimationCnt);
 		} break;
 		case TestDataType::Rendering: {
 			auto renderingData = static_cast<RenderingData *>(x);
 			gfProgressToNextGameTick = renderingData->_fProgressToNextGameTick;
-			EXPECT_EQ(animInfo.GetFrameToUseForRendering(), renderingData->_ExpectedRenderingFrame)
+			EXPECT_EQ(animInfo.getFrameToUseForRendering(), renderingData->_ExpectedRenderingFrame)
 			    << std::fixed << std::setprecision(2)
 			    << "ProgressToNextGameTick: " << renderingData->_fProgressToNextGameTick
-			    << " CurrentFrame: " << animInfo.CurrentFrame
-			    << " DelayCounter: " << animInfo.TickCounterOfCurrentFrame
+			    << " currentFrame_: " << animInfo.getCurrentFrame()
+			    << " DelayCounter: " << animInfo.getTickCounterOfCurrentFrame()
 			    << " GameTick: " << currentGameTick;
 		} break;
 		}
@@ -130,7 +130,7 @@ TEST(AnimationInfo, AttackSwordWarrior) // ProcessAnimationPending should be con
 	RunAnimationTest(
 	    {
 	        new SetNewAnimationData(16, 1, AnimationDistributionFlags::ProcessAnimationPending, 0, 9),
-	        // ProcessAnimation directly after StartAttack (in same GameTick). So we don't see any rendering before.
+	        // processAnimation directly after StartAttack (in same GameTick). So we don't see any rendering before.
 	        new GameTickData(1, 0),
 	        new RenderingData(0.0f, 0),
 	        new RenderingData(0.3f, 0),
@@ -184,7 +184,7 @@ TEST(AnimationInfo, AttackSwordWarrior) // ProcessAnimationPending should be con
 	        new RenderingData(0.6f, 14),
 	        new GameTickData(15, 0),
 	        new RenderingData(0.6f, 15),
-	        // Animation stopped cause PM_DoAttack would stop the Animation "if (plr[pnum].AnimInfo.CurrentFrame == plr[pnum]._pAFrames - 1) {"
+	        // Animation stopped cause PM_DoAttack would stop the Animation "if (plr[pnum].AnimInfo.currentFrame_ == plr[pnum]._pAFrames - 1) {"
 	    });
 }
 
@@ -193,7 +193,7 @@ TEST(AnimationInfo, AttackSwordWarriorWithFastestAttack) // Skipped frames and P
 	RunAnimationTest(
 	    {
 	        new SetNewAnimationData(16, 1, AnimationDistributionFlags::ProcessAnimationPending, 2, 9),
-	        // ProcessAnimation directly after StartAttack (in same GameTick). So we don't see any rendering before.
+	        // processAnimation directly after StartAttack (in same GameTick). So we don't see any rendering before.
 	        new GameTickData(3, 0),
 	        new RenderingData(0.0f, 0),
 	        new RenderingData(0.3f, 0),
@@ -237,7 +237,7 @@ TEST(AnimationInfo, AttackSwordWarriorWithFastestAttack) // Skipped frames and P
 	        new RenderingData(0.6f, 14),
 	        new GameTickData(15, 0),
 	        new RenderingData(0.6f, 15),
-	        // Animation stopped cause PM_DoAttack would stop the Animation "if (plr[pnum].AnimInfo.CurrentFrame == plr[pnum]._pAFrames - 1) {"
+	        // Animation stopped cause PM_DoAttack would stop the Animation "if (plr[pnum].AnimInfo.currentFrame_ == plr[pnum]._pAFrames - 1) {"
 	    });
 }
 
@@ -249,7 +249,7 @@ TEST(AnimationInfo, AttackSwordWarriorRepeated)
 	RunAnimationTest(
 	    {
 	        new SetNewAnimationData(16, 1, AnimationDistributionFlags::ProcessAnimationPending, 0, 9),
-	        // ProcessAnimation directly after StartAttack (in same GameTick). So we don't see any rendering before.
+	        // processAnimation directly after StartAttack (in same GameTick). So we don't see any rendering before.
 	        new GameTickData(1, 0),
 	        new RenderingData(0.0f, 0),
 	        new RenderingData(0.3f, 0),
@@ -292,9 +292,9 @@ TEST(AnimationInfo, AttackSwordWarriorRepeated)
 	        new GameTickData(9, 0),
 	        new RenderingData(0.3f, 9),
 
-	        // Start of repeated attack, cause plr[pnum].AnimInfo.CurrentFrame > plr[myplr]._pAFNum
+	        // Start of repeated attack, cause plr[pnum].AnimInfo.currentFrame_ > plr[myplr]._pAFNum
 	        new SetNewAnimationData(16, 1, static_cast<AnimationDistributionFlags>(AnimationDistributionFlags::ProcessAnimationPending | AnimationDistributionFlags::RepeatedAction), 0, 9),
-	        // ProcessAnimation directly after StartAttack (in same GameTick). So we don't see any rendering before.
+	        // processAnimation directly after StartAttack (in same GameTick). So we don't see any rendering before.
 	        new GameTickData(1, 0),
 	        new RenderingData(0.0f, 10),
 	        new RenderingData(0.3f, 10),
@@ -348,7 +348,7 @@ TEST(AnimationInfo, AttackSwordWarriorRepeated)
 	        new RenderingData(0.6f, 14),
 	        new GameTickData(15, 0),
 	        new RenderingData(0.6f, 15),
-	        // Animation stopped cause PM_DoAttack would stop the Animation "if (plr[pnum].AnimInfo.CurrentFrame == plr[pnum]._pAFrames - 1) {"
+	        // Animation stopped cause PM_DoAttack would stop the Animation "if (plr[pnum].AnimInfo.currentFrame_ == plr[pnum]._pAFrames - 1) {"
 	    });
 }
 
@@ -376,7 +376,7 @@ TEST(AnimationInfo, BlockingWarriorNormal) // Ignored delay for last Frame shoul
 	        new RenderingData(0.3f, 1),
 	        new RenderingData(0.6f, 1),
 	        new RenderingData(0.8f, 1),
-	        // Animation stopped cause PM_DoBlock would stop the Animation "if (plr[pnum].AnimInfo.CurrentFrame >= plr[pnum]._pBFrames) {"
+	        // Animation stopped cause PM_DoBlock would stop the Animation "if (plr[pnum].AnimInfo.currentFrame_ >= plr[pnum]._pBFrames) {"
 	    });
 }
 
@@ -404,7 +404,7 @@ TEST(AnimationInfo, BlockingSorcererWithFastBlock) // Skipped frames and ignored
 	        new RenderingData(0.3f, 4),
 	        new RenderingData(0.6f, 5),
 	        new RenderingData(0.8f, 5),
-	        // Animation stopped cause PM_DoBlock would stop the Animation "if (plr[pnum].AnimInfo.CurrentFrame >= plr[pnum]._pBFrames) {"
+	        // Animation stopped cause PM_DoBlock would stop the Animation "if (plr[pnum].AnimInfo.currentFrame_ >= plr[pnum]._pBFrames) {"
 	    });
 }
 
@@ -432,7 +432,7 @@ TEST(AnimationInfo, HitRecoverySorcererZenMode) // Skipped frames and ignored de
 	        new RenderingData(0.3f, 6),
 	        new RenderingData(0.6f, 7),
 	        new RenderingData(0.8f, 7),
-	        // Animation stopped cause PM_DoGotHit would stop the Animation "if (plr[pnum].AnimInfo.CurrentFrame >= plr[pnum]._pHFrames) {"
+	        // Animation stopped cause PM_DoGotHit would stop the Animation "if (plr[pnum].AnimInfo.currentFrame_ >= plr[pnum]._pHFrames) {"
 	    });
 }
 TEST(AnimationInfo, Stand) // Distribution Logic shouldn't change anything here

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -22,7 +22,7 @@ int RunBlockTest(int frames, ItemSpecialEffect flags)
 		TestPlayerDoGotHit(pnum);
 		if (player._pmode != PM_GOTHIT)
 			break;
-		player.AnimInfo.CurrentFrame++;
+		player.AnimInfo.setCurrentFrame(player.AnimInfo.getCurrentFrame() + 1);
 	}
 
 	return i;

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -264,10 +264,10 @@ static void AssertPlayer(Player &player)
 	ASSERT_EQ(player._pmode, 0);
 	ASSERT_EQ(Count8(player.walkpath, MaxPathLength), 25);
 	ASSERT_EQ(player._pgfxnum, 36);
-	ASSERT_EQ(player.AnimInfo.TicksPerFrame, 4);
-	ASSERT_EQ(player.AnimInfo.TickCounterOfCurrentFrame, 1);
-	ASSERT_EQ(player.AnimInfo.NumberOfFrames, 20);
-	ASSERT_EQ(player.AnimInfo.CurrentFrame, 0);
+	ASSERT_EQ(player.AnimInfo.getTicksPerFrame(), 4);
+	ASSERT_EQ(player.AnimInfo.getTickCounterOfCurrentFrame(), 1);
+	ASSERT_EQ(player.AnimInfo.getNumberOfFrames(), 20);
+	ASSERT_EQ(player.AnimInfo.getCurrentFrame(), 0);
 	ASSERT_EQ(player._pSpell, -1);
 	ASSERT_EQ(player._pSplType, 4);
 	ASSERT_EQ(player._pSplFrom, 0);


### PR DESCRIPTION
- Added helpers to animationinfo (improves readability of it's usage in the code)
  added `triggerFrame`
- clean all clang-tidy remarks in animationinfo in the process (access/ case style / casts)

review remarks:
[animationinfo.h](https://github.com/diasurgical/devilutionX/blob/bf9c09cbd5198ee8d0cc44354d3bdb1c71a4bf12/Source/engine/animationinfo.h) <- here are vast majority of changes, but mainly access/sort/case style + added helpers
the rest of the code is derivates of these changes.

other change in the rest of the code is support for triggerFrame (load/save/monster/player).
