### PR TITLE
Recalculate cursor position after level change

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -747,8 +747,6 @@ void GameEventHandler(const SDL_Event &event, uint16_t modState)
 			nthread_ignore_mutex(true);
 			PaletteFadeOut(8);
 			sound_stop();
-			LastMouseButtonAction = MouseActionType::None;
-			sgbMouseDown = CLICK_NONE;
 			ShowProgress(GetCustomEvent(event.type));
 
 			RedrawEverything();
@@ -2923,12 +2921,12 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 
 	CompleteProgress();
 
-	// Reset mouse selection of entities
-	pcursmonst = -1;
-	ObjectUnderCursor = nullptr;
-	pcursitem = -1;
-	pcursinvitem = -1;
-	pcursplr = -1;
+	// Recalculate mouse selection of entities after level change/load
+	LastMouseButtonAction = MouseActionType::None;
+	sgbMouseDown = CLICK_NONE;
+	ResetItemlabelHighlighted(); // level changed => item changed
+	pcursmonst = -1;             // ensure pcurstemp is set to a valid value
+	CheckCursMove();
 }
 
 bool game_loop(bool bStartup)

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -83,6 +83,11 @@ bool IsItemLabelHighlighted()
 	return isLabelHighlighted;
 }
 
+void ResetItemlabelHighlighted()
+{
+	isLabelHighlighted = false;
+}
+
 bool IsHighlightingLabelsEnabled()
 {
 	return altPressed != *sgOptions.Gameplay.showItemLabels;

--- a/Source/qol/itemlabels.h
+++ b/Source/qol/itemlabels.h
@@ -12,6 +12,7 @@ namespace devilution {
 void ToggleItemLabelHighlight();
 void AltPressed(bool pressed);
 bool IsItemLabelHighlighted();
+void ResetItemlabelHighlighted();
 bool IsHighlightingLabelsEnabled();
 void AddItemToLabelQueue(int id, Point position);
 void DrawItemNameLabels(const Surface &out);


### PR DESCRIPTION
Fixes #5571

How does the bug happen:
1. Player initializes level transition
2. Player clicks right mouse button
3. New level is loaded. First game loop is processed.
4. `HandleMessage` is called. It sees the right mouse click sdl event and adds `CMD_SPELLXY` Message. Here are the old coordinates used (`cursPosition`). The coordinates get updated in `ProcessInput` that is called after `HandleMessage`.

With this pr `CheckCursMove` is called after every level change/load and before the normal game loop runs.
This ensures that that all cursor related information are initialized correctly.
`ResetItemlabelHighlighted` and `sgbMouseDown` must be called so that `CheckCursMove` always calculates a new value (even if previous a item was selected or the player locked on a target).

Alternative fixes:
- Discard all messages after level change (`HandleMessage` don't add new commands).
- Call `ProcessInput`/`CheckCursMove` before `HandleMessage`.