### PR TITLE
rg99: Enable `-fipa-pta`

### DIFF
--- a/CMake/platforms/rg99.cmake
+++ b/CMake/platforms/rg99.cmake
@@ -11,7 +11,8 @@ set(DEVILUTIONX_STATIC_CXX_STDLIB OFF)
 
 # -fmerge-all-constants saves ~4 KiB
 # -fsection-anchors saves ~4 KiB
-set(_extra_flags "-fmerge-all-constants -fsection-anchors")
+# -fipa-pta improves performance.
+set(_extra_flags "-fmerge-all-constants -fsection-anchors -fipa-pta")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_extra_flags}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_extra_flags}")
 # -Wl,-z-stack-size: the default thread stack size for RG99 is 128 KiB, reduce it.

--- a/Packaging/OpenDingux/build.sh
+++ b/Packaging/OpenDingux/build.sh
@@ -159,6 +159,7 @@ cmake_configure() {
 	# libzt uses `-fstack-protector` GCC flag by default.
 	# We disable `-fstack-protector` because it isn't supported by target libc.
 	cmake -S. -B"$BUILD_DIR" \
+		-G "Unix Makefiles" \
 		"-DTARGET_PLATFORM=$TARGET" \
 		-DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN}/usr/share/buildroot/toolchainfile.cmake" \
 		-DBUILD_TESTING=OFF \


### PR DESCRIPTION
From GCC documentation:

> Perform interprocedural pointer analysis and interprocedural modification and reference analysis.
> This option can cause excessive memory and compile-time usage on large compilation units.
> It is not enabled by default at any optimization level.

Also forces the CMake generation to `make` because `ninja` gets into an infinite loop for some reason on my laptop.