### PR TITLE
Consume Resource After Successful Spell Usage

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -2136,15 +2136,27 @@ void CloseStash()
 
 void DoTelekinesis()
 {
-	if (ObjectUnderCursor != nullptr && !ObjectUnderCursor->IsDisabled())
+	Player &myPlayer = *MyPlayer;
+	bool consumeSpell = false;
+
+	if (ObjectUnderCursor != nullptr && !ObjectUnderCursor->IsDisabled()) {
 		NetSendCmdLoc(MyPlayerId, true, CMD_OPOBJT, cursPosition);
-	if (pcursitem != -1)
+		consumeSpell = true;
+	}
+	if (pcursitem != -1) {
 		NetSendCmdGItem(true, CMD_REQUESTAGITEM, MyPlayerId, pcursitem);
+		consumeSpell = true;
+	}
 	if (pcursmonst != -1) {
 		auto &monter = Monsters[pcursmonst];
 		if (!M_Talker(monter) && monter.talkMsg == TEXT_NONE)
 			NetSendCmdParam1(true, CMD_KNOCKBACK, pcursmonst);
+		consumeSpell = true;
 	}
+
+	if (consumeSpell)
+		ConsumeSpell(myPlayer, SpellID::Telekinesis);
+
 	NewCursor(CURSOR_HAND);
 }
 

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -212,24 +212,29 @@ void CastSpell(int id, SpellID spl, int sx, int sy, int dx, int dy, int spllvl)
 {
 	Player &player = Players[id];
 	Direction dir = player._pdir;
+
 	if (IsWallSpell(spl)) {
 		dir = player.tempDirection;
 	}
 
 	bool fizzled = false;
 	const SpellData &spellData = GetSpellData(spl);
+
 	for (size_t i = 0; i < sizeof(spellData.sMissiles) / sizeof(spellData.sMissiles[0]) && spellData.sMissiles[i] != MissileID::Null; i++) {
 		Missile *missile = AddMissile({ sx, sy }, { dx, dy }, dir, spellData.sMissiles[i], TARGET_MONSTERS, id, 0, spllvl);
 		fizzled |= (missile == nullptr);
 	}
+
 	if (spl == SpellID::ChargedBolt) {
 		for (int i = (spllvl / 2) + 3; i > 0; i--) {
 			Missile *missile = AddMissile({ sx, sy }, { dx, dy }, dir, MissileID::ChargedBolt, TARGET_MONSTERS, id, 0, spllvl);
 			fizzled |= (missile == nullptr);
 		}
 	}
+
 	if (!fizzled) {
-		ConsumeSpell(player, spl);
+		if (IsNoneOf(pcurs, CURSOR_DISARM, CURSOR_HEALOTHER, CURSOR_IDENTIFY, CURSOR_RECHARGE, CURSOR_REPAIR, CURSOR_RESURRECT, CURSOR_TELEKINESIS, CURSOR_TELEPORT))
+			ConsumeSpell(player, spl);
 	}
 }
 


### PR DESCRIPTION
When using any spell/scroll/charge that has a cursor, resources do not get consumed until the spell successfully is used.

Currently has a problem that allows you to still cast a cursor mana-consuming spell if your mana drops below the mana cost for the spell and you already have the spell active.