### PR TITLE
AnimationInfo: Use fixed point math for fractions

### DIFF
--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -78,9 +78,9 @@ public:
 	[[nodiscard]] int8_t getFrameToUseForRendering() const;
 
 	/**
-	 * @brief Calculates the progress of the current animation as a fraction (0.0f to 1.0f)
+	 * @brief Calculates the progress of the current animation as a fraction (see baseValueFraction)
 	 */
-	[[nodiscard]] float getAnimationProgress() const;
+	[[nodiscard]] uint8_t getAnimationProgress() const;
 
 	/**
 	 * @brief Sets the new Animation with all relevant information for rendering
@@ -92,7 +92,7 @@ public:
 	 * @param distributeFramesBeforeFrame Distribute the numSkippedFrames only before this frame
 	 * @param previewShownGameTickFragments Defines how long (in game ticks fraction) the preview animation was shown
 	 */
-	void setNewAnimation(OptionalClxSpriteList sprites, int8_t numberOfFrames, int8_t ticksPerFrame, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int8_t numSkippedFrames = 0, int8_t distributeFramesBeforeFrame = 0, float previewShownGameTickFragments = 0.F);
+	void setNewAnimation(OptionalClxSpriteList sprites, int8_t numberOfFrames, int8_t ticksPerFrame, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int8_t numSkippedFrames = 0, int8_t distributeFramesBeforeFrame = 0, int8_t previewShownGameTickFragments = 0);
 
 	/**
 	 * @brief Changes the Animation Data on-the-fly. This is needed if a animation is currently in progress and the player changes his gear.
@@ -108,11 +108,16 @@ public:
 	 */
 	void processAnimation(bool reverseAnimation = false);
 
+	/**
+	 * @brief Fractions in AnimationInfo are stored as fixed point (baseValueFraction/128 correspondents to 1/100%).
+	 */
+	constexpr static uint8_t baseValueFraction = 128;
+
 private:
 	/**
-	 * @brief returns the progress as a fraction (0.0f to 1.0f) in time to the next game tick or 0.0f if the animation is frozen
+	 * @brief returns the progress as a fraction in time to the next game tick or no progress if the animation is frozen (see baseValueFraction)
 	 */
-	[[nodiscard]] float getProgressToNextGameTick() const;
+	[[nodiscard]] uint8_t getProgressToNextGameTick() const;
 
 	/**
 	 * @brief Animation Frames that will be adjusted for the skipped Frames/game ticks
@@ -122,15 +127,14 @@ private:
 	 * @brief Animation Frames that wasn't shown from previous Animation
 	 */
 	int8_t skippedFramesFromPreviousAnimation_;
-
 	/**
-	 * @brief Specifies how many animations-fractions are displayed between two game ticks. this can be > 0, if animations are skipped or < 0 if the same animation is shown in multiple times (delay specified).
+	 * @brief Specifies how many animations-fractions (see baseValueFraction) are displayed between two game ticks. this can be more then one frame, if animations are skipped or less then one frame if the same animation is shown in multiple times (delay specified).
 	 */
-	float tickModifier_;
+	uint16_t tickModifier_;
 	/**
 	 * @brief Number of game ticks after the current animation sequence started
 	 */
-	float ticksSinceSequenceStarted_;
+	int16_t ticksSinceSequenceStarted_;
 };
 
 } // namespace devilution

--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -153,7 +153,7 @@ bool LoadDemoMessages(int i)
 void RecordEventHeader(const SDL_Event &event)
 {
 	WriteLE32(DemoRecording, static_cast<uint32_t>(DemoMsgType::Message));
-	WriteLEFloat(DemoRecording, gfProgressToNextGameTick);
+	WriteLEFloat(DemoRecording, ProgressToNextGameTick / static_cast<float>(AnimationInfo::baseValueFraction));
 	WriteLE32(DemoRecording, event.type);
 }
 
@@ -226,14 +226,14 @@ bool GetRunGameLoop(bool &drawGame, bool &processInput)
 			float progressToNextGameTick = clamp((float)ticksElapsed / (float)gnTickDelay, 0.F, 1.F);
 			if (dmsg.type == DemoMsgType::GameTick || dmsg.progressToNextGameTick > progressToNextGameTick) {
 				// we are ahead of the replay => add a additional rendering for smoothness
-				gfProgressToNextGameTick = progressToNextGameTick;
+				ProgressToNextGameTick = static_cast<uint8_t>(AnimationInfo::baseValueFraction * progressToNextGameTick);
 				processInput = false;
 				drawGame = true;
 				return false;
 			}
 		}
 	}
