### PR TITLE
Fix "Stairlock" Exploit

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3043,6 +3043,12 @@ bool IsRelativeMoveOK(const Monster &monster, Point position, Direction mdir)
 	Point futurePosition = position + mdir;
 	if (!InDungeonBounds(futurePosition) || !IsTileAvailable(monster, futurePosition))
 		return false;
+	// Fixes exploit that allows a monster to become "stuck" in a trigger tile
+	for (int i = 0; i < numtrigs; i++) {
+		if (futurePosition == trigs[i].position) {
+			return false;
+		}
+	}
 	if (mdir == Direction::East) {
 		if (IsTileSolid(position + Direction::SouthEast))
 			return false;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3043,9 +3043,9 @@ bool IsRelativeMoveOK(const Monster &monster, Point position, Direction mdir)
 	Point futurePosition = position + mdir;
 	if (!InDungeonBounds(futurePosition) || !IsTileAvailable(monster, futurePosition))
 		return false;
-	// Fixes exploit that allows a monster to become "stuck" in a trigger tile
+	// Fixes exploit that allows a monster to become "stuck" in a trigger tile in Cathedral and Crypt levels
 	for (int i = 0; i < numtrigs; i++) {
-		if (futurePosition == trigs[i].position) {
+		if (futurePosition == trigs[i].position && ((currlevel >= 1 && currlevel <= 4) || (currlevel >= 21 && currlevel <= 24))) {
 			return false;
 		}
 	}

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3044,9 +3044,12 @@ bool IsRelativeMoveOK(const Monster &monster, Point position, Direction mdir)
 	if (!InDungeonBounds(futurePosition) || !IsTileAvailable(monster, futurePosition))
 		return false;
 	// Fixes exploit that allows a monster to become "stuck" in a trigger tile in Cathedral and Crypt levels
-	for (int i = 0; i < numtrigs; i++) {
-		if (futurePosition == trigs[i].position && ((currlevel >= 1 && currlevel <= 4) || (currlevel >= 21 && currlevel <= 24))) {
-			return false;
+	if ((currlevel >= 1 && currlevel <= 4)
+	    || (currlevel >= 21 && currlevel <= 24)) {
+		for (int i = 0; i < numtrigs; i++) {
+			if (futurePosition == trigs[i].position) {
+				return false;
+			}
 		}
 	}
 	if (mdir == Direction::East) {

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3044,8 +3044,7 @@ bool IsRelativeMoveOK(const Monster &monster, Point position, Direction mdir)
 	if (!InDungeonBounds(futurePosition) || !IsTileAvailable(monster, futurePosition))
 		return false;
 	// Fixes exploit that allows a monster to become "stuck" in a trigger tile in Cathedral and Crypt levels
-	if ((currlevel >= 1 && currlevel <= 4)
-	    || (currlevel >= 21 && currlevel <= 24)) {
+	if ((currlevel >= 1 && currlevel <= 4) || (currlevel >= 21 && currlevel <= 24)) {
 		for (int i = 0; i < numtrigs; i++) {
 			if (futurePosition == trigs[i].position) {
 				return false;


### PR DESCRIPTION
This fix prevents monsters from pathing into a trigger tile in the Cathedral and Crypt levels, fixing the infamous "Butcher Stairlock Bug". Monsters can still occupy these tiles (example: Player uses knockback item), however they will not willingly walk into the tile in question.
