### PR TITLE
Multiplayer: Prevent trapped doors to fire twice

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -700,10 +700,7 @@ void DeltaSyncObject(WorldTilePosition position, _cmd_id bCmd, const Player &pla
 
 	sgbDeltaChanged = true;
 	auto &objectDeltas = GetDeltaLevel(player).object;
-	if (bCmd == _cmd_id::CMD_CLOSEDOOR)
-		objectDeltas.erase(position);
-	else
-		objectDeltas[position].bCmd = bCmd;
+	objectDeltas[position].bCmd = bCmd;
 }
 
 bool DeltaGetItem(const TCmdGItem &message, uint8_t bLevel)
@@ -2876,6 +2873,10 @@ void DeltaLoadLevel()
 			case CMD_OPENDOOR:
 			case CMD_OPERATEOBJ:
 				DeltaSyncOpObject(*object);
+				it++;
+				break;
+			case CMD_CLOSEDOOR:
+				DeltaSyncCloseObj(*object);
 				it++;
 				break;
 			case CMD_BREAKOBJ:

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4170,7 +4170,7 @@ bool UpdateTrapState(Object &trap)
 	case OBJ_L3RDOOR:
 	case OBJ_L5LDOOR:
 	case OBJ_L5RDOOR:
-		if (trigger._oVar4 == DOOR_CLOSED)
+		if (trigger._oVar4 == DOOR_CLOSED && trigger._oTrapFlag)
 			return false;
 		break;
 	case OBJ_LEVER:
@@ -4181,7 +4181,7 @@ bool UpdateTrapState(Object &trap)
 	case OBJ_SARC:
 	case OBJ_L5LEVER:
 	case OBJ_L5SARC:
-		if (trigger._oSelFlag != 0)
+		if (trigger._oSelFlag != 0 && trigger._oTrapFlag)
 			return false;
 		break;
 	default:
@@ -4570,6 +4570,13 @@ void DeltaSyncOpObject(Object &object)
 	default:
 		break;
 	}
+}
+
+void DeltaSyncCloseObj(Object &object)
+{
+	// Object was closed.
+	// That means it was opened once, so all traps have been activated.
+	object._oTrapFlag = false;
 }
 
 void SyncOpObject(Player &player, int cmd, Object &object)

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -327,6 +327,7 @@ void SyncOpObject(Player &player, int cmd, Object &object);
 void BreakObjectMissile(const Player *player, Object &object);
 void BreakObject(const Player &player, Object &object);
 void DeltaSyncOpObject(Object &object);
+void DeltaSyncCloseObj(Object &object);
 void DeltaSyncBreakObj(Object &object);
 void SyncBreakObj(const Player &player, Object &object);
 void SyncObjectAnim(Object &object);


### PR DESCRIPTION
Fixes #5184

Now `CMD_DOORCLOSE` is stored in delta messages.
When we found this message we set `_oTrapFlag`.
And when `_oTrapFlag` is not set the trap will not activate.