### PR TITLE
Update libzt to include compile-time detection for ARMv8a crypto extensions

### DIFF
--- a/3rdParty/libzt/CMakeLists.txt
+++ b/3rdParty/libzt/CMakeLists.txt
@@ -5,7 +5,7 @@ set(BUILD_HOST_SELFTEST OFF)
 include(FetchContent)
 FetchContent_Declare(libzt
   GIT_REPOSITORY https://github.com/diasurgical/libzt.git
-  GIT_TAG 47e38259e9c99ba2d8e7241515fa1b56cb538c8c)
+  GIT_TAG d6c6a069a5041a3e89594c447ced3f15d77618b8)
 FetchContent_MakeAvailableExcludeFromAll(libzt)
 
 if(NOT ANDROID)


### PR DESCRIPTION
Related to #5689. I don't know if this should resolve it, but I should mention it at least.