### PR TITLE
Don't turn monster towards player during hit recovery if monster is petrified

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3651,7 +3651,9 @@ void M_StartHit(Monster &monster, const Player &player, int dam)
 		monster.enemy = player.getId();
 		monster.enemyPosition = player.position.future;
 		monster.flags &= ~MFLAG_TARGETS_MONSTER;
-		monster.direction = GetMonsterDirection(monster);
+		if (monster.mode != MonsterMode::Petrified) {
+			monster.direction = GetMonsterDirection(monster);
+		}
 	}
 
 	M_StartHit(monster, dam);


### PR DESCRIPTION
If an attack puts a petrified monster into hit recovery, the logic will change the direction the monster is facing. This causes the animation logic to recompute the monster's tile offset based on the new direction the monster is facing, causing the sprite to move when it shouldn't.

In the following video, the damage number shows up as zero because it was hardcoded for testing, but the attack would have put the monster into hit recovery.

https://github.com/diasurgical/devilutionX/assets/9203145/f12bdfc2-a756-42f7-a8bd-c11133c850b5

It makes more sense to assume that a petrified monster cannot change the direction it's facing so that's what this PR does.