-	gfProgressToNextGameTick = dmsg.progressToNextGameTick;
+	ProgressToNextGameTick = static_cast<uint8_t>(AnimationInfo::baseValueFraction * dmsg.progressToNextGameTick);
 	Demo_Message_Queue.pop_front();
 	if (dmsg.type == DemoMsgType::GameTick)
 		LogicTick++;
@@ -302,7 +302,7 @@ bool FetchMessage(SDL_Event *event, uint16_t *modState)
 				}
 				break;
 			}
-			gfProgressToNextGameTick = dmsg.progressToNextGameTick;
+			ProgressToNextGameTick = static_cast<uint8_t>(AnimationInfo::baseValueFraction * dmsg.progressToNextGameTick);
 			Demo_Message_Queue.pop_front();
 			return true;
 		}
@@ -314,7 +314,7 @@ bool FetchMessage(SDL_Event *event, uint16_t *modState)
 void RecordGameLoopResult(bool runGameLoop)
 {
 	WriteLE32(DemoRecording, static_cast<uint32_t>(runGameLoop ? DemoMsgType::GameTick : DemoMsgType::Rendering));
-	WriteLEFloat(DemoRecording, gfProgressToNextGameTick);
+	WriteLEFloat(DemoRecording, ProgressToNextGameTick / static_cast<float>(AnimationInfo::baseValueFraction));
 }
 
 void RecordMessage(const SDL_Event &event, uint16_t modState)

--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -24,7 +24,7 @@ uintptr_t glpMsgTbl[MAX_PLRS];
 uint32_t gdwLargestMsgSize;
 uint32_t gdwNormalMsgSize;
 int last_tick;
-float gfProgressToNextGameTick = 0.0;
+uint8_t ProgressToNextGameTick = 0;
 
 namespace {
 
@@ -242,18 +242,15 @@ void nthread_UpdateProgressToNextGameTick()
 	if (!gbRunGame || PauseMode != 0 || (!gbIsMultiplayer && gmenu_is_active()) || !gbProcessPlayers || demo::IsRunning()) // if game is not running or paused there is no next gametick in the near future
 		return;
 	int currentTickCount = SDL_GetTicks();
-	int ticksElapsed = last_tick - currentTickCount;
-	if (ticksElapsed <= 0) {
-		gfProgressToNextGameTick = 1.0; // game tick is due
+	int ticksMissing = last_tick - currentTickCount;
+	if (ticksMissing <= 0) {
+		ProgressToNextGameTick = AnimationInfo::baseValueFraction; // game tick is due
 		return;
 	}
-	int ticksAdvanced = gnTickDelay - ticksElapsed;
-	float fraction = (float)ticksAdvanced / (float)gnTickDelay;
-	if (fraction > 1.0)
-		gfProgressToNextGameTick = 1.0;
-	if (fraction < 0.0)
-		gfProgressToNextGameTick = 0.0;
-	gfProgressToNextGameTick = fraction;
+	int ticksAdvanced = gnTickDelay - ticksMissing;
+	int32_t fraction = ticksAdvanced * AnimationInfo::baseValueFraction / gnTickDelay;
+	fraction = clamp<int32_t>(fraction, 0, AnimationInfo::baseValueFraction);
+	ProgressToNextGameTick = static_cast<uint8_t>(fraction);
 }
 
 } // namespace devilution

--- a/Source/nthread.h
+++ b/Source/nthread.h
@@ -16,7 +16,8 @@ extern uint32_t gdwTurnsInTransit;
 extern uintptr_t glpMsgTbl[MAX_PLRS];
 extern uint32_t gdwLargestMsgSize;
 extern uint32_t gdwNormalMsgSize;
