### PR TITLE
Prevent sequence-point warning in DeltaImportObjects when compiling with GCC

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -355,7 +355,8 @@ const byte *DeltaImportObjects(const byte *src, std::unordered_map<WorldTilePosi
 	dst.reserve(numDeltas);
 
 	for (unsigned i = 0; i < numDeltas; i++) {
-		WorldTilePosition objectPosition { static_cast<WorldTileCoord>(*src++), static_cast<WorldTileCoord>(*src++) };
+		WorldTilePosition objectPosition { static_cast<WorldTileCoord>(src[0]), static_cast<WorldTileCoord>(src[1]) };
+		src += 2;
 		dst[objectPosition] = DObjectStr { static_cast<_cmd_id>(*src++) };
 	}
 


### PR DESCRIPTION
Doing `foo++` twice is a big no-no.