### PR TITLE
Use no-background spell icons with UNPACKED_MPQS

### DIFF
--- a/Source/controls/modifier_hints.cpp
+++ b/Source/controls/modifier_hints.cpp
@@ -12,12 +12,11 @@
 #include "engine/render/clx_render.hpp"
 #include "engine/render/text_render.hpp"
 #include "options.h"
+#include "panels/spell_book.hpp"
 #include "panels/spell_icons.hpp"
 #include "utils/language.h"
 
 namespace devilution {
-
-extern OptionalOwnedClxSpriteList pSBkIconCels;
 
 namespace {
 
@@ -140,7 +139,11 @@ void DrawSpellsCircleMenuHint(const Surface &out, const Point &origin)
 		}
 
 		SetSpellTrans(splType);
-		DrawSpellCel(out, spellIconPositions[slot], *pSBkIconCels, SpellITbl[splId]);
+#ifdef UNPACKED_MPQS
+		DrawSpellCel(out, spellIconPositions[slot], (*pSBkIconsForeground)[SpellITbl[splId]], (*pSBkIconsBackground)[0]);
+#else
+		DrawSpellCel(out, spellIconPositions[slot], (*pSBkIconCels)[SpellITbl[splId]]);
+#endif
 		RenderClxSprite(out, (*hintBox)[0], hintBoxPositions[slot]);
 	}
 }

--- a/Source/panels/spell_book.hpp
+++ b/Source/panels/spell_book.hpp
@@ -1,8 +1,16 @@
 #pragma once
 
+#include "engine/clx_sprite.hpp"
 #include "engine/surface.hpp"
 
 namespace devilution {
+
+#ifdef UNPACKED_MPQS
+extern OptionalOwnedClxSpriteList pSBkIconsBackground;
+extern OptionalOwnedClxSpriteList pSBkIconsForeground;
+#else
+extern OptionalOwnedClxSpriteList pSBkIconCels;
+#endif
 
 void InitSpellBook();
 void FreeSpellBook();

--- a/Source/panels/spell_icons.hpp
+++ b/Source/panels/spell_icons.hpp
@@ -25,9 +25,14 @@ void DrawSpellCel(const Surface &out, Point position, int nCel);
  * @param out Output buffer.
  * @param position Buffer coordinates.
  * @param sprite Icons sprite sheet.
- * @param nCel Index of the cel frame to draw. 0 based.
  */
-void DrawSpellCel(const Surface &out, Point position, const OwnedClxSpriteList &sprite, int nCel);
+#ifdef UNPACKED_MPQS
+void DrawSpellCel(const Surface &out, Point position, ClxSprite sprite, ClxSprite background);
+#else
+void DrawSpellCel(const Surface &out, Point position, ClxSprite sprite);
+#endif
+
+void DrawSpellBorder(const Surface &out, Point position, ClxSprite sprite);
 
 void SetSpellTrans(spell_type t);
 


### PR DESCRIPTION
Corresponding devilutionx-mpq-tools PR: https://github.com/diasurgical/devilutionx-mpq-tools/pull/4
Should be merged at the same time

Saves 120 KiB of RAM in Hellfire

Total size: 200 KiB -> 81 KiB

Images without backgrounds:
Large: ![spelicon_fg_clx](https://user-images.githubusercontent.com/216339/200957687-008693b8-3bb3-4bba-aa01-b883f0956cd5.png)
Small: ![spelli2_fg_clx](https://user-images.githubusercontent.com/216339/200957693-0956e798-3920-497c-aacf-d02236a92694.png)

Fixes #5470