### PR TITLE
Refactor Automap

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -303,10 +303,8 @@ void DrawDirt(const Surface &out, Point center, AutomapTile nwTile, AutomapTile 
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
 	// Prevent the top dirt pixel from appearing inside arch diamonds
-	if (!nwTile.HasFlag(AutomapTile::Flags::HorizontalArch)
-	    && !nwTile.HasFlag(AutomapTile::Flags::HorizontalGrate)
-	    && !neTile.HasFlag(AutomapTile::Flags::VerticalArch)
-	    && !neTile.HasFlag(AutomapTile::Flags::VerticalGrate))
+	if (!nwTile.hasAnyFlag(AutomapTile::Flags::HorizontalArch, AutomapTile::Flags::HorizontalGrate)
+	    && !neTile.hasAnyFlag(AutomapTile::Flags::VerticalArch, AutomapTile::Flags::VerticalGrate))
 		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
 	out.SetPixel(center, color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
@@ -658,14 +656,9 @@ void DrawHorizontal(const Surface &out, Point center, AutomapTile tile, AutomapT
 	AmLineLength l = AmLineLength::FullAndHalfTile;
 
 	// Draw a diamond in the top tile
-	if (neTile.HasFlag(AutomapTile::Flags::VerticalArch)         // NE tile has an arch, so add a diamond for visual consistency
-	    || neTile.HasFlag(AutomapTile::Flags::VerticalGrate)     // NE tile has a grate, so add a diamond for visual consistency
-	    || nwTile.HasFlag(AutomapTile::Flags::HorizontalArch)    // NW tile has an arch, so add a diamond for visual consistency
-	    || nwTile.HasFlag(AutomapTile::Flags::HorizontalGrate)   // NW tile has a grate, so add a diamond for visual consistency
-	    || tile.HasFlag(AutomapTile::Flags::VerticalArch)        // Current tile has an arch, add a diamond
-	    || tile.HasFlag(AutomapTile::Flags::HorizontalArch)      // Current tile has an arch, add a diamond
-	    || tile.HasFlag(AutomapTile::Flags::VerticalGrate)       // Current tile has an grate, add a diamond
-	    || tile.HasFlag(AutomapTile::Flags::HorizontalGrate)     // Current tile has an grate, add a diamond
+	if (neTile.hasAnyFlag(AutomapTile::Flags::VerticalArch, AutomapTile::Flags::VerticalGrate) // NE tile has an arch, so add a diamond for visual consistency
+	    || nwTile.hasAnyFlag(AutomapTile::Flags::HorizontalArch, AutomapTile::Flags::HorizontalGrate) // NW tile has an arch, so add a diamond for visual consistency
+	    || tile.hasAnyFlag(AutomapTile::Flags::VerticalArch, AutomapTile::Flags::HorizontalArch, AutomapTile::Flags::VerticalGrate, AutomapTile::Flags::HorizontalGrate) // Current tile has an arch, add a diamond
 	    || tile.type == AutomapTile::Types::HorizontalDiamond) { // wall ending in hell that should end with a diamond
 		w = AmWidthOffset::QuarterTileRight;
 		h = AmHeightOffset::QuarterTileUp;
@@ -702,14 +695,9 @@ void DrawVertical(const Surface &out, Point center, AutomapTile tile, AutomapTil
 	AmLineLength l = AmLineLength::FullAndHalfTile;
 
 	// Draw a diamond in the top tile
-	if (neTile.HasFlag(AutomapTile::Flags::VerticalArch)       // NE tile has an arch, so add a diamond for visual consistency
-	    || neTile.HasFlag(AutomapTile::Flags::VerticalGrate)   // NE tile has a grate, so add a diamond for visual consistency
-	    || nwTile.HasFlag(AutomapTile::Flags::HorizontalArch)  // NW tile has an arch, so add a diamond for visual consistency
-	    || nwTile.HasFlag(AutomapTile::Flags::HorizontalGrate) // NW tile has a grate, so add a diamond for visual consistency
-	    || tile.HasFlag(AutomapTile::Flags::VerticalArch)      // Current tile has an arch, add a diamond
-	    || tile.HasFlag(AutomapTile::Flags::HorizontalArch)    // Current tile has an arch, add a diamond
-	    || tile.HasFlag(AutomapTile::Flags::VerticalGrate)     // Current tile has an grate, add a diamond
-	    || tile.HasFlag(AutomapTile::Flags::HorizontalGrate)   // Current tile has an grate, add a diamond
+	if (neTile.hasAnyFlag(AutomapTile::Flags::VerticalArch, AutomapTile::Flags::VerticalGrate) // NE tile has an arch, so add a diamond for visual consistency
+	    || nwTile.hasAnyFlag(AutomapTile::Flags::HorizontalArch, AutomapTile::Flags::HorizontalGrate) // NW tile has an arch, so add a diamond for visual consistency
+	    || tile.hasAnyFlag(AutomapTile::Flags::VerticalArch, AutomapTile::Flags::HorizontalArch, AutomapTile::Flags::VerticalGrate, AutomapTile::Flags::HorizontalGrate) // Current tile has an arch, add a diamond
 	    || tile.type == AutomapTile::Types::VerticalDiamond) { // wall ending in hell that should end with a diamond
 		l = AmLineLength::FullTile;                            // shorten line to avoid overdraw
 		DrawDiamond(out, center, colorDim);

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -572,9 +572,16 @@ void DrawStairs(const Surface &out, Point center, uint8_t color)
 {
 	constexpr int NumStairSteps = 4;
 	const Displacement offset = AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown);
+	AmWidthOffset w = AmWidthOffset::QuarterTileLeft;
+	AmHeightOffset h = AmHeightOffset::QuarterTileUp;
+
+	if (IsAnyOf(leveltype, DTYPE_CATACOMBS, DTYPE_HELL)) {
+		w = AmWidthOffset::QuarterTileLeft;
+		h = AmHeightOffset::ThreeQuartersTileUp;
+	}
 
 	// Initial point based on the 'center' position.
-	Point p = center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileUp);
+	Point p = center + AmOffset(w, h);
 
 	for (int i = 0; i < NumStairSteps; ++i) {
 		DrawMapLineSE(out, p, AmLine(AmLineLength::DoubleTile), color);

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -41,12 +41,6 @@ enum MapColors : uint8_t {
 	MapColorsDim = (PAL16_YELLOW + 8),
 	/** color for items on automap */
 	MapColorsItem = (PAL8_BLUE + 1),
-	/** color for cave lava on automap */
-	MapColorsLava = (PAL8_ORANGE + 2),
-	/** color for cave water on automap */
-	MapColorsWater = (PAL8_BLUE + 2),
-	/** color for hive acid on automap */
-	MapColorsAcid = (PAL8_YELLOW + 4),
 };
 
 struct AutomapTile {
@@ -87,27 +81,27 @@ struct AutomapTile {
 		CaveWoodCross,
 		CaveRightWoodCross,
 		CaveLeftWoodCross,
-		HorizontalLavaThin,
-		VerticalLavaThin,
-		BendSouthLavaThin,
-		BendWestLavaThin,
-		BendEastLavaThin,
-		BendNorthLavaThin,
+		HorizontalLavaThin, // unused
+		VerticalLavaThin,   // unused
+		BendSouthLavaThin,  // unused
+		BendWestLavaThin,   // unused
+		BendEastLavaThin,   // unused
+		BendNorthLavaThin,  // unused
 		VerticalWallLava,
 		HorizontalWallLava,
-		SELava,
-		SWLava,
-		NELava,
-		NWLava,
-		SLava,
-		WLava,
-		ELava,
-		NLava,
-		Lava,
+		SELava, // unused
+		SWLava, // unused
+		NELava, // unused
+		NWLava, // unused
+		SLava,  // unused
+		WLava,  // unused
+		ELava,  // unused
+		NLava,  // unused
+		Lava,   // unused
 		CaveHorizontalWallLava,
 		CaveVerticalWallLava,
-		HorizontalBridgeLava,
-		VerticalBridgeLava,
+		HorizontalBridgeLava, // unused
+		VerticalBridgeLava,   // unused
 		VerticalDiamond,
 		HorizontalDiamond,
 	};
@@ -461,99 +455,6 @@ void DrawRiverForkOut(const Surface &out, Point center, uint8_t color)
 	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
 
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
-}
-
-template <Direction TDir1, Direction TDir2>
-void DrawLavaRiver(const Surface &out, Point center, uint8_t color, bool hasBridge)
-{
-	// First row (y = 0)
-	if constexpr (IsAnyOf(TDir1, Direction::NorthWest) || IsAnyOf(TDir2, Direction::NorthWest)) {
-		if (!(hasBridge && IsAnyOf(TDir1, Direction::NorthWest))) {
-			out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
-			out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
-		}
-	}
-
-	// Second row (y = 1)
-	if constexpr (IsAnyOf(TDir1, Direction::NorthEast) || IsAnyOf(TDir2, Direction::NorthEast)) {
-		if (!(hasBridge && (IsAnyOf(TDir1, Direction::NorthEast) || IsAnyOf(TDir2, Direction::NorthEast))))
-			out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
-	}
-	if constexpr (IsAnyOf(TDir1, Direction::NorthWest, Direction::NorthEast) || IsAnyOf(TDir2, Direction::NorthWest, Direction::NorthEast)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
-	}
-	if constexpr (IsAnyOf(TDir1, Direction::SouthWest, Direction::NorthWest) || IsAnyOf(TDir2, Direction::SouthWest, Direction::NorthWest)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
-	}
-	if constexpr (IsAnyOf(TDir1, Direction::SouthWest) || IsAnyOf(TDir2, Direction::SouthWest)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
-	}
-
-	// Third row (y = 2)
-	if constexpr (IsAnyOf(TDir1, Direction::NorthEast) || IsAnyOf(TDir2, Direction::NorthEast)) {
-		if (!(hasBridge && (IsAnyOf(TDir1, Direction::NorthEast) || IsAnyOf(TDir2, Direction::NorthEast))))
-			out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
-	}
-	if constexpr (IsAnyOf(TDir1, Direction::NorthEast, Direction::SouthEast) || IsAnyOf(TDir2, Direction::NorthEast, Direction::SouthEast)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
-	}
-	if constexpr (IsAnyOf(TDir1, Direction::SouthWest, Direction::SouthEast) || IsAnyOf(TDir2, Direction::SouthWest, Direction::SouthEast)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
-	}
-	if constexpr (IsAnyOf(TDir1, Direction::SouthWest) || IsAnyOf(TDir2, Direction::SouthWest)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
-	}
-
-	// Fourth row (y = 3)
-	if constexpr (IsAnyOf(TDir1, Direction::SouthEast) || IsAnyOf(TDir2, Direction::SouthEast)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
-	}
-}
-
-template <Direction TDir>
-void DrawLava(const Surface &out, Point center, uint8_t color)
-{
-	if constexpr (IsAnyOf(TDir, Direction::NorthWest, Direction::North, Direction::NorthEast, Direction::NoDirection)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color); // north corner
-	}
-	if constexpr (IsAnyOf(TDir, Direction::SouthWest, Direction::West, Direction::NorthWest, Direction::North, Direction::NorthEast, Direction::NoDirection)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color); // northwest edge
-		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);             // northwest edge
-	}
-	if constexpr (IsAnyOf(TDir, Direction::SouthWest, Direction::West, Direction::NorthWest, Direction::NoDirection)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color); // west corner
-	}
-	if constexpr (IsAnyOf(TDir, Direction::South, Direction::SouthWest, Direction::West, Direction::NorthWest, Direction::SouthEast, Direction::NoDirection)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);             // southwest edge
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color); // southwest edge
-	}
-	if constexpr (IsAnyOf(TDir, Direction::South, Direction::SouthWest, Direction::SouthEast, Direction::NoDirection)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color); // south corner
-	}
-	if constexpr (IsAnyOf(TDir, Direction::South, Direction::SouthWest, Direction::NorthEast, Direction::East, Direction::SouthEast, Direction::NoDirection)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);             // southeast edge
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color); // southeast edge
-	}
-	if constexpr (IsAnyOf(TDir, Direction::NorthEast, Direction::East, Direction::SouthEast, Direction::NoDirection)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color); // east corner
-	}
-	if constexpr (IsAnyOf(TDir, Direction::NorthWest, Direction::North, Direction::NorthEast, Direction::East, Direction::SouthEast, Direction::NoDirection)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color); // northeast edge
-		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);             // northeast edge
-	}
-	if constexpr (IsNoneOf(TDir, Direction::South)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color); // north center
-	}
-	if constexpr (IsNoneOf(TDir, Direction::East)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color); // west center
-	}
-	if constexpr (IsNoneOf(TDir, Direction::West)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color); // east center
-	}
-	if constexpr (IsNoneOf(TDir, Direction::North)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color); // south center
-	}
 }
 
 /**
@@ -925,17 +826,6 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 		DrawWallConnections(out, center, nwTile, neTile, colorBright, colorDim);
 	}
 
-	uint8_t lavaColor = MapColorsLava;
-	if (leveltype == DTYPE_NEST) {
-		lavaColor = MapColorsAcid;
-	} else if (setlevel && setlvlnum == Quests[Q_PWATER]._qslvl) {
-		if (Quests[Q_PWATER]._qactive != QUEST_DONE) {
-			lavaColor = MapColorsAcid;
-		} else {
-			lavaColor = MapColorsWater;
-		}
-	}
-
 	switch (tile.type) {
 	case AutomapTile::Types::Diamond: // stand-alone column or other unpassable object
 		DrawDiamond(out, center, colorDim);
@@ -1034,71 +924,28 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 		DrawRiverRightOut(out, center, MapColorsItem);
 		break;
 	case AutomapTile::Types::HorizontalLavaThin:
-		DrawLavaRiver<Direction::NorthWest, Direction::SouthEast>(out, center, lavaColor, false);
 		break;
 	case AutomapTile::Types::VerticalLavaThin:
-		DrawLavaRiver<Direction::NorthEast, Direction::SouthWest>(out, center, lavaColor, false);
 		break;
 	case AutomapTile::Types::BendSouthLavaThin:
-		DrawLavaRiver<Direction::SouthWest, Direction::SouthEast>(out, center, lavaColor, false);
 		break;
 	case AutomapTile::Types::BendWestLavaThin:
-		DrawLavaRiver<Direction::NorthWest, Direction::SouthWest>(out, center, lavaColor, false);
 		break;
 	case AutomapTile::Types::BendEastLavaThin:
-		DrawLavaRiver<Direction::NorthEast, Direction::SouthEast>(out, center, lavaColor, false);
 		break;
 	case AutomapTile::Types::BendNorthLavaThin:
-		DrawLavaRiver<Direction::NorthWest, Direction::NorthEast>(out, center, lavaColor, false);
 		break;
 	case AutomapTile::Types::VerticalWallLava:
 		DrawVertical(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim);
-		DrawLavaRiver<Direction::SouthEast, Direction::NoDirection>(out, center, lavaColor, false);
 		break;
 	case AutomapTile::Types::HorizontalWallLava:
 		DrawHorizontal(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim);
-		DrawLavaRiver<Direction::SouthWest, Direction::NoDirection>(out, center, lavaColor, false);
-		break;
-	case AutomapTile::Types::SELava:
-		DrawLava<Direction::SouthEast>(out, center, lavaColor);
-		break;
-	case AutomapTile::Types::SWLava:
-		DrawLava<Direction::SouthWest>(out, center, lavaColor);
-		break;
-	case AutomapTile::Types::NELava:
-		DrawLava<Direction::NorthEast>(out, center, lavaColor);
-		break;
-	case AutomapTile::Types::NWLava:
-		DrawLava<Direction::NorthWest>(out, center, lavaColor);
-		break;
-	case AutomapTile::Types::SLava:
-		DrawLava<Direction::South>(out, center, lavaColor);
-		break;
-	case AutomapTile::Types::WLava:
-		DrawLava<Direction::West>(out, center, lavaColor);
-		break;
-	case AutomapTile::Types::ELava:
-		DrawLava<Direction::East>(out, center, lavaColor);
-		break;
-	case AutomapTile::Types::NLava:
-		DrawLava<Direction::North>(out, center, lavaColor);
-		break;
-	case AutomapTile::Types::Lava:
-		DrawLava<Direction::NoDirection>(out, center, lavaColor);
 		break;
 	case AutomapTile::Types::CaveHorizontalWallLava:
 		DrawCaveHorizontal(out, center, tile, nwTile, swTile, colorBright, colorDim);
-		DrawLavaRiver<Direction::NorthEast, Direction::NoDirection>(out, center, lavaColor, false);
 		break;
 	case AutomapTile::Types::CaveVerticalWallLava:
 		DrawCaveVertical(out, center, tile, neTile, seTile, colorBright, colorDim);
-		DrawLavaRiver<Direction::NorthWest, Direction::NoDirection>(out, center, lavaColor, false);
-		break;
-	case AutomapTile::Types::HorizontalBridgeLava:
-		DrawLavaRiver<Direction::NorthWest, Direction::SouthEast>(out, center, lavaColor, true);
-		break;
-	case AutomapTile::Types::VerticalBridgeLava:
-		DrawLavaRiver<Direction::NorthEast, Direction::SouthWest>(out, center, lavaColor, true);
 		break;
 	}
 }

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -41,6 +41,8 @@ enum MapColors : uint8_t {
 	MapColorsDim = (PAL16_YELLOW + 8),
 	/** color for items on automap */
 	MapColorsItem = (PAL8_BLUE + 1),
+	/** color for lava/water on automap */
+	MapColorsLava = 1,
 };
 
 struct AutomapTile {
@@ -59,11 +61,6 @@ struct AutomapTile {
 		CaveHorizontal,
 		CaveVertical,
 		CaveCross,
-		CaveHorizontalWoodCross,
-		CaveVerticalWoodCross,
-		CaveLeftCorner,
-		CaveRightCorner,
-		CaveBottomCorner,
 		Bridge,
 		River,
 		RiverCornerEast,
@@ -76,6 +73,38 @@ struct AutomapTile {
 		RiverLeftOut,
 		RiverRightIn,
 		RiverRightOut,
+		CaveHorizontalWoodCross,
+		CaveVerticalWoodCross,
+		CaveLeftCorner,
+		CaveRightCorner,
+		CaveBottomCorner,
+		CaveHorizontalWood,
+		CaveVerticalWood,
+		CaveWoodCross,
+		CaveRightWoodCross,
+		CaveLeftWoodCross,
+		HorizontalLavaThin,
+		VerticalLavaThin,
+		BendSouthLavaThin,
+		BendWestLavaThin,
+		BendEastLavaThin,
+		BendNorthLavaThin,
+		VerticalWallLava,
+		HorizontalWallLava,
+		SELava,
+		SWLava,
+		NELava,
+		NWLava,
+		SLava,
+		WLava,
+		ELava,
+		NLava,
+		Lava,
+		CaveHorizontalWallLava,
+		CaveVerticalWallLava,
+		HorizontalBridgeLava,
+		VerticalBridgeLava,
+
 	};
 
 	Types type;
@@ -230,29 +259,24 @@ void DrawMapHorizontalDoorOrGrate(const Surface &out, Point center, uint8_t colo
 /**
  * @brief Draw 16 individual pixels equally spaced apart, used to communicate OOB area to the player.
  */
-void DrawDirt(const Surface &out, Point center, uint8_t color)
+void DrawDirt(const Surface &out, Point center, AutomapTile nwTile, uint8_t color)
 {
 	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
-
 	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
-
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
-
-	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	if (!nwTile.HasFlag(AutomapTile::Flags::HorizontalArch))                                                       // Prevent the top dirt pixel from appearing inside arch diamonds
+		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
 	out.SetPixel(center, color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
-
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
-
 	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
-
 	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
 }
 
@@ -434,6 +458,576 @@ void DrawRiverForkOut(const Surface &out, Point center, uint8_t color)
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
 }
 
+void DrawHorizontalLavaThin(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+
+	// Second row (y = 1)
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+
+	// Third row (y = 2)
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+
+	// Fourth row (y = 3)
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+}
+
+void DrawVerticalLavaThin(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// Second row (y = 1)
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+
+	// Third row (y = 2)
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+}
+void DrawBendSouthLavaThin(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawBendWestLavaThin(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawBendEastLavaThin(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawBendNorthLavaThin(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawHorizontalWallLava(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawVerticalWallLava(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+
+void DrawSELava(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawSWLava(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawNELava(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)	
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)	
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawNWLava(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawSLava(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawWLava(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawELava(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawNLava(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawLava(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawCaveHorizontalWallLava(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawCaveVerticalWallLava(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawHorizontalBridgeLava(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color); // maybe first row too??
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+void DrawVerticalBridgeLava(const Surface &out, Point center, uint8_t color)
+{
+	// Start at lowest x,y (southeast is positive x and southwest is positive y)
+	// First row (y = 0)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+
+	// Second row (y = 1)
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color); // maybe this too?
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	// Third row (y = 2)
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color); // maybe this too?
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+
+	// Fourth row (y = 3)
+	//out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
+	//out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+}
+
+
+
 /**
  * @brief Draw 4 south-east facing lines, used to communicate trigger locations to the player.
  */
@@ -454,7 +1048,7 @@ void DrawStairs(const Surface &out, Point center, uint8_t color)
 /**
  * @brief Draw half-tile length lines to connect walls to any walls to the north-west and/or north-east
  */
-void DrawWallConnections(const Surface &out, Point center, AutomapTile tile, AutomapTile nwTile, AutomapTile neTile, uint8_t colorDim)
+void DrawWallConnections(const Surface &out, Point center, AutomapTile nwTile, AutomapTile neTile, uint8_t colorDim)
 {
 	bool doorCorrection = false;
 	if (IsAnyOf(nwTile.type, AutomapTile::Types::Horizontal, AutomapTile::Types::FenceHorizontal, AutomapTile::Types::Cross, AutomapTile::Types::CaveVerticalWoodCross, AutomapTile::Types::CaveRightCorner)
@@ -462,9 +1056,7 @@ void DrawWallConnections(const Surface &out, Point center, AutomapTile tile, Aut
 		if (!IsAnyOf(leveltype, DTYPE_CATACOMBS) && nwTile.HasFlag(AutomapTile::Flags::HorizontalDoor)) {
 			doorCorrection = true;
 		}
-		//if (!(IsAnyOf(nwTile.type, AutomapTile::Types::CaveVerticalCross, AutomapTile::Types::CaveVerticalWoodCross) && tile.HasFlag(AutomapTile::Flags::Dirt)))
-		//if (!IsAnyOf(nwTile.type, AutomapTile::Types::CaveVerticalCross))
-			DrawMapLineSE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileUp, doorCorrection), AmLine(AmLineLength::HalfTile, doorCorrection), colorDim);
+		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileUp, doorCorrection), AmLine(AmLineLength::HalfTile, doorCorrection), colorDim);
 	}
 	doorCorrection = false;
 	if (IsAnyOf(neTile.type, AutomapTile::Types::Vertical, AutomapTile::Types::FenceVertical, AutomapTile::Types::Cross, AutomapTile::Types::CaveHorizontalWoodCross, AutomapTile::Types::CaveLeftCorner)
@@ -472,9 +1064,7 @@ void DrawWallConnections(const Surface &out, Point center, AutomapTile tile, Aut
 		if (neTile.HasFlag(AutomapTile::Flags::VerticalDoor)) {
 			doorCorrection = true;
 		}
-		//if (!(IsAnyOf(neTile.type, AutomapTile::Types::CaveHorizontalCross, AutomapTile::Types::CaveHorizontalWoodCross) && tile.HasFlag(AutomapTile::Flags::Dirt)))
-		//if (!IsAnyOf(neTile.type, AutomapTile::Types::CaveHorizontalCross))
-			DrawMapLineNE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::HalfTile, doorCorrection), colorDim);
+		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::HalfTile, doorCorrection), colorDim);
 	}
 }
 
@@ -483,26 +1073,28 @@ void DrawWallConnections(const Surface &out, Point center, AutomapTile tile, Aut
  */
 void DrawHorizontal(const Surface &out, Point center, AutomapTile tile, AutomapTile nwTile, AutomapTile neTile, AutomapTile seTile, uint8_t colorBright, uint8_t colorDim, bool noConnection)
 {
-	AmWidthOffset w;
-	AmHeightOffset h;
-	AmLineLength l;
+	AmWidthOffset w = AmWidthOffset::None;
+	AmHeightOffset h = AmHeightOffset::HalfTileUp;
+	AmLineLength l = AmLineLength::FullAndHalfTile;
 
-	if (neTile.HasFlag(AutomapTile::Flags::VerticalArch) || nwTile.HasFlag(AutomapTile::Flags::HorizontalArch)) {
+	if (neTile.HasFlag(AutomapTile::Flags::VerticalArch)
+	    || nwTile.HasFlag(AutomapTile::Flags::HorizontalArch)
+	    || tile.HasFlag(AutomapTile::Flags::VerticalArch)
+	    || tile.HasFlag(AutomapTile::Flags::HorizontalArch)) {
 		noConnection = true;
 		w = AmWidthOffset::QuarterTileRight;
 		h = AmHeightOffset::QuarterTileUp;
 		l = AmLineLength::FullTile;
 		DrawDiamond(out, center, colorDim);
-	} else {
-		w = AmWidthOffset::None;
-		h = AmHeightOffset::HalfTileUp;
-		if (IsAnyOf(leveltype, DTYPE_CAVES, DTYPE_NEST) && IsAnyOf(tile.type, AutomapTile::Types::CaveVerticalCross, AutomapTile::Types::CaveVerticalWoodCross) && !(IsAnyOf(seTile.type, AutomapTile::Types::Horizontal, AutomapTile::Types::CaveVerticalCross, AutomapTile::Types::CaveVerticalWoodCross, AutomapTile::Types::Corner)))
-			l = AmLineLength::FullTile;
-		else
-			l = AmLineLength::FullAndHalfTile;
+	}
+	if (IsAnyOf(leveltype, DTYPE_CAVES, DTYPE_NEST)
+	    && IsAnyOf(tile.type, AutomapTile::Types::CaveVerticalCross, AutomapTile::Types::CaveVerticalWoodCross)
+	    && !(IsAnyOf(seTile.type, AutomapTile::Types::Horizontal, AutomapTile::Types::CaveVerticalCross, AutomapTile::Types::CaveVerticalWoodCross, AutomapTile::Types::Corner))) {
+		l = AmLineLength::FullTile;
 	}
 	if (!tile.HasFlag(AutomapTile::Flags::HorizontalPassage)) {
 		DrawMapLineSE(out, center + AmOffset(w, h), AmLine(l), colorDim);
+		return;
 	}
 	if (tile.HasFlag(AutomapTile::Flags::HorizontalDoor)) {
 		DrawMapHorizontalDoorOrGrate(out, center, colorBright, colorDim);
@@ -516,27 +1108,28 @@ void DrawHorizontal(const Surface &out, Point center, AutomapTile tile, AutomapT
  */
 void DrawVertical(const Surface &out, Point center, AutomapTile tile, AutomapTile nwTile, AutomapTile neTile, AutomapTile swTile, uint8_t colorBright, uint8_t colorDim, bool noConnection)
 {
-	AmWidthOffset w;
-	AmHeightOffset h;
-	AmLineLength l;
+	AmWidthOffset w = AmWidthOffset::ThreeQuartersTileLeft;
+	AmHeightOffset h = AmHeightOffset::QuarterTileDown;
+	AmLineLength l = AmLineLength::FullAndHalfTile;
 
-	if (neTile.HasFlag(AutomapTile::Flags::VerticalArch) || nwTile.HasFlag(AutomapTile::Flags::HorizontalArch)) {
+	if (neTile.HasFlag(AutomapTile::Flags::VerticalArch)
+	    || nwTile.HasFlag(AutomapTile::Flags::HorizontalArch)
+	    || tile.HasFlag(AutomapTile::Flags::VerticalArch)
+	    || tile.HasFlag(AutomapTile::Flags::HorizontalArch)) {
 		noConnection = true;
 		l = AmLineLength::FullTile;
 		DrawDiamond(out, center, colorDim);
-	} else {
-		if (IsAnyOf(leveltype, DTYPE_CAVES, DTYPE_NEST) && IsAnyOf(tile.type, AutomapTile::Types::CaveHorizontalCross, AutomapTile::Types::CaveHorizontalWoodCross) && !(IsAnyOf(swTile.type, AutomapTile::Types::Vertical, AutomapTile::Types::CaveHorizontalCross, AutomapTile::Types::CaveHorizontalWoodCross, AutomapTile::Types::Corner))) {
-			w = AmWidthOffset::HalfTileLeft;
-			h = AmHeightOffset::None;
-			l = AmLineLength::FullTile;
-		} else {
-			w = AmWidthOffset::ThreeQuartersTileLeft;
-			h = AmHeightOffset::QuarterTileDown;
-			l = AmLineLength::FullAndHalfTile;
-		}
+	}
+	if (IsAnyOf(leveltype, DTYPE_CAVES, DTYPE_NEST)
+	    && IsAnyOf(tile.type, AutomapTile::Types::CaveHorizontalCross, AutomapTile::Types::CaveHorizontalWoodCross)
+	    && !(IsAnyOf(swTile.type, AutomapTile::Types::Vertical, AutomapTile::Types::CaveHorizontalCross, AutomapTile::Types::CaveHorizontalWoodCross, AutomapTile::Types::Corner))) {
+		w = AmWidthOffset::HalfTileLeft;
+		h = AmHeightOffset::None;
+		l = AmLineLength::FullTile;
 	}
 	if (!tile.HasFlag(AutomapTile::Flags::VerticalPassage)) {
 		DrawMapLineNE(out, center + AmOffset(w, h), AmLine(l), colorDim);
+		return;
 	}
 	if (tile.HasFlag(AutomapTile::Flags::VerticalDoor)) {
 		DrawMapVerticalDoorOrGrate(out, center, colorBright, colorDim);
@@ -552,16 +1145,16 @@ void DrawVertical(const Surface &out, Point center, AutomapTile tile, AutomapTil
 void DrawCaveWallConnections(const Surface &out, Point center, AutomapTile swTile, AutomapTile seTile, uint8_t colorDim)
 {
 	bool doorCorrection = false;
-	if (IsAnyOf(swTile.type, AutomapTile::Types::CaveVertical, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveRightCorner)) {
+	if (IsAnyOf(swTile.type, AutomapTile::Types::CaveVertical, AutomapTile::Types::CaveVerticalWood, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross, AutomapTile::Types::CaveLeftWoodCross, AutomapTile::Types::CaveRightCorner)) {
 		//if (swTile.HasFlag(AutomapTile::Flags::HorizontalDoor)) {
 		//	doorCorrection = true;
 		//}
 		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown, doorCorrection), AmLine(AmLineLength::HalfTile, doorCorrection), colorDim);
 	}
 	doorCorrection = false;
-	if (IsAnyOf(seTile.type, AutomapTile::Types::CaveHorizontal, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveLeftCorner)) {
+	if (IsAnyOf(seTile.type, AutomapTile::Types::CaveHorizontal, AutomapTile::Types::CaveHorizontalWood, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross, AutomapTile::Types::CaveLeftWoodCross, AutomapTile::Types::CaveLeftCorner)) {
 		//if (seTile.HasFlag(AutomapTile::Flags::VerticalDoor)) {
-			//doorCorrection = true;
+		//doorCorrection = true;
 		//}
 		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), AmLine(AmLineLength::HalfTile, doorCorrection), colorDim);
 	}
@@ -588,6 +1181,13 @@ void DrawCaveHorizontal(const Surface &out, Point center, AutomapTile tile, uint
 			h = AmHeightOffset::QuarterTileUp;
 			l = AmLineLength::FullAndHalfTile;
 		}
+		if (!(IsAnyOf(tile.type, AutomapTile::Types::CaveHorizontalWood, AutomapTile::Types::CaveHorizontalWoodCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveLeftWoodCross))) {
+			out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), colorDim);
+			out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), colorDim);
+			out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), colorDim);
+			out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), colorDim);
+		}
+
 		DrawMapLineSE(out, center + AmOffset(w, h), AmLine(l), colorDim);
 	}
 }
@@ -609,17 +1209,24 @@ void DrawCaveVertical(const Surface &out, Point center, AutomapTile tile, uint8_
 		} else {
 			l = AmLineLength::FullAndHalfTile;
 		}
+		if (!(IsAnyOf(tile.type, AutomapTile::Types::CaveVerticalWood, AutomapTile::Types::CaveVerticalWoodCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross))) {
+			out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), colorDim);
+			out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), colorDim);
+			out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), colorDim);
+			out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), colorDim);
+		}
+
 		DrawMapLineNE(out, { center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown) }, AmLine(l), colorDim);
 	}
 }
 
