### PR TITLE
Hp cleanup

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1369,7 +1369,7 @@ void control_drop_gold(SDL_Keycode vkey)
 {
 	Player &myPlayer = *MyPlayer;
 
-	if (myPlayer._pHitPoints >> 6 <= 0) {
+	if (!myPlayer.IsAlive()) {
 		CloseGoldDrop();
 		dropGoldValue = 0;
 		return;

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -71,7 +71,7 @@ bool InGameMenu()
 	    || qtextflag
 	    || gmenu_is_active()
 	    || PauseMode == 2
-	    || (MyPlayer != nullptr && MyPlayer->_pInvincible && MyPlayer->_pHitPoints == 0);
+	    || (MyPlayer != nullptr && MyPlayer->_pInvincible && !MyPlayer->IsAlive());
 }
 
 namespace {
@@ -389,7 +389,7 @@ void CheckPlayerNearby()
 		const int my = player.position.future.y;
 		if (dPlayer[mx][my] == 0
 		    || !IsTileLit(player.position.future)
-		    || (player._pHitPoints == 0 && spl != SpellID::Resurrect))
+		    || (!player.IsAlive() && spl != SpellID::Resurrect))
 			continue;
 
 		if (myPlayer.UsesRangedWeapon() || HasRangedSpell() || spl == SpellID::HealOther) {

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -241,7 +241,7 @@ bool CanTargetMonster(const Monster &monster)
 		return false;
 	if (monster.isPlayerMinion())
 		return false;
-	if (monster.hitPoints >> 6 <= 0) // dead
+	if (!monster.IsAlive()) // dead
 		return false;
 
 	if (!IsTileLit(monster.position.tile)) // not visible

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -505,49 +505,49 @@ void CheckCursMove()
 		if (pcurstemp != -1) {
 			if (!flipflag && mx + 2 < MAXDUNX && my + 1 < MAXDUNY && dMonster[mx + 2][my + 1] != 0 && IsTileLit({ mx + 2, my + 1 })) {
 				const uint16_t monsterId = abs(dMonster[mx + 2][my + 1]) - 1;
-				if (monsterId == pcurstemp && Monsters[monsterId].hitPoints >> 6 > 0 && (Monsters[monsterId].data().selectionType & 4) != 0) {
+				if (monsterId == pcurstemp && Monsters[monsterId].IsAlive() && (Monsters[monsterId].data().selectionType & 4) != 0) {
 					cursPosition = Point { mx, my } + Displacement { 2, 1 };
 					pcursmonst = monsterId;
 				}
 			}
 			if (flipflag && mx + 1 < MAXDUNX && my + 2 < MAXDUNY && dMonster[mx + 1][my + 2] != 0 && IsTileLit({ mx + 1, my + 2 })) {
 				const uint16_t monsterId = abs(dMonster[mx + 1][my + 2]) - 1;
-				if (monsterId == pcurstemp && Monsters[monsterId].hitPoints >> 6 > 0 && (Monsters[monsterId].data().selectionType & 4) != 0) {
+				if (monsterId == pcurstemp && Monsters[monsterId].IsAlive() && (Monsters[monsterId].data().selectionType & 4) != 0) {
 					cursPosition = Point { mx, my } + Displacement { 1, 2 };
 					pcursmonst = monsterId;
 				}
 			}
 			if (mx + 2 < MAXDUNX && my + 2 < MAXDUNY && dMonster[mx + 2][my + 2] != 0 && IsTileLit({ mx + 2, my + 2 })) {
 				const uint16_t monsterId = abs(dMonster[mx + 2][my + 2]) - 1;
-				if (monsterId == pcurstemp && Monsters[monsterId].hitPoints >> 6 > 0 && (Monsters[monsterId].data().selectionType & 4) != 0) {
+				if (monsterId == pcurstemp && Monsters[monsterId].IsAlive() && (Monsters[monsterId].data().selectionType & 4) != 0) {
 					cursPosition = Point { mx, my } + Displacement { 2, 2 };
 					pcursmonst = monsterId;
 				}
 			}
 			if (mx + 1 < MAXDUNX && !flipflag && dMonster[mx + 1][my] != 0 && IsTileLit({ mx + 1, my })) {
 				const uint16_t monsterId = abs(dMonster[mx + 1][my]) - 1;
-				if (monsterId == pcurstemp && Monsters[monsterId].hitPoints >> 6 > 0 && (Monsters[monsterId].data().selectionType & 2) != 0) {
+				if (monsterId == pcurstemp && Monsters[monsterId].IsAlive() && (Monsters[monsterId].data().selectionType & 2) != 0) {
 					cursPosition = Point { mx, my } + Displacement { 1, 0 };
 					pcursmonst = monsterId;
 				}
 			}
 			if (my + 1 < MAXDUNY && flipflag && dMonster[mx][my + 1] != 0 && IsTileLit({ mx, my + 1 })) {
 				const uint16_t monsterId = abs(dMonster[mx][my + 1]) - 1;
-				if (monsterId == pcurstemp && Monsters[monsterId].hitPoints >> 6 > 0 && (Monsters[monsterId].data().selectionType & 2) != 0) {
+				if (monsterId == pcurstemp && Monsters[monsterId].IsAlive() && (Monsters[monsterId].data().selectionType & 2) != 0) {
 					cursPosition = Point { mx, my } + Displacement { 0, 1 };
 					pcursmonst = monsterId;
 				}
 			}
 			if (dMonster[mx][my] != 0 && IsTileLit({ mx, my })) {
 				const uint16_t monsterId = abs(dMonster[mx][my]) - 1;
-				if (monsterId == pcurstemp && Monsters[monsterId].hitPoints >> 6 > 0 && (Monsters[monsterId].data().selectionType & 1) != 0) {
+				if (monsterId == pcurstemp && Monsters[monsterId].IsAlive() && (Monsters[monsterId].data().selectionType & 1) != 0) {
 					cursPosition = { mx, my };
 					pcursmonst = monsterId;
 				}
 			}
 			if (mx + 1 < MAXDUNX && my + 1 < MAXDUNY && dMonster[mx + 1][my + 1] != 0 && IsTileLit({ mx + 1, my + 1 })) {
 				const uint16_t monsterId = abs(dMonster[mx + 1][my + 1]) - 1;
-				if (monsterId == pcurstemp && Monsters[monsterId].hitPoints >> 6 > 0 && (Monsters[monsterId].data().selectionType & 2) != 0) {
+				if (monsterId == pcurstemp && Monsters[monsterId].IsAlive() && (Monsters[monsterId].data().selectionType & 2) != 0) {
 					cursPosition = Point { mx, my } + Displacement { 1, 1 };
 					pcursmonst = monsterId;
 				}
@@ -565,49 +565,49 @@ void CheckCursMove()
 		}
 		if (!flipflag && mx + 2 < MAXDUNX && my + 1 < MAXDUNY && dMonster[mx + 2][my + 1] != 0 && IsTileLit({ mx + 2, my + 1 })) {
 			int monsterId = abs(dMonster[mx + 2][my + 1]) - 1;
-			if (Monsters[monsterId].hitPoints >> 6 > 0 && (Monsters[monsterId].data().selectionType & 4) != 0) {
+			if (Monsters[monsterId].IsAlive() && (Monsters[monsterId].data().selectionType & 4) != 0) {
 				cursPosition = Point { mx, my } + Displacement { 2, 1 };
 				pcursmonst = monsterId;
 			}
 		}
 		if (flipflag && mx + 1 < MAXDUNX && my + 2 < MAXDUNY && dMonster[mx + 1][my + 2] != 0 && IsTileLit({ mx + 1, my + 2 })) {
 			const uint16_t monsterId = abs(dMonster[mx + 1][my + 2]) - 1;
-			if (Monsters[monsterId].hitPoints >> 6 > 0 && (Monsters[monsterId].data().selectionType & 4) != 0) {
+			if (Monsters[monsterId].IsAlive() && (Monsters[monsterId].data().selectionType & 4) != 0) {
 				cursPosition = Point { mx, my } + Displacement { 1, 2 };
 				pcursmonst = monsterId;
 			}
 		}
 		if (mx + 2 < MAXDUNX && my + 2 < MAXDUNY && dMonster[mx + 2][my + 2] != 0 && IsTileLit({ mx + 2, my + 2 })) {
 			const uint16_t monsterId = abs(dMonster[mx + 2][my + 2]) - 1;
-			if (Monsters[monsterId].hitPoints >> 6 > 0 && (Monsters[monsterId].data().selectionType & 4) != 0) {
+			if (Monsters[monsterId].IsAlive() && (Monsters[monsterId].data().selectionType & 4) != 0) {
 				cursPosition = Point { mx, my } + Displacement { 2, 2 };
 				pcursmonst = monsterId;
 			}
 		}
 		if (!flipflag && mx + 1 < MAXDUNX && dMonster[mx + 1][my] != 0 && IsTileLit({ mx + 1, my })) {
 			const uint16_t monsterId = abs(dMonster[mx + 1][my]) - 1;
-			if (Monsters[monsterId].hitPoints >> 6 > 0 && (Monsters[monsterId].data().selectionType & 2) != 0) {
+			if (Monsters[monsterId].IsAlive() && (Monsters[monsterId].data().selectionType & 2) != 0) {
 				cursPosition = Point { mx, my } + Displacement { 1, 0 };
 				pcursmonst = monsterId;
 			}
 		}
 		if (flipflag && my + 1 < MAXDUNY && dMonster[mx][my + 1] != 0 && IsTileLit({ mx, my + 1 })) {
 			const uint16_t monsterId = abs(dMonster[mx][my + 1]) - 1;
-			if (Monsters[monsterId].hitPoints >> 6 > 0 && (Monsters[monsterId].data().selectionType & 2) != 0) {
+			if (Monsters[monsterId].IsAlive() && (Monsters[monsterId].data().selectionType & 2) != 0) {
 				cursPosition = Point { mx, my } + Displacement { 0, 1 };
 				pcursmonst = monsterId;
 			}
 		}
 		if (dMonster[mx][my] != 0 && IsTileLit({ mx, my })) {
 			const uint16_t monsterId = abs(dMonster[mx][my]) - 1;
-			if (Monsters[monsterId].hitPoints >> 6 > 0 && (Monsters[monsterId].data().selectionType & 1) != 0) {
+			if (Monsters[monsterId].IsAlive() && (Monsters[monsterId].data().selectionType & 1) != 0) {
 				cursPosition = { mx, my };
 				pcursmonst = monsterId;
 			}
 		}
 		if (mx + 1 < MAXDUNX && my + 1 < MAXDUNY && dMonster[mx + 1][my + 1] != 0 && IsTileLit({ mx + 1, my + 1 })) {
 			const uint16_t monsterId = abs(dMonster[mx + 1][my + 1]) - 1;
-			if (Monsters[monsterId].hitPoints >> 6 > 0 && (Monsters[monsterId].data().selectionType & 2) != 0) {
+			if (Monsters[monsterId].IsAlive() && (Monsters[monsterId].data().selectionType & 2) != 0) {
 				cursPosition = Point { mx, my } + Displacement { 1, 1 };
 				pcursmonst = monsterId;
 			}

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -642,7 +642,7 @@ void CheckCursMove()
 		if (!flipflag && mx + 1 < MAXDUNX && dPlayer[mx + 1][my] != 0) {
 			const uint8_t playerId = abs(dPlayer[mx + 1][my]) - 1;
 			Player &player = Players[playerId];
-			if (&player != MyPlayer && player._pHitPoints != 0) {
+			if (&player != MyPlayer && player.IsAlive()) {
 				cursPosition = Point { mx, my } + Displacement { 1, 0 };
 				pcursplr = static_cast<int8_t>(playerId);
 			}
@@ -650,7 +650,7 @@ void CheckCursMove()
 		if (flipflag && my + 1 < MAXDUNY && dPlayer[mx][my + 1] != 0) {
 			const uint8_t playerId = abs(dPlayer[mx][my + 1]) - 1;
 			Player &player = Players[playerId];
-			if (&player != MyPlayer && player._pHitPoints != 0) {
+			if (&player != MyPlayer && player.IsAlive()) {
 				cursPosition = Point { mx, my } + Displacement { 0, 1 };
 				pcursplr = static_cast<int8_t>(playerId);
 			}
@@ -687,7 +687,7 @@ void CheckCursMove()
 		if (mx + 1 < MAXDUNX && my + 1 < MAXDUNY && dPlayer[mx + 1][my + 1] != 0) {
 			const uint8_t playerId = abs(dPlayer[mx + 1][my + 1]) - 1;
 			const Player &player = Players[playerId];
-			if (&player != MyPlayer && player._pHitPoints != 0) {
+			if (&player != MyPlayer && player.IsAlive()) {
 				cursPosition = Point { mx, my } + Displacement { 1, 1 };
 				pcursplr = static_cast<int8_t>(playerId);
 			}

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2915,7 +2915,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 
 	for (Player &player : Players) {
 		if (player.plractive && player.isOnActiveLevel() && (!player._pLvlChanging || &player == MyPlayer)) {
-			if (player._pHitPoints > 0) {
+			if (player.IsAlive()) {
 				if (lvldir != ENTRY_LOAD)
 					SyncInitPlrPos(player);
 			} else {

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -442,7 +442,7 @@ void DrawDeadPlayer(const Surface &out, Point tilePosition, Point targetBufferPo
 	dFlags[tilePosition.x][tilePosition.y] &= ~DungeonFlag::DeadPlayer;
 
 	for (Player &player : Players) {
-		if (player.plractive && player._pHitPoints == 0 && player.isOnActiveLevel() && player.position.tile == tilePosition) {
+		if (player.plractive && !player.IsAlive() && player.isOnActiveLevel() && player.position.tile == tilePosition) {
 			dFlags[tilePosition.x][tilePosition.y] |= DungeonFlag::DeadPlayer;
 			const Point playerRenderPosition { targetBufferPosition };
 			DrawPlayer(out, player, tilePosition, playerRenderPosition);

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1966,7 +1966,7 @@ bool UseInvItem(int cii)
 
 	Player &player = *MyPlayer;
 
-	if (player._pInvincible && player._pHitPoints == 0 && &player == MyPlayer)
+	if (player._pInvincible && !player.IsAlive() && &player == MyPlayer)
 		return true;
 	if (pcurs != CURSOR_HAND)
 		return true;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2755,7 +2755,7 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 	player._pMaxHP = ihp + player._pMaxHPBase;
 	player._pHitPoints = std::min(ihp + player._pHPBase, player._pMaxHP);
 
-	if (&player == MyPlayer && (player._pHitPoints >> 6) <= 0) {
+	if (&player == MyPlayer && !player.IsAlive()) {
 		SetPlayerHitPoints(player, 0);
 	}
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -975,7 +975,7 @@ bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, Missil
 
 	Player &player = Players[pnum];
 
-	if (player._pHitPoints >> 6 <= 0) {
+	if (!player.IsAlive()) {
 		return false;
 	}
 
@@ -1091,7 +1091,7 @@ bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, Missil
 			ApplyPlrDamage(damageType, player, 0, 0, dam, deathReason);
 		}
 
-		if (player._pHitPoints >> 6 > 0) {
+		if (player.IsAlive()) {
 			player.Say(HeroSpeech::ArghClang);
 		}
 		return true;
@@ -1101,7 +1101,7 @@ bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, Missil
 		ApplyPlrDamage(damageType, player, 0, 0, dam, deathReason);
 	}
 
-	if (player._pHitPoints >> 6 > 0) {
+	if (player.IsAlive()) {
 		StartPlrHit(player, dam, false);
 	}
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -260,7 +260,7 @@ bool MonsterMHit(int pnum, int monsterId, int mindam, int maxdam, int dist, Miss
 	if (&player == MyPlayer)
 		ApplyMonsterDamage(damageType, monster, dam);
 
-	if (monster.hitPoints >> 6 <= 0) {
+	if (!monster.IsAlive()) {
 		M_StartKill(monster, player);
 	} else if (resist) {
 		monster.tag(player);
@@ -658,7 +658,7 @@ bool GuardianTryFireAt(Missile &missile, Point target)
 	const Monster &monster = Monsters[mid];
 	if (monster.isPlayerMinion())
 		return false;
-	if (monster.hitPoints >> 6 <= 0)
+	if (!monster.IsAlive())
 		return false;
 
 	Player &player = Players[missile._misource];
@@ -959,7 +959,7 @@ bool MonsterTrapHit(int monsterId, int mindam, int maxdam, int dist, MissileID t
 	if (DebugGodMode)
 		monster.hitPoints = 0;
 #endif
-	if (monster.hitPoints >> 6 <= 0) {
+	if (!monster.IsAlive()) {
 		MonsterDeath(monster, monster.direction, true);
 	} else if (resist) {
 		PlayEffect(monster, MonsterSound::Hit);
@@ -3655,7 +3655,7 @@ void ProcessStoneCurse(Missile &missile)
 {
 	missile._mirange--;
 	auto &monster = Monsters[missile.var2];
-	if (monster.hitPoints == 0 && missile._miAnimType != MissileGraphicID::StoneCurseShatter) {
+	if (!monster.IsAlive() && missile._miAnimType != MissileGraphicID::StoneCurseShatter) {
 		missile._mimfnum = 0;
 		missile._miDrawFlag = true;
 		SetMissAnim(missile, MissileGraphicID::StoneCurseShatter);
@@ -3668,7 +3668,7 @@ void ProcessStoneCurse(Missile &missile)
 
 	if (missile._mirange == 0) {
 		missile._miDelFlag = true;
-		if (monster.hitPoints > 0) {
+		if (monster.IsAlive()) {
 			monster.mode = static_cast<MonsterMode>(missile.var1);
 			monster.animInfo.isPetrified = false;
 		} else {

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -620,7 +620,7 @@ void UpdateEnemy(Monster &monster)
 		for (size_t pnum = 0; pnum < Players.size(); pnum++) {
 			const Player &player = Players[pnum];
 			if (!player.plractive || !player.isOnActiveLevel() || player._pLvlChanging
-			    || (((player._pHitPoints >> 6) == 0) && gbIsMultiplayer))
+			    || (!player.IsAlive() && gbIsMultiplayer))
 				continue;
 			const bool sameroom = (dTransVal[position.x][position.y] == dTransVal[player.position.tile.x][player.position.tile.y]);
 			const int dist = position.WalkingDistance(player.position.tile);
@@ -1142,7 +1142,7 @@ int GetMinHit()
 
 void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, int maxDam)
 {
-	if (player._pHitPoints >> 6 <= 0 || player._pInvincible || HasAnyOf(player._pSpellFlags, SpellFlag::Etherealize))
+	if (!player.IsAlive() || player._pInvincible || HasAnyOf(player._pSpellFlags, SpellFlag::Etherealize))
 		return;
 	if (monster.position.tile.WalkingDistance(player.position.tile) >= 2)
 		return;
@@ -1216,7 +1216,7 @@ void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, 
 
 	if ((monster.flags & MFLAG_NOLIFESTEAL) == 0 && monster.type().type == MT_SKING && gbIsMultiplayer)
 		monster.hitPoints += dam;
-	if (player._pHitPoints >> 6 <= 0) {
+	if (!player.IsAlive()) {
 		if (gbIsHellfire)
 			M_StartStand(monster, monster.direction);
 		return;
@@ -3826,7 +3826,7 @@ void PrepDoEnding()
 		player._pmode = PM_QUIT;
 		player._pInvincible = true;
 		if (gbIsMultiplayer) {
-			if (player._pHitPoints >> 6 == 0)
+			if (!player.IsAlive())
 				player._pHitPoints = 64;
 			if (player._pMana >> 6 == 0)
 				player._pMana = 64;

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -316,6 +316,11 @@ struct Monster { // note: missing field _mAFNum
 		return *type().data;
 	}
 
+	bool IsAlive() const
+	{
+		return hitPoints > 0;
+	}
+
 	/**
 	 * @brief Returns monster's name
 	 * Internally it returns a name stored in global array of monsters' data.

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1785,7 +1785,7 @@ size_t OnPlayerDamage(const TCmd *pCmd, Player &player)
 
 	Player &target = Players[message.bPlr];
 	if (&target == MyPlayer && leveltype != DTYPE_TOWN && gbBufferMsgs != 1) {
-		if (player.isOnActiveLevel() && damage <= 192000 && target._pHitPoints >> 6 > 0) {
+		if (player.isOnActiveLevel() && damage <= 192000 && target.IsAlive()) {
 			ApplyPlrDamage(message.damageType, target, 0, 0, damage, DeathReason::Player);
 		}
 	}
@@ -2038,7 +2038,7 @@ size_t OnPlayerJoinLevel(const TCmd *pCmd, size_t pnum)
 		ResetPlayerGFX(player);
 		if (player.isOnActiveLevel()) {
 			SyncInitPlr(player);
-			if ((player._pHitPoints >> 6) > 0) {
+			if (player.IsAlive()) {
 				StartStand(player, Direction::South);
 			} else {
 				player._pgfxnum &= ~0xFU;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -673,7 +673,7 @@ void DeltaLeaveSync(uint8_t bLevel)
 	for (size_t i = 0; i < ActiveMonsterCount; i++) {
 		int ma = ActiveMonsters[i];
 		auto &monster = Monsters[ma];
-		if (monster.hitPoints == 0)
+		if (!monster.IsAlive())
 			continue;
 		DMonsterStr &delta = deltaLevel.monster[ma];
 		delta.position = monster.position.tile;
@@ -1745,7 +1745,7 @@ size_t OnMonstDamage(const TCmd *pCmd, size_t pnum)
 			if (player.isOnActiveLevel() && monsterIdx < MaxMonsters) {
 				auto &monster = Monsters[monsterIdx];
 				monster.tag(player);
-				if (monster.hitPoints > 0) {
+				if (monster.IsAlive()) {
 					monster.hitPoints -= SDL_SwapLE32(message.dwDam);
 					if ((monster.hitPoints >> 6) < 1)
 						monster.hitPoints = 1 << 6;

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -647,7 +647,7 @@ void multi_process_network_packets()
 			player._pBaseStr = pkt->bstr;
 			player._pBaseMag = pkt->bmag;
 			player._pBaseDex = pkt->bdex;
-			if (!cond && player.plractive && player._pHitPoints != 0) {
+			if (!cond && player.plractive && player.IsAlive()) {
 				if (player.isOnActiveLevel() && !player._pLvlChanging) {
 					if (player.position.tile.WalkingDistance(syncPosition) > 3 && PosOkPlayer(player, syncPosition)) {
 						// got out of sync, clear the tiles around where we last thought the player was located
@@ -857,7 +857,7 @@ void recv_plrinfo(int pnum, const TCmdPlrInfoHdr &header, bool recv)
 		return;
 	}
 
-	if (player._pHitPoints >> 6 > 0) {
+	if (player.IsAlive()) {
 		StartStand(player, Direction::South);
 		return;
 	}

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1758,7 +1758,7 @@ void UpdateBurningCrossDamage(Object &cross)
 		return;
 
 	ApplyPlrDamage(DamageType::Fire, myPlayer, 0, 0, damage[leveltype - 1]);
-	if (myPlayer._pHitPoints >> 6 > 0) {
+	if (myPlayer.IsAlive()) {
 		myPlayer.Say(HeroSpeech::Argh);
 	}
 }

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -175,7 +175,7 @@ void StartWalkAnimation(Player &player, Direction dir, bool pmWillBeCalled)
  */
 void StartWalk(Player &player, Direction dir, bool pmWillBeCalled)
 {
-	if (player._pInvincible && player._pHitPoints == 0 && &player == MyPlayer) {
+	if (player._pInvincible && !player.IsAlive() && &player == MyPlayer) {
 		SyncPlrKill(player, DeathReason::Unknown);
 		return;
 	}
@@ -193,7 +193,7 @@ void ClearStateVariables(Player &player)
 
 void StartAttack(Player &player, Direction d, bool includesFirstFrame)
 {
-	if (player._pInvincible && player._pHitPoints == 0 && &player == MyPlayer) {
+	if (player._pInvincible && !player.IsAlive() && &player == MyPlayer) {
 		SyncPlrKill(player, DeathReason::Unknown);
 		return;
 	}
@@ -236,7 +236,7 @@ void StartAttack(Player &player, Direction d, bool includesFirstFrame)
 
 void StartRangeAttack(Player &player, Direction d, WorldTileCoord cx, WorldTileCoord cy, bool includesFirstFrame)
 {
-	if (player._pInvincible && player._pHitPoints == 0 && &player == MyPlayer) {
+	if (player._pInvincible && !player.IsAlive() && &player == MyPlayer) {
 		SyncPlrKill(player, DeathReason::Unknown);
 		return;
 	}
@@ -276,7 +276,7 @@ player_graphic GetPlayerGraphicForSpell(SpellID spellId)
 
 void StartSpell(Player &player, Direction d, WorldTileCoord cx, WorldTileCoord cy)
 {
-	if (player._pInvincible && player._pHitPoints == 0 && &player == MyPlayer) {
+	if (player._pInvincible && !player.IsAlive() && &player == MyPlayer) {
 		SyncPlrKill(player, DeathReason::Unknown);
 		return;
 	}
@@ -1171,7 +1171,7 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 	case ACTION_RATTACKPLR:
 	case ACTION_SPELLPLR:
 		target = &Players[targetId];
-		if ((target->_pHitPoints >> 6) <= 0) {
+		if (!target->IsAlive()) {
 			player.Stop();
 			return;
 		}
@@ -2161,7 +2161,7 @@ void InitPlayerGFX(Player &player)
 
 	ResetPlayerGFX(player);
 
-	if (player._pHitPoints >> 6 == 0) {
+	if (!player.IsAlive()) {
 		player._pgfxnum &= ~0xFU;
 		LoadPlrGFX(player, player_graphic::Death);
 		return;
@@ -2433,7 +2433,7 @@ void NextPlrLevel(Player &player)
 
 void AddPlrExperience(Player &player, int lvl, int exp)
 {
-	if (&player != MyPlayer || player._pHitPoints <= 0)
+	if (&player != MyPlayer || !player.IsAlive())
 		return;
 
 	if (player._pLevel >= MaxCharacterLevel) {
@@ -2512,7 +2512,7 @@ void InitPlayer(Player &player, bool firstTime)
 
 		ClearStateVariables(player);
 
-		if (player._pHitPoints >> 6 > 0) {
+		if (player.IsAlive()) {
 			player._pmode = PM_STAND;
 			NewPlrAnim(player, player_graphic::Stand, Direction::South);
 			player.AnimInfo.currentFrame = GenerateRnd(player._pNFrames - 1);
@@ -2603,7 +2603,7 @@ void FixPlayerLocation(Player &player, Direction bDir)
 
 void StartStand(Player &player, Direction dir)
 {
-	if (player._pInvincible && player._pHitPoints == 0 && &player == MyPlayer) {
+	if (player._pInvincible && !player.IsAlive() && &player == MyPlayer) {
 		SyncPlrKill(player, DeathReason::Unknown);
 		return;
 	}
@@ -2618,7 +2618,7 @@ void StartStand(Player &player, Direction dir)
 
 void StartPlrBlock(Player &player, Direction dir)
 {
-	if (player._pInvincible && player._pHitPoints == 0 && &player == MyPlayer) {
+	if (player._pInvincible && !player.IsAlive() && &player == MyPlayer) {
 		SyncPlrKill(player, DeathReason::Unknown);
 		return;
 	}
@@ -2652,7 +2652,7 @@ void FixPlrWalkTags(const Player &player)
 
 void StartPlrHit(Player &player, int dam, bool forcehit)
 {
-	if (player._pInvincible && player._pHitPoints == 0 && &player == MyPlayer) {
+	if (player._pInvincible && !player.IsAlive() && &player == MyPlayer) {
 		SyncPlrKill(player, DeathReason::Unknown);
 		return;
 	}
@@ -2696,7 +2696,7 @@ __attribute__((no_sanitize("shift-base")))
 void
 StartPlayerKill(Player &player, DeathReason deathReason)
 {
-	if (player._pHitPoints <= 0 && player._pmode == PM_DEATH) {
+	if (!player.IsAlive() && player._pmode == PM_DEATH) {
 		return;
 	}
 
@@ -2860,14 +2860,14 @@ void ApplyPlrDamage(DamageType damageType, Player &player, int dam, int minHP /*
 	if (player._pHitPoints < minHitPoints) {
 		SetPlayerHitPoints(player, minHitPoints);
 	}
-	if (player._pHitPoints >> 6 <= 0) {
+	if (!player.IsAlive()) {
 		SyncPlrKill(player, deathReason);
 	}
 }
 
 void SyncPlrKill(Player &player, DeathReason deathReason)
 {
-	if (player._pHitPoints <= 0 && leveltype == DTYPE_TOWN) {
+	if (!player.IsAlive() && leveltype == DTYPE_TOWN) {
 		SetPlayerHitPoints(player, 64);
 		return;
 	}
@@ -3026,7 +3026,7 @@ void ProcessPlayers()
 		if (player.plractive && player.isOnActiveLevel() && (&player == MyPlayer || !player._pLvlChanging)) {
 			CheckCheatStats(player);
 
-			if (!PlrDeathModeOK(player) && (player._pHitPoints >> 6) <= 0) {
+			if (!PlrDeathModeOK(player) && !player.IsAlive()) {
 				SyncPlrKill(player, DeathReason::Unknown);
 			}
 
@@ -3105,7 +3105,7 @@ bool PosOkPlayer(const Player &player, Point position)
 		return false;
 	if (dPlayer[position.x][position.y] != 0) {
 		auto &otherPlayer = Players[abs(dPlayer[position.x][position.y]) - 1];
-		if (&otherPlayer != &player && otherPlayer._pHitPoints != 0) {
+		if (&otherPlayer != &player && otherPlayer.IsAlive()) {
 			return false;
 		}
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -730,7 +730,7 @@ bool PlrHitMonst(Player &player, Monster &monster, bool adjacentDamage = false)
 		}
 		RedrawComponent(PanelDrawComponent::Health);
 	}
-	if ((monster.hitPoints >> 6) <= 0) {
+	if (!monster.IsAlive()) {
 		M_StartKill(monster, player);
 	} else {
 		if (monster.mode != MonsterMode::Petrified && HasAnyOf(player._pIFlags, ItemSpecialEffect::Knockback))
@@ -1160,7 +1160,7 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 	case ACTION_RATTACKMON:
 	case ACTION_SPELLMON:
 		monster = &Monsters[targetId];
-		if ((monster->hitPoints >> 6) <= 0) {
+		if (!monster->IsAlive()) {
 			player.Stop();
 			return;
 		}
@@ -3117,7 +3117,7 @@ bool PosOkPlayer(const Player &player, Point position)
 		if (dMonster[position.x][position.y] <= 0) {
 			return false;
 		}
-		if ((Monsters[dMonster[position.x][position.y] - 1].hitPoints >> 6) > 0) {
+		if (Monsters[dMonster[position.x][position.y] - 1].IsAlive()) {
 			return false;
 		}
 	}

--- a/Source/player.h
+++ b/Source/player.h
@@ -656,6 +656,11 @@ struct Player {
 		return _pManaPer;
 	}
 
+	bool IsAlive() const
+	{
+		return _pHitPoints > 0;
+	}
+
 	/**
 	 * @brief Restores between 1/8 (inclusive) and 1/4 (exclusive) of the players max HP (further adjusted by class).
 	 *

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -458,7 +458,7 @@ uint16_t CheckStashHLight(Point mousePosition)
 
 bool UseStashItem(uint16_t c)
 {
-	if (MyPlayer->_pInvincible && MyPlayer->_pHitPoints == 0)
+	if (MyPlayer->_pInvincible && !MyPlayer->IsAlive())
 		return true;
 	if (pcurs != CURSOR_HAND)
 		return true;
@@ -608,7 +608,7 @@ void WithdrawGoldKeyPress(SDL_Keycode vkey)
 {
 	Player &myPlayer = *MyPlayer;
 
-	if (myPlayer._pHitPoints >> 6 <= 0) {
+	if (!myPlayer.IsAlive()) {
 		CloseGoldWithdraw();
 		return;
 	}

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -241,7 +241,7 @@ void DoResurrect(size_t pnum, Player &target)
 
 	AddMissile(target.position.tile, target.position.tile, Direction::South, MissileID::ResurrectBeam, TARGET_MONSTERS, pnum, 0, 0);
 
-	if (target._pHitPoints != 0)
+	if (target.IsAlive())
 		return;
 
 	if (&target == MyPlayer) {
@@ -262,7 +262,6 @@ void DoResurrect(size_t pnum, Player &target)
 	}
 	SetPlayerHitPoints(target, hp);
 
-	target._pHPBase = target._pHitPoints + (target._pMaxHPBase - target._pMaxHP); // CODEFIX: does the same stuff as SetPlayerHitPoints above, can be removed
 	target._pMana = 0;
 	target._pManaBase = target._pMana + (target._pMaxManaBase - target._pMaxMana);
 
@@ -277,7 +276,7 @@ void DoResurrect(size_t pnum, Player &target)
 
 void DoHealOther(const Player &caster, Player &target)
 {
-	if ((target._pHitPoints >> 6) <= 0) {
+	if (!target.IsAlive()) {
 		return;
 	}
 

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -154,7 +154,7 @@ void SyncMonster(bool isOwner, const TSyncMonster &monsterSync)
 {
 	const int monsterId = monsterSync._mndx;
 	Monster &monster = Monsters[monsterId];
-	if (monster.hitPoints <= 0 || monster.mode == MonsterMode::Death) {
+	if (!monster.IsAlive() || monster.mode == MonsterMode::Death) {
 		return;
 	}
 
@@ -225,7 +225,7 @@ bool IsEnemyIdValid(const Monster &monster, int enemyId)
 		return false;
 	}
 
-	if (enemy.hitPoints <= 0) {
+	if (!enemy.IsAlive()) {
 		return false;
 	}
 

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -39,7 +39,7 @@ void InvalidateTargets()
 {
 	if (pcursmonst != -1) {
 		const Monster &monster = Monsters[pcursmonst];
-		if (monster.isInvalid || monster.hitPoints >> 6 <= 0
+		if (monster.isInvalid || !monster.IsAlive()
 		    || (monster.flags & MFLAG_HIDDEN) != 0
 		    || !IsTileLit(monster.position.tile)) {
 			pcursmonst = -1;

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -52,7 +52,7 @@ void InvalidateTargets()
 	if (pcursplr != -1) {
 		Player &targetPlayer = Players[pcursplr];
 		if (targetPlayer._pmode == PM_DEATH || targetPlayer._pmode == PM_QUIT || !targetPlayer.plractive
-		    || !targetPlayer.isOnActiveLevel() || targetPlayer._pHitPoints >> 6 <= 0
+		    || !targetPlayer.isOnActiveLevel() || !targetPlayer.IsAlive()
 		    || !IsTileLit(targetPlayer.position.tile))
 			pcursplr = -1;
 	}


### PR DESCRIPTION
Unifies checking if a monster/player is alive - before this change I've set monster hp to 63 and disabled regen - they were unselectable and unkillable but other than that 100% alive - killed my char 😢 