### PR TITLE
`IncProgress`: Do not render bar if not active

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2328,8 +2328,10 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 		music_mute();
 	}
 
-	while (!IncProgress())
-		;
+	if (firstflag) {
+		while (!IncProgress())
+			;
+	}
 
 	if (!gbIsSpawn && setlevel && setlvlnum == SL_SKELKING && Quests[Q_SKELKING]._qactive == QUEST_ACTIVE)
 		PlaySFX(USFX_SKING1);

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -32,6 +32,7 @@ namespace {
 
 std::optional<OwnedCelSprite> sgpBackCel;
 
+bool IsProgress;
 uint32_t sgdwProgress;
 int progress_id;
 
@@ -217,6 +218,8 @@ void interface_msg_pump()
 bool IncProgress()
 {
 	interface_msg_pump();
+	if (!IsProgress)
+		return false;
 	sgdwProgress += 23;
 	if (sgdwProgress > 534)
 		sgdwProgress = 534;
@@ -227,6 +230,7 @@ bool IncProgress()
 void ShowProgress(interface_mode uMsg)
 {
 	WNDPROC saveProc;
+	IsProgress = true;
 
 	gbSomebodyWonGameKludge = false;
 	plrmsg_delay(true);
@@ -413,6 +417,7 @@ void ShowProgress(interface_mode uMsg)
 
 	saveProc = SetWindowProc(saveProc);
 	assert(saveProc == DisableInputWndProc);
+	IsProgress = false;
 
 	NetSendCmdLocParam2(true, CMD_PLAYER_JOINLEVEL, myPlayer.position.tile, myPlayer.plrlevel, myPlayer.plrIsOnSetLevel ? 1 : 0);
 	plrmsg_delay(false);


### PR DESCRIPTION
Loading the game from within the game calls `IncProgress` multiple times but we should not render the progress bar when that happens.

Fixes #4821