### PR TITLE
Sync and validate spellFrom and unify normal casting and casting from inventory

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2508,11 +2508,11 @@ bool TryIconCurs()
 
 	if (pcurs == CURSOR_TELEPORT) {
 		if (pcursmonst != -1)
-			NetSendCmdParam4(true, CMD_TSPELLID, pcursmonst, static_cast<int8_t>(myPlayer._pTSpell), myPlayer.GetSpellLevel(myPlayer._pTSpell), myPlayer.queuedSpell.spellFrom);
+			NetSendCmdParam4(true, CMD_TSPELLID, pcursmonst, static_cast<int8_t>(myPlayer.inventorySpell), myPlayer.GetSpellLevel(myPlayer.inventorySpell), myPlayer.spellFrom);
 		else if (pcursplr != -1)
-			NetSendCmdParam4(true, CMD_TSPELLPID, pcursplr, static_cast<int8_t>(myPlayer._pTSpell), myPlayer.GetSpellLevel(myPlayer._pTSpell), myPlayer.queuedSpell.spellFrom);
+			NetSendCmdParam4(true, CMD_TSPELLPID, pcursplr, static_cast<int8_t>(myPlayer.inventorySpell), myPlayer.GetSpellLevel(myPlayer.inventorySpell), myPlayer.spellFrom);
 		else
-			NetSendCmdLocParam3(true, CMD_TSPELLXY, cursPosition, static_cast<int8_t>(myPlayer._pTSpell), myPlayer.GetSpellLevel(myPlayer._pTSpell), myPlayer.queuedSpell.spellFrom);
+			NetSendCmdLocParam3(true, CMD_TSPELLXY, cursPosition, static_cast<int8_t>(myPlayer.inventorySpell), myPlayer.GetSpellLevel(myPlayer.inventorySpell), myPlayer.spellFrom);
 		NewCursor(CURSOR_HAND);
 		return true;
 	}

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2507,12 +2507,20 @@ bool TryIconCurs()
 	}
 
 	if (pcurs == CURSOR_TELEPORT) {
-		if (pcursmonst != -1)
-			NetSendCmdParam4(true, CMD_TSPELLID, pcursmonst, static_cast<int8_t>(myPlayer.inventorySpell), myPlayer.GetSpellLevel(myPlayer.inventorySpell), myPlayer.spellFrom);
-		else if (pcursplr != -1)
-			NetSendCmdParam4(true, CMD_TSPELLPID, pcursplr, static_cast<int8_t>(myPlayer.inventorySpell), myPlayer.GetSpellLevel(myPlayer.inventorySpell), myPlayer.spellFrom);
-		else
-			NetSendCmdLocParam3(true, CMD_TSPELLXY, cursPosition, static_cast<int8_t>(myPlayer.inventorySpell), myPlayer.GetSpellLevel(myPlayer.inventorySpell), myPlayer.spellFrom);
+		const SpellID spellID = myPlayer.inventorySpell;
+		const SpellType spellType = SpellType::Scroll;
+		const int spellLevel = myPlayer.GetSpellLevel(spellID);
+		const int spellFrom = myPlayer.spellFrom;
+		if (IsWallSpell(spellID)) {
+			Direction sd = GetDirection(myPlayer.position.tile, cursPosition);
+			NetSendCmdLocParam5(true, CMD_SPELLXYD, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), static_cast<uint16_t>(sd), spellLevel, spellFrom);
+		} else if (pcursmonst != -1) {
+			NetSendCmdParam5(true, CMD_SPELLID, pcursmonst, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
+		} else if (pcursplr != -1 && !myPlayer.friendlyMode) {
+			NetSendCmdParam5(true, CMD_SPELLPID, pcursplr, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
+		} else {
+			NetSendCmdLocParam4(true, CMD_SPELLXY, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
+		}
 		NewCursor(CURSOR_HAND);
 		return true;
 	}

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -2094,7 +2094,7 @@ bool UseInvItem(int cii)
 	else if (&player == MyPlayer)
 		PlaySFX(ItemInvSnds[idata]);
 
-	UseItem(player.getId(), item->_iMiscId, item->_iSpell);
+	UseItem(player.getId(), item->_iMiscId, item->_iSpell, cii);
 
 	if (speedlist) {
 		if (player.SpdList[c]._iMiscId == IMISC_NOTE) {
@@ -2104,8 +2104,6 @@ bool UseInvItem(int cii)
 		}
 		if (!item->isScroll() && !item->isRune())
 			player.RemoveSpdBarItem(c);
-		else
-			player.queuedSpell.spellFrom = cii;
 		return true;
 	}
 	if (player.InvList[c]._iMiscId == IMISC_MAPOFDOOM)
@@ -2117,8 +2115,6 @@ bool UseInvItem(int cii)
 	}
 	if (!item->isScroll() && !item->isRune())
 		player.RemoveInvItem(c);
-	else
-		player.queuedSpell.spellFrom = cii;
 
 	return true;
 }

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4051,15 +4051,10 @@ void UseItem(size_t pnum, item_misc_id mid, SpellID spellID, int spellFrom)
 		if (ControlMode == ControlTypes::KeyboardAndMouse && GetSpellData(spellID).isTargeted()) {
 			prepareSpellID = spellID;
 		} else {
-			ClrPlrPath(player);
-			player.queuedSpell.spellId = spellID;
-			player.queuedSpell.spellType = SpellType::Scroll;
-			player.queuedSpell.spellFrom = 0;
-			player.destAction = ACTION_SPELL;
-			player.destParam1 = cursPosition.x;
-			player.destParam2 = cursPosition.y;
-			if (&player == MyPlayer && spellID == SpellID::Nova)
-				NetSendCmdLoc(pnum, true, CMD_NOVA, cursPosition);
+			const int spellLevel = player.GetSpellLevel(spellID);
+			// Use CMD_SPELLXY, because tile coords aren't used anyway and it's the same behavior as normal casting
+			assert(IsValidSpellFrom(spellFrom));
+			NetSendCmdLocParam4(true, CMD_SPELLXY, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(SpellType::Scroll), spellLevel, static_cast<uint16_t>(spellFrom));
 		}
 		break;
 	case IMISC_BOOK:

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3975,9 +3975,10 @@ void PrintItemDur(const Item &item)
 	PrintItemInfo(item);
 }
 
