### PR TITLE
Update gamepad motion state regardless of the active event handler

### DIFF
--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -479,7 +479,7 @@ void UiSettingsMenu()
 
 				StaticVector<ControllerButtonEvent, 4> ctrlEvents = ToControllerButtonEvents(event);
 				for (ControllerButtonEvent ctrlEvent : ctrlEvents) {
-					bool isGamepadMotion = ProcessControllerMotion(event, ctrlEvent);
+					bool isGamepadMotion = IsControllerMotion(event);
 					DetectInputMethod(event, ctrlEvent);
 					if (event.type == SDL_KEYUP && event.key.keysym.sym == SDLK_ESCAPE) {
 						StopPadEntryTimer();

--- a/Source/controls/controller_motion.h
+++ b/Source/controls/controller_motion.h
@@ -22,9 +22,15 @@ extern float leftStickX, leftStickY, rightStickX, rightStickY;
 extern bool leftStickNeedsScaling, rightStickNeedsScaling;
 
 // Updates motion state for mouse and joystick sticks.
-bool ProcessControllerMotion(const SDL_Event &event, ControllerButtonEvent ctrlEvent);
+void ProcessControllerMotion(const SDL_Event &event);
+
+// Indicates whether the event represents movement of an analog thumbstick.
+bool IsControllerMotion(const SDL_Event &event);
 
 // Returns direction of the left thumb stick or DPad (if allow_dpad = true).
 AxisDirection GetLeftStickOrDpadDirection(bool usePadmapper);
+
+// Simulates right-stick movement based on input from padmapper mouse movement actions.
+void SimulateRightStickWithPadmapper(ControllerButtonEvent ctrlEvent);
 
 } // namespace devilution

--- a/Source/controls/devices/kbcontroller.cpp
+++ b/Source/controls/devices/kbcontroller.cpp
@@ -174,11 +174,5 @@ bool IsKbCtrlButtonPressed(ControllerButton button)
 #endif
 }
 
-bool ProcessKbCtrlAxisMotion(const SDL_Event &event)
-{
-	// Mapping keyboard to right stick axis not implemented.
-	return false;
-}
-
 } // namespace devilution
 #endif

--- a/Source/controls/devices/kbcontroller.h
+++ b/Source/controls/devices/kbcontroller.h
@@ -21,7 +21,5 @@ SDL_Keycode ControllerButtonToKbCtrlKeyCode(ControllerButton button);
 
 bool IsKbCtrlButtonPressed(ControllerButton button);
 
-bool ProcessKbCtrlAxisMotion(const SDL_Event &event);
-
 } // namespace devilution
 #endif

--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -360,7 +360,10 @@ bool HandleControllerButtonEvent(const SDL_Event &event, const ControllerButtonE
 	};
 
 	const ButtonReleaser buttonReleaser { ctrlEvent };
-	bool isGamepadMotion = ProcessControllerMotion(event, ctrlEvent);
+	bool isGamepadMotion = IsControllerMotion(event);
+	if (!isGamepadMotion) {
+		SimulateRightStickWithPadmapper(ctrlEvent);
+	}
 	DetectInputMethod(event, ctrlEvent);
 	if (isGamepadMotion) {
 		return true;

--- a/Source/controls/input.h
+++ b/Source/controls/input.h
@@ -3,6 +3,7 @@
 #include <SDL.h>
 
 #include "controls/controller.h"
+#include "controls/controller_motion.h"
 
 namespace devilution {
 
@@ -11,6 +12,7 @@ inline int PollEvent(SDL_Event *event)
 	int result = SDL_PollEvent(event);
 	if (result != 0) {
 		UnlockControllerState(*event);
+		ProcessControllerMotion(*event);
 	}
 
 	return result;

--- a/Source/controls/menu_controls.cpp
+++ b/Source/controls/menu_controls.cpp
@@ -32,7 +32,7 @@ std::vector<MenuAction> GetMenuActions(const SDL_Event &event)
 			continue;
 		}
 
-		bool isGamepadMotion = ProcessControllerMotion(event, ctrlEvent);
+		bool isGamepadMotion = IsControllerMotion(event);
 		DetectInputMethod(event, ctrlEvent);
 		if (isGamepadMotion) {
 			menuActions.push_back(GetMenuHeldUpDownAction());


### PR DESCRIPTION
This PR splits `ProcessControllerMotion()` up so that gamepad thumbstick state can be updated consistently in `PollEvent()` regardless of the event handler currently in use by the game.

* Reduce `ProcessControllerMotion()` to only updating thumbstick state based on an SDL event
* Remove unimplemented function `ProcessKbCtrlAxisMotion()`
* Introduce `IsControllerMotion()` to indicate whether an SDL event represents controller motion, taking the place of the bool previously returned by `ProcessControllerMotion()`
* Call `SimulateRightStickWithPadmapper()` directly in the game event handler

This resolves #5946