### PR TITLE
Sync break crux correctly

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3497,8 +3497,11 @@ bool AreAllCruxesOfTypeBroken(int cruxType)
 	return true;
 }
 
-void BreakCrux(const Player *player, Object &crux)
+void BreakCrux(Object &crux, bool sendmsg)
 {
+	if (crux._oSelFlag == 0)
+		return;
+
 	crux._oAnimFlag = true;
 	crux._oAnimFrame = 1;
 	crux._oAnimDelay = 1;
@@ -3507,7 +3510,7 @@ void BreakCrux(const Player *player, Object &crux)
 	crux._oBreak = -1;
 	crux._oSelFlag = 0;
 
-	if (player == MyPlayer || player == nullptr)
+	if (sendmsg)
 		NetSendCmdLoc(MyPlayerId, false, CMD_BREAKOBJ, crux.position);
 
 	if (!AreAllCruxesOfTypeBroken(crux._oVar8))
@@ -4734,14 +4737,14 @@ void SyncOpObject(Player &player, int cmd, Object &object)
 void BreakObjectMissile(const Player *player, Object &object)
 {
 	if (object.IsCrux())
-		BreakCrux(player, object);
+		BreakCrux(object, true);
 }
 void BreakObject(const Player &player, Object &object)
 {
 	if (object.IsBarrel()) {
 		BreakBarrel(player, object, false, true);
 	} else if (object.IsCrux()) {
-		BreakCrux(&player, object);
+		BreakCrux(object, true);
 	}
 }
 
@@ -4768,6 +4771,8 @@ void SyncBreakObj(const Player &player, Object &object)
 {
 	if (object.IsBarrel()) {
 		BreakBarrel(player, object, true, false);
+	} else if (object.IsCrux()) {
+		BreakCrux(object, false);
 	}
 }
 


### PR DESCRIPTION
Fixes #6022

Notes:
- SyncBreakObj was missing handling for crux
- Simplified logic for breaking crux. Now all missiles will sync breaking cruxes, but multiple events (from different clients) will be ignored
- Would be great if someone else could test it, because it's hard to get a small desync alone 😉