### PR TITLE
Remove macOS release builds from CI

### DIFF
--- a/.github/workflows/macOS_x86_64.yml
+++ b/.github/workflows/macOS_x86_64.yml
@@ -56,12 +56,5 @@ jobs:
         name: devilutionx-x86_64-macOS.dmg
         path: build/devilutionx-x86_64-macOS.dmg
 
-    - name: Update Release
-      if: ${{ github.event_name == 'release' && !env.ACT }}
-      uses: svenstaro/upload-release-action@v2
-      with:
-        file: build/devilutionx-x86_64-macOS.dmg
-        overwrite: true
-
     - name: Clean up artifacts
       run: rm -rf build/_CPack_Packages build/*.dmg


### PR DESCRIPTION
fixes #6230

Since the host system has consequences for the resulting binary's comparability level we will unfortunately still need to build the macOS version manually until we figure out how to set the target version for each library and build them from src.