### PR TITLE
Reduce double scans in GetSizeForThemeRoom

### DIFF
--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -351,6 +351,13 @@ void InitGlobals()
 
 } // namespace
 
+#ifdef BUILD_TESTING
+std::optional<Size> GetSizeForThemeRoom()
+{
+	return GetSizeForThemeRoom(0, { 0, 0 }, 5, 10);
+}
+#endif
+
 dungeon_type GetLevelType(int level)
 {
 	if (level == 0)

--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -105,7 +105,7 @@ std::optional<Size> GetSizeForThemeRoom(int floor, Point origin, int minSize, in
 	Size room { maxWidth, maxHeight };
 
 	for (int i = 0; i < maxSize; i++) {
-		int width = 0;
+		int width = i < room.height ? i : 0;
 		if (i < maxHeight) {
 			while (width < room.width) {
 				if (dungeon[origin.x + width][origin.y + i] != floor)
@@ -115,7 +115,7 @@ std::optional<Size> GetSizeForThemeRoom(int floor, Point origin, int minSize, in
 			}
 		}
 
-		int height = 0;
+		int height = i < room.width ? i : 0;
 		if (i < maxWidth) {
 			while (height < room.height) {
 				if (dungeon[origin.x + i][origin.y + height] != floor)

--- a/Source/levels/gendung.h
+++ b/Source/levels/gendung.h
@@ -215,6 +215,10 @@ extern char dSpecial[MAXDUNX][MAXDUNY];
 extern int themeCount;
 extern THEME_LOC themeLoc[MAXTHEMES];
 
+#ifdef BUILD_TESTING
+std::optional<Size> GetSizeForThemeRoom();
+#endif
+
 dungeon_type GetLevelType(int level);
 void CreateDungeon(uint32_t rseed, lvl_entry entry);
 

--- a/test/drlg_common_test.cpp
+++ b/test/drlg_common_test.cpp
@@ -4,6 +4,7 @@
 #include <array>
 
 #include "engine/points_in_rectangle_range.hpp"
+#include "levels/gendung.h"
 
 namespace devilution {
 
@@ -68,6 +69,40 @@ TEST(DrlgTest, RectangleRangeIterator)
 	EXPECT_EQ(region[4][2], 3) << "Reverse iterators are required";
 	EXPECT_EQ(region[2][4], 7) << "Reverse iterators are required";
 	EXPECT_EQ(region[2][2], 9) << "Reverse iterators are required";
+}
+
+TEST(DrlgTest, ThemeRoomSize)
+{
+	memset(dungeon, 0, sizeof(dungeon));
+
+	EXPECT_EQ(GetSizeForThemeRoom(), Size(8, 8)) << "All floor theme area should be 8x8";
+
+	dungeon[9][9] = 1;
+	EXPECT_EQ(GetSizeForThemeRoom(), Size(7, 7)) << "Corners shrink the chosen dimensions";
+	dungeon[9][5] = 1;
+	EXPECT_EQ(GetSizeForThemeRoom(), Size(7, 3)) << "Minimum dimensions are determined by corners outside the min area";
+	dungeon[9][4] = 1;
+	EXPECT_EQ(GetSizeForThemeRoom(), Size(7, 8)) << "Walls below the min size let larger opposing dimensions get picked";
+	dungeon[9][5] = 0;
+	dungeon[9][4] = 0;
+	dungeon[9][9] = 0;
+
+	// Time for some unusual cases
+	dungeon[7][2] = 1;
+	dungeon[5][9] = 1;
+	EXPECT_EQ(GetSizeForThemeRoom(), Size(5, 7)) << "Search space terminates at width 8 due to the wall being in the first three rows";
+
+	dungeon[6][4] = 1;
+	EXPECT_EQ(GetSizeForThemeRoom(), Size(4, 7)) << "Smallest width now defined by row 5, height still extends due to minSize";
+	dungeon[6][4] = 0;
+
+	dungeon[5][9] = 0;
+	dungeon[7][2] = 0;
+
+	dungeon[7][0] = 1;
+	dungeon[6][6] = 1;
+	dungeon[8][5] = 1;
+	EXPECT_EQ(GetSizeForThemeRoom(), Size(4, 4)) << "Search is terminated by the 0 width row 7, inset corner gives a larger height than otherwise expected";
 }
 
 } // namespace devilution


### PR DESCRIPTION
Double scan goes from `n^2` to just `n`. Resulting in a further 13% performance boost. Hope that makes it feel a bit more ideal :)

The remaining over scan comes from both loops starting from the same diagonal coordinates.

Given the following map and a max of 10x10:
![image](https://user-images.githubusercontent.com/204594/179366705-41340bb1-27dc-4a2c-9c2a-45e34f1f19ab.png)
Black = floor
Red = wall

Here is the scan patterns from the original:
![image](https://user-images.githubusercontent.com/204594/179366649-833a3b22-c242-4456-a06f-6d43df18f430.png)
Blue = vertical
Orange = horizontal
Green = overlapping scans

The version in this PR instead has this pattern:
![image](https://user-images.githubusercontent.com/204594/179366731-66192346-8e41-4d2c-a38e-d49f72cacc6f.png)
