### PR TITLE
Use fixed sizes for player properties

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1980,9 +1980,9 @@ _item_indexes RndPremiumItem(const Player &player, int minlvl, int maxlvl)
 
 void SpawnOnePremium(Item &premiumItem, int plvl, const Player &player)
 {
-	int strength = std::max(player.GetMaximumAttributeValue(CharacterAttribute::Strength), player._pStrength);
-	int dexterity = std::max(player.GetMaximumAttributeValue(CharacterAttribute::Dexterity), player._pDexterity);
-	int magic = std::max(player.GetMaximumAttributeValue(CharacterAttribute::Magic), player._pMagic);
+	int strength = std::max<int>(player.GetMaximumAttributeValue(CharacterAttribute::Strength), player._pStrength);
+	int dexterity = std::max<int>(player.GetMaximumAttributeValue(CharacterAttribute::Dexterity), player._pDexterity);
+	int magic = std::max<int>(player.GetMaximumAttributeValue(CharacterAttribute::Magic), player._pMagic);
 	strength += strength / 5;
 	dexterity += dexterity / 5;
 	magic += magic / 5;
@@ -2748,14 +2748,14 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 	imana += (madd << 6);
 
 	player._pMaxHP = ihp + player._pMaxHPBase;
-	player._pHitPoints = std::min(ihp + player._pHPBase, player._pMaxHP);
+	player._pHitPoints = std::min<int32_t>(ihp + player._pHPBase, player._pMaxHP);
 
 	if (&player == MyPlayer && (player._pHitPoints >> 6) <= 0) {
 		SetPlayerHitPoints(player, 0);
 	}
 
 	player._pMaxMana = imana + player._pMaxManaBase;
-	player._pMana = std::min(imana + player._pManaBase, player._pMaxMana);
+	player._pMana = std::min<int32_t>(imana + player._pManaBase, player._pMaxMana);
 
 	player._pIFMinDam = fmin;
 	player._pIFMaxDam = fmax;
@@ -4343,9 +4343,9 @@ void SpawnBoy(int lvl)
 	Player &myPlayer = *MyPlayer;
 
 	HeroClass pc = myPlayer._pClass;
-	int strength = std::max(myPlayer.GetMaximumAttributeValue(CharacterAttribute::Strength), myPlayer._pStrength);
-	int dexterity = std::max(myPlayer.GetMaximumAttributeValue(CharacterAttribute::Dexterity), myPlayer._pDexterity);
-	int magic = std::max(myPlayer.GetMaximumAttributeValue(CharacterAttribute::Magic), myPlayer._pMagic);
+	int strength = std::max<int>(myPlayer.GetMaximumAttributeValue(CharacterAttribute::Strength), myPlayer._pStrength);
+	int dexterity = std::max<int>(myPlayer.GetMaximumAttributeValue(CharacterAttribute::Dexterity), myPlayer._pDexterity);
+	int magic = std::max<int>(myPlayer.GetMaximumAttributeValue(CharacterAttribute::Magic), myPlayer._pMagic);
 	strength += strength / 5;
 	dexterity += dexterity / 5;
 	magic += magic / 5;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2362,8 +2362,8 @@ void AddHealing(Missile &missile, AddMissileParameter & /*parameter*/)
 		hp += hp / 2;
 	}
 
-	player._pHitPoints = std::min(player._pHitPoints + hp, player._pMaxHP);
-	player._pHPBase = std::min(player._pHPBase + hp, player._pMaxHPBase);
+	player._pHitPoints = std::min<int32_t>(player._pHitPoints + hp, player._pMaxHP);
+	player._pHPBase = std::min<int16_t>(player._pHPBase + hp, player._pMaxHPBase);
 
 	missile._miDelFlag = true;
 	RedrawComponent(PanelDrawComponent::Health);

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -121,8 +121,8 @@ void PackPlayer(PlayerPack &packed, const Player &player)
 	packed.pStatPts = player._pStatPts;
 	packed.pExperience = SDL_SwapLE32(player._pExperience);
 	packed.pGold = SDL_SwapLE32(player._pGold);
