### PR TITLE
Ensure valid animation state when loading death animation in InitPlayer()

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2693,6 +2693,7 @@ void InitPlayer(Player &player, bool firstTime)
 			player.AnimInfo.currentFrame = GenerateRnd(player._pNFrames - 1);
 			player.AnimInfo.tickCounterOfCurrentFrame = GenerateRnd(3);
 		} else {
+			player._pgfxnum &= ~0xF;
 			player._pmode = PM_DEATH;
 			NewPlrAnim(player, player_graphic::Death, Direction::South, player._pDFrames, 2);
 			player.AnimInfo.currentFrame = player.AnimInfo.numberOfFrames - 2;


### PR DESCRIPTION
Fixes this error...
![image](https://user-images.githubusercontent.com/9203145/183229572-e22c2889-3cef-482f-a143-d3ff354eb05e.png)

**To reproduce...**
1. On client 1, create a new warrior and start a TCP game
2. On client 2, create another new warrior and join the TCP game
3. On client 2, use the "New Game" option in the menu to leave the game
4. On client 2, immediately rejoin the game
5. You should see the error on client 1

---

The error was introduced with the recent CLX changes, but the conditions for the error existed long before that. This fix follows the pattern used in a handful of other places throughout the codebase that also load the `PM_DEATH` animation. For example...

https://github.com/diasurgical/devilutionX/blob/52780a37125452f9ac5cb5010af7071e0ecd10f1/Source/msg.cpp#L1836-L1838