### PR TITLE
Remove global gossip variables and Towner::seed

### DIFF
--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -120,11 +120,6 @@ int8_t stextscrldbtn;
 /** Remember current store while displaying a dialog */
 TalkID stextshold;
 
-/** Start of possible gossip dialogs for current store */
-_speech_id gossipstart;
-/** End of possible gossip dialogs for current store */
-_speech_id gossipend;
-
 /** Temporary item used to hold the the item being traided */
 Item StoreItem;
 
@@ -1344,8 +1339,6 @@ void SmithEnter()
 		talker = TOWN_SMITH;
 		stextlhold = 10;
 		stextshold = TalkID::Smith;
-		gossipstart = TEXT_GRISWOLD2;
-		gossipend = TEXT_GRISWOLD13;
 		StartStore(TalkID::Gossip);
 		break;
 	case 12:
@@ -1597,8 +1590,6 @@ void WitchEnter()
 		stextlhold = 12;
 		talker = TOWN_WITCH;
 		stextshold = TalkID::Witch;
-		gossipstart = TEXT_ADRIA2;
-		gossipend = TEXT_ADRIA13;
 		StartStore(TalkID::Gossip);
 		break;
 	case 14:
@@ -1764,8 +1755,6 @@ void BoyEnter()
 	talker = TOWN_PEGBOY;
 	stextshold = TalkID::Boy;
 	stextlhold = stextsel;
-	gossipstart = TEXT_WIRT2;
-	gossipend = TEXT_WIRT12;
 	StartStore(TalkID::Gossip);
 }
 
@@ -1934,8 +1923,6 @@ void HealerEnter()
 		stextlhold = 12;
 		talker = TOWN_HEALER;
 		stextshold = TalkID::Healer;
-		gossipstart = TEXT_PEPIN2;
-		gossipend = TEXT_PEPIN11;
 		StartStore(TalkID::Gossip);
 		break;
 	case 14:
@@ -1982,8 +1969,6 @@ void StorytellerEnter()
 		stextlhold = 12;
 		talker = TOWN_STORY;
 		stextshold = TalkID::Storyteller;
-		gossipstart = TEXT_STORY2;
-		gossipend = TEXT_STORY11;
 		StartStore(TalkID::Gossip);
 		break;
 	case 14:
@@ -2040,9 +2025,7 @@ void TalkEnter()
 	}
 
 	if (stextsel == sn - 2) {
-		SetRndSeed(Towners[talker].seed);
-		auto tq = static_cast<_speech_id>(gossipstart + GenerateRnd(gossipend - gossipstart + 1));
-		InitQTextMsg(tq);
+		InitQTextMsg(Towners[talker].gossip);
 		return;
 	}
 
@@ -2063,8 +2046,6 @@ void TavernEnter()
 		stextlhold = 12;
 		talker = TOWN_TAVERN;
 		stextshold = TalkID::Tavern;
-		gossipstart = TEXT_OGDEN2;
-		gossipend = TEXT_OGDEN10;
 		StartStore(TalkID::Gossip);
 		break;
 	case 18:
@@ -2080,8 +2061,6 @@ void BarmaidEnter()
 		stextlhold = 12;
 		talker = TOWN_BMAID;
 		stextshold = TalkID::Barmaid;
-		gossipstart = TEXT_GILLIAN2;
-		gossipend = TEXT_GILLIAN10;
 		StartStore(TalkID::Gossip);
 		break;
 	case 14:
@@ -2108,8 +2087,6 @@ void DrunkEnter()
 		stextlhold = 12;
 		talker = TOWN_DRUNK;
 		stextshold = TalkID::Drunk;
-		gossipstart = TEXT_FARNHAM2;
-		gossipend = TEXT_FARNHAM13;
 		StartStore(TalkID::Gossip);
 		break;
 	case 18:

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -44,7 +44,6 @@ void InitTownerInfo(int i, const TownerData &townerData)
 	towner._ttype = townerData.type;
 	towner.position = townerData.position;
 	towner.talk = townerData.talk;
-	towner.seed = AdvanceRndSeed(); // TODO: Narrowing conversion, tSeed might need to be uint16_t
 
 	dMonster[towner.position.x][towner.position.y] = i + 1;
 
@@ -79,6 +78,7 @@ void InitSmith(Towner &towner, const TownerData &townerData)
 	towner.animOrderSize = sizeof(AnimOrder);
 	LoadTownerAnimations(towner, "towners\\smith\\smithn", 16, 3);
 	towner.name = _("Griswold the Blacksmith");
+	towner.gossip = PickRandomlyAmong({ TEXT_GRISWOLD2, TEXT_GRISWOLD3, TEXT_GRISWOLD4, TEXT_GRISWOLD5, TEXT_GRISWOLD6, TEXT_GRISWOLD7, TEXT_GRISWOLD8, TEXT_GRISWOLD9, TEXT_GRISWOLD10, TEXT_GRISWOLD12, TEXT_GRISWOLD13 });
 }
 
 void InitBarOwner(Towner &towner, const TownerData &townerData)
@@ -101,6 +101,7 @@ void InitBarOwner(Towner &towner, const TownerData &townerData)
 	towner.animOrderSize = sizeof(AnimOrder);
 	LoadTownerAnimations(towner, "towners\\twnf\\twnfn", 16, 3);
 	towner.name = _("Ogden the Tavern owner");
+	towner.gossip = PickRandomlyAmong({ TEXT_OGDEN2, TEXT_OGDEN3, TEXT_OGDEN4, TEXT_OGDEN5, TEXT_OGDEN6, TEXT_OGDEN8, TEXT_OGDEN9, TEXT_OGDEN10 });
 }
 
 void InitTownDead(Towner &towner, const TownerData &townerData)
@@ -132,6 +133,7 @@ void InitWitch(Towner &towner, const TownerData &townerData)
 	towner.animOrderSize = sizeof(AnimOrder);
 	LoadTownerAnimations(towner, "towners\\townwmn1\\witch", 19, 6);
 	towner.name = _("Adria the Witch");
+	towner.gossip = PickRandomlyAmong({ TEXT_ADRIA2, TEXT_ADRIA3, TEXT_ADRIA4, TEXT_ADRIA5, TEXT_ADRIA6, TEXT_ADRIA7, TEXT_ADRIA8, TEXT_ADRIA9, TEXT_ADRIA10, TEXT_ADRIA12, TEXT_ADRIA13 });
 }
 
 void InitBarmaid(Towner &towner, const TownerData &townerData)
@@ -141,6 +143,7 @@ void InitBarmaid(Towner &towner, const TownerData &townerData)
 	towner.animOrderSize = 0;
 	LoadTownerAnimations(towner, "towners\\townwmn1\\wmnn", 18, 6);
 	towner.name = _("Gillian the Barmaid");
+	towner.gossip = PickRandomlyAmong({ TEXT_GILLIAN2, TEXT_GILLIAN3, TEXT_GILLIAN4, TEXT_GILLIAN5, TEXT_GILLIAN6, TEXT_GILLIAN7, TEXT_GILLIAN9, TEXT_GILLIAN10 });
 }
 
 void InitBoy(Towner &towner, const TownerData &townerData)
@@ -150,6 +153,7 @@ void InitBoy(Towner &towner, const TownerData &townerData)
 	towner.animOrderSize = 0;
 	LoadTownerAnimations(towner, "towners\\townboy\\pegkid1", 20, 6);
 	towner.name = _("Wirt the Peg-legged boy");
+	towner.gossip = PickRandomlyAmong({ TEXT_WIRT2, TEXT_WIRT3, TEXT_WIRT4, TEXT_WIRT5, TEXT_WIRT6, TEXT_WIRT7, TEXT_WIRT8, TEXT_WIRT9, TEXT_WIRT11, TEXT_WIRT12 });
 }
 
 void InitHealer(Towner &towner, const TownerData &townerData)
@@ -172,6 +176,7 @@ void InitHealer(Towner &towner, const TownerData &townerData)
 	towner.animOrderSize = sizeof(AnimOrder);
 	LoadTownerAnimations(towner, "towners\\healer\\healer", 20, 6);
 	towner.name = _("Pepin the Healer");
+	towner.gossip = PickRandomlyAmong({ TEXT_PEPIN2, TEXT_PEPIN3, TEXT_PEPIN4, TEXT_PEPIN5, TEXT_PEPIN6, TEXT_PEPIN7, TEXT_PEPIN9, TEXT_PEPIN10, TEXT_PEPIN11 });
 }
 
 void InitTeller(Towner &towner, const TownerData &townerData)
@@ -189,6 +194,7 @@ void InitTeller(Towner &towner, const TownerData &townerData)
 	towner.animOrderSize = sizeof(AnimOrder);
 	LoadTownerAnimations(towner, "towners\\strytell\\strytell", 25, 3);
 	towner.name = _("Cain the Elder");
+	towner.gossip = PickRandomlyAmong({ TEXT_STORY2, TEXT_STORY3, TEXT_STORY4, TEXT_STORY5, TEXT_STORY6, TEXT_STORY7, TEXT_STORY9, TEXT_STORY10, TEXT_STORY11 });
 }
 
 void InitDrunk(Towner &towner, const TownerData &townerData)
@@ -205,6 +211,7 @@ void InitDrunk(Towner &towner, const TownerData &townerData)
 	towner.animOrderSize = sizeof(AnimOrder);
 	LoadTownerAnimations(towner, "towners\\drunk\\twndrunk", 18, 3);
 	towner.name = _("Farnham the Drunk");
+	towner.gossip = PickRandomlyAmong({ TEXT_FARNHAM2, TEXT_FARNHAM3, TEXT_FARNHAM4, TEXT_FARNHAM5, TEXT_FARNHAM6, TEXT_FARNHAM8, TEXT_FARNHAM9, TEXT_FARNHAM10, TEXT_FARNHAM11, TEXT_FARNHAM12, TEXT_FARNHAM13 });
 }
 
 void InitCows(Towner &towner, const TownerData &townerData)

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -46,8 +46,8 @@ struct Towner {
 
 	/** Tile position of NPC */
 	Point position;
-	/** Used to get a voice line and text related to active quests when the player speaks to a town npc */
-	int16_t seed;
+	/** Randomly chosen topic for discussion (picked when loading into town) */
+	_speech_id gossip;
 	uint16_t _tAnimWidth;
 	/** Tick length of each frame in the current animation */
 	int16_t _tAnimDelay;


### PR DESCRIPTION
Replace this with a direct reference to the chosen gossip topic when towners are init.