### PR TITLE
Overhaul backbuffer state handling

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -96,6 +96,7 @@ set(libdevilutionx_SRCS
   engine/actor_position.cpp
   engine/animationinfo.cpp
   engine/assets.cpp
+  engine/backbuffer_state.cpp
   engine/direction.cpp
   engine/dx.cpp
   engine/load_cel.cpp

--- a/Source/DiabloUI/progress.cpp
+++ b/Source/DiabloUI/progress.cpp
@@ -96,14 +96,19 @@ bool UiProgressDialog(int (*fnfunc)())
 
 	// Blit the background once and then free it.
 	ProgressLoadBackground();
+
 	ProgressRenderBackground();
-	if (RenderDirectlyToOutputSurface && IsDoubleBuffered()) {
-		// Blit twice for triple buffering.
-		for (unsigned i = 0; i < 2; ++i) {
-			UiFadeIn();
+
+	if (RenderDirectlyToOutputSurface && PalSurface != nullptr) {
+		// Render into all the backbuffers if there are multiple.
+		const void *initialPixels = PalSurface->pixels;
+		UiFadeIn();
+		while (PalSurface->pixels != initialPixels) {
 			ProgressRenderBackground();
+			UiFadeIn();
 		}
 	}
+
 	ProgressFreeBackground();
 
 	ProgressLoadForeground();

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 
 #include "DiabloUI/diabloui.h"
+#include "engine/backbuffer_state.hpp"
 #include "engine/dx.h"
 #include "engine/palette.h"
 #include "utils/file_util.h"
@@ -195,7 +196,7 @@ void CaptureScreen()
 		system_palette[i] = palette[i];
 	}
 	palette_update();
-	force_redraw = 255;
+	RedrawEverything();
 }
 
 } // namespace devilution

--- a/Source/control.h
+++ b/Source/control.h
@@ -32,12 +32,10 @@ namespace devilution {
 
 constexpr Size SidePanelSize { 320, 352 };
 
-extern bool drawhpflag;
 extern bool dropGoldFlag;
 extern bool chrbtn[4];
 extern bool lvlbtndown;
 extern int dropGoldValue;
-extern bool drawmanaflag;
 extern bool chrbtnactive;
 extern UiFlags InfoColor;
 extern int sbooktab;
@@ -45,7 +43,6 @@ extern int8_t initialDropGoldIndex;
 extern bool talkflag;
 extern bool sbookflag;
 extern bool chrflag;
-extern bool drawbtnflag;
 extern StringOrView InfoString;
 extern bool panelflag;
 extern int initialDropGoldValue;

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -12,6 +12,7 @@
 #include "controls/plrctrls.h"
 #include "doom.h"
 #include "engine.h"
+#include "engine/backbuffer_state.hpp"
 #include "engine/load_cel.hpp"
 #include "engine/point.hpp"
 #include "engine/render/clx_render.hpp"
@@ -381,7 +382,7 @@ void CheckCursMove()
 	ObjectUnderCursor = nullptr;
 	pcursitem = -1;
 	if (pcursinvitem != -1) {
-		drawsbarflag = true;
+		RedrawComponent(PanelDrawComponent::Belt);
 	}
 	pcursinvitem = -1;
 	pcursstashitem = uint16_t(-1);

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -14,6 +14,7 @@
 #include "automap.h"
 #include "control.h"
 #include "cursor.h"
+#include "engine/backbuffer_state.hpp"
 #include "engine/load_cel.hpp"
 #include "engine/point.hpp"
 #include "error.h"
@@ -550,8 +551,8 @@ std::string DebugCmdRefillHealthMana(const string_view parameter)
 	Player &myPlayer = *MyPlayer;
 	myPlayer.RestoreFullLife();
 	myPlayer.RestoreFullMana();
-	drawhpflag = true;
-	drawmanaflag = true;
+	RedrawComponent(PanelDrawComponent::Health);
+	RedrawComponent(PanelDrawComponent::Mana);
 
 	return "Ready for more.";
 }
@@ -589,7 +590,7 @@ std::string DebugCmdChangeMana(const string_view parameter)
 	int newMana = myPlayer._pMana + (change * 64);
 	myPlayer._pMana = newMana;
 	myPlayer._pManaBase = myPlayer._pMana + myPlayer._pMaxManaBase - myPlayer._pMaxMana;
-	drawmanaflag = true;
+	RedrawComponent(PanelDrawComponent::Mana);
 
 	return "Mana has changed.";
 }

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -66,7 +66,6 @@ extern bool ReturnToMainMenu;
 extern bool gbProcessPlayers;
 extern DVL_API_FOR_TEST bool gbLoadGame;
 extern bool cineflag;
-extern int force_redraw;
 /* These are defined in fonts.h */
 extern void FontsCleanup();
 extern DVL_API_FOR_TEST int PauseMode;

