### PR TITLE
Refactor Character Panel

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -106,10 +106,10 @@ bool IsRightPanelOpen()
 constexpr Size IncrementAttributeButtonSize { 41, 22 };
 /** Maps from attribute_id to the rectangle on screen used for attribute increment buttons. */
 Rectangle ChrBtnsRect[4] = {
-	{ { 137, 138 }, IncrementAttributeButtonSize },
-	{ { 137, 166 }, IncrementAttributeButtonSize },
-	{ { 137, 195 }, IncrementAttributeButtonSize },
-	{ { 137, 223 }, IncrementAttributeButtonSize }
+	{ { 113, 110 }, IncrementAttributeButtonSize },
+	{ { 113, 138 }, IncrementAttributeButtonSize },
+	{ { 113, 166 }, IncrementAttributeButtonSize },
+	{ { 113, 195 }, IncrementAttributeButtonSize }
 };
 
 /** Positions of panel buttons. */

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -10,6 +10,7 @@
 #include "engine/load_clx.hpp"
 #include "engine/render/clx_render.hpp"
 #include "engine/render/text_render.hpp"
+#include "missiles.h"
 #include "panels/ui_panels.hpp"
 #include "player.h"
 #include "playerdat.hpp"
@@ -92,6 +93,62 @@ std::pair<int, int> GetDamage()
 	return { mindam, maxdam };
 }
 
+std::pair<int, int> GetSpellDamage()
+{
+	int min;
+	int max;
+
+	GetDamageAmt(InspectPlayer->_pRSpell, &min, &max);
+
+	return { min, max };
+}
+
+UiFlags GetSpellTextColor()
+{
+	UiFlags color;
+
+	switch (InspectPlayer->_pRSpell) {
+	case SpellID::Firebolt:
+	case SpellID::FireWall:
+	case SpellID::Fireball:
+	case SpellID::Guardian:
+	case SpellID::FlameWave:
+	case SpellID::Inferno:
+	case SpellID::Elemental:
+	case SpellID::Immolation:
+	case SpellID::RingOfFire:
+	case SpellID::RuneOfFire:
+	case SpellID::RuneOfImmolation:
+		color = UiFlags::ColorOrange;
+		break;
+	case SpellID::Lightning:
+	case SpellID::ChainLightning:
+	case SpellID::Nova:
+	case SpellID::ChargedBolt:
+	case SpellID::LightningWall:
+	case SpellID::RuneOfLight:
+	case SpellID::RuneOfNova:
+		color = UiFlags::ColorYellow;
+		break;
+	case SpellID::Healing:
+	case SpellID::Flash:
+	case SpellID::HealOther:
+	case SpellID::BloodStar:
+	case SpellID::BoneSpirit:
+		color = UiFlags::ColorBlue;
+		break;
+	case SpellID::DoomSerpents:
+	case SpellID::Apocalypse:
+		color = UiFlags::ColorRed;
+		break;
+	default:
+		color = UiFlags::ColorWhite;
+		break;
+	}
+
+	return color;
+}
+
 StyledText GetResistInfo(int8_t resist)
 {
 	UiFlags style = UiFlags::ColorBlue;
@@ -105,7 +162,10 @@ StyledText GetResistInfo(int8_t resist)
 	return { style, StrCat(resist, "%") };
 }
 
-constexpr int LeftColumnLabelX = 88;
+constexpr int LeftColumnLabelX = 63;
+constexpr int CenterColumnLabelX = LeftColumnLabelX + 47;
+constexpr int TopLeftLabelX = 9;
+constexpr int TopCenterLabelX = 110;
 constexpr int TopRightLabelX = 211;
 constexpr int RightColumnLabelX = 253;
 
@@ -113,75 +173,69 @@ constexpr int LeftColumnLabelWidth = 76;
 constexpr int RightColumnLabelWidth = 68;
 
 // Indices in `panelEntries`.
-constexpr unsigned AttributeHeaderEntryIndices[2] = { 5, 6 };
+constexpr unsigned ExperienceHeaderEntryIndices[2] = { 2, 4 };
+constexpr unsigned AttributeHeaderEntryIndices[2] = { 6, 7 };
 constexpr unsigned GoldHeaderEntryIndex = 16;
 
 PanelEntry panelEntries[] = {
 	{ "", { 9, 14 }, 150, 0,
 	    []() { return StyledText { UiFlags::ColorWhite, InspectPlayer->_pName }; } },
 	{ "", { 161, 14 }, 149, 0,
-	    []() { return StyledText { UiFlags::ColorWhite, std::string(_(PlayersData[static_cast<std::size_t>(InspectPlayer->_pClass)].className)) }; } },
+	    []() { return StyledText { UiFlags::ColorWhite, StrCat("Lvl ", InspectPlayer->_pLevel, " ", std::string(_(PlayersData[static_cast<std::size_t>(InspectPlayer->_pClass)].className))) }; } },
 
