### PR TITLE
Multiplayer: Enable Ogden's Sign Quest

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4473,9 +4473,8 @@ Monster *PreSpawnSkeleton()
 	return skeleton;
 }
 
-void TalktoMonster(Monster &monster)
+void TalktoMonster(Player &player, Monster &monster)
 {
-	Player &player = Players[monster.enemy];
 	monster.mode = MonsterMode::Talk;
 	if (monster.ai != AI_SNOTSPIL && monster.ai != AI_LACHDAN) {
 		return;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1426,6 +1426,7 @@ void MonsterTalk(Monster &monster)
 			if (Quests[Q_LTBANNER]._qactive == QUEST_INIT)
 				Quests[Q_LTBANNER]._qactive = QUEST_ACTIVE;
 			monster.flags |= MFLAG_QUEST_COMPLETE;
+			NetSendCmdQuest(true, Quests[Q_LTBANNER]);
 		}
 		if (Quests[Q_LTBANNER]._qvar1 < 2) {
 			app_fatal(StrCat("SS Talk = ", monster.talkMsg, ", Flags = ", monster.flags));
@@ -2563,6 +2564,7 @@ void SnotSpilAi(Monster &monster)
 			if (!effect_is_playing(USFX_SNOT3) && monster.goal == MonsterGoal::Talking) {
 				ObjChangeMap(SetPiece.position.x, SetPiece.position.y, SetPiece.position.x + SetPiece.size.width + 1, SetPiece.position.y + SetPiece.size.height + 1);
 				Quests[Q_LTBANNER]._qvar1 = 3;
+				NetSendCmdQuest(true, Quests[Q_LTBANNER]);
 				RedoPlayerVision();
 				monster.activeForTicks = UINT8_MAX;
 				monster.talkMsg = TEXT_NONE;
@@ -4485,6 +4487,7 @@ void TalktoMonster(Player &player, Monster &monster)
 			Quests[Q_LTBANNER]._qactive = QUEST_DONE;
 			monster.talkMsg = TEXT_BANNER12;
 			monster.goal = MonsterGoal::Inquiring;
+			NetSendCmdQuest(true, Quests[Q_LTBANNER]);
 		}
 	}
 	if (Quests[Q_VEIL].IsAvailable() && monster.talkMsg >= TEXT_VEIL9) {

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -504,7 +504,7 @@ bool IsGoat(_monster_id mt);
  */
 void ActivateSkeleton(Monster &monster, Point position);
 Monster *PreSpawnSkeleton();
-void TalktoMonster(Monster &monster);
+void TalktoMonster(Player &player, Monster &monster);
 void SpawnGolem(Player &player, Monster &golem, Point position, Missile &missile);
 bool CanTalkToMonst(const Monster &monster);
 int encode_enemy(Monster &monster);

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2140,7 +2140,7 @@ void OperateMushroomPatch(const Player &player, Object &mushroomPatch)
 	Quests[Q_MUSHROOM]._qvar1 = QS_MUSHSPAWNED;
 }
 
-void OperateInnSignChest(const Player &player, Object &questContainer)
+void OperateInnSignChest(const Player &player, Object &questContainer, bool sendmsg)
 {
 	if (ActiveItemCount >= MAXITEMS) {
 		return;
@@ -2161,8 +2161,12 @@ void OperateInnSignChest(const Player &player, Object &questContainer)
 	questContainer._oAnimFrame += 2;
 
 	PlaySfxLoc(IS_CHEST, questContainer.position);
-	Point pos = GetSuperItemLoc(questContainer.position);
-	SpawnQuestItem(IDI_BANNER, pos, 0, 0, true);
+
+	if (sendmsg) {
+		Point pos = GetSuperItemLoc(questContainer.position);
+		SpawnQuestItem(IDI_BANNER, pos, 0, 0, true);
+		NetSendCmdLoc(MyPlayerId, true, CMD_OPERATEOBJ, questContainer.position);
+	}
 }
 
 void OperateSlainHero(const Player &player, Object &corpse)
@@ -4438,7 +4442,7 @@ void OperateObject(Player &player, Object &object)
 		OperateSlainHero(player, object);
 		break;
 	case OBJ_SIGNCHEST:
-		OperateInnSignChest(player, object);
+		OperateInnSignChest(player, object, sendmsg);
 		break;
 	default:
 		break;
@@ -4512,7 +4516,7 @@ void DeltaSyncOpObject(Object &object)
 		}
 		break;
 	case OBJ_SIGNCHEST:
-		if (Quests[Q_LTBANNER]._qvar1 == 2) {
+		if (Quests[Q_LTBANNER]._qvar1 >= 2) {
 			UpdateState(object, object._oAnimFrame + 2);
 		}
 		break;
@@ -4612,7 +4616,7 @@ void SyncOpObject(Player &player, int cmd, Object &object)
 		OperateSlainHero(player, object);
 		break;
 	case OBJ_SIGNCHEST:
-		OperateInnSignChest(player, object);
+		OperateInnSignChest(player, object, sendmsg);
 		break;
 	default:
 		break;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1362,7 +1362,7 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 					if (x < 2 && y < 2) {
 						ClrPlrPath(player);
 						if (player.destAction == ACTION_ATTACKMON && monster->talkMsg != TEXT_NONE && monster->talkMsg != TEXT_VILE14) {
-							TalktoMonster(*monster);
+							TalktoMonster(player, *monster);
 						} else {
 							StartAttack(player, d);
 						}
@@ -1428,7 +1428,7 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 			if (x <= 1 && y <= 1) {
 				d = GetDirection(player.position.future, monster->position.future);
 				if (monster->talkMsg != TEXT_NONE && monster->talkMsg != TEXT_VILE14) {
-					TalktoMonster(*monster);
+					TalktoMonster(player, *monster);
 				} else {
 					StartAttack(player, d);
 				}
@@ -1449,7 +1449,7 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 		case ACTION_RATTACKMON:
 			d = GetDirection(player.position.future, monster->position.future);
 			if (monster->talkMsg != TEXT_NONE && monster->talkMsg != TEXT_VILE14) {
-				TalktoMonster(*monster);
+				TalktoMonster(player, *monster);
 			} else {
 				StartRangeAttack(player, d, monster->position.future.x, monster->position.future.y);
 			}

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -609,6 +609,7 @@ void ResyncQuests()
 		return;
 
 	if (Quests[Q_LTBANNER].IsAvailable()) {
+		Monster *snotSpill = FindUniqueMonster(UniqueMonsterType::SnotSpill);
 		if (Quests[Q_LTBANNER]._qvar1 == 1) {
 			ObjChangeMapResync(
 			    SetPiece.position.x + SetPiece.size.width - 2,
@@ -629,6 +630,11 @@ void ResyncQuests()
 			TransVal = 9;
 			DRLG_MRectTrans({ SetPiece.position, WorldTileSize(SetPiece.size.width / 2 + 4, SetPiece.size.height / 2) });
 			TransVal = tren;
+			if (gbIsMultiplayer && snotSpill != nullptr && snotSpill->talkMsg != TEXT_BANNER12) {
+				snotSpill->goal = MonsterGoal::Inquiring;
+				snotSpill->talkMsg = Quests[Q_LTBANNER]._qactive == QUEST_DONE ? TEXT_BANNER12 : TEXT_BANNER11;
+				snotSpill->flags |= MFLAG_QUEST_COMPLETE;
+			}
 		}
 		if (Quests[Q_LTBANNER]._qvar1 == 3) {
 			ObjChangeMapResync(SetPiece.position.x, SetPiece.position.y, SetPiece.position.x + SetPiece.size.width + 1, SetPiece.position.y + SetPiece.size.height + 1);
@@ -638,6 +644,13 @@ void ResyncQuests()
 			TransVal = 9;
 			DRLG_MRectTrans({ SetPiece.position, WorldTileSize(SetPiece.size.width / 2 + 4, SetPiece.size.height / 2) });
 			TransVal = tren;
+			if (gbIsMultiplayer && snotSpill != nullptr) {
+				snotSpill->goal = MonsterGoal::Normal;
+				snotSpill->flags |= MFLAG_QUEST_COMPLETE;
+				snotSpill->talkMsg = TEXT_NONE;
+				snotSpill->activeForTicks = UINT8_MAX;
+				RedoPlayerVision();
+			}
 		}
 	}
 	if (currlevel == Quests[Q_MUSHROOM]._qlevel) {

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -326,6 +326,7 @@ void TalkToBarOwner(Player &player, Towner &barOwner)
 					bannerQuest._qactive = QUEST_ACTIVE;
 				}
 				bannerQuest._qlog = true;
+				NetSendCmdQuest(true, bannerQuest);
 				InitQTextMsg(TEXT_BANNER2);
 				return;
 			}
@@ -333,6 +334,7 @@ void TalkToBarOwner(Player &player, Towner &barOwner)
 			if (bannerQuest._qvar2 == 1 && RemoveInventoryItemById(player, IDI_BANNER)) {
 				bannerQuest._qactive = QUEST_DONE;
 				bannerQuest._qvar1 = 3;
+				NetSendCmdQuest(true, bannerQuest);
 				SpawnUnique(UITEM_HARCREST, barOwner.position + Direction::SouthWest);
 				InitQTextMsg(TEXT_BANNER3);
 				return;

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -318,7 +318,7 @@ void TalkToBarOwner(Player &player, Towner &barOwner)
 
 	auto &bannerQuest = Quests[Q_LTBANNER];
 	if (bannerQuest._qactive != QUEST_NOTAVAIL) {
-		if (player._pLvlVisited[3] && bannerQuest._qactive != QUEST_DONE) {
+		if ((player._pLvlVisited[3] || player._pLvlVisited[4]) && bannerQuest._qactive != QUEST_DONE) {
 			if (bannerQuest._qvar2 == 0) {
 				bannerQuest._qvar2 = 1;
 				if (bannerQuest._qactive == QUEST_INIT) {


### PR DESCRIPTION
Contributes to #926

- Sign chest was not synced
- Ogden now also talk about the quest when you only entered lvl 4 and skipped 3 (for example cause you just joined the game and other player made a portal for you)
- `TalktoMonster` now uses the player that talks to the monster to check behavior not the player that is the current target of the monster
- When a player talks to a monster this is currently played back for all players on the same level
- A player can still enter catacombs even if the quest is not completed