### PR TITLE
Point: Disallow mixed size unsigned and signed +/-

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1800,9 +1800,9 @@ void UpdateSpellTarget(spell_id spell)
 
 	Player &myPlayer = *MyPlayer;
 
-	int range = spell == SPL_TELEPORT ? 4 : 1;
+	const int8_t range = spell == SPL_TELEPORT ? 4 : 1;
 
-	cursPosition = myPlayer.position.future + Displacement(myPlayer._pdir) * range;
+	cursPosition = myPlayer.position.future + DisplacementOf<int8_t>(myPlayer._pdir) * range;
 }
 
 /**

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -1246,8 +1246,8 @@ void FreeMonsterSnd()
 
 bool CalculateSoundPosition(Point soundPosition, int *plVolume, int *plPan)
 {
-	const auto &playerPosition = MyPlayer->position.tile;
-	const auto delta = soundPosition - playerPosition;
+	const WorldTilePosition playerPosition = MyPlayer->position.tile;
+	const Displacement delta = soundPosition - Point(playerPosition);
 
 	int pan = (delta.deltaX - delta.deltaY) * 256;
 	*plPan = clamp(pan, PAN_MIN, PAN_MAX);

--- a/Source/engine/path.h
+++ b/Source/engine/path.h
@@ -51,7 +51,7 @@ int FindPath(const std::function<bool(Point)> &posOk, Point startPosition, Point
 bool path_solid_pieces(Point startPosition, Point destinationPosition);
 
 /** For iterating over the 8 possible movement directions */
