### PR TITLE
Use PROJECT_SOURCE_DIR instead of referencing the project name

### DIFF
--- a/CMake/functions/devilutionx_library.cmake
+++ b/CMake/functions/devilutionx_library.cmake
@@ -6,7 +6,7 @@ include(functions/set_relative_file_macro)
 function(add_devilutionx_library NAME)
   add_library(${NAME} ${ARGN})
 
-  target_include_directories(${NAME} PUBLIC ${DevilutionX_SOURCE_DIR}/Source)
+  target_include_directories(${NAME} PUBLIC ${PROJECT_SOURCE_DIR}/Source)
 
   target_compile_definitions(${NAME} PUBLIC ${DEVILUTIONX_PLATFORM_COMPILE_DEFINITIONS})
   target_compile_options(${NAME} PUBLIC ${DEVILUTIONX_PLATFORM_COMPILE_OPTIONS})


### PR DESCRIPTION
Assuming CI passes, this should help modders who want to change their project name in `CMakeLists.txt`.