### PR TITLE
vcpkg.json: Add builtin-baseline

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,6 +6,7 @@
         "bzip2",
         "simpleini"
     ],
+    "builtin-baseline": "662dbb50e63af15baa2909b7eac5b1b87e86a0aa",
     "features": {
         "sdl1": {
             "description": "Use SDL1.2 instead of SDL2",


### PR DESCRIPTION
This field is now required, otherwise we get this error:

> error: this vcpkg instance requires a manifest with a specified baseline in order to interact with ports.
> Please add 'builtin-baseline' to the manifest or add a 'vcpkg-configuration.json' that redefines the default registry.

The hash here is a commit hash from https://github.com/microsoft/vcpkg/commits/master

https://learn.microsoft.com/en-us/vcpkg/users/examples/versioning.getting-started#builtin-baseline