### PR TITLE
Always spawn players in a valid location

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2916,10 +2916,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 	for (Player &player : Players) {
 		if (player.plractive && player.isOnActiveLevel() && (!player._pLvlChanging || &player == MyPlayer)) {
 			if (player._pHitPoints > 0) {
-				if (!gbIsMultiplayer)
-					dPlayer[player.position.tile.x][player.position.tile.y] = player.getId() + 1;
-				else
-					SyncInitPlrPos(player);
+				SyncInitPlrPos(player);
 			} else {
 				dFlags[player.position.tile.x][player.position.tile.y] |= DungeonFlag::DeadPlayer;
 			}

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -362,13 +362,12 @@ void SetupLocalPositions()
 	leveltype = DTYPE_TOWN;
 	setlevel = false;
 
-	const auto x = static_cast<WorldTileCoord>(75 + plrxoff[MyPlayerId]);
-	const auto y = static_cast<WorldTileCoord>(68 + plryoff[MyPlayerId]);
+	const WorldTilePosition spawns[9] = { { 75, 68 }, { 77, 70 }, { 75, 70 }, { 77, 68 }, { 76, 69 }, { 75, 69 }, { 76, 68 }, { 77, 69 }, { 76, 70 } };
 
 	Player &myPlayer = *MyPlayer;
 
-	myPlayer.position.tile = WorldTilePosition { x, y };
-	myPlayer.position.future = WorldTilePosition { x, y };
+	myPlayer.position.tile = spawns[MyPlayerId];
+	myPlayer.position.future = myPlayer.position.tile;
 	myPlayer.setLevel(currlevel);
 	myPlayer._pLvlChanging = true;
 	myPlayer.pLvlLoad = 0;

--- a/Source/player.h
+++ b/Source/player.h
@@ -852,11 +852,4 @@ void SetPlrVit(Player &player, int v);
 void InitDungMsgs(Player &player);
 void PlayDungMsgs();
 
-/* data */
-
-extern const int8_t plrxoff[9];
-extern const int8_t plryoff[9];
-extern const int8_t plrxoff2[9];
-extern const int8_t plryoff2[9];
-
 } // namespace devilution

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -65,45 +65,6 @@ void ClearReadiedSpell(Player &player)
 	}
 }
 
-void PlacePlayer(Player &player)
-{
-	if (!player.isOnActiveLevel())
-		return;
-
-	Point newPosition = [&]() {
-		Point okPosition = {};
-
-		for (int i = 0; i < 8; i++) {
-			okPosition = player.position.tile + Displacement { plrxoff2[i], plryoff2[i] };
-			if (PosOkPlayer(player, okPosition))
-				return okPosition;
-		}
-
-		for (int max = 1, min = -1; min > -50; max++, min--) {
-			for (int y = min; y <= max; y++) {
-				okPosition.y = player.position.tile.y + y;
-
-				for (int x = min; x <= max; x++) {
-					okPosition.x = player.position.tile.x + x;
-
-					if (PosOkPlayer(player, okPosition))
-						return okPosition;
-				}
-			}
-		}
-
-		return okPosition;
-	}();
-
-	player.position.tile = newPosition;
-
-	dPlayer[newPosition.x][newPosition.y] = player.getId() + 1;
-
-	if (&player == MyPlayer) {
-		ViewPosition = newPosition;
-	}
-}
-
 } // namespace
 
 bool IsValidSpell(SpellID spl)
@@ -293,7 +254,7 @@ void DoResurrect(size_t pnum, Player &target)
 	ClrPlrPath(target);
 	target.destAction = ACTION_NONE;
 	target._pInvincible = false;
-	PlacePlayer(target);
+	SyncInitPlrPos(target);
 
 	int hp = 10 << 6;
 	if (target._pMaxHPBase < (10 << 6)) {


### PR DESCRIPTION
Fixes #1492
Fixes #2838

- Deduplicate `PlacePlayer()` -> `SyncInitPlrPos()`
- Don't try to find the player spawn twice `InitPlayer()` -> `SyncInitPlrPos()`
- Don't spawn on the level trigger (instant warp back to previous level)
- Use the same spawn rules in MP and SP (do not spawn where `!PosOkPlayer()`)
- Convert `plrxoff`/`plrxoff` and `plrxoff2`/`plryoff2` to cordinates

For 1.5.0 this will also avoid spawning in a pitch black level in cases where you would have spawned inside a solid spike (light no longer cast light from inside solid objects)