### PR TITLE
Padmapper: Simplify `buttonTo*` data structures

### DIFF
--- a/Source/controls/controller_buttons.h
+++ b/Source/controls/controller_buttons.h
@@ -28,7 +28,9 @@ enum ControllerButton : uint8_t {
 	ControllerButton_BUTTON_DPAD_UP,
 	ControllerButton_BUTTON_DPAD_DOWN,
 	ControllerButton_BUTTON_DPAD_LEFT,
-	ControllerButton_BUTTON_DPAD_RIGHT
+	ControllerButton_BUTTON_DPAD_RIGHT,
+	FIRST = ControllerButton_NONE,
+	LAST = ControllerButton_BUTTON_DPAD_RIGHT
 };
 
 struct ControllerButtonCombo {

--- a/Source/options.h
+++ b/Source/options.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <forward_list>
@@ -746,8 +747,8 @@ struct PadmapperOptions : OptionCategoryBase {
 
 private:
 	std::forward_list<Action> actions;
-	std::unordered_map<ControllerButton, std::reference_wrapper<const Action>> buttonToReleaseAction;
-	std::unordered_map<ControllerButton, std::string> buttonToButtonName;
+	std::array<const Action *, enum_size<ControllerButton>::value> buttonToReleaseAction;
+	std::array<std::string, enum_size<ControllerButton>::value> buttonToButtonName;
 	std::unordered_map<std::string, ControllerButton> buttonNameToButton;
 	bool committed = false;
 


### PR DESCRIPTION
Use an `std::array` instead of `std::unordered_map`.