### PR TITLE
refresh staff after using stone shrine

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2503,6 +2503,8 @@ void OperateShrineStone(Player &player)
 			item._iCharges = item._iMaxCharges;
 	}
 
+	CalcPlrInv(player, true);
+
 	RedrawEverything();
 
 	InitDiabloMsg(EMSG_SHRINE_STONE);


### PR DESCRIPTION
Fixes https://github.com/diasurgical/devilutionX/issues/6141
CalcPlrInv was called in all other cases where staff charges were changed