--- a/Source/engine/backbuffer_state.cpp
+++ b/Source/engine/backbuffer_state.cpp
@@ -1,0 +1,98 @@
+#include "engine/backbuffer_state.hpp"
+
+#include <unordered_map>
+
+#include "engine/dx.h"
+#include "utils/enum_traits.h"
+
+namespace devilution {
+namespace {
+
+struct RedrawState {
+	enum {
+		RedrawNone,
+		RedrawViewportOnly,
+		RedrawAll
+	} Redraw;
+	std::array<bool, enum_size<PanelDrawComponent>::value> redrawComponents;
+};
+
+struct BackbufferState {
+	RedrawState redrawState;
+	DrawnCursor cursor;
+};
+
+std::unordered_map<void *, BackbufferState> States;
+
+BackbufferState &GetBackbufferState()
+{
+	// `PalSurface` is null in headless mode.
+	void *ptr = PalSurface != nullptr ? PalSurface->pixels : nullptr;
+	auto result = States.emplace(std::piecewise_construct, std::forward_as_tuple(ptr), std::forward_as_tuple());
+	BackbufferState &state = result.first->second;
+	if (result.second)
+		state.redrawState.Redraw = RedrawState::RedrawAll;
+	return state;
+}
+
+} // namespace
+
+bool IsRedrawEverything()
+{
+	return GetBackbufferState().redrawState.Redraw == RedrawState::RedrawAll;
+}
+
+void RedrawViewport()
+{
+	for (auto &&it : States) {
+		if (it.second.redrawState.Redraw != RedrawState::RedrawAll) {
+			it.second.redrawState.Redraw = RedrawState::RedrawViewportOnly;
+		}
+	}
+}
+
+bool IsRedrawViewport()
+{
+	return GetBackbufferState().redrawState.Redraw == RedrawState::RedrawViewportOnly;
+}
+
+void RedrawComplete()
+{
+	GetBackbufferState().redrawState.Redraw = RedrawState::RedrawNone;
+}
+
+void RedrawEverything()
+{
+	for (auto &&it : States) {
+		it.second.redrawState.Redraw = RedrawState::RedrawAll;
+	}
+}
+
+void InitBackbufferState()
+{
+	States.clear();
+}
+
+void RedrawComponent(PanelDrawComponent component)
+{
+	for (auto &&it : States) {
+		it.second.redrawState.redrawComponents[static_cast<size_t>(component)] = true;
+	}
+}
+
+bool IsRedrawComponent(PanelDrawComponent component)
+{
+	return GetBackbufferState().redrawState.redrawComponents[static_cast<size_t>(component)];
+}
+
+void RedrawComponentComplete(PanelDrawComponent component)
+{
+	GetBackbufferState().redrawState.redrawComponents[static_cast<size_t>(component)] = false;
+}
+
+DrawnCursor &GetDrawnCursor()
+{
+	return GetBackbufferState().cursor;
+}
+
+} // namespace devilution

--- a/Source/engine/backbuffer_state.hpp
+++ b/Source/engine/backbuffer_state.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+
+#include "engine/rectangle.hpp"
+#include "engine/surface.hpp"
+
+namespace devilution {
+
+enum class PanelDrawComponent {
+	Health,
+	Mana,
+	ControlButtons,
+	Belt,
+	ChatInput,
+
+	FIRST = Health,
+	LAST = ChatInput
+};
+
+struct DrawnCursor {
+	Rectangle rect;
+	uint8_t behindBuffer[8192];
+};
+
+void InitBackbufferState();
+
+void RedrawEverything();
+bool IsRedrawEverything();
+void RedrawViewport();
+bool IsRedrawViewport();
+void RedrawComplete();
+
+void RedrawComponent(PanelDrawComponent component);
+bool IsRedrawComponent(PanelDrawComponent component);
+void RedrawComponentComplete(PanelDrawComponent component);
+
+DrawnCursor &GetDrawnCursor();
+
+} // namespace devilution

--- a/Source/engine/dx.h
+++ b/Source/engine/dx.h
@@ -12,6 +12,8 @@ namespace devilution {
 /** Whether we render directly to the screen surface, i.e. `PalSurface == GetOutputSurface()` */
 extern bool RenderDirectlyToOutputSurface;
 
+extern SDL_Surface *PalSurface;
+
 Surface GlobalBackBuffer();
 
 void dx_init();

--- a/Source/engine/palette.cpp
+++ b/Source/engine/palette.cpp
@@ -7,6 +7,7 @@
 
 #include <fmt/compile.h>
 
+#include "engine/backbuffer_state.hpp"
 #include "engine/dx.h"
 #include "engine/load_file.hpp"
 #include "engine/random.hpp"
@@ -195,7 +196,7 @@ void ApplyGamma(SDL_Color *dst, const SDL_Color *src, int n)
 		dst[i].g = static_cast<Uint8>(pow(src[i].g / 256.0, g) * 256.0);
 		dst[i].b = static_cast<Uint8>(pow(src[i].b / 256.0, g) * 256.0);
 	}
-	force_redraw = 255;
+	RedrawEverything();
 }
 
 void palette_init()

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -6,6 +6,7 @@
 #include "gamemenu.h"
 
 #include "cursor.h"
+#include "engine/backbuffer_state.hpp"
 #include "engine/sound.h"
 #include "engine/sound_defs.hpp"
 #include "error.h"
