### PR TITLE
Add missing <cstdint> includes

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -1,6 +1,7 @@
 #include "DiabloUI/diabloui.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <string>
 
 #include "DiabloUI/button.h"

--- a/Source/DiabloUI/hero/selhero.cpp
+++ b/Source/DiabloUI/hero/selhero.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <random>
 
 #include <fmt/format.h>

--- a/Source/DiabloUI/mainmenu.cpp
+++ b/Source/DiabloUI/mainmenu.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 
 #include "DiabloUI/diabloui.h"
 #include "DiabloUI/selok.h"

--- a/Source/DiabloUI/multi/selgame.cpp
+++ b/Source/DiabloUI/multi/selgame.cpp
@@ -1,5 +1,7 @@
 #include "DiabloUI/multi/selgame.h"
 
+#include <cstdint>
+
 #include <fmt/format.h>
 
 #include "DiabloUI/diabloui.h"

--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -1,5 +1,7 @@
 #include "selstart.h"
 
+#include <cstdint>
+
 #include <function_ref.hpp>
 
 #include "DiabloUI/diabloui.h"

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <string>
 
 #include <fmt/format.h>

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -6,6 +6,7 @@
 
 #ifdef _DEBUG
 
+#include <cstdint>
 #include <cstdio>
 
 #include "debug.h"

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <unordered_map>
 
 #include "engine.h"

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -4,6 +4,7 @@
  * Implementation of the main game initialization functions.
  */
 #include <array>
+#include <cstdint>
 
 #include <fmt/format.h>
 

--- a/Source/dvlnet/abstract_net.h
+++ b/Source/dvlnet/abstract_net.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <exception>
 #include <memory>
 #include <string>

--- a/Source/dvlnet/base.cpp
+++ b/Source/dvlnet/base.cpp
@@ -1,6 +1,7 @@
 #include "dvlnet/base.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 

--- a/Source/dvlnet/base.h
+++ b/Source/dvlnet/base.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <deque>
 #include <map>
 #include <memory>

--- a/Source/dvlnet/cdwrap.h
+++ b/Source/dvlnet/cdwrap.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <exception>
 #include <map>
 #include <memory>

--- a/Source/dvlnet/loopback.cpp
+++ b/Source/dvlnet/loopback.cpp
@@ -1,5 +1,7 @@
 #include "dvlnet/loopback.h"
 
+#include <cstdint>
+
 #include "multi.h"
 #include "player.h"
 #include "utils/language.h"

--- a/Source/dvlnet/loopback.h
+++ b/Source/dvlnet/loopback.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <queue>
 #include <string>
 

--- a/Source/dvlnet/protocol_zt.h
+++ b/Source/dvlnet/protocol_zt.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <cstdint>
 #include <deque>
 #include <exception>
 #include <map>

--- a/Source/encrypt.cpp
+++ b/Source/encrypt.cpp
@@ -5,6 +5,7 @@
  */
 #include <array>
 #include <cctype>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 

--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -1,5 +1,6 @@
 #include "engine/demomode.h"
 
+#include <cstdint>
 #include <cstdio>
 #include <deque>
 

--- a/Source/engine/dx.cpp
+++ b/Source/engine/dx.cpp
@@ -6,6 +6,7 @@
 #include "engine/dx.h"
 
 #include <SDL.h>
+#include <cstdint>
 
 #include "controls/plrctrls.h"
 #include "engine.h"

--- a/Source/engine/palette.cpp
+++ b/Source/engine/palette.cpp
@@ -5,6 +5,8 @@
  */
 #include "engine/palette.h"
 
+#include <cstdint>
+
 #include <fmt/core.h>
 
 #include "engine/backbuffer_state.hpp"

--- a/Source/engine/path.cpp
+++ b/Source/engine/path.cpp
@@ -6,6 +6,7 @@
 #include "engine/path.h"
 
 #include <array>
+#include <cstdint>
 
 #include <function_ref.hpp>
 

--- a/Source/engine/random.cpp
+++ b/Source/engine/random.cpp
@@ -1,5 +1,6 @@
 #include "engine/random.hpp"
 
+#include <cstdint>
 #include <limits>
 #include <random>
 

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -5,6 +5,8 @@
  */
 #include "engine/render/scrollrt.h"
 
