### PR TITLE
Fix template data type when loading class TRN

### DIFF
--- a/Source/engine/trn.cpp
+++ b/Source/engine/trn.cpp
@@ -56,7 +56,7 @@ std::optional<std::array<uint8_t, 256>> GetClassTRN(Player &player)
 		path = debugTRN.c_str();
 	}
 #endif
-	if (LoadOptionalFileInMem(path, &trn, 256)) {
+	if (LoadOptionalFileInMem(path, &trn[0], 256)) {
 		return trn;
 	}
 	return std::nullopt;


### PR DESCRIPTION
Fixes an issue where class TRNs could not be loaded directly from assets placed on the filesystem, causing the colorless sprite seen below.

![image](https://user-images.githubusercontent.com/9203145/185926777-67452322-1946-4955-9f94-c93eaba5c1fa.png)

The TRN used here was infra.trn copied directly from diabdat.mpq to my assets folder. Attempting to load the TRN with `trn infra` will result in the following error messages, indicating that there are errors preventing it from reading the data.

```
DEBUG: Error reading from datastream
DEBUG: Error reading from datastream
DEBUG: Error reading from datastream
DEBUG: Error reading from datastream
DEBUG: Error reading from datastream
INFO: DebugCmd: trn infra Result: I am a pretty butterfly. 
(Loading TRN: infra.trn)
```

The issue is caused by the data type of the `trn` variable used on the line modified by this PR. `&trn` produces a value of type `std::array<uint8_t, 256> *` which results in a call to `LoadOptionalFileInMem<std::array<uint8_t, 256>>`. This causes an attempt to read beyond the end of the file because `count * sizeof(T)` evaluates to the wrong size.

https://github.com/diasurgical/devilutionX/blob/17bf252608a06bc723dac4bf05e875fbe786b885/Source/engine/load_file.hpp#L83

For TRNs that are packed in an MPQ, it seems the rwops treats the size we pass in as a maximum size for the output buffer, so it doesn't produce an error when passing a value that is too large. This explains why using `trn plr infra` to load the TRN from diabdat.mpq works correctly despite passing the wrong size. Instead, attempting to load an invalid TRN from an MPQ that is larger than 256 bytes would produce a buffer overflow.

https://github.com/diasurgical/devilutionX/blob/17bf252608a06bc723dac4bf05e875fbe786b885/Source/mpq/mpq_sdl_rwops.cpp#L93