### PR TITLE
Adjust position of Flame Wave missiles before processing

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2074,7 +2074,9 @@ void AddFlameWave(Missile &missile, AddMissileParameter &parameter)
 	missile._midam = GenerateRnd(10) + Players[missile._misource]._pLevel + 1;
 	UpdateMissileVelocity(missile, parameter.dst, 16);
 	missile._mirange = 255;
-	missile.position.tile += Displacement { 1, 1 };
+
+	// Adjust missile's position for rendering
+	missile.position.tile += Direction::South;
 	missile.position.offset.deltaY -= 32;
 }
 
@@ -3403,6 +3405,10 @@ void ProcessFlameWave(Missile &missile)
 {
 	constexpr int ExpLight[14] = { 2, 3, 4, 5, 5, 6, 7, 8, 9, 10, 11, 12, 12 };
 
+	// Adjust missile's position for processing
+	missile.position.tile += Direction::North;
+	missile.position.offset.deltaY += 32;
+
 	missile.var1++;
 	if (missile.var1 == missile._miAnimLen) {
 		SetMissDir(missile, 1);
@@ -3428,6 +3434,7 @@ void ProcessFlameWave(Missile &missile)
 		ChangeLight(missile._mlid, missile.position.tile, ExpLight[missile.var2]);
 		missile.var2++;
 	}
+	// Adjust missile's position for rendering
 	missile.position.tile += Direction::South;
 	missile.position.offset.deltaY -= 32;
 	PutMissile(missile);


### PR DESCRIPTION
Discord user Silmaril (possibly better known as FireIceTalon) reported an issue where the Flame Wave spell was not rendering when aimed along diagonals. This can be observed in the following video around 5:50.

https://youtu.be/SL1uSZxrxII?t=350

It seems that Flame Wave missiles have a bit of a quirk where the position of the missile is adjusted one tile to the south and then readjusted one tile north only while the game logic is processing the missile. DevX preserved the logic to adjust the tile's position south, but not the northward readjustment during processing. I assume it was probably removed because `missile.position.start` is used when updating the missile's position so the move-missile logic was correcting the southward adjustment. However, DevilutionX's missile collision interpolation logic uses the missile's position at the start of the frame to determine whether interpolation is needed, and because the missile's position is not readjusted, it's getting the wrong answer.

https://github.com/diasurgical/devilutionX/blob/b61dac853bc197983926639363ae5d85c6231fc5/Source/missiles.cpp#L480-L494

This causes the interpolation logic to skip over the missile's destination tile and check collisions along the missile's route as far as it can go before reaching an obstacle, such as a wall, that would stop the missile from proceeding. Therefore, the missile ends up hitting everything in its path and then gets deleted all in the first frame of processing.

Incidentally, we noticed that Flame Wave in DevX couldn't hit enemies next to the player. We couldn't reproduce that behavior in vanilla, and this fix seems to resolve that issue as well.

EDIT: I forgot to mention that my best guess is that the position for Flame Wave missiles is adjusted for the purpose of rendering them in a more visually accurate position. Maybe someone else knows more than I do about that.