### PR TITLE
Simplify MonsterOperateDoor

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4698,38 +4698,38 @@ void MonstCheckDoors(Monster &monster)
 	    || dObject[mx][my + 1] != 0
 	    || dObject[mx + 1][my + 1] != 0) {
 		for (int i = 0; i < ActiveObjectCount; i++) {
-			Object &object = Objects[ActiveObjects[i]];
-			if ((object._otype == OBJ_L1LDOOR || object._otype == OBJ_L1RDOOR) && object._oVar4 == 0) {
-				int dpx = abs(object.position.x - mx);
-				int dpy = abs(object.position.y - my);
-				if (dpx == 1 && dpy <= 1 && object._otype == OBJ_L1LDOOR)
-					OperateL1LDoor(object, true);
-				if (dpx <= 1 && dpy == 1 && object._otype == OBJ_L1RDOOR)
-					OperateL1RDoor(object, true);
+			// Assuming the object is a door, if it isn't none of the OperateDoor functions will actually be called and we just go to the next object.
+			Object &door = Objects[ActiveObjects[i]];
+
+			if (door._oVar4 != 0) {
+				// Door is not closed, don't need to try open it
+				continue;
 			}
-			if ((object._otype == OBJ_L2LDOOR || object._otype == OBJ_L2RDOOR) && object._oVar4 == 0) {
-				int dpx = abs(object.position.x - mx);
-				int dpy = abs(object.position.y - my);
-				if (dpx == 1 && dpy <= 1 && object._otype == OBJ_L2LDOOR)
-					OperateL2LDoor(object, true);
-				if (dpx <= 1 && dpy == 1 && object._otype == OBJ_L2RDOOR)
-					OperateL2RDoor(object, true);
+
+			// L3 doors are backwards, see OperateL3Door
+			int dpx = abs(door.position.x - mx);
+			int dpy = abs(door.position.y - my);
+			if (dpx == 1 && dpy <= 1) {
+				if (door._otype == OBJ_L1LDOOR) {
+					OperateL1LDoor(door, true);
+				} else if (door._otype == OBJ_L2LDOOR) {
+					OperateL2LDoor(door, true);
+				} else if (door._otype == OBJ_L3RDOOR) {
+					OperateL3RDoor(door, true);
+				} else if (door._otype == OBJ_L5LDOOR) {
+					OperateL5LDoor(door, true);
+				}
 			}
-			if ((object._otype == OBJ_L3LDOOR || object._otype == OBJ_L3RDOOR) && object._oVar4 == 0) {
-				int dpx = abs(object.position.x - mx);
-				int dpy = abs(object.position.y - my);
-				if (dpx == 1 && dpy <= 1 && object._otype == OBJ_L3RDOOR)
-					OperateL3RDoor(object, true);
-				if (dpx <= 1 && dpy == 1 && object._otype == OBJ_L3LDOOR)
-					OperateL3LDoor(object, true);
-			}
-			if ((object._otype == OBJ_L5LDOOR || object._otype == OBJ_L5RDOOR) && object._oVar4 == 0) {
-				int dpx = abs(object.position.x - mx);
-				int dpy = abs(object.position.y - my);
-				if (dpx == 1 && dpy <= 1 && object._otype == OBJ_L5LDOOR)
-					OperateL5LDoor(object, true);
-				if (dpx <= 1 && dpy == 1 && object._otype == OBJ_L5RDOOR)
-					OperateL5RDoor(object, true);
+			if (dpx <= 1 && dpy == 1) {
+				if (door._otype == OBJ_L1RDOOR) {
+					OperateL1RDoor(door, true);
+				} else if (door._otype == OBJ_L2RDOOR) {
+					OperateL2RDoor(door, true);
+				} else if (door._otype == OBJ_L3LDOOR) {
+					OperateL3LDoor(door, true);
+				} else if (door._otype == OBJ_L5RDOOR) {
+					OperateL5RDoor(door, true);
+				}
 			}
 		}
 	}

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4685,51 +4685,43 @@ void RedoPlayerVision()
 	}
 }
 
-void MonstCheckDoors(Monster &monster)
+void MonstCheckDoors(const Monster &monster)
 {
-	int mx = monster.position.tile.x;
-	int my = monster.position.tile.y;
-	if (dObject[mx - 1][my - 1] != 0
-	    || dObject[mx][my - 1] != 0
-	    || dObject[mx + 1][my - 1] != 0
-	    || dObject[mx - 1][my] != 0
-	    || dObject[mx + 1][my] != 0
-	    || dObject[mx - 1][my + 1] != 0
-	    || dObject[mx][my + 1] != 0
-	    || dObject[mx + 1][my + 1] != 0) {
-		for (int i = 0; i < ActiveObjectCount; i++) {
-			// Assuming the object is a door, if it isn't none of the OperateDoor functions will actually be called and we just go to the next object.
-			Object &door = Objects[ActiveObjects[i]];
+	for (Direction dir : { Direction::NorthEast, Direction::SouthWest, Direction::North, Direction::East, Direction::South, Direction::West, Direction::NorthWest, Direction::SouthEast }) {
+		Object *object = ObjectAtPosition(monster.position.tile + dir);
+		if (object == nullptr)
+			continue;
 
-			if (door._oVar4 != 0) {
-				// Door is not closed, don't need to try open it
-				continue;
-			}
+		Object &door = *object;
+		// Doors use _oVar4 to track open/closed state, non-zero values indicate an open door
+		// we don't use Object::isDoor since the later conditions will check the object is actually a door anyway.
+		if (door._oVar4 != 0)
+			continue;
 
-			// L3 doors are backwards, see OperateL3Door
-			int dpx = abs(door.position.x - mx);
-			int dpy = abs(door.position.y - my);
-			if (dpx == 1 && dpy <= 1) {
-				if (door._otype == OBJ_L1LDOOR) {
-					OperateL1LDoor(door, true);
-				} else if (door._otype == OBJ_L2LDOOR) {
-					OperateL2LDoor(door, true);
-				} else if (door._otype == OBJ_L3RDOOR) {
-					OperateL3RDoor(door, true);
-				} else if (door._otype == OBJ_L5LDOOR) {
-					OperateL5LDoor(door, true);
-				}
+		// Strictly speaking these checks shouldn't be required, they're guarding against monsters
+		// standing in a wall opening an adjacent door. Shouldn't be possible?
+		if (IsNoneOf(dir, Direction::NorthEast, Direction::SouthWest)) {
+			if (door._otype == OBJ_L1LDOOR) {
+				OperateL1LDoor(door, true);
+			} else if (door._otype == OBJ_L2LDOOR) {
+				OperateL2LDoor(door, true);
+			} else if (door._otype == OBJ_L3RDOOR) {
+				// L3 doors are backwards, see OperateL3Door
+				OperateL3RDoor(door, true);
+			} else if (door._otype == OBJ_L5LDOOR) {
+				OperateL5LDoor(door, true);
 			}
-			if (dpx <= 1 && dpy == 1) {
-				if (door._otype == OBJ_L1RDOOR) {
-					OperateL1RDoor(door, true);
-				} else if (door._otype == OBJ_L2RDOOR) {
-					OperateL2RDoor(door, true);
-				} else if (door._otype == OBJ_L3LDOOR) {
-					OperateL3LDoor(door, true);
-				} else if (door._otype == OBJ_L5RDOOR) {
-					OperateL5RDoor(door, true);
-				}
+		}
+		if (IsNoneOf(dir, Direction::NorthWest, Direction::SouthEast)) {
+			if (door._otype == OBJ_L1RDOOR) {
+				OperateL1RDoor(door, true);
+			} else if (door._otype == OBJ_L2RDOOR) {
+				OperateL2RDoor(door, true);
+			} else if (door._otype == OBJ_L3LDOOR) {
+				// L3 doors are backwards, see OperateL3Door
+				OperateL3LDoor(door, true);
+			} else if (door._otype == OBJ_L5RDOOR) {
+				OperateL5RDoor(door, true);
 			}
 		}
 	}

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -301,7 +301,7 @@ void AddObject(_object_id objType, Point objPos);
 void OperateTrap(Object &trap);
 void ProcessObjects();
 void RedoPlayerVision();
-void MonstCheckDoors(Monster &monster);
+void MonstCheckDoors(const Monster &monster);
 void ObjChangeMap(int x1, int y1, int x2, int y2);
 void ObjChangeMapResync(int x1, int y1, int x2, int y2);
 int ItemMiscIdIdx(item_misc_id imiscid);


### PR DESCRIPTION
No real need to loop over all level objects when we already check based on position, can just use ObjectAtPosition instead.

It could also use `considerLargeObjects = false` but doors are single tile objects anyway so I don't think it's necessary, makes the call simpler.