### PR TITLE
Multiplayer: Enable Zhar the Mad Quest

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1423,8 +1423,10 @@ void MonsterTalk(Monster &monster)
 	    && (monster.flags & MFLAG_QUEST_COMPLETE) == 0) {
 		Quests[Q_ZHAR]._qactive = QUEST_ACTIVE;
 		Quests[Q_ZHAR]._qlog = true;
+		Quests[Q_ZHAR]._qvar1 = QS_ZHAR_ITEM_SPAWNED;
 		CreateTypeItem(monster.position.tile + Displacement { 1, 1 }, false, ItemType::Misc, IMISC_BOOK, true, false);
 		monster.flags |= MFLAG_QUEST_COMPLETE;
+		NetSendCmdQuest(true, Quests[Q_ZHAR]);
 	}
 	if (monster.uniqueType == UniqueMonsterType::SnotSpill) {
 		if (monster.talkMsg == TEXT_BANNER10 && (monster.flags & MFLAG_QUEST_COMPLETE) == 0) {
@@ -2709,6 +2711,8 @@ void ZharAi(Monster &monster)
 	if (monster.talkMsg == TEXT_ZHAR1 && !IsTileVisible(monster.position.tile) && monster.goal == MonsterGoal::Talking) {
 		monster.talkMsg = TEXT_ZHAR2;
 		monster.goal = MonsterGoal::Inquiring;
+		Quests[Q_ZHAR]._qvar1 = QS_ZHAR_ANGRY;
+		NetSendCmdQuest(true, Quests[Q_ZHAR]);
 	}
 
 	if (IsTileVisible(monster.position.tile)) {
@@ -2717,6 +2721,8 @@ void ZharAi(Monster &monster)
 				monster.activeForTicks = UINT8_MAX;
 				monster.talkMsg = TEXT_NONE;
 				monster.goal = MonsterGoal::Normal;
+				Quests[Q_ZHAR]._qvar1 = QS_ZHAR_ATTACKING;
+				NetSendCmdQuest(true, Quests[Q_ZHAR]);
 			}
 		}
 	}

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -430,6 +430,7 @@ void CheckQuestKill(const Monster &monster, bool sendmsg)
 		myPlayer.Say(HeroSpeech::ImNotImpressed, 30);
 	} else if (monster.uniqueType == UniqueMonsterType::Zhar) { //"Zhar the Mad"
 		Quests[Q_ZHAR]._qactive = QUEST_DONE;
+		NetSendCmdQuest(true, Quests[Q_ZHAR]);
 		myPlayer.Say(HeroSpeech::ImSorryDidIBreakYourConcentration, 30);
 	} else if (monster.uniqueType == UniqueMonsterType::Lazarus) { //"Arch-Bishop Lazarus"
 		auto &betrayerQuest = Quests[Q_BETRAYER];
@@ -748,6 +749,27 @@ void ResyncQuests()
 				garbud->flags |= MFLAG_QUEST_COMPLETE;
 				garbud->goal = MonsterGoal::Normal;
 				garbud->activeForTicks = UINT8_MAX;
+				break;
+			}
+		}
+	}
+	if (Quests[Q_ZHAR].IsAvailable() && gbIsMultiplayer) {
+		Monster *zhar = FindUniqueMonster(UniqueMonsterType::Zhar);
+		if (zhar != nullptr && Quests[Q_ZHAR]._qvar1 != QS_ZHAR_INIT) {
+			zhar->flags |= MFLAG_QUEST_COMPLETE;
+
+			switch (Quests[Q_ZHAR]._qvar1) {
+			case QS_ZHAR_ITEM_SPAWNED:
+				zhar->goal = MonsterGoal::Talking;
+				break;
+			case QS_ZHAR_ANGRY:
+				zhar->talkMsg = TEXT_ZHAR2;
+				zhar->goal = MonsterGoal::Inquiring;
+				break;
+			case QS_ZHAR_ATTACKING:
+				zhar->talkMsg = TEXT_NONE;
+				zhar->goal = MonsterGoal::Normal;
+				zhar->activeForTicks = UINT8_MAX;
 				break;
 			}
 		}

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -43,7 +43,7 @@ enum {
 	QS_GHARBAD_ATTACKING,
 };
 
-/** @brief States of the zhar the ma the week quest for multiplayer sync */
+/** @brief States of Zhar the Mad quest for multiplayer sync */
 enum {
 	QS_ZHAR_INIT,
 	QS_ZHAR_ITEM_SPAWNED,

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -43,6 +43,14 @@ enum {
 	QS_GHARBAD_ATTACKING,
 };
 
+/** @brief States of the zhar the ma the week quest for multiplayer sync */
+enum {
+	QS_ZHAR_INIT,
+	QS_ZHAR_ITEM_SPAWNED,
+	QS_ZHAR_ANGRY,
+	QS_ZHAR_ATTACKING,
+};
+
 enum quest_state : uint8_t {
 	QUEST_NOTAVAIL, // quest did not spawn this game
 	QUEST_INIT,     // quest has spawned, waiting to trigger


### PR DESCRIPTION
Contributes to #926

Monster `talkmsg` and `flags` is not synced in multiplayer.
In multiplayer `_qvar1` is used to sync Zhar's state.

Remaining quests:
- Warlord of Blood
- Lachdanan