### PR TITLE
fix adria's 'you have nothing to recharge' alignment

### DIFF
--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -931,7 +931,7 @@ void StartWitchRecharge()
 		stextscrl = false;
 
 		RenderGold = true;
-		AddSText(20, 1, _("You have nothing to recharge."), UiFlags::ColorWhitegold | UiFlags::AlignCenter, false);
+		AddSText(20, 1, _("You have nothing to recharge."), UiFlags::ColorWhitegold, false);
 		AddSLine(3);
 		AddItemListBackButton(/*selectable=*/true);
 		return;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/14297035/182824663-3c817081-5d3c-470a-a9f5-5a6efc2eb371.png)

After:
![image](https://user-images.githubusercontent.com/14297035/182824740-8e2b6468-2ff6-4fbd-8e71-a7b754fbc949.png)
