### PR TITLE
Use object pointer for pcursobj

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -913,8 +913,8 @@ void DrawInfoBox(const Surface &out)
 	} else {
 		if (pcursitem != -1)
 			GetItemStr(Items[pcursitem]);
-		else if (pcursobj != -1)
-			GetObjectStr(Objects[pcursobj]);
+		else if (ObjectUnderCursor != nullptr)
+			GetObjectStr(*ObjectUnderCursor);
 		if (pcursmonst != -1) {
 			if (leveltype != DTYPE_TOWN) {
 				const auto &monster = Monsters[pcursmonst];

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -200,7 +200,7 @@ void FindItemOrObject()
 		}
 
 		rotations = newRotations;
-		pcursobj = object->GetId();
+		ObjectUnderCursor = object;
 		cursPosition = targetPosition;
 	}
 }
@@ -417,7 +417,7 @@ void FindTrigger()
 	int rotations = 0;
 	int distance = 0;
 
-	if (pcursitem != -1 || pcursobj != -1)
+	if (pcursitem != -1 || ObjectUnderCursor != nullptr)
 		return; // Prefer showing items/objects over triggers (use of cursm* conflicts)
 
 	for (auto &missile : Missiles) {
@@ -521,7 +521,7 @@ void Interact()
 		return;
 	}
 