@@ -102,7 +103,7 @@ void GamemenuNewGame(bool /*bActivate*/)
 
 	MyPlayerIsDead = false;
 	if (!HeadlessMode) {
-		force_redraw = 255;
+		RedrawEverything();
 		scrollrt_draw_game_screen();
 	}
 	CornerStone.activated = false;
@@ -293,14 +294,14 @@ void gamemenu_load_game(bool /*bActivate*/)
 	gamemenu_off();
 	NewCursor(CURSOR_NONE);
 	InitDiabloMsg(EMSG_LOADING);
-	force_redraw = 255;
+	RedrawEverything();
 	DrawAndBlit();
 	LoadGame(false);
 	ClrDiabloMsg();
 	CornerStone.activated = false;
 	PaletteFadeOut(8);
 	MyPlayerIsDead = false;
-	force_redraw = 255;
+	RedrawEverything();
 	DrawAndBlit();
 	LoadPWaterPalette();
 	PaletteFadeIn(8);
@@ -324,11 +325,11 @@ void gamemenu_save_game(bool /*bActivate*/)
 	NewCursor(CURSOR_NONE);
 	gamemenu_off();
 	InitDiabloMsg(EMSG_SAVING);
-	force_redraw = 255;
+	RedrawEverything();
 	DrawAndBlit();
 	SaveGame();
 	ClrDiabloMsg();
