### PR TITLE
workaround drop gold input

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -472,9 +472,9 @@ void PressKey(SDL_Keycode vkey, uint16_t modState)
 		return;
 	}
 
-	if (sgnTimeoutCurs != CURSOR_NONE || dropGoldFlag || IsWithdrawGoldOpen) {
+	/*if (sgnTimeoutCurs != CURSOR_NONE || dropGoldFlag || IsWithdrawGoldOpen) {
 		return;
-	}
+	}*/
 
 	sgOptions.Keymapper.KeyPressed(vkey);
 


### PR DESCRIPTION
I would like to point out the issue so that it can be resolved quickly and professionally.

Workarounds issue #5145.

Creates a new issue:
When pressing the 0-9 keys except on the keypad, potions are consumed although you are in drop gold dialogue.

