### PR TITLE
Don't validate creation flags on gold

### DIFF
--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -178,7 +178,8 @@ bool UnPackNetItem(const Player &player, const ItemNetPack &packedItem, Item &it
 
 	uint16_t creationFlags = SDL_SwapLE16(packedItem.item.wCI);
 	uint32_t dwBuff = SDL_SwapLE16(packedItem.item.dwBuff);
-	ValidateField(creationFlags, IsCreationFlagComboValid(creationFlags));
+	if (idx != IDI_GOLD)
+		ValidateField(creationFlags, IsCreationFlagComboValid(creationFlags));
 	if ((creationFlags & CF_TOWN) != 0)
 		ValidateField(creationFlags, IsTownItemValid(creationFlags, player));
 	else if ((creationFlags & CF_USEFUL) == CF_UPER15)

--- a/test/pack_test.cpp
+++ b/test/pack_test.cpp
@@ -1275,7 +1275,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_pregenItemFlags)
 	for (Item &item : MyPlayer->InvList) {
 		if (item.isEmpty())
 			continue;
-		if (item.IDidx == IDI_EAR)
+		if (IsAnyOf(item.IDidx, IDI_GOLD, IDI_EAR))
 			continue;
 		uint16_t createInfo = item._iCreateInfo;
 		item._iCreateInfo |= CF_PREGEN;
@@ -1293,7 +1293,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_usefulItemFlags)
 	for (Item &item : MyPlayer->InvList) {
 		if (item.isEmpty())
 			continue;
-		if (item.IDidx == IDI_EAR)
+		if (IsAnyOf(item.IDidx, IDI_GOLD, IDI_EAR))
 			continue;
 		if ((item._iCreateInfo & CF_USEFUL) != CF_USEFUL)
 			continue;
@@ -1313,7 +1313,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_townItemFlags)
 	for (Item &item : MyPlayer->InvList) {
 		if (item.isEmpty())
 			continue;
-		if (item.IDidx == IDI_EAR)
+		if (IsAnyOf(item.IDidx, IDI_GOLD, IDI_EAR))
 			continue;
 		if ((item._iCreateInfo & CF_TOWN) == 0)
 			continue;
@@ -1334,7 +1334,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_townItemLevel)
 	for (Item &item : MyPlayer->InvBody) {
 		if (item.isEmpty())
 			continue;
-		if (item.IDidx == IDI_EAR)
+		if (IsAnyOf(item.IDidx, IDI_GOLD, IDI_EAR))
 			continue;
 		if ((item._iCreateInfo & CF_TOWN) == 0)
 			continue;
@@ -1359,7 +1359,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_uniqueMonsterItemLevel)
 	for (Item &item : MyPlayer->InvList) {
 		if (item.isEmpty())
 			continue;
-		if (item.IDidx == IDI_EAR)
+		if (IsAnyOf(item.IDidx, IDI_GOLD, IDI_EAR))
 			continue;
 		if ((item._iCreateInfo & CF_USEFUL) != CF_UPER15)
 			continue;
@@ -1380,7 +1380,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_monsterItemLevel)
 	for (Item &item : MyPlayer->InvBody) {
 		if (item.isEmpty())
 			continue;
-		if (item.IDidx == IDI_EAR)
+		if (IsAnyOf(item.IDidx, IDI_GOLD, IDI_EAR))
 			continue;
 		if ((item._iCreateInfo & CF_TOWN) != 0)
 			continue;


### PR DESCRIPTION
In vanilla, `LoadGameLevel()` calls `InitItems()`. This calls `GetItemAttrs()` on `item[0]`, passing in `IDI_GOLD` and ilvl 1. You'd think that would set the creation flags to 1, but it seems this ilvl only gets used for books and oils. It doesn't modify creation flags at all. After that, `item[0]` gets copied into a `golditem` global variable. So whenever Blizzard wanted to place gold from a vendor into the player's inventory, they can just set the seed of `golditem` and then copy it into the player's inventory.

So the case in #6559 was probably gold from a vendor that had the creation flags of some pregen item that was generated in `item[0]` on whatever dlvl they were previously on before returning to town to shop. DevX doesn't have this problem because we don't use a `golditem` global and we zero-initialize items. So our gold creation flags should always be zero.

IMO, it's kind of a drag to have to add a special cases just for garbage data from vanilla, but in this case changing creation flags on `IDI_GOLD` doesn't do anything so it's not really a case we should care to validate. It should be okay to skip this validation.

This resolves #6559