### PR TITLE
GitHub Actions: Maybe fix release uploading

### DIFF
--- a/.github/workflows/miyoo_mini_release.yml
+++ b/.github/workflows/miyoo_mini_release.yml
@@ -2,7 +2,7 @@ name: Miyoo Mini Release Build
 
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -39,12 +39,9 @@ jobs:
         path: build-miyoo-mini/devilutionx-miniui.zip
 
     - name: Update Release
-      if: ${{ github.event_name == 'release' && github.event.action == 'created' && !env.ACT }}
-      uses: ncipollo/release-action@v1
+      if: ${{ github.event_name == 'release' && !env.ACT }}
+      uses: svenstaro/upload-release-action@v2
       with:
-        artifacts: "build-miyoo-mini/devilutionx-onion-os.zip,build-miyoo-mini/devilutionx-miniui.zip"
-        allowUpdates: true
-        omitBody: true
-        omitName: true
-        omitPrereleaseDuringUpdate: true
-        token: ${{ secrets.GITHUB_TOKEN }}
+        file: "build-miyoo-mini/devilutionx-*.zip"
+        file_glob: true
+        overwrite: true

--- a/.github/workflows/opendingux_release.yml
+++ b/.github/workflows/opendingux_release.yml
@@ -2,7 +2,7 @@ name: OpenDingux Release Build
 
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -37,15 +37,11 @@ jobs:
         path: build-rg350/devilutionx-rg350.opk
 
     - name: Update Release
-      if: ${{ github.event_name == 'release' && github.event.action == 'created' && !env.ACT }}
-      uses: ncipollo/release-action@v1
+      if: ${{ github.event_name == 'release' && !env.ACT }}
+      uses: svenstaro/upload-release-action@v2
       with:
-        artifacts: "build-rg350/devilutionx-rg350.opk"
-        allowUpdates: true
-        omitBody: true
-        omitName: true
-        omitPrereleaseDuringUpdate: true
-        token: ${{ secrets.GITHUB_TOKEN }}
+        file: "build-rg350/devilutionx-rg350.opk"
+        overwrite: true
 
   lepus:
     runs-on: ubuntu-22.04
@@ -78,12 +74,8 @@ jobs:
         path: build-lepus/devilutionx-lepus.opk
 
     - name: Update Release
-      if: ${{ github.event_name == 'release' && github.event.action == 'created' && !env.ACT }}
-      uses: ncipollo/release-action@v1
+      if: ${{ github.event_name == 'release' && !env.ACT }}
+      uses: svenstaro/upload-release-action@v2
       with:
-        artifacts: "build-lepus/devilutionx-lepus.opk"
-        allowUpdates: true
-        omitBody: true
-        omitName: true
-        omitPrereleaseDuringUpdate: true
-        token: ${{ secrets.GITHUB_TOKEN }}
+        file: "build-lepus/devilutionx-lepus.opk"
+        overwrite: true

--- a/.github/workflows/retrofw_release.yml
+++ b/.github/workflows/retrofw_release.yml
@@ -2,7 +2,7 @@ name: RetroFW Release Build
 
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -38,12 +38,8 @@ jobs:
         path: build-retrofw/devilutionx-retrofw.opk
 
     - name: Update Release
-      if: ${{ github.event_name == 'release' && github.event.action == 'created' && !env.ACT }}
-      uses: ncipollo/release-action@v1
+      if: ${{ github.event_name == 'release' && !env.ACT }}
+      uses: svenstaro/upload-release-action@v2
       with:
-        artifacts: "build-retrofw/devilutionx-retrofw.opk"
-        allowUpdates: true
-        omitBody: true
-        omitName: true
-        omitPrereleaseDuringUpdate: true
-        token: ${{ secrets.GITHUB_TOKEN }}
+        file: "build-retrofw/devilutionx-retrofw.opk"
+        overwrite: true

--- a/.github/workflows/src_dist_release.yml
+++ b/.github/workflows/src_dist_release.yml
@@ -2,7 +2,7 @@ name: Build source tarball
 
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -31,15 +31,12 @@ jobs:
         path: devilutionx-src.tar.xz
 
     - name: Update Release
-      if: ${{ github.event_name == 'release' && github.event.action == 'created' && !env.ACT }}
-      uses: ncipollo/release-action@v1
+      if: ${{ github.event_name == 'release' && !env.ACT }}
+      uses: svenstaro/upload-release-action@v2
       with:
-        artifacts: "devilutionx-src.tar.xz"
-        allowUpdates: true
-        omitBody: true
-        omitName: true
-        omitPrereleaseDuringUpdate: true
-        token: ${{ secrets.GITHUB_TOKEN }}
+        file: "devilutionx-src.tar.xz"
+        overwrite: true
+
   make_src_dist_fully_vendored:
     runs-on: ubuntu-latest
     steps:
@@ -65,12 +62,8 @@ jobs:
         path: devilutionx-src-fully-vendored.tar.xz
 
     - name: Update Release
-      if: ${{ github.event_name == 'release' && github.event.action == 'created' && !env.ACT }}
-      uses: ncipollo/release-action@v1
+      if: ${{ github.event_name == 'release' && !env.ACT }}
+      uses: svenstaro/upload-release-action@v2
       with:
-        artifacts: "devilutionx-src-fully-vendored.tar.xz"
-        allowUpdates: true
-        omitBody: true
-        omitName: true
-        omitPrereleaseDuringUpdate: true
-        token: ${{ secrets.GITHUB_TOKEN }}
+        file: "devilutionx-src-fully-vendored.tar.xz"
+        overwrite: true


### PR DESCRIPTION
1. Use the `release.published` event because `release.created` never triggers for releases that start off as drafts.
2. Use a simpler action to upload files (the defaults are more appropriate for what we need, which is just uploading the files and not doing anything else).