### PR TITLE
Fix year in screenshot file names

### DIFF
--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -138,7 +138,7 @@ FILE *CaptureFile(std::string *dstPath)
 	const std::tm *tm = std::localtime(&tt);
 	const std::string filename = tm != nullptr
 	    ? fmt::format("Screenshot from {:04}-{:02}-{:02} {:02}-{:02}-{:02}",
-	        tm->tm_year, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec)
+	        tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec)
 	    : "Screenshot";
 	*dstPath = StrCat(paths::PrefPath(), filename, ".pcx");
 	int i = 0;


### PR DESCRIPTION
The standard defines `tm_year` to be the number of years since 1900.

This resolves #5905