### PR TITLE
Add helper to check if a monster belongs to a player

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -230,7 +230,7 @@ bool CanTargetMonster(const Monster &monster)
 {
 	if ((monster.flags & MFLAG_HIDDEN) != 0)
 		return false;
-	if (monster.ai == AI_GOLUM)
+	if (monster.isPlayerMinion())
 		return false;
 	if (monster.hitPoints >> 6 <= 0) // dead
 		return false;

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -469,7 +469,7 @@ void CheckCursMove()
 				pcursmonst = -1;
 				cursPosition = { mx, my };
 			}
-			if (pcursmonst != -1 && (Monsters[pcursmonst].flags & MFLAG_GOLEM) != 0 && (Monsters[pcursmonst].flags & MFLAG_BERSERK) == 0) {
+			if (pcursmonst != -1 && Monsters[pcursmonst].isPlayerMinion()) {
 				pcursmonst = -1;
 			}
 			if (pcursmonst != -1) {
@@ -529,7 +529,7 @@ void CheckCursMove()
 			pcursmonst = -1;
 			cursPosition = { mx, my };
 		}
-		if (pcursmonst != -1 && (Monsters[pcursmonst].flags & MFLAG_GOLEM) != 0 && (Monsters[pcursmonst].flags & MFLAG_BERSERK) == 0) {
+		if (pcursmonst != -1 && Monsters[pcursmonst].isPlayerMinion()) {
 			pcursmonst = -1;
 		}
 	} else {
@@ -680,7 +680,7 @@ void CheckCursMove()
 		pcursitem = -1;
 		cursPosition = { mx, my };
 	}
-	if (pcursmonst != -1 && (Monsters[pcursmonst].flags & MFLAG_GOLEM) != 0 && (Monsters[pcursmonst].flags & MFLAG_BERSERK) == 0) {
+	if (pcursmonst != -1 && Monsters[pcursmonst].isPlayerMinion()) {
 		pcursmonst = -1;
 	}
 }

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -640,7 +640,7 @@ void LoadMonster(LoadHelper *file, Monster &monster)
 	file->Skip(1); // Alignment
 	monster.exp = file->NextLE<uint16_t>();
 
-	if ((monster.flags & MFLAG_GOLEM) != 0) // Don't skip for golems
+	if (monster.isPlayerMinion()) // Don't skip for golems
 		monster.toHit = file->NextLE<uint8_t>();
 	else
 		file->Skip(1); // Skip hit as it's already initialized

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -338,6 +338,12 @@ struct Monster { // note: missing field _mAFNum
 	bool isWalking() const;
 	bool isImmune(missile_id mitype) const;
 	bool isResistant(missile_id mitype) const;
+
+	/**
+	 * Is this a player's golem?
+	 */
+	[[nodiscard]] bool isPlayerMinion() const;
+
 	bool isPossibleToHit() const;
 
 	[[nodiscard]] bool isUnique() const


### PR DESCRIPTION
Spawned from the discussion in #5072, but relevant to the chat in discord around berserked monsters as well?

Please note I haven't captured every use of MFLAG_GOLEM and/or MT_GOLEM as some contexts I think still need to handle garbage data (like saves with golems in slots 4-19 from before #2822 was fixed).