### PR TITLE
Upgrade libpng to 1.6.38

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -30,8 +30,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: android-project/app/.cxx
-        key: android-cmake-v3-${{ github.sha }}
-        restore-keys: android-cmake-v3-
+        key: android-cmake-v5-${{ github.sha }}
+        restore-keys: android-cmake-v5-
 
     - name: Build
       working-directory: ${{github.workspace}}

--- a/3rdParty/libpng/CMakeLists.txt
+++ b/3rdParty/libpng/CMakeLists.txt
@@ -25,8 +25,8 @@ endif()
 
 include(FetchContent)
 FetchContent_Declare(libpng
-  URL https://github.com/diasurgical/libpng/archive/3fe9510f01748b8c706550974e23b09166e5a42d.tar.gz
-  URL_HASH MD5=5c813665b54143a1c2a89dd38b598075
+  URL https://github.com/glennrp/libpng/archive/0a158f3506502dfa23edfc42790dfaed82efba17.tar.gz
+  URL_HASH MD5=6d705417242732e8e081bff752c98c18
 )
 FetchContent_MakeAvailableExcludeFromAll(libpng)
 


### PR DESCRIPTION
I'm pretty sure that https://github.com/diasurgical/libpng/commit/838a5dc474b896fec83f5a42508f739f23f66176 was originally necessary to get the Android build to work, but I didn't encounter any errors in my tests today so we're just going to try without it. 🤞 