### PR TITLE
Fix state of doors after ObjChangeMapResync

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3644,6 +3644,21 @@ void SyncDoor(Object &door)
 	}
 }
 
+void ResyncDoors(WorldTilePosition p1, WorldTilePosition p2)
+{
+	const WorldTileSize size { static_cast<WorldTileCoord>(p2.x - p1.x), static_cast<WorldTileCoord>(p2.y - p1.y) };
+	const WorldTileRectangle area { p1, size };
+
+	for (WorldTilePosition p : PointsInRectangleRange<WorldTileCoord> { area }) {
+		Object *obj = FindObjectAtPosition(p);
+		if (obj == nullptr)
+			continue;
+		if (IsNoneOf(obj->_otype, OBJ_L1LDOOR, OBJ_L1RDOOR, OBJ_L2LDOOR, OBJ_L2RDOOR, OBJ_L3LDOOR, OBJ_L3RDOOR, OBJ_L5LDOOR, OBJ_L5RDOOR))
+			continue;
+		SyncDoor(*obj);
+	}
+}
+
 void UpdateState(Object &object, int frame)
 {
 	if (object._oSelFlag == 0) {
@@ -4350,8 +4365,8 @@ void ObjChangeMap(int x1, int y1, int x2, int y2)
 		}
 	}
 
-	WorldTilePosition mega1 { x1, y1 };
-	WorldTilePosition mega2 { x2, y2 };
+	WorldTilePosition mega1 { static_cast<WorldTileCoord>(x1), static_cast<WorldTileCoord>(y1) };
+	WorldTilePosition mega2 { static_cast<WorldTileCoord>(x2), static_cast<WorldTileCoord>(y2) };
 	WorldTilePosition world1 = mega1.megaToWorld();
 	WorldTilePosition world2 = mega2.megaToWorld() + Displacement { 1, 1 };
 	if (leveltype == DTYPE_CATHEDRAL) {
@@ -4368,6 +4383,7 @@ void ObjChangeMap(int x1, int y1, int x2, int y2)
 	if (leveltype == DTYPE_CRYPT) {
 		AddCryptObjects(world1.x, world1.y, world2.x, world2.y);
 	}
+	ResyncDoors(world1, world2);
 }
 
 void ObjChangeMapResync(int x1, int y1, int x2, int y2)
@@ -4379,8 +4395,8 @@ void ObjChangeMapResync(int x1, int y1, int x2, int y2)
 		}
 	}
 
-	WorldTilePosition mega1 { x1, y1 };
-	WorldTilePosition mega2 { x2, y2 };
+	WorldTilePosition mega1 { static_cast<WorldTileCoord>(x1), static_cast<WorldTileCoord>(y1) };
+	WorldTilePosition mega2 { static_cast<WorldTileCoord>(x2), static_cast<WorldTileCoord>(y2) };
 	WorldTilePosition world1 = mega1.megaToWorld();
 	WorldTilePosition world2 = mega2.megaToWorld() + Displacement { 1, 1 };
 	if (leveltype == DTYPE_CATHEDRAL) {
@@ -4389,6 +4405,7 @@ void ObjChangeMapResync(int x1, int y1, int x2, int y2)
 	if (leveltype == DTYPE_CATACOMBS) {
 		ObjL2Special(world1.x, world1.y, world2.x, world2.y);
 	}
+	ResyncDoors(world1, world2);
 }
 
 _item_indexes ItemMiscIdIdx(item_misc_id imiscid)

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4349,19 +4349,24 @@ void ObjChangeMap(int x1, int y1, int x2, int y2)
 			dungeon[i][j] = pdungeon[i][j];
 		}
 	}
+
+	WorldTilePosition mega1 { x1, y1 };
+	WorldTilePosition mega2 { x2, y2 };
+	WorldTilePosition world1 = mega1.megaToWorld();
+	WorldTilePosition world2 = mega2.megaToWorld() + Displacement { 1, 1 };
 	if (leveltype == DTYPE_CATHEDRAL) {
-		ObjL1Special(2 * x1 + 16, 2 * y1 + 16, 2 * x2 + 17, 2 * y2 + 17);
-		AddL1Objs(2 * x1 + 16, 2 * y1 + 16, 2 * x2 + 17, 2 * y2 + 17);
+		ObjL1Special(world1.x, world1.y, world2.x, world2.y);
+		AddL1Objs(world1.x, world1.y, world2.x, world2.y);
 	}
 	if (leveltype == DTYPE_CATACOMBS) {
-		ObjL2Special(2 * x1 + 16, 2 * y1 + 16, 2 * x2 + 17, 2 * y2 + 17);
-		AddL2Objs(2 * x1 + 16, 2 * y1 + 16, 2 * x2 + 17, 2 * y2 + 17);
+		ObjL2Special(world1.x, world1.y, world2.x, world2.y);
+		AddL2Objs(world1.x, world1.y, world2.x, world2.y);
 	}
 	if (leveltype == DTYPE_CAVES) {
-		AddL3Objs(2 * x1 + 16, 2 * y1 + 16, 2 * x2 + 17, 2 * y2 + 17);
+		AddL3Objs(world1.x, world1.y, world2.x, world2.y);
 	}
 	if (leveltype == DTYPE_CRYPT) {
-		AddCryptObjects(2 * x1 + 16, 2 * y1 + 16, 2 * x2 + 17, 2 * y2 + 17);
+		AddCryptObjects(world1.x, world1.y, world2.x, world2.y);
 	}
 }
 
@@ -4373,11 +4378,16 @@ void ObjChangeMapResync(int x1, int y1, int x2, int y2)
 			dungeon[i][j] = pdungeon[i][j];
 		}
 	}
+
+	WorldTilePosition mega1 { x1, y1 };
+	WorldTilePosition mega2 { x2, y2 };
+	WorldTilePosition world1 = mega1.megaToWorld();
+	WorldTilePosition world2 = mega2.megaToWorld() + Displacement { 1, 1 };
 	if (leveltype == DTYPE_CATHEDRAL) {
-		ObjL1Special(2 * x1 + 16, 2 * y1 + 16, 2 * x2 + 17, 2 * y2 + 17);
+		ObjL1Special(world1.x, world1.y, world2.x, world2.y);
 	}
 	if (leveltype == DTYPE_CATACOMBS) {
-		ObjL2Special(2 * x1 + 16, 2 * y1 + 16, 2 * x2 + 17, 2 * y2 + 17);
+		ObjL2Special(world1.x, world1.y, world2.x, world2.y);
 	}
 }
 


### PR DESCRIPTION
When the Book of the Blind is first used, `ObjChangeMap()` will update the `dPiece` values for the setpiece using the values in `pMegaTiles`. For doors, this assigned the `dPiece` value the door would have if it were open. This normally gets corrected by `AddL2Objs()` which creates all new doors to replace the existing doors, forcing the new doors into a closed state and updating the `dPiece` values.

If the level has no more space for new doors, the door won't be replaced and the door state won't be forced into the closed state. Also, when loading the delta for the Book of the Blind object, the code would instead call `ObjChangeMapResync()` which doesn't call `AddL2Objs()`. In both of these cases, the `dPiece` would be forced to the open state regardless of the existing door's state.

This PR introduces a `ResyncDoors()` function to force the `dPiece` state to match the door state for all tiles that were updated by `ObjChangeMap()` and `ObjChangeMapResync()`.

This resolves #5953