### PR TITLE
Add option to enable singleplayer quests in multiplayer

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -485,6 +485,7 @@ void InitGameInfo()
 	sgGameInitInfo.bTheoQuest = *sgOptions.Gameplay.theoQuest ? 1 : 0;
 	sgGameInitInfo.bCowQuest = *sgOptions.Gameplay.cowQuest ? 1 : 0;
 	sgGameInitInfo.bFriendlyFire = *sgOptions.Gameplay.friendlyFire ? 1 : 0;
+	sgGameInitInfo.fullQuests = (!gbIsMultiplayer || *sgOptions.Gameplay.multiplayerFullQuests) ? 1 : 0;
 }
 
 void NetSendLoPri(int playerId, const byte *data, size_t size)

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -31,6 +31,7 @@ struct GameData {
 	uint8_t bTheoQuest;
 	uint8_t bCowQuest;
 	uint8_t bFriendlyFire;
+	uint8_t fullQuests;
 };
 
 /* @brief Contains info of running public game (for game list browsing) */
@@ -44,7 +45,7 @@ extern bool gbSomebodyWonGameKludge;
 extern uint16_t sgwPackPlrOffsetTbl[MAX_PLRS];
 extern uint8_t gbActivePlayers;
 extern bool gbGameDestroyed;
-extern GameData sgGameInitInfo;
+extern DVL_API_FOR_TEST GameData sgGameInitInfo;
 extern bool gbSelectProvider;
 extern DVL_API_FOR_TEST bool gbIsMultiplayer;
 extern std::string GameName;

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1062,6 +1062,7 @@ GameplayOptions::GameplayOptions()
     , theoQuest("Theo Quest", OptionEntryFlags::CantChangeInGame | OptionEntryFlags::OnlyHellfire, N_("Theo Quest"), N_("Enable Little Girl quest."), false)
     , cowQuest("Cow Quest", OptionEntryFlags::CantChangeInGame | OptionEntryFlags::OnlyHellfire, N_("Cow Quest"), N_("Enable Jersey's quest. Lester the farmer is replaced by the Complete Nut."), false)
     , friendlyFire("Friendly Fire", OptionEntryFlags::CantChangeInMultiPlayer, N_("Friendly Fire"), N_("Allow arrow/spell damage between players in multiplayer even when the friendly mode is on."), true)
+    , multiplayerFullQuests("MultiplayerFullQuests", OptionEntryFlags::CantChangeInMultiPlayer, N_("Full quests in Multiplayer"), N_("Enables the full/uncut singleplayer version of quests."), false)
     , testBard("Test Bard", OptionEntryFlags::CantChangeInGame, N_("Test Bard"), N_("Force the Bard character type to appear in the hero selection menu."), false)
     , testBarbarian("Test Barbarian", OptionEntryFlags::CantChangeInGame, N_("Test Barbarian"), N_("Force the Barbarian character type to appear in the hero selection menu."), false)
     , experienceBar("Experience Bar", OptionEntryFlags::None, N_("Experience Bar"), N_("Experience Bar is added to the UI at the bottom of the screen."), false)
@@ -1110,6 +1111,7 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&theoQuest,
 		&cowQuest,
 		&friendlyFire,
+		&multiplayerFullQuests,
 		&testBard,
 		&testBarbarian,
 		&experienceBar,

