### PR TITLE
Fix Automap - Catacombs Tile 42

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -470,6 +470,9 @@ AutomapTile GetAutomapTypeView(Point map)
 		}
 		return { AutomapTile::Types::None, AutomapTile::Flags::Dirt };
 	}
+	// This tile incorrectly has flags for both HorizontalArch and VerticalArch in the amp data
+	if (leveltype == DTYPE_CATACOMBS && dungeon[map.x][map.y] == 42)
+		return { AutomapTile::Types::Cross, AutomapTile::Flags::VerticalArch };
 
 	if (map.x < 0 || map.x >= DMAXX) {
 		return {};


### PR DESCRIPTION
Before:
![image](https://github.com/diasurgical/devilutionX/assets/68359262/bce0438f-76fc-4b9b-8998-e515232e9cdf)

After:
![image](https://github.com/diasurgical/devilutionX/assets/68359262/694df56d-cb27-4e6c-8689-b11ecfebb45a)

Note: This is a vanilla Diablo bug