### PR TITLE
Monster: Remove MType/MData pointers

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -911,7 +911,7 @@ void DrawInfoBox(const Surface &out)
 					InfoColor = UiFlags::ColorWhitegold;
 					PrintUniqueHistory();
 				} else {
-					PrintMonstHistory(monster.MType->type);
+					PrintMonstHistory(monster.type().type);
 				}
 			} else if (pcursitem == -1) {
 				InfoString = string_view(Towners[pcursmonst].name);

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -404,49 +404,49 @@ void CheckCursMove()
 		if (pcurstemp != -1) {
 			if (!flipflag && mx + 2 < MAXDUNX && my + 1 < MAXDUNY && dMonster[mx + 2][my + 1] != 0 && IsTileLit({ mx + 2, my + 1 })) {
 				int mi = abs(dMonster[mx + 2][my + 1]) - 1;
-				if (mi == pcurstemp && Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].MData->mSelFlag & 4) != 0) {
+				if (mi == pcurstemp && Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].data().mSelFlag & 4) != 0) {
 					cursPosition = Point { mx, my } + Displacement { 2, 1 };
 					pcursmonst = mi;
 				}
 			}
 			if (flipflag && mx + 1 < MAXDUNX && my + 2 < MAXDUNY && dMonster[mx + 1][my + 2] != 0 && IsTileLit({ mx + 1, my + 2 })) {
 				int mi = abs(dMonster[mx + 1][my + 2]) - 1;
-				if (mi == pcurstemp && Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].MData->mSelFlag & 4) != 0) {
+				if (mi == pcurstemp && Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].data().mSelFlag & 4) != 0) {
 					cursPosition = Point { mx, my } + Displacement { 1, 2 };
 					pcursmonst = mi;
 				}
 			}
 			if (mx + 2 < MAXDUNX && my + 2 < MAXDUNY && dMonster[mx + 2][my + 2] != 0 && IsTileLit({ mx + 2, my + 2 })) {
 				int mi = abs(dMonster[mx + 2][my + 2]) - 1;
-				if (mi == pcurstemp && Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].MData->mSelFlag & 4) != 0) {
+				if (mi == pcurstemp && Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].data().mSelFlag & 4) != 0) {
 					cursPosition = Point { mx, my } + Displacement { 2, 2 };
 					pcursmonst = mi;
 				}
 			}
 			if (mx + 1 < MAXDUNX && !flipflag && dMonster[mx + 1][my] != 0 && IsTileLit({ mx + 1, my })) {
 				int mi = abs(dMonster[mx + 1][my]) - 1;
-				if (mi == pcurstemp && Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].MData->mSelFlag & 2) != 0) {
+				if (mi == pcurstemp && Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].data().mSelFlag & 2) != 0) {
 					cursPosition = Point { mx, my } + Displacement { 1, 0 };
 					pcursmonst = mi;
 				}
 			}
 			if (my + 1 < MAXDUNY && flipflag && dMonster[mx][my + 1] != 0 && IsTileLit({ mx, my + 1 })) {
 				int mi = abs(dMonster[mx][my + 1]) - 1;
-				if (mi == pcurstemp && Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].MData->mSelFlag & 2) != 0) {
+				if (mi == pcurstemp && Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].data().mSelFlag & 2) != 0) {
 					cursPosition = Point { mx, my } + Displacement { 0, 1 };
 					pcursmonst = mi;
 				}
 			}
 			if (dMonster[mx][my] != 0 && IsTileLit({ mx, my })) {
 				int mi = abs(dMonster[mx][my]) - 1;
-				if (mi == pcurstemp && Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].MData->mSelFlag & 1) != 0) {
+				if (mi == pcurstemp && Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].data().mSelFlag & 1) != 0) {
 					cursPosition = { mx, my };
 					pcursmonst = mi;
 				}
 			}
 			if (mx + 1 < MAXDUNX && my + 1 < MAXDUNY && dMonster[mx + 1][my + 1] != 0 && IsTileLit({ mx + 1, my + 1 })) {
 				int mi = abs(dMonster[mx + 1][my + 1]) - 1;
-				if (mi == pcurstemp && Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].MData->mSelFlag & 2) != 0) {
+				if (mi == pcurstemp && Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].data().mSelFlag & 2) != 0) {
 					cursPosition = Point { mx, my } + Displacement { 1, 1 };
 					pcursmonst = mi;
 				}
