### PR TITLE
Remove No Monster Heal from Fire Arrows

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -247,9 +247,6 @@ bool MonsterMHit(int pnum, int monsterId, int mindam, int maxdam, int dist, miss
 	if (&player == MyPlayer)
 		ApplyMonsterDamage(monster, dam);
 
-	if (!gbIsHellfire && HasAnyOf(player._pIFlags, ItemSpecialEffect::FireArrows))
-		monster.flags |= MFLAG_NOHEAL;
-
 	if (monster.hitPoints >> 6 <= 0) {
 		M_StartKill(monster, player);
 	} else if (resist) {

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1381,12 +1381,6 @@ bool MonsterFadeout(Monster &monster)
  */
 void MonsterHeal(Monster &monster)
 {
-	if ((monster.flags & MFLAG_NOHEAL) != 0) {
-		monster.flags &= ~MFLAG_ALLOW_SPECIAL;
-		monster.mode = MonsterMode::SpecialMeleeAttack;
-		return;
-	}
-
 	if (monster.animInfo.currentFrame == 0) {
 		monster.flags &= ~MFLAG_LOCK_ANIMATION;
 		monster.flags |= MFLAG_ALLOW_SPECIAL;
@@ -2129,17 +2123,15 @@ void ScavengerAi(Monster &monster)
 		monster.goalVar3--;
 		if (dCorpse[monster.position.tile.x][monster.position.tile.y] != 0) {
 			StartEating(monster);
-			if ((monster.flags & MFLAG_NOHEAL) == 0) {
-				if (gbIsHellfire) {
-					int mMaxHP = monster.maxHitPoints; // BUGFIX use hitPointsMaximum or we loose health when difficulty isn't normal (fixed)
-					monster.hitPoints += mMaxHP / 8;
-					if (monster.hitPoints > monster.maxHitPoints)
-						monster.hitPoints = monster.maxHitPoints;
-					if (monster.goalVar3 <= 0 || monster.hitPoints == monster.maxHitPoints)
-						dCorpse[monster.position.tile.x][monster.position.tile.y] = 0;
-				} else {
-					monster.hitPoints += 64;
-				}
+			if (gbIsHellfire) {
+				int mMaxHP = monster.maxHitPoints;
+				monster.hitPoints += mMaxHP / 8;
+				if (monster.hitPoints > monster.maxHitPoints)
+					monster.hitPoints = monster.maxHitPoints;
+				if (monster.goalVar3 <= 0 || monster.hitPoints == monster.maxHitPoints)
+					dCorpse[monster.position.tile.x][monster.position.tile.y] = 0;
+			} else {
+				monster.hitPoints += 64;
 			}
 			int targetHealth = monster.maxHitPoints;
 			if (!gbIsHellfire)
@@ -2252,13 +2244,11 @@ void FallenAi(Monster &monster)
 		if (!FlipCoin(4)) {
 			return;
 		}
-		if ((monster.flags & MFLAG_NOHEAL) == 0) {
-			StartSpecialStand(monster, monster.direction);
-			if (monster.maxHitPoints - (2 * monster.intelligence + 2) >= monster.hitPoints)
-				monster.hitPoints += 2 * monster.intelligence + 2;
-			else
-				monster.hitPoints = monster.maxHitPoints;
-		}
+		StartSpecialStand(monster, monster.direction);
+		if (monster.maxHitPoints - (2 * monster.intelligence + 2) >= monster.hitPoints)
+			monster.hitPoints += 2 * monster.intelligence + 2;
+		else
+			monster.hitPoints = monster.maxHitPoints;
 		int rad = 2 * monster.intelligence + 4;
 		for (int y = -rad; y <= rad; y++) {
 			for (int x = -rad; x <= rad; x++) {
@@ -2411,8 +2401,7 @@ void GargoyleAi(Monster &monster)
 	}
 
 	if (monster.hitPoints < (monster.maxHitPoints / 2))
-		if ((monster.flags & MFLAG_NOHEAL) == 0)
-			monster.goal = MonsterGoal::Retreat;
+		monster.goal = MonsterGoal::Retreat;
 	if (monster.goal == MonsterGoal::Retreat) {
 		if (distanceToEnemy >= monster.intelligence + 2u) {
 			monster.goal = MonsterGoal::Normal;
@@ -3939,7 +3928,7 @@ void ProcessMonsters()
 			SetRndSeed(monster.aiSeed);
 			monster.aiSeed = AdvanceRndSeed();
 		}
-		if ((monster.flags & MFLAG_NOHEAL) == 0 && monster.hitPoints < monster.maxHitPoints && monster.hitPoints >> 6 > 0) {
+		if (monster.hitPoints < monster.maxHitPoints && monster.hitPoints >> 6 > 0) {
 			if (monster.level(sgGameInitInfo.nDifficulty) > 1) {
 				monster.hitPoints += monster.level(sgGameInitInfo.nDifficulty) / 2;
 			} else {

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -39,7 +39,6 @@ enum monster_flag : uint16_t {
 	MFLAG_HIDDEN          = 1 << 0,
 	MFLAG_LOCK_ANIMATION  = 1 << 1,
 	MFLAG_ALLOW_SPECIAL   = 1 << 2,
-	MFLAG_NOHEAL          = 1 << 3,
 	MFLAG_TARGETS_MONSTER = 1 << 4,
 	MFLAG_GOLEM           = 1 << 5,
 	MFLAG_QUEST_COMPLETE  = 1 << 6,


### PR DESCRIPTION
This PR is meant to correct an alleged bug as a result of an alleged oversight in the development of Diablo.

The evidence:

To preface, the item power `ISPL_NOHEALMON` was originally used for the suffix "vileness" as shown here: https://gitlab.com/moralbacteria/diablo-prdemo-decomp/-/blob/main/src/itemdat.cpp on line 295. The intent was for this item power to set `MFLAG_NOHEAL`, preventing monsters from regenerating life.

This bug was corrected in Hellfire (https://github.com/diasurgical/devilution/blob/master/Source/missiles.cpp on line 753). 

Per Blighthorn and staphen, there is some evidence that this was an oversight. It appears that it's entirely possible that `plr[pnum]._pIFlags & MFLAG_NOHEAL` may have been used rather than `plr[pnum]._pIFlags & ISPL_NOHEALMON`. Since `_pIFlags` is not used for monster flags, this would have had the result of `ISPL_FIRE_ARROWS` being used rather than `ISPL_NOHEALMON`, since both `MFLAG_NOHEAL` and `ISPL_FIRE_ARROWS` resolve to `8`. (See https://github.com/diasurgical/devilution/blob/master/enums.h at line 3351 and line 1827).

There is a similar mistake found in https://github.com/diasurgical/devilution/blob/master/Source/player.cpp at line 3049, where the incorrect item power `ISPL_NOHEALPLR` is used rather than `ISPL_NOHEALMON`.