### PR TITLE
Use SDL for creating file during RW test

### DIFF
--- a/Source/restrict.cpp
+++ b/Source/restrict.cpp
@@ -8,17 +8,19 @@
 #include "utils/file_util.h"
 #include "utils/paths.h"
 
+#include <SDL.h>
+
 namespace devilution {
 
 void ReadOnlyTest()
 {
 	const std::string path = paths::PrefPath() + "Diablo1ReadOnlyTest.foo";
-	FILE *f = FOpen(path.c_str(), "w");
-	if (f == nullptr) {
+	SDL_RWops *file = SDL_RWFromFile(path.c_str(), "w");
+	if (file == nullptr) {
 		DirErrorDlg(paths::PrefPath());
 	}
 
-	fclose(f);
+	SDL_RWclose(file);
 	RemoveFile(path.c_str());
 }
 

--- a/Source/utils/file_util.cpp
+++ b/Source/utils/file_util.cpp
@@ -76,7 +76,7 @@ bool FileExists(const char *path)
 	return ::access(path, F_OK) == 0;
 #else
 	SDL_RWops *file = SDL_RWFromFile(path, "r+b");
-	if (file == NULL)
+	if (file == nullptr)
 		return false;
 	SDL_RWclose(file);
 	return true;
@@ -115,7 +115,7 @@ bool FileExistsAndIsWriteable(const char *path)
 	if (!FileExists(path))
 		return false;
 	SDL_RWops *file = SDL_RWFromFile(path, "a+b");
-	if (file == NULL)
+	if (file == nullptr)
 		return false;
 	SDL_RWclose(file);
 	return true;
@@ -222,25 +222,6 @@ std::optional<std::fstream> CreateFileStream(const char *path, std::ios::openmod
 	return { std::fstream(pathUtf16.get(), mode) };
 #else
 	return { std::fstream(path, mode) };
-#endif
-}
-
-FILE *FOpen(const char *path, const char *mode)
-{
-#if (defined(_WIN64) || defined(_WIN32)) && !defined(NXDK)
-	const auto pathUtf16 = ToWideChar(path);
-	if (pathUtf16 == nullptr) {
-		LogError("UTF-8 -> UTF-16 conversion error code {}", ::GetLastError());
-		return nullptr;
-	}
-	const auto modeUtf16 = ToWideChar(mode);
-	if (modeUtf16 == nullptr) {
-		LogError("UTF-8 -> UTF-16 conversion error code {}", ::GetLastError());
-		return nullptr;
-	}
-	return ::_wfopen(&pathUtf16[0], &modeUtf16[0]);
-#else
-	return std::fopen(path, mode);
 #endif
 }
 

--- a/Source/utils/file_util.h
+++ b/Source/utils/file_util.h
@@ -17,7 +17,6 @@ bool GetFileSize(const char *path, std::uintmax_t *size);
 bool ResizeFile(const char *path, std::uintmax_t size);
 void RemoveFile(const char *path);
 std::optional<std::fstream> CreateFileStream(const char *path, std::ios::openmode mode);
-FILE *FOpen(const char *path, const char *mode);
 
 #if (defined(_WIN64) || defined(_WIN32)) && !defined(NXDK)
 std::unique_ptr<wchar_t[]> ToWideChar(string_view path);


### PR DESCRIPTION
It looks like this is mostly a left over from when file handeling was migrated to SDL