### PR TITLE
GitHub Actions: Test on a big-endian platform

### DIFF
--- a/.github/workflows/s390x_qemu_big_endian_tests.yml
+++ b/.github/workflows/s390x_qemu_big_endian_tests.yml
@@ -1,0 +1,42 @@
+name: s390x qemu tests (big-endian)
+
+# The test suite takes ~50m to run so we only trigger it manually
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  big-endian-qemu:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Cache .ccache
+      uses: actions/cache@v3
+      with:
+        path: .ccache
+        key: ${{ github.workflow }}-ccache
+
+    - name: Get the qemu container
+      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+    - name: Run tests
+      run: >
+        docker run --rm --interactive --mount type=bind,source=$(pwd),target=/host s390x/alpine sh -c
+        "
+        apk add --update-cache g++ ninja cmake ccache sdl2-dev sdl2_image-dev fmt-dev libpng-dev bzip2-dev gtest-dev wget &&
+        cd /host &&
+        export CCACHE_DIR=/host/.ccache &&
+        cmake -S. -Bbuild -G Ninja -DNONET=ON -DNOSOUND=ON -DVERSION_NUM=1.0.0 -DVERSION_SUFFIX=FFFFFFF &&
+        wget -nv -nc https://github.com/diasurgical/devilutionx-assets/releases/download/v2/spawn.mpq -P build &&
+        cmake --build build -j $(nproc) &&
+        ctest --test-dir build --output-on-failure -j $(nproc)
+        "


### PR DESCRIPTION
Run tests on a big-endian platform (s390x) via qemu.

The test suite takes ~50m to run so we only trigger it manually.

There are a few failing tests: https://github.com/diasurgical/devilutionX/actions/runs/3646395402/jobs/6157431868

Refs #5573