### PR TITLE
Convert town portal level type to vanilla hellfire logic

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -891,6 +891,8 @@ void LoadPortal(LoadHelper *file, int i)
 	pPortal->level = file->NextLE<int32_t>();
 	pPortal->ltype = static_cast<dungeon_type>(file->NextLE<int32_t>());
 	pPortal->setlvl = file->NextBool32();
+	if (!pPortal->setlvl)
+		pPortal->ltype = GetLevelType(pPortal->level);
 }
 
 void GetLevelNames(string_view prefix, char *out)
@@ -1669,7 +1671,7 @@ void SavePortal(SaveHelper *file, int i)
 	file->WriteLE<int32_t>(pPortal->position.x);
 	file->WriteLE<int32_t>(pPortal->position.y);
 	file->WriteLE<int32_t>(pPortal->level);
-	file->WriteLE<int32_t>(pPortal->ltype);
+	file->WriteLE<int32_t>(pPortal->setlvl ? pPortal->ltype : getHellfireLevelType(pPortal->ltype));
 	file->WriteLE<uint32_t>(pPortal->setlvl ? 1 : 0);
 }
 


### PR DESCRIPTION
Fixes #6277

Hellfire reuses the level types from Diablo for nest and crypt.
This was confusing and it was changed in devilutionX. 👍 
To stay compatible with vanilla hellfire the level types where converted In loading and saving.
But town portals level type was missed.
This PR adds the missing conversion for town portal level types.