### PR TITLE
Merge more Doors logic

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -41,7 +41,6 @@
 
 namespace devilution {
 
-bool deltaload;
 uint8_t gbBufferMsgs;
 int dwRecCount;
 
@@ -2188,7 +2187,6 @@ void delta_init()
 	memset(&sgJunk, 0xFF, sizeof(sgJunk));
 	DeltaLevels.clear();
 	LocalLevels.clear();
-	deltaload = false;
 }
 
 void delta_kill_monster(const Monster &monster, Point position, const Player &player)
@@ -2376,7 +2374,6 @@ void DeltaLoadLevel()
 	if (!gbIsMultiplayer)
 		return;
 
-	deltaload = true;
 	uint8_t localLevel = GetLevelForMultiplayer(*MyPlayer);
 	DLevel &deltaLevel = GetDeltaLevel(localLevel);
 	if (leveltype != DTYPE_TOWN) {
@@ -2493,10 +2490,9 @@ void DeltaLoadLevel()
 		for (int i = 0; i < MAXOBJECTS; i++) {
 			switch (deltaLevel.object[i].bCmd) {
 			case CMD_OPENDOOR:
-			case CMD_CLOSEDOOR:
 			case CMD_OPERATEOBJ:
 			case CMD_PLROPOBJ:
-				DeltaSyncOpObject(deltaLevel.object[i].bCmd, Objects[i]);
+				DeltaSyncOpObject(Objects[i]);
 				break;
 			case CMD_BREAKOBJ:
 				DeltaSyncBreakObj(Objects[i]);
@@ -2513,7 +2509,6 @@ void DeltaLoadLevel()
 			}
 		}
 	}
-	deltaload = false;
 }
 
 void NetSendCmd(bool bHiPri, _cmd_id bCmd)

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -713,7 +713,6 @@ struct TBuffer {
 	byte bData[4096];
 };
 
-extern bool deltaload;
 extern uint8_t gbBufferMsgs;
 extern int dwRecCount;
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1080,6 +1080,8 @@ void AddDoor(Object &door)
 	case OBJ_L3RDOOR:
 		ObjSetMicro(door.position, 533);
 		break;
+	default:
+		break;
 	}
 }
 
@@ -2048,6 +2050,8 @@ void OperateDoor(const Player &player, Object &door)
 		case OBJ_L5LDOOR:
 			OperateL5LDoor(door, true);
 			break;
+		default:
+			break;
 		}
 	}
 	if (dpx <= 1 && dpy == 1) {
@@ -2063,6 +2067,8 @@ void OperateDoor(const Player &player, Object &door)
 			break;
 		case OBJ_L5RDOOR:
 			OperateL5RDoor(door, true);
+			break;
+		default:
 			break;
 		}
 	}
@@ -2081,7 +2087,7 @@ bool AreAllLeversActivated(int leverId)
 	return true;
 }
 
