### PR TITLE
Player Death Messages and Player Hostile/Friendly alert

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -570,7 +570,7 @@ std::string DebugCmdChangeHealth(const string_view parameter)
 	int newHealth = myPlayer._pHitPoints + (change * 64);
 	SetPlayerHitPoints(myPlayer, newHealth);
 	if (newHealth <= 0)
-		SyncPlrKill(myPlayer, DeathReason::MonsterOrTrap);
+		SyncPlrKill(myPlayer, DeathReason::Unknown);
 
 	return "Health has changed.";
 }

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -443,10 +443,10 @@ void CheckMissileCol(Missile &missile, DamageType damageType, int minDamage, int
 					isPlayerHit = Plr2PlrMHit(Players[missile._misource], pid - 1, minDamage, maxDamage, missile._midist, missile._mitype, damageType, isDamageShifted, &blocked);
 			} else {
 				Monster &monster = Monsters[missile._misource];
-				isPlayerHit = PlayerMHit(pid - 1, &monster, missile._midist, minDamage, maxDamage, missile._mitype, damageType, isDamageShifted, DeathReason::MonsterOrTrap, &blocked);
+				isPlayerHit = PlayerMHit(pid - 1, &monster, missile._midist, minDamage, maxDamage, missile._mitype, damageType, isDamageShifted, DeathReason::Monster, &blocked);
 			}
 		} else {
-			DeathReason deathReason = (!missile.IsTrap() && (missile._miAnimType == MissileGraphicID::FireWall || missile._miAnimType == MissileGraphicID::Lightning)) ? DeathReason::Player : DeathReason::MonsterOrTrap;
+			DeathReason deathReason = (!missile.IsTrap() && (missile._miAnimType == MissileGraphicID::FireWall || missile._miAnimType == MissileGraphicID::Lightning)) ? DeathReason::Player : DeathReason::Trap;
 			isPlayerHit = PlayerMHit(pid - 1, nullptr, missile._midist, minDamage, maxDamage, missile._mitype, damageType, isDamageShifted, deathReason, &blocked);
 		}
 	}
@@ -1088,7 +1088,7 @@ bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, Missil
 	if (resper > 0) {
 		dam -= dam * resper / 100;
 		if (&player == MyPlayer) {
-			ApplyPlrDamage(damageType, player, 0, 0, dam, deathReason);
+			ApplyPlrDamage(damageType, player, 0, 0, dam, deathReason, monster->getId() ? monster != nullptr : 0);
 		}
 
 		if (player._pHitPoints >> 6 > 0) {
@@ -1098,7 +1098,7 @@ bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, Missil
 	}
 
 	if (&player == MyPlayer) {
-		ApplyPlrDamage(damageType, player, 0, 0, dam, deathReason);
+		ApplyPlrDamage(damageType, player, 0, 0, dam, deathReason, monster->getId() ? monster != nullptr : 0);
 	}
 
 	if (player._pHitPoints >> 6 > 0) {
@@ -1137,7 +1137,7 @@ void InitMissiles()
 				if (missile.sourcePlayer() == MyPlayer) {
 					int missingHP = myPlayer._pMaxHP - myPlayer._pHitPoints;
 					CalcPlrItemVals(myPlayer, true);
-					ApplyPlrDamage(DamageType::Physical, myPlayer, 0, 1, missingHP + missile.var2);
+					ApplyPlrDamage(DamageType::Physical, myPlayer, 0, 1, missingHP + missile.var2, DeathReason::Unknown);
 				}
 			}
 		}
@@ -3853,7 +3853,7 @@ void ProcessRage(Missile &missile)
 	}
 
 	CalcPlrItemVals(player, true);
-	ApplyPlrDamage(DamageType::Physical, player, 0, 1, hpdif);
+	ApplyPlrDamage(DamageType::Physical, player, 0, 1, hpdif, DeathReason::Unknown);
 	RedrawEverything();
 	player.Say(HeroSpeech::HeavyBreathing);
 }

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1088,7 +1088,7 @@ bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, Missil
 	if (resper > 0) {
 		dam -= dam * resper / 100;
 		if (&player == MyPlayer) {
-			ApplyPlrDamage(damageType, player, 0, 0, dam, deathReason, monster->getId() ? monster != nullptr : 0);
+			ApplyPlrDamage(damageType, player, 0, 0, dam, deathReason, static_cast<uint16_t>(monster->type().type) ? monster != nullptr : -1, static_cast<uint16_t>(monster->uniqueType), monster->isUnique() ? monster != nullptr : false);
 		}
 
 		if (player._pHitPoints >> 6 > 0) {
@@ -1098,7 +1098,7 @@ bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, Missil
 	}
 
 	if (&player == MyPlayer) {
-		ApplyPlrDamage(damageType, player, 0, 0, dam, deathReason, monster->getId() ? monster != nullptr : 0);
+		ApplyPlrDamage(damageType, player, 0, 0, dam, deathReason, static_cast<uint16_t>(monster->type().type) ? monster != nullptr : -1, static_cast<uint16_t>(monster->uniqueType), monster->isUnique() ? monster != nullptr : false);
 	}
 
 	if (player._pHitPoints >> 6 > 0) {

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1141,7 +1141,7 @@ void InitMissiles()
 				if (missile.sourcePlayer() == MyPlayer) {
 					int missingHP = myPlayer._pMaxHP - myPlayer._pHitPoints;
 					CalcPlrItemVals(myPlayer, true);
-					ApplyPlrDamage(DamageType::Physical, myPlayer, 0, 1, missingHP + missile.var2, DeathReason::Unknown);
+					ApplyPlrDamage(DamageType::Physical, myPlayer, 0, 1, missingHP + missile.var2, DeathReason::BloodMagic);
 				}
 			}
 		}
