### PR TITLE
Make DirectionSettings::offset match ActorPosition::offset2

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -163,7 +163,7 @@ namespace {
 struct DirectionSettings {
 	Direction dir;
 	DisplacementOf<int8_t> tileAdd;
-	DisplacementOf<int8_t> offset;
+	DisplacementOf<int16_t> offset;
 	DisplacementOf<int8_t> map;
 	ScrollDirection scrollDir;
 	PLR_MODE walkMode;


### PR DESCRIPTION
With this #2490 works again.

The following line overflows:
```cpp
player.position.offset2 = dirModeParams.offset * 256;
```

`ActorPosition::offset2` is defined as `int16_t`