### PR TITLE
CMake: Cleanup no-mpq config

### DIFF
--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -12,12 +12,15 @@ else()
   endif()
 endif()
 
-if(EMSCRIPTEN)
-  emscripten_system_library("bzip2" BZip2::BZip2 USE_BZIP2=1)
-else()
-  dependency_options("bzip2" DEVILUTIONX_SYSTEM_BZIP2 ON DEVILUTIONX_STATIC_BZIP2)
-  if(NOT DEVILUTIONX_SYSTEM_BZIP2)
-    add_subdirectory(3rdParty/bzip2)
+if(SUPPORTS_MPQ)
+  # bzip2 is a libmpq dependency.
+  if(EMSCRIPTEN)
+    emscripten_system_library("bzip2" BZip2::BZip2 USE_BZIP2=1)
+  else()
+    dependency_options("bzip2" DEVILUTIONX_SYSTEM_BZIP2 ON DEVILUTIONX_STATIC_BZIP2)
+    if(NOT DEVILUTIONX_SYSTEM_BZIP2)
+      add_subdirectory(3rdParty/bzip2)
+    endif()
   endif()
 endif()
 
@@ -182,7 +185,7 @@ else()
   add_subdirectory(3rdParty/simpleini)
 endif()
 
-if(NOT (UNPACKED_MPQS AND UNPACKED_SAVES))
+if(SUPPORTS_MPQ)
   add_subdirectory(3rdParty/libmpq)
 endif()
 
@@ -190,7 +193,7 @@ add_subdirectory(3rdParty/tl)
 
 add_subdirectory(3rdParty/hoehrmann_utf8)
 
-if(NOT (UNPACKED_MPQS AND UNPACKED_SAVES AND NONET))
+if(SUPPORTS_MPQ OR NOT NONET)
   add_subdirectory(3rdParty/PKWare)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,18 +139,29 @@ mark_as_advanced(DEVILUTIONX_PALETTE_TRANSPARENCY_BLACK_16_LUT)
 option(DISABLE_DEMOMODE "Disable demo mode support" OFF)
 option(DISCORD_INTEGRATION "Build with Discord SDK for rich presence support" OFF)
 
-# By default, devilutionx.mpq is built only if smpq is installed.
-if(NOT DEFINED BUILD_ASSETS_MPQ AND NOT SRC_DIST)
-  find_program(SMPQ smpq)
-elseif(BUILD_ASSETS_MPQ)
-  find_program(SMPQ smpq REQUIRED)
-endif()
-if(SMPQ)
-  set(_has_smpq ON)
+# If both UNPACKED_MPQS and UNPACKED_SAVES are enabled, we completely remove MPQ support.
+if(UNPACKED_MPQS AND UNPACKED_SAVES)
+  set(SUPPORTS_MPQ OFF)
 else()
-  set(_has_smpq OFF)
+  set(SUPPORTS_MPQ ON)
 endif()
-option(BUILD_ASSETS_MPQ "If true, assets are packaged into devilutionx.mpq." ${_has_smpq})
+
+# By default, devilutionx.mpq is built only if smpq is installed and MPQ support is enabled.
+if(SUPPORTS_MPQ)
+  if(NOT DEFINED BUILD_ASSETS_MPQ AND NOT SRC_DIST)
+    find_program(SMPQ smpq)
+  elseif(BUILD_ASSETS_MPQ)
+    find_program(SMPQ smpq REQUIRED)
+  endif()
+  if(SMPQ)
+    set(_has_smpq ON)
+  else()
+    set(_has_smpq OFF)
+  endif()
+  option(BUILD_ASSETS_MPQ "If true, assets are packaged into devilutionx.mpq." ${_has_smpq})
+else()
+  set(BUILD_ASSETS_MPQS OFF)
+endif()
 
 # === Option overrides ===
 # TSAN is not compatible with ASAN.

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -164,7 +164,7 @@ set(libdevilutionx_SRCS
   utils/surface_to_clx.cpp
   utils/utf8.cpp)
 
-if(NOT (UNPACKED_MPQS AND UNPACKED_SAVES))
+if(SUPPORTS_MPQ)
   list(APPEND libdevilutionx_DEPS libmpq)
   list(APPEND libdevilutionx_SRCS
     mpq/mpq_reader.cpp
@@ -172,7 +172,7 @@ if(NOT (UNPACKED_MPQS AND UNPACKED_SAVES))
     mpq/mpq_writer.cpp)
 endif()
 
-if(NOT (UNPACKED_MPQS AND UNPACKED_SAVES AND NONET))
+if(SUPPORTS_MPQ OR NOT NONET)
   list(APPEND libdevilutionx_DEPS PKWare)
   list(APPEND libdevilutionx_SRCS encrypt.cpp)
 endif()


### PR DESCRIPTION
Introduce a `SUPPORTS_MPQ` variable and use it throughout. Also disables fetching bzip2 when MPQ support is disabled.