### PR TITLE
Move hp/mana display and item graphics to gameplay options

### DIFF
--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1677,9 +1677,9 @@ void DrawAndBlit()
 		DrawTalkPan(out);
 	}
 	DrawXPBar(out);
-	if (*sgOptions.Graphics.showHealthValues)
+	if (*sgOptions.Gameplay.showHealthValues)
 		DrawFlaskValues(out, { mainPanel.position.x + 134, mainPanel.position.y + 28 }, MyPlayer->_pHitPoints >> 6, MyPlayer->_pMaxHP >> 6);
-	if (*sgOptions.Graphics.showManaValues)
+	if (*sgOptions.Gameplay.showManaValues)
 		DrawFlaskValues(out, { mainPanel.position.x + mainPanel.size.width - 138, mainPanel.position.y + 28 }, MyPlayer->_pMana >> 6, MyPlayer->_pMaxMana >> 6);
 
 	DrawCursor(out);

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -992,10 +992,7 @@ GraphicsOptions::GraphicsOptions()
     , hardwareCursorMaxSize("Hardware Cursor Maximum Size", OptionEntryFlags::CantChangeInGame | OptionEntryFlags::RecreateUI | (HardwareCursorSupported() ? OptionEntryFlags::None : OptionEntryFlags::Invisible), N_("Hardware Cursor Maximum Size"), N_("Maximum width / height for the hardware cursor. Larger cursors fall back to software."), 128, { 0, 64, 128, 256, 512 })
 #endif
     , limitFPS("FPS Limiter", OptionEntryFlags::None, N_("FPS Limiter"), N_("FPS is limited to avoid high CPU load. Limit considers refresh rate."), true)
-    , showItemGraphicsInStores("Show Item Graphics in Stores", OptionEntryFlags::None, N_("Show Item Graphics in Stores"), N_("Show item graphics to the left of item descriptions in store menus."), false)
     , showFPS("Show FPS", OptionEntryFlags::None, N_("Show FPS"), N_("Displays the FPS in the upper left corner of the screen."), false)
