### PR TITLE
DiabloUI: Clean up logo handling

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -45,8 +45,10 @@
 
 namespace devilution {
 
+std::optional<OwnedPcxSpriteSheet> ArtLogoMed;
+
 // These are stored as PCX but we load them as CEL to reduce memory usage.
-std::array<std::optional<OwnedCelSpriteWithFrameHeight>, 3> ArtLogos;
+std::optional<OwnedCelSpriteWithFrameHeight> ArtLogoBig;
 std::array<std::optional<OwnedCelSpriteWithFrameHeight>, 3> ArtFocus;
 
 std::optional<OwnedPcxSprite> ArtBackgroundWidescreen;
@@ -572,9 +574,9 @@ void LoadHeros()
 void LoadUiGFX()
 {
 	if (gbIsHellfire) {
-		ArtLogos[LOGO_MED] = LoadPcxAssetAsCel("ui_art\\hf_logo2.pcx", /*numFrames=*/16);
+		ArtLogoMed = LoadPcxSpriteSheetAsset("ui_art\\hf_logo2.pcx", /*numFrames=*/16, /*transparentColor=*/1);
 	} else {
-		ArtLogos[LOGO_MED] = LoadPcxAssetAsCel("ui_art\\smlogo.pcx", /*numFrames=*/15, /*generateFrameHeaders=*/false, /*transparentColorIndex=*/250);
+		ArtLogoMed = LoadPcxSpriteSheetAsset("ui_art\\smlogo.pcx", /*numFrames=*/15, /*transparentColor=*/250);
 	}
 	ArtFocus[FOCUS_SMALL] = LoadPcxAssetAsCel("ui_art\\focus16.pcx", /*numFrames=*/8, /*generateFrameHeaders=*/false, /*transparentColorIndex=*/250);
 	ArtFocus[FOCUS_MED] = LoadPcxAssetAsCel("ui_art\\focus.pcx", /*numFrames=*/8, /*generateFrameHeaders=*/false, /*transparentColorIndex=*/250);
@@ -600,8 +602,8 @@ void UnloadUiGFX()
 	ArtCursor.Unload();
 	for (auto &art : ArtFocus)
 		art = std::nullopt;
-	for (auto &art : ArtLogos)
-		art = std::nullopt;
+	ArtLogoMed = std::nullopt;
+	ArtLogoBig = std::nullopt;
 }
 
 void UiInitialize()
@@ -709,11 +711,17 @@ void UiAddBackground(std::vector<std::unique_ptr<UiItemBase>> *vecDialog)
 	vecDialog->push_back(std::make_unique<UiImagePcx>(PcxSpriteSheet { *ArtBackground }.sprite(0), rect, UiFlags::AlignCenter));
 }
 
