### PR TITLE
Cleanup lighttable generation

### DIFF
--- a/Source/engine/load_pcx.cpp
+++ b/Source/engine/load_pcx.cpp
@@ -45,7 +45,7 @@ OptionalOwnedClxSpriteList LoadPcxSpriteList(const char *filename, int numFrames
 	if (outPalette != nullptr) {
 		std::memcpy(pathEnd - 3, "pal", 3);
 		std::array<uint8_t, 256 * 3> palette;
-		LoadFileInMem(path, &palette[0], palette.size());
+		LoadFileInMem(path, palette);
 		for (unsigned i = 0; i < 256; i++) {
 			outPalette[i].r = palette[i * 3];
 			outPalette[i].g = palette[i * 3 + 1];

--- a/Source/engine/render/clx_render.hpp
+++ b/Source/engine/render/clx_render.hpp
@@ -94,7 +94,7 @@ extern int LightTableIndex;
 inline void ClxDrawLight(const Surface &out, Point position, ClxSprite clx)
 {
 	if (LightTableIndex != 0)
-		ClxDrawTRN(out, position, clx, &LightTables[LightTableIndex * 256]);
+		ClxDrawTRN(out, position, clx, LightTables[LightTableIndex].data());
 	else
 		ClxDraw(out, position, clx);
 }
@@ -107,7 +107,7 @@ inline void ClxDrawLight(const Surface &out, Point position, ClxSprite clx)
  */
 inline void ClxDrawLightBlended(const Surface &out, Point position, ClxSprite clx)
 {
-	ClxDrawBlendedTRN(out, position, clx, &LightTables[LightTableIndex * 256]);
+	ClxDrawBlendedTRN(out, position, clx, LightTables[LightTableIndex].data());
 }
 
 /**

--- a/Source/engine/render/dun_render.cpp
+++ b/Source/engine/render/dun_render.cpp
@@ -1143,7 +1143,7 @@ void RenderTile(const Surface &out, Point position,
 	if (clip.width <= 0 || clip.height <= 0)
 		return;
 
-	const uint8_t *tbl = &LightTables[256 * lightTableIndex];
+	const uint8_t *tbl = LightTables[LightTableIndex].data();
 	const auto *pFrameTable = reinterpret_cast<const uint32_t *>(pDungeonCels.get());
 	const auto *src = reinterpret_cast<const uint8_t *>(&pDungeonCels[SDL_SwapLE32(pFrameTable[levelCelBlock.frame()])]);
 	uint8_t *dst = out.at(static_cast<int>(position.x + clip.left), static_cast<int>(position.y - clip.bottom));

--- a/Source/engine/render/dun_render.hpp
+++ b/Source/engine/render/dun_render.hpp
@@ -262,7 +262,7 @@ string_view MaskTypeToString(MaskType maskType);
  * @param position Target buffer coordinates
  * @param levelCelBlock The MIN block of the level CEL file.
  * @param maskType The mask to use,
- * @param lightTableIndex The light level to use for rendering (index into LightTables / 256).
+ * @param lightTableIndex The light level to use for rendering (index into LightTables).
  */
 void RenderTile(const Surface &out, Point position,
     LevelCelBlock levelCelBlock, MaskType maskType, uint8_t lightTableIndex);

--- a/Source/engine/trn.cpp
+++ b/Source/engine/trn.cpp
@@ -12,17 +12,17 @@ namespace devilution {
 
 uint8_t *GetInfravisionTRN()
 {
-	return &LightTables[16 * 256];
+	return InfravisionTable.data();
 }
 
 uint8_t *GetStoneTRN()
 {
-	return &LightTables[17 * 256];
+	return StoneTable.data();
 }
 
 uint8_t *GetPauseTRN()
 {
-	return &LightTables[18 * 256];
+	return PauseTable.data();
 }
 
 std::optional<std::array<uint8_t, 256>> GetClassTRN(Player &player)

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -457,28 +457,30 @@ void MakeLightTable()
 	LoadFileInMem("plrgfx\\stone.trn", StoneTable);
 	LoadFileInMem("gendata\\pause.trn", PauseTable);
 
-	for (int j = 0; j < 16; j++) {
-		for (int i = 0; i < 128; i++) {
-			if (i > (j + 1) * 8) {
-				LightFalloffs[j][i] = 15;
-			} else {
-				double fs = (double)15 * i / ((double)8 * (j + 1));
-				LightFalloffs[j][i] = static_cast<uint8_t>(fs + 0.5);
-			}
-		}
-	}
-
+	// Generate light falloffs ranges
 	if (IsAnyOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
 		for (int j = 0; j < 16; j++) {
 			double fa = (sqrt((double)(16 - j))) / 128;
 			fa *= fa;
 			for (int i = 0; i < 128; i++) {
-				LightFalloffs[15 - j][i] = 15 - static_cast<uint8_t>(fa * (double)((128 - i) * (128 - i)));
-				if (LightFalloffs[15 - j][i] > 15)
-					LightFalloffs[15 - j][i] = 0;
-				LightFalloffs[15 - j][i] = LightFalloffs[15 - j][i] - static_cast<uint8_t>((15 - j) / 2);
-				if (LightFalloffs[15 - j][i] > 15)
-					LightFalloffs[15 - j][i] = 0;
+				uint8_t color = 15 - static_cast<uint8_t>(fa * (double)((128 - i) * (128 - i)));
+				if (color > 15)
+					color = 0;
+				color -= static_cast<uint8_t>((15 - j) / 2);
+				if (color > 15)
+					color = 0;
+				LightFalloffs[15 - j][i] = color;
+			}
+		}
+	} else {
+		for (int j = 0; j < 16; j++) {
+			for (int i = 0; i < 128; i++) {
+				if (i > (j + 1) * 8) {
+					LightFalloffs[j][i] = 15;
+				} else {
+					double fs = (double)15 * i / ((double)8 * (j + 1));
+					LightFalloffs[j][i] = static_cast<uint8_t>(fs + 0.5);
+				}
 			}
 		}
 	}

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -725,21 +725,12 @@ void ProcessVisionList()
 
 void lighting_color_cycling()
 {
-	if (leveltype != DTYPE_HELL) {
-		return;
-	}
-
-	uint8_t *tbl = LightTables[0].data();
-
-	for (int j = 0; j < 16; j++) {
-		tbl++;
-		uint8_t col = *tbl;
-		for (int i = 0; i < 30; i++) {
-			tbl[0] = tbl[1];
-			tbl++;
+	for (auto &lightTable : LightTables) {
+		uint8_t firstColor = lightTable[1];
+		for (int colorIndex = 1; colorIndex < 31; colorIndex++) {
+			lightTable[colorIndex] = lightTable[colorIndex + 1];
 		}
-		*tbl = col;
-		tbl += 225;
+		lightTable[31] = firstColor;
 	}
 }
 

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -400,45 +400,17 @@ void MakeLightTable()
 	}
 
 	if (leveltype == DTYPE_HELL) {
-		uint8_t blood[16];
-		tbl = LightTables[0].data();
-		for (int i = 0; i < lights; i++) {
-			int l1 = lights - i;
-			int l2 = l1;
-			int div = lights / l1;
-			int rem = lights % l1;
-			int cnt = 0;
-			blood[0] = 0;
-			uint8_t col = 1;
-			for (int j = 1; j < 16; j++) {
-				blood[j] = col;
-				l2 += rem;
-				if (l2 > l1 && j < 15) {
-					j++;
-					blood[j] = col;
-					l2 -= l1;
-				}
-				cnt++;
-				if (cnt == div) {
-					col++;
-					cnt = 0;
-				}
+		// Blood wall lighting
+		const int shades = LightTables.size() - 1;
+		for (int i = 0; i < shades; i++) {
+			auto &lightTable = LightTables[i];
+			constexpr int range = 16;
+			for (int j = 0; j < range; j++) {
+				uint8_t color = ((range - 1) << 4) / shades * (shades - i) / range * (j + 1);
+				color = 1 + (color >> 4);
+				lightTable[j + 1] = color;
+				lightTable[31 - j] = color;
 			}
-			*tbl++ = 0;
-			for (int j = 1; j <= 15; j++) {
-				*tbl++ = blood[j];
-			}
-			for (int j = 15; j > 0; j--) {
-				*tbl++ = blood[j];
-			}
-			*tbl++ = 1;
-			tbl += 224;
-		}
-		*tbl++ = 0;
-		for (int j = 0; j < 31; j++) {
-			*tbl++ = 1;
-		}
-		tbl += 224;
 		}
 	} else if (IsAnyOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
 		// Make the lava fully bright

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -20,7 +20,10 @@ int VisionId;
 Light Lights[MAXLIGHTS];
 uint8_t ActiveLights[MAXLIGHTS];
 int ActiveLightCount;
-std::array<uint8_t, LIGHTSIZE> LightTables;
+std::array<std::array<uint8_t, 256>, NumLightingLevels> LightTables;
+std::array<uint8_t, 256> InfravisionTable;
+std::array<uint8_t, 256> StoneTable;
+std::array<uint8_t, 256> PauseTable;
 bool DisableLighting;
 bool UpdateLighting;
 
@@ -336,7 +339,7 @@ void DoVision(Point position, int radius, MapExplorationType doAutomap, bool vis
 
 void MakeLightTable()
 {
-	uint8_t *tbl = LightTables.data();
+	uint8_t *tbl = LightTables[0].data();
 	int shade = 0;
 	int lights = 15;
 
@@ -396,7 +399,7 @@ void MakeLightTable()
 
 	if (leveltype == DTYPE_HELL) {
 		uint8_t blood[16];
-		tbl = LightTables.data();
+		tbl = LightTables[0].data();
 		for (int i = 0; i < lights; i++) {
 			int l1 = lights - i;
 			int l2 = l1;
@@ -436,7 +439,7 @@ void MakeLightTable()
 		tbl += 224;
 	}
 	if (IsAnyOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
-		tbl = LightTables.data();
+		tbl = LightTables[0].data();
 		for (int i = 0; i < lights; i++) {
 			*tbl++ = 0;
 			for (int j = 1; j < 16; j++)
@@ -449,14 +452,9 @@ void MakeLightTable()
 		tbl += 240;
 	}
 
-	LoadFileInMem("plrgfx\\infra.trn", tbl, 256);
-	tbl += 256;
-
-	LoadFileInMem("plrgfx\\stone.trn", tbl, 256);
-	tbl += 256;
-
-	LoadFileInMem("gendata\\pause.trn", tbl, 256);
-	tbl += 256;
+	LoadFileInMem("plrgfx\\infra.trn", InfravisionTable);
+	LoadFileInMem("plrgfx\\stone.trn", StoneTable);
+	LoadFileInMem("gendata\\pause.trn", PauseTable);
 
 	for (int j = 0; j < 16; j++) {
 		for (int i = 0; i < 128; i++) {
@@ -788,7 +786,7 @@ void lighting_color_cycling()
 		return;
 	}
 
-	uint8_t *tbl = LightTables.data();
+	uint8_t *tbl = LightTables[0].data();
 
 	for (int j = 0; j < 16; j++) {
 		tbl++;

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -6,6 +6,7 @@
 #include "lighting.h"
 
 #include <algorithm>
+#include <numeric>
 
 #include "automap.h"
 #include "diablo.h"
@@ -438,19 +439,13 @@ void MakeLightTable()
 			*tbl++ = 1;
 		}
 		tbl += 224;
-	}
-	if (IsAnyOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
-		tbl = LightTables[0].data();
-		for (int i = 0; i < lights; i++) {
-			*tbl++ = 0;
-			for (int j = 1; j < 16; j++)
-				*tbl++ = j;
-			tbl += 240;
 		}
-		*tbl++ = 0;
-		for (int j = 1; j < 16; j++)
-			*tbl++ = 1;
-		tbl += 240;
+	} else if (IsAnyOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
+		// Make the lava fully bright
+		for (auto &lightTable : LightTables)
+			std::iota(lightTable.begin(), lightTable.begin() + 16, 0);
+		LightTables[15][0] = 0;
+		std::fill_n(LightTables[15].begin() + 1, 15, 1);
 	}
 
 	LoadFileInMem("plrgfx\\infra.trn", InfravisionTable);

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -21,8 +21,8 @@ namespace devilution {
 
 #define MAXLIGHTS 32
 #define MAXVISION 32
-/** 16 light levels + infravision + stone curse + red for pause/death screen */
-#define LIGHTSIZE (19 * 256)
+/** @brief Number of supported light levels */
+constexpr size_t NumLightingLevels = 16;
 #define NO_LIGHT -1
 
 struct LightPosition {
@@ -50,7 +50,10 @@ extern Light Lights[MAXLIGHTS];
 extern uint8_t ActiveLights[MAXLIGHTS];
 extern int ActiveLightCount;
 constexpr char LightsMax = 15;
-extern std::array<uint8_t, LIGHTSIZE> LightTables;
+extern std::array<std::array<uint8_t, 256>, NumLightingLevels> LightTables;
+extern std::array<uint8_t, 256> InfravisionTable;
+extern std::array<uint8_t, 256> StoneTable;
+extern std::array<uint8_t, 256> PauseTable;
 extern bool DisableLighting;
 extern bool UpdateLighting;
 


### PR DESCRIPTION
There is a slight inefficiency compared to the previous code since it will litterat over all shades because of the range loops, where the old for loop skipped the last shade. However this is during game loading so won't affect performance.

Regarding the fix to the Hell animated blood light table:
![image](https://user-images.githubusercontent.com/204594/233480541-e6015726-f4e8-44a8-b161-2eb654c9f52f.png)
