### PR TITLE
Fix Flash hits north east direction

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3385,7 +3385,7 @@ void ProcessFlashTop(Missile &missile)
 
 	constexpr Direction Offsets[] = {
 		Direction::North,
-		Direction::North,
+		Direction::NorthEast,
 		Direction::East
 	};
 	for (Direction offset : Offsets)


### PR DESCRIPTION
Fixes #5872

Flash did not hit north east direction but instead hit north direction twice. 😉 

Was introduced with #5311
