### PR TITLE
Handle window focus events when svid movie is playing

### DIFF
--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -55,6 +55,23 @@ void play_movie(const char *pszMovie, bool userCanClose)
 					if (userCanClose || (event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_ESCAPE))
 						movie_playing = false;
 					break;
+#ifndef USE_SDL1
+				case SDL_WINDOWEVENT:
+					if (event.window.event == SDL_WINDOWEVENT_FOCUS_LOST)
+						diablo_focus_pause();
+					else if (event.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
+						diablo_focus_unpause();
+					break;
+#else
+				case SDL_ACTIVEEVENT:
+					if ((event.active.state & SDL_APPINPUTFOCUS) != 0) {
+						if (event.active.gain == 0)
+							diablo_focus_pause();
+						else
+							diablo_focus_unpause();
+					}
+					break;
+#endif
 				case SDL_QUIT:
 					SVidPlayEnd();
 					diablo_quit(0);


### PR DESCRIPTION
The bisected commit mentioned in #5931 moved the handling of these events from `FetchMessage_Real()` to `MainWndProc()`. Therefore, these were no longer being handled by the movie's event loop.

I settled on `diablo_focus_pause()`/`diablo_focus_unpause()` rather than calling `SVidMute()`/`SVidUnmute()` after some testing against Lazarus' video.

This resolves #5931