### PR TITLE
Fix warp position offset and leorics lair spawn position

### DIFF
--- a/Source/levels/setmaps.cpp
+++ b/Source/levels/setmaps.cpp
@@ -75,7 +75,7 @@ void LoadSetMap()
 			Quests[Q_SKELKING]._qvar1 = 1;
 		}
 		LoadPreL1Dungeon("levels\\l1data\\sklkng1.dun");
-		LoadL1Dungeon("levels\\l1data\\sklkng2.dun", { 83, 45 });
+		LoadL1Dungeon("levels\\l1data\\sklkng2.dun", { 83, 44 });
 		SetMapTransparency("levels\\l1data\\sklkngt.dun");
 		LoadPalette("levels\\l1data\\l1_2.pal");
 		AddSKingObjs();

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1394,7 +1394,7 @@ void AddWarp(Missile &missile, const AddMissileParameter & /*parameter*/)
 		TriggerStruct *trg = &trigs[i];
 		if (IsAnyOf(trg->_tmsg, WM_DIABTWARPUP, WM_DIABPREVLVL, WM_DIABNEXTLVL, WM_DIABRTNLVL)) {
 			Point candidate = trg->position;
-			if (IsAnyOf(leveltype, DTYPE_CATHEDRAL, DTYPE_CATACOMBS) && IsAnyOf(trg->_tmsg, WM_DIABNEXTLVL, WM_DIABPREVLVL, WM_DIABRTNLVL)) {
+			if (IsAnyOf(leveltype, DTYPE_CATHEDRAL, DTYPE_CATACOMBS, DTYPE_CRYPT) && IsAnyOf(trg->_tmsg, WM_DIABNEXTLVL, WM_DIABPREVLVL, WM_DIABRTNLVL)) {
 				candidate += Displacement { 0, 1 };
 			} else {
 				candidate += Displacement { 1, 0 };

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1394,7 +1394,9 @@ void AddWarp(Missile &missile, const AddMissileParameter & /*parameter*/)
 		TriggerStruct *trg = &trigs[i];
 		if (IsAnyOf(trg->_tmsg, WM_DIABTWARPUP, WM_DIABPREVLVL, WM_DIABNEXTLVL, WM_DIABRTNLVL)) {
 			Point candidate = trg->position;
-			if (IsAnyOf(leveltype, DTYPE_CATHEDRAL, DTYPE_CATACOMBS, DTYPE_CRYPT) && IsAnyOf(trg->_tmsg, WM_DIABNEXTLVL, WM_DIABPREVLVL, WM_DIABRTNLVL)) {
+			if (leveltype == DTYPE_CATHEDRAL && IsAnyOf(trg->_tmsg, WM_DIABPREVLVL, WM_DIABRTNLVL)) {
+				candidate += Displacement { 1, 2 };
+			} else if (IsAnyOf(leveltype, DTYPE_CATHEDRAL, DTYPE_CATACOMBS, DTYPE_CRYPT) && IsAnyOf(trg->_tmsg, WM_DIABNEXTLVL, WM_DIABPREVLVL, WM_DIABRTNLVL)) {
 				candidate += Displacement { 0, 1 };
 			} else {
 				candidate += Displacement { 1, 0 };

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1392,9 +1392,9 @@ void AddWarp(Missile &missile, const AddMissileParameter & /*parameter*/)
 
 	for (int i = 0; i < numtrigs && i < MAXTRIGGERS; i++) {
 		TriggerStruct *trg = &trigs[i];
-		if (trg->_tmsg == WM_DIABTWARPUP || trg->_tmsg == WM_DIABPREVLVL || trg->_tmsg == WM_DIABNEXTLVL || trg->_tmsg == WM_DIABRTNLVL) {
+		if (IsAnyOf(trg->_tmsg, WM_DIABTWARPUP, WM_DIABPREVLVL, WM_DIABNEXTLVL, WM_DIABRTNLVL)) {
 			Point candidate = trg->position;
-			if ((leveltype == DTYPE_CATHEDRAL || leveltype == DTYPE_CATACOMBS) && (trg->_tmsg == WM_DIABNEXTLVL || trg->_tmsg == WM_DIABPREVLVL || trg->_tmsg == WM_DIABRTNLVL)) {
+			if (IsAnyOf(leveltype, DTYPE_CATHEDRAL, DTYPE_CATACOMBS) && IsAnyOf(trg->_tmsg, WM_DIABNEXTLVL, WM_DIABPREVLVL, WM_DIABRTNLVL)) {
 				candidate += Displacement { 0, 1 };
 			} else {
 				candidate += Displacement { 1, 0 };


### PR DESCRIPTION
Fixes #5185

I also changed skeleton kings lair's players spawn position to match the position of normal cathedral stairs.
That way it's consistent with normal cathedral and no special in `AddWarp` is needed. 😁 