### PR TITLE
DiabloUI: Clean up portrait loading

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -105,6 +105,7 @@ set(libdevilutionx_SRCS
   engine/load_pcx.cpp
   engine/palette.cpp
   engine/path.cpp
+  engine/pcx_sprite.cpp
   engine/random.cpp
   engine/surface.cpp
   engine/trn.cpp

--- a/Source/DiabloUI/diabloui.h
+++ b/Source/DiabloUI/diabloui.h
@@ -67,7 +67,6 @@ extern std::array<std::optional<OwnedCelSpriteWithFrameHeight>, 3> ArtFocus;
 extern std::optional<OwnedPcxSprite> ArtBackgroundWidescreen;
 extern std::optional<OwnedPcxSpriteSheet> ArtBackground;
 extern Art ArtCursor;
-extern Art ArtHero;
 
 extern void (*gfnSoundFunction)(const char *file);
 extern bool (*gfnHeroInfo)(bool (*fninfofunc)(_uiheroinfo *));
@@ -109,6 +108,7 @@ void UiPollAndRender(std::function<bool(SDL_Event &)> eventHandler = nullptr);
 void UiRenderItems(const std::vector<UiItemBase *> &items);
 void UiRenderItems(const std::vector<std::unique_ptr<UiItemBase>> &items);
 void UiInitList_clear();
+PcxSprite UiGetHeroDialogSprite(size_t heroClassIndex);
 
 void mainmenu_restart_repintro();
 } // namespace devilution

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -44,7 +44,7 @@ std::vector<std::unique_ptr<UiItemBase>> vecSelHeroDialog;
 std::vector<std::unique_ptr<UiListItem>> vecSelHeroDlgItems;
 std::vector<std::unique_ptr<UiItemBase>> vecSelDlgItems;
 
-UiImage *SELHERO_DIALOG_HERO_IMG;
+UiImagePcx *SELHERO_DIALOG_HERO_IMG;
 
 void SelheroListFocus(int value);
 void SelheroListSelect(int value);
@@ -77,7 +77,7 @@ void SelheroFree()
 
 void SelheroSetStats()
 {
-	SELHERO_DIALOG_HERO_IMG->SetFrame(static_cast<int>(selhero_heroInfo.heroclass));
+	SELHERO_DIALOG_HERO_IMG->setSprite(UiGetHeroDialogSprite(static_cast<size_t>(selhero_heroInfo.heroclass)));
 	CopyUtf8(textStats[0], fmt::format("{}", selhero_heroInfo.level), sizeof(textStats[0]));
 	CopyUtf8(textStats[1], fmt::format("{}", selhero_heroInfo.strength), sizeof(textStats[1]));
 	CopyUtf8(textStats[2], fmt::format("{}", selhero_heroInfo.magic), sizeof(textStats[2]));
@@ -109,7 +109,7 @@ void SelheroListFocus(int value)
 		return;
 	}
 
-	SELHERO_DIALOG_HERO_IMG->SetFrame(static_cast<int>(enum_size<HeroClass>::value));
+	SELHERO_DIALOG_HERO_IMG->setSprite(UiGetHeroDialogSprite(enum_size<HeroClass>::value));
 	for (char *textStat : textStats)
 		strcpy(textStat, "--");
 	SELLIST_DIALOG_DELETE_BUTTON->SetFlags(baseFlags | UiFlags::ColorUiSilver | UiFlags::ElementDisabled);
@@ -449,7 +449,7 @@ void selhero_Init()
 	vecSelHeroDialog.push_back(std::make_unique<UiArtText>(&title, rect1, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
 	SDL_Rect rect2 = { (Sint16)(uiPosition.x + 30), (Sint16)(uiPosition.y + 211), 180, 76 };
-	auto heroImg = std::make_unique<UiImage>(&ArtHero, rect2, UiFlags::None, /*bAnimated=*/false, static_cast<int>(enum_size<HeroClass>::value));
+	auto heroImg = std::make_unique<UiImagePcx>(UiGetHeroDialogSprite(0), rect2, UiFlags::None);
 	SELHERO_DIALOG_HERO_IMG = heroImg.get();
 	vecSelHeroDialog.push_back(std::move(heroImg));
 

--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -195,6 +195,11 @@ public:
 		return sprite_;
 	}
 
+	void setSprite(PcxSprite sprite)
+	{
+		sprite_ = sprite;
+	}
+
 private:
 	PcxSprite sprite_;
 };

