### PR TITLE
Fix lighting on quest maps

### DIFF
--- a/Source/levels/themes.cpp
+++ b/Source/levels/themes.cpp
@@ -913,7 +913,6 @@ void CreateThemeRooms()
 		return;
 	}
 
-	ApplyObjectLighting = true;
 	for (int i = 0; i < numthemes; i++) {
 		themex = 0;
 		themey = 0;
@@ -973,7 +972,6 @@ void CreateThemeRooms()
 			app_fatal(StrCat("Unknown theme type: ", static_cast<int>(themes[i].ttype)));
 		}
 	}
-	ApplyObjectLighting = false;
 	if (leveltype == DTYPE_HELL && themeCount > 0) {
 		UpdateL4Trans();
 	}

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -241,8 +241,9 @@ void DoLighting(Point position, uint8_t radius, DisplacementOf<int8_t> offset)
 
 	// Allow for dim lights in crypt and nest
 	if (IsAnyOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
-		SetLight(position, LightFalloffs[radius][0]);
-	} else if (GetLight(position) > LightFalloffs[radius][0]) {
+		if (GetLight(position) > LightFalloffs[radius][0])
+			SetLight(position, LightFalloffs[radius][0]);
+	} else {
 		SetLight(position, 0);
 	}
 

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -578,6 +578,8 @@ void ProcessLightList()
 			i--;
 			continue;
 		}
+		if (TileHasAny(dPiece[light.position.tile.x][light.position.tile.y], TileProperties::Solid))
+			continue; // Monster hidden in a wall, don't spoil the surprise
 		DoLighting(light.position.tile, light.radius, light.position.offset);
 	}
 

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -109,19 +109,6 @@ uint8_t GetLight(Point position)
 	return dLight[position.x][position.y];
 }
 
-void DoUnLight(Point position, uint8_t radius)
-{
-	radius++;
-	radius++; // If lights moved at a diagonal it can result in some extra tiles being lit
-
-	auto searchArea = PointsInRectangle(WorldTileRectangle { position, radius });
-
-	for (WorldTilePosition targetPosition : searchArea) {
-		if (InDungeonBounds(targetPosition))
-			dLight[targetPosition.x][targetPosition.y] = dPreLight[targetPosition.x][targetPosition.y];
-	}
-}
-
 bool CrawlFlipsX(Displacement mirrored, tl::function_ref<bool(Displacement)> function)
 {
 	for (const Displacement displacement : { mirrored.flipX(), mirrored }) {
@@ -201,6 +188,19 @@ bool DoCrawl(unsigned minRadius, unsigned maxRadius, tl::function_ref<bool(Displ
 			return false;
 	}
 	return true;
+}
+
+void DoUnLight(Point position, uint8_t radius)
+{
+	radius++;
+	radius++; // If lights moved at a diagonal it can result in some extra tiles being lit
+
+	auto searchArea = PointsInRectangle(WorldTileRectangle { position, radius });
+
+	for (WorldTilePosition targetPosition : searchArea) {
+		if (InDungeonBounds(targetPosition))
+			dLight[targetPosition.x][targetPosition.y] = dPreLight[targetPosition.x][targetPosition.y];
+	}
 }
 
 void DoLighting(Point position, uint8_t radius, DisplacementOf<int8_t> offset)

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -56,6 +56,7 @@ extern bool DisableLighting;
 #endif
 extern bool UpdateLighting;
 
+void DoUnLight(Point position, uint8_t radius);
 void DoLighting(Point position, uint8_t radius, DisplacementOf<int8_t> offset);
 void DoUnVision(Point position, uint8_t radius);
 void DoVision(Point position, uint8_t radius, MapExplorationType doAutomap, bool visible);

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1370,6 +1370,10 @@ void AddObjectLight(Object &object)
 	}
 
 	DoLighting(object.position, radius, {});
+	if (LoadingMapObjects) {
+		DoUnLight(object.position, radius);
+		UpdateLighting = true;
+	}
 	object._oVar1 = -1;
 }
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1342,9 +1342,34 @@ void AddTrap(Object &trap)
 	trap._oVar4 = 0;
 }
 
