### PR TITLE
 Update Linux builds to more recent OS versions 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2
 jobs:
   linux_x86_64:
     docker:
-      - image: debian:stretch-backports
+      - image: debian:buster
     working_directory: ~/repo
     steps:
       - checkout
-      - run: echo deb http://deb.debian.org/debian stretch-backports-sloppy main >> /etc/apt/sources.list.d/debian-backports.list
+      - run: echo deb http://deb.debian.org/debian buster-backports main >> /etc/apt/sources.list.d/debian-backports.list
       - run: apt-get update -y
-      - run: apt-get install -y g++ libsdl2-dev libbz2-dev git rpm wget smpq
-      - run: apt-get install -y -t 'stretch-backports*' cmake libsodium-dev libpng-dev
+      - run: apt-get install -y -t 'buster-backports*' cmake
+      - run: apt-get install -y g++ libsdl2-dev libbz2-dev git rpm wget smpq cmake libsodium-dev libpng-dev file
       - run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF -DCPACK=ON -DCMAKE_INSTALL_PREFIX=/usr
       - run: cmake --build build -j 2 --target package
       - store_artifacts: {path: ./build/devilutionx, destination: devilutionx_linux_x86_64}

--- a/.github/workflows/Linux_x86.yml
+++ b/.github/workflows/Linux_x86.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/Linux_x86_64_SDL1.yml
+++ b/.github/workflows/Linux_x86_64_SDL1.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -23,14 +23,14 @@ jobs:
     - name: Create Build Environment
       run: >
         sudo apt-get update &&
-        sudo apt-get install -y cmake file g++ git libfmt-dev libsdl-dev libsodium-dev libpng-dev libbz2-dev rpm smpq
+        sudo apt-get install -y cmake file g++ git libfmt-dev libsdl1.2-dev libsodium-dev libpng-dev libbz2-dev rpm smpq
 
     - name: Cache CMake build folder
       uses: actions/cache@v2
       with:
         path: build
-        key: linux-x86_64-sdl1-cmake-v4-${{ github.sha }}
-        restore-keys: linux-x86_64-sdl1-cmake-v4-
+        key: linux-x86_64-sdl1-cmake-v5-${{ github.sha }}
+        restore-keys: linux-x86_64-sdl1-cmake-v5-
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/Linux_x86_64_test.yml
+++ b/.github/workflows/Linux_x86_64_test.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Ubuntu 22.04 for all GitHub CI builds and Debian Buster for the CircleCI build.

Fixes #5655 