### PR TITLE
Calculate Missile damage from Items

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1953,6 +1953,20 @@ void AddLightningControl(Missile &missile, AddMissileParameter &parameter)
 	UpdateMissileVelocity(missile, parameter.dst, 32);
 	missile._miAnimFrame = GenerateRnd(8) + 1;
 	missile._mirange = 256;
+
+	switch (missile.sourceType()) {
+	case MissileSource::Player: {
+		const Player &player = *missile.sourcePlayer();
+		missile._midam = (GenerateRnd(2) + GenerateRnd(player._pLevel) + 2) << 6;
+	} break;
+	case MissileSource::Monster: {
+		const Monster &monster = *missile.sourceMonster();
+		missile._midam = 2 * (monster.minDamage + GenerateRnd(monster.maxDamage - monster.minDamage + 1));
+	} break;
+	case MissileSource::Trap:
+		missile._midam = (2 * currlevel) + GenerateRnd(currlevel);
+		break;
+	}
 }
 
 void AddLightning(Missile &missile, AddMissileParameter &parameter)
@@ -3281,19 +3295,7 @@ void ProcessLightningControl(Missile &missile)
 {
 	missile._mirange--;
 
-	int dam;
-	if (missile.IsTrap()) {
-		// BUGFIX: damage of missile should be encoded in missile struct; monster can be dead before missile arrives.
-		dam = GenerateRnd(currlevel) + 2 * currlevel;
-	} else if (missile._micaster == TARGET_MONSTERS) {
-		// BUGFIX: damage of missile should be encoded in missile struct; player can be dead/have left the game before missile arrives.
-		dam = (GenerateRnd(2) + GenerateRnd(Players[missile._misource]._pLevel) + 2) << 6;
-	} else {
-		auto &monster = Monsters[missile._misource];
-		dam = 2 * (monster.minDamage + GenerateRnd(monster.maxDamage - monster.minDamage + 1));
-	}
-
-	SpawnLightning(missile, dam);
+	SpawnLightning(missile, missile._midam);
 }
 
 void ProcessLightning(Missile &missile)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2024,22 +2024,19 @@ void AddWeaponExplosion(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.var2 = parameter.dst.x;
 
-	if (missile.var2 == 1)
-		SetMissAnim(missile, MissileGraphicID::MagmaBallExplosion);
-	else
-		SetMissAnim(missile, MissileGraphicID::ChargedBolt);
-
-	missile._mirange = missile._miAnimLen - 1;
-
 	const Player &player = *missile.sourcePlayer();
 
 	if (missile.var2 == 1) {
 		missile._midam = player._pIFMinDam; // min fire damage
 		missile.var3 = player._pIFMaxDam;   // max fire damage
+		SetMissAnim(missile, MissileGraphicID::MagmaBallExplosion);
 	} else {
 		missile._midam = player._pILMinDam; // min lightning damage
 		missile.var3 = player._pILMaxDam;   // max lightning damage
+		SetMissAnim(missile, MissileGraphicID::ChargedBolt);
 	}
+
+	missile._mirange = missile._miAnimLen - 1;
 }
 
 void AddTownPortal(Missile &missile, AddMissileParameter &parameter)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -21,7 +21,6 @@
 #include "engine/random.hpp"
 #include "init.h"
 #include "inv.h"
-//#include "inv_iterators.hpp"
 #include "levels/trigs.h"
 #include "lighting.h"
 #include "monster.h"

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -201,6 +201,11 @@ int ProjectileTrapDamage(Missile &missile)
 	return currlevel + GenerateRnd(2 * currlevel);
 }
 
