### PR TITLE
Damage vs. demons description string

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3547,7 +3547,7 @@ bool DoOil(Player &player, int cii)
 	case IPL_KNOCKBACK:
 		return _("knocks target back");
 	case IPL_3XDAMVDEM:
-		return _(/*xgettext:no-c-format*/ "+200% damage vs. demons");
+		return fmt::format(fmt::runtime(_(/*xgettext:no-c-format*/ "+{:d}% damage vs. demons")), 200);
 	case IPL_ALLRESZERO:
 		return _("All Resistance equals 0");
 	case IPL_STEALMANA:

--- a/Translations/bg.po
+++ b/Translations/bg.po
@@ -4273,8 +4273,8 @@ msgstr "избутва целта назад"
 
 #: Source/items.cpp:3666
 #, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "+200% щети срещу демони"
+msgid "+{:d}% damage vs. demons"
+msgstr "+{:d}% щети срещу демони"
 
 #: Source/items.cpp:3668
 msgid "All Resistance equals 0"

--- a/Translations/cs.po
+++ b/Translations/cs.po
@@ -4268,8 +4268,8 @@ msgstr "odhodí nepřítele dozadu"
 
 #: Source/items.cpp:3666
 #, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "+200% poškození proti démonům"
+msgid "+{:d}% damage vs. demons"
+msgstr "+{:d}% poškození proti démonům"
 
 #: Source/items.cpp:3668
 msgid "All Resistance equals 0"

--- a/Translations/da.po
+++ b/Translations/da.po
@@ -4519,7 +4519,7 @@ msgstr ""
 
 #: Source/items.cpp:3666
 #, no-c-format
-msgid "+200% damage vs. demons"
+msgid "+{:d}% damage vs. demons"
 msgstr ""
 
 #: Source/items.cpp:3668

--- a/Translations/de.po
+++ b/Translations/de.po
@@ -4271,8 +4271,8 @@ msgstr "Zurückstoßung"
 
 #: Source/items.cpp:3666
 #, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "+200% Schaden gegen Dämonen"
+msgid "+{:d}% damage vs. demons"
+msgstr "+{:d}% Schaden gegen Dämonen"
 
 #: Source/items.cpp:3668
 msgid "All Resistance equals 0"

--- a/Translations/devilutionx.pot
+++ b/Translations/devilutionx.pot
@@ -4106,7 +4106,7 @@ msgstr ""
 
 #: Source/items.cpp:3672
 #, no-c-format
-msgid "+200% damage vs. demons"
+msgid "+{:d}% damage vs. demons"
 msgstr ""
 
 #: Source/items.cpp:3674

--- a/Translations/el.po
+++ b/Translations/el.po
@@ -4301,8 +4301,8 @@ msgstr "σπρώχνει τον στόχο πίσω"
 
 #: Source/items.cpp:3657
 #, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "+200% ζημιά εναντίων δαιμονων"
+msgid "+{:d}% damage vs. demons"
+msgstr "+{:d}% ζημιά εναντίων δαιμονων"
 
 #: Source/items.cpp:3659
 msgid "All Resistance equals 0"

--- a/Translations/es.po
+++ b/Translations/es.po
@@ -4545,8 +4545,8 @@ msgstr "hace retroceder al objetivo"
 
 #: Source/items.cpp:3550
 #, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "+200% de daño contra demonios"
+msgid "+{:d}% damage vs. demons"
+msgstr "+{:d}% de daño contra demonios"
 
 #: Source/items.cpp:3552
 msgid "All Resistance equals 0"

--- a/Translations/fr.po
+++ b/Translations/fr.po
@@ -4281,8 +4281,8 @@ msgstr "repousse la cible"
 
 #: Source/items.cpp:3638
 #, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "+200% dégâts vs. démons"
+msgid "+{:d}% damage vs. demons"
+msgstr "+{:d}% dégâts vs. démons"
 
 #: Source/items.cpp:3640
 msgid "All Resistance equals 0"

--- a/Translations/hr.po
+++ b/Translations/hr.po
@@ -4288,7 +4288,7 @@ msgstr ""
 
 #: Source/items.cpp:3641
 #, no-c-format
-msgid "+200% damage vs. demons"
+msgid "+{:d}% damage vs. demons"
 msgstr ""
 
 #: Source/items.cpp:3643

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -4537,8 +4537,8 @@ msgstr "respinge il bersaglio"
 
 #: Source/items.cpp:3550
 #, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "+200% danno contro demoni"
