### PR TITLE
Set player old position on level join to prevent a crash when leaving the game

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2073,6 +2073,7 @@ size_t OnPlayerJoinLevel(const TCmd *pCmd, size_t pnum)
 
 	if (player.plractive && &player != MyPlayer) {
 		player.position.tile = position;
+		SetPlayerOld(player);
 		if (isSetLevel)
 			player.setLevel(static_cast<_setlevels>(playerLevel));
 		else


### PR DESCRIPTION
Steps to reproduce the bug in master:
- Player 1 enter level 1 and don't move
- Player 2 enter level 1
- Player 1 leaves the game
- Player 2 crashes when trying to render player 1, cause his graphics are already unloaded

When player leaves the game his position is removed from `dPlayer`. This is done with `FixPlrWalkTags` functions. But `FixPlrWalkTags` uses `player.position.old`. And if `player.position.old` has incorrect/old data it doesn't clear `dPlayer`.

In previous version this doesn't result in a crash, cause `DrawPlayer` only logged a error when the graphics were not present.