### PR TITLE
Make zoom a setting in the menu

### DIFF
--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -302,7 +302,7 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, Game
 			case ControllerButton_BUTTON_Y: // Top button
 #ifdef __3DS__
 				if (!ctrlEvent.up) {
-					zoomflag = !zoomflag;
+					sgOptions.Graphics.zoom.SetValue(!*sgOptions.Graphics.zoom);
 					CalcViewportGeometry();
 				}
 #else

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -20,6 +20,7 @@
 #include "inv.h"
 #include "levels/trigs.h"
 #include "missiles.h"
+#include "options.h"
 #include "qol/itemlabels.h"
 #include "qol/stash.h"
 #include "towners.h"
@@ -269,7 +270,7 @@ void CheckCursMove()
 		sy = mainPanel.position.y - 1;
 	}
 
-	if (!zoomflag) {
+	if (*sgOptions.Graphics.zoom) {
 		sx /= 2;
 		sy /= 2;
 	}
@@ -316,7 +317,7 @@ void CheckCursMove()
 		my++;
 	}
 
-	if (!zoomflag) {
+	if (*sgOptions.Graphics.zoom) {
 		sy -= TILE_HEIGHT / 4;
 	}
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -95,7 +95,6 @@ Point MousePosition;
 bool gbRunGame;
 bool gbRunGameResult;
 bool ReturnToMainMenu;
-bool zoomflag;
 /** Enable updating of player character, set to false once Diablo dies */
 bool gbProcessPlayers;
 bool gbLoadGame;
@@ -147,7 +146,6 @@ bool was_ui_init = false;
 
 void StartGame(interface_mode uMsg)
 {
-	zoomflag = true;
 	CalcViewportGeometry();
 	cineflag = false;
 	InitCursor();
@@ -1628,7 +1626,7 @@ void InitKeymapActions()
 	    N_("Zoom Game Screen."),
 	    'Z',
 	    [] {
-		    zoomflag = !zoomflag;
+		    sgOptions.Graphics.zoom.SetValue(!*sgOptions.Graphics.zoom);
 		    CalcViewportGeometry();
 	    },
 	    nullptr,

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -63,7 +63,6 @@ extern Point MousePosition;
 extern bool gbRunGame;
 extern bool gbRunGameResult;
 extern bool ReturnToMainMenu;
-extern DVL_API_FOR_TEST bool zoomflag;
 extern bool gbProcessPlayers;
 extern bool gbLoadGame;
 extern bool cineflag;

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -30,6 +30,7 @@
 #include "minitext.h"
 #include "missiles.h"
 #include "nthread.h"
+#include "options.h"
 #include "panels/charpanel.hpp"
 #include "plrmsg.h"
 #include "qol/chatlog.h"
@@ -1070,7 +1071,7 @@ int tileRows;
 void DrawGame(const Surface &fullOut, Point position)
 {
 	// Limit rendering to the view area
-	const Surface &out = zoomflag
+	const Surface &out = !*sgOptions.Graphics.zoom
 	    ? fullOut.subregionY(0, gnViewportHeight)
 	    : fullOut.subregionY(0, (gnViewportHeight + 1) / 2);
 
@@ -1089,7 +1090,7 @@ void DrawGame(const Surface &fullOut, Point position)
 
 	// Skip rendering parts covered by the panels
 	if (CanPanelsCoverView()) {
-		if (zoomflag) {
+		if (!*sgOptions.Graphics.zoom) {
 			if (IsLeftPanelOpen()) {
 				position += Displacement(Direction::East) * 2;
 				columns -= 4;
@@ -1164,7 +1165,7 @@ void DrawGame(const Surface &fullOut, Point position)
 	DrawFloor(out, position, { sx, sy }, rows, columns);
 	DrawTileContent(out, position, { sx, sy }, rows, columns);
 
-	if (!zoomflag) {
+	if (*sgOptions.Graphics.zoom) {
 		Zoom(fullOut.subregionY(0, gnViewportHeight));
 	}
 }
@@ -1198,11 +1199,11 @@ void DrawView(const Surface &out, Point startPosition)
 			Point pixelCoords = m.second;
 			if (megaTiles)
 				pixelCoords += Displacement { 0, TILE_HEIGHT / 2 };
-			if (!zoomflag)
+			if (*sgOptions.Graphics.zoom)
 				pixelCoords *= 2;
 			if (debugGridTextNeeded && GetDebugGridText(dunCoords, debugGridTextBuffer)) {
 				Size tileSize = { TILE_WIDTH, TILE_HEIGHT };
-				if (!zoomflag)
+				if (*sgOptions.Graphics.zoom)
 					tileSize *= 2;
 				DrawString(out, debugGridTextBuffer, { pixelCoords - Displacement { 0, tileSize.height }, tileSize }, UiFlags::ColorRed | UiFlags::AlignCenter | UiFlags::VerticalCenter);
 			}
@@ -1228,7 +1229,7 @@ void DrawView(const Surface &out, Point startPosition)
 
 				Displacement hor = { TILE_WIDTH / 2, 0 };
 				Displacement ver = { 0, TILE_HEIGHT / 2 };
-				if (!zoomflag) {
+				if (*sgOptions.Graphics.zoom) {
 					hor *= 2;
 					ver *= 2;
 				}
@@ -1448,7 +1449,7 @@ int RowsCoveredByPanel()
 	}
 
 	int rows = mainPanelSize.height / TILE_HEIGHT;
-	if (!zoomflag) {
+	if (*sgOptions.Graphics.zoom) {
 		rows /= 2;
 	}
 
@@ -1463,7 +1464,7 @@ void CalcTileOffset(int *offsetX, int *offsetY)
 	int x;
 	int y;
 
-	if (zoomflag) {
+	if (!*sgOptions.Graphics.zoom) {
 		x = screenWidth % TILE_WIDTH;
 		y = viewportHeight % TILE_HEIGHT;
 	} else {
@@ -1494,7 +1495,7 @@ void TilesInView(int *rcolumns, int *rrows)
 		rows++;
 	}
 
-	if (!zoomflag) {
+	if (*sgOptions.Graphics.zoom) {
 		// Half the number of tiles, rounded up
 		if ((columns & 1) != 0) {
 			columns++;
@@ -1545,7 +1546,7 @@ void CalcViewportGeometry()
 	}
 
 	// Slightly lower the zoomed view
-	if (!zoomflag) {
+	if (*sgOptions.Graphics.zoom) {
 		tileOffset.deltaY += TILE_HEIGHT / 4;
 		if (yo < TILE_HEIGHT / 4)
 			tileRows++;

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -899,6 +899,7 @@ GraphicsOptions::GraphicsOptions()
     , vSync("Vertical Sync", OptionEntryFlags::RecreateUI, N_("Vertical Sync"), N_("Forces waiting for Vertical Sync. Prevents tearing effect when drawing a frame. Disabling it can help with mouse lag on some systems."), true)
 #endif
     , gammaCorrection("Gamma Correction", OptionEntryFlags::Invisible, "Gamma Correction", "Gamma correction level.", 100)
+    , zoom("Zoom", OptionEntryFlags::None, N_("Zoom"), N_("Zoom on when enabled."), false)
     , colorCycling("Color Cycling", OptionEntryFlags::None, N_("Color Cycling"), N_("Color cycling effect used for water, lava, and acid animation."), true)
     , alternateNestArt("Alternate nest art", OptionEntryFlags::OnlyHellfire | OptionEntryFlags::CantChangeInGame, N_("Alternate nest art"), N_("The game will use an alternative palette for Hellfire’s nest tileset."), false)
 #if SDL_VERSION_ATLEAST(2, 0, 0)
@@ -942,6 +943,7 @@ std::vector<OptionEntryBase *> GraphicsOptions::GetEntries()
 		&vSync,
 #endif
 		&gammaCorrection,
+		&zoom,
 		&limitFPS,
 		&showFPS,
 		&showHealthValues,

--- a/Source/options.h
+++ b/Source/options.h
@@ -474,6 +474,8 @@ struct GraphicsOptions : OptionCategoryBase {
 #endif
 	/** @brief Gamma correction level. */
 	OptionEntryInt<int> gammaCorrection;
+	/** @brief Zoom on start. */
+	OptionEntryBoolean zoom;
 	/** @brief Enable color cycling animations. */
 	OptionEntryBoolean colorCycling;
 	/** @brief Use alternate nest palette. */

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -283,7 +283,7 @@ void ScrollViewPort(const Player &player, ScrollDirection dir)
 {
 	ScrollInfo.tile = Point { 0, 0 } + (player.position.tile - ViewPosition);
 
-	if (zoomflag) {
+	if (!*sgOptions.Graphics.zoom) {
 		if (abs(ScrollInfo.tile.x) >= 3 || abs(ScrollInfo.tile.y) >= 3) {
 			ScrollInfo._sdir = ScrollDirection::None;
 		} else {

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -86,7 +86,7 @@ void AddItemToLabelQueue(int id, int x, int y)
 
 	x += *labelCenterOffsets[index];
 	y -= TILE_HEIGHT;
-	if (!zoomflag) {
+	if (*sgOptions.Graphics.zoom) {
 		x *= 2;
 		y *= 2;
 	}

--- a/test/scrollrt_test.cpp
+++ b/test/scrollrt_test.cpp
@@ -3,6 +3,7 @@
 #include "control.h"
 #include "diablo.h"
 #include "engine/render/scrollrt.h"
+#include "options.h"
 #include "utils/ui_fwd.h"
 
 using namespace devilution;
@@ -14,7 +15,7 @@ TEST(Scroll_rt, calc_tiles_in_view_original)
 	gnScreenWidth = 640;
 	gnScreenHeight = 480;
 	gnViewportHeight = gnScreenHeight - 128;
-	zoomflag = true;
+	sgOptions.Graphics.zoom.SetValue(false);
 	int columns = 0;
 	int rows = 0;
 	TilesInView(&columns, &rows);
@@ -27,7 +28,7 @@ TEST(Scroll_rt, calc_tiles_in_view_original_zoom)
 	gnScreenWidth = 640;
 	gnScreenHeight = 480;
 	gnViewportHeight = gnScreenHeight - 128;
-	zoomflag = false;
+	sgOptions.Graphics.zoom.SetValue(true);
 	int columns = 0;
 	int rows = 0;
 	TilesInView(&columns, &rows);
@@ -40,7 +41,7 @@ TEST(Scroll_rt, calc_tiles_in_view_960_540)
 	gnScreenWidth = 960;
 	gnScreenHeight = 540;
 	gnViewportHeight = gnScreenHeight;
-	zoomflag = true;
+	sgOptions.Graphics.zoom.SetValue(false);
 	int columns = 0;
 	int rows = 0;
 	TilesInView(&columns, &rows);
@@ -53,7 +54,7 @@ TEST(Scroll_rt, calc_tiles_in_view_640_512)
 	gnScreenWidth = 640;
 	gnScreenHeight = 512;
 	gnViewportHeight = gnScreenHeight - 128;
-	zoomflag = true;
+	sgOptions.Graphics.zoom.SetValue(false);
 	int columns = 0;
 	int rows = 0;
 	TilesInView(&columns, &rows);
@@ -66,7 +67,7 @@ TEST(Scroll_rt, calc_tiles_in_view_768_480_zoom)
 	gnScreenWidth = 768;
 	gnScreenHeight = 480;
 	gnViewportHeight = gnScreenHeight;
-	zoomflag = false;
+	sgOptions.Graphics.zoom.SetValue(true);
 	int columns = 0;
 	int rows = 0;
 	TilesInView(&columns, &rows);
@@ -81,7 +82,7 @@ TEST(Scroll_rt, calc_tile_offset_original)
 	gnScreenWidth = 640;
 	gnScreenHeight = 480;
 	gnViewportHeight = gnScreenHeight - 128;
-	zoomflag = true;
+	sgOptions.Graphics.zoom.SetValue(false);
 	int x = 0;
 	int y = 0;
 	CalcTileOffset(&x, &y);
@@ -94,7 +95,7 @@ TEST(Scroll_rt, calc_tile_offset_original_zoom)
 	gnScreenWidth = 640;
 	gnScreenHeight = 480;
 	gnViewportHeight = gnScreenHeight - 128;
-	zoomflag = false;
+	sgOptions.Graphics.zoom.SetValue(true);
 	int x = 0;
 	int y = 0;
 	CalcTileOffset(&x, &y);
@@ -107,7 +108,7 @@ TEST(Scroll_rt, calc_tile_offset_960_540)
 	gnScreenWidth = 960;
 	gnScreenHeight = 540;
 	gnViewportHeight = gnScreenHeight;
-	zoomflag = true;
+	sgOptions.Graphics.zoom.SetValue(false);
 	int x = 0;
 	int y = 0;
 	CalcTileOffset(&x, &y);
@@ -120,7 +121,7 @@ TEST(Scroll_rt, calc_tile_offset_853_480)
 	gnScreenWidth = 853;
 	gnScreenHeight = 480;
 	gnViewportHeight = gnScreenHeight;
-	zoomflag = true;
+	sgOptions.Graphics.zoom.SetValue(false);
 	int x = 0;
 	int y = 0;
 	CalcTileOffset(&x, &y);
@@ -133,7 +134,7 @@ TEST(Scroll_rt, calc_tile_offset_768_480_zoom)
 	gnScreenWidth = 768;
 	gnScreenHeight = 480;
 	gnViewportHeight = gnScreenHeight;
-	zoomflag = false;
+	sgOptions.Graphics.zoom.SetValue(true);
 	int x = 0;
 	int y = 0;
 	CalcTileOffset(&x, &y);
@@ -146,7 +147,7 @@ TEST(Scroll_rt, calc_tile_offset_768_480_zoom)
 TEST(Scroll_rt, calc_tiles_covered_by_panel_original)
 {
 	gnScreenWidth = 640;
-	zoomflag = true;
+	sgOptions.Graphics.zoom.SetValue(false);
 	CalculatePanelAreas();
 	EXPECT_EQ(RowsCoveredByPanel(), 0);
 }
@@ -154,7 +155,7 @@ TEST(Scroll_rt, calc_tiles_covered_by_panel_original)
 TEST(Scroll_rt, calc_tiles_covered_by_panel_960)
 {
 	gnScreenWidth = 960;
-	zoomflag = true;
+	sgOptions.Graphics.zoom.SetValue(false);
 	CalculatePanelAreas();
 	EXPECT_EQ(RowsCoveredByPanel(), 4);
 }
@@ -162,7 +163,7 @@ TEST(Scroll_rt, calc_tiles_covered_by_panel_960)
 TEST(Scroll_rt, calc_tiles_covered_by_panel_960_zoom)
 {
 	gnScreenWidth = 960;
-	zoomflag = false;
+	sgOptions.Graphics.zoom.SetValue(true);
 	CalculatePanelAreas();
 	EXPECT_EQ(RowsCoveredByPanel(), 2);
 }


### PR DESCRIPTION
Replaces #4432 

This makes zoom a toggle in the menu and does it like #4509 did for the item labels. 

Also I flipped all the zoom flags to make the toggle be true for zoomed and false for not.