### PR TITLE
Fix a libfmt compilation error on master

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4896,12 +4896,12 @@ void GetObjectStr(const Object &object)
 	InfoString = object.name();
 	if (MyPlayer->_pClass == HeroClass::Rogue) {
 		if (object._oTrapFlag) {
-			InfoString = fmt::format(fmt::runtime(_(/* TRANSLATORS: {:s} will either be a chest or a door */ "Trapped {:s}")), InfoString);
+			InfoString = fmt::format(fmt::runtime(_(/* TRANSLATORS: {:s} will either be a chest or a door */ "Trapped {:s}")), InfoString.str());
 			InfoColor = UiFlags::ColorRed;
 		}
 	}
 	if (object.IsDisabled()) {
-		InfoString = fmt::format(fmt::runtime(_(/* TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls lever */ "{:s} (disabled)")), InfoString);
+		InfoString = fmt::format(fmt::runtime(_(/* TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls lever */ "{:s} (disabled)")), InfoString.str());
 		InfoColor = UiFlags::ColorRed;
 	}
 }


### PR DESCRIPTION
`InfoString` is a `StringOrView` and libfmt master does not know how to print that. Pass it a `string_view` instead.