### PR TITLE
Unify and clean up door logic

### DIFF
--- a/Source/engine/path.cpp
+++ b/Source/engine/path.cpp
@@ -329,7 +329,7 @@ bool IsTileWalkable(Point position, bool ignoreDoors)
 {
 	Object *object = FindObjectAtPosition(position);
 	if (object != nullptr) {
-		if (ignoreDoors && object->IsDoor()) {
+		if (ignoreDoors && object->isDoor()) {
 			return true;
 		}
 		if (object->_oSolidFlag) {

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1823,238 +1823,30 @@ void CloseDoor(Object &door)
 	SetDoorStateClosed(door);
 }
 
-void OperateL1RDoor(Object &door, bool sendflag)
+void OperateDoor(Object &door, bool sendflag)
 {
-	if (!IsDoorClear(door.position)) {
-		PlaySfxLoc(IS_DOORCLOS, door.position);
+	bool isCrypt = IsAnyOf(door._otype, OBJ_L5LDOOR, OBJ_L5RDOOR);
+
+	if (!IsDoorClear(door)) {
+		PlaySfxLoc(isCrypt ? IS_CRCLOS : IS_DOORCLOS, door.position);
 		door._oVar4 = DOOR_BLOCKED;
 		return;
 	}
 
-	if (door._oVar4 == DOOR_CLOSED) {
-		if (sendflag)
-			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
-		PlaySfxLoc(IS_DOOROPEN, door.position);
+	bool openDoor = door._oVar4 == DOOR_CLOSED;
+
+	if (openDoor) {
+		PlaySfxLoc(isCrypt ? IS_CROPEN : IS_DOOROPEN, door.position);
 		OpenDoor(door);
 	} else {
-		PlaySfxLoc(IS_DOORCLOS, door.position);
-
-		if (sendflag)
-			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
+		PlaySfxLoc(isCrypt ? IS_CRCLOS : IS_DOORCLOS, door.position);
 		CloseDoor(door);
 	}
 
 	RedoPlayerVision();
-}
 
-void OperateL1LDoor(Object &door, bool sendflag)
-{
-	if (!IsDoorClear(door.position)) {
-		PlaySfxLoc(IS_DOORCLOS, door.position);
-		door._oVar4 = DOOR_BLOCKED;
-		return;
-	}
-
-	if (door._oVar4 == DOOR_CLOSED) {
-		if (sendflag)
-			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
-		PlaySfxLoc(IS_DOOROPEN, door.position);
-		OpenDoor(door);
-	} else {
-		PlaySfxLoc(IS_DOORCLOS, door.position);
-
-		if (sendflag)
-			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
-		CloseDoor(door);
-	}
-
-	RedoPlayerVision();
-}
-
-void OperateL2RDoor(Object &door, bool sendflag)
-{
-	if (!IsDoorClear(door.position)) {
-		PlaySfxLoc(IS_DOORCLOS, door.position);
-		door._oVar4 = DOOR_BLOCKED;
-		return;
-	}
-
-	if (door._oVar4 == DOOR_CLOSED) {
-		if (sendflag)
-			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
-		PlaySfxLoc(IS_DOOROPEN, door.position);
-		OpenDoor(door);
-	} else {
-		PlaySfxLoc(IS_DOORCLOS, door.position);
-
-		if (sendflag)
-			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
-		CloseDoor(door);
-	}
-
-	RedoPlayerVision();
-}
-
-void OperateL2LDoor(Object &door, bool sendflag)
-{
-	if (!IsDoorClear(door.position)) {
-		PlaySfxLoc(IS_DOORCLOS, door.position);
-		door._oVar4 = DOOR_BLOCKED;
-		return;
-	}
-
-	if (door._oVar4 == DOOR_CLOSED) {
-		if (sendflag)
-			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
-		PlaySfxLoc(IS_DOOROPEN, door.position);
-		OpenDoor(door);
-	} else {
-		PlaySfxLoc(IS_DOORCLOS, door.position);
-
-		if (sendflag)
-			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
-		CloseDoor(door);
-	}
-
-	RedoPlayerVision();
-}
-
-void OperateL3RDoor(Object &door, bool sendflag)
-{
-	if (!IsDoorClear(door.position)) {
-		PlaySfxLoc(IS_DOORCLOS, door.position);
-		door._oVar4 = DOOR_BLOCKED;
-		return;
-	}
-
-	if (door._oVar4 == DOOR_CLOSED) {
-		if (sendflag)
-			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
-		PlaySfxLoc(IS_DOOROPEN, door.position);
-		OpenDoor(door);
-	} else {
-		PlaySfxLoc(IS_DOORCLOS, door.position);
-
-		if (sendflag)
-			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
-		CloseDoor(door);
-	}
-
-	RedoPlayerVision();
-}
-
-void OperateL3LDoor(Object &door, bool sendflag)
-{
-	if (!IsDoorClear(door.position)) {
-		PlaySfxLoc(IS_DOORCLOS, door.position);
-		door._oVar4 = DOOR_BLOCKED;
-		return;
-	}
-
-	if (door._oVar4 == DOOR_CLOSED) {
-		if (sendflag)
-			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
-		PlaySfxLoc(IS_DOOROPEN, door.position);
-		OpenDoor(door);
-	} else {
-		PlaySfxLoc(IS_DOORCLOS, door.position);
-
-		if (sendflag)
-			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
-		CloseDoor(door);
-	}
-
-	RedoPlayerVision();
-}
-
-void OperateL5RDoor(Object &door, bool sendflag)
-{
-	if (!IsDoorClear(door.position)) {
-		PlaySfxLoc(IS_CRCLOS, door.position);
-		door._oVar4 = DOOR_BLOCKED;
-		return;
-	}
-
-	if (door._oVar4 == DOOR_CLOSED) {
-		if (sendflag)
-			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
-		PlaySfxLoc(IS_CROPEN, door.position);
-		OpenDoor(door);
-	} else {
-		PlaySfxLoc(IS_CRCLOS, door.position);
-
-		if (sendflag)
-			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
-		CloseDoor(door);
-	}
-
-	RedoPlayerVision();
-}
-
-void OperateL5LDoor(Object &door, bool sendflag)
-{
-	if (!IsDoorClear(door.position)) {
-		PlaySfxLoc(IS_CRCLOS, door.position);
-		door._oVar4 = DOOR_BLOCKED;
-		return;
-	}
-
-	if (door._oVar4 == DOOR_CLOSED) {
-		if (sendflag)
-			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
-		PlaySfxLoc(IS_CROPEN, door.position);
-		OpenDoor(door);
-	} else {
-		PlaySfxLoc(IS_CRCLOS, door.position);
-
-		if (sendflag)
-			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
-		CloseDoor(door);
-	}
-
-	RedoPlayerVision();
-}
-
-void OperateDoor(const Player &player, Object &door)
-{
-	int dpx = abs(door.position.x - player.position.tile.x);
-	int dpy = abs(door.position.y - player.position.tile.y);
-	if (dpx == 1 && dpy <= 1) {
-		switch (door._otype) {
-		case OBJ_L1LDOOR:
-			OperateL1LDoor(door, true);
-			break;
-		case OBJ_L2LDOOR:
-			OperateL2LDoor(door, true);
-			break;
-		case OBJ_L3RDOOR:
-			OperateL3RDoor(door, true);
-			break;
-		case OBJ_L5LDOOR:
-			OperateL5LDoor(door, true);
-			break;
-		default:
-			break;
-		}
-	}
-	if (dpx <= 1 && dpy == 1) {
-		switch (door._otype) {
-		case OBJ_L1RDOOR:
-			OperateL1RDoor(door, true);
-			break;
-		case OBJ_L2RDOOR:
-			OperateL2RDoor(door, true);
-			break;
-		case OBJ_L3LDOOR:
-			OperateL3LDoor(door, true);
-			break;
-		case OBJ_L5RDOOR:
-			OperateL5RDoor(door, true);
-			break;
-		default:
-			break;
-		}
-	}
+	if (sendflag)
+		NetSendCmdLoc(MyPlayerId, true, openDoor ? CMD_OPENDOOR : CMD_CLOSEDOOR, door.position);
 }
 
 bool AreAllLeversActivated(int leverId)
@@ -3603,43 +3395,6 @@ void OperateLazStand(Object &stand)
 	SpawnQuestItem(IDI_LAZSTAFF, pos, 0, 0);
 }
 
-void SyncOperateDoor(int cmd, Object &door)
-{
-	if (cmd == CMD_CLOSEDOOR && door._oVar4 == DOOR_CLOSED)
-		return;
-	if (cmd == CMD_OPENDOOR && door._oVar4 == DOOR_OPEN)
-		return;
-
-	switch (door._otype) {
-	case OBJ_L1LDOOR:
-		OperateL1LDoor(door, false);
-		break;
-	case OBJ_L1RDOOR:
-		OperateL1RDoor(door, false);
-		break;
-	case OBJ_L2LDOOR:
-		OperateL2LDoor(door, false);
-		break;
-	case OBJ_L2RDOOR:
-		OperateL2RDoor(door, false);
-		break;
-	case OBJ_L3LDOOR:
-		OperateL3LDoor(door, false);
-		break;
-	case OBJ_L3RDOOR:
-		OperateL3RDoor(door, false);
-		break;
-	case OBJ_L5LDOOR:
-		OperateL5LDoor(door, false);
-		break;
-	case OBJ_L5RDOOR:
-		OperateL5RDoor(door, false);
-		break;
-	default:
-		break;
-	}
-}
-
 /**
  * @brief Checks if all active crux objects of the given type have been broken.
  *
@@ -4509,36 +4264,10 @@ void MonstCheckDoors(const Monster &monster)
 
 		Object &door = *object;
 		// Doors use _oVar4 to track open/closed state, non-zero values indicate an open door
-		// we don't use Object::isDoor since the later conditions will check the object is actually a door anyway.
-		if (door._oVar4 != DOOR_CLOSED)
+		if (!door.isDoor() || door._oVar4 != DOOR_CLOSED)
 			continue;
 
-		// Strictly speaking these checks shouldn't be required, they're guarding against monsters
-		// standing in a wall opening an adjacent door. Shouldn't be possible?
-		if (IsNoneOf(dir, Direction::NorthEast, Direction::SouthWest)) {
-			if (door._otype == OBJ_L1LDOOR) {
-				OperateL1LDoor(door, true);
-			} else if (door._otype == OBJ_L2LDOOR) {
-				OperateL2LDoor(door, true);
-			} else if (door._otype == OBJ_L3RDOOR) {
-				// L3 doors are backwards, see OperateDoor
-				OperateL3RDoor(door, true);
-			} else if (door._otype == OBJ_L5LDOOR) {
-				OperateL5LDoor(door, true);
-			}
-		}
-		if (IsNoneOf(dir, Direction::NorthWest, Direction::SouthEast)) {
-			if (door._otype == OBJ_L1RDOOR) {
-				OperateL1RDoor(door, true);
-			} else if (door._otype == OBJ_L2RDOOR) {
-				OperateL2RDoor(door, true);
-			} else if (door._otype == OBJ_L3LDOOR) {
-				// L3 doors are backwards, see OperateDoor
-				OperateL3LDoor(door, true);
-			} else if (door._otype == OBJ_L5RDOOR) {
-				OperateL5RDoor(door, true);
-			}
-		}
+		OperateDoor(door, true);
 	}
 }
 
@@ -4606,27 +4335,8 @@ void OperateObject(Player &player, int i, bool teleFlag)
 	case OBJ_L3RDOOR:
 	case OBJ_L5LDOOR:
 	case OBJ_L5RDOOR:
-		if (teleFlag) {
-			if (object._otype == OBJ_L1LDOOR)
-				OperateL1LDoor(object, sendmsg);
-			if (object._otype == OBJ_L1RDOOR)
-				OperateL1RDoor(object, sendmsg);
-			if (object._otype == OBJ_L2LDOOR)
-				OperateL2LDoor(object, sendmsg);
-			if (object._otype == OBJ_L2RDOOR)
-				OperateL2RDoor(object, sendmsg);
-			if (object._otype == OBJ_L3LDOOR)
-				OperateL3LDoor(object, sendmsg);
-			if (object._otype == OBJ_L3RDOOR)
-				OperateL3RDoor(object, sendmsg);
-			if (object._otype == OBJ_L5LDOOR)
-				OperateL5LDoor(object, sendmsg);
-			if (object._otype == OBJ_L5RDOOR)
-				OperateL5RDoor(object, sendmsg);
-			break;
-		}
-		if (sendmsg)
-			OperateDoor(player, object);
+		if (teleFlag || (sendmsg && abs(object.position.x - player.position.tile.x) <= 1 && abs(object.position.y - player.position.tile.y) <= 1))
+			OperateDoor(object, sendmsg);
 		break;
 	case OBJ_LEVER:
 	case OBJ_L5LEVER:
@@ -4805,8 +4515,13 @@ void SyncOpObject(Player &player, int cmd, Object &object)
 	case OBJ_L3RDOOR:
 	case OBJ_L5LDOOR:
 	case OBJ_L5RDOOR:
-		if (!sendmsg)
-			SyncOperateDoor(cmd, object);
+		if (sendmsg)
+			break;
+		if (cmd == CMD_CLOSEDOOR && object._oVar4 == DOOR_CLOSED)
+			break;
+		if (cmd == CMD_OPENDOOR && object._oVar4 == DOOR_OPEN)
+			break;
+		OperateDoor(object, false);
 		break;
 	case OBJ_LEVER:
 	case OBJ_L5LEVER:

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1055,6 +1055,175 @@ void ObjSetMicro(Point position, int pn)
 	dPiece[position.x][position.y] = pn;
 }
 
+void DoorSet(Point position, bool isLeftDoor)
+{
+	int pn = dPiece[position.x][position.y];
+	switch (pn) {
+	case 42:
+		ObjSetMicro(position, 391);
+		break;
+	case 44:
+		ObjSetMicro(position, 393);
+		break;
+	case 49:
+		ObjSetMicro(position, isLeftDoor ? 410 : 411);
+		break;
+	case 53:
+		ObjSetMicro(position, 396);
+		break;
+	case 54:
+		ObjSetMicro(position, 397);
+		break;
+	case 60:
+		ObjSetMicro(position, 398);
+		break;
+	case 66:
+		ObjSetMicro(position, 399);
+		break;
+	case 67:
+		ObjSetMicro(position, 400);
+		break;
+	case 68:
+		ObjSetMicro(position, 402);
+		break;
+	case 69:
+		ObjSetMicro(position, 403);
+		break;
+	case 71:
+		ObjSetMicro(position, 405);
+		break;
+	case 211:
+		ObjSetMicro(position, 406);
+		break;
+	case 353:
+		ObjSetMicro(position, 408);
+		break;
+	case 354:
+		ObjSetMicro(position, 409);
+		break;
+	case 410:
+	case 411:
+		ObjSetMicro(position, 395);
+		break;
+	}
+}
+
+void CryptDoorSet(Point position, bool isLeftDoor)
+{
+	int pn = dPiece[position.x][position.y];
+	switch (pn) {
+	case 74:
+		ObjSetMicro(position, 203);
+		break;
+	case 78:
+		ObjSetMicro(position, 207);
+		break;
+	case 85:
+		ObjSetMicro(position, isLeftDoor ? 231 : 233);
+		break;
+	case 90:
+		ObjSetMicro(position, 214);
+		break;
+	case 92:
+		ObjSetMicro(position, 217);
+		break;
+	case 98:
+		ObjSetMicro(position, 219);
+		break;
+	case 110:
+		ObjSetMicro(position, 221);
+		break;
+	case 112:
+		ObjSetMicro(position, 223);
+		break;
+	case 114:
+		ObjSetMicro(position, 225);
+		break;
+	case 116:
+		ObjSetMicro(position, 227);
+		break;
+	case 118:
+		ObjSetMicro(position, 229);
+		break;
+	case 231:
+	case 233:
+		ObjSetMicro(position, 211);
+		break;
+	}
+}
+
+void SetDoorStateOpen(Object &door)
+{
+	door._oPreFlag = true;
+	door._oVar4 = DOOR_OPEN;
+	door._oMissFlag = true;
+	door._oSelFlag = 2;
+
+	switch (door._otype) {
+	case OBJ_L1LDOOR:
+		ObjSetMicro(door.position, door._oVar1 == 214 ? 407 : 392);
+		dSpecial[door.position.x][door.position.y] = 7;
+		DoorSet(door.position + Direction::NorthEast, true);
+		break;
+	case OBJ_L1RDOOR:
+		ObjSetMicro(door.position, 394);
+		dSpecial[door.position.x][door.position.y] = 8;
+		DoorSet(door.position + Direction::NorthWest, false);
+		break;
+	case OBJ_L2LDOOR:
+		ObjSetMicro(door.position, 12);
+		dSpecial[door.position.x][door.position.y] = 5;
+		break;
+	case OBJ_L2RDOOR:
+		ObjSetMicro(door.position, 16);
+		dSpecial[door.position.x][door.position.y] = 6;
+		break;
+	case OBJ_L3LDOOR:
+		ObjSetMicro(door.position, 537);
+		break;
+	case OBJ_L3RDOOR:
+		ObjSetMicro(door.position, 540);
+		break;
+	case OBJ_L5LDOOR:
+		ObjSetMicro(door.position, 205);
+		dSpecial[door.position.x][door.position.y] = 1;
+		CryptDoorSet(door.position + Direction::NorthEast, true);
+		break;
+	case OBJ_L5RDOOR:
+		ObjSetMicro(door.position, 208);
+		dSpecial[door.position.x][door.position.y] = 2;
+		CryptDoorSet(door.position + Direction::NorthWest, false);
+		break;
+	default:
+		break;
+	}
+}
+
+void SetDoorStateClosed(Object &door)
+{
+	door._oMissFlag = false;
+	door._oSelFlag = 3;
+
+	switch (door._otype) {
+	case OBJ_L2LDOOR:
+		ObjSetMicro(door.position, 537);
+		dSpecial[door.position.x][door.position.y] = 0;
+		break;
+	case OBJ_L2RDOOR:
+		ObjSetMicro(door.position, 539);
+		dSpecial[door.position.x][door.position.y] = 0;
+		break;
+	case OBJ_L3LDOOR:
+		ObjSetMicro(door.position, 530);
+		break;
+	case OBJ_L3RDOOR:
+		ObjSetMicro(door.position, 533);
+		break;
+	default:
+		break;
+	}
+}
+
 void AddDoor(Object &door)
 {
 	door._oDoorFlag = true;
@@ -1606,103 +1775,6 @@ void ObjL2Special(int x1, int y1, int x2, int y2)
 				dSpecial[i + 2][j] = 4;
 			}
 		}
-	}
-}
-
-void DoorSet(Point position, bool isLeftDoor)
-{
-	int pn = dPiece[position.x][position.y];
-	switch (pn) {
-	case 42:
-		ObjSetMicro(position, 391);
-		break;
-	case 44:
-		ObjSetMicro(position, 393);
-		break;
-	case 49:
-		ObjSetMicro(position, isLeftDoor ? 410 : 411);
-		break;
-	case 53:
-		ObjSetMicro(position, 396);
-		break;
-	case 54:
-		ObjSetMicro(position, 397);
-		break;
-	case 60:
-		ObjSetMicro(position, 398);
-		break;
-	case 66:
-		ObjSetMicro(position, 399);
-		break;
-	case 67:
-		ObjSetMicro(position, 400);
-		break;
-	case 68:
-		ObjSetMicro(position, 402);
-		break;
-	case 69:
-		ObjSetMicro(position, 403);
-		break;
-	case 71:
-		ObjSetMicro(position, 405);
-		break;
-	case 211:
-		ObjSetMicro(position, 406);
-		break;
-	case 353:
-		ObjSetMicro(position, 408);
-		break;
-	case 354:
-		ObjSetMicro(position, 409);
-		break;
-	case 410:
-	case 411:
-		ObjSetMicro(position, 395);
-		break;
-	}
-}
-
-void CryptDoorSet(Point position, bool isLeftDoor)
-{
-	int pn = dPiece[position.x][position.y];
-	switch (pn) {
-	case 74:
-		ObjSetMicro(position, 203);
-		break;
-	case 78:
-		ObjSetMicro(position, 207);
-		break;
-	case 85:
-		ObjSetMicro(position, isLeftDoor ? 231 : 233);
-		break;
-	case 90:
-		ObjSetMicro(position, 214);
-		break;
-	case 92:
-		ObjSetMicro(position, 217);
-		break;
-	case 98:
-		ObjSetMicro(position, 219);
-		break;
-	case 110:
-		ObjSetMicro(position, 221);
-		break;
-	case 112:
-		ObjSetMicro(position, 223);
-		break;
-	case 114:
-		ObjSetMicro(position, 225);
-		break;
-	case 116:
-		ObjSetMicro(position, 227);
-		break;
-	case 118:
-		ObjSetMicro(position, 229);
-		break;
-	case 231:
-	case 233:
-		ObjSetMicro(position, 211);
-		break;
 	}
 }
 
@@ -3810,84 +3882,12 @@ void SyncPedestal(const Object &pedestal, Point origin, int width)
 	}
 }
 
-void OpenDoor(Object &door)
-{
-	door._oPreFlag = true;
-	door._oVar4 = DOOR_OPEN;
-	door._oMissFlag = true;
-	door._oSelFlag = 2;
-
-	switch (door._otype) {
-	case OBJ_L1LDOOR:
-		ObjSetMicro(door.position, door._oVar1 == 214 ? 407 : 392);
-		dSpecial[door.position.x][door.position.y] = 7;
-		DoorSet(door.position + Direction::NorthEast, true);
-		break;
-	case OBJ_L1RDOOR:
-		ObjSetMicro(door.position, 394);
-		dSpecial[door.position.x][door.position.y] = 8;
-		DoorSet(door.position + Direction::NorthWest, false);
-		break;
-	case OBJ_L2LDOOR:
-		ObjSetMicro(door.position, 12);
-		dSpecial[door.position.x][door.position.y] = 5;
-		break;
-	case OBJ_L2RDOOR:
-		ObjSetMicro(door.position, 16);
-		dSpecial[door.position.x][door.position.y] = 6;
-		break;
-	case OBJ_L3LDOOR:
-		ObjSetMicro(door.position, 537);
-		break;
-	case OBJ_L3RDOOR:
-		ObjSetMicro(door.position, 540);
-		break;
-	case OBJ_L5LDOOR:
-		ObjSetMicro(door.position, 205);
-		dSpecial[door.position.x][door.position.y] = 1;
-		CryptDoorSet(door.position + Direction::NorthEast, true);
-		break;
-	case OBJ_L5RDOOR:
-		ObjSetMicro(door.position, 208);
-		dSpecial[door.position.x][door.position.y] = 2;
-		CryptDoorSet(door.position + Direction::NorthWest, false);
-		break;
-	default:
-		break;
-	}
-}
-
-void CloseDoor(Object &door)
-{
-	door._oMissFlag = false;
-	door._oSelFlag = 3;
-
-	switch (door._otype) {
-	case OBJ_L2LDOOR:
-		ObjSetMicro(door.position, 537);
-		dSpecial[door.position.x][door.position.y] = 0;
-		break;
-	case OBJ_L2RDOOR:
-		ObjSetMicro(door.position, 539);
-		dSpecial[door.position.x][door.position.y] = 0;
-		break;
-	case OBJ_L3LDOOR:
-		ObjSetMicro(door.position, 530);
-		break;
-	case OBJ_L3RDOOR:
-		ObjSetMicro(door.position, 533);
-		break;
-	default:
-		break;
-	}
-}
-
 void SyncDoor(Object &door)
 {
 	if (door._oVar4 == DOOR_CLOSED) {
-		CloseDoor(door);
+		SetDoorStateClosed(door);
 	} else {
-		OpenDoor(door);
+		SetDoorStateOpen(door);
 	}
 }
 
@@ -4827,7 +4827,7 @@ void DeltaSyncOpObject(Object &object)
 	case OBJ_L5LDOOR:
 	case OBJ_L5RDOOR:
 		object._oAnimFrame += 2;
-		OpenDoor(object);
+		SetDoorStateOpen(object);
 		break;
 	case OBJ_LEVER:
 	case OBJ_L5LEVER:

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1767,8 +1767,9 @@ void ObjL2Special(int x1, int y1, int x2, int y2)
 
 void OperateL1RDoor(Object &door, bool sendflag)
 {
-	if (door._oVar4 == DOOR_BLOCKED) {
+	if (!IsDoorClear(door.position)) {
 		PlaySfxLoc(IS_DOORCLOS, door.position);
+		door._oVar4 = DOOR_BLOCKED;
 		return;
 	}
 
@@ -1783,12 +1784,9 @@ void OperateL1RDoor(Object &door, bool sendflag)
 		DoorSet(door.position + Direction::NorthWest, false);
 		door._oVar4 = DOOR_OPEN;
 		door._oSelFlag = 2;
-		RedoPlayerVision();
-		return;
-	}
+	} else {
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 
-	PlaySfxLoc(IS_DOORCLOS, door.position);
-	if (IsDoorClear(door.position)) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
 		door._oVar4 = DOOR_CLOSED;
@@ -1805,16 +1803,16 @@ void OperateL1RDoor(Object &door, bool sendflag)
 		dSpecial[door.position.x][door.position.y] = 0;
 		door._oAnimFrame -= 2;
 		door._oPreFlag = false;
-		RedoPlayerVision();
-	} else {
-		door._oVar4 = DOOR_BLOCKED;
 	}
+
+	RedoPlayerVision();
 }
 
 void OperateL1LDoor(Object &door, bool sendflag)
 {
-	if (door._oVar4 == DOOR_BLOCKED) {
+	if (!IsDoorClear(door.position)) {
 		PlaySfxLoc(IS_DOORCLOS, door.position);
+		door._oVar4 = DOOR_BLOCKED;
 		return;
 	}
 
@@ -1829,12 +1827,9 @@ void OperateL1LDoor(Object &door, bool sendflag)
 		DoorSet(door.position + Direction::NorthEast, true);
 		door._oVar4 = DOOR_OPEN;
 		door._oSelFlag = 2;
-		RedoPlayerVision();
-		return;
-	}
+	} else {
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 
-	PlaySfxLoc(IS_DOORCLOS, door.position);
-	if (IsDoorClear(door.position)) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
 		door._oVar4 = DOOR_CLOSED;
@@ -1851,16 +1846,16 @@ void OperateL1LDoor(Object &door, bool sendflag)
 		dSpecial[door.position.x][door.position.y] = 0;
 		door._oAnimFrame -= 2;
 		door._oPreFlag = false;
-		RedoPlayerVision();
-	} else {
-		door._oVar4 = DOOR_BLOCKED;
 	}
+
+	RedoPlayerVision();
 }
 
 void OperateL2RDoor(Object &door, bool sendflag)
 {
-	if (door._oVar4 == DOOR_BLOCKED) {
+	if (!IsDoorClear(door.position)) {
 		PlaySfxLoc(IS_DOORCLOS, door.position);
+		door._oVar4 = DOOR_BLOCKED;
 		return;
 	}
 
@@ -1874,13 +1869,9 @@ void OperateL2RDoor(Object &door, bool sendflag)
 		door._oPreFlag = true;
 		door._oVar4 = DOOR_OPEN;
 		door._oSelFlag = 2;
-		RedoPlayerVision();
-		return;
-	}
+	} else {
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 
-	PlaySfxLoc(IS_DOORCLOS, door.position);
-
-	if (IsDoorClear(door.position)) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
 		door._oVar4 = DOOR_CLOSED;
@@ -1889,16 +1880,16 @@ void OperateL2RDoor(Object &door, bool sendflag)
 		dSpecial[door.position.x][door.position.y] = 0;
 		door._oAnimFrame -= 2;
 		door._oPreFlag = false;
-		RedoPlayerVision();
-	} else {
-		door._oVar4 = DOOR_BLOCKED;
 	}
+
+	RedoPlayerVision();
 }
 
 void OperateL2LDoor(Object &door, bool sendflag)
 {
-	if (door._oVar4 == DOOR_BLOCKED) {
+	if (!IsDoorClear(door.position)) {
 		PlaySfxLoc(IS_DOORCLOS, door.position);
+		door._oVar4 = DOOR_BLOCKED;
 		return;
 	}
 
@@ -1912,13 +1903,9 @@ void OperateL2LDoor(Object &door, bool sendflag)
 		door._oPreFlag = true;
 		door._oVar4 = DOOR_OPEN;
 		door._oSelFlag = 2;
-		RedoPlayerVision();
-		return;
-	}
+	} else {
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 
-	PlaySfxLoc(IS_DOORCLOS, door.position);
-
-	if (IsDoorClear(door.position)) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
 		door._oVar4 = DOOR_CLOSED;
@@ -1927,16 +1914,16 @@ void OperateL2LDoor(Object &door, bool sendflag)
 		dSpecial[door.position.x][door.position.y] = 0;
 		door._oAnimFrame -= 2;
 		door._oPreFlag = false;
-		RedoPlayerVision();
-	} else {
-		door._oVar4 = DOOR_BLOCKED;
 	}
+
+	RedoPlayerVision();
 }
 
 void OperateL3RDoor(Object &door, bool sendflag)
 {
-	if (door._oVar4 == DOOR_BLOCKED) {
+	if (!IsDoorClear(door.position)) {
 		PlaySfxLoc(IS_DOORCLOS, door.position);
+		door._oVar4 = DOOR_BLOCKED;
 		return;
 	}
 
@@ -1949,13 +1936,9 @@ void OperateL3RDoor(Object &door, bool sendflag)
 		door._oPreFlag = true;
 		door._oVar4 = DOOR_OPEN;
 		door._oSelFlag = 2;
-		RedoPlayerVision();
-		return;
-	}
+	} else {
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 
-	PlaySfxLoc(IS_DOORCLOS, door.position);
-
-	if (IsDoorClear(door.position)) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
 		door._oVar4 = DOOR_CLOSED;
@@ -1963,16 +1946,16 @@ void OperateL3RDoor(Object &door, bool sendflag)
 		ObjSetMicro(door.position, 533);
 		door._oAnimFrame -= 2;
 		door._oPreFlag = false;
-		RedoPlayerVision();
-	} else {
-		door._oVar4 = DOOR_BLOCKED;
 	}
+
+	RedoPlayerVision();
 }
 
 void OperateL3LDoor(Object &door, bool sendflag)
 {
-	if (door._oVar4 == DOOR_BLOCKED) {
+	if (!IsDoorClear(door.position)) {
 		PlaySfxLoc(IS_DOORCLOS, door.position);
+		door._oVar4 = DOOR_BLOCKED;
 		return;
 	}
 
@@ -1985,13 +1968,9 @@ void OperateL3LDoor(Object &door, bool sendflag)
 		door._oPreFlag = true;
 		door._oVar4 = DOOR_OPEN;
 		door._oSelFlag = 2;
-		RedoPlayerVision();
-		return;
-	}
+	} else {
+		PlaySfxLoc(IS_DOORCLOS, door.position);
 
-	PlaySfxLoc(IS_DOORCLOS, door.position);
-
-	if (IsDoorClear(door.position)) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
 		door._oVar4 = DOOR_CLOSED;
@@ -1999,16 +1978,16 @@ void OperateL3LDoor(Object &door, bool sendflag)
 		ObjSetMicro(door.position, 530);
 		door._oAnimFrame -= 2;
 		door._oPreFlag = false;
-		RedoPlayerVision();
-	} else {
-		door._oVar4 = DOOR_BLOCKED;
 	}
+
+	RedoPlayerVision();
 }
 
 void OperateL5RDoor(Object &door, bool sendflag)
 {
-	if (door._oVar4 == DOOR_BLOCKED) {
-		PlaySfxLoc(IS_DOORCLOS, door.position);
+	if (!IsDoorClear(door.position)) {
+		PlaySfxLoc(IS_CRCLOS, door.position);
+		door._oVar4 = DOOR_BLOCKED;
 		return;
 	}
 
@@ -2023,12 +2002,9 @@ void OperateL5RDoor(Object &door, bool sendflag)
 		CryptDoorSet(door.position + Direction::NorthWest, false);
 		door._oVar4 = DOOR_OPEN;
 		door._oSelFlag = 2;
-		RedoPlayerVision();
-		return;
-	}
+	} else {
+		PlaySfxLoc(IS_CRCLOS, door.position);
 
-	PlaySfxLoc(IS_CRCLOS, door.position);
-	if (IsDoorClear(door.position)) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
 		door._oVar4 = DOOR_CLOSED;
@@ -2045,16 +2021,16 @@ void OperateL5RDoor(Object &door, bool sendflag)
 		dSpecial[door.position.x][door.position.y] = 0;
 		door._oAnimFrame -= 2;
 		door._oPreFlag = false;
-		RedoPlayerVision();
-	} else {
-		door._oVar4 = DOOR_BLOCKED;
 	}
+
+	RedoPlayerVision();
 }
 
 void OperateL5LDoor(Object &door, bool sendflag)
 {
-	if (door._oVar4 == DOOR_BLOCKED) {
-		PlaySfxLoc(IS_DOORCLOS, door.position);
+	if (!IsDoorClear(door.position)) {
+		PlaySfxLoc(IS_CRCLOS, door.position);
+		door._oVar4 = DOOR_BLOCKED;
 		return;
 	}
 
@@ -2069,12 +2045,9 @@ void OperateL5LDoor(Object &door, bool sendflag)
 		CryptDoorSet(door.position + Direction::NorthEast, true);
 		door._oVar4 = DOOR_OPEN;
 		door._oSelFlag = 2;
-		RedoPlayerVision();
-		return;
-	}
+	} else {
+		PlaySfxLoc(IS_CRCLOS, door.position);
 
-	PlaySfxLoc(IS_CRCLOS, door.position);
-	if (IsDoorClear(door.position)) {
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
 		door._oVar4 = DOOR_CLOSED;
@@ -2091,10 +2064,9 @@ void OperateL5LDoor(Object &door, bool sendflag)
 		dSpecial[door.position.x][door.position.y] = 0;
 		door._oAnimFrame -= 2;
 		door._oPreFlag = false;
-		RedoPlayerVision();
-	} else {
-		door._oVar4 = DOOR_BLOCKED;
 	}
+
+	RedoPlayerVision();
 }
 
 void OperateDoor(const Player &player, Object &door)

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1201,6 +1201,7 @@ void SetDoorStateOpen(Object &door)
 
 void SetDoorStateClosed(Object &door)
 {
+	door._oVar4 = DOOR_CLOSED;
 	door._oMissFlag = false;
 	door._oSelFlag = 3;
 
@@ -1227,7 +1228,6 @@ void SetDoorStateClosed(Object &door)
 void AddDoor(Object &door)
 {
 	door._oDoorFlag = true;
-	door._oVar4 = DOOR_CLOSED;
 
 	switch (door._otype) {
 	case OBJ_L1LDOOR:
@@ -1240,24 +1240,11 @@ void AddDoor(Object &door)
 		door._oVar1 = dPiece[door.position.x][door.position.y] + 1;
 		door._oVar2 = dPiece[door.position.x - 1][door.position.y] + 1;
 		break;
-	case OBJ_L2LDOOR:
-		// If a catacombs door happens to overlap an arch then clear the arch tile to prevent weird rendering
-		dSpecial[door.position.x][door.position.y] = 0;
-		ObjSetMicro(door.position, 537);
-		break;
-	case OBJ_L2RDOOR:
-		dSpecial[door.position.x][door.position.y] = 0;
-		ObjSetMicro(door.position, 539);
-		break;
-	case OBJ_L3LDOOR:
-		ObjSetMicro(door.position, 530);
-		break;
-	case OBJ_L3RDOOR:
-		ObjSetMicro(door.position, 533);
-		break;
 	default:
 		break;
 	}
+
+	SetDoorStateClosed(door);
 }
 
 void AddSarcophagus(Object &sarcophagus)

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1154,8 +1154,8 @@ void CryptDoorSet(Point position, bool isLeftDoor)
 
 void SetDoorStateOpen(Object &door)
 {
-	door._oPreFlag = true;
 	door._oVar4 = DOOR_OPEN;
+	door._oPreFlag = true;
 	door._oMissFlag = true;
 	door._oSelFlag = 2;
 
@@ -1202,10 +1202,37 @@ void SetDoorStateOpen(Object &door)
 void SetDoorStateClosed(Object &door)
 {
 	door._oVar4 = DOOR_CLOSED;
+	door._oPreFlag = false;
 	door._oMissFlag = false;
 	door._oSelFlag = 3;
 
 	switch (door._otype) {
+	case OBJ_L1LDOOR: {
+		ObjSetMicro(door.position, door._oVar1 - 1);
+
+		// Restore the normal tile where the open door used to be
+		auto openPosition = door.position + Direction::NorthEast;
+		if (door._oVar2 == 50 && dPiece[openPosition.x][openPosition.y] == 395)
+			ObjSetMicro(openPosition, 411);
+		else
+			ObjSetMicro(openPosition, door._oVar2 - 1);
+
+		dSpecial[door.position.x][door.position.y] = 0;
+		break;
+	} break;
+	case OBJ_L1RDOOR: {
+		ObjSetMicro(door.position, door._oVar1 - 1);
+
+		// Restore the normal tile where the open door used to be
+		auto openPosition = door.position + Direction::NorthWest;
+		if (door._oVar2 == 50 && dPiece[openPosition.x][openPosition.y] == 395)
+			ObjSetMicro(openPosition, 410);
+		else
+			ObjSetMicro(openPosition, door._oVar2 - 1);
+
+		dSpecial[door.position.x][door.position.y] = 0;
+		break;
+	} break;
 	case OBJ_L2LDOOR:
 		ObjSetMicro(door.position, 537);
 		dSpecial[door.position.x][door.position.y] = 0;
@@ -1220,6 +1247,30 @@ void SetDoorStateClosed(Object &door)
 	case OBJ_L3RDOOR:
 		ObjSetMicro(door.position, 533);
 		break;
+	case OBJ_L5LDOOR: {
+		ObjSetMicro(door.position, door._oVar1 - 1);
+
+		// Restore the normal tile where the open door used to be
+		auto openPosition = door.position + Direction::NorthEast;
+		if (door._oVar2 == 86 && dPiece[openPosition.x][openPosition.y] == 209)
+			ObjSetMicro(openPosition, 233);
+		else
+			ObjSetMicro(openPosition, door._oVar2 - 1);
+
+		dSpecial[door.position.x][door.position.y] = 0;
+	} break;
+	case OBJ_L5RDOOR: {
+		ObjSetMicro(door.position, door._oVar1 - 1);
+
+		// Restore the normal tile where the open door used to be
+		auto openPosition = door.position + Direction::NorthWest;
+		if (door._oVar2 == 86 && dPiece[openPosition.x][openPosition.y] == 209)
+			ObjSetMicro(openPosition, 231);
+		else
+			ObjSetMicro(openPosition, door._oVar2 - 1);
+
+		dSpecial[door.position.x][door.position.y] = 0;
+	} break;
 	default:
 		break;
 	}
@@ -1765,6 +1816,18 @@ void ObjL2Special(int x1, int y1, int x2, int y2)
 	}
 }
 
+void OpenDoor(Object &door)
+{
+	door._oAnimFrame += 2;
+	SetDoorStateOpen(door);
+}
+
+void CloseDoor(Object &door)
+{
+	door._oAnimFrame -= 2;
+	SetDoorStateClosed(door);
+}
+
 void OperateL1RDoor(Object &door, bool sendflag)
 {
 	if (!IsDoorClear(door.position)) {
@@ -1777,32 +1840,13 @@ void OperateL1RDoor(Object &door, bool sendflag)
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
 		PlaySfxLoc(IS_DOOROPEN, door.position);
-		ObjSetMicro(door.position, 394);
-		dSpecial[door.position.x][door.position.y] = 8;
-		door._oAnimFrame += 2;
-		door._oPreFlag = true;
-		DoorSet(door.position + Direction::NorthWest, false);
-		door._oVar4 = DOOR_OPEN;
-		door._oSelFlag = 2;
+		OpenDoor(door);
 	} else {
 		PlaySfxLoc(IS_DOORCLOS, door.position);
 
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
-		door._oVar4 = DOOR_CLOSED;
-		door._oSelFlag = 3;
-		ObjSetMicro(door.position, door._oVar1 - 1);
-
-		// Restore the normal tile where the open door used to be
-		auto openPosition = door.position + Direction::NorthWest;
-		if (door._oVar2 == 50 && dPiece[openPosition.x][openPosition.y] == 395)
-			ObjSetMicro(openPosition, 410);
-		else
-			ObjSetMicro(openPosition, door._oVar2 - 1);
-
-		dSpecial[door.position.x][door.position.y] = 0;
-		door._oAnimFrame -= 2;
-		door._oPreFlag = false;
+		CloseDoor(door);
 	}
 
 	RedoPlayerVision();
@@ -1820,32 +1864,13 @@ void OperateL1LDoor(Object &door, bool sendflag)
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
 		PlaySfxLoc(IS_DOOROPEN, door.position);
-		ObjSetMicro(door.position, door._oVar1 == 214 ? 407 : 392);
-		dSpecial[door.position.x][door.position.y] = 7;
-		door._oAnimFrame += 2;
-		door._oPreFlag = true;
-		DoorSet(door.position + Direction::NorthEast, true);
-		door._oVar4 = DOOR_OPEN;
-		door._oSelFlag = 2;
+		OpenDoor(door);
 	} else {
 		PlaySfxLoc(IS_DOORCLOS, door.position);
 
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
-		door._oVar4 = DOOR_CLOSED;
-		door._oSelFlag = 3;
-		ObjSetMicro(door.position, door._oVar1 - 1);
-
-		// Restore the normal tile where the open door used to be
-		auto openPosition = door.position + Direction::NorthEast;
-		if (door._oVar2 == 50 && dPiece[openPosition.x][openPosition.y] == 395)
-			ObjSetMicro(openPosition, 411);
-		else
-			ObjSetMicro(openPosition, door._oVar2 - 1);
-
-		dSpecial[door.position.x][door.position.y] = 0;
-		door._oAnimFrame -= 2;
-		door._oPreFlag = false;
+		CloseDoor(door);
 	}
 
 	RedoPlayerVision();
@@ -1863,23 +1888,13 @@ void OperateL2RDoor(Object &door, bool sendflag)
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
 		PlaySfxLoc(IS_DOOROPEN, door.position);
-		ObjSetMicro(door.position, 16);
-		dSpecial[door.position.x][door.position.y] = 6;
-		door._oAnimFrame += 2;
-		door._oPreFlag = true;
-		door._oVar4 = DOOR_OPEN;
-		door._oSelFlag = 2;
+		OpenDoor(door);
 	} else {
 		PlaySfxLoc(IS_DOORCLOS, door.position);
 
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
-		door._oVar4 = DOOR_CLOSED;
-		door._oSelFlag = 3;
-		ObjSetMicro(door.position, 539);
-		dSpecial[door.position.x][door.position.y] = 0;
-		door._oAnimFrame -= 2;
-		door._oPreFlag = false;
+		CloseDoor(door);
 	}
 
 	RedoPlayerVision();
@@ -1897,23 +1912,13 @@ void OperateL2LDoor(Object &door, bool sendflag)
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
 		PlaySfxLoc(IS_DOOROPEN, door.position);
-		ObjSetMicro(door.position, 12);
-		dSpecial[door.position.x][door.position.y] = 5;
-		door._oAnimFrame += 2;
-		door._oPreFlag = true;
-		door._oVar4 = DOOR_OPEN;
-		door._oSelFlag = 2;
+		OpenDoor(door);
 	} else {
 		PlaySfxLoc(IS_DOORCLOS, door.position);
 
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
-		door._oVar4 = DOOR_CLOSED;
-		door._oSelFlag = 3;
-		ObjSetMicro(door.position, 537);
-		dSpecial[door.position.x][door.position.y] = 0;
-		door._oAnimFrame -= 2;
-		door._oPreFlag = false;
+		CloseDoor(door);
 	}
 
 	RedoPlayerVision();
@@ -1931,21 +1936,13 @@ void OperateL3RDoor(Object &door, bool sendflag)
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
 		PlaySfxLoc(IS_DOOROPEN, door.position);
-		ObjSetMicro(door.position, 540);
-		door._oAnimFrame += 2;
-		door._oPreFlag = true;
-		door._oVar4 = DOOR_OPEN;
-		door._oSelFlag = 2;
+		OpenDoor(door);
 	} else {
 		PlaySfxLoc(IS_DOORCLOS, door.position);
 
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
-		door._oVar4 = DOOR_CLOSED;
-		door._oSelFlag = 3;
-		ObjSetMicro(door.position, 533);
-		door._oAnimFrame -= 2;
-		door._oPreFlag = false;
+		CloseDoor(door);
 	}
 
 	RedoPlayerVision();
@@ -1963,21 +1960,13 @@ void OperateL3LDoor(Object &door, bool sendflag)
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
 		PlaySfxLoc(IS_DOOROPEN, door.position);
-		ObjSetMicro(door.position, 537);
-		door._oAnimFrame += 2;
-		door._oPreFlag = true;
-		door._oVar4 = DOOR_OPEN;
-		door._oSelFlag = 2;
+		OpenDoor(door);
 	} else {
 		PlaySfxLoc(IS_DOORCLOS, door.position);
 
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
-		door._oVar4 = DOOR_CLOSED;
-		door._oSelFlag = 3;
-		ObjSetMicro(door.position, 530);
-		door._oAnimFrame -= 2;
-		door._oPreFlag = false;
+		CloseDoor(door);
 	}
 
 	RedoPlayerVision();
@@ -1995,32 +1984,13 @@ void OperateL5RDoor(Object &door, bool sendflag)
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
 		PlaySfxLoc(IS_CROPEN, door.position);
-		ObjSetMicro(door.position, 208);
-		dSpecial[door.position.x][door.position.y] = 2;
-		door._oAnimFrame += 2;
-		door._oPreFlag = true;
-		CryptDoorSet(door.position + Direction::NorthWest, false);
-		door._oVar4 = DOOR_OPEN;
-		door._oSelFlag = 2;
+		OpenDoor(door);
 	} else {
 		PlaySfxLoc(IS_CRCLOS, door.position);
 
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
-		door._oVar4 = DOOR_CLOSED;
-		door._oSelFlag = 3;
-		ObjSetMicro(door.position, door._oVar1 - 1);
-
-		// Restore the normal tile where the open door used to be
-		auto openPosition = door.position + Direction::NorthWest;
-		if (door._oVar2 == 86 && dPiece[openPosition.x][openPosition.y] == 209)
-			ObjSetMicro(openPosition, 231);
-		else
-			ObjSetMicro(openPosition, door._oVar2 - 1);
-
-		dSpecial[door.position.x][door.position.y] = 0;
-		door._oAnimFrame -= 2;
-		door._oPreFlag = false;
+		CloseDoor(door);
 	}
 
 	RedoPlayerVision();
@@ -2038,32 +2008,13 @@ void OperateL5LDoor(Object &door, bool sendflag)
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPENDOOR, door.position);
 		PlaySfxLoc(IS_CROPEN, door.position);
-		ObjSetMicro(door.position, 205);
-		dSpecial[door.position.x][door.position.y] = 1;
-		door._oAnimFrame += 2;
-		door._oPreFlag = true;
-		CryptDoorSet(door.position + Direction::NorthEast, true);
-		door._oVar4 = DOOR_OPEN;
-		door._oSelFlag = 2;
+		OpenDoor(door);
 	} else {
 		PlaySfxLoc(IS_CRCLOS, door.position);
 
 		if (sendflag)
 			NetSendCmdLoc(MyPlayerId, true, CMD_CLOSEDOOR, door.position);
-		door._oVar4 = DOOR_CLOSED;
-		door._oSelFlag = 3;
-		ObjSetMicro(door.position, door._oVar1 - 1);
-
-		// Restore the normal tile where the open door used to be
-		auto openPosition = door.position + Direction::NorthEast;
-		if (door._oVar2 == 86 && dPiece[openPosition.x][openPosition.y] == 209)
-			ObjSetMicro(openPosition, 233);
-		else
-			ObjSetMicro(openPosition, door._oVar2 - 1);
-
-		dSpecial[door.position.x][door.position.y] = 0;
-		door._oAnimFrame -= 2;
-		door._oPreFlag = false;
+		CloseDoor(door);
 	}
 
 	RedoPlayerVision();
@@ -4785,8 +4736,7 @@ void DeltaSyncOpObject(Object &object)
 	case OBJ_L3RDOOR:
 	case OBJ_L5LDOOR:
 	case OBJ_L5RDOOR:
-		object._oAnimFrame += 2;
-		SetDoorStateOpen(object);
+		OpenDoor(object);
 		break;
 	case OBJ_LEVER:
 	case OBJ_L5LEVER:

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1611,16 +1611,17 @@ void ObjectStopAnim(Object &object)
 /**
  * @brief Checks if an open door can be closed
  *
- * In order to be able to close a door the space where the closed door would be must be free of bodies, monsters, and items
+ * In order to be able to close a door the space where the closed door would be must be free of bodies, monsters, players, and items
  *
  * @param doorPosition Map tile where the door is in its closed position
  * @return true if the door is free to be closed, false if anything is blocking it
  */
-inline bool IsDoorClear(const Point &doorPosition)
+inline bool IsDoorClear(const Object &door)
 {
-	return dCorpse[doorPosition.x][doorPosition.y] == 0
-	    && dMonster[doorPosition.x][doorPosition.y] == 0
-	    && dItem[doorPosition.x][doorPosition.y] == 0;
+	return dCorpse[door.position.x][door.position.y] == 0
+	    && dMonster[door.position.x][door.position.y] == 0
+	    && dItem[door.position.x][door.position.y] == 0
+	    && dPlayer[door.position.x][door.position.y] == 0;
 }
 
 void UpdateDoor(Object &door)
@@ -1633,8 +1634,7 @@ void UpdateDoor(Object &door)
 
 	door._oMissFlag = true;
 	door._oSelFlag = 2;
-	bool dok = IsDoorClear(door.position) && dPlayer[door.position.x][door.position.y] == 0;
-	door._oVar4 = dok ? DOOR_OPEN : DOOR_BLOCKED;
+	door._oVar4 = IsDoorClear(door) ? DOOR_OPEN : DOOR_BLOCKED;
 }
 
 void UpdateSarcophagus(Object &sarcophagus)

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1189,12 +1189,10 @@ void SetDoorStateOpen(Object &door)
 		break;
 	case OBJ_L5LDOOR:
 		ObjSetMicro(door.position, 205);
-		dSpecial[door.position.x][door.position.y] = 1;
 		CryptDoorSet(door.position + Direction::NorthEast, true);
 		break;
 	case OBJ_L5RDOOR:
 		ObjSetMicro(door.position, 208);
-		dSpecial[door.position.x][door.position.y] = 2;
 		CryptDoorSet(door.position + Direction::NorthWest, false);
 		break;
 	default:
@@ -1261,8 +1259,6 @@ void SetDoorStateClosed(Object &door)
 			ObjSetMicro(openPosition, 233);
 		else
 			ObjSetMicro(openPosition, door._oVar2 - 1);
-
-		dSpecial[door.position.x][door.position.y] = 0;
 	} break;
 	case OBJ_L5RDOOR: {
 		ObjSetMicro(door.position, door._oVar1 - 1);
@@ -1273,8 +1269,6 @@ void SetDoorStateClosed(Object &door)
 			ObjSetMicro(openPosition, 231);
 		else
 			ObjSetMicro(openPosition, door._oVar2 - 1);
-
-		dSpecial[door.position.x][door.position.y] = 0;
 	} break;
 	default:
 		break;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4321,7 +4321,7 @@ int ItemMiscIdIdx(item_misc_id imiscid)
 	return i;
 }
 
-void OperateObject(Player &player, int i, bool teleFlag)
+void OperateObject(Player &player, int i)
 {
 	Object &object = Objects[i];
 	bool sendmsg = &player == MyPlayer;
@@ -4335,7 +4335,7 @@ void OperateObject(Player &player, int i, bool teleFlag)
 	case OBJ_L3RDOOR:
 	case OBJ_L5LDOOR:
 	case OBJ_L5RDOOR:
-		if (teleFlag || (sendmsg && abs(object.position.x - player.position.tile.x) <= 1 && abs(object.position.y - player.position.tile.y) <= 1))
+		if (sendmsg)
 			OperateDoor(object, sendmsg);
 		break;
 	case OBJ_LEVER:

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1161,6 +1161,9 @@ void SetDoorStateOpen(Object &door)
 
 	switch (door._otype) {
 	case OBJ_L1LDOOR:
+		// 214: blood splater
+		// 407: blood pool
+		// 392: open door (no frame)
 		ObjSetMicro(door.position, door._oVar1 == 214 ? 407 : 392);
 		dSpecial[door.position.x][door.position.y] = 7;
 		DoorSet(door.position + Direction::NorthEast, true);
@@ -1208,6 +1211,8 @@ void SetDoorStateClosed(Object &door)
 
 	switch (door._otype) {
 	case OBJ_L1LDOOR: {
+		// Clear overlapping arches
+		dSpecial[door.position.x][door.position.y] = 0;
 		ObjSetMicro(door.position, door._oVar1 - 1);
 
 		// Restore the normal tile where the open door used to be
@@ -1216,11 +1221,11 @@ void SetDoorStateClosed(Object &door)
 			ObjSetMicro(openPosition, 411);
 		else
 			ObjSetMicro(openPosition, door._oVar2 - 1);
-
-		dSpecial[door.position.x][door.position.y] = 0;
 		break;
 	} break;
 	case OBJ_L1RDOOR: {
+		// Clear overlapping arches
+		dSpecial[door.position.x][door.position.y] = 0;
 		ObjSetMicro(door.position, door._oVar1 - 1);
 
 		// Restore the normal tile where the open door used to be
@@ -1229,17 +1234,17 @@ void SetDoorStateClosed(Object &door)
 			ObjSetMicro(openPosition, 410);
 		else
 			ObjSetMicro(openPosition, door._oVar2 - 1);
-
-		dSpecial[door.position.x][door.position.y] = 0;
 		break;
 	} break;
 	case OBJ_L2LDOOR:
-		ObjSetMicro(door.position, 537);
+		// Clear overlapping arches
 		dSpecial[door.position.x][door.position.y] = 0;
+		ObjSetMicro(door.position, 537);
 		break;
 	case OBJ_L2RDOOR:
-		ObjSetMicro(door.position, 539);
+		// Clear overlapping arches
 		dSpecial[door.position.x][door.position.y] = 0;
+		ObjSetMicro(door.position, 539);
 		break;
 	case OBJ_L3LDOOR:
 		ObjSetMicro(door.position, 530);
@@ -1627,13 +1632,9 @@ inline bool IsDoorClear(const Object &door)
 void UpdateDoor(Object &door)
 {
 	if (door._oVar4 == DOOR_CLOSED) {
-		door._oMissFlag = false;
-		door._oSelFlag = 3;
 		return;
 	}
 
-	door._oMissFlag = true;
-	door._oSelFlag = 2;
 	door._oVar4 = IsDoorClear(door) ? DOOR_OPEN : DOOR_BLOCKED;
 }
 
@@ -4358,7 +4359,7 @@ bool UpdateTrapState(Object &trap)
 	case OBJ_L3RDOOR:
 	case OBJ_L5LDOOR:
 	case OBJ_L5RDOOR:
-		if (trigger._oVar4 == 0)
+		if (trigger._oVar4 == DOOR_CLOSED)
 			return false;
 		break;
 	case OBJ_LEVER:

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -222,7 +222,7 @@ struct Object {
 	 * @brief Check if this object is a door
 	 * @return True if the object is one of the door types (see _object_id)
 	 */
-	[[nodiscard]] constexpr bool IsDoor() const
+	[[nodiscard]] constexpr bool isDoor() const
 	{
 		return IsAnyOf(_otype, _object_id::OBJ_L1LDOOR, _object_id::OBJ_L1RDOOR, _object_id::OBJ_L2LDOOR, _object_id::OBJ_L2RDOOR, _object_id::OBJ_L3LDOOR, _object_id::OBJ_L3RDOOR, _object_id::OBJ_L5LDOOR, _object_id::OBJ_L5RDOOR);
 	}

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -314,7 +314,7 @@ void MonstCheckDoors(const Monster &monster);
 void ObjChangeMap(int x1, int y1, int x2, int y2);
 void ObjChangeMapResync(int x1, int y1, int x2, int y2);
 int ItemMiscIdIdx(item_misc_id imiscid);
-void OperateObject(Player &player, int i, bool TeleFlag);
+void OperateObject(Player &player, int i);
 void SyncOpObject(Player &player, int cmd, Object &object);
 void BreakObjectMissile(Object &object);
 void BreakObject(const Player &player, Object &object);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1480,7 +1480,7 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 					d = GetDirection(player.position.tile, object->position);
 					StartAttack(player, d);
 				} else {
-					OperateObject(player, targetId, false);
+					OperateObject(player, targetId);
 				}
 			}
 			break;
@@ -1491,13 +1491,13 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 					StartAttack(player, d);
 				} else {
 					TryDisarm(player, *object);
-					OperateObject(player, targetId, false);
+					OperateObject(player, targetId);
 				}
 			}
 			break;
 		case ACTION_OPERATETK:
 			if (object->_oBreak != 1) {
-				OperateObject(player, targetId, true);
+				OperateObject(player, targetId);
 			}
 			break;
 		case ACTION_PICKUPITEM:

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -109,7 +109,7 @@ void RepeatMouseAction()
 			CheckPlrSpell(false);
 		break;
 	case MouseActionType::OperateObject:
-		if (ObjectUnderCursor != nullptr && !ObjectUnderCursor->IsDoor()) {
+		if (ObjectUnderCursor != nullptr && !ObjectUnderCursor->isDoor()) {
 			// This should probably be cursPosition so paths to large objects are consistent
 			NetSendCmdLoc(MyPlayerId, true, CMD_OPOBJXY, ObjectUnderCursor->position);
 		}


### PR DESCRIPTION
Besides removing a lot of redundant code the now shared logic means that some original inconsistencies are now fixed:
- Doors could be drawn in the wrong order if opened by other players
- Crypt doors made the wrong sound when blocked

And one that we had introduced
- Crypt doors looked wrong after closing them

In total the logic has been reduced by over 500 lines.