### PR TITLE
Start enabling singleplayer quests for multiplayer

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2745,10 +2745,10 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 				for (int y = 0; y < DMAXY; y++)
 					UpdateAutomapExplorer({ x, y }, MAP_EXP_SELF);
 		}
-		if (!gbIsMultiplayer)
-			ResyncQuests();
-		else
+		if (UseMultiplayerQuests())
 			ResyncMPQuests();
+		else
+			ResyncQuests();
 	} else {
 		LoadSetMap();
 		IncProgress();
@@ -2791,8 +2791,11 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 		} else {
 			LoadLevel();
 		}
-		if (gbIsMultiplayer)
+		if (gbIsMultiplayer) {
 			DeltaLoadLevel();
+			if (!UseMultiplayerQuests())
+				ResyncQuests();
+		}
 
 		InitMissiles();
 		IncProgress();

--- a/Source/levels/drlg_l4.cpp
+++ b/Source/levels/drlg_l4.cpp
@@ -1112,10 +1112,10 @@ bool PlaceStairs(lvl_entry entry)
 		}
 	} else {
 		// Place hell gate
-		bool isGateOpen = UseMultiplayerQuests() || Quests[Q_DIABLO]._qactive == QUEST_ACTIVE;
-		position = PlaceMiniSet(isGateOpen ? L4PENTA2 : L4PENTA);
+		position = PlaceMiniSet(L4PENTA2);
 		if (!position)
 			return false;
+		Quests[Q_DIABLO].position = *position;
 		if (entry == ENTRY_PREV)
 			ViewPosition = position->megaToWorld() + Displacement { 6, 5 };
 	}
