### PR TITLE
Fix PVP Bow damage

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -360,8 +360,10 @@ bool Plr2PlrMHit(const Player &player, Player &target, int mindam, int maxdam, i
 		dam = target._pHitPoints / 3;
 	} else {
 		dam = RandomIntBetween(mindam, maxdam);
-		if (missileData.isArrow() && damageType == DamageType::Physical)
-			dam += player._pIBonusDamMod + player._pDamageMod + dam * player._pIBonusDam / 100;
+		if (missileData.isArrow() && damageType == DamageType::Physical) {
+			int damMod = IsAnyOf(player._pClass, HeroClass::Rogue) ? player._pDamageMod : player._pDamageMod / 2;
+			dam += player._pIBonusDamMod + damMod + dam * player._pIBonusDam / 100;
+		}
 		if (!shift)
 			dam <<= 6;
 	}


### PR DESCRIPTION
Wasn't sure how to write a title for this one. The player's base damage while holding a bow is modified by cutting the base player damage in half if the hero is not a Rogue. This applies to the character panel damage, and against monsters. The code for this is missing in the `Plr2PlrMHit()` function, causing no base damage reduction for non-Rogue heroes. There is no evidence that this is an oversight other than speculation, however I believe this adds consistency. There is also no evidence in favor of no damage reduction for PVP, as this is only a result of missing code, and there is no code that deliberately gives more damage to non-Rogue heroes in PVP.