-	if (pcursobj != -1) {
+	if (ObjectUnderCursor != nullptr) {
 		NetSendCmdLoc(MyPlayerId, true, CMD_OPOBJXY, cursPosition);
 		LastMouseButtonAction = MouseActionType::OperateObject;
 		return;
@@ -1624,7 +1624,7 @@ void plrctrls_after_check_curs_move()
 	if (ControllerButtonHeld != ControllerButton_NONE && IsNoneOf(LastMouseButtonAction, MouseActionType::None, MouseActionType::Attack, MouseActionType::Spell)) {
 		InvalidateTargets();
 
-		if (pcursmonst == -1 && pcursobj == -1 && pcursitem == -1 && pcursinvitem == -1 && pcursstashitem == uint16_t(-1) && pcursplr == -1) {
+		if (pcursmonst == -1 && ObjectUnderCursor == nullptr && pcursitem == -1 && pcursinvitem == -1 && pcursstashitem == uint16_t(-1) && pcursplr == -1) {
 			FindTrigger();
 		}
 		return;
@@ -1634,7 +1634,7 @@ void plrctrls_after_check_curs_move()
 	pcursplr = -1;
 	pcursmonst = -1;
 	pcursitem = -1;
-	pcursobj = -1;
+	ObjectUnderCursor = nullptr;
 
 	pcursmissile = nullptr;
 	pcurstrig = -1;
@@ -1879,7 +1879,7 @@ void PerformSpellAction()
 	const Player &myPlayer = *MyPlayer;
 	int spl = myPlayer._pRSpell;
 	if ((pcursplr == -1 && (spl == SPL_RESURRECT || spl == SPL_HEALOTHER))
-	    || (pcursobj == -1 && spl == SPL_DISARM)) {
+	    || (ObjectUnderCursor == nullptr && spl == SPL_DISARM)) {
 		myPlayer.Say(HeroSpeech::ICantCastThatHere);
 		return;
 	}
@@ -1972,7 +1972,7 @@ void PerformSecondaryAction()
 
 	if (pcursitem != -1) {
 		NetSendCmdLocParam1(true, CMD_GOTOAGETITEM, cursPosition, pcursitem);
-	} else if (pcursobj != -1) {
+	} else if (ObjectUnderCursor != nullptr) {
 		NetSendCmdLoc(MyPlayerId, true, CMD_OPOBJXY, cursPosition);
 		LastMouseButtonAction = MouseActionType::OperateObject;
 	} else {

--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -445,7 +445,7 @@ VirtualGamepadButtonType SecondaryActionButtonRenderer::GetButtonType()
 	}
 	if (InGameMenu() || QuestLogIsOpen || sbookflag)
 		return GetBlankButtonType(virtualPadButton->isHeld);
-	if (pcursobj != -1)
+	if (ObjectUnderCursor != nullptr)
 		return GetObjectButtonType(virtualPadButton->isHeld);
 	if (pcursitem != -1)
 		return GetItemButtonType(virtualPadButton->isHeld);

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -120,7 +120,7 @@ uint16_t pcursstashitem;
 /** Current highlighted item */
 int8_t pcursitem;
 /** Current highlighted object */
-int8_t pcursobj;
+Object *ObjectUnderCursor;
 /** Current highlighted player */
 int8_t pcursplr;
 /** Current highlighted tile position */
@@ -226,7 +226,7 @@ void InitLevelCursor()
 	cursPosition = ViewPosition;
 	pcurstemp = -1;
 	pcursmonst = -1;
-	pcursobj = -1;
+	ObjectUnderCursor = nullptr;
 	pcursitem = -1;
 	pcursstashitem = uint16_t(-1);
 	pcursplr = -1;
@@ -361,7 +361,7 @@ void CheckCursMove()
 	if ((sgbMouseDown != CLICK_NONE || ControllerButtonHeld != ControllerButton_NONE) && IsNoneOf(LastMouseButtonAction, MouseActionType::None, MouseActionType::Attack, MouseActionType::Spell)) {
 		InvalidateTargets();
 
-		if (pcursmonst == -1 && pcursobj == -1 && pcursitem == -1 && pcursinvitem == -1 && pcursstashitem == uint16_t(-1) && pcursplr == -1) {
+		if (pcursmonst == -1 && ObjectUnderCursor == nullptr && pcursitem == -1 && pcursinvitem == -1 && pcursstashitem == uint16_t(-1) && pcursplr == -1) {
 			cursPosition = { mx, my };
 			CheckTrigForce();
 			CheckTown();
@@ -374,7 +374,7 @@ void CheckCursMove()
 
 	pcurstemp = pcursmonst;
 	pcursmonst = -1;
-	pcursobj = -1;
+	ObjectUnderCursor = nullptr;
 	pcursitem = -1;
 	if (pcursinvitem != -1) {
 		drawsbarflag = true;
@@ -634,10 +634,10 @@ void CheckCursMove()
 		if (object != nullptr) {
 			// found object that can be activated with the given cursor position
 			cursPosition = testPosition;
-			pcursobj = object->GetId();
+			ObjectUnderCursor = object;
 		}
 	}
-	if (pcursplr == -1 && pcursobj == -1 && pcursmonst == -1) {
+	if (pcursplr == -1 && ObjectUnderCursor == nullptr && pcursmonst == -1) {
 		if (!flipflag && mx + 1 < MAXDUNX && dItem[mx + 1][my] > 0) {
 			int8_t bv = dItem[mx + 1][my] - 1;
 			if (Items[bv]._iSelFlag >= 2) {
@@ -675,7 +675,7 @@ void CheckCursMove()
 	}
 
 	if (pcurs == CURSOR_IDENTIFY) {
-		pcursobj = -1;
+		ObjectUnderCursor = nullptr;
 		pcursmonst = -1;
 		pcursitem = -1;
 		cursPosition = { mx, my };

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -35,7 +35,10 @@ extern int pcursmonst;
 extern int8_t pcursinvitem;
 extern uint16_t pcursstashitem;
 extern int8_t pcursitem;
-extern int8_t pcursobj;
+
+struct Object; // Defined in objects.h
+extern Object *ObjectUnderCursor;
+
 extern int8_t pcursplr;
 extern Point cursPosition;
 extern DVL_API_FOR_TEST int pcurs;

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -238,7 +238,7 @@ void LeftMouseCmd(bool bShift)
 	bNear = myPlayer.position.tile.WalkingDistance(cursPosition) < 2;
 	if (pcursitem != -1 && pcurs == CURSOR_HAND && !bShift) {
 		NetSendCmdLocParam1(true, invflag ? CMD_GOTOGETITEM : CMD_GOTOAGETITEM, cursPosition, pcursitem);
-	} else if (pcursobj != -1 && !Objects[pcursobj].IsDisabled() && (!bShift || (bNear && Objects[pcursobj]._oBreak == 1))) {
+	} else if (ObjectUnderCursor != nullptr && !ObjectUnderCursor->IsDisabled() && (!bShift || (bNear && ObjectUnderCursor->_oBreak == 1))) {
 		LastMouseButtonAction = MouseActionType::OperateObject;
 		NetSendCmdLoc(MyPlayerId, true, pcurs == CURSOR_DISARM ? CMD_DISARMXY : CMD_OPOBJXY, cursPosition);
 	} else if (myPlayer.UsesRangedWeapon()) {
@@ -277,7 +277,7 @@ void LeftMouseCmd(bool bShift)
 			NetSendCmdParam1(true, CMD_ATTACKPID, pcursplr);
 		}
 	}
-	if (!bShift && pcursitem == -1 && pcursobj == -1 && pcursmonst == -1 && pcursplr == -1) {
+	if (!bShift && pcursitem == -1 && ObjectUnderCursor == nullptr && pcursmonst == -1 && pcursplr == -1) {
 		LastMouseButtonAction = MouseActionType::Walk;
 		NetSendCmdLoc(MyPlayerId, true, CMD_WALKXY, cursPosition);
 	}
@@ -1882,7 +1882,7 @@ bool TryIconCurs()
 		return true;
 	}
 
-	if (pcurs == CURSOR_DISARM && pcursobj == -1) {
+	if (pcurs == CURSOR_DISARM && ObjectUnderCursor == nullptr) {
 		NewCursor(CURSOR_HAND);
 		return true;
 	}
@@ -2319,7 +2319,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 
 	// Reset mouse selection of entities
 	pcursmonst = -1;
-	pcursobj = -1;
+	ObjectUnderCursor = nullptr;
 	pcursitem = -1;
 	pcursinvitem = -1;
 	pcursplr = -1;

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -634,7 +634,7 @@ void DrawObject(const Surface &out, Point tilePosition, Point targetBufferPositi
 	}
 
 	CelSprite cel { objectToDraw._oAnimData, objectToDraw._oAnimWidth };
-	if (pcursobj != -1 && &objectToDraw == &Objects[pcursobj]) {
+	if (&objectToDraw == ObjectUnderCursor) {
 		Cl2DrawOutlineSkipColorZero(out, 194, screenPosition, cel, nCel);
 	}
 	if (objectToDraw._oLight) {

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -2083,7 +2083,7 @@ void CloseInventory()
 
 void DoTelekinesis()
 {
-	if (pcursobj != -1)
+	if (ObjectUnderCursor != nullptr)
 		NetSendCmdLoc(MyPlayerId, true, CMD_OPOBJT, cursPosition);
 	if (pcursitem != -1)
 		NetSendCmdGItem(true, CMD_REQUESTAGITEM, MyPlayerId, pcursitem);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2394,7 +2394,7 @@ void AddDisarm(Missile &missile, const AddMissileParameter & /*parameter*/)
 	if (&player == MyPlayer) {
 		NewCursor(CURSOR_DISARM);
 		if (ControlMode != ControlTypes::KeyboardAndMouse) {
-			if (pcursobj != -1)
+			if (ObjectUnderCursor != nullptr)
 				NetSendCmdLoc(MyPlayerId, true, CMD_DISARMXY, cursPosition);
 			else
 				NewCursor(CURSOR_HAND);

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -973,13 +973,14 @@ void AddLazStand()
 
 void DeleteObject(int oi, int i)
 {
-	int ox = Objects[oi].position.x;
-	int oy = Objects[oi].position.y;
+	const Object &object = Objects[oi];
+	int ox = object.position.x;
+	int oy = object.position.y;
 	dObject[ox][oy] = 0;
 	AvailableObjects[-ActiveObjectCount + MAXOBJECTS] = oi;
 	ActiveObjectCount--;
-	if (pcursobj == oi) // Unselect object if this was highlighted by player
-		pcursobj = -1;
+	if (ObjectUnderCursor == &object) // Unselect object if this was highlighted by player
+		ObjectUnderCursor = nullptr;
 	if (ActiveObjectCount > 0 && i != ActiveObjectCount)
 		ActiveObjects[i] = ActiveObjects[ActiveObjectCount];
 }

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -46,10 +46,8 @@ void InvalidateTargets()
 		}
 	}
 
-	if (pcursobj != -1) {
-		if (Objects[pcursobj]._oSelFlag < 1)
-			pcursobj = -1;
-	}
+	if (ObjectUnderCursor != nullptr && ObjectUnderCursor->_oSelFlag < 1)
+		ObjectUnderCursor = nullptr;
 
 	if (pcursplr != -1) {
 		Player &targetPlayer = Players[pcursplr];
@@ -111,12 +109,9 @@ void RepeatMouseAction()
 			CheckPlrSpell(false);
 		break;
 	case MouseActionType::OperateObject:
-		if (pcursobj != -1) {
-			auto &object = Objects[pcursobj];
-			if (object.IsDoor())
-				break;
+		if (ObjectUnderCursor != nullptr && !ObjectUnderCursor->IsDoor()) {
 			// This should probably be cursPosition so paths to large objects are consistent
-			NetSendCmdLoc(MyPlayerId, true, CMD_OPOBJXY, object.position);
+			NetSendCmdLoc(MyPlayerId, true, CMD_OPOBJXY, ObjectUnderCursor->position);
 		}
 		break;
 	case MouseActionType::Walk:


### PR DESCRIPTION
This was mainly to remove uses of `Object::GetId` but with #4987 most uses are already gone. Maybe it's still worthwhile?

It's still used for two network messages and player.destParam1, need to refactor player actions and handle loading/saving before it can be completely removed.