### PR TITLE
Multiplayer: Sync Hellfire Quests

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -909,7 +909,6 @@ void CheckQuestItem(Player &player, Item &questItem)
 	}
 
 	if (questItem.IDidx == IDI_MAPOFDOOM) {
-		Quests[Q_GRAVE]._qlog = false;
 		Quests[Q_GRAVE]._qactive = QUEST_ACTIVE;
 		if (Quests[Q_GRAVE]._qvar1 != 1) {
 			MyPlayer->Say(HeroSpeech::UhHuh, 10);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3126,7 +3126,6 @@ uint8_t PlaceItemInWorld(Item &&item, WorldTilePosition position)
 	if (CornerStone.isAvailable() && position == CornerStone.position) {
 		CornerStone.item = item_;
 		InitQTextMsg(TEXT_CORNSTN);
-		Quests[Q_CORNSTN]._qlog = false;
 		Quests[Q_CORNSTN]._qactive = QUEST_DONE;
 	}
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2208,7 +2208,7 @@ void RecreateTownItem(const Player &player, Item &item, _item_indexes idx, uint1
 		RecreateHealerItem(player, item, idx, icreateinfo & CF_LEVEL, iseed);
 }
 
-void CreateMagicItem(Point position, int lvl, ItemType itemType, int imid, int icurs, bool sendmsg, bool delta)
+void CreateMagicItem(Point position, int lvl, ItemType itemType, int imid, int icurs, bool sendmsg, bool delta, bool spawn = false)
 {
 	if (ActiveItemCount >= MAXITEMS)
 		return;
@@ -2231,6 +2231,8 @@ void CreateMagicItem(Point position, int lvl, ItemType itemType, int imid, int i
 		NetSendCmdPItem(false, CMD_DROPITEM, item.position, item);
 	if (delta)
 		DeltaAddItem(ii);
+	if (spawn)
+		NetSendCmdPItem(false, CMD_SPAWNITEM, item.position, item);
 }
 
 void NextItemRecord(int i)
@@ -4515,9 +4517,9 @@ void CreateMagicArmor(Point position, ItemType itemType, int icurs, bool sendmsg
 	CreateMagicItem(position, lvl, itemType, IMISC_NONE, icurs, sendmsg, delta);
 }
 
-void CreateAmulet(Point position, int lvl, bool sendmsg, bool delta)
+void CreateAmulet(Point position, int lvl, bool sendmsg, bool delta, bool spawn /*= false*/)
 {
-	CreateMagicItem(position, lvl, ItemType::Amulet, IMISC_AMULET, ICURS_AMULET, sendmsg, delta);
+	CreateMagicItem(position, lvl, ItemType::Amulet, IMISC_AMULET, ICURS_AMULET, sendmsg, delta, spawn);
 }
 
 void CreateMagicWeapon(Point position, ItemType itemType, int icurs, bool sendmsg, bool delta)

--- a/Source/items.h
+++ b/Source/items.h
@@ -549,7 +549,7 @@ void MakeGoldStack(Item &goldItem, int value);
 int ItemNoFlippy();
 void CreateSpellBook(Point position, SpellID ispell, bool sendmsg, bool delta);
 void CreateMagicArmor(Point position, ItemType itemType, int icurs, bool sendmsg, bool delta);
-void CreateAmulet(Point position, int lvl, bool sendmsg, bool delta);
+void CreateAmulet(Point position, int lvl, bool sendmsg, bool delta, bool spawn = false);
 void CreateMagicWeapon(Point position, ItemType itemType, int icurs, bool sendmsg, bool delta);
 bool GetItemRecord(uint32_t nSeed, uint16_t wCI, int nIndex);
 void SetItemRecord(uint32_t nSeed, uint16_t wCI, int nIndex);

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -870,8 +870,9 @@ void SpawnLoot(Monster &monster, bool sendmsg)
 	} else if (monster.uniqueType == UniqueMonsterType::Defiler) {
 		if (effect_is_playing(USFX_DEFILER8))
 			stream_stop();
-		Quests[Q_DEFILER]._qlog = false;
 		SpawnMapOfDoom(monster.position.tile, sendmsg);
+		Quests[Q_DEFILER]._qactive = QUEST_DONE;
+		NetSendCmdQuest(true, Quests[Q_DEFILER]);
 	} else if (monster.uniqueType == UniqueMonsterType::HorkDemon) {
 		if (sgGameInitInfo.bTheoQuest != 0) {
 			SpawnTheodore(monster.position.tile, sendmsg);
@@ -884,7 +885,6 @@ void SpawnLoot(Monster &monster, bool sendmsg)
 			nSFX = USFX_NAKRUL6;
 		if (effect_is_playing(nSFX))
 			stream_stop();
-		Quests[Q_NAKRUL]._qlog = false;
 		UberDiabloMonsterIndex = -2;
 		CreateMagicWeapon(monster.position.tile, ItemType::Sword, ICURS_GREAT_SWORD, sendmsg, false);
 		CreateMagicWeapon(monster.position.tile, ItemType::Staff, ICURS_WAR_STAFF, sendmsg, false);
@@ -3430,7 +3430,6 @@ void WeakenNaKrul()
 
 	auto &monster = Monsters[UberDiabloMonsterIndex];
 	PlayEffect(monster, MonsterSound::Death);
-	Quests[Q_NAKRUL]._qlog = false;
 	monster.armorClass -= 50;
 	int hp = monster.maxHitPoints / 2;
 	monster.resistance = 0;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1933,6 +1933,7 @@ void OperateLever(Object &object, bool sendmsg)
 	if (currlevel == 24) {
 		PlaySfxLoc(IS_CROPEN, { UberRow, UberCol });
 		Quests[Q_NAKRUL]._qactive = QUEST_DONE;
+		NetSendCmdQuest(true, Quests[Q_NAKRUL]);
 	}
 
 	if (sendmsg)
@@ -3451,6 +3452,7 @@ void OperateStoryBook(Object &storyBook)
 		Quests[Q_NAKRUL]._qactive = QUEST_ACTIVE;
 		Quests[Q_NAKRUL]._qlog = true;
 		Quests[Q_NAKRUL]._qmsg = msg;
+		NetSendCmdQuest(true, Quests[Q_NAKRUL]);
 	}
 	InitQTextMsg(msg);
 	NetSendCmdLoc(MyPlayerId, false, CMD_OPERATEOBJ, storyBook.position);
@@ -4598,6 +4600,10 @@ void DeltaSyncOpObject(Object &object)
 		break;
 	case OBJ_CAULDRON:
 		UpdateState(object, 3);
+		break;
+	case OBJ_STORYBOOK:
+	case OBJ_L5BOOKS:
+		object._oAnimFrame = object._oVar4;
 		break;
 	case OBJ_MUSHPATCH:
 		if (Quests[Q_MUSHROOM]._qvar1 >= QS_MUSHSPAWNED) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3487,6 +3487,7 @@ void PlayDungMsgs()
 		Quests[Q_DEFILER]._qactive = QUEST_ACTIVE;
 		Quests[Q_DEFILER]._qlog = true;
 		Quests[Q_DEFILER]._qmsg = TEXT_DEFILER1;
+		NetSendCmdQuest(true, Quests[Q_DEFILER]);
 		myPlayer.pDungMsgs2 |= 1;
 	} else if (!setlevel && currlevel == 19 && !myPlayer._pLvlVisited[19] && (myPlayer.pDungMsgs2 & 4) == 0) {
 		sfxdelay = 10;

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -917,7 +917,7 @@ void SetMultiQuest(int q, quest_state s, bool log, int v1, int v2, int16_t qmsg)
 	auto &quest = Quests[q];
 	quest_state oldQuestState = quest._qactive;
 	if (quest._qactive != QUEST_DONE) {
-		if (s > quest._qactive)
+		if (s > quest._qactive || (IsAnyOf(s, QUEST_ACTIVE, QUEST_DONE) && IsAnyOf(quest._qactive, QUEST_HIVE_TEASE1, QUEST_HIVE_TEASE2, QUEST_HIVE_ACTIVE)))
 			quest._qactive = s;
 		if (log)
 			quest._qlog = true;
@@ -936,6 +936,8 @@ void SetMultiQuest(int q, quest_state s, bool log, int v1, int v2, int16_t qmsg)
 			StartPWaterPurify();
 		if (quest._qidx == Q_GIRL && questGotCompleted && MyPlayer->isOnLevel(0))
 			UpdateGirlAnimAfterQuestComplete();
+		if (quest._qidx == Q_JERSEY && questGotCompleted && MyPlayer->isOnLevel(0))
+			UpdateCowFarmerAnimAfterQuestComplete();
 	}
 }
 

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -930,9 +930,12 @@ void SetMultiQuest(int q, quest_state s, bool log, int v1, int v2, int16_t qmsg)
 		// Ensure that changes on another client is also updated on our own
 		ResyncQuests();
 
+		bool questGotCompleted = oldQuestState != QUEST_DONE && quest._qactive == QUEST_DONE;
 		// Ensure that water also changes for remote players
-		if (quest._qidx == Q_PWATER && oldQuestState == QUEST_ACTIVE && quest._qactive == QUEST_DONE && MyPlayer->isOnLevel(quest._qslvl))
+		if (quest._qidx == Q_PWATER && questGotCompleted && MyPlayer->isOnLevel(quest._qslvl))
 			StartPWaterPurify();
+		if (quest._qidx == Q_GIRL && questGotCompleted && MyPlayer->isOnLevel(0))
+			UpdateGirlAnimAfterQuestComplete();
 	}
 }
 

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -673,9 +673,8 @@ void TalkToCowFarmer(Player &player, Towner &cowFarmer)
 		SpawnUnique(UITEM_BOVINE, cowFarmer.position + Direction::SouthEast);
 		InitQTextMsg(TEXT_JERSEY8);
 		quest._qactive = QUEST_DONE;
-		auto curFrame = cowFarmer._tAnimFrame;
-		LoadTownerAnimations(cowFarmer, "towners\\farmer\\mfrmrn2", 15, 3);
-		cowFarmer._tAnimFrame = std::min<uint8_t>(curFrame, cowFarmer._tAnimLen - 1);
+		UpdateCowFarmerAnimAfterQuestComplete();
+		NetSendCmdQuest(true, quest);
 		return;
 	}
 
@@ -685,6 +684,7 @@ void TalkToCowFarmer(Player &player, Towner &cowFarmer)
 		quest._qvar1 = 1;
 		quest._qmsg = TEXT_JERSEY4;
 		quest._qlog = true;
+		NetSendCmdQuest(true, quest);
 		return;
 	}
 
@@ -923,6 +923,14 @@ void UpdateGirlAnimAfterQuestComplete()
 	auto curFrame = girl->_tAnimFrame;
 	LoadTownerAnimations(*girl, "towners\\girl\\girls1", 20, 6);
 	girl->_tAnimFrame = std::min<uint8_t>(curFrame, girl->_tAnimLen - 1);
+}
+
+void UpdateCowFarmerAnimAfterQuestComplete()
+{
+	Towner *cowFarmer = GetTowner(TOWN_COWFARM);
+	auto curFrame = cowFarmer->_tAnimFrame;
+	LoadTownerAnimations(*cowFarmer, "towners\\farmer\\mfrmrn2", 15, 3);
+	cowFarmer->_tAnimFrame = std::min<uint8_t>(curFrame, cowFarmer->_tAnimLen - 1);
 }
 
 #ifdef _DEBUG

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -479,6 +479,7 @@ void TalkToBarmaid(Player &player, Towner & /*barmaid*/)
 		Quests[Q_GRAVE]._qactive = QUEST_ACTIVE;
 		Quests[Q_GRAVE]._qlog = true;
 		Quests[Q_GRAVE]._qmsg = TEXT_GRAVE8;
+		NetSendCmdQuest(true, Quests[Q_GRAVE]);
 		InitQTextMsg(TEXT_GRAVE8);
 		return;
 	}

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -750,11 +750,9 @@ void TalkToGirl(Player &player, Towner &girl)
 
 	if (quest._qactive != QUEST_DONE && RemoveInventoryItemById(player, IDI_THEODORE)) {
 		InitQTextMsg(TEXT_GIRL4);
-		CreateAmulet(girl.position, 13, true, false);
+		CreateAmulet(girl.position, 13, false, false, true);
 		quest._qactive = QUEST_DONE;
-		auto curFrame = girl._tAnimFrame;
-		LoadTownerAnimations(girl, "towners\\girl\\girls1", 20, 6);
-		girl._tAnimFrame = std::min<uint8_t>(curFrame, girl._tAnimLen - 1);
+		UpdateGirlAnimAfterQuestComplete();
 		if (gbIsMultiplayer)
 			NetSendCmdQuest(true, quest);
 		return;
@@ -915,6 +913,16 @@ void TalkToTowner(Player &player, int t)
 	}
 
 	towner.talk(player, towner);
+}
+
+void UpdateGirlAnimAfterQuestComplete()
+{
+	Towner *girl = GetTowner(TOWN_GIRL);
+	if (girl == nullptr || !girl->ownedAnim)
+		return; // Girl is not spawned in town yet
+	auto curFrame = girl->_tAnimFrame;
+	LoadTownerAnimations(*girl, "towners\\girl\\girls1", 20, 6);
+	girl->_tAnimFrame = std::min<uint8_t>(curFrame, girl->_tAnimLen - 1);
 }
 
 #ifdef _DEBUG

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -648,7 +648,6 @@ void TalkToFarmer(Player &player, Towner &farmer)
 		InitQTextMsg(TEXT_FARMER4);
 		SpawnRewardItem(IDI_AURIC, farmer.position + Displacement { 1, 0 }, true);
 		quest._qactive = QUEST_HIVE_DONE;
-		quest._qlog = false;
 		if (gbIsMultiplayer)
 			NetSendCmdQuest(true, quest);
 		break;
@@ -751,7 +750,6 @@ void TalkToGirl(Player &player, Towner &girl)
 	if (quest._qactive != QUEST_DONE && RemoveInventoryItemById(player, IDI_THEODORE)) {
 		InitQTextMsg(TEXT_GIRL4);
 		CreateAmulet(girl.position, 13, true, false);
-		quest._qlog = false;
 		quest._qactive = QUEST_DONE;
 		auto curFrame = girl._tAnimFrame;
 		LoadTownerAnimations(girl, "towners\\girl\\girls1", 20, 6);

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -80,6 +80,8 @@ void FreeTownerGFX();
 void ProcessTowners();
 void TalkToTowner(Player &player, int t);
 
+void UpdateGirlAnimAfterQuestComplete();
+
 #ifdef _DEBUG
 bool DebugTalkToTowner(std::string targetName);
 #endif

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -81,6 +81,7 @@ void ProcessTowners();
 void TalkToTowner(Player &player, int t);
 
 void UpdateGirlAnimAfterQuestComplete();
+void UpdateCowFarmerAnimAfterQuestComplete();
 
 #ifdef _DEBUG
 bool DebugTalkToTowner(std::string targetName);


### PR DESCRIPTION
Fixes #4192

When looking at #4192 I found multiple other syncing issue for hellfire quests (see notes)
This PR fixes most of them and #4192 but there are still likely some edge-cases missing.

## Notes
- Defiler Quest is now synced when the first player enters nest level 1
- Little Girl Quest animation is now synced correctly #4192 
- Little Girl Quest quest reward (Amulet) is now synced (can be seen and taken by other players)
- Jersey's Jersey Quest animation is now synced correctly #4192
- Jersey's Jersey Quest is now correctly activated and complete on remote players quest log
- Grave Matters Quest is now synced when talking to gillian and having the cathedral map
- Na-Krul Quest is now activated for all clients (when reading the story book)
- Na-Krul Quest story books are now loaded correctly (are used/open) when reentering the level
- Na-Krul Quest is now also completed for remote players when operating Na-Krul's room the lever
- Hellfire Quests don't disappear from quest-log when completed (they stay in quest log like diablo quests; see #2609)