### PR TITLE
Bugfix: AnimationInfo integer division by 0

### DIFF
--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -162,7 +162,11 @@ void AnimationInfo::setNewAnimation(OptionalClxSpriteList celSprite, int8_t numb
 		relevantAnimationTicksWithSkipping += previewShownGameTickFragments;
 
 		// if we skipped Frames we need to expand the game ticks to make one game tick for this Animation "faster"
-		int32_t tickModifier = baseValueFraction * relevantAnimationTicksForDistribution / relevantAnimationTicksWithSkipping;
+		int32_t tickModifier;
+		if (relevantAnimationTicksWithSkipping != 0)
+			tickModifier = baseValueFraction * relevantAnimationTicksForDistribution / relevantAnimationTicksWithSkipping;
+		else
+			tickModifier = 0;
 
 		// tickModifier specifies the Animation fraction per game tick, so we have to remove the delay from the variable
 		tickModifier /= ticksPerFrame;


### PR DESCRIPTION
Fixes issue #5624.

Issue stems from #5469. The `setNewAnimation` function divides by 0 when processing hit recovery animations for Balrog type monsters. Previously, floats were used and dividing by 0 did not cause a crash. With integers, we are unable to divide by 0 since an exception is thrown.