### PR TITLE
Deduplicate logic for placing an item in the current level

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1742,14 +1742,8 @@ bool CanPut(Point position)
 	return true;
 }
 
-int InvPutItem(const Player &player, Point position, const Item &item)
+int PlaceItemInWorld(const Item &item, WorldTilePosition position)
 {
-	std::optional<Point> itemTile = FindAdjacentPositionForItem(player.position.tile, GetDirection(player.position.tile, position));
-	if (!itemTile)
-		return -1;
-
-	Point position = *itemTile;
-
 	int ii = AllocateItem();
 
 	dItem[position.x][position.y] = ii + 1;
@@ -1766,6 +1760,15 @@ int InvPutItem(const Player &player, Point position, const Item &item)
 	}
 
 	return ii;
+}
+
+int InvPutItem(const Player &player, Point position, const Item &item)
+{
+	std::optional<Point> itemTile = FindAdjacentPositionForItem(player.position.tile, GetDirection(player.position.tile, position));
+	if (!itemTile)
+		return -1;
+
+	return PlaceItemInWorld(item, *itemTile);
 }
 
 int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac)
@@ -1790,22 +1793,7 @@ int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int is
 	item._iAC = ac;
 	item.dwBuff = ibuff;
 
-	int ii = AllocateItem();
-
-	dItem[position.x][position.y] = ii + 1;
-	auto &item_ = Items[ii];
-	item_ = item;
-	item_.position = position;
-	RespawnItem(item_, true);
-
-	if (CornerStone.isAvailable() && position == CornerStone.position) {
-		CornerStone.item = item_;
-		InitQTextMsg(TEXT_CORNSTN);
-		Quests[Q_CORNSTN]._qlog = false;
-		Quests[Q_CORNSTN]._qactive = QUEST_DONE;
-	}
-
-	return ii;
+	return PlaceItemInWorld(item, position);
 }
 
 int SyncDropEar(Point position, uint16_t icreateinfo, uint32_t iseed, uint8_t cursval, string_view heroname)
@@ -1816,22 +1804,7 @@ int SyncDropEar(Point position, uint16_t icreateinfo, uint32_t iseed, uint8_t cu
 	Item item;
 	RecreateEar(item, icreateinfo, iseed, cursval, heroname);
 
-	int ii = AllocateItem();
-
-	dItem[position.x][position.y] = ii + 1;
-	auto &item_ = Items[ii];
-	item_ = item;
-	item_.position = position;
-	RespawnItem(item_, true);
-
-	if (CornerStone.isAvailable() && position == CornerStone.position) {
-		CornerStone.item = item_;
-		InitQTextMsg(TEXT_CORNSTN);
-		Quests[Q_CORNSTN]._qlog = false;
-		Quests[Q_CORNSTN]._qactive = QUEST_DONE;
-	}
-
-	return ii;
+	return PlaceItemInWorld(item, position);
 }
 
 int8_t CheckInvHLight()

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1742,26 +1742,6 @@ bool CanPut(Point position)
 	return true;
 }
 
-int PlaceItemInWorld(const Item &item, WorldTilePosition position)
-{
-	int ii = AllocateItem();
-
-	dItem[position.x][position.y] = ii + 1;
-	auto &item_ = Items[ii];
-	item_ = item;
-	item_.position = position;
-	RespawnItem(item_, true);
-
-	if (CornerStone.isAvailable() && position == CornerStone.position) {
-		CornerStone.item = item_;
-		InitQTextMsg(TEXT_CORNSTN);
-		Quests[Q_CORNSTN]._qlog = false;
-		Quests[Q_CORNSTN]._qactive = QUEST_DONE;
-	}
-
-	return ii;
-}
-
 int InvPutItem(const Player &player, Point position, const Item &item)
 {
 	std::optional<Point> itemTile = FindAdjacentPositionForItem(player.position.tile, GetDirection(player.position.tile, position));

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1764,7 +1764,7 @@ int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int is
 	item._iAC = ac;
 	item.dwBuff = ibuff;
 
-	return PlaceItemInWorld(item, position);
+	return PlaceItemInWorld(std::move(item), position);
 }
 
 int SyncDropEar(Point position, uint16_t icreateinfo, uint32_t iseed, uint8_t cursval, string_view heroname)
@@ -1775,7 +1775,7 @@ int SyncDropEar(Point position, uint16_t icreateinfo, uint32_t iseed, uint8_t cu
 	Item item;
 	RecreateEar(item, icreateinfo, iseed, cursval, heroname);
 
-	return PlaceItemInWorld(item, position);
+	return PlaceItemInWorld(std::move(item), position);
 }
 
 int8_t CheckInvHLight()

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1748,15 +1748,18 @@ int InvPutItem(const Player &player, Point position, const Item &item)
 	if (!itemTile)
 		return -1;
 
