### PR TITLE
Refactor missiles.cpp to use Direction enum instead of magic Point/Displacement constants.

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -468,6 +468,8 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, int 
 		DrawHorizontalLine(out, point, AmLine(8) + 1, playerColor);
 		DrawMapLineSteepSE(out, point, AmLine(4), playerColor);
 	} break;
+	case Direction::NoDirection:
+	break;
 	}
 }
 

--- a/Source/engine/direction.hpp
+++ b/Source/engine/direction.hpp
@@ -16,6 +16,7 @@ enum class Direction : std::uint8_t {
 	NorthEast,
 	East,
 	SouthEast,
+	NoDirection
 };
 
 /** Maps from direction to a left turn from the direction. */

--- a/Source/engine/displacement.hpp
+++ b/Source/engine/displacement.hpp
@@ -244,6 +244,8 @@ private:
 			return { 1, -1 };
 		case Direction::SouthEast:
 			return { 1, 0 };
+		case Direction::NoDirection:
+			return { 0, 0 };
 		default:
 			return { 0, 0 };
 		}

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -16,6 +16,7 @@
 #endif
 #include "engine/load_file.hpp"
 #include "engine/random.hpp"
+#include "engine/points_in_rectangle_range.hpp"
 #include "init.h"
 #include "inv.h"
 #include "levels/trigs.h"
@@ -1442,9 +1443,11 @@ void AddRuneExplosion(Missile &missile, const AddMissileParameter & /*parameter*
 
 		missile._midam = dmg;
 
-		constexpr Displacement Offsets[] = { { -1, -1 }, { 0, -1 }, { 1, -1 }, { -1, 0 }, { 0, 0 }, { 1, 0 }, { -1, 1 }, { 0, 1 }, { 1, 1 } };
-		for (Displacement offset : Offsets)
-			CheckMissileCol(missile, dmg, dmg, false, missile.position.tile + offset, true);
+		auto searchArea = PointsInRectangleRangeColMajor { 
+			Rectangle { missile.position.tile, 1 } 
+		};
+		for (Point position : searchArea)
+			CheckMissileCol(missile, dmg, dmg, false, position, true);
 	}
 	missile._mlid = AddLight(missile.position.start, 8);
 	SetMissDir(missile, 0);
@@ -2976,8 +2979,18 @@ void MI_Fireball(Missile &missile)
 			const Point missilePosition = missile.position.tile;
 			ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame);
 
-			constexpr Displacement Offsets[] = { { 0, 0 }, { 0, 1 }, { 0, -1 }, { 1, 0 }, { 1, -1 }, { 1, 1 }, { -1, 0 }, { -1, 1 }, { -1, -1 } };
-			for (Displacement offset : Offsets) {
+			constexpr Direction Offsets[] = { 
+				Direction::NoDirection, 
+				Direction::SouthWest, 
+				Direction::NorthEast, 
+				Direction::SouthEast, 
+				Direction::East, 
+				Direction::South, 
+				Direction::NorthWest, 
+				Direction::West, 
+				Direction::North 
+			};
+			for (Direction offset : Offsets) {
 				if (!CheckBlock(missile.position.start, missilePosition + offset))
 					CheckMissileCol(missile, minDam, maxDam, false, missilePosition + offset, true);
 			}
@@ -3314,8 +3327,15 @@ void MI_Flash(Missile &missile)
 	}
 	missile._mirange--;
 
-	constexpr Displacement Offsets[] = { { -1, 0 }, { 0, 0 }, { 1, 0 }, { -1, 1 }, { 0, 1 }, { 1, 1 } };
-	for (Displacement offset : Offsets)
+	constexpr Direction Offsets[] = { 
+		Direction::NorthWest, 
+		Direction::NoDirection, 
+		Direction::SouthEast, 
+		Direction::West, 
+		Direction::SouthWest,
+		Direction::South 
+	};
+	for (Direction offset : Offsets)
 		CheckMissileCol(missile, missile._midam, missile._midam, true, missile.position.tile + offset, true);
 
 	if (missile._mirange == 0) {
@@ -3336,8 +3356,12 @@ void MI_Flash2(Missile &missile)
 	}
 	missile._mirange--;
 
-	constexpr Displacement Offsets[] = { { -1, -1 }, { 0, -1 }, { 1, -1 } };
-	for (Displacement offset : Offsets)
+	constexpr Direction Offsets[] = { 
+		Direction::North, 
+		Direction::North, 
+		Direction::East
+	};
+	for (Direction offset : Offsets)
 		CheckMissileCol(missile, missile._midam, missile._midam, true, missile.position.tile + offset, true);
 
 	if (missile._mirange == 0) {
@@ -3925,8 +3949,18 @@ void MI_Element(Missile &missile)
 		ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame);
 
 		Point startPoint = missile.var3 == 2 ? Point { missile.var4, missile.var5 } : Point(missile.position.start);
-		constexpr Displacement Offsets[] = { { 0, 0 }, { 0, 1 }, { 0, -1 }, { 1, 0 }, { 1, -1 }, { 1, 1 }, { -1, 0 }, { -1, 1 }, { -1, -1 } };
-		for (Displacement offset : Offsets) {
+		constexpr Direction Offsets[] = { 
+			Direction::NoDirection, 
+			Direction::SouthWest, 
+			Direction::NorthEast, 
+			Direction::SouthEast, 
+			Direction::East, 
+			Direction::South, 
+			Direction::NorthWest, 
+			Direction::West, 
+			Direction::North
+		};
+		for (Direction offset : Offsets) {
 			if (!CheckBlock(startPoint, missilePosition + offset))
 				CheckMissileCol(missile, dam, dam, true, missilePosition + offset, true);
 		}

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -15,8 +15,8 @@
 #include "debug.h"
 #endif
 #include "engine/load_file.hpp"
-#include "engine/random.hpp"
 #include "engine/points_in_rectangle_range.hpp"
+#include "engine/random.hpp"
 #include "init.h"
 #include "inv.h"
 #include "levels/trigs.h"
@@ -1443,8 +1443,8 @@ void AddRuneExplosion(Missile &missile, const AddMissileParameter & /*parameter*
 
 		missile._midam = dmg;
 
-		auto searchArea = PointsInRectangleRangeColMajor { 
-			Rectangle { missile.position.tile, 1 } 
+		auto searchArea = PointsInRectangleRangeColMajor {
+			Rectangle { missile.position.tile, 1 }
 		};
 		for (Point position : searchArea)
 			CheckMissileCol(missile, dmg, dmg, false, position, true);
@@ -2979,16 +2979,16 @@ void MI_Fireball(Missile &missile)
 			const Point missilePosition = missile.position.tile;
 			ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame);
 
-			constexpr Direction Offsets[] = { 
-				Direction::NoDirection, 
-				Direction::SouthWest, 
-				Direction::NorthEast, 
-				Direction::SouthEast, 
-				Direction::East, 
-				Direction::South, 
-				Direction::NorthWest, 
-				Direction::West, 
-				Direction::North 
+			constexpr Direction Offsets[] = {
+				Direction::NoDirection,
+				Direction::SouthWest,
+				Direction::NorthEast,
+				Direction::SouthEast,
+				Direction::East,
+				Direction::South,
+				Direction::NorthWest,
+				Direction::West,
+				Direction::North
 			};
 			for (Direction offset : Offsets) {
 				if (!CheckBlock(missile.position.start, missilePosition + offset))
@@ -3327,13 +3327,13 @@ void MI_Flash(Missile &missile)
 	}
 	missile._mirange--;
 
-	constexpr Direction Offsets[] = { 
-		Direction::NorthWest, 
-		Direction::NoDirection, 
-		Direction::SouthEast, 
-		Direction::West, 
+	constexpr Direction Offsets[] = {
+		Direction::NorthWest,
+		Direction::NoDirection,
+		Direction::SouthEast,
+		Direction::West,
 		Direction::SouthWest,
-		Direction::South 
+		Direction::South
 	};
 	for (Direction offset : Offsets)
 		CheckMissileCol(missile, missile._midam, missile._midam, true, missile.position.tile + offset, true);
@@ -3356,9 +3356,9 @@ void MI_Flash2(Missile &missile)
 	}
 	missile._mirange--;
 
-	constexpr Direction Offsets[] = { 
-		Direction::North, 
-		Direction::North, 
+	constexpr Direction Offsets[] = {
+		Direction::North,
+		Direction::North,
 		Direction::East
 	};
 	for (Direction offset : Offsets)
@@ -3949,15 +3949,15 @@ void MI_Element(Missile &missile)
 		ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame);
 
 		Point startPoint = missile.var3 == 2 ? Point { missile.var4, missile.var5 } : Point(missile.position.start);
-		constexpr Direction Offsets[] = { 
-			Direction::NoDirection, 
-			Direction::SouthWest, 
-			Direction::NorthEast, 
-			Direction::SouthEast, 
-			Direction::East, 
-			Direction::South, 
-			Direction::NorthWest, 
-			Direction::West, 
+		constexpr Direction Offsets[] = {
+			Direction::NoDirection,
+			Direction::SouthWest,
+			Direction::NorthEast,
+			Direction::SouthEast,
+			Direction::East,
+			Direction::South,
+			Direction::NorthWest,
+			Direction::West,
 			Direction::North
 		};
 		for (Direction offset : Offsets) {

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3832,6 +3832,8 @@ bool Walk(Monster &monster, Direction md)
 	case Direction::NorthWest:
 		WalkNorthwards(monster, -1, 0, Direction::NorthWest);
 		break;
+	case Direction::NoDirection:
+		break;
 	}
 	return true;
 }


### PR DESCRIPTION
This PR supersedes PR #4011 which was opened by @Sergentfox234.  This is a solution for issue #2260. @AJenbo suggested a number of changes to PR #4011 on January 29th, and since these changes have not been implemented yet, I opted to do it myself. 

Besides implementing the suggested changes, I have also made an additional change. I've added a direction called `NoDirection` to `enum class Direction`, and added this direction to the Displacement switch statement in `displacement.hpp` so that displacement `{ 0, 0 }` can be labelled in the code. To prevent warnings during compilation, I've added a case for `Direction::NoDirection` to switch statements in `monster.cpp` and `automap.cpp` (the case does nothing, just breaks). 