### PR TITLE
When player position desyncs ensure position.old is also updated

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -657,6 +657,7 @@ void multi_process_network_packets()
 						player.position.future = syncPosition;
 						if (player.isWalking())
 							player.position.temp = syncPosition;
+						SetPlayerOld(player);
 						dPlayer[player.position.tile.x][player.position.tile.y] = playerId + 1;
 					}
 					if (player.position.future.WalkingDistance(player.position.tile) > 1) {
@@ -668,6 +669,7 @@ void multi_process_network_packets()
 				} else {
 					player.position.tile = syncPosition;
 					player.position.future = syncPosition;
+					SetPlayerOld(player);
 				}
 			}
 		}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2588,6 +2588,7 @@ void InitPlayer(Player &player, bool firstTime)
 		}
 
 		player.position.future = player.position.tile;
+		SetPlayerOld(player);
 		player.walkpath[0] = WALK_NONE;
 		player.destAction = ACTION_NONE;
 
@@ -2701,6 +2702,16 @@ void FixPlrWalkTags(const Player &player)
 			dPlayer[searchTile.x][searchTile.y] = 0;
 		}
 	}
+
+#ifdef _DEBUG
+	// Checks that FixPlrWalkTags really removes player from all dPlayer tiles
+	// FixPlrWalkTags could fail if player.position.old is not updated correctly
+	for (int y = 0; y < MAXDUNY; y++) {
+		for (int x = 0; x < MAXDUNX; x++) {
+			assert(PlayerAtPosition({ x, y }) != &player);
+		}
+	}
+#endif
 }
 
 void StartPlrHit(Player &player, int dam, bool forcehit)


### PR DESCRIPTION
Could fix #5981

`FixPlrWalkTags` uses `player.position.old` but in some cases the old position is not updated correctly:
- when joining a game
- when desyncs happen and the remote player position is instant updated/"teleported"
- when player is not on the same level (this is relevant when another player joins the level)

This PR resolves the desyncs from above and add's a debug routine to help diagnostic this kind of problems earlier.

Steps to reproduce #5981 in master:
- In StartSpell change NewPlrAnim to: `NewPlrAnim(player, GetPlayerGraphicForSpell(player.queuedSpell.spellId), d, animationFlags, -100, player._pSFNum);` note: this change is only needed to have enough time for the cast between the two clients 😉
- Player 1 goes to dungeon
- Player 1 walks 5 tiles away from upstairs entry
- Player 1 cast teleports to stairs
- Player 2 goes down to dungeon
- Player 2 sees Player 1 standing (note: cast is not synced)
- Player 1 finishes teleport cast
- Player 1 starts town warp
- Player 2 still sees Player 1 in dungeon
- ==> crash

Note:
Perhaps there are other reasons why `player.position.old` is out of sync.
So it is still possible #5981 is not fixed with this PR.