### PR TITLE
Remove `MAX_PATH`

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -13,7 +13,6 @@
 #include "engine/render/automap_render.hpp"
 #include "levels/gendung.h"
 #include "levels/setmaps.h"
-#include "miniwin/miniwin.h"
 #include "player.h"
 #include "utils/language.h"
 #include "utils/stdcompat/algorithm.hpp"

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -9,7 +9,6 @@
 #include "engine/sound.h"
 #include "engine/sound_defs.hpp"
 #include "init.h"
-#include "miniwin/miniwin.h"
 #include "player.h"
 #include "utils/stdcompat/algorithm.hpp"
 #include "utils/str_cat.hpp"

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -26,7 +26,6 @@
 #include "inv.h"
 #include "lighting.h"
 #include "menu.h"
-#include "miniwin/miniwin.h"
 #include "missiles.h"
 #include "mpq/mpq_writer.hpp"
 #include "pfile.h"
@@ -922,7 +921,7 @@ void GetPermLevelNames(char *szPerm)
 
 bool LevelFileExists(MpqWriter &archive)
 {
-	char szName[MAX_PATH];
+	char szName[MaxMpqPathSize];
 
 	GetTempLevelNames(szName);
 	if (archive.HasFile(szName))
@@ -2466,7 +2465,7 @@ void SaveLevel(MpqWriter &saveWriter)
 	if (leveltype == DTYPE_TOWN)
 		glSeedTbl[0] = AdvanceRndSeed();
 
-	char szName[MAX_PATH];
+	char szName[MaxMpqPathSize];
 	GetTempLevelNames(szName);
 	SaveHelper file(saveWriter, szName, 256 * 1024);
 
@@ -2533,7 +2532,7 @@ void SaveLevel(MpqWriter &saveWriter)
 
 void LoadLevel()
 {
-	char szName[MAX_PATH];
+	char szName[MaxMpqPathSize];
 	std::optional<MpqArchive> archive = OpenSaveArchive(gSaveNumber);
 	GetTempLevelNames(szName);
 	if (!archive || !archive->HasFile(szName))

--- a/Source/miniwin/miniwin.h
+++ b/Source/miniwin/miniwin.h
@@ -1,9 +1,0 @@
-#pragma once
-
-namespace devilution {
-
-#ifndef MAX_PATH
-#define MAX_PATH 260
-#endif
-
-} // namespace devilution

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -28,7 +28,6 @@
 #include "levels/trigs.h"
 #include "lighting.h"
 #include "minitext.h"
-#include "miniwin/miniwin.h"
 #include "missiles.h"
 #include "movie.h"
 #include "options.h"
@@ -164,7 +163,7 @@ bool IsDirectionalAnim(const CMonster &monster, size_t animIndex)
 
 void InitMonsterTRN(CMonster &monst)
 {
-	char path[MAX_PATH];
+	char path[64];
 	std::array<uint8_t, 256> colorTranslations;
 	*BufCopy(path, "Monsters\\", monst.data->trnFile, ".TRN") = '\0';
 	LoadFileInMem(path, colorTranslations);
@@ -3595,7 +3594,7 @@ void InitMonsterSND(CMonster &monsterType)
 			continue;
 
 		for (int j = 0; j < 2; j++) {
-			char path[MAX_PATH];
+			char path[64];
 			*BufCopy(path, "Monsters\\", soundSuffix, prefix, j + 1, ".WAV") = '\0';
 			monsterType.sounds[i][j] = sound_file_load(path);
 		}

--- a/Source/mpq/mpq_common.hpp
+++ b/Source/mpq/mpq_common.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 #include "utils/endian.hpp"
 
 namespace devilution {
+
+constexpr size_t MaxMpqPathSize = 256;
 
 #pragma pack(push, 1)
 struct MpqFileHeader {

--- a/Source/mpq/mpq_writer.cpp
+++ b/Source/mpq/mpq_writer.cpp
@@ -11,7 +11,6 @@
 #include "appfat.h"
 #include "encrypt.h"
 #include "engine.h"
-#include "miniwin/miniwin.h"
 #include "utils/endian.hpp"
 #include "utils/file_util.h"
 #include "utils/language.h"
@@ -500,7 +499,7 @@ void MpqWriter::RemoveHashEntry(const char *filename)
 
 void MpqWriter::RemoveHashEntries(bool (*fnGetName)(uint8_t, char *))
 {
-	char pszFileName[MAX_PATH];
+	char pszFileName[MaxMpqPathSize];
 
 	for (uint8_t i = 0; fnGetName(i, pszFileName); i++) {
 		RemoveHashEntry(pszFileName);

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -14,7 +14,6 @@
 #include "init.h"
 #include "loadsave.h"
 #include "menu.h"
-#include "miniwin/miniwin.h"
 #include "mpq/mpq_reader.hpp"
 #include "pack.h"
 #include "qol/stash.h"
@@ -84,8 +83,8 @@ bool GetTempSaveNames(uint8_t dwIndex, char *szTemp)
 
 void RenameTempToPerm(MpqWriter &saveWriter)
 {
-	char szTemp[MAX_PATH];
-	char szPerm[MAX_PATH];
+	char szTemp[MaxMpqPathSize];
+	char szPerm[MaxMpqPathSize];
 
 	uint32_t dwIndex = 0;
 	while (GetTempSaveNames(dwIndex, szTemp)) {
@@ -194,7 +193,7 @@ bool CompareSaves(const std::string &actualSavePath, const std::string &referenc
 	possibleFileNamesToCheck.emplace_back("hero");
 	possibleFileNamesToCheck.emplace_back("game");
 	possibleFileNamesToCheck.emplace_back("additionalMissiles");
-	char szPerm[MAX_PATH];
+	char szPerm[MaxMpqPathSize];
 	for (int i = 0; GetPermSaveNames(i, szPerm); i++) {
 		possibleFileNamesToCheck.emplace_back(szPerm);
 	}

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "engine/assets.hpp"
-#include "miniwin/miniwin.h"
 #include "options.h"
 #include "utils/file_util.h"
 #include "utils/log.hpp"


### PR DESCRIPTION
Rather than using the Windows-like `MAX_PATH`, what we really want is 2 things:

1. Maximum path of a file in an MPQ. This is now `MaxMpqPathSize`.
2. Max size for the known monster paths. This is now 64 for sounds and TRNs, which is more than enough (picked arbitrarily).