### PR TITLE
Fix alignment for 2x2 armor sprite in the chest slot

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1122,12 +1122,9 @@ void DrawInv(const Surface &out)
 
 			auto frameSize = GetInvItemSize(cursId);
 
-			// calc item offsets for weapons smaller than 2x3 slots
-			if (slot == INVLOC_HAND_LEFT) {
+			// calc item offsets for weapons/armor smaller than 2x3 slots
+			if (IsAnyOf(slot, INVLOC_HAND_LEFT, INVLOC_HAND_RIGHT, INVLOC_CHEST)) {
 				screenX += frameSize.width == InventorySlotSizeInPixels.width ? INV_SLOT_HALF_SIZE_PX : 0;
-				screenY += frameSize.height == (3 * InventorySlotSizeInPixels.height) ? 0 : -INV_SLOT_HALF_SIZE_PX;
-			} else if (slot == INVLOC_HAND_RIGHT) {
-				screenX += frameSize.width == InventorySlotSizeInPixels.width ? (INV_SLOT_HALF_SIZE_PX - 1) : 1;
 				screenY += frameSize.height == (3 * InventorySlotSizeInPixels.height) ? 0 : -INV_SLOT_HALF_SIZE_PX;
 			}
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9203145/219889885-004ccc89-5e84-4a33-96a1-b7feb7959c8a.png)

After:
![image](https://user-images.githubusercontent.com/9203145/219889906-9db9412f-ca7e-4992-814d-4a5336098c1c.png)
