### PR TITLE
Clean up ProcessLightsList()

### DIFF
--- a/Source/levels/drlg_l3.cpp
+++ b/Source/levels/drlg_l3.cpp
@@ -2150,11 +2150,11 @@ void PlaceCaveLights()
 	for (int j = 0; j < MAXDUNY; j++) {
 		for (int i = 0; i < MAXDUNX; i++) {
 			if (dPiece[i][j] >= 55 && dPiece[i][j] <= 146) {
-				DoLighting({ i, j }, 7, -1);
+				DoLighting({ i, j }, 7, {});
 			} else if (dPiece[i][j] >= 153 && dPiece[i][j] <= 160) {
-				DoLighting({ i, j }, 7, -1);
+				DoLighting({ i, j }, 7, {});
 			} else if (IsAnyOf(dPiece[i][j], 149, 151)) {
-				DoLighting({ i, j }, 7, -1);
+				DoLighting({ i, j }, 7, {});
 			}
 		}
 	}
@@ -2166,7 +2166,7 @@ void PlaceHiveLights()
 	for (int j = 0; j < MAXDUNY; j++) {
 		for (int i = 0; i < MAXDUNX; i++) {
 			if (dPiece[i][j] >= 381 && dPiece[i][j] <= 456) {
-				DoLighting({ i, j }, 9, -1);
+				DoLighting({ i, j }, 9, {});
 			}
 		}
 	}

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -56,7 +56,7 @@ extern bool DisableLighting;
 #endif
 extern bool UpdateLighting;
 
-void DoLighting(Point position, uint8_t radius, int Lnum);
+void DoLighting(Point position, uint8_t radius, DisplacementOf<int8_t> offset);
 void DoUnVision(Point position, uint8_t radius);
 void DoVision(Point position, uint8_t radius, MapExplorationType doAutomap, bool visible);
 void MakeLightTable();

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1348,7 +1348,7 @@ void AddTrap(Object &trap)
 void AddObjectLight(Object &object, int r)
 {
 	if (ApplyObjectLighting) {
-		DoLighting(object.position, r, -1);
+		DoLighting(object.position, r, {});
 		object._oVar1 = -1;
 	} else {
 		object._oVar1 = 0;


### PR DESCRIPTION
This should be the last of the lighting cleanups. This merges the updating of lights in to a single loop that both frees expired lights reapplies the rest.

Use Displacements by reference instead of int pointers in `RotateRadius()`.

Remove use of the `Lights` global from inside `DoLighting()` which makes the call to it less confusing.