### PR TITLE
Dedupe OnRespawnItem/OnSpawnItem

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1666,7 +1666,7 @@ void AutoGetItem(Player &player, Item *itemPointer, int ii)
 		player.Say(HeroSpeech::ICantCarryAnymore);
 	}
 	RespawnItem(item, true);
-	NetSendCmdPItem(true, CMD_RESPAWNITEM, item.position, item);
+	NetSendCmdPItem(true, CMD_SPAWNITEM, item.position, item);
 }
 
 int FindGetItem(uint32_t iseed, _item_indexes idx, uint16_t createInfo)

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1364,27 +1364,6 @@ size_t OnSyncPutItem(const TCmd *pCmd, size_t pnum)
 	return sizeof(message);
 }
 
-size_t OnRespawnItem(const TCmd *pCmd, size_t pnum)
-{
-	const auto &message = *reinterpret_cast<const TCmdPItem *>(pCmd);
-
-	if (gbBufferMsgs == 1) {
-		SendPacket(pnum, &message, sizeof(message));
-	} else if (IsPItemValid(message)) {
-		Player &player = Players[pnum];
-		if (player.isOnActiveLevel() && &player != MyPlayer) {
-			SyncDropItem(message);
-		}
-		const int32_t dwSeed = SDL_SwapLE32(message.def.dwSeed);
-		const uint16_t wCI = SDL_SwapLE16(message.def.wCI);
-		const _item_indexes wIndx = static_cast<_item_indexes>(SDL_SwapLE16(message.def.wIndx));
-		PutItemRecord(dwSeed, wCI, wIndx);
-		DeltaPutItem(message, { message.x, message.y }, player);
-	}
-
-	return sizeof(message);
-}
-
 size_t OnAttackTile(const TCmd *pCmd, Player &player)
 {
 	const auto &message = *reinterpret_cast<const TCmdLoc *>(pCmd);
@@ -3166,8 +3145,6 @@ size_t ParseCmd(size_t pnum, const TCmd *pCmd)
 		return OnSyncPutItem(pCmd, pnum);
 	case CMD_SPAWNITEM:
 		return OnSpawnItem(pCmd, pnum);
-	case CMD_RESPAWNITEM:
-		return OnRespawnItem(pCmd, pnum);
 	case CMD_ATTACKXY:
 		return OnAttackTile(pCmd, player);
 	case CMD_SATTACKXY:

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -63,15 +63,10 @@ enum _cmd_id : uint8_t {
 	//
 	// body (TCmdPItem)
 	CMD_PUTITEM,
-	// Spawn item on ground (place quest items).
-	//
+	// Spawn item on ground (place quest items, drop dead player item, or drop
+	// attempted loot item when inventory is full).
 	// body (TCmdPItem)
 	CMD_SPAWNITEM,
-	// Respawn item on ground (drop dead player item, or drop attempted loot item
-	// when inventory is full).
-	//
-	// body (TCmdPItem)
-	CMD_RESPAWNITEM,
 	// Attack target location.
 	//
 	// body (TCmdLoc)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -340,7 +340,7 @@ void RespawnDeadItem(Item &&itm, Point target)
 	Items[ii] = itm;
 	Items[ii].position = target;
 	RespawnItem(Items[ii], true);
-	NetSendCmdPItem(false, CMD_RESPAWNITEM, target, Items[ii]);
+	NetSendCmdPItem(false, CMD_SPAWNITEM, target, Items[ii]);
 }
 
 void DeadItem(Player &player, Item &&itm, Displacement direction)


### PR DESCRIPTION
Both methods were exactly the same apart from the use of temporaries for swapped message params.