### PR TITLE
Unify vision and lights

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1386,7 +1386,6 @@ void GameLogic()
 		gGameLogicStep = GameLogicStep::ProcessItems;
 		ProcessItems();
 		ProcessLightList();
-		ProcessVisionList();
 	} else {
 		gGameLogicStep = GameLogicStep::ProcessTowners;
 		ProcessTowners();
@@ -2937,7 +2936,6 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 	UnstuckChargers();
 	if (leveltype != DTYPE_TOWN) {
 		ProcessLightList();
-		ProcessVisionList();
 	}
 
 	if (leveltype == DTYPE_CRYPT) {

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2660,8 +2660,7 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 	lrad = clamp(lrad, 2, 15);
 
 	if (player._pLightRad != lrad) {
-		ChangeLightRadius(player.lightId, lrad);
-		ChangeVisionRadius(player.getId(), lrad);
+		ChangeLightRadius(player.lightId, lrad, true);
 		player._pLightRad = lrad;
 	}
 

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -20,7 +20,6 @@
 namespace devilution {
 
 #define MAXLIGHTS 32
-#define MAXVISION 4
 /** @brief Number of supported light levels */
 constexpr size_t NumLightingLevels = 16;
 #define NO_LIGHT -1
@@ -39,10 +38,9 @@ struct Light {
 	uint8_t oldRadius;
 	bool isInvalid;
 	bool hasChanged;
+	bool isRemote;
 };
 
-extern Light VisionList[MAXVISION];
-extern std::array<bool, MAXVISION> VisionActive;
 extern Light Lights[MAXLIGHTS];
 extern std::array<uint8_t, MAXLIGHTS> ActiveLights;
 extern int ActiveLightCount;
@@ -55,6 +53,7 @@ extern std::array<uint8_t, 256> PauseTable;
 extern bool DisableLighting;
 #endif
 extern bool UpdateLighting;
+extern bool UpdateVision;
 
 void DoLighting(Point position, uint8_t radius, int Lnum);
 void DoUnVision(Point position, uint8_t radius);
@@ -64,18 +63,14 @@ void MakeLightTable();
 void ToggleLighting();
 #endif
 void InitLighting();
-int AddLight(Point position, uint8_t radius);
+int AddLight(Point position, uint8_t radius, bool updateVision = false, bool isRemote = false);
 void AddUnLight(int i);
-void ChangeLightRadius(int i, uint8_t radius);
-void ChangeLightXY(int i, Point position);
+void ChangeLightRadius(int i, uint8_t radius, bool updateVision = false);
+void ChangeLightXY(int i, Point position, bool updateVision = false);
 void ChangeLightOffset(int i, Displacement offset);
 void ChangeLight(int i, Point position, uint8_t radius);
 void ProcessLightList();
 void SavePreLighting();
-void ActivateVision(Point position, int r, int id);
-void ChangeVisionRadius(int id, int r);
-void ChangeVisionXY(int id, Point position);
-void ProcessVisionList();
 void lighting_color_cycling();
 
 constexpr int MaxCrawlRadius = 18;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3622,8 +3622,7 @@ void ProcessTeleport(Missile &missile)
 	missile.var1 = 1;
 	dPlayer[player.position.tile.x][player.position.tile.y] = id + 1;
 	if (leveltype != DTYPE_TOWN) {
-		ChangeLightXY(player.lightId, player.position.tile);
-		ChangeVisionXY(player.getId(), player.position.tile);
+		ChangeLightXY(player.lightId, player.position.tile, true);
 	}
 	if (&player == MyPlayer) {
 		ViewPosition = player.position.tile;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2117,7 +2117,7 @@ size_t OnPlayerJoinLevel(const TCmd *pCmd, size_t pnum)
 				dFlags[player.position.tile.x][player.position.tile.y] |= DungeonFlag::DeadPlayer;
 			}
 
-			ActivateVision(player.position.tile, player._pLightRad, player.getId());
+			player.lightId = AddLight(player.position.tile, player._pLightRad, true, true);
 		}
 	}
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4315,7 +4315,7 @@ void RedoPlayerVision()
 {
 	for (const Player &player : Players) {
 		if (player.plractive && player.isOnActiveLevel()) {
-			ChangeVisionXY(player.getId(), player.position.tile);
+			ChangeLightXY(player.lightId, player.position.tile, true);
 		}
 	}
 }

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -111,7 +111,7 @@ void WalkSouthwards(Player &player, const DirectionSettings & /*walkParams*/)
 	player.position.tile = player.position.future; // Move player to the next tile to maintain correct render order
 	dPlayer[player.position.tile.x][player.position.tile.y] = playerId + 1;
 	// BUGFIX: missing `if (leveltype != DTYPE_TOWN) {` for call to ChangeLightXY and PM_ChangeLightOff.
-	ChangeLightXY(player.lightId, player.position.tile);
+	ChangeLightXY(player.lightId, player.position.tile, true);
 	PmChangeLightOff(player);
 }
 
