### PR TITLE
High FPS player light update

### DIFF
--- a/Source/engine/displacement.hpp
+++ b/Source/engine/displacement.hpp
@@ -170,7 +170,7 @@ struct DisplacementOf {
 	constexpr DisplacementOf<DeltaT> screenToLight() const
 	{
 		static_assert(std::is_signed<DeltaT>::value, "DeltaT must be signed for transformations involving a rotation");
-		return { (2 * deltaY + deltaX) / 8, (2 * deltaY - deltaX) / 8 };
+		return { static_cast<DeltaT>((2 * deltaY + deltaX) / 8), static_cast<DeltaT>((2 * deltaY - deltaX) / 8) };
 	}
 
 	/**

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -513,7 +513,7 @@ void ChangeLightXY(int i, Point position)
 	UpdateLighting = true;
 }
 
-void ChangeLightOffset(int i, Displacement offset)
+void ChangeLightOffset(int i, DisplacementOf<int8_t> offset)
 {
 #ifdef _DEBUG
 	if (DisableLighting)
@@ -523,6 +523,9 @@ void ChangeLightOffset(int i, Displacement offset)
 		return;
 
 	Light &light = Lights[i];
+	if (light.position.offset == offset)
+		return;
+
 	light.hasChanged = true;
 	light.position.old = light.position.tile;
 	light.oldRadius = light.radius;

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -69,7 +69,7 @@ int AddLight(Point position, uint8_t radius);
 void AddUnLight(int i);
 void ChangeLightRadius(int i, uint8_t radius);
 void ChangeLightXY(int i, Point position);
-void ChangeLightOffset(int i, Displacement offset);
+void ChangeLightOffset(int i, DisplacementOf<int8_t> offset);
 void ChangeLight(int i, Point position, uint8_t radius);
 void ProcessLightList();
 void SavePreLighting();

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1012,7 +1012,10 @@ void StartHeal(Monster &monster)
 
 void SyncLightPosition(Monster &monster)
 {
-	Displacement offset = monster.position.CalculateWalkingOffset(monster.direction, monster.animInfo);
+	if (monster.lightId == NO_LIGHT)
+		return;
+
+	const WorldTileDisplacement offset = monster.position.CalculateWalkingOffset(monster.direction, monster.animInfo);
 	ChangeLightOffset(monster.lightId, offset.screenToLight());
 }
 


### PR DESCRIPTION
Finding this out was a complete coincidence. I was just cleaning up `PmChangeLightOff()` because it was using pointers instead of references, which I noticed while searching for something else :D

- No need to add `(light.position * 8)` to both values before comparing
- Conversion to negative isn't needed (this is already  handled in `DoLighting()`)
- Remove light update throttling (only updated 1/3 as often for players as other things)
- Move change check to `ChangeLightOffset()` so it applies to monsters and missiles as well
- Don't calculate the offset for monsters that do not have lights

Old:
![oldwalk](https://user-images.githubusercontent.com/204594/235326600-5e061292-1248-4ae5-9183-fe857a88ae3e.gif)

New:
![newwalk](https://user-images.githubusercontent.com/204594/235326603-798e2370-2af5-452e-ad0a-37877833859c.gif)


