### PR TITLE
Use position for object delta messages

### DIFF
--- a/Source/engine/world_tile.hpp
+++ b/Source/engine/world_tile.hpp
@@ -11,3 +11,18 @@ using WorldTileOffset = int8_t;
 using WorldTileDisplacement = DisplacementOf<WorldTileOffset>;
 
 } // namespace devilution
+
+namespace std {
+
+/**
+ * @brief Allows using WorldTilePosition as a map key for contexts where we want to lookup an entity by physical dungeon location
+ */
+template <>
+struct hash<devilution::WorldTilePosition> {
+	size_t operator()(const devilution::WorldTilePosition &position) const noexcept
+	{
+		return static_cast<size_t>(position.x) << 8 | position.y;
+	}
+};
+
+} // namespace std


### PR DESCRIPTION
In the worst case this ends up increasing the size of the DLevel object by 127*2 bytes (since we now need to track object position in the delta) + map overhead. Having said that deltas are only really needed for objects which actually allow interaction. Decorations no longer get a delta since they never change. Actual network traffic is compressed so should end up about the same in practice.

Static memory usage increases by 127*2+1 bytes unfortunately due to the use of `sgRecvBuf`. Hard to tell if we even need this chunk of memory to be on the stack given the use in `OnLevelData()`.

fixes #5172 