### PR TITLE
Use cursor position for position based network messages targeting objects

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -522,7 +522,7 @@ void Interact()
 	}
 
 	if (pcursobj != -1) {
-		NetSendCmdLocParam1(true, CMD_OPOBJXY, cursPosition, pcursobj);
+		NetSendCmdLoc(MyPlayerId, true, CMD_OPOBJXY, cursPosition);
 		LastMouseButtonAction = MouseActionType::OperateObject;
 		return;
 	}
@@ -1973,7 +1973,7 @@ void PerformSecondaryAction()
 	if (pcursitem != -1) {
 		NetSendCmdLocParam1(true, CMD_GOTOAGETITEM, cursPosition, pcursitem);
 	} else if (pcursobj != -1) {
-		NetSendCmdLocParam1(true, CMD_OPOBJXY, cursPosition, pcursobj);
+		NetSendCmdLoc(MyPlayerId, true, CMD_OPOBJXY, cursPosition);
 		LastMouseButtonAction = MouseActionType::OperateObject;
 	} else {
 		if (pcursmissile != nullptr) {

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -240,7 +240,7 @@ void LeftMouseCmd(bool bShift)
 		NetSendCmdLocParam1(true, invflag ? CMD_GOTOGETITEM : CMD_GOTOAGETITEM, cursPosition, pcursitem);
 	} else if (pcursobj != -1 && !Objects[pcursobj].IsDisabled() && (!bShift || (bNear && Objects[pcursobj]._oBreak == 1))) {
 		LastMouseButtonAction = MouseActionType::OperateObject;
-		NetSendCmdLocParam1(true, pcurs == CURSOR_DISARM ? CMD_DISARMXY : CMD_OPOBJXY, cursPosition, pcursobj);
+		NetSendCmdLoc(MyPlayerId, true, pcurs == CURSOR_DISARM ? CMD_DISARMXY : CMD_OPOBJXY, cursPosition);
 	} else if (myPlayer.UsesRangedWeapon()) {
 		if (bShift) {
 			LastMouseButtonAction = MouseActionType::Attack;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -2084,7 +2084,7 @@ void CloseInventory()
 void DoTelekinesis()
 {
 	if (pcursobj != -1)
-		NetSendCmdParam1(true, CMD_OPOBJT, pcursobj);
+		NetSendCmdLoc(MyPlayerId, true, CMD_OPOBJT, cursPosition);
 	if (pcursitem != -1)
 		NetSendCmdGItem(true, CMD_REQUESTAGITEM, MyPlayerId, pcursitem);
 	if (pcursmonst != -1) {

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2395,7 +2395,7 @@ void AddDisarm(Missile &missile, const AddMissileParameter & /*parameter*/)
 		NewCursor(CURSOR_DISARM);
 		if (ControlMode != ControlTypes::KeyboardAndMouse) {
 			if (pcursobj != -1)
-				NetSendCmdLocParam1(true, CMD_DISARMXY, cursPosition, pcursobj);
+				NetSendCmdLoc(MyPlayerId, true, CMD_DISARMXY, cursPosition);
 			else
 				NewCursor(CURSOR_HAND);
 		}

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1215,29 +1215,18 @@ size_t OnTargetSpellTile(const TCmd *pCmd, Player &player)
 	return sizeof(message);
 }
 
-size_t OnObjectTileAction(const TCmd &cmd, Player &player, action_id action)
+size_t OnObjectTileAction(const TCmd &cmd, Player &player, action_id action, bool pathToObject = true)
 {
 	const auto &message = reinterpret_cast<const TCmdLoc &>(cmd);
 	const Point position { message.x, message.y };
 	const Object *object = ObjectAtPosition(position);
 
 	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && object != nullptr) {
-		MakePlrPath(player, position, !object->_oSolidFlag && !object->_oDoorFlag);
+		if (pathToObject)
+			MakePlrPath(player, position, !object->_oSolidFlag && !object->_oDoorFlag);
 
 		player.destAction = action;
 		player.destParam1 = object->GetId();
-	}
-
-	return sizeof(message);
-}
-
-size_t OnOperateObjectTelekinesis(const TCmd *pCmd, Player &player)
-{
-	const auto &message = *reinterpret_cast<const TCmdParam1 *>(pCmd);
-
-	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && message.wParam1 < MAXOBJECTS) {
-		player.destAction = ACTION_OPERATETK;
-		player.destParam1 = message.wParam1;
 	}
 
 	return sizeof(message);
@@ -3005,7 +2994,7 @@ size_t ParseCmd(int pnum, const TCmd *pCmd)
 	case CMD_DISARMXY:
 		return OnObjectTileAction(*pCmd, player, ACTION_DISARM);
 	case CMD_OPOBJT:
-		return OnOperateObjectTelekinesis(pCmd, player);
+		return OnObjectTileAction(*pCmd, player, ACTION_OPERATETK, false);
 	case CMD_ATTACKID:
 		return OnAttackMonster(pCmd, player);
 	case CMD_ATTACKPID:

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1215,29 +1215,17 @@ size_t OnTargetSpellTile(const TCmd *pCmd, Player &player)
 	return sizeof(message);
 }
 
-size_t OnOperateObjectTile(const TCmd *pCmd, Player &player)
+size_t OnObjectTileAction(const TCmd &cmd, Player &player, action_id action)
 {
-	const auto &message = *reinterpret_cast<const TCmdLocParam1 *>(pCmd);
+	const auto &message = reinterpret_cast<const TCmdLoc &>(cmd);
 	const Point position { message.x, message.y };
+	const Object *object = ObjectAtPosition(position);
 
-	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && InDungeonBounds(position) && message.wParam1 < MAXOBJECTS) {
-		MakePlrPath(player, position, !Objects[message.wParam1]._oSolidFlag && !Objects[message.wParam1]._oDoorFlag);
-		player.destAction = ACTION_OPERATE;
-		player.destParam1 = message.wParam1;
-	}
+	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && object != nullptr) {
+		MakePlrPath(player, position, !object->_oSolidFlag && !object->_oDoorFlag);
 
-	return sizeof(message);
-}
-
-size_t OnDisarm(const TCmd *pCmd, Player &player)
-{
-	const auto &message = *reinterpret_cast<const TCmdLocParam1 *>(pCmd);
-	const Point position { message.x, message.y };
-
-	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && InDungeonBounds(position) && message.wParam1 < MAXOBJECTS) {
-		MakePlrPath(player, position, !Objects[message.wParam1]._oSolidFlag && !Objects[message.wParam1]._oDoorFlag);
-		player.destAction = ACTION_DISARM;
-		player.destParam1 = message.wParam1;
+		player.destAction = action;
+		player.destParam1 = object->GetId();
 	}
 
 	return sizeof(message);
@@ -3013,9 +3001,9 @@ size_t ParseCmd(int pnum, const TCmd *pCmd)
 	case CMD_TSPELLXY:
 		return OnTargetSpellTile(pCmd, player);
 	case CMD_OPOBJXY:
-		return OnOperateObjectTile(pCmd, player);
+		return OnObjectTileAction(*pCmd, player, ACTION_OPERATE);
 	case CMD_DISARMXY:
-		return OnDisarm(pCmd, player);
+		return OnObjectTileAction(*pCmd, player, ACTION_DISARM);
 	case CMD_OPOBJT:
 		return OnOperateObjectTelekinesis(pCmd, player);
 	case CMD_ATTACKID:

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -99,17 +99,15 @@ enum _cmd_id : uint8_t {
 	CMD_TSPELLXY,
 	// Operate object at location.
 	//
-	// body (TCmdLocParam1):
+	// body (TCmdLoc):
 	//    int8_t x
 	//    int8_t y
-	//    int16_t object_num
 	CMD_OPOBJXY,
 	// Disarm trap at location.
 	//
-	// body (TCmdLocParam1):
+	// body (TCmdLoc):
 	//    int8_t x
 	//    int8_t y
-	//    int16_t object_num
 	CMD_DISARMXY,
 	// Attack target monster.
 	//

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -164,8 +164,9 @@ enum _cmd_id : uint8_t {
 	CMD_RESURRECT,
 	// Operate object using telekinesis.
 	//
-	// body (TCmdParam1):
-	//    int16_t object_num
+	// body (TCmdLoc):
+	//    int8_t x
+	//    int8_t y
 	CMD_OPOBJT,
 	// Knockback target monster using telekinesis.
 	//

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -115,7 +115,8 @@ void RepeatMouseAction()
 			auto &object = Objects[pcursobj];
 			if (object.IsDoor())
 				break;
-			NetSendCmdLocParam1(true, CMD_OPOBJXY, object.position, pcursobj);
+			// This should probably be cursPosition so paths to large objects are consistent
+			NetSendCmdLoc(MyPlayerId, true, CMD_OPOBJXY, object.position);
 		}
 		break;
 	case MouseActionType::Walk:


### PR DESCRIPTION
pcursobj was used as a pointer so might as well make it an actual pointer. This also allows cleaning up some of the network messages to work off a position instead of ignoring the passed info and relying on index instead