### PR TITLE
Update mWhoHit and remote clients when hitting resistant monsters

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -285,6 +285,12 @@ bool MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, missile_id t
 		}
 	} else {
 		if (resist) {
+			if (pnum >= 0)
+				monster.mWhoHit |= 1 << pnum;
+			if (pnum == MyPlayerId) {
+				delta_monster_hp(m, monster._mhitpoints, currlevel);
+				NetSendCmdMonDmg(false, m, dam);
+			}
 			PlayEffect(monster, 1);
 		} else if (monster._mmode == MonsterMode::Petrified) {
 			if (m > MAX_PLRS - 1)


### PR DESCRIPTION
This merely copies the logic from `M_StartHit()` to the branch that runs when the monster resists the damage. This is a minimally invasive change for 1.4.1. For 1.5.0, I think it would be better to consolidate the logic between `HitMonster()`, `M_StartHit()`, and this branch of the logic.