+msgid "+{:d}% damage vs. demons"
+msgstr "+{:d}% danno contro demoni"
 
 #: Source/items.cpp:3552
 msgid "All Resistance equals 0"

--- a/Translations/ja.po
+++ b/Translations/ja.po
@@ -4494,8 +4494,8 @@ msgstr "ノック​バック​効果"
 
 #: Source/items.cpp:3616
 #, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "対​悪魔​族​ダメージ​+200​%"
+msgid "+{:d}% damage vs. demons"
+msgstr "対​悪魔​族​ダメージ​+{:d}​%"
 
 #: Source/items.cpp:3618
 msgid "All Resistance equals 0"

--- a/Translations/ko.po
+++ b/Translations/ko.po
@@ -4247,8 +4247,8 @@ msgstr "목표물을 뒤로 밀침"
 
 #: Source/items.cpp:3672
 #, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "악마 상대 시 +200% 피해"
+msgid "+{:d}% damage vs. demons"
+msgstr "악마 상대 시 +{:d}% 피해"
 
 #: Source/items.cpp:3674
 msgid "All Resistance equals 0"

--- a/Translations/pl.po
+++ b/Translations/pl.po
@@ -4267,8 +4267,8 @@ msgstr "odrzuca przeciwnika"
 
 #: Source/items.cpp:3675
 #, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "+200% obrażeń wobec demonów"
+msgid "+{:d}% damage vs. demons"
+msgstr "+{:d}% obrażeń wobec demonów"
 
 #: Source/items.cpp:3677
 msgid "All Resistance equals 0"

--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -4276,8 +4276,8 @@ msgstr "empurra alvo para trás"
 
 #: Source/items.cpp:3666
 #, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "+200% de dano vs. demônios"
+msgid "+{:d}% damage vs. demons"
+msgstr "+{:d}% de dano vs. demônios"
 
 #: Source/items.cpp:3668
 msgid "All Resistance equals 0"

--- a/Translations/ro.po
+++ b/Translations/ro.po
@@ -4364,7 +4364,7 @@ msgstr "lovește ținta inapoi"
 
 #: Source/items.cpp:3666
 #, no-c-format
-msgid "+200% damage vs. demons"
+msgid "+{:d}% damage vs. demons"
 msgstr ""
 
 #: Source/items.cpp:3668

--- a/Translations/ru.po
+++ b/Translations/ru.po
@@ -4327,8 +4327,8 @@ msgstr "отталкивает цель назад"
 
 #: Source/items.cpp:3666
 #, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "+200% урона демонам"
+msgid "+{:d}% damage vs. demons"
+msgstr "+{:d}% урона демонам"
 
 #: Source/items.cpp:3668
 msgid "All Resistance equals 0"

--- a/Translations/sv.po
+++ b/Translations/sv.po
@@ -4266,8 +4266,8 @@ msgstr "knuffar målet bakåt"
 
 #: Source/items.cpp:3666
 #, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "+200% skada mot demoner"
+msgid "+{:d}% damage vs. demons"
+msgstr "+{:d}% skada mot demoner"
 
 #: Source/items.cpp:3668
 msgid "All Resistance equals 0"

--- a/Translations/uk.po
+++ b/Translations/uk.po
@@ -4527,8 +4527,8 @@ msgstr "відбиває ворога назад"
 
 #: Source/items.cpp:3550
 #, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "+200% шкоди проти демонів"
+msgid "+{:d}% damage vs. demons"
+msgstr "+{:d}% шкоди проти демонів"
 
 #: Source/items.cpp:3552
 msgid "All Resistance equals 0"

--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -4222,8 +4222,8 @@ msgstr "击​退​目标"
 
 #: Source/items.cpp:3666
 #, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "+200​% 对​恶魔​的​伤害"
+msgid "+{:d}% damage vs. demons"
+msgstr "+{:d}​% 对​恶魔​的​伤害"
 
 #: Source/items.cpp:3668
 msgid "All Resistance equals 0"

--- a/Translations/zh_TW.po
+++ b/Translations/zh_TW.po
@@ -4365,8 +4365,8 @@ msgstr "擊​退目標"
 
 #: Source/items.cpp:3666
 #, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "+​對​惡​魔​造成​200​%​傷害"
+msgid "+{:d}% damage vs. demons"
+msgstr "+​對​惡​魔​造成​{:d}​%​傷害"
 
 #: Source/items.cpp:3668
 msgid "All Resistance equals 0"


### PR DESCRIPTION
Pulling out the number out the description string.  This makes it easier for modding, resolving issues with the translation.  The same can be done for a few other affixes, if we decide this is something that is desirable.