### PR TITLE
Add draft for 1.5.1 release notes in metainfo

### DIFF
--- a/Packaging/nix/devilutionx.metainfo.xml
+++ b/Packaging/nix/devilutionx.metainfo.xml
@@ -64,6 +64,23 @@
 		</screenshot>
 	</screenshots>
 	<releases>
+		<release version="1.5.1" date="2023-xx-xx">
+			<description>
+				<p>This is a primarily bugfix release, which includes the following updates:</p>
+				<ul>
+					<li>"Loopback" multiplayer is renamed "Offline"</li>
+					<li>HP/Mana display and item graphics options are moved from "Graphics" to "Gameplay" option menu</li>
+					<li>Gameplay fixes, such as book requirements not updating</li>
+					<li>Fixes to crashes found in 1.5.0</li>
+					<li>Reduction in RAM usage</li>
+					<li>Updates to PVP arenas</li>
+					<li>Multiplayer stability improvements</li>
+					<li>Updates to French, Portuguese, German, Greek, Ukrainian, Korean and Japanese translations</li>
+				</ul>
+				<p>Please visit the full changelog for more detailed notes</p>
+			</description>
+			<url>https://github.com/diasurgical/devilutionX/releases/tag/1.5.1</url>
+		</release>
 		<release version="1.5.0" date="2023-06-13">
 			<description>
 				<p>This release includes a lot of features, such as:</p>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Being able to enter Lazarus' chamber before opening the portal
 - Book requirements not updating
 - Diablo: Incorrect level 4 layout when Magic Banner quest is active
-- Halls of the Blind not being compleated by picking up the amulet
+- Halls of the Blind not being completed by picking up the amulet
 
 #### Platforms
 
@@ -399,7 +399,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve Romanian localization
 - Improve Russian localization ([optional dub](https://github.com/diasurgical/devilutionx-assets/releases/download/v2/ru.mpq) by Stream)
 - Improve Spanish localization
- 
+
 #### Gameplay
 
 - Added a stash at Gillian's house


### PR DESCRIPTION
Release date and changelog URL will be added on 1.5.1 release

Please review the notes for items missing or unneeded