### PR TITLE
3rdParty/SDL2: Disable SDL_TEST

### DIFF
--- a/3rdParty/SDL2/CMakeLists.txt
+++ b/3rdParty/SDL2/CMakeLists.txt
@@ -10,6 +10,7 @@ else()
   set(SDL_SHARED ON)
   set(SDL_STATIC OFF)
 endif()
+set(SDL_TEST OFF)
 
 include(functions/FetchContent_MakeAvailableExcludeFromAll)
 include(FetchContent)


### PR DESCRIPTION
The fully-vendored source distribution removes all test files to reduce the size, which causes a CMake configuration error if `SDL_TEST` is on.