### PR TITLE
Fix Multiple Arrows item power

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -398,6 +398,10 @@ void StartRangeAttack(Player &player, Direction d, WorldTileCoord cx, WorldTileC
 		if (HasAnyOf(player._pIFlags, ItemSpecialEffect::FastAttack)) {
 			skippedAnimationFrames += 1;
 		}
+	} else {
+		if (HasAnyOf(player._pIFlags, ItemSpecialEffect::MultipleArrows)) {
+			skippedAnimationFrames -= 1;
+		}
 	}
 
 	auto animationFlags = AnimationDistributionFlags::ProcessAnimationPending;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1060,7 +1060,7 @@ bool DoRangeAttack(Player &player)
 		arrows = 1;
 	}
 
-	if (HasAnyOf(player._pIFlags, ItemSpecialEffect::MultipleArrows) && player.AnimInfo.currentFrame == player._pAFNum + 1) {
+	if (HasAnyOf(player._pIFlags, ItemSpecialEffect::MultipleArrows) && player.AnimInfo.currentFrame == player._pAFNum) {
 		arrows = 2;
 	}
 


### PR DESCRIPTION


https://user-images.githubusercontent.com/68359262/206922593-880e6051-2ce5-4755-9a74-dd8cc8421234.mp4

Description:
This PR changes the behavior of `ItemSpecialEffect::MultipleArrows` in `doRangeAttack()`.

If a player has an item equipped with `IPL_MULTARROWS`, the flag `ItemSpecialEffect::MultipleArrows` is set, and when `DoRangeAttack()` is called, the player will shoot a `MIS_ARROW` missile on the respective class's `AFNum`, and then shoot 2 more `MIS_ARROW` missiles at a positive and negative angle of the first arrow shot, 1 frame after the `AFNum`.

In context, the original behavior is undesirable because of how the game repeats melee and ranged attack animations. There is a set amount of frames (`AFrames`) in any given animation, and an attack is initiated on the `AFNum` which is a set frame number that occurs well before the value of `AFrames`. when a ranged attack is initiated during player mode `PM_RATTACK`, the game shortens the animation and does not reach any frames that occur after `AFNum`, starting the animation over again from the first frame (See CheckNewPath() function). The result of the original code for this functionality is that the `IPL_MULTARROWS` does not activate if the player the player clicks to attack while already performing an attack. The effect will only activate on the "final attack". This forces the player to time their clicks very precisely where they are required to click 0.05 seconds or more after the action frame to use the item power successfully, and completely negates the usefulness that the QoL feature of click and hold offers. The player is not able to successful utilize this to intentionally not fire 2 extra `MIS_ARROW` missiles, since under normal circumstances, the final shot will fire them, regardless if they intend to or not.

This change causes the 2 extra `MIS_ARROW`  missiles to be shot on the `AFNum` instead of 1 frame later, and also reduces adds 1 more frame of animation to ranged attack. 
The result is that the player will ALWAYS be able to repeatedly attack and shoot 3 arrows without extra effort with timing clicks, and it maintains the same balance (since reliably doing multishot means that you're 1 frame of animation or more slower than any other bow). The only drawback to this is that you end up firing the primary arrow 1 frame later than without the fix.