### PR TITLE
Multiplayer: Enable Warlord of Blood Quest

### DIFF
--- a/Source/levels/drlg_l4.cpp
+++ b/Source/levels/drlg_l4.cpp
@@ -251,7 +251,6 @@ void FirstRoom()
 	WorldTileRectangle room { { 0, 0 }, { 14, 14 } };
 	if (currlevel != 16) {
 		if (currlevel == Quests[Q_WARLORD]._qlevel && Quests[Q_WARLORD]._qactive != QUEST_NOTAVAIL) {
-			assert(!gbIsMultiplayer);
 			room.size = { 11, 11 };
 		} else if (currlevel == Quests[Q_BETRAYER]._qlevel && UseMultiplayerQuests()) {
 			room.size = { 11, 11 };

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1455,8 +1455,10 @@ void MonsterTalk(Monster &monster)
 			monster.flags |= MFLAG_QUEST_COMPLETE;
 		}
 	}
-	if (monster.uniqueType == UniqueMonsterType::WarlordOfBlood)
-		Quests[Q_WARLORD]._qvar1 = 2;
+	if (monster.uniqueType == UniqueMonsterType::WarlordOfBlood) {
+		Quests[Q_WARLORD]._qvar1 = QS_WARLORD_TALKING;
+		NetSendCmdQuest(true, Quests[Q_WARLORD]);
+	}
 	if (monster.uniqueType == UniqueMonsterType::Lazarus && UseMultiplayerQuests()) {
 		Quests[Q_BETRAYER]._qvar1 = 6;
 		monster.goal = MonsterGoal::Normal;
@@ -2906,6 +2908,8 @@ void WarlordAi(Monster &monster)
 			monster.activeForTicks = UINT8_MAX;
 			monster.talkMsg = TEXT_NONE;
 			monster.goal = MonsterGoal::Normal;
+			Quests[Q_WARLORD]._qvar1 = QS_WARLORD_ATTACKING;
+			NetSendCmdQuest(true, Quests[Q_WARLORD]);
 		}
 	}
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2002,10 +2002,11 @@ void OperateBookLever(Object &questBook, bool sendmsg)
 			if (sendmsg)
 				SpawnQuestItem(IDI_BLDSTONE, SetPiece.position.megaToWorld() + Displacement { 9, 17 }, 0, 1, true);
 		}
-		if (questBook._otype == OBJ_STEELTOME && Quests[Q_WARLORD]._qvar1 == 0) {
+		if (questBook._otype == OBJ_STEELTOME && Quests[Q_WARLORD]._qvar1 == QS_WARLORD_INIT) {
 			Quests[Q_WARLORD]._qactive = QUEST_ACTIVE;
 			Quests[Q_WARLORD]._qlog = true;
-			Quests[Q_WARLORD]._qvar1 = 1;
+			Quests[Q_WARLORD]._qvar1 = QS_WARLORD_STEELTOME_READ;
+			NetSendCmdQuest(true, Quests[Q_WARLORD]);
 		}
 		if (questBook._oAnimFrame != questBook._oVar6) {
 			if (questBook._otype != OBJ_BLOODBOOK)

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -461,6 +461,7 @@ void CheckQuestKill(const Monster &monster, bool sendmsg)
 		}
 	} else if (monster.uniqueType == UniqueMonsterType::WarlordOfBlood) {
 		Quests[Q_WARLORD]._qactive = QUEST_DONE;
+		NetSendCmdQuest(true, Quests[Q_WARLORD]);
 		myPlayer.Say(HeroSpeech::YourReignOfPainHasEnded, 30);
 	}
 }
@@ -772,6 +773,14 @@ void ResyncQuests()
 				zhar->activeForTicks = UINT8_MAX;
 				break;
 			}
+		}
+	}
+	if (Quests[Q_WARLORD].IsAvailable() && gbIsMultiplayer) {
+		Monster *warlord = FindUniqueMonster(UniqueMonsterType::WarlordOfBlood);
+		if (warlord != nullptr && Quests[Q_WARLORD]._qvar1 == QS_WARLORD_ATTACKING) {
+			warlord->activeForTicks = UINT8_MAX;
+			warlord->talkMsg = TEXT_NONE;
+			warlord->goal = MonsterGoal::Normal;
 		}
 	}
 }

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -51,6 +51,15 @@ enum {
 	QS_ZHAR_ATTACKING,
 };
 
+/** @brief States of the Warlord of Blood quest */
+enum {
+	QS_WARLORD_INIT,
+	QS_WARLORD_STEELTOME_READ,
+	QS_WARLORD_TALKING,
+	/** @brief State only added for multiplayer quests. Doesn't affect vanilla compatibility. */
+	QS_WARLORD_ATTACKING,
+};
+
 enum quest_state : uint8_t {
 	QUEST_NOTAVAIL, // quest did not spawn this game
 	QUEST_INIT,     // quest has spawned, waiting to trigger


### PR DESCRIPTION
Contributes to #926

Monster `talkmsg` and `goal` is not synced in multiplayer.
In multiplayer `_qvar1` is used to sync Warlord's attacking state.
This additional `_qvar1` should not interfere with vanilla/old saves.
I added a enum for all quest states.

Remaining quest:
- Lachdanan