### PR TITLE
3rdParty/SDL2: Use SDL_TEST_ENABLED_BY_DEFAULT

### DIFF
--- a/3rdParty/SDL2/CMakeLists.txt
+++ b/3rdParty/SDL2/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
   set(SDL_SHARED ON)
   set(SDL_STATIC OFF)
 endif()
-set(SDL_TEST OFF)
+set(SDL_TEST_ENABLED_BY_DEFAULT OFF)
 
 include(functions/FetchContent_MakeAvailableExcludeFromAll)
 include(FetchContent)


### PR DESCRIPTION
I poked around a bit after https://github.com/diasurgical/devilutionX/pull/5306#issuecomment-1230342956, and it seems they're doing something a bit odd with that `SDL_TEST` variable.
https://github.com/libsdl-org/SDL/blob/cb46e1b3f06a08d57b4ccd83127d1ec3139e1c0f/CMakeLists.txt#L510