### PR TITLE
Load deltas after saving pre-lighting data

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2816,12 +2816,11 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 #ifdef _DEBUG
 				SetDebugLevelSeedInfos(mid1Seed, mid2Seed, mid3Seed, GetLCGEngineState());
 #endif
+				SavePreLighting();
+				IncProgress();
 
 				if (gbIsMultiplayer)
 					DeltaLoadLevel();
-
-				IncProgress();
-				SavePreLighting();
 			} else {
 				HoldThemeRooms();
 				InitGolems();


### PR DESCRIPTION
`DeltaLoadLevel()` calls `DeltaSyncOpObject()` for the pedestal, leading to `UpdatePedestalState()`, `SyncPedestal()`, and finally `LoadMapObjects()`. This last function appropriately sets `LoadingMapObjects = true` to indicate that any new light objects should be working directly with `dPreLight` instead of `dLight`. The only caveat is that `DeltaLoadLevel()` is called before `SavePreLighting()`, which is what initially copies light data from `dLight` to `dPreLight` during level generation.

This PR swaps the order of those function calls to match the order they are called on setlevels. Lighting changes for monsters and portals are handled later in `LoadGameLevel()` so changing the function call order here shouldn't cause any problems with other light sources.

Special thanks to AJenbo for talking me through the `dLight` vs `dPreLight` and level generation vs runtime lighting behavior. He has a plan to clean some of this up for the long-term, but this PR should be good enough to resolve the bug for 1.5.0.

This resolves #6087