### PR TITLE
Remove some utils/stdcompat/ headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,8 +294,8 @@ if(GPERF)
 endif()
 
 # Despite setting C++ standard to 20, features from this version are not being used.
-# The oldest compiler used is GCC 6.5 - and that defines our C++ feature set (meaning most of C++17).
-# It's present only to take advantage of fmt::format build time errors.
+# DevilutionX is compatible with C++ 17.
+# Here we set it to 20 only to take advantage of the fmt::format build time errors.
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED OFF)

--- a/Source/DiabloUI/diabloui.h
+++ b/Source/DiabloUI/diabloui.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <SDL.h>
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 
+#include <SDL.h>
 #include <function_ref.hpp>
 
 #include "DiabloUI/ui_item.h"
@@ -12,7 +13,6 @@
 #include "engine/load_pcx.hpp" // IWYU pragma: export
 #include "player.h"
 #include "utils/display.h"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/DiabloUI/multi/selgame.cpp
+++ b/Source/DiabloUI/multi/selgame.cpp
@@ -244,16 +244,16 @@ void selgame_GameSelection_Focus(int value)
 			infoString += '\n';
 			switch (gameInfo.gameData.nTickRate) {
 			case 20:
-				AppendStrView(infoString, _("Speed: Normal"));
+				infoString.append(_("Speed: Normal"));
 				break;
 			case 30:
-				AppendStrView(infoString, _("Speed: Fast"));
+				infoString.append(_("Speed: Fast"));
 				break;
 			case 40:
-				AppendStrView(infoString, _("Speed: Faster"));
+				infoString.append(_("Speed: Faster"));
 				break;
 			case 50:
-				AppendStrView(infoString, _("Speed: Fastest"));
+				infoString.append(_("Speed: Fastest"));
 				break;
 			default:
 				// This should not occure, so no translations is needed
@@ -261,7 +261,7 @@ void selgame_GameSelection_Focus(int value)
 				break;
 			}
 			infoString += '\n';
