### PR TITLE
Add OptionalCelSprite: smaller than std::optional

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -85,7 +85,7 @@ Rectangle MainPanel;
 Rectangle LeftPanel;
 Rectangle RightPanel;
 std::optional<OwnedSurface> pBtmBuff;
-std::optional<OwnedCelSprite> pGBoxBuff;
+OptionalOwnedCelSprite pGBoxBuff;
 
 const Rectangle &GetMainPanel()
 {
@@ -135,10 +135,10 @@ namespace {
 
 std::optional<OwnedSurface> pLifeBuff;
 std::optional<OwnedSurface> pManaBuff;
-std::optional<OwnedCelSprite> talkButtons;
-std::optional<OwnedCelSprite> pDurIcons;
-std::optional<OwnedCelSprite> multiButtons;
-std::optional<OwnedCelSprite> pPanelButtons;
+OptionalOwnedCelSprite talkButtons;
+OptionalOwnedCelSprite pDurIcons;
+OptionalOwnedCelSprite multiButtons;
+OptionalOwnedCelSprite pPanelButtons;
 
 bool PanelButtons[8];
 int PanelButtonIndex;

--- a/Source/control.h
+++ b/Source/control.h
@@ -52,7 +52,7 @@ const Rectangle &GetRightPanel();
 bool IsLeftPanelOpen();
 bool IsRightPanelOpen();
 extern std::optional<OwnedSurface> pBtmBuff;
-extern std::optional<OwnedCelSprite> pGBoxBuff;
+extern OptionalOwnedCelSprite pGBoxBuff;
 extern SDL_Rect PanBtnPos[8];
 
 void CalculatePanelAreas();

--- a/Source/controls/modifier_hints.cpp
+++ b/Source/controls/modifier_hints.cpp
@@ -16,7 +16,7 @@
 
 namespace devilution {
 
-extern std::optional<OwnedCelSprite> pSBkIconCels;
+extern OptionalOwnedCelSprite pSBkIconCels;
 
 namespace {
 

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -31,8 +31,8 @@
 namespace devilution {
 namespace {
 /** Cursor images CEL */
-std::optional<OwnedCelSprite> pCursCels;
-std::optional<OwnedCelSprite> pCursCels2;
+OptionalOwnedCelSprite pCursCels;
+OptionalOwnedCelSprite pCursCels2;
 
 /** Maps from objcurs.cel frame number to frame width. */
 const uint16_t InvItemWidth1[] = {

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -35,7 +35,7 @@
 namespace devilution {
 
 std::string TestMapPath;
-std::optional<OwnedCelSprite> pSquareCel;
+OptionalOwnedCelSprite pSquareCel;
 bool DebugToggle = false;
 bool DebugGodMode = false;
 bool DebugVision = false;

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -15,7 +15,7 @@
 namespace devilution {
 
 extern std::string TestMapPath;
-extern std::optional<OwnedCelSprite> pSquareCel;
+extern OptionalOwnedCelSprite pSquareCel;
 extern bool DebugToggle;
 extern bool DebugGodMode;
 extern bool DebugVision;

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -10,7 +10,6 @@
 #include "engine.h"
 #include "engine/cel_sprite.hpp"
 #include "miniwin/miniwin.h"
-#include "utils/stdcompat/optional.hpp"
 #include "utils/stdcompat/string_view.hpp"
 
 namespace devilution {

--- a/Source/doom.cpp
+++ b/Source/doom.cpp
@@ -14,7 +14,7 @@
 
 namespace devilution {
 namespace {
-std::optional<OwnedCelSprite> DoomCel;
+OptionalOwnedCelSprite DoomCel;
 } // namespace
 
 bool DoomFlag;

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -74,7 +74,7 @@ float AnimationInfo::GetAnimationProgress() const
 	return animationFraction;
 }
 
-void AnimationInfo::SetNewAnimation(std::optional<CelSprite> celSprite, int8_t numberOfFrames, int8_t ticksPerFrame, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int8_t numSkippedFrames /*= 0*/, int8_t distributeFramesBeforeFrame /*= 0*/, float previewShownGameTickFragments /*= 0.F*/)
+void AnimationInfo::SetNewAnimation(OptionalCelSprite celSprite, int8_t numberOfFrames, int8_t ticksPerFrame, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int8_t numSkippedFrames /*= 0*/, int8_t distributeFramesBeforeFrame /*= 0*/, float previewShownGameTickFragments /*= 0.F*/)
 {
 	if ((flags & AnimationDistributionFlags::RepeatedAction) == AnimationDistributionFlags::RepeatedAction && distributeFramesBeforeFrame != 0 && NumberOfFrames == numberOfFrames && CurrentFrame + 1 >= distributeFramesBeforeFrame && CurrentFrame != NumberOfFrames - 1) {
 		// We showed the same Animation (for example a melee attack) before but truncated the Animation.
@@ -167,7 +167,7 @@ void AnimationInfo::SetNewAnimation(std::optional<CelSprite> celSprite, int8_t n
 	}
 }
 
-void AnimationInfo::ChangeAnimationData(std::optional<CelSprite> celSprite, int8_t numberOfFrames, int8_t ticksPerFrame)
+void AnimationInfo::ChangeAnimationData(OptionalCelSprite celSprite, int8_t numberOfFrames, int8_t ticksPerFrame)
 {
 	if (numberOfFrames != NumberOfFrames || ticksPerFrame != TicksPerFrame) {
 		// Ensure that the CurrentFrame is still valid and that we disable ADL cause the calculcated values (for example TickModifier) could be wrong

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -9,7 +9,6 @@
 #include <type_traits>
 
 #include "engine/cel_sprite.hpp"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 
@@ -40,7 +39,7 @@ public:
 	/**
 	 * @brief Animation sprite
 	 */
-	std::optional<CelSprite> celSprite;
+	OptionalCelSprite celSprite;
 	/**
 	 * @brief How many game ticks are needed to advance one Animation Frame
 	 */
@@ -83,7 +82,7 @@ public:
 	 * @param distributeFramesBeforeFrame Distribute the numSkippedFrames only before this frame
 	 * @param previewShownGameTickFragments Defines how long (in game ticks fraction) the preview animation was shown
 	 */
-	void SetNewAnimation(std::optional<CelSprite> celSprite, int8_t numberOfFrames, int8_t ticksPerFrame, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int8_t numSkippedFrames = 0, int8_t distributeFramesBeforeFrame = 0, float previewShownGameTickFragments = 0.F);
+	void SetNewAnimation(OptionalCelSprite celSprite, int8_t numberOfFrames, int8_t ticksPerFrame, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int8_t numSkippedFrames = 0, int8_t distributeFramesBeforeFrame = 0, float previewShownGameTickFragments = 0.F);
 
 	/**
 	 * @brief Changes the Animation Data on-the-fly. This is needed if a animation is currently in progress and the player changes his gear.
@@ -91,7 +90,7 @@ public:
 	 * @param numberOfFrames Number of Frames in Animation
 	 * @param ticksPerFrame How many game ticks are needed to advance one Animation Frame
 	 */
-	void ChangeAnimationData(std::optional<CelSprite> celSprite, int8_t numberOfFrames, int8_t ticksPerFrame);
+	void ChangeAnimationData(OptionalCelSprite celSprite, int8_t numberOfFrames, int8_t ticksPerFrame);
 
 	/**
 	 * @brief Process the Animation for a game tick (for example advances the frame)

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -509,7 +509,7 @@ void DrawPlayer(const Surface &out, const Player &player, Point tilePosition, Po
 		return;
 	}
 
-	std::optional<CelSprite> sprite = player.AnimInfo.celSprite;
+	OptionalCelSprite sprite = player.AnimInfo.celSprite;
 	int nCel = player.AnimInfo.GetFrameToUseForRendering();
 
 	if (player.previewCelSprite) {
@@ -713,7 +713,7 @@ void DrawItem(const Surface &out, Point tilePosition, Point targetBufferPosition
 	if (item._iPostDraw == pre)
 		return;
 
-	std::optional<CelSprite> cel = item.AnimInfo.celSprite;
+	OptionalCelSprite cel = item.AnimInfo.celSprite;
 	if (!cel) {
 		Log("Draw Item \"{}\" 1: NULL CelSprite", item._iIName);
 		return;

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -31,7 +31,7 @@
 
 namespace devilution {
 
-std::optional<OwnedCelSprite> pSPentSpn2Cels;
+OptionalOwnedCelSprite pSPentSpn2Cels;
 
 namespace {
 

--- a/Source/engine/render/text_render.hpp
+++ b/Source/engine/render/text_render.hpp
@@ -123,7 +123,7 @@ private:
  *
  * Also used in the stores and the quest log.
  */
-extern std::optional<OwnedCelSprite> pSPentSpn2Cels;
+extern OptionalOwnedCelSprite pSPentSpn2Cels;
 
 void LoadSmallSelectionSpinner();
 

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -24,10 +24,10 @@ namespace devilution {
 
 namespace {
 
-std::optional<OwnedCelSprite> optbar_cel;
-std::optional<OwnedCelSprite> PentSpin_cel;
-std::optional<OwnedCelSprite> option_cel;
-std::optional<OwnedCelSprite> sgpLogo;
+OptionalOwnedCelSprite optbar_cel;
+OptionalOwnedCelSprite PentSpin_cel;
+OptionalOwnedCelSprite option_cel;
+OptionalOwnedCelSprite sgpLogo;
 bool mouseNavigation;
 TMenuItem *sgpCurrItem;
 int LogoAnim_tick;

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -30,7 +30,7 @@ namespace devilution {
 
 namespace {
 
-std::optional<OwnedCelSprite> sgpBackCel;
+OptionalOwnedCelSprite sgpBackCel;
 
 bool IsProgress;
 uint32_t sgdwProgress;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -137,7 +137,7 @@ const Point InvRect[] = {
 
 namespace {
 
-std::optional<OwnedCelSprite> pInvCels;
+OptionalOwnedCelSprite pInvCels;
 
 /**
  * @brief Adds an item to a player's InvGrid array

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -131,7 +131,7 @@ _sfx_id ItemInvSnds[] = {
 
 namespace {
 
-std::optional<OwnedCelSprite> itemanims[ITEMTYPES];
+OptionalOwnedCelSprite itemanims[ITEMTYPES];
 
 enum class PlayerArmorGraphic : uint8_t {
 	// clang-format off

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4582,7 +4582,7 @@ void Item::setNewAnimation(bool showAnimation)
 {
 	int8_t it = ItemCAnimTbl[_iCurs];
 	int8_t numberOfFrames = ItemAnimLs[it];
-	auto celSprite = itemanims[it] ? std::optional<CelSprite> { *itemanims[it] } : std::nullopt;
+	auto celSprite = itemanims[it] ? OptionalCelSprite { *itemanims[it] } : std::nullopt;
 	if (_iCurs != ICURS_MAGIC_ROCK)
 		AnimInfo.SetNewAnimation(celSprite, numberOfFrames, 1, AnimationDistributionFlags::ProcessAnimationPending, 0, numberOfFrames);
 	else

--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -21,7 +21,7 @@ Bitset2d<DMAXX, DMAXY> Protected;
 Rectangle SetPieceRoom;
 Rectangle SetPiece;
 std::unique_ptr<uint16_t[]> pSetPiece;
-std::optional<OwnedCelSprite> pSpecialCels;
+OptionalOwnedCelSprite pSpecialCels;
 std::unique_ptr<MegaTile[]> pMegaTiles;
 std::unique_ptr<byte[]> pDungeonCels;
 std::array<TileProperties, MAXTILES> SOLData;

--- a/Source/levels/gendung.h
+++ b/Source/levels/gendung.h
@@ -148,7 +148,7 @@ extern Rectangle SetPieceRoom;
 extern Rectangle SetPiece;
 /** Contains the contents of the single player quest DUN file. */
 extern std::unique_ptr<uint16_t[]> pSetPiece;
-extern std::optional<OwnedCelSprite> pSpecialCels;
+extern OptionalOwnedCelSprite pSpecialCels;
 /** Specifies the tile definitions of the active dungeon type; (e.g. levels/l1data/l1.til). */
 extern DVL_API_FOR_TEST std::unique_ptr<MegaTile[]> pMegaTiles;
 extern std::unique_ptr<byte[]> pDungeonCels;

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -30,7 +30,7 @@ int qtextSpd;
 /** Start time of scrolling */
 Uint32 ScrollStart;
 /** Graphics for the window border */
-std::optional<OwnedCelSprite> pTextBoxCels;
+OptionalOwnedCelSprite pTextBoxCels;
 
 /** Pixels for a line of text and the empty space under it. */
 const int LineHeight = 38;

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -20,7 +20,6 @@
 #include "monstdat.h"
 #include "spelldat.h"
 #include "textdat.h"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 
@@ -133,7 +132,7 @@ enum class LeaderRelation : uint8_t {
 };
 
 struct AnimStruct {
-	[[nodiscard]] std::optional<CelSprite> getCelSpritesForDirection(Direction direction) const
+	[[nodiscard]] OptionalCelSprite getCelSpritesForDirection(Direction direction) const
 	{
 		const byte *spriteData = celSpritesForDirections[static_cast<size_t>(direction)];
 		if (spriteData == nullptr)

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -17,7 +17,7 @@
 
 namespace devilution {
 
-std::optional<OwnedCelSprite> pChrButtons;
+OptionalOwnedCelSprite pChrButtons;
 
 /** Map of hero class names */
 const char *const ClassStrTbl[] = {

--- a/Source/panels/charpanel.hpp
+++ b/Source/panels/charpanel.hpp
@@ -5,7 +5,7 @@
 
 namespace devilution {
 
-extern std::optional<OwnedCelSprite> pChrButtons;
+extern OptionalOwnedCelSprite pChrButtons;
 extern const char *const ClassStrTbl[];
 
 void DrawChr(const Surface &);

--- a/Source/panels/charpanel.hpp
+++ b/Source/panels/charpanel.hpp
@@ -2,7 +2,6 @@
 
 #include "engine/cel_sprite.hpp"
 #include "engine/surface.hpp"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/panels/info_box.cpp
+++ b/Source/panels/info_box.cpp
@@ -4,8 +4,8 @@
 
 namespace devilution {
 
-std::optional<OwnedCelSprite> pSTextBoxCels;
-std::optional<OwnedCelSprite> pSTextSlidCels;
+OptionalOwnedCelSprite pSTextBoxCels;
+OptionalOwnedCelSprite pSTextSlidCels;
 
 void InitInfoBoxGfx()
 {

--- a/Source/panels/info_box.hpp
+++ b/Source/panels/info_box.hpp
@@ -9,14 +9,14 @@ namespace devilution {
  *
  * Used in stores, the quest log, the help window, and the unique item info window.
  */
-extern std::optional<OwnedCelSprite> pSTextBoxCels;
+extern OptionalOwnedCelSprite pSTextBoxCels;
 
 /**
  * @brief Info box scrollbar graphics.
  *
  * Used in stores and `DrawDiabloMsg`.
  */
-extern std::optional<OwnedCelSprite> pSTextSlidCels;
+extern OptionalOwnedCelSprite pSTextSlidCels;
 
 void InitInfoBoxGfx();
 void FreeInfoBoxGfx();

--- a/Source/panels/info_box.hpp
+++ b/Source/panels/info_box.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "engine/cel_sprite.hpp"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -21,12 +21,12 @@
 
 namespace devilution {
 
-std::optional<OwnedCelSprite> pSBkIconCels;
+OptionalOwnedCelSprite pSBkIconCels;
 
 namespace {
 
-std::optional<OwnedCelSprite> pSBkBtnCel;
-std::optional<OwnedCelSprite> pSpellBkCel;
+OptionalOwnedCelSprite pSBkBtnCel;
+OptionalOwnedCelSprite pSpellBkCel;
 
 /** Maps from spellbook page number and position to spell_id. */
 spell_id SpellPages[6][7] = {

--- a/Source/panels/spell_icons.cpp
+++ b/Source/panels/spell_icons.cpp
@@ -9,7 +9,7 @@
 namespace devilution {
 
 namespace {
-std::optional<OwnedCelSprite> pSpellCels;
+OptionalOwnedCelSprite pSpellCels;
 uint8_t SplTransTbl[256];
 } // namespace
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -368,7 +368,7 @@ void StartWalk(int pnum, Displacement vel, Direction dir, bool pmWillBeCalled)
 	StartWalkAnimation(player, dir, pmWillBeCalled);
 }
 
-void SetPlayerGPtrs(const char *path, std::unique_ptr<byte[]> &data, std::array<std::optional<CelSprite>, 8> &anim, int width)
+void SetPlayerGPtrs(const char *path, std::unique_ptr<byte[]> &data, std::array<OptionalCelSprite, 8> &anim, int width)
 {
 	data = nullptr;
 	data = LoadFileInMem(path);
@@ -2188,7 +2188,7 @@ void Player::UpdatePreviewCelSprite(_cmd_id cmdId, Point point, uint16_t wParam1
 		return;
 
 	LoadPlrGFX(*this, *graphic);
-	std::optional<CelSprite> celSprites = AnimationData[static_cast<size_t>(*graphic)].GetCelSpritesForDirection(dir);
+	OptionalCelSprite celSprites = AnimationData[static_cast<size_t>(*graphic)].GetCelSpritesForDirection(dir);
 	if (celSprites && previewCelSprite != celSprites) {
 		previewCelSprite = celSprites;
 		progressToNextGameTickWhenPreviewWasSet = gfProgressToNextGameTick;
@@ -2343,7 +2343,7 @@ void NewPlrAnim(Player &player, player_graphic graphic, Direction dir, int8_t nu
 {
 	LoadPlrGFX(player, graphic);
 
-	std::optional<CelSprite> celSprite = player.AnimationData[static_cast<size_t>(graphic)].GetCelSpritesForDirection(dir);
+	OptionalCelSprite celSprite = player.AnimationData[static_cast<size_t>(graphic)].GetCelSpritesForDirection(dir);
 
 	float previewShownGameTickFragments = 0.F;
 	if (celSprite == player.previewCelSprite && !player.IsWalking())

--- a/Source/player.h
+++ b/Source/player.h
@@ -196,14 +196,14 @@ struct PlayerAnimationData {
 	/**
 	 * @brief CelSprites for the different directions
 	 */
-	std::array<std::optional<CelSprite>, 8> CelSpritesForDirections;
+	std::array<OptionalCelSprite, 8> CelSpritesForDirections;
 	/**
 	 * @brief Raw Data (binary) of the CL2 file.
 	 *        Is referenced from CelSprite in celSpritesForDirections
 	 */
 	std::unique_ptr<byte[]> RawData;
 
-	[[nodiscard]] std::optional<CelSprite> GetCelSpritesForDirection(Direction direction) const
+	[[nodiscard]] OptionalCelSprite GetCelSpritesForDirection(Direction direction) const
 	{
 		return CelSpritesForDirections[static_cast<size_t>(direction)];
 	}
@@ -234,7 +234,7 @@ struct Player {
 	/**
 	 * @brief Contains a optional preview CelSprite that is displayed until the current command is handled by the game logic
 	 */
-	std::optional<CelSprite> previewCelSprite;
+	OptionalCelSprite previewCelSprite;
 	/**
 	 * @brief Contains the progress to next game tick when previewCelSprite was set
 	 */

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -30,7 +30,7 @@
 namespace devilution {
 
 bool QuestLogIsOpen;
-std::optional<OwnedCelSprite> pQLogCel;
+OptionalOwnedCelSprite pQLogCel;
 /** Contains the quests of the current game. */
 Quest Quests[MAXQUESTS];
 Point ReturnLvlPosition;

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -16,7 +16,6 @@
 #include "panels/info_box.hpp"
 #include "textdat.h"
 #include "utils/attributes.h"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -73,7 +73,7 @@ struct QuestData {
 };
 
 extern bool QuestLogIsOpen;
-extern std::optional<OwnedCelSprite> pQLogCel;
+extern OptionalOwnedCelSprite pQLogCel;
 extern DVL_API_FOR_TEST Quest Quests[MAXQUESTS];
 extern Point ReturnLvlPosition;
 extern dungeon_type ReturnLevelType;

--- a/Source/utils/stdcompat/optional.hpp
+++ b/Source/utils/stdcompat/optional.hpp
@@ -7,6 +7,7 @@
 #include <experimental/optional> // IWYU pragma: export
 #define optional experimental::optional
 #define nullopt experimental::nullopt
+#define nullopt_t experimental::nullopt_t
 #else
 #error "Missing support for <optional> or <experimental/optional>"
 #endif


### PR DESCRIPTION
`CelSprite` data pointer can never be `nullptr`.

We implement a smaller `optional` for it by taking advantage of that.

Saves 8 bytes per optional `CelSprite`:

```c++
sizeof(OptionalCelSprite) == 16
sizeof(std::optional<OptionalCelSprite>) == 24
```

@ephphatha 