### PR TITLE
Clear padmapper state when changing event handlers

### DIFF
--- a/Source/engine/events.cpp
+++ b/Source/engine/events.cpp
@@ -5,6 +5,7 @@
 #include "engine/demomode.h"
 #include "interfac.h"
 #include "movie.h"
+#include "options.h"
 #include "utils/log.hpp"
 
 #ifdef USE_SDL1
@@ -149,6 +150,8 @@ EventHandler CurrentEventHandler;
 
 EventHandler SetEventHandler(EventHandler eventHandler)
 {
+	sgOptions.Padmapper.ReleaseAllActiveButtons();
+
 	EventHandler previousHandler = CurrentEventHandler;
 	CurrentEventHandler = eventHandler;
 	return previousHandler;

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1703,6 +1703,16 @@ void PadmapperOptions::ButtonReleased(ControllerButton button, bool invokeAction
 	buttonToReleaseAction[static_cast<size_t>(button)] = nullptr;
 }
 
+void PadmapperOptions::ReleaseAllActiveButtons()
+{
+	for (auto *action : buttonToReleaseAction) {
+		if (action == nullptr)
+			continue;
+		ControllerButton button = action->boundInput.button;
+		ButtonReleased(button, true);
+	}
+}
+
 bool PadmapperOptions::IsActive(string_view actionName) const
 {
 	for (const Action &action : actions) {

--- a/Source/options.h
+++ b/Source/options.h
@@ -759,6 +759,7 @@ struct PadmapperOptions : OptionCategoryBase {
 	void CommitActions();
 	void ButtonPressed(ControllerButton button);
 	void ButtonReleased(ControllerButton button, bool invokeAction = true);
+	void ReleaseAllActiveButtons();
 	bool IsActive(string_view actionName) const;
 	string_view ActionNameTriggeredByButtonEvent(ControllerButtonEvent ctrlEvent) const;
 	string_view InputNameForAction(string_view actionName) const;


### PR DESCRIPTION
When the game swaps from the `GameEventHandler` to the `DisableInputEventHandler` during loading screens, the event handler will no longer forward input events to the padmapper. This causes any buttons which are pressed before entering a loading screen and then released during the loading screen to be stuck in the "pressed" state after the loading screen completes, until they are pressed and released again. This PR forces padmapper to trigger release actions and clear "pressed" state for all buttons whenever the event handler is swapped to ensure that padmapper state gets reset whenever one of these transitions occurs.

Incidentally, this is also a problem for keymapper, but keymapper doesn't save "pressed" state so there's no convenient way to clear it. The only keymapper action affected by this issue is `Item Highlighting` because it updates global game state using the `AltPressed()` function.

This resolves #5716