### PR TITLE
Remove "Zen" hit recovery

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2921,10 +2921,7 @@ void StartPlrHit(Player &player, int dam, bool forcehit)
 	Direction pd = player._pdir;
 
 	int8_t skippedAnimationFrames = 0;
-	constexpr ItemSpecialEffect ZenFlags = ItemSpecialEffect::FastHitRecovery | ItemSpecialEffect::FasterHitRecovery | ItemSpecialEffect::FastestHitRecovery;
-	if (HasAllOf(player._pIFlags, ZenFlags)) { // if multiple hitrecovery modes are present the skipping of frames can go so far, that they skip frames that would skip. so the additional skipping thats skipped. that means we can't add the different modes together.
-		skippedAnimationFrames = 4;
-	} else if (HasAnyOf(player._pIFlags, ItemSpecialEffect::FastestHitRecovery)) {
+	if (HasAnyOf(player._pIFlags, ItemSpecialEffect::FastestHitRecovery)) {
 		skippedAnimationFrames = 3;
 	} else if (HasAnyOf(player._pIFlags, ItemSpecialEffect::FasterHitRecovery)) {
 		skippedAnimationFrames = 2;

--- a/test/animationinfo_test.cpp
+++ b/test/animationinfo_test.cpp
@@ -408,6 +408,38 @@ TEST(AnimationInfo, BlockingSorcererWithFastBlock) // Skipped frames and ignored
 	    });
 }
 
+TEST(AnimationInfo, HitRecoverySorcererHarmony) // Skipped frames and ignored delay for last Frame should be considered by distribution logic
+{
+	RunAnimationTest(
+	    {
+	        new SetNewAnimationData(8, 1, AnimationDistributionFlags::None, 3),
+	        new RenderingData(0.0f, 0),
+	        new RenderingData(0.3f, 0),
+	        new RenderingData(0.6f, 0),
+	        new RenderingData(0.8f, 1),
+	        new GameTickData(4, 0),
+	        new RenderingData(0.0f, 1),
+	        new RenderingData(0.3f, 2),
+	        new RenderingData(0.6f, 2),
+	        new RenderingData(0.8f, 2),
+	        new GameTickData(5, 0),
+	        new RenderingData(0.0f, 3),
+	        new RenderingData(0.3f, 3),
+	        new RenderingData(0.6f, 4),
+	        new RenderingData(0.8f, 4),
+	        new GameTickData(6, 0),
+	        new RenderingData(0.0f, 4),
+	        new RenderingData(0.3f, 5),
+	        new RenderingData(0.6f, 5),
+	        new RenderingData(0.8f, 6),
+	        new GameTickData(7, 0),
+	        new RenderingData(0.0f, 6),
+	        new RenderingData(0.3f, 6),
+	        new RenderingData(0.6f, 7),
+	        new RenderingData(0.8f, 7),
+	        // Animation stopped cause PM_DoGotHit would stop the Animation "if (plr[pnum].AnimInfo.currentFrame >= plr[pnum]._pHFrames) {"
+	    });
+}
 TEST(AnimationInfo, Stand) // Distribution Logic shouldn't change anything here
 {
 	RunAnimationTest(

--- a/test/animationinfo_test.cpp
+++ b/test/animationinfo_test.cpp
@@ -408,6 +408,33 @@ TEST(AnimationInfo, BlockingSorcererWithFastBlock) // Skipped frames and ignored
 	    });
 }
 
