### PR TITLE
get rid of hardcoded ALT in variable/function name

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1678,8 +1678,8 @@ void InitKeymapActions()
 	    N_("Item highlighting"),
 	    N_("Show/hide items on ground."),
 	    SDLK_LALT,
-	    [] { AltPressed(true); },
-	    [] { AltPressed(false); });
+	    [] { HighlightKeyPressed(true); },
+	    [] { HighlightKeyPressed(false); });
 	sgOptions.Keymapper.AddAction(
 	    "Toggle Item Highlighting",
 	    N_("Toggle item highlighting"),
@@ -2198,8 +2198,8 @@ void InitPadmapActions()
 	    N_("Item highlighting"),
 	    N_("Show/hide items on ground."),
 	    ControllerButton_NONE,
-	    [] { AltPressed(true); },
-	    [] { AltPressed(false); });
+	    [] { HighlightKeyPressed(true); },
+	    [] { HighlightKeyPressed(false); });
 	sgOptions.Padmapper.AddAction(
 	    "Toggle Item Highlighting",
 	    N_("Toggle item highlighting"),

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -32,7 +32,7 @@ struct ItemLabel {
 
 std::vector<ItemLabel> labelQueue;
 
-bool altPressed = false;
+bool highlightKeyPressed = false;
 bool isLabelHighlighted = false;
 std::array<std::optional<int>, ITEMTYPES> labelCenterOffsets;
 
@@ -74,9 +74,9 @@ void ToggleItemLabelHighlight()
 	sgOptions.Gameplay.showItemLabels.SetValue(!*sgOptions.Gameplay.showItemLabels);
 }
 
-void AltPressed(bool pressed)
+void HighlightKeyPressed(bool pressed)
 {
-	altPressed = pressed;
+	highlightKeyPressed = pressed;
 }
 
 bool IsItemLabelHighlighted()
@@ -91,7 +91,7 @@ void ResetItemlabelHighlighted()
 
 bool IsHighlightingLabelsEnabled()
 {
-	return stextflag == TalkID::None && altPressed != *sgOptions.Gameplay.showItemLabels;
+	return stextflag == TalkID::None && highlightKeyPressed != *sgOptions.Gameplay.showItemLabels;
 }
 
 void AddItemToLabelQueue(int id, Point position)

--- a/Source/qol/itemlabels.h
+++ b/Source/qol/itemlabels.h
@@ -10,7 +10,7 @@
 namespace devilution {
 
 void ToggleItemLabelHighlight();
-void AltPressed(bool pressed);
+void HighlightKeyPressed(bool pressed);
 bool IsItemLabelHighlighted();
 void ResetItemlabelHighlighted();
 bool IsHighlightingLabelsEnabled();


### PR DESCRIPTION
Didn't really make sense after we allowed rebinding keys