### PR TITLE
Clarification of C++ standard usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,9 @@ if(GPERF)
   endif()
 endif()
 
+# Despite setting C++ standard to 20, features from this version are not being used.
+# The oldest compiler used is GCC 6.5 - and that defines our C++ feature set (meaning most of C++17).
+# It's present only to take advantage of fmt::format build time errors.
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED OFF)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -3,6 +3,11 @@
 This guide outlines useful resources, tools and processes for contribution to
 DevilutionX.
 
+## C++ Standard
+Despite setting C++ standard to 20 in CMakeLists.txt, features from this version are not being used.
+The oldest compiler used is GCC 6.5 - and that defines our C++ feature set (meaning most of C++17).
+It's present only to take advantage of fmt::format build time errors.
+
 ## Code style guide
 
 [The code style guide](https://github.com/diasurgical/devilutionX/wiki/Code-Style) is evolving with the project.


### PR DESCRIPTION
Add clarification in CMakelists.txt regarding C++ standard, as well as add new section in CONTRIBUTING.md.

This should help to clear the confusion about which standard is being used.

The reasons behind using C++17 while setting standard to C++20 are probably not described correctly - they have been taken from Discord discussion. As such, it would be great if somebody knowing the ins and outs of standard situation could clarify this. 