### PR TITLE
Fix Friendly Fire name and description

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -271,7 +271,7 @@ bool Plr2PlrMHit(const Player &player, int p, int mindam, int maxdam, int dist, 
 {
 	Player &target = Players[p];
 
-	if (sgGameInitInfo.bFriendlyFire == 0 && player.friendlyMode)
+	if (sgGameInitInfo.bNoFriendlyFire == 0 && player.friendlyMode)
 		return false;
 
 	*blocked = false;

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -484,7 +484,7 @@ void InitGameInfo()
 	sgGameInitInfo.bRunInTown = *sgOptions.Gameplay.runInTown ? 1 : 0;
 	sgGameInitInfo.bTheoQuest = *sgOptions.Gameplay.theoQuest ? 1 : 0;
 	sgGameInitInfo.bCowQuest = *sgOptions.Gameplay.cowQuest ? 1 : 0;
-	sgGameInitInfo.bFriendlyFire = *sgOptions.Gameplay.friendlyFire ? 1 : 0;
+	sgGameInitInfo.bNoFriendlyFire = *sgOptions.Gameplay.noFriendlyFire ? 1 : 0;
 }
 
 void NetSendLoPri(int playerId, const byte *data, size_t size)

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -30,7 +30,7 @@ struct GameData {
 	uint8_t bRunInTown;
 	uint8_t bTheoQuest;
 	uint8_t bCowQuest;
-	uint8_t bFriendlyFire;
+	uint8_t bNoFriendlyFire;
 };
 
 /* @brief Contains info of running public game (for game list browsing) */

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -996,7 +996,7 @@ GameplayOptions::GameplayOptions()
     , grabInput("Grab Input", OptionEntryFlags::None, N_("Grab Input"), N_("When enabled mouse is locked to the game window."), false)
     , theoQuest("Theo Quest", OptionEntryFlags::CantChangeInGame | OptionEntryFlags::OnlyHellfire, N_("Theo Quest"), N_("Enable Little Girl quest."), false)
     , cowQuest("Cow Quest", OptionEntryFlags::CantChangeInGame | OptionEntryFlags::OnlyHellfire, N_("Cow Quest"), N_("Enable Jersey's quest. Lester the farmer is replaced by the Complete Nut."), false)
-    , friendlyFire("Friendly Fire", OptionEntryFlags::CantChangeInMultiPlayer, N_("Friendly Fire"), N_("Allow arrow/spell damage between players in multiplayer even when the friendly mode is on."), true)
+    , noFriendlyFire("No Friendly Fire", OptionEntryFlags::CantChangeInMultiPlayer, N_("No Friendly Fire"), N_("Disallow arrow/spell damage between players in multiplayer."), true)
     , testBard("Test Bard", OptionEntryFlags::CantChangeInGame, N_("Test Bard"), N_("Force the Bard character type to appear in the hero selection menu."), false)
     , testBarbarian("Test Barbarian", OptionEntryFlags::CantChangeInGame, N_("Test Barbarian"), N_("Force the Barbarian character type to appear in the hero selection menu."), false)
     , experienceBar("Experience Bar", OptionEntryFlags::None, N_("Experience Bar"), N_("Experience Bar is added to the UI at the bottom of the screen."), false)
@@ -1038,7 +1038,7 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&randomizeQuests,
 		&theoQuest,
 		&cowQuest,
-		&friendlyFire,
+		&noFriendlyFire,
 		&testBard,
 		&testBarbarian,
 		&experienceBar,

--- a/Source/options.h
+++ b/Source/options.h
@@ -528,7 +528,7 @@ struct GameplayOptions : OptionCategoryBase {
 	/** @brief Enable the cow quest. */
 	OptionEntryBoolean cowQuest;
 	/** @brief Will players still damage other players in non-PvP mode. */
-	OptionEntryBoolean friendlyFire;
+	OptionEntryBoolean noFriendlyFire;
 	/** @brief Enable the bard hero class. */
 	OptionEntryBoolean testBard;
 	/** @brief Enable the babarian hero class. */


### PR DESCRIPTION
Friendly Fire game option is backwards. When turning Friendly Fire game option to On, friendly fire in game is prevented, rather than allowed. The description is misleading as well, since it states that it allows friendly fire, even when friendly mode is enabled.

Note: The term "Friendly Fire" may be a bit misleading, which may have been the reason it got implemented this way in the first place, as one might assume it means "Firing becomes friendly, not hitting allies". The actual definition is "weapon fire coming from one's own side, especially fire that causes accidental injury or death to one's own forces."

As the default in Diablo is that friendly fire is allowed to happen, the game option should be "No Friendly Fire" or "Disable Friendly Fire", which can be changed to Yes to prevent friendly fire from happening. If the game options remains as "Friendly Fire", the default option would have to be Yes to match the default Diablo behavior. I believe changing it to No Friendly Fire would be the optimal option as No seems to be the default for most options to match vanilla behavior.