### PR TITLE
GetOffsetForWalking: use uint8_t for animation fraction

### DIFF
--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1278,7 +1278,7 @@ Displacement GetOffsetForWalking(const AnimationInfo &animationInfo, const Direc
 	constexpr Displacement MovingOffset[8]   = { {   0,  32 }, { -32,  16 }, { -64,   0 }, { -32, -16 }, {   0, -32 }, {  32, -16 },  {  64,   0 }, {  32,  16 } };
 	// clang-format on
 
-	int8_t animationProgress = animationInfo.getAnimationProgress();
+	uint8_t animationProgress = animationInfo.getAnimationProgress();
 	Displacement offset = MovingOffset[static_cast<size_t>(dir)];
 	offset *= animationProgress;
 	offset /= AnimationInfo::baseValueFraction;


### PR DESCRIPTION
Fixes #5477

`getAnimationProgress` returns a `uint8_t` but `GetOffsetForWalking` used `int8_t`.
Only if the walk animation is completed the value gets wrapped from 128 to -128 => glitch 😉 

@glebm Thanks for spotting the issue 🙂 