### PR TITLE
Keep track of MonsterKillCounts across New Games and in MP

### DIFF
--- a/Source/loadsave.h
+++ b/Source/loadsave.h
@@ -22,6 +22,7 @@ _item_indexes RemapItemIdxToSpawn(_item_indexes i);
 bool IsHeaderValid(uint32_t magicNumber);
 void LoadHotkeys();
 void LoadHeroItems(Player &player);
+void LoadMonsterKillCounts();
 /**
  * @brief Remove invalid inventory items from the inventory grid
  * @param player The player to remove invalid items from
@@ -35,6 +36,7 @@ void RemoveEmptyInventory(Player &player);
 void LoadGame(bool firstflag);
 void SaveHotkeys(MpqWriter &saveWriter);
 void SaveHeroItems(MpqWriter &saveWriter, Player &player);
+void SaveMonsterKillCounts(MpqWriter &saveWriter);
 void SaveGameData(MpqWriter &saveWriter);
 void SaveGame();
 void SaveLevel(MpqWriter &saveWriter);

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -55,7 +55,7 @@ int ActiveMonsters[MaxMonsters];
 size_t ActiveMonsterCount;
 // BUGFIX: replace MonsterKillCounts[MaxMonsters] with MonsterKillCounts[NUM_MTYPES].
 /** Tracks the total number of monsters killed per monster_id. */
-int MonsterKillCounts[MaxMonsters];
+int32_t MonsterKillCounts[MaxMonsters];
 bool sgbSaveSoundOn;
 
 namespace {

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -369,7 +369,7 @@ extern size_t LevelMonsterTypeCount;
 extern Monster Monsters[MaxMonsters];
 extern int ActiveMonsters[MaxMonsters];
 extern size_t ActiveMonsterCount;
-extern int MonsterKillCounts[MaxMonsters];
+extern int32_t MonsterKillCounts[MaxMonsters];
 extern bool sgbSaveSoundOn;
 
 void PrepareUniqueMonst(Monster &monster, UniqueMonsterType monsterType, size_t miniontype, int bosspacksize, const UniqueMonsterData &uniqueMonsterData);

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -480,6 +480,7 @@ void pfile_write_hero(MpqWriter &saveWriter, bool writeGameData)
 	if (!gbVanilla) {
 		SaveHotkeys(saveWriter);
 		SaveHeroItems(saveWriter, myPlayer);
+		SaveMonsterKillCounts(saveWriter);
 	}
 }
 
@@ -682,6 +683,7 @@ void pfile_read_player_from_save(uint32_t saveNum, Player &player)
 	}
 
 	LoadHeroItems(player);
+	LoadMonsterKillCounts();
 	RemoveEmptyInventory(player);
 	CalcPlrInv(player, false);
 }


### PR DESCRIPTION
This patch preserves MonsterKillCounts values in MP and when using New
Game in SP.

It is implemented by adding a "monsterkillcounts" section in the save
archive.

This patch also changes the type of MonsterKillCounts elements to be
`int32_t` instead of `int`, for better compatibility across platforms,
as the `int` datatype might not always be 4 bytes.

Implements https://github.com/diasurgical/devilutionX/issues/3831

I tested it locally on dlvl1 in the following scenarios : 
- launch devilutionX, create a MP game, kill some monsters. Quit devilutionX. Relaunch it. Start a MP game: the kill counters were preserved.
- launch devilutionX, create a SP game, kill some monsters, Save Game, quit devilutionX, relaunch devilutionX, create New Game from SP menu. The kill counters seemed to be preserved.
- launch devilutionX, Save Game, kill some monsters, Load Game: the kill counters are appropriately reset to their previous value

Previous PR: https://github.com/diasurgical/devilutionX/pull/5269
Apologies for the duplicated PR, I wanted to reopen the 5269 but it is not possible to do after a force push. I am still discovering Github PR system (we use Phabricator at work). In the future i will either avoid closing the PR, or reopen before updating it.