-void DeltaOperateLever(Object &object)
+void UpdateLeverState(Object &object)
 {
 	if (object._oSelFlag == 0) {
 		return;
@@ -2110,7 +2116,7 @@ void OperateLever(Object &object, bool sendmsg)
 
 	PlaySfxLoc(IS_LEVER, object.position);
 
-	DeltaOperateLever(object);
+	UpdateLeverState(object);
 
 	if (currlevel == 24) {
 		PlaySfxLoc(IS_CROPEN, { UberRow, UberCol });
@@ -3646,50 +3652,7 @@ void SyncOperateDoor(int cmd, Object &door)
 	case OBJ_L5RDOOR:
 		OperateL5RDoor(door, false);
 		break;
-	}
-}
-
-void DeltaSyncDoor(Object &door)
-{
-	door._oAnimFrame += 2;
-	door._oPreFlag = true;
-	door._oVar4 = DOOR_OPEN;
-	door._oSelFlag = 2;
-
-	switch (door._otype) {
-	case OBJ_L1LDOOR:
-		ObjSetMicro(door.position, door._oVar1 == 214 ? 407 : 392);
-		dSpecial[door.position.x][door.position.y] = 7;
-		DoorSet(door.position + Direction::NorthEast, true);
-		break;
-	case OBJ_L1RDOOR:
-		ObjSetMicro(door.position, 394);
-		dSpecial[door.position.x][door.position.y] = 8;
-		DoorSet(door.position + Direction::NorthWest, false);
-		break;
-	case OBJ_L2LDOOR:
-		ObjSetMicro(door.position, 12);
-		dSpecial[door.position.x][door.position.y] = 5;
-		break;
-	case OBJ_L2RDOOR:
-		ObjSetMicro(door.position, 16);
-		dSpecial[door.position.x][door.position.y] = 6;
-		break;
-	case OBJ_L3LDOOR:
-		ObjSetMicro(door.position, 537);
-		break;
-	case OBJ_L3RDOOR:
-		ObjSetMicro(door.position, 540);
-		break;
-	case OBJ_L5LDOOR:
-		ObjSetMicro(door.position, 205);
-		dSpecial[door.position.x][door.position.y] = 1;
-		CryptDoorSet(door.position + Direction::NorthEast, true);
-		break;
-	case OBJ_L5RDOOR:
-		ObjSetMicro(door.position, 208);
-		dSpecial[door.position.x][door.position.y] = 2;
-		CryptDoorSet(door.position + Direction::NorthWest, false);
+	default:
 		break;
 	}
 }
@@ -3843,6 +3806,8 @@ void SyncPedestal(const Object &pedestal, Point origin, int width)
 
 void OpenDoor(Object &door)
 {
+	door._oPreFlag = true;
+	door._oVar4 = DOOR_OPEN;
 	door._oMissFlag = true;
 	door._oSelFlag = 2;
 
@@ -3881,6 +3846,8 @@ void OpenDoor(Object &door)
 		dSpecial[door.position.x][door.position.y] = 2;
 		CryptDoorSet(door.position + Direction::NorthWest, false);
 		break;
+	default:
+		break;
 	}
 }
 
@@ -3903,6 +3870,8 @@ void CloseDoor(Object &door)
 		break;
 	case OBJ_L3RDOOR:
 		ObjSetMicro(door.position, 533);
+		break;
+	default:
 		break;
 	}
 }
@@ -4843,12 +4812,13 @@ void DeltaSyncOpObject(Object &object)
 	case OBJ_L3RDOOR:
 	case OBJ_L5LDOOR:
 	case OBJ_L5RDOOR:
-		DeltaSyncDoor(object);
+		object._oAnimFrame += 2;
+		OpenDoor(object);
 		break;
 	case OBJ_LEVER:
 	case OBJ_L5LEVER:
 	case OBJ_SWITCHSKL:
-		DeltaOperateLever(object);
+		UpdateLeverState(object);
 		break;
 	case OBJ_CHEST1:
 	case OBJ_CHEST2:

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1701,16 +1701,14 @@ void CryptDoorSet(Point position, bool isLeftDoor)
 void OperateL1RDoor(Object &door, bool sendflag)
 {
 	if (door._oVar4 == DOOR_BLOCKED) {
-		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, door.position);
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 		return;
 	}
 
 	if (door._oVar4 == DOOR_CLOSED) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
-		if (!deltaload)
-			PlaySfxLoc(IS_DOOROPEN, door.position);
+		PlaySfxLoc(IS_DOOROPEN, door.position);
 		ObjSetMicro(door.position, 394);
 		dSpecial[door.position.x][door.position.y] = 8;
 		door._oAnimFrame += 2;
@@ -1722,9 +1720,8 @@ void OperateL1RDoor(Object &door, bool sendflag)
 		return;
 	}
 
