### PR TITLE
Fix Life/Mana bugs

### DIFF
--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1687,10 +1687,10 @@ void DrawAndBlit()
 	DrawXPBar(out);
 	if (*sgOptions.Gameplay.showHealthValues)
 		DrawFlaskValues(out, { mainPanel.position.x + 134, mainPanel.position.y + 28 }, MyPlayer->_pHitPoints >> 6, MyPlayer->_pMaxHP >> 6);
-	if (*sgOptions.Graphics.showManaValues)
-		DrawFlaskValues(out, { mainPanel.position.x + mainPanel.size.width - 138, mainPanel.position.y + 28 }, 
-	(HasAnyOf(InspectPlayer->_pIFlags, ItemSpecialEffect::NoMana) || (MyPlayer->_pMana >> 6) <= 0) ? 0 : MyPlayer->_pMana >> 6, 
-	HasAnyOf(InspectPlayer->_pIFlags, ItemSpecialEffect::NoMana) ? 0 : MyPlayer->_pMaxMana >> 6);
+	if (*sgOptions.Gameplay.showManaValues)
+		DrawFlaskValues(out, { mainPanel.position.x + mainPanel.size.width - 138, mainPanel.position.y + 28 },
+		    (HasAnyOf(InspectPlayer->_pIFlags, ItemSpecialEffect::NoMana) || (MyPlayer->_pMana >> 6) <= 0) ? 0 : MyPlayer->_pMana >> 6,
+		    HasAnyOf(InspectPlayer->_pIFlags, ItemSpecialEffect::NoMana) ? 0 : MyPlayer->_pMaxMana >> 6);
 
 	DrawCursor(out);
 

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1687,8 +1687,10 @@ void DrawAndBlit()
 	DrawXPBar(out);
 	if (*sgOptions.Gameplay.showHealthValues)
 		DrawFlaskValues(out, { mainPanel.position.x + 134, mainPanel.position.y + 28 }, MyPlayer->_pHitPoints >> 6, MyPlayer->_pMaxHP >> 6);
