### PR TITLE
Avoid DLevel copy constructor in GetDeltaLevel()

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -139,9 +139,7 @@ DLevel &GetDeltaLevel(uint8_t level)
 	auto keyIt = DeltaLevels.find(level);
 	if (keyIt != DeltaLevels.end())
 		return keyIt->second;
-	auto emplaceRet = DeltaLevels.emplace(level, DLevel {});
-	assert(emplaceRet.second);
-	DLevel &deltaLevel = emplaceRet.first->second;
+	DLevel &deltaLevel = DeltaLevels[level];
 	memset(&deltaLevel.item, 0xFF, sizeof(deltaLevel.item));
 	memset(&deltaLevel.monster, 0xFF, sizeof(deltaLevel.monster));
 	return deltaLevel;


### PR DESCRIPTION
Fixes a crash due to data alignment on 3DS when attempting to create a Multiplayer game.

Some relevant notes from @glebm on Discord.

> Sounds like `DLevel` has a broken copy constructor
> may have something to do with `#pragma pack(push, 1)`
> older ARM CPUs crash on unaligned writes (and reads sometimes)