### PR TITLE
Synchronize player inventories

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -155,13 +155,17 @@ void AddItemToInvGrid(Player &player, int invGridIndex, int invListIndex, Size i
 {
 	const int pitch = 10;
 	for (int y = 0; y < itemSize.height; y++) {
+		int rowGridIndex = invGridIndex + pitch * y;
 		for (int x = 0; x < itemSize.width; x++) {
 			if (x == 0 && y == itemSize.height - 1)
-				player.InvGrid[invGridIndex + x] = invListIndex;
+				player.InvGrid[rowGridIndex + x] = invListIndex;
 			else
-				player.InvGrid[invGridIndex + x] = -invListIndex;
+				player.InvGrid[rowGridIndex + x] = -invListIndex;
 		}
-		invGridIndex += pitch;
+	}
+
+	if (&player == MyPlayer) {
+		NetSendCmdChInvItem(false, invGridIndex);
 	}
 }
 
@@ -1467,6 +1471,54 @@ void inv_update_rem_item(Player &player, inv_body_loc iv)
 	player.InvBody[iv].clear();
 
 	CalcPlrInv(player, player._pmode != PM_DEATH);
+}
+
+void CheckInvSwap(Player &player, int invGridIndex, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff)
+{
+	Item item = {};
+	RecreateItem(item, idx, wCI, seed, 0, (dwBuff & CF_HELLFIRE) != 0);
+
+	if (bId) {
+		item._iIdentified = true;
+	}
+
+	auto itemSize = GetInventorySize(item);
+
+	const int pitch = 10;
+	int invListIndex = [&]() -> int {
+		for (int y = 0; y < itemSize.height; y++) {
+			int rowGridIndex = invGridIndex + pitch * y;
+			for (int x = 0; x < itemSize.width; x++) {
+				if (player.InvGrid[rowGridIndex + x] != 0)
+					return abs(player.InvGrid[rowGridIndex]);
+			}
+		}
+		player._pNumInv++;
+		return player._pNumInv;
+	}();
+
+	if (invListIndex < player._pNumInv) {
+		for (auto &itemIndex : player.InvGrid) {
+			if (itemIndex == invListIndex)
+				itemIndex = 0;
+			if (itemIndex == -invListIndex)
+				itemIndex = 0;
+		}
+	}
+
+	player.InvList[invListIndex - 1] = item;
+
+	for (int y = 0; y < itemSize.height; y++) {
+		int rowGridIndex = invGridIndex + pitch * y;
+		for (int x = 0; x < itemSize.width; x++) {
+			if (x == 0 && y == itemSize.height - 1)
+				player.InvGrid[rowGridIndex + x] = invListIndex;
+			else
+				player.InvGrid[rowGridIndex + x] = -invListIndex;
+		}
+	}
+
+	CalcPlrInv(player, true);
 }
 
 void TransferItemToStash(Player &player, int location)

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -560,6 +560,9 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 			if (player.HoldItem._itype == ItemType::Gold)
 				player._pGold = CalculateGold(player);
 		}
+		if (&player == MyPlayer) {
+			NetSendCmdChBeltItem(false, ii);
+		}
 		drawsbarflag = true;
 	} break;
 	case ILOC_NONE:
@@ -803,8 +806,7 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 			}
 
 			if (!automaticMove || automaticallyMoved) {
-				beltItem.clear();
-				drawsbarflag = true;
+				player.RemoveSpdBarItem(r - SLOTXY_BELT_FIRST);
 			}
 		}
 	}
@@ -1237,6 +1239,10 @@ bool AutoPlaceItemInBelt(Player &player, const Item &item, bool persistItem)
 				beltItem = item;
 				player.CalcScrolls();
 				drawsbarflag = true;
+				if (&player == MyPlayer) {
+					size_t beltIndex = std::distance<const Item *>(&player.SpdList[0], &beltItem);
+					NetSendCmdChBeltItem(false, beltIndex);
+				}
 			}
 
 			return true;
