### PR TITLE
Sync learned/changed spells

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -92,7 +92,7 @@ uint32_t glMid2Seed[NUMLEVELS];
 uint32_t glMid3Seed[NUMLEVELS];
 uint32_t glEndSeed[NUMLEVELS];
 
-void SetSpellLevelCheat(SpellID spl, int spllvl)
+void SetSpellLevelCheat(SpellID spl, uint8_t spllvl)
 {
 	Player &myPlayer = *MyPlayer;
 
@@ -529,7 +529,7 @@ std::string DebugCmdMinStats(const string_view parameter)
 
 std::string DebugCmdSetSpellsLevel(const string_view parameter)
 {
-	int level = std::max(0, atoi(parameter.data()));
+	uint8_t level = static_cast<uint8_t>(std::max(0, atoi(parameter.data())));
 	for (int i = static_cast<int8_t>(SpellID::Firebolt); i < MAX_SPELLS; i++) {
 		if (GetSpellBookLevel(static_cast<SpellID>(i)) != -1) {
 			SetSpellLevelCheat(static_cast<SpellID>(i), level);

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -92,14 +92,6 @@ uint32_t glMid2Seed[NUMLEVELS];
 uint32_t glMid3Seed[NUMLEVELS];
 uint32_t glEndSeed[NUMLEVELS];
 
-void SetSpellLevelCheat(SpellID spl, uint8_t spllvl)
-{
-	Player &myPlayer = *MyPlayer;
-
-	myPlayer._pMemSpells |= GetSpellBitmask(spl);
-	myPlayer._pSplLvl[static_cast<int8_t>(spl)] = spllvl;
-}
-
 void PrintDebugMonster(const Monster &monster)
 {
 	EventPlrMsg(StrCat(
@@ -530,9 +522,9 @@ std::string DebugCmdMinStats(const string_view parameter)
 std::string DebugCmdSetSpellsLevel(const string_view parameter)
 {
 	uint8_t level = static_cast<uint8_t>(std::max(0, atoi(parameter.data())));
-	for (int i = static_cast<int8_t>(SpellID::Firebolt); i < MAX_SPELLS; i++) {
+	for (uint8_t i = static_cast<uint8_t>(SpellID::Firebolt); i < MAX_SPELLS; i++) {
 		if (GetSpellBookLevel(static_cast<SpellID>(i)) != -1) {
-			SetSpellLevelCheat(static_cast<SpellID>(i), level);
+			NetSendCmdParam2(true, CMD_CHANGE_SPELL_LEVEL, i, level);
 		}
 	}
 	if (level == 0)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4052,10 +4052,10 @@ void UseItem(size_t pnum, item_misc_id mid, SpellID spellID, int spellFrom)
 			NetSendCmdLocParam4(true, CMD_SPELLXY, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(SpellType::Scroll), spellLevel, static_cast<uint16_t>(spellFrom));
 		}
 		break;
-	case IMISC_BOOK:
-		player._pMemSpells |= GetSpellBitmask(spellID);
-		if (player._pSplLvl[static_cast<int8_t>(spellID)] < MaxSpellLevel)
-			player._pSplLvl[static_cast<int8_t>(spellID)]++;
+	case IMISC_BOOK: {
+		uint8_t newSpellLevel = player._pSplLvl[static_cast<int8_t>(spellID)] + 1;
+		if (newSpellLevel <= MaxSpellLevel)
+			NetSendCmdParam2(true, CMD_CHANGE_SPELL_LEVEL, static_cast<uint16_t>(spellID), newSpellLevel);
 		if (HasNoneOf(player._pIFlags, ItemSpecialEffect::NoMana)) {
 			player._pMana += GetSpellData(spellID).sManaCost << 6;
 			player._pMana = std::min(player._pMana, player._pMaxMana);
@@ -4071,7 +4071,7 @@ void UseItem(size_t pnum, item_misc_id mid, SpellID spellID, int spellFrom)
 			}
 		}
 		RedrawComponent(PanelDrawComponent::Mana);
-		break;
+	} break;
 	case IMISC_MAPOFDOOM:
 		doom_init();
 		break;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -374,8 +374,8 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	file.Skip(3); // Alignment
 	player._pSBkSpell = static_cast<SpellID>(file.NextLE<int32_t>());
 	file.Skip<int8_t>(); // Skip _pSBkSplType
-	for (int8_t &spellLevel : player._pSplLvl)
-		spellLevel = file.NextLE<int8_t>();
+	for (uint8_t &spellLevel : player._pSplLvl)
+		spellLevel = file.NextLE<uint8_t>();
 	file.Skip(7); // Alignment
 	player._pMemSpells = file.NextLE<uint64_t>();
 	player._pAblSpells = file.NextLE<uint64_t>();
@@ -1149,8 +1149,8 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.WriteLE<int32_t>(static_cast<int8_t>(player._pSBkSpell));
 	file.Skip<int8_t>(); // Skip _pSBkSplType
 
-	for (int8_t spellLevel : player._pSplLvl)
-		file.WriteLE<int8_t>(spellLevel);
+	for (uint8_t spellLevel : player._pSplLvl)
+		file.WriteLE<uint8_t>(spellLevel);
 
 	file.Skip(7); // Alignment
 	file.WriteLE<uint64_t>(player._pMemSpells);

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -178,10 +178,12 @@ enum _cmd_id : uint8_t {
 	//
 	// body (TCmd)
 	CMD_CHEAT_EXPERIENCE,
-	// Cheat: increase active spell level of player.
+	// Change spell level of player.
 	//
-	// body (TCmd)
-	CMD_CHEAT_SPELL_LEVEL,
+	// body (TCmdParam2)
+	//    int16_t spellID
+	//    int16_t spellLevel
+	CMD_CHANGE_SPELL_LEVEL,
 	// Debug command (nop).
 	//
 	// body (TCmd)

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -52,7 +52,7 @@ struct PlayerPack {
 	int32_t pMaxHPBase;
 	int32_t pManaBase;
 	int32_t pMaxManaBase;
-	int8_t pSplLvl[37]; // Should be MAX_SPELLS but set to 37 to make save games compatible
+	uint8_t pSplLvl[37]; // Should be MAX_SPELLS but set to 37 to make save games compatible
 	uint64_t pMemSpells;
 	ItemPack InvBody[NUM_INVLOC];
 	ItemPack InvList[InventoryGridCells];
@@ -69,9 +69,9 @@ struct PlayerPack {
 	int8_t bIsHellfire;
 	int8_t bReserved; // For future use
 	uint16_t wReflections;
-	int16_t wReserved2;  // For future use
-	int8_t pSplLvl2[10]; // Hellfire spells
-	int16_t wReserved8;  // For future use
+	int16_t wReserved2;   // For future use
+	uint8_t pSplLvl2[10]; // Hellfire spells
+	int16_t wReserved8;   // For future use
 	uint32_t pDiabloKillLevel;
 	uint32_t pDifficulty;
 	uint32_t pDamAcFlags; // `ItemSpecialEffectHf` is 1 byte but this is 4 bytes.

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1825,7 +1825,7 @@ bool Player::isWalking() const
 
 int Player::GetManaShieldDamageReduction()
 {
-	constexpr int8_t Max = 7;
+	constexpr uint8_t Max = 7;
 	return 24 - std::min(_pSplLvl[static_cast<int8_t>(SpellID::ManaShield)], Max) * 3;
 }
 
@@ -2357,7 +2357,7 @@ void CreatePlayer(Player &player, HeroClass c)
 		player._pMemSpells = 0;
 	}
 
-	for (int8_t &spellLevel : player._pSplLvl) {
+	for (uint8_t &spellLevel : player._pSplLvl) {
 		spellLevel = 0;
 	}
 
@@ -2871,7 +2871,7 @@ void ApplyPlrDamage(DamageType damageType, Player &player, int dam, int minHP /*
 		AddFloatingNumber(damageType, player, totalDamage);
 	}
 	if (totalDamage > 0 && player.pManaShield) {
-		int8_t manaShieldLevel = player._pSplLvl[static_cast<int8_t>(SpellID::ManaShield)];
+		uint8_t manaShieldLevel = player._pSplLvl[static_cast<int8_t>(SpellID::ManaShield)];
 		if (manaShieldLevel > 0) {
 			totalDamage += totalDamage / -player.GetManaShieldDamageReduction();
 		}

--- a/Source/player.h
+++ b/Source/player.h
@@ -33,7 +33,7 @@ constexpr int InventoryGridCells = 40;
 constexpr int MaxBeltItems = 8;
 constexpr int MaxResistance = 75;
 constexpr int MaxCharacterLevel = 50;
-constexpr int MaxSpellLevel = 15;
+constexpr uint8_t MaxSpellLevel = 15;
 constexpr int PlayerNameLength = 32;
 
 constexpr size_t NumHotkeys = 12;
@@ -338,7 +338,7 @@ struct Player {
 	SpellID _pRSpell;
 	SpellType _pRSplType;
 	SpellID _pSBkSpell;
-	int8_t _pSplLvl[64];
+	uint8_t _pSplLvl[64];
 	/** @brief Bitmask of staff spell */
 	uint64_t _pISpells;
 	/** @brief Bitmask of learned spells */
@@ -593,7 +593,7 @@ struct Player {
 			return 0;
 		}
 
-		return std::max<int8_t>(_pISplLvlAdd + _pSplLvl[static_cast<std::size_t>(spell)], 0);
+		return std::max<int>(_pISplLvlAdd + _pSplLvl[static_cast<std::size_t>(spell)], 0);
 	}
 
 	/**

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -741,7 +741,7 @@ void WitchBookLevel(Item &bookItem)
 	if (bookItem._iMiscId != IMISC_BOOK)
 		return;
 	bookItem._iMinMag = GetSpellData(bookItem._iSpell).minInt;
-	int8_t spellLevel = MyPlayer->_pSplLvl[static_cast<int8_t>(bookItem._iSpell)];
+	uint8_t spellLevel = MyPlayer->_pSplLvl[static_cast<int8_t>(bookItem._iSpell)];
 	while (spellLevel > 0) {
 		bookItem._iMinMag += 20 * bookItem._iMinMag / 100;
 		spellLevel--;

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -86,7 +86,7 @@ TEST(Player, PM_DoGotHit)
 
 static void AssertPlayer(Player &player)
 {
-	ASSERT_EQ(Count8(player._pSplLvl, 64), 0);
+	ASSERT_EQ(CountU8(player._pSplLvl, 64), 0);
 	ASSERT_EQ(Count8(player.InvGrid, InventoryGridCells), 1);
 	ASSERT_EQ(CountItems(player.InvBody, NUM_INVLOC), 1);
 	ASSERT_EQ(CountItems(player.InvList, InventoryGridCells), 1);

--- a/test/player_test.h
+++ b/test/player_test.h
@@ -12,30 +12,20 @@ using namespace devilution;
 
 static int CountItems(Item *items, int n)
 {
-	int count = n;
-	for (int i = 0; i < n; i++)
-		if (items[i].isEmpty())
-			count--;
-
-	return count;
+	return std::count_if(items, items + n, [](Item x) { return !x.isEmpty(); });
 }
 
 static int Count8(int8_t *ints, int n)
 {
-	int count = n;
-	for (int i = 0; i < n; i++)
-		if (ints[i] == 0)
-			count--;
+	return std::count_if(ints, ints + n, [](int8_t x) { return x != 0; });
+}
 
-	return count;
+static int CountU8(uint8_t *ints, int n)
+{
+	return std::count_if(ints, ints + n, [](uint8_t x) { return x != 0; });
 }
 
 static int CountBool(bool *bools, int n)
 {
-	int count = n;
-	for (int i = 0; i < n; i++)
-		if (!bools[i])
-			count--;
-
-	return count;
+	return std::count_if(bools, bools + n, [](bool x) { return x; });
 }

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -257,7 +257,7 @@ void PackPlayerTest(PlayerPack *pPack)
 
 void AssertPlayer(Player &player)
 {
-	ASSERT_EQ(Count8(player._pSplLvl, 64), 23);
+	ASSERT_EQ(CountU8(player._pSplLvl, 64), 23);
 	ASSERT_EQ(Count8(player.InvGrid, InventoryGridCells), 9);
 	ASSERT_EQ(CountItems(player.InvBody, NUM_INVLOC), 6);
 	ASSERT_EQ(CountItems(player.InvList, InventoryGridCells), 2);


### PR DESCRIPTION
Fixes #5980

When changing a spell level a new command `CMD_CHANGE_SPELL_LEVEL` is used.
This is a similar approach to adding stat points (`CMD_ADDSTR`).