### PR TITLE
Spanish translation - Little adjustments in object descriptions

### DIFF
--- a/Translations/es.po
+++ b/Translations/es.po
@@ -4330,19 +4330,19 @@ msgstr "Duplica la capacidad de oro"
 
 #: Source/items.cpp:1825 Source/stores.cpp:322
 msgid "Required:"
-msgstr "Requerido:"
+msgstr "Requiere:"
 
 #: Source/items.cpp:1827 Source/stores.cpp:324
 msgid " {:d} Str"
-msgstr " {:d} Fuerza"
+msgstr " {:d} Fue"
 
 #: Source/items.cpp:1829 Source/stores.cpp:326
 msgid " {:d} Mag"
-msgstr " {:d} Magia"
+msgstr " {:d} Mag"
 
 #: Source/items.cpp:1831 Source/stores.cpp:328
 msgid " {:d} Dex"
-msgstr " {:d} Destreza"
+msgstr " {:d} Des"
 
 #. TRANSLATORS: {:s} will be a Character Name
 #: Source/items.cpp:3126 Source/player.cpp:3003
@@ -4699,7 +4699,7 @@ msgstr "40% de Salud se movió a Maná"
 
 #: Source/items.cpp:3671 Source/items.cpp:3712
 msgid "damage: {:d}  Indestructible"
-msgstr "daño: {:d} Indestructible"
+msgstr "daño: {:d}  Indestructible"
 
 #. TRANSLATORS: Dur: is durability
 #: Source/items.cpp:3673 Source/items.cpp:3714
@@ -4708,21 +4708,21 @@ msgstr "daño: {:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3676 Source/items.cpp:3717
 msgid "damage: {:d}-{:d}  Indestructible"
-msgstr "daño: {:d}-{:d} Indestructible"
+msgstr "daño: {:d}-{:d}  Indestructible"
 
 #. TRANSLATORS: Dur: is durability
 #: Source/items.cpp:3678 Source/items.cpp:3719
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
-msgstr "daño: {:d}-{:d} Dur: {:d}/{:d}"
+msgstr "daño: {:d}-{:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3683 Source/items.cpp:3729
 msgid "armor: {:d}  Indestructible"
-msgstr "armadura: {:d} Indestructible"
+msgstr "defensa: {:d}  Indestructible"
 
 #. TRANSLATORS: Dur: is durability
 #: Source/items.cpp:3685 Source/items.cpp:3731
 msgid "armor: {:d}  Dur: {:d}/{:d}"
-msgstr "armadura: {:d} Dur: {:d}/{:d}"
+msgstr "defensa: {:d}  Dur: {:d}/{:d}"
 
 #: Source/items.cpp:3688 Source/items.cpp:3722 Source/items.cpp:3735
 #: Source/stores.cpp:296
@@ -7753,19 +7753,19 @@ msgstr ",  "
 
 #: Source/stores.cpp:306
 msgid "Damage: {:d}-{:d}  "
-msgstr "Daño: {:d}-{:d} "
+msgstr "Daño: {:d}-{:d}  "
 
 #: Source/stores.cpp:308
 msgid "Armor: {:d}  "
-msgstr "Armadura:{:d} "
+msgstr "Defensa: {:d}  "
 
 #: Source/stores.cpp:310
 msgid "Dur: {:d}/{:d},  "
-msgstr "Dur:  {:d}/ {:d}, "
+msgstr "Dur: {:d}/{:d},  "
 
 #: Source/stores.cpp:312
 msgid "Indestructible,  "
-msgstr "Indestructible, "
+msgstr "Indestructible,  "
 
 #: Source/stores.cpp:320
 msgid "No required attributes"


### PR DESCRIPTION
- Simplification to three characters of the terms "Fuerza"->"Fue", "Magia"->"Mag", "Destreza"->"Des". The reason for the change is that on objects with long descriptions there is a possibility that the String exceeds the width of the frame, giving sometimes an ugly and unintelligible result. It also resembles the original English version.

- "armadura" replaced by "defensa". Fewer characters and better approach to the Diablo II object description system. And, in my opinion, less repetitive and more elegant.

- Fixed blank spaces.

Examples:

Before (store descriptions)
![Captura desde 2023-04-19 23-03-16](https://user-images.githubusercontent.com/131033547/233202865-a6cacc27-0897-4bc0-8b41-76c3d6ee57ad.png)
![Captura desde 2023-04-19 23-08-19](https://user-images.githubusercontent.com/131033547/233202947-6f9c230e-0dd0-43e5-bdc9-11a45982c5a7.png)

After
![Captura desde 2023-04-19 23-11-11](https://user-images.githubusercontent.com/131033547/233203334-d1de527a-2e86-47ef-8214-059e9c5b7b3e.png)


Before (item description)
![Captura desde 2023-04-19 23-16-54](https://user-images.githubusercontent.com/131033547/233203579-d254bc2d-7a6a-4a6d-a44e-8800187755d4.png)
![Captura desde 2023-04-19 23-16-38](https://user-images.githubusercontent.com/131033547/233203598-6813f948-daea-450e-83e9-15eec34709a0.png)

After
![Captura desde 2023-04-19 23-15-44](https://user-images.githubusercontent.com/131033547/233203656-3493aef5-8237-433c-b9e9-c425564be7ca.png)
![Captura desde 2023-04-19 23-15-34](https://user-images.githubusercontent.com/131033547/233203674-77b17ec5-9052-4dbc-a0ed-d2ec2b3f923a.png)
