### PR TITLE
Prevent oil damage wrap around

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4659,12 +4659,12 @@ bool ApplyOilToItem(Item &item, Player &player)
 		}
 		break;
 	case IMISC_OILSHARP:
-		if (item._iMaxDam - item._iMinDam < 30) {
+		if (item._iMaxDam - item._iMinDam < 30 && item._iMaxDam < 255) {
 			item._iMaxDam = item._iMaxDam + 1;
 		}
 		break;
 	case IMISC_OILDEATH:
-		if (item._iMaxDam - item._iMinDam < 30) {
+		if (item._iMaxDam - item._iMinDam < 30 && item._iMaxDam < 254) {
 			item._iMinDam = item._iMinDam + 1;
 			item._iMaxDam = item._iMaxDam + 2;
 		}


### PR DESCRIPTION
per discussion in #development on 30/Sep/2022 (could hypothetically use gloomy shrine, in single player, to subtract 1 max damage each time you use an oil of death and eventually, after much effort, exceed max value for damage)