### PR TITLE
Add toggles for disabling "Sturdy" and "Burgundy"

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1013,10 +1013,13 @@ void DrawInfoBox(const Surface &out)
 		} else if (!myPlayer.CanUseItem(myPlayer.HoldItem)) {
 			InfoString = _("Requirements not met");
 		} else {
-			if (myPlayer.HoldItem._iIdentified)
-				InfoString = string_view(myPlayer.HoldItem._iIName);
-			else
+			if (myPlayer.HoldItem._iIdentified) {
+				char itemName[64];
+				CopyUtf8(itemName, GetIdentifiedItemString(myPlayer.HoldItem).c_str(), 64);
+				InfoString = string_view(itemName);
+			} else {
 				InfoString = string_view(myPlayer.HoldItem._iName);
+			}
 			InfoColor = myPlayer.HoldItem.getTextColor();
 		}
 	} else {

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1925,7 +1925,9 @@ int8_t CheckInvHLight()
 	} else {
 		InfoColor = pi->getTextColor();
 		if (pi->_iIdentified) {
-			InfoString = string_view(pi->_iIName);
+			char itemName[64];
+			CopyUtf8(itemName, GetIdentifiedItemString(*pi).c_str(), 64);
+			InfoString = string_view(itemName);
 			PrintItemDetails(*pi);
 		} else {
 			InfoString = string_view(pi->_iName);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3377,22 +3377,21 @@ void GetItemFrm(Item &item)
 
 std::string GetIdentifiedItemString(Item &item)
 {
-	if (!*sgOptions.Gameplay.disableAffixNameFix) {
-		return item._iIName;
-	}
 	char itemName[64];
-	CopyUtf8(itemName, item._iIName, 64);
-
+	CopyUtf8(itemName, item._iIName, sizeof(itemName));
 	std::string itemNameString = itemName;
-	if (itemNameString.find("Sturdy") != std::string::npos) {
+
+	if ((itemNameString.find("Sturdy") != std::string::npos) && *sgOptions.Gameplay.disableFineAffixFix) {
 		size_t pos = itemNameString.find("Sturdy");
 		itemNameString.replace(pos, 6, "Fine");
-	} else if (itemNameString.find("Burgundy") != std::string::npos) {
+		return itemNameString;
+	}
+	if ((itemNameString.find("Burgundy") != std::string::npos) && *sgOptions.Gameplay.disableCrimsonAffixFix) {
 		size_t pos = itemNameString.find("Burgundy");
 		itemNameString.replace(pos, 8, "Crimson");
+		return itemNameString;
 	}
-
-	return itemNameString;
+	return item._iIName;
 }
 
 void GetItemStr(Item &item)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3375,14 +3375,36 @@ void GetItemFrm(Item &item)
 		item.AnimInfo.sprites.emplace(*itemanims[it]);
 }
 
+std::string GetIdentifiedItemString(Item &item)
+{
+	if (!*sgOptions.Gameplay.disableAffixNameFix) {
+		return item._iIName;
+	}
+	char itemName[64];
+	CopyUtf8(itemName, item._iIName, 64);
+
+	std::string itemNameString = itemName;
+	if (itemNameString.find("Sturdy") != std::string::npos) {
+		size_t pos = itemNameString.find("Sturdy");
+		itemNameString.replace(pos, 6, "Fine");
+	} else if (itemNameString.find("Burgundy") != std::string::npos) {
+		size_t pos = itemNameString.find("Burgundy");
+		itemNameString.replace(pos, 8, "Crimson");
+	}
+
+	return itemNameString;
+}
+
 void GetItemStr(Item &item)
 {
 	if (item._itype != ItemType::Gold) {
-		if (item._iIdentified)
-			InfoString = string_view(item._iIName);
-		else
+		if (item._iIdentified) {
+			char itemName[64];
+			CopyUtf8(itemName, GetIdentifiedItemString(item).c_str(), sizeof(itemName));
+			InfoString = std::string(itemName);
+		} else {
 			InfoString = string_view(item._iName);
-
+		}
 		InfoColor = item.getTextColor();
 	} else {
 		int nGold = item._ivalue;

--- a/Source/items.h
+++ b/Source/items.h
@@ -517,6 +517,7 @@ void DeleteItem(int i);
 void ProcessItems();
 void FreeItemGFX();
 void GetItemFrm(Item &item);
+std::string GetIdentifiedItemString(Item &item);
 void GetItemStr(Item &item);
 void CheckIdentify(Player &player, int cii);
 void DoRepair(Player &player, int cii);

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1068,6 +1068,7 @@ GameplayOptions::GameplayOptions()
               { FloatingNumbers::Random, N_("Random Angles") },
               { FloatingNumbers::Vertical, N_("Vertical Only") },
           })
+    , disableAffixNameFix("Disable Duplicate Affix Names Fix", OptionEntryFlags::None, N_("Disable Duplicate Affix Names Fix"), N_("Disables the fixes to the affixes Fine and Crimson."), false)
 {
 	grabInput.SetValueChangedCallback(OptionGrabInputChanged);
 	experienceBar.SetValueChangedCallback(OptionExperienceBarChanged);
@@ -1109,6 +1110,7 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&numRejuPotionPickup,
 		&numFullRejuPotionPickup,
 		&enableFloatingNumbers,
+		&disableAffixNameFix,
 	};
 }
 

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1068,7 +1068,8 @@ GameplayOptions::GameplayOptions()
               { FloatingNumbers::Random, N_("Random Angles") },
               { FloatingNumbers::Vertical, N_("Vertical Only") },
           })