@@ -1180,6 +1180,10 @@ void GenerateLevel(lvl_entry entry)
 	DRLG_CheckQuests(SetPieceRoom.position);
 
 	if (currlevel == 15) {
+		bool isGateOpen = UseMultiplayerQuests() || Quests[Q_DIABLO]._qactive == QUEST_ACTIVE;
+		if (!isGateOpen)
+			L4PENTA.place(Quests[Q_DIABLO].position);
+
 		for (WorldTileCoord j = 1; j < DMAXY; j++) {
 			for (WorldTileCoord i = 1; i < DMAXX; i++) {
 				if (IsAnyOf(dungeon[i][j], 98, 107)) {

--- a/Source/levels/drlg_l4.cpp
+++ b/Source/levels/drlg_l4.cpp
@@ -1184,10 +1184,8 @@ void GenerateLevel(lvl_entry entry)
 			for (WorldTileCoord i = 1; i < DMAXX; i++) {
 				if (IsAnyOf(dungeon[i][j], 98, 107)) {
 					Make_SetPC({ WorldTilePosition(i - 1, j - 1), { 5, 5 } });
-					if (Quests[Q_BETRAYER]._qactive >= QUEST_ACTIVE) { /// Lazarus staff skip bug fixed
-						// Set the portal position to the location of the northmost pentagram tile.
-						Quests[Q_BETRAYER].position = { i, j };
-					}
+					// Set the portal position to the location of the northmost pentagram tile.
+					Quests[Q_BETRAYER].position = { i, j };
 				}
 			}
 		}

--- a/Source/levels/drlg_l4.cpp
+++ b/Source/levels/drlg_l4.cpp
@@ -160,7 +160,7 @@ void LoadQuestSetPieces()
 {
 	if (Quests[Q_WARLORD].IsAvailable()) {
 		pSetPiece = LoadFileInMem<uint16_t>("levels\\l4data\\warlord.dun");
-	} else if (currlevel == 15 && gbIsMultiplayer) {
+	} else if (currlevel == 15 && UseMultiplayerQuests()) {
 		pSetPiece = LoadFileInMem<uint16_t>("levels\\l4data\\vile1.dun");
 	}
 }
@@ -253,7 +253,7 @@ void FirstRoom()
 		if (currlevel == Quests[Q_WARLORD]._qlevel && Quests[Q_WARLORD]._qactive != QUEST_NOTAVAIL) {
 			assert(!gbIsMultiplayer);
 			room.size = { 11, 11 };
-		} else if (currlevel == Quests[Q_BETRAYER]._qlevel && gbIsMultiplayer) {
+		} else if (currlevel == Quests[Q_BETRAYER]._qlevel && UseMultiplayerQuests()) {
 			room.size = { 11, 11 };
 		} else {
 			const int32_t randomWidth = GenerateRnd(5) + 2;
@@ -273,7 +273,7 @@ void FirstRoom()
 	if (currlevel == 16) {
 		L4Hold = room.position;
 	}
-	if (Quests[Q_WARLORD].IsAvailable() || (currlevel == Quests[Q_BETRAYER]._qlevel && gbIsMultiplayer)) {
+	if (Quests[Q_WARLORD].IsAvailable() || (currlevel == Quests[Q_BETRAYER]._qlevel && UseMultiplayerQuests())) {
 		SetPieceRoom = { room.position + WorldTileDisplacement { 1, 1 }, WorldTileSize(room.size.width + 1, room.size.height + 1) };
 	} else {
 		SetPieceRoom = {};
@@ -1112,7 +1112,7 @@ bool PlaceStairs(lvl_entry entry)
 		}
 	} else {
 		// Place hell gate
-		bool isGateOpen = gbIsMultiplayer || Quests[Q_DIABLO]._qactive == QUEST_ACTIVE;
+		bool isGateOpen = UseMultiplayerQuests() || Quests[Q_DIABLO]._qactive == QUEST_ACTIVE;
 		position = PlaceMiniSet(isGateOpen ? L4PENTA2 : L4PENTA);
 		if (!position)
 			return false;
@@ -1145,7 +1145,7 @@ void GenerateLevel(lvl_entry entry)
 		if (currlevel == 16) {
 			ProtectQuads();
 		}
-		if (Quests[Q_WARLORD].IsAvailable() || (currlevel == Quests[Q_BETRAYER]._qlevel && gbIsMultiplayer)) {
+		if (Quests[Q_WARLORD].IsAvailable() || (currlevel == Quests[Q_BETRAYER]._qlevel && UseMultiplayerQuests())) {
 			for (int spi = SetPieceRoom.position.x; spi < SetPieceRoom.position.x + SetPieceRoom.size.width - 1; spi++) {
 				for (int spj = SetPieceRoom.position.y; spj < SetPieceRoom.position.y + SetPieceRoom.size.height - 1; spj++) {
 					Protected.set(spi, spj);

--- a/Source/levels/town.cpp
+++ b/Source/levels/town.cpp
@@ -346,6 +346,13 @@ void TownOpenGrave()
 	dPiece[34][21] = 0x53b;
 }
 
+void CleanTownFountain()
+{
+	if (!pMegaTiles)
+		return;
+	FillTile(60, 70, 71);
+}
+
 void CreateTown(lvl_entry entry)
 {
 	dminPosition = { 10, 10 };
@@ -374,7 +381,6 @@ void CreateTown(lvl_entry entry)
 	}
 
 	DrlgTPass3();
-	pMegaTiles = nullptr;
 }
 
 } // namespace devilution

--- a/Source/levels/town.h
+++ b/Source/levels/town.h
@@ -45,6 +45,11 @@ void TownOpenHive();
 void TownOpenGrave();
 
 /**
+ * @brief Update town to show clean/not poisoned water fountain
+ */
+void CleanTownFountain();
+
+/**
  * @brief Initialize town level
  * @param entry Method of entry
  */

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4392,6 +4392,17 @@ Monster *FindMonsterAtPosition(Point position, bool ignoreMovingMonsters)
 	return &Monsters[abs(monsterId) - 1];
 }
 
+Monster *FindUniqueMonster(UniqueMonsterType monsterType)
+{
+	for (size_t i = 0; i < ActiveMonsterCount; i++) {
+		int monsterId = ActiveMonsters[i];
+		auto &monster = Monsters[monsterId];
+		if (monster.uniqueType == monsterType)
+			return &monster;
+	}
+	return nullptr;
+}
+
 bool IsTileAvailable(const Monster &monster, Point position)
 {
 	if (!IsTileAvailable(position))

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -489,6 +489,7 @@ void PlayEffect(Monster &monster, MonsterSound mode);
 void MissToMonst(Missile &missile, Point position);
 
 Monster *FindMonsterAtPosition(Point position, bool ignoreMovingMonsters = false);
+Monster *FindUniqueMonster(UniqueMonsterType monsterType);
 
 /**
  * @brief Check that the given tile is available to the monster

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -102,7 +102,7 @@ struct MultiQuests {
 
 struct DJunk {
 	DPortal portal[MAXPORTAL];
-	MultiQuests quests[MAXMULTIQUESTS];
+	MultiQuests quests[MAXQUESTS];
 };
 #pragma pack(pop)
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2505,7 +2505,7 @@ void delta_sync_monster(const TSyncMonster &monsterSync, uint8_t level)
 	if (!gbIsMultiplayer)
 		return;
 
-	assert(level < MAX_MULTIPLAYERLEVELS);
+	assert(level <= MAX_MULTIPLAYERLEVELS);
 	sgbDeltaChanged = true;
 
 	DMonsterStr &monster = GetDeltaLevel(level).monster[monsterSync._mndx];

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2248,7 +2248,7 @@ size_t OnSyncQuest(const TCmd *pCmd, size_t pnum)
 		SendPacket(pnum, &message, sizeof(message));
 	} else {
 		if (pnum != MyPlayerId && message.q < MAXQUESTS && message.qstate <= QUEST_HIVE_DONE)
-			SetMultiQuest(message.q, message.qstate, message.qlog != 0, message.qvar1);
+			SetMultiQuest(message.q, message.qstate, message.qlog != 0, message.qvar1, message.qvar2);
 		sgbDeltaChanged = true;
 	}
 
@@ -2936,6 +2936,7 @@ void NetSendCmdQuest(bool bHiPri, const Quest &quest)
 	cmd.qstate = quest._qactive;
 	cmd.qlog = quest._qlog ? 1 : 0;
 	cmd.qvar1 = quest._qvar1;
+	cmd.qvar2 = quest._qvar2;
 
 	if (bHiPri)
 		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -423,14 +423,15 @@ byte *DeltaExportJunk(byte *dst)
 
 	int q = 0;
 	for (auto &quest : Quests) {
-		if (!QuestsData[quest._qidx].isSinglePlayerOnly) {
-			sgJunk.quests[q].qlog = quest._qlog ? 1 : 0;
-			sgJunk.quests[q].qstate = quest._qactive;
-			sgJunk.quests[q].qvar1 = quest._qvar1;
-			memcpy(dst, &sgJunk.quests[q], sizeof(MultiQuests));
-			dst += sizeof(MultiQuests);
-			q++;
+		if (QuestsData[quest._qidx].isSinglePlayerOnly && UseMultiplayerQuests()) {
+			continue;
 		}
+		sgJunk.quests[q].qlog = quest._qlog ? 1 : 0;
+		sgJunk.quests[q].qstate = quest._qactive;
+		sgJunk.quests[q].qvar1 = quest._qvar1;
+		memcpy(dst, &sgJunk.quests[q], sizeof(MultiQuests));
+		dst += sizeof(MultiQuests);
+		q++;
 	}
 
 	return dst;
@@ -450,11 +451,12 @@ void DeltaImportJunk(const byte *src)
 
 	int q = 0;
 	for (int qidx = 0; qidx < MAXQUESTS; qidx++) {
-		if (!QuestsData[qidx].isSinglePlayerOnly) {
-			memcpy(&sgJunk.quests[q], src, sizeof(MultiQuests));
-			src += sizeof(MultiQuests);
-			q++;
+		if (QuestsData[qidx].isSinglePlayerOnly && UseMultiplayerQuests()) {
+			continue;
 		}
+		memcpy(&sgJunk.quests[q], src, sizeof(MultiQuests));
+		src += sizeof(MultiQuests);
+		q++;
 	}
 }
 
@@ -2537,7 +2539,7 @@ void DeltaSyncJunk()
 
 	int q = 0;
 	for (auto &quest : Quests) {
-		if (QuestsData[quest._qidx].isSinglePlayerOnly) {
+		if (QuestsData[quest._qidx].isSinglePlayerOnly && UseMultiplayerQuests()) {
 			continue;
 		}
 		if (sgJunk.quests[q].qstate != QUEST_INVALID) {

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -536,6 +536,7 @@ struct TCmdQuest {
 	quest_state qstate;
 	uint8_t qlog;
 	uint8_t qvar1;
+	uint8_t qvar2;
 };
 
 struct TItemDef {

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -17,7 +17,6 @@
 namespace devilution {
 
 #define MAX_SEND_STR_LEN 80
-#define MAXMULTIQUESTS 10
 
 enum _cmd_id : uint8_t {
 	// Player mode standing.

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1880,6 +1880,9 @@ void UpdateLeverState(Object &object)
 		return;
 	}
 
+	if (setlevel && setlvlnum == SL_VILEBETRAYER)
+		ObjectAtPosition({ 35, 36 })._oVar5++;
+
 	ObjChangeMap(object._oVar1, object._oVar2, object._oVar3, object._oVar4);
 }
 
@@ -1939,6 +1942,8 @@ void OperateBook(Player &player, Object &book)
 
 	book._oSelFlag = 0;
 	book._oAnimFrame++;
+
+	NetSendCmdLoc(MyPlayerId, false, CMD_OPERATEOBJ, book.position);
 
 	if (!setlevel) {
 		return;
@@ -3400,6 +3405,7 @@ void OperateLazStand(Object &stand)
 	stand._oSelFlag = 0;
 	Point pos = GetSuperItemLoc(stand.position);
 	SpawnQuestItem(IDI_LAZSTAFF, pos, 0, 0);
+	NetSendCmdLoc(MyPlayerId, false, CMD_OPERATEOBJ, stand.position);
 }
 
 /**
@@ -3891,7 +3897,7 @@ void InitObjects()
 				AddBookLever(OBJ_STEELTOME, SetPiece, spId);
 				LoadMapObjects("levels\\l4data\\warlord.dun", SetPiece.position.megaToWorld());
 			}
-			if (Quests[Q_BETRAYER].IsAvailable() && !gbIsMultiplayer)
+			if (Quests[Q_BETRAYER].IsAvailable() && !UseMultiplayerQuests())
 				AddLazStand();
 			InitRndBarrels();
 			AddL4Goodies();
@@ -4452,6 +4458,7 @@ void DeltaSyncOpObject(Object &object)
 	case OBJ_LEVER:
 	case OBJ_L5LEVER:
 	case OBJ_SWITCHSKL:
+	case OBJ_BOOK2L:
 		UpdateLeverState(object);
 		break;
 	case OBJ_CHEST1:
@@ -4490,6 +4497,7 @@ void DeltaSyncOpObject(Object &object)
 	case OBJ_WARARMOR:
 	case OBJ_WARWEAP:
 	case OBJ_WEAPONRACK:
+	case OBJ_LAZSTAND:
 		UpdateState(object, object._oAnimFrame + 1);
 		break;
 	case OBJ_CAULDRON:

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -828,6 +828,11 @@ bool PlrHitMonst(Player &player, Monster &monster, bool adjacentDamage = false)
 			}
 			dam *= 2;
 		}
+#ifdef _DEBUG
+		if (DebugGodMode) {
+			dam = monster.hitPoints; /* ensure monster is killed with one hit */
+		}
+#endif
 		ApplyMonsterDamage(monster, dam);
 	}
 
@@ -878,11 +883,6 @@ bool PlrHitMonst(Player &player, Monster &monster, bool adjacentDamage = false)
 		}
 		RedrawComponent(PanelDrawComponent::Health);
 	}
-#ifdef _DEBUG
-	if (DebugGodMode) {
-		monster.hitPoints = 0; /* double check */
-	}
-#endif
 	if ((monster.hitPoints >> 6) <= 0) {
 		M_StartKill(monster, player);
 	} else {

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -234,7 +234,6 @@ void InitQuests()
 	QuestLogIsOpen = false;
 	WaterDone = 0;
 
-	int initiatedQuests = 0;
 	int q = 0;
 	for (auto &quest : Quests) {
 		quest._qidx = static_cast<quest_id>(q);
@@ -256,7 +255,6 @@ void InitQuests()
 		} else if (!questData.isSinglePlayerOnly) {
 			quest._qlevel = questData._qdmultlvl;
 			quest._qactive = QUEST_INIT;
-			initiatedQuests++;
 		}
 	}
 

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -683,6 +683,14 @@ void ResyncQuests()
 		Quests[Q_BETRAYER]._qvar2 = 2;
 		NetSendCmdQuest(true, Quests[Q_BETRAYER]);
 	}
+	if (currlevel == Quests[Q_DIABLO]._qlevel
+	    && !setlevel
+	    && Quests[Q_DIABLO]._qactive == QUEST_ACTIVE
+	    && gbIsMultiplayer) {
+		Point posPentagram = Quests[Q_DIABLO].position;
+		ObjChangeMapResync(posPentagram.x, posPentagram.y, posPentagram.x + 5, posPentagram.y + 5);
+		InitL4Triggers();
+	}
 }
 
 void DrawQuestLog(const Surface &out)

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -812,6 +812,10 @@ void SetMultiQuest(int q, quest_state s, bool log, int v1, int v2)
 	if (v1 > quest._qvar1)
 		quest._qvar1 = v1;
 	quest._qvar2 = v2;
