### PR TITLE
Fix crash after dying and changing gear

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2888,6 +2888,10 @@ void CalcPlrInv(Player &player, bool loadgfx)
 	CalcSelfItems(player);
 
 	// Determine the current item bonuses gained from usable equipped items
+	if (&player != MyPlayer && !player.isOnActiveLevel()) {
+		// Ensure we don't load graphics for players that aren't on our level
+		loadgfx = false;
+	}
 	CalcPlrItemVals(player, loadgfx);
 
 	if (&player == MyPlayer) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2998,9 +2998,9 @@ void RestartTownLvl(Player &player)
 	player._pManaBase = player._pMana - (player._pMaxMana - player._pMaxManaBase);
 
 	CalcPlrInv(player, false);
+	player._pmode = PM_NEWLVL;
 
 	if (&player == MyPlayer) {
-		player._pmode = PM_NEWLVL;
 		player._pInvincible = true;
 		SDL_Event event;
 		event.type = CustomEventToSdlEvent(WM_DIABRETOWN);


### PR DESCRIPTION
While testing #5975 I could reproduce a crash when dying that is currently in master and was mentioned in discord before.

How to reproduce the crash:
- Have two players in the game on the same dungeon level
- Player 2 dies
- Player 2 respawns in town
- Player 2 changes gear (for example removes weapon or armor)

Background:
- When the player respawns in town, he still haves the "old" player mode `PM_NEWLVL` set (cause `RestartTownLvl` doesn't set a new one)
- Normally player graphics are not loaded for remote players that aren't on the same level
- When changing gear the new inventory synchronization sends a `CMD_CHANGEINVITEMS`
- `CMD_CHANGEINVITEMS` calls `CheckInvSwap` and then `CalcPlrInv` with `loadgfx` true
- The game tries to load the changed animations for the current player mode (`Player::getGraphic()` and `LoadPlrGFX`)
- But the mode is still `PM_DEATH` for the remote client (client of Player 1) and there are no death animations for weapons
- When loading the not existing animations the game crashes

Changes in this PR:
- Ensure we don't load graphics for players that aren't on our level
- Ensure `PM_DEATH` is reset when restarting in town for remote players