### PR TITLE
Fix opening Hive/Crypt with mouse

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -26,6 +26,7 @@
 #include "hwcursor.hpp"
 #include "inv.h"
 #include "items.h"
+#include "levels/town.h"
 #include "levels/trigs.h"
 #include "minitext.h"
 #include "missiles.h"
@@ -1970,12 +1971,12 @@ bool TryDropItem()
 
 	if (leveltype == DTYPE_TOWN) {
 		if (UseItemOpensHive(myPlayer.HoldItem, myPlayer.position.tile)) {
-			NetSendCmdPItem(true, CMD_PUTITEM, { 79, 61 }, myPlayer.HoldItem.pop());
+			OpenHive();
 			NewCursor(CURSOR_HAND);
 			return true;
 		}
-		if (UseItemOpensCrypt(myPlayer.HoldItem, myPlayer.position.tile)) {
-			NetSendCmdPItem(true, CMD_PUTITEM, { 35, 20 }, myPlayer.HoldItem.pop());
+		if (UseItemOpensGrave(myPlayer.HoldItem, myPlayer.position.tile)) {
+			OpenGrave();
 			NewCursor(CURSOR_HAND);
 			return true;
 		}

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -287,6 +287,23 @@ void LeftMouseCmd(bool bShift)
 	}
 }
 
