### PR TITLE
Take player by references

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1141,10 +1141,10 @@ void DrawTalkPan(const Surface &out)
 	x += 46;
 	int talkBtn = 0;
 	for (int i = 0; i < 4; i++) {
-		if (i == MyPlayerId)
+		Player &player = Players[i];
+		if (&player == MyPlayer)
 			continue;
 
-		Player &player = Players[i];
 		UiFlags color = player.friendlyMode ? UiFlags::ColorWhitegold : UiFlags::ColorRed;
 		const Point talkPanPosition = mainPanelPosition + Displacement { 172, 84 + 18 * talkBtn };
 		if (WhisperList[i]) {

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -370,9 +370,9 @@ void CheckPlayerNearby()
 		return;
 
 	for (int i = 0; i < MAX_PLRS; i++) {
-		if (i == MyPlayerId)
-			continue;
 		const Player &player = Players[i];
+		if (&player == MyPlayer)
+			continue;
 		const int mx = player.position.future.x;
 		const int my = player.position.future.y;
 		if (dPlayer[mx][my] == 0

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -540,14 +540,16 @@ void CheckCursMove()
 	if (pcursmonst == -1) {
 		if (!flipflag && mx + 1 < MAXDUNX && dPlayer[mx + 1][my] != 0) {
 			int8_t bv = abs(dPlayer[mx + 1][my]) - 1;
-			if (bv != MyPlayerId && Players[bv]._pHitPoints != 0) {
+			Player &player = Players[bv];
+			if (&player != MyPlayer && player._pHitPoints != 0) {
 				cursPosition = Point { mx, my } + Displacement { 1, 0 };
 				pcursplr = bv;
 			}
 		}
 		if (flipflag && my + 1 < MAXDUNY && dPlayer[mx][my + 1] != 0) {
 			int8_t bv = abs(dPlayer[mx][my + 1]) - 1;
-			if (bv != MyPlayerId && Players[bv]._pHitPoints != 0) {
+			Player &player = Players[bv];
+			if (&player != MyPlayer && player._pHitPoints != 0) {
 				cursPosition = Point { mx, my } + Displacement { 0, 1 };
 				pcursplr = bv;
 			}
@@ -561,7 +563,8 @@ void CheckCursMove()
 		}
 		if (TileContainsDeadPlayer({ mx, my })) {
 			for (int i = 0; i < MAX_PLRS; i++) {
-				if (Players[i].position.tile == Point { mx, my } && i != MyPlayerId) {
+				const Player &player = Players[i];
+				if (player.position.tile == Point { mx, my } && &player != MyPlayer) {
 					cursPosition = { mx, my };
 					pcursplr = i;
 				}
@@ -572,7 +575,8 @@ void CheckCursMove()
 				for (int yy = -1; yy < 2; yy++) {
 					if (TileContainsDeadPlayer({ mx + xx, my + yy })) {
 						for (int i = 0; i < MAX_PLRS; i++) {
-							if (Players[i].position.tile.x == mx + xx && Players[i].position.tile.y == my + yy && i != MyPlayerId) {
+							const Player &player = Players[i];
+							if (player.position.tile.x == mx + xx && player.position.tile.y == my + yy && &player != MyPlayer) {
 								cursPosition = Point { mx, my } + Displacement { xx, yy };
 								pcursplr = i;
 							}
@@ -583,7 +587,8 @@ void CheckCursMove()
 		}
 		if (mx + 1 < MAXDUNX && my + 1 < MAXDUNY && dPlayer[mx + 1][my + 1] != 0) {
 			int8_t bv = abs(dPlayer[mx + 1][my + 1]) - 1;
-			if (bv != MyPlayerId && Players[bv]._pHitPoints != 0) {
+			const Player &player = Players[bv];
+			if (&player != MyPlayer && player._pHitPoints != 0) {
 				cursPosition = Point { mx, my } + Displacement { 1, 1 };
 				pcursplr = bv;
 			}

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -569,7 +569,7 @@ std::string DebugCmdChangeHealth(const string_view parameter)
 	int newHealth = myPlayer._pHitPoints + (change * 64);
 	SetPlayerHitPoints(myPlayer, newHealth);
 	if (newHealth <= 0)
-		SyncPlrKill(MyPlayerId, 0);
+		SyncPlrKill(myPlayer, 0);
 
 	return "Health has changed.";
 }

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2171,9 +2171,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 		IncProgress();
 
 		bool visited = false;
-		int players = gbIsMultiplayer ? MAX_PLRS : 1;
-		for (int i = 0; i < players; i++) {
-			Player &player = Players[i];
+		for (const Player &player : Players) {
 			if (player.plractive)
 				visited = visited || player._pLvlVisited[currlevel];
 		}
@@ -2288,7 +2286,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 
 	for (int i = 0; i < MAX_PLRS; i++) {
 		Player &player = Players[i];
-		if (player.plractive && player.isOnActiveLevel() && (!player._pLvlChanging || i == MyPlayerId)) {
+		if (player.plractive && player.isOnActiveLevel() && (!player._pLvlChanging || &player == MyPlayer)) {
 			if (player._pHitPoints > 0) {
 				if (!gbIsMultiplayer)
 					dPlayer[player.position.tile.x][player.position.tile.y] = i + 1;

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -578,8 +578,7 @@ void DrawDeadPlayer(const Surface &out, Point tilePosition, Point targetBufferPo
 {
 	dFlags[tilePosition.x][tilePosition.y] &= ~DungeonFlag::DeadPlayer;
 
-	for (int i = 0; i < MAX_PLRS; i++) {
-		Player &player = Players[i];
+	for (Player &player : Players) {
 		if (player.plractive && player._pHitPoints == 0 && player.isOnActiveLevel() && player.position.tile == tilePosition) {
 			dFlags[tilePosition.x][tilePosition.y] |= DungeonFlag::DeadPlayer;
 			const Point playerRenderPosition { targetBufferPosition + player.position.offset };

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1953,7 +1953,7 @@ bool UseInvItem(int pnum, int cii)
 {
 	Player &player = Players[pnum];
 
-	if (player._pInvincible && player._pHitPoints == 0 && pnum == MyPlayerId)
+	if (player._pInvincible && player._pHitPoints == 0 && &player == MyPlayer)
 		return true;
 	if (pcurs != CURSOR_HAND)
 		return true;
@@ -2054,7 +2054,7 @@ bool UseInvItem(int pnum, int cii)
 	int idata = ItemCAnimTbl[item->_iCurs];
 	if (item->_iMiscId == IMISC_BOOK)
 		PlaySFX(IS_RBOOK);
-	else if (pnum == MyPlayerId)
+	else if (&player == MyPlayer)
 		PlaySFX(ItemInvSnds[idata]);
 
 	UseItem(pnum, item->_iMiscId, item->_iSpell);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1960,12 +1960,10 @@ int RndPremiumItem(int minlvl, int maxlvl)
 	return RndVendorItem<PremiumItemOk>(minlvl, maxlvl);
 }
 
-void SpawnOnePremium(Item &premiumItem, int plvl, int playerId)
+void SpawnOnePremium(Item &premiumItem, int plvl, Player &player)
 {
 	int itemValue = 0;
 	bool keepGoing = false;
-
-	Player &player = Players[playerId];
 
 	int strength = std::max(player.GetMaximumAttributeValue(CharacterAttribute::Strength), player._pStrength);
 	int dexterity = std::max(player.GetMaximumAttributeValue(CharacterAttribute::Dexterity), player._pDexterity);
@@ -3916,7 +3914,7 @@ void UseItem(int pnum, item_misc_id mid, spell_id spl)
 	case IMISC_SCROLLT:
 		if (ControlMode == ControlTypes::KeyboardAndMouse && spelldata[spl].sTargeted) {
 			player._pTSpell = spl;
-			if (pnum == MyPlayerId)
+			if (&player == MyPlayer)
 				NewCursor(CURSOR_TELEPORT);
 		} else {
 			ClrPlrPath(player);
@@ -3926,7 +3924,7 @@ void UseItem(int pnum, item_misc_id mid, spell_id spl)
 			player.destAction = ACTION_SPELL;
 			player.destParam1 = cursPosition.x;
 			player.destParam2 = cursPosition.y;
-			if (pnum == MyPlayerId && spl == SPL_NOVA)
+			if (&player == MyPlayer && spl == SPL_NOVA)
 				NetSendCmdLoc(pnum, true, CMD_NOVA, cursPosition);
 		}
 		break;
@@ -3964,7 +3962,7 @@ void UseItem(int pnum, item_misc_id mid, spell_id spl)
 	case IMISC_OILHARD:
 	case IMISC_OILIMP:
 		player._pOilType = mid;
-		if (pnum != MyPlayerId) {
+		if (&player != MyPlayer) {
 			return;
 		}
 		if (sbookflag) {
@@ -3983,27 +3981,27 @@ void UseItem(int pnum, item_misc_id mid, spell_id spl)
 		break;
 	case IMISC_RUNEF:
 		player._pTSpell = SPL_RUNEFIRE;
-		if (pnum == MyPlayerId)
+		if (&player == MyPlayer)
 			NewCursor(CURSOR_TELEPORT);
 		break;
 	case IMISC_RUNEL:
 		player._pTSpell = SPL_RUNELIGHT;
-		if (pnum == MyPlayerId)
+		if (&player == MyPlayer)
 			NewCursor(CURSOR_TELEPORT);
 		break;
 	case IMISC_GR_RUNEL:
 		player._pTSpell = SPL_RUNENOVA;
-		if (pnum == MyPlayerId)
+		if (&player == MyPlayer)
 			NewCursor(CURSOR_TELEPORT);
 		break;
 	case IMISC_GR_RUNEF:
 		player._pTSpell = SPL_RUNEIMMOLAT;
-		if (pnum == MyPlayerId)
+		if (&player == MyPlayer)
 			NewCursor(CURSOR_TELEPORT);
 		break;
 	case IMISC_RUNES:
 		player._pTSpell = SPL_RUNESTONE;
-		if (pnum == MyPlayerId)
+		if (&player == MyPlayer)
 			NewCursor(CURSOR_TELEPORT);
 		break;
 	default:
@@ -4067,15 +4065,15 @@ void SpawnSmith(int lvl)
 	SortVendor(smithitem + PinnedItemCount);
 }
 
-void SpawnPremium(int pnum)
+void SpawnPremium(Player &player)
 {
-	int8_t lvl = Players[pnum]._pLevel;
+	int8_t lvl = player._pLevel;
 	int maxItems = gbIsHellfire ? SMITH_PREMIUM_ITEMS : 6;
 	if (numpremium < maxItems) {
 		for (int i = 0; i < maxItems; i++) {
 			if (premiumitems[i].isEmpty()) {
 				int plvl = premiumlevel + (gbIsHellfire ? premiumLvlAddHellfire[i] : premiumlvladd[i]);
-				SpawnOnePremium(premiumitems[i], plvl, pnum);
+				SpawnOnePremium(premiumitems[i], plvl, player);
 			}
 		}
 		numpremium = maxItems;
@@ -4085,17 +4083,17 @@ void SpawnPremium(int pnum)
 		if (gbIsHellfire) {
 			// Discard first 3 items and shift next 10
 			std::move(&premiumitems[3], &premiumitems[12] + 1, &premiumitems[0]);
-			SpawnOnePremium(premiumitems[10], premiumlevel + premiumLvlAddHellfire[10], pnum);
+			SpawnOnePremium(premiumitems[10], premiumlevel + premiumLvlAddHellfire[10], player);
 			premiumitems[11] = premiumitems[13];
-			SpawnOnePremium(premiumitems[12], premiumlevel + premiumLvlAddHellfire[12], pnum);
+			SpawnOnePremium(premiumitems[12], premiumlevel + premiumLvlAddHellfire[12], player);
 			premiumitems[13] = premiumitems[14];
-			SpawnOnePremium(premiumitems[14], premiumlevel + premiumLvlAddHellfire[14], pnum);
+			SpawnOnePremium(premiumitems[14], premiumlevel + premiumLvlAddHellfire[14], player);
 		} else {
 			// Discard first 2 items and shift next 3
 			std::move(&premiumitems[2], &premiumitems[4] + 1, &premiumitems[0]);
-			SpawnOnePremium(premiumitems[3], premiumlevel + premiumlvladd[3], pnum);
+			SpawnOnePremium(premiumitems[3], premiumlevel + premiumlvladd[3], player);
 			premiumitems[4] = premiumitems[5];
-			SpawnOnePremium(premiumitems[5], premiumlevel + premiumlvladd[5], pnum);
+			SpawnOnePremium(premiumitems[5], premiumlevel + premiumlvladd[5], player);
 		}
 	}
 }

--- a/Source/items.h
+++ b/Source/items.h
@@ -504,7 +504,7 @@ void UseItem(int p, item_misc_id Mid, spell_id spl);
 bool UseItemOpensHive(const Item &item, Point position);
 bool UseItemOpensCrypt(const Item &item, Point position);
 void SpawnSmith(int lvl);
-void SpawnPremium(int pnum);
+void SpawnPremium(Player &player);
 void SpawnWitch(int lvl);
 void SpawnBoy(int lvl);
 void SpawnHealer(int lvl);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2179,7 +2179,7 @@ void LoadGame(bool firstflag)
 	for (int i = 0; i < giNumberOfSmithPremiumItems; i++)
 		LoadPremium(file, i);
 	if (gbIsHellfire && !gbIsHellfireSaveGame)
-		SpawnPremium(MyPlayerId);
+		SpawnPremium(myPlayer);
 
 	AutomapActive = file.NextBool8();
 	AutoMapScale = file.NextBE<int32_t>();

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -151,13 +151,14 @@ bool IsNetPlayerValid(const Player &player)
 void CheckPlayerInfoTimeouts()
 {
 	for (int i = 0; i < MAX_PLRS; i++) {
-		if (i == MyPlayerId) {
+		Player &player = Players[i];
+		if (&player == MyPlayer) {
 			continue;
 		}
 
 		Uint32 &timerStart = playerInfoTimers[i];
 		bool isPlayerConnected = (player_state[i] & PS_CONNECTED) != 0;
-		bool isPlayerValid = isPlayerConnected && IsNetPlayerValid(Players[i]);
+		bool isPlayerValid = isPlayerConnected && IsNetPlayerValid(player);
 		if (isPlayerConnected && !isPlayerValid && timerStart == 0) {
 			timerStart = SDL_GetTicks();
 		}
@@ -228,15 +229,12 @@ void ParseTurn(int pnum, uint32_t turn)
 
 void PlayerLeftMsg(int pnum, bool left)
 {
-	if (pnum == MyPlayerId) {
-		return;
-	}
-
 	Player &player = Players[pnum];
 
-	if (!player.plractive) {
+	if (&player == MyPlayer)
 		return;
-	}
+	if (!player.plractive)
+		return;
 
 	FixPlrWalkTags(player);
 	RemovePortalMissile(pnum);
@@ -783,11 +781,11 @@ void recv_plrinfo(int pnum, const TCmdPlrInfoHdr &header, bool recv)
 {
 	static PlayerPack PackedPlayerBuffer[MAX_PLRS];
 
-	if (pnum == MyPlayerId) {
-		return;
-	}
 	assert(pnum >= 0 && pnum < MAX_PLRS);
 	Player &player = Players[pnum];
+	if (&player == MyPlayer) {
+		return;
+	}
 	auto &packedPlayer = PackedPlayerBuffer[pnum];
 
 	if (sgwPackPlrOffsetTbl[pnum] != header.wOffset) {

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1522,7 +1522,7 @@ void UpdateBurningCrossDamage(Object &cross)
 	if (myPlayer.position.tile != cross.position + Displacement { 0, -1 })
 		return;
 
-	ApplyPlrDamage(MyPlayerId, 0, 0, damage[leveltype - 1]);
+	ApplyPlrDamage(myPlayer, 0, 0, damage[leveltype - 1]);
 	if (myPlayer._pHitPoints >> 6 > 0) {
 		myPlayer.Say(HeroSpeech::Argh);
 	}
@@ -2350,8 +2350,8 @@ void OperateChest(int pnum, int i, bool sendmsg)
 				CreateRndUseful(Objects[i].position, sendmsg);
 		}
 	}
+	const Player &player = Players[pnum];
 	if (Objects[i].IsTrappedChest()) {
-		const Player &player = Players[pnum];
 		Direction mdir = GetDirection(Objects[i].position, player.position.tile);
 		missile_id mtype;
 		switch (Objects[i]._oVar4) {
@@ -2379,7 +2379,7 @@ void OperateChest(int pnum, int i, bool sendmsg)
 		AddMissile(Objects[i].position, player.position.tile, mdir, mtype, TARGET_PLAYERS, -1, 0, 0);
 		Objects[i]._oTrapFlag = false;
 	}
-	if (pnum == MyPlayerId)
+	if (&player == MyPlayer)
 		NetSendCmdParam2(false, CMD_PLROPOBJ, pnum, i);
 }
 
@@ -3521,7 +3521,7 @@ bool OperateFountains(int pnum, int i)
 	bool applied = false;
 	switch (Objects[i]._otype) {
 	case OBJ_BLOODFTN:
-		if (pnum != MyPlayerId)
+		if (&player != MyPlayer)
 			return false;
 
 		if (player._pHitPoints < player._pMaxHP) {
@@ -3537,7 +3537,7 @@ bool OperateFountains(int pnum, int i)
 			PlaySfxLoc(LS_FOUNTAIN, Objects[i].position);
 		break;
 	case OBJ_PURIFYINGFTN:
-		if (pnum != MyPlayerId)
+		if (&player != MyPlayer)
 			return false;
 
 		if (player._pMana < player._pMaxMana) {
@@ -3569,7 +3569,7 @@ bool OperateFountains(int pnum, int i)
 		    0,
 		    2 * leveltype);
 		applied = true;
-		if (pnum == MyPlayerId)
+		if (&player == MyPlayer)
 			NetSendCmdParam1(false, CMD_OPERATEOBJ, i);
 		break;
 	case OBJ_TEARFTN: {
@@ -3577,7 +3577,7 @@ bool OperateFountains(int pnum, int i)
 			break;
 		PlaySfxLoc(LS_FOUNTAIN, Objects[i].position);
 		Objects[i]._oSelFlag = 0;
-		if (pnum != MyPlayerId)
+		if (&player != MyPlayer)
 			return false;
 
 		unsigned randomValue = (Objects[i]._oRndSeed >> 16) % 12;
@@ -3606,7 +3606,7 @@ bool OperateFountains(int pnum, int i)
 
 		CheckStats(player);
 		applied = true;
-		if (pnum == MyPlayerId)
+		if (&player == MyPlayer)
 			NetSendCmdParam1(false, CMD_OPERATEOBJ, i);
 	} break;
 	default:
@@ -4809,8 +4809,8 @@ int ItemMiscIdIdx(item_misc_id imiscid)
 
 void OperateObject(int pnum, int i, bool teleFlag)
 {
-	bool sendmsg = pnum == MyPlayerId;
 	const Player &player = Players[pnum];
+	bool sendmsg = &player == MyPlayer;
 	switch (Objects[i]._otype) {
 	case OBJ_L1LDOOR:
 	case OBJ_L1RDOOR:
@@ -5034,28 +5034,28 @@ void DeltaSyncOpObject(int cmd, int i)
 
 void SyncOpObject(int pnum, int cmd, int i)
 {
-	bool sendmsg = pnum == MyPlayerId;
 	const Player &player = Players[pnum];
+	bool sendmsg = &player == MyPlayer;
 
 	switch (Objects[i]._otype) {
 	case OBJ_L1LDOOR:
 	case OBJ_L1RDOOR:
-		if (pnum != MyPlayerId)
+		if (!sendmsg)
 			SyncOpL1Door(cmd, i);
 		break;
 	case OBJ_L2LDOOR:
 	case OBJ_L2RDOOR:
-		if (pnum != MyPlayerId)
+		if (!sendmsg)
 			SyncOpL2Door(cmd, i);
 		break;
 	case OBJ_L3LDOOR:
 	case OBJ_L3RDOOR:
-		if (pnum != MyPlayerId)
+		if (!sendmsg)
 			SyncOpL3Door(cmd, i);
 		break;
 	case OBJ_L5LDOOR:
 	case OBJ_L5RDOOR:
-		if (pnum != MyPlayerId)
+		if (!sendmsg)
 			SyncOpL5Door(cmd, i);
 		break;
 	case OBJ_LEVER:

--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -63,7 +63,7 @@ spell_type GetSBookTrans(spell_id ii, bool townok)
 		st = RSPLTYPE_SKILL;
 	}
 	if (st == RSPLTYPE_SPELL) {
-		if (CheckSpell(MyPlayerId, ii, st, true) != SpellCheckResult::Success) {
+		if (CheckSpell(*MyPlayer, ii, st, true) != SpellCheckResult::Success) {
 			st = RSPLTYPE_INVALID;
 		}
 		if (player.GetSpellLevel(ii) == 0) {

--- a/Source/panels/spell_list.cpp
+++ b/Source/panels/spell_list.cpp
@@ -110,7 +110,7 @@ void DrawSpell(const Surface &out)
 
 	if (st == RSPLTYPE_SPELL) {
 		int tlvl = myPlayer.GetSpellLevel(spl);
-		if (CheckSpell(MyPlayerId, spl, st, true) != SpellCheckResult::Success)
+		if (CheckSpell(*MyPlayer, spl, st, true) != SpellCheckResult::Success)
 			st = RSPLTYPE_INVALID;
 		if (tlvl <= 0)
 			st = RSPLTYPE_INVALID;

--- a/Source/player.h
+++ b/Source/player.h
@@ -764,7 +764,7 @@ void NextPlrLevel(Player &player);
 #endif
 void AddPlrExperience(Player &player, int lvl, int exp);
 void AddPlrMonstExper(int lvl, int exp, char pmask);
-void ApplyPlrDamage(int pnum, int dam, int minHP = 0, int frac = 0, int earflag = 0);
+void ApplyPlrDamage(Player &player, int dam, int minHP = 0, int frac = 0, int earflag = 0);
 void InitPlayer(Player &player, bool FirstTime);
 void InitMultiView();
 void PlrClrTrans(Point position);
@@ -772,15 +772,15 @@ void PlrDoTrans(Point position);
 void SetPlayerOld(Player &player);
 void FixPlayerLocation(Player &player, Direction bDir);
 void StartStand(int pnum, Direction dir);
-void StartPlrBlock(int pnum, Direction dir);
+void StartPlrBlock(Player &player, Direction dir);
 void FixPlrWalkTags(const Player &player);
 void StartPlrHit(int pnum, int dam, bool forcehit);
-void StartPlayerKill(int pnum, int earflag);
+void StartPlayerKill(Player &player, int earflag);
 /**
  * @brief Strip the top off gold piles that are larger than MaxGold
  */
 void StripTopGold(Player &player);
-void SyncPlrKill(int pnum, int earflag);
+void SyncPlrKill(Player &player, int earflag);
 void RemovePlrMissiles(const Player &player);
 void StartNewLvl(int pnum, interface_mode fom, int lvl);
 void RestartTownLvl(int pnum);

--- a/Source/qol/autopickup.cpp
+++ b/Source/qol/autopickup.cpp
@@ -75,13 +75,14 @@ bool DoPickup(Item item)
 
 void AutoPickup(int pnum)
 {
-	if (pnum != MyPlayerId)
+	const Player &player = Players[pnum];
+	if (&player != MyPlayer)
 		return;
 	if (leveltype == DTYPE_TOWN && !*sgOptions.Gameplay.autoPickupInTown)
 		return;
 
 	for (auto pathDir : PathDirs) {
-		Point tile = Players[pnum].position.tile + pathDir;
+		Point tile = player.position.tile + pathDir;
 		if (dItem[tile.x][tile.y] != 0) {
 			int itemIndex = dItem[tile.x][tile.y] - 1;
 			auto &item = Items[itemIndex];

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -100,7 +100,7 @@ void PlacePlayer(int pnum)
 
 	dPlayer[newPosition.x][newPosition.y] = pnum + 1;
 
-	if (pnum == MyPlayerId) {
+	if (&player == MyPlayer) {
 		ViewPosition = newPosition;
 	}
 }
@@ -208,7 +208,7 @@ void EnsureValidReadiedSpell(Player &player)
 	}
 }
 
-SpellCheckResult CheckSpell(int id, spell_id sn, spell_type st, bool manaonly)
+SpellCheckResult CheckSpell(const Player &player, spell_id sn, spell_type st, bool manaonly)
 {
 #ifdef _DEBUG
 	if (DebugGodMode)
@@ -223,7 +223,6 @@ SpellCheckResult CheckSpell(int id, spell_id sn, spell_type st, bool manaonly)
 		return SpellCheckResult::Success;
 	}
 
-	const Player &player = Players[id];
 	if (player.GetSpellLevel(sn) <= 0) {
 		return SpellCheckResult::Fail_Level0;
 	}
@@ -271,7 +270,7 @@ void DoResurrect(int pnum, uint16_t rid)
 	if (target._pHitPoints != 0)
 		return;
 
-	if (rid == MyPlayerId) {
+	if (&target == MyPlayer) {
 		MyPlayerIsDead = false;
 		gamemenu_off();
 		drawhpflag = true;

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -21,7 +21,7 @@ bool IsWallSpell(spell_id spl);
 bool TargetsMonster(spell_id id);
 int GetManaAmount(const Player &player, spell_id sn);
 void UseMana(Player &player, spell_id sn);
-SpellCheckResult CheckSpell(int id, spell_id sn, spell_type st, bool manaonly);
+SpellCheckResult CheckSpell(const Player &player, spell_id sn, spell_type st, bool manaonly);
 
 /**
  * @brief Ensures the player's current readied spell is a valid selection for the character. If the current selection is

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -1465,7 +1465,7 @@ void SmithBuyPItem(Item &item)
 
 	premiumitems[xx].clear();
 	numpremium--;
-	SpawnPremium(MyPlayerId);
+	SpawnPremium(*MyPlayer);
 }
 
 void SmithPremiumBuyEnter()
@@ -2244,7 +2244,7 @@ void SetupTownStores()
 	SpawnWitch(l);
 	SpawnHealer(l);
 	SpawnBoy(myPlayer._pLevel);
-	SpawnPremium(MyPlayerId);
+	SpawnPremium(myPlayer);
 }
 
 void FreeStoreMem()


### PR DESCRIPTION
With https://github.com/diasurgical/devilutionX/commit/1fb45a7f2548663294fe6e6996963033e6c70407 solved it unlocked a few more methods to take the player by reference rather then as an ID.

It looks like the rest are pretty much tied up in needing the player ID, we can solve that the same way we did for monsters, but I think this is a good place to cut this PR. I also changed comparisons from `playerId == MyPlayerId` when the function already had the player pointer since this will also simplify https://github.com/diasurgical/devilutionX/pull/4754