### PR TITLE
Make debug command restart compatible with multiplayer

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -432,6 +432,7 @@ std::string DebugCmdResetLevel(const string_view parameter)
 	if (level < 0 || level > (gbIsHellfire ? 24 : 16))
 		return StrCat("Level ", level, " is not known. Do you want to write an extension mod?");
 	myPlayer._pLvlVisited[level] = false;
+	DeltaClearLevel(level);
 
 	if (std::getline(paramsStream, singleParameter, ' ')) {
 		uint32_t seed = static_cast<uint32_t>(std::stoul(singleParameter));

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2649,6 +2649,12 @@ void delta_init()
 	LocalLevels.clear();
 }
 
+void DeltaClearLevel(uint8_t level)
+{
+	DeltaLevels.erase(level);
+	LocalLevels.erase(level);
+}
+
 void delta_kill_monster(const Monster &monster, Point position, const Player &player)
 {
 	if (!gbIsMultiplayer)

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -743,6 +743,7 @@ void run_delta_info();
 void DeltaExportData(int pnum);
 void DeltaSyncJunk();
 void delta_init();
+void DeltaClearLevel(uint8_t level);
 void delta_kill_monster(const Monster &monster, Point position, const Player &player);
 void delta_monster_hp(const Monster &monster, const Player &player);
 void delta_sync_monster(const TSyncMonster &monsterSync, uint8_t level);


### PR DESCRIPTION
In singleplayer reseting `_pLvlVisited` is good enough, but in multiplayer the delta levels are used.
This pr changes the `restart` debug command to also reset the delta level.