### PR TITLE
Display resolution height when FitToScreen is on

### DIFF
--- a/Source/options.h
+++ b/Source/options.h
@@ -325,6 +325,7 @@ public:
 	[[nodiscard]] string_view GetListDescription(size_t index) const override;
 	[[nodiscard]] size_t GetActiveListIndex() const override;
 	void SetActiveListIndex(size_t index) override;
+	void InvalidateList();
 
 	Size operator*() const
 	{


### PR DESCRIPTION
Based on comments in #5749. If `Fit to Screen` is on, display resolutions using only the height of the resolution (for example, 480p or 720p).

* Force the resolutions list to refresh when the `Fit to Screen` setting is changed.
* If `Fit to Screen` is on, force all resolutions with the same height to also have the same width. This way, the call to `std::unique()` will filter the list to one resolution per height.
* Nintendo 3DS enables the `Fit to Screen` setting even though it uses SDL1. However, the setting works differently on that platform so it is intentionally excluded from this new logic.

![image](https://user-images.githubusercontent.com/9203145/216795315-bfae33f3-3c69-4371-9a08-6ee9394a68c4.png)