### PR TITLE
Disable fade-in/out in demomode

### DIFF
--- a/Source/engine/palette.cpp
+++ b/Source/engine/palette.cpp
@@ -8,6 +8,7 @@
 #include <fmt/compile.h>
 
 #include "engine/backbuffer_state.hpp"
+#include "engine/demomode.h"
 #include "engine/dx.h"
 #include "engine/load_file.hpp"
 #include "engine/random.hpp"
@@ -326,22 +327,29 @@ void PaletteFadeIn(int fr)
 {
 	if (HeadlessMode)
 		return;
+	if (demo::IsRunning())
+		fr = 0;
 
 	ApplyGamma(logical_palette, orig_palette, 256);
 
-	const uint32_t tc = SDL_GetTicks();
-	fr *= 3;
-
-	uint32_t prevFadeValue = 255;
-	for (uint32_t i = 0; i < 256; i = fr * (SDL_GetTicks() - tc) / 50) {
-		if (i != prevFadeValue) {
-			SetFadeLevel(i);
-			prevFadeValue = i;
+	if (fr > 0) {
+		const uint32_t tc = SDL_GetTicks();
+		fr *= 3;
+		uint32_t prevFadeValue = 255;
+		for (uint32_t i = 0; i < 256; i = fr * (SDL_GetTicks() - tc) / 50) {
+			if (i != prevFadeValue) {
+				SetFadeLevel(i);
+				prevFadeValue = i;
+			}
+			BltFast(nullptr, nullptr);
+			RenderPresent();
 		}
+		SetFadeLevel(256);
+	} else {
+		SetFadeLevel(256);
 		BltFast(nullptr, nullptr);
 		RenderPresent();
 	}
-	SetFadeLevel(256);
 
 	memcpy(logical_palette, orig_palette, sizeof(orig_palette));
 
@@ -352,20 +360,27 @@ void PaletteFadeOut(int fr)
 {
 	if (!sgbFadedIn || HeadlessMode)
 		return;
+	if (demo::IsRunning())
+		fr = 0;
 
-	const uint32_t tc = SDL_GetTicks();
-	fr *= 3;
-
-	uint32_t prevFadeValue = 0;
-	for (uint32_t i = 0; i < 256; i = fr * (SDL_GetTicks() - tc) / 50) {
-		if (i != prevFadeValue) {
-			SetFadeLevel(256 - i);
-			prevFadeValue = i;
+	if (fr > 0) {
+		const uint32_t tc = SDL_GetTicks();
+		fr *= 3;
+		uint32_t prevFadeValue = 0;
+		for (uint32_t i = 0; i < 256; i = fr * (SDL_GetTicks() - tc) / 50) {
+			if (i != prevFadeValue) {
+				SetFadeLevel(256 - i);
+				prevFadeValue = i;
+			}
+			BltFast(nullptr, nullptr);
+			RenderPresent();
 		}
+		SetFadeLevel(0);
+	} else {
+		SetFadeLevel(0);
 		BltFast(nullptr, nullptr);
 		RenderPresent();
 	}
-	SetFadeLevel(0);
 
 	sgbFadedIn = false;
 }

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -11,6 +11,7 @@
 #include "control.h"
 #include "engine.h"
 #include "engine/clx_sprite.hpp"
+#include "engine/demomode.h"
 #include "engine/dx.h"
 #include "engine/load_cel.hpp"
 #include "engine/load_clx.hpp"
@@ -252,15 +253,15 @@ void interface_msg_pump()
 
 void IncProgress()
 {
-	if (HeadlessMode)
-		return;
-	interface_msg_pump();
+	if (!HeadlessMode && !demo::IsRunning())
+		interface_msg_pump();
 	if (!IsProgress)
 		return;
 	sgdwProgress += 23;
 	if (sgdwProgress > MaxProgress)
 		sgdwProgress = MaxProgress;
-	DrawCutsceneForeground();
+	if (!HeadlessMode && !demo::IsRunning())
+		DrawCutsceneForeground();
 }
 
 void CompleteProgress()


### PR DESCRIPTION
Disables FadeIn/FadeOut and progress bar updates in demo mode. This makes the demo run much faster (6s -> 2s).