### PR TITLE
Pixel based selection

### DIFF
--- a/Source/engine/point.hpp
+++ b/Source/engine/point.hpp
@@ -88,6 +88,13 @@ struct PointOf {
 		return *this;
 	}
 
+	constexpr PointOf<CoordT> &operator/=(const int factor)
+	{
+		x /= factor;
+		y /= factor;
+		return *this;
+	}
+
 	constexpr PointOf<CoordT> operator-() const
 	{
 		return { -x, -y };

--- a/Source/engine/render/clx_render.hpp
+++ b/Source/engine/render/clx_render.hpp
@@ -111,6 +111,11 @@ inline void ClxDrawLightBlended(const Surface &out, Point position, ClxSprite cl
 }
 
 /**
+ * Returns if cursor is within the CLX sprite (ignores shadow)
+ */
+bool IsPointWithinClx(Point position, ClxSprite clx);
+
+/**
  * Returns a pair of X coordinates containing the start (inclusive) and end (exclusive)
  * of fully transparent columns in the sprite.
  */

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1510,6 +1510,20 @@ void CalcViewportGeometry()
 	tileColums = (screenWidth - renderStart.x + TILE_WIDTH - 1) / TILE_WIDTH;
 }
 
+Point GetScreenPosition(Point tile)
+{
+	Point firstTile = ViewPosition;
+	Displacement offset = {};
+	CalcFirstTilePosition(firstTile, offset);
+
+	Displacement delta = firstTile - tile;
+
+	Point position {};
+	position += delta.worldToScreen();
+	position += offset;
+	return position;
+}
+
 extern SDL_Surface *PalSurface;
 
 void ClearScreenBuffer()

--- a/Source/engine/render/scrollrt.h
+++ b/Source/engine/render/scrollrt.h
@@ -61,6 +61,12 @@ void TilesInView(int *columns, int *rows);
 void CalcViewportGeometry();
 
 /**
+ * @brief Calculate the screen position of a given tile
+ * @param tile Position of a dungeon tile
+ */
+Point GetScreenPosition(Point tile);
+
+/**
  * @brief Render the whole screen black
  */
 void ClearScreenBuffer();

