### PR TITLE
Fix broken dirt tile in cathedral/crypt

### DIFF
--- a/Source/levels/drlg_l1.cpp
+++ b/Source/levels/drlg_l1.cpp
@@ -1088,6 +1088,9 @@ void FixCornerTiles()
 			if (dungeon[i][j] == DirtCorner2 && dungeon[i + 1][j] == Floor && dungeon[i][j + 1] == VWall) {
 				dungeon[i][j] = HArchEnd;
 			}
+			if (dungeon[i][j] == DirtCorner2 && dungeon[i][j + 1] == Floor && dungeon[i + 1][j] == HWall) {
+				dungeon[i][j] = VArchEnd;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Can't seem to find an open issue for this, but I know it was reported and found long ago.

![image](https://user-images.githubusercontent.com/65138215/116955675-d07ec300-ac58-11eb-80b8-922b1e7ad179.png)