### PR TITLE
Reorder/optimize large structs

### DIFF
--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -115,14 +115,6 @@ private:
 	[[nodiscard]] float getProgressToNextGameTick() const;
 
 	/**
-	 * @brief Specifies how many animations-fractions are displayed between two game ticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
-	 */
-	float tickModifier_;
-	/**
-	 * @brief Number of game ticks after the current animation sequence started
-	 */
-	float ticksSinceSequenceStarted_;
-	/**
 	 * @brief Animation Frames that will be adjusted for the skipped Frames/game ticks
 	 */
 	int8_t relevantFramesForDistributing_;
@@ -130,6 +122,15 @@ private:
 	 * @brief Animation Frames that wasn't shown from previous Animation
 	 */
 	int8_t skippedFramesFromPreviousAnimation_;
+
+	/**
+	 * @brief Specifies how many animations-fractions are displayed between two game ticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
+	 */
+	float tickModifier_;
+	/**
+	 * @brief Number of game ticks after the current animation sequence started
+	 */
+	float ticksSinceSequenceStarted_;
 };
 
 } // namespace devilution

--- a/Source/itemdat.h
+++ b/Source/itemdat.h
@@ -355,7 +355,7 @@ enum class ItemSpecialEffect : uint32_t {
 };
 use_enum_as_flags(ItemSpecialEffect);
 
