### PR TITLE
Improve Gnat Sting item usage

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1570,7 +1570,7 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 		}
 	}
 
-	if (player._pmode == PM_RATTACK && player.AnimInfo.currentFrame >= player._pAFNum) {
+	if (player._pmode == PM_RATTACK && player.AnimInfo.currentFrame >= player._pAFNum + (HasAnyOf(player._pIFlags, ItemSpecialEffect::MultipleArrows) ? 1 : 0)) {
 		if (player.destAction == ACTION_RATTACK) {
 			d = GetDirection(player.position.tile, { player.destParam1, player.destParam2 });
 			StartRangeAttack(player, d, player.destParam1, player.destParam2);


### PR DESCRIPTION


https://user-images.githubusercontent.com/68359262/206923229-c3e53559-6595-49ff-9633-196f52b6b5a2.mp4

Refer to #5595
This PR adjusts when a ranged attack is repeated when attempting to repeat a ranged attack immediately following a ranged attack when using Gnat Sting, allowing players to effortlessly shoot multiple arrows every time consistently, without changing how the item power works.