### PR TITLE
Multiplayer: Spawn butcher's cleaver and undead crown

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3058,7 +3058,7 @@ void SpawnItem(Monster &monster, Point position, bool sendmsg)
 
 	bool dropsSpecialTreasure = (monster.data().treasure & T_UNIQ) != 0;
 
-	if (dropsSpecialTreasure && !gbIsMultiplayer) {
+	if (dropsSpecialTreasure && !UseMultiplayerQuests()) {
 		Item *uniqueItem = SpawnUnique(static_cast<_unique_items>(monster.data().treasure & T_MASK), position, false);
 		if (uniqueItem != nullptr && sendmsg)
 			NetSendCmdPItem(false, CMD_DROPITEM, uniqueItem->position, *uniqueItem);


### PR DESCRIPTION
When singleplayer quests are activated in multiplayer butcher and skeleton kings drops their unique items (butcher's cleaver and undead crown).

- Only one item is dropped regardless how many player are present in the game.
- Currently the items drops every time you kill butcher/skeleton king (no limit per character).
- I checked that the items don't morph when loading the save game or dropping the item on the ground and pick them up with another character.

This change can be a bit controversial that's why it was separated from #5485