-	packed.pHPBase = SDL_SwapLE32(player._pHPBase);
-	packed.pMaxHPBase = SDL_SwapLE32(player._pMaxHPBase);
+	packed.pHPBase = SDL_SwapLE16(player._pHPBase);
+	packed.pMaxHPBase = SDL_SwapLE16(player._pMaxHPBase);
 	packed.pManaBase = SDL_SwapLE32(player._pManaBase);
 	packed.pMaxManaBase = SDL_SwapLE32(player._pMaxManaBase);
 	packed.pMemSpells = SDL_SwapLE64(player._pMemSpells);
@@ -165,8 +165,8 @@ void PackNetPlayer(PlayerNetPack &packed, const Player &player)
 	packed.pLevel = player._pLevel;
 	packed.pStatPts = player._pStatPts;
 	packed.pExperience = SDL_SwapLE32(player._pExperience);
-	packed.pHPBase = SDL_SwapLE32(player._pHPBase);
-	packed.pMaxHPBase = SDL_SwapLE32(player._pMaxHPBase);
+	packed.pHPBase = SDL_SwapLE16(player._pHPBase);
+	packed.pMaxHPBase = SDL_SwapLE16(player._pMaxHPBase);
 	packed.pManaBase = SDL_SwapLE32(player._pManaBase);
 	packed.pMaxManaBase = SDL_SwapLE32(player._pMaxManaBase);
 	packed.pMemSpells = SDL_SwapLE64(player._pMemSpells);
@@ -201,21 +201,21 @@ void PackNetPlayer(PlayerNetPack &packed, const Player &player)
 	packed.pMaxHP = SDL_SwapLE32(player._pMaxHP);
 	packed.pMana = SDL_SwapLE32(player._pMana);
 	packed.pMaxMana = SDL_SwapLE32(player._pMaxMana);
-	packed.pDamageMod = SDL_SwapLE32(player._pDamageMod);
-	packed.pBaseToBlk = SDL_SwapLE32(player._pBaseToBlk);
-	packed.pIMinDam = SDL_SwapLE32(player._pIMinDam);
-	packed.pIMaxDam = SDL_SwapLE32(player._pIMaxDam);
-	packed.pIAC = SDL_SwapLE32(player._pIAC);
-	packed.pIBonusDam = SDL_SwapLE32(player._pIBonusDam);
-	packed.pIBonusToHit = SDL_SwapLE32(player._pIBonusToHit);
-	packed.pIBonusAC = SDL_SwapLE32(player._pIBonusAC);
-	packed.pIBonusDamMod = SDL_SwapLE32(player._pIBonusDamMod);
-	packed.pIGetHit = SDL_SwapLE32(player._pIGetHit);
-	packed.pIEnAc = SDL_SwapLE32(player._pIEnAc);
-	packed.pIFMinDam = SDL_SwapLE32(player._pIFMinDam);
-	packed.pIFMaxDam = SDL_SwapLE32(player._pIFMaxDam);
-	packed.pILMinDam = SDL_SwapLE32(player._pILMinDam);
-	packed.pILMaxDam = SDL_SwapLE32(player._pILMaxDam);
+	packed.pDamageMod = player._pDamageMod;
+	packed.pBaseToBlk = player._pBaseToBlk;
+	packed.pIMinDam = SDL_SwapLE16(player._pIMinDam);
+	packed.pIMaxDam = SDL_SwapLE16(player._pIMaxDam);
+	packed.pIAC = SDL_SwapLE16(player._pIAC);
+	packed.pIBonusDam = SDL_SwapLE16(player._pIBonusDam);
+	packed.pIBonusToHit = SDL_SwapLE16(player._pIBonusToHit);
+	packed.pIBonusAC = SDL_SwapLE16(player._pIBonusAC);
+	packed.pIBonusDamMod = player._pIBonusDamMod;
+	packed.pIGetHit = player._pIGetHit;
+	packed.pIEnAc = player._pIEnAc;
+	packed.pIFMinDam = player._pIFMinDam;
+	packed.pIFMaxDam = player._pIFMaxDam;
+	packed.pILMinDam = player._pILMinDam;
+	packed.pILMaxDam = player._pILMaxDam;
 }
 
 void UnPackItem(const ItemPack &packedItem, const Player &player, Item &item, bool isHellfire)
