### PR TITLE
StrCat improvements

### DIFF
--- a/Source/qol/floatingnumbers.cpp
+++ b/Source/qol/floatingnumbers.cpp
@@ -7,6 +7,7 @@
 
 #include "engine/render/text_render.hpp"
 #include "options.h"
+#include "utils/str_cat.hpp"
 
 namespace devilution {
 
@@ -61,9 +62,10 @@ UiFlags GetFontSizeByDamage(int value)
 
 void UpdateFloatingData(FloatingNumber &num)
 {
-	num.text = fmt::format("{:d}", num.value >> 6);
 	if (num.value > 0 && num.value < 64) {
 		num.text = fmt::format("{:.2f}", num.value / 64.0);
+	} else {
+		num.text = StrCat(num.value >> 6);
 	}
 
 	num.style &= ~(UiFlags::FontSize12 | UiFlags::FontSize24 | UiFlags::FontSize30);

--- a/Source/utils/str_cat.cpp
+++ b/Source/utils/str_cat.cpp
@@ -1,28 +1,20 @@
 #include "utils/str_cat.hpp"
 
-#include <cstddef>
-
-#include <fmt/compile.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace devilution {
 
-namespace {
-
-template <typename T>
-constexpr size_t MaxDecimalDigits = 241 * sizeof(T) / 100 + 1;
-
-} // namespace
-
 char *BufCopy(char *out, int value)
 {
-	return fmt::format_to(out, FMT_COMPILE("{}"), value);
+	const fmt::format_int formatted { value };
+	std::memcpy(out, formatted.data(), formatted.size());
+	return out + formatted.size();
 }
 
 void StrAppend(std::string &out, int value)
 {
-	char buf[MaxDecimalDigits<int> + 1];
-	out.append(&buf[0], BufCopy(buf, value) - &buf[0]);
+	const fmt::format_int formatted { value };
+	out.append(formatted.data(), formatted.size());
 }
 
 } // namespace devilution

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ set(tests
   rectangle_test
   scrollrt_test
   stores_test
+  str_cat_test
   timedemo_test
   utf8_test
   writehero_test

--- a/test/str_cat_test.cpp
+++ b/test/str_cat_test.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+
+#include "utils/str_cat.hpp"
+
+namespace devilution {
+namespace {
+
+TEST(StrCatTest, StrCatBasicTest)
+{
+	EXPECT_EQ(StrCat("a", "b", "c", 5), "abc5");
+}
+
+TEST(StrCatTest, BufCopyBasicTest)
+{
+	char buf[5];
+	char *end = BufCopy(buf, "a", "b", "c", 5);
+	EXPECT_EQ(string_view(buf, end - buf), "abc5");
+}
+
+} // namespace
+} // namespace devilution


### PR DESCRIPTION
1. Use `fmt::format_int` directly instead of parsing a format string.
2. Use `AppendStrView`.
3. Define the varargs versions using fold expressions when available.
4. Add tests.