### PR TITLE
sdl_bilinear_scale.cpp: Fix `MixColorsWithAlpha` comment

### DIFF
--- a/Source/utils/sdl_bilinear_scale.cpp
+++ b/Source/utils/sdl_bilinear_scale.cpp
@@ -56,9 +56,9 @@ uint8_t MixColorsWithAlpha(uint8_t first, uint8_t firstAlpha,
 	// To avoid the overflow we divide each term by `mixedAlpha` separately.
 	//
 	// This would be lower precision and could result in a negative overall result,
-	// so we do the rounding integer division for each term (instead of a truncating one):
+	// so we do the rounding-up integer division for each term (instead of a truncating one):
 	//
-	//    (a + (a - 1)) / b`
+	//    (a + (b - 1)) / b
 	return ToInt((secondWithAlpha - firstWithAlpha) * ((ratio + (mixedAlpha - 1)) / mixedAlpha)) + (firstWithAlpha + (mixedAlpha - 1)) / mixedAlpha;
 }
 


### PR DESCRIPTION
The previous comment was incorrect and had a typo in the formula.