### PR TITLE
Remove `PointsInRectangle` factory functions

### DIFF
--- a/Source/engine/points_in_rectangle_range.hpp
+++ b/Source/engine/points_in_rectangle_range.hpp
@@ -67,7 +67,7 @@ protected:
 };
 
 template <typename CoordT>
-class PointsInRectangleRange {
+class PointsInRectangle {
 public:
 	using const_iterator = class PointsInRectangleIterator : public PointsInRectangleIteratorBase<CoordT> {
 	public:
@@ -188,7 +188,7 @@ public:
 		}
 	};
 
-	constexpr PointsInRectangleRange(RectangleOf<CoordT> region)
+	constexpr PointsInRectangle(RectangleOf<CoordT> region)
 	    : region(region)
 	{
 	}
@@ -240,13 +240,7 @@ protected:
 };
 
 template <typename CoordT>
-constexpr PointsInRectangleRange<CoordT> PointsInRectangle(RectangleOf<CoordT> region)
-{
-	return PointsInRectangleRange<CoordT> { region };
-}
-
-template <typename CoordT>
-class PointsInRectangleColMajorRange {
+class PointsInRectangleColMajor {
 public:
 	using const_iterator = class PointsInRectangleIteratorColMajor : public PointsInRectangleIteratorBase<CoordT> {
 	public:
@@ -368,7 +362,7 @@ public:
 	};
 
 	// gcc6 needs a defined constructor?
-	constexpr PointsInRectangleColMajorRange(RectangleOf<CoordT> region)
+	constexpr PointsInRectangleColMajor(RectangleOf<CoordT> region)
 	    : region(region)
 	{
 	}
@@ -418,11 +412,5 @@ public:
 protected:
 	RectangleOf<CoordT> region;
 };
-
-template <typename CoordT = int>
-constexpr PointsInRectangleColMajorRange<CoordT> PointsInRectangleColMajor(RectangleOf<CoordT> region)
-{
-	return PointsInRectangleColMajorRange<CoordT> { region };
-}
 
 } // namespace devilution

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3579,7 +3579,7 @@ void ResyncDoors(WorldTilePosition p1, WorldTilePosition p2, bool sendmsg)
 	const WorldTileSize size { static_cast<WorldTileCoord>(p2.x - p1.x), static_cast<WorldTileCoord>(p2.y - p1.y) };
 	const WorldTileRectangle area { p1, size };
 
-	for (WorldTilePosition p : PointsInRectangleRange<WorldTileCoord> { area }) {
+	for (const WorldTilePosition p : PointsInRectangle { area }) {
 		Object *obj = FindObjectAtPosition(p);
 		if (obj == nullptr)
 			continue;

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -50,7 +50,7 @@ constexpr Rectangle StashButtonRect[] = {
 	// clang-format on
 };
 
-constexpr PointsInRectangleRange<int> StashGridRange { { { 0, 0 }, Size { 10, 10 } } };
+constexpr PointsInRectangle<int> StashGridRange { { { 0, 0 }, Size { 10, 10 } } };
 
 OptionalOwnedClxSpriteList StashPanelArt;
 OptionalOwnedClxSpriteList StashNavButtonArt;


### PR DESCRIPTION
These are no longer needed in C++17 thanks to CTAD.