### PR TITLE
Multiplayer: Enable Lachdanan Quest

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2309,8 +2309,12 @@ void InitItems()
 		if (sgGameInitInfo.bCowQuest != 0 && currlevel == 19)
 			SpawnQuestItem(IDI_GREYSUIT, { 25, 25 }, 3, 1, false);
 		// In multiplayer items spawn during level generation to avoid desyncs
-		if (gbIsMultiplayer && Quests[Q_MUSHROOM].IsAvailable())
-			SpawnQuestItem(IDI_FUNGALTM, { 0, 0 }, 5, 1, false);
+		if (gbIsMultiplayer) {
+			if (Quests[Q_MUSHROOM].IsAvailable())
+				SpawnQuestItem(IDI_FUNGALTM, { 0, 0 }, 5, 1, false);
+			if (currlevel == Quests[Q_VEIL]._qlevel + 1 && Quests[Q_VEIL]._qactive != QUEST_NOTAVAIL)
+				SpawnQuestItem(IDI_GLDNELIX, { 0, 0 }, 5, 1, false);
+		}
 		if (currlevel > 0 && currlevel < 16)
 			AddInitItems();
 		if (currlevel >= 21 && currlevel <= 23)

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -680,9 +680,10 @@ void ResyncQuests()
 			}
 		}
 	}
-	if (currlevel == Quests[Q_VEIL]._qlevel + 1 && Quests[Q_VEIL]._qactive == QUEST_ACTIVE && Quests[Q_VEIL]._qvar1 == 0) {
+	if (currlevel == Quests[Q_VEIL]._qlevel + 1 && Quests[Q_VEIL]._qactive == QUEST_ACTIVE && Quests[Q_VEIL]._qvar1 == 0 && !gbIsMultiplayer) {
 		Quests[Q_VEIL]._qvar1 = 1;
-		SpawnQuestItem(IDI_GLDNELIX, { 0, 0 }, 5, 1, false);
+		SpawnQuestItem(IDI_GLDNELIX, { 0, 0 }, 5, 1, true);
+		NetSendCmdQuest(true, Quests[Q_VEIL]);
 	}
 	if (setlevel && setlvlnum == SL_VILEBETRAYER) {
 		if (Quests[Q_BETRAYER]._qvar1 >= 4)
@@ -781,6 +782,24 @@ void ResyncQuests()
 			warlord->activeForTicks = UINT8_MAX;
 			warlord->talkMsg = TEXT_NONE;
 			warlord->goal = MonsterGoal::Normal;
+		}
+	}
+	if (Quests[Q_VEIL].IsAvailable() && gbIsMultiplayer) {
+		Monster *lachdan = FindUniqueMonster(UniqueMonsterType::Lachdan);
+		if (lachdan != nullptr) {
+			switch (Quests[Q_VEIL]._qvar2) {
+			case QS_VEIL_EARLY_RETURN:
+				lachdan->talkMsg = TEXT_VEIL10;
+				lachdan->goal = MonsterGoal::Inquiring;
+				break;
+			case QS_VEIL_ITEM_SPAWNED:
+				if (lachdan->talkMsg == TEXT_VEIL11)
+					break;
+				lachdan->talkMsg = TEXT_VEIL11;
+				lachdan->flags |= MFLAG_QUEST_COMPLETE;
+				lachdan->goal = MonsterGoal::Inquiring;
+				break;
+			}
 		}
 	}
 }

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -60,6 +60,13 @@ enum {
 	QS_WARLORD_ATTACKING,
 };
 
+/** @brief States of Lachdanan quest for multiplayer sync */
+enum {
+	QS_VEIL_INIT,
+	QS_VEIL_EARLY_RETURN,
+	QS_VEIL_ITEM_SPAWNED,
+};
+
 enum quest_state : uint8_t {
 	QUEST_NOTAVAIL, // quest did not spawn this game
 	QUEST_INIT,     // quest has spawned, waiting to trigger


### PR DESCRIPTION
Contributes to #926

Monster `talkmsg` and `goal` is not synced in multiplayer.
In multiplayer `_qvar2` is used to sync Lachdanan's state.
I changed where the unique is spawned (from `MonsterTalk` to `TalktoMonster`), so I can check that only one player (that talks to lachdanan) spawns the Veil of Steel.

Remaining quest:
- None 🚀🎉

... but many bugs. 😁 

Next step after this pr is adding a toggle for switching between classic multiplayer quests and singleplayer quests in multiplayer.