### PR TITLE
Remove assert to check if value is in bounds in NextLENarrow.

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -148,7 +148,6 @@ public:
 		static_assert(std::numeric_limits<TSource>::min() < std::numeric_limits<TDesired>::min());
 		static_assert(std::numeric_limits<TSource>::max() > std::numeric_limits<TDesired>::max());
 		TSource value = SwapLE(Next<TSource>()) + modifier;
-		assert(value >= std::numeric_limits<TDesired>::min() && value <= std::numeric_limits<TDesired>::max());
 		return static_cast<TDesired>(clamp<TSource>(value, std::numeric_limits<TDesired>::min(), std::numeric_limits<TDesired>::max()));
 	}
 


### PR DESCRIPTION
Remove assert to check if value is in bounds in NextLENarrow. The behaviour now is to fallback to either minimum or maximum a type can hold (it was there before, as std::clamp is used. It was not possible for clamp to fallback to min/max, since the assert to prevent this was present).

This fixes issue  #4871. It potentially will fix other issues with older saves, in case where a variable ranged has been changed between versions - the save will load and fallback per std::clamp.

The fallback to min/max means that variables may get unexpected values assigned - always valid though. I didn't see a case where it could break things, but such possibility exists. Nonetheless, this change will allow older saves alike to the one in issue #4871 load - and then maybe break.