### PR TITLE
Remove GNU style strip args

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,7 +307,7 @@ else()
         TARGET ${BIN_TARGET} POST_BUILD
         DEPENDS ${BIN_TARGET}
         COMMAND $<$<CONFIG:Release>:${CMAKE_STRIP}>
-        ARGS --strip-all $<TARGET_FILE:${BIN_TARGET}>)
+        ARGS $<TARGET_FILE:${BIN_TARGET}>)
     endif()
 endif()
 


### PR DESCRIPTION
The --strip-all argument to the strip command breaks the build on BSD strip. Removing it altogether for now so it doesn't break non GNU builds. Possibly can be improved with selecting the proper argument depending on the implementation of strip.