### PR TITLE
dont always force staff recharge to change spell

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -260,7 +260,7 @@ void ChangeEquipment(Player &player, inv_body_loc bodyLocation, const Item &item
 	player.InvBody[bodyLocation] = item;
 
 	if (&player == MyPlayer) {
-		NetSendCmdChItem(false, bodyLocation);
+		NetSendCmdChItem(false, bodyLocation, true);
 	}
 }
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1907,7 +1907,7 @@ size_t OnChangePlayerItems(const TCmd *pCmd, size_t pnum)
 		CheckInvSwap(player, bodyLocation);
 	}
 
-	player.ReadySpellFromEquipment(bodyLocation);
+	player.ReadySpellFromEquipment(bodyLocation, message.forceSpell);
 
 	return sizeof(message);
 }
@@ -2990,7 +2990,7 @@ void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position, const Item &item
 		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
 }
 
-void NetSendCmdChItem(bool bHiPri, uint8_t bLoc)
+void NetSendCmdChItem(bool bHiPri, uint8_t bLoc, bool forceSpellChange)
 {
 	TCmdChItem cmd {};
 
@@ -2998,6 +2998,7 @@ void NetSendCmdChItem(bool bHiPri, uint8_t bLoc)
 
 	cmd.bCmd = CMD_CHANGEPLRITEMS;
 	cmd.bLoc = bLoc;
+	cmd.forceSpell = forceSpellChange;
 	PrepareItemForNetwork(item, cmd);
 
 	if (bHiPri)

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -611,6 +611,7 @@ struct TCmdPItem {
 struct TCmdChItem {
 	_cmd_id bCmd;
 	uint8_t bLoc;
+	bool forceSpell;
 
 	union {
 		TItemDef def;
@@ -756,7 +757,7 @@ void NetSendCmdQuest(bool bHiPri, const Quest &quest);
 void NetSendCmdGItem(bool bHiPri, _cmd_id bCmd, uint8_t pnum, uint8_t ii);
 void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position, const Item &item);
 void NetSyncInvItem(const Player &player, int invListIndex);
-void NetSendCmdChItem(bool bHiPri, uint8_t bLoc);
+void NetSendCmdChItem(bool bHiPri, uint8_t bLoc, bool forceSpellChange = false);
 void NetSendCmdDelItem(bool bHiPri, uint8_t bLoc);
 void NetSendCmdChInvItem(bool bHiPri, int invGridIndex);
 void NetSendCmdChBeltItem(bool bHiPri, int invGridIndex);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1831,13 +1831,15 @@ void Player::RestorePartialMana()
 	}
 }
 
-void Player::ReadySpellFromEquipment(inv_body_loc bodyLocation)
+void Player::ReadySpellFromEquipment(inv_body_loc bodyLocation, bool forceSpell)
 {
 	auto &item = InvBody[bodyLocation];
 	if (item._itype == ItemType::Staff && IsValidSpell(item._iSpell) && item._iCharges > 0) {
-		_pRSpell = item._iSpell;
-		_pRSplType = SpellType::Charges;
-		RedrawEverything();
+		if (forceSpell || _pRSpell == SpellID::Invalid || _pRSplType == SpellType::Invalid) {
+			_pRSpell = item._iSpell;
+			_pRSplType = SpellType::Charges;
+			RedrawEverything();
+		}
 	}
 }
 

--- a/Source/player.h
+++ b/Source/player.h
@@ -700,8 +700,9 @@ struct Player {
 	/**
 	 * @brief Sets the readied spell to the spell in the specified equipment slot. Does nothing if the item does not have a valid spell.
 	 * @param bodyLocation - the body location whose item will be checked for the spell.
+	 * @param forceSpell - if true, always change active spell, if false, only when current spell slot is empty
 	 */
-	void ReadySpellFromEquipment(inv_body_loc bodyLocation);
+	void ReadySpellFromEquipment(inv_body_loc bodyLocation, bool forceSpell);
 
 	/**
 	 * @brief Does the player currently have a ranged weapon equipped?


### PR DESCRIPTION
Fixes https://github.com/diasurgical/devilutionX/issues/6143

cases when active spell can be changed because of a staff: 
recharging staff - player's skill
recharging staff - adria
recharging staff - shrine
reequipping staff

I made all of them change the spell if you have no other spell selected but only reequipping staff always forces the change
