### PR TITLE
CMake: Set CMP0135 to NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,11 @@
 cmake_minimum_required(VERSION 3.13)
 
-if(POLICY CMP0092)
-  cmake_policy(SET CMP0092 NEW)
-endif()
-if(POLICY CMP0083)
-  cmake_policy(SET CMP0083 NEW)
-endif()
-if(POLICY CMP0111)
-  cmake_policy(SET CMP0111 NEW)
-endif()
-if(POLICY CMP0126)
-  cmake_policy(SET CMP0126 NEW)
-endif()
+foreach(_policy CMP0083 CMP0092 CMP0111 CMP0126 CMP0135)
+  if(POLICY ${_policy})
+    cmake_policy(SET ${_policy} NEW)
+    set(CMAKE_POLICY_DEFAULT_${_policy} NEW)
+  endif()
+endforeach()
 
 # Projects added via `add_subdirectory` or `FetchContent` may have a lower
 # `cmake_minimum_required` than we set here. Set policies that we require


### PR DESCRIPTION
Also cleans up how the policies are set and ensures all the NEW policies also have `CMAKE_POLICY_DEFAULT_CMP<NNNN>` set to `NEW`.

Eliminates the warning in CMake v3.24+ https://cmake.org/cmake/help/latest/policy/CMP0135.html