### PR TITLE
Deterministic timer simulation for shrine messages in demo mode

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -166,6 +166,7 @@ set(libdevilutionx_SRCS
   utils/str_cat.cpp
   utils/str_case.cpp
   utils/surface_to_clx.cpp
+  utils/timer.cpp
   utils/utf8.cpp)
 
 if(SUPPORTS_MPQ)

--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -715,6 +715,9 @@ bool FetchMessage(SDL_Event *event, uint16_t *modState)
 void RecordGameLoopResult(bool runGameLoop)
 {
 	WriteDemoMsgHeader(runGameLoop ? DemoMsg::GameTick : DemoMsg::Rendering);
+
+	if (runGameLoop && !IsRunning())
+		LogicTick++;
 }
 
 void RecordMessage(const SDL_Event &event, uint16_t modState)
@@ -790,6 +793,12 @@ void RecordMessage(const SDL_Event &event, uint16_t modState)
 
 void NotifyGameLoopStart()
 {
+	LogicTick = 0;
+
+	if (IsRunning()) {
+		StartTime = SDL_GetTicks();
+	}
+
 	if (IsRecording()) {
 		const std::string path = StrCat(paths::PrefPath(), "demo_", RecordNumber, ".dmo");
 		DemoRecording = OpenFile(path.c_str(), "wb");
@@ -802,11 +811,6 @@ void NotifyGameLoopStart()
 		WriteByte(DemoRecording, Version);
 		WriteLE32(DemoRecording, gSaveNumber);
 		WriteSettings(DemoRecording);
-	}
-
-	if (IsRunning()) {
-		StartTime = SDL_GetTicks();
-		LogicTick = 0;
 	}
 }
 
@@ -841,6 +845,11 @@ void NotifyGameLoopEnd()
 			break;
 		}
 	}
+}
+
+uint32_t GetTicks()
+{
+	return LogicTick * 50;
 }
 
 } // namespace demo

--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -847,7 +847,7 @@ void NotifyGameLoopEnd()
 	}
 }
 
-uint32_t GetTicks()
+uint32_t SimulateMillisecondsSinceStartup()
 {
 	return LogicTick * 50;
 }

--- a/Source/engine/demomode.h
+++ b/Source/engine/demomode.h
@@ -29,7 +29,7 @@ void RecordMessage(const SDL_Event &event, uint16_t modState);
 void NotifyGameLoopStart();
 void NotifyGameLoopEnd();
 