-			AppendStrView(infoString, _("Players: "));
+			infoString.append(_("Players: "));
 			for (auto &playerName : gameInfo.players) {
 				infoString.append(playerName);
 				infoString += ' ';

--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -1,6 +1,7 @@
 #include "selstart.h"
 
 #include <cstdint>
+#include <optional>
 
 #include <function_ref.hpp>
 
@@ -14,7 +15,6 @@
 #include "hwcursor.hpp"
 #include "options.h"
 #include "utils/language.h"
-#include "utils/stdcompat/optional.hpp"
 #include "utils/utf8.hpp"
 
 namespace devilution {

--- a/Source/DiabloUI/title.cpp
+++ b/Source/DiabloUI/title.cpp
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "DiabloUI/diabloui.h"
 #include "control.h"
 #include "controls/input.h"
@@ -8,7 +10,6 @@
 #include "utils/algorithm/container.hpp"
 #include "utils/language.h"
 #include "utils/sdl_geometry.h"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 namespace {

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -5,6 +5,7 @@
  */
 #include "automap.h"
 
+#include <algorithm>
 #include <cstdint>
 
 #include <fmt/format.h>
@@ -17,7 +18,6 @@
 #include "levels/setmaps.h"
 #include "player.h"
 #include "utils/language.h"
-#include "utils/stdcompat/algorithm.hpp"
 #include "utils/ui_fwd.h"
 #include "utils/utf8.hpp"
 
@@ -480,7 +480,7 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 	AutomapTile tile = GetAutomapTypeView(map);
 	uint8_t colorBright = MapColorsBright;
 	uint8_t colorDim = MapColorsDim;
-	MapExplorationType explorationType = static_cast<MapExplorationType>(AutomapView[clamp(map.x, 0, DMAXX - 1)][clamp(map.y, 0, DMAXY - 1)]);
+	MapExplorationType explorationType = static_cast<MapExplorationType>(AutomapView[std::clamp(map.x, 0, DMAXX - 1)][std::clamp(map.y, 0, DMAXY - 1)]);
 
 	switch (explorationType) {
 	case MAP_EXP_SHRINE:
@@ -593,11 +593,11 @@ void SearchAutomapItem(const Surface &out, const Displacement &myPlayerOffset, i
 			tile.y++;
 	}
 
-	const int startX = clamp(tile.x - searchRadius, 0, MAXDUNX);
-	const int startY = clamp(tile.y - searchRadius, 0, MAXDUNY);
+	const int startX = std::clamp(tile.x - searchRadius, 0, MAXDUNX);
+	const int startY = std::clamp(tile.y - searchRadius, 0, MAXDUNY);
 
-	const int endX = clamp(tile.x + searchRadius, 0, MAXDUNX);
-	const int endY = clamp(tile.y + searchRadius, 0, MAXDUNY);
+	const int endX = std::clamp(tile.x + searchRadius, 0, MAXDUNX);
+	const int endY = std::clamp(tile.y + searchRadius, 0, MAXDUNY);
 
 	for (int i = startX; i < endX; i++) {
 		for (int j = startY; j < endY; j++) {

--- a/Source/codec.cpp
+++ b/Source/codec.cpp
@@ -7,7 +7,6 @@
 #include "sha.h"
 #include "utils/endian.hpp"
 #include "utils/log.hpp"
-#include "utils/stdcompat/cstddef.hpp"
 
 namespace devilution {
 namespace {
@@ -53,7 +52,7 @@ SHA1Context CodecInitKey(const char *pszPassword)
 	return context;
 }
 
-CodecSignature GetCodecSignature(byte *src)
+CodecSignature GetCodecSignature(std::byte *src)
 {
 	CodecSignature result;
 	result.checksum = LoadLE32(src);
@@ -63,16 +62,16 @@ CodecSignature GetCodecSignature(byte *src)
 	return result;
 }
 
-void SetCodecSignature(byte *dst, CodecSignature sig)
+void SetCodecSignature(std::byte *dst, CodecSignature sig)
 {
-	*dst++ = static_cast<byte>(sig.checksum);
-	*dst++ = static_cast<byte>(sig.checksum >> 8);
-	*dst++ = static_cast<byte>(sig.checksum >> 16);
-	*dst++ = static_cast<byte>(sig.checksum >> 24);
-	*dst++ = static_cast<byte>(sig.error);
-	*dst++ = static_cast<byte>(sig.lastChunkSize);
-	*dst++ = static_cast<byte>(0);
-	*dst++ = static_cast<byte>(0);
+	*dst++ = static_cast<std::byte>(sig.checksum);
+	*dst++ = static_cast<std::byte>(sig.checksum >> 8);
+	*dst++ = static_cast<std::byte>(sig.checksum >> 16);
+	*dst++ = static_cast<std::byte>(sig.checksum >> 24);
+	*dst++ = static_cast<std::byte>(sig.error);
+	*dst++ = static_cast<std::byte>(sig.lastChunkSize);
+	*dst++ = static_cast<std::byte>(0);
+	*dst++ = static_cast<std::byte>(0);
 }
 
 void ByteSwapBlock(uint32_t *data)
@@ -89,7 +88,7 @@ void XorBlock(const uint32_t *shaResult, uint32_t *out)
 
 } // namespace
 
-std::size_t codec_decode(byte *pbSrcDst, std::size_t size, const char *pszPassword)
+std::size_t codec_decode(std::byte *pbSrcDst, std::size_t size, const char *pszPassword)
 {
 	uint32_t buf[BlockSize];
 	uint32_t dst[SHA1HashSize];
@@ -134,7 +133,7 @@ std::size_t codec_get_encoded_len(std::size_t dwSrcBytes)
 	return dwSrcBytes + SignatureSize;
 }
 
-void codec_encode(byte *pbSrcDst, std::size_t size, std::size_t size64, const char *pszPassword)
+void codec_encode(std::byte *pbSrcDst, std::size_t size, std::size_t size64, const char *pszPassword)
 {
 	uint32_t buf[BlockSize];
 	uint32_t tmp[SHA1HashSize];

--- a/Source/codec.h
+++ b/Source/codec.h
@@ -5,12 +5,12 @@
  */
 #pragma once
 
-#include "utils/stdcompat/cstddef.hpp"
+#include <cstddef>
 
 namespace devilution {
 
-std::size_t codec_decode(byte *pbSrcDst, std::size_t size, const char *pszPassword);
+std::size_t codec_decode(std::byte *pbSrcDst, std::size_t size, const char *pszPassword);
 std::size_t codec_get_encoded_len(std::size_t dwSrcBytes);
-void codec_encode(byte *pbSrcDst, std::size_t size, std::size_t size_64, const char *pszPassword);
+void codec_encode(std::byte *pbSrcDst, std::size_t size, std::size_t size_64, const char *pszPassword);
 
 } // namespace devilution

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -214,7 +214,7 @@ void DrawFlask(const Surface &out, const Surface &celBuf, Point sourcePosition, 
 void DrawFlaskUpper(const Surface &out, const Surface &sourceBuffer, int offset, int fillPer)
 {
 	// clamping because this function only draws the top 12% of the flask display
-	int emptyPortion = clamp(80 - fillPer, 0, 11) + 2; // +2 to account for the frame being included in the sprite
+	int emptyPortion = std::clamp(80 - fillPer, 0, 11) + 2; // +2 to account for the frame being included in the sprite
 
 	// Draw the empty part of the flask
 	DrawFlask(out, sourceBuffer, { 13, 3 }, GetMainPanel().position + Displacement { offset, -13 }, emptyPortion);
@@ -233,7 +233,7 @@ void DrawFlaskUpper(const Surface &out, const Surface &sourceBuffer, int offset,
  */
 void DrawFlaskLower(const Surface &out, const Surface &sourceBuffer, int offset, int fillPer)
 {
-	int filled = clamp(fillPer, 0, 69);
+	int filled = std::clamp(fillPer, 0, 69);
 
 	if (filled < 69)
 		DrawFlaskTop(out, GetMainPanel().position + Displacement { offset, 0 }, sourceBuffer, 16, 85 - filled);

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -9,6 +9,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <string>
 
 #include <fmt/format.h>
@@ -50,7 +51,6 @@
 #include "utils/log.hpp"
 #include "utils/parse_int.hpp"
 #include "utils/sdl_geometry.h"
-#include "utils/stdcompat/optional.hpp"
 #include "utils/str_case.hpp"
 #include "utils/str_cat.hpp"
 #include "utils/string_or_view.hpp"

--- a/Source/control.h
+++ b/Source/control.h
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 
 #include <SDL.h>
 
@@ -23,7 +24,6 @@
 #include "spelldat.h"
 #include "spells.h"
 #include "utils/attributes.h"
-#include "utils/stdcompat/optional.hpp"
 #include "utils/stdcompat/string_view.hpp"
 #include "utils/string_or_view.hpp"
 #include "utils/ui_fwd.h"

--- a/Source/controls/controller_motion.cpp
+++ b/Source/controls/controller_motion.cpp
@@ -48,7 +48,7 @@ void ScaleJoystickAxes(float *x, float *y, float deadzone)
 		analogX = (analogX * scalingFactor);
 		analogY = (analogY * scalingFactor);
 
-		// clamp to ensure results will never exceed the max_axis value
+		// std::clamp to ensure results will never exceed the max_axis value
 		float clampingFactor = 1.F;
 		float absAnalogX = std::fabs(analogX);
 		float absAnalogY = std::fabs(analogY);

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1,6 +1,7 @@
 #include "controls/plrctrls.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <list>
 
@@ -103,7 +104,7 @@ int GetRotaryDistance(Point destination)
 	int d1 = static_cast<int>(myPlayer._pdir);
 	int d2 = static_cast<int>(GetDirection(myPlayer.position.future, destination));
 
-	int d = abs(d1 - d2);
+	int d = std::abs(d1 - d2);
 	if (d > 4)
 		return 4 - (d % 4);
 
@@ -328,7 +329,7 @@ void FindMeleeTarget()
 				visited[dx][dy] = true;
 
 				if (dMonster[dx][dy] != 0) {
-					const int mi = abs(dMonster[dx][dy]) - 1;
+					const int mi = std::abs(dMonster[dx][dy]) - 1;
 					const auto &monster = Monsters[mi];
 					if (CanTargetMonster(monster)) {
 						const bool newCanTalk = CanTalkToMonst(monster);
@@ -666,7 +667,7 @@ Point GetSlotCoord(int slot)
 int GetItemIdOnSlot(int slot)
 {
 	if (slot >= SLOTXY_INV_FIRST && slot <= SLOTXY_INV_LAST) {
-		return abs(MyPlayer->InvGrid[slot - SLOTXY_INV_FIRST]);
+		return std::abs(MyPlayer->InvGrid[slot - SLOTXY_INV_FIRST]);
 	}
 
 	return 0;

--- a/Source/controls/touch/renderers.h
+++ b/Source/controls/touch/renderers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 
 #include <SDL.h>
 
@@ -9,7 +10,6 @@
 #include "engine/surface.hpp"
 #include "utils/png.h"
 #include "utils/sdl_ptrs.h"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -753,8 +753,8 @@ void CheckCursMove()
 		mx++;
 	}
 
-	mx = clamp(mx, 0, MAXDUNX - 1);
-	my = clamp(my, 0, MAXDUNY - 1);
+	mx = std::clamp(mx, 0, MAXDUNX - 1);
+	my = std::clamp(my, 0, MAXDUNY - 1);
 
 	const Point currentTile { mx, my };
 

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -373,9 +373,9 @@ bool TrySelectPixelBased(Point tile)
 			}
 		}
 
-		int playerId = dPlayer[adjacentTile.x][adjacentTile.y];
-		if (playerId != 0) {
-			playerId = std::abs(playerId) - 1;
+		const int8_t dPlayerValue = dPlayer[adjacentTile.x][adjacentTile.y];
+		if (dPlayerValue != 0) {
+			const uint8_t playerId = std::abs(dPlayerValue) - 1;
 			if (playerId != MyPlayerId) {
 				const Player &player = Players[playerId];
 				const ClxSprite sprite = player.currentSprite();
@@ -832,7 +832,7 @@ void CheckCursMove()
 			if (pcurstemp != -1 && TrySelectMonster(flipflag, currentTile, [](const Monster &monster) {
 				    if (!IsValidMonsterForSelection(monster))
 					    return false;
-				    if (monster.getId() != pcurstemp)
+				    if (monster.getId() != static_cast<unsigned>(pcurstemp))
 					    return false;
 				    return true;
 			    })) {

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -5,6 +5,7 @@
  */
 #include "cursor.h"
 
+#include <cmath>
 #include <cstdint>
 
 #include <fmt/format.h>
@@ -134,7 +135,7 @@ bool TrySelectMonster(bool flipflag, Point tile, tl::function_ref<bool(const Mon
 		Point posToCheck = tile + displacement;
 		if (!InDungeonBounds(posToCheck) || dMonster[posToCheck.x][posToCheck.y] == 0)
 			return;
-		const uint16_t monsterId = abs(dMonster[posToCheck.x][posToCheck.y]) - 1;
+		const uint16_t monsterId = std::abs(dMonster[posToCheck.x][posToCheck.y]) - 1;
 		const Monster &monster = Monsters[monsterId];
 		if (IsTileLit(posToCheck) && (monster.data().selectionType & selectionType) != 0 && isValidMonster(monster)) {
 			cursPosition = posToCheck;
@@ -162,7 +163,7 @@ bool TrySelectTowner(bool flipflag, Point tile)
 		Point posToCheck = tile + displacement;
 		if (!InDungeonBounds(posToCheck) || dMonster[posToCheck.x][posToCheck.y] == 0)
 			return;
-		const uint16_t monsterId = abs(dMonster[posToCheck.x][posToCheck.y]) - 1;
+		const uint16_t monsterId = std::abs(dMonster[posToCheck.x][posToCheck.y]) - 1;
 		cursPosition = posToCheck;
 		pcursmonst = monsterId;
 	};
@@ -178,7 +179,7 @@ bool TrySelectTowner(bool flipflag, Point tile)
 bool TrySelectPlayer(bool flipflag, int mx, int my)
 {
 	if (!flipflag && mx + 1 < MAXDUNX && dPlayer[mx + 1][my] != 0) {
-		const uint8_t playerId = abs(dPlayer[mx + 1][my]) - 1;
+		const uint8_t playerId = std::abs(dPlayer[mx + 1][my]) - 1;
 		Player &player = Players[playerId];
 		if (&player != MyPlayer && player._pHitPoints != 0) {
 			cursPosition = Point { mx, my } + Displacement { 1, 0 };
@@ -186,7 +187,7 @@ bool TrySelectPlayer(bool flipflag, int mx, int my)
 		}
 	}
 	if (flipflag && my + 1 < MAXDUNY && dPlayer[mx][my + 1] != 0) {
-		const uint8_t playerId = abs(dPlayer[mx][my + 1]) - 1;
+		const uint8_t playerId = std::abs(dPlayer[mx][my + 1]) - 1;
 		Player &player = Players[playerId];
 		if (&player != MyPlayer && player._pHitPoints != 0) {
 			cursPosition = Point { mx, my } + Displacement { 0, 1 };
@@ -194,7 +195,7 @@ bool TrySelectPlayer(bool flipflag, int mx, int my)
 		}
 	}
 	if (dPlayer[mx][my] != 0) {
-		const uint8_t playerId = abs(dPlayer[mx][my]) - 1;
+		const uint8_t playerId = std::abs(dPlayer[mx][my]) - 1;
 		if (playerId != MyPlayerId) {
 			cursPosition = { mx, my };
 			pcursplr = static_cast<int8_t>(playerId);
@@ -223,7 +224,7 @@ bool TrySelectPlayer(bool flipflag, int mx, int my)
 		}
 	}
 	if (mx + 1 < MAXDUNX && my + 1 < MAXDUNY && dPlayer[mx + 1][my + 1] != 0) {
-		const uint8_t playerId = abs(dPlayer[mx + 1][my + 1]) - 1;
+		const uint8_t playerId = std::abs(dPlayer[mx + 1][my + 1]) - 1;
 		const Player &player = Players[playerId];
 		if (&player != MyPlayer && player._pHitPoints != 0) {
 			cursPosition = Point { mx, my } + Displacement { 1, 1 };
@@ -348,7 +349,7 @@ bool TrySelectPixelBased(Point tile)
 		int monsterId = dMonster[adjacentTile.x][adjacentTile.y];
 		// Never select a monster if a target-player-only spell is selected
 		if (monsterId != 0 && IsNoneOf(pcurs, CURSOR_HEALOTHER, CURSOR_RESURRECT)) {
-			monsterId = abs(monsterId) - 1;
+			monsterId = std::abs(monsterId) - 1;
 			if (leveltype == DTYPE_TOWN) {
 				const Towner &towner = Towners[monsterId];
 				const ClxSprite sprite = towner.currentSprite();
@@ -374,7 +375,7 @@ bool TrySelectPixelBased(Point tile)
 
 		int playerId = dPlayer[adjacentTile.x][adjacentTile.y];
 		if (playerId != 0) {
-			playerId = abs(playerId) - 1;
+			playerId = std::abs(playerId) - 1;
 			if (playerId != MyPlayerId) {
 				const Player &player = Players[playerId];
 				const ClxSprite sprite = player.currentSprite();

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -6,12 +6,12 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <utility>
 
 #include "engine.h"
 #include "engine/clx_sprite.hpp"
 #include "utils/attributes.h"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -6,6 +6,7 @@
 
 #ifdef _DEBUG
 
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 
@@ -314,7 +315,7 @@ std::string ExportDun(const string_view parameter)
 			uint16_t monsterId = 0;
 			if (dMonster[x][y] > 0) {
 				for (int i = 0; i < 157; i++) {
-					if (MonstConvTbl[i] == Monsters[abs(dMonster[x][y]) - 1].type().type) {
+					if (MonstConvTbl[i] == Monsters[std::abs(dMonster[x][y]) - 1].type().type) {
 						monsterId = i + 1;
 						break;
 					}
@@ -1150,7 +1151,7 @@ void GetDebugMonster()
 {
 	int monsterIndex = pcursmonst;
 	if (monsterIndex == -1)
-		monsterIndex = abs(dMonster[cursPosition.x][cursPosition.y]) - 1;
+		monsterIndex = std::abs(dMonster[cursPosition.x][cursPosition.y]) - 1;
 
 	if (monsterIndex == -1)
 		monsterIndex = DebugMonsterId;
@@ -1315,14 +1316,14 @@ bool ShouldHighlightDebugAutomapTile(Point position)
 	};
 
 	if (SearchMonsters.size() > 0 && dMonster[position.x][position.y] != 0) {
-		const int mi = abs(dMonster[position.x][position.y]) - 1;
+		const int mi = std::abs(dMonster[position.x][position.y]) - 1;
 		const Monster &monster = Monsters[mi];
 		if (matchesSearched(monster.name(), SearchMonsters))
 			return true;
 	}
 
 	if (SearchItems.size() > 0 && dItem[position.x][position.y] != 0) {
-		const int itemId = abs(dItem[position.x][position.y]) - 1;
+		const int itemId = std::abs(dItem[position.x][position.y]) - 1;
 		const Item &item = Items[itemId];
 		if (matchesSearched(item.getName(), SearchItems))
 			return true;

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -706,7 +706,7 @@ std::string DebugCmdSpawnUniqueMonster(const string_view parameter)
 			count = num;
 			break;
 		}
-		AppendStrView(name, arg);
+		name.append(arg);
 		name += ' ';
 	}
 	if (name.empty())
@@ -796,7 +796,7 @@ std::string DebugCmdSpawnMonster(const string_view parameter)
 			count = num;
 			break;
 		}
-		AppendStrView(name, arg);
+		name.append(arg);
 		name += ' ';
 	}
 	if (name.empty())
@@ -1044,7 +1044,7 @@ std::string DebugCmdSearchMonster(const string_view parameter)
 	}
 
 	std::string name;
-	AppendStrView(name, parameter);
+	name.append(parameter);
 	AsciiStrToLower(name);
 	SearchMonsters.push_back(name);
 
@@ -1059,7 +1059,7 @@ std::string DebugCmdSearchItem(const string_view parameter)
 	}
 
 	std::string name;
-	AppendStrView(name, parameter);
+	name.append(parameter);
 	AsciiStrToLower(name);
 	SearchItems.push_back(name);
 
@@ -1074,7 +1074,7 @@ std::string DebugCmdSearchObject(const string_view parameter)
 	}
 
 	std::string name;
-	AppendStrView(name, parameter);
+	name.append(parameter);
 	AsciiStrToLower(name);
 	SearchObjects.push_back(name);
 

--- a/Source/doom.cpp
+++ b/Source/doom.cpp
@@ -5,12 +5,13 @@
  */
 #include "doom.h"
 
+#include <optional>
+
 #include "control.h"
 #include "engine.h"
 #include "engine/clx_sprite.hpp"
 #include "engine/load_cel.hpp"
 #include "engine/render/clx_render.hpp"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 namespace {

--- a/Source/dvlnet/cdwrap.h
+++ b/Source/dvlnet/cdwrap.h
@@ -4,12 +4,12 @@
 #include <exception>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "dvlnet/abstract_net.h"
 #include "storm/storm_net.hpp"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 namespace net {

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -5,6 +5,7 @@
  */
 #include "effects.h"
 
+#include <algorithm>
 #include <cstdint>
 
 #include "engine/random.hpp"
@@ -13,7 +14,6 @@
 #include "engine/sound_position.hpp"
 #include "init.h"
 #include "player.h"
-#include "utils/stdcompat/algorithm.hpp"
 #include "utils/str_cat.hpp"
 
 namespace devilution {

--- a/Source/encrypt.cpp
+++ b/Source/encrypt.cpp
@@ -102,7 +102,7 @@ uint32_t Hash(const char *s, int type)
 	return seed1;
 }
 
-uint32_t PkwareCompress(byte *srcData, uint32_t size)
+uint32_t PkwareCompress(std::byte *srcData, uint32_t size)
 {
 	std::unique_ptr<char[]> ptr = std::make_unique<char[]>(CMP_BUFFER_SIZE);
 
@@ -110,7 +110,7 @@ uint32_t PkwareCompress(byte *srcData, uint32_t size)
 	if (destSize < 2 * 4096)
 		destSize = 2 * 4096;
 
-	std::unique_ptr<byte[]> destData { new byte[destSize] };
+	std::unique_ptr<std::byte[]> destData { new std::byte[destSize] };
 
 	TDataInfo param;
 	param.srcData = srcData;
@@ -131,10 +131,10 @@ uint32_t PkwareCompress(byte *srcData, uint32_t size)
 	return size;
 }
 
-void PkwareDecompress(byte *inBuff, uint32_t recvSize, int maxBytes)
+void PkwareDecompress(std::byte *inBuff, uint32_t recvSize, int maxBytes)
 {
 	std::unique_ptr<char[]> ptr = std::make_unique<char[]>(CMP_BUFFER_SIZE);
-	std::unique_ptr<byte[]> outBuff { new byte[maxBytes] };
+	std::unique_ptr<std::byte[]> outBuff { new std::byte[maxBytes] };
 
 	TDataInfo info;
 	info.srcData = inBuff;

--- a/Source/encrypt.h
+++ b/Source/encrypt.h
@@ -5,16 +5,15 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
-
-#include "utils/stdcompat/cstddef.hpp"
 
 namespace devilution {
 
 struct TDataInfo {
-	byte *srcData;
+	std::byte *srcData;
 	uint32_t srcOffset;
-	byte *destData;
+	std::byte *destData;
 	uint32_t destOffset;
 	uint32_t size;
 };
@@ -22,7 +21,7 @@ struct TDataInfo {
 void Decrypt(uint32_t *castBlock, uint32_t size, uint32_t key);
 void Encrypt(uint32_t *castBlock, uint32_t size, uint32_t key);
 uint32_t Hash(const char *s, int type);
-uint32_t PkwareCompress(byte *srcData, uint32_t size);
-void PkwareDecompress(byte *inBuff, uint32_t recvSize, int maxBytes);
+uint32_t PkwareCompress(std::byte *srcData, uint32_t size);
+void PkwareDecompress(std::byte *inBuff, uint32_t recvSize, int maxBytes);
 
 } // namespace devilution

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -25,6 +25,7 @@
 // defines for `PRIuMAX` et al. SDL transitively includes `inttypes.h`.
 // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=97044
 #include <cinttypes>
+#include <cstddef>
 
 #include <SDL.h>
 
@@ -36,7 +37,6 @@
 #include "engine/point.hpp"
 #include "engine/size.hpp"
 #include "engine/surface.hpp"
-#include "utils/stdcompat/cstddef.hpp"
 
 #define TILE_WIDTH 64
 #define TILE_HEIGHT 32

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -6,12 +6,12 @@
 
 #include "animationinfo.h"
 
+#include <algorithm>
 #include <cstdint>
 
 #include "appfat.h"
 #include "nthread.h"
 #include "utils/log.hpp"
-#include "utils/stdcompat/algorithm.hpp"
 
 namespace devilution {
 
@@ -182,7 +182,7 @@ void AnimationInfo::changeAnimationData(OptionalClxSpriteList celSprite, int8_t 
 	if (numberOfFrames != this->numberOfFrames || ticksPerFrame != this->ticksPerFrame) {
 		// Ensure that the currentFrame is still valid and that we disable ADL cause the calculcated values (for example tickModifier_) could be wrong
 		if (numberOfFrames >= 1)
-			currentFrame = clamp<int8_t>(currentFrame, 0, numberOfFrames - 1);
+			currentFrame = std::clamp<int8_t>(currentFrame, 0, numberOfFrames - 1);
 		else
 			currentFrame = -1;
 

--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -560,7 +560,7 @@ bool GetRunGameLoop(bool &drawGame, bool &processInput)
 			}
 		} else {
 			int32_t fraction = ticksElapsed * AnimationInfo::baseValueFraction / gnTickDelay;
-			fraction = clamp<int32_t>(fraction, 0, AnimationInfo::baseValueFraction);
+			fraction = std::clamp<int32_t>(fraction, 0, AnimationInfo::baseValueFraction);
 			uint8_t progressToNextGameTick = static_cast<uint8_t>(fraction);
 			if (dmsg.type == DemoMsgType::GameTick || dmsg.progressToNextGameTick > progressToNextGameTick) {
 				// we are ahead of the replay => add a additional rendering for smoothness

--- a/Source/engine/displacement.hpp
+++ b/Source/engine/displacement.hpp
@@ -7,7 +7,6 @@
 
 #include "engine/direction.hpp"
 #include "engine/size.hpp"
-#include "utils/stdcompat/abs.hpp"
 
 namespace devilution {
 
@@ -342,7 +341,7 @@ constexpr DisplacementOf<DisplacementDeltaT> operator>>(DisplacementOf<Displacem
 template <typename DisplacementDeltaT>
 constexpr DisplacementOf<DisplacementDeltaT> abs(DisplacementOf<DisplacementDeltaT> a)
 {
-	return { abs(a.deltaX), abs(a.deltaY) };
+	return { std::abs(a.deltaX), std::abs(a.deltaY) };
 }
 
 template <typename DeltaT>

--- a/Source/engine/load_file.hpp
+++ b/Source/engine/load_file.hpp
@@ -13,7 +13,6 @@
 #include "engine/assets.hpp"
 #include "mpq/mpq_common.hpp"
 #include "utils/static_vector.hpp"
-#include "utils/stdcompat/cstddef.hpp"
 #include "utils/str_cat.hpp"
 
 namespace devilution {
@@ -58,7 +57,7 @@ void LoadFileInMem(const char *path, std::array<T, N> &data)
  * @param numRead Number of T elements read
  * @return Buffer with content of file
  */
-template <typename T = byte>
+template <typename T = std::byte>
 std::unique_ptr<T[]> LoadFileInMem(const char *path, std::size_t *numRead = nullptr)
 {
 	size_t size;
@@ -95,10 +94,10 @@ struct MultiFileLoader {
 	 * @param pathFn a function that returns the path for the given index
 	 * @param outOffsets a buffer index for the start of each file will be written here, then the total file size at the end.
 	 * @param filterFn a function that returns whether to load a file for the given index
-	 * @return std::unique_ptr<byte[]> the buffer with all the files
+	 * @return std::unique_ptr<std::byte[]> the buffer with all the files
 	 */
 	template <typename PathFn, typename FilterFn = DefaultFilterFn>
-	[[nodiscard]] std::unique_ptr<byte[]> operator()(size_t numFiles, PathFn &&pathFn, uint32_t *outOffsets,
+	[[nodiscard]] std::unique_ptr<std::byte[]> operator()(size_t numFiles, PathFn &&pathFn, uint32_t *outOffsets,
 	    FilterFn filterFn = DefaultFilterFn {})
 	{
 		StaticVector<std::array<char, MaxMpqPathSize>, MaxFiles> paths;
@@ -125,7 +124,7 @@ struct MultiFileLoader {
 			++j;
 		}
 		outOffsets[files.size()] = totalSize;
-		std::unique_ptr<byte[]> buf { new byte[totalSize] };
+		std::unique_ptr<std::byte[]> buf { new std::byte[totalSize] };
 		for (size_t i = 0, j = 0; i < numFiles; ++i) {
 			if (!filterFn(i))
 				continue;

--- a/Source/engine/load_pcx.hpp
+++ b/Source/engine/load_pcx.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 
 #include <SDL.h>
 
 #include "engine/clx_sprite.hpp"
-#include "utils/stdcompat/optional.hpp"
 
 #ifdef UNPACKED_MPQS
 #define DEVILUTIONX_PCX_EXT ".clx"

--- a/Source/engine/palette.cpp
+++ b/Source/engine/palette.cpp
@@ -38,7 +38,7 @@ bool sgbFadedIn = true;
 void LoadGamma()
 {
 	int gammaValue = *sgOptions.Graphics.gammaCorrection;
-	gammaValue = clamp(gammaValue, 30, 100);
+	gammaValue = std::clamp(gammaValue, 30, 100);
 	sgOptions.Graphics.gammaCorrection.SetValue(gammaValue - gammaValue % 5);
 }
 

--- a/Source/engine/path.h
+++ b/Source/engine/path.h
@@ -7,13 +7,13 @@
 
 #include <cstdint>
 #include <limits>
+#include <optional>
 
 #include <SDL.h>
 #include <function_ref.hpp>
 
 #include "engine/direction.hpp"
 #include "engine/point.hpp"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/engine/point.hpp
+++ b/Source/engine/point.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <type_traits>
 #ifdef BUILD_TESTING
@@ -8,7 +9,6 @@
 
 #include "engine/direction.hpp"
 #include "engine/displacement.hpp"
-#include "utils/stdcompat/algorithm.hpp"
 
 namespace devilution {
 

--- a/Source/engine/point.hpp
+++ b/Source/engine/point.hpp
@@ -8,7 +8,6 @@
 
 #include "engine/direction.hpp"
 #include "engine/displacement.hpp"
-#include "utils/stdcompat/abs.hpp"
 #include "utils/stdcompat/algorithm.hpp"
 
 namespace devilution {
@@ -141,16 +140,16 @@ struct PointOf {
 	template <typename PointCoordT>
 	constexpr int ManhattanDistance(PointOf<PointCoordT> other) const
 	{
-		return abs(static_cast<int>(x) - static_cast<int>(other.x))
-		    + abs(static_cast<int>(y) - static_cast<int>(other.y));
+		return std::abs(static_cast<int>(x) - static_cast<int>(other.x))
+		    + std::abs(static_cast<int>(y) - static_cast<int>(other.y));
 	}
 
 	template <typename PointCoordT>
 	constexpr int WalkingDistance(PointOf<PointCoordT> other) const
 	{
 		return std::max<int>(
-		    abs(static_cast<int>(x) - static_cast<int>(other.x)),
-		    abs(static_cast<int>(y) - static_cast<int>(other.y)));
+		    std::abs(static_cast<int>(x) - static_cast<int>(other.x)),
+		    std::abs(static_cast<int>(y) - static_cast<int>(other.y)));
 	}
 
 	/**
@@ -229,7 +228,7 @@ constexpr PointOf<PointCoordT> operator*(PointOf<PointCoordT> a, const int facto
 template <typename PointCoordT>
 constexpr PointOf<PointCoordT> abs(PointOf<PointCoordT> a)
 {
-	return { abs(a.x), abs(a.y) };
+	return { std::abs(a.x), std::abs(a.y) };
 }
 
 } // namespace devilution

--- a/Source/engine/random.cpp
+++ b/Source/engine/random.cpp
@@ -1,10 +1,9 @@
 #include "engine/random.hpp"
 
+#include <cmath>
 #include <cstdint>
 #include <limits>
 #include <random>
-
-#include "utils/stdcompat/abs.hpp"
 
 namespace devilution {
 
@@ -43,7 +42,7 @@ int32_t AdvanceRndSeed()
 {
 	const int32_t seed = static_cast<int32_t>(GenerateSeed());
 	// since abs(INT_MIN) is undefined behavior, handle this value specially
-	return seed == std::numeric_limits<int32_t>::min() ? std::numeric_limits<int32_t>::min() : abs(seed);
+	return seed == std::numeric_limits<int32_t>::min() ? std::numeric_limits<int32_t>::min() : std::abs(seed);
 }
 
 int32_t GenerateRnd(int32_t v)

--- a/Source/engine/render/dun_render.cpp
+++ b/Source/engine/render/dun_render.cpp
@@ -22,7 +22,6 @@
 #include "lighting.h"
 #include "options.h"
 #include "utils/attributes.h"
-#include "utils/stdcompat/algorithm.hpp"
 #ifdef DEBUG_STR
 #include "engine/render/text_render.hpp"
 #endif
@@ -139,7 +138,7 @@ DVL_ALWAYS_INLINE int8_t InitPrefix(int8_t y)
 template <bool OpaquePrefix, int8_t PrefixIncrement>
 std::string prefixDebugString(int8_t prefix) {
 	std::string out(32, OpaquePrefix ? '0' : '1');
-	const uint8_t clamped = clamp<int8_t>(prefix, 0, 32);
+	const uint8_t clamped = std::clamp<int8_t>(prefix, 0, 32);
 	out.replace(0, clamped, clamped, OpaquePrefix ? '1' : '0');
 	StrAppend(out, " prefix=", prefix, " OpaquePrefix=", OpaquePrefix, " PrefixIncrement=", PrefixIncrement);
 	return out;
@@ -242,7 +241,7 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLine(uint8_t *DVL_RESTRICT dst, c
 	if (PrefixIncrement == 0) {
 		RenderLineTransparentOrOpaque<Light, OpaquePrefix>(dst, src, n, tbl);
 	} else if (prefix >= static_cast<int8_t>(n)) {
-		// We clamp the prefix to (0, n] and avoid calling `RenderLineTransparent/Opaque` with width=0.
+		// We std::clamp the prefix to (0, n] and avoid calling `RenderLineTransparent/Opaque` with width=0.
 		if (OpaquePrefix) {
 			RenderLineOpaque<Light>(dst, src, n, tbl);
 		} else {

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -5,6 +5,7 @@
  */
 #include "engine/render/scrollrt.h"
 
+#include <cmath>
 #include <cstdint>
 
 #include "DiabloUI/ui_flags.hpp"
@@ -677,7 +678,7 @@ void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBuffe
 {
 	int mi = dMonster[tilePosition.x][tilePosition.y];
 	bool isNegativeMonster = mi < 0;
-	mi = abs(mi) - 1;
+	mi = std::abs(mi) - 1;
 
 	if (leveltype == DTYPE_TOWN) {
 		if (isNegativeMonster)
@@ -1152,7 +1153,7 @@ void DrawView(const Surface &out, Point startPosition)
 					auto DrawLine = [&out](Point from, Point to, uint8_t col) {
 						int dx = to.x - from.x;
 						int dy = to.y - from.y;
-						int steps = abs(dx) > abs(dy) ? abs(dx) : abs(dy);
+						int steps = std::abs(dx) > std::abs(dy) ? std::abs(dx) : std::abs(dy);
 						float ix = dx / (float)steps;
 						float iy = dy / (float)steps;
 						float sx = from.x;

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -8,6 +8,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <unordered_map>
 #include <utility>
 
@@ -27,7 +28,6 @@
 #include "utils/display.h"
 #include "utils/language.h"
 #include "utils/sdl_compat.h"
-#include "utils/stdcompat/optional.hpp"
 #include "utils/utf8.hpp"
 
 namespace devilution {

--- a/Source/engine/render/text_render.hpp
+++ b/Source/engine/render/text_render.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -16,7 +17,6 @@
 #include "engine.h"
 #include "engine/clx_sprite.hpp"
 #include "engine/rectangle.hpp"
-#include "utils/stdcompat/optional.hpp"
 #include "utils/stdcompat/string_view.hpp"
 
 namespace devilution {

--- a/Source/engine/sound.cpp
+++ b/Source/engine/sound.cpp
@@ -9,6 +9,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <optional>
 
 #include <SDL.h>
 
@@ -19,7 +20,6 @@
 #include "utils/math.h"
 #include "utils/sdl_mutex.h"
 #include "utils/stdcompat/algorithm.hpp"
-#include "utils/stdcompat/optional.hpp"
 #include "utils/stdcompat/shared_ptr_array.hpp"
 #include "utils/str_cat.hpp"
 #include "utils/stubs.h"

--- a/Source/engine/sound.cpp
+++ b/Source/engine/sound.cpp
@@ -5,6 +5,7 @@
  */
 #include "engine/sound.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <list>
 #include <memory>
@@ -19,7 +20,6 @@
 #include "utils/log.hpp"
 #include "utils/math.h"
 #include "utils/sdl_mutex.h"
-#include "utils/stdcompat/algorithm.hpp"
 #include "utils/stdcompat/shared_ptr_array.hpp"
 #include "utils/str_cat.hpp"
 #include "utils/stubs.h"
@@ -152,7 +152,7 @@ const char *const MusicTracks[NUM_MUSIC] = {
 
 int CapVolume(int volume)
 {
-	return clamp(volume, VOLUME_MIN, VOLUME_MAX);
+	return std::clamp(volume, VOLUME_MIN, VOLUME_MAX);
 }
 
 } // namespace

--- a/Source/engine/sound_position.cpp
+++ b/Source/engine/sound_position.cpp
@@ -11,7 +11,7 @@ bool CalculateSoundPosition(Point soundPosition, int *plVolume, int *plPan)
 	const Displacement delta = soundPosition - playerPosition;
 
 	const int pan = (delta.deltaX - delta.deltaY) * 256;
-	*plPan = clamp(pan, PAN_MIN, PAN_MAX);
+	*plPan = std::clamp(pan, PAN_MIN, PAN_MAX);
 
 	const int volume = playerPosition.ApproxDistance(soundPosition) * -64;
 

--- a/Source/engine/trn.hpp
+++ b/Source/engine/trn.hpp
@@ -6,9 +6,9 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 
 #include "player.h"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -6,6 +6,7 @@
 #include "gmenu.h"
 
 #include <cstdint>
+#include <optional>
 
 #include "DiabloUI/ui_flags.hpp"
 #include "control.h"
@@ -20,7 +21,6 @@
 #include "stores.h"
 #include "utils/language.h"
 #include "utils/stdcompat/algorithm.hpp"
-#include "utils/stdcompat/optional.hpp"
 #include "utils/ui_fwd.h"
 
 namespace devilution {

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -5,6 +5,7 @@
  */
 #include "gmenu.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <optional>
 
@@ -20,7 +21,6 @@
 #include "options.h"
 #include "stores.h"
 #include "utils/language.h"
-#include "utils/stdcompat/algorithm.hpp"
 #include "utils/ui_fwd.h"
 
 namespace devilution {
@@ -161,7 +161,7 @@ bool GmenuMouseIsOverSlider()
 
 int GmenuGetSliderFill()
 {
-	return clamp(MousePosition.x - SliderValueLeft - GetUIRectangle().position.x, SliderFillMin, SliderFillMax);
+	return std::clamp(MousePosition.x - SliderValueLeft - GetUIRectangle().position.x, SliderFillMin, SliderFillMax);
 }
 
 } // namespace

--- a/Source/init.h
+++ b/Source/init.h
@@ -5,8 +5,9 @@
  */
 #pragma once
 
+#include <optional>
+
 #include "utils/attributes.h"
-#include "utils/stdcompat/optional.hpp"
 
 #ifdef UNPACKED_MPQS
 #include <string>

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <cstdint>
+#include <optional>
 
 #include <SDL.h>
 
@@ -25,7 +26,6 @@
 #include "pfile.h"
 #include "plrmsg.h"
 #include "utils/sdl_geometry.h"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <optional>
 #include <utility>
 
 #include <fmt/format.h>
@@ -32,7 +33,6 @@
 #include "utils/format_int.hpp"
 #include "utils/language.h"
 #include "utils/sdl_geometry.h"
-#include "utils/stdcompat/optional.hpp"
 #include "utils/str_cat.hpp"
 #include "utils/utf8.hpp"
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -4,6 +4,7 @@
  * Implementation of player inventory.
  */
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <utility>
 
@@ -367,7 +368,7 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 					if (xx >= INV_ROW_SLOT_SIZE)
 						return;
 					if (player.InvGrid[xx + yy] != 0) {
-						int8_t iv = abs(player.InvGrid[xx + yy]);
+						int8_t iv = std::abs(player.InvGrid[xx + yy]);
 						if (it != 0) {
 							if (it != iv)
 								return;
@@ -1137,7 +1138,7 @@ void DrawInv(const Surface &out)
 			    out,
 			    GetPanelPosition(UiPanels::Inventory, InvRect[i + SLOTXY_INV_FIRST].position) + Displacement { 0, InventorySlotSizeInPixels.height },
 			    InventorySlotSizeInPixels,
-			    myPlayer.InvList[abs(myPlayer.InvGrid[i]) - 1]._iMagical);
+			    myPlayer.InvList[std::abs(myPlayer.InvGrid[i]) - 1]._iMagical);
 		}
 	}
 
@@ -1461,7 +1462,7 @@ void CheckInvSwap(Player &player, const Item &item, int invGridIndex)
 			for (int x = 0; x < itemSize.width; x++) {
 				int gridIndex = rowGridIndex + x;
 				if (player.InvGrid[gridIndex] != 0)
-					return abs(player.InvGrid[gridIndex]);
+					return std::abs(player.InvGrid[gridIndex]);
 			}
 		}
 		player._pNumInv++;
@@ -1494,7 +1495,7 @@ void CheckInvSwap(Player &player, const Item &item, int invGridIndex)
 
 void CheckInvRemove(Player &player, int invGridIndex)
 {
-	int invListIndex = abs(player.InvGrid[invGridIndex]) - 1;
+	int invListIndex = std::abs(player.InvGrid[invGridIndex]) - 1;
 
 	if (invListIndex >= 0) {
 		player.RemoveInvItem(invListIndex);
@@ -1855,7 +1856,7 @@ int8_t CheckInvHLight()
 		rv = INVLOC_CHEST;
 		pi = &myPlayer.InvBody[rv];
 	} else if (r >= SLOTXY_INV_FIRST && r <= SLOTXY_INV_LAST) {
-		int8_t itemId = abs(myPlayer.InvGrid[r - SLOTXY_INV_FIRST]);
+		int8_t itemId = std::abs(myPlayer.InvGrid[r - SLOTXY_INV_FIRST]);
 		if (itemId == 0)
 			return -1;
 		int ii = itemId - 1;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1752,7 +1752,7 @@ int ClampDurability(const Item &item, int durability)
 	if (item._iMaxDur == 0)
 		return 0;
 
-	return clamp<int>(durability, 1, item._iMaxDur);
+	return std::clamp<int>(durability, 1, item._iMaxDur);
 }
 
 int16_t ClampToHit(const Item &item, int16_t toHit)
@@ -1783,8 +1783,8 @@ int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int is
 		item._iIdentified = true;
 	item._iMaxDur = mdur;
 	item._iDurability = ClampDurability(item, dur);
-	item._iMaxCharges = clamp<int>(mch, 0, item._iMaxCharges);
-	item._iCharges = clamp<int>(ch, 0, item._iMaxCharges);
+	item._iMaxCharges = std::clamp<int>(mch, 0, item._iMaxCharges);
+	item._iCharges = std::clamp<int>(ch, 0, item._iMaxCharges);
 	if (gbIsHellfire) {
 		item._iPLToHit = ClampToHit(item, toHit);
 		item._iMaxDam = ClampMaxDam(item, maxDam);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -45,7 +45,6 @@
 #include "utils/language.h"
 #include "utils/log.hpp"
 #include "utils/math.h"
-#include "utils/stdcompat/algorithm.hpp"
 #include "utils/str_case.hpp"
 #include "utils/str_cat.hpp"
 #include "utils/utf8.hpp"
@@ -1992,7 +1991,7 @@ void SpawnOnePremium(Item &premiumItem, int plvl, const Player &player)
 	dexterity += dexterity / 5;
 	magic += magic / 5;
 
-	plvl = clamp(plvl, 1, 30);
+	plvl = std::clamp(plvl, 1, 30);
 
 	int maxCount = 150;
 	const bool unlimited = !gbIsHellfire; // TODO: This could lead to an infinite loop if a suitable item can never be generated
@@ -2664,7 +2663,7 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 	player._pIBonusDamMod = dmod;
 	player._pIGetHit = ghit;
 
-	lrad = clamp(lrad, 2, 15);
+	lrad = std::clamp(lrad, 2, 15);
 
 	if (player._pLightRad != lrad) {
 		ChangeLightRadius(player.lightId, lrad);
@@ -2742,9 +2741,9 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 		lr = 0;
 	}
 
-	player._pMagResist = clamp(mr, 0, MaxResistance);
-	player._pFireResist = clamp(fr, 0, MaxResistance);
-	player._pLghtResist = clamp(lr, 0, MaxResistance);
+	player._pMagResist = std::clamp(mr, 0, MaxResistance);
+	player._pFireResist = std::clamp(fr, 0, MaxResistance);
+	player._pLghtResist = std::clamp(lr, 0, MaxResistance);
 
 	vadd = (vadd * PlayersData[static_cast<size_t>(player._pClass)].itmLife) >> 6;
 	ihp += (vadd << 6); // BUGFIX: blood boil can cause negative shifts here (see line 757)

--- a/Source/items.h
+++ b/Source/items.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 
 #include "DiabloUI/ui_flags.hpp"
 #include "engine.h"
@@ -13,7 +14,6 @@
 #include "engine/point.hpp"
 #include "itemdat.h"
 #include "monster.h"
-#include "utils/stdcompat/optional.hpp"
 #include "utils/string_or_view.hpp"
 
 namespace devilution {

--- a/Source/levels/drlg_l2.cpp
+++ b/Source/levels/drlg_l2.cpp
@@ -5,6 +5,7 @@
  */
 #include "levels/drlg_l2.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <list>
@@ -18,7 +19,6 @@
 #include "levels/setmaps.h"
 #include "player.h"
 #include "quests.h"
-#include "utils/stdcompat/algorithm.hpp"
 
 namespace devilution {
 
@@ -1788,10 +1788,10 @@ void CreateRoom(WorldTilePosition topLeft, WorldTilePosition bottomRight, int nR
 		roomTopLeft.y = bottomRight.y - roomSize.height;
 	}
 
-	roomTopLeft.x = clamp<WorldTileCoord>(roomTopLeft.x, 1, 38);
-	roomTopLeft.y = clamp<WorldTileCoord>(roomTopLeft.y, 1, 38);
-	roomBottomRight.x = clamp<WorldTileCoord>(roomBottomRight.x, 1, 38);
-	roomBottomRight.y = clamp<WorldTileCoord>(roomBottomRight.y, 1, 38);
+	roomTopLeft.x = std::clamp<WorldTileCoord>(roomTopLeft.x, 1, 38);
+	roomTopLeft.y = std::clamp<WorldTileCoord>(roomTopLeft.y, 1, 38);
+	roomBottomRight.x = std::clamp<WorldTileCoord>(roomBottomRight.x, 1, 38);
+	roomBottomRight.y = std::clamp<WorldTileCoord>(roomBottomRight.y, 1, 38);
 
 	DefineRoom(roomTopLeft, roomBottomRight, static_cast<bool>(size));
 

--- a/Source/levels/drlg_l2.cpp
+++ b/Source/levels/drlg_l2.cpp
@@ -5,6 +5,7 @@
  */
 #include "levels/drlg_l2.h"
 
+#include <cmath>
 #include <cstdint>
 #include <list>
 
@@ -1908,8 +1909,8 @@ void ConnectHall(const HallNode &node)
 			if (predungeon[beginning.x][beginning.y] != ',')
 				fInroom = true;
 		}
-		int nDx = abs(end.x - beginning.x);
-		int nDy = abs(end.y - beginning.y);
+		int nDx = std::abs(end.x - beginning.x);
+		int nDy = std::abs(end.y - beginning.y);
 		if (nDx > nDy) {
 			int nRp = std::min(2 * nDx, 30);
 			if (GenerateRnd(100) < nRp) {

--- a/Source/levels/drlg_l2.cpp
+++ b/Source/levels/drlg_l2.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstdint>
 #include <list>
+#include <optional>
 
 #include "diablo.h"
 #include "engine/load_file.hpp"
@@ -18,7 +19,6 @@
 #include "player.h"
 #include "quests.h"
 #include "utils/stdcompat/algorithm.hpp"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -25,7 +25,7 @@ WorldTileRectangle SetPiece;
 std::unique_ptr<uint16_t[]> pSetPiece;
 OptionalOwnedClxSpriteList pSpecialCels;
 std::unique_ptr<MegaTile[]> pMegaTiles;
-std::unique_ptr<byte[]> pDungeonCels;
+std::unique_ptr<std::byte[]> pDungeonCels;
 std::array<TileProperties, MAXTILES> SOLData;
 WorldTilePosition dminPosition;
 WorldTilePosition dmaxPosition;

--- a/Source/levels/gendung.h
+++ b/Source/levels/gendung.h
@@ -163,7 +163,7 @@ extern std::unique_ptr<uint16_t[]> pSetPiece;
 extern OptionalOwnedClxSpriteList pSpecialCels;
 /** Specifies the tile definitions of the active dungeon type; (e.g. levels/l1data/l1.til). */
 extern DVL_API_FOR_TEST std::unique_ptr<MegaTile[]> pMegaTiles;
-extern std::unique_ptr<byte[]> pDungeonCels;
+extern std::unique_ptr<std::byte[]> pDungeonCels;
 /**
  * List tile properties
  */

--- a/Source/levels/gendung.h
+++ b/Source/levels/gendung.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 
 #include "engine.h"
 #include "engine/clx_sprite.hpp"
@@ -17,7 +18,6 @@
 #include "utils/attributes.h"
 #include "utils/bitset2d.hpp"
 #include "utils/enum_traits.h"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/levels/trigs.cpp
+++ b/Source/levels/trigs.cpp
@@ -5,6 +5,7 @@
  */
 #include "levels/trigs.h"
 
+#include <cmath>
 #include <cstdint>
 
 #include <fmt/format.h>
@@ -444,8 +445,8 @@ bool ForceL2Trig()
 		if (dPiece[cursPosition.x][cursPosition.y] == tileId) {
 			for (int j = 0; j < numtrigs; j++) {
 				if (trigs[j]._tmsg == WM_DIABPREVLVL) {
-					int dx = abs(trigs[j].position.x - cursPosition.x);
-					int dy = abs(trigs[j].position.y - cursPosition.y);
+					int dx = std::abs(trigs[j].position.x - cursPosition.x);
+					int dy = std::abs(trigs[j].position.y - cursPosition.y);
 					if (dx < 4 && dy < 4) {
 						InfoString = fmt::format(fmt::runtime(_("Up to level {:d}")), currlevel - 1);
 						cursPosition = trigs[j].position;
@@ -473,8 +474,8 @@ bool ForceL2Trig()
 			if (dPiece[cursPosition.x][cursPosition.y] == tileId) {
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABTWARPUP) {
-						int dx = abs(trigs[j].position.x - cursPosition.x);
-						int dy = abs(trigs[j].position.y - cursPosition.y);
+						int dx = std::abs(trigs[j].position.x - cursPosition.x);
+						int dy = std::abs(trigs[j].position.y - cursPosition.y);
 						if (dx < 4 && dy < 4) {
 							InfoString = _("Up to town");
 							cursPosition = trigs[j].position;
@@ -496,8 +497,8 @@ bool ForceL3Trig()
 			InfoString = fmt::format(fmt::runtime(_("Up to level {:d}")), currlevel - 1);
 			for (int j = 0; j < numtrigs; j++) {
 				if (trigs[j]._tmsg == WM_DIABPREVLVL) {
-					int dx = abs(trigs[j].position.x - cursPosition.x);
-					int dy = abs(trigs[j].position.y - cursPosition.y);
+					int dx = std::abs(trigs[j].position.x - cursPosition.x);
+					int dy = std::abs(trigs[j].position.y - cursPosition.y);
 					if (dx < 4 && dy < 4) {
 						cursPosition = trigs[j].position;
 						return true;
@@ -525,8 +526,8 @@ bool ForceL3Trig()
 			if (dPiece[cursPosition.x][cursPosition.y] == tileId) {
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABTWARPUP) {
-						int dx = abs(trigs[j].position.x - cursPosition.x);
-						int dy = abs(trigs[j].position.y - cursPosition.y);
+						int dx = std::abs(trigs[j].position.x - cursPosition.x);
+						int dy = std::abs(trigs[j].position.y - cursPosition.y);
 						if (dx < 4 && dy < 4) {
 							InfoString = _("Up to town");
 							cursPosition = trigs[j].position;
@@ -572,8 +573,8 @@ bool ForceL4Trig()
 			if (dPiece[cursPosition.x][cursPosition.y] == tileId) {
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABTWARPUP) {
-						int dx = abs(trigs[j].position.x - cursPosition.x);
-						int dy = abs(trigs[j].position.y - cursPosition.y);
+						int dx = std::abs(trigs[j].position.x - cursPosition.x);
+						int dy = std::abs(trigs[j].position.y - cursPosition.y);
 						if (dx < 4 && dy < 4) {
 							InfoString = _("Up to town");
 							cursPosition = trigs[j].position;
@@ -634,8 +635,8 @@ bool ForceHiveTrig()
 			if (dPiece[cursPosition.x][cursPosition.y] == tileId) {
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABTWARPUP) {
-						int dx = abs(trigs[j].position.x - cursPosition.x);
-						int dy = abs(trigs[j].position.y - cursPosition.y);
+						int dx = std::abs(trigs[j].position.x - cursPosition.x);
+						int dy = std::abs(trigs[j].position.y - cursPosition.y);
 						if (dx < 4 && dy < 4) {
 							InfoString = _("Up to town");
 							cursPosition = trigs[j].position;
@@ -683,8 +684,8 @@ bool ForceCryptTrig()
 			if (dPiece[cursPosition.x][cursPosition.y] == tileId) {
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABTWARPUP) {
-						int dx = abs(trigs[j].position.x - cursPosition.x);
-						int dy = abs(trigs[j].position.y - cursPosition.y);
+						int dx = std::abs(trigs[j].position.x - cursPosition.x);
+						int dy = std::abs(trigs[j].position.y - cursPosition.y);
 						if (dx < 4 && dy < 4) {
 							InfoString = _("Up to town");
 							cursPosition = trigs[j].position;

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -8,6 +8,7 @@
 #include <array>
 #include <cstdint>
 #include <optional>
+#include <type_traits>
 #include <vector>
 
 #include <function_ref.hpp>
@@ -16,7 +17,6 @@
 #include "engine.h"
 #include "engine/point.hpp"
 #include "utils/attributes.h"
-#include "utils/stdcompat/invoke_result_t.hpp"
 
 namespace devilution {
 
@@ -110,9 +110,9 @@ bool DoCrawl(unsigned radius, tl::function_ref<bool(Displacement)> function);
 bool DoCrawl(unsigned minRadius, unsigned maxRadius, tl::function_ref<bool(Displacement)> function);
 
 template <typename F>
-auto Crawl(unsigned radius, F function) -> invoke_result_t<decltype(function), Displacement>
+auto Crawl(unsigned radius, F function) -> std::invoke_result_t<decltype(function), Displacement>
 {
-	invoke_result_t<decltype(function), Displacement> result;
+	std::invoke_result_t<decltype(function), Displacement> result;
 	DoCrawl(radius, [&result, &function](Displacement displacement) -> bool {
 		result = function(displacement);
 		return !result;
@@ -121,9 +121,9 @@ auto Crawl(unsigned radius, F function) -> invoke_result_t<decltype(function), D
 }
 
 template <typename F>
-auto Crawl(unsigned minRadius, unsigned maxRadius, F function) -> invoke_result_t<decltype(function), Displacement>
+auto Crawl(unsigned minRadius, unsigned maxRadius, F function) -> std::invoke_result_t<decltype(function), Displacement>
 {
-	invoke_result_t<decltype(function), Displacement> result;
+	std::invoke_result_t<decltype(function), Displacement> result;
 	DoCrawl(minRadius, maxRadius, [&result, &function](Displacement displacement) -> bool {
 		result = function(displacement);
 		return !result;

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 #include <function_ref.hpp>
@@ -16,7 +17,6 @@
 #include "engine/point.hpp"
 #include "utils/attributes.h"
 #include "utils/stdcompat/invoke_result_t.hpp"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -81,7 +81,7 @@ T SwapBE(T in)
 }
 
 class LoadHelper {
-	std::unique_ptr<byte[]> m_buffer_;
+	std::unique_ptr<std::byte[]> m_buffer_;
 	size_t m_cur_ = 0;
 	size_t m_size_;
 
@@ -168,7 +168,7 @@ public:
 class SaveHelper {
 	SaveWriter &m_mpqWriter;
 	const char *m_szFileName_;
-	std::unique_ptr<byte[]> m_buffer_;
+	std::unique_ptr<std::byte[]> m_buffer_;
 	size_t m_cur_ = 0;
 	size_t m_capacity_;
 
@@ -176,7 +176,7 @@ public:
 	SaveHelper(SaveWriter &mpqWriter, const char *szFileName, size_t bufferLen)
 	    : m_mpqWriter(mpqWriter)
 	    , m_szFileName_(szFileName)
-	    , m_buffer_(new byte[codec_get_encoded_len(bufferLen)])
+	    , m_buffer_(new std::byte[codec_get_encoded_len(bufferLen)])
 	    , m_capacity_(bufferLen)
 	{
 	}

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -151,7 +151,7 @@ public:
 	{
 		static_assert(sizeof(TSource) > sizeof(TDesired), "Can only narrow to a smaller type");
 		TSource value = SwapLE(Next<TSource>()) + modifier;
-		return static_cast<TDesired>(clamp<TSource>(value, std::numeric_limits<TDesired>::min(), std::numeric_limits<TDesired>::max()));
+		return static_cast<TDesired>(std::clamp<TSource>(value, std::numeric_limits<TDesired>::min(), std::numeric_limits<TDesired>::max()));
 	}
 
 	bool NextBool8()

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -4,6 +4,7 @@
  * Implementation of scrolling dialog text.
  */
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -18,7 +19,6 @@
 #include "playerdat.hpp"
 #include "textdat.h"
 #include "utils/language.h"
-#include "utils/stdcompat/optional.hpp"
 #include "utils/stdcompat/string_view.hpp"
 
 namespace devilution {

--- a/Source/misdat.h
+++ b/Source/misdat.h
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <type_traits>
 #include <vector>
@@ -14,7 +15,6 @@
 #include "engine/clx_sprite.hpp"
 #include "spelldat.h"
 #include "utils/enum_traits.h"
-#include "utils/stdcompat/cstddef.hpp"
 #include "utils/stdcompat/string_view.hpp"
 
 namespace devilution {

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -6,6 +6,7 @@
 #include "missiles.h"
 
 #include <climits>
+#include <cmath>
 #include <cstdint>
 
 #include "control.h"
@@ -412,8 +413,8 @@ void CheckMissileCol(Missile &missile, DamageType damageType, int minDamage, int
 
 	bool isMonsterHit = false;
 	int mid = dMonster[mx][my];
-	if (mid > 0 || (mid != 0 && Monsters[abs(mid) - 1].mode == MonsterMode::Petrified)) {
-		mid = abs(mid) - 1;
+	if (mid > 0 || (mid != 0 && Monsters[std::abs(mid) - 1].mode == MonsterMode::Petrified)) {
+		mid = std::abs(mid) - 1;
 		if (missile.IsTrap()
 		    || (missile._micaster == TARGET_PLAYERS && (                                           // or was fired by a monster and
 		            Monsters[mid].isPlayerMinion() != Monsters[missile._misource].isPlayerMinion() //  the monsters are on opposing factions
@@ -526,7 +527,7 @@ bool MoveMissile(Missile &missile, tl::function_ref<bool(Point)> checkTile, bool
 			// skip collision logic if the missile is on a corner between tiles
 			if (pixelsTraveled.deltaY % 16 == 0
 			    && pixelsTraveled.deltaX % 32 == 0
-			    && abs(pixelsTraveled.deltaY / 16) % 2 != abs(pixelsTraveled.deltaX / 32) % 2) {
+			    && std::abs(pixelsTraveled.deltaY / 16) % 2 != std::abs(pixelsTraveled.deltaX / 32) % 2) {
 				continue;
 			}
 
@@ -1229,7 +1230,7 @@ void AddBerserk(Missile &missile, AddMissileParameter &parameter)
 			    return false;
 		    }
 
-		    int monsterId = abs(dMonster[target.x][target.y]) - 1;
+		    int monsterId = std::abs(dMonster[target.x][target.y]) - 1;
 		    if (monsterId < 0)
 			    return false;
 
@@ -1252,7 +1253,7 @@ void AddBerserk(Missile &missile, AddMissileParameter &parameter)
 	    parameter.dst, 0, 5);
 
 	if (targetMonsterPosition) {
-		auto &monster = Monsters[abs(dMonster[targetMonsterPosition->x][targetMonsterPosition->y]) - 1];
+		auto &monster = Monsters[std::abs(dMonster[targetMonsterPosition->x][targetMonsterPosition->y]) - 1];
 		Player &player = *missile.sourcePlayer();
 		const int slvl = player.GetSpellLevel(SpellID::Berserk);
 		monster.flags |= MFLAG_BERSERK | MFLAG_GOLEM;
@@ -1321,7 +1322,7 @@ void AddStealPotions(Missile &missile, AddMissileParameter & /*parameter*/)
 		int8_t pnum = dPlayer[target.x][target.y];
 		if (pnum == 0)
 			return false;
-		Player &player = Players[abs(pnum) - 1];
+		Player &player = Players[std::abs(pnum) - 1];
 
 		bool hasPlayedSFX = false;
 		for (int si = 0; si < MaxBeltItems; si++) {
@@ -1388,7 +1389,7 @@ void AddStealMana(Missile &missile, AddMissileParameter & /*parameter*/)
 	    missile.position.start, 0, 2);
 
 	if (trappedPlayerPosition) {
-		Player &player = Players[abs(dPlayer[trappedPlayerPosition->x][trappedPlayerPosition->y]) - 1];
+		Player &player = Players[std::abs(dPlayer[trappedPlayerPosition->x][trappedPlayerPosition->y]) - 1];
 
 		player._pMana = 0;
 		player._pManaBase = player._pMana + player._pMaxManaBase - player._pMaxMana;
@@ -2288,7 +2289,7 @@ void AddStoneCurse(Missile &missile, AddMissileParameter &parameter)
 			    return false;
 		    }
 
-		    int monsterId = abs(dMonster[target.x][target.y]) - 1;
+		    int monsterId = std::abs(dMonster[target.x][target.y]) - 1;
 		    if (monsterId < 0) {
 			    return false;
 		    }
@@ -2313,7 +2314,7 @@ void AddStoneCurse(Missile &missile, AddMissileParameter &parameter)
 	}
 
 	// Petrify the targeted monster
-	int monsterId = abs(dMonster[targetMonsterPosition->x][targetMonsterPosition->y]) - 1;
+	int monsterId = std::abs(dMonster[targetMonsterPosition->x][targetMonsterPosition->y]) - 1;
 	auto &monster = Monsters[monsterId];
 
 	if (monster.mode == MonsterMode::Petrified) {
@@ -3105,7 +3106,7 @@ void ProcessRune(Missile &missile)
 	int mid = dMonster[position.x][position.y];
 	int pid = dPlayer[position.x][position.y];
 	if (mid != 0 || pid != 0) {
-		Point targetPosition = mid != 0 ? Monsters[abs(mid) - 1].position.tile : Players[abs(pid) - 1].position.tile;
+		Point targetPosition = mid != 0 ? Monsters[std::abs(mid) - 1].position.tile : Players[std::abs(pid) - 1].position.tile;
 		Direction dir = GetDirection(position, targetPosition);
 
 		missile._miDelFlag = true;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -221,7 +221,7 @@ bool MonsterMHit(int pnum, int monsterId, int mindam, int maxdam, int dist, Miss
 		hper = player.GetMagicToHit() - (monster.level(sgGameInitInfo.nDifficulty) * 2) - dist;
 	}
 
-	hper = clamp(hper, 5, 95);
+	hper = std::clamp(hper, 5, 95);
 
 	if (monster.mode == MonsterMode::Petrified)
 		hit = 0;
@@ -337,7 +337,7 @@ bool Plr2PlrMHit(const Player &player, int p, int mindam, int maxdam, int dist, 
 		    - dist;
 	}
 
-	hit = clamp(hit, 5, 95);
+	hit = std::clamp(hit, 5, 95);
 
 	if (hper >= hit) {
 		return false;
@@ -349,7 +349,7 @@ bool Plr2PlrMHit(const Player &player, int p, int mindam, int maxdam, int dist, 
 	}
 
 	int blk = target.GetBlockChance() - (player._pLevel * 2);
-	blk = clamp(blk, 0, 100);
+	blk = std::clamp(blk, 0, 100);
 
 	int dam;
 	if (mtype == MissileID::BoneSpirit) {
@@ -948,7 +948,7 @@ bool MonsterTrapHit(int monsterId, int mindam, int maxdam, int dist, MissileID t
 
 	int hit = GenerateRnd(100);
 	int hper = 90 - monster.armorClass - dist;
-	hper = clamp(hper, 5, 95);
+	hper = std::clamp(hper, 5, 95);
 	if (monster.tryLiftGargoyle())
 		return true;
 	if (hit >= hper && monster.mode != MonsterMode::Petrified) {
@@ -1041,7 +1041,7 @@ bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, Missil
 	int blkper = player.GetBlockChance(false);
 	if (monster != nullptr)
 		blkper -= (monster->level(sgGameInitInfo.nDifficulty) - player._pLevel) * 2;
-	blkper = clamp(blkper, 0, 100);
+	blkper = std::clamp(blkper, 0, 100);
 
 	int8_t resper;
 	switch (damageType) {

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <list>
+#include <optional>
 
 #include "engine.h"
 #include "engine/point.hpp"
@@ -14,7 +15,6 @@
 #include "monster.h"
 #include "player.h"
 #include "spelldat.h"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1169,7 +1169,7 @@ void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, 
 		blkper = GenerateRnd(100);
 	}
 	int blk = player.GetBlockChance() - (monster.level(sgGameInitInfo.nDifficulty) * 2);
-	blk = clamp(blk, 0, 100);
+	blk = std::clamp(blk, 0, 100);
 	if (hper >= hit)
 		return;
 	if (blkper < blk) {

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4283,21 +4283,21 @@ void PrintMonstHistory(int mt)
 			if ((res & (RESIST_MAGIC | RESIST_FIRE | RESIST_LIGHTNING)) != 0) {
 				std::string resists = std::string(_("Resists:"));
 				if ((res & RESIST_MAGIC) != 0)
-					AppendStrView(resists, _(" Magic"));
+					resists.append(_(" Magic"));
 				if ((res & RESIST_FIRE) != 0)
-					AppendStrView(resists, _(" Fire"));
+					resists.append(_(" Fire"));
 				if ((res & RESIST_LIGHTNING) != 0)
-					AppendStrView(resists, _(" Lightning"));
+					resists.append(_(" Lightning"));
 				AddPanelString(resists);
 			}
 			if ((res & (IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING)) != 0) {
 				std::string immune = std::string(_("Immune:"));
 				if ((res & IMMUNE_MAGIC) != 0)
-					AppendStrView(immune, _(" Magic"));
+					immune.append(_(" Magic"));
 				if ((res & IMMUNE_FIRE) != 0)
-					AppendStrView(immune, _(" Fire"));
+					immune.append(_(" Fire"));
 				if ((res & IMMUNE_LIGHTNING) != 0)
-					AppendStrView(immune, _(" Lightning"));
+					immune.append(_(" Lightning"));
 				AddPanelString(immune);
 			}
 		}

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -6,6 +6,7 @@
 #include "monster.h"
 
 #include <climits>
+#include <cmath>
 #include <cstdint>
 
 #include <algorithm>
@@ -266,7 +267,7 @@ void PlaceGroup(size_t typeIndex, unsigned num, Monster *leader = nullptr, bool 
 		for (unsigned try2 = 0; j < num && try2 < 100; xp += Displacement(static_cast<Direction>(GenerateRnd(8))).deltaX, yp += Displacement(static_cast<Direction>(GenerateRnd(8))).deltaX) { /// BUGFIX: `yp += Point.y`
 			if (!CanPlaceMonster({ xp, yp })
 			    || (dTransVal[xp][yp] != dTransVal[x1][y1])
-			    || (leashed && (abs(xp - x1) >= 4 || abs(yp - y1) >= 4))) {
+			    || (leashed && (std::abs(xp - x1) >= 4 || std::abs(yp - y1) >= 4))) {
 				try2++;
 				continue;
 			}
@@ -3894,7 +3895,7 @@ void GolumAi(Monster &golem)
 		int mex = golem.position.tile.x - enemy.position.future.x;
 		int mey = golem.position.tile.y - enemy.position.future.y;
 		golem.direction = GetDirection(golem.position.tile, enemy.position.tile);
-		if (abs(mex) < 2 && abs(mey) < 2) {
+		if (std::abs(mex) < 2 && std::abs(mey) < 2) {
 			golem.enemyPosition = enemy.position.tile;
 			if (enemy.activeForTicks == 0) {
 				enemy.activeForTicks = UINT8_MAX;
@@ -4092,7 +4093,7 @@ bool LineClear(tl::function_ref<bool(Point)> clear, Point startPoint, Point endP
 
 	int dx = endPoint.x - position.x;
 	int dy = endPoint.y - position.y;
-	if (abs(dx) > abs(dy)) {
+	if (std::abs(dx) > std::abs(dy)) {
 		if (dx < 0) {
 			std::swap(position, endPoint);
 			dx = -dx;
@@ -4224,7 +4225,7 @@ void M_FallenFear(Point position)
 		int m = dMonster[tile.x][tile.y];
 		if (m == 0)
 			continue;
-		Monster &monster = Monsters[abs(m) - 1];
+		Monster &monster = Monsters[std::abs(m) - 1];
 		if (monster.ai != MonsterAIID::Fallen || monster.hitPoints >> 6 <= 0)
 			continue;
 
@@ -4426,7 +4427,7 @@ Monster *FindMonsterAtPosition(Point position, bool ignoreMovingMonsters)
 		return nullptr;
 	}
 
-	return &Monsters[abs(monsterId) - 1];
+	return &Monsters[std::abs(monsterId) - 1];
 }
 
 Monster *FindUniqueMonster(UniqueMonsterType monsterType)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3372,7 +3372,7 @@ void InitMonsterGFX(CMonster &monsterType)
 		}
 		animOffsets[clxData.size()] = accumulatedSize;
 		monsterType.animData = nullptr;
-		monsterType.animData = std::unique_ptr<byte[]>(new byte[accumulatedSize]);
+		monsterType.animData = std::unique_ptr<std::byte[]>(new std::byte[accumulatedSize]);
 		for (size_t i = 0; i < clxData.size(); ++i) {
 			memcpy(&monsterType.animData[animOffsets[i]], clxData[i].data(), clxData[i].size());
 		}

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -176,7 +176,7 @@ enum class MonsterSound : uint8_t {
 };
 
 struct CMonster {
-	std::unique_ptr<byte[]> animData;
+	std::unique_ptr<std::byte[]> animData;
 	AnimStruct anims[6];
 	std::unique_ptr<TSnd> sounds[4][2];
 	const MonsterData *data;

--- a/Source/mpq/mpq_reader.cpp
+++ b/Source/mpq/mpq_reader.cpp
@@ -1,10 +1,9 @@
 #include "mpq/mpq_reader.hpp"
 
 #include <cstdint>
+#include <optional>
 
 #include <libmpq/mpq.h>
-
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/mpq/mpq_reader.cpp
+++ b/Source/mpq/mpq_reader.cpp
@@ -62,9 +62,9 @@ bool MpqArchive::GetFileNumber(MpqArchive::FileHash fileHash, uint32_t &fileNumb
 	return libmpq__file_number_from_hash(archive_, fileHash[0], fileHash[1], fileHash[2], &fileNumber) == 0;
 }
 
-std::unique_ptr<byte[]> MpqArchive::ReadFile(const char *filename, std::size_t &fileSize, int32_t &error)
+std::unique_ptr<std::byte[]> MpqArchive::ReadFile(const char *filename, std::size_t &fileSize, int32_t &error)
 {
-	std::unique_ptr<byte[]> result;
+	std::unique_ptr<std::byte[]> result;
 	std::uint32_t fileNumber;
 	error = libmpq__file_number(archive_, filename, &fileNumber);
 	if (error != 0)
@@ -79,7 +79,7 @@ std::unique_ptr<byte[]> MpqArchive::ReadFile(const char *filename, std::size_t &
 	if (error != 0)
 		return result;
 
-	result = std::make_unique<byte[]>(unpackedSize);
+	result = std::make_unique<std::byte[]>(unpackedSize);
 
 	const std::size_t blockSize = GetBlockSize(fileNumber, 0, error);
 	if (error != 0)

--- a/Source/mpq/mpq_reader.hpp
+++ b/Source/mpq/mpq_reader.hpp
@@ -4,10 +4,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
-
-#include "utils/stdcompat/optional.hpp"
 
 // Forward-declare so that we can avoid exposing libmpq.
 struct mpq_archive;

--- a/Source/mpq/mpq_reader.hpp
+++ b/Source/mpq/mpq_reader.hpp
@@ -7,7 +7,6 @@
 #include <string>
 #include <vector>
 
-#include "utils/stdcompat/cstddef.hpp"
 #include "utils/stdcompat/optional.hpp"
 
 // Forward-declare so that we can avoid exposing libmpq.
@@ -43,7 +42,7 @@ public:
 	// Returns false if the file does not exit.
 	bool GetFileNumber(FileHash fileHash, uint32_t &fileNumber);
 
-	std::unique_ptr<byte[]> ReadFile(const char *filename, std::size_t &fileSize, int32_t &error);
+	std::unique_ptr<std::byte[]> ReadFile(const char *filename, std::size_t &fileSize, int32_t &error);
 
 	// Returns error code.
 	int32_t ReadBlock(uint32_t fileNumber, uint32_t blockNumber, uint8_t *out, uint32_t outSize);

--- a/Source/mpq/mpq_writer.cpp
+++ b/Source/mpq/mpq_writer.cpp
@@ -362,7 +362,7 @@ MpqBlockEntry *MpqWriter::AddFile(const char *filename, MpqBlockEntry *block, ui
 	return block;
 }
 
-bool MpqWriter::WriteFileContents(const char *filename, const byte *fileData, size_t fileSize, MpqBlockEntry *block)
+bool MpqWriter::WriteFileContents(const char *filename, const std::byte *fileData, size_t fileSize, MpqBlockEntry *block)
 {
 	const char *tmp;
 	while ((tmp = strchr(filename, ':')) != nullptr)
@@ -408,7 +408,7 @@ bool MpqWriter::WriteFileContents(const char *filename, const byte *fileData, si
 #endif
 
 	uint32_t destSize = offsetTableByteSize;
-	byte mpqBuf[BlockSize];
+	std::byte mpqBuf[BlockSize];
 	size_t curSector = 0;
 	while (true) {
 		uint32_t len = std::min<uint32_t>(fileSize, BlockSize);
@@ -504,7 +504,7 @@ void MpqWriter::RemoveHashEntries(bool (*fnGetName)(uint8_t, char *))
 	}
 }
 
-bool MpqWriter::WriteFile(const char *filename, const byte *data, size_t size)
+bool MpqWriter::WriteFile(const char *filename, const std::byte *data, size_t size)
 {
 	MpqBlockEntry *blockEntry;
 

--- a/Source/mpq/mpq_writer.hpp
+++ b/Source/mpq/mpq_writer.hpp
@@ -5,11 +5,11 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 #include "mpq/mpq_common.hpp"
 #include "utils/logged_fstream.hpp"
-#include "utils/stdcompat/cstddef.hpp"
 
 namespace devilution {
 class MpqWriter {
@@ -27,7 +27,7 @@ public:
 
 	void RemoveHashEntry(const char *filename);
 	void RemoveHashEntries(bool (*fnGetName)(uint8_t, char *));
-	bool WriteFile(const char *filename, const byte *data, size_t size);
+	bool WriteFile(const char *filename, const std::byte *data, size_t size);
 	void RenameFile(const char *name, const char *newName);
 
 private:
@@ -37,7 +37,7 @@ private:
 
 	bool ReadMPQHeader(MpqFileHeader *hdr);
 	MpqBlockEntry *AddFile(const char *filename, MpqBlockEntry *block, uint32_t blockIndex);
-	bool WriteFileContents(const char *filename, const byte *fileData, size_t fileSize, MpqBlockEntry *block);
+	bool WriteFileContents(const char *filename, const std::byte *fileData, size_t fileSize, MpqBlockEntry *block);
 
 	// Returns an unused entry in the block entry table.
 	MpqBlockEntry *NewBlock(uint32_t *blockIndex = nullptr);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2351,8 +2351,8 @@ void RecreateItem(const Player &player, const TItem &messageItem, Item &item)
 		item._iIdentified = true;
 	item._iMaxDur = messageItem.bMDur;
 	item._iDurability = ClampDurability(item, messageItem.bDur);
-	item._iMaxCharges = clamp<int>(messageItem.bMCh, 0, item._iMaxCharges);
-	item._iCharges = clamp<int>(messageItem.bCh, 0, item._iMaxCharges);
+	item._iMaxCharges = std::clamp<int>(messageItem.bMCh, 0, item._iMaxCharges);
+	item._iCharges = std::clamp<int>(messageItem.bCh, 0, item._iMaxCharges);
 	if (gbIsHellfire) {
 		item._iPLToHit = ClampToHit(item, SDL_SwapLE16(messageItem.wToHit));
 		item._iMaxDam = ClampMaxDam(item, SDL_SwapLE16(messageItem.wMaxDam));

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -150,7 +150,7 @@ string_view CmdIdString(_cmd_id cmd)
 
 struct TMegaPkt {
 	uint32_t spaceLeft;
-	byte data[32000];
+	std::byte data[32000];
 
 	TMegaPkt()
 	    : spaceLeft(sizeof(data))
@@ -220,7 +220,7 @@ uint8_t sbLastCmd;
 /**
  * @brief buffer used to receive level deltas, size is the worst expected case assuming every object on a level was touched
  */
-byte sgRecvBuf[1U + sizeof(DLevel::item) + sizeof(uint8_t) + (sizeof(WorldTilePosition) + sizeof(_cmd_id)) * MAXOBJECTS + sizeof(DLevel::monster)];
+std::byte sgRecvBuf[1U + sizeof(DLevel::item) + sizeof(uint8_t) + (sizeof(WorldTilePosition) + sizeof(_cmd_id)) * MAXOBJECTS + sizeof(DLevel::monster)];
 _cmd_id sgbRecvCmd;
 std::unordered_map<uint8_t, LocalLevel> LocalLevels;
 DJunk sgJunk;
@@ -338,7 +338,7 @@ void PrePacket()
 {
 	uint8_t playerId = std::numeric_limits<uint8_t>::max();
 	for (TMegaPkt &pkt : MegaPktList) {
-		byte *data = pkt.data;
+		std::byte *data = pkt.data;
 		size_t spaceLeft = sizeof(pkt.data);
 		while (spaceLeft != pkt.spaceLeft) {
 			auto cmdId = static_cast<_cmd_id>(*data);
@@ -426,11 +426,11 @@ int WaitForTurns()
 	return 100 * sgbDeltaChunks / MAX_CHUNKS;
 }
 
-byte *DeltaExportItem(byte *dst, const TCmdPItem *src)
+std::byte *DeltaExportItem(std::byte *dst, const TCmdPItem *src)
 {
 	for (int i = 0; i < MAXITEMS; i++, src++) {
 		if (src->bCmd == CMD_INVALID) {
-			*dst++ = byte { 0xFF };
+			*dst++ = std::byte { 0xFF };
 		} else {
 			memcpy(dst, src, sizeof(TCmdPItem));
 			dst += sizeof(TCmdPItem);
@@ -440,11 +440,11 @@ byte *DeltaExportItem(byte *dst, const TCmdPItem *src)
 	return dst;
 }
 
-size_t DeltaImportItem(const byte *src, TCmdPItem *dst)
+size_t DeltaImportItem(const std::byte *src, TCmdPItem *dst)
 {
 	size_t size = 0;
 	for (int i = 0; i < MAXITEMS; i++, dst++) {
-		if (src[size] == byte { 0xFF }) {
+		if (src[size] == std::byte { 0xFF }) {
 			memset(dst, 0xFF, sizeof(TCmdPItem));
 			size++;
 		} else {
@@ -456,19 +456,19 @@ size_t DeltaImportItem(const byte *src, TCmdPItem *dst)
 	return size;
 }
 
-byte *DeltaExportObject(byte *dst, const std::unordered_map<WorldTilePosition, DObjectStr> &src)
+std::byte *DeltaExportObject(std::byte *dst, const std::unordered_map<WorldTilePosition, DObjectStr> &src)
 {
-	*dst++ = static_cast<byte>(src.size());
+	*dst++ = static_cast<std::byte>(src.size());
 	for (auto &pair : src) {
-		*dst++ = static_cast<byte>(pair.first.x);
-		*dst++ = static_cast<byte>(pair.first.y);
-		*dst++ = static_cast<byte>(pair.second.bCmd);
+		*dst++ = static_cast<std::byte>(pair.first.x);
+		*dst++ = static_cast<std::byte>(pair.first.y);
+		*dst++ = static_cast<std::byte>(pair.second.bCmd);
 	}
 
 	return dst;
 }
 
-const byte *DeltaImportObjects(const byte *src, std::unordered_map<WorldTilePosition, DObjectStr> &dst)
+const std::byte *DeltaImportObjects(const std::byte *src, std::unordered_map<WorldTilePosition, DObjectStr> &dst)
 {
 	dst.clear();
 
@@ -484,11 +484,11 @@ const byte *DeltaImportObjects(const byte *src, std::unordered_map<WorldTilePosi
 	return src;
 }
 
-byte *DeltaExportMonster(byte *dst, const DMonsterStr *src)
+std::byte *DeltaExportMonster(std::byte *dst, const DMonsterStr *src)
 {
 	for (size_t i = 0; i < MaxMonsters; i++, src++) {
 		if (src->position.x == 0xFF) {
-			*dst++ = byte { 0xFF };
+			*dst++ = std::byte { 0xFF };
 		} else {
 			memcpy(dst, src, sizeof(DMonsterStr));
 			dst += sizeof(DMonsterStr);
@@ -498,11 +498,11 @@ byte *DeltaExportMonster(byte *dst, const DMonsterStr *src)
 	return dst;
 }
 
-void DeltaImportMonster(const byte *src, DMonsterStr *dst)
+void DeltaImportMonster(const std::byte *src, DMonsterStr *dst)
 {
 	size_t size = 0;
 	for (size_t i = 0; i < MaxMonsters; i++, dst++) {
-		if (src[size] == byte { 0xFF }) {
+		if (src[size] == std::byte { 0xFF }) {
 			memset(dst, 0xFF, sizeof(DMonsterStr));
 			size++;
 		} else {
@@ -512,11 +512,11 @@ void DeltaImportMonster(const byte *src, DMonsterStr *dst)
 	}
 }
 
-byte *DeltaExportJunk(byte *dst)
+std::byte *DeltaExportJunk(std::byte *dst)
 {
 	for (auto &portal : sgJunk.portal) {
 		if (portal.x == 0xFF) {
-			*dst++ = byte { 0xFF };
+			*dst++ = std::byte { 0xFF };
 		} else {
 			memcpy(dst, &portal, sizeof(DPortal));
 			dst += sizeof(DPortal);
@@ -541,10 +541,10 @@ byte *DeltaExportJunk(byte *dst)
 	return dst;
 }
 
-void DeltaImportJunk(const byte *src)
+void DeltaImportJunk(const std::byte *src)
 {
 	for (int i = 0; i < MAXPORTAL; i++) {
-		if (*src == byte { 0xFF }) {
+		if (*src == std::byte { 0xFF }) {
 			memset(&sgJunk.portal[i], 0xFF, sizeof(DPortal));
 			src++;
 		} else {
@@ -564,17 +564,17 @@ void DeltaImportJunk(const byte *src)
 	}
 }
 
-uint32_t CompressData(byte *buffer, byte *end)
+uint32_t CompressData(std::byte *buffer, std::byte *end)
 {
 #ifdef USE_PKWARE
 	const auto size = static_cast<uint32_t>(end - buffer - 1);
 	const uint32_t pkSize = PkwareCompress(buffer + 1, size);
 
-	*buffer = size != pkSize ? byte { 1 } : byte { 0 };
+	*buffer = size != pkSize ? std::byte { 1 } : std::byte { 0 };
 
 	return pkSize + 1;
 #else
-	*buffer = byte { 0 };
+	*buffer = std::byte { 0 };
 	return end - buffer;
 #endif
 }
@@ -582,11 +582,11 @@ uint32_t CompressData(byte *buffer, byte *end)
 void DeltaImportData(_cmd_id cmd, uint32_t recvOffset)
 {
 #ifdef USE_PKWARE
-	if (sgRecvBuf[0] != byte { 0 })
+	if (sgRecvBuf[0] != std::byte { 0 })
 		PkwareDecompress(&sgRecvBuf[1], recvOffset, sizeof(sgRecvBuf) - 1);
 #endif
 
-	const byte *src = &sgRecvBuf[1];
+	const std::byte *src = &sgRecvBuf[1];
 	if (cmd == CMD_DLEVEL_JUNK) {
 		DeltaImportJunk(src);
 	} else if (cmd == CMD_DLEVEL) {
@@ -823,7 +823,7 @@ void NetSendCmdGItem2(bool usonly, _cmd_id bCmd, uint8_t mast, uint8_t pnum, con
 
 	if (!usonly) {
 		cmd.dwTime = 0;
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 		return;
 	}
 
@@ -834,7 +834,7 @@ void NetSendCmdGItem2(bool usonly, _cmd_id bCmd, uint8_t mast, uint8_t pnum, con
 		return;
 	}
 
-	tmsg_add((byte *)&cmd, sizeof(cmd));
+	tmsg_add((std::byte *)&cmd, sizeof(cmd));
 }
 
 bool NetSendCmdReq2(_cmd_id bCmd, uint8_t mast, uint8_t pnum, const TCmdGItem &item)
@@ -852,7 +852,7 @@ bool NetSendCmdReq2(_cmd_id bCmd, uint8_t mast, uint8_t pnum, const TCmdGItem &i
 	else if (ticks - SDL_SwapLE32(cmd.dwTime) > 5000)
 		return false;
 
-	tmsg_add((byte *)&cmd, sizeof(cmd));
+	tmsg_add((std::byte *)&cmd, sizeof(cmd));
 
 	return true;
 }
@@ -864,7 +864,7 @@ void NetSendCmdExtra(const TCmdGItem &item)
 	memcpy(&cmd, &item, sizeof(cmd));
 	cmd.dwTime = 0;
 	cmd.bCmd = CMD_ITEMEXTRA;
-	NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+	NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
 size_t OnWalk(const TCmd *pCmd, Player &player)
@@ -2428,10 +2428,10 @@ void DeltaExportData(int pnum)
 		    + sizeof(uint8_t)                                                             /* count of object interactions which caused a state change since dungeon generation */
 		    + (sizeof(WorldTilePosition) + sizeof(DObjectStr)) * deltaLevel.object.size() /* location/action pairs for the object interactions */
 		    + sizeof(deltaLevel.monster);                                                 /* latest monster state */
-		std::unique_ptr<byte[]> dst { new byte[bufferSize] };
+		std::unique_ptr<std::byte[]> dst { new std::byte[bufferSize] };
 
-		byte *dstEnd = &dst.get()[1];
-		*dstEnd = static_cast<byte>(it.first);
+		std::byte *dstEnd = &dst.get()[1];
+		*dstEnd = static_cast<std::byte>(it.first);
 		dstEnd += sizeof(uint8_t);
 		dstEnd = DeltaExportItem(dstEnd, deltaLevel.item);
 		dstEnd = DeltaExportObject(dstEnd, deltaLevel.object);
@@ -2440,13 +2440,13 @@ void DeltaExportData(int pnum)
 		multi_send_zero_packet(pnum, CMD_DLEVEL, dst.get(), size);
 	}
 
-	byte dst[sizeof(DJunk) + 1];
-	byte *dstEnd = &dst[1];
+	std::byte dst[sizeof(DJunk) + 1];
+	std::byte *dstEnd = &dst[1];
 	dstEnd = DeltaExportJunk(dstEnd);
 	uint32_t size = CompressData(dst, dstEnd);
 	multi_send_zero_packet(pnum, CMD_DLEVEL_JUNK, dst, size);
 
-	byte src[1] = { static_cast<byte>(0) };
+	std::byte src[1] = { static_cast<std::byte>(0) };
 	multi_send_zero_packet(pnum, CMD_DLEVEL_END, src, 1);
 }
 
@@ -2730,9 +2730,9 @@ void NetSendCmd(bool bHiPri, _cmd_id bCmd)
 
 	cmd.bCmd = bCmd;
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdGolem(uint8_t mx, uint8_t my, Direction dir, uint8_t menemy, int hp, uint8_t cl)
@@ -2746,7 +2746,7 @@ void NetSendCmdGolem(uint8_t mx, uint8_t my, Direction dir, uint8_t menemy, int 
 	cmd._menemy = menemy;
 	cmd._mhitpoints = hp;
 	cmd._currlevel = cl;
-	NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+	NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdLoc(size_t playerId, bool bHiPri, _cmd_id bCmd, Point position)
@@ -2760,9 +2760,9 @@ void NetSendCmdLoc(size_t playerId, bool bHiPri, _cmd_id bCmd, Point position)
 	cmd.x = position.x;
 	cmd.y = position.y;
 	if (bHiPri)
-		NetSendHiPri(playerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(playerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(playerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(playerId, (std::byte *)&cmd, sizeof(cmd));
 
 	MyPlayer->UpdatePreviewCelSprite(bCmd, position, 0, 0);
 }
@@ -2779,9 +2779,9 @@ void NetSendCmdLocParam1(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 	cmd.y = position.y;
 	cmd.wParam1 = SDL_SwapLE16(wParam1);
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 
 	MyPlayer->UpdatePreviewCelSprite(bCmd, position, wParam1, 0);
 }
@@ -2799,9 +2799,9 @@ void NetSendCmdLocParam2(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 	cmd.wParam1 = SDL_SwapLE16(wParam1);
 	cmd.wParam2 = SDL_SwapLE16(wParam2);
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 
 	MyPlayer->UpdatePreviewCelSprite(bCmd, position, wParam1, wParam2);
 }
@@ -2820,9 +2820,9 @@ void NetSendCmdLocParam3(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 	cmd.wParam2 = SDL_SwapLE16(wParam2);
 	cmd.wParam3 = SDL_SwapLE16(wParam3);
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 
 	MyPlayer->UpdatePreviewCelSprite(bCmd, position, wParam1, wParam2);
 }
@@ -2842,9 +2842,9 @@ void NetSendCmdLocParam4(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 	cmd.wParam3 = SDL_SwapLE16(wParam3);
 	cmd.wParam4 = SDL_SwapLE16(wParam4);
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 
 	MyPlayer->UpdatePreviewCelSprite(bCmd, position, wParam1, wParam3);
 }
@@ -2865,9 +2865,9 @@ void NetSendCmdLocParam5(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 	cmd.wParam4 = SDL_SwapLE16(wParam4);
 	cmd.wParam5 = SDL_SwapLE16(wParam5);
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 
 	MyPlayer->UpdatePreviewCelSprite(bCmd, position, wParam1, wParam3);
 }
@@ -2882,9 +2882,9 @@ void NetSendCmdParam1(bool bHiPri, _cmd_id bCmd, uint16_t wParam1)
 	cmd.bCmd = bCmd;
 	cmd.wParam1 = SDL_SwapLE16(wParam1);
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 
 	MyPlayer->UpdatePreviewCelSprite(bCmd, {}, wParam1, 0);
 }
@@ -2897,9 +2897,9 @@ void NetSendCmdParam2(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wPar
 	cmd.wParam1 = SDL_SwapLE16(wParam1);
 	cmd.wParam2 = SDL_SwapLE16(wParam2);
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdParam5(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4, uint16_t wParam5)
@@ -2916,9 +2916,9 @@ void NetSendCmdParam5(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wPar
 	cmd.wParam4 = SDL_SwapLE16(wParam4);
 	cmd.wParam5 = SDL_SwapLE16(wParam5);
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 
 	MyPlayer->UpdatePreviewCelSprite(bCmd, {}, wParam1, wParam2);
 }
@@ -2935,9 +2935,9 @@ void NetSendCmdQuest(bool bHiPri, const Quest &quest)
 	cmd.qmsg = quest._qmsg;
 
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdGItem(bool bHiPri, _cmd_id bCmd, uint8_t pnum, uint8_t ii)
@@ -2955,9 +2955,9 @@ void NetSendCmdGItem(bool bHiPri, _cmd_id bCmd, uint8_t pnum, uint8_t ii)
 	PrepareItemForNetwork(Items[ii], cmd);
 
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position, const Item &item)
@@ -2972,9 +2972,9 @@ void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position, const Item &item
 	ItemLimbo = item;
 
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdChItem(bool bHiPri, uint8_t bLoc, bool forceSpellChange)
@@ -2989,9 +2989,9 @@ void NetSendCmdChItem(bool bHiPri, uint8_t bLoc, bool forceSpellChange)
 	PrepareItemForNetwork(item, cmd);
 
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdDelItem(bool bHiPri, uint8_t bLoc)
@@ -3001,9 +3001,9 @@ void NetSendCmdDelItem(bool bHiPri, uint8_t bLoc)
 	cmd.bLoc = bLoc;
 	cmd.bCmd = CMD_DELPLRITEMS;
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
 void NetSyncInvItem(const Player &player, int invListIndex)
@@ -3031,9 +3031,9 @@ void NetSendCmdChInvItem(bool bHiPri, int invGridIndex)
 	PrepareItemForNetwork(item, cmd);
 
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdChBeltItem(bool bHiPri, int beltIndex)
@@ -3047,9 +3047,9 @@ void NetSendCmdChBeltItem(bool bHiPri, int beltIndex)
 	PrepareItemForNetwork(item, cmd);
 
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdDamage(bool bHiPri, uint8_t bPlr, uint32_t dwDam, DamageType damageType)
@@ -3061,9 +3061,9 @@ void NetSendCmdDamage(bool bHiPri, uint8_t bPlr, uint32_t dwDam, DamageType dama
 	cmd.dwDam = dwDam;
 	cmd.damageType = damageType;
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdMonDmg(bool bHiPri, uint16_t wMon, uint32_t dwDam)
@@ -3074,9 +3074,9 @@ void NetSendCmdMonDmg(bool bHiPri, uint16_t wMon, uint32_t dwDam)
 	cmd.wMon = wMon;
 	cmd.dwDam = dwDam;
 	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else
-		NetSendLoPri(MyPlayerId, (byte *)&cmd, sizeof(cmd));
+		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
 void NetSendCmdString(uint32_t pmask, const char *pszStr)
@@ -3085,7 +3085,7 @@ void NetSendCmdString(uint32_t pmask, const char *pszStr)
 
 	cmd.bCmd = CMD_STRING;
 	CopyUtf8(cmd.str, pszStr, sizeof(cmd.str));
-	multi_send_msg_packet(pmask, (byte *)&cmd, strlen(cmd.str) + 2);
+	multi_send_msg_packet(pmask, (std::byte *)&cmd, strlen(cmd.str) + 2);
 }
 
 void delta_close_portal(int pnum)

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -4,6 +4,7 @@
  * Implementation of function for sending and reciving network messages.
  */
 #include <climits>
+#include <cmath>
 #include <cstdint>
 #include <list>
 #include <memory>
@@ -1090,7 +1091,7 @@ size_t OnRequestGetItem(const TCmd *pCmd, Player &player)
 		if (GetItemRecord(dwSeed, wCI, wIndx)) {
 			int ii = -1;
 			if (InDungeonBounds(position)) {
-				ii = abs(dItem[position.x][position.y]) - 1;
+				ii = std::abs(dItem[position.x][position.y]) - 1;
 				if (ii >= 0 && !Items[ii].keyAttributesMatch(dwSeed, wIndx, wCI)) {
 					ii = -1;
 				}
@@ -3023,7 +3024,7 @@ void NetSendCmdChInvItem(bool bHiPri, int invGridIndex)
 {
 	TCmdChItem cmd {};
 
-	int8_t invListIndex = abs(MyPlayer->InvGrid[invGridIndex]) - 1;
+	int8_t invListIndex = std::abs(MyPlayer->InvGrid[invGridIndex]) - 1;
 	const Item &item = MyPlayer->InvList[invListIndex];
 
 	cmd.bCmd = CMD_CHANGEINVITEMS;

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -708,13 +708,13 @@ struct TPktHdr {
 
 struct TPkt {
 	TPktHdr hdr;
-	byte body[493];
+	std::byte body[493];
 };
 #pragma pack(pop)
 
 struct TBuffer {
 	uint32_t dwNextWriteOffset;
-	byte bData[4096];
+	std::byte bData[4096];
 };
 
 extern uint8_t gbBufferMsgs;

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -56,9 +56,9 @@ extern uint32_t player_state[MAX_PLRS];
 extern bool IsLoopback;
 
 void InitGameInfo();
-void NetSendLoPri(int playerId, const byte *data, size_t size);
-void NetSendHiPri(int playerId, const byte *data, size_t size);
-void multi_send_msg_packet(uint32_t pmask, const byte *data, size_t size);
+void NetSendLoPri(int playerId, const std::byte *data, size_t size);
+void NetSendHiPri(int playerId, const std::byte *data, size_t size);
+void multi_send_msg_packet(uint32_t pmask, const std::byte *data, size_t size);
 void multi_msg_countdown();
 void multi_player_left(int pnum, int reason);
 void multi_net_ping();
@@ -68,7 +68,7 @@ void multi_net_ping();
  */
 bool multi_handle_delta();
 void multi_process_network_packets();
-void multi_send_zero_packet(size_t pnum, _cmd_id bCmd, const byte *data, size_t size);
+void multi_send_zero_packet(size_t pnum, _cmd_id bCmd, const std::byte *data, size_t size);
 void NetClose();
 bool NetInit(bool bSinglePlayer);
 void recv_plrinfo(int pnum, const TCmdPlrInfoHdr &header, bool recv);

--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -258,7 +258,7 @@ void nthread_UpdateProgressToNextGameTick()
 	}
 	int ticksAdvanced = gnTickDelay - ticksMissing;
 	int32_t fraction = ticksAdvanced * AnimationInfo::baseValueFraction / gnTickDelay;
-	fraction = clamp<int32_t>(fraction, 0, AnimationInfo::baseValueFraction);
+	fraction = std::clamp<int32_t>(fraction, 0, AnimationInfo::baseValueFraction);
 	ProgressToNextGameTick = static_cast<uint8_t>(fraction);
 }
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4,6 +4,7 @@
  * Implementation of object functionality, interaction, spawning, loading, etc.
  */
 #include <climits>
+#include <cmath>
 #include <cstdint>
 #include <ctime>
 
@@ -3607,7 +3608,7 @@ void UpdateState(Object &object, int frame)
 
 unsigned int Object::GetId() const
 {
-	return abs(dObject[position.x][position.y]) - 1;
+	return std::abs(dObject[position.x][position.y]) - 1;
 }
 
 bool Object::IsDisabled() const
@@ -3633,7 +3634,7 @@ Object *FindObjectAtPosition(Point position, bool considerLargeObjects)
 	auto objectId = dObject[position.x][position.y];
 
 	if (objectId > 0 || (considerLargeObjects && objectId != 0)) {
-		return &Objects[abs(objectId) - 1];
+		return &Objects[std::abs(objectId) - 1];
 	}
 
 	// nothing at this position, return a nullptr

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <cmath>
 #include <cstdint>
 
 #include "engine/clx_sprite.hpp"
@@ -305,7 +306,7 @@ inline bool IsObjectAtPosition(Point position)
  */
 inline Object &ObjectAtPosition(Point position)
 {
-	return Objects[abs(dObject[position.x][position.y]) - 1];
+	return Objects[std::abs(dObject[position.x][position.y]) - 1];
 }
 
 /**

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -4,6 +4,7 @@
  * Load and save options from the diablo.ini file.
  */
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdio>
 
@@ -30,7 +31,6 @@
 #include "utils/language.h"
 #include "utils/log.hpp"
 #include "utils/paths.h"
-#include "utils/stdcompat/algorithm.hpp"
 #include "utils/str_cat.hpp"
 #include "utils/str_split.hpp"
 #include "utils/utf8.hpp"

--- a/Source/options.h
+++ b/Source/options.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <forward_list>
+#include <optional>
 #include <unordered_map>
 
 #include <SDL_version.h>
@@ -14,7 +15,6 @@
 #include "engine/sound_defs.hpp"
 #include "pack.h"
 #include "utils/enum_traits.h"
-#include "utils/stdcompat/optional.hpp"
 #include "utils/stdcompat/string_view.hpp"
 
 namespace devilution {

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -404,8 +404,8 @@ void UnPackItem(const ItemPack &packedItem, const Player &player, Item &item, bo
 		item._iIdentified = (packedItem.bId & 1) != 0;
 		item._iMaxDur = packedItem.bMDur;
 		item._iDurability = ClampDurability(item, packedItem.bDur);
-		item._iMaxCharges = clamp<int>(packedItem.bMCh, 0, item._iMaxCharges);
-		item._iCharges = clamp<int>(packedItem.bCh, 0, item._iMaxCharges);
+		item._iMaxCharges = std::clamp<int>(packedItem.bMCh, 0, item._iMaxCharges);
+		item._iCharges = std::clamp<int>(packedItem.bCh, 0, item._iMaxCharges);
 
 		RemoveInvalidItem(item);
 
@@ -421,17 +421,17 @@ void UnPackPlayer(const PlayerPack &packed, Player &player)
 	Point position { packed.px, packed.py };
 
 	player = {};
-	player._pLevel = clamp<int8_t>(packed.pLevel, 1, MaxCharacterLevel);
+	player._pLevel = std::clamp<int8_t>(packed.pLevel, 1, MaxCharacterLevel);
 	player._pMaxHPBase = SDL_SwapLE32(packed.pMaxHPBase);
 	player._pHPBase = SDL_SwapLE32(packed.pHPBase);
-	player._pHPBase = clamp<int32_t>(player._pHPBase, 0, player._pMaxHPBase);
+	player._pHPBase = std::clamp<int32_t>(player._pHPBase, 0, player._pMaxHPBase);
 	player._pMaxHP = player._pMaxHPBase;
 	player._pHitPoints = player._pHPBase;
 	player.position.tile = position;
 	player.position.future = position;
-	player.setLevel(clamp<int8_t>(packed.plrlevel, 0, NUMLEVELS));
+	player.setLevel(std::clamp<int8_t>(packed.plrlevel, 0, NUMLEVELS));
 
-	player._pClass = static_cast<HeroClass>(clamp<uint8_t>(packed.pClass, 0, enum_size<HeroClass>::value - 1));
+	player._pClass = static_cast<HeroClass>(std::clamp<uint8_t>(packed.pClass, 0, enum_size<HeroClass>::value - 1));
 
 	ClrPlrPath(player);
 	player.destAction = ACTION_NONE;

--- a/Source/panels/mainpanel.cpp
+++ b/Source/panels/mainpanel.cpp
@@ -1,6 +1,7 @@
 #include "panels/mainpanel.hpp"
 
 #include <cstdint>
+#include <optional>
 
 #include "control.h"
 #include "engine/clx_sprite.hpp"
@@ -11,7 +12,6 @@
 #include "utils/language.h"
 #include "utils/sdl_compat.h"
 #include "utils/sdl_geometry.h"
-#include "utils/stdcompat/optional.hpp"
 #include "utils/surface_to_clx.hpp"
 
 namespace devilution {

--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -1,6 +1,7 @@
 #include "panels/spell_book.hpp"
 
 #include <cstdint>
+#include <optional>
 
 #include <fmt/format.h>
 
@@ -19,7 +20,6 @@
 #include "player.h"
 #include "spelldat.h"
 #include "utils/language.h"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/panels/spell_icons.cpp
+++ b/Source/panels/spell_icons.cpp
@@ -1,6 +1,7 @@
 #include "panels/spell_icons.hpp"
 
 #include <cstdint>
+#include <optional>
 
 #include "engine.h"
 #include "engine/load_cel.hpp"
@@ -8,7 +9,6 @@
 #include "engine/palette.h"
 #include "engine/render/clx_render.hpp"
 #include "init.h"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -26,7 +26,6 @@
 #include "utils/language.h"
 #include "utils/parse_int.hpp"
 #include "utils/paths.h"
-#include "utils/stdcompat/abs.hpp"
 #include "utils/stdcompat/string_view.hpp"
 #include "utils/str_cat.hpp"
 #include "utils/str_split.hpp"

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -144,7 +144,7 @@ bool ReadHero(SaveReader &archive, PlayerPack *pPack)
 void EncodeHero(SaveWriter &saveWriter, const PlayerPack *pack)
 {
 	size_t packedLen = codec_get_encoded_len(sizeof(*pack));
-	std::unique_ptr<byte[]> packed { new byte[packedLen] };
+	std::unique_ptr<std::byte[]> packed { new std::byte[packedLen] };
 
 	memcpy(packed.get(), pack, sizeof(*pack));
 	codec_encode(packed.get(), sizeof(*pack), packedLen, pfile_get_password());
@@ -233,7 +233,7 @@ std::optional<SaveReader> CreateSaveReader(std::string &&path)
 
 #ifndef DISABLE_DEMOMODE
 struct CompareInfo {
-	std::unique_ptr<byte[]> &data;
+	std::unique_ptr<std::byte[]> &data;
 	size_t currentPosition;
 	size_t size;
 	bool isTownLevel;
@@ -275,7 +275,7 @@ void CreateDetailDiffs(string_view prefix, string_view memoryMapFile, CompareInf
 	}
 
 	size_t readBytes = SDL_RWsize(handle);
-	std::unique_ptr<byte[]> memoryMapFileData { new byte[readBytes] };
+	std::unique_ptr<std::byte[]> memoryMapFileData { new std::byte[readBytes] };
 	SDL_RWread(handle, memoryMapFileData.get(), readBytes, 1);
 	const string_view buffer(reinterpret_cast<const char *>(memoryMapFileData.get()), readBytes);
 
@@ -502,9 +502,9 @@ void pfile_write_hero(SaveWriter &saveWriter, bool writeGameData)
 } // namespace
 
 #ifdef UNPACKED_SAVES
-std::unique_ptr<byte[]> SaveReader::ReadFile(const char *filename, std::size_t &fileSize, int32_t &error)
+std::unique_ptr<std::byte[]> SaveReader::ReadFile(const char *filename, std::size_t &fileSize, int32_t &error)
 {
-	std::unique_ptr<byte[]> result;
+	std::unique_ptr<std::byte[]> result;
 	error = 0;
 	const std::string path = dir_ + filename;
 	uintmax_t size;
@@ -518,7 +518,7 @@ std::unique_ptr<byte[]> SaveReader::ReadFile(const char *filename, std::size_t &
 		error = 1;
 		return nullptr;
 	}
-	result.reset(new byte[size]);
+	result.reset(new std::byte[size]);
 	if (std::fread(result.get(), size, 1, file) != 1) {
 		std::fclose(file);
 		error = 1;
@@ -528,7 +528,7 @@ std::unique_ptr<byte[]> SaveReader::ReadFile(const char *filename, std::size_t &
 	return result;
 }
 
-bool SaveWriter::WriteFile(const char *filename, const byte *data, size_t size)
+bool SaveWriter::WriteFile(const char *filename, const std::byte *data, size_t size)
 {
 	const std::string path = dir_ + filename;
 	FILE *file = OpenFile(path.c_str(), "wb");
@@ -563,12 +563,12 @@ std::optional<SaveReader> OpenStashArchive()
 	return CreateSaveReader(GetStashSavePath());
 }
 
-std::unique_ptr<byte[]> ReadArchive(SaveReader &archive, const char *pszName, size_t *pdwLen)
+std::unique_ptr<std::byte[]> ReadArchive(SaveReader &archive, const char *pszName, size_t *pdwLen)
 {
 	int32_t error;
 	std::size_t length;
 
-	std::unique_ptr<byte[]> result = archive.ReadFile(pszName, length, error);
+	std::unique_ptr<std::byte[]> result = archive.ReadFile(pszName, length, error);
 	if (error != 0)
 		return nullptr;
 

--- a/Source/pfile.h
+++ b/Source/pfile.h
@@ -35,7 +35,7 @@ struct SaveReader {
 		return dir_;
 	}
 
-	std::unique_ptr<byte[]> ReadFile(const char *filename, std::size_t &fileSize, int32_t &error);
+	std::unique_ptr<std::byte[]> ReadFile(const char *filename, std::size_t &fileSize, int32_t &error);
 
 	bool HasFile(const char *path)
 	{
@@ -52,7 +52,7 @@ struct SaveWriter {
 	{
 	}
 
-	bool WriteFile(const char *filename, const byte *data, size_t size);
+	bool WriteFile(const char *filename, const std::byte *data, size_t size);
 
 	bool HasFile(const char *path)
 	{
@@ -96,7 +96,7 @@ struct HeroCompareResult {
 std::optional<SaveReader> OpenSaveArchive(uint32_t saveNum);
 std::optional<SaveReader> OpenStashArchive();
 const char *pfile_get_password();
-std::unique_ptr<byte[]> ReadArchive(SaveReader &archive, const char *pszName, size_t *pdwLen = nullptr);
+std::unique_ptr<std::byte[]> ReadArchive(SaveReader &archive, const char *pszName, size_t *pdwLen = nullptr);
 void pfile_write_hero(bool writeGameData = false);
 
 #ifndef DISABLE_DEMOMODE
@@ -124,7 +124,7 @@ void pfile_read_player_from_save(uint32_t saveNum, Player &player);
 void pfile_save_level();
 void pfile_convert_levels();
 void pfile_remove_temp_files();
-std::unique_ptr<byte[]> pfile_read(const char *pszName, size_t *pdwLen);
+std::unique_ptr<std::byte[]> pfile_read(const char *pszName, size_t *pdwLen);
 void pfile_update(bool forceSave);
 
 } // namespace devilution

--- a/Source/platform/locale.cpp
+++ b/Source/platform/locale.cpp
@@ -1,5 +1,6 @@
 #include "locale.hpp"
 
+#include <algorithm>
 #include <cstdint>
 
 #ifdef __ANDROID__
@@ -26,7 +27,6 @@
 #include <clocale>
 #endif
 
-#include "utils/stdcompat/algorithm.hpp"
 #include "utils/stdcompat/string_view.hpp"
 
 namespace devilution {

--- a/Source/platform/locale.cpp
+++ b/Source/platform/locale.cpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 
 #ifdef __ANDROID__
-#include "SDL.h"
+#include <SDL.h>
 #include <jni.h>
 #elif defined(__vita__)
 #include <cstring>

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -4,6 +4,7 @@
  * Implementation of player functionality, leveling, actions, creation, loading, etc.
  */
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 
 #include <fmt/core.h>
@@ -1111,11 +1112,11 @@ bool DoDeath(Player &player)
 
 bool IsPlayerAdjacentToObject(Player &player, Object &object)
 {
-	int x = abs(player.position.tile.x - object.position.x);
-	int y = abs(player.position.tile.y - object.position.y);
+	int x = std::abs(player.position.tile.x - object.position.x);
+	int y = std::abs(player.position.tile.y - object.position.y);
 	if (y > 1 && object.position.y >= 1 && FindObjectAtPosition(object.position + Direction::NorthEast) == &object) {
 		// special case for activating a large object from the north-east side
-		y = abs(player.position.tile.y - object.position.y + 1);
+		y = std::abs(player.position.tile.y - object.position.y + 1);
 	}
 	return x <= 1 && y <= 1;
 }
@@ -1197,12 +1198,12 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 			if (&player == MyPlayer) {
 				if (player.destAction == ACTION_ATTACKMON || player.destAction == ACTION_ATTACKPLR) {
 					if (player.destAction == ACTION_ATTACKMON) {
-						x = abs(player.position.future.x - monster->position.future.x);
-						y = abs(player.position.future.y - monster->position.future.y);
+						x = std::abs(player.position.future.x - monster->position.future.x);
+						y = std::abs(player.position.future.y - monster->position.future.y);
 						d = GetDirection(player.position.future, monster->position.future);
 					} else {
-						x = abs(player.position.future.x - target->position.future.x);
-						y = abs(player.position.future.y - target->position.future.y);
+						x = std::abs(player.position.future.x - target->position.future.x);
+						y = std::abs(player.position.future.y - target->position.future.y);
 						d = GetDirection(player.position.future, target->position.future);
 					}
 
@@ -1270,8 +1271,8 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 			StartAttack(player, d, pmWillBeCalled);
 			break;
 		case ACTION_ATTACKMON:
-			x = abs(player.position.tile.x - monster->position.future.x);
-			y = abs(player.position.tile.y - monster->position.future.y);
+			x = std::abs(player.position.tile.x - monster->position.future.x);
+			y = std::abs(player.position.tile.y - monster->position.future.y);
 			if (x <= 1 && y <= 1) {
 				d = GetDirection(player.position.future, monster->position.future);
 				if (monster->talkMsg != TEXT_NONE && monster->talkMsg != TEXT_VILE14) {
@@ -1282,8 +1283,8 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 			}
 			break;
 		case ACTION_ATTACKPLR:
-			x = abs(player.position.tile.x - target->position.future.x);
-			y = abs(player.position.tile.y - target->position.future.y);
+			x = std::abs(player.position.tile.x - target->position.future.x);
+			y = std::abs(player.position.tile.y - target->position.future.y);
 			if (x <= 1 && y <= 1) {
 				d = GetDirection(player.position.future, target->position.future);
 				StartAttack(player, d, pmWillBeCalled);
@@ -1353,8 +1354,8 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 			break;
 		case ACTION_PICKUPITEM:
 			if (&player == MyPlayer) {
-				x = abs(player.position.tile.x - item->position.x);
-				y = abs(player.position.tile.y - item->position.y);
+				x = std::abs(player.position.tile.x - item->position.x);
+				y = std::abs(player.position.tile.y - item->position.y);
 				if (x <= 1 && y <= 1 && pcurs == CURSOR_HAND && !item->_iRequest) {
 					NetSendCmdGItem(true, CMD_REQUESTGITEM, player.getId(), targetId);
 					item->_iRequest = true;
@@ -1363,8 +1364,8 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 			break;
 		case ACTION_PICKUPAITEM:
 			if (&player == MyPlayer) {
-				x = abs(player.position.tile.x - item->position.x);
-				y = abs(player.position.tile.y - item->position.y);
+				x = std::abs(player.position.tile.x - item->position.x);
+				y = std::abs(player.position.tile.y - item->position.y);
 				if (x <= 1 && y <= 1 && pcurs == CURSOR_HAND) {
 					NetSendCmdGItem(true, CMD_REQUESTAGITEM, player.getId(), targetId);
 				}
@@ -1392,16 +1393,16 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 			StartAttack(player, d, pmWillBeCalled);
 			player.destAction = ACTION_NONE;
 		} else if (player.destAction == ACTION_ATTACKMON) {
-			x = abs(player.position.tile.x - monster->position.future.x);
-			y = abs(player.position.tile.y - monster->position.future.y);
+			x = std::abs(player.position.tile.x - monster->position.future.x);
+			y = std::abs(player.position.tile.y - monster->position.future.y);
 			if (x <= 1 && y <= 1) {
 				d = GetDirection(player.position.future, monster->position.future);
 				StartAttack(player, d, pmWillBeCalled);
 			}
 			player.destAction = ACTION_NONE;
 		} else if (player.destAction == ACTION_ATTACKPLR) {
-			x = abs(player.position.tile.x - target->position.future.x);
-			y = abs(player.position.tile.y - target->position.future.y);
+			x = std::abs(player.position.tile.x - target->position.future.x);
+			y = std::abs(player.position.tile.y - target->position.future.y);
 			if (x <= 1 && y <= 1) {
 				d = GetDirection(player.position.future, target->position.future);
 				StartAttack(player, d, pmWillBeCalled);
@@ -1625,7 +1626,7 @@ void Player::RemoveInvItem(int iv, bool calcScrolls)
 		// Locate the first grid index containing this item and notify remote clients
 		for (size_t i = 0; i < InventoryGridCells; i++) {
 			int8_t itemIndex = InvGrid[i];
-			if (abs(itemIndex) - 1 == iv) {
+			if (std::abs(itemIndex) - 1 == iv) {
 				NetSendCmdParam1(false, CMD_DELINVITEMS, i);
 				break;
 			}
@@ -1634,7 +1635,7 @@ void Player::RemoveInvItem(int iv, bool calcScrolls)
 
 	// Iterate through invGrid and remove every reference to item
 	for (int8_t &itemIndex : InvGrid) {
-		if (abs(itemIndex) - 1 == iv) {
+		if (std::abs(itemIndex) - 1 == iv) {
 			itemIndex = 0;
 		}
 	}
@@ -2076,7 +2077,7 @@ Player *PlayerAtPosition(Point position)
 	if (playerIndex == 0)
 		return nullptr;
 
-	return &Players[abs(playerIndex) - 1];
+	return &Players[std::abs(playerIndex) - 1];
 }
 
 void LoadPlrGFX(Player &player, player_graphic graphic)
@@ -3104,7 +3105,7 @@ bool PosOkPlayer(const Player &player, Point position)
 	if (!IsTileWalkable(position))
 		return false;
 	if (dPlayer[position.x][position.y] != 0) {
-		auto &otherPlayer = Players[abs(dPlayer[position.x][position.y]) - 1];
+		auto &otherPlayer = Players[std::abs(dPlayer[position.x][position.y]) - 1];
 		if (&otherPlayer != &player && otherPlayer._pHitPoints != 0) {
 			return false;
 		}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -590,7 +590,7 @@ bool PlrHitMonst(Player &player, Monster &monster, bool adjacentDamage = false)
 	}
 
 	hper += player.GetMeleePiercingToHit() - player.CalculateArmorPierce(monster.armorClass, true);
-	hper = clamp(hper, 5, 95);
+	hper = std::clamp(hper, 5, 95);
 
 	if (monster.tryLiftGargoyle())
 		return true;
@@ -754,7 +754,7 @@ bool PlrHitPlr(Player &attacker, Player &target)
 	int hit = GenerateRnd(100);
 
 	int hper = attacker.GetMeleeToHit() - target.GetArmor();
-	hper = clamp(hper, 5, 95);
+	hper = std::clamp(hper, 5, 95);
 
 	int blk = 100;
 	if ((target._pmode == PM_STAND || target._pmode == PM_ATTACK) && target._pBlockFlag) {
@@ -762,7 +762,7 @@ bool PlrHitPlr(Player &attacker, Player &target)
 	}
 
 	int blkper = target.GetBlockChance() - (attacker._pLevel * 2);
-	blkper = clamp(blkper, 0, 100);
+	blkper = std::clamp(blkper, 0, 100);
 
 	if (hit >= hper) {
 		return false;
@@ -2193,7 +2193,7 @@ void NewPlrAnim(Player &player, player_graphic graphic, Direction dir, Animation
 	if (!HeadlessMode) {
 		sprites = player.AnimationData[static_cast<size_t>(graphic)].spritesForDirection(dir);
 		if (player.previewCelSprite && (*sprites)[0] == *player.previewCelSprite && !player.isWalking()) {
-			previewShownGameTickFragments = clamp<int>(AnimationInfo::baseValueFraction - player.progressToNextGameTickWhenPreviewWasSet, 0, AnimationInfo::baseValueFraction);
+			previewShownGameTickFragments = std::clamp<int>(AnimationInfo::baseValueFraction - player.progressToNextGameTickWhenPreviewWasSet, 0, AnimationInfo::baseValueFraction);
 		}
 	}
 
@@ -2447,7 +2447,7 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 
 	// Prevent power leveling
 	if (gbIsMultiplayer) {
-		const uint32_t clampedPlayerLevel = clamp(static_cast<int>(player._pLevel), 1, MaxCharacterLevel);
+		const uint32_t clampedPlayerLevel = std::clamp(static_cast<int>(player._pLevel), 1, MaxCharacterLevel);
 
 		// for low level characters experience gain is capped to 1/20 of current levels xp
 		// for high level characters experience gain is capped to 200 * current level - this is a smaller value than 1/20 of the exp needed for the next level after level 5.
@@ -3303,16 +3303,16 @@ void CheckStats(Player &player)
 		int maxStatPoint = player.GetMaximumAttributeValue(attribute);
 		switch (attribute) {
 		case CharacterAttribute::Strength:
-			player._pBaseStr = clamp(player._pBaseStr, 0, maxStatPoint);
+			player._pBaseStr = std::clamp(player._pBaseStr, 0, maxStatPoint);
 			break;
 		case CharacterAttribute::Magic:
-			player._pBaseMag = clamp(player._pBaseMag, 0, maxStatPoint);
+			player._pBaseMag = std::clamp(player._pBaseMag, 0, maxStatPoint);
 			break;
 		case CharacterAttribute::Dexterity:
-			player._pBaseDex = clamp(player._pBaseDex, 0, maxStatPoint);
+			player._pBaseDex = std::clamp(player._pBaseDex, 0, maxStatPoint);
 			break;
 		case CharacterAttribute::Vitality:
-			player._pBaseVit = clamp(player._pBaseVit, 0, maxStatPoint);
+			player._pBaseVit = std::clamp(player._pBaseVit, 0, maxStatPoint);
 			break;
 		}
 	}
@@ -3320,7 +3320,7 @@ void CheckStats(Player &player)
 
 void ModifyPlrStr(Player &player, int l)
 {
-	l = clamp(l, 0 - player._pBaseStr, player.GetMaximumAttributeValue(CharacterAttribute::Strength) - player._pBaseStr);
+	l = std::clamp(l, 0 - player._pBaseStr, player.GetMaximumAttributeValue(CharacterAttribute::Strength) - player._pBaseStr);
 
 	player._pStrength += l;
 	player._pBaseStr += l;
@@ -3334,7 +3334,7 @@ void ModifyPlrStr(Player &player, int l)
 
 void ModifyPlrMag(Player &player, int l)
 {
-	l = clamp(l, 0 - player._pBaseMag, player.GetMaximumAttributeValue(CharacterAttribute::Magic) - player._pBaseMag);
+	l = std::clamp(l, 0 - player._pBaseMag, player.GetMaximumAttributeValue(CharacterAttribute::Magic) - player._pBaseMag);
 
 	player._pMagic += l;
 	player._pBaseMag += l;
@@ -3358,7 +3358,7 @@ void ModifyPlrMag(Player &player, int l)
 
 void ModifyPlrDex(Player &player, int l)
 {
-	l = clamp(l, 0 - player._pBaseDex, player.GetMaximumAttributeValue(CharacterAttribute::Dexterity) - player._pBaseDex);
+	l = std::clamp(l, 0 - player._pBaseDex, player.GetMaximumAttributeValue(CharacterAttribute::Dexterity) - player._pBaseDex);
 
 	player._pDexterity += l;
 	player._pBaseDex += l;
@@ -3371,7 +3371,7 @@ void ModifyPlrDex(Player &player, int l)
 
 void ModifyPlrVit(Player &player, int l)
 {
-	l = clamp(l, 0 - player._pBaseVit, player.GetMaximumAttributeValue(CharacterAttribute::Vitality) - player._pBaseVit);
+	l = std::clamp(l, 0 - player._pBaseVit, player.GetMaximumAttributeValue(CharacterAttribute::Vitality) - player._pBaseVit);
 
 	player._pVitality += l;
 	player._pBaseVit += l;

--- a/Source/player.h
+++ b/Source/player.h
@@ -25,7 +25,6 @@
 #include "spelldat.h"
 #include "utils/attributes.h"
 #include "utils/enum_traits.h"
-#include "utils/stdcompat/algorithm.hpp"
 
 namespace devilution {
 
@@ -638,7 +637,7 @@ struct Player {
 			// Maximum achievable HP is approximately 1200. Diablo uses fixed point integers where the last 6 bits are
 			// fractional values. This means that we will never overflow HP values normally by doing this multiplication
 			// as the max value is representable in 17 bits and the multiplication result will be at most 23 bits
-			_pHPPer = clamp(_pHitPoints * 80 / _pMaxHP, 0, 80); // hp should never be greater than maxHP but just in case
+			_pHPPer = std::clamp(_pHitPoints * 80 / _pMaxHP, 0, 80); // hp should never be greater than maxHP but just in case
 		}
 
 		return _pHPPer;
@@ -649,7 +648,7 @@ struct Player {
 		if (_pMaxMana <= 0) {
 			_pManaPer = 0;
 		} else {
-			_pManaPer = clamp(_pMana * 80 / _pMaxMana, 0, 80);
+			_pManaPer = std::clamp(_pMana * 80 / _pMaxMana, 0, 80);
 		}
 
 		return _pManaPer;

--- a/Source/plrmsg.h
+++ b/Source/plrmsg.h
@@ -5,9 +5,10 @@
  */
 #pragma once
 
-#include "SDL.h"
 #include <cstdint>
 #include <string>
+
+#include <SDL.h>
 
 #include "DiabloUI/ui_flags.hpp"
 #include "engine.h"

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -1,6 +1,7 @@
 #include "itemlabels.h"
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 #include <string>
 #include <vector>
@@ -161,7 +162,7 @@ void DrawItemNameLabels(const Surface &out)
 			for (unsigned j = 0; j < i; ++j) {
 				ItemLabel &a = labelQueue[i];
 				ItemLabel &b = labelQueue[j];
-				if (abs(b.pos.y - a.pos.y) < Height + BorderY) {
+				if (std::abs(b.pos.y - a.pos.y) < Height + BorderY) {
 					const int widthA = a.width + BorderX + MarginX * 2;
 					const int widthB = b.width + BorderX + MarginX * 2;
 					int newpos = b.pos.x;

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -1,5 +1,6 @@
 #include "qol/stash.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <utility>
 
@@ -20,7 +21,6 @@
 #include "stores.h"
 #include "utils/format_int.hpp"
 #include "utils/language.h"
-#include "utils/stdcompat/algorithm.hpp"
 #include "utils/str_cat.hpp"
 #include "utils/utf8.hpp"
 

--- a/Source/sha.h
+++ b/Source/sha.h
@@ -5,9 +5,8 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
-
-#include "utils/stdcompat/cstddef.hpp"
 
 namespace devilution {
 

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2135,7 +2135,7 @@ void SetupTownStores()
 		SetRndSeed(glSeedTbl[currlevel] * SDL_GetTicks());
 	}
 
-	l = clamp(l + 2, 6, 16);
+	l = std::clamp(l + 2, 6, 16);
 	SpawnSmith(l);
 	SpawnWitch(l);
 	SpawnHealer(l);

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -250,7 +250,7 @@ void AddSText(uint8_t x, size_t y, string_view text, UiFlags flags, bool sel, in
 	stext[y]._sx = x;
 	stext[y]._syoff = 0;
 	stext[y].text.clear();
-	AppendStrView(stext[y].text, text);
+	stext[y].text.append(text);
 	stext[y].flags = flags;
 	stext[y].type = sel ? STextStruct::Selectable : STextStruct::Label;
 	stext[y].cursId = cursId;
@@ -284,18 +284,18 @@ void PrintStoreItem(const Item &item, int l, UiFlags flags, bool cursIndent = fa
 	if (item._iIdentified) {
 		if (item._iMagical != ITEM_QUALITY_UNIQUE) {
 			if (item._iPrePower != -1) {
-				AppendStrView(productLine, PrintItemPower(item._iPrePower, item));
+				productLine.append(PrintItemPower(item._iPrePower, item));
 			}
 		}
 		if (item._iSufPower != -1) {
 			if (!productLine.empty())
-				AppendStrView(productLine, _(",  "));
-			AppendStrView(productLine, PrintItemPower(item._iSufPower, item));
+				productLine.append(_(",  "));
+			productLine.append(PrintItemPower(item._iSufPower, item));
 		}
 	}
 	if (item._iMiscId == IMISC_STAFF && item._iMaxCharges != 0) {
 		if (!productLine.empty())
-			AppendStrView(productLine, _(",  "));
+			productLine.append(_(",  "));
 		productLine.append(fmt::format(fmt::runtime(_("Charges: {:d}/{:d}")), item._iCharges, item._iMaxCharges));
 	}
 	if (!productLine.empty()) {
@@ -312,7 +312,7 @@ void PrintStoreItem(const Item &item, int l, UiFlags flags, bool cursIndent = fa
 		if (item._iMaxDur != DUR_INDESTRUCTIBLE && item._iMaxDur != 0)
 			productLine += fmt::format(fmt::runtime(_("Dur: {:d}/{:d},  ")), item._iDurability, item._iMaxDur);
 		else
-			AppendStrView(productLine, _("Indestructible,  "));
+			productLine.append(_("Indestructible,  "));
 	}
 
 	int8_t str = item._iMinStr;
@@ -320,9 +320,9 @@ void PrintStoreItem(const Item &item, int l, UiFlags flags, bool cursIndent = fa
 	int8_t dex = item._iMinDex;
 
 	if (str == 0 && mag == 0 && dex == 0) {
-		AppendStrView(productLine, _("No required attributes"));
+		productLine.append(_("No required attributes"));
 	} else {
-		AppendStrView(productLine, _("Required:"));
+		productLine.append(_("Required:"));
 		if (str != 0)
 			productLine.append(fmt::format(fmt::runtime(_(" {:d} Str")), str));
 		if (mag != 0)

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -6,13 +6,13 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 
 #include "DiabloUI/ui_flags.hpp"
 #include "control.h"
 #include "engine.h"
 #include "engine/clx_sprite.hpp"
 #include "utils/attributes.h"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/storm/storm_svid.cpp
+++ b/Source/storm/storm_svid.cpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <optional>
 
 #include <SmackerDecoder.h>
 
@@ -19,7 +20,6 @@
 #include "utils/log.hpp"
 #include "utils/sdl_compat.h"
 #include "utils/sdl_wrap.h"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 namespace {

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -250,7 +250,7 @@ bool IsTSyncMonsterValidate(const TSyncMonster &monsterSync)
 
 } // namespace
 
-uint32_t sync_all_monsters(byte *pbBuf, uint32_t dwMaxLen)
+uint32_t sync_all_monsters(std::byte *pbBuf, uint32_t dwMaxLen)
 {
 	if (ActiveMonsterCount < 1) {
 		return dwMaxLen;

--- a/Source/sync.h
+++ b/Source/sync.h
@@ -5,13 +5,12 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
-
-#include "utils/stdcompat/cstddef.hpp"
 
 namespace devilution {
 
-uint32_t sync_all_monsters(byte *pbBuf, uint32_t dwMaxLen);
+uint32_t sync_all_monsters(std::byte *pbBuf, uint32_t dwMaxLen);
 uint32_t OnSyncData(const TCmd *pCmd, size_t pnum);
 void sync_init();
 

--- a/Source/tmsg.cpp
+++ b/Source/tmsg.cpp
@@ -16,12 +16,12 @@ namespace {
 
 struct TMsg {
 	uint32_t time;
-	std::unique_ptr<byte[]> body;
+	std::unique_ptr<std::byte[]> body;
 	uint8_t len;
 
-	TMsg(uint32_t time, const byte *data, uint8_t len)
+	TMsg(uint32_t time, const std::byte *data, uint8_t len)
 	    : time(time)
-	    , body(new byte[len])
+	    , body(new std::byte[len])
 	    , len(len)
 	{
 		memcpy(body.get(), data, len);
@@ -32,7 +32,7 @@ std::list<TMsg> TimedMsgList;
 
 } // namespace
 
-uint8_t tmsg_get(std::unique_ptr<byte[]> *msg)
+uint8_t tmsg_get(std::unique_ptr<std::byte[]> *msg)
 {
 	if (TimedMsgList.empty())
 		return 0;
@@ -47,7 +47,7 @@ uint8_t tmsg_get(std::unique_ptr<byte[]> *msg)
 	return len;
 }
 
-void tmsg_add(const byte *msg, uint8_t len)
+void tmsg_add(const std::byte *msg, uint8_t len)
 {
 	uint32_t time = SDL_GetTicks() + gnTickDelay * 10;
 	TimedMsgList.emplace_back(time, msg, len);

--- a/Source/tmsg.h
+++ b/Source/tmsg.h
@@ -5,15 +5,14 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 
-#include "utils/stdcompat/cstddef.hpp"
-
 namespace devilution {
 
-uint8_t tmsg_get(std::unique_ptr<byte[]> *msg);
-void tmsg_add(const byte *msg, uint8_t bLen);
+uint8_t tmsg_get(std::unique_ptr<std::byte[]> *msg);
+void tmsg_add(const std::byte *msg, uint8_t bLen);
 void tmsg_start();
 void tmsg_cleanup();
 

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -5,14 +5,14 @@
  */
 #pragma once
 
-#include "utils/stdcompat/string_view.hpp"
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 
 #include "items.h"
 #include "player.h"
 #include "quests.h"
-#include "utils/stdcompat/cstddef.hpp"
+#include "utils/stdcompat/string_view.hpp"
 
 namespace devilution {
 

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -1,6 +1,7 @@
 #include "utils/display.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 
 #ifdef __vita__

--- a/Source/utils/format_int.cpp
+++ b/Source/utils/format_int.cpp
@@ -36,7 +36,7 @@ std::string FormatInteger(int n)
 	out.append(begin, mlen);
 	begin += mlen;
 	for (; begin != end; begin += GroupSize) {
-		AppendStrView(out, separator);
+		out.append(separator);
 		out.append(begin, GroupSize);
 	}
 

--- a/Source/utils/intrusive_optional.hpp
+++ b/Source/utils/intrusive_optional.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <optional>
 #include <type_traits>
 #include <utility>
 
 #include "appfat.h"
-#include "utils/stdcompat/optional.hpp"
 
 /// An optional that uses a field of the stored class and some value to store nullopt.
 #define DEFINE_INTRUSIVE_OPTIONAL_IMPL(OPTIONAL_CLASS, VALUE_CLASS, FIELD, NULL_VALUE, CONSTEXPR) \

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -272,7 +272,7 @@ bool ReadEntry(AssetHandle &handle, const MoEntry &e, char *result)
 	return handle.read(result, e.length);
 }
 
-bool CopyData(void *dst, const byte *data, size_t dataSize, size_t offset, size_t length)
+bool CopyData(void *dst, const std::byte *data, size_t dataSize, size_t offset, size_t length)
 {
 	if (offset + length > dataSize)
 		return false;
@@ -280,7 +280,7 @@ bool CopyData(void *dst, const byte *data, size_t dataSize, size_t offset, size_
 	return true;
 }
 
-bool ReadEntry(const byte *data, size_t dataSize, const MoEntry &e, char *result)
+bool ReadEntry(const std::byte *data, size_t dataSize, const MoEntry &e, char *result)
 {
 	if (!CopyData(result, data, dataSize, e.offset, e.length))
 		return false;
@@ -410,9 +410,9 @@ void LanguageInitialize()
 	const bool readWholeFile = handle.handle->type == SDL_RWOPS_UNKNOWN;
 #endif
 
-	std::unique_ptr<byte[]> data;
+	std::unique_ptr<std::byte[]> data;
 	if (readWholeFile) {
-		data.reset(new byte[fileSize]);
+		data.reset(new std::byte[fileSize]);
 		if (!handle.read(data.get(), fileSize))
 			return;
 		handle = {};

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -297,7 +297,7 @@ string_view LanguageParticularTranslate(string_view context, string_view message
 	std::string key = std::string(context);
 	key.reserve(key.size() + 1 + message.size());
 	key += Glue;
-	AppendStrView(key, message);
+	key.append(message);
 
 	auto it = translation[0].find(key.c_str());
 	if (it == translation[0].end()) {

--- a/Source/utils/logged_fstream.hpp
+++ b/Source/utils/logged_fstream.hpp
@@ -3,12 +3,11 @@
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
+#include <optional>
 #include <string>
 
 #include "utils/file_util.h"
 #include "utils/log.hpp"
-#include "utils/stdcompat/optional.hpp"
-
 namespace devilution {
 
 // A wrapper around `FILE *` that logs errors.

--- a/Source/utils/parse_int.hpp
+++ b/Source/utils/parse_int.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
-#if __cplusplus >= 201703L
 #include <charconv>
 #include <system_error>
-#endif
 
 #include "utils/stdcompat/string_view.hpp"
 

--- a/Source/utils/paths.h
+++ b/Source/utils/paths.h
@@ -1,8 +1,7 @@
 #pragma once
 
+#include <optional>
 #include <string>
-
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/utils/pcx_to_clx.cpp
+++ b/Source/utils/pcx_to_clx.cpp
@@ -1,5 +1,6 @@
 #include "utils/pcx_to_clx.hpp"
 
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 
@@ -13,7 +14,6 @@
 #include "utils/clx_encode.hpp"
 #include "utils/endian.hpp"
 #include "utils/pcx.hpp"
-#include "utils/stdcompat/cstddef.hpp"
 
 #ifdef DEBUG_PCX_TO_CL2_SIZE
 #include <iomanip>

--- a/Source/utils/pcx_to_clx.hpp
+++ b/Source/utils/pcx_to_clx.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 
 #include "engine/assets.hpp"
 #include "engine/clx_sprite.hpp"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <cstddef>
 #include <initializer_list>
 #include <memory>
 #include <utility>
 
 #include "appfat.h"
-#include "utils/stdcompat/cstddef.hpp"
 
 namespace devilution {
 
@@ -79,7 +79,7 @@ public:
 
 private:
 	struct AlignedStorage {
-		alignas(alignof(T)) byte data[sizeof(T)];
+		alignas(alignof(T)) std::byte data[sizeof(T)];
 
 		const T *ptr() const
 		{

--- a/Source/utils/stdcompat/abs.hpp
+++ b/Source/utils/stdcompat/abs.hpp
@@ -1,7 +1,0 @@
-#pragma once
-
-#include <cstdlib>
-
-namespace devilution {
-using ::std::abs;
-} // namespace devilution

--- a/Source/utils/stdcompat/algorithm.hpp
+++ b/Source/utils/stdcompat/algorithm.hpp
@@ -1,7 +1,0 @@
-#pragma once
-
-#include <algorithm> // IWYU pragma: export
-
-namespace devilution {
-using ::std::clamp;
-} // namespace devilution

--- a/Source/utils/stdcompat/cstddef.hpp
+++ b/Source/utils/stdcompat/cstddef.hpp
@@ -1,7 +1,0 @@
-#pragma once
-
-#include <cstddef> // IWYU pragma: export
-
-namespace devilution {
-using ::std::byte;
-}

--- a/Source/utils/stdcompat/invoke_result_t.hpp
+++ b/Source/utils/stdcompat/invoke_result_t.hpp
@@ -1,7 +1,0 @@
-#pragma once
-
-#include <type_traits>
-
-namespace devilution {
-using ::std::invoke_result_t;
-} // namespace devilution

--- a/Source/utils/stdcompat/optional.hpp
+++ b/Source/utils/stdcompat/optional.hpp
@@ -1,3 +1,0 @@
-#pragma once
-
-#include <optional> // IWYU pragma: export

--- a/Source/utils/stdcompat/string_view.hpp
+++ b/Source/utils/stdcompat/string_view.hpp
@@ -4,9 +4,4 @@
 #include <string_view> // IWYU pragma: export
 namespace devilution {
 using ::std::string_view;
-
-inline void AppendStrView(std::string &out, string_view str)
-{
-	out.append(str);
-}
 } // namespace devilution

--- a/Source/utils/str_cat.hpp
+++ b/Source/utils/str_cat.hpp
@@ -33,7 +33,7 @@ inline char *BufCopy(char *out, string_view value)
  */
 inline void StrAppend(std::string &out, string_view value)
 {
-	AppendStrView(out, value);
+	out.append(value);
 }
 
 /**
@@ -51,7 +51,7 @@ inline char *BufCopy(char *out, const char *str)
  */
 inline void StrAppend(std::string &out, const char *str)
 {
-	AppendStrView(out, string_view(str != nullptr ? str : "(nullptr)"));
+	out.append(string_view(str != nullptr ? str : "(nullptr)"));
 }
 
 template <typename... Args>

--- a/Source/utils/surface_to_clx.hpp
+++ b/Source/utils/surface_to_clx.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 
 #include "engine/clx_sprite.hpp"
 #include "engine/surface.hpp"
-#include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 

--- a/test/lighting_test.cpp
+++ b/test/lighting_test.cpp
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include <gtest/gtest.h>
 
 #include "control.h"
@@ -25,7 +27,7 @@ TEST(Lighting, CrawlTables)
 		for (int j = -MaxCrawlRadius; j <= MaxCrawlRadius; j++) {
 			if (added[i + 20][j + 20])
 				continue;
-			if (abs(i) == MaxCrawlRadius && abs(j) == MaxCrawlRadius)
+			if (std::abs(i) == MaxCrawlRadius && std::abs(j) == MaxCrawlRadius)
 				continue; // Limit of the crawl table rage
 			EXPECT_EQ(false, true) << "while checking location " << i << ":" << j;
 		}


### PR DESCRIPTION
Most of the stdcompat headers are no longer needed now that we require C++17.
Removes some of these headers.

`string_view.hpp` will be removed in a (huge) separate PR