+#include <cstdint>
+
 #include "DiabloUI/ui_flags.hpp"
 #include "automap.h"
 #include "controls/plrctrls.h"

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <unordered_map>
 #include <utility>
 

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -4,6 +4,7 @@
  * Implementation of in-game message functions.
  */
 
+#include <cstdint>
 #include <deque>
 
 #include "error.h"

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -5,6 +5,8 @@
  */
 #include "gmenu.h"
 
+#include <cstdint>
+
 #include "DiabloUI/ui_flags.hpp"
 #include "control.h"
 #include "controls/axis_direction.h"

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -3,9 +3,10 @@
  *
  * Implementation of player inventory.
  */
+#include <algorithm>
+#include <cstdint>
 #include <utility>
 
-#include <algorithm>
 #include <fmt/format.h>
 
 #include "DiabloUI/ui_flags.hpp"

--- a/Source/levels/drlg_l1.cpp
+++ b/Source/levels/drlg_l1.cpp
@@ -1,5 +1,7 @@
 #include "levels/drlg_l1.h"
 
+#include <cstdint>
+
 #include "engine/load_file.hpp"
 #include "engine/point.hpp"
 #include "engine/random.hpp"

--- a/Source/levels/drlg_l1.h
+++ b/Source/levels/drlg_l1.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #include "engine/world_tile.hpp"
 #include "levels/gendung.h"
 

--- a/Source/levels/drlg_l2.cpp
+++ b/Source/levels/drlg_l2.cpp
@@ -5,6 +5,7 @@
  */
 #include "levels/drlg_l2.h"
 
+#include <cstdint>
 #include <list>
 
 #include "diablo.h"

