### PR TITLE
Hellfire: Fix light fall off not within its radius

### DIFF
--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -369,29 +369,26 @@ void MakeLightTable()
 	LoadFileInMem("gendata\\pause.trn", PauseTable);
 
 	// Generate light falloffs ranges
-	if (IsAnyOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
-		for (size_t j = 0; j < NumLightRadiuses; j++) {
-			double fa = (sqrt((double)(16 - j))) / 128;
-			fa *= fa;
-			for (int i = 0; i < 128; i++) {
-				uint8_t color = 15 - static_cast<uint8_t>(fa * (double)((128 - i) * (128 - i)));
-				if (color > 15)
-					color = 0;
-				color -= static_cast<uint8_t>((NumLightRadiuses - j - 1) / 2);
-				if (color > 15)
-					color = 0;
-				LightFalloffs[NumLightRadiuses - j - 1][i] = color;
-			}
-		}
-	} else {
-		for (size_t j = 0; j < NumLightRadiuses; j++) {
-			for (size_t i = 0; i < 128; i++) {
-				if (i > (j + 1) * 8) {
-					LightFalloffs[j][i] = 15;
+	const float maxDarkness = 15;
+	const float maxBrightness = 0;
+	for (size_t radius = 0; radius < NumLightRadiuses; radius++) {
+		size_t maxDistance = (radius + 1) * 8;
+		for (size_t distance = 0; distance < 128; distance++) {
+			if (distance > maxDistance) {
+				LightFalloffs[radius][distance] = 15;
+			} else {
+				const float factor = static_cast<float>(distance) / maxDistance;
+				float scaled;
+				if (IsAnyOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
+					// quardratic falloff with over exposure
+					const float brightness = radius * 1.5;
+					scaled = factor * factor * brightness + (maxDarkness - brightness);
+					scaled = std::max(maxBrightness, scaled);
 				} else {
-					double fs = (double)15 * i / ((double)8 * (j + 1));
-					LightFalloffs[j][i] = static_cast<uint8_t>(fs + 0.5);
+					// Leaner falloff
+					scaled = factor * maxDarkness;
 				}
+				LightFalloffs[radius][distance] = static_cast<uint8_t>(scaled + 0.5F); // round up
 			}
 		}
 	}


### PR DESCRIPTION
Helfire makes various modifications to the lighting system. One of them is to calculate a new falloff table for lights.
Unfortunately this table isn't adhering to the radius bound which results in several visual artifacts (some can be seen here: https://github.com/diasurgical/devilutionX/issues/3601) and light smearing.
On clear destination form the normal lighting is that it allows for dim lights which is used for the lava candles.

It's possible that the overshot lighting was somewhat intentional in order to apply a glow to the floor, but since it will vary in intensity based on the players light radius this isn't very consistent. A much better way to handle it is to apply illumination to the lave tiles in the same way as for caves (but with a lower intensity). I intent to do so in a follow up to this PR.

Hellfire:
![Screenshot from 2023-04-23 11-45-52](https://user-images.githubusercontent.com/204594/233836573-32f50677-e5b8-4831-906e-bcf2f3e36a25.png)
(a lot of things outside visual range are being lit, this will cause issues as these areas are not consistently updated)

Diablo:
![Screenshot from 2023-04-23 12-08-40](https://user-images.githubusercontent.com/204594/233836589-6695c44b-c017-4229-9342-fa8ca6e70353.png)
(notice the bright candles) 

PR:
![Screenshot from 2023-04-23 11-52-13](https://user-images.githubusercontent.com/204594/233837270-a018f0e4-5794-4471-b61e-0678bd20fa51.png)

The X axis is distance from light, with left being at the light source. Y is the brightness value, with top being complete darkness at the bottom being fully lit.

I have also plotted the 3 decay models.
The X axis is distance from light, with left being at the light source. Y is the brightness value, with top being complete darkness at the bottom being fully lit.
Notice how Hellfires never reach fully dark (15 on the Y axis) for most light radii, only 0 and 1 tile lights strength do so, the rest will cause lighting glitches outside of there set range.

Diablo:
![image](https://user-images.githubusercontent.com/204594/233837251-ff5448c4-dac0-4539-aca7-ebfaf55f7d29.png)
Hellfire:
![image](https://user-images.githubusercontent.com/204594/233837266-19cf7453-d2ff-48ef-9ead-bb4147bee521.png)
PR:
![image](https://user-images.githubusercontent.com/204594/233837473-737a3e58-3a43-4221-bd7f-9139a7764522.png)