-	if (!deltaload)
-		PlaySfxLoc(IS_DOORCLOS, door.position);
-	if (!deltaload && IsDoorClear(door.position)) {
+	PlaySfxLoc(IS_DOORCLOS, door.position);
+	if (IsDoorClear(door.position)) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
 		door._oVar4 = DOOR_CLOSED;
@@ -1750,20 +1747,15 @@ void OperateL1RDoor(Object &door, bool sendflag)
 void OperateL1LDoor(Object &door, bool sendflag)
 {
 	if (door._oVar4 == DOOR_BLOCKED) {
-		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, door.position);
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 		return;
 	}
 
 	if (door._oVar4 == DOOR_CLOSED) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
-		if (!deltaload)
-			PlaySfxLoc(IS_DOOROPEN, door.position);
-		if (door._oVar1 == 214)
-			ObjSetMicro(door.position, 407);
-		else
-			ObjSetMicro(door.position, 392);
+		PlaySfxLoc(IS_DOOROPEN, door.position);
+		ObjSetMicro(door.position, door._oVar1 == 214 ? 407 : 392);
 		dSpecial[door.position.x][door.position.y] = 7;
 		door._oAnimFrame += 2;
 		door._oPreFlag = true;
@@ -1774,8 +1766,7 @@ void OperateL1LDoor(Object &door, bool sendflag)
 		return;
 	}
 
-	if (!deltaload)
-		PlaySfxLoc(IS_DOORCLOS, door.position);
+	PlaySfxLoc(IS_DOORCLOS, door.position);
 	if (IsDoorClear(door.position)) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
@@ -1802,16 +1793,14 @@ void OperateL1LDoor(Object &door, bool sendflag)
 void OperateL2RDoor(Object &door, bool sendflag)
 {
 	if (door._oVar4 == DOOR_BLOCKED) {
-		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, door.position);
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 		return;
 	}
 
 	if (door._oVar4 == DOOR_CLOSED) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
-		if (!deltaload)
-			PlaySfxLoc(IS_DOOROPEN, door.position);
+		PlaySfxLoc(IS_DOOROPEN, door.position);
 		ObjSetMicro(door.position, 16);
 		dSpecial[door.position.x][door.position.y] = 6;
 		door._oAnimFrame += 2;
@@ -1822,8 +1811,7 @@ void OperateL2RDoor(Object &door, bool sendflag)
 		return;
 	}
 
-	if (!deltaload)
-		PlaySfxLoc(IS_DOORCLOS, door.position);
+	PlaySfxLoc(IS_DOORCLOS, door.position);
 
 	if (IsDoorClear(door.position)) {
 		if (sendflag)
@@ -1843,16 +1831,14 @@ void OperateL2RDoor(Object &door, bool sendflag)
 void OperateL2LDoor(Object &door, bool sendflag)
 {
 	if (door._oVar4 == DOOR_BLOCKED) {
-		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, door.position);
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 		return;
 	}
 
 	if (door._oVar4 == DOOR_CLOSED) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
-		if (!deltaload)
-			PlaySfxLoc(IS_DOOROPEN, door.position);
+		PlaySfxLoc(IS_DOOROPEN, door.position);
 		ObjSetMicro(door.position, 12);
 		dSpecial[door.position.x][door.position.y] = 5;
 		door._oAnimFrame += 2;
@@ -1863,8 +1849,7 @@ void OperateL2LDoor(Object &door, bool sendflag)
 		return;
 	}
 
-	if (!deltaload)
-		PlaySfxLoc(IS_DOORCLOS, door.position);
+	PlaySfxLoc(IS_DOORCLOS, door.position);
 
 	if (IsDoorClear(door.position)) {
 		if (sendflag)
@@ -1884,16 +1869,14 @@ void OperateL2LDoor(Object &door, bool sendflag)
 void OperateL3RDoor(Object &door, bool sendflag)
 {
 	if (door._oVar4 == DOOR_BLOCKED) {
-		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, door.position);
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 		return;
 	}
 
 	if (door._oVar4 == DOOR_CLOSED) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
-		if (!deltaload)
-			PlaySfxLoc(IS_DOOROPEN, door.position);
+		PlaySfxLoc(IS_DOOROPEN, door.position);
 		ObjSetMicro(door.position, 540);
 		door._oAnimFrame += 2;
 		door._oPreFlag = true;
@@ -1903,8 +1886,7 @@ void OperateL3RDoor(Object &door, bool sendflag)
 		return;
 	}
 
