### PR TITLE
CMake: Clean up dead code removal flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,23 +213,16 @@ endif()
 
 # Remove unused symbols in non-debug mode.
 # This is useful even with LTO (-84 KiB with MinSizeRel).
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  # For some reason, adding to CMAKE_CXX_FLAGS results in a slightly smaller
-  # binary than using `add_compile/link_options`
-
-  set(_extra_flags "-ffunction-sections -fdata-sections")
+#
+# PS4 toolchain crashes in `create-fself` when linking with these flags, so we exclude it:
+# https://github.com/PacBrew/ps4-openorbis/issues/8
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND NOT PS4)
+  add_compile_options("$<$<NOT:$<CONFIG:Debug>>:-ffunction-sections;-fdata-sections>")
   if(APPLE)
-    set(_extra_flags "${_extra_flags} -Wl,-dead_strip")
+    add_link_options("$<$<NOT:$<CONFIG:Debug>>:LINKER:-dead_strip>")
   else()
-    set(_extra_flags "${_extra_flags} -Wl,--gc-sections,--as-needed")
+    add_link_options("$<$<NOT:$<CONFIG:Debug>>:LINKER:--gc-sections,--as-needed>")
   endif()
-
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${_extra_flags}")
-  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${_extra_flags}")
-  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${_extra_flags}")
-  set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} ${_extra_flags}")
-  set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} ${_extra_flags}")
-  set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} ${_extra_flags}")
 endif()
 
 # Not a genexp because CMake doesn't support it

--- a/docs/building.md
+++ b/docs/building.md
@@ -181,11 +181,14 @@ Make sure to install the workload `Desktop development with C++` and the individ
 
 Install [Git for Windows](https://gitforwindows.org/)
 
-Run the following commands in Command Prompt or Powershell  
-git clone https://github.com/microsoft/vcpkg  
-cd vcpkg  
-bootstrap-vcpkg.bat  
+Run the following commands in Command Prompt or Powershell
+
+~~~ bat
+git clone https://github.com/microsoft/vcpkg
+cd vcpkg
+bootstrap-vcpkg.bat
 vcpkg integrate install
+~~~
 
 If you need aditional instructions for vcpkg you can find the documentation [here](https://github.com/microsoft/vcpkg#quick-start-windows).
 
@@ -431,8 +434,8 @@ Emscripten port is a work in progress. It builds but does not do more than that 
 To build, install the [Emscripten SDK](https://emscripten.org/docs/getting_started/downloads.html), then run:
 
 ~~~ bash
-emcmake cmake -S. -Bbuild-em -DCMAKE\_BUILD\_TYPE=Release
-cmake --build build-em -j $(getconf \_NPROCESSORS\_ONLN)
+emcmake cmake -S. -Bbuild-em -DCMAKE_BUILD_TYPE=Release
+cmake --build build-em -j $(getconf _NPROCESSORS_ONLN)
 ~~~
 
 To then run it:
@@ -479,7 +482,7 @@ Packaging/xbox-one/build.bat
 <details><summary>Miyoo Mini</summary>
 
 Building for Miyoo Mini must be run from inside the [Toolchain Docker image](https://github.com/MiyooMini/union-toolchain).
-Executing `Packaging/miyoo_mini/build.sh` will create the folder `build-miyoo-mini/SDROOT` which has the correct structure to be used with 
+Executing `Packaging/miyoo_mini/build.sh` will create the folder `build-miyoo-mini/SDROOT` which has the correct structure to be used with
 OnionOS Port Collection.
 </details>
 


### PR DESCRIPTION
`-Wl,--gc-sections,--as-needed` only needs to be passed to the linker. Fixes an unused linker flags warning with clang.