@@ -464,49 +464,49 @@ void CheckCursMove()
 		}
 		if (!flipflag && mx + 2 < MAXDUNX && my + 1 < MAXDUNY && dMonster[mx + 2][my + 1] != 0 && IsTileLit({ mx + 2, my + 1 })) {
 			int mi = abs(dMonster[mx + 2][my + 1]) - 1;
-			if (Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].MData->mSelFlag & 4) != 0) {
+			if (Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].data().mSelFlag & 4) != 0) {
 				cursPosition = Point { mx, my } + Displacement { 2, 1 };
 				pcursmonst = mi;
 			}
 		}
 		if (flipflag && mx + 1 < MAXDUNX && my + 2 < MAXDUNY && dMonster[mx + 1][my + 2] != 0 && IsTileLit({ mx + 1, my + 2 })) {
 			int mi = abs(dMonster[mx + 1][my + 2]) - 1;
-			if (Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].MData->mSelFlag & 4) != 0) {
+			if (Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].data().mSelFlag & 4) != 0) {
 				cursPosition = Point { mx, my } + Displacement { 1, 2 };
 				pcursmonst = mi;
 			}
 		}
 		if (mx + 2 < MAXDUNX && my + 2 < MAXDUNY && dMonster[mx + 2][my + 2] != 0 && IsTileLit({ mx + 2, my + 2 })) {
 			int mi = abs(dMonster[mx + 2][my + 2]) - 1;
-			if (Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].MData->mSelFlag & 4) != 0) {
+			if (Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].data().mSelFlag & 4) != 0) {
 				cursPosition = Point { mx, my } + Displacement { 2, 2 };
 				pcursmonst = mi;
 			}
 		}
 		if (!flipflag && mx + 1 < MAXDUNX && dMonster[mx + 1][my] != 0 && IsTileLit({ mx + 1, my })) {
 			int mi = abs(dMonster[mx + 1][my]) - 1;
-			if (Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].MData->mSelFlag & 2) != 0) {
+			if (Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].data().mSelFlag & 2) != 0) {
 				cursPosition = Point { mx, my } + Displacement { 1, 0 };
 				pcursmonst = mi;
 			}
 		}
 		if (flipflag && my + 1 < MAXDUNY && dMonster[mx][my + 1] != 0 && IsTileLit({ mx, my + 1 })) {
 			int mi = abs(dMonster[mx][my + 1]) - 1;
-			if (Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].MData->mSelFlag & 2) != 0) {
+			if (Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].data().mSelFlag & 2) != 0) {
 				cursPosition = Point { mx, my } + Displacement { 0, 1 };
 				pcursmonst = mi;
 			}
 		}
 		if (dMonster[mx][my] != 0 && IsTileLit({ mx, my })) {
 			int mi = abs(dMonster[mx][my]) - 1;
-			if (Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].MData->mSelFlag & 1) != 0) {
+			if (Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].data().mSelFlag & 1) != 0) {
 				cursPosition = { mx, my };
 				pcursmonst = mi;
 			}
 		}
 		if (mx + 1 < MAXDUNX && my + 1 < MAXDUNY && dMonster[mx + 1][my + 1] != 0 && IsTileLit({ mx + 1, my + 1 })) {
 			int mi = abs(dMonster[mx + 1][my + 1]) - 1;
-			if (Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].MData->mSelFlag & 2) != 0) {
+			if (Monsters[mi]._mhitpoints >> 6 > 0 && (Monsters[mi].data().mSelFlag & 2) != 0) {
 				cursPosition = Point { mx, my } + Displacement { 1, 1 };
 				pcursmonst = mi;
 			}

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -58,7 +58,7 @@ void InitCorpses()
 	for (int i = 0; i < ActiveMonsterCount; i++) {
 		auto &monster = Monsters[ActiveMonsters[i]];
 		if (monster._uniqtype != 0) {
-			InitDeadAnimationFromMonster(Corpses[nd], *monster.MType);
+			InitDeadAnimationFromMonster(Corpses[nd], monster.type());
 			Corpses[nd].translationPaletteIndex = ActiveMonsters[i] + 1;
 			nd++;
 

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -335,7 +335,7 @@ std::string ExportDun(const string_view parameter)
 			uint16_t monsterId = 0;
 			if (dMonster[x][y] > 0) {
 				for (int i = 0; i < 157; i++) {
-					if (MonstConvTbl[i] == Monsters[abs(dMonster[x][y]) - 1].MType->type) {
+					if (MonstConvTbl[i] == Monsters[abs(dMonster[x][y]) - 1].type().type) {
 						monsterId = i + 1;
 						break;
 					}

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -772,11 +772,6 @@ void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBuffe
 		return;
 	}
 
-	if (monster.MType == nullptr) {
-		Log("Draw Monster \"{}\": uninitialized monster", monster.mName);
-		return;
-	}
-
 	CelSprite cel = *monster.AnimInfo.celSprite;
 
 	Displacement offset = monster.position.offset;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1334,8 +1334,8 @@ void GetItemBonus(Item &item, int minlvl, int maxlvl, bool onlygood, bool allows
 
 int RndUItem(Monster *monster)
 {
-	if (monster != nullptr && (monster->MData->mTreasure & T_UNIQ) != 0 && !gbIsMultiplayer)
-		return -((monster->MData->mTreasure & T_MASK) + 1);
+	if (monster != nullptr && (monster->data().mTreasure & T_UNIQ) != 0 && !gbIsMultiplayer)
+		return -((monster->data().mTreasure & T_MASK) + 1);
 
 	int ril[512];
 
@@ -3007,10 +3007,10 @@ void SetupItem(Item &item)
 
 int RndItem(const Monster &monster)
 {
-	if ((monster.MData->mTreasure & T_UNIQ) != 0)
-		return -((monster.MData->mTreasure & T_MASK) + 1);
+	if ((monster.data().mTreasure & T_UNIQ) != 0)
+		return -((monster.data().mTreasure & T_MASK) + 1);
 
-	if ((monster.MData->mTreasure & T_NODROP) != 0)
+	if ((monster.data().mTreasure & T_NODROP) != 0)
 		return 0;
 
 	if (GenerateRnd(100) > 40)
@@ -3070,7 +3070,7 @@ void SpawnItem(Monster &monster, Point position, bool sendmsg)
 	int idx;
 	bool onlygood = true;
 
-	if (monster._uniqtype != 0 || ((monster.MData->mTreasure & T_UNIQ) != 0 && gbIsMultiplayer)) {
+	if (monster._uniqtype != 0 || ((monster.data().mTreasure & T_UNIQ) != 0 && gbIsMultiplayer)) {
 		idx = RndUItem(&monster);
 		if (idx < 0) {
 			SpawnUnique((_unique_items) - (idx + 1), position);
@@ -3101,8 +3101,8 @@ void SpawnItem(Monster &monster, Point position, bool sendmsg)
 	GetSuperItemSpace(position, ii);
 	int uper = monster._uniqtype != 0 ? 15 : 1;
 
-	int8_t mLevel = monster.MData->mLevel;
-	if (!gbIsHellfire && monster.MType->type == MT_DIABLO)
+	int8_t mLevel = monster.data().mLevel;
+	if (!gbIsHellfire && monster.type().type == MT_DIABLO)
 		mLevel -= 15;
 
 	SetupAllItems(item, idx, AdvanceRndSeed(), mLevel, uper, onlygood, false, false);
@@ -4462,7 +4462,7 @@ std::string DebugSpawnItem(std::string itemName)
 
 	uint32_t begin = SDL_GetTicks();
 	Monster fake_m;
-	fake_m.MData = &MonstersData[0];
+	fake_m._mMTidx = 0;
 	fake_m._uniqtype = 0;
 
 	int i = 0;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -657,8 +657,6 @@ void LoadMonster(LoadHelper *file, Monster &monster)
 		monster.mlid = NO_LIGHT; // Correct incorect values in old saves
 
 	// Omit pointer mName;
-	// Omit pointer MType;
-	// Omit pointer data;
 
 	if (gbSkipSync)
 		return;
@@ -1396,8 +1394,6 @@ void SaveMonster(SaveHelper *file, Monster &monster)
 		file->WriteLE<int8_t>(monster.mlid);
 
 	// Omit pointer mName;
-	// Omit pointer MType;
-	// Omit pointer data;
 }
 
 void SaveMissile(SaveHelper *file, const Missile &missile)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -228,7 +228,7 @@ bool MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, missile_id t
 			dam += player._pDamageMod;
 		else
 			dam += player._pDamageMod / 2;
-		if (monster.MData->mMonstClass == MonsterClass::Demon && HasAnyOf(player._pIFlags, ItemSpecialEffect::TripleDemonDamage))
+		if (monster.data().mMonstClass == MonsterClass::Demon && HasAnyOf(player._pIFlags, ItemSpecialEffect::TripleDemonDamage))
 			dam *= 3;
 	}
 	bool resist = monster.IsResistant(t);
@@ -250,7 +250,7 @@ bool MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, missile_id t
 	} else {
 		if (monster._mmode != MonsterMode::Petrified && MissilesData[t].mType == 0 && HasAnyOf(player._pIFlags, ItemSpecialEffect::Knockback))
 			M_GetKnockback(m);
-		if (monster.MType->type != MT_GOLEM)
+		if (monster.type().type != MT_GOLEM)
 			M_StartHit(m, pnum, dam);
 	}
 
@@ -594,7 +594,7 @@ bool GuardianTryFireAt(Missile &missile, Point target)
 	if (mid < 0)
 		return false;
 	const Monster &monster = Monsters[mid];
-	if (monster.MType->type == MT_GOLEM)
+	if (monster.type().type == MT_GOLEM)
 		return false;
 	if (monster._mhitpoints >> 6 <= 0)
 		return false;
@@ -641,7 +641,7 @@ void SpawnLightning(Missile &missile, int dam)
 		if (position != Point { missile.var1, missile.var2 } && InDungeonBounds(position)) {
 			missile_id type = MIS_LIGHTNING;
 			if (!missile.IsTrap() && missile._micaster == TARGET_PLAYERS
-			    && IsAnyOf(Monsters[missile._misource].MType->type, MT_STORM, MT_RSTORM, MT_STORML, MT_MAEL)) {
+			    && IsAnyOf(Monsters[missile._misource].type().type, MT_STORM, MT_RSTORM, MT_STORML, MT_MAEL)) {
 				type = MIS_LIGHTNING2;
 			}
 			AddMissile(
@@ -882,7 +882,7 @@ bool MonsterTrapHit(int m, int mindam, int maxdam, int dist, missile_id t, bool 
 	} else if (resist) {
 		PlayEffect(monster, 1);
 	} else {
-		if (monster.MType->type != MT_GOLEM)
+		if (monster.type().type != MT_GOLEM)
 			M_StartHit(m, dam);
 	}
 	return true;
@@ -1144,7 +1144,7 @@ void AddBerserk(Missile &missile, const AddMissileParameter &parameter)
 			    return false;
 
 		    const Monster &monster = Monsters[monsterId];
-		    if (monster.MType->type == MT_GOLEM)
+		    if (monster.type().type == MT_GOLEM)
 			    return false;
 		    if ((monster._mFlags & MFLAG_BERSERK) != 0)
 			    return false;
@@ -1786,7 +1786,7 @@ void AddLightning(Missile &missile, const AddMissileParameter &parameter)
 	missile._miAnimFrame = GenerateRnd(8) + 1;
 
 	if (missile._micaster == TARGET_PLAYERS || missile.IsTrap()) {
-		if (missile.IsTrap() || Monsters[missile._misource].MType->type == MT_FAMILIAR)
+		if (missile.IsTrap() || Monsters[missile._misource].type().type == MT_FAMILIAR)
 			missile._mirange = 8;
 		else
 			missile._mirange = 10;
@@ -1799,7 +1799,7 @@ void AddLightning(Missile &missile, const AddMissileParameter &parameter)
 void AddMisexp(Missile &missile, const AddMissileParameter &parameter)
 {
 	if (missile._micaster != TARGET_MONSTERS && missile._misource >= 0) {
-		switch (Monsters[missile._misource].MType->type) {
+		switch (Monsters[missile._misource].type().type) {
 		case MT_SUCCUBUS:
 			SetMissAnim(missile, MFILE_FLAREEXP);
 			break;
@@ -2016,7 +2016,7 @@ void AddChain(Missile &missile, const AddMissileParameter &parameter)
 namespace {
 void InitMissileAnimationFromMonster(Missile &mis, Direction midir, const Monster &mon, MonsterGraphic graphic)
 {
-	const AnimStruct &anim = mon.MType->getAnimData(graphic);
+	const AnimStruct &anim = mon.type().getAnimData(graphic);
 	mis._mimfnum = static_cast<int32_t>(midir);
 	mis._miAnimFlags = MissileDataFlags::None;
 	CelSprite celSprite = *anim.getCelSpritesForDirection(midir);
@@ -2038,14 +2038,14 @@ void AddRhino(Missile &missile, const AddMissileParameter &parameter)
 	Monster &monster = Monsters[missile._misource];
 
 	MonsterGraphic graphic = MonsterGraphic::Walk;
-	if (IsAnyOf(monster.MType->type, MT_HORNED, MT_MUDRUN, MT_FROSTC, MT_OBLORD)) {
+	if (IsAnyOf(monster.type().type, MT_HORNED, MT_MUDRUN, MT_FROSTC, MT_OBLORD)) {
 		graphic = MonsterGraphic::Special;
-	} else if (IsAnyOf(monster.MType->type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE)) {
+	} else if (IsAnyOf(monster.type().type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE)) {
 		graphic = MonsterGraphic::Attack;
 	}
 	UpdateMissileVelocity(missile, parameter.dst, 18);
 	InitMissileAnimationFromMonster(missile, parameter.midir, monster, graphic);
-	if (IsAnyOf(monster.MType->type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE))
+	if (IsAnyOf(monster.type().type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE))
 		missile._miAnimFrame = 7;
 	if (monster._uniqtype != 0) {
 		missile._mlid = monster.mlid;
@@ -2069,13 +2069,13 @@ void AddFlare(Missile &missile, const AddMissileParameter &parameter)
 		ApplyPlrDamage(missile._misource, 5);
 	} else if (missile._misource > 0) {
 		auto &monster = Monsters[missile._misource];
-		if (monster.MType->type == MT_SUCCUBUS)
+		if (monster.type().type == MT_SUCCUBUS)
 			SetMissAnim(missile, MFILE_FLARE);
-		if (monster.MType->type == MT_SNOWWICH)
+		if (monster.type().type == MT_SNOWWICH)
 			SetMissAnim(missile, MFILE_SCUBMISB);
-		if (monster.MType->type == MT_HLSPWN)
+		if (monster.type().type == MT_HLSPWN)
 			SetMissAnim(missile, MFILE_SCUBMISD);
-		if (monster.MType->type == MT_SOLBRNR)
+		if (monster.type().type == MT_SOLBRNR)
 			SetMissAnim(missile, MFILE_SCUBMISC);
 	}
 
@@ -2121,7 +2121,7 @@ void AddStone(Missile &missile, const AddMissileParameter &parameter)
 
 		    auto &monster = Monsters[monsterId];
 
-		    if (IsAnyOf(monster.MType->type, MT_GOLEM, MT_DIABLO, MT_NAKRUL)) {
+		    if (IsAnyOf(monster.type().type, MT_GOLEM, MT_DIABLO, MT_NAKRUL)) {
 			    return false;
 		    }
 		    if (IsAnyOf(monster._mmode, MonsterMode::FadeIn, MonsterMode::FadeOut, MonsterMode::Charge)) {
@@ -3455,7 +3455,7 @@ void MI_Acidsplat(Missile &missile)
 	if (missile._mirange == 0) {
 		missile._miDelFlag = true;
 		int monst = missile._misource;
-		int dam = (Monsters[monst].MData->mLevel >= 2 ? 2 : 1);
+		int dam = (Monsters[monst].data().mLevel >= 2 ? 2 : 1);
 		AddMissile(missile.position.tile, { 0, 0 }, Direction::South, MIS_ACIDPUD, TARGET_PLAYERS, monst, dam, missile._mispllvl);
 	} else {
 		PutMissile(missile);
@@ -3620,7 +3620,7 @@ void MI_Apoca(Missile &missile)
 			int mid = dMonster[k][j] - 1;
 			if (mid < 0)
 				continue;
-			if (Monsters[mid].MType->type == MT_GOLEM)
+			if (Monsters[mid].type().type == MT_GOLEM)
 				continue;
 			if (TileHasAny(dPiece[k][j], TileProperties::Solid))
 				continue;
@@ -4016,17 +4016,17 @@ void missiles_process_charge()
 		if (missile._mitype != MIS_RHINO)
 			continue;
 
-		CMonster *mon = Monsters[missile._misource].MType;
+		const CMonster &mon = Monsters[missile._misource].type();
 
 		MonsterGraphic graphic;
-		if (IsAnyOf(mon->type, MT_HORNED, MT_MUDRUN, MT_FROSTC, MT_OBLORD)) {
+		if (IsAnyOf(mon.type, MT_HORNED, MT_MUDRUN, MT_FROSTC, MT_OBLORD)) {
 			graphic = MonsterGraphic::Special;
-		} else if (IsAnyOf(mon->type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE)) {
+		} else if (IsAnyOf(mon.type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE)) {
 			graphic = MonsterGraphic::Attack;
 		} else {
 			graphic = MonsterGraphic::Walk;
 		}
-		missile._miAnimData = mon->getAnimData(graphic).celSpritesForDirections[missile._mimfnum];
+		missile._miAnimData = mon.getAnimData(graphic).celSpritesForDirections[missile._mimfnum];
 	}
 }
 

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -166,10 +166,10 @@ struct CMonster {
 	const MonsterData *data;
 };
 
+extern CMonster LevelMonsterTypes[MaxLvlMTypes];
+
 struct Monster { // note: missing field _mAFNum
 	const char *mName;
-	CMonster *MType;
-	const MonsterData *MData;
 	std::unique_ptr<uint8_t[]> uniqueTRN;
 	AnimationInfo AnimInfo;
 	int _mgoalvar1;
@@ -234,7 +234,7 @@ struct Monster { // note: missing field _mAFNum
 	 */
 	void ChangeAnimationData(MonsterGraphic graphic, Direction direction)
 	{
-		auto &animationData = this->MType->getAnimData(graphic);
+		auto &animationData = type().getAnimData(graphic);
 
 		// Passing the Frames and rate properties here is only relevant when initialising a monster, but doesn't cause any harm when switching animations.
 		this->AnimInfo.ChangeAnimationData(animationData.getCelSpritesForDirection(direction), animationData.frames, animationData.rate);
@@ -260,6 +260,16 @@ struct Monster { // note: missing field _mAFNum
 	 */
 	void Petrify();
 
+	const CMonster &type() const
+	{
+		return LevelMonsterTypes[_mMTidx];
+	}
+
+	const MonsterData &data() const
+	{
+		return *type().data;
+	}
+
 	/**
 	 * @brief Is the monster currently walking?
 	 */
@@ -270,7 +280,6 @@ struct Monster { // note: missing field _mAFNum
 	bool TryLiftGargoyle();
 };
 
-extern CMonster LevelMonsterTypes[MaxLvlMTypes];
 extern int LevelMonsterTypeCount;
 extern Monster Monsters[MaxMonsters];
 extern int ActiveMonsters[MaxMonsters];

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2417,8 +2417,7 @@ void DeltaLoadLevel()
 				M_ClearSquares(i);
 				if (monster._mAi != AI_DIABLO) {
 					if (monster._uniqtype == 0) {
-						assert(monster.MType != nullptr);
-						AddCorpse(monster.position.tile, monster.MType->corpseId, monster._mdir);
+						AddCorpse(monster.position.tile, monster.type().corpseId, monster._mdir);
 					} else {
 						AddCorpse(monster.position.tile, monster._udeadval, monster._mdir);
 					}
@@ -2429,7 +2428,7 @@ void DeltaLoadLevel()
 				decode_enemy(monster, deltaLevel.monster[i]._menemy);
 				if (monster.position.tile != Point { 0, 0 } && monster.position.tile != GolemHoldingCell)
 					dMonster[monster.position.tile.x][monster.position.tile.y] = i + 1;
-				if (monster.MType->type == MT_GOLEM) {
+				if (monster.type().type == MT_GOLEM) {
 					GolumAi(i);
 					monster._mFlags |= (MFLAG_TARGETS_MONSTER | MFLAG_GOLEM);
 				} else {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -868,7 +868,7 @@ bool PlrHitMonst(int pnum, int m, bool adjacentDamage = false)
 		phanditype = ItemType::Mace;
 	}
 
-	switch (monster.MData->mMonstClass) {
+	switch (monster.data().mMonstClass) {
 	case MonsterClass::Undead:
 		if (phanditype == ItemType::Sword) {
 			dam -= dam / 2;
@@ -894,7 +894,7 @@ bool PlrHitMonst(int pnum, int m, bool adjacentDamage = false)
 		dam *= 3;
 	}
 
-	if (HasAnyOf(player.pDamAcFlags, ItemSpecialEffectHf::Doppelganger) && monster.MType->type != MT_DIABLO && monster._uniqtype == 0 && GenerateRnd(100) < 10) {
+	if (HasAnyOf(player.pDamAcFlags, ItemSpecialEffectHf::Doppelganger) && monster.type().type != MT_DIABLO && monster._uniqtype == 0 && GenerateRnd(100) < 10) {
 		AddDoppelganger(monster);
 	}
 
@@ -3193,7 +3193,7 @@ void RemovePlrMissiles(int pnum)
 		auto &golem = Monsters[MyPlayerId];
 		if (golem.position.tile.x != 1 || golem.position.tile.y != 0) {
 			M_StartKill(MyPlayerId, MyPlayerId);
-			AddCorpse(golem.position.tile, golem.MType->corpseId, golem._mdir);
+			AddCorpse(golem.position.tile, golem.type().corpseId, golem._mdir);
 			int mx = golem.position.tile.x;
 			int my = golem.position.tile.y;
 			dMonster[mx][my] = 0;

--- a/Source/qol/monhealthbar.cpp
+++ b/Source/qol/monhealthbar.cpp
@@ -122,7 +122,7 @@ void DrawMonsterHealthBar(const Surface &out)
 	};
 
 	if (*sgOptions.Gameplay.showMonsterType) {
-		Uint8 borderColor = getBorderColor(monster.MData->mMonstClass);
+		Uint8 borderColor = getBorderColor(monster.data().mMonstClass);
 		int borderWidth = width - (border * 2);
 		UnsafeDrawHorizontalLine(out, { position.x + border, position.y + border }, borderWidth, borderColor);
 		UnsafeDrawHorizontalLine(out, { position.x + border, position.y + height - border - 1 }, borderWidth, borderColor);
@@ -143,7 +143,7 @@ void DrawMonsterHealthBar(const Surface &out)
 
 	if (multiplier > 0)
 		DrawString(out, fmt::format("x{:d}", multiplier), { position, { width - 2, height } }, UiFlags::ColorWhite | UiFlags::AlignRight | UiFlags::VerticalCenter);
-	if (monster._uniqtype != 0 || MonsterKillCounts[monster.MType->type] >= 15) {
+	if (monster._uniqtype != 0 || MonsterKillCounts[monster.type().type] >= 15) {
 		monster_resistance immunes[] = { IMMUNE_MAGIC, IMMUNE_FIRE, IMMUNE_LIGHTNING };
 		monster_resistance resists[] = { RESIST_MAGIC, RESIST_FIRE, RESIST_LIGHTNING };
 

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -405,14 +405,14 @@ void CheckQuestKill(const Monster &monster, bool sendmsg)
 
 	Player &myPlayer = *MyPlayer;
 
-	if (monster.MType->type == MT_SKING) {
+	if (monster.type().type == MT_SKING) {
 		auto &quest = Quests[Q_SKELKING];
 		quest._qactive = QUEST_DONE;
 		myPlayer.Say(HeroSpeech::RestWellLeoricIllFindYourSon, 30);
 		if (sendmsg)
 			NetSendCmdQuest(true, quest);
 
-	} else if (monster.MType->type == MT_CLEAVER) {
+	} else if (monster.type().type == MT_CLEAVER) {
 		auto &quest = Quests[Q_BUTCHER];
 		quest._qactive = QUEST_DONE;
 		myPlayer.Say(HeroSpeech::TheSpiritsOfTheDeadAreNowAvenged, 30);


### PR DESCRIPTION
These pointers are redundant, replaces them with methods.

`Monster` is down to 176 bytes, `Monsters` down to 33,600 bytes.