### PR TITLE
Fix left sideways walking monsters draw order

### DIFF
--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -747,7 +747,9 @@ void DrawItem(const Surface &out, Point tilePosition, Point targetBufferPosition
  */
 void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBufferPosition)
 {
-	int mi = abs(dMonster[tilePosition.x][tilePosition.y]) - 1;
+	int mi = dMonster[tilePosition.x][tilePosition.y];
+	bool isNegativeMonster = mi < 0;
+	mi = abs(mi) - 1;
 
 	if (leveltype == DTYPE_TOWN) {
 		auto &towner = Towners[mi];
@@ -779,7 +781,16 @@ void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBuffe
 
 	Displacement offset = monster.position.offset;
 	if (monster.isWalking()) {
+		bool isSideWalkingToLeft = monster.mode == MonsterMode::MoveSideways && monster.direction == Direction::West;
+		if (isNegativeMonster && !isSideWalkingToLeft)
+			return;
+		if (!isNegativeMonster && isSideWalkingToLeft)
+			return;
 		offset = GetOffsetForWalking(monster.animInfo, monster.direction);
+		if (isSideWalkingToLeft)
+			offset -= Displacement { 64, 0 };
+	} else if (isNegativeMonster) {
+		return;
 	}
 
 	const Point monsterRenderPosition { targetBufferPosition + offset - Displacement { CalculateWidth2(cel.Width()), 0 } };
@@ -869,7 +880,7 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 	if (playerId > 0 && playerId <= MAX_PLRS) {
 		DrawPlayerHelper(out, Players[playerId - 1], tilePosition, targetBufferPosition);
 	}
-	if (dMonster[tilePosition.x][tilePosition.y] > 0) {
+	if (dMonster[tilePosition.x][tilePosition.y] != 0) {
 		DrawMonsterHelper(out, tilePosition, targetBufferPosition);
 	}
 	DrawMissile(out, tilePosition, targetBufferPosition, false);


### PR DESCRIPTION
Fixes #4822

The renderer draws from left to right.
Left sideways walking monsters have a positive index to there target tile (left) and a negative index to there origin tile (right).
In master we only render the positive monster index.
But after that we render the (right) neighbor tile. This can override the drawn monster.

This pr now draws (for left side walking) the monster with the negative index. This ensures we the monster is not "overdrawn".
A similar check was removed by the broken commit (e62aaa562f12e50db62ee288c6c15c5d3aa9febf).

Thanks @qndel for finding the broken commit 🙂 