### PR TITLE
items.cpp: fix inconsistent localization for miscellanous items

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1762,7 +1762,7 @@ void printItemMiscGenericGamepad(const Item &item, const bool isOil, bool isCast
 			AddPanelString(_("Activate to use"));
 		}
 	} else if (isCastOnTarget) {
-		AddPanelString(_("Select from spell book, then\ncast to read"));
+		AddPanelString(_("Select from spell book, then\ncast spell to read"));
 	} else if (IsAnyOf(item._iMiscId, IMISC_BOOK, IMISC_NOTE, IMISC_SCROLL, IMISC_SCROLLT)) {
 		AddPanelString(_("Activate to read"));
 	}

--- a/Translations/bg.po
+++ b/Translations/bg.po
@@ -4004,12 +4004,9 @@ msgid "Right-click to read"
 msgstr "Десен клик за прочитане"
 
 #: Source/items.cpp:1814 Source/items.cpp:1835
-msgid "Select from spell book, then"
-msgstr "Изберете от книгата със заклинания,"
-
-#: Source/items.cpp:1815 Source/items.cpp:1836
-msgid "cast spell to read"
-msgstr "след това изричане на заклинанието за прочит "
+msgid "Select from spell book, then\ncast spell to read"
+msgstr "Изберете от книгата със заклинания,\nслед това изричане на "
+"заклинанието за прочит"
 
 #: Source/items.cpp:1817 Source/items.cpp:1838 Source/items.cpp:1852
 msgid "Open inventory to use"

--- a/Translations/bg.po
+++ b/Translations/bg.po
@@ -4020,12 +4020,8 @@ msgid "Activate to read"
 msgstr "Активиране за прочит"
 
 #: Source/items.cpp:1825
-msgid "Right-click to read, then"
-msgstr "Десен клик за прочитане, "
-
-#: Source/items.cpp:1826
-msgid "left-click to target"
-msgstr "следван от ляв клик върху цел"
+msgid "Right-click to read, then\nleft-click to target"
+msgstr "Десен клик за прочитане,\nследван от ляв клик върху цел"
 
 #: Source/items.cpp:1849
 msgid "Right-click to use"

--- a/Translations/cs.po
+++ b/Translations/cs.po
@@ -4012,12 +4012,8 @@ msgid "Activate to read"
 msgstr "Aktivuj pro přečtení"
 
 #: Source/items.cpp:1825
-msgid "Right-click to read, then"
-msgstr "Přečtení - klikni Pravým, poté"
-
-#: Source/items.cpp:1826
-msgid "left-click to target"
-msgstr "klikni Levým na cíl"
+msgid "Right-click to read, then\nleft-click to target"
+msgstr "Přečtení - klikni Pravým, poté\nklikni Levým na cíl"
 
 #: Source/items.cpp:1849
 msgid "Right-click to use"

--- a/Translations/cs.po
+++ b/Translations/cs.po
@@ -3996,12 +3996,8 @@ msgid "Right-click to read"
 msgstr "Přečtení - klikni Pravým"
 
 #: Source/items.cpp:1814 Source/items.cpp:1835
-msgid "Select from spell book, then"
-msgstr "Vyber si z knihy kouzel, a poté"
-
-#: Source/items.cpp:1815 Source/items.cpp:1836
-msgid "cast spell to read"
-msgstr "vyčaruj kouzlo pro přečtení"
+msgid "Select from spell book, then\ncast spell to read"
+msgstr "Vyber si z knihy kouzel, a poté\nvyčaruj kouzlo pro přečtení"
 
 #: Source/items.cpp:1817 Source/items.cpp:1838 Source/items.cpp:1852
 msgid "Open inventory to use"

--- a/Translations/da.po
+++ b/Translations/da.po
@@ -4212,12 +4212,8 @@ msgid "Right-click to read"
 msgstr "Skrivebeskyttet mappe fejl"
 
 #: Source/items.cpp:1814 Source/items.cpp:1835
-msgid "Select from spell book, then"
-msgstr ""
-
-#: Source/items.cpp:1815 Source/items.cpp:1836
-msgid "cast spell to read"
-msgstr ""
+msgid "Select from spell book, then\ncast spell to read"
+msgstr "Vælg fra stavebog, og\nkast derefter stave for at læse"
 
 #: Source/items.cpp:1817 Source/items.cpp:1838 Source/items.cpp:1852
 msgid "Open inventory to use"

