### PR TITLE
Spanish translation - Fixes in some descriptions

### DIFF
--- a/Translations/es.po
+++ b/Translations/es.po
@@ -1112,19 +1112,19 @@ msgstr "Tecla de acceso rápido: 's'"
 
 #: Source/control.cpp:847 Source/panels/spell_list.cpp:147
 msgid "{:s} Skill"
-msgstr "{:s} Habilidad"
+msgstr "Habilidad {:s}"
 
 #: Source/control.cpp:850 Source/panels/spell_list.cpp:154
 msgid "{:s} Spell"
-msgstr "{:s} Hechizo"
+msgstr "Hechizo {:s}"
 
 #: Source/control.cpp:852 Source/panels/spell_list.cpp:159
 msgid "Spell Level 0 - Unusable"
-msgstr "Nivel de Hechizo 0: Inutilizable"
+msgstr "Nivel 0 - Inutilizable"
 
 #: Source/control.cpp:852 Source/panels/spell_list.cpp:161
 msgid "Spell Level {:d}"
-msgstr "Nivel de Hechizo {:d}"
+msgstr "Nivel {:d}"
 
 #: Source/control.cpp:855 Source/panels/spell_list.cpp:168
 msgid "Scroll of {:s}"

--- a/Translations/es.po
+++ b/Translations/es.po
@@ -6443,7 +6443,7 @@ msgstr "Héroe Asesinado"
 #. TRANSLATORS: {:s} will either be a chest or a door
 #: Source/objects.cpp:4901
 msgid "Trapped {:s}"
-msgstr "{:s} Atrapado"
+msgstr "{:s} Trampa"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls lever
 #: Source/objects.cpp:4906


### PR DESCRIPTION

- Trapped containers/doors description fixed.

Before
![Captura desde 2023-04-19 13-34-18](https://user-images.githubusercontent.com/131033547/233073342-040f1dd8-e773-4ae4-b2c3-58ce4c6f3890.png)
After
![Captura desde 2023-04-19 13-30-21](https://user-images.githubusercontent.com/131033547/233073399-f8c76a1e-4e02-44e2-9144-6852110f634d.png)


- Fixed missaligned skill description.

Before
![Captura desde 2023-04-19 13-45-08](https://user-images.githubusercontent.com/131033547/233074324-d2e69af7-70c1-4c04-a203-642f6dd05407.png)
After
![Captura desde 2023-04-19 13-43-35](https://user-images.githubusercontent.com/131033547/233074428-7657db44-9d57-4531-984e-f2fecf07812c.png)

- Fixed missaligned spell description + simplification in level to avoid repetition of "spell".

Before
![Captura desde 2023-04-19 13-45-19](https://user-images.githubusercontent.com/131033547/233075919-987595a8-0e44-4230-8b96-e1b41b2f3b5e.png)

After
![Captura desde 2023-04-19 13-43-51](https://user-images.githubusercontent.com/131033547/233076028-f5a3468b-06fc-48f0-a71a-f48697ccabcd.png)
