### PR TITLE
[Hellfire] Prevent morphing of books from Adria's shop

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4089,6 +4089,7 @@ void SpawnWitch(int lvl)
 				if (lvl >= AllItemsList[bookType].iMinMLvl) {
 					item._iSeed = AdvanceRndSeed();
 					SetRndSeed(item._iSeed);
+					AdvanceRndSeed();
 					GetItemAttrs(item, bookType, lvl);
 					item._iCreateInfo = lvl | CF_WITCH;
 					item._iIdentified = true;


### PR DESCRIPTION
Introduced in 1.4.0, and reported by user Exocet on Discord.

> how about observed issue with spellbooks on ground (sometimes, not always, but eventually) morphing into different spellbooks when i repeatedly leave/enter town? I don't see any other open issues which seem related.
> 
> windows hellfire multiplayer/loopback 1.4.1
> 
> it can be replicated easily enough ... go into cata, open a tp, then keep entering/exiting hell shortcut in town ... each visit to town buy whatever books adria sells and dump on ground in a big pile ... eventually you'll come back to town and see one or several books have changed

In the case of pinned books, the random number which would normally have determined the `_item_indexes` in `RndWitchItem()` needs to be burned because the book types are hardcoded.