### PR TITLE
Gnat Sting Fix

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -904,25 +904,22 @@ bool DoRangeAttack(Player &player)
 {
 	int arrows = 0;
 	if (player.AnimInfo.currentFrame == player._pAFNum - 1) {
-		arrows = 1;
-	}
-
-	if (HasAnyOf(player._pIFlags, ItemSpecialEffect::MultipleArrows) && player.AnimInfo.currentFrame == player._pAFNum + 1) {
-		arrows = 2;
+	    arrows = HasAnyOf(player._pIFlags, ItemSpecialEffect::MultipleArrows) ? 3 : 1;
 	}
 
 	for (int arrow = 0; arrow < arrows; arrow++) {
-		int xoff = 0;
-		int yoff = 0;
-		if (arrows != 1) {
-			int angle = arrow == 0 ? -1 : 1;
-			int x = player.position.temp.x - player.position.tile.x;
-			if (x != 0)
-				yoff = x < 0 ? angle : -angle;
-			int y = player.position.temp.y - player.position.tile.y;
-			if (y != 0)
-				xoff = y < 0 ? -angle : angle;
-		}
+	    int xoff = 0;
+	    int yoff = 0;
+
+	    if (arrows == 3) {
+	        int angle = arrow - 1;  // This will result in -1, 0, or 1
+	        int x = player.position.temp.x - player.position.tile.x;
+	        if (x != 0)
+	            yoff = x < 0 ? angle : -angle;
+	        int y = player.position.temp.y - player.position.tile.y;
+	        if (y != 0)
+	            xoff = y < 0 ? -angle : angle;
+	    }
 
 		int dmg = 4;
 		MissileID mistype = MissileID::Arrow;
@@ -947,9 +944,13 @@ bool DoRangeAttack(Player &player)
 		    dmg,
 		    0);
 
-		if (arrow == 0 && mistype != MissileID::SpectralArrow) {
-			PlaySfxLoc(arrows != 1 ? IS_STING1 : PS_BFIRE, player.position.tile);
-		}
+    	if (mistype != MissileID::SpectralArrow) {
+    	    if (arrow == 0) {
+    	        PlaySfxLoc(PS_BFIRE, player.position.tile);
+    	    } else if (arrow == 1) {
+    	        PlaySfxLoc(IS_STING1, player.position.tile);
+    	    }
+    	}
 
 		if (DamageWeapon(player, 40)) {
 			StartStand(player, player._pdir);


### PR DESCRIPTION
This commit fixes an issue with Gnat Sting that causes the bow to only fire single shots if the player attacks too quickly.  There is nothing in the description of the bow that indicates that this was intended.  It seems like this was coded in a way to properly play sound effects for both the single shot and side shots, but had the unintended consequence of causing Gnat Sting to override itself if fired too quickly, causing the bow to only fire single shots instead of multiple shots as it is intended to do.