--- a/Translations/da.po
+++ b/Translations/da.po
@@ -4228,13 +4228,8 @@ msgid "Activate to read"
 msgstr ""
 
 #: Source/items.cpp:1825
-#, fuzzy
-msgid "Right-click to read, then"
-msgstr "Skrivebeskyttet mappe fejl"
-
-#: Source/items.cpp:1826
-msgid "left-click to target"
-msgstr ""
+msgid "Right-click to read, then\nleft-click to target"
+msgstr "Højreklik for at læse, og\nvenstreklik derefter for at målrette"
 
 #: Source/items.cpp:1849
 msgid "Right-click to use"

--- a/Translations/de.po
+++ b/Translations/de.po
@@ -4018,12 +4018,8 @@ msgid "Activate to read"
 msgstr "Linksklick zum Lesen"
 
 #: Source/items.cpp:1825
-msgid "Right-click to read, then"
-msgstr "Rechtsklick zum Lesen, dann"
-
-#: Source/items.cpp:1826
-msgid "left-click to target"
-msgstr "Linksklick zum Zielen"
+msgid "Right-click to read, then\nleft-click to target"
+msgstr "Rechtsklick zum Lesen, dann Linksklick zum Zielen"
 
 #: Source/items.cpp:1849
 msgid "Right-click to use"

--- a/Translations/de.po
+++ b/Translations/de.po
@@ -4002,12 +4002,8 @@ msgid "Right-click to read"
 msgstr "Rechtsklick zum Lesen"
 
 #: Source/items.cpp:1814 Source/items.cpp:1835
-msgid "Select from spell book, then"
-msgstr "Aus dem Zauberbuch wählen, dann"
-
-#: Source/items.cpp:1815 Source/items.cpp:1836
-msgid "cast spell to read"
-msgstr "Zaubern zum Lesen"
+msgid "Select from spell book, then\ncast spell to read"
+msgstr "Aus dem Zauberbuch wählen, dann\nZaubern zum Lesen"
 
 #: Source/items.cpp:1817 Source/items.cpp:1838 Source/items.cpp:1852
 msgid "Open inventory to use"

--- a/Translations/devilutionx.pot
+++ b/Translations/devilutionx.pot
@@ -3845,12 +3845,7 @@ msgid "Activate to read"
 msgstr ""
 
 #: Source/items.cpp:1837
-msgid "Right-click to read, then"
-msgstr ""
-
-#: Source/items.cpp:1838
-msgid "left-click to target"
-msgstr ""
+msgid "Right-click to read, then\nleft-click to target"
 
 #: Source/items.cpp:1841
 msgid "Select from spell book, then"

--- a/Translations/devilutionx.pot
+++ b/Translations/devilutionx.pot
@@ -3848,11 +3848,7 @@ msgstr ""
 msgid "Right-click to read, then\nleft-click to target"
 
 #: Source/items.cpp:1841
-msgid "Select from spell book, then"
-msgstr ""
-
-#: Source/items.cpp:1842
-msgid "cast spell to read"
+msgid "Select from spell book, then\ncast spell to read"
 msgstr ""
 
 #: Source/items.cpp:1855

--- a/Translations/el.po
+++ b/Translations/el.po
@@ -4040,12 +4040,8 @@ msgid "Activate to read"
 msgstr ""
 
 #: Source/items.cpp:1822
-msgid "Right-click to read, then"
-msgstr "Δεξί-κλικ για διάβασμα, και"
-
-#: Source/items.cpp:1823
-msgid "left-click to target"
-msgstr "αριστερό-κλικ στον στόχο"
+msgid "Right-click to read, then\nleft-click to target"
+msgstr "Δεξί-κλικ για διάβασμα, και\nαριστερό-κλικ στον στόχο"
 
 #: Source/items.cpp:1826
 msgid "Select from spell book, then"

