### PR TITLE
Don't consume mana when Mana Shield is already active

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2051,14 +2051,16 @@ void AddFlash2(Missile &missile, AddMissileParameter & /*parameter*/)
 	missile._mirange = 19;
 }
 
-void AddManashield(Missile &missile, AddMissileParameter & /*parameter*/)
+void AddManashield(Missile &missile, AddMissileParameter &parameter)
 {
 	missile._miDelFlag = true;
 
 	Player &player = Players[missile._misource];
 
-	if (player.pManaShield)
+	if (player.pManaShield) {
+		parameter.spellFizzled = true;
 		return;
+	}
 
 	player.pManaShield = true;
 	if (&player == MyPlayer)


### PR DESCRIPTION
@kphoenix137 pointed out on Discord that the Mana Shield spell didn't consume mana in Diablo 1.09 if Mana Shield was already active. This seems to have originally been implemented as a special case in `AddMissile()` which would completely skip initialization of the Mana Shield missile.

https://github.com/diasurgical/devilution/blob/50c9b533cf949e7a8e7cc61bdc539a8d60c19a4c/Source/missiles.cpp#L3598-L3609

The fact that this code was not present in Hellfire suggests that Blizzard probably added this logic in one of their patches. The 1.07 patch notes suggest that this code could have been their solution to an entirely different issue.

> Prevented repeated castings (128 or more) of Mana Shield from disabling the casting of any more spells.

Even so, it seems reasonable to have the spell fizzle if it would otherwise have no effect, like what happens with similar spells such as Stone Curse or Guardian.