### PR TITLE
Add glow to Crypt lava tiles

### DIFF
--- a/Source/levels/crypt.cpp
+++ b/Source/levels/crypt.cpp
@@ -4,6 +4,7 @@
 #include "engine/point.hpp"
 #include "items.h"
 #include "levels/drlg_l1.h"
+#include "lighting.h"
 
 namespace devilution {
 
@@ -806,6 +807,29 @@ void SetCryptSetPieceRoom()
 			}
 			if (dPiece[i][j] == 316) {
 				CornerStone.position = { i, j };
+			}
+		}
+	}
+}
+
+void PlaceCryptLights()
+{
+	constexpr int lavaTiles[] = {
+		124, 128, 130, 132, 133, 134, 135, 139, 141, 143, 145, 156, 164, 166,
+		167, 168, 169, 170, 182, 190, 192, 195, 196, 199, 200, 254, 266, 273,
+		276, 281, 282, 283, 284, 285, 286, 287, 288, 290, 302, 316, 434, 435,
+		436, 437, 445, 446, 447, 453, 457, 460, 466, 470, 477, 479, 484, 485,
+		486, 490, 507, 537, 557, 559, 561, 563, 564, 568, 569, 572, 578, 580,
+		584, 585, 589, 592, 593, 594, 595, 596, 597, 598, 599, 600, 601
+	};
+
+	for (int j = 0; j < MAXDUNY; j++) {
+		for (int i = 0; i < MAXDUNX; i++) {
+			for (const int lavaTile : lavaTiles) {
+				if (dPiece[i][j] == lavaTile) {
+					DoLighting({ i, j }, 3, {});
+					break;
+				}
 			}
 		}
 	}

--- a/Source/levels/crypt.h
+++ b/Source/levels/crypt.h
@@ -24,5 +24,6 @@ void FixCryptDirtTiles();
 bool PlaceCryptStairs(lvl_entry entry);
 void CryptSubstitution();
 void SetCryptSetPieceRoom();
+void PlaceCryptLights();
 
 } // namespace devilution

--- a/Source/levels/drlg_l1.cpp
+++ b/Source/levels/drlg_l1.cpp
@@ -1298,6 +1298,7 @@ void CreateL5Dungeon(uint32_t rseed, lvl_entry entry)
 	Pass3();
 
 	if (leveltype == DTYPE_CRYPT) {
+		PlaceCryptLights();
 		SetCryptSetPieceRoom();
 	}
 }
@@ -1324,10 +1325,12 @@ void LoadL1Dungeon(const char *path, Point spawn)
 
 	Pass3();
 
-	if (setlvltype == DTYPE_CRYPT)
+	if (setlvltype == DTYPE_CRYPT) {
 		AddCryptObjects(0, 0, MAXDUNX, MAXDUNY);
-	else
+		PlaceCryptLights();
+	} else {
 		AddL1Objs(0, 0, MAXDUNX, MAXDUNY);
+	}
 }
 
 } // namespace devilution

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -381,7 +381,7 @@ void MakeLightTable()
 				float scaled;
 				if (IsAnyOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
 					// quardratic falloff with over exposure
-					const float brightness = radius * 1.5;
+					const float brightness = radius * 1.25;
 					scaled = factor * factor * brightness + (maxDarkness - brightness);
 					scaled = std::max(maxBrightness, scaled);
 				} else {


### PR DESCRIPTION
The visual artifacts caused by https://github.com/diasurgical/devilutionX/issues/3601 lead to the appearance of lava tiles glowing. In order to instead achieve this in a deliberate and stable manner the proper solution is to add a faint glow in the same way as with lava tiles in caves. A value of 3 for lighting radius is chosen to match that of the lava touchs around story books, lower values are very faint, and higher values would be odd as it would out shine the touchs.

Additionally i have adjusted the over exposure to better match the original lighting now that everything is in place.

Hellfire when first entering the level:
![image](https://user-images.githubusercontent.com/204594/233989291-03553c24-2101-43ae-92ad-d7b6bd4b8587.png)

Hellfire after trying to smear lighting all over the leve:
![image](https://user-images.githubusercontent.com/204594/233988958-a2b56d90-8914-4543-8050-679a160697a2.png)

PR:
![image](https://user-images.githubusercontent.com/204594/233988993-b36fc850-0af6-43a2-bc9d-d2f280e6793a.png)
