### PR TITLE
Fix character panel label for CJK

### DIFF
--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -1,6 +1,8 @@
 #include "panels/charpanel.hpp"
 
 #include <cstdint>
+
+#include <algorithm>
 #include <string>
 
 #include <fmt/format.h>
@@ -236,8 +238,13 @@ void DrawShadowString(const Surface &out, const PanelEntry &entry)
 		labelPosition += Displacement { -entry.labelLength - (IsSmallFontTall() ? 2 : 3), 0 };
 	}
 
-	DrawString(out, text, { labelPosition + Displacement { -2, 2 }, { entry.labelLength, PanelFieldHeight } }, style | UiFlags::ColorBlack, Spacing);
-	DrawString(out, text, { labelPosition, { entry.labelLength, PanelFieldHeight } }, style | UiFlags::ColorWhite, Spacing);
+	// If the text is less tall then the field, we center it vertically relative to the field.
+	// Otherwise, we draw from the top of the field.
+	const int textHeight = (std::count(wrapped.begin(), wrapped.end(), '\n') + 1) * GetLineHeight(wrapped, GameFont12);
+	const int labelHeight = std::max(PanelFieldHeight, textHeight);
+
+	DrawString(out, text, { labelPosition + Displacement { -2, 2 }, { entry.labelLength, labelHeight } }, style | UiFlags::ColorBlack, Spacing);
+	DrawString(out, text, { labelPosition, { entry.labelLength, labelHeight } }, style | UiFlags::ColorWhite, Spacing);
 }
 
 void DrawStatButtons(const Surface &out)


### PR DESCRIPTION
We fixed clipping in text rendering between 1.4 and 1.5. This surfaced a bug in the char panel label height (regression from how it was in https://github.com/diasurgical/devilutionX/pull/3623).

Before | After
-----|------
![devilutionx-ja-before](https://github.com/diasurgical/devilutionX/assets/216339/79a37c6e-08c9-43bb-9432-be9b23ac5b39) | ![devilutionx-ja-after](https://github.com/diasurgical/devilutionX/assets/216339/1b5be059-f7d8-4c1d-b2a0-b5a2d6d3122f)
