### PR TITLE
Immediately drop player who sends invalid player data

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -831,6 +831,7 @@ void recv_plrinfo(int pnum, const TCmdPlrInfoHdr &header, bool recv)
 	PlayerLeftMsg(pnum, false);
 	if (!UnPackNetPlayer(packedPlayer, player)) {
 		player = {};
+		SNetDropPlayer(pnum, LEAVE_DROP);
 		return;
 	}
 


### PR DESCRIPTION
If the new validation catches invalid player data, it would inevitably lead to a timeout in `CheckPlayerInfoTimeouts()` due to the empty player data in that slot failing the `IsNetPlayerValid()` check. However, we can speed this whole process up by dropping the player immediately since we know they will be dropped after the timeout interval anyway.