### PR TITLE
Use SDL_SetWindowDisplayMode() to resize fullscreen windows

### DIFF
--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -318,7 +318,7 @@ void FullscreenChanged()
 
 	for (auto &vecItem : vecDialogItems) {
 		int vecItemValue = vecItem->m_value;
-		if (vecItemValue < 0)
+		if (vecItemValue < 0 || vecItemValue >= vecOptions.size())
 			continue;
 
 		auto *pOption = vecOptions[vecItemValue];


### PR DESCRIPTION
If you use `Alt+Enter` to toggle fullscreen while browsing any settings menu type besides `ShownMenuType::Settings`, the `FullscreenChanged()` handler will attempt to access an item in the empty `vecOptions` vector. The first commit fixes that.

As for the rest, it seems that `SDL_SetWindowDisplayMode()` is the appropriate function to call when resizing a window with the `SDL_WINDOW_FULLSCREEN` flag set. This required some additional logic in both `ResizeWindow()` and `SetFullscreenMode()`. Hopefully the comments help to explain a lot of the nuance better than I can here.

Fair warning: I only tested this on Windows.

This resolves #6059