-void AddObjectLight(Object &object, int r)
+void AddObjectLight(Object &object)
 {
-	DoLighting(object.position, r, {});
+	int radius;
+	switch (object._otype) {
+	case OBJ_STORYCANDLE:
+	case OBJ_L5CANDLE:
+		radius = 3;
+		break;
+	case OBJ_L1LIGHT:
+	case OBJ_SKFIRE:
+	case OBJ_CANDLE1:
+	case OBJ_CANDLE2:
+	case OBJ_BOOKCANDLE:
+	case OBJ_BCROSS:
+	case OBJ_TBCROSS:
+		radius = 5;
+		break;
+	case OBJ_TORCHL:
+	case OBJ_TORCHR:
+	case OBJ_TORCHL2:
+	case OBJ_TORCHR2:
+		radius = 8;
+		break;
+	default:
+		return;
+	}
+
+	DoLighting(object.position, radius, {});
 	object._oVar1 = -1;
 }
 
@@ -4016,23 +4041,6 @@ Object *AddObject(_object_id objType, Point objPos)
 	Object &object = Objects[oi];
 	SetupObject(object, objPos, objType);
 	switch (object._otype) {
-	case OBJ_L1LIGHT:
-	case OBJ_SKFIRE:
-	case OBJ_CANDLE1:
-	case OBJ_CANDLE2:
-	case OBJ_BOOKCANDLE:
-		AddObjectLight(object, 5);
-		break;
-	case OBJ_STORYCANDLE:
-	case OBJ_L5CANDLE:
-		AddObjectLight(object, 3);
-		break;
-	case OBJ_TORCHL:
-	case OBJ_TORCHR:
-	case OBJ_TORCHL2:
-	case OBJ_TORCHR2:
-		AddObjectLight(object, 8);
-		break;
 	case OBJ_L1LDOOR:
 	case OBJ_L1RDOOR:
 	case OBJ_L2LDOOR:
@@ -4129,7 +4137,6 @@ Object *AddObject(_object_id objType, Point objPos)
 	case OBJ_BCROSS:
 	case OBJ_TBCROSS:
 		object._oRndSeed = AdvanceRndSeed();
-		AddObjectLight(object, 5);
 		break;
 	case OBJ_PEDESTAL:
 		AddPedestalOfBlood(object);
@@ -4144,6 +4151,9 @@ Object *AddObject(_object_id objType, Point objPos)
 	default:
 		break;
 	}
+
+	AddObjectLight(object);
+
 	ActiveObjectCount++;
 	return &object;
 }

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -258,7 +258,7 @@ extern DVL_API_FOR_TEST Object Objects[MAXOBJECTS];
 extern int AvailableObjects[MAXOBJECTS];
 extern int ActiveObjects[MAXOBJECTS];
 extern int ActiveObjectCount;
-extern bool ApplyObjectLighting;
+/** @brief Indicates that objects are being loaded during gameplay and pre calculated data should be updated. */
 extern bool LoadingMapObjects;
 
 /**

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -604,6 +604,8 @@ void ResyncQuests()
 	if (gbIsSpawn)
 		return;
 
+	LoadingMapObjects = true;
+
 	if (Quests[Q_LTBANNER].IsAvailable()) {
 		Monster *snotSpill = FindUniqueMonster(UniqueMonsterType::SnotSpill);
 		if (Quests[Q_LTBANNER]._qvar1 == 1) {
@@ -787,6 +789,8 @@ void ResyncQuests()
 			}
 		}
 	}
+
+	LoadingMapObjects = false;
 }
 
 void DrawQuestLog(const Surface &out)


### PR DESCRIPTION
This fixes lights being visibly off at a distance and turning on when getting closer.
(If you resolution is high enough to see past the normal render distance)
It also provides a performance boost since these lights no longer have to be updated each frame.
This removes the need for `ApplyObjectLighting` as lighting should always be applied to objects.

Also applies a fix for Lazarus and his minions glowing inside the wall:
![image](https://user-images.githubusercontent.com/204594/233816470-8b8752a7-01eb-4756-a7cd-7e6104f4e717.png)

fixes https://github.com/diasurgical/devilutionX/issues/6028