### PR TITLE
Turn off monster highlighting with Heal Other and Resurrect cursors

### DIFF
--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -535,7 +535,7 @@ void CheckCursMove()
 			pcursmonst = -1;
 			cursPosition = { mx, my };
 		}
-		if (pcursmonst != -1 && Monsters[pcursmonst].isPlayerMinion()) {
+		if (pcursmonst != -1 && (Monsters[pcursmonst].isPlayerMinion() || IsAnyOf(pcurs, CURSOR_HEALOTHER, CURSOR_RESURRECT))) {
 			pcursmonst = -1;
 		}
 	} else {


### PR DESCRIPTION
This implements issue 5104 : https://github.com/diasurgical/devilutionX/issues/5104

Tested locally, seems to work alright.