### PR TITLE
LoggedFread: Do not log EOF as an error

### DIFF
--- a/Source/utils/endian_stream.hpp
+++ b/Source/utils/endian_stream.hpp
@@ -13,7 +13,7 @@ namespace devilution {
 
 inline void LoggedFread(void *buffer, size_t size, FILE *stream)
 {
-	if (std::fread(buffer, size, 1, stream) != 1) {
+	if (std::fread(buffer, size, 1, stream) != 1 && !std::feof(stream)) {
 		LogError("fread failed: {}", std::strerror(errno));
 	}
 }


### PR DESCRIPTION
Usually we call fread in a loop until reaching EOF. Reaching EOF is not an error, so we should not log it as such.

The error message was previously seen when loading demo files.