### PR TITLE
Demomode: Store/override gameplay options

### DIFF
--- a/Source/controls/controller.cpp
+++ b/Source/controls/controller.cpp
@@ -8,6 +8,8 @@
 #include "controls/devices/joystick.h"
 #include "controls/devices/kbcontroller.h"
 
+#include "engine/demomode.h"
+
 namespace devilution {
 
 void UnlockControllerState(const SDL_Event &event)
@@ -39,9 +41,11 @@ StaticVector<ControllerButtonEvent, 4> ToControllerButtonEvents(const SDL_Event 
 		break;
 	}
 #if HAS_KBCTRL == 1
-	result.button = KbCtrlToControllerButton(event);
-	if (result.button != ControllerButton_NONE)
-		return { result };
+	if (!demo::IsRunning()) {
+		result.button = KbCtrlToControllerButton(event);
+		if (result.button != ControllerButton_NONE)
+			return { result };
+	}
 #endif
 #ifndef USE_SDL1
 	GameController *const controller = GameController::Get(event);
@@ -71,7 +75,7 @@ bool IsControllerButtonPressed(ControllerButton button)
 		return true;
 #endif
 #if HAS_KBCTRL == 1
-	if (IsKbCtrlButtonPressed(button))
+	if (!demo::IsRunning() && IsKbCtrlButtonPressed(button))
 		return true;
 #endif
 	return Joystick::IsPressedOnAnyJoystick(button);

--- a/Source/controls/controller_motion.cpp
+++ b/Source/controls/controller_motion.cpp
@@ -11,6 +11,7 @@
 #include "controls/game_controls.h"
 #include "controls/plrctrls.h"
 #include "controls/touch/gamepad.h"
+#include "engine/demomode.h"
 #include "options.h"
 #include "utils/log.hpp"
 


### PR DESCRIPTION
The advantage of having a specific list rather than storing the whole `diablo.ini` file is that non-gameplay options, such as floating numbers, can still be changed in the config and visually affect the demo.