### PR TITLE
RG99: Run from disk rather than from /opk squashfs

### DIFF
--- a/Packaging/OpenDingux/build.sh
+++ b/Packaging/OpenDingux/build.sh
@@ -105,6 +105,13 @@ parse_args() {
 		>&2 echo "Error: at most one of --profile-use and --profile-generate is allowed"
 		exit 64
 	fi
+	if [[ $TARGET = rg99 ]]; then
+		OPK_EXTRA_FILES+=(
+			Packaging/OpenDingux/devilutionx-from-disk.sh
+			Packaging/OpenDingux/devilutionx-umount-opk-and-run.sh
+		)
+		OPK_DESKTOP_EXEC="devilutionx-from-disk.sh"
+	fi
 	if (( PROFILE_GENERATE )); then
 		CMAKE_CONFIGURE_OPTS+=(
 			"-DDEVILUTIONX_PROFILE_GENERATE=ON"
@@ -112,7 +119,7 @@ parse_args() {
 		)
 		OPK_DESKTOP_NAME="DevilutionX PG"
 		OPK_DESKTOP_EXEC="profile-generate.sh"
-		OPK_EXTRA_FILES=(
+		OPK_EXTRA_FILES+=(
 			Packaging/OpenDingux/profile-generate.sh
 			test/fixtures/timedemo/WarriorLevel1to2/demo_0.dmo
 		)

--- a/Packaging/OpenDingux/devilutionx-from-disk.sh
+++ b/Packaging/OpenDingux/devilutionx-from-disk.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Unpacks the mounted OPK to disk before running it
+# in order to avoid the memory overhead of squashfs.
+
+OPK_DIR="${PWD}"
+STORAGE="$(grep mmcblk /proc/mounts | cut -d' ' -f2 || echo /media/data/local/home)"
+UNPACK_DIR="${STORAGE}/devilutionx-opk-on-disk"
+
+set -e
+set -x
+
+DO_COPY=1
+if [ -f "${UNPACK_DIR}/devilutionx" ]; then
+	INSTALLED_MD5="$(md5sum "${UNPACK_DIR}/devilutionx" | cut -d' ' -f1)"
+	OPK_MD5="$(md5sum "${PWD}/devilutionx" | cut -d' ' -f1)"
+	if [ "$INSTALLED_MD5" = "$OPK_MD5" ]; then
+		DO_COPY=0
+	fi
+fi
+
+if [ "$DO_COPY" = "1" ]; then
+	rm -rf "$UNPACK_DIR"
+	mkdir -p "$UNPACK_DIR"
+	cp -rf "$OPK_DIR"/* "$UNPACK_DIR"
+fi
+
+exec "${UNPACK_DIR}/devilutionx-umount-opk-and-run.sh" "${UNPACK_DIR}/devilutionx" "$@"

--- a/Packaging/OpenDingux/devilutionx-umount-opk-and-run.sh
+++ b/Packaging/OpenDingux/devilutionx-umount-opk-and-run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -x
+echo | sudo -S umount -l "$PWD"
+exec "$@"

--- a/Packaging/OpenDingux/profile-generate.sh
+++ b/Packaging/OpenDingux/profile-generate.sh
@@ -3,10 +3,10 @@
 set -x
 
 SAVE_DIR="$(mktemp -d)"
-ln -s "${PWD}/demo_0_reference_spawn_0_sv" "${SAVE_DIR}/"
-ln -s "${PWD}/demo_0.dmo" "${SAVE_DIR}/"
+cp "${PWD}/demo_0_reference_spawn_0_sv" "${SAVE_DIR}/"
+cp "${PWD}/demo_0.dmo" "${SAVE_DIR}/"
 cp -r "${PWD}/spawn_0_sv" "${SAVE_DIR}/"
 rm -rf "${HOME}/devilutionx-profile"
 mkdir -p "${HOME}/devilutionx-profile"
-./devilutionx --diablo --spawn --demo 0 --timedemo --save-dir "$SAVE_DIR" --data-dir ~/.local/share/diasurgical/devilution
+./devilutionx-from-disk.sh --diablo --spawn --demo 0 --timedemo --save-dir "$SAVE_DIR" --data-dir ~/.local/share/diasurgical/devilution
 rm -rf "$SAVE_DIR"


### PR DESCRIPTION
Turns out the squashfs mount has some non-trivial RAM overhead.

Copy the game to local storage and run from there to avoid the overhead. This completely eliminates long 0 FPS periods when running the demo for PGO.

It may be possible to reduce the overhead by setting CONFIG_SQUASHFS_FRAGMENT_CACHE_SIZE kernel setting to 1.