-void DrawCaveLeftCorner(const Surface &out, Point center, AutomapTile tile, uint8_t colorBright, uint8_t colorDim)
+void DrawCaveLeftCorner(const Surface &out, Point center, uint8_t colorDim)
 {
 	DrawMapLineSE(out, center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::HalfTile), colorDim);
 	DrawMapLineNE(out, center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::HalfTile), colorDim);
 }
 
-void DrawCaveRightCorner(const Surface &out, Point center, AutomapTile tile, uint8_t colorBright, uint8_t colorDim)
+void DrawCaveRightCorner(const Surface &out, Point center, uint8_t colorDim)
 {
 	DrawMapLineSE(out, center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), AmLine(AmLineLength::HalfTile), colorDim);
 	DrawMapLineNE(out, center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), AmLine(AmLineLength::HalfTile), colorDim);
@@ -701,13 +1308,88 @@ AutomapTile GetAutomapTypeView(Point map)
 		case 14:
 			return { AutomapTile::Types::CaveLeftCorner };
 		case 130:
-			return { AutomapTile::Types::CaveHorizontalWoodCross };
-		case 131:
-			return { AutomapTile::Types::CaveVerticalWoodCross };
 		case 132:
 			return { AutomapTile::Types::CaveHorizontalWoodCross };
+		case 134:
+		case 136:
+		case 151:
+			return { AutomapTile::Types::CaveHorizontalWood };
+		case 146:
+		case 148:
+			return { AutomapTile::Types::CaveHorizontalWood, AutomapTile::Flags::VerticalDoor };
+		case 131:
 		case 133:
 			return { AutomapTile::Types::CaveVerticalWoodCross };
+		case 135:
+		case 137:
+		case 152:
+			return { AutomapTile::Types::CaveVerticalWood };
+		case 147:
+		case 149:
+			return { AutomapTile::Types::CaveVerticalWood, AutomapTile::Flags::HorizontalDoor };
+		case 138:
+		case 141:
+		case 142:
+		case 143:
+			return { AutomapTile::Types::CaveWoodCross };
+		case 139:
+			return { AutomapTile::Types::CaveRightWoodCross };
+		case 140:
+			return { AutomapTile::Types::CaveLeftWoodCross };
+		case 15:
+			return { AutomapTile::Types::HorizontalLavaThin };
+		case 16:
+			return { AutomapTile::Types::HorizontalLavaThin };
+		case 17:
+			return { AutomapTile::Types::VerticalLavaThin };
+		case 18:
+			return { AutomapTile::Types::VerticalLavaThin };
+		case 19:
+			return { AutomapTile::Types::BendSouthLavaThin };
+		case 20:
+			return { AutomapTile::Types::BendWestLavaThin };
+		case 21:
+			return { AutomapTile::Types::BendEastLavaThin };
+		case 22:
+			return { AutomapTile::Types::BendNorthLavaThin };
+		case 23:
+			return { AutomapTile::Types::VerticalWallLava };
+		case 24:
+			return { AutomapTile::Types::HorizontalWallLava };
+		case 25:
+			return { AutomapTile::Types::SELava };
+		case 26:
+			return { AutomapTile::Types::SWLava };
+		case 27:
+			return { AutomapTile::Types::NELava };
+		case 28:
+			return { AutomapTile::Types::NWLava };
+		case 29:
+			return { AutomapTile::Types::SLava };
+		case 30:
+			return { AutomapTile::Types::WLava };
+		case 31:
+			return { AutomapTile::Types::ELava };
+		case 32:
+			return { AutomapTile::Types::NLava };
+		case 33:
+		case 34:
+		case 35:
+		case 36:
+		case 37:
+		case 38:
+		case 39:
+		case 40:
+		case 41:
+			return { AutomapTile::Types::Lava };
+		case 42:
+			return { AutomapTile::Types::CaveHorizontalWallLava };
+		case 43:
+			return { AutomapTile::Types::CaveVerticalWallLava };
+		case 44:
+			return { AutomapTile::Types::HorizontalBridgeLava };
+		case 45:
+			return { AutomapTile::Types::VerticalBridgeLava };
 		}
 	}
 
@@ -744,28 +1426,29 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 		break;
 	}
 
+	bool noConnect = false;
+
+	// If the tile contains an arch, we draw a diamond and therefore don't want connection lines
+	if (tile.HasFlag(AutomapTile::Flags::HorizontalArch) || tile.HasFlag(AutomapTile::Flags::VerticalArch)) {
+		noConnect = true;
+	}
+
+	// These tilesets have doors where the connection lines would be drawn
+	if (IsAnyOf(leveltype, DTYPE_CATACOMBS, DTYPE_CAVES, DTYPE_NEST) && (tile.HasFlag(AutomapTile::Flags::HorizontalDoor) || tile.HasFlag(AutomapTile::Flags::VerticalDoor)))
+		noConnect = true;
+
 	if (tile.HasFlag(AutomapTile::Flags::Dirt)) {
-		DrawDirt(out, center, colorDim);
+		DrawDirt(out, center, nwTile, colorDim);
 	}
 
 	if (tile.HasFlag(AutomapTile::Flags::Stairs)) {
 		DrawStairs(out, center, colorBright);
 	}
 
-	bool noConnect = false;
-
-	// If the tile contains an arch, we draw a diamond and therefore don't want connection lines
-	if (tile.HasFlag(AutomapTile::Flags::HorizontalArch) || tile.HasFlag(AutomapTile::Flags::VerticalArch)) {
-		DrawDiamond(out, center, colorDim);
-		noConnect = true;
-	}
-	// These tilesets have doors where the connection lines would be drawn
-	if (IsAnyOf(leveltype, DTYPE_CATACOMBS, DTYPE_CAVES, DTYPE_NEST) && (tile.HasFlag(AutomapTile::Flags::HorizontalDoor) || tile.HasFlag(AutomapTile::Flags::VerticalDoor)))
-		noConnect = true;
 	if (!noConnect) {
 		if (IsAnyOf(leveltype, DTYPE_CAVES, DTYPE_NEST))
 			DrawCaveWallConnections(out, center, swTile, seTile, colorDim);
-		DrawWallConnections(out, center, tile, nwTile, neTile, colorDim);
+		DrawWallConnections(out, center, nwTile, neTile, colorDim);
 	}
 
 	// debug
@@ -799,24 +1482,28 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 		DrawCaveVertical(out, center, tile, colorBright, colorDim);
 		break;
 	case AutomapTile::Types::CaveHorizontal:
+	case AutomapTile::Types::CaveHorizontalWood:
 		DrawCaveHorizontal(out, center, tile, colorBright, colorDim);
 		break;
 	case AutomapTile::Types::CaveVertical:
+	case AutomapTile::Types::CaveVerticalWood:
 		DrawCaveVertical(out, center, tile, colorBright, colorDim);
 		break;
 	case AutomapTile::Types::CaveCross:
+	case AutomapTile::Types::CaveWoodCross:
+	case AutomapTile::Types::CaveRightWoodCross:
+	case AutomapTile::Types::CaveLeftWoodCross:
 		DrawCaveHorizontal(out, center, tile, colorBright, colorDim);
 		DrawCaveVertical(out, center, tile, colorBright, colorDim);
 		break;
-	case AutomapTile::Types::CaveBottomCorner:
-		break;
 	case AutomapTile::Types::CaveLeftCorner:
-		DrawCaveLeftCorner(out, center, tile, colorBright, colorDim);
+		DrawCaveLeftCorner(out, center, colorDim);
 		break;
 	case AutomapTile::Types::CaveRightCorner:
-		DrawCaveRightCorner(out, center, tile, colorBright, colorDim);
+		DrawCaveRightCorner(out, center, colorDim);
 		break;
 	case AutomapTile::Types::Corner:
+	case AutomapTile::Types::CaveBottomCorner:
 	case AutomapTile::Types::None:
 		break;
 	case AutomapTile::Types::Bridge:
@@ -854,6 +1541,73 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 		break;
 	case AutomapTile::Types::RiverRightOut:
 		DrawRiverRightOut(out, center, MapColorsItem);
