### PR TITLE
OpenDingux rg350: Disable LTO

### DIFF
--- a/CMake/platforms/rg350.cmake
+++ b/CMake/platforms/rg350.cmake
@@ -1,6 +1,10 @@
 set(BUILD_ASSETS_MPQ OFF)
 set(USE_SDL1 ON)
 
+# LTO temporarily disabled to work around a compiler bug.
+# https://github.com/diasurgical/devilutionX/issues/4953
+set(DISABLE_LTO OFF)
+
 set(SDL1_VIDEO_MODE_BPP 8)
 set(SDL1_VIDEO_MODE_FLAGS SDL_HWSURFACE|SDL_TRIPLEBUF)
 set(SDL1_FORCE_SVID_VIDEO_MODE ON)


### PR DESCRIPTION
Thanks to @pcercuei we've learned that currently enabling LTO breaks the rg350 build.

Disable it for now.

Fixes #4953