### PR TITLE
GitHub CI: Fix cache strategy

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -38,7 +38,8 @@ jobs:
       uses: actions/cache@v3
       with:
         path: android-project/app/.cxx
-        key: ${{ github.workflow }}-v1
+        key: ${{ github.workflow }}-v1-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v1-
 
     - name: Build
       working-directory: ${{github.workspace}}

--- a/.github/workflows/Linux_x86.yml
+++ b/.github/workflows/Linux_x86.yml
@@ -34,7 +34,8 @@ jobs:
       uses: actions/cache@v3
       with:
         path: build
-        key: ${{ github.workflow }}-v1
+        key: ${{ github.workflow }}-v1-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v1-
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/Linux_x86_64_SDL1.yml
+++ b/.github/workflows/Linux_x86_64_SDL1.yml
@@ -33,7 +33,8 @@ jobs:
       uses: actions/cache@v3
       with:
         path: build
-        key: ${{ github.workflow }}-v1
+        key: ${{ github.workflow }}-v1-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v1-
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/Linux_x86_64_test.yml
+++ b/.github/workflows/Linux_x86_64_test.yml
@@ -21,27 +21,31 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y cmake curl g++ git lcov libgtest-dev libgmock-dev libfmt-dev libsdl2-dev libsodium-dev libpng-dev libbz2-dev wget
-      - name: Cache CMake build folder
-        uses: actions/cache@v3
-        with:
-          path: build
-          key: ${{ github.workflow }}-v1
-      - name: Build tests
-        run: |
-          cmake -S. -Bbuild -DENABLE_CODECOVERAGE=ON
-          wget -nc https://github.com/diasurgical/devilutionx-assets/releases/download/v2/spawn.mpq -P build
-          cmake --build build -j $(nproc)
-      - name: Run tests
-        run: cd build && ctest --output-on-failure
-      - name: Upload results
-        uses: codecov/codecov-action@v3
-        with:
-          gcov: true
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y cmake curl g++ git lcov libgtest-dev libgmock-dev libfmt-dev libsdl2-dev libsodium-dev libpng-dev libbz2-dev wget
+    - name: Cache CMake build folder
+      uses: actions/cache@v3
+      with:
+        path: build
+        key: ${{ github.workflow }}-v1-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v1-
+
+    - name: Build tests
+      run: |
+        cmake -S. -Bbuild -DENABLE_CODECOVERAGE=ON
+        wget -nc https://github.com/diasurgical/devilutionx-assets/releases/download/v2/spawn.mpq -P build
+        cmake --build build -j $(nproc)
+
+    - name: Run tests
+      run: cd build && ctest --output-on-failure
+
+    - name: Upload results
+      uses: codecov/codecov-action@v3
+      with:
+        gcov: true

--- a/.github/workflows/MacOSX.yml
+++ b/.github/workflows/MacOSX.yml
@@ -39,7 +39,8 @@ jobs:
       uses: actions/cache@v3
       with:
         path: build
-        key: ${{ github.workflow }}-v1
+        key: ${{ github.workflow }}-v1-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v1-
 
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,33 @@
+name: Delete cache for a closed Pull Request
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR; do
+            gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -36,7 +36,8 @@ jobs:
       uses: actions/cache@v3
       with:
         path: build
-        key: ${{ github.workflow }}-v1
+        key: ${{ github.workflow }}-v1-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v1-
 
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable

--- a/.github/workflows/s390x_qemu_big_endian_tests.yml
+++ b/.github/workflows/s390x_qemu_big_endian_tests.yml
@@ -25,7 +25,8 @@ jobs:
       uses: actions/cache@v3
       with:
         path: .ccache
-        key: ${{ github.workflow }}-ccache
+        key: ${{ github.workflow }}-v1-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v1-
 
     - name: Get the qemu container
       run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes


### PR DESCRIPTION
GitHub caches are immutable, so #5883 was wrong (caches were never updated).

Goes back to the previous caching strategy but with a cleanup workflow to delete caches for merged/closed PRs.

The cleanup code comes from the example in GitHub docs: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries