### PR TITLE
Store items: Draw unusable items in red

### DIFF
--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -113,6 +113,7 @@ const uint16_t InvItemHeight2[InvItems2Size] = {
 
 constexpr size_t NumInvItems = InvItems1Size + InvItems2Size - static_cast<size_t>(CURSOR_FIRSTITEM);
 StaticVector<OwnedClxSpriteList, NumInvItems> *HalfSizeItemSprites;
+StaticVector<OwnedClxSpriteList, NumInvItems> *HalfSizeItemSpritesRed;
 
 } // namespace
 
@@ -177,11 +178,18 @@ ClxSprite GetHalfSizeItemSprite(int cursId)
 	return (*HalfSizeItemSprites)[cursId][0];
 }
 
+ClxSprite GetHalfSizeItemSpriteRed(int cursId)
+{
+	return (*HalfSizeItemSpritesRed)[cursId][0];
+}
+
 void CreateHalfSizeItemSprites()
 {
 	if (HalfSizeItemSprites != nullptr)
 		return;
 	HalfSizeItemSprites = new StaticVector<OwnedClxSpriteList, NumInvItems>;
+	HalfSizeItemSpritesRed = new StaticVector<OwnedClxSpriteList, NumInvItems>;
+	const uint8_t *redTrn = GetInfravisionTRN();
 	for (size_t i = 0; i < NumInvItems; ++i) {
 		const ClxSprite itemSprite = GetInvItemSprite(static_cast<int>(CURSOR_FIRSTITEM) + static_cast<int>(i));
 		const OwnedSurface itemSurface(itemSprite.width(), itemSprite.height());
@@ -191,6 +199,11 @@ void CreateHalfSizeItemSprites()
 		const OwnedSurface halfSurface(itemSurface.w() / 2, itemSurface.h() / 2);
 		BilinearDownscaleByHalf8(itemSurface.surface, paletteTransparencyLookup, halfSurface.surface, 1);
 		HalfSizeItemSprites->emplace_back(SurfaceToClx(halfSurface, 1, 1));
+
+		SDL_FillRect(itemSurface.surface, nullptr, 1);
+		ClxDrawTRN(itemSurface, { 0, itemSurface.h() }, itemSprite, redTrn);
+		BilinearDownscaleByHalf8(itemSurface.surface, paletteTransparencyLookup, halfSurface.surface, 1);
+		HalfSizeItemSpritesRed->emplace_back(SurfaceToClx(halfSurface, 1, 1));
 	}
 }
 
@@ -199,6 +212,8 @@ void FreeHalfSizeItemSprites()
 	if (HalfSizeItemSprites != nullptr) {
 		delete HalfSizeItemSprites;
 		HalfSizeItemSprites = nullptr;
+		delete HalfSizeItemSpritesRed;
+		HalfSizeItemSpritesRed = nullptr;
 	}
 }
 

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -68,6 +68,7 @@ void DrawItem(const Item &item, const Surface &out, Point position, ClxSprite cl
 ClxSprite GetInvItemSprite(int cursId);
 
 ClxSprite GetHalfSizeItemSprite(int cursId);
+ClxSprite GetHalfSizeItemSpriteRed(int cursId);
 void CreateHalfSizeItemSprites();
 void FreeHalfSizeItemSprites();
 

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -16,6 +16,7 @@
 #include "engine/random.hpp"
 #include "engine/render/clx_render.hpp"
 #include "engine/render/text_render.hpp"
+#include "engine/trn.hpp"
 #include "init.h"
 #include "minitext.h"
 #include "options.h"
@@ -2288,11 +2289,14 @@ void PrintSString(const Surface &out, int margin, int line, string_view text, Ui
 	const int halfCursWidth = cursWidth / 2;
 
 	if (*sgOptions.Graphics.showItemGraphicsInStores && cursId >= 0) {
-		const ClxSprite halfSprite = GetHalfSizeItemSprite(cursId);
-		ClxDraw(out,
-		    { rect.position.x + (halfCursWidth - halfSprite.width()) / 2,
-		        rect.position.y + (TextHeight() * 3 + halfSprite.height()) / 2 },
-		    halfSprite);
+		const ClxSprite halfSprite = HasAnyOf(flags, UiFlags::ColorRed)
+		    ? GetHalfSizeItemSpriteRed(cursId)
+		    : GetHalfSizeItemSprite(cursId);
+		const Point position {
+			rect.position.x + (halfCursWidth - halfSprite.width()) / 2,
+			rect.position.y + (TextHeight() * 3 + halfSprite.height()) / 2
+		};
+		ClxDraw(out, position, halfSprite);
 	}
 
 	if (*sgOptions.Graphics.showItemGraphicsInStores && cursIndent) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/216339/213926135-5c2da60b-4574-49d6-bc03-8ed06c5b07d4.png)

We generate separate downscaled sprites for the red versions because simply applying TRN after downscaling leads to some non-red pixels (because of blending during downscaling).