### PR TITLE
`CreateHalfSizeItemSprites`: Reuse surfaces

### DIFF
--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -191,12 +191,21 @@ void CreateHalfSizeItemSprites()
 	HalfSizeItemSpritesRed = new StaticVector<OwnedClxSpriteList, NumInvItems>;
 	const uint8_t *redTrn = GetInfravisionTRN();
 
-	const auto createHalfSize = [redTrn](const ClxSprite itemSprite) {
-		const OwnedSurface itemSurface(itemSprite.width(), itemSprite.height());
+	constexpr int MaxWidth = 28 * 3;
+	constexpr int MaxHeight = 28 * 3;
+	OwnedSurface ownedItemSurface { MaxWidth, MaxHeight };
+	OwnedSurface ownedHalfSurface { MaxWidth / 2, MaxHeight / 2 };
+
+	const auto createHalfSize = [&, redTrn](const ClxSprite itemSprite) {
+		const Surface itemSurface = ownedItemSurface.subregion(0, 0, itemSprite.width(), itemSprite.height());
+		SDL_Rect itemSurfaceRect = MakeSdlRect(0, 0, itemSurface.w(), itemSurface.h());
+		SDL_SetClipRect(itemSurface.surface, &itemSurfaceRect);
 		SDL_FillRect(itemSurface.surface, nullptr, 1);
 		ClxDraw(itemSurface, { 0, itemSurface.h() }, itemSprite);
 
-		const OwnedSurface halfSurface(itemSurface.w() / 2, itemSurface.h() / 2);
+		const Surface halfSurface = ownedHalfSurface.subregion(0, 0, itemSurface.w() / 2, itemSurface.h() / 2);
+		SDL_Rect halfSurfaceRect = MakeSdlRect(0, 0, halfSurface.w(), halfSurface.h());
+		SDL_SetClipRect(halfSurface.surface, &halfSurfaceRect);
 		BilinearDownscaleByHalf8(itemSurface.surface, paletteTransparencyLookup, halfSurface.surface, 1);
 		HalfSizeItemSprites->emplace_back(SurfaceToClx(halfSurface, 1, 1));
 

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -29,7 +29,6 @@
 #include "utils/attributes.h"
 #include "utils/language.h"
 #include "utils/sdl_bilinear_scale.hpp"
-#include "utils/static_vector.hpp"
 #include "utils/surface_to_clx.hpp"
 #include "utils/utf8.hpp"
 
@@ -111,9 +110,8 @@ const uint16_t InvItemHeight2[InvItems2Size] = {
 	// clang-format on
 };
 
-constexpr size_t NumInvItems = InvItems1Size + InvItems2Size - (static_cast<size_t>(CURSOR_FIRSTITEM) - 1);
-StaticVector<OwnedClxSpriteList, NumInvItems> *HalfSizeItemSprites;
-StaticVector<OwnedClxSpriteList, NumInvItems> *HalfSizeItemSpritesRed;
+OptionalOwnedClxSpriteList *HalfSizeItemSprites;
+OptionalOwnedClxSpriteList *HalfSizeItemSpritesRed;
 
 } // namespace
 
@@ -175,20 +173,23 @@ Size GetInvItemSize(int cursId)
 
 ClxSprite GetHalfSizeItemSprite(int cursId)
 {
-	return (*HalfSizeItemSprites)[cursId][0];
+	return (*HalfSizeItemSprites[cursId])[0];
 }
 
 ClxSprite GetHalfSizeItemSpriteRed(int cursId)
 {
-	return (*HalfSizeItemSpritesRed)[cursId][0];
+	return (*HalfSizeItemSpritesRed[cursId])[0];
 }
 
 void CreateHalfSizeItemSprites()
 {
 	if (HalfSizeItemSprites != nullptr)
 		return;
-	HalfSizeItemSprites = new StaticVector<OwnedClxSpriteList, NumInvItems>;
-	HalfSizeItemSpritesRed = new StaticVector<OwnedClxSpriteList, NumInvItems>;
+	const int numInvItems = gbIsHellfire
+	    ? InvItems1Size + InvItems2Size - (static_cast<size_t>(CURSOR_FIRSTITEM) - 1)
+	    : InvItems1Size + (static_cast<size_t>(CURSOR_FIRSTITEM) - 1);
+	HalfSizeItemSprites = new OptionalOwnedClxSpriteList[numInvItems];
+	HalfSizeItemSpritesRed = new OptionalOwnedClxSpriteList[numInvItems];
 	const uint8_t *redTrn = GetInfravisionTRN();
 
 	constexpr int MaxWidth = 28 * 3;
@@ -196,7 +197,11 @@ void CreateHalfSizeItemSprites()
 	OwnedSurface ownedItemSurface { MaxWidth, MaxHeight };
 	OwnedSurface ownedHalfSurface { MaxWidth / 2, MaxHeight / 2 };
 
-	const auto createHalfSize = [&, redTrn](const ClxSprite itemSprite) {
+	const auto createHalfSize = [&, redTrn](const ClxSprite itemSprite, size_t outputIndex) {
+		if (itemSprite.width() <= 28 && itemSprite.height() <= 28) {
+			// Skip creating half-size sprites for 1x1 items because we always render them at full size anyway.
+			return;
+		}
 		const Surface itemSurface = ownedItemSurface.subregion(0, 0, itemSprite.width(), itemSprite.height());
 		SDL_Rect itemSurfaceRect = MakeSdlRect(0, 0, itemSurface.w(), itemSurface.h());
 		SDL_SetClipRect(itemSurface.surface, &itemSurfaceRect);
@@ -207,20 +212,21 @@ void CreateHalfSizeItemSprites()
 		SDL_Rect halfSurfaceRect = MakeSdlRect(0, 0, halfSurface.w(), halfSurface.h());
 		SDL_SetClipRect(halfSurface.surface, &halfSurfaceRect);
 		BilinearDownscaleByHalf8(itemSurface.surface, paletteTransparencyLookup, halfSurface.surface, 1);
-		HalfSizeItemSprites->emplace_back(SurfaceToClx(halfSurface, 1, 1));
+		HalfSizeItemSprites[outputIndex].emplace(SurfaceToClx(halfSurface, 1, 1));
 
 		SDL_FillRect(itemSurface.surface, nullptr, 1);
 		ClxDrawTRN(itemSurface, { 0, itemSurface.h() }, itemSprite, redTrn);
 		BilinearDownscaleByHalf8(itemSurface.surface, paletteTransparencyLookup, halfSurface.surface, 1);
-		HalfSizeItemSpritesRed->emplace_back(SurfaceToClx(halfSurface, 1, 1));
+		HalfSizeItemSpritesRed[outputIndex].emplace(SurfaceToClx(halfSurface, 1, 1));
 	};
 
-	for (size_t i = static_cast<int>(CURSOR_FIRSTITEM) - 1; i < InvItems1Size; ++i) {
-		createHalfSize((*pCursCels)[i]);
+	size_t outputIndex = 0;
+	for (size_t i = static_cast<int>(CURSOR_FIRSTITEM) - 1; i < InvItems1Size; ++i, ++outputIndex) {
+		createHalfSize((*pCursCels)[i], outputIndex);
 	}
 	if (gbIsHellfire) {
-		for (size_t i = 0; i < InvItems2Size; ++i) {
-			createHalfSize((*pCursCels2)[i]);
+		for (size_t i = 0; i < InvItems2Size; ++i, ++outputIndex) {
+			createHalfSize((*pCursCels2)[i], outputIndex);
 		}
 	}
 }
@@ -228,9 +234,9 @@ void CreateHalfSizeItemSprites()
 void FreeHalfSizeItemSprites()
 {
 	if (HalfSizeItemSprites != nullptr) {
-		delete HalfSizeItemSprites;
+		delete[] HalfSizeItemSprites;
 		HalfSizeItemSprites = nullptr;
-		delete HalfSizeItemSpritesRed;
+		delete[] HalfSizeItemSpritesRed;
 		HalfSizeItemSpritesRed = nullptr;
 	}
 }

--- a/Source/utils/sdl_bilinear_scale.cpp
+++ b/Source/utils/sdl_bilinear_scale.cpp
@@ -148,12 +148,16 @@ void BilinearScale32(SDL_Surface *src, SDL_Surface *dst)
 	}
 }
 
-void BilinearDownscaleByHalf8(SDL_Surface *src, const uint8_t (*paletteBlendingTable)[256], SDL_Surface *dst, uint8_t transparentIndex)
+void BilinearDownscaleByHalf8(const SDL_Surface *src, const uint8_t (*paletteBlendingTable)[256], SDL_Surface *dst, uint8_t transparentIndex)
 {
-	for (unsigned y = 0; y < static_cast<unsigned>(dst->h); ++y) {
-		auto *srcPixels = static_cast<uint8_t *>(src->pixels) + 2 * y * src->pitch;
-		auto *dstPixels = static_cast<uint8_t *>(dst->pixels) + y * dst->pitch;
-		for (unsigned x = 0; x < static_cast<unsigned>(dst->w); ++x) {
+	const auto *const srcPixelsBegin = static_cast<const uint8_t *>(src->pixels)
+	    + static_cast<size_t>(src->clip_rect.y * src->pitch + src->clip_rect.x);
+	auto *const dstPixelsBegin = static_cast<uint8_t *>(dst->pixels)
+	    + static_cast<size_t>(dst->clip_rect.y * dst->pitch + dst->clip_rect.x);
+	for (unsigned y = 0, h = static_cast<unsigned>(dst->clip_rect.h); y < h; ++y) {
+		const uint8_t *srcPixels = srcPixelsBegin + static_cast<size_t>(2 * y * src->pitch);
+		uint8_t *dstPixels = dstPixelsBegin + static_cast<size_t>(y * dst->pitch);
+		for (unsigned x = 0, w = static_cast<unsigned>(dst->clip_rect.w); x < w; ++x) {
 			uint8_t quad[] = {
 				srcPixels[0],
 				srcPixels[1],

--- a/Source/utils/sdl_bilinear_scale.hpp
+++ b/Source/utils/sdl_bilinear_scale.hpp
@@ -20,6 +20,6 @@ void BilinearScale32(SDL_Surface *src, SDL_Surface *dst);
  * @brief Streamlined bilinear downscaling using blended transparency table.
  * Requires `src` and `dst` to have the same pixel format (INDEX8).
  */
-void BilinearDownscaleByHalf8(SDL_Surface *src, const uint8_t (*paletteBlendingTable)[256], SDL_Surface *dst, uint8_t transparentIndex);
+void BilinearDownscaleByHalf8(const SDL_Surface *src, const uint8_t (*paletteBlendingTable)[256], SDL_Surface *dst, uint8_t transparentIndex);
 
 } // namespace devilution


### PR DESCRIPTION
Rather than allocating surfaces on every loop iteration, reuse the same 2 surfaces.

Also skips creating half-size sprites for 1x1 items.

All of the half-sprite data takes about 140 KiB (not a big deal in town, which uses less memory to begin with).