### PR TITLE
Bump `cmake_minimum_required` to 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.15)
 
-foreach(_policy CMP0083 CMP0092 CMP0111 CMP0126 CMP0135)
+foreach(_policy CMP0111 CMP0126 CMP0135)
   if(POLICY ${_policy})
     cmake_policy(SET ${_policy} NEW)
     set(CMAKE_POLICY_DEFAULT_${_policy} NEW)


### PR DESCRIPTION
DevilutionX already does not build on 3.13 because of libzt.

libzt uses the `TARGET_OBJECTS` generator expression with non-OBJECT libraries. This is only supported in CMake 3.15+:
https://gitlab.kitware.com/cmake/cmake/-/merge_requests/3178