### PR TITLE
Find valid target when casting scroll from inventory

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4087,9 +4087,14 @@ void UseItem(size_t pnum, item_misc_id mid, SpellID spellID, int spellFrom)
 			prepareSpellID = spellID;
 		} else {
 			const int spellLevel = player.GetSpellLevel(spellID);
-			// Use CMD_SPELLXY, because tile coords aren't used anyway and it's the same behavior as normal casting
+			// Find a valid target for the spell because tile coords
+			// will be validated when processing the network message
+			Point target = cursPosition;
+			if (!InDungeonBounds(target))
+				target = player.position.future + Displacement(player._pdir);
+			// Use CMD_SPELLXY because it's the same behavior as normal casting
 			assert(IsValidSpellFrom(spellFrom));
-			NetSendCmdLocParam4(true, CMD_SPELLXY, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(SpellType::Scroll), spellLevel, static_cast<uint16_t>(spellFrom));
+			NetSendCmdLocParam4(true, CMD_SPELLXY, target, static_cast<int8_t>(spellID), static_cast<uint8_t>(SpellType::Scroll), spellLevel, static_cast<uint16_t>(spellFrom));
 		}
 		break;
 	case IMISC_BOOK: {


### PR DESCRIPTION
Since we are explicitly using `CMD_SPELLXY` here, I didn't simply call `UpdateSpellTarget()` because that function doesn't may not set cursor position if the player is targeting another player or a monster. That should be irrelevant when casting from the inventory, but is relevant when casting from the belt using the "heal" button as described in the linked issue.

This resolves #6231