### PR TITLE
Reenable tests on MSVC build

### DIFF
--- a/Packaging/windows/CMakePresets.json
+++ b/Packaging/windows/CMakePresets.json
@@ -21,7 +21,7 @@
 		},
 		{
 			"name": "ninja-vcpkg-debug",
-			"displayName": "Ninja with VcPkg Configure Settings with CMAKE_BUILD_TYPE=RelWithDebInfo",
+			"displayName": "Ninja with VcPkg Configure Settings with CMAKE_BUILD_TYPE=Debug",
 			"inherits": "ninja-vcpkg",
 			"cacheVariables": {
 				"CMAKE_BUILD_TYPE": "Debug"
@@ -32,7 +32,11 @@
 			"displayName": "Ninja with VcPkg Configure Settings with CMAKE_BUILD_TYPE=RelWithDebInfo",
 			"inherits": "ninja-vcpkg",
 			"cacheVariables": {
-				"CMAKE_BUILD_TYPE": "RelWithDebInfo"
+				"CMAKE_BUILD_TYPE": "RelWithDebInfo",
+				"DISABLE_LTO": {
+					"type": "BOOL",
+					"value": "ON"
+				}
 			}
 		},
 		{


### PR DESCRIPTION
It seems the tests aren't running in the MSVC CI jobs since we made the switch to `RelWithDebInfo`.

https://github.com/diasurgical/devilutionX/blob/25e9b7320d7a265dfec1cc9de81d55bb3dd25716/CMakeLists.txt#L161-L166