### PR TITLE
Add more missing <cstdint> includes

### DIFF
--- a/Source/DiabloUI/credits.cpp
+++ b/Source/DiabloUI/credits.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/Source/DiabloUI/dialogs.cpp
+++ b/Source/DiabloUI/dialogs.cpp
@@ -1,5 +1,6 @@
 #include "DiabloUI/dialogs.h"
 
+#include <cstdint>
 #include <utility>
 
 #include "DiabloUI/button.h"

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -5,6 +5,8 @@
  */
 #include "automap.h"
 
+#include <cstdint>
+
 #include <fmt/format.h>
 
 #include "control.h"

--- a/Source/controls/modifier_hints.cpp
+++ b/Source/controls/modifier_hints.cpp
@@ -1,6 +1,7 @@
 #include "controls/modifier_hints.h"
 
 #include <cstddef>
+#include <cstdint>
 
 #include "DiabloUI/ui_flags.hpp"
 #include "control.h"

--- a/Source/controls/touch/renderers.h
+++ b/Source/controls/touch/renderers.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include <SDL.h>
 
 #include "controls/plrctrls.h"

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -5,6 +5,8 @@
  */
 #include "cursor.h"
 
+#include <cstdint>
+
 #include <fmt/format.h>
 
 #include "DiabloUI/diabloui.h"

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -5,6 +5,8 @@
  */
 #include "dead.h"
 
+#include <cstdint>
+
 #include "diablo.h"
 #include "levels/gendung.h"
 #include "lighting.h"

--- a/Source/dvlnet/packet.cpp
+++ b/Source/dvlnet/packet.cpp
@@ -1,13 +1,14 @@
+#include "dvlnet/packet.h"
+
+#include <cassert>
+#include <cstdint>
+
 #ifdef PACKET_ENCRYPTION
 #include <sodium.h>
 #else
 #include <chrono>
 #include <random>
 #endif
