### PR TITLE
Fix mouse simulation

### DIFF
--- a/Source/controls/controller_motion.cpp
+++ b/Source/controls/controller_motion.cpp
@@ -81,26 +81,32 @@ void SetSimulatingMouseWithPadmapper(bool value)
 // SELECT + D-Pad to simulate right stick movement.
 bool SimulateRightStickWithDpad(ControllerButtonEvent ctrlEvent)
 {
+	if (IsAnyOf(ctrlEvent.button, ControllerButton_NONE, ControllerButton_IGNORE))
+		return false;
+
 	ControllerButtonCombo upCombo = sgOptions.Padmapper.ButtonComboForAction("MouseUp");
 	ControllerButtonCombo downCombo = sgOptions.Padmapper.ButtonComboForAction("MouseDown");
 	ControllerButtonCombo leftCombo = sgOptions.Padmapper.ButtonComboForAction("MouseLeft");
 	ControllerButtonCombo rightCombo = sgOptions.Padmapper.ButtonComboForAction("MouseRight");
+	if (IsNoneOf(ctrlEvent.button, upCombo.button, downCombo.button, leftCombo.button, rightCombo.button)) {
+		if (rightStickX == 0 && rightStickY == 0)
+			SetSimulatingMouseWithPadmapper(false);
+		return false;
+	}
 
-	int simulatedRightStickX = 0;
-	int simulatedRightStickY = 0;
+	rightStickX = 0;
+	rightStickY = 0;
 	if (IsControllerButtonComboPressed(upCombo))
-		simulatedRightStickY += 1;
+		rightStickY += 1.F;
 	if (IsControllerButtonComboPressed(downCombo))
-		simulatedRightStickY -= 1;
+		rightStickY -= 1.F;
 	if (IsControllerButtonComboPressed(leftCombo))
-		simulatedRightStickX -= 1;
+		rightStickX -= 1.F;
 	if (IsControllerButtonComboPressed(rightCombo))
-		simulatedRightStickX += 1;
-	SetSimulatingMouseWithPadmapper(simulatedRightStickX != 0 || simulatedRightStickY != 0);
-
-	rightStickX += simulatedRightStickX;
-	rightStickY += simulatedRightStickY;
-	return SimulatingMouseWithPadmapper && IsAnyOf(ctrlEvent.button, upCombo.button, downCombo.button, leftCombo.button, rightCombo.button);
+		rightStickX += 1.F;
+	if (rightStickX != 0 || rightStickY != 0)
+		SetSimulatingMouseWithPadmapper(true);
+	return true;
 }
 
 } // namespace

--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -349,7 +349,17 @@ AxisDirection GetMoveDirection()
 
 bool HandleControllerButtonEvent(const SDL_Event &event, GameAction &action)
 {
+	struct ButtonReleaser {
+		~ButtonReleaser()
+		{
+			if (ctrlEvent.up)
+				sgOptions.Padmapper.ButtonReleased(ctrlEvent.button, false);
+		}
+		ControllerButtonEvent ctrlEvent;
+	};
+
 	const ControllerButtonEvent ctrlEvent = ToControllerButtonEvent(event);
+	const ButtonReleaser buttonReleaser { ctrlEvent };
 	bool isGamepadMotion = ProcessControllerMotion(event, ctrlEvent);
 	DetectInputMethod(event, ctrlEvent);
 	if (isGamepadMotion) {

--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -332,14 +332,12 @@ bool SkipsMovie(ControllerButtonEvent ctrlEvent)
 
 bool IsSimulatedMouseClickBinding(ControllerButtonEvent ctrlEvent)
 {
-	ControllerButtonCombo leftMouseClickBinding1 = sgOptions.Padmapper.ButtonComboForAction("LeftMouseClick1");
-	ControllerButtonCombo leftMouseClickBinding2 = sgOptions.Padmapper.ButtonComboForAction("LeftMouseClick2");
-	ControllerButtonCombo rightMouseClickBinding1 = sgOptions.Padmapper.ButtonComboForAction("RightMouseClick1");
-	ControllerButtonCombo rightMouseClickBinding2 = sgOptions.Padmapper.ButtonComboForAction("RightMouseClick2");
-	return (ctrlEvent.button == leftMouseClickBinding1.button && IsControllerButtonComboPressed(leftMouseClickBinding1))
-	    || (ctrlEvent.button == leftMouseClickBinding2.button && IsControllerButtonComboPressed(leftMouseClickBinding2))
-	    || (ctrlEvent.button == rightMouseClickBinding1.button && IsControllerButtonComboPressed(rightMouseClickBinding1))
-	    || (ctrlEvent.button == rightMouseClickBinding2.button && IsControllerButtonComboPressed(rightMouseClickBinding2));
+	if (IsAnyOf(ctrlEvent.button, ControllerButton_NONE, ControllerButton_IGNORE))
+		return false;
+	if (!ctrlEvent.up && ctrlEvent.button == SuppressedButton)
+		return false;
+	string_view actionName = sgOptions.Padmapper.ActionNameTriggeredByButtonEvent(ctrlEvent);
+	return IsAnyOf(actionName, "LeftMouseClick1", "LeftMouseClick2", "RightMouseClick1", "RightMouseClick2");
 }
 
 AxisDirection GetMoveDirection()
@@ -365,8 +363,11 @@ bool HandleControllerButtonEvent(const SDL_Event &event, GameAction &action)
 	if (isGamepadMotion) {
 		return true;
 	}
+	if (IsAnyOf(ctrlEvent.button, ControllerButton_NONE, ControllerButton_IGNORE)) {
+		return false;
+	}
 
-	if (ctrlEvent.button != ControllerButton_NONE && ctrlEvent.button == SuppressedButton) {
+	if (ctrlEvent.button == SuppressedButton) {
 		if (!ctrlEvent.up)
 			return true;
 		SuppressedButton = ControllerButton_NONE;

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1481,7 +1481,7 @@ float rightStickLastMove = 0;
 
 bool ContinueSimulatedMouseEvent(const SDL_Event &event, const ControllerButtonEvent &gamepadEvent)
 {
-	if (IsAutomapActive())
+	if (AutomapActive)
 		return false;
 
 #if !defined(USE_SDL1) && !defined(JOY_AXIS_RIGHTX) && !defined(JOY_AXIS_RIGHTY)
@@ -1691,11 +1691,6 @@ void ProcessGameAction(const GameAction &action)
 	}
 }
 
-bool IsAutomapActive()
-{
-	return AutomapActive && leveltype != DTYPE_TOWN;
-}
-
 void HandleRightStickMotion()
 {
 	static RightStickAccumulator acc;
@@ -1705,7 +1700,7 @@ void HandleRightStickMotion()
 		return;
 	}
 
-	if (IsAutomapActive()) { // move map
+	if (AutomapActive) { // move map
 		int dx = 0;
 		int dy = 0;
 		acc.Pool(&dx, &dy, 32);

--- a/Source/controls/plrctrls.h
+++ b/Source/controls/plrctrls.h
@@ -67,9 +67,6 @@ bool IsPointAndClick();
 void DetectInputMethod(const SDL_Event &event, const ControllerButtonEvent &gamepadEvent);
 void ProcessGameAction(const GameAction &action);
 
-// Whether the automap is being displayed.
-bool IsAutomapActive();
-
 void UseBeltItem(int type);
 
 // Talk to towners, click on inv items, attack, etc.

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2203,6 +2203,7 @@ void InitPadmapActions()
 	    [] {
 		    ToggleChatLog();
 	    });
+	sgOptions.Padmapper.CommitActions();
 }
 
 void FreeGameMem()

--- a/Source/miniwin/misc_msg.cpp
+++ b/Source/miniwin/misc_msg.cpp
@@ -159,6 +159,7 @@ bool FetchMessage_Real(SDL_Event *event, uint16_t *modState)
 	case SDL_FINGERUP:
 #endif
 	case SDL_JOYAXISMOTION:
+	case SDL_JOYHATMOTION:
 	case SDL_JOYBUTTONDOWN:
 	case SDL_JOYBUTTONUP:
 		*event = e;

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1632,19 +1632,19 @@ void PadmapperOptions::ButtonPressed(ControllerButton button)
 	}
 }
 
-void PadmapperOptions::ButtonReleased(ControllerButton button)
+void PadmapperOptions::ButtonReleased(ControllerButton button, bool invokeAction)
 {
-	auto it = buttonToReleaseAction.find(button);
-	if (it == buttonToReleaseAction.end())
-		return; // Ignore unmapped buttons.
+	if (invokeAction) {
+		auto it = buttonToReleaseAction.find(button);
+		if (it == buttonToReleaseAction.end())
+			return; // Ignore unmapped buttons.
 
-	const Action &action = it->second.get();
+		const Action &action = it->second.get();
 
-	// Check that the action can be triggered.
-	if (!action.actionReleased || (action.enable && !action.enable()))
-		return;
-
-	action.actionReleased();
+		// Check that the action can be triggered.
+		if (action.actionReleased && (!action.enable || action.enable()))
+			action.actionReleased();
+	}
 	buttonToReleaseAction.erase(button);
 }
 

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1648,6 +1648,21 @@ void PadmapperOptions::ButtonReleased(ControllerButton button, bool invokeAction
 	buttonToReleaseAction.erase(button);
 }
 
+bool PadmapperOptions::IsActive(string_view actionName) const
+{
+	for (const Action &action : actions) {
+		if (action.key != actionName)
+			continue;
+		ControllerButton button = action.boundInput.button;
+		auto it = buttonToReleaseAction.find(button);
+		if (it == buttonToReleaseAction.end())
+			return false;
+		const Action &releaseAction = it->second.get();
+		return releaseAction.key == actionName;
+	}
+	return false;
+}
+
 string_view PadmapperOptions::InputNameForAction(string_view actionName) const
 {
 	for (const Action &action : actions) {

--- a/Source/options.h
+++ b/Source/options.h
@@ -7,6 +7,7 @@
 
 #include <SDL_version.h>
 
+#include "controls/controller.h"
 #include "controls/controller_buttons.h"
 #include "engine/sound_defs.hpp"
 #include "miniwin/misc_msg.h"
@@ -739,15 +740,18 @@ struct PadmapperOptions : OptionCategoryBase {
 	void ButtonPressed(ControllerButton button);
 	void ButtonReleased(ControllerButton button, bool invokeAction = true);
 	bool IsActive(string_view actionName) const;
+	string_view ActionNameTriggeredByButtonEvent(ControllerButtonEvent ctrlEvent) const;
 	string_view InputNameForAction(string_view actionName) const;
 	ControllerButtonCombo ButtonComboForAction(string_view actionName) const;
 
 private:
 	std::forward_list<Action> actions;
-	std::unordered_map<ControllerButton, std::reference_wrapper<Action>> buttonToReleaseAction;
+	std::unordered_map<ControllerButton, std::reference_wrapper<const Action>> buttonToReleaseAction;
 	std::unordered_map<ControllerButton, std::string> buttonToButtonName;
 	std::unordered_map<std::string, ControllerButton> buttonNameToButton;
 	bool committed = false;
+
+	const Action *FindAction(ControllerButton button) const;
 };
 
 struct Options {

--- a/Source/options.h
+++ b/Source/options.h
@@ -735,6 +735,7 @@ struct PadmapperOptions : OptionCategoryBase {
 	    std::function<void()> actionReleased = nullptr,
 	    std::function<bool()> enable = nullptr,
 	    unsigned index = 0);
+	void CommitActions();
 	void ButtonPressed(ControllerButton button);
 	void ButtonReleased(ControllerButton button);
 	string_view InputNameForAction(string_view actionName) const;
@@ -745,9 +746,7 @@ private:
 	std::unordered_map<ControllerButton, std::reference_wrapper<Action>> buttonToReleaseAction;
 	std::unordered_map<ControllerButton, std::string> buttonToButtonName;
 	std::unordered_map<std::string, ControllerButton> buttonNameToButton;
-	bool reversed = false;
-
-	std::forward_list<Action> &GetActions();
+	bool committed = false;
 };
 
 struct Options {

--- a/Source/options.h
+++ b/Source/options.h
@@ -738,6 +738,7 @@ struct PadmapperOptions : OptionCategoryBase {
 	void CommitActions();
 	void ButtonPressed(ControllerButton button);
 	void ButtonReleased(ControllerButton button, bool invokeAction = true);
+	bool IsActive(string_view actionName) const;
 	string_view InputNameForAction(string_view actionName) const;
 	ControllerButtonCombo ButtonComboForAction(string_view actionName) const;
 

--- a/Source/options.h
+++ b/Source/options.h
@@ -737,7 +737,7 @@ struct PadmapperOptions : OptionCategoryBase {
 	    unsigned index = 0);
 	void CommitActions();
 	void ButtonPressed(ControllerButton button);
-	void ButtonReleased(ControllerButton button);
+	void ButtonReleased(ControllerButton button, bool invokeAction = true);
 	string_view InputNameForAction(string_view actionName) const;
 	ControllerButtonCombo ButtonComboForAction(string_view actionName) const;
 


### PR DESCRIPTION
The interactions here are so complex that it's difficult to summarize this. I hope, when paired with the commit messages, that the following bullet points should suffice.

* `PadmapperOptions::ActionNameTriggeredByButtonEvent()` is intended for use by mouse simulation functions because these run during input detection, before `PadmapperOptions::ButtonPressed()`
* `PadmapperOptions::IsActive()` is intended for basically anything else that runs after the `PadmapperOptions::ButtonPressed()`
* `SimulateRightStickWithDpad()` returned a value to indicate whether the pad button input represents a gamepad movement event in order to shortcut further processing. That return value was removed from `SimulateRightStickWithPadmapper()` because it now uses `PadmapperOptions::IsActive()` to determine whether other mouse movement actions were activated by previous events. In order for that to work, those button events need to make it through to the padmapper to activate those mouse movement actions.
* `GetLeftStickOrDpadDirection(false)` is intended for use with stores, in-game menus, and char/inv/etc panels. The `false` flag overrides the padmapper actions for moving the character so that the d-pad works as you might expect in these menus, but mouse simulation actually trumps these controls.
* `IsAutomapActive()` was removed because there is now a valid automap in town so it doesn't need to be excluded

This resolves #5449
This resolves #5452