### PR TITLE
Include runes in CanUseScroll() validation

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -2013,7 +2013,7 @@ bool CanUseScroll(Player &player, spell_id spell)
 		return false;
 
 	return HasInventoryOrBeltItem(player, [spell](const Item &item) {
-		return item.isScrollOf(spell);
+		return item.isScrollOf(spell) || item.isRuneOf(spell);
 	});
 }
 


### PR DESCRIPTION
Fixes an issue where the player simply cannot use runes.

https://user-images.githubusercontent.com/9203145/196257264-db3721f5-4f62-4180-860a-8d6fa98bf579.mp4