### PR TITLE
Remove `FMT_COMPILE` in "cold" places

### DIFF
--- a/Source/engine/palette.cpp
+++ b/Source/engine/palette.cpp
@@ -5,7 +5,7 @@
  */
 #include "engine/palette.h"
 
-#include <fmt/compile.h>
+#include <fmt/core.h>
 
 #include "engine/backbuffer_state.hpp"
 #include "engine/demomode.h"
@@ -265,9 +265,9 @@ void LoadRndLvlPal(dungeon_type l)
 		if (!*sgOptions.Graphics.alternateNestArt) {
 			rv++;
 		}
-		*fmt::format_to(szFileName, FMT_COMPILE(R"(nlevels\l{0}data\l{0}base{1}.pal)"), 6, rv) = '\0';
+		*fmt::format_to(szFileName, R"(nlevels\l{0}data\l{0}base{1}.pal)", 6, rv) = '\0';
 	} else {
-		*fmt::format_to(szFileName, FMT_COMPILE(R"(levels\l{0}data\l{0}_{1}.pal)"), l, rv) = '\0';
+		*fmt::format_to(szFileName, R"(levels\l{0}data\l{0}_{1}.pal)", static_cast<int>(l), rv) = '\0';
 	}
 	LoadPalette(szFileName);
 }

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -10,7 +10,7 @@
 #include <unordered_map>
 #include <utility>
 
-#include <fmt/compile.h>
+#include <fmt/core.h>
 
 #include "DiabloUI/diabloui.h"
 #include "DiabloUI/ui_item.h"
@@ -143,7 +143,7 @@ bool IsSmallFontTallRow(uint16_t row)
 
 void GetFontPath(GameFontTables size, uint16_t row, string_view ext, char *out)
 {
-	*fmt::format_to(out, FMT_COMPILE(R"(fonts\{}-{:02x}.{})"), FontSizes[size], row, ext) = '\0';
+	*fmt::format_to(out, R"(fonts\{}-{:02x}.{})", FontSizes[size], row, ext) = '\0';
 }
 
 uint32_t GetFontId(GameFontTables size, uint16_t row)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -13,7 +13,7 @@
 #include <climits>
 #include <cstdint>
 
-#include <fmt/compile.h>
+#include <fmt/core.h>
 #include <fmt/format.h>
 
 #include "DiabloUI/ui_flags.hpp"
@@ -3169,7 +3169,7 @@ void CornerstoneSave()
 		PackItem(id, CornerStone.item, (CornerStone.item.dwBuff & CF_HELLFIRE) != 0);
 		const auto *buffer = reinterpret_cast<uint8_t *>(&id);
 		for (size_t i = 0; i < sizeof(ItemPack); i++) {
-			fmt::format_to(&sgOptions.Hellfire.szItem[i * 2], FMT_COMPILE("{:02X}"), buffer[i]);
+			fmt::format_to(&sgOptions.Hellfire.szItem[i * 2], "{:02X}", buffer[i]);
 		}
 		sgOptions.Hellfire.szItem[sizeof(sgOptions.Hellfire.szItem) - 1] = '\0';
 	} else {

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -11,7 +11,7 @@
 #include <unordered_map>
 
 #include <SDL.h>
-#include <fmt/compile.h>
+#include <fmt/core.h>
 
 #include "automap.h"
 #include "codec.h"
@@ -901,7 +901,7 @@ void GetLevelNames(string_view prefix, char *out)
 		suf = 'l';
 		num = currlevel;
 	}
-	*fmt::format_to(out, FMT_COMPILE("{}{}{:02d}"), prefix, suf, num) = '\0';
+	*fmt::format_to(out, "{}{}{:02d}", prefix, suf, num) = '\0';
 }
 
 void GetTempLevelNames(char *szTemp)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -10,7 +10,7 @@
 #include <algorithm>
 #include <array>
 
-#include <fmt/compile.h>
+#include <fmt/core.h>
 #include <fmt/format.h>
 
 #include "control.h"

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -8,7 +8,7 @@
 #include <string>
 #include <unordered_map>
 
-#include <fmt/compile.h>
+#include <fmt/core.h>
 
 #include "codec.h"
 #include "engine.h"
@@ -89,7 +89,7 @@ bool GetSaveNames(uint8_t index, string_view prefix, char *out)
 		return false;
 	}
 
-	*fmt::format_to(out, FMT_COMPILE("{}{}{:02d}"), prefix, suf, index) = '\0';
+	*fmt::format_to(out, "{}{}{:02d}", prefix, suf, index) = '\0';
 	return true;
 }
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <cstdint>
 
-#include <fmt/compile.h>
+#include <fmt/core.h>
 
 #include "control.h"
 #include "controls/plrctrls.h"
@@ -2157,7 +2157,7 @@ void LoadPlrGFX(Player &player, player_graphic graphic)
 
 	char prefix[3] = { CharChar[static_cast<std::size_t>(cls)], ArmourChar[player._pgfxnum >> 4], WepChar[static_cast<std::size_t>(animWeaponId)] };
 	char pszName[256];
-	*fmt::format_to(pszName, FMT_COMPILE(R"(plrgfx\{0}\{1}\{1}{2})"), path, string_view(prefix, 3), szCel) = 0;
+	*fmt::format_to(pszName, R"(plrgfx\{0}\{1}\{1}{2})", path, string_view(prefix, 3), szCel) = 0;
 	const uint16_t animationWidth = GetPlayerSpriteWidth(cls, graphic, animWeaponId);
 	animationData.sprites = LoadCl2Sheet(pszName, animationWidth);
 	std::optional<std::array<uint8_t, 256>> trn = GetClassTRN(player);

--- a/Source/utils/format_int.cpp
+++ b/Source/utils/format_int.cpp
@@ -1,8 +1,5 @@
 #include "utils/format_int.hpp"
 
-#include <fmt/compile.h>
-#include <fmt/core.h>
-
 #include "utils/language.h"
 #include "utils/stdcompat/string_view.hpp"
 #include "utils/str_cat.hpp"


### PR DESCRIPTION
Removes most `FMT_COMPILE` calls.
`FMT_COMPILE` results in better performance but larger code size.

Removes `FMT_COMPILE` calls for places that are called infrequently, i.e. not on every frame.

RG-99 binary size reduced by ~4 KiB.