-	force_redraw = 255;
+	RedrawEverything();
 	NewCursor(CURSOR_HAND);
 	if (CornerStone.activated) {
 		CornerstoneSave();

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -14,6 +14,7 @@
 
 #include "DiabloUI/diabloui.h"
 #include "engine/assets.hpp"
+#include "engine/backbuffer_state.hpp"
 #include "engine/dx.h"
 #include "hwcursor.hpp"
 #include "miniwin/misc_msg.h"
@@ -332,10 +333,10 @@ void MainWndProc(const SDL_Event &event)
 		break;
 	case SDL_WINDOWEVENT_SHOWN:
 		gbActive = false;
-		force_redraw = 255;
+		RedrawEverything();
 		break;
 	case SDL_WINDOWEVENT_EXPOSED:
-		force_redraw = 255;
+		RedrawEverything();
 		break;
 	case SDL_WINDOWEVENT_SIZE_CHANGED:
 		ReinitializeHardwareCursor();
@@ -343,7 +344,7 @@ void MainWndProc(const SDL_Event &event)
 	case SDL_WINDOWEVENT_LEAVE:
 		sgbMouseDown = CLICK_NONE;
 		LastMouseButtonAction = MouseActionType::None;
-		force_redraw = 255;
+		RedrawEverything();
 		break;
 	case SDL_WINDOWEVENT_CLOSE:
 		diablo_quit(0);

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -293,13 +293,17 @@ void ShowProgress(interface_mode uMsg)
 		// Blit the background once and then free it.
 		LoadCutsceneBackground(uMsg);
 		DrawCutsceneBackground();
-		if (RenderDirectlyToOutputSurface && IsDoubleBuffered()) {
-			// Blit twice for triple buffering.
-			for (unsigned i = 0; i < 2; ++i) {
+		if (RenderDirectlyToOutputSurface && PalSurface != nullptr) {
+			// Render into all the backbuffers if there are multiple.
+			const void *initialPixels = PalSurface->pixels;
+			if (DiabloUiSurface() == PalSurface)
+				BltFast(nullptr, nullptr);
+			RenderPresent();
+			while (PalSurface->pixels != initialPixels) {
+				DrawCutsceneBackground();
 				if (DiabloUiSurface() == PalSurface)
 					BltFast(nullptr, nullptr);
 				RenderPresent();
-				DrawCutsceneBackground();
 			}
 		}
 		FreeCutsceneBackground();

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -11,6 +11,7 @@
 #include "DiabloUI/ui_flags.hpp"
 #include "controls/plrctrls.h"
 #include "cursor.h"
+#include "engine/backbuffer_state.hpp"
 #include "engine/clx_sprite.hpp"
 #include "engine/load_cel.hpp"
 #include "engine/render/clx_render.hpp"
@@ -37,7 +38,6 @@
 namespace devilution {
 
 bool invflag;
-bool drawsbarflag;
 
 /**
  * Maps from inventory slot to screen position. The inventory slots are
@@ -566,7 +566,7 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 		if (&player == MyPlayer) {
 			NetSendCmdChBeltItem(false, ii);
 		}
-		drawsbarflag = true;
+		RedrawComponent(PanelDrawComponent::Belt);
 	} break;
 	case ILOC_NONE:
 	case ILOC_INVALID:
@@ -1235,7 +1235,7 @@ bool AutoPlaceItemInBelt(Player &player, const Item &item, bool persistItem)
 			if (persistItem) {
 				beltItem = item;
 				player.CalcScrolls();
-				drawsbarflag = true;
+				RedrawComponent(PanelDrawComponent::Belt);
 				if (&player == MyPlayer) {
 					size_t beltIndex = std::distance<const Item *>(&player.SpdList[0], &beltItem);
 					NetSendCmdChBeltItem(false, beltIndex);
@@ -1907,7 +1907,7 @@ int8_t CheckInvHLight()
 		pi = &myPlayer.InvList[ii];
 	} else if (r >= SLOTXY_BELT_FIRST) {
 		r -= SLOTXY_BELT_FIRST;
-		drawsbarflag = true;
+		RedrawComponent(PanelDrawComponent::Belt);
 		pi = &myPlayer.SpdList[r];
 		if (pi->isEmpty())
 			return -1;

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -83,7 +83,6 @@ enum item_color : uint8_t {
 };
 
 extern bool invflag;
-extern bool drawsbarflag;
 extern const Point InvRect[73];
 
 void InvDrawSlotBack(const Surface &out, Point targetPosition, Size size, item_quality itemQuality);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -20,6 +20,7 @@
 #include "controls/plrctrls.h"
 #include "cursor.h"
 #include "doom.h"
+#include "engine/backbuffer_state.hpp"
 #include "engine/clx_sprite.hpp"
 #include "engine/dx.h"
 #include "engine/load_cel.hpp"
@@ -823,11 +824,11 @@ int SaveItemPower(const Player &player, Item &item, ItemPower &power)
 		break;
 	case IPL_MANA:
 		item._iPLMana += r << 6;
-		drawmanaflag = true;
+		RedrawComponent(PanelDrawComponent::Mana);
 		break;
 	case IPL_MANA_CURSE:
 		item._iPLMana -= r << 6;
-		drawmanaflag = true;
+		RedrawComponent(PanelDrawComponent::Mana);
 		break;
 	case IPL_DUR: {
 		int bonus = r * item._iMaxDur / 100;
@@ -883,7 +884,7 @@ int SaveItemPower(const Player &player, Item &item, ItemPower &power)
 		break;
 	case IPL_NOMANA:
 		item._iFlags |= ItemSpecialEffect::NoMana;
-		drawmanaflag = true;
+		RedrawComponent(PanelDrawComponent::Mana);
 		break;
 	case IPL_ABSHALFTRAP:
 		item._iFlags |= ItemSpecialEffect::HalfTrapDamage;
@@ -902,14 +903,14 @@ int SaveItemPower(const Player &player, Item &item, ItemPower &power)
 			item._iFlags |= ItemSpecialEffect::StealMana3;
 		if (power.param1 == 5)
 			item._iFlags |= ItemSpecialEffect::StealMana5;
-		drawmanaflag = true;
+		RedrawComponent(PanelDrawComponent::Mana);
 		break;
 	case IPL_STEALLIFE:
 		if (power.param1 == 3)
 			item._iFlags |= ItemSpecialEffect::StealLife3;
 		if (power.param1 == 5)
 			item._iFlags |= ItemSpecialEffect::StealLife5;
-		drawhpflag = true;
+		RedrawComponent(PanelDrawComponent::Health);
 		break;
 	case IPL_TARGAC:
 		if (gbIsHellfire)
@@ -2719,8 +2720,8 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 		}
 	}
 
-	drawmanaflag = true;
-	drawhpflag = true;
+	RedrawComponent(PanelDrawComponent::Mana);
+	RedrawComponent(PanelDrawComponent::Health);
 }
 
 void CalcPlrInv(Player &player, bool loadgfx)
@@ -3813,25 +3814,25 @@ void UseItem(size_t pnum, item_misc_id mid, spell_id spl)
 	case IMISC_HEAL:
 		player.RestorePartialLife();
 		if (&player == MyPlayer) {
-			drawhpflag = true;
+			RedrawComponent(PanelDrawComponent::Health);
 		}
 		break;
 	case IMISC_FULLHEAL:
 		player.RestoreFullLife();
 		if (&player == MyPlayer) {
-			drawhpflag = true;
+			RedrawComponent(PanelDrawComponent::Health);
 		}
 		break;
 	case IMISC_MANA:
 		player.RestorePartialMana();
 		if (&player == MyPlayer) {
-			drawmanaflag = true;
+			RedrawComponent(PanelDrawComponent::Mana);
 		}
 		break;
 	case IMISC_FULLMANA:
 		player.RestoreFullMana();
 		if (&player == MyPlayer) {
-			drawmanaflag = true;
+			RedrawComponent(PanelDrawComponent::Mana);
 		}
 		break;
 	case IMISC_ELIXSTR:
@@ -3842,7 +3843,7 @@ void UseItem(size_t pnum, item_misc_id mid, spell_id spl)
 		if (gbIsHellfire) {
 			player.RestoreFullMana();
 			if (&player == MyPlayer) {
-				drawmanaflag = true;
+				RedrawComponent(PanelDrawComponent::Mana);
 			}
 		}
 		break;
@@ -3854,7 +3855,7 @@ void UseItem(size_t pnum, item_misc_id mid, spell_id spl)
 		if (gbIsHellfire) {
 			player.RestoreFullLife();
 			if (&player == MyPlayer) {
-				drawhpflag = true;
+				RedrawComponent(PanelDrawComponent::Health);
 			}
 		}
 		break;
@@ -3862,16 +3863,16 @@ void UseItem(size_t pnum, item_misc_id mid, spell_id spl)
 		player.RestorePartialLife();
 		player.RestorePartialMana();
 		if (&player == MyPlayer) {
-			drawhpflag = true;
-			drawmanaflag = true;
+			RedrawComponent(PanelDrawComponent::Health);
+			RedrawComponent(PanelDrawComponent::Mana);
 		}
 	} break;
 	case IMISC_FULLREJUV:
 		player.RestoreFullLife();
 		player.RestoreFullMana();
 		if (&player == MyPlayer) {
-			drawhpflag = true;
-			drawmanaflag = true;
+			RedrawComponent(PanelDrawComponent::Health);
+			RedrawComponent(PanelDrawComponent::Mana);
 		}
 		break;
 	case IMISC_SCROLL:
@@ -3910,7 +3911,7 @@ void UseItem(size_t pnum, item_misc_id mid, spell_id spl)
 				Stash.RefreshItemStatFlags();
 			}
 		}
-		drawmanaflag = true;
+		RedrawComponent(PanelDrawComponent::Mana);
 		break;
 	case IMISC_MAPOFDOOM:
 		doom_init();

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -14,6 +14,7 @@
 #ifdef _DEBUG
 #include "debug.h"
 #endif
+#include "engine/backbuffer_state.hpp"
 #include "engine/load_file.hpp"
 #include "engine/points_in_rectangle_range.hpp"
 #include "engine/random.hpp"
@@ -1323,7 +1324,7 @@ void AddStealPotions(Missile &missile, AddMissileParameter & /*parameter*/)
 				hasPlayedSFX = true;
 			}
 		}
-		force_redraw = 255;
+		RedrawEverything();
 
 		return false;
 	});
