### PR TITLE
added missing Ubuntu library

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -46,7 +46,7 @@ When the transfer is done you can disconnect your device and press "Check again"
 
 - Copy the MPQ files to the folder containing the DevilutionX executable, or to the data folder. The data folder path may differ depending on distro, version, and security settings, but will normally be `~/.local/share/diasurgical/devilution/`
 - Install [SDL2](https://www.libsdl.org/download-2.0.php):
-- Ubuntu/Debian/Rasbian `sudo apt install libsdl2-2.0-0`
+- Ubuntu/Debian/Rasbian `sudo apt install libsdl2-2.0-0 libsdl2-image-2.0-0`
 - Fedora `sudo dnf install SDL2`
 - Run `./devilutionx`
 


### PR DESCRIPTION
Huge fan of the game and the project; awesome job!
While installing it for Ubuntu 22.04 I got an error of a missing library _libSDL2 image-2.0.s0.0_.
Anyways, I added this library to the installing instructions for Linux/Ubuntu, just in case it could help future linux gamers.