-	{ N_("Level"), { 57, 52 }, 57, 45,
-	    []() { return StyledText { UiFlags::ColorWhite, StrCat(InspectPlayer->_pLevel) }; } },
-	{ N_("Experience"), { TopRightLabelX, 52 }, 99, 91,
+	{ N_("Experience"), { TopCenterLabelX, /* set dynamically */ 0 }, 0, 99, {} },
+	{ "", { TopCenterLabelX, 62 }, 99, 0,
 	    []() {
-	        int spacing = ((InspectPlayer->_pExperience >= 1000000000) ? 0 : 1);
-	        return StyledText { UiFlags::ColorWhite, FormatInteger(InspectPlayer->_pExperience), spacing };
-	    } },
-	{ N_("Next level"), { TopRightLabelX, 80 }, 99, 198,
+		int spacing = ((InspectPlayer->_pExperience >= 1000000000) ? 0 : 1);
+		return StyledText { UiFlags::ColorWhite, FormatInteger(InspectPlayer->_pExperience), spacing }; } },
+	{ N_("Next level"), { TopRightLabelX, /* set dynamically */ 0 }, 0, 99, {} },
+	{ "", { TopRightLabelX, 62 }, 99, 0,
 	    []() {
-	        if (InspectPlayer->_pLevel == MaxCharacterLevel) {
-		        return StyledText { UiFlags::ColorWhitegold, std::string(_("None")) };
-	        }
-	        int spacing = ((InspectPlayer->_pNextExper >= 1000000000) ? 0 : 1);
-	        return StyledText { UiFlags::ColorWhite, FormatInteger(InspectPlayer->_pNextExper), spacing };
-	    } },
+		if (InspectPlayer->_pLevel == MaxCharacterLevel) {
+			return StyledText { UiFlags::ColorWhitegold, std::string(_("None")) };
+		}
+		int spacing = ((InspectPlayer->_pNextExper >= 1000000000) ? 0 : 1);
+		return StyledText { UiFlags::ColorWhite, FormatInteger(InspectPlayer->_pNextExper), spacing }; } },
 
 	{ N_("Base"), { LeftColumnLabelX, /* set dynamically */ 0 }, 0, 44, {} },
-	{ N_("Now"), { 135, /* set dynamically */ 0 }, 0, 44, {} },
-	{ N_("Strength"), { LeftColumnLabelX, 135 }, 45, LeftColumnLabelWidth,
+	{ N_("Now"), { CenterColumnLabelX, /* set dynamically */ 0 }, 0, 44, {} },
+	{ N_("Str"), { LeftColumnLabelX, 107 }, 45, LeftColumnLabelWidth,
 	    []() { return StyledText { GetBaseStatColor(CharacterAttribute::Strength), StrCat(InspectPlayer->_pBaseStr) }; } },
-	{ "", { 135, 135 }, 45, 0,
+	{ "", { CenterColumnLabelX, 107 }, 45, 0,
 	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Strength), StrCat(InspectPlayer->_pStrength) }; } },
-	{ N_("Magic"), { LeftColumnLabelX, 163 }, 45, LeftColumnLabelWidth,
+	{ N_("Mag"), { LeftColumnLabelX, 135 }, 45, LeftColumnLabelWidth,
 	    []() { return StyledText { GetBaseStatColor(CharacterAttribute::Magic), StrCat(InspectPlayer->_pBaseMag) }; } },
-	{ "", { 135, 163 }, 45, 0,
+	{ "", { CenterColumnLabelX, 135 }, 45, 0,
 	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Magic), StrCat(InspectPlayer->_pMagic) }; } },
-	{ N_("Dexterity"), { LeftColumnLabelX, 191 }, 45, LeftColumnLabelWidth, []() { return StyledText { GetBaseStatColor(CharacterAttribute::Dexterity), StrCat(InspectPlayer->_pBaseDex) }; } },
-	{ "", { 135, 191 }, 45, 0,
+	{ N_("Dex"), { LeftColumnLabelX, 163 }, 45, LeftColumnLabelWidth, []() { return StyledText { GetBaseStatColor(CharacterAttribute::Dexterity), StrCat(InspectPlayer->_pBaseDex) }; } },
+	{ "", { CenterColumnLabelX, 163 }, 45, 0,
 	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Dexterity), StrCat(InspectPlayer->_pDexterity) }; } },
