### PR TITLE
Handle multiline strings in PrintInfo

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -256,6 +256,16 @@ void SetButtonStateDown(int btnId)
 	panbtndown = true;
 }
 
+int CountNewlines(std::string_view str)
+{
+	int count = 0;
+	for (char c : str) {
+		if (c == '\n')
+			count++;
+	}
+	return count;
+}
+
 void PrintInfo(const Surface &out)
 {
 	if (talkflag)
@@ -264,7 +274,8 @@ void PrintInfo(const Surface &out)
 	const int LineStart[] = { 70, 58, 52, 48, 46 };
 	const int LineHeights[] = { 30, 24, 18, 15, 12 };
 
-	Rectangle line { GetMainPanel().position + Displacement { 177, LineStart[pnumlines] }, { 288, 12 } };
+	const int yAdjust = 6 * CountNewlines(InfoString);
+	Rectangle line { GetMainPanel().position + Displacement { 177, LineStart[pnumlines] - yAdjust }, { 288, 12 + yAdjust } };
 
 	if (!InfoString.empty()) {
 		DrawString(out, InfoString, line, InfoColor | UiFlags::AlignCenter | UiFlags::KerningFitSpacing, 2);


### PR DESCRIPTION
Currently, using multiline strings in InfoString results in the text not
being centered, in addition to strings with 3 lines and more being just
cut even though there should be enough space in the box.

This patch counts the newlines in the InfoString to adjust accordingly
the text box: text with 2 or 3 lines can now be printed correctly.

Here are a few pictures in my mod that shows the difference:

2-line string, before:
![twolines-before](https://user-images.githubusercontent.com/6163502/187436380-48797344-189f-41d9-935b-2a30585d98e0.png)

2-line string, with this patch:
![twolines-after](https://user-images.githubusercontent.com/6163502/187436459-bc4cd771-aee2-4e10-94e2-d74e27f7986d.png)

3-line string, before:
![threelines-before](https://user-images.githubusercontent.com/6163502/187436488-a8265a8a-6a84-49ca-988c-7ecdd9cd3510.png)

3-line string, after:
![threelines-after](https://user-images.githubusercontent.com/6163502/187436510-526353aa-12e4-4fef-ad52-9a59c3a393b7.png)

I believe this change could benefit modders by allowing them to print more text in the InfoString if they want to.
It could also benefit translations as well: some languages require more words to say the same thing. Perhaps some of the existing translations could be updated to benefit this new multiline string support.

Right now I multiply by 6 the number of newlines and that's the offset I apply to the text box. I pulled this magic number out of my hat, tried different numbers until it looked alright. I am open to have a more precise method if someone can think of one.