### PR TITLE
[Xbox One] Use recursive wildcard to reference assets in subfolders

### DIFF
--- a/uwp-project/devilutionx.vcxproj
+++ b/uwp-project/devilutionx.vcxproj
@@ -127,7 +127,7 @@
       <DeploymentContent>true</DeploymentContent>
       <Link>Assets\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </None>
-    <None Include="..\build\assets\*\*.*">
+    <None Include="..\build\assets\**\*.*">
       <DeploymentContent>true</DeploymentContent>
       <Link>Assets\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </None>


### PR DESCRIPTION
Fixes an error with the UWP build that was shared on the Discord today.

![image](https://github.com/diasurgical/devilutionX/assets/9203145/fe1a6f8f-ef41-4b2a-b3d2-eb05b8acdcc7)