### PR TITLE
Use C FILE instead of C++ streams throughout

### DIFF
--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -4,8 +4,9 @@
  * Implementation of the screenshot function.
  */
 #include <cstdint>
+#include <cstdio>
+
 #include <fmt/chrono.h>
-#include <fstream>
 
 #include "DiabloUI/diabloui.h"
 #include "engine/backbuffer_state.hpp"
@@ -28,7 +29,7 @@ namespace {
  * @param out File stream to write to
  * @return True on success
  */
-bool CaptureHdr(int16_t width, int16_t height, std::ofstream *out)
+bool CaptureHdr(int16_t width, int16_t height, FILE *out)
 {
 	PCXHeader buffer;
 
@@ -44,8 +45,7 @@ bool CaptureHdr(int16_t width, int16_t height, std::ofstream *out)
 	buffer.NPlanes = 1;
 	buffer.BytesPerLine = SDL_SwapLE16(width);
 
-	out->write(reinterpret_cast<const char *>(&buffer), sizeof(buffer));
-	return !out->fail();
+	return std::fwrite(&buffer, sizeof(buffer), 1, out) == 1;
 }
 
 /**
@@ -54,7 +54,7 @@ bool CaptureHdr(int16_t width, int16_t height, std::ofstream *out)
  * @param out File stream for the PCX file.
  * @return True if successful, else false
  */
-bool CapturePal(SDL_Color *palette, std::ofstream *out)
+bool CapturePal(SDL_Color *palette, FILE *out)
 {
 	uint8_t pcxPalette[1 + 256 * 3];
 
@@ -65,8 +65,7 @@ bool CapturePal(SDL_Color *palette, std::ofstream *out)
 		pcxPalette[1 + 3 * i + 2] = palette[i].b;
 	}
 
-	out->write(reinterpret_cast<const char *>(pcxPalette), sizeof(pcxPalette));
-	return !out->fail();
+	return std::fwrite(pcxPalette, sizeof(pcxPalette), 1, out) == 1;
 }
 
 /**
@@ -118,7 +117,7 @@ uint8_t *CaptureEnc(uint8_t *src, uint8_t *dst, int width)
  * @param out File stream for the PCX file.
  * @return True if successful, else false
  */
-bool CapturePix(const Surface &buf, std::ofstream *out)
+bool CapturePix(const Surface &buf, FILE *out)
 {
 	int width = buf.w();
 	std::unique_ptr<uint8_t[]> pBuffer { new uint8_t[2 * width] };
@@ -126,14 +125,13 @@ bool CapturePix(const Surface &buf, std::ofstream *out)
 	for (int height = buf.h(); height > 0; height--) {
 		const uint8_t *pBufferEnd = CaptureEnc(pixels, pBuffer.get(), width);
 		pixels += buf.pitch();
-		out->write(reinterpret_cast<const char *>(pBuffer.get()), pBufferEnd - pBuffer.get());
-		if (out->fail())
+		if (std::fwrite(pBuffer.get(), pBufferEnd - pBuffer.get(), 1, out) != 1)
 			return false;
 	}
 	return true;
 }
 
-std::ofstream CaptureFile(std::string *dstPath)
+FILE *CaptureFile(std::string *dstPath)
 {
 	std::time_t tt = std::time(nullptr);
 	std::tm *tm = std::localtime(&tt);
@@ -144,7 +142,7 @@ std::ofstream CaptureFile(std::string *dstPath)
 		i++;
 		*dstPath = StrCat(paths::PrefPath(), filename, "-", i, ".pcx");
 	}