-	{ N_("Vitality"), { LeftColumnLabelX, 219 }, 45, LeftColumnLabelWidth, []() { return StyledText { GetBaseStatColor(CharacterAttribute::Vitality), StrCat(InspectPlayer->_pBaseVit) }; } },
-	{ "", { 135, 219 }, 45, 0,
+	{ N_("Vit"), { LeftColumnLabelX, 191 }, 45, LeftColumnLabelWidth, []() { return StyledText { GetBaseStatColor(CharacterAttribute::Vitality), StrCat(InspectPlayer->_pBaseVit) }; } },
+	{ "", { CenterColumnLabelX, 191 }, 45, 0,
 	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Vitality), StrCat(InspectPlayer->_pVitality) }; } },
-	{ N_("Points to distribute"), { LeftColumnLabelX, 248 }, 45, LeftColumnLabelWidth,
-	    []() {
-	        InspectPlayer->_pStatPts = std::min(CalcStatDiff(*InspectPlayer), InspectPlayer->_pStatPts);
-	        return StyledText { UiFlags::ColorRed, (InspectPlayer->_pStatPts > 0 ? StrCat(InspectPlayer->_pStatPts) : "") };
-	    } },
 
-	{ N_("Gold"), { TopRightLabelX, /* set dynamically */ 0 }, 0, 98, {} },
-	{ "", { TopRightLabelX, 127 }, 99, 0,
+	{ N_("Gold"), { TopLeftLabelX, /* set dynamically */ 0 }, 0, 98, {} },
+	{ "", { TopLeftLabelX, 62 }, 99, 0,
 	    []() { return StyledText { UiFlags::ColorWhite, FormatInteger(InspectPlayer->_pGold) }; } },
 
-	{ N_("Armor class"), { RightColumnLabelX, 163 }, 57, RightColumnLabelWidth,
+	{ N_("Armor class"), { RightColumnLabelX, 107 }, 57, RightColumnLabelWidth,
 	    []() { return StyledText { GetValueColor(InspectPlayer->_pIBonusAC), StrCat(InspectPlayer->GetArmor() + InspectPlayer->_pLevel * 2) }; } },
-	{ N_("To hit"), { RightColumnLabelX, 191 }, 57, RightColumnLabelWidth,
+	{ N_("Chance to hit"), { RightColumnLabelX, 135 }, 57, RightColumnLabelWidth,
 	    []() { return StyledText { GetValueColor(InspectPlayer->_pIBonusToHit), StrCat(InspectPlayer->InvBody[INVLOC_HAND_LEFT]._itype == ItemType::Bow ? InspectPlayer->GetRangedToHit() : InspectPlayer->GetMeleeToHit(), "%") }; } },
-	{ N_("Damage"), { RightColumnLabelX, 219 }, 57, RightColumnLabelWidth,
+	{ N_("Damage"), { RightColumnLabelX, 163 }, 57, RightColumnLabelWidth,
 	    []() {
 	        std::pair<int, int> dmg = GetDamage();
 	        int spacing = ((dmg.first >= 100) ? -1 : 1);
 	        return StyledText { GetValueColor(InspectPlayer->_pIBonusDam), StrCat(dmg.first, "-", dmg.second), spacing };
 	    } },
 
-	{ N_("Life"), { LeftColumnLabelX, 284 }, 45, LeftColumnLabelWidth,
+	{ N_("Life"), { LeftColumnLabelX, 256 }, 45, LeftColumnLabelWidth,
 	    []() { return StyledText { GetMaxHealthColor(), StrCat(InspectPlayer->_pMaxHP >> 6) }; } },
-	{ "", { 135, 284 }, 45, 0,
+	{ "", { CenterColumnLabelX, 256 }, 45, 0,
 	    []() { return StyledText { (InspectPlayer->_pHitPoints != InspectPlayer->_pMaxHP ? UiFlags::ColorRed : GetMaxHealthColor()), StrCat(InspectPlayer->_pHitPoints >> 6) }; } },
-	{ N_("Mana"), { LeftColumnLabelX, 312 }, 45, LeftColumnLabelWidth,
+	{ N_("Mana"), { LeftColumnLabelX, 284 }, 45, LeftColumnLabelWidth,
 	    []() { return StyledText { GetMaxManaColor(), StrCat(InspectPlayer->_pMaxMana >> 6) }; } },
-	{ "", { 135, 312 }, 45, 0,
+	{ "", { CenterColumnLabelX, 284 }, 45, 0,
 	    []() { return StyledText { (InspectPlayer->_pMana != InspectPlayer->_pMaxMana ? UiFlags::ColorRed : GetMaxManaColor()), StrCat(InspectPlayer->_pMana >> 6) }; } },
 
 	{ N_("Resist magic"), { RightColumnLabelX, 256 }, 57, RightColumnLabelWidth,
@@ -190,6 +244,23 @@ PanelEntry panelEntries[] = {
 	    []() { return GetResistInfo(InspectPlayer->_pFireResist); } },
 	{ N_("Resist lightning"), { RightColumnLabelX, 313 }, 57, RightColumnLabelWidth,
 	    []() { return GetResistInfo(InspectPlayer->_pLghtResist); } },
+};
+
+PanelEntry pointsToDistributeEntry[] = {
+	{ N_("Stat points remaining"), { LeftColumnLabelX + 47, 220 }, 45, LeftColumnLabelWidth + 47,
+	    []() {
+	        InspectPlayer->_pStatPts = std::min(CalcStatDiff(*InspectPlayer), InspectPlayer->_pStatPts);
+	        return StyledText { UiFlags::ColorRed, (InspectPlayer->_pStatPts > 0 ? StrCat(InspectPlayer->_pStatPts) : "") };
+	    } }
+};
+
+PanelEntry spellDamageEntry[] = {
+	{ N_("Spell Damage"), { RightColumnLabelX, 191 }, 57, RightColumnLabelWidth,
+	    []() {
+	        std::pair<int, int> dmg = GetSpellDamage();
+	        int spacing = ((dmg.first >= 100) ? -1 : 1);
+	        return StyledText { GetSpellTextColor(), StrCat(dmg.first, "-", dmg.second), spacing };
+	    } },
 };
 
 OptionalOwnedClxSpriteList Panel;
@@ -243,14 +314,32 @@ void DrawShadowString(const Surface &out, const PanelEntry &entry)
 void DrawStatButtons(const Surface &out)
 {
 	if (InspectPlayer->_pStatPts > 0 && !IsInspectingPlayer()) {
+		auto &entry = pointsToDistributeEntry[0];
+		if (entry.statDisplayFunc) {
+			OwnedClxSpriteList boxLeft = LoadClx("data\\boxleftend.clx");
+			OwnedClxSpriteList boxMiddle = LoadClx("data\\boxmiddle.clx");
+			OwnedClxSpriteList boxRight = LoadClx("data\\boxrightend.clx");
+			Point pos = GetPanelPosition(UiPanels::Character, { 0, 0 });
+			StyledText tmp = (*entry.statDisplayFunc)();
+
+			DrawPanelField(out, entry.position, entry.length, boxLeft[0], boxMiddle[0], boxRight[0]);
+
+			DrawString(
+			    out,
+			    tmp.text,
+			    { entry.position + Displacement { pos.x, pos.y + PanelFieldPaddingTop }, { entry.length, PanelFieldInnerHeight } },
+			    UiFlags::AlignCenter | UiFlags::VerticalCenter | tmp.style, tmp.spacing);
+		}
+		DrawShadowString(out, entry);
+
 		if (InspectPlayer->_pBaseStr < InspectPlayer->GetMaximumAttributeValue(CharacterAttribute::Strength))
-			ClxDraw(out, GetPanelPosition(UiPanels::Character, { 137, 157 }), (*pChrButtons)[chrbtn[static_cast<size_t>(CharacterAttribute::Strength)] ? 2 : 1]);
+			ClxDraw(out, GetPanelPosition(UiPanels::Character, { 113, 129 }), (*pChrButtons)[chrbtn[static_cast<size_t>(CharacterAttribute::Strength)] ? 2 : 1]);
 		if (InspectPlayer->_pBaseMag < InspectPlayer->GetMaximumAttributeValue(CharacterAttribute::Magic))
-			ClxDraw(out, GetPanelPosition(UiPanels::Character, { 137, 185 }), (*pChrButtons)[chrbtn[static_cast<size_t>(CharacterAttribute::Magic)] ? 4 : 3]);
+			ClxDraw(out, GetPanelPosition(UiPanels::Character, { 113, 157 }), (*pChrButtons)[chrbtn[static_cast<size_t>(CharacterAttribute::Magic)] ? 4 : 3]);
 		if (InspectPlayer->_pBaseDex < InspectPlayer->GetMaximumAttributeValue(CharacterAttribute::Dexterity))
-			ClxDraw(out, GetPanelPosition(UiPanels::Character, { 137, 214 }), (*pChrButtons)[chrbtn[static_cast<size_t>(CharacterAttribute::Dexterity)] ? 6 : 5]);
+			ClxDraw(out, GetPanelPosition(UiPanels::Character, { 113, 185 }), (*pChrButtons)[chrbtn[static_cast<size_t>(CharacterAttribute::Dexterity)] ? 6 : 5]);
 		if (InspectPlayer->_pBaseVit < InspectPlayer->GetMaximumAttributeValue(CharacterAttribute::Vitality))
-			ClxDraw(out, GetPanelPosition(UiPanels::Character, { 137, 242 }), (*pChrButtons)[chrbtn[static_cast<size_t>(CharacterAttribute::Vitality)] ? 8 : 7]);
+			ClxDraw(out, GetPanelPosition(UiPanels::Character, { 113, 214 }), (*pChrButtons)[chrbtn[static_cast<size_t>(CharacterAttribute::Vitality)] ? 8 : 7]);
 	}
 }
 
@@ -269,11 +358,15 @@ void LoadCharPanel()
 		OwnedClxSpriteList boxRight = LoadClx("data\\boxrightend.clx");
 
 		const bool isSmallFontTall = IsSmallFontTall();
-		const int attributeHeadersY = isSmallFontTall ? 112 : 114;
+		const int attributeHeadersY = isSmallFontTall ? 84 : 86;
 		for (unsigned i : AttributeHeaderEntryIndices) {
 			panelEntries[i].position.y = attributeHeadersY;
 		}
-		panelEntries[GoldHeaderEntryIndex].position.y = isSmallFontTall ? 105 : 106;
+		const int experienceHeadersY = isSmallFontTall ? 40 : 41;
+		for (unsigned i : ExperienceHeaderEntryIndices) {
+			panelEntries[i].position.y = experienceHeadersY;
+		}
+		panelEntries[GoldHeaderEntryIndex].position.y = isSmallFontTall ? 40 : 41;
 
 		for (auto &entry : panelEntries) {
 			if (entry.statDisplayFunc) {
@@ -295,6 +388,7 @@ void DrawChr(const Surface &out)
 {
 	Point pos = GetPanelPosition(UiPanels::Character, { 0, 0 });
 	RenderClxSprite(out, (*Panel)[0], pos);
+
 	for (auto &entry : panelEntries) {
 		if (entry.statDisplayFunc) {
 			StyledText tmp = (*entry.statDisplayFunc)();
@@ -305,6 +399,34 @@ void DrawChr(const Surface &out)
 			    UiFlags::AlignCenter | UiFlags::VerticalCenter | tmp.style, tmp.spacing);
 		}
 	}
+
+	OwnedClxSpriteList boxLeft = LoadClx("data\\boxleftend.clx");
+	OwnedClxSpriteList boxMiddle = LoadClx("data\\boxmiddle.clx");
+	OwnedClxSpriteList boxRight = LoadClx("data\\boxrightend.clx");
+
+	if (IsNoneOf(InspectPlayer->_pRSpell, SpellID::Invalid, SpellID::Null)) {
+		auto &entry = spellDamageEntry[0];
+
+		if (entry.statDisplayFunc) {
+
+			StyledText tmp = (*entry.statDisplayFunc)();
+
+			DrawPanelField(out, entry.position, entry.length, boxLeft[0], boxMiddle[0], boxRight[0]);
+
+			std::pair<int, int> damage = GetSpellDamage();
+			if (damage.first != -1 && damage.second != -1 && IsNoneOf(InspectPlayer->_pRSpell, SpellID::Jester, SpellID::Mana, SpellID::Magi)) {
+				DrawString(
+				    out,
+				    tmp.text,
+				    { entry.position + Displacement { pos.x, pos.y + PanelFieldPaddingTop }, { entry.length, PanelFieldInnerHeight } },
+				    UiFlags::AlignCenter | UiFlags::VerticalCenter | tmp.style, tmp.spacing);
+			}
+		}
+
+		entry.label = GetSpellData(InspectPlayer->_pRSpell).sNameText;
+		DrawShadowString(out, entry);
+	}
+
 	DrawStatButtons(out);
 }
 


### PR DESCRIPTION
   * Points to distribute only displays if there are more than 0 points to distribute
   * Reorganizes Gold, Experience, and Next Level for better usage of panel space
   * Adds Spell Damage for current spell, only displayed if a Spell is selected
   * Changes "To hit" to "Chance to hit"
   * Changes "Points to distribute" to "Stat points remaining"
   * Moves stat boxes to the left to make space for Spell text and Resistance text
   
   

https://github.com/diasurgical/devilutionX/assets/68359262/4065e11c-0185-4376-89bd-cdeb06245f14

