### PR TITLE
Add a debug function that describes a CLX

### DIFF
--- a/Source/engine/render/clx_render.hpp
+++ b/Source/engine/render/clx_render.hpp
@@ -10,6 +10,10 @@
 #include <array>
 #include <utility>
 
+#ifdef DEBUG_CLX
+#include <string>
+#endif
+
 #include "engine.h"
 #include "engine/clx_sprite.hpp"
 #include "engine/point.hpp"
@@ -111,5 +115,9 @@ inline void ClxDrawLightBlended(const Surface &out, Point position, ClxSprite cl
  * of fully transparent columns in the sprite.
  */
 std::pair<int, int> ClxMeasureSolidHorizontalBounds(ClxSprite clx);
+
+#ifdef DEBUG_CLX
+std::string ClxDescribe(ClxSprite clx);
+#endif
 
 } // namespace devilution


### PR DESCRIPTION
Example output (also demonstrates a bug in our encoder):

CLX sprite: 16x20 pixelDataSize=97b

command | width | bytes | color(s)
--------|------:|------:|---------
Transp. |    80 |     1 |
Pixels  |     2 |     3 | 203 199
Fill    |     3 |     2 | 202
Pixels  |     2 |     3 | 199 201
Fill    |     1 |     2 | 205
Transp. |     8 |     1 |
Pixels  |     3 |     4 | 205 199 196
Fill    |     4 |     2 | 197
Fill    |     1 |     2 | 202
Transp. |     9 |     1 |
Pixels  |     6 |     7 | 206 199 197 203 206 202
Fill    |     1 |     2 | 204
Transp. |    10 |     1 |
Pixels  |     4 |     5 | 206 199 197 205
Fill    |     1 |     2 | 207
Transp. |    12 |     1 |
Pixels  |     3 |     4 | 206 197 197
Fill    |     1 |     2 | 205
Transp. |     9 |     1 |
Pixels  |     7 |     8 | 207 205 203 206 206 197 197
Fill    |     1 |     2 | 206
Transp. |     8 |     1 |
Pixels  |     3 |     4 | 204 197 199
Fill    |     1 |     2 | 205
Transp. |     1 |     1 |
Pixels  |     2 |     3 | 202 197
Fill    |     1 |     2 | 204
Transp. |     8 |     1 |
Pixels  |     7 |     8 | 206 197 199 207 206 199 196
Fill    |     1 |     2 | 205
Transp. |     9 |     1 |
Pixels  |     1 |     2 | 203
Fill    |     4 |     2 | 197
Fill    |     1 |     2 | 202
Transp. |    10 |     1 |
Pixels  |     5 |     6 | 207 205 199 199 203
Fill    |     1 |     2 | 207
Transp. |    89 |     1 |