### PR TITLE
GitHub CI: Remove git SHA from cache key

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -35,11 +35,10 @@ jobs:
         cache: gradle
 
     - name: Cache CMake build folder
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: android-project/app/.cxx
-        key: android-cmake-v5-${{ github.sha }}
-        restore-keys: android-cmake-v5-
+        key: ${{ github.workflow }}-v1
 
     - name: Build
       working-directory: ${{github.workspace}}

--- a/.github/workflows/Linux_x86.yml
+++ b/.github/workflows/Linux_x86.yml
@@ -31,11 +31,10 @@ jobs:
         sudo apt-get install -y cmake file g++-multilib git libfmt-dev:i386 libsdl2-dev:i386 libsodium-dev:i386 libpng-dev:i386 libbz2-dev:i386 rpm wget smpq
 
     - name: Cache CMake build folder
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: build
-        key: linux-x86-cmake-v5-${{ github.sha }}
-        restore-keys: linux-x86-cmake-v5-
+        key: ${{ github.workflow }}-v1
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/Linux_x86_64_SDL1.yml
+++ b/.github/workflows/Linux_x86_64_SDL1.yml
@@ -30,11 +30,10 @@ jobs:
         sudo apt-get install -y cmake file g++ git libfmt-dev libsdl1.2-dev libsodium-dev libpng-dev libbz2-dev rpm smpq
 
     - name: Cache CMake build folder
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: build
-        key: linux-x86_64-sdl1-cmake-v5-${{ github.sha }}
-        restore-keys: linux-x86_64-sdl1-cmake-v5-
+        key: ${{ github.workflow }}-v1
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/Linux_x86_64_test.yml
+++ b/.github/workflows/Linux_x86_64_test.yml
@@ -33,8 +33,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: build
-          key: linux-x86-64-test-cmake-v2-${{ github.sha }}
-          restore-keys: linux-x86-64-test-cmake-v2-
+          key: ${{ github.workflow }}-v1
       - name: Build tests
         run: |
           cmake -S. -Bbuild -DENABLE_CODECOVERAGE=ON

--- a/.github/workflows/MacOSX.yml
+++ b/.github/workflows/MacOSX.yml
@@ -36,11 +36,10 @@ jobs:
       run: brew bundle install
 
     - name: Cache CMake build folder
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: build
-        key: macos-cmake-v3-${{ github.sha }}
-        restore-keys: macos-cmake-v3-
+        key: ${{ github.workflow }}-v1
 
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable

--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -33,11 +33,10 @@ jobs:
         fetch-depth: 0
 
     - name: Cache CMake build folder
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: build
-        key: ios-cmake-v3-${{ github.sha }}
-        restore-keys: ios-cmake-v3-
+        key: ${{ github.workflow }}-v1
 
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable


### PR DESCRIPTION
We're hitting the GitHub cache limit because we create a new cache for every commit.

Reuse the same cache instead.

![image](https://user-images.githubusercontent.com/216339/224666859-d933b4db-15b2-4915-a1d9-f404b3049648.png)
