### PR TITLE
Fix gold withdrawal in SDL1

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -653,6 +653,28 @@ void HandleMouseButtonUp(Uint8 button, uint16_t modState)
 	}
 }
 
+bool HandleTextInput(string_view text)
+{
+	if (IsTalkActive()) {
+		control_new_text(text);
+		return true;
+	}
+	if (dropGoldFlag) {
+		GoldDropNewText(text);
+		return true;
+	}
+	if (IsWithdrawGoldOpen) {
+		GoldWithdrawNewText(text);
+		return true;
+	}
+	return false;
+}
+
+[[maybe_unused]] void LogUnhandledEvent(const char *name, int value)
+{
+	LogVerbose("Unhandled SDL event: {} {}", name, value);
+}
+
 void GameEventHandler(const SDL_Event &event, uint16_t modState)
 {
 	GameAction action;
@@ -675,12 +697,33 @@ void GameEventHandler(const SDL_Event &event, uint16_t modState)
 	}
 
 	switch (event.type) {
-	case SDL_KEYDOWN:
+	case SDL_KEYDOWN: {
+#ifdef USE_SDL1
+		// SDL1 does not support TEXTINPUT events, so we emulate them here.
+		const Uint16 bmpCodePoint = event.key.keysym.unicode;
+		if (bmpCodePoint >= ' ') {
+			std::string utf8;
+			AppendUtf8(bmpCodePoint, utf8);
+			if (HandleTextInput(utf8)) {
+				return;
+			}
+		}
+#endif
 		PressKey(event.key.keysym.sym, modState);
 		return;
+	}
 	case SDL_KEYUP:
 		ReleaseKey(event.key.keysym.sym);
 		return;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	case SDL_TEXTEDITING:
+		return;
+	case SDL_TEXTINPUT:
+		if (!HandleTextInput(event.text.text)) {
+			LogUnhandledEvent("SDL_TEXTINPUT", event.text.windowID);
+		}
+		return;
+#endif
 	case SDL_MOUSEMOTION:
 		MousePosition = { event.motion.x, event.motion.y };
 		gmenu_on_mouse_move();

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -288,9 +288,6 @@ bool SpawnWindow(const char *lpWindowName)
 #endif
 
 #ifdef USE_SDL1
-	SDL_EnableUNICODE(1);
-#endif
-#ifdef USE_SDL1
 	// On SDL 1, there are no ADDED/REMOVED events.
 	// Always try to initialize the first joystick.
 	Joystick::Add(0);

--- a/Source/utils/sdl2_to_1_2_backports.h
+++ b/Source/utils/sdl2_to_1_2_backports.h
@@ -97,10 +97,12 @@ SDL_LogPriority SDL_LogGetPriority(int category);
 
 inline void SDL_StartTextInput()
 {
+	SDL_EnableUNICODE(1);
 }
 
 inline void SDL_StopTextInput()
 {
+	SDL_EnableUNICODE(0);
 }
 
 inline void SDL_SetTextInputRect(const SDL_Rect *r)


### PR DESCRIPTION
1. Unifies SDL1 and SDL2 text input handling.
2. Moves game-specific text input handling out of misc_msg.
3. Disables Unicode processing when not inputting text in SDL1.

This fixes gold withdrawal in SDL1.