### PR TITLE
Reenable lights for active monsters when loading level

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2600,8 +2600,12 @@ void LoadLevel()
 	if (leveltype != DTYPE_TOWN) {
 		for (int &monsterId : ActiveMonsters)
 			monsterId = file.NextBE<int32_t>();
-		for (size_t i = 0; i < ActiveMonsterCount; i++)
-			LoadMonster(&file, Monsters[ActiveMonsters[i]]);
+		for (size_t i = 0; i < ActiveMonsterCount; i++) {
+			Monster &monster = Monsters[ActiveMonsters[i]];
+			LoadMonster(&file, monster);
+			if (monster.isUnique() && monster.lightId != NO_LIGHT)
+				Lights[monster.lightId].isInvalid = false;
+		}
 		for (int &objectId : ActiveObjects)
 			objectId = file.NextLE<int8_t>();
 		for (int &objectId : AvailableObjects)


### PR DESCRIPTION
Besides Stone Curse, the other reason a monster might not have a corpse is that they are still alive. 😓 