### PR TITLE
Change InitMissileGFX()

### DIFF
--- a/Source/misdat.cpp
+++ b/Source/misdat.cpp
@@ -311,7 +311,7 @@ void InitMissileGFX(bool loadHellfireGraphics)
 		return;
 
 	for (size_t mi = 0; MissileSpriteData[mi].animFAmt != 0; mi++) {
-		if (!loadHellfireGraphics && mi > static_cast<uint8_t>(MissileGraphicID::BloodStarRedExplosion))
+		if (!loadHellfireGraphics && mi >= static_cast<uint8_t>(MissileGraphicID::HorkSpawn))
 			break;
 		if (MissileSpriteData[mi].flags == MissileGraphicsFlags::MonsterOwned)
 			continue;


### PR DESCRIPTION
Minor change for ease of modding, so adding missile graphics doesn't require the modder to change this line each time they want to add a missile graphic in D1 when adding lines between the last D1 graphic and first Hellfire graphic.