### PR TITLE
Removed ability to try and join incompatible ZeroTier games

### DIFF
--- a/Source/DiabloUI/selgame.cpp
+++ b/Source/DiabloUI/selgame.cpp
@@ -633,7 +633,6 @@ void selgame_Password_Select(int /*value*/)
 			UiInitList_clear();
 			selgame_endMenu = true;
 		} else {
-
 			InitGameInfo();
 			selgame_Free();
 			std::string error;

--- a/Source/DiabloUI/selgame.cpp
+++ b/Source/DiabloUI/selgame.cpp
@@ -624,7 +624,7 @@ void selgame_Password_Select(int /*value*/)
 			strcpy(sgOptions.Network.szPreviousHost, selgame_Ip);
 		}
 		if (allowJoin && SNetJoinGame(selgame_Ip, gamePassword, gdwPlayerId)) {
-			if (!IsGameCompatibleWithErrorMessage(Gamelist[selgame_selectedGame - 3].gameData)) {
+			if (!IsGameCompatibleWithErrorMessage(*m_game_data)) {
 				InitGameInfo();
 				selgame_GameSelection_Select(1);
 				return;


### PR DESCRIPTION
While the panel said the public game was incompatible, you could still try and join the game, which then caused the game you were trying to join to "hourglass" for the players in it. This only allows SNetJoinGame to be called for public games if host and client have compatible game versions.

Also fixed what may have been a bug with using *m_game_data (found by @StephenCWills), since it does not look like this was referring to the Gamelist gameData, but what is created locally.