-uint32_t GetTicks();
+uint32_t SimulateMillisecondsSinceStartup();
 #else
 inline void OverrideOptions()
 {
@@ -62,7 +62,7 @@ inline void NotifyGameLoopStart()
 inline void NotifyGameLoopEnd()
 {
 }
-inline uint32_t GetTicks()
+inline uint32_t SimulateMillisecondsSinceStartup()
 {
 	return 0;
 }

--- a/Source/engine/demomode.h
+++ b/Source/engine/demomode.h
@@ -28,6 +28,8 @@ void RecordMessage(const SDL_Event &event, uint16_t modState);
 
 void NotifyGameLoopStart();
 void NotifyGameLoopEnd();
+
+uint32_t GetTicks();
 #else
 inline void OverrideOptions()
 {
@@ -59,6 +61,10 @@ inline void NotifyGameLoopStart()
 }
 inline void NotifyGameLoopEnd()
 {
+}
+inline uint32_t GetTicks()
+{
+	return 0;
 }
 #endif
 

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -31,7 +31,7 @@ const int LineWidth = 418;
 
 void InitNextLines()
 {
-	msgdelay = GetTicks();
+	msgdelay = GetMillisecondsSinceStartup();
 	TextLines.clear();
 
 	const std::string paragraphs = WordWrapString(DiabloMessages.front(), LineWidth, GameFont12, 1);
@@ -173,7 +173,7 @@ void DrawDiabloMsg(const Surface &out)
 		lineNumber += 1;
 	}
 
-	if (msgdelay > 0 && msgdelay <= GetTicks() - 3500) {
+	if (msgdelay > 0 && msgdelay <= GetMillisecondsSinceStartup() - 3500) {
 		msgdelay = 0;
 	}
 	if (msgdelay == 0) {

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -16,6 +16,7 @@
 #include "stores.h"
 #include "utils/algorithm/container.hpp"
 #include "utils/language.h"
+#include "utils/timer.hpp"
 
 namespace devilution {
 
@@ -30,7 +31,7 @@ const int LineWidth = 418;
 
 void InitNextLines()
 {
-	msgdelay = SDL_GetTicks();
+	msgdelay = GetTicks();
 	TextLines.clear();
 
 	const std::string paragraphs = WordWrapString(DiabloMessages.front(), LineWidth, GameFont12, 1);
@@ -172,7 +173,7 @@ void DrawDiabloMsg(const Surface &out)
 		lineNumber += 1;
 	}
 
-	if (msgdelay > 0 && msgdelay <= SDL_GetTicks() - 3500) {
+	if (msgdelay > 0 && msgdelay <= GetTicks() - 3500) {
 		msgdelay = 0;
 	}
 	if (msgdelay == 0) {

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -20,6 +20,7 @@
 #include "playerdat.hpp"
 #include "textdat.h"
 #include "utils/language.h"
+#include "utils/timer.hpp"
 
 namespace devilution {
 
@@ -81,7 +82,7 @@ uint32_t CalculateTextSpeed(int nSFX)
 
 int CalculateTextPosition()
 {
-	uint32_t currTime = SDL_GetTicks();
+	uint32_t currTime = GetTicks();
 
 	int y = (currTime - ScrollStart) / qtextSpd - 260;
 
@@ -165,7 +166,7 @@ void InitQTextMsg(_speech_id m)
 		LoadText(_(Speeches[m].txtstr));
 		qtextflag = true;
 		qtextSpd = CalculateTextSpeed(sfxnr);
-		ScrollStart = SDL_GetTicks();
+		ScrollStart = GetTicks();
 	}
 	PlaySFX(sfxnr);
 }

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -82,7 +82,7 @@ uint32_t CalculateTextSpeed(int nSFX)
 
 int CalculateTextPosition()
 {
-	uint32_t currTime = GetTicks();
+	uint32_t currTime = GetMillisecondsSinceStartup();
 
 	int y = (currTime - ScrollStart) / qtextSpd - 260;
 
@@ -166,7 +166,7 @@ void InitQTextMsg(_speech_id m)
 		LoadText(_(Speeches[m].txtstr));
 		qtextflag = true;
 		qtextSpd = CalculateTextSpeed(sfxnr);
-		ScrollStart = GetTicks();
+		ScrollStart = GetMillisecondsSinceStartup();
 	}
 	PlaySFX(sfxnr);
 }

--- a/Source/utils/timer.cpp
+++ b/Source/utils/timer.cpp
@@ -1,0 +1,10 @@
+#include "engine/demomode.h"
+
+namespace devilution {
+
+uint32_t GetTicks()
+{
+	return (demo::IsRunning() || demo::IsRecording()) ? demo::GetTicks() : SDL_GetTicks();
+}
+
+} // namespace devilution

--- a/Source/utils/timer.cpp
+++ b/Source/utils/timer.cpp
@@ -2,9 +2,9 @@
 
 namespace devilution {
 
-uint32_t GetTicks()
+uint32_t GetMillisecondsSinceStartup()
 {
-	return (demo::IsRunning() || demo::IsRecording()) ? demo::GetTicks() : SDL_GetTicks();
+	return (demo::IsRunning() || demo::IsRecording()) ? demo::SimulateMillisecondsSinceStartup() : SDL_GetTicks();
 }
 
 } // namespace devilution

--- a/Source/utils/timer.hpp
+++ b/Source/utils/timer.hpp
@@ -2,6 +2,6 @@
 
 namespace devilution {
 
-uint32_t GetTicks();
+uint32_t GetMillisecondsSinceStartup();
 
 }

--- a/Source/utils/timer.hpp
+++ b/Source/utils/timer.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace devilution {
+
+uint32_t GetTicks();
+
+}


### PR DESCRIPTION
Solves one of the issues listed in #2745.

> Dialogs playback is realtime, if the player did not interrupt it (or playback is slower then playtime) the dialog will stay open for a different duration

When recording a demo or playing it back, the game simulates `SDL_GetTicks()` based on the number of game ticks that have elapsed since the start of the demo, assuming 20 fps. When recording or playing back at faster speeds, this means that shrine messages will disappear faster and dialog will move faster than the corresponding audio.