@@ -285,9 +285,9 @@ void UnPackPlayer(const PlayerPack &packed, Player &player)
 
 	player = {};
 	player._pLevel = clamp<int8_t>(packed.pLevel, 1, MaxCharacterLevel);
-	player._pMaxHPBase = SDL_SwapLE32(packed.pMaxHPBase);
-	player._pHPBase = SDL_SwapLE32(packed.pHPBase);
-	player._pHPBase = clamp<int32_t>(player._pHPBase, 0, player._pMaxHPBase);
+	player._pMaxHPBase = SDL_SwapLE16(packed.pMaxHPBase);
+	player._pHPBase = SDL_SwapLE16(packed.pHPBase);
+	player._pHPBase = clamp<int16_t>(player._pHPBase, 0, player._pMaxHPBase);
 	player._pMaxHP = player._pMaxHPBase;
 	player._pHitPoints = player._pHPBase;
 	player.position.tile = position;
@@ -367,8 +367,8 @@ bool UnPackNetPlayer(const PlayerNetPack &packed, Player &player)
 	if (packed.pLevel > MaxCharacterLevel || packed.pLevel < 1)
 		return false;
 
-	int32_t baseHpMax = SDL_SwapLE32(packed.pMaxHPBase);
-	int32_t baseHp = SDL_SwapLE32(packed.pHPBase);
+	int16_t baseHpMax = SDL_SwapLE16(packed.pMaxHPBase);
+	int16_t baseHp = SDL_SwapLE16(packed.pHPBase);
 	if (baseHp > baseHpMax || baseHp < 0)
 		return false;
 
@@ -445,13 +445,13 @@ bool UnPackNetPlayer(const PlayerNetPack &packed, Player &player)
 	CalcPlrInv(player, false);
 	player._pGold = CalculateGold(player);
 
-	if (player._pStrength != SDL_SwapLE32(packed.pStrength))
+	if (player._pStrength != SDL_SwapLE16(packed.pStrength))
 		return false;
-	if (player._pMagic != SDL_SwapLE32(packed.pMagic))
+	if (player._pMagic != SDL_SwapLE16(packed.pMagic))
 		return false;
-	if (player._pDexterity != SDL_SwapLE32(packed.pDexterity))
+	if (player._pDexterity != SDL_SwapLE16(packed.pDexterity))
 		return false;
-	if (player._pVitality != SDL_SwapLE32(packed.pVitality))
+	if (player._pVitality != SDL_SwapLE16(packed.pVitality))
 		return false;
 	if (player._pHitPoints != SDL_SwapLE32(packed.pHitPoints))
 		return false;
@@ -461,35 +461,35 @@ bool UnPackNetPlayer(const PlayerNetPack &packed, Player &player)
 		return false;
 	if (player._pMaxMana != SDL_SwapLE32(packed.pMaxMana))
 		return false;
-	if (player._pDamageMod != SDL_SwapLE32(packed.pDamageMod))
+	if (player._pDamageMod != packed.pDamageMod)
 		return false;
-	if (player._pBaseToBlk != SDL_SwapLE32(packed.pBaseToBlk))
+	if (player._pBaseToBlk != packed.pBaseToBlk)
 		return false;
-	if (player._pIMinDam != SDL_SwapLE32(packed.pIMinDam))
+	if (player._pIMinDam != SDL_SwapLE16(packed.pIMinDam))
 		return false;
-	if (player._pIMaxDam != SDL_SwapLE32(packed.pIMaxDam))
+	if (player._pIMaxDam != SDL_SwapLE16(packed.pIMaxDam))
 		return false;
-	if (player._pIAC != SDL_SwapLE32(packed.pIAC))
+	if (player._pIAC != SDL_SwapLE16(packed.pIAC))
 		return false;
