### PR TITLE
Multiplayer: Ensure monster hitpoints are calculated reproducable in quest/set-maps

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2710,7 +2710,14 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 		InitStores();
 		InitAutomapOnce();
 	}
-	SetRndSeed(glSeedTbl[currlevel]);
+	if (!setlevel) {
+		SetRndSeed(glSeedTbl[currlevel]);
+	} else {
+		// Maps are not randomly generated, but the monsters max hitpoints are.
+		// So we need to ensure that we have a stable seed when generating quest/set-maps.
+		// For this purpose we reuse the normal dungeon seeds.
+		SetRndSeed(glSeedTbl[static_cast<size_t>(setlvlnum)]);
+	}
 
 	if (leveltype == DTYPE_TOWN) {
 		SetupTownStores();

--- a/Source/levels/drlg_l1.cpp
+++ b/Source/levels/drlg_l1.cpp
@@ -1304,7 +1304,7 @@ void CreateL5Dungeon(uint32_t rseed, lvl_entry entry)
 
 void LoadPreL1Dungeon(const char *path)
 {
-	memset(dungeon, Dirt, sizeof(dungeon));
+	InitDungeonFlags();
 
 	auto dunData = LoadFileInMem<uint16_t>(path);
 	PlaceDunTiles(dunData.get(), { 0, 0 }, Floor);

--- a/Source/levels/drlg_l1.cpp
+++ b/Source/levels/drlg_l1.cpp
@@ -1309,7 +1309,7 @@ void LoadPreL1Dungeon(const char *path)
 	auto dunData = LoadFileInMem<uint16_t>(path);
 	PlaceDunTiles(dunData.get(), { 0, 0 }, Floor);
 
-	if (leveltype == DTYPE_CATHEDRAL)
+	if (setlvltype == DTYPE_CATHEDRAL)
 		FillFloor();
 
 	memcpy(pdungeon, dungeon, sizeof(pdungeon));
@@ -1319,12 +1319,12 @@ void LoadL1Dungeon(const char *path, Point spawn)
 {
 	LoadDungeonBase(path, spawn, Floor, Dirt);
 
-	if (leveltype == DTYPE_CATHEDRAL)
+	if (setlvltype == DTYPE_CATHEDRAL)
 		FillFloor();
 
 	Pass3();
 
-	if (leveltype == DTYPE_CRYPT)
+	if (setlvltype == DTYPE_CRYPT)
 		AddCryptObjects(0, 0, MAXDUNX, MAXDUNY);
 	else
 		AddL1Objs(0, 0, MAXDUNX, MAXDUNY);


### PR DESCRIPTION
Fixes #5954

When a quest/set-map is loaded, the monsters gets added with `SetMapMonsters` -> `PlaceMonster` -> `InitMonster`.
`InitMonster` initializes the max monster hitpoints [randomly](https://github.com/diasurgical/devilutionX/blob/957bd03b987fbef49f0448d862078f27295a3120/Source/monster.cpp#L135).
That means the monster hitpoints depend on a reproducible set/quest-map loading (seed stay the same).
For singleplayer this is irrelevant, cause the monsters hp/maxhp are loaded from the save when reentering the level.
But now with multiplayer quests this can result in a desync where one client thinks the monsters have more hp then the other.
The desynced hp are synced to the other clients so they think the monsters have > 100% hp (seen in monster health bar).

This PR makes loading quest/set-map reproducible:
- Use `glSeedTbl` when loading a quest/set-map
- Use correct level type when loading a quest/set-map (and ensure `FillFloor` is always called)
- Ensure `Protected` is initialized correctly, because `FillFloor` uses it.