### PR TITLE
RNG fixes for dungeon generation that don't break timedemo

### DIFF
--- a/Source/engine/random.cpp
+++ b/Source/engine/random.cpp
@@ -27,16 +27,23 @@ uint32_t GetLCGEngineState()
 
 void DiscardRandomValues(unsigned count)
 {
-	while (count != 0) {
-		GenerateSeed();
-		count--;
-	}
+	if (count > 1)
+		diabloGenerator.discard(count - 1);
+	if (count > 0)
+		sglGameSeed = diabloGenerator();
 }
 
 uint32_t GenerateSeed()
 {
 	sglGameSeed = diabloGenerator();
 	return sglGameSeed;
+}
+
+uint32_t AllocateRandomSequence(unsigned count)
+{
+	uint32_t seed = GenerateSeed();
+	DiscardRandomValues(count);
+	return seed;
 }
 
 int32_t AdvanceRndSeed()

--- a/Source/engine/random.hpp
+++ b/Source/engine/random.hpp
@@ -40,7 +40,18 @@ void DiscardRandomValues(unsigned count);
 /**
  * @brief Advances the global RandomNumberEngine state and returns the new value
  */
-uint32_t GenerateSeed();
+[[nodiscard]] uint32_t GenerateSeed();
+
+/**
+ * @brief Provides the seed value for a sequence of random numbers of predetermined size
+ *
+ * This advances the engine state of the random number generator by count+1 rounds to ensure that
+ * subsequently generated random numbers will not overlap with the allocated sequence.
+ *
+ * @param count The size of the random number sequence to be allocated
+ * @return The seed for the allocated sequence of random numbers
+ */
+[[nodiscard]] uint32_t AllocateRandomSequence(unsigned count);
 
 /**
  * @brief Generates a random non-negative integer (most of the time) using the vanilla RNG

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -787,7 +787,7 @@ bool NetInit(bool bSinglePlayer)
 	gnTickDelay = 1000 / sgGameInitInfo.nTickRate;
 
 	for (int i = 0; i < NUMLEVELS; i++) {
-		glSeedTbl[i] = AdvanceRndSeed();
+		glSeedTbl[i] = AllocateRandomSequence(10000);
 	}
 	PublicGame = DvlNet_IsPublicGame();
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1484,9 +1484,7 @@ void AddPedestalOfBlood(Object &pedestalOfBlood)
 
 void AddStoryBook(Object &storyBook)
 {
-	SetRndSeed(glSeedTbl[16]);
-
-	storyBook._oVar1 = GenerateRnd(3);
+	storyBook._oVar1 = (glSeedTbl[16] >> 16) % 3;
 	if (currlevel == 4)
 		storyBook._oVar2 = StoryText[storyBook._oVar1][0];
 	else if (currlevel == 8)


### PR DESCRIPTION
The idea here is to implement the strategy described in https://github.com/diasurgical/devilution/issues/64#issuecomment-1535561455 for reserving space in the RNG sequence. However, using it for object seeds would break timedemo in a couple different ways so I'm saving that for another PR. I decided that changing the level seeds would be pretty harmless since these are captured in SP save files directly so the change should only affect newly created game sessions.

Additional notes:
* Based on my testing, I've seen the game use anywhere from around 1500 to over 6000 random values to generate monsters and objects during dungeon generation before the next call to `SetRndSeed()` that occurs in `InitItems()`. Since I can't exhaustively test all possible dungeon seeds, I went with 10k because it's quite a bit bigger than 6k without being excessively large.
* It seems it's actually pretty common for the dungeon generation algorithm to burn through hundreds of thousands of random numbers right around the call to `CreateLevel()`. The highest number I saw was around 480k. However, I think the sky is the limit on this one because `GenerateLevel()` will often go through hundreds of attempts to generate the dungeon layout before settling on one, so I decided not to take this phase of level generation into account when allocating space for the level seeds. There may still be some overlap between dungeon levels here, but I doubt there will be any noticeable effects of it.
* `AllocateRandomSequence()` uses `GenerateSeed()` to produce a seed value from the raw engine state. Dungeon levels will no longer be seeded by the random numbers from `AdvanceRndSeed()` to which `std::abs()` has been applied. This is important for avoiding overlapping RNG sequences because `std::abs()` was basically replacing the current random sequence for another one arbitrarily, and it would be infeasible to determine whether the new sequence overlaps with the old one.
* The technique used in `AddStoryBook()` mirrors the fix used in #3314. Avoiding this call to `SetRndSeed()` prevents RNG sequence overlap between dlvls 4, 8, 12, and 16.

This resolves #6261