### PR TITLE
:memo: Fixes Doxygen warnings

### DIFF
--- a/Source/DiabloUI/ui_item.h
+++ b/Source/DiabloUI/ui_item.h
@@ -241,6 +241,8 @@ public:
 	 * @param text Pointer to the first character of a c-string
 	 * @param rect screen region defining the area to draw the text
 	 * @param flags UiFlags controlling color/alignment/size
+	 * @param spacing Spacing between characters
+	 * @param lineHeight Vertical distance between text lines
 	 */
 	UiArtText(const char *text, SDL_Rect rect, UiFlags flags = UiFlags::None, int spacing = 1, int lineHeight = -1)
 	    : UiItemBase(UiType::ArtText, rect, flags)
@@ -255,6 +257,8 @@ public:
 	 * @param ptext Pointer to a c-string (pointer to a pointer to the first character)
 	 * @param rect screen region defining the area to draw the text
 	 * @param flags UiFlags controlling color/alignment/size
+	 * @param spacing Spacing between characters
+	 * @param lineHeight Vertical distance between text lines
 	 */
 	UiArtText(const char **ptext, SDL_Rect rect, UiFlags flags = UiFlags::None, int spacing = 1, int lineHeight = -1)
 	    : UiItemBase(UiType::ArtText, rect, flags)

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -111,7 +111,9 @@ BYTE *CaptureEnc(BYTE *src, BYTE *dst, int width)
 
 /**
  * @brief Write the pixel data to the PCX file
- * @param buf Buffer
+ *
+ * @param buf Pixel data
+ * @param out File stream for the PCX file.
  * @return True if successful, else false
  */
 bool CapturePix(const Surface &buf, std::ofstream *out)