-enum class ItemSpecialEffectHf : uint32_t {
+enum class ItemSpecialEffectHf : uint8_t {
 	// clang-format off
 	None               = 0,
 	Devastation        = 1 << 0,

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2694,7 +2694,7 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 		player._pIAC += player._pLevel * 2;
 	}
 
-	int gfxNum = static_cast<int>(animWeaponId) | static_cast<int>(animArmorId);
+	const uint8_t gfxNum = static_cast<uint8_t>(animWeaponId) | static_cast<uint8_t>(animArmorId);
 	if (player._pgfxnum != gfxNum && loadgfx) {
 		player._pgfxnum = gfxNum;
 		ResetPlayerGFX(player);

--- a/Source/items.h
+++ b/Source/items.h
@@ -179,9 +179,9 @@ struct Item {
 	/** Randomly generated identifier */
 	int32_t _iSeed = 0;
 	uint16_t _iCreateInfo = 0;
-	enum ItemType _itype = ItemType::None;
-	Point position = { 0, 0 };
+	ItemType _itype = ItemType::None;
 	bool _iAnimFlag = false;
+	Point position = { 0, 0 };
 	/*
 	 * @brief Contains Information for current Animation
 	 */
@@ -193,8 +193,8 @@ struct Item {
 	item_quality _iMagical = ITEM_QUALITY_NORMAL;
 	char _iName[64] = {};
 	char _iIName[64] = {};
-	enum item_equip_type _iLoc = ILOC_NONE;
-	enum item_class _iClass = ICLASS_NONE;
+	item_equip_type _iLoc = ILOC_NONE;
+	item_class _iClass = ICLASS_NONE;
 	uint8_t _iCurs = 0;
 	int _ivalue = 0;
 	int _iIvalue = 0;
@@ -202,8 +202,9 @@ struct Item {
 	uint8_t _iMaxDam = 0;
 	int16_t _iAC = 0;
 	ItemSpecialEffect _iFlags = ItemSpecialEffect::None;
-	enum item_misc_id _iMiscId = IMISC_NONE;
-	enum spell_id _iSpell = SPL_NULL;
+	item_misc_id _iMiscId = IMISC_NONE;
+	spell_id _iSpell = SPL_NULL;
+	_item_indexes IDidx = IDI_NONE;
 	int _iCharges = 0;
 	int _iMaxCharges = 0;
 	int _iDurability = 0;
@@ -242,9 +243,8 @@ struct Item {
 	uint8_t _iMinMag = 0;
 	int8_t _iMinDex = 0;
 	bool _iStatFlag = false;
-	_item_indexes IDidx = IDI_NONE;
-	uint32_t dwBuff = 0;
 	ItemSpecialEffectHf _iDamAcFlags = ItemSpecialEffectHf::None;
+	uint32_t dwBuff = 0;
 
 	/**
 	 * @brief Clears this item and returns the old value

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -146,8 +146,7 @@ public:
 	template <class TSource, class TDesired>
 	TDesired NextLENarrow(TSource modifier = 0)
 	{
-		static_assert(std::numeric_limits<TSource>::min() < std::numeric_limits<TDesired>::min());
-		static_assert(std::numeric_limits<TSource>::max() > std::numeric_limits<TDesired>::max());
+		static_assert(sizeof(TSource) > sizeof(TDesired), "Can only narrow to a smaller type");
 		TSource value = SwapLE(Next<TSource>()) + modifier;
 		return static_cast<TDesired>(clamp<TSource>(value, std::numeric_limits<TDesired>::min(), std::numeric_limits<TDesired>::max()));
 	}
@@ -346,7 +345,7 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	file.Skip<int32_t>(4); // Skip offset and velocity
 	player._pdir = static_cast<Direction>(file.NextLE<int32_t>());
 	file.Skip(4); // Unused
-	player._pgfxnum = file.NextLE<int32_t>();
+	player._pgfxnum = file.NextLENarrow<uint32_t, uint8_t>();
 	file.Skip<uint32_t>(); // Skip pointer pData
 	player.AnimInfo = {};
 	player.AnimInfo.ticksPerFrame = file.NextLENarrow<int32_t, int8_t>(1);
@@ -1116,7 +1115,7 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.WriteLE<int32_t>(velocity.deltaY);
 	file.WriteLE<int32_t>(static_cast<int32_t>(player._pdir));
 	file.Skip(4); // Unused
-	file.WriteLE<int32_t>(player._pgfxnum);
+	file.WriteLE<uint32_t>(player._pgfxnum);
 	file.Skip(4); // Skip pointer _pAnimData
 	file.WriteLE<int32_t>(std::max(0, player.AnimInfo.ticksPerFrame - 1));
 	file.WriteLE<int32_t>(player.AnimInfo.tickCounterOfCurrentFrame);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2090,7 +2090,7 @@ size_t OnPlayerJoinLevel(const TCmd *pCmd, size_t pnum)
 			if ((player._pHitPoints >> 6) > 0) {
 				StartStand(player, Direction::South);
 			} else {
-				player._pgfxnum &= ~0xF;
+				player._pgfxnum &= ~0xFU;
 				player._pmode = PM_DEATH;
 				NewPlrAnim(player, player_graphic::Death, Direction::South);
 				player.AnimInfo.currentFrame = player.AnimInfo.numberOfFrames - 2;

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -839,7 +839,7 @@ void recv_plrinfo(int pnum, const TCmdPlrInfoHdr &header, bool recv)
 		return;
 	}
 
-	player._pgfxnum &= ~0xF;
+	player._pgfxnum &= ~0xFU;
 	player._pmode = PM_DEATH;
 	NewPlrAnim(player, player_graphic::Death, Direction::South);
 	player.AnimInfo.currentFrame = player.AnimInfo.numberOfFrames - 2;

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -22,8 +22,11 @@ namespace devilution {
 
 struct Object {
 	_object_id _otype = OBJ_NULL;
-	Point position;
 	bool _oLight = false;
+	bool _oTrapFlag = false;
+	bool _oDoorFlag = false;
+
+	Point position;
 	uint32_t _oAnimFlag = 0;
 	OptionalClxSpriteList _oAnimData;
 	int _oAnimDelay = 0;      // Tick length of each frame in the current animation
@@ -42,8 +45,6 @@ struct Object {
 	bool _oMissFlag = false;
 	uint8_t _oSelFlag = 0;
 	bool _oPreFlag = false;
-	bool _oTrapFlag = false;
-	bool _oDoorFlag = false;
 	int _olid = 0;
 	/**
 	 * Saves the absolute value of the engine state (typically from a call to AdvanceRndSeed()) to later use when spawning items from a container object
@@ -56,6 +57,8 @@ struct Object {
 	int _oVar4 = 0;
 	int _oVar5 = 0;
 	uint32_t _oVar6 = 0;
+	int _oVar8 = 0;
+
 	/**
 	 * @brief ID of a quest message to play when this object is activated.
 	 *
@@ -63,7 +66,6 @@ struct Object {
 	 */
 	// TODO: Should be TEXT_NONE (timedemo save will need to be updated).
 	_speech_id bookMessage = TEXT_KING1;
-	int _oVar8 = 0;
 
 	/**
 	 * @brief Returns the network identifier for this object

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -132,7 +132,7 @@ void PackPlayer(PlayerPack *pPack, const Player &player, bool manashield, bool n
 
 	pPack->wReflections = SDL_SwapLE16(player.wReflections);
 	pPack->pDifficulty = SDL_SwapLE32(player.pDifficulty);
-	pPack->pDamAcFlags = static_cast<ItemSpecialEffectHf>(SDL_SwapLE32(static_cast<uint32_t>(player.pDamAcFlags)));
+	pPack->pDamAcFlags = SDL_SwapLE32(static_cast<uint32_t>(player.pDamAcFlags));
 	pPack->pDiabloKillLevel = SDL_SwapLE32(player.pDiabloKillLevel);
 	pPack->bIsHellfire = gbIsHellfire ? 1 : 0;
 

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -74,7 +74,7 @@ struct PlayerPack {
 	int16_t wReserved8;  // For future use
 	uint32_t pDiabloKillLevel;
 	uint32_t pDifficulty;
-	ItemSpecialEffectHf pDamAcFlags;
+	uint32_t pDamAcFlags; // `ItemSpecialEffectHf` is 1 byte but this is 4 bytes.
 	/**@brief Only used in multiplayer sync (SendPlayerInfo/recv_plrinfo). Never used in save games (single- or multiplayer). */
 	uint8_t friendlyMode;
 	/**@brief Only used in multiplayer sync (SendPlayerInfo/recv_plrinfo). Never used in save games (single- or multiplayer). */

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2293,7 +2293,7 @@ void InitPlayerGFX(Player &player)
 	ResetPlayerGFX(player);
 
 	if (player._pHitPoints >> 6 == 0) {
-		player._pgfxnum &= ~0xF;
+		player._pgfxnum &= ~0xFU;
 		LoadPlrGFX(player, player_graphic::Death);
 		return;
 	}
@@ -2354,8 +2354,8 @@ void SetPlrAnims(Player &player)
 	}
 	player._pSFNum = PlrGFXAnimLens[static_cast<std::size_t>(pc)][10];
 
-	auto gn = static_cast<PlayerWeaponGraphic>(player._pgfxnum & 0xF);
-	int armorGraphicIndex = player._pgfxnum & ~0xF;
+	auto gn = static_cast<PlayerWeaponGraphic>(player._pgfxnum & 0xFU);
+	int armorGraphicIndex = player._pgfxnum & ~0xFU;
 	if (pc == HeroClass::Warrior) {
 		if (gn == PlayerWeaponGraphic::Bow) {
 			if (leveltype != DTYPE_TOWN) {
@@ -2570,7 +2570,7 @@ void CreatePlayer(Player &player, HeroClass c)
 		animWeaponId = PlayerWeaponGraphic::Staff;
 		break;
 	}
-	player._pgfxnum = static_cast<int>(animWeaponId);
+	player._pgfxnum = static_cast<uint8_t>(animWeaponId);
 
 	for (bool &levelVisited : player._pLvlVisited) {
 		levelVisited = false;
@@ -2745,7 +2745,7 @@ void InitPlayer(Player &player, bool firstTime)
 			player.AnimInfo.currentFrame = GenerateRnd(player._pNFrames - 1);
 			player.AnimInfo.tickCounterOfCurrentFrame = GenerateRnd(3);
 		} else {
-			player._pgfxnum &= ~0xF;
+			player._pgfxnum &= ~0xFU;
 			player._pmode = PM_DEATH;
 			NewPlrAnim(player, player_graphic::Death, Direction::South);
 			player.AnimInfo.currentFrame = player.AnimInfo.numberOfFrames - 2;
@@ -2955,7 +2955,7 @@ StartPlayerKill(Player &player, int earflag)
 
 	if (player._pgfxnum != 0) {
 		if (diablolevel || earflag != 0)
-			player._pgfxnum &= ~0xF;
+			player._pgfxnum &= ~0xFU;
 		else
 			player._pgfxnum = 0;
 		ResetPlayerGFX(player);

--- a/Source/player.h
+++ b/Source/player.h
@@ -220,54 +220,16 @@ struct Player {
 	Player(Player &&) noexcept = default;
 	Player &operator=(Player &&) noexcept = default;
 
-	PLR_MODE _pmode;
-	int8_t walkpath[MaxPathLength];
-	bool plractive;
-	action_id destAction;
-	int destParam1;
-	int destParam2;
-	int destParam3;
-	int destParam4;
-	uint8_t plrlevel;
-	bool plrIsOnSetLevel;
-	ActorPosition position;
-	Direction _pdir; // Direction faced by player (direction enum)
-	int _pgfxnum;    // Bitmask indicating what variant of the sprite the player is using. Lower byte define weapon (PlayerWeaponGraphic) and higher values define armour (starting with PlayerArmorGraphic)
-	/**
-	 * @brief Contains Information for current Animation
-	 */
-	AnimationInfo AnimInfo;
-	/**
-	 * @brief Contains a optional preview ClxSprite that is displayed until the current command is handled by the game logic
-	 */
-	OptionalClxSprite previewCelSprite;
-	/**
-	 * @brief Contains the progress to next game tick when previewCelSprite was set
-	 */
-	float progressToNextGameTickWhenPreviewWasSet;
+	char _pName[PlayerNameLength];
+	Item InvBody[NUM_INVLOC];
+	Item InvList[InventoryGridCells];
+	Item SpdList[MaxBeltItems];
+	Item HoldItem;
+
 	int _plid;
 	int _pvid;
-	/* @brief next queued spell */
-	SpellCastInfo queuedSpell;
-	/* @brief the spell that is currently casted */
-	SpellCastInfo executedSpell;
-	spell_id _pTSpell;
-	spell_id _pRSpell;
-	spell_type _pRSplType;
-	spell_id _pSBkSpell;
-	int8_t _pSplLvl[64];
-	uint64_t _pMemSpells;  // Bitmask of learned spells
-	uint64_t _pAblSpells;  // Bitmask of abilities
-	uint64_t _pScrlSpells; // Bitmask of spells available via scrolls
-	SpellFlag _pSpellFlags;
-	spell_id _pSplHotKey[NumHotkeys];
-	spell_type _pSplTHotKey[NumHotkeys];
-	bool _pBlockFlag;
-	bool _pInvincible;
-	int8_t _pLightRad;
-	bool _pLvlChanging; // True when the player is transitioning between levels
-	char _pName[PlayerNameLength];
-	HeroClass _pClass;
+
+	int _pNumInv;
 	int _pStrength;
 	int _pBaseStr;
 	int _pMagic;
@@ -289,21 +251,46 @@ struct Player {
 	int _pMana;
 	int _pMaxMana;
 	int _pManaPer;
-	int8_t _pLevel;
-	int8_t _pMaxLvl;
+	int _pIMinDam;
+	int _pIMaxDam;
+	int _pIAC;
+	int _pIBonusDam;
+	int _pIBonusToHit;
+	int _pIBonusAC;
+	int _pIBonusDamMod;
+	int _pIGetHit;
+	int _pISplDur;
+	int _pIEnAc;
+	int _pIFMinDam;
+	int _pIFMaxDam;
+	int _pILMinDam;
+	int _pILMaxDam;
 	uint32_t _pExperience;
 	uint32_t _pNextExper;
-	int8_t _pArmorClass;
-	int8_t _pMagResist;
-	int8_t _pFireResist;
-	int8_t _pLghtResist;
+	PLR_MODE _pmode;
+	int8_t walkpath[MaxPathLength];
+	bool plractive;
+	action_id destAction;
+	int destParam1;
+	int destParam2;
+	int destParam3;
+	int destParam4;
 	int _pGold;
-	bool _pInfraFlag;
-	/** Player's direction when ending movement. Also used for casting direction of SPL_FIREWALL. */
-	Direction tempDirection;
 
-	bool _pLvlVisited[NUMLEVELS];
-	bool _pSLvlVisited[NUMLEVELS]; // only 10 used
+	/**
+	 * @brief Contains Information for current Animation
+	 */
+	AnimationInfo AnimInfo;
+	/**
+	 * @brief Contains a optional preview ClxSprite that is displayed until the current command is handled by the game logic
+	 */
+	OptionalClxSprite previewCelSprite;
+	/**
+	 * @brief Contains the progress to next game tick when previewCelSprite was set
+	 */
+	float progressToNextGameTickWhenPreviewWasSet;
+	/** @brief Bitmask using item_special_effect */
+	ItemSpecialEffect _pIFlags;
 	/**
 	 * @brief Contains Data (Sprites) for the different Animations
 	 */
@@ -317,31 +304,57 @@ struct Player {
 	int8_t _pHFrames;
 	int8_t _pDFrames;
 	int8_t _pBFrames;
-	Item InvBody[NUM_INVLOC];
-	Item InvList[InventoryGridCells];
-	int _pNumInv;
 	int8_t InvGrid[InventoryGridCells];
-	Item SpdList[MaxBeltItems];
-	Item HoldItem;
-	int _pIMinDam;
-	int _pIMaxDam;
-	int _pIAC;
-	int _pIBonusDam;
-	int _pIBonusToHit;
-	int _pIBonusAC;
-	int _pIBonusDamMod;
-	/** Bitmask of staff spell */
-	uint64_t _pISpells;
-	/** Bitmask using item_special_effect */
-	ItemSpecialEffect _pIFlags;
-	int _pIGetHit;
+
+	uint8_t plrlevel;
+	bool plrIsOnSetLevel;
+	ActorPosition position;
+	Direction _pdir; // Direction faced by player (direction enum)
+	HeroClass _pClass;
+	int8_t _pLevel;
+	int8_t _pMaxLvl;
+	uint8_t _pgfxnum; // Bitmask indicating what variant of the sprite the player is using. The 3 lower bits define weapon (PlayerWeaponGraphic) and the higher bits define armour (starting with PlayerArmorGraphic)
 	int8_t _pISplLvlAdd;
-	int _pISplDur;
-	int _pIEnAc;
-	int _pIFMinDam;
-	int _pIFMaxDam;
-	int _pILMinDam;
-	int _pILMaxDam;
+	/** @brief Specifies whether players are in non-PvP mode. */
+	bool friendlyMode = true;
+
+	/** @brief The next queued spell */
+	SpellCastInfo queuedSpell;
+	/** @brief The spell that is currently being cast */
+	SpellCastInfo executedSpell;
+	spell_id _pTSpell;
+	spell_id _pRSpell;
+	spell_type _pRSplType;
+	spell_id _pSBkSpell;
+	int8_t _pSplLvl[64];
+	/** @brief Bitmask of staff spell */
+	uint64_t _pISpells;
+	/** @brief Bitmask of learned spells */
+	uint64_t _pMemSpells;
+	/** @brief Bitmask of abilities */
+	uint64_t _pAblSpells;
+	/** @brief Bitmask of spells available via scrolls */
+	uint64_t _pScrlSpells;
+	SpellFlag _pSpellFlags;
+	spell_id _pSplHotKey[NumHotkeys];
+	spell_type _pSplTHotKey[NumHotkeys];
+	bool _pBlockFlag;
+	bool _pInvincible;
+	int8_t _pLightRad;
+	/** @brief True when the player is transitioning between levels */
+	bool _pLvlChanging;
+
+	int8_t _pArmorClass;
+	int8_t _pMagResist;
+	int8_t _pFireResist;
+	int8_t _pLghtResist;
+	bool _pInfraFlag;
+	/** Player's direction when ending movement. Also used for casting direction of SPL_FIREWALL. */
+	Direction tempDirection;
+
+	bool _pLvlVisited[NUMLEVELS];
+	bool _pSLvlVisited[NUMLEVELS]; // only 10 used
+
 	item_misc_id _pOilType;
 	uint8_t pTownWarps;
 	uint8_t pDungMsgs;
@@ -350,12 +363,10 @@ struct Player {
 	bool pManaShield;
 	uint8_t pDungMsgs2;
 	bool pOriginalCathedral;
-	uint16_t wReflections;
 	uint8_t pDiabloKillLevel;
+	uint16_t wReflections;
 	_difficulty pDifficulty;
 	ItemSpecialEffectHf pDamAcFlags;
-	/** @brief Specifies whether players are in non-PvP mode. */
-	bool friendlyMode = true;
 
 	void CalcScrolls();
 

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -38,11 +38,16 @@ enum _talker_id : uint8_t {
 struct Towner {
 	OptionalOwnedClxSpriteList ownedAnim;
 	OptionalClxSpriteList anim;
+	/** Specifies the animation frame sequence. */
+	const uint8_t *animOrder; // unowned
+	void (*talk)(Player &player, Towner &towner);
 
-	/** Used to get a voice line and text related to active quests when the player speaks to a town npc */
-	int16_t seed;
+	string_view name;
+
 	/** Tile position of NPC */
 	Point position;
+	/** Used to get a voice line and text related to active quests when the player speaks to a town npc */
+	int16_t seed;
 	uint16_t _tAnimWidth;
 	/** Tick length of each frame in the current animation */
 	int16_t _tAnimDelay;
@@ -53,11 +58,7 @@ struct Towner {
 	/** Current frame of animation. */
 	uint8_t _tAnimFrame;
 	uint8_t _tAnimFrameCnt;
-	string_view name;
-	/** Specifies the animation frame sequence. */
-	const uint8_t *animOrder; // unowned
-	std::size_t animOrderSize;
-	void (*talk)(Player &player, Towner &towner);
+	uint8_t animOrderSize;
 	_talker_id _ttype;
 
 	ClxSprite currentSprite() const


### PR DESCRIPTION
[`pahole`](https://linux.die.net/man/1/pahole) showed a few simple reorderings to reduce struct sizes:

```
pahole --reorganize --show_reorg_steps --show_only_data_members -C AnimationInfo build/devilutionx
```

This PR also changes a couple of members to a smaller size.

This leads to significant reduction in the overall size of compound structs, e.g. `Player`: 18,304 bytes -> 16,848 bytes.
`Monster`: 112 -> 104