### PR TITLE
Be explicit about effect of CLOSEDOOR command on multi level delta

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -561,8 +561,11 @@ void DeltaSyncObject(WorldTilePosition position, _cmd_id bCmd, const Player &pla
 		return;
 
 	sgbDeltaChanged = true;
-
-	GetDeltaLevel(player).object[position].bCmd = bCmd;
+	auto &objectDeltas = GetDeltaLevel(player).object;
+	if (bCmd == _cmd_id::CMD_CLOSEDOOR)
+		objectDeltas.erase(position);
+	else
+		objectDeltas[position].bCmd = bCmd;
 }
 
 bool DeltaGetItem(const TCmdGItem &message, uint8_t bLevel)

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2534,7 +2534,6 @@ void DeltaLoadLevel()
 			switch (it->second.bCmd) {
 			case CMD_OPENDOOR:
 			case CMD_OPERATEOBJ:
-			case CMD_PLROPOBJ:
 				DeltaSyncOpObject(*object);
 				it++;
 				break;
@@ -3038,7 +3037,6 @@ size_t ParseCmd(int pnum, const TCmd *pCmd)
 	case CMD_OPENDOOR:
 	case CMD_CLOSEDOOR:
 	case CMD_OPERATEOBJ:
-	case CMD_PLROPOBJ:
 		return OnOperateObject(*pCmd, pnum);
 	case CMD_BREAKOBJ:
 		return OnBreakObject(*pCmd, pnum);

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -266,12 +266,6 @@ enum _cmd_id : uint8_t {
 	//    int8_t x
 	//    int8_t y
 	CMD_OPERATEOBJ,
-	// Player operate object.
-	//
-	// body (TCmdLoc):
-	//    int8_t x
-	//    int8_t y
-	CMD_PLROPOBJ,
 	// Break object.
 	//
 	// body (TCmdLoc):

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4320,9 +4320,8 @@ int ItemMiscIdIdx(item_misc_id imiscid)
 	return i;
 }
 
-void OperateObject(Player &player, int i)
+void OperateObject(Player &player, Object &object)
 {
-	Object &object = Objects[i];
 	bool sendmsg = &player == MyPlayer;
 
 	switch (object._otype) {

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2105,7 +2105,7 @@ void OperateChest(const Player &player, Object &chest, bool sendLootMsg)
 		chest._oTrapFlag = false;
 	}
 	if (&player == MyPlayer)
-		NetSendCmdLoc(MyPlayerId, false, CMD_PLROPOBJ, chest.position);
+		NetSendCmdLoc(MyPlayerId, false, CMD_OPERATEOBJ, chest.position);
 }
 
 void OperateMushroomPatch(const Player &player, Object &mushroomPatch)
@@ -3090,7 +3090,7 @@ void OperateShrine(Player &player, Object &shrine, _sfx_id sType)
 	}
 
 	if (&player == MyPlayer)
-		NetSendCmdLoc(MyPlayerId, false, CMD_PLROPOBJ, shrine.position);
+		NetSendCmdLoc(MyPlayerId, false, CMD_OPERATEOBJ, shrine.position);
 }
 
 void OperateBookStand(Object &bookStand, bool sendmsg, bool sendLootMsg)

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -314,7 +314,7 @@ void MonstCheckDoors(const Monster &monster);
 void ObjChangeMap(int x1, int y1, int x2, int y2);
 void ObjChangeMapResync(int x1, int y1, int x2, int y2);
 int ItemMiscIdIdx(item_misc_id imiscid);
-void OperateObject(Player &player, int i);
+void OperateObject(Player &player, Object &object);
 void SyncOpObject(Player &player, int cmd, Object &object);
 void BreakObjectMissile(Object &object);
 void BreakObject(const Player &player, Object &object);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1480,7 +1480,7 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 					d = GetDirection(player.position.tile, object->position);
 					StartAttack(player, d);
 				} else {
-					OperateObject(player, targetId);
+					OperateObject(player, *object);
 				}
 			}
 			break;
@@ -1491,13 +1491,13 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 					StartAttack(player, d);
 				} else {
 					TryDisarm(player, *object);
-					OperateObject(player, targetId);
+					OperateObject(player, *object);
 				}
 			}
 			break;
 		case ACTION_OPERATETK:
 			if (object->_oBreak != 1) {
-				OperateObject(player, targetId);
+				OperateObject(player, *object);
 			}
 			break;
 		case ACTION_PICKUPITEM:


### PR DESCRIPTION
Also included some minor cleanups while in the area. PLROPOBJ and OPERATEOBJ are synonyms now so we only need one.

This doesn't change behaviour currently as CMD_CLOSEDOOR level delta messages will be dropped when replaying the state on (re)entering a level, this makes the effect explicit and moves it to a more relevant area.