### PR TITLE
OpenDingux: Fix lepus GitHub Action

### DIFF
--- a/.github/workflows/opendingux_release.yml
+++ b/.github/workflows/opendingux_release.yml
@@ -48,7 +48,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
   lepus:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
Updates to ubuntu-22.04 because ubuntu-latest (20.04) fails with:

> version `GLIBC_2.33' not found (required by /opt/lepus-toolchain/bin/mipsel-lepus-linux-musl-gcc.br_real)