### PR TITLE
language.cpp: Fix slow translation loading when using MPQ

### DIFF
--- a/Source/utils/sdl2_to_1_2_backports.h
+++ b/Source/utils/sdl2_to_1_2_backports.h
@@ -315,6 +315,7 @@ int SDL_BlitScaled(SDL_Surface *src, SDL_Rect *srcrect,
     SDL_Surface *dst, SDL_Rect *dstrect);
 
 //== Filesystem
+#define SDL_RWOPS_UNKNOWN 0U
 
 Sint64 SDL_RWsize(SDL_RWops *context);
 


### PR DESCRIPTION
Fixes very slow translation loading from MPQs.

Compressed MPQs files are very slow to seek in.
If the RWops is and MPQ, load the whole file first.