### PR TITLE
Fix Building SDL2 for MinGW

### DIFF
--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -1,3 +1,6 @@
+#if (defined(_WIN64) || defined(_WIN32)) && defined(__GNUC__)
+#define SDL_MAIN_HANDLED
+#endif
 #include <SDL.h>
 #include <SDL_main.h>
 


### PR DESCRIPTION
Before this fix trying to compile with -DDEVILUTIONX_SYSTEM_SDL2=OFF for MinGW would give a undefined reference to `WinMain'.