### PR TITLE
Dedupe operate object message handlers, use position for break object

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1638,38 +1638,6 @@ size_t OnPlayerDamage(const TCmd *pCmd, Player &player)
 	return sizeof(message);
 }
 
-size_t OnOpenDoor(const TCmd *pCmd, int pnum)
-{
-	const auto &message = *reinterpret_cast<const TCmdParam1 *>(pCmd);
-
-	if (gbBufferMsgs == 1) {
-		SendPacket(pnum, &message, sizeof(message));
-	} else if (message.wParam1 < MAXOBJECTS) {
-		Player &player = Players[pnum];
-		if (player.isOnActiveLevel())
-			SyncOpObject(player, CMD_OPENDOOR, message.wParam1);
-		DeltaSyncObject(Objects[message.wParam1], CMD_OPENDOOR, player);
-	}
-
-	return sizeof(message);
-}
-
-size_t OnCloseDoor(const TCmd *pCmd, int pnum)
-{
-	const auto &message = *reinterpret_cast<const TCmdParam1 *>(pCmd);
-
-	if (gbBufferMsgs == 1) {
-		SendPacket(pnum, &message, sizeof(message));
-	} else if (message.wParam1 < MAXOBJECTS) {
-		Player &player = Players[pnum];
-		if (player.isOnActiveLevel())
-			SyncOpObject(player, CMD_CLOSEDOOR, message.wParam1);
-		DeltaSyncObject(Objects[message.wParam1], CMD_CLOSEDOOR, player);
-	}
-
-	return sizeof(message);
-}
-
 size_t OnOperateObject(const TCmd *pCmd, int pnum)
 {
 	const auto &message = *reinterpret_cast<const TCmdParam1 *>(pCmd);
@@ -1679,24 +1647,8 @@ size_t OnOperateObject(const TCmd *pCmd, int pnum)
 	} else if (message.wParam1 < MAXOBJECTS) {
 		Player &player = Players[pnum];
 		if (player.isOnActiveLevel())
-			SyncOpObject(player, CMD_OPERATEOBJ, message.wParam1);
-		DeltaSyncObject(Objects[message.wParam1], CMD_OPERATEOBJ, player);
-	}
-
-	return sizeof(message);
-}
-
-size_t OnPlayerOperateObject(const TCmd *pCmd, int pnum)
-{
-	const auto &message = *reinterpret_cast<const TCmdParam1 *>(pCmd);
-
-	if (gbBufferMsgs == 1) {
-		SendPacket(pnum, &message, sizeof(message));
-	} else if (message.wParam1 < MAXOBJECTS) {
-		Player &player = Players[pnum];
-		if (player.isOnActiveLevel())
-			SyncOpObject(player, CMD_PLROPOBJ, message.wParam1);
-		DeltaSyncObject(Objects[message.wParam1], CMD_PLROPOBJ, player);
+			SyncOpObject(player, message.bCmd, message.wParam1);
+		DeltaSyncObject(Objects[message.wParam1], message.bCmd, player);
 	}
 
 	return sizeof(message);
@@ -3042,13 +2994,10 @@ size_t ParseCmd(int pnum, const TCmd *pCmd)
 	case CMD_PLRDAMAGE:
 		return OnPlayerDamage(pCmd, player);
 	case CMD_OPENDOOR:
-		return OnOpenDoor(pCmd, pnum);
 	case CMD_CLOSEDOOR:
-		return OnCloseDoor(pCmd, pnum);
 	case CMD_OPERATEOBJ:
-		return OnOperateObject(pCmd, pnum);
 	case CMD_PLROPOBJ:
-		return OnPlayerOperateObject(pCmd, pnum);
+		return OnOperateObject(pCmd, pnum);
 	case CMD_BREAKOBJ:
 		return OnBreakObject(*pCmd, pnum);
 	case CMD_CHANGEPLRITEMS:

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1702,18 +1702,19 @@ size_t OnPlayerOperateObject(const TCmd *pCmd, int pnum)
 	return sizeof(message);
 }
 
-size_t OnBreakObject(const TCmd *pCmd, int pnum)
+size_t OnBreakObject(const TCmd &pCmd, int pnum)
 {
-	const auto &message = *reinterpret_cast<const TCmdParam1 *>(pCmd);
+	const auto &message = reinterpret_cast<const TCmdLoc &>(pCmd);
+	Object *breakable = ObjectAtPosition({ message.x, message.y });
 
 	if (gbBufferMsgs == 1) {
 		SendPacket(pnum, &message, sizeof(message));
-	} else if (message.wParam1 < MAXOBJECTS) {
+	} else if (breakable != nullptr) {
 		Player &player = Players[pnum];
 		if (player.isOnActiveLevel()) {
-			SyncBreakObj(player, Objects[message.wParam1]);
+			SyncBreakObj(player, *breakable);
 		}
-		DeltaSyncObject(Objects[message.wParam1], CMD_BREAKOBJ, player);
+		DeltaSyncObject(*breakable, CMD_BREAKOBJ, player);
 	}
 
 	return sizeof(message);

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -271,9 +271,9 @@ enum _cmd_id : uint8_t {
 	CMD_PLROPOBJ,
 	// Break object.
 	//
-	// body (TCmdParam2):
-	//    int16_t player_num
-	//    int16_t object_num
+	// body (TCmdLoc):
+	//    int8_t x
+	//    int8_t y
 	CMD_BREAKOBJ,
 	// Equip item for player.
 	//

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3858,7 +3858,7 @@ void BreakBarrel(const Player &player, Object &barrel, bool forcebreak, bool sen
 			SpawnSkeleton(&Monsters[barrel._oVar4], barrel.position);
 	}
 	if (&player == MyPlayer) {
-		NetSendCmdParam1(false, CMD_BREAKOBJ, static_cast<uint16_t>(barrel.GetId()));
+		NetSendCmdLoc(MyPlayerId, false, CMD_BREAKOBJ, barrel.position);
 	}
 }
 


### PR DESCRIPTION
These messages are handled almost identically, the only difference is the SyncBreakObject special case function. Prep to switch object messages over to position based instead of ID based.