### PR TITLE
Use PROJECT_SOURCE_DIR in asio_defs.cmake

### DIFF
--- a/CMake/platforms/ctr/asio_defs.cmake
+++ b/CMake/platforms/ctr/asio_defs.cmake
@@ -3,4 +3,4 @@ target_compile_definitions(asio INTERFACE
   ASIO_HAS_UNISTD_H=ON)
 
 # Missing headers and declarations provided by DevilutionX
-target_include_directories(asio BEFORE INTERFACE ${DevilutionX_SOURCE_DIR}/Source/platform/ctr/asio/include)
+target_include_directories(asio BEFORE INTERFACE ${PROJECT_SOURCE_DIR}/Source/platform/ctr/asio/include)

--- a/CMake/platforms/switch/asio_defs.cmake
+++ b/CMake/platforms/switch/asio_defs.cmake
@@ -2,4 +2,4 @@
 target_compile_definitions(asio INTERFACE _DEFAULT_SOURCE=ON)
 
 # Missing headers and declarations provided by DevilutionX
-target_include_directories(asio BEFORE INTERFACE ${DevilutionX_SOURCE_DIR}/Source/platform/switch/asio/include)
+target_include_directories(asio BEFORE INTERFACE ${PROJECT_SOURCE_DIR}/Source/platform/switch/asio/include)


### PR DESCRIPTION
Enables these scripts to find the right include directory in mods that change the project name.