### PR TITLE
Skip rendering on low-end devices

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -841,7 +841,7 @@ void RunGameLoop(interface_mode uMsg)
 
 		bool drawGame = true;
 		bool processInput = true;
-		bool runGameLoop = demo::IsRunning() ? demo::GetRunGameLoop(drawGame, processInput) : nthread_has_500ms_passed();
+		bool runGameLoop = demo::IsRunning() ? demo::GetRunGameLoop(drawGame, processInput) : nthread_has_500ms_passed(&drawGame);
 		if (demo::IsRecording())
 			demo::RecordGameLoopResult(runGameLoop);
 

--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -212,7 +212,7 @@ void nthread_ignore_mutex(bool bStart)
 	sgbThreadIsRunning = bStart;
 }
 
-bool nthread_has_500ms_passed()
+bool nthread_has_500ms_passed(bool *drawGame /*= nullptr*/)
 {
 	int currentTickCount = SDL_GetTicks();
 	int ticksElapsed = currentTickCount - last_tick;
@@ -233,6 +233,13 @@ bool nthread_has_500ms_passed()
 			last_tick = currentTickCount;
 			ticksElapsed = 0;
 		}
+	}
+	if (drawGame != nullptr) {
+		// Check if we missed a game tick.
+		// This can happen when we run a low-end device that can't render fast enough (typically 20fps).
+		// If this happens, try to speed-up the game by skipping the rendering.
+		// This avoids desyncs and hourglasses when running multiplayer and slowdowns in singleplayer.
+		*drawGame = ticksElapsed <= gnTickDelay;
 	}
 	return ticksElapsed >= 0;
 }

--- a/Source/nthread.h
+++ b/Source/nthread.h
@@ -32,7 +32,7 @@ void nthread_ignore_mutex(bool bStart);
  * @brief Checks if it's time for the logic to advance
  * @return True if the engine should tick
  */
-bool nthread_has_500ms_passed();
+bool nthread_has_500ms_passed(bool *drawGame = nullptr);
 /**
  * @brief Updates the progress in time to the next game tick
  */


### PR DESCRIPTION
Check if we missed a game tick.
This can happen when we run a low-end device that can't render fast enough (typically 20fps).
If this happens, try to speed-up the game by skipping the rendering.
This avoids desyncs and hourglasses when running multiplayer and slowdowns in singleplayer.

Edge-case:
If the game runs so slow, that we can't calculate the gamelogic in 50ms (one game tick) no frames will be rendered.
But if this happens the game should be unplayable anyway.

<details><summary>Comparison video</summary>

Comparison video with a ~10 fps (for testing I added a `_sleep(100);` in `DrawAndBlit`).

## Master ~10fps

https://user-images.githubusercontent.com/25415264/219756349-01cbef34-8cf7-41b7-8748-116a8f994ed3.mp4

## PR ~10fps

https://user-images.githubusercontent.com/25415264/219756458-23f09e44-0cd6-41ff-95fb-41d1aecaa30b.mp4

## Fast devices ~160fps

https://user-images.githubusercontent.com/25415264/219756974-4753f33d-5ceb-4fd3-99ca-45c537961542.mp4

</details>