### PR TITLE
Fix skipping intro using gamepad

### DIFF
--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -103,10 +103,6 @@ bool HandleStartAndSelect(const ControllerButtonEvent &ctrlEvent, GameAction *ac
 
 bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, GameAction *action)
 {
-	if (MyPlayer == nullptr) {
-		return false;
-	}
-
 	const bool inGameMenu = InGameMenu();
 
 #ifndef USE_SDL1

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -63,7 +63,7 @@ bool InGameMenu()
 	    || qtextflag
 	    || gmenu_is_active()
 	    || PauseMode == 2
-	    || (MyPlayer->_pInvincible && MyPlayer->_pHitPoints == 0);
+	    || (MyPlayer != nullptr && MyPlayer->_pInvincible && MyPlayer->_pHitPoints == 0);
 }
 
 namespace {


### PR DESCRIPTION
It is currently not possible to skip the logo or intro videos using the gamepad because `MyPlayer == nullptr` until you enter the `Single Player` or `Multi Player` menus. The issue was introduced by 188dc79f6e19645b282567612c6166eb63662b27 due to changes in `MyPlayer` initialization.

It seems like `InGameMenu()` is the only function making use of `MyPlayer` in the input event handler. I tried to test all the button combinations to make sure nothing crashes so I'm pretty confident.