### PR TITLE
Introduce AnimationInfo::isLastFrame and use it instead of _pXYZFrames

### DIFF
--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -66,6 +66,11 @@ public:
 		return (*sprites)[getFrameToUseForRendering()];
 	}
 
+	[[nodiscard]] bool isLastFrame() const
+	{
+		return currentFrame >= (numberOfFrames - 1);
+	}
+
 	/**
 	 * @brief Calculates the Frame to use for the Animation rendering
 	 * @return The Frame to use for rendering

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -655,7 +655,7 @@ void DrawItem(const Surface &out, Point tilePosition, Point targetBufferPosition
 		ClxDrawOutlineSkipColorZero(out, GetOutlineColor(item, false), position, sprite);
 	}
 	ClxDrawLight(out, position, sprite);
-	if (item.AnimInfo.currentFrame == item.AnimInfo.numberOfFrames - 1 || item._iCurs == ICURS_MAGIC_ROCK)
+	if (item.AnimInfo.isLastFrame() || item._iCurs == ICURS_MAGIC_ROCK)
 		AddItemToLabelQueue(bItem - 1, px, targetBufferPosition.y);
 }
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3404,7 +3404,7 @@ void ProcessItems()
 			if (item.AnimInfo.currentFrame == (item.AnimInfo.numberOfFrames - 1) / 2)
 				PlaySfxLoc(ItemDropSnds[ItemCAnimTbl[item._iCurs]], item.position);
 
-			if (item.AnimInfo.currentFrame >= item.AnimInfo.numberOfFrames - 1) {
+			if (item.AnimInfo.isLastFrame()) {
 				item.AnimInfo.currentFrame = item.AnimInfo.numberOfFrames - 1;
 				item._iAnimFlag = false;
 				item._iSelFlag = 1;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1015,7 +1015,7 @@ void MonsterIdle(Monster &monster)
 	else
 		monster.changeAnimationData(MonsterGraphic::Stand);
 
-	if (monster.animInfo.currentFrame == monster.animInfo.numberOfFrames - 1)
+	if (monster.animInfo.isLastFrame())
 		UpdateEnemy(monster);
 
 	monster.var2++;
@@ -1027,7 +1027,7 @@ void MonsterIdle(Monster &monster)
 bool MonsterWalk(Monster &monster, MonsterMode variant)
 {
 	// Check if we reached new tile
-	const bool isAnimationEnd = monster.animInfo.currentFrame == monster.animInfo.numberOfFrames - 1;
+	const bool isAnimationEnd = monster.animInfo.isLastFrame();
 	if (isAnimationEnd) {
 		switch (variant) {
 		case MonsterMode::MoveNorthwards:
@@ -1241,7 +1241,7 @@ bool MonsterAttack(Monster &monster)
 	}
 	if (monster.ai == AI_SNAKE && monster.animInfo.currentFrame == 0)
 		PlayEffect(monster, MonsterSound::Attack);
-	if (monster.animInfo.currentFrame == monster.animInfo.numberOfFrames - 1) {
+	if (monster.animInfo.isLastFrame()) {
 		M_StartStand(monster, monster.direction);
 		return true;
 	}
@@ -1272,7 +1272,7 @@ bool MonsterRangedAttack(Monster &monster)
 		PlayEffect(monster, MonsterSound::Attack);
 	}
 
-	if (monster.animInfo.currentFrame == monster.animInfo.numberOfFrames - 1) {
+	if (monster.animInfo.isLastFrame()) {
 		M_StartStand(monster, monster.direction);
 		return true;
 	}
@@ -1305,7 +1305,7 @@ bool MonsterRangedSpecialAttack(Monster &monster)
 		}
 	}
 
-	if (monster.animInfo.currentFrame == monster.animInfo.numberOfFrames - 1) {
+	if (monster.animInfo.isLastFrame()) {
 		M_StartStand(monster, monster.direction);
 		return true;
 	}
@@ -1319,7 +1319,7 @@ bool MonsterSpecialAttack(Monster &monster)
 		MonsterAttackEnemy(monster, monster.toHitSpecial, monster.minDamageSpecial, monster.maxDamageSpecial);
 	}
 
-	if (monster.animInfo.currentFrame == monster.animInfo.numberOfFrames - 1) {
+	if (monster.animInfo.isLastFrame()) {
 		M_StartStand(monster, monster.direction);
 		return true;
 	}
@@ -1447,7 +1447,7 @@ void MonsterTalk(Monster &monster)
 
 bool MonsterGotHit(Monster &monster)
 {
-	if (monster.animInfo.currentFrame == monster.animInfo.numberOfFrames - 1) {
+	if (monster.animInfo.isLastFrame()) {
 		M_StartStand(monster, monster.direction);
 
 		return true;
@@ -1491,7 +1491,7 @@ void MonsterDeath(Monster &monster)
 
 		if (monster.var1 == 140)
 			PrepDoEnding();
-	} else if (monster.animInfo.currentFrame == monster.animInfo.numberOfFrames - 1) {
+	} else if (monster.animInfo.isLastFrame()) {
 		if (monster.isUnique())
 			AddCorpse(monster.position.tile, monster.corpseId, monster.direction);
 		else
@@ -1509,7 +1509,7 @@ bool MonsterSpecialStand(Monster &monster)
 	if (monster.animInfo.currentFrame == monster.data().animFrameNumSpecial - 1)
 		PlayEffect(monster, MonsterSound::Special);
 
-	if (monster.animInfo.currentFrame == monster.animInfo.numberOfFrames - 1) {
+	if (monster.animInfo.isLastFrame()) {
 		M_StartStand(monster, monster.direction);
 		return true;
 	}
@@ -2240,7 +2240,7 @@ void FallenAi(Monster &monster)
 		}
 	}
 
-	if (monster.animInfo.currentFrame == monster.animInfo.numberOfFrames - 1) {
+	if (monster.animInfo.isLastFrame()) {
 		if (!FlipCoin(4)) {
 			return;
 		}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1243,7 +1243,7 @@ bool DoGotHit(Player &player)
 
 bool DoDeath(Player &player)
 {
-	if (player.AnimInfo.currentFrame == player.AnimInfo.numberOfFrames - 1) {
+	if (player.AnimInfo.isLastFrame()) {
 		if (player.AnimInfo.tickCounterOfCurrentFrame == 0) {
 			player.AnimInfo.ticksPerFrame = 100;
 			dFlags[player.position.tile.x][player.position.tile.y] |= DungeonFlag::DeadPlayer;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -587,51 +587,51 @@ bool DoWalk(Player &player, int variant)
 		}
 	}
 
-	// Check if we reached new tile
-	if (player.AnimInfo.currentFrame >= player._pWFrames - 1) {
+	if (!player.AnimInfo.isLastFrame()) {
+		// We didn't reach new tile so update player's "sub-tile" position
+		ChangeOffset(player);
+		return false;
+	}
 
-		// Update the player's tile position
-		switch (variant) {
-		case PM_WALK_NORTHWARDS:
-			dPlayer[player.position.tile.x][player.position.tile.y] = 0;
-			player.position.tile = player.position.temp;
-			dPlayer[player.position.tile.x][player.position.tile.y] = player.getId() + 1;
-			break;
-		case PM_WALK_SOUTHWARDS:
-			dPlayer[player.position.temp.x][player.position.temp.y] = 0;
-			break;
-		case PM_WALK_SIDEWAYS:
-			dPlayer[player.position.tile.x][player.position.tile.y] = 0;
-			player.position.tile = player.position.temp;
-			// dPlayer is set here for backwards comparability, without it the player would be invisible if loaded from a vanilla save.
-			dPlayer[player.position.tile.x][player.position.tile.y] = player.getId() + 1;
-			break;
-		}
+	// We reached the new tile -> update the player's tile position
+	switch (variant) {
+	case PM_WALK_NORTHWARDS:
+		dPlayer[player.position.tile.x][player.position.tile.y] = 0;
+		player.position.tile = player.position.temp;
+		dPlayer[player.position.tile.x][player.position.tile.y] = player.getId() + 1;
+		break;
+	case PM_WALK_SOUTHWARDS:
+		dPlayer[player.position.temp.x][player.position.temp.y] = 0;
+		break;
+	case PM_WALK_SIDEWAYS:
+		dPlayer[player.position.tile.x][player.position.tile.y] = 0;
+		player.position.tile = player.position.temp;
+		// dPlayer is set here for backwards comparability, without it the player would be invisible if loaded from a vanilla save.
+		dPlayer[player.position.tile.x][player.position.tile.y] = player.getId() + 1;
+		break;
+	}
 
-		// Update the coordinates for lighting and vision entries for the player
-		if (leveltype != DTYPE_TOWN) {
-			ChangeLightXY(player._plid, player.position.tile);
-			ChangeVisionXY(player._pvid, player.position.tile);
-		}
+	// Update the coordinates for lighting and vision entries for the player
+	if (leveltype != DTYPE_TOWN) {
+		ChangeLightXY(player._plid, player.position.tile);
+		ChangeVisionXY(player._pvid, player.position.tile);
+	}
 
-		if (player.walkpath[0] != WALK_NONE) {
-			StartWalkStand(player);
-		} else {
-			StartStand(player, player.tempDirection);
-		}
+	if (player.walkpath[0] != WALK_NONE) {
+		StartWalkStand(player);
+	} else {
+		StartStand(player, player.tempDirection);
+	}
 
-		ClearStateVariables(player);
+	ClearStateVariables(player);
 
-		// Reset the "sub-tile" position of the player's light entry to 0
-		if (leveltype != DTYPE_TOWN) {
-			ChangeLightOffset(player._plid, { 0, 0 });
-		}
+	// Reset the "sub-tile" position of the player's light entry to 0
+	if (leveltype != DTYPE_TOWN) {
+		ChangeLightOffset(player._plid, { 0, 0 });
+	}
 
-		AutoPickup(player);
-		return true;
-	} // We didn't reach new tile so update player's "sub-tile" position
-	ChangeOffset(player);
-	return false;
+	AutoPickup(player);
+	return true;
 }
 
 bool WeaponDecay(Player &player, int ii)
@@ -1040,7 +1040,7 @@ bool DoAttack(Player &player)
 		}
 	}
 
-	if (player.AnimInfo.currentFrame == player._pAFrames - 1) {
+	if (player.AnimInfo.isLastFrame()) {
 		StartStand(player, player._pdir);
 		ClearStateVariables(player);
 		return true;
@@ -1107,7 +1107,7 @@ bool DoRangeAttack(Player &player)
 		}
 	}
 
-	if (player.AnimInfo.currentFrame >= player._pAFrames - 1) {
+	if (player.AnimInfo.isLastFrame()) {
 		StartStand(player, player._pdir);
 		ClearStateVariables(player);
 		return true;
@@ -1146,7 +1146,7 @@ void DamageParryItem(Player &player)
 
 bool DoBlock(Player &player)
 {
-	if (player.AnimInfo.currentFrame >= player._pBFrames - 1) {
+	if (player.AnimInfo.isLastFrame()) {
 		StartStand(player, player._pdir);
 		ClearStateVariables(player);
 
@@ -1217,7 +1217,7 @@ bool DoSpell(Player &player)
 		}
 	}
 
-	if (player.AnimInfo.currentFrame >= player._pSFrames - 1) {
+	if (player.AnimInfo.isLastFrame()) {
 		StartStand(player, player._pdir);
 		ClearStateVariables(player);
 		return true;
@@ -1228,7 +1228,7 @@ bool DoSpell(Player &player)
 
 bool DoGotHit(Player &player)
 {
-	if (player.AnimInfo.currentFrame >= player._pHFrames - 1) {
+	if (player.AnimInfo.isLastFrame()) {
 		StartStand(player, player._pdir);
 		ClearStateVariables(player);
 		if (!FlipCoin(4)) {

--- a/Source/player.h
+++ b/Source/player.h
@@ -693,7 +693,7 @@ struct Player {
 			return true;
 		if (_pmode == PM_SPELL && AnimInfo.currentFrame >= _pSFNum)
 			return true;
-		if (IsWalking() && AnimInfo.currentFrame == AnimInfo.numberOfFrames - 1)
+		if (IsWalking() && AnimInfo.isLastFrame())
 			return true;
 		return false;
 	}


### PR DESCRIPTION
Fixes #5046

The cause of #5046 was that the `AnimationInfo` and player mode got out of sync.
This is mostly not problematic, but in some actions (for example `DoAttack`), we don't use `AnimationInfo::numberOfFrames` to check if an animation ends but instead the original value (for example `_pAFrames`). This can result in problems (see #5046).

With this pr a new helper (`AnimationInfo::isLastFrame`) is introduced to check for the last frame (inspired by #4818).
And this helper is used instead of `_pXYZFrames` (first commit; fixes the issue) and where we previous used `numberOfFrames` (second commit; makes the code more readable).

This pr makes the game more stable and is additional to #5324 (Both pr's fixes #5046 but #5324 is the cleaner way).