+int ProjectileTrapElementalDamage(Missile &missile)
+{
+	return currlevel + GenerateRnd(2 * currlevel); // shit
+}
+
 bool MonsterMHit(int pnum, int monsterId, int mindam, int maxdam, int dist, MissileID t, DamageType damageType, bool shift)
 {
 	auto &monster = Monsters[monsterId];
@@ -1673,6 +1678,44 @@ void AddElementalArrow(Missile &missile, AddMissileParameter &parameter)
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 5);
+
+	bool errorFlag = false;
+
+	if (missile._midam == 0) {
+		if (missile.sourceType() == MissileSource::Player) {
+			const auto &player = *missile.sourcePlayer();
+			missile._midam = player._pIMinDam; // min physical damage
+			missile.var3 = player._pIMaxDam;   // max physical damage
+
+			switch (missile._mitype) {
+			case MissileID::LightningArrow:
+				missile.var4 = player._pILMinDam; // min lightning damage
+				missile.var5 = player._pILMaxDam; // max lightning damage
+				break;
+			case MissileID::FireArrow:
+				missile.var4 = player._pIFMinDam; // min fire damage
+				missile.var5 = player._pIFMaxDam; // max fire damage
+				break;
+			default:
+				app_fatal(StrCat("wrong missile ID ", static_cast<int>(missile._mitype)));
+				break;
+			}
+		} else if (missile.sourceType() == MissileSource::Trap) {
+			missile._midam = currlevel + GenerateRnd(10) + 1;     // min physical damage
+			missile.var3 = (currlevel * 2) + GenerateRnd(10) + 1; // max physical damage
+
+			switch (missile._mitype) {
+			case MissileID::LightningArrow:
+			case MissileID::FireArrow:
+				missile.var4 = currlevel + GenerateRnd(10) + 1;       // min elemental damage
+				missile.var5 = (currlevel * 2) + GenerateRnd(10) + 1; // max elemental damage
+				break;
+			default:
+				app_fatal(StrCat("wrong missile ID ", static_cast<int>(missile._mitype)));
+				break;
+			}
+		}
+	}
 }
 
 void AddArrow(Missile &missile, AddMissileParameter &parameter)
