### PR TITLE
Update SDL2 used from source to v2.24.1

### DIFF
--- a/3rdParty/SDL2/CMakeLists.txt
+++ b/3rdParty/SDL2/CMakeLists.txt
@@ -15,7 +15,7 @@ set(SDL_TEST_ENABLED_BY_DEFAULT OFF)
 include(functions/FetchContent_MakeAvailableExcludeFromAll)
 include(FetchContent)
 FetchContent_Declare(SDL2
-    URL https://github.com/libsdl-org/SDL/archive/cb46e1b3f06a08d57b4ccd83127d1ec3139e1c0f.tar.gz
-    URL_HASH MD5=b5539b578ef77f6364f621dc55c244d7
+    URL https://github.com/libsdl-org/SDL/archive/a1d1946dcba6509f0679f507b57e7b228d32e6f8.tar.gz
+    URL_HASH MD5=d1bc6ea361b9d65d05fb698968466ace
 )
 FetchContent_MakeAvailableExcludeFromAll(SDL2)


### PR DESCRIPTION
VCPKG already updated
Release notes: https://github.com/libsdl-org/SDL/releases/tag/release-2.24.1