### PR TITLE
Remove unnecessary assert

### DIFF
--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -140,8 +140,6 @@ constexpr int MaxCrawlRadius = 18;
 template <typename F>
 auto Crawl(unsigned radius, F function) -> invoke_result_t<decltype(function), Displacement>
 {
-	assert(radius <= MaxCrawlRadius);
-
 	if (radius == 0)
 		return function(Displacement { 0, 0 });
 


### PR DESCRIPTION
Fixes #4910 

To be strictly equivalent to vanilla behaviour we need to check the corner tiles of a radius 19 search area. This isn't really critical to any behaviour though so in the initial implementation I let FindClosestValidPosition continue to pretty much the entire dungeon area to ensure we at least cover the same search space eventually. Crawl can do the same thing, using larger radiuses is perfectly acceptable.