### PR TITLE
Clean up Light structure properties

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1354,7 +1354,7 @@ void UpdateMonsterLights()
 		}
 
 		if (monster.lightId != NO_LIGHT) {
-			if (monster.lightId == MyPlayer->_plid) { // Fix old saves where some monsters had 0 instead of NO_LIGHT
+			if (monster.lightId == MyPlayer->lightId) { // Fix old saves where some monsters had 0 instead of NO_LIGHT
 				monster.lightId = NO_LIGHT;
 				continue;
 			}
@@ -2737,7 +2737,6 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 
 	if (leveltype != DTYPE_TOWN && lvldir != ENTRY_LOAD) {
 		InitLighting();
-		InitVision();
 	}
 
 	InitLevelMonsters();

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2660,7 +2660,7 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 	lrad = clamp(lrad, 2, 15);
 
 	if (player._pLightRad != lrad) {
-		ChangeLightRadius(player._plid, lrad);
+		ChangeLightRadius(player.lightId, lrad);
 		ChangeVisionRadius(player._pvid, lrad);
 		player._pLightRad = lrad;
 	}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2661,7 +2661,7 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 
 	if (player._pLightRad != lrad) {
 		ChangeLightRadius(player.lightId, lrad);
-		ChangeVisionRadius(player._pvid, lrad);
+		ChangeVisionRadius(player.getId(), lrad);
 		player._pLightRad = lrad;
 	}
 

--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -36,7 +36,7 @@ dungeon_type setlvltype;
 Point ViewPosition;
 uint_fast8_t MicroTileLen;
 int8_t TransVal;
-bool TransList[256];
+std::array<bool, 256> TransList;
 uint16_t dPiece[MAXDUNX][MAXDUNY];
 MICROS DPieceMicros[MAXTILES];
 int8_t dTransVal[MAXDUNX][MAXDUNY];
@@ -501,7 +501,7 @@ void SetDungeonMicros()
 void DRLG_InitTrans()
 {
 	memset(dTransVal, 0, sizeof(dTransVal));
-	memset(TransList, 0, sizeof(TransList));
+	TransList = {}; // TODO duplicate reset in InitLighting()
 	TransVal = 1;
 }
 

--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -338,7 +338,12 @@ void InitGlobals()
 	memset(dItem, 0, sizeof(dItem));
 	memset(dObject, 0, sizeof(dObject));
 	memset(dSpecial, 0, sizeof(dSpecial));
-	memset(dLight, DisableLighting || leveltype == DTYPE_TOWN ? 0 : 15, sizeof(dLight));
+	uint8_t defaultLight = leveltype == DTYPE_TOWN ? 0 : 15;
+#ifdef _DEBUG
+	if (DisableLighting)
+		defaultLight = 0;
+#endif
+	memset(dLight, defaultLight, sizeof(dLight));
 
 	DRLG_InitTrans();
 

--- a/Source/levels/gendung.h
+++ b/Source/levels/gendung.h
@@ -186,7 +186,7 @@ extern DVL_API_FOR_TEST Point ViewPosition;
 extern uint_fast8_t MicroTileLen;
 extern int8_t TransVal;
 /** Specifies the active transparency indices. */
-extern bool TransList[256];
+extern std::array<bool, 256> TransList;
 /** Contains the piece IDs of each tile on the map. */
 extern DVL_API_FOR_TEST uint16_t dPiece[MAXDUNX][MAXDUNY];
 /** Map of micros that comprises a full tile for any given dungeon piece. */

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -25,7 +25,9 @@ std::array<std::array<uint8_t, 256>, NumLightingLevels> LightTables;
 std::array<uint8_t, 256> InfravisionTable;
 std::array<uint8_t, 256> StoneTable;
 std::array<uint8_t, 256> PauseTable;
+#ifdef _DEBUG
 bool DisableLighting;
+#endif
 bool UpdateLighting;
 
 namespace {
@@ -463,7 +465,9 @@ void InitLighting()
 	UpdateVision = false;
 	VisionCount = 0;
 	VisionId = 1;
+#ifdef _DEBUG
 	DisableLighting = false;
+#endif
 
 	for (int i = 0; i < MAXLIGHTS; i++) {
 		ActiveLights[i] = i;
@@ -476,8 +480,10 @@ void InitLighting()
 
 int AddLight(Point position, uint8_t radius)
 {
+#ifdef _DEBUG
 	if (DisableLighting)
 		return NO_LIGHT;
+#endif
 	if (ActiveLightCount >= MAXLIGHTS)
 		return NO_LIGHT;
 
@@ -496,9 +502,12 @@ int AddLight(Point position, uint8_t radius)
 
 void AddUnLight(int i)
 {
-	if (DisableLighting || i == NO_LIGHT) {
+#ifdef _DEBUG
+	if (DisableLighting)
 		return;
-	}
+#endif
+	if (i == NO_LIGHT)
+		return;
 
 	Lights[i].isInvalid = true;
 
@@ -507,9 +516,12 @@ void AddUnLight(int i)
 
 void ChangeLightRadius(int i, uint8_t radius)
 {
-	if (DisableLighting || i == NO_LIGHT) {
+#ifdef _DEBUG
+	if (DisableLighting)
 		return;
-	}
+#endif
+	if (i == NO_LIGHT)
+		return;
 
 	Light &light = Lights[i];
 	light.hasChanged = true;
@@ -522,9 +534,12 @@ void ChangeLightRadius(int i, uint8_t radius)
 
 void ChangeLightXY(int i, Point position)
 {
-	if (DisableLighting || i == NO_LIGHT) {
+#ifdef _DEBUG
+	if (DisableLighting)
 		return;
-	}
+#endif
+	if (i == NO_LIGHT)
+		return;
 
 	Light &light = Lights[i];
 	light.hasChanged = true;
@@ -537,9 +552,12 @@ void ChangeLightXY(int i, Point position)
 
 void ChangeLightOffset(int i, Displacement offset)
 {
-	if (DisableLighting || i == NO_LIGHT) {
+#ifdef _DEBUG
+	if (DisableLighting)
 		return;
-	}
+#endif
+	if (i == NO_LIGHT)
+		return;
 
 	Light &light = Lights[i];
 	light.hasChanged = true;
@@ -552,9 +570,12 @@ void ChangeLightOffset(int i, Displacement offset)
 
 void ChangeLight(int i, Point position, uint8_t radius)
 {
-	if (DisableLighting || i == NO_LIGHT) {
+#ifdef _DEBUG
+	if (DisableLighting)
 		return;
-	}
+#endif
+	if (i == NO_LIGHT)
+		return;
 
 	Light &light = Lights[i];
 	light.hasChanged = true;
@@ -568,8 +589,10 @@ void ChangeLight(int i, Point position, uint8_t radius)
 
 void ProcessLightList()
 {
+#ifdef _DEBUG
 	if (DisableLighting)
 		return;
+#endif
 	if (!UpdateLighting)
 		return;
 	for (int i = 0; i < ActiveLightCount; i++) {

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -26,20 +26,20 @@ constexpr size_t NumLightingLevels = 16;
 #define NO_LIGHT -1
 
 struct LightPosition {
-	Point tile;
+	WorldTilePosition tile;
 	/** Pixel offset from tile. */
-	Displacement offset;
+	DisplacementOf<int8_t> offset;
 	/** Prevous position. */
-	Point old;
+	WorldTilePosition old;
 };
 
 struct Light {
 	LightPosition position;
-	int _lradius;
+	uint8_t radius;
+	uint8_t oldRadius;
+	bool isInvalid;
+	bool hasChanged;
 	int _lid;
-	bool _ldel;
-	bool _lunflag;
-	int oldRadius;
 	bool _lflags;
 };
 
@@ -57,23 +57,22 @@ extern std::array<uint8_t, 256> PauseTable;
 extern bool DisableLighting;
 extern bool UpdateLighting;
 
-void DoLighting(Point position, int nRadius, int Lnum);
-void DoUnVision(Point position, int nRadius);
-void DoVision(Point position, int radius, MapExplorationType doAutomap, bool visible);
+void DoLighting(Point position, uint8_t radius, int Lnum);
+void DoUnVision(Point position, uint8_t radius);
+void DoVision(Point position, uint8_t radius, MapExplorationType doAutomap, bool visible);
 void MakeLightTable();
 #ifdef _DEBUG
 void ToggleLighting();
 #endif
 void InitLighting();
-int AddLight(Point position, int r);
+int AddLight(Point position, uint8_t radius);
 void AddUnLight(int i);
-void ChangeLightRadius(int i, int r);
+void ChangeLightRadius(int i, uint8_t radius);
 void ChangeLightXY(int i, Point position);
 void ChangeLightOffset(int i, Displacement offset);
-void ChangeLight(int i, Point position, int r);
+void ChangeLight(int i, Point position, uint8_t radius);
 void ProcessLightList();
 void SavePreLighting();
-void InitVision();
 int AddVision(Point position, int r, bool mine);
 void ChangeVisionRadius(int id, int r);
 void ChangeVisionXY(int id, Point position);

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -54,7 +54,9 @@ extern std::array<std::array<uint8_t, 256>, NumLightingLevels> LightTables;
 extern std::array<uint8_t, 256> InfravisionTable;
 extern std::array<uint8_t, 256> StoneTable;
 extern std::array<uint8_t, 256> PauseTable;
+#ifdef _DEBUG
 extern bool DisableLighting;
+#endif
 extern bool UpdateLighting;
 
 void DoLighting(Point position, uint8_t radius, int Lnum);

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -20,7 +20,7 @@
 namespace devilution {
 
 #define MAXLIGHTS 32
-#define MAXVISION 32
+#define MAXVISION 4
 /** @brief Number of supported light levels */
 constexpr size_t NumLightingLevels = 16;
 #define NO_LIGHT -1
@@ -39,15 +39,12 @@ struct Light {
 	uint8_t oldRadius;
 	bool isInvalid;
 	bool hasChanged;
-	int _lid;
-	bool _lflags;
 };
 
 extern Light VisionList[MAXVISION];
-extern int VisionCount;
-extern int VisionId;
+extern std::array<bool, MAXVISION> VisionActive;
 extern Light Lights[MAXLIGHTS];
-extern uint8_t ActiveLights[MAXLIGHTS];
+extern std::array<uint8_t, MAXLIGHTS> ActiveLights;
 extern int ActiveLightCount;
 constexpr char LightsMax = 15;
 extern std::array<std::array<uint8_t, 256>, NumLightingLevels> LightTables;
@@ -75,7 +72,7 @@ void ChangeLightOffset(int i, Displacement offset);
 void ChangeLight(int i, Point position, uint8_t radius);
 void ProcessLightList();
 void SavePreLighting();
-int AddVision(Point position, int r, bool mine);
+void ActivateVision(Point position, int r, int id);
 void ChangeVisionRadius(int id, int r);
 void ChangeVisionXY(int id, Point position);
 void ProcessVisionList();

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -355,7 +355,7 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	player.AnimInfo.numberOfFrames = file.NextLENarrow<int32_t, int8_t>();
 	player.AnimInfo.currentFrame = file.NextLENarrow<int32_t, int8_t>(-1);
 	file.Skip<uint32_t>(3); // Skip _pAnimWidth, _pAnimWidth2, _peflag
-	player._plid = file.NextLE<int32_t>();
+	player.lightId = file.NextLE<int32_t>();
 	player._pvid = file.NextLE<int32_t>();
 
 	player.queuedSpell.spellId = static_cast<SpellID>(file.NextLE<int32_t>());
@@ -870,10 +870,10 @@ void LoadLighting(LoadHelper *file, Light *pLight)
 {
 	pLight->position.tile.x = file->NextLE<int32_t>();
 	pLight->position.tile.y = file->NextLE<int32_t>();
-	pLight->_lradius = file->NextLE<int32_t>();
+	pLight->radius = file->NextLE<int32_t>();
 	pLight->_lid = file->NextLE<int32_t>();
-	pLight->_ldel = file->NextBool32();
-	pLight->_lunflag = file->NextBool32();
+	pLight->isInvalid = file->NextBool32();
+	pLight->hasChanged = file->NextBool32();
 	file->Skip(4); // Unused
 	pLight->position.old.x = file->NextLE<int32_t>();
 	pLight->position.old.y = file->NextLE<int32_t>();
@@ -1133,7 +1133,7 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	// write _pAnimWidth2 for vanilla compatibility
 	file.WriteLE<int32_t>(CalculateWidth2(animWidth));
 	file.Skip<uint32_t>(); // Skip _peflag
-	file.WriteLE<int32_t>(player._plid);
+	file.WriteLE<int32_t>(player.lightId);
 	file.WriteLE<int32_t>(player._pvid);
 
 	file.WriteLE<int32_t>(static_cast<int8_t>(player.queuedSpell.spellId));
@@ -1614,10 +1614,10 @@ void SaveLighting(SaveHelper *file, Light *pLight)
 {
 	file->WriteLE<int32_t>(pLight->position.tile.x);
 	file->WriteLE<int32_t>(pLight->position.tile.y);
-	file->WriteLE<int32_t>(pLight->_lradius);
+	file->WriteLE<int32_t>(pLight->radius);
 	file->WriteLE<int32_t>(pLight->_lid);
-	file->WriteLE<uint32_t>(pLight->_ldel ? 1 : 0);
-	file->WriteLE<uint32_t>(pLight->_lunflag ? 1 : 0);
+	file->WriteLE<uint32_t>(pLight->isInvalid ? 1 : 0);
+	file->WriteLE<uint32_t>(pLight->hasChanged ? 1 : 0);
 	file->Skip(4); // Unused
 	file->WriteLE<int32_t>(pLight->position.old.x);
 	file->WriteLE<int32_t>(pLight->position.old.y);
@@ -2654,7 +2654,7 @@ void LoadLevel()
 
 	for (Player &player : Players) {
 		if (player.plractive && player.isOnActiveLevel())
-			Lights[player._plid]._lunflag = true;
+			Lights[player.lightId].hasChanged = true;
 	}
 }
 

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2227,11 +2227,12 @@ void LoadGame(bool firstflag)
 	AutomapZoomReset();
 	ResyncQuests();
 
-	if (leveltype != DTYPE_TOWN)
+	if (leveltype != DTYPE_TOWN) {
+		RedoPlayerVision();
+		ProcessVisionList();
 		ProcessLightList();
+	}
 
-	RedoPlayerVision();
-	ProcessVisionList();
 	// convert stray manashield missiles into pManaShield flag
 	for (auto &missile : Missiles) {
 		if (missile._mitype == MissileID::ManaShield && !missile._miDelFlag) {

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3622,7 +3622,7 @@ void ProcessTeleport(Missile &missile)
 	missile.var1 = 1;
 	dPlayer[player.position.tile.x][player.position.tile.y] = id + 1;
 	if (leveltype != DTYPE_TOWN) {
-		ChangeLightXY(player._plid, player.position.tile);
+		ChangeLightXY(player.lightId, player.position.tile);
 		ChangeVisionXY(player._pvid, player.position.tile);
 	}
 	if (&player == MyPlayer) {

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3623,7 +3623,7 @@ void ProcessTeleport(Missile &missile)
 	dPlayer[player.position.tile.x][player.position.tile.y] = id + 1;
 	if (leveltype != DTYPE_TOWN) {
 		ChangeLightXY(player.lightId, player.position.tile);
-		ChangeVisionXY(player._pvid, player.position.tile);
+		ChangeVisionXY(player.getId(), player.position.tile);
 	}
 	if (&player == MyPlayer) {
 		ViewPosition = player.position.tile;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2117,7 +2117,7 @@ size_t OnPlayerJoinLevel(const TCmd *pCmd, size_t pnum)
 				dFlags[player.position.tile.x][player.position.tile.y] |= DungeonFlag::DeadPlayer;
 			}
 
-			player._pvid = AddVision(player.position.tile, player._pLightRad, &player == MyPlayer);
+			ActivateVision(player.position.tile, player._pLightRad, player.getId());
 		}
 	}
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4315,7 +4315,7 @@ void RedoPlayerVision()
 {
 	for (const Player &player : Players) {
 		if (player.plractive && player.isOnActiveLevel()) {
-			ChangeVisionXY(player._pvid, player.position.tile);
+			ChangeVisionXY(player.getId(), player.position.tile);
 		}
 	}
 }

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1529,28 +1529,35 @@ void AddMushPatch()
 	}
 }
 
+bool IsLightVisible(Object &light, int lightRadius)
+{
+#ifdef _DEBUG
+	if (!DisableLighting)
+		return false;
+#endif
+
+	for (const Player &player : Players) {
+		if (!player.plractive)
+			continue;
+
+		if (!player.isOnActiveLevel())
+			continue;
+
+		if (player.position.tile.WalkingDistance(light.position) < lightRadius + 10) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void UpdateObjectLight(Object &light, int lightRadius)
 {
 	if (light._oVar1 == -1) {
 		return;
 	}
 
-	bool turnon = false;
-	if (!DisableLighting) {
-		for (const Player &player : Players) {
-			if (!player.plractive)
-				continue;
-
-			if (!player.isOnActiveLevel())
-				continue;
-
-			if (player.position.tile.WalkingDistance(light.position) < lightRadius + 10) {
-				turnon = true;
-				break;
-			}
-		}
-	}
-	if (turnon) {
+	if (IsLightVisible(light, lightRadius)) {
 		if (light._oVar1 == 0)
 			light._olid = AddLight(light.position, lightRadius);
 		light._oVar1 = 1;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -76,10 +76,10 @@ struct DirectionSettings {
 
 void PmChangeLightOff(Player &player)
 {
-	if (player._plid == NO_LIGHT)
+	if (player.lightId == NO_LIGHT)
 		return;
 
-	const Light *l = &Lights[player._plid];
+	const Light *l = &Lights[player.lightId];
 	WorldTileDisplacement offset = player.position.CalculateWalkingOffset(player._pdir, player.AnimInfo);
 	int x = 2 * offset.deltaY + offset.deltaX;
 	int y = 2 * offset.deltaY - offset.deltaX;
@@ -94,7 +94,7 @@ void PmChangeLightOff(Player &player)
 	if (abs(lx - offx) < 3 && abs(ly - offy) < 3)
 		return;
 
-	ChangeLightOffset(player._plid, { x, y });
+	ChangeLightOffset(player.lightId, { x, y });
 }
 
 void WalkNorthwards(Player &player, const DirectionSettings &walkParams)
@@ -111,7 +111,7 @@ void WalkSouthwards(Player &player, const DirectionSettings & /*walkParams*/)
 	player.position.tile = player.position.future; // Move player to the next tile to maintain correct render order
 	dPlayer[player.position.tile.x][player.position.tile.y] = playerId + 1;
 	// BUGFIX: missing `if (leveltype != DTYPE_TOWN) {` for call to ChangeLightXY and PM_ChangeLightOff.
-	ChangeLightXY(player._plid, player.position.tile);
+	ChangeLightXY(player.lightId, player.position.tile);
 	PmChangeLightOff(player);
 }
 
@@ -124,7 +124,7 @@ void WalkSideways(Player &player, const DirectionSettings &walkParams)
 	dPlayer[player.position.future.x][player.position.future.y] = playerId + 1;
 
 	if (leveltype != DTYPE_TOWN) {
-		ChangeLightXY(player._plid, nextPosition);
+		ChangeLightXY(player.lightId, nextPosition);
 		PmChangeLightOff(player);
 	}
 
@@ -505,7 +505,7 @@ bool DoWalk(Player &player, int variant)
 
 	// Update the coordinates for lighting and vision entries for the player
 	if (leveltype != DTYPE_TOWN) {
-		ChangeLightXY(player._plid, player.position.tile);
+		ChangeLightXY(player.lightId, player.position.tile);
 		ChangeVisionXY(player._pvid, player.position.tile);
 	}
 
@@ -519,7 +519,7 @@ bool DoWalk(Player &player, int variant)
 
 	// Reset the "sub-tile" position of the player's light entry to 0
 	if (leveltype != DTYPE_TOWN) {
-		ChangeLightOffset(player._plid, { 0, 0 });
+		ChangeLightOffset(player.lightId, { 0, 0 });
 	}
 
 	AutoPickup(player);
@@ -2576,10 +2576,10 @@ void InitPlayer(Player &player, bool firstTime)
 		player.destAction = ACTION_NONE;
 
 		if (&player == MyPlayer) {
-			player._plid = AddLight(player.position.tile, player._pLightRad);
-			ChangeLightXY(player._plid, player.position.tile); // fix for a bug where old light is still visible at the entrance after reentering level
+			player.lightId = AddLight(player.position.tile, player._pLightRad);
+			ChangeLightXY(player.lightId, player.position.tile); // fix for a bug where old light is still visible at the entrance after reentering level
 		} else {
-			player._plid = NO_LIGHT;
+			player.lightId = NO_LIGHT;
 		}
 		player._pvid = AddVision(player.position.tile, player._pLightRad, &player == MyPlayer);
 	}
@@ -2638,7 +2638,7 @@ void FixPlayerLocation(Player &player, Direction bDir)
 	if (&player == MyPlayer) {
 		ViewPosition = player.position.tile;
 	}
-	ChangeLightXY(player._plid, player.position.tile);
+	ChangeLightXY(player.lightId, player.position.tile);
 	ChangeVisionXY(player._pvid, player.position.tile);
 }
 
@@ -3335,7 +3335,7 @@ void SyncInitPlr(Player &player)
 	SetPlrAnims(player);
 	SyncInitPlrPos(player);
 	if (&player != MyPlayer)
-		player._plid = NO_LIGHT;
+		player.lightId = NO_LIGHT;
 }
 
 void CheckStats(Player &player)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -506,7 +506,7 @@ bool DoWalk(Player &player, int variant)
 	// Update the coordinates for lighting and vision entries for the player
 	if (leveltype != DTYPE_TOWN) {
 		ChangeLightXY(player.lightId, player.position.tile);
-		ChangeVisionXY(player._pvid, player.position.tile);
+		ChangeVisionXY(player.getId(), player.position.tile);
 	}
 
 	if (player.walkpath[0] != WALK_NONE) {
@@ -2581,7 +2581,7 @@ void InitPlayer(Player &player, bool firstTime)
 		} else {
 			player.lightId = NO_LIGHT;
 		}
-		player._pvid = AddVision(player.position.tile, player._pLightRad, &player == MyPlayer);
+		ActivateVision(player.position.tile, player._pLightRad, player.getId());
 	}
 
 	SpellID s = PlayersData[static_cast<size_t>(player._pClass)].skill;
@@ -2639,7 +2639,7 @@ void FixPlayerLocation(Player &player, Direction bDir)
 		ViewPosition = player.position.tile;
 	}
 	ChangeLightXY(player.lightId, player.position.tile);
-	ChangeVisionXY(player._pvid, player.position.tile);
+	ChangeVisionXY(player.getId(), player.position.tile);
 }
 
 void StartStand(Player &player, Direction dir)

--- a/Source/player.h
+++ b/Source/player.h
@@ -237,7 +237,6 @@ struct Player {
 	Item HoldItem;
 
 	int lightId;
-	int _pvid;
 
 	int _pNumInv;
 	int _pStrength;

--- a/Source/player.h
+++ b/Source/player.h
@@ -236,7 +236,7 @@ struct Player {
 	Item SpdList[MaxBeltItems];
 	Item HoldItem;
 
-	int _plid;
+	int lightId;
 	int _pvid;
 
 	int _pNumInv;

--- a/test/fixtures/memory_map/lightning.txt
+++ b/test/fixtures/memory_map/lightning.txt
@@ -1,9 +1,9 @@
 R 32 positionX
 R 32 positionY
-R 32 _lradius
+R 32 radius
 R 32 _lid
-R 32 _ldel
-R 32 _lunflag
+R 32 isInvalid
+R 32 hasChanged
 R 32 unused
 R 32 oldX
 R 32 oldY

--- a/test/fixtures/memory_map/player.txt
+++ b/test/fixtures/memory_map/player.txt
@@ -33,7 +33,7 @@ R 32 currentFrame
 R 32 _pAnimWidth
 R 32 _pAnimWidth2
 R 32 _peflag
-R 32 _plid
+R 32 lightId
 R 32 _pvid
 R 32 _pSpell
 R 8 _pSplType


### PR DESCRIPTION
Vision will never grow to more then 4, since there is only 4 players... so why have a list of 32 of them.

Also optimize the Light struct.

All the changes to data structures should save us about 3KB ram, but there should also be some savings in terms of runtime processing and less code generation.

Use `Rectangle` logic in `DoUnLight()` and `DoUnVision()`, and take a `Point` as an input.

Use early return to avoid indentation of the function body (so probably view with "ignore white-space").

Remove `DisableLighting` from release builds.