### PR TITLE
Remove unique monster's light when no corpse is left behind

### DIFF
--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -28,6 +28,19 @@ void InitDeadAnimationFromMonster(Corpse &corpse, const CMonster &mon)
 	corpse.frame = animData.frames - 1;
 	corpse.width = animData.width;
 }
+
+void MoveLightToCorpse(Monster &monster)
+{
+	for (int dx = 0; dx < MAXDUNX; dx++) {
+		for (int dy = 0; dy < MAXDUNY; dy++) {
+			if ((dCorpse[dx][dy] & 0x1F) == monster.corpseId) {
+				ChangeLightXY(monster.lightId, { dx, dy });
+				return;
+			}
+		}
+	}
+	AddUnLight(monster.lightId);
+}
 } // namespace
 
 void InitCorpses()
@@ -79,18 +92,13 @@ void AddCorpse(Point tilePosition, int8_t dv, Direction ddir)
 	dCorpse[tilePosition.x][tilePosition.y] = (dv & 0x1F) + (static_cast<int>(ddir) << 5);
 }
 
-void SyncUniqDead()
+void MoveLightsToCorpses()
 {
 	for (size_t i = 0; i < ActiveMonsterCount; i++) {
 		auto &monster = Monsters[ActiveMonsters[i]];
 		if (!monster.isUnique())
 			continue;
-		for (int dx = 0; dx < MAXDUNX; dx++) {
-			for (int dy = 0; dy < MAXDUNY; dy++) {
-				if ((dCorpse[dx][dy] & 0x1F) == monster.corpseId)
-					ChangeLightXY(monster.lightId, { dx, dy });
-			}
-		}
+		MoveLightToCorpse(monster);
 	}
 }
 

--- a/Source/dead.h
+++ b/Source/dead.h
@@ -39,6 +39,6 @@ extern int8_t stonendx;
 
 void InitCorpses();
 void AddCorpse(Point tilePosition, int8_t dv, Direction ddir);
-void SyncUniqDead();
+void MoveLightsToCorpses();
 
 } // namespace devilution

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2590,7 +2590,7 @@ void LoadLevel()
 			for (int i = 0; i < MAXDUNX; i++) // NOLINT(modernize-loop-convert)
 				dCorpse[i][j] = file.NextLE<int8_t>();
 		}
-		SyncUniqDead();
+		MoveLightsToCorpses();
 	}
 
 	ActiveMonsterCount = file.NextBE<int32_t>();

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3699,6 +3699,8 @@ void MonsterDeath(Monster &monster, Direction md, bool sendmsg)
 			md = Direction::South;
 		NewMonsterAnim(monster, MonsterGraphic::Death, md, gGameLogicStep < GameLogicStep::ProcessMonsters ? AnimationDistributionFlags::ProcessAnimationPending : AnimationDistributionFlags::None);
 		monster.mode = MonsterMode::Death;
+	} else if (monster.isUnique()) {
+		AddUnLight(monster.lightId);
 	}
 	monster.goal = MonsterGoal::None;
 	monster.var1 = 0;


### PR DESCRIPTION
When a monster is killed while petrified via Stone Curse, they don't leave behind a corpse. It stands to reason that an empty tile should not be illuminated. This also resolves the issue where the light would move to the monster's initial spawn position after entering and leaving the dungeon level, since there's no corpse to move it to.

The matter of whether corpses should be illuminated at all is also up for discussion.