+bool TryOpenDungeonWithMouse()
+{
+	if (leveltype != DTYPE_TOWN)
+		return false;
+
+	Item &holdItem = MyPlayer->HoldItem;
+	if (holdItem.IDidx == IDI_RUNEBOMB && OpensHive(cursPosition))
+		OpenHive();
+	else if (holdItem.IDidx == IDI_MAPOFDOOM && OpensGrave(cursPosition))
+		OpenGrave();
+	else
+		return false;
+
+	NewCursor(CURSOR_HAND);
+	return true;
+}
+
 void LeftMouseDown(uint16_t modState)
 {
 	LastMouseButtonAction = MouseActionType::None;
@@ -345,11 +362,13 @@ void LeftMouseDown(uint16_t modState)
 			} else if (sbookflag && GetRightPanel().contains(MousePosition)) {
 				CheckSBook();
 			} else if (!MyPlayer->HoldItem.isEmpty()) {
-				Point currentPosition = MyPlayer->position.tile;
-				std::optional<Point> itemTile = FindAdjacentPositionForItem(currentPosition, GetDirection(currentPosition, cursPosition));
-				if (itemTile) {
-					NetSendCmdPItem(true, CMD_PUTITEM, *itemTile, MyPlayer->HoldItem);
-					NewCursor(CURSOR_HAND);
+				if (!TryOpenDungeonWithMouse()) {
+					Point currentPosition = MyPlayer->position.tile;
+					std::optional<Point> itemTile = FindAdjacentPositionForItem(currentPosition, GetDirection(currentPosition, cursPosition));
+					if (itemTile) {
+						NetSendCmdPItem(true, CMD_PUTITEM, *itemTile, MyPlayer->HoldItem);
+						NewCursor(CURSOR_HAND);
+					}
 				}
 			} else {
 				CheckLvlBtn();

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -937,24 +937,6 @@ void CheckQuestItem(Player &player, Item &questItem)
 	TryCombineNaKrulNotes(player, questItem);
 }
 
-void OpenHive()
-{
-	NetSendCmd(false, CMD_OPENHIVE);
-	auto &quest = Quests[Q_FARMER];
-	quest._qactive = QUEST_DONE;
-	if (gbIsMultiplayer)
-		NetSendCmdQuest(true, quest);
-}
-
-void OpenCrypt()
-{
-	NetSendCmd(false, CMD_OPENCRYPT);
-	auto &quest = Quests[Q_GRAVE];
-	quest._qactive = QUEST_DONE;
-	if (gbIsMultiplayer)
-		NetSendCmdQuest(true, quest);
-}
-
 void CleanupItems(int ii)
 {
 	auto &item = Items[ii];
@@ -1776,17 +1758,6 @@ bool CanPut(Point position)
 
 int InvPutItem(const Player &player, Point position, const Item &item)
 {
-	if (player.isOnLevel(0)) {
-		if (item.IDidx == IDI_RUNEBOMB && OpensHive(position)) {
-			OpenHive();
-			return -1;
-		}
-		if (item.IDidx == IDI_MAPOFDOOM && OpensGrave(position)) {
-			OpenCrypt();
-			return -1;
-		}
-	}
-
 	std::optional<Point> itemTile = FindAdjacentPositionForItem(player.position.tile, GetDirection(player.position.tile, position));
 	if (!itemTile)
 		return -1;
@@ -1810,13 +1781,6 @@ int InvPutItem(const Player &player, Point position, const Item &item)
 
 int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac)
 {
-	if (MyPlayer->isOnLevel(0)) {
-		if (idx == IDI_RUNEBOMB && OpensHive(position))
-			return -1;
-		if (idx == IDI_MAPOFDOOM && OpensGrave(position))
-			return -1;
-	}
-
 	if (ActiveItemCount >= MAXITEMS)
 		return -1;
 
@@ -2101,8 +2065,8 @@ bool UseInvItem(size_t pnum, int cii)
 			player.RemoveInvItem(c);
 			return true;
 		}
-		if (UseItemOpensCrypt(*item, player.position.tile)) {
-			OpenCrypt();
+		if (UseItemOpensGrave(*item, player.position.tile)) {
+			OpenGrave();
 			player.RemoveInvItem(c);
 			return true;
 		}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3985,7 +3985,7 @@ bool UseItemOpensHive(const Item &item, Point position)
 	return false;
 }
 
-bool UseItemOpensCrypt(const Item &item, Point position)
+bool UseItemOpensGrave(const Item &item, Point position)
 {
 	if (item.IDidx != IDI_MAPOFDOOM)
 		return false;

--- a/Source/items.h
+++ b/Source/items.h
@@ -527,7 +527,7 @@ void PrintItemDetails(const Item &item);
 void PrintItemDur(const Item &item);
 void UseItem(size_t pnum, item_misc_id Mid, spell_id spl);
 bool UseItemOpensHive(const Item &item, Point position);
-bool UseItemOpensCrypt(const Item &item, Point position);
+bool UseItemOpensGrave(const Item &item, Point position);
 void SpawnSmith(int lvl);
 void SpawnPremium(const Player &player);
 void SpawnWitch(int lvl);

--- a/Source/levels/town.cpp
+++ b/Source/levels/town.cpp
@@ -259,6 +259,24 @@ bool OpensGrave(Point position)
 	return xp >= 35 && xp <= 38 && yp >= 20 && yp <= 24;
 }
 
+void OpenHive()
+{
+	NetSendCmd(false, CMD_OPENHIVE);
+	auto &quest = Quests[Q_FARMER];
+	quest._qactive = QUEST_DONE;
+	if (gbIsMultiplayer)
+		NetSendCmdQuest(true, quest);
+}
+
+void OpenGrave()
+{
+	NetSendCmd(false, CMD_OPENGRAVE);
+	auto &quest = Quests[Q_GRAVE];
+	quest._qactive = QUEST_DONE;
+	if (gbIsMultiplayer)
+		NetSendCmdQuest(true, quest);
+}
+
 void TownOpenHive()
 {
 	dungeon[36][27] = 47;

--- a/Source/levels/town.h
+++ b/Source/levels/town.h
@@ -25,6 +25,16 @@ bool OpensHive(Point position);
 bool OpensGrave(Point position);
 
 /**
+ * @brief Initiate opening of hive by sending network messages and updating quest state
+ */
+void OpenHive();
+
+/**
+ * @brief Initiate opening of grave by sending network messages and updating quest state
+ */
+void OpenGrave();
+
+/**
  * @brief Update the map to show the open hive
  */
 void TownOpenHive();

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2368,7 +2368,7 @@ size_t OnOpenHive(const TCmd *pCmd, size_t pnum)
 	return sizeof(*pCmd);
 }
 
-size_t OnOpenCrypt(const TCmd *pCmd)
+size_t OnOpenGrave(const TCmd *pCmd)
 {
 	if (gbBufferMsgs != 1) {
 		TownOpenGrave();
@@ -3269,8 +3269,8 @@ size_t ParseCmd(size_t pnum, const TCmd *pCmd)
 		return OnNakrul(pCmd);
 	case CMD_OPENHIVE:
 		return OnOpenHive(pCmd, pnum);
-	case CMD_OPENCRYPT:
-		return OnOpenCrypt(pCmd);
+	case CMD_OPENGRAVE:
+		return OnOpenGrave(pCmd);
 	default:
 		break;
 	}

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -437,7 +437,7 @@ enum _cmd_id : uint8_t {
 	CMD_SETREFLECT,
 	CMD_NAKRUL,
 	CMD_OPENHIVE,
-	CMD_OPENCRYPT,
+	CMD_OPENGRAVE,
 	// Fake command; set current player for succeeding mega pkt buffer messages.
 	//
 	// body (TFakeCmdPlr)


### PR DESCRIPTION
Previously, dropping the Rune Bomb or Cathedral Map would generate a `CMD_PUTITEM` message, triggering `InvPutItem()` on the local client or `SyncDropItem()` on remote clients. The local client would then proceed to generate `CMD_OPENHIVE` or `CMD_OPENCRYPT` as appropriate and skip the rest of the `InvPutItem()` logic. Remote clients would literally just ignore the `CMD_PUTITEM` message. The idea here is to skip the unnecessary `CMD_PUTITEM` command when it would be more appropriate to just generate `CMD_OPENHIVE` or `CMD_OPENCRYPT` instead.

I also went ahead and renamed functions/enums to use the term "Grave" instead of "Crypt" more consistently.

This resolves #5433