### PR TITLE
Take Player reference in FixPlrWalkTags

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1401,7 +1401,7 @@ void MonsterAttackPlayer(int monsterId, int pnum, int hit, int minDam, int maxDa
 		if (PosOkPlayer(player, newPosition)) {
 			player.position.tile = newPosition;
 			FixPlayerLocation(player, player._pdir);
-			FixPlrWalkTags(pnum);
+			FixPlrWalkTags(player);
 			dPlayer[newPosition.x][newPosition.y] = pnum + 1;
 			SetPlayerOld(player);
 		}
@@ -4642,7 +4642,7 @@ void MissToMonst(Missile &missile, Point position)
 		if (PosOkPlayer(player, newPosition)) {
 			player.position.tile = newPosition;
 			FixPlayerLocation(player, player._pdir);
-			FixPlrWalkTags(pnum);
+			FixPlrWalkTags(player);
 			dPlayer[newPosition.x][newPosition.y] = pnum + 1;
 			SetPlayerOld(player);
 		}

--- a/Source/player.h
+++ b/Source/player.h
@@ -738,6 +738,8 @@ extern DVL_API_FOR_TEST Player Players[MAX_PLRS];
 extern bool MyPlayerIsDead;
 extern const int BlockBonuses[enum_size<HeroClass>::value];
 
+Player *PlayerAtPosition(Point position);
+
 void LoadPlrGFX(Player &player, player_graphic graphic);
 void InitPlayerGFX(Player &player);
 void ResetPlayerGFX(Player &player);
@@ -771,8 +773,7 @@ void SetPlayerOld(Player &player);
 void FixPlayerLocation(Player &player, Direction bDir);
 void StartStand(int pnum, Direction dir);
 void StartPlrBlock(int pnum, Direction dir);
-void FixPlrWalkTags(int pnum);
-void RemovePlrFromMap(int pnum);
+void FixPlrWalkTags(const Player &player);
 void StartPlrHit(int pnum, int dam, bool forcehit);
 void StartPlayerKill(int pnum, int earflag);
 /**


### PR DESCRIPTION
Untested, not sure if there's still situations where player positions can get so out of sync in multiplayer games that a player disconnecting leaves an invalid index in `dPlayers`