-void UseItem(size_t pnum, item_misc_id mid, SpellID spl)
+void UseItem(size_t pnum, item_misc_id mid, SpellID spellID, int spellFrom)
 {
 	Player &player = Players[pnum];
+	std::optional<SpellID> prepareSpellID;
 
 	switch (mid) {
 	case IMISC_HEAL:
@@ -4047,30 +4048,28 @@ void UseItem(size_t pnum, item_misc_id mid, SpellID spl)
 		break;
 	case IMISC_SCROLL:
 	case IMISC_SCROLLT:
-		if (ControlMode == ControlTypes::KeyboardAndMouse && GetSpellData(spl).isTargeted()) {
-			player._pTSpell = spl;
-			if (&player == MyPlayer)
-				NewCursor(CURSOR_TELEPORT);
+		if (ControlMode == ControlTypes::KeyboardAndMouse && GetSpellData(spellID).isTargeted()) {
+			prepareSpellID = spellID;
 		} else {
 			ClrPlrPath(player);
-			player.queuedSpell.spellId = spl;
+			player.queuedSpell.spellId = spellID;
 			player.queuedSpell.spellType = SpellType::Scroll;
 			player.queuedSpell.spellFrom = 0;
 			player.destAction = ACTION_SPELL;
 			player.destParam1 = cursPosition.x;
 			player.destParam2 = cursPosition.y;
-			if (&player == MyPlayer && spl == SpellID::Nova)
+			if (&player == MyPlayer && spellID == SpellID::Nova)
 				NetSendCmdLoc(pnum, true, CMD_NOVA, cursPosition);
 		}
 		break;
 	case IMISC_BOOK:
-		player._pMemSpells |= GetSpellBitmask(spl);
-		if (player._pSplLvl[static_cast<int8_t>(spl)] < MaxSpellLevel)
-			player._pSplLvl[static_cast<int8_t>(spl)]++;
+		player._pMemSpells |= GetSpellBitmask(spellID);
+		if (player._pSplLvl[static_cast<int8_t>(spellID)] < MaxSpellLevel)
+			player._pSplLvl[static_cast<int8_t>(spellID)]++;
 		if (HasNoneOf(player._pIFlags, ItemSpecialEffect::NoMana)) {
-			player._pMana += GetSpellData(spl).sManaCost << 6;
+			player._pMana += GetSpellData(spellID).sManaCost << 6;
 			player._pMana = std::min(player._pMana, player._pMaxMana);
-			player._pManaBase += GetSpellData(spl).sManaCost << 6;
+			player._pManaBase += GetSpellData(spellID).sManaCost << 6;
 			player._pManaBase = std::min(player._pManaBase, player._pMaxManaBase);
 		}
 		if (&player == MyPlayer) {
@@ -4115,32 +4114,30 @@ void UseItem(size_t pnum, item_misc_id mid, SpellID spl)
 		ModifyPlrVit(player, 3);
 		break;
 	case IMISC_RUNEF:
-		player._pTSpell = SpellID::RuneOfFire;
-		if (&player == MyPlayer)
-			NewCursor(CURSOR_TELEPORT);
+		prepareSpellID = SpellID::RuneOfFire;
 		break;
 	case IMISC_RUNEL:
-		player._pTSpell = SpellID::RuneOfLight;
-		if (&player == MyPlayer)
-			NewCursor(CURSOR_TELEPORT);
+		prepareSpellID = SpellID::RuneOfLight;
 		break;
 	case IMISC_GR_RUNEL:
-		player._pTSpell = SpellID::RuneOfNova;
-		if (&player == MyPlayer)
-			NewCursor(CURSOR_TELEPORT);
+		prepareSpellID = SpellID::RuneOfNova;
 		break;
 	case IMISC_GR_RUNEF:
-		player._pTSpell = SpellID::RuneOfImmolation;
-		if (&player == MyPlayer)
-			NewCursor(CURSOR_TELEPORT);
+		prepareSpellID = SpellID::RuneOfImmolation;
 		break;
 	case IMISC_RUNES:
-		player._pTSpell = SpellID::RuneOfStone;
-		if (&player == MyPlayer)
-			NewCursor(CURSOR_TELEPORT);
+		prepareSpellID = SpellID::RuneOfStone;
 		break;
 	default:
 		break;
+	}
+
+	if (prepareSpellID) {
+		assert(IsValidSpellFrom(spellFrom));
+		player.inventorySpell = *prepareSpellID;
+		player.spellFrom = spellFrom;
+		if (&player == MyPlayer)
+			NewCursor(CURSOR_TELEPORT);
 	}
 }
 

--- a/Source/items.h
+++ b/Source/items.h
@@ -530,7 +530,7 @@ bool DoOil(Player &player, int cii);
 void DrawUniqueInfo(const Surface &out);
 void PrintItemDetails(const Item &item);
 void PrintItemDur(const Item &item);
-void UseItem(size_t pnum, item_misc_id Mid, SpellID spl);
+void UseItem(size_t pnum, item_misc_id Mid, SpellID spellID, int spellFrom);
 bool UseItemOpensHive(const Item &item, Point position);
 bool UseItemOpensGrave(const Item &item, Point position);
 void SpawnSmith(int lvl);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -360,9 +360,13 @@ void LoadPlayer(LoadHelper &file, Player &player)
 
 	player.queuedSpell.spellId = static_cast<SpellID>(file.NextLE<int32_t>());
 	player.queuedSpell.spellType = static_cast<SpellType>(file.NextLE<int8_t>());
-	player.queuedSpell.spellFrom = file.NextLE<int8_t>();
+	auto spellFrom = file.NextLE<int8_t>();
+	if (!IsValidSpellFrom(spellFrom))
+		spellFrom = 0;
+	player.spellFrom = spellFrom;
+	player.queuedSpell.spellFrom = spellFrom;
 	file.Skip(2); // Alignment
-	player._pTSpell = static_cast<SpellID>(file.NextLE<int32_t>());
+	player.inventorySpell = static_cast<SpellID>(file.NextLE<int32_t>());
 	file.Skip<int8_t>(); // Skip _pTSplType
 	file.Skip(3);        // Alignment
 	player._pRSpell = static_cast<SpellID>(file.NextLE<int32_t>());
@@ -1136,7 +1140,7 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.WriteLE<int8_t>(static_cast<int8_t>(player.queuedSpell.spellType));
 	file.WriteLE<int8_t>(player.queuedSpell.spellFrom);
 	file.Skip(2); // Alignment
-	file.WriteLE<int32_t>(static_cast<int8_t>(player._pTSpell));
+	file.WriteLE<int32_t>(static_cast<int8_t>(player.inventorySpell));
 	file.Skip<int8_t>(); // Skip _pTSplType
 	file.Skip(3);        // Alignment
 	file.WriteLE<int32_t>(static_cast<int8_t>(player._pRSpell));

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -82,20 +82,14 @@ enum _cmd_id : uint8_t {
 	CMD_RATTACKXY,
 	// Cast spell at target location.
 	//
-	// body (TCmdLocParam2):
+	// body (TCmdLocParam4):
 	//    int8_t x
 	//    int8_t y
-	//    int16_t SpellID
-	//    int16_t spell_lvl
+	//    int16_t spellID
+	//    int16_t spellType
+	//    int16_t spellLevel
+	//    int16_t spellFrom
 	CMD_SPELLXY,
-	// Cast targetted spell at target location.
-	//
-	// body (TCmdLocParam2):
-	//    int8_t x
-	//    int8_t y
-	//    int16_t SpellID
-	//    int16_t spell_lvl
-	CMD_TSPELLXY,
 	// Operate object at location.
 	//
 	// body (TCmdLoc):
@@ -130,32 +124,22 @@ enum _cmd_id : uint8_t {
 	CMD_RATTACKPID,
 	// Cast spell on target monster.
 	//
-	// body (TCmdParam3):
+	// body (TCmdParam5):
 	//    int16_t monster_num
-	//    int16_t SpellID
-	//    int16_t spell_lvl
+	//    int16_t spellID
+	//    int16_t spellType
+	//    int16_t spellLevel
+	//    int16_t spellFrom
 	CMD_SPELLID,
 	// Cast spell on target player.
 	//
-	// body (TCmdParam3):
+	// body (TCmdParam5):
 	//    int16_t player_num
-	//    int16_t SpellID
-	//    int16_t spell_lvl
+	//    int16_t spellID
+	//    int16_t spellType
+	//    int16_t spellLevel
+	//    int16_t spellFrom
 	CMD_SPELLPID,
-	// Cast targetted spell on target monster.
-	//
-	// body (TCmdParam3):
-	//    int16_t monster_num
-	//    int16_t SpellID
-	//    int16_t spell_lvl
-	CMD_TSPELLID,
-	// Cast targetted spell on target player.
-	//
-	// body (TCmdParam3):
-	//    int16_t player_num
-	//    int16_t SpellID
-	//    int16_t spell_lvl
-	CMD_TSPELLPID,
 	// Cast resurrect spell on target player.
 	//
 	// body (TCmdParam1):
@@ -389,12 +373,14 @@ enum _cmd_id : uint8_t {
 	CMD_RETOWN,
 	// Cast spell with direction at target location (e.g. firewall).
 	//
-	// body (TCmdLocParam3):
+	// body (TCmdLocParam5):
 	//    int8_t x
 	//    int8_t y
-	//    int16_t SpellID
-	//    int16_t dir
-	//    int16_t spell_lvl
+	//    int16_t spellID
+	//    int16_t spellType
+	//    int16_t direction
+	//    int16_t spellLevel
+	//    int16_t spellFrom
 	CMD_SPELLXYD,
 	// Track (dungeon generated) item looted by other player on dungeon level not
 	// yet visited by player. The item is tracked as "already taken" in the delta
@@ -421,10 +407,6 @@ enum _cmd_id : uint8_t {
 	//
 	// body (TCmdGolem)
 	CMD_AWAKEGOLEM,
-	// Cast nova spell at target location.
-	//
-	// body (TCmdLoc)
-	CMD_NOVA,
 	// Enable mana shield of player (render).
 	//
 	// body (TCmd)
@@ -494,6 +476,17 @@ struct TCmdLocParam4 {
 	uint16_t wParam4;
 };
 
+struct TCmdLocParam5 {
+	_cmd_id bCmd;
+	uint8_t x;
+	uint8_t y;
+	uint16_t wParam1;
+	uint16_t wParam2;
+	uint16_t wParam3;
+	uint16_t wParam4;
+	uint16_t wParam5;
+};
+
 struct TCmdParam1 {
 	_cmd_id bCmd;
 	uint16_t wParam1;
@@ -505,19 +498,13 @@ struct TCmdParam2 {
 	uint16_t wParam2;
 };
 
-struct TCmdParam3 {
-	_cmd_id bCmd;
-	uint16_t wParam1;
-	uint16_t wParam2;
-	uint16_t wParam3;
-};
-
-struct TCmdParam4 {
+struct TCmdParam5 {
 	_cmd_id bCmd;
 	uint16_t wParam1;
 	uint16_t wParam2;
 	uint16_t wParam3;
 	uint16_t wParam4;
+	uint16_t wParam5;
 };
 
 struct TCmdGolem {
@@ -764,10 +751,10 @@ void NetSendCmdLocParam1(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 void NetSendCmdLocParam2(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2);
 void NetSendCmdLocParam3(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3);
 void NetSendCmdLocParam4(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4);
+void NetSendCmdLocParam5(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4, uint16_t wParam5);
 void NetSendCmdParam1(bool bHiPri, _cmd_id bCmd, uint16_t wParam1);
 void NetSendCmdParam2(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2);
-void NetSendCmdParam3(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3);
-void NetSendCmdParam4(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4);
+void NetSendCmdParam5(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4, uint16_t wParam5);
 void NetSendCmdQuest(bool bHiPri, const Quest &quest);
 void NetSendCmdGItem(bool bHiPri, _cmd_id bCmd, uint8_t pnum, uint8_t ii);
 void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position, const Item &item);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1958,8 +1958,7 @@ void Player::UpdatePreviewCelSprite(_cmd_id cmdId, Point point, uint16_t wParam1
 		graphic = player_graphic::Attack;
 		break;
 	}
-	case _cmd_id::CMD_SPELLID:
-	case _cmd_id::CMD_TSPELLID: {
+	case _cmd_id::CMD_SPELLID: {
 		auto &monster = Monsters[wParam1];
 		dir = GetDirection(position.future, monster.position.future);
 		graphic = GetPlayerGraphicForSpell(static_cast<SpellID>(wParam2));
@@ -1981,8 +1980,7 @@ void Player::UpdatePreviewCelSprite(_cmd_id cmdId, Point point, uint16_t wParam1
 		graphic = player_graphic::Attack;
 		break;
 	}
-	case _cmd_id::CMD_SPELLPID:
-	case _cmd_id::CMD_TSPELLPID: {
+	case _cmd_id::CMD_SPELLPID: {
 		Player &targetPlayer = Players[wParam1];
 		dir = GetDirection(position.future, targetPlayer.position.future);
 		graphic = GetPlayerGraphicForSpell(static_cast<SpellID>(wParam2));
@@ -2007,7 +2005,6 @@ void Player::UpdatePreviewCelSprite(_cmd_id cmdId, Point point, uint16_t wParam1
 		graphic = player_graphic::Attack;
 		break;
 	case _cmd_id::CMD_SPELLXY:
-	case _cmd_id::CMD_TSPELLXY:
 		dir = GetDirection(position.tile, point);
 		graphic = GetPlayerGraphicForSpell(static_cast<SpellID>(wParam1));
 		break;
@@ -3278,20 +3275,21 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 		return;
 	}
 
-	int sl = myPlayer.GetSpellLevel(spellID);
+	const int spellLevel = myPlayer.GetSpellLevel(spellID);
+	const int spellFrom = 0;
 	if (IsWallSpell(spellID)) {
 		LastMouseButtonAction = MouseActionType::Spell;
 		Direction sd = GetDirection(myPlayer.position.tile, cursPosition);
-		NetSendCmdLocParam4(true, CMD_SPELLXYD, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), static_cast<uint16_t>(sd), sl);
+		NetSendCmdLocParam5(true, CMD_SPELLXYD, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), static_cast<uint16_t>(sd), spellLevel, spellFrom);
 	} else if (pcursmonst != -1 && !isShiftHeld) {
 		LastMouseButtonAction = MouseActionType::SpellMonsterTarget;
-		NetSendCmdParam4(true, CMD_SPELLID, pcursmonst, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), sl);
+		NetSendCmdParam5(true, CMD_SPELLID, pcursmonst, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
 	} else if (pcursplr != -1 && !isShiftHeld && !myPlayer.friendlyMode) {
 		LastMouseButtonAction = MouseActionType::SpellPlayerTarget;
-		NetSendCmdParam4(true, CMD_SPELLPID, pcursplr, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), sl);
+		NetSendCmdParam5(true, CMD_SPELLPID, pcursplr, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
 	} else {
 		LastMouseButtonAction = MouseActionType::Spell;
-		NetSendCmdLocParam3(true, CMD_SPELLXY, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), sl);
+		NetSendCmdLocParam4(true, CMD_SPELLXY, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
 	}
 }
 

--- a/Source/player.h
+++ b/Source/player.h
@@ -332,7 +332,10 @@ struct Player {
 	SpellCastInfo queuedSpell;
 	/** @brief The spell that is currently being cast */
 	SpellCastInfo executedSpell;
-	SpellID _pTSpell;
+	/* @brief Which spell should be executed with CURSOR_TELEPORT */
+	SpellID inventorySpell;
+	/* @brief Inventory location for scrolls with CURSOR_TELEPORT */
+	int8_t spellFrom;
 	SpellID _pRSpell;
 	SpellType _pRSplType;
 	SpellID _pSBkSpell;

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -503,7 +503,7 @@ bool UseStashItem(uint16_t c)
 	else
 		PlaySFX(ItemInvSnds[ItemCAnimTbl[item->_iCurs]]);
 
-	UseItem(MyPlayerId, item->_iMiscId, item->_iSpell);
+	UseItem(MyPlayerId, item->_iMiscId, item->_iSpell, -1);
 
 	if (Stash.stashList[c]._iMiscId == IMISC_MAPOFDOOM)
 		return true;

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -113,6 +113,17 @@ bool IsValidSpell(SpellID spl)
 	    && (spl <= SpellID::LastDiablo || gbIsHellfire);
 }
 
+bool IsValidSpellFrom(int spellFrom)
+{
+	if (spellFrom == 0)
+		return true;
+	if (spellFrom >= INVITEM_INV_FIRST && spellFrom <= INVITEM_INV_LAST)
+		return true;
+	if (spellFrom >= INVITEM_BELT_FIRST && spellFrom <= INVITEM_BELT_LAST)
+		return true;
+	return false;
+}
+
 bool IsWallSpell(SpellID spl)
 {
 	return spl == SpellID::FireWall || spl == SpellID::LightningWall;

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -17,6 +17,7 @@ enum class SpellCheckResult : uint8_t {
 };
 
 bool IsValidSpell(SpellID spl);
+bool IsValidSpellFrom(int spellFrom);
 bool IsWallSpell(SpellID spl);
 bool TargetsMonster(SpellID id);
 int GetManaAmount(const Player &player, SpellID sn);

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -136,7 +136,7 @@ static void AssertPlayer(Player &player)
 	ASSERT_EQ(player.queuedSpell.spellId, SpellID::Null);
 	ASSERT_EQ(player.queuedSpell.spellType, SpellType::Skill);
 	ASSERT_EQ(player.queuedSpell.spellFrom, 0);
-	ASSERT_EQ(player._pTSpell, SpellID::Null);
+	ASSERT_EQ(player.inventorySpell, SpellID::Null);
 	ASSERT_EQ(player._pRSpell, SpellID::TrapDisarm);
 	ASSERT_EQ(player._pRSplType, SpellType::Skill);
 	ASSERT_EQ(player._pSBkSpell, SpellID::Null);

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -312,7 +312,7 @@ void AssertPlayer(Player &player)
 	ASSERT_EQ(player.queuedSpell.spellId, SpellID::Invalid);
 	ASSERT_EQ(player.queuedSpell.spellType, SpellType::Invalid);
 	ASSERT_EQ(player.queuedSpell.spellFrom, 0);
-	ASSERT_EQ(player._pTSpell, SpellID::Null);
+	ASSERT_EQ(player.inventorySpell, SpellID::Null);
 	ASSERT_EQ(player._pRSpell, SpellID::Invalid);
 	ASSERT_EQ(player._pRSplType, SpellType::Invalid);
 	ASSERT_EQ(player._pSBkSpell, SpellID::Invalid);


### PR DESCRIPTION
Fixes #5809

Notes
- `spellFrom` is validated when loading from save game
- `CMD_TSPELL*` (Casting from inventory/Teleport cursor spells) is removed and combined with normal `CMD_SPELL*`
- `CMD_SPELL*` now also includes `spellFrom`
- This PR also fixes three vanilla issues related to casting scrolls/runes from inventory
   - Spell level is correctly initialized (not remains from last spell)
   - Scrolls without target (no teleport cursor) are synced/visible to other clients (for example healing)
   - Fire/lightning walls scrolls direction is correctly initialized (not remains from last spell)
- This PR reintroduces `Player::spellFrom`. This variable contains the selected scroll (prior to casting) but `SpellCastInfo::spellFrom` contains the executed/queued scroll.
- Verifies direction for `CMD_SPELLXYD` (fire/lightning wall)