### PR TITLE
Add used acids2.wav back to game

### DIFF
--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -107,6 +107,7 @@ TSFX sgSFX[] = {
 /*IS_CAST8*/      { sfx_MISC,                  "sfx\\misc\\cast8.wav",        nullptr },
 /*IS_REPAIR*/     { sfx_MISC,                  "sfx\\misc\\repair.wav",       nullptr },
 /*LS_ACID*/       { sfx_MISC,                  "sfx\\misc\\acids1.wav",       nullptr },
+/*LS_ACIDS*/      { sfx_MISC,                  "sfx\\misc\\acids2.wav",       nullptr },
 /*LS_APOC*/       { sfx_MISC,                  "sfx\\misc\\apoc.wav",         nullptr },
 /*LS_BLODSTAR*/   { sfx_MISC,                  "sfx\\misc\\blodstar.wav",     nullptr },
 /*LS_BLSIMPT*/    { sfx_MISC,                  "sfx\\misc\\blsimpt.wav",      nullptr },

--- a/Source/effects.h
+++ b/Source/effects.h
@@ -194,6 +194,7 @@ enum _sfx_id : int16_t {
 	IS_CAST8,
 	IS_REPAIR,
 	LS_ACID,
+	LS_ACIDS,
 	LS_APOC,
 	LS_BLODSTAR,
 	LS_BLSIMPT,


### PR DESCRIPTION
Reintroduce `LS_ACIDS`/`acids2.wav` that was removed in #5692.

When `LS_ACID` is called [`RndSFX`](https://github.com/diasurgical/devilutionX/blob/55dc2315bc195928cddc8fc13f144e6adc7742f2/Source/effects.cpp#L1033) can increase it's index by 1.
Before #5692 it was `LS_ACIDS` after it is `LS_APOC`.
That means `LS_ACIDS` is still used but it wasn't quite obvious.