### PR TITLE
Minimize propegation of global Players index

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1897,11 +1897,11 @@ bool TryIconCurs()
 
 	if (pcurs == CURSOR_TELEPORT) {
 		if (pcursmonst != -1)
-			NetSendCmdParam3(true, CMD_TSPELLID, pcursmonst, myPlayer._pTSpell, GetSpellLevel(MyPlayerId, myPlayer._pTSpell));
+			NetSendCmdParam3(true, CMD_TSPELLID, pcursmonst, myPlayer._pTSpell, GetSpellLevel(myPlayer, myPlayer._pTSpell));
 		else if (pcursplr != -1)
-			NetSendCmdParam3(true, CMD_TSPELLPID, pcursplr, myPlayer._pTSpell, GetSpellLevel(MyPlayerId, myPlayer._pTSpell));
+			NetSendCmdParam3(true, CMD_TSPELLPID, pcursplr, myPlayer._pTSpell, GetSpellLevel(myPlayer, myPlayer._pTSpell));
 		else
-			NetSendCmdLocParam2(true, CMD_TSPELLXY, cursPosition, myPlayer._pTSpell, GetSpellLevel(MyPlayerId, myPlayer._pTSpell));
+			NetSendCmdLocParam2(true, CMD_TSPELLXY, cursPosition, myPlayer._pTSpell, GetSpellLevel(myPlayer, myPlayer._pTSpell));
 		NewCursor(CURSOR_HAND);
 		return true;
 	}

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -489,7 +489,7 @@ void DrawPlayerIconHelper(const Surface &out, missile_graphic_id missileGraphicI
  * @param position Output buffer coordinates
  * @param lighting Should lighting be applied
  */
-void DrawPlayerIcons(const Surface &out, Player &player, Point position, bool infraVision)
+void DrawPlayerIcons(const Surface &out, const Player &player, Point position, bool infraVision)
 {
 	if (player.pManaShield)
 		DrawPlayerIconHelper(out, MFILE_MANASHLD, position, &player != MyPlayer, infraVision);
@@ -500,20 +500,14 @@ void DrawPlayerIcons(const Surface &out, Player &player, Point position, bool in
 /**
  * @brief Render a player sprite
  * @param out Output buffer
- * @param pnum Player id
  * @param tilePosition dPiece coordinates
  * @param targetBufferPosition Output buffer coordinates
- * @param pCelBuff sprite buffer
- * @param nCel frame
- * @param nWidth width
  */
-void DrawPlayer(const Surface &out, int pnum, Point tilePosition, Point targetBufferPosition)
+void DrawPlayer(const Surface &out, const Player &player, Point tilePosition, Point targetBufferPosition)
 {
 	if (!IsTileLit(tilePosition) && !MyPlayer->_pInfraFlag && leveltype != DTYPE_TOWN) {
 		return;
 	}
-
-	Player &player = Players[pnum];
 
 	std::optional<CelSprite> sprite = player.AnimInfo.celSprite;
 	int nCel = player.AnimInfo.GetFrameToUseForRendering();
@@ -524,7 +518,7 @@ void DrawPlayer(const Surface &out, int pnum, Point tilePosition, Point targetBu
 	}
 
 	if (!sprite) {
-		Log("Drawing player {} \"{}\": NULL CelSprite", pnum, player._pName);
+		Log("Drawing player {} \"{}\": NULL CelSprite", std::distance(const_cast<const Player *>(&Players[0]), &player), player._pName);
 		return;
 	}
 
@@ -537,7 +531,7 @@ void DrawPlayer(const Surface &out, int pnum, Point tilePosition, Point targetBu
 			szMode = PlayerModeNames[player._pmode];
 		Log(
 		    "Drawing player {} \"{}\" {}: facing {}, frame {} of {}",
-		    pnum,
+		    std::distance(const_cast<const Player *>(&Players[0]), &player),
 		    player._pName,
 		    szMode,
 		    DirectionToString(player._pdir),
@@ -546,10 +540,10 @@ void DrawPlayer(const Surface &out, int pnum, Point tilePosition, Point targetBu
 		return;
 	}
 
-	if (pnum == pcursplr)
+	if (pcursplr >= 0 && pcursplr < MAX_PLRS && &player == &Players[pcursplr])
 		Cl2DrawOutline(out, 165, spriteBufferPosition.x, spriteBufferPosition.y, *sprite, nCel);
 
-	if (pnum == MyPlayerId) {
+	if (&player == MyPlayer) {
 		Cl2Draw(out, spriteBufferPosition.x, spriteBufferPosition.y, *sprite, nCel);
 		DrawPlayerIcons(out, player, targetBufferPosition, false);
 		return;
@@ -588,7 +582,7 @@ void DrawDeadPlayer(const Surface &out, Point tilePosition, Point targetBufferPo
 		if (player.plractive && player._pHitPoints == 0 && player.isOnActiveLevel() && player.position.tile == tilePosition) {
 			dFlags[tilePosition.x][tilePosition.y] |= DungeonFlag::DeadPlayer;
 			const Point playerRenderPosition { targetBufferPosition + player.position.offset };
-			DrawPlayer(out, i, tilePosition, playerRenderPosition);
+			DrawPlayer(out, player, tilePosition, playerRenderPosition);
 		}
 	}
 }
@@ -803,10 +797,8 @@ void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBuffe
  * @param tilePosition dPiece coordinates
  * @param targetBufferPosition Output buffer coordinates
  */
-void DrawPlayerHelper(const Surface &out, int p, Point tilePosition, Point targetBufferPosition)
+void DrawPlayerHelper(const Surface &out, const Player &player, Point tilePosition, Point targetBufferPosition)
 {
-	Player &player = Players[p];
-
 	Displacement offset = player.position.offset;
 	if (player.IsWalking()) {
 		offset = GetOffsetForWalking(player.AnimInfo, player._pdir);
@@ -814,7 +806,7 @@ void DrawPlayerHelper(const Surface &out, int p, Point tilePosition, Point targe
 
 	const Point playerRenderPosition { targetBufferPosition + offset };
 
-	DrawPlayer(out, p, tilePosition, playerRenderPosition);
+	DrawPlayer(out, player, tilePosition, playerRenderPosition);
 }
 
 /**
@@ -876,7 +868,7 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 	}
 	int8_t playerId = dPlayer[tilePosition.x][tilePosition.y];
 	if (playerId > 0 && playerId <= MAX_PLRS) {
-		DrawPlayerHelper(out, abs(playerId) - 1, tilePosition, targetBufferPosition);
+		DrawPlayerHelper(out, Players[abs(playerId) - 1], tilePosition, targetBufferPosition);
 	}
 	if (dMonster[tilePosition.x][tilePosition.y] > 0) {
 		DrawMonsterHelper(out, tilePosition, targetBufferPosition);

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -13,6 +13,7 @@
 #include "miniwin/miniwin.h"
 #include "misdat.h"
 #include "monster.h"
+#include "player.h"
 #include "spelldat.h"
 
 namespace devilution {
@@ -138,7 +139,7 @@ extern std::list<Missile> Missiles;
 extern bool MissilePreFlag;
 
 void GetDamageAmt(int i, int *mind, int *maxd);
-int GetSpellLevel(int playerId, spell_id sn);
+int GetSpellLevel(const Player &player, spell_id sn);
 
 /**
  * @brief Returns the direction a vector from p1(x1, y1) to p2(x2, y2) is pointing to.

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2030,14 +2030,13 @@ DWORD OnDebug(const TCmd *pCmd)
 	return sizeof(*pCmd);
 }
 
-DWORD OnNova(const TCmd *pCmd, int pnum)
+DWORD OnNova(const TCmd *pCmd, Player &player)
 {
 	const auto &message = *reinterpret_cast<const TCmdLoc *>(pCmd);
 	const Point position { message.x, message.y };
 
 	if (gbBufferMsgs != 1) {
-		Player &player = Players[pnum];
-		if (player.isOnActiveLevel() && pnum != MyPlayerId && InDungeonBounds(position)) {
+		if (player.isOnActiveLevel() && &player != MyPlayer && InDungeonBounds(position)) {
 			ClrPlrPath(player);
 			player._pSpell = SPL_NOVA;
 			player._pSplType = RSPLTYPE_INVALID;
@@ -3060,7 +3059,7 @@ uint32_t ParseCmd(int pnum, const TCmd *pCmd)
 	case CMD_CHEAT_SPELL_LEVEL:
 		return OnCheatSpellLevel(pCmd, pnum);
 	case CMD_NOVA:
-		return OnNova(pCmd, pnum);
+		return OnNova(pCmd, player);
 	case CMD_SETSHIELD:
 		return OnSetShield(pCmd, player);
 	case CMD_REMSHIELD:

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2093,20 +2093,20 @@ void OperateL5LDoor(int oi, bool sendflag)
 	}
 }
 
-void OperateL1Door(int pnum, int i)
+void OperateL1Door(const Player &player, int i)
 {
-	int dpx = abs(Objects[i].position.x - Players[pnum].position.tile.x);
-	int dpy = abs(Objects[i].position.y - Players[pnum].position.tile.y);
+	int dpx = abs(Objects[i].position.x - player.position.tile.x);
+	int dpy = abs(Objects[i].position.y - player.position.tile.y);
 	if (dpx == 1 && dpy <= 1 && Objects[i]._otype == OBJ_L1LDOOR)
 		OperateL1LDoor(i, true);
 	if (dpx <= 1 && dpy == 1 && Objects[i]._otype == OBJ_L1RDOOR)
 		OperateL1RDoor(i, true);
 }
 
-void OperateL5Door(int pnum, int i)
+void OperateL5Door(const Player &player, int i)
 {
-	int dpx = abs(Objects[i].position.x - Players[pnum].position.tile.x);
-	int dpy = abs(Objects[i].position.y - Players[pnum].position.tile.y);
+	int dpx = abs(Objects[i].position.x - player.position.tile.x);
+	int dpy = abs(Objects[i].position.y - player.position.tile.y);
 	if (dpx == 1 && dpy <= 1 && Objects[i]._otype == OBJ_L5LDOOR)
 		OperateL5LDoor(i, true);
 	if (dpx <= 1 && dpy == 1 && Objects[i]._otype == OBJ_L5RDOOR)
@@ -2345,7 +2345,7 @@ void OperateChest(int pnum, int i, bool sendmsg)
 		}
 	}
 	if (Objects[i].IsTrappedChest()) {
-		Player &player = Players[pnum];
+		const Player &player = Players[pnum];
 		Direction mdir = GetDirection(Objects[i].position, player.position.tile);
 		missile_id mtype;
 		switch (Objects[i]._oVar4) {
@@ -2377,15 +2377,15 @@ void OperateChest(int pnum, int i, bool sendmsg)
 		NetSendCmdParam2(false, CMD_PLROPOBJ, pnum, i);
 }
 
-void OperateMushroomPatch(int pnum, Object &questContainer)
+void OperateMushroomPatch(const Player &player, Object &questContainer)
 {
 	if (ActiveItemCount >= MAXITEMS) {
 		return;
 	}
 
 	if (Quests[Q_MUSHROOM]._qactive != QUEST_ACTIVE) {
-		if (pnum == MyPlayerId) {
-			Players[pnum].Say(HeroSpeech::ICantUseThisYet);
+		if (&player == MyPlayer) {
+			player.Say(HeroSpeech::ICantUseThisYet);
 		}
 		return;
 	}
@@ -2403,15 +2403,15 @@ void OperateMushroomPatch(int pnum, Object &questContainer)
 	Quests[Q_MUSHROOM]._qvar1 = QS_MUSHSPAWNED;
 }
 
-void OperateInnSignChest(int pnum, Object &questContainer)
+void OperateInnSignChest(const Player &player, Object &questContainer)
 {
 	if (ActiveItemCount >= MAXITEMS) {
 		return;
 	}
 
 	if (Quests[Q_LTBANNER]._qvar1 != 2) {
-		if (pnum == MyPlayerId) {
-			Players[pnum].Say(HeroSpeech::ICantOpenThisYet);
+		if (&player == MyPlayer) {
+			player.Say(HeroSpeech::ICantOpenThisYet);
 		}
 		return;
 	}
@@ -2428,14 +2428,12 @@ void OperateInnSignChest(int pnum, Object &questContainer)
 	SpawnQuestItem(IDI_BANNER, pos, 0, 0);
 }
 
-void OperateSlainHero(int pnum, int i)
+void OperateSlainHero(const Player &player, int i)
 {
 	if (Objects[i]._oSelFlag == 0) {
 		return;
 	}
 	Objects[i]._oSelFlag = 0;
-
-	Player &player = Players[pnum];
 
 	if (player._pClass == HeroClass::Warrior) {
 		CreateMagicArmor(Objects[i].position, ItemType::HeavyArmor, ICURS_BREAST_PLATE, true, false);
@@ -2451,7 +2449,7 @@ void OperateSlainHero(int pnum, int i)
 		CreateMagicWeapon(Objects[i].position, ItemType::Axe, ICURS_BATTLE_AXE, true, false);
 	}
 	MyPlayer->Say(HeroSpeech::RestInPeaceMyFriend);
-	if (pnum == MyPlayerId)
+	if (&player == MyPlayer)
 		NetSendCmdParam1(false, CMD_OPERATEOBJ, i);
 }
 
@@ -2483,7 +2481,7 @@ void OperateTrapLever(Object &flameLever)
 	}
 }
 
-void OperateSarc(int pnum, int i, bool sendmsg)
+void OperateSarc(int i, bool sendMsg, bool sendLootMsg)
 {
 	if (Objects[i]._oSelFlag == 0) {
 		return;
@@ -2495,27 +2493,27 @@ void OperateSarc(int pnum, int i, bool sendmsg)
 	Objects[i]._oAnimDelay = 3;
 	SetRndSeed(Objects[i]._oRndSeed);
 	if (Objects[i]._oVar1 <= 2)
-		CreateRndItem(Objects[i].position, false, sendmsg, false);
+		CreateRndItem(Objects[i].position, false, sendLootMsg, false);
 	if (Objects[i]._oVar1 >= 8)
 		SpawnSkeleton(Objects[i]._oVar2, Objects[i].position);
-	if (pnum == MyPlayerId)
+	if (sendMsg)
 		NetSendCmdParam1(false, CMD_OPERATEOBJ, i);
 }
 
-void OperateL2Door(int pnum, int i)
+void OperateL2Door(const Player &player, int i)
 {
-	int dpx = abs(Objects[i].position.x - Players[pnum].position.tile.x);
-	int dpy = abs(Objects[i].position.y - Players[pnum].position.tile.y);
+	int dpx = abs(Objects[i].position.x - player.position.tile.x);
+	int dpy = abs(Objects[i].position.y - player.position.tile.y);
 	if (dpx == 1 && dpy <= 1 && Objects[i]._otype == OBJ_L2LDOOR)
 		OperateL2LDoor(i, true);
 	if (dpx <= 1 && dpy == 1 && Objects[i]._otype == OBJ_L2RDOOR)
 		OperateL2RDoor(i, true);
 }
 
-void OperateL3Door(int pnum, int i)
+void OperateL3Door(const Player &player, int i)
 {
-	int dpx = abs(Objects[i].position.x - Players[pnum].position.tile.x);
-	int dpy = abs(Objects[i].position.y - Players[pnum].position.tile.y);
+	int dpx = abs(Objects[i].position.x - player.position.tile.x);
+	int dpy = abs(Objects[i].position.y - player.position.tile.y);
 	if (dpx == 1 && dpy <= 1 && Objects[i]._otype == OBJ_L3RDOOR)
 		OperateL3RDoor(i, true);
 	if (dpx <= 1 && dpy == 1 && Objects[i]._otype == OBJ_L3LDOOR)
@@ -2697,7 +2695,7 @@ void OperateShrineWeird(Player &player)
 
 void OperateShrineMagical(int pnum)
 {
-	Player &player = Players[pnum];
+	const Player &player = Players[pnum];
 
 	AddMissile(
 	    player.position.tile,
@@ -2778,7 +2776,7 @@ void OperateShrineEnchanted(Player &player)
 	InitDiabloMsg(EMSG_SHRINE_ENCHANTED);
 }
 
-void OperateShrineThaumaturgic(Player &player)
+void OperateShrineThaumaturgic(const Player &player)
 {
 	for (int j = 0; j < ActiveObjectCount; j++) {
 		int v1 = ActiveObjects[j];
@@ -2925,7 +2923,7 @@ void OperateShrineDivine(Player &player, Point spawnPosition)
 
 void OperateShrineHoly(int pnum)
 {
-	Player &player = Players[pnum];
+	const Player &player = Players[pnum];
 
 	AddMissile(player.position.tile, { 0, 0 }, Direction::South, MIS_RNDTELEPORT, TARGET_PLAYERS, pnum, 0, 2 * leveltype);
 
@@ -2954,7 +2952,7 @@ void OperateShrineSpiritual(Player &player)
 	InitDiabloMsg(EMSG_SHRINE_SPIRITUAL);
 }
 
-void OperateShrineSpooky(Player &player)
+void OperateShrineSpooky(const Player &player)
 {
 	if (&player == MyPlayer) {
 		InitDiabloMsg(EMSG_SHRINE_SPOOKY1);
@@ -3012,7 +3010,7 @@ void OperateShrineQuiet(Player &player)
 	InitDiabloMsg(EMSG_SHRINE_QUIET);
 }
 
-void OperateShrineSecluded(Player &player)
+void OperateShrineSecluded(const Player &player)
 {
 	if (&player != MyPlayer)
 		return;
@@ -3041,7 +3039,7 @@ void OperateShrineGlimmering(Player &player)
 	InitDiabloMsg(EMSG_SHRINE_GLIMMERING);
 }
 
-void OperateShrineTainted(Player &player)
+void OperateShrineTainted(const Player &player)
 {
 	if (&player == MyPlayer) {
 		InitDiabloMsg(EMSG_SHRINE_TAINTED1);
@@ -3186,7 +3184,7 @@ void OperateShrineSparkling(Player &player, Point spawnPosition)
  */
 void OperateShrineTown(int pnum, Point spawnPosition)
 {
-	Player &player = Players[pnum];
+	const Player &player = Players[pnum];
 
 	if (&player != MyPlayer)
 		return;
@@ -3396,7 +3394,7 @@ void OperateShrine(int pnum, int i, _sfx_id sType)
 		NetSendCmdParam2(false, CMD_PLROPOBJ, pnum, i);
 }
 
-void OperateSkelBook(int pnum, int i, bool sendmsg)
+void OperateSkelBook(int i, bool sendmsg, bool sendLootMsg)
 {
 	if (Objects[i]._oSelFlag == 0) {
 		return;
@@ -3407,14 +3405,14 @@ void OperateSkelBook(int pnum, int i, bool sendmsg)
 	Objects[i]._oAnimFrame += 2;
 	SetRndSeed(Objects[i]._oRndSeed);
 	if (GenerateRnd(5) != 0)
-		CreateTypeItem(Objects[i].position, false, ItemType::Misc, IMISC_SCROLL, sendmsg, false);
+		CreateTypeItem(Objects[i].position, false, ItemType::Misc, IMISC_SCROLL, sendLootMsg, false);
 	else
-		CreateTypeItem(Objects[i].position, false, ItemType::Misc, IMISC_BOOK, sendmsg, false);
-	if (pnum == MyPlayerId)
+		CreateTypeItem(Objects[i].position, false, ItemType::Misc, IMISC_BOOK, sendLootMsg, false);
+	if (sendmsg)
 		NetSendCmdParam1(false, CMD_OPERATEOBJ, i);
 }
 
-void OperateBookCase(int pnum, int i, bool sendmsg)
+void OperateBookCase(int i, bool sendmsg, bool sendLootMsg)
 {
 	if (Objects[i]._oSelFlag == 0) {
 		return;
@@ -3424,7 +3422,7 @@ void OperateBookCase(int pnum, int i, bool sendmsg)
 	Objects[i]._oSelFlag = 0;
 	Objects[i]._oAnimFrame -= 2;
 	SetRndSeed(Objects[i]._oRndSeed);
-	CreateTypeItem(Objects[i].position, false, ItemType::Misc, IMISC_BOOK, sendmsg, false);
+	CreateTypeItem(Objects[i].position, false, ItemType::Misc, IMISC_BOOK, sendLootMsg, false);
 
 	if (Quests[Q_ZHAR].IsAvailable()) {
 		auto &zhar = Monsters[MAX_PLRS];
@@ -3438,23 +3436,23 @@ void OperateBookCase(int pnum, int i, bool sendmsg)
 			zhar._mmode = MonsterMode::Talk;
 		}
 	}
-	if (pnum == MyPlayerId)
+	if (sendmsg)
 		NetSendCmdParam1(false, CMD_OPERATEOBJ, i);
 }
 
-void OperateDecap(int pnum, int i, bool sendmsg)
+void OperateDecap(int i, bool sendmsg, bool sendLootMsg)
 {
 	if (Objects[i]._oSelFlag == 0) {
 		return;
 	}
 	Objects[i]._oSelFlag = 0;
 	SetRndSeed(Objects[i]._oRndSeed);
-	CreateRndItem(Objects[i].position, false, sendmsg, false);
-	if (pnum == MyPlayerId)
+	CreateRndItem(Objects[i].position, false, sendLootMsg, false);
+	if (sendmsg)
 		NetSendCmdParam1(false, CMD_OPERATEOBJ, i);
 }
 
-void OperateArmorStand(int pnum, int i, bool sendmsg)
+void OperateArmorStand(int i, bool sendmsg, bool sendLootMsg)
 {
 	if (Objects[i]._oSelFlag == 0) {
 		return;
@@ -3464,15 +3462,15 @@ void OperateArmorStand(int pnum, int i, bool sendmsg)
 	SetRndSeed(Objects[i]._oRndSeed);
 	bool uniqueRnd = (GenerateRnd(2) != 0);
 	if (currlevel <= 5) {
-		CreateTypeItem(Objects[i].position, true, ItemType::LightArmor, IMISC_NONE, sendmsg, false);
+		CreateTypeItem(Objects[i].position, true, ItemType::LightArmor, IMISC_NONE, sendLootMsg, false);
 	} else if (currlevel >= 6 && currlevel <= 9) {
-		CreateTypeItem(Objects[i].position, uniqueRnd, ItemType::MediumArmor, IMISC_NONE, sendmsg, false);
+		CreateTypeItem(Objects[i].position, uniqueRnd, ItemType::MediumArmor, IMISC_NONE, sendLootMsg, false);
 	} else if (currlevel >= 10 && currlevel <= 12) {
-		CreateTypeItem(Objects[i].position, false, ItemType::HeavyArmor, IMISC_NONE, sendmsg, false);
+		CreateTypeItem(Objects[i].position, false, ItemType::HeavyArmor, IMISC_NONE, sendLootMsg, false);
 	} else if (currlevel >= 13) {
-		CreateTypeItem(Objects[i].position, true, ItemType::HeavyArmor, IMISC_NONE, sendmsg, false);
+		CreateTypeItem(Objects[i].position, true, ItemType::HeavyArmor, IMISC_NONE, sendLootMsg, false);
 	}
-	if (pnum == MyPlayerId)
+	if (sendmsg)
 		NetSendCmdParam1(false, CMD_OPERATEOBJ, i);
 }
 
@@ -3610,7 +3608,7 @@ bool OperateFountains(int pnum, int i)
 	return applied;
 }
 
-void OperateWeaponRack(int pnum, int i, bool sendmsg)
+void OperateWeaponRack(int i, bool sendmsg, bool sendLootMsg)
 {
 	if (Objects[i]._oSelFlag == 0)
 		return;
@@ -3621,9 +3619,9 @@ void OperateWeaponRack(int pnum, int i, bool sendmsg)
 	Objects[i]._oSelFlag = 0;
 	Objects[i]._oAnimFrame++;
 
-	CreateTypeItem(Objects[i].position, leveltype != DTYPE_CATHEDRAL, weaponType, IMISC_NONE, sendmsg, false);
+	CreateTypeItem(Objects[i].position, leveltype != DTYPE_CATHEDRAL, weaponType, IMISC_NONE, sendLootMsg, false);
 
-	if (pnum == MyPlayerId)
+	if (sendmsg)
 		NetSendCmdParam1(false, CMD_OPERATEOBJ, i);
 }
 
@@ -3660,9 +3658,9 @@ bool OperateNakrulBook(int s)
 	return false;
 }
 
-void OperateStoryBook(int pnum, int i)
+void OperateStoryBook(int i)
 {
-	if (Objects[i]._oSelFlag == 0 || qtextflag || pnum != MyPlayerId) {
+	if (Objects[i]._oSelFlag == 0 || qtextflag) {
 		return;
 	}
 	Objects[i]._oAnimFrame = Objects[i]._oVar4;
@@ -3682,13 +3680,13 @@ void OperateStoryBook(int pnum, int i)
 	NetSendCmdParam1(false, CMD_OPERATEOBJ, i);
 }
 
-void OperateLazStand(int pnum, int i)
+void OperateLazStand(int i)
 {
 	if (ActiveItemCount >= MAXITEMS) {
 		return;
 	}
 
-	if (Objects[i]._oSelFlag == 0 || qtextflag || pnum != MyPlayerId) {
+	if (Objects[i]._oSelFlag == 0 || qtextflag) {
 		return;
 	}
 
@@ -4694,7 +4692,7 @@ void ProcessObjects()
 
 void RedoPlayerVision()
 {
-	for (Player &player : Players) {
+	for (const Player &player : Players) {
 		if (player.plractive && player.isOnActiveLevel()) {
 			ChangeVisionXY(player._pvid, player.position.tile);
 		}
@@ -4791,29 +4789,6 @@ void ObjChangeMapResync(int x1, int y1, int x2, int y2)
 	}
 }
 
-void TryDisarm(int pnum, int i)
-{
-	if (pnum == MyPlayerId)
-		NewCursor(CURSOR_HAND);
-	if (!Objects[i]._oTrapFlag) {
-		return;
-	}
-	int trapdisper = 2 * Players[pnum]._pDexterity - 5 * currlevel;
-	if (GenerateRnd(100) > trapdisper) {
-		return;
-	}
-	for (int j = 0; j < ActiveObjectCount; j++) {
-		Object &trap = Objects[ActiveObjects[j]];
-		if (trap.IsTrap() && dObject[trap._oVar1][trap._oVar2] - 1 == i) {
-			trap._oVar4 = 1;
-			Objects[i]._oTrapFlag = false;
-		}
-	}
-	if (Objects[i].IsTrappedChest()) {
-		Objects[i]._oTrapFlag = false;
-	}
-}
-
 int ItemMiscIdIdx(item_misc_id imiscid)
 {
 	int i = IDI_GOLD;
@@ -4827,6 +4802,7 @@ int ItemMiscIdIdx(item_misc_id imiscid)
 void OperateObject(int pnum, int i, bool teleFlag)
 {
 	bool sendmsg = pnum == MyPlayerId;
+	const Player &player = Players[pnum];
 	switch (Objects[i]._otype) {
 	case OBJ_L1LDOOR:
 	case OBJ_L1RDOOR:
@@ -4838,7 +4814,7 @@ void OperateObject(int pnum, int i, bool teleFlag)
 			break;
 		}
 		if (sendmsg)
-			OperateL1Door(pnum, i);
+			OperateL1Door(player, i);
 		break;
 	case OBJ_L2LDOOR:
 	case OBJ_L2RDOOR:
@@ -4850,7 +4826,7 @@ void OperateObject(int pnum, int i, bool teleFlag)
 			break;
 		}
 		if (sendmsg)
-			OperateL2Door(pnum, i);
+			OperateL2Door(player, i);
 		break;
 	case OBJ_L3LDOOR:
 	case OBJ_L3RDOOR:
@@ -4862,7 +4838,7 @@ void OperateObject(int pnum, int i, bool teleFlag)
 			break;
 		}
 		if (sendmsg)
-			OperateL3Door(pnum, i);
+			OperateL3Door(player, i);
 		break;
 	case OBJ_L5LDOOR:
 	case OBJ_L5RDOOR:
@@ -4874,7 +4850,7 @@ void OperateObject(int pnum, int i, bool teleFlag)
 			break;
 		}
 		if (sendmsg)
-			OperateL5Door(pnum, i);
+			OperateL5Door(player, i);
 		break;
 	case OBJ_LEVER:
 	case OBJ_L5LEVER:
@@ -4897,7 +4873,7 @@ void OperateObject(int pnum, int i, bool teleFlag)
 		break;
 	case OBJ_SARC:
 	case OBJ_L5SARC:
-		OperateSarc(pnum, i, sendmsg);
+		OperateSarc(i, sendmsg, sendmsg);
 		break;
 	case OBJ_FLAMELVR:
 		OperateTrapLever(Objects[i]);
@@ -4913,18 +4889,18 @@ void OperateObject(int pnum, int i, bool teleFlag)
 		break;
 	case OBJ_SKELBOOK:
 	case OBJ_BOOKSTAND:
-		OperateSkelBook(pnum, i, sendmsg);
+		OperateSkelBook(i, sendmsg, sendmsg);
 		break;
 	case OBJ_BOOKCASEL:
 	case OBJ_BOOKCASER:
-		OperateBookCase(pnum, i, sendmsg);
+		OperateBookCase(i, sendmsg, sendmsg);
 		break;
 	case OBJ_DECAP:
-		OperateDecap(pnum, i, sendmsg);
+		OperateDecap(i, sendmsg, sendmsg);
 		break;
 	case OBJ_ARMORSTAND:
 	case OBJ_WARARMOR:
-		OperateArmorStand(pnum, i, sendmsg);
+		OperateArmorStand(i, sendmsg, sendmsg);
 		break;
 	case OBJ_GOATSHRINE:
 		OperateGoatShrine(pnum, i, LS_GSHRINE);
@@ -4940,26 +4916,28 @@ void OperateObject(int pnum, int i, bool teleFlag)
 		break;
 	case OBJ_STORYBOOK:
 	case OBJ_L5BOOKS:
-		OperateStoryBook(pnum, i);
+		if (sendmsg)
+			OperateStoryBook(i);
 		break;
 	case OBJ_PEDISTAL:
 		OperatePedistal(pnum, i);
 		break;
 	case OBJ_WARWEAP:
 	case OBJ_WEAPONRACK:
-		OperateWeaponRack(pnum, i, sendmsg);
+		OperateWeaponRack(i, sendmsg, sendmsg);
 		break;
 	case OBJ_MUSHPATCH:
-		OperateMushroomPatch(pnum, Objects[i]);
+		OperateMushroomPatch(player, Objects[i]);
 		break;
 	case OBJ_LAZSTAND:
-		OperateLazStand(pnum, i);
+		if (sendmsg)
+			OperateLazStand(i);
 		break;
 	case OBJ_SLAINHERO:
-		OperateSlainHero(pnum, i);
+		OperateSlainHero(player, i);
 		break;
 	case OBJ_SIGNCHEST:
-		OperateInnSignChest(pnum, Objects[i]);
+		OperateInnSignChest(player, Objects[i]);
 		break;
 	default:
 		break;
@@ -5048,6 +5026,9 @@ void DeltaSyncOpObject(int cmd, int i)
 
 void SyncOpObject(int pnum, int cmd, int i)
 {
+	bool sendmsg = pnum == MyPlayerId;
+	const Player &player = Players[pnum];
+
 	switch (Objects[i]._otype) {
 	case OBJ_L1LDOOR:
 	case OBJ_L1RDOOR:
@@ -5072,7 +5053,7 @@ void SyncOpObject(int pnum, int cmd, int i)
 	case OBJ_LEVER:
 	case OBJ_L5LEVER:
 	case OBJ_SWITCHSKL:
-		OperateLever(i, pnum == MyPlayerId);
+		OperateLever(i, sendmsg);
 		break;
 	case OBJ_CHEST1:
 	case OBJ_CHEST2:
@@ -5084,12 +5065,12 @@ void SyncOpObject(int pnum, int cmd, int i)
 		break;
 	case OBJ_SARC:
 	case OBJ_L5SARC:
-		OperateSarc(pnum, i, false);
+		OperateSarc(i, sendmsg, false);
 		break;
 	case OBJ_BLINDBOOK:
 	case OBJ_BLOODBOOK:
 	case OBJ_STEELTOME:
-		OperateBookLever(i, pnum == MyPlayerId);
+		OperateBookLever(i, sendmsg);
 		break;
 	case OBJ_SHRINEL:
 	case OBJ_SHRINER:
@@ -5097,18 +5078,18 @@ void SyncOpObject(int pnum, int cmd, int i)
 		break;
 	case OBJ_SKELBOOK:
 	case OBJ_BOOKSTAND:
-		OperateSkelBook(pnum, i, false);
+		OperateSkelBook(i, sendmsg, false);
 		break;
 	case OBJ_BOOKCASEL:
 	case OBJ_BOOKCASER:
-		OperateBookCase(pnum, i, false);
+		OperateBookCase(i, sendmsg, false);
 		break;
 	case OBJ_DECAP:
-		OperateDecap(pnum, i, false);
+		OperateDecap(i, sendmsg, false);
 		break;
 	case OBJ_ARMORSTAND:
 	case OBJ_WARARMOR:
-		OperateArmorStand(pnum, i, false);
+		OperateArmorStand(i, sendmsg, false);
 		break;
 	case OBJ_GOATSHRINE:
 		OperateGoatShrine(pnum, i, LS_GSHRINE);
@@ -5122,23 +5103,24 @@ void SyncOpObject(int pnum, int cmd, int i)
 		break;
 	case OBJ_STORYBOOK:
 	case OBJ_L5BOOKS:
-		OperateStoryBook(pnum, i);
+		if (sendmsg)
+			OperateStoryBook(i);
 		break;
 	case OBJ_PEDISTAL:
 		OperatePedistal(pnum, i);
 		break;
 	case OBJ_WARWEAP:
 	case OBJ_WEAPONRACK:
-		OperateWeaponRack(pnum, i, false);
+		OperateWeaponRack(i, sendmsg, false);
 		break;
 	case OBJ_MUSHPATCH:
-		OperateMushroomPatch(pnum, Objects[i]);
+		OperateMushroomPatch(player, Objects[i]);
 		break;
 	case OBJ_SLAINHERO:
-		OperateSlainHero(pnum, i);
+		OperateSlainHero(player, i);
 		break;
 	case OBJ_SIGNCHEST:
-		OperateInnSignChest(pnum, Objects[i]);
+		OperateInnSignChest(player, Objects[i]);
 		break;
 	default:
 		break;

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -304,7 +304,6 @@ void RedoPlayerVision();
 void MonstCheckDoors(Monster &monster);
 void ObjChangeMap(int x1, int y1, int x2, int y2);
 void ObjChangeMapResync(int x1, int y1, int x2, int y2);
-void TryDisarm(int pnum, int i);
 int ItemMiscIdIdx(item_misc_id imiscid);
 void OperateObject(int pnum, int i, bool TeleFlag);
 void SyncOpObject(int pnum, int cmd, int i);

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -220,11 +220,11 @@ SpellCheckResult CheckSpell(int id, spell_id sn, spell_type st, bool manaonly)
 		return SpellCheckResult::Success;
 	}
 
-	if (GetSpellLevel(id, sn) <= 0) {
+	Player &player = Players[id];
+	if (GetSpellLevel(player, sn) <= 0) {
 		return SpellCheckResult::Fail_Level0;
 	}
 
-	Player &player = Players[id];
 	if (player._pMana < GetManaAmount(player, sn)) {
 		return SpellCheckResult::Fail_NoMana;
 	}


### PR DESCRIPTION
Another set of cleanups to minimize the impact of https://github.com/diasurgical/devilutionX/pull/4754

Just 8 more files (84 lines) left to investigate after this one :sweat_smile: 

`TryDisarm()` was moved to player.cpp (only usage) to avoid circular references