### PR TITLE
Stash Gold Limit

### DIFF
--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -96,6 +96,8 @@ void CheckStashPaste(Point cursorPosition)
 	}
 
 	if (player.HoldItem._itype == ItemType::Gold) {
+		if (Stash.gold > std::numeric_limits<int>::max() - player.HoldItem._ivalue)
+			return;
 		Stash.gold += player.HoldItem._ivalue;
 		player.HoldItem.clear();
 		PlaySFX(IS_GOLD);
@@ -668,6 +670,8 @@ void GoldWithdrawNewText(string_view text)
 bool AutoPlaceItemInStash(Player &player, const Item &item, bool persistItem)
 {
 	if (item._itype == ItemType::Gold) {
+		if (Stash.gold > std::numeric_limits<int>::max() - item._ivalue)
+			return false;
 		if (persistItem) {
 			Stash.gold += item._ivalue;
 			Stash.dirty = true;


### PR DESCRIPTION
Prevents overflow of the stash gold that happens around 2B gold.  The solution was provided during a discussion on discord.  Currently this change causes the game to crash when accessing the stash in a debug build as outlined here https://github.com/diasurgical/devilutionX/issues/5474.  I was able to test building a release version as well as implementing https://github.com/diasurgical/devilutionX/pull/5475 in debug (and setting a lower limit for the test).  Both placing gold above the limit as well as Ctrl + clicking gold to move it caused no issues and the game behaved as expected, limiting placing gold above the limit.