### PR TITLE
apply clang-format to GetTowner

### DIFF
--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -841,9 +841,9 @@ bool IsTownerPresent(_talker_id npc)
 	}
 }
 
-Towner* GetTowner(_talker_id type)
+Towner *GetTowner(_talker_id type)
 {
-	for (Towner& towner : Towners) {
+	for (Towner &towner : Towners) {
 		if (towner._ttype == type)
 			return &towner;
 	}


### PR DESCRIPTION
Just realised VS didn't apply the correct formatting to this function in the previous PR.