### PR TITLE
Fix warp position offset and adjust some spawn positions

### DIFF
--- a/Source/levels/drlg_l1.cpp
+++ b/Source/levels/drlg_l1.cpp
@@ -1130,7 +1130,7 @@ bool PlaceCathedralStairs(lvl_entry entry)
 	// Place stairs down
 	if (Quests[Q_LTBANNER].IsAvailable()) {
 		if (entry == ENTRY_PREV)
-			ViewPosition = SetPiece.position.megaToWorld() + Displacement { 4, 12 };
+			ViewPosition = SetPiece.position.megaToWorld() + Displacement { 3, 11 };
 	} else {
 		position = PlaceMiniSet(STAIRSDOWN, DMAXX * DMAXY, true);
 		if (!position) {

--- a/Source/levels/drlg_l4.cpp
+++ b/Source/levels/drlg_l4.cpp
@@ -1086,7 +1086,7 @@ bool PlaceStairs(lvl_entry entry)
 		if (currlevel != 16) {
 			if (Quests[Q_WARLORD].IsAvailable()) {
 				if (entry == ENTRY_PREV)
-					ViewPosition = SetPiece.position.megaToWorld() + Displacement { 6, 6 };
+					ViewPosition = SetPiece.position.megaToWorld() + Displacement { 7, 7 };
 			} else {
 				position = PlaceMiniSet(L4DSTAIRS);
 				if (!position)

--- a/Source/levels/drlg_l4.cpp
+++ b/Source/levels/drlg_l4.cpp
@@ -1111,7 +1111,7 @@ bool PlaceStairs(lvl_entry entry)
 		if (!position)
 			return false;
 		if (entry == ENTRY_PREV)
-			ViewPosition = position->megaToWorld() + Displacement { 5, 7 };
+			ViewPosition = position->megaToWorld() + Displacement { 6, 5 };
 	}
 
 	return true;

--- a/Source/levels/drlg_l4.cpp
+++ b/Source/levels/drlg_l4.cpp
@@ -1092,7 +1092,7 @@ bool PlaceStairs(lvl_entry entry)
 				if (!position)
 					return false;
 				if (entry == ENTRY_PREV)
-					ViewPosition = position->megaToWorld() + Displacement { 5, 7 };
+					ViewPosition = position->megaToWorld() + Displacement { 7, 5 };
 			}
 		}
 

--- a/Source/levels/setmaps.cpp
+++ b/Source/levels/setmaps.cpp
@@ -83,7 +83,7 @@ void LoadSetMap()
 		break;
 	case SL_BONECHAMB:
 		LoadPreL2Dungeon("levels\\l2data\\bonecha2.dun");
-		LoadL2Dungeon("levels\\l2data\\bonecha1.dun", { 69, 39 });
+		LoadL2Dungeon("levels\\l2data\\bonecha1.dun", { 70, 40 });
 		SetMapTransparency("levels\\l2data\\bonechat.dun");
 		LoadPalette("levels\\l2data\\l2_2.pal");
 		AddSChamObjs();

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -508,7 +508,7 @@ void SetReturnLvlPos()
 		ReturnLevelType = DTYPE_CATHEDRAL;
 		break;
 	case SL_VILEBETRAYER:
-		ReturnLvlPosition = Quests[Q_BETRAYER].position + Direction::East;
+		ReturnLvlPosition = Quests[Q_BETRAYER].position + Direction::South;
 		ReturnLevel = Quests[Q_BETRAYER]._qlevel;
 		ReturnLevelType = DTYPE_HELL;
 		break;

--- a/test/drlg_l1_test.cpp
+++ b/test/drlg_l1_test.cpp
@@ -209,7 +209,7 @@ TEST(Drlg_l1, CreateL5Dungeon_hellfire_4_1924296259)
 	TestCreateDungeon(4, 1924296259, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(83, 54));
 	TestCreateDungeon(4, 1924296259, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition, Point(52, 88));
+	EXPECT_EQ(ViewPosition, Point(51, 87));
 }
 
 TEST(Drlg_l1, CreateL5Dungeon_crypt_1_2122696790)

--- a/test/drlg_l4_test.cpp
+++ b/test/drlg_l4_test.cpp
@@ -35,7 +35,7 @@ TEST(Drlg_l4, CreateL4Dungeon_diablo_13_594689775)
 	TestCreateDungeon(13, 594689775, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(72, 38));
 	TestCreateDungeon(13, 594689775, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition, Point(32, 40));
+	EXPECT_EQ(ViewPosition, Point(33, 41));
 	TestCreateDungeon(13, 594689775, ENTRY_TWARPDN);
 	EXPECT_EQ(ViewPosition, Point(36, 88));
 }

--- a/test/drlg_l4_test.cpp
+++ b/test/drlg_l4_test.cpp
@@ -61,7 +61,7 @@ TEST(Drlg_l4, CreateL4Dungeon_diablo_15_1583642716)
 	TestCreateDungeon(15, 1583642716, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(44, 26));
 	TestCreateDungeon(15, 1583642716, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition, Point(87, 69));
+	EXPECT_EQ(ViewPosition, Point(88, 67));
 
 	Quests[Q_BETRAYER]._qactive = QUEST_ACTIVE;
 	TestCreateDungeon(15, 1583642716, ENTRY_MAIN); // Betrayer quest does not change level gen
