### PR TITLE
:recycle: Splits FindMonsterAtPosition in two functions.

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -182,10 +182,8 @@ void MoveMissilePos(Missile &missile)
 	}
 }
 
-bool MonsterMHit(int pnum, int monsterId, int mindam, int maxdam, int dist, missile_id t, bool shift)
+bool MonsterMHit(int pnum, Monster &monster, int mindam, int maxdam, int dist, missile_id t, bool shift)
 {
-	auto &monster = Monsters[monsterId];
-
 	if (!monster.isPossibleToHit() || monster.isImmune(t))
 		return false;
 
@@ -388,19 +386,18 @@ void CheckMissileCol(Missile &missile, int minDamage, int maxDamage, bool isDama
 	int my = position.y;
 
 	bool isMonsterHit = false;
-	int mid = dMonster[mx][my];
-	if (mid > 0 || (mid != 0 && Monsters[abs(mid) - 1].mode == MonsterMode::Petrified)) {
-		mid = abs(mid) - 1;
+	auto [hitMonster, isMoving] = FindMonsterMovingStateAtPosition(position);
+	if (hitMonster != nullptr && (!isMoving || (isMoving && hitMonster->mode == MonsterMode::Petrified))) {
 		if (missile.IsTrap()
-		    || (missile._micaster == TARGET_PLAYERS && (                                           // or was fired by a monster and
-		            Monsters[mid].isPlayerMinion() != Monsters[missile._misource].isPlayerMinion() //  the monsters are on opposing factions
-		            || (Monsters[missile._misource].flags & MFLAG_BERSERK) != 0                    //  or the attacker is berserked
-		            || (Monsters[mid].flags & MFLAG_BERSERK) != 0                                  //  or the target is berserked
+		    || (missile._micaster == TARGET_PLAYERS && (                                         // or was fired by a monster and
+		            hitMonster->isPlayerMinion() != Monsters[missile._misource].isPlayerMinion() //  the monsters are on opposing factions
+		            || (Monsters[missile._misource].flags & MFLAG_BERSERK) != 0                  //  or the attacker is berserked
+		            || (hitMonster->flags & MFLAG_BERSERK) != 0                                  //  or the target is berserked
 		            ))) {
 			// then the missile can potentially hit this target
-			isMonsterHit = MonsterTrapHit(mid, minDamage, maxDamage, missile._midist, missile._mitype, isDamageShifted);
+			isMonsterHit = MonsterTrapHit(*hitMonster, minDamage, maxDamage, missile._midist, missile._mitype, isDamageShifted);
 		} else if (IsAnyOf(missile._micaster, TARGET_BOTH, TARGET_MONSTERS)) {
-			isMonsterHit = MonsterMHit(missile._misource, mid, minDamage, maxDamage, missile._midist, missile._mitype, isDamageShifted);
+			isMonsterHit = MonsterMHit(missile._misource, *hitMonster, minDamage, maxDamage, missile._midist, missile._mitype, isDamageShifted);
 		}
 	}
 
@@ -852,10 +849,8 @@ Direction16 GetDirection16(Point p1, Point p2)
 	return ret;
 }
 
-bool MonsterTrapHit(int monsterId, int mindam, int maxdam, int dist, missile_id t, bool shift)
+bool MonsterTrapHit(Monster &monster, int mindam, int maxdam, int dist, missile_id t, bool shift)
 {
-	auto &monster = Monsters[monsterId];
-
 	if (!monster.isPossibleToHit() || monster.isImmune(t))
 		return false;
 

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -197,7 +197,7 @@ void GetDamageAmt(spell_id i, int *mind, int *maxd);
  * @return the direction of the p1->p2 vector
  */
 Direction16 GetDirection16(Point p1, Point p2);
-bool MonsterTrapHit(int monsterId, int mindam, int maxdam, int dist, missile_id t, bool shift);
+bool MonsterTrapHit(Monster &monster, int mindam, int maxdam, int dist, missile_id t, bool shift);
 bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, missile_id mtype, bool shift, int earflag, bool *blocked);
 
 /**

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4385,20 +4385,26 @@ void MissToMonst(Missile &missile, Point position)
 	}
 }
 
-Monster *FindMonsterAtPosition(Point position, bool ignoreMovingMonsters)
+std::tuple<Monster *, bool> FindMonsterMovingStateAtPosition(Point position)
 {
-	if (!InDungeonBounds(position)) {
-		return nullptr;
-	}
+	if (!InDungeonBounds(position))
+		return { nullptr, false };
 
 	auto monsterId = dMonster[position.x][position.y];
 
-	if (monsterId == 0 || (ignoreMovingMonsters && monsterId < 0)) {
+	if (monsterId == 0)
 		// nothing at this position, return a nullptr
-		return nullptr;
-	}
+		return { nullptr, false };
 
-	return &Monsters[abs(monsterId) - 1];
+	return { &Monsters[abs(monsterId) - 1], monsterId < 0 };
+}
+
+Monster *FindMonsterAtPosition(Point position, bool ignoreMovingMonsters)
+{
+	auto [monster, isMoving] = FindMonsterMovingStateAtPosition(position);
+	if (isMoving && ignoreMovingMonsters)
+		return nullptr;
+	return monster;
 }
 
 bool IsTileAvailable(const Monster &monster, Point position)

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -413,6 +413,7 @@ void PlayEffect(Monster &monster, MonsterSound mode);
 void MissToMonst(Missile &missile, Point position);
 
 Monster *FindMonsterAtPosition(Point position, bool ignoreMovingMonsters = false);
+std::tuple<Monster *, bool> FindMonsterMovingStateAtPosition(Point position);
 
 /**
  * @brief Check that the given tile is available to the monster

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1691,8 +1691,9 @@ void UpdateFlameTrap(Object &trap)
 
 		int x = trap.position.x;
 		int y = trap.position.y;
-		if (dMonster[x][y] > 0)
-			MonsterTrapHit(dMonster[x][y] - 1, mindam / 2, maxdam / 2, 0, MIS_FIREWALLC, false);
+		Monster *monster = FindMonsterAtPosition(trap.position, true);
+		if (monster != nullptr)
+			MonsterTrapHit(*monster, mindam / 2, maxdam / 2, 0, MIS_FIREWALLC, false);
 		if (dPlayer[x][y] > 0) {
 			bool unused;
 			PlayerMHit(dPlayer[x][y] - 1, nullptr, 0, mindam, maxdam, MIS_FIREWALLC, false, 0, &unused);
@@ -3462,8 +3463,9 @@ void BreakBarrel(const Player &player, Object &barrel, bool forcebreak, bool sen
 			PlaySfxLoc(IS_BARLFIRE, barrel.position);
 		for (int yp = barrel.position.y - 1; yp <= barrel.position.y + 1; yp++) {
 			for (int xp = barrel.position.x - 1; xp <= barrel.position.x + 1; xp++) {
-				if (dMonster[xp][yp] > 0) {
-					MonsterTrapHit(dMonster[xp][yp] - 1, 1, 4, 0, MIS_FIREBOLT, false);
+				Monster *monster = FindMonsterAtPosition({ xp, yp }, true);
+				if (monster != nullptr) {
+					MonsterTrapHit(*monster, 1, 4, 0, MIS_FIREBOLT, false);
 				}
 				if (dPlayer[xp][yp] > 0) {
 					bool unused;


### PR DESCRIPTION
We recently added the parameter `ignoreMovingMonsters` to the `FindMovingMonster` function and while it helps, there are still places where we need to find the monster at a position and also know whether it's moving or not.

Therefore, this adds the function `FindMonsterMovingStateAtPosition` that returns a tuple with the monster pointer and a bool representing if it's moving or not.

CheckMissileCol was refactored to use the new function.

MonsterTrapHit and MonsterMHit and new receiving monster references.