### PR TITLE
Use absolute coordinates for temp position when north-walking

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -431,10 +431,18 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	player._pFireResist = file.NextLE<int8_t>();
 	player._pLghtResist = file.NextLE<int8_t>();
 	player._pGold = file.NextLE<int32_t>();
-
 	player._pInfraFlag = file.NextBool32();
-	player.position.temp.x = file.NextLE<int32_t>();
-	player.position.temp.y = file.NextLE<int32_t>();
+
+	int32_t tempPositionX = file.NextLE<int32_t>();
+	int32_t tempPositionY = file.NextLE<int32_t>();
+	if (player._pmode == PM_WALK_NORTHWARDS) {
+		// These values are saved as offsets to remain consistent with old savefiles
+		tempPositionX += player.position.tile.x;
+		tempPositionY += player.position.tile.y;
+	}
+	player.position.temp.x = static_cast<WorldTileCoord>(tempPositionX);
+	player.position.temp.y = static_cast<WorldTileCoord>(tempPositionY);
+
 	player.tempDirection = static_cast<Direction>(file.NextLE<int32_t>());
 	player.spellLevel = file.NextLE<int32_t>();
 	file.Skip<uint32_t>(); // skip _pVar5, was used for storing position of a tile which should have its HorizontalMovingPlayer flag removed after walking
@@ -1191,10 +1199,18 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.WriteLE<int8_t>(player._pFireResist);
 	file.WriteLE<int8_t>(player._pLghtResist);
 	file.WriteLE<int32_t>(player._pGold);
-
 	file.WriteLE<uint32_t>(player._pInfraFlag ? 1 : 0);
-	file.WriteLE<int32_t>(player.position.temp.x);
-	file.WriteLE<int32_t>(player.position.temp.y);
+
+	int32_t tempPositionX = player.position.temp.x;
+	int32_t tempPositionY = player.position.temp.y;
+	if (player._pmode == PM_WALK_NORTHWARDS) {
+		// For backwards compatibility, save this as an offset
+		tempPositionX -= player.position.tile.x;
+		tempPositionY -= player.position.tile.y;
+	}
+	file.WriteLE<int32_t>(tempPositionX);
+	file.WriteLE<int32_t>(tempPositionY);
+
 	file.WriteLE<int32_t>(static_cast<int32_t>(player.tempDirection));
 	file.WriteLE<int32_t>(player.spellLevel);
 	file.Skip<int32_t>(); // skip _pVar5, was used for storing position of a tile which should have its HorizontalMovingPlayer flag removed after walking

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -225,7 +225,7 @@ void WalkNorthwards(int pnum, const DirectionSettings &walkParams)
 {
 	Player &player = Players[pnum];
 	dPlayer[player.position.future.x][player.position.future.y] = -(pnum + 1);
-	player.position.temp = WorldTilePosition { static_cast<WorldTileCoord>(walkParams.tileAdd.deltaX), static_cast<WorldTileCoord>(walkParams.tileAdd.deltaY) };
+	player.position.temp = player.position.tile + walkParams.tileAdd;
 }
 
 void WalkSouthwards(int pnum, const DirectionSettings & /*walkParams*/)
@@ -669,7 +669,7 @@ bool DoWalk(int pnum, int variant)
 		switch (variant) {
 		case PM_WALK_NORTHWARDS:
 			dPlayer[player.position.tile.x][player.position.tile.y] = 0;
-			player.position.tile += { player.position.temp.x, player.position.temp.y };
+			player.position.tile = player.position.temp;
 			dPlayer[player.position.tile.x][player.position.tile.y] = pnum + 1;
 			break;
 		case PM_WALK_SOUTHWARDS:


### PR DESCRIPTION
This resolves an issue where position desync when walking north would cause the player's position to warp out of bounds, leading to disconnects in multiplayer games. This also fixes some errors in loadsave.cpp related to the type change from `Point` to `PointOf<WorldTileCoord>`.