### PR TITLE
Restore item seed when converting potions to rejuvenation potions

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1279,11 +1279,12 @@ void AddStealPotions(Missile &missile, const AddMissileParameter & /*parameter*/
 
 		bool hasPlayedSFX = false;
 		for (int si = 0; si < MaxBeltItems; si++) {
-			int ii = -1;
-			if (player.SpdList[si]._itype == ItemType::Misc) {
+			Item &beltItem = player.SpdList[si];
+			int ii = IDI_NONE;
+			if (beltItem._itype == ItemType::Misc) {
 				if (FlipCoin())
 					continue;
-				switch (player.SpdList[si]._iMiscId) {
+				switch (beltItem._iMiscId) {
 				case IMISC_FULLHEAL:
 					ii = ItemMiscIdIdx(IMISC_HEAL);
 					break;
@@ -1314,9 +1315,11 @@ void AddStealPotions(Missile &missile, const AddMissileParameter & /*parameter*/
 					continue;
 				}
 			}
-			if (ii != -1) {
-				InitializeItem(player.SpdList[si], ii);
-				player.SpdList[si]._iStatFlag = true;
+			if (ii != IDI_NONE) {
+				auto seed = beltItem._iSeed;
+				InitializeItem(beltItem, ii);
+				beltItem._iSeed = seed;
+				beltItem._iStatFlag = true;
 			}
 			if (!hasPlayedSFX) {
 				PlaySfxLoc(IS_POPPOP2, target);

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2568,12 +2568,19 @@ void OperateShrineEldritch(Player &player)
 			continue;
 		}
 		if (IsAnyOf(item._iMiscId, IMISC_HEAL, IMISC_MANA)) {
+			// Reinitializing the item zeroes out the seed, we save and restore here to avoid triggering false
+			// positives on duplicated item checks (e.g. when picking up the item).
+			auto seed = item._iSeed;
 			InitializeItem(item, ItemMiscIdIdx(IMISC_REJUV));
+			item._iSeed = seed;
 			item._iStatFlag = true;
 			continue;
 		}
 		if (IsAnyOf(item._iMiscId, IMISC_FULLHEAL, IMISC_FULLMANA)) {
+			// As above.
+			auto seed = item._iSeed;
 			InitializeItem(item, ItemMiscIdIdx(IMISC_FULLREJUV));
+			item._iSeed = seed;
 			item._iStatFlag = true;
 			continue;
 		}


### PR DESCRIPTION
Items are initialised using either `GetItemAttrs` (which copies values from `AllItemAttrs` over whatever memory values were already present) or `InitializeItems` (which re-initialises the item struct explicitly then copies values from `AllItemAttrs` over the default/zero-init values).

We can be confident that potions have been spawned in a way that initialises their seed to some random value, so reusing the seed is not harmful.

Out of interest, the only items I saw which have a fixed seed are uniques spawned via `SpawnUnique` (seeds are either 0 from the earlier call to `AllocItem` or set to the `uid` inside `GetUniqueItem`) and the quest items Magic Rock/the combined note which both use a zero-initialised seed.