### PR TITLE
Fix missiles passing through enemies on SW/NE diagonal

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -526,7 +526,7 @@ bool MoveMissile(Missile &missile, tl::function_ref<bool(Point)> checkTile, bool
 			// skip collision logic if the missile is on a corner between tiles
 			if (pixelsTraveled.deltaY % 16 == 0
 			    && pixelsTraveled.deltaX % 32 == 0
-			    && (pixelsTraveled.deltaY / 16) % 2 != (pixelsTraveled.deltaX / 32) % 2) {
+			    && abs(pixelsTraveled.deltaY / 16) % 2 != abs(pixelsTraveled.deltaX / 32) % 2) {
 				continue;
 			}
 


### PR DESCRIPTION
In this case, at the speed of an slvl 17 Firebolt or Fireball, the missile would skip over the tile at a distance of 5 from the player. Interpolation logic should kick in and detect the collision in the skipped tile, but in this particular case it did not.

Demonstration of the bug:

https://github.com/diasurgical/devilutionX/assets/9203145/74a5e799-85a8-41f6-ba8e-34a543fc45ed

The analysis is much simpler this time. The logic to determine if the missile is on a corner between tiles checks to see if the missile has moved by an odd number of half-tiles. The logic uses mod 2 on both the x and y components of the missile's displacement to compare them. But if the missile's displacement is negative, the remainder is also negative so the comparison isn't valid when the two components of displacement don't have the same sign. Taking the absolute value of both sides is a straightforward way to resolve this.