+		break;
+	case AutomapTile::Types::HorizontalLavaThin:
+		DrawHorizontalLavaThin(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::VerticalLavaThin:
+		DrawVerticalLavaThin(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::BendSouthLavaThin:
+		DrawBendSouthLavaThin(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::BendWestLavaThin:
+		DrawBendWestLavaThin(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::BendEastLavaThin:
+		DrawBendEastLavaThin(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::BendNorthLavaThin:
+		DrawBendNorthLavaThin(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::VerticalWallLava:
+		DrawVertical(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim, noConnect);
+		DrawVerticalWallLava(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::HorizontalWallLava:
+		DrawHorizontal(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim, noConnect);
+		DrawHorizontalWallLava(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::SELava:
+		DrawSELava(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::SWLava:
+		DrawSWLava(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::NELava:
+		DrawNELava(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::NWLava:
+		DrawNWLava(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::SLava:
+		DrawSLava(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::WLava:
+		DrawWLava(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::ELava:
+		DrawELava(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::NLava:
+		DrawNLava(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::Lava:
+		DrawLava(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::CaveHorizontalWallLava:
+		DrawCaveHorizontal(out, center, tile, colorBright, colorDim);
+		DrawCaveHorizontalWallLava(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::CaveVerticalWallLava:
+		DrawCaveVertical(out, center, tile, colorBright, colorDim);
+		DrawCaveVerticalWallLava(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::HorizontalBridgeLava:
+		DrawHorizontalBridgeLava(out, center, MapColorsLava);
+		break;
+	case AutomapTile::Types::VerticalBridgeLava:
+		DrawVerticalBridgeLava(out, center, MapColorsLava);
 		break;
 	}
 }

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -39,6 +39,8 @@ enum MapColors : uint8_t {
 	MapColorsBright = PAL8_YELLOW,
 	/** color for dim map lines/dots */
 	MapColorsDim = (PAL16_YELLOW + 8),
+	/** color for grates */
+	MapColorsGrate = (PAL16_YELLOW + 4),
 	/** color for items on automap */
 	MapColorsItem = (PAL8_BLUE + 1),
 	/** color for lava on automap */
@@ -649,7 +651,7 @@ void DrawWallConnections(const Surface &out, Point center, AutomapTile nwTile, A
 /**
  * Left-facing obstacle
  */
-void DrawHorizontal(const Surface &out, Point center, AutomapTile tile, AutomapTile nwTile, AutomapTile neTile, AutomapTile seTile, uint8_t colorBright, uint8_t colorDim)
+void DrawHorizontal(const Surface &out, Point center, AutomapTile tile, AutomapTile nwTile, AutomapTile neTile, AutomapTile seTile, uint8_t colorBright, uint8_t colorDim, uint8_t colorGrate)
 {
 	AmWidthOffset w = AmWidthOffset::None;
 	AmHeightOffset h = AmHeightOffset::HalfTileUp;
@@ -686,14 +688,14 @@ void DrawHorizontal(const Surface &out, Point center, AutomapTile tile, AutomapT
 	if (tile.HasFlag(AutomapTile::Flags::HorizontalDoor)) {
 		DrawMapHorizontalDoor(out, center, nwTile, colorBright, colorDim);
 	} else if (tile.HasFlag(AutomapTile::Flags::HorizontalGrate)) {
-		DrawMapHorizontalGrate(out, center, colorDim);
+		DrawMapHorizontalGrate(out, center, colorGrate);
 	}
 }
 
 /**
  * Right-facing obstacle
  */
-void DrawVertical(const Surface &out, Point center, AutomapTile tile, AutomapTile nwTile, AutomapTile neTile, AutomapTile swTile, uint8_t colorBright, uint8_t colorDim)
+void DrawVertical(const Surface &out, Point center, AutomapTile tile, AutomapTile nwTile, AutomapTile neTile, AutomapTile swTile, uint8_t colorBright, uint8_t colorDim, uint8_t colorGrate)
 {
 	AmWidthOffset w = AmWidthOffset::ThreeQuartersTileLeft;
 	AmHeightOffset h = AmHeightOffset::QuarterTileDown;
@@ -730,7 +732,7 @@ void DrawVertical(const Surface &out, Point center, AutomapTile tile, AutomapTil
 	if (tile.HasFlag(AutomapTile::Flags::VerticalDoor)) {
 		DrawMapVerticalDoor(out, center, neTile, colorBright, colorDim);
 	} else if (tile.HasFlag(AutomapTile::Flags::VerticalGrate)) {
-		DrawMapVerticalGrate(out, center, colorDim);
+		DrawMapVerticalGrate(out, center, colorGrate);
 	}
 }
 
@@ -912,16 +914,19 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 
 	uint8_t colorBright = MapColorsBright;
 	uint8_t colorDim = MapColorsDim;
+	uint8_t colorGrate = MapColorsGrate;
 	MapExplorationType explorationType = static_cast<MapExplorationType>(AutomapView[std::clamp(map.x, 0, DMAXX - 1)][std::clamp(map.y, 0, DMAXY - 1)]);
 
 	switch (explorationType) {
 	case MAP_EXP_SHRINE:
 		colorDim = PAL16_GRAY + 11;
 		colorBright = PAL16_GRAY + 3;
+		colorGrate = PAL16_GRAY + 7;
 		break;
 	case MAP_EXP_OTHERS:
 		colorDim = PAL16_BEIGE + 10;
 		colorBright = PAL16_BEIGE + 2;
+		colorGrate = PAL16_BEIGE + 6;
 		break;
 	case MAP_EXP_SELF:
 	case MAP_EXP_NONE:
@@ -972,25 +977,25 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 	case AutomapTile::Types::Vertical:
 	case AutomapTile::Types::FenceVertical:
 	case AutomapTile::Types::VerticalDiamond:
-		DrawVertical(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim);
+		DrawVertical(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim, colorGrate);
 		break;
 	case AutomapTile::Types::Horizontal:
 	case AutomapTile::Types::FenceHorizontal:
 	case AutomapTile::Types::HorizontalDiamond:
-		DrawHorizontal(out, center, tile, nwTile, neTile, seTile, colorBright, colorDim);
+		DrawHorizontal(out, center, tile, nwTile, neTile, seTile, colorBright, colorDim, colorGrate);
 		break;
 	case AutomapTile::Types::Cross:
-		DrawVertical(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim);
-		DrawHorizontal(out, center, tile, nwTile, neTile, seTile, colorBright, colorDim);
+		DrawVertical(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim, colorGrate);
+		DrawHorizontal(out, center, tile, nwTile, neTile, seTile, colorBright, colorDim, colorGrate);
 		break;
 	case AutomapTile::Types::CaveHorizontalCross:
 	case AutomapTile::Types::CaveHorizontalWoodCross:
-		DrawVertical(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim);
+		DrawVertical(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim, colorGrate);
 		DrawCaveHorizontal(out, center, tile, nwTile, colorBright, colorDim);
 		break;
 	case AutomapTile::Types::CaveVerticalCross:
 	case AutomapTile::Types::CaveVerticalWoodCross:
-		DrawHorizontal(out, center, tile, nwTile, neTile, seTile, colorBright, colorDim);
+		DrawHorizontal(out, center, tile, nwTile, neTile, seTile, colorBright, colorDim, colorGrate);
 		DrawCaveVertical(out, center, tile, neTile, colorBright, colorDim);
 		break;
 	case AutomapTile::Types::CaveHorizontal:
@@ -1074,11 +1079,11 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 		DrawLavaRiver<Direction::NorthWest, Direction::NorthEast>(out, center, MapColorsLava, false);
 		break;
 	case AutomapTile::Types::VerticalWallLava:
-		DrawVertical(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim);
+		DrawVertical(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim, colorGrate);
 		DrawLavaRiver<Direction::SouthEast, Direction::NoDirection>(out, center, MapColorsLava, false);
 		break;
 	case AutomapTile::Types::HorizontalWallLava:
-		DrawHorizontal(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim);
+		DrawHorizontal(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim, colorGrate);
 		DrawLavaRiver<Direction::SouthWest, Direction::NoDirection>(out, center, MapColorsLava, false);
 		break;
 	case AutomapTile::Types::SELava:

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1312,104 +1312,105 @@ void InitAutomap()
 {
 	size_t tileCount = 0;
 	std::unique_ptr<AutomapTile[]> tileTypes = LoadAutomapData(tileCount);
+
+	if (IsAnyOf(leveltype, DTYPE_TOWN, DTYPE_CAVES, DTYPE_NEST)) {
+		tileTypes[4] = { AutomapTile::Types::CaveBottomCorner };
+		tileTypes[12] = { AutomapTile::Types::CaveRightCorner };
+		tileTypes[13] = { AutomapTile::Types::CaveLeftCorner };
+	}
+	if (IsAnyOf(leveltype, DTYPE_CAVES)) {
+		tileTypes[129] = { AutomapTile::Types::CaveHorizontalWoodCross };
+		tileTypes[131] = { AutomapTile::Types::CaveHorizontalWoodCross };
+		tileTypes[133] = { AutomapTile::Types::CaveHorizontalWood };
+		tileTypes[135] = { AutomapTile::Types::CaveHorizontalWood };
+		tileTypes[150] = { AutomapTile::Types::CaveHorizontalWood };
+		tileTypes[145] = { AutomapTile::Types::CaveHorizontalWood, AutomapTile::Flags::VerticalDoor };
+		tileTypes[147] = { AutomapTile::Types::CaveHorizontalWood, AutomapTile::Flags::VerticalDoor };
+		tileTypes[130] = { AutomapTile::Types::CaveVerticalWoodCross };
+		tileTypes[132] = { AutomapTile::Types::CaveVerticalWoodCross };
+		tileTypes[134] = { AutomapTile::Types::CaveVerticalWood };
+		tileTypes[136] = { AutomapTile::Types::CaveVerticalWood };
+		tileTypes[151] = { AutomapTile::Types::CaveVerticalWood };
+		tileTypes[146] = { AutomapTile::Types::CaveVerticalWood, AutomapTile::Flags::HorizontalDoor };
+		tileTypes[148] = { AutomapTile::Types::CaveVerticalWood, AutomapTile::Flags::HorizontalDoor };
+		tileTypes[137] = { AutomapTile::Types::CaveWoodCross };
+		tileTypes[140] = { AutomapTile::Types::CaveWoodCross };
+		tileTypes[141] = { AutomapTile::Types::CaveWoodCross };
+		tileTypes[142] = { AutomapTile::Types::CaveWoodCross };
+		tileTypes[138] = { AutomapTile::Types::CaveRightWoodCross };
+		tileTypes[139] = { AutomapTile::Types::CaveLeftWoodCross };
+		tileTypes[14] = { AutomapTile::Types::HorizontalLavaThin };
+		tileTypes[15] = { AutomapTile::Types::HorizontalLavaThin };
+		tileTypes[16] = { AutomapTile::Types::VerticalLavaThin };
+		tileTypes[17] = { AutomapTile::Types::VerticalLavaThin };
+		tileTypes[18] = { AutomapTile::Types::BendSouthLavaThin };
+		tileTypes[19] = { AutomapTile::Types::BendWestLavaThin };
+		tileTypes[20] = { AutomapTile::Types::BendEastLavaThin };
+		tileTypes[21] = { AutomapTile::Types::BendNorthLavaThin };
+		tileTypes[22] = { AutomapTile::Types::VerticalWallLava };
+		tileTypes[23] = { AutomapTile::Types::HorizontalWallLava };
+		tileTypes[24] = { AutomapTile::Types::SELava };
+		tileTypes[25] = { AutomapTile::Types::SWLava };
+		tileTypes[26] = { AutomapTile::Types::NELava };
+		tileTypes[27] = { AutomapTile::Types::NWLava };
+		tileTypes[28] = { AutomapTile::Types::SLava };
+		tileTypes[29] = { AutomapTile::Types::WLava };
+		tileTypes[30] = { AutomapTile::Types::ELava };
+		tileTypes[31] = { AutomapTile::Types::NLava };
+		tileTypes[32] = { AutomapTile::Types::Lava };
+		tileTypes[33] = { AutomapTile::Types::Lava };
+		tileTypes[34] = { AutomapTile::Types::Lava };
+		tileTypes[35] = { AutomapTile::Types::Lava };
+		tileTypes[36] = { AutomapTile::Types::Lava };
+		tileTypes[37] = { AutomapTile::Types::Lava };
+		tileTypes[38] = { AutomapTile::Types::Lava };
+		tileTypes[39] = { AutomapTile::Types::Lava };
+		tileTypes[40] = { AutomapTile::Types::Lava };
+		tileTypes[41] = { AutomapTile::Types::CaveHorizontalWallLava };
+		tileTypes[42] = { AutomapTile::Types::CaveVerticalWallLava };
+		tileTypes[43] = { AutomapTile::Types::HorizontalBridgeLava };
+		tileTypes[44] = { AutomapTile::Types::VerticalBridgeLava };
+	}
+	if (IsAnyOf(leveltype, DTYPE_NEST)) {
+		tileTypes[102] = { AutomapTile::Types::HorizontalLavaThin };
+		tileTypes[103] = { AutomapTile::Types::HorizontalLavaThin };
+		tileTypes[108] = { AutomapTile::Types::HorizontalLavaThin };
+		tileTypes[104] = { AutomapTile::Types::VerticalLavaThin };
+		tileTypes[105] = { AutomapTile::Types::VerticalLavaThin };
+		tileTypes[107] = { AutomapTile::Types::VerticalLavaThin };
+		tileTypes[112] = { AutomapTile::Types::BendSouthLavaThin };
+		tileTypes[113] = { AutomapTile::Types::BendWestLavaThin };
+		tileTypes[110] = { AutomapTile::Types::BendEastLavaThin };
+		tileTypes[111] = { AutomapTile::Types::BendNorthLavaThin };
+		tileTypes[134] = { AutomapTile::Types::VerticalWallLava };
+		tileTypes[135] = { AutomapTile::Types::HorizontalWallLava };
+		tileTypes[118] = { AutomapTile::Types::SELava };
+		tileTypes[119] = { AutomapTile::Types::SWLava };
+		tileTypes[120] = { AutomapTile::Types::NELava };
+		tileTypes[121] = { AutomapTile::Types::NWLava };
+		tileTypes[106] = { AutomapTile::Types::SLava };
+		tileTypes[114] = { AutomapTile::Types::WLava };
+		tileTypes[130] = { AutomapTile::Types::ELava };
+		tileTypes[122] = { AutomapTile::Types::NLava };
+		tileTypes[117] = { AutomapTile::Types::Lava };
+		tileTypes[124] = { AutomapTile::Types::Lava };
+		tileTypes[126] = { AutomapTile::Types::Lava };
+		tileTypes[127] = { AutomapTile::Types::Lava };
+		tileTypes[128] = { AutomapTile::Types::Lava };
+		tileTypes[129] = { AutomapTile::Types::Lava };
+		tileTypes[131] = { AutomapTile::Types::Lava };
+		tileTypes[132] = { AutomapTile::Types::Lava };
+		tileTypes[133] = { AutomapTile::Types::Lava };
+		tileTypes[136] = { AutomapTile::Types::CaveHorizontalWallLava };
+		tileTypes[137] = { AutomapTile::Types::CaveVerticalWallLava };
+		tileTypes[115] = { AutomapTile::Types::HorizontalBridgeLava };
+		tileTypes[116] = { AutomapTile::Types::VerticalBridgeLava };
+	}
+	if (IsAnyOf(leveltype, DTYPE_HELL)) {
+		tileTypes[51] = { AutomapTile::Types::VerticalDiamond };
+		tileTypes[55] = { AutomapTile::Types::HorizontalDiamond };
+	}
 	for (unsigned i = 0; i < tileCount; i++) {
-		if (IsAnyOf(leveltype, DTYPE_TOWN, DTYPE_CAVES, DTYPE_NEST)) {
-			tileTypes[4] = { AutomapTile::Types::CaveBottomCorner };
-			tileTypes[12] = { AutomapTile::Types::CaveRightCorner };
-			tileTypes[13] = { AutomapTile::Types::CaveLeftCorner };
-		}
-		if (IsAnyOf(leveltype, DTYPE_CAVES)) {
-			tileTypes[129] = { AutomapTile::Types::CaveHorizontalWoodCross };
-			tileTypes[131] = { AutomapTile::Types::CaveHorizontalWoodCross };
-			tileTypes[133] = { AutomapTile::Types::CaveHorizontalWood };
-			tileTypes[135] = { AutomapTile::Types::CaveHorizontalWood };
-			tileTypes[150] = { AutomapTile::Types::CaveHorizontalWood };
-			tileTypes[145] = { AutomapTile::Types::CaveHorizontalWood, AutomapTile::Flags::VerticalDoor };
-			tileTypes[147] = { AutomapTile::Types::CaveHorizontalWood, AutomapTile::Flags::VerticalDoor };
-			tileTypes[130] = { AutomapTile::Types::CaveVerticalWoodCross };
-			tileTypes[132] = { AutomapTile::Types::CaveVerticalWoodCross };
-			tileTypes[134] = { AutomapTile::Types::CaveVerticalWood };
-			tileTypes[136] = { AutomapTile::Types::CaveVerticalWood };
-			tileTypes[151] = { AutomapTile::Types::CaveVerticalWood };
-			tileTypes[146] = { AutomapTile::Types::CaveVerticalWood, AutomapTile::Flags::HorizontalDoor };
-			tileTypes[148] = { AutomapTile::Types::CaveVerticalWood, AutomapTile::Flags::HorizontalDoor };
-			tileTypes[137] = { AutomapTile::Types::CaveWoodCross };
-			tileTypes[140] = { AutomapTile::Types::CaveWoodCross };
-			tileTypes[141] = { AutomapTile::Types::CaveWoodCross };
-			tileTypes[142] = { AutomapTile::Types::CaveWoodCross };
-			tileTypes[138] = { AutomapTile::Types::CaveRightWoodCross };
-			tileTypes[139] = { AutomapTile::Types::CaveLeftWoodCross };
-			tileTypes[14] = { AutomapTile::Types::HorizontalLavaThin };
-			tileTypes[15] = { AutomapTile::Types::HorizontalLavaThin };
-			tileTypes[16] = { AutomapTile::Types::VerticalLavaThin };
-			tileTypes[17] = { AutomapTile::Types::VerticalLavaThin };
-			tileTypes[18] = { AutomapTile::Types::BendSouthLavaThin };
-			tileTypes[19] = { AutomapTile::Types::BendWestLavaThin };
-			tileTypes[20] = { AutomapTile::Types::BendEastLavaThin };
-			tileTypes[21] = { AutomapTile::Types::BendNorthLavaThin };
-			tileTypes[22] = { AutomapTile::Types::VerticalWallLava };
-			tileTypes[23] = { AutomapTile::Types::HorizontalWallLava };
-			tileTypes[24] = { AutomapTile::Types::SELava };
-			tileTypes[25] = { AutomapTile::Types::SWLava };
-			tileTypes[26] = { AutomapTile::Types::NELava };
-			tileTypes[27] = { AutomapTile::Types::NWLava };
-			tileTypes[28] = { AutomapTile::Types::SLava };
-			tileTypes[29] = { AutomapTile::Types::WLava };
-			tileTypes[30] = { AutomapTile::Types::ELava };
-			tileTypes[31] = { AutomapTile::Types::NLava };
-			tileTypes[32] = { AutomapTile::Types::Lava };
-			tileTypes[33] = { AutomapTile::Types::Lava };
-			tileTypes[34] = { AutomapTile::Types::Lava };
-			tileTypes[35] = { AutomapTile::Types::Lava };
-			tileTypes[36] = { AutomapTile::Types::Lava };
-			tileTypes[37] = { AutomapTile::Types::Lava };
-			tileTypes[38] = { AutomapTile::Types::Lava };
-			tileTypes[39] = { AutomapTile::Types::Lava };
-			tileTypes[40] = { AutomapTile::Types::Lava };
-			tileTypes[41] = { AutomapTile::Types::CaveHorizontalWallLava };
-			tileTypes[42] = { AutomapTile::Types::CaveVerticalWallLava };
-			tileTypes[43] = { AutomapTile::Types::HorizontalBridgeLava };
-			tileTypes[44] = { AutomapTile::Types::VerticalBridgeLava };
-			}
-		if (IsAnyOf(leveltype, DTYPE_NEST)) {
-			tileTypes[102] = { AutomapTile::Types::HorizontalLavaThin };
-			tileTypes[103] = { AutomapTile::Types::HorizontalLavaThin };
-			tileTypes[108] = { AutomapTile::Types::HorizontalLavaThin };
-			tileTypes[104] = { AutomapTile::Types::VerticalLavaThin };
-			tileTypes[105] = { AutomapTile::Types::VerticalLavaThin };
-			tileTypes[107] = { AutomapTile::Types::VerticalLavaThin };
-			tileTypes[112] = { AutomapTile::Types::BendSouthLavaThin };
-			tileTypes[113] = { AutomapTile::Types::BendWestLavaThin };
-			tileTypes[110] = { AutomapTile::Types::BendEastLavaThin };
-			tileTypes[111] = { AutomapTile::Types::BendNorthLavaThin };
-			tileTypes[134] = { AutomapTile::Types::VerticalWallLava };
-			tileTypes[135] = { AutomapTile::Types::HorizontalWallLava };
-			tileTypes[118] = { AutomapTile::Types::SELava };
-			tileTypes[119] = { AutomapTile::Types::SWLava };
-			tileTypes[120] = { AutomapTile::Types::NELava };
-			tileTypes[121] = { AutomapTile::Types::NWLava };
-			tileTypes[106] = { AutomapTile::Types::SLava };
-			tileTypes[114] = { AutomapTile::Types::WLava };
-			tileTypes[130] = { AutomapTile::Types::ELava };
-			tileTypes[122] = { AutomapTile::Types::NLava };
-			tileTypes[117] = { AutomapTile::Types::Lava };
-			tileTypes[124] = { AutomapTile::Types::Lava };
-			tileTypes[126] = { AutomapTile::Types::Lava };
-			tileTypes[127] = { AutomapTile::Types::Lava };
-			tileTypes[128] = { AutomapTile::Types::Lava };
-			tileTypes[129] = { AutomapTile::Types::Lava };
-			tileTypes[131] = { AutomapTile::Types::Lava };
-			tileTypes[132] = { AutomapTile::Types::Lava };
-			tileTypes[133] = { AutomapTile::Types::Lava };
-			tileTypes[136] = { AutomapTile::Types::CaveHorizontalWallLava };
-			tileTypes[137] = { AutomapTile::Types::CaveVerticalWallLava };
-			tileTypes[115] = { AutomapTile::Types::HorizontalBridgeLava };
-			tileTypes[116] = { AutomapTile::Types::VerticalBridgeLava };
-		}
-		if (IsAnyOf(leveltype, DTYPE_HELL)) {
-			tileTypes[51] = { AutomapTile::Types::VerticalDiamond };
-			tileTypes[55] = { AutomapTile::Types::HorizontalDiamond };
-		}
 		AutomapTypeTiles[i + 1] = tileTypes[i];
 	}
 

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1313,226 +1313,104 @@ void InitAutomap()
 	size_t tileCount = 0;
 	std::unique_ptr<AutomapTile[]> tileTypes = LoadAutomapData(tileCount);
 	for (unsigned i = 0; i < tileCount; i++) {
-		AutomapTile tempTileType = tileTypes[i];
-
 		if (IsAnyOf(leveltype, DTYPE_TOWN, DTYPE_CAVES, DTYPE_NEST)) {
-			switch (i + 1) {
-			case 5:
-				tempTileType = { AutomapTile::Types::CaveBottomCorner };
-				break;
-			case 13:
-				tempTileType = { AutomapTile::Types::CaveRightCorner };
-				break;
-			case 14:
-				tempTileType = { AutomapTile::Types::CaveLeftCorner };
-				break;
-			}
+			tileTypes[4] = { AutomapTile::Types::CaveBottomCorner };
+			tileTypes[12] = { AutomapTile::Types::CaveRightCorner };
+			tileTypes[13] = { AutomapTile::Types::CaveLeftCorner };
 		}
 		if (IsAnyOf(leveltype, DTYPE_CAVES)) {
-			switch (i + 1) {
-			case 130:
-			case 132:
-				tempTileType = { AutomapTile::Types::CaveHorizontalWoodCross };
-				break;
-			case 134:
-			case 136:
-			case 151:
-				tempTileType = { AutomapTile::Types::CaveHorizontalWood };
-				break;
-			case 146:
-			case 148:
-				tempTileType = { AutomapTile::Types::CaveHorizontalWood, AutomapTile::Flags::VerticalDoor };
-				break;
-			case 131:
-			case 133:
-				tempTileType = { AutomapTile::Types::CaveVerticalWoodCross };
-				break;
-			case 135:
-			case 137:
-			case 152:
-				tempTileType = { AutomapTile::Types::CaveVerticalWood };
-				break;
-			case 147:
-			case 149:
-				tempTileType = { AutomapTile::Types::CaveVerticalWood, AutomapTile::Flags::HorizontalDoor };
-				break;
-			case 138:
-			case 141:
-			case 142:
-			case 143:
-				tempTileType = { AutomapTile::Types::CaveWoodCross };
-				break;
-			case 139:
-				tempTileType = { AutomapTile::Types::CaveRightWoodCross };
-				break;
-			case 140:
-				tempTileType = { AutomapTile::Types::CaveLeftWoodCross };
-				break;
-			case 15:
-			case 16:
-				tempTileType = { AutomapTile::Types::HorizontalLavaThin };
-				break;
-			case 17:
-			case 18:
-				tempTileType = { AutomapTile::Types::VerticalLavaThin };
-				break;
-			case 19:
-				tempTileType = { AutomapTile::Types::BendSouthLavaThin };
-				break;
-			case 20:
-				tempTileType = { AutomapTile::Types::BendWestLavaThin };
-				break;
-			case 21:
-				tempTileType = { AutomapTile::Types::BendEastLavaThin };
-				break;
-			case 22:
-				tempTileType = { AutomapTile::Types::BendNorthLavaThin };
-				break;
-			case 23:
-				tempTileType = { AutomapTile::Types::VerticalWallLava };
-				break;
-			case 24:
-				tempTileType = { AutomapTile::Types::HorizontalWallLava };
-				break;
-			case 25:
-				tempTileType = { AutomapTile::Types::SELava };
-				break;
-			case 26:
-				tempTileType = { AutomapTile::Types::SWLava };
-				break;
-			case 27:
-				tempTileType = { AutomapTile::Types::NELava };
-				break;
-			case 28:
-				tempTileType = { AutomapTile::Types::NWLava };
-				break;
-			case 29:
-				tempTileType = { AutomapTile::Types::SLava };
-				break;
-			case 30:
-				tempTileType = { AutomapTile::Types::WLava };
-				break;
-			case 31:
-				tempTileType = { AutomapTile::Types::ELava };
-				break;
-			case 32:
-				tempTileType = { AutomapTile::Types::NLava };
-				break;
-			case 33:
-			case 34:
-			case 35:
-			case 36:
-			case 37:
-			case 38:
-			case 39:
-			case 40:
-			case 41:
-				tempTileType = { AutomapTile::Types::Lava };
-				break;
-			case 42:
-				tempTileType = { AutomapTile::Types::CaveHorizontalWallLava };
-				break;
-			case 43:
-				tempTileType = { AutomapTile::Types::CaveVerticalWallLava };
-				break;
-			case 44:
-				tempTileType = { AutomapTile::Types::HorizontalBridgeLava };
-				break;
-			case 45:
-				tempTileType = { AutomapTile::Types::VerticalBridgeLava };
-				break;
+			tileTypes[129] = { AutomapTile::Types::CaveHorizontalWoodCross };
+			tileTypes[131] = { AutomapTile::Types::CaveHorizontalWoodCross };
+			tileTypes[133] = { AutomapTile::Types::CaveHorizontalWood };
+			tileTypes[135] = { AutomapTile::Types::CaveHorizontalWood };
+			tileTypes[150] = { AutomapTile::Types::CaveHorizontalWood };
+			tileTypes[145] = { AutomapTile::Types::CaveHorizontalWood, AutomapTile::Flags::VerticalDoor };
+			tileTypes[147] = { AutomapTile::Types::CaveHorizontalWood, AutomapTile::Flags::VerticalDoor };
+			tileTypes[130] = { AutomapTile::Types::CaveVerticalWoodCross };
+			tileTypes[132] = { AutomapTile::Types::CaveVerticalWoodCross };
+			tileTypes[134] = { AutomapTile::Types::CaveVerticalWood };
+			tileTypes[136] = { AutomapTile::Types::CaveVerticalWood };
+			tileTypes[151] = { AutomapTile::Types::CaveVerticalWood };
+			tileTypes[146] = { AutomapTile::Types::CaveVerticalWood, AutomapTile::Flags::HorizontalDoor };
+			tileTypes[148] = { AutomapTile::Types::CaveVerticalWood, AutomapTile::Flags::HorizontalDoor };
+			tileTypes[137] = { AutomapTile::Types::CaveWoodCross };
+			tileTypes[140] = { AutomapTile::Types::CaveWoodCross };
+			tileTypes[141] = { AutomapTile::Types::CaveWoodCross };
+			tileTypes[142] = { AutomapTile::Types::CaveWoodCross };
+			tileTypes[138] = { AutomapTile::Types::CaveRightWoodCross };
+			tileTypes[139] = { AutomapTile::Types::CaveLeftWoodCross };
+			tileTypes[14] = { AutomapTile::Types::HorizontalLavaThin };
+			tileTypes[15] = { AutomapTile::Types::HorizontalLavaThin };
+			tileTypes[16] = { AutomapTile::Types::VerticalLavaThin };
+			tileTypes[17] = { AutomapTile::Types::VerticalLavaThin };
+			tileTypes[18] = { AutomapTile::Types::BendSouthLavaThin };
+			tileTypes[19] = { AutomapTile::Types::BendWestLavaThin };
+			tileTypes[20] = { AutomapTile::Types::BendEastLavaThin };
+			tileTypes[21] = { AutomapTile::Types::BendNorthLavaThin };
+			tileTypes[22] = { AutomapTile::Types::VerticalWallLava };
+			tileTypes[23] = { AutomapTile::Types::HorizontalWallLava };
+			tileTypes[24] = { AutomapTile::Types::SELava };
+			tileTypes[25] = { AutomapTile::Types::SWLava };
+			tileTypes[26] = { AutomapTile::Types::NELava };
+			tileTypes[27] = { AutomapTile::Types::NWLava };
+			tileTypes[28] = { AutomapTile::Types::SLava };
+			tileTypes[29] = { AutomapTile::Types::WLava };
+			tileTypes[30] = { AutomapTile::Types::ELava };
+			tileTypes[31] = { AutomapTile::Types::NLava };
+			tileTypes[32] = { AutomapTile::Types::Lava };
+			tileTypes[33] = { AutomapTile::Types::Lava };
+			tileTypes[34] = { AutomapTile::Types::Lava };
+			tileTypes[35] = { AutomapTile::Types::Lava };
+			tileTypes[36] = { AutomapTile::Types::Lava };
+			tileTypes[37] = { AutomapTile::Types::Lava };
+			tileTypes[38] = { AutomapTile::Types::Lava };
+			tileTypes[39] = { AutomapTile::Types::Lava };
+			tileTypes[40] = { AutomapTile::Types::Lava };
+			tileTypes[41] = { AutomapTile::Types::CaveHorizontalWallLava };
+			tileTypes[42] = { AutomapTile::Types::CaveVerticalWallLava };
+			tileTypes[43] = { AutomapTile::Types::HorizontalBridgeLava };
+			tileTypes[44] = { AutomapTile::Types::VerticalBridgeLava };
 			}
-		}
 		if (IsAnyOf(leveltype, DTYPE_NEST)) {
-			switch (i + 1) {
-			case 103:
-			case 104:
-			case 109:
-				tempTileType = { AutomapTile::Types::HorizontalLavaThin };
-				break;
-			case 105:
-			case 106:
-			case 108:
-				tempTileType = { AutomapTile::Types::VerticalLavaThin };
-				break;
-			case 113:
-				tempTileType = { AutomapTile::Types::BendSouthLavaThin };
-				break;
-			case 114:
-				tempTileType = { AutomapTile::Types::BendWestLavaThin };
-				break;
-			case 111:
-				tempTileType = { AutomapTile::Types::BendEastLavaThin };
-				break;
-			case 112:
-				tempTileType = { AutomapTile::Types::BendNorthLavaThin };
-				break;
-			case 135:
-				tempTileType = { AutomapTile::Types::VerticalWallLava };
-				break;
-			case 136:
-				tempTileType = { AutomapTile::Types::HorizontalWallLava };
-				break;
-			case 119:
-				tempTileType = { AutomapTile::Types::SELava };
-				break;
-			case 120:
-				tempTileType = { AutomapTile::Types::SWLava };
-				break;
-			case 121:
-				tempTileType = { AutomapTile::Types::NELava };
-				break;
-			case 122:
-				tempTileType = { AutomapTile::Types::NWLava };
-				break;
-			case 107:
-				tempTileType = { AutomapTile::Types::SLava };
-				break;
-			case 115:
-				tempTileType = { AutomapTile::Types::WLava };
-				break;
-			case 131:
-				tempTileType = { AutomapTile::Types::ELava };
-				break;
-			case 123:
-				tempTileType = { AutomapTile::Types::NLava };
-				break;
-			case 118:
-			case 125:
-			case 127:
-			case 128:
-			case 129:
-			case 130:
-			case 132:
-			case 133:
-			case 134:
-				tempTileType = { AutomapTile::Types::Lava };
-				break;
-			case 137:
-				tempTileType = { AutomapTile::Types::CaveHorizontalWallLava };
-				break;
-			case 138:
-				tempTileType = { AutomapTile::Types::CaveVerticalWallLava };
-				break;
-			case 116:
-				tempTileType = { AutomapTile::Types::HorizontalBridgeLava };
-				break;
-			case 117:
-				tempTileType = { AutomapTile::Types::VerticalBridgeLava };
-				break;
-			}
+			tileTypes[102] = { AutomapTile::Types::HorizontalLavaThin };
+			tileTypes[103] = { AutomapTile::Types::HorizontalLavaThin };
+			tileTypes[108] = { AutomapTile::Types::HorizontalLavaThin };
+			tileTypes[104] = { AutomapTile::Types::VerticalLavaThin };
+			tileTypes[105] = { AutomapTile::Types::VerticalLavaThin };
+			tileTypes[107] = { AutomapTile::Types::VerticalLavaThin };
+			tileTypes[112] = { AutomapTile::Types::BendSouthLavaThin };
+			tileTypes[113] = { AutomapTile::Types::BendWestLavaThin };
+			tileTypes[110] = { AutomapTile::Types::BendEastLavaThin };
+			tileTypes[111] = { AutomapTile::Types::BendNorthLavaThin };
+			tileTypes[134] = { AutomapTile::Types::VerticalWallLava };
+			tileTypes[135] = { AutomapTile::Types::HorizontalWallLava };
+			tileTypes[118] = { AutomapTile::Types::SELava };
+			tileTypes[119] = { AutomapTile::Types::SWLava };
+			tileTypes[120] = { AutomapTile::Types::NELava };
+			tileTypes[121] = { AutomapTile::Types::NWLava };
+			tileTypes[106] = { AutomapTile::Types::SLava };
+			tileTypes[114] = { AutomapTile::Types::WLava };
+			tileTypes[130] = { AutomapTile::Types::ELava };
+			tileTypes[122] = { AutomapTile::Types::NLava };
+			tileTypes[117] = { AutomapTile::Types::Lava };
+			tileTypes[124] = { AutomapTile::Types::Lava };
+			tileTypes[126] = { AutomapTile::Types::Lava };
+			tileTypes[127] = { AutomapTile::Types::Lava };
+			tileTypes[128] = { AutomapTile::Types::Lava };
+			tileTypes[129] = { AutomapTile::Types::Lava };
+			tileTypes[131] = { AutomapTile::Types::Lava };
+			tileTypes[132] = { AutomapTile::Types::Lava };
+			tileTypes[133] = { AutomapTile::Types::Lava };
+			tileTypes[136] = { AutomapTile::Types::CaveHorizontalWallLava };
+			tileTypes[137] = { AutomapTile::Types::CaveVerticalWallLava };
+			tileTypes[115] = { AutomapTile::Types::HorizontalBridgeLava };
+			tileTypes[116] = { AutomapTile::Types::VerticalBridgeLava };
 		}
 		if (IsAnyOf(leveltype, DTYPE_HELL)) {
-			switch (i + 1) {
-			case 52:
-				tempTileType = { AutomapTile::Types::VerticalDiamond };
-				break;
-			case 56:
-				tempTileType = { AutomapTile::Types::HorizontalDiamond };
-				break;
-			}
+			tileTypes[51] = { AutomapTile::Types::VerticalDiamond };
+			tileTypes[55] = { AutomapTile::Types::HorizontalDiamond };
 		}
-		AutomapTypeTiles[i + 1] = tempTileType;
+		AutomapTypeTiles[i + 1] = tileTypes[i];
 	}
 
 	memset(AutomapView, 0, sizeof(AutomapView));

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -911,6 +911,7 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 	AutomapTile neTile = GetAutomapTypeView(map + Displacement { 0, -1 });
 	AutomapTile swTile = GetAutomapTypeView(map + Displacement { 0, 1 });
 	AutomapTile seTile = GetAutomapTypeView(map + Displacement { 1, 0 });
+	AutomapTile sTile = GetAutomapTypeView(map + Displacement { 1, 1 });
 
 	uint8_t colorBright = MapColorsBright;
 	uint8_t colorDim = MapColorsDim;
@@ -953,15 +954,13 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 	if (IsAnyOf(leveltype, DTYPE_CATACOMBS, DTYPE_CAVES) && (tile.HasFlag(AutomapTile::Flags::HorizontalDoor) || tile.HasFlag(AutomapTile::Flags::VerticalDoor)))
 		noConnect = true;
 
-	if (tile.HasFlag(AutomapTile::Flags::Dirt)) {
+	if ((tile.type != AutomapTile::Types::None || swTile.type != AutomapTile::Types::None || seTile.type != AutomapTile::Types::None || sTile.type != AutomapTile::Types::None)&& tile.HasFlag(AutomapTile::Flags::Dirt)) {
 		DrawDirt(out, center, nwTile, neTile, colorDim);
 	}
 
 	if (tile.HasFlag(AutomapTile::Flags::Stairs)) {
 		DrawStairs(out, center, colorBright);
 	}
-
-	AutomapTile sTile = GetAutomapTypeView(map + Displacement { 1, 1 });
 
 	if (!noConnect) {
 		if (IsAnyOf(leveltype, DTYPE_TOWN, DTYPE_CAVES, DTYPE_NEST)) {

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -906,9 +906,9 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 	            || swTile.type != AutomapTile::Types::None
 	            || sTile.type != AutomapTile::Types::None
 	            || seTile.type != AutomapTile::Types::None
-	            || IsAnyOf(nwTile.type, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveVertical, AutomapTile::Types::CaveVerticalCross, AutomapTile::Types::CaveVerticalWallLava, AutomapTile::Types::CaveVerticalWoodCross)
+	            || IsAnyOf(nwTile.type, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveVertical, AutomapTile::Types::CaveVerticalCross, AutomapTile::Types::CaveVerticalWallLava, AutomapTile::Types::CaveLeftWoodCross)
 	            || IsAnyOf(nTile.type, AutomapTile::Types::CaveCross)
-	            || IsAnyOf(neTile.type, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveHorizontal, AutomapTile::Types::CaveHorizontalCross, AutomapTile::Types::CaveHorizontalWallLava, AutomapTile::Types::CaveHorizontalWoodCross)
+	            || IsAnyOf(neTile.type, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveHorizontal, AutomapTile::Types::CaveHorizontalCross, AutomapTile::Types::CaveHorizontalWallLava, AutomapTile::Types::CaveRightWoodCross)
 	            || IsAnyOf(wTile.type, AutomapTile::Types::CaveVerticalCross)
 	            || IsAnyOf(eTile.type, AutomapTile::Types::CaveHorizontalCross)))) {
 		DrawDirt(out, center, nwTile, neTile, colorDim);

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -578,7 +578,7 @@ void DrawCorner(const Surface &out, Point center, AutomapTile nwTile, AutomapTil
  * @brief Draw half-tile length lines to connect walls to any walls to the south-west and/or south-east
  * (For caves the horizontal/vertical flags are swapped)
  */
-void DrawCaveWallConnections(const Surface &out, Point center, AutomapTile sTile, AutomapTile swTile, AutomapTile seTile, uint8_t colorDim)
+void DrawCaveWallConnections(const Surface &out, Point center, AutomapTile swTile, AutomapTile seTile, uint8_t colorDim)
 {
 	if (IsAnyOf(swTile.type, AutomapTile::Types::CaveVertical, AutomapTile::Types::CaveVerticalWood, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross, AutomapTile::Types::CaveLeftWoodCross, AutomapTile::Types::CaveRightCorner)) {
 		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), AmLine(AmLineLength::HalfTile), colorDim);

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1074,17 +1074,15 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 	if (tile.HasFlag(AutomapTile::Flags::Stairs)) {
 		DrawStairs(out, center, colorBright);
 	}
+
 	AutomapTile sTile = GetAutomapTypeView(map + Displacement { 1, 1 });
+
 	if (!noConnect) {
 		if (IsAnyOf(leveltype, DTYPE_CAVES, DTYPE_NEST)) {
 			DrawCaveWallConnections(out, center, sTile, swTile, seTile, colorDim);
 		}
 		DrawWallConnections(out, center, nwTile, neTile, colorBright, colorDim);
 	}
-
-	// debug
-	int colorBright2 = PAL8_BLUE;
-	int colorDim2 = PAL16_BLUE + 8;
 
 	switch (tile.type) {
 	case AutomapTile::Types::Diamond: // stand-alone column or other unpassable object
@@ -1326,15 +1324,12 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, int 
 	case Direction::North: {
 		const Point point = base + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileUp);
 		DrawVerticalLine(out, point, AmLine(AmLineLength::DoubleTile), playerColor);
-		//DrawMapLineSteepNE(out, { point.x - AmLine(4), point.y + 2 * AmLine(4) }, AmLine(AmLineLength::HalfTile), playerColor);
 		DrawMapLineSteepNE(out, point + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::HalfTileDown), AmLine(AmLineLength::HalfTile), playerColor);
-		//DrawMapLineSteepNW(out, { point.x + AmLine(4), point.y + 2 * AmLine(4) }, AmLine(AmLineLength::HalfTile), playerColor);
 		DrawMapLineSteepNW(out, point + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::HalfTileDown), AmLine(AmLineLength::HalfTile), playerColor);
 	} break;
 	case Direction::NorthEast: {
 		const Point point = base + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileUp);
 		DrawHorizontalLine(out, point + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), AmLine(AmLineLength::FullTile), playerColor);
-		//DrawMapLineNE(out, { point.x - 2 * AmLine(8), point.y + AmLine(8) }, AmLine(AmLineLength::FullTile), playerColor);
 		DrawMapLineNE(out, point + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), AmLine(AmLineLength::FullTile), playerColor);
 		DrawMapLineSteepSW(out, point, AmLine(AmLineLength::HalfTile), playerColor);
 	} break;
@@ -1565,7 +1560,6 @@ void DrawAutomap(const Surface &out)
 	Displacement myPlayerOffset = {};
 	if (myPlayer.isWalking())
 		myPlayerOffset = GetOffsetForWalking(myPlayer.AnimInfo, myPlayer._pdir, true);
-	//myPlayerOffset += Displacement { -1, (leveltype != DTYPE_CAVES) ? TILE_HEIGHT - 1 : -1 };
 
 	int d = (AutoMapScale * 64) / 100;
 	int cells = 2 * (gnScreenWidth / 2 / d) + 1;
@@ -1631,8 +1625,6 @@ void DrawAutomap(const Surface &out)
 		screen.y += AmOffset(AmWidthOffset::None, AmHeightOffset::DoubleTileDown).deltaY;
 	}
 
-	//if (leveltype == DTYPE_CAVES)
-	//	myPlayerOffset.deltaY += TILE_HEIGHT;
 	for (size_t playerId = 0; playerId < Players.size(); playerId++) {
 		Player &player = Players[playerId];
 		if (player.isOnActiveLevel() && player.plractive && !player._pLvlChanging && (&player == MyPlayer || player.friendlyMode)) {
@@ -1640,7 +1632,6 @@ void DrawAutomap(const Surface &out)
 		}
 	}
 
-	//myPlayerOffset.deltaY -= TILE_HEIGHT / 2;
 	if (AutoMapShowItems)
 		SearchAutomapItem(out, myPlayerOffset, 8, [](Point position) { return dItem[position.x][position.y] != 0; });
 #ifdef _DEBUG

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -976,16 +976,16 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 	AutomapTile eTile = GetAutomapTileInDirection(Direction::East, map);
 
 	if ((leveltype == DTYPE_TOWN && tile.HasFlag(AutomapTile::Flags::Dirt))
-		|| (tile.HasFlag(AutomapTile::Flags::Dirt)
-	    && (tile.type != AutomapTile::Types::None
-	        || swTile.type != AutomapTile::Types::None
-	        || sTile.type != AutomapTile::Types::None
-	        || seTile.type != AutomapTile::Types::None
-	        || IsAnyOf(nwTile.type, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveVertical, AutomapTile::Types::CaveVerticalCross, AutomapTile::Types::CaveVerticalWallLava, AutomapTile::Types::CaveVerticalWoodCross)
-	        || IsAnyOf(nTile.type, AutomapTile::Types::CaveCross)
-	        || IsAnyOf(neTile.type, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveHorizontal, AutomapTile::Types::CaveHorizontalCross, AutomapTile::Types::CaveHorizontalWallLava, AutomapTile::Types::CaveHorizontalWoodCross)
-	        || IsAnyOf(wTile.type, AutomapTile::Types::CaveVerticalCross)
-	        || IsAnyOf(eTile.type, AutomapTile::Types::CaveHorizontalCross)))) {
+	    || (tile.HasFlag(AutomapTile::Flags::Dirt)
+	        && (tile.type != AutomapTile::Types::None
+	            || swTile.type != AutomapTile::Types::None
+	            || sTile.type != AutomapTile::Types::None
+	            || seTile.type != AutomapTile::Types::None
+	            || IsAnyOf(nwTile.type, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveVertical, AutomapTile::Types::CaveVerticalCross, AutomapTile::Types::CaveVerticalWallLava, AutomapTile::Types::CaveVerticalWoodCross)
+	            || IsAnyOf(nTile.type, AutomapTile::Types::CaveCross)
+	            || IsAnyOf(neTile.type, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveHorizontal, AutomapTile::Types::CaveHorizontalCross, AutomapTile::Types::CaveHorizontalWallLava, AutomapTile::Types::CaveHorizontalWoodCross)
+	            || IsAnyOf(wTile.type, AutomapTile::Types::CaveVerticalCross)
+	            || IsAnyOf(eTile.type, AutomapTile::Types::CaveHorizontalCross)))) {
 		DrawDirt(out, center, nwTile, neTile, colorDim);
 	}
 
@@ -1410,101 +1410,98 @@ void InitAutomap()
 
 	if (IsAnyOf(leveltype, DTYPE_CATACOMBS)) {
 		tileTypes[41] = { AutomapTile::Types::FenceHorizontal };
-	}
-	if (IsAnyOf(leveltype, DTYPE_TOWN, DTYPE_CAVES, DTYPE_NEST)) {
+	} else if (IsAnyOf(leveltype, DTYPE_TOWN, DTYPE_CAVES, DTYPE_NEST)) {
 		tileTypes[4] = { AutomapTile::Types::CaveBottomCorner };
 		tileTypes[12] = { AutomapTile::Types::CaveRightCorner };
 		tileTypes[13] = { AutomapTile::Types::CaveLeftCorner };
-	}
-	if (IsAnyOf(leveltype, DTYPE_CAVES)) {
-		tileTypes[129] = { AutomapTile::Types::CaveHorizontalWoodCross };
-		tileTypes[131] = { AutomapTile::Types::CaveHorizontalWoodCross };
-		tileTypes[133] = { AutomapTile::Types::CaveHorizontalWood };
-		tileTypes[135] = { AutomapTile::Types::CaveHorizontalWood };
-		tileTypes[150] = { AutomapTile::Types::CaveHorizontalWood };
-		tileTypes[145] = { AutomapTile::Types::CaveHorizontalWood, AutomapTile::Flags::VerticalDoor };
-		tileTypes[147] = { AutomapTile::Types::CaveHorizontalWood, AutomapTile::Flags::VerticalDoor };
-		tileTypes[130] = { AutomapTile::Types::CaveVerticalWoodCross };
-		tileTypes[132] = { AutomapTile::Types::CaveVerticalWoodCross };
-		tileTypes[134] = { AutomapTile::Types::CaveVerticalWood };
-		tileTypes[136] = { AutomapTile::Types::CaveVerticalWood };
-		tileTypes[151] = { AutomapTile::Types::CaveVerticalWood };
-		tileTypes[146] = { AutomapTile::Types::CaveVerticalWood, AutomapTile::Flags::HorizontalDoor };
-		tileTypes[148] = { AutomapTile::Types::CaveVerticalWood, AutomapTile::Flags::HorizontalDoor };
-		tileTypes[137] = { AutomapTile::Types::CaveWoodCross };
-		tileTypes[140] = { AutomapTile::Types::CaveWoodCross };
-		tileTypes[141] = { AutomapTile::Types::CaveWoodCross };
-		tileTypes[142] = { AutomapTile::Types::CaveWoodCross };
-		tileTypes[138] = { AutomapTile::Types::CaveRightWoodCross };
-		tileTypes[139] = { AutomapTile::Types::CaveLeftWoodCross };
-		tileTypes[14] = { AutomapTile::Types::HorizontalLavaThin };
-		tileTypes[15] = { AutomapTile::Types::HorizontalLavaThin };
-		tileTypes[16] = { AutomapTile::Types::VerticalLavaThin };
-		tileTypes[17] = { AutomapTile::Types::VerticalLavaThin };
-		tileTypes[18] = { AutomapTile::Types::BendSouthLavaThin };
-		tileTypes[19] = { AutomapTile::Types::BendWestLavaThin };
-		tileTypes[20] = { AutomapTile::Types::BendEastLavaThin };
-		tileTypes[21] = { AutomapTile::Types::BendNorthLavaThin };
-		tileTypes[22] = { AutomapTile::Types::VerticalWallLava };
-		tileTypes[23] = { AutomapTile::Types::HorizontalWallLava };
-		tileTypes[24] = { AutomapTile::Types::SELava };
-		tileTypes[25] = { AutomapTile::Types::SWLava };
-		tileTypes[26] = { AutomapTile::Types::NELava };
-		tileTypes[27] = { AutomapTile::Types::NWLava };
-		tileTypes[28] = { AutomapTile::Types::SLava };
-		tileTypes[29] = { AutomapTile::Types::WLava };
-		tileTypes[30] = { AutomapTile::Types::ELava };
-		tileTypes[31] = { AutomapTile::Types::NLava };
-		tileTypes[32] = { AutomapTile::Types::Lava };
-		tileTypes[33] = { AutomapTile::Types::Lava };
-		tileTypes[34] = { AutomapTile::Types::Lava };
-		tileTypes[35] = { AutomapTile::Types::Lava };
-		tileTypes[36] = { AutomapTile::Types::Lava };
-		tileTypes[37] = { AutomapTile::Types::Lava };
-		tileTypes[38] = { AutomapTile::Types::Lava };
-		tileTypes[39] = { AutomapTile::Types::Lava };
-		tileTypes[40] = { AutomapTile::Types::Lava };
-		tileTypes[41] = { AutomapTile::Types::CaveHorizontalWallLava };
-		tileTypes[42] = { AutomapTile::Types::CaveVerticalWallLava };
-		tileTypes[43] = { AutomapTile::Types::HorizontalBridgeLava };
-		tileTypes[44] = { AutomapTile::Types::VerticalBridgeLava };
-	}
-	if (IsAnyOf(leveltype, DTYPE_NEST)) {
-		tileTypes[102] = { AutomapTile::Types::HorizontalLavaThin };
-		tileTypes[103] = { AutomapTile::Types::HorizontalLavaThin };
-		tileTypes[108] = { AutomapTile::Types::HorizontalLavaThin };
-		tileTypes[104] = { AutomapTile::Types::VerticalLavaThin };
-		tileTypes[105] = { AutomapTile::Types::VerticalLavaThin };
-		tileTypes[107] = { AutomapTile::Types::VerticalLavaThin };
-		tileTypes[112] = { AutomapTile::Types::BendSouthLavaThin };
-		tileTypes[113] = { AutomapTile::Types::BendWestLavaThin };
-		tileTypes[110] = { AutomapTile::Types::BendEastLavaThin };
-		tileTypes[111] = { AutomapTile::Types::BendNorthLavaThin };
-		tileTypes[134] = { AutomapTile::Types::VerticalWallLava };
-		tileTypes[135] = { AutomapTile::Types::HorizontalWallLava };
-		tileTypes[118] = { AutomapTile::Types::SELava };
-		tileTypes[119] = { AutomapTile::Types::SWLava };
-		tileTypes[120] = { AutomapTile::Types::NELava };
-		tileTypes[121] = { AutomapTile::Types::NWLava };
-		tileTypes[106] = { AutomapTile::Types::SLava };
-		tileTypes[114] = { AutomapTile::Types::WLava };
-		tileTypes[130] = { AutomapTile::Types::ELava };
-		tileTypes[122] = { AutomapTile::Types::NLava };
-		tileTypes[117] = { AutomapTile::Types::Lava };
-		tileTypes[124] = { AutomapTile::Types::Lava };
-		tileTypes[126] = { AutomapTile::Types::Lava };
-		tileTypes[127] = { AutomapTile::Types::Lava };
-		tileTypes[128] = { AutomapTile::Types::Lava };
-		tileTypes[129] = { AutomapTile::Types::Lava };
-		tileTypes[131] = { AutomapTile::Types::Lava };
-		tileTypes[132] = { AutomapTile::Types::Lava };
-		tileTypes[133] = { AutomapTile::Types::Lava };
-		tileTypes[136] = { AutomapTile::Types::CaveHorizontalWallLava };
-		tileTypes[137] = { AutomapTile::Types::CaveVerticalWallLava };
-		tileTypes[115] = { AutomapTile::Types::HorizontalBridgeLava };
-		tileTypes[116] = { AutomapTile::Types::VerticalBridgeLava };
-	}
-	if (IsAnyOf(leveltype, DTYPE_HELL)) {
+		if (IsAnyOf(leveltype, DTYPE_CAVES)) {
+			tileTypes[129] = { AutomapTile::Types::CaveHorizontalWoodCross };
+			tileTypes[131] = { AutomapTile::Types::CaveHorizontalWoodCross };
+			tileTypes[133] = { AutomapTile::Types::CaveHorizontalWood };
+			tileTypes[135] = { AutomapTile::Types::CaveHorizontalWood };
+			tileTypes[150] = { AutomapTile::Types::CaveHorizontalWood };
+			tileTypes[145] = { AutomapTile::Types::CaveHorizontalWood, AutomapTile::Flags::VerticalDoor };
+			tileTypes[147] = { AutomapTile::Types::CaveHorizontalWood, AutomapTile::Flags::VerticalDoor };
+			tileTypes[130] = { AutomapTile::Types::CaveVerticalWoodCross };
+			tileTypes[132] = { AutomapTile::Types::CaveVerticalWoodCross };
+			tileTypes[134] = { AutomapTile::Types::CaveVerticalWood };
+			tileTypes[136] = { AutomapTile::Types::CaveVerticalWood };
+			tileTypes[151] = { AutomapTile::Types::CaveVerticalWood };
+			tileTypes[146] = { AutomapTile::Types::CaveVerticalWood, AutomapTile::Flags::HorizontalDoor };
+			tileTypes[148] = { AutomapTile::Types::CaveVerticalWood, AutomapTile::Flags::HorizontalDoor };
+			tileTypes[137] = { AutomapTile::Types::CaveWoodCross };
+			tileTypes[140] = { AutomapTile::Types::CaveWoodCross };
+			tileTypes[141] = { AutomapTile::Types::CaveWoodCross };
+			tileTypes[142] = { AutomapTile::Types::CaveWoodCross };
+			tileTypes[138] = { AutomapTile::Types::CaveRightWoodCross };
+			tileTypes[139] = { AutomapTile::Types::CaveLeftWoodCross };
+			tileTypes[14] = { AutomapTile::Types::HorizontalLavaThin };
+			tileTypes[15] = { AutomapTile::Types::HorizontalLavaThin };
+			tileTypes[16] = { AutomapTile::Types::VerticalLavaThin };
+			tileTypes[17] = { AutomapTile::Types::VerticalLavaThin };
+			tileTypes[18] = { AutomapTile::Types::BendSouthLavaThin };
+			tileTypes[19] = { AutomapTile::Types::BendWestLavaThin };
+			tileTypes[20] = { AutomapTile::Types::BendEastLavaThin };
+			tileTypes[21] = { AutomapTile::Types::BendNorthLavaThin };
+			tileTypes[22] = { AutomapTile::Types::VerticalWallLava };
+			tileTypes[23] = { AutomapTile::Types::HorizontalWallLava };
+			tileTypes[24] = { AutomapTile::Types::SELava };
+			tileTypes[25] = { AutomapTile::Types::SWLava };
+			tileTypes[26] = { AutomapTile::Types::NELava };
+			tileTypes[27] = { AutomapTile::Types::NWLava };
+			tileTypes[28] = { AutomapTile::Types::SLava };
+			tileTypes[29] = { AutomapTile::Types::WLava };
+			tileTypes[30] = { AutomapTile::Types::ELava };
+			tileTypes[31] = { AutomapTile::Types::NLava };
+			tileTypes[32] = { AutomapTile::Types::Lava };
+			tileTypes[33] = { AutomapTile::Types::Lava };
+			tileTypes[34] = { AutomapTile::Types::Lava };
+			tileTypes[35] = { AutomapTile::Types::Lava };
+			tileTypes[36] = { AutomapTile::Types::Lava };
+			tileTypes[37] = { AutomapTile::Types::Lava };
+			tileTypes[38] = { AutomapTile::Types::Lava };
+			tileTypes[39] = { AutomapTile::Types::Lava };
+			tileTypes[40] = { AutomapTile::Types::Lava };
+			tileTypes[41] = { AutomapTile::Types::CaveHorizontalWallLava };
+			tileTypes[42] = { AutomapTile::Types::CaveVerticalWallLava };
+			tileTypes[43] = { AutomapTile::Types::HorizontalBridgeLava };
+			tileTypes[44] = { AutomapTile::Types::VerticalBridgeLava };
+		} else if (IsAnyOf(leveltype, DTYPE_NEST)) {
+			tileTypes[102] = { AutomapTile::Types::HorizontalLavaThin };
+			tileTypes[103] = { AutomapTile::Types::HorizontalLavaThin };
+			tileTypes[108] = { AutomapTile::Types::HorizontalLavaThin };
+			tileTypes[104] = { AutomapTile::Types::VerticalLavaThin };
+			tileTypes[105] = { AutomapTile::Types::VerticalLavaThin };
+			tileTypes[107] = { AutomapTile::Types::VerticalLavaThin };
+			tileTypes[112] = { AutomapTile::Types::BendSouthLavaThin };
+			tileTypes[113] = { AutomapTile::Types::BendWestLavaThin };
+			tileTypes[110] = { AutomapTile::Types::BendEastLavaThin };
+			tileTypes[111] = { AutomapTile::Types::BendNorthLavaThin };
+			tileTypes[134] = { AutomapTile::Types::VerticalWallLava };
+			tileTypes[135] = { AutomapTile::Types::HorizontalWallLava };
+			tileTypes[118] = { AutomapTile::Types::SELava };
+			tileTypes[119] = { AutomapTile::Types::SWLava };
+			tileTypes[120] = { AutomapTile::Types::NELava };
+			tileTypes[121] = { AutomapTile::Types::NWLava };
+			tileTypes[106] = { AutomapTile::Types::SLava };
+			tileTypes[114] = { AutomapTile::Types::WLava };
+			tileTypes[130] = { AutomapTile::Types::ELava };
+			tileTypes[122] = { AutomapTile::Types::NLava };
+			tileTypes[117] = { AutomapTile::Types::Lava };
+			tileTypes[124] = { AutomapTile::Types::Lava };
+			tileTypes[126] = { AutomapTile::Types::Lava };
+			tileTypes[127] = { AutomapTile::Types::Lava };
+			tileTypes[128] = { AutomapTile::Types::Lava };
+			tileTypes[129] = { AutomapTile::Types::Lava };
+			tileTypes[131] = { AutomapTile::Types::Lava };
+			tileTypes[132] = { AutomapTile::Types::Lava };
+			tileTypes[133] = { AutomapTile::Types::Lava };
+			tileTypes[136] = { AutomapTile::Types::CaveHorizontalWallLava };
+			tileTypes[137] = { AutomapTile::Types::CaveVerticalWallLava };
+			tileTypes[115] = { AutomapTile::Types::HorizontalBridgeLava };
+			tileTypes[116] = { AutomapTile::Types::VerticalBridgeLava };
+		}
+	} else if (IsAnyOf(leveltype, DTYPE_HELL)) {
 		tileTypes[51] = { AutomapTile::Types::VerticalDiamond };
 		tileTypes[55] = { AutomapTile::Types::HorizontalDiamond };
 	}

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -711,8 +711,10 @@ void DrawCaveWallConnections(const Surface &out, Point center, AutomapTile sTile
 		dirtFill2 = true;
 	}
 
-	if (sTile.HasFlag(AutomapTile::Flags::Dirt) || (sTile.type != AutomapTile::Types::None && dirtFill1 && dirtFill2))
-		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), colorDim);
+	if (sTile.HasFlag(AutomapTile::Flags::Dirt) || (sTile.type != AutomapTile::Types::None && dirtFill1 && dirtFill2)) {
+		if (leveltype != DTYPE_TOWN)
+			out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), colorDim);
+	}
 }
 
 /**
@@ -736,7 +738,7 @@ void DrawCaveHorizontal(const Surface &out, Point center, AutomapTile tile, uint
 			h = AmHeightOffset::QuarterTileUp;
 			l = AmLineLength::FullAndHalfTile;
 		}
-		if (!(IsAnyOf(tile.type, AutomapTile::Types::CaveHorizontalWood, AutomapTile::Types::CaveHorizontalWoodCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveLeftWoodCross))) {
+		if (leveltype != DTYPE_TOWN && !(IsAnyOf(tile.type, AutomapTile::Types::CaveHorizontalWood, AutomapTile::Types::CaveHorizontalWoodCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveLeftWoodCross))) {
 			out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), colorDim);
 			out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), colorDim);
 			out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), colorDim);
@@ -764,7 +766,7 @@ void DrawCaveVertical(const Surface &out, Point center, AutomapTile tile, uint8_
 		} else {
 			l = AmLineLength::FullAndHalfTile;
 		}
-		if (!(IsAnyOf(tile.type, AutomapTile::Types::CaveVerticalWood, AutomapTile::Types::CaveVerticalWoodCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross))) {
+		if (leveltype != DTYPE_TOWN && !(IsAnyOf(tile.type, AutomapTile::Types::CaveVerticalWood, AutomapTile::Types::CaveVerticalWoodCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross))) {
 			out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), colorDim);
 			out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), colorDim);
 			out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), colorDim);
@@ -907,7 +909,7 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 	AutomapTile sTile = GetAutomapTypeView(map + Displacement { 1, 1 });
 
 	if (!noConnect) {
-		if (IsAnyOf(leveltype, DTYPE_CAVES, DTYPE_NEST)) {
+		if (IsAnyOf(leveltype, DTYPE_TOWN, DTYPE_CAVES, DTYPE_NEST)) {
 			DrawCaveWallConnections(out, center, sTile, swTile, seTile, colorDim);
 		}
 		DrawWallConnections(out, center, nwTile, neTile, colorBright, colorDim);
@@ -1313,7 +1315,7 @@ void InitAutomap()
 	for (unsigned i = 0; i < tileCount; i++) {
 		AutomapTile tempTileType = tileTypes[i];
 
-		if (IsAnyOf(leveltype, DTYPE_CAVES, DTYPE_NEST)) {
+		if (IsAnyOf(leveltype, DTYPE_TOWN, DTYPE_CAVES, DTYPE_NEST)) {
 			switch (i + 1) {
 			case 5:
 				tempTileType = { AutomapTile::Types::CaveBottomCorner };

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -81,27 +81,6 @@ struct AutomapTile {
 		CaveWoodCross,
 		CaveRightWoodCross,
 		CaveLeftWoodCross,
-		HorizontalLavaThin, // unused
-		VerticalLavaThin,   // unused
-		BendSouthLavaThin,  // unused
-		BendWestLavaThin,   // unused
-		BendEastLavaThin,   // unused
-		BendNorthLavaThin,  // unused
-		VerticalWallLava,
-		HorizontalWallLava,
-		SELava, // unused
-		SWLava, // unused
-		NELava, // unused
-		NWLava, // unused
-		SLava,  // unused
-		WLava,  // unused
-		ELava,  // unused
-		NLava,  // unused
-		Lava,   // unused
-		CaveHorizontalWallLava,
-		CaveVerticalWallLava,
-		HorizontalBridgeLava, // unused
-		VerticalBridgeLava,   // unused
 		VerticalDiamond,
 		HorizontalDiamond,
 	};
@@ -505,11 +484,11 @@ void FixVerticalDoor(const Surface &out, Point center, AutomapTile neTile, uint8
  */
 void DrawWallConnections(const Surface &out, Point center, AutomapTile nwTile, AutomapTile neTile, uint8_t colorBright, uint8_t colorDim)
 {
-	if (IsAnyOf(nwTile.type, AutomapTile::Types::HorizontalWallLava, AutomapTile::Types::Horizontal, AutomapTile::Types::HorizontalDiamond, AutomapTile::Types::FenceHorizontal, AutomapTile::Types::Cross, AutomapTile::Types::CaveVerticalWoodCross, AutomapTile::Types::CaveRightCorner)) {
+	if (IsAnyOf(nwTile.type, AutomapTile::Types::Horizontal, AutomapTile::Types::HorizontalDiamond, AutomapTile::Types::FenceHorizontal, AutomapTile::Types::Cross, AutomapTile::Types::CaveVerticalWoodCross, AutomapTile::Types::CaveRightCorner)) {
 		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileUp), AmLine(AmLineLength::HalfTile), colorDim);
 		FixHorizontalDoor(out, center, nwTile, colorBright);
 	}
-	if (IsAnyOf(neTile.type, AutomapTile::Types::VerticalWallLava, AutomapTile::Types::Vertical, AutomapTile::Types::VerticalDiamond, AutomapTile::Types::FenceVertical, AutomapTile::Types::Cross, AutomapTile::Types::CaveHorizontalWoodCross, AutomapTile::Types::CaveLeftCorner)) {
+	if (IsAnyOf(neTile.type, AutomapTile::Types::Vertical, AutomapTile::Types::VerticalDiamond, AutomapTile::Types::FenceVertical, AutomapTile::Types::Cross, AutomapTile::Types::CaveHorizontalWoodCross, AutomapTile::Types::CaveLeftCorner)) {
 		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::HalfTile), colorDim);
 		FixVerticalDoor(out, center, neTile, colorBright);
 	}
@@ -601,10 +580,10 @@ void DrawCorner(const Surface &out, Point center, AutomapTile nwTile, AutomapTil
  */
 void DrawCaveWallConnections(const Surface &out, Point center, AutomapTile sTile, AutomapTile swTile, AutomapTile seTile, uint8_t colorDim)
 {
-	if (IsAnyOf(swTile.type, AutomapTile::Types::CaveVerticalWallLava, AutomapTile::Types::CaveVertical, AutomapTile::Types::CaveVerticalWood, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross, AutomapTile::Types::CaveLeftWoodCross, AutomapTile::Types::CaveRightCorner)) {
+	if (IsAnyOf(swTile.type, AutomapTile::Types::CaveVertical, AutomapTile::Types::CaveVerticalWood, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross, AutomapTile::Types::CaveLeftWoodCross, AutomapTile::Types::CaveRightCorner)) {
 		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), AmLine(AmLineLength::HalfTile), colorDim);
 	}
-	if (IsAnyOf(seTile.type, AutomapTile::Types::CaveHorizontalWallLava, AutomapTile::Types::CaveHorizontal, AutomapTile::Types::CaveHorizontalWood, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross, AutomapTile::Types::CaveLeftWoodCross, AutomapTile::Types::CaveLeftCorner)) {
+	if (IsAnyOf(seTile.type, AutomapTile::Types::CaveHorizontal, AutomapTile::Types::CaveHorizontalWood, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross, AutomapTile::Types::CaveLeftWoodCross, AutomapTile::Types::CaveLeftCorner)) {
 		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), AmLine(AmLineLength::HalfTile), colorDim);
 	}
 }
@@ -807,9 +786,9 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 	            || swTile.type != AutomapTile::Types::None
 	            || sTile.type != AutomapTile::Types::None
 	            || seTile.type != AutomapTile::Types::None
-	            || IsAnyOf(nwTile.type, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveVertical, AutomapTile::Types::CaveVerticalCross, AutomapTile::Types::CaveVerticalWallLava, AutomapTile::Types::CaveLeftWoodCross)
+	            || IsAnyOf(nwTile.type, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveVertical, AutomapTile::Types::CaveVerticalCross, AutomapTile::Types::CaveLeftWoodCross)
 	            || IsAnyOf(nTile.type, AutomapTile::Types::CaveCross)
-	            || IsAnyOf(neTile.type, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveHorizontal, AutomapTile::Types::CaveHorizontalCross, AutomapTile::Types::CaveHorizontalWallLava, AutomapTile::Types::CaveRightWoodCross)
+	            || IsAnyOf(neTile.type, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveHorizontal, AutomapTile::Types::CaveHorizontalCross, AutomapTile::Types::CaveRightWoodCross)
 	            || IsAnyOf(wTile.type, AutomapTile::Types::CaveVerticalCross)
 	            || IsAnyOf(eTile.type, AutomapTile::Types::CaveHorizontalCross)))) {
 		DrawDirt(out, center, nwTile, neTile, colorDim);
@@ -922,25 +901,6 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 		break;
 	case AutomapTile::Types::RiverRightOut:
 		DrawRiverRightOut(out, center, MapColorsItem);
-		break;
-	case AutomapTile::Types::HorizontalLavaThin:
-	case AutomapTile::Types::VerticalLavaThin:
-	case AutomapTile::Types::BendSouthLavaThin:
-	case AutomapTile::Types::BendWestLavaThin:
-	case AutomapTile::Types::BendEastLavaThin:
-	case AutomapTile::Types::BendNorthLavaThin:
-		break;
-	case AutomapTile::Types::VerticalWallLava:
-		DrawVertical(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim);
-		break;
-	case AutomapTile::Types::HorizontalWallLava:
-		DrawHorizontal(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim);
-		break;
-	case AutomapTile::Types::CaveHorizontalWallLava:
-		DrawCaveHorizontal(out, center, tile, nwTile, swTile, colorBright, colorDim);
-		break;
-	case AutomapTile::Types::CaveVerticalWallLava:
-		DrawCaveVertical(out, center, tile, neTile, seTile, colorBright, colorDim);
 		break;
 	}
 }
@@ -1214,71 +1174,6 @@ void InitAutomap()
 			tileTypes[142] = { AutomapTile::Types::CaveWoodCross };
 			tileTypes[138] = { AutomapTile::Types::CaveRightWoodCross };
 			tileTypes[139] = { AutomapTile::Types::CaveLeftWoodCross };
-			tileTypes[14] = { AutomapTile::Types::HorizontalLavaThin };
-			tileTypes[15] = { AutomapTile::Types::HorizontalLavaThin };
-			tileTypes[16] = { AutomapTile::Types::VerticalLavaThin };
-			tileTypes[17] = { AutomapTile::Types::VerticalLavaThin };
-			tileTypes[18] = { AutomapTile::Types::BendSouthLavaThin };
-			tileTypes[19] = { AutomapTile::Types::BendWestLavaThin };
-			tileTypes[20] = { AutomapTile::Types::BendEastLavaThin };
-			tileTypes[21] = { AutomapTile::Types::BendNorthLavaThin };
-			tileTypes[22] = { AutomapTile::Types::VerticalWallLava };
-			tileTypes[23] = { AutomapTile::Types::HorizontalWallLava };
-			tileTypes[24] = { AutomapTile::Types::SELava };
-			tileTypes[25] = { AutomapTile::Types::SWLava };
-			tileTypes[26] = { AutomapTile::Types::NELava };
-			tileTypes[27] = { AutomapTile::Types::NWLava };
-			tileTypes[28] = { AutomapTile::Types::SLava };
-			tileTypes[29] = { AutomapTile::Types::WLava };
-			tileTypes[30] = { AutomapTile::Types::ELava };
-			tileTypes[31] = { AutomapTile::Types::NLava };
-			tileTypes[32] = { AutomapTile::Types::Lava };
-			tileTypes[33] = { AutomapTile::Types::Lava };
-			tileTypes[34] = { AutomapTile::Types::Lava };
-			tileTypes[35] = { AutomapTile::Types::Lava };
-			tileTypes[36] = { AutomapTile::Types::Lava };
-			tileTypes[37] = { AutomapTile::Types::Lava };
-			tileTypes[38] = { AutomapTile::Types::Lava };
-			tileTypes[39] = { AutomapTile::Types::Lava };
-			tileTypes[40] = { AutomapTile::Types::Lava };
-			tileTypes[41] = { AutomapTile::Types::CaveHorizontalWallLava };
-			tileTypes[42] = { AutomapTile::Types::CaveVerticalWallLava };
-			tileTypes[43] = { AutomapTile::Types::HorizontalBridgeLava };
-			tileTypes[44] = { AutomapTile::Types::VerticalBridgeLava };
-		} else if (IsAnyOf(leveltype, DTYPE_NEST)) {
-			tileTypes[102] = { AutomapTile::Types::HorizontalLavaThin };
-			tileTypes[103] = { AutomapTile::Types::HorizontalLavaThin };
-			tileTypes[108] = { AutomapTile::Types::HorizontalLavaThin };
-			tileTypes[104] = { AutomapTile::Types::VerticalLavaThin };
-			tileTypes[105] = { AutomapTile::Types::VerticalLavaThin };
-			tileTypes[107] = { AutomapTile::Types::VerticalLavaThin };
-			tileTypes[112] = { AutomapTile::Types::BendSouthLavaThin };
-			tileTypes[113] = { AutomapTile::Types::BendWestLavaThin };
-			tileTypes[110] = { AutomapTile::Types::BendEastLavaThin };
-			tileTypes[111] = { AutomapTile::Types::BendNorthLavaThin };
-			tileTypes[134] = { AutomapTile::Types::VerticalWallLava };
-			tileTypes[135] = { AutomapTile::Types::HorizontalWallLava };
-			tileTypes[118] = { AutomapTile::Types::SELava };
-			tileTypes[119] = { AutomapTile::Types::SWLava };
-			tileTypes[120] = { AutomapTile::Types::NELava };
-			tileTypes[121] = { AutomapTile::Types::NWLava };
-			tileTypes[106] = { AutomapTile::Types::SLava };
-			tileTypes[114] = { AutomapTile::Types::WLava };
-			tileTypes[130] = { AutomapTile::Types::ELava };
-			tileTypes[122] = { AutomapTile::Types::NLava };
-			tileTypes[117] = { AutomapTile::Types::Lava };
-			tileTypes[124] = { AutomapTile::Types::Lava };
-			tileTypes[126] = { AutomapTile::Types::Lava };
-			tileTypes[127] = { AutomapTile::Types::Lava };
-			tileTypes[128] = { AutomapTile::Types::Lava };
-			tileTypes[129] = { AutomapTile::Types::Lava };
-			tileTypes[131] = { AutomapTile::Types::Lava };
-			tileTypes[132] = { AutomapTile::Types::Lava };
-			tileTypes[133] = { AutomapTile::Types::Lava };
-			tileTypes[136] = { AutomapTile::Types::CaveHorizontalWallLava };
-			tileTypes[137] = { AutomapTile::Types::CaveVerticalWallLava };
-			tileTypes[115] = { AutomapTile::Types::HorizontalBridgeLava };
-			tileTypes[116] = { AutomapTile::Types::VerticalBridgeLava };
 		}
 		break;
 	case DTYPE_HELL:

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -656,10 +656,10 @@ void DrawHorizontal(const Surface &out, Point center, AutomapTile tile, AutomapT
 	AmLineLength l = AmLineLength::FullAndHalfTile;
 
 	// Draw a diamond in the top tile
-	if (neTile.hasAnyFlag(AutomapTile::Flags::VerticalArch, AutomapTile::Flags::VerticalGrate) // NE tile has an arch, so add a diamond for visual consistency
-	    || nwTile.hasAnyFlag(AutomapTile::Flags::HorizontalArch, AutomapTile::Flags::HorizontalGrate) // NW tile has an arch, so add a diamond for visual consistency
+	if (neTile.hasAnyFlag(AutomapTile::Flags::VerticalArch, AutomapTile::Flags::VerticalGrate)                                                                           // NE tile has an arch, so add a diamond for visual consistency
+	    || nwTile.hasAnyFlag(AutomapTile::Flags::HorizontalArch, AutomapTile::Flags::HorizontalGrate)                                                                    // NW tile has an arch, so add a diamond for visual consistency
 	    || tile.hasAnyFlag(AutomapTile::Flags::VerticalArch, AutomapTile::Flags::HorizontalArch, AutomapTile::Flags::VerticalGrate, AutomapTile::Flags::HorizontalGrate) // Current tile has an arch, add a diamond
-	    || tile.type == AutomapTile::Types::HorizontalDiamond) { // wall ending in hell that should end with a diamond
+	    || tile.type == AutomapTile::Types::HorizontalDiamond) {                                                                                                         // wall ending in hell that should end with a diamond
 		w = AmWidthOffset::QuarterTileRight;
 		h = AmHeightOffset::QuarterTileUp;
 		l = AmLineLength::FullTile; // shorten line to avoid overdraw
@@ -695,11 +695,11 @@ void DrawVertical(const Surface &out, Point center, AutomapTile tile, AutomapTil
 	AmLineLength l = AmLineLength::FullAndHalfTile;
 
 	// Draw a diamond in the top tile
-	if (neTile.hasAnyFlag(AutomapTile::Flags::VerticalArch, AutomapTile::Flags::VerticalGrate) // NE tile has an arch, so add a diamond for visual consistency
-	    || nwTile.hasAnyFlag(AutomapTile::Flags::HorizontalArch, AutomapTile::Flags::HorizontalGrate) // NW tile has an arch, so add a diamond for visual consistency
+	if (neTile.hasAnyFlag(AutomapTile::Flags::VerticalArch, AutomapTile::Flags::VerticalGrate)                                                                           // NE tile has an arch, so add a diamond for visual consistency
+	    || nwTile.hasAnyFlag(AutomapTile::Flags::HorizontalArch, AutomapTile::Flags::HorizontalGrate)                                                                    // NW tile has an arch, so add a diamond for visual consistency
 	    || tile.hasAnyFlag(AutomapTile::Flags::VerticalArch, AutomapTile::Flags::HorizontalArch, AutomapTile::Flags::VerticalGrate, AutomapTile::Flags::HorizontalGrate) // Current tile has an arch, add a diamond
-	    || tile.type == AutomapTile::Types::VerticalDiamond) { // wall ending in hell that should end with a diamond
-		l = AmLineLength::FullTile;                            // shorten line to avoid overdraw
+	    || tile.type == AutomapTile::Types::VerticalDiamond) {                                                                                                           // wall ending in hell that should end with a diamond
+		l = AmLineLength::FullTile;                                                                                                                                      // shorten line to avoid overdraw
 		DrawDiamond(out, center, colorDim);
 		FixVerticalDoor(out, center, nwTile, colorBright);
 	}
@@ -1396,9 +1396,13 @@ void InitAutomap()
 	size_t tileCount = 0;
 	std::unique_ptr<AutomapTile[]> tileTypes = LoadAutomapData(tileCount);
 
-	if (IsAnyOf(leveltype, DTYPE_CATACOMBS)) {
+	switch (leveltype) {
+	case DTYPE_CATACOMBS:
 		tileTypes[41] = { AutomapTile::Types::FenceHorizontal };
-	} else if (IsAnyOf(leveltype, DTYPE_TOWN, DTYPE_CAVES, DTYPE_NEST)) {
+		break;
+	case DTYPE_TOWN: // Town automap uses a dun file that contains caves tileset
+	case DTYPE_CAVES:
+	case DTYPE_NEST:
 		tileTypes[4] = { AutomapTile::Types::CaveBottomCorner };
 		tileTypes[12] = { AutomapTile::Types::CaveRightCorner };
 		tileTypes[13] = { AutomapTile::Types::CaveLeftCorner };
@@ -1489,9 +1493,11 @@ void InitAutomap()
 			tileTypes[115] = { AutomapTile::Types::HorizontalBridgeLava };
 			tileTypes[116] = { AutomapTile::Types::VerticalBridgeLava };
 		}
-	} else if (IsAnyOf(leveltype, DTYPE_HELL)) {
+		break;
+	case DTYPE_HELL:
 		tileTypes[51] = { AutomapTile::Types::VerticalDiamond };
 		tileTypes[55] = { AutomapTile::Types::HorizontalDiamond };
+		break;
 	}
 	for (unsigned i = 0; i < tileCount; i++) {
 		AutomapTypeTiles[i + 1] = tileTypes[i];

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -924,15 +924,10 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 		DrawRiverRightOut(out, center, MapColorsItem);
 		break;
 	case AutomapTile::Types::HorizontalLavaThin:
-		break;
 	case AutomapTile::Types::VerticalLavaThin:
-		break;
 	case AutomapTile::Types::BendSouthLavaThin:
-		break;
 	case AutomapTile::Types::BendWestLavaThin:
-		break;
 	case AutomapTile::Types::BendEastLavaThin:
-		break;
 	case AutomapTile::Types::BendNorthLavaThin:
 		break;
 	case AutomapTile::Types::VerticalWallLava:

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -800,7 +800,7 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 
 	if (!noConnect) {
 		if (IsAnyOf(leveltype, DTYPE_TOWN, DTYPE_CAVES, DTYPE_NEST)) {
-			DrawCaveWallConnections(out, center, sTile, swTile, seTile, colorDim);
+			DrawCaveWallConnections(out, center, swTile, seTile, colorDim);
 		}
 		DrawWallConnections(out, center, nwTile, neTile, colorBright, colorDim);
 	}

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -848,177 +848,6 @@ AutomapTile GetAutomapTypeView(Point map)
 		return {};
 	}
 
-	// TODO: Patch AMP data directly instead of the following
-	uint8_t tile = dungeon[map.x][map.y];
-	// This tile incorrectly has flags for both HorizontalArch and VerticalArch in the amp data
-	if (leveltype == DTYPE_CATACOMBS && tile == 42)
-		return { AutomapTile::Types::Cross, AutomapTile::Flags::VerticalArch };
-	if (IsAnyOf(leveltype, DTYPE_CAVES, DTYPE_NEST)) {
-		switch (tile) {
-		case 5:
-			return { AutomapTile::Types::CaveBottomCorner };
-		case 13:
-			return { AutomapTile::Types::CaveRightCorner };
-		case 14:
-			return { AutomapTile::Types::CaveLeftCorner };
-		}
-	}
-	if (IsAnyOf(leveltype, DTYPE_CAVES)) {
-		switch (tile) {
-		case 130:
-		case 132:
-			return { AutomapTile::Types::CaveHorizontalWoodCross };
-		case 134:
-		case 136:
-		case 151:
-			return { AutomapTile::Types::CaveHorizontalWood };
-		case 146:
-		case 148:
-			return { AutomapTile::Types::CaveHorizontalWood, AutomapTile::Flags::VerticalDoor };
-		case 131:
-		case 133:
-			return { AutomapTile::Types::CaveVerticalWoodCross };
-		case 135:
-		case 137:
-		case 152:
-			return { AutomapTile::Types::CaveVerticalWood };
-		case 147:
-		case 149:
-			return { AutomapTile::Types::CaveVerticalWood, AutomapTile::Flags::HorizontalDoor };
-		case 138:
-		case 141:
-		case 142:
-		case 143:
-			return { AutomapTile::Types::CaveWoodCross };
-		case 139:
-			return { AutomapTile::Types::CaveRightWoodCross };
-		case 140:
-			return { AutomapTile::Types::CaveLeftWoodCross };
-		case 15:
-		case 16:
-			return { AutomapTile::Types::HorizontalLavaThin };
-		case 17:
-		case 18:
-			return { AutomapTile::Types::VerticalLavaThin };
-		case 19:
-			return { AutomapTile::Types::BendSouthLavaThin };
-		case 20:
-			return { AutomapTile::Types::BendWestLavaThin };
-		case 21:
-			return { AutomapTile::Types::BendEastLavaThin };
-		case 22:
-			return { AutomapTile::Types::BendNorthLavaThin };
-		case 23:
-			return { AutomapTile::Types::VerticalWallLava };
-		case 24:
-			return { AutomapTile::Types::HorizontalWallLava };
-		case 25:
-			return { AutomapTile::Types::SELava };
-		case 26:
-			return { AutomapTile::Types::SWLava };
-		case 27:
-			return { AutomapTile::Types::NELava };
-		case 28:
-			return { AutomapTile::Types::NWLava };
-		case 29:
-			return { AutomapTile::Types::SLava };
-		case 30:
-			return { AutomapTile::Types::WLava };
-		case 31:
-			return { AutomapTile::Types::ELava };
-		case 32:
-			return { AutomapTile::Types::NLava };
-		case 33:
-		case 34:
-		case 35:
-		case 36:
-		case 37:
-		case 38:
-		case 39:
-		case 40:
-		case 41:
-			return { AutomapTile::Types::Lava };
-		case 42:
-			return { AutomapTile::Types::CaveHorizontalWallLava };
-		case 43:
-			return { AutomapTile::Types::CaveVerticalWallLava };
-		case 44:
-			return { AutomapTile::Types::HorizontalBridgeLava };
-		case 45:
-			return { AutomapTile::Types::VerticalBridgeLava };
-		}
-	}
-	if (IsAnyOf(leveltype, DTYPE_NEST)) {
-		switch (tile) {
-		case 103:
-		case 104:
-		case 109:
-			return { AutomapTile::Types::HorizontalLavaThin };
-		case 105:
-		case 106:
-		case 108:
-			return { AutomapTile::Types::VerticalLavaThin };
-		case 113:
-			return { AutomapTile::Types::BendSouthLavaThin };
-		case 114:
-			return { AutomapTile::Types::BendWestLavaThin };
-		case 111:
-			return { AutomapTile::Types::BendEastLavaThin };
-		case 112:
-			return { AutomapTile::Types::BendNorthLavaThin };
-		case 135:
-			return { AutomapTile::Types::VerticalWallLava };
-		case 136:
-			return { AutomapTile::Types::HorizontalWallLava };
-		case 119:
-			return { AutomapTile::Types::SELava };
-		case 120:
-			return { AutomapTile::Types::SWLava };
-		case 121:
-			return { AutomapTile::Types::NELava };
-		case 122:
-			return { AutomapTile::Types::NWLava };
-		case 107:
-			return { AutomapTile::Types::SLava };
-		case 115:
-			return { AutomapTile::Types::WLava };
-		case 131:
-			return { AutomapTile::Types::ELava };
-		case 123:
-			return { AutomapTile::Types::NLava };
-		//case 110:
-		//case 124:
-		//case 126:
-		//case 145:
-		case 118:
-		case 125:
-		case 127:
-		case 128:
-		case 129:
-		case 130:
-		case 132:
-		case 133:
-		case 134:
-			return { AutomapTile::Types::Lava };
-		case 137:
-			return { AutomapTile::Types::CaveHorizontalWallLava };
-		case 138:
-			return { AutomapTile::Types::CaveVerticalWallLava };
-		case 116:
-			return { AutomapTile::Types::HorizontalBridgeLava };
-		case 117:
-			return { AutomapTile::Types::VerticalBridgeLava };
-		}
-	}
-	if (IsAnyOf(leveltype, DTYPE_HELL)) {
-		switch (tile) {
-		case 52:
-			return { AutomapTile::Types::VerticalDiamond };
-		case 56:
-			return { AutomapTile::Types::HorizontalDiamond };
-		}
-	}
-
 	return GetAutomapType(map);
 }
 
@@ -1482,7 +1311,226 @@ void InitAutomap()
 	size_t tileCount = 0;
 	std::unique_ptr<AutomapTile[]> tileTypes = LoadAutomapData(tileCount);
 	for (unsigned i = 0; i < tileCount; i++) {
-		AutomapTypeTiles[i + 1] = tileTypes[i];
+		AutomapTile tempTileType = tileTypes[i];
+
+		if (IsAnyOf(leveltype, DTYPE_CAVES, DTYPE_NEST)) {
+			switch (i + 1) {
+			case 5:
+				tempTileType = { AutomapTile::Types::CaveBottomCorner };
+				break;
+			case 13:
+				tempTileType = { AutomapTile::Types::CaveRightCorner };
+				break;
+			case 14:
+				tempTileType = { AutomapTile::Types::CaveLeftCorner };
+				break;
+			}
+		}
+		if (IsAnyOf(leveltype, DTYPE_CAVES)) {
+			switch (i + 1) {
+			case 130:
+			case 132:
+				tempTileType = { AutomapTile::Types::CaveHorizontalWoodCross };
+				break;
+			case 134:
+			case 136:
+			case 151:
+				tempTileType = { AutomapTile::Types::CaveHorizontalWood };
+				break;
+			case 146:
+			case 148:
+				tempTileType = { AutomapTile::Types::CaveHorizontalWood, AutomapTile::Flags::VerticalDoor };
+				break;
+			case 131:
+			case 133:
+				tempTileType = { AutomapTile::Types::CaveVerticalWoodCross };
+				break;
+			case 135:
+			case 137:
+			case 152:
+				tempTileType = { AutomapTile::Types::CaveVerticalWood };
+				break;
+			case 147:
+			case 149:
+				tempTileType = { AutomapTile::Types::CaveVerticalWood, AutomapTile::Flags::HorizontalDoor };
+				break;
+			case 138:
+			case 141:
+			case 142:
+			case 143:
+				tempTileType = { AutomapTile::Types::CaveWoodCross };
+				break;
+			case 139:
+				tempTileType = { AutomapTile::Types::CaveRightWoodCross };
+				break;
+			case 140:
+				tempTileType = { AutomapTile::Types::CaveLeftWoodCross };
+				break;
+			case 15:
+			case 16:
+				tempTileType = { AutomapTile::Types::HorizontalLavaThin };
+				break;
+			case 17:
+			case 18:
+				tempTileType = { AutomapTile::Types::VerticalLavaThin };
+				break;
+			case 19:
+				tempTileType = { AutomapTile::Types::BendSouthLavaThin };
+				break;
+			case 20:
+				tempTileType = { AutomapTile::Types::BendWestLavaThin };
+				break;
+			case 21:
+				tempTileType = { AutomapTile::Types::BendEastLavaThin };
+				break;
+			case 22:
+				tempTileType = { AutomapTile::Types::BendNorthLavaThin };
+				break;
+			case 23:
+				tempTileType = { AutomapTile::Types::VerticalWallLava };
+				break;
+			case 24:
+				tempTileType = { AutomapTile::Types::HorizontalWallLava };
+				break;
+			case 25:
+				tempTileType = { AutomapTile::Types::SELava };
+				break;
+			case 26:
+				tempTileType = { AutomapTile::Types::SWLava };
+				break;
+			case 27:
+				tempTileType = { AutomapTile::Types::NELava };
+				break;
+			case 28:
+				tempTileType = { AutomapTile::Types::NWLava };
+				break;
+			case 29:
+				tempTileType = { AutomapTile::Types::SLava };
+				break;
+			case 30:
+				tempTileType = { AutomapTile::Types::WLava };
+				break;
+			case 31:
+				tempTileType = { AutomapTile::Types::ELava };
+				break;
+			case 32:
+				tempTileType = { AutomapTile::Types::NLava };
+				break;
+			case 33:
+			case 34:
+			case 35:
+			case 36:
+			case 37:
+			case 38:
+			case 39:
+			case 40:
+			case 41:
+				tempTileType = { AutomapTile::Types::Lava };
+				break;
+			case 42:
+				tempTileType = { AutomapTile::Types::CaveHorizontalWallLava };
+				break;
+			case 43:
+				tempTileType = { AutomapTile::Types::CaveVerticalWallLava };
+				break;
+			case 44:
+				tempTileType = { AutomapTile::Types::HorizontalBridgeLava };
+				break;
+			case 45:
+				tempTileType = { AutomapTile::Types::VerticalBridgeLava };
+				break;
+			}
+		}
+		if (IsAnyOf(leveltype, DTYPE_NEST)) {
+			switch (i + 1) {
+			case 103:
+			case 104:
+			case 109:
+				tempTileType = { AutomapTile::Types::HorizontalLavaThin };
+				break;
+			case 105:
+			case 106:
+			case 108:
+				tempTileType = { AutomapTile::Types::VerticalLavaThin };
+				break;
+			case 113:
+				tempTileType = { AutomapTile::Types::BendSouthLavaThin };
+				break;
+			case 114:
+				tempTileType = { AutomapTile::Types::BendWestLavaThin };
+				break;
+			case 111:
+				tempTileType = { AutomapTile::Types::BendEastLavaThin };
+				break;
+			case 112:
+				tempTileType = { AutomapTile::Types::BendNorthLavaThin };
+				break;
+			case 135:
+				tempTileType = { AutomapTile::Types::VerticalWallLava };
+				break;
+			case 136:
+				tempTileType = { AutomapTile::Types::HorizontalWallLava };
+				break;
+			case 119:
+				tempTileType = { AutomapTile::Types::SELava };
+				break;
+			case 120:
+				tempTileType = { AutomapTile::Types::SWLava };
+				break;
+			case 121:
+				tempTileType = { AutomapTile::Types::NELava };
+				break;
+			case 122:
+				tempTileType = { AutomapTile::Types::NWLava };
+				break;
+			case 107:
+				tempTileType = { AutomapTile::Types::SLava };
+				break;
+			case 115:
+				tempTileType = { AutomapTile::Types::WLava };
+				break;
+			case 131:
+				tempTileType = { AutomapTile::Types::ELava };
+				break;
+			case 123:
+				tempTileType = { AutomapTile::Types::NLava };
+				break;
+			case 118:
+			case 125:
+			case 127:
+			case 128:
+			case 129:
+			case 130:
+			case 132:
+			case 133:
+			case 134:
+				tempTileType = { AutomapTile::Types::Lava };
+				break;
+			case 137:
+				tempTileType = { AutomapTile::Types::CaveHorizontalWallLava };
+				break;
+			case 138:
+				tempTileType = { AutomapTile::Types::CaveVerticalWallLava };
+				break;
+			case 116:
+				tempTileType = { AutomapTile::Types::HorizontalBridgeLava };
+				break;
+			case 117:
+				tempTileType = { AutomapTile::Types::VerticalBridgeLava };
+				break;
+			}
+		}
+		if (IsAnyOf(leveltype, DTYPE_HELL)) {
+			switch (i + 1) {
+			case 52:
+				tempTileType = { AutomapTile::Types::VerticalDiamond };
+				break;
+			case 56:
+				tempTileType = { AutomapTile::Types::HorizontalDiamond };
+				break;
+			}
+		}
+		AutomapTypeTiles[i + 1] = tempTileType;
 	}
 
 	memset(AutomapView, 0, sizeof(AutomapView));

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -379,7 +379,7 @@ void DrawRiverLeftOut(const Surface &out, Point center, uint8_t color)
 
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::FullTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
 
 	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
@@ -443,7 +443,7 @@ void DrawRiver(const Surface &out, Point center, uint8_t color)
 	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
 
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::FullTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
 
 	out.SetPixel(center, color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
@@ -748,27 +748,27 @@ void DrawCorner(const Surface &out, Point center, AutomapTile nwTile, AutomapTil
  */
 void DrawCaveWallConnections(const Surface &out, Point center, AutomapTile sTile, AutomapTile swTile, AutomapTile seTile, uint8_t colorDim)
 {
-	bool dirtFill1 = false;
-	bool dirtFill2 = false;
 	if (IsAnyOf(swTile.type, AutomapTile::Types::CaveVerticalWallLava, AutomapTile::Types::CaveVertical, AutomapTile::Types::CaveVerticalWood, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross, AutomapTile::Types::CaveLeftWoodCross, AutomapTile::Types::CaveRightCorner)) {
 		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), AmLine(AmLineLength::HalfTile), colorDim);
-		dirtFill1 = true;
 	}
 	if (IsAnyOf(seTile.type, AutomapTile::Types::CaveHorizontalWallLava, AutomapTile::Types::CaveHorizontal, AutomapTile::Types::CaveHorizontalWood, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross, AutomapTile::Types::CaveLeftWoodCross, AutomapTile::Types::CaveLeftCorner)) {
 		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), AmLine(AmLineLength::HalfTile), colorDim);
-		dirtFill2 = true;
 	}
-
-	if (sTile.HasFlag(AutomapTile::Flags::Dirt) || (sTile.type != AutomapTile::Types::None && dirtFill1 && dirtFill2)) {
-		if (leveltype != DTYPE_TOWN)
-			out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), colorDim);
+}
+void DrawCaveHorizontalDirt(const Surface &out, Point center, AutomapTile tile, AutomapTile swTile, uint8_t colorDim)
+{
+	if (swTile.HasFlag(AutomapTile::Flags::Dirt) || (leveltype != DTYPE_TOWN && IsNoneOf(tile.type, AutomapTile::Types::CaveHorizontalWood, AutomapTile::Types::CaveHorizontalWoodCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveLeftWoodCross))) {
+		out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), colorDim);
+		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), colorDim);
+		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), colorDim);
+		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), colorDim);
 	}
 }
 
 /**
  * For caves the horizontal/vertical flags are swapped
  */
