### PR TITLE
Split network player sync and hero save file

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -531,10 +531,9 @@ void LoadPlayer(LoadHelper &file, Player &player)
 
 	if (gbIsHellfireSaveGame) {
 		player.pDungMsgs2 = file.NextLE<uint8_t>();
-		player.pBattleNet = false;
 	} else {
 		player.pDungMsgs2 = 0;
-		player.pBattleNet = file.NextBool8();
+		file.Skip(1); // pBattleNet
 	}
 	player.pManaShield = file.NextBool8();
 	if (gbIsHellfireSaveGame) {
@@ -548,7 +547,7 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	file.Skip(14); // Available bytes
 
 	player.pDiabloKillLevel = file.NextLE<uint32_t>();
-	player.pDifficulty = static_cast<_difficulty>(file.NextLE<uint32_t>());
+	sgGameInitInfo.nDifficulty = static_cast<_difficulty>(file.NextLE<uint32_t>());
 	player.pDamAcFlags = static_cast<ItemSpecialEffectHf>(file.NextLE<uint32_t>());
 	file.Skip(20); // Available bytes
 	CalcPlrItemVals(player, false);
@@ -1344,7 +1343,7 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	if (gbIsHellfire)
 		file.WriteLE<uint8_t>(player.pDungMsgs2);
 	else
-		file.WriteLE<uint8_t>(player.pBattleNet ? 1 : 0);
+		file.WriteLE<uint8_t>(0);
 	file.WriteLE<uint8_t>(player.pManaShield ? 1 : 0);
 	file.WriteLE<uint8_t>(player.pOriginalCathedral ? 1 : 0);
 	file.Skip(2); // Available bytes
@@ -1352,7 +1351,7 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.Skip(14); // Available bytes
 
 	file.WriteLE<uint32_t>(player.pDiabloKillLevel);
-	file.WriteLE<uint32_t>(player.pDifficulty);
+	file.WriteLE<uint32_t>(sgGameInitInfo.nDifficulty);
 	file.WriteLE<uint32_t>(static_cast<uint32_t>(player.pDamAcFlags));
 	file.Skip(20); // Available bytes
 
@@ -2138,7 +2137,6 @@ void LoadGame(bool firstflag)
 
 	LoadPlayer(file, myPlayer);
 
-	sgGameInitInfo.nDifficulty = myPlayer.pDifficulty;
 	if (sgGameInitInfo.nDifficulty < DIFF_NORMAL || sgGameInitInfo.nDifficulty > DIFF_HELL)
 		sgGameInitInfo.nDifficulty = DIFF_NORMAL;
 
@@ -2418,7 +2416,6 @@ void SaveGameData(SaveWriter &saveWriter)
 	}
 
 	Player &myPlayer = *MyPlayer;
-	myPlayer.pDifficulty = sgGameInitInfo.nDifficulty;
 	SavePlayer(file, myPlayer);
 
 	for (int i = 0; i < giNumberQuests; i++)

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -970,19 +970,6 @@ bool IsPItemValid(const TCmdPItem &message)
 	return IsItemAvailable(static_cast<_item_indexes>(SDL_SwapLE16(message.def.wIndx)));
 }
 
