### PR TITLE
Move initialization of gbIsHellfire back to DiabloInit()

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1117,15 +1117,6 @@ void ApplicationInit()
 	init_create_window();
 	was_window_init = true;
 
-	if (forceSpawn || *sgOptions.StartUp.shareware)
-		gbIsSpawn = true;
-	if (forceDiablo || *sgOptions.StartUp.gameMode == StartUpGameMode::Diablo)
-		gbIsHellfire = false;
-	if (forceHellfire)
-		gbIsHellfire = true;
-
-	gbIsHellfireSaveGame = gbIsHellfire;
-
 	LanguageInitialize();
 
 	SetApplicationVersions();
@@ -1135,6 +1126,15 @@ void ApplicationInit()
 
 void DiabloInit()
 {
+	if (forceSpawn || *sgOptions.StartUp.shareware)
+		gbIsSpawn = true;
+	if (forceDiablo || *sgOptions.StartUp.gameMode == StartUpGameMode::Diablo)
+		gbIsHellfire = false;
+	if (forceHellfire)
+		gbIsHellfire = true;
+
+	gbIsHellfireSaveGame = gbIsHellfire;
+
 	for (size_t i = 0; i < QUICK_MESSAGE_OPTIONS; i++) {
 		auto &messages = sgOptions.Chat.szHotKeyMsgs[i];
 		if (messages.empty()) {


### PR DESCRIPTION
`gbIsHellfire` and `gbIsSpawn` are initialized to `true` in `LoadGameArchives()` based on the set of MPQs the game client detects in the data directory. This enables us to select appropriate defaults based on the existence of specific MPQs and then override them with the INI settings in `DiabloInit()` if necessary. Therefore, these statements that initialize `gbIsHellfire` and `gbIsSpawn` from startup options and INI settings need to be executed after `LoadGameArchives()`.

Also, in hindsight, it just seems appropriate to initialize these Diablo-specific variables in `DiabloInit()` rather than `ApplicationInit()`.

This resolves #5824