### PR TITLE
OpenDingux: Set ccache directory explicitly

### DIFF
--- a/Packaging/OpenDingux/build.sh
+++ b/Packaging/OpenDingux/build.sh
@@ -94,7 +94,7 @@ cmake_configure() {
 }
 
 cmake_build() {
-	cmake --build "$BUILD_DIR" -j "$(getconf _NPROCESSORS_ONLN)"
+	BR_CACHE_DIR="${HOME}/.buildroot-ccache" cmake --build "$BUILD_DIR" -j "$(getconf _NPROCESSORS_ONLN)"
 }
 
 strip_bin() {


### PR DESCRIPTION
The latest OpenDingux toolchains default to the `/__w/` ccache directory due to a bug.

Set the ccache directory explicitly to work around that.