### PR TITLE
Add a `--lang` command line argument

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -907,6 +907,7 @@ void PrintHelpOption(string_view flags, string_view description)
 	PrintHelpOption("--data-dir", _(/* TRANSLATORS: Commandline Option */ "Specify the folder of diabdat.mpq"));
 	PrintHelpOption("--save-dir", _(/* TRANSLATORS: Commandline Option */ "Specify the folder of save files"));
 	PrintHelpOption("--config-dir", _(/* TRANSLATORS: Commandline Option */ "Specify the location of diablo.ini"));
+	PrintHelpOption("--lang", _(/* TRANSLATORS: Commandline Option */ "Specify the language code (e.g. en or pt_BR)"));
 	PrintHelpOption("-n", _(/* TRANSLATORS: Commandline Option */ "Skip startup videos"));
 	PrintHelpOption("-f", _(/* TRANSLATORS: Commandline Option */ "Display frames per second"));
 	PrintHelpOption("--verbose", _(/* TRANSLATORS: Commandline Option */ "Enable verbose logging"));
@@ -939,7 +940,7 @@ void PrintHelpOption(string_view flags, string_view description)
 void PrintFlagsRequiresArgument(string_view flag)
 {
 	printInConsole(flag);
-	printInConsole("requires an argument");
+	printInConsole(" requires an argument");
 	printNewlineInConsole();
 }
 
@@ -968,26 +969,32 @@ void DiabloParseFlags(int argc, char **argv)
 		} else if (arg == "--data-dir") {
 			if (i + 1 == argc) {
 				PrintFlagsRequiresArgument("--data-dir");
-				diablo_quit(0);
+				diablo_quit(64);
 			}
 			paths::SetBasePath(argv[++i]);
 		} else if (arg == "--save-dir") {
 			if (i + 1 == argc) {
 				PrintFlagsRequiresArgument("--save-dir");
-				diablo_quit(0);
+				diablo_quit(64);
 			}
 			paths::SetPrefPath(argv[++i]);
 		} else if (arg == "--config-dir") {
 			if (i + 1 == argc) {
 				PrintFlagsRequiresArgument("--config-dir");
-				diablo_quit(0);
+				diablo_quit(64);
 			}
 			paths::SetConfigPath(argv[++i]);
+		} else if (arg == "--lang") {
+			if (i + 1 == argc) {
+				PrintFlagsRequiresArgument("--lang");
+				diablo_quit(64);
+			}
+			forceLocale = argv[++i];
 #ifndef DISABLE_DEMOMODE
 		} else if (arg == "--demo") {
 			if (i + 1 == argc) {
 				PrintFlagsRequiresArgument("--demo");
-				diablo_quit(0);
+				diablo_quit(64);
 			}
 			demoNumber = SDL_atoi(argv[++i]);
 			gbShowIntro = false;
@@ -996,7 +1003,7 @@ void DiabloParseFlags(int argc, char **argv)
 		} else if (arg == "--record") {
 			if (i + 1 == argc) {
 				PrintFlagsRequiresArgument("--record");
-				diablo_quit(0);
+				diablo_quit(64);
 			}
 			recordNumber = SDL_atoi(argv[++i]);
 		} else if (arg == "--create-reference") {

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -216,7 +216,7 @@ void LoadLanguageArchive()
 	lang_mpq = std::nullopt;
 #endif
 
-	string_view code = *sgOptions.Language.code;
+	string_view code = GetLanguageCode();
 	if (code != "en") {
 		std::string langMpqName { code };
 #ifdef UNPACKED_MPQS

--- a/Source/utils/language.h
+++ b/Source/utils/language.h
@@ -10,6 +10,10 @@
 #define N_(x) (x)
 #define P_(context, x) (x)
 
+extern std::string forceLocale;
+
+devilution::string_view GetLanguageCode();
+
 bool HasTranslation(const std::string &locale);
 void LanguageInitialize();
 

--- a/tools/measure_timedemo_performance.py
+++ b/tools/measure_timedemo_performance.py
@@ -15,7 +15,7 @@ class RunMetrics(NamedTuple):
 
 def measure(binary: str) -> RunMetrics:
 	result: subprocess.CompletedProcess = subprocess.run(
-		[binary, '--diablo', '--spawn', '--demo', '0', '--timedemo'], capture_output=True)
+		[binary, '--diablo', '--spawn', '--lang', 'en', '--demo', '0', '--timedemo'], capture_output=True)
 	match = _TIME_AND_FPS_REGEX.search(result.stderr)
 	if not match:
 		raise Exception(f"Failed to parse output in:\n{result.stderr}")


### PR DESCRIPTION
This allows forcing the locale without changing the settings.

The `forceLocale` option also lets us avoid changing the locale in settings if fonts.mpq is missing, fixing the following scenario:
1. System locale is ja
2. Launch the game -- fonts are missing
3. Close the game, download fonts.mpq
4. Launch the game again -- it is now in English because the settings have changed