### PR TITLE
Sync potion drops from Divine shrine

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2726,11 +2726,11 @@ void OperateShrineDivine(Player &player, Point spawnPosition)
 		return;
 
 	if (currlevel < 4) {
-		CreateTypeItem(spawnPosition, false, ItemType::Misc, IMISC_FULLMANA, false, true);
-		CreateTypeItem(spawnPosition, false, ItemType::Misc, IMISC_FULLHEAL, false, true);
+		CreateTypeItem(spawnPosition, false, ItemType::Misc, IMISC_FULLMANA, false, false, true);
+		CreateTypeItem(spawnPosition, false, ItemType::Misc, IMISC_FULLHEAL, false, false, true);
 	} else {
-		CreateTypeItem(spawnPosition, false, ItemType::Misc, IMISC_FULLREJUV, false, true);
-		CreateTypeItem(spawnPosition, false, ItemType::Misc, IMISC_FULLREJUV, false, true);
+		CreateTypeItem(spawnPosition, false, ItemType::Misc, IMISC_FULLREJUV, false, false, true);
+		CreateTypeItem(spawnPosition, false, ItemType::Misc, IMISC_FULLREJUV, false, false, true);
 	}
 
 	player._pMana = player._pMaxMana;


### PR DESCRIPTION
Syncs the potion drops from Divine shrines using the `spawn` flag to trigger `CMD_SPAWNITEM`, instead of using the `delta` flag. `CMD_SPAWNITEM` takes the necessary steps to ensure the item gets dropped on the ground and added to deltas on remote clients.

The `delta` flag only ensures that the item is added to the deltas on the local client. This flag should be used exclusively for items that are placed on the ground during dungeon generation, such as treasure rooms and monster pits.

This resolves #6446

_Note: One might be tempted to use the `delta` flag and instead rely on `SyncOpObject()` to invoke `CreateTypeItem()` on every client, using the object seed to keep things in sync. But this would only work if all players are on the same dungeon level. Players on other dungeon levels would use the wrong `currlevel` value in `CreateTypeItem()` and also wouldn't know what the object seed is in the first place. Better to just sync the items themselves._