-void DrawCaveHorizontal(const Surface &out, Point center, AutomapTile tile, AutomapTile nwTile, uint8_t colorBright, uint8_t colorDim)
+void DrawCaveHorizontal(const Surface &out, Point center, AutomapTile tile, AutomapTile nwTile, AutomapTile swTile, uint8_t colorBright, uint8_t colorDim)
 {
 	if (tile.HasFlag(AutomapTile::Flags::VerticalDoor)) {
 		DrawMapHorizontalDoor(out, center, nwTile, colorBright, colorDim);
@@ -786,21 +786,25 @@ void DrawCaveHorizontal(const Surface &out, Point center, AutomapTile tile, Auto
 			h = AmHeightOffset::QuarterTileUp;
 			l = AmLineLength::FullAndHalfTile;
 		}
-		if (leveltype != DTYPE_TOWN && !(IsAnyOf(tile.type, AutomapTile::Types::CaveHorizontalWood, AutomapTile::Types::CaveHorizontalWoodCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveLeftWoodCross))) {
-			out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), colorDim);
-			out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), colorDim);
-			out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), colorDim);
-			out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), colorDim);
-		}
-
+		DrawCaveHorizontalDirt(out, center, tile, swTile, colorDim);
 		DrawMapLineSE(out, center + AmOffset(w, h), AmLine(l), colorDim);