-void PrepareItemForNetwork(const Item &item, TItem &messageItem)
-{
-	messageItem.bId = item._iIdentified ? 1 : 0;
-	messageItem.bDur = item._iDurability;
-	messageItem.bMDur = item._iMaxDur;
-	messageItem.bCh = item._iCharges;
-	messageItem.bMCh = item._iMaxCharges;
-	messageItem.wValue = SDL_SwapLE16(item._ivalue);
-	messageItem.wToHit = SDL_SwapLE16(item._iPLToHit);
-	messageItem.wMaxDam = SDL_SwapLE16(item._iMaxDam);
-	messageItem.dwBuff = SDL_SwapLE32(item.dwBuff);
-}
-
 void PrepareEarForNetwork(const Item &item, TEar &ear)
 {
 	ear.bCursval = item._ivalue | ((item._iCurs - ICURS_EAR_SORCERER) << 6);
@@ -1023,25 +1010,6 @@ void PrepareItemForNetwork(const Item &item, TCmdChItem &message)
 		PrepareEarForNetwork(item, message.ear);
 	else
 		PrepareItemForNetwork(item, message.item);
-}
-
-void RecreateItem(const Player &player, const TItem &messageItem, Item &item)
-{
-	const uint32_t dwBuff = SDL_SwapLE32(messageItem.dwBuff);
-	RecreateItem(player, item,
-	    static_cast<_item_indexes>(SDL_SwapLE16(messageItem.wIndx)), SDL_SwapLE16(messageItem.wCI),
-	    SDL_SwapLE32(messageItem.dwSeed), SDL_SwapLE16(messageItem.wValue), (dwBuff & CF_HELLFIRE) != 0);
-	if (messageItem.bId != 0)
-		item._iIdentified = true;
-	item._iMaxDur = messageItem.bMDur;
-	item._iDurability = ClampDurability(item, messageItem.bDur);
-	item._iMaxCharges = clamp<int>(messageItem.bMCh, 0, item._iMaxCharges);
-	item._iCharges = clamp<int>(messageItem.bCh, 0, item._iMaxCharges);
-	if (gbIsHellfire) {
-		item._iPLToHit = ClampToHit(item, SDL_SwapLE16(messageItem.wToHit));
-		item._iMaxDam = ClampMaxDam(item, SDL_SwapLE16(messageItem.wMaxDam));
-	}
-	item.dwBuff = dwBuff;
 }
 
 void RecreateItem(const Player &player, const TCmdPItem &message, Item &item)
@@ -2358,6 +2326,38 @@ size_t OnOpenGrave(const TCmd *pCmd)
 }
 
 } // namespace