-	return std::ofstream(*dstPath, std::ios::binary | std::ios::trunc);
+	return OpenFile(dstPath->c_str(), "wb");
 }
 
 /**
@@ -168,22 +166,22 @@ void CaptureScreen()
 	std::string fileName;
 	bool success;
 
-	std::ofstream outStream = CaptureFile(&fileName);
-	if (!outStream.is_open())
+	FILE *outStream = CaptureFile(&fileName);
+	if (outStream == nullptr)
 		return;
 	DrawAndBlit();
 	PaletteGetEntries(256, palette);
 	RedPalette();
 
 	const Surface &buf = GlobalBackBuffer();
-	success = CaptureHdr(buf.w(), buf.h(), &outStream);
+	success = CaptureHdr(buf.w(), buf.h(), outStream);
 	if (success) {
-		success = CapturePix(buf, &outStream);
+		success = CapturePix(buf, outStream);
 	}
 	if (success) {
-		success = CapturePal(palette, &outStream);
+		success = CapturePal(palette, outStream);
 	}
-	outStream.close();
+	std::fclose(outStream);
 
 	if (!success) {
 		Log("Failed to save screenshot at {}", fileName);

--- a/Source/dvlnet/tcp_client.cpp
+++ b/Source/dvlnet/tcp_client.cpp
@@ -6,7 +6,6 @@
 #include <exception>
 #include <functional>
 #include <memory>
-#include <sstream>
 #include <stdexcept>
 #include <system_error>
 

--- a/Source/engine/assets.hpp
+++ b/Source/engine/assets.hpp
@@ -81,7 +81,7 @@ struct AssetHandle {
 		return std::fread(buffer, len, 1, handle) == 1;
 	}
 
-	bool seek(std::ios::pos_type pos)
+	bool seek(long pos)
 	{
 		return std::fseek(handle, pos, SEEK_SET) == 0;
 	}
@@ -193,7 +193,7 @@ struct AssetHandle {
 		return handle->read(handle, buffer, len, 1) == 1;
 	}
 
-	bool seek(std::ios::pos_type pos)
+	bool seek(long pos)
 	{
 		return handle->seek(handle, pos, RW_SEEK_SET) != -1;
 	}

--- a/Source/mpq/mpq_writer.hpp
+++ b/Source/mpq/mpq_writer.hpp
@@ -67,7 +67,7 @@ private:
 #endif
 
 #ifndef CAN_SEEKP_BEYOND_EOF
-	std::streampos streamBegin_;
+	long streamBegin_;
 #endif
 };
 

--- a/Source/utils/endian_stream.hpp
+++ b/Source/utils/endian_stream.hpp
@@ -1,41 +1,40 @@
 #pragma once
 
+#include <cstdio>
 #include <cstring>
-
-#include <fstream>
 
 #include "utils/endian.hpp"
 
 namespace devilution {
 
 template <typename T = uint8_t>
-T ReadByte(std::ifstream &stream)
+T ReadByte(FILE *stream)
 {
 	static_assert(sizeof(T) == 1, "invalid argument");
 	char buf;
-	stream.read(&buf, 1);
+	std::fread(&buf, sizeof(buf), 1, stream);
 	return static_cast<T>(buf);
 }
 
 template <typename T = uint16_t>
-T ReadLE16(std::ifstream &stream)
+T ReadLE16(FILE *stream)
 {
 	static_assert(sizeof(T) == 2, "invalid argument");
 	char buf[2];
-	stream.read(buf, 2);
+	std::fread(buf, sizeof(buf), 1, stream);
 	return static_cast<T>(LoadLE16(buf));
 }
 
 template <typename T = uint32_t>
-T ReadLE32(std::ifstream &stream)
+T ReadLE32(FILE *stream)
 {
 	static_assert(sizeof(T) == 4, "invalid argument");
 	char buf[4];
-	stream.read(buf, 4);
+	std::fread(buf, sizeof(buf), 1, stream);
 	return static_cast<T>(LoadLE32(buf));
 }
 
-inline float ReadLEFloat(std::ifstream &stream)
+inline float ReadLEFloat(FILE *stream)
 {
 	static_assert(sizeof(float) == sizeof(uint32_t), "invalid float size");
 	const uint32_t val = ReadLE32(stream);
@@ -44,33 +43,33 @@ inline float ReadLEFloat(std::ifstream &stream)
 	return result;
 }
 
-inline void WriteByte(std::ofstream &out, uint8_t val)
+inline void WriteByte(FILE *out, uint8_t val)
 {
-	out.write(reinterpret_cast<const char *>(&val), 1);
+	std::fwrite(&val, sizeof(val), 1, out);
 }
 
-inline void WriteLE16(std::ofstream &out, uint16_t val)
+inline void WriteLE16(FILE *out, uint16_t val)
 {
 	char data[2];
 	WriteLE16(data, val);
-	out.write(data, 2);
+	std::fwrite(data, sizeof(data), 1, out);
 }
 
-inline void WriteLE32(std::ofstream &out, uint32_t val)
+inline void WriteLE32(FILE *out, uint32_t val)
 {
 	char data[4];
 	WriteLE32(data, val);
-	out.write(data, 4);
+	std::fwrite(data, sizeof(data), 1, out);
 }
 
-inline void WriteLEFloat(std::ofstream &out, float val)
+inline void WriteLEFloat(FILE *out, float val)
 {
 	static_assert(sizeof(float) == sizeof(uint32_t), "invalid float size");
 	uint32_t intVal;
 	memcpy(&intVal, &val, sizeof(uint32_t));
 	char data[4];
 	WriteLE32(data, intVal);
-	out.write(data, 4);
+	std::fwrite(data, sizeof(data), 1, out);
 }
 
 } // namespace devilution

--- a/Source/utils/file_util.h
+++ b/Source/utils/file_util.h
@@ -2,11 +2,9 @@
 
 #include <cstdint>
 #include <cstdio>
-#include <fstream>
 #include <memory>
 #include <string>
 
-#include "utils/stdcompat/optional.hpp"
 #include "utils/stdcompat/string_view.hpp"
 
 namespace devilution {
@@ -22,8 +20,8 @@ bool FileExistsAndIsWriteable(const char *path);
 bool GetFileSize(const char *path, std::uintmax_t *size);
 bool ResizeFile(const char *path, std::uintmax_t size);
 void RenameFile(const char *from, const char *to);
+void CopyFileOverwrite(const char *from, const char *to);
 void RemoveFile(const char *path);
-std::optional<std::fstream> CreateFileStream(const char *path, std::ios::openmode mode);
 FILE *OpenFile(const char *path, const char *mode);
 
 #if (defined(_WIN64) || defined(_WIN32)) && !defined(NXDK)

--- a/Source/utils/logged_fstream.cpp
+++ b/Source/utils/logged_fstream.cpp
@@ -2,38 +2,18 @@
 
 namespace devilution {
 
-const char *LoggedFStream::DirToString(std::ios::seekdir dir)
+const char *LoggedFStream::DirToString(int dir)
 {
 	switch (dir) {
-	case std::ios::beg:
-		return "std::ios::beg";
-	case std::ios::end:
-		return "std::ios::end";
-	case std::ios::cur:
-		return "std::ios::cur";
+	case SEEK_SET:
+		return "SEEK_SET";
+	case SEEK_END:
+		return "SEEK_END";
+	case SEEK_CUR:
+		return "SEEK_CUR";
 	default:
 		return "invalid";
 	}
-}
-
-std::string LoggedFStream::OpenModeToString(std::ios::openmode mode)
-{
-	std::string result;
-	if ((mode & std::ios::app) != 0)
-		result.append("std::ios::app | ");
-	if ((mode & std::ios::ate) != 0)
-		result.append("std::ios::ate | ");
-	if ((mode & std::ios::binary) != 0)
-		result.append("std::ios::binary | ");
-	if ((mode & std::ios::in) != 0)
-		result.append("std::ios::in | ");
-	if ((mode & std::ios::out) != 0)
-		result.append("std::ios::out | ");
-	if ((mode & std::ios::trunc) != 0)
-		result.append("std::ios::trunc | ");
-	if (!result.empty())
-		result.resize(result.size() - 3);
-	return result;
 }
 
 } // namespace devilution

--- a/test/file_util_test.cpp
+++ b/test/file_util_test.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <fstream>
-#include <iostream>
+#include <cstdio>
 
 #include "utils/file_util.h"
 
@@ -11,13 +10,15 @@ namespace {
 
 void WriteDummyFile(const char *name, std::uintmax_t size)
 {
-	std::ofstream test_file(name, std::ios::out | std::ios::trunc | std::ios::binary);
-	ASSERT_FALSE(test_file.fail());
+	std::printf("Writing test file %s\n", name);
+	FILE *test_file = std::fopen(name, "wb");
+	ASSERT_TRUE(test_file != nullptr);
 	const char c = '\0';
 	for (std::uintmax_t i = 0; i < size; ++i) {
-		test_file.write(&c, 1);
-		ASSERT_FALSE(test_file.fail());
+		std::fwrite(&c, sizeof(c), 1, test_file);
+		ASSERT_EQ(std::ferror(test_file), 0);
 	}
+	std::fclose(test_file);
 }
 
 std::string GetTmpPathName(const char *suffix = ".tmp")
@@ -34,7 +35,6 @@ std::string GetTmpPathName(const char *suffix = ".tmp")
 TEST(FileUtil, GetFileSize)
 {
 	const std::string path = GetTmpPathName();
-	std::cout << path << std::endl;
 	WriteDummyFile(path.c_str(), 42);
 	std::uintmax_t result;
 	ASSERT_TRUE(GetFileSize(path.c_str(), &result));
@@ -45,7 +45,6 @@ TEST(FileUtil, FileExists)
 {
 	EXPECT_FALSE(FileExists("this-file-should-not-exist"));
 	const std::string path = GetTmpPathName();
-	std::cout << path << std::endl;
 	WriteDummyFile(path.c_str(), 42);
 	EXPECT_TRUE(FileExists(path.c_str()));
 }
@@ -53,7 +52,6 @@ TEST(FileUtil, FileExists)
 TEST(FileUtil, ResizeFile)
 {
 	const std::string path = GetTmpPathName();
-	std::cout << path << std::endl;
 	WriteDummyFile(path.c_str(), 42);
 	std::uintmax_t size;
 	ASSERT_TRUE(GetFileSize(path.c_str(), &size));


### PR DESCRIPTION
1. Replaces `fstream` with `FILE *`.
2. Replaces `sstream` and `istream_buf` with `SplitByChar`.

Reduces binary size by ~2 KiB and may improve compatibility with oddball systems (e.g. PS2).