@@ -1344,7 +1345,7 @@ void AddManaTrap(Missile &missile, AddMissileParameter & /*parameter*/)
 		player._pMana = 0;
 		player._pManaBase = player._pMana + player._pMaxManaBase - player._pMaxMana;
 		CalcPlrInv(player, false);
-		drawmanaflag = true;
+		RedrawComponent(PanelDrawComponent::Mana);
 		PlaySfxLoc(TSFX_COW7, *trappedPlayerPosition);
 	}
 
@@ -1535,7 +1536,7 @@ void AddMana(Missile &missile, AddMissileParameter & /*parameter*/)
 	if (player._pManaBase > player._pMaxManaBase)
 		player._pManaBase = player._pMaxManaBase;
 	missile._miDelFlag = true;
-	drawmanaflag = true;
+	RedrawComponent(PanelDrawComponent::Mana);
 }
 
 void AddMagi(Missile &missile, AddMissileParameter & /*parameter*/)
@@ -1545,7 +1546,7 @@ void AddMagi(Missile &missile, AddMissileParameter & /*parameter*/)
 	player._pMana = player._pMaxMana;
 	player._pManaBase = player._pMaxManaBase;
 	missile._miDelFlag = true;
-	drawmanaflag = true;
+	RedrawComponent(PanelDrawComponent::Mana);
 }
 
 void AddRing(Missile &missile, AddMissileParameter & /*parameter*/)
@@ -2264,7 +2265,7 @@ void AddHeal(Missile &missile, AddMissileParameter & /*parameter*/)
 	player._pHPBase = std::min(player._pHPBase + hp, player._pMaxHPBase);
 
 	missile._miDelFlag = true;
-	drawhpflag = true;
+	RedrawComponent(PanelDrawComponent::Health);
 }
 
 void AddHealOther(Missile &missile, AddMissileParameter & /*parameter*/)
@@ -2394,7 +2395,7 @@ void AddBlodboil(Missile &missile, AddMissileParameter &parameter)
 	int lvl = player._pLevel * 2;
 	missile._mirange = lvl + 10 * missile._mispllvl + 245;
 	CalcPlrItemVals(player, true);
-	force_redraw = 255;
+	RedrawEverything();
 	player.Say(HeroSpeech::Aaaaargh);
 }
 
@@ -3788,7 +3789,7 @@ void MI_Blodboil(Missile &missile)
 
 	CalcPlrItemVals(player, true);
 	ApplyPlrDamage(player, 0, 1, hpdif);
-	force_redraw = 255;
+	RedrawEverything();
 	player.Say(HeroSpeech::HeavyBreathing);
 }
 

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -7,6 +7,7 @@
 #include "controls/plrctrls.h"
 #include "diablo.h"
 #include "effects.h"
+#include "engine/backbuffer_state.hpp"
 #include "engine/demomode.h"
 #include "engine/sound.h"
 #include "hwcursor.hpp"
@@ -74,10 +75,10 @@ void PlayInGameMovie(const char *pszMovie)
 	PaletteFadeOut(8);
 	play_movie(pszMovie, false);
 	ClearScreenBuffer();
-	force_redraw = 255;
+	RedrawEverything();
 	scrollrt_draw_game_screen();
 	PaletteFadeIn(8);
