### PR TITLE
Rename: Hit Points -> Life

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1204,7 +1204,7 @@ void DrawInfoBox(const Surface &out)
 			auto &target = Players[pcursplr];
 			InfoString = string_view(target._pName);
 			AddPanelString(fmt::format(fmt::runtime(_("{:s}, Level: {:d}")), _(PlayersData[static_cast<std::size_t>(target._pClass)].className), target._pLevel));
-			AddPanelString(fmt::format(fmt::runtime(_("Hit Points {:d} of {:d}")), target._pHitPoints >> 6, target._pMaxHP >> 6));
+			AddPanelString(fmt::format(fmt::runtime(_("Life {:d} of {:d}")), target._pHitPoints >> 6, target._pMaxHP >> 6));
 		}
 	}
 	if (!InfoString.empty())

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3778,7 +3778,7 @@ bool DoOil(Player &player, int cii)
 		return fmt::format(fmt::runtime(_("{:+d} damage from enemies")), item._iPLGetHit);
 	case IPL_LIFE:
 	case IPL_LIFE_CURSE:
-		return fmt::format(fmt::runtime(_("Hit Points: {:+d}")), item._iPLHP >> 6);
+		return fmt::format(fmt::runtime(_("Life: {:+d}")), item._iPLHP >> 6);
 	case IPL_MANA:
 	case IPL_MANA_CURSE:
 		return fmt::format(fmt::runtime(_("Mana: {:+d}")), item._iPLMana >> 6);

--- a/Translations/bg.po
+++ b/Translations/bg.po
@@ -1063,7 +1063,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Ниво: {:d}"
 
 #: Source/control.cpp:898
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "Точки живот {:d} от {:d}"
 
 #: Source/control.cpp:932
@@ -4188,7 +4189,8 @@ msgid "{:+d} damage from enemies"
 msgstr "{:+d} щети от врагове"
 
 #: Source/items.cpp:3624
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr "Живот: {:+d}"
 
 #: Source/items.cpp:3627

--- a/Translations/cs.po
+++ b/Translations/cs.po
@@ -1060,7 +1060,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Úroveň: {:d}"
 
 #: Source/control.cpp:898
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "Životy {:d} ze {:d}"
 
 #: Source/control.cpp:932
@@ -4182,7 +4183,8 @@ msgid "{:+d} damage from enemies"
 msgstr "{:+d} poškození od nepřátel"
 
 #: Source/items.cpp:3624
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr "Životy {:+d}"
 
 #: Source/items.cpp:3627

--- a/Translations/da.po
+++ b/Translations/da.po
@@ -1146,7 +1146,7 @@ msgstr "Niveau:"
 
 #: Source/control.cpp:898
 #, fuzzy
-msgid "Hit Points {:d} of {:d}"
+msgid "Life {:d} of {:d}"
 msgstr "Understøttede spillere: {:d}"
 
 #: Source/control.cpp:932
@@ -4425,7 +4425,7 @@ msgstr ""
 
 #: Source/items.cpp:3624
 #, fuzzy
-msgid "Hit Points: {:+d}"
+msgid "Life: {:+d}"
 msgstr "Understøttede spillere: {:d}"
 
 #: Source/items.cpp:3627

--- a/Translations/de.po
+++ b/Translations/de.po
@@ -1068,7 +1068,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Level: {:d}"
 
 #: Source/control.cpp:898
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "Trefferpunkte {:d} von {:d}"
 
 #: Source/control.cpp:932
@@ -4185,7 +4186,8 @@ msgid "{:+d} damage from enemies"
 msgstr "{:+d} Schaden von Feinden"
 
 #: Source/items.cpp:3624
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr "Leben: {:+d}"
 
 #: Source/items.cpp:3627

--- a/Translations/devilutionx.pot
+++ b/Translations/devilutionx.pot
@@ -970,7 +970,8 @@ msgid "{:s}, Level: {:d}"
 msgstr ""
 
 #: Source/control.cpp:897
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr ""
 
 #: Source/control.cpp:931
@@ -4018,7 +4019,8 @@ msgid "{:+d} damage from enemies"
 msgstr ""
 
 #: Source/items.cpp:3630
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr ""
 
 #: Source/items.cpp:3633