+	}
+}
+
+void DrawCaveVerticalDirt(const Surface &out, Point center, AutomapTile tile, AutomapTile seTile, uint8_t colorDim)
+{
+	if (seTile.HasFlag(AutomapTile::Flags::Dirt) || (leveltype != DTYPE_TOWN && IsNoneOf(tile.type, AutomapTile::Types::CaveVerticalWood, AutomapTile::Types::CaveVerticalWoodCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross))) {
+		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), colorDim);
+		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), colorDim);
+		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), colorDim);
+		out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), colorDim);
 	}
 }
 
 /**
  * For caves the horizontal/vertical flags are swapped
  */
-void DrawCaveVertical(const Surface &out, Point center, AutomapTile tile, AutomapTile neTile, uint8_t colorBright, uint8_t colorDim)
+void DrawCaveVertical(const Surface &out, Point center, AutomapTile tile, AutomapTile neTile, AutomapTile seTile, uint8_t colorBright, uint8_t colorDim)
 {
 	if (tile.HasFlag(AutomapTile::Flags::HorizontalDoor)) {
 		DrawMapVerticalDoor(out, center, neTile, colorBright, colorDim);
@@ -814,12 +818,7 @@ void DrawCaveVertical(const Surface &out, Point center, AutomapTile tile, Automa
 		} else {
 			l = AmLineLength::FullAndHalfTile;
 		}
-		if (leveltype != DTYPE_TOWN && !(IsAnyOf(tile.type, AutomapTile::Types::CaveVerticalWood, AutomapTile::Types::CaveVerticalWoodCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross))) {
-			out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), colorDim);
-			out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), colorDim);
-			out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), colorDim);
-			out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), colorDim);
-		}
+		DrawCaveVerticalDirt(out, center, tile, seTile, colorDim);
 		DrawMapLineNE(out, { center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown) }, AmLine(l), colorDim);
 	}
 }
@@ -901,18 +900,35 @@ AutomapTile GetAutomapTypeView(Point map)
 	return GetAutomapType(map);
 }
 
+AutomapTile GetAutomapTileInDirection(Direction dir, Point map)
+{
+	switch (dir) {
+	case Direction::South:
+		return GetAutomapTypeView(map + Displacement { 1, 1 });
+	case Direction::SouthWest:
+		return GetAutomapTypeView(map + Displacement { 0, 1 });
+	case Direction::West:
+		return GetAutomapTypeView(map + Displacement { -1, 1 });
+	case Direction::NorthWest:
+		return GetAutomapTypeView(map + Displacement { -1, 0 });
+	case Direction::North:
+		return GetAutomapTypeView(map + Displacement { -1, -1 });
+	case Direction::NorthEast:
+		return GetAutomapTypeView(map + Displacement { 0, -1 });
+	case Direction::East:
+		return GetAutomapTypeView(map + Displacement { 1, -1 });
+	case Direction::SouthEast:
+		return GetAutomapTypeView(map + Displacement { 1, 0 });
+	case Direction::NoDirection:
+		return GetAutomapTypeView(map);
+	}
+}
+
 /**
  * @brief Renders the given automap shape at the specified screen coordinates.
  */
 void DrawAutomapTile(const Surface &out, Point center, Point map)
 {
-	AutomapTile tile = GetAutomapTypeView(map);
-	AutomapTile nwTile = GetAutomapTypeView(map + Displacement { -1, 0 });
-	AutomapTile neTile = GetAutomapTypeView(map + Displacement { 0, -1 });
-	AutomapTile swTile = GetAutomapTypeView(map + Displacement { 0, 1 });
-	AutomapTile seTile = GetAutomapTypeView(map + Displacement { 1, 0 });
-	AutomapTile sTile = GetAutomapTypeView(map + Displacement { 1, 1 });
-
 	uint8_t colorBright = MapColorsBright;
 	uint8_t colorDim = MapColorsDim;
 	uint8_t colorGrate = MapColorsGrate;
@@ -936,16 +952,14 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 	}
 
 	bool noConnect = false;
+	AutomapTile tile = GetAutomapTileInDirection(Direction::NoDirection, map);
+	AutomapTile nwTile = GetAutomapTileInDirection(Direction::NorthWest, map);
+	AutomapTile neTile = GetAutomapTileInDirection(Direction::NorthEast, map);
 
 	// If the tile is an arch, grate, or diamond, we draw a diamond and therefore don't want connection lines
-	if (tile.HasFlag(AutomapTile::Flags::HorizontalArch)
-	    || tile.HasFlag(AutomapTile::Flags::VerticalArch)
-	    || tile.HasFlag(AutomapTile::Flags::HorizontalGrate)
-	    || tile.HasFlag(AutomapTile::Flags::VerticalGrate)
-	    || nwTile.HasFlag(AutomapTile::Flags::HorizontalArch)
-	    || nwTile.HasFlag(AutomapTile::Flags::HorizontalGrate)
-	    || neTile.HasFlag(AutomapTile::Flags::VerticalArch)
-	    || neTile.HasFlag(AutomapTile::Flags::VerticalGrate)
+	if (tile.hasAnyFlag(AutomapTile::Flags::HorizontalArch, AutomapTile::Flags::VerticalArch, AutomapTile::Flags::HorizontalGrate, AutomapTile::Flags::VerticalGrate)
+	    || nwTile.hasAnyFlag(AutomapTile::Flags::HorizontalArch, AutomapTile::Flags::HorizontalGrate)
+	    || neTile.hasAnyFlag(AutomapTile::Flags::VerticalArch, AutomapTile::Flags::VerticalGrate)
 	    || tile.type == AutomapTile::Types::Diamond) {
 		noConnect = true;
 	}
@@ -954,7 +968,24 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 	if (IsAnyOf(leveltype, DTYPE_CATACOMBS, DTYPE_CAVES) && (tile.HasFlag(AutomapTile::Flags::HorizontalDoor) || tile.HasFlag(AutomapTile::Flags::VerticalDoor)))
 		noConnect = true;
 
-	if ((tile.type != AutomapTile::Types::None || swTile.type != AutomapTile::Types::None || seTile.type != AutomapTile::Types::None || sTile.type != AutomapTile::Types::None)&& tile.HasFlag(AutomapTile::Flags::Dirt)) {
+	AutomapTile swTile = GetAutomapTileInDirection(Direction::SouthWest, map);
+	AutomapTile sTile = GetAutomapTileInDirection(Direction::South, map);
+	AutomapTile seTile = GetAutomapTileInDirection(Direction::SouthEast, map);
+	AutomapTile nTile = GetAutomapTileInDirection(Direction::North, map);
+	AutomapTile wTile = GetAutomapTileInDirection(Direction::West, map);
+	AutomapTile eTile = GetAutomapTileInDirection(Direction::East, map);
+
+	if ((leveltype == DTYPE_TOWN && tile.HasFlag(AutomapTile::Flags::Dirt))
+		|| (tile.HasFlag(AutomapTile::Flags::Dirt)
+	    && (tile.type != AutomapTile::Types::None
+	        || swTile.type != AutomapTile::Types::None
+	        || sTile.type != AutomapTile::Types::None
+	        || seTile.type != AutomapTile::Types::None
+	        || IsAnyOf(nwTile.type, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveVertical, AutomapTile::Types::CaveVerticalCross, AutomapTile::Types::CaveVerticalWallLava, AutomapTile::Types::CaveVerticalWoodCross)
+	        || IsAnyOf(nTile.type, AutomapTile::Types::CaveCross)
+	        || IsAnyOf(neTile.type, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveHorizontal, AutomapTile::Types::CaveHorizontalCross, AutomapTile::Types::CaveHorizontalWallLava, AutomapTile::Types::CaveHorizontalWoodCross)
+	        || IsAnyOf(wTile.type, AutomapTile::Types::CaveVerticalCross)
+	        || IsAnyOf(eTile.type, AutomapTile::Types::CaveHorizontalCross)))) {
 		DrawDirt(out, center, nwTile, neTile, colorDim);
 	}
 
@@ -990,27 +1021,31 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 	case AutomapTile::Types::CaveHorizontalCross:
 	case AutomapTile::Types::CaveHorizontalWoodCross:
 		DrawVertical(out, center, tile, nwTile, neTile, swTile, colorBright, colorDim, colorGrate);
-		DrawCaveHorizontal(out, center, tile, nwTile, colorBright, colorDim);
+		DrawCaveHorizontal(out, center, tile, nwTile, swTile, colorBright, colorDim);
 		break;
 	case AutomapTile::Types::CaveVerticalCross:
 	case AutomapTile::Types::CaveVerticalWoodCross:
 		DrawHorizontal(out, center, tile, nwTile, neTile, seTile, colorBright, colorDim, colorGrate);
-		DrawCaveVertical(out, center, tile, neTile, colorBright, colorDim);
+		DrawCaveVertical(out, center, tile, neTile, seTile, colorBright, colorDim);
 		break;
 	case AutomapTile::Types::CaveHorizontal:
 	case AutomapTile::Types::CaveHorizontalWood:
-		DrawCaveHorizontal(out, center, tile, nwTile, colorBright, colorDim);
+		DrawCaveHorizontal(out, center, tile, nwTile, swTile, colorBright, colorDim);
 		break;
 	case AutomapTile::Types::CaveVertical:
 	case AutomapTile::Types::CaveVerticalWood:
-		DrawCaveVertical(out, center, tile, neTile, colorBright, colorDim);
+		DrawCaveVertical(out, center, tile, neTile, seTile, colorBright, colorDim);
 		break;
 	case AutomapTile::Types::CaveCross:
+		// Add the missing dirt pixel
+		if (sTile.HasFlag(AutomapTile::Flags::Dirt) || (leveltype != DTYPE_TOWN && IsNoneOf(tile.type, AutomapTile::Types::None))) {
+			out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), colorDim);
+		}
 	case AutomapTile::Types::CaveWoodCross:
 	case AutomapTile::Types::CaveRightWoodCross:
 	case AutomapTile::Types::CaveLeftWoodCross:
-		DrawCaveHorizontal(out, center, tile, nwTile, colorBright, colorDim);
-		DrawCaveVertical(out, center, tile, neTile, colorBright, colorDim);
+		DrawCaveHorizontal(out, center, tile, nwTile, swTile, colorBright, colorDim);
+		DrawCaveVertical(out, center, tile, neTile, seTile, colorBright, colorDim);
 		break;
 	case AutomapTile::Types::CaveLeftCorner:
 		DrawCaveLeftCorner(out, center, colorDim);
@@ -1020,7 +1055,13 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 		break;
 	case AutomapTile::Types::Corner:
 		DrawCorner(out, center, nwTile, neTile, colorDim);
+		break;
 	case AutomapTile::Types::CaveBottomCorner:
+		// Add the missing dirt pixel
+		if (sTile.HasFlag(AutomapTile::Flags::Dirt) || (leveltype != DTYPE_TOWN && IsNoneOf(tile.type, AutomapTile::Types::None))) {
+			out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), colorDim);
+		}
+		break;
 	case AutomapTile::Types::None:
 		break;
 	case AutomapTile::Types::Bridge:
@@ -1113,11 +1154,11 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 		DrawLava<Direction::NoDirection>(out, center, MapColorsLava);
 		break;
 	case AutomapTile::Types::CaveHorizontalWallLava:
-		DrawCaveHorizontal(out, center, tile, nwTile, colorBright, colorDim);
+		DrawCaveHorizontal(out, center, tile, nwTile, swTile, colorBright, colorDim);
 		DrawLavaRiver<Direction::NorthEast, Direction::NoDirection>(out, center, MapColorsLava, false);
 		break;
 	case AutomapTile::Types::CaveVerticalWallLava:
-		DrawCaveVertical(out, center, tile, neTile, colorBright, colorDim);
+		DrawCaveVertical(out, center, tile, neTile, seTile, colorBright, colorDim);
 		DrawLavaRiver<Direction::NorthWest, Direction::NoDirection>(out, center, MapColorsLava, false);
 		break;
 	case AutomapTile::Types::HorizontalBridgeLava:

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -46,7 +46,7 @@ enum MapColors : uint8_t {
 	/** color for cave water on automap */
 	MapColorsWater = (PAL8_BLUE + 2),
 	/** color for hive acid on automap */
-	MapColorsAcid = (PAL8_YELLOW + 2),
+	MapColorsAcid = (PAL8_YELLOW + 4),
 };
 
 struct AutomapTile {

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -457,111 +457,96 @@ void DrawRiverForkOut(const Surface &out, Point center, uint8_t color)
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
 }
 
-template <Direction direction1, Direction direction2>
+template <Direction TDir1, Direction TDir2>
 void DrawLavaRiver(const Surface &out, Point center, uint8_t color, bool hasBridge)
 {
 	// First row (y = 0)
-	if constexpr (IsAnyOf(direction1, Direction::NorthWest) || IsAnyOf(direction2, Direction::NorthWest)) {
-		if (!(hasBridge && IsAnyOf(direction1, Direction::NorthWest))) {
+	if constexpr (IsAnyOf(TDir1, Direction::NorthWest) || IsAnyOf(TDir2, Direction::NorthWest)) {
+		if (!(hasBridge && IsAnyOf(TDir1, Direction::NorthWest))) {
 			out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
 			out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
 		}
 	}
 
 	// Second row (y = 1)
-	if constexpr (IsAnyOf(direction1, Direction::NorthEast) || IsAnyOf(direction2, Direction::NorthEast)) {
-		if (!(hasBridge && (IsAnyOf(direction1, Direction::NorthEast) || IsAnyOf(direction2, Direction::NorthEast))))
+	if constexpr (IsAnyOf(TDir1, Direction::NorthEast) || IsAnyOf(TDir2, Direction::NorthEast)) {
+		if (!(hasBridge && (IsAnyOf(TDir1, Direction::NorthEast) || IsAnyOf(TDir2, Direction::NorthEast))))
 			out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
 	}
-	if constexpr (IsAnyOf(direction1, Direction::NorthWest, Direction::NorthEast) || IsAnyOf(direction2, Direction::NorthWest, Direction::NorthEast)) {
+	if constexpr (IsAnyOf(TDir1, Direction::NorthWest, Direction::NorthEast) || IsAnyOf(TDir2, Direction::NorthWest, Direction::NorthEast)) {
 		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
 	}
-	if constexpr (IsAnyOf(direction1, Direction::SouthWest, Direction::NorthWest) || IsAnyOf(direction2, Direction::SouthWest, Direction::NorthWest)) {
+	if constexpr (IsAnyOf(TDir1, Direction::SouthWest, Direction::NorthWest) || IsAnyOf(TDir2, Direction::SouthWest, Direction::NorthWest)) {
 		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
 	}
-	if constexpr (IsAnyOf(direction1, Direction::SouthWest) || IsAnyOf(direction2, Direction::SouthWest)) {
+	if constexpr (IsAnyOf(TDir1, Direction::SouthWest) || IsAnyOf(TDir2, Direction::SouthWest)) {
 		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
 	}
 
 	// Third row (y = 2)
-	if constexpr (IsAnyOf(direction1, Direction::NorthEast) || IsAnyOf(direction2, Direction::NorthEast)) {
-		if (!(hasBridge && (IsAnyOf(direction1, Direction::NorthEast) || IsAnyOf(direction2, Direction::NorthEast))))
+	if constexpr (IsAnyOf(TDir1, Direction::NorthEast) || IsAnyOf(TDir2, Direction::NorthEast)) {
+		if (!(hasBridge && (IsAnyOf(TDir1, Direction::NorthEast) || IsAnyOf(TDir2, Direction::NorthEast))))
 			out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
 	}
-	if constexpr (IsAnyOf(direction1, Direction::NorthEast, Direction::SouthEast) || IsAnyOf(direction2, Direction::NorthEast, Direction::SouthEast)) {
+	if constexpr (IsAnyOf(TDir1, Direction::NorthEast, Direction::SouthEast) || IsAnyOf(TDir2, Direction::NorthEast, Direction::SouthEast)) {
 		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
 	}
-	if constexpr (IsAnyOf(direction1, Direction::SouthWest, Direction::SouthEast) || IsAnyOf(direction2, Direction::SouthWest, Direction::SouthEast)) {
+	if constexpr (IsAnyOf(TDir1, Direction::SouthWest, Direction::SouthEast) || IsAnyOf(TDir2, Direction::SouthWest, Direction::SouthEast)) {
 		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
 	}
-	if constexpr (IsAnyOf(direction1, Direction::SouthWest) || IsAnyOf(direction2, Direction::SouthWest)) {
+	if constexpr (IsAnyOf(TDir1, Direction::SouthWest) || IsAnyOf(TDir2, Direction::SouthWest)) {
 		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
 	}
 
 	// Fourth row (y = 3)
-	if constexpr (IsAnyOf(direction1, Direction::SouthEast) || IsAnyOf(direction2, Direction::SouthEast)) {
+	if constexpr (IsAnyOf(TDir1, Direction::SouthEast) || IsAnyOf(TDir2, Direction::SouthEast)) {
 		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
 		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
 	}
 }
 
-template <Direction direction>
+template <Direction TDir>
 void DrawLava(const Surface &out, Point center, uint8_t color)
 {
-	if constexpr (IsNoneOf(direction, Direction::South, Direction::SouthEast, Direction::East)) {
-		// First row
-		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
-		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
-		out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+	if constexpr (IsAnyOf(TDir, Direction::NorthWest, Direction::North, Direction::NorthEast, Direction::NoDirection)) {
+		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color); // north corner
 	}
-
-	if constexpr (IsNoneOf(direction, Direction::South, Direction::SouthWest, Direction::West)) {
-		// Second row
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	if constexpr (IsAnyOf(TDir, Direction::SouthWest, Direction::West, Direction::NorthWest, Direction::North, Direction::NorthEast, Direction::NoDirection)) {
+		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color); // northwest edge
+		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);             // northwest edge
 	}
-
-	if constexpr (IsNoneOf(direction, Direction::South)) {
-		// Both second and third row
-		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+	if constexpr (IsAnyOf(TDir, Direction::SouthWest, Direction::West, Direction::NorthWest, Direction::NoDirection)) {
+		out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color); // west corner
 	}
-
-	if constexpr (IsNoneOf(direction, Direction::East)) {
-		// Second and third row
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	if constexpr (IsAnyOf(TDir, Direction::South, Direction::SouthWest, Direction::West, Direction::NorthWest, Direction::SouthEast, Direction::NoDirection)) {
+		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);             // southwest edge
+		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color); // southwest edge
 	}
-
-	if constexpr (IsNoneOf(direction, Direction::North, Direction::NorthEast, Direction::East)) {
-		// Second row
-		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+	if constexpr (IsAnyOf(TDir, Direction::South, Direction::SouthWest, Direction::SouthEast, Direction::NoDirection)) {
+		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color); // south corner
 	}
-
-	if constexpr (IsNoneOf(direction, Direction::South, Direction::SouthWest, Direction::West)) {
-		// Third row
-		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	if constexpr (IsAnyOf(TDir, Direction::South, Direction::SouthWest, Direction::NorthEast, Direction::East, Direction::SouthEast, Direction::NoDirection)) {
+		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);             // southeast edge
+		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color); // southeast edge
 	}
-
-	if constexpr (IsNoneOf(direction, Direction::West)) {
-		// Third row
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	if constexpr (IsAnyOf(TDir, Direction::NorthEast, Direction::East, Direction::SouthEast, Direction::NoDirection)) {
+		out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color); // east corner
 	}
-
-	if constexpr (IsNoneOf(direction, Direction::North)) {
-		// Both third and fourth row
-		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	if constexpr (IsAnyOf(TDir, Direction::NorthWest, Direction::North, Direction::NorthEast, Direction::East, Direction::SouthEast, Direction::NoDirection)) {
+		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color); // northeast edge
+		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);             // northeast edge
 	}
-
-	if constexpr (IsNoneOf(direction, Direction::North, Direction::NorthEast, Direction::East)) {
-		// Third row
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
+	if constexpr (IsNoneOf(TDir, Direction::South)) {
+		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color); // north center
 	}
-
-	if constexpr (IsNoneOf(direction, Direction::North, Direction::NorthWest, Direction::West)) {
-		// Fourth row
-		out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
-		out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
-		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
+	if constexpr (IsNoneOf(TDir, Direction::East)) {
+		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color); // west center
+	}
+	if constexpr (IsNoneOf(TDir, Direction::West)) {
+		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color); // east center
+	}
+	if constexpr (IsNoneOf(TDir, Direction::North)) {
+		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color); // south center
 	}
 }
 

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -974,9 +974,7 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 		break;
 	case AutomapTile::Types::CaveCross:
 		// Add the missing dirt pixel
-		if (sTile.HasFlag(AutomapTile::Flags::Dirt) || (leveltype != DTYPE_TOWN && IsNoneOf(tile.type, AutomapTile::Types::None))) {
-			out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), colorDim);
-		}
+		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), colorDim);
 	case AutomapTile::Types::CaveWoodCross:
 	case AutomapTile::Types::CaveRightWoodCross:
 	case AutomapTile::Types::CaveLeftWoodCross:
@@ -994,9 +992,8 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 		break;
 	case AutomapTile::Types::CaveBottomCorner:
 		// Add the missing dirt pixel
-		if (sTile.HasFlag(AutomapTile::Flags::Dirt) || (leveltype != DTYPE_TOWN && IsNoneOf(tile.type, AutomapTile::Types::None))) {
-			out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), colorDim);
-		}
+		// BUGFIX: A tile in poisoned water supply isn't drawing this pixel
+		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), colorDim);
 		break;
 	case AutomapTile::Types::None:
 		break;

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -18,6 +18,7 @@
 #include "levels/setmaps.h"
 #include "player.h"
 #include "utils/attributes.h"
