### PR TITLE
Avoid overflow of tickCounterOfCurrentFrame

### DIFF
--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -185,11 +185,9 @@ void AnimationInfo::changeAnimationData(OptionalCelSprite celSprite, int8_t numb
 	this->celSprite = celSprite;
 }
 
-void AnimationInfo::processAnimation(bool reverseAnimation /*= false*/, bool dontProgressAnimation /*= false*/)
+void AnimationInfo::processAnimation(bool reverseAnimation /*= false*/)
 {
 	tickCounterOfCurrentFrame++;
-	if (dontProgressAnimation)
-		return;
 	ticksSinceSequenceStarted_++;
 	if (tickCounterOfCurrentFrame >= ticksPerFrame) {
 		tickCounterOfCurrentFrame = 0;

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -97,7 +97,7 @@ public:
 	 * @param reverseAnimation Play the animation backwards (for example is used for "unseen" monster fading)
 	 * @param dontProgressAnimation Increase tickCounterOfCurrentFrame but don't change currentFrame
 	 */
-	void processAnimation(bool reverseAnimation = false, bool dontProgressAnimation = false);
+	void processAnimation(bool reverseAnimation = false);
 
 private:
 	/**

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -594,7 +594,8 @@ void LoadMonster(LoadHelper *file, Monster &monster)
 	file->Skip(4); // Skip pointer _mAnimData
 	monster.AnimInfo = {};
 	monster.AnimInfo.ticksPerFrame = file->NextLENarrow<int32_t, int8_t>();
-	monster.AnimInfo.tickCounterOfCurrentFrame = file->NextLENarrow<int32_t, int8_t>();
+	// Ensure that we can increase the tickCounterOfCurrentFrame at least once without overflow (needed for backwards compatibility for sitting gargoyles)
+	monster.AnimInfo.tickCounterOfCurrentFrame = file->NextLENarrow<int32_t, int8_t>(1) - 1;
 	monster.AnimInfo.numberOfFrames = file->NextLENarrow<int32_t, int8_t>();
 	monster.AnimInfo.currentFrame = file->NextLENarrow<int32_t, int8_t>(-1);
 	file->Skip(4); // Skip _meflag

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1467,7 +1467,7 @@ bool MonsterRangedSpecialAttack(int monsterId)
 	assert(monsterId >= 0 && monsterId < MaxMonsters);
 	auto &monster = Monsters[monsterId];
 
-	if (monster.AnimInfo.currentFrame == monster.data().mAFNum2 - 1 && monster.AnimInfo.tickCounterOfCurrentFrame == 0 && monster._mVar2 == 0) {
+	if (monster.AnimInfo.currentFrame == monster.data().mAFNum2 - 1 && monster.AnimInfo.tickCounterOfCurrentFrame == 0 && (monster._mAi != AI_MEGA || monster._mVar2 == 0)) {
 		if (AddMissile(
 		        monster.position.tile,
 		        monster.enemyPosition,

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1467,7 +1467,7 @@ bool MonsterRangedSpecialAttack(int monsterId)
 	assert(monsterId >= 0 && monsterId < MaxMonsters);
 	auto &monster = Monsters[monsterId];
 
-	if (monster.AnimInfo.currentFrame == monster.data().mAFNum2 - 1 && monster.AnimInfo.tickCounterOfCurrentFrame == 0) {
+	if (monster.AnimInfo.currentFrame == monster.data().mAFNum2 - 1 && monster.AnimInfo.tickCounterOfCurrentFrame == 0 && monster._mVar2 == 0) {
 		if (AddMissile(
 		        monster.position.tile,
 		        monster.enemyPosition,
@@ -4290,8 +4290,8 @@ void ProcessMonsters()
 				GroupUnity(monster);
 			}
 		} while (raflag);
-		if (monster._mmode != MonsterMode::Petrified) {
-			monster.AnimInfo.processAnimation((monster._mFlags & MFLAG_LOCK_ANIMATION) != 0, (monster._mFlags & MFLAG_ALLOW_SPECIAL) != 0);
+		if (monster._mmode != MonsterMode::Petrified && (monster._mFlags & MFLAG_ALLOW_SPECIAL) == 0) {
+			monster.AnimInfo.processAnimation((monster._mFlags & MFLAG_LOCK_ANIMATION) != 0);
 		}
 	}
 


### PR DESCRIPTION
When `MFLAG_ALLOW_SPECIAL` was set on a monster, the `tickCounterOfCurrentFrame` was increased but nothing more.

`MFLAG_ALLOW_SPECIAL` is set, when

- a the gargoyle sits on the ground
- or a mega (winged demon) sits on the ground and casts inferno

Both are specified to stop the animation from advancing.
The logic [exists in vanilla](https://github.com/diasurgical/devilution/blob/b86b8fd7c4966385e3a7dbcb29e6d7e05bdab95e/Source/monster.cpp#L5663).
This could result in overflowing the `tickCounterOfCurrentFrame` (for gargoyles, for mega the duration is too short).

With this pr `tickCounterOfCurrentFrame` isn't blindly increased anymore.
The logic is simplified by using the same approach as petrified.

Notes
- Backwards compatibility: A `tickCounterOfCurrentFrame` > `ticksPerFrame` is no problem. As long as it doesn't overflow in negative (the change in `loadsave.cpp` ensures that this doesn't happen even with vanilla saves).
- Without this pr a gargoyles `tickCounterOfCurrentFrame`, could overflow and let him awaken later (cause a overflown negative `tickCounterOfCurrentFrame` needs to be increased to a positive value again).
- In vanilla this could theoretical also happen (after ~29k hours in a level with a gargoyle) and then the gargoyle would need the same time to awaken again. 😜 
- #4890 is still needed, cause I didn't thought about this edge case when adding the assert.