### PR TITLE
Clean up handling for gamepad IGNORE/NONE buttons

### DIFF
--- a/Source/controls/controller_motion.cpp
+++ b/Source/controls/controller_motion.cpp
@@ -80,7 +80,7 @@ void SetSimulatingMouseWithPadmapper(bool value)
 
 void SimulateRightStickWithPadmapper(ControllerButtonEvent ctrlEvent)
 {
-	if (IsAnyOf(ctrlEvent.button, ControllerButton_NONE, ControllerButton_IGNORE))
+	if (ctrlEvent.button == ControllerButton_NONE)
 		return;
 	if (!ctrlEvent.up && ctrlEvent.button == SuppressedButton)
 		return;

--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -332,7 +332,7 @@ bool SkipsMovie(ControllerButtonEvent ctrlEvent)
 
 bool IsSimulatedMouseClickBinding(ControllerButtonEvent ctrlEvent)
 {
-	if (IsAnyOf(ctrlEvent.button, ControllerButton_NONE, ControllerButton_IGNORE))
+	if (ctrlEvent.button == ControllerButton_NONE)
 		return false;
 	if (!ctrlEvent.up && ctrlEvent.button == SuppressedButton)
 		return false;
@@ -357,17 +357,18 @@ bool HandleControllerButtonEvent(const SDL_Event &event, GameAction &action)
 	};
 
 	const ControllerButtonEvent ctrlEvent = ToControllerButtonEvent(event);
+	if (ctrlEvent.button == ControllerButton_IGNORE) {
+		return false;
+	}
+
 	const ButtonReleaser buttonReleaser { ctrlEvent };
 	bool isGamepadMotion = ProcessControllerMotion(event, ctrlEvent);
 	DetectInputMethod(event, ctrlEvent);
 	if (isGamepadMotion) {
 		return true;
 	}
-	if (IsAnyOf(ctrlEvent.button, ControllerButton_NONE, ControllerButton_IGNORE)) {
-		return false;
-	}
 
-	if (ctrlEvent.button == SuppressedButton) {
+	if (ctrlEvent.button != ControllerButton_NONE && ctrlEvent.button == SuppressedButton) {
 		if (!ctrlEvent.up)
 			return true;
 		SuppressedButton = ControllerButton_NONE;

--- a/Source/controls/menu_controls.cpp
+++ b/Source/controls/menu_controls.cpp
@@ -27,8 +27,11 @@ MenuAction GetMenuHeldUpDownAction()
 MenuAction GetMenuAction(const SDL_Event &event)
 {
 	const ControllerButtonEvent ctrlEvent = ToControllerButtonEvent(event);
-	bool isGamepadMotion = ProcessControllerMotion(event, ctrlEvent);
+	if (ctrlEvent.button == ControllerButton_IGNORE) {
+		return MenuAction_NONE;
+	}
 
+	bool isGamepadMotion = ProcessControllerMotion(event, ctrlEvent);
 	DetectInputMethod(event, ctrlEvent);
 	if (isGamepadMotion) {
 		return GetMenuHeldUpDownAction();
@@ -36,8 +39,6 @@ MenuAction GetMenuAction(const SDL_Event &event)
 
 	if (!ctrlEvent.up) {
 		switch (TranslateTo(GamepadType, ctrlEvent.button)) {
-		case ControllerButton_IGNORE:
-			return MenuAction_NONE;
 		case ControllerButton_BUTTON_A:
 		case ControllerButton_BUTTON_START:
 			return MenuAction_SELECT;

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1573,7 +1573,7 @@ void DetectInputMethod(const SDL_Event &event, const ControllerButtonEvent &game
 #endif
 
 #if HAS_KBCTRL == 1
-	if (inputType == ControlTypes::KeyboardAndMouse && IsNoneOf(gamepadEvent.button, ControllerButton_NONE, ControllerButton_IGNORE)) {
+	if (inputType == ControlTypes::KeyboardAndMouse && gamepadEvent.button != ControllerButton_NONE) {
 		inputType = ControlTypes::Gamepad;
 	}
 #endif


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/diasurgical/devilutionX/pull/5455#issuecomment-1297991823.

* Shortcut processing for `ControllerButton_IGNORE` ASAP because the intent is clear: this is a gamepad button but we intend to ignore it
* Allow `ControllerButton_NONE` to be processed because it may represent an unrecognized gamepad button or another event entirely, like a touchscreen event