### PR TITLE
Multiplayer: Sync circles in Lazarus' Lair

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1563,9 +1563,9 @@ void UpdateObjectLight(Object &light, int lightRadius)
 
 void UpdateCircle(Object &circle)
 {
-	Player &myPlayer = *MyPlayer;
+	Player *playerOnCircle = PlayerAtPosition(circle.position);
 
-	if (myPlayer.position.tile != circle.position) {
+	if (!playerOnCircle) {
 		if (circle._otype == OBJ_MCIRCLE1)
 			circle._oAnimFrame = 1;
 		if (circle._otype == OBJ_MCIRCLE2)
@@ -1589,14 +1589,16 @@ void UpdateCircle(Object &circle)
 		circle._oVar6 = 4;
 		if (Quests[Q_BETRAYER]._qvar1 <= 4) {
 			ObjChangeMap(circle._oVar1, circle._oVar2, circle._oVar3, circle._oVar4);
-			if (Quests[Q_BETRAYER]._qactive == QUEST_ACTIVE)
-				Quests[Q_BETRAYER]._qvar1 = 4;
+			Quests[Q_BETRAYER]._qvar1 = 4;
+			NetSendCmdQuest(true, Quests[Q_BETRAYER]);
 		}
-		AddMissile(myPlayer.position.tile, { 35, 46 }, Direction::South, MissileID::Phasing, TARGET_BOTH, MyPlayerId, 0, 0);
-		LastMouseButtonAction = MouseActionType::None;
-		sgbMouseDown = CLICK_NONE;
-		ClrPlrPath(myPlayer);
-		StartStand(myPlayer, Direction::South);
+		AddMissile(playerOnCircle->position.tile, { 35, 46 }, Direction::South, MissileID::Phasing, TARGET_BOTH, playerOnCircle->getId(), 0, 0);
+		if (playerOnCircle == MyPlayer) {
+			LastMouseButtonAction = MouseActionType::None;
+			sgbMouseDown = CLICK_NONE;
+		}
+		ClrPlrPath(*playerOnCircle);
+		StartStand(*playerOnCircle, Direction::South);
 	}
 }
 
@@ -1913,32 +1915,26 @@ void OperateBook(Player &player, Object &book, bool sendmsg)
 	}
 
 	if (setlevel && setlvlnum == SL_VILEBETRAYER) {
-		bool missileAdded = false;
-		for (int j = 0; j < ActiveObjectCount; j++) {
-			Object &questObject = Objects[ActiveObjects[j]];
-
-			Point target {};
-			bool doAddMissile = false;
-
-			if (questObject._otype == OBJ_MCIRCLE2 && questObject._oVar6 == 1) {
-				target = { 27, 29 };
-				doAddMissile = true;
-			}
-			if (questObject._otype == OBJ_MCIRCLE2 && questObject._oVar6 == 2) {
-				target = { 43, 29 };
-				doAddMissile = true;
-			}
-
-			if (doAddMissile) {
-				questObject._oVar6 = 4;
-				ObjectAtPosition({ 35, 36 })._oVar5++;
-				AddMissile(player.position.tile, target, Direction::South, MissileID::Phasing, TARGET_BOTH, player.getId(), 0, 0);
-				missileAdded = true;
-			}
-		}
-		if (!missileAdded) {
+		Point target {};
+		if (book.position == Point { 26, 45 }) {
+			target = { 27, 29 };
+		} else if (book.position == Point { 45, 46 }) {
+			target = { 43, 29 };
+		} else {
 			return;
 		}
+
+		Object &circle = ObjectAtPosition(book.position + Direction::SouthWest);
+		assert(circle._otype == OBJ_MCIRCLE2);
+
+		// Only verfiy that the player stands on the circle when it's the local player (sendmsg), cause for remote players the position could be desynced
+		if (sendmsg && circle.position != player.position.tile) {
+			return;
+		}
+
+		circle._oVar6 = 4;
+		ObjectAtPosition({ 35, 36 })._oVar5++;
+		AddMissile(player.position.tile, target, Direction::South, MissileID::Phasing, TARGET_BOTH, player.getId(), 0, 0);
 	}
 
 	book._oSelFlag = 0;
@@ -4405,7 +4401,8 @@ void OperateObject(Player &player, Object &object)
 		OperateLever(object, sendmsg);
 		break;
 	case OBJ_BOOK2L:
-		OperateBook(player, object, sendmsg);
+		if (sendmsg)
+			OperateBook(player, object, sendmsg);
 		break;
 	case OBJ_BOOK2R:
 		OperateChamberOfBoneBook(object, sendmsg);
@@ -4605,6 +4602,10 @@ void SyncOpObject(Player &player, int cmd, Object &object)
 	case OBJ_L5LEVER:
 	case OBJ_SWITCHSKL:
 		OperateLever(object, sendmsg);
+		break;
+	case OBJ_BOOK2L:
+		if (!sendmsg)
+			OperateBook(player, object, sendmsg);
 		break;
 	case OBJ_CHEST1:
 	case OBJ_CHEST2:


### PR DESCRIPTION
Fixes #5963

Notes:
- Check circle state independent of `MyPlayer` (also makes the circle red for remote players)
- In `OperateBook` only check if the player stands on the circle if it's the local client, cause on remote clients this can desync
- Call `OperateBook` also in `SyncOpObject` without the position check