### PR TITLE
When checking chamber of bone entry also check the current dungeon level

### DIFF
--- a/Source/levels/trigs.cpp
+++ b/Source/levels/trigs.cpp
@@ -170,7 +170,7 @@ void InitL2Triggers()
 	numtrigs = 0;
 	for (WorldTileCoord j = 0; j < MAXDUNY; j++) {
 		for (WorldTileCoord i = 0; i < MAXDUNX; i++) {
-			if (dPiece[i][j] == 266 && (i != Quests[Q_SCHAMB].position.x || j != Quests[Q_SCHAMB].position.y)) {
+			if (dPiece[i][j] == 266 && (!Quests[Q_SCHAMB].IsAvailable() || i != Quests[Q_SCHAMB].position.x || j != Quests[Q_SCHAMB].position.y)) {
 				trigs[numtrigs].position = { i, j };
 				trigs[numtrigs]._tmsg = WM_DIABPREVLVL;
 				numtrigs++;


### PR DESCRIPTION
Fixes #110 and #4436

This is a vanilla issue.
The entry to chamber of bone reuses the dungeon pieces for going upwards.
That's why `InitL2Triggers` checks that this is not the entry to chamber of bone before placing a upwards-trigger on it.
And this check is faulty, because it's missing a dungeon level check.
The saves in #110 and #4436 were unlucky to have the same position for entry to chamber and the upwards pieces in dungeon level 7.

This PR adds the missing dungeon level check.