### PR TITLE
Don't recalculate player position when loading a game

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2916,7 +2916,8 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 	for (Player &player : Players) {
 		if (player.plractive && player.isOnActiveLevel() && (!player._pLvlChanging || &player == MyPlayer)) {
 			if (player._pHitPoints > 0) {
-				SyncInitPlrPos(player);
+				if (lvldir != ENTRY_LOAD)
+					SyncInitPlrPos(player);
 			} else {
 				dFlags[player.position.tile.x][player.position.tile.y] |= DungeonFlag::DeadPlayer;
 			}

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2115,7 +2115,7 @@ void LoadGame(bool firstflag)
 	}
 
 	LoadGameLevel(firstflag, ENTRY_LOAD);
-	SyncInitPlr(myPlayer);
+	SetPlrAnims(myPlayer);
 	SyncPlrAnim(myPlayer);
 
 	ViewPosition = { viewX, viewY };


### PR DESCRIPTION
Fixes #6075

Introduced by #6065

Thanks @FitzRoyX for reporting and finding the bad commit.

## Background

When loading a save game `LoadGame` is called and this does
- Call `LoadGameLevel`
   - `LoadGameLevel` generate the level
   - `LoadGameLevel` don't load the monsters from save game. Instead its generates the monsters as they are first spawned.
   - Calls `SyncInitPlrPos` to ensure that the player position is valid
      - `SyncInitPlrPos` see that the player is on a tile where a monster initial spawns
      - Player Position is reset, but `Player::position::temp` still contains the old destination position of the walk
- `SyncInitPlr` calls `SyncInitPlrPos` again
- Saved monsters are loaded in `LoadGame` and this overrides the generated/initial monsters

## Change

The saved player position should be valid (else the saved game would be invalid).
So this PR changes that when loading a save game the player position is not validated at all.

This avoids changing
- the loading order
- `SyncInitPlr` to include handling of walking player mode/state
- save game state while loading