### PR TITLE
Fix item levels for set/quest-maps

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -387,6 +387,21 @@ bool IsSuffixValidForItemType(int i, AffixItemType flgs)
 
 int ItemsGetCurrlevel()
 {
+	if (setlevel) {
+		switch (setlvlnum) {
+		case SL_SKELKING:
+			return Quests[Q_SKELKING]._qlevel;
+		case SL_BONECHAMB:
+			return Quests[Q_SCHAMB]._qlevel;
+		case SL_POISONWATER:
+			return Quests[Q_PWATER]._qlevel;
+		case SL_VILEBETRAYER:
+			return Quests[Q_BETRAYER]._qlevel;
+		default:
+			return 1;
+		}
+	}
+
 	if (leveltype == DTYPE_NEST)
 		return currlevel - 8;
 


### PR DESCRIPTION
Fixes #5757

After #5196 `currlevel` is always identically with `setlvlnum` for set/quest-maps.
But `currlevel` is used in [`ItemsGetCurrlevel`](https://github.com/diasurgical/devilutionX/blob/98294e0ad57865331202b916e2f71cd7fa6c82ae/Source/items.cpp#L388-L397) to determinate the value of the item.
With this pr we always use the entry level of the set/quest-map for determinating the value of a item.

Note:
This can also happen in vanilla if you open a town portal in the set/quest-map, go to town, go back and open a chest/kill a monster.
See #5196 for further analysis. :wink:

Thanks @Chance4us for reporting the issue. 🙂 