+	if (!UseMultiplayerQuests()) {
+		// Ensure that changes on another client is also updated on our own
+		ResyncQuests();
+	}
 }
 
 bool UseMultiplayerQuests()

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -17,6 +17,7 @@
 #include "engine/world_tile.hpp"
 #include "init.h"
 #include "levels/gendung.h"
+#include "levels/town.h"
 #include "levels/trigs.h"
 #include "minitext.h"
 #include "missiles.h"
@@ -350,6 +351,7 @@ void CheckQuests()
 		    && ActiveMonsterCount == 4
 		    && Quests[Q_PWATER]._qactive != QUEST_DONE) {
 			Quests[Q_PWATER]._qactive = QUEST_DONE;
+			NetSendCmdQuest(true, Quests[Q_PWATER]);
 			PlaySfxLoc(IS_QUESTDN, MyPlayer->position.tile);
 			LoadPalette("levels\\l3data\\l3pwater.pal", false);
 			UpdatePWaterPalette();
@@ -690,6 +692,11 @@ void ResyncQuests()
 		Point posPentagram = Quests[Q_DIABLO].position;
 		ObjChangeMapResync(posPentagram.x, posPentagram.y, posPentagram.x + 5, posPentagram.y + 5);
 		InitL4Triggers();
+	}
+	if (currlevel == 0
+	    && Quests[Q_PWATER]._qactive == QUEST_DONE
+	    && gbIsMultiplayer) {
+		CleanTownFountain();
 	}
 }
 

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -249,7 +249,7 @@ void InitQuests()
 		quest._qlog = false;
 		quest._qmsg = questData._qdmsg;
 
