### PR TITLE
Update zlib to 1.2.13

### DIFF
--- a/3rdParty/zlib/CMakeLists.txt
+++ b/3rdParty/zlib/CMakeLists.txt
@@ -2,8 +2,8 @@ include(functions/FetchContent_MakeAvailableExcludeFromAll)
 
 include(FetchContent)
 FetchContent_Declare(zlib
-    URL https://www.zlib.net/zlib-1.2.12.tar.gz
-    URL_HASH MD5=5fc414a9726be31427b440b434d05f78
+    URL https://www.zlib.net/zlib-1.2.13.tar.gz
+    URL_HASH MD5=9b8aa094c4e5765dabf4da391f00d15c
 )
 FetchContent_MakeAvailableExcludeFromAll(zlib)
 


### PR DESCRIPTION
The link to the 1.2.12 source is now gone.