### PR TITLE
Fix null pointer exception when choosing an external files directory

### DIFF
--- a/android-project/app/src/main/java/org/diasurgical/devilutionx/ExternalFilesManager.java
+++ b/android-project/app/src/main/java/org/diasurgical/devilutionx/ExternalFilesManager.java
@@ -61,6 +61,8 @@ public class ExternalFilesManager {
 
 			for (int i = 0; i < externalDirs.length; i++) {
 				File dir = externalDirs[i];
+				if (dir == null)
+					continue;
 				File[] iniFiles = dir.listFiles((dir1, name) -> name.equals("diablo.ini"));
 				if (iniFiles.length > 0)
 					return dir.getAbsolutePath();
@@ -68,6 +70,8 @@ public class ExternalFilesManager {
 
 			for (int i = 0; i < externalDirs.length; i++) {
 				File dir = externalDirs[i];
+				if (dir == null)
+					continue;
 				if (dir.listFiles().length > 0)
 					return dir.getAbsolutePath();
 			}


### PR DESCRIPTION
From Google's documentation on the return value...
https://developer.android.com/reference/android/content/Context#getExternalFilesDirs(java.lang.String)

> Some individual paths may be null if that shared storage is not currently available.

This resolves #6201