### PR TITLE
Update NDK to v26

### DIFF
--- a/Source/utils/stdcompat/shared_ptr_array.hpp
+++ b/Source/utils/stdcompat/shared_ptr_array.hpp
@@ -6,7 +6,7 @@
 namespace devilution {
 
 // Apple Clang 12 has a buggy implementation that fails to compile `std::shared_ptr<T[]>(new T[size])`.
-#if (__cplusplus >= 201611L && (!defined(__clang_major__) || __clang_major__ >= 13)) && !defined(NXDK) && !defined(__ANDROID__)
+#if (__cplusplus >= 201611L && (!defined(__clang_major__) || __clang_major__ >= 13)) && !defined(NXDK)
 template <typename T>
 using ArraySharedPtr = std::shared_ptr<T[]>;
 

--- a/android-project/app/build.gradle
+++ b/android-project/app/build.gradle
@@ -7,13 +7,13 @@ if (buildAsApplication) {
 }
 
 android {
-	ndkVersion '25.2.9519653'
+	ndkVersion '26.0.10792818'
 	compileSdk 33
 	defaultConfig {
 		if (buildAsApplication) {
 			applicationId "org.diasurgical.devilutionx"
 		}
-		minSdkVersion 18
+		minSdkVersion 21
 		targetSdkVersion 33
 		versionCode 28
 		versionName project.file('../../VERSION').text.trim()


### PR DESCRIPTION
This version of NDK finally comes with updated libc++.
The last update to libc++ in NDK was in early 2020.

This update brings lots of improvements and bugfixes from upstream
libc++.

NDK 26 only support SDK 21+, so we bump `minSdkVersion` as well.

GitHub Actions runner images update to this NDK version is tracked in https://github.com/actions/runner-images/issues/8327