@@ -1527,6 +1533,18 @@ void CheckInvRemove(Player &player, int invGridIndex)
 
 	if (invListIndex >= 0) {
 		player.RemoveInvItem(invListIndex);
+	}
+}
+
+void CheckBeltSwap(Player &player, int beltIndex, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff)
+{
+	Item &item = player.SpdList[beltIndex];
+
+	item = {};
+	RecreateItem(item, idx, wCI, seed, 0, (dwBuff & CF_HELLFIRE) != 0);
+
+	if (bId) {
+		item._iIdentified = true;
 	}
 }
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1521,6 +1521,15 @@ void CheckInvSwap(Player &player, int invGridIndex, int idx, uint16_t wCI, int s
 	CalcPlrInv(player, true);
 }
 
+void CheckInvRemove(Player &player, int invGridIndex)
+{
+	int invListIndex = abs(player.InvGrid[invGridIndex]) - 1;
+
+	if (invListIndex >= 0) {
+		player.RemoveInvItem(invListIndex);
+	}
+}
+
 void TransferItemToStash(Player &player, int location)
 {
 	if (location == -1) {

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -184,6 +184,7 @@ void CheckInvSwap(Player &player, inv_body_loc bLoc, int idx, uint16_t wCI, int 
 void inv_update_rem_item(Player &player, inv_body_loc iv);
 void CheckInvSwap(Player &player, int invGridIndex, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff);
 void CheckInvRemove(Player &player, int invGridIndex);
+void CheckBeltSwap(Player &player, int beltIndex, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff);
 void TransferItemToStash(Player &player, int location);
 void CheckInvItem(bool isShiftHeld = false, bool isCtrlHeld = false);
 

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -183,6 +183,7 @@ bool GoldAutoPlace(Player &player, Item &goldStack);
 void CheckInvSwap(Player &player, inv_body_loc bLoc, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff);
 void inv_update_rem_item(Player &player, inv_body_loc iv);
 void CheckInvSwap(Player &player, int invGridIndex, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff);
+void CheckInvRemove(Player &player, int invGridIndex);
 void TransferItemToStash(Player &player, int location);
 void CheckInvItem(bool isShiftHeld = false, bool isCtrlHeld = false);
 

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -182,6 +182,7 @@ int AddGoldToInventory(Player &player, int value);
 bool GoldAutoPlace(Player &player, Item &goldStack);
 void CheckInvSwap(Player &player, inv_body_loc bLoc, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff);
 void inv_update_rem_item(Player &player, inv_body_loc iv);
+void CheckInvSwap(Player &player, int invGridIndex, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff);
 void TransferItemToStash(Player &player, int location);
 void CheckInvItem(bool isShiftHeld = false, bool isCtrlHeld = false);
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2954,7 +2954,7 @@ void NetSendCmdChInvItem(bool bHiPri, int invGridIndex)
 	TCmdChItem cmd;
 
 	int8_t invListIndex = abs(MyPlayer->InvGrid[invGridIndex]) - 1;
-	Item &item = MyPlayer->InvList[invListIndex];
+	const Item &item = MyPlayer->InvList[invListIndex];
 
 	cmd.bCmd = CMD_CHANGEINVITEMS;
 	cmd.bLoc = invGridIndex;
@@ -2974,7 +2974,7 @@ void NetSendCmdChBeltItem(bool bHiPri, int beltIndex)
 {
 	TCmdChItem cmd;
 
-	Item &item = MyPlayer->SpdList[beltIndex];
+	const Item &item = MyPlayer->SpdList[beltIndex];
 
 	cmd.bCmd = CMD_CHANGEBELTITEMS;
 	cmd.bLoc = beltIndex;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1753,6 +1753,20 @@ size_t OnChangeInventoryItems(const TCmd *pCmd, int pnum)
 	return sizeof(message);
 }
 
+size_t OnDeleteInventoryItems(const TCmd *pCmd, int pnum)
+{
+	const auto &message = *reinterpret_cast<const TCmdParam1 *>(pCmd);
+	Player &player = Players[pnum];
+
+	if (gbBufferMsgs == 1) {
+		SendPacket(pnum, &message, sizeof(message));
+	} else if (&player != MyPlayer && message.wParam1 < InventoryGridCells) {
+		CheckInvRemove(player, message.wParam1);
+	}
+
+	return sizeof(message);
+}
+
 size_t OnPlayerLevel(const TCmd *pCmd, int pnum)
 {
 	const auto &message = *reinterpret_cast<const TCmdParam1 *>(pCmd);
@@ -3084,6 +3098,8 @@ size_t ParseCmd(int pnum, const TCmd *pCmd)
 		return OnDeletePlayerItems(pCmd, pnum);
 	case CMD_CHANGEINVITEMS:
 		return OnChangeInventoryItems(pCmd, pnum);
+	case CMD_DELINVITEMS:
+		return OnDeleteInventoryItems(pCmd, pnum);
 	case CMD_PLRLEVEL:
 		return OnPlayerLevel(pCmd, pnum);
 	case CMD_DROPITEM:

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -281,6 +281,10 @@ enum _cmd_id : uint8_t {
 	//
 	// body (TCmdDelItem)
 	CMD_DELPLRITEMS,
+	// Put item into player's backpack.
+	//
+	// body (TCmdChItem)
+	CMD_CHANGEINVITEMS,
 	// Damage target player.
 	//
 	// body (TCmdDamage)
@@ -743,6 +747,7 @@ void NetSendCmdGItem(bool bHiPri, _cmd_id bCmd, uint8_t pnum, uint8_t ii);
 void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position, const Item &item);
 void NetSendCmdChItem(bool bHiPri, uint8_t bLoc);
 void NetSendCmdDelItem(bool bHiPri, uint8_t bLoc);
+void NetSendCmdChInvItem(bool bHiPri, int invGridIndex);
 void NetSendCmdDamage(bool bHiPri, uint8_t bPlr, uint32_t dwDam);
 void NetSendCmdMonDmg(bool bHiPri, uint16_t wMon, uint32_t dwDam);
 void NetSendCmdString(uint32_t pmask, const char *pszStr);

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -289,6 +289,14 @@ enum _cmd_id : uint8_t {
 	//
 	// body (TCmdParam1)
 	CMD_DELINVITEMS,
+	// Put item into player's belt.
+	//
+	// body (TCmdChItem)
+	CMD_CHANGEBELTITEMS,
+	// Remove item from player's belt.
+	//
+	// body (TCmdParam1)
+	CMD_DELBELTITEMS,
 	// Damage target player.
 	//
 	// body (TCmdDamage)
@@ -752,6 +760,7 @@ void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position, const Item &item
 void NetSendCmdChItem(bool bHiPri, uint8_t bLoc);
 void NetSendCmdDelItem(bool bHiPri, uint8_t bLoc);
 void NetSendCmdChInvItem(bool bHiPri, int invGridIndex);
+void NetSendCmdChBeltItem(bool bHiPri, int invGridIndex);
 void NetSendCmdDamage(bool bHiPri, uint8_t bPlr, uint32_t dwDam);
 void NetSendCmdMonDmg(bool bHiPri, uint16_t wMon, uint32_t dwDam);
 void NetSendCmdString(uint32_t pmask, const char *pszStr);

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -285,6 +285,10 @@ enum _cmd_id : uint8_t {
 	//
 	// body (TCmdChItem)
 	CMD_CHANGEINVITEMS,
+	// Remove item from player's backpack.
+	//
+	// body (TCmdParam1)
+	CMD_DELINVITEMS,
 	// Damage target player.
 	//
 	// body (TCmdDamage)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1819,6 +1819,10 @@ void Player::RemoveInvItem(int iv, bool calcScrolls)
 
 void Player::RemoveSpdBarItem(int iv)
 {
+	if (this == MyPlayer) {
+		NetSendCmdParam1(false, CMD_DELBELTITEMS, iv);
+	}
+
 	SpdList[iv].clear();
 
 	CalcScrolls();

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1776,6 +1776,17 @@ void Player::CalcScrolls()
 
 void Player::RemoveInvItem(int iv, bool calcScrolls)
 {
+	if (this == MyPlayer) {
+		// Locate the first grid index containing this item and notify remote clients
+		for (size_t i = 0; i < InventoryGridCells; i++) {
+			int8_t itemIndex = InvGrid[i];
+			if (abs(itemIndex) - 1 == iv) {
+				NetSendCmdParam1(false, CMD_DELINVITEMS, i);
+				break;
+			}
+		}
+	}
+
 	// Iterate through invGrid and remove every reference to item
 	for (int8_t &itemIndex : InvGrid) {
 		if (abs(itemIndex) - 1 == iv) {

--- a/Source/storm/storm_net.cpp
+++ b/Source/storm/storm_net.cpp
@@ -9,6 +9,7 @@
 #endif
 
 #include "dvlnet/abstract_net.h"
+#include "engine/demomode.h"
 #include "menu.h"
 #include "options.h"
 #include "utils/stubs.h"
@@ -142,7 +143,7 @@ bool SNetInitializeProvider(uint32_t provider, struct GameData *gameData)
 	std::lock_guard<SdlMutex> lg(storm_net_mutex);
 #endif
 	dvlnet_inst = net::abstract_net::MakeNet(provider);
-	return mainmenu_select_hero_dialog(gameData);
+	return (HeadlessMode && !demo::IsRunning()) || mainmenu_select_hero_dialog(gameData);
 }
 
 /**

--- a/test/inv_test.cpp
+++ b/test/inv_test.cpp
@@ -3,6 +3,7 @@
 #include "cursor.h"
 #include "inv.h"
 #include "player.h"
+#include "storm/storm_net.hpp"
 
 using namespace devilution;
 
@@ -136,6 +137,8 @@ TEST(Inv, GoldAutoPlace)
 // Test removing an item from inventory with no other items.
 TEST(Inv, RemoveInvItem)
 {
+	SNetInitializeProvider(SELCONN_LOOPBACK, nullptr);
+
 	clear_inventory();
 	// Put a two-slot misc item into the inventory:
 	// | (item) | (item) | ... | ...
@@ -153,6 +156,8 @@ TEST(Inv, RemoveInvItem)
 // Test removing an item from inventory with other items in it.
 TEST(Inv, RemoveInvItem_other_item)
 {
+	SNetInitializeProvider(SELCONN_LOOPBACK, nullptr);
+
 	clear_inventory();
 	// Put a two-slot misc item and a ring into the inventory:
 	// | (item) | (item) | (ring) | ...
@@ -175,6 +180,8 @@ TEST(Inv, RemoveInvItem_other_item)
 // Test removing an item from the belt
 TEST(Inv, RemoveSpdBarItem)
 {
+	SNetInitializeProvider(SELCONN_LOOPBACK, nullptr);
+
 	// Clear the belt
 	for (int i = 0; i < MaxBeltItems; i++) {
 		MyPlayer->SpdList[i].clear();
@@ -206,6 +213,8 @@ TEST(Inv, RemoveCurrentSpellScroll_inventory)
 // Test removing a scroll from the belt
 TEST(Inv, RemoveCurrentSpellScroll_belt)
 {
+	SNetInitializeProvider(SELCONN_LOOPBACK, nullptr);
+
 	// Clear the belt
 	for (int i = 0; i < MaxBeltItems; i++) {
 		MyPlayer->SpdList[i].clear();


### PR DESCRIPTION
Synchronizes changes to the player's inventory to remote clients. There are definitely some missing edge cases, but this can get us started on resolving many of the sources of desync discussed in #4074.

Here is a video demonstration of how the synchronization looks when testing in conjunction with https://github.com/StephenCWills/devilutionX/commit/5df65ff54f6ee6fef6d13cb23e01d9710f4a0060:

https://user-images.githubusercontent.com/9203145/183315099-ff6d09f9-d43a-4304-bc2a-72db5a11a4b3.mp4
