### PR TITLE
Fixes for book lever synchronization

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3600,7 +3600,8 @@ void SyncLever(const Object &lever)
 void SyncQSTLever(const Object &qstLever)
 {
 	if (qstLever._oAnimFrame == qstLever._oVar6) {
-		ObjChangeMapResync(qstLever._oVar1, qstLever._oVar2, qstLever._oVar3, qstLever._oVar4);
+		if (qstLever._otype != OBJ_BLOODBOOK)
+			ObjChangeMapResync(qstLever._oVar1, qstLever._oVar2, qstLever._oVar3, qstLever._oVar4);
 		if (qstLever._otype == OBJ_BLINDBOOK) {
 			auto tren = TransVal;
 			TransVal = 9;
@@ -4436,7 +4437,8 @@ void OperateObject(Player &player, Object &object)
 	case OBJ_BLINDBOOK:
 	case OBJ_BLOODBOOK:
 	case OBJ_STEELTOME:
-		OperateBookLever(object, sendmsg);
+		if (sendmsg)
+			OperateBookLever(object, sendmsg);
 		break;
 	case OBJ_SHRINEL:
 	case OBJ_SHRINER:
@@ -4633,7 +4635,10 @@ void SyncOpObject(Player &player, int cmd, Object &object)
 	case OBJ_BLINDBOOK:
 	case OBJ_BLOODBOOK:
 	case OBJ_STEELTOME:
-		OperateBookLever(object, sendmsg);
+		if (sendmsg)
+			break;
+		object._oAnimFrame = object._oVar6;
+		SyncQSTLever(object);
 		break;
 	case OBJ_SHRINEL:
 	case OBJ_SHRINER:


### PR DESCRIPTION
This PR blocks operating book-levers based on `sendmsg`. It also borrows logic from `DeltaSyncOpObject()` to sync booklevers when activated by another player. This allows the book animation frame and map state to sync up without actually operating the book-lever and quest text when a remote client operates the book-lever.

The change to `SyncQSTLever()` is meant to better match the logic in `OperateBookLever()`. It seems that attempting to call `ObjChangeMap()` on the Arkaine's Valor book-lever will open the first closed-off section that is supposed to be opened by placing the first Bloodstone on the pedestal. This change actually fixes an error where leaving dlvl 5 after operating the book-lever and coming back will open the first closed-off section prematurely.

This resolves #6023