### PR TITLE
Update Linux Packaging Script

### DIFF
--- a/Packaging/nix/LinuxReleasePackaging.sh
+++ b/Packaging/nix/LinuxReleasePackaging.sh
@@ -1,7 +1,7 @@
 mkdir ./build/package
 find build/_CPack_Packages/Linux/7Z/ -name 'devilutionx' -exec cp "{}" ./build/devilutionx \;
 cp ./build/devilutionx ./build/package/devilutionx
-cp ./Packaging/resources/devilutionx.mpq ./build/package/devilutionx.mpq
+cp ./build/devilutionx.mpq ./build/package/devilutionx.mpq
 cp ./build/devilutionx*.deb ./build/package/devilutionx.deb
 cp ./build/devilutionx*.rpm ./build/package/devilutionx.rpm
 cp ./Packaging/nix/README.txt ./build/package/README.txt


### PR DESCRIPTION
Change location of devilutionx.mpq to the build folder instead of the packaging/resources folder since it is now built at compile.