### PR TITLE
Missing fonts.mpq: Show an error, fall back to en

### DIFF
--- a/Source/options.h
+++ b/Source/options.h
@@ -284,6 +284,14 @@ public:
 		return szCode;
 	}
 
+	OptionEntryLanguageCode &operator=(string_view code)
+	{
+		assert(code.size() < 6);
+		memcpy(szCode, code.data(), code.size());
+		szCode[code.size()] = '\0';
+		return *this;
+	}
+
 private:
 	/** @brief Language code (ISO-15897) for text. */
 	char szCode[6];

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -326,6 +326,17 @@ void LanguageInitialize()
 	translationKeys = nullptr;
 	translationValues = nullptr;
 
+	if (IsSmallFontTall() && !font_mpq) {
+		UiErrorOkDialog(
+		    "Missing fonts.mpq",
+		    StrCat("fonts.mpq is required for locale \"",
+		        *sgOptions.Language.code,
+		        "\"\n\n"
+		        "Please download fonts.mpq from:\n"
+		        "github.com/diasurgical/\ndevilutionx-assets/releases"));
+		sgOptions.Language.code = "en";
+	}
+
 	const std::string lang(*sgOptions.Language.code);
 	SDL_RWops *rw;
 


### PR DESCRIPTION
If the language is set to one of the locales that requires extra fonts and `fonts.mpq` is missing, show an error dialog and fall back to English.

![image](https://user-images.githubusercontent.com/216339/182024539-dccce086-4611-4481-8d78-1080d3b51672.png)

Fixes #5140