+	Point position = *itemTile;
+
 	int ii = AllocateItem();
 
-	dItem[itemTile->x][itemTile->y] = ii + 1;
-	Items[ii] = item;
-	Items[ii].position = *itemTile;
-	RespawnItem(Items[ii], true);
+	dItem[position.x][position.y] = ii + 1;
+	auto &item_ = Items[ii];
+	item_ = item;
+	item_.position = position;
+	RespawnItem(item_, true);
 
-	if (CornerStone.isAvailable() && *itemTile == CornerStone.position) {
-		CornerStone.item = Items[ii];
+	if (CornerStone.isAvailable() && position == CornerStone.position) {
+		CornerStone.item = item_;
 		InitQTextMsg(TEXT_CORNSTN);
 		Quests[Q_CORNSTN]._qlog = false;
 		Quests[Q_CORNSTN]._qactive = QUEST_DONE;
@@ -1770,10 +1773,7 @@ int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int is
 	if (ActiveItemCount >= MAXITEMS)
 		return -1;
 
-	int ii = AllocateItem();
-	auto &item = Items[ii];
-
-	dItem[position.x][position.y] = ii + 1;
+	Item item;
 
 	RecreateItem(*MyPlayer, item, idx, icreateinfo, iseed, ivalue, (ibuff & CF_HELLFIRE) != 0);
 	if (id != 0)
@@ -1789,15 +1789,22 @@ int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int is
 	item._iMinDex = minDex;
 	item._iAC = ac;
 	item.dwBuff = ibuff;
-	item.position = position;
-	RespawnItem(item, true);
+
+	int ii = AllocateItem();
+
+	dItem[position.x][position.y] = ii + 1;
+	auto &item_ = Items[ii];
+	item_ = item;
+	item_.position = position;
+	RespawnItem(item_, true);
 
 	if (CornerStone.isAvailable() && position == CornerStone.position) {
-		CornerStone.item = item;
+		CornerStone.item = item_;
 		InitQTextMsg(TEXT_CORNSTN);
 		Quests[Q_CORNSTN]._qlog = false;
 		Quests[Q_CORNSTN]._qactive = QUEST_DONE;
 	}
+
 	return ii;
 }
 
@@ -1806,20 +1813,24 @@ int SyncDropEar(Point position, uint16_t icreateinfo, uint32_t iseed, uint8_t cu
 	if (ActiveItemCount >= MAXITEMS)
 		return -1;
 
+	Item item;
+	RecreateEar(item, icreateinfo, iseed, cursval, heroname);
+
 	int ii = AllocateItem();
-	auto &item = Items[ii];
 
 	dItem[position.x][position.y] = ii + 1;
-	RecreateEar(item, icreateinfo, iseed, cursval, heroname);
-	item.position = position;
-	RespawnItem(item, true);
+	auto &item_ = Items[ii];
+	item_ = item;
+	item_.position = position;
+	RespawnItem(item_, true);
 
 	if (CornerStone.isAvailable() && position == CornerStone.position) {
-		CornerStone.item = item;
+		CornerStone.item = item_;
 		InitQTextMsg(TEXT_CORNSTN);
 		Quests[Q_CORNSTN]._qlog = false;
 		Quests[Q_CORNSTN]._qactive = QUEST_DONE;
 	}
+
 	return ii;
 }
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1742,15 +1742,6 @@ bool CanPut(Point position)
 	return true;
 }
 
-int InvPutItem(const Player &player, Point position, const Item &item)
-{
-	std::optional<Point> itemTile = FindAdjacentPositionForItem(player.position.tile, GetDirection(player.position.tile, position));
-	if (!itemTile)
-		return -1;
-
-	return PlaceItemInWorld(item, *itemTile);
-}
-
 int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac)
 {
 	if (ActiveItemCount >= MAXITEMS)

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -218,7 +218,6 @@ void SyncGetItem(Point position, uint32_t iseed, _item_indexes idx, uint16_t ci)
  */
 bool CanPut(Point position);
 
-int InvPutItem(const Player &player, Point position, const Item &item);
 int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam, int minStr, int minMag, int minDex, int ac);
 int SyncDropEar(Point position, uint16_t icreateinfo, uint32_t iseed, uint8_t cursval, string_view heroname);
 int8_t CheckInvHLight();

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3113,13 +3113,16 @@ int AllocateItem()
 	return inum;
 }
 
