### PR TITLE
Add padmapper for gamepad customization

### DIFF
--- a/Source/controls/controller.cpp
+++ b/Source/controls/controller.cpp
@@ -75,10 +75,8 @@ bool IsControllerButtonPressed(ControllerButton button)
 
 bool IsControllerButtonComboPressed(ControllerButtonCombo combo)
 {
-	bool comboPressed = IsControllerButtonPressed(combo.button);
-	if (combo.modifier != ControllerButton_NONE)
-		comboPressed = comboPressed && IsControllerButtonPressed(combo.modifier);
-	return comboPressed;
+	return IsControllerButtonPressed(combo.button)
+	    && (combo.modifier == ControllerButton_NONE || IsControllerButtonPressed(combo.modifier));
 }
 
 bool HandleControllerAddedOrRemovedEvent(const SDL_Event &event)

--- a/Source/controls/controller.cpp
+++ b/Source/controls/controller.cpp
@@ -73,6 +73,14 @@ bool IsControllerButtonPressed(ControllerButton button)
 	return Joystick::IsPressedOnAnyJoystick(button);
 }
 
+bool IsControllerButtonComboPressed(ControllerButtonCombo combo)
+{
+	bool comboPressed = IsControllerButtonPressed(combo.button);
+	if (combo.modifier != ControllerButton_NONE)
+		comboPressed = comboPressed && IsControllerButtonPressed(combo.modifier);
+	return comboPressed;
+}
+
 bool HandleControllerAddedOrRemovedEvent(const SDL_Event &event)
 {
 #ifndef USE_SDL1

--- a/Source/controls/controller.h
+++ b/Source/controls/controller.h
@@ -17,6 +17,7 @@ void UnlockControllerState(const SDL_Event &event);
 ControllerButtonEvent ToControllerButtonEvent(const SDL_Event &event);
 
 bool IsControllerButtonPressed(ControllerButton button);
+bool IsControllerButtonComboPressed(ControllerButtonCombo combo);
 
 bool HandleControllerAddedOrRemovedEvent(const SDL_Event &event);
 

--- a/Source/controls/controller_buttons.h
+++ b/Source/controls/controller_buttons.h
@@ -2,6 +2,7 @@
 // Unifies joystick, gamepad, and keyboard controller APIs.
 
 #include <cstdint>
+#include <functional>
 
 #include "utils/stdcompat/string_view.hpp"
 
@@ -28,6 +29,29 @@ enum ControllerButton : uint8_t {
 	ControllerButton_BUTTON_DPAD_DOWN,
 	ControllerButton_BUTTON_DPAD_LEFT,
 	ControllerButton_BUTTON_DPAD_RIGHT
+};
+
+struct ControllerButtonCombo {
+	constexpr ControllerButtonCombo()
+	    : modifier(ControllerButton_NONE)
+	    , button(ControllerButton_NONE)
+	{
+	}
+
+	constexpr ControllerButtonCombo(ControllerButton button)
+	    : modifier(ControllerButton_NONE)
+	    , button(button)
+	{
+	}
+
+	constexpr ControllerButtonCombo(ControllerButton modifier, ControllerButton button)
+	    : modifier(modifier)
+	    , button(button)
+	{
+	}
+
+	ControllerButton modifier;
+	ControllerButton button;
 };
 
 inline bool IsDPadButton(ControllerButton button)

--- a/Source/controls/controller_motion.cpp
+++ b/Source/controls/controller_motion.cpp
@@ -16,7 +16,7 @@
 
 namespace devilution {
 
-bool SimulatingMouseWithSelectAndDPad;
+bool SimulatingMouseWithPadmapper;
 
 namespace {
 
@@ -66,11 +66,11 @@ void ScaleJoystickAxes(float *x, float *y, float deadzone)
 	}
 }
 
-void SetSimulatingMouseWithDpad(bool value)
+void SetSimulatingMouseWithPadmapper(bool value)
 {
-	if (SimulatingMouseWithSelectAndDPad == value)
+	if (SimulatingMouseWithPadmapper == value)
 		return;
-	SimulatingMouseWithSelectAndDPad = value;
+	SimulatingMouseWithPadmapper = value;
 	if (value) {
 		LogVerbose("Control: begin simulating mouse with D-Pad");
 	} else {
@@ -81,65 +81,26 @@ void SetSimulatingMouseWithDpad(bool value)
 // SELECT + D-Pad to simulate right stick movement.
 bool SimulateRightStickWithDpad(ControllerButtonEvent ctrlEvent)
 {
-	if (sgOptions.Controller.bDpadHotkeys)
-		return false;
-	if (ctrlEvent.button == ControllerButton_NONE || ctrlEvent.button == ControllerButton_IGNORE)
-		return false;
-	if (ctrlEvent.button == ControllerButton_BUTTON_BACK) {
-		if (SimulatingMouseWithSelectAndDPad) {
-			if (ctrlEvent.up) {
-				rightStickX = rightStickY = 0;
-			}
-			return true;
-		}
-		return false;
-	}
+	ControllerButtonCombo upCombo = sgOptions.Padmapper.ButtonComboForAction("MouseUp");
+	ControllerButtonCombo downCombo = sgOptions.Padmapper.ButtonComboForAction("MouseDown");
+	ControllerButtonCombo leftCombo = sgOptions.Padmapper.ButtonComboForAction("MouseLeft");
+	ControllerButtonCombo rightCombo = sgOptions.Padmapper.ButtonComboForAction("MouseRight");
 
-	if (!IsControllerButtonPressed(ControllerButton_BUTTON_BACK)) {
-		SetSimulatingMouseWithDpad(false);
-		return false;
-	}
-	switch (ctrlEvent.button) {
-	case ControllerButton_BUTTON_DPAD_LEFT:
-		if (ctrlEvent.up) {
-			rightStickX = 0;
-		} else {
-			rightStickX = -1.F;
-			SetSimulatingMouseWithDpad(true);
-		}
-		break;
-	case ControllerButton_BUTTON_DPAD_RIGHT:
-		if (ctrlEvent.up) {
-			rightStickX = 0;
-		} else {
-			rightStickX = 1.F;
-			SetSimulatingMouseWithDpad(true);
-		}
-		break;
-	case ControllerButton_BUTTON_DPAD_UP:
-		if (ctrlEvent.up) {
-			rightStickY = 0;
-		} else {
-			rightStickY = 1.F;
-			SetSimulatingMouseWithDpad(true);
-		}
-		break;
-	case ControllerButton_BUTTON_DPAD_DOWN:
-		if (ctrlEvent.up) {
-			rightStickY = 0;
-		} else {
-			rightStickY = -1.F;
-			SetSimulatingMouseWithDpad(true);
-		}
-		break;
-	default:
-		if (!IsSimulatedMouseClickBinding(ctrlEvent)) {
-			SetSimulatingMouseWithDpad(false);
-		}
-		return false;
-	}
+	int simulatedRightStickX = 0;
+	int simulatedRightStickY = 0;
+	if (IsControllerButtonComboPressed(upCombo))
+		simulatedRightStickY += 1;
+	if (IsControllerButtonComboPressed(downCombo))
+		simulatedRightStickY -= 1;
+	if (IsControllerButtonComboPressed(leftCombo))
+		simulatedRightStickX -= 1;
+	if (IsControllerButtonComboPressed(rightCombo))
+		simulatedRightStickX += 1;
+	SetSimulatingMouseWithPadmapper(simulatedRightStickX != 0 || simulatedRightStickY != 0);
 
-	return true;
+	rightStickX += simulatedRightStickX;
+	rightStickY += simulatedRightStickY;
+	return SimulatingMouseWithPadmapper && IsAnyOf(ctrlEvent.button, upCombo.button, downCombo.button, leftCombo.button, rightCombo.button);
 }
 
 } // namespace
@@ -179,14 +140,14 @@ bool ProcessControllerMotion(const SDL_Event &event, ControllerButtonEvent ctrlE
 	GameController *const controller = GameController::Get(event);
 	if (controller != nullptr && devilution::GameController::ProcessAxisMotion(event)) {
 		ScaleJoysticks();
-		SetSimulatingMouseWithDpad(false);
+		SetSimulatingMouseWithPadmapper(false);
 		return true;
 	}
 #endif
 	Joystick *const joystick = Joystick::Get(event);
 	if (joystick != nullptr && devilution::Joystick::ProcessAxisMotion(event)) {
 		ScaleJoysticks();
-		SetSimulatingMouseWithDpad(false);
+		SetSimulatingMouseWithPadmapper(false);
 		return true;
 	}
 #if HAS_KBCTRL == 1
@@ -198,19 +159,33 @@ bool ProcessControllerMotion(const SDL_Event &event, ControllerButtonEvent ctrlE
 	return SimulateRightStickWithDpad(ctrlEvent);
 }
 
-AxisDirection GetLeftStickOrDpadDirection(bool allowDpad)
+AxisDirection GetLeftStickOrDpadDirection(bool usePadmapper)
 {
 	const float stickX = leftStickX;
 	const float stickY = leftStickY;
 
 	AxisDirection result { AxisDirectionX_NONE, AxisDirectionY_NONE };
 
-	allowDpad = allowDpad && !IsControllerButtonPressed(ControllerButton_BUTTON_START);
+	bool isUpPressed = stickY >= 0.5;
+	bool isDownPressed = stickY <= -0.5;
+	bool isLeftPressed = stickX <= -0.5;
+	bool isRightPressed = stickX >= 0.5;
 
-	bool isUpPressed = stickY >= 0.5 || (allowDpad && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_UP));
-	bool isDownPressed = stickY <= -0.5 || (allowDpad && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_DOWN));
-	bool isLeftPressed = stickX <= -0.5 || (allowDpad && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_LEFT));
-	bool isRightPressed = stickX >= 0.5 || (allowDpad && IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_RIGHT));
+	if (usePadmapper) {
+		ControllerButtonCombo upCombo = sgOptions.Padmapper.ButtonComboForAction("MoveUp");
+		ControllerButtonCombo downCombo = sgOptions.Padmapper.ButtonComboForAction("MoveDown");
+		ControllerButtonCombo leftCombo = sgOptions.Padmapper.ButtonComboForAction("MoveLeft");
+		ControllerButtonCombo rightCombo = sgOptions.Padmapper.ButtonComboForAction("MoveRight");
+		isUpPressed |= IsControllerButtonComboPressed(upCombo);
+		isDownPressed |= IsControllerButtonComboPressed(downCombo);
+		isLeftPressed |= IsControllerButtonComboPressed(leftCombo);
+		isRightPressed |= IsControllerButtonComboPressed(rightCombo);
+	} else {
+		isUpPressed |= IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_UP);
+		isDownPressed |= IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_DOWN);
+		isLeftPressed |= IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_LEFT);
+		isRightPressed |= IsControllerButtonPressed(ControllerButton_BUTTON_DPAD_RIGHT);
+	}
 
 #ifndef USE_SDL1
 	if (ControlMode == ControlTypes::VirtualGamepad) {

--- a/Source/controls/controller_motion.h
+++ b/Source/controls/controller_motion.h
@@ -10,7 +10,7 @@
 namespace devilution {
 
 // Whether we're currently simulating the mouse with SELECT + D-Pad.
-extern bool SimulatingMouseWithSelectAndDPad;
+extern bool SimulatingMouseWithPadmapper;
 
 // Raw axis values.
 extern float leftStickXUnscaled, leftStickYUnscaled, rightStickXUnscaled, rightStickYUnscaled;
@@ -25,6 +25,6 @@ extern bool leftStickNeedsScaling, rightStickNeedsScaling;
 bool ProcessControllerMotion(const SDL_Event &event, ControllerButtonEvent ctrlEvent);
 
 // Returns direction of the left thumb stick or DPad (if allow_dpad = true).
-AxisDirection GetLeftStickOrDpadDirection(bool allowDpad = true);
+AxisDirection GetLeftStickOrDpadDirection(bool usePadmapper);
 
 } // namespace devilution

--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -2,47 +2,57 @@
 
 #include <cstdint>
 
-#include "controls/controller.h"
 #include "controls/controller_motion.h"
 #include "miniwin/misc_msg.h"
 #ifndef USE_SDL1
 #include "controls/devices/game_controller.h"
 #endif
 #include "controls/devices/joystick.h"
-#include "controls/menu_controls.h"
-#include "controls/modifier_hints.h"
 #include "controls/plrctrls.h"
 #include "controls/touch/gamepad.h"
 #include "doom.h"
 #include "gmenu.h"
 #include "options.h"
-#include "qol/stash.h"
 #include "stores.h"
 
 namespace devilution {
 
-bool start_modifier_active = false;
-bool select_modifier_active = false;
-const ControllerButton ControllerButtonPrimary = ControllerButton_BUTTON_B;
-const ControllerButton ControllerButtonSecondary = ControllerButton_BUTTON_Y;
-const ControllerButton ControllerButtonTertiary = ControllerButton_BUTTON_X;
+bool PadMenuNavigatorActive = false;
+bool PadHotspellMenuActive = false;
+ControllerButton SuppressedButton = ControllerButton_NONE;
 
 namespace {
 
-SDL_Keycode TranslateControllerButtonToKey(ControllerButton controllerButton)
+SDL_Keycode TranslateControllerButtonToGameMenuKey(ControllerButton controllerButton)
 {
-	switch (controllerButton) {
-	case ControllerButton_BUTTON_A: // Bottom button
-		return QuestLogIsOpen ? SDLK_SPACE : SDLK_ESCAPE;
-	case ControllerButton_BUTTON_B: // Right button
-		return (sgpCurrentMenu != nullptr || stextflag != STORE_NONE || QuestLogIsOpen) ? SDLK_RETURN : SDLK_SPACE;
-	case ControllerButton_BUTTON_Y: // Top button
-		return SDLK_RETURN;
-	case ControllerButton_BUTTON_LEFTSTICK:
-		return SDLK_TAB; // Map
+	switch (TranslateTo(GamepadType, controllerButton)) {
+	case ControllerButton_BUTTON_A:
 	case ControllerButton_BUTTON_BACK:
 	case ControllerButton_BUTTON_START:
 		return SDLK_ESCAPE;
+	case ControllerButton_BUTTON_B:
+	case ControllerButton_BUTTON_Y:
+		return SDLK_RETURN;
+	case ControllerButton_BUTTON_LEFTSTICK:
+		return SDLK_TAB; // Map
+	default:
+		return SDLK_UNKNOWN;
+	}
+}
+
+SDL_Keycode TranslateControllerButtonToMenuKey(ControllerButton controllerButton)
+{
+	switch (TranslateTo(GamepadType, controllerButton)) {
+	case ControllerButton_BUTTON_A:
+	case ControllerButton_BUTTON_BACK:
+	case ControllerButton_BUTTON_START:
+		return SDLK_ESCAPE;
+	case ControllerButton_BUTTON_B:
+		return SDLK_SPACE;
+	case ControllerButton_BUTTON_Y:
+		return SDLK_RETURN;
+	case ControllerButton_BUTTON_LEFTSTICK:
+		return SDLK_TAB; // Map
 	case ControllerButton_BUTTON_DPAD_LEFT:
 		return SDLK_LEFT;
 	case ControllerButton_BUTTON_DPAD_RIGHT:
@@ -56,50 +66,72 @@ SDL_Keycode TranslateControllerButtonToKey(ControllerButton controllerButton)
 	}
 }
 
-bool HandleStartAndSelect(const ControllerButtonEvent &ctrlEvent, GameAction *action)
+SDL_Keycode TranslateControllerButtonToQuestLogKey(ControllerButton controllerButton)
 {
-	const bool inGameMenu = InGameMenu();
-
-	const bool startIsDown = IsControllerButtonPressed(ControllerButton_BUTTON_START);
-	const bool selectIsDown = IsControllerButtonPressed(ControllerButton_BUTTON_BACK);
-	start_modifier_active = !inGameMenu && startIsDown;
-	select_modifier_active = !inGameMenu && selectIsDown && !start_modifier_active;
-
-	// Tracks whether we've received both START and SELECT down events.
-	//
-	// Using `IsControllerButtonPressed()` for this would be incorrect.
-	// If both buttons are pressed simultaneously, SDL sends 2 events for which both buttons are in the pressed state.
-	// This allows us to avoid triggering START+SELECT action twice in this case.
-	static bool startDownReceived = false;
-	static bool selectDownReceived = false;
-	switch (ctrlEvent.button) {
-	case ControllerButton_BUTTON_BACK:
-		selectDownReceived = !ctrlEvent.up;
-		break;
-	case ControllerButton_BUTTON_START:
-		startDownReceived = !ctrlEvent.up;
-		break;
+	switch (TranslateTo(GamepadType, controllerButton)) {
+	case ControllerButton_BUTTON_A:
+		return SDLK_SPACE;
+	case ControllerButton_BUTTON_B:
+	case ControllerButton_BUTTON_Y:
+		return SDLK_RETURN;
+	case ControllerButton_BUTTON_LEFTSTICK:
+		return SDLK_TAB; // Map
 	default:
-		return false;
+		return SDLK_UNKNOWN;
 	}
+}
 
-	if (startDownReceived && selectDownReceived) {
-		*action = GameActionSendKey { SDLK_ESCAPE, ctrlEvent.up };
-		return true;
+SDL_Keycode TranslateControllerButtonToSpellbookKey(ControllerButton controllerButton)
+{
+	switch (TranslateTo(GamepadType, controllerButton)) {
+	case ControllerButton_BUTTON_B:
+		return SDLK_SPACE;
+	case ControllerButton_BUTTON_Y:
+		return SDLK_RETURN;
+	case ControllerButton_BUTTON_LEFTSTICK:
+		return SDLK_TAB; // Map
+	case ControllerButton_BUTTON_DPAD_LEFT:
+		return SDLK_LEFT;
+	case ControllerButton_BUTTON_DPAD_RIGHT:
+		return SDLK_RIGHT;
+	case ControllerButton_BUTTON_DPAD_UP:
+		return SDLK_UP;
+	case ControllerButton_BUTTON_DPAD_DOWN:
+		return SDLK_DOWN;
+	default:
+		return SDLK_UNKNOWN;
 	}
-
-	if (inGameMenu && (startIsDown || selectIsDown) && !ctrlEvent.up) {
-		// If both are down, do nothing because `both_received` will trigger soon.
-		if (startIsDown && selectIsDown)
-			return true;
-		*action = GameActionSendKey { SDLK_ESCAPE, ctrlEvent.up };
-		return true;
-	}
-
-	return false;
 }
 
 } // namespace
+
+ControllerButton TranslateTo(GamepadLayout layout, ControllerButton button)
+{
+	if (layout != GamepadLayout::Nintendo)
+		return button;
+
+	switch (button) {
+	case ControllerButton_BUTTON_A:
+		return ControllerButton_BUTTON_B;
+	case ControllerButton_BUTTON_B:
+		return ControllerButton_BUTTON_A;
+	case ControllerButton_BUTTON_X:
+		return ControllerButton_BUTTON_Y;
+	case ControllerButton_BUTTON_Y:
+		return ControllerButton_BUTTON_X;
+	default:
+		return button;
+	}
+}
+
+bool SkipsMovie(ControllerButtonEvent ctrlEvent)
+{
+	return IsAnyOf(ctrlEvent.button,
+	    ControllerButton_BUTTON_A,
+	    ControllerButton_BUTTON_B,
+	    ControllerButton_BUTTON_START,
+	    ControllerButton_BUTTON_BACK);
+}
 
 bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, GameAction *action)
 {
@@ -127,8 +159,8 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, Game
 			if (VirtualGamepadState.primaryActionButton.isHeld && VirtualGamepadState.primaryActionButton.didStateChange) {
 				if (!inGameMenu && !QuestLogIsOpen && !sbookflag) {
 					*action = GameAction(GameActionType_PRIMARY_ACTION);
-					if (ControllerButtonHeld == ControllerButton_NONE) {
-						ControllerButtonHeld = ControllerButtonPrimary;
+					if (ControllerActionHeld == GameActionType_NONE) {
+						ControllerActionHeld = GameActionType_PRIMARY_ACTION;
 					}
 				} else if (sgpCurrentMenu != nullptr || stextflag != STORE_NONE || QuestLogIsOpen) {
 					*action = GameActionSendKey { SDLK_RETURN, false };
@@ -140,16 +172,16 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, Game
 			if (VirtualGamepadState.secondaryActionButton.isHeld && VirtualGamepadState.secondaryActionButton.didStateChange) {
 				if (!inGameMenu && !QuestLogIsOpen && !sbookflag) {
 					*action = GameAction(GameActionType_SECONDARY_ACTION);
-					if (ControllerButtonHeld == ControllerButton_NONE)
-						ControllerButtonHeld = ControllerButtonSecondary;
+					if (ControllerActionHeld == GameActionType_NONE)
+						ControllerActionHeld = GameActionType_SECONDARY_ACTION;
 				}
 				return true;
 			}
 			if (VirtualGamepadState.spellActionButton.isHeld && VirtualGamepadState.spellActionButton.didStateChange) {
 				if (!inGameMenu && !QuestLogIsOpen && !sbookflag) {
 					*action = GameAction(GameActionType_CAST_SPELL);
-					if (ControllerButtonHeld == ControllerButton_NONE)
-						ControllerButtonHeld = ControllerButtonTertiary;
+					if (ControllerActionHeld == GameActionType_NONE)
+						ControllerActionHeld = GameActionType_CAST_SPELL;
 				}
 				return true;
 			}
@@ -177,288 +209,53 @@ bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, Game
 				return true;
 			}
 		} else if (event.type == SDL_FINGERUP) {
-			if ((!VirtualGamepadState.primaryActionButton.isHeld && ControllerButtonHeld == ControllerButtonPrimary)
-			    || (!VirtualGamepadState.secondaryActionButton.isHeld && ControllerButtonHeld == ControllerButtonSecondary)
-			    || (!VirtualGamepadState.spellActionButton.isHeld && ControllerButtonHeld == ControllerButtonTertiary)) {
-				ControllerButtonHeld = ControllerButton_NONE;
+			if ((!VirtualGamepadState.primaryActionButton.isHeld && ControllerActionHeld == GameActionType_PRIMARY_ACTION)
+			    || (!VirtualGamepadState.secondaryActionButton.isHeld && ControllerActionHeld == GameActionType_SECONDARY_ACTION)
+			    || (!VirtualGamepadState.spellActionButton.isHeld && ControllerActionHeld == GameActionType_CAST_SPELL)) {
+				ControllerActionHeld = GameActionType_NONE;
 				LastMouseButtonAction = MouseActionType::None;
 			}
 		}
 	}
 #endif
-	if (IsStashOpen && ctrlEvent.button == ControllerButton_BUTTON_BACK) {
-		StartGoldWithdraw();
+
+	if (PadMenuNavigatorActive || PadHotspellMenuActive)
 		return false;
-	}
 
-	if (HandleStartAndSelect(ctrlEvent, action))
-		return true;
+	SDL_Keycode translation = SDLK_UNKNOWN;
 
-	// Stick clicks simulate the mouse both in menus and in-game.
-	switch (ctrlEvent.button) {
-	case ControllerButton_BUTTON_LEFTSTICK:
-		if (select_modifier_active) {
-			if (!IsAutomapActive())
-				*action = GameActionSendKey { SDL_BUTTON_LEFT | KeymapperMouseButtonMask, ctrlEvent.up };
-			return true;
-		}
-		break;
-	case ControllerButton_BUTTON_RIGHTSTICK:
-		if (!IsAutomapActive()) {
-			if (IsControllerButtonPressed(ControllerButton_BUTTON_BACK))
-				*action = GameActionSendKey { SDL_BUTTON_RIGHT | KeymapperMouseButtonMask, ctrlEvent.up };
-			else
-				*action = GameActionSendKey { SDL_BUTTON_LEFT | KeymapperMouseButtonMask, ctrlEvent.up };
-		}
-		return true;
-	default:
-		break;
-	}
+	if (gmenu_is_active() || stextflag != STORE_NONE)
+		translation = TranslateControllerButtonToGameMenuKey(ctrlEvent.button);
+	else if (inGameMenu)
+		translation = TranslateControllerButtonToMenuKey(ctrlEvent.button);
+	else if (QuestLogIsOpen)
+		translation = TranslateControllerButtonToQuestLogKey(ctrlEvent.button);
+	else if (sbookflag)
+		translation = TranslateControllerButtonToSpellbookKey(ctrlEvent.button);
 
-	if (!inGameMenu) {
-		switch (ctrlEvent.button) {
-		case ControllerButton_BUTTON_LEFTSHOULDER:
-			if ((select_modifier_active && !sgOptions.Controller.bSwapShoulderButtonMode) || (sgOptions.Controller.bSwapShoulderButtonMode && !select_modifier_active)) {
-				if (!IsAutomapActive())
-					*action = GameActionSendKey { SDL_BUTTON_LEFT | KeymapperMouseButtonMask, ctrlEvent.up };
-				return true;
-			}
-			break;
-		case ControllerButton_BUTTON_RIGHTSHOULDER:
-			if ((select_modifier_active && !sgOptions.Controller.bSwapShoulderButtonMode) || (sgOptions.Controller.bSwapShoulderButtonMode && !select_modifier_active)) {
-				if (!IsAutomapActive())
-					*action = GameActionSendKey { SDL_BUTTON_RIGHT | KeymapperMouseButtonMask, ctrlEvent.up };
-				return true;
-			}
-			break;
-		case ControllerButton_AXIS_TRIGGERLEFT: // ZL (aka L2)
-			if (!ctrlEvent.up) {
-				if (select_modifier_active)
-					*action = GameAction(GameActionType_TOGGLE_QUEST_LOG);
-				else
-					*action = GameAction(GameActionType_TOGGLE_CHARACTER_INFO);
-			}
-			return true;
-		case ControllerButton_AXIS_TRIGGERRIGHT: // ZR (aka R2)
-			if (!ctrlEvent.up) {
-				if (select_modifier_active)
-					*action = GameAction(GameActionType_TOGGLE_SPELL_BOOK);
-				else
-					*action = GameAction(GameActionType_TOGGLE_INVENTORY);
-			}
-			return true;
-		case ControllerButton_IGNORE:
-		case ControllerButton_BUTTON_START:
-		case ControllerButton_BUTTON_BACK:
-			return true;
-		default:
-			break;
-		}
-		if (sgOptions.Controller.bDpadHotkeys) {
-			switch (ctrlEvent.button) {
-			case ControllerButton_BUTTON_DPAD_UP:
-				if (IsControllerButtonPressed(ControllerButton_BUTTON_BACK))
-					*action = GameActionSendKey { sgOptions.Keymapper.KeyForAction("QuickSpell2"), ctrlEvent.up };
-				else
-					*action = GameActionSendKey { SDLK_ESCAPE, ctrlEvent.up };
-				return true;
-			case ControllerButton_BUTTON_DPAD_RIGHT:
-				if (IsControllerButtonPressed(ControllerButton_BUTTON_BACK))
-					*action = GameActionSendKey { sgOptions.Keymapper.KeyForAction("QuickSpell4"), ctrlEvent.up };
-				else if (!ctrlEvent.up)
-					*action = GameAction(GameActionType_TOGGLE_INVENTORY);
-				return true;
-			case ControllerButton_BUTTON_DPAD_DOWN:
-				if (IsControllerButtonPressed(ControllerButton_BUTTON_BACK))
-					*action = GameActionSendKey { sgOptions.Keymapper.KeyForAction("QuickSpell3"), ctrlEvent.up };
-				else
-					*action = GameActionSendKey { SDLK_TAB, ctrlEvent.up };
-				return true;
-			case ControllerButton_BUTTON_DPAD_LEFT:
-				if (IsControllerButtonPressed(ControllerButton_BUTTON_BACK))
-					*action = GameActionSendKey { sgOptions.Keymapper.KeyForAction("QuickSpell1"), ctrlEvent.up };
-				else if (!ctrlEvent.up)
-					*action = GameAction(GameActionType_TOGGLE_CHARACTER_INFO);
-				return true;
-			default:
-				break;
-			}
-		}
-		if (start_modifier_active) {
-			switch (ctrlEvent.button) {
-			case ControllerButton_BUTTON_DPAD_UP:
-				*action = GameActionSendKey { SDLK_ESCAPE, ctrlEvent.up };
-				return true;
-			case ControllerButton_BUTTON_DPAD_RIGHT:
-				if (!ctrlEvent.up)
-					*action = GameAction(GameActionType_TOGGLE_INVENTORY);
-				return true;
-			case ControllerButton_BUTTON_DPAD_DOWN:
-				*action = GameActionSendKey { SDLK_TAB, ctrlEvent.up };
-				return true;
-			case ControllerButton_BUTTON_DPAD_LEFT:
-				if (!ctrlEvent.up)
-					*action = GameAction(GameActionType_TOGGLE_CHARACTER_INFO);
-				return true;
-			case ControllerButton_BUTTON_Y: // Top button
-#ifdef __3DS__
-				if (!ctrlEvent.up) {
-					sgOptions.Graphics.zoom.SetValue(!*sgOptions.Graphics.zoom);
-					CalcViewportGeometry();
-				}
-#else
-				/* Not mapped. Reserved for future use. */
-#endif
-				return true;
-			case ControllerButton_BUTTON_B: // Right button
-				// Not mapped. TODO: map to attack in place.
-				return true;
-			case ControllerButton_BUTTON_A: // Bottom button
-				if (!ctrlEvent.up)
-					*action = GameAction(GameActionType_TOGGLE_SPELL_BOOK);
-				return true;
-			case ControllerButton_BUTTON_X: // Left button
-				if (!ctrlEvent.up)
-					*action = GameAction(GameActionType_TOGGLE_QUEST_LOG);
-				return true;
-			case ControllerButton_BUTTON_LEFTSHOULDER:
-				if (!ctrlEvent.up)
-					*action = GameAction(GameActionType_TOGGLE_CHARACTER_INFO);
-				return true;
-			case ControllerButton_BUTTON_RIGHTSHOULDER:
-				if (!ctrlEvent.up)
-					*action = GameAction(GameActionType_TOGGLE_INVENTORY);
-				return true;
-			default:
-				return true;
-			}
-		}
-
-		// Bottom button: Closes menus or opens quick spell book if nothing is open.
-		if (ctrlEvent.button == ControllerButton_BUTTON_A) { // Bottom button
-			if (ctrlEvent.up)
-				return true;
-			if (IsControllerButtonPressed(ControllerButton_BUTTON_BACK))
-				*action = GameActionSendKey { sgOptions.Keymapper.KeyForAction("QuickSpell3"), ctrlEvent.up };
-			else if (DoomFlag)
-				*action = GameActionSendKey { SDLK_ESCAPE, ctrlEvent.up };
-			else if (invflag)
-				*action = GameAction(GameActionType_TOGGLE_INVENTORY);
-			else if (sbookflag)
-				*action = GameAction(GameActionType_TOGGLE_SPELL_BOOK);
-			else if (QuestLogIsOpen)
-				*action = GameAction(GameActionType_TOGGLE_QUEST_LOG);
-			else if (chrflag)
-				*action = GameAction(GameActionType_TOGGLE_CHARACTER_INFO);
-			else
-				*action = GameAction(GameActionType_TOGGLE_QUICK_SPELL_MENU);
-			return true;
-		}
-
-		if (!QuestLogIsOpen && !sbookflag) {
-			switch (ctrlEvent.button) {
-			case ControllerButton_IGNORE:
-				return true;
-			case ControllerButton_BUTTON_B: // Right button
-				if (!ctrlEvent.up) {
-					if (IsControllerButtonPressed(ControllerButton_BUTTON_BACK))
-						*action = GameActionSendKey { sgOptions.Keymapper.KeyForAction("QuickSpell4"), ctrlEvent.up };
-					else
-						*action = GameAction(GameActionType_PRIMARY_ACTION);
-				}
-				return true;
-			case ControllerButton_BUTTON_Y: // Top button
-				if (!ctrlEvent.up) {
-					if (IsControllerButtonPressed(ControllerButton_BUTTON_BACK))
-						*action = GameActionSendKey { sgOptions.Keymapper.KeyForAction("QuickSpell2"), ctrlEvent.up };
-					else
-						*action = GameAction(GameActionType_SECONDARY_ACTION);
-				}
-				return true;
-			case ControllerButton_BUTTON_X: // Left button
-				if (!ctrlEvent.up) {
-					if (IsControllerButtonPressed(ControllerButton_BUTTON_BACK))
-						*action = GameActionSendKey { sgOptions.Keymapper.KeyForAction("QuickSpell1"), ctrlEvent.up };
-					else
-						*action = GameAction(GameActionType_CAST_SPELL);
-				}
-				return true;
-			case ControllerButton_BUTTON_LEFTSHOULDER:
-				if (stextflag == STORE_NONE && !ctrlEvent.up)
-					*action = GameAction(GameActionType_USE_HEALTH_POTION);
-				return true;
-			case ControllerButton_BUTTON_RIGHTSHOULDER:
-				if (stextflag == STORE_NONE && !ctrlEvent.up)
-					*action = GameAction(GameActionType_USE_MANA_POTION);
-				return true;
-			case ControllerButton_BUTTON_DPAD_UP:
-			case ControllerButton_BUTTON_DPAD_DOWN:
-			case ControllerButton_BUTTON_DPAD_LEFT:
-			case ControllerButton_BUTTON_DPAD_RIGHT:
-				// The rest of D-Pad actions are handled in charMovement() on every game_logic() call.
-				return true;
-			default:
-				break;
-			}
-		}
-
-		if (ctrlEvent.button == ControllerButton_BUTTON_BACK) {
-			return true; // Ignore mod button
-		}
-	}
-
-	// DPad navigation is handled separately for these.
-	if (gmenu_is_active() || QuestLogIsOpen || stextflag != STORE_NONE) {
-		switch (ctrlEvent.button) {
-		case ControllerButton_BUTTON_DPAD_UP:
-		case ControllerButton_BUTTON_DPAD_DOWN:
-		case ControllerButton_BUTTON_DPAD_LEFT:
-		case ControllerButton_BUTTON_DPAD_RIGHT:
-			return true;
-		default:
-			break;
-		}
-	}
-
-	// By default, map to a keyboard key.
-	if (ctrlEvent.button != ControllerButton_NONE) {
-		*action = GameActionSendKey { static_cast<uint32_t>(TranslateControllerButtonToKey(ctrlEvent.button)),
-			ctrlEvent.up };
+	if (translation != SDLK_UNKNOWN) {
+		*action = GameActionSendKey { static_cast<uint32_t>(translation), ctrlEvent.up };
 		return true;
 	}
-
-#ifndef USE_SDL1
-	// Ignore unhandled joystick events where a GameController is open for this joystick.
-	// This is because SDL sends both game controller and joystick events in this case.
-	const Joystick *const joystick = Joystick::Get(event);
-	if (joystick != nullptr && GameController::Get(joystick->instance_id()) != nullptr) {
-		return true;
-	}
-	if (event.type == SDL_CONTROLLERAXISMOTION) {
-		return true; // Ignore releasing the trigger buttons
-	}
-#endif
 
 	return false;
 }
 
 bool IsSimulatedMouseClickBinding(ControllerButtonEvent ctrlEvent)
 {
-	switch (ctrlEvent.button) {
-	case ControllerButton_BUTTON_LEFTSTICK:
-	case ControllerButton_BUTTON_LEFTSHOULDER:
-	case ControllerButton_BUTTON_RIGHTSHOULDER:
-		return select_modifier_active;
-	case ControllerButton_BUTTON_RIGHTSTICK:
-		return true;
-	default:
-		return false;
-	}
+	ControllerButtonCombo leftMouseClickBinding1 = sgOptions.Padmapper.ButtonComboForAction("LeftMouseClick1");
+	ControllerButtonCombo leftMouseClickBinding2 = sgOptions.Padmapper.ButtonComboForAction("LeftMouseClick2");
+	ControllerButtonCombo rightMouseClickBinding1 = sgOptions.Padmapper.ButtonComboForAction("RightMouseClick1");
+	ControllerButtonCombo rightMouseClickBinding2 = sgOptions.Padmapper.ButtonComboForAction("RightMouseClick2");
+	return (ctrlEvent.button == leftMouseClickBinding1.button && IsControllerButtonComboPressed(leftMouseClickBinding1))
+	    || (ctrlEvent.button == leftMouseClickBinding2.button && IsControllerButtonComboPressed(leftMouseClickBinding2))
+	    || (ctrlEvent.button == rightMouseClickBinding1.button && IsControllerButtonComboPressed(rightMouseClickBinding1))
+	    || (ctrlEvent.button == rightMouseClickBinding2.button && IsControllerButtonComboPressed(rightMouseClickBinding2));
 }
 
 AxisDirection GetMoveDirection()
 {
-	return GetLeftStickOrDpadDirection(/*allowDpad=*/!sgOptions.Controller.bDpadHotkeys);
+	return GetLeftStickOrDpadDirection(true);
 }
 
 } // namespace devilution

--- a/Source/controls/game_controls.h
+++ b/Source/controls/game_controls.h
@@ -62,11 +62,12 @@ struct GameAction {
 ControllerButton TranslateTo(GamepadLayout layout, ControllerButton button);
 
 bool SkipsMovie(ControllerButtonEvent ctrlEvent);
-bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, GameAction *action);
 
 bool IsSimulatedMouseClickBinding(ControllerButtonEvent ctrlEvent);
 
 AxisDirection GetMoveDirection();
+
+bool HandleControllerButtonEvent(const SDL_Event &event, GameAction &action);
 
 extern bool PadMenuNavigatorActive;
 extern bool PadHotspellMenuActive;

--- a/Source/controls/game_controls.h
+++ b/Source/controls/game_controls.h
@@ -59,16 +59,23 @@ struct GameAction {
 	};
 };
 
+ControllerButton TranslateTo(GamepadLayout layout, ControllerButton button);
+
+bool SkipsMovie(ControllerButtonEvent ctrlEvent);
 bool GetGameAction(const SDL_Event &event, ControllerButtonEvent ctrlEvent, GameAction *action);
 
 bool IsSimulatedMouseClickBinding(ControllerButtonEvent ctrlEvent);
 
 AxisDirection GetMoveDirection();
 
-extern bool start_modifier_active;
-extern bool select_modifier_active;
-extern const ControllerButton ControllerButtonPrimary;
-extern const ControllerButton ControllerButtonSecondary;
-extern const ControllerButton ControllerButtonTertiary;
+extern bool PadMenuNavigatorActive;
+extern bool PadHotspellMenuActive;
+
+// Tracks the button most recently used as a modifier for another button.
+//
+// If two buttons are pressed simultaneously, SDL sends two events for which both buttons are in the pressed state.
+// The event processor may interpret the second event's button as a modifier for the action taken when processing the first event.
+// The code for the modifier will be stored here, and the event processor can check this value when processing the second event to suppress it.
+extern ControllerButton SuppressedButton;
 
 } // namespace devilution

--- a/Source/controls/menu_controls.cpp
+++ b/Source/controls/menu_controls.cpp
@@ -13,7 +13,7 @@ namespace devilution {
 MenuAction GetMenuHeldUpDownAction()
 {
 	static AxisDirectionRepeater repeater;
-	const AxisDirection dir = repeater.Get(GetLeftStickOrDpadDirection());
+	const AxisDirection dir = repeater.Get(GetLeftStickOrDpadDirection(false));
 	switch (dir.y) {
 	case AxisDirectionY_UP:
 		return MenuAction_UP;
@@ -35,16 +35,16 @@ MenuAction GetMenuAction(const SDL_Event &event)
 	}
 
 	if (!ctrlEvent.up) {
-		switch (ctrlEvent.button) {
+		switch (TranslateTo(GamepadType, ctrlEvent.button)) {
 		case ControllerButton_IGNORE:
 			return MenuAction_NONE;
-		case ControllerButton_BUTTON_B: // Right button
+		case ControllerButton_BUTTON_A:
 		case ControllerButton_BUTTON_START:
 			return MenuAction_SELECT;
 		case ControllerButton_BUTTON_BACK:
-		case ControllerButton_BUTTON_A: // Bottom button
+		case ControllerButton_BUTTON_B:
 			return MenuAction_BACK;
-		case ControllerButton_BUTTON_X: // Left button
+		case ControllerButton_BUTTON_X:
 			return MenuAction_DELETE;
 		case ControllerButton_BUTTON_DPAD_UP:
 		case ControllerButton_BUTTON_DPAD_DOWN:

--- a/Source/controls/modifier_hints.cpp
+++ b/Source/controls/modifier_hints.cpp
@@ -145,9 +145,9 @@ void DrawSpellsCircleMenuHint(const Surface &out, const Point &origin)
 	}
 }
 
-void DrawStartModifierMenu(const Surface &out)
+void DrawGamepadMenuNavigator(const Surface &out)
 {
-	if (!start_modifier_active)
+	if (!PadMenuNavigatorActive || SimulatingMouseWithPadmapper)
 		return;
 	static const CircleMenuHint DPad(/*top=*/HintIcon::IconMenu, /*right=*/HintIcon::IconInv, /*bottom=*/HintIcon::IconMap, /*left=*/HintIcon::IconChar);
 	static const CircleMenuHint Buttons(/*top=*/HintIcon::IconNull, /*right=*/HintIcon::IconNull, /*bottom=*/HintIcon::IconSpells, /*left=*/HintIcon::IconQuests);
@@ -156,15 +156,12 @@ void DrawStartModifierMenu(const Surface &out)
 	DrawCircleMenuHint(out, Buttons, { mainPanel.position.x + mainPanel.size.width - HintBoxSize * 3 - CircleMarginX - HintBoxMargin * 2, mainPanel.position.y - CircleTop });
 }
 
-void DrawSelectModifierMenu(const Surface &out)
+void DrawGamepadHotspellMenu(const Surface &out)
 {
-	if (!select_modifier_active || SimulatingMouseWithSelectAndDPad)
+	if (!PadHotspellMenuActive || SimulatingMouseWithPadmapper)
 		return;
 
 	const Rectangle &mainPanel = GetMainPanel();
-	if (sgOptions.Controller.bDpadHotkeys) {
-		DrawSpellsCircleMenuHint(out, { mainPanel.position.x + CircleMarginX, mainPanel.position.y - CircleTop });
-	}
 	DrawSpellsCircleMenuHint(out, { mainPanel.position.x + mainPanel.size.width - HintBoxSize * 3 - CircleMarginX - HintBoxMargin * 2, mainPanel.position.y - CircleTop });
 }
 
@@ -186,8 +183,8 @@ void FreeModifierHints()
 
 void DrawControllerModifierHints(const Surface &out)
 {
-	DrawStartModifierMenu(out);
-	DrawSelectModifierMenu(out);
+	DrawGamepadMenuNavigator(out);
+	DrawGamepadHotspellMenu(out);
 }
 
 } // namespace devilution

--- a/Source/controls/plrctrls.h
+++ b/Source/controls/plrctrls.h
@@ -36,9 +36,11 @@ extern ControlTypes ControlMode;
  */
 extern ControlTypes ControlDevice;
 
-extern ControllerButton ControllerButtonHeld;
+extern GameActionType ControllerActionHeld;
 
 extern GamepadLayout GamepadType;
+
+extern bool StandToggle;
 
 // Runs every frame.
 // Handles menu movement.
@@ -63,6 +65,7 @@ void SetPointAndClick(bool value);
 bool IsPointAndClick();
 
 void DetectInputMethod(const SDL_Event &event, const ControllerButtonEvent &gamepadEvent);
+void ProcessGameAction(const GameAction &action);
 
 // Whether the automap is being displayed.
 bool IsAutomapActive();

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -362,7 +362,7 @@ void CheckCursMove()
 	const Point currentTile { mx, my };
 
 	// While holding the button down we should retain target (but potentially lose it if it dies, goes out of view, etc)
-	if ((sgbMouseDown != CLICK_NONE || ControllerButtonHeld != ControllerButton_NONE) && IsNoneOf(LastMouseButtonAction, MouseActionType::None, MouseActionType::Attack, MouseActionType::Spell)) {
+	if ((sgbMouseDown != CLICK_NONE || ControllerActionHeld != GameActionType_NONE) && IsNoneOf(LastMouseButtonAction, MouseActionType::None, MouseActionType::Attack, MouseActionType::Spell)) {
 		InvalidateTargets();
 
 		if (pcursmonst == -1 && ObjectUnderCursor == nullptr && pcursitem == -1 && pcursinvitem == -1 && pcursstashitem == uint16_t(-1) && pcursplr == -1) {

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -139,7 +139,7 @@ void GmenuDrawMenuItem(const Surface &out, TMenuItem *pItem, int y)
 void GameMenuMove()
 {
 	static AxisDirectionRepeater repeater;
-	const AxisDirection moveDir = repeater.Get(GetLeftStickOrDpadDirection());
+	const AxisDirection moveDir = repeater.Get(GetLeftStickOrDpadDirection(false));
 	if (moveDir.x != AxisDirectionX_NONE)
 		GmenuLeftRight(moveDir.x == AxisDirectionX_RIGHT);
 	if (moveDir.y != AxisDirectionY_NONE)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1783,8 +1783,8 @@ void printItemMiscGamepad(const Item &item, bool isOil, bool isCastOnTarget)
 		castButton = controller_button_icon::Playstation_Square;
 		break;
 	case GamepadLayout::Nintendo:
-		activateButton = controller_button_icon::Nintendo_Y;
-		castButton = controller_button_icon::Nintendo_X;
+		activateButton = controller_button_icon::Nintendo_X;
+		castButton = controller_button_icon::Nintendo_Y;
 		break;
 	}
 

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -41,6 +41,9 @@ void play_movie(const char *pszMovie, bool userCanClose)
 		uint16_t modState;
 		while (movie_playing) {
 			while (movie_playing && FetchMessage(&event, &modState)) {
+				ControllerButtonEvent ctrlEvent = ToControllerButtonEvent(event);
+				if (userCanClose && SkipsMovie(ctrlEvent))
+					movie_playing = false;
 				switch (event.type) {
 				case SDL_KEYDOWN:
 				case SDL_MOUSEBUTTONUP:

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1494,14 +1494,16 @@ void PadmapperOptions::Action::LoadFromIni(string_view category)
 
 	std::string modName;
 	std::string buttonName;
-	for (string_view name : SplitByChar(result.data(), '+')) {
-		modName = buttonName;
-		buttonName = name;
-	}
-
-	if (buttonName.empty()) {
+	auto parts = SplitByChar(result.data(), '+');
+	auto it = parts.begin();
+	if (it == parts.end()) {
 		SetValue(ControllerButtonCombo {});
 		return;
+	}
+	buttonName = std::string(*it);
+	if (++it != parts.end()) {
+		modName = std::move(buttonName);
+		buttonName = std::string(*it);
 	}
 
 	ControllerButtonCombo input {};

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -63,7 +63,7 @@ void RepeatMouseAction()
 	if (pcurs != CURSOR_HAND)
 		return;
 
-	if (sgbMouseDown == CLICK_NONE && ControllerButtonHeld == ControllerButton_NONE)
+	if (sgbMouseDown == CLICK_NONE && ControllerActionHeld == GameActionType_NONE)
 		return;
 
 	if (stextflag != STORE_NONE)

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -262,6 +262,9 @@ bool SpawnWindow(const char *lpWindowName)
 #if SDL_VERSION_ATLEAST(2, 0, 2)
 	SDL_SetHint(SDL_HINT_ACCELEROMETER_AS_JOYSTICK, "0");
 #endif
+#if SDL_VERSION_ATLEAST(2, 0, 12)
+	SDL_SetHint(SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS, "0");
+#endif
 
 	int initFlags = SDL_INIT_VIDEO | SDL_INIT_JOYSTICK;
 #ifndef NOSOUND


### PR DESCRIPTION
Adds a padmapper for customizing actions associated with gamepad buttons. The controls basically feel the same, as far as I've been able to tell. Hopefully the code is easier to follow now as well.

* Enables mappings for two-button combos
* Introduces gamepad actions for nearly all of the keyboard actions
* Introduces actions for "stand ground" and "toggle stand ground" to enable Shift+Click functionality for gamepad
* Implements the currently hardcoded control scheme as the padmapper defaults
* Swaps A/B and X/Y menu actions for non-Nintendo controllers based on the `GamepadLayout` (note, this may have a somewhat adverse effect on the Quest Log and Spellbook screens that should be addressed at some point)
* Removes settings for d-pad hotkeys and swap shoulder button mode as it should now be more or less possible to achieve the same result by remapping buttons

Some additional notes for reviewers...

* Options are currently hidden from the settings menu since the code to bind the gamepad buttons has not yet been written
* Most of the actions were straight-up copied from keymapper, and I haven't tested to make sure they work the same when mapped to the gamepad
* This PR sets the `SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS` hint so that buttons are always positional regardless of the gamepad layout. This was done to ensure that the on-screen hints we display when holding Start or Select would be accurate to the position of the buttons on the gamepad. This is why it was necessary to add the `TranslateTo()` function to swap button codes around for Nintendo layout controllers. My hope for when the settings menu is implemented would be to add gamepad icons for the larger font so we can display the appropriate buttons based on the layout, but continue to save the positional layout to the INI.