-	force_redraw = 255;
+	RedrawEverything();
 }
 
 } // namespace devilution

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -16,6 +16,7 @@
 #include "control.h"
 #include "dead.h"
 #include "encrypt.h"
+#include "engine/backbuffer_state.hpp"
 #include "engine/random.hpp"
 #include "engine/world_tile.hpp"
 #include "gamemenu.h"
@@ -2235,7 +2236,7 @@ size_t OnString(const TCmd *pCmd, Player &player)
 size_t OnFriendlyMode(const TCmd *pCmd, Player &player) // NOLINT(misc-unused-parameters)
 {
 	player.friendlyMode = !player.friendlyMode;
-	force_redraw = 255;
+	RedrawEverything();
 	return sizeof(*pCmd);
 }
 
@@ -2262,7 +2263,7 @@ size_t OnCheatExperience(const TCmd *pCmd, size_t pnum) // NOLINT(misc-unused-pa
 	else if (Players[pnum]._pLevel < MaxCharacterLevel) {
 		Players[pnum]._pExperience = Players[pnum]._pNextExper;
 		if (*sgOptions.Gameplay.experienceBar) {
-			force_redraw = 255;
+			RedrawEverything();
 		}
 		NextPlrLevel(Players[pnum]);
 	}

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -17,6 +17,7 @@
 #ifdef _DEBUG
 #include "debug.h"
 #endif
+#include "engine/backbuffer_state.hpp"
 #include "engine/load_cel.hpp"
 #include "engine/load_file.hpp"
 #include "engine/points_in_rectangle_range.hpp"
@@ -2289,7 +2290,7 @@ void OperateShrineMysterious(Player &player)
 
 	CheckStats(player);
 	CalcPlrInv(player, true);
-	force_redraw = 255;
+	RedrawEverything();
 
 	InitDiabloMsg(EMSG_SHRINE_MYSTERIOUS);
 }
@@ -2432,7 +2433,7 @@ void OperateShrineStone(Player &player)
 			item._iCharges = item._iMaxCharges;
 	}
 
-	force_redraw = 255;
+	RedrawEverything();
 
 	InitDiabloMsg(EMSG_SHRINE_STONE);
 }
@@ -2530,7 +2531,7 @@ void OperateShrineCostOfWisdom(Player &player, spell_id spellId, diablo_message 
 		player._pMaxManaBase = 0;
 	}
 
-	force_redraw = 255;
+	RedrawEverything();
 
 	InitDiabloMsg(message);
 }
@@ -2555,7 +2556,7 @@ void OperateShrineCryptic(Player &player)
 
 	InitDiabloMsg(EMSG_SHRINE_CRYPTIC);
 
-	force_redraw = 255;
+	RedrawEverything();
 }
 
 void OperateShrineEldritch(Player &player)
@@ -2586,7 +2587,7 @@ void OperateShrineEldritch(Player &player)
 		}
 	}
 
-	force_redraw = 255;
+	RedrawEverything();
 
 	InitDiabloMsg(EMSG_SHRINE_ELDRITCH);
 }
@@ -2599,7 +2600,7 @@ void OperateShrineEerie(Player &player)
 	ModifyPlrMag(player, 2);
 	CheckStats(player);
 	CalcPlrInv(player, true);
-	force_redraw = 255;
+	RedrawEverything();
 
 	InitDiabloMsg(EMSG_SHRINE_EERIE);
 }
@@ -2628,7 +2629,7 @@ void OperateShrineDivine(Player &player, Point spawnPosition)
 	player._pHitPoints = player._pMaxHP;
 	player._pHPBase = player._pMaxHPBase;
 
-	force_redraw = 255;
+	RedrawEverything();
 
 	InitDiabloMsg(EMSG_SHRINE_DIVINE);
 }
@@ -2676,7 +2677,7 @@ void OperateShrineSpooky(const Player &player)
 	myPlayer._pMana = myPlayer._pMaxMana;
 	myPlayer._pManaBase = myPlayer._pMaxManaBase;
 
-	force_redraw = 255;
+	RedrawEverything();
 
 	InitDiabloMsg(EMSG_SHRINE_SPOOKY2);
 }
@@ -2689,7 +2690,7 @@ void OperateShrineAbandoned(Player &player)
 	ModifyPlrDex(player, 2);
 	CheckStats(player);
 	CalcPlrInv(player, true);
-	force_redraw = 255;
+	RedrawEverything();
 
 	InitDiabloMsg(EMSG_SHRINE_ABANDONED);
 }
@@ -2702,7 +2703,7 @@ void OperateShrineCreepy(Player &player)
 	ModifyPlrStr(player, 2);
 	CheckStats(player);
 	CalcPlrInv(player, true);
-	force_redraw = 255;
+	RedrawEverything();
 
 	InitDiabloMsg(EMSG_SHRINE_CREEPY);
 }
@@ -2715,7 +2716,7 @@ void OperateShrineQuiet(Player &player)
 	ModifyPlrVit(player, 2);
 	CheckStats(player);
 	CalcPlrInv(player, true);
