### PR TITLE
amiga.cmake: Remove `find_package(ZLIB)`

### DIFF
--- a/3rdParty/zlib/CMake/FindZLIB.cmake
+++ b/3rdParty/zlib/CMake/FindZLIB.cmake
@@ -1,0 +1,1 @@
+# No-op, ZLIB::ZLIB is built from source.

--- a/3rdParty/zlib/CMakeLists.txt
+++ b/3rdParty/zlib/CMakeLists.txt
@@ -1,5 +1,7 @@
 include(functions/FetchContent_MakeAvailableExcludeFromAll)
 
+set(CMAKE_POLICY_DEFAULT_CMP0048 NEW)
+
 include(FetchContent)
 FetchContent_Declare(zlib
     URL https://www.zlib.net/zlib-1.2.13.tar.gz
@@ -8,42 +10,18 @@ FetchContent_Declare(zlib
 FetchContent_MakeAvailableExcludeFromAll(zlib)
 
 if(DEVILUTIONX_STATIC_ZLIB)
-  set(_lib_type STATIC)
+  add_library(ZLIB::ZLIB ALIAS zlibstatic)
+  target_include_directories(zlibstatic INTERFACE ${zlib_BINARY_DIR} ${zlib_SOURCE_DIR})
 else()
-  set(_lib_type SHARED)
+  add_library(ZLIB::ZLIB ALIAS zlib)
+  target_include_directories(zlib INTERFACE ${zlib_BINARY_DIR} ${zlib_SOURCE_DIR})
 endif()
-add_library(ZLIB ${_lib_type}
-  ${zlib_SOURCE_DIR}/crc32.h
-  ${zlib_SOURCE_DIR}/gzguts.h
-  ${zlib_SOURCE_DIR}/inffixed.h
-  ${zlib_SOURCE_DIR}/inftrees.h
-  ${zlib_BINARY_DIR}/zconf.h
-  ${zlib_SOURCE_DIR}/zutil.h
-  ${zlib_SOURCE_DIR}/deflate.h
-  ${zlib_SOURCE_DIR}/inffast.h
-  ${zlib_SOURCE_DIR}/inflate.h
-  ${zlib_SOURCE_DIR}/trees.h
-  ${zlib_SOURCE_DIR}/zlib.h
-  ${zlib_SOURCE_DIR}/adler32.c
-  ${zlib_SOURCE_DIR}/deflate.c
-  ${zlib_SOURCE_DIR}/gzread.c
-  ${zlib_SOURCE_DIR}/inffast.c
-  ${zlib_SOURCE_DIR}/trees.c
-  ${zlib_SOURCE_DIR}/compress.c
-  ${zlib_SOURCE_DIR}/gzclose.c
-  ${zlib_SOURCE_DIR}/gzwrite.c
-  ${zlib_SOURCE_DIR}/inflate.c
-  ${zlib_SOURCE_DIR}/uncompr.c
-  ${zlib_SOURCE_DIR}/crc32.c
-  ${zlib_SOURCE_DIR}/gzlib.c
-  ${zlib_SOURCE_DIR}/infback.c
-  ${zlib_SOURCE_DIR}/inftrees.c
-  ${zlib_SOURCE_DIR}/zutil.c
-)
-target_include_directories(ZLIB PUBLIC ${zlib_SOURCE_DIR})
-target_include_directories(ZLIB PUBLIC ${zlib_BINARY_DIR})
 
-add_library(ZLIB::ZLIB ALIAS ZLIB)
-
+# 1. Set the variables that are usually set by FindZLIB.cmake.
+# 2. Add the module that stubs out `find_package(ZLIB ...)` calls.
+set(ZLIB_FOUND ON PARENT_SCOPE)
 set(ZLIB_LIBRARY ZLIB::ZLIB PARENT_SCOPE)
-set(ZLIB_INCLUDE_DIR HINTS ${zlib_SOURCE_DIR} ${zlib_BINARY_DIR} PARENT_SCOPE)
+set(ZLIB_LIBRARIES ZLIB::ZLIB PARENT_SCOPE)
+set(ZLIB_INCLUDE_DIR ${zlib_SOURCE_DIR} ${zlib_BINARY_DIR} PARENT_SCOPE)
+set(ZLIB_INCLUDE_DIRS ${zlib_SOURCE_DIR} ${zlib_BINARY_DIR} PARENT_SCOPE)
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_LIST_DIR}/CMake" PARENT_SCOPE)

--- a/CMake/platforms/amiga.cmake
+++ b/CMake/platforms/amiga.cmake
@@ -9,7 +9,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions")
 
 set(DEVILUTIONX_SYSTEM_BZIP2 OFF)
 set(DEVILUTIONX_SYSTEM_ZLIB OFF)
-find_package(ZLIB REQUIRED)
 
 # Do not warn about unknown attributes, such as [[nodiscard]].
 # As this build uses an older compiler, there are lots of them.

--- a/uwp-project/devilutionx.vcxproj
+++ b/uwp-project/devilutionx.vcxproj
@@ -72,7 +72,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Link>
-      <AdditionalDependencies>sdl_image.lib;libpng16_staticd.lib;pkware.lib;fmtd.lib;zlib.lib;bzip2.lib;libsmackerdec.lib;libmpq.lib;libdevilutionx.lib;sdl2.lib;sdl_audiolib.lib;sodium.lib;zt.lib;lwip_pic.lib;miniupnpc_pic.lib;natpmp_pic.lib;zt_pic.lib;zto_pic.lib;shlwapi.lib;shell32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>sdl_image.lib;libpng16_staticd.lib;pkware.lib;fmtd.lib;zlibstatic.lib;bzip2.lib;libsmackerdec.lib;libmpq.lib;libdevilutionx.lib;sdl2.lib;sdl_audiolib.lib;sodium.lib;zt.lib;lwip_pic.lib;miniupnpc_pic.lib;natpmp_pic.lib;zt_pic.lib;zto_pic.lib;shlwapi.lib;shell32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\build\SDL\VisualC-WinRT\x64\Debug\SDL-UWP;..\build\3rdParty\SDL_image\Debug;..\build\3rdParty\zlib\Debug;..\build\3rdParty\PKWare\Debug;..\build\3rdParty\bzip2\Debug;..\build\3rdParty\libsmackerdec\Debug;..\build\3rdParty\libmpq\Debug;..\build\_deps\sdl_audiolib-build\Debug;..\build\_deps\libsodium-build\Debug;..\build\_deps\libzt-build\lib\Debug;..\build\_deps\libfmt-build\Debug;..\build\_deps\libpng-build\Debug;..\build\Source\libdevilutionx.dir\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
@@ -91,7 +91,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
-      <AdditionalDependencies>sdl_image.lib;libpng16_static.lib;pkware.lib;fmt.lib;zlib.lib;bzip2.lib;libsmackerdec.lib;libmpq.lib;libdevilutionx.lib;sdl2.lib;sdl_audiolib.lib;sodium.lib;zt.lib;lwip_pic.lib;miniupnpc_pic.lib;natpmp_pic.lib;zt_pic.lib;zto_pic.lib;shlwapi.lib;shell32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>sdl_image.lib;libpng16_static.lib;pkware.lib;fmt.lib;zlibstatic.lib;bzip2.lib;libsmackerdec.lib;libmpq.lib;libdevilutionx.lib;sdl2.lib;sdl_audiolib.lib;sodium.lib;zt.lib;lwip_pic.lib;miniupnpc_pic.lib;natpmp_pic.lib;zt_pic.lib;zto_pic.lib;shlwapi.lib;shell32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\build\SDL\VisualC-WinRT\x64\Release\SDL-UWP;..\build\3rdParty\SDL_image\Release;..\build\3rdParty\zlib\Release;..\build\3rdParty\PKWare\Release;..\build\3rdParty\bzip2\Release;..\build\3rdParty\libsmackerdec\Release;..\build\3rdParty\libmpq\Release;..\build\_deps\sdl_audiolib-build\Release;..\build\_deps\libsodium-build\Release;..\build\_deps\libzt-build\lib\Release;..\build\_deps\libfmt-build\Release;..\build\_deps\libpng-build\Release;..\build\Source\libdevilutionx.dir\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>

--- a/uwp-project/devilutionx.vcxproj
+++ b/uwp-project/devilutionx.vcxproj
@@ -73,7 +73,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Link>
       <AdditionalDependencies>sdl_image.lib;libpng16_staticd.lib;pkware.lib;fmtd.lib;zlibstatic.lib;bzip2.lib;libsmackerdec.lib;libmpq.lib;libdevilutionx.lib;sdl2.lib;sdl_audiolib.lib;sodium.lib;zt.lib;lwip_pic.lib;miniupnpc_pic.lib;natpmp_pic.lib;zt_pic.lib;zto_pic.lib;shlwapi.lib;shell32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\build\SDL\VisualC-WinRT\x64\Debug\SDL-UWP;..\build\3rdParty\SDL_image\Debug;..\build\3rdParty\zlib\Debug;..\build\3rdParty\PKWare\Debug;..\build\3rdParty\bzip2\Debug;..\build\3rdParty\libsmackerdec\Debug;..\build\3rdParty\libmpq\Debug;..\build\_deps\sdl_audiolib-build\Debug;..\build\_deps\libsodium-build\Debug;..\build\_deps\libzt-build\lib\Debug;..\build\_deps\libfmt-build\Debug;..\build\_deps\libpng-build\Debug;..\build\Source\libdevilutionx.dir\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\build\SDL\VisualC-WinRT\x64\Debug\SDL-UWP;..\build\3rdParty\SDL_image\Debug;..\build\_deps\zlib-build\Debug;..\build\3rdParty\PKWare\Debug;..\build\3rdParty\bzip2\Debug;..\build\3rdParty\libsmackerdec\Debug;..\build\3rdParty\libmpq\Debug;..\build\_deps\sdl_audiolib-build\Debug;..\build\_deps\libsodium-build\Debug;..\build\_deps\libzt-build\lib\Debug;..\build\_deps\libfmt-build\Debug;..\build\_deps\libpng-build\Debug;..\build\Source\libdevilutionx.dir\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -92,7 +92,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
       <AdditionalDependencies>sdl_image.lib;libpng16_static.lib;pkware.lib;fmt.lib;zlibstatic.lib;bzip2.lib;libsmackerdec.lib;libmpq.lib;libdevilutionx.lib;sdl2.lib;sdl_audiolib.lib;sodium.lib;zt.lib;lwip_pic.lib;miniupnpc_pic.lib;natpmp_pic.lib;zt_pic.lib;zto_pic.lib;shlwapi.lib;shell32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\build\SDL\VisualC-WinRT\x64\Release\SDL-UWP;..\build\3rdParty\SDL_image\Release;..\build\3rdParty\zlib\Release;..\build\3rdParty\PKWare\Release;..\build\3rdParty\bzip2\Release;..\build\3rdParty\libsmackerdec\Release;..\build\3rdParty\libmpq\Release;..\build\_deps\sdl_audiolib-build\Release;..\build\_deps\libsodium-build\Release;..\build\_deps\libzt-build\lib\Release;..\build\_deps\libfmt-build\Release;..\build\_deps\libpng-build\Release;..\build\Source\libdevilutionx.dir\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\build\SDL\VisualC-WinRT\x64\Release\SDL-UWP;..\build\3rdParty\SDL_image\Release;..\build\_deps\zlib-build\Release;..\build\3rdParty\PKWare\Release;..\build\3rdParty\bzip2\Release;..\build\3rdParty\libsmackerdec\Release;..\build\3rdParty\libmpq\Release;..\build\_deps\sdl_audiolib-build\Release;..\build\_deps\libsodium-build\Release;..\build\_deps\libzt-build\lib\Release;..\build\_deps\libfmt-build\Release;..\build\_deps\libpng-build\Release;..\build\Source\libdevilutionx.dir\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>


### PR DESCRIPTION
We're not using the system zlib on Amiga
