### PR TITLE
Defer d-pad inputs to movement handlers

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1741,6 +1741,11 @@ bool IsPointAndClick()
 	return PointAndClickState;
 }
 
+bool IsMovementHandlerActive()
+{
+	return GetLeftStickOrDPadGameUIHandler() != nullptr;
+}
+
 void plrctrls_after_check_curs_move()
 {
 	// check for monsters first, then items, then towners.

--- a/Source/controls/plrctrls.h
+++ b/Source/controls/plrctrls.h
@@ -63,6 +63,7 @@ bool InGameMenu();
 void SetPointAndClick(bool value);
 
 bool IsPointAndClick();
+bool IsMovementHandlerActive();
 
 void DetectInputMethod(const SDL_Event &event, const ControllerButtonEvent &gamepadEvent);
 void ProcessGameAction(const GameAction &action);

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1704,6 +1704,8 @@ void PadmapperOptions::ButtonPressed(ControllerButton button)
 	const Action *action = FindAction(button);
 	if (action == nullptr)
 		return;
+	if (IsMovementHandlerActive() && CanDeferToMovementHandler(*action))
+		return;
 	if (action->actionPressed)
 		action->actionPressed();
 	SuppressedButton = action->boundInput.modifier;
@@ -1809,6 +1811,28 @@ const PadmapperOptions::Action *PadmapperOptions::FindAction(ControllerButton bu
 	}
 
 	return nullptr;
+}
+
+bool PadmapperOptions::CanDeferToMovementHandler(const Action &action) const
+{
+	if (action.boundInput.modifier != ControllerButton_NONE)
+		return false;
+
+	if (spselflag) {
+		const string_view prefix { "QuickSpell" };
+		const string_view key { action.key };
+		if (key.size() >= prefix.size()) {
+			const string_view truncated { key.data(), prefix.size() };
+			if (truncated == prefix)
+				return false;
+		}
+	}
+
+	return IsAnyOf(action.boundInput.button,
+	    ControllerButton_BUTTON_DPAD_UP,
+	    ControllerButton_BUTTON_DPAD_DOWN,
+	    ControllerButton_BUTTON_DPAD_LEFT,
+	    ControllerButton_BUTTON_DPAD_RIGHT);
 }
 
 namespace {

--- a/Source/options.h
+++ b/Source/options.h
@@ -778,6 +778,7 @@ private:
 	bool committed = false;
 
 	const Action *FindAction(ControllerButton button) const;
+	bool CanDeferToMovementHandler(const Action &action) const;
 };
 
 struct Options {


### PR DESCRIPTION
Sort of a continuation of #5986

In this case, we want to ignore padmapper actions in favor of movement in menus when the action would have been triggered by the d-pad alone. The only exception to the rule is quick spell actions when the speedbook is open, so that d-pad buttons can still be mapped to spells.