--- a/Translations/el.po
+++ b/Translations/el.po
@@ -1205,7 +1205,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Επίπεδο: {:d}"
 
 #: Source/control.cpp:1207
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "Πόντοι Ζωής {:d} από {:d}"
 
 #: Source/control.cpp:1238
@@ -4513,7 +4514,8 @@ msgid "{:+d} damage from enemies"
 msgstr "{:+d} ζημιά από εχθρούς"
 
 #: Source/items.cpp:3781
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr "Πόντοι Ζωής {:+d}"
 
 #: Source/items.cpp:3784

--- a/Translations/es.po
+++ b/Translations/es.po
@@ -1162,7 +1162,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Nivel: {:d}"
 
 #: Source/control.cpp:1027
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "Vida {:d} de {:d}"
 
 #: Source/control.cpp:1061
@@ -4499,7 +4500,8 @@ msgid "{:+d} damage from enemies"
 msgstr "{:+d} de daño de enemigos"
 
 #: Source/items.cpp:3510
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr "Puntos de Vida: {:+d}"
 
 #: Source/items.cpp:3513

--- a/Translations/fr.po
+++ b/Translations/fr.po
@@ -1068,7 +1068,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Niveau: {:d}"
 
 #: Source/control.cpp:898
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "Dommages {:d} sur {:d}"
 
 #: Source/control.cpp:932
@@ -4202,8 +4203,9 @@ msgid "{:+d} damage from enemies"
 msgstr "{:+d} dégâts des ennemis"
 
 #: Source/items.cpp:3596
-msgid "Hit Points: {:+d}"
-msgstr "Points de vie : {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
+msgstr "Points de vie: {:+d}"
 
 #: Source/items.cpp:3599
 msgid "Mana: {:+d}"

--- a/Translations/hr.po
+++ b/Translations/hr.po
@@ -1066,7 +1066,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Razina: {:d}"
 
 #: Source/control.cpp:926
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "Pogoci {:d} od {:d}"
 
 #: Source/control.cpp:960
@@ -4202,7 +4203,8 @@ msgid "{:+d} damage from enemies"
 msgstr "{:+d} na štetu od neprijatelja"
 
 #: Source/items.cpp:3599
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr "Pogodci: {:+d}"
 
 #: Source/items.cpp:3602

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -1208,7 +1208,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Livello: {:d}"
 
 #: Source/control.cpp:1147
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "Punti Ferita {:d} di {:d}"
 
 #: Source/control.cpp:1178
@@ -4514,7 +4515,8 @@ msgid "{:+d} damage from enemies"
 msgstr "{:+d} danno dai nemici"
 
 #: Source/items.cpp:3740
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr "Punti Ferita: {:+d}"
 
 #: Source/items.cpp:3743

--- a/Translations/ja.po
+++ b/Translations/ja.po
@@ -1135,7 +1135,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Level: {:d}"
 
 #: Source/control.cpp:1027
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "ヒット​ポイント: {:d}/{:d}"
 
 #: Source/control.cpp:1061
@@ -4420,7 +4421,8 @@ msgid "{:+d} damage from enemies"
 msgstr "敵​から​受ける​ダメージ​{:+d}"
 
 #: Source/items.cpp:3576
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr "ヒット​ポイント: {:+d}"
 
 #: Source/items.cpp:3579

--- a/Translations/ko.po
+++ b/Translations/ko.po
@@ -1191,7 +1191,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, 레벨: {:d}"
 
 #: Source/control.cpp:1207
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "히트 포인트 {:d} / {:d}"
 
 #: Source/control.cpp:1238
@@ -4491,7 +4492,8 @@ msgid "{:+d} damage from enemies"
 msgstr "{:+d} 적에게서 받는 피해"
 
 #: Source/items.cpp:3781
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr "히트포인트: {:+d}"
 
 #: Source/items.cpp:3784

--- a/Translations/pl.po
+++ b/Translations/pl.po
@@ -1067,7 +1067,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Poziom: {:d}"
 
 #: Source/control.cpp:898
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "Punkty Życia {:d} / {:d}"
 
 #: Source/control.cpp:932
