### PR TITLE
Use `function_ref` instead of `function`

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -762,11 +762,11 @@ void UiClearScreen()
 		SDL_FillRect(DiabloUiSurface(), nullptr, 0x000000);
 }
 
-void UiPollAndRender(std::function<bool(SDL_Event &)> eventHandler)
+void UiPollAndRender(std::optional<tl::function_ref<bool(SDL_Event &)>> eventHandler)
 {
 	SDL_Event event;
 	while (PollEvent(&event) != 0) {
-		if (eventHandler && eventHandler(event))
+		if (eventHandler && (*eventHandler)(event))
 			continue;
 		UiFocusNavigation(&event);
 		UiHandleEvents(&event);

--- a/Source/DiabloUI/diabloui.h
+++ b/Source/DiabloUI/diabloui.h
@@ -5,11 +5,14 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <function_ref.hpp>
+
 #include "DiabloUI/ui_item.h"
 #include "engine/clx_sprite.hpp"
 #include "engine/load_pcx.hpp" // IWYU pragma: export
 #include "player.h"
 #include "utils/display.h"
+#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 
@@ -105,7 +108,7 @@ void UiFocusNavigationEsc();
 void UiFocusNavigationYesNo();
 void UiInitList(void (*fnFocus)(int value), void (*fnSelect)(int value), void (*fnEsc)(), const std::vector<std::unique_ptr<UiItemBase>> &items, bool wraps = false, void (*fnFullscreen)() = nullptr, bool (*fnYesNo)() = nullptr, size_t selectedItem = 0);
 void UiClearScreen();
-void UiPollAndRender(std::function<bool(SDL_Event &)> eventHandler = nullptr);
+void UiPollAndRender(std::optional<tl::function_ref<bool(SDL_Event &)>> eventHandler = std::nullopt);
 void UiRenderItem(const UiItemBase &item);
 void UiRenderItems(const std::vector<UiItemBase *> &items);
 void UiRenderItems(const std::vector<std::unique_ptr<UiItemBase>> &items);

--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -1,5 +1,7 @@
 #include "selstart.h"
 
+#include <function_ref.hpp>
+
 #include "DiabloUI/diabloui.h"
 #include "DiabloUI/scrollbar.h"
 #include "control.h"
@@ -9,6 +11,7 @@
 #include "miniwin/misc_msg.h"
 #include "options.h"
 #include "utils/language.h"
+#include "utils/stdcompat/optional.hpp"
 #include "utils/utf8.hpp"
 
 namespace devilution {
@@ -268,7 +271,7 @@ void UiSettingsMenu()
 		vecDialog.push_back(std::make_unique<UiArtText>(optionDescription, MakeSdlRect(rectDescription), UiFlags::FontSize12 | UiFlags::ColorUiSilverDark | UiFlags::AlignCenter, 1, IsSmallFontTall() ? 22 : 18));
 
 		size_t itemToSelect = 1;
-		std::function<bool(SDL_Event &)> eventHandler;
+		std::optional<tl::function_ref<bool(SDL_Event &)>> eventHandler;
 
 		switch (shownMenu) {
 		case ShownMenuType::Settings: {

--- a/Source/engine/path.cpp
+++ b/Source/engine/path.cpp
@@ -7,6 +7,8 @@
 
 #include <array>
 
+#include <function_ref.hpp>
+
 #include "levels/gendung.h"
 #include "lighting.h"
 #include "objects.h"
@@ -290,7 +292,7 @@ bool ParentPath(uint16_t pathIndex, Point candidatePosition, Point destinationPo
  *
  * @return false if we ran out of preallocated nodes to use, else true
  */
-bool GetPath(const std::function<bool(Point)> &posOk, uint16_t pathIndex, Point destination)
+bool GetPath(tl::function_ref<bool(Point)> posOk, uint16_t pathIndex, Point destination)
 {
 	for (Displacement dir : PathDirs) {
 		const PathNode &path = PathNodes[pathIndex];
@@ -362,7 +364,7 @@ bool IsTileOccupied(Point position)
 	return false;
 }
 
-int FindPath(const std::function<bool(Point)> &posOk, Point startPosition, Point destinationPosition, int8_t path[MaxPathLength])
+int FindPath(tl::function_ref<bool(Point)> posOk, Point startPosition, Point destinationPosition, int8_t path[MaxPathLength])
 {
 	/**
 	 * for reconstructing the path after the A* search is done. The longest
@@ -434,7 +436,7 @@ bool path_solid_pieces(Point startPosition, Point destinationPosition)
 	return rv;
 }
 
-std::optional<Point> FindClosestValidPosition(const std::function<bool(Point)> &posOk, Point startingPosition, unsigned int minimumRadius, unsigned int maximumRadius)
+std::optional<Point> FindClosestValidPosition(tl::function_ref<bool(Point)> posOk, Point startingPosition, unsigned int minimumRadius, unsigned int maximumRadius)
 {
 	return Crawl(minimumRadius, maximumRadius, [&](Displacement displacement) -> std::optional<Point> {
 		Point candidatePosition = startingPosition + displacement;

--- a/Source/engine/path.h
+++ b/Source/engine/path.h
@@ -6,10 +6,10 @@
 #pragma once
 
 #include <cstdint>
-#include <functional>
 #include <limits>
 
 #include <SDL.h>
+#include <function_ref.hpp>
 
 #include "engine/direction.hpp"
 #include "engine/point.hpp"
@@ -36,7 +36,7 @@ bool IsTileOccupied(Point position);
  * @brief Find the shortest path from startPosition to destinationPosition, using PosOk(Point) to check that each step is a valid position.
  * Store the step directions (corresponds to an index in PathDirs) in path, which must have room for 24 steps
  */
-int FindPath(const std::function<bool(Point)> &posOk, Point startPosition, Point destinationPosition, int8_t path[MaxPathLength]);
+int FindPath(tl::function_ref<bool(Point)> posOk, Point startPosition, Point destinationPosition, int8_t path[MaxPathLength]);
 
 /**
  * @brief check if stepping from a given position to a neighbouring tile cuts a corner.
@@ -83,6 +83,6 @@ const Displacement PathDirs[8] = {
  * @param maximumRadius The maximum distance to check, defaults to 18 for vanilla compatibility but supports values up to 50
  * @return either the closest valid point or an empty optional
  */
-std::optional<Point> FindClosestValidPosition(const std::function<bool(Point)> &posOk, Point startingPosition, unsigned int minimumRadius = 0, unsigned int maximumRadius = 18);
+std::optional<Point> FindClosestValidPosition(tl::function_ref<bool(Point)> posOk, Point startingPosition, unsigned int minimumRadius = 0, unsigned int maximumRadius = 18);
 
 } // namespace devilution

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -458,7 +458,7 @@ void CheckMissileCol(Missile &missile, int minDamage, int maxDamage, bool isDama
 		PlaySfxLoc(MissilesData[missile._mitype].miSFX, missile.position.tile);
 }
 
-bool MoveMissile(Missile &missile, const std::function<bool(Point)> &checkTile, bool ifCheckTileFailsDontMoveToTile = false)
+bool MoveMissile(Missile &missile, tl::function_ref<bool(Point)> checkTile, bool ifCheckTileFailsDontMoveToTile = false)
 {
 	Point prevTile = missile.position.tile;
 	missile.position.traveled += missile.position.velocity;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4049,7 +4049,7 @@ bool LineClearMissile(Point startPoint, Point endPoint)
 	return LineClear(PosOkMissile, startPoint, endPoint);
 }
 
-bool LineClear(const std::function<bool(Point)> &clear, Point startPoint, Point endPoint)
+bool LineClear(tl::function_ref<bool(Point)> clear, Point startPoint, Point endPoint)
 {
 	Point position = startPoint;
 

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -11,6 +11,8 @@
 #include <array>
 #include <functional>
 
+#include <function_ref.hpp>
+
 #include "engine.h"
 #include "engine/actor_position.hpp"
 #include "engine/animationinfo.h"
@@ -478,7 +480,7 @@ void FreeMonsters();
 bool DirOK(const Monster &monster, Direction mdir);
 bool PosOkMissile(Point position);
 bool LineClearMissile(Point startPoint, Point endPoint);
-bool LineClear(const std::function<bool(Point)> &clear, Point startPoint, Point endPoint);
+bool LineClear(tl::function_ref<bool(Point)> clear, Point startPoint, Point endPoint);
 void SyncMonsterAnim(Monster &monster);
 void M_FallenFear(Point position);
 void PrintMonstHistory(int mt);

--- a/Source/platform/vita/CMakeLists.txt
+++ b/Source/platform/vita/CMakeLists.txt
@@ -23,4 +23,5 @@ target_link_libraries(libdevilutionx_vita PUBLIC
   SceAppUtil_stub
   SceNet_stub
   SceNetCtl_stub
+  tl
 )

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -1,9 +1,10 @@
 #include "utils/language.h"
 
-#include <functional>
 #include <memory>
 #include <unordered_map>
 #include <vector>
+
+#include <function_ref.hpp>
 
 #include "engine/assets.hpp"
 #include "options.h"
@@ -104,7 +105,7 @@ string_view TrimRight(string_view str)
 
 // English, Danish, Spanish, Italian, Swedish
 unsigned PluralForms = 2;
-std::function<int(int n)> GetLocalPluralId = [](int n) -> int { return n != 1 ? 1 : 0; };
+tl::function_ref<int(int n)> GetLocalPluralId = [](int n) -> int { return n != 1 ? 1 : 0; };
 
 /**
  * Match plural=(n != 1);"


### PR DESCRIPTION
`function_ref` is a lightweight function pointer, whereas `std::function` always involves a heap allocation.