### PR TITLE
Change exp member to uint32 to fix Diablo exp going overbounds

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -638,7 +638,7 @@ void LoadMonster(LoadHelper *file, Monster &monster)
 	monster.whoHit = file->NextLE<int8_t>();
 	monster.level = file->NextLE<int8_t>();
 	file->Skip(1); // Alignment
-	monster.exp = file->NextLE<uint16_t>();
+	monster.exp = file->NextLE<uint32_t>();
 
 	if ((monster.flags & MFLAG_GOLEM) != 0) // Don't skip for golems
 		monster.toHit = file->NextLE<uint8_t>();
@@ -1388,7 +1388,7 @@ void SaveMonster(SaveHelper *file, Monster &monster)
 	file->WriteLE<int8_t>(monster.whoHit);
 	file->WriteLE<int8_t>(monster.level);
 	file->Skip(1); // Alignment
-	file->WriteLE<uint16_t>(monster.exp);
+	file->WriteLE<uint32_t>(monster.exp);
 
 	file->WriteLE<uint8_t>(static_cast<uint8_t>(std::min<uint16_t>(monster.toHit, std::numeric_limits<uint8_t>::max()))); // For backwards compatibility
 	file->WriteLE<uint8_t>(monster.minDamage);

--- a/Source/monstdat.h
+++ b/Source/monstdat.h
@@ -129,7 +129,7 @@ struct MonsterData {
 	int8_t selectionType; // TODO Create enum
 	/** Using monster_treasure */
 	uint16_t treasure;
-	uint16_t exp;
+	uint32_t exp;
 };
 
 enum _monster_id : int16_t {

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -185,7 +185,7 @@ struct Monster { // note: missing field _mAFNum
 	uint32_t rndItemSeed;
 	/** Seed used to determine AI behaviour/sync sounds in multiplayer games? */
 	uint32_t aiSeed;
-	uint16_t exp;
+	uint32_t exp;
 	uint16_t toHit;
 	uint16_t toHitSpecial;
 	uint16_t resistance;


### PR DESCRIPTION
Changed exp member to uint32_t from uint16_t in monster data and monster. This is done to fix a bug where diablo exp goes overbounds on hell difficulty.

I make it as a draft, since it breaks previous saves and I don't know how to supply backwards compatibility. 

Also, I don't know if this change even makes sense, since as far as I know only diablo's exp behaves like that on hell, so maybe a simple fallback to max value of unit16_t is better?