### PR TITLE
CMake: Use FindPatch

### DIFF
--- a/3rdParty/discord/CMakeLists.txt
+++ b/3rdParty/discord/CMakeLists.txt
@@ -1,10 +1,12 @@
 include(functions/FetchContent_MakeAvailableExcludeFromAll)
 include(FetchContent)
 
+find_package(Patch REQUIRED)
+
 FetchContent_Declare(discordsrc
   URL https://dl-game-sdk.discordapp.net/2.5.6/discord_game_sdk.zip
   URL_HASH MD5=f86f15957cc9fbf04e3db10462027d58
-  PATCH_COMMAND patch -p0 < "${CMAKE_CURRENT_LIST_DIR}/fix-types-h.patch"
+  PATCH_COMMAND "${Patch_EXECUTABLE}" -p0 -N < "${CMAKE_CURRENT_LIST_DIR}/fix-types-h.patch" || true
 )
 FetchContent_MakeAvailableExcludeFromAll(discordsrc)
 

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -469,7 +469,7 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, int 
 		DrawMapLineSteepSE(out, point, AmLine(4), playerColor);
 	} break;
 	case Direction::NoDirection:
-	break;
+		break;
 	}
 }
 


### PR DESCRIPTION
CMake's built-in FindPatch will look in the Git installation directory on Windows, eliminating the need for Windows users to modify PATH.

See https://github.com/Kitware/CMake/blob/master/Modules/FindPatch.cmake