### PR TITLE
Multiplayer: Fix desync when teleporting

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -129,7 +129,11 @@ byte *ReceivePacket(TBuffer *pBuf, byte *body, size_t *size)
 void NetReceivePlayerData(TPkt *pkt)
 {
 	const Player &myPlayer = *MyPlayer;
-	const Point target = myPlayer.GetTargetPosition();
+	Point target = myPlayer.GetTargetPosition();
+	// Don't send desired target position when we will change our position soon.
+	// This prevents a desync where the remote client starts a walking to the old target position when the teleport is finished but the the new position isn't received yet.
+	if (myPlayer._pmode == PM_SPELL && IsAnyOf(myPlayer.executedSpell.spellId, SpellID::Teleport, SpellID::Phasing, SpellID::Warp))
+		target = {};
 
 	pkt->hdr.wCheck = HeaderCheckVal;
 	pkt->hdr.px = myPlayer.position.tile.x;
@@ -653,7 +657,9 @@ void multi_process_network_packets()
 					if (player.position.future.WalkingDistance(player.position.tile) > 1) {
 						player.position.future = player.position.tile;
 					}
-					MakePlrPath(player, { pkt->targx, pkt->targy }, true);
+					Point target = { pkt->targx, pkt->targy };
+					if (target != Point {}) // does the client send a desired (future) position of remote player?
+						MakePlrPath(player, target, true);
 				} else {
 					player.position.tile = syncPosition;
 					player.position.future = syncPosition;


### PR DESCRIPTION
in master a desync can happen when using a spell that changes your position (teleport, phasing or warp).
When the the desyncs happens the remote client starts/sees a walking one tile to the old position (before teleport).
After that the remote client sees the player walk back to the correct position.

Example Video:

https://user-images.githubusercontent.com/25415264/226195322-13e4dae6-bca8-499b-806a-8a9cedfc5ba8.mp4

How does this happen?
- Background: In multiplayer the "player data" is frequently send to the remote client.
  - These "player data" include a "target"-position (current position or position where the player is moving to) along with hp and other stuff.
  - This data is used for a syncing/position logic: the remote client tries to walk the player to this position (`MakePlrPath`). This ensures that the player always stands on the correct tile. Normally the "target"-position is in sync with the calculated position on the remote client.
- When starting a teleport a `CMD_SPELLXY` is send with the desired coordinates. But the "target"-position isn't set to something new (the player didn't changed position yet and is not moving).
- When the teleport is finished on the client, A new "player data" with a new "target"-position is send to the remote client.
- But when this package is too slow, the remote client uses the old "target"-position for it's syncing/position logic and starts walking towards the old position (before the teleport).
- After this it's receives a new "player data" info and walks back to the correct/new tile.

Fix:
Don't send desired "target"-position when the player will change his position soon.