### PR TITLE
Ignore build workflows if only change is markdown

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
   pull_request:
     types: [ opened, synchronize ]
+    paths-ignore:
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/Linux_x86.yml
+++ b/.github/workflows/Linux_x86.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
   pull_request:
     types: [ opened, synchronize ]
+    paths-ignore:
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/Linux_x86_64_SDL1.yml
+++ b/.github/workflows/Linux_x86_64_SDL1.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
   pull_request:
     types: [ opened, synchronize ]
+    paths-ignore:
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/Linux_x86_64_test.yml
+++ b/.github/workflows/Linux_x86_64_test.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
   pull_request:
     types: [ opened, synchronize ]
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/MacOSX.yml
+++ b/.github/workflows/MacOSX.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
   pull_request:
     types: [ opened, synchronize ]
+    paths-ignore:
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/PS4.yml
+++ b/.github/workflows/PS4.yml
@@ -4,10 +4,16 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - '*.md'
   release:
     types: [published]
+    paths-ignore:
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/Windows_MSVC_x64.yml
+++ b/.github/workflows/Windows_MSVC_x64.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
   pull_request:
     types: [ opened, synchronize ]
+    paths-ignore:
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/Windows_MinGW_x64.yml
+++ b/.github/workflows/Windows_MinGW_x64.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
   pull_request:
     types: [ opened, synchronize ]
+    paths-ignore:
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/Windows_MinGW_x86.yml
+++ b/.github/workflows/Windows_MinGW_x86.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
   pull_request:
     types: [ opened, synchronize ]
+    paths-ignore:
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
   pull_request:
     types: [ opened, synchronize ]
+    paths-ignore:
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -4,10 +4,16 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - '*.md'
   release:
     types: [published]
+    paths-ignore:
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/miyoo_mini_release.yml
+++ b/.github/workflows/miyoo_mini_release.yml
@@ -3,6 +3,8 @@ name: Miyoo Mini Release Build
 on:
   release:
     types: [published]
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/opendingux_release.yml
+++ b/.github/workflows/opendingux_release.yml
@@ -3,6 +3,8 @@ name: OpenDingux Release Build
 on:
   release:
     types: [published]
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/retrofw_release.yml
+++ b/.github/workflows/retrofw_release.yml
@@ -3,6 +3,8 @@ name: RetroFW Release Build
 on:
   release:
     types: [published]
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/s390x_qemu_big_endian_tests.yml
+++ b/.github/workflows/s390x_qemu_big_endian_tests.yml
@@ -4,6 +4,8 @@ name: s390x qemu tests (big-endian)
 on:
   release:
     types: [published]
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/src_dist_release.yml
+++ b/.github/workflows/src_dist_release.yml
@@ -3,6 +3,8 @@ name: Build source tarball
 on:
   release:
     types: [published]
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
   pull_request:
     types: [ opened, synchronize ]
+    paths-ignore:
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/xbox_nxdk.yml
+++ b/.github/workflows/xbox_nxdk.yml
@@ -4,10 +4,16 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - '*.md'
   release:
     types: [published]
+    paths-ignore:
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/xbox_one.yml
+++ b/.github/workflows/xbox_one.yml
@@ -4,10 +4,16 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - '*.md'
   release:
     types: [published]
+    paths-ignore:
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
No need to rebuild everything if the only change is to documentation.