### PR TITLE
Fix cursor glitch after playing an in-game movie

### DIFF
--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -73,6 +73,7 @@ void play_movie(const char *pszMovie, bool userCanClose)
 
 	SDL_GetMouseState(&MousePosition.x, &MousePosition.y);
 	OutputToLogical(&MousePosition.x, &MousePosition.y);
+	InitBackbufferState();
 }
 
 void PlayInGameMovie(const char *pszMovie)


### PR DESCRIPTION
Clears backbuffer state after a movie has been played.

Fixes #5611