### PR TITLE
Refactor SaveItemPower()

### DIFF
--- a/Source/itemdat.h
+++ b/Source/itemdat.h
@@ -567,8 +567,8 @@ use_enum_as_flags(AffixItemType);
 
 struct ItemPower {
 	item_effect_type type = IPL_INVALID;
-	int param1 = 0;
-	int param2 = 0;
+	int16_t param1 = 0;
+	int16_t param2 = 0;
 };
 
 struct PLStruct {


### PR DESCRIPTION
* Changed param sizes to int16_t from int. No params should ever be high enough to require 32 bits.
* Removed code from IPL_ALLRES to enforce resistance bonus being at least 0 (Not needed)
* clamped `r` for adding to `_iSplLvlAdd` to avoid overflow/underflow for too large/too low of values being set in itemdat.cpp
* Removed useless lines intended to prevent elemental weapons from having Spectral effects, but simply do not
* Refactored Durability bonus application (Added a clamp so durability values cannot exceed a range of 1 to 254, which prevents any possible overflow/underflow)
* Added switch-case for some powers to replace if-else. Adds `app_fatal` for these switch-cases in case a wrong param value is passed from itemdat