### PR TITLE
TFit_Obj5: Fix theme room generation when only last skipped candidate was valid

### DIFF
--- a/Source/levels/themes.cpp
+++ b/Source/levels/themes.cpp
@@ -109,20 +109,20 @@ bool TFit_Obj5(int t)
 		return true;
 	}
 
+	bool validFound = false;
 	for (int yp = 0; yp < MAXDUNY; yp++) {
 		for (int xp = 0; xp < MAXDUNX; xp++) {
 			if (dTransVal[xp][yp] == themes[t].ttval && IsTileNotSolid({ xp, yp }) && CheckThemeObj5({ xp, yp }, themes[t].ttval)) {
-				if (skipCandidates > 0) {
-					skipCandidates--;
-					continue;
-				}
 				themex = xp;
 				themey = yp;
-				return true;
+				validFound = true;
+				skipCandidates--;
+				if (skipCandidates <= 0)
+					return true;
 			}
 		}
 	}
-	return false;
+	return validFound;
 }
 bool TFit_SkelRoom(int t)
 {


### PR DESCRIPTION
Fixes #5360

The bug was introduced with #5117 / 08acd4aac05158e09655a54ee60fd5e15014993a

Previous `TFit_Obj5` only returned false when [no place for the (first candidate) theme room was found (`r == rs`)](https://github.com/diasurgical/devilutionX/commit/08acd4aac05158e09655a54ee60fd5e15014993a#diff-b22a42607df3745a75d7085a9f065fbd0be5b4522c3d24527480312e4e7a3bf5L128). In this case searching for a second candidate/position is not necessary, cause the entire dungeon can't fit any.
Else the function [returned true and used the coordinates for the last candidate](https://github.com/diasurgical/devilutionX/commit/08acd4aac05158e09655a54ee60fd5e15014993a#diff-b22a42607df3745a75d7085a9f065fbd0be5b4522c3d24527480312e4e7a3bf5L139-L142).

@ephphatha Could you take a look? That would be great. 🙂