### PR TITLE
Multiplayer: Enable Anvil of Fury Quest

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -901,6 +901,7 @@ void CheckQuestItem(Player &player, Item &questItem)
 	if (questItem.IDidx == IDI_ANVIL && Quests[Q_ANVIL]._qactive != QUEST_NOTAVAIL) {
 		if (Quests[Q_ANVIL]._qactive == QUEST_INIT) {
 			Quests[Q_ANVIL]._qactive = QUEST_ACTIVE;
+			NetSendCmdQuest(true, Quests[Q_ANVIL]);
 		}
 		if (Quests[Q_ANVIL]._qlog) {
 			myPlayer.Say(HeroSpeech::INeedToGetThisToGriswold, 10);

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -387,24 +387,24 @@ void TalkToBlackSmith(Player &player, Towner &blackSmith)
 			}
 		}
 	}
-	if (Quests[Q_ANVIL]._qactive != QUEST_NOTAVAIL) {
-		if (player._pLvlVisited[9] && Quests[Q_ANVIL]._qactive != QUEST_DONE) {
-			if (Quests[Q_ANVIL]._qvar2 == 0 && Quests[Q_ROCK]._qactive != QUEST_INIT) {
-				Quests[Q_ANVIL]._qvar2 = 1;
-				Quests[Q_ANVIL]._qlog = true;
-				if (Quests[Q_ANVIL]._qactive == QUEST_INIT) {
-					Quests[Q_ANVIL]._qactive = QUEST_ACTIVE;
-				}
-				InitQTextMsg(TEXT_ANVIL5);
-				return;
+	if (IsNoneOf(Quests[Q_ANVIL]._qactive, QUEST_NOTAVAIL, QUEST_DONE)) {
+		if ((player._pLvlVisited[9] || player._pLvlVisited[10]) && Quests[Q_ANVIL]._qvar2 == 0) {
+			Quests[Q_ANVIL]._qvar2 = 1;
+			Quests[Q_ANVIL]._qlog = true;
+			if (Quests[Q_ANVIL]._qactive == QUEST_INIT) {
+				Quests[Q_ANVIL]._qactive = QUEST_ACTIVE;
 			}
+			NetSendCmdQuest(true, Quests[Q_ANVIL]);
+			InitQTextMsg(TEXT_ANVIL5);
+			return;
+		}
 
-			if (Quests[Q_ANVIL]._qvar2 == 1 && RemoveInventoryItemById(player, IDI_ANVIL)) {
-				Quests[Q_ANVIL]._qactive = QUEST_DONE;
-				SpawnUnique(UITEM_GRISWOLD, blackSmith.position + Direction::SouthWest);
-				InitQTextMsg(TEXT_ANVIL7);
-				return;
-			}
+		if (Quests[Q_ANVIL]._qvar2 == 1 && RemoveInventoryItemById(player, IDI_ANVIL)) {
+			Quests[Q_ANVIL]._qactive = QUEST_DONE;
+			NetSendCmdQuest(true, Quests[Q_ANVIL]);
+			SpawnUnique(UITEM_GRISWOLD, blackSmith.position + Direction::SouthWest);
+			InitQTextMsg(TEXT_ANVIL7);
+			return;
 		}
 	}
 


### PR DESCRIPTION
Contributes to #926

- Quest is only activated when player was on level 9 or 10
- Removed checks for magic rock, cause in vanilla both quests (magic rock and anvil of fury) can't be present at the same time.