### PR TITLE
Fix error mapping keys when typing lowercase characters

### DIFF
--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -318,10 +318,10 @@ void UiSettingsMenu()
 				case SDL_KEYDOWN: {
 					SDL_Keycode keycode = event.key.keysym.sym;
 					remap_keyboard_key(&keycode);
+					key = static_cast<uint32_t>(keycode);
 					if (key >= SDLK_a && key <= SDLK_z) {
 						key -= 'a' - 'A';
 					}
-					key = static_cast<uint32_t>(keycode);
 				} break;
 				case SDL_MOUSEBUTTONDOWN:
 					switch (event.button.button) {


### PR DESCRIPTION
Fixes an error where key bindings would not be assigned when typing a letter key unless the player entered an uppercase character.

Introduced in #5018