### PR TITLE
Load stash data based on gbIsHellfire, not gbIsHellfireSaveGame

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2756,7 +2756,10 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 	}
 
 	if (firstflag || lvldir == ENTRY_LOAD) {
+		bool isHellfireSaveGame = gbIsHellfireSaveGame;
+		gbIsHellfireSaveGame = gbIsHellfire;
 		LoadStash();
+		gbIsHellfireSaveGame = isHellfireSaveGame;
 	}
 
 	IncProgress();


### PR DESCRIPTION
This resolves #5580