### PR TITLE
vcpkg.json: Update builtin-baseline

### DIFF
--- a/.github/workflows/Windows_MSVC_x64.yml
+++ b/.github/workflows/Windows_MSVC_x64.yml
@@ -31,9 +31,9 @@ jobs:
       uses: lukka/get-cmake@latest
 
     - name: Restore or setup vcpkg
-      uses: lukka/run-vcpkg@v10
+      uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: '1ba9a2591f15af5900f2ce2b3e2bf31771e3ac48'
+        vcpkgGitCommitId: '78b61582c9e093fda56a01ebb654be15a0033897'
 
     - name: Fetch test data
       run: |

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
         "bzip2",
         "simpleini"
     ],
-    "builtin-baseline": "662dbb50e63af15baa2909b7eac5b1b87e86a0aa",
+    "builtin-baseline": "78b61582c9e093fda56a01ebb654be15a0033897",
     "features": {
         "sdl1": {
             "description": "Use SDL1.2 instead of SDL2",


### PR DESCRIPTION
This is the version that is currently installed on GitHub Actions.

We may want this for 1.5.1 as well.