### PR TITLE
CMake: Use the mold linker where available

### DIFF
--- a/CMake/MoldLinker.cmake
+++ b/CMake/MoldLinker.cmake
@@ -1,0 +1,33 @@
+if(NOT CMAKE_CROSSCOMPILING)
+  find_program(
+    LD_MOLD_PATH
+    ld
+    PATHS
+    ${CMAKE_INSTALL_PREFIX}/libexec/mold
+    ENV LD_MOLD_PATH
+    NO_DEFAULT_PATH
+  )
+  if(NOT LD_MOLD_PATH STREQUAL "LD_MOLD_PATH-NOTFOUND")
+    set(_have_ld_mold ON)
+  else()
+    set(_have_ld_mold OFF)
+  endif()
+endif()
+
+option(USE_LD_MOLD "Use mold linker" ${_have_ld_mold})
+
+if(USE_LD_MOLD)
+  message("-- Using Mold linker (pass -DUSE_LD_MOLD=OFF to disable)")
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
+    if (_have_ld_mold)
+      get_filename_component(_mold_dir ${LD_MOLD_PATH} DIRECTORY)
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -B${_mold_dir}")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -B${_mold_dir}")
+    else()
+      message(WARNING "Cannot use mold linker: mold ld directory not found")
+    endif()
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fuse-ld=mold")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=mold")
+  endif()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,8 @@ cmake_dependent_option(DEVILUTIONX_DISABLE_RTTI "Disable RTTI" ON "NONET" OFF)
 cmake_dependent_option(DEVILUTIONX_DISABLE_EXCEPTIONS "Disable exceptions" ON "NONET" OFF)
 RELEASE_OPTION(DEVILUTIONX_STATIC_CXX_STDLIB "Link C++ standard library statically (if available)")
 
+include(MoldLinker)
+
 # Memory / performance trade-off options
 option(DISABLE_STREAMING_MUSIC "Disable streaming music (to work around broken platform implementations)" OFF)
 mark_as_advanced(DISABLE_STREAMING_MUSIC)


### PR DESCRIPTION
https://github.com/rui314/mold is quite stable these days and is insanely fast.

Let's use it by default if it's there.

Linking a debug `devilutionx` binary:

GNU ld: 1.82s
Mold: 0.03s

(mold 1.3.1 [installed from source](https://github.com/rui314/mold#compile-mold) on Ubuntu 22.04)