### PR TITLE
artifacts as releases

### DIFF
--- a/.github/workflows/Windows_x64.yml
+++ b/.github/workflows/Windows_x64.yml
@@ -40,34 +40,14 @@ jobs:
         name: devilutionx_x64.zip
         path: build/devilutionx.zip
         
-    - name: Move artifacts to new folder and split exe and other data into two folders
+    - name: Upload artifacts as release in storage repo
       if: ${{ !env.ACT && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
-      working-directory: ${{github.workspace}}
-      shell: bash
-      run: mkdir artifacts_dir && unzip build/devilutionx.zip -d artifacts_dir && mkdir artifacts_dir/exe_dir && mv artifacts_dir/devilutionx/devilutionx.exe artifacts_dir/exe_dir && zip -m artifacts_dir/exe_dir/build.zip artifacts_dir/exe_dir/devilutionx.exe
-
-    - name: Pushes exe to another repository
-      if: ${{ !env.ACT && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
-      uses: cpina/github-action-push-to-another-repository@main
-      env:
-        SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+      uses: svenstaro/upload-release-action@v2
       with:
-        source-directory: artifacts_dir/exe_dir
-        destination-github-username: 'artifacts-storage'
-        destination-repository-name: 'devilutionx-artifacts'     
-        target-directory: ${{ github.sha }}
-        commit-message: "[EXE]${{ github.event.head_commit.message }}"
-        target-branch: master
-        
-    - name: Pushes DLLs and devilutionx.mpq to another repository
-      if: ${{ !env.ACT && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
-      uses: cpina/github-action-push-to-another-repository@main
-      env:
-        SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
-      with:
-        source-directory: artifacts_dir/devilutionx/
-        destination-github-username: 'artifacts-storage'
-        destination-repository-name: 'devilutionx-artifacts' 
-        target-directory: data
-        commit-message: "[DATA]${{ github.event.head_commit.message }}"
-        target-branch: master
+        repo_name: artifacts-storage/devilutionx-artifacts
+        repo_token: ${{ secrets.ARTIFACTS_STORAGE_TOKEN }}
+        file: build/devilutionx.zip
+        asset_name: artifacts.zip
+        tag: "WIN64-${{ github.sha }}"
+        overwrite: true
+        body: ${{ github.event.head_commit.message }}


### PR DESCRIPTION
Since there doesn't seem to be any limit on releases, this should be the best way atm :D (Thx @Trihedraf for the idea)
https://github.com/artifacts-storage/devilutionx-artifacts
The question is if we want to also have linux artifacts (if yes, I'll push it into this PR so we have both windows and linux artifacts from the same moment)