-void UiAddLogo(std::vector<std::unique_ptr<UiItemBase>> *vecDialog, int size, int y)
+void UiAddLogo(std::vector<std::unique_ptr<UiItemBase>> *vecDialog)
+{
+	vecDialog->push_back(std::make_unique<UiImageAnimatedPcx>(
+	    PcxSpriteSheet { *ArtLogoMed }, MakeSdlRect(0, GetUIRectangle().position.y, 0, 0), UiFlags::AlignCenter));
+}
+
+void UiAddLogoBig(std::vector<std::unique_ptr<UiItemBase>> *vecDialog, int y)
 {
 	SDL_Rect rect = MakeSdlRect(0, GetUIRectangle().position.y + y, 0, 0);
 	vecDialog->push_back(std::make_unique<UiImageCel>(
-	    CelSpriteWithFrameHeight { CelSprite { ArtLogos[size]->sprite }, ArtLogos[size]->frameHeight }, rect, UiFlags::AlignCenter, /*bAnimated=*/true));
+	    CelSpriteWithFrameHeight { CelSprite { ArtLogoBig->sprite }, ArtLogoBig->frameHeight }, rect, UiFlags::AlignCenter, /*bAnimated=*/true));
 }
 
 void UiFadeIn()

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -45,10 +45,9 @@
 
 namespace devilution {
 
-std::optional<OwnedPcxSpriteSheet> ArtLogoMed;
+std::optional<OwnedPcxSpriteSheet> ArtLogo;
 
 // These are stored as PCX but we load them as CEL to reduce memory usage.
-std::optional<OwnedCelSpriteWithFrameHeight> ArtLogoBig;
 std::array<std::optional<OwnedCelSpriteWithFrameHeight>, 3> ArtFocus;
 
 std::optional<OwnedPcxSprite> ArtBackgroundWidescreen;
@@ -574,9 +573,9 @@ void LoadHeros()
 void LoadUiGFX()
 {
 	if (gbIsHellfire) {
-		ArtLogoMed = LoadPcxSpriteSheetAsset("ui_art\\hf_logo2.pcx", /*numFrames=*/16, /*transparentColor=*/1);
+		ArtLogo = LoadPcxSpriteSheetAsset("ui_art\\hf_logo2.pcx", /*numFrames=*/16, /*transparentColor=*/1);
 	} else {
-		ArtLogoMed = LoadPcxSpriteSheetAsset("ui_art\\smlogo.pcx", /*numFrames=*/15, /*transparentColor=*/250);
+		ArtLogo = LoadPcxSpriteSheetAsset("ui_art\\smlogo.pcx", /*numFrames=*/15, /*transparentColor=*/250);
 	}
 	ArtFocus[FOCUS_SMALL] = LoadPcxAssetAsCel("ui_art\\focus16.pcx", /*numFrames=*/8, /*generateFrameHeaders=*/false, /*transparentColorIndex=*/250);
 	ArtFocus[FOCUS_MED] = LoadPcxAssetAsCel("ui_art\\focus.pcx", /*numFrames=*/8, /*generateFrameHeaders=*/false, /*transparentColorIndex=*/250);
@@ -602,8 +601,7 @@ void UnloadUiGFX()
 	ArtCursor.Unload();
 	for (auto &art : ArtFocus)
 		art = std::nullopt;
-	ArtLogoMed = std::nullopt;
-	ArtLogoBig = std::nullopt;
+	ArtLogo = std::nullopt;
 }
 
 void UiInitialize()
@@ -714,14 +712,7 @@ void UiAddBackground(std::vector<std::unique_ptr<UiItemBase>> *vecDialog)
 void UiAddLogo(std::vector<std::unique_ptr<UiItemBase>> *vecDialog)
 {
 	vecDialog->push_back(std::make_unique<UiImageAnimatedPcx>(
-	    PcxSpriteSheet { *ArtLogoMed }, MakeSdlRect(0, GetUIRectangle().position.y, 0, 0), UiFlags::AlignCenter));
-}
-
-void UiAddLogoBig(std::vector<std::unique_ptr<UiItemBase>> *vecDialog, int y)
-{
-	SDL_Rect rect = MakeSdlRect(0, GetUIRectangle().position.y + y, 0, 0);
-	vecDialog->push_back(std::make_unique<UiImageCel>(
-	    CelSpriteWithFrameHeight { CelSprite { ArtLogoBig->sprite }, ArtLogoBig->frameHeight }, rect, UiFlags::AlignCenter, /*bAnimated=*/true));
+	    PcxSpriteSheet { *ArtLogo }, MakeSdlRect(0, GetUIRectangle().position.y, 0, 0), UiFlags::AlignCenter));
 }
 
 void UiFadeIn()

--- a/Source/DiabloUI/diabloui.h
+++ b/Source/DiabloUI/diabloui.h
@@ -62,8 +62,7 @@ struct _uiheroinfo {
 	bool spawned;
 };
 