+TEST(AnimationInfo, HitRecoverySorcererZenMode) // Skipped frames and ignored delay for last Frame should be considered by distribution logic
+{
+	RunAnimationTest(
+	    {
+	        new SetNewAnimationData(8, 1, AnimationDistributionFlags::None, 4),
+	        new RenderingData(0.0f, 0),
+	        new RenderingData(0.3f, 0),
+	        new RenderingData(0.6f, 1),
+	        new RenderingData(0.8f, 1),
+	        new GameTickData(5, 0),
+	        new RenderingData(0.0f, 2),
+	        new RenderingData(0.3f, 2),
+	        new RenderingData(0.6f, 3),
+	        new RenderingData(0.8f, 3),
+	        new GameTickData(6, 0),
+	        new RenderingData(0.0f, 4),
+	        new RenderingData(0.3f, 4),
+	        new RenderingData(0.6f, 5),
+	        new RenderingData(0.8f, 5),
+	        new GameTickData(7, 0),
+	        new RenderingData(0.0f, 6),
+	        new RenderingData(0.3f, 6),
+	        new RenderingData(0.6f, 7),
+	        new RenderingData(0.8f, 7),
+	        // Animation stopped cause PM_DoGotHit would stop the Animation "if (plr[pnum].AnimInfo.currentFrame >= plr[pnum]._pHFrames) {"
+	    });
+}
 TEST(AnimationInfo, Stand) // Distribution Logic shouldn't change anything here
 {
 	RunAnimationTest(

--- a/test/animationinfo_test.cpp
+++ b/test/animationinfo_test.cpp
@@ -408,33 +408,6 @@ TEST(AnimationInfo, BlockingSorcererWithFastBlock) // Skipped frames and ignored
 	    });
 }
 
-TEST(AnimationInfo, HitRecoverySorcererZenMode) // Skipped frames and ignored delay for last Frame should be considered by distribution logic
-{
-	RunAnimationTest(
-	    {
-	        new SetNewAnimationData(8, 1, AnimationDistributionFlags::None, 4),
-	        new RenderingData(0.0f, 0),
-	        new RenderingData(0.3f, 0),
-	        new RenderingData(0.6f, 1),
-	        new RenderingData(0.8f, 1),
-	        new GameTickData(5, 0),
-	        new RenderingData(0.0f, 2),
-	        new RenderingData(0.3f, 2),
-	        new RenderingData(0.6f, 3),
-	        new RenderingData(0.8f, 3),
-	        new GameTickData(6, 0),
-	        new RenderingData(0.0f, 4),
-	        new RenderingData(0.3f, 4),
-	        new RenderingData(0.6f, 5),
-	        new RenderingData(0.8f, 5),
-	        new GameTickData(7, 0),
-	        new RenderingData(0.0f, 6),
-	        new RenderingData(0.3f, 6),
-	        new RenderingData(0.6f, 7),
-	        new RenderingData(0.8f, 7),
-	        // Animation stopped cause PM_DoGotHit would stop the Animation "if (plr[pnum].AnimInfo.currentFrame >= plr[pnum]._pHFrames) {"
-	    });
-}
 TEST(AnimationInfo, Stand) // Distribution Logic shouldn't change anything here
 {
 	RunAnimationTest(

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -34,7 +34,6 @@ constexpr ItemSpecialEffect Harmony = ItemSpecialEffect::FastestHitRecovery;
 constexpr ItemSpecialEffect BalanceStability = Balance | Stability;
 constexpr ItemSpecialEffect BalanceHarmony = Balance | Harmony;
 constexpr ItemSpecialEffect StabilityHarmony = Stability | Harmony;
-constexpr ItemSpecialEffect Zen = Balance | Stability | Harmony;
 
 constexpr int Warrior = 6;
 constexpr int Rogue = 7;
@@ -74,10 +73,6 @@ BlockTestCase BlockData[] = {
 	{ 3, Warrior, StabilityHarmony },
 	{ 4, Rogue, StabilityHarmony },
 	{ 5, Sorcerer, StabilityHarmony },
-
-	{ 2, Warrior, Zen },
-	{ 3, Rogue, Zen },
-	{ 4, Sorcerer, Zen },
 };
 
 TEST(Player, PM_DoGotHit)


### PR DESCRIPTION
I have always perceived this mechanic to be a bug or an oversight that Blizzard simply didn't need to care about.  Gameplay wise it makes no perceivable difference.  My reasoning is that the description of Harmony says "Fastest", clearly implying that this is the fastest recovery bonus that is attainable for a given character and also an indication that the bonus from these affixes is not cumulative.