### PR TITLE
Update SDL2 to versoin 2.23.2

### DIFF
--- a/3rdParty/SDL2/CMakeLists.txt
+++ b/3rdParty/SDL2/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 include(functions/FetchContent_MakeAvailableExcludeFromAll)
 include(FetchContent)
 FetchContent_Declare(SDL2
-    URL https://github.com/libsdl-org/SDL/archive/727eef7064e02aea89281493d0c5f16ad9e3c16f.tar.gz
-    URL_HASH MD5=0fd8f95b01967423af7705250beb7208
+    URL https://github.com/libsdl-org/SDL/archive/cb46e1b3f06a08d57b4ccd83127d1ec3139e1c0f.tar.gz
+    URL_HASH MD5=b5539b578ef77f6364f621dc55c244d7
 )
 FetchContent_MakeAvailableExcludeFromAll(SDL2)


### PR DESCRIPTION
Required for PS2 support, and probably Android NDK 25 (default version by November)