### PR TITLE
Xbox One: Fix SDL2 checkout command

### DIFF
--- a/.github/workflows/xbox_one.yml
+++ b/.github/workflows/xbox_one.yml
@@ -36,6 +36,12 @@ jobs:
       with:
         msbuild-architecture: x64
 
+    - name: Configure git
+      shell: cmd
+      run: |
+        git config --global core.filemode false
+        git config --global core.autocrlf false
+
     - name: Build
       shell: cmd
       run: |

--- a/Packaging/xbox-one/build.bat
+++ b/Packaging/xbox-one/build.bat
@@ -3,8 +3,8 @@ call VsDevCmd.bat
 mkdir ..\..\build
 cd ..\..\build
 
-git clone https://github.com/libsdl-org/SDL.git
-git -C SDL checkout 5d1e6b28d9c97e5223281c0f0189f6c99a564b70
+git clone --branch SDL2 https://github.com/libsdl-org/SDL.git
+git -C SDL reset --hard 10135b2d7bbed6ea0cba24410ebc12887d92968d
 msbuild /p:PlatformToolset=v143;TargetPlatformVersion=10.0.22000.0;TargetPlatformMinVersion=10.0.14393.0;ConfigurationType=StaticLibrary;Configuration=Release;Platform=x64 SDL\VisualC-WinRT\SDL-UWP.vcxproj
 
 cmake -DUWP_LIB=1 -DUWP_SDL2_DIR="%CD%/SDL" -DCMAKE_BUILD_TYPE=x64-Release ..


### PR DESCRIPTION
Also updates SDL2 version to the latest SDL2 branch commit.

We may want this for 1.5.1 as well.