### PR TITLE
Cursor: Always use result of CalcTileOffset

### DIFF
--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -287,12 +287,15 @@ void CheckCursMove()
 	int xo = 0;
 	int yo = 0;
 	CalcTileOffset(&xo, &yo);
+	sx += xo;
+	sy += yo;
+
 	const Player &myPlayer = *MyPlayer;
 
 	if (myPlayer.IsWalking()) {
 		Displacement offset = GetOffsetForWalking(myPlayer.AnimInfo, myPlayer._pdir, true);
-		sx -= offset.deltaX - xo;
-		sy -= offset.deltaY - yo;
+		sx -= offset.deltaX;
+		sy -= offset.deltaY;
 
 		// Predict the next frame when walking to avoid input jitter
 		DisplacementOf<int16_t> offset2 = myPlayer.position.CalculateWalkingOffsetShifted8(myPlayer._pdir, myPlayer.AnimInfo);


### PR DESCRIPTION
Fixes #5215

Bug was introduced with #5157.
Previous the result of `CalcTileOffset` [was always](https://github.com/diasurgical/devilutionX/commit/2493f06116c1458c2ccaf2e5b8d913561705226d#diff-6bdd34b6b6de7cd16b5142d8430ea1b05825d9b2d15bf8d27e33fced02ae707bL295-L296) applied to `sx` and `sy`.
But with #5157 it was only [applied when walking](https://github.com/diasurgical/devilutionX/commit/2493f06116c1458c2ccaf2e5b8d913561705226d#diff-6bdd34b6b6de7cd16b5142d8430ea1b05825d9b2d15bf8d27e33fced02ae707bR295-R296).

Thanks @FireIceTalon for reporting and thanks @qndel for bisecting and helping with testing. 🙂 

Side-Note:
When I tested #5157 the issue was not present for me, cause I run the game with 640x480 with FitToScreen=off.
And with this configuration `CalcTileOffset` returns 0 and it's safe to ignore 0. 😉 