### PR TITLE
Party

### DIFF
--- a/Source/control.h
+++ b/Source/control.h
@@ -192,6 +192,7 @@ bool control_presskeys(SDL_Keycode vkey);
 void DiabloHotkeyMsg(uint32_t dwMsg);
 void CloseGoldDrop();
 void GoldDropNewText(string_view text);
+void DrawParty(const Surface &out);
 extern Rectangle ChrBtnsRect[4];
 
 } // namespace devilution

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1201,6 +1201,7 @@ void DrawView(const Surface &out, Point startPosition)
 	DrawItemNameLabels(out);
 	DrawMonsterHealthBar(out);
 	DrawFloatingNumbers(out, startPosition, offset);
+	DrawParty(out);
 
 	if (stextflag != TalkID::None && !qtextflag)
 		DrawSText(out);


### PR DESCRIPTION
Planned features:

Basic Party Functionality:
* Party side panel
* Ability to invite other players in game to party
* Players in party are unable to damage each other even with missiles (Adapted from friendly fire game toggle. maybe that means we can get rid of another toggle!) (Being in a party will act as Friendly Fire Off and not being in a party will act as Friendly Fire On)
* Per player Mute button and Friendly/Hostile button
* Player names in panel with location if in party together
* Toggling Hostile removes you from active party and prevents you from joining party if active
* Party icons on left side of the screen for party members with life bars and names (toggleable using a hotkey)
* Town Portals only able to be accessed by other players in your party, if you are in a party
