### PR TITLE
Synchronize ears and gold in player inventories

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -378,10 +378,12 @@ void RemoveGold(Player &player, int goldIndex)
 {
 	int gi = goldIndex - INVITEM_INV_FIRST;
 	player.InvList[gi]._ivalue -= dropGoldValue;
-	if (player.InvList[gi]._ivalue > 0)
+	if (player.InvList[gi]._ivalue > 0) {
 		SetPlrHandGoldCurs(player.InvList[gi]);
-	else
+		NetSyncInvItem(player, gi);
+	} else {
 		player.RemoveInvItem(gi);
+	}
 
 	MakeGoldStack(player.HoldItem, dropGoldValue);
 	NewCursor(player.HoldItem);

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1848,25 +1848,48 @@ int SyncDropItem(Point position, int idx, uint16_t icreateinfo, int iseed, int i
 
 	dItem[position.x][position.y] = ii + 1;
 
-	if (idx == IDI_EAR) {
-		RecreateEar(item, icreateinfo, iseed, id, dur, mdur, ch, mch, ivalue, ibuff);
-	} else {
-		RecreateItem(*MyPlayer, item, idx, icreateinfo, iseed, ivalue, (ibuff & CF_HELLFIRE) != 0);
-		if (id != 0)
-			item._iIdentified = true;
-		item._iDurability = dur;
-		item._iMaxDur = mdur;
-		item._iCharges = ch;
-		item._iMaxCharges = mch;
-		item._iPLToHit = toHit;
-		item._iMaxDam = maxDam;
-		item._iMinStr = minStr;
-		item._iMinMag = minMag;
-		item._iMinDex = minDex;
-		item._iAC = ac;
-		item.dwBuff = ibuff;
-	}
+	RecreateItem(*MyPlayer, item, idx, icreateinfo, iseed, ivalue, (ibuff & CF_HELLFIRE) != 0);
+	if (id != 0)
+		item._iIdentified = true;
+	item._iDurability = dur;
+	item._iMaxDur = mdur;
+	item._iCharges = ch;
+	item._iMaxCharges = mch;
+	item._iPLToHit = toHit;
+	item._iMaxDam = maxDam;
+	item._iMinStr = minStr;
+	item._iMinMag = minMag;
+	item._iMinDex = minDex;
+	item._iAC = ac;
+	item.dwBuff = ibuff;
+	item.position = position;
+	RespawnItem(item, true);
 
+	if (currlevel == 21 && position == CornerStone.position) {
+		CornerStone.item = item;
+		InitQTextMsg(TEXT_CORNSTN);
+		Quests[Q_CORNSTN]._qlog = false;
+		Quests[Q_CORNSTN]._qactive = QUEST_DONE;
+	}
+	return ii;
+}
+
+int SyncPutEar(const Player &player, Point position, uint16_t icreateinfo, int iseed, uint8_t cursval, string_view heroname)
+{
+	std::optional<Point> itemTile = FindAdjacentPositionForItem(player.position.tile, GetDirection(player.position.tile, position));
+	if (!itemTile)
+		return -1;
+
+	return SyncDropEar(*itemTile, icreateinfo, iseed, cursval, heroname);
+}
+
+int SyncDropEar(Point position, uint16_t icreateinfo, int iseed, uint8_t cursval, string_view heroname)
+{
+	int ii = AllocateItem();
+	auto &item = Items[ii];
+
+	dItem[position.x][position.y] = ii + 1;
+	RecreateEar(item, icreateinfo, iseed, cursval, heroname);
 	item.position = position;
 	RespawnItem(item, true);
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1488,8 +1488,9 @@ void CheckInvSwap(Player &player, const Item &item, int invGridIndex)
 		for (int y = 0; y < itemSize.height; y++) {
 			int rowGridIndex = invGridIndex + pitch * y;
 			for (int x = 0; x < itemSize.width; x++) {
-				if (player.InvGrid[rowGridIndex + x] != 0)
-					return abs(player.InvGrid[rowGridIndex]);
+				int gridIndex = rowGridIndex + x;
+				if (player.InvGrid[gridIndex] != 0)
+					return abs(player.InvGrid[gridIndex]);
 			}
 		}
 		player._pNumInv++;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1452,16 +1452,9 @@ bool GoldAutoPlace(Player &player, Item &goldStack)
 	return goldStack._ivalue == 0;
 }
 
-void CheckInvSwap(Player &player, inv_body_loc bLoc, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff)
+void CheckInvSwap(Player &player, inv_body_loc bLoc)
 {
 	Item &item = player.InvBody[bLoc];
-
-	item = {};
-	RecreateItem(player, item, idx, wCI, seed, 0, (dwBuff & CF_HELLFIRE) != 0);
-
-	if (bId) {
-		item._iIdentified = true;
-	}
 
 	if (bLoc == INVLOC_HAND_LEFT && player.GetItemLocation(item) == ILOC_TWOHAND) {
 		player.InvBody[INVLOC_HAND_RIGHT].clear();
@@ -1479,15 +1472,8 @@ void inv_update_rem_item(Player &player, inv_body_loc iv)
 	CalcPlrInv(player, player._pmode != PM_DEATH);
 }
 
-void CheckInvSwap(Player &player, int invGridIndex, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff)
+void CheckInvSwap(Player &player, const Item &item, int invGridIndex)
 {
-	Item item = {};
-	RecreateItem(player, item, idx, wCI, seed, 0, (dwBuff & CF_HELLFIRE) != 0);
-
-	if (bId) {
-		item._iIdentified = true;
-	}
-
 	auto itemSize = GetInventorySize(item);
 
 	const int pitch = 10;
@@ -1533,18 +1519,6 @@ void CheckInvRemove(Player &player, int invGridIndex)
 
 	if (invListIndex >= 0) {
 		player.RemoveInvItem(invListIndex);
-	}
-}
-
-void CheckBeltSwap(Player &player, int beltIndex, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff)
-{
-	Item &item = player.SpdList[beltIndex];
-
-	item = {};
-	RecreateItem(player, item, idx, wCI, seed, 0, (dwBuff & CF_HELLFIRE) != 0);
-
-	if (bId) {
-		item._iIdentified = true;
 	}
 }
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -523,6 +523,9 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 				player._pNumInv++;
 				player.InvGrid[ii] = player._pNumInv;
 			}
+			if (&player == MyPlayer) {
+				NetSendCmdChInvItem(false, ii);
+			}
 		} else {
 			if (it == 0) {
 				player.InvList[player._pNumInv] = player.HoldItem.pop();
@@ -1020,6 +1023,9 @@ int CreateGoldItemInInventorySlot(Player &player, int slotIndex, int value)
 	MakeGoldStack(goldItem, std::min(value, MaxGold));
 	player._pNumInv++;
 	player.InvGrid[slotIndex] = player._pNumInv;
+	if (&player == MyPlayer) {
+		NetSendCmdChInvItem(false, slotIndex);
+	}
 
 	value -= goldItem._ivalue;
 
@@ -1424,6 +1430,7 @@ int AddGoldToInventory(Player &player, int value)
 			value = 0;
 		}
 
+		NetSyncInvItem(player, i);
 		SetPlrHandGoldCurs(goldItem);
 	}
 

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -227,6 +227,8 @@ bool CanPut(Point position);
 int InvPutItem(const Player &player, Point position, const Item &item);
 int SyncPutItem(const Player &player, Point position, int idx, uint16_t icreateinfo, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
 int SyncDropItem(Point position, int idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
+int SyncPutEar(const Player &player, Point position, uint16_t icreateinfo, int iseed, uint8_t cursval, string_view heroname);
+int SyncDropEar(Point position, uint16_t icreateinfo, int iseed, uint8_t cursval, string_view heroname);
 int8_t CheckInvHLight();
 bool CanUseScroll(Player &player, spell_id spell);
 void ConsumeStaffCharge(Player &player);

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -180,11 +180,10 @@ int RoomForGold();
  */
 int AddGoldToInventory(Player &player, int value);
 bool GoldAutoPlace(Player &player, Item &goldStack);
-void CheckInvSwap(Player &player, inv_body_loc bLoc, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff);
+void CheckInvSwap(Player &player, inv_body_loc bLoc);
 void inv_update_rem_item(Player &player, inv_body_loc iv);
-void CheckInvSwap(Player &player, int invGridIndex, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff);
+void CheckInvSwap(Player &player, const Item &item, int invGridIndex);
 void CheckInvRemove(Player &player, int invGridIndex);
-void CheckBeltSwap(Player &player, int beltIndex, int idx, uint16_t wCI, int seed, bool bId, uint32_t dwBuff);
 void TransferItemToStash(Player &player, int location);
 void CheckInvItem(bool isShiftHeld = false, bool isCtrlHeld = false);
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3182,36 +3182,17 @@ void RecreateItem(const Player &player, Item &item, int idx, uint16_t icreateinf
 	gbIsHellfire = tmpIsHellfire;
 }
 
-void RecreateEar(Item &item, uint16_t ic, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, int ibuff)
+void RecreateEar(Item &item, uint16_t ic, int iseed, uint8_t bCursval, string_view heroName)
 {
 	InitializeItem(item, IDI_EAR);
-
-	char heroName[17];
-	heroName[0] = static_cast<char>((ic >> 8) & 0x7F);
-	heroName[1] = static_cast<char>(ic & 0x7F);
-	heroName[2] = static_cast<char>((iseed >> 24) & 0x7F);
-	heroName[3] = static_cast<char>((iseed >> 16) & 0x7F);
-	heroName[4] = static_cast<char>((iseed >> 8) & 0x7F);
-	heroName[5] = static_cast<char>(iseed & 0x7F);
-	heroName[6] = static_cast<char>(id & 0x7F);
-	heroName[7] = static_cast<char>(dur & 0x7F);
-	heroName[8] = static_cast<char>(mdur & 0x7F);
-	heroName[9] = static_cast<char>(ch & 0x7F);
-	heroName[10] = static_cast<char>(mch & 0x7F);
-	heroName[11] = static_cast<char>((ivalue >> 8) & 0x7F);
-	heroName[12] = static_cast<char>((ibuff >> 24) & 0x7F);
-	heroName[13] = static_cast<char>((ibuff >> 16) & 0x7F);
-	heroName[14] = static_cast<char>((ibuff >> 8) & 0x7F);
-	heroName[15] = static_cast<char>(ibuff & 0x7F);
-	heroName[16] = '\0';
 
 	std::string itemName = fmt::format(fmt::runtime(_(/* TRANSLATORS: {:s} will be a Character Name */ "Ear of {:s}")), heroName);
 
 	CopyUtf8(item._iName, itemName, sizeof(item._iName));
 	CopyUtf8(item._iIName, heroName, sizeof(item._iIName));
 
-	item._iCurs = ((ivalue >> 6) & 3) + ICURS_EAR_SORCERER;
-	item._ivalue = ivalue & 0x3F;
+	item._iCurs = ((bCursval >> 6) & 3) + ICURS_EAR_SORCERER;
+	item._ivalue = bCursval & 0x3F;
 	item._iCreateInfo = ic;
 	item._iSeed = iseed;
 }

--- a/Source/items.h
+++ b/Source/items.h
@@ -503,7 +503,7 @@ void CreateRndItem(Point position, bool onlygood, bool sendmsg, bool delta);
 void CreateRndUseful(Point position, bool sendmsg);
 void CreateTypeItem(Point position, bool onlygood, ItemType itemType, int imisc, bool sendmsg, bool delta);
 void RecreateItem(const Player &player, Item &item, int idx, uint16_t icreateinfo, int iseed, int ivalue, bool isHellfire);
-void RecreateEar(Item &item, uint16_t ic, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, int ibuff);
+void RecreateEar(Item &item, uint16_t ic, int iseed, uint8_t bCursval, string_view heroName);
 void CornerstoneSave();
 void CornerstoneLoad(Point position);
 void SpawnQuestItem(int itemid, Point position, int randarea, int selflag);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -845,6 +845,48 @@ bool IsPItemValid(const TCmdPItem &message)
 	return IsItemAvailable(message.def.wIndx);
 }
 
+void RecreateItem(const Player &player, const TItem &messageItem, Item &item)
+{
+	RecreateItem(player, item, messageItem.wIndx, messageItem.wCI, messageItem.dwSeed, messageItem.wValue, (messageItem.dwBuff & CF_HELLFIRE) != 0);
+	if (messageItem.bId != 0)
+		item._iIdentified = true;
+	item._iDurability = messageItem.bDur;
+	item._iMaxDur = messageItem.bMDur;
+	item._iCharges = messageItem.bCh;
+	item._iMaxCharges = messageItem.bMCh;
+	item._iPLToHit = messageItem.wToHit;
+	item._iMaxDam = messageItem.wMaxDam;
+	item._iMinStr = messageItem.bMinStr;
+	item._iMinMag = messageItem.bMinMag;
+	item._iMinDex = messageItem.bMinDex;
+	item._iAC = messageItem.bAC;
+	item.dwBuff = messageItem.dwBuff;
+}
+
+void RecreateItem(const Player &player, const TCmdGItem &message, Item &item)
+{
+	if (message.def.wIndx == IDI_EAR)
+		RecreateEar(item, message.ear.wCI, message.ear.dwSeed, message.ear.bCursval, message.ear.heroname);
+	else
+		RecreateItem(player, message.item, item);
+}
+
+void RecreateItem(const Player &player, const TCmdPItem &message, Item &item)
+{
+	if (message.def.wIndx == IDI_EAR)
+		RecreateEar(item, message.ear.wCI, message.ear.dwSeed, message.ear.bCursval, message.ear.heroname);
+	else
+		RecreateItem(player, message.item, item);
+}
+
+void RecreateItem(const Player &player, const TCmdChItem &message, Item &item)
+{
+	if (message.def.wIndx == IDI_EAR)
+		RecreateEar(item, message.ear.wCI, message.ear.dwSeed, message.ear.bCursval, message.ear.heroname);
+	else
+		RecreateItem(player, message.item, item);
+}
+
 size_t OnRequestGetItem(const TCmd *pCmd, Player &player)
 {
 	const auto &message = *reinterpret_cast<const TCmdGItem *>(pCmd);
@@ -1835,39 +1877,7 @@ size_t OnChangePlayerItems(const TCmd *pCmd, size_t pnum)
 	} else if (&player != MyPlayer && IsItemAvailable(message.def.wIndx)) {
 		Item &item = player.InvBody[message.bLoc];
 		item = {};
-
-		if (message.def.wIndx == IDI_EAR) {
-			RecreateEar(
-			    item,
-			    message.ear.wCI,
-			    message.ear.dwSeed,
-			    message.ear.bCursval,
-			    message.ear.heroname);
-		} else {
-			RecreateItem(
-				player,
-				item,
-				message.item.wIndx,
-				message.item.wCI,
-				message.item.dwSeed,
-				message.item.wValue,
-				(message.item.dwBuff & CF_HELLFIRE) != 0);
-
-			if (message.item.bId != 0)
-				item._iIdentified = true;
-			item._iDurability = message.item.bDur;
-			item._iMaxDur = message.item.bMDur;
-			item._iCharges = message.item.bCh;
-			item._iMaxCharges = message.item.bMCh;
-			item._iPLToHit = message.item.wToHit;
-			item._iMaxDam = message.item.wMaxDam;
-			item._iMinStr = message.item.bMinStr;
-			item._iMinMag = message.item.bMinMag;
-			item._iMinDex = message.item.bMinDex;
-			item._iAC = message.item.bAC;
-			item.dwBuff = message.item.dwBuff;
-		}
-
+		RecreateItem(player, message, item);
 		CheckInvSwap(player, bodyLocation);
 	}
 
@@ -1903,39 +1913,7 @@ size_t OnChangeInventoryItems(const TCmd *pCmd, int pnum)
 		SendPacket(pnum, &message, sizeof(message));
 	} else if (&player != MyPlayer && IsItemAvailable(message.def.wIndx)) {
 		Item item {};
-
-		if (message.def.wIndx == IDI_EAR) {
-			RecreateEar(
-			    item,
-			    message.ear.wCI,
-			    message.ear.dwSeed,
-			    message.ear.bCursval,
-			    message.ear.heroname);
-		} else {
-			RecreateItem(
-			    player,
-			    item,
-			    message.item.wIndx,
-			    message.item.wCI,
-			    message.item.dwSeed,
-			    message.item.wValue,
-			    (message.item.dwBuff & CF_HELLFIRE) != 0);
-
-			if (message.item.bId != 0)
-				item._iIdentified = true;
-			item._iDurability = message.item.bDur;
-			item._iMaxDur = message.item.bMDur;
-			item._iCharges = message.item.bCh;
-			item._iMaxCharges = message.item.bMCh;
-			item._iPLToHit = message.item.wToHit;
-			item._iMaxDam = message.item.wMaxDam;
-			item._iMinStr = message.item.bMinStr;
-			item._iMinMag = message.item.bMinMag;
-			item._iMinDex = message.item.bMinDex;
-			item._iAC = message.item.bAC;
-			item.dwBuff = message.item.dwBuff;
-		}
-
+		RecreateItem(player, message, item);
 		CheckInvSwap(player, item, message.bLoc);
 	}
 
