### PR TITLE
Multiplayer: When updating remote player tile ensures that it's free

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -641,7 +641,7 @@ void multi_process_network_packets()
 			player._pBaseDex = pkt->bdex;
 			if (!cond && player.plractive && player._pHitPoints != 0) {
 				if (player.isOnActiveLevel() && !player._pLvlChanging) {
-					if (player.position.tile.WalkingDistance(syncPosition) > 3 && dPlayer[pkt->px][pkt->py] == 0) {
+					if (player.position.tile.WalkingDistance(syncPosition) > 3 && PosOkPlayer(player, syncPosition)) {
 						// got out of sync, clear the tiles around where we last thought the player was located
 						FixPlrWalkTags(player);
 


### PR DESCRIPTION
Small improvement:
When a remotes player position is updated and it's too far away, the game places/warps the player to the new tile.
This ensures that the desyncs are minimized.
But currently the game only checks if the tile doesn't have a player on it.
It doesn't check if a monster is on the tile or if there is a closed door.
This pr ensures that the game checks this facts before the player gets warped to his new position.

<details><summary>Old content with a possible desync fix for PvP szenarios</summary>
In a PvP match it's possible that the position of a player can desync between clients.
Normally this is no big deal and in some way a interesting aspect of PvP.

But there are cases where this is problematic:
- Player A walks to a new tile
- On Player A's client he finished the walk
- On Player B's client Player A is still on the walk
- Player B hit's Player A
   - Player A starts a hit recovery and is set to his old position (only on Player B's client)
   - Player B sends `CMD_PLRDAMAGE` to Player A's client
 - Player B can continue to hit Player A

With this pr this is solved by syncing the player position/tile instant when Player A gets in hit recovery (or blocking).
That way Player B can only get on hit.
This fix is only applied on arenas, cause in normal PvE it's not that relevant (but it would be possible to do this always).
Another fix is that we now check (in a separate commit) that the new tile is also free from monsters and other objects (for example closed door).

Thanks @StephenCWills for providing a testing method. ❤️ It reproducible forced the desync. Without it this pr wouldn't be possible, cause fighting with yourself is really hard. 😁 

For now this pr is a draft until the PvP-Community confirms that the fix works as desired.

**The feedback was negative. That why this approach will be discarded.**

# Example Video (with testing method)

## Master

https://user-images.githubusercontent.com/25415264/226703459-dfd51f04-e347-4a5e-ac55-90f396f83e91.mp4

## PR

https://user-images.githubusercontent.com/25415264/226703507-302c244e-b42a-4046-8e06-4d938b09b710.mp4

</details>