### PR TITLE
:sparkles: Adds ignoreMovingMonsters to MonsterAtPosition

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4482,17 +4482,18 @@ void MissToMonst(Missile &missile, Point position)
 		return;
 	}
 
-	if (dMonster[oldPosition.x][oldPosition.y] <= 0)
+	Monster *target = FindMonsterAtPosition(oldPosition, true);
+
+	if (target == nullptr)
 		return;
 
-	Monster &target = *FindMonsterAtPosition(oldPosition);
-	MonsterAttackMonster(monster, target, 500, monster.minDamageSpecial, monster.maxDamageSpecial);
+	MonsterAttackMonster(monster, *target, 500, monster.minDamageSpecial, monster.maxDamageSpecial);
 
 	if (IsAnyOf(monster.type().type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE))
 		return;
 
 	Point newPosition = oldPosition + monster.direction;
-	if (IsTileAvailable(target, newPosition)) {
+	if (IsTileAvailable(*target, newPosition)) {
 		monsterId = dMonster[oldPosition.x][oldPosition.y];
 		dMonster[newPosition.x][newPosition.y] = monsterId;
 		dMonster[oldPosition.x][oldPosition.y] = 0;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3729,7 +3729,7 @@ void M_StartStand(Monster &monster, Direction md)
 void M_ClearSquares(const Monster &monster)
 {
 	for (Point searchTile : PointsInRectangleRange { Rectangle { monster.position.old, 1 } }) {
-		if (MonsterAtPosition(searchTile) == &monster)
+		if (FindMonsterAtPosition(searchTile) == &monster)
 			dMonster[searchTile.x][searchTile.y] = 0;
 	}
 }
@@ -4151,7 +4151,7 @@ bool DirOK(const Monster &monster, Direction mdir)
 		for (int y = futurePosition.y - 3; y <= futurePosition.y + 3; y++) {
 			if (!InDungeonBounds({ x, y }))
 				continue;
-			Monster *minion = MonsterAtPosition({ x, y }, true);
+			Monster *minion = FindMonsterAtPosition({ x, y }, true);
 			if (minion == nullptr)
 				continue;
 
@@ -4485,7 +4485,7 @@ void MissToMonst(Missile &missile, Point position)
 	if (dMonster[oldPosition.x][oldPosition.y] <= 0)
 		return;
 
-	Monster &target = *MonsterAtPosition(oldPosition);
+	Monster &target = *FindMonsterAtPosition(oldPosition);
 	MonsterAttackMonster(monster, target, 500, monster.minDamageSpecial, monster.maxDamageSpecial);
 
 	if (IsAnyOf(monster.type().type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE))
@@ -4502,7 +4502,7 @@ void MissToMonst(Missile &missile, Point position)
 	}
 }
 
-Monster *MonsterAtPosition(Point position, bool ignoreMovingMonsters)
+Monster *FindMonsterAtPosition(Point position, bool ignoreMovingMonsters)
 {
 	if (!InDungeonBounds(position)) {
 		return nullptr;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4151,12 +4151,11 @@ bool DirOK(const Monster &monster, Direction mdir)
 		for (int y = futurePosition.y - 3; y <= futurePosition.y + 3; y++) {
 			if (!InDungeonBounds({ x, y }))
 				continue;
-			int mi = dMonster[x][y];
-			if (mi <= 0)
+			Monster *minion = MonsterAtPosition({ x, y }, true);
+			if (minion == nullptr)
 				continue;
 
-			auto &minion = Monsters[mi - 1];
-			if (minion.leaderRelation == LeaderRelation::Leashed && minion.getLeader() == &monster) {
+			if (minion->leaderRelation == LeaderRelation::Leashed && minion->getLeader() == &monster) {
 				mcount++;
 			}
 		}
@@ -4503,7 +4502,7 @@ void MissToMonst(Missile &missile, Point position)
 	}
 }
 
-Monster *MonsterAtPosition(Point position)
+Monster *MonsterAtPosition(Point position, bool ignoreMovingMonsters)
 {
 	if (!InDungeonBounds(position)) {
 		return nullptr;
@@ -4511,12 +4510,12 @@ Monster *MonsterAtPosition(Point position)
 
 	auto monsterId = dMonster[position.x][position.y];
 
-	if (monsterId != 0) {
-		return &Monsters[abs(monsterId) - 1];
+	if (monsterId == 0 || (ignoreMovingMonsters && monsterId < 0)) {
+		// nothing at this position, return a nullptr
+		return nullptr;
 	}
 
-	// nothing at this position, return a nullptr
-	return nullptr;
+	return &Monsters[abs(monsterId) - 1];
 }
 
 bool IsTileAvailable(const Monster &monster, Point position)

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -401,7 +401,7 @@ void PrintUniqueHistory();
 void PlayEffect(Monster &monster, int mode);
 void MissToMonst(Missile &missile, Point position);
 
-Monster *MonsterAtPosition(Point position);
+Monster *MonsterAtPosition(Point position, bool ignoreMovingMonsters = false);
 
 /**
  * @brief Check that the given tile is available to the monster

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -401,7 +401,7 @@ void PrintUniqueHistory();
 void PlayEffect(Monster &monster, int mode);
 void MissToMonst(Missile &missile, Point position);
 
-Monster *MonsterAtPosition(Point position, bool ignoreMovingMonsters = false);
+Monster *FindMonsterAtPosition(Point position, bool ignoreMovingMonsters = false);
 
 /**
  * @brief Check that the given tile is available to the monster

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1033,7 +1033,7 @@ bool DoAttack(Player &player)
 
 	if (player.AnimInfo.currentFrame == player._pAFNum - 1) {
 		Point position = player.position.tile + player._pdir;
-		Monster *monster = MonsterAtPosition(position);
+		Monster *monster = FindMonsterAtPosition(position);
 
 		if (monster != nullptr) {
 			if (CanTalkToMonst(*monster)) {
@@ -1075,7 +1075,7 @@ bool DoAttack(Player &player)
 		                && !(player.InvBody[INVLOC_HAND_LEFT]._itype == ItemType::Shield || player.InvBody[INVLOC_HAND_RIGHT]._itype == ItemType::Shield))))) {
 			// playing as a class/weapon with cleave
 			position = player.position.tile + Right(player._pdir);
-			monster = MonsterAtPosition(position);
+			monster = FindMonsterAtPosition(position);
 			if (monster != nullptr) {
 				if (!CanTalkToMonst(*monster) && monster->position.old == position) {
 					if (PlrHitMonst(player, *monster, true))
@@ -1083,7 +1083,7 @@ bool DoAttack(Player &player)
 				}
 			}
 			position = player.position.tile + Left(player._pdir);
-			monster = MonsterAtPosition(position);
+			monster = FindMonsterAtPosition(position);
 			if (monster != nullptr) {
 				if (!CanTalkToMonst(*monster) && monster->position.old == position) {
 					if (PlrHitMonst(player, *monster, true))


### PR DESCRIPTION
I believe that most read access to the `dMonster` global could be replaced with calls to `MonsterAtPosition`, which should improve the code readability and reduce global variable usage.

But, some places are checking if the dMonster contains no monster at all (`== 0`) while other places are checking for moving monsters as well (`<= 0`) and the current version of `MonsterAtPosition` only supports `== 0`.

This PR adds a strict flag that allows the `MonsterAtPosition` caller to switch the function's behaviour.

~~Note: I don't think `strict` is a good name, if you guys like this proposal we should find a better name~~
The parameter was renamed to `ignoreMovingMonsters` thanks to the feedback