### PR TITLE
Add duration parameter to InitDiabloMsg()

### DIFF
--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -23,7 +23,6 @@ namespace {
 struct MessageEntry {
 	std::string text;
 	uint32_t duration;  // Duration in milliseconds
-	uint32_t startTime; // Time when the message started displaying
 };
 
 std::deque<MessageEntry> DiabloMessages;
@@ -127,7 +126,7 @@ void InitDiabloMsg(string_view msg, uint32_t duration /*= 3500*/)
 	    != DiabloMessages.end())
 		return;
 
-	DiabloMessages.push_back({ std::string(msg), duration, SDL_GetTicks() });
+	DiabloMessages.push_back({ std::string(msg), duration });
 	if (DiabloMessages.size() == 1) {
 		InitNextLines();
 		msgStartTime = SDL_GetTicks();

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -29,14 +29,12 @@ struct MessageEntry {
 std::deque<MessageEntry> DiabloMessages;
 uint32_t msgStartTime = 0;
 std::vector<std::string> TextLines;
-uint32_t msgdelay;
 int ErrorWindowHeight = 54;
 const int LineHeight = 12;
 const int LineWidth = 418;
 
 void InitNextLines()
 {
-	msgdelay = SDL_GetTicks();
 	TextLines.clear();
 
 	const std::string paragraphs = WordWrapString(DiabloMessages.front().text, LineWidth, GameFont12, 1);
@@ -143,7 +141,13 @@ bool IsDiabloMsgAvailable()
 
 void CancelCurrentDiabloMsg()
 {
-	msgdelay = 0;
+	if (!DiabloMessages.empty()) {
+		DiabloMessages.pop_front();
+		if (!DiabloMessages.empty()) {
+			InitNextLines();
+			msgStartTime = SDL_GetTicks();
+		}
+	}
 }
 
 void ClrDiabloMsg()

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -20,7 +20,14 @@ namespace devilution {
 
 namespace {
 
-std::deque<std::string> DiabloMessages;
+struct MessageEntry {
+	std::string text;
+	uint32_t duration;  // Duration in milliseconds
+	uint32_t startTime; // Time when the message started displaying
+};
+
+std::deque<MessageEntry> DiabloMessages;
+uint32_t msgStartTime = 0;
 std::vector<std::string> TextLines;
 uint32_t msgdelay;
 int ErrorWindowHeight = 54;
@@ -32,7 +39,7 @@ void InitNextLines()
 	msgdelay = SDL_GetTicks();
 	TextLines.clear();
 
-	const std::string paragraphs = WordWrapString(DiabloMessages.front(), LineWidth, GameFont12, 1);
+	const std::string paragraphs = WordWrapString(DiabloMessages.front().text, LineWidth, GameFont12, 1);
 
 	size_t previous = 0;
 	while (true) {
@@ -107,22 +114,26 @@ const char *const MsgStrings[] = {
 	N_(/* TRANSLATORS: Shrine Text. Keep atmospheric. :) */ "That which can break will."),
 };
 
-void InitDiabloMsg(diablo_message e)
+void InitDiabloMsg(diablo_message e, uint32_t duration /*= 3500*/)
 {
-	InitDiabloMsg(LanguageTranslate(MsgStrings[e]));
+	InitDiabloMsg(LanguageTranslate(MsgStrings[e]), duration);
 }
 
-void InitDiabloMsg(string_view msg)
+void InitDiabloMsg(string_view msg, uint32_t duration /*= 3500*/)
 {
 	if (DiabloMessages.size() >= MAX_SEND_STR_LEN)
 		return;
 
-	if (std::find(DiabloMessages.begin(), DiabloMessages.end(), msg) != DiabloMessages.end())
+	if (std::find_if(DiabloMessages.begin(), DiabloMessages.end(),
+	        [&msg](const MessageEntry &entry) { return entry.text == msg; })
+	    != DiabloMessages.end())
 		return;
 
-	DiabloMessages.push_back(std::string(msg));
-	if (DiabloMessages.size() == 1)
+	DiabloMessages.push_back({ std::string(msg), duration, SDL_GetTicks() });
+	if (DiabloMessages.size() == 1) {
 		InitNextLines();
+		msgStartTime = SDL_GetTicks();
+	}
 }
 
 bool IsDiabloMsgAvailable()
@@ -171,13 +182,17 @@ void DrawDiabloMsg(const Surface &out)
 		lineNumber += 1;
 	}
 
-	if (msgdelay > 0 && msgdelay <= SDL_GetTicks() - 3500) {
-		msgdelay = 0;
-	}
-	if (msgdelay == 0) {
+	// Calculate the time the current message has been displayed
+	uint32_t currentTime = SDL_GetTicks();
+	uint32_t messageElapsedTime = currentTime - msgStartTime;
+
+	// Check if the current message's duration has passed
+	if (!DiabloMessages.empty() && messageElapsedTime >= DiabloMessages.front().duration) {
 		DiabloMessages.pop_front();
-		if (!DiabloMessages.empty())
+		if (!DiabloMessages.empty()) {
 			InitNextLines();
+			msgStartTime = currentTime;
+		}
 	}
 }
 

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -22,7 +22,7 @@ namespace {
 
 struct MessageEntry {
 	std::string text;
-	uint32_t duration;  // Duration in milliseconds
+	uint32_t duration; // Duration in milliseconds
 };
 
 std::deque<MessageEntry> DiabloMessages;

--- a/Source/error.h
+++ b/Source/error.h
@@ -71,8 +71,8 @@ enum diablo_message : uint8_t {
 	EMSG_SHRINE_MURPHYS,
 };
 
-void InitDiabloMsg(diablo_message e);
-void InitDiabloMsg(string_view msg);
+void InitDiabloMsg(diablo_message e, uint32_t duration = 3500);
+void InitDiabloMsg(string_view msg, uint32_t duration = 3500);
 bool IsDiabloMsgAvailable();
 void CancelCurrentDiabloMsg();
 void ClrDiabloMsg();

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -332,7 +332,7 @@ void gamemenu_save_game(bool /*bActivate*/)
 	DrawAndBlit();
 	SaveGame();
 	ClrDiabloMsg();
-	InitDiabloMsg(EMSG_GAME_SAVED);
+	InitDiabloMsg(EMSG_GAME_SAVED, 1000);
 	RedrawEverything();
 	NewCursor(CURSOR_HAND);
 	if (CornerStone.activated) {


### PR DESCRIPTION
Allows each DiabloMsg to have a set duration. Modified the `Game Saved` duration to 1 second (from default 3.5 seconds) as proof of concept and to quell a complaint. I'd like to make another PR to adjust various other messages that either last too long or not long enough (i.e. Debug Help menu is too short, various debug command messages last too long)

https://github.com/diasurgical/devilutionX/pull/6506