### PR TITLE
Fix wrong flip sound: Tavern Sign

### DIFF
--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -70,6 +70,7 @@ TSFX sgSFX[] = {
 /*IS_FROCK*/      { sfx_MISC,                  "sfx\\items\\fliprock.wav",    nullptr },
 /*IS_FSCRL*/      { sfx_MISC,                  "sfx\\items\\flipscrl.wav",    nullptr },
 /*IS_FSHLD*/      { sfx_MISC,                  "sfx\\items\\flipshld.wav",    nullptr },
+/*IS_FSIGN*/      { sfx_MISC,                  "sfx\\items\\flipsign.wav",    nullptr },
 /*IS_FSTAF*/      { sfx_MISC,                  "sfx\\items\\flipstaf.wav",    nullptr },
 /*IS_FSWOR*/      { sfx_MISC,                  "sfx\\items\\flipswor.wav",    nullptr },
 /*IS_GOLD*/       { sfx_MISC,                  "sfx\\items\\gold.wav",        nullptr },

--- a/Source/effects.h
+++ b/Source/effects.h
@@ -157,6 +157,7 @@ enum _sfx_id : int16_t {
 	IS_FROCK,
 	IS_FSCRL,
 	IS_FSHLD,
+	IS_FSIGN,
 	IS_FSTAF,
 	IS_FSWOR,
 	IS_GOLD,

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -305,7 +305,7 @@ _sfx_id ItemDropSnds[] = {
 	IS_FBODY,
 	IS_FBODY,
 	IS_FMUSH,
-	IS_ISIGN,
+	IS_FSIGN,
 	IS_FBLST,
 	IS_FANVL,
 	IS_FSTAF,


### PR DESCRIPTION
Tavern Sign was set to use the inventory placement sound, rather than the flip sound.

What it sounds like with the fix:

https://user-images.githubusercontent.com/68359262/216803557-320a096b-4676-4c1a-b700-1a5addcbd4ad.mp4

