### PR TITLE
Automap Enhancements

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -118,7 +118,7 @@ struct AutomapTile {
  */
 std::array<AutomapTile, 256> AutomapTypeTiles;
 
-void DrawDiamond(const Surface &out, Point center, uint8_t color)
+void DrawMapDiamond(const Surface &out, Point center, uint8_t color)
 {
 	const Point left { center.x - AmLine(16), center.y };
 	const Point top { center.x, center.y - AmLine(8) };
@@ -130,7 +130,7 @@ void DrawDiamond(const Surface &out, Point center, uint8_t color)
 	DrawMapLineNE(out, bottom, AmLine(8), color);
 }
 
-void DrawCross(const Surface &out, Point center, uint8_t color)
+void DrawMapCross(const Surface &out, Point center, uint8_t color)
 {
 	DrawMapLineNE(out, { center.x, center.y - AmLine(8) }, AmLine(8), color);
 	DrawMapLineNE(out, { center.x - AmLine(32), center.y + AmLine(8) }, AmLine(8), color);
@@ -151,11 +151,11 @@ void DrawMapVerticalDoor(const Surface &out, Point center, uint8_t colorBright, 
 	if (leveltype != DTYPE_CATACOMBS) {
 		DrawMapLineNE(out, { center.x + AmLine(8), center.y - AmLine(4) }, AmLine(4), colorDim);
 		DrawMapLineNE(out, { center.x - AmLine(16), center.y + AmLine(8) }, AmLine(4), colorDim);
-		DrawDiamond(out, center, colorBright);
+		DrawMapDiamond(out, center, colorBright);
 	} else {
 		DrawMapLineNE(out, { center.x - AmLine(8), center.y + AmLine(4) }, AmLine(8), colorDim);
 		DrawMapLineNE(out, { center.x - AmLine(16), center.y + AmLine(8) }, AmLine(4), colorDim);
-		DrawDiamond(out, { center.x + AmLine(16), center.y - AmLine(8) }, colorBright);
+		DrawMapDiamond(out, { center.x + AmLine(16), center.y - AmLine(8) }, colorBright);
 	}
 }
 
@@ -164,216 +164,216 @@ void DrawMapHorizontalDoor(const Surface &out, Point center, uint8_t colorBright
 	if (leveltype != DTYPE_CATACOMBS) {
 		DrawMapLineSE(out, { center.x - AmLine(16), center.y - AmLine(8) }, AmLine(4), colorDim);
 		DrawMapLineSE(out, { center.x + AmLine(8), center.y + AmLine(4) }, AmLine(4), colorDim);
-		DrawDiamond(out, center, colorBright);
+		DrawMapDiamond(out, center, colorBright);
 	} else {
 		DrawMapLineSE(out, { center.x - AmLine(8), center.y - AmLine(4) }, AmLine(8), colorDim);
 		DrawMapLineSE(out, { center.x + AmLine(8), center.y + AmLine(4) }, AmLine(4), colorDim);
-		DrawDiamond(out, { center.x - AmLine(16), center.y - AmLine(8) }, colorBright);
+		DrawMapDiamond(out, { center.x - AmLine(16), center.y - AmLine(8) }, colorBright);
 	}
 }
 
 void DrawDirt(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x + AmLine(8) - AmLine(32), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8) - AmLine(32), center.y + AmLine(4) }, color);
 
-	out.SetPixel({ center.x - AmLine(16), center.y }, color);
-	out.SetPixel({ center.x - AmLine(16), center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x - AmLine(16), center.y }, color);
+	SetMapPixel(out, { center.x - AmLine(16), center.y + AmLine(8) }, color);
 
-	out.SetPixel({ center.x - AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y - AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
 
-	out.SetPixel({ center.x, center.y - AmLine(8) }, color);
-	out.SetPixel(center, color);
-	out.SetPixel({ center.x, center.y + AmLine(8) }, color);
-	out.SetPixel({ center.x, center.y + AmLine(16) }, color);
+	SetMapPixel(out, { center.x, center.y - AmLine(8) }, color);
+	SetMapPixel(out, center, color);
+	SetMapPixel(out, { center.x, center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x, center.y + AmLine(16) }, color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y - AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
 
-	out.SetPixel({ center.x + AmLine(16), center.y }, color);
-	out.SetPixel({ center.x + AmLine(16), center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x + AmLine(16), center.y }, color);
+	SetMapPixel(out, { center.x + AmLine(16), center.y + AmLine(8) }, color);
 
-	out.SetPixel({ center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
 }
 
 void DrawBridge(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel(center, color);
+	SetMapPixel(out, center, color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y - AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y + AmLine(4) }, color);
 
-	out.SetPixel({ center.x + AmLine(16), center.y }, color);
-	out.SetPixel({ center.x + AmLine(16), center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x + AmLine(16), center.y }, color);
+	SetMapPixel(out, { center.x + AmLine(16), center.y + AmLine(8) }, color);
 
-	out.SetPixel({ center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
 }
 
 void DrawRiverRightIn(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x - AmLine(16), center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x - AmLine(16), center.y + AmLine(8) }, color);
 
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
 
-	out.SetPixel(center, color);
-	out.SetPixel({ center.x, center.y + AmLine(8) }, color);
-	out.SetPixel({ center.x, center.y + AmLine(16) }, color);
+	SetMapPixel(out, center, color);
+	SetMapPixel(out, { center.x, center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x, center.y + AmLine(16) }, color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
 
-	out.SetPixel({ center.x + AmLine(16), center.y }, color);
-	out.SetPixel({ center.x + AmLine(16), center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x + AmLine(16), center.y }, color);
+	SetMapPixel(out, { center.x + AmLine(16), center.y + AmLine(8) }, color);
 
-	out.SetPixel({ center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
 }
 
 void DrawRiverCornerSouth(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x, center.y + AmLine(16) }, color);
+	SetMapPixel(out, { center.x, center.y + AmLine(16) }, color);
 }
 
 void DrawRiverCornerNorth(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x - AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x, center.y - AmLine(8) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y - AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y - AmLine(4) }, color);
+	SetMapPixel(out, { center.x, center.y - AmLine(8) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y - AmLine(4) }, color);
 }
 
 void DrawRiverLeftOut(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x + AmLine(8) - AmLine(32), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8) - AmLine(32), center.y + AmLine(4) }, color);
 