--- a/Translations/el.po
+++ b/Translations/el.po
@@ -4044,12 +4044,8 @@ msgid "Right-click to read, then\nleft-click to target"
 msgstr "Δεξί-κλικ για διάβασμα, και\nαριστερό-κλικ στον στόχο"
 
 #: Source/items.cpp:1826
-msgid "Select from spell book, then"
-msgstr ""
-
-#: Source/items.cpp:1827
-msgid "cast spell to read"
-msgstr ""
+msgid "Select from spell book, then\ncast spell to read"
+msgstr "Επιλέξτε από το βιβλίο με τα ξόρκια και μετά\nκάντε ξόρκι για ανάγνωση"
 
 #: Source/items.cpp:1840
 msgid "Right-click to use"

--- a/Translations/es.po
+++ b/Translations/es.po
@@ -4290,7 +4290,7 @@ msgstr "Activar para usar"
 #: Source/items.cpp:1743
 msgid ""
 "Select from spell book, then\n"
-"cast to read"
+"cast spell to read"
 msgstr ""
 "Seleccione del libro de hechizos, luego\n"
 "lance para leer"

--- a/Translations/fr.po
+++ b/Translations/fr.po
@@ -4020,12 +4020,8 @@ msgid "Activate to read"
 msgstr "Activer pour lire"
 
 #: Source/items.cpp:1794
-msgid "Right-click to read, then"
-msgstr "Clic-droit pour lire, puis"
-
-#: Source/items.cpp:1795
-msgid "left-click to target"
-msgstr "clic-gauche pour la cible"
+msgid "Right-click to read, then\nleft-click to target"
+msgstr "Clic-droit pour lire, puis\nclic-gauche pour la cible"
 
 #: Source/items.cpp:1798
 msgid "Select from spell book, then"

--- a/Translations/fr.po
+++ b/Translations/fr.po
@@ -4024,12 +4024,9 @@ msgid "Right-click to read, then\nleft-click to target"
 msgstr "Clic-droit pour lire, puis\nclic-gauche pour la cible"
 
 #: Source/items.cpp:1798
-msgid "Select from spell book, then"
-msgstr "Sélectionner depuis le livre des sorts, puis"
-
-#: Source/items.cpp:1799
-msgid "cast spell to read"
-msgstr "lancer le sort pour le lire"
+msgid "Select from spell book, then\ncast spell to read"
+msgstr "Sélectionner depuis le livre des sorts, puis\nlancer le sort pour "
+"le lire"
 
 #: Source/items.cpp:1812
 msgid "Right-click to use"

--- a/Translations/hr.po
+++ b/Translations/hr.po
@@ -4028,12 +4028,8 @@ msgid "Right-click to read, then\nleft-click to target"
 msgstr "Desno klikni za čitanje, zatim\nlijevo klikni na metu"
 
 #: Source/items.cpp:1802
-msgid "Select from spell book, then"
-msgstr "Odaberi iz knjige čarolije, zatim"
-
-#: Source/items.cpp:1803
-msgid "cast spell to read"
-msgstr "bacite čaroliju za čitanje"
+msgid "Select from spell book, then\ncast spell to read"
+msgstr "Odaberi iz knjige čarolije, zatim\nbacite čaroliju za čitanje"
 
 #: Source/items.cpp:1816
 msgid "Right-click to use"

--- a/Translations/hr.po
+++ b/Translations/hr.po
@@ -4024,12 +4024,8 @@ msgid "Activate to read"
 msgstr "Aktiviraj za čitanje"
 
 #: Source/items.cpp:1798
-msgid "Right-click to read, then"
-msgstr "Desno klikni za čitanje, zatim"
-
-#: Source/items.cpp:1799
-msgid "left-click to target"
-msgstr "lijevo klikni na metu"
+msgid "Right-click to read, then\nleft-click to target"
+msgstr "Desno klikni za čitanje, zatim\nlijevo klikni na metu"
 
 #: Source/items.cpp:1802
 msgid "Select from spell book, then"

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -4289,7 +4289,7 @@ msgstr "Attiva per usare"
 #: Source/items.cpp:1765
 msgid ""
 "Select from spell book, then\n"
-"cast to read"
+"cast spell to read"
 msgstr ""
 "Seleziona dal libro di magia, poi\n"
 "lancia per leggere"

