### PR TITLE
Fix vanilla compatibility for saving in quest maps

### DIFF
--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -366,6 +366,7 @@ void ShowProgress(interface_mode uMsg)
 		IncProgress();
 		setlevel = true;
 		leveltype = setlvltype;
+		currlevel = static_cast<uint8_t>(setlvlnum);
 		FreeGameMem();
 		IncProgress();
 		LoadGameLevel(false, ENTRY_SETLVL);


### PR DESCRIPTION
Fixes: When saving while in a quest map and try to load the game in devX <= 1.4.1 or vanilla the player will stop responding.
The issue was introduced with #4738 and is only present in master (not 1.4.1).

Background:
For multiplayer support the `Player` class needed to correctly store the player level (including set maps)
That's why [this line](https://github.com/diasurgical/devilutionX/commit/ceb08d783f38a4773c3dbea3b39cfd0b6e236fee#diff-71461699ae2f94f652e6cba2136d3c696151ba3a6c0e357eaf55438a5c212ad3R3270) was introduced when entering a set map: `player.setLevel(setlvlnum);`
Previous `plrlevel` wasn't initialized correctly.
This compatibility issue with old saves was addressed with [this changes](https://github.com/diasurgical/devilutionX/commit/ceb08d783f38a4773c3dbea3b39cfd0b6e236fee#diff-eb2db6084d42c0224b56a122152915d07d944c27040e427d6193bc382ca754b3R548-R552).
But `currlevel` wasn't changed.
In master this is fine, cause `isOnActiveLevel` also checks `setlevel`. So the content of `currlevel` is irrelevant.
But not in vanilla and old devX versions.
There is still a [check](https://github.com/diasurgical/devilutionX/blob/1.4/Source/msg.cpp#L647) for `currlevel` = `plrlevel`.
And this checks fails in this case, cause master updates `plrlevel` but not `currlevel`.
With this pr we update both correctly.

Fun-Fact:
In vanilla and old devX versions `currlevel` is not updated when entering the quest-map normally (`WM_DIABSETLVL`).
But when opening a town portal, going to town and back `currlevel` is [updated](https://github.com/diasurgical/devilutionX/blob/1.4/Source/portal.cpp#L142-L147).
Example: Leoric's Tomb can have `currlevel`=3/`plrlevel`=3 when entering via `WM_DIABSETLVL` and `currlevel`=1/`plrlevel`=1 when entering via town portal. 😕 
So changing `currlevel` should be no problem for vanilla. It only needs to be in sync with `plrlevel` when `setlevel` is true.

Thanks @qndel for finding the issue and helping with fixing it. 🙂 
