### PR TITLE
Empty cursor when closing inventory

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -658,7 +658,7 @@ void OpenCharPanel()
 {
 	QuestLogIsOpen = false;
 	CloseGoldWithdraw();
-	IsStashOpen = false;
+	CloseStash();
 	chrflag = true;
 }
 
@@ -1032,7 +1032,7 @@ void CheckBtnUp()
 		case PanelButtonQlog:
 			CloseCharPanel();
 			CloseGoldWithdraw();
-			IsStashOpen = false;
+			CloseStash();
 			if (!QuestLogIsOpen)
 				StartQuestlog();
 			else
@@ -1049,7 +1049,7 @@ void CheckBtnUp()
 		case PanelButtonInventory:
 			sbookflag = false;
 			CloseGoldWithdraw();
-			IsStashOpen = false;
+			CloseStash();
 			invflag = !invflag;
 			if (dropGoldFlag) {
 				CloseGoldDrop();

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1627,7 +1627,7 @@ void ProcessGameAction(const GameAction &action)
 			QuestLogIsOpen = false;
 			sbookflag = false;
 			CloseGoldWithdraw();
-			IsStashOpen = false;
+			CloseStash();
 		}
 		break;
 	case GameActionType_TOGGLE_CHARACTER_INFO:
@@ -1644,7 +1644,7 @@ void ProcessGameAction(const GameAction &action)
 			StartQuestlog();
 			CloseCharPanel();
 			CloseGoldWithdraw();
-			IsStashOpen = false;
+			CloseStash();
 			spselflag = false;
 		} else {
 			QuestLogIsOpen = false;

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -227,7 +227,7 @@ void LeftMouseCmd(bool bShift)
 
 	if (leveltype == DTYPE_TOWN) {
 		CloseGoldWithdraw();
-		IsStashOpen = false;
+		CloseStash();
 		if (pcursitem != -1 && pcurs == CURSOR_HAND)
 			NetSendCmdLocParam1(true, invflag ? CMD_GOTOGETITEM : CMD_GOTOAGETITEM, cursPosition, pcursitem);
 		if (pcursmonst != -1)
@@ -1482,7 +1482,7 @@ void InventoryKeyPressed()
 	}
 	sbookflag = false;
 	CloseGoldWithdraw();
-	IsStashOpen = false;
+	CloseStash();
 }
 
 void CharacterSheetKeyPressed()
@@ -1525,7 +1525,7 @@ void QuestLogKeyPressed()
 	}
 	CloseCharPanel();
 	CloseGoldWithdraw();
-	IsStashOpen = false;
+	CloseStash();
 }
 
 void DisplaySpellsKeyPressed()

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -96,6 +96,7 @@ bool CanBePlacedOnBelt(const Item &item);
 using ItemFunc = void (*)(Item &);
 
 void CloseInventory();
+void CloseStash();
 void FreeInvGFX();
 void InitInv();
 


### PR DESCRIPTION
Fixes #4205

An alternative to #4226

When closing the stash while an item is held we now first try to drop it, place it in the belt, or inventory.
If that fails we assume that we can stick it in the stash since it's huge.

The item put sound is played to let the player know what happened.