### PR TITLE
Fix edge cases in DrawString()

### DIFF
--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -383,10 +383,11 @@ int DoDrawString(const Surface &out, string_view text, Rectangle rect, Point &ch
 
 		uint8_t frame = next & 0xFF;
 		if (next == '\n' || characterPosition.x > rightMargin) {
-			if (characterPosition.y + lineHeight >= bottomMargin)
+			int nextLineY = characterPosition.y + lineHeight;
+			if (nextLineY + lineHeight > bottomMargin)
 				break;
 			characterPosition.x = rect.position.x;
-			characterPosition.y += lineHeight;
+			characterPosition.y = nextLineY;
 
 			if (HasAnyOf(flags, (UiFlags::AlignCenter | UiFlags::AlignRight))) {
 				lineWidth = (*kerning)[frame];

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -631,7 +631,7 @@ uint32_t DrawString(const Surface &out, string_view text, const Rectangle &rect,
 	else if (HasAnyOf(flags, UiFlags::AlignRight))
 		characterPosition.x += rect.size.width - lineWidth;
 
-	int rightMargin = rect.position.x + rect.size.width;
+	const int rightMargin = rect.position.x + rect.size.width;
 	const int bottomMargin = rect.size.height != 0 ? std::min(rect.position.y + rect.size.height, out.h()) : out.h();
 
 	if (lineHeight == -1)
@@ -639,7 +639,7 @@ uint32_t DrawString(const Surface &out, string_view text, const Rectangle &rect,
 
 	if (HasAnyOf(flags, UiFlags::VerticalCenter)) {
 		int textHeight = (std::count(text.cbegin(), text.cend(), '\n') + 1) * lineHeight;
-		characterPosition.y += (rect.size.height - textHeight) / 2;
+		characterPosition.y += std::max(0, (rect.size.height - textHeight) / 2);
 	}
 
 	characterPosition.y += BaseLineOffset[size];
@@ -675,7 +675,7 @@ void DrawStringWithColors(const Surface &out, string_view fmt, DrawStringFormatA
 	else if (HasAnyOf(flags, UiFlags::AlignRight))
 		characterPosition.x += rect.size.width - lineWidth;
 
-	int rightMargin = rect.position.x + rect.size.width;
+	const int rightMargin = rect.position.x + rect.size.width;
 	const int bottomMargin = rect.size.height != 0 ? std::min(rect.position.y + rect.size.height, out.h()) : out.h();
 
 	if (lineHeight == -1)
@@ -683,7 +683,7 @@ void DrawStringWithColors(const Surface &out, string_view fmt, DrawStringFormatA
 
 	if (HasAnyOf(flags, UiFlags::VerticalCenter)) {
 		int textHeight = (CountNewlines(fmt, args, argsLen) + 1) * lineHeight;
-		characterPosition.y += (rect.size.height - textHeight) / 2;
+		characterPosition.y += std::max(0, (rect.size.height - textHeight) / 2);
 	}
 
 	characterPosition.y += BaseLineOffset[size];


### PR DESCRIPTION
My work from reviewing #5267 compelled me to test some of the `DrawString()` functionality to make sure it was working right. My testing was done using the following code. It should be pretty self-explanatory, but just to be clear, the point is to draw a rectangle around the text area in the info panel and then attempt to display a multiline string within that area to get a clear picture of what's going on.

```diff
diff --git a/Source/control.cpp b/Source/control.cpp
index e35c74132..53bfb7be5 100644
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -264,17 +264,23 @@ void PrintInfo(const Surface &out)
 	const int LineStart[] = { 70, 58, 52, 48, 46 };
 	const int LineHeights[] = { 30, 24, 18, 15, 12 };
 
-	Rectangle line { GetMainPanel().position + Displacement { 177, LineStart[pnumlines] }, { 288, 12 } };
-
-	if (!InfoString.empty()) {
-		DrawString(out, InfoString, line, InfoColor | UiFlags::AlignCenter | UiFlags::KerningFitSpacing, 2);
-		line.position.y += LineHeights[pnumlines];
-	}
-
-	for (int i = 0; i < pnumlines; i++) {
-		DrawString(out, panelstr[i], line, InfoColor | UiFlags::AlignCenter | UiFlags::KerningFitSpacing, 2);
-		line.position.y += LineHeights[pnumlines];
-	}
+	Rectangle line { GetMainPanel().position + Displacement { 177, LineStart[4] }, { 288, 60 } };
+	DrawHorizontalLine(out, line.position, line.size.width, 255);
+	DrawHorizontalLine(out, line.position + Displacement { 0, line.size.height }, line.size.width, 255);
+	DrawVerticalLine(out, line.position, line.size.height, 255);
+	DrawVerticalLine(out, line.position + Displacement { line.size.width, 0 }, line.size.height, 255);
+
+	DrawString(out, "this\nis\na\ntest\nof\ntoo\nmany\nlines", line, InfoColor | UiFlags::AlignCenter | UiFlags::KerningFitSpacing, 2, 12);
+
+	//if (!InfoString.empty()) {
+	//	DrawString(out, InfoString, line, InfoColor | UiFlags::AlignCenter | UiFlags::KerningFitSpacing, 2);
+	//	line.position.y += LineHeights[pnumlines];
+	//}
+
+	//for (int i = 0; i < pnumlines; i++) {
+	//	DrawString(out, panelstr[i], line, InfoColor | UiFlags::AlignCenter | UiFlags::KerningFitSpacing, 2);
+	//	line.position.y += LineHeights[pnumlines];
+	//}
 }
 
 int CapStatPointsToAdd(int remainingStatPoints, const Player &player, CharacterAttribute attribute)
```

This code without any other modifications produced this image, illustrating the issue of text displaying outside the bottom boundary specified by the rectangle. The second commit addresses this by computing the location of the next line of text before checking to see if the _bottom edge_ of that text exceeds the bounds of the rectangle.

![image](https://user-images.githubusercontent.com/9203145/192107310-07122a31-8a1a-4168-a67e-65e3396d7a5b.png)

This next image was produced by using the code modification above along with the `UiFlags::VerticalCenter` flag. This illustrates the issue of the `DrawString()` function placing text outside the upper bounds of the rectangle when centering text vertically. This occurs due to the computation not taking into account that the text may exceed the vertical limits of its bounding box, producing a negative offset from the computation. The first commit addresses this by specifying a minimum offset of zero, effectively disallowing the negative offset that would exceed the bounds of the box. There are a couple other ways we could handle this, but this method is simple and works well for #5267.

![image](https://user-images.githubusercontent.com/9203145/192107616-eac23a82-f4db-4b0d-abbd-b2dacf3a27cb.png)

This last image is just what the code modification above with `UiFlags::VerticalCenter` looks like after applying the changes from this PR. You can see that both issues have been fixed.

![image](https://user-images.githubusercontent.com/9203145/192107744-9c0cb012-fca6-4f4c-a19c-d48e3162d6cf.png)

I'm putting this in draft mode for now so I can review other areas of the code that use `DrawString()`, particularly cases where `UiFlags::VerticalCenter` is used.