-		if (!gbIsMultiplayer) {
+		if (!UseMultiplayerQuests()) {
 			quest._qlevel = questData._qdlvl;
 			quest._qactive = QUEST_INIT;
 		} else if (!questData.isSinglePlayerOnly) {
@@ -258,7 +258,7 @@ void InitQuests()
 		}
 	}
 
-	if (!gbIsMultiplayer && *sgOptions.Gameplay.randomizeQuests) {
+	if (!UseMultiplayerQuests() && *sgOptions.Gameplay.randomizeQuests) {
 		// Quests are set from the seed used to generate level 16.
 		InitialiseQuestPools(glSeedTbl[15], Quests);
 	}
@@ -274,7 +274,7 @@ void InitQuests()
 	if (Quests[Q_ROCK]._qactive == QUEST_NOTAVAIL)
 		Quests[Q_ROCK]._qvar2 = 2;
 	Quests[Q_LTBANNER]._qvar1 = 1;
-	if (gbIsMultiplayer)
+	if (UseMultiplayerQuests())
 		Quests[Q_BETRAYER]._qvar1 = 2;
 }
 
@@ -804,6 +804,11 @@ void SetMultiQuest(int q, quest_state s, bool log, int v1, int v2)
 	quest._qvar2 = v2;
 }
 
