### PR TITLE
rg99: add -fdevirtualize-at-ltrans

### DIFF
--- a/CMake/platforms/rg99.cmake
+++ b/CMake/platforms/rg99.cmake
@@ -12,8 +12,8 @@ set(DEVILUTIONX_STATIC_CXX_STDLIB OFF)
 
 # -fmerge-all-constants saves ~4 KiB
 # -fsection-anchors saves ~4 KiB
-# -fipa-pta improves performance.
-set(_extra_flags "-fmerge-all-constants -fsection-anchors -fipa-pta")
+# -fipa-pta and -fdevirtualize-at-ltrans improves performance.
+set(_extra_flags "-fmerge-all-constants -fsection-anchors -fipa-pta -fdevirtualize-at-ltrans")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_extra_flags}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_extra_flags}")
 # -Wl,-z-stack-size: the default thread stack size for RG99 is 128 KiB, reduce it.


### PR DESCRIPTION
Another option that improves performance. From GCC documentation:

> Stream extra information needed for aggressive devirtualization when running the link-time optimizer in local transformation mode. This option enables more devirtualization but significantly increases the size of streamed data. For this reason it is disabled by default.