@@ -1969,38 +1947,7 @@ size_t OnChangeBeltItems(const TCmd *pCmd, int pnum)
 	} else if (&player != MyPlayer && IsItemAvailable(message.def.wIndx)) {
 		Item &item = player.SpdList[message.bLoc];
 		item = {};
-
-		if (message.def.wIndx == IDI_EAR) {
-			RecreateEar(
-			    item,
-			    message.ear.wCI,
-			    message.ear.dwSeed,
-			    message.ear.bCursval,
-			    message.ear.heroname);
-		} else {
-			RecreateItem(
-			    player,
-			    item,
-			    message.item.wIndx,
-			    message.item.wCI,
-			    message.item.dwSeed,
-			    message.item.wValue,
-			    (message.item.dwBuff & CF_HELLFIRE) != 0);
-
-			if (message.item.bId != 0)
-				item._iIdentified = true;
-			item._iDurability = message.item.bDur;
-			item._iMaxDur = message.item.bMDur;
-			item._iCharges = message.item.bCh;
-			item._iMaxCharges = message.item.bMCh;
-			item._iPLToHit = message.item.wToHit;
-			item._iMaxDam = message.item.wMaxDam;
-			item._iMinStr = message.item.bMinStr;
-			item._iMinMag = message.item.bMinMag;
-			item._iMinDex = message.item.bMinDex;
-			item._iAC = message.item.bAC;
-			item.dwBuff = message.item.dwBuff;
-		}
+		RecreateItem(player, message, item);
 	}
 
 	return sizeof(message);
