### PR TITLE
Audio: Avoid creating same-rate resamplers

### DIFF
--- a/Source/storm/storm_svid.cpp
+++ b/Source/storm/storm_svid.cpp
@@ -260,7 +260,7 @@ bool SVidPlayBegin(const char *filename, int flags)
 		SVidAudioBuffer = std::unique_ptr<int16_t[]> { new int16_t[audioInfo.idealBufferSize] };
 		auto decoder = std::make_unique<PushAulibDecoder>(audioInfo.nChannels, audioInfo.sampleRate);
 		SVidAudioDecoder = decoder.get();
-		SVidAudioStream.emplace(/*rwops=*/nullptr, std::move(decoder), CreateAulibResampler(), /*closeRw=*/false);
+		SVidAudioStream.emplace(/*rwops=*/nullptr, std::move(decoder), CreateAulibResampler(audioInfo.sampleRate), /*closeRw=*/false);
 		const float volume = static_cast<float>(*sgOptions.Audio.soundVolume - VOLUME_MIN) / -VOLUME_MIN;
 		SVidAudioStream->setVolume(volume);
 		if (!diablo_is_focused())

--- a/Source/utils/aulib.hpp
+++ b/Source/utils/aulib.hpp
@@ -17,8 +17,10 @@
 
 namespace devilution {
 
-inline std::unique_ptr<Aulib::Resampler> CreateAulibResampler()
+inline std::unique_ptr<Aulib::Resampler> CreateAulibResampler(int sourceRate)
 {
+	if (static_cast<int>(*sgOptions.Audio.sampleRate) == sourceRate)
+		return nullptr;
 	switch (*sgOptions.Audio.resampler) {
 #ifdef DEVILUTIONX_RESAMPLER_SPEEX
 	case Resampler::Speex:

--- a/Source/utils/soundsample.cpp
+++ b/Source/utils/soundsample.cpp
@@ -66,7 +66,11 @@ std::unique_ptr<Aulib::Decoder> CreateDecoder(bool isMp3)
 
 std::unique_ptr<Aulib::Stream> CreateStream(SDL_RWops *handle, bool isMp3)
 {
-	return std::make_unique<Aulib::Stream>(handle, CreateDecoder(isMp3), CreateAulibResampler(), /*closeRw=*/true);
+	auto decoder = CreateDecoder(isMp3);
+	if (!decoder->open(handle)) // open for `getRate`
+		return nullptr;
+	auto resampler = CreateAulibResampler(decoder->getRate());
+	return std::make_unique<Aulib::Stream>(handle, std::move(decoder), std::move(resampler), /*closeRw=*/true);
 }
 
 /**


### PR DESCRIPTION
Each resampler allocates an input buffer and an output buffer.

Since we create ~100 audio stream objects (1 per `sfx_MISC` effect), the memory cost of these buffers adds up.

Avoids creating a resampler when the audio sampler rate matches the output sample rate. This is mostly the case when the output sample rate is 22050.

/cc @realnc