@@ -3857,7 +3857,7 @@ void ProcessRage(Missile &missile)
 	}
 
 	CalcPlrItemVals(player, true);
-	ApplyPlrDamage(DamageType::Physical, player, 0, 1, hpdif, DeathReason::Unknown);
+	ApplyPlrDamage(DamageType::Physical, player, 0, 1, hpdif, DeathReason::BloodMagic);
 	RedrawEverything();
 	player.Say(HeroSpeech::HeavyBreathing);
 }

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1085,10 +1085,14 @@ bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, Missil
 		return true;
 	}
 
+	uint16_t monsterType = monster != nullptr ? static_cast<uint16_t>(monster->type().type) : -1;
+	uint16_t monsterUid = monster != nullptr ? static_cast<uint16_t>(monster->uniqueType) : -1;
+	bool isMonsterUnique = monster != nullptr ? monster->isUnique() : false;
+
 	if (resper > 0) {
 		dam -= dam * resper / 100;
 		if (&player == MyPlayer) {
-			ApplyPlrDamage(damageType, player, 0, 0, dam, deathReason, static_cast<uint16_t>(monster->type().type) ? monster != nullptr : -1, static_cast<uint16_t>(monster->uniqueType), monster->isUnique() ? monster != nullptr : false);
+			ApplyPlrDamage(damageType, player, 0, 0, dam, deathReason, monsterType, monsterUid, isMonsterUnique);
 		}
 
 		if (player._pHitPoints >> 6 > 0) {
@@ -1098,7 +1102,7 @@ bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, Missil
 	}
 
 	if (&player == MyPlayer) {
-		ApplyPlrDamage(damageType, player, 0, 0, dam, deathReason, static_cast<uint16_t>(monster->type().type) ? monster != nullptr : -1, static_cast<uint16_t>(monster->uniqueType), monster->isUnique() ? monster != nullptr : false);
+		ApplyPlrDamage(damageType, player, 0, 0, dam, deathReason, monsterType, monsterUid, isMonsterUnique);
 	}
 
 	if (player._pHitPoints >> 6 > 0) {

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1201,7 +1201,11 @@ void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, 
 			int reflectedDamage = CheckReflect(monster, player, dam);
 			dam = std::max(dam - reflectedDamage, 0);
 		}
-		ApplyPlrDamage(DamageType::Physical, player, 0, 0, dam, DeathReason::Monster, static_cast<uint16_t>(monster.type().type), static_cast<uint16_t>(monster.uniqueType), monster.isUnique());
+		uint16_t monsterType = static_cast<uint16_t>(monster.type().type);
+		uint16_t monsterUid = static_cast<uint16_t>(monster.uniqueType);
+		bool isMonsterUnique = monster.isUnique();
+
+		ApplyPlrDamage(DamageType::Physical, player, 0, 0, dam, DeathReason::Monster, monsterType, monsterUid, isMonsterUnique);
 	}
 
 	// Reflect can also kill a monster, so make sure the monster is still alive

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1201,7 +1201,7 @@ void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, 
 			int reflectedDamage = CheckReflect(monster, player, dam);
 			dam = std::max(dam - reflectedDamage, 0);
 		}
-		ApplyPlrDamage(DamageType::Physical, player, 0, 0, dam);
+		ApplyPlrDamage(DamageType::Physical, player, 0, 0, dam, DeathReason::Monster, monster.getId());
 	}
 
 	// Reflect can also kill a monster, so make sure the monster is still alive

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1201,7 +1201,7 @@ void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, 
 			int reflectedDamage = CheckReflect(monster, player, dam);
 			dam = std::max(dam - reflectedDamage, 0);
 		}
