### PR TITLE
Remove devilutionx.mpq from Linux release archive

### DIFF
--- a/Packaging/nix/LinuxReleasePackaging.sh
+++ b/Packaging/nix/LinuxReleasePackaging.sh
@@ -1,7 +1,6 @@
 mkdir ./build/package
 find build/_CPack_Packages/Linux/7Z/ -name 'devilutionx' -exec cp "{}" ./build/devilutionx \;
 cp ./build/devilutionx ./build/package/devilutionx
-cp ./build/devilutionx.mpq ./build/package/devilutionx.mpq
 cp ./build/devilutionx*.deb ./build/package/devilutionx.deb
 cp ./build/devilutionx*.rpm ./build/package/devilutionx.rpm
 cp ./Packaging/nix/README.txt ./build/package/README.txt


### PR DESCRIPTION
`devilutionx.mpq` is already present in the deb/rpm.