### PR TITLE
PS4: Update SDK (1.0 -> 1.1)

### DIFF
--- a/.github/workflows/PS4.yml
+++ b/.github/workflows/PS4.yml
@@ -15,10 +15,10 @@ concurrency:
 
 jobs:
   ps4:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -26,8 +26,8 @@ jobs:
       run: >
         sudo apt-get update &&
         sudo apt-get install -y wget cmake git gettext smpq &&
-        wget https://github.com/PacBrew/pacbrew-pacman/releases/download/pacbrew-release-1.0/pacbrew-pacman-1.0.deb &&
-        sudo dpkg -i pacbrew-pacman-1.0.deb && sudo pacbrew-pacman -Sy &&
+        wget https://github.com/PacBrew/pacbrew-pacman/releases/download/v1.1/pacbrew-pacman-1.1.deb &&
+        sudo dpkg -i pacbrew-pacman-1.1.deb && sudo pacbrew-pacman -Sy &&
         sudo pacbrew-pacman --noconfirm -S ps4-openorbis ps4-openorbis-portlibs &&
         echo "#include <endian.h>" | sudo tee /opt/pacbrew/ps4/openorbis/include/sys/endian.h
 


### PR DESCRIPTION
pacbrew-pacman is updated for Ubuntu 22.04 (the new version works on 22.04 but not on 20.04, the old version does not work on 20.04)