+#include "utils/enum_traits.h"
 #include "utils/language.h"
 #include "utils/ui_fwd.h"
 #include "utils/utf8.hpp"
@@ -113,250 +114,259 @@ std::array<AutomapTile, 256> AutomapTypeTiles;
 
 void DrawDiamond(const Surface &out, Point center, uint8_t color)
 {
-	DrawMapLineNE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), AmLine(AmLineLength::FullTile), color);
-	DrawMapLineSE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), AmLine(AmLineLength::FullTile), color);
-	DrawMapLineSE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::FullTile), color);
-	DrawMapLineNE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::FullTile), color);
+	DrawMapLineNE(out, center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::FullTile), color);
+	DrawMapLineSE(out, center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::FullTile), color);
+	DrawMapLineSE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileUp), AmLine(AmLineLength::FullTile), color);
+	DrawMapLineNE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), AmLine(AmLineLength::FullTile), color);
 }
 
 void DrawMapVerticalDoor(const Surface &out, Point center, uint8_t colorBright, uint8_t colorDim)
 {
-	//if (leveltype != DTYPE_CATACOMBS) {
-	DrawMapLineNE(out, center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), AmLine(AmLineLength::HalfTile), colorDim);
-	DrawMapLineNE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::HalfTile), colorDim);
+	DrawMapLineNE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::FullTile), colorDim);
+	DrawDiamond(out, center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), colorBright);
+}
+
+void DrawMapCrossVerticalDoor(const Surface &out, Point center, uint8_t colorBright, uint8_t colorDim)
+{
+	DrawMapLineNE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::HalfTile), colorDim);
 	DrawDiamond(out, center, colorBright);
-	//} else {
-	//	DrawMapLineNE(out, { center.x - AmLine(8), center.y + AmLine(4) }, AmLine(8), colorDim);
-	//	DrawMapLineNE(out, { center.x - AmLine(16), center.y + AmLine(8) }, AmLine(4), colorDim);
-	//	DrawDiamond(out, { center.x + AmLine(16), center.y - AmLine(8) }, colorBright);
-	//}
+}
+
+void DrawMapDiamondVerticalDoor(const Surface &out, Point center, uint8_t colorBright, uint8_t colorDim)
+{
+	DrawMapLineNE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::QuarterTile), colorDim);
+	DrawDiamond(out, center, colorBright);
 }
 
 void DrawMapHorizontalDoor(const Surface &out, Point center, uint8_t colorBright, uint8_t colorDim)
 {
-	//if (leveltype != DTYPE_CATACOMBS) {
-	DrawMapLineSE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::HalfTile), colorDim);
-	DrawMapLineSE(out, center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), AmLine(AmLineLength::HalfTile), colorDim);
-	DrawDiamond(out, center, colorBright);
-	//} else {
-	//	DrawMapLineSE(out, { center.x - AmLine(8), center.y - AmLine(4) }, AmLine(8), colorDim);
-	//	DrawMapLineSE(out, { center.x + AmLine(8), center.y + AmLine(4) }, AmLine(4), colorDim);
-	//	DrawDiamond(out, { center.x - AmLine(16), center.y - AmLine(8) }, colorBright);
-	//}
+	DrawMapLineSE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileUp), AmLine(AmLineLength::FullTile), colorDim);
+	DrawDiamond(out, center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), colorBright);
+}
+
+void DrawMapCrossHorizontalDoor(const Surface &out, Point center, uint8_t colorBright, uint8_t colorDim)
+{
+	DrawMapLineSE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::HalfTile), colorDim);
+	DrawDiamond(out, center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), colorBright);
+}
+
+void DrawMapDiamondHorizontalDoor(const Surface &out, Point center, uint8_t colorBright, uint8_t colorDim)
+{
+	DrawMapLineSE(out, center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::QuarterTile), colorDim);
+	DrawDiamond(out, center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), colorBright);
 }
 
 void DrawDirt(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileUp), color);
-
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::ThreeEighthsTileDown), color);
-
-	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
 	out.SetPixel(center, color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::ThreeEighthsTileDown), color);
-
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileRight, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
 }
 
 void DrawBridge(const Surface &out, Point center, uint8_t color)
 {
 	out.SetPixel(center, color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
-
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileRight, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
 }
 
 void DrawRiverRightIn(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::ThreeEighthsTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
 
 	out.SetPixel(center, color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::ThreeEighthsTileDown), color);
-
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileRight, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
 }
 
 void DrawRiverCornerSouth(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
 }
 
 void DrawRiverCornerNorth(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileUp), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
 }
 
 void DrawRiverLeftOut(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileLeft, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
-
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::ThreeEighthsTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
 
 	out.SetPixel(center, color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::HalfTileDown), color);
-
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::FullTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileRight, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
 }
 
 void DrawRiverLeftIn(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileUp), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::ThreeEighthsTileDown), color);
-
-	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
 	out.SetPixel(center, color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::ThreeEighthsTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
 }
 
 void DrawRiverCornerWest(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileLeft, AmHeightOffset::EighthTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
 }
 
 void DrawRiverCornerEast(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileRight, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
 }
 
 void DrawRiverRightOut(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::ThreeEighthsTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
 
 	out.SetPixel(center, color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::ThreeEighthsTileDown), color);
-
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileRight, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
 }
 
 void DrawRiver(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::FullTileDown), color);
 
 	out.SetPixel(center, color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::ThreeEighthsTileDown), color);
-
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileRight, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
 }
 
 void DrawRiverForkIn(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
+
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::FullTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileUp), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::HalfTileDown), color);
-
-	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), color);
 	out.SetPixel(center, color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::ThreeEighthsTileDown), color);
-
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
 	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileRight, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), color);
+
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), color);
 }
 
 void DrawRiverForkOut(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileLeft, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), color);
-	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::ThreeEighthsTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown), color);
 
-	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::ThreeEighthsTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::ThreeQuartersTileDown), color);
 }
 
 void DrawStairs(const Surface &out, Point center, uint8_t color)
 {
 	constexpr int NumStairSteps = 4;
-	const Displacement offset = AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown);
+	const Displacement offset = AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown);
 
 	// Initial point based on the 'center' position.
-	Point p = center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::ThreeEighthsTileUp);
+	Point p = center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileUp);
 
 	for (int i = 0; i < NumStairSteps; ++i) {
 		DrawMapLineSE(out, p, AmLine(AmLineLength::DoubleTile), color);
@@ -370,17 +380,36 @@ void DrawStairs(const Surface &out, Point center, uint8_t color)
 void DrawHorizontal(const Surface &out, Point center, AutomapTile tile, uint8_t colorBright, uint8_t colorDim)
 {
 	if (!tile.HasFlag(AutomapTile::Flags::HorizontalPassage)) {
-		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), AmLine(AmLineLength::DoubleTile), colorDim);
+		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileUp), AmLine(AmLineLength::DoubleTile), colorDim);
 		return;
 	}
 	if (tile.HasFlag(AutomapTile::Flags::HorizontalDoor)) {
-		DrawMapHorizontalDoor(out, center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), colorBright, colorDim);
+		DrawMapHorizontalDoor(out, center, colorBright, colorDim);
 	}
 	if (tile.HasFlag(AutomapTile::Flags::HorizontalGrate)) {
 		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::FullTile), colorDim);
-		DrawDiamond(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), colorDim);
+		DrawDiamond(out, center, colorDim);
 	} else if (tile.HasFlag(AutomapTile::Flags::HorizontalArch)) {
-		DrawDiamond(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), colorDim);
+		DrawDiamond(out, center, colorDim);
+	}
+}
+
+void DrawFenceHorizontal(const Surface &out, Point center, AutomapTile tile, uint8_t colorBright, uint8_t colorDim)
+{
+	if (!tile.HasFlag(AutomapTile::Flags::HorizontalPassage)) {
+		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::FullAndHalfTile), colorDim);
+		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::HalfTile), colorDim);
+		return;
+	}
+	if (tile.HasFlag(AutomapTile::Flags::HorizontalDoor)) {
+		DrawMapHorizontalDoor(out, center, colorBright, colorDim);
+	}
+	if (tile.HasFlag(AutomapTile::Flags::HorizontalGrate)) {
+		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::FullAndHalfTile), colorDim);
+		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::HalfTile), colorDim);
+		DrawDiamond(out, center, colorDim);
+	} else if (tile.HasFlag(AutomapTile::Flags::HorizontalArch)) {
+		DrawDiamond(out, center, colorDim);
 	}
 }
 
@@ -390,18 +419,69 @@ void DrawHorizontal(const Surface &out, Point center, AutomapTile tile, uint8_t 
 void DrawVertical(const Surface &out, Point center, AutomapTile tile, uint8_t colorBright, uint8_t colorDim)
 {
 	if (!tile.HasFlag(AutomapTile::Flags::VerticalPassage)) {
-		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), AmLine(AmLineLength::DoubleTile), colorDim);
+		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::DoubleTile), colorDim);
 		return;
 	}
 	if (tile.HasFlag(AutomapTile::Flags::VerticalDoor)) {
-		DrawMapVerticalDoor(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), colorBright, colorDim);
+		DrawMapVerticalDoor(out, center, colorBright, colorDim);
 	}
 	if (tile.HasFlag(AutomapTile::Flags::VerticalGrate)) {
-		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), AmLine(AmLineLength::FullTile), colorDim);
-		DrawDiamond(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), colorDim);
+		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::FullTile), colorDim);
+		DrawDiamond(out, center, colorDim);
 	} else if (tile.HasFlag(AutomapTile::Flags::VerticalArch)) {
-		DrawDiamond(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), colorDim);
+		DrawDiamond(out, center, colorDim);
 	}
