### PR TITLE
Fix multiline `DrawStringWithColors` alignment

### DIFF
--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -78,7 +78,7 @@ std::vector<DrawStringFormatArg> CreateDrawStringFormatArgForEntry(OptionEntryBa
 /** @brief Check if the option text can't fit in one list line (list width minus drawn selector) */
 bool NeedsTwoLinesToDisplayOption(std::vector<DrawStringFormatArg> &formatArgs)
 {
-	return GetLineWidth("{}: {}", formatArgs.data(), formatArgs.size(), GameFontTables::GameFont24, 1) >= (rectList.size.width - 90);
+	return GetLineWidth("{}: {}", formatArgs.data(), formatArgs.size(), 0, GameFontTables::GameFont24, 1) >= (rectList.size.width - 90);
 }
 
 void CleanUpSettingsUI()

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -258,11 +258,12 @@ class FmtArgParser {
 public:
 	FmtArgParser(string_view fmt,
 	    DrawStringFormatArg *args,
-	    std::size_t len)
+	    size_t len,
+	    size_t offset = 0)
 	    : fmt_(fmt)
 	    , args_(args)
 	    , len_(len)
-	    , next_(0)
+	    , next_(offset)
 	{
 	}
 
@@ -302,6 +303,11 @@ public:
 			rest.remove_prefix(fmtLen);
 		}
 		return result;
+	}
+
+	size_t offset() const
+	{
+		return next_;
 	}
 
 private:
@@ -481,7 +487,7 @@ int GetLineWidth(string_view text, GameFontTables size, int spacing, int *charac
 	return lineWidth != 0 ? (lineWidth - spacing) : 0;
 }
 
-int GetLineWidth(string_view fmt, DrawStringFormatArg *args, std::size_t argsLen, GameFontTables size, int spacing, int *charactersInLine)
+int GetLineWidth(string_view fmt, DrawStringFormatArg *args, std::size_t argsLen, size_t argsOffset, GameFontTables size, int spacing, int *charactersInLine)
 {
 	int lineWidth = 0;
 
@@ -491,7 +497,7 @@ int GetLineWidth(string_view fmt, DrawStringFormatArg *args, std::size_t argsLen
 	char32_t prev = U'\0';
 	char32_t next;
 
-	FmtArgParser fmtArgParser { fmt, args, argsLen };
+	FmtArgParser fmtArgParser { fmt, args, argsLen, argsOffset };
 	string_view rest = fmt;
 	while (!rest.empty()) {
 		if ((prev == U'{' || prev == U'}') && static_cast<char>(prev) == rest[0]) {
@@ -693,7 +699,7 @@ void DrawStringWithColors(const Surface &out, string_view fmt, DrawStringFormatA
 	int charactersInLine = 0;
 	int lineWidth = 0;
 	if (HasAnyOf(flags, (UiFlags::AlignCenter | UiFlags::AlignRight | UiFlags::KerningFitSpacing)))
-		lineWidth = GetLineWidth(fmt, args, argsLen, size, spacing, &charactersInLine);
+		lineWidth = GetLineWidth(fmt, args, argsLen, 0, size, spacing, &charactersInLine);
 
 	int maxSpacing = spacing;
 	if (HasAnyOf(flags, UiFlags::KerningFitSpacing))
@@ -764,7 +770,7 @@ void DrawStringWithColors(const Surface &out, string_view fmt, DrawStringFormatA
 			if (HasAnyOf(flags, (UiFlags::AlignCenter | UiFlags::AlignRight))) {
 				lineWidth = (*kerning)[frame];
 				if (remaining.size() > cpLen)
-					lineWidth += spacing + GetLineWidth(remaining.substr(cpLen), size, spacing);
+					lineWidth += spacing + GetLineWidth(remaining.substr(cpLen), args, argsLen, fmtArgParser.offset(), size, spacing);
 			}
 			characterPosition.x = GetLineStartX(flags, rect, lineWidth);
 

--- a/Source/engine/render/text_render.hpp
+++ b/Source/engine/render/text_render.hpp
@@ -143,12 +143,13 @@ int GetLineWidth(string_view text, GameFontTables size = GameFont12, int spacing
  * @param fmt An fmt::format string.
  * @param args Format arguments.
  * @param argsLen Number of format arguments.
+ * @param argsOffset Index of the first unprocessed format argument.
  * @param size Font size to use
  * @param spacing Extra spacing to add per character
  * @param charactersInLine Receives characters read until newline or terminator
  * @return Line width in pixels
  */
-int GetLineWidth(string_view fmt, DrawStringFormatArg *args, std::size_t argsLen, GameFontTables size, int spacing, int *charactersInLine = nullptr);
+int GetLineWidth(string_view fmt, DrawStringFormatArg *args, size_t argsLen, size_t argsOffset, GameFontTables size, int spacing, int *charactersInLine = nullptr);
 
 int GetLineHeight(string_view text, GameFontTables fontIndex);
 


### PR DESCRIPTION
For center or right alignment, the lines past the first line were aligned incorrectly. The alignment after the first line was based on the width of the format string.

We do not currently render any such strings, the bug was discovered by @kphoenix137 while working on a feature.