-	force_redraw = 255;
+	RedrawEverything();
 
 	InitDiabloMsg(EMSG_SHRINE_QUIET);
 }
@@ -2744,7 +2745,7 @@ void OperateShrineGlimmering(Player &player)
 	}
 
 	CalcPlrInv(player, true);
-	force_redraw = 255;
+	RedrawEverything();
 
 	InitDiabloMsg(EMSG_SHRINE_GLIMMERING);
 }
@@ -2772,7 +2773,7 @@ void OperateShrineTainted(const Player &player)
 
 	CheckStats(myPlayer);
 	CalcPlrInv(myPlayer, true);
-	force_redraw = 255;
+	RedrawEverything();
 
 	InitDiabloMsg(EMSG_SHRINE_TAINTED2);
 }
@@ -2813,7 +2814,7 @@ void OperateShrineOily(Player &player, Point spawnPosition)
 
 	CheckStats(player);
 	CalcPlrInv(player, true);
-	force_redraw = 255;
+	RedrawEverything();
 
 	AddMissile(
 	    spawnPosition,
@@ -2843,7 +2844,7 @@ void OperateShrineGlowing(Player &player)
 		player._pExperience = 0;
 
 	CheckStats(player);
-	force_redraw = 255;
+	RedrawEverything();
 
 	InitDiabloMsg(EMSG_SHRINE_GLOWING);
 }
@@ -2857,7 +2858,7 @@ void OperateShrineMendicant(Player &player)
 	AddPlrExperience(player, player._pLevel, gold);
 	TakePlrsMoney(gold);
 
-	force_redraw = 255;
+	RedrawEverything();
 
 	InitDiabloMsg(EMSG_SHRINE_MENDICANT);
 }
@@ -2884,7 +2885,7 @@ void OperateShrineSparkling(Player &player, Point spawnPosition)
 	    3 * currlevel + 2,
 	    0);
 
-	force_redraw = 255;
+	RedrawEverything();
 
 	InitDiabloMsg(EMSG_SHRINE_SPARKLING);
 }
@@ -2920,7 +2921,7 @@ void OperateShrineShimmering(Player &player)
 	player._pMana = player._pMaxMana;
 	player._pManaBase = player._pMaxManaBase;
 
-	force_redraw = 255;
+	RedrawEverything();
 
 	InitDiabloMsg(EMSG_SHRINE_SHIMMERING);
 }
@@ -2949,7 +2950,7 @@ void OperateShrineSolar(Player &player)
 
 	CheckStats(player);
 	CalcPlrInv(player, true);
-	force_redraw = 255;
+	RedrawEverything();
 }
 
 void OperateShrineMurphys(Player &player)
@@ -3200,7 +3201,7 @@ void OperateGoatShrine(Player &player, Object &object, _sfx_id sType)
 	object._oVar1 = FindValidShrine();
 	OperateShrine(player, object, sType);
 	object._oAnimDelay = 2;
-	force_redraw = 255;
+	RedrawEverything();
 }
 
 void OperateCauldron(Player &player, Object &object, _sfx_id sType)
@@ -3210,7 +3211,7 @@ void OperateCauldron(Player &player, Object &object, _sfx_id sType)
 	OperateShrine(player, object, sType);
 	object._oAnimFrame = 3;
 	object._oAnimFlag = false;
-	force_redraw = 255;
+	RedrawEverything();
 }
 
 bool OperateFountains(Player &player, Object &fountain)
@@ -3309,7 +3310,7 @@ bool OperateFountains(Player &player, Object &fountain)
 	default:
 		break;
 	}
-	force_redraw = 255;
+	RedrawEverything();
 	return applied;
 }
 

--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -3,6 +3,7 @@
 #include <fmt/format.h>
 
 #include "control.h"
+#include "engine/backbuffer_state.hpp"
 #include "engine/clx_sprite.hpp"
 #include "engine/load_cel.hpp"
 #include "engine/rectangle.hpp"
@@ -202,7 +203,7 @@ void CheckSBook()
 			}
 			player._pRSpell = sn;
 			player._pRSplType = st;
-			force_redraw = 255;
+			RedrawEverything();
 		}
 		return;
 	}

--- a/Source/panels/spell_list.cpp
+++ b/Source/panels/spell_list.cpp
@@ -4,6 +4,7 @@
 
 #include "control.h"
 #include "engine.h"
+#include "engine/backbuffer_state.hpp"
 #include "engine/palette.h"
 #include "engine/render/text_render.hpp"
 #include "inv_iterators.hpp"
@@ -280,7 +281,7 @@ void SetSpell()
 	myPlayer._pRSpell = pSpell;
 	myPlayer._pRSplType = pSplType;
 
-	force_redraw = 255;
+	RedrawEverything();
 }
 
 void SetSpeedSpell(size_t slot)
@@ -331,7 +332,7 @@ void ToggleSpell(size_t slot)
 	if ((spells & GetSpellBitmask(spellId)) != 0) {
 		myPlayer._pRSpell = spellId;
 		myPlayer._pRSplType = myPlayer._pSplTHotKey[slot];
-		force_redraw = 255;
+		RedrawEverything();
 	}
 }
 

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -10,6 +10,7 @@
 #ifdef _DEBUG
 #include "debug.h"
 #endif