@@ -77,7 +77,7 @@ TEST(Drlg_l4, CreateL4Dungeon_diablo_15_1583642716)
 	EXPECT_EQ(ViewPosition, Point(44, 26));
 	EXPECT_EQ(Quests[Q_BETRAYER].position, Point(34, 24)) << "Not really required? current bugfix sets this position anyway";
 	TestCreateDungeon(15, 1583642716, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition, Point(87, 69));
+	EXPECT_EQ(ViewPosition, Point(88, 67));
 	EXPECT_EQ(Quests[Q_BETRAYER].position, Point(34, 24)) << "Not really required? current bugfix sets this position anyway";
 }
 
@@ -91,7 +91,7 @@ TEST(Drlg_l4, CreateL4Dungeon_diablo_15_1256511996)
 	TestCreateDungeon(15, 1256511996, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(80, 70));
 	TestCreateDungeon(15, 1256511996, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition, Point(33, 67));
+	EXPECT_EQ(ViewPosition, Point(34, 65));
 }
 
 TEST(Drlg_l4, CreateL4Dungeon_diablo_16_741281013)

--- a/test/drlg_l4_test.cpp
+++ b/test/drlg_l4_test.cpp
@@ -20,7 +20,7 @@ TEST(Drlg_l4, CreateL4Dungeon_diablo_13_428074402)
 	TestCreateDungeon(13, 428074402, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(26, 64));
 	TestCreateDungeon(13, 428074402, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition, Point(47, 79));
+	EXPECT_EQ(ViewPosition, Point(49, 77));
 	TestCreateDungeon(13, 428074402, ENTRY_TWARPDN);
 	EXPECT_EQ(ViewPosition, Point(26, 44));
 }
@@ -47,7 +47,7 @@ TEST(Drlg_l4, CreateL4Dungeon_diablo_14_717625719)
 	TestCreateDungeon(14, 717625719, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(90, 64));
 	TestCreateDungeon(14, 717625719, ENTRY_PREV);
-	EXPECT_EQ(ViewPosition, Point(49, 31));
+	EXPECT_EQ(ViewPosition, Point(51, 29));
 }
 
 TEST(Drlg_l4, CreateL4Dungeon_diablo_15_1583642716)


### PR DESCRIPTION
Fixes #5185 (second try 😉)

This PR fixes the warp positions (hopefully) and changes some spawn positions (for examples see bottom).
Please review the changed spawn positions especially. I think the most controversial could be hellgate and hell downstairs. 😉 

<details><summary>Banner Quest</summary>

## Master
![BannerQuest_Master](https://user-images.githubusercontent.com/25415264/191553234-b73cd089-c3fe-46d1-bdd2-20c6822342e2.png)

## PR
![BannerQuest_PR](https://user-images.githubusercontent.com/25415264/191553249-0bf51407-cd9a-4dc8-bec6-12dfbb24c8df.png)

## Reference (normal level, not changed)
![BannerQuest_Reference](https://user-images.githubusercontent.com/25415264/191553262-efa42b27-66a1-4e2d-b05d-7844d65f5c07.png)

</details>

<details><summary>Chamber of Bone</summary>

## Master
![ChamberOfBone_Master](https://user-images.githubusercontent.com/25415264/191553537-e254a9ad-2172-4c6e-946a-2ece78ca2e98.png)

## PR
![ChamberOfBone_PR](https://user-images.githubusercontent.com/25415264/191553553-df7a1f93-36f2-4be3-9dd5-df80e3a43f7d.png)

## Reference (normal level, not changed)
![ChamberOfBone_Reference](https://user-images.githubusercontent.com/25415264/191553563-45a52981-8ea3-4d66-98c5-0651d18de547.png)

</details>

<details><summary>Lazarus Portal</summary>

## Master
![Lazarus_Master](https://user-images.githubusercontent.com/25415264/191666120-ce640890-b9bf-4eeb-97c8-67310a98c3fd.png)

## PR
![Lazarus_PR](https://user-images.githubusercontent.com/25415264/191666138-f72105cd-9763-4a6f-a11e-24625c727600.png)

## Reference
![Lazarus_Reference](https://user-images.githubusercontent.com/25415264/191666366-061fc56c-05e4-411d-84af-e4caccb9b912.png)

</details>

<details><summary>Warlord of Blood</summary>

## Master
![WarlordOfBlood_Master](https://user-images.githubusercontent.com/25415264/191553839-2fed5daf-b038-466d-b35b-0e3afcf63925.png)

## PR
![WarlordOfBlood_PR](https://user-images.githubusercontent.com/25415264/191553860-4302df5f-7669-4f27-8ee5-b10e8864ea34.png)

</details>

<details><summary>Hell downstairs</summary>

## Master
![HellDownstairs_Master](https://user-images.githubusercontent.com/25415264/191554015-b508bafe-90dd-4b4e-bc6e-5c1931467249.png)

## PR
![HellDownstairs_PR](https://user-images.githubusercontent.com/25415264/191554039-39c6a6d9-c79b-40bf-9fe3-666233b80b0b.png)

</details>

<details><summary>Hell gate</summary>

## Master
![Hellgate_Master](https://user-images.githubusercontent.com/25415264/191554384-d17296ca-d3ca-496d-9d35-38262e32ee30.png)

## PR
![Hellgate_PR](https://user-images.githubusercontent.com/25415264/191554396-d9eb5447-020c-40ee-965c-8f4309d335c4.png)

</details>

@Chance4us It would be great if you could test this pr. 🙂 

I didn't change
>  upstairs: The warp and hero position is the same, but the hero stands displaced in the entrance (unclear if vanilla behavior)