### PR TITLE
Don't sync monsters while level changing

### DIFF
--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -303,6 +303,7 @@ uint32_t OnSyncData(const TCmd *pCmd, size_t pnum)
 	int monsterCount = header.wLen / sizeof(TSyncMonster);
 
 	uint8_t level = header.bLevel;
+	bool syncLocalLevel = !MyPlayer->_pLvlChanging && GetLevelForMultiplayer(*MyPlayer) == level;
 
 	if (IsValidLevelForMultiplayer(level)) {
 		const auto *monsterSyncs = reinterpret_cast<const TSyncMonster *>(pCmd + sizeof(header));
@@ -311,7 +312,7 @@ uint32_t OnSyncData(const TCmd *pCmd, size_t pnum)
 			if (!IsTSyncMonsterValidate(monsterSyncs[i]))
 				continue;
 
-			if (GetLevelForMultiplayer(*MyPlayer) == level) {
+			if (syncLocalLevel) {
 				SyncMonster(pnum > MyPlayerId, monsterSyncs[i]);
 			}
 


### PR DESCRIPTION
This one is a nasty one.
Got this sporadic when testing the multiplayer quests changes (but can also happen when these are disabled).

The game can sync monsters from a different level to the current level.
This only happens when the local player changes levels.

Result:
The game can crash when rendering invalid monsters (similar to #5527).
(In previous version this doesn't result in a crash, cause `DrawPlayer` only logged a error when the graphics were not present.)
or
Accessing undefined memory (and perhaps crash here).

How to reproduce:
- Player 1 needs to be in a dungeon level
- Player 1 opens a portal
- Player 1 needs to stay next to a monster that uses some coords that are next to portal in town
- Player 2 uses the portal to the dungeon

Perhaps multiple tires (go down and up from dungeon) are needed, cause it depends on how sync messages are send/processed.

What can happen:
- Player 2 is sends a `CMD_WARP` to start the warp
- Player 1 send syncs monsters messages (`CMD_SYNCDATA`)
- Both messages get handled by the local client
   - `StartWarpLvl` is called and `MyPlayer->plrlevel` is changed, a `WM_DIABWARPLVL` is queued and `_pLvlChanging` is set. `currlevel` isn't changed.
   - `OnSyncData` sees the new `plrlevel` and start to update `dMonsters` (in `SyncMonster`). Now we can get invalid data.
- `DrawAndBlit` is called sees the invalid monster ids in `dMonsters` and tries to draw the monsters with `DrawMonsterHelper` but `leveltype` is still `DTYPE_TOWN`. That's why `Towners` are used and not `Monsters`. Here we can get a crash.

This only happens when both `CMD_WARP` and `CMD_SYNCDATA` are present in the same game tick and  `CMD_WARP` is **before** `CMD_SYNCDATA`.

The fix is to not update the `dMonsters` for `CMD_SYNCDATA` while the local player is changing levels. The changes get stored in delta levels and this information is used in `LoadGameLevel`. So hopefully everything should be still in sync.

I hope the explanation makes sense and sorry for the long post.