--- a/Source/engine/load_pcx.hpp
+++ b/Source/engine/load_pcx.hpp
@@ -10,6 +10,7 @@
 namespace devilution {
 
 std::optional<OwnedPcxSprite> LoadPcxAsset(const char *path, std::optional<uint8_t> transparentColor = std::nullopt, SDL_Color *outPalette = nullptr);
+std::optional<OwnedPcxSprite> LoadPcxAsset(SDL_RWops *handle, std::optional<uint8_t> transparentColor = std::nullopt, SDL_Color *outPalette = nullptr);
 std::optional<OwnedPcxSpriteSheet> LoadPcxSpriteSheetAsset(const char *path, uint16_t numFrames, std::optional<uint8_t> transparentColor = std::nullopt, SDL_Color *outPalette = nullptr);
 
 } // namespace devilution

--- a/Source/engine/pcx_sprite.cpp
+++ b/Source/engine/pcx_sprite.cpp
@@ -1,0 +1,34 @@
+#include "engine/pcx_sprite.hpp"
+
+namespace devilution {
+
+std::unique_ptr<uint32_t[]> OwnedPcxSpriteSheet::calculateFrameOffsets(PcxSprite sprite, uint16_t numFrames)
+{
+	uint16_t frameHeight = sprite.height() / numFrames;
+	std::unique_ptr<uint32_t[]> frameOffsets { new uint32_t[numFrames] };
+	frameOffsets[0] = 0;
+	const unsigned width = sprite.width();
+	const unsigned srcSkip = width % 2;
+	const uint8_t *data = sprite.data();
+	for (unsigned frame = 1; frame < numFrames; ++frame) {
+		for (unsigned y = 0; y < frameHeight; ++y) {
+			for (unsigned x = 0; x < width;) {
+				constexpr uint8_t PcxMaxSinglePixel = 0xBF;
+				const uint8_t byte = *data++;
+				if (byte <= PcxMaxSinglePixel) {
+					++x;
+					continue;
+				}
+				constexpr uint8_t PcxRunLengthMask = 0x3F;
+				const uint8_t runLength = (byte & PcxRunLengthMask);
+				++data;
+				x += runLength;
+			}
+			data += srcSkip;
+		}
+		frameOffsets[frame] = static_cast<uint32_t>(data - sprite.data());
+	}
+	return frameOffsets;
+}
+
+} // namespace devilution

--- a/Source/engine/pcx_sprite.hpp
+++ b/Source/engine/pcx_sprite.hpp
@@ -139,8 +139,11 @@ public:
 	{
 	}
 
-	OwnedPcxSpriteSheet(OwnedPcxSprite &&sprite, std::unique_ptr<uint32_t[]> &&frameOffsets, uint16_t numFrames)
-	    : OwnedPcxSpriteSheet(std::move(sprite.data_), std::move(frameOffsets), numFrames, sprite.width_, sprite.height_ / numFrames, sprite.transparent_color_)
+	OwnedPcxSpriteSheet(OwnedPcxSprite &&sprite, uint16_t numFrames)
+	    : OwnedPcxSpriteSheet(
+	        std::move(sprite.data_),
+	        calculateFrameOffsets(PcxSprite { sprite.data_.get(), sprite.width_, sprite.height_ }, numFrames),
+	        numFrames, sprite.width_, sprite.height_ / numFrames, sprite.transparent_color_)
 	{
 	}
 
@@ -148,6 +151,8 @@ public:
 	OwnedPcxSpriteSheet &operator=(OwnedPcxSpriteSheet &&) noexcept = default;
 
 private:
+	static std::unique_ptr<uint32_t[]> calculateFrameOffsets(PcxSprite sprite, uint16_t numFrames);
+
 	std::unique_ptr<uint8_t[]> data_;
 	std::unique_ptr<uint32_t[]> frame_offsets_;
 	uint16_t num_frames_;


### PR DESCRIPTION
1. Load portraits as PCX (~30% smaller).
2. Simplify the portrait override logic.