### PR TITLE
Fix SDL MinGW build

### DIFF
--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -1,6 +1,3 @@
-#if (defined(_WIN64) || defined(_WIN32)) && defined(__GNUC__)
-#define SDL_MAIN_HANDLED
-#endif
 #include <SDL.h>
 #include <SDL_main.h>
 


### PR DESCRIPTION
Fixes building MinGW after updating SDL version with #5322.
Removes workaround for static building SDL with MinGW. No longer needed after updating 2.24.0.