### PR TITLE
:recycle: MonsterAttackPlayer receives monster and player as references

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1236,13 +1236,8 @@ void CheckReflect(Monster &monster, Player &player, int dam)
 		M_StartHit(monster, player, mdam);
 }
 
-void MonsterAttackPlayer(int monsterId, int pnum, int hit, int minDam, int maxDam)
+void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, int maxDam)
 {
-	assert(static_cast<size_t>(monsterId) < MaxMonsters);
-	auto &monster = Monsters[monsterId];
-
-	Player &player = Players[pnum];
-
 	if (player._pHitPoints >> 6 <= 0 || player._pInvincible || HasAnyOf(player._pSpellFlags, SpellFlag::Etherealize))
 		return;
 	if (monster.position.tile.WalkingDistance(player.position.tile) >= 2)
@@ -1336,7 +1331,7 @@ void MonsterAttackPlayer(int monsterId, int pnum, int hit, int minDam, int maxDa
 			player.position.tile = newPosition;
 			FixPlayerLocation(player, player._pdir);
 			FixPlrWalkTags(player);
-			dPlayer[newPosition.x][newPosition.y] = pnum + 1;
+			dPlayer[newPosition.x][newPosition.y] = player.getId() + 1;
 			SetPlayerOld(player);
 		}
 	}
@@ -1351,7 +1346,7 @@ bool MonsterAttack(int monsterId)
 		if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0)
 			MonsterAttackMonster(monster, Monsters[monster.enemy], monster.toHit, monster.minDamage, monster.maxDamage);
 		else
-			MonsterAttackPlayer(monsterId, monster.enemy, monster.toHit, monster.minDamage, monster.maxDamage);
+			MonsterAttackPlayer(monster, Players[monster.enemy], monster.toHit, monster.minDamage, monster.maxDamage);
 		if (monster.ai != AI_SNAKE)
 			PlayEffect(monster, 0);
 	}
@@ -1359,7 +1354,7 @@ bool MonsterAttack(int monsterId)
 		if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0)
 			MonsterAttackMonster(monster, Monsters[monster.enemy], monster.toHit + 10, monster.minDamage - 2, monster.maxDamage - 2);
 		else
-			MonsterAttackPlayer(monsterId, monster.enemy, monster.toHit + 10, monster.minDamage - 2, monster.maxDamage - 2);
+			MonsterAttackPlayer(monster, Players[monster.enemy], monster.toHit + 10, monster.minDamage - 2, monster.maxDamage - 2);
 
 		PlayEffect(monster, 0);
 	}
@@ -1367,7 +1362,7 @@ bool MonsterAttack(int monsterId)
 		if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0)
 			MonsterAttackMonster(monster, Monsters[monster.enemy], monster.toHit - 20, monster.minDamage + 4, monster.maxDamage + 4);
 		else
-			MonsterAttackPlayer(monsterId, monster.enemy, monster.toHit - 20, monster.minDamage + 4, monster.maxDamage + 4);
+			MonsterAttackPlayer(monster, Players[monster.enemy], monster.toHit - 20, monster.minDamage + 4, monster.maxDamage + 4);
 
 		PlayEffect(monster, 0);
 	}
@@ -1457,7 +1452,7 @@ bool MonsterSpecialAttack(int monsterId)
 		if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0)
 			MonsterAttackMonster(monster, Monsters[monster.enemy], monster.toHitSpecial, monster.minDamageSpecial, monster.maxDamageSpecial);
 		else
-			MonsterAttackPlayer(monsterId, monster.enemy, monster.toHitSpecial, monster.minDamageSpecial, monster.maxDamageSpecial);
+			MonsterAttackPlayer(monster, Players[monster.enemy], monster.toHitSpecial, monster.minDamageSpecial, monster.maxDamageSpecial);
 	}
 
 	if (monster.animInfo.currentFrame == monster.animInfo.numberOfFrames - 1) {
@@ -4562,12 +4557,12 @@ void MissToMonst(Missile &missile, Point position)
 			return;
 
 		int pnum = dPlayer[oldPosition.x][oldPosition.y] - 1;
-		MonsterAttackPlayer(monsterId, pnum, 500, monster.minDamageSpecial, monster.maxDamageSpecial);
+		Player &player = Players[pnum];
+		MonsterAttackPlayer(monster, player, 500, monster.minDamageSpecial, monster.maxDamageSpecial);
 
 		if (IsAnyOf(monster.type().type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE))
 			return;
 
-		Player &player = Players[pnum];
 		if (player._pmode != PM_GOTHIT && player._pmode != PM_DEATH)
 			StartPlrHit(player, 0, true);
 		Point newPosition = oldPosition + monster.direction;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1403,11 +1403,8 @@ bool MonsterRangedAttack(Monster &monster)
 	return false;
 }
 
