### PR TITLE
Don't extrapolate missile position in collision interpolation logic

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -503,14 +503,23 @@ bool MoveMissile(Missile &missile, tl::function_ref<bool(Point)> checkTile, bool
 		if (incVelocity.deltaX != 0)
 			traveled.deltaX = (traveled.deltaX / incVelocity.deltaX) * incVelocity.deltaX;
 		do {
+			auto initialDiff = missile.position.traveled - traveled;
 			traveled += incVelocity;
+			auto incDiff = missile.position.traveled - traveled;
+
+			// we are at the original calculated position => resume with normal logic
+			if ((initialDiff.deltaX < 0) != (incDiff.deltaX < 0))
+				break;
+			if ((initialDiff.deltaY < 0) != (incDiff.deltaY < 0))
+				break;
 
 			// calculate in-between tile
 			Displacement pixelsTraveled = traveled >> 16;
 			Displacement tileOffset = pixelsTraveled.screenToMissile();
 			Point tile = missile.position.start + tileOffset;
 
-			// we are at the original calculated position => resume with normal logic
+			// we haven't quite reached the missile's current position,
+			// but we can break early to avoid checking collisions in this tile twice
 			if (tile == missile.position.tile)
 				break;
 


### PR DESCRIPTION
This resolves an issue where slvl 18 Fireball was sometimes disappearing partway across the player's screen.

Demonstration of the issue (right around 10 seconds):

https://github.com/diasurgical/devilutionX/assets/9203145/6865ebe1-3309-4655-ad38-07d83815b0e1

> It looks like, if you count 9 tiles SE of the player and then 1 tile SW from there, casting Fireball will get a path for the missile that, after traversing 5 half-tiles south of its starting position, will have traversed almost exactly 4 half-tiles east as well. It's like 0.002 pixels away from the corner between four tiles.
> 
> At the velocity of an slvl 18 Fireball, this causes a rounding error right around that point where the missile thinks it's occupying the tile SW of fourth tile SE of the player, but the missile collision interpolation logic slips directly from the fourth tile SE of the player to the tile SW of the fifth tile SE of the player.
> 
> Since the collision interpolation logic computes a path that doesn't pass through the tile that the missile thinks it's on, the interpolation logic will just keep on going assuming it hasn't reached the missile's position yet. Therefore, the missile immediately collides with whatever is at the end of the path that the interpolation logic computed.

After more detailed analysis...

> At the point where the missile has traveled 78 pixels south, it mathematically should have traveled 124.802438738422 east.
If you truncate that result to (124,78) and compute tile coordinates, you get (4.875,1). If instead you don't truncate and compute tile coordinates using fractional pixels, you get (4.8875381053,0.9874618947).
> 
> The first one truncates to (4,1) and the second one truncates to (4,0). That explains the discrepancy between the missile's actual position and the interpolation logic. Interpolation is correctly deducing mathematically that the missile shouldn't be traveling through (4,1) at all, but the missile itself is truncating 0.8 pixels from the x value of its position and placing it in the wrong tile.

The solution here just adds some additional logic to detect whether the interpolated position has become an extrapolated position. With this additional logic, we don't depend on the computed tile coordinates to determine whether we have reached or exceeded the actual position of the missile.