@@ -4181,7 +4182,8 @@ msgid "{:+d} damage from enemies"
 msgstr "{:+d} obrażeń od wrogów"
 
 #: Source/items.cpp:3633
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr "Punkty życia: {:+d}"
 
 #: Source/items.cpp:3636

--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -1066,7 +1066,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Nível: {:d}"
 
 #: Source/control.cpp:898
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "Pontos de vida {:d} de {:d}"
 
 #: Source/control.cpp:932
@@ -4190,7 +4191,8 @@ msgid "{:+d} damage from enemies"
 msgstr "{:+d} de dano a inimigos"
 
 #: Source/items.cpp:3624
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr "Pontos de vida: {:+d}"
 
 #: Source/items.cpp:3627

--- a/Translations/ro.po
+++ b/Translations/ro.po
@@ -1084,7 +1084,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Nivel: {:d}"
 
 #: Source/control.cpp:898
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "Puncte viață {:d} din {:d}"
 
 #: Source/control.cpp:932
@@ -4276,7 +4277,8 @@ msgid "{:+d} damage from enemies"
 msgstr ""
 
 #: Source/items.cpp:3624
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr ""
 
 #: Source/items.cpp:3627

--- a/Translations/ru.po
+++ b/Translations/ru.po
@@ -1085,7 +1085,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Уровень: {:d}"
 
 #: Source/control.cpp:898
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "Здоровье {:d} из {:d}"
 
 #: Source/control.cpp:932
@@ -4240,7 +4241,8 @@ msgid "{:+d} damage from enemies"
 msgstr "{:+d} урон от врагов"
 
 #: Source/items.cpp:3624
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr "Здоровье: {:+d}"
 
 #: Source/items.cpp:3627

--- a/Translations/sv.po
+++ b/Translations/sv.po
@@ -1060,7 +1060,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Nivå: {:d}"
 
 #: Source/control.cpp:898
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "Kroppspoäng {:d} av {:d}"
 
 #: Source/control.cpp:932
@@ -4180,7 +4181,8 @@ msgid "{:+d} damage from enemies"
 msgstr "{:+d} skada från fiender"
 
 #: Source/items.cpp:3624
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr "Kroppspoäng: {:+d}"
 
 #: Source/items.cpp:3627

--- a/Translations/uk.po
+++ b/Translations/uk.po
@@ -1209,7 +1209,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Рівень {:d}"
 
 #: Source/control.cpp:1207
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "Здоров'я {:d} з {:d}"
 
 #: Source/control.cpp:1238
@@ -4516,7 +4517,8 @@ msgid "{:+d} damage from enemies"
 msgstr "{:+d} шкоди від ворогів"
 
 #: Source/items.cpp:3781
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr "Здоров'я {:+d}"
 
 #: Source/items.cpp:3784

--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -1043,7 +1043,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}, 等级: {:d}"
 
 #: Source/control.cpp:898
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "生命值 {:d} 的 {:d}"
 
 #: Source/control.cpp:932
@@ -4136,7 +4137,8 @@ msgid "{:+d} damage from enemies"
 msgstr "{:+d} 来自​敌人​的​伤害"
 
 #: Source/items.cpp:3624
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr "生命​值: {:+d}"
 
 #: Source/items.cpp:3627

--- a/Translations/zh_TW.po
+++ b/Translations/zh_TW.po
@@ -1093,7 +1093,8 @@ msgid "{:s}, Level: {:d}"
 msgstr "{:s}，層數: {:d}"
 
 #: Source/control.cpp:898
-msgid "Hit Points {:d} of {:d}"
+#, fuzzy
+msgid "Life {:d} of {:d}"
 msgstr "生命​點{:d}​的​{:d}"
 
 #: Source/control.cpp:932
@@ -4275,7 +4276,8 @@ msgid "{:+d} damage from enemies"
 msgstr "{:+d}​敵人​傷害"
 
 #: Source/items.cpp:3624
-msgid "Hit Points: {:+d}"
+#, fuzzy
+msgid "Life: {:+d}"
 msgstr "生命​值: {:+d}"
 
 #: Source/items.cpp:3627


### PR DESCRIPTION
The stat is called Life, but it's referred to as "Hit Points" in the control panel when cursor over other players, and in item power description.

Fixes https://github.com/diasurgical/devilutionX/issues/815