### PR TITLE
Hellfire: let light affect the player

### DIFF
--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -405,7 +405,7 @@ void DrawPlayer(const Surface &out, const Player &player, Point tilePosition, Po
 	if (static_cast<size_t>(pcursplr) < Players.size() && &player == &Players[pcursplr])
 		ClxDrawOutlineSkipColorZero(out, 165, spriteBufferPosition, sprite);
 
-	if (&player == MyPlayer) {
+	if (&player == MyPlayer && IsNoneOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
 		ClxDraw(out, spriteBufferPosition, sprite);
 		DrawPlayerIcons(out, player, targetBufferPosition, false);
 		return;


### PR DESCRIPTION
Center of lights in Hellfire can go darker then full bright. This is already have special cases in a few places to make sure that it's rendered correctly by disabling this optimization for Hellfire levels. This applies the same exception for the local hero graphics.

Example while having -40% light radius

Before
![image](https://user-images.githubusercontent.com/204594/234020926-71eca870-9642-42f9-ae50-875388252ac5.png)
After
![image](https://user-images.githubusercontent.com/204594/234020984-910dab0b-94a9-48d6-b2f0-b6d7ecc38449.png)