-	out.SetPixel({ center.x - AmLine(16), center.y }, color);
-	out.SetPixel({ center.x - AmLine(16), center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x - AmLine(16), center.y }, color);
+	SetMapPixel(out, { center.x - AmLine(16), center.y + AmLine(8) }, color);
 
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
 
-	out.SetPixel(center, color);
-	out.SetPixel({ center.x, center.y + AmLine(8) }, color);
+	SetMapPixel(out, center, color);
+	SetMapPixel(out, { center.x, center.y + AmLine(8) }, color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y - AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
 
-	out.SetPixel({ center.x + AmLine(16), center.y }, color);
-	out.SetPixel({ center.x + AmLine(16), center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x + AmLine(16), center.y }, color);
+	SetMapPixel(out, { center.x + AmLine(16), center.y + AmLine(8) }, color);
 
-	out.SetPixel({ center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
 }
 
 void DrawRiverLeftIn(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x - AmLine(16), center.y }, color);
-	out.SetPixel({ center.x - AmLine(16), center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x - AmLine(16), center.y }, color);
+	SetMapPixel(out, { center.x - AmLine(16), center.y + AmLine(8) }, color);
 
-	out.SetPixel({ center.x - AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y - AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
 
-	out.SetPixel({ center.x, center.y - AmLine(8) }, color);
-	out.SetPixel(center, color);
-	out.SetPixel({ center.x, center.y + AmLine(8) }, color);
-	out.SetPixel({ center.x, center.y + AmLine(16) }, color);
+	SetMapPixel(out, { center.x, center.y - AmLine(8) }, color);
+	SetMapPixel(out, center, color);
+	SetMapPixel(out, { center.x, center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x, center.y + AmLine(16) }, color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y - AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
 }
 
 void DrawRiverCornerWest(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x + AmLine(8) - AmLine(32), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(16), center.y }, color);
+	SetMapPixel(out, { center.x + AmLine(8) - AmLine(32), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(16), center.y }, color);
 }
 
 void DrawRiverCornerEast(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x + AmLine(16), center.y }, color);
