### PR TITLE
Support `const` inventory iterators

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1028,7 +1028,7 @@ void CheckPanelInfo()
 		InfoColor = UiFlags::ColorWhite;
 		panelflag = true;
 		AddPanelString(_("Hotkey: 's'"));
-		Player &myPlayer = *MyPlayer;
+		const Player &myPlayer = *MyPlayer;
 		const SpellID spellId = myPlayer._pRSpell;
 		if (IsValidSpell(spellId)) {
 			switch (myPlayer._pRSplType) {

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -245,7 +245,7 @@ Size GetInventorySize(const Item &item);
  * @brief Checks whether the player has an inventory item matching the predicate.
  */
 template <typename Predicate>
-bool HasInventoryItem(Player &player, Predicate &&predicate)
+bool HasInventoryItem(const Player &player, Predicate &&predicate)
 {
 	const InventoryPlayerItemsRange items { player };
 	return c_find_if(items, std::forward<Predicate>(predicate)) != items.end();
@@ -255,7 +255,7 @@ bool HasInventoryItem(Player &player, Predicate &&predicate)
  * @brief Checks whether the player has a belt item matching the predicate.
  */
 template <typename Predicate>
-bool HasBeltItem(Player &player, Predicate &&predicate)
+bool HasBeltItem(const Player &player, Predicate &&predicate)
 {
 	const BeltPlayerItemsRange items { player };
 	return c_find_if(items, std::forward<Predicate>(predicate)) != items.end();
@@ -265,7 +265,7 @@ bool HasBeltItem(Player &player, Predicate &&predicate)
  * @brief Checks whether the player has an inventory or a belt item matching the predicate.
  */
 template <typename Predicate>
-bool HasInventoryOrBeltItem(Player &player, Predicate &&predicate)
+bool HasInventoryOrBeltItem(const Player &player, Predicate &&predicate)
 {
 	return HasInventoryItem(player, predicate) || HasBeltItem(player, predicate);
 }
@@ -273,7 +273,7 @@ bool HasInventoryOrBeltItem(Player &player, Predicate &&predicate)
 /**
  * @brief Checks whether the player has an inventory item with the given ID (IDidx).
  */
-inline bool HasInventoryItemWithId(Player &player, _item_indexes id)
+inline bool HasInventoryItemWithId(const Player &player, _item_indexes id)
 {
 	return HasInventoryItem(player, [id](const Item &item) {
 		return item.IDidx == id;
@@ -283,7 +283,7 @@ inline bool HasInventoryItemWithId(Player &player, _item_indexes id)
 /**
  * @brief Checks whether the player has a belt item with the given ID (IDidx).
  */
-inline bool HasBeltItemWithId(Player &player, _item_indexes id)
+inline bool HasBeltItemWithId(const Player &player, _item_indexes id)
 {
 	return HasBeltItem(player, [id](const Item &item) {
 		return item.IDidx == id;
@@ -293,7 +293,7 @@ inline bool HasBeltItemWithId(Player &player, _item_indexes id)
 /**
  * @brief Checks whether the player has an inventory or a belt item with the given ID (IDidx).
  */
-inline bool HasInventoryOrBeltItemWithId(Player &player, _item_indexes id)
+inline bool HasInventoryOrBeltItemWithId(const Player &player, _item_indexes id)
 {
 	return HasInventoryItemWithId(player, id) || HasBeltItemWithId(player, id);
 }

--- a/Source/panels/spell_list.cpp
+++ b/Source/panels/spell_list.cpp
@@ -116,7 +116,7 @@ void DrawSpellList(const Surface &out)
 {
 	InfoString = StringOrView {};
 
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 
 	for (auto &spellListItem : GetSpellListItems()) {
 		const SpellID spellId = spellListItem.id;


### PR DESCRIPTION
Previously, inventory iterators could only be used with non-const objects, leading to suboptimal const correctness.

Adds support for `const` objects to inventory iterators via C++17 CTAD.