### PR TITLE
Don't recalculate leveltype (from currlevel) in SaveGameData

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2326,8 +2326,6 @@ void SaveGameData(MpqWriter &saveWriter)
 	file.WriteBE<uint32_t>(static_cast<uint32_t>(std::min(Missiles.size(), MaxMissilesForSaveGame)));
 	file.WriteBE<int32_t>(ActiveObjectCount);
 
-	leveltype = GetLevelType(currlevel);
-
 	for (uint8_t i = 0; i < giNumberOfLevels; i++) {
 		file.WriteBE<uint32_t>(glSeedTbl[i]);
 		file.WriteBE<int32_t>(getHellfireLevelType(GetLevelType(i)));


### PR DESCRIPTION
Fixes #4954

Setting `leveltype` from `GetLevelType(currlevel)` is wrong if we are on a quest map (`setlevel` is true).

Was [introduced](https://github.com/diasurgical/devilutionX/commit/54cd839cf6c7b4647f3b1906275f9dcae225b7a8#diff-eb2db6084d42c0224b56a122152915d07d944c27040e427d6193bc382ca754b3R2267) in #4665 /  54cd839cf6c7b4647f3b1906275f9dcae225b7a8 .

Many thanks to @Chance4us for finding the buggy commit and the nice reproduction videos. 🙂👍 