### PR TITLE
Remove ConsumeSpell() from AddMissile() functions

### DIFF
--- a/Source/misdat.h
+++ b/Source/misdat.h
@@ -115,7 +115,7 @@ struct Missile;
 struct AddMissileParameter;
 
 struct MissileData {
-	void (*mAddProc)(Missile &, const AddMissileParameter &);
+	void (*mAddProc)(Missile &, AddMissileParameter &);
 	void (*mProc)(Missile &);
 	uint8_t mName;
 	bool mDraw;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1111,7 +1111,7 @@ void InitMissiles()
 	}
 }
 
-void AddHiveExplosion(Missile &missile, const AddMissileParameter &parameter)
+void AddHiveExplosion(Missile &missile, AddMissileParameter &parameter)
 {
 	for (int x : { 80, 81 }) {
 		for (int y : { 62, 63 }) {
@@ -1121,40 +1121,35 @@ void AddHiveExplosion(Missile &missile, const AddMissileParameter &parameter)
 	missile._miDelFlag = true;
 }
 
-void AddFireRune(Missile &missile, const AddMissileParameter &parameter)
+void AddFireRune(Missile &missile, AddMissileParameter &parameter)
 {
 	AddRune(missile, parameter.dst, MIS_HIVEEXP);
-	ConsumeSpell(Players[missile._misource], SPL_RUNEFIRE);
 }
 
-void AddLightningRune(Missile &missile, const AddMissileParameter &parameter)
+void AddLightningRune(Missile &missile, AddMissileParameter &parameter)
 {
 	int lvl = (missile.sourceType() == MissileSource::Player) ? missile.sourcePlayer()->_pLevel : 0;
 	int dmg = 16 * (GenerateRndSum(10, 2) + lvl + 2);
 	missile._midam = dmg;
 	AddRune(missile, parameter.dst, MIS_LIGHTWALL);
-	ConsumeSpell(Players[missile._misource], SPL_RUNELIGHT);
 }
 
-void AddGreatLightningRune(Missile &missile, const AddMissileParameter &parameter)
+void AddGreatLightningRune(Missile &missile, AddMissileParameter &parameter)
 {
 	AddRune(missile, parameter.dst, MIS_NOVA);
-	ConsumeSpell(Players[missile._misource], SPL_RUNENOVA);
 }
 
-void AddImmolationRune(Missile &missile, const AddMissileParameter &parameter)
+void AddImmolationRune(Missile &missile, AddMissileParameter &parameter)
 {
 	AddRune(missile, parameter.dst, MIS_IMMOLATION);
-	ConsumeSpell(Players[missile._misource], SPL_RUNEIMMOLAT);
 }
 
-void AddStoneRune(Missile &missile, const AddMissileParameter &parameter)
+void AddStoneRune(Missile &missile, AddMissileParameter &parameter)
 {
 	AddRune(missile, parameter.dst, MIS_STONE);
-	ConsumeSpell(Players[missile._misource], SPL_RUNESTONE);
 }
 
-void AddReflection(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddReflection(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	missile._miDelFlag = true;
 
@@ -1169,13 +1164,12 @@ void AddReflection(Missile &missile, const AddMissileParameter & /*parameter*/)
 	player.wReflections += add;
 	if (&player == MyPlayer)
 		NetSendCmdParam1(true, CMD_SETREFLECT, player.wReflections);
-
-	ConsumeSpell(player, SPL_REFLECT);
 }
 
-void AddBerserk(Missile &missile, const AddMissileParameter &parameter)
+void AddBerserk(Missile &missile, AddMissileParameter &parameter)
 {
 	missile._miDelFlag = true;
+	parameter.spellFizzled = true;
 
 	if (missile.sourceType() == MissileSource::Trap)
 		return;
@@ -1219,11 +1213,11 @@ void AddBerserk(Missile &missile, const AddMissileParameter &parameter)
 		monster.maxDamageSpecial = (GenerateRnd(10) + 120) * monster.maxDamageSpecial / 100 + slvl;
 		int lightRadius = leveltype == DTYPE_NEST ? 9 : 3;
 		monster.lightId = AddLight(monster.position.tile, lightRadius);
-		ConsumeSpell(player, SPL_BERSERK);
+		parameter.spellFizzled = false;
 	}
 }
 
-void AddHorkSpawn(Missile &missile, const AddMissileParameter &parameter)
+void AddHorkSpawn(Missile &missile, AddMissileParameter &parameter)
 {
 	UpdateMissileVelocity(missile, parameter.dst, 8);
 	missile._mirange = 9;
@@ -1231,7 +1225,7 @@ void AddHorkSpawn(Missile &missile, const AddMissileParameter &parameter)
 	PutMissile(missile);
 }
 
-void AddJester(Missile &missile, const AddMissileParameter &parameter)
+void AddJester(Missile &missile, AddMissileParameter &parameter)
 {
 	missile_id spell = MIS_FIREBOLT;
 	switch (GenerateRnd(10)) {
@@ -1253,7 +1247,6 @@ void AddJester(Missile &missile, const AddMissileParameter &parameter)
 		break;
 	case 6:
 		spell = MIS_TOWN;
-		ConsumeSpell(Players[missile._misource], SPL_TOWN);
 		break;
 	case 7:
 		spell = MIS_TELEPORT;
@@ -1265,11 +1258,12 @@ void AddJester(Missile &missile, const AddMissileParameter &parameter)
 		spell = MIS_STONE;
 		break;
 	}
-	AddMissile(missile.position.start, parameter.dst, parameter.midir, spell, missile._micaster, missile._misource, 0, missile._mispllvl);
+	Missile *randomMissile = AddMissile(missile.position.start, parameter.dst, parameter.midir, spell, missile._micaster, missile._misource, 0, missile._mispllvl);
+	parameter.spellFizzled = randomMissile == nullptr;
 	missile._miDelFlag = true;
 }
 
-void AddStealPotions(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddStealPotions(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	Crawl(0, 2, [&](Displacement displacement) {
 		Point target = missile.position.start + displacement;
@@ -1336,7 +1330,7 @@ void AddStealPotions(Missile &missile, const AddMissileParameter & /*parameter*/
 	missile._miDelFlag = true;
 }
 
-void AddManaTrap(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddManaTrap(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	std::optional<Point> trappedPlayerPosition = FindClosestValidPosition(
 	    [](Point target) {
@@ -1357,7 +1351,7 @@ void AddManaTrap(Missile &missile, const AddMissileParameter & /*parameter*/)
 	missile._miDelFlag = true;
 }
 
-void AddSpecArrow(Missile &missile, const AddMissileParameter &parameter)
+void AddSpecArrow(Missile &missile, AddMissileParameter &parameter)
 {
 	int av = 0;
 
@@ -1385,7 +1379,7 @@ void AddSpecArrow(Missile &missile, const AddMissileParameter &parameter)
 	missile.var3 = av;
 }
 
-void AddWarp(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddWarp(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	int minDistanceSq = std::numeric_limits<int>::max();
 	Point src = missile.position.start;
@@ -1441,12 +1435,9 @@ void AddWarp(Missile &missile, const AddMissileParameter & /*parameter*/)
 	}
 	missile._mirange = 2;
 	missile.position.tile = tile;
-	if (missileSource == MissileSource::Player) {
-		ConsumeSpell(*missile.sourcePlayer(), SPL_WARP);
-	}
 }
 
-void AddLightningWall(Missile &missile, const AddMissileParameter &parameter)
+void AddLightningWall(Missile &missile, AddMissileParameter &parameter)
 {
 	UpdateMissileVelocity(missile, parameter.dst, 16);
 	missile._miAnimFrame = GenerateRnd(8) + 1;
@@ -1467,7 +1458,7 @@ void AddLightningWall(Missile &missile, const AddMissileParameter &parameter)
 	}
 }
 
-void AddRuneExplosion(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddRuneExplosion(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	if (missile.sourceType() == MissileSource::Player) {
 		int dmg = 2 * (missile.sourcePlayer()->_pLevel + GenerateRndSum(10, 2)) + 4;
@@ -1483,7 +1474,7 @@ void AddRuneExplosion(Missile &missile, const AddMissileParameter & /*parameter*
 	missile._mirange = missile._miAnimLen - 1;
 }
 
-void AddFireNova(Missile &missile, const AddMissileParameter &parameter)
+void AddFireNova(Missile &missile, AddMissileParameter &parameter)
 {
 	Point dst = parameter.dst;
 	if (missile.position.start == parameter.dst) {
@@ -1499,7 +1490,7 @@ void AddFireNova(Missile &missile, const AddMissileParameter &parameter)
 	missile._mlid = AddLight(missile.position.start, 8);
 }
 
-void AddLightningArrow(Missile &missile, const AddMissileParameter &parameter)
+void AddLightningArrow(Missile &missile, AddMissileParameter &parameter)
 {
 	Point dst = parameter.dst;
 	if (missile.position.start == parameter.dst) {
@@ -1518,7 +1509,7 @@ void AddLightningArrow(Missile &missile, const AddMissileParameter &parameter)
 	missile._midam <<= 6;
 }
 
-void AddMana(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddMana(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	Player &player = Players[missile._misource];
 
@@ -1539,32 +1530,28 @@ void AddMana(Missile &missile, const AddMissileParameter & /*parameter*/)
 	player._pManaBase += manaAmount;
 	if (player._pManaBase > player._pMaxManaBase)
 		player._pManaBase = player._pMaxManaBase;
-	ConsumeSpell(player, SPL_MANA);
 	missile._miDelFlag = true;
 	drawmanaflag = true;
 }
 
-void AddMagi(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddMagi(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	Player &player = Players[missile._misource];
 
 	player._pMana = player._pMaxMana;
 	player._pManaBase = player._pMaxManaBase;
-	ConsumeSpell(player, SPL_MAGI);
 	missile._miDelFlag = true;
 	drawmanaflag = true;
 }
 
-void AddRing(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddRing(Missile &missile, AddMissileParameter & /*parameter*/)
 {
-	if (missile._micaster == TARGET_MONSTERS)
-		ConsumeSpell(Players[missile._misource], SPL_FIRERING);
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile._mirange = 7;
 }
 
-void AddSearch(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddSearch(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	Player &player = Players[missile._misource];
 
@@ -1574,8 +1561,6 @@ void AddSearch(Missile &missile, const AddMissileParameter & /*parameter*/)
 	if (missile._misource >= 0)
 		lvl = player._pLevel * 2;
 	missile._mirange = lvl + 10 * missile._mispllvl + 245;
-	if (missile._micaster == TARGET_MONSTERS)
-		ConsumeSpell(player, SPL_SEARCH);
 
 	for (auto &other : Missiles) {
 		if (&other != &missile && missile.isSameSource(other) && other._mitype == MIS_SEARCH) {
@@ -1589,7 +1574,7 @@ void AddSearch(Missile &missile, const AddMissileParameter & /*parameter*/)
 	}
 }
 
-void AddCboltArrow(Missile &missile, const AddMissileParameter &parameter)
+void AddCboltArrow(Missile &missile, AddMissileParameter &parameter)
 {
 	Point dst = parameter.dst;
 	missile._mirnd = GenerateRnd(15) + 1;
@@ -1608,7 +1593,7 @@ void AddCboltArrow(Missile &missile, const AddMissileParameter &parameter)
 	missile._mirange = 256;
 }
 
-void AddLArrow(Missile &missile, const AddMissileParameter &parameter)
+void AddLArrow(Missile &missile, AddMissileParameter &parameter)
 {
 	Point dst = parameter.dst;
 	if (missile.position.start == dst) {
@@ -1645,7 +1630,7 @@ void AddLArrow(Missile &missile, const AddMissileParameter &parameter)
 	missile._mlid = AddLight(missile.position.start, 5);
 }
 
-void AddArrow(Missile &missile, const AddMissileParameter &parameter)
+void AddArrow(Missile &missile, AddMissileParameter &parameter)
 {
 	Point dst = parameter.dst;
 	if (missile.position.start == dst) {
@@ -1695,7 +1680,7 @@ void UpdateVileMissPos(Missile &missile, Point dst)
 	}
 }
 
-void AddRndTeleport(Missile &missile, const AddMissileParameter &parameter)
+void AddRndTeleport(Missile &missile, AddMissileParameter &parameter)
 {
 	missile._mirange = 2;
 
@@ -1731,12 +1716,9 @@ void AddRndTeleport(Missile &missile, const AddMissileParameter &parameter)
 	}
 
 	missile.position.tile = targets[std::max<int32_t>(GenerateRnd(count), 0)];
-
-	if (missile._micaster == TARGET_MONSTERS)
-		ConsumeSpell(player, SPL_RNDTELEPORT);
 }
 
-void AddFirebolt(Missile &missile, const AddMissileParameter &parameter)
+void AddFirebolt(Missile &missile, AddMissileParameter &parameter)
 {
 	Point dst = parameter.dst;
 	if (missile.position.start == dst) {
@@ -1748,9 +1730,6 @@ void AddFirebolt(Missile &missile, const AddMissileParameter &parameter)
 		if (!missile.IsTrap()) {
 			sp += std::min(missile._mispllvl * 2, 47);
 		}
-
-		if (parameter.pParent == nullptr || parameter.pParent->_mitype != MIS_GUARDIAN)
-			ConsumeSpell(Players[missile._misource], SPL_FIREBOLT);
 	}
 	UpdateMissileVelocity(missile, dst, sp);
 	SetMissDir(missile, GetDirection16(missile.position.start, dst));
@@ -1760,7 +1739,7 @@ void AddFirebolt(Missile &missile, const AddMissileParameter &parameter)
 	missile._mlid = AddLight(missile.position.start, 8);
 }
 
-void AddMagmaball(Missile &missile, const AddMissileParameter &parameter)
+void AddMagmaball(Missile &missile, AddMissileParameter &parameter)
 {
 	UpdateMissileVelocity(missile, parameter.dst, 16);
 	missile.position.traveled.deltaX += 3 * missile.position.velocity.deltaX;
@@ -1775,7 +1754,7 @@ void AddMagmaball(Missile &missile, const AddMissileParameter &parameter)
 	missile._mlid = AddLight(missile.position.start, 8);
 }
 
-void AddTeleport(Missile &missile, const AddMissileParameter &parameter)
+void AddTeleport(Missile &missile, AddMissileParameter &parameter)
 {
 	Player &player = Players[missile._misource];
 
@@ -1788,14 +1767,14 @@ void AddTeleport(Missile &missile, const AddMissileParameter &parameter)
 	if (teleportDestination) {
 		missile.position.tile = *teleportDestination;
 		missile.position.start = *teleportDestination;
-		ConsumeSpell(player, SPL_TELEPORT);
 		missile._mirange = 2;
 	} else {
 		missile._miDelFlag = true;
+		parameter.spellFizzled = true;
 	}
 }
 
-void AddLightball(Missile &missile, const AddMissileParameter &parameter)
+void AddLightball(Missile &missile, AddMissileParameter &parameter)
 {
 	UpdateMissileVelocity(missile, parameter.dst, 16);
 	missile._miAnimFrame = GenerateRnd(8) + 1;
@@ -1805,7 +1784,7 @@ void AddLightball(Missile &missile, const AddMissileParameter &parameter)
 	missile.var2 = position.y;
 }
 
-void AddFirewall(Missile &missile, const AddMissileParameter &parameter)
+void AddFirewall(Missile &missile, AddMissileParameter &parameter)
 {
 	missile._midam = GenerateRndSum(10, 2) + 2;
 	missile._midam += missile._misource >= 0 ? Players[missile._misource]._pLevel : currlevel; // BUGFIX: missing parenthesis around ternary (fixed)
@@ -1823,7 +1802,7 @@ void AddFirewall(Missile &missile, const AddMissileParameter &parameter)
 	missile.var1 = missile._mirange - missile._miAnimLen;
 }
 
-void AddFireball(Missile &missile, const AddMissileParameter &parameter)
+void AddFireball(Missile &missile, AddMissileParameter &parameter)
 {
 	Point dst = parameter.dst;
 	if (missile.position.start == dst) {
@@ -1836,8 +1815,6 @@ void AddFireball(Missile &missile, const AddMissileParameter &parameter)
 
 		int dmg = 2 * (player._pLevel + GenerateRndSum(10, 2)) + 4;
 		missile._midam = ScaleSpellEffect(dmg, missile._mispllvl);
-
-		ConsumeSpell(player, SPL_FIREBALL);
 	}
 	UpdateMissileVelocity(missile, dst, sp);
 	SetMissDir(missile, GetDirection16(missile.position.start, dst));
@@ -1847,10 +1824,8 @@ void AddFireball(Missile &missile, const AddMissileParameter &parameter)
 	missile._mlid = AddLight(missile.position.start, 8);
 }
 
-void AddLightctrl(Missile &missile, const AddMissileParameter &parameter)
+void AddLightctrl(Missile &missile, AddMissileParameter &parameter)
 {
-	if (missile._midam == 0 && missile._micaster == TARGET_MONSTERS)
-		ConsumeSpell(Players[missile._misource], SPL_LIGHTNING);
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	UpdateMissileVelocity(missile, parameter.dst, 32);
@@ -1858,7 +1833,7 @@ void AddLightctrl(Missile &missile, const AddMissileParameter &parameter)
 	missile._mirange = 256;
 }
 
-void AddLightning(Missile &missile, const AddMissileParameter &parameter)
+void AddLightning(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.position.start = parameter.dst;
 
@@ -1877,7 +1852,7 @@ void AddLightning(Missile &missile, const AddMissileParameter &parameter)
 	missile._mlid = AddLight(missile.position.tile, 4);
 }
 
-void AddMisexp(Missile &missile, const AddMissileParameter &parameter)
+void AddMisexp(Missile &missile, AddMissileParameter &parameter)
 {
 	if (missile._micaster != TARGET_MONSTERS && missile._misource >= 0) {
 		switch (Monsters[missile._misource].type().type) {
@@ -1907,7 +1882,7 @@ void AddMisexp(Missile &missile, const AddMissileParameter &parameter)
 	missile._mirange = missile._miAnimLen;
 }
 
-void AddWeapexp(Missile &missile, const AddMissileParameter &parameter)
+void AddWeapexp(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.var2 = parameter.dst.x;
 	if (parameter.dst.x == 1)
@@ -1917,7 +1892,7 @@ void AddWeapexp(Missile &missile, const AddMissileParameter &parameter)
 	missile._mirange = missile._miAnimLen - 1;
 }
 
-void AddTown(Missile &missile, const AddMissileParameter &parameter)
+void AddTown(Missile &missile, AddMissileParameter &parameter)
 {
 	if (leveltype == DTYPE_TOWN) {
 		missile.position.tile = parameter.dst;
@@ -1971,7 +1946,7 @@ void AddTown(Missile &missile, const AddMissileParameter &parameter)
 	}
 }
 
-void AddFlash(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddFlash(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	switch (missile.sourceType()) {
 	case MissileSource::Player: {
@@ -1979,7 +1954,6 @@ void AddFlash(Missile &missile, const AddMissileParameter & /*parameter*/)
 		int dmg = GenerateRndSum(20, player._pLevel + 1) + player._pLevel + 1;
 		missile._midam = ScaleSpellEffect(dmg, missile._mispllvl);
 		missile._midam += missile._midam / 2;
-		ConsumeSpell(player, SPL_FLASH);
 	} break;
 	case MissileSource::Monster:
 		missile._midam = missile.sourceMonster()->level(sgGameInitInfo.nDifficulty) * 2;
@@ -1992,7 +1966,7 @@ void AddFlash(Missile &missile, const AddMissileParameter & /*parameter*/)
 	missile._mirange = 19;
 }
 
-void AddFlash2(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddFlash2(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	if (missile._micaster == TARGET_MONSTERS) {
 		if (!missile.IsTrap()) {
@@ -2008,7 +1982,7 @@ void AddFlash2(Missile &missile, const AddMissileParameter & /*parameter*/)
 	missile._mirange = 19;
 }
 
-void AddManashield(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddManashield(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	missile._miDelFlag = true;
 
@@ -2020,12 +1994,9 @@ void AddManashield(Missile &missile, const AddMissileParameter & /*parameter*/)
 	player.pManaShield = true;
 	if (&player == MyPlayer)
 		NetSendCmd(true, CMD_SETSHIELD);
-
-	if (missile._micaster == TARGET_MONSTERS)
-		ConsumeSpell(player, SPL_MANASHIELD);
 }
 
-void AddFiremove(Missile &missile, const AddMissileParameter &parameter)
+void AddFiremove(Missile &missile, AddMissileParameter &parameter)
 {
 	missile._midam = GenerateRnd(10) + Players[missile._misource]._pLevel + 1;
 	UpdateMissileVelocity(missile, parameter.dst, 16);
@@ -2034,7 +2005,7 @@ void AddFiremove(Missile &missile, const AddMissileParameter &parameter)
 	missile.position.offset.deltaY -= 32;
 }
 
-void AddGuardian(Missile &missile, const AddMissileParameter &parameter)
+void AddGuardian(Missile &missile, AddMissileParameter &parameter)
 {
 	Player &player = Players[missile._misource];
 
@@ -2067,13 +2038,13 @@ void AddGuardian(Missile &missile, const AddMissileParameter &parameter)
 
 	if (!spawnPosition) {
 		missile._miDelFlag = true;
+		parameter.spellFizzled = true;
 		return;
 	}
 
 	missile._miDelFlag = false;
 	missile.position.tile = *spawnPosition;
 	missile.position.start = *spawnPosition;
-	ConsumeSpell(player, SPL_GUARDIAN);
 
 	missile._mlid = AddLight(missile.position.tile, 1);
 	missile._mirange = missile._mispllvl + (player._pLevel / 2);
@@ -2089,12 +2060,11 @@ void AddGuardian(Missile &missile, const AddMissileParameter &parameter)
 	missile.var3 = 1;
 }
 
-void AddChain(Missile &missile, const AddMissileParameter &parameter)
+void AddChain(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.var1 = parameter.dst.x;
 	missile.var2 = parameter.dst.y;
 	missile._mirange = 1;
-	ConsumeSpell(Players[missile._misource], SPL_CHAIN);
 }
 
 namespace {
@@ -2118,7 +2088,7 @@ void InitMissileAnimationFromMonster(Missile &mis, Direction midir, const Monste
 }
 } // namespace
 
-void AddRhino(Missile &missile, const AddMissileParameter &parameter)
+void AddRhino(Missile &missile, AddMissileParameter &parameter)
 {
 	Monster &monster = Monsters[missile._misource];
 
@@ -2138,7 +2108,7 @@ void AddRhino(Missile &missile, const AddMissileParameter &parameter)
 	PutMissile(missile);
 }
 
-void AddFlare(Missile &missile, const AddMissileParameter &parameter)
+void AddFlare(Missile &missile, AddMissileParameter &parameter)
 {
 	Point dst = parameter.dst;
 	if (missile.position.start == dst) {
@@ -2149,11 +2119,7 @@ void AddFlare(Missile &missile, const AddMissileParameter &parameter)
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 8);
-	if (missile._micaster == TARGET_MONSTERS) {
-		Player &player = Players[missile._misource];
-		ConsumeSpell(player, SPL_FLARE);
-		ApplyPlrDamage(player, 5);
-	} else if (missile._misource > 0) {
+	if (missile._micaster != TARGET_MONSTERS && missile._misource > 0) {
 		auto &monster = Monsters[missile._misource];
 		if (monster.type().type == MT_SUCCUBUS)
 			SetMissAnim(missile, MFILE_FLARE);
@@ -2170,7 +2136,7 @@ void AddFlare(Missile &missile, const AddMissileParameter &parameter)
 	}
 }
 
-void AddAcid(Missile &missile, const AddMissileParameter &parameter)
+void AddAcid(Missile &missile, AddMissileParameter &parameter)
 {
 	UpdateMissileVelocity(missile, parameter.dst, 16);
 	SetMissDir(missile, GetDirection16(missile.position.start, parameter.dst));
@@ -2184,7 +2150,7 @@ void AddAcid(Missile &missile, const AddMissileParameter &parameter)
 	PutMissile(missile);
 }
 
-void AddAcidpud(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddAcidpud(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	missile._miLightFlag = true;
 	int monst = missile._misource;
@@ -2192,7 +2158,7 @@ void AddAcidpud(Missile &missile, const AddMissileParameter & /*parameter*/)
 	missile._miPreFlag = true;
 }
 
-void AddStone(Missile &missile, const AddMissileParameter &parameter)
+void AddStone(Missile &missile, AddMissileParameter &parameter)
 {
 	std::optional<Point> targetMonsterPosition = FindClosestValidPosition(
 	    [](Point target) {
@@ -2220,6 +2186,7 @@ void AddStone(Missile &missile, const AddMissileParameter &parameter)
 
 	if (!targetMonsterPosition) {
 		missile._miDelFlag = true;
+		parameter.spellFizzled = true;
 		return;
 	}
 
@@ -2241,10 +2208,9 @@ void AddStone(Missile &missile, const AddMissileParameter &parameter)
 	if (missile._mirange > 15)
 		missile._mirange = 15;
 	missile._mirange <<= 4;
-	ConsumeSpell(player, SPL_STONE);
 }
 
-void AddGolem(Missile &missile, const AddMissileParameter &parameter)
+void AddGolem(Missile &missile, AddMissileParameter &parameter)
 {
 	missile._miDelFlag = true;
 
@@ -2254,8 +2220,6 @@ void AddGolem(Missile &missile, const AddMissileParameter &parameter)
 
 	if (golem.position.tile != GolemHoldingCell && &player == MyPlayer)
 		KillMyGolem();
-
-	ConsumeSpell(player, SPL_GOLEM);
 
 	if (golem.position.tile == GolemHoldingCell) {
 		std::optional<Point> spawnPosition = FindClosestValidPosition(
@@ -2270,14 +2234,14 @@ void AddGolem(Missile &missile, const AddMissileParameter &parameter)
 	}
 }
 
-void AddBoom(Missile &missile, const AddMissileParameter &parameter)
+void AddBoom(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.position.tile = parameter.dst;
 	missile.position.start = parameter.dst;
 	missile._mirange = missile._miAnimLen;
 }
 
-void AddHeal(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddHeal(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	Player &player = Players[missile._misource];
 
@@ -2295,17 +2259,15 @@ void AddHeal(Missile &missile, const AddMissileParameter & /*parameter*/)
 	player._pHitPoints = std::min(player._pHitPoints + hp, player._pMaxHP);
 	player._pHPBase = std::min(player._pHPBase + hp, player._pMaxHPBase);
 
-	ConsumeSpell(player, SPL_HEAL);
 	missile._miDelFlag = true;
 	drawhpflag = true;
 }
 
-void AddHealOther(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddHealOther(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	Player &player = Players[missile._misource];
 
 	missile._miDelFlag = true;
-	ConsumeSpell(player, SPL_HEALOTHER);
 	if (&player == MyPlayer) {
 		NewCursor(CURSOR_HEALOTHER);
 		if (ControlMode != ControlTypes::KeyboardAndMouse)
@@ -2313,7 +2275,7 @@ void AddHealOther(Missile &missile, const AddMissileParameter & /*parameter*/)
 	}
 }
 
-void AddElement(Missile &missile, const AddMissileParameter &parameter)
+void AddElement(Missile &missile, AddMissileParameter &parameter)
 {
 	Point dst = parameter.dst;
 	if (missile.position.start == dst) {
@@ -2333,17 +2295,15 @@ void AddElement(Missile &missile, const AddMissileParameter &parameter)
 	missile.var4 = dst.x;
 	missile.var5 = dst.y;
 	missile._mlid = AddLight(missile.position.start, 8);
-	ConsumeSpell(player, SPL_ELEMENT);
 }
 
 extern void FocusOnInventory();
 
-void AddIdentify(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddIdentify(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	Player &player = Players[missile._misource];
 
 	missile._miDelFlag = true;
-	ConsumeSpell(player, SPL_IDENTIFY);
 	if (&player == MyPlayer) {
 		if (sbookflag)
 			sbookflag = false;
@@ -2356,7 +2316,7 @@ void AddIdentify(Missile &missile, const AddMissileParameter & /*parameter*/)
 	}
 }
 
-void AddFirewallC(Missile &missile, const AddMissileParameter &parameter)
+void AddFirewallC(Missile &missile, AddMissileParameter &parameter)
 {
 	std::optional<Point> spreadPosition = FindClosestValidPosition(
 	    [start = missile.position.start](Point target) {
@@ -2366,6 +2326,7 @@ void AddFirewallC(Missile &missile, const AddMissileParameter &parameter)
 
 	if (!spreadPosition) {
 		missile._miDelFlag = true;
+		parameter.spellFizzled = true;
 		return;
 	}
 
@@ -2377,30 +2338,25 @@ void AddFirewallC(Missile &missile, const AddMissileParameter &parameter)
 	missile.var3 = static_cast<int>(Left(Left(parameter.midir)));
 	missile.var4 = static_cast<int>(Right(Right(parameter.midir)));
 	missile._mirange = 7;
-	ConsumeSpell(Players[missile._misource], SPL_FIREWALL);
 }
 
-void AddInfra(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddInfra(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	Player &player = Players[missile._misource];
 
 	missile._mirange = ScaleSpellEffect(1584, missile._mispllvl);
 	missile._mirange += missile._mirange * player._pISplDur / 128;
-
-	if (missile._micaster == TARGET_MONSTERS)
-		ConsumeSpell(player, SPL_INFRA);
 }
 
-void AddWave(Missile &missile, const AddMissileParameter &parameter)
+void AddWave(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.var1 = parameter.dst.x;
 	missile.var2 = parameter.dst.y;
 	missile._mirange = 1;
 	missile._miAnimFrame = 4;
-	ConsumeSpell(Players[missile._misource], SPL_WAVE);
 }
 
-void AddNova(Missile &missile, const AddMissileParameter &parameter)
+void AddNova(Missile &missile, AddMissileParameter &parameter)
 {
 	Player &player = Players[missile._misource];
 
@@ -2410,9 +2366,6 @@ void AddNova(Missile &missile, const AddMissileParameter &parameter)
 	if (!missile.IsTrap()) {
 		int dmg = GenerateRndSum(6, 5) + player._pLevel + 5;
 		missile._midam = ScaleSpellEffect(dmg / 2, missile._mispllvl);
-
-		if (missile._micaster == TARGET_MONSTERS)
-			ConsumeSpell(player, SPL_NOVA);
 	} else {
 		missile._midam = (currlevel / 2) + GenerateRndSum(3, 3);
 	}
@@ -2420,16 +2373,16 @@ void AddNova(Missile &missile, const AddMissileParameter &parameter)
 	missile._mirange = 1;
 }
 
-void AddBlodboil(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddBlodboil(Missile &missile, AddMissileParameter &parameter)
 {
 	Player &player = Players[missile._misource];
 
 	if (HasAnyOf(player._pSpellFlags, SpellFlag::RageActive | SpellFlag::RageCooldown) || player._pHitPoints <= player._pLevel << 6) {
 		missile._miDelFlag = true;
+		parameter.spellFizzled = true;
 		return;
 	}
 
-	ConsumeSpell(player, SPL_BLODBOIL);
 	int tmp = 3 * player._pLevel;
 	tmp <<= 7;
 	player._pSpellFlags |= SpellFlag::RageActive;
@@ -2441,12 +2394,11 @@ void AddBlodboil(Missile &missile, const AddMissileParameter & /*parameter*/)
 	player.Say(HeroSpeech::Aaaaargh);
 }
 
-void AddRepair(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddRepair(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	Player &player = Players[missile._misource];
 
 	missile._miDelFlag = true;
-	ConsumeSpell(player, SPL_REPAIR);
 	if (&player == MyPlayer) {
 		if (sbookflag)
 			sbookflag = false;
@@ -2459,12 +2411,11 @@ void AddRepair(Missile &missile, const AddMissileParameter & /*parameter*/)
 	}
 }
 
-void AddRecharge(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddRecharge(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	Player &player = Players[missile._misource];
 
 	missile._miDelFlag = true;
-	ConsumeSpell(player, SPL_RECHARGE);
 	if (&player == MyPlayer) {
 		if (sbookflag)
 			sbookflag = false;
@@ -2477,12 +2428,11 @@ void AddRecharge(Missile &missile, const AddMissileParameter & /*parameter*/)
 	}
 }
 
-void AddDisarm(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddDisarm(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	Player &player = Players[missile._misource];
 
 	missile._miDelFlag = true;
-	ConsumeSpell(player, SPL_DISARM);
 	if (&player == MyPlayer) {
 		NewCursor(CURSOR_DISARM);
 		if (ControlMode != ControlTypes::KeyboardAndMouse) {
@@ -2494,7 +2444,7 @@ void AddDisarm(Missile &missile, const AddMissileParameter & /*parameter*/)
 	}
 }
 
-void AddApoca(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddApoca(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	Player &player = Players[missile._misource];
 
@@ -2507,10 +2457,9 @@ void AddApoca(Missile &missile, const AddMissileParameter & /*parameter*/)
 	int playerLevel = player._pLevel;
 	missile._midam = GenerateRndSum(6, playerLevel) + playerLevel;
 	missile._mirange = 255;
-	ConsumeSpell(player, SPL_APOCA);
 }
 
-void AddFlame(Missile &missile, const AddMissileParameter &parameter)
+void AddFlame(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.var2 = 5 * missile._midam;
 	missile.position.start = parameter.dst;
@@ -2528,22 +2477,19 @@ void AddFlame(Missile &missile, const AddMissileParameter &parameter)
 	}
 }
 
-void AddFlamec(Missile &missile, const AddMissileParameter &parameter)
+void AddFlamec(Missile &missile, AddMissileParameter &parameter)
 {
 	Point dst = parameter.dst;
 	if (missile.position.start == parameter.dst) {
 		dst += parameter.midir;
 	}
 	UpdateMissileVelocity(missile, dst, 32);
-	if (missile._micaster == TARGET_MONSTERS) {
-		ConsumeSpell(Players[missile._misource], SPL_FLAME);
-	}
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile._mirange = 256;
 }
 
-void AddCbolt(Missile &missile, const AddMissileParameter &parameter)
+void AddCbolt(Missile &missile, AddMissileParameter &parameter)
 {
 	Point dst = parameter.dst;
 	missile._mirnd = GenerateRnd(15) + 1;
@@ -2561,7 +2507,7 @@ void AddCbolt(Missile &missile, const AddMissileParameter &parameter)
 	missile._mirange = 256;
 }
 
-void AddHbolt(Missile &missile, const AddMissileParameter &parameter)
+void AddHbolt(Missile &missile, AddMissileParameter &parameter)
 {
 	Point dst = parameter.dst;
 	if (missile.position.start == dst) {
@@ -2581,14 +2527,12 @@ void AddHbolt(Missile &missile, const AddMissileParameter &parameter)
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 8);
 	missile._midam = GenerateRnd(10) + player._pLevel + 9;
-	ConsumeSpell(player, SPL_HBOLT);
 }
 
-void AddResurrect(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddResurrect(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	Player &player = Players[missile._misource];
 
-	ConsumeSpell(player, SPL_RESURRECT);
 	if (&player == MyPlayer) {
 		NewCursor(CURSOR_RESURRECT);
 		if (ControlMode != ControlTypes::KeyboardAndMouse)
@@ -2597,24 +2541,23 @@ void AddResurrect(Missile &missile, const AddMissileParameter & /*parameter*/)
 	missile._miDelFlag = true;
 }
 
-void AddResurrectBeam(Missile &missile, const AddMissileParameter &parameter)
+void AddResurrectBeam(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.position.tile = parameter.dst;
 	missile.position.start = parameter.dst;
 	missile._mirange = MissileSpriteData[MFILE_RESSUR1].animLen[0];
 }
 
-void AddTelekinesis(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddTelekinesis(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	Player &player = Players[missile._misource];
 
 	missile._miDelFlag = true;
-	ConsumeSpell(player, SPL_TELEKINESIS);
 	if (&player == MyPlayer)
 		NewCursor(CURSOR_TELEKINESIS);
 }
 
-void AddBoneSpirit(Missile &missile, const AddMissileParameter &parameter)
+void AddBoneSpirit(Missile &missile, AddMissileParameter &parameter)
 {
 	Point dst = parameter.dst;
 	if (missile.position.start == parameter.dst) {
@@ -2628,21 +2571,16 @@ void AddBoneSpirit(Missile &missile, const AddMissileParameter &parameter)
 	missile.var4 = dst.x;
 	missile.var5 = dst.y;
 	missile._mlid = AddLight(missile.position.start, 8);
-	if (missile._micaster == TARGET_MONSTERS) {
-		Player &player = Players[missile._misource];
-		ConsumeSpell(player, SPL_BONESPIRIT);
-		ApplyPlrDamage(player, 6);
-	}
 }
 
-void AddRportal(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddRportal(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	missile._mirange = 100;
 	missile.var1 = 100 - missile._miAnimLen;
 	PutMissile(missile);
 }
 
-void AddDiabApoca(Missile &missile, const AddMissileParameter & /*parameter*/)
+void AddDiabApoca(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	for (const Player &player : Players) {
 		if (!player.plractive)
@@ -2695,8 +2633,11 @@ Missile *AddMissile(Point src, Point dst, Direction midir, missile_id mitype, mi
 		PlaySfxLoc(missileData.mlSFX, missile.position.start);
 	}
 
-	AddMissileParameter parameter = { dst, midir, pParent };
+	AddMissileParameter parameter = { dst, midir, pParent, false };
 	missileData.mAddProc(missile, parameter);
+	if (parameter.spellFizzled) {
+		return nullptr;
+	}
 
 	return &missile;
 }

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -238,43 +238,44 @@ struct AddMissileParameter {
 	Point dst;
 	Direction midir;
 	Missile *pParent;
+	bool spellFizzled;
 };
 
-void AddHiveExplosion(Missile &missile, const AddMissileParameter &parameter);
-void AddFireRune(Missile &missile, const AddMissileParameter &parameter);
-void AddLightningRune(Missile &missile, const AddMissileParameter &parameter);
-void AddGreatLightningRune(Missile &missile, const AddMissileParameter &parameter);
-void AddImmolationRune(Missile &missile, const AddMissileParameter &parameter);
-void AddStoneRune(Missile &missile, const AddMissileParameter &parameter);
-void AddReflection(Missile &missile, const AddMissileParameter &parameter);
-void AddBerserk(Missile &missile, const AddMissileParameter &parameter);
+void AddHiveExplosion(Missile &missile, AddMissileParameter &parameter);
+void AddFireRune(Missile &missile, AddMissileParameter &parameter);
+void AddLightningRune(Missile &missile, AddMissileParameter &parameter);
+void AddGreatLightningRune(Missile &missile, AddMissileParameter &parameter);
+void AddImmolationRune(Missile &missile, AddMissileParameter &parameter);
+void AddStoneRune(Missile &missile, AddMissileParameter &parameter);
+void AddReflection(Missile &missile, AddMissileParameter &parameter);
+void AddBerserk(Missile &missile, AddMissileParameter &parameter);
 
 /**
  * var1: Direction to place the spawn
  */
-void AddHorkSpawn(Missile &missile, const AddMissileParameter &parameter);
-void AddJester(Missile &missile, const AddMissileParameter &parameter);
-void AddStealPotions(Missile &missile, const AddMissileParameter &parameter);
-void AddManaTrap(Missile &missile, const AddMissileParameter &parameter);
-void AddSpecArrow(Missile &missile, const AddMissileParameter &parameter);
-void AddWarp(Missile &missile, const AddMissileParameter &parameter);
-void AddLightningWall(Missile &missile, const AddMissileParameter &parameter);
-void AddRuneExplosion(Missile &missile, const AddMissileParameter &parameter);
-void AddFireNova(Missile &missile, const AddMissileParameter &parameter);
-void AddLightningArrow(Missile &missile, const AddMissileParameter &parameter);
-void AddMana(Missile &missile, const AddMissileParameter &parameter);
-void AddMagi(Missile &missile, const AddMissileParameter &parameter);
-void AddRing(Missile &missile, const AddMissileParameter &parameter);
-void AddSearch(Missile &missile, const AddMissileParameter &parameter);
-void AddCboltArrow(Missile &missile, const AddMissileParameter &parameter);
-void AddLArrow(Missile &missile, const AddMissileParameter &parameter);
-void AddArrow(Missile &missile, const AddMissileParameter &parameter);
-void AddRndTeleport(Missile &missile, const AddMissileParameter &parameter);
-void AddFirebolt(Missile &missile, const AddMissileParameter &parameter);
-void AddMagmaball(Missile &missile, const AddMissileParameter &parameter);
-void AddTeleport(Missile &missile, const AddMissileParameter &parameter);
-void AddLightball(Missile &missile, const AddMissileParameter &parameter);
-void AddFirewall(Missile &missile, const AddMissileParameter &parameter);
+void AddHorkSpawn(Missile &missile, AddMissileParameter &parameter);
+void AddJester(Missile &missile, AddMissileParameter &parameter);
+void AddStealPotions(Missile &missile, AddMissileParameter &parameter);
+void AddManaTrap(Missile &missile, AddMissileParameter &parameter);
+void AddSpecArrow(Missile &missile, AddMissileParameter &parameter);
+void AddWarp(Missile &missile, AddMissileParameter &parameter);
+void AddLightningWall(Missile &missile, AddMissileParameter &parameter);
+void AddRuneExplosion(Missile &missile, AddMissileParameter &parameter);
+void AddFireNova(Missile &missile, AddMissileParameter &parameter);
+void AddLightningArrow(Missile &missile, AddMissileParameter &parameter);
+void AddMana(Missile &missile, AddMissileParameter &parameter);
+void AddMagi(Missile &missile, AddMissileParameter &parameter);
+void AddRing(Missile &missile, AddMissileParameter &parameter);
+void AddSearch(Missile &missile, AddMissileParameter &parameter);
+void AddCboltArrow(Missile &missile, AddMissileParameter &parameter);
+void AddLArrow(Missile &missile, AddMissileParameter &parameter);
+void AddArrow(Missile &missile, AddMissileParameter &parameter);
+void AddRndTeleport(Missile &missile, AddMissileParameter &parameter);
+void AddFirebolt(Missile &missile, AddMissileParameter &parameter);
+void AddMagmaball(Missile &missile, AddMissileParameter &parameter);
+void AddTeleport(Missile &missile, AddMissileParameter &parameter);
+void AddLightball(Missile &missile, AddMissileParameter &parameter);
+void AddFirewall(Missile &missile, AddMissileParameter &parameter);
 
 /**
  * var1: X coordinate of the missile-light
@@ -282,61 +283,61 @@ void AddFirewall(Missile &missile, const AddMissileParameter &parameter);
  * var4: X coordinate of the missile-light
  * var5: Y coordinate of the missile-light
  */
-void AddFireball(Missile &missile, const AddMissileParameter &parameter);
+void AddFireball(Missile &missile, AddMissileParameter &parameter);
 
 /**
  * var1: X coordinate of the missile
  * var2: Y coordinate of the missile
  */
-void AddLightctrl(Missile &missile, const AddMissileParameter &parameter);
-void AddLightning(Missile &missile, const AddMissileParameter &parameter);
-void AddMisexp(Missile &missile, const AddMissileParameter &parameter);
-void AddWeapexp(Missile &missile, const AddMissileParameter &parameter);
+void AddLightctrl(Missile &missile, AddMissileParameter &parameter);
+void AddLightning(Missile &missile, AddMissileParameter &parameter);
+void AddMisexp(Missile &missile, AddMissileParameter &parameter);
+void AddWeapexp(Missile &missile, AddMissileParameter &parameter);
 
 /**
  * var1: Animation
  */
-void AddTown(Missile &missile, const AddMissileParameter &parameter);
-void AddFlash(Missile &missile, const AddMissileParameter &parameter);
-void AddFlash2(Missile &missile, const AddMissileParameter &parameter);
-void AddManashield(Missile &missile, const AddMissileParameter &parameter);
-void AddFiremove(Missile &missile, const AddMissileParameter &parameter);
+void AddTown(Missile &missile, AddMissileParameter &parameter);
+void AddFlash(Missile &missile, AddMissileParameter &parameter);
+void AddFlash2(Missile &missile, AddMissileParameter &parameter);
+void AddManashield(Missile &missile, AddMissileParameter &parameter);
+void AddFiremove(Missile &missile, AddMissileParameter &parameter);
 
 /**
  * var1: Animation
  * var3: Light strength
  */
-void AddGuardian(Missile &missile, const AddMissileParameter &parameter);
+void AddGuardian(Missile &missile, AddMissileParameter &parameter);
 
 /**
  * var1: X coordinate of the destination
  * var2: Y coordinate of the destination
  */
-void AddChain(Missile &missile, const AddMissileParameter &parameter);
-void AddRhino(Missile &missile, const AddMissileParameter &parameter);
+void AddChain(Missile &missile, AddMissileParameter &parameter);
+void AddRhino(Missile &missile, AddMissileParameter &parameter);
 
 /**
  * var1: X coordinate of the missile-light
  * var2: Y coordinate of the missile-light
  */
-void AddFlare(Missile &missile, const AddMissileParameter &parameter);
+void AddFlare(Missile &missile, AddMissileParameter &parameter);
 
 /**
  * var1: X coordinate of the missile-light
  * var2: Y coordinate of the missile-light
  */
-void AddAcid(Missile &missile, const AddMissileParameter &parameter);
-void AddAcidpud(Missile &missile, const AddMissileParameter &parameter);
+void AddAcid(Missile &missile, AddMissileParameter &parameter);
+void AddAcidpud(Missile &missile, AddMissileParameter &parameter);
 
 /**
  * var1: mmode of the monster
  * var2: mnum of the monster
  */
-void AddStone(Missile &missile, const AddMissileParameter &parameter);
-void AddGolem(Missile &missile, const AddMissileParameter &parameter);
-void AddBoom(Missile &missile, const AddMissileParameter &parameter);
-void AddHeal(Missile &missile, const AddMissileParameter &parameter);
-void AddHealOther(Missile &missile, const AddMissileParameter &parameter);
+void AddStone(Missile &missile, AddMissileParameter &parameter);
+void AddGolem(Missile &missile, AddMissileParameter &parameter);
+void AddBoom(Missile &missile, AddMissileParameter &parameter);
+void AddHeal(Missile &missile, AddMissileParameter &parameter);
+void AddHealOther(Missile &missile, AddMissileParameter &parameter);
 
 /**
  * var1: X coordinate of the missile-light
@@ -344,8 +345,8 @@ void AddHealOther(Missile &missile, const AddMissileParameter &parameter);
  * var4: X coordinate of the destination
  * var5: Y coordinate of the destination
  */
-void AddElement(Missile &missile, const AddMissileParameter &parameter);
-void AddIdentify(Missile &missile, const AddMissileParameter &parameter);
+void AddElement(Missile &missile, AddMissileParameter &parameter);
+void AddIdentify(Missile &missile, AddMissileParameter &parameter);
 
 /**
  * var1: X coordinate of the first wave
@@ -355,35 +356,35 @@ void AddIdentify(Missile &missile, const AddMissileParameter &parameter);
  * var5: X coordinate of the second wave
  * var6: Y coordinate of the second wave
  */
-void AddFirewallC(Missile &missile, const AddMissileParameter &parameter);
-void AddInfra(Missile &missile, const AddMissileParameter &parameter);
+void AddFirewallC(Missile &missile, AddMissileParameter &parameter);
+void AddInfra(Missile &missile, AddMissileParameter &parameter);
 
 /**
  * var1: X coordinate of the destination
  * var2: Y coordinate of the destination
  */
-void AddWave(Missile &missile, const AddMissileParameter &parameter);
-void AddNova(Missile &missile, const AddMissileParameter &parameter);
-void AddBlodboil(Missile &missile, const AddMissileParameter &parameter);
-void AddRepair(Missile &missile, const AddMissileParameter &parameter);
-void AddRecharge(Missile &missile, const AddMissileParameter &parameter);
-void AddDisarm(Missile &missile, const AddMissileParameter &parameter);
-void AddApoca(Missile &missile, const AddMissileParameter &parameter);
-void AddFlame(Missile &missile, const AddMissileParameter &parameter);
-void AddFlamec(Missile &missile, const AddMissileParameter &parameter);
+void AddWave(Missile &missile, AddMissileParameter &parameter);
+void AddNova(Missile &missile, AddMissileParameter &parameter);
+void AddBlodboil(Missile &missile, AddMissileParameter &parameter);
+void AddRepair(Missile &missile, AddMissileParameter &parameter);
+void AddRecharge(Missile &missile, AddMissileParameter &parameter);
+void AddDisarm(Missile &missile, AddMissileParameter &parameter);
+void AddApoca(Missile &missile, AddMissileParameter &parameter);
+void AddFlame(Missile &missile, AddMissileParameter &parameter);
+void AddFlamec(Missile &missile, AddMissileParameter &parameter);
 
 /**
  * var1: Light strength
  * var2: Base direction
  */
-void AddCbolt(Missile &missile, const AddMissileParameter &parameter);
-void AddHbolt(Missile &missile, const AddMissileParameter &parameter);
-void AddResurrect(Missile &missile, const AddMissileParameter &parameter);
-void AddResurrectBeam(Missile &missile, const AddMissileParameter &parameter);
-void AddTelekinesis(Missile &missile, const AddMissileParameter &parameter);
-void AddBoneSpirit(Missile &missile, const AddMissileParameter &parameter);
-void AddRportal(Missile &missile, const AddMissileParameter &parameter);
-void AddDiabApoca(Missile &missile, const AddMissileParameter &parameter);
+void AddCbolt(Missile &missile, AddMissileParameter &parameter);
+void AddHbolt(Missile &missile, AddMissileParameter &parameter);
+void AddResurrect(Missile &missile, AddMissileParameter &parameter);
+void AddResurrectBeam(Missile &missile, AddMissileParameter &parameter);
+void AddTelekinesis(Missile &missile, AddMissileParameter &parameter);
+void AddBoneSpirit(Missile &missile, AddMissileParameter &parameter);
+void AddRportal(Missile &missile, AddMissileParameter &parameter);
+void AddDiabApoca(Missile &missile, AddMissileParameter &parameter);
 Missile *AddMissile(Point src, Point dst, Direction midir, missile_id mitype, mienemy_type micaster, int id, int midam, int spllvl, Missile *pParent = nullptr);
 void MI_LArrow(Missile &missile);
 void MI_Arrow(Missile &missile);

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -194,6 +194,12 @@ void ConsumeSpell(Player &player, spell_id sn)
 		drawmanaflag = true;
 		break;
 	}
+	if (sn == SPL_FLARE) {
+		ApplyPlrDamage(player, 5);
+	}
+	if (sn == SPL_BONESPIRIT) {
+		ApplyPlrDamage(player, 6);
+	}
 }
 
 void EnsureValidReadiedSpell(Player &player)
@@ -237,18 +243,19 @@ void CastSpell(int id, spell_id spl, int sx, int sy, int dx, int dy, int spllvl)
 		dir = player.tempDirection;
 	}
 
+	bool fizzled = false;
 	for (int i = 0; i < 3 && spelldata[spl].sMissiles[i] != MIS_NULL; i++) {
-		AddMissile({ sx, sy }, { dx, dy }, dir, spelldata[spl].sMissiles[i], TARGET_MONSTERS, id, 0, spllvl);
+		Missile *missile = AddMissile({ sx, sy }, { dx, dy }, dir, spelldata[spl].sMissiles[i], TARGET_MONSTERS, id, 0, spllvl);
+		fizzled |= (missile == nullptr);
 	}
-
-	if (spl == SPL_TOWN) {
-		ConsumeSpell(player, SPL_TOWN);
-	} else if (spl == SPL_CBOLT) {
-		ConsumeSpell(player, SPL_CBOLT);
-
+	if (spl == SPL_CBOLT) {
 		for (int i = (spllvl / 2) + 3; i > 0; i--) {
-			AddMissile({ sx, sy }, { dx, dy }, dir, MIS_CBOLT, TARGET_MONSTERS, id, 0, spllvl);
+			Missile *missile = AddMissile({ sx, sy }, { dx, dy }, dir, MIS_CBOLT, TARGET_MONSTERS, id, 0, spllvl);
+			fizzled |= (missile == nullptr);
 		}
+	}
+	if (!fizzled) {
+		ConsumeSpell(player, spl);
 	}
 }
 


### PR DESCRIPTION
Moves the invocation of `ConsumeSpell()` to the `CastSpell()` function. This ensures that the mana, scroll, or staff charge is only consumed when a player casts a spell, and avoids all the tricky logic in the `AddMissile()` functions to ensure that a player did indeed cast the spell (as opposed to a monster, trap, Guardian, etc). For missiles that would conditionally fail, such as Stone Curse when it can't find a target, I added the `Missile::_miSpellFizzle` variable to indicate that the spell should not consume mana. This works out well for `AddJester()` which previously relied on the call to `ConsumeSpell()` in the `AddMissile()` function for the random missile that it generated to consume the staff charge. Now it more appropriately invokes `ConsumeSpell(player, SPL_JESTER)` if the generated missile does not fizzle.

Alternative to #5243
This resolves #5237