### PR TITLE
upload windows artifacts to second repo

### DIFF
--- a/.github/workflows/Windows_x64.yml
+++ b/.github/workflows/Windows_x64.yml
@@ -39,3 +39,35 @@ jobs:
       with:
         name: devilutionx_x64.zip
         path: build/devilutionx.zip
+        
+    - name: Move artifacts to new folder and split exe and other data into two folders
+      if: ${{ !env.ACT && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
+      working-directory: ${{github.workspace}}
+      shell: bash
+      run: mkdir artifacts_dir && unzip build/devilutionx.zip -d artifacts_dir && mkdir artifacts_dir/exe_dir && mv artifacts_dir/devilutionx/devilutionx.exe artifacts_dir/exe_dir && zip -m artifacts_dir/exe_dir/build.zip artifacts_dir/exe_dir/devilutionx.exe
+
+    - name: Pushes exe to another repository
+      if: ${{ !env.ACT && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
+      uses: cpina/github-action-push-to-another-repository@main
+      env:
+        SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+      with:
+        source-directory: artifacts_dir/exe_dir
+        destination-github-username: 'artifacts-storage'
+        destination-repository-name: 'devilutionx-artifacts'     
+        target-directory: ${{ github.sha }}
+        commit-message: "[EXE]${{ github.event.head_commit.message }}"
+        target-branch: master
+        
+    - name: Pushes DLLs and devilutionx.mpq to another repository
+      if: ${{ !env.ACT && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
+      uses: cpina/github-action-push-to-another-repository@main
+      env:
+        SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+      with:
+        source-directory: artifacts_dir/devilutionx/
+        destination-github-username: 'artifacts-storage'
+        destination-repository-name: 'devilutionx-artifacts' 
+        target-directory: data
+        commit-message: "[DATA]${{ github.event.head_commit.message }}"
+        target-branch: master


### PR DESCRIPTION
Will upload artifacts from every windows master build to https://github.com/artifacts-storage/devilutionx-artifacts
Should be pretty useful for bisecting in the future as builds take a pretty long time and after 1.4.0 a lot of them failed locally for me 
zip takes 9.45 mb, max github repo size is 10gb = artifacts from ~1k commits, let's worry about the limit when we get there :D

I've split exe and all other data - zip with exe takes 2.35mb, other data (DLLs, devilutionx.mpq, licenses) rarely changes so it shouldn't take much = we good for 4k commits? :D