### PR TITLE
Fix the string for packet type PT_ECHO_REPLY.

### DIFF
--- a/Source/dvlnet/packet.cpp
+++ b/Source/dvlnet/packet.cpp
@@ -73,7 +73,7 @@ const char *packet_type_to_string(uint8_t packetType)
 	case PT_ECHO_REQUEST:
 		return "PT_ECHO_REQUEST";
 	case PT_ECHO_REPLY:
-		return "PT_ECHO_REQUEST";
+		return "PT_ECHO_REPLY";
 	default:
 		return nullptr;
 	}


### PR DESCRIPTION
Fix the string for packet type PT_ECHO_REPLY. It seems somebody mistakenly typed "PT_ECHO_REQUEST" instead of "PT_ECHO_REPLY".