### PR TITLE
StartNewLvl: Only update setlvlnum for the local player

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3098,7 +3098,8 @@ StartNewLvl(Player &player, interface_mode fom, int lvl)
 		player.setLevel(lvl);
 		break;
 	case WM_DIABSETLVL:
-		setlvlnum = (_setlevels)lvl;
+		if (&player == MyPlayer)
+			setlvlnum = (_setlevels)lvl;
 		player.setLevel(setlvlnum);
 		break;
 	case WM_DIABTWARPUP:


### PR DESCRIPTION
Found by pvp-community while testing #4599