### PR TITLE
Pull distinct points from VisionCrawlTable used by guardians

### DIFF
--- a/Source/engine/world_tile.hpp
+++ b/Source/engine/world_tile.hpp
@@ -7,4 +7,7 @@ namespace devilution {
 using WorldTileCoord = uint8_t;
 using WorldTilePosition = PointOf<WorldTileCoord>;
 
+using WorldTileOffset = int8_t;
+using WorldTileDisplacement = DisplacementOf<WorldTileOffset>;
+
 } // namespace devilution

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -24,6 +24,8 @@ std::array<uint8_t, LIGHTSIZE> LightTables;
 bool DisableLighting;
 bool UpdateLighting;
 
+namespace {
+
 /*
  * X- Y-coordinate offsets of lighting visions.
  * The last entry-pair is only for alignment.
@@ -55,8 +57,6 @@ const uint8_t VisionCrawlTable[23][30] = {
 	{ 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0, 9,  0, 10,  0, 11,  0, 12,  0, 13,  0, 14,  0, 15 },
 	// clang-format on
 };
-
-namespace {
 
 uint8_t lightradius[16][128];
 bool dovision;

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -131,6 +131,4 @@ auto Crawl(unsigned minRadius, unsigned maxRadius, F function) -> invoke_result_
 
 /* rdata */
 
-extern const uint8_t VisionCrawlTable[23][30];
-
 } // namespace devilution

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3104,11 +3104,11 @@ void MI_NovaCommon(Missile &missile, missile_id projectileType)
 		en = TARGET_MONSTERS;
 	}
 
-	constexpr std::array<Displacement, 9> quarterRadius = { { { 4, 0 }, { 4, 1 }, { 4, 2 }, { 4, 3 }, { 4, 4 }, { 3, 4 }, { 2, 4 }, { 1, 4 }, { 0, 4 } } };
-	for (Displacement quarterOffset : quarterRadius) {
+	constexpr std::array<WorldTileDisplacement, 9> quarterRadius = { { { 4, 0 }, { 4, 1 }, { 4, 2 }, { 4, 3 }, { 4, 4 }, { 3, 4 }, { 2, 4 }, { 1, 4 }, { 0, 4 } } };
+	for (WorldTileDisplacement quarterOffset : quarterRadius) {
 		// This ends up with two missiles targeting offsets 4,0, 0,4, -4,0, 0,-4.
-		std::array<Displacement, 4> offsets { quarterOffset, quarterOffset.flipXY(), quarterOffset.flipX(), quarterOffset.flipY() };
-		for (Displacement offset : offsets)
+		std::array<WorldTileDisplacement, 4> offsets { quarterOffset, quarterOffset.flipXY(), quarterOffset.flipX(), quarterOffset.flipY() };
+		for (WorldTileDisplacement offset : offsets)
 			AddMissile(src, src + offset, dir, projectileType, en, id, dam, missile._mispllvl);
 	}
 	missile._mirange--;
@@ -3323,26 +3323,38 @@ void MI_Guardian(Missile &missile)
 	Point position = missile.position.tile;
 
 	if ((missile._mirange % 16) == 0) {
-		Displacement previous = { 0, 0 };
-
-		bool found = false;
-		for (int j = 0; j < 23 && !found; j++) {
-			for (int k = 10; k >= 0 && !found; k -= 2) {
-				const Displacement offset { VisionCrawlTable[j][k], VisionCrawlTable[j][k + 1] };
-				if (offset == Displacement { 0, 0 }) {
-					break;
-				}
-				if (previous == offset) {
-					continue;
-				}
-				found = GuardianTryFireAt(missile, { position.x + offset.deltaX, position.y + offset.deltaY })
-				    || GuardianTryFireAt(missile, { position.x - offset.deltaX, position.y - offset.deltaY })
-				    || GuardianTryFireAt(missile, { position.x + offset.deltaX, position.y - offset.deltaY })
-				    || GuardianTryFireAt(missile, { position.x - offset.deltaX, position.y + offset.deltaY });
-				if (!found) {
-					previous = offset;
-				}
+		// Guardians pick a target by working backwards along lines originally based on VisionCrawlTable.
+		// Because of their rather unique behaviour the points checked have been unrolled here
+		constexpr std::array<WorldTileDisplacement, 48> guardianArc {
+			{
+			    // clang-format off
+			    { 6, 0 }, { 5, 0 }, { 4, 0 }, { 3, 0 }, { 2, 0 }, { 1, 0 },
+			    { 6, 1 }, { 5, 1 }, { 4, 1 }, { 3, 1 },
+			    { 6, 2 }, { 2, 1 },
+			    { 5, 2 },
+			    { 6, 3 }, { 4, 2 },
+			    { 5, 3 }, { 3, 2 }, { 1, 1 },
+			    { 6, 4 },
+			    { 6, 5 }, { 5, 4 }, { 4, 3 }, { 2, 2 },
+			    { 5, 5 }, { 4, 4 }, { 3, 3 },
+			    { 6, 6 }, { 5, 6 }, { 4, 5 }, { 3, 4 }, { 2, 3 },
+			    { 4, 6 }, { 3, 5 }, { 2, 4 }, { 1, 2 },
+			    { 3, 6 }, { 2, 5 }, { 1, 3 }, { 0, 1 },
+			    { 2, 6 }, { 1, 4 },
+			    { 1, 5 },
+			    { 1, 6 },
+			    { 0, 2 },
+			    { 0, 3 },
+			    { 0, 6 }, { 0, 5 }, { 0, 4 },
+			    // clang-format on
 			}
+		};
+		for (WorldTileDisplacement offset : guardianArc) {
+			if (GuardianTryFireAt(missile, position + offset)
+			    || GuardianTryFireAt(missile, position + offset.flipXY())
+			    || GuardianTryFireAt(missile, position + offset.flipY())
+			    || GuardianTryFireAt(missile, position + offset.flipX()))
+				break;
 		}
 	}
 


### PR DESCRIPTION
Opening this to highlight the odd targeting Guardians use more than anything. If we're happy to change behaviour this can be made way simpler by using `FindClosestValidPosition` instead of having guardians search for targets from far to near. Based off #4843 since it was the last remaining use of VisionCrawlTable outside of lighting.cpp