### PR TITLE
Move theme internals into anonymous namespace, misc cleanups

### DIFF
--- a/Source/levels/themes.cpp
+++ b/Source/levels/themes.cpp
@@ -170,7 +170,7 @@ bool TFit_GoatShrine(int t)
 	return false;
 }
 
-bool CheckThemeObj3(Point origin, int8_t regionId, unsigned frequency = std::numeric_limits<unsigned>::max())
+bool CheckThemeObj3(Point origin, int8_t regionId, unsigned frequency = 0)
 {
 	const PointsInRectangleRange searchArea { Rectangle { origin, 1 } };
 	return std::all_of(searchArea.cbegin(), searchArea.cend(), [regionId, frequency](Point testPosition) {
@@ -187,7 +187,7 @@ bool CheckThemeObj3(Point origin, int8_t regionId, unsigned frequency = std::num
 		if (IsObjectAtPosition(testPosition)) {
 			return false;
 		}
-		if (frequency != std::numeric_limits<unsigned>::max() && FlipCoin(frequency)) {
+		if (frequency > 0 && FlipCoin(frequency)) {
 			return false;
 		}
 		return true;

--- a/Source/levels/themes.cpp
+++ b/Source/levels/themes.cpp
@@ -199,57 +199,30 @@ bool CheckThemeReqs(theme_id t)
 	case THEME_SHRINE:
 	case THEME_SKELROOM:
 	case THEME_LIBRARY:
-		if (leveltype == DTYPE_CAVES || leveltype == DTYPE_HELL) {
-			return false;
-		}
-		break;
-	case THEME_BLOODFOUNTAIN:
-		if (!bFountainFlag) {
-			return false;
-		}
-		break;
-	case THEME_PURIFYINGFOUNTAIN:
-		if (!pFountainFlag) {
-			return false;
-		}
-		break;
+		return IsNoneOf(leveltype, DTYPE_CAVES, DTYPE_HELL);
 	case THEME_ARMORSTAND:
-		if (leveltype == DTYPE_CATHEDRAL) {
-			return false;
-		}
-		break;
-	case THEME_CAULDRON:
-		if (leveltype != DTYPE_HELL || !cauldronFlag) {
-			return false;
-		}
-		break;
-	case THEME_MURKYFOUNTAIN:
-		if (!mFountainFlag) {
-			return false;
-		}
-		break;
-	case THEME_TEARFOUNTAIN:
-		if (!tFountainFlag) {
-			return false;
-		}
-		break;
 	case THEME_WEAPONRACK:
-		if (leveltype == DTYPE_CATHEDRAL) {
-			return false;
-		}
-		break;
+		return IsNoneOf(leveltype, DTYPE_CATHEDRAL);
+	case THEME_CAULDRON:
+		return leveltype == DTYPE_HELL && cauldronFlag;
+	case THEME_BLOODFOUNTAIN:
+		return bFountainFlag;
+	case THEME_PURIFYINGFOUNTAIN:
+		return pFountainFlag;
+	case THEME_MURKYFOUNTAIN:
+		return mFountainFlag;
+	case THEME_TEARFOUNTAIN:
+		return tFountainFlag;
+	case THEME_TREASURE:
+		return treasureFlag;
 	default:
-		break;
+		return true;
 	}
-
-	return true;
 }
 
 bool SpecialThemeFit(int i, theme_id t)
 {
-	bool rv;
-
-	rv = CheckThemeReqs(t);
+	bool rv = CheckThemeReqs(t);
 	switch (t) {
 	case THEME_SHRINE:
 	case THEME_LIBRARY:
@@ -317,7 +290,6 @@ bool SpecialThemeFit(int i, theme_id t)
 		}
 		break;
 	case THEME_TREASURE:
-		rv = treasureFlag;
 		if (rv) {
 			treasureFlag = false;
 		}

--- a/Source/levels/themes.cpp
+++ b/Source/levels/themes.cpp
@@ -22,20 +22,22 @@ namespace devilution {
 int numthemes;
 bool armorFlag;
 bool weaponFlag;
-bool treasureFlag;
-bool mFountainFlag;
-bool cauldronFlag;
-bool tFountainFlag;
 int zharlib;
+ThemeStruct themes[MAXTHEMES];
+
+namespace {
+
+bool cauldronFlag;
+bool bFountainFlag;
+bool mFountainFlag;
+bool pFountainFlag;
+bool tFountainFlag;
+bool treasureFlag;
+
 int themex;
 int themey;
 int themeVar1;
-ThemeStruct themes[MAXTHEMES];
-bool pFountainFlag;
-bool bFountainFlag;
 
-/** Specifies the set of special theme IDs from which one will be selected at random. */
-theme_id ThemeGood[4] = { THEME_GOATSHRINE, THEME_SHRINE, THEME_SKELROOM, THEME_LIBRARY };
 bool TFit_Shrine(int i)
 {
 	int xp = 0;
@@ -122,7 +124,6 @@ bool TFit_Obj5(int t)
 	}
 	return false;
 }
-
 bool TFit_SkelRoom(int t)
 {
 	if (IsNoneOf(leveltype, DTYPE_CATHEDRAL, DTYPE_CATACOMBS)) {
@@ -244,7 +245,7 @@ bool CheckThemeReqs(theme_id t)
 	return true;
 }
 
-static bool SpecialThemeFit(int i, theme_id t)
+bool SpecialThemeFit(int i, theme_id t)
 {
 	bool rv;
 
@@ -368,88 +369,6 @@ bool CheckThemeRoom(int tv)
 	return true;
 }
 
-void InitThemes()
-{
-	zharlib = -1;
-	numthemes = 0;
-	armorFlag = true;
-	bFountainFlag = true;
-	cauldronFlag = true;
-	mFountainFlag = true;
-	pFountainFlag = true;
-	tFountainFlag = true;
-	treasureFlag = true;
-	weaponFlag = true;
-
-	if (currlevel == 16 || IsAnyOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
-		return;
-	}
-
-	if (leveltype == DTYPE_CATHEDRAL) {
-		for (size_t i = 0; i < 256 && numthemes < MAXTHEMES; i++) {
-			if (CheckThemeRoom(i)) {
-				themes[numthemes].ttval = i;
-				theme_id j = ThemeGood[GenerateRnd(4)];
-				while (!SpecialThemeFit(numthemes, j)) {
-					j = (theme_id)GenerateRnd(17);
-				}
-				themes[numthemes].ttype = j;
-				numthemes++;
-			}
-		}
-		return;
-	}
-
-	for (int i = 0; i < themeCount; i++) {
-		themes[i].ttype = THEME_NONE;
-	}
-
-	if (Quests[Q_ZHAR].IsAvailable()) {
-		for (int j = 0; j < themeCount; j++) {
-			themes[j].ttval = themeLoc[j].ttval;
-			if (SpecialThemeFit(j, THEME_LIBRARY)) {
-				themes[j].ttype = THEME_LIBRARY;
-				zharlib = j;
-				break;
-			}
-		}
-	}
-	for (int i = 0; i < themeCount; i++) {
-		if (themes[i].ttype == THEME_NONE) {
-			themes[i].ttval = themeLoc[i].ttval;
-			theme_id j = ThemeGood[GenerateRnd(4)];
-			while (!SpecialThemeFit(i, j)) {
-				j = (theme_id)GenerateRnd(17);
-			}
-			themes[i].ttype = j;
-		}
-	}
-	numthemes += themeCount;
-}
-
-void HoldThemeRooms()
-{
-	if (currlevel == 16 || IsAnyOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
-		return;
-	}
-
-	if (leveltype != DTYPE_CATHEDRAL) {
-		DRLG_HoldThemeRooms();
-		return;
-	}
-
-	for (int i = 0; i < numthemes; i++) {
-		int8_t v = themes[i].ttval;
-		for (int y = 0; y < MAXDUNY; y++) {
-			for (int x = 0; x < MAXDUNX; x++) {
-				if (dTransVal[x][y] == v) {
-					dFlags[x][y] |= DungeonFlag::Populated;
-				}
-			}
-		}
-	}
-}
-
 /**
  * PlaceThemeMonsts places theme monsters with the specified frequency.
  *
@@ -556,7 +475,6 @@ void Theme_MonstPit(int t)
 	PlaceThemeMonsts(t, monstrnd[leveltype - 1]);
 }
 
-namespace {
 void SpawnObjectOrSkeleton(unsigned frequency, _object_id objectType, Point tile)
 {
 	if (FlipCoin(frequency)) {
@@ -567,7 +485,6 @@ void SpawnObjectOrSkeleton(unsigned frequency, _object_id objectType, Point tile
 			ActivateSkeleton(*skeleton, tile);
 	}
 }
-} // namespace
 
 /**
  * Theme_SkelRoom initializes the skeleton room theme.
@@ -925,6 +842,93 @@ void UpdateL4Trans()
 		for (int i = 0; i < MAXDUNX; i++) { // NOLINT(modernize-loop-convert)
 			if (dTransVal[i][j] != 0) {
 				dTransVal[i][j] = 1;
+			}
+		}
+	}
+}
+
+} // namespace
+
+void InitThemes()
+{
+	zharlib = -1;
+	numthemes = 0;
+	armorFlag = true;
+	bFountainFlag = true;
+	cauldronFlag = true;
+	mFountainFlag = true;
+	pFountainFlag = true;
+	tFountainFlag = true;
+	treasureFlag = true;
+	weaponFlag = true;
+
+	if (currlevel == 16 || IsAnyOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
+		return;
+	}
+
+	/** Specifies the set of special theme IDs from which one will be selected at random. */
+	constexpr theme_id ThemeGood[4] = { THEME_GOATSHRINE, THEME_SHRINE, THEME_SKELROOM, THEME_LIBRARY };
+
+	if (leveltype == DTYPE_CATHEDRAL) {
+		for (size_t i = 0; i < 256 && numthemes < MAXTHEMES; i++) {
+			if (CheckThemeRoom(i)) {
+				themes[numthemes].ttval = i;
+				theme_id j = ThemeGood[GenerateRnd(4)];
+				while (!SpecialThemeFit(numthemes, j)) {
+					j = (theme_id)GenerateRnd(17);
+				}
+				themes[numthemes].ttype = j;
+				numthemes++;
+			}
+		}
+		return;
+	}
+
+	for (int i = 0; i < themeCount; i++) {
+		themes[i].ttype = THEME_NONE;
+	}
+
+	if (Quests[Q_ZHAR].IsAvailable()) {
+		for (int j = 0; j < themeCount; j++) {
+			themes[j].ttval = themeLoc[j].ttval;
+			if (SpecialThemeFit(j, THEME_LIBRARY)) {
+				themes[j].ttype = THEME_LIBRARY;
+				zharlib = j;
+				break;
+			}
+		}
+	}
+	for (int i = 0; i < themeCount; i++) {
+		if (themes[i].ttype == THEME_NONE) {
+			themes[i].ttval = themeLoc[i].ttval;
+			theme_id j = ThemeGood[GenerateRnd(4)];
+			while (!SpecialThemeFit(i, j)) {
+				j = (theme_id)GenerateRnd(17);
+			}
+			themes[i].ttype = j;
+		}
+	}
+	numthemes += themeCount;
+}
+
+void HoldThemeRooms()
+{
+	if (currlevel == 16 || IsAnyOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
+		return;
+	}
+
+	if (leveltype != DTYPE_CATHEDRAL) {
+		DRLG_HoldThemeRooms();
+		return;
+	}
+
+	for (int i = 0; i < numthemes; i++) {
+		int8_t v = themes[i].ttval;
+		for (int y = 0; y < MAXDUNY; y++) {
+			for (int x = 0; x < MAXDUNX; x++) {
+				if (dTransVal[x][y] == v) {
+					dFlags[x][y] |= DungeonFlag::Populated;
+				}
 			}
 		}
 	}

--- a/test/random_test.cpp
+++ b/test/random_test.cpp
@@ -237,4 +237,54 @@ TEST(RandomTest, ModDistributionSignPreserving)
 	    << "Distribution must map negative numbers using sign preserving modulo";
 }
 
+TEST(RandomTest, NegativeReturnValues)
+{
+	// The bug in vanilla RNG stemming from mod instead of bitmasking means that negative values are possible for
+	// non-power of 2 arguments to GenerateRnd
+	SetRndSeed(1457187811);
+	EXPECT_EQ(GenerateRnd(3), -2) << "Unexpected return value for a limit of 3";
+
+	SetRndSeed(1457187811);
+	EXPECT_EQ(GenerateRnd(5), -3) << "Unexpected return value for a limit of 5";
+	SetRndSeed(1457187811);
+	EXPECT_EQ(GenerateRnd(6), -2) << "Unexpected return value for a limit of 6";
+	SetRndSeed(1457187811);
+	EXPECT_EQ(GenerateRnd(7), -1) << "Unexpected return value for a limit of 7";
+
+	SetRndSeed(1457187811);
+	EXPECT_EQ(GenerateRnd(11), -10) << "Unexpected return value for a limit of 11";
+
+	SetRndSeed(1457187811);
+	EXPECT_EQ(GenerateRnd(17), -9) << "Unexpected return value for a limit of 17";
+
+	SetRndSeed(1457187811);
+	EXPECT_EQ(GenerateRnd(19), -12) << "Unexpected return value for a limit of 19";
+
+	SetRndSeed(1457187811);
+	EXPECT_EQ(GenerateRnd(22), -10) << "Unexpected return value for a limit of 22";
+	SetRndSeed(1457187811);
+	EXPECT_EQ(GenerateRnd(23), -16) << "Unexpected return value for a limit of 23";
+
+	SetRndSeed(1457187811);
+	EXPECT_EQ(GenerateRnd(25), -18) << "Unexpected return value for a limit of 25";
+
+	SetRndSeed(1457187811);
+	EXPECT_EQ(GenerateRnd(27), -17) << "Unexpected return value for a limit of 27";
+
+	SetRndSeed(1457187811);
+	EXPECT_EQ(GenerateRnd(29), -27) << "Unexpected return value for a limit of 29";
+
+	SetRndSeed(1457187811);
+	EXPECT_EQ(GenerateRnd(31), -1) << "Unexpected return value for a limit of 31";
+
+	for (int i : { 9, 10, 12, 13, 14, 15, 18, 20, 21, 24, 26, 28, 30 }) {
+		SetRndSeed(1457187811);
+		EXPECT_EQ(GenerateRnd(i), -8) << "Unexpected return value for a limit of " << i;
+	}
+
+	for (int i = 1; i < 32768; i *= 2) {
+		SetRndSeed(1457187811);
+		EXPECT_EQ(GenerateRnd(i), 0) << "Expect powers of 2 such as " << i << " to cleanly divide the int_min RNG value ";
+	}
+}
 } // namespace devilution


### PR DESCRIPTION
Was looking at adding a helper for checking if a point matches a given regionId however I don't really want to introduce an unavoidable function call by using the same pattern as IsTileSolid and defining it in path.cpp. Probably move all that into a new header for dungeon tile checks?

This was the intent for CheckThemeObj5 but omitted for now:
```cpp
bool IsTileInRegion(Point position, int8_t regionId)
{
	return InDungeonBounds(position) && dTransVal[position.x][position.y] == regionId;
}
```