### PR TITLE
Turn off modernize-use-nodiscard in .clang-tidy

### DIFF
--- a/Source/.clang-tidy
+++ b/Source/.clang-tidy
@@ -34,6 +34,9 @@
 # -modernize-concat-nested-namespaces
 # -modernize-avoid-bind
 #   Compatibility with older compilers.
+# -modernize-use-nodiscard
+#   This checks suggests to add [[nodiscard]] to member functions,
+#   without a good reason to do so, cluttering the code.
 Checks: >
   -*,
   bugprone-*,
@@ -51,7 +54,8 @@ Checks: >
   -modernize-avoid-c-arrays,
   -modernize-use-trailing-return-type,
   -modernize-concat-nested-namespaces,
-  -modernize-avoid-bind
+  -modernize-avoid-bind,
+  -modernize-use-nodiscard
 
 HeaderFilterRegex: "^(Source|test)\\.h$"
 


### PR DESCRIPTION
Turn off `modernize-use-nodiscard` check in `.clang-tidy`. This check suggests to add `[[nodiscard]]` to some member functions, particularly to `const` members. `[[nodiscard]]` causes the compiler to issue a warning when the result is discarded. This of course is fine, but most of the times .clang-tidy suggests to apply this check to functions that even if ignored won't do any harm (for example `level` function of `Monster`), cluttering the code. I simply stick to the rational that `[[nodiscard]]` should be used only when discarding the result results in a disaster, like a memory leak, not when it simply does not make any sense, but is harmless (like calling `level` and discarding the result). Of course this is a matter of preference; simply put, I think that `[[nodiscard]]` unnecessarily clutters the code.