### PR TITLE
Multiplayer: Enable Gharbad the Week Quest

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1408,11 +1408,14 @@ void MonsterTalk(Monster &monster)
 	if (monster.uniqueType == UniqueMonsterType::Garbud) {
 		if (monster.talkMsg == TEXT_GARBUD1) {
 			Quests[Q_GARBUD]._qactive = QUEST_ACTIVE;
-			Quests[Q_GARBUD]._qlog = true; // BUGFIX: (?) for other quests qactive and qlog go together, maybe this should actually go into the if above (fixed)
+			Quests[Q_GARBUD]._qlog = true;
+			NetSendCmdQuest(true, Quests[Q_GARBUD]);
 		}
 		if (monster.talkMsg == TEXT_GARBUD2 && (monster.flags & MFLAG_QUEST_COMPLETE) == 0) {
 			SpawnItem(monster, monster.position.tile + Displacement { 1, 1 }, true);
 			monster.flags |= MFLAG_QUEST_COMPLETE;
+			Quests[Q_GARBUD]._qvar1 = QS_GHARBAD_FIRST_ITEM_SPAWNED;
+			NetSendCmdQuest(true, Quests[Q_GARBUD]);
 		}
 	}
 	if (monster.uniqueType == UniqueMonsterType::Zhar
@@ -2505,12 +2508,18 @@ void GharbadAi(Monster &monster)
 		switch (monster.talkMsg) {
 		case TEXT_GARBUD1:
 			monster.talkMsg = TEXT_GARBUD2;
+			Quests[Q_GARBUD]._qvar1 = QS_GHARBAD_FIRST_ITEM_READY;
+			NetSendCmdQuest(true, Quests[Q_GARBUD]);
 			break;
 		case TEXT_GARBUD2:
 			monster.talkMsg = TEXT_GARBUD3;
+			Quests[Q_GARBUD]._qvar1 = QS_GHARBAD_SECOND_ITEM_NEARLY_DONE;
+			NetSendCmdQuest(true, Quests[Q_GARBUD]);
 			break;
 		case TEXT_GARBUD3:
 			monster.talkMsg = TEXT_GARBUD4;
+			Quests[Q_GARBUD]._qvar1 = QS_GHARBAD_SECOND_ITEM_READY;
+			NetSendCmdQuest(true, Quests[Q_GARBUD]);
 			break;
 		default:
 			break;
@@ -2523,6 +2532,8 @@ void GharbadAi(Monster &monster)
 				monster.goal = MonsterGoal::Normal;
 				monster.activeForTicks = UINT8_MAX;
 				monster.talkMsg = TEXT_NONE;
+				Quests[Q_GARBUD]._qvar1 = QS_GHARBAD_ATTACKING;
+				NetSendCmdQuest(true, Quests[Q_GARBUD]);
 			}
 		}
 	}

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -426,6 +426,7 @@ void CheckQuestKill(const Monster &monster, bool sendmsg)
 			NetSendCmdQuest(true, quest);
 	} else if (monster.uniqueType == UniqueMonsterType::Garbud) { //"Gharbad the Weak"
 		Quests[Q_GARBUD]._qactive = QUEST_DONE;
+		NetSendCmdQuest(true, Quests[Q_GARBUD]);
 		myPlayer.Say(HeroSpeech::ImNotImpressed, 30);
 	} else if (monster.uniqueType == UniqueMonsterType::Zhar) { //"Zhar the Mad"
 		Quests[Q_ZHAR]._qactive = QUEST_DONE;
@@ -719,6 +720,37 @@ void ResyncQuests()
 	    && Quests[Q_PWATER]._qactive == QUEST_DONE
 	    && gbIsMultiplayer) {
 		CleanTownFountain();
+	}
+	if (Quests[Q_GARBUD].IsAvailable() && gbIsMultiplayer) {
+		Monster *garbud = FindUniqueMonster(UniqueMonsterType::Garbud);
+		if (garbud != nullptr && Quests[Q_GARBUD]._qvar1 != QS_GHARBAD_INIT) {
+			switch (Quests[Q_GARBUD]._qvar1) {
+			case QS_GHARBAD_FIRST_ITEM_READY:
+				garbud->goal = MonsterGoal::Inquiring;
+				break;
+			case QS_GHARBAD_FIRST_ITEM_SPAWNED:
+				garbud->talkMsg = TEXT_GARBUD2;
+				garbud->flags |= MFLAG_QUEST_COMPLETE;
+				garbud->goal = MonsterGoal::Talking;
+				break;
+			case QS_GHARBAD_SECOND_ITEM_NEARLY_DONE:
+				garbud->talkMsg = TEXT_GARBUD3;
+				garbud->flags |= MFLAG_QUEST_COMPLETE;
+				garbud->goal = MonsterGoal::Inquiring;
+				break;
+			case QS_GHARBAD_SECOND_ITEM_READY:
+				garbud->talkMsg = TEXT_GARBUD4;
+				garbud->flags |= MFLAG_QUEST_COMPLETE;
+				garbud->goal = MonsterGoal::Inquiring;
+				break;
+			case QS_GHARBAD_ATTACKING:
+				garbud->talkMsg = TEXT_NONE;
+				garbud->flags |= MFLAG_QUEST_COMPLETE;
+				garbud->goal = MonsterGoal::Normal;
+				garbud->activeForTicks = UINT8_MAX;
+				break;
+			}
+		}
 	}
 }
 

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -33,6 +33,16 @@ enum {
 	QS_BRAINGIVEN,
 };
 
+/** @brief States of the gharbad the week quest for multiplayer sync */
+enum {
+	QS_GHARBAD_INIT,
+	QS_GHARBAD_FIRST_ITEM_READY,
+	QS_GHARBAD_FIRST_ITEM_SPAWNED,
+	QS_GHARBAD_SECOND_ITEM_NEARLY_DONE,
+	QS_GHARBAD_SECOND_ITEM_READY,
+	QS_GHARBAD_ATTACKING,
+};
+
 enum quest_state : uint8_t {
 	QUEST_NOTAVAIL, // quest did not spawn this game
 	QUEST_INIT,     // quest has spawned, waiting to trigger


### PR DESCRIPTION
Contributes to #926

Monster `talkmsg` and `flags` is not synced in multiplayer.
In multiplayer `_qvar1` is used to sync Gharbad's state.

Remaining quests:
- Zhar the Mad
- Warlord of Blood
- Lachdanan