### PR TITLE
Clean up logic in enchanted shrine

### DIFF
--- a/Source/engine/random.hpp
+++ b/Source/engine/random.hpp
@@ -44,6 +44,20 @@ uint32_t GetLCGEngineState();
 int32_t AdvanceRndSeed();
 
 /**
+ * @brief A distribution function to go from a given state to a non-uniform value between 0 and v
+ *
+ * This is intended for use where we would otherwise be constructing a temporary engine or resetting the global RNG
+ * for a single random value.
+ * @param state 32 bit value assumed to come from an LCG algorithm
+ * @param v upper limit for the returned value, should be less than 2^15 for good results
+ * @return a value less than v with slight bias towards 0
+ */
+constexpr unsigned ShiftModDistribution(uint32_t state, unsigned v)
+{
+	return (state >> 16) % v;
+}
+
+/**
  * @brief Generates a random integer less than the given limit using the vanilla RNG
  *
  * If v is not a positive number this function returns 0 without calling the RNG.

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -103,10 +103,12 @@ void PackPlayer(PlayerPack *pPack, const Player &player, bool manashield, bool n
 	pPack->pMaxManaBase = SDL_SwapLE32(player._pMaxManaBase);
 	pPack->pMemSpells = SDL_SwapLE64(player._pMemSpells);
 
-	for (int i = 0; i < 37; i++) // Should be MAX_SPELLS but set to 37 to make save games compatible
+	// For save game compatibility only save diablo spells in PlayerPack::pSplLvl
+	for (size_t i = static_cast<size_t>(spell_id::SPL_NULL); i <= static_cast<size_t>(spell_id::SPL_LASTDIABLO); i++)
 		pPack->pSplLvl[i] = player._pSplLvl[i];
-	for (int i = 37; i < 47; i++)
-		pPack->pSplLvl2[i - 37] = player._pSplLvl[i];
+	// and hellfire spells go into PlayerPack::pSplLvl2, runes are not learnable so get ignored here
+	for (size_t i = static_cast<size_t>(spell_id::SPL_MANA); i <= static_cast<size_t>(spell_id::SPL_SEARCH); i++)
+		pPack->pSplLvl2[i - static_cast<size_t>(spell_id::SPL_MANA)] = player._pSplLvl[i];
 
 	for (int i = 0; i < NUM_INVLOC; i++) {
 		const Item &item = player.InvBody[i];
@@ -252,10 +254,12 @@ bool UnPackPlayer(const PlayerPack *pPack, Player &player, bool netSync)
 	player._pManaBase = SDL_SwapLE32(pPack->pManaBase);
 	player._pMemSpells = SDL_SwapLE64(pPack->pMemSpells);
 
-	for (int i = 0; i < 37; i++) // Should be MAX_SPELLS but set to 36 to make save games compatible
+	// For save game compatibility only load diablo spells from PlayerPack::pSplLvl
+	for (size_t i = static_cast<size_t>(spell_id::SPL_NULL); i <= static_cast<size_t>(spell_id::SPL_LASTDIABLO); i++)
 		player._pSplLvl[i] = pPack->pSplLvl[i];
-	for (int i = 37; i < 47; i++)
-		player._pSplLvl[i] = pPack->pSplLvl2[i - 37];
+	// hellfire spells are loaded from PlayerPack::pSplLvl2, runes are not learnable so get ignored here
+	for (size_t i = static_cast<size_t>(spell_id::SPL_MANA); i <= static_cast<size_t>(spell_id::SPL_SEARCH); i++)
+		player._pSplLvl[i] = pPack->pSplLvl2[i - static_cast<size_t>(spell_id::SPL_MANA)];
 
 	for (int i = 0; i < NUM_INVLOC; i++) {
 		auto packedItem = pPack->InvBody[i];

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -52,7 +52,7 @@ struct PlayerPack {
 	int32_t pMaxHPBase;
 	int32_t pManaBase;
 	int32_t pMaxManaBase;
-	int8_t pSplLvl[37]; // Should be MAX_SPELLS but set to 37 to make save games compatible
+	int8_t pSplLvl[37]; // Only Diablo spells, for save game compatibility
 	uint64_t pMemSpells;
 	ItemPack InvBody[NUM_INVLOC];
 	ItemPack InvList[InventoryGridCells];

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1728,9 +1728,9 @@ void ValidatePlayer()
 	}
 
 	uint64_t msk = 0;
-	for (int b = SPL_FIREBOLT; b < MAX_SPELLS; b++) {
-		if (GetSpellBookLevel((spell_id)b) != -1) {
-			msk |= GetSpellBitmask(b);
+	for (size_t b = static_cast<size_t>(spell_id::SPL_FIREBOLT); b <= static_cast<size_t>(spell_id::SPL_LAST); b++) {
+		if (GetSpellBookLevel(static_cast<spell_id>(b)) != -1) {
+			msk |= GetSpellBitmask(static_cast<spell_id>(b));
 			if (myPlayer._pSplLvl[b] > MaxSpellLevel)
 				myPlayer._pSplLvl[b] = MaxSpellLevel;
 		}
@@ -2557,9 +2557,7 @@ void CreatePlayer(Player &player, HeroClass c)
 		player._pMemSpells = 0;
 	}
 
-	for (int8_t &spellLevel : player._pSplLvl) {
-		spellLevel = 0;
-	}
+	std::fill(player._pSplLvl, player._pSplLvl + sizeof(player._pSplLvl) / sizeof(player._pSplLvl[0]), 0);
 
 	player._pSpellFlags = SpellFlag::None;
 

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -50,9 +50,9 @@ int GetSpellStaffLevel(spell_id s);
  * @param spellId The id of the spell to get a bitmask for.
  * @return A 64bit bitmask representation for the specified spell.
  */
-constexpr uint64_t GetSpellBitmask(int spellId)
+constexpr uint64_t GetSpellBitmask(spell_id spellId)
 {
-	return 1ULL << (spellId - 1);
+	return 1ULL << (static_cast<unsigned>(spellId) - 1);
 }
 
 } // namespace devilution


### PR DESCRIPTION
Ended up looking at this due to a discussion in discord. The way a spell is chosen to take a level (or two) from was wasteful and didn't really need to be kept as is since it happens after dungeon generation. Using the same approach as Stephen pioneered in #3314 we can just directly use the object seed to determine the effect.

While trying to confirm the loop range was correct I noticed a lot of magic numbers/hardcoded values that really related to `spell_id` enum members, updated those as I went along.