### PR TITLE
Align cursor a bit better in the stash when using gamepad movement

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1167,9 +1167,9 @@ void StashMove(AxisDirection dir)
 
 	if (ActiveStashSlot != InvalidStashPoint) {
 		Point mousePos = GetStashSlotCoord(ActiveStashSlot);
-		if (pcurs == CURSOR_HAND) {
-			mousePos += Displacement { INV_SLOT_HALF_SIZE_PX, INV_SLOT_HALF_SIZE_PX };
-		}
+		// Stash coordinates are all the top left of the cell, so we need to shift the mouse to the center of the held item
+		// or the center of the cell if we have a hand cursor (itemSize will be 1x1 here so we can use the same calculation)
+		mousePos += Displacement { itemSize.width * INV_SLOT_HALF_SIZE_PX, itemSize.height * INV_SLOT_HALF_SIZE_PX };
 		SetCursorPos(mousePos);
 		return;
 	}

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -158,8 +158,9 @@ void CheckStashPaste(Point cursorPosition)
 		// stashList will have at most 10 000 items, up to 65 535 are supported with uint16_t indexes
 		stashIndex = static_cast<uint16_t>(Stash.stashList.size() - 1);
 	} else {
-		// remove item from stash grid
+		// swap the held item and whatever was in the stash at this position
 		std::swap(Stash.stashList[stashIndex], player.HoldItem);
+		// then clear the space occupied by the old item
 		for (auto &row : Stash.GetCurrentGrid()) {
 			for (auto &itemId : row) {
 				if (itemId - 1 == stashIndex)
@@ -168,6 +169,7 @@ void CheckStashPaste(Point cursorPosition)
 		}
 	}
 
+	// Finally mark the area now occupied by the pasted item in the current page/grid.
 	AddItemToStashGrid(Stash.GetPage(), firstSlot, stashIndex, itemSize);
 
 	Stash.dirty = true;


### PR DESCRIPTION
This keeps the current stash behaviour (where movement is always cell based, even when empty handed) with one change that I thought looked a little better visually. When pasting an item into empty space the hand cursor is now aligned with the centre of the bottom right cell of the item, not the top left. This was because I didn't like the way the hand cursor overlapped 2x2 and 2x3 items if it was left as is.

I'll open a separate PR to make the stash movement behave like the inventory movement (where you skip over large items in a single direction press and you only navigate from the stash to the relevant body slot depending on the held item) which will remove the special case for an empty held item following a stash primary action.

Part of #6532