### PR TITLE
Fix activate to use showing up on all items

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1823,7 +1823,7 @@ void PrintItemMisc(const Item &item)
 		printItemMiscKBM(item, isOil, isCastOnTarget);
 	} else if (ControlMode == ControlTypes::VirtualGamepad) {
 		printItemMiscVirtualGamepad(item, isOil, isCastOnTarget);
-	} else {
+	} else if (IsAnyOf(item._iMiscId, IMISC_BOOK, IMISC_NOTE, IMISC_SCROLL, IMISC_SCROLLT)) {
 		printItemMiscGamepad(item, isOil, isCastOnTarget);
 	}
 }


### PR DESCRIPTION
Fixes "Activate to use" showing up on all items when using a virtual gamepad.