### PR TITLE
Add killall, breakall, openall and clearall debug commands

### DIFF
--- a/Source/objects.h
+++ b/Source/objects.h
@@ -191,6 +191,26 @@ struct Object {
 		return IsAnyOf(_otype, _object_id::OBJ_CHEST1, _object_id::OBJ_CHEST2, _object_id::OBJ_CHEST3, _object_id::OBJ_TCHEST1, _object_id::OBJ_TCHEST2, _object_id::OBJ_TCHEST3);
 	}
 
+	[[nodiscard]] constexpr bool isSarcophagus() const
+	{
+		return _otype == _object_id::OBJ_SARC;
+	}
+
+	/**
+	 * @brief Check if the object is open
+	 *
+	 * Only chests, sarcophagus and doors are handled.
+	 */
+	[[nodiscard]] constexpr bool isOpen() const
+	{
+		assert((IsChest() || isSarcophagus() || isDoor()) && "IsOpen can only be called on chests, sarcophagus and doors");
+		if (IsChest() || isSarcophagus())
+			return _oSelFlag == 0U;
+		if (isDoor())
+			return _oSelFlag == 2U;
+		return false;
+	}
+
 	/**
 	 * @brief Check if this object is a trapped chest (specifically a chest which is currently trapped).
 	 * @return True if the object is one of the trapped chest types (see _object_id) and has an active trap.

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -208,7 +208,7 @@ struct Object {
 		if (IsChest() || isSarcophagus())
 			return _oSelFlag == 0U;
 		if (isDoor())
-			return _oSelFlag == 2U;
+			return _oVar4 != DOOR_CLOSED;
 		return false;
 	}
 

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -203,7 +203,8 @@ struct Object {
 	 */
 	[[nodiscard]] constexpr bool isOpen() const
 	{
-		assert((IsChest() || isSarcophagus() || isDoor()) && "IsOpen can only be called on chests, sarcophagus and doors");
+		assert((IsChest() || isSarcophagus() || isDoor()) && "isOpen can only be called on chests, sarcophagus and doors");
+
 		if (IsChest() || isSarcophagus())
 			return _oSelFlag == 0U;
 		if (isDoor())


### PR DESCRIPTION
In the current level:
- killall: kill all monsters
- openall: open all chests and sarcophagus
- breakall: break all barrels
- clearall: mix of the three above commands

This is an arranged cherry-pick from devilutionX-ironman 98bbbc337d9e83e6dedc358fe0832630b614d34d, where those debug commands have been useful to me

CC @obligaron who was interested in the PR