### PR TITLE
Fix monster light offset after walk animation ends

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1016,7 +1016,7 @@ void SyncLightPosition(Monster &monster)
 	if (monster.lightId == NO_LIGHT)
 		return;
 
-	const WorldTileDisplacement offset = monster.position.CalculateWalkingOffset(monster.direction, monster.animInfo);
+	const WorldTileDisplacement offset = monster.isWalking() ? monster.position.CalculateWalkingOffset(monster.direction, monster.animInfo) : WorldTileDisplacement {};
 	ChangeLightOffset(monster.lightId, offset.screenToLight());
 }
 


### PR DESCRIPTION
Looks like, before 2493f06, `monster.position.offset` was used to determine the offset for the light. A few functions such as `M_StartStand()` and `MonsterDeath()` would set `monster.position.offset = { 0, 0 }` to prevent stale values from offsetting the position of the monster's light. After that commit, we just always calculate the walking offset based on the current animation info, regardless of the type of animation is being used. This means that calling `M_StartStand()` at the end of the walking animation followed by `SyncLightOffset()` would result in the light being placed as if the start of the stand animation was actually the start of the walking animation, causing the light to be placed at the wrong offset.

This resolves #6102