### PR TITLE
Update vcpkg commit ID for MSVC CI

### DIFF
--- a/.github/workflows/Windows_MSVC_x64.yml
+++ b/.github/workflows/Windows_MSVC_x64.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Restore or setup vcpkg
       uses: lukka/run-vcpkg@v10
       with:
-        vcpkgGitCommitId: '98f8d00e89fb6a8019c2045cfa1edbe9d92d3405'
+        vcpkgGitCommitId: '1ba9a2591f15af5900f2ce2b3e2bf31771e3ac48'
 
     - name: Fetch test data
       run: |


### PR DESCRIPTION
Updates the vcpkg commit ID to the one currently listed in...
https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md

Permalink, for posterity.
https://github.com/actions/runner-images/blob/c26258168863fb6f3f15307411be1665edfac90c/images/win/Windows2022-Readme.md?plain=1#L37