### PR TITLE
Text rendering and chat input fixes

### DIFF
--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -319,15 +319,17 @@ void UiSettingsMenu()
 
 		const Rectangle &uiRectangle = GetUIRectangle();
 
+		const int descriptionLineHeight = IsSmallFontTall() ? 20 : 18;
+		const int descriptionMarginTop = IsSmallFontTall() ? 10 : 16;
 		rectList = { uiRectangle.position + Displacement { 50, 204 }, Size { 540, 208 } };
-		rectDescription = { rectList.position + Displacement { -26, rectList.size.height + 16 }, Size { 590, 35 } };
+		rectDescription = { rectList.position + Displacement { -26, rectList.size.height + descriptionMarginTop }, Size { 590, 80 - descriptionMarginTop } };
 
 		optionDescription[0] = '\0';
 
 		string_view titleText = shownMenu == ShownMenuType::Settings ? _("Settings") : selectedOption->GetName();
 		vecDialog.push_back(std::make_unique<UiArtText>(titleText.data(), MakeSdlRect(uiRectangle.position.x, uiRectangle.position.y + 161, uiRectangle.size.width, 35), UiFlags::FontSize30 | UiFlags::ColorUiSilver | UiFlags::AlignCenter, 8));
 		vecDialog.push_back(std::make_unique<UiScrollbar>((*ArtScrollBarBackground)[0], (*ArtScrollBarThumb)[0], *ArtScrollBarArrow, MakeSdlRect(rectList.position.x + rectList.size.width + 5, rectList.position.y, 25, rectList.size.height)));
-		vecDialog.push_back(std::make_unique<UiArtText>(optionDescription, MakeSdlRect(rectDescription), UiFlags::FontSize12 | UiFlags::ColorUiSilverDark | UiFlags::AlignCenter, 1, IsSmallFontTall() ? 22 : 18));
+		vecDialog.push_back(std::make_unique<UiArtText>(optionDescription, MakeSdlRect(rectDescription), UiFlags::FontSize12 | UiFlags::ColorUiSilverDark | UiFlags::AlignCenter, 1, descriptionLineHeight));
 
 		size_t itemToSelect = 1;
 		std::optional<tl::function_ref<bool(SDL_Event &)>> eventHandler;

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1232,9 +1232,8 @@ void DrawTalkPan(const Surface &out)
 	int x = mainPanelPosition.x + 200;
 	int y = mainPanelPosition.y + 10;
 
-	uint32_t idx = DrawString(out, TalkMessage, { { x, y }, { 250, 27 } }, UiFlags::ColorWhite | UiFlags::PentaCursor, 1, 13);
-	if (idx < sizeof(TalkMessage))
-		TalkMessage[idx] = '\0';
+	const uint32_t len = DrawString(out, TalkMessage, { { x, y }, { 250, 39 } }, UiFlags::ColorWhite | UiFlags::PentaCursor, 1, 13);
+	TalkMessage[std::min<size_t>(len, sizeof(TalkMessage) - 1)] = '\0';
 
 	x += 46;
 	int talkBtn = 0;
@@ -1320,7 +1319,7 @@ void control_type_message()
 		return;
 
 	talkflag = true;
-	SDL_Rect rect = MakeSdlRect(GetMainPanel().position.x + 200, GetMainPanel().position.y + 22, 250, 39);
+	SDL_Rect rect = MakeSdlRect(GetMainPanel().position.x + 200, GetMainPanel().position.y + 22, 0, 27);
 	SDL_SetTextInputRect(&rect);
 	TalkMessage[0] = '\0';
 	for (bool &talkButtonDown : TalkButtonsDown) {

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -254,6 +254,9 @@ bool SpawnWindow(const char *lpWindowName)
 	}
 #endif
 
+#if SDL_VERSION_ATLEAST(2, 0, 4)
+	SDL_SetHint(SDL_HINT_IME_INTERNAL_EDITING, "1");
+#endif
 #if SDL_VERSION_ATLEAST(2, 0, 6) && defined(__vita__)
 	SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
 #endif


### PR DESCRIPTION
1. Fixes the return value (bytes rendered).
2. Fixes line wrapping / end-of-rendering based on the given rectangle:
   1. Accounts for `BaseLineOffset`.
   2. Fixes an off-by-one error for the y coordinate.
   3. Wraps the cursor when needed.
3. Fix chat input box dimensions (height is 3 * line height).
4. Set the hint that indicates that we do not render the current  IME suggestion (SDL_TEXTEDITING). This indicates to IME that it should render the suggestion instead.
5. Also fixes the settings description dimensions for CJK.