### PR TITLE
Reverse A and B in pad button to key translation functions

### DIFF
--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -29,12 +29,12 @@ SDL_Keycode TranslateControllerButtonToGameMenuKey(ControllerButton controllerBu
 {
 	switch (TranslateTo(GamepadType, controllerButton)) {
 	case ControllerButton_BUTTON_A:
+	case ControllerButton_BUTTON_Y:
+		return SDLK_RETURN;
+	case ControllerButton_BUTTON_B:
 	case ControllerButton_BUTTON_BACK:
 	case ControllerButton_BUTTON_START:
 		return SDLK_ESCAPE;
-	case ControllerButton_BUTTON_B:
-	case ControllerButton_BUTTON_Y:
-		return SDLK_RETURN;
 	case ControllerButton_BUTTON_LEFTSTICK:
 		return SDLK_TAB; // Map
 	default:
@@ -46,11 +46,11 @@ SDL_Keycode TranslateControllerButtonToMenuKey(ControllerButton controllerButton
 {
 	switch (TranslateTo(GamepadType, controllerButton)) {
 	case ControllerButton_BUTTON_A:
+		return SDLK_SPACE;
+	case ControllerButton_BUTTON_B:
 	case ControllerButton_BUTTON_BACK:
 	case ControllerButton_BUTTON_START:
 		return SDLK_ESCAPE;
-	case ControllerButton_BUTTON_B:
-		return SDLK_SPACE;
 	case ControllerButton_BUTTON_Y:
 		return SDLK_RETURN;
 	case ControllerButton_BUTTON_LEFTSTICK:
@@ -72,10 +72,10 @@ SDL_Keycode TranslateControllerButtonToQuestLogKey(ControllerButton controllerBu
 {
 	switch (TranslateTo(GamepadType, controllerButton)) {
 	case ControllerButton_BUTTON_A:
-		return SDLK_SPACE;
-	case ControllerButton_BUTTON_B:
 	case ControllerButton_BUTTON_Y:
 		return SDLK_RETURN;
+	case ControllerButton_BUTTON_B:
+		return SDLK_SPACE;
 	case ControllerButton_BUTTON_LEFTSTICK:
 		return SDLK_TAB; // Map
 	default:


### PR DESCRIPTION
It looks like most of these mappings were just plain wrong. There's still a bit of confusion on non-Nintendo gamepads because there are a few menus (inventory, char panel, speedbook, etc) that depend on `PrimaryAction` and `CancelAction` instead of these hardcoded mappings. In the long term, I'm aiming to have a separate `ConfirmAction` to help resolve that discrepancy.

This resolves #5448