### PR TITLE
Toward importing characters to/from multiplayer

### DIFF
--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -167,6 +167,10 @@ void SelheroListSelect(int value)
 		return;
 	}
 
+	if (static_cast<std::size_t>(value) == selhero_SaveCount + 1) {
+		return;
+	}
+
 	if (selhero_heroInfo.hassaved) {
 		vecSelDlgItems.clear();
 
@@ -507,6 +511,8 @@ void selhero_List_Init()
 			selectedItem = i;
 	}
 	vecSelHeroDlgItems.push_back(std::make_unique<UiListItem>(_("New Hero").data(), static_cast<int>(selhero_SaveCount)));
+
+	vecSelHeroDlgItems.push_back(std::make_unique<UiListItem>(_("Import Hero").data(), static_cast<int>(selhero_SaveCount + 1)));
 
 	vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, 6, uiPosition.x + 265, (uiPosition.y + 256), 320, 26, UiFlags::AlignCenter | UiFlags::FontSize24 | UiFlags::ColorUiGold));
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3226,6 +3226,7 @@ void CornerstoneSave()
 		return;
 	if (!CornerStone.item.isEmpty()) {
 		ItemPack id;
+		// TODO: what if item is foreign?
 		PackItem(id, CornerStone.item, (CornerStone.item.dwBuff & CF_HELLFIRE) != 0);
 		const auto *buffer = reinterpret_cast<uint8_t *>(&id);
 		for (size_t i = 0; i < sizeof(ItemPack); i++) {
@@ -3268,6 +3269,7 @@ void CornerstoneLoad(Point position)
 
 	dItem[position.x][position.y] = ii + 1;
 
+	//TODO: handle foreign item
 	UnPackItem(pkSItem, item, (pkSItem.dwBuff & CF_HELLFIRE) != 0);
 	item.position = position;
 	RespawnItem(item, false);

--- a/Source/items.h
+++ b/Source/items.h
@@ -245,6 +245,7 @@ struct Item {
 	_item_indexes IDidx = IDI_NONE;
 	uint32_t dwBuff = 0;
 	ItemSpecialEffectHf _iDamAcFlags = ItemSpecialEffectHf::None;
+	bool isForeign = false;
 
 	/**
 	 * @brief Clears this item and returns the old value

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -79,7 +79,12 @@ struct PlayerPack {
 	uint8_t friendlyMode;
 	/**@brief Only used in multiplayer sync (SendPlayerInfo/recv_plrinfo). Never used in save games (single- or multiplayer). */
 	uint8_t isOnSetLevel;
-	uint8_t dwReserved[18]; // For future use
+
+	uint64_t foreignInvFlags;
+	uint8_t foreignBodyFlags;
+	uint8_t foreignBeltFlags;
+
+	uint8_t dwReserved[8]; // For future use
 };
 #pragma pack(pop)
 


### PR DESCRIPTION
This PR is an early proof-of-concept attempting to resurrect https://github.com/diasurgical/devilutionX/issues/3474. In a nutshell, I think importing characters to and from multiplayer would be awesome, and some of you probably do, as well.

The main problem that item seeds generate wildly different items between single player and multiplayer. All that would be needed to be able to use both kinds of items at the same time is an extra flag, indicating whether or not the item is "foreign".

As far as storing the foreign items in save files, we have three options:

- An extra flag in the `ItemPack` structure: There doesn't seem to be any room.
- Flags in the `PlayerPack` structure: There are 18B of reserved space, which are set to 0. We can use 10B (8b for equipped items, 8b for belt items, 40b for the regular inventory). The PR uses this approach,
- An extra file in the MPQ archive containing the packed foreign items: This would be, by far, the cleanest approach. Loading such a save in vanilla DIablo would simply strip all foreign items without a hitch. (The other two would cause foreign items to morph.)

This PR does not consider the cornerstone of the world, or items dropped on the ground in multiplayer.

The PR also features stub menu entries that show how I'd envision the UI going forward. The UI code needs some refactoring to make this work.
