### PR TITLE
Relax latency requirements for online games

### DIFF
--- a/Source/dvlnet/base.h
+++ b/Source/dvlnet/base.h
@@ -69,6 +69,7 @@ protected:
 		uint32_t roundTripLatency = {};
 	};
 
+	seq_t current_turn = 0;
 	seq_t next_turn = 0;
 	message_t message_last;
 	std::deque<message_t> message_queue;


### PR DESCRIPTION
The short explanation for this is that it relaxes the tolerance for how long the client will wait for a remote client's response before displaying the hourglass to the user. Turns are processed by every client on 400-millisecond intervals, and the hourglass will be displayed to the user if the local client hasn't received all of the remote clients' turns when that 400-millisecond timer comes up. By increasing the `defaultturnsintransit` to `2`, clients will have an extra turn in the queue to process while waiting on the second turn in transit.

I haven't done any latency testing yet to see what the new limits are compared to the old ones, but I did notice that I no longer see the hourglass when a client warps to another dungeon level. I suppose it may still happen when playing with others over the internet, but it doesn't happen when I test locally over ZT or using localhost with TCP.

For additional detail and justification, see below.

---

Based on my testing with IPX wrapper on my local network, vanilla Diablo used a value of `2` for the `defaultturnsintransit` returned by `SNetGetProviderCaps()`. This causes `SNetSendTurn()` to potentially be called multiple times in a row by the game loop, as seen in the following lines of code.

https://github.com/diasurgical/devilutionX/blob/e9e67b3971fbd2bf243e5232203c5dcd37001642/Source/nthread.cpp#L86-L100

Several Wireshark captures reveal that new clients are presented with two turns initially from the host instead of one, suggesting that each client maintains two turns in its local queue so they can be provided on demand. DevilutionX already has turn queues it maintains for each client so it already mostly supported this adjustment.

The main thing I had to do was separate the notion of `next_turn` from `current_turn` so they can be adjusted independently. This is because we can no longer assume that the next turn to be sent will always be the one immediately after the last turn that was processed.

_Side note: It may be possible to assume that the next turn to be sent will always be `defaultturnsintransit` after the last turn that was processed, but turns are already so complicated and I feel it's quite a bit easier to understand what's going on by letting these variables move independently._

* `next_turn` tracks the next sequence number to be sent to remote clients when `SNetSendTurn()` is called.
* `current_turn` tracks the next sequence number to be popped from the queues when `SNetReceiveTurns()` is called.
* When sending the initial set of turns to a newly connected remote client, we need to send whatever is currently in the queue. This should help to ensure there are no gaps in the sequence of turns. If there are no turns in the queue yet, we can just wait for the game loop to call `SNetSendTurn()`, which it will do twice because it's tracking the number of turns in transit.