-	if (!deltaload)
-		PlaySfxLoc(IS_DOORCLOS, door.position);
+	PlaySfxLoc(IS_DOORCLOS, door.position);
 
 	if (IsDoorClear(door.position)) {
 		if (sendflag)
@@ -1923,16 +1905,14 @@ void OperateL3RDoor(Object &door, bool sendflag)
 void OperateL3LDoor(Object &door, bool sendflag)
 {
 	if (door._oVar4 == DOOR_BLOCKED) {
-		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, door.position);
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 		return;
 	}
 
 	if (door._oVar4 == DOOR_CLOSED) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
-		if (!deltaload)
-			PlaySfxLoc(IS_DOOROPEN, door.position);
+		PlaySfxLoc(IS_DOOROPEN, door.position);
 		ObjSetMicro(door.position, 537);
 		door._oAnimFrame += 2;
 		door._oPreFlag = true;
@@ -1942,8 +1922,7 @@ void OperateL3LDoor(Object &door, bool sendflag)
 		return;
 	}
 
-	if (!deltaload)
-		PlaySfxLoc(IS_DOORCLOS, door.position);
+	PlaySfxLoc(IS_DOORCLOS, door.position);
 
 	if (IsDoorClear(door.position)) {
 		if (sendflag)
@@ -1962,16 +1941,14 @@ void OperateL3LDoor(Object &door, bool sendflag)
 void OperateL5RDoor(Object &door, bool sendflag)
 {
 	if (door._oVar4 == DOOR_BLOCKED) {
-		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, door.position);
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 		return;
 	}
 
 	if (door._oVar4 == DOOR_CLOSED) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
-		if (!deltaload)
-			PlaySfxLoc(IS_CROPEN, door.position);
+		PlaySfxLoc(IS_CROPEN, door.position);
 		ObjSetMicro(door.position, 208);
 		dSpecial[door.position.x][door.position.y] = 2;
 		door._oAnimFrame += 2;
@@ -1983,9 +1960,8 @@ void OperateL5RDoor(Object &door, bool sendflag)
 		return;
 	}
 
-	if (!deltaload)
-		PlaySfxLoc(IS_CRCLOS, door.position);
-	if (!deltaload && IsDoorClear(door.position)) {
+	PlaySfxLoc(IS_CRCLOS, door.position);
+	if (IsDoorClear(door.position)) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
 		door._oVar4 = DOOR_CLOSED;
@@ -2011,16 +1987,14 @@ void OperateL5RDoor(Object &door, bool sendflag)
 void OperateL5LDoor(Object &door, bool sendflag)
 {
 	if (door._oVar4 == DOOR_BLOCKED) {
-		if (!deltaload)
-			PlaySfxLoc(IS_DOORCLOS, door.position);
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 		return;
 	}
 
 	if (door._oVar4 == DOOR_CLOSED) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
-		if (!deltaload)
-			PlaySfxLoc(IS_CROPEN, door.position);
+		PlaySfxLoc(IS_CROPEN, door.position);
 		ObjSetMicro(door.position, 205);
 		dSpecial[door.position.x][door.position.y] = 1;
 		door._oAnimFrame += 2;
@@ -2032,8 +2006,7 @@ void OperateL5LDoor(Object &door, bool sendflag)
 		return;
 	}
 
-	if (!deltaload)
-		PlaySfxLoc(IS_CRCLOS, door.position);
+	PlaySfxLoc(IS_CRCLOS, door.position);
 	if (IsDoorClear(door.position)) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
@@ -3676,6 +3649,51 @@ void SyncOperateDoor(int cmd, Object &door)
 	}
 }
 