-		ApplyPlrDamage(DamageType::Physical, player, 0, 0, dam, DeathReason::Monster, monster.getId());
+		ApplyPlrDamage(DamageType::Physical, player, 0, 0, dam, DeathReason::Monster, static_cast<uint16_t>(monster.type().type), static_cast<uint16_t>(monster.uniqueType), monster.isUnique());
 	}
 
 	// Reflect can also kill a monster, so make sure the monster is still alive

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1790,22 +1790,115 @@ size_t OnPlayerDeath(const TCmd *pCmd, size_t pnum)
 
 	switch (deathReason) {
 	case DeathReason::Monster: {
-		if (monsterUid != -1) {
+		uint16_t rnd = GenerateRnd(9);
+		switch (rnd) {
+		case 0:
+			szEvent = _("{:s} was slain by {:s}.");
+			break;
+		case 1:
+			szEvent = _("{:s} was exsanguinated by {:s}.");
+			break;
+		case 2:
+			szEvent = _("{:s} was eviscerated by {:s}.");
+			break;
+		case 3:
+			szEvent = _("{:s} met a gruesome end at the hands of {:s}.");
+			break;
+		case 4:
+			szEvent = _("{:s} was obliterated by {:s}.");
+			break;
+		case 5:
+			szEvent = _("In a brutal display, {:s} ripped apart {:s}.");
+			break;
+		case 6:
+			szEvent = _("{:s} was dragged into the abyss by {:s}.");
+			break;
+		case 7:
+			szEvent = _("{:s} was vanquished by {:s}, leaving no trace behind.");
+			break;
+		case 8:
+			szEvent = _("With a deadly strike, {:s} eradicated {:s}.");
+			break;
+		case 9:
+			szEvent = _("{:s} was torn limb from limb by {:s}.");
+			break;
+		default:
+			szEvent = _("{:s} was slain by {:s}.");
+			break;
+		}
+		if (wasKilledByUnique) {
 			const UniqueMonsterData unique = UniqueMonstersData[monsterUid];
-			EventPlrMsg(fmt::format(fmt::runtime(_("{:s} was slain by {:s}.")), player._pName, unique.mName), textColor);
+			EventPlrMsg(fmt::format(fmt::runtime(szEvent), player._pName, unique.mName), textColor);
 		} else {
 			const MonsterData monster = MonstersData[deathSourceIndex];
-			EventPlrMsg(fmt::format(fmt::runtime(_("{:s} was slain by {:s}.")), player._pName, monster.name), textColor);
+			EventPlrMsg(fmt::format(fmt::runtime(szEvent), player._pName, monster.name), textColor);
 		}
 		break;
 	}
 	case DeathReason::Trap: {
-		EventPlrMsg(fmt::format(fmt::runtime(_("{:s} was slain by a trap.")), player._pName), textColor);
+		uint16_t rnd = GenerateRnd(4);
+		switch (rnd) {
+		case 0:
+			szEvent = _("{:s} was slain by a trap.");
+			break;
+		case 1:
+			szEvent = _("{:s} was ensnared by a deadly trap.");
+			break;
+		case 2:
+			szEvent = _("{:s} fell victim to a cunningly hidden trap.");
+			break;
+		case 3:
+			szEvent = _("{:s} was overwhelmed by a trap's deadly mechanism.");
+			break;
+		case 4:
+			szEvent = _("{:s} met a sudden demise from a devious trap.");
+			break;
+		default:
+			szEvent = _("{:s} was slain by a trap.");
+			break;
+		}
+		EventPlrMsg(fmt::format(fmt::runtime(szEvent), player._pName), textColor);
 		break;
 	}
 	case DeathReason::Player: {
+		uint16_t rnd = GenerateRnd(9);
+		switch (rnd) {
+		case 0:
+			szEvent = _("{:s} was slain by {:s}.");
+			break;
+		case 1:
+			szEvent = _("{:s} met their end at the hands of {:s}.");
+			break;
+		case 2:
+			szEvent = _("{:s} was vanquished by the might of {:s}.");
+			break;
+		case 3:
+			szEvent = _("{:s} fell victim to the treachery of {:s}.");
+			break;
+		case 4:
+			szEvent = _("{:s} was obliterated by the power of {:s}.");
+			break;
+		case 5:
+			szEvent = _("{:s} was annihilated by the wrath of {:s}.");
+			break;
+		case 6:
+			szEvent = _("{:s} was struck down by {:s}.");
+			break;
+		case 7:
+			szEvent = _("{:s} was executed by {:s}'s deadly assault.");
+			break;
+		case 8:
+			szEvent = _("{:s} was overpowered by {:s}'s devastating attack.");
+			break;
+		case 9:
+			szEvent = _("{:s} was defeated by {:s}'s cunning tactics.");
+			break;
+		default:
+			szEvent = _("{:s} was slain by {:s}.");
+			break;
+		}
 		const Player &killer = Players[deathSourceIndex];
-		EventPlrMsg(fmt::format(fmt::runtime(_("{:s} was slain by {:s}.")), player._pName, killer._pName), textColor);
+		EventPlrMsg(fmt::format(fmt::runtime(szEvent), player._pName, killer._pName), textColor);
 		break;
 	}
 	case DeathReason::DrainLife: {

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1805,7 +1805,7 @@ size_t OnPlayerDeath(const TCmd *pCmd, size_t pnum)
 			szEvent = _("{:s} met a gruesome end at the hands of {:s}.");
 			break;
 		case 4:
-			szEvent = _("{:s} was obliterated by {:s}.");
+			szEvent = _("{:s} was disemboweled by {:s}.");
 			break;
 		case 5:
 			szEvent = _("In a brutal display, {:s} ripped apart {:s}.");

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1785,17 +1785,21 @@ size_t OnPlayerDeath(const TCmd *pCmd, size_t pnum)
 		SendPacket(pnum, &message, sizeof(message));
 	}
 
+	string_view szEvent;
+
 	switch (deathReason) {
 	case DeathReason::MonsterOrTrap:
-		EventPlrMsg(fmt::format(fmt::runtime(_("{:s} was slain while fighting the denizens of Diablo.")), player._pName));
+		szEvent = _("{:s} was slain while fighting the denizens of Diablo.");
 		break;
 	case DeathReason::Player:
-		EventPlrMsg(fmt::format(fmt::runtime(_("{:s} was slain by a fellow hero.")), player._pName));
+		szEvent = _("{:s} was slain by a fellow hero.");
 		break;
 	case DeathReason::Unknown:
-		EventPlrMsg(fmt::format(fmt::runtime(_("{:s} was slain.")), player._pName));
+		szEvent = _("{:s} was slain.");
 		break;
 	}
+
+	EventPlrMsg(fmt::format(fmt::runtime(szEvent), player._pName));
 
 	return sizeof(message);
 }
@@ -2223,9 +2227,15 @@ size_t OnString(const TCmd *pCmd, Player &player)
 size_t OnFriendlyMode(const TCmd *pCmd, Player &player) // NOLINT(misc-unused-parameters)
 {
 	player.friendlyMode = !player.friendlyMode;
+
+	string_view szEvent;
+
 	if (&player != MyPlayer)
-		player.friendlyMode ? EventPlrMsg(fmt::format(fmt::runtime(_("{:s} has become friendly towards you.")), player._pName)) : EventPlrMsg(fmt::format(fmt::runtime(_("{:s} has expressed hostility towards you.")), player._pName));
+		szEvent = player.friendlyMode ? _("{:s} has become friendly towards you.") : _("{:s} has expressed hostility towards you.");
+
+	EventPlrMsg(fmt::format(fmt::runtime(szEvent), player._pName));
 	RedrawEverything();
+
 	return sizeof(*pCmd);
 }
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1808,6 +1808,18 @@ size_t OnPlayerDeath(const TCmd *pCmd, size_t pnum)
 		EventPlrMsg(fmt::format(fmt::runtime(_("{:s} was slain by {:s}.")), player._pName, killer._pName), textColor);
 		break;
 	}