+}
+
+void DrawFenceVertical(const Surface &out, Point center, AutomapTile tile, uint8_t colorBright, uint8_t colorDim)
+{
+	if (!tile.HasFlag(AutomapTile::Flags::VerticalPassage)) {
+		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::FullAndHalfTile), colorDim);
+		DrawMapLineNW(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::HalfTile), colorDim);
+		return;
+	}
+	if (tile.HasFlag(AutomapTile::Flags::VerticalDoor)) {
+		DrawMapVerticalDoor(out, center, colorBright, colorDim);
+	}
+	if (tile.HasFlag(AutomapTile::Flags::VerticalGrate)) {
+		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::None), AmLine(AmLineLength::FullTile), colorDim);
+		DrawDiamond(out, center, colorDim);
+	} else if (tile.HasFlag(AutomapTile::Flags::VerticalArch)) {
+		DrawDiamond(out, center, colorDim);
+	}
+}
+
+void DrawCross(const Surface &out, Point center, AutomapTile tile, uint8_t colorBright, uint8_t colorDim)
+{
+	if (tile.HasFlag(AutomapTile::Flags::HorizontalGrate) || tile.HasFlag(AutomapTile::Flags::VerticalGrate) || tile.HasFlag(AutomapTile::Flags::HorizontalArch) || tile.HasFlag(AutomapTile::Flags::VerticalArch)) {
+		if (tile.HasFlag(AutomapTile::Flags::HorizontalGrate)) {
+			DrawMapLineSE(out, center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::FullTile), colorDim);
+		} else if (tile.HasFlag(AutomapTile::Flags::HorizontalDoor)) {
+			DrawMapDiamondHorizontalDoor(out, center, colorBright, colorDim);
+		} else if (!tile.HasFlag(AutomapTile::Flags::HorizontalPassage)) {
+			DrawMapLineSE(out, center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::FullTile), colorDim);
+		}
+		if (tile.HasFlag(AutomapTile::Flags::VerticalGrate)) {
+			DrawMapLineNE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::FullTile), colorDim);
+		} else if (tile.HasFlag(AutomapTile::Flags::VerticalDoor)) {
+			DrawMapDiamondVerticalDoor(out, center, colorBright, colorDim);
+		} else if (!tile.HasFlag(AutomapTile::Flags::VerticalPassage)) {
+			DrawMapLineNE(out, center + AmOffset(AmWidthOffset::FullTileLeft, AmHeightOffset::HalfTileDown), AmLine(AmLineLength::FullTile), colorDim);
+		}
+		DrawDiamond(out, center, colorDim);
+	} else {
+		if (tile.HasFlag(AutomapTile::Flags::HorizontalDoor)) {
+			DrawMapCrossHorizontalDoor(out, center, colorBright, colorDim);
+		} else if (!tile.HasFlag(AutomapTile::Flags::HorizontalPassage)) {
+			DrawMapLineSE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::FullAndHalfTile), colorDim);
+		}
+		if (tile.HasFlag(AutomapTile::Flags::VerticalDoor)) {
+			DrawMapCrossVerticalDoor(out, center, colorBright, colorDim);
+		} else if (!tile.HasFlag(AutomapTile::Flags::VerticalPassage)) {
+			DrawMapLineNE(out, center + AmOffset(AmWidthOffset::ThreeQuartersTileLeft, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::FullAndHalfTile), colorDim);
+		}
+	}
+
 }
 
 /**
@@ -410,9 +490,9 @@ void DrawVertical(const Surface &out, Point center, AutomapTile tile, uint8_t co
 void DrawCaveHorizontal(const Surface &out, Point center, AutomapTile tile, uint8_t colorBright, uint8_t colorDim)
 {
 	if (tile.HasFlag(AutomapTile::Flags::VerticalDoor)) {
-		DrawMapHorizontalDoor(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), colorBright, colorDim);
+		DrawMapHorizontalDoor(out, center, colorBright, colorDim);
 	} else {
-		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), AmLine(AmLineLength::DoubleTile), colorDim);
+		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::FullTileLeft, AmHeightOffset::None), AmLine(AmLineLength::DoubleTile), colorDim);
 	}
 }
 
@@ -422,10 +502,16 @@ void DrawCaveHorizontal(const Surface &out, Point center, AutomapTile tile, uint
 void DrawCaveVertical(const Surface &out, Point center, AutomapTile tile, uint8_t colorBright, uint8_t colorDim)
 {
 	if (tile.HasFlag(AutomapTile::Flags::HorizontalDoor)) {
-		DrawMapVerticalDoor(out, center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), colorBright, colorDim);
+		DrawMapVerticalDoor(out, center, colorBright, colorDim);
 	} else {
-		DrawMapLineNE(out, { center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown) }, AmLine(AmLineLength::DoubleTile), colorDim);
+		DrawMapLineNE(out, { center + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown) }, AmLine(AmLineLength::DoubleTile), colorDim);
 	}
+}
+
+void DrawCorner(const Surface &out, Point center, AutomapTile tile, uint8_t colorBright, uint8_t colorDim)
+{
+	DrawMapLineNW(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::HalfTile), colorDim);
+	DrawMapLineNE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::HalfTile), colorDim);
 }
 
 /**
@@ -528,19 +614,22 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 
 	switch (tile.type) {
 	case AutomapTile::Types::Diamond: // stand-alone column or other unpassable object
-		DrawDiamond(out, { center.x, center.y }, colorDim);
+		DrawDiamond(out, center, colorDim);
 		break;
 	case AutomapTile::Types::Vertical:
-	case AutomapTile::Types::FenceVertical:
 		DrawVertical(out, center, tile, colorBright, colorDim);
+		break;
+	case AutomapTile::Types::FenceVertical:
+		DrawFenceVertical(out, center, tile, colorBright, colorDim);
 		break;
 	case AutomapTile::Types::Horizontal:
-	case AutomapTile::Types::FenceHorizontal:
 		DrawHorizontal(out, center, tile, colorBright, colorDim);
 		break;
+	case AutomapTile::Types::FenceHorizontal:
+		DrawFenceHorizontal(out, center, tile, colorBright, colorDim);
+		break;
 	case AutomapTile::Types::Cross:
-		DrawVertical(out, center, tile, colorBright, colorDim);
-		DrawHorizontal(out, center, tile, colorBright, colorDim);
+		DrawCross(out, center, tile, colorBright, colorDim);
 		break;
 	case AutomapTile::Types::CaveHorizontalCross:
 		DrawVertical(out, center, tile, colorBright, colorDim);
@@ -561,6 +650,8 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 		DrawCaveVertical(out, center, tile, colorBright, colorDim);
 		break;
 	case AutomapTile::Types::Corner:
+		DrawCorner(out, center, tile, colorBright, colorDim);
+		break;
 	case AutomapTile::Types::None:
 		break;
 	case AutomapTile::Types::Bridge:
@@ -667,7 +758,7 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, int 
 
 	Point base = {
 		((playerOffset.deltaX + myPlayerOffset.deltaX) * AutoMapScale / 100 / 2) + (px - py) * AmLine(AmLineLength::DoubleTile) + gnScreenWidth / 2,
-		((playerOffset.deltaY + myPlayerOffset.deltaY) * AutoMapScale / 100 / 2) + (px + py) * AmLine(AmLineLength::FullTile) + (gnScreenHeight - GetMainPanel().size.height) / 2 + TILE_HEIGHT / 2 - 1
+		((playerOffset.deltaY + myPlayerOffset.deltaY) * AutoMapScale / 100 / 2) + (px + py) * AmLine(AmLineLength::FullTile) + (gnScreenHeight - GetMainPanel().size.height) / 2 + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown).deltaY
 	};
 
 	if (CanPanelsCoverView()) {
@@ -680,53 +771,53 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, int 
 
 	switch (player._pdir) {
 	case Direction::North: {
-		const Point point = base + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp);
+		const Point point = base + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileUp);
 		DrawVerticalLine(out, point, AmLine(AmLineLength::DoubleTile), playerColor);
 		//DrawMapLineSteepNE(out, { point.x - AmLine(4), point.y + 2 * AmLine(4) }, AmLine(AmLineLength::HalfTile), playerColor);
-		DrawMapLineSteepNE(out, point + AmOffset(AmWidthOffset::SixteenthTileLeft, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::HalfTile), playerColor);
+		DrawMapLineSteepNE(out, point + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::HalfTileDown), AmLine(AmLineLength::HalfTile), playerColor);
 		//DrawMapLineSteepNW(out, { point.x + AmLine(4), point.y + 2 * AmLine(4) }, AmLine(AmLineLength::HalfTile), playerColor);
-		DrawMapLineSteepNW(out, point + AmOffset(AmWidthOffset::SixteenthTileRight, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::HalfTile), playerColor);
+		DrawMapLineSteepNW(out, point + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::HalfTileDown), AmLine(AmLineLength::HalfTile), playerColor);
 	} break;
 	case Direction::NorthEast: {
-		const Point point = base + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp);
-		DrawHorizontalLine(out, point + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::None), AmLine(AmLineLength::FullTile), playerColor);
+		const Point point = base + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileUp);
+		DrawHorizontalLine(out, point + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), AmLine(AmLineLength::FullTile), playerColor);
 		//DrawMapLineNE(out, { point.x - 2 * AmLine(8), point.y + AmLine(8) }, AmLine(AmLineLength::FullTile), playerColor);
-		DrawMapLineNE(out, point + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::FullTile), playerColor);
+		DrawMapLineNE(out, point + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), AmLine(AmLineLength::FullTile), playerColor);
 		DrawMapLineSteepSW(out, point, AmLine(AmLineLength::HalfTile), playerColor);
 	} break;
 	case Direction::East: {
-		const Point point = base + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None);
+		const Point point = base + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None);
 		DrawMapLineNW(out, point, AmLine(AmLineLength::HalfTile), playerColor);
-		DrawHorizontalLine(out, point + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), AmLine(AmLineLength::DoubleTile), playerColor);
+		DrawHorizontalLine(out, point + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), AmLine(AmLineLength::DoubleTile), playerColor);
 		DrawMapLineSW(out, point, AmLine(AmLineLength::HalfTile), playerColor);
 	} break;
 	case Direction::SouthEast: {
-		const Point point = base + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown);
+		const Point point = base + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown);
 		DrawMapLineSteepNW(out, point, AmLine(AmLineLength::HalfTile), playerColor);
-		DrawMapLineSE(out, point + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::FullTile), playerColor);
-		DrawHorizontalLine(out, point + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::None) + Displacement { -1, 0 }, AmLine(AmLineLength::FullTile) + 1, playerColor);
+		DrawMapLineSE(out, point + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::FullTile), playerColor);
+		DrawHorizontalLine(out, point + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None) + Displacement { -1, 0 }, AmLine(AmLineLength::FullTile) + 1, playerColor);
 	} break;
 	case Direction::South: {
-		const Point point = base + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown);
-		DrawVerticalLine(out, point + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::DoubleTile), playerColor);
-		DrawMapLineSteepSW(out, point + AmOffset(AmWidthOffset::SixteenthTileRight, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::HalfTile), playerColor);
-		DrawMapLineSteepSE(out, point + AmOffset(AmWidthOffset::SixteenthTileLeft, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::HalfTile), playerColor);
+		const Point point = base + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown);
+		DrawVerticalLine(out, point + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileUp), AmLine(AmLineLength::DoubleTile), playerColor);
+		DrawMapLineSteepSW(out, point + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::HalfTile), playerColor);
+		DrawMapLineSteepSE(out, point + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::HalfTile), playerColor);
 	} break;
 	case Direction::SouthWest: {
-		const Point point = base + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown);
+		const Point point = base + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown);
 		DrawMapLineSteepNE(out, point, AmLine(AmLineLength::HalfTile), playerColor);
-		DrawMapLineSW(out, point + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::FullTile), playerColor);
+		DrawMapLineSW(out, point + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::FullTile), playerColor);
 		DrawHorizontalLine(out, point, AmLine(AmLineLength::FullTile) + 1, playerColor);
 	} break;
 	case Direction::West: {
-		const Point point = base + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None);
+		const Point point = base + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None);
 		DrawMapLineNE(out, point, AmLine(AmLineLength::HalfTile), playerColor);
 		DrawHorizontalLine(out, point, AmLine(AmLineLength::DoubleTile) + 1, playerColor);
 		DrawMapLineSE(out, point, AmLine(AmLineLength::HalfTile), playerColor);
 	} break;
 	case Direction::NorthWest: {
-		const Point point = base + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp);
-		DrawMapLineNW(out, point + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::FullTile), playerColor);
+		const Point point = base + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileUp);
+		DrawMapLineNW(out, point + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::HalfTileDown), AmLine(AmLineLength::FullTile), playerColor);
 		DrawHorizontalLine(out, point, AmLine(AmLineLength::FullTile) + 1, playerColor);
 		DrawMapLineSteepSE(out, point, AmLine(AmLineLength::HalfTile), playerColor);
 	} break;
@@ -938,20 +1029,20 @@ void DrawAutomap(const Surface &out)
 	};
 
 	if ((cells & 1) != 0) {
-		screen.x -= AmOffset(AmWidthOffset::FullTileRight, AmHeightOffset::None).deltaX * ((cells - 1) / 2);
-		screen.y -= AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown).deltaY * ((cells + 1) / 2);
-		
+		screen.x -= AmOffset(AmWidthOffset::DoubleTileRight, AmHeightOffset::None).deltaX * ((cells - 1) / 2);
+		screen.y -= AmOffset(AmWidthOffset::None, AmHeightOffset::DoubleTileDown).deltaY * ((cells + 1) / 2);
+
 	} else {
-		screen.x -= AmOffset(AmWidthOffset::FullTileRight, AmHeightOffset::None).deltaX * (cells / 2) - AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None).deltaX;
-		screen.y -= AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown).deltaY * (cells / 2) + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown).deltaY;
+		screen.x -= AmOffset(AmWidthOffset::DoubleTileRight, AmHeightOffset::None).deltaX * (cells / 2) - AmOffset(AmWidthOffset::FullTileRight, AmHeightOffset::None).deltaX;
+		screen.y -= AmOffset(AmWidthOffset::None, AmHeightOffset::DoubleTileDown).deltaY * (cells / 2) + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown).deltaY;
 	}
 	if ((ViewPosition.x & 1) != 0) {
-		screen.x -= AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None).deltaX;
-		screen.y -= AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown).deltaY;
+		screen.x -= AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None).deltaX;
+		screen.y -= AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown).deltaY;
 	}
 	if ((ViewPosition.y & 1) != 0) {
-		screen.x += AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None).deltaX;
-		screen.y -= AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown).deltaY;
+		screen.x += AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None).deltaX;
+		screen.y -= AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown).deltaY;
 	}
 
 	screen.x += AutoMapScale * myPlayerOffset.deltaX / 100 / 2;
@@ -972,17 +1063,17 @@ void DrawAutomap(const Surface &out)
 		Point tile1 = screen;
 		for (int j = 0; j < cells; j++) {
 			DrawAutomapTile(out, tile1, { map.x + j, map.y - j });
-			tile1.x += AmOffset(AmWidthOffset::FullTileRight, AmHeightOffset::None).deltaX;
+			tile1.x += AmOffset(AmWidthOffset::DoubleTileRight, AmHeightOffset::None).deltaX;
 		}
 		map.y++;
 
-		Point tile2 = screen + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown);
+		Point tile2 = screen + AmOffset(AmWidthOffset::FullTileLeft, AmHeightOffset::FullTileDown);
 		for (int j = 0; j <= cells; j++) {
 			DrawAutomapTile(out, tile2, { map.x + j, map.y - j });
-			tile2.x += AmOffset(AmWidthOffset::FullTileRight, AmHeightOffset::None).deltaX;
+			tile2.x += AmOffset(AmWidthOffset::DoubleTileRight, AmHeightOffset::None).deltaX;
 		}
 		map.x++;
-		screen.y += AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown).deltaY;
+		screen.y += AmOffset(AmWidthOffset::None, AmHeightOffset::DoubleTileDown).deltaY;
 	}
 
 	//if (leveltype == DTYPE_CAVES)

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -113,253 +113,253 @@ std::array<AutomapTile, 256> AutomapTypeTiles;
 
 void DrawDiamond(const Surface &out, Point center, uint8_t color)
 {
-	const Point left { center.x - AmLine(16), center.y };
-	const Point top { center.x, center.y - AmLine(8) };
-	const Point bottom { center.x, center.y + AmLine(8) };
-
-	DrawMapLineNE(out, left, AmLine(8), color);
-	DrawMapLineSE(out, left, AmLine(8), color);
-	DrawMapLineSE(out, top, AmLine(8), color);
-	DrawMapLineNE(out, bottom, AmLine(8), color);
+	DrawMapLineNE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), AmLine(AmLineLength::FullTile), color);
+	DrawMapLineSE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), AmLine(AmLineLength::FullTile), color);
+	DrawMapLineSE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::FullTile), color);
+	DrawMapLineNE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::FullTile), color);
 }
 
 void DrawMapVerticalDoor(const Surface &out, Point center, uint8_t colorBright, uint8_t colorDim)
 {
-	if (leveltype != DTYPE_CATACOMBS) {
-		DrawMapLineNE(out, { center.x + AmLine(8), center.y - AmLine(4) }, AmLine(4), colorDim);
-		DrawMapLineNE(out, { center.x - AmLine(16), center.y + AmLine(8) }, AmLine(4), colorDim);
-		DrawDiamond(out, center, colorBright);
-	} else {
-		DrawMapLineNE(out, { center.x - AmLine(8), center.y + AmLine(4) }, AmLine(8), colorDim);
-		DrawMapLineNE(out, { center.x - AmLine(16), center.y + AmLine(8) }, AmLine(4), colorDim);
-		DrawDiamond(out, { center.x + AmLine(16), center.y - AmLine(8) }, colorBright);
-	}
+	//if (leveltype != DTYPE_CATACOMBS) {
+	DrawMapLineNE(out, center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), AmLine(AmLineLength::HalfTile), colorDim);
+	DrawMapLineNE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::HalfTile), colorDim);
+	DrawDiamond(out, center, colorBright);
+	//} else {
+	//	DrawMapLineNE(out, { center.x - AmLine(8), center.y + AmLine(4) }, AmLine(8), colorDim);
+	//	DrawMapLineNE(out, { center.x - AmLine(16), center.y + AmLine(8) }, AmLine(4), colorDim);
+	//	DrawDiamond(out, { center.x + AmLine(16), center.y - AmLine(8) }, colorBright);
+	//}
 }
 
 void DrawMapHorizontalDoor(const Surface &out, Point center, uint8_t colorBright, uint8_t colorDim)
 {
-	if (leveltype != DTYPE_CATACOMBS) {
-		DrawMapLineSE(out, { center.x - AmLine(16), center.y - AmLine(8) }, AmLine(4), colorDim);
-		DrawMapLineSE(out, { center.x + AmLine(8), center.y + AmLine(4) }, AmLine(4), colorDim);
-		DrawDiamond(out, center, colorBright);
-	} else {
-		DrawMapLineSE(out, { center.x - AmLine(8), center.y - AmLine(4) }, AmLine(8), colorDim);
-		DrawMapLineSE(out, { center.x + AmLine(8), center.y + AmLine(4) }, AmLine(4), colorDim);
-		DrawDiamond(out, { center.x - AmLine(16), center.y - AmLine(8) }, colorBright);
-	}
+	//if (leveltype != DTYPE_CATACOMBS) {
+	DrawMapLineSE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::HalfTile), colorDim);
+	DrawMapLineSE(out, center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), AmLine(AmLineLength::HalfTile), colorDim);
+	DrawDiamond(out, center, colorBright);
+	//} else {
+	//	DrawMapLineSE(out, { center.x - AmLine(8), center.y - AmLine(4) }, AmLine(8), colorDim);
+	//	DrawMapLineSE(out, { center.x + AmLine(8), center.y + AmLine(4) }, AmLine(4), colorDim);
+	//	DrawDiamond(out, { center.x - AmLine(16), center.y - AmLine(8) }, colorBright);
+	//}
 }
 
 void DrawDirt(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x + AmLine(8) - AmLine(32), center.y + AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(16), center.y }, color);
-	out.SetPixel({ center.x - AmLine(16), center.y + AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileUp), color);
 
-	out.SetPixel({ center.x, center.y - AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::ThreeEighthsTileDown), color);
+
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), color);
 	out.SetPixel(center, color);
-	out.SetPixel({ center.x, center.y + AmLine(8) }, color);
-	out.SetPixel({ center.x, center.y + AmLine(16) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::ThreeEighthsTileDown), color);
 
-	out.SetPixel({ center.x + AmLine(16), center.y }, color);
-	out.SetPixel({ center.x + AmLine(16), center.y + AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileRight, AmHeightOffset::EighthTileDown), color);
 }
 
 void DrawBridge(const Surface &out, Point center, uint8_t color)
 {
 	out.SetPixel(center, color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
 
-	out.SetPixel({ center.x + AmLine(16), center.y }, color);
-	out.SetPixel({ center.x + AmLine(16), center.y + AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileRight, AmHeightOffset::EighthTileDown), color);
 }
 
 void DrawRiverRightIn(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x - AmLine(16), center.y + AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::ThreeEighthsTileDown), color);
 
 	out.SetPixel(center, color);
-	out.SetPixel({ center.x, center.y + AmLine(8) }, color);
-	out.SetPixel({ center.x, center.y + AmLine(16) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::ThreeEighthsTileDown), color);
 
-	out.SetPixel({ center.x + AmLine(16), center.y }, color);
-	out.SetPixel({ center.x + AmLine(16), center.y + AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileRight, AmHeightOffset::EighthTileDown), color);
 }
 
 void DrawRiverCornerSouth(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x, center.y + AmLine(16) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
 }
 
 void DrawRiverCornerNorth(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x - AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x, center.y - AmLine(8) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), color);
 }
 
 void DrawRiverLeftOut(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x + AmLine(8) - AmLine(32), center.y + AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileLeft, AmHeightOffset::EighthTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(16), center.y }, color);
-	out.SetPixel({ center.x - AmLine(16), center.y + AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::ThreeEighthsTileDown), color);
 
 	out.SetPixel(center, color);
-	out.SetPixel({ center.x, center.y + AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::HalfTileDown), color);
 
-	out.SetPixel({ center.x + AmLine(16), center.y }, color);
-	out.SetPixel({ center.x + AmLine(16), center.y + AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileRight, AmHeightOffset::EighthTileDown), color);
 }
 
 void DrawRiverLeftIn(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x - AmLine(16), center.y }, color);
-	out.SetPixel({ center.x - AmLine(16), center.y + AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::ThreeEighthsTileDown), color);
 
-	out.SetPixel({ center.x, center.y - AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), color);
 	out.SetPixel(center, color);
-	out.SetPixel({ center.x, center.y + AmLine(8) }, color);
-	out.SetPixel({ center.x, center.y + AmLine(16) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::ThreeEighthsTileDown), color);
 }
 
 void DrawRiverCornerWest(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x + AmLine(8) - AmLine(32), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(16), center.y }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileLeft, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), color);
 }
 
 void DrawRiverCornerEast(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x + AmLine(16), center.y }, color);
-	out.SetPixel({ center.x + AmLine(16), center.y + AmLine(8) }, color);
-	out.SetPixel({ center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileRight, AmHeightOffset::EighthTileDown), color);
 }
 
 void DrawRiverRightOut(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::ThreeEighthsTileDown), color);
 
 	out.SetPixel(center, color);
-	out.SetPixel({ center.x, center.y + AmLine(8) }, color);
-	out.SetPixel({ center.x, center.y + AmLine(16) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::ThreeEighthsTileDown), color);
 
-	out.SetPixel({ center.x + AmLine(16), center.y }, color);
-	out.SetPixel({ center.x + AmLine(16), center.y + AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileRight, AmHeightOffset::EighthTileDown), color);
 }
 
 void DrawRiver(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x - AmLine(16), center.y + AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::HalfTileDown), color);
 
 	out.SetPixel(center, color);
-	out.SetPixel({ center.x, center.y + AmLine(8) }, color);
-	out.SetPixel({ center.x, center.y + AmLine(16) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::ThreeEighthsTileDown), color);
 
-	out.SetPixel({ center.x + AmLine(16), center.y }, color);
-	out.SetPixel({ center.x + AmLine(16), center.y + AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileRight, AmHeightOffset::EighthTileDown), color);
 }
 
 void DrawRiverForkIn(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x - AmLine(16), center.y }, color);
-	out.SetPixel({ center.x - AmLine(16), center.y + AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::HalfTileDown), color);
 
-	out.SetPixel({ center.x, center.y - AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), color);
 	out.SetPixel(center, color);
-	out.SetPixel({ center.x, center.y + AmLine(8) }, color);
-	out.SetPixel({ center.x, center.y + AmLine(16) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y - AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(4) }, color);
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::ThreeEighthsTileDown), color);
 
-	out.SetPixel({ center.x + AmLine(16), center.y }, color);
-	out.SetPixel({ center.x + AmLine(16), center.y + AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(8) + AmLine(32), center.y + AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileRight, AmHeightOffset::EighthTileDown), color);
 }
 
 void DrawRiverForkOut(const Surface &out, Point center, uint8_t color)
 {
-	out.SetPixel({ center.x + AmLine(8) - AmLine(32), center.y + AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::ThreeEighthsTileLeft, AmHeightOffset::EighthTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(16), center.y }, color);
-	out.SetPixel({ center.x - AmLine(16), center.y + AmLine(8) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
 
-	out.SetPixel({ center.x - AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::ThreeEighthsTileDown), color);
 
-	out.SetPixel({ center.x, center.y + AmLine(16) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
 
-	out.SetPixel({ center.x + AmLine(8), center.y + AmLine(16) - AmLine(4) }, color);
+	out.SetPixel(center + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::ThreeEighthsTileDown), color);
 }
 
 void DrawStairs(const Surface &out, Point center, uint8_t color)
 {
 	constexpr int NumStairSteps = 4;
-	const Displacement offset = { -AmLine(8), AmLine(4) };
-	Point p = { center.x - AmLine(8), center.y - AmLine(8) - AmLine(4) };
+	const Displacement offset = AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown);
+
+	// Initial point based on the 'center' position.
+	Point p = center + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::ThreeEighthsTileUp);
+
 	for (int i = 0; i < NumStairSteps; ++i) {
-		DrawMapLineSE(out, p, AmLine(16), color);
+		DrawMapLineSE(out, p, AmLine(AmLineLength::DoubleTile), color);
 		p += offset;
 	}
 }
@@ -370,17 +370,17 @@ void DrawStairs(const Surface &out, Point center, uint8_t color)
 void DrawHorizontal(const Surface &out, Point center, AutomapTile tile, uint8_t colorBright, uint8_t colorDim)
 {
 	if (!tile.HasFlag(AutomapTile::Flags::HorizontalPassage)) {
-		DrawMapLineSE(out, { center.x, center.y - AmLine(16) }, AmLine(16), colorDim);
+		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), AmLine(AmLineLength::DoubleTile), colorDim);
 		return;
 	}
 	if (tile.HasFlag(AutomapTile::Flags::HorizontalDoor)) {
-		DrawMapHorizontalDoor(out, { center.x + AmLine(16), center.y - AmLine(8) }, colorBright, colorDim);
+		DrawMapHorizontalDoor(out, center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), colorBright, colorDim);
 	}
 	if (tile.HasFlag(AutomapTile::Flags::HorizontalGrate)) {
-		DrawMapLineSE(out, { center.x + AmLine(16), center.y - AmLine(8) }, AmLine(8), colorDim);
-		DrawDiamond(out, { center.x, center.y - AmLine(8) }, colorDim);
+		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::FullTile), colorDim);
+		DrawDiamond(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), colorDim);
 	} else if (tile.HasFlag(AutomapTile::Flags::HorizontalArch)) {
-		DrawDiamond(out, { center.x, center.y - AmLine(8) }, colorDim);
+		DrawDiamond(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), colorDim);
 	}
 }
 
@@ -390,17 +390,17 @@ void DrawHorizontal(const Surface &out, Point center, AutomapTile tile, uint8_t 
 void DrawVertical(const Surface &out, Point center, AutomapTile tile, uint8_t colorBright, uint8_t colorDim)
 {
 	if (!tile.HasFlag(AutomapTile::Flags::VerticalPassage)) {
-		DrawMapLineNE(out, { center.x - AmLine(32), center.y }, AmLine(16), colorDim);
+		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), AmLine(AmLineLength::DoubleTile), colorDim);
 		return;
 	}
-	if (tile.HasFlag(AutomapTile::Flags::VerticalDoor)) { // two wall segments with a door in the middle
-		DrawMapVerticalDoor(out, { center.x - AmLine(16), center.y - AmLine(8) }, colorBright, colorDim);
+	if (tile.HasFlag(AutomapTile::Flags::VerticalDoor)) {
+		DrawMapVerticalDoor(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), colorBright, colorDim);
 	}
-	if (tile.HasFlag(AutomapTile::Flags::VerticalGrate)) { // right-facing half-wall
-		DrawMapLineNE(out, { center.x - AmLine(32), center.y }, AmLine(8), colorDim);
-		DrawDiamond(out, { center.x, center.y - AmLine(8) }, colorDim);
-	} else if (tile.HasFlag(AutomapTile::Flags::VerticalArch)) { // window or passable column
-		DrawDiamond(out, { center.x, center.y - AmLine(8) }, colorDim);
+	if (tile.HasFlag(AutomapTile::Flags::VerticalGrate)) {
+		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), AmLine(AmLineLength::FullTile), colorDim);
+		DrawDiamond(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), colorDim);
+	} else if (tile.HasFlag(AutomapTile::Flags::VerticalArch)) {
+		DrawDiamond(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileUp), colorDim);
 	}
 }
 
@@ -410,9 +410,9 @@ void DrawVertical(const Surface &out, Point center, AutomapTile tile, uint8_t co
 void DrawCaveHorizontal(const Surface &out, Point center, AutomapTile tile, uint8_t colorBright, uint8_t colorDim)
 {
 	if (tile.HasFlag(AutomapTile::Flags::VerticalDoor)) {
-		DrawMapHorizontalDoor(out, { center.x - AmLine(16), center.y + AmLine(8) }, colorBright, colorDim);
+		DrawMapHorizontalDoor(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), colorBright, colorDim);
 	} else {
-		DrawMapLineSE(out, { center.x - AmLine(32), center.y }, AmLine(16), colorDim);
+		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None), AmLine(AmLineLength::DoubleTile), colorDim);
 	}
 }
 
@@ -422,9 +422,9 @@ void DrawCaveHorizontal(const Surface &out, Point center, AutomapTile tile, uint
 void DrawCaveVertical(const Surface &out, Point center, AutomapTile tile, uint8_t colorBright, uint8_t colorDim)
 {
 	if (tile.HasFlag(AutomapTile::Flags::HorizontalDoor)) {
-		DrawMapVerticalDoor(out, { center.x + AmLine(16), center.y + AmLine(8) }, colorBright, colorDim);
+		DrawMapVerticalDoor(out, center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), colorBright, colorDim);
 	} else {
-		DrawMapLineNE(out, { center.x, center.y + AmLine(16) }, AmLine(16), colorDim);
+		DrawMapLineNE(out, { center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown) }, AmLine(AmLineLength::DoubleTile), colorDim);
 	}
 }
 
@@ -528,7 +528,7 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 
 	switch (tile.type) {
 	case AutomapTile::Types::Diamond: // stand-alone column or other unpassable object
-		DrawDiamond(out, { center.x, center.y - AmLine(8) }, colorDim);
+		DrawDiamond(out, { center.x, center.y }, colorDim);
 		break;
 	case AutomapTile::Types::Vertical:
 	case AutomapTile::Types::FenceVertical:
@@ -629,8 +629,8 @@ void SearchAutomapItem(const Surface &out, const Displacement &myPlayerOffset, i
 			int py = j - 2 * AutomapOffset.deltaY - ViewPosition.y;
 
 			Point screen = {
-				(myPlayerOffset.deltaX * AutoMapScale / 100 / 2) + (px - py) * AmLine(16) + gnScreenWidth / 2,
-				(myPlayerOffset.deltaY * AutoMapScale / 100 / 2) + (px + py) * AmLine(8) + (gnScreenHeight - GetMainPanel().size.height) / 2
+				(myPlayerOffset.deltaX * AutoMapScale / 100 / 2) + (px - py) * AmLine(AmLineLength::DoubleTile) + gnScreenWidth / 2,
+				(myPlayerOffset.deltaY * AutoMapScale / 100 / 2) + (px + py) * AmLine(AmLineLength::FullTile) + (gnScreenHeight - GetMainPanel().size.height) / 2
 			};
 
 			if (CanPanelsCoverView()) {
@@ -639,7 +639,7 @@ void SearchAutomapItem(const Surface &out, const Displacement &myPlayerOffset, i
 				if (IsLeftPanelOpen())
 					screen.x += 160;
 			}
-			screen.y -= AmLine(8);
+			screen.y -= AmLine(AmLineLength::FullTile);
 			DrawDiamond(out, screen, MapColorsItem);
 		}
 	}
@@ -666,8 +666,8 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, int 
 		playerOffset = GetOffsetForWalking(player.AnimInfo, player._pdir);
 
 	Point base = {
-		((playerOffset.deltaX + myPlayerOffset.deltaX) * AutoMapScale / 100 / 2) + (px - py) * AmLine(16) + gnScreenWidth / 2,
-		((playerOffset.deltaY + myPlayerOffset.deltaY) * AutoMapScale / 100 / 2) + (px + py) * AmLine(8) + (gnScreenHeight - GetMainPanel().size.height) / 2
+		((playerOffset.deltaX + myPlayerOffset.deltaX) * AutoMapScale / 100 / 2) + (px - py) * AmLine(AmLineLength::DoubleTile) + gnScreenWidth / 2,
+		((playerOffset.deltaY + myPlayerOffset.deltaY) * AutoMapScale / 100 / 2) + (px + py) * AmLine(AmLineLength::FullTile) + (gnScreenHeight - GetMainPanel().size.height) / 2 + TILE_HEIGHT / 2 - 1
 	};
 
 	if (CanPanelsCoverView()) {
@@ -676,56 +676,59 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, int 
 		if (IsLeftPanelOpen())
 			base.x += gnScreenWidth / 4;
 	}
-	base.y -= AmLine(16);
+	base.y -= AmLine(AmLineLength::DoubleTile);
 
 	switch (player._pdir) {
 	case Direction::North: {
-		const Point point { base.x, base.y - AmLine(16) };
-		DrawVerticalLine(out, point, AmLine(16), playerColor);
-		DrawMapLineSteepNE(out, { point.x - AmLine(4), point.y + 2 * AmLine(4) }, AmLine(4), playerColor);
-		DrawMapLineSteepNW(out, { point.x + AmLine(4), point.y + 2 * AmLine(4) }, AmLine(4), playerColor);
+		const Point point = base + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp);
+		DrawVerticalLine(out, point, AmLine(AmLineLength::DoubleTile), playerColor);
+		//DrawMapLineSteepNE(out, { point.x - AmLine(4), point.y + 2 * AmLine(4) }, AmLine(AmLineLength::HalfTile), playerColor);
+		DrawMapLineSteepNE(out, point + AmOffset(AmWidthOffset::SixteenthTileLeft, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::HalfTile), playerColor);
+		//DrawMapLineSteepNW(out, { point.x + AmLine(4), point.y + 2 * AmLine(4) }, AmLine(AmLineLength::HalfTile), playerColor);
+		DrawMapLineSteepNW(out, point + AmOffset(AmWidthOffset::SixteenthTileRight, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::HalfTile), playerColor);
 	} break;
 	case Direction::NorthEast: {
-		const Point point { base.x + AmLine(16), base.y - AmLine(8) };
-		DrawHorizontalLine(out, { point.x - AmLine(8), point.y }, AmLine(8), playerColor);
-		DrawMapLineNE(out, { point.x - 2 * AmLine(8), point.y + AmLine(8) }, AmLine(8), playerColor);
-		DrawMapLineSteepSW(out, point, AmLine(4), playerColor);
+		const Point point = base + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp);
+		DrawHorizontalLine(out, point + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::None), AmLine(AmLineLength::FullTile), playerColor);
+		//DrawMapLineNE(out, { point.x - 2 * AmLine(8), point.y + AmLine(8) }, AmLine(AmLineLength::FullTile), playerColor);
+		DrawMapLineNE(out, point + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::FullTile), playerColor);
+		DrawMapLineSteepSW(out, point, AmLine(AmLineLength::HalfTile), playerColor);
 	} break;
 	case Direction::East: {
-		const Point point { base.x + AmLine(16), base.y };
-		DrawMapLineNW(out, point, AmLine(4), playerColor);
-		DrawHorizontalLine(out, { point.x - AmLine(16), point.y }, AmLine(16), playerColor);
-		DrawMapLineSW(out, point, AmLine(4), playerColor);
+		const Point point = base + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None);
+		DrawMapLineNW(out, point, AmLine(AmLineLength::HalfTile), playerColor);
+		DrawHorizontalLine(out, point + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None), AmLine(AmLineLength::DoubleTile), playerColor);
+		DrawMapLineSW(out, point, AmLine(AmLineLength::HalfTile), playerColor);
 	} break;
 	case Direction::SouthEast: {
-		const Point point { base.x + AmLine(16), base.y + AmLine(8) };
-		DrawMapLineSteepNW(out, point, AmLine(4), playerColor);
-		DrawMapLineSE(out, { point.x - 2 * AmLine(8), point.y - AmLine(8) }, AmLine(8), playerColor);
-		DrawHorizontalLine(out, { point.x - (AmLine(8) + 1), point.y }, AmLine(8) + 1, playerColor);
+		const Point point = base + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown);
+		DrawMapLineSteepNW(out, point, AmLine(AmLineLength::HalfTile), playerColor);
+		DrawMapLineSE(out, point + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::FullTile), playerColor);
+		DrawHorizontalLine(out, point + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::None) + Displacement { -1, 0 }, AmLine(AmLineLength::FullTile) + 1, playerColor);
 	} break;
 	case Direction::South: {
-		const Point point { base.x, base.y + AmLine(16) };
-		DrawVerticalLine(out, { point.x, point.y - AmLine(16) }, AmLine(16), playerColor);
-		DrawMapLineSteepSW(out, { point.x + AmLine(4), point.y - 2 * AmLine(4) }, AmLine(4), playerColor);
-		DrawMapLineSteepSE(out, { point.x - AmLine(4), point.y - 2 * AmLine(4) }, AmLine(4), playerColor);
+		const Point point = base + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown);
+		DrawVerticalLine(out, point + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileUp), AmLine(AmLineLength::DoubleTile), playerColor);
+		DrawMapLineSteepSW(out, point + AmOffset(AmWidthOffset::SixteenthTileRight, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::HalfTile), playerColor);
+		DrawMapLineSteepSE(out, point + AmOffset(AmWidthOffset::SixteenthTileLeft, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::HalfTile), playerColor);
 	} break;
 	case Direction::SouthWest: {
-		const Point point { base.x - AmLine(16), base.y + AmLine(8) };
-		DrawMapLineSteepNE(out, point, AmLine(4), playerColor);
-		DrawMapLineSW(out, { point.x + 2 * AmLine(8), point.y - AmLine(8) }, AmLine(8), playerColor);
-		DrawHorizontalLine(out, point, AmLine(8) + 1, playerColor);
+		const Point point = base + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown);
+		DrawMapLineSteepNE(out, point, AmLine(AmLineLength::HalfTile), playerColor);
+		DrawMapLineSW(out, point + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), AmLine(AmLineLength::FullTile), playerColor);
+		DrawHorizontalLine(out, point, AmLine(AmLineLength::FullTile) + 1, playerColor);
 	} break;
 	case Direction::West: {
-		const Point point { base.x - AmLine(16), base.y };
-		DrawMapLineNE(out, point, AmLine(4), playerColor);
-		DrawHorizontalLine(out, point, AmLine(16) + 1, playerColor);
-		DrawMapLineSE(out, point, AmLine(4), playerColor);
+		const Point point = base + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::None);
+		DrawMapLineNE(out, point, AmLine(AmLineLength::HalfTile), playerColor);
+		DrawHorizontalLine(out, point, AmLine(AmLineLength::DoubleTile) + 1, playerColor);
+		DrawMapLineSE(out, point, AmLine(AmLineLength::HalfTile), playerColor);
 	} break;
 	case Direction::NorthWest: {
-		const Point point { base.x - AmLine(16), base.y - AmLine(8) };
-		DrawMapLineNW(out, { point.x + 2 * AmLine(8), point.y + AmLine(8) }, AmLine(8), playerColor);
-		DrawHorizontalLine(out, point, AmLine(8) + 1, playerColor);
-		DrawMapLineSteepSE(out, point, AmLine(4), playerColor);
+		const Point point = base + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileUp);
+		DrawMapLineNW(out, point + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), AmLine(AmLineLength::FullTile), playerColor);
+		DrawHorizontalLine(out, point, AmLine(AmLineLength::FullTile) + 1, playerColor);
+		DrawMapLineSteepSE(out, point, AmLine(AmLineLength::HalfTile), playerColor);
 	} break;
 	case Direction::NoDirection:
 		break;
@@ -918,7 +921,7 @@ void DrawAutomap(const Surface &out)
 	Displacement myPlayerOffset = {};
 	if (myPlayer.isWalking())
 		myPlayerOffset = GetOffsetForWalking(myPlayer.AnimInfo, myPlayer._pdir, true);
-	myPlayerOffset += Displacement { -1, (leveltype != DTYPE_CAVES) ? TILE_HEIGHT - 1 : -1 };
+	//myPlayerOffset += Displacement { -1, (leveltype != DTYPE_CAVES) ? TILE_HEIGHT - 1 : -1 };
 
 	int d = (AutoMapScale * 64) / 100;
 	int cells = 2 * (gnScreenWidth / 2 / d) + 1;
@@ -931,22 +934,24 @@ void DrawAutomap(const Surface &out)
 
 	Point screen {
 		gnScreenWidth / 2,
-		(gnScreenHeight - GetMainPanel().size.height) / 2
+		(gnScreenHeight - GetMainPanel().size.height) / 2 + TILE_HEIGHT / 2 - 1
 	};
+
 	if ((cells & 1) != 0) {
-		screen.x -= AmLine(64) * ((cells - 1) / 2);
-		screen.y -= AmLine(32) * ((cells + 1) / 2);
+		screen.x -= AmOffset(AmWidthOffset::FullTileRight, AmHeightOffset::None).deltaX * ((cells - 1) / 2);
+		screen.y -= AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown).deltaY * ((cells + 1) / 2);
+		
 	} else {
-		screen.x -= AmLine(64) * (cells / 2) - AmLine(32);
-		screen.y -= AmLine(32) * (cells / 2) + AmLine(16);
+		screen.x -= AmOffset(AmWidthOffset::FullTileRight, AmHeightOffset::None).deltaX * (cells / 2) - AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None).deltaX;
+		screen.y -= AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown).deltaY * (cells / 2) + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown).deltaY;
 	}
 	if ((ViewPosition.x & 1) != 0) {
-		screen.x -= AmLine(16);
-		screen.y -= AmLine(8);
+		screen.x -= AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None).deltaX;
+		screen.y -= AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown).deltaY;
 	}
 	if ((ViewPosition.y & 1) != 0) {
-		screen.x += AmLine(16);
-		screen.y -= AmLine(8);
+		screen.x += AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::None).deltaX;
+		screen.y -= AmOffset(AmWidthOffset::None, AmHeightOffset::QuarterTileDown).deltaY;
 	}
 
 	screen.x += AutoMapScale * myPlayerOffset.deltaX / 100 / 2;
@@ -967,21 +972,21 @@ void DrawAutomap(const Surface &out)
 		Point tile1 = screen;
 		for (int j = 0; j < cells; j++) {
 			DrawAutomapTile(out, tile1, { map.x + j, map.y - j });
-			tile1.x += AmLine(64);
+			tile1.x += AmOffset(AmWidthOffset::FullTileRight, AmHeightOffset::None).deltaX;
 		}
 		map.y++;
 
-		Point tile2 { screen.x - AmLine(32), screen.y + AmLine(16) };
+		Point tile2 = screen + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown);
 		for (int j = 0; j <= cells; j++) {
 			DrawAutomapTile(out, tile2, { map.x + j, map.y - j });
-			tile2.x += AmLine(64);
+			tile2.x += AmOffset(AmWidthOffset::FullTileRight, AmHeightOffset::None).deltaX;
 		}
 		map.x++;
-		screen.y += AmLine(32);
+		screen.y += AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileDown).deltaY;
 	}
 
-	if (leveltype == DTYPE_CAVES)
-		myPlayerOffset.deltaY += TILE_HEIGHT;
+	//if (leveltype == DTYPE_CAVES)
+	//	myPlayerOffset.deltaY += TILE_HEIGHT;
 	for (size_t playerId = 0; playerId < Players.size(); playerId++) {
 		Player &player = Players[playerId];
 		if (player.isOnActiveLevel() && player.plractive && !player._pLvlChanging && (&player == MyPlayer || player.friendlyMode)) {
@@ -989,7 +994,7 @@ void DrawAutomap(const Surface &out)
 		}
 	}
 
-	myPlayerOffset.deltaY -= TILE_HEIGHT / 2;
+	//myPlayerOffset.deltaY -= TILE_HEIGHT / 2;
 	if (AutoMapShowItems)
 		SearchAutomapItem(out, myPlayerOffset, 8, [](Point position) { return dItem[position.x][position.y] != 0; });
 #ifdef _DEBUG

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -589,7 +589,7 @@ void DrawStairs(const Surface &out, Point center, uint8_t color)
 void DrawWallConnections(const Surface &out, Point center, AutomapTile nwTile, AutomapTile neTile, uint8_t colorDim)
 {
 	bool doorCorrection = false;
-	if (IsAnyOf(nwTile.type, AutomapTile::Types::Horizontal, AutomapTile::Types::FenceHorizontal, AutomapTile::Types::Cross, AutomapTile::Types::CaveVerticalWoodCross, AutomapTile::Types::CaveRightCorner)
+	if (IsAnyOf(nwTile.type, AutomapTile::Types::HorizontalWallLava, AutomapTile::Types::Horizontal, AutomapTile::Types::FenceHorizontal, AutomapTile::Types::Cross, AutomapTile::Types::CaveVerticalWoodCross, AutomapTile::Types::CaveRightCorner)
 	    && !nwTile.HasFlag(AutomapTile::Flags::HorizontalArch) && !neTile.HasFlag(AutomapTile::Flags::VerticalArch)) {
 		if (!IsAnyOf(leveltype, DTYPE_CATACOMBS) && nwTile.HasFlag(AutomapTile::Flags::HorizontalDoor)) {
 			doorCorrection = true;
@@ -597,7 +597,7 @@ void DrawWallConnections(const Surface &out, Point center, AutomapTile nwTile, A
 		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileUp, doorCorrection), AmLine(AmLineLength::HalfTile, doorCorrection), colorDim);
 	}
 	doorCorrection = false;
-	if (IsAnyOf(neTile.type, AutomapTile::Types::Vertical, AutomapTile::Types::FenceVertical, AutomapTile::Types::Cross, AutomapTile::Types::CaveHorizontalWoodCross, AutomapTile::Types::CaveLeftCorner)
+	if (IsAnyOf(neTile.type, AutomapTile::Types::VerticalWallLava, AutomapTile::Types::Vertical, AutomapTile::Types::FenceVertical, AutomapTile::Types::Cross, AutomapTile::Types::CaveHorizontalWoodCross, AutomapTile::Types::CaveLeftCorner)
 	    && !nwTile.HasFlag(AutomapTile::Flags::HorizontalArch) && !neTile.HasFlag(AutomapTile::Flags::VerticalArch)) {
 		if (neTile.HasFlag(AutomapTile::Flags::VerticalDoor)) {
 			doorCorrection = true;
@@ -683,17 +683,11 @@ void DrawVertical(const Surface &out, Point center, AutomapTile tile, AutomapTil
 void DrawCaveWallConnections(const Surface &out, Point center, AutomapTile swTile, AutomapTile seTile, uint8_t colorDim)
 {
 	bool doorCorrection = false;
-	if (IsAnyOf(swTile.type, AutomapTile::Types::CaveVertical, AutomapTile::Types::CaveVerticalWood, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross, AutomapTile::Types::CaveLeftWoodCross, AutomapTile::Types::CaveRightCorner)) {
-		//if (swTile.HasFlag(AutomapTile::Flags::HorizontalDoor)) {
-		//	doorCorrection = true;
-		//}
+	if (IsAnyOf(swTile.type, AutomapTile::Types::CaveVerticalWallLava, AutomapTile::Types::CaveVertical, AutomapTile::Types::CaveVerticalWood, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross, AutomapTile::Types::CaveLeftWoodCross, AutomapTile::Types::CaveRightCorner)) {
 		DrawMapLineNE(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown, doorCorrection), AmLine(AmLineLength::HalfTile, doorCorrection), colorDim);
 	}
 	doorCorrection = false;
-	if (IsAnyOf(seTile.type, AutomapTile::Types::CaveHorizontal, AutomapTile::Types::CaveHorizontalWood, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross, AutomapTile::Types::CaveLeftWoodCross, AutomapTile::Types::CaveLeftCorner)) {
-		//if (seTile.HasFlag(AutomapTile::Flags::VerticalDoor)) {
-		//doorCorrection = true;
-		//}
+	if (IsAnyOf(seTile.type, AutomapTile::Types::CaveHorizontalWallLava, AutomapTile::Types::CaveHorizontal, AutomapTile::Types::CaveHorizontalWood, AutomapTile::Types::CaveCross, AutomapTile::Types::CaveWoodCross, AutomapTile::Types::CaveRightWoodCross, AutomapTile::Types::CaveLeftWoodCross, AutomapTile::Types::CaveLeftCorner)) {
 		DrawMapLineSE(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), AmLine(AmLineLength::HalfTile, doorCorrection), colorDim);
 	}
 }
@@ -733,7 +727,7 @@ void DrawCaveHorizontal(const Surface &out, Point center, AutomapTile tile, uint
 /**
  * For caves the horizontal/vertical flags are swapped
  */
-void DrawCaveVertical(const Surface &out, Point center, AutomapTile tile, uint8_t colorBright, uint8_t colorDim)
+void DrawCaveVertical(const Surface &out, Point center, AutomapTile tile, AutomapTile neTile, uint8_t colorBright, uint8_t colorDim)
 {
 	if (tile.HasFlag(AutomapTile::Flags::HorizontalDoor)) {
 		DrawMapVerticalDoorOrGrate(out, center, colorBright, colorDim);
@@ -754,7 +748,11 @@ void DrawCaveVertical(const Surface &out, Point center, AutomapTile tile, uint8_
 			out.SetPixel(center + AmOffset(AmWidthOffset::ThreeQuartersTileRight, AmHeightOffset::QuarterTileDown), colorDim);
 		}
 
-		DrawMapLineNE(out, { center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown) }, AmLine(l), colorDim);
+		bool doorCorrection = false;
+
+		if (neTile.HasFlag(AutomapTile::Flags::HorizontalDoor))
+			doorCorrection = true; // Doesn't look good, but not sure else how to fix pixels overlapping doors without having 2 passes of the AM
+		DrawMapLineNE(out, { center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown) }, AmLine(l, doorCorrection), colorDim);
 	}
 }
 
@@ -832,11 +830,11 @@ AutomapTile GetAutomapTypeView(Point map)
 		return {};
 	}
 
+	// TODO: Patch AMP data directly instead of the following
 	uint8_t tile = dungeon[map.x][map.y];
 	// This tile incorrectly has flags for both HorizontalArch and VerticalArch in the amp data
 	if (leveltype == DTYPE_CATACOMBS && tile == 42)
 		return { AutomapTile::Types::Cross, AutomapTile::Flags::VerticalArch };
