### PR TITLE
Fix OOB array access when spawning arena pots

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -414,7 +414,7 @@ std::string TextCmdArenaPot(const string_view parameter)
 	Player &myPlayer = *MyPlayer;
 
 	for (int potNumber = std::max(1, atoi(parameter.data())); potNumber > 0; potNumber--) {
-		Item &item = myPlayer.InvList[myPlayer._pNumInv];
+		Item item {};
 		InitializeItem(item, IDI_ARENAPOT);
 		GenerateNewSeed(item);
 		item.updateRequiredStatsCacheForPlayer(myPlayer);


### PR DESCRIPTION
calling this with a full inventory would write past the end of InvList, potentially causing a crash or data corruption.