### PR TITLE
Sync SpawnUnique (multiplayer unique quest rewards)

### DIFF
--- a/Source/items.h
+++ b/Source/items.h
@@ -496,7 +496,6 @@ int AllocateItem();
 Point GetSuperItemLoc(Point position);
 void GetItemAttrs(Item &item, _item_indexes itemData, int lvl);
 void SetupItem(Item &item);
-int RndItem(const Monster &monster);
 void SpawnUnique(_unique_items uid, Point position);
 void SpawnItem(Monster &monster, Point position, bool sendmsg);
 void CreateRndItem(Point position, bool onlygood, bool sendmsg, bool delta);

--- a/Source/items.h
+++ b/Source/items.h
@@ -496,7 +496,7 @@ int AllocateItem();
 Point GetSuperItemLoc(Point position);
 void GetItemAttrs(Item &item, _item_indexes itemData, int lvl);
 void SetupItem(Item &item);
-void SpawnUnique(_unique_items uid, Point position);
+Item *SpawnUnique(_unique_items uid, Point position, bool sendmsg = true);
 void SpawnItem(Monster &monster, Point position, bool sendmsg);
 void CreateRndItem(Point position, bool onlygood, bool sendmsg, bool delta);
 void CreateRndUseful(Point position, bool sendmsg);


### PR DESCRIPTION
First commit refactors `SpawnItem` to make the behavior of `T_UNIQ` more clear.
Second commit allows to pick up unique quest reward items for all multiplayer clients (for example bovine plate).