### PR TITLE
Align random number functions with C++ random number concepts

### DIFF
--- a/Source/engine/random.cpp
+++ b/Source/engine/random.cpp
@@ -76,4 +76,14 @@ bool FlipCoin(unsigned frequency)
 	return GenerateRnd(static_cast<int32_t>(frequency)) == 0;
 }
 
+int32_t RandomIntLessThan(int32_t v)
+{
+	return DiabloDistribution(v)(generator);
+}
+
+int32_t RandomIntBetween(int32_t min, int32_t max, bool halfOpen)
+{
+	return DiabloDistribution(min, max + (halfOpen ? 0 : 1))(generator);
+}
+
 } // namespace devilution

--- a/Source/engine/random.cpp
+++ b/Source/engine/random.cpp
@@ -1,6 +1,7 @@
 #include "engine/random.hpp"
 
 #include <limits>
+#include <random>
 
 #include "utils/stdcompat/abs.hpp"
 
@@ -9,18 +10,12 @@ namespace devilution {
 /** Current game seed */
 uint32_t sglGameSeed;
 
-/**
- * Specifies the increment used in the Borland C/C++ pseudo-random number generator algorithm.
- */
-const uint32_t RndInc = 1;
-
-/**
- * Specifies the multiplier used in the Borland C/C++ pseudo-random number generator algorithm.
- */
-const uint32_t RndMult = 0x015A4E35;
+/** Borland C/C++ psuedo-random number generator needed for vanilla compatibility */
+std::linear_congruential_engine<uint32_t, 0x015A4E35, 1, 0> diabloGenerator;
 
 void SetRndSeed(uint32_t seed)
 {
+	diabloGenerator.seed(seed);
 	sglGameSeed = seed;
 }
 
@@ -38,7 +33,7 @@ int32_t GetRndSeed()
 
 int32_t AdvanceRndSeed()
 {
-	sglGameSeed = (RndMult * sglGameSeed) + RndInc;
+	sglGameSeed = diabloGenerator();
 	return GetRndSeed();
 }
 

--- a/Source/engine/random.hpp
+++ b/Source/engine/random.hpp
@@ -30,7 +30,7 @@ void SetRndSeed(uint32_t seed);
 uint32_t GetLCGEngineState();
 
 /**
- * @brief Generates a random non-negative integer (most of the time) using the vanilla RNG
+ * @brief Generates a random non-negative integer (most of the time) using the vanilla RNG/distribution function
  *
  * This advances the engine state then interprets the new engine state as a signed value and calls std::abs to try
  * discard the high bit of the result. This usually returns a positive number but may very rarely return -2^31.
@@ -39,6 +39,7 @@ uint32_t GetLCGEngineState();
  * as the returned value is transformed about 50% of values do not reflect the actual engine state. It would be more
  * appropriate to use GetLCGEngineState() in these cases but that may break compatibility with the base game.
  *
+ * @see AbsoluteDistribution
  * @return A random number in the range [0,2^31) or -2^31
  */
 int32_t AdvanceRndSeed();
@@ -51,7 +52,7 @@ int32_t AdvanceRndSeed();
  * Limits between 32768 and 65534 should be avoided as a bug in vanilla means this function always returns a value
  * less than 32768 for limits in that range.
  *
- * This can very rarely return a negative value in the range (-v, -1] due to the bug in AdvanceRndSeed()
+ * This can very rarely return a negative value in the range (-v, -1] due to the bug described in AdvanceRndSeed()
  *
  * @see AdvanceRndSeed()
  * @param v The upper limit for the return value
@@ -71,30 +72,13 @@ int32_t GenerateRnd(int32_t v);
 bool FlipCoin(unsigned frequency = 2);
 
 /**
- * @brief Picks one of the elements in the list randomly.
- *
- * @param values The values to pick from
- * @return A random value from the 'values' list.
- */
-template <typename T>
-const T PickRandomlyAmong(const std::initializer_list<T> &values)
-{
-	const auto index { std::max<int32_t>(GenerateRnd(static_cast<int32_t>(values.size())), 0) };
-
-	return *(values.begin() + index);
-}
-
-/**
  * @brief Generates a random non-negative integer
  *
  * Effectively the same as GenerateRnd but will never return a negative value
  * @param v upper limit for the return value
  * @return a value between 0 and v-1 inclusive, i.e. the range [0, v)
  */
-inline int32_t RandomIntLessThan(int32_t v)
-{
-	return std::max<int32_t>(GenerateRnd(v), 0);
-}
+int32_t RandomIntLessThan(int32_t v);
 
 /**
  * @brief Randomly chooses a value somewhere within the given range
@@ -103,9 +87,18 @@ inline int32_t RandomIntLessThan(int32_t v)
  * @param halfOpen whether to use the limits as a half-open range or not
  * @return a randomly selected integer
  */
-inline int32_t RandomIntBetween(int32_t min, int32_t max, bool halfOpen = false)
+int32_t RandomIntBetween(int32_t min, int32_t max, bool halfOpen = false);
+
+/**
+ * @brief Picks one of the elements in the list randomly.
+ *
+ * @param values The values to pick from
+ * @return A random value from the 'values' list.
+ */
+template <typename T>
+const T PickRandomlyAmong(const std::initializer_list<T> &values)
 {
-	return RandomIntLessThan(max - min + (halfOpen ? 0 : 1)) + min;
+	return *(values.begin() + RandomIntLessThan(static_cast<int32_t>(values.size())));
 }
 
 } // namespace devilution

--- a/Source/engine/random_distribution.hpp
+++ b/Source/engine/random_distribution.hpp
@@ -1,0 +1,258 @@
+/**
+ * @file random_distribution.hpp
+ *
+ * Definition for the random number distribution function objects used in Diablo dungeon/item generation functions
+ */
+#pragma once
+
+#include <istream>
+#include <limits>
+#include <ostream>
+
+#include "utils/stdcompat/abs.hpp"
+
+namespace devilution {
+
+/**
+ * @brief This type of distribution attempts to mask the MSB off a value assumed to come from a LCG using abs()
+ *
+ * If the generator yields a value that casts to INT_MIN we can't reliably take the absolute value. In this case
+ * return either 0 or INT_MIN (a large negative value) based on the params used when creating the distribution
+ */
+struct AbsoluteDistribution {
+	using result_type = int32_t;
+
+	struct param_type {
+		using distribution_type = AbsoluteDistribution;
+
+		param_type()
+		    : allowIntMin(false)
+		{
+		}
+
+		explicit param_type(bool allowIntMin)
+		    : allowIntMin(allowIntMin)
+		{
+		}
+
+		bool allowIntMin;
+
+		[[nodiscard]] friend bool operator==(const param_type &left, const param_type &right)
+		{
+			return left.allowIntMin == right.allowIntMin;
+		}
+	};
+
+	AbsoluteDistribution()
+	    : param_()
+	{
+	}
+
+	explicit AbsoluteDistribution(bool allowIntMin)
+	    : param_(allowIntMin)
+	{
+	}
+
+	void reset()
+	{
+	}
+
+	[[nodiscard]] param_type param() const
+	{
+		return param_;
+	}
+
+	void param(param_type &param)
+	{
+		param_ = param;
+	}
+
+	template <class Generator>
+	result_type operator()(Generator &generator, const param_type &param = {})
+	{
+		result_type value = static_cast<result_type>(generator());
+		// in an attempt to mask off the MSB the returned value is converted to a positive value
+		// however since abs(INT_MIN) is undefined behavior, need to handle this value specially
+		return value == std::numeric_limits<int32_t>::min() ? min() : abs(value);
+	}
+
+	[[nodiscard]] result_type min() const
+	{
+		return param_.allowIntMin ? std::numeric_limits<result_type>::min() : 0;
+	}
+
+	[[nodiscard]] result_type max() const
+	{
+		return std::numeric_limits<result_type>::max();
+	}
+
+	[[nodiscard]] friend bool operator==(const AbsoluteDistribution &left, const AbsoluteDistribution &right)
+	{
+		return left.param() == right.param();
+	}
+
+	template <class CharT, class Traits>
+	friend std::basic_ostream<CharT, Traits> &operator<<(std::basic_istream<CharT, Traits> &stream, const AbsoluteDistribution &distribution)
+	{
+		return stream << distribution.param_.allowIntMin;
+	}
+
+	template <class CharT, class Traits>
+	friend std::basic_istream<CharT, Traits> &operator>>(std::basic_istream<CharT, Traits> &stream, AbsoluteDistribution &distribution)
+	{
+		AbsoluteDistribution::param_type params;
+		stream >> params.allowIntMin;
+		distribution.param(params);
+		return stream;
+	}
+
+private:
+	param_type param_;
+};
+
+/**
+ * @brief This type of distribution uses the provided generator to get a random number within [min, max) in at most a single call to g()
+ *
+ * The distribution is slightly biased towards lower values unless the difference between min and max is a power of 2.
+ * This distribution function assumes the generator is a LCG engine and tries to compensate for biases in the sequence given by that type of
+ * engine. It attempts to discard the MSB by casting the unsigned value yielded by the engine to a signed value and taking the absolute value
+ * of the result. This can fail if the cast results in INT_MIN, so depending on the parameters provided we use either 0 or keep it unchanged.
+ * If the difference between min and max is not a power of 2 and you've set the allowIntMin parameter to true then this will return a value
+ * less than the min parameter.
+ */
+class DiabloDistribution {
+public:
+	using result_type = int32_t;
+
+	struct param_type {
+		using distribution_type = DiabloDistribution;
+
+		param_type()
+		    : min(0)
+		    , max(std::numeric_limits<result_type>::max())
+		    , allowIntMin(false)
+		{
+		}
+
+		explicit param_type(bool allowIntMin)
+		    : min(0)
+		    , max(std::numeric_limits<result_type>::max())
+		    , allowIntMin(allowIntMin)
+		{
+		}
+
+		explicit param_type(result_type max, bool allowIntMin = false)
+		    : min(0)
+		    , max(max)
+		    , allowIntMin(allowIntMin)
+		{
+		}
+
+		explicit param_type(result_type min, result_type max)
+		    : min(min)
+		    , max(max)
+		    , allowIntMin(false)
+		{
+		}
+
+		result_type min;
+		result_type max;
+		bool allowIntMin;
+
+		[[nodiscard]] friend bool operator==(const param_type &left, const param_type &right)
+		{
+			return left.min == right.min && left.max == right.max && left.allowIntMin == right.allowIntMin;
+		}
+	};
+
+	DiabloDistribution()
+	    : param_()
+	{
+	}
+
+	explicit DiabloDistribution(result_type max, bool allowIntMin = false)
+	    : param_(max, allowIntMin)
+	{
+	}
+
+	explicit DiabloDistribution(result_type min, result_type max)
+	    : param_(min, max)
+	{
+	}
+
+	void reset()
+	{
+	}
+
+	[[nodiscard]] param_type param() const
+	{
+		return param_;
+	}
+
+	void param(param_type &param)
+	{
+		param_ = param;
+	}
+
+	template <class Generator>
+	result_type operator()(Generator &generator)
+	{
+		return this->operator()(generator, param());
+	}
+
+	template <class Generator>
+	result_type operator()(Generator &generator, const param_type &param)
+	{
+		if (param.max <= param.min)
+			return 0;
+
+		result_type value = static_cast<result_type>(generator());
+
+		if (value == std::numeric_limits<int32_t>::min())
+			// in an attempt to mask off the MSB the returned value is converted to a positive value
+			// however since abs(INT_MIN) is undefined behavior, need to handle this value specially
+			value = param_.allowIntMin ? std::numeric_limits<result_type>::min() : 0;
+		else
+			value = abs(value);
+
+		if (param.max - param.min <= 0x7FFF) // This distribution assumes it is called with a LCG, for smaller values it uses the high bits to correct for LCG bias
+			value >>= 16;
+
+		return param.min + value % (param.max - param.min);
+	}
+
+	[[nodiscard]] result_type min() const
+	{
+		return param_.allowIntMin ? param_.min + std::numeric_limits<result_type>::min() % (param_.max - param_.min) : param_.min;
+	}
+
+	[[nodiscard]] result_type max() const
+	{
+		return param_.max - 1;
+	}
+
+	[[nodiscard]] friend bool operator==(const DiabloDistribution &left, const DiabloDistribution &right)
+	{
+		return left.param() == right.param();
+	}
+
+	template <class CharT, class Traits>
+	friend std::basic_ostream<CharT, Traits> &operator<<(std::basic_istream<CharT, Traits> &stream, const DiabloDistribution &distribution)
+	{
+		return stream << distribution.param_.min << ' ' << distribution.param_.max << ' ' << distribution.param_.allowIntMin;
+	}
+
+	template <class CharT, class Traits>
+	friend std::basic_istream<CharT, Traits> &operator>>(std::basic_istream<CharT, Traits> &stream, DiabloDistribution &distribution)
+	{
+		DiabloDistribution::param_type params;
+		stream >> params.min >> params.max >> params.allowIntMin;
+		distribution.param(params);
+		return stream;
+	}
+
+private:
+	param_type param_;
+};
+
+} // namespace devilution


### PR DESCRIPTION
With the way that the vanilla RNG works it's a combination of a specific `uniform random bit generator` (a `linear_congruential_engine` using the Borland C++ constants) and one of two related near-uniform int distribution functions depending on the use case. Given we can use the engine from `<random>` I implemented the classes required to meet the `RandomNumberDistribution` concept for both distribution functions (at least far enough to compile in MSVC...)

This should hopefully allow code paths that require these exact engine and distribution functions to use their own generator instances instead of relying on global state. Opening this as a draft until I can find a good enough code path to use to show how it can be used for item generation...

Up to this commit the timedemo test passes, depending on how the global state is handled when generating items during dungeon generation and/or gameplay this will break.