-	if (player._pIBonusDam != SDL_SwapLE32(packed.pIBonusDam))
+	if (player._pIBonusDam != SDL_SwapLE16(packed.pIBonusDam))
 		return false;
-	if (player._pIBonusToHit != SDL_SwapLE32(packed.pIBonusToHit))
+	if (player._pIBonusToHit != SDL_SwapLE16(packed.pIBonusToHit))
 		return false;
-	if (player._pIBonusAC != SDL_SwapLE32(packed.pIBonusAC))
+	if (player._pIBonusAC != SDL_SwapLE16(packed.pIBonusAC))
 		return false;
-	if (player._pIBonusDamMod != SDL_SwapLE32(packed.pIBonusDamMod))
+	if (player._pIBonusDamMod != packed.pIBonusDamMod)
 		return false;
-	if (player._pIGetHit != SDL_SwapLE32(packed.pIGetHit))
+	if (player._pIGetHit != packed.pIGetHit)
 		return false;
-	if (player._pIEnAc != SDL_SwapLE32(packed.pIEnAc))
+	if (player._pIEnAc != packed.pIEnAc)
 		return false;
-	if (player._pIFMinDam != SDL_SwapLE32(packed.pIFMinDam))
+	if (player._pIFMinDam != packed.pIFMinDam)
 		return false;
-	if (player._pIFMaxDam != SDL_SwapLE32(packed.pIFMaxDam))
+	if (player._pIFMaxDam != packed.pIFMaxDam)
 		return false;
-	if (player._pILMinDam != SDL_SwapLE32(packed.pILMinDam))
+	if (player._pILMinDam != packed.pILMinDam)
 		return false;
-	if (player._pILMaxDam != SDL_SwapLE32(packed.pILMaxDam))
+	if (player._pILMaxDam != packed.pILMaxDam)
 		return false;
 
 	return true;

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -92,8 +92,8 @@ struct PlayerNetPack {
 	int8_t pLevel;
 	uint8_t pStatPts;
 	uint32_t pExperience;
-	int32_t pHPBase;
-	int32_t pMaxHPBase;
+	int16_t pHPBase;
+	int16_t pMaxHPBase;
 	int32_t pManaBase;
 	int32_t pMaxManaBase;
 	uint8_t pSplLvl[MAX_SPELLS];
@@ -110,29 +110,29 @@ struct PlayerNetPack {
 	uint8_t isOnSetLevel;
 
 	// For validation
-	int32_t pStrength;
-	int32_t pMagic;
-	int32_t pDexterity;
-	int32_t pVitality;
+	int16_t pStrength;
+	int16_t pMagic;
+	int16_t pDexterity;
+	int16_t pVitality;
 	int32_t pHitPoints;
 	int32_t pMaxHP;
 	int32_t pMana;
 	int32_t pMaxMana;
-	int32_t pDamageMod;
-	int32_t pBaseToBlk;
-	int32_t pIMinDam;
-	int32_t pIMaxDam;
-	int32_t pIAC;
-	int32_t pIBonusDam;
-	int32_t pIBonusToHit;
-	int32_t pIBonusAC;
-	int32_t pIBonusDamMod;
-	int32_t pIGetHit;
-	int32_t pIEnAc;
-	int32_t pIFMinDam;
-	int32_t pIFMaxDam;
-	int32_t pILMinDam;
-	int32_t pILMaxDam;
+	uint8_t pDamageMod;
+	uint8_t pBaseToBlk;
+	int16_t pIMinDam;
+	int16_t pIMaxDam;
+	int16_t pIAC;
+	int16_t pIBonusDam;
+	int16_t pIBonusToHit;
+	int16_t pIBonusAC;
+	int8_t pIBonusDamMod;
+	int8_t pIGetHit;
+	int8_t pIEnAc;
+	uint8_t pIFMinDam;
+	uint8_t pIFMaxDam;
+	uint8_t pILMinDam;
+	uint8_t pILMaxDam;
 };
 #pragma pack(pop)
 

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -156,7 +156,7 @@ PanelEntry panelEntries[] = {
 	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Vitality), StrCat(InspectPlayer->_pVitality) }; } },
 	{ N_("Points to distribute"), { LeftColumnLabelX, 248 }, 45, LeftColumnLabelWidth,
 	    []() {
-	        InspectPlayer->_pStatPts = std::min(CalcStatDiff(*InspectPlayer), InspectPlayer->_pStatPts);
+	        InspectPlayer->_pStatPts = std::min<uint8_t>(CalcStatDiff(*InspectPlayer), InspectPlayer->_pStatPts);
 	        return StyledText { UiFlags::ColorRed, (InspectPlayer->_pStatPts > 0 ? StrCat(InspectPlayer->_pStatPts) : "") };
 	    } },
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1813,8 +1813,8 @@ void Player::RestorePartialLife()
 		l *= 2;
 	if (IsAnyOf(_pClass, HeroClass::Rogue, HeroClass::Monk, HeroClass::Bard))
 		l += l / 2;
