### PR TITLE
Add item graphics to store menus

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -939,6 +939,7 @@ GraphicsOptions::GraphicsOptions()
 #endif
     , limitFPS("FPS Limiter", OptionEntryFlags::None, N_("FPS Limiter"), N_("FPS is limited to avoid high CPU load. Limit considers refresh rate."), true)
     , showFPS("Show FPS", OptionEntryFlags::None, N_("Show FPS"), N_("Displays the FPS in the upper left corner of the screen."), false)
+    , showItemGraphicsInStores("Show Item Graphics in Stores", OptionEntryFlags::None, N_("Show Item Graphics in Stores"), N_("Show item graphics to the left of item desriptions in store menus."), false)
     , showHealthValues("Show health values", OptionEntryFlags::None, N_("Show health values"), N_("Displays current / max health value on health globe."), false)
     , showManaValues("Show mana values", OptionEntryFlags::None, N_("Show mana values"), N_("Displays current / max mana value on mana globe."), false)
 {
@@ -976,6 +977,7 @@ std::vector<OptionEntryBase *> GraphicsOptions::GetEntries()
 		&zoom,
 		&limitFPS,
 		&showFPS,
+		&showItemGraphicsInStores,
 		&showHealthValues,
 		&showManaValues,
 		&colorCycling,

--- a/Source/options.h
+++ b/Source/options.h
@@ -505,6 +505,8 @@ struct GraphicsOptions : OptionCategoryBase {
 #endif
 	/** @brief Enable FPS Limiter. */
 	OptionEntryBoolean limitFPS;
+	/** @brief Show item graphics to the left of item desriptions in store menus. */
+	OptionEntryBoolean showItemGraphicsInStores;
 	/** @brief Show FPS, even without the -f command line flag. */
 	OptionEntryBoolean showFPS;
 	/** @brief Display current/max health values on health globe. */

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2288,7 +2288,7 @@ void PrintSString(const Surface &out, int margin, int line, string_view text, Ui
 	const int halfCursWidth = cursWidth / 2;
 	const int halfCursHeight = cursHeight / 2;
 
-	if (cursId >= 0) {
+	if (*sgOptions.Graphics.showItemGraphicsInStores && cursId >= 0) {
 		const ClxSprite itemSprite = GetInvItemSprite(static_cast<int>(CURSOR_FIRSTITEM) + cursId);
 		const OwnedSurface itemSurface(itemSprite.width(), itemSprite.height());
 		SDL_FillRect(itemSurface.surface, nullptr, 1);
@@ -2302,7 +2302,7 @@ void PrintSString(const Surface &out, int margin, int line, string_view text, Ui
 		ClxDraw(out, rect.position + spriteOffset, halfSprite[0]);
 	}
 
-	if (cursIndent) {
+	if (*sgOptions.Graphics.showItemGraphicsInStores && cursIndent) {
 		const Rectangle textRect { { rect.position.x + halfCursWidth + 8, rect.position.y }, { rect.size.width - halfCursWidth + 8, rect.size.height } };
 		DrawString(out, text, textRect, flags);
 	} else {

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -86,7 +86,7 @@ void SetupTownStores();
 
 void FreeStoreMem();
 
-void PrintSString(const Surface &out, int margin, int line, string_view text, UiFlags flags, int price = 0);
+void PrintSString(const Surface &out, int margin, int line, string_view text, UiFlags flags, int price = 0, int cursId = -1, bool cursIndent = false);
 void DrawSLine(const Surface &out, int sy);
 void DrawSTextHelp();
 void ClearSText(int s, int e);

--- a/Source/utils/sdl_bilinear_scale.hpp
+++ b/Source/utils/sdl_bilinear_scale.hpp
@@ -16,4 +16,10 @@ namespace devilution {
  */
 void BilinearScale32(SDL_Surface *src, SDL_Surface *dst);
 
+/**
+ * @brief Streamlined bilinear downscaling using blended transparency table.
+ * Requires `src` and `dst` to have the same pixel format (INDEX8).
+ */
+void BilinearDownscaleByHalf8(SDL_Surface *src, const uint8_t (*paletteBlendingTable)[256], SDL_Surface *dst, uint8_t transparentIndex);
+
 } // namespace devilution


### PR DESCRIPTION
Adds item graphics to the store menu, based on mockups posted in #1359.

![image](https://user-images.githubusercontent.com/9203145/213886403-5b4300f6-d1c0-405c-b104-7d8971716204.png)

Graphics are downscaled by half to fit in the available space to the left of the item description. The `BilinearDownscaleByHalf8()` function was provided courtesy of @glebm. I had to modify it a bit to handle transparency.

This resolves #1359.