-
-#include <cassert>
-
-#include "dvlnet/packet.h"
 
 namespace devilution {
 namespace net {

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -5,6 +5,8 @@
  */
 #include "effects.h"
 
+#include <cstdint>
+
 #include "engine/random.hpp"
 #include "engine/sound.h"
 #include "engine/sound_defs.hpp"

--- a/Source/engine/actor_position.cpp
+++ b/Source/engine/actor_position.cpp
@@ -1,6 +1,7 @@
 #include "actor_position.hpp"
 
 #include <array>
+#include <cstdint>
 
 namespace devilution {
 

--- a/Source/engine/actor_position.hpp
+++ b/Source/engine/actor_position.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "engine/animationinfo.h"
 #include "engine/point.hpp"
 #include "engine/world_tile.hpp"

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -5,6 +5,9 @@
  */
 
 #include "animationinfo.h"
+
+#include <cstdint>
+
 #include "appfat.h"
 #include "nthread.h"
 #include "utils/log.hpp"

--- a/Source/engine/demomode.h
+++ b/Source/engine/demomode.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #include <SDL.h>
 
 namespace devilution {

--- a/Source/engine/events.cpp
+++ b/Source/engine/events.cpp
@@ -1,5 +1,7 @@
 #include "engine/events.hpp"
 
+#include <cstdint>
+
 #include "controls/input.h"
 #include "engine.h"
 #include "engine/demomode.h"

--- a/Source/engine/load_cel.cpp
+++ b/Source/engine/load_cel.cpp
@@ -1,5 +1,8 @@
 #include "engine/load_cel.hpp"
 
+#include <cstddef>
+#include <cstdint>
+
 #ifdef DEBUG_CEL_TO_CL2_SIZE
 #include <iostream>
 #endif

--- a/Source/engine/load_cl2.cpp
+++ b/Source/engine/load_cl2.cpp
@@ -1,5 +1,6 @@
 #include "engine/load_cl2.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <utility>
 

--- a/Source/engine/load_clx.cpp
+++ b/Source/engine/load_clx.cpp
@@ -1,5 +1,7 @@
 #include "engine/load_clx.hpp"
 
+#include <cstdint>
+
 #include <SDL.h>
 
 #ifdef USE_SDL1

--- a/Source/engine/load_pcx.cpp
+++ b/Source/engine/load_pcx.cpp
@@ -1,6 +1,7 @@
 #include "engine/load_pcx.hpp"
 
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <utility>

--- a/Source/engine/render/automap_render.cpp
+++ b/Source/engine/render/automap_render.cpp
@@ -5,6 +5,8 @@
  */
 #include "engine/render/automap_render.hpp"
 
+#include <cstdint>
+
 namespace devilution {
 namespace {
 

--- a/Source/engine/render/automap_render.hpp
+++ b/Source/engine/render/automap_render.hpp
@@ -10,6 +10,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #include "engine.h"
 #include "engine/point.hpp"
 

--- a/Source/engine/render/clx_render.cpp
+++ b/Source/engine/render/clx_render.cpp
@@ -6,6 +6,7 @@
 #include "clx_render.hpp"
 
 #include <algorithm>
+#include <cstdint>
 
 #include "engine/render/blit_impl.hpp"
 #include "engine/render/scrollrt.h"

--- a/Source/engine/surface.cpp
+++ b/Source/engine/surface.cpp
@@ -1,5 +1,6 @@
 #include "engine/surface.hpp"
 
+#include <cstdint>
 #include <cstring>
 
 namespace devilution {

--- a/Source/engine/trn.cpp
+++ b/Source/engine/trn.cpp
@@ -1,11 +1,14 @@
-#include <fmt/format.h>
+#include "engine/trn.hpp"
+
+#include <cstdint>
 #include <unordered_map>
+
+#include <fmt/format.h>
 
 #ifdef _DEBUG
 #include "debug.h"
 #endif
 #include "engine/load_file.hpp"
-#include "engine/trn.hpp"
 #include "lighting.h"
 
 namespace devilution {

--- a/Source/engine/trn.hpp
+++ b/Source/engine/trn.hpp
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #include "player.h"
 #include "utils/stdcompat/optional.hpp"
 

--- a/Source/engine/world_tile.hpp
+++ b/Source/engine/world_tile.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "engine/point.hpp"
 #include "engine/rectangle.hpp"
 #include "engine/size.hpp"

--- a/Source/hwcursor.hpp
+++ b/Source/hwcursor.hpp
@@ -3,6 +3,10 @@
  *
  * Hardware cursor (SDL2 only).
  */
+#pragma once
+
+#include <cstdint>
+
 #include <SDL_version.h>
 
 #include "options.h"

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -3,10 +3,14 @@
  *
  * Implementation of routines for initializing the environment, disable screen saver, load MPQ.
  */
-#include <SDL.h>
-#include <config.h>
+#include "init.h"
+
+#include <cstdint>
 #include <string>
 #include <vector>
+
+#include <SDL.h>
+#include <config.h>
 
 #if (defined(_WIN64) || defined(_WIN32)) && !defined(__UWP__) && !defined(NXDK)
 #include <find_steam_game.h>

--- a/Source/levels/crypt.cpp
+++ b/Source/levels/crypt.cpp
@@ -1,5 +1,7 @@
 #include "levels/crypt.h"
 
+#include <cstdint>
+
 #include "engine/load_file.hpp"
 #include "engine/point.hpp"
 #include "items.h"

--- a/Source/levels/setmaps.cpp
+++ b/Source/levels/setmaps.cpp
@@ -1,5 +1,7 @@
 #include "levels/setmaps.h"
 
+#include <cstdint>
+
 #ifdef _DEBUG
 #include "debug.h"
 #endif

--- a/Source/levels/themes.cpp
+++ b/Source/levels/themes.cpp
@@ -5,6 +5,8 @@
  */
 #include "levels/themes.h"
 
+#include <cstdint>
+
 #include <fmt/core.h>
 
 #include "engine/path.h"

--- a/Source/levels/town.cpp
+++ b/Source/levels/town.cpp
@@ -1,5 +1,7 @@
 #include "levels/town.h"
 
+#include <cstdint>
+
 #include "engine/load_file.hpp"
 #include "engine/random.hpp"
 #include "init.h"

--- a/Source/levels/trigs.cpp
+++ b/Source/levels/trigs.cpp
@@ -5,6 +5,8 @@
  */
 #include "levels/trigs.h"
 
+#include <cstdint>
+
 #include <fmt/format.h>
 
 #include "control.h"

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -6,6 +6,7 @@
 #include "lighting.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <numeric>
 
 #include "automap.h"

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <vector>
 
 #include <function_ref.hpp>

--- a/Source/misdat.cpp
+++ b/Source/misdat.cpp
@@ -5,6 +5,8 @@
  */
 #include "misdat.h"
 
+#include <cstdint>
+
 #include "engine/load_cl2.hpp"
 #include "engine/load_clx.hpp"
 #include "missiles.h"

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -6,6 +6,7 @@
 #include "missiles.h"
 
 #include <climits>
+#include <cstdint>
 
 #include "control.h"
 #include "controls/plrctrls.h"

--- a/Source/monstdat.cpp
+++ b/Source/monstdat.cpp
@@ -4,8 +4,10 @@
  * Implementation of all monster data.
  */
 #include "monstdat.h"
-#include "items.h"
 
+#include <cstdint>
+
+#include "items.h"
 #include "monster.h"
 #include "textdat.h"
 #include "utils/language.h"

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -4,6 +4,8 @@
  * Implementation of video playback.
  */
 
+#include <cstdint>
+
 #include "controls/plrctrls.h"
 #include "diablo.h"
 #include "effects.h"

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -1,5 +1,6 @@
 #include "panels/charpanel.hpp"
 
+#include <cstdint>
 #include <string>
 
 #include <fmt/format.h>

--- a/Source/panels/mainpanel.cpp
+++ b/Source/panels/mainpanel.cpp
@@ -1,5 +1,7 @@
 #include "panels/mainpanel.hpp"
 
+#include <cstdint>
+
 #include "control.h"
 #include "engine/clx_sprite.hpp"
 #include "engine/load_clx.hpp"

--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -1,5 +1,7 @@
 #include "panels/spell_book.hpp"
 
+#include <cstdint>
+
 #include <fmt/format.h>
 
 #include "control.h"

--- a/Source/panels/spell_icons.cpp
+++ b/Source/panels/spell_icons.cpp
@@ -1,5 +1,7 @@
 #include "panels/spell_icons.hpp"
 
+#include <cstdint>
+
 #include "engine.h"
 #include "engine/load_cel.hpp"
 #include "engine/load_clx.hpp"

--- a/Source/panels/spell_icons.hpp
+++ b/Source/panels/spell_icons.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "engine/clx_sprite.hpp"
 #include "engine/point.hpp"
 #include "engine/surface.hpp"

--- a/Source/panels/spell_list.cpp
+++ b/Source/panels/spell_list.cpp
@@ -1,5 +1,7 @@
 #include "panels/spell_list.hpp"
 
+#include <cstdint>
+
 #include <fmt/format.h>
 
 #include "control.h"

--- a/Source/panels/ui_panels.hpp
+++ b/Source/panels/ui_panels.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 namespace devilution {
 
 enum class UiPanels : uint8_t {

--- a/Source/platform/locale.cpp
+++ b/Source/platform/locale.cpp
@@ -1,5 +1,7 @@
 #include "locale.hpp"
 
+#include <cstdint>
+
 #ifdef __ANDROID__
 #include "SDL.h"
 #include <jni.h>

--- a/Source/platform/switch/docking.cpp
+++ b/Source/platform/switch/docking.cpp
@@ -1,5 +1,7 @@
 #include "platform/switch/docking.h"
 
+#include <cstdint>
+
 #include <SDL.h>
 #include <switch.h>
 

--- a/Source/platform/vita/keyboard.cpp
+++ b/Source/platform/vita/keyboard.cpp
@@ -1,5 +1,6 @@
 #include "platform/vita/keyboard.h"
 
+#include <cstdint>
 #include <cstring>
 
 #include <SDL.h>

--- a/Source/qol/monhealthbar.cpp
+++ b/Source/qol/monhealthbar.cpp
@@ -3,6 +3,9 @@
  *
  * Adds monster health bar QoL feature
  */
+#include "monhealthbar.h"
+
+#include <cstdint>
 
 #include <fmt/format.h>
 

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -1,5 +1,6 @@
 #include "qol/stash.h"
 
+#include <cstdint>
 #include <utility>
 
 #include <fmt/format.h>

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -6,6 +6,7 @@
 #include "xpbar.h"
 
 #include <array>
+#include <cstdint>
 
 #include <fmt/core.h>
 

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #include "player.h"
 
 namespace devilution {

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #include "DiabloUI/ui_flags.hpp"
 #include "control.h"
 #include "engine.h"

--- a/Source/textdat.h
+++ b/Source/textdat.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #include "effects.h"
 
 namespace devilution {

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -1,5 +1,7 @@
 #include "towners.h"
 
+#include <cstdint>
+
 #include "cursor.h"
 #include "engine/clx_sprite.hpp"
 #include "engine/load_cel.hpp"

--- a/Source/utils/push_aulib_decoder.cpp
+++ b/Source/utils/push_aulib_decoder.cpp
@@ -1,6 +1,7 @@
 #include "push_aulib_decoder.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <limits>
 #include <mutex>

--- a/Source/utils/sdl_bilinear_scale.hpp
+++ b/Source/utils/sdl_bilinear_scale.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <array>
+#include <cstdint>
+
 #include <SDL_version.h>
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
@@ -7,8 +10,6 @@
 #else
 #include <SDL_video.h>
 #endif
-
-#include <array>
 
 namespace devilution {
 

--- a/Source/utils/soundsample.cpp
+++ b/Source/utils/soundsample.cpp
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <utility>
 
 #include <Aulib/DecoderDrmp3.h>


### PR DESCRIPTION
https://github.com/diasurgical/devilutionX/pull/6095 only added includes for `uint32_t`, this PR also adds the includes for the remaining integral types.

Refs https://github.com/bebbo/gcc/issues/201#issuecomment-1541884125