### PR TITLE
Use padmapper bindings on spell icons

### DIFF
--- a/Source/options.h
+++ b/Source/options.h
@@ -729,6 +729,7 @@ struct PadmapperOptions : OptionCategoryBase {
 		void SaveToIni(string_view category) const override;
 
 		[[nodiscard]] string_view GetValueDescription() const override;
+		[[nodiscard]] string_view GetValueDescription(bool useShortName) const;
 
 		bool SetValue(ControllerButtonCombo value);
 
@@ -740,11 +741,13 @@ struct PadmapperOptions : OptionCategoryBase {
 		ControllerButtonCombo boundInput {};
 		mutable GamepadLayout boundInputDescriptionType = GamepadLayout::Generic;
 		mutable std::string boundInputDescription;
+		mutable std::string boundInputShortDescription;
 		unsigned dynamicIndex;
 		std::string dynamicKey;
 		mutable std::string dynamicName;
 
 		void UpdateValueDescription() const;
+		string_view Shorten(string_view buttonName) const;
 
 		friend struct PadmapperOptions;
 	};
@@ -764,7 +767,7 @@ struct PadmapperOptions : OptionCategoryBase {
 	void ReleaseAllActiveButtons();
 	bool IsActive(string_view actionName) const;
 	string_view ActionNameTriggeredByButtonEvent(ControllerButtonEvent ctrlEvent) const;
-	string_view InputNameForAction(string_view actionName) const;
+	string_view InputNameForAction(string_view actionName, bool useShortName = false) const;
 	ControllerButtonCombo ButtonComboForAction(string_view actionName) const;
 
 private:


### PR DESCRIPTION
Had to limit button names to two characters so they'd fit in the spell icons. Here's a couple screenshots.

Generic gamepad:
![image](https://user-images.githubusercontent.com/9203145/232179500-4b54a87b-afa3-46d1-8885-364db4f709d6.png)

PlayStation:
![image](https://user-images.githubusercontent.com/9203145/232179506-094a621d-6716-4714-99c5-0012b0cd68b2.png)
