### PR TITLE
Localize the wording returned by the system on macOS/iOS.

### DIFF
--- a/Packaging/apple/Info.plist
+++ b/Packaging/apple/Info.plist
@@ -74,5 +74,7 @@
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 	</dict>
+	<key>CFBundleAllowMixedLocalizations</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
On macOS/iOS, the text returned by the system will be localized.
https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleallowmixedlocalizations

Before:
![before](https://user-images.githubusercontent.com/78299054/177579215-b4a55b8f-ac14-43fe-8d6d-76afa21e2ea8.png)

After:
![after](https://user-images.githubusercontent.com/78299054/177579228-0abed5b5-fab4-44c5-b23b-7849dcbb29e7.png)

