### PR TITLE
Optimize AddPlrExperience()

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2716,7 +2716,7 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 		RedrawEverything();
 	}
 
-	/* set player level to 50 if the experience value for MaxCharacterLevel is reached, which exits the function early
+	/* set player level to MaxCharacterLevel if the experience value for MaxCharacterLevel is reached, which exits the function early
 	and does not call NextPlrLevel(), which is responsible for giving Attribute points and Life/Mana on level up */
 	if (player._pExperience >= ExpLvlsTbl[MaxCharacterLevel - 1]) {
 		player._pLevel = MaxCharacterLevel;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2686,6 +2686,11 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 		return;
 	}
 
+	// exit function early if player is unable to gain more experience
+	if (player._pExperience >= ExpLvlsTbl[50]) {
+		return;
+	}
+
 	if (player._pHitPoints <= 0) {
 		return;
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2687,7 +2687,7 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 	}
 
 	// exit function early if player is unable to gain more experience
-	if (player._pExperience >= ExpLvlsTbl[50]) {
+	if (player._pExperience >= ExpLvlsTbl[MaxCharacterLevel]) {
 		return;
 	}
 
@@ -2716,8 +2716,8 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 		RedrawEverything();
 	}
 
-	if (player._pExperience >= ExpLvlsTbl[49]) {
-		player._pLevel = 50;
+	if (player._pExperience >= ExpLvlsTbl[MaxCharacterLevel - 1]) {
+		player._pLevel = MaxCharacterLevel;
 		return;
 	}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2716,6 +2716,8 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 		RedrawEverything();
 	}
 
+	/* set player level to 50 if the experience value for MaxCharacterLevel is reached, which exits the function early
+	and does not call NextPlrLevel(), which is responsible for giving Attribute points and Life/Mana on level up */
 	if (player._pExperience >= ExpLvlsTbl[MaxCharacterLevel - 1]) {
 		player._pLevel = MaxCharacterLevel;
 		return;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2686,8 +2686,9 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 		return;
 	}
 
-	// exit function early if player is unable to gain more experience
-	if (player._pExperience >= ExpLvlsTbl[-1]) {
+	// exit function early if player is unable to gain more experience by checking final index of ExpLvlsTbl
+	int expLvlsTblSize = sizeof(ExpLvlsTbl) / sizeof(ExpLvlsTbl[0]);
+	if (player._pExperience >= ExpLvlsTbl[expLvlsTblSize - 1]) {
 		return;
 	}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2687,7 +2687,7 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 	}
 
 	// exit function early if player is unable to gain more experience
-	if (player._pExperience >= ExpLvlsTbl[MaxCharacterLevel]) {
+	if (player._pExperience >= ExpLvlsTbl[-1]) {
 		return;
 	}
 


### PR DESCRIPTION
`AddPlrExperience()` is called whenever the player performs an action that would give them more experience points. This is unncessary when the player is at the hardcoded maximum already. `return` added near beginning of function, as well as some magic numbers replaced.