### PR TITLE
rg99: Build with -O2 and tune buffer size

### DIFF
--- a/CMake/platforms/rg99.cmake
+++ b/CMake/platforms/rg99.cmake
@@ -11,7 +11,8 @@ set(USE_SDL1 ON)
 set(DEVILUTIONX_STATIC_CXX_STDLIB OFF)
 
 # -fmerge-all-constants saves ~4 KiB
-set(_extra_flags "-fmerge-all-constants")
+# -fsection-anchors saves ~4 KiB
+set(_extra_flags "-fmerge-all-constants -fsection-anchors")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_extra_flags}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_extra_flags}")
 # -Wl,-z-stack-size: the default thread stack size for RG99 is 128 KiB, reduce it.
@@ -24,8 +25,8 @@ set(DEVILUTIONX_PALETTE_TRANSPARENCY_BLACK_16_LUT OFF)
 # Must stream all the audio due to RAM constraints.
 set(STREAM_ALL_AUDIO ON)
 
-# Must use a tiny audio buffer due to RAM constraints.
-set(DEFAULT_AUDIO_BUFFER_SIZE 256)
+# Must use a smaller audio buffer due to RAM constraints.
+set(DEFAULT_AUDIO_BUFFER_SIZE 768)
 
 # Use lower resampling quality for FPS.
 set(DEFAULT_AUDIO_RESAMPLING_QUALITY 2)

--- a/Packaging/OpenDingux/build.sh
+++ b/Packaging/OpenDingux/build.sh
@@ -125,11 +125,7 @@ build_release() {
 
 build() {
 	rm -f "${BUILD_DIR}/CMakeCache.txt"
-	if [[ $TARGET == rg99 ]]; then
-		build_minsizerel
-	else
-		build_release
-	fi
+	build_release
 }
 
 main


### PR DESCRIPTION
`-O2` increases the binary size by 0.5 MiB which we can now afford. Increasing audio buffer size to `768` improves performance (seems to be the sweet spot).

15-20 FPS in dungeon on the max-mem OD fork.