### PR TITLE
Only load Hellfire music when Hellfire is active

### DIFF
--- a/Source/menu.cpp
+++ b/Source/menu.cpp
@@ -34,9 +34,9 @@ _music_id NextTrack()
 	case TMUSIC_CAVES:
 		return TMUSIC_HELL;
 	case TMUSIC_HELL:
-		return TMUSIC_NEST;
+		return gbIsHellfire ? TMUSIC_NEST : TMUSIC_INTRO;
 	case TMUSIC_NEST:
-		return TMUSIC_CRYPT;
+		return gbIsHellfire ? TMUSIC_CRYPT : TMUSIC_INTRO;
 	default:
 		return TMUSIC_INTRO;
 	}


### PR DESCRIPTION
The game was attempting to load Nest and Crypt music in the menu when playing DevilutionX Diablo, causing silence in the menus because the assets failed to load.