### PR TITLE
Don't send monster data while warping

### DIFF
--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -254,6 +254,9 @@ uint32_t sync_all_monsters(byte *pbBuf, uint32_t dwMaxLen)
 	if (dwMaxLen < sizeof(TSyncHeader) + sizeof(TSyncMonster)) {
 		return dwMaxLen;
 	}
+	if (MyPlayer->_pLvlChanging) {
+		return dwMaxLen;
+	}
 
 	auto *pHdr = (TSyncHeader *)pbBuf;
 	pbBuf += sizeof(TSyncHeader);


### PR DESCRIPTION
Related to #5541, but in this case the client attempts to send a sync packet immediately after updating `player.plrlevel` using the monster data from the previous level. This causes some weird issues in Multiplayer games if you leave active monsters on a level before using the stairs, like monsters warping to the stairs out of nowhere with incorrect HP values.