### PR TITLE
Store graphics: Scale sprites only once

### DIFF
--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -67,6 +67,10 @@ void DrawItem(const Item &item, const Surface &out, Point position, ClxSprite cl
 /** Returns the sprite for the given inventory index. */
 ClxSprite GetInvItemSprite(int cursId);
 
+ClxSprite GetHalfSizeItemSprite(int cursId);
+void CreateHalfSizeItemSprites();
+void FreeHalfSizeItemSprites();
+
 /** Returns the width and height for an inventory index. */
 Size GetInvItemSize(int cursId);
 


### PR DESCRIPTION
Prepare downscaled sprites once instead of doing it on every frame.

Note that we do this lazily in `StartStore` rather than `SetupTownStores` because we need the palette blending table to be available when downscaling.