### PR TITLE
Fix Spanish "al" cases and Blood Knight name

### DIFF
--- a/Translations/es.po
+++ b/Translations/es.po
@@ -4822,7 +4822,7 @@ msgstr "Sube al nivel {:d}"
 #: Source/levels/trigs.cpp:637 Source/levels/trigs.cpp:686
 #: Source/levels/trigs.cpp:793
 msgid "Up to town"
-msgstr "Subir a el pueblo"
+msgstr "Sube al pueblo"
 
 #: Source/levels/trigs.cpp:425 Source/levels/trigs.cpp:458
 #: Source/levels/trigs.cpp:510 Source/levels/trigs.cpp:557
@@ -5305,7 +5305,7 @@ msgstr "Señor de Acero"
 #: Source/monstdat.cpp:127
 msgctxt "monster"
 msgid "Blood Knight"
-msgstr "Caballero deSangre"
+msgstr "Caballero de Sangre"
 
 #: Source/monstdat.cpp:128
 msgctxt "monster"
@@ -7490,7 +7490,7 @@ msgstr "Muro de Fuego"
 #: Source/spelldat.cpp:22
 msgctxt "spell"
 msgid "Town Portal"
-msgstr "Portal a el pueblo"
+msgstr "Portal al pueblo"
 
 #: Source/spelldat.cpp:23
 msgctxt "spell"


### PR DESCRIPTION
Some cases of "a el" should be contracted into "al". Blood Knight's translation of "deSangre" should separate "de" and "Sangre".

I am not a native speaker of Spanish, so a native speaker should also review these changes, if necessary.