### PR TITLE
D2 Style Experience Sharing

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1815,9 +1815,10 @@ void InitKeymapActions()
 	    'V',
 	    [] {
 		    EventPlrMsg(fmt::format(
-		                    fmt::runtime(_(/* TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty. */ "{:s} {:s}")),
+		                    fmt::runtime(_(/* TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty. */ "{:s} {:s} {:d}")),
 		                    PROJECT_NAME,
-		                    PROJECT_VERSION),
+		                    PROJECT_VERSION,
+							sgGameInitInfo.bSharedExperience),
 		        UiFlags::ColorWhite);
 	    },
 	    nullptr,

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1815,10 +1815,9 @@ void InitKeymapActions()
 	    'V',
 	    [] {
 		    EventPlrMsg(fmt::format(
-		                    fmt::runtime(_(/* TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty. */ "{:s} {:s} {:d}")),
+		                    fmt::runtime(_(/* TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty. */ "{:s} {:s}")),
 		                    PROJECT_NAME,
-		                    PROJECT_VERSION,
-							sgGameInitInfo.bSharedExperience),
+		                    PROJECT_VERSION),
 		        UiFlags::ColorWhite);
 	    },
 	    nullptr,

--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -95,6 +95,7 @@ struct {
 	bool showItemLabels = false;
 	bool autoRefillBelt = false;
 	bool disableCripplingShrines = false;
+	bool enableSharedExperience = false;
 	uint8_t numHealPotionPickup = 0;
 	uint8_t numFullHealPotionPickup = 0;
 	uint8_t numManaPotionPickup = 0;
@@ -135,6 +136,7 @@ void ReadSettings(FILE *in, uint8_t version)
 		DemoSettings.showItemLabels = ReadByte(in) != 0;
 		DemoSettings.autoRefillBelt = ReadByte(in) != 0;
 		DemoSettings.disableCripplingShrines = ReadByte(in) != 0;
+		DemoSettings.enableSharedExperience = ReadByte(in) != 0;
 		DemoSettings.numHealPotionPickup = ReadByte(in);
 		DemoSettings.numFullHealPotionPickup = ReadByte(in);
 		DemoSettings.numManaPotionPickup = ReadByte(in);
@@ -167,6 +169,7 @@ void WriteSettings(FILE *out)
 	WriteByte(out, *sgOptions.Gameplay.showItemLabels);
 	WriteByte(out, *sgOptions.Gameplay.autoRefillBelt);
 	WriteByte(out, *sgOptions.Gameplay.disableCripplingShrines);
+	WriteByte(out, *sgOptions.Gameplay.enableSharedExperience);
 	WriteByte(out, *sgOptions.Gameplay.numHealPotionPickup);
 	WriteByte(out, *sgOptions.Gameplay.numFullHealPotionPickup);
 	WriteByte(out, *sgOptions.Gameplay.numManaPotionPickup);
@@ -503,12 +506,14 @@ void OverrideOptions()
 	sgOptions.Gameplay.showItemLabels.SetValue(DemoSettings.showItemLabels);
 	sgOptions.Gameplay.autoRefillBelt.SetValue(DemoSettings.autoRefillBelt);
 	sgOptions.Gameplay.disableCripplingShrines.SetValue(DemoSettings.disableCripplingShrines);
+	sgOptions.Gameplay.enableSharedExperience.SetValue(DemoSettings.enableSharedExperience);
 	sgOptions.Gameplay.numHealPotionPickup.SetValue(DemoSettings.numHealPotionPickup);
 	sgOptions.Gameplay.numFullHealPotionPickup.SetValue(DemoSettings.numFullHealPotionPickup);
 	sgOptions.Gameplay.numManaPotionPickup.SetValue(DemoSettings.numManaPotionPickup);
 	sgOptions.Gameplay.numFullManaPotionPickup.SetValue(DemoSettings.numFullManaPotionPickup);
 	sgOptions.Gameplay.numRejuPotionPickup.SetValue(DemoSettings.numRejuPotionPickup);
 	sgOptions.Gameplay.numFullRejuPotionPickup.SetValue(DemoSettings.numFullRejuPotionPickup);
+	sgOptions.Gameplay.enableSharedExperience.SetValue(DemoSettings.enableSharedExperience);
 }
 
 bool IsRunning()

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -492,6 +492,7 @@ void InitGameInfo()
 	sgGameInitInfo.bCowQuest = *sgOptions.Gameplay.cowQuest ? 1 : 0;
 	sgGameInitInfo.bFriendlyFire = *sgOptions.Gameplay.friendlyFire ? 1 : 0;
 	sgGameInitInfo.fullQuests = (!gbIsMultiplayer || *sgOptions.Gameplay.multiplayerFullQuests) ? 1 : 0;
+	sgGameInitInfo.bSharedExperience = *sgOptions.Gameplay.enableSharedExperience ? 1 : 0;
 }
 
 void NetSendLoPri(int playerId, const byte *data, size_t size)

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -32,6 +32,7 @@ struct GameData {
 	uint8_t bCowQuest;
 	uint8_t bFriendlyFire;
 	uint8_t fullQuests;
+	uint8_t bSharedExperience;
 };
 
 /* @brief Contains info of running public game (for game list browsing) */

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1086,6 +1086,7 @@ GameplayOptions::GameplayOptions()
               { FloatingNumbers::Random, N_("Random Angles") },
               { FloatingNumbers::Vertical, N_("Vertical Only") },
           })
