### PR TITLE
Remove pragma pack from DLevel struct

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -64,6 +64,7 @@ struct DMonsterStr {
 	int32_t hitPoints;
 	int8_t mWhoHit;
 };
+#pragma pack(pop)
 
 struct DObjectStr {
 	_cmd_id bCmd;
@@ -75,6 +76,7 @@ struct DLevel {
 	DMonsterStr monster[MaxMonsters];
 };
 
+#pragma pack(push, 1)
 struct LocalLevel {
 	LocalLevel(const uint8_t (&other)[DMAXX][DMAXY])
 	{


### PR DESCRIPTION
This actually fixes the crash due to data alignment on 3DS when attempting to create a Multiplayer game. I tested with and without debug code this time, so I'm pretty confident this will fix it for good.

The previous fix worked when I had my debug log statements in, but not when I removed them. Probably, the data alignment just happened to be valid for that `DLevel` instance with those specific changes and the debug statements in.

I also removed pragma pack from `DObjectStr` since object deltas don't use `memcpy()` to import/export the data.