### PR TITLE
Only color cycle animations if game logic is processed

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -765,9 +765,9 @@ void RunGameLoop(interface_mode uMsg)
 			continue;
 		}
 
-		diablo_color_cyc_logic();
 		multi_process_network_packets();
-		game_loop(gbGameLoopStartup);
+		if (game_loop(gbGameLoopStartup))
+			diablo_color_cyc_logic();
 		gbGameLoopStartup = false;
 		if (drawGame)
 			DrawAndBlit();
@@ -2818,14 +2818,14 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 	pcursplr = -1;
 }
 
-void game_loop(bool bStartup)
+bool game_loop(bool bStartup)
 {
 	uint16_t wait = bStartup ? sgGameInitInfo.nTickRate * 3 : 3;
 
 	for (unsigned i = 0; i < wait; i++) {
 		if (!multi_handle_delta()) {
 			TimeoutCursor(true);
-			break;
+			return false;
 		}
 		TimeoutCursor(false);
 		GameLogic();
@@ -2834,6 +2834,7 @@ void game_loop(bool bStartup)
 		if (!gbRunGame || !gbIsMultiplayer || demo::IsRunning() || demo::IsRecording() || !nthread_has_500ms_passed())
 			break;
 	}
+	return true;
 }
 
 void diablo_color_cyc_logic()

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -99,7 +99,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir);
 /**
  * @param bStartup Process additional ticks before returning
  */
-void game_loop(bool bStartup);
+bool game_loop(bool bStartup);
 void diablo_color_cyc_logic();
 
 /* rdata */


### PR DESCRIPTION
Fixes #5282

When a lag occurs the game tries to run `game_loop`. But fails to do so (cause of the lag).
Then the game is drawn and in the next main loop it tires to run `game_loop` again (and fails).

The problem is that at every try it executes `diablo_color_cyc_logic`. That's why the animations updates very fast/go crazy.

Solution: Only call `diablo_color_cyc_logic` when the game loop is successfully executed. If not don't update the animations (similar to game pause).