### PR TITLE
Fix infravision lasts forever

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2603,6 +2603,8 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 	player._pILMinDam = lmin;
 	player._pILMaxDam = lmax;
 
+	player._pInfraFlag = false;
+
 	player._pBlockFlag = false;
 	if (player._pClass == HeroClass::Monk) {
 		if (player.InvBody[INVLOC_HAND_LEFT]._itype == ItemType::Staff && player.InvBody[INVLOC_HAND_LEFT]._iStatFlag) {


### PR DESCRIPTION
Fixes #5296

`MI_Infra` calls `CalcPlrItemVals` when infravision is removed. `CalcPlrItemVals` is expect to reset `_pInfraFlag`.

Line [was removed](https://github.com/diasurgical/devilutionX/commit/58ae9169f1df10a59319c145d517a27dbc4bf03b#diff-be3ecbe1ead4062ccd317dfeb0428b38adf3d54377059e602229c75bfc052da8L2616-L2617) in #5229 / 58ae9169f1df10a59319c145d517a27dbc4bf03b

Thanks @Chance4us for reporting and finding the correct commit. 🙂 