### PR TITLE
:bug: fix town boundaries

### DIFF
--- a/Source/levels/town.cpp
+++ b/Source/levels/town.cpp
@@ -187,10 +187,10 @@ void DrlgTPass3()
 {
 	for (int yy = 0; yy < MAXDUNY; yy += 2) {
 		for (int xx = 0; xx < MAXDUNX; xx += 2) {
-			dPiece[xx][yy] = 218;
-			dPiece[xx + 1][yy] = 218;
-			dPiece[xx][yy + 1] = 218;
-			dPiece[xx + 1][yy + 1] = 218;
+			dPiece[xx][yy] = 426;
+			dPiece[xx + 1][yy] = 426;
+			dPiece[xx][yy + 1] = 426;
+			dPiece[xx + 1][yy + 1] = 426;
 		}
 	}
 


### PR DESCRIPTION
Hello,

I noticed that the town boundaries were a bit weird:
![Screenshot 2022-06-30 at 23 23 27](https://user-images.githubusercontent.com/288227/176781403-45901084-b8f0-46e0-8c35-8bf7c97bc8e4.jpg)

So I did a git bisect and I found that the issue was introduced at 4cc3a5264ce75511163081ee9372ca4f7fd1c1cc, this is how it was before:
![Screenshot 2022-06-30 at 23 12 45](https://user-images.githubusercontent.com/288227/176781647-1d6f81a7-1671-4fd6-b0c8-eb368e7922c9.jpg)

I am not sure if the change was intentional or not, but I looked into the tiles and I found that 426 is a black tile, it looks like the original:
![Screenshot 2022-06-30 at 23 26 25](https://user-images.githubusercontent.com/288227/176781868-75248094-eaaa-478e-9dbd-b65b7d677136.jpg)