--- a/Source/options.h
+++ b/Source/options.h
@@ -540,6 +540,8 @@ struct GameplayOptions : OptionCategoryBase {
 	OptionEntryBoolean cowQuest;
 	/** @brief Will players still damage other players in non-PvP mode. */
 	OptionEntryBoolean friendlyFire;
+	/** @brief Enables the full/uncut singleplayer version of quests. */
+	OptionEntryBoolean multiplayerFullQuests;
 	/** @brief Enable the bard hero class. */
 	OptionEntryBoolean testBard;
 	/** @brief Enable the babarian hero class. */

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -945,7 +945,7 @@ void SetMultiQuest(int q, quest_state s, bool log, int v1, int v2, int16_t qmsg)
 
 bool UseMultiplayerQuests()
 {
-	return gbIsMultiplayer;
+	return sgGameInitInfo.fullQuests == 0;
 }
 
 bool Quest::IsAvailable()

--- a/test/drlg_l1_test.cpp
+++ b/test/drlg_l1_test.cpp
@@ -1,8 +1,6 @@
 #include <gtest/gtest.h>
 
 #include "drlg_test.hpp"
-#include "player.h"
-#include "quests.h"
 
 using namespace devilution;
 
@@ -12,9 +10,7 @@ TEST(Drlg_l1, CreateL5Dungeon_diablo_1_2588)
 {
 	LoadExpectedLevelData("diablo/1-2588.dun");
 
-	Players.resize(1);
-	MyPlayer = &Players[0];
-	MyPlayer->pOriginalCathedral = true;
+	TestInitGame();
 
 	TestCreateDungeon(1, 2588, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(77, 46));
@@ -26,9 +22,7 @@ TEST(Drlg_l1, CreateL5Dungeon_diablo_1_743271966)
 {
 	LoadExpectedLevelData("diablo/1-743271966.dun");
 
-	Players.resize(1);
-	MyPlayer = &Players[0];
-	MyPlayer->pOriginalCathedral = true;
+	TestInitGame();
 
 	TestCreateDungeon(1, 743271966, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(51, 82));
@@ -40,11 +34,7 @@ TEST(Drlg_l1, CreateL5Dungeon_diablo_2_1383137027)
 {
 	LoadExpectedLevelData("diablo/2-1383137027.dun");
 
-	Players.resize(1);
-	MyPlayer = &Players[0];
-	MyPlayer->pOriginalCathedral = true;
-
-	InitQuests();
+	TestInitGame();
 	Quests[Q_PWATER]._qactive = QUEST_INIT;
 	Quests[Q_BUTCHER]._qactive = QUEST_NOTAVAIL;
 
@@ -60,10 +50,7 @@ TEST(Drlg_l1, CreateL5Dungeon_diablo_3_844660068)
 {
 	LoadExpectedLevelData("diablo/3-844660068.dun");
 
-	Players.resize(1);
-	MyPlayer = &Players[0];
-	MyPlayer->pOriginalCathedral = true;
-	Quests[Q_SKELKING]._qactive = QUEST_NOTAVAIL;
+	TestInitGame();
 
 	TestCreateDungeon(3, 844660068, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(67, 52));
@@ -75,9 +62,7 @@ TEST(Drlg_l1, CreateL5Dungeon_diablo_4_609325643)
 {
 	LoadExpectedLevelData("diablo/4-609325643.dun");
 
-	Players.resize(1);
-	MyPlayer = &Players[0];
-	MyPlayer->pOriginalCathedral = true;
+	TestInitGame();
 	Quests[Q_LTBANNER]._qactive = QUEST_NOTAVAIL;
 
 	TestCreateDungeon(4, 609325643, ENTRY_MAIN);
@@ -90,9 +75,7 @@ TEST(Drlg_l1, CreateL5Dungeon_hellfire_1_401921334)
 {
 	LoadExpectedLevelData("hellfire/1-401921334.dun");
 
-	Players.resize(1);
-	MyPlayer = &Players[0];
-	MyPlayer->pOriginalCathedral = false;
+	TestInitGame(true, false);
 
 	TestCreateDungeon(1, 401921334, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(79, 80));
@@ -104,9 +87,7 @@ TEST(Drlg_l1, CreateL5Dungeon_hellfire_1_536340718)
 {
 	LoadExpectedLevelData("hellfire/1-536340718.dun");
 
-	Players.resize(1);
-	MyPlayer = &Players[0];
-	MyPlayer->pOriginalCathedral = false;
+	TestInitGame(true, false);
 
 	TestCreateDungeon(1, 536340718, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(55, 72));
@@ -118,10 +99,7 @@ TEST(Drlg_l1, CreateL5Dungeon_hellfire_2_128964898)
 {
 	LoadExpectedLevelData("hellfire/2-128964898.dun");
 
-	Players.resize(1);
-	MyPlayer = &Players[0];
-	MyPlayer->pOriginalCathedral = false;
-	InitQuests();
+	TestInitGame(true, false);
 	Quests[Q_PWATER]._qactive = QUEST_NOTAVAIL;
 	Quests[Q_BUTCHER]._qactive = QUEST_NOTAVAIL;
 
@@ -135,10 +113,7 @@ TEST(Drlg_l1, CreateL5Dungeon_hellfire_2_1180526547)
 {
 	LoadExpectedLevelData("hellfire/2-1180526547.dun");
 
-	Players.resize(1);
-	MyPlayer = &Players[0];
-	MyPlayer->pOriginalCathedral = false;
-	InitQuests();
+	TestInitGame(true, false);
 	Quests[Q_PWATER]._qactive = QUEST_NOTAVAIL;
 	Quests[Q_BUTCHER]._qactive = QUEST_INIT;
 
@@ -152,10 +127,7 @@ TEST(Drlg_l1, CreateL5Dungeon_hellfire_3_1369955278)
 {
 	LoadExpectedLevelData("hellfire/3-1369955278.dun");
 
-	Players.resize(1);
-	MyPlayer = &Players[0];
-	MyPlayer->pOriginalCathedral = false;
-	InitQuests();
+	TestInitGame(true, false);
 	Quests[Q_SKELKING]._qactive = QUEST_INIT;
 
 	TestCreateDungeon(3, 1369955278, ENTRY_MAIN);
@@ -168,10 +140,7 @@ TEST(Drlg_l1, CreateL5Dungeon_hellfire_3_1799396623)
 {
 	LoadExpectedLevelData("hellfire/3-1799396623.dun");
 
-	Players.resize(1);
-	MyPlayer = &Players[0];
-	MyPlayer->pOriginalCathedral = false;
-	InitQuests();
+	TestInitGame(true, false);
 	Quests[Q_SKELKING]._qactive = QUEST_NOTAVAIL;
 
 	TestCreateDungeon(3, 1799396623, ENTRY_MAIN);
@@ -184,10 +153,7 @@ TEST(Drlg_l1, CreateL5Dungeon_hellfire_3_1512491184)
 {
 	LoadExpectedLevelData("hellfire/3-1512491184.dun");
 
-	Players.resize(1);
-	MyPlayer = &Players[0];
-	MyPlayer->pOriginalCathedral = false;
-	InitQuests();
+	TestInitGame(true, false);
 	Quests[Q_SKELKING]._qactive = QUEST_INIT;
 
 	TestCreateDungeon(3, 1512491184, ENTRY_MAIN);
@@ -200,10 +166,7 @@ TEST(Drlg_l1, CreateL5Dungeon_hellfire_4_1190318991)
 {
 	LoadExpectedLevelData("hellfire/4-1190318991.dun");
 
-	Players.resize(1);
-	MyPlayer = &Players[0];
-	MyPlayer->pOriginalCathedral = false;
-	InitQuests();
+	TestInitGame(true, false);
 	Quests[Q_LTBANNER]._qactive = QUEST_NOTAVAIL;
 
 	TestCreateDungeon(4, 1190318991, ENTRY_MAIN);
@@ -216,10 +179,7 @@ TEST(Drlg_l1, CreateL5Dungeon_hellfire_4_1924296259)
 {
 	LoadExpectedLevelData("hellfire/4-1924296259.dun");
 
-	Players.resize(1);
-	MyPlayer = &Players[0];
-	MyPlayer->pOriginalCathedral = false;
-	InitQuests();
+	TestInitGame(true, false);
 	Quests[Q_LTBANNER]._qactive = QUEST_INIT;
 
 	TestCreateDungeon(4, 1924296259, ENTRY_MAIN);
@@ -233,6 +193,7 @@ TEST(Drlg_l1, CreateL5Dungeon_crypt_1_2122696790)
 	LoadExpectedLevelData("hellfire/21-2122696790.dun");
 
 	paths::SetAssetsPath(paths::BasePath() + "/assets");
+	TestInitGame();
 
 	TestCreateDungeon(21, 2122696790, ENTRY_TWARPDN);
 	EXPECT_EQ(ViewPosition, Point(61, 81));
@@ -244,7 +205,7 @@ TEST(Drlg_l1, CreateL5Dungeon_crypt_2_1191662129)
 {
 	LoadExpectedLevelData("hellfire/22-1191662129.dun");
 
-	InitQuests();
+	TestInitGame();
 	Quests[Q_PWATER]._qactive = QUEST_NOTAVAIL;
 	Quests[Q_BUTCHER]._qactive = QUEST_NOTAVAIL;
 
@@ -258,6 +219,8 @@ TEST(Drlg_l1, CreateL5Dungeon_crypt_3_97055268)
 {
 	LoadExpectedLevelData("hellfire/23-97055268.dun");
 
+	TestInitGame();
+
 	TestCreateDungeon(23, 97055268, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(71, 57));
 	TestCreateDungeon(23, 97055268, ENTRY_PREV);
@@ -269,6 +232,7 @@ TEST(Drlg_l1, CreateL5Dungeon_crypt_4_1324803725)
 	LoadExpectedLevelData("hellfire/24-1324803725.dun");
 
 	paths::SetAssetsPath(paths::BasePath() + "/assets");
+	TestInitGame();
 
 	TestCreateDungeon(24, 1324803725, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(79, 47));

--- a/test/drlg_l2_test.cpp
+++ b/test/drlg_l2_test.cpp
@@ -3,7 +3,6 @@
 
 #include "drlg_test.hpp"
 #include "levels/gendung.h"
-#include "quests.h"
 
 using namespace devilution;
 
@@ -28,7 +27,7 @@ TEST(Drlg_l2, CreateL2Dungeon_diablo_5_68685319)
 {
 	LoadExpectedLevelData("diablo/5-68685319.dun");
 
-	InitQuests();
+	TestInitGame();
 	Quests[Q_BLOOD]._qactive = QUEST_INIT;
 
 	TestCreateDungeon(5, 68685319, ENTRY_MAIN);
@@ -43,7 +42,7 @@ TEST(Drlg_l2, CreateL2Dungeon_diablo_6_2034738122)
 {
 	LoadExpectedLevelData("diablo/6-2034738122.dun");
 
-	InitQuests();
+	TestInitGame();
 	Quests[Q_SCHAMB]._qactive = QUEST_NOTAVAIL;
 
 	TestCreateDungeon(6, 2034738122, ENTRY_MAIN);
@@ -56,7 +55,7 @@ TEST(Drlg_l2, CreateL2Dungeon_diablo_6_1824554527)
 {
 	LoadExpectedLevelData("diablo/6-1824554527.dun");
 
-	InitQuests();
+	TestInitGame();
 	Quests[Q_SCHAMB]._qactive = QUEST_INIT;
 
 	TestCreateDungeon(6, 1824554527, ENTRY_MAIN);
@@ -69,7 +68,7 @@ TEST(Drlg_l2, CreateL2Dungeon_diablo_6_2033265779)
 {
 	LoadExpectedLevelData("diablo/6-2033265779.dun");
 
-	InitQuests();
+	TestInitGame();
 	Quests[Q_SCHAMB]._qactive = QUEST_INIT;
 
 	TestCreateDungeon(6, 2033265779, ENTRY_MAIN);
@@ -82,7 +81,7 @@ TEST(Drlg_l2, CreateL2Dungeon_diablo_7_680552750)
 {
 	LoadExpectedLevelData("diablo/7-680552750.dun");
 
-	InitQuests();
+	TestInitGame();
 	Quests[Q_BLIND]._qactive = QUEST_NOTAVAIL;
 
 	TestCreateDungeon(7, 680552750, ENTRY_MAIN);
@@ -95,7 +94,7 @@ TEST(Drlg_l2, CreateL2Dungeon_diablo_7_1607627156)
 {
 	LoadExpectedLevelData("diablo/7-1607627156.dun");
 
-	InitQuests();
+	TestInitGame();
 	Quests[Q_BLIND]._qactive = QUEST_INIT;
 
 	TestCreateDungeon(7, 1607627156, ENTRY_MAIN);
@@ -107,6 +106,8 @@ TEST(Drlg_l2, CreateL2Dungeon_diablo_7_1607627156)
 TEST(Drlg_l2, CreateL2Dungeon_diablo_8_1999936419)
 {
 	LoadExpectedLevelData("diablo/8-1999936419.dun");
+
+	TestInitGame();
 
 	TestCreateDungeon(8, 1999936419, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(39, 74));

--- a/test/drlg_l3_test.cpp
+++ b/test/drlg_l3_test.cpp
@@ -3,7 +3,6 @@
 
 #include "drlg_test.hpp"
 #include "levels/gendung.h"
-#include "quests.h"
 
 using namespace devilution;
 
@@ -12,6 +11,8 @@ namespace {
 TEST(Drlg_l3, CreateL3Dungeon_diablo_9_262005438)
 {
 	LoadExpectedLevelData("diablo/9-262005438.dun");
+
+	TestInitGame();
 
 	TestCreateDungeon(9, 262005438, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(41, 73));
@@ -25,6 +26,7 @@ TEST(Drlg_l3, CreateL3Dungeon_diablo_10_1630062353)
 {
 	LoadExpectedLevelData("diablo/10-1630062353.dun");
 
+	TestInitGame();
 	Quests[Q_ANVIL]._qactive = QUEST_NOTAVAIL;
 
 	TestCreateDungeon(10, 1630062353, ENTRY_MAIN);
@@ -37,6 +39,7 @@ TEST(Drlg_l3, CreateL3Dungeon_diablo_10_879635115)
 {
 	LoadExpectedLevelData("diablo/10-879635115.dun");
 
+	TestInitGame();
 	Quests[Q_ANVIL]._qlevel = 10;
 	Quests[Q_ANVIL]._qactive = QUEST_INIT;
 
@@ -50,6 +53,8 @@ TEST(Drlg_l3, CreateL3Dungeon_diablo_11_384626536)
 {
 	LoadExpectedLevelData("diablo/11-384626536.dun");
 
+	TestInitGame();
+
 	TestCreateDungeon(11, 384626536, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(29, 19));
 	TestCreateDungeon(11, 384626536, ENTRY_PREV);
@@ -59,6 +64,8 @@ TEST(Drlg_l3, CreateL3Dungeon_diablo_11_384626536)
 TEST(Drlg_l3, CreateL3Dungeon_diablo_12_2104541047)
 {
 	LoadExpectedLevelData("diablo/12-2104541047.dun");
+
+	TestInitGame();
 
 	TestCreateDungeon(12, 2104541047, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(35, 23));
@@ -70,6 +77,8 @@ TEST(Drlg_l3, CreateL3Dungeon_hive_1_19770182)
 {
 	LoadExpectedLevelData("hellfire/17-19770182.dun");
 
+	TestInitGame();
+
 	TestCreateDungeon(17, 19770182, ENTRY_TWARPDN);
 	EXPECT_EQ(ViewPosition, Point(75, 81));
 	TestCreateDungeon(17, 19770182, ENTRY_PREV);
@@ -79,6 +88,8 @@ TEST(Drlg_l3, CreateL3Dungeon_hive_1_19770182)
 TEST(Drlg_l3, CreateL3Dungeon_hive_2_1522546307)
 {
 	LoadExpectedLevelData("hellfire/18-1522546307.dun");
+
+	TestInitGame();
 
 	TestCreateDungeon(18, 1522546307, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(47, 19));
@@ -90,6 +101,8 @@ TEST(Drlg_l3, CreateL3Dungeon_hive_3_125121312)
 {
 	LoadExpectedLevelData("hellfire/19-125121312.dun");
 
+	TestInitGame();
+
 	TestCreateDungeon(19, 125121312, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(61, 25));
 	TestCreateDungeon(19, 125121312, ENTRY_PREV);
@@ -99,6 +112,8 @@ TEST(Drlg_l3, CreateL3Dungeon_hive_3_125121312)
 TEST(Drlg_l3, CreateL3Dungeon_hive_4_1511478689)
 {
 	LoadExpectedLevelData("hellfire/20-1511478689.dun");
+
+	TestInitGame();
 
 	TestCreateDungeon(20, 1511478689, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(65, 41));

--- a/test/drlg_l4_test.cpp
+++ b/test/drlg_l4_test.cpp
@@ -3,8 +3,6 @@
 
 #include "drlg_test.hpp"
 #include "levels/gendung.h"
-#include "multi.h"
-#include "quests.h"
 
 using namespace devilution;
 
@@ -14,7 +12,7 @@ TEST(Drlg_l4, CreateL4Dungeon_diablo_13_428074402)
 {
 	LoadExpectedLevelData("diablo/13-428074402.dun");
 
-	InitQuests();
+	TestInitGame();
 	Quests[Q_WARLORD]._qactive = QUEST_NOTAVAIL;
 
 	TestCreateDungeon(13, 428074402, ENTRY_MAIN);
@@ -29,7 +27,7 @@ TEST(Drlg_l4, CreateL4Dungeon_diablo_13_594689775)
 {
 	LoadExpectedLevelData("diablo/13-594689775.dun");
 
-	InitQuests();
+	TestInitGame();
 	Quests[Q_WARLORD]._qactive = QUEST_INIT;
 
 	TestCreateDungeon(13, 594689775, ENTRY_MAIN);
@@ -44,6 +42,8 @@ TEST(Drlg_l4, CreateL4Dungeon_diablo_14_717625719)
 {
 	LoadExpectedLevelData("diablo/14-717625719.dun");
 
+	TestInitGame();
+
 	TestCreateDungeon(14, 717625719, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(90, 64));
 	TestCreateDungeon(14, 717625719, ENTRY_PREV);
@@ -54,8 +54,7 @@ TEST(Drlg_l4, CreateL4Dungeon_diablo_15_1583642716)
 {
 	LoadExpectedLevelData("diablo/15-1583642716.dun");
 
-	gbIsMultiplayer = false;
-	InitQuests();
+	TestInitGame();
 	Quests[Q_DIABLO]._qactive = QUEST_INIT;
 
 	TestCreateDungeon(15, 1583642716, ENTRY_MAIN);
@@ -85,8 +84,7 @@ TEST(Drlg_l4, CreateL4Dungeon_diablo_15_1256511996)
 {
 	LoadExpectedLevelData("diablo/15-1256511996.dun");
 
-	gbIsMultiplayer = true;
-	InitQuests();
+	TestInitGame(false);
 
 	TestCreateDungeon(15, 1256511996, ENTRY_MAIN);
 	EXPECT_EQ(ViewPosition, Point(80, 70));

--- a/test/drlg_test.hpp
+++ b/test/drlg_test.hpp
@@ -57,6 +57,7 @@ void TestInitGame(bool fullQuests = true, bool originalCathedral = true)
 	MyPlayer = &Players[0];
 	MyPlayer->pOriginalCathedral = originalCathedral;
 
+	sgGameInitInfo.fullQuests = fullQuests ? 1 : 0;
 	gbIsMultiplayer = !fullQuests;
 
 	InitQuests();

--- a/test/drlg_test.hpp
+++ b/test/drlg_test.hpp
@@ -7,6 +7,9 @@
 
 #include "engine/load_file.hpp"
 #include "levels/themes.h"
+#include "multi.h"
+#include "player.h"
+#include "quests.h"
 #include "utils/paths.h"
 
 using namespace devilution;
@@ -46,6 +49,17 @@ void LoadExpectedLevelData(const char *fixture)
 	DunData = LoadFileInMem<uint16_t>(dunPath.c_str());
 	ASSERT_NE(DunData, nullptr) << "Unable to load test fixture " << dunPath;
 	ASSERT_EQ(Size(DMAXX, DMAXY), Size(SDL_SwapLE16(DunData[0]), SDL_SwapLE16(DunData[1])));
+}
+
+void TestInitGame(bool fullQuests = true, bool originalCathedral = true)
+{
+	Players.resize(1);
+	MyPlayer = &Players[0];
+	MyPlayer->pOriginalCathedral = originalCathedral;
+
+	gbIsMultiplayer = !fullQuests;
+
+	InitQuests();
 }
 
 void TestCreateDungeon(int level, uint32_t seed, lvl_entry entry)


### PR DESCRIPTION
Fixes #926

Now all quests should be implemented and (not much tested) working.
This pr adds a option that allows to specify how quests are handled in multiplayer (currently in the settings menu under gameplay).
The default is the vanilla behavior (full quests off).
The server decides how the quests are handled (same behavior as friendly fire or town jogging).

Many bugs are expected and some fine tuning is still needed (quest rewards discussion, how to handle some quests stats, ...).
But when this pr is merged everyone can start playing & testing the quests. 🙂