### PR TITLE
:recycle: Refactor M_WalkDir

### DIFF
--- a/Source/monster.h
+++ b/Source/monster.h
@@ -327,7 +327,7 @@ void M_SyncStartKill(int monsterId, Point position, int pnum);
 void M_UpdateLeader(int monsterId);
 void DoEnding();
 void PrepDoEnding();
-void M_WalkDir(Monster &monster, Direction md);
+bool Walk(Monster &monster, Direction md);
 void GolumAi(int monsterId);
 void DeleteMonsterList();
 void ProcessMonsters();

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -182,7 +182,7 @@ void SyncMonster(bool isOwner, const TSyncMonster &monsterSync)
 			if (DirOK(monsterId, md)) {
 				M_ClearSquares(monster);
 				dMonster[monster.position.tile.x][monster.position.tile.y] = monsterId + 1;
-				M_WalkDir(monster, md);
+				Walk(monster, md);
 				monster.activeForTicks = UINT8_MAX;
 			}
 		}


### PR DESCRIPTION
- :fire: Removed DumbWalk
- :truck: Renames M_WalkDir to Walk

This integrates the DirOK check into M_WalkDir itself, that makes the DumbWalk function useless and most places that were calling DirOK before M_WalkDir can now be simplified.