-    , disableAffixNameFix("Disable Duplicate Affix Names Fix", OptionEntryFlags::None, N_("Disable Duplicate Affix Names Fix"), N_("Disables the fixes to the affixes Fine and Crimson."), false)
+    , disableFineAffixFix("Disable Fine Affix Fix", OptionEntryFlags::None, N_("Disable Fine Affix Fix"), N_("Disables the fix to the affix Fine."), false)
+    , disableCrimsonAffixFix("Disable Burgundy Affix Fix", OptionEntryFlags::None, N_("Disable Crimson Affix Fix"), N_("Disables the fix to the affix Crimson."), false)
 {
 	grabInput.SetValueChangedCallback(OptionGrabInputChanged);
 	experienceBar.SetValueChangedCallback(OptionExperienceBarChanged);
@@ -1110,7 +1111,8 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&numRejuPotionPickup,
 		&numFullRejuPotionPickup,
 		&enableFloatingNumbers,
-		&disableAffixNameFix,
+		&disableFineAffixFix,
+		&disableCrimsonAffixFix,
 	};
 }
 

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1068,8 +1068,8 @@ GameplayOptions::GameplayOptions()
               { FloatingNumbers::Random, N_("Random Angles") },
               { FloatingNumbers::Vertical, N_("Vertical Only") },
           })
