### PR TITLE
Multiplayer: Enable skeleton king's lair

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2781,7 +2781,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 			}
 		}
 		IncProgress();
-
+		PlayDungMsgs();
 		InitMultiView();
 		IncProgress();
 
@@ -2851,9 +2851,6 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 	}
 
 	CompleteProgress();
-
-	if (!gbIsSpawn && setlevel && setlvlnum == SL_SKELKING && Quests[Q_SKELKING]._qactive == QUEST_ACTIVE)
-		PlaySFX(USFX_SKING1);
 
 	// Reset mouse selection of entities
 	pcursmonst = -1;

--- a/Source/levels/drlg_l1.cpp
+++ b/Source/levels/drlg_l1.cpp
@@ -383,7 +383,7 @@ void LoadQuestSetPieces()
 {
 	if (Quests[Q_BUTCHER].IsAvailable()) {
 		pSetPiece = LoadFileInMem<uint16_t>("levels\\l1data\\rnd6.dun");
-	} else if (Quests[Q_SKELKING].IsAvailable() && !gbIsMultiplayer) {
+	} else if (Quests[Q_SKELKING].IsAvailable() && !UseMultiplayerQuests()) {
 		pSetPiece = LoadFileInMem<uint16_t>("levels\\l1data\\skngdo.dun");
 	} else if (Quests[Q_LTBANNER].IsAvailable()) {
 		pSetPiece = LoadFileInMem<uint16_t>("levels\\l1data\\banner2.dun");

--- a/Source/levels/setmaps.cpp
+++ b/Source/levels/setmaps.cpp
@@ -11,6 +11,7 @@
 #include "levels/drlg_l4.h"
 #include "levels/gendung.h"
 #include "levels/trigs.h"
+#include "msg.h"
 #include "objdat.h"
 #include "objects.h"
 #include "quests.h"
@@ -109,6 +110,7 @@ void LoadSetMap()
 		if (Quests[Q_SKELKING]._qactive == QUEST_INIT) {
 			Quests[Q_SKELKING]._qactive = QUEST_ACTIVE;
 			Quests[Q_SKELKING]._qvar1 = 1;
+			NetSendCmdQuest(true, Quests[Q_SKELKING]);
 		}
 		LoadPreL1Dungeon("levels\\l1data\\sklkng1.dun");
 		LoadL1Dungeon("levels\\l1data\\sklkng2.dun", { 83, 44 });

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -446,7 +446,7 @@ void CheckMissileCol(Missile &missile, int minDamage, int maxDamage, bool isDama
 	if (IsMissileBlockedByTile({ mx, my })) {
 		Object *object = FindObjectAtPosition({ mx, my });
 		if (object != nullptr && object->IsBreakable()) {
-			BreakObjectMissile(*object);
+			BreakObjectMissile(missile.sourcePlayer(), *object);
 		}
 
 		if (!dontDeleteOnCollision)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -481,7 +481,7 @@ void PlaceQuestMonsters()
 			PlaceUniqueMonst(UniqueMonsterType::Butcher, 0, 0);
 		}
 
-		if (currlevel == Quests[Q_SKELKING]._qlevel && gbIsMultiplayer) {
+		if (currlevel == Quests[Q_SKELKING]._qlevel && UseMultiplayerQuests()) {
 			for (size_t i = 0; i < LevelMonsterTypeCount; i++) {
 				if (IsSkel(LevelMonsterTypes[i].type)) {
 					PlaceUniqueMonst(UniqueMonsterType::SkeletonKing, i, 30);
@@ -3262,7 +3262,7 @@ void GetLevelMTypes()
 		if (Quests[Q_WARLORD].IsAvailable())
 			AddMonsterType(UniqueMonsterType::WarlordOfBlood, PLACE_UNIQUE);
 
-		if (gbIsMultiplayer && currlevel == Quests[Q_SKELKING]._qlevel) {
+		if (UseMultiplayerQuests() && currlevel == Quests[Q_SKELKING]._qlevel) {
 
 			AddMonsterType(MT_SKING, PLACE_UNIQUE);
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2674,35 +2674,6 @@ void DeltaLoadLevel()
 			memset(AutomapView, 0, sizeof(AutomapView));
 	}
 
-	for (int i = 0; i < MAXITEMS; i++) {
-		if (deltaLevel.item[i].bCmd == CMD_INVALID)
-			continue;
-
-		if (deltaLevel.item[i].bCmd == TCmdPItem::PickedUpItem) {
-			int activeItemIndex = FindGetItem(
-			    deltaLevel.item[i].def.dwSeed,
-			    deltaLevel.item[i].def.wIndx,
-			    deltaLevel.item[i].def.wCI);
-			if (activeItemIndex != -1) {
-				const auto &position = Items[ActiveItems[activeItemIndex]].position;
-				if (dItem[position.x][position.y] == ActiveItems[activeItemIndex] + 1)
-					dItem[position.x][position.y] = 0;
-				DeleteItem(activeItemIndex);
-			}
-		}
-		if (deltaLevel.item[i].bCmd == TCmdPItem::DroppedItem) {
-			int ii = AllocateItem();
-			auto &item = Items[ii];
-			RecreateItem(*MyPlayer, deltaLevel.item[i], item);
-
-			int x = deltaLevel.item[i].x;
-			int y = deltaLevel.item[i].y;
-			item.position = GetItemPosition({ x, y });
-			dItem[item.position.x][item.position.y] = ii + 1;
-			RespawnItem(Items[ii], false);
-		}
-	}
-
 	if (leveltype != DTYPE_TOWN) {
 		for (auto it = deltaLevel.object.begin(); it != deltaLevel.object.end();) {
 			Object *object = FindObjectAtPosition(it->first);
@@ -2732,6 +2703,35 @@ void DeltaLoadLevel()
 			if (object.IsTrap()) {
 				UpdateTrapState(object);
 			}
+		}
+	}
+
+	for (int i = 0; i < MAXITEMS; i++) {
+		if (deltaLevel.item[i].bCmd == CMD_INVALID)
+			continue;
+
+		if (deltaLevel.item[i].bCmd == TCmdPItem::PickedUpItem) {
+			int activeItemIndex = FindGetItem(
+			    deltaLevel.item[i].def.dwSeed,
+			    deltaLevel.item[i].def.wIndx,
+			    deltaLevel.item[i].def.wCI);
+			if (activeItemIndex != -1) {
+				const auto &position = Items[ActiveItems[activeItemIndex]].position;
+				if (dItem[position.x][position.y] == ActiveItems[activeItemIndex] + 1)
+					dItem[position.x][position.y] = 0;
+				DeleteItem(activeItemIndex);
+			}
+		}
+		if (deltaLevel.item[i].bCmd == TCmdPItem::DroppedItem) {
+			int ii = AllocateItem();
+			auto &item = Items[ii];
+			RecreateItem(*MyPlayer, deltaLevel.item[i], item);
+
+			int x = deltaLevel.item[i].x;
+			int y = deltaLevel.item[i].y;
+			item.position = GetItemPosition({ x, y });
+			dItem[item.position.x][item.position.y] = ii + 1;
+			RespawnItem(Items[ii], false);
 		}
 	}
 }

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -319,7 +319,7 @@ void ObjChangeMapResync(int x1, int y1, int x2, int y2);
 _item_indexes ItemMiscIdIdx(item_misc_id imiscid);
 void OperateObject(Player &player, Object &object);
 void SyncOpObject(Player &player, int cmd, Object &object);
-void BreakObjectMissile(Object &object);
+void BreakObjectMissile(const Player *player, Object &object);
 void BreakObject(const Player &player, Object &object);
 void DeltaSyncOpObject(Object &object);
 void DeltaSyncBreakObj(Object &object);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3701,36 +3701,39 @@ void PlayDungMsgs()
 	assert(MyPlayer != nullptr);
 	Player &myPlayer = *MyPlayer;
 
-	if (currlevel == 1 && !myPlayer._pLvlVisited[1] && (myPlayer.pDungMsgs & DungMsgCathedral) == 0) {
+	if (!setlevel && currlevel == 1 && !myPlayer._pLvlVisited[1] && (myPlayer.pDungMsgs & DungMsgCathedral) == 0) {
 		myPlayer.Say(HeroSpeech::TheSanctityOfThisPlaceHasBeenFouled, 40);
 		myPlayer.pDungMsgs = myPlayer.pDungMsgs | DungMsgCathedral;
-	} else if (currlevel == 5 && !myPlayer._pLvlVisited[5] && (myPlayer.pDungMsgs & DungMsgCatacombs) == 0) {
+	} else if (!setlevel && currlevel == 5 && !myPlayer._pLvlVisited[5] && (myPlayer.pDungMsgs & DungMsgCatacombs) == 0) {
 		myPlayer.Say(HeroSpeech::TheSmellOfDeathSurroundsMe, 40);
 		myPlayer.pDungMsgs |= DungMsgCatacombs;
-	} else if (currlevel == 9 && !myPlayer._pLvlVisited[9] && (myPlayer.pDungMsgs & DungMsgCaves) == 0) {
+	} else if (!setlevel && currlevel == 9 && !myPlayer._pLvlVisited[9] && (myPlayer.pDungMsgs & DungMsgCaves) == 0) {
 		myPlayer.Say(HeroSpeech::ItsHotDownHere, 40);
 		myPlayer.pDungMsgs |= DungMsgCaves;
-	} else if (currlevel == 13 && !myPlayer._pLvlVisited[13] && (myPlayer.pDungMsgs & DungMsgHell) == 0) {
+	} else if (!setlevel && currlevel == 13 && !myPlayer._pLvlVisited[13] && (myPlayer.pDungMsgs & DungMsgHell) == 0) {
 		myPlayer.Say(HeroSpeech::IMustBeGettingClose, 40);
 		myPlayer.pDungMsgs |= DungMsgHell;
-	} else if (currlevel == 16 && !myPlayer._pLvlVisited[16] && (myPlayer.pDungMsgs & DungMsgDiablo) == 0) {
+	} else if (!setlevel && currlevel == 16 && !myPlayer._pLvlVisited[16] && (myPlayer.pDungMsgs & DungMsgDiablo) == 0) {
 		sfxdelay = 40;
 		sfxdnum = PS_DIABLVLINT;
 		myPlayer.pDungMsgs |= DungMsgDiablo;
-	} else if (currlevel == 17 && !myPlayer._pLvlVisited[17] && (myPlayer.pDungMsgs2 & 1) == 0) {
+	} else if (!setlevel && currlevel == 17 && !myPlayer._pLvlVisited[17] && (myPlayer.pDungMsgs2 & 1) == 0) {
 		sfxdelay = 10;
 		sfxdnum = USFX_DEFILER1;
 		Quests[Q_DEFILER]._qactive = QUEST_ACTIVE;
 		Quests[Q_DEFILER]._qlog = true;
 		Quests[Q_DEFILER]._qmsg = TEXT_DEFILER1;
 		myPlayer.pDungMsgs2 |= 1;
-	} else if (currlevel == 19 && !myPlayer._pLvlVisited[19] && (myPlayer.pDungMsgs2 & 4) == 0) {
+	} else if (!setlevel && currlevel == 19 && !myPlayer._pLvlVisited[19] && (myPlayer.pDungMsgs2 & 4) == 0) {
 		sfxdelay = 10;
 		sfxdnum = USFX_DEFILER3;
 		myPlayer.pDungMsgs2 |= 4;
-	} else if (currlevel == 21 && !myPlayer._pLvlVisited[21] && (myPlayer.pDungMsgs & 32) == 0) {
+	} else if (!setlevel && currlevel == 21 && !myPlayer._pLvlVisited[21] && (myPlayer.pDungMsgs & 32) == 0) {
 		myPlayer.Say(HeroSpeech::ThisIsAPlaceOfGreatPower, 30);
 		myPlayer.pDungMsgs |= 32;
+	} else if (setlevel && setlvlnum == SL_SKELKING && !gbIsSpawn && !myPlayer._pSLvlVisited[SL_SKELKING] && Quests[Q_SKELKING]._qactive == QUEST_ACTIVE) {
+		sfxdelay = 10;
+		sfxdnum = USFX_SKING1;
 	} else {
 		sfxdelay = 0;
 	}


### PR DESCRIPTION
Contributes to #926

When singleplayer quests are activated in multiplayer use singleplayer skeleton king's quest including his lair.

- DeltaLoadLevel: Item's check that they are not placed on a solid tiles. But objects can change the dungeon layout. That's why objects need to be synced/loaded before items else items could get placed on a wrong tile.
- Break crux wasn't synced in multiplayer (cause they were only used in skeleton king's lair).
- Ensures that entering skeleton king's lair plays skeleton kings speech in multiplayer. For this the already existing `PlayDungMsgs`/`sfxdelay` is used (normal `PlaySFX` don't work in the first 10 game ticks in multiplayer).
- For single- and multiplayer: Changed that skeleton kings speech is only played once when entering skeleton king's lair (not on every entrance).

![SkeletongKingsLair_PR](https://user-images.githubusercontent.com/25415264/201543665-2f82c84d-1f9f-4d0b-be88-10bc15220830.png)