@@ -124,7 +124,7 @@ void WalkSideways(Player &player, const DirectionSettings &walkParams)
 	dPlayer[player.position.future.x][player.position.future.y] = playerId + 1;
 
 	if (leveltype != DTYPE_TOWN) {
-		ChangeLightXY(player.lightId, nextPosition);
+		ChangeLightXY(player.lightId, nextPosition, true);
 		PmChangeLightOff(player);
 	}
 
@@ -505,8 +505,7 @@ bool DoWalk(Player &player, int variant)
 
 	// Update the coordinates for lighting and vision entries for the player
 	if (leveltype != DTYPE_TOWN) {
-		ChangeLightXY(player.lightId, player.position.tile);
-		ChangeVisionXY(player.getId(), player.position.tile);
+		ChangeLightXY(player.lightId, player.position.tile, true);
 	}
 
 	if (player.walkpath[0] != WALK_NONE) {
@@ -2576,12 +2575,11 @@ void InitPlayer(Player &player, bool firstTime)
 		player.destAction = ACTION_NONE;
 
 		if (&player == MyPlayer) {
-			player.lightId = AddLight(player.position.tile, player._pLightRad);
-			ChangeLightXY(player.lightId, player.position.tile); // fix for a bug where old light is still visible at the entrance after reentering level
+			player.lightId = AddLight(player.position.tile, player._pLightRad, true);
+			ChangeLightXY(player.lightId, player.position.tile, true); // fix for a bug where old light is still visible at the entrance after reentering level
 		} else {
-			player.lightId = NO_LIGHT;
+			player.lightId = AddLight(player.position.tile, player._pLightRad, true, true);
 		}
-		ActivateVision(player.position.tile, player._pLightRad, player.getId());
 	}
 
 	SpellID s = PlayersData[static_cast<size_t>(player._pClass)].skill;
@@ -2638,8 +2636,7 @@ void FixPlayerLocation(Player &player, Direction bDir)
 	if (&player == MyPlayer) {
 		ViewPosition = player.position.tile;
 	}
-	ChangeLightXY(player.lightId, player.position.tile);
-	ChangeVisionXY(player.getId(), player.position.tile);
+	ChangeLightXY(player.lightId, player.position.tile, true);
 }
 
 void StartStand(Player &player, Direction dir)


### PR DESCRIPTION
Vision will never grow to more then 4, since there is only 4 players... so why have a list of 32 of them.

Since vision needs to stay in sync with your light, might as well drop all the duplicate code. The only special case is remote players where the lighting should not be rendered.

Also optimize the Light struct.

All the changes to data structures should save us about 3KB ram, but there should also be some savings in terms of runtime processing and less code generation.

Use `Rectangle` logic in `DoUnLight()` and `DoUnVision()`, and take a `Point` as an input.

Have `ProcessLightList()` free deleted lights before applying lighting to simplify the process. And use early return to avoid indentation of the function body (so probably view with "ignore white-space").

Remove `DisableLighting` from release builds.