@@ -2791,37 +2738,8 @@ void DeltaLoadLevel()
 		if (deltaLevel.item[i].bCmd == TCmdPItem::DroppedItem) {
 			int ii = AllocateItem();
 			auto &item = Items[ii];
+			RecreateItem(*MyPlayer, deltaLevel.item[i], item);
 
-			if (deltaLevel.item[i].def.wIndx == IDI_EAR) {
-				RecreateEar(
-				    item,
-				    deltaLevel.item[i].ear.wCI,
-				    deltaLevel.item[i].ear.dwSeed,
-				    deltaLevel.item[i].ear.bCursval,
-				    deltaLevel.item[i].ear.heroname);
-			} else {
-				RecreateItem(
-				    *MyPlayer,
-				    item,
-				    deltaLevel.item[i].item.wIndx,
-				    deltaLevel.item[i].item.wCI,
-				    deltaLevel.item[i].item.dwSeed,
-				    deltaLevel.item[i].item.wValue,
-				    (deltaLevel.item[i].item.dwBuff & CF_HELLFIRE) != 0);
-				if (deltaLevel.item[i].item.bId != 0)
-					item._iIdentified = true;
-				item._iDurability = deltaLevel.item[i].item.bDur;
-				item._iMaxDur = deltaLevel.item[i].item.bMDur;
-				item._iCharges = deltaLevel.item[i].item.bCh;
-				item._iMaxCharges = deltaLevel.item[i].item.bMCh;
-				item._iPLToHit = deltaLevel.item[i].item.wToHit;
-				item._iMaxDam = deltaLevel.item[i].item.wMaxDam;
-				item._iMinStr = deltaLevel.item[i].item.bMinStr;
-				item._iMinMag = deltaLevel.item[i].item.bMinMag;
-				item._iMinDex = deltaLevel.item[i].item.bMinDex;
-				item._iAC = deltaLevel.item[i].item.bAC;
-				item.dwBuff = deltaLevel.item[i].item.dwBuff;
-			}
 			int x = deltaLevel.item[i].x;
 			int y = deltaLevel.item[i].y;
 			item.position = GetItemPosition({ x, y });

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -3118,6 +3118,19 @@ void NetSendCmdDelItem(bool bHiPri, uint8_t bLoc)
 		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
 }
 