+    , enableSharedExperience("Enable Shared Experience", OptionEntryFlags::CantChangeInMultiPlayer, N_("Enable Shared Experience"), N_("Shares experience points from killed monsters with all players in the level."), false)
 {
 	grabInput.SetValueChangedCallback(OptionGrabInputChanged);
 	experienceBar.SetValueChangedCallback(OptionExperienceBarChanged);
@@ -1109,6 +1110,7 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&showMonsterType,
 		&showItemLabels,
 		&enableFloatingNumbers,
+		&enableSharedExperience,
 		&autoRefillBelt,
 		&autoEquipWeapons,
 		&autoEquipArmor,

--- a/Source/options.h
+++ b/Source/options.h
@@ -596,6 +596,8 @@ struct GameplayOptions : OptionCategoryBase {
 	OptionEntryInt<int> numFullRejuPotionPickup;
 	/** @brief Enable floating numbers. */
 	OptionEntryEnum<FloatingNumbers> enableFloatingNumbers;
+	/** @brief Enable shared experience between players. */
+	OptionEntryBoolean enableSharedExperience;
 };
 
 struct ControllerOptions : OptionCategoryBase {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2479,7 +2479,7 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 
 void AddPlrMonstExper(int lvl, int exp, char pmask)
 {
-	if (sgGameInitInfo.bSharedExperience != 0) {
+	if (sgGameInitInfo.bSharedExperience == 0) {
 		int totplrs = 0;
 		for (size_t i = 0; i < Players.size(); i++) {
 			if (((1 << i) & pmask) != 0) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2493,12 +2493,10 @@ void AddPlrMonstExper(int lvl, int exp, char pmask)
 				AddPlrExperience(*MyPlayer, lvl, e);
 		}
 	} else {
-		int totalPlayersInLevel = 0;
 		int playerLevelTotal = 0;
 
 		for (size_t i = 0; i < Players.size(); i++) {
 			if (Players[i].isOnActiveLevel()) {
-				totalPlayersInLevel++;
 				playerLevelTotal += Players[i]._pLevel;
 			}
 		}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2479,7 +2479,7 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 
 void AddPlrMonstExper(int lvl, int exp, char pmask)
 {
-	if (sgGameInitInfo.bSharedExperience == 0) {
+	if (sgGameInitInfo.bSharedExperience != 0) {
 		int totplrs = 0;
 		for (size_t i = 0; i < Players.size(); i++) {
 			if (((1 << i) & pmask) != 0) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2495,13 +2495,13 @@ void AddPlrMonstExper(int lvl, int exp, char pmask)
 	} else {
 		int playerLevelTotal = 0;
 
-		for (size_t i = 0; i < Players.size(); i++) {
-			if (Players[i].isOnActiveLevel()) {
-				playerLevelTotal += Players[i]._pLevel;
+		for (const auto &player : Players) {
+			if (player.isOnActiveLevel()) {
+				playerLevelTotal += player._pLevel;
 			}
 		}
 
-		int adjustedExp = exp * Players[MyPlayerId]._pLevel / playerLevelTotal;
+		int adjustedExp = exp * MyPlayer->_pLevel / playerLevelTotal;
 
 		AddPlrExperience(*MyPlayer, lvl, adjustedExp);
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2479,17 +2479,33 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 
 void AddPlrMonstExper(int lvl, int exp, char pmask)
 {
-	int totplrs = 0;
-	for (size_t i = 0; i < Players.size(); i++) {
-		if (((1 << i) & pmask) != 0) {
-			totplrs++;
+	if (sgGameInitInfo.bSharedExperience == 0) {
+		int totplrs = 0;
+		for (size_t i = 0; i < Players.size(); i++) {
+			if (((1 << i) & pmask) != 0) {
+				totplrs++;
+			}
 		}
-	}
 
-	if (totplrs != 0) {
-		int e = exp / totplrs;
-		if ((pmask & (1 << MyPlayerId)) != 0)
-			AddPlrExperience(*MyPlayer, lvl, e);
+		if (totplrs != 0) {
+			int e = exp / totplrs;
+			if ((pmask & (1 << MyPlayerId)) != 0)
+				AddPlrExperience(*MyPlayer, lvl, e);
+		}
+	} else {
+		int totalPlayersInLevel = 0;
+		int playerLevelTotal = 0;
+		
+		for (size_t i = 0; i < Players.size(); i++) {
+			if (Players[i].isOnActiveLevel()) {
+				totalPlayersInLevel++;
+				playerLevelTotal += Players[i]._pLevel;
+			}
+		}
+
+		int adjustedExp = (exp * ((Players[MyPlayerId]._pLevel * 100) / playerLevelTotal)) / 100;
+
+		AddPlrExperience(*MyPlayer, lvl, adjustedExp);
 	}
 }
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2495,7 +2495,7 @@ void AddPlrMonstExper(int lvl, int exp, char pmask)
 	} else {
 		int totalPlayersInLevel = 0;
 		int playerLevelTotal = 0;
-		
+
 		for (size_t i = 0; i < Players.size(); i++) {
 			if (Players[i].isOnActiveLevel()) {
 				totalPlayersInLevel++;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2501,7 +2501,7 @@ void AddPlrMonstExper(int lvl, int exp, char pmask)
 			}
 		}
 
-		int adjustedExp = (exp * ((Players[MyPlayerId]._pLevel * 100) / playerLevelTotal)) / 100;
+		int adjustedExp = exp * Players[MyPlayerId]._pLevel / playerLevelTotal;
 
 		AddPlrExperience(*MyPlayer, lvl, adjustedExp);
 	}


### PR DESCRIPTION
Adds shared experience using the formula from Diablo 2. Each player in the dlvl receives a portion of the experience gain from the monster equal to clvl divided by the total clvl of each player in the dlvl. This has been a recurring requested feature from players, so I thought I'd make it. Haven't bothered with the demo stuff and likely won't unless there's some sort of indication this feature will be approved (Although I doubt it'll break the demo since experience gains are only adjusted in multiple person games)