### PR TITLE
Bump libfmt to the latest master

### DIFF
--- a/3rdParty/libfmt/CMakeLists.txt
+++ b/3rdParty/libfmt/CMakeLists.txt
@@ -12,15 +12,16 @@ else()
 endif()
 include(FetchContent)
 if(NXDK)
-  # branch: nxdk-2022-07-19
+  # branch: nxdk-v9.1.0
   FetchContent_Declare(libfmt
-    URL https://github.com/diasurgical/fmt/archive/16d67608437f4fb9d293e561b4ddbccf3815a097.tar.gz
-    URL_HASH MD5=7ef45573ef301c250717c60458aa7536
+    URL https://github.com/diasurgical/fmt/archive/f69d48bf4049bbdfa74afca02fac3c81bb609dc8.tar.gz
+    URL_HASH MD5=310c79c7a5cda3ad8f4e0d44d9fc1c57
   )
 else()
+  # master on 2022-03-12
   FetchContent_Declare(libfmt
-    URL https://github.com/fmtlib/fmt/archive/688a627d6c4d1fb6dfe070397b7cd4bf55a0024e.tar.gz
-    URL_HASH MD5=55a7ac3c12ee83cc86b76275fd1e5f6b
+    URL https://github.com/fmtlib/fmt/archive/7f882918eba6430a0509b5e8547de21611264c5c.tar.gz
+    URL_HASH MD5=03fd08aeabf9021c6bf19fbd84d5e62e
   )
 endif()
 FetchContent_MakeAvailableExcludeFromAll(libfmt)

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -5,8 +5,9 @@
  */
 #include <cstdint>
 #include <cstdio>
+#include <ctime>
 
-#include <fmt/chrono.h>
+#include <fmt/format.h>
 
 #include "DiabloUI/diabloui.h"
 #include "engine/backbuffer_state.hpp"
@@ -133,9 +134,12 @@ bool CapturePix(const Surface &buf, FILE *out)
 
 FILE *CaptureFile(std::string *dstPath)
 {
-	std::time_t tt = std::time(nullptr);
-	std::tm *tm = std::localtime(&tt);
-	std::string filename = fmt::format("Screenshot from {:%Y-%m-%d %H-%M-%S}", *tm);
+	const std::time_t tt = std::time(nullptr);
+	const std::tm *tm = std::localtime(&tt);
+	const std::string filename = tm != nullptr
+	    ? fmt::format("Screenshot from {:04}-{:02}-{:02} {:02}-{:02}-{:02}",
+	        tm->tm_year, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec)
+	    : "Screenshot";
 	*dstPath = StrCat(paths::PrefPath(), filename, ".pcx");
 	int i = 0;
 	while (FileExists(dstPath->c_str())) {


### PR DESCRIPTION
At first I tried to bump it to v9.1.0 but that had some issues.

Based on top of #5879 