### PR TITLE
Only upload artifacts to sotrage repo in diasurgical org

### DIFF
--- a/.github/workflows/Windows_MinGW_x64.yml
+++ b/.github/workflows/Windows_MinGW_x64.yml
@@ -41,7 +41,7 @@ jobs:
         path: build/devilutionx.zip
 
     - name: Upload artifacts as release in storage repo
-      if: ${{ !env.ACT && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
+      if: ${{ !env.ACT && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'diasurgical/devilutionX' }}
       uses: svenstaro/upload-release-action@v2
       with:
         repo_name: artifacts-storage/devilutionx-artifacts


### PR DESCRIPTION
When updating master in a fork, the github action `Windows MinGW x64` always fails in the following step;

> Upload artifacts as release in storage repo

In a fork this step shouldn't execute.

Fix: Only try to upload artifacts when running the github action in the diasurgical/devilutionX github repro.