### PR TITLE
Enable override for the externalNativeBuild's buildStagingDirectory

### DIFF
--- a/android-project/app/build.gradle
+++ b/android-project/app/build.gradle
@@ -44,6 +44,7 @@ android {
 			cmake {
 				path '../../CMakeLists.txt'
 				version "3.22.1+"
+				buildStagingDirectory System.env.DevilutionX_Android_StagingDirectory
 			}
 		}
 


### PR DESCRIPTION
I discovered today that all my Intellisense-related performance problems had to do with Visual Studio indiscriminately scanning all files in every folder beneath the root folder where `CMakeLists.txt` resides. This behavior doesn't play nice with the massive number of intermediate files produced by Android Studio builds in the `...\devilutionX\android-project\app\.cxx` folder. The change in this PR simply allows me to override the location of the Android build's intermediate files by setting the `DevilutionX_Android_StagingDirectory` environment variable. That way I can put it in an entirely different location that Visual Studio doesn't care about. It seems to do nothing if the environment variable isn't set so this hopefully shouldn't affect anyone else.