### PR TITLE
:recycle: Adds Missile::SourcePlayer and Missile::SourceMonster

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1883,15 +1883,20 @@ void AddTown(Missile &missile, const AddMissileParameter &parameter)
 
 void AddFlash(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
-	if (Player *player = missile.SourcePlayer(); player != nullptr) {
+	Player *player = missile.SourcePlayer();
+	if (player != nullptr) {
 		int dmg = GenerateRndSum(20, player->_pLevel + 1) + player->_pLevel + 1;
 		missile._midam = ScaleSpellEffect(dmg, missile._mispllvl);
 		missile._midam += missile._midam / 2;
 		UseMana(*player, SPL_FLASH);
-	} else if (Monster *monster = missile.SourceMonster(); monster != nullptr) {
-		missile._midam = monster->level * 2;
 	} else {
-		missile._midam = currlevel / 2;
+		Monster *monster = missile.SourceMonster();
+		if (monster != nullptr) {
+			missile._midam = monster->level * 2;
+		} else {
+			// Trap
+			missile._midam = currlevel / 2;
+		}
 	}
 
 	missile._mirange = 19;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1883,7 +1883,7 @@ void AddTown(Missile &missile, const AddMissileParameter &parameter)
 
 void AddFlash(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
-	switch (missile.SourceType()) {
+	switch (missile.sourceType()) {
 	case MissileSource::Player: {
 		Player *player = missile.sourcePlayer();
 		int dmg = GenerateRndSum(20, player->_pLevel + 1) + player->_pLevel + 1;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1883,19 +1883,17 @@ void AddTown(Missile &missile, const AddMissileParameter &parameter)
 
 void AddFlash(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
-	if (!missile.IsTrap()) {
-		if (missile._micaster == TARGET_MONSTERS) {
-			Player &player = Players[missile._misource];
-			int dmg = GenerateRndSum(20, player._pLevel + 1) + player._pLevel + 1;
-			missile._midam = ScaleSpellEffect(dmg, missile._mispllvl);
-			missile._midam += missile._midam / 2;
-			UseMana(player, SPL_FLASH);
-		} else {
-			missile._midam = Monsters[missile._misource].level * 2;
-		}
+	if (Player *player = missile.SourcePlayer(); player != nullptr) {
+		int dmg = GenerateRndSum(20, player->_pLevel + 1) + player->_pLevel + 1;
+		missile._midam = ScaleSpellEffect(dmg, missile._mispllvl);
+		missile._midam += missile._midam / 2;
+		UseMana(*player, SPL_FLASH);
+	} else if (Monster *monster = missile.SourceMonster(); monster != nullptr) {
+		missile._midam = monster->level * 2;
 	} else {
 		missile._midam = currlevel / 2;
 	}
+
 	missile._mirange = 19;
 }
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1884,17 +1884,17 @@ void AddTown(Missile &missile, const AddMissileParameter &parameter)
 void AddFlash(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
 	switch (missile.SourceType()) {
-	case MissileSourceType::Player: {
-		Player *player = missile.SourcePlayer();
+	case MissileSource::Player: {
+		Player *player = missile.sourcePlayer();
 		int dmg = GenerateRndSum(20, player->_pLevel + 1) + player->_pLevel + 1;
 		missile._midam = ScaleSpellEffect(dmg, missile._mispllvl);
 		missile._midam += missile._midam / 2;
 		UseMana(*player, SPL_FLASH);
 	} break;
-	case MissileSource::Monster: {
+	case MissileSource::Monster:
 		missile._midam = missile.sourceMonster()->level * 2;
 		break;
-	case MissileSourceType::Trap:
+	case MissileSource::Trap:
 		missile._midam = currlevel / 2;
 		break;
 	}

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1891,10 +1891,9 @@ void AddFlash(Missile &missile, const AddMissileParameter & /*parameter*/)
 		missile._midam += missile._midam / 2;
 		UseMana(*player, SPL_FLASH);
 	} break;
-	case MissileSourceType::Monster: {
-		Monster *monster = missile.SourceMonster();
-		missile._midam = monster->level * 2;
-	} break;
+	case MissileSource::Monster: {
+		missile._midam = missile.sourceMonster()->level * 2;
+		break;
 	case MissileSourceType::Trap:
 		missile._midam = currlevel / 2;
 		break;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1883,20 +1883,21 @@ void AddTown(Missile &missile, const AddMissileParameter &parameter)
 
 void AddFlash(Missile &missile, const AddMissileParameter & /*parameter*/)
 {
-	Player *player = missile.SourcePlayer();
-	if (player != nullptr) {
+	switch (missile.SourceType()) {
+	case MissileSourceType::Player: {
+		Player *player = missile.SourcePlayer();
 		int dmg = GenerateRndSum(20, player->_pLevel + 1) + player->_pLevel + 1;
 		missile._midam = ScaleSpellEffect(dmg, missile._mispllvl);
 		missile._midam += missile._midam / 2;
 		UseMana(*player, SPL_FLASH);
-	} else {
+	} break;
+	case MissileSourceType::Monster: {
 		Monster *monster = missile.SourceMonster();
-		if (monster != nullptr) {
-			missile._midam = monster->level * 2;
-		} else {
-			// Trap
-			missile._midam = currlevel / 2;
-		}
+		missile._midam = monster->level * 2;
+	} break;
+	case MissileSourceType::Trap:
+		missile._midam = currlevel / 2;
+		break;
 	}
 
 	missile._mirange = 19;

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -85,7 +85,7 @@ enum class Direction16 {
 	South_SouthEast,
 };
 
-enum class MissileSourceType {
+enum class MissileSource {
 	Player,
 	Monster,
 	Trap,

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -139,7 +139,7 @@ struct Missile {
 		return _misource == -1;
 	}
 
-	[[nodiscard]] Player *SourcePlayer()
+	[[nodiscard]] Player *sourcePlayer()
 	{
 		if (IsNoneOf(_micaster, TARGET_BOTH, TARGET_MONSTERS) || _misource == -1)
 			return nullptr;

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -132,6 +132,20 @@ struct Missile {
 	{
 		return _misource == -1;
 	}
+
+	[[nodiscard]] Player *SourcePlayer()
+	{
+		if (IsNoneOf(_micaster, TARGET_BOTH, TARGET_MONSTERS) || _misource == -1)
+			return nullptr;
+		return &Players[_misource];
+	}
+
+	[[nodiscard]] Monster *SourceMonster()
+	{
+		if (_micaster != TARGET_PLAYERS || _misource == -1)
+			return nullptr;
+		return &Monsters[_misource];
+	}
 };
 
 extern std::list<Missile> Missiles;

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -85,6 +85,12 @@ enum class Direction16 {
 	South_SouthEast,
 };
 
+enum class MissileSourceType {
+	Player,
+	Monster,
+	Trap,
+};
+
 struct Missile {
 	/** Type of projectile */
 	missile_id _mitype;
@@ -145,6 +151,15 @@ struct Missile {
 		if (_micaster != TARGET_PLAYERS || _misource == -1)
 			return nullptr;
 		return &Monsters[_misource];
+	}
+
+	MissileSourceType SourceType()
+	{
+		if (_misource == -1)
+			return MissileSourceType::Trap;
+		if (_micaster == TARGET_PLAYERS)
+			return MissileSourceType::Monster;
+		return MissileSourceType::Player;
 	}
 };
 

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -153,7 +153,7 @@ struct Missile {
 		return &Monsters[_misource];
 	}
 
-	MissileSource SourceType()
+	MissileSource sourceType()
 	{
 		if (_misource == -1)
 			return MissileSource::Trap;

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -146,20 +146,20 @@ struct Missile {
 		return &Players[_misource];
 	}
 
-	[[nodiscard]] Monster *SourceMonster()
+	[[nodiscard]] Monster *sourceMonster()
 	{
 		if (_micaster != TARGET_PLAYERS || _misource == -1)
 			return nullptr;
 		return &Monsters[_misource];
 	}
 
-	MissileSourceType SourceType()
+	MissileSource SourceType()
 	{
 		if (_misource == -1)
-			return MissileSourceType::Trap;
+			return MissileSource::Trap;
 		if (_micaster == TARGET_PLAYERS)
-			return MissileSourceType::Monster;
-		return MissileSourceType::Player;
+			return MissileSource::Monster;
+		return MissileSource::Player;
 	}
 };
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2714,7 +2714,7 @@ void OperateShrineMagical(int pnum)
 	    player.position.tile,
 	    player._pdir,
 	    MIS_MANASHIELD,
-	    TARGET_PLAYERS,
+	    TARGET_MONSTERS,
 	    pnum,
 	    0,
 	    2 * leveltype);
@@ -2848,7 +2848,7 @@ void OperateShrineCryptic(int pnum)
 	    player.position.tile,
 	    player._pdir,
 	    MIS_NOVA,
-	    TARGET_PLAYERS,
+	    TARGET_MONSTERS,
 	    pnum,
 	    0,
 	    2 * leveltype);
@@ -2936,7 +2936,7 @@ void OperateShrineHoly(int pnum)
 {
 	const Player &player = Players[pnum];
 
-	AddMissile(player.position.tile, { 0, 0 }, Direction::South, MIS_RNDTELEPORT, TARGET_PLAYERS, pnum, 0, 2 * leveltype);
+	AddMissile(player.position.tile, { 0, 0 }, Direction::South, MIS_RNDTELEPORT, TARGET_MONSTERS, pnum, 0, 2 * leveltype);
 
 	if (&player != MyPlayer)
 		return;
@@ -3207,7 +3207,7 @@ void OperateShrineTown(int pnum, Point spawnPosition)
 	    player.position.tile,
 	    player._pdir,
 	    MIS_TOWN,
-	    TARGET_PLAYERS,
+	    TARGET_MONSTERS,
 	    pnum,
 	    0,
 	    0);
@@ -3570,7 +3570,7 @@ bool OperateFountains(int pnum, int i)
 		    player.position.tile,
 		    player._pdir,
 		    MIS_INFRA,
-		    TARGET_PLAYERS,
+		    TARGET_MONSTERS,
 		    pnum,
 		    0,
 		    2 * leveltype);


### PR DESCRIPTION
This is a follow up from the discussions on #4994

Adds the helper methods `SourcePlayer` and `SourceMonster` to the `Missile` struct.

The end goal is to replace every direct access to `_misource` with calls to `SourcePlayer` and/or `SourceMonster`

`AddFlash` already converted to use the new methods.