### PR TITLE
Fix crash with locale=ja and missing fonts.mpq

### DIFF
--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -378,6 +378,8 @@ void LanguageInitialize()
 		        "Please download fonts.mpq from:\n"
 		        "github.com/diasurgical/\ndevilutionx-assets/releases"));
 		forceLocale = "en";
+		GetLocalPluralId = PluralIfNotOne;
+		return;
 	}
 
 	AssetHandle handle;


### PR DESCRIPTION
After clicking OK on the error message, the game proceeded to try to display the main menu in Japanese, resulting in a crash. Fixes #5818.