### PR TITLE
Restore packed item state when regenerating an item using heroitem data

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -969,6 +969,11 @@ void LoadMatchingItems(LoadHelper &file, const Player &player, const int n, Item
 			if ((heroItem.dwBuff & CF_HELLFIRE) != (unpackedItem.dwBuff & CF_HELLFIRE)) {
 				unpackedItem = {};
 				RecreateItem(player, unpackedItem, heroItem.IDidx, heroItem._iCreateInfo, heroItem._iSeed, heroItem._ivalue, (heroItem.dwBuff & CF_HELLFIRE) != 0);
+				unpackedItem._iIdentified = heroItem._iIdentified;
+				unpackedItem._iMaxDur = heroItem._iMaxDur;
+				unpackedItem._iDurability = ClampDurability(unpackedItem, heroItem._iDurability);
+				unpackedItem._iMaxCharges = std::clamp<int>(heroItem._iMaxCharges, 0, unpackedItem._iMaxCharges);
+				unpackedItem._iCharges = std::clamp<int>(heroItem._iCharges, 0, unpackedItem._iMaxCharges);
 			}
 			if (!IsShopPriceValid(unpackedItem)) {
 				unpackedItem.clear();

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -318,7 +318,11 @@ void LoadItemData(LoadHelper &file, Item &item)
 	else
 		item._iDamAcFlags = ItemSpecialEffectHf::None;
 	UpdateHellfireFlag(item, item._iIName);
+}
 
+void LoadAndValidateItemData(LoadHelper &file, Item &item)
+{
+	LoadItemData(file, item);
 	RemoveInvalidItem(item);
 }
 
@@ -489,10 +493,10 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	file.Skip<uint32_t>(); // skip _pBWidth
 
 	for (Item &item : player.InvBody)
-		LoadItemData(file, item);
+		LoadAndValidateItemData(file, item);
 
 	for (Item &item : player.InvList)
-		LoadItemData(file, item);
+		LoadAndValidateItemData(file, item);
 
 	player._pNumInv = file.NextLE<int32_t>();
 
@@ -500,9 +504,9 @@ void LoadPlayer(LoadHelper &file, Player &player)
 		cell = file.NextLE<int8_t>();
 
 	for (Item &item : player.SpdList)
-		LoadItemData(file, item);
+		LoadAndValidateItemData(file, item);
 
-	LoadItemData(file, player.HoldItem);
+	LoadAndValidateItemData(file, player.HoldItem);
 
 	player._pIMinDam = file.NextLE<int32_t>();
 	player._pIMaxDam = file.NextLE<int32_t>();
@@ -824,13 +828,13 @@ void LoadObject(LoadHelper &file, Object &object)
 
 void LoadItem(LoadHelper &file, Item &item)
 {
-	LoadItemData(file, item);
+	LoadAndValidateItemData(file, item);
 	GetItemFrm(item);
 }
 
 void LoadPremium(LoadHelper &file, int i)
 {
-	LoadItemData(file, premiumitems[i]);
+	LoadAndValidateItemData(file, premiumitems[i]);
 }
 
 void LoadQuest(LoadHelper *file, int i)
@@ -2075,7 +2079,7 @@ void LoadStash()
 	auto itemCount = file.NextLE<uint32_t>();
 	Stash.stashList.resize(itemCount);
 	for (unsigned i = 0; i < itemCount; i++) {
-		LoadItemData(file, Stash.stashList[i]);
+		LoadAndValidateItemData(file, Stash.stashList[i]);
 	}
 
 	Stash.SetPage(file.NextLE<uint32_t>());

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -407,7 +407,6 @@ void UnPackItem(const ItemPack &packedItem, const Player &player, Item &item, bo
 		item._iDurability = ClampDurability(item, packedItem.bDur);
 		item._iMaxCharges = std::clamp<int>(packedItem.bMCh, 0, item._iMaxCharges);
 		item._iCharges = std::clamp<int>(packedItem.bCh, 0, item._iMaxCharges);
-		RemoveInvalidItem(item);
 	}
 }
 

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -407,13 +407,7 @@ void UnPackItem(const ItemPack &packedItem, const Player &player, Item &item, bo
 		item._iDurability = ClampDurability(item, packedItem.bDur);
 		item._iMaxCharges = std::clamp<int>(packedItem.bMCh, 0, item._iMaxCharges);
 		item._iCharges = std::clamp<int>(packedItem.bCh, 0, item._iMaxCharges);
-
 		RemoveInvalidItem(item);
-
-		if (isHellfire)
-			item.dwBuff |= CF_HELLFIRE;
-		else
-			item.dwBuff &= ~CF_HELLFIRE;
 	}
 }
 

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -509,6 +509,17 @@ void pfile_write_hero(SaveWriter &saveWriter, bool writeGameData)
 	}
 }
 
+void RemoveAllInvalidItems(Player &player)
+{
+	for (int i = 0; i < NUM_INVLOC; i++)
+		RemoveInvalidItem(player.InvBody[i]);
+	for (int i = 0; i < player._pNumInv; i++)
+		RemoveInvalidItem(player.InvList[i]);
+	for (int i = 0; i < MaxBeltItems; i++)
+		RemoveInvalidItem(player.SpdList[i]);
+	RemoveEmptyInventory(player);
+}
+
 } // namespace
 
 #ifdef UNPACKED_SAVES
@@ -664,7 +675,7 @@ bool pfile_ui_set_hero_infos(bool (*uiAddHeroInfo)(_uiheroinfo *))
 
 				UnPackPlayer(pkplr, player);
 				LoadHeroItems(player);
-				RemoveEmptyInventory(player);
+				RemoveAllInvalidItems(player);
 				CalcPlrInv(player, false);
 
 				Game2UiPlayer(player, &uihero, hasSaveGame);
@@ -750,7 +761,7 @@ void pfile_read_player_from_save(uint32_t saveNum, Player &player)
 
 	UnPackPlayer(pkplr, player);
 	LoadHeroItems(player);
-	RemoveEmptyInventory(player);
+	RemoveAllInvalidItems(player);
 	CalcPlrInv(player, false);
 }
 


### PR DESCRIPTION
Mirrors the logic in `UnPackItem()` to restore and validate the values of fields that would have been restored during unpacking if the item didn't need to be regenerated in `LoadHeroItems()`.

https://github.com/diasurgical/devilutionX/blob/49c5aea845e32cb217a1ccf41eb4bd35674cacad/Source/pack.cpp#L405-L411

This resolves #6561
Introduced in 1.5.1 (#6258)
Unrelated to #5580