### PR TITLE
Avoid copy construction of PadmapperOptions::Action

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1591,7 +1591,7 @@ bool PadmapperOptions::Action::SetValue(ControllerButtonCombo value)
 
 void PadmapperOptions::AddAction(string_view key, const char *name, const char *description, ControllerButtonCombo defaultInput, std::function<void()> actionPressed, std::function<void()> actionReleased, std::function<bool()> enable, unsigned index)
 {
-	actions.push_front(Action { key, name, description, defaultInput, std::move(actionPressed), std::move(actionReleased), std::move(enable), index });
+	actions.emplace_front(key, name, description, defaultInput, std::move(actionPressed), std::move(actionReleased), std::move(enable), index);
 }
 
 void PadmapperOptions::ButtonPressed(ControllerButton button)

--- a/Source/options.h
+++ b/Source/options.h
@@ -633,6 +633,10 @@ struct KeymapperOptions : OptionCategoryBase {
 	 */
 	class Action final : public OptionEntryBase {
 	public:
+		// OptionEntryBase::key may be referencing Action::dynamicKey.
+		// The implicit copy constructor would copy that reference instead of referencing the copy.
+		Action(const Action &) = delete;
+
 		[[nodiscard]] string_view GetName() const override;
 		[[nodiscard]] OptionEntryType GetType() const override
 		{
@@ -689,6 +693,12 @@ struct PadmapperOptions : OptionCategoryBase {
 	 */
 	class Action final : public OptionEntryBase {
 	public:
+		Action(string_view key, const char *name, const char *description, ControllerButtonCombo defaultInput, std::function<void()> actionPressed, std::function<void()> actionReleased, std::function<bool()> enable, unsigned index);
+
+		// OptionEntryBase::key may be referencing Action::dynamicKey.
+		// The implicit copy constructor would copy that reference instead of referencing the copy.
+		Action(const Action &) = delete;
+
 		[[nodiscard]] string_view GetName() const override;
 		[[nodiscard]] OptionEntryType GetType() const override
 		{
@@ -703,7 +713,6 @@ struct PadmapperOptions : OptionCategoryBase {
 		bool SetValue(ControllerButtonCombo value);
 
 	private:
-		Action(string_view key, const char *name, const char *description, ControllerButtonCombo defaultInput, std::function<void()> actionPressed, std::function<void()> actionReleased, std::function<bool()> enable, unsigned index);
 		ControllerButtonCombo defaultInput;
 		std::function<void()> actionPressed;
 		std::function<void()> actionReleased;


### PR DESCRIPTION
Padmapper actions which use format args to generate their key produce garbage data in the INI file. This happens because the `std::forward_list::push_front()` function uses the copy constructor of `PadmapperOptions::Action` which copies the reference in the `OptionEntryBase::key` variable instead of updating the reference to point to the copy. Once the copied action is deallocated, the copy points to the deallocated memory.

Special thanks to @obligaron for noticing the issue and identifying the cause.