-	out.SetPixel({ center.x + AmLine(16), center.y + AmLine(8) }, color);
-	out.SetPixel({ center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(16), center.y }, color);
+	SetMapPixel(out, { center.x + AmLine(16), center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
 }
 
 void DrawRiverRightOut(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
 
-	out.SetPixel(center, color);
-	out.SetPixel({ center.x, center.y + AmLine(8) }, color);
-	out.SetPixel({ center.x, center.y + AmLine(16) }, color);
+	SetMapPixel(out, center, color);
+	SetMapPixel(out, { center.x, center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x, center.y + AmLine(16) }, color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y - AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
 
-	out.SetPixel({ center.x + AmLine(16), center.y }, color);
-	out.SetPixel({ center.x + AmLine(16), center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x + AmLine(16), center.y }, color);
+	SetMapPixel(out, { center.x + AmLine(16), center.y + AmLine(8) }, color);
 
-	out.SetPixel({ center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
 }
 
 void DrawRiver(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x - AmLine(16), center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x - AmLine(16), center.y + AmLine(8) }, color);
 
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
 
-	out.SetPixel(center, color);
-	out.SetPixel({ center.x, center.y + AmLine(8) }, color);
-	out.SetPixel({ center.x, center.y + AmLine(16) }, color);
+	SetMapPixel(out, center, color);
+	SetMapPixel(out, { center.x, center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x, center.y + AmLine(16) }, color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y - AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
 
-	out.SetPixel({ center.x + AmLine(16), center.y }, color);
-	out.SetPixel({ center.x + AmLine(16), center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x + AmLine(16), center.y }, color);
+	SetMapPixel(out, { center.x + AmLine(16), center.y + AmLine(8) }, color);
 
-	out.SetPixel({ center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
 }
 
 void DrawRiverForkIn(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x - AmLine(16), center.y }, color);
-	out.SetPixel({ center.x - AmLine(16), center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x - AmLine(16), center.y }, color);
+	SetMapPixel(out, { center.x - AmLine(16), center.y + AmLine(8) }, color);
 
-	out.SetPixel({ center.x - AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y - AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
 
-	out.SetPixel({ center.x, center.y - AmLine(8) }, color);
-	out.SetPixel(center, color);
-	out.SetPixel({ center.x, center.y + AmLine(8) }, color);
-	out.SetPixel({ center.x, center.y + AmLine(16) }, color);
+	SetMapPixel(out, { center.x, center.y - AmLine(8) }, color);
+	SetMapPixel(out, center, color);
+	SetMapPixel(out, { center.x, center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x, center.y + AmLine(16) }, color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y - AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
 
-	out.SetPixel({ center.x + AmLine(16), center.y }, color);
-	out.SetPixel({ center.x + AmLine(16), center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x + AmLine(16), center.y }, color);
+	SetMapPixel(out, { center.x + AmLine(16), center.y + AmLine(8) }, color);
 
-	out.SetPixel({ center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
 }
 
 void DrawRiverForkOut(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x + AmLine(8) - AmLine(32), center.y + AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8) - AmLine(32), center.y + AmLine(4) }, color);
 
-	out.SetPixel({ center.x - AmLine(16), center.y }, color);
-	out.SetPixel({ center.x - AmLine(16), center.y + AmLine(8) }, color);
+	SetMapPixel(out, { center.x - AmLine(16), center.y }, color);
+	SetMapPixel(out, { center.x - AmLine(16), center.y + AmLine(8) }, color);
 
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	SetMapPixel(out, { center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
 
-	out.SetPixel({ center.x, center.y + AmLine(16) }, color);
+	SetMapPixel(out, { center.x, center.y + AmLine(16) }, color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	SetMapPixel(out, { center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
 }
 
 enum class StairsType : uint8_t {
@@ -501,9 +501,9 @@ void DrawHorizontal(const Surface &out, Point center, AutomapTile tile, uint8_t 
 	}
 	if (tile.HasFlag(AutomapTile::Flags::HorizontalGrate)) {
 		DrawMapLineSE(out, { center.x + AmLine(16), center.y - AmLine(8) }, AmLine(8), colorDim);
-		DrawDiamond(out, { center.x, center.y - AmLine(8) }, colorDim);
+		DrawMapDiamond(out, { center.x, center.y - AmLine(8) }, colorDim);
 	} else if (tile.HasFlag(AutomapTile::Flags::HorizontalArch)) {
-		DrawDiamond(out, { center.x, center.y - AmLine(8) }, colorDim);
+		DrawMapDiamond(out, { center.x, center.y - AmLine(8) }, colorDim);
 	}
 }
 
@@ -521,9 +521,9 @@ void DrawVertical(const Surface &out, Point center, AutomapTile tile, uint8_t co
 	}
 	if (tile.HasFlag(AutomapTile::Flags::VerticalGrate)) { // right-facing half-wall
 		DrawMapLineNE(out, { center.x - AmLine(32), center.y }, AmLine(8), colorDim);
-		DrawDiamond(out, { center.x, center.y - AmLine(8) }, colorDim);
+		DrawMapDiamond(out, { center.x, center.y - AmLine(8) }, colorDim);
 	} else if (tile.HasFlag(AutomapTile::Flags::VerticalArch)) { // window or passable column
-		DrawDiamond(out, { center.x, center.y - AmLine(8) }, colorDim);
+		DrawMapDiamond(out, { center.x, center.y - AmLine(8) }, colorDim);
 	}
 }
 
@@ -651,16 +651,15 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 
 	if (currlevel == Quests[Q_BETRAYER]._qlevel && map == Quests[Q_BETRAYER].position.worldToMega() + Displacement { 1, 1 }) {
 		int pentaColor = (Quests[Q_BETRAYER]._qactive == QUEST_DONE) ? PAL8_RED + 2 : PAL16_YELLOW + 8;
-		Displacement pentaOffset = { 0, -(TILE_HEIGHT / 2) };
-		DrawMapEllipse(out, center + Displacement { 0, 1 } + pentaOffset, AmLine(64), 0); // shadow
-		DrawMapStar(out, center + Displacement { 0, 1 } + pentaOffset, AmLine(64), 0);    // shadow
-		DrawMapEllipse(out, center + pentaOffset, AmLine(64), pentaColor);
-		DrawMapStar(out, center + pentaOffset, AmLine(64), pentaColor);
+		DrawMapEllipse(out, center + Displacement { 0, 1 }, AmLine(64), 0); // shadow
+		DrawMapStar(out, center + Displacement { 0, 1 }, AmLine(64), 0);    // shadow
+		DrawMapEllipse(out, center, AmLine(64), pentaColor);
+		DrawMapStar(out, center, AmLine(64), pentaColor);
 	}
 
 	switch (tile.type) {
 	case AutomapTile::Types::Diamond: // stand-alone column or other unpassable object
-		DrawDiamond(out, { center.x, center.y - AmLine(8) }, colorDim);
+		DrawMapDiamond(out, { center.x, center.y - AmLine(8) }, colorDim);
 		break;
 	case AutomapTile::Types::Vertical:
 	case AutomapTile::Types::FenceVertical:
@@ -739,9 +738,21 @@ Point GetAutomapScreen(const int i, const int j, const Displacement &myPlayerOff
 	int px = i - 2 * AutomapOffset.deltaX - ViewPosition.x;
 	int py = j - 2 * AutomapOffset.deltaY - ViewPosition.y;
 
+	Point screenOffset {
+		gnScreenWidth / 2,
+		(gnScreenHeight - GetMainPanel().size.height) / 2
+	};
+
+	if (AutomapMini) {
+		screenOffset = {
+			AutomapMiniRect.position.x + AutomapMiniRect.size.width / 2,
+			AutomapMiniRect.position.y + AutomapMiniRect.size.height / 2
+		};
+	}
+
 	Point screen = {
-		(myPlayerOffset.deltaX * AutoMapScale / 100 / 2) + (px - py) * AmLine(16) + gnScreenWidth / 2,
-		(myPlayerOffset.deltaY * AutoMapScale / 100 / 2) + (px + py) * AmLine(8) + (gnScreenHeight - GetMainPanel().size.height) / 2
+		(myPlayerOffset.deltaX * AutoMapScale / 100 / 2) + (px - py) * AmLine(16) + screenOffset.x,
+		(myPlayerOffset.deltaY * AutoMapScale / 100 / 2) + (px + py) * AmLine(8) + screenOffset.y
 	};
 
 	if (CanPanelsCoverView()) {
@@ -779,7 +790,7 @@ void SearchAutomapItem(const Surface &out, const Displacement &myPlayerOffset, i
 			if (!highlightTile({ i, j }))
 				continue;
 
-			DrawDiamond(out, GetAutomapScreen(i, j, myPlayerOffset), MapColorsItem);
+			DrawMapDiamond(out, GetAutomapScreen(i, j, myPlayerOffset), MapColorsItem);
 		}
 	}
 }
@@ -793,7 +804,7 @@ void DrawAutomapObject(const Surface &out, const Displacement &myPlayerOffset, t
 			if (!highlightTile({ i, j }) || explorationType == MAP_EXP_NONE || !IsAnyOf(ObjectAtPosition({ i, j })._otype, OBJ_BLINDBOOK, OBJ_BLOODBOOK, OBJ_BOOK2R, OBJ_CRUX1, OBJ_CRUX2, OBJ_CRUX3, OBJ_L5BOOKS, OBJ_L5LEVER, OBJ_LAZSTAND, OBJ_LEVER, OBJ_MCIRCLE1, OBJ_MCIRCLE2, OBJ_MUSHPATCH, OBJ_PEDESTAL, OBJ_SIGNCHEST, OBJ_SLAINHERO, OBJ_STAND, OBJ_STORYBOOK, OBJ_SWITCHSKL, OBJ_WARARMOR, OBJ_WARWEAP))
 				continue;
 
-			DrawDiamond(out, GetAutomapScreen(i, j, myPlayerOffset), MapColorsObject);
+			DrawMapDiamond(out, GetAutomapScreen(i, j, myPlayerOffset), MapColorsObject);
 		}
 	}
 }
@@ -813,7 +824,7 @@ void DrawAutomapMissile(const Surface &out, const Displacement &myPlayerOffset)
 			if (portal == nullptr || (explorationType == MAP_EXP_NONE && portal->_mitype == MissileID::RedPortal))
 				continue;
 
-			DrawCross(out, GetAutomapScreen(i, j, myPlayerOffset), portal->_mitype == MissileID::TownPortal ? MapColorsPortal : MapColorsRedPortal);
+			DrawMapEllipse(out, GetAutomapScreen(i, j, myPlayerOffset), AmLine(16), portal->_mitype == MissileID::TownPortal ? MapColorsPortal : MapColorsRedPortal);
 		}
 	}
 }
@@ -849,9 +860,21 @@ void DrawAutomapArrow(const Surface &out, const EntityType &entity, const Displa
 
 	Displacement offset = GetAutomapWalkingOffset(entity);
 
+	Point screen {
+		gnScreenWidth / 2,
+		(gnScreenHeight - GetMainPanel().size.height) / 2
+	};
+
+	if (AutomapMini) {
+		screen = {
+			AutomapMiniRect.position.x + AutomapMiniRect.size.width / 2,
+			AutomapMiniRect.position.y + AutomapMiniRect.size.height / 2
+		};
+	}
+
 	Point base = {
-		((offset.deltaX + myPlayerOffset.deltaX) * AutoMapScale / 100 / 2) + (px - py) * AmLine(16) + gnScreenWidth / 2,
-		((offset.deltaY + myPlayerOffset.deltaY) * AutoMapScale / 100 / 2) + (px + py) * AmLine(8) + (gnScreenHeight - GetMainPanel().size.height) / 2
+		((offset.deltaX + myPlayerOffset.deltaX) * AutoMapScale / 100 / 2) + (px - py) * AmLine(16) + screen.x,
+		((offset.deltaY + myPlayerOffset.deltaY) * AutoMapScale / 100 / 2) + (px + py) * AmLine(8) + screen.y
 	};
 
 	if (CanPanelsCoverView()) {
@@ -921,15 +944,6 @@ void DrawAutomapArrow(const Surface &out, const EntityType &entity, const Displa
 		DrawMapLineNW(out, { point.x + AmLine(8), point.y }, AmLine(8), deadCol);
 	}
 }
-
-/* void DrawAutomapTowner(const Surface &out, const Displacement &myPlayerOffset)
-{
-	for (auto &towner : Towners) {
-		bool townerAlive = towner._tAnimLen != 1;
-		Point tile = towner.position;
-		DrawCross(out, GetAutomapScreen(towner.position.x, towner.position.y, myPlayerOffset), (townerAlive) ? MapColorsTowner : MapColorsDead);
-	}
-}*/
 
 /**
  * @brief Renders an arrow on the automap, centered on and facing the direction of the towner.
@@ -1108,16 +1122,23 @@ std::unique_ptr<AutomapTile[]> LoadAutomapData(size_t &tileCount)
 } // namespace
 
 bool AutomapActive;
+bool AutomapMini;
 bool AutomapTransparent;
 uint8_t AutomapView[DMAXX][DMAXY];
 int AutoMapScale;
 Displacement AutomapOffset;
+Rectangle AutomapMiniRect {};
 
 void InitAutomapOnce()
 {
 	AutomapActive = false;
-	AutomapTransparent = false;
+	AutomapMini = false;
+	AutomapTransparent = true;
 	AutoMapScale = 50;
+	int minimapWidth = gnScreenWidth / 4;
+	Size minimapSize { minimapWidth, minimapWidth / 2 };
+	int minimapPadding = 16;
+	AutomapMiniRect = Rectangle { { gnScreenWidth - minimapPadding - minimapSize.width, minimapPadding }, minimapSize };
 }
 
 void InitAutomap()
@@ -1139,6 +1160,22 @@ void StartAutomap()
 {
 	AutomapOffset = { 0, 0 };
 	AutomapActive = true;
+	AutoMapScale = 50;
+}
+
+void StartMinimap()
+{
+	AutomapOffset = { 0, 0 };
+	AutomapMini = true;
+	if (gnScreenHeight >= 0 && gnScreenHeight < 960)
+		AutoMapScale = 25;
+	else if (gnScreenHeight >= 960 && gnScreenHeight < 1440)
+		AutoMapScale = 50;
+	else if (gnScreenHeight >= 1440 && gnScreenHeight < 1920)
+		AutoMapScale = 75;
+	else
+		AutoMapScale = 100;
+
 }
 
 void AutomapUp()
@@ -1167,7 +1204,7 @@ void AutomapRight()
 
 void AutomapZoomIn()
 {
-	if (AutoMapScale >= 200)
+	if (AutoMapScale >= 400)
 		return;
 
 	AutoMapScale += 25;
@@ -1175,7 +1212,7 @@ void AutomapZoomIn()
 
 void AutomapZoomOut()
 {
-	if (AutoMapScale <= 50)
+	if (AutoMapScale <= 25)
 		return;
 
 	AutoMapScale -= 25;
@@ -1184,6 +1221,7 @@ void AutomapZoomOut()
 void DrawAutomap(const Surface &out)
 {
 	Automap = { (ViewPosition.x - 8) / 2, (ViewPosition.y - 8) / 2 };
+
 	if (leveltype != DTYPE_TOWN) {
 		Automap += { -4, -4 };
 	}
@@ -1218,6 +1256,18 @@ void DrawAutomap(const Surface &out)
 		gnScreenWidth / 2,
 		(gnScreenHeight - GetMainPanel().size.height) / 2
 	};
+
+	if (AutomapMini) {
+		screen = {
+			AutomapMiniRect.position.x + AutomapMiniRect.size.width / 2,
+			AutomapMiniRect.position.y + AutomapMiniRect.size.height / 2
+		};
+		DrawHorizontalLine(out, AutomapMiniRect.position + Displacement { -1, -1 }, AutomapMiniRect.size.width + 2, MapColorsDim);
+		DrawHorizontalLine(out, AutomapMiniRect.position + Displacement { -1, AutomapMiniRect.size.height }, AutomapMiniRect.size.width + 2, MapColorsDim);
+		DrawVerticalLine(out, AutomapMiniRect.position + Displacement { -1, 0 }, AutomapMiniRect.size.height, MapColorsDim);
+		DrawVerticalLine(out, AutomapMiniRect.position + Displacement { AutomapMiniRect.size.width, 0 }, AutomapMiniRect.size.height, MapColorsDim);
+	}
+
 	if ((cells & 1) != 0) {
 		screen.x -= AmLine(64) * ((cells - 1) / 2);
 		screen.y -= AmLine(32) * ((cells + 1) / 2);

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1177,7 +1177,6 @@ void StartMinimap()
 		AutoMapScale = 75;
 	else
 		AutoMapScale = 100;
-
 }
 
 void AutomapUp()

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -651,10 +651,11 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 
 	if (currlevel == Quests[Q_BETRAYER]._qlevel && map == Quests[Q_BETRAYER].position.worldToMega() + Displacement { 1, 1 }) {
 		int pentaColor = (Quests[Q_BETRAYER]._qactive == QUEST_DONE) ? PAL8_RED + 2 : PAL16_YELLOW + 8;
-		DrawMapEllipse(out, center + Displacement { 0, 1 }, AmLine(64), 0); // shadow
-		DrawMapStar(out, center + Displacement { 0, 1 }, AmLine(64), 0);    // shadow
-		DrawMapEllipse(out, center, AmLine(64), pentaColor);
-		DrawMapStar(out, center, AmLine(64), pentaColor);
+		Displacement pentaOffset = { 0, -(TILE_HEIGHT / 2) };
+		DrawMapEllipse(out, center + Displacement { 0, 1 } + pentaOffset, AmLine(64), 0); // shadow
+		DrawMapStar(out, center + Displacement { 0, 1 } + pentaOffset, AmLine(64), 0);    // shadow
+		DrawMapEllipse(out, center + pentaOffset, AmLine(64), pentaColor);
+		DrawMapStar(out, center + pentaOffset, AmLine(64), pentaColor);
 	}
 
 	switch (tile.type) {

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1137,7 +1137,7 @@ void InitAutomapOnce()
 	AutoMapScale = 50;
 	int minimapWidth = gnScreenWidth / 4;
 	Size minimapSize { minimapWidth, minimapWidth / 2 };
-	int minimapPadding = 16;
+	int minimapPadding = 8;
 	AutomapMiniRect = Rectangle { { gnScreenWidth - minimapPadding - minimapSize.width, minimapPadding }, minimapSize };
 }
 
@@ -1160,6 +1160,7 @@ void StartAutomap()
 {
 	AutomapOffset = { 0, 0 };
 	AutomapActive = true;
+	AutomapTransparent = true;
 	AutoMapScale = 50;
 }
 
@@ -1167,6 +1168,7 @@ void StartMinimap()
 {
 	AutomapOffset = { 0, 0 };
 	AutomapMini = true;
+	AutomapTransparent = false;
 	if (gnScreenHeight >= 0 && gnScreenHeight < 960)
 		AutoMapScale = 25;
 	else if (gnScreenHeight >= 960 && gnScreenHeight < 1440)
@@ -1262,6 +1264,7 @@ void DrawAutomap(const Surface &out)
 			AutomapMiniRect.position.x + AutomapMiniRect.size.width / 2,
 			AutomapMiniRect.position.y + AutomapMiniRect.size.height / 2
 		};
+		DrawHalfTransparentRectTo(out, AutomapMiniRect.position.x, AutomapMiniRect.position.y, AutomapMiniRect.size.width, AutomapMiniRect.size.height);
 		DrawHorizontalLine(out, AutomapMiniRect.position + Displacement { -1, -1 }, AutomapMiniRect.size.width + 2, MapColorsDim);
 		DrawHorizontalLine(out, AutomapMiniRect.position + Displacement { -1, AutomapMiniRect.size.height }, AutomapMiniRect.size.width + 2, MapColorsDim);
 		DrawVerticalLine(out, AutomapMiniRect.position + Displacement { -1, 0 }, AutomapMiniRect.size.height, MapColorsDim);

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -30,6 +30,8 @@ enum MapExplorationType : uint8_t {
 
 /** Specifies whether the automap is enabled. */
 extern DVL_API_FOR_TEST bool AutomapActive;
+/** Specifies whether the automap is transparent. */
+extern DVL_API_FOR_TEST bool AutomapTransparent;
 /** Tracks the explored areas of the map. */
 extern uint8_t AutomapView[DMAXX][DMAXY];
 /** Specifies the scale of the automap. */
@@ -38,8 +40,8 @@ extern DVL_API_FOR_TEST Displacement AutomapOffset;
 
 inline int AmLine(int x)
 {
-	assert(x >= 4 && x <= 64);
-	assert((x & (x - 1)) == 0);
+	assert(x >= 2 && x <= 64);
+	//assert((x & (x - 1)) == 0);
 	return AutoMapScale * x / 100;
 }
 

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -30,6 +30,8 @@ enum MapExplorationType : uint8_t {
 
 /** Specifies whether the automap is enabled. */
 extern DVL_API_FOR_TEST bool AutomapActive;
+/** Specifies whether the automap is in minimap mode. */
+extern DVL_API_FOR_TEST bool AutomapMini;
 /** Specifies whether the automap is transparent. */
 extern DVL_API_FOR_TEST bool AutomapTransparent;
 /** Tracks the explored areas of the map. */
@@ -37,6 +39,7 @@ extern uint8_t AutomapView[DMAXX][DMAXY];
 /** Specifies the scale of the automap. */
 extern DVL_API_FOR_TEST int AutoMapScale;
 extern DVL_API_FOR_TEST Displacement AutomapOffset;
+extern Rectangle AutomapMiniRect;
 
 inline int AmLine(int x)
 {
@@ -59,6 +62,11 @@ void InitAutomap();
  * @brief Displays the automap.
  */
 void StartAutomap();
+
+/**
+ * @brief Displays the minimap.
+ */
+void StartMinimap();
 
 /**
  * @brief Scrolls the automap upwards.

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -993,11 +993,11 @@ void DoAutoMap()
 {
 	if (!AutomapActive) {
 		StartAutomap();
-	} else if (!AutomapTransparent) {
-		AutomapTransparent = true;
+	} else if (!AutomapMini) {
+		StartMinimap();
 	} else {
 		AutomapActive = false;
-		AutomapTransparent = false;
+		AutomapMini = false;
 	}
 }
 

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -991,10 +991,14 @@ void control_check_btn_press()
 
 void DoAutoMap()
 {
-	if (!AutomapActive)
+	if (!AutomapActive) {
 		StartAutomap();
-	else
+	} else if (!AutomapTransparent) {
+		AutomapTransparent = true;
+	} else {
 		AutomapActive = false;
+		AutomapTransparent = false;
+	}
 }
 
 void CheckPanelInfo()

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1760,7 +1760,6 @@ void InitKeymapActions()
 			    stream_stop();
 		    }
 		    AutomapActive = false;
-		    AutomapTransparent = false;
 		    CancelCurrentDiabloMsg();
 		    gamemenu_off();
 		    doom_close();
@@ -2229,7 +2228,6 @@ void InitPadmapActions()
 			    stream_stop();
 		    }
 		    AutomapActive = false;
-		    AutomapTransparent = false;
 		    CancelCurrentDiabloMsg();
 		    gamemenu_off();
 		    doom_close();

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1760,6 +1760,7 @@ void InitKeymapActions()
 			    stream_stop();
 		    }
 		    AutomapActive = false;
+		    AutomapTransparent = false;
 		    CancelCurrentDiabloMsg();
 		    gamemenu_off();
 		    doom_close();
@@ -2228,6 +2229,7 @@ void InitPadmapActions()
 			    stream_stop();
 		    }
 		    AutomapActive = false;
+		    AutomapTransparent = false;
 		    CancelCurrentDiabloMsg();
 		    gamemenu_off();
 		    doom_close();

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -163,6 +163,15 @@ void DrawHalfTransparentRectTo(const Surface &out, int sx, int sy, int width, in
 	DrawHalfTransparentBlendedRectTo(out, sx, sy, width, height);
 }
 
+void SetHalfTransparentPixel(const Surface &out, Point position, std::uint8_t col)
+{
+	if (out.InBounds(position)) {
+		uint8_t *pix = out.at(position.x, position.y);
+		const std::array<uint8_t, 256> &lookupTable = paletteTransparencyLookup[col];
+		*pix = lookupTable[*pix];
+	}
+}
+
 void UnsafeDrawBorder2px(const Surface &out, Rectangle rect, uint8_t color)
 {
 	const size_t width = rect.size.width;

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -117,6 +117,7 @@ void UnsafeDrawVerticalLine(const Surface &out, Point from, int height, std::uin
  * @param height Rectangle height
  */
 void DrawHalfTransparentRectTo(const Surface &out, int sx, int sy, int width, int height);
+void SetHalfTransparentPixel(const Surface &out, Point position, std::uint8_t col);
 
 /**
  * Draws a 2px inset border.

--- a/Source/engine/render/automap_render.cpp
+++ b/Source/engine/render/automap_render.cpp
@@ -4,6 +4,8 @@
  * Line drawing routines for the automap.
  */
 #include "engine/render/automap_render.hpp"
+#include "automap.h"
+#include "engine.h"
 
 #include <cstdint>
 
@@ -20,36 +22,72 @@ enum class DirectionY : int8_t {
 	NORTH = -1,
 };
 
+void SetMapPixel(const Surface &out, Point point, uint8_t color)
+{
+	if (!AutomapTransparent) {
+		out.SetPixel(point, color);
+	} else {
+		SetHalfTransparentPixel(out, point, color);
+	}
+}
+
 template <DirectionX DirX, DirectionY DirY>
 void DrawMapLine(const Surface &out, Point from, int height, std::uint8_t colorIndex)
 {
 	while (height-- > 0) {
-		out.SetPixel({ from.x, from.y + 1 }, 0);
-		out.SetPixel(from, colorIndex);
+		SetMapPixel(out, { from.x, from.y + 1 }, 0);
+		SetMapPixel(out, from, colorIndex);
 		from.x += static_cast<int>(DirX);
-		out.SetPixel({ from.x, from.y + 1 }, 0);
-		out.SetPixel(from, colorIndex);
+		SetMapPixel(out, { from.x, from.y + 1 }, 0);
+		SetMapPixel(out, from, colorIndex);
 		from.x += static_cast<int>(DirX);
 		from.y += static_cast<int>(DirY);
 	}
-	out.SetPixel({ from.x, from.y + 1 }, 0);
-	out.SetPixel(from, colorIndex);
+	SetMapPixel(out, { from.x, from.y + 1 }, 0);
+	SetMapPixel(out, from, colorIndex);
 }
 
 template <DirectionX DirX, DirectionY DirY>
 void DrawMapLineSteep(const Surface &out, Point from, int width, std::uint8_t colorIndex)
 {
 	while (width-- > 0) {
-		out.SetPixel({ from.x, from.y + 1 }, 0);
-		out.SetPixel(from, colorIndex);
+		SetMapPixel(out, { from.x, from.y + 1 }, 0);
+		SetMapPixel(out, from, colorIndex);
 		from.y += static_cast<int>(DirY);
-		out.SetPixel({ from.x, from.y + 1 }, 0);
-		out.SetPixel(from, colorIndex);
+		SetMapPixel(out, { from.x, from.y + 1 }, 0);
+		SetMapPixel(out, from, colorIndex);
 		from.y += static_cast<int>(DirY);
 		from.x += static_cast<int>(DirX);
 	}
-	out.SetPixel({ from.x, from.y + 1 }, 0);
-	out.SetPixel(from, colorIndex);
+	SetMapPixel(out, { from.x, from.y + 1 }, 0);
+	SetMapPixel(out, from, colorIndex);
+}
+
+void DrawMapFreeLine(const Surface &out, Point from, Point to, uint8_t colorIndex)
+{
+	int dx = std::abs(to.x - from.x);
+	int dy = std::abs(to.y - from.y);
+	int sx = from.x < to.x ? 1 : -1;
+	int sy = from.y < to.y ? 1 : -1;
+	int err = dx - dy;
+
+	while (true) {
+		SetMapPixel(out, from, colorIndex);
+
+		if (from.x == to.x && from.y == to.y) {
+			break;
+		}
+
+		int e2 = 2 * err;
+		if (e2 > -dy) {
+			err -= dy;
+			from.x += sx;
+		}
+		if (e2 < dx) {
+			err += dx;
+			from.y += sy;
+		}
+	}
 }
 
 } // namespace
@@ -92,6 +130,76 @@ void DrawMapLineSteepNW(const Surface &out, Point from, int width, std::uint8_t 
 void DrawMapLineSteepSW(const Surface &out, Point from, int width, std::uint8_t colorIndex)
 {
 	DrawMapLineSteep<DirectionX::WEST, DirectionY::SOUTH>(out, from, width, colorIndex);
+}
+
+void DrawMapEllipse(const Surface &out, Point from, int radius, uint8_t colorIndex)
+{
+	const int a = radius;
+	const int b = radius / 2;
+
+	int x = 0;
+	int y = b;
+
+	// Initial point
+	SetMapPixel(out, { from.x, from.y + b }, colorIndex);
+	SetMapPixel(out, { from.x, from.y - b }, colorIndex);
+
+	// Initialize the parameters
+	int p1 = (b * b) - (a * a * b) + (a * a) / 4;
+
+	// Region 1
+	while ((b * b * x) < (a * a * y)) {
+		x++;
+		if (p1 < 0) {
+			p1 += (2 * b * b * x) + (b * b);
+		} else {
+			y--;
+			p1 += (2 * b * b * x) - (2 * a * a * y) + (b * b);
+		}
+
+		SetMapPixel(out, { from.x + x, from.y + y }, colorIndex);
+		SetMapPixel(out, { from.x - x, from.y + y }, colorIndex);
+		SetMapPixel(out, { from.x + x, from.y - y }, colorIndex);
+		SetMapPixel(out, { from.x - x, from.y - y }, colorIndex);
+	}
+
+	// Initialize the second parameter for Region 2
+	int p2 = (b * b * ((x + 1) * (x + 1))) + (a * a * ((y - 1) * (y - 1))) - (a * a * b * b);
+
+	// Region 2
+	while (y > 0) {
+		y--;
+		if (p2 > 0) {
+			p2 += (-2 * a * a * y) + (a * a);
+		} else {
+			x++;
+			p2 += (2 * b * b * x) - (2 * a * a * y) + (a * a);
+		}
+
+		SetMapPixel(out, { from.x + x, from.y + y }, colorIndex);
+		SetMapPixel(out, { from.x - x, from.y + y }, colorIndex);
+		SetMapPixel(out, { from.x + x, from.y - y }, colorIndex);
+		SetMapPixel(out, { from.x - x, from.y - y }, colorIndex);
+	}
+}
+
+void DrawMapStar(const Surface &out, Point center, int radius, uint8_t color)
+{
+	const int scaleFactor = 128;
+	Point anchors[5];
+
+	anchors[0] = { center.x - (121 * radius / scaleFactor), center.y + (19 * radius / scaleFactor) }; // Left Point
+	anchors[1] = { center.x + (121 * radius / scaleFactor), center.y + (19 * radius / scaleFactor) }; // Right Point
+	anchors[2] = { center.x, center.y + (64 * radius / scaleFactor) };                                // Bottom Point
+	anchors[3] = { center.x - (75 * radius / scaleFactor), center.y - (51 * radius / scaleFactor) };  // Top Left Point
+	anchors[4] = { center.x + (75 * radius / scaleFactor), center.y - (51 * radius / scaleFactor) };  // Top Right Point
+
+	// Draw lines between the anchors to form a star
+	DrawMapFreeLine(out, anchors[3], anchors[1], color); // Connect Top Left -> Right
+	DrawMapFreeLine(out, anchors[1], anchors[0], color); // Connect Right -> Left
+	DrawMapFreeLine(out, anchors[0], anchors[4], color); // Connect Left -> Top Right
+	DrawMapFreeLine(out, anchors[4], anchors[2], color); // Connect Top Right -> Bottom
+	DrawMapFreeLine(out, anchors[2], anchors[3], color); // Connect Bottom -> Top Left
 }
 
 } // namespace devilution

--- a/Source/engine/render/automap_render.cpp
+++ b/Source/engine/render/automap_render.cpp
@@ -22,15 +22,6 @@ enum class DirectionY : int8_t {
 	NORTH = -1,
 };
 
-void SetMapPixel(const Surface &out, Point point, uint8_t color)
-{
-	if (!AutomapTransparent) {
-		out.SetPixel(point, color);
-	} else {
-		SetHalfTransparentPixel(out, point, color);
-	}
-}
-
 template <DirectionX DirX, DirectionY DirY>
 void DrawMapLine(const Surface &out, Point from, int height, std::uint8_t colorIndex)
 {
@@ -92,6 +83,17 @@ void DrawMapFreeLine(const Surface &out, Point from, Point to, uint8_t colorInde
 
 } // namespace
 
+void SetMapPixel(const Surface &out, Point point, uint8_t color)
+{
+	if (AutomapMini && !AutomapMiniRect.contains(point))
+		return;
+	if (!AutomapTransparent) {
+		out.SetPixel(point, color);
+	} else {
+		SetHalfTransparentPixel(out, point, color);
+	}
+}
+
 void DrawMapLineNE(const Surface &out, Point from, int height, std::uint8_t colorIndex)
 {
 	DrawMapLine<DirectionX::EAST, DirectionY::NORTH>(out, from, height, colorIndex);
@@ -134,6 +136,8 @@ void DrawMapLineSteepSW(const Surface &out, Point from, int width, std::uint8_t 
 
 void DrawMapEllipse(const Surface &out, Point from, int radius, uint8_t colorIndex)
 {
+	from.y -= AmLine(8);
+
 	const int a = radius;
 	const int b = radius / 2;
 
@@ -183,16 +187,18 @@ void DrawMapEllipse(const Surface &out, Point from, int radius, uint8_t colorInd
 	}
 }
 
-void DrawMapStar(const Surface &out, Point center, int radius, uint8_t color)
+void DrawMapStar(const Surface &out, Point from, int radius, uint8_t color)
 {
+	from.y -= AmLine(8);
+
 	const int scaleFactor = 128;
 	Point anchors[5];
 
-	anchors[0] = { center.x - (121 * radius / scaleFactor), center.y + (19 * radius / scaleFactor) }; // Left Point
-	anchors[1] = { center.x + (121 * radius / scaleFactor), center.y + (19 * radius / scaleFactor) }; // Right Point
-	anchors[2] = { center.x, center.y + (64 * radius / scaleFactor) };                                // Bottom Point
-	anchors[3] = { center.x - (75 * radius / scaleFactor), center.y - (51 * radius / scaleFactor) };  // Top Left Point
-	anchors[4] = { center.x + (75 * radius / scaleFactor), center.y - (51 * radius / scaleFactor) };  // Top Right Point
+	anchors[0] = { from.x - (121 * radius / scaleFactor), from.y + (19 * radius / scaleFactor) }; // Left Point
+	anchors[1] = { from.x + (121 * radius / scaleFactor), from.y + (19 * radius / scaleFactor) }; // Right Point
+	anchors[2] = { from.x, from.y + (64 * radius / scaleFactor) };                                // Bottom Point
+	anchors[3] = { from.x - (75 * radius / scaleFactor), from.y - (51 * radius / scaleFactor) };  // Top Left Point
+	anchors[4] = { from.x + (75 * radius / scaleFactor), from.y - (51 * radius / scaleFactor) };  // Top Right Point
 
 	// Draw lines between the anchors to form a star
 	DrawMapFreeLine(out, anchors[3], anchors[1], color); // Connect Top Left -> Right

--- a/Source/engine/render/automap_render.hpp
+++ b/Source/engine/render/automap_render.hpp
@@ -88,5 +88,7 @@ void DrawMapLineSteepNW(const Surface &out, Point from, int width, std::uint8_t 
  * The end point is at `{ from.x - (width + 1), from.y + 2 * width }`.
  */
 void DrawMapLineSteepSW(const Surface &out, Point from, int width, std::uint8_t colorIndex);
+void DrawMapEllipse(const Surface &out, Point from, int radius, uint8_t colorIndex);
+void DrawMapStar(const Surface &out, Point from, int radius, uint8_t colorIndex);
 
 } // namespace devilution

--- a/Source/engine/render/automap_render.hpp
+++ b/Source/engine/render/automap_render.hpp
@@ -17,6 +17,7 @@
 
 namespace devilution {
 
+void SetMapPixel(const Surface &out, Point point, uint8_t color);
 /**
  * @brief Draw a line in the target buffer from the given point towards north east at an `atan(1/2)` angle.
  *


### PR DESCRIPTION
Adds the following to the automap:
* Important Objects
    - Orange
    - Diamond shape
    - Only in explored area
* Town Portal
    - Blue
    - Cross shape
    - Shows even in unexplored area
* Red Portal
    - Red
    - Cross shape
    - Only in explored area
* Towners
    - White
    - Arrow (red X when dead - ala Slain Townsman)
* Golems
    - Gray
    - Arrow
    - Shows even in unexplored area
* Berserked Monsters
    - Yellow
    - Arrow
    - Shows even in unexplored area
 * Players
     - Arrow (Red X when dead)

Showcasing objects and portal on the automap:

https://github.com/diasurgical/devilutionX/assets/68359262/f7009ad0-8c6e-49ca-ac87-52b8e4567cec

Towners on automap:
![image](https://github.com/diasurgical/devilutionX/assets/68359262/1a0b5a2f-091e-4dca-a15b-9d7afd0c0fa9)

Dead players turning red on automap:

https://github.com/diasurgical/devilutionX/assets/68359262/a57d1720-b23d-40e4-9af0-c01670fc0ad0

Golem on automap:

https://github.com/diasurgical/devilutionX/assets/68359262/7c1a3afc-d44b-49a7-80dc-e57173319162

Pentagram:

![image](https://github.com/diasurgical/devilutionX/assets/68359262/9cb1239e-cec5-4c41-8a40-45ea86dd6287)

Transparency:




https://github.com/diasurgical/devilutionX/assets/68359262/99f3d2c1-e22a-41b9-b188-161449e39449






Fixes https://github.com/diasurgical/devilutionX/issues/6515

