### PR TITLE
Upgrade vcpkg baseline commit

### DIFF
--- a/.github/workflows/Windows_MSVC_x64.yml
+++ b/.github/workflows/Windows_MSVC_x64.yml
@@ -31,9 +31,9 @@ jobs:
       uses: lukka/get-cmake@latest
 
     - name: Restore or setup vcpkg
-      uses: lukka/run-vcpkg@v11
+      uses: lukka/run-vcpkg@v11.1
       with:
-        vcpkgGitCommitId: '78b61582c9e093fda56a01ebb654be15a0033897'
+        vcpkgGitCommitId: '927bc12e31148b0d44ae9d174b96c20e3bcf08eb'
 
     - name: Fetch test data
       run: |

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
         "bzip2",
         "simpleini"
     ],
-    "builtin-baseline": "78b61582c9e093fda56a01ebb654be15a0033897",
+    "builtin-baseline": "927bc12e31148b0d44ae9d174b96c20e3bcf08eb",
     "features": {
         "sdl1": {
             "description": "Use SDL1.2 instead of SDL2",


### PR DESCRIPTION
The main purpose of this is for MSVC builds to use SDL2 v2.28.2 (from v2.26.5) and fmt v10.1.0 (from v10.0.0) which the project uses already in source-download builds
vcpkg didn't update from 2.26.5 to 2.28 until yesterday (2023-08-28), even though I filed a port update request in July and two bugfix releases happened before the upgrade: https://github.com/microsoft/vcpkg/issues/32186

IMO, this is good to merge into `master` for 1.5.1, but I can retarget to `development` if needed