### PR TITLE
Move item info from panel to Unique window

### DIFF
--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -387,7 +387,7 @@ void CheckCursMove()
 	pcursinvitem = -1;
 	pcursstashitem = uint16_t(-1);
 	pcursplr = -1;
-	ShowUniqueItemInfoBox = false;
+	ShowItemInfoBox = false;
 	panelflag = false;
 	trigflag = false;
 

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1116,8 +1116,8 @@ void DrawView(const Surface &out, Point startPosition)
 		DrawStash(out);
 	}
 	DrawLevelUpIcon(out);
-	if (ShowUniqueItemInfoBox) {
-		DrawUniqueInfo(out);
+	if (ShowItemInfoBox) {
+		DrawItemInfo(out);
 	}
 	if (qtextflag) {
 		DrawQText(out);

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1922,7 +1922,7 @@ int8_t CheckInvHLight()
 		InfoString = fmt::format(fmt::runtime(ngettext("{:s} gold piece", "{:s} gold pieces", nGold)), FormatInteger(nGold));
 	} else {
 		InfoColor = pi->getTextColor();
-		if (pi->_iIdentified) {
+		if (pi->_iIdentified || pi->_iMagical == ITEM_QUALITY_NORMAL) {
 			InfoString = string_view(pi->_iIName);
 			PrintItemDetails(*pi);
 		} else {

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3815,13 +3815,14 @@ void DrawItemInfo(const Surface &out)
 			DrawString(out, fmt::format(fmt::runtime(_("-50% damage vs. animals"))), rect, UiFlags::ColorRed | UiFlags::AlignCenter);
 		}
 
-		rect.position.y += nextLine;
-
 		if (modifiedAC) {
+			rect.position.y += nextLine;
 			rect.position.y += nextLine;
 			DrawString(out, fmt::format(fmt::runtime(_("armor class: {:d}")), curritem._iAC * (curritem._iPLAC + 100) / 100), rect, UiFlags::ColorGold | UiFlags::AlignCenter);
 		}
+
 		if (modifiedDam) {
+			rect.position.y += nextLine;
 			rect.position.y += nextLine;
 			DrawString(out, fmt::format(fmt::runtime(_("damage: {:d}-{:d}")), curritem._iMinDam * (curritem._iPLDam + 100) / 100 + curritem._iPLDamMod, curritem._iMaxDam * (curritem._iPLDam + 100) / 100 + curritem._iPLDamMod), rect, UiFlags::ColorGold | UiFlags::AlignCenter);
 		}
@@ -3871,6 +3872,12 @@ void DrawItemInfo(const Surface &out)
 			noBonuses = false;
 		}
 
+		if (curritem._iCharges != 0) {
+			rect.position.y += nextLine;
+			DrawString(out, PrintItemPower(IPL_SPELL, curritem), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
+			noBonuses = false;
+		}
+
 		if (curritem._iPLToHit > 0 && IsNoneOf(curritem._iPrePower, IPL_TOHIT, IPL_TOHIT_CURSE, IPL_TOHIT_DAMP, IPL_TOHIT_DAMP_CURSE)) {
 			rect.position.y += nextLine;
 			DrawString(out, PrintItemPower(IPL_TOHIT, curritem), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
@@ -3891,13 +3898,14 @@ void DrawItemInfo(const Surface &out)
 			noBonuses = false;
 		}
 
-		rect.position.y += nextLine;
-
 		if (modifiedAC) {
+			rect.position.y += nextLine;
 			rect.position.y += nextLine;
 			DrawString(out, fmt::format(fmt::runtime(_("armor class: {:d}")), curritem._iAC * (curritem._iPLAC + 100) / 100), rect, UiFlags::ColorGold | UiFlags::AlignCenter);
 		}
+
 		if (modifiedDam) {
+			rect.position.y += nextLine;
 			rect.position.y += nextLine;
 			DrawString(out, fmt::format(fmt::runtime(_("damage: {:d}-{:d}")), curritem._iMinDam * (curritem._iPLDam + 100) / 100 + curritem._iPLDamMod, curritem._iMaxDam * (curritem._iPLDam + 100) / 100 + curritem._iPLDamMod), rect, UiFlags::ColorGold | UiFlags::AlignCenter);
 		}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1731,8 +1731,13 @@ void PrintItemOil(char iDidx)
 
 void DrawItemInfoWindow(const Surface &out)
 {
-	ClxDraw(out, GetPanelPosition(UiPanels::Inventory, { 24 - SidePanelSize.width, 327 }), (*pSTextBoxCels)[0]);
-	DrawHalfTransparentRectTo(out, GetRightPanel().position.x - SidePanelSize.width + 27, GetRightPanel().position.y + 28, 265, 297);
+	if (IsStashOpen && GetLeftPanel().contains(MousePosition)) {
+		ClxDraw(out, GetPanelPosition(UiPanels::Stash, { 24 + SidePanelSize.width, 327 }), (*pSTextBoxCels)[0]);
+		DrawHalfTransparentRectTo(out, GetLeftPanel().position.x + SidePanelSize.width + 27, GetLeftPanel().position.y + 28, 265, 297);
+	} else {
+		ClxDraw(out, GetPanelPosition(UiPanels::Inventory, { 24 - SidePanelSize.width, 327 }), (*pSTextBoxCels)[0]);
+		DrawHalfTransparentRectTo(out, GetRightPanel().position.x - SidePanelSize.width + 27, GetRightPanel().position.y + 28, 265, 297);
+	}
 }
 
 void printItemMiscKBM(const Item &item, const bool isOil, const bool isCastOnTarget)
@@ -3733,7 +3738,13 @@ UiFlags GetItemPowerTextColor(char plidx, const Item &item)
 
 void DrawItemInfo(const Surface &out)
 {
-	const Point position = GetRightPanel().position - Displacement { SidePanelSize.width, 0 };
+	Point position;
+
+	if (IsStashOpen && GetLeftPanel().contains(MousePosition))
+		position = GetLeftPanel().position + Displacement { SidePanelSize.width, 0 };
+	else
+		position = GetRightPanel().position - Displacement { SidePanelSize.width, 0 };
+
 	if (IsLeftPanelOpen() && GetLeftPanel().contains(position) && !IsStashOpen) {
 		return;
 	}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3695,6 +3695,65 @@ bool DoOil(Player &player, int cii)
 	}
 }
 
+UiFlags GetItemPowerTextColor(char plidx, const Item &item)
+{
+	switch (plidx) {
+	case IPL_TOHIT_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_DAMP_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_TOHIT_DAMP_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_ACP_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_AC_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_FIRERES_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_LIGHTRES_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_MAGICRES_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_SPLLVLADD:
+		if (item._iSplLvlAdd < 0)
+			return UiFlags::ColorRed;
+	case IPL_STR_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_MAG_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_DEX_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_VIT_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_ATTRIBS_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_GETHIT_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_LIFE_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_MANA_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_DUR_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_LIGHT_CURSE:
+		return UiFlags::ColorRed;
+	case IPL_NOMANA:
+		return UiFlags::ColorRed;
+	case IPL_ALLRESZERO:
+		return UiFlags::ColorRed;
+	case IPL_DRAINLIFE:
+		return UiFlags::ColorRed;
+	case IPL_DECAY:
+		return UiFlags::ColorRed;
+	case IPL_PERIL:
+		return UiFlags::ColorRed;
+	case IPL_CRYSTALLINE:
+		return UiFlags::ColorRed;
+	default:
+		return UiFlags::ColorWhite;
+	}
+}
+
 void DrawItemInfo(const Surface &out)
 {
 	const Point position = GetRightPanel().position - Displacement { SidePanelSize.width, 0 };
@@ -3707,6 +3766,7 @@ void DrawItemInfo(const Surface &out)
 	Rectangle rect { position + Displacement { 32, 56 }, { 257, 0 } };
 	int nextLine = 2 * 12;
 	bool noBonuses = true;
+	bool hasToHitPower = false;
 
 	switch (curritem._iMagical) {
 	case ITEM_QUALITY_UNIQUE: {
@@ -3724,24 +3784,29 @@ void DrawItemInfo(const Surface &out)
 			rect.position.y += nextLine;
 			DrawString(out, fmt::format(fmt::runtime(_("+50% damage vs. animals"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
 			rect.position.y += nextLine;
-			DrawString(out, fmt::format(fmt::runtime(_("-50% damage vs. undead"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
+			DrawString(out, fmt::format(fmt::runtime(_("-50% damage vs. undead"))), rect, UiFlags::ColorRed | UiFlags::AlignCenter);
 		} else if (curritem._itype == ItemType::Mace) {
 			rect.position.y += nextLine;
 			DrawString(out, fmt::format(fmt::runtime(_("+50% damage vs. undead"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
 			rect.position.y += nextLine;
-			DrawString(out, fmt::format(fmt::runtime(_("-50% damage vs. animals"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
+			DrawString(out, fmt::format(fmt::runtime(_("-50% damage vs. animals"))), rect, UiFlags::ColorRed | UiFlags::AlignCenter);
 		}
 
 		for (const auto &power : uitem.powers) {
+			if (IsAnyOf(power.type, IPL_TOHIT, IPL_TOHIT_CURSE, IPL_TOHIT_DAMP, IPL_TOHIT_DAMP_CURSE))
+				hasToHitPower = true;
+
 			if (power.type == IPL_INVALID)
 				break;
 
 			rect.position.y += nextLine;
-			DrawString(out, PrintItemPower(power.type, curritem), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
+			DrawString(out, PrintItemPower(power.type, curritem), rect, GetItemPowerTextColor(power.type, curritem) | UiFlags::AlignCenter);
 		}
-		if (curritem._iPLToHit > 0) {
+
+		if (curritem._iPLToHit > 0 && !hasToHitPower) {
 			rect.position.y += nextLine;
 			DrawString(out, PrintItemPower(IPL_TOHIT, curritem), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
+			noBonuses = false;
 		}
 	} break;
 	case ITEM_QUALITY_MAGIC:
@@ -3757,29 +3822,29 @@ void DrawItemInfo(const Surface &out)
 			rect.position.y += nextLine;
 			DrawString(out, fmt::format(fmt::runtime(_("+50% damage vs. animals"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
 			rect.position.y += nextLine;
-			DrawString(out, fmt::format(fmt::runtime(_("-50% damage vs. undead"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
+			DrawString(out, fmt::format(fmt::runtime(_("-50% damage vs. undead"))), rect, UiFlags::ColorRed | UiFlags::AlignCenter);
 			noBonuses = false;
 		} else if (curritem._itype == ItemType::Mace) {
 			rect.position.y += nextLine;
 			DrawString(out, fmt::format(fmt::runtime(_("+50% damage vs. undead"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
 			rect.position.y += nextLine;
-			DrawString(out, fmt::format(fmt::runtime(_("-50% damage vs. animals"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
+			DrawString(out, fmt::format(fmt::runtime(_("-50% damage vs. animals"))), rect, UiFlags::ColorRed | UiFlags::AlignCenter);
 			noBonuses = false;
 		}
 
 		if (curritem._iPrePower != IPL_INVALID) {
 			rect.position.y += nextLine;
-			DrawString(out, PrintItemPower(curritem._iPrePower, curritem), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
+			DrawString(out, PrintItemPower(curritem._iPrePower, curritem), rect, GetItemPowerTextColor(curritem._iPrePower, curritem) | UiFlags::AlignCenter);
 			noBonuses = false;
 		}
 
 		if (curritem._iSufPower != IPL_INVALID) {
 			rect.position.y += nextLine;
-			DrawString(out, PrintItemPower(curritem._iSufPower, curritem), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
+			DrawString(out, PrintItemPower(curritem._iSufPower, curritem), rect, GetItemPowerTextColor(curritem._iSufPower, curritem) | UiFlags::AlignCenter);
 			noBonuses = false;
 		}
 
-		if (curritem._iPLToHit > 0) {
+		if (curritem._iPLToHit > 0 && IsNoneOf(curritem._iSufPower, IPL_TOHIT, IPL_TOHIT_CURSE, IPL_TOHIT_DAMP, IPL_TOHIT_DAMP_CURSE)) {
 			rect.position.y += nextLine;
 			DrawString(out, PrintItemPower(IPL_TOHIT, curritem), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
 			noBonuses = false;
@@ -3832,7 +3897,7 @@ void PrintItemDetails(const Item &item)
 			AddPanelString(_("magic item"));
 			break;
 		case ITEM_QUALITY_NORMAL:
-			AddPanelString(_("mundane item"));
+			AddPanelString(_("normal item"));
 			break;
 		default:
 			break;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3705,7 +3705,8 @@ void DrawItemInfo(const Surface &out)
 	DrawItemInfoWindow(out);
 
 	Rectangle rect { position + Displacement { 32, 56 }, { 257, 0 } };
-	int nextline = 2 * 12;
+	int nextLine = 2 * 12;
+	bool noBonuses = true;
 
 	switch (curritem._iMagical) {
 	case ITEM_QUALITY_UNIQUE: {
@@ -3720,14 +3721,14 @@ void DrawItemInfo(const Surface &out)
 		assert(uitem.UINumPL <= sizeof(uitem.powers) / sizeof(*uitem.powers));
 
 		if (curritem._itype == ItemType::Sword) {
-			rect.position.y += nextline;
+			rect.position.y += nextLine;
 			DrawString(out, fmt::format(fmt::runtime(_("+50% damage vs. animals"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
-			rect.position.y += nextline;
+			rect.position.y += nextLine;
 			DrawString(out, fmt::format(fmt::runtime(_("-50% damage vs. undead"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
 		} else if (curritem._itype == ItemType::Mace) {
-			rect.position.y += nextline;
+			rect.position.y += nextLine;
 			DrawString(out, fmt::format(fmt::runtime(_("+50% damage vs. undead"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
-			rect.position.y += nextline;
+			rect.position.y += nextLine;
 			DrawString(out, fmt::format(fmt::runtime(_("-50% damage vs. animals"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
 		}
 
@@ -3735,8 +3736,12 @@ void DrawItemInfo(const Surface &out)
 			if (power.type == IPL_INVALID)
 				break;
 
-			rect.position.y += nextline;
+			rect.position.y += nextLine;
 			DrawString(out, PrintItemPower(power.type, curritem), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
+		}
+		if (curritem._iPLToHit > 0) {
+			rect.position.y += nextLine;
+			DrawString(out, PrintItemPower(IPL_TOHIT, curritem), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
 		}
 	} break;
 	case ITEM_QUALITY_MAGIC:
@@ -3749,26 +3754,39 @@ void DrawItemInfo(const Surface &out)
 		rect.position.y += (10 - (curritem._iPrePower != IPL_INVALID ? 1 : 0) - (curritem._iSufPower != IPL_INVALID ? 1 : 0) - ((curritem._itype == ItemType::Sword || curritem._itype == ItemType::Mace) ? 2 : 0)) * 12;
 
 		if (curritem._itype == ItemType::Sword) {
-			rect.position.y += nextline;
+			rect.position.y += nextLine;
 			DrawString(out, fmt::format(fmt::runtime(_("+50% damage vs. animals"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
-			rect.position.y += nextline;
+			rect.position.y += nextLine;
 			DrawString(out, fmt::format(fmt::runtime(_("-50% damage vs. undead"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
+			noBonuses = false;
 		} else if (curritem._itype == ItemType::Mace) {
-			rect.position.y += nextline;
+			rect.position.y += nextLine;
 			DrawString(out, fmt::format(fmt::runtime(_("+50% damage vs. undead"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
-			rect.position.y += nextline;
+			rect.position.y += nextLine;
 			DrawString(out, fmt::format(fmt::runtime(_("-50% damage vs. animals"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
+			noBonuses = false;
 		}
 
 		if (curritem._iPrePower != IPL_INVALID) {
-			rect.position.y += nextline;
+			rect.position.y += nextLine;
 			DrawString(out, PrintItemPower(curritem._iPrePower, curritem), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
+			noBonuses = false;
 		}
 
 		if (curritem._iSufPower != IPL_INVALID) {
-			rect.position.y += nextline;
+			rect.position.y += nextLine;
 			DrawString(out, PrintItemPower(curritem._iSufPower, curritem), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
+			noBonuses = false;
 		}
+
+		if (curritem._iPLToHit > 0) {
+			rect.position.y += nextLine;
+			DrawString(out, PrintItemPower(IPL_TOHIT, curritem), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
+			noBonuses = false;
+		}
+
+		if (noBonuses)
+			DrawString(out, fmt::format(fmt::runtime(_("no bonuses"))), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
 	} break;
 	default:
 		break;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3864,18 +3864,15 @@ void PrintItemDetails(const Item &item)
 				AddPanelString(fmt::format(fmt::runtime(_(/* TRANSLATORS: Dur: is durability */ "damage: {:d}-{:d}  Dur: {:d}/{:d}")), item._iMinDam, item._iMaxDam, item._iDurability, item._iMaxDur));
 		}
 	}
-
 	if (item._iClass == ICLASS_ARMOR) {
 		if (item._iMaxDur == DUR_INDESTRUCTIBLE)
 			AddPanelString(fmt::format(fmt::runtime(_("armor: {:d}  Indestructible")), item._iAC));
 		else
 			AddPanelString(fmt::format(fmt::runtime(_(/* TRANSLATORS: Dur: is durability */ "armor: {:d}  Dur: {:d}/{:d}")), item._iAC, item._iDurability, item._iMaxDur));
 	}
-
 	if (item._iMiscId == IMISC_STAFF && item._iMaxCharges != 0) {
 		AddPanelString(fmt::format(fmt::runtime(_("Charges: {:d}/{:d}")), item._iCharges, item._iMaxCharges));
 	}
-
 	if (item._itype != ItemType::Misc) {
 		switch (item._iMagical) {
 		case ITEM_QUALITY_UNIQUE:

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3734,7 +3734,7 @@ UiFlags GetItemPowerTextColor(char plidx, const Item &item)
 void DrawItemInfo(const Surface &out)
 {
 	const Point position = GetRightPanel().position - Displacement { SidePanelSize.width, 0 };
-	if (IsLeftPanelOpen() && GetLeftPanel().contains(position)) {
+	if (IsLeftPanelOpen() && GetLeftPanel().contains(position) && !IsStashOpen) {
 		return;
 	}
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3751,7 +3751,7 @@ void DrawItemInfo(const Surface &out)
 
 	DrawItemInfoWindow(out);
 
-	Rectangle rect { position + Displacement { 32, 56 }, { 257, 0 } };
+	Rectangle rect { position + Displacement { 32, 60 }, { 257, 0 } };
 	int nextLine = 2 * 12;
 	bool noBonuses = true;
 	bool hasToHitPower = false;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3821,7 +3821,7 @@ void DrawItemInfo(const Surface &out)
 			noBonuses = false;
 		}
 
-		if (curritem._iPLToHit > 0 && IsNoneOf(curritem._iSufPower, IPL_TOHIT, IPL_TOHIT_CURSE, IPL_TOHIT_DAMP, IPL_TOHIT_DAMP_CURSE)) {
+		if (curritem._iPLToHit > 0 && IsNoneOf(curritem._iPrePower, IPL_TOHIT, IPL_TOHIT_CURSE, IPL_TOHIT_DAMP, IPL_TOHIT_DAMP_CURSE)) {
 			rect.position.y += nextLine;
 			DrawString(out, PrintItemPower(IPL_TOHIT, curritem), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
 			noBonuses = false;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3791,8 +3791,6 @@ void DrawItemInfo(const Surface &out)
 	default:
 		break;
 	}
-
-
 }
 
 void PrintItemDetails(const Item &item)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3699,56 +3699,33 @@ UiFlags GetItemPowerTextColor(char plidx, const Item &item)
 {
 	switch (plidx) {
 	case IPL_TOHIT_CURSE:
-		return UiFlags::ColorRed;
 	case IPL_DAMP_CURSE:
-		return UiFlags::ColorRed;
 	case IPL_TOHIT_DAMP_CURSE:
-		return UiFlags::ColorRed;
 	case IPL_ACP_CURSE:
-		return UiFlags::ColorRed;
 	case IPL_AC_CURSE:
-		return UiFlags::ColorRed;
 	case IPL_FIRERES_CURSE:
-		return UiFlags::ColorRed;
 	case IPL_LIGHTRES_CURSE:
-		return UiFlags::ColorRed;
 	case IPL_MAGICRES_CURSE:
+	case IPL_STR_CURSE:
+	case IPL_MAG_CURSE:
+	case IPL_DEX_CURSE:
+	case IPL_VIT_CURSE:
+	case IPL_ATTRIBS_CURSE:
+	case IPL_GETHIT_CURSE:
+	case IPL_LIFE_CURSE:
+	case IPL_MANA_CURSE:
+	case IPL_DUR_CURSE:
+	case IPL_LIGHT_CURSE:
+	case IPL_NOMANA:
+	case IPL_ALLRESZERO:
+	case IPL_DRAINLIFE:
+	case IPL_DECAY:
+	case IPL_PERIL:
+	case IPL_CRYSTALLINE:
 		return UiFlags::ColorRed;
 	case IPL_SPLLVLADD:
 		if (item._iSplLvlAdd < 0)
 			return UiFlags::ColorRed;
-	case IPL_STR_CURSE:
-		return UiFlags::ColorRed;
-	case IPL_MAG_CURSE:
-		return UiFlags::ColorRed;
-	case IPL_DEX_CURSE:
-		return UiFlags::ColorRed;
-	case IPL_VIT_CURSE:
-		return UiFlags::ColorRed;
-	case IPL_ATTRIBS_CURSE:
-		return UiFlags::ColorRed;
-	case IPL_GETHIT_CURSE:
-		return UiFlags::ColorRed;
-	case IPL_LIFE_CURSE:
-		return UiFlags::ColorRed;
-	case IPL_MANA_CURSE:
-		return UiFlags::ColorRed;
-	case IPL_DUR_CURSE:
-		return UiFlags::ColorRed;
-	case IPL_LIGHT_CURSE:
-		return UiFlags::ColorRed;
-	case IPL_NOMANA:
-		return UiFlags::ColorRed;
-	case IPL_ALLRESZERO:
-		return UiFlags::ColorRed;
-	case IPL_DRAINLIFE:
-		return UiFlags::ColorRed;
-	case IPL_DECAY:
-		return UiFlags::ColorRed;
-	case IPL_PERIL:
-		return UiFlags::ColorRed;
-	case IPL_CRYSTALLINE:
-		return UiFlags::ColorRed;
 	default:
 		return UiFlags::ColorWhite;
 	}

--- a/Source/items.h
+++ b/Source/items.h
@@ -470,7 +470,7 @@ extern uint8_t ActiveItems[MAXITEMS];
 extern uint8_t ActiveItemCount;
 /** Contains the location of dropped items. */
 extern int8_t dItem[MAXDUNX][MAXDUNY];
-extern bool ShowUniqueItemInfoBox;
+extern bool ShowItemInfoBox;
 extern CornerStoneStruct CornerStone;
 extern bool UniqueItemFlags[128];
 
@@ -521,7 +521,7 @@ void DoRepair(Player &player, int cii);
 void DoRecharge(Player &player, int cii);
 bool DoOil(Player &player, int cii);
 [[nodiscard]] StringOrView PrintItemPower(char plidx, const Item &item);
-void DrawUniqueInfo(const Surface &out);
+void DrawItemInfo(const Surface &out);
 void PrintItemDetails(const Item &item);
 void PrintItemDur(const Item &item);
 void UseItem(size_t pnum, item_misc_id Mid, spell_id spl);

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -435,7 +435,7 @@ uint16_t CheckStashHLight(Point mousePosition)
 	}
 
 	InfoColor = item.getTextColor();
-	if (item._iIdentified) {
+	if (item._iIdentified || item._iMagical == ITEM_QUALITY_NORMAL) {
 		InfoString = string_view(item._iIName);
 		PrintItemDetails(item);
 	} else {


### PR DESCRIPTION
This PR repurposes the Unique Item Info Panel to display all item powers within the Unique window regardless of item quality. The control panel display continues to display base item details (item name, durability, item quality, armor, damage). I opted for this solution over transforming the control panel information into a floating box (a la Diablo 2) since such a method would render the obtuse black square obsolete, making it feel very confusing to players why it's there. This solution appears to be the least invasive way of displaying more item information without changing too much.

The purpose of this PR is to allow for more lines of text for item details. The hidden bonus for sword and maces VS animals and undead are additionally displayed in the window.

![image](https://user-images.githubusercontent.com/68359262/206601321-a1011252-199b-49c1-b15a-7c29736b5a0a.png)
![image](https://user-images.githubusercontent.com/68359262/206601341-2bfdd868-1bcb-41e0-bbba-542333c473ba.png)
![image](https://user-images.githubusercontent.com/68359262/206601342-92671bad-0fd6-48e3-a77a-348026458805.png)
![image](https://user-images.githubusercontent.com/68359262/206601356-560580d5-671a-4454-b092-f4d326e37d9f.png)
![image](https://user-images.githubusercontent.com/68359262/206601367-c2d7d1bd-6236-4b8c-a2fd-fcc7fcedf271.png)



