### PR TITLE
Clean up hit detection for inventory slots when pasting large items

### DIFF
--- a/Source/inv.h
+++ b/Source/inv.h
@@ -17,7 +17,8 @@ namespace devilution {
 
 #define INV_SLOT_SIZE_PX 28
 #define INV_SLOT_HALF_SIZE_PX (INV_SLOT_SIZE_PX / 2)
-#define INV_ROW_SLOT_SIZE 10
+constexpr Size InventorySizeInSlots { 10, 4 };
+#define INV_ROW_SLOT_SIZE InventorySizeInSlots.width
 constexpr Size InventorySlotSizeInPixels { INV_SLOT_SIZE_PX };
 
 enum inv_item : int8_t {
@@ -43,12 +44,14 @@ enum inv_item : int8_t {
 enum inv_xy_slot : uint8_t {
 	// clang-format off
 	SLOTXY_HEAD           = 0,
+	SLOTXY_EQUIPPED_FIRST = SLOTXY_HEAD,
 	SLOTXY_RING_LEFT      = 1,
 	SLOTXY_RING_RIGHT     = 2,
 	SLOTXY_AMULET         = 3,
 	SLOTXY_HAND_LEFT      = 4,
 	SLOTXY_HAND_RIGHT     = 5,
 	SLOTXY_CHEST          = 6,
+	SLOTXY_EQUIPPED_LAST  = SLOTXY_CHEST,
 
 	// regular inventory
 	SLOTXY_INV_FIRST      = 7,
@@ -79,7 +82,7 @@ enum item_color : uint8_t {
 };
 
 extern bool invflag;
-extern const Rectangle InvRect[73];
+extern const Rectangle InvRect[NUM_XY_SLOTS];
 
 void InvDrawSlotBack(const Surface &out, Point targetPosition, Size size, item_quality itemQuality);
 /**


### PR DESCRIPTION
In vanilla Diablo/Hellfire the hit detection for pasting an item into an inventory cell has a couple of flaws.

* Pasting an item taller than one cell into the first row works as expected as the code adjusts the target slot to prevent underflow, but when trying to paste in the last row it just returns early instead of attempting to prevent overflow.
* Pasting an item with an even dimension (2 cells wide and/or 2 cells high) also shifted the hot pixel before testing if it overlaps an inventory cell which made for odd behaviour when pasting these items in the first or last column/row of the inventory.

This PR changes the hit detection logic to determine if the hot pixel is in the inventory first, then adjust the target slot to the top left cell of the item while also clamping to the acceptable range given the item size.

Old behaviour:
https://github.com/diasurgical/devilutionX/assets/357684/a5fb1ca4-293e-4e49-b7a8-ad905cd37679

New behaviour:
https://github.com/diasurgical/devilutionX/assets/357684/e2baea37-13c2-4bc5-84e0-263f75b5c184