### PR TITLE
Fix errors rendering progress dialog

### DIFF
--- a/Source/DiabloUI/progress.cpp
+++ b/Source/DiabloUI/progress.cpp
@@ -69,11 +69,9 @@ void ProgressRenderBackground()
 	SDL_FillRect(DiabloUiSurface(), nullptr, 0x000000);
 
 	const Surface &out = Surface(DiabloUiSurface());
-	RenderPcxSprite(out, PcxSpriteSheet { *ArtBackground }.sprite(0), { 0, 0 });
-
 	const Point position = GetPosition();
-	RenderPcxSprite(out, PcxSprite { *ArtPopupSm }, position);
-	RenderPcxSprite(out, PcxSprite { *ArtProgBG }, { GetCenterOffset(227), position.y + 52 });
+	RenderPcxSprite(out.subregion(position.x, position.y, 280, 140), PcxSprite { *ArtPopupSm }, { 0, 0 });
+	RenderPcxSprite(out.subregion(GetCenterOffset(227), 0, 227, out.h()), PcxSprite { *ArtProgBG }, { 0, position.y + 52 });
 }
 
 void ProgressRenderForeground(int progress)


### PR DESCRIPTION
First, this fixes an issue where `ArtBackground` is always `std::nullopt` because of a change made recently in diabloui.cpp.

https://github.com/diasurgical/devilutionX/blob/98a2fc53c9b99f8fcf8f85560f13cb019689f8bd/Source/DiabloUI/diabloui.cpp#L683-L684

Instead of checking for the existence of `ArtBackground`, I simply removed the code because `ProgressLoadBackground()` explicitly calls `UiLoadBlackBackground()` so there should never be any background to render here.

---

Second, the `ArtPopupSm` and `ArtProgBG` graphics have white and green areas that were not being rendered before the change to render backgrounds as PCX.

![image](https://user-images.githubusercontent.com/9203145/177050637-82142ab0-cac3-4a0a-8140-dec1a955beca.png)

Since `RenderPcxSprite()` does not accept a width or height to exclude these regions, I referenced code that renders the filled-in progress bar in `ProgressRenderForeground()` and modified the render calls to use subregions of the output surface.

https://github.com/diasurgical/devilutionX/blob/98a2fc53c9b99f8fcf8f85560f13cb019689f8bd/Source/DiabloUI/progress.cpp#L84-L86