### PR TITLE
Draw item labels before the monster health bar

### DIFF
--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1186,8 +1186,8 @@ void DrawView(const Surface &out, Point startPosition)
 		}
 	}
 #endif
-	DrawMonsterHealthBar(out);
 	DrawItemNameLabels(out);
+	DrawMonsterHealthBar(out);
 	DrawFloatingNumbers(out, startPosition, offset);
 
 	if (stextflag != TalkID::None && !qtextflag)


### PR DESCRIPTION
Fixes #5867

![image](https://user-images.githubusercontent.com/216339/227767438-7e30f0fa-6a54-45ed-b1c3-b1d7e81cc8d1.png)
