### PR TITLE
Fix issues with light offset calculation

### DIFF
--- a/Source/engine/actor_position.cpp
+++ b/Source/engine/actor_position.cpp
@@ -105,19 +105,17 @@ constexpr std::array<const WalkParameter, 8> WalkParameters { {
 
 } // namespace
 
-DisplacementOf<int8_t> ActorPosition::CalculateWalkingOffset(Direction dir, const AnimationInfo &animInfo, bool pendingProcessAnimation /*= false*/) const
+DisplacementOf<int8_t> ActorPosition::CalculateWalkingOffset(Direction dir, const AnimationInfo &animInfo) const
 {
-	DisplacementOf<int16_t> offset = CalculateWalkingOffsetShifted4(dir, animInfo, pendingProcessAnimation);
+	DisplacementOf<int16_t> offset = CalculateWalkingOffsetShifted4(dir, animInfo);
 	offset.deltaX >>= 4;
 	offset.deltaY >>= 4;
 	return offset;
 }
 
-DisplacementOf<int16_t> ActorPosition::CalculateWalkingOffsetShifted4(Direction dir, const AnimationInfo &animInfo, bool pendingProcessAnimation /*= false*/) const
+DisplacementOf<int16_t> ActorPosition::CalculateWalkingOffsetShifted4(Direction dir, const AnimationInfo &animInfo) const
 {
-	int8_t velocityProgress = animInfo.currentFrame + 1;
-	if (pendingProcessAnimation)
-		velocityProgress += 1;
+	int16_t velocityProgress = static_cast<int16_t>(animInfo.getAnimationProgress()) * animInfo.numberOfFrames / AnimationInfo::baseValueFraction;
 	const WalkParameter &walkParameter = WalkParameters[static_cast<size_t>(dir)];
 	DisplacementOf<int16_t> offset = walkParameter.startingOffset;
 	DisplacementOf<int16_t> velocity = walkParameter.getVelocity(animInfo.numberOfFrames);
@@ -125,9 +123,9 @@ DisplacementOf<int16_t> ActorPosition::CalculateWalkingOffsetShifted4(Direction 
 	return offset;
 }
 
-DisplacementOf<int16_t> ActorPosition::CalculateWalkingOffsetShifted8(Direction dir, const AnimationInfo &animInfo, bool pendingProcessAnimation /*= false*/) const
+DisplacementOf<int16_t> ActorPosition::CalculateWalkingOffsetShifted8(Direction dir, const AnimationInfo &animInfo) const
 {
-	DisplacementOf<int16_t> offset = CalculateWalkingOffsetShifted4(dir, animInfo, pendingProcessAnimation);
+	DisplacementOf<int16_t> offset = CalculateWalkingOffsetShifted4(dir, animInfo);
 	offset.deltaX <<= 4;
 	offset.deltaY <<= 4;
 	return offset;

--- a/Source/engine/actor_position.hpp
+++ b/Source/engine/actor_position.hpp
@@ -20,11 +20,11 @@ struct ActorPosition {
 	WorldTilePosition temp;
 
 	/** @brief Calculates the offset for the walking animation. */
-	DisplacementOf<int8_t> CalculateWalkingOffset(Direction dir, const AnimationInfo &animInfo, bool pendingProcessAnimation = false) const;
+	DisplacementOf<int8_t> CalculateWalkingOffset(Direction dir, const AnimationInfo &animInfo) const;
 	/** @brief Calculates the offset for the walking animation. */
-	DisplacementOf<int16_t> CalculateWalkingOffsetShifted4(Direction dir, const AnimationInfo &animInfo, bool pendingProcessAnimation = false) const;
+	DisplacementOf<int16_t> CalculateWalkingOffsetShifted4(Direction dir, const AnimationInfo &animInfo) const;
 	/** @brief Calculates the offset for the walking animation. */
-	DisplacementOf<int16_t> CalculateWalkingOffsetShifted8(Direction dir, const AnimationInfo &animInfo, bool pendingProcessAnimation = false) const;
+	DisplacementOf<int16_t> CalculateWalkingOffsetShifted8(Direction dir, const AnimationInfo &animInfo) const;
 	/** @brief Returns Pixel velocity while walking. */
 	DisplacementOf<int16_t> GetWalkingVelocityShifted4(Direction dir, const AnimationInfo &animInfo) const;
 	/** @brief Returns Pixel velocity while walking. */

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -61,7 +61,7 @@ int8_t AnimationInfo::getFrameToUseForRendering() const
 
 uint8_t AnimationInfo::getAnimationProgress() const
 {
-	int16_t ticksSinceSequenceStarted = ticksSinceSequenceStarted_;
+	int16_t ticksSinceSequenceStarted = std::max<int16_t>(0, ticksSinceSequenceStarted_);
 	int32_t tickModifier = tickModifier_;
 
 	if (relevantFramesForDistributing_ <= 0) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -149,6 +149,8 @@ void HandleWalkMode(Player &player, Direction dir)
 		return;
 	}
 
+	player._pdir = dir;
+
 	// The player's tile position after finishing this movement action
 	player.position.future = player.position.tile + dirModeParams.tileAdd;
 
@@ -156,8 +158,6 @@ void HandleWalkMode(Player &player, Direction dir)
 
 	player.tempDirection = dirModeParams.dir;
 	player._pmode = dirModeParams.walkMode;
-
-	player._pdir = dir;
 }
 
 void StartWalkAnimation(Player &player, Direction dir, bool pmWillBeCalled)
@@ -180,8 +180,8 @@ void StartWalk(Player &player, Direction dir, bool pmWillBeCalled)
 		return;
 	}
 
-	HandleWalkMode(player, dir);
 	StartWalkAnimation(player, dir, pmWillBeCalled);
+	HandleWalkMode(player, dir);
 }
 
 void ClearStateVariables(Player &player)


### PR DESCRIPTION
This fixes some bugs in the logic to calculate the walking offset that often caused the light's position to flicker when starting a new walk animation.

* Remove `pendingProcessAnimation` parameter from `CalculateWalkingOffset()` functions because it is not used by any caller.
* Use `getAnimationProgress()` in `CalculateWalkingOffset()` instead of `currentFrame` as it provides a more accurate sense of progress based on skipped frames and ticks per frame.
* Don't allow negative values for `ticksSinceSequenceStarted` in `getAnimationProgress()` since it is now used in `CalculateWalkingOffset()` which means it could be invoked before the call to `processAnimation()`.
* Move `_pdir` assignment up in `HandleWalkMode()` so that the direction of the new walking animation is passed into `CalculateWalkingOffset()`.
* Call `StartWalkAnimation()` before the call to `HandleWalkMode()` so that the animation progress of the previous animation is not used in `CalculateWalkingOffset()`.

---

Additional notes for curious readers:

* The flicker bug has two causes. One is that the first call to `CalculateWalkingOffset()` after starting a new animation would use the previous animation's value for `currentFrame`, so the initial offset was sort of random. The other is that the first call to `CalculateWalkingOffset()` used the direction the player was facing before starting the new walk animation.
* The default `skippedFrames = -2` caused `currentFrame` to be initialized to -2, which would have produced an invalid walking offset and potentially caused an OOB in `DoLighting()` if it weren't for the flicker bug.
* The aforementioned OOBs in `DoLighting()` were the cause of the lighting bugs that occur when you decrease the number of skipped frames, as demonstrated in the following video. This PR resolves both the flicker bug and produces valid walking offsets to avoid the OOBs.

https://github.com/diasurgical/devilutionX/assets/9203145/cbeb868b-ee41-4d81-ab1c-23ac9dc33814

FYI, the OOBs occur here, when the walking offset calculation produces negative values.

https://github.com/diasurgical/devilutionX/blob/45f7c2084ce56b1058adf8805e89662115d16017/Source/lighting.cpp#L256