### PR TITLE
Fix dungeon entrance position in MP

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2527,6 +2527,22 @@ void InitPlayer(Player &player, bool firstTime)
 		player._pdir = Direction::South;
 
 		if (&player == MyPlayer && (!firstTime || leveltype != DTYPE_TOWN)) {
+			Displacement d[9] = { { 0, 0 }, { -1, -1 }, { -1, 0 }, { -1, 1 }, { 0, -1 }, { 0, 1 }, { 1, -1 }, { 1, 0 }, { 1, 1 } };
+
+			for (auto dir : d) {
+				for (auto &player : Players) {
+					if (&player == MyPlayer || !player.isOnActiveLevel()) {
+						continue;
+					}
+
+					if (player.position.tile == ViewPosition + Displacement(dir)) {
+						continue;
+					}
+
+					ViewPosition += Displacement(dir);
+				}
+			}
+
 			player.position.tile = ViewPosition;
 		}
 


### PR DESCRIPTION
If you enter a dungeon level, and a player is already standing on the entrance tile, it will opt to check other squares to place you. Unfortunately, I could not figure out how to correctly handle when 2 players are entering the dungeon nearly simultaneously.