+void DeltaSyncDoor(Object &door)
+{
+	door._oAnimFrame += 2;
+	door._oPreFlag = true;
+	door._oVar4 = DOOR_OPEN;
+	door._oSelFlag = 2;
+
+	switch (door._otype) {
+	case OBJ_L1LDOOR:
+		ObjSetMicro(door.position, door._oVar1 == 214 ? 407 : 392);
+		dSpecial[door.position.x][door.position.y] = 7;
+		DoorSet(door.position + Direction::NorthEast, true);
+		break;
+	case OBJ_L1RDOOR:
+		ObjSetMicro(door.position, 394);
+		dSpecial[door.position.x][door.position.y] = 8;
+		DoorSet(door.position + Direction::NorthWest, false);
+		break;
+	case OBJ_L2LDOOR:
+		ObjSetMicro(door.position, 12);
+		dSpecial[door.position.x][door.position.y] = 5;
+		break;
+	case OBJ_L2RDOOR:
+		ObjSetMicro(door.position, 16);
+		dSpecial[door.position.x][door.position.y] = 6;
+		break;
+	case OBJ_L3LDOOR:
+		ObjSetMicro(door.position, 537);
+		break;
+	case OBJ_L3RDOOR:
+		ObjSetMicro(door.position, 540);
+		break;
+	case OBJ_L5LDOOR:
+		ObjSetMicro(door.position, 205);
+		dSpecial[door.position.x][door.position.y] = 1;
+		CryptDoorSet(door.position + Direction::NorthEast, true);
+		break;
+	case OBJ_L5RDOOR:
+		ObjSetMicro(door.position, 208);
+		dSpecial[door.position.x][door.position.y] = 2;
+		CryptDoorSet(door.position + Direction::NorthWest, false);
+		break;
+	}
+}
+
 /**
  * @brief Checks if all active crux objects of the given type have been broken.
  *
@@ -4814,7 +4832,7 @@ void OperateObject(Player &player, int i, bool teleFlag)
 	}
 }
 
-void DeltaSyncOpObject(int cmd, Object &object)
+void DeltaSyncOpObject(Object &object)
 {
 	switch (object._otype) {
 	case OBJ_L1LDOOR:
@@ -4825,7 +4843,7 @@ void DeltaSyncOpObject(int cmd, Object &object)
 	case OBJ_L3RDOOR:
 	case OBJ_L5LDOOR:
 	case OBJ_L5RDOOR:
-		SyncOperateDoor(cmd, object);
+		DeltaSyncDoor(object);
 		break;
 	case OBJ_LEVER:
 	case OBJ_L5LEVER:

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -121,16 +121,6 @@ struct Object {
 	}
 
 	/**
-	 * @brief Initializes this object as some form of door. Futher initialization of other game structures needs to be
-	 * performed separately, refer to the code in objects.cpp.
-	 */
-	constexpr void InitializeDoor()
-	{
-		_oDoorFlag = true;
-		_oVar4 = 0;
-	}
-
-	/**
 	 * @brief Marks an object which was spawned from a sublevel in response to a lever activation.
 	 * @param mapRange The region which was updated to spawn this object.
 	 * @param leverID The id (*not* an object ID/index) of the lever responsible for the map change.

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -311,7 +311,7 @@ void OperateObject(Player &player, int i, bool TeleFlag);
 void SyncOpObject(Player &player, int cmd, Object &object);
 void BreakObjectMissile(Object &object);
 void BreakObject(const Player &player, Object &object);
-void DeltaSyncOpObject(int cmd, Object &object);
+void DeltaSyncOpObject(Object &object);
 void DeltaSyncBreakObj(Object &object);
 void SyncBreakObj(const Player &player, Object &object);
 void SyncObjectAnim(Object &object);


### PR DESCRIPTION
Merge most of the high level door functions and split delta sync from the door functions. This revealed delta sync to be almost identical to `OpenDoor()`.

A bigger chunk of the door logic refactoring. Split in to a few logical commits. All in all this should still be mostly simple changes.

### Logic changes
`OpenDoor()` now sets
```cpp
door._oPreFlag = true;
door._oVar4 = DOOR_OPEN;
```

This was done during delta sync/direct operation so setting it on network sync should be correct.

-----

`CloseDoor()` now set:
```cpp
door._oMissFlag = false;
door._oSelFlag = 3;
```
This was done each frame by `UpdateDoor()` so L3 setting `true` and synced doors setting `2` was pretty pointless.

-----

`DeltaSyncOpObject()` is no longer called for `CMD_CLOSEDOOR`, doors are closed on spawn so this was probably just there to satisfy the call path being used previously.


P.s. this also completely removes the `deltaload` global