### PR TITLE
gcc: -fipa-pta -fdevirtualize-at-ltrans

### DIFF
--- a/CMake/platforms/rg99.cmake
+++ b/CMake/platforms/rg99.cmake
@@ -12,8 +12,7 @@ set(DEVILUTIONX_STATIC_CXX_STDLIB OFF)
 
 # -fmerge-all-constants saves ~4 KiB
 # -fsection-anchors saves ~4 KiB
-# -fipa-pta and -fdevirtualize-at-ltrans improves performance.
-set(_extra_flags "-fmerge-all-constants -fsection-anchors -fipa-pta -fdevirtualize-at-ltrans")
+set(_extra_flags "-fmerge-all-constants -fsection-anchors")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_extra_flags}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_extra_flags}")
 # -Wl,-z-stack-size: the default thread stack size for RG99 is 128 KiB, reduce it.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND NOT PS4)
   endif()
 endif()
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  # -fipa-pta and -fdevirtualize-at-ltrans improve performance.
+  add_compile_options("$<$<NOT:$<CONFIG:Debug>>:-fipa-pta;-fdevirtualize-at-ltrans>")
+endif()
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   add_compile_options("$<$<BOOL:${DEVILUTIONX_PROFILE_GENERATE}>:-fprofile-generate>")
   add_link_options("$<$<BOOL:${DEVILUTIONX_PROFILE_GENERATE}>:-fprofile-generate>")


### PR DESCRIPTION
Enable these options for all platforms that use GCC.

They do not seem to significantly affect build times on our codebase, while resulting in a slight 2-3% performance increase on low-end devices, such as RG-99.