### PR TITLE
Network drop Items: Always use passed coordinates for item position

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1981,14 +1981,13 @@ bool TryDropItem()
 		}
 	}
 
-	Point position = myPlayer.position.future;
-	Direction direction = myPlayer._pdir;
-	if (!FindAdjacentPositionForItem(position, direction)) {
+	std::optional<Point> itemTile = FindAdjacentPositionForItem(myPlayer.position.future, myPlayer._pdir);
+	if (!itemTile) {
 		myPlayer.Say(HeroSpeech::WhereWouldIPutThis);
 		return false;
 	}
 
-	NetSendCmdPItem(true, CMD_PUTITEM, position + direction, myPlayer.HoldItem);
+	NetSendCmdPItem(true, CMD_PUTITEM, *itemTile, myPlayer.HoldItem);
 	myPlayer.HoldItem.clear();
 	NewCursor(CURSOR_HAND);
 	return true;

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -346,8 +346,9 @@ void LeftMouseDown(uint16_t modState)
 				CheckSBook();
 			} else if (!MyPlayer->HoldItem.isEmpty()) {
 				Point currentPosition = MyPlayer->position.tile;
-				if (FindAdjacentPositionForItem(currentPosition, GetDirection(currentPosition, cursPosition))) {
-					NetSendCmdPItem(true, CMD_PUTITEM, cursPosition, MyPlayer->HoldItem);
+				std::optional<Point> itemTile = FindAdjacentPositionForItem(currentPosition, GetDirection(currentPosition, cursPosition));
+				if (itemTile) {
+					NetSendCmdPItem(true, CMD_PUTITEM, *itemTile, MyPlayer->HoldItem);
 					NewCursor(CURSOR_HAND);
 				}
 			} else {

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1817,11 +1817,10 @@ int SyncPutItem(const Player &player, Point position, _item_indexes idx, uint16_
 			return -1;
 	}
 
-	std::optional<Point> itemTile = FindAdjacentPositionForItem(player.position.tile, GetDirection(player.position.tile, position));
-	if (!itemTile)
+	if (ActiveItemCount >= MAXITEMS)
 		return -1;
 
-	return SyncDropItem(*itemTile, idx, icreateinfo, iseed, id, dur, mdur, ch, mch, ivalue, ibuff, toHit, maxDam, minStr, minMag, minDex, ac);
+	return SyncDropItem(position, idx, icreateinfo, iseed, id, dur, mdur, ch, mch, ivalue, ibuff, toHit, maxDam, minStr, minMag, minDex, ac);
 }
 
 int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac)

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1808,9 +1808,9 @@ int InvPutItem(const Player &player, Point position, const Item &item)
 	return ii;
 }
 