-	// Manually set cave corners so we can draw them
 	if (IsAnyOf(leveltype, DTYPE_CAVES, DTYPE_NEST)) {
 		switch (tile) {
 		case 5:
@@ -875,11 +873,9 @@ AutomapTile GetAutomapTypeView(Point map)
 		case 140:
 			return { AutomapTile::Types::CaveLeftWoodCross };
 		case 15:
-			return { AutomapTile::Types::HorizontalLavaThin };
 		case 16:
 			return { AutomapTile::Types::HorizontalLavaThin };
 		case 17:
-			return { AutomapTile::Types::VerticalLavaThin };
 		case 18:
 			return { AutomapTile::Types::VerticalLavaThin };
 		case 19:
@@ -1017,7 +1013,7 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 	case AutomapTile::Types::CaveVerticalCross:
 	case AutomapTile::Types::CaveVerticalWoodCross:
 		DrawHorizontal(out, center, tile, nwTile, neTile, seTile, colorBright, colorDim, noConnect);
-		DrawCaveVertical(out, center, tile, colorBright, colorDim);
+		DrawCaveVertical(out, center, tile, neTile, colorBright, colorDim);
 		break;
 	case AutomapTile::Types::CaveHorizontal:
 	case AutomapTile::Types::CaveHorizontalWood:
@@ -1025,14 +1021,14 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 		break;
 	case AutomapTile::Types::CaveVertical:
 	case AutomapTile::Types::CaveVerticalWood:
-		DrawCaveVertical(out, center, tile, colorBright, colorDim);
+		DrawCaveVertical(out, center, tile, neTile, colorBright, colorDim);
 		break;
 	case AutomapTile::Types::CaveCross:
 	case AutomapTile::Types::CaveWoodCross:
 	case AutomapTile::Types::CaveRightWoodCross:
 	case AutomapTile::Types::CaveLeftWoodCross:
 		DrawCaveHorizontal(out, center, tile, colorBright, colorDim);
-		DrawCaveVertical(out, center, tile, colorBright, colorDim);
+		DrawCaveVertical(out, center, tile, neTile, colorBright, colorDim);
 		break;
 	case AutomapTile::Types::CaveLeftCorner:
 		DrawCaveLeftCorner(out, center, colorDim);
@@ -1138,7 +1134,7 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 		DrawLavaRiver<Direction::NorthEast, Direction::NoDirection>(out, center, MapColorsLava, false);
 		break;
 	case AutomapTile::Types::CaveVerticalWallLava:
-		DrawCaveVertical(out, center, tile, colorBright, colorDim);
+		DrawCaveVertical(out, center, tile, neTile, colorBright, colorDim);
 		DrawLavaRiver<Direction::NorthWest, Direction::NoDirection>(out, center, MapColorsLava, false);
 		break;
 	case AutomapTile::Types::HorizontalBridgeLava:

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1313,6 +1313,9 @@ void InitAutomap()
 	size_t tileCount = 0;
 	std::unique_ptr<AutomapTile[]> tileTypes = LoadAutomapData(tileCount);
 
+	if (IsAnyOf(leveltype, DTYPE_CATACOMBS)) {
+		tileTypes[41] = { AutomapTile::Types::FenceHorizontal };
+	}
 	if (IsAnyOf(leveltype, DTYPE_TOWN, DTYPE_CAVES, DTYPE_NEST)) {
 		tileTypes[4] = { AutomapTile::Types::CaveBottomCorner };
 		tileTypes[12] = { AutomapTile::Types::CaveRightCorner };

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -35,48 +35,40 @@ extern uint8_t AutomapView[DMAXX][DMAXY];
 /** Specifies the scale of the automap. */
 extern DVL_API_FOR_TEST int AutoMapScale;
 extern DVL_API_FOR_TEST Displacement AutomapOffset;
+
 /** Defines the offsets used for Automap lines */
 enum class AmWidthOffset : int8_t {
 	None,
-
 	EighthTileRight = TILE_WIDTH >> 4,
 	QuarterTileRight = TILE_WIDTH >> 3,
 	HalfTileRight = TILE_WIDTH >> 2,
+	ThreeQuartersTileRight = (TILE_WIDTH >> 1) - (TILE_WIDTH >> 3),
 	FullTileRight = TILE_WIDTH >> 1,
 	DoubleTileRight = TILE_WIDTH,
-
-	ThreeQuartersTileRight = FullTileRight - QuarterTileRight,
-
 	EighthTileLeft = -EighthTileRight,
 	QuarterTileLeft = -QuarterTileRight,
 	HalfTileLeft = -HalfTileRight,
+	ThreeQuartersTileLeft = -ThreeQuartersTileRight,
 	FullTileLeft = -FullTileRight,
 	DoubleTileLeft = -DoubleTileRight,
-
-	ThreeQuartersTileLeft = -ThreeQuartersTileRight,
 };
 
 enum class AmHeightOffset : int8_t {
 	None,
-
 	QuarterTileDown = TILE_HEIGHT >> 3,
 	HalfTileDown = TILE_HEIGHT >> 2,
+	ThreeQuartersTileDown = (TILE_HEIGHT >> 1) - (TILE_HEIGHT >> 3),
 	FullTileDown = TILE_HEIGHT >> 1,
 	DoubleTileDown = TILE_HEIGHT,
-
-	ThreeQuartersTileDown = FullTileDown - QuarterTileDown,
-
 	QuarterTileUp = -QuarterTileDown,
 	HalfTileUp = -HalfTileDown,
+	ThreeQuartersTileUp = -ThreeQuartersTileDown,
 	FullTileUp = -FullTileDown,
 	DoubleTileUp = -DoubleTileDown,
-
-	ThreeQuartersTileUp = -ThreeQuartersTileDown,
 };
 
 enum class AmLineLength : uint8_t {
 	QuarterTile = 2,
-	ThirdTile = 3,
 	HalfTile = 4,
 	FullTile = 8,
 	FullAndHalfTile = 12,

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -35,12 +35,62 @@ extern uint8_t AutomapView[DMAXX][DMAXY];
 /** Specifies the scale of the automap. */
 extern DVL_API_FOR_TEST int AutoMapScale;
 extern DVL_API_FOR_TEST Displacement AutomapOffset;
+/** Defines the offsets used for Automap lines */
+enum class AmWidthOffset : int8_t {
+	None,
 
-inline int AmLine(int x)
+	SixteenthTileRight = TILE_WIDTH >> 4,
+	EighthTileRight = TILE_WIDTH >> 3,
+	QuarterTileRight = TILE_WIDTH >> 2,
+	HalfTileRight = TILE_WIDTH >> 1,
+	FullTileRight = TILE_WIDTH,
+
+	ThreeEighthsTileRight = HalfTileRight - EighthTileRight,
+
+	SixteenthTileLeft = -SixteenthTileRight,
+	EighthTileLeft = -EighthTileRight,
+	QuarterTileLeft = -QuarterTileRight,
+	HalfTileLeft = -HalfTileRight,
+	FullTileLeft = -FullTileRight,
+
+	ThreeEighthsTileLeft = -ThreeEighthsTileRight,
+};
+
+enum class AmHeightOffset : int8_t {
+	None,
+
+	EighthTileDown = TILE_HEIGHT >> 3,
+	QuarterTileDown = TILE_HEIGHT >> 2,
+	HalfTileDown = TILE_HEIGHT >> 1,
+	FullTileDown = TILE_HEIGHT,
+
+	ThreeEighthsTileDown = HalfTileDown - EighthTileDown,
+	//SixEighthsTileDown = HalfTileDown + EighthTileDown,
+
+	EighthTileUp = -EighthTileDown,
+	QuarterTileUp = -QuarterTileDown,
+	HalfTileUp = -HalfTileDown,
+	FullTileUp = -FullTileDown,
+
+	ThreeEighthsTileUp = -ThreeEighthsTileDown,
+};
+
+enum class AmLineLength : uint8_t {
+	EighthTile = 1,
+	QuarterTile = 2,
+	HalfTile = 4,
+	FullTile = 8,
+	DoubleTile = 16,
+};
+
+inline Displacement AmOffset(AmWidthOffset x, AmHeightOffset y)
 {
-	assert(x >= 4 && x <= 64);
-	assert((x & (x - 1)) == 0);
-	return AutoMapScale * x / 100;
+	return { AutoMapScale * static_cast<int>(x) / 100, AutoMapScale * static_cast<int>(y) / 100 };
+}
+
+inline int AmLine(AmLineLength l)
+{
+	return AutoMapScale * static_cast<int>(l) / 100;
 }
 
 /**

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -55,11 +55,13 @@ enum class AmWidthOffset : int8_t {
 
 enum class AmHeightOffset : int8_t {
 	None,
+	EighthTileDown = TILE_HEIGHT >> 4,
 	QuarterTileDown = TILE_HEIGHT >> 3,
 	HalfTileDown = TILE_HEIGHT >> 2,
 	ThreeQuartersTileDown = (TILE_HEIGHT >> 1) - (TILE_HEIGHT >> 3),
 	FullTileDown = TILE_HEIGHT >> 1,
 	DoubleTileDown = TILE_HEIGHT,
+	EighthTileUp = -EighthTileDown,
 	QuarterTileUp = -QuarterTileDown,
 	HalfTileUp = -HalfTileDown,
 	ThreeQuartersTileUp = -ThreeQuartersTileDown,

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -39,40 +39,40 @@ extern DVL_API_FOR_TEST Displacement AutomapOffset;
 enum class AmWidthOffset : int8_t {
 	None,
 
-	SixteenthTileRight = TILE_WIDTH >> 4,
-	EighthTileRight = TILE_WIDTH >> 3,
-	QuarterTileRight = TILE_WIDTH >> 2,
-	HalfTileRight = TILE_WIDTH >> 1,
-	FullTileRight = TILE_WIDTH,
+	EighthTileRight = TILE_WIDTH >> 4,
+	QuarterTileRight = TILE_WIDTH >> 3,
+	HalfTileRight = TILE_WIDTH >> 2,
+	FullTileRight = TILE_WIDTH >> 1,
+	DoubleTileRight = TILE_WIDTH,
 
-	ThreeEighthsTileRight = HalfTileRight - EighthTileRight,
+	ThreeQuartersTileRight = FullTileRight - QuarterTileRight,
 
-	SixteenthTileLeft = -SixteenthTileRight,
 	EighthTileLeft = -EighthTileRight,
 	QuarterTileLeft = -QuarterTileRight,
 	HalfTileLeft = -HalfTileRight,
 	FullTileLeft = -FullTileRight,
+	DoubleTileLeft = -DoubleTileRight,
 
-	ThreeEighthsTileLeft = -ThreeEighthsTileRight,
+	ThreeQuartersTileLeft = -ThreeQuartersTileRight,
 };
 
 enum class AmHeightOffset : int8_t {
 	None,
 
-	EighthTileDown = TILE_HEIGHT >> 3,
-	QuarterTileDown = TILE_HEIGHT >> 2,
-	HalfTileDown = TILE_HEIGHT >> 1,
-	FullTileDown = TILE_HEIGHT,
+	QuarterTileDown = TILE_HEIGHT >> 3,
+	HalfTileDown = TILE_HEIGHT >> 2,
+	FullTileDown = TILE_HEIGHT >> 1,
+	DoubleTileDown = TILE_HEIGHT,
 
-	ThreeEighthsTileDown = HalfTileDown - EighthTileDown,
-	//SixEighthsTileDown = HalfTileDown + EighthTileDown,
+	ThreeQuartersTileDown = FullTileDown - QuarterTileDown,
+	//SixEighthsTileDown = FullTileDown + QuarterTileDown,
 
-	EighthTileUp = -EighthTileDown,
 	QuarterTileUp = -QuarterTileDown,
 	HalfTileUp = -HalfTileDown,
 	FullTileUp = -FullTileDown,
+	DoubleTileUp = -DoubleTileDown,
 
-	ThreeEighthsTileUp = -ThreeEighthsTileDown,
+	ThreeQuartersTileUp = -ThreeQuartersTileDown,
 };
 
 enum class AmLineLength : uint8_t {
@@ -80,6 +80,7 @@ enum class AmLineLength : uint8_t {
 	QuarterTile = 2,
 	HalfTile = 4,
 	FullTile = 8,
+	FullAndHalfTile = 12,
 	DoubleTile = 16,
 };
 

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -85,14 +85,14 @@ enum class AmLineLength : uint8_t {
 	DoubleTile = 16,
 };
 
-inline Displacement AmOffset(AmWidthOffset x, AmHeightOffset y, bool doorCorrection = false)
+inline Displacement AmOffset(AmWidthOffset x, AmHeightOffset y)
 {
-	return { AutoMapScale * static_cast<int>(x) / 100 + (doorCorrection ? 1 : 0), AutoMapScale * static_cast<int>(y) / 100 + (doorCorrection ? 1 : 0) };
+	return { AutoMapScale * static_cast<int>(x) / 100, AutoMapScale * static_cast<int>(y) / 100 };
 }
 
-inline int AmLine(AmLineLength l, bool doorCorrection = false)
+inline int AmLine(AmLineLength l)
 {
-	return AutoMapScale * static_cast<int>(l) / 100 - (doorCorrection ? 1 : 0);
+	return AutoMapScale * static_cast<int>(l) / 100;
 }
 
 /**

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -78,20 +78,21 @@ enum class AmHeightOffset : int8_t {
 enum class AmLineLength : uint8_t {
 	EighthTile = 1,
 	QuarterTile = 2,
+	ThirdTile = 3,
 	HalfTile = 4,
 	FullTile = 8,
 	FullAndHalfTile = 12,
 	DoubleTile = 16,
 };
 
-inline Displacement AmOffset(AmWidthOffset x, AmHeightOffset y)
+inline Displacement AmOffset(AmWidthOffset x, AmHeightOffset y, bool doorCorrection = false)
 {
-	return { AutoMapScale * static_cast<int>(x) / 100, AutoMapScale * static_cast<int>(y) / 100 };
+	return { AutoMapScale * static_cast<int>(x) / 100 + (doorCorrection ? 1 : 0), AutoMapScale * static_cast<int>(y) / 100 + (doorCorrection ? 1 : 0) };
 }
 
-inline int AmLine(AmLineLength l)
+inline int AmLine(AmLineLength l, bool doorCorrection = false)
 {
-	return AutoMapScale * static_cast<int>(l) / 100;
+	return AutoMapScale * static_cast<int>(l) / 100 - (doorCorrection ? 1 : 0);
 }
 
 /**

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -75,7 +75,6 @@ enum class AmHeightOffset : int8_t {
 };
 
 enum class AmLineLength : uint8_t {
-	EighthTile = 1,
 	QuarterTile = 2,
 	ThirdTile = 3,
 	HalfTile = 4,

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -65,7 +65,6 @@ enum class AmHeightOffset : int8_t {
 	DoubleTileDown = TILE_HEIGHT,
 
 	ThreeQuartersTileDown = FullTileDown - QuarterTileDown,
-	//SixEighthsTileDown = FullTileDown + QuarterTileDown,
 
 	QuarterTileUp = -QuarterTileDown,
 	HalfTileUp = -HalfTileDown,

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3961,6 +3961,7 @@ void DeleteMonsterList()
 
 void ProcessMonsters()
 {
+	return;
 	DeleteMonsterList();
 
 	assert(ActiveMonsterCount <= MaxMonsters);
@@ -3998,7 +3999,7 @@ void ProcessMonsters()
 				PlaySFX(USFX_DEFILER8);
 			UpdateEnemy(monster);
 		}
-
+		
 		if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0) {
 			assert(monster.enemy >= 0 && monster.enemy < MaxMonsters);
 			// BUGFIX: enemy target may be dead at time of access, thus reading garbage data from `Monsters[monster.enemy].position.future`.
@@ -4028,6 +4029,7 @@ void ProcessMonsters()
 		if (monster.mode != MonsterMode::Petrified && (monster.flags & MFLAG_ALLOW_SPECIAL) == 0) {
 			monster.animInfo.processAnimation((monster.flags & MFLAG_LOCK_ANIMATION) != 0);
 		}
+		
 	}
 
 	DeleteMonsterList();

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3961,7 +3961,6 @@ void DeleteMonsterList()
 
 void ProcessMonsters()
 {
-	return;
 	DeleteMonsterList();
 
 	assert(ActiveMonsterCount <= MaxMonsters);
@@ -3999,7 +3998,6 @@ void ProcessMonsters()
 				PlaySFX(USFX_DEFILER8);
 			UpdateEnemy(monster);
 		}
-		
 		if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0) {
 			assert(monster.enemy >= 0 && monster.enemy < MaxMonsters);
 			// BUGFIX: enemy target may be dead at time of access, thus reading garbage data from `Monsters[monster.enemy].position.future`.
@@ -4031,7 +4029,6 @@ void ProcessMonsters()
 		}
 		
 	}
-
 	DeleteMonsterList();
 }
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3998,6 +3998,7 @@ void ProcessMonsters()
 				PlaySFX(USFX_DEFILER8);
 			UpdateEnemy(monster);
 		}
+
 		if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0) {
 			assert(monster.enemy >= 0 && monster.enemy < MaxMonsters);
 			// BUGFIX: enemy target may be dead at time of access, thus reading garbage data from `Monsters[monster.enemy].position.future`.
@@ -4027,8 +4028,8 @@ void ProcessMonsters()
 		if (monster.mode != MonsterMode::Petrified && (monster.flags & MFLAG_ALLOW_SPECIAL) == 0) {
 			monster.animInfo.processAnimation((monster.flags & MFLAG_LOCK_ANIMATION) != 0);
 		}
-		
 	}
+
 	DeleteMonsterList();
 }
 

--- a/test/automap_test.cpp
+++ b/test/automap_test.cpp
@@ -65,24 +65,24 @@ TEST(Automap, AutomapZoomIn)
 	AutoMapScale = 50;
 	AutomapZoomIn();
 	EXPECT_EQ(AutoMapScale, 75);
-	EXPECT_EQ(AmLine(64), 48);
-	EXPECT_EQ(AmLine(32), 24);
-	EXPECT_EQ(AmLine(16), 12);
-	EXPECT_EQ(AmLine(8), 6);
-	EXPECT_EQ(AmLine(4), 3);
+	EXPECT_EQ(AmLine(AmLineLength::FullTile), static_cast<AmLineLength>(6));
+	EXPECT_EQ(AmLine(AmLineLength::HalfTile), AmLineLength::ThirdTile);
+	EXPECT_EQ(AmLine(AmLineLength::ThirdTile), AmLineLength::QuarterTile);
+	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), static_cast<AmLineLength>(1));
 }
 
 TEST(Automap, AutomapZoomIn_Max)
 {
 	AutoMapScale = 175;
+	AutoMapScale = 175;
 	AutomapZoomIn();
 	AutomapZoomIn();
 	EXPECT_EQ(AutoMapScale, 200);
-	EXPECT_EQ(AmLine(64), 128);
-	EXPECT_EQ(AmLine(32), 64);
-	EXPECT_EQ(AmLine(16), 32);
-	EXPECT_EQ(AmLine(8), 16);
-	EXPECT_EQ(AmLine(4), 8);
+	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), static_cast<AmLineLength>(32));
+	EXPECT_EQ(AmLine(AmLineLength::FullTile), AmLineLength::DoubleTile);
+	EXPECT_EQ(AmLine(AmLineLength::HalfTile), AmLineLength::FullTile);
+	EXPECT_EQ(AmLine(AmLineLength::ThirdTile), static_cast<AmLineLength>(6));
+	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), AmLineLength::HalfTile);
 }
 
 TEST(Automap, AutomapZoomOut)

--- a/test/automap_test.cpp
+++ b/test/automap_test.cpp
@@ -9,11 +9,11 @@ TEST(Automap, InitAutomap)
 	InitAutomapOnce();
 	EXPECT_EQ(AutomapActive, false);
 	EXPECT_EQ(AutoMapScale, 50);
-	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), static_cast<int>(AmLineLength::HalfTile));
+	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), static_cast<int>(AmLineLength::FullTile));
 	EXPECT_EQ(AmLine(AmLineLength::FullAndHalfTile), 6);
-	EXPECT_EQ(AmLine(AmLineLength::FullTile), static_cast<int>(AmLineLength::QuarterTile));
-	EXPECT_EQ(AmLine(AmLineLength::HalfTile), 1);
-	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), 0);
+	EXPECT_EQ(AmLine(AmLineLength::FullTile), static_cast<int>(AmLineLength::HalfTile));
+	EXPECT_EQ(AmLine(AmLineLength::HalfTile), static_cast<int>(AmLineLength::QuarterTile));
+	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), 1);
 }
 
 TEST(Automap, StartAutomap)

--- a/test/automap_test.cpp
+++ b/test/automap_test.cpp
@@ -9,11 +9,11 @@ TEST(Automap, InitAutomap)
 	InitAutomapOnce();
 	EXPECT_EQ(AutomapActive, false);
 	EXPECT_EQ(AutoMapScale, 50);
-	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), AmLineLength::HalfTile);
-	EXPECT_EQ(AmLine(AmLineLength::FullAndHalfTile), static_cast<AmLineLength>(6));
-	EXPECT_EQ(AmLine(AmLineLength::FullTile), AmLineLength::QuarterTile);
-	EXPECT_EQ(AmLine(AmLineLength::HalfTile), static_cast<AmLineLength>(1));
-	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), static_cast<AmLineLength>(0));
+	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), static_cast<int>(AmLineLength::HalfTile));
+	EXPECT_EQ(AmLine(AmLineLength::FullAndHalfTile), 6);
+	EXPECT_EQ(AmLine(AmLineLength::FullTile), static_cast<int>(AmLineLength::QuarterTile));
+	EXPECT_EQ(AmLine(AmLineLength::HalfTile), 1);
+	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), 0);
 }
 
 TEST(Automap, StartAutomap)
@@ -65,10 +65,10 @@ TEST(Automap, AutomapZoomIn)
 	AutoMapScale = 50;
 	AutomapZoomIn();
 	EXPECT_EQ(AutoMapScale, 75);
-	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), AmLineLength::FullAndHalfTile);
-	EXPECT_EQ(AmLine(AmLineLength::FullTile), static_cast<AmLineLength>(6));
-	EXPECT_EQ(AmLine(AmLineLength::HalfTile), static_cast<AmLineLength>(3));
-	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), static_cast<AmLineLength>(1));
+	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), static_cast<int>(AmLineLength::FullAndHalfTile));
+	EXPECT_EQ(AmLine(AmLineLength::FullTile), 6);
+	EXPECT_EQ(AmLine(AmLineLength::HalfTile), 3);
+	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), 1);
 }
 
 TEST(Automap, AutomapZoomIn_Max)
@@ -78,10 +78,10 @@ TEST(Automap, AutomapZoomIn_Max)
 	AutomapZoomIn();
 	AutomapZoomIn();
 	EXPECT_EQ(AutoMapScale, 200);
-	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), static_cast<AmLineLength>(32));
-	EXPECT_EQ(AmLine(AmLineLength::FullTile), AmLineLength::DoubleTile);
-	EXPECT_EQ(AmLine(AmLineLength::HalfTile), AmLineLength::FullTile);
-	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), AmLineLength::HalfTile);
+	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), 32);
+	EXPECT_EQ(AmLine(AmLineLength::FullTile), static_cast<int>(AmLineLength::DoubleTile));
+	EXPECT_EQ(AmLine(AmLineLength::HalfTile), static_cast<int>(AmLineLength::FullTile));
+	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), static_cast<int>(AmLineLength::HalfTile));
 }
 
 TEST(Automap, AutomapZoomOut)
@@ -89,10 +89,10 @@ TEST(Automap, AutomapZoomOut)
 	AutoMapScale = 200;
 	AutomapZoomOut();
 	EXPECT_EQ(AutoMapScale, 175);
-	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), static_cast<AmLineLength>(28));
-	EXPECT_EQ(AmLine(AmLineLength::FullTile), static_cast<AmLineLength>(14));
-	EXPECT_EQ(AmLine(AmLineLength::HalfTile), static_cast<AmLineLength>(7));
-	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), static_cast<AmLineLength>(3));
+	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), 28);
+	EXPECT_EQ(AmLine(AmLineLength::FullTile), 14);
+	EXPECT_EQ(AmLine(AmLineLength::HalfTile), 7);
+	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), 3);
 }
 
 TEST(Automap, AutomapZoomOut_Min)
@@ -101,10 +101,10 @@ TEST(Automap, AutomapZoomOut_Min)
 	AutomapZoomOut();
 	AutomapZoomOut();
 	EXPECT_EQ(AutoMapScale, 25);
-	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), AmLineLength::HalfTile);
-	EXPECT_EQ(AmLine(AmLineLength::FullTile), AmLineLength::QuarterTile);
-	EXPECT_EQ(AmLine(AmLineLength::HalfTile), static_cast<AmLineLength>(1));
-	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), static_cast<AmLineLength>(0));
+	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), static_cast<int>(AmLineLength::HalfTile));
+	EXPECT_EQ(AmLine(AmLineLength::FullTile), static_cast<int>(AmLineLength::QuarterTile));
+	EXPECT_EQ(AmLine(AmLineLength::HalfTile), 1);
+	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), 0);
 }
 
 TEST(Automap, AutomapZoomReset)
@@ -116,8 +116,8 @@ TEST(Automap, AutomapZoomReset)
 	EXPECT_EQ(AutomapOffset.deltaX, 0);
 	EXPECT_EQ(AutomapOffset.deltaY, 0);
 	EXPECT_EQ(AutoMapScale, 50);
-	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), AmLineLength::FullTile);
-	EXPECT_EQ(AmLine(AmLineLength::FullTile), AmLineLength::HalfTile);
-	EXPECT_EQ(AmLine(AmLineLength::HalfTile), AmLineLength::QuarterTile);
-	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), static_cast<AmLineLength>(1));
+	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), static_cast<int>(AmLineLength::FullTile));
+	EXPECT_EQ(AmLine(AmLineLength::FullTile), static_cast<int>(AmLineLength::HalfTile));
+	EXPECT_EQ(AmLine(AmLineLength::HalfTile), static_cast<int>(AmLineLength::QuarterTile));
+	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), 1);
 }

--- a/test/automap_test.cpp
+++ b/test/automap_test.cpp
@@ -9,11 +9,11 @@ TEST(Automap, InitAutomap)
 	InitAutomapOnce();
 	EXPECT_EQ(AutomapActive, false);
 	EXPECT_EQ(AutoMapScale, 50);
-	EXPECT_EQ(AmLine(64), 32);
-	EXPECT_EQ(AmLine(32), 16);
-	EXPECT_EQ(AmLine(16), 8);
-	EXPECT_EQ(AmLine(8), 4);
-	EXPECT_EQ(AmLine(4), 2);
+	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), AmLineLength::HalfTile);
+	EXPECT_EQ(AmLine(AmLineLength::FullAndHalfTile), static_cast<AmLineLength>(6));
+	EXPECT_EQ(AmLine(AmLineLength::FullTile), AmLineLength::QuarterTile);
+	EXPECT_EQ(AmLine(AmLineLength::HalfTile), static_cast<AmLineLength>(1));
+	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), static_cast<AmLineLength>(0));
 }
 
 TEST(Automap, StartAutomap)

--- a/test/automap_test.cpp
+++ b/test/automap_test.cpp
@@ -65,9 +65,9 @@ TEST(Automap, AutomapZoomIn)
 	AutoMapScale = 50;
 	AutomapZoomIn();
 	EXPECT_EQ(AutoMapScale, 75);
+	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), AmLineLength::FullAndHalfTile);
 	EXPECT_EQ(AmLine(AmLineLength::FullTile), static_cast<AmLineLength>(6));
-	EXPECT_EQ(AmLine(AmLineLength::HalfTile), AmLineLength::ThirdTile);
-	EXPECT_EQ(AmLine(AmLineLength::ThirdTile), AmLineLength::QuarterTile);
+	EXPECT_EQ(AmLine(AmLineLength::HalfTile), static_cast<AmLineLength>(3));
 	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), static_cast<AmLineLength>(1));
 }
 
@@ -81,7 +81,6 @@ TEST(Automap, AutomapZoomIn_Max)
 	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), static_cast<AmLineLength>(32));
 	EXPECT_EQ(AmLine(AmLineLength::FullTile), AmLineLength::DoubleTile);
 	EXPECT_EQ(AmLine(AmLineLength::HalfTile), AmLineLength::FullTile);
-	EXPECT_EQ(AmLine(AmLineLength::ThirdTile), static_cast<AmLineLength>(6));
 	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), AmLineLength::HalfTile);
 }
 
@@ -90,11 +89,10 @@ TEST(Automap, AutomapZoomOut)
 	AutoMapScale = 200;
 	AutomapZoomOut();
 	EXPECT_EQ(AutoMapScale, 175);
-	EXPECT_EQ(AmLine(64), 112);
-	EXPECT_EQ(AmLine(32), 56);
-	EXPECT_EQ(AmLine(16), 28);
-	EXPECT_EQ(AmLine(8), 14);
-	EXPECT_EQ(AmLine(4), 7);
+	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), static_cast<AmLineLength>(28));
+	EXPECT_EQ(AmLine(AmLineLength::FullTile), static_cast<AmLineLength>(14));
+	EXPECT_EQ(AmLine(AmLineLength::HalfTile), static_cast<AmLineLength>(7));
+	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), static_cast<AmLineLength>(3));
 }
 
 TEST(Automap, AutomapZoomOut_Min)
@@ -103,11 +101,10 @@ TEST(Automap, AutomapZoomOut_Min)
 	AutomapZoomOut();
 	AutomapZoomOut();
 	EXPECT_EQ(AutoMapScale, 25);
-	EXPECT_EQ(AmLine(64), 16);
-	EXPECT_EQ(AmLine(32), 8);
-	EXPECT_EQ(AmLine(16), 4);
-	EXPECT_EQ(AmLine(8), 2);
-	EXPECT_EQ(AmLine(4), 1);
+	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), AmLineLength::HalfTile);
+	EXPECT_EQ(AmLine(AmLineLength::FullTile), AmLineLength::QuarterTile);
+	EXPECT_EQ(AmLine(AmLineLength::HalfTile), static_cast<AmLineLength>(1));
+	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), static_cast<AmLineLength>(0));
 }
 
 TEST(Automap, AutomapZoomReset)
@@ -119,9 +116,8 @@ TEST(Automap, AutomapZoomReset)
 	EXPECT_EQ(AutomapOffset.deltaX, 0);
 	EXPECT_EQ(AutomapOffset.deltaY, 0);
 	EXPECT_EQ(AutoMapScale, 50);
-	EXPECT_EQ(AmLine(64), 32);
-	EXPECT_EQ(AmLine(32), 16);
-	EXPECT_EQ(AmLine(16), 8);
-	EXPECT_EQ(AmLine(8), 4);
-	EXPECT_EQ(AmLine(4), 2);
+	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), AmLineLength::FullTile);
+	EXPECT_EQ(AmLine(AmLineLength::FullTile), AmLineLength::HalfTile);
+	EXPECT_EQ(AmLine(AmLineLength::HalfTile), AmLineLength::QuarterTile);
+	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), static_cast<AmLineLength>(1));
 }


### PR DESCRIPTION
This is a hefty one. The automap has some issues:
* Automap scales that aren't multiples of 25 can produce misaligned pixels and lines
* Automap functions draw lines beyond the boundaries of their respective megatile, making it problematic to correctly align Catacombs doors
* Caves automap incorrectly draws A LOT

## Foundational Changes:
* `AmLine()` split into `AmOffset()` and `AmLine()`
    - `AmLine()` was used for both offsetting `Point` as well as providing the length for drawn lines.
* Enumerators for `AmOffset()` arguments: `AmWidthOffset` and `AmHeightOffset`
    - This way of using enumerators allows us to intuitively adjust offsets without needing to reference `TILE_WIDTH` and `TILE_HEIGHT`, and also softcodes these values. The enumerators are set to values that are friendly with the original `assert` found in `AmLine()`, intended to keep everything aligned to a grid.
* Enumerators for `AmLine()` argument: `AmLineLength`
* `center` offset moved from the center of the top tile to the center of the megatile
    - Automap tiles are a full megatile in size, and are drawn mostly to cover the bounds of the megatile, however, due to drawing from the center of the top tile, the entire automap appears to be a half tile too high. This was recently corrected with a workaround hack in 1.5.1.
* Automap lines no longer are drawn outside their respective megatile boundaries
    - Previously, lines were drawn beyond the boundaries of the megatile in order to avoid leaving gaps in walls. I found this behavior to have edge cases where it was problematic. Therefore, tiles have "connection lines" drawn within a megatile to fill in gaps, with logic that depends on the context of the megatile being checked, and surrounding megatiles. These lines are drawn at the top of the megatile facing NW and/or NE. There is a caves version, due to the nature of cave walls, which draws lines at the bottom of the megatile facing SW and/or SE.
    
## Changes:
* Many shape drawing functions were revised
    - Many shapes were incorrectly drawn; The most noticeable case of this is in the Caves. Cave walls are located on the lower half of the megatiles, where standard walls are located on the upper half of megatiles. Cave walls were drawn as if there were in the upper half of the megatile, which caused 2 tile thick walls to have lines drawn on top of each other, and displayed an overall incorrect layout of the map.
* Door positions are corrected
    - Previously, the drawing function for doors maintained the same logic regardless of tileset, even though different tilesets had different door placements.
* More enumerators for special case tile types in `AutomapTile::Types`
    - There are 2 tiles in Hell that needed to be overridden, since they were defined as an Arch, causing a missing wall line. It was likely done this way originally because Blizzard North wanted these tiles to have a Diamond for visual consistency. I opted to use this new enumerator to draw an automap tile that contains both a Diamond and a line.
    - There is 1 tile in the Catacombs that needed to be overridden for the same reason as the above. No new enumerator was added; it was changed to behave like a standard wall.
    - There are 2 tiles in Caves that needed east and west facing corners to be added, since the current wall connection functions only draw on the tops and bottoms of metatiles, not on the sides.
    - ~~Lava was added to the Caves and Nest automap, which includes several new enumerators for various lava tiles.~~
 * Extra diamonds drawn on opposite side of arches and grates
     - If an arch or grate is drawn, a diamond will be drawn on the opposite side of the opening for visual consistency. If a diamond is drawn in a dirt tile, a single pixel will be omitted to prevent drawing inside the diamond.
 * Door correction
     - To avoid a problem with the new door positions causing the door diamond to be drawn over by the next drawn automap tile, 2 functions have been added to redraw the line of the door diamond being overwritten, in any case where another tile will draw pixels over the door diamond.
 * ~~Grates~~
     - ~~Grates are now representing by 3 pixels in the path that the original line took, in order to show the player that they are not solid walls.~~