-bool MonsterRangedSpecialAttack(int monsterId)
+bool MonsterRangedSpecialAttack(Monster &monster)
 {
-	assert(static_cast<size_t>(monsterId) < MaxMonsters);
-	auto &monster = Monsters[monsterId];
-
 	if (monster.animInfo.currentFrame == monster.data().animFrameNumSpecial - 1 && monster.animInfo.tickCounterOfCurrentFrame == 0 && (monster.ai != AI_MEGA || monster.var2 == 0)) {
 		if (AddMissile(
 		        monster.position.tile,
@@ -1415,7 +1412,7 @@ bool MonsterRangedSpecialAttack(int monsterId)
 		        monster.direction,
 		        static_cast<missile_id>(monster.var1),
 		        TARGET_PLAYERS,
-		        monsterId,
+		        monster.getId(),
 		        monster.var3,
 		        0)
 		    != nullptr) {
@@ -3272,7 +3269,7 @@ bool UpdateModeStance(int monsterId)
 	case MonsterMode::SpecialStand:
 		return MonsterSpecialStand(monster);
 	case MonsterMode::SpecialRangedAttack:
-		return MonsterRangedSpecialAttack(monsterId);
+		return MonsterRangedSpecialAttack(monster);
 	case MonsterMode::Delay:
 		return MonsterDelay(monster);
 	case MonsterMode::Petrified:

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1345,11 +1345,8 @@ void MonsterAttackEnemy(Monster &monster, int hit, int minDam, int maxDam)
 		MonsterAttackPlayer(monster, Players[monster.enemy], monster.toHit, monster.minDamage, monster.maxDamage);
 }
 
-bool MonsterAttack(int monsterId)
+bool MonsterAttack(Monster &monster)
 {
-	assert(static_cast<size_t>(monsterId) < MaxMonsters);
-	auto &monster = Monsters[monsterId];
-
 	if (monster.animInfo.currentFrame == monster.data().animFrameNum - 1) {
 		MonsterAttackEnemy(monster, monster.toHit, monster.minDamage, monster.maxDamage);
 		if (monster.ai != AI_SNAKE)
@@ -3261,7 +3258,7 @@ bool UpdateModeStance(int monsterId)
 	case MonsterMode::MoveSideways:
 		return MonsterWalk(monster, monster.mode);
 	case MonsterMode::MeleeAttack:
-		return MonsterAttack(monsterId);
+		return MonsterAttack(monster);
 	case MonsterMode::HitRecovery:
 		return MonsterGotHit(monster);
 	case MonsterMode::Death:

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1194,12 +1194,8 @@ bool MonsterWalk(Monster &monster, MonsterMode variant)
 	return isAnimationEnd;
 }
 
-void MonsterAttackMonster(int i, int mid, int hper, int mind, int maxd)
+void MonsterAttackMonster(Monster &attacker, Monster &target, int hper, int mind, int maxd)
 {
-	assert(static_cast<size_t>(mid) < MaxMonsters);
-	auto &target = Monsters[mid];
-	Monster &attacker = Monsters[i];
-
 	if (!target.isPossibleToHit())
 		return;
 
@@ -1246,7 +1242,7 @@ void MonsterAttackPlayer(int monsterId, int pnum, int hit, int minDam, int maxDa
 	auto &monster = Monsters[monsterId];
 
 	if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0) {
-		MonsterAttackMonster(monsterId, pnum, hit, minDam, maxDam);
+		MonsterAttackMonster(monster, Monsters[pnum], hit, minDam, maxDam);
 		return;
 	}
 
@@ -4578,14 +4574,14 @@ void MissToMonst(Missile &missile, Point position)
 	if (dMonster[oldPosition.x][oldPosition.y] <= 0)
 		return;
 
-	int mid = dMonster[oldPosition.x][oldPosition.y] - 1;
-	MonsterAttackMonster(monsterId, mid, 500, monster.minDamageSpecial, monster.maxDamageSpecial);
+	Monster &target = *MonsterAtPosition(oldPosition);
+	MonsterAttackMonster(monster, target, 500, monster.minDamageSpecial, monster.maxDamageSpecial);
 
 	if (IsAnyOf(monster.type().type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE))
 		return;
 
 	Point newPosition = oldPosition + monster.direction;
-	if (IsTileAvailable(Monsters[mid], newPosition)) {
+	if (IsTileAvailable(target, newPosition)) {
 		monsterId = dMonster[oldPosition.x][oldPosition.y];
 		dMonster[newPosition.x][newPosition.y] = monsterId;
 		dMonster[oldPosition.x][oldPosition.y] = 0;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3239,10 +3239,8 @@ bool IsMonsterAvalible(const MonsterData &monsterData)
 	return currlevel >= monsterData.minDunLvl && currlevel <= monsterData.maxDunLvl;
 }
 
-bool UpdateModeStance(int monsterId)
+bool UpdateModeStance(Monster &monster)
 {
-	Monster &monster = Monsters[monsterId];
-
 	switch (monster.mode) {
 	case MonsterMode::Stand:
 		MonsterIdle(monster);
@@ -4189,7 +4187,7 @@ void ProcessMonsters()
 				AiProc[monster.ai](monsterId);
 			}
 
-			if (!UpdateModeStance(monsterId))
+			if (!UpdateModeStance(monster))
 				break;
 
 			GroupUnity(monster);

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1197,31 +1197,31 @@ bool MonsterWalk(Monster &monster, MonsterMode variant)
 void MonsterAttackMonster(int i, int mid, int hper, int mind, int maxd)
 {
 	assert(static_cast<size_t>(mid) < MaxMonsters);
-	auto &monster = Monsters[mid];
+	auto &target = Monsters[mid];
 	Monster &attacker = Monsters[i];
 
-	if (!monster.isPossibleToHit())
+	if (!target.isPossibleToHit())
 		return;
 
 	int hit = GenerateRnd(100);
-	if (monster.mode == MonsterMode::Petrified)
+	if (target.mode == MonsterMode::Petrified)
 		hit = 0;
-	if (monster.tryLiftGargoyle())
+	if (target.tryLiftGargoyle())
 		return;
 	if (hit >= hper)
 		return;
 
 	int dam = (mind + GenerateRnd(maxd - mind + 1)) << 6;
-	monster.hitPoints -= dam;
-	if (monster.hitPoints >> 6 <= 0) {
-		StartDeathFromMonster(attacker, monster);
+	target.hitPoints -= dam;
+	if (target.hitPoints >> 6 <= 0) {
+		StartDeathFromMonster(attacker, target);
 	} else {
-		MonsterHitMonster(attacker, monster, dam);
+		MonsterHitMonster(attacker, target, dam);
 	}
 
-	if (monster.activeForTicks == 0) {
-		monster.activeForTicks = UINT8_MAX;
-		monster.position.last = attacker.position.tile;
+	if (target.activeForTicks == 0) {
+		target.activeForTicks = UINT8_MAX;
+		target.position.last = attacker.position.tile;
 	}
 }
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1241,11 +1241,6 @@ void MonsterAttackPlayer(int monsterId, int pnum, int hit, int minDam, int maxDa
 	assert(static_cast<size_t>(monsterId) < MaxMonsters);
 	auto &monster = Monsters[monsterId];
 
-	if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0) {
-		MonsterAttackMonster(monster, Monsters[pnum], hit, minDam, maxDam);
-		return;
-	}
-
 	Player &player = Players[pnum];
 
 	if (player._pHitPoints >> 6 <= 0 || player._pInvincible || HasAnyOf(player._pSpellFlags, SpellFlag::Etherealize))
@@ -1353,16 +1348,27 @@ bool MonsterAttack(int monsterId)
 	auto &monster = Monsters[monsterId];
 
 	if (monster.animInfo.currentFrame == monster.data().animFrameNum - 1) {
-		MonsterAttackPlayer(monsterId, monster.enemy, monster.toHit, monster.minDamage, monster.maxDamage);
+		if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0)
+			MonsterAttackMonster(monster, Monsters[monster.enemy], monster.toHit, monster.minDamage, monster.maxDamage);
+		else
+			MonsterAttackPlayer(monsterId, monster.enemy, monster.toHit, monster.minDamage, monster.maxDamage);
 		if (monster.ai != AI_SNAKE)
 			PlayEffect(monster, 0);
 	}
 	if (IsAnyOf(monster.type().type, MT_NMAGMA, MT_YMAGMA, MT_BMAGMA, MT_WMAGMA) && monster.animInfo.currentFrame == 8) {
-		MonsterAttackPlayer(monsterId, monster.enemy, monster.toHit + 10, monster.minDamage - 2, monster.maxDamage - 2);
+		if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0)
+			MonsterAttackMonster(monster, Monsters[monster.enemy], monster.toHit + 10, monster.minDamage - 2, monster.maxDamage - 2);
+		else
+			MonsterAttackPlayer(monsterId, monster.enemy, monster.toHit + 10, monster.minDamage - 2, monster.maxDamage - 2);
+
 		PlayEffect(monster, 0);
 	}
 	if (IsAnyOf(monster.type().type, MT_STORM, MT_RSTORM, MT_STORML, MT_MAEL) && monster.animInfo.currentFrame == 12) {
-		MonsterAttackPlayer(monsterId, monster.enemy, monster.toHit - 20, monster.minDamage + 4, monster.maxDamage + 4);
+		if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0)
+			MonsterAttackMonster(monster, Monsters[monster.enemy], monster.toHit - 20, monster.minDamage + 4, monster.maxDamage + 4);
+		else
+			MonsterAttackPlayer(monsterId, monster.enemy, monster.toHit - 20, monster.minDamage + 4, monster.maxDamage + 4);
+
 		PlayEffect(monster, 0);
 	}
 	if (monster.ai == AI_SNAKE && monster.animInfo.currentFrame == 0)
@@ -1447,8 +1453,12 @@ bool MonsterSpecialAttack(int monsterId)
 	assert(static_cast<size_t>(monsterId) < MaxMonsters);
 	auto &monster = Monsters[monsterId];
 
-	if (monster.animInfo.currentFrame == monster.data().animFrameNumSpecial - 1)
-		MonsterAttackPlayer(monsterId, monster.enemy, monster.toHitSpecial, monster.minDamageSpecial, monster.maxDamageSpecial);
+	if (monster.animInfo.currentFrame == monster.data().animFrameNumSpecial - 1) {
+		if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0)
+			MonsterAttackMonster(monster, Monsters[monster.enemy], monster.toHitSpecial, monster.minDamageSpecial, monster.maxDamageSpecial);
+		else
+			MonsterAttackPlayer(monsterId, monster.enemy, monster.toHitSpecial, monster.minDamageSpecial, monster.maxDamageSpecial);
+	}
 
 	if (monster.animInfo.currentFrame == monster.animInfo.numberOfFrames - 1) {
 		M_StartStand(monster, monster.direction);

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1225,10 +1225,8 @@ void MonsterAttackMonster(int i, int mid, int hper, int mind, int maxd)
 	}
 }
 
-void CheckReflect(Monster &monster, int pnum, int dam)
+void CheckReflect(Monster &monster, Player &player, int dam)
 {
-	Player &player = Players[pnum];
-
 	player.wReflections--;
 	if (player.wReflections <= 0)
 		NetSendCmdParam1(true, CMD_SETREFLECT, 0);
@@ -1294,7 +1292,7 @@ void MonsterAttackPlayer(int monsterId, int pnum, int hit, int minDam, int maxDa
 		if (&player == MyPlayer && player.wReflections > 0) {
 			int dam = GenerateRnd(((maxDam - minDam) << 6) + 1) + (minDam << 6);
 			dam = std::max(dam + (player._pIGetHit << 6), 64);
-			CheckReflect(monster, pnum, dam);
+			CheckReflect(monster, player, dam);
 		}
 		return;
 	}
@@ -1316,7 +1314,7 @@ void MonsterAttackPlayer(int monsterId, int pnum, int hit, int minDam, int maxDa
 	dam = std::max(dam + (player._pIGetHit << 6), 64);
 	if (&player == MyPlayer) {
 		if (player.wReflections > 0)
-			CheckReflect(monster, pnum, dam);
+			CheckReflect(monster, player, dam);
 		ApplyPlrDamage(player, 0, 0, dam);
 	}
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1337,32 +1337,31 @@ void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, 
 	}
 }
 
+void MonsterAttackEnemy(Monster &monster, int hit, int minDam, int maxDam)
+{
+	if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0)
+		MonsterAttackMonster(monster, Monsters[monster.enemy], monster.toHit, monster.minDamage, monster.maxDamage);
+	else
+		MonsterAttackPlayer(monster, Players[monster.enemy], monster.toHit, monster.minDamage, monster.maxDamage);
+}
+
 bool MonsterAttack(int monsterId)
 {
 	assert(static_cast<size_t>(monsterId) < MaxMonsters);
 	auto &monster = Monsters[monsterId];
 
 	if (monster.animInfo.currentFrame == monster.data().animFrameNum - 1) {
-		if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0)
-			MonsterAttackMonster(monster, Monsters[monster.enemy], monster.toHit, monster.minDamage, monster.maxDamage);
-		else
-			MonsterAttackPlayer(monster, Players[monster.enemy], monster.toHit, monster.minDamage, monster.maxDamage);
+		MonsterAttackEnemy(monster, monster.toHit, monster.minDamage, monster.maxDamage);
 		if (monster.ai != AI_SNAKE)
 			PlayEffect(monster, 0);
 	}
 	if (IsAnyOf(monster.type().type, MT_NMAGMA, MT_YMAGMA, MT_BMAGMA, MT_WMAGMA) && monster.animInfo.currentFrame == 8) {
-		if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0)
-			MonsterAttackMonster(monster, Monsters[monster.enemy], monster.toHit + 10, monster.minDamage - 2, monster.maxDamage - 2);
-		else
-			MonsterAttackPlayer(monster, Players[monster.enemy], monster.toHit + 10, monster.minDamage - 2, monster.maxDamage - 2);
+		MonsterAttackEnemy(monster, monster.toHit + 10, monster.minDamage - 2, monster.maxDamage - 2);
 
 		PlayEffect(monster, 0);
 	}
 	if (IsAnyOf(monster.type().type, MT_STORM, MT_RSTORM, MT_STORML, MT_MAEL) && monster.animInfo.currentFrame == 12) {
-		if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0)
-			MonsterAttackMonster(monster, Monsters[monster.enemy], monster.toHit - 20, monster.minDamage + 4, monster.maxDamage + 4);
-		else
-			MonsterAttackPlayer(monster, Players[monster.enemy], monster.toHit - 20, monster.minDamage + 4, monster.maxDamage + 4);
+		MonsterAttackEnemy(monster, monster.toHit - 20, monster.minDamage + 4, monster.maxDamage + 4);
 
 		PlayEffect(monster, 0);
 	}
