### PR TITLE
Also disallow boosted stats for ground items

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1760,12 +1760,14 @@ int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int is
 	item._iMaxDur = mdur;
 	item._iCharges = ch;
 	item._iMaxCharges = mch;
-	item._iPLToHit = toHit;
-	item._iMaxDam = maxDam;
-	item._iMinStr = minStr;
-	item._iMinMag = minMag;
-	item._iMinDex = minDex;
-	item._iAC = ac;
+	if (gbIsHellfire) {
+		item._iPLToHit = toHit;
+		item._iMaxDam = maxDam;
+		item._iMinStr = minStr;
+		item._iMinMag = minMag;
+		item._iMinDex = minDex;
+		item._iAC = ac;
+	}
 	item.dwBuff = ibuff;
 
 	return PlaceItemInWorld(std::move(item), position);


### PR DESCRIPTION
I looked a bit closer at #6222, and the `RecreateItem()` function only applies to inventory synchronization and item deltas. We also need to modify `SyncDropItem()` to correct items dropped from players' inventories.