### PR TITLE
Fix mana and health gain at character level 50

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2718,7 +2718,7 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 
 	/* set player level to MaxCharacterLevel if the experience value for MaxCharacterLevel is reached, which exits the function early
 	and does not call NextPlrLevel(), which is responsible for giving Attribute points and Life/Mana on level up */
-	if (player._pExperience >= ExpLvlsTbl[MaxCharacterLevel - 1]) {
+	if (player._pExperience >= ExpLvlsTbl[MaxCharacterLevel]) {
 		player._pLevel = MaxCharacterLevel;
 		return;
 	}


### PR DESCRIPTION
https://github.com/diasurgical/devilutionX/pull/3928 was opened about a year ago, not merged because it was supposed be added as part of https://github.com/diasurgical/devilutionX/pull/1626 that was opened two years ago.  It looks like people have different ideas about the colors of the character's panel and what numbers should be shown there, but in the mean time, if possible let's consider fixing the health and mana gain at character level 50 so that people can get the benefit of this gameplay fix.