-int PlaceItemInWorld(Item &&item, WorldTilePosition position)
+uint8_t PlaceItemInWorld(Item &&item, WorldTilePosition position)
 {
-	int ii = AllocateItem();
+	assert(ActiveItemCount < MAXITEMS);
+
+	uint8_t ii = ActiveItems[ActiveItemCount];
+	ActiveItemCount++;
 
 	dItem[position.x][position.y] = ii + 1;
 	auto &item_ = Items[ii];
-	item_ = item;
+	item_ = std::move(item);
 	item_.position = position;
 	RespawnItem(item_, true);
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -31,6 +31,7 @@
 #include "inv_iterators.hpp"
 #include "levels/town.h"
 #include "lighting.h"
+#include "minitext.h"
 #include "missiles.h"
 #include "options.h"
 #include "panels/info_box.hpp"
@@ -3110,6 +3111,26 @@ int AllocateItem()
 	Items[inum] = {};
 
 	return inum;
+}
+
+int PlaceItemInWorld(Item &&item, WorldTilePosition position)
+{
+	int ii = AllocateItem();
+
+	dItem[position.x][position.y] = ii + 1;
+	auto &item_ = Items[ii];
+	item_ = item;
+	item_.position = position;
+	RespawnItem(item_, true);
+
+	if (CornerStone.isAvailable() && position == CornerStone.position) {
+		CornerStone.item = item_;
+		InitQTextMsg(TEXT_CORNSTN);
+		Quests[Q_CORNSTN]._qlog = false;
+		Quests[Q_CORNSTN]._qactive = QUEST_DONE;
+	}
+
+	return ii;
 }
 
 Point GetSuperItemLoc(Point position)

--- a/Source/items.h
+++ b/Source/items.h
@@ -499,6 +499,13 @@ void SetPlrHandGoldCurs(Item &gold);
 void CreatePlrItems(Player &player);
 bool ItemSpaceOk(Point position);
 int AllocateItem();
+/**
+ * @brief Puts the item onto the floor of the current dungeon level
+ * @param item The source of the item data
+ * @param position Coordinates of the tile to place the item on
+ * @return The index assigned to the item
+ */
+int PlaceItemInWorld(const Item &item, WorldTilePosition position);
 Point GetSuperItemLoc(Point position);
 void GetItemAttrs(Item &item, _item_indexes itemData, int lvl);
 void SetupItem(Item &item);

--- a/Source/items.h
+++ b/Source/items.h
@@ -500,12 +500,12 @@ void CreatePlrItems(Player &player);
 bool ItemSpaceOk(Point position);
 int AllocateItem();
 /**
- * @brief Puts the item onto the floor of the current dungeon level
- * @param item The source of the item data
+ * @brief Moves the item onto the floor of the current dungeon level
+ * @param item The source of the item data, should not be used after calling this function
  * @param position Coordinates of the tile to place the item on
  * @return The index assigned to the item
  */
-int PlaceItemInWorld(const Item &item, WorldTilePosition position);
+uint8_t PlaceItemInWorld(Item &&item, WorldTilePosition position);
 Point GetSuperItemLoc(Point position);
 void GetItemAttrs(Item &item, _item_indexes itemData, int lvl);
 void SetupItem(Item &item);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1314,7 +1314,7 @@ size_t OnPutItem(const TCmd *pCmd, size_t pnum)
 			if (isSelf) {
 				std::optional<Point> itemTile = FindAdjacentPositionForItem(player.position.tile, GetDirection(player.position.tile, position));
 				if (itemTile)
-					ii = PlaceItemInWorld(ItemLimbo, *itemTile);
+					ii = PlaceItemInWorld(std::move(ItemLimbo), *itemTile);
 				else
 					ii = -1;
 			} else

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1311,9 +1311,13 @@ size_t OnPutItem(const TCmd *pCmd, size_t pnum)
 		const _item_indexes wIndx = static_cast<_item_indexes>(SDL_SwapLE16(message.def.wIndx));
 		if (player.isOnActiveLevel()) {
 			int ii;
-			if (isSelf)
-				ii = InvPutItem(player, position, ItemLimbo);
-			else
+			if (isSelf) {
+				std::optional<Point> itemTile = FindAdjacentPositionForItem(player.position.tile, GetDirection(player.position.tile, position));
+				if (itemTile)
+					ii = PlaceItemInWorld(ItemLimbo, *itemTile);
+				else
+					ii = -1;
+			} else
 				ii = SyncDropItem(message);
 			if (ii != -1) {
 				PutItemRecord(dwSeed, wCI, wIndx);


### PR DESCRIPTION
Specifically the cases which consider whether the item was placed on the CornerStone. There are many other uses of AllocateItem which skip that check, but it might be possible to get some commonality between them as well in the future...