-extern DVL_API_FOR_TEST float gfProgressToNextGameTick; // the progress as a fraction (0.0f to 1.0f) in time to the next game tick
+/** @brief the progress as a fraction (see AnimationInfo::baseValueFraction) in time to the next game tick */
+extern DVL_API_FOR_TEST uint8_t ProgressToNextGameTick;
 extern int last_tick;
 
 void nthread_terminate_game(const char *pszFcn);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2198,7 +2198,7 @@ void Player::UpdatePreviewCelSprite(_cmd_id cmdId, Point point, uint16_t wParam1
 	ClxSpriteList sprites = AnimationData[static_cast<size_t>(*graphic)].spritesForDirection(dir);
 	if (!previewCelSprite || *previewCelSprite != sprites[0]) {
 		previewCelSprite = sprites[0];
-		progressToNextGameTickWhenPreviewWasSet = gfProgressToNextGameTick;
+		progressToNextGameTickWhenPreviewWasSet = ProgressToNextGameTick;
 	}
 }
 
@@ -2323,18 +2323,18 @@ void NewPlrAnim(Player &player, player_graphic graphic, Direction dir, Animation
 	LoadPlrGFX(player, graphic);
 
 	OptionalClxSpriteList sprites;
-	float previewShownGameTickFragments = 0.F;
+	int previewShownGameTickFragments = 0;
 	if (!HeadlessMode) {
 		sprites = player.AnimationData[static_cast<size_t>(graphic)].spritesForDirection(dir);
 		if (player.previewCelSprite && (*sprites)[0] == *player.previewCelSprite && !player.IsWalking()) {
-			previewShownGameTickFragments = clamp(1.F - player.progressToNextGameTickWhenPreviewWasSet, 0.F, 1.F);
+			previewShownGameTickFragments = clamp<int>(AnimationInfo::baseValueFraction - player.progressToNextGameTickWhenPreviewWasSet, 0, AnimationInfo::baseValueFraction);
 		}
 	}
 
 	int8_t numberOfFrames;
 	int8_t ticksPerFrame;
 	player.getAnimationFramesAndTicksPerFrame(graphic, numberOfFrames, ticksPerFrame);
-	player.AnimInfo.setNewAnimation(sprites, numberOfFrames, ticksPerFrame, flags, numSkippedFrames, distributeFramesBeforeFrame, previewShownGameTickFragments);
+	player.AnimInfo.setNewAnimation(sprites, numberOfFrames, ticksPerFrame, flags, numSkippedFrames, distributeFramesBeforeFrame, static_cast<uint8_t>(previewShownGameTickFragments));
 }
 
 void SetPlrAnims(Player &player)

--- a/Source/player.h
+++ b/Source/player.h
@@ -288,7 +288,7 @@ struct Player {
 	/**
 	 * @brief Contains the progress to next game tick when previewCelSprite was set
 	 */
-	float progressToNextGameTickWhenPreviewWasSet;
+	int8_t progressToNextGameTickWhenPreviewWasSet;
 	/** @brief Bitmask using item_special_effect */
 	ItemSpecialEffect _pIFlags;
 	/**

--- a/test/animationinfo_test.cpp
+++ b/test/animationinfo_test.cpp
@@ -110,7 +110,7 @@ void RunAnimationTest(const std::vector<TestData *> &vecTestData)
 		} break;
 		case TestDataType::Rendering: {
 			auto renderingData = static_cast<RenderingData *>(x);
-			gfProgressToNextGameTick = renderingData->_fProgressToNextGameTick;
+			ProgressToNextGameTick = static_cast<uint8_t>(renderingData->_fProgressToNextGameTick * AnimationInfo::baseValueFraction);
 			EXPECT_EQ(animInfo.getFrameToUseForRendering(), renderingData->_ExpectedRenderingFrame)
 			    << std::fixed << std::setprecision(2)
 			    << "ProgressToNextGameTick: " << renderingData->_fProgressToNextGameTick


### PR DESCRIPTION
Addressed glebm's [comment](https://github.com/diasurgical/devilutionX/issues/4849#issuecomment-1173046136).

Uses fixed point math for fractions (game ticks, animations, ...).

The pros:
- reduces size of `AnimationInfo` in 32bit builds (from 20 to 16 bytes)
- better performance for devices that don't have hardware float support

The cons:
- a little bit harder to read
- a fraction can only contain 128 distinct values. That means if you have a device that can show more than 2560fps you could see a difference. 😜