-	_pHitPoints = std::min(_pHitPoints + l, _pMaxHP);
-	_pHPBase = std::min(_pHPBase + l, _pMaxHPBase);
+	_pHitPoints = std::min<int32_t>(_pHitPoints + l, _pMaxHP);
+	_pHPBase = std::min<int16_t>(_pHPBase + l, _pMaxHPBase);
 }
 
 void Player::RestorePartialMana()
@@ -3303,16 +3303,16 @@ void CheckStats(Player &player)
 		int maxStatPoint = player.GetMaximumAttributeValue(attribute);
 		switch (attribute) {
 		case CharacterAttribute::Strength:
-			player._pBaseStr = clamp(player._pBaseStr, 0, maxStatPoint);
+			player._pBaseStr = clamp<int16_t>(player._pBaseStr, 0, maxStatPoint);
 			break;
 		case CharacterAttribute::Magic:
-			player._pBaseMag = clamp(player._pBaseMag, 0, maxStatPoint);
+			player._pBaseMag = clamp<int16_t>(player._pBaseMag, 0, maxStatPoint);
 			break;
 		case CharacterAttribute::Dexterity:
-			player._pBaseDex = clamp(player._pBaseDex, 0, maxStatPoint);
+			player._pBaseDex = clamp<int16_t>(player._pBaseDex, 0, maxStatPoint);
 			break;
 		case CharacterAttribute::Vitality:
-			player._pBaseVit = clamp(player._pBaseVit, 0, maxStatPoint);
+			player._pBaseVit = clamp<int16_t>(player._pBaseVit, 0, maxStatPoint);
 			break;
 		}
 	}

