### PR TITLE
Revert "artifacts as releases (#4892)"

### DIFF
--- a/.github/workflows/Windows_MinGW_x64.yml
+++ b/.github/workflows/Windows_MinGW_x64.yml
@@ -39,15 +39,35 @@ jobs:
       with:
         name: devilutionx_x64.zip
         path: build/devilutionx.zip
+        
+    - name: Move artifacts to new folder and split exe and other data into two folders
+      if: ${{ !env.ACT && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'diasurgical/devilutionX'}}
+      working-directory: ${{github.workspace}}
+      shell: bash
+      run: mkdir artifacts_dir && unzip build/devilutionx.zip -d artifacts_dir && mkdir artifacts_dir/exe_dir && mv artifacts_dir/devilutionx/devilutionx.exe artifacts_dir/exe_dir && zip -m artifacts_dir/exe_dir/build.zip artifacts_dir/exe_dir/devilutionx.exe
 
-    - name: Upload artifacts as release in storage repo
+    - name: Pushes exe to another repository
       if: ${{ !env.ACT && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'diasurgical/devilutionX' }}
-      uses: svenstaro/upload-release-action@v2
+      uses: cpina/github-action-push-to-another-repository@main
+      env:
+        SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
       with:
-        repo_name: artifacts-storage/devilutionx-artifacts
-        repo_token: ${{ secrets.ARTIFACTS_STORAGE_TOKEN }}
-        file: build/devilutionx.zip
-        asset_name: artifacts.zip
-        tag: "WIN64-${{ github.sha }}"
-        overwrite: true
-        body: ${{ github.event.head_commit.message }}
+        source-directory: artifacts_dir/exe_dir
+        destination-github-username: 'artifacts-storage'
+        destination-repository-name: 'devilutionx-artifacts'     
+        target-directory: ${{ github.sha }}
+        commit-message: "[EXE] ${{ github.event.head_commit.message }}"
+        target-branch: master
+        
+    - name: Pushes DLLs and devilutionx.mpq to another repository
+      if: ${{ !env.ACT && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'diasurgical/devilutionX' }}
+      uses: cpina/github-action-push-to-another-repository@main
+      env:
+        SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+      with:
+        source-directory: artifacts_dir/devilutionx/
+        destination-github-username: 'artifacts-storage'
+        destination-repository-name: 'devilutionx-artifacts' 
+        target-directory: data
+        commit-message: "[DATA] ${{ github.event.head_commit.message }}"
+        target-branch: master


### PR DESCRIPTION
This reverts commit 7612fb4bb5636f993afbad9e15fffa09e204ff89.

and adds a check if it's devilutionX main repo from https://github.com/diasurgical/devilutionX/pull/4980



![image](https://user-images.githubusercontent.com/14297035/178566676-5ce3e34d-1ba2-452f-87bd-1da2a23a0839.png)


Storing artifacts as releases was no bueno.


