### PR TITLE
Fix Guardian damage

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2035,9 +2035,6 @@ void AddGuardian(Missile &missile, AddMissileParameter &parameter)
 {
 	Player &player = Players[missile._misource];
 
-	int dmg = GenerateRnd(10) + (player._pLevel / 2) + 1;
-	missile._midam = ScaleSpellEffect(dmg, missile._mispllvl);
-
 	std::optional<Point> spawnPosition = FindClosestValidPosition(
 	    [start = missile.position.start](Point target) {
 		    if (!InDungeonBounds(target)) {
@@ -2811,6 +2808,10 @@ void MI_Firebolt(Missile &missile)
 				break;
 			case MissileID::BoneSpirit:
 				d = 0;
+				break;
+			case MissileID::Guardian:		
+				d = GenerateRnd(10) + (player._pLevel / 2) + 1;
+				missile._midam = ScaleSpellEffect(dmg, missile._mispllvl);
 				break;
 			default:
 				break;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2809,7 +2809,7 @@ void MI_Firebolt(Missile &missile)
 			case MissileID::BoneSpirit:
 				d = 0;
 				break;
-			case MissileID::Guardian:		
+			case MissileID::Guardian:
 				d = GenerateRnd(10) + (player._pLevel / 2) + 1;
 				missile._midam = ScaleSpellEffect(dmg, missile._mispllvl);
 				break;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -648,7 +648,7 @@ bool GuardianTryFireAt(Missile &missile, Point target)
 		return false;
 
 	Direction dir = GetDirection(position, target);
-	AddMissile(position, target, dir, MissileID::Firebolt, TARGET_MONSTERS, missile._misource, missile._midam, missile.sourcePlayer()->GetSpellLevel(SPL_FIREBOLT), &missile);
+	AddMissile(position, target, dir, MissileID::Firebolt, TARGET_MONSTERS, missile._misource, missile._midam, missile.sourcePlayer()->GetSpellLevel(SPL_GUARDIAN), &missile);
 	SetMissDir(missile, 2);
 	missile.var2 = 3;
 


### PR DESCRIPTION
The intended damage for the Guardian spell in the AddGuardian function is never used because it uses the function MI_Firebolt to create the missiles which have their own damage formula.