@@ -1449,10 +1448,7 @@ bool MonsterSpecialAttack(int monsterId)
 	auto &monster = Monsters[monsterId];
 
 	if (monster.animInfo.currentFrame == monster.data().animFrameNumSpecial - 1) {
-		if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0)
-			MonsterAttackMonster(monster, Monsters[monster.enemy], monster.toHitSpecial, monster.minDamageSpecial, monster.maxDamageSpecial);
-		else
-			MonsterAttackPlayer(monster, Players[monster.enemy], monster.toHitSpecial, monster.minDamageSpecial, monster.maxDamageSpecial);
+		MonsterAttackEnemy(monster, monster.toHitSpecial, monster.minDamageSpecial, monster.maxDamageSpecial);
 	}
 
 	if (monster.animInfo.currentFrame == monster.animInfo.numberOfFrames - 1) {

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1439,11 +1439,8 @@ bool MonsterRangedSpecialAttack(int monsterId)
 	return false;
 }
 
-bool MonsterSpecialAttack(int monsterId)
+bool MonsterSpecialAttack(Monster &monster)
 {
-	assert(static_cast<size_t>(monsterId) < MaxMonsters);
-	auto &monster = Monsters[monsterId];
-
 	if (monster.animInfo.currentFrame == monster.data().animFrameNumSpecial - 1) {
 		MonsterAttackEnemy(monster, monster.toHitSpecial, monster.minDamageSpecial, monster.maxDamageSpecial);
 	}
@@ -3265,7 +3262,7 @@ bool UpdateModeStance(int monsterId)
 		MonsterDeath(monster);
 		return false;
 	case MonsterMode::SpecialMeleeAttack:
-		return MonsterSpecialAttack(monsterId);
+		return MonsterSpecialAttack(monster);
 	case MonsterMode::FadeIn:
 		return MonsterFadein(monster);
 	case MonsterMode::FadeOut:

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1198,7 +1198,7 @@ void MonsterAttackMonster(int i, int mid, int hper, int mind, int maxd)
 {
 	assert(static_cast<size_t>(mid) < MaxMonsters);
 	auto &monster = Monsters[mid];
-	Monster &attackingMonster = Monsters[i];
+	Monster &attacker = Monsters[i];
 
 	if (!monster.isPossibleToHit())
 		return;
@@ -1214,14 +1214,14 @@ void MonsterAttackMonster(int i, int mid, int hper, int mind, int maxd)
 	int dam = (mind + GenerateRnd(maxd - mind + 1)) << 6;
 	monster.hitPoints -= dam;
 	if (monster.hitPoints >> 6 <= 0) {
-		StartDeathFromMonster(attackingMonster, monster);
+		StartDeathFromMonster(attacker, monster);
 	} else {
-		MonsterHitMonster(attackingMonster, monster, dam);
+		MonsterHitMonster(attacker, monster, dam);
 	}
 
 	if (monster.activeForTicks == 0) {
 		monster.activeForTicks = UINT8_MAX;
-		monster.position.last = attackingMonster.position.tile;
+		monster.position.last = attacker.position.tile;
 	}
 }
 


### PR DESCRIPTION
- ♻️  [pass the Player reference to CheckReflect](https://github.com/diasurgical/devilutionX/commit/8c92bddf5fa57794b929dc086b9d9a8d93ca9e22)
- 🚚 [Rename attackingMonster to attacker](https://github.com/diasurgical/devilutionX/commit/8523f9468cfda9e6d713b961f856d38b9bc11ed9)
- 🚚 [Rename monster to target](https://github.com/diasurgical/devilutionX/commit/b873945d7860fd1fd7a8533a34e50188722139b9)
- ♻️  [pass the attacker and target as reference to MonsterAttackMonster](https://github.com/diasurgical/devilutionX/commit/7cb343f5f044a3a64098025cd498a9bcb7874e85)
- ♻️  [MonsterAttackPlayer only takes players as target](https://github.com/diasurgical/devilutionX/commit/ec4f4f124d589b31adb2d2784f5e2cf59e777350)
- ♻️  [MonsterAttackPlayer receives player and monster as references](https://github.com/diasurgical/devilutionX/commit/d7d7af77c9c26486389ca27074e1d2e19f33976d)
- ♻️ [MonsterAttack receives monster reference](https://github.com/diasurgical/devilutionX/pull/5111/commits/a4d9f35d2934b9e70cfe593aaa2d70926ac7df79)
- ♻️  [MonsterSpecialAttack receives monster reference](https://github.com/diasurgical/devilutionX/pull/5111/commits/78caca3ec02e4356b4bb715141d2f64122bffc74)
- ♻️  [MonsterRangedSpecialAttack receives monster reference](https://github.com/diasurgical/devilutionX/pull/5111/commits/74915b9263941e14f6045b8915cc5c327c4c23e1)
- ♻️  [UpdateModeStance receives monster reference](https://github.com/diasurgical/devilutionX/pull/5111/commits/9bc585473062e691d65bee57126de8dd08442d83)