--- a/Translations/ja.po
+++ b/Translations/ja.po
@@ -4242,7 +4242,7 @@ msgstr "アクティベート​し​て​使う"
 #: Source/items.cpp:1764
 msgid ""
 "Select from spell book, then\n"
-"cast to read"
+"cast spell to read"
 msgstr ""
 "スペル​ブック​から​選択​し​\n"
 "​読ん​で​キャスト"

--- a/Translations/ko.po
+++ b/Translations/ko.po
@@ -3988,12 +3988,8 @@ msgstr "활성화해서 읽기"
 
 # 조합 방식 확인 필요
 #: Source/items.cpp:1837
-msgid "Right-click to read, then"
-msgstr "우클릭으로 읽고"
-
-#: Source/items.cpp:1838
-msgid "left-click to target"
-msgstr "좌클릭으로 목표 지정"
+msgid "Right-click to read, then\nleft-click to target"
+msgstr "우클릭으로 읽고\n좌클릭으로 목표 지정"
 
 #: Source/items.cpp:1841
 msgid "Select from spell book, then"

--- a/Translations/ko.po
+++ b/Translations/ko.po
@@ -3992,12 +3992,8 @@ msgid "Right-click to read, then\nleft-click to target"
 msgstr "우클릭으로 읽고\n좌클릭으로 목표 지정"
 
 #: Source/items.cpp:1841
-msgid "Select from spell book, then"
-msgstr "주문서에서 선택 후"
-
-#: Source/items.cpp:1842
-msgid "cast spell to read"
-msgstr "주문 시전"
+msgid "Select from spell book, then\ncast spell to read"
+msgstr "주문서에서 선택 후\n주문 시전"
 
 #: Source/items.cpp:1855
 msgid "Right-click to use"

--- a/Translations/pl.po
+++ b/Translations/pl.po
@@ -4007,12 +4007,8 @@ msgid "Right-click to read, then\nleft-click to target"
 msgstr "PPM by odczytać, następnie\nLPM na cel"
 
 #: Source/items.cpp:1841
-msgid "Select from spell book, then"
-msgstr "Wybierz z księgi zaklęć, a następnie"
-
-#: Source/items.cpp:1842
-msgid "cast spell to read"
-msgstr "rzuć zaklęcie, aby przeczytać"
+msgid "Select from spell book, then\ncast spell to read"
+msgstr "Wybierz z księgi zaklęć, a następnie\nrzuć zaklęcie, aby przeczytać"
 
 #: Source/items.cpp:1855
 msgid "Right-click to use"

--- a/Translations/pl.po
+++ b/Translations/pl.po
@@ -4003,12 +4003,8 @@ msgid "Activate to read"
 msgstr "Aktywuj, aby przeczytać"
 
 #: Source/items.cpp:1837
-msgid "Right-click to read, then"
-msgstr "PPM by odczytać, następnie"
-
-#: Source/items.cpp:1838
-msgid "left-click to target"
-msgstr "LPM na cel"
+msgid "Right-click to read, then\nleft-click to target"
+msgstr "PPM by odczytać, następnie\nLPM na cel"
 
 #: Source/items.cpp:1841
 msgid "Select from spell book, then"

--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -4023,12 +4023,8 @@ msgid "Activate to read"
 msgstr "Ative para ler"
 
 #: Source/items.cpp:1825
-msgid "Right-click to read, then"
-msgstr "Clique direito para ler e então"
-
-#: Source/items.cpp:1826
-msgid "left-click to target"
-msgstr "clique esquerdo para golpear"
+msgid "Right-click to read, then\nleft-click to target"
+msgstr "Clique direito para ler e então\nclique esquerdo para golpear"
 
 #: Source/items.cpp:1849
 msgid "Right-click to use"

--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -4005,12 +4005,8 @@ msgid "Right-click to read"
 msgstr "Clique direito para ler"
 
 #: Source/items.cpp:1814 Source/items.cpp:1835
-msgid "Select from spell book, then"
-msgstr "Selecionar feitiço atual, então"
-
-#: Source/items.cpp:1815 Source/items.cpp:1836
-msgid "cast spell to read"
-msgstr "lance o feitiço para ler"
+msgid "Select from spell book, then\ncast spell to read"
+msgstr "Selecionar feitiço atual, então\nlance o feitiço para ler"
 
 #: Source/items.cpp:1817 Source/items.cpp:1838 Source/items.cpp:1852
 #, fuzzy

