### PR TITLE
Prevent monsters from standing idle in feared element

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1676,7 +1676,7 @@ bool IsTileSafe(const Monster &monster, Point position)
 	const bool fearsFire = (monster.resistance & IMMUNE_FIRE) == 0 || monster.type().type == MT_DIABLO;
 	const bool fearsLightning = (monster.resistance & IMMUNE_LIGHTNING) == 0 || monster.type().type == MT_DIABLO;
 
-	bool isInFire= HasAnyOf(dFlags[monster.position.tile.x][monster.position.tile.y], DungeonFlag::MissileFireWall);
+	bool isInFire = HasAnyOf(dFlags[monster.position.tile.x][monster.position.tile.y], DungeonFlag::MissileFireWall);
 	bool isInLightning = HasAnyOf(dFlags[monster.position.tile.x][monster.position.tile.y], DungeonFlag::MissileLightningWall);
 
 	if ((fearsFire && isInFire) || (fearsLightning && isInLightning))

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1676,10 +1676,10 @@ bool IsTileSafe(const Monster &monster, Point position)
 	const bool fearsFire = (monster.resistance & IMMUNE_FIRE) == 0 || monster.type().type == MT_DIABLO;
 	const bool fearsLightning = (monster.resistance & IMMUNE_LIGHTNING) == 0 || monster.type().type == MT_DIABLO;
 
-	bool isInFireTile = HasAnyOf(dFlags[monster.position.tile.x][monster.position.tile.y], DungeonFlag::MissileFireWall);
-	bool isInLightningTile = HasAnyOf(dFlags[monster.position.tile.x][monster.position.tile.y], DungeonFlag::MissileLightningWall);
+	bool isInFire= HasAnyOf(dFlags[monster.position.tile.x][monster.position.tile.y], DungeonFlag::MissileFireWall);
+	bool isInLightning = HasAnyOf(dFlags[monster.position.tile.x][monster.position.tile.y], DungeonFlag::MissileLightningWall);
 
-	if ((fearsFire && isInFireTile) || (fearsLightning && isInLightningTile))
+	if ((fearsFire && isInFire) || (fearsLightning && isInLightning))
 		return true;
 
 	return !(fearsFire && HasAnyOf(dFlags[position.x][position.y], DungeonFlag::MissileFireWall))

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1676,6 +1676,12 @@ bool IsTileSafe(const Monster &monster, Point position)
 	const bool fearsFire = (monster.resistance & IMMUNE_FIRE) == 0 || monster.type().type == MT_DIABLO;
 	const bool fearsLightning = (monster.resistance & IMMUNE_LIGHTNING) == 0 || monster.type().type == MT_DIABLO;
 
+	bool isInFireTile = HasAnyOf(dFlags[monster.position.tile.x][monster.position.tile.y], DungeonFlag::MissileFireWall);
+	bool isInLightningTile = HasAnyOf(dFlags[monster.position.tile.x][monster.position.tile.y], DungeonFlag::MissileLightningWall);
+
+	if ((fearsFire && isInFireTile) || (fearsLightning && isInLightningTile))
+		return true;
+
 	return !(fearsFire && HasAnyOf(dFlags[position.x][position.y], DungeonFlag::MissileFireWall))
 	    && !(fearsLightning && HasAnyOf(dFlags[position.x][position.y], DungeonFlag::MissileLightningWall));
 }


### PR DESCRIPTION
This allows monsters to treat tiles with feared elements as safe, if the monster is already standing in a tile with the feared element.

I chose this route as opposed to reworking monster AIs, since I believe changing the AI of monsters to allow them to behave differently (such as walking away from the player when this previously was never an option for them), is against the scope of the project. This change does not put the monster in more peril than it previously was, and adds difficulty for the player.