-	if (*sgOptions.Gameplay.showManaValues)
-		DrawFlaskValues(out, { mainPanel.position.x + mainPanel.size.width - 138, mainPanel.position.y + 28 }, HasAnyOf(InspectPlayer->_pIFlags, ItemSpecialEffect::NoMana) ? 0 : MyPlayer->_pMana >> 6, HasAnyOf(InspectPlayer->_pIFlags, ItemSpecialEffect::NoMana) ? 0 : MyPlayer->_pMaxMana >> 6);
+	if (*sgOptions.Graphics.showManaValues)
+		DrawFlaskValues(out, { mainPanel.position.x + mainPanel.size.width - 138, mainPanel.position.y + 28 }, 
+	(HasAnyOf(InspectPlayer->_pIFlags, ItemSpecialEffect::NoMana) || (MyPlayer->_pMana >> 6) <= 0) ? 0 : MyPlayer->_pMana >> 6, 
+	HasAnyOf(InspectPlayer->_pIFlags, ItemSpecialEffect::NoMana) ? 0 : MyPlayer->_pMaxMana >> 6);
 
 	DrawCursor(out);
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2629,14 +2629,14 @@ void CalcPlrLifeMana(Player &player, int vitality, int magic, int life, int mana
 	magic = (magic * playerClassAttributes.itmMana) >> 6;
 	mana += (magic << 6);
 
-	player._pMaxHP = std::max(life + player._pMaxHPBase, 1 << 6);
+	player._pMaxHP = std::clamp(life + player._pMaxHPBase, 1 << 6, 2000 << 6);
 	player._pHitPoints = std::min(life + player._pHPBase, player._pMaxHP);
 
 	if (&player == MyPlayer && (player._pHitPoints >> 6) <= 0) {
 		SetPlayerHitPoints(player, 0);
 	}
 
-	player._pMaxMana = std::max(mana + player._pMaxManaBase, 0);
+	player._pMaxMana = std::clamp(mana + player._pMaxManaBase, 0, 2000);
 	player._pMana = std::min(mana + player._pManaBase, player._pMaxMana);
 }
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2629,16 +2629,15 @@ void CalcPlrLifeMana(Player &player, int vitality, int magic, int life, int mana
 	magic = (magic * playerClassAttributes.itmMana) >> 6;
 	mana += (magic << 6);
 
-	player._pMaxHP = life + player._pMaxHPBase;
+	player._pMaxHP = std::max(life + player._pMaxHPBase, 1 << 6);
 	player._pHitPoints = std::min(life + player._pHPBase, player._pMaxHP);
 
 	if (&player == MyPlayer && (player._pHitPoints >> 6) <= 0) {
 		SetPlayerHitPoints(player, 0);
 	}
 
-	player._pMaxMana = mana + player._pMaxManaBase;
+	player._pMaxMana = std::max(mana + player._pMaxManaBase, 0);
 	player._pMana = std::min(mana + player._pManaBase, player._pMaxMana);
-}
 
 void CalcPlrBlockFlag(Player &player)
 {

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2636,7 +2636,7 @@ void CalcPlrLifeMana(Player &player, int vitality, int magic, int life, int mana
 		SetPlayerHitPoints(player, 0);
 	}
 
-	player._pMaxMana = std::clamp(mana + player._pMaxManaBase, 0, 2000);
+	player._pMaxMana = std::clamp(mana + player._pMaxManaBase, 0, 2000 << 6);
 	player._pMana = std::min(mana + player._pManaBase, player._pMaxMana);
 }
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2638,6 +2638,7 @@ void CalcPlrLifeMana(Player &player, int vitality, int magic, int life, int mana
 
 	player._pMaxMana = std::max(mana + player._pMaxManaBase, 0);
 	player._pMana = std::min(mana + player._pManaBase, player._pMaxMana);
+}
 
 void CalcPlrBlockFlag(Player &player)
 {

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -189,7 +189,7 @@ PanelEntry panelEntries[] = {
 	{ N_("Mana"), { LeftColumnLabelX, 312 }, 45, LeftColumnLabelWidth,
 	    []() { return StyledText { GetMaxManaColor(), StrCat(HasAnyOf(InspectPlayer->_pIFlags, ItemSpecialEffect::NoMana) ? 0 : InspectPlayer->_pMaxMana >> 6) }; } },
 	{ "", { 135, 312 }, 45, 0,
-	    []() { return StyledText { (InspectPlayer->_pMana != InspectPlayer->_pMaxMana ? UiFlags::ColorRed : GetMaxManaColor()), StrCat(HasAnyOf(InspectPlayer->_pIFlags, ItemSpecialEffect::NoMana) ? 0 : InspectPlayer->_pMana >> 6) }; } },
+	    []() { return StyledText { (InspectPlayer->_pMana != InspectPlayer->_pMaxMana ? UiFlags::ColorRed : GetMaxManaColor()), StrCat((HasAnyOf(InspectPlayer->_pIFlags, ItemSpecialEffect::NoMana) || (InspectPlayer->_pMana >> 6) <= 0) ? 0 : InspectPlayer->_pMana >> 6) }; } },
 
 	{ N_("Resist magic"), { RightColumnLabelX, 256 }, 57, RightColumnLabelWidth,
 	    []() { return GetResistInfo(InspectPlayer->_pMagResist); } },

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1754,8 +1754,6 @@ void Player::RestorePartialLife()
 
 void Player::RestorePartialMana()
 {
-	if (_pMana <= 0)
-		return;
 	int wholeManaPoints = _pMaxMana >> 6;
 	int l = ((wholeManaPoints / 8) + GenerateRnd(wholeManaPoints / 4)) << 6;
 	if (_pClass == HeroClass::Sorcerer)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1460,29 +1460,30 @@ void ValidatePlayer()
 
 void CheckCheatStats(Player &player)
 {
-	if (player._pStrength > 750) {
+	if (player._pStrength > 750)
 		player._pStrength = 750;
-	}
 
-	if (player._pDexterity > 750) {
+	if (player._pDexterity > 750)
 		player._pDexterity = 750;
-	}
 
-	if (player._pMagic > 750) {
+	if (player._pMagic > 750)
 		player._pMagic = 750;
-	}
 
-	if (player._pVitality > 750) {
+	if (player._pVitality > 750)
 		player._pVitality = 750;
-	}
 
-	if (player._pHitPoints > player._pMaxHP) {
+	if (player._pMaxHP > (2000 << 6))
+		player._pMaxHP = (2000 << 6);
+
+	if (player._pMaxMana > (2000 << 6))
+		player._pMaxMana = (2000 << 6);
+
+
+	if (player._pHitPoints > player._pMaxHP)
 		player._pHitPoints = player._pMaxHP;
-	}
 
-	if (player._pMana > player._pMaxMana) {
+	if (player._pMana > player._pMaxMana)
 		player._pMana = player._pMaxMana;
-	}
 }
 
 HeroClass GetPlayerSpriteClass(HeroClass cls)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1754,6 +1754,8 @@ void Player::RestorePartialLife()
 
 void Player::RestorePartialMana()
 {
+	if (_pMana <= 0)
+		return;
 	int wholeManaPoints = _pMaxMana >> 6;
 	int l = ((wholeManaPoints / 8) + GenerateRnd(wholeManaPoints / 4)) << 6;
 	if (_pClass == HeroClass::Sorcerer)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1476,12 +1476,12 @@ void CheckCheatStats(Player &player)
 		player._pVitality = 750;
 	}
 
-	if (player._pHitPoints > 128000) {
-		player._pHitPoints = 128000;
+	if (player._pHitPoints > player._pMaxHP) {
+		player._pHitPoints = player._pMaxHP;
 	}
 
-	if (player._pMana > 128000) {
-		player._pMana = 128000;
+	if (player._pMana > player._pMaxMana) {
+		player._pMana = player._pMaxMana;
 	}
 }
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1478,7 +1478,6 @@ void CheckCheatStats(Player &player)
 	if (player._pMaxMana > (2000 << 6))
 		player._pMaxMana = (2000 << 6);
 
-
 	if (player._pHitPoints > player._pMaxHP)
 		player._pHitPoints = player._pMaxHP;
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1460,29 +1460,48 @@ void ValidatePlayer()
 
 void CheckCheatStats(Player &player)
 {
-	if (player._pStrength > 750)
+	if (player._pStrength > 750) {
 		player._pStrength = 750;
+	}
 
-	if (player._pDexterity > 750)
+	if (player._pDexterity > 750) {
 		player._pDexterity = 750;
+	}
 
-	if (player._pMagic > 750)
+	if (player._pMagic > 750) {
 		player._pMagic = 750;
+	}
 
-	if (player._pVitality > 750)
+	if (player._pVitality > 750) {
 		player._pVitality = 750;
+	}
 
-	if (player._pMaxHP > (2000 << 6))
-		player._pMaxHP = (2000 << 6);
+	if (player._pHitPoints > 128000) {
+		player._pHitPoints = 128000;
+	}
 
-	if (player._pMaxMana > (2000 << 6))
-		player._pMaxMana = (2000 << 6);
+	if (player._pMana > 128000) {
+		player._pMana = 128000;
+	}
+}
 
-	if (player._pHitPoints > player._pMaxHP)
-		player._pHitPoints = player._pMaxHP;
+void CheckCheatStats(Player &player)
+{
+	if (player._pStrength > 750) {
+		player._pStrength = 750;
+	}
 
-	if (player._pMana > player._pMaxMana)
-		player._pMana = player._pMaxMana;
+	if (player._pDexterity > 750) {
+		player._pDexterity = 750;
+	}
+
+	if (player._pMagic > 750) {
+		player._pMagic = 750;
+	}
+
+	if (player._pVitality > 750) {
+		player._pVitality = 750;
+	}
 }
 
 HeroClass GetPlayerSpriteClass(HeroClass cls)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1485,25 +1485,6 @@ void CheckCheatStats(Player &player)
 	}
 }
 
-void CheckCheatStats(Player &player)
-{
-	if (player._pStrength > 750) {
-		player._pStrength = 750;
-	}
-
-	if (player._pDexterity > 750) {
-		player._pDexterity = 750;
-	}
-
-	if (player._pMagic > 750) {
-		player._pMagic = 750;
-	}
-
-	if (player._pVitality > 750) {
-		player._pVitality = 750;
-	}
-}
-
 HeroClass GetPlayerSpriteClass(HeroClass cls)
 {
 	if (cls == HeroClass::Bard && !gbBard)


### PR DESCRIPTION
Fixes: https://github.com/diasurgical/devilutionX/issues/6520

This PR fixes problems related to Life and Mana regarding negative numbers.

- Max Life will never go under 1 (Fixes town death bug)
- Max Mana will never go under 0 (I would have outright removed ALL negative numbers for life and mana, however it's absolutely essential to keep a relative relationship between Current Mana and Max Mana to avoid having Current Mana changed when equipping and unequipping items)
- Current Mana visually appears to never go under 0 to the player (Not able to actually set Current Mana to 0, since this would allow the player to exploit this mechanic and fully restore their Mana.)
- Current Life and Current Mana can no longer exceed Max Life and Max Mana

The fixes to Max Life and Max Mana will not cause an exploit where the user can gain Current Life or Current Mana by equipping cursed items and unequipping them (excluding gaining Current Life while in town, an already exiting exploit, however not really an issue because the Healer can be used to gain Life for free).

Players can still die in the dungeon by equipping cursed items/unequipping +life items, however there isn't a good way around this, since min capping Current Life at 1 when equipping/unequipping items would allow the player to fully restore their Life.

The town death bug occurs when a player dies with a negative Max Life. If the player still has negative Max Life while dead, respawning in Town will cause you to appear dead at the start location, and never be able to come back to life unless someone casts Resurrect on you. A similar bug appears while in the dungeon. If you are alive with negative Max Life, casting Healing or having someone else cast Heal Other on you will kill you. Haven't tested, but it's likely that Potion of Healing and Potion of Full Healing would also kill you.