+void NetSyncInvItem(const Player &player, int invListIndex)
+{
+	if (&player != MyPlayer)
+		return;
+
+	for (int j = 0; j < InventoryGridCells; j++) {
+		if (player.InvGrid[j] == invListIndex + 1) {
+			NetSendCmdChInvItem(false, j);
+			break;
+		}
+	}
+}
+
 void NetSendCmdChInvItem(bool bHiPri, int invGridIndex)
 {
 	TCmdChItem cmd {};

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1832,8 +1832,43 @@ size_t OnChangePlayerItems(const TCmd *pCmd, size_t pnum)
 
 	if (gbBufferMsgs == 1) {
 		SendPacket(pnum, &message, sizeof(message));
-	} else if (&player != MyPlayer && message.wIndx <= IDI_LAST) {
-		CheckInvSwap(player, bodyLocation, message.wIndx, message.wCI, message.dwSeed, message.bId != 0, message.dwBuff);
+	} else if (&player != MyPlayer && IsItemAvailable(message.def.wIndx)) {
+		Item &item = player.InvBody[message.bLoc];
+		item = {};
+
+		if (message.def.wIndx == IDI_EAR) {
+			RecreateEar(
+			    item,
+			    message.ear.wCI,
+			    message.ear.dwSeed,
+			    message.ear.bCursval,
+			    message.ear.heroname);
+		} else {
+			RecreateItem(
+				player,
+				item,
+				message.item.wIndx,
+				message.item.wCI,
+				message.item.dwSeed,
+				message.item.wValue,
+				(message.item.dwBuff & CF_HELLFIRE) != 0);
+
+			if (message.item.bId != 0)
+				item._iIdentified = true;
+			item._iDurability = message.item.bDur;
+			item._iMaxDur = message.item.bMDur;
+			item._iCharges = message.item.bCh;
+			item._iMaxCharges = message.item.bMCh;
+			item._iPLToHit = message.item.wToHit;
+			item._iMaxDam = message.item.wMaxDam;
+			item._iMinStr = message.item.bMinStr;
+			item._iMinMag = message.item.bMinMag;
+			item._iMinDex = message.item.bMinDex;
+			item._iAC = message.item.bAC;
+			item.dwBuff = message.item.dwBuff;
+		}
+
+		CheckInvSwap(player, bodyLocation);
 	}
 
 	player.ReadySpellFromEquipment(bodyLocation);
@@ -1861,10 +1896,47 @@ size_t OnChangeInventoryItems(const TCmd *pCmd, int pnum)
 	const auto &message = *reinterpret_cast<const TCmdChItem *>(pCmd);
 	Player &player = Players[pnum];
 
+	if (message.bLoc >= InventoryGridCells)
+		return sizeof(message);
+
 	if (gbBufferMsgs == 1) {
 		SendPacket(pnum, &message, sizeof(message));
-	} else if (&player != MyPlayer && message.bLoc < InventoryGridCells && message.wIndx <= IDI_LAST) {
-		CheckInvSwap(player, message.bLoc, message.wIndx, message.wCI, message.dwSeed, message.bId != 0, message.dwBuff);
+	} else if (&player != MyPlayer && IsItemAvailable(message.def.wIndx)) {
+		Item item {};
+
+		if (message.def.wIndx == IDI_EAR) {
+			RecreateEar(
+			    item,
+			    message.ear.wCI,
+			    message.ear.dwSeed,
+			    message.ear.bCursval,
+			    message.ear.heroname);
+		} else {
+			RecreateItem(
+			    player,
+			    item,
+			    message.item.wIndx,
+			    message.item.wCI,
+			    message.item.dwSeed,
+			    message.item.wValue,
+			    (message.item.dwBuff & CF_HELLFIRE) != 0);
+
+			if (message.item.bId != 0)
+				item._iIdentified = true;
+			item._iDurability = message.item.bDur;
+			item._iMaxDur = message.item.bMDur;
+			item._iCharges = message.item.bCh;
+			item._iMaxCharges = message.item.bMCh;
+			item._iPLToHit = message.item.wToHit;
+			item._iMaxDam = message.item.wMaxDam;
+			item._iMinStr = message.item.bMinStr;
+			item._iMinMag = message.item.bMinMag;
+			item._iMinDex = message.item.bMinDex;
+			item._iAC = message.item.bAC;
+			item.dwBuff = message.item.dwBuff;
+		}
+
+		CheckInvSwap(player, item, message.bLoc);
 	}
 
 	return sizeof(message);
@@ -1889,10 +1961,46 @@ size_t OnChangeBeltItems(const TCmd *pCmd, int pnum)
 	const auto &message = *reinterpret_cast<const TCmdChItem *>(pCmd);
 	Player &player = Players[pnum];
 
+	if (message.bLoc >= MaxBeltItems)
+		return sizeof(message);
+
 	if (gbBufferMsgs == 1) {
 		SendPacket(pnum, &message, sizeof(message));
-	} else if (&player != MyPlayer && message.bLoc < MaxBeltItems && message.wIndx <= IDI_LAST) {
-		CheckBeltSwap(player, message.bLoc, message.wIndx, message.wCI, message.dwSeed, message.bId != 0, message.dwBuff);
+	} else if (&player != MyPlayer && IsItemAvailable(message.def.wIndx)) {
+		Item &item = player.SpdList[message.bLoc];
+		item = {};
+
+		if (message.def.wIndx == IDI_EAR) {
+			RecreateEar(
+			    item,
+			    message.ear.wCI,
+			    message.ear.dwSeed,
+			    message.ear.bCursval,
+			    message.ear.heroname);
+		} else {
+			RecreateItem(
+			    player,
+			    item,
+			    message.item.wIndx,
+			    message.item.wCI,
+			    message.item.dwSeed,
+			    message.item.wValue,
+			    (message.item.dwBuff & CF_HELLFIRE) != 0);
+
+			if (message.item.bId != 0)
+				item._iIdentified = true;
+			item._iDurability = message.item.bDur;
+			item._iMaxDur = message.item.bMDur;
+			item._iCharges = message.item.bCh;
+			item._iMaxCharges = message.item.bMCh;
+			item._iPLToHit = message.item.wToHit;
+			item._iMaxDam = message.item.wMaxDam;
+			item._iMinStr = message.item.bMinStr;
+			item._iMinMag = message.item.bMinMag;
+			item._iMinDex = message.item.bMinDex;
+			item._iAC = message.item.bAC;
+			item.dwBuff = message.item.dwBuff;
+		}
 	}
 
 	return sizeof(message);
@@ -3045,17 +3153,34 @@ void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position, const Item &item
 
 void NetSendCmdChItem(bool bHiPri, uint8_t bLoc)
 {
-	TCmdChItem cmd;
+	TCmdChItem cmd {};
 
 	Item &item = MyPlayer->InvBody[bLoc];
 
 	cmd.bCmd = CMD_CHANGEPLRITEMS;
 	cmd.bLoc = bLoc;
-	cmd.wIndx = item.IDidx;
-	cmd.wCI = item._iCreateInfo;
-	cmd.dwSeed = item._iSeed;
-	cmd.bId = item._iIdentified ? 1 : 0;
-	cmd.dwBuff = item.dwBuff;
+	cmd.def.wIndx = item.IDidx;
+	cmd.def.wCI = item._iCreateInfo;
+	cmd.def.dwSeed = item._iSeed;
+
+	if (item.IDidx == IDI_EAR) {
+		cmd.ear.bCursval = item._ivalue | ((item._iCurs - ICURS_EAR_SORCERER) << 6);
+		CopyUtf8(cmd.ear.heroname, item._iIName, sizeof(cmd.ear.heroname));
+	} else {
+		cmd.item.bId = item._iIdentified ? 1 : 0;
+		cmd.item.bDur = item._iDurability;
+		cmd.item.bMDur = item._iMaxDur;
+		cmd.item.bCh = item._iCharges;
+		cmd.item.bMCh = item._iMaxCharges;
+		cmd.item.wValue = item._ivalue;
+		cmd.item.wToHit = item._iPLToHit;
+		cmd.item.wMaxDam = item._iMaxDam;
+		cmd.item.bMinStr = item._iMinStr;
+		cmd.item.bMinMag = item._iMinMag;
+		cmd.item.bMinDex = item._iMinDex;
+		cmd.item.bAC = item._iAC;
+		cmd.item.dwBuff = item.dwBuff;
+	}
 
 	if (bHiPri)
 		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
@@ -3077,18 +3202,35 @@ void NetSendCmdDelItem(bool bHiPri, uint8_t bLoc)
 
 void NetSendCmdChInvItem(bool bHiPri, int invGridIndex)
 {
-	TCmdChItem cmd;
+	TCmdChItem cmd {};
 
 	int8_t invListIndex = abs(MyPlayer->InvGrid[invGridIndex]) - 1;
 	const Item &item = MyPlayer->InvList[invListIndex];
 
 	cmd.bCmd = CMD_CHANGEINVITEMS;
 	cmd.bLoc = invGridIndex;
-	cmd.wIndx = item.IDidx;
-	cmd.wCI = item._iCreateInfo;
-	cmd.dwSeed = item._iSeed;
-	cmd.bId = item._iIdentified ? 1 : 0;
-	cmd.dwBuff = item.dwBuff;
+	cmd.def.wIndx = item.IDidx;
+	cmd.def.wCI = item._iCreateInfo;
+	cmd.def.dwSeed = item._iSeed;
+
+	if (item.IDidx == IDI_EAR) {
+		cmd.ear.bCursval = item._ivalue | ((item._iCurs - ICURS_EAR_SORCERER) << 6);
+		CopyUtf8(cmd.ear.heroname, item._iIName, sizeof(cmd.ear.heroname));
+	} else {
+		cmd.item.bId = item._iIdentified ? 1 : 0;
+		cmd.item.bDur = item._iDurability;
+		cmd.item.bMDur = item._iMaxDur;
+		cmd.item.bCh = item._iCharges;
+		cmd.item.bMCh = item._iMaxCharges;
+		cmd.item.wValue = item._ivalue;
+		cmd.item.wToHit = item._iPLToHit;
+		cmd.item.wMaxDam = item._iMaxDam;
+		cmd.item.bMinStr = item._iMinStr;
+		cmd.item.bMinMag = item._iMinMag;
+		cmd.item.bMinDex = item._iMinDex;
+		cmd.item.bAC = item._iAC;
+		cmd.item.dwBuff = item.dwBuff;
+	}
 
 	if (bHiPri)
 		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
@@ -3098,17 +3240,34 @@ void NetSendCmdChInvItem(bool bHiPri, int invGridIndex)
 
 void NetSendCmdChBeltItem(bool bHiPri, int beltIndex)
 {
-	TCmdChItem cmd;
+	TCmdChItem cmd {};
 
 	const Item &item = MyPlayer->SpdList[beltIndex];
 
 	cmd.bCmd = CMD_CHANGEBELTITEMS;
 	cmd.bLoc = beltIndex;
-	cmd.wIndx = item.IDidx;
-	cmd.wCI = item._iCreateInfo;
-	cmd.dwSeed = item._iSeed;
-	cmd.bId = item._iIdentified ? 1 : 0;
-	cmd.dwBuff = item.dwBuff;
+	cmd.def.wIndx = item.IDidx;
+	cmd.def.wCI = item._iCreateInfo;
+	cmd.def.dwSeed = item._iSeed;
+
+	if (item.IDidx == IDI_EAR) {
+		cmd.ear.bCursval = item._ivalue | ((item._iCurs - ICURS_EAR_SORCERER) << 6);
+		CopyUtf8(cmd.ear.heroname, item._iIName, sizeof(cmd.ear.heroname));
+	} else {
+		cmd.item.bId = item._iIdentified ? 1 : 0;
+		cmd.item.bDur = item._iDurability;
+		cmd.item.bMDur = item._iMaxDur;
+		cmd.item.bCh = item._iCharges;
+		cmd.item.bMCh = item._iMaxCharges;
+		cmd.item.wValue = item._ivalue;
+		cmd.item.wToHit = item._iPLToHit;
+		cmd.item.wMaxDam = item._iMaxDam;
+		cmd.item.bMinStr = item._iMinStr;
+		cmd.item.bMinMag = item._iMinMag;
+		cmd.item.bMinDex = item._iMinDex;
+		cmd.item.bAC = item._iAC;
+		cmd.item.dwBuff = item.dwBuff;
+	}
 
 	if (bHiPri)
 		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -599,28 +599,33 @@ bool DeltaGetItem(const TCmdGItem &message, uint8_t bLevel)
 	if ((message.def.wCI & CF_PREGEN) == 0)
 		return false;
 
-	for (TCmdPItem &item : deltaLevel.item) {
-		if (item.bCmd == CMD_INVALID) {
+	for (TCmdPItem &delta : deltaLevel.item) {
+		if (delta.bCmd == CMD_INVALID) {
 			sgbDeltaChanged = true;
-			item.bCmd = TCmdPItem::PickedUpItem;
-			item.x = message.x;
-			item.y = message.y;
-			item.item.wIndx = message.item.wIndx;
-			item.item.wCI = message.item.wCI;
-			item.item.dwSeed = message.item.dwSeed;
-			item.item.bId = message.item.bId;
-			item.item.bDur = message.item.bDur;
-			item.item.bMDur = message.item.bMDur;
-			item.item.bCh = message.item.bCh;
-			item.item.bMCh = message.item.bMCh;
-			item.item.wValue = message.item.wValue;
-			item.item.dwBuff = message.item.dwBuff;
-			item.item.wToHit = message.item.wToHit;
-			item.item.wMaxDam = message.item.wMaxDam;
-			item.item.bMinStr = message.item.bMinStr;
-			item.item.bMinMag = message.item.bMinMag;
-			item.item.bMinDex = message.item.bMinDex;
-			item.item.bAC = message.item.bAC;
+			delta.bCmd = TCmdPItem::PickedUpItem;
+			delta.x = message.x;
+			delta.y = message.y;
+			delta.def.wIndx = message.def.wIndx;
+			delta.def.wCI = message.def.wCI;
+			delta.def.dwSeed = message.def.dwSeed;
+			if (message.def.wIndx == IDI_EAR) {
+				delta.ear.bCursval = message.ear.bCursval;
+				CopyUtf8(delta.ear.heroname, message.ear.heroname, sizeof(delta.ear.heroname));
+			} else {
+				delta.item.bId = message.item.bId;
+				delta.item.bDur = message.item.bDur;
+				delta.item.bMDur = message.item.bMDur;
+				delta.item.bCh = message.item.bCh;
+				delta.item.bMCh = message.item.bMCh;
+				delta.item.wValue = message.item.wValue;
+				delta.item.dwBuff = message.item.dwBuff;
+				delta.item.wToHit = message.item.wToHit;
+				delta.item.wMaxDam = message.item.wMaxDam;
+				delta.item.bMinStr = message.item.bMinStr;
+				delta.item.bMinMag = message.item.bMinMag;
+				delta.item.bMinDex = message.item.bMinDex;
+				delta.item.bAC = message.item.bAC;
+			}
 			break;
 		}
 	}
@@ -2635,30 +2640,15 @@ void DeltaAddItem(int ii)
 		}
 	}
 
-	for (TCmdPItem &item : deltaLevel.item) {
-		if (item.bCmd != CMD_INVALID)
+	for (TCmdPItem &delta : deltaLevel.item) {
+		if (delta.bCmd != CMD_INVALID)
 			continue;
 
 		sgbDeltaChanged = true;
-		item.bCmd = TCmdPItem::FloorItem;
-		item.x = Items[ii].position.x;
-		item.y = Items[ii].position.y;
-		item.item.wIndx = Items[ii].IDidx;
-		item.item.wCI = Items[ii]._iCreateInfo;
-		item.item.dwSeed = Items[ii]._iSeed;
-		item.item.bId = Items[ii]._iIdentified ? 1 : 0;
-		item.item.bDur = Items[ii]._iDurability;
-		item.item.bMDur = Items[ii]._iMaxDur;
-		item.item.bCh = Items[ii]._iCharges;
-		item.item.bMCh = Items[ii]._iMaxCharges;
-		item.item.wValue = Items[ii]._ivalue;
-		item.item.wToHit = Items[ii]._iPLToHit;
-		item.item.wMaxDam = Items[ii]._iMaxDam;
-		item.item.bMinStr = Items[ii]._iMinStr;
-		item.item.bMinMag = Items[ii]._iMinMag;
-		item.item.bMinDex = Items[ii]._iMinDex;
-		item.item.bAC = Items[ii]._iAC;
-		item.item.dwBuff = Items[ii].dwBuff;
+		delta.bCmd = TCmdPItem::FloorItem;
+		delta.x = Items[ii].position.x;
+		delta.y = Items[ii].position.y;
+		PrepareItemForNetwork(Items[ii], delta);
 		return;
 	}
 }

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -768,6 +768,7 @@ void NetSendCmdParam4(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wPar
 void NetSendCmdQuest(bool bHiPri, const Quest &quest);
 void NetSendCmdGItem(bool bHiPri, _cmd_id bCmd, uint8_t pnum, uint8_t ii);
 void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position, const Item &item);
+void NetSyncInvItem(const Player &player, int invListIndex);
 void NetSendCmdChItem(bool bHiPri, uint8_t bLoc);
 void NetSendCmdDelItem(bool bHiPri, uint8_t bLoc);
 void NetSendCmdChInvItem(bool bHiPri, int invGridIndex);

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -626,11 +626,12 @@ struct TCmdPItem {
 struct TCmdChItem {
 	_cmd_id bCmd;
 	uint8_t bLoc;
-	uint16_t wIndx;
-	uint16_t wCI;
-	int32_t dwSeed;
-	uint8_t bId;
-	uint32_t dwBuff;
+
+	union {
+		TItemDef def;
+		TItem item;
+		TEar ear;
+	};
 };
 
 struct TCmdDelItem {

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -539,17 +539,13 @@ struct TCmdQuest {
 	uint8_t qvar1;
 };
 
-/**
- * Represents an item being picked up from the ground
- */
-struct TCmdGItem {
-	_cmd_id bCmd;
-	uint8_t bMaster;
-	uint8_t bPnum;
-	uint8_t bCursitem;
-	uint8_t bLevel;
-	uint8_t x;
-	uint8_t y;
+struct TItemDef {
+	_item_indexes wIndx;
+	uint16_t wCI;
+	int32_t dwSeed;
+};
+
+struct TItem {
 	_item_indexes wIndx;
 	uint16_t wCI;
 	int32_t dwSeed;
@@ -560,13 +556,41 @@ struct TCmdGItem {
 	uint8_t bMCh;
 	uint16_t wValue;
 	uint32_t dwBuff;
-	int32_t dwTime;
 	uint16_t wToHit;
 	uint16_t wMaxDam;
 	uint8_t bMinStr;
 	uint8_t bMinMag;
 	uint8_t bMinDex;
 	int16_t bAC;
+};
+
+struct TEar {
+	_item_indexes wIndx;
+	uint16_t wCI;
+	int32_t dwSeed;
+	uint8_t bCursval;
+	char heroname[17];
+};
+
+/**
+ * Represents an item being picked up from the ground
+ */
+struct TCmdGItem {
+	_cmd_id bCmd;
+	uint8_t x;
+	uint8_t y;
+
+	union {
+		TItemDef def;
+		TItem item;
+		TEar ear;
+	};
+
+	uint8_t bMaster;
+	uint8_t bPnum;
+	uint8_t bCursitem;
+	uint8_t bLevel;
+	int32_t dwTime;
 };
 
 /**
@@ -576,26 +600,12 @@ struct TCmdPItem {
 	_cmd_id bCmd;
 	uint8_t x;
 	uint8_t y;
-	_item_indexes wIndx;
-	uint16_t wCI;
-	/**
-	 * Item identifier
-	 * @see Item::_iSeed
-	 */
-	int32_t dwSeed;
-	uint8_t bId;
-	uint8_t bDur;
-	uint8_t bMDur;
-	uint8_t bCh;
-	uint8_t bMCh;
-	uint16_t wValue;
-	uint32_t dwBuff;
-	uint16_t wToHit;
-	uint16_t wMaxDam;
-	uint8_t bMinStr;
-	uint8_t bMinMag;
-	uint8_t bMinDex;
-	int16_t bAC;
+
+	union {
+		TItemDef def;
+		TItem item;
+		TEar ear;
+	};
 
 	/**
 	 * Items placed during dungeon generation

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -159,17 +159,31 @@ void UnPackItem(const ItemPack &packedItem, const Player &player, Item &item, bo
 	}
 
 	if (idx == IDI_EAR) {
-		RecreateEar(
-		    item,
-		    SDL_SwapLE16(packedItem.iCreateInfo),
-		    SDL_SwapLE32(packedItem.iSeed),
-		    packedItem.bId,
-		    packedItem.bDur,
-		    packedItem.bMDur,
-		    packedItem.bCh,
-		    packedItem.bMCh,
-		    SDL_SwapLE16(packedItem.wValue),
-		    SDL_SwapLE32(packedItem.dwBuff));
+		uint16_t ic = SDL_SwapLE16(packedItem.iCreateInfo);
+		uint32_t iseed = SDL_SwapLE32(packedItem.iSeed);
+		uint16_t ivalue = SDL_SwapLE16(packedItem.wValue);
+		int32_t ibuff = SDL_SwapLE32(packedItem.dwBuff);
+
+		char heroName[17];
+		heroName[0] = static_cast<char>((ic >> 8) & 0x7F);
+		heroName[1] = static_cast<char>(ic & 0x7F);
+		heroName[2] = static_cast<char>((iseed >> 24) & 0x7F);
+		heroName[3] = static_cast<char>((iseed >> 16) & 0x7F);
+		heroName[4] = static_cast<char>((iseed >> 8) & 0x7F);
+		heroName[5] = static_cast<char>(iseed & 0x7F);
+		heroName[6] = static_cast<char>(packedItem.bId & 0x7F);
+		heroName[7] = static_cast<char>(packedItem.bDur & 0x7F);
+		heroName[8] = static_cast<char>(packedItem.bMDur & 0x7F);
+		heroName[9] = static_cast<char>(packedItem.bCh & 0x7F);
+		heroName[10] = static_cast<char>(packedItem.bMCh & 0x7F);
+		heroName[11] = static_cast<char>((ivalue >> 8) & 0x7F);
+		heroName[12] = static_cast<char>((ibuff >> 24) & 0x7F);
+		heroName[13] = static_cast<char>((ibuff >> 16) & 0x7F);
+		heroName[14] = static_cast<char>((ibuff >> 8) & 0x7F);
+		heroName[15] = static_cast<char>(ibuff & 0x7F);
+		heroName[16] = '\0';
+
+		RecreateEar(item, ic, iseed, ivalue & 0xFF, heroName);
 	} else {
 		item = {};
 		RecreateItem(player, item, idx, SDL_SwapLE16(packedItem.iCreateInfo), SDL_SwapLE32(packedItem.iSeed), SDL_SwapLE16(packedItem.wValue), isHellfire);

--- a/test/inv_test.cpp
+++ b/test/inv_test.cpp
@@ -125,6 +125,8 @@ TEST_F(InvTest, CalculateGold)
 // Test automatic gold placing
 TEST_F(InvTest, GoldAutoPlace)
 {
+	SNetInitializeProvider(SELCONN_LOOPBACK, nullptr);
+
 	// Empty the inventory
 	clear_inventory();
 


### PR DESCRIPTION
Continuation of #5217

* Introduce a struct to differentiate ears from other items in the network code
* Expand `TCmdChItem` to include the same level of item information as `TCmdGItem` and `TCmdPItem`
* Send network messages when adding gold to and removing gold from the player's inventory
* Fix an error that used the wrong inventory grid index when a remote player swaps items

While testing, I noticed that moving ears around in a player's inventory will cause remote clients to crash due to the inventory synchronization. This PR should fix that as well.