### PR TITLE
Fix Amiga build to known good container image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - store_artifacts: {path: ./build/devilutionx.cia, destination: devilutionx.cia}
   amigaos-m68k:
     docker:
-      - image: amigadev/crosstools:m68k-amigaos
+      - image: amigadev/crosstools@sha256:889cb157c71911bca24adcc3aa1ed0956e9e0df940127bf953dc33896d7546f6
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
Something brok in the latest update to the Amiga build chain, so fixing the version to the last known good one.