-int SyncPutItem(const Player &player, Point position, _item_indexes idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac)
+int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac)
 {
-	if (player.isOnLevel(0)) {
+	if (MyPlayer->isOnLevel(0)) {
 		if (idx == IDI_RUNEBOMB && OpensHive(position))
 			return -1;
 		if (idx == IDI_MAPOFDOOM && OpensGrave(position))
@@ -1820,11 +1820,6 @@ int SyncPutItem(const Player &player, Point position, _item_indexes idx, uint16_
 	if (ActiveItemCount >= MAXITEMS)
 		return -1;
 
-	return SyncDropItem(position, idx, icreateinfo, iseed, id, dur, mdur, ch, mch, ivalue, ibuff, toHit, maxDam, minStr, minMag, minDex, ac);
-}
-
-int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac)
-{
 	int ii = AllocateItem();
 	auto &item = Items[ii];
 
@@ -1856,17 +1851,11 @@ int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int is
 	return ii;
 }
 
-int SyncPutEar(const Player &player, Point position, uint16_t icreateinfo, int iseed, uint8_t cursval, string_view heroname)
-{
-	std::optional<Point> itemTile = FindAdjacentPositionForItem(player.position.tile, GetDirection(player.position.tile, position));
-	if (!itemTile)
-		return -1;
-
-	return SyncDropEar(*itemTile, icreateinfo, iseed, cursval, heroname);
-}
-
 int SyncDropEar(Point position, uint16_t icreateinfo, int iseed, uint8_t cursval, string_view heroname)
 {
+	if (ActiveItemCount >= MAXITEMS)
+		return -1;
+
 	int ii = AllocateItem();
 	auto &item = Items[ii];
 

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -224,9 +224,7 @@ void SyncGetItem(Point position, int32_t iseed, _item_indexes idx, uint16_t ci);
 bool CanPut(Point position);
 
 int InvPutItem(const Player &player, Point position, const Item &item);
-int SyncPutItem(const Player &player, Point position, _item_indexes idx, uint16_t icreateinfo, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
 int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
-int SyncPutEar(const Player &player, Point position, uint16_t icreateinfo, int iseed, uint8_t cursval, string_view heroname);
 int SyncDropEar(Point position, uint16_t icreateinfo, int iseed, uint8_t cursval, string_view heroname);
 int8_t CheckInvHLight();
 bool CanUseScroll(Player &player, spell_id spell);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -154,6 +154,25 @@ DLevel &GetDeltaLevel(const Player &player)
 	return GetDeltaLevel(level);
 }
 
+Point GetItemPosition(Point position)
+{
+	if (CanPut(position))
+		return position;
+
+	for (int k = 1; k < 50; k++) {
+		for (int j = -k; j <= k; j++) {
+			int yy = position.y + j;
+			for (int l = -k; l <= k; l++) {
+				int xx = position.x + l;
+				if (CanPut({ xx, yy }))
+					return { xx, yy };
+			}
+		}
+	}
+
+	return position;
+}
+
 /**
  * @brief Throttles that a player command is only sent once per game tick.
  * This is a workaround for a desync that happens when a command is processed in different game ticks for different clients. See https://github.com/diasurgical/devilutionX/issues/2681 for details.
@@ -962,11 +981,11 @@ int SyncPutEar(const TEar &ear)
 	    ear.heroname);
 }
 
-int SyncPutItem(const Player &player, const TItem &item)
+int SyncPutItem(const Player &player, Point position, const TItem &item)
 {
 	return SyncPutItem(
 	    player,
-	    player.position.tile,
+	    position,
 	    item.wIndx,
 	    item.wCI,
 	    item.dwSeed,
@@ -989,14 +1008,14 @@ int SyncPutItem(const Player &player, const TCmdGItem &message)
 {
 	if (message.def.wIndx == IDI_EAR)
 		return SyncPutEar(message.ear);
-	return SyncPutItem(player, message.item);
+	return SyncPutItem(player, GetItemPosition({ message.x, message.y }), message.item);
 }
 
 int SyncPutItem(const Player &player, const TCmdPItem &message)
 {
 	if (message.def.wIndx == IDI_EAR)
 		return SyncPutEar(message.ear);
-	return SyncPutItem(player, message.item);
+	return SyncPutItem(player, GetItemPosition({ message.x, message.y }), message.item);
 }
 
 int SyncDropItem(Point position, const TCmdPItem message)
@@ -2608,29 +2627,6 @@ void DeltaSaveLevel()
 	}
 	DeltaLeaveSync(localLevel);
 }
-
-namespace {
-
-Point GetItemPosition(Point position)
-{
-	if (CanPut(position))
-		return position;
-
-	for (int k = 1; k < 50; k++) {
-		for (int j = -k; j <= k; j++) {
-			int yy = position.y + j;
-			for (int l = -k; l <= k; l++) {
-				int xx = position.x + l;
-				if (CanPut({ xx, yy }))
-					return { xx, yy };
-			}
-		}
-	}
-
-	return position;
-}
-
-} // namespace
 
 uint8_t GetLevelForMultiplayer(const Player &player)
 {


### PR DESCRIPTION
Fixes #4124

When syncing dropped items `SyncPutItem` is used on the remote client.
`SyncPutItem` used `FindAdjacentPositionForItem` and the player position to get the coordinates of the new item.
`FindAdjacentPositionForItem` use only the adjacent positions relative to the player.
If no space is free the item is not placed on the remote client.
This is okay for normal player drops, cause the same check is done in `LeftMouseDown` or `TryDropItem`.

But when items are dropped on death `FindAdjacentPositionForItem` is not used (see `DeadItem`).
That allows dropping on death to occupy more tiles then `FindAdjacentPositionForItem`.
But when syncing with other clients the remote client uses `SyncPutItem` and `SyncPutItem` only allows adjacent tiles.
That can result in desyncs.

The bugfix is that `SyncPutItem` don't use `FindAdjacentPositionForItem` and instead get the desired tile from the remote client.
To further ensure no item desyncs happens, we use the same logic when loading a level (a call to `GetItemPosition` that looks for the next free tile).

Last commit combines `SyncPutItem` and `SyncDropItem` and fixes the issue also for dropped ears.