### PR TITLE
Don't process get request item commands after start changing level

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -670,6 +670,8 @@ bool IOwnLevel(const Player &player)
 			continue;
 		if (other._pLvlChanging)
 			continue;
+		if (other._pmode == PM_NEWLVL)
+			continue;
 		if (other.plrlevel != player.plrlevel)
 			continue;
 		if (other.plrIsOnSetLevel != player.plrIsOnSetLevel)


### PR DESCRIPTION
Fixes #4566

- Game logic
  - `ProcessPlayers` is called -> Player gets next to item tile / on the portal tile -> `CMD_REQUESTAGITEM` is send
  - `ProcessMissiles` is called -> `MI_Town` is called -> CMD_WARP is send and `PM_NEWLVL` is set
- Messages gets handled
  - `OnRequestAutoGetItem` is called -> No space for item is found -> `CMD_RESPAWNITEM` is send
  - `OnWarp` is called -> Player level is changed
  - `OnRespawnItem` is called -> Item is placed not in the original level but in the warped level. That means the item is not really destroyed only placed very badly. 😜 

Bugfix is that the player stops owning the level when he starts to warp (`PM_NEWLVL` is set).

Side effect: When started warping item is not tried to pick up In single- and multiplayer.