### PR TITLE
TimeoutCursor: Only restore previous cursor when cursor is not already changed

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1324,7 +1324,11 @@ void TimeoutCursor(bool bTimeout)
 		}
 		scrollrt_draw_game_screen();
 	} else if (sgnTimeoutCurs != CURSOR_NONE) {
-		NewCursor(sgnTimeoutCurs);
+		// Timeout is gone, we should restore the previous cursor.
+		// But the timeout cursor could already be changed by the now processed messages (for example item cursor from CMD_GETITEM).
+		// Changing the item cursor back to the previous (hand) cursor could result in deleted items, cause this resets Player.HoldItem (see NewCursor).
+		if (pcurs == CURSOR_HOURGLASS)
+			NewCursor(sgnTimeoutCurs);
 		sgnTimeoutCurs = CURSOR_NONE;
 		InfoString = {};
 		force_redraw = 255;


### PR DESCRIPTION
Contributes to #4491 (or fixes it? 🤔)

How to reproduce #4491 in master
- Try to pick up a item as a remote client (OnRequestItem).
- Add a sleep in OnRequestItem.
- Lag => `TimeoutCursor(true)` is called. It stores current hand cursor in `sgnTimeoutCurs` and sets hourglass cursor.
- Lag is gone => Messages gets handled => `OnGetItem` is called => `OnGetItem` sets item cursor => `TimeoutCursor(false)` is called and calls NewCursor with the stored cursor (`sgnTimeoutCurs` with the stored hand cursor) => `NewCursor` clears `HoldItem` => Item is gone.