--- a/Translations/ro.po
+++ b/Translations/ro.po
@@ -4108,12 +4108,8 @@ msgid "Activate to read"
 msgstr ""
 
 #: Source/items.cpp:1825
-msgid "Right-click to read, then"
-msgstr "Clic-dreapta citire, și apoi"
-
-#: Source/items.cpp:1826
-msgid "left-click to target"
-msgstr "clic-stânga țintire"
+msgid "Right-click to read, then\nleft-click to target"
+msgstr "Clic-dreapta citire, și apoi\nclic-stânga țintire"
 
 #: Source/items.cpp:1849
 msgid "Right-click to use"

--- a/Translations/ro.po
+++ b/Translations/ro.po
@@ -4088,14 +4088,8 @@ msgid "Right-click to read"
 msgstr "Clic-dreapta citire"
 
 #: Source/items.cpp:1814 Source/items.cpp:1835
-#, fuzzy
-#| msgid "Select current spell button"
-msgid "Select from spell book, then"
-msgstr "Selectați buton curent de vrajă"
-
-#: Source/items.cpp:1815 Source/items.cpp:1836
-msgid "cast spell to read"
-msgstr ""
+msgid "Select from spell book, then\ncast spell to read"
+msgstr "Selectați din cartea de vrăji, apoi\nvrăjiți pentru a citi"
 
 #: Source/items.cpp:1817 Source/items.cpp:1838 Source/items.cpp:1852
 #, fuzzy

--- a/Translations/ru.po
+++ b/Translations/ru.po
@@ -4054,12 +4054,8 @@ msgstr "Правый клик для чтения"
 
 # Оставил именно этот вариант, так как полностью корректный перевод в игре выглядит глупо.
 #: Source/items.cpp:1814 Source/items.cpp:1835
-msgid "Select from spell book, then"
-msgstr "Выберите в книге заклинаний, затем"
-
-#: Source/items.cpp:1815 Source/items.cpp:1836
-msgid "cast spell to read"
-msgstr "произнесите заклинание для чтения"
+msgid "Select from spell book, then\ncast spell to read"
+msgstr "Выберите в книге заклинаний, затем\nпроизнесите заклинание для чтения"
 
 #: Source/items.cpp:1817 Source/items.cpp:1838 Source/items.cpp:1852
 msgid "Open inventory to use"

--- a/Translations/ru.po
+++ b/Translations/ru.po
@@ -4070,12 +4070,8 @@ msgid "Activate to read"
 msgstr "Активируйте для чтения"
 
 #: Source/items.cpp:1825
-msgid "Right-click to read, then"
-msgstr "Правый клик для чтения, затем"
-
-#: Source/items.cpp:1826
-msgid "left-click to target"
-msgstr "левый клик по цели"
+msgid "Right-click to read, then\nleft-click to target"
+msgstr "Правый клик для чтения, затем\nлевый клик по цели"
 
 #: Source/items.cpp:1849
 msgid "Right-click to use"

--- a/Translations/sv.po
+++ b/Translations/sv.po
@@ -3997,12 +3997,8 @@ msgid "Right-click to read"
 msgstr "Högerklicka för att läsa"
 
 #: Source/items.cpp:1814 Source/items.cpp:1835
-msgid "Select from spell book, then"
-msgstr "Välj från magibok, därefter"
-
-#: Source/items.cpp:1815 Source/items.cpp:1836
-msgid "cast spell to read"
-msgstr "använd trollformel för att läsa"
+msgid "Select from spell book, then\ncast spell to read"
+msgstr "Välj från magibok, därefter\nanvänd trollformel för att läsa"
 
 #: Source/items.cpp:1817 Source/items.cpp:1838 Source/items.cpp:1852
 msgid "Open inventory to use"

--- a/Translations/sv.po
+++ b/Translations/sv.po
@@ -4013,12 +4013,8 @@ msgid "Activate to read"
 msgstr "Aktivera för att läsa"
 
 #: Source/items.cpp:1825
