### PR TITLE
Resurrect SyncPositionWithParent

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -626,6 +626,17 @@ bool GrowWall(int playerId, Point position, Point target, missile_id type, int s
 	return true;
 }
 
+/** @brief Sync missile position with parent missile */
+void SyncPositionWithParent(Missile &missile, const AddMissileParameter &parameter)
+{
+	const Missile *parent = parameter.pParent;
+	if (parent == nullptr)
+		return;
+
+	missile.position.offset = parent->position.offset;
+	missile.position.traveled = parent->position.traveled;
+}
+
 void SpawnLightning(Missile &missile, int dam)
 {
 	missile._mirange--;
@@ -658,7 +669,8 @@ void SpawnLightning(Missile &missile, int dam)
 			    missile._micaster,
 			    missile._misource,
 			    dam,
-			    missile._mispllvl);
+			    missile._mispllvl,
+			    &missile);
 			missile.var1 = position.x;
 			missile.var2 = position.y;
 		}
@@ -1796,6 +1808,8 @@ void AddLightning(Missile &missile, const AddMissileParameter &parameter)
 {
 	missile.position.start = parameter.dst;
 
+	SyncPositionWithParent(missile, parameter);
+
 	missile._miAnimFrame = GenerateRnd(8) + 1;
 
 	if (missile._micaster == TARGET_PLAYERS || missile.IsTrap()) {
@@ -2446,6 +2460,8 @@ void AddFlame(Missile &missile, const AddMissileParameter &parameter)
 {
 	missile.var2 = 5 * missile._midam;
 	missile.position.start = parameter.dst;
+
+	SyncPositionWithParent(missile, parameter);
 
 	missile._mirange = missile.var2 + 20;
 	missile._mlid = AddLight(missile.position.start, 1);
@@ -3783,7 +3799,8 @@ void MI_Flamec(Missile &missile)
 			    missile._micaster,
 			    missile._misource,
 			    missile.var3,
-			    missile._mispllvl);
+			    missile._mispllvl,
+			    &missile);
 		} else {
 			missile._mirange = 0;
 		}


### PR DESCRIPTION
This resurrects `SyncPositionWithParent` that was removed in #3957 / ed5a3b3dcbe5455f5f423b15b63d92e512bbfe8a

This is only a visual difference change and doesn't affect gameplay (cause lightning and inferno flames don't move)

The changes is most notable with lightning, cause now we have more fragmentation and a spawned lightning isn't always shown exactly on a line.

## 1.4 & master
![lightning140](https://user-images.githubusercontent.com/25415264/184434786-fb739cde-0a92-4c16-8c41-4c1caea00fe4.gif)

## 1.3 & pr
![lightning130](https://user-images.githubusercontent.com/25415264/184434855-6aa7d8b4-7fd0-4c2e-ad15-1908de7c2ca4.gif)

Thanks galaxyhaxz for reporting, AJenbo for bisecting and qndel for the gifs 🙂 
