### PR TITLE
Bump NDK version

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -26,11 +26,6 @@ jobs:
         distribution: 'adopt'
         cache: gradle
 
-    # CMake version 3.21.3 causes gradle to throw a NullPointerException during the build
-    # Removing it will cause gradle to fall back on 3.18.1 installed by the Android SDK
-    - name: Create Build Environment
-      run: rm /usr/local/bin/cmake
-
     - name: Cache CMake build folder
       uses: actions/cache@v2
       with:

--- a/CMake/platforms/android.cmake
+++ b/CMake/platforms/android.cmake
@@ -25,8 +25,3 @@ set(UBSAN OFF)
 
 # Disable in-game options to exit the game.
 set(NOEXIT ON)
-
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
-  # Work around a linker bug in clang: https://github.com/android/ndk/issues/721
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -flto=full")
-endif()

--- a/android-project/app/build.gradle
+++ b/android-project/app/build.gradle
@@ -7,6 +7,9 @@ if (buildAsApplication) {
 }
 
 android {
+	//ndkVersion '25.0.8775105'
+	//ndkVersion '24.0.8215888'
+	ndkVersion '23.2.8568313'
 	compileSdkVersion 32
 	defaultConfig {
 		if (buildAsApplication) {
@@ -40,7 +43,7 @@ android {
 		externalNativeBuild {
 			cmake {
 				path '../../CMakeLists.txt'
-				version "3.13.0+"
+				version "3.22.1+"
 			}
 		}
 

--- a/android-project/gradle/wrapper/gradle-wrapper.properties
+++ b/android-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Nov 11 18:20:34 PST 2021
+#Mon Jul 25 04:46:02 CEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
25 LTS gives SDL build errors (will be default in august).
24 gives a build error for one of our std polyfills.
23 works, but is not LTS.
21 LTS (current default) chokes on CMake 3.22 (which is now the version on Ubuntu, and also de latest in Android Studio).

Hopefully the SDL build errors for 25 will be solved in the not to distant future.