### PR TITLE
Fix Book requirements not updating

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4100,8 +4100,10 @@ void UseItem(size_t pnum, item_misc_id mid, SpellID spellID, int spellFrom)
 		break;
 	case IMISC_BOOK: {
 		uint8_t newSpellLevel = player._pSplLvl[static_cast<int8_t>(spellID)] + 1;
-		if (newSpellLevel <= MaxSpellLevel)
+		if (newSpellLevel <= MaxSpellLevel) {
+			player._pSplLvl[static_cast<int8_t>(spellID)] = newSpellLevel;
 			NetSendCmdParam2(true, CMD_CHANGE_SPELL_LEVEL, static_cast<uint16_t>(spellID), newSpellLevel);
+		}
 		if (HasNoneOf(player._pIFlags, ItemSpecialEffect::NoMana)) {
 			player._pMana += GetSpellData(spellID).sManaCost << 6;
 			player._pMana = std::min(player._pMana, player._pMaxMana);


### PR DESCRIPTION
When you read a Book, it attempts to update the Spell Level by sending a network command, and then attempts to recalculate the Magic requirement. The network command doesn't resolve the Spell Level before the function calls `updateRequiredStatsCacheForPlayer()`, resulting in the incorrect requirement being displayed until this function gets called again at a later time, observed by the call to `CheckInvCut()` in the attached issue report. To solve this, I added a line to locally change the Spell Level to `newSpellLevel`, which will be overwritten anyway when the network command resolves.

Fixes: https://github.com/diasurgical/devilutionX/issues/6271