### PR TITLE
[amiga] Fix build warning `Ignoring extra path from command line: ".."`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - checkout
       - run: Packaging/amiga/prep.sh
-      - run: PKG_CONFIG_PATH=/opt/m68k-amigaos/lib/pkgconfig/:/opt/m68k-amigaos/share/pkgconfig/ cmake -S. -Bbuild -DM68K_CPU=68040 -DM68K_FPU=hard -DM68K_COMMON="-s -fbbb=- -m68040 -ffast-math -O2 -noixemul -D__BIG_ENDIAN__ -D__AMIGA__ -fpermissive" ..
+      - run: PKG_CONFIG_PATH=/opt/m68k-amigaos/lib/pkgconfig/:/opt/m68k-amigaos/share/pkgconfig/ cmake -S. -Bbuild -DM68K_CPU=68040 -DM68K_FPU=hard -DM68K_COMMON="-s -fbbb=- -m68040 -ffast-math -O2 -noixemul -D__BIG_ENDIAN__ -D__AMIGA__ -fpermissive"
       - run: cd build && make -j2
       - store_artifacts: {path: ./build/devilutionx, destination: devilutionx_m68k}
   vita:


### PR DESCRIPTION
Fixes a warning in the CircleCI logs for amiga builds.