### PR TITLE
msg.cpp: Always set `spellFrom`

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1525,6 +1525,7 @@ size_t OnSpellTile(const TCmd *pCmd, Player &player)
 	player.destParam3 = SDL_SwapLE16(message.wParam3);
 	player.queuedSpell.spellId = spell;
 	player.queuedSpell.spellType = static_cast<SpellType>(wParam2);
+	player.queuedSpell.spellFrom = 0;
 
 	return sizeof(message);
 }
@@ -2484,7 +2485,7 @@ size_t OnNova(const TCmd *pCmd, Player &player)
 			ClrPlrPath(player);
 			player.queuedSpell.spellId = SpellID::Nova;
 			player.queuedSpell.spellType = SpellType::Scroll;
-			player.queuedSpell.spellFrom = 3;
+			player.queuedSpell.spellFrom = 0;
 			player.destAction = ACTION_SPELL;
 			player.destParam1 = position.x;
 			player.destParam2 = position.y;


### PR DESCRIPTION
Note that in a few places it is always being set to 0.

This is probably wrong and should instead be passed in the network message as a parameter.

For now, this at least fixes the crash observed in #5791.

/cc @obligaron 