--- a/Source/controls/README.md
+++ b/Source/controls/README.md
@@ -1,4 +1,4 @@
-#Controls handling
+# Controls handling
 
 DevilutionX supports mouse & keyboard and gamepad input.
 

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -101,7 +101,7 @@ int GetRotaryDistance(Point destination)
 
 /**
  * @brief Get the best case walking steps to coordinates
- * @param Position Tile coordinates
+ * @param position Tile coordinates
  */
 int GetMinDistance(Point position)
 {

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -163,23 +163,6 @@ void DrawHalfTransparentRectTo(const Surface &out, int sx, int sy, int width, in
 	DrawHalfTransparentBlendedRectTo(out, sx, sy, width, height);
 }
 
-/**
- * @brief Returns the direction a vector from p1(x1, y1) to p2(x2, y2) is pointing to.
- *
- *      W    SW     S
- *            ^
- *            |
- *     NW ----+---> SE
- *            |
- *            |
- *      N    NE     E
- *
- * @param x1 the x coordinate of p1
- * @param y1 the y coordinate of p1
- * @param x2 the x coordinate of p2
- * @param y2 the y coordinate of p2
- * @return the direction of the p1->p2 vector
- */
 Direction GetDirection(Point start, Point destination)
 {
 	Direction md;

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -95,7 +95,6 @@ public:
 	/**
 	 * @brief Process the Animation for a game tick (for example advances the frame)
 	 * @param reverseAnimation Play the animation backwards (for example is used for "unseen" monster fading)
-	 * @param dontProgressAnimation Increase tickCounterOfCurrentFrame but don't change currentFrame
 	 */
 	void processAnimation(bool reverseAnimation = false);
 

--- a/Source/engine/render/cel_render.cpp
+++ b/Source/engine/render/cel_render.cpp
@@ -546,6 +546,7 @@ void RenderCelOutline(const Surface &out, Point position, const byte *src, std::
  * @param position Target buffer coordinate
  * @param pRLEBytes CEL pixel stream (run-length encoded)
  * @param nDataSize Size of CEL in bytes
+ * @param nWidth Width of sprite in pixels
  */
 void CelBlitSafeTo(const Surface &out, Point position, const byte *pRLEBytes, int nDataSize, int nWidth)
 {
@@ -555,10 +556,11 @@ void CelBlitSafeTo(const Surface &out, Point position, const byte *pRLEBytes, in
 
 /**
  * @brief Same as CelBlitLightSafe, with blended transparency applied
- * @param out The output buffer
+ * @param out Target buffer
+ * @param position Target buffer coordinate
  * @param pRLEBytes CEL pixel stream (run-length encoded)
  * @param nDataSize Size of CEL in bytes
- * @param nWidth Width of sprite
+ * @param nWidth Width of sprite in pixels
  * @param tbl Palette translation table
  */
 void CelBlitLightBlendedSafeTo(const Surface &out, Point position, const byte *pRLEBytes, int nDataSize, int nWidth, const uint8_t *tbl)
@@ -583,6 +585,7 @@ void CelBlitLightBlendedSafeTo(const Surface &out, Point position, const byte *p
  * @param position Target buffer coordinate
  * @param pRLEBytes CEL pixel stream (run-length encoded)
  * @param nDataSize Size of CEL in bytes
+ * @param nWidth Width of sprite in pixels
  * @param tbl Palette translation table
  */
 void CelBlitLightSafeTo(const Surface &out, Point position, const byte *pRLEBytes, int nDataSize, int nWidth, uint8_t *tbl)

--- a/Source/engine/render/cel_render.hpp
+++ b/Source/engine/render/cel_render.hpp
@@ -38,7 +38,7 @@ void CelApplyTrans(byte *p, const std::array<uint8_t, 256> &translation);
 void CelDrawTo(const Surface &out, Point position, CelSprite cel, int frame);
 
 /**
- * @briefBlit CEL sprite to the given buffer, does not perform bounds-checking.
+ * @brief Blit CEL sprite to the given buffer, does not perform bounds-checking.
  * @param out Target buffer
  * @param position Coordinate in the target buffer coordinate
  * @param cel CEL sprite
@@ -61,6 +61,7 @@ void CelClippedDrawTo(const Surface &out, Point position, CelSprite cel, int fra
  * @param position Target buffer coordinate
  * @param cel CEL sprite
  * @param frame CEL frame number
+ * @param tbl Palette translation table
  */
 void CelDrawLightTo(const Surface &out, Point position, CelSprite cel, int frame, uint8_t *tbl);
 
@@ -106,7 +107,7 @@ void CelDrawItem(const Item &item, const Surface &out, Point position, CelSprite
  * @param out Target buffer
  * @param col Color index from current palette
  * @param position Target buffer coordinate
- * @param pCelBuff CEL buffer
+ * @param cel CEL sprite
  * @param frame CEL frame number
  * @param skipColorIndexZero If true, color in index 0 will be treated as transparent (these are typically used for shadows in sprites)
  */

--- a/Source/engine/render/cl2_render.hpp
+++ b/Source/engine/render/cl2_render.hpp
@@ -27,8 +27,8 @@ void Cl2ApplyTrans(byte *p, const std::array<uint8_t, 256> &ttbl, int numFrames)
  * @param out Output buffer
  * @param sx Output buffer coordinate
  * @param sy Output buffer coordinate
- * @param pCelBuff CL2 buffer
- * @param nCel CL2 frame number
+ * @param cel CL2 buffer
+ * @param frame CL2 frame number
  */
 void Cl2Draw(const Surface &out, int sx, int sy, CelSprite cel, int frame);
 
@@ -38,8 +38,8 @@ void Cl2Draw(const Surface &out, int sx, int sy, CelSprite cel, int frame);
  * @param out Output buffer
  * @param sx Output buffer coordinate
  * @param sy Output buffer coordinate
- * @param pCelBuff CL2 buffer
- * @param nCel CL2 frame number
+ * @param cel CL2 buffer
+ * @param frame CL2 frame number
  */
 void Cl2DrawOutline(const Surface &out, uint8_t col, int sx, int sy, CelSprite cel, int frame);
 
@@ -48,9 +48,9 @@ void Cl2DrawOutline(const Surface &out, uint8_t col, int sx, int sy, CelSprite c
  * @param out Output buffer
  * @param sx Output buffer coordinate
  * @param sy Output buffer coordinate
- * @param pCelBuff CL2 buffer
- * @param nCel CL2 frame number
- * @param TRN to use
+ * @param cel CL2 buffer
+ * @param frame CL2 frame number
+ * @param trn TRN to use
  */
 void Cl2DrawTRN(const Surface &out, int sx, int sy, CelSprite cel, int frame, uint8_t *trn);
 
@@ -59,8 +59,8 @@ void Cl2DrawTRN(const Surface &out, int sx, int sy, CelSprite cel, int frame, ui
  * @param out Output buffer
  * @param sx Output buffer coordinate
  * @param sy Output buffer coordinate
- * @param pCelBuff CL2 buffer
- * @param nCel CL2 frame number
+ * @param cel CL2 buffer
+ * @param frame CL2 frame number
  */
 void Cl2DrawLight(const Surface &out, int sx, int sy, CelSprite cel, int frame);
 

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -309,7 +309,7 @@ void DrawCursor(const Surface &out)
 /**
  * @brief Render a missile sprite
  * @param out Output buffer
- * @param m Pointer to Missile struct
+ * @param missile Pointer to Missile struct
  * @param targetBufferPosition Output buffer coordinate
  * @param pre Is the sprite in the background
  */
@@ -359,7 +359,7 @@ void DrawMissile(const Surface &out, Point tilePosition, Point targetBufferPosit
  * @param out Output buffer
  * @param tilePosition dPiece coordinates
  * @param targetBufferPosition Output buffer coordinates
- * @param m Id of monster
+ * @param monster Monster reference
  */
 void DrawMonster(const Surface &out, Point tilePosition, Point targetBufferPosition, const Monster &monster)
 {
@@ -486,8 +486,9 @@ void DrawPlayerIconHelper(const Surface &out, missile_graphic_id missileGraphicI
 /**
  * @brief Helper for rendering player icons (Mana Shield and Reflect)
  * @param out Output buffer
+ * @param player Player reference
  * @param position Output buffer coordinates
- * @param lighting Should lighting be applied
+ * @param infraVision Should infravision be applied
  */
 void DrawPlayerIcons(const Surface &out, const Player &player, Point position, bool infraVision)
 {
@@ -500,6 +501,7 @@ void DrawPlayerIcons(const Surface &out, const Player &player, Point position, b
 /**
  * @brief Render a player sprite
  * @param out Output buffer
+ * @param player Player reference
  * @param tilePosition dPiece coordinates
  * @param targetBufferPosition Output buffer coordinates
  */
@@ -789,6 +791,7 @@ void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBuffe
 /**
  * @brief Check if and how a player should be rendered
  * @param out Output buffer
+ * @param player Player reference
  * @param tilePosition dPiece coordinates
  * @param targetBufferPosition Output buffer coordinates
  */
@@ -1061,7 +1064,7 @@ int tileRows;
 
 /**
  * @brief Configure render and process screen rows
- * @param full_out Buffer to render to
+ * @param fullOut Buffer to render to
  * @param position Center of view in dPiece coordinate
  */
 void DrawGame(const Surface &fullOut, Point position)
@@ -1353,11 +1356,11 @@ void DoBlitScreen(Sint16 dwX, Sint16 dwY, Uint16 dwWdt, Uint16 dwHgt)
 /**
  * @brief Check render pipeline and blit individual screen parts
  * @param dwHgt Section of screen to update from top to bottom
- * @param draw_desc Render info box
- * @param draw_hp Render health bar
- * @param draw_mana Render mana bar
- * @param draw_sbar Render belt
- * @param draw_btn Render panel buttons
+ * @param drawDesc Render info box
+ * @param drawHp Render health bar
+ * @param drawMana Render mana bar
+ * @param drawSbar Render belt
+ * @param drawBtn Render panel buttons
  */
 void DrawMain(int dwHgt, bool drawDesc, bool drawHp, bool drawMana, bool drawSbar, bool drawBtn)
 {

--- a/Source/engine/render/scrollrt.h
+++ b/Source/engine/render/scrollrt.h
@@ -50,6 +50,8 @@ void ClearCursor();
 /**
  * @brief Shifting the view area along the logical grid
  *        Note: this won't allow you to shift between even and odd rows
+ * @param x X offset
+ * @param y Y offset
  * @param horizontal Shift the screen left or right
  * @param vertical Shift the screen up or down
  */

--- a/Source/engine/render/text_render.hpp
+++ b/Source/engine/render/text_render.hpp
@@ -143,6 +143,7 @@ int GetLineWidth(string_view text, GameFontTables size = GameFont12, int spacing
  * @brief Calculate pixel width of first line of text, respecting kerning
  * @param fmt An fmt::format string.
  * @param args Format arguments.
+ * @param argsLen Number of format arguments.
  * @param size Font size to use
  * @param spacing Extra spacing to add per character
  * @param charactersInLine Receives characters read until newline or terminator
@@ -210,12 +211,13 @@ inline void DrawString(const Surface &out, string_view text, const Point &positi
 /**
  * @brief Draws a line of text with different colors for certain parts of the text.
  *
- * @example DrawStringWithColors(out, "Press {} to start", {{"Ⓧ", UiFlags::ColorBlue}}, UiFlags::ColorWhite)
+ *     DrawStringWithColors(out, "Press {} to start", {{"Ⓧ", UiFlags::ColorBlue}}, UiFlags::ColorWhite)
  *
  * @param out Output buffer to draw the text on.
  * @param fmt An fmt::format string.
  * @param args Format arguments.
- * @param position Location of the top left corner of the string relative to the top left corner of the output buffer.
+ * @param argsLen Number of format arguments.
+ * @param rect Clipping region relative to the output buffer describing where to draw the text and when to wrap long lines.
  * @param flags A combination of UiFlags to describe font size, color, alignment, etc. See ui_items.h for available options
  * @param spacing Additional space to add between characters.
  *                This value may be adjusted if the flag UIS_FIT_SPACING is passed in the flags parameter.

--- a/Source/engine/surface.hpp
+++ b/Source/engine/surface.hpp
@@ -77,7 +77,7 @@ struct Surface {
 
 	/**
 	 * @brief Set the value of a single pixel if it is in bounds.
-	 * @param point Target buffer coordinate
+	 * @param position Target buffer coordinate
 	 * @param col Color index from current palette
 	 */
 	void SetPixel(Point position, std::uint8_t col) const

--- a/Source/engine/trn.hpp
+++ b/Source/engine/trn.hpp
@@ -1,5 +1,5 @@
 /**
- * @file trn.h
+ * @file trn.hpp
  *
  * Contains most of trn logic
  */

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -40,6 +40,8 @@ bool drawsbarflag;
 /**
  * Maps from inventory slot to screen position. The inventory slots are
  * arranged as follows:
+ *
+ * @code{.unparsed}
  *                          00 01
  *                          02 03   06
  *
@@ -55,6 +57,7 @@ bool drawsbarflag;
  *              55 56 57 58 59 60 61 62 63 64
  *
  * 65 66 67 68 69 70 71 72
+ * @endcode
  */
 const Point InvRect[] = {
 	// clang-format off
@@ -141,6 +144,7 @@ OptionalOwnedCelSprite pInvCels;
 
 /**
  * @brief Adds an item to a player's InvGrid array
+ * @param player The player reference
  * @param invGridIndex Item's position in InvGrid (this should be the item's topleft grid tile)
  * @param invListIndex The item's InvList index (it's expected this already has +1 added to it since InvGrid can't store a 0 index)
  * @param itemSize Size of item

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -38,7 +38,7 @@ enum inv_item : int8_t {
 
 /**
  * identifiers for each of the inventory squares
- * @see #InvRect
+ * @see InvRect
  */
 enum inv_xy_slot : uint8_t {
 	// clang-format off
@@ -130,7 +130,7 @@ bool AutoEquipEnabled(const Player &player, const Item &item);
 /**
  * @brief Automatically attempts to equip the specified item in the most appropriate location in the player's body.
  * @note On success, this will broadcast an equipment_change event to let other players know about the equipment change.
- * @param playerId The player number whose inventory will be checked for compatibility with the item.
+ * @param player The player whose inventory will be checked for compatibility with the item.
  * @param item The item to equip.
  * @param persistItem Indicates whether or not the item should be persisted in the player's body. Pass 'False' to check
  * whether the player can equip the item but you don't want the item to actually be equipped. 'True' by default.
@@ -141,6 +141,7 @@ bool AutoEquip(Player &player, const Item &item, bool persistItem = true);
 /**
  * @brief Checks whether the given item can be placed on the specified player's inventory.
  * If 'persistItem' is 'True', the item is also placed in the inventory.
+ * @param player The player whose inventory will be checked.
  * @param item The item to be checked.
  * @param persistItem Pass 'True' to actually place the item in the inventory. The default is 'False'.
  * @return 'True' in case the item can be placed on the player's inventory and 'False' otherwise.
@@ -150,6 +151,7 @@ bool AutoPlaceItemInInventory(Player &player, const Item &item, bool persistItem
 /**
  * @brief Checks whether the given item can be placed on the specified player's inventory slot.
  * If 'persistItem' is 'True', the item is also placed in the inventory slot.
+ * @param player The player whose inventory will be checked.
  * @param slotIndex The 0-based index of the slot to put the item on.
  * @param item The item to be checked.
  * @param persistItem Pass 'True' to actually place the item in the inventory slot. The default is 'False'.
@@ -206,7 +208,7 @@ void AutoGetItem(Player &player, Item *itemPointer, int ii);
  * @brief Searches for a dropped item with the same type/createInfo/seed
  * @param iseed The value used to initialise the RNG when generating the item
  * @param idx The overarching type of the target item
- * @param createInfo Flags used to describe the specific subtype of the target item
+ * @param ci Flags used to describe the specific subtype of the target item
  * @return An index into ActiveItems or -1 if no matching item was found
  */
 int FindGetItem(int32_t iseed, _item_indexes idx, uint16_t ci);

--- a/Source/items.h
+++ b/Source/items.h
@@ -462,7 +462,7 @@ int GetGoldCursor(int value);
 
 /**
  * @brief Update the gold cursor on the given gold item
- * @param h The item to update
+ * @param gold The item to update
  */
 void SetPlrHandGoldCurs(Item &gold);
 void CreatePlrItems(Player &player);

--- a/Source/levels/gendung.h
+++ b/Source/levels/gendung.h
@@ -284,6 +284,7 @@ struct Miniset {
 	uint8_t replace[6][6];
 
 	/**
+	 * @param position Coordinates of the dungeon tile to check
 	 * @param respectProtected Match bug from Crypt levels
 	 */
 	bool matches(Point position, bool respectProtected = true) const
@@ -325,6 +326,7 @@ void LoadTransparency(const uint16_t *dunData);
 void LoadDungeonBase(const char *path, Point spawn, int floorId, int dirtId);
 void Make_SetPC(Rectangle area);
 /**
+ * @param miniset The miniset to place
  * @param tries Tiles to try, 1600 will scan the full map
  * @param drlg1Quirk Match buggy behaviour of Diablo's Cathedral
  */

--- a/Source/levels/town.cpp
+++ b/Source/levels/town.cpp
@@ -56,7 +56,6 @@ void FillSector(const char *path, int xi, int yy)
 
 /**
  * @brief Load a tile in to dPiece
- * @param megas Map from mega tiles to macro tiles
  * @param xx upper left destination
  * @param yy upper left destination
  * @param t tile id

--- a/Source/levels/trigs.h
+++ b/Source/levels/trigs.h
@@ -43,6 +43,7 @@ void CheckTriggers();
 
 /**
  * @brief Check if the provided position is in the entrance boundary of the entrance.
+ * @param entrance The entrance to check.
  * @param position The position to check against the entrance boundary.
  */
 bool EntranceBoundaryContains(Point entrance, Point position);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1607,7 +1607,7 @@ std::unordered_map<uint8_t, uint8_t> SaveDroppedItems(SaveHelper &file)
 /**
  * @brief Saves the position of dropped items (in dItem)
  * @param file interface to the save file
- * @param indexMap a map converting from runtime item indexes to the relative position in the save file
+ * @param itemIndexes a map converting from runtime item indexes to the relative position in the save file
  */
 void SaveDroppedItemLocations(SaveHelper &file, const std::unordered_map<uint8_t, uint8_t> &itemIndexes)
 {

--- a/Source/loadsave.h
+++ b/Source/loadsave.h
@@ -24,7 +24,7 @@ void LoadHotkeys();
 void LoadHeroItems(Player &player);
 /**
  * @brief Remove invalid inventory items from the inventory grid
- * @param pnum The id of the player
+ * @param player The player to remove invalid items from
  */
 void RemoveEmptyInventory(Player &player);
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -116,7 +116,7 @@ void UpdateMissileVelocity(Missile &missile, Point destination, int velocityInPi
 
 /**
  * @brief Add the missile to the lookup tables
- * @param i Missiles index
+ * @param missile The missile to add
  */
 void PutMissile(Missile &missile)
 {

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -143,6 +143,7 @@ void GetDamageAmt(spell_id i, int *mind, int *maxd);
 /**
  * @brief Returns the direction a vector from p1(x1, y1) to p2(x2, y2) is pointing to.
  *
+ * @code{.unparsed}
  *      W  sW  SW   Sw  S
  *              ^
  *     nW       |       Se
@@ -152,11 +153,10 @@ void GetDamageAmt(spell_id i, int *mind, int *maxd);
  *     Nw       |       sE
  *              |
  *      N  Ne  NE   nE  E
+ * @endcode
  *
- * @param x1 the x coordinate of p1
- * @param y1 the y coordinate of p1
- * @param x2 the x coordinate of p2
- * @param y2 the y coordinate of p2
+ * @param p1 The point from which the vector starts.
+ * @param p2 The point from which the vector ends.
  * @return the direction of the p1->p2 vector
  */
 Direction16 GetDirection16(Point p1, Point p2);

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -774,7 +774,7 @@ void UpdateEnemy(Monster &monster)
 
 /**
  * @brief Make the AI wait a bit before thinking again
- * @param monster The monster what will wait
+ * @param monster The monster that will wait
  * @param len
  */
 void AiDelay(Monster &monster, int len)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -774,6 +774,7 @@ void UpdateEnemy(Monster &monster)
 
 /**
  * @brief Make the AI wait a bit before thinking again
+ * @param monster The monster what will wait
  * @param len
  */
 void AiDelay(Monster &monster, int len)
@@ -1162,6 +1163,15 @@ void StartFadeout(Monster &monster, Direction md, bool backwards)
 	}
 }
 
+/**
+ * @brief Starts the monster healing procedure.
+ *
+ * The monster will be healed between 1.47% and 25% of its max HP. The healing amount is stored in _mVar1.
+ *
+ * This is only used by Gargoyles.
+ *
+ * @param monster The monster that will be healed.
+ */
 void StartHeal(Monster &monster)
 {
 	monster.changeAnimationData(MonsterGraphic::Special);
@@ -1539,6 +1549,14 @@ bool MonsterFadeout(Monster &monster)
 	return true;
 }
 
+/**
+ * @brief Applies the healing effect on the monster.
+ *
+ * This is triggered by StartHeal()
+ *
+ * @param monster The monster that will be healed.
+ * @return
+ */
 bool MonsterHeal(Monster &monster)
 {
 	if ((monster.flags & MFLAG_NOHEAL) != 0) {

--- a/Source/nthread.h
+++ b/Source/nthread.h
@@ -33,8 +33,7 @@ void nthread_ignore_mutex(bool bStart);
  */
 bool nthread_has_500ms_passed();
 /**
- * @brief Calculates the progress in time to the next game tick
- * @return Progress as a fraction (0.0f to 1.0f)
+ * @brief Updates the progress in time to the next game tick
  */
 void nthread_UpdateProgressToNextGameTick();
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1720,7 +1720,7 @@ void CryptDoorSet(Point position, bool isLeftDoor)
  *
  * In order to be able to close a door the space where the closed door would be must be free of bodies, monsters, and items
  *
- * @param doorPos Map tile where the door is in its closed position
+ * @param doorPosition Map tile where the door is in its closed position
  * @return true if the door is free to be closed, false if anything is blocking it
  */
 inline bool IsDoorClear(const Point &doorPosition)
@@ -2906,9 +2906,8 @@ void OperateShrineEerie(Player &player)
 /**
  * @brief Fully restores HP and Mana of the active player and spawns a pair of potions
  *        in response to the player activating a Divine shrine
+ * @param player The player who activated the shrine
  * @param spawnPosition The map tile where the potions will be spawned
- * @return false if the shrine was activated by another player in a multiplayer game and
- *               no changes were made by this instance, true otherwise.
  */
 void OperateShrineDivine(Player &player, Point spawnPosition)
 {
@@ -3082,6 +3081,7 @@ void OperateShrineTainted(const Player &player)
 /**
  * @brief Oily shrines increase the players primary stat(s) by a total of two, but spawn a
  *        firewall near the shrine that will spread towards the player
+ * @param player The player that will be affected by the shrine
  * @param spawnPosition Start location for the firewall
  */
 void OperateShrineOily(Player &player, Point spawnPosition)
@@ -3165,6 +3165,7 @@ void OperateShrineMendicant(Player &player)
 
 /**
  * @brief Grants experience to the player based on their current level while also triggering a magic trap
+ * @param player The player that will be affected by the shrine
  * @param spawnPosition The trap results in casting flash from this location targeting the player
  */
 void OperateShrineSparkling(Player &player, Point spawnPosition)

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -91,6 +91,7 @@ bool UnPackPlayer(const PlayerPack *pPack, Player &player, bool netSync);
  *
  * @param packedItem The destination packed struct
  * @param item The source item
+ * @param isHellfire Whether the item is from Hellfire or not
  */
 void PackItem(ItemPack &packedItem, const Item &item, bool isHellfire);
 
@@ -99,6 +100,7 @@ void PackItem(ItemPack &packedItem, const Item &item, bool isHellfire);
  *
  * @param packedItem The source packed item
  * @param item The destination item
+ * @param isHellfire Whether the item is from Hellfire or not
  */
 void UnPackItem(const ItemPack &packedItem, Item &item, bool isHellfire);
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2460,6 +2460,7 @@ void SetPlrAnims(Player &player)
 }
 
 /**
+ * @param player The player reference.
  * @param c The hero class.
  */
 void CreatePlayer(Player &player, HeroClass c)
@@ -3405,6 +3406,7 @@ void ClrPlrPath(Player &player)
  *
  * This requires an ID instead of a Player& to compare with the dPlayer lookup table values.
  *
+ * @param player The player to check.
  * @param position Dungeon tile coordinates.
  * @return False if something (other than the player themselves) is blocking the tile.
  */

--- a/Source/player.h
+++ b/Source/player.h
@@ -433,6 +433,7 @@ struct Player {
 	void Say(HeroSpeech speechId) const;
 	/**
 	 * @brief Says a speech line after a given delay.
+	 * @param speechId The speech ID to say.
 	 * @param delay Multiple of 50ms wait before starting the speech
 	 */
 	void Say(HeroSpeech speechId, int delay) const;
@@ -751,6 +752,7 @@ void ResetPlayerGFX(Player &player);
 
 /**
  * @brief Sets the new Player Animation with all relevant information for rendering
+ * @param player The player to set the animation for
  * @param graphic What player animation should be displayed
  * @param dir Direction of the animation
  * @param numberOfFrames Number of Frames in Animation

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -52,6 +52,8 @@ Art StashPanelArt;
 Art StashNavButtonArt;
 
 /**
+ * @param page The stash page index.
+ * @param position Position to add the item to.
  * @param stashListIndex The item's StashList index
  * @param itemSize Size of item
  */

--- a/Source/qol/stash.h
+++ b/Source/qol/stash.h
@@ -95,6 +95,7 @@ void GoldWithdrawNewText(string_view text);
 /**
  * @brief Checks whether the given item can be placed on the specified player's stash.
  * If 'persistItem' is 'True', the item is also placed in the inventory.
+ * @param player The player to check.
  * @param item The item to be checked.
  * @param persistItem Pass 'True' to actually place the item in the inventory. The default is 'False'.
  * @return 'True' in case the item can be placed on the player's inventory and 'False' otherwise.

--- a/Source/storm/storm_net.cpp
+++ b/Source/storm/storm_net.cpp
@@ -151,6 +151,7 @@ bool SNetLeaveGame(int type)
 /**
  * @brief Called by engine for single, called by ui for multi
  * @param provider BNET, IPXN, MODM, SCBL or UDPN
+ * @param gameData The game data
  */
 bool SNetInitializeProvider(uint32_t provider, struct GameData *gameData)
 {

--- a/Source/utils/file_name_generator.hpp
+++ b/Source/utils/file_name_generator.hpp
@@ -59,7 +59,7 @@ private:
 /**
  * @brief Generates file names from prefixes, a suffix, and an index.
  *
- * @example FileNameGenerator f({"a/", "b"}, ".txt", 1);
+ *     FileNameGenerator f({"a/", "b"}, ".txt", 1);
  *     f()  // "a/b.txt"
  *     f(0) // "a/b1.txt"
  *     f(1) // "a/b2.txt"
@@ -87,7 +87,7 @@ private:
 /**
  * @brief Generates file names from prefixes, a suffix, a char array and an index into it.
  *
- * @example FileNameWithCharAffixGenerator f({"a/", "b"}, ".txt", "ABC");
+ *     FileNameWithCharAffixGenerator f({"a/", "b"}, ".txt", "ABC");
  *     f(0) // "a/bA.txt"
  *     f(1) // "a/bB.txt"
  */

--- a/Source/utils/soundsample.h
+++ b/Source/utils/soundsample.h
@@ -38,6 +38,7 @@ public:
 	 * @brief Sets the sample's WAV, FLAC, or Ogg/Vorbis data.
 	 * @param fileData Buffer containing the data
 	 * @param dwBytes Length of buffer
+	 * @param isMp3 Whether the data is an MP3
 	 * @return 0 on success, -1 otherwise
 	 */
 	int SetChunk(ArraySharedPtr<std::uint8_t> fileData, std::size_t dwBytes, bool isMp3);

--- a/Source/utils/utf8.hpp
+++ b/Source/utils/utf8.hpp
@@ -69,6 +69,8 @@ inline std::size_t FindLastUtf8Symbols(string_view input)
 
 /**
  * @brief Copy up to a given number of bytes from a UTF8 string, and zero terminate string
+ * @param dest The destination buffer
+ * @param source The source string
  * @param bytes Max number of bytes to copy
  */
 void CopyUtf8(char *dest, string_view source, std::size_t bytes);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
@@ -7,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## DevilutionX 1.3.0
 
 ### Features
+
 #### Platforms
+
 - Added support for [Android](https://play.google.com/store/apps/details?id=org.diasurgical.devilutionx) (please leave us a review 🤗)
 - Added support for the original Nintendo 3DS
 - Added support for Lepus - jz4760/RG300 with multiplayer support
@@ -16,7 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenDingux: Added TCP/IP multiplayer support
 - 3DS: Added TCP/IP multiplayer support
 - 3DS: Add launcher sound
+
 #### Graphics / Audio
+
 - Animations are now updated at render time for high fps visuals
 - Added support for hardware cursor (solves cursor lag)
 - Quests being ordered logically in the quest panel
@@ -31,12 +36,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved XP bar visuals
 - More widescreen loading scenes
 - Mac: Icon now follow Big Sur style guide
+
 #### Multiplayer
+
 - Added built in support for ZeroTier (no need for port forwarding, no need for an extra application)
 - Added support for unencrypted public games
 - Added auto discovery of public games over ZeroTier
 - Share map exploration (in a different color than your own exploration)
+
 #### Controls
+
 - Press alt to show items on ground with labels
 - Added option for stopping the hero with a key-press
 - Hold click to continue to attack/walk/consume
@@ -54,7 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - gamepad: Inventory now takes object size into consideration
 - gamepad: Add joystick dead zone range to ini
 - touch: Add input hint to virtual keyboards
+
 #### Stability / Performance / System
+
 - Add support for translations
 - Run in self-contained (portable) mode if diablo.ini is in the same folder as DevilutionX
 - Chat now supports Unicode, including emojis
@@ -70,7 +81,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow for multiple heroes with the same name
 - Only update diablo.ini if there are changes
 - Windows: Auto detect location of MPQ files from GOG installation
+
 #### Translations
+
 - Added Brazilian Portuguese
 - Added Bulgarian
 - Added Czech
@@ -85,7 +98,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Traditional Chinese (requires the [additional fonts](https://github.com/diasurgical/devilutionx-assets/releases/download/v1/fonts.mpq))
 
 ### Bugfixes
+
 #### Gameplay
+
 - Fix small rooms missing from some levels
 - Golem's to-hit being incorrect after loading a save game
 - Diablo: Correct spells mana cost for the Sorcerer
@@ -93,26 +108,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Diablo: Barbarian missing his armor piercing bonus
 - Hellfire: Elemental spell was missing
 - Hellfire: Firering spell not creating the correct shape
+
 #### Platforms
+
 - Switch: No longer reacts to touch events
+
 #### Graphics / Audio
+
 - Corrected directional sounds for distant sources
 - Fix sound cut off when exiting game or starting the intro video
 - Entirely new audio mixer to solve audio issues and lower memory usage
 - Fixed rendering issues on 8bit outputs
 - Hellfire: Clearly indicate if it's in shareware mode
+
 #### Multiplayer
+
 - Reverted melee damage, when friendly fire and friendly mode is on
 - Do not show XP bar when chat is open
 - Do not show unbound status in place of game name
 - Show host version when incompatible
+
 #### Controls
+
 - Gamepad: Prevent wasting stat points on maxed out stats
 - Gamepad: Do not reset cursor position when switching between mouse and gamepad
 - Gamepad: Unable to open crypt and hive
 - Gamepad: Close cathedral map when pressing B-button
 - Touch: Open virtual keyboard when text input is needed
+
 #### Stability / Performance / System
+
 - Correctly reset game state if not saved
 - Compatibility with shareware save games
 - Correctly handle folders with non English symbols in them
@@ -129,7 +154,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Windows: Only show network errors once
 
 ### Bugfixes for original Diablo bugs
+
 #### Gameplay
+
 - Player becoming immune to stun while using manashield at low health
 - Monsters and players are no-longer immune to missiles when moving horizontally
 - Fix missiles hitting multiple times
@@ -162,7 +189,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix stairs up to level 8 sometimes taking the player to town instead
 - Fix random tiles being explored on automap
 - Fixed various typos
+
 #### Graphics / Audio
+
 - Monster light not updating when monster teleports
 - Correctly shorten item names depending on visual length
 - Missing dirt corners on map
@@ -172,7 +201,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fully close the dialog screen when pausing game
 - Changed player saying "Not enough mana" to a more fitting message when using a level 0 spell
 - Draw belt item number for unusable scrolls
+
 #### Multiplayer
+
 - Correct dsync caused by incorrect vision range for other players
 - Sync monster active state
 - Player attack speed being out of sync
@@ -181,9 +212,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Golem dsyncing if owner leaves level
 - Prevent golems from fighting each other
 - Play the correct sound when a player is hit by missiles
+
 #### Controls
+
 - Controls [ + ] stat point buttons sometimes not responding to clicks
+
 #### Stability / Performance / System
+
 - Keyboard layout is now correct when entering chat messages
 - Validate network messages to harden security
 - Fix corrupt save games for levels with large amount of entities
@@ -193,7 +228,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected multiple crashes and stability issues
 
 ### Bugfixes for original Hellfire bugs
+
 #### Gameplay
+
 - Range monsters cannot hit target at melee range
 - Monsters could not see firewalls if covered by lightning wall and vice versa
 - Armor piercing affix on ranged weapons decreasing hit chance instead of increasing it
@@ -204,7 +241,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reflect spell not working after loading a save game
 - Potion trap was not degrading rejuvenation potion into mana or life
 - Barbarian's skill not correctly updating health points
+
 #### Graphics / Audio
+
 - Fix missing player lights when loading Hive level 3
 - Apply lights to all berserked monsters after loading save game
 - Remove light when killing a berserked monster
@@ -215,7 +254,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Celia and Complete Nut graphics when completing their quests
 - Only play "Uh uh" sound the first time you pick up the cathedral map
 - Glass breaking sound sometimes not playing for the potion trap
+
 #### Multiplayer
+
 - Fix dsync in Hive
 - Open Crypt from the start
 - Restrict access to Hive and Crypt based on level
@@ -223,36 +264,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Search spell affecting all players
 
 ### Known issues
+
 - Switch/3DS: Polish dub produces static sounds
 - OpenDingux: Now requires Beta
 
 ## DevilutionX 1.2.1
+
 ### Bugfixes
+
 #### Gameplay
+
 - Gharbad not having to go out of vision before progressing his quest
 - Diablo: Items with negative AC morphing in multiplayer
 - Diablo: Griswold and Wirt selling unusually expensive items
 - Diablo: Gold not going directly to inventory
 - Hellfire: Some monsters having lower than intended HP
 - Hellfire: Auric Amulet not taking effect in most scenarios
+
 #### Graphics / Audio
+
 - Windows: Glitchy audio
+
 #### Controls
+
 - Vita: Inability to edit hero name on the creation screen
+
 #### Stability / Performance / System
+
 - Quest panel crashing the game for some quests
 - Windows: Some systems getting a sensor permission error
 - Windows: Stability issues and item morphing in Hellfire
 
 ### Bugfixes for original Hellfire bugs
+
 #### Gameplay
+
 - Rage/Search/Lightningwall not factoring in the hero level for the first player
 - Sparkling Shrine dealing an incorrect amount of damage
 - Items with negative AC morphing in multiplayer
 
 ## DevilutionX 1.2.0
+
 ### Features
+
 #### Gameplay
+
 - Hellfire support
 - Shareware support
 - Fully migrate saves between Diablo and Hellfire
@@ -271,7 +327,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disable quest randomization (off by default)
 - Adria refills mana (off by default)
 - Barbarian and Bard heroes in Diablo (off by default)
+
 #### Controls
+
 - Use belt via the numpad
 - Close panels when pressing <kbd>ESC</kbd>
 - <kbd>Shift-click</kbd> to spend all stat points
@@ -284,7 +342,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Right stick mouse emulation has been improved.
 - Gamepads plugged in while the game is running can be used.
 - All connected gamepads can be used (previously, only the first one).
+
 #### Graphics / Audio
+
 - Widescreen menus
 - Scroll subtitles at the same speed as narration reader
 - Apply sound volume to videos
@@ -292,7 +352,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auto-equip sounds (off by default)
 - Show monster type (off by default)
 - Disable walking sounds (off by default)
+
 #### Stability / Performance / System
+
 - Document [ini-file options](https://github.com/diasurgical/devilutionX/wiki/DevilutionX-diablo.ini-configuration-guide)
 - Reorganize ini-file
 - Allow for up to 99 save games of each type
@@ -310,22 +372,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added AppImage for Linux
 
 ### Bugfixes
+
 #### Gameplay
+
 - Catacombs doors never having traps
+
 #### Graphics / Audio
+
 - Incorrect graphics under cave doors in multiplayer
 - Minor color issues in some videos
 - Command-line output missing on Windows
 - Correct visuals and function of the joining-game-dialog
+
 #### Controls
+
 - Mouse jumping to the top of the windows when using the menu
 - Mouse not releasing when exiting the window
 - Dragging on touch devices
+
 #### Stability / Performance / System
+
 - Multiplayer host crashing after beating the game
 
 ### Bugfixes for original Diablo bugs
+
 #### Gameplay
+
 - Base damage not being updated when leveling up
 - Player vision radius not updating properly before changing level
 - Tiles not properly being marked as out of visibility when walking
@@ -351,9 +423,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Randomly being teleported from level 15 to Lazarus' chamber
 - Several bugs in Lazarus quest when re-entering the teleport
 - Town portals appearing on two levels when cast in a quest level
+
 #### Controls
+
 - Inconsistent mouse behavior when opening/closing various panels
+
 #### Graphics / Audio
+
 - Gold icons graphics are always correct
 - Arrows graphics not aligning with the move direction
 - Wrong death sound when monster/golem kills another monster
@@ -364,15 +440,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lava pools sometimes having roof tiles in them
 - Doors sometimes missing in Halls of The Blind
 - Broken outline on some inventory items
+
 #### Stability / Performance / System
+
 - Fix more stability issues
+
 #### Bugfixes from Hellfire 1.00 - 1.01
+
 - Monster hitpoints overflowing in Nightmare/Hell difficulty
 - Gharbad the Weak not dropping his item when killed by a golem
 - Some stability issues
 
 ### Bugfixes for original Hellfire bugs
+
 #### Gameplay
+
 - Firewall damage calculation being too low
 - Firewall/Lightningwall damage being based on the dungeon level instead of spell level for the first player
 - Right-hand item's decay suffix being applied to the left-hand item in multiplayer
@@ -382,12 +464,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scavenger/Gravedigger AI being stuck for a round after eating
 - Sync available quests in multiplayer
 - Correct spell level being ignored for Search and Rage
+
 #### Graphics / Audio
+
 - Monster attack sound sometimes not playing
 - Missing sounds when bards and barbarians talk to cows
 - "0 Gold" sometimes spawning on The Cornerstone
 - Minor typography corrections
+
 #### Bugfixes from Diablo 1.03 - 1.09
+
 - The Hidden Shrine freezes when not holding an applicable item
 - Memory corruption when casting town portal
 - Crashes associated with Black Death
@@ -411,11 +497,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Some stability issues
 
 ### Known issues
+
 - Save game difficulty does not carry over from 1.1.0
 - Amiga builds are currently unstable
 
 ## DevilutionX 1.1.0
+
 ### Features
+
 - Proper widescreen (and other aspects) support
 - Select difficulty in single player (remembered in the save game)
 - Adjustable game speed in-game
@@ -426,10 +515,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for joining a game via hostname instead of IP
 
 ### Bugfixes
+
 - You can now enter and exit fullscreen also when the game is paused
 - [Amiga] Fix double-clicking in menu
 
 ### Original Diablo bugs
+
 - Fix some monsters AC and to-hit values on Nightmare/Hell ending up as 0
 - Fix player base block resetting to 0 after loading a save game
 - Correctly render trees in front of the player
@@ -442,17 +533,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correctly align the inventory slots
 
 ## DevilutionX 1.0.3
+
 ### Bugfixes
+
 - Fix keyboard input in the menu
 
 ## DevilutionX 1.0.2
+
 ### Features
+
 - Support for integer scaling
 - Controller: Map Start + L1/R1 to char/inventory
 - Added `--save-dir` to allow for specifying the save game folder
 - Correctly scale the game on systems with a non-standard DPI setting
 
 ### Bugfixes
+
 - Some cave levels were generated with an incorrect layout
 - Firebolt mana cost is now correct
 - Allow players to join Nightmare/Hell games without first creating a game
@@ -463,7 +559,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix hanging for 20 sec on the error screen
 
 ## DevilutionX 1.0.1
+
 ### Features
+
 - Toggle fullscreen at any point by hitting alt+enter (mouse grab can be disabled in diablo.ini)
 - Controller: B button closes the currently active panel.
 - Added a navigation menu for controllers
@@ -472,6 +570,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a list of [known mods](https://github.com/diasurgical/devilutionX/blob/master/docs/mods.md)
 
 ### Platforms
+
 - Added support for 32bit PowerPc
 - Added support for Amiga
 - Added support Clockwork PI GameShell
@@ -480,6 +579,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update OpenDingux/RetroFW build root
 
 ### Bugfixes
+
 - Game crashing on systems that do not report monitor refresh rate.
 - Fixed belt not working correctly when holding shift on us keyboard layouts
 - Always keep track of the latest hero level when selecting difficulty.
@@ -491,11 +591,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a couple of typos in error messages
 
 ### Original Diablo bugs
+
 - Fix belt not working correctly when holding shift on *non-*us keyboard layouts
 - Fix one more rare crash.
 
 ## DevilutionX 1.0.0
+
 ### Features
+
 - FPS no longer capped at 20hz; smoother mouse and transitions
 - Full-featured gamepad support
 - All movies can now be skipped via ESC
@@ -509,12 +612,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Faster loading
 
 ### Platforms
+
 - Added Nintendo Switch support
 - Added Retro Gamer Handheld (OpenDingux/Retrofw) support
 - Added OpenBSD support
 - Windows version is now build as GUI an app and has an icon
 
 ### Bugfixes
+
 - Fixed random missing sounds
 - Fixed NPCs not talking about the right quest
 - Error messages implemented in GUI
@@ -525,12 +630,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed end movie not looping
 
 ### Original Diablo bugs
+
 - Fixed a large number of rare stability issues from the original game
 - Correctly take open panels into account when casting spells
 - Fix sound some times being muted after Diablo dies
 
 ## DevilutionX 0.5.0
+
 ### Features
+
 - Sound is now accurate to the original
 - All in-game issues fixed
 - Delete hero, inline dialogs and scrollbars are now implemented
@@ -544,11 +652,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - diabdat.mpq can now be loaded with read-only access
 
 ### Known issues
+
 - Error dialogs not implemented in main UI
 - The game must restart after hosting multiplayer
 
 ## [0.10.0](https://github.com/diasurgical/devilution/compare/0.9.6...0.10.0)
+
 ### June 22, 2019
+
 - [All functions are now binary identical](https://github.com/diasurgical/devilution/milestone/3) to the 1.09b version
 - Fix buying from Wirt
 - Replace many magic numbers with constants
@@ -556,13 +667,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add toggle fullscreen with alt+enter in debug builds
 
 ### June 21, 2019
+
 - All functions are now [binary identical](https://github.com/diasurgical/devilution/milestone/3) to Diablo 1.09b
 
 ### June 1, 2019
+
 - MVG posts [a video about the project](https://www.youtube.com/watch?v=5tADL_fmsHQ) and releases a Nintendo Switch port
 
 ## DevilutionX 0.4.0
+
 ### May 20, 2019
+
 - Fixed flickering mouse in caves
 - 32bit ARM build (Raspberry Pi)
 - 32bit FreeBSD build
@@ -575,48 +690,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Music and speech memory leaks fixed
 
 ## [0.9.6](https://github.com/diasurgical/devilution/compare/0.9.0...0.9.6)
+
 ### May 19, 2019
+
 - [96% of functions are now binary identical](https://github.com/diasurgical/devilution/milestone/3) to the 1.09b version
 - Fix several item corruption issues introduced in 0.9.0
 
 ## [0.9.0](https://github.com/diasurgical/devilution/compare/0.8.0...0.9.0)
+
 ### May 2, 2019
+
 - [90% of functions are now binary identical](https://github.com/diasurgical/devilution/milestone/3) to the 1.09b version
 - Mute buttons now work correctly
 
 ### April 15, 2019
+
 - Code is once again compiled as C++ as some parts appear to require despite the indications in Rich header
 
 ## [0.8.0](https://github.com/diasurgical/devilution/compare/0.7.0...0.8.0)
+
 ### April 12, 2019
+
 - [80% of functions are now binary identical](https://github.com/diasurgical/devilution/milestone/3) to the 1.09b version
 - Fixes a few minor issues with generated items
 
 ## [0.7.0](https://github.com/diasurgical/devilution/compare/0.6.0...0.7.0)
+
 ### April 9, 2019
+
 - [70% of functions are now binary identical](https://github.com/diasurgical/devilution/milestone/3) to the 1.09b version
 
 ### April 9, 2019
+
 - The last of the compiler flags are figured out
 
 ### March 22, 2019
+
 - Devilution appears on [Phoronix](https://www.phoronix.com/scan.php?page=news_item&px=DeviluitionX-Open-Diablo)
 
 ## DevilutionX 0.3.0
+
 ### March 20, 2019
+
 - Fix dialog volume
 - 32bit macOS build
 - Fix crash in town during multiplayer
 - Screenshot implemented
 
 ## [0.6.0](https://github.com/diasurgical/devilution/compare/v0.5.0...0.6.0)
+
 ### March 19, 2019
+
 - [60% of functions are now binary identical](https://github.com/diasurgical/devilution/milestone/3) to the 1.09b version
 - Added a guide for people wanting to join in [Cleaning the code](https://github.com/diasurgical/devilution/wiki/Cleaning-Code)
 - File size is now only 968 bytes (0.13%) larger than the original Diablo 1.09b.
 
 ## DevilutionX 0.2.0
+
 ### March 17, 2019
+
 - Fully implemented audio (all issues from 0.1.0 fixed)
 - Fully implemented multiplayer
 - Windows 32bit build
@@ -625,10 +757,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Most known crashes have been fixed
 
 ### March 7, 2019
+
 - [GOG re-release Diablo](https://www.gog.com/news/release_diablo)
 
 ## DevilutionX 0.1.0
+
 ### February 27, 2019
+
 - Linux 32bit build
 - Basic audio
 - Video playback
@@ -640,7 +775,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Encrypted network connection with password protection
 
 ## [0.5.0](https://github.com/diasurgical/devilution/compare/0.4...v0.5.0)
+
 ### January 14, 2019
+
 - [50% of functions are now binary identical](https://github.com/diasurgical/devilution/milestone/3) to the 1.09b version
 - [#456](https://github.com/diasurgical/devilution/pull/456) Assets can now be loaded directly form disk (no need for MPQ-files when modding)
 - [#528](https://github.com/diasurgical/devilution/pull/528) Code ported to C (can still be compiled as C++)
@@ -655,25 +792,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix a few issues, mostly relating to multiplayer
 
 ### November 17, 2018
+
 - An older and more original PSX symbol file is discovered
 
 ### October 1, 2018
+
 - Compiler version is confirmed to be correct by discovery of the [Rich header](https://bytepointer.com/articles/the_microsoft_rich_header.htm)
 
 ### September 18, 2018
+
 - Merge nightly back in to devilution
 
 ### September 3, 2018
+
 - Travis is configured to report the overall project delta to 1.09b on every change
 
 ### September 1, 2018
+
 - Devilution-comparer is developed for comparing binary diff in compiled functions
 
 ### August 28, 2018
+
 - The correct compiler combination is found by trial and error plus a bit of luck
 
 ## [0.4.0](https://github.com/diasurgical/devilution/compare/0.3...0.4)
+
 ### September 16, 2018
+
 - Fix crash
 - Get the first functions bin exact
 - Fix render issues
@@ -686,16 +831,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correct names based on PSX symbols and DX SDK
 
 ### August 20, 2018
+
 - Created nightly fork where code clean up can take place until major bugs are fixed in the main project
 
 ### July 6, 2018
+
 - Setup a Discord channel
 
 ### July 1, 2018
+
 - Diablo 1.09b is determined to have been compiled with the /O1 flag
 
 ## [0.3.0](https://github.com/diasurgical/devilution/compare/0.1.0...0.3)
+
 ### June 28, 2018
+
 - Windows binary can now be compiled under Linux and Mac OS X
 - Windows binary can now be compiled under VS 5.10
 - Fix multiple crashes
@@ -706,127 +856,158 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use consts for various values
 
 ### June 20, 2018
+
 - The [media](https://www.pcgamer.com/a-coder-spent-1200-hours-reverse-engineering-diablos-source-code/) catches wind and [several](https://bloody-disgusting.com/video-games/3505673/fan-completes-reverse-engineering-source-code-diablo/) [articles](https://kotaku.com/coder-spends-1-200-hours-piecing-together-diablos-sourc-1827001247) [appear](https://www.diabloii.net/blog/comments/reverse-engineered-diablo-source-code-released)
 
 ### June 18, 2018
+
 - Devilution gets posted on [Y Combinator](https://news.ycombinator.com/item?id=17338886)
 
 ## 0.1.0
+
 ### June 6, 2018
+
 - Devilution is unleashed upon the world! Version 0.1.0!
 
 ### June 3, 2018
+
 - Polishing things up for final release
 - Added a cheesy fake copyright notice to dissuade monetary gain
 - Properly integrated Storm and DiabloUI into the project
 
 ### May 28, 2018
+
 - Fixed bugs with save files
 - You can now load Devilution saves in the vanilla game
 
 ### May 25, 2018
+
 - Finally! Figured it out and now monsters spawn correctly
 - The game can be completed from start to finish with a few tricks
 
 ### May 21, 2018
+
 - Took a week break, begin working on monster code again
 - Nearly all quests work now
 - Fixed a bug with Adria
 
 ### May 8, 2018
+
 - Fix bugs with character drawing
 - Fix bugs relating to item affix generation
 - Towners no longer crash the game
 
 ### May 7, 2018
+
 - Port debugging functions from the debug release
 - Still can't figure out the zombie problem
 
 ### May 5, 2018
+
 - Begin fixing quest code and testing completion
 
 ### April 26, 2018
+
 - Zombies are spawning in all dungeon types... sigh
 
 ### April 20, 2018
+
 - Split code from IDA's C file into separate CPP files
 - All dungeon types can now be entered
 - Objects are now mostly working
 - Begin uncommenting monster code and fixing them
 
 ### April 11, 2018
+
 - Begin fixing up dungeon generation and objects
 
 ### April 4, 2018
+
 - Fixed many crashing bugs when in town and dungeon
 - Items, missiles, and spells are now drawn
 
 ### April 1, 2018
+
 - Finally fixed the render bug, everything draws correctly!
 - Character animation now draws correctly
 - The cathedral is now mostly working
 
 ### March 29, 2018
+
 - Fixed tons of bugs
 - You can now walk around in town
 - Entering the dungeon almost always crashes
 
 ### March 27, 2018
+
 - Uncommented and fixed lots of broken code
 - The game screen now appears, although very glitchy
 
 ### March 22, 2018
+
 - Control panel and inventory now work almost flawlessly
 
 ### March 21, 2018
+
 - Temporarily commented out tons of broken code
 - You can now get past the loading screen and into town
 - Music also works
 - Control panel mostly works but game screen is black
 
 ### March 18, 2018
+
 - The title screen now works
 - Freezes during the loading screen
 
 ### March 16, 2018
+
 - Fixed enough bugs that you can now launch binary
 - Crashes during title screen
 
 ### March 14, 2018
+
 - Fix remaining errors in code
 - Code now compiles and produces a non-working binary
 
 ### March 13, 2018 -- *!  SPECIAL DAY  !*
+
 - Dump the database to C code via IDA
 
 ### March 8, 2018
+
 - Correct various function signatures
 - Correct struct names and types
 - Plug in enumerates
 - Finish correcting and documenting data sections
 
 ### February 26, 2018
+
 - Finish documenting functions
 - Begin correcting names to match PSX
 
 ### February 18, 2018
+
 - Begin adding enumerates
 - Add more minor structs
 - Clean up data sections
 
 ### February 15, 2018
+
 - Almost finished adding every function
 - Begin working on major structs
 
 ### February 8, 2018
+
 - Add more functions
 - Begin adding data from Sanctuary project
 
 ### February 4, 2018
+
 - IDA disassembly begin
 - Start adding function names from [Sanctuary project](https://github.com/sanctuary/notes)
 
 ### January 15, 2018
+
 - The concept of Devilution is born
 - Research into Diablo's code and mechanics
 - Research from [Jarulf's guide](http://www.bigd-online.com/JG/JGFrame.html)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,6 +4,7 @@ This guide outlines useful resources, tools and processes for contribution to
 DevilutionX.
 
 ## C++ Standard
+
 Despite setting C++ standard to 20 in CMakeLists.txt, features from this version are not being used.
 The oldest compiler used is GCC 6.5 - and that defines our C++ feature set (meaning most of C++17).
 It's present only to take advantage of fmt::format build time errors.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,8 +1,10 @@
 ### Comments
+
 - `BUGFIX` known bugs in original (vanilla) code
 - `/* */` block comments are things to be fixed/checked
 - `FIX_ME` bad data
 
 Code issues (incorrect code that still works)
+
 - Critical sections should be constructors using `CCritSect`
 - Some functions/structures have incorrect signing (signed/unsigned BYTE)

--- a/docs/building.md
+++ b/docs/building.md
@@ -6,6 +6,7 @@ This is the version most appropriate for packaging DevilutionX for Linux distrib
 For other use cases, use the git repository.
 
 Note: If you do not use git or `devilutionx-src.tar.xz` to get the source you must provide the version to CMake manually:
+
 ```bash
 cmake -S. -Bbuild -DVERSION_NUM=1.0.0 -DVERSION_SUFFIX=FFFFFFF -DCMAKE_BUILD_TYPE=Release
 ```
@@ -15,26 +16,36 @@ cmake -S. -Bbuild -DVERSION_NUM=1.0.0 -DVERSION_SUFFIX=FFFFFFF -DCMAKE_BUILD_TYP
 Note that ```pkg-config``` is an optional dependency for finding libsodium, although we have a fallback if necessary.
 
 ### Installing dependencies on Debian and Ubuntu
+
 ```
 sudo apt-get install cmake g++ libsdl2-dev libsodium-dev libpng-dev libbz2-dev libgtest-dev libgmock-dev libsdl2-image-dev libfmt-dev
 ```
+
 ### If you want to build the translations (optional)
+
 ```
 sudo apt-get install gettext poedit
 ```
+
 ### If you want to build the devilutionX.mpq File (optional)
+
 ```
 sudo apt-get install smpq
 ```
+
 ### Installing dependencies on Fedora
+
 ```
 sudo dnf install cmake gcc-c++ glibc-devel libstdc++-static SDL2-devel libsodium-devel libpng-devel bzip2-devel gmock-devel gtest-devel libasan libubsan fmt-devel
 ```
+
 ### Compiling
+
 ```bash
 cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j $(getconf _NPROCESSORS_ONLN)
 ```
+
 </details>
 
 <details><summary>macOS</summary>
@@ -46,6 +57,7 @@ brew bundle install
 cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j $(sysctl -n hw.physicalcpu)
 ```
+
 </details>
 <details><summary>iOS</summary>
 
@@ -73,39 +85,51 @@ Then open the generated Xcode project and run things from there.
 <details><summary>FreeBSD</summary>
 
 ### Installing dependencies
+
 ```
 pkg install cmake sdl2 libsodium libpng bzip2 googletest
 ```
+
 ### Compiling
+
 ```bash
 cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j $(sysctl -n hw.ncpu)
 ```
+
 </details>
 <details><summary>NetBSD</summary>
 
 ### Installing dependencies
+
 ```
 pkgin install cmake SDL2 libsodium libpng bzip2 googletest
 ```
+
 ### Compiling
+
 ```bash
 cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j $(sysctl -n hw.ncpu)
 ```
+
 </details>
 
 <details><summary>OpenBSD</summary>
 
 ### Installing dependencies
+
 ```
 pkg_add cmake sdl2 libsodium libpng bzip2 gmake googletest
 ```
+
 ### Compiling
+
 ```bash
 cmake -S. -Bbuild -DCMAKE_MAKE_PROGRAM=gmake -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j $(sysctl -n hw.ncpuonline)
 ```
+
 </details>
 
 <details><summary>Windows via MinGW</summary>
@@ -127,6 +151,7 @@ Download the 64bit MinGW Development Libraries of [SDL2](https://www.libsdl.org/
 ```
 sudo apt-get install cmake gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 pkg-config-mingw-w64-x86-64 libz-mingw-w64-dev
 ```
+
 ### Compiling
 
 ### 32-bit
@@ -150,6 +175,7 @@ of the `(i686|x86_64)-w64-mingw32` directory.
 <details><summary>Windows via Visual Studio</summary>
 
 ### Installing dependencies
+
 Make sure to install the workload `Desktop development with C++` and the individual components `C++ CMake tools for Windows` and `Windows SDK` for Visual Studio.
 *Note: `Windows SDK` component should match your Windows build version.*
 
@@ -164,17 +190,20 @@ vcpkg integrate install
 If you need aditional instructions for vcpkg you can find the documentation [here](https://github.com/microsoft/vcpkg#quick-start-windows).
 
 ### If you want to build the devilutionX.mpq File (optional)
+
 In order to build devilutionx.mpq, install smpq from https://launchpad.net/smpq/trunk/1.6/+download/SMPQ-1.6-x86_64.exe.
 The location of this tool will need to be [added to the system's PATH environment variable](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/).
 
 ### Compiling
 
 * **Through Open->CMake in Visual Studio**
+
 1. Go to `File -> Open -> CMake`, select `CMakeLists.txt` from the project root.
 2. Select the `x64-Release` configuration (or `x86` for 32 bit builds, `-Debug` for debug builds).
 3. Select `Build devilution.exe` from the `Build` menu.
 
 * **Through GCC/WSL in Visual Studio**
+
 1. Ensure the WSL environment has the build pre-requisites for both devilutionX (see "Installing Dependencies on Debian and Ubuntu" under the "Linux" section above) and [WSL remote development](https://docs.microsoft.com/en-us/cpp/linux/connect-to-your-remote-linux-computer?view=msvc-160#connect-to-wsl).
 2. Select the `WSL-GCC-x64-Debug` configuration.
 3. Select `Build devilution` from the `Build` menu.
@@ -188,16 +217,19 @@ The location of this tool will need to be [added to the system's PATH environmen
 5. In case you need to select any paths to dependencies manually do this right in cmake-gui window.
 6. Press `Generate` and open produced `.sln` file using Visual Studio.
 7. Use build/debug etc. commands inside Visual Studio Solution like with any normal Visual Studio project.
+
 </details>
 
 <details><summary>Android</summary>
 
 ### Installing dependencies
+
 Install [Android Studio](https://developer.android.com/studio)
 After first launch configuration, go to "Configure -> SDK Manager -> SDK Tools".
 Select "NDK (Side by side)" and "CMake" checkboxes and click "OK".
 
 ### Compiling
+
 Click "Open Existing Project" and choose "android-project" folder in DevilutionX root folder.
 Wait until Gradle sync is completed.
 In Android Studio, go to "Build -> Make Project" or use the shortcut Ctrl+F9
@@ -210,27 +242,29 @@ You can find the compiled APK in `/android-project/app/build/outputs/apk/`
 
 https://devkitpro.org/wiki/Getting_Started
 
-
 - Install (dkp-)pacman: https://devkitpro.org/wiki/devkitPro_pacman
 
 - Install required packages with (dkp-)pacman:
+
 ```
 sudo (dkp-)pacman -S --needed - < Packaging/switch/packages.txt
 ```
 
 - Install smpq (if building from git or a source archive without devilutionx.mpq)
-DevilutionX requires some core assets to render UI elements and fonts even if game data is not available. While some
-platforms can load this from the filesystem as loose files the switch build currently only supports bundling the mpq
-archive inside the nro. If you're building DevilutionX on a supported platform a prebuilt binary may be available from
-your package distribution system (e.g. `sudo apt install smpq` or `yum install smpq`), on windows you can
-[download the latest version from Launchpad.net](https://launchpad.net/smpq/+download), and unix based OSes can build
-from source using [tools/build_and_install_smpq.sh](../tools/build_and_install_smpq.sh)
+  DevilutionX requires some core assets to render UI elements and fonts even if game data is not available. While some
+  platforms can load this from the filesystem as loose files the switch build currently only supports bundling the mpq
+  archive inside the nro. If you're building DevilutionX on a supported platform a prebuilt binary may be available from
+  your package distribution system (e.g. `sudo apt install smpq` or `yum install smpq`), on windows you can
+  [download the latest version from Launchpad.net](https://launchpad.net/smpq/+download), and unix based OSes can build
+  from source using [tools/build_and_install_smpq.sh](../tools/build_and_install_smpq.sh)
 
 ### Compiling
+
 ```bash
 cmake -S. -Bbuild -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/Switch.cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_ASSETS_MPQ=ON
 cmake --build build -j $(getconf _NPROCESSORS_ONLN)
 ```
+
 The nro-file will be generated in the build folder. Test with an emulator (RyuJinx) or real hardware.
 
 [Nintendo Switch manual](manual/platforms/switch.md)
@@ -242,20 +276,22 @@ The nro-file will be generated in the build folder. Test with an emulator (RyuJi
 
 https://devkitpro.org/wiki/Getting_Started
 
-
 - Install (dkp-)pacman: https://devkitpro.org/wiki/devkitPro_pacman
 
 - Install required packages with (dkp-)pacman:
+
 ```
 sudo (dkp-)pacman -S \
 		devkitARM general-tools 3dstools devkitpro-pkgbuild-helpers \
 		libctru citro3d 3ds-sdl 3ds-libpng \
 		3ds-cmake 3ds-pkg-config picasso 3dslink
 ```
+
 - Download or compile [bannertool](https://github.com/Steveice10/bannertool/releases) and [makerom](https://github.com/jakcron/Project_CTR/releases)
-  - Copy binaries to: `/opt/devkitpro/tools/bin/`
+    - Copy binaries to: `/opt/devkitpro/tools/bin/`
 
 ### Compiling
+
 _If you are compiling using MSYS2, you will need to run `export MSYS2_ARG_CONV_EXCL=-D` before compiling.
 Otherwise, MSYS will sanitize file paths in compiler flags which will likely lead to errors in the build._
 
@@ -263,6 +299,7 @@ Otherwise, MSYS will sanitize file paths in compiler flags which will likely lea
 cmake -S. -Bbuild -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/3DS.cmake -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j $(getconf _NPROCESSORS_ONLN)
 ```
+
 The output files will be generated in the build folder.
 
 [Nintendo 3DS manual](/docs/manual/platforms/3ds.md)
@@ -271,10 +308,12 @@ The output files will be generated in the build folder.
 <details><summary>PlayStation Vita</summary>
 
 ### Compiling
+
 ```bash
 cmake -S. -Bbuild -DCMAKE_TOOLCHAIN_FILE=${VITASDK}/share/vita.toolchain.cmake -DCMAKE_BUILD_TYPE=Release
 cmake --build build
 ```
+
 [PlayStation Vita manual](/docs/manual/platforms/vita.md)
 </details>
 
@@ -282,25 +321,34 @@ cmake --build build
 <details><summary>Haiku</summary>
 
 ### Installing dependencies on 32 bit Haiku
+
 ```
 pkgman install cmake_x86 devel:libsdl2_x86 devel:libsodium_x86 devel:libpng_x86 devel:bzip2_x86
 ```
+
 ### Installing dependencies on 64 bit Haiku
+
 ```
 pkgman install cmake devel:libsdl2 devel:libsodium devel:libpng devel:bzip2
 ```
+
 ### Compiling on 32 bit Haiku
+
 ```bash
 setarch x86 # Switch to secondary compiler toolchain (GCC8+)
 cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j $(getconf _NPROCESSORS_ONLN)
 ```
+
 ### Compiling on 64 bit Haiku
+
 No setarch required, as there is no secondary toolchain on x86_64, and the primary is GCC8+
+
 ```bash
 cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j $(getconf _NPROCESSORS_ONLN)
 ```
+
 </details>
 
 <details><summary>OpenDingux / RetroFW</summary>
@@ -338,9 +386,11 @@ End-user manuals are available here:
 <details><summary>Clockwork PI GameShell</summary>
 
 You can either call
+
 ~~~ bash
 Packaging/cpi-gamesh/build.sh
 ~~~
+
 to install dependencies and build the code.
 
 Or you create a new directory under `/home/cpi/apps/Menu` and copy [the file](Packaging/cpi-gamesh/__init__.py) there. After restarting the UI, you can download and compile the game directly from the device itself. See [the readme](Packaging/cpi-gamesh/readme.md) for more details.
@@ -391,6 +441,7 @@ To then run it:
 cd build-em
 emrun index.html
 ~~~
+
 </details>
 
 <details><summary>Xbox One/Series</summary>
@@ -411,11 +462,13 @@ _Note: Visual Studio Community Edition can be used._
 ### Building
 
 Add the following to the PATH:
+
 * CMake
 * GIT
 * VsDevCmd.bat
 
 Run:
+
 ```
 Packaging/xbox-one/build.bat
 ```
@@ -426,12 +479,14 @@ Packaging/xbox-one/build.bat
 <details><summary><b>CMake build options</b></summary>
 
 ### General
+
 - `-DCMAKE_BUILD_TYPE=Release` changed build type to release and optimize for distribution.
 - `-DNONET=ON` disable network support, this also removes the need for the ASIO and Sodium.
 - `-DUSE_SDL1=ON` build for SDL v1 instead of v2, not all features are supported under SDL v1, notably upscaling.
 - `-DCMAKE_TOOLCHAIN_FILE=../CMake/platforms/linux_i386.toolchain..cmake` generate 32bit builds on 64bit platforms (remember to use the `linux32` command if on Linux).
 
 ### Debug builds
+
 - `-DDEBUG=OFF` disable debug mode of the Diablo engine.
 - `-DASAN=OFF` disable address sanitizer.
 - `-DUBSAN=OFF` disable undefined behavior sanitizer.

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,6 +1,7 @@
 # Installing
 
 First, you will need access to the game's MPQ files.
+
 - Locate `DIABDAT.MPQ` on your CD, or in the [GoG](https://www.gog.com/game/diablo) installation (or [extract it from the GoG installer](https://github.com/diasurgical/devilutionX/wiki/Extracting-the-.MPQs-from-the-GoG-installer)).
 - For the Diablo: Hellfire expansion you will also need `hellfire.mpq`, `hfmonk.mpq`, `hfmusic.mpq`, `hfvoice.mpq`.
 - DevilutionX comes with [devilutionx.mpq](https://github.com/diasurgical/devilutionx-assets/releases/download/v2/devilutionx.mpq) which is required to run the game properly.
@@ -13,20 +14,21 @@ Download the latest [DevilutionX release](https://github.com/diasurgical/devilut
 <details><summary>Android</summary>
 
 First install the App via one of these 3 methods:
-  - [Google Play](https://play.google.com/store/apps/details?id=org.diasurgical.devilutionx)
-  - Copy the APK file to the device and tap on it in the device's file explorer and follow the instructions
-  - Install via `adb install` (if USB debugging is enabled on the device)
+
+- [Google Play](https://play.google.com/store/apps/details?id=org.diasurgical.devilutionx)
+- Copy the APK file to the device and tap on it in the device's file explorer and follow the instructions
+- Install via `adb install` (if USB debugging is enabled on the device)
 
 Then launch the App, this will let it create the folder where you need to place the MPQ files.
 
 Connect the device to your computer via USB cable, and allow data access from your device:
 
 ![image](https://user-images.githubusercontent.com/204594/139543023-3c45bb22-35f7-41af-8b3d-c714a9542d23.png)
-  
+
 Open the device's internal storage, and navigate to `Android/data/org.diasurgical.devilutionx/files`, then copy the MPQ-files to this folder.
 
 ![image](https://user-images.githubusercontent.com/204594/139542962-4e776854-6ca4-4872-8ed6-6303fc4bf040.png)
-  
+
 When the transfer is done you can disconnect your device and press "Check again" in the App to start the game.
 
 ![image](https://user-images.githubusercontent.com/204594/139541657-d8c1197d-fbef-42b6-a34f-2b17f1ceab5f.png)
@@ -44,8 +46,8 @@ When the transfer is done you can disconnect your device and press "Check again"
 
 - Copy the MPQ files to the folder containing the DevilutionX executable, or to the data folder. The data folder path may differ depending on distro, version, and security settings, but will normally be `~/.local/share/diasurgical/devilution/`
 - Install [SDL2](https://www.libsdl.org/download-2.0.php):
- - Ubuntu/Debian/Rasbian `sudo apt install libsdl2-2.0-0`
- - Fedora `sudo dnf install SDL2`
+- Ubuntu/Debian/Rasbian `sudo apt install libsdl2-2.0-0`
+- Fedora `sudo dnf install SDL2`
 - Run `./devilutionx`
 
 </details>
@@ -64,7 +66,7 @@ When the transfer is done you can disconnect your device and press "Check again"
 - To add the package, run one of these commands:
   `pkg install games/devilutionX` || `pkg install devilutionX`
 - Run `devilutionx`
-  
+
 </details>
 
 <details><summary>iOS & iPadOS</summary>
@@ -92,7 +94,7 @@ Method 2: Using Finder (MacOS)
 On more recent versions of MacOS, iTunes is no more. Instead you can use Finder to directly copy data to and from your iDevices
 
 - Connect your iDevice to your computer and click on the "Files" tab.
-  
+
   ![ios_mpq_finder01](https://user-images.githubusercontent.com/1339414/145089218-f5424196-f345-45da-aca6-9c2b2e06cdf0.png)
 
 - Drag and drop the MPQ files on the devilutionx directory
@@ -104,7 +106,7 @@ Method 3: Using iTunes (Windows and older MacOS)
 - Click on your device and in the files tab drag and drop the MPQ files to the devilutionx directory
 
 </details>
-  
+
 <details><summary>Nintendo Switch</summary>
 
 - Copy `devilutionx.nro` in into `/switch/devilutionx`
@@ -142,19 +144,20 @@ If you'd like to use this option, scan the QR code below.
 
 <details><summary>Playstation 4</summary>
 
- - Install devilutionx-ps4.pkg
- - Copy the MPQ files (e.g., using ftp) to `/user/data/diasurgical/devilution/`
- - Create the file `/user/data/diasurgical/devilution/diablo.ini` with the following contents:
-    ```
-    [Language]
-    Code=en
-    ```
+- Install devilutionx-ps4.pkg
+- Copy the MPQ files (e.g., using ftp) to `/user/data/diasurgical/devilution/`
+- Create the file `/user/data/diasurgical/devilution/diablo.ini` with the following contents:
+   ```
+   [Language]
+   Code=en
+   ```
+
 </details>
 
 <details><summary>Playstation Vita</summary>
 
- - Install devilutionx.vpk
- - Copy the MPQ files to `ux0:/data/diasurgical/devilution/`.
+- Install devilutionx.vpk
+- Copy the MPQ files to `ux0:/data/diasurgical/devilution/`.
 
 </details>
 
@@ -192,8 +195,7 @@ If you'd like to use this option, scan the QR code below.
 
 - Copy [devilutionx-rg350.opk](https://github.com/diasurgical/devilutionX/releases/latest/download/devilutionx-rg350.opk) to `/media/sdcard/APPS/`.
 - Copy the MPQ files to `/media/home/.local/share/diasurgical/devilution/`
--
- **NOTE:** You can copy the MPQ files to sdcard instead and create a symlink at the expected location. To do this, SSH into your RG350 and run:
+- **NOTE:** You can copy the MPQ files to sdcard instead and create a symlink at the expected location. To do this, SSH into your RG350 and run:
 
  ~~~bash
  ln -sf /media/sdcard/<path_to_MPQ> /media/home/.local/share/diasurgical/devilution/<MPQ>

--- a/docs/profiling-linux.md
+++ b/docs/profiling-linux.md
@@ -52,4 +52,5 @@ google-pprof --web build-gperf/devilutionx main.0001.heap
 See [gperftools heap profiling documentation] for more information.
 
 [gperftools]: https://github.com/gperftools/gperftools/wiki
+
 [gperftools heap profiling documentation]: https://gperftools.github.io/gperftools/heapprofile.html

--- a/doxygen.config
+++ b/doxygen.config
@@ -1,6 +1,6 @@
 PROJECT_NAME           = "Devilution"
 PROJECT_BRIEF          = "Diablo devolved - magic behind the 1996 computer game"
-USE_MDFILE_AS_MAINPAGE = README.md
+USE_MDFILE_AS_MAINPAGE = ./README.md
 OUTPUT_DIRECTORY       = docs
 INPUT                  = ./ ./Source ./docs
 INPUT_ENCODING         = UTF-8
@@ -16,7 +16,6 @@ EXCLUDE                = ./build ./3rdParty ./CMake ./cmake-build-debug
 GENERATE_LATEX         = NO
 WARNINGS               = YES
 SOURCE_BROWSER         = YES
-EXTRACT_STATIC         = YES
 JAVADOC_AUTOBRIEF      = YES
 OPTIMIZE_OUTPUT_FOR_C  = YES
 SEPARATE_MEMBER_PAGES  = YES


### PR DESCRIPTION
This fixes 200+ Doxygen warnings. There is only one left:

```
Generating docs for README.md:38: warning: unable to resolve reference to 'building-from-source' for \ref command
```

That's because Doxygen and GitHub are using different flavours of Markdown, so it can't be solved.