### PR TITLE
Change default monster missile damage to zero

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1905,9 +1905,9 @@ void AiRanged(Monster &monster)
 			if (LineClearMissile(monster.position.tile, monster.enemyPosition)) {
 				MissileID missileType = GetMissileType(monster.ai);
 				if (monster.ai == MonsterAIID::AcidUnique)
-					StartRangedSpecialAttack(monster, missileType, 4);
+					StartRangedSpecialAttack(monster, missileType, 0);
 				else
-					StartRangedAttack(monster, missileType, 4);
+					StartRangedAttack(monster, missileType, 0);
 			} else {
 				monster.checkStandAnimationIsLoaded(md);
 			}
@@ -1931,7 +1931,7 @@ void AiRangedAvoidance(Monster &monster)
 	if (IsAnyOf(monster.ai, MonsterAIID::Magma, MonsterAIID::Storm, MonsterAIID::BoneDemon) && monster.activeForTicks < UINT8_MAX)
 		MonstCheckDoors(monster);
 	int lessmissiles = (monster.ai == MonsterAIID::Acid) ? 1 : 0;
-	int dam = (monster.ai == MonsterAIID::Diablo) ? 40 : 4;
+	int dam = (monster.ai == MonsterAIID::Diablo) ? 40 : 0;
 	MissileID missileType = GetMissileType(monster.ai);
 	int v = GenerateRnd(10000);
 	unsigned distanceToEnemy = monster.distanceToEnemy();


### PR DESCRIPTION
Recently saw a recording on Discord where a Barbarian with 50% resist in Hell/Hell was consistently receiving exactly 2 damage from every Blood Star missile. Testing reveals this was a bug, introduced by #5731. That PR interprets non-zero damage as a custom amount provided to the missile, like in the case of the Guardian spell. This PR uses zero to indicate that there is no custom damage amount for missiles produced by monsters, apart from Diablo's Apocalypse attack.

I checked all the missile types returned by `GetMissileType(MonsterAIID)`, and I wasn't able to determine why 4 was being used as the default missile damage for monsters. Maybe the original developers used it for testing at some point during development. 🤷 