### PR TITLE
DeltaSyncOpObject: Add handling for shrine

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4459,6 +4459,8 @@ void DeltaSyncOpObject(Object &object)
 	case OBJ_SARC:
 	case OBJ_L5SARC:
 	case OBJ_GOATSHRINE:
+	case OBJ_SHRINEL:
+	case OBJ_SHRINER:
 		UpdateState(object, object._oAnimLen);
 		break;
 	case OBJ_BLINDBOOK:


### PR DESCRIPTION
Fixes #5230

`OBJ_SHRINEL` and `OBJ_SHRINER` wasn't updated when delta loading (multiplayer) a level.