### PR TITLE
Flatpak install improvements

### DIFF
--- a/Packaging/nix/devilutionx.metainfo.xml
+++ b/Packaging/nix/devilutionx.metainfo.xml
@@ -1,39 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>org.diasurgical.DevilutionX</id>
-  
-  <name>DevilutionX</name>
-  <summary>Diablo/Hellfire source port for modern operating systems</summary>
-  
-  <metadata_license>CC-BY-SA-4.0</metadata_license>
-  <project_license>LicenseRef=https://github.com/diasurgical/devilutionX/blob/master/LICENSE.md</project_license>
-  
-  <supports>
-    <control>pointing</control>
-    <control>keyboard</control>
-    <control>touch</control>
-    <control>gamepad</control>
-  </supports>
-  
-  <description>
-    <p>
+	<id>org.diasurgical.DevilutionX</id>
+
+	<name>DevilutionX</name>
+	<summary>Diablo/Hellfire source port for modern operating systems</summary>
+
+	<metadata_license>CC-BY-SA-4.0</metadata_license>
+	<project_license>LicenseRef-proprietary</project_license>
+
+	<url type="homepage">https://github.com/diasurgical/devilutionX</url>
+	<url type="bugtracker">https://github.com/diasurgical/devilutionX/issues</url>
+	<url type="contact">https://discord.gg/YQKCAYQ</url>
+	<url type="vcs-browser">https://github.com/diasurgical/devilutionX</url>
+
+	<content_rating type="oars-1.1">
+		<content_attribute id="violence-fantasy">moderate</content_attribute>
+		<content_attribute id="drugs-alcohol">moderate</content_attribute>
+		<content_attribute id="sex-nudity">moderate</content_attribute>
+		<content_attribute id="sex-themes">moderate</content_attribute>
+		<content_attribute id="language-profanity">mild</content_attribute>
+		<content_attribute id="language-humor">mild</content_attribute>
+		<content_attribute id="social-chat">intense</content_attribute>
+	</content_rating>
+
+	<supports>
+		<control>pointing</control>
+		<control>keyboard</control>
+		<control>touch</control>
+		<control>gamepad</control>
+	</supports>
+
+	<description>
+		<p>
       DevilutionX is a source port of Diablo and Hellfire that strives to make it simple to run the game while providing engine improvements, bugfixes, and some optional quality of life features. This includes support for modern operating systems and higher resolutions, controller and touch control support, stash, optional experience and enemy health bars, etc.
-    </p>
-    <p>
-      Note: DevilutionX requires data files from original Diablo/Hellfire. Alternatively, a demo version of Diablo can be downloaded.
-    </p>
-  </description>
-  
-  <launchable type="desktop-id">devilutionx.desktop</launchable>
-  <screenshots>
-    <screenshot type="default">
-      <image>https://cdn.discordapp.com/attachments/518541192993046562/965941731579277312/unknown.png</image>
-    </screenshot>
-    <screenshot>
-      <image>https://cdn.discordapp.com/attachments/518541192993046562/965941904086818826/unknown.png</image>
-    </screenshot>
-    <screenshot>
-      <image>https://cdn.discordapp.com/attachments/518541192993046562/965942617223348284/unknown.png</image>
-    </screenshot>
-  </screenshots>
+		</p>
+		<p>
+      Note: DevilutionX requires data files from original Diablo/Hellfire. By default, a demo version of Diablo is installed.
+		</p>
+	</description>
+
+	<launchable type="desktop-id">devilutionx.desktop</launchable>
+	<screenshots>
+		<screenshot type="default">
+			<image>https://cdn.discordapp.com/attachments/518541192993046562/965941731579277312/unknown.png</image>
+		</screenshot>
+		<screenshot>
+			<image>https://cdn.discordapp.com/attachments/518541192993046562/965941904086818826/unknown.png</image>
+		</screenshot>
+		<screenshot>
+			<image>https://cdn.discordapp.com/attachments/518541192993046562/965942617223348284/unknown.png</image>
+		</screenshot>
+	</screenshots>
+	<releases>
+		<release version="1.5.0" date="2023-06-13"/>
+		<release version="1.4.1" date="2022-07-25"/>
+		<release version="1.4.0" date="2022-04-14"/>
+		<release version="1.3.0" date="2021-11-02"/>
+		<release version="1.2.1" date="2021-04-13"/>
+		<release version="1.2.0" date="2021-04-06"/>
+		<release version="1.1.0" date="2020-10-11"/>
+		<release version="1.0.3" date="2020-10-11"/>
+		<release version="1.0.2" date="2020-10-10"/>
+		<release version="1.0.1" date="2020-03-09"/>
+		<release version="1.0.0" date="2019-12-31"/>
+		<release version="0.5.0" date="2019-10-10"/>
+		<release version="0.4.0" date="2019-03-20"/>
+		<release version="0.3.1" date="2019-03-20"/>
+		<release version="0.3.0" date="2019-03-20"/>
+		<release version="0.2.0" date="2019-03-17"/>
+		<release version="0.1.0" date="2019-02-27"/>
+	</releases>
 </component>

--- a/Packaging/nix/org.diasurgical.DevilutionX.yml
+++ b/Packaging/nix/org.diasurgical.DevilutionX.yml
@@ -22,9 +22,23 @@ modules:
         - -DCMAKE_BUILD_TYPE=Release
       sources:
         - type: archive
-          url: https://github.com/diasurgical/devilutionX/releases/download/1.4.1/devilutionx-src-fully-vendored.tar.xz
-          sha256: 80527c29cd1d369ce905be426b671350b400c9468b73ef8cfbe6a09a563aeac0
+          url: https://github.com/diasurgical/devilutionX/releases/download/1.5.0/devilutionx-src-fully-vendored.tar.xz
+          sha256: 18aee4324c71198a26f15fe2b342552411c2f62039b64cf9b2fa3e249f1bc4f9
+        # CJK fonts
+        - type: file
+          filename: fonts.mpq
+          url: https://github.com/diasurgical/devilutionx-assets/releases/download/v3/fonts.mpq
+          sha256: 6b62e03c42ae4427055e0f292a1beafb5e840c397adaf1f641b909be37b8653e
+          size: 58488019
+        # Diablo shareware demo
+        - type: file
+          filename: spawn.mpq
+          url: https://github.com/diasurgical/devilutionx-assets/releases/download/v3/spawn.mpq
+          sha256: 64427cd7c1ba904eaa2e0031c16a6b136d0ecef9abc888c5ff8344b459356e38
+          size: 25448219
       post-install:
         - "sed -i 's/Icon=devilutionx-hellfire/Icon=org.diasurgical.DevilutionX-hellfire/g' ${FLATPAK_DEST}/share/applications/devilutionx-hellfire.desktop"
         - "mv ${FLATPAK_DEST}/share/applications/devilutionx-hellfire.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}-hellfire.desktop"
         - "mv ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/devilutionx-hellfire.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/${FLATPAK_ID}-hellfire.png"
+        - "mv fonts.mpq ${FLATPAK_DEST}/share/diasurgical/devilutionx"
+        - "mv spawn.mpq ${FLATPAK_DEST}/share/diasurgical/devilutionx"


### PR DESCRIPTION
* Base flatpak on version 1.5.0
* Bundle CJK fonts
* Bundle Diablo demo

I am bundling fonts to ensure easy onboarding for CJK users, so that they should to copy only the data files
IMO, bundling demo version is good to make sure that program was installed correctly, and it's freeware anyway

Refs #4469, IMO this will be a good MVP to submit to Flathub after merging