### PR TITLE
Rename Loopback to Offline and hide in-game info

### DIFF
--- a/Source/DiabloUI/multi/selconn.cpp
+++ b/Source/DiabloUI/multi/selconn.cpp
@@ -12,7 +12,7 @@ int provider;
 const char *ConnectionNames[] {
 	"ZeroTier",
 	N_("Client-Server (TCP)"),
-	N_("Loopback"),
+	N_("Offline"),
 };
 
 namespace {

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -718,7 +718,7 @@ void DrawAutomapText(const Surface &out)
 {
 	Point linePosition { 8, 8 };
 
-	if (gbIsMultiplayer) {
+	if (gbIsMultiplayer && !LoopbackGame) {
 		if (GameName != "0.0.0.0") {
 			std::string description = std::string(_("Game: "));
 			description.append(GameName);

--- a/Source/dvlnet/loopback.cpp
+++ b/Source/dvlnet/loopback.cpp
@@ -113,7 +113,7 @@ bool loopback::SNetGetTurnsInTransit(uint32_t *turns)
 
 std::string loopback::make_default_gamename()
 {
-	return std::string(_("loopback"));
+	return std::string(_("Offline"));
 }
 
 } // namespace net

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -58,6 +58,7 @@ bool sgbTimeout;
 std::string GameName;
 std::string GamePassword;
 bool PublicGame;
+bool LoopbackGame;
 uint8_t gbDeltaSender;
 bool sgbNetInited;
 uint32_t player_state[MAX_PLRS];

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -51,6 +51,7 @@ extern DVL_API_FOR_TEST bool gbIsMultiplayer;
 extern std::string GameName;
 extern std::string GamePassword;
 extern bool PublicGame;
+extern bool LoopbackGame;
 extern uint8_t gbDeltaSender;
 extern uint32_t player_state[MAX_PLRS];
 


### PR DESCRIPTION
Rename Loopback to Offline to help make the menu option a little more direct and clear to the end user. Also the in-game info overlay for Loopback doesn't need a Password info and the name of the game.

LoopbackGame still needs a definition