### PR TITLE
Fix stand ground for gamepad controls

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1989,8 +1989,8 @@ void InitPadmapActions()
 	    N_("Toggle stand ground"),
 	    N_("Toggle whether the player moves."),
 	    ControllerButton_NONE,
-	    [] { StandToggle = true; },
-	    [] { StandToggle = false; },
+	    [] { StandToggle = !StandToggle; },
+	    nullptr,
 	    CanPlayerTakeAction);
 	sgOptions.Padmapper.AddAction(
 	    "UseHealthPotion",


### PR DESCRIPTION
Gamepad "stand ground" logic wasn't being checked by `WalkInDir()`. I fixed things up so that the logic for stand ground would be encapsulated by a function and called by both `Interact()` and `WalkInDir()` so there'd be no discrepancies. And the game now also checks gamepad stand ground logic on SDL1 platforms.

Lastly, the `Toggle stand ground` option was implemented incorrectly so I fixed that too.