### PR TITLE
Use StashStruct::EmptyCell instead for empty stash item check

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -999,7 +999,7 @@ void FreeControlPan()
 void DrawInfoBox(const Surface &out)
 {
 	DrawPanelBox(out, { 177, 62, 288, 63 }, GetMainPanel().position + Displacement { 177, 46 });
-	if (!panelflag && !trigflag && pcursinvitem == -1 && pcursstashitem == uint16_t(-1) && !spselflag) {
+	if (!panelflag && !trigflag && pcursinvitem == -1 && pcursstashitem == StashStruct::EmptyCell && !spselflag) {
 		InfoString = {};
 		InfoColor = UiFlags::ColorWhite;
 	}

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1769,7 +1769,7 @@ void plrctrls_after_check_curs_move()
 	if (ControllerActionHeld != GameActionType_NONE && IsNoneOf(LastMouseButtonAction, MouseActionType::None, MouseActionType::Attack, MouseActionType::Spell)) {
 		InvalidateTargets();
 
-		if (pcursmonst == -1 && ObjectUnderCursor == nullptr && pcursitem == -1 && pcursinvitem == -1 && pcursstashitem == uint16_t(-1) && pcursplr == -1) {
+		if (pcursmonst == -1 && ObjectUnderCursor == nullptr && pcursitem == -1 && pcursinvitem == -1 && pcursstashitem == StashStruct::EmptyCell && pcursplr == -1) {
 			FindTrigger();
 		}
 		return;
@@ -2003,7 +2003,7 @@ void PerformSpellAction()
 			CheckInvItem(true, false);
 			if (itemId != GetItemIdOnSlot(Slot))
 				ResetInvCursorPosition();
-		} else if (pcursstashitem != uint16_t(-1)) {
+		} else if (pcursstashitem != StashStruct::EmptyCell) {
 			CheckStashItem(MousePosition, true, false);
 		}
 		return;
@@ -2067,7 +2067,7 @@ void CtrlUseInvItem()
 
 void CtrlUseStashItem()
 {
-	if (pcursstashitem == uint16_t(-1)) {
+	if (pcursstashitem == StashStruct::EmptyCell) {
 		return;
 	}
 
@@ -2097,7 +2097,7 @@ void PerformSecondaryAction()
 			TryIconCurs();
 			NewCursor(CURSOR_HAND);
 		} else if (IsStashOpen) {
-			if (pcursstashitem != uint16_t(-1)) {
+			if (pcursstashitem != StashStruct::EmptyCell) {
 				TransferItemToInventory(myPlayer, pcursstashitem);
 			} else if (pcursinvitem != -1) {
 				TransferItemToStash(myPlayer, pcursinvitem);

--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -12,6 +12,7 @@
 #include "levels/gendung.h"
 #include "minitext.h"
 #include "panels/ui_panels.hpp"
+#include "qol/stash.h"
 #include "stores.h"
 #include "towners.h"
 #include "utils/sdl_compat.h"
@@ -443,7 +444,7 @@ VirtualGamepadButtonType PrimaryActionButtonRenderer::GetDungeonButtonType()
 
 VirtualGamepadButtonType PrimaryActionButtonRenderer::GetInventoryButtonType()
 {
-	if (pcursinvitem != -1 || pcursstashitem != uint16_t(-1) || pcurs > CURSOR_HAND)
+	if (pcursinvitem != -1 || pcursstashitem != StashStruct::EmptyCell || pcurs > CURSOR_HAND)
 		return GetItemButtonType(virtualPadButton->isHeld);
 	return GetBlankButtonType(virtualPadButton->isHeld);
 }

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -310,7 +310,7 @@ void InitLevelCursor()
 	pcursmonst = -1;
 	ObjectUnderCursor = nullptr;
 	pcursitem = -1;
-	pcursstashitem = uint16_t(-1);
+	pcursstashitem = StashStruct::EmptyCell;
 	pcursplr = -1;
 	ClearCursor();
 }
@@ -446,7 +446,7 @@ void CheckCursMove()
 	if ((sgbMouseDown != CLICK_NONE || ControllerActionHeld != GameActionType_NONE) && IsNoneOf(LastMouseButtonAction, MouseActionType::None, MouseActionType::Attack, MouseActionType::Spell)) {
 		InvalidateTargets();
 
-		if (pcursmonst == -1 && ObjectUnderCursor == nullptr && pcursitem == -1 && pcursinvitem == -1 && pcursstashitem == uint16_t(-1) && pcursplr == -1) {
+		if (pcursmonst == -1 && ObjectUnderCursor == nullptr && pcursitem == -1 && pcursinvitem == -1 && pcursstashitem == StashStruct::EmptyCell && pcursplr == -1) {
 			cursPosition = { mx, my };
 			CheckTrigForce();
 			CheckTown();
@@ -465,7 +465,7 @@ void CheckCursMove()
 		RedrawComponent(PanelDrawComponent::Belt);
 	}
 	pcursinvitem = -1;
-	pcursstashitem = uint16_t(-1);
+	pcursstashitem = StashStruct::EmptyCell;
 	pcursplr = -1;
 	ShowUniqueItemInfoBox = false;
 	panelflag = false;

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -427,7 +427,7 @@ void RightMouseDown(bool isShiftHeld)
 		return;
 	if (pcursinvitem != -1 && UseInvItem(MyPlayerId, pcursinvitem))
 		return;
-	if (pcursstashitem != uint16_t(-1) && UseStashItem(pcursstashitem))
+	if (pcursstashitem != StashStruct::EmptyCell && UseStashItem(pcursstashitem))
 		return;
 	if (pcurs == CURSOR_HAND) {
 		CheckPlrSpell(isShiftHeld);
@@ -2468,7 +2468,7 @@ bool TryIconCurs()
 	if (pcurs == CURSOR_IDENTIFY) {
 		if (pcursinvitem != -1)
 			CheckIdentify(myPlayer, pcursinvitem);
-		else if (pcursstashitem != uint16_t(-1)) {
+		else if (pcursstashitem != StashStruct::EmptyCell) {
 			Item &item = Stash.stashList[pcursstashitem];
 			item._iIdentified = true;
 		}
@@ -2479,7 +2479,7 @@ bool TryIconCurs()
 	if (pcurs == CURSOR_REPAIR) {
 		if (pcursinvitem != -1)
 			DoRepair(myPlayer, pcursinvitem);
-		else if (pcursstashitem != uint16_t(-1)) {
+		else if (pcursstashitem != StashStruct::EmptyCell) {
 			Item &item = Stash.stashList[pcursstashitem];
 			RepairItem(item, myPlayer._pLevel);
 		}
@@ -2490,7 +2490,7 @@ bool TryIconCurs()
 	if (pcurs == CURSOR_RECHARGE) {
 		if (pcursinvitem != -1)
 			DoRecharge(myPlayer, pcursinvitem);
-		else if (pcursstashitem != uint16_t(-1)) {
+		else if (pcursstashitem != StashStruct::EmptyCell) {
 			Item &item = Stash.stashList[pcursstashitem];
 			RechargeItem(item, myPlayer);
 		}
@@ -2502,7 +2502,7 @@ bool TryIconCurs()
 		bool changeCursor = true;
 		if (pcursinvitem != -1)
 			changeCursor = DoOil(myPlayer, pcursinvitem);
-		else if (pcursstashitem != uint16_t(-1)) {
+		else if (pcursstashitem != StashStruct::EmptyCell) {
 			Item &item = Stash.stashList[pcursstashitem];
 			changeCursor = ApplyOilToItem(item, myPlayer);
 		}

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -277,7 +277,7 @@ void InitStash()
 
 void TransferItemToInventory(Player &player, uint16_t itemId)
 {
-	if (itemId == uint16_t(-1)) {
+	if (itemId == StashStruct::EmptyCell) {
 		return;
 	}
 


### PR DESCRIPTION
Small refactoring.
Replaces all `uint16_t(-1)` with `StashStruct::EmptyCell` to describe empty cell behavior better.