-msgid "Right-click to read, then"
-msgstr "Högerklicka för att läsa, därefter"
-
-#: Source/items.cpp:1826
-msgid "left-click to target"
-msgstr "vänsterklicka för att ange mål"
+msgid "Right-click to read, then\nleft-click to target"
+msgstr "Högerklicka för att läsa, därefter\nvänsterklicka för att ange mål"
 
 #: Source/items.cpp:1849
 msgid "Right-click to use"

--- a/Translations/uk.po
+++ b/Translations/uk.po
@@ -4276,7 +4276,7 @@ msgstr "Активуйте щоб використати"
 #: Source/items.cpp:1765
 msgid ""
 "Select from spell book, then\n"
-"cast to read"
+"cast spell to read"
 msgstr ""
 "Виберіть з книги чарувань, а потім\n"
 "чаруйте, щоб прочитати"

--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -3956,12 +3956,8 @@ msgid "Right-click to read"
 msgstr "右击​阅读"
 
 #: Source/items.cpp:1814 Source/items.cpp:1835
-msgid "Select from spell book, then"
-msgstr "从​法术​书​中​选择，之后"
-
-#: Source/items.cpp:1815 Source/items.cpp:1836
-msgid "cast spell to read"
-msgstr "施放​法术​进行​阅读"
+msgid "Select from spell book, then\ncast spell to read"
+msgstr "从​法术​书​中​选择，之后\n施放​法术​进行​阅读"
 
 #: Source/items.cpp:1817 Source/items.cpp:1838 Source/items.cpp:1852
 msgid "Open inventory to use"

--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -3972,12 +3972,8 @@ msgid "Activate to read"
 msgstr "激活​阅读"
 
 #: Source/items.cpp:1825
-msgid "Right-click to read, then"
-msgstr "右击​阅读，然后"
-
-#: Source/items.cpp:1826
-msgid "left-click to target"
-msgstr "左击​目标"
+msgid "Right-click to read, then\nleft-click to target"
+msgstr "右击​阅读，然后\n左击​目标"
 
 #: Source/items.cpp:1849
 msgid "Right-click to use"

--- a/Translations/zh_TW.po
+++ b/Translations/zh_TW.po
@@ -4083,14 +4083,8 @@ msgid "Right-click to read"
 msgstr "右​擊閱讀"
 
 #: Source/items.cpp:1814 Source/items.cpp:1835
-#, fuzzy
-#| msgid "Select current spell button"
-msgid "Select from spell book, then"
-msgstr "選​擇​目前​法術​按​鈕"
-
-#: Source/items.cpp:1815 Source/items.cpp:1836
-msgid "cast spell to read"
-msgstr ""
+msgid "Select from spell book, then\ncast spell to read"
+msgstr "從拼寫書中選擇​, 然後\n施放拼寫來閱讀"
 
 #: Source/items.cpp:1817 Source/items.cpp:1838 Source/items.cpp:1852
 msgid "Open inventory to use"
@@ -4102,7 +4096,7 @@ msgstr ""
 
 #: Source/items.cpp:1825
 msgid "Right-click to read, then\nleft-click to target"
-msgstr "右​擊​閱讀，然​後\n左​擊目標"
+msgstr "右​擊​閱讀, 然​後\n左​擊目標"
 
 #: Source/items.cpp:1849
 msgid "Right-click to use"

--- a/Translations/zh_TW.po
+++ b/Translations/zh_TW.po
@@ -4101,12 +4101,8 @@ msgid "Activate to read"
 msgstr ""
 
 #: Source/items.cpp:1825
-msgid "Right-click to read, then"
-msgstr "右​擊​閱讀，然​後"
-
-#: Source/items.cpp:1826
-msgid "left-click to target"
-msgstr "左​擊目標"
+msgid "Right-click to read, then\nleft-click to target"
+msgstr "右​擊​閱讀，然​後\n左​擊目標"
 
 #: Source/items.cpp:1849
 msgid "Right-click to use"


### PR DESCRIPTION
* For some reason, in `items.cpp`, `"Select from spell book, then\ncast spell to read"` was at some point changed to `"Select from spell book, then\ncast to read"`, breaking most of the translations.
* Update translations to be a single string when expected