### PR TITLE
Use C++20 `using enum` instead of aliasing enum members manually

### DIFF
--- a/Source/misdat.cpp
+++ b/Source/misdat.cpp
@@ -17,13 +17,7 @@
 namespace devilution {
 
 namespace {
-constexpr auto Physical = MissileDataFlags::Physical;
-constexpr auto Fire = MissileDataFlags::Fire;
-constexpr auto Lightning = MissileDataFlags::Lightning;
-constexpr auto Magic = MissileDataFlags::Magic;
-constexpr auto Acid = MissileDataFlags::Acid;
-constexpr auto Arrow = MissileDataFlags::Arrow;
-constexpr auto Invisible = MissileDataFlags::Invisible;
+using enum MissileDataFlags;
 } // namespace
 
 /** Data related to each missile ID. */

--- a/Source/objdat.cpp
+++ b/Source/objdat.cpp
@@ -159,12 +159,7 @@ const _object_id ObjTypeConv[] = {
 };
 
 namespace {
-constexpr auto Animated = ObjectDataFlags::Animated;
-constexpr auto Solid = ObjectDataFlags::Solid;
-constexpr auto MissilesPassThrough = ObjectDataFlags::MissilesPassThrough;
-constexpr auto Light = ObjectDataFlags::Light;
-constexpr auto Trap = ObjectDataFlags::Trap;
-constexpr auto Breakable = ObjectDataFlags::Breakable;
+using enum ObjectDataFlags;
 } // namespace
 
 /** Contains the data related to each object ID. */

--- a/Source/spelldat.cpp
+++ b/Source/spelldat.cpp
@@ -9,11 +9,7 @@
 namespace devilution {
 
 namespace {
-const auto Fire = SpellDataFlags::Fire;
-const auto Lightning = SpellDataFlags::Lightning;
-const auto Magic = SpellDataFlags::Magic;
-const auto Targeted = SpellDataFlags::Targeted;
-const auto AllowedInTown = SpellDataFlags::AllowedInTown;
+using enum SpellDataFlags;
 } // namespace
 
 /** Data related to each spell ID. */


### PR DESCRIPTION
`using enum` is only available from GCC 11, so let's see where we use compilers older than that

https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1099r5.html

**Update:** Vita and MinGW are still using GCC 10.

MinGW will resolve itself once GitHub publishes an Ubuntu 24.04 runner (perhaps August 2024 based on the timeline for 22.04) and we switch to that for MinGW actions.
Vita might take longer, unclear.