-extern std::optional<OwnedPcxSpriteSheet> ArtLogoMed;
-extern std::optional<OwnedCelSpriteWithFrameHeight> ArtLogoBig;
+extern std::optional<OwnedPcxSpriteSheet> ArtLogo;
 extern std::array<std::optional<OwnedCelSpriteWithFrameHeight>, 3> ArtFocus;
 extern std::optional<OwnedPcxSprite> ArtBackgroundWidescreen;
 extern std::optional<OwnedPcxSpriteSheet> ArtBackground;
@@ -101,7 +100,6 @@ void DrawMouse();
 void LoadBackgroundArt(const char *pszFile, int frames = 1);
 void UiAddBackground(std::vector<std::unique_ptr<UiItemBase>> *vecDialog);
 void UiAddLogo(std::vector<std::unique_ptr<UiItemBase>> *vecDialog);
-void UiAddLogoBig(std::vector<std::unique_ptr<UiItemBase>> *vecDialog, int y);
 void UiFocusNavigationSelect();
 void UiFocusNavigationEsc();
 void UiFocusNavigationYesNo();

--- a/Source/DiabloUI/diabloui.h
+++ b/Source/DiabloUI/diabloui.h
@@ -23,12 +23,6 @@ enum _artFocus : uint8_t {
 	FOCUS_BIG,
 };
 
-enum _artLogo : uint8_t {
-	LOGO_SMALL,
-	LOGO_MED,
-	LOGO_BIG,
-};
-
 enum _mainmenu_selections : uint8_t {
 	MAINMENU_NONE,
 	MAINMENU_SINGLE_PLAYER,
@@ -68,7 +62,8 @@ struct _uiheroinfo {
 	bool spawned;
 };
 
-extern std::array<std::optional<OwnedCelSpriteWithFrameHeight>, 3> ArtLogos;
+extern std::optional<OwnedPcxSpriteSheet> ArtLogoMed;
+extern std::optional<OwnedCelSpriteWithFrameHeight> ArtLogoBig;
 extern std::array<std::optional<OwnedCelSpriteWithFrameHeight>, 3> ArtFocus;
 extern std::optional<OwnedPcxSprite> ArtBackgroundWidescreen;
 extern std::optional<OwnedPcxSpriteSheet> ArtBackground;
@@ -105,7 +100,8 @@ void LoadPalInMem(const SDL_Color *pPal);
 void DrawMouse();
 void LoadBackgroundArt(const char *pszFile, int frames = 1);
 void UiAddBackground(std::vector<std::unique_ptr<UiItemBase>> *vecDialog);
-void UiAddLogo(std::vector<std::unique_ptr<UiItemBase>> *vecDialog, int size = LOGO_MED, int y = 0);
+void UiAddLogo(std::vector<std::unique_ptr<UiItemBase>> *vecDialog);
+void UiAddLogoBig(std::vector<std::unique_ptr<UiItemBase>> *vecDialog, int y);
 void UiFocusNavigationSelect();
 void UiFocusNavigationEsc();
 void UiFocusNavigationYesNo();

--- a/Source/DiabloUI/title.cpp
+++ b/Source/DiabloUI/title.cpp
@@ -20,7 +20,7 @@ void TitleLoad()
 		ArtBackgroundWidescreen = LoadPcxAsset("ui_art\\hf_titlew.pcx");
 	} else {
 		LoadBackgroundArt("ui_art\\title.pcx");
-		ArtLogos[LOGO_BIG] = LoadPcxAssetAsCel("ui_art\\logo.pcx", /*numFrames=*/15, /*generateFrameHeaders=*/false, /*transparentColorIndex=*/250);
+		ArtLogoBig = LoadPcxAssetAsCel("ui_art\\logo.pcx", /*numFrames=*/15, /*generateFrameHeaders=*/false, /*transparentColorIndex=*/250);
 	}
 }
 
@@ -28,7 +28,7 @@ void TitleFree()
 {
 	ArtBackground = std::nullopt;
 	ArtBackgroundWidescreen = std::nullopt;
-	ArtLogos[LOGO_BIG] = std::nullopt;
+	ArtLogoBig = std::nullopt;
 
 	vecTitleScreen.clear();
 }
