### PR TITLE
Update Gradle to version 7.4.2

### DIFF
--- a/android-project/app/build.gradle
+++ b/android-project/app/build.gradle
@@ -32,6 +32,7 @@ android {
 			proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
 		}
 	}
+	namespace 'org.diasurgical.devilutionx'
 	applicationVariants.all { variant ->
 		tasks["merge${variant.name.capitalize()}Assets"]
 			.dependsOn("externalNativeBuild${variant.name.capitalize()}")

--- a/android-project/app/src/main/AndroidManifest.xml
+++ b/android-project/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="org.diasurgical.devilutionx"
     android:installLocation="auto">
 
     <!-- OpenGL ES 2.0 -->

--- a/android-project/build.gradle
+++ b/android-project/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 		google()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:7.3.1'
+		classpath 'com.android.tools.build:gradle:7.4.2'
 
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files


### PR DESCRIPTION
I also took their recommendation to move the namespace declaration from the `AndroidManifest.xml` file to the `build.gradle` file. Apparently, Google deprecated the `AndroidManifest.xml` declaration. 🤷 