### PR TITLE
Use rectangles for inventory/belt hit areas

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -584,32 +584,32 @@ Point InvGetEquipSlotCoord(const inv_body_loc invSlot)
 	Point result = GetPanelPosition(UiPanels::Inventory);
 	switch (invSlot) {
 	case INVLOC_HEAD:
-		result.x += ((InvRect[SLOTXY_HEAD_FIRST].x + InvRect[SLOTXY_HEAD_LAST].x) / 2);
-		result.y += ((InvRect[SLOTXY_HEAD_FIRST].y + InvRect[SLOTXY_HEAD_LAST].y) / 2);
+		result.x += InvRect[SLOTXY_HEAD].Center().x;
+		result.y += InvRect[SLOTXY_HEAD].Center().y;
 		break;
 	case INVLOC_RING_LEFT:
-		result.x += InvRect[SLOTXY_RING_LEFT].x;
-		result.y += InvRect[SLOTXY_RING_LEFT].y;
+		result.x += InvRect[SLOTXY_RING_LEFT].Center().x;
+		result.y += InvRect[SLOTXY_RING_LEFT].Center().y;
 		break;
 	case INVLOC_RING_RIGHT:
-		result.x += InvRect[SLOTXY_RING_RIGHT].x;
-		result.y += InvRect[SLOTXY_RING_RIGHT].y;
+		result.x += InvRect[SLOTXY_RING_RIGHT].Center().x;
+		result.y += InvRect[SLOTXY_RING_RIGHT].Center().y;
 		break;
 	case INVLOC_AMULET:
-		result.x += InvRect[SLOTXY_AMULET].x;
-		result.y += InvRect[SLOTXY_AMULET].y;
+		result.x += InvRect[SLOTXY_AMULET].Center().x;
+		result.y += InvRect[SLOTXY_AMULET].Center().y;
 		break;
 	case INVLOC_HAND_LEFT:
-		result.x += ((InvRect[SLOTXY_HAND_LEFT_FIRST].x + InvRect[SLOTXY_HAND_LEFT_LAST].x) / 2);
-		result.y += ((InvRect[SLOTXY_HAND_LEFT_FIRST].y + InvRect[SLOTXY_HAND_LEFT_LAST].y) / 2);
+		result.x += InvRect[SLOTXY_HAND_LEFT].Center().x;
+		result.y += InvRect[SLOTXY_HAND_LEFT].Center().y;
 		break;
 	case INVLOC_HAND_RIGHT:
-		result.x += ((InvRect[SLOTXY_HAND_RIGHT_FIRST].x + InvRect[SLOTXY_HAND_RIGHT_LAST].x) / 2);
-		result.y += ((InvRect[SLOTXY_HAND_RIGHT_FIRST].y + InvRect[SLOTXY_HAND_RIGHT_LAST].y) / 2);
+		result.x += InvRect[SLOTXY_HAND_RIGHT].Center().x;
+		result.y += InvRect[SLOTXY_HAND_RIGHT].Center().y;
 		break;
 	case INVLOC_CHEST:
-		result.x += ((InvRect[SLOTXY_CHEST_FIRST].x + InvRect[SLOTXY_CHEST_LAST].x) / 2);
-		result.y += ((InvRect[SLOTXY_CHEST_FIRST].y + InvRect[SLOTXY_CHEST_LAST].y) / 2);
+		result.x += InvRect[SLOTXY_CHEST].Center().x;
+		result.y += InvRect[SLOTXY_CHEST].Center().y;
 		break;
 	default:
 		break;
@@ -620,7 +620,7 @@ Point InvGetEquipSlotCoord(const inv_body_loc invSlot)
 
 Point InvGetEquipSlotCoordFromInvSlot(const inv_xy_slot slot)
 {
-	if (slot >= SLOTXY_HEAD_FIRST && slot <= SLOTXY_HEAD_LAST) {
+	if (slot == SLOTXY_HEAD) {
 		return InvGetEquipSlotCoord(INVLOC_HEAD);
 	}
 	if (slot == SLOTXY_RING_LEFT) {
@@ -632,13 +632,13 @@ Point InvGetEquipSlotCoordFromInvSlot(const inv_xy_slot slot)
 	if (slot == SLOTXY_AMULET) {
 		return InvGetEquipSlotCoord(INVLOC_AMULET);
 	}
-	if (slot >= SLOTXY_HAND_LEFT_FIRST && slot <= SLOTXY_HAND_LEFT_LAST) {
+	if (slot == SLOTXY_HAND_LEFT) {
 		return InvGetEquipSlotCoord(INVLOC_HAND_LEFT);
 	}
-	if (slot >= SLOTXY_HAND_RIGHT_FIRST && slot <= SLOTXY_HAND_RIGHT_LAST) {
+	if (slot == SLOTXY_HAND_RIGHT) {
 		return InvGetEquipSlotCoord(INVLOC_HAND_RIGHT);
 	}
-	if (slot >= SLOTXY_CHEST_FIRST && slot <= SLOTXY_CHEST_LAST) {
+	if (slot == SLOTXY_CHEST) {
 		return InvGetEquipSlotCoord(INVLOC_CHEST);
 	}
 
@@ -651,10 +651,10 @@ Point InvGetEquipSlotCoordFromInvSlot(const inv_xy_slot slot)
 Point GetSlotCoord(int slot)
 {
 	if (slot >= SLOTXY_BELT_FIRST && slot <= SLOTXY_BELT_LAST) {
-		return GetPanelPosition(UiPanels::Main, InvRect[slot]);
+		return GetPanelPosition(UiPanels::Main, InvRect[slot].position);
 	}
 
-	return GetPanelPosition(UiPanels::Inventory, InvRect[slot]);
+	return GetPanelPosition(UiPanels::Inventory, InvRect[slot].position);
 }
 
 /**
@@ -796,7 +796,7 @@ inv_xy_slot InventoryMoveToBody(int slot)
 		return SLOTXY_RING_LEFT;
 	}
 	if (slot <= SLOTXY_INV_ROW1_FIRST + 6) { // middle 4 general slots
-		return SLOTXY_CHEST_FIRST;
+		return SLOTXY_CHEST;
 	}
 	// last 3 general slots
 	return SLOTXY_RING_RIGHT;
@@ -809,14 +809,6 @@ void InventoryMove(AxisDirection dir)
 	// normalize slots
 	if (Slot < 0)
 		Slot = FindClosestInventorySlot(mousePos);
-	else if (Slot >= SLOTXY_HEAD_FIRST && Slot <= SLOTXY_HEAD_LAST)
-		Slot = SLOTXY_HEAD_FIRST;
-	else if (Slot >= SLOTXY_HAND_LEFT_FIRST && Slot <= SLOTXY_HAND_LEFT_LAST)
-		Slot = SLOTXY_HAND_LEFT_FIRST;
-	else if (Slot >= SLOTXY_CHEST_FIRST && Slot <= SLOTXY_CHEST_LAST)
-		Slot = SLOTXY_CHEST_FIRST;
-	else if (Slot >= SLOTXY_HAND_RIGHT_FIRST && Slot <= SLOTXY_HAND_RIGHT_LAST)
-		Slot = SLOTXY_HAND_RIGHT_FIRST;
 	else if (Slot > SLOTXY_BELT_LAST)
 		Slot = SLOTXY_BELT_LAST;
 
@@ -836,15 +828,15 @@ void InventoryMove(AxisDirection dir)
 			} else if (heldItem._itype == ItemType::Ring) {
 				Slot = SLOTXY_RING_LEFT;
 			} else if (heldItem.isWeapon() || heldItem.isShield()) {
-				Slot = SLOTXY_HAND_LEFT_FIRST;
+				Slot = SLOTXY_HAND_LEFT;
 			}
 		} else {
-			if (Slot == SLOTXY_HAND_RIGHT_FIRST) {
-				Slot = SLOTXY_CHEST_FIRST;
-			} else if (Slot == SLOTXY_CHEST_FIRST) {
-				Slot = SLOTXY_HAND_LEFT_FIRST;
+			if (Slot == SLOTXY_HAND_RIGHT) {
+				Slot = SLOTXY_CHEST;
+			} else if (Slot == SLOTXY_CHEST) {
+				Slot = SLOTXY_HAND_LEFT;
 			} else if (Slot == SLOTXY_AMULET) {
-				Slot = SLOTXY_HEAD_FIRST;
+				Slot = SLOTXY_HEAD;
 			} else if (Slot == SLOTXY_RING_RIGHT) {
 				Slot = SLOTXY_RING_LEFT;
 			} else if (Slot >= SLOTXY_INV_FIRST && Slot <= SLOTXY_BELT_LAST) {
@@ -870,16 +862,16 @@ void InventoryMove(AxisDirection dir)
 			} else if (heldItem._itype == ItemType::Ring) {
 				Slot = SLOTXY_RING_RIGHT;
 			} else if (heldItem.isWeapon() || heldItem.isShield()) {
-				Slot = SLOTXY_HAND_RIGHT_FIRST;
+				Slot = SLOTXY_HAND_RIGHT;
 			}
 		} else {
 			if (Slot == SLOTXY_RING_LEFT) {
 				Slot = SLOTXY_RING_RIGHT;
-			} else if (Slot == SLOTXY_HAND_LEFT_FIRST) {
-				Slot = SLOTXY_CHEST_FIRST;
-			} else if (Slot == SLOTXY_CHEST_FIRST) {
-				Slot = SLOTXY_HAND_RIGHT_FIRST;
-			} else if (Slot == SLOTXY_HEAD_FIRST) {
+			} else if (Slot == SLOTXY_HAND_LEFT) {
+				Slot = SLOTXY_CHEST;
+			} else if (Slot == SLOTXY_CHEST) {
+				Slot = SLOTXY_HAND_RIGHT;
+			} else if (Slot == SLOTXY_HEAD) {
 				Slot = SLOTXY_AMULET;
 			} else if (Slot >= SLOTXY_INV_FIRST && Slot <= SLOTXY_BELT_LAST) {
 				int8_t itemId = GetItemIdOnSlot(Slot);
@@ -908,13 +900,13 @@ void InventoryMove(AxisDirection dir)
 						Slot = SLOTXY_RING_RIGHT;
 					}
 				} else if (heldItem.isWeapon()) {
-					Slot = SLOTXY_HAND_LEFT_FIRST;
+					Slot = SLOTXY_HAND_LEFT;
 				} else if (heldItem.isShield()) {
-					Slot = SLOTXY_HAND_RIGHT_FIRST;
+					Slot = SLOTXY_HAND_RIGHT;
 				} else if (heldItem.isHelm()) {
-					Slot = SLOTXY_HEAD_FIRST;
+					Slot = SLOTXY_HEAD;
 				} else if (heldItem.isArmor()) {
-					Slot = SLOTXY_CHEST_FIRST;
+					Slot = SLOTXY_CHEST;
 				} else if (heldItem._itype == ItemType::Amulet) {
 					Slot = SLOTXY_AMULET;
 				}
@@ -922,13 +914,13 @@ void InventoryMove(AxisDirection dir)
 		} else {
 			if (Slot >= SLOTXY_INV_ROW1_FIRST && Slot <= SLOTXY_INV_ROW1_LAST) {
 				Slot = InventoryMoveToBody(Slot);
-			} else if (Slot == SLOTXY_CHEST_FIRST || Slot == SLOTXY_HAND_LEFT_FIRST) {
-				Slot = SLOTXY_HEAD_FIRST;
+			} else if (Slot == SLOTXY_CHEST || Slot == SLOTXY_HAND_LEFT) {
+				Slot = SLOTXY_HEAD;
 			} else if (Slot == SLOTXY_RING_LEFT) {
-				Slot = SLOTXY_HAND_LEFT_FIRST;
+				Slot = SLOTXY_HAND_LEFT;
 			} else if (Slot == SLOTXY_RING_RIGHT) {
-				Slot = SLOTXY_HAND_RIGHT_FIRST;
-			} else if (Slot == SLOTXY_HAND_RIGHT_FIRST) {
+				Slot = SLOTXY_HAND_RIGHT;
+			} else if (Slot == SLOTXY_HAND_RIGHT) {
 				Slot = SLOTXY_AMULET;
 			} else if (Slot >= SLOTXY_INV_ROW2_FIRST) {
 				int8_t itemId = GetItemIdOnSlot(Slot);
@@ -950,11 +942,11 @@ void InventoryMove(AxisDirection dir)
 		}
 	} else if (dir.y == AxisDirectionY_DOWN) {
 		if (isHoldingItem) {
-			if (Slot == SLOTXY_HEAD_FIRST || Slot == SLOTXY_CHEST_FIRST) {
+			if (Slot == SLOTXY_HEAD || Slot == SLOTXY_CHEST) {
 				Slot = SLOTXY_INV_ROW1_FIRST + 4;
-			} else if (Slot == SLOTXY_RING_LEFT || Slot == SLOTXY_HAND_LEFT_FIRST) {
+			} else if (Slot == SLOTXY_RING_LEFT || Slot == SLOTXY_HAND_LEFT) {
 				Slot = SLOTXY_INV_ROW1_FIRST + 1;
-			} else if (Slot == SLOTXY_RING_RIGHT || Slot == SLOTXY_HAND_RIGHT_FIRST || Slot == SLOTXY_AMULET) {
+			} else if (Slot == SLOTXY_RING_RIGHT || Slot == SLOTXY_HAND_RIGHT || Slot == SLOTXY_AMULET) {
 				Slot = SLOTXY_INV_ROW1_LAST - 1;
 			} else if (Slot <= (SLOTXY_INV_ROW4_LAST - (itemSize.height * INV_ROW_SLOT_SIZE))) {
 				Slot += INV_ROW_SLOT_SIZE;
@@ -963,14 +955,14 @@ void InventoryMove(AxisDirection dir)
 					Slot += INV_ROW_SLOT_SIZE;
 			}
 		} else {
-			if (Slot == SLOTXY_HEAD_FIRST) {
-				Slot = SLOTXY_CHEST_FIRST;
-			} else if (Slot == SLOTXY_CHEST_FIRST) {
+			if (Slot == SLOTXY_HEAD) {
+				Slot = SLOTXY_CHEST;
+			} else if (Slot == SLOTXY_CHEST) {
 				if (PreviousInventoryColumn >= 3 && PreviousInventoryColumn <= 6)
 					Slot = SLOTXY_INV_ROW1_FIRST + PreviousInventoryColumn;
 				else
 					Slot = SLOTXY_INV_ROW1_FIRST + (INV_ROW_SLOT_SIZE / 2);
-			} else if (Slot == SLOTXY_HAND_LEFT_FIRST) {
+			} else if (Slot == SLOTXY_HAND_LEFT) {
 				Slot = SLOTXY_RING_LEFT;
 			} else if (Slot == SLOTXY_RING_LEFT) {
 				if (PreviousInventoryColumn >= 0 && PreviousInventoryColumn <= 2)
@@ -983,8 +975,8 @@ void InventoryMove(AxisDirection dir)
 				else
 					Slot = SLOTXY_INV_ROW1_LAST - 1;
 			} else if (Slot == SLOTXY_AMULET) {
-				Slot = SLOTXY_HAND_RIGHT_FIRST;
-			} else if (Slot == SLOTXY_HAND_RIGHT_FIRST) {
+				Slot = SLOTXY_HAND_RIGHT;
+			} else if (Slot == SLOTXY_HAND_RIGHT) {
 				Slot = SLOTXY_RING_RIGHT;
 			} else if (Slot <= SLOTXY_INV_LAST) {
 				int8_t itemId = GetItemIdOnSlot(Slot);
@@ -1016,28 +1008,23 @@ void InventoryMove(AxisDirection dir)
 		if (Slot < SLOTXY_INV_FIRST) {
 			// The coordinates we get for body slots are based on the centre of the region relative to the hand cursor
 			// Need to adjust the position for items larger than 1x1 so they're aligned as expected
-			mousePos.x -= (itemSize.width - 1) * INV_SLOT_HALF_SIZE_PX;
-			mousePos.y -= (itemSize.height - 1) * INV_SLOT_HALF_SIZE_PX;
+			mousePos.x -= itemSize.width * INV_SLOT_HALF_SIZE_PX;
+			mousePos.y -= itemSize.height * INV_SLOT_HALF_SIZE_PX;
 		}
-		// Also the y position is off... so shift the mouse a cell up to compensate.
-		mousePos.y -= InventorySlotSizeInPixels.height;
 	} else {
 		// get item under new slot if navigating on the inventory
-		if (Slot >= SLOTXY_INV_FIRST && Slot <= SLOTXY_INV_LAST) {
+		if (Slot >= SLOTXY_INV_FIRST && Slot <= SLOTXY_BELT_LAST) {
 			int8_t itemInvId = GetItemIdOnSlot(Slot);
 			int itemSlot = FindFirstSlotOnItem(itemInvId);
 			if (itemSlot < 0)
 				itemSlot = Slot;
 
-			// offset the slot to always move to the top-left most slot of that item
+			// offset the cursor so it shows over the center of the item
 			mousePos = GetSlotCoord(itemSlot);
 			itemSize = GetItemSizeOnSlot(itemSlot);
-			mousePos.x += ((itemSize.width - 1) * InventorySlotSizeInPixels.width) / 2;
-			mousePos.y += ((itemSize.height - 1) * InventorySlotSizeInPixels.height) / 2;
+			mousePos.x += (itemSize.width * InventorySlotSizeInPixels.width) / 2;
+			mousePos.y += (itemSize.height * InventorySlotSizeInPixels.height) / 2;
 		}
-
-		mousePos.x += (InventorySlotSizeInPixels.width / 2);
-		mousePos.y -= (InventorySlotSizeInPixels.height / 2);
 	}
 
 	if (mousePos == MousePosition) {
@@ -1141,8 +1128,8 @@ void StashMove(AxisDirection dir)
 		}
 	}
 
-	bool isHeadSlot = SLOTXY_HEAD_FIRST <= Slot && Slot <= SLOTXY_HEAD_LAST;
-	bool isLeftHandSlot = SLOTXY_HAND_LEFT_FIRST <= Slot && Slot <= SLOTXY_HAND_LEFT_LAST;
+	bool isHeadSlot = SLOTXY_HEAD == Slot;
+	bool isLeftHandSlot = SLOTXY_HAND_LEFT == Slot;
 	bool isLeftRingSlot = Slot == SLOTXY_RING_LEFT;
 	if (isHeadSlot || isLeftHandSlot || isLeftRingSlot) {
 		if (dir.x == AxisDirectionX_LEFT) {
@@ -1867,7 +1854,6 @@ void PerformPrimaryAction()
 			int newSlot = FindFirstSlotOnItem(itemUnderCursor);
 			if (jumpSlot >= 0 && jumpSlot != newSlot) {
 				Point mousePos = GetSlotCoord(jumpSlot);
-				mousePos.y -= InventorySlotSizeInPixels.height;
 				Slot = jumpSlot;
 				SetCursorPos(mousePos);
 			}

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -60,82 +60,64 @@ bool invflag;
  * 65 66 67 68 69 70 71 72
  * @endcode
  */
-const Point InvRect[] = {
+const Rectangle InvRect[] = {
 	// clang-format off
-	//  X,   Y
-	{ 132,  31 }, // helmet
-	{ 160,  31 }, // helmet
-	{ 132,  59 }, // helmet
-	{ 160,  59 }, // helmet
-	{  45, 205 }, // left ring
-	{ 247, 205 }, // right ring
-	{ 204,  59 }, // amulet
-	{  17, 104 }, // left hand
-	{  46, 104 }, // left hand
-	{  17, 132 }, // left hand
-	{  46, 132 }, // left hand
-	{  17, 160 }, // left hand
-	{  46, 160 }, // left hand
-	{ 247, 104 }, // right hand
-	{ 276, 104 }, // right hand
-	{ 247, 132 }, // right hand
-	{ 276, 132 }, // right hand
-	{ 247, 160 }, // right hand
-	{ 276, 160 }, // right hand
-	{ 132, 104 }, // chest
-	{ 160, 104 }, // chest
-	{ 132, 132 }, // chest
-	{ 160, 132 }, // chest
-	{ 132, 160 }, // chest
-	{ 160, 160 }, // chest
-	{  17, 250 }, // inv row 1
-	{  46, 250 }, // inv row 1
-	{  75, 250 }, // inv row 1
-	{ 104, 250 }, // inv row 1
-	{ 133, 250 }, // inv row 1
-	{ 162, 250 }, // inv row 1
-	{ 191, 250 }, // inv row 1
-	{ 220, 250 }, // inv row 1
-	{ 249, 250 }, // inv row 1
-	{ 278, 250 }, // inv row 1
-	{  17, 279 }, // inv row 2
-	{  46, 279 }, // inv row 2
-	{  75, 279 }, // inv row 2
-	{ 104, 279 }, // inv row 2
-	{ 133, 279 }, // inv row 2
-	{ 162, 279 }, // inv row 2
-	{ 191, 279 }, // inv row 2
-	{ 220, 279 }, // inv row 2
-	{ 249, 279 }, // inv row 2
-	{ 278, 279 }, // inv row 2
-	{  17, 308 }, // inv row 3
-	{  46, 308 }, // inv row 3
-	{  75, 308 }, // inv row 3
-	{ 104, 308 }, // inv row 3
-	{ 133, 308 }, // inv row 3
-	{ 162, 308 }, // inv row 3
-	{ 191, 308 }, // inv row 3
-	{ 220, 308 }, // inv row 3
-	{ 249, 308 }, // inv row 3
-	{ 278, 308 }, // inv row 3
-	{  17, 337 }, // inv row 4
-	{  46, 337 }, // inv row 4
-	{  75, 337 }, // inv row 4
-	{ 104, 337 }, // inv row 4
-	{ 133, 337 }, // inv row 4
-	{ 162, 337 }, // inv row 4
-	{ 191, 337 }, // inv row 4
-	{ 220, 337 }, // inv row 4
-	{ 249, 337 }, // inv row 4
-	{ 278, 337 }, // inv row 4
-	{ 205,  33 }, // belt
-	{ 234,  33 }, // belt
-	{ 263,  33 }, // belt
-	{ 292,  33 }, // belt
-	{ 321,  33 }, // belt
-	{ 350,  33 }, // belt
-	{ 379,  33 }, // belt
-	{ 408,  33 }  // belt
+	//{   X,   Y }, {  W,  H }
+	{ { 132,   2 }, { 58, 59 } }, // helmet
+	{ {  47, 177 }, { 28, 29 } }, // left ring
+	{ { 248, 177 }, { 28, 29 } }, // right ring
+	{ { 205,  32 }, { 28, 29 } }, // amulet
+	{ {  17,  75 }, { 58, 86 } }, // left hand
+	{ { 248,  75 }, { 58, 87 } }, // right hand
+	{ { 132,  75 }, { 58, 87 } }, // chest
+	{ {  17, 222 }, { 29, 29 } }, // inv row 1
+	{ {  46, 222 }, { 29, 29 } }, // inv row 1
+	{ {  75, 222 }, { 29, 29 } }, // inv row 1
+	{ { 104, 222 }, { 29, 29 } }, // inv row 1
+	{ { 133, 222 }, { 29, 29 } }, // inv row 1
+	{ { 162, 222 }, { 29, 29 } }, // inv row 1
+	{ { 191, 222 }, { 29, 29 } }, // inv row 1
+	{ { 220, 222 }, { 29, 29 } }, // inv row 1
+	{ { 249, 222 }, { 29, 29 } }, // inv row 1
+	{ { 278, 222 }, { 29, 29 } }, // inv row 1
+	{ {  17, 251 }, { 29, 29 } }, // inv row 2
+	{ {  46, 251 }, { 29, 29 } }, // inv row 2
+	{ {  75, 251 }, { 29, 29 } }, // inv row 2
+	{ { 104, 251 }, { 29, 29 } }, // inv row 2
+	{ { 133, 251 }, { 29, 29 } }, // inv row 2
+	{ { 162, 251 }, { 29, 29 } }, // inv row 2
+	{ { 191, 251 }, { 29, 29 } }, // inv row 2
+	{ { 220, 251 }, { 29, 29 } }, // inv row 2
+	{ { 249, 251 }, { 29, 29 } }, // inv row 2
+	{ { 278, 251 }, { 29, 29 } }, // inv row 2
+	{ {  17, 280 }, { 29, 29 } }, // inv row 3
+	{ {  46, 280 }, { 29, 29 } }, // inv row 3
+	{ {  75, 280 }, { 29, 29 } }, // inv row 3
+	{ { 104, 280 }, { 29, 29 } }, // inv row 3
+	{ { 133, 280 }, { 29, 29 } }, // inv row 3
+	{ { 162, 280 }, { 29, 29 } }, // inv row 3
+	{ { 191, 280 }, { 29, 29 } }, // inv row 3
+	{ { 220, 280 }, { 29, 29 } }, // inv row 3
+	{ { 249, 280 }, { 29, 29 } }, // inv row 3
+	{ { 278, 280 }, { 29, 29 } }, // inv row 3
+	{ {  17, 309 }, { 29, 29 } }, // inv row 4
+	{ {  46, 309 }, { 29, 29 } }, // inv row 4
+	{ {  75, 309 }, { 29, 29 } }, // inv row 4
+	{ { 104, 309 }, { 29, 29 } }, // inv row 4
+	{ { 133, 309 }, { 29, 29 } }, // inv row 4
+	{ { 162, 309 }, { 29, 29 } }, // inv row 4
+	{ { 191, 309 }, { 29, 29 } }, // inv row 4
+	{ { 220, 309 }, { 29, 29 } }, // inv row 4
+	{ { 249, 309 }, { 29, 29 } }, // inv row 4
+	{ { 278, 309 }, { 29, 29 } }, // inv row 4
+	{ { 205,   5 }, { 29, 29 } }, // belt
+	{ { 234,   5 }, { 29, 29 } }, // belt
+	{ { 263,   5 }, { 29, 29 } }, // belt
+	{ { 292,   5 }, { 29, 29 } }, // belt
+	{ { 321,   5 }, { 29, 29 } }, // belt
+	{ { 350,   5 }, { 29, 29 } }, // belt
+	{ { 379,   5 }, { 29, 29 } }, // belt
+	{ { 408,   5 }, { 29, 29 } }  // belt
 	// clang-format on
 };
 
@@ -319,16 +301,14 @@ int FindSlotUnderCursor(Point cursorPosition, Size itemSize)
 			yo = GetMainPanel().position.y;
 		}
 
-		if (i >= InvRect[r].x + xo && i <= InvRect[r].x + xo + InventorySlotSizeInPixels.width) {
-			if (j >= InvRect[r].y + yo - InventorySlotSizeInPixels.height - 1 && j < InvRect[r].y + yo) {
-				return r;
-			}
-		}
-		if (r == SLOTXY_CHEST_LAST) {
+		if (r == SLOTXY_INV_FIRST) {
 			if (itemSize.width % 2 == 0)
 				i -= INV_SLOT_HALF_SIZE_PX;
 			if (itemSize.height % 2 == 0)
 				j -= INV_SLOT_HALF_SIZE_PX;
+		}
+		if (InvRect[r].contains(i - xo, j - yo)) {
+			return r;
 		}
 		if (r == SLOTXY_INV_LAST && itemSize.height % 2 == 0)
 			j += INV_SLOT_HALF_SIZE_PX;
@@ -345,15 +325,15 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 		return;
 
 	item_equip_type il = ILOC_UNEQUIPABLE;
-	if (slot >= SLOTXY_HEAD_FIRST && slot <= SLOTXY_HEAD_LAST)
+	if (slot == SLOTXY_HEAD)
 		il = ILOC_HELM;
-	if (slot >= SLOTXY_RING_LEFT && slot <= SLOTXY_RING_RIGHT)
+	if (slot == SLOTXY_RING_LEFT || slot == SLOTXY_RING_RIGHT)
 		il = ILOC_RING;
 	if (slot == SLOTXY_AMULET)
 		il = ILOC_AMULET;
-	if (slot >= SLOTXY_HAND_LEFT_FIRST && slot <= SLOTXY_HAND_RIGHT_LAST)
+	if (slot == SLOTXY_HAND_LEFT || slot == SLOTXY_HAND_RIGHT)
 		il = ILOC_ONEHAND;
-	if (slot >= SLOTXY_CHEST_FIRST && slot <= SLOTXY_CHEST_LAST)
+	if (slot == SLOTXY_CHEST)
 		il = ILOC_ARMOR;
 	if (slot >= SLOTXY_BELT_FIRST && slot <= SLOTXY_BELT_LAST)
 		il = ILOC_BELT;
@@ -445,8 +425,8 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 		break;
 	}
 	case ILOC_ONEHAND: {
-		inv_body_loc selectedHand = slot <= SLOTXY_HAND_LEFT_LAST ? INVLOC_HAND_LEFT : INVLOC_HAND_RIGHT;
-		inv_body_loc otherHand = slot <= SLOTXY_HAND_LEFT_LAST ? INVLOC_HAND_RIGHT : INVLOC_HAND_LEFT;
+		inv_body_loc selectedHand = slot == SLOTXY_HAND_LEFT ? INVLOC_HAND_LEFT : INVLOC_HAND_RIGHT;
+		inv_body_loc otherHand = slot == SLOTXY_HAND_LEFT ? INVLOC_HAND_RIGHT : INVLOC_HAND_LEFT;
 
 		bool pasteIntoSelectedHand = (player.InvBody[otherHand].isEmpty() || player.InvBody[otherHand]._iClass != player.HoldItem._iClass)
 		    || (player._pClass == HeroClass::Bard && player.InvBody[otherHand]._iClass == ICLASS_WEAPON && player.HoldItem._iClass == ICLASS_WEAPON);
@@ -600,10 +580,7 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 		}
 
 		// check which inventory rectangle the mouse is in, if any
-		if (cursorPosition.x >= InvRect[r].x + xo
-		    && cursorPosition.x < InvRect[r].x + xo + (InventorySlotSizeInPixels.width + 1)
-		    && cursorPosition.y >= InvRect[r].y + yo - (InventorySlotSizeInPixels.height + 1)
-		    && cursorPosition.y < InvRect[r].y + yo) {
+		if (InvRect[r].contains(cursorPosition - Displacement(xo, yo))) {
 			break;
 		}
 	}
@@ -621,7 +598,7 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 	bool automaticallyUnequip = false;
 
 	Item &headItem = player.InvBody[INVLOC_HEAD];
-	if (r >= SLOTXY_HEAD_FIRST && r <= SLOTXY_HEAD_LAST && !headItem.isEmpty()) {
+	if (r == SLOTXY_HEAD && !headItem.isEmpty()) {
 		holdItem = headItem;
 		if (automaticMove) {
 			automaticallyUnequip = true;
@@ -673,7 +650,7 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 	}
 
 	Item &leftHandItem = player.InvBody[INVLOC_HAND_LEFT];
-	if (r >= SLOTXY_HAND_LEFT_FIRST && r <= SLOTXY_HAND_LEFT_LAST && !leftHandItem.isEmpty()) {
+	if (r == SLOTXY_HAND_LEFT && !leftHandItem.isEmpty()) {
 		holdItem = leftHandItem;
 		if (automaticMove) {
 			automaticallyUnequip = true;
@@ -686,7 +663,7 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 	}
 
 	Item &rightHandItem = player.InvBody[INVLOC_HAND_RIGHT];
-	if (r >= SLOTXY_HAND_RIGHT_FIRST && r <= SLOTXY_HAND_RIGHT_LAST && !rightHandItem.isEmpty()) {
+	if (r == SLOTXY_HAND_RIGHT && !rightHandItem.isEmpty()) {
 		holdItem = rightHandItem;
 		if (automaticMove) {
 			automaticallyUnequip = true;
@@ -699,7 +676,7 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 	}
 
 	Item &chestItem = player.InvBody[INVLOC_CHEST];
-	if (r >= SLOTXY_CHEST_FIRST && r <= SLOTXY_CHEST_LAST && !chestItem.isEmpty()) {
+	if (r == SLOTXY_CHEST && !chestItem.isEmpty()) {
 		holdItem = chestItem;
 		if (automaticMove) {
 			automaticallyUnequip = true;
@@ -1154,7 +1131,7 @@ void DrawInv(const Surface &out)
 		if (myPlayer.InvGrid[i] != 0) {
 			InvDrawSlotBack(
 			    out,
-			    GetPanelPosition(UiPanels::Inventory, InvRect[i + SLOTXY_INV_FIRST]) + Displacement { 0, -1 },
+			    GetPanelPosition(UiPanels::Inventory, InvRect[i + SLOTXY_INV_FIRST].position) + Displacement { 0, InventorySlotSizeInPixels.height },
 			    InventorySlotSizeInPixels,
 			    myPlayer.InvList[abs(myPlayer.InvGrid[i]) - 1]._iMagical);
 		}
@@ -1166,7 +1143,7 @@ void DrawInv(const Surface &out)
 			int cursId = myPlayer.InvList[ii]._iCurs + CURSOR_FIRSTITEM;
 
 			const ClxSprite sprite = GetInvItemSprite(cursId);
-			const Point position = GetPanelPosition(UiPanels::Inventory, InvRect[j + SLOTXY_INV_FIRST]) + Displacement { 0, -1 };
+			const Point position = GetPanelPosition(UiPanels::Inventory, InvRect[j + SLOTXY_INV_FIRST].position) + Displacement { 0, InventorySlotSizeInPixels.height };
 			if (pcursinvitem == ii + INVITEM_INV_FIRST) {
 				ClxDrawOutline(out, GetOutlineColor(myPlayer.InvList[ii], true), position, sprite);
 			}
@@ -1193,7 +1170,7 @@ void DrawInvBelt(const Surface &out)
 			continue;
 		}
 
-		const Point position { InvRect[i + SLOTXY_BELT_FIRST].x + mainPanelPosition.x, InvRect[i + SLOTXY_BELT_FIRST].y + mainPanelPosition.y - 1 };
+		const Point position { InvRect[i + SLOTXY_BELT_FIRST].position.x + mainPanelPosition.x, InvRect[i + SLOTXY_BELT_FIRST].position.y + mainPanelPosition.y + InventorySlotSizeInPixels.height };
 		InvDrawSlotBack(out, position, InventorySlotSizeInPixels, myPlayer.SpdList[i]._iMagical);
 		const int cursId = myPlayer.SpdList[i]._iCurs + CURSOR_FIRSTITEM;
 
@@ -1855,10 +1832,7 @@ int8_t CheckInvHLight()
 			yo = GetMainPanel().position.y;
 		}
 
-		if (MousePosition.x >= InvRect[r].x + xo
-		    && MousePosition.x < InvRect[r].x + xo + (InventorySlotSizeInPixels.width + 1)
-		    && MousePosition.y >= InvRect[r].y + yo - (InventorySlotSizeInPixels.height + 1)
-		    && MousePosition.y < InvRect[r].y + yo) {
+		if (InvRect[r].contains(MousePosition - Displacement(xo, yo))) {
 			break;
 		}
 	}
@@ -1871,7 +1845,7 @@ int8_t CheckInvHLight()
 	Item *pi = nullptr;
 	Player &myPlayer = *MyPlayer;
 
-	if (r >= SLOTXY_HEAD_FIRST && r <= SLOTXY_HEAD_LAST) {
+	if (r == SLOTXY_HEAD) {
 		rv = INVLOC_HEAD;
 		pi = &myPlayer.InvBody[rv];
 	} else if (r == SLOTXY_RING_LEFT) {
@@ -1883,10 +1857,10 @@ int8_t CheckInvHLight()
 	} else if (r == SLOTXY_AMULET) {
 		rv = INVLOC_AMULET;
 		pi = &myPlayer.InvBody[rv];
-	} else if (r >= SLOTXY_HAND_LEFT_FIRST && r <= SLOTXY_HAND_LEFT_LAST) {
+	} else if (r == SLOTXY_HAND_LEFT) {
 		rv = INVLOC_HAND_LEFT;
 		pi = &myPlayer.InvBody[rv];
-	} else if (r >= SLOTXY_HAND_RIGHT_FIRST && r <= SLOTXY_HAND_RIGHT_LAST) {
+	} else if (r == SLOTXY_HAND_RIGHT) {
 		pi = &myPlayer.InvBody[INVLOC_HAND_LEFT];
 		if (pi->isEmpty() || myPlayer.GetItemLocation(*pi) != ILOC_TWOHAND) {
 			rv = INVLOC_HAND_RIGHT;
@@ -1894,7 +1868,7 @@ int8_t CheckInvHLight()
 		} else {
 			rv = INVLOC_HAND_LEFT;
 		}
-	} else if (r >= SLOTXY_CHEST_FIRST && r <= SLOTXY_CHEST_LAST) {
+	} else if (r == SLOTXY_CHEST) {
 		rv = INVLOC_CHEST;
 		pi = &myPlayer.InvBody[rv];
 	} else if (r >= SLOTXY_INV_FIRST && r <= SLOTXY_INV_LAST) {

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -42,34 +42,30 @@ enum inv_item : int8_t {
  */
 enum inv_xy_slot : uint8_t {
 	// clang-format off
-	SLOTXY_HEAD_FIRST       = 0,
-	SLOTXY_HEAD_LAST        = 3,
-	SLOTXY_RING_LEFT        = 4,
-	SLOTXY_RING_RIGHT       = 5,
-	SLOTXY_AMULET           = 6,
-	SLOTXY_HAND_LEFT_FIRST  = 7,
-	SLOTXY_HAND_LEFT_LAST   = 12,
-	SLOTXY_HAND_RIGHT_FIRST = 13,
-	SLOTXY_HAND_RIGHT_LAST  = 18,
-	SLOTXY_CHEST_FIRST      = 19,
-	SLOTXY_CHEST_LAST       = 24,
+	SLOTXY_HEAD           = 0,
+	SLOTXY_RING_LEFT      = 1,
+	SLOTXY_RING_RIGHT     = 2,
+	SLOTXY_AMULET         = 3,
+	SLOTXY_HAND_LEFT      = 4,
+	SLOTXY_HAND_RIGHT     = 5,
+	SLOTXY_CHEST          = 6,
 
 	// regular inventory
-	SLOTXY_INV_FIRST        = 25,
-	SLOTXY_INV_ROW1_FIRST   = SLOTXY_INV_FIRST,
-	SLOTXY_INV_ROW1_LAST    = 34,
-	SLOTXY_INV_ROW2_FIRST   = 35,
-	SLOTXY_INV_ROW2_LAST    = 44,
-	SLOTXY_INV_ROW3_FIRST   = 45,
-	SLOTXY_INV_ROW3_LAST    = 54,
-	SLOTXY_INV_ROW4_FIRST   = 55,
-	SLOTXY_INV_ROW4_LAST    = 64,
-	SLOTXY_INV_LAST         = SLOTXY_INV_ROW4_LAST,
+	SLOTXY_INV_FIRST      = 7,
+	SLOTXY_INV_ROW1_FIRST = SLOTXY_INV_FIRST,
+	SLOTXY_INV_ROW1_LAST  = 16,
+	SLOTXY_INV_ROW2_FIRST = 17,
+	SLOTXY_INV_ROW2_LAST  = 26,
+	SLOTXY_INV_ROW3_FIRST = 27,
+	SLOTXY_INV_ROW3_LAST  = 36,
+	SLOTXY_INV_ROW4_FIRST = 37,
+	SLOTXY_INV_ROW4_LAST  = 46,
+	SLOTXY_INV_LAST       = SLOTXY_INV_ROW4_LAST,
 
 	// belt items
-	SLOTXY_BELT_FIRST       = 65,
-	SLOTXY_BELT_LAST        = 72,
-	NUM_XY_SLOTS            = 73
+	SLOTXY_BELT_FIRST     = 47,
+	SLOTXY_BELT_LAST      = 54,
+	NUM_XY_SLOTS          = 55
 	// clang-format on
 };
 
@@ -83,7 +79,7 @@ enum item_color : uint8_t {
 };
 
 extern bool invflag;
-extern const Point InvRect[73];
+extern const Rectangle InvRect[73];
 
 void InvDrawSlotBack(const Surface &out, Point targetPosition, Size size, item_quality itemQuality);
 /**


### PR DESCRIPTION
Controller movement should be working as normal now but I still haven't tested in depth, this was a quick proof of concept for a comment on #5917 

`inv_xy_slot` and `inv_item` can be deduplicated, haven't done that yet either.

Pretty much all the rectangles were defined as the coordinate of the bottom left corner, not the top left as would be normal for the way the UI coordinates work. This seems to have been to avoid adding an offset when rendering, but there was a -1 y offset anyway... changing that to the top left corner makes the inventory code way simpler.