### PR TITLE
Fix width of Monk bow animation

### DIFF
--- a/Source/playerdat.cpp
+++ b/Source/playerdat.cpp
@@ -96,13 +96,13 @@ const PlayerData PlayersData[] = {
 /** Contains the data related to each player class. */
 const PlayerSpriteData PlayersSpriteData[] = {
 	// clang-format off
-// HeroClass                 stand, walk, attack, bow, swHit, block, lightning, fire, magic, death
+// HeroClass                   stand,   walk,   attack,   bow, swHit,   block,   lightning,   fire,   magic,   death
 
 // TRANSLATORS: Player Block
 /* HeroClass::Warrior */   {      96,     96,      128,    96,    96,      96,          96,     96,      96,     128 },
 /* HeroClass::Rogue */     {      96,     96,      128,   128,    96,      96,          96,     96,      96,     128 },
 /* HeroClass::Sorcerer */  {      96,     96,      128,   128,    96,      96,         128,    128,     128,     128 },
-/* HeroClass::Monk */      {     112,    112,      130,   128,    98,      98,         114,    114,     114,     160 },
+/* HeroClass::Monk */      {     112,    112,      130,   130,    98,      98,         114,    114,     114,     160 },
 /* HeroClass::Bard */      {      96,     96,      128,   128,    96,      96,          96,     96,      96,     128 },
 /* HeroClass::Barbarian */ {      96,     96,      128,    96,    96,      96,          96,     96,      96,     128 },
 	// clang-format on


### PR DESCRIPTION
Fixes an issue where Monk's sprite would deform when performing an attack with a bow.

![image](https://user-images.githubusercontent.com/9203145/236633109-38b0c68c-7607-4022-9913-3fc24101781f.png)