### PR TITLE
Spellbook text revision

### DIFF
--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -132,19 +132,15 @@ void DrawSpellBook(const Surface &out)
 
 	int yp = 12;
 	const int textPaddingTop = 7;
-
 	for (int i = 1; i < 8; i++) {
-<<<<<<< HEAD
 		SpellID sn = SpellPages[sbooktab][i - 1];
-=======
-		spell_id sn = SpellPages[sbooktab][i - 1];
 
 >>>>>>> d87240e2d (Revise Spell Book Colors and Text)
 		if (IsValidSpell(sn) && (spl & GetSpellBitmask(sn)) != 0) {
 			SpellType st = GetSBookTrans(sn, true);
 			SetSpellTrans(st);
 			const Point spellCellPosition = GetPanelPosition(UiPanels::Spell, { 11, yp + SpellBookDescription.height });
-			DrawSpellCel(out, spellCellPosition, *pSBkIconCels, SpellITbl[sn]);
+			DrawSmallSpellIcon(out, spellCellPosition, sn);
 
 			bool isSkill = false;
 			bool isStaff = false;

--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -135,7 +135,6 @@ void DrawSpellBook(const Surface &out)
 	for (int i = 1; i < 8; i++) {
 		SpellID sn = SpellPages[sbooktab][i - 1];
 
->>>>>>> d87240e2d (Revise Spell Book Colors and Text)
 		if (IsValidSpell(sn) && (spl & GetSpellBitmask(sn)) != 0) {
 			SpellType st = GetSBookTrans(sn, true);
 			SetSpellTrans(st);
@@ -163,17 +162,17 @@ void DrawSpellBook(const Surface &out)
 
 			const Point line0 { 0, yp + textPaddingTop };
 			const Point line1 { 0, yp + textPaddingTop + lineHeight };
-<<<<<<< HEAD
 			PrintSBookStr(out, line0, pgettext("spell", GetSpellData(sn).sNameText));
+
 			switch (GetSBookTrans(sn, false)) {
 			case SpellType::Skill:
 				PrintSBookStr(out, line1, _("Skill"));
 				break;
-			case SpellType::Charges: {
-				int charges = player.InvBody[INVLOC_HAND_LEFT]._iCharges;
+			case SpellType::Charges:
+				charges = player.InvBody[INVLOC_HAND_LEFT]._iCharges;
 				PrintSBookStr(out, line1, fmt::format(fmt::runtime(ngettext("Staff ({:d} charge)", "Staff ({:d} charges)", charges)), charges));
-			} break;
-			default: {
+				break;
+			default:
 				int mana = GetManaAmount(player, sn) >> 6;
 				int lvl = player.GetSpellLevel(sn);
 				PrintSBookStr(out, line0, fmt::format(fmt::runtime(pgettext(/* TRANSLATORS: UI constraints, keep short please.*/ "spellbook", "Level {:d}")), lvl), UiFlags::AlignRight);
@@ -190,8 +189,13 @@ void DrawSpellBook(const Surface &out)
 							} else {
 								PrintSBookStr(out, line1, fmt::format(fmt::runtime(_(/* TRANSLATORS: UI constraints, keep short please.*/ "Damage: {:d} - {:d}")), min, max), UiFlags::AlignRight);
 							}
-=======
-			PrintSBookStr(out, line0, pgettext("spell", spelldata[sn].sNameText), UiFlags::ColorWhite);
+						}
+					}
+				}
+				break;
+			}
+
+			PrintSBookStr(out, line0, pgettext("spell", GetSpellData(sn).sNameText), UiFlags::ColorWhite);
 
 			if (GetSBookTrans(sn, false) == SpellType::Skill)
 				isSkill = true;
@@ -219,11 +223,10 @@ void DrawSpellBook(const Surface &out)
 					GetDamageAmt(sn, &min, &max);
 
 					if (min != -1) {
-						if (sn == SPL_HEAL || sn == SPL_HEALOTHER) {
+						if (sn == SpellID::Healing || sn == SpellID::HealOther) {
 							PrintSBookStr(out, line1, fmt::format(fmt::runtime(_(/* TRANSLATORS: UI constraints, keep short please.*/ "Heals: {:d} - {:d}")), min, max), UiFlags::AlignRight | UiFlags::ColorWhite);
 						} else {
 							PrintSBookStr(out, line1, fmt::format(fmt::runtime(_(/* TRANSLATORS: UI constraints, keep short please.*/ "Damage: {:d} - {:d}")), min, max), UiFlags::AlignRight | UiFlags::ColorWhite);
->>>>>>> d87240e2d (Revise Spell Book Colors and Text)
 						}
 					}
 				}


### PR DESCRIPTION
Visual explanation:

![image](https://user-images.githubusercontent.com/68359262/190830720-19967302-0f1f-45f6-89c7-877473d27a88.png)
![image](https://user-images.githubusercontent.com/68359262/190830728-21775656-ac2b-43f1-a32c-fea59ae02fe2.png)
![image](https://user-images.githubusercontent.com/68359262/190830730-7650ab9f-f8e3-4ec2-aa62-0f092efc343c.png)
![image](https://user-images.githubusercontent.com/68359262/190830741-91a3f724-e996-4c26-a805-97acfb4ae8e7.png)
![image](https://user-images.githubusercontent.com/68359262/190830755-ef240396-1a65-4d27-a2d4-eecf7ba7e08b.png)
![image](https://user-images.githubusercontent.com/68359262/190830872-194bf170-c354-48a0-b703-74863b1ab668.png)

Text explanation:
This changes the spellbook to be more uniform with the character panel. In the character panel, red is used to signify when stats are lower than base, and blue is used to signify when stats are higher than base. Also gold is used when a stat is maxed out. I used this method for the spellbook, as well and showing exactly how many spell levels are being gained or lost from items.

On top of that, I revised how spell information is shown for skill and staves. In vanilla, you were given no information other than the fact a skill is a skill, or how many charges a staff has remaining. This gives the player access to that missing information.

