### PR TITLE
Multiplayer: Spectral Elixir only randomly gives full bonus

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3887,10 +3887,38 @@ void UseItem(size_t pnum, item_misc_id mid, SpellID spl)
 		NewCursor(CURSOR_OIL);
 		break;
 	case IMISC_SPECELIX:
-		ModifyPlrStr(player, 3);
-		ModifyPlrMag(player, 3);
-		ModifyPlrDex(player, 3);
-		ModifyPlrVit(player, 3);
+		if (!gbIsMultiplayer || FlipCoin(10)) { // Don't give the full bonus every time in multiplayer
+			ModifyPlrStr(player, 3);
+			ModifyPlrMag(player, 3);
+			ModifyPlrDex(player, 3);
+			ModifyPlrVit(player, 3);
+		} else {
+			// Find attributes that can increased
+			std::vector<CharacterAttribute> increasableAttributes;
+			for (auto attribute : enum_values<CharacterAttribute>()) {
+				if (player.GetBaseAttributeValue(attribute) >= player.GetMaximumAttributeValue(attribute))
+					continue; // attribute can't be increased
+				increasableAttributes.push_back(attribute);
+			}
+			if (increasableAttributes.empty())
+				break; // no attributes to increase
+			size_t index = static_cast<size_t>(RandomIntLessThan(increasableAttributes.size()));
+			CharacterAttribute attributeToIncrease = increasableAttributes[index];
+			switch (attributeToIncrease) {
+			case CharacterAttribute::Strength:
+				ModifyPlrStr(player, 3);
+				break;
+			case CharacterAttribute::Magic:
+				ModifyPlrMag(player, 3);
+				break;
+			case CharacterAttribute::Dexterity:
+				ModifyPlrDex(player, 3);
+				break;
+			case CharacterAttribute::Vitality:
+				ModifyPlrVit(player, 3);
+				break;
+			}
+		}
 		break;
 	case IMISC_RUNEF:
 		player._pTSpell = SpellID::RuneOfFire;


### PR DESCRIPTION
Follow-up of #5765 and similar to #5619

Notes
- Spectral Elixir only has a 10% to get the full bonus (+3 to all attributes)
- In 90% of all uses it adds +3 to a random attribute
- When selecting the random attributes max stats are ignored
- Change doesn't affect singleplayer

All numbers above aren't fix. They can be discussed and be changed.
I hope with this pr can give us more options how to balance Spectral Elixir in multiplayer. 🙂