### PR TITLE
Disable item labels when in store

### DIFF
--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -650,7 +650,7 @@ void DrawItem(const Surface &out, Point tilePosition, Point targetBufferPosition
 	const ClxSprite sprite = item.AnimInfo.currentSprite();
 	int px = targetBufferPosition.x - CalculateWidth2(sprite.width());
 	const Point position { px, targetBufferPosition.y };
-	if (bItem - 1 == pcursitem || AutoMapShowItems) {
+	if (stextflag == STORE_NONE && (bItem - 1 == pcursitem || AutoMapShowItems)) {
 		ClxDrawOutlineSkipColorZero(out, GetOutlineColor(item, false), position, sprite);
 	}
 	ClxDrawLight(out, position, sprite);

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -15,6 +15,7 @@
 #include "inv.h"
 #include "options.h"
 #include "qol/stash.h"
+#include "stores.h"
 #include "utils/format_int.hpp"
 #include "utils/language.h"
 #include "utils/stdcompat/string_view.hpp"
@@ -85,7 +86,7 @@ bool IsItemLabelHighlighted()
 
 bool IsHighlightingLabelsEnabled()
 {
-	return altPressed != *sgOptions.Gameplay.showItemLabels;
+	return stextflag == STORE_NONE && altPressed != *sgOptions.Gameplay.showItemLabels;
 }
 
 void AddItemToLabelQueue(int id, Point position)
@@ -181,13 +182,18 @@ void DrawItemNameLabels(const Surface &out)
 		Item &item = Items[label.id];
 
 		if (MousePosition.x >= label.pos.x && MousePosition.x < label.pos.x + label.width && MousePosition.y >= label.pos.y + MarginY && MousePosition.y < label.pos.y + MarginY + Height) {
-			if (!gmenu_is_active() && PauseMode == 0 && !MyPlayerIsDead && IsMouseOverGameArea() && LastMouseButtonAction == MouseActionType::None) {
+			if (!gmenu_is_active()
+			    && PauseMode == 0
+			    && !MyPlayerIsDead
+			    && stextflag == STORE_NONE
+			    && IsMouseOverGameArea()
+			    && LastMouseButtonAction == MouseActionType::None) {
 				isLabelHighlighted = true;
 				cursPosition = item.position;
 				pcursitem = label.id;
 			}
 		}
-		if (pcursitem == label.id)
+		if (pcursitem == label.id && stextflag == STORE_NONE)
 			FillRect(clippedOut, label.pos.x, label.pos.y + MarginY, label.width, Height, PAL8_BLUE + 6);
 		else
 			DrawHalfTransparentRectTo(clippedOut, label.pos.x, label.pos.y + MarginY, label.width, Height);


### PR DESCRIPTION
Before:
![store-before](https://user-images.githubusercontent.com/216339/213921220-d43c19c5-d48e-492a-a012-61ad5a91b214.png)

After:
![Screenshot from 2023-01-22 14-30-43](https://user-images.githubusercontent.com/216339/213921227-f316d31e-45d6-4cfe-8b93-5c59d39908c4.png)

Also disable ground item outlines on hover when in store.