--- a/Source/items.h
+++ b/Source/items.h
@@ -454,6 +454,11 @@ struct Item {
 
 	/** @brief Returns the translated item name to display (respects identified flag) */
 	StringOrView getName() const;
+
+	[[nodiscard]] Displacement getRenderingOffset(const ClxSprite sprite) const
+	{
+		return { -CalculateWidth2(sprite.width()), 0 };
+	}
 };
 
 struct ItemGetRecordStruct {

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -445,6 +445,14 @@ struct Monster { // note: missing field _mAFNum
 	 * But for graphics and rendering we show the old/real mode.
 	 */
 	[[nodiscard]] MonsterMode getVisualMonsterMode() const;
+
+	[[nodiscard]] Displacement getRenderingOffset(const ClxSprite sprite) const
+	{
+		Displacement offset = { -CalculateWidth2(sprite.width()), 0 };
+		if (isWalking())
+			offset += GetOffsetForWalking(animInfo, direction);
+		return offset;
+	}
 };
 
 extern size_t LevelMonsterTypeCount;

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -252,6 +252,21 @@ struct Object {
 	 * @brief Returns the name of the object as shown in the info box
 	 */
 	[[nodiscard]] StringOrView name() const;
+
+	[[nodiscard]] ClxSprite currentSprite() const
+	{
+		return (*_oAnimData)[_oAnimFrame - 1];
+	}
+	[[nodiscard]] Displacement getRenderingOffset(const ClxSprite sprite, Point tilePosition) const
+	{
+		Displacement offset = Displacement { -CalculateWidth2(sprite.width()), 0 };
+		if (position != tilePosition) {
+			// drawing a large or offset object, calculate the correct position for the center of the sprite
+			Displacement worldOffset = position - tilePosition;
+			offset -= worldOffset.worldToScreen();
+		}
+		return offset;
+	}
 };
 
 extern DVL_API_FOR_TEST Object Objects[MAXOBJECTS];

--- a/Source/player.h
+++ b/Source/player.h
@@ -730,6 +730,18 @@ struct Player {
 
 	void getAnimationFramesAndTicksPerFrame(player_graphic graphics, int8_t &numberOfFrames, int8_t &ticksPerFrame) const;
 
+	[[nodiscard]] ClxSprite currentSprite() const
+	{
+		return previewCelSprite ? *previewCelSprite : AnimInfo.currentSprite();
+	}
+	[[nodiscard]] Displacement getRenderingOffset(const ClxSprite sprite) const
+	{
+		Displacement offset = { -CalculateWidth2(sprite.width()), 0 };
+		if (isWalking())
+			offset += GetOffsetForWalking(AnimInfo, _pdir);
+		return offset;
+	}
+
 	/**
 	 * @brief Updates previewCelSprite according to new requested command
 	 * @param cmdId What command is requested

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -61,9 +61,13 @@ struct Towner {
 	uint8_t animOrderSize;
 	_talker_id _ttype;
 
-	ClxSprite currentSprite() const
+	[[nodiscard]] ClxSprite currentSprite() const
 	{
 		return (*anim)[_tAnimFrame];
+	}
+	[[nodiscard]] Displacement getRenderingOffset() const
+	{
+		return { -CalculateWidth2(_tAnimWidth), 0 };
 	}
 };
 


### PR DESCRIPTION
Fixes #2227
Fixes #2158

## Notes

- Based on the idea of qndel's #3013 PR. Thanks @qndel 🙂 
- The cursor selection is now divided in two steps
  - First try to select an game entity with pixel perfect selection
    - This ensures that the player selects what he sees
    - This also ensures that the player can access objects that are visible but the tile is "occupied" with something else (for example a monster, see #2158)
  - Second try the old/vanilla tile based selection when pixel perfect selection find nothing
    - This ensures that the player can select small objects (for example a ring)
    - This ensures that the player doesn't get "less" selections in general then vanilla
- The first commit is a refactoring to make `CheckCursMove()` smaller and see the behavior better
- The second commit is a refactoring to make rendering offset and current sprite generally available (for both rendering & selection)
- Pixel based selection is not depended/embedded on the renderer but it needs the sprite to get the pixels. That means it is not compatible with headless mode (where we don't load sprites). So for now this is disabled in headless mode and demo mode.
- Current search area is based on rendering rows/columns and covers a area of 3x8 (for large monsters/objects)
  <details><summary>Rendering Rows/Columns and world-tile-mapping</summary>

   ![PixelSelectionRenderingRowsColumns](https://github.com/diasurgical/devilutionX/assets/25415264/cf232b11-8028-4860-8431-90cd3a40f44a)

  </details>
- This PR should not go in 1.5.1, because it needs some play testing.

## Example Videos

<details><summary>Monsters</summary>

### Master

https://github.com/diasurgical/devilutionX/assets/25415264/af421b68-dc09-446c-be23-9e5f225cd558

### PR

https://github.com/diasurgical/devilutionX/assets/25415264/b563a301-bfba-425d-afa3-a4cb63abeebb

</details>

---

<details><summary>Objects</summary>

### Master

https://github.com/diasurgical/devilutionX/assets/25415264/f3745446-8b3e-4669-a649-499a30ad55c5

### PR

https://github.com/diasurgical/devilutionX/assets/25415264/a322710a-063d-44bc-952a-ab28a5c6ea6c

</details>

---

<details><summary>NPC</summary>

### Master

https://github.com/diasurgical/devilutionX/assets/25415264/2f19f1d0-9db0-4a62-bfb2-292ee3575f60

### PR

https://github.com/diasurgical/devilutionX/assets/25415264/90aabe30-30b9-45e9-a795-7601116da8b1

</details>

---

<details><summary>Items</summary>

### Master

https://github.com/diasurgical/devilutionX/assets/25415264/1d8a0873-e746-4a76-87ed-004dd613523d

### PR

https://github.com/diasurgical/devilutionX/assets/25415264/f3ee72f5-4f42-4f94-9c83-d225880e6f91

</details>