+	case DeathReason::DrainLife: {
+		EventPlrMsg(fmt::format(fmt::runtime(_("{:s} succumbed to the curse of Constricting Ring.")), player._pName), textColor);
+		break;
+	}
+	case DeathReason::Peril: {
+		EventPlrMsg(fmt::format(fmt::runtime(_("{:s} was betrayed by their own weapon.")), player._pName), textColor);
+		break;
+	}
+	case DeathReason::BloodMagic: {
+		EventPlrMsg(fmt::format(fmt::runtime(_("{:s} perished from overuse of their lifeforce.")), player._pName), textColor);
+		break;
+	}
 	case DeathReason::Unknown: {
 		EventPlrMsg(fmt::format(fmt::runtime(_("{:s} died.")), player._pName), textColor);
 		break;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2251,7 +2251,6 @@ size_t OnFriendlyMode(const TCmd *pCmd, Player &player) // NOLINT(misc-unused-pa
 			textColor = UiFlags::ColorRed;
 			szEvent = _("{:s} has expressed hostility towards you.");
 		}
-		 
 	}
 
 	EventPlrMsg(fmt::format(fmt::runtime(szEvent), player._pName), textColor);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1777,7 +1777,6 @@ size_t OnPlayerDeath(const TCmd *pCmd, size_t pnum)
 	Player &player = Players[pnum];
 
 	if (gbBufferMsgs != 1) {
-		
 		if (&player != MyPlayer)
 			StartPlayerKill(player, deathReason);
 		else

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1692,10 +1692,6 @@ size_t OnMonstDeath(const TCmd *pCmd, size_t pnum)
 		SendPacket(pnum, &message, sizeof(message));
 	}
 
-	if (monster.isUnique()) {
-		EventPlrMsg(fmt::format(fmt::runtime(_("{:s} has been defeated!")), monster.name()));
-	}
-
 	return sizeof(message);
 }
 