@@ -2758,69 +2801,31 @@ void ProcessElementalArrow(Missile &missile)
 	if (missile._miAnimType == MissileGraphicID::ChargedBolt || missile._miAnimType == MissileGraphicID::MagmaBallExplosion) {
 		ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame + 5);
 	} else {
-		int mind;
-		int maxd;
-		int p = missile._misource;
 		missile._midist++;
-		if (!missile.IsTrap()) {
-			if (missile._micaster == TARGET_MONSTERS) {
-				// BUGFIX: damage of missile should be encoded in missile struct; player can be dead/have left the game before missile arrives.
-				const Player &player = Players[p];
-				mind = player._pIMinDam;
-				maxd = player._pIMaxDam;
-			} else {
-				// BUGFIX: damage of missile should be encoded in missile struct; monster can be dead before missile arrives.
-				Monster &monster = Monsters[p];
-				mind = monster.minDamage;
-				maxd = monster.maxDamage;
-			}
-		} else {
-			mind = GenerateRnd(10) + 1 + currlevel;
-			maxd = GenerateRnd(10) + 1 + currlevel * 2;
-		}
-		MoveMissileAndCheckMissileCol(missile, DamageType::Physical, mind, maxd, true, false);
+
+		MoveMissileAndCheckMissileCol(missile, DamageType::Physical, 0, 0, true, false);
+
 		if (missile._mirange == 0) {
 			missile._mimfnum = 0;
 			missile._mirange = missile._miAnimLen - 1;
 			missile.position.StopMissile();
 
-			int eMind;
-			int eMaxd;
 			MissileGraphicID eAnim;
 			DamageType damageType;
+
 			switch (missile._mitype) {
 			case MissileID::LightningArrow:
-				if (!missile.IsTrap()) {
-					// BUGFIX: damage of missile should be encoded in missile struct; player can be dead/have left the game before missile arrives.
-					const Player &player = Players[p];
-					eMind = player._pILMinDam;
-					eMaxd = player._pILMaxDam;
-				} else {
-					eMind = GenerateRnd(10) + 1 + currlevel;
-					eMaxd = GenerateRnd(10) + 1 + currlevel * 2;
-				}
 				eAnim = MissileGraphicID::ChargedBolt;
 				damageType = DamageType::Lightning;
 				break;
 			case MissileID::FireArrow:
-				if (!missile.IsTrap()) {
-					// BUGFIX: damage of missile should be encoded in missile struct; player can be dead/have left the game before missile arrives.
-					const Player &player = Players[p];
-					eMind = player._pIFMinDam;
-					eMaxd = player._pIFMaxDam;
-				} else {
-					eMind = GenerateRnd(10) + 1 + currlevel;
-					eMaxd = GenerateRnd(10) + 1 + currlevel * 2;
-				}
 				eAnim = MissileGraphicID::MagmaBallExplosion;
 				damageType = DamageType::Fire;
 				break;
-			default:
-				app_fatal(StrCat("wrong missile ID ", static_cast<int>(missile._mitype)));
-				break;
 			}
+
 			SetMissAnim(missile, eAnim);
-			CheckMissileCol(missile, damageType, eMind, eMaxd, false, missile.position.tile, true);
+			CheckMissileCol(missile, damageType, missile.var4, missile.var5, false, missile.position.tile, true);
 		} else {
 			if (missile.position.tile != Point { missile.var1, missile.var2 }) {
 				missile.var1 = missile.position.tile.x;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1393,11 +1393,10 @@ void AddStealMana(Missile &missile, AddMissileParameter & /*parameter*/)
 
 void AddSpectralArrow(Missile &missile, AddMissileParameter &parameter)
 {
+	const Player &player = *missile.sourcePlayer();
 	int av = 0;
 
 	if (missile.sourceType() == MissileSource::Player) {
-		const Player &player = *missile.sourcePlayer();
-
 		if (player._pClass == HeroClass::Rogue)
 			av += (player._pLevel - 1) / 4;
 		else if (player._pClass == HeroClass::Warrior || player._pClass == HeroClass::Bard)
@@ -1417,6 +1416,7 @@ void AddSpectralArrow(Missile &missile, AddMissileParameter &parameter)
 	missile.var1 = parameter.dst.x;
 	missile.var2 = parameter.dst.y;
 	missile.var3 = av;
+	missile._midam = player._pILMinDam;
 }
 
 void AddWarp(Missile &missile, AddMissileParameter & /*parameter*/)
@@ -3277,7 +3277,7 @@ void ProcessSpectralArrow(Missile &missile)
 		dir = player._pdir;
 		micaster = TARGET_MONSTERS;
 
-		switch (player._pILMinDam) {
+		switch (missile._midam) {
 		case 0:
 			mitype = MissileID::FireballBow;
 			break;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -201,11 +201,6 @@ int ProjectileTrapDamage(Missile &missile)
 	return currlevel + GenerateRnd(2 * currlevel);
 }
 
-int ProjectileTrapElementalDamage(Missile &missile)
-{
-	return currlevel + GenerateRnd(2 * currlevel); // shit
-}
-
 bool MonsterMHit(int pnum, int monsterId, int mindam, int maxdam, int dist, MissileID t, DamageType damageType, bool shift)
 {
 	auto &monster = Monsters[monsterId];

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1393,10 +1393,11 @@ void AddStealMana(Missile &missile, AddMissileParameter & /*parameter*/)
 
 void AddSpectralArrow(Missile &missile, AddMissileParameter &parameter)
 {
-	Player &player = *missile.sourcePlayer();
 	int av = 0;
 
 	if (missile.sourceType() == MissileSource::Player) {
+		Player &player = *missile.sourcePlayer();
+
 		if (player._pClass == HeroClass::Rogue)
 			av += (player._pLevel - 1) / 4;
 		else if (player._pClass == HeroClass::Warrior || player._pClass == HeroClass::Bard)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1393,7 +1393,7 @@ void AddStealMana(Missile &missile, AddMissileParameter & /*parameter*/)
 
 void AddSpectralArrow(Missile &missile, AddMissileParameter &parameter)
 {
-	const Player &player = *missile.sourcePlayer();
+	Player &player = *missile.sourcePlayer();
 	int av = 0;
 
 	if (missile.sourceType() == MissileSource::Player) {
@@ -1416,7 +1416,16 @@ void AddSpectralArrow(Missile &missile, AddMissileParameter &parameter)
 	missile.var1 = parameter.dst.x;
 	missile.var2 = parameter.dst.y;
 	missile.var3 = av;
-	missile._midam = player._pILMinDam;
+	
+	int16_t spectralID = 0;
+
+	for (Item &item : EquippedPlayerItemsRange { player }) {
+		if (item.isWeapon()) {
+			spectralID = item._iLMinDam;
+			break;
+		}
+	}
+	missile._midam = spectralID;
 }
 
 void AddWarp(Missile &missile, AddMissileParameter & /*parameter*/)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1679,8 +1679,6 @@ void AddElementalArrow(Missile &missile, AddMissileParameter &parameter)
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 5);
 
-	bool errorFlag = false;
-
 	if (missile.sourceType() == MissileSource::Player) {
 		const auto &player = *missile.sourcePlayer();
 		missile._midam = player._pIMinDam; // min physical damage
@@ -1748,6 +1746,23 @@ void AddArrow(Missile &missile, AddMissileParameter &parameter)
 	UpdateMissileVelocity(missile, dst, av);
 	missile._miAnimFrame = static_cast<int>(GetDirection16(missile.position.start, dst)) + 1;
 	missile._mirange = 256;
+
+	switch (missile.sourceType()) {
+	case MissileSource::Player: {
+		const Player &player = *missile.sourcePlayer();
+		missile._midam = player._pIMinDam; // min damage
+		missile.var1 = player._pIMaxDam;   // max damage
+	} break;
+	case MissileSource::Monster: {
+		const Monster &monster = *missile.sourceMonster();
+		missile._midam = monster.minDamage; // min damage
+		missile.var1 = monster.maxDamage;   // max damage
+	} break;
+	case MissileSource::Trap:
+		missile._midam = currlevel;   // min damage
+		missile.var1 = 2 * currlevel; // max damage
+		break;
+	}
 }
 
 void UpdateVileMissPos(Missile &missile, Point dst)
@@ -2844,29 +2859,11 @@ void ProcessArrow(Missile &missile)
 	missile._mirange--;
 	missile._midist++;
 
-	int mind;
-	int maxd;
-	switch (missile.sourceType()) {
-	case MissileSource::Player: {
-		// BUGFIX: damage of missile should be encoded in missile struct; player can be dead/have left the game before missile arrives.
-		const Player &player = *missile.sourcePlayer();
-		mind = player._pIMinDam;
-		maxd = player._pIMaxDam;
-	} break;
-	case MissileSource::Monster: {
-		// BUGFIX: damage of missile should be encoded in missile struct; monster can be dead before missile arrives.
-		const Monster &monster = *missile.sourceMonster();
-		mind = monster.minDamage;
-		maxd = monster.maxDamage;
-	} break;
-	case MissileSource::Trap:
-		mind = currlevel;
-		maxd = 2 * currlevel;
-		break;
-	}
-	MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), mind, maxd, true, false);
+	MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile.var1, true, false);
+
 	if (missile._mirange == 0)
 		missile._miDelFlag = true;
+
 	PutMissile(missile);
 }
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1410,22 +1410,22 @@ void AddSpectralArrow(Missile &missile, AddMissileParameter &parameter)
 			av += 4;
 		if (HasAnyOf(player._pIFlags, ItemSpecialEffect::FastestAttack))
 			av += 8;
+
+		int16_t spectralID = 0;
+
+		for (Item &item : EquippedPlayerItemsRange { player }) {
+			if (item.isWeapon()) {
+				spectralID = item._iLMinDam;
+				break;
+			}
+		}
+		missile._midam = spectralID;
 	}
 
 	missile._mirange = 1;
 	missile.var1 = parameter.dst.x;
 	missile.var2 = parameter.dst.y;
 	missile.var3 = av;
-	
-	int16_t spectralID = 0;
-
-	for (Item &item : EquippedPlayerItemsRange { player }) {
-		if (item.isWeapon()) {
-			spectralID = item._iLMinDam;
-			break;
-		}
-	}
-	missile._midam = spectralID;
 }
 
 void AddWarp(Missile &missile, AddMissileParameter & /*parameter*/)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1681,39 +1681,37 @@ void AddElementalArrow(Missile &missile, AddMissileParameter &parameter)
 
 	bool errorFlag = false;
 
-	if (missile._midam == 0) {
-		if (missile.sourceType() == MissileSource::Player) {
-			const auto &player = *missile.sourcePlayer();
-			missile._midam = player._pIMinDam; // min physical damage
-			missile.var3 = player._pIMaxDam;   // max physical damage
+	if (missile.sourceType() == MissileSource::Player) {
+		const auto &player = *missile.sourcePlayer();
+		missile._midam = player._pIMinDam; // min physical damage
+		missile.var3 = player._pIMaxDam;   // max physical damage
 
-			switch (missile._mitype) {
-			case MissileID::LightningArrow:
-				missile.var4 = player._pILMinDam; // min lightning damage
-				missile.var5 = player._pILMaxDam; // max lightning damage
-				break;
-			case MissileID::FireArrow:
-				missile.var4 = player._pIFMinDam; // min fire damage
-				missile.var5 = player._pIFMaxDam; // max fire damage
-				break;
-			default:
-				app_fatal(StrCat("wrong missile ID ", static_cast<int>(missile._mitype)));
-				break;
-			}
-		} else if (missile.sourceType() == MissileSource::Trap) {
-			missile._midam = currlevel + GenerateRnd(10) + 1;     // min physical damage
-			missile.var3 = (currlevel * 2) + GenerateRnd(10) + 1; // max physical damage
+		switch (missile._mitype) {
+		case MissileID::LightningArrow:
+			missile.var4 = player._pILMinDam; // min lightning damage
+			missile.var5 = player._pILMaxDam; // max lightning damage
+			break;
+		case MissileID::FireArrow:
+			missile.var4 = player._pIFMinDam; // min fire damage
+			missile.var5 = player._pIFMaxDam; // max fire damage
+			break;
+		default:
+			app_fatal(StrCat("wrong missile ID ", static_cast<int>(missile._mitype)));
+			break;
+		}
+	} else if (missile.sourceType() == MissileSource::Trap) {
+		missile._midam = currlevel + GenerateRnd(10) + 1;     // min physical damage
+		missile.var3 = (currlevel * 2) + GenerateRnd(10) + 1; // max physical damage
 
-			switch (missile._mitype) {
-			case MissileID::LightningArrow:
-			case MissileID::FireArrow:
-				missile.var4 = currlevel + GenerateRnd(10) + 1;       // min elemental damage
-				missile.var5 = (currlevel * 2) + GenerateRnd(10) + 1; // max elemental damage
-				break;
-			default:
-				app_fatal(StrCat("wrong missile ID ", static_cast<int>(missile._mitype)));
-				break;
-			}
+		switch (missile._mitype) {
+		case MissileID::LightningArrow:
+		case MissileID::FireArrow:
+			missile.var4 = currlevel + GenerateRnd(10) + 1;       // min elemental damage
+			missile.var5 = (currlevel * 2) + GenerateRnd(10) + 1; // max elemental damage
+			break;
+		default:
+			app_fatal(StrCat("wrong missile ID ", static_cast<int>(missile._mitype)));
+			break;
 		}
 	}
 }

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1641,12 +1641,16 @@ void AddChargedBoltBow(Missile &missile, AddMissileParameter &parameter)
 void AddElementalArrow(Missile &missile, AddMissileParameter &parameter)
 {
 	Point dst = parameter.dst;
+
 	if (missile.position.start == dst) {
 		dst += parameter.midir;
 	}
+
 	int av = 32;
-	if (missile._micaster == TARGET_MONSTERS) {
-		const Player &player = Players[missile._misource];
+
+	if (missile.sourceType() == MissileSource::Player) {
+		const auto &player = *missile.sourcePlayer();
+
 		if (player._pClass == HeroClass::Rogue)
 			av += (player._pLevel) / 4;
 		else if (IsAnyOf(player._pClass, HeroClass::Warrior, HeroClass::Bard))
@@ -1665,17 +1669,7 @@ void AddElementalArrow(Missile &missile, AddMissileParameter &parameter)
 			if (IsAnyOf(player._pClass, HeroClass::Rogue, HeroClass::Warrior, HeroClass::Bard))
 				av -= 1;
 		}
-	}
-	UpdateMissileVelocity(missile, dst, av);
 
-	SetMissDir(missile, GetDirection16(missile.position.start, dst));
-	missile._mirange = 256;
-	missile.var1 = missile.position.start.x;
-	missile.var2 = missile.position.start.y;
-	missile._mlid = AddLight(missile.position.start, 5);
-
-	if (missile.sourceType() == MissileSource::Player) {
-		const auto &player = *missile.sourcePlayer();
 		missile._midam = player._pIMinDam; // min physical damage
 		missile.var3 = player._pIMaxDam;   // max physical damage
 
@@ -1707,6 +1701,14 @@ void AddElementalArrow(Missile &missile, AddMissileParameter &parameter)
 			break;
 		}
 	}
+
+	UpdateMissileVelocity(missile, dst, av);
+
+	SetMissDir(missile, GetDirection16(missile.position.start, dst));
+	missile._mirange = 256;
+	missile.var1 = missile.position.start.x;
+	missile.var2 = missile.position.start.y;
+	missile._mlid = AddLight(missile.position.start, 5);
 }
 
 void AddArrow(Missile &missile, AddMissileParameter &parameter)
@@ -2021,11 +2023,23 @@ void AddMissileExplosion(Missile &missile, AddMissileParameter &parameter)
 void AddWeaponExplosion(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.var2 = parameter.dst.x;
-	if (parameter.dst.x == 1)
+
+	if (missile.var2 == 1)
 		SetMissAnim(missile, MissileGraphicID::MagmaBallExplosion);
 	else
 		SetMissAnim(missile, MissileGraphicID::ChargedBolt);
+
 	missile._mirange = missile._miAnimLen - 1;
+
+	const Player &player = *missile.sourcePlayer();
+
+	if (missile.var2 == 1) {
+		missile._midam = player._pIFMinDam; // min fire damage
+		missile.var3 = player._pIFMaxDam;   // max fire damage
+	} else {
+		missile._midam = player._pILMinDam; // min lightning damage
+		missile.var3 = player._pILMaxDam;   // max lightning damage
+	}
 }
 
 void AddTownPortal(Missile &missile, AddMissileParameter &parameter)
@@ -3536,29 +3550,27 @@ void ProcessWeaponExplosion(Missile &missile)
 	constexpr int ExpLight[10] = { 9, 10, 11, 12, 11, 10, 8, 6, 4, 2 };
 
 	missile._mirange--;
-	const Player &player = Players[missile._misource];
-	int mind;
-	int maxd;
+
+	const Player &player = *missile.sourcePlayer();
 	DamageType damageType;
+
 	if (missile.var2 == 1) {
-		// BUGFIX: damage of missile should be encoded in missile struct; player can be dead/have left the game before missile arrives.
-		mind = player._pIFMinDam;
-		maxd = player._pIFMaxDam;
 		damageType = DamageType::Fire;
 	} else {
-		// BUGFIX: damage of missile should be encoded in missile struct; player can be dead/have left the game before missile arrives.
-		mind = player._pILMinDam;
-		maxd = player._pILMaxDam;
 		damageType = DamageType::Lightning;
 	}
-	CheckMissileCol(missile, damageType, mind, maxd, false, missile.position.tile, false);
+
+	CheckMissileCol(missile, damageType, missile._midam, missile.var3, false, missile.position.tile, false);
+
 	if (missile.var1 == 0) {
 		missile._mlid = AddLight(missile.position.tile, 9);
 	} else {
 		if (missile._mirange != 0)
 			ChangeLight(missile._mlid, missile.position.tile, ExpLight[missile.var1]);
 	}
+
 	missile.var1++;
+
 	if (missile._mirange == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2801,7 +2801,7 @@ void ProcessElementalArrow(Missile &missile)
 	} else {
 		missile._midist++;
 
-		MoveMissileAndCheckMissileCol(missile, DamageType::Physical, 0, 0, true, false);
+		MoveMissileAndCheckMissileCol(missile, DamageType::Physical, missile._midam, missile.var3, true, false);
 
 		if (missile._mirange == 0) {
 			missile._mimfnum = 0;


### PR DESCRIPTION
Prevents read/writing to the lightning and fire damage member variables in `Player` struct, and calculates lightning and fire damage by iterating the items and directly writing to the `Missile` struct. Based on https://github.com/diasurgical/devilutionX/pull/6327