### PR TITLE
Normalise the player and monster walking function naming

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -347,7 +347,7 @@ void SearchAutomapItem(const Surface &out, const Displacement &myPlayerOffset)
 {
 	const Player &player = *MyPlayer;
 	Point tile = player.position.tile;
-	if (player._pmode == PM_WALK3) {
+	if (player._pmode == PM_WALK_SIDEWAYS) {
 		tile = player.position.future;
 		if (player._pdir == Direction::West)
 			tile.x++;
@@ -395,7 +395,7 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, int 
 
 	Player &player = Players[playerId];
 	Point tile = player.position.tile;
-	if (player._pmode == PM_WALK3) {
+	if (player._pmode == PM_WALK_SIDEWAYS) {
 		tile = player.position.future;
 	}
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -236,7 +236,7 @@ bool CanWield(Player &player, const Item &item)
  */
 bool CanEquip(Player &player, const Item &item, inv_body_loc bodyLocation)
 {
-	if (!CanEquip(item) || player._pmode > PM_WALK3 || !player.InvBody[bodyLocation].isEmpty()) {
+	if (!CanEquip(item) || player._pmode > PM_WALK_SIDEWAYS || !player.InvBody[bodyLocation].isEmpty()) {
 		return false;
 	}
 
@@ -402,7 +402,7 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 		return;
 	}
 
-	if (player._pmode > PM_WALK3 && IsNoneOf(il, ILOC_UNEQUIPABLE, ILOC_BELT))
+	if (player._pmode > PM_WALK_SIDEWAYS && IsNoneOf(il, ILOC_UNEQUIPABLE, ILOC_BELT))
 		return;
 
 	if (&player == MyPlayer)
@@ -566,7 +566,7 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 
 void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool dropItem)
 {
-	if (player._pmode > PM_WALK3) {
+	if (player._pmode > PM_WALK_SIDEWAYS) {
 		return;
 	}
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -808,7 +808,7 @@ void StartSpecialStand(Monster &monster, Direction md)
 	monster.position.old = monster.position.tile;
 }
 
-void StartWalkNorthwards(Monster &monster, int xvel, int yvel, int xadd, int yadd, Direction endDir)
+void WalkNorthwards(Monster &monster, int xvel, int yvel, int xadd, int yadd, Direction endDir)
 {
 	const auto fx = static_cast<WorldTileCoord>(xadd + monster.position.tile.x);
 	const auto fy = static_cast<WorldTileCoord>(yadd + monster.position.tile.y);
@@ -825,7 +825,7 @@ void StartWalkNorthwards(Monster &monster, int xvel, int yvel, int xadd, int yad
 	monster.position.offset2 = { 0, 0 };
 }
 
-void StartWalkSouthwards(Monster &monster, int xvel, int yvel, int xoff, int yoff, int xadd, int yadd, Direction endDir)
+void WalkSouthwards(Monster &monster, int xvel, int yvel, int xoff, int yoff, int xadd, int yadd, Direction endDir)
 {
 	const auto fx = static_cast<WorldTileCoord>(xadd + monster.position.tile.x);
 	const auto fy = static_cast<WorldTileCoord>(yadd + monster.position.tile.y);
@@ -847,7 +847,7 @@ void StartWalkSouthwards(Monster &monster, int xvel, int yvel, int xoff, int yof
 	monster.position.offset2 = DisplacementOf<int16_t> { static_cast<int16_t>(16 * xoff), static_cast<int16_t>(16 * yoff) };
 }
 
-void StartWalkSideways(Monster &monster, int xvel, int yvel, int xoff, int yoff, int xadd, int yadd, int mapx, int mapy, Direction endDir)
+void WalkSideways(Monster &monster, int xvel, int yvel, int xoff, int yoff, int xadd, int yadd, int mapx, int mapy, Direction endDir)
 {
 	const auto fx = static_cast<WorldTileCoord>(xadd + monster.position.tile.x);
 	const auto fy = static_cast<WorldTileCoord>(yadd + monster.position.tile.y);
@@ -4076,28 +4076,28 @@ void M_WalkDir(Monster &monster, Direction md)
 	int mwi = monster.type().getAnimData(MonsterGraphic::Walk).frames - 1;
 	switch (md) {
 	case Direction::North:
-		StartWalkNorthwards(monster, 0, -MWVel[mwi][1], -1, -1, Direction::North);
+		WalkNorthwards(monster, 0, -MWVel[mwi][1], -1, -1, Direction::North);
 		break;
 	case Direction::NorthEast:
-		StartWalkNorthwards(monster, MWVel[mwi][1], -MWVel[mwi][0], 0, -1, Direction::NorthEast);
+		WalkNorthwards(monster, MWVel[mwi][1], -MWVel[mwi][0], 0, -1, Direction::NorthEast);
 		break;
 	case Direction::East:
-		StartWalkSideways(monster, MWVel[mwi][2], 0, -32, -16, 1, -1, 1, 0, Direction::East);
+		WalkSideways(monster, MWVel[mwi][2], 0, -32, -16, 1, -1, 1, 0, Direction::East);
 		break;
 	case Direction::SouthEast:
-		StartWalkSouthwards(monster, MWVel[mwi][1], MWVel[mwi][0], -32, -16, 1, 0, Direction::SouthEast);
+		WalkSouthwards(monster, MWVel[mwi][1], MWVel[mwi][0], -32, -16, 1, 0, Direction::SouthEast);
 		break;
 	case Direction::South:
-		StartWalkSouthwards(monster, 0, MWVel[mwi][1], 0, -32, 1, 1, Direction::South);
+		WalkSouthwards(monster, 0, MWVel[mwi][1], 0, -32, 1, 1, Direction::South);
 		break;
 	case Direction::SouthWest:
-		StartWalkSouthwards(monster, -MWVel[mwi][1], MWVel[mwi][0], 32, -16, 0, 1, Direction::SouthWest);
+		WalkSouthwards(monster, -MWVel[mwi][1], MWVel[mwi][0], 32, -16, 0, 1, Direction::SouthWest);
 		break;
 	case Direction::West:
-		StartWalkSideways(monster, -MWVel[mwi][2], 0, 32, -16, -1, 1, 0, 1, Direction::West);
+		WalkSideways(monster, -MWVel[mwi][2], 0, 32, -16, -1, 1, 0, 1, Direction::West);
 		break;
 	case Direction::NorthWest:
-		StartWalkNorthwards(monster, -MWVel[mwi][1], -MWVel[mwi][0], -1, 0, Direction::NorthWest);
+		WalkNorthwards(monster, -MWVel[mwi][1], -MWVel[mwi][0], -1, 0, Direction::NorthWest);
 		break;
 	}
 }

--- a/Source/player.h
+++ b/Source/player.h
@@ -115,9 +115,9 @@ enum class PlayerWeaponGraphic : uint8_t {
 
 enum PLR_MODE : uint8_t {
 	PM_STAND,
-	PM_WALK,  // Movement towards N, NW, or NE
-	PM_WALK2, // Movement towards S, SW, or SE
-	PM_WALK3, // Movement towards W or E
+	PM_WALK_NORTHWARDS,
+	PM_WALK_SOUTHWARDS,
+	PM_WALK_SIDEWAYS,
 	PM_ATTACK,
 	PM_RATTACK,
 	PM_BLOCK,


### PR DESCRIPTION
Both player and monster walking functions are now named WalkNorthwards, WalkSouthwards and WalkSideways.

Also renames the PLT_MODE enum to follow the same pattern and removes unnecessary comments.