### PR TITLE
Bugfix: Hellfire "Life to mana" and "Mana to life" 

### DIFF
--- a/Source/itemdat.h
+++ b/Source/itemdat.h
@@ -364,7 +364,7 @@ enum class ItemSpecialEffect : uint32_t {
 };
 use_enum_as_flags(ItemSpecialEffect);
 
-enum class ItemSpecialEffectHf : uint8_t {
+enum class ItemSpecialEffectHf : uint16_t {
 	// clang-format off
 	None               = 0,
 	Devastation        = 1 << 0,
@@ -374,6 +374,8 @@ enum class ItemSpecialEffectHf : uint8_t {
 	Doppelganger       = 1 << 4,
 	ACAgainstDemons    = 1 << 5,
 	ACAgainstUndead    = 1 << 6,
+	ManaToLife         = 1 << 7,
+	LifeToMana         = 1 << 8,
 	// clang-format on
 };
 use_enum_as_flags(ItemSpecialEffectHf);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2648,6 +2648,7 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 					int portion = ((player._pMaxHPBase >> 6) * 40 / 100) << 6;
 					ihp -= portion;
 					imana += portion;
+				}
 				if (HasNoneOf(item._iDamAcFlags, ItemSpecialEffectHf::ManaToLife, ItemSpecialEffectHf::LifeToMana)) {
 					ihp += item._iPLHP;
 					imana += item._iPLMana;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1035,11 +1035,15 @@ int SaveItemPower(const Player &player, Item &item, ItemPower &power)
 		item._iDamAcFlags |= ItemSpecialEffectHf::ACAgainstUndead;
 		break;
 	case IPL_MANATOLIFE: {
+		item._iDamAcFlags |= ItemSpecialEffectHf::ManaToLife;
+		// Calculate for reverse compatibility
 		int portion = ((player._pMaxManaBase >> 6) * 50 / 100) << 6;
 		item._iPLMana -= portion;
 		item._iPLHP += portion;
 	} break;
 	case IPL_LIFETOMANA: {
+		item._iDamAcFlags |= ItemSpecialEffectHf::LifeToMana;
+		// Calculate for reverse compatibility
 		int portion = ((player._pMaxHPBase >> 6) * 40 / 100) << 6;
 		item._iPLHP -= portion;
 		item._iPLMana += portion;
@@ -2633,8 +2637,22 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 				dmod += item._iPLDamMod;
 				ghit += item._iPLGetHit;
 				lrad += item._iPLLight;
-				ihp += item._iPLHP;
-				imana += item._iPLMana;
+
+				if (IsAnyOf(item._iDamAcFlags, ItemSpecialEffectHf::ManaToLife)) {
+					int portion = ((player._pMaxManaBase >> 6) * 50 / 100) << 6;
+					imana -= portion;
+					ihp += portion;
+				}
+				if (IsAnyOf(item._iDamAcFlags, ItemSpecialEffectHf::LifeToMana)) {
+					int portion = ((player._pMaxHPBase >> 6) * 40 / 100) << 6;
+					ihp -= portion;
+					imana += portion;
+				}
+				if (IsNoneOf(item._iDamAcFlags, ItemSpecialEffectHf::ManaToLife, ItemSpecialEffectHf::LifeToMana)) {
+					ihp += item._iPLHP;
+					imana += item._iPLMana;
+				}
+
 				spllvladd += item._iSplLvlAdd;
 				enac += item._iPLEnAc;
 				fmin += item._iFMinDam;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2639,17 +2639,17 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 				lrad += item._iPLLight;
 
 				// Check for Acolyte's Amulet and Gladiator Ring to apply bonuses as life and mana changes, rather than getting static bonuses from the item data
-				if (HasAnyOf(item._iDamAcFlags, ItemSpecialEffectHf::ManaToLife)) {
+				if (HasAnyOf(pDamAcFlags, ItemSpecialEffectHf::ManaToLife)) {
 					int portion = ((player._pMaxManaBase >> 6) * 50 / 100) << 6;
 					imana -= portion;
 					ihp += portion;
 				}
-				if (HasAnyOf(item._iDamAcFlags, ItemSpecialEffectHf::LifeToMana)) {
+				if (HasAnyOf(pDamAcFlags, ItemSpecialEffectHf::LifeToMana)) {
 					int portion = ((player._pMaxHPBase >> 6) * 40 / 100) << 6;
 					ihp -= portion;
 					imana += portion;
 				}
-				if (HasNoneOf(item._iDamAcFlags, ItemSpecialEffectHf::ManaToLife, ItemSpecialEffectHf::LifeToMana)) {
+				if (HasNoneOf(pDamAcFlags, ItemSpecialEffectHf::ManaToLife | ItemSpecialEffectHf::LifeToMana)) {
 					ihp += item._iPLHP;
 					imana += item._iPLMana;
 				}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2643,11 +2643,12 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 					int portion = ((player._pMaxManaBase >> 6) * 50 / 100) << 6;
 					imana -= portion;
 					ihp += portion;
-				} else if (HasAnyOf(item._iDamAcFlags, ItemSpecialEffectHf::LifeToMana)) {
+				}
+				if (HasAnyOf(item._iDamAcFlags, ItemSpecialEffectHf::LifeToMana)) {
 					int portion = ((player._pMaxHPBase >> 6) * 40 / 100) << 6;
 					ihp -= portion;
 					imana += portion;
-				} else {
+				if (HasNoneOf(item._iDamAcFlags, ItemSpecialEffectHf::ManaToLife, ItemSpecialEffectHf::LifeToMana)) {
 					ihp += item._iPLHP;
 					imana += item._iPLMana;
 				}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2638,17 +2638,16 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 				ghit += item._iPLGetHit;
 				lrad += item._iPLLight;
 
-				if (IsAnyOf(item._iDamAcFlags, ItemSpecialEffectHf::ManaToLife)) {
+				// Check for Acolyte's Amulet and Gladiator Ring to apply bonuses as life and mana changes, rather than getting static bonuses from the item data
+				if (HasAnyOf(item._iDamAcFlags, ItemSpecialEffectHf::ManaToLife)) {
 					int portion = ((player._pMaxManaBase >> 6) * 50 / 100) << 6;
 					imana -= portion;
 					ihp += portion;
-				}
-				if (IsAnyOf(item._iDamAcFlags, ItemSpecialEffectHf::LifeToMana)) {
+				} else if (HasAnyOf(item._iDamAcFlags, ItemSpecialEffectHf::LifeToMana)) {
 					int portion = ((player._pMaxHPBase >> 6) * 40 / 100) << 6;
 					ihp -= portion;
 					imana += portion;
-				}
-				if (IsNoneOf(item._iDamAcFlags, ItemSpecialEffectHf::ManaToLife, ItemSpecialEffectHf::LifeToMana)) {
+				} else {
 					ihp += item._iPLHP;
 					imana += item._iPLMana;
 				}


### PR DESCRIPTION
Fixes: https://github.com/diasurgical/devilutionX/issues/6875

Hellfire writes the Life and Mana directly to the item. This is a problem since it does not dynamically change the values, but keeps the values from when the item is originally generated. This becomes less of a problem the more frequently the item with one of these powers is regenerated, however it is a terrible way of doing it.

This PR rather sets the Life and Mana values dynamically so they stay accurate to the item description.