@@ -46,7 +46,7 @@ void UiTitleDialog()
 		vecTitleScreen.push_back(std::make_unique<UiImageAnimatedPcx>(PcxSpriteSheet { *ArtBackground }, rect, UiFlags::AlignCenter));
 	} else {
 		UiAddBackground(&vecTitleScreen);
-		UiAddLogo(&vecTitleScreen, LOGO_BIG, 182);
+		UiAddLogoBig(&vecTitleScreen, 182);
 
 		SDL_Rect rect = MakeSdlRect(uiPosition.x, uiPosition.y + 410, 640, 26);
 		vecTitleScreen.push_back(std::make_unique<UiArtText>(_("Copyright © 1996-2001 Blizzard Entertainment").data(), rect, UiFlags::AlignCenter | UiFlags::FontSize24 | UiFlags::ColorUiSilver));

--- a/Source/DiabloUI/title.cpp
+++ b/Source/DiabloUI/title.cpp
@@ -4,12 +4,14 @@
 #include "controls/menu_controls.h"
 #include "discord/discord.h"
 #include "engine/load_pcx.hpp"
-#include "engine/load_pcx_as_cel.hpp"
 #include "utils/language.h"
 #include "utils/sdl_geometry.h"
+#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 namespace {
+
+std::optional<OwnedPcxSpriteSheet> DiabloTitleLogo;
 
 std::vector<std::unique_ptr<UiItemBase>> vecTitleScreen;
 
@@ -20,7 +22,7 @@ void TitleLoad()
 		ArtBackgroundWidescreen = LoadPcxAsset("ui_art\\hf_titlew.pcx");
 	} else {
 		LoadBackgroundArt("ui_art\\title.pcx");
-		ArtLogoBig = LoadPcxAssetAsCel("ui_art\\logo.pcx", /*numFrames=*/15, /*generateFrameHeaders=*/false, /*transparentColorIndex=*/250);
+		DiabloTitleLogo = LoadPcxSpriteSheetAsset("ui_art\\logo.pcx", /*numFrames=*/15, /*transparentColor=*/250);
 	}
 }
 
@@ -28,7 +30,7 @@ void TitleFree()
 {
 	ArtBackground = std::nullopt;
 	ArtBackgroundWidescreen = std::nullopt;
-	ArtLogoBig = std::nullopt;
+	DiabloTitleLogo = std::nullopt;
 
 	vecTitleScreen.clear();
 }
@@ -46,7 +48,9 @@ void UiTitleDialog()
 		vecTitleScreen.push_back(std::make_unique<UiImageAnimatedPcx>(PcxSpriteSheet { *ArtBackground }, rect, UiFlags::AlignCenter));
 	} else {
 		UiAddBackground(&vecTitleScreen);
-		UiAddLogoBig(&vecTitleScreen, 182);
+
+		vecTitleScreen.push_back(std::make_unique<UiImageAnimatedPcx>(
+		    PcxSpriteSheet { *DiabloTitleLogo }, MakeSdlRect(0, uiPosition.y + 182, 0, 0), UiFlags::AlignCenter));
 
 		SDL_Rect rect = MakeSdlRect(uiPosition.x, uiPosition.y + 410, 640, 26);
 		vecTitleScreen.push_back(std::make_unique<UiArtText>(_("Copyright © 1996-2001 Blizzard Entertainment").data(), rect, UiFlags::AlignCenter | UiFlags::FontSize24 | UiFlags::ColorUiSilver));


### PR DESCRIPTION
1. There is no small logo. Simply use 2 variables instead of an array with an enum.
2. The medium logo is much smaller as PCX:
   * Hellfire (`ui_art\hf_logo2.pcx`): 1,591,816 bytes -> 195,850 bytes
   * Diablo (`ui_art\smlogo.pcx`): 341,923 bytes -> 333,099 bytes