### PR TITLE
Debug: Add `takexp` command

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -525,6 +525,14 @@ std::string DebugCmdQuest(const string_view parameter)
 	return StrCat(QuestsData[questId]._qlstr, " enabled.");
 }
 
+std::string DebugCmdLevelDown(const string_view parameter)
+{
+	int levels = std::max(1, atoi(parameter.data()));
+	for (int i = 0; i < levels; i++)
+		NetSendCmd(true, CMD_CHEAT_REMOVE_EXPERIENCE);
+	return "Don't eat the lead paint.";
+}
+
 std::string DebugCmdLevelUp(const string_view parameter)
 {
 	int levels = std::max(1, atoi(parameter.data()));
@@ -1010,6 +1018,7 @@ std::vector<DebugCmdItem> DebugCmdList = {
 	{ "help", "Prints help overview or help for a specific command.", "({command})", &DebugCmdHelp },
 	{ "givegold", "Fills the inventory with gold.", "", &DebugCmdGiveGoldCheat },
 	{ "givexp", "Levels the player up (min 1 level or {levels}).", "({levels})", &DebugCmdLevelUp },
+	{ "takexp", "Levels the player up (min 1 level or {levels}).", "({levels})", &DebugCmdLevelDown },
 	{ "maxstats", "Sets all stat values to maximum.", "", &DebugCmdMaxStats },
 	{ "minstats", "Sets all stat values to minimum.", "", &DebugCmdMinStats },
 	{ "setspells", "Set spell level to {level} for all spells.", "{level}", &DebugCmdSetSpellsLevel },

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2440,6 +2440,22 @@ size_t OnSyncQuest(const TCmd *pCmd, size_t pnum)
 	return sizeof(message);
 }
 
+size_t OnCheatRemoveExperience(const TCmd *pCmd, size_t pnum) // NOLINT(misc-unused-parameters)
+{
+#ifdef _DEBUG
+	if (gbBufferMsgs == 1)
+		SendPacket(pnum, pCmd, sizeof(*pCmd));
+	else if (Players[pnum]._pLevel > 1) {
+		Players[pnum]._pExperience = ExpLvlsTbl[Players[pnum]._pLevel - 2];
+		if (*sgOptions.Gameplay.experienceBar) {
+			RedrawEverything();
+		}
+		PreviousPlrLevel(Players[pnum]);
+	}
+#endif
+	return sizeof(*pCmd);
+}
+
 size_t OnCheatExperience(const TCmd *pCmd, size_t pnum) // NOLINT(misc-unused-parameters)
 {
 #ifdef _DEBUG
@@ -3443,6 +3459,8 @@ size_t ParseCmd(size_t pnum, const TCmd *pCmd)
 		return OnFriendlyMode(pCmd, player);
 	case CMD_SYNCQUEST:
 		return OnSyncQuest(pCmd, pnum);
+	case CMD_CHEAT_REMOVE_EXPERIENCE:
+		return OnCheatRemoveExperience(pCmd, pnum);
 	case CMD_CHEAT_EXPERIENCE:
 		return OnCheatExperience(pCmd, pnum);
 	case CMD_CHEAT_SPELL_LEVEL:

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -190,6 +190,10 @@ enum _cmd_id : uint8_t {
 	// body (TCmdParam1):
 	//    int16_t portal_num
 	CMD_WARP,
+	// Cheat: give player level down.
+	//
+	// body (TCmd)
+	CMD_CHEAT_REMOVE_EXPERIENCE,
 	// Cheat: give player level up.
 	//
 	// body (TCmd)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2629,6 +2629,52 @@ int CalcStatDiff(Player &player)
 	return diff;
 }
 
+void PreviousPlrLevel(Player &player)
+{
+#ifdef _DEBUG
+	player._pLevel--;
+	player._pMaxLvl--;
+
+	CalcPlrInv(player, true);
+
+	player._pNextExper = ExpLvlsTbl[player._pLevel];
+
+	int hp = player._pClass == HeroClass::Sorcerer ? 64 : 128;
+
+	player._pMaxHP -= hp;
+	player._pHitPoints = player._pMaxHP;
+	player._pMaxHPBase -= hp;
+	player._pHPBase = player._pMaxHPBase;
+
+	if (&player == MyPlayer) {
+		RedrawComponent(PanelDrawComponent::Health);
+	}
+
+	int mana = 128;
+	if (player._pClass == HeroClass::Warrior)
+		mana = 64;
+	else if (player._pClass == HeroClass::Barbarian)
+		mana = 0;
+
+	player._pMaxMana -= mana;
+	player._pMaxManaBase -= mana;
+
+	if (HasNoneOf(player._pIFlags, ItemSpecialEffect::NoMana)) {
+		player._pMana = player._pMaxMana;
+		player._pManaBase = player._pMaxManaBase;
+	}
+
+	if (&player == MyPlayer) {
+		RedrawComponent(PanelDrawComponent::Mana);
+	}
+
+	if (ControlMode != ControlTypes::KeyboardAndMouse)
+		FocusOnCharInfo();
+
+	CalcPlrInv(player, true);
+#endif
+}
+
 void NextPlrLevel(Player &player)
 {
 	player._pLevel++;

--- a/Source/player.h
+++ b/Source/player.h
@@ -789,6 +789,7 @@ void SetPlrAnims(Player &player);
 void CreatePlayer(Player &player, HeroClass c);
 int CalcStatDiff(Player &player);
 #ifdef _DEBUG
+void PreviousPlrLevel(Player &player);
 void NextPlrLevel(Player &player);
 #endif
 void AddPlrExperience(Player &player, int lvl, int exp);


### PR DESCRIPTION
Based on #5759 

Adds a debug command that reduces player level and adjusts life/mana accordingly. Does not refund stat points.