+bool UseMultiplayerQuests()
+{
+	return gbIsMultiplayer;
+}
+
 bool Quest::IsAvailable()
 {
 	if (setlevel)
@@ -812,7 +817,7 @@ bool Quest::IsAvailable()
 		return false;
 	if (_qactive == QUEST_NOTAVAIL)
 		return false;
-	if (gbIsMultiplayer && QuestsData[_qidx].isSinglePlayerOnly)
+	if (QuestsData[_qidx].isSinglePlayerOnly && UseMultiplayerQuests())
 		return false;
 
 	return true;

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -787,19 +787,21 @@ void QuestlogESC()
 	}
 }
 
-void SetMultiQuest(int q, quest_state s, bool log, int v1)
+void SetMultiQuest(int q, quest_state s, bool log, int v1, int v2)
 {
 	if (gbIsSpawn)
 		return;
 
-	if (Quests[q]._qactive != QUEST_DONE) {
-		if (s > Quests[q]._qactive)
-			Quests[q]._qactive = s;
+	auto &quest = Quests[q];
+	if (quest._qactive != QUEST_DONE) {
+		if (s > quest._qactive)
+			quest._qactive = s;
 		if (log)
-			Quests[q]._qlog = true;
-		if (v1 > Quests[q]._qvar1)
-			Quests[q]._qvar1 = v1;
+			quest._qlog = true;
 	}
+	if (v1 > quest._qvar1)
+		quest._qvar1 = v1;
+	quest._qvar2 = v2;
 }
 
 bool Quest::IsAvailable()

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -104,6 +104,7 @@ void QuestlogDown();
 void QuestlogEnter();
 void QuestlogESC();
 void SetMultiQuest(int q, quest_state s, bool log, int v1, int v2);
+bool UseMultiplayerQuests();
 
 /* rdata */
 extern QuestData QuestsData[];

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -103,7 +103,7 @@ void QuestlogUp();
 void QuestlogDown();
 void QuestlogEnter();
 void QuestlogESC();
-void SetMultiQuest(int q, quest_state s, bool log, int v1);
+void SetMultiQuest(int q, quest_state s, bool log, int v1, int v2);
 
 /* rdata */
 extern QuestData QuestsData[];

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -484,12 +484,14 @@ void TalkToHealer(Player &player, Towner &healer)
 			Quests[Q_PWATER]._qlog = true;
 			Quests[Q_PWATER]._qmsg = TEXT_POISON3;
 			InitQTextMsg(TEXT_POISON3);
+			NetSendCmdQuest(true, Quests[Q_PWATER]);
 			return;
 		}
 		if (Quests[Q_PWATER]._qactive == QUEST_DONE && Quests[Q_PWATER]._qvar1 != 2) {
 			Quests[Q_PWATER]._qvar1 = 2;
 			InitQTextMsg(TEXT_POISON5);
 			SpawnUnique(UITEM_TRING, healer.position + Direction::SouthWest);
+			NetSendCmdQuest(true, Quests[Q_PWATER]);
 			return;
 		}
 	}

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -516,12 +516,13 @@ void TalkToBoy(Player & /*player*/, Towner & /*boy*/)
 void TalkToStoryteller(Player &player, Towner & /*storyteller*/)
 {
 	auto &betrayerQuest = Quests[Q_BETRAYER];
-	if (!gbIsMultiplayer) {
+	if (!UseMultiplayerQuests()) {
 		if (betrayerQuest._qactive == QUEST_INIT && RemoveInventoryItemById(player, IDI_LAZSTAFF)) {
 			InitQTextMsg(TEXT_VILE1);
 			betrayerQuest._qlog = true;
 			betrayerQuest._qactive = QUEST_ACTIVE;
 			betrayerQuest._qvar1 = 2;
+			NetSendCmdQuest(true, betrayerQuest);
 			return;
 		}
 	} else {


### PR DESCRIPTION
Contributes to #926

With #4738 (and it's successors) quest/set-maps are multiplayer compatible.
This pr now starts with the ground work for syncing all quests and enabling two singleplayer quests for multiplayer (Lazarus and Poisoned Water Supply).

Notes:
- `UseMultiplayerQuests()` was introduced to switch between single- and multiplayer quests (In theory it could also be used to play the multiplayer quests in singleplayer 😉). Previous this was done with `gbIsMultiplayer` checks, but now that we start supporting singleplayer quests in multiplayer this is insufficient. Currently `UseMultiplayerQuests()` is identically to `gbIsMultiplayer`, but later it will be likely replaced by a setting that is synced between clients (like missile friendly fire). For my testing i replaced it with a hardcoded false. 😉 Side-note: This make understanding the code easier, cause previous many `gbIsMultiplayer` checks are quests specific and not really multiplayer specific.
- Some syncing of map changing is necessary that also didn't happen in singleplayer. For example: one player kills lazarus and another player stands in dungeon level 15 at the pentagram the pentagram must be updated on the fly (and not at level load time). Another example: the poisoned water fountain in town must be cleared if another player kills all monsters. Currently `ResyncQuests` is used for that.
- For other quests some general issues need to be fixed (for example spawning unique items from quests #4188)
- This pr is not 100% tested. There should be some edge-cases missing. But I hope this is a good start.
- After the pr is merged, it is hopefully possible to work independent and parallel on different quests. I killed Lazarus and the monsters in poisioned water supply a lot already 🥴, so any help is more then welcome. 🙂 