--- a/Source/levels/drlg_l2.h
+++ b/Source/levels/drlg_l2.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #include "levels/gendung.h"
 
 namespace devilution {

--- a/Source/levels/drlg_l3.cpp
+++ b/Source/levels/drlg_l3.cpp
@@ -1,4 +1,7 @@
+#include "levels/drlg_l3.h"
+
 #include <algorithm>
+#include <cstdint>
 
 #include "engine/load_file.hpp"
 #include "engine/points_in_rectangle_range.hpp"

--- a/Source/levels/drlg_l3.h
+++ b/Source/levels/drlg_l3.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #include "levels/gendung.h"
 
 namespace devilution {

--- a/Source/levels/drlg_l4.cpp
+++ b/Source/levels/drlg_l4.cpp
@@ -5,6 +5,8 @@
  */
 #include "levels/drlg_l4.h"
 
+#include <cstdint>
+
 #include "engine/load_file.hpp"
 #include "engine/random.hpp"
 #include "levels/gendung.h"

--- a/Source/levels/drlg_l4.h
+++ b/Source/levels/drlg_l4.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #include "engine/world_tile.hpp"
 #include "levels/gendung.h"
 

--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -1,6 +1,7 @@
-#include <stack>
-
 #include "levels/gendung.h"
+
+#include <cstdint>
+#include <stack>
 
 #include "engine/load_file.hpp"
 #include "engine/random.hpp"

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -6,6 +6,7 @@
 #include "loadsave.h"
 
 #include <climits>
+#include <cstdint>
 #include <cstring>
 #include <numeric>
 #include <unordered_map>

--- a/Source/loadsave.h
+++ b/Source/loadsave.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #include "pfile.h"
 #include "player.h"
 #include "utils/attributes.h"

--- a/Source/menu.cpp
+++ b/Source/menu.cpp
@@ -4,6 +4,8 @@
  * Implementation of functions for interacting with the main menu.
  */
 
+#include <cstdint>
+
 #include "DiabloUI/diabloui.h"
 #include "DiabloUI/settingsmenu.h"
 #include "engine/demomode.h"

--- a/Source/menu.h
+++ b/Source/menu.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #include "multi.h"
 
 namespace devilution {

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -3,6 +3,7 @@
  *
  * Implementation of scrolling dialog text.
  */
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -6,6 +6,7 @@
 #include "monster.h"
 
 #include <climits>
+#include <cstdint>
 
 #include <algorithm>
 #include <array>

--- a/Source/mpq/mpq_reader.cpp
+++ b/Source/mpq/mpq_reader.cpp
@@ -1,5 +1,7 @@
 #include "mpq/mpq_reader.hpp"
 
+#include <cstdint>
+
 #include <libmpq/mpq.h>
 
 #include "utils/stdcompat/optional.hpp"

--- a/Source/mpq/mpq_sdl_rwops.cpp
+++ b/Source/mpq/mpq_sdl_rwops.cpp
@@ -1,5 +1,6 @@
 #include "mpq/mpq_sdl_rwops.hpp"
 
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <vector>

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -4,6 +4,7 @@
  * Implementation of function for sending and reciving network messages.
  */
 #include <climits>
+#include <cstdint>
 #include <list>
 #include <memory>
 #include <unordered_map>

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -4,10 +4,11 @@
  * Implementation of functions for keeping multiplaye games in sync.
  */
 
+#include <cstdint>
+#include <ctime>
+
 #include <SDL.h>
 #include <config.h>
-
-#include <ctime>
 #include <fmt/format.h>
 
 #include "DiabloUI/diabloui.h"

--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -5,6 +5,8 @@
  */
 #include "nthread.h"
 
+#include <cstdint>
+
 #include <fmt/core.h>
 
 #include "diablo.h"

--- a/Source/nthread.h
+++ b/Source/nthread.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #include "player.h"
 #include "utils/attributes.h"
 

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -5,6 +5,8 @@
  */
 #include "pack.h"
 
+#include <cstdint>
+
 #include "engine/random.hpp"
 #include "init.h"
 #include "loadsave.h"

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -5,6 +5,7 @@
  */
 #include "pfile.h"
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 

--- a/Source/pfile.h
+++ b/Source/pfile.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #include "DiabloUI/diabloui.h"
 #include "player.h"
 

--- a/Source/platform/ctr/asio/include/netinet/in.h
+++ b/Source/platform/ctr/asio/include/netinet/in.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include_next <netinet/in.h>
 
 struct in6_addr {

--- a/Source/platform/ctr/display.cpp
+++ b/Source/platform/ctr/display.cpp
@@ -1,6 +1,7 @@
 #include "platform/ctr/display.hpp"
 #include <SDL.h>
 
+#include <cstdint>
 uint32_t Get3DSScalingFlag(bool fitToScreen, int width, int height)
 {
 	if (fitToScreen)

--- a/Source/platform/ctr/random.cpp
+++ b/Source/platform/ctr/random.cpp
@@ -1,4 +1,5 @@
 #include <3ds.h>
+#include <cstdint>
 #include <sodium.h>
 #include <sys/types.h>
 

--- a/Source/platform/ctr/sockets.cpp
+++ b/Source/platform/ctr/sockets.cpp
@@ -1,5 +1,6 @@
 #include "platform/ctr/sockets.hpp"
 
+#include <cstdint>
 #include <malloc.h>
 
 #include <3ds.h>

--- a/Source/platform/switch/keyboard.cpp
+++ b/Source/platform/switch/keyboard.cpp
@@ -1,5 +1,6 @@
 #include "platform/switch/keyboard.h"
 
+#include <cstdint>
 #include <cstring>
 
 #include <SDL.h>

--- a/Source/platform/switch/random.cpp
+++ b/Source/platform/switch/random.cpp
@@ -1,5 +1,6 @@
 #include "platform/switch/random.hpp"
 
+#include <cstdint>
 #include <sys/types.h>
 
 #include <sodium.h>

--- a/Source/platform/vita/random.cpp
+++ b/Source/platform/vita/random.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <psp2/kernel/rng.h>
 #include <sodium.h>
 #include <sys/types.h>

--- a/Source/platform/vita/touch.cpp
+++ b/Source/platform/vita/touch.cpp
@@ -1,6 +1,7 @@
 #include "platform/vita/touch.h"
 
 #include <cmath>
+#include <cstdint>
 
 #include "options.h"
 #include "utils/display.h"

--- a/Source/playerdat.cpp
+++ b/Source/playerdat.cpp
@@ -6,6 +6,8 @@
 
 #include "playerdat.hpp"
 
+#include <cstdint>
+
 #include "items.h"
 #include "player.h"
 #include "textdat.h"

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -6,6 +6,7 @@
 #include "plrmsg.h"
 
 #include <algorithm>
+#include <cstdint>
 
 #include <fmt/format.h>
 

--- a/Source/qol/floatingnumbers.cpp
+++ b/Source/qol/floatingnumbers.cpp
@@ -1,5 +1,6 @@
 #include "floatingnumbers.h"
 
+#include <cstdint>
 #include <ctime>
 #include <deque>
 #include <fmt/format.h>

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -5,6 +5,8 @@
  */
 #include "quests.h"
 
+#include <cstdint>
+
 #include <fmt/format.h>
 
 #include "DiabloUI/ui_flags.hpp"

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -6,6 +6,7 @@
 #include "stores.h"
 
 #include <algorithm>
+#include <cstdint>
 
 #include <fmt/format.h>
 

--- a/Source/storm/storm_net.cpp
+++ b/Source/storm/storm_net.cpp
@@ -1,11 +1,14 @@
 #include "storm/storm_net.hpp"
 
+#include <cstdint>
 #include <memory>
+
 #ifndef NONET
-#include "utils/sdl_mutex.h"
 #include <mutex>
 #include <thread>
 #include <utility>
+
+#include "utils/sdl_mutex.h"
 #endif
 
 #include "dvlnet/abstract_net.h"

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -4,6 +4,7 @@
  * Implementation of functionality for syncing game state with other players.
  */
 #include <climits>
+#include <cstdint>
 
 #include "levels/gendung.h"
 #include "monster.h"

--- a/Source/tmsg.cpp
+++ b/Source/tmsg.cpp
@@ -5,6 +5,8 @@
  */
 #include <list>
 
+#include <cstdint>
+
 #include "diablo.h"
 #include "tmsg.h"
 

--- a/Source/utils/cel_to_clx.cpp
+++ b/Source/utils/cel_to_clx.cpp
@@ -1,5 +1,6 @@
 #include "utils/cel_to_clx.hpp"
 
+#include <cstdint>
 #include <cstring>
 
 #include <vector>

--- a/Source/utils/cl2_to_clx.cpp
+++ b/Source/utils/cl2_to_clx.cpp
@@ -1,5 +1,6 @@
 #include "utils/cl2_to_clx.hpp"
 
+#include <cstdint>
 #include <cstring>
 
 #include "utils/endian.hpp"

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -1,6 +1,7 @@
 #include "utils/display.h"
 
 #include <algorithm>
+#include <cstdint>
 
 #ifdef __vita__
 #include <psp2/power.h>

--- a/Source/utils/endian_stream.hpp
+++ b/Source/utils/endian_stream.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 

--- a/Source/utils/file_util.cpp
+++ b/Source/utils/file_util.cpp
@@ -1,6 +1,7 @@
 #include "utils/file_util.h"
 
 #include <cerrno>
+#include <cstdint>
 #include <cstring>
 
 #include <algorithm>

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -1,5 +1,6 @@
 #include "utils/language.h"
 
+#include <cstdint>
 #include <memory>
 #include <unordered_map>
 #include <vector>

--- a/Source/utils/surface_to_clx.cpp
+++ b/Source/utils/surface_to_clx.cpp
@@ -1,5 +1,6 @@
 #include "utils/surface_to_clx.hpp"
 
+#include <cstdint>
 #include <cstring>
 #include <vector>
 

--- a/Source/utils/utf8.cpp
+++ b/Source/utils/utf8.cpp
@@ -1,6 +1,7 @@
 #include "utils/utf8.hpp"
 
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 
 #include <hoehrmann_utf8.h>


### PR DESCRIPTION
Done with the following script:

```ruby
Dir["Source/**/*.{h,c,cc,cpp,hpp}"].each do |path|
  v = File.read(path)
  next if !v.include?("uint32_t") || v.include?("cstdint")

  lines = v.lines
  line_num = if lines[2].start_with?(" *")
    lines.index { |l| l.start_with?(" */") } + 3
  else
    3
  end

  lines.insert(line_num, "#include <cstdint>\n")

  File.write(path, lines.join(""))
end
```

then fixed-up manually

Refs https://github.com/bebbo/gcc/issues/201#issuecomment-1541884125