### PR TITLE
Decode min-data on load

### DIFF
--- a/Source/engine/render/dun_render.cpp
+++ b/Source/engine/render/dun_render.cpp
@@ -20,72 +20,6 @@ namespace devilution {
 
 namespace {
 
-/**
- * Tile type.
- *
- * The tile type determines data encoding and the shape.
- *
- * Each tile type has its own encoding but they all encode data in the order
- * of bottom-to-top (bottom row first).
- */
-enum class TileType : uint8_t {
-	/**
-	 * 🮆 A 32x32 square. Stored as an array of pixels.
-	 */
-	Square,
-
-	/**
-	 * 🮆 A 32x32 square with transparency. RLE encoded.
-	 *
-	 * Each run starts with an int8_t value.
-	 * If positive, it is followed by this many pixels.
-	 * If negative, it indicates `-value` fully transparent pixels, which are omitted.
-	 *
-	 * Runs do not cross row boundaries.
-	 */
-	TransparentSquare,
-
-	/**
-	 *🭮 Left-pointing 32x31 triangle. Encoded as 31 varying-width rows with 2 padding bytes before every even row.
-	 *
-	 * The smallest rows (bottom and top) are 2px wide, the largest row is 16px wide (middle row).
-	 *
-	 * Encoding:
-	 * for i in [0, 30]:
-	 * - 2 unused bytes if i is even
-	 * - row (only the pixels within the triangle)
-	 */
-	LeftTriangle,
-
-	/**
-	 * 🭬Right-pointing 32x31 triangle.  Encoded as 31 varying-width rows with 2 padding bytes after every even row.
-	 *
-	 * The smallest rows (bottom and top) are 2px wide, the largest row is 16px wide (middle row).
-	 *
-	 * Encoding:
-	 * for i in [0, 30]:
-	 * - row (only the pixels within the triangle)
-	 * - 2 unused bytes if i is even
-	 */
-	RightTriangle,
-
-	/**
-	 * 🭓 Left-pointing 32x32 trapezoid: a 32x16 rectangle and the 16x16 bottom part of `LeftTriangle`.
-	 *
-	 * Begins with triangle part, which uses the `LeftTriangle` encoding,
-	 * and is followed by a flat array of pixels for the top rectangle part.
-	 */
-	LeftTrapezoid,
-
-	/**
-	 * 🭞 Right-pointing 32x32 trapezoid: 32x16 rectangle and the 16x16 bottom part of `RightTriangle`.
-	 *
-	 * Begins with the triangle part, which uses the `RightTriangle` encoding,
-	 * and is followed by a flat array of pixels for the top rectangle part.
-	 */
-	RightTrapezoid,
-};
-
 /** Width of a tile rendering primitive. */
 constexpr std::int_fast16_t Width = TILE_WIDTH / 2;
 
@@ -1208,10 +1142,9 @@ void RenderBlackTileFull(std::uint8_t *dst, int dstPitch)
 
 } // namespace
 
-void RenderTile(const Surface &out, Point position)
+void RenderTile(const Surface &out, Point position, MicroTile tile)
 {
-	const auto tile = static_cast<TileType>((level_cel_block & 0x7000) >> 12);
-	const auto *mask = GetMask(tile);
+	const auto *mask = GetMask(tile.type);
 	if (mask == nullptr)
 		return;
 
@@ -1222,35 +1155,35 @@ void RenderTile(const Surface &out, Point position)
 	position.y += DEBUG_RENDER_OFFSET_Y;
 #endif
 #ifdef DEBUG_RENDER_COLOR
-	DBGCOLOR = GetTileDebugColor(tile);
+	DBGCOLOR = GetTileDebugColor(tile.type);
 #endif
 
-	Clip clip = CalculateClip(position.x, position.y, Width, GetTileHeight(tile), out);
+	Clip clip = CalculateClip(position.x, position.y, Width, GetTileHeight(tile.type), out);
 	if (clip.width <= 0 || clip.height <= 0)
 		return;
 
 	const std::uint8_t *tbl = &LightTables[256 * LightTableIndex];
 	const auto *pFrameTable = reinterpret_cast<const std::uint32_t *>(pDungeonCels.get());
-	const auto *src = reinterpret_cast<const std::uint8_t *>(&pDungeonCels[SDL_SwapLE32(pFrameTable[level_cel_block & 0xFFF])]);
+	const auto *src = reinterpret_cast<const std::uint8_t *>(&pDungeonCels[SDL_SwapLE32(pFrameTable[tile.id])]);
 	std::uint8_t *dst = out.at(static_cast<int>(position.x + clip.left), static_cast<int>(position.y - clip.bottom));
 	const auto dstPitch = out.pitch();
 
 	if (mask == &SolidMask[TILE_HEIGHT - 1]) {
 		if (LightTableIndex == LightsMax) {
-			RenderTileType<TransparencyType::Solid, LightType::FullyDark>(tile, dst, dstPitch, src, mask, tbl, clip);
+			RenderTileType<TransparencyType::Solid, LightType::FullyDark>(tile.type, dst, dstPitch, src, mask, tbl, clip);
 		} else if (LightTableIndex == 0) {
-			RenderTileType<TransparencyType::Solid, LightType::FullyLit>(tile, dst, dstPitch, src, mask, tbl, clip);
+			RenderTileType<TransparencyType::Solid, LightType::FullyLit>(tile.type, dst, dstPitch, src, mask, tbl, clip);
 		} else {
-			RenderTileType<TransparencyType::Solid, LightType::PartiallyLit>(tile, dst, dstPitch, src, mask, tbl, clip);
+			RenderTileType<TransparencyType::Solid, LightType::PartiallyLit>(tile.type, dst, dstPitch, src, mask, tbl, clip);
 		}
 	} else {
 		mask -= clip.bottom;
 		if (LightTableIndex == LightsMax) {
-			RenderTileType<TransparencyType::Blended, LightType::FullyDark>(tile, dst, dstPitch, src, mask, tbl, clip);
+			RenderTileType<TransparencyType::Blended, LightType::FullyDark>(tile.type, dst, dstPitch, src, mask, tbl, clip);
 		} else if (LightTableIndex == 0) {
-			RenderTileType<TransparencyType::Blended, LightType::FullyLit>(tile, dst, dstPitch, src, mask, tbl, clip);
+			RenderTileType<TransparencyType::Blended, LightType::FullyLit>(tile.type, dst, dstPitch, src, mask, tbl, clip);
 		} else {
-			RenderTileType<TransparencyType::Blended, LightType::PartiallyLit>(tile, dst, dstPitch, src, mask, tbl, clip);
+			RenderTileType<TransparencyType::Blended, LightType::PartiallyLit>(tile.type, dst, dstPitch, src, mask, tbl, clip);
 		}
 	}
 }

--- a/Source/engine/render/dun_render.hpp
+++ b/Source/engine/render/dun_render.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "engine.h"
+#include "levels/gendung.h"
 
 namespace devilution {
 
@@ -14,7 +15,7 @@ namespace devilution {
  * @param out Target buffer
  * @param position Target buffer coordinates
  */
-void RenderTile(const Surface &out, Point position);
+void RenderTile(const Surface &out, Point position, MicroTile tile);
 
 /**
  * @brief Render a black 64x31 tile ◆

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -60,13 +60,6 @@ namespace devilution {
  */
 int LightTableIndex;
 
-/**
- * Specifies the current MIN block of the level CEL file, as used during rendering of the level tiles.
- *
- * frameNum  := block & 0x0FFF
- * frameType := block & 0x7000 >> 12
- */
-uint32_t level_cel_block;
 bool AutoMapShowItems;
 /**
  * Specifies the type of arches to render.
@@ -599,15 +592,15 @@ void DrawCell(const Surface &out, Point tilePosition, Point targetBufferPosition
 	cel_transparency_active = TileHasAny(level_piece_id, TileProperties::Transparent) && TransList[dTransVal[tilePosition.x][tilePosition.y]];
 	cel_foliage_active = !TileHasAny(level_piece_id, TileProperties::Solid);
 	for (int i = 0; i < (MicroTileLen / 2); i++) {
-		level_cel_block = pMap->mt[2 * i];
-		if (level_cel_block != 0) {
+		MicroTile tile = pMap->mt[2 * i];
+		if (tile.id != 0) {
 			arch_draw_type = i == 0 ? 1 : 0;
-			RenderTile(out, targetBufferPosition);
+			RenderTile(out, targetBufferPosition, tile);
 		}
-		level_cel_block = pMap->mt[2 * i + 1];
-		if (level_cel_block != 0) {
+		tile = pMap->mt[2 * i + 1];
+		if (tile.id != 0) {
 			arch_draw_type = i == 0 ? 2 : 0;
-			RenderTile(out, targetBufferPosition + Displacement { TILE_WIDTH / 2, 0 });
+			RenderTile(out, targetBufferPosition + Displacement { TILE_WIDTH / 2, 0 }, tile);
 		}
 		targetBufferPosition.y -= TILE_HEIGHT;
 	}
@@ -625,16 +618,16 @@ void DrawFloor(const Surface &out, Point tilePosition, Point targetBufferPositio
 	cel_transparency_active = false;
 	LightTableIndex = dLight[tilePosition.x][tilePosition.y];
 
-	arch_draw_type = 1; // Left
 	int pn = dPiece[tilePosition.x][tilePosition.y];
-	level_cel_block = DPieceMicros[pn].mt[0];
-	if (level_cel_block != 0) {
-		RenderTile(out, targetBufferPosition);
+	MicroTile tile = DPieceMicros[pn].mt[0];
+	if (tile.id != 0) {
+		arch_draw_type = 1; // Left
+		RenderTile(out, targetBufferPosition, tile);
 	}
-	arch_draw_type = 2; // Right
-	level_cel_block = DPieceMicros[pn].mt[1];
-	if (level_cel_block != 0) {
-		RenderTile(out, targetBufferPosition + Displacement { TILE_WIDTH / 2, 0 });
+	tile = DPieceMicros[pn].mt[1];
+	if (tile.id != 0) {
+		arch_draw_type = 2; // Right
+		RenderTile(out, targetBufferPosition + Displacement { TILE_WIDTH / 2, 0 }, tile);
 	}
 }
 

--- a/Source/engine/render/scrollrt.h
+++ b/Source/engine/render/scrollrt.h
@@ -14,7 +14,6 @@
 namespace devilution {
 
 extern int LightTableIndex;
-extern uint32_t level_cel_block;
 extern char arch_draw_type;
 extern bool cel_transparency_active;
 extern bool cel_foliage_active;

--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -447,25 +447,25 @@ void LoadLevelSOLData()
 
 void SetDungeonMicros()
 {
-	MicroTileLen = 10;
-	size_t blocks = 10;
-
-	if (leveltype == DTYPE_TOWN) {
-		MicroTileLen = 16;
-		blocks = 16;
-	} else if (leveltype == DTYPE_HELL) {
-		MicroTileLen = 12;
-		blocks = 16;
-	}
-
 	size_t tileCount;
 	std::unique_ptr<uint16_t[]> levelPieces = LoadMinData(tileCount);
 
-	for (size_t i = 0; i < tileCount / blocks; i++) {
-		uint16_t *pieces = &levelPieces[blocks * i];
-		for (size_t block = 0; block < blocks; block++) {
-			DPieceMicros[i].mt[block] = SDL_SwapLE16(pieces[blocks - 2 + (block & 1) - (block & 0xE)]);
+	MicroTileLen = 10; // Todo tileCount / sizeof(.sol)
+	if (IsAnyOf(leveltype, DTYPE_TOWN, DTYPE_HELL)) {
+		MicroTileLen = 16;
+	}
+
+	for (size_t i = 0; i < tileCount / MicroTileLen; i++) {
+		uint16_t *pieces = &levelPieces[MicroTileLen * i];
+		for (size_t block = 0; block < MicroTileLen; block++) {
+			uint16_t micro = SDL_SwapLE16(pieces[MicroTileLen - 2 + (block & 1) - (block & 0xE)]);
+			DPieceMicros[i].mt[block].type = static_cast<TileType>((micro & 0x7000) >> 12);
+			DPieceMicros[i].mt[block].id = micro & 0xFFF;
 		}
+	}
+
+	if (leveltype == DTYPE_HELL) {
+		MicroTileLen = 12; // Optimize render performance (no tile uses the full height)
 	}
 }
 

--- a/Source/levels/gendung.h
+++ b/Source/levels/gendung.h
@@ -114,8 +114,79 @@ struct MegaTile {
 	uint16_t micro4;
 };
 
+/**
+ * Tile type.
+ *
+ * The tile type determines data encoding and the shape.
+ *
+ * Each tile type has its own encoding but they all encode data in the order
+ * of bottom-to-top (bottom row first).
+ */
+enum class TileType : uint8_t {
+	/**
+	 * 🮆 A 32x32 square. Stored as an array of pixels.
+	 */
+	Square,
+
+	/**
+	 * 🮆 A 32x32 square with transparency. RLE encoded.
+	 *
+	 * Each run starts with an int8_t value.
+	 * If positive, it is followed by this many pixels.
+	 * If negative, it indicates `-value` fully transparent pixels, which are omitted.
+	 *
+	 * Runs do not cross row boundaries.
+	 */
+	TransparentSquare,
+
+	/**
+	 *🭮 Left-pointing 32x31 triangle. Encoded as 31 varying-width rows with 2 padding bytes before every even row.
+	 *
+	 * The smallest rows (bottom and top) are 2px wide, the largest row is 16px wide (middle row).
+	 *
+	 * Encoding:
+	 * for i in [0, 30]:
+	 * - 2 unused bytes if i is even
+	 * - row (only the pixels within the triangle)
+	 */
+	LeftTriangle,
+
+	/**
+	 * 🭬Right-pointing 32x31 triangle.  Encoded as 31 varying-width rows with 2 padding bytes after every even row.
+	 *
+	 * The smallest rows (bottom and top) are 2px wide, the largest row is 16px wide (middle row).
+	 *
+	 * Encoding:
+	 * for i in [0, 30]:
+	 * - row (only the pixels within the triangle)
+	 * - 2 unused bytes if i is even
+	 */
+	RightTriangle,
+
+	/**
+	 * 🭓 Left-pointing 32x32 trapezoid: a 32x16 rectangle and the 16x16 bottom part of `LeftTriangle`.
+	 *
+	 * Begins with triangle part, which uses the `LeftTriangle` encoding,
+	 * and is followed by a flat array of pixels for the top rectangle part.
+	 */
+	LeftTrapezoid,
+
+	/**
+	 * 🭞 Right-pointing 32x32 trapezoid: 32x16 rectangle and the 16x16 bottom part of `RightTriangle`.
+	 *
+	 * Begins with the triangle part, which uses the `RightTriangle` encoding,
+	 * and is followed by a flat array of pixels for the top rectangle part.
+	 */
+	RightTrapezoid,
+};
+
+struct MicroTile {
+	TileType type;
+	uint16_t id;
+};
+
 struct MICROS {
-	uint16_t mt[16];
+	MicroTile mt[16];
 };
 
 struct ShadowStruct {


### PR DESCRIPTION
I guess this is going to grow the memory usage a bit. But I think it improves readability, and it gets rid of a global.

Let me know if you have some suggestions.

Maybe not hardcode MICROS to 16, or DPieceMicros to MAXTILES?