### PR TITLE
Fix incorrect SOLData for L1 Piece 27 (BlockMissile is missing)

### DIFF
--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -422,6 +422,7 @@ void LoadLevelSOLData()
 		break;
 	case DTYPE_CATHEDRAL:
 		LoadFileInMem("levels\\l1data\\l1.sol", SOLData);
+		SOLData[27] |= TileProperties::BlockMissile; // Tile is incorrectly marked
 		break;
 	case DTYPE_CATACOMBS:
 		LoadFileInMem("levels\\l2data\\l2.sol", SOLData);


### PR DESCRIPTION
- Use the save from #4384
- move one tile to the right
- shoot straight upwards (with any missile)
- you can shoot through the corner

Screenshot (with `tiledata dPiece`):
![grafik](https://user-images.githubusercontent.com/25415264/185782649-262c7976-d9be-43bb-9e74-eb0f568cbc77.png)

This is due dPiece 27 is incorrectly not marked as blocking missiles.

Thanks @FitzRoyX for reporting 🙂 