### PR TITLE
dont show hit indicator for 1 player

### DIFF
--- a/Source/qol/monhealthbar.cpp
+++ b/Source/qol/monhealthbar.cpp
@@ -157,14 +157,16 @@ void DrawMonsterHealthBar(const Surface &out)
 		}
 	}
 
-	int tagOffset = 5;
-	for (size_t i = 0; i < Players.size(); i++) {
-		if (((1U << i) & monster.whoHit) != 0) {
-			RenderClxSprite(out, (*playerExpTags)[i + 1], position + Displacement { tagOffset, height - 31 });
-		} else if (Players[i].plractive) {
-			RenderClxSprite(out, (*playerExpTags)[0], position + Displacement { tagOffset, height - 31 });
+	if (Players.size() > 1) {
+		int tagOffset = 5;
+		for (size_t i = 0; i < Players.size(); i++) {
+			if (((1U << i) & monster.whoHit) != 0) {
+				RenderClxSprite(out, (*playerExpTags)[i + 1], position + Displacement { tagOffset, height - 31 });
+			} else if (Players[i].plractive) {
+				RenderClxSprite(out, (*playerExpTags)[0], position + Displacement { tagOffset, height - 31 });
+			}
+			tagOffset += (*playerExpTags)[0].width();
 		}
-		tagOffset += (*playerExpTags)[0].width();
 	}
 }
 


### PR DESCRIPTION
No reason to show it when there's only 1 player in game - if you kill the monster, we know you will get xp :D

Before:
![image](https://github.com/diasurgical/devilutionX/assets/14297035/4379861e-1e2f-4286-bec5-aaab1402b8a5)

After:
![image](https://github.com/diasurgical/devilutionX/assets/14297035/6bd68607-3669-4604-9921-9fc814364bc7)


Diff with hidden whitespaces:
![image](https://github.com/diasurgical/devilutionX/assets/14297035/f837b764-302e-4e81-b947-985202ad4d0e)
