### PR TITLE
Delay reinitializing hwcursor until fade 1

### DIFF
--- a/Source/engine/palette.h
+++ b/Source/engine/palette.h
@@ -60,7 +60,7 @@ void ApplyGamma(std::array<SDL_Color, 256> &dst, const std::array<SDL_Color, 256
 void DecreaseGamma();
 int UpdateGamma(int gamma);
 void BlackPalette();
-void SetFadeLevel(int fadeval);
+void SetFadeLevel(int fadeval, bool updateHardwareCursor = true);
 /**
  * @brief Fade screen from black
  * @param fr Steps per 50ms

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -295,6 +295,10 @@ void ShowProgress(interface_mode uMsg)
 		interface_msg_pump();
 		ClearScreenBuffer();
 		scrollrt_draw_game_screen();
+
+		if (IsHardwareCursor())
+			SetHardwareCursorVisible(false);
+
 		BlackPalette();
 
 		// Blit the background once and then free it.
@@ -314,9 +318,6 @@ void ShowProgress(interface_mode uMsg)
 			}
 		}
 		FreeCutsceneBackground();
-
-		if (IsHardwareCursor())
-			SetHardwareCursorVisible(false);
 
 		PaletteFadeIn(8);
 		IncProgress();


### PR DESCRIPTION
With fade 0 the cursor is never visible because everything is black.

While this is a very minor optimization, it works around
one of the instances of a bug in certain drivers as seen in https://github.com/diasurgical/devilutionX/issues/5618.