+#include "engine/backbuffer_state.hpp"
 #include "engine/point.hpp"
 #include "engine/random.hpp"
 #include "gamemenu.h"
@@ -55,12 +56,12 @@ void ClearReadiedSpell(Player &player)
 {
 	if (player._pRSpell != SPL_INVALID) {
 		player._pRSpell = SPL_INVALID;
-		force_redraw = 255;
+		RedrawEverything();
 	}
 
 	if (player._pRSplType != RSPLTYPE_INVALID) {
 		player._pRSplType = RSPLTYPE_INVALID;
-		force_redraw = 255;
+		RedrawEverything();
 	}
 }
 
@@ -191,7 +192,7 @@ void ConsumeSpell(Player &player, spell_id sn)
 		int ma = GetManaAmount(player, sn);
 		player._pMana -= ma;
 		player._pManaBase -= ma;
-		drawmanaflag = true;
+		RedrawComponent(PanelDrawComponent::Mana);
 		break;
 	}
 	if (sn == SPL_FLARE) {
@@ -273,8 +274,8 @@ void DoResurrect(size_t pnum, Player &target)
 	if (&target == MyPlayer) {
 		MyPlayerIsDead = false;
 		gamemenu_off();
-		drawhpflag = true;
-		drawmanaflag = true;
+		RedrawComponent(PanelDrawComponent::Health);
+		RedrawComponent(PanelDrawComponent::Mana);
 	}
 
 	ClrPlrPath(target);
@@ -327,7 +328,7 @@ void DoHealOther(const Player &caster, Player &target)
 	target._pHPBase = std::min(target._pHPBase + hp, target._pMaxHPBase);
 
 	if (&target == MyPlayer) {
-		drawhpflag = true;
+		RedrawComponent(PanelDrawComponent::Health);
 	}
 }
 

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -11,6 +11,7 @@
 
 #include "controls/plrctrls.h"
 #include "cursor.h"
+#include "engine/backbuffer_state.hpp"
 #include "engine/load_cel.hpp"
 #include "engine/random.hpp"
 #include "engine/render/clx_render.hpp"
@@ -695,7 +696,7 @@ void FillManaPlayer()
 	}
 	myPlayer._pMana = myPlayer._pMaxMana;
 	myPlayer._pManaBase = myPlayer._pMaxManaBase;
-	drawmanaflag = true;
+	RedrawComponent(PanelDrawComponent::Mana);
 }
 
 void StartWitch()
@@ -1090,7 +1091,7 @@ void HealPlayer()
 	}
 	myPlayer._pHitPoints = myPlayer._pMaxHP;
 	myPlayer._pHPBase = myPlayer._pMaxHPBase;
-	drawhpflag = true;
+	RedrawComponent(PanelDrawComponent::Health);
 }
 
 void StartHealer()

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -24,6 +24,7 @@
 #include "controls/devices/kbcontroller.h"
 #include "controls/game_controls.h"
 #include "controls/touch/gamepad.h"
+#include "engine/backbuffer_state.hpp"
 #include "engine/dx.h"
 #include "options.h"
 #include "utils/log.hpp"
@@ -449,7 +450,7 @@ void SetFullscreenMode()
 	}
 	InitializeVirtualGamepad();
 #endif
-	force_redraw = 255;
+	RedrawEverything();
 }
 
 void ResizeWindow()
@@ -473,7 +474,7 @@ void ResizeWindow()
 #endif
 
 	CreateBackBuffer();
-	force_redraw = 255;
+	RedrawEverything();
 }
 
 SDL_Surface *GetOutputSurface()
@@ -490,15 +491,6 @@ SDL_Surface *GetOutputSurface()
 	if (ret == nullptr)
 		ErrSdl();
 	return ret;
-#endif
-}
-
-bool IsDoubleBuffered()
-{
-#ifdef USE_SDL1
-	return (GetOutputSurface()->flags & SDL_DOUBLEBUF) == SDL_DOUBLEBUF;
-#else
-	return true;
 #endif
 }
 

--- a/Source/utils/display.h
+++ b/Source/utils/display.h
@@ -40,8 +40,6 @@ bool IsFullScreen();
 // SDL2, upscale: Renderer texture surface.
 SDL_Surface *GetOutputSurface();
 
-bool IsDoubleBuffered();
-
 // Whether the output surface requires software scaling.
 // Always returns false on SDL2.
 bool OutputRequiresScaling();


### PR DESCRIPTION
When rendering directly to the output buffer, we need to maintain the state of what has been drawn and what needs redrawing per-buffer.

We previously tried to do it implicitly by checking `SDL_DOUBLEBUF` and other flags. The previous implementation was broken in several ways, resulting in rendering issues on devices that support 8-bit output directly.

Changes this mechanism to explicitly maintain buffer state per output buffer. The new mechanism doesn't require knowledge of the number of buffers, and thus also works correctly with triple-buffering.

Fixes #5447