### PR TITLE
Fix net validation of durability for items without durability

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1746,6 +1746,14 @@ bool CanPut(Point position)
 	return true;
 }
 
+int ClampDurability(const Item &item, int durability)
+{
+	if (item._iMaxDur == 0)
+		return 0;
+
+	return clamp<int>(durability, 1, item._iMaxDur);
+}
+
 int16_t ClampToHit(const Item &item, int16_t toHit)
 {
 	if (toHit < item._iPLToHit || toHit > 51)
@@ -1773,7 +1781,7 @@ int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int is
 	if (id != 0)
 		item._iIdentified = true;
 	item._iMaxDur = mdur;
-	item._iDurability = clamp<int>(dur, 1, item._iMaxDur);
+	item._iDurability = ClampDurability(item, dur);
 	item._iMaxCharges = clamp<int>(mch, 0, item._iMaxCharges);
 	item._iCharges = clamp<int>(ch, 0, item._iMaxCharges);
 	if (gbIsHellfire) {

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -219,6 +219,7 @@ void SyncGetItem(Point position, uint32_t iseed, _item_indexes idx, uint16_t ci)
  */
 bool CanPut(Point position);
 
+int ClampDurability(const Item &item, int durability);
 int16_t ClampToHit(const Item &item, int16_t toHit);
 uint8_t ClampMaxDam(const Item &item, uint8_t maxDam);
 int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int iseed, int id, int dur, int mdur, int ch, int mch, int ivalue, uint32_t ibuff, int toHit, int maxDam);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1034,7 +1034,7 @@ void RecreateItem(const Player &player, const TItem &messageItem, Item &item)
 	if (messageItem.bId != 0)
 		item._iIdentified = true;
 	item._iMaxDur = messageItem.bMDur;
-	item._iDurability = clamp<int>(messageItem.bDur, 1, item._iMaxDur);
+	item._iDurability = ClampDurability(item, messageItem.bDur);
 	item._iMaxCharges = clamp<int>(messageItem.bMCh, 0, item._iMaxCharges);
 	item._iCharges = clamp<int>(messageItem.bCh, 0, item._iMaxCharges);
 	if (gbIsHellfire) {


### PR DESCRIPTION
Potions, scrolls, books, etc do not have durability and would therefore cause an error because the max value is smaller than the min value in the call to `clamp()`. I introduced a new function, following the pattern for validation of CTH and max damage.