### PR TITLE
Use sampling for testing missiles rotate evenly

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories(libdevilutionx_so INTERFACE "${PROJECT_SOURCE_DIR}/So
 set_target_properties(libdevilutionx_so PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 add_library(test_main STATIC main.cpp)
-target_link_libraries(test_main PUBLIC libdevilutionx_so GTest::gtest)
+target_link_libraries(test_main PUBLIC libdevilutionx_so GTest::gtest GTest::gmock)
 
 set(tests
   animationinfo_test

--- a/test/missiles_test.cpp
+++ b/test/missiles_test.cpp
@@ -1,9 +1,27 @@
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "engine/random.hpp"
 #include "missiles.h"
 
 using namespace devilution;
+using ::testing::AllOf;
+using ::testing::Gt;
+using ::testing::Lt;
+using ::testing::Pair;
+using ::testing::UnorderedElementsAre;
+
+void TestMissileRotatesUniformly(Missile &missile, int startingFrame, int leftFrame, int rightFrame)
+{
+	std::unordered_map<int, unsigned> observed {};
+	for (auto i = 0; i < 100; i++) {
+		missile._miAnimFrame = startingFrame;
+		TestRotateBlockedMissile(missile);
+		observed[missile._miAnimFrame]++;
+	}
+
+	EXPECT_THAT(observed, UnorderedElementsAre(Pair(leftFrame, AllOf(Gt(30), Lt(70))), Pair(rightFrame, AllOf(Gt(30), Lt(70))))) << "Arrows should rotate either direction roughly 50% of the time";
+}
 
 TEST(Missiles, RotateBlockedMissileArrow)
 {
@@ -17,18 +35,9 @@ TEST(Missiles, RotateBlockedMissileArrow)
 	Missile missile = *AddMissile({ 0, 0 }, { 0, 0 }, Direction::South, MissileID::Arrow, TARGET_MONSTERS, player.getId(), 0, 0);
 	EXPECT_EQ(missile._miAnimFrame, 1);
 
-	SetRndSeed(0);
-	TestRotateBlockedMissile(missile);
-	EXPECT_EQ(missile._miAnimFrame, 16);
-
-	SetRndSeed(3210);
-	TestRotateBlockedMissile(missile);
-	EXPECT_EQ(missile._miAnimFrame, 1);
-
-	missile._miAnimFrame = 5;
-	SetRndSeed(1234);
-	TestRotateBlockedMissile(missile);
-	EXPECT_EQ(missile._miAnimFrame, 6);
+	TestMissileRotatesUniformly(missile, 5, 4, 6);
+	TestMissileRotatesUniformly(missile, 1, 16, 2);
+	TestMissileRotatesUniformly(missile, 16, 15, 1);
 }
 
 TEST(Missiles, GetDirection8)


### PR DESCRIPTION
Avoids relying on a specific seed for test cases, hopefully 100 samples is enough to avoid long runs of a single direction? Normal runs seem to be 60/40 at worst. The tests fail when the rotation ends up 100% preferencing a single direction at least which is a pretty good indicator something broke.