### PR TITLE
Move seedinfo to text commands

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -462,11 +462,49 @@ std::string TextCmdInspect(const string_view parameter)
 	return ret;
 }
 
+std::string TextCmdLevelSeed(const string_view parameter)
+{
+	string_view levelType = setlevel ? "set level" : "dungeon level";
+
+	char gameId[] = {
+		static_cast<char>((sgGameInitInfo.programid >> 24) & 0xFF),
+		static_cast<char>((sgGameInitInfo.programid >> 16) & 0xFF),
+		static_cast<char>((sgGameInitInfo.programid >> 8) & 0xFF),
+		static_cast<char>(sgGameInitInfo.programid & 0xFF),
+		'\0'
+	};
+
+	string_view mode = gbIsMultiplayer ? "MP" : "SP";
+
+	string_view questPool;
+	if (UseMultiplayerQuests())
+		questPool = "MP";
+	else if (*sgOptions.Gameplay.randomizeQuests)
+		questPool = "Random";
+	else
+		questPool = "All";
+
+	return StrCat(
+	    "Seedinfo for ", levelType, " ", currlevel, "\n",
+	    "seed: ", glSeedTbl[currlevel], "\n",
+#ifdef _DEBUG
+	    "Mid1: ", glMid1Seed[currlevel], "\n",
+	    "Mid2: ", glMid2Seed[currlevel], "\n",
+	    "Mid3: ", glMid3Seed[currlevel], "\n",
+	    "End: ", glEndSeed[currlevel], "\n",
+#endif
+	    "\n",
+	    gameId, " ", mode, "\n",
+	    questPool, " quests: ", glSeedTbl[15], "\n",
+	    "Storybook: ", glSeedTbl[16]);
+}
+
 std::vector<TextCmdItem> TextCmdList = {
 	{ N_("/help"), N_("Prints help overview or help for a specific command."), N_("({command})"), &TextCmdHelp },
 	{ N_("/arena"), N_("Enter a PvP Arena."), N_("{arena-number}"), &TextCmdArena },
 	{ N_("/arenapot"), N_("Gives Arena Potions."), N_("{number}"), &TextCmdArenaPot },
 	{ N_("/inspect"), N_("Inspects stats and equipment of another player."), N_("{player name}"), &TextCmdInspect },
+	{ N_("/seedinfo"), N_("Show seed infos for current level."), "", &TextCmdLevelSeed },
 };
 
 bool CheckTextCommand(const string_view text)

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -24,7 +24,6 @@
 #include "lighting.h"
 #include "monstdat.h"
 #include "monster.h"
-#include "options.h"
 #include "plrmsg.h"
 #include "quests.h"
 #include "spells.h"
@@ -48,6 +47,12 @@ bool DebugGrid = false;
 std::unordered_map<int, Point> DebugCoordsMap;
 bool DebugScrollViewEnabled = false;
 std::string debugTRN;
+
+// Used for debugging level generation
+uint32_t glMid1Seed[NUMLEVELS];
+uint32_t glMid2Seed[NUMLEVELS];
+uint32_t glMid3Seed[NUMLEVELS];
+uint32_t glEndSeed[NUMLEVELS];
 
 namespace {
 
@@ -88,12 +93,6 @@ int DebugMonsterId;
 std::vector<std::string> SearchMonsters;
 std::vector<std::string> SearchItems;
 std::vector<std::string> SearchObjects;
-
-// Used for debugging level generation
-uint32_t glMid1Seed[NUMLEVELS];
-uint32_t glMid2Seed[NUMLEVELS];
-uint32_t glMid3Seed[NUMLEVELS];
-uint32_t glEndSeed[NUMLEVELS];
 
 void PrintDebugMonster(const Monster &monster)
 {
@@ -650,41 +649,6 @@ std::string DebugCmdShowGrid(const string_view parameter)
 	return "Back to boring.";
 }
 
-std::string DebugCmdLevelSeed(const string_view parameter)
-{
-	string_view levelType = setlevel ? "set level" : "dungeon level";
-
-	char gameId[] = {
-		static_cast<char>((sgGameInitInfo.programid >> 24) & 0xFF),
-		static_cast<char>((sgGameInitInfo.programid >> 16) & 0xFF),
-		static_cast<char>((sgGameInitInfo.programid >> 8) & 0xFF),
-		static_cast<char>(sgGameInitInfo.programid & 0xFF),
-		'\0'
-	};
-
-	string_view mode = gbIsMultiplayer ? "MP" : "SP";
-
-	string_view questPool;
-	if (UseMultiplayerQuests())
-		questPool = "MP";
-	else if (*sgOptions.Gameplay.randomizeQuests)
-		questPool = "Random";
-	else
-		questPool = "All";
-
-	return StrCat(
-	    "Seedinfo for ", levelType, " ", currlevel, "\n",
-	    "seed: ", glSeedTbl[currlevel], "\n",
-	    "Mid1: ", glMid1Seed[currlevel], "\n",
-	    "Mid2: ", glMid2Seed[currlevel], "\n",
-	    "Mid3: ", glMid3Seed[currlevel], "\n",
-	    "End: ", glEndSeed[currlevel], "\n",
-	    "\n",
-	    gameId, " ", mode, "\n",
-	    questPool, " quests: ", glSeedTbl[15], "\n",
-	    "Storybook: ", glSeedTbl[16]);
-}
-
 std::string DebugCmdSpawnUniqueMonster(const string_view parameter)
 {
 	if (leveltype == DTYPE_TOWN)
@@ -1101,7 +1065,6 @@ std::vector<DebugCmdItem> DebugCmdList = {
 	{ "exit", "Exits the game.", "", &DebugCmdExit },
 	{ "arrow", "Changes arrow effect (normal, fire, lightning, explosion).", "{effect}", &DebugCmdArrow },
 	{ "grid", "Toggles showing grid.", "", &DebugCmdShowGrid },
-	{ "seedinfo", "Show seed infos for current level.", "", &DebugCmdLevelSeed },
 	{ "spawnu", "Spawns unique monster {name}.", "{name} ({count})", &DebugCmdSpawnUniqueMonster },
 	{ "spawn", "Spawns monster {name}.", "{name} ({count})", &DebugCmdSpawnMonster },
 	{ "tiledata", "Toggles showing tile data {name} (leave name empty to see a list).", "{name}", &DebugCmdShowTileData },

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <unordered_map>
 
+#include "diablo.h"
 #include "engine.h"
 #include "engine/clx_sprite.hpp"
 #include "utils/stdcompat/string_view.hpp"
@@ -24,6 +25,10 @@ extern bool DebugGrid;
 extern std::unordered_map<int, Point> DebugCoordsMap;
 extern bool DebugScrollViewEnabled;
 extern std::string debugTRN;
+extern uint32_t glMid1Seed[NUMLEVELS];
+extern uint32_t glMid2Seed[NUMLEVELS];
+extern uint32_t glMid3Seed[NUMLEVELS];
+extern uint32_t glEndSeed[NUMLEVELS];
 
 void FreeDebugGFX();
 void LoadDebugGFX();


### PR DESCRIPTION
Moves the `seedinfo` debug command to text commands so it can be used in release builds. The extra information about mid/end seeds is still only included in debug builds. Here's how it looks in a release build.

![image](https://github.com/diasurgical/devilutionX/assets/9203145/c575cfc7-3ce1-4363-b106-371cafc57657)

Thought I might slip this in as an option for 1.5.0 in case we want to be able to ask players of release builds to share seed info, but it does add some new strings for translation so may be better to defer. 🤷 

I considered attempting to translate some of the output strings, but devs are ultimately the ones who need to be able to read it so probably not a great idea.