### PR TITLE
Add bounds check to MonsterIdle() to prevent var2 overflow

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1030,7 +1030,8 @@ void MonsterIdle(Monster &monster)
 	if (monster.animInfo.isLastFrame())
 		UpdateEnemy(monster);
 
-	monster.var2++;
+	if (monster.var2 < std::numeric_limits<int16_t>::max())
+		monster.var2++;
 }
 
 /**


### PR DESCRIPTION
This doesn't fix the save file where the value is already negative, but it does prevent the overflow from occurring in the first place.

This resolves #6016

---

Suggested changelog entry under `Bugfixes > Gameplay`:
> Overlords remain idle while the player is in sight