### PR TITLE
Disable corner stone of the world in multiplayer

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2929,7 +2929,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 	}
 
 	if (leveltype == DTYPE_CRYPT) {
-		if (currlevel == 21) {
+		if (CornerStone.isAvailable()) {
 			CornerstoneLoad(CornerStone.position);
 		}
 		if (Quests[Q_NAKRUL]._qactive == QUEST_DONE && currlevel == 24) {

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -947,7 +947,7 @@ void CleanupItems(int ii)
 	auto &item = Items[ii];
 	dItem[item.position.x][item.position.y] = 0;
 
-	if (currlevel == 21 && item.position == CornerStone.position) {
+	if (CornerStone.isAvailable() && item.position == CornerStone.position) {
 		CornerStone.item.clear();
 		CornerStone.item._iSelFlag = 0;
 		CornerStone.item.position = { 0, 0 };
@@ -1776,7 +1776,7 @@ int InvPutItem(const Player &player, Point position, const Item &item)
 	Items[ii].position = *itemTile;
 	RespawnItem(Items[ii], true);
 
-	if (currlevel == 21 && *itemTile == CornerStone.position) {
+	if (CornerStone.isAvailable() && *itemTile == CornerStone.position) {
 		CornerStone.item = Items[ii];
 		InitQTextMsg(TEXT_CORNSTN);
 		Quests[Q_CORNSTN]._qlog = false;
@@ -1813,7 +1813,7 @@ int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int is
 	item.position = position;
 	RespawnItem(item, true);
 
-	if (currlevel == 21 && position == CornerStone.position) {
+	if (CornerStone.isAvailable() && position == CornerStone.position) {
 		CornerStone.item = item;
 		InitQTextMsg(TEXT_CORNSTN);
 		Quests[Q_CORNSTN]._qlog = false;
@@ -1835,7 +1835,7 @@ int SyncDropEar(Point position, uint16_t icreateinfo, int iseed, uint8_t cursval
 	item.position = position;
 	RespawnItem(item, true);
 
-	if (currlevel == 21 && position == CornerStone.position) {
+	if (CornerStone.isAvailable() && position == CornerStone.position) {
 		CornerStone.item = item;
 		InitQTextMsg(TEXT_CORNSTN);
 		Quests[Q_CORNSTN]._qlog = false;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4531,6 +4531,11 @@ void Item::updateRequiredStatsCacheForPlayer(const Player &player)
 	_iStatFlag = player.CanUseItem(*this);
 }
 
+bool CornerStoneStruct::isAvailable()
+{
+	return currlevel == 21;
+}
+
 void initItemGetRecords()
 {
 	memset(itemrecord, 0, sizeof(itemrecord));

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4533,7 +4533,7 @@ void Item::updateRequiredStatsCacheForPlayer(const Player &player)
 
 bool CornerStoneStruct::isAvailable()
 {
-	return currlevel == 21;
+	return currlevel == 21 && !gbIsMultiplayer;
 }
 
 void initItemGetRecords()

--- a/Source/items.h
+++ b/Source/items.h
@@ -464,6 +464,7 @@ struct CornerStoneStruct {
 	Point position;
 	bool activated;
 	Item item;
+	bool isAvailable();
 };
 
 /** Contains the items on ground in the current game. */

--- a/Source/levels/drlg_l1.cpp
+++ b/Source/levels/drlg_l1.cpp
@@ -1010,7 +1010,7 @@ void FillChambers()
 	if (leveltype == DTYPE_CRYPT) {
 		if (currlevel == 24) {
 			SetCryptRoom();
-		} else if (currlevel == 21) {
+		} else if (CornerStone.isAvailable()) {
 			SetCornerRoom();
 		}
 	} else if (pSetPiece != nullptr) {


### PR DESCRIPTION
Fixes #4193

First commit adds helper function for all places that check for the corner stone.
Second commit removes it for multiplayer.