### PR TITLE
Split delta trap operation from realtime trap operation

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2550,7 +2550,7 @@ void DeltaLoadLevel()
 		for (int i = 0; i < ActiveObjectCount; i++) {
 			Object &object = Objects[ActiveObjects[i]];
 			if (object.IsTrap()) {
-				OperateTrap(object);
+				UpdateTrapState(object);
 			}
 		}
 	}

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -306,6 +306,7 @@ void SetMapObjects(const uint16_t *dunData, int startx, int starty);
  * @param objPos tile coordinates
  */
 Object *AddObject(_object_id objType, Point objPos);
+bool UpdateTrapState(Object &trap);
 void OperateTrap(Object &trap);
 void ProcessObjects();
 void RedoPlayerVision();


### PR DESCRIPTION
Fixes an issue reported by user Malignus on Discord.

> When you go in a level where there are traps, if you go to town and take back the town portal, all the traps will re-activate themselves upon entry of TP.
> 
> So if you opened all chests and doors with traps fireball and arrows will be sent through the rooms.

The issue was introduced by #4805, where the condition that checked for `deltaload` was removed.