--- a/Source/player.h
+++ b/Source/player.h
@@ -236,54 +236,54 @@ struct Player {
 	Item SpdList[MaxBeltItems];
 	Item HoldItem;
 
-	int lightId;
+	int8_t lightId;
 
-	int _pNumInv;
-	int _pStrength;
-	int _pBaseStr;
-	int _pMagic;
-	int _pBaseMag;
-	int _pDexterity;
-	int _pBaseDex;
-	int _pVitality;
-	int _pBaseVit;
-	int _pStatPts;
-	int _pDamageMod;
-	int _pBaseToBlk;
-	int _pHPBase;
-	int _pMaxHPBase;
-	int _pHitPoints;
-	int _pMaxHP;
-	int _pHPPer;
-	int _pManaBase;
-	int _pMaxManaBase;
-	int _pMana;
-	int _pMaxMana;
-	int _pManaPer;
-	int _pIMinDam;
-	int _pIMaxDam;
-	int _pIAC;
-	int _pIBonusDam;
-	int _pIBonusToHit;
-	int _pIBonusAC;
-	int _pIBonusDamMod;
-	int _pIGetHit;
-	int _pIEnAc;
-	int _pIFMinDam;
-	int _pIFMaxDam;
-	int _pILMinDam;
-	int _pILMaxDam;
+	uint8_t _pNumInv;
+	uint8_t _pBaseStr;
+	uint8_t _pBaseMag;
+	uint8_t _pBaseDex;
+	uint8_t _pBaseVit;
+	uint8_t _pStatPts;
+	int16_t _pStrength;
+	int16_t _pMagic;
+	int16_t _pDexterity;
+	int16_t _pVitality;
+	uint8_t _pDamageMod;
+	uint8_t _pBaseToBlk;
+	int16_t _pHPBase;
+	int16_t _pMaxHPBase;
+	int32_t _pHitPoints;
+	int32_t _pMaxHP;
+	uint8_t _pHPPer;
+	int32_t _pManaBase;
+	int32_t _pMaxManaBase;
+	int32_t _pMana;
+	int32_t _pMaxMana;
+	uint8_t _pManaPer;
+	int16_t _pIMinDam;
+	int16_t _pIMaxDam;
+	int16_t _pIAC;
+	int16_t _pIBonusDam;
+	int16_t _pIBonusToHit;
+	int16_t _pIBonusAC;
+	int8_t _pIBonusDamMod;
+	int8_t _pIGetHit;
+	int8_t _pIEnAc;
+	uint8_t _pIFMinDam;
+	uint8_t _pIFMaxDam;
+	uint8_t _pILMinDam;
+	uint8_t _pILMaxDam;
 	uint32_t _pExperience;
 	uint32_t _pNextExper;
 	PLR_MODE _pmode;
 	int8_t walkpath[MaxPathLength];
 	bool plractive;
 	action_id destAction;
-	int destParam1;
-	int destParam2;
-	int destParam3;
-	int destParam4;
-	int _pGold;
+	uint8_t destParam1;
+	uint8_t destParam2;
+	uint8_t destParam3;
+	uint8_t destParam4;
+	int32_t _pGold;
 
 	/**
 	 * @brief Contains Information for current Animation
@@ -639,7 +639,7 @@ struct Player {
 			// Maximum achievable HP is approximately 1200. Diablo uses fixed point integers where the last 6 bits are
 			// fractional values. This means that we will never overflow HP values normally by doing this multiplication
 			// as the max value is representable in 17 bits and the multiplication result will be at most 23 bits
-			_pHPPer = clamp(_pHitPoints * 80 / _pMaxHP, 0, 80); // hp should never be greater than maxHP but just in case
+			_pHPPer = clamp<uint8_t>(_pHitPoints * 80 / _pMaxHP, 0, 80); // hp should never be greater than maxHP but just in case
 		}
 
 		return _pHPPer;
@@ -650,7 +650,7 @@ struct Player {
 		if (_pMaxMana <= 0) {
 			_pManaPer = 0;
 		} else {
-			_pManaPer = clamp(_pMana * 80 / _pMaxMana, 0, 80);
+			_pManaPer = clamp<uint8_t>(_pMana * 80 / _pMaxMana, 0, 80);
 		}
 
 		return _pManaPer;

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -297,8 +297,8 @@ void DoHealOther(const Player &caster, Player &target)
 		hp *= 3;
 	}
 
-	target._pHitPoints = std::min(target._pHitPoints + hp, target._pMaxHP);
-	target._pHPBase = std::min(target._pHPBase + hp, target._pMaxHPBase);
+	target._pHitPoints = std::min<int32_t>(target._pHitPoints + hp, target._pMaxHP);
+	target._pHPBase = std::min<int16_t>(target._pHPBase + hp, target._pMaxHPBase);
 
 	if (&target == MyPlayer) {
 		RedrawComponent(PanelDrawComponent::Health);

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2649,7 +2649,7 @@ void TakePlrsMoney(int cost)
 {
 	Player &myPlayer = *MyPlayer;
 
-	myPlayer._pGold -= std::min(cost, myPlayer._pGold);
+	myPlayer._pGold -= std::min<int32_t>(cost, myPlayer._pGold);
 
 	cost = TakeGold(myPlayer, cost, true);
 	if (cost != 0) {


### PR DESCRIPTION
save about 50 bytes in the player sync and saves som byte swapping

- [ ] use https://manpages.ubuntu.com/manpages/jammy/man1/pahole.1.html to optimize for size