-const Displacement PathDirs[8] = {
+const DisplacementOf<int8_t> PathDirs[8] = {
 	// clang-format off
 	{ -1, -1 }, //Direction::North
 	{ -1,  1 }, //Direction::West

--- a/Source/engine/point.hpp
+++ b/Source/engine/point.hpp
@@ -90,6 +90,7 @@ struct PointOf {
 
 	constexpr PointOf<CoordT> operator-() const
 	{
+		static_assert(std::is_signed<CoordT>::value, "CoordT must be signed");
 		return { -x, -y };
 	}
 
@@ -180,6 +181,8 @@ std::ostream &operator<<(std::ostream &stream, const PointOf<PointCoordT> &point
 template <typename PointCoordT, typename DisplacementDeltaT>
 constexpr PointOf<PointCoordT> operator+(PointOf<PointCoordT> a, DisplacementOf<DisplacementDeltaT> displacement)
 {
+	static_assert(std::is_signed<PointCoordT>::value == std::is_signed<DisplacementDeltaT>::value || sizeof(PointCoordT) == sizeof(DisplacementDeltaT),
+	    "different size unsigned and signed addition is not allowed");
 	a += displacement;
 	return a;
 }
@@ -194,12 +197,16 @@ constexpr PointOf<PointCoordT> operator+(PointOf<PointCoordT> a, Direction direc
 template <typename PointCoordT, typename OtherPointCoordT>
 constexpr DisplacementOf<PointCoordT> operator-(PointOf<PointCoordT> a, PointOf<OtherPointCoordT> b)
 {
+	static_assert(std::is_signed<PointCoordT>::value == std::is_signed<OtherPointCoordT>::value || sizeof(PointCoordT) == sizeof(OtherPointCoordT),
+	    "different size unsigned and signed subtraction is not allowed");
 	return { static_cast<PointCoordT>(a.x - b.x), static_cast<PointCoordT>(a.y - b.y) };
 }
 
 template <typename PointCoordT, typename DisplacementDeltaT>
 constexpr PointOf<PointCoordT> operator-(PointOf<PointCoordT> a, DisplacementOf<DisplacementDeltaT> displacement)
 {
+	static_assert(std::is_signed<PointCoordT>::value == std::is_signed<DisplacementDeltaT>::value || sizeof(PointCoordT) == sizeof(DisplacementDeltaT),
+	    "different size unsigned and signed subtraction is not allowed");
 	a -= displacement;
 	return a;
 }

--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -4,6 +4,7 @@
 
 #include "engine/load_file.hpp"
 #include "engine/random.hpp"
+#include "engine/world_tile.hpp"
 #include "init.h"
 #include "levels/drlg_l1.h"
 #include "levels/drlg_l2.h"
@@ -32,7 +33,7 @@ uint8_t currlevel;
 bool setlevel;
 _setlevels setlvlnum;
 dungeon_type setlvltype;
-Point ViewPosition;
+WorldTilePosition ViewPosition;
 ScrollStruct ScrollInfo;
 int MicroTileLen;
 char TransVal;

--- a/Source/levels/gendung.h
+++ b/Source/levels/gendung.h
@@ -13,6 +13,7 @@
 #include "engine/point.hpp"
 #include "engine/rectangle.hpp"
 #include "engine/render/scrollrt.h"
+#include "engine/world_tile.hpp"
 #include "utils/attributes.h"
 #include "utils/bitset2d.hpp"
 #include "utils/enum_traits.h"
@@ -104,7 +105,7 @@ enum _difficulty : uint8_t {
 
 struct ScrollStruct {
 	/** @brief Tile offset of camera. */
-	Point tile;
+	PointOf<int8_t> tile;
 	/** @brief Pixel offset of camera. */
 	Displacement offset;
 	/** @brief Move direction of camera. */
@@ -170,7 +171,7 @@ extern _setlevels setlvlnum;
 /** Specifies the player viewpoint X-coordinate of the map. */
 extern dungeon_type setlvltype;
 /** Specifies the player viewpoint X,Y-coordinates of the map. */
-extern DVL_API_FOR_TEST Point ViewPosition;
+extern DVL_API_FOR_TEST WorldTilePosition ViewPosition;
 extern ScrollStruct ScrollInfo;
 extern int MicroTileLen;
 extern char TransVal;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2024,8 +2024,8 @@ void LoadGame(bool firstflag)
 	leveltype = static_cast<dungeon_type>(file.NextBE<uint32_t>());
 	if (!setlevel)
 		leveltype = GetLevelType(currlevel);
-	int viewX = file.NextBE<int32_t>();
-	int viewY = file.NextBE<int32_t>();
+	const auto viewX = static_cast<WorldTileCoord>(file.NextBE<int32_t>());
+	const auto viewY = static_cast<WorldTileCoord>(file.NextBE<int32_t>());
 	invflag = file.NextBool8();
 	chrflag = file.NextBool8();
 	int tmpNummonsters = file.NextBE<int32_t>();

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3480,7 +3480,7 @@ void MI_Teleport(Missile &missile)
 		ChangeVisionXY(player._pvid, player.position.tile);
 	}
 	if (&player == MyPlayer) {
-		ViewPosition = Point { 0, 0 } + (player.position.tile - ScrollInfo.tile);
+		ViewPosition = WorldTilePosition { 0, 0 } + (player.position.tile - ScrollInfo.tile);
 	}
 }
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -971,7 +971,7 @@ void SpawnLoot(Monster &monster, bool sendmsg)
 	}
 
 	if (Quests[Q_GARBUD].IsAvailable() && monster._uniqtype - 1 == UMT_GARBUD) {
-		CreateTypeItem(monster.position.tile + Displacement { 1, 1 }, true, ItemType::Mace, IMISC_NONE, sendmsg, false);
+		CreateTypeItem(monster.position.tile + Direction::South, true, ItemType::Mace, IMISC_NONE, sendmsg, false);
 	} else if (monster._uniqtype - 1 == UMT_DEFILER) {
 		if (effect_is_playing(USFX_DEFILER8))
 			stream_stop();
@@ -1587,7 +1587,7 @@ bool MonsterTalk(Monster &monster)
 			Quests[Q_GARBUD]._qlog = true; // BUGFIX: (?) for other quests qactive and qlog go together, maybe this should actually go into the if above (fixed)
 		}
 		if (monster.mtalkmsg == TEXT_GARBUD2 && (monster._mFlags & MFLAG_QUEST_COMPLETE) == 0) {
-			SpawnItem(monster, monster.position.tile + Displacement { 1, 1 }, true);
+			SpawnItem(monster, monster.position.tile + Direction::South, true);
 			monster._mFlags |= MFLAG_QUEST_COMPLETE;
 		}
 	}
@@ -1596,7 +1596,7 @@ bool MonsterTalk(Monster &monster)
 	    && (monster._mFlags & MFLAG_QUEST_COMPLETE) == 0) {
 		Quests[Q_ZHAR]._qactive = QUEST_ACTIVE;
 		Quests[Q_ZHAR]._qlog = true;
-		CreateTypeItem(monster.position.tile + Displacement { 1, 1 }, false, ItemType::Misc, IMISC_BOOK, true, false);
+		CreateTypeItem(monster.position.tile + Direction::South, false, ItemType::Misc, IMISC_BOOK, true, false);
 		monster._mFlags |= MFLAG_QUEST_COMPLETE;
 	}
 	if (monster._uniqtype - 1 == UMT_SNOTSPIL) {
@@ -2333,13 +2333,13 @@ void SkeletonBowAi(int monsterId)
 std::optional<Point> ScavengerFindCorpse(const Monster &scavenger)
 {
 	bool lowToHigh = GenerateRnd(2) != 0;
-	int first = lowToHigh ? -4 : 4;
-	int last = lowToHigh ? 4 : -4;
-	int increment = lowToHigh ? 1 : -1;
+	const int_fast8_t first = lowToHigh ? -4 : 4;
+	const int_fast8_t last = lowToHigh ? 4 : -4;
+	const int_fast8_t increment = lowToHigh ? 1 : -1;
 
-	for (int y = first; y <= last; y += increment) {
-		for (int x = first; x <= last; x += increment) {
-			Point position = scavenger.position.tile + Displacement { x, y };
+	for (int_fast8_t y = first; y <= last; y += increment) {
+		for (int_fast8_t x = first; x <= last; x += increment) {
+			Point position = scavenger.position.tile + DisplacementOf<int8_t> { x, y };
 			// BUGFIX: incorrect check of offset against limits of the dungeon (fixed)
 			if (!InDungeonBounds(position))
 				continue;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -281,7 +281,7 @@ constexpr std::array<const DirectionSettings, 8> WalkSettings { {
 
 void ScrollViewPort(const Player &player, ScrollDirection dir)
 {
-	ScrollInfo.tile = Point { 0, 0 } + (player.position.tile - ViewPosition);
+	ScrollInfo.tile = PointOf<int8_t> { 0, 0 } + (player.position.tile - ViewPosition);
 
 	if (zoomflag) {
 		if (abs(ScrollInfo.tile.x) >= 3 || abs(ScrollInfo.tile.y) >= 3) {
@@ -545,21 +545,21 @@ void RespawnDeadItem(Item &&itm, Point target)
 	NetSendCmdPItem(false, CMD_RESPAWNITEM, target, Items[ii]);
 }
 
-void DeadItem(Player &player, Item &&itm, Displacement direction)
+void DeadItem(Player &player, Item &&itm, DisplacementOf<int8_t> direction)
 {
 	if (itm.isEmpty())
 		return;
 
 	Point target = player.position.tile + direction;
-	if (direction != Displacement { 0, 0 } && ItemSpaceOk(target)) {
+	if (direction != DisplacementOf<int8_t> { 0, 0 } && ItemSpaceOk(target)) {
 		RespawnDeadItem(std::move(itm), target);
 		return;
 	}
 
-	for (int k = 1; k < 50; k++) {
-		for (int j = -k; j <= k; j++) {
-			for (int i = -k; i <= k; i++) {
-				Point next = player.position.tile + Displacement { i, j };
+	for (int_fast8_t k = 1; k < 50; k++) {
+		for (int_fast8_t j = -k; j <= k; j++) {
+			for (int_fast8_t i = -k; i <= k; i++) {
+				Point next = player.position.tile + DisplacementOf<int8_t> { i, j };
 				if (ItemSpaceOk(next)) {
 					RespawnDeadItem(std::move(itm), next);
 					return;
@@ -689,7 +689,7 @@ bool DoWalk(int pnum, int variant)
 
 		// Update the "camera" tile position
 		if (pnum == MyPlayerId && ScrollInfo._sdir != ScrollDirection::None) {
-			ViewPosition = Point { 0, 0 } + (player.position.tile - ScrollInfo.tile);
+			ViewPosition = PointOf<uint8_t> { 0, 0 } + (player.position.tile - ScrollInfo.tile);
 		}
 
 		if (player.walkpath[0] != WALK_NONE) {
@@ -1187,14 +1187,14 @@ bool DoRangeAttack(int pnum)
 	}
 
 	for (int arrow = 0; arrow < arrows; arrow++) {
-		int xoff = 0;
-		int yoff = 0;
+		int8_t xoff = 0;
+		int8_t yoff = 0;
 		if (arrows != 1) {
-			int angle = arrow == 0 ? -1 : 1;
-			int x = player.position.temp.x - player.position.tile.x;
+			int8_t angle = arrow == 0 ? -1 : 1;
+			int8_t x = player.position.temp.x - player.position.tile.x;
 			if (x != 0)
 				yoff = x < 0 ? angle : -angle;
-			int y = player.position.temp.y - player.position.tile.y;
+			int8_t y = player.position.temp.y - player.position.tile.y;
 			if (y != 0)
 				xoff = y < 0 ? -angle : angle;
 		}
@@ -1214,7 +1214,7 @@ bool DoRangeAttack(int pnum)
 
 		AddMissile(
 		    player.position.tile,
-		    player.position.temp + Displacement { xoff, yoff },
+		    player.position.temp + DisplacementOf<int8_t> { xoff, yoff },
 		    player._pdir,
 		    mistype,
 		    TARGET_MONSTERS,
@@ -2775,7 +2775,7 @@ void InitPlayer(Player &player, bool firstTime)
 			}
 		} else {
 			unsigned i;
-			for (i = 0; i < 8 && !PosOkPlayer(player, player.position.tile + Displacement { plrxoff2[i], plryoff2[i] }); i++)
+			for (i = 0; i < 8 && !PosOkPlayer(player, player.position.tile + DisplacementOf<int8_t> { plrxoff2[i], plryoff2[i] }); i++)
 				;
 			player.position.tile.x += plrxoff2[i];
 			player.position.tile.y += plryoff2[i];
@@ -3618,7 +3618,7 @@ void SyncInitPlrPos(int pnum)
 
 	Point position = [&]() {
 		for (int i = 0; i < 8; i++) {
-			Point position = player.position.tile + Displacement { plrxoff2[i], plryoff2[i] };
+			Point position = Point(player.position.tile) + Displacement { plrxoff2[i], plryoff2[i] };
 			if (PosOkPlayer(player, position))
 				return position;
 		}

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -75,7 +75,7 @@ void PlacePlayer(int pnum)
 		Point okPosition = {};
 
 		for (int i = 0; i < 8; i++) {
-			okPosition = player.position.tile + Displacement { plrxoff2[i], plryoff2[i] };
+			okPosition = player.position.tile + DisplacementOf<int8_t> { plrxoff2[i], plryoff2[i] };
 			if (PosOkPlayer(player, okPosition))
 				return okPosition;
 		}


### PR DESCRIPTION
In C++, when doing arithmetic between a signed and unsigned type, the signed type is first cast to unsigned (e.g. -1 -> 255).

This is not a problem when types are of the same size but can easily cause bugs when they are not.

Disallow it in a couple of places as an example.