### PR TITLE
Fix Item::getName() for Doppelganger's prefix

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2397,6 +2397,7 @@ std::string GetTranslatedItemNameMagical(const Item &item, bool hellfireItem, bo
 			    // GenerateRnd(prefix.power.param2 - prefix.power.param2 + 1)
 			    DiscardRandomValues(1);
 			    switch (pPrefix->power.type) {
+			    case IPL_DOPPELGANGER:
 			    case IPL_TOHIT_DAMP:
 				    DiscardRandomValues(2);
 				    break;


### PR DESCRIPTION
Because of the fallthrough...

https://github.com/diasurgical/devilutionX/blob/555dac5d22bf4cd0e1d672c526f94b3e0db62c77/Source/items.cpp#L735-L742

Doppelganger's should discard the same amount of random numbers as `IPL_TOHIT_DAMP` when computing the translated name of the item.

This resolves #6185

![image](https://github.com/diasurgical/devilutionX/assets/9203145/8f5ea98d-855f-4fa9-8a1b-2ea0ffa517db)