-    , disableFineAffixFix("Disable Fine Affix Fix", OptionEntryFlags::None, N_("Disable Fine Affix Fix"), N_("Disables the fix to the affix Fine."), false)
-    , disableCrimsonAffixFix("Disable Burgundy Affix Fix", OptionEntryFlags::None, N_("Disable Crimson Affix Fix"), N_("Disables the fix to the affix Crimson."), false)
+    , disableFineAffixFix("Disable Fine Affix Fix", OptionEntryFlags::None, N_("Disable Fine Affix Fix"), N_("Disables the fix to the affix Fine."), true)
+    , disableCrimsonAffixFix("Disable Burgundy Affix Fix", OptionEntryFlags::None, N_("Disable Crimson Affix Fix"), N_("Disables the fix to the affix Crimson."), true)
 {
 	grabInput.SetValueChangedCallback(OptionGrabInputChanged);
 	experienceBar.SetValueChangedCallback(OptionExperienceBarChanged);

--- a/Source/options.h
+++ b/Source/options.h
@@ -594,8 +594,10 @@ struct GameplayOptions : OptionCategoryBase {
 	OptionEntryInt<int> numFullRejuPotionPickup;
 	/** @brief Enable floating numbers. */
 	OptionEntryEnum<FloatingNumbers> enableFloatingNumbers;
-	/** @brief Disable fix for duplicate affix names */
-	OptionEntryBoolean disableAffixNameFix;
+	/** @brief Disable fix to Fine affix */
+	OptionEntryBoolean disableFineAffixFix;
+	/** @brief Disable fix to Crimson affix */
+	OptionEntryBoolean disableCrimsonAffixFix;
 };
 
 struct ControllerOptions : OptionCategoryBase {

--- a/Source/options.h
+++ b/Source/options.h
@@ -594,6 +594,8 @@ struct GameplayOptions : OptionCategoryBase {
 	OptionEntryInt<int> numFullRejuPotionPickup;
 	/** @brief Enable floating numbers. */
 	OptionEntryEnum<FloatingNumbers> enableFloatingNumbers;
+	/** @brief Disable fix for duplicate affix names */
+	OptionEntryBoolean disableAffixNameFix;
 };
 
 struct ControllerOptions : OptionCategoryBase {

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -435,7 +435,9 @@ uint16_t CheckStashHLight(Point mousePosition)
 
 	InfoColor = item.getTextColor();
 	if (item._iIdentified) {
-		InfoString = string_view(item._iIName);
+		char itemName[64];
+		CopyUtf8(itemName, GetIdentifiedItemString(item).c_str(), sizeof(itemName));
+		InfoString = std::string(itemName);
 		PrintItemDetails(item);
 	} else {
 		InfoString = string_view(item._iName);

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -379,7 +379,9 @@ void ScrollSmithBuy(int idx)
 			UiFlags itemColor = smithitem[idx].getTextColorWithStatCheck();
 
 			if (smithitem[idx]._iMagical != ITEM_QUALITY_NORMAL) {
-				AddSText(20, l, smithitem[idx]._iIName, itemColor, true, smithitem[idx]._iCurs, true);
+				char itemName[64];
+				CopyUtf8(itemName, GetIdentifiedItemString(smithitem[idx]).c_str(), sizeof(itemName));
+				AddSText(20, l, itemName, itemColor, true, smithitem[idx]._iCurs, true);
 			} else {
 				AddSText(20, l, smithitem[idx]._iName, itemColor, true, smithitem[idx]._iCurs, true);
 			}
@@ -444,7 +446,9 @@ void ScrollSmithPremiumBuy(int boughtitems)
 	for (int l = 5; l < 20 && idx < SMITH_PREMIUM_ITEMS; l += 4) {
 		if (!premiumitems[idx].isEmpty()) {
 			UiFlags itemColor = premiumitems[idx].getTextColorWithStatCheck();
-			AddSText(20, l, premiumitems[idx]._iIName, itemColor, true, premiumitems[idx]._iCurs, true);
+			char itemName[64];
+			CopyUtf8(itemName, GetIdentifiedItemString(premiumitems[idx]).c_str(), sizeof(itemName));
+			AddSText(20, l, itemName, itemColor, true, premiumitems[idx]._iCurs, true);
 			AddSTextVal(l, premiumitems[idx]._iIvalue);
 			PrintStoreItem(premiumitems[idx], l + 1, itemColor, true);
 			stextdown = l;
@@ -531,7 +535,9 @@ void ScrollSmithSell(int idx)
 			UiFlags itemColor = storehold[idx].getTextColorWithStatCheck();
 
 			if (storehold[idx]._iMagical != ITEM_QUALITY_NORMAL && storehold[idx]._iIdentified) {
-				AddSText(20, l, storehold[idx]._iIName, itemColor, true, storehold[idx]._iCurs, true);
+				char itemName[64];
+				CopyUtf8(itemName, GetIdentifiedItemString(storehold[idx]).c_str(), sizeof(itemName));
+				AddSText(20, l, itemName, itemColor, true, storehold[idx]._iCurs, true);
 				AddSTextVal(l, storehold[idx]._iIvalue);
 			} else {
 				AddSText(20, l, storehold[idx]._iName, itemColor, true, storehold[idx]._iCurs, true);
@@ -732,7 +738,9 @@ void ScrollWitchBuy(int idx)
 			UiFlags itemColor = witchitem[idx].getTextColorWithStatCheck();
 
 			if (witchitem[idx]._iMagical != ITEM_QUALITY_NORMAL) {
-				AddSText(20, l, witchitem[idx]._iIName, itemColor, true, witchitem[idx]._iCurs, true);
+				char itemName[64];
+				CopyUtf8(itemName, GetIdentifiedItemString(witchitem[idx]).c_str(), sizeof(itemName));
+				AddSText(20, l, itemName, itemColor, true, witchitem[idx]._iCurs, true);
 			} else {
 				AddSText(20, l, witchitem[idx]._iName, itemColor, true, witchitem[idx]._iCurs, true);
 			}
@@ -996,10 +1004,13 @@ void StoreConfirm(Item &item)
 		if (stextshold == TalkID::WitchRecharge)
 			idprint = false;
 	}
-	if (idprint)
-		AddSText(20, 8, item._iIName, itemColor, false);
-	else
+	if (idprint) {
+		char itemName[64];
+		CopyUtf8(itemName, GetIdentifiedItemString(item).c_str(), sizeof(itemName));
+		AddSText(20, 8, itemName, itemColor, false);
+	} else {
 		AddSText(20, 8, item._iName, itemColor, false);
+	}
 
 	AddSTextVal(8, item._iIvalue);
 	PrintStoreItem(item, 9, itemColor);
@@ -1068,10 +1079,13 @@ void SStartBoyBuy()
 	boyitem._iStatFlag = MyPlayer->CanUseItem(boyitem);
 	UiFlags itemColor = boyitem.getTextColorWithStatCheck();
 
-	if (boyitem._iMagical != ITEM_QUALITY_NORMAL)
-		AddSText(20, 10, boyitem._iIName, itemColor, true, boyitem._iCurs, true);
-	else
+	if (boyitem._iMagical != ITEM_QUALITY_NORMAL) {
+		char itemName[64];
+		CopyUtf8(itemName, GetIdentifiedItemString(boyitem).c_str(), sizeof(itemName));
+		AddSText(20, 10, itemName, itemColor, true, boyitem._iCurs, true);
+	} else {
 		AddSText(20, 10, boyitem._iName, itemColor, true, boyitem._iCurs, true);
+	}
 
 	if (gbIsHellfire)
 		AddSTextVal(10, boyitem._iIvalue - (boyitem._iIvalue / 4));
@@ -1288,7 +1302,9 @@ void StartStorytellerIdentifyShow(Item &item)
 	UiFlags itemColor = item.getTextColorWithStatCheck();
 
 	AddSText(0, 7, _("This item is:"), UiFlags::ColorWhite | UiFlags::AlignCenter, false);
-	AddSText(20, 11, item._iIName, itemColor, false);
+	char itemName[64];
+	CopyUtf8(itemName, GetIdentifiedItemString(item).c_str(), sizeof(itemName));
+	AddSText(20, 11, itemName, itemColor, false);
 	PrintStoreItem(item, 12, itemColor);
 	AddSText(0, 18, _("Done"), UiFlags::ColorWhite | UiFlags::AlignCenter, true);
 }


### PR DESCRIPTION
Adds toggles to Gameplay options that will visually appear to change "Sturdy" and "Burgundy" back to "Fine" and "Crimson", respectively. This does not write to item data, so it can be toggled on and off without permanently changing the names on items.