### PR TITLE
Use real `CalculateSoundPosition` with NOSOUND

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -459,3 +459,4 @@ uwp-project/Assets/fonts
 uwp-project/Assets/gendata
 uwp-project/Assets/ui_art
 !uwp-project/devilutionX_TemporaryKey.pfx
+/.s390x-ccache/

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -106,6 +106,7 @@ set(libdevilutionx_SRCS
   engine/palette.cpp
   engine/path.cpp
   engine/random.cpp
+  engine/sound_position.cpp
   engine/surface.cpp
   engine/trn.cpp
 

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -8,6 +8,7 @@
 #include "engine/random.hpp"
 #include "engine/sound.h"
 #include "engine/sound_defs.hpp"
+#include "engine/sound_position.hpp"
 #include "init.h"
 #include "player.h"
 #include "utils/stdcompat/algorithm.hpp"
@@ -1199,25 +1200,6 @@ void stream_stop()
 		sgpStreamSFX->pSnd = nullptr;
 		sgpStreamSFX = nullptr;
 	}
-}
-
-bool CalculateSoundPosition(Point soundPosition, int *plVolume, int *plPan)
-{
-	const auto &playerPosition = MyPlayer->position.tile;
-	const auto delta = soundPosition - playerPosition;
-
-	int pan = (delta.deltaX - delta.deltaY) * 256;
-	*plPan = clamp(pan, PAN_MIN, PAN_MAX);
-
-	int volume = playerPosition.ApproxDistance(soundPosition);
-	volume *= -64;
-
-	if (volume <= ATTENUATION_MIN)
-		return false;
-
-	*plVolume = volume;
-
-	return true;
 }
 
 void PlaySFX(_sfx_id psfx)

--- a/Source/effects.h
+++ b/Source/effects.h
@@ -1177,7 +1177,6 @@ extern _sfx_id sfxdnum;
 
 bool effect_is_playing(int nSFX);
 void stream_stop();
-bool CalculateSoundPosition(Point soundPosition, int *plVolume, int *plPan);
 void PlaySFX(_sfx_id psfx);
 void PlaySfxLoc(_sfx_id psfx, Point position, bool randomizeByCategory = true);
 void sound_stop();

--- a/Source/effects_stubs.cpp
+++ b/Source/effects_stubs.cpp
@@ -12,7 +12,6 @@ _sfx_id sfxdnum;
 // clang-format off
 bool effect_is_playing(int nSFX) { return false; }
 void stream_stop() { }
-bool CalculateSoundPosition(Point soundPosition, int *plVolume, int *plPan) { return false; }
 void PlaySFX(_sfx_id psfx)
 {
 	switch (psfx) {

--- a/Source/engine/sound_position.cpp
+++ b/Source/engine/sound_position.cpp
@@ -1,0 +1,27 @@
+#include "engine/sound_position.hpp"
+
+#include "engine/sound_defs.hpp"
+#include "player.h"
+
+namespace devilution {
+
+bool CalculateSoundPosition(Point soundPosition, int *plVolume, int *plPan)
+{
+	const auto &playerPosition = MyPlayer->position.tile;
+	const auto delta = soundPosition - playerPosition;
+
+	int pan = (delta.deltaX - delta.deltaY) * 256;
+	*plPan = clamp(pan, PAN_MIN, PAN_MAX);
+
+	int volume = playerPosition.ApproxDistance(soundPosition);
+	volume *= -64;
+
+	if (volume <= ATTENUATION_MIN)
+		return false;
+
+	*plVolume = volume;
+
+	return true;
+}
+
+} // namespace devilution

--- a/Source/engine/sound_position.hpp
+++ b/Source/engine/sound_position.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "engine/point.hpp"
+
+namespace devilution {
+
+bool CalculateSoundPosition(Point soundPosition, int *plVolume, int *plPan);
+
+} // namespace devilution

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -21,6 +21,7 @@
 #include "engine/points_in_rectangle_range.hpp"
 #include "engine/random.hpp"
 #include "engine/render/clx_render.hpp"
+#include "engine/sound_position.hpp"
 #include "engine/world_tile.hpp"
 #include "init.h"
 #include "levels/crypt.h"

--- a/test/effects_test.cpp
+++ b/test/effects_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "effects.h"
+#include "engine/sound_position.hpp"
 #include "player.h"
 
 using namespace devilution;

--- a/tools/Dockerfile.s390x
+++ b/tools/Dockerfile.s390x
@@ -1,0 +1,13 @@
+FROM s390x/alpine
+
+# This command uses the `wget` from BusyBox.
+RUN wget -nv -nc https://github.com/diasurgical/devilutionx-assets/releases/download/v2/spawn.mpq -P /opt/
+
+# We use clang instead of GCC to have ASAN. GCC does not support ASAN with musl.
+# We also need to install GCC because it provides crtbeginS.o:
+# https://pkgs.alpinelinux.org/contents?file=crtbeginS.o&path=&name=gcc&branch=edge&repo=main&arch=s390x
+RUN apk add --no-cache \
+	clang15 gcc binutils musl-dev ninja cmake ccache sdl2-dev sdl2_image-dev fmt-dev \
+	libpng-dev bzip2-dev gtest-dev
+
+ENV CC=/usr/bin/clang CXX=/usr/bin/clang++

--- a/tools/run_big_endian_tests.sh
+++ b/tools/run_big_endian_tests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+PARALLELISM="$(getconf _NPROCESSORS_ONLN)"
+
+set -xeuo pipefail
+
+if [[ "$(docker images -q devilutionx-s390x-test)" = "" ]]; then
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+	docker build -f tools/Dockerfile.s390x -t devilutionx-s390x-test tools/
+fi
+
+# We disable ASAN and UBSAN for now because of:
+# https://gitlab.alpinelinux.org/alpine/aports/-/issues/14435
+docker run -u "$(id -u "$USER"):$(id -g "$USER")" --rm --mount "type=bind,source=${PWD},target=/host" devilutionx-s390x-test sh -c "cd /host && \
+export CCACHE_DIR=/host/.s390x-ccache && \
+cmake -S. -Bbuild-s390x-test -G Ninja -DASAN=OFF -DUBSAN=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
+  -DNONET=ON -DNOSOUND=ON -DVERSION_NUM=1.0.0 -DVERSION_SUFFIX=FFFFFFF && \
+ln -sf /opt/spawn.mpq /host/build-s390x-test/spawn.mpq && \
+cmake --build build-s390x-test -j ${PARALLELISM} && \
+ctest --test-dir build-s390x-test --output-on-failure -j ${PARALLELISM}"


### PR DESCRIPTION
Fixes `effects_test` on big-endian, which currently builds with `-DNOSOUND` (to reduce build time).

Also adds a tool to run tests on a big-endian system using an Alpine s390x Docker container.

Fixes #5588 