### PR TITLE
Use `std::from_chars` instead of `std::stoi`

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -48,6 +48,7 @@
 #include "utils/format_int.hpp"
 #include "utils/language.h"
 #include "utils/log.hpp"
+#include "utils/parse_int.hpp"
 #include "utils/sdl_geometry.h"
 #include "utils/stdcompat/optional.hpp"
 #include "utils/str_case.hpp"
@@ -388,9 +389,9 @@ std::string TextCmdArena(const string_view parameter)
 		return ret;
 	}
 
-	int arenaNumber = atoi(parameter.data());
-	_setlevels arenaLevel = static_cast<_setlevels>(arenaNumber - 1 + SL_FIRST_ARENA);
-	if (arenaNumber < 0 || !IsArenaLevel(arenaLevel)) {
+	const ParseIntResult<int> parsedParam = ParseInt<int>(parameter, /*min=*/0);
+	const _setlevels arenaLevel = parsedParam.ok() ? static_cast<_setlevels>(parsedParam.value - 1 + SL_FIRST_ARENA) : _setlevels::SL_NONE;
+	if (!IsArenaLevel(arenaLevel)) {
 		StrAppend(ret, _("Invalid arena-number. Valid numbers are:"));
 		AppendArenaOverview(ret);
 		return ret;
@@ -413,10 +414,11 @@ std::string TextCmdArenaPot(const string_view parameter)
 		StrAppend(ret, _("Arenas are only supported in multiplayer."));
 		return ret;
 	}
+	int numPots = ParseInt<int>(parameter, /*min=*/1).value_or(1);
 
 	Player &myPlayer = *MyPlayer;
 
-	for (int potNumber = std::max(1, atoi(parameter.data())); potNumber > 0; potNumber--) {
+	for (int potNumber = numPots; potNumber > 0; potNumber--) {
 		Item item {};
 		InitializeItem(item, IDI_ARENAPOT);
 		GenerateNewSeed(item);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -79,6 +79,7 @@
 #include "utils/console.h"
 #include "utils/display.h"
 #include "utils/language.h"
+#include "utils/parse_int.hpp"
 #include "utils/paths.h"
 #include "utils/stdcompat/string_view.hpp"
 #include "utils/str_cat.hpp"
@@ -949,11 +950,16 @@ void PrintHelpOption(string_view flags, string_view description)
 	diablo_quit(0);
 }
 
-void PrintFlagsRequiresArgument(string_view flag)
+void PrintFlagMessage(string_view flag, string_view message)
 {
 	printInConsole(flag);
-	printInConsole(" requires an argument");
+	printInConsole(message);
 	printNewlineInConsole();
+}
+
+void PrintFlagRequiresArgument(string_view flag)
+{
+	PrintFlagMessage(flag, " requires an argument");
 }
 
 void DiabloParseFlags(int argc, char **argv)
@@ -980,44 +986,54 @@ void DiabloParseFlags(int argc, char **argv)
 			diablo_quit(0);
 		} else if (arg == "--data-dir") {
 			if (i + 1 == argc) {
-				PrintFlagsRequiresArgument("--data-dir");
+				PrintFlagRequiresArgument("--data-dir");
 				diablo_quit(64);
 			}
 			paths::SetBasePath(argv[++i]);
 		} else if (arg == "--save-dir") {
 			if (i + 1 == argc) {
-				PrintFlagsRequiresArgument("--save-dir");
+				PrintFlagRequiresArgument("--save-dir");
 				diablo_quit(64);
 			}
 			paths::SetPrefPath(argv[++i]);
 		} else if (arg == "--config-dir") {
 			if (i + 1 == argc) {
-				PrintFlagsRequiresArgument("--config-dir");
+				PrintFlagRequiresArgument("--config-dir");
 				diablo_quit(64);
 			}
 			paths::SetConfigPath(argv[++i]);
 		} else if (arg == "--lang") {
 			if (i + 1 == argc) {
-				PrintFlagsRequiresArgument("--lang");
+				PrintFlagRequiresArgument("--lang");
 				diablo_quit(64);
 			}
 			forceLocale = argv[++i];
 #ifndef DISABLE_DEMOMODE
 		} else if (arg == "--demo") {
 			if (i + 1 == argc) {
-				PrintFlagsRequiresArgument("--demo");
+				PrintFlagRequiresArgument("--demo");
 				diablo_quit(64);
 			}
-			demoNumber = SDL_atoi(argv[++i]);
+			ParseIntResult<int> parsedParam = ParseInt<int>(argv[++i]);
+			if (!parsedParam.ok()) {
+				PrintFlagMessage("--demo", " must be a number");
+				diablo_quit(64);
+			}
+			demoNumber = parsedParam.value;
 			gbShowIntro = false;
 		} else if (arg == "--timedemo") {
 			timedemo = true;
 		} else if (arg == "--record") {
 			if (i + 1 == argc) {
-				PrintFlagsRequiresArgument("--record");
+				PrintFlagRequiresArgument("--record");
 				diablo_quit(64);
 			}
-			recordNumber = SDL_atoi(argv[++i]);
+			ParseIntResult<int> parsedParam = ParseInt<int>(argv[++i]);
+			if (!parsedParam.ok()) {
+				PrintFlagMessage("--record", " must be a number");
+				diablo_quit(64);
+			}
+			recordNumber = parsedParam.value;
 		} else if (arg == "--create-reference") {
 			createDemoReference = true;
 #else

--- a/Source/utils/parse_int.hpp
+++ b/Source/utils/parse_int.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#if __cplusplus >= 201703L
+#include <charconv>
+#include <system_error>
+#endif
+
+#include "utils/stdcompat/string_view.hpp"
+
+namespace devilution {
+
+enum class ParseIntStatus {
+	Ok,
+	ParseError,
+	OutOfRange
+};
+
+template <typename IntT>
+struct ParseIntResult {
+	ParseIntStatus status;
+	IntT value = 0;
+
+	[[nodiscard]] bool ok() const
+	{
+		return status == ParseIntStatus::Ok;
+	}
+
+	template <typename T>
+	[[nodiscard]] IntT value_or(T defaultValue) const // NOLINT(readability-identifier-naming)
+	{
+		return ok() ? value : static_cast<IntT>(defaultValue);
+	}
+};
+
+template <typename IntT>
+ParseIntResult<IntT> ParseInt(
+    string_view str, IntT min = std::numeric_limits<IntT>::min(),
+    IntT max = std::numeric_limits<IntT>::max())
+{
+	IntT value;
+	const std::from_chars_result result = std::from_chars(str.data(), str.data() + str.size(), value);
+	if (result.ec == std::errc::invalid_argument)
+		return ParseIntResult<IntT> { ParseIntStatus::ParseError };
+	if (result.ec == std::errc::result_out_of_range || value < min || value > max)
+		return ParseIntResult<IntT> { ParseIntStatus::OutOfRange };
+	if (result.ec != std::errc())
+		return ParseIntResult<IntT> { ParseIntStatus::ParseError };
+	return ParseIntResult<IntT> { ParseIntStatus::Ok, value };
+}
+
+} // namespace devilution


### PR DESCRIPTION
Adds a `ParseInt` function which uses `std::from_chars`.

From `std::from_chars` documentation:
> Unlike other parsing functions in C++ and C libraries,
> std::from_chars is locale-independent, non-allocating, and non-throwing.