@@ -2988,22 +2984,6 @@ void NetSendCmdPDeath(bool bHiPri, _cmd_id bCmd, uint16_t wDeathReason, uint16_t
 	cmd.wDeathSourceIndex = SDL_SwapLE16(wDeathSourceIndex);
 	cmd.wMonsterUid = SDL_SwapLE16(wMonsterUid);
 	cmd.bWasKilledByUnique = SDL_SwapLE16(bWasKilledByUnique);
-	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
-	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
-}
-
-void NetSendCmdMDeath(bool bHiPri, _cmd_id bCmd, uint16_t wMonsterUid, bool bIsMonsterUnique)
-{
-	if (WasPlayerCmdAlreadyRequested(bCmd, {}, wMonsterUid, bIsMonsterUnique))
-		return;
-
-	TCmdMDeath cmd;
-
-	cmd.bCmd = bCmd;
-	cmd.wMonsterUid = SDL_SwapLE16(wMonsterUid);
-	cmd.bIsMonsterUnique = SDL_SwapLE16(bIsMonsterUnique);
 	if (bHiPri)
 		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
 	else

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1808,7 +1808,7 @@ size_t OnPlayerDeath(const TCmd *pCmd, size_t pnum)
 			szEvent = _("{:s} was disemboweled by {:s}.");
 			break;
 		case 5:
-			szEvent = _("In a brutal display, {:s} ripped apart {:s}.");
+			szEvent = _("In a brutal display, {:s} was ripped apart by {:s}.");
 			break;
 		case 6:
 			szEvent = _("{:s} was dragged into the abyss by {:s}.");
@@ -1817,7 +1817,7 @@ size_t OnPlayerDeath(const TCmd *pCmd, size_t pnum)
 			szEvent = _("{:s} was vanquished by {:s}, leaving no trace behind.");
 			break;
 		case 8:
-			szEvent = _("With a deadly strike, {:s} eradicated {:s}.");
+			szEvent = _("With a deadly strike, {:s} was eradicated by {:s}.");
 			break;
 		case 9:
 			szEvent = _("{:s} was torn limb from limb by {:s}.");

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -203,9 +203,10 @@ enum _cmd_id : uint8_t {
 	CMD_MONSTDAMAGE,
 	// Player death.
 	//
-	// body (TCmdParam2):
+	// body (TCmdParam3):
 	//    int16_t ear_flag
-	//    int16_t death_source_index
+	//    int16_t death_source
+	//    int16_t is_monster_unique
 	CMD_PLRDEAD,
 	// Lift item to hand request.
 	//
@@ -505,6 +506,20 @@ struct TCmdParam5 {
 	uint16_t wParam5;
 };
 
+struct TCmdPDeath {
+	_cmd_id bCmd;
+	uint16_t wDeathReason;
+	uint16_t wDeathSourceIndex;
+	uint16_t wMonsterUid;
+	bool bWasKilledByUnique;
+};
+
+struct TCmdMDeath {
+	_cmd_id bCmd;
+	uint16_t wMonsterUid;
+	bool bIsMonsterUnique;
+};
+
 struct TCmdGolem {
 	_cmd_id bCmd;
 	uint8_t _mx;
@@ -752,6 +767,8 @@ void NetSendCmdLocParam5(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 void NetSendCmdParam1(bool bHiPri, _cmd_id bCmd, uint16_t wParam1);
 void NetSendCmdParam2(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2);
 void NetSendCmdParam5(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4, uint16_t wParam5);
+void NetSendCmdPDeath(bool bHiPri, _cmd_id bCmd, uint16_t wDeathReason, uint16_t wDeathSourceIndex, uint16_t wMonsterUid, bool bWasKilledByUnique = false);
+void NetSendCmdMDeath(bool bHiPri, _cmd_id bCmd, uint16_t wMonsterUid, bool bIsMonsterUnique = false);
 void NetSendCmdQuest(bool bHiPri, const Quest &quest);
 void NetSendCmdGItem(bool bHiPri, _cmd_id bCmd, uint8_t pnum, uint8_t ii);
 void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position, const Item &item);

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -203,10 +203,11 @@ enum _cmd_id : uint8_t {
 	CMD_MONSTDAMAGE,
 	// Player death.
 	//
-	// body (TCmdParam3):
-	//    int16_t ear_flag
-	//    int16_t death_source
-	//    int16_t is_monster_unique
+	// body (TCmdPDeath):
+	//    uint16_t wDeathReason;
+	//    uint16_t wDeathSourceIndex;
+	//    uint16_t wMonsterUid;
+	//    bool bWasKilledByUnique;
 	CMD_PLRDEAD,
 	// Lift item to hand request.
 	//

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -203,8 +203,9 @@ enum _cmd_id : uint8_t {
 	CMD_MONSTDAMAGE,
 	// Player death.
 	//
-	// body (TCmdParam1):
+	// body (TCmdParam2):
 	//    int16_t ear_flag
+	//    int16_t death_source_index
 	CMD_PLRDEAD,
 	// Lift item to hand request.
 	//

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -514,12 +514,6 @@ struct TCmdPDeath {
 	bool bWasKilledByUnique;
 };
 
-struct TCmdMDeath {
-	_cmd_id bCmd;
-	uint16_t wMonsterUid;
-	bool bIsMonsterUnique;
-};
-
 struct TCmdGolem {
 	_cmd_id bCmd;
 	uint8_t _mx;

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -842,16 +842,24 @@ void recv_plrinfo(int pnum, const TCmdPlrInfoHdr &header, bool recv)
 
 	string_view szEvent;
 	if (sgbPlayerTurnBitTbl[pnum]) {
-		szEvent = _("Player '{:s}' (level {:d}) just joined the game");
+		szEvent = _("Player '{:s}' (level {:d} {:s}) just joined the game");
 	} else {
-		szEvent = _("Player '{:s}' (level {:d}) is already in the game");
+		szEvent = _("Player '{:s}' (level {:d} {:s}) is already in the game");
 	}
-	EventPlrMsg(fmt::format(fmt::runtime(szEvent), player._pName, player._pLevel));
+	EventPlrMsg(fmt::format(fmt::runtime(szEvent), player._pName, player._pLevel, player.GetClassName()));
 
-	if (&player != MyPlayer)
-		szEvent = player.friendlyMode ? _("{:s} is friendly.") : _("{:s} is hostile.");
+	UiFlags textColor = UiFlags::ColorWhitegold;
 
-	EventPlrMsg(fmt::format(fmt::runtime(szEvent), player._pName));
+	if (&player != MyPlayer) {
+		if (player.friendlyMode) {
+			szEvent = _("{:s} is friendly.");
+		} else {
+			textColor = UiFlags::ColorRed;
+			szEvent = _("{:s} is hostile.");
+		}
+	}
+
+	EventPlrMsg(fmt::format(fmt::runtime(szEvent), player._pName), textColor);
 
 	SyncInitPlr(player);
 

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -848,6 +848,11 @@ void recv_plrinfo(int pnum, const TCmdPlrInfoHdr &header, bool recv)
 	}
 	EventPlrMsg(fmt::format(fmt::runtime(szEvent), player._pName, player._pLevel));
 
+	if (&player != MyPlayer)
+		szEvent = player.friendlyMode ? _("{:s} is friendly.") : _("{:s} is hostile.");
+
+	EventPlrMsg(fmt::format(fmt::runtime(szEvent), player._pName));
+
 	SyncInitPlr(player);
 
 	if (!player.isOnActiveLevel()) {

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1730,7 +1730,7 @@ void UpdateFlameTrap(Object &trap)
 			MonsterTrapHit(dMonster[x][y] - 1, mindam / 2, maxdam / 2, 0, TrapMissile, GetMissileData(TrapMissile).damageType(), false);
 		if (dPlayer[x][y] > 0) {
 			bool unused;
-			PlayerMHit(dPlayer[x][y] - 1, nullptr, 0, mindam, maxdam, TrapMissile, GetMissileData(TrapMissile).damageType(), false, DeathReason::MonsterOrTrap, &unused);
+			PlayerMHit(dPlayer[x][y] - 1, nullptr, 0, mindam, maxdam, TrapMissile, GetMissileData(TrapMissile).damageType(), false, DeathReason::Trap, &unused);
 		}
 
 		if (trap._oAnimFrame == trap._oAnimLen)
@@ -1756,7 +1756,7 @@ void UpdateBurningCrossDamage(Object &cross)
 	if (myPlayer.position.tile != cross.position + Displacement { 0, -1 })
 		return;
 
-	ApplyPlrDamage(DamageType::Fire, myPlayer, 0, 0, damage[leveltype - 1]);
+	ApplyPlrDamage(DamageType::Fire, myPlayer, 0, 0, damage[leveltype - 1], DeathReason::Trap);
 	if (myPlayer._pHitPoints >> 6 > 0) {
 		myPlayer.Say(HeroSpeech::Argh);
 	}
@@ -3557,7 +3557,7 @@ void BreakBarrel(const Player &player, Object &barrel, bool forcebreak, bool sen
 				}
 				if (dPlayer[xp][yp] > 0) {
 					bool unused;
-					PlayerMHit(dPlayer[xp][yp] - 1, nullptr, 0, 8, 16, TrapMissile, GetMissileData(TrapMissile).damageType(), false, DeathReason::MonsterOrTrap, &unused);
+					PlayerMHit(dPlayer[xp][yp] - 1, nullptr, 0, 8, 16, TrapMissile, GetMissileData(TrapMissile).damageType(), false, DeathReason::Trap, &unused);
 				}
 				// don't really need to exclude large objects as explosive barrels are single tile objects, but using considerLargeObjects == false as this matches the old logic.
 				Object *adjacentObject = FindObjectAtPosition({ xp, yp }, false);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3497,7 +3497,7 @@ void PlayDungMsgs()
 	}
 }
 
-const char* Player::GetClassName()
+const char *Player::GetClassName()
 {
 	return PlayersData[static_cast<uint8_t>(_pClass)].className;
 }

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2694,7 +2694,8 @@ void StartPlrHit(Player &player, int dam, bool forcehit)
 #if defined(__clang__) || defined(__GNUC__)
 __attribute__((no_sanitize("shift-base")))
 #endif
-void StartPlayerKill(Player &player, DeathReason deathReason, uint16_t deathSourceIndex)
+void
+StartPlayerKill(Player &player, DeathReason deathReason, uint16_t deathSourceIndex)
 {
 	if (player._pHitPoints <= 0 && player._pmode == PM_DEATH) {
 		return;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2695,14 +2695,14 @@ void StartPlrHit(Player &player, int dam, bool forcehit)
 __attribute__((no_sanitize("shift-base")))
 #endif
 void
-StartPlayerKill(Player &player, DeathReason deathReason, uint16_t deathSourceIndex)
+StartPlayerKill(Player &player, DeathReason deathReason, uint16_t deathSource, uint16_t monsterUid, bool wasKilledByUnique)
 {
 	if (player._pHitPoints <= 0 && player._pmode == PM_DEATH) {
 		return;
 	}
 
 	if (&player == MyPlayer) {
-		NetSendCmdParam2(true, CMD_PLRDEAD, static_cast<uint16_t>(deathReason), static_cast<uint16_t>(deathSourceIndex));
+		NetSendCmdPDeath(true, CMD_PLRDEAD, static_cast<uint16_t>(deathReason), deathSource, monsterUid, wasKilledByUnique);
 	}
 
 	const bool dropGold = !gbIsMultiplayer || !(player.isOnLevel(16) || player.isOnArenaLevel());
@@ -2818,7 +2818,7 @@ void StripTopGold(Player &player)
 	player._pGold = CalculateGold(player);
 }
 
-void ApplyPlrDamage(DamageType damageType, Player &player, int dam, int minHP /*= 0*/, int frac /*= 0*/, DeathReason deathReason /*= DeathReason::Monster*/, uint16_t deathSourceIndex /*= 0*/)
+void ApplyPlrDamage(DamageType damageType, Player &player, int dam, int minHP /*= 0*/, int frac /*= 0*/, DeathReason deathReason /*= DeathReason::Monster*/, uint16_t deathSourceIndex /*= -1*/, uint16_t monsterUid /*= -1*/, bool wasKilledByUnique /*= false*/)
 {
 	int totalDamage = (dam << 6) + frac;
 	if (&player == MyPlayer) {
@@ -2862,11 +2862,11 @@ void ApplyPlrDamage(DamageType damageType, Player &player, int dam, int minHP /*
 		SetPlayerHitPoints(player, minHitPoints);
 	}
 	if (player._pHitPoints >> 6 <= 0) {
-		SyncPlrKill(player, deathReason, deathSourceIndex);
+		SyncPlrKill(player, deathReason, deathSourceIndex, monsterUid, wasKilledByUnique);
 	}
 }
 
-void SyncPlrKill(Player &player, DeathReason deathReason, uint16_t deathSourceIndex /*= 0*/)
+void SyncPlrKill(Player &player, DeathReason deathReason, uint16_t deathSourceIndex /*= -1*/, uint16_t monsterUid /*= -1*/, bool wasKilledByUnique /*= false*/)
 {
 	if (player._pHitPoints <= 0 && leveltype == DTYPE_TOWN) {
 		SetPlayerHitPoints(player, 64);
@@ -2874,7 +2874,7 @@ void SyncPlrKill(Player &player, DeathReason deathReason, uint16_t deathSourceIn
 	}
 
 	SetPlayerHitPoints(player, 0);
-	StartPlayerKill(player, deathReason, deathSourceIndex);
+	StartPlayerKill(player, deathReason, deathSourceIndex, monsterUid, wasKilledByUnique);
 }
 
 void RemovePlrMissiles(const Player &player)
@@ -3495,6 +3495,11 @@ void PlayDungMsgs()
 	} else {
 		sfxdelay = 0;
 	}
+}
+
+const char* Player::GetClassName()
+{
+	return PlayersData[static_cast<uint8_t>(_pClass)].className;
 }
 
 #ifdef BUILD_TESTING

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -671,7 +671,7 @@ bool PlrHitMonst(Player &player, Monster &monster, bool adjacentDamage = false)
 		if (HasAnyOf(player.pDamAcFlags, ItemSpecialEffectHf::Peril)) {
 			dam2 += player._pIGetHit << 6;
 			if (dam2 >= 0) {
-				ApplyPlrDamage(DamageType::Physical, player, 0, 1, dam2, DeathReason::Unknown);
+				ApplyPlrDamage(DamageType::Physical, player, 0, 1, dam2, DeathReason::Peril);
 			}
 			dam *= 2;
 		}
@@ -3033,7 +3033,7 @@ void ProcessPlayers()
 
 			if (&player == MyPlayer) {
 				if (HasAnyOf(player._pIFlags, ItemSpecialEffect::DrainLife) && leveltype != DTYPE_TOWN) {
-					ApplyPlrDamage(DamageType::Physical, player, 0, 0, 4, DeathReason::Unknown);
+					ApplyPlrDamage(DamageType::Physical, player, 0, 0, 4, DeathReason::DrainLife);
 				}
 				if (HasAnyOf(player._pIFlags, ItemSpecialEffect::NoMana) && player._pManaBase > 0) {
 					player._pManaBase -= player._pMana;

--- a/Source/player.h
+++ b/Source/player.h
@@ -776,7 +776,7 @@ struct Player {
 		this->plrIsOnSetLevel = true;
 	}
 
-	const char* GetClassName();
+	const char *GetClassName();
 };
 
 extern DVL_API_FOR_TEST size_t MyPlayerId;

--- a/Source/player.h
+++ b/Source/player.h
@@ -164,8 +164,10 @@ use_enum_as_flags(SpellFlag);
 
 /* @brief When the player dies, what is the reason/source why? */
 enum class DeathReason {
-	/* @brief Monster or Trap (dungeon) */
-	MonsterOrTrap,
+	/* @brief Monster (dungeon) */
+	Monster,
+	/* @brief Trap (dungeon) */
+	Trap,
 	/* @brief Other player or selfkill (for example firewall) */
 	Player,
 	/* @brief HP is zero but we don't know when or where this happend */
@@ -813,7 +815,7 @@ void NextPlrLevel(Player &player);
 #endif
 void AddPlrExperience(Player &player, int lvl, int exp);
 void AddPlrMonstExper(int lvl, int exp, char pmask);
-void ApplyPlrDamage(DamageType damageType, Player &player, int dam, int minHP = 0, int frac = 0, DeathReason deathReason = DeathReason::MonsterOrTrap);
+void ApplyPlrDamage(DamageType damageType, Player &player, int dam, int minHP = 0, int frac = 0, DeathReason deathReason = DeathReason::Monster, uint16_t deathSourceIndex = 0);
 void InitPlayer(Player &player, bool FirstTime);
 void InitMultiView();
 void PlrClrTrans(Point position);
@@ -824,12 +826,12 @@ void StartStand(Player &player, Direction dir);
 void StartPlrBlock(Player &player, Direction dir);
 void FixPlrWalkTags(const Player &player);
 void StartPlrHit(Player &player, int dam, bool forcehit);
-void StartPlayerKill(Player &player, DeathReason deathReason);
+void StartPlayerKill(Player &player, DeathReason deathReason, uint16_t deathSourceIndex);
 /**
  * @brief Strip the top off gold piles that are larger than MaxGold
  */
 void StripTopGold(Player &player);
-void SyncPlrKill(Player &player, DeathReason deathReason);
+void SyncPlrKill(Player &player, DeathReason deathReason, uint16_t deathSourceIndex = 0);
 void RemovePlrMissiles(const Player &player);
 void StartNewLvl(Player &player, interface_mode fom, int lvl);
 void RestartTownLvl(Player &player);

--- a/Source/player.h
+++ b/Source/player.h
@@ -168,9 +168,15 @@ enum class DeathReason {
 	Monster,
 	/* @brief Trap (dungeon) */
 	Trap,
-	/* @brief Other player or selfkill (for example firewall) */
+	/* @brief Other player or selfkill (for example, Fire Wall) */
 	Player,
-	/* @brief HP is zero but we don't know when or where this happend */
+	/* @brief Drain Life item effect */
+	DrainLife,
+	/* @brief Peril item effect */
+	Peril,
+	/* @brief Spell effect */
+	BloodMagic,
+	/* @brief HP is zero but we don't know when or where this happened */
 	Unknown,
 };
 

--- a/Source/player.h
+++ b/Source/player.h
@@ -775,6 +775,8 @@ struct Player {
 		this->plrlevel = static_cast<uint8_t>(level);
 		this->plrIsOnSetLevel = true;
 	}
+
+	const char* GetClassName();
 };
 
 extern DVL_API_FOR_TEST size_t MyPlayerId;
@@ -815,7 +817,7 @@ void NextPlrLevel(Player &player);
 #endif
 void AddPlrExperience(Player &player, int lvl, int exp);
 void AddPlrMonstExper(int lvl, int exp, char pmask);
-void ApplyPlrDamage(DamageType damageType, Player &player, int dam, int minHP = 0, int frac = 0, DeathReason deathReason = DeathReason::Monster, uint16_t deathSourceIndex = 0);
+void ApplyPlrDamage(DamageType damageType, Player &player, int dam, int minHP = 0, int frac = 0, DeathReason deathReason = DeathReason::Monster, uint16_t deathSourceIndex = -1, uint16_t monsterUid = -1, bool wasKilledByUnique = false);
 void InitPlayer(Player &player, bool FirstTime);
 void InitMultiView();
 void PlrClrTrans(Point position);
@@ -826,12 +828,12 @@ void StartStand(Player &player, Direction dir);
 void StartPlrBlock(Player &player, Direction dir);
 void FixPlrWalkTags(const Player &player);
 void StartPlrHit(Player &player, int dam, bool forcehit);
-void StartPlayerKill(Player &player, DeathReason deathReason, uint16_t deathSourceIndex);
+void StartPlayerKill(Player &player, DeathReason deathReason, uint16_t deathSourceIndex, uint16_t monsterUid, bool wasKilledByUnique);
 /**
  * @brief Strip the top off gold piles that are larger than MaxGold
  */
 void StripTopGold(Player &player);
-void SyncPlrKill(Player &player, DeathReason deathReason, uint16_t deathSourceIndex = 0);
+void SyncPlrKill(Player &player, DeathReason deathReason, uint16_t deathSource = -1, uint16_t monsterUid = -1, bool wasKilledByUnique = false);
 void RemovePlrMissiles(const Player &player);
 void StartNewLvl(Player &player, interface_mode fom, int lvl);
 void RestartTownLvl(Player &player);

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -168,10 +168,10 @@ void ConsumeSpell(Player &player, SpellID sn)
 		break;
 	}
 	if (sn == SpellID::BloodStar) {
-		ApplyPlrDamage(DamageType::Physical, player, 5);
+		ApplyPlrDamage(DamageType::Physical, player, 5, 0, 0, DeathReason::Unknown);
 	}
 	if (sn == SpellID::BoneSpirit) {
-		ApplyPlrDamage(DamageType::Physical, player, 6);
+		ApplyPlrDamage(DamageType::Physical, player, 6, 0, 0, DeathReason::Unknown);
 	}
 }
 

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -168,10 +168,10 @@ void ConsumeSpell(Player &player, SpellID sn)
 		break;
 	}
 	if (sn == SpellID::BloodStar) {
-		ApplyPlrDamage(DamageType::Physical, player, 5, 0, 0, DeathReason::Unknown);
+		ApplyPlrDamage(DamageType::Physical, player, 5, 0, 0, DeathReason::BloodMagic);
 	}
 	if (sn == SpellID::BoneSpirit) {
-		ApplyPlrDamage(DamageType::Physical, player, 6, 0, 0, DeathReason::Unknown);
+		ApplyPlrDamage(DamageType::Physical, player, 6, 0, 0, DeathReason::BloodMagic);
 	}
 }
 


### PR DESCRIPTION
Adds chat messages for when a player dies, showing the thing that killed the player. Many messages are randomized for fun and variety. Also shows a chat message when a player toggles Friendly or Hostile. Will also show Friendly or Hostile for players joining into a game for each player already in the game. Also added player class to the message that shows player names and level when joining games.

Downside: Needs translation for every language.