### PR TITLE
Perform some basic initialization before loading game data

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1109,7 +1109,7 @@ void CheckArchivesUpToDate()
 	}
 }
 
-void DiabloInit()
+void ApplicationInit()
 {
 	if (*sgOptions.Graphics.showFPS)
 		EnableFrameCount();
@@ -1130,6 +1130,11 @@ void DiabloInit()
 
 	SetApplicationVersions();
 
+	ReadOnlyTest();
+}
+
+void DiabloInit()
+{
 	for (size_t i = 0; i < QUICK_MESSAGE_OPTIONS; i++) {
 		auto &messages = sgOptions.Chat.szHotKeyMsgs[i];
 		if (messages.empty()) {
@@ -1143,8 +1148,6 @@ void DiabloInit()
 
 	UiInitialize();
 	was_ui_init = true;
-
-	ReadOnlyTest();
 
 	if (gbIsHellfire && !forceHellfire && *sgOptions.StartUp.gameMode == StartUpGameMode::Ask) {
 		UiSelStartUpGameOption();
@@ -2413,6 +2416,9 @@ int DiabloMain(int argc, char **argv)
 	LoadOptions();
 	// Then look for a voice pack file based on the selected translation
 	LoadLanguageArchive();
+
+	ApplicationInit();
+	SaveOptions();
 
 	// Finally load game data
 	LoadGameArchives();


### PR DESCRIPTION
Some of the initialization steps in `DiabloInit()` did not require the game data to be loaded in order to perform them. This moves those steps earlier in the startup process, providing a couple benefits.

* Errors that occur while loading game data couldn't display the proper error dialog because the main window hadn't been created yet. This change prioritizes window creation so the error dialog can be displayed for those errors.
* `SaveOptions()` can be called after calling `ReadOnlyTest()` and before attempting to load game archives, allowing for #5796 to be resolved.

Here is some proof that the error dialog still works properly for `ReadOnlyTest()` despite changing the order of events.
![image](https://user-images.githubusercontent.com/9203145/219932295-cf93a730-983c-425e-9a77-4bac28ce4697.png)

Also, here is an error dialog that didn't previously show up properly because the main window was created too late.
![image](https://user-images.githubusercontent.com/9203145/219932322-669e5d69-5eda-4eea-a209-ad1355e0481e.png)

This resolves #5796