### PR TITLE
Fix fmt v9 deprecation warnings

### DIFF
--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -322,13 +322,13 @@ void DrawMissilePrivate(const Surface &out, const Missile &missile, Point target
 		return;
 
 	if (missile._miAnimData == nullptr) {
-		Log("Draw Missile 2 type {}: NULL Cel Buffer", missile._mitype);
+		Log("Draw Missile 2 type {}: NULL Cel Buffer", static_cast<int>(missile._mitype));
 		return;
 	}
 	int nCel = missile._miAnimFrame - 1;
 	const uint32_t frames = LoadLE32(missile._miAnimData);
 	if (nCel < 0 || frames > 50 || nCel >= static_cast<int>(frames)) {
-		Log("Draw Missile 2: frame {} of {}, missile type=={}", nCel, frames, missile._mitype);
+		Log("Draw Missile 2: frame {} of {}, missile type {}", nCel, frames, static_cast<int>(missile._mitype));
 		return;
 	}
 
@@ -623,14 +623,14 @@ void DrawObject(const Surface &out, Point tilePosition, Point targetBufferPositi
 
 	byte *pCelBuff = objectToDraw._oAnimData;
 	if (pCelBuff == nullptr) {
-		Log("Draw Object type {}: NULL Cel Buffer", objectToDraw._otype);
+		Log("Draw Object type {}: NULL Cel Buffer", static_cast<int>(objectToDraw._otype));
 		return;
 	}
 
 	const uint32_t nCel = objectToDraw._oAnimFrame - 1;
 	const uint32_t frames = LoadLE32(pCelBuff);
 	if (nCel == static_cast<uint32_t>(-1) || frames > 50 || nCel >= frames) {
-		Log("Draw Object: frame {} of {}, object type=={}", nCel, frames, objectToDraw._otype);
+		Log("Draw Object: frame {} of {}, object type {}", nCel, frames, static_cast<int>(objectToDraw._otype));
 		return;
 	}
 

--- a/Source/miniwin/misc_msg.cpp
+++ b/Source/miniwin/misc_msg.cpp
@@ -260,7 +260,7 @@ int TranslateSdlKey(SDL_Keysym key)
 		} else if (sym >= SDLK_F1 && sym <= SDLK_F12) {
 			return DVL_VK_F1 + (sym - SDLK_F1);
 		}
-		Log("unknown key: name={} sym=0x{:X} scan={} mod=0x{:X}", SDL_GetKeyName(sym), sym, key.scancode, key.mod);
+		Log("unknown key: name={} sym=0x{:X} scan={} mod=0x{:X}", SDL_GetKeyName(sym), static_cast<int>(sym), static_cast<int>(key.scancode), static_cast<unsigned>(key.mod));
 		return -1;
 	}
 }

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -769,7 +769,7 @@ void SetupObject(Object &object, Point position, _object_id ot)
 	if (!HeadlessMode) {
 		const auto &found = std::find(std::begin(ObjFileList), std::end(ObjFileList), ofi);
 		if (found == std::end(ObjFileList)) {
-			LogCritical("Unable to find object_graphic_id {} in list of objects to load, level generation error.", ofi);
+			LogCritical("Unable to find object_graphic_id {} in list of objects to load, level generation error.", static_cast<int>(ofi));
 			return;
 		}
 
@@ -5181,7 +5181,7 @@ void SyncObjectAnim(Object &object)
 	if (!HeadlessMode) {
 		const auto &found = std::find(std::begin(ObjFileList), std::end(ObjFileList), index);
 		if (found == std::end(ObjFileList)) {
-			LogCritical("Unable to find object_graphic_id {} in list of objects to load, level generation error.", index);
+			LogCritical("Unable to find object_graphic_id {} in list of objects to load, level generation error.", static_cast<int>(index));
 			return;
 		}
 


### PR DESCRIPTION
Version 9 of libfmt deprecates printing `enum` without casting it to an integral type explicitly (consistent with `enum class`).