-    , showHealthValues("Show health values", OptionEntryFlags::None, N_("Show health values"), N_("Displays current / max health value on health globe."), false)
-    , showManaValues("Show mana values", OptionEntryFlags::None, N_("Show mana values"), N_("Displays current / max mana value on mana globe."), false)
 {
 	resolution.SetValueChangedCallback(ResizeWindow);
 	fullscreen.SetValueChangedCallback(SetFullscreenMode);
@@ -1021,9 +1018,6 @@ std::vector<OptionEntryBase *> GraphicsOptions::GetEntries()
 #if !defined(USE_SDL1) || defined(__3DS__)
 		&fitToScreen,
 #endif
-		&showItemGraphicsInStores,
-		&showHealthValues,
-		&showManaValues,
 #ifndef USE_SDL1
 		&upscale,
 		&scaleQuality,
@@ -1057,6 +1051,9 @@ GameplayOptions::GameplayOptions()
     , testBard("Test Bard", OptionEntryFlags::CantChangeInGame, N_("Test Bard"), N_("Force the Bard character type to appear in the hero selection menu."), false)
     , testBarbarian("Test Barbarian", OptionEntryFlags::CantChangeInGame, N_("Test Barbarian"), N_("Force the Barbarian character type to appear in the hero selection menu."), false)
     , experienceBar("Experience Bar", OptionEntryFlags::None, N_("Experience Bar"), N_("Experience Bar is added to the UI at the bottom of the screen."), false)
+    , showItemGraphicsInStores("Show Item Graphics in Stores", OptionEntryFlags::None, N_("Show Item Graphics in Stores"), N_("Show item graphics to the left of item descriptions in store menus."), false)
+    , showHealthValues("Show health values", OptionEntryFlags::None, N_("Show health values"), N_("Displays current / max health value on health globe."), false)
+    , showManaValues("Show mana values", OptionEntryFlags::None, N_("Show mana values"), N_("Displays current / max mana value on mana globe."), false)
     , enemyHealthBar("Enemy Health Bar", OptionEntryFlags::None, N_("Enemy Health Bar"), N_("Enemy Health Bar is displayed at the top of the screen."), false)
     , autoGoldPickup("Auto Gold Pickup", OptionEntryFlags::None, N_("Auto Gold Pickup"), N_("Gold is automatically collected when in close proximity to the player."), false)
     , autoElixirPickup("Auto Elixir Pickup", OptionEntryFlags::None, N_("Auto Elixir Pickup"), N_("Elixirs are automatically collected when in close proximity to the player."), false)
@@ -1105,6 +1102,9 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&testBard,
 		&testBarbarian,
 		&experienceBar,
+		&showItemGraphicsInStores,
+		&showHealthValues,
+		&showManaValues,
 		&enemyHealthBar,
 		&showMonsterType,
 		&showItemLabels,

--- a/Source/options.h
+++ b/Source/options.h
@@ -514,14 +514,8 @@ struct GraphicsOptions : OptionCategoryBase {
 #endif
 	/** @brief Enable FPS Limiter. */
 	OptionEntryBoolean limitFPS;
-	/** @brief Show item graphics to the left of item descriptions in store menus. */
-	OptionEntryBoolean showItemGraphicsInStores;
 	/** @brief Show FPS, even without the -f command line flag. */
 	OptionEntryBoolean showFPS;
-	/** @brief Display current/max health values on health globe. */
-	OptionEntryBoolean showHealthValues;
-	/** @brief Display current/max mana values on mana globe. */
-	OptionEntryBoolean showManaValues;
 };
 
 struct GameplayOptions : OptionCategoryBase {
@@ -548,6 +542,12 @@ struct GameplayOptions : OptionCategoryBase {
 	OptionEntryBoolean testBarbarian;
 	/** @brief Show the current level progress. */
 	OptionEntryBoolean experienceBar;
+	/** @brief Show item graphics to the left of item descriptions in store menus. */
+	OptionEntryBoolean showItemGraphicsInStores;
+	/** @brief Display current/max health values on health globe. */
+	OptionEntryBoolean showHealthValues;
+	/** @brief Display current/max mana values on mana globe. */
+	OptionEntryBoolean showManaValues;
 	/** @brief Show enemy health at the top of the screen. */
 	OptionEntryBoolean enemyHealthBar;
 	/** @brief Automatically pick up gold when walking over it. */

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2202,7 +2202,7 @@ void SetupTownStores()
 
 void FreeStoreMem()
 {
-	if (*sgOptions.Graphics.showItemGraphicsInStores) {
+	if (*sgOptions.Gameplay.showItemGraphicsInStores) {
 		FreeHalfSizeItemSprites();
 	}
 	stextflag = TalkID::None;
@@ -2234,7 +2234,7 @@ void PrintSString(const Surface &out, int margin, int line, string_view text, Ui
 	constexpr int CursWidth = INV_SLOT_SIZE_PX * 2;
 	constexpr int HalfCursWidth = CursWidth / 2;
 
-	if (*sgOptions.Graphics.showItemGraphicsInStores && cursId >= 0) {
+	if (*sgOptions.Gameplay.showItemGraphicsInStores && cursId >= 0) {
 		const Size size = GetInvItemSize(static_cast<int>(CURSOR_FIRSTITEM) + cursId);
 		const bool useHalfSize = size.width > INV_SLOT_SIZE_PX || size.height > INV_SLOT_SIZE_PX;
 		const bool useRed = HasAnyOf(flags, UiFlags::ColorRed);
@@ -2252,7 +2252,7 @@ void PrintSString(const Surface &out, int margin, int line, string_view text, Ui
 		}
 	}
 
-	if (*sgOptions.Graphics.showItemGraphicsInStores && cursIndent) {
+	if (*sgOptions.Gameplay.showItemGraphicsInStores && cursIndent) {
 		const Rectangle textRect { { rect.position.x + HalfCursWidth + 8, rect.position.y }, { rect.size.width - HalfCursWidth + 8, rect.size.height } };
 		DrawString(out, text, textRect, flags);
 	} else {
@@ -2306,7 +2306,7 @@ void ClearSText(int s, int e)
 
 void StartStore(TalkID s)
 {
-	if (*sgOptions.Graphics.showItemGraphicsInStores) {
+	if (*sgOptions.Gameplay.showItemGraphicsInStores) {
 		CreateHalfSizeItemSprites();
 	}
 	sbookflag = false;


### PR DESCRIPTION
Experience bar, enemy health bar, floating numbers, etc. are all under gameplay, these options should be as well.