### PR TITLE
Better Control Panel

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -203,7 +203,7 @@ void DrawFlaskTop(const Surface &out, Point position, const Surface &celBuf, int
  */
 void DrawFlask(const Surface &out, const Surface &celBuf, Point sourcePosition, Point targetPosition, int h)
 {
-	constexpr int FlaskWidth = 59;
+	constexpr int FlaskWidth = 88;
 	out.BlitFromSkipColorIndexZero(celBuf, MakeSdlRect(sourcePosition.x, sourcePosition.y, FlaskWidth, h), targetPosition);
 }
 
@@ -218,7 +218,7 @@ void DrawFlask(const Surface &out, const Surface &celBuf, Point sourcePosition, 
 void DrawFlaskUpper(const Surface &out, const Surface &sourceBuffer, int offset, int fillPer)
 {
 	// clamping because this function only draws the top 12% of the flask display
-	int emptyPortion = clamp(80 - fillPer, 0, 11) + 2; // +2 to account for the frame being included in the sprite
+	int emptyPortion = clamp(80 - fillPer, 0, 67) + 2; // +2 to account for the frame being included in the sprite
 
 	// Draw the empty part of the flask
 	DrawFlask(out, sourceBuffer, { 13, 3 }, GetMainPanel().position + Displacement { offset, -13 }, emptyPortion);
@@ -237,7 +237,7 @@ void DrawFlaskUpper(const Surface &out, const Surface &sourceBuffer, int offset,
  */
 void DrawFlaskLower(const Surface &out, const Surface &sourceBuffer, int offset, int fillPer)
 {
-	int filled = clamp(fillPer, 0, 69);
+	int filled = clamp(fillPer, 0, 13);
 
 	if (filled < 69)
 		DrawFlaskTop(out, GetMainPanel().position + Displacement { offset, 0 }, sourceBuffer, 16, 85 - filled);
@@ -596,13 +596,13 @@ void DrawPanelBox(const Surface &out, SDL_Rect srcRect, Point targetPosition)
 void DrawLifeFlaskUpper(const Surface &out)
 {
 	constexpr int LifeFlaskUpperOffset = 109;
-	DrawFlaskUpper(out, *pLifeBuff, LifeFlaskUpperOffset, MyPlayer->_pHPPer);
+	DrawFlaskUpper(out, *pLifeBuff, LifeFlaskUpperOffset, Players[MyPlayerId]._pHPPer);
 }
 
 void DrawManaFlaskUpper(const Surface &out)
 {
 	constexpr int ManaFlaskUpperOffset = 475;
-	DrawFlaskUpper(out, *pManaBuff, ManaFlaskUpperOffset, MyPlayer->_pManaPer);
+	DrawFlaskUpper(out, *pManaBuff, ManaFlaskUpperOffset, Players[MyPlayerId]._pManaPer);
 }
 
 void DrawLifeFlaskLower(const Surface &out)

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -769,7 +769,7 @@ void DoPanBtn()
 			}
 		}
 	}
-	if (!spselflag && MousePosition.x >= 565 + mainPanelPosition.x && MousePosition.x < 621 + mainPanelPosition.x && MousePosition.y >= 64 + mainPanelPosition.y && MousePosition.y < 120 + mainPanelPosition.y) {
+	if (!spselflag && MousePosition.x >= 565 + mainPanelPosition.x && MousePosition.x < 621 + mainPanelPosition.x && MousePosition.y >= 64 - 56 + mainPanelPosition.y && MousePosition.y < 120 - 56 + mainPanelPosition.y) {
 		if ((SDL_GetModState() & KMOD_SHIFT) != 0) {
 			Player &myPlayer = *MyPlayer;
 			myPlayer._pRSpell = SPL_INVALID;
@@ -964,7 +964,7 @@ void FreeControlPan()
 	pLifeBuff = std::nullopt;
 	FreeSpellIcons();
 	FreeSpellBook();
-	pPanelButtons = std::nullopt;
+	//pPanelButtons = std::nullopt;
 	multiButtons = std::nullopt;
 	talkButtons = std::nullopt;
 	pChrButtons = std::nullopt;

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -119,16 +119,24 @@ Rectangle ChrBtnsRect[4] = {
 };
 
 /** Positions of panel buttons. */
-SDL_Rect PanBtnPos[8] = {
+int8_t panBtnX = 215;
+int8_t panBtnY = 50;
+int8_t panBtnSpacing = 21;
+int8_t panBtnW = 20;
+int8_t panBtnH = 20;
+
+SDL_Rect PanBtnPos[10] = {
 	// clang-format off
-	{   9,   9, 71, 19 }, // char button
-	{   9,  35, 71, 19 }, // quests button
-	{   9,  75, 71, 19 }, // map button
-	{   9, 101, 71, 19 }, // menu button
-	{ 560,   9, 71, 19 }, // inv button
-	{ 560,  35, 71, 19 }, // spells button
-	{  87,  91, 33, 32 }, // chat button
-	{ 527,  91, 33, 32 }, // friendly fire button
+	{ panBtnX + (panBtnSpacing * 0),  panBtnY, panBtnW, panBtnH }, // char button
+	{ panBtnX + (panBtnSpacing * 1),  panBtnY, panBtnW, panBtnH }, // inv button
+	{ panBtnX + (panBtnSpacing * 2),  panBtnY, panBtnW, panBtnH }, // stash button
+	{ panBtnX + (panBtnSpacing * 3),  panBtnY, panBtnW, panBtnH }, // spells button
+	{ panBtnX + (panBtnSpacing * 4),  panBtnY, panBtnW, panBtnH }, // party button
+	{ panBtnX + (panBtnSpacing * 5),  panBtnY, panBtnW, panBtnH }, // beastiary button
+	{ panBtnX + (panBtnSpacing * 6),  panBtnY, panBtnW, panBtnH }, // map button
+	{ panBtnX + (panBtnSpacing * 7),  panBtnY, panBtnW, panBtnH }, // chat button
+	{ panBtnX + (panBtnSpacing * 8),  panBtnY, panBtnW, panBtnH }, // quests button
+	{ panBtnX + (panBtnSpacing * 9),  panBtnY, panBtnW, panBtnH }, // menu button
 	// clang-format on
 };
 
@@ -141,7 +149,7 @@ OptionalOwnedClxSpriteList pDurIcons;
 OptionalOwnedClxSpriteList multiButtons;
 OptionalOwnedClxSpriteList pPanelButtons;
 
-bool PanelButtons[8];
+bool PanelButtons[10];
 int PanelButtonIndex;
 char TalkSave[8][MAX_SEND_STR_LEN];
 uint8_t TalkSaveIndex;
@@ -153,27 +161,31 @@ bool WhisperList[MAX_PLRS];
 
 enum panel_button_id : uint8_t {
 	PanelButtonCharinfo,
-	PanelButtonQlog,
-	PanelButtonAutomap,
-	PanelButtonMainmenu,
 	PanelButtonInventory,
+	PanelButtonStash,
 	PanelButtonSpellbook,
+	PanelButtonParty,
+	PanelButtonBeastiary,
+	PanelButtonAutomap,
 	PanelButtonSendmsg,
-	PanelButtonFriendly,
+	PanelButtonQlog,
+	PanelButtonMainmenu,
 };
 
 /** Maps from panel_button_id to hotkey name. */
-const char *const PanBtnHotKey[8] = { "'c'", "'q'", N_("Tab"), N_("Esc"), "'i'", "'b'", N_("Enter"), nullptr };
+const char *const PanBtnHotKey[10] = { "'c'", "'i'", "'x'", "'b'", "'p'", "'m'", N_("Tab"), N_("Enter"), "'q'", N_("Esc")};
 /** Maps from panel_button_id to panel button description. */
-const char *const PanBtnStr[8] = {
+const char *const PanBtnStr[10] = {
 	N_("Character Information"),
-	N_("Quests log"),
-	N_("Automap"),
-	N_("Main Menu"),
 	N_("Inventory"),
+	N_("Stash"),
 	N_("Spell book"),
-	N_("Send Message"),
-	"" // Player attack
+	N_("Party"),
+	N_("Beastiary"),
+	N_("Automap"),
+	N_("Chat"),
+	N_("Quests log"),
+	N_("Main Menu"),
 };
 
 /**
@@ -595,7 +607,7 @@ void DrawPanelBox(const Surface &out, SDL_Rect srcRect, Point targetPosition)
 
 void DrawLifeFlaskUpper(const Surface &out)
 {
-	constexpr int LifeFlaskUpperOffset = 96 - 19 + 3;
+	constexpr int LifeFlaskUpperOffset = 96 - 19 + 4;
 	DrawFlaskUpper(out, *pLifeBuff, LifeFlaskUpperOffset, Players[MyPlayerId]._pHPPer);
 }
 
@@ -884,7 +896,7 @@ void CheckBtnUp()
 	drawbtnflag = true;
 	panbtndown = false;
 
-	for (int i = 0; i < 8; i++) {
+	for (int i = 0; i < 10; i++) {
 		if (!PanelButtons[i]) {
 			continue;
 		}
@@ -932,6 +944,19 @@ void CheckBtnUp()
 				dropGoldValue = 0;
 			}
 			break;
+		case PanelButtonStash:
+			chrflag = false;
+			QuestLogIsOpen = false;
+			//stashflag = !invstashflag;
+			if (dropGoldFlag) {
+				CloseGoldDrop();
+				dropGoldValue = 0;
+			}
+			//if (withdrawStashGold) {
+			//	CloseWithdrawStashGold();
+			//	withdrawStashGoldValue = 0;
+			//}
+			break;
 		case PanelButtonSpellbook:
 			CloseInventory();
 			if (dropGoldFlag) {
@@ -939,6 +964,13 @@ void CheckBtnUp()
 				dropGoldValue = 0;
 			}
 			sbookflag = !sbookflag;
+			break;
+		case PanelButtonParty:
+			break;
+		case PanelButtonBeastiary:
+			break;
+		case PanelButtonAutomap:
+			DoAutoMap();
 			break;
 		case PanelButtonSendmsg:
 			if (talkflag)
@@ -964,7 +996,7 @@ void FreeControlPan()
 	pLifeBuff = std::nullopt;
 	FreeSpellIcons();
 	FreeSpellBook();
-	//pPanelButtons = std::nullopt;
+	pPanelButtons = std::nullopt;
 	multiButtons = std::nullopt;
 	talkButtons = std::nullopt;
 	pChrButtons = std::nullopt;

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -203,7 +203,7 @@ void DrawFlaskTop(const Surface &out, Point position, const Surface &celBuf, int
  */
 void DrawFlask(const Surface &out, const Surface &celBuf, Point sourcePosition, Point targetPosition, int h)
 {
-	constexpr int FlaskWidth = 88;
+	constexpr int FlaskWidth = 118;
 	out.BlitFromSkipColorIndexZero(celBuf, MakeSdlRect(sourcePosition.x, sourcePosition.y, FlaskWidth, h), targetPosition);
 }
 
@@ -595,13 +595,13 @@ void DrawPanelBox(const Surface &out, SDL_Rect srcRect, Point targetPosition)
 
 void DrawLifeFlaskUpper(const Surface &out)
 {
-	constexpr int LifeFlaskUpperOffset = 109;
+	constexpr int LifeFlaskUpperOffset = 96 - 19 + 3;
 	DrawFlaskUpper(out, *pLifeBuff, LifeFlaskUpperOffset, Players[MyPlayerId]._pHPPer);
 }
 
 void DrawManaFlaskUpper(const Surface &out)
 {
-	constexpr int ManaFlaskUpperOffset = 475;
+	constexpr int ManaFlaskUpperOffset = 464 - 19;
 	DrawFlaskUpper(out, *pManaBuff, ManaFlaskUpperOffset, Players[MyPlayerId]._pManaPer);
 }
 
@@ -868,7 +868,7 @@ void CheckPanelInfo()
 			}
 		}
 	}
-	if (MousePosition.x > 190 + mainPanelPosition.x && MousePosition.x < 437 + mainPanelPosition.x && MousePosition.y > 4 + mainPanelPosition.y && MousePosition.y < 33 + mainPanelPosition.y)
+	if (MousePosition.x > 190 + mainPanelPosition.x && MousePosition.x < 437 + mainPanelPosition.x && MousePosition.y > 4 + 17 + mainPanelPosition.y && MousePosition.y < 33 + 17 + mainPanelPosition.y)
 		pcursinvitem = CheckInvHLight();
 
 	if (CheckXPBarInfo()) {

--- a/Source/controls/touch/event_handlers.cpp
+++ b/Source/controls/touch/event_handlers.cpp
@@ -96,7 +96,7 @@ void HandleBottomPanelInteraction(const SDL_Event &event)
 
 	if (event.type != SDL_FINGERUP) {
 		spselflag = true;
-		DoPanBtn();
+			DoPanBtn();
 		spselflag = false;
 	} else {
 		DoPanBtn();

--- a/Source/engine/palette.cpp
+++ b/Source/engine/palette.cpp
@@ -14,6 +14,7 @@
 #include "options.h"
 #include "utils/display.h"
 #include "utils/sdl_compat.h"
+#include "control.h"
 
 namespace devilution {
 

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1229,7 +1229,7 @@ void DrawView(const Surface &out, Point startPosition)
 	DrawPlrMsg(out);
 	gmenu_draw(out);
 	doom_draw(out);
-	DrawInfoBox(out);
+	//DrawInfoBox(out);
 	control_update_life_mana(); // Update life/mana totals before rendering any portion of the flask.
 	DrawLifeFlaskUpper(out);
 	DrawManaFlaskUpper(out);
@@ -1634,14 +1634,14 @@ void DrawAndBlit()
 
 		DrawSpell(out);
 	}
-	if (drawbtnflag) {
-		DrawCtrlBtns(out);
-	}
+	//if (drawbtnflag) {
+	//	DrawCtrlBtns(out);
+	//}
 	if (drawsbarflag) {
 		DrawInvBelt(out);
 	}
 	if (talkflag) {
-		DrawTalkPan(out);
+		//DrawTalkPan(out);
 		hgt = gnScreenHeight;
 	}
 	DrawXPBar(out);

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1634,9 +1634,9 @@ void DrawAndBlit()
 
 		DrawSpell(out);
 	}
-	//if (drawbtnflag) {
-	//	DrawCtrlBtns(out);
-	//}
+	if (drawbtnflag) {
+		DrawCtrlBtns(out);
+	}
 	if (drawsbarflag) {
 		DrawInvBelt(out);
 	}

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1634,7 +1634,7 @@ void DrawAndBlit()
 
 		DrawSpell(out);
 	}
-	if (drawbtnflag) {
+	if (drawbtnflag && panelBtnsOpen) {
 		DrawCtrlBtns(out);
 	}
 	if (drawsbarflag) {

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -129,14 +129,14 @@ const Point InvRect[] = {
 	{ 220, 337 }, // inv row 4
 	{ 249, 337 }, // inv row 4
 	{ 278, 337 }, // inv row 4
-	{ 205,  33 }, // belt
-	{ 234,  33 }, // belt
-	{ 263,  33 }, // belt
-	{ 292,  33 }, // belt
-	{ 321,  33 }, // belt
-	{ 350,  33 }, // belt
-	{ 379,  33 }, // belt
-	{ 408,  33 }  // belt
+	{ 205,  50 }, // belt
+	{ 234,  50 }, // belt
+	{ 263,  50 }, // belt
+	{ 292,  50 }, // belt
+	{ 321,  50 }, // belt
+	{ 350,  50 }, // belt
+	{ 379,  50 }, // belt
+	{ 408,  50 }  // belt
 	// clang-format on
 };
 
@@ -1551,7 +1551,7 @@ void CheckInvScrn(bool isShiftHeld, bool isCtrlHeld)
 {
 	const Point mainPanelPosition = GetMainPanel().position;
 	if (MousePosition.x > 190 + mainPanelPosition.x && MousePosition.x < 437 + mainPanelPosition.x
-	    && MousePosition.y > mainPanelPosition.y && MousePosition.y < 33 + mainPanelPosition.y) {
+	    && MousePosition.y > mainPanelPosition.y + 17 && MousePosition.y < 33 + 17 + mainPanelPosition.y) {
 		CheckInvItem(isShiftHeld, isCtrlHeld);
 	}
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/68359262/199080999-2095787d-079b-41f3-abfa-e3a6a7982c2f.png)

Changes:
-Reduce Control Panel height (Opens up more viewport)
-Remove Info Panel
    This means you no longer get detailed monster info on mouseover (see Beastiary below), as well as detailed player info on mouseover.
-Add Floating Info Box to replace Info Panel
-Remove buttons
-Add collapsible Mini-panel which contains buttons to open up sub-panels, chat, menu, etc
-Add left mouse button spell select (Includes a speed spell icon that represents standard left click action which can be mapped to either left or right click, or both)
    Selecting a spell on left mouse button will make left mouse button behave the same way that it does for a bow user, but instead of firing an arrow, it casts a spell.

Sub-panel Additions:
-Party panel
    Gives the user a panel that displays all players in game, along with information such as clvl, class, location, as well as a per player Mute button and Player Attack/Friendly button
-Beastiary panel
    Displays pages of monsters along with information about them (like you'd find in the Info Panel, but with more). Amount of information divulged follows the classic rule that you need have a certain amount of kills to see more information.
    Has a button for each game difficulty, to see the correct stats for the difficulty you are playing in. Nightmare button will only appear for clvl 20 and Hell button will only appear for clvl 30.