+
+void PrepareItemForNetwork(const Item &item, TItem &messageItem)
+{
+	messageItem.bId = item._iIdentified ? 1 : 0;
+	messageItem.bDur = item._iDurability;
+	messageItem.bMDur = item._iMaxDur;
+	messageItem.bCh = item._iCharges;
+	messageItem.bMCh = item._iMaxCharges;
+	messageItem.wValue = SDL_SwapLE16(item._ivalue);
+	messageItem.wToHit = SDL_SwapLE16(item._iPLToHit);
+	messageItem.wMaxDam = SDL_SwapLE16(item._iMaxDam);
+	messageItem.dwBuff = SDL_SwapLE32(item.dwBuff);
+}
+
+void RecreateItem(const Player &player, const TItem &messageItem, Item &item)
+{
+	const uint32_t dwBuff = SDL_SwapLE32(messageItem.dwBuff);
+	RecreateItem(player, item,
+	    static_cast<_item_indexes>(SDL_SwapLE16(messageItem.wIndx)), SDL_SwapLE16(messageItem.wCI),
+	    SDL_SwapLE32(messageItem.dwSeed), SDL_SwapLE16(messageItem.wValue), (dwBuff & CF_HELLFIRE) != 0);
+	if (messageItem.bId != 0)
+		item._iIdentified = true;
+	item._iMaxDur = messageItem.bMDur;
+	item._iDurability = ClampDurability(item, messageItem.bDur);
+	item._iMaxCharges = clamp<int>(messageItem.bMCh, 0, item._iMaxCharges);
+	item._iCharges = clamp<int>(messageItem.bCh, 0, item._iMaxCharges);
+	if (gbIsHellfire) {
+		item._iPLToHit = ClampToHit(item, SDL_SwapLE16(messageItem.wToHit));
+		item._iMaxDam = ClampMaxDam(item, SDL_SwapLE16(messageItem.wMaxDam));
+	}
+	item.dwBuff = dwBuff;
+}
 
 void ClearLastSentPlayerCmd()
 {

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -720,6 +720,8 @@ struct TBuffer {
 extern uint8_t gbBufferMsgs;
 extern int dwRecCount;
 
+void PrepareItemForNetwork(const Item &item, TItem &messageItem);
+void RecreateItem(const Player &player, const TItem &messageItem, Item &item);
 void msg_send_drop_pkt(int pnum, int reason);
 bool msg_wait_resync();
 void run_delta_info();

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -156,7 +156,6 @@ bool IsNetPlayerValid(const Player &player)
 	    && player._pLevel <= MaxCharacterLevel
 	    && static_cast<uint8_t>(player._pClass) < enum_size<HeroClass>::value
 	    && player.plrlevel < NUMLEVELS
-	    && player.pDifficulty <= DIFF_LAST
 	    && InDungeonBounds(player.position.tile)
 	    && !string_view(player._pName).empty();
 }

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -349,12 +349,10 @@ void ProcessTmsgs()
 
 void SendPlayerInfo(int pnum, _cmd_id cmd)
 {
-	PlayerPack pPack;
+	PlayerNetPack packed;
 	Player &myPlayer = *MyPlayer;
-	PackPlayer(&pPack, myPlayer, true, true);
-	pPack.friendlyMode = myPlayer.friendlyMode ? 1 : 0;
-	pPack.isOnSetLevel = myPlayer.plrIsOnSetLevel;
-	multi_send_zero_packet(pnum, cmd, reinterpret_cast<byte *>(&pPack), sizeof(PlayerPack));
+	PackNetPlayer(packed, myPlayer);
+	multi_send_zero_packet(pnum, cmd, reinterpret_cast<byte *>(&packed), sizeof(PlayerNetPack));
 }
 
 void SetupLocalPositions()
@@ -803,7 +801,7 @@ bool NetInit(bool bSinglePlayer)
 
 void recv_plrinfo(int pnum, const TCmdPlrInfoHdr &header, bool recv)
 {
-	static PlayerPack PackedPlayerBuffer[MAX_PLRS];
+	static PlayerNetPack PackedPlayerBuffer[MAX_PLRS];
 
 	assert(pnum >= 0 && pnum < MAX_PLRS);
 	Player &player = Players[pnum];
@@ -831,11 +829,9 @@ void recv_plrinfo(int pnum, const TCmdPlrInfoHdr &header, bool recv)
 	sgwPackPlrOffsetTbl[pnum] = 0;
 
 	PlayerLeftMsg(pnum, false);
-	if (!UnPackPlayer(&packedPlayer, player, true)) {
+	if (!UnPackNetPlayer(packedPlayer, player)) {
 		return;
 	}
-	player.friendlyMode = packedPlayer.friendlyMode != 0;
-	player.plrIsOnSetLevel = packedPlayer.isOnSetLevel != 0;
 
 	if (!recv) {
 		return;

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -9,6 +9,7 @@
 
 #include "inv.h"
 #include "items.h"
+#include "msg.h"
 #include "player.h"
 
 namespace devilution {
@@ -24,7 +25,7 @@ struct ItemPack {
 	uint8_t bCh;
 	uint8_t bMCh;
 	uint16_t wValue;
-	int32_t dwBuff;
+	uint32_t dwBuff;
 };
 
 struct PlayerPack {
@@ -67,24 +68,56 @@ struct PlayerPack {
 	uint8_t pDungMsgs2;
 	/** The format the charater is in, 0: Diablo, 1: Hellfire */
 	int8_t bIsHellfire;
-	int8_t bReserved; // For future use
+	uint8_t reserved; // For future use
 	uint16_t wReflections;
-	int16_t wReserved2;   // For future use
+	uint8_t reserved2[2]; // For future use
 	uint8_t pSplLvl2[10]; // Hellfire spells
 	int16_t wReserved8;   // For future use
 	uint32_t pDiabloKillLevel;
 	uint32_t pDifficulty;
-	uint32_t pDamAcFlags; // `ItemSpecialEffectHf` is 1 byte but this is 4 bytes.
-	/**@brief Only used in multiplayer sync (SendPlayerInfo/recv_plrinfo). Never used in save games (single- or multiplayer). */
+	uint32_t pDamAcFlags;  // `ItemSpecialEffectHf` is 1 byte but this is 4 bytes.
+	uint8_t reserved3[20]; // For future use
+};
+
+struct PlayerNetPack {
+	uint8_t plrlevel;
+	uint8_t px;
+	uint8_t py;
+	char pName[PlayerNameLength];
+	uint8_t pClass;
+	uint8_t pBaseStr;
+	uint8_t pBaseMag;
+	uint8_t pBaseDex;
+	uint8_t pBaseVit;
+	int8_t pLevel;
+	uint8_t pStatPts;
+	uint32_t pExperience;
+	int32_t pGold;
+	int32_t pHPBase;
+	int32_t pMaxHPBase;
+	int32_t pManaBase;
+	int32_t pMaxManaBase;
+	uint8_t pSplLvl[MAX_SPELLS];
+	uint64_t pMemSpells;
+	TItem InvBody[NUM_INVLOC];
+	TItem InvList[InventoryGridCells];
+	int8_t InvGrid[InventoryGridCells];
+	uint8_t _pNumInv;
+	TItem SpdList[MaxBeltItems];
+	uint8_t pManaShield;
+	uint16_t wReflections;
+	uint8_t pDiabloKillLevel;
+	uint8_t pDifficulty;
+	ItemSpecialEffectHf pDamAcFlags;
 	uint8_t friendlyMode;
-	/**@brief Only used in multiplayer sync (SendPlayerInfo/recv_plrinfo). Never used in save games (single- or multiplayer). */
 	uint8_t isOnSetLevel;
-	uint8_t dwReserved[18]; // For future use
 };
 #pragma pack(pop)
 
-void PackPlayer(PlayerPack *pPack, const Player &player, bool manashield, bool netSync);
-bool UnPackPlayer(const PlayerPack *pPack, Player &player, bool netSync);
+void PackPlayer(PlayerPack *pPack, const Player &player);
+void UnPackPlayer(const PlayerPack *pPack, Player &player);
+void PackNetPlayer(PlayerNetPack &packed, const Player &player);
+bool UnPackNetPlayer(const PlayerNetPack &packed, Player &player);
 
 /**
  * @brief Save the attributes needed to recreate this item into an ItemPack struct

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -92,7 +92,6 @@ struct PlayerNetPack {
 	int8_t pLevel;
 	uint8_t pStatPts;
 	uint32_t pExperience;
-	int32_t pGold;
 	int32_t pHPBase;
 	int32_t pMaxHPBase;
 	int32_t pManaBase;
@@ -107,15 +106,13 @@ struct PlayerNetPack {
 	uint8_t pManaShield;
 	uint16_t wReflections;
 	uint8_t pDiabloKillLevel;
-	uint8_t pDifficulty;
-	ItemSpecialEffectHf pDamAcFlags;
 	uint8_t friendlyMode;
 	uint8_t isOnSetLevel;
 };
 #pragma pack(pop)
 
-void PackPlayer(PlayerPack *pPack, const Player &player);
-void UnPackPlayer(const PlayerPack *pPack, Player &player);
+void PackPlayer(PlayerPack &pPack, const Player &player);
+void UnPackPlayer(const PlayerPack &pPack, Player &player);
 void PackNetPlayer(PlayerNetPack &packed, const Player &player);
 bool UnPackNetPlayer(const PlayerNetPack &packed, Player &player);
 

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -482,7 +482,7 @@ void pfile_write_hero(SaveWriter &saveWriter, bool writeGameData)
 	PlayerPack pkplr;
 	Player &myPlayer = *MyPlayer;
 
-	PackPlayer(&pkplr, myPlayer);
+	PackPlayer(pkplr, myPlayer);
 	EncodeHero(saveWriter, &pkplr);
 	if (!gbVanilla) {
 		SaveHotkeys(saveWriter, myPlayer);
@@ -643,7 +643,7 @@ bool pfile_ui_set_hero_infos(bool (*uiAddHeroInfo)(_uiheroinfo *))
 
 				Player &player = Players[0];
 
-				UnPackPlayer(&pkplr, player);
+				UnPackPlayer(pkplr, player);
 				LoadHeroItems(player);
 				RemoveEmptyInventory(player);
 				CalcPlrInv(player, false);
@@ -693,7 +693,7 @@ bool pfile_ui_save_create(_uiheroinfo *heroinfo)
 	Player &player = Players[0];
 	CreatePlayer(player, heroinfo->heroclass);
 	CopyUtf8(player._pName, heroinfo->name, PlayerNameLength);
-	PackPlayer(&pkplr, player);
+	PackPlayer(pkplr, player);
 	EncodeHero(saveWriter, &pkplr);
 	Game2UiPlayer(player, heroinfo, false);
 	if (!gbVanilla) {
@@ -729,7 +729,7 @@ void pfile_read_player_from_save(uint32_t saveNum, Player &player)
 			pkplr.bIsHellfire = gbIsHellfireSaveGame ? 1 : 0;
 	}
 
-	UnPackPlayer(&pkplr, player);
+	UnPackPlayer(pkplr, player);
 	LoadHeroItems(player);
 	RemoveEmptyInventory(player);
 	CalcPlrInv(player, false);

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -482,7 +482,7 @@ void pfile_write_hero(SaveWriter &saveWriter, bool writeGameData)
 	PlayerPack pkplr;
 	Player &myPlayer = *MyPlayer;
 
-	PackPlayer(&pkplr, myPlayer, !gbIsMultiplayer, false);
+	PackPlayer(&pkplr, myPlayer);
 	EncodeHero(saveWriter, &pkplr);
 	if (!gbVanilla) {
 		SaveHotkeys(saveWriter, myPlayer);
@@ -643,16 +643,13 @@ bool pfile_ui_set_hero_infos(bool (*uiAddHeroInfo)(_uiheroinfo *))
 
 				Player &player = Players[0];
 
-				player = {};
+				UnPackPlayer(&pkplr, player);
+				LoadHeroItems(player);
+				RemoveEmptyInventory(player);
+				CalcPlrInv(player, false);
 
-				if (UnPackPlayer(&pkplr, player, false)) {
-					LoadHeroItems(player);
-					RemoveEmptyInventory(player);
-					CalcPlrInv(player, false);
-
-					Game2UiPlayer(player, &uihero, hasSaveGame);
-					uiAddHeroInfo(&uihero);
-				}
+				Game2UiPlayer(player, &uihero, hasSaveGame);
+				uiAddHeroInfo(&uihero);
 			}
 		}
 	}
@@ -696,7 +693,7 @@ bool pfile_ui_save_create(_uiheroinfo *heroinfo)
 	Player &player = Players[0];
 	CreatePlayer(player, heroinfo->heroclass);
 	CopyUtf8(player._pName, heroinfo->name, PlayerNameLength);
-	PackPlayer(&pkplr, player, true, false);
+	PackPlayer(&pkplr, player);
 	EncodeHero(saveWriter, &pkplr);
 	Game2UiPlayer(player, heroinfo, false);
 	if (!gbVanilla) {
@@ -719,8 +716,6 @@ bool pfile_delete_save(_uiheroinfo *heroInfo)
 
 void pfile_read_player_from_save(uint32_t saveNum, Player &player)
 {
-	player = {};
-
 	PlayerPack pkplr;
 	{
 		std::optional<SaveReader> archive = OpenSaveArchive(saveNum);
@@ -734,10 +729,7 @@ void pfile_read_player_from_save(uint32_t saveNum, Player &player)
 			pkplr.bIsHellfire = gbIsHellfireSaveGame ? 1 : 0;
 	}
 
-	if (!UnPackPlayer(&pkplr, player, false)) {
-		return;
-	}
-
+	UnPackPlayer(&pkplr, player);
 	LoadHeroItems(player);
 	RemoveEmptyInventory(player);
 	CalcPlrInv(player, false);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2279,14 +2279,6 @@ void CreatePlayer(Player &player, HeroClass c)
 	player._pBaseVit = PlayersData[static_cast<std::size_t>(c)].baseVit;
 	player._pVitality = player._pBaseVit;
 
-	player._pStatPts = 0;
-	player.pTownWarps = 0;
-	player.pDungMsgs = 0;
-	player.pDungMsgs2 = 0;
-	player.pLvlLoad = 0;
-	player.pDiabloKillLevel = 0;
-	player.pDifficulty = DIFF_NORMAL;
-
 	player._pLevel = 1;
 
 	player._pBaseToBlk = PlayersData[static_cast<std::size_t>(c)].blockBonus;
@@ -2376,7 +2368,6 @@ void CreatePlayer(Player &player, HeroClass c)
 	player._pLvlChanging = false;
 	player.pTownWarps = 0;
 	player.pLvlLoad = 0;
-	player.pBattleNet = false;
 	player.pManaShield = false;
 	player.pDamAcFlags = ItemSpecialEffectHf::None;
 	player.wReflections = 0;

--- a/Source/player.h
+++ b/Source/player.h
@@ -371,13 +371,11 @@ struct Player {
 	uint8_t pTownWarps;
 	uint8_t pDungMsgs;
 	uint8_t pLvlLoad;
-	bool pBattleNet;
 	bool pManaShield;
 	uint8_t pDungMsgs2;
 	bool pOriginalCathedral;
 	uint8_t pDiabloKillLevel;
 	uint16_t wReflections;
-	_difficulty pDifficulty;
 	ItemSpecialEffectHf pDamAcFlags;
 
 	void CalcScrolls();

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -126,9 +126,7 @@ static void AssertPlayer(Player &player)
 	ASSERT_EQ(player.pDungMsgs2, 0);
 	ASSERT_EQ(player.pLvlLoad, 0);
 	ASSERT_EQ(player.pDiabloKillLevel, 0);
-	ASSERT_EQ(player.pBattleNet, 0);
 	ASSERT_EQ(player.pManaShield, 0);
-	ASSERT_EQ(player.pDifficulty, 0);
 	ASSERT_EQ(player.pDamAcFlags, ItemSpecialEffectHf::None);
 
 	ASSERT_EQ(player._pmode, 0);

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -295,9 +295,7 @@ void AssertPlayer(Player &player)
 	ASSERT_EQ(player.pDungMsgs2, 0);
 	ASSERT_EQ(player.pLvlLoad, 0);
 	ASSERT_EQ(player.pDiabloKillLevel, 3);
-	ASSERT_EQ(player.pBattleNet, 0);
 	ASSERT_EQ(player.pManaShield, 0);
-	ASSERT_EQ(player.pDifficulty, 0);
 	ASSERT_EQ(player.pDamAcFlags, ItemSpecialEffectHf::None);
 
 	ASSERT_EQ(player._pmode, 0);
@@ -381,7 +379,7 @@ TEST(Writehero, pfile_write_hero)
 	pfile_ui_save_create(&info);
 	PlayerPack pks;
 	PackPlayerTest(&pks);
-	UnPackPlayer(&pks, *MyPlayer);
+	UnPackPlayer(pks, *MyPlayer);
 	AssertPlayer(Players[0]);
 	pfile_write_hero();
 

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -53,8 +53,6 @@ void SwapLE(PlayerPack &player)
 		SwapLE(item);
 	}
 	player.wReflections = SDL_SwapLE16(player.wReflections);
-	player.wReserved2 = SDL_SwapLE16(player.wReserved2);
-	player.wReserved8 = SDL_SwapLE16(player.wReserved8);
 	player.pDiabloKillLevel = SDL_SwapLE32(player.pDiabloKillLevel);
 	player.pDifficulty = SDL_SwapLE32(player.pDifficulty);
 	player.pDamAcFlags = SDL_SwapLE32(player.pDamAcFlags);
@@ -377,15 +375,13 @@ TEST(Writehero, pfile_write_hero)
 	Players.resize(1);
 	MyPlayerId = 0;
 	MyPlayer = &Players[MyPlayerId];
-	*MyPlayer = {};
 
 	_uiheroinfo info {};
-	strcpy(info.name, "TestPlayer");
 	info.heroclass = HeroClass::Rogue;
 	pfile_ui_save_create(&info);
 	PlayerPack pks;
 	PackPlayerTest(&pks);
-	UnPackPlayer(&pks, *MyPlayer, true);
+	UnPackPlayer(&pks, *MyPlayer);
 	AssertPlayer(Players[0]);
 	pfile_write_hero();
 


### PR DESCRIPTION
This should fix items not appearing correct when inspecting a player wearing oiled items after they joined (and didn't change gear).