### PR TITLE
Fix stone curse shows the wrong animation & infinite petrify

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -669,6 +669,9 @@ void LoadMonster(LoadHelper *file, Monster &monster)
 
 	// Omit pointer name;
 
+	if (monster.mode == MonsterMode::Petrified)
+		monster.animInfo.isPetrified = true;
+
 	if (gbSkipSync)
 		return;
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2296,6 +2296,13 @@ void AddStoneCurse(Missile &missile, AddMissileParameter &parameter)
 	// Petrify the targeted monster
 	int monsterId = abs(dMonster[targetMonsterPosition->x][targetMonsterPosition->y]) - 1;
 	auto &monster = Monsters[monsterId];
+
+	if (monster.mode == MonsterMode::Petrified) {
+		// Monster is already petrified and StoneCurse doesn't stack
+		missile._miDelFlag = true;
+		return;
+	}
+
 	missile.var1 = static_cast<int>(monster.mode);
 	missile.var2 = monsterId;
 	monster.petrify();

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4146,7 +4146,7 @@ void SyncMonsterAnim(Monster &monster)
 	}
 	MonsterGraphic graphic = MonsterGraphic::Stand;
 
-	switch (monster.mode) {
+	switch (monster.getVisualMonsterMode()) {
 	case MonsterMode::Stand:
 	case MonsterMode::Delay:
 	case MonsterMode::Talk:
@@ -4637,7 +4637,7 @@ void Monster::petrify()
 
 bool Monster::isWalking() const
 {
-	switch (mode) {
+	switch (getVisualMonsterMode()) {
 	case MonsterMode::MoveNorthwards:
 	case MonsterMode::MoveSouthwards:
 	case MonsterMode::MoveSideways:
@@ -4697,6 +4697,21 @@ bool Monster::tryLiftGargoyle()
 		return true;
 	}
 	return false;
+}
+
+MonsterMode Monster::getVisualMonsterMode() const
+{
+	if (mode != MonsterMode::Petrified)
+		return mode;
+	size_t monsterId = this->getId();
+	for (auto &missile : Missiles) {
+		// Search the missile that will restore the original monster mode and use the saved/original monster mode from it
+		if (missile._mitype == MissileID::StoneCurse && missile.var2 == monsterId) {
+			return static_cast<MonsterMode>(missile.var1);
+		}
+	}
+	assert("getVisualMonsterMode: Found a monster that is infinited petrified (bug)");
+	return MonsterMode::Petrified;
 }
 
 unsigned int Monster::toHitSpecial(_difficulty difficulty) const

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -437,6 +437,14 @@ struct Monster { // note: missing field _mAFNum
 	}
 
 	bool tryLiftGargoyle();
+
+	/**
+	 * @brief Gets the visual/shown monster mode.
+	 *
+	 * When a monster is petrified it's monster mode is changed to MonsterMode::Petrified.
+	 * But for graphics and rendering we show the old/real mode.
+	 */
+	[[nodiscard]] MonsterMode getVisualMonsterMode() const;
 };
 
 extern size_t LevelMonsterTypeCount;


### PR DESCRIPTION
Fixes #6125

## Background
- stone curse changes monster mode to petrified to prevent monster ai take action
- stone curse "missile" holds the old/previous monster mode
- In vanilla/master it's possible to create multiple stone curses "missiles" for a monster

## Notes
- Use the monster mode stored in the stone curse "missile" to decide which graphics are used to visualize the monster
- Prevent multiple stone curse "missiles" for one monster, else `RemovePlrMissiles` could restore the wrong monster mode (petrified) for a missile