### PR TITLE
zlib: Add an alternative URL

### DIFF
--- a/3rdParty/zlib/CMakeLists.txt
+++ b/3rdParty/zlib/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_POLICY_DEFAULT_CMP0048 NEW)
 include(FetchContent)
 FetchContent_Declare(zlib
     URL https://www.zlib.net/zlib-1.2.13.tar.gz
+        https://www.zlib.net/fossils/zlib-1.2.13.tar.gz
     URL_HASH MD5=9b8aa094c4e5765dabf4da391f00d15c
 )
 FetchContent_MakeAvailableExcludeFromAll(zlib)


### PR DESCRIPTION
1. Hopefully this will make the Xbox One build less flaky. Refs #5616.
2. The second URL will work even when zlib releases a new version.