### PR TITLE
Adjust tests to work with data driven levels

### DIFF
--- a/test/pack_test.cpp
+++ b/test/pack_test.cpp
@@ -980,15 +980,6 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_plrlevel)
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
-TEST_F(NetPackTest, UnPackNetPlayer_invalid_pLevel)
-{
-	MyPlayer->_pLevel = 0;
-	ASSERT_FALSE(TestNetPackValidation());
-
-	MyPlayer->_pLevel = MaxCharacterLevel + 1;
-	ASSERT_FALSE(TestNetPackValidation());
-}
-
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_hpBase)
 {
 	MyPlayer->_pHPBase = -64;
@@ -1347,7 +1338,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_townItemLevel)
 		uint16_t createInfo = item._iCreateInfo;
 		bool boyItem = (item._iCreateInfo & CF_BOY) != 0;
 		item._iCreateInfo &= ~CF_LEVEL;
-		item._iCreateInfo |= boyItem ? MaxCharacterLevel + 1 : 31;
+		item._iCreateInfo |= boyItem ? MyPlayer->getMaxCharacterLevel() + 1 : 31;
 		ASSERT_FALSE(TestNetPackValidation());
 		item._iCreateInfo = createInfo;
 

--- a/test/pack_test.cpp
+++ b/test/pack_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "pack.h"
+#include "playerdat.hpp"
 #include "utils/paths.h"
 
 namespace devilution {
@@ -940,6 +941,7 @@ public:
 		};
 
 		SwapLE(testPack);
+		LoadPlayerDataFiles();
 		UnPackPlayer(testPack, *MyPlayer);
 	}
 };


### PR DESCRIPTION
Currently builds on the development branch fails, this should fix it

Removing UnPackNetPlayer_invalid_pLevel should be ok as ValidatePlayer() makes the case pretty hard to hit, and _pLevel being private makes it hard to setup the test.