### PR TITLE
Update gbActive correctly when minimizing the app

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -485,9 +485,9 @@ void UiHandleEvents(SDL_Event *event)
 	HandleControllerAddedOrRemovedEvent(*event);
 
 	if (event->type == SDL_WINDOWEVENT) {
-		if (event->window.event == SDL_WINDOWEVENT_SHOWN) {
+		if (IsAnyOf(event->window.event, SDL_WINDOWEVENT_SHOWN, SDL_WINDOWEVENT_EXPOSED)) {
 			gbActive = true;
-		} else if (event->window.event == SDL_WINDOWEVENT_HIDDEN) {
+		} else if (IsAnyOf(event->window.event, SDL_WINDOWEVENT_HIDDEN, SDL_WINDOWEVENT_MINIMIZED)) {
 			gbActive = false;
 		} else if (event->window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
 			ReinitializeHardwareCursor();

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -331,13 +331,12 @@ void MainWndProc(const SDL_Event &event)
 		return;
 	switch (event.window.event) {
 	case SDL_WINDOWEVENT_HIDDEN:
+	case SDL_WINDOWEVENT_MINIMIZED:
 		gbActive = false;
 		break;
 	case SDL_WINDOWEVENT_SHOWN:
-		gbActive = false;
-		RedrawEverything();
-		break;
 	case SDL_WINDOWEVENT_EXPOSED:
+		gbActive = true;
 		RedrawEverything();
 		break;
 	case SDL_WINDOWEVENT_SIZE_CHANGED:


### PR DESCRIPTION
Fixes a crash when the game is in fullscreen mode (with upscaling=1) and minimizing the window (win+m or win+d).

## Notes
- When the game is minimized on windows only `SDL_WINDOWEVENT_MINIMIZED` is send. But `SDL_WINDOWEVENT_HIDDEN` isn't. This PR handles `SDL_WINDOWEVENT_MINIMIZED` like `SDL_WINDOWEVENT_HIDDEN`: assume game is not active and don't render.
- When the game is activated again on windows only `SDL_WINDOWEVENT_EXPOSED` is send. But `SDL_WINDOWEVENT_SHOWN` isn't. This PR handles `SDL_WINDOWEVENT_EXPOSED` like `SDL_WINDOWEVENT_SHOWN`: assume game is active and render everything again.
- Prevents rendering when the game is minimized (saves some cpu cylcles)
- Also fixes that the intro is played when the game is minimized

Tested only on windows. It would be great if someone else could test this at least on linux.