### PR TITLE
Update existing fonts.mpq

### DIFF
--- a/android-project/app/src/main/java/org/diasurgical/devilutionx/DataActivity.java
+++ b/android-project/app/src/main/java/org/diasurgical/devilutionx/DataActivity.java
@@ -101,8 +101,8 @@ public class DataActivity extends Activity {
 			return true;
 		}
 
-		if (lang.startsWith("ko") || lang.startsWith("zh") || lang.startsWith("ja")) {
-			File fonts_mpq = fileManager.getFile("/fonts.mpq");
+		File fonts_mpq = fileManager.getFile("/fonts.mpq");
+		if (lang.startsWith("ko") || lang.startsWith("zh") || lang.startsWith("ja") || fonts_mpq.exists()) {
 			if (!fonts_mpq.exists() || fonts_mpq.length() == 53991069 /* v2 */) {
 				if (!isDownloadingFonts) {
 					fonts_mpq.delete();

--- a/android-project/app/src/main/java/org/diasurgical/devilutionx/DevilutionXSDLActivity.java
+++ b/android-project/app/src/main/java/org/diasurgical/devilutionx/DevilutionXSDLActivity.java
@@ -82,6 +82,9 @@ public class DevilutionXSDLActivity extends SDLActivity {
 			if (!fileManager.hasFile("fonts.mpq"))
 				return true;
 		}
+		if (fileManager.fileSize("fonts.mpq") == 53991069 /* v2 */) {
+			return true;
+		}
 
 		return !fileManager.hasFile("diabdat.mpq") &&
 				!fileManager.hasFile("DIABDAT.MPQ") &&

--- a/android-project/app/src/main/java/org/diasurgical/devilutionx/ExternalFilesManager.java
+++ b/android-project/app/src/main/java/org/diasurgical/devilutionx/ExternalFilesManager.java
@@ -28,6 +28,11 @@ public class ExternalFilesManager {
 		return file.exists();
 	}
 
+	public long fileSize(String fileName) {
+		File file = getFile(fileName);
+		return file.length();
+	}
+
 	public File getFile(String fileName) {
 		return new File(externalFilesDirectory + "/" + fileName);
 	}


### PR DESCRIPTION
The logic here is to also report that the fonts.mpq needs to be downloaded if v2 of it has been manually added along with the game files.

From what I can tell our previous check was only activated if we where missing other data files, since we would then no go to the DataActivity activity and there for not invoke it.

The chnages will also cause it to detect and update the old file is the system default is cjk which was not the case before.

fileSize() will return 0 if the file doesn't exist