### PR TITLE
Include leftover coinflips following conflict resolution

### DIFF
--- a/Source/levels/drlg_l4.cpp
+++ b/Source/levels/drlg_l4.cpp
@@ -274,7 +274,7 @@ void FirstRoom()
 	}
 
 	MapRoom(room);
-	GenerateRoom(room, GenerateRnd(2));
+	GenerateRoom(room, !FlipCoin());
 }
 
 void MakeDungeon()

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1300,7 +1300,7 @@ void DamageArmor(Player &player)
 		return;
 	}
 
-	bool targetHead = GenerateRnd(3);
+	bool targetHead = FlipCoin(3);
 	if (!player.InvBody[INVLOC_CHEST].isEmpty() && player.InvBody[INVLOC_HEAD].isEmpty()) {
 		targetHead = false;
 	}


### PR DESCRIPTION
One I missed and one introduced/moved in one of the GenerateRoom refactors.

targetHead is not negated as I flipped the cases in #4913 but somehow lost the actual change to the function...