### PR TITLE
show difficulty indicator on multiplayer characters

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -44,6 +44,7 @@
 namespace devilution {
 
 OptionalOwnedClxSpriteList ArtLogo;
+std::array<OptionalOwnedClxSpriteList, 2> DifficultyIndicator;
 
 std::array<OptionalOwnedClxSpriteList, 3> ArtFocus;
 
@@ -562,6 +563,8 @@ void LoadUiGFX()
 	} else {
 		ArtLogo = LoadPcxSpriteList("ui_art\\smlogo.pcx", /*numFrames=*/15, /*transparentColor=*/250);
 	}
+	DifficultyIndicator[0] = LoadPcx("ui_art\\radio1.pcx");
+	DifficultyIndicator[1] = LoadPcx("ui_art\\radio3.pcx");
 	ArtFocus[FOCUS_SMALL] = LoadPcxSpriteList("ui_art\\focus16.pcx", /*numFrames=*/8, /*transparentColor=*/250);
 	ArtFocus[FOCUS_MED] = LoadPcxSpriteList("ui_art\\focus.pcx", /*numFrames=*/8, /*transparentColor=*/250);
 	ArtFocus[FOCUS_BIG] = LoadPcxSpriteList("ui_art\\focus42.pcx", /*numFrames=*/8, /*transparentColor=*/250);
@@ -589,6 +592,8 @@ void UnloadUiGFX()
 	for (auto &art : ArtFocus)
 		art = std::nullopt;
 	ArtLogo = std::nullopt;
+	for (auto &diffInd : DifficultyIndicator)
+		diffInd = std::nullopt;
 }
 
 void UiInitialize()

--- a/Source/DiabloUI/diabloui.h
+++ b/Source/DiabloUI/diabloui.h
@@ -61,6 +61,7 @@ struct _uiheroinfo {
 };
 
 extern OptionalOwnedClxSpriteList ArtLogo;
+extern std::array<OptionalOwnedClxSpriteList, 2> DifficultyIndicator;
 extern std::array<OptionalOwnedClxSpriteList, 3> ArtFocus;
 extern OptionalOwnedClxSpriteList ArtBackgroundWidescreen;
 extern OptionalOwnedClxSpriteList ArtBackground;

--- a/Source/DiabloUI/selhero.cpp
+++ b/Source/DiabloUI/selhero.cpp
@@ -44,6 +44,7 @@ bool selhero_deleteEnabled;
 std::vector<std::unique_ptr<UiItemBase>> vecSelHeroDialog;
 std::vector<std::unique_ptr<UiListItem>> vecSelHeroDlgItems;
 std::vector<std::unique_ptr<UiItemBase>> vecSelDlgItems;
+std::vector<std::unique_ptr<UiItemBase>> vecDifficultyIndicators;
 
 UiImageClx *SELHERO_DIALOG_HERO_IMG;
 
@@ -70,6 +71,7 @@ void SelheroFree()
 	ArtBackground = std::nullopt;
 
 	vecSelHeroDialog.clear();
+	vecDifficultyIndicators.clear();
 
 	vecSelDlgItems.clear();
 	vecSelHeroDlgItems.clear();
@@ -85,6 +87,14 @@ void SelheroSetStats()
 	CopyUtf8(textStats[3], StrCat(selhero_heroInfo.dexterity), sizeof(textStats[3]));
 	CopyUtf8(textStats[4], StrCat(selhero_heroInfo.vitality), sizeof(textStats[4]));
 	CopyUtf8(textStats[5], StrCat(selhero_heroInfo.saveNumber), sizeof(textStats[5]));
+
+	const Point uiPosition = GetUIRectangle().position;
+	vecDifficultyIndicators.clear();
+	SDL_Rect rect = MakeSdlRect(uiPosition.x + 28, uiPosition.y + 198, 12, 12);
+	for (int i = 0; i <= DIFF_LAST; i++) {
+		vecDifficultyIndicators.push_back(std::make_unique<UiImageAnimatedClx>(*DifficultyIndicator[i < selhero_heroInfo.herorank ? 0 : 1], rect, UiFlags::None));
+		rect.x += 12;
+	}
 }
 
 UiArtTextButton *SELLIST_DIALOG_DELETE_BUTTON;
@@ -563,6 +573,7 @@ static void UiSelHeroDialog(
 		while (!selhero_endMenu && !selhero_navigateYesNo) {
 			UiClearScreen();
 			UiRenderItems(vecSelHeroDialog);
+			UiRenderItems(vecDifficultyIndicators);
 			UiPollAndRender();
 		}
 		SelheroFree();

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -860,6 +860,10 @@ void DiabloDeath(Monster &diablo, bool sendmsg)
 	diablo.var3 = ViewPosition.x << 16;
 	diablo.position.temp.x = ViewPosition.y << 16;
 	diablo.position.temp.y = (int)((diablo.var3 - (diablo.position.tile.x << 16)) / (double)dist);
+	if (!gbIsMultiplayer) {
+		Player &myPlayer = *MyPlayer;
+		myPlayer.pDiabloKillLevel = std::max(myPlayer.pDiabloKillLevel, static_cast<uint8_t>(sgGameInitInfo.nDifficulty + 1));
+	}
 }
 
 void SpawnLoot(Monster &monster, bool sendmsg)


### PR DESCRIPTION
Resolves https://github.com/diasurgical/devilutionX/issues/5031
![image](https://user-images.githubusercontent.com/14297035/183457832-39374343-550f-4e9b-baf0-5e4c7e8cc9d1.png)

```cpp
myPlayer.pDiabloKillLevel = std::max(myPlayer.pDiabloKillLevel, static_cast<uint8_t>(sgGameInitInfo.nDifficulty + 1));
```
this happens in PrepDoEnding  which means showing difficulty thingies works only in multiplayer - multi autosaves after outro so the value is preserved while in singleplayer you have no way to save after it got set.
That's why I've added 
```cpp
	if (!gbIsMultiplayer) {
		Player &myPlayer = *MyPlayer;
		myPlayer.pDiabloKillLevel = std::max(myPlayer.pDiabloKillLevel, static_cast<uint8_t>(sgGameInitInfo.nDifficulty + 1));
	}
```
to DiabloDeath to compensate for that - the variable will increase by 2 in singleplayer after outro, but since you have no way to save the second increase, it's all good. You can only save the increased variable if you save the game while diablo is dying. This will color a gem above your character's portrait.