### PR TITLE
Bugfix: Items over 255 durability

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -855,7 +855,7 @@ int SaveItemPower(const Player &player, Item &item, ItemPower &power)
 		RedrawComponent(PanelDrawComponent::Mana);
 		break;
 	case IPL_DUR: {
-		int bonus = std::min(r * item._iMaxDur / 100, DUR_INDESTRUCTIBLE - item._iMaxDur);
+		int bonus = std::min(r * item._iMaxDur / 100, DUR_INDESTRUCTIBLE - item._iMaxDur - 1);
 		item._iMaxDur += bonus;
 		item._iDurability += bonus;
 	} break;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -855,7 +855,7 @@ int SaveItemPower(const Player &player, Item &item, ItemPower &power)
 		RedrawComponent(PanelDrawComponent::Mana);
 		break;
 	case IPL_DUR: {
-		int bonus = r * item._iMaxDur / 100;
+		int bonus = std::min(r * item._iMaxDur / 100, DUR_INDESTRUCTIBLE - item._iMaxDur);
 		item._iMaxDur += bonus;
 		item._iDurability += bonus;
 	} break;


### PR DESCRIPTION
Some items with the `of Structure` power can exceed 255 durability, causing the item to drop to a low durability when regenerated. This clamps the bonus given from the affix so that it doesn't exceed 255.