### PR TITLE
Add scrollbar to help window

### DIFF
--- a/Source/help.cpp
+++ b/Source/help.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "DiabloUI/ui_flags.hpp"
+#include "engine/render/clx_render.hpp"
 #include "engine/render/text_render.hpp"
 #include "init.h"
 #include "minitext.h"
@@ -101,7 +102,7 @@ constexpr int PaddingTop = 32;
 constexpr int PaddingLeft = 32;
 
 constexpr int PanelHeight = 297;
-constexpr int ContentTextWidth = 577;
+constexpr int ContentTextWidth = 565;
 
 int LineHeight()
 {
@@ -138,6 +139,29 @@ int NumVisibleLines()
 	return (ContentsTextHeight() - 1) / LineHeight() + 1; // Ceil
 }
 
+void DrawHelpSlider(const Surface &out)
+{
+	const Point uiPosition = GetUIRectangle().position;
+	const int sliderXPos = ContentTextWidth + uiPosition.x + 36;
+	const Point sliderPosition = uiPosition;
+	int sliderStart = uiPosition.y + HeaderHeight() + LineHeight() + 3;
+	int sliderEnd = uiPosition.y + PaddingTop + PanelHeight - 12;
+	ClxDraw(out, { sliderXPos, sliderStart }, (*pSTextSlidCels)[11]);
+	sliderStart += 12;
+	int sliderCurrent = sliderStart;
+	for (; sliderCurrent < sliderEnd; sliderCurrent += 12) {
+		ClxDraw(out, { sliderXPos, sliderCurrent }, (*pSTextSlidCels)[13]);
+	}
+	ClxDraw(out, { sliderXPos, sliderCurrent }, (*pSTextSlidCels)[10]);
+	// Subtract visible lines from the total number of lines to get the actual
+	// scroll range
+	const float scrollRange = HelpTextLines.size() - NumVisibleLines();
+	// Subtract the size of the arrow buttons to get the length of the interior
+	// part of the slider
+	const float sliderLength = sliderCurrent - 12 - sliderStart;
+	ClxDraw(out, { sliderXPos, sliderStart + (int)(((float)SkipLines * sliderLength) / scrollRange) }, (*pSTextSlidCels)[12]);
+}
+
 } // namespace
 
 void InitHelp()
@@ -149,7 +173,7 @@ void InitHelp()
 	HelpFlag = false;
 
 	for (const auto *text : HelpText) {
-		const std::string paragraph = WordWrapString(_(text), 577);
+		const std::string paragraph = WordWrapString(_(text), ContentTextWidth);
 
 		size_t previous = 0;
 		while (true) {
@@ -210,6 +234,8 @@ void DrawHelp(const Surface &out)
 	DrawString(out, _("Press ESC to end or the arrow keys to scroll."),
 	    { { sx, contentY + ContentsTextHeight() + ContentPaddingY() + blankLineHeight }, { ContentTextWidth, lineHeight } },
 	    UiFlags::ColorWhitegold | UiFlags::AlignCenter);
+
+	DrawHelpSlider(out);
 }
 
 void DisplayHelp()

--- a/Source/help.cpp
+++ b/Source/help.cpp
@@ -155,11 +155,11 @@ void DrawHelpSlider(const Surface &out)
 	ClxDraw(out, { sliderXPos, sliderCurrent }, (*pSTextSlidCels)[10]);
 	// Subtract visible lines from the total number of lines to get the actual
 	// scroll range
-	const float scrollRange = HelpTextLines.size() - NumVisibleLines();
+	const int scrollRange = HelpTextLines.size() - NumVisibleLines();
 	// Subtract the size of the arrow buttons to get the length of the interior
 	// part of the slider
-	const float sliderLength = sliderCurrent - 12 - sliderStart;
-	ClxDraw(out, { sliderXPos, sliderStart + (int)(((float)SkipLines * sliderLength) / scrollRange) }, (*pSTextSlidCels)[12]);
+	const int sliderLength = sliderCurrent - 12 - sliderStart;
+	ClxDraw(out, { sliderXPos, sliderStart + ((SkipLines * sliderLength) / scrollRange) }, (*pSTextSlidCels)[12]);
 }
 
 } // namespace


### PR DESCRIPTION
This is my attempt at adding a scrollbar to the help window. It is heavily inspired by the code for the store sliders in `stores.cpp`.

I had to reduce the width of the text a bit to actually leave enough space for the scrollbar (also explicitly using this width value for the wrapping of the text).

Directly using the code from the stores UI code looks hard because it uses store-specific variables and the way the help window text and scroll works seems different as well.

This PR is for issue #5192 