### PR TITLE
Fix light brightness pop on load

### DIFF
--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -256,10 +256,11 @@ void DoLighting(Point position, uint8_t radius, int Lnum)
 		maxY = MAXDUNY - position.y;
 	}
 
-	if (IsNoneOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
-		SetLight(position, 0);
-	} else if (GetLight(position) > LightFalloffs[radius][0]) {
+	// Allow for dim lights in crypt and nest
+	if (IsAnyOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
 		SetLight(position, LightFalloffs[radius][0]);
+	} else if (GetLight(position) > LightFalloffs[radius][0]) {
+		SetLight(position, 0);
 	}
 
 	for (int i = 0; i < 4; i++) {

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1532,7 +1532,7 @@ void AddMushPatch()
 bool IsLightVisible(Object &light, int lightRadius)
 {
 #ifdef _DEBUG
-	if (!DisableLighting)
+	if (DisableLighting)
 		return false;
 #endif
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4224,9 +4224,8 @@ void ProcessObjects()
 		Object &object = Objects[ActiveObjects[i]];
 		switch (object._otype) {
 		case OBJ_L1LIGHT:
-			UpdateObjectLight(object, 10);
-			break;
 		case OBJ_SKFIRE:
+		case OBJ_CANDLE1:
 		case OBJ_CANDLE2:
 		case OBJ_BOOKCANDLE:
 			UpdateObjectLight(object, 5);
@@ -4281,7 +4280,7 @@ void ProcessObjects()
 			break;
 		case OBJ_BCROSS:
 		case OBJ_TBCROSS:
-			UpdateObjectLight(object, 10);
+			UpdateObjectLight(object, 5);
 			UpdateBurningCrossDamage(object);
 			break;
 		default:


### PR DESCRIPTION
Light radios for 3 objects did not match between `addObject` and `updateObject`. This caused some lights (especially in the cathedral) to fade in with the lower brightness on level loading, then pop to full brightness once the transition is over.