### PR TITLE
Force-inline methods to improve debug build perf

### DIFF
--- a/Source/engine.h
+++ b/Source/engine.h
@@ -37,6 +37,7 @@
 #include "engine/point.hpp"
 #include "engine/size.hpp"
 #include "engine/surface.hpp"
+#include "utils/attributes.h"
 
 #define TILE_WIDTH 64
 #define TILE_HEIGHT 32
@@ -44,13 +45,13 @@
 namespace devilution {
 
 template <typename V, typename X, typename... Xs>
-constexpr bool IsAnyOf(const V &v, X x, Xs... xs)
+DVL_ALWAYS_INLINE constexpr bool IsAnyOf(const V &v, X x, Xs... xs)
 {
 	return v == x || ((v == xs) || ...);
 }
 
 template <typename V, typename X, typename... Xs>
-constexpr bool IsNoneOf(const V &v, X x, Xs... xs)
+DVL_ALWAYS_INLINE constexpr bool IsNoneOf(const V &v, X x, Xs... xs)
 {
 	return v != x && ((v != xs) && ...);
 }

--- a/Source/engine/direction.hpp
+++ b/Source/engine/direction.hpp
@@ -4,6 +4,8 @@
 #include <string_view>
 #include <type_traits>
 
+#include "utils/attributes.h"
+
 namespace devilution {
 
 enum class Direction : std::uint8_t {
@@ -19,21 +21,21 @@ enum class Direction : std::uint8_t {
 };
 
 /** Maps from direction to a left turn from the direction. */
-constexpr Direction Left(Direction facing)
+DVL_ALWAYS_INLINE constexpr Direction Left(Direction facing)
 {
 	// Direction left[8] = { Direction::SouthEast, Direction::South, Direction::SouthWest, Direction::West, Direction::NorthWest, Direction::North, Direction::NorthEast, Direction::East };
 	return static_cast<Direction>((static_cast<std::underlying_type_t<Direction>>(facing) + 7) % 8);
 }
 
 /** Maps from direction to a right turn from the direction. */
-constexpr Direction Right(Direction facing)
+DVL_ALWAYS_INLINE constexpr Direction Right(Direction facing)
 {
 	// Direction right[8] = { Direction::SouthWest, Direction::West, Direction::NorthWest, Direction::North, Direction::NorthEast, Direction::East, Direction::SouthEast, Direction::South };
 	return static_cast<Direction>((static_cast<std::underlying_type_t<Direction>>(facing) + 1) % 8);
 }
 
 /** Maps from direction to the opposite direction. */
-constexpr Direction Opposite(Direction facing)
+DVL_ALWAYS_INLINE constexpr Direction Opposite(Direction facing)
 {
 	// Direction opposite[8] = { Direction::North, Direction::NorthEast, Direction::East, Direction::SouthEast, Direction::South, Direction::SouthWest, Direction::West, Direction::NorthWest };
 	return static_cast<Direction>((static_cast<std::underlying_type_t<Direction>>(facing) + 4) % 8);

--- a/Source/engine/displacement.hpp
+++ b/Source/engine/displacement.hpp
@@ -7,6 +7,7 @@
 
 #include "engine/direction.hpp"
 #include "engine/size.hpp"
+#include "utils/attributes.h"
 
 namespace devilution {
 
@@ -23,50 +24,50 @@ struct DisplacementOf {
 	DisplacementOf() = default;
 
 	template <typename DisplacementDeltaT>
-	constexpr DisplacementOf(DisplacementOf<DisplacementDeltaT> other)
+	DVL_ALWAYS_INLINE constexpr DisplacementOf(DisplacementOf<DisplacementDeltaT> other)
 	    : deltaX(other.deltaX)
 	    , deltaY(other.deltaY)
 	{
 	}
 
-	constexpr DisplacementOf(DeltaT deltaX, DeltaT deltaY)
+	DVL_ALWAYS_INLINE constexpr DisplacementOf(DeltaT deltaX, DeltaT deltaY)
 	    : deltaX(deltaX)
 	    , deltaY(deltaY)
 	{
 	}
 
-	explicit constexpr DisplacementOf(DeltaT delta)
+	DVL_ALWAYS_INLINE explicit constexpr DisplacementOf(DeltaT delta)
 	    : deltaX(delta)
 	    , deltaY(delta)
 	{
 	}
 
 	template <typename SizeT>
-	explicit constexpr DisplacementOf(const SizeOf<SizeT> &size)
+	DVL_ALWAYS_INLINE explicit constexpr DisplacementOf(const SizeOf<SizeT> &size)
 	    : deltaX(size.width)
 	    , deltaY(size.height)
 	{
 	}
 
-	explicit constexpr DisplacementOf(Direction direction)
+	DVL_ALWAYS_INLINE explicit constexpr DisplacementOf(Direction direction)
 	    : DisplacementOf(fromDirection(direction))
 	{
 	}
 
 	template <typename DisplacementDeltaT>
-	constexpr bool operator==(const DisplacementOf<DisplacementDeltaT> &other) const
+	DVL_ALWAYS_INLINE constexpr bool operator==(const DisplacementOf<DisplacementDeltaT> &other) const
 	{
 		return deltaX == other.deltaX && deltaY == other.deltaY;
 	}
 
 	template <typename DisplacementDeltaT>
-	constexpr bool operator!=(const DisplacementOf<DisplacementDeltaT> &other) const
+	DVL_ALWAYS_INLINE constexpr bool operator!=(const DisplacementOf<DisplacementDeltaT> &other) const
 	{
 		return !(*this == other);
 	}
 
 	template <typename DisplacementDeltaT = DeltaT>
-	constexpr DisplacementOf<DeltaT> &operator+=(DisplacementOf<DisplacementDeltaT> displacement)
+	DVL_ALWAYS_INLINE constexpr DisplacementOf<DeltaT> &operator+=(DisplacementOf<DisplacementDeltaT> displacement)
 	{
 		deltaX += displacement.deltaX;
 		deltaY += displacement.deltaY;
@@ -74,21 +75,21 @@ struct DisplacementOf {
 	}
 
 	template <typename DisplacementDeltaT = DeltaT>
-	constexpr DisplacementOf<DeltaT> &operator-=(DisplacementOf<DisplacementDeltaT> displacement)
+	DVL_ALWAYS_INLINE constexpr DisplacementOf<DeltaT> &operator-=(DisplacementOf<DisplacementDeltaT> displacement)
 	{
 		deltaX -= displacement.deltaX;
 		deltaY -= displacement.deltaY;
 		return *this;
 	}
 
-	constexpr DisplacementOf<DeltaT> &operator*=(const int factor)
+	DVL_ALWAYS_INLINE constexpr DisplacementOf<DeltaT> &operator*=(const int factor)
 	{
 		deltaX *= factor;
 		deltaY *= factor;
 		return *this;
 	}
 
-	constexpr DisplacementOf<DeltaT> &operator*=(const float factor)
+	DVL_ALWAYS_INLINE constexpr DisplacementOf<DeltaT> &operator*=(const float factor)
 	{
 		deltaX = static_cast<DeltaT>(deltaX * factor);
 		deltaY = static_cast<DeltaT>(deltaY * factor);
@@ -96,28 +97,28 @@ struct DisplacementOf {
 	}
 
 	template <typename DeltaU>
-	constexpr DisplacementOf<DeltaT> &operator*=(const DisplacementOf<DeltaU> factor)
+	DVL_ALWAYS_INLINE constexpr DisplacementOf<DeltaT> &operator*=(const DisplacementOf<DeltaU> factor)
 	{
 		deltaX = static_cast<DeltaT>(deltaX * factor.deltaX);
 		deltaY = static_cast<DeltaT>(deltaY * factor.deltaY);
 		return *this;
 	}
 
-	constexpr DisplacementOf<DeltaT> &operator/=(const int factor)
+	DVL_ALWAYS_INLINE constexpr DisplacementOf<DeltaT> &operator/=(const int factor)
 	{
 		deltaX /= factor;
 		deltaY /= factor;
 		return *this;
 	}
 
-	constexpr DisplacementOf<DeltaT> &operator/=(const float factor)
+	DVL_ALWAYS_INLINE constexpr DisplacementOf<DeltaT> &operator/=(const float factor)
 	{
 		deltaX = static_cast<DeltaT>(deltaX / factor);
 		deltaY = static_cast<DeltaT>(deltaY / factor);
 		return *this;
 	}
 
-	float magnitude() const
+	DVL_ALWAYS_INLINE float magnitude() const
 	{
 		return static_cast<float>(hypot(deltaX, deltaY));
 	}
@@ -133,7 +134,7 @@ struct DisplacementOf {
 	 *
 	 * @return A representation of the original displacement in screen coordinates.
 	 */
-	constexpr DisplacementOf<DeltaT> worldToScreen() const
+	DVL_ALWAYS_INLINE constexpr DisplacementOf<DeltaT> worldToScreen() const
 	{
 		static_assert(std::is_signed<DeltaT>::value, "DeltaT must be signed for transformations involving a rotation");
 		return { (deltaY - deltaX) * 32, (deltaY + deltaX) * -16 };
@@ -146,7 +147,7 @@ struct DisplacementOf {
 	 *
 	 * @return A representation of the original displacement in world coordinates.
 	 */
-	constexpr DisplacementOf<DeltaT> screenToWorld() const
+	DVL_ALWAYS_INLINE constexpr DisplacementOf<DeltaT> screenToWorld() const
 	{
 		static_assert(std::is_signed<DeltaT>::value, "DeltaT must be signed for transformations involving a rotation");
 		return { (2 * deltaY + deltaX) / -64, (2 * deltaY - deltaX) / -64 };
@@ -197,7 +198,7 @@ struct DisplacementOf {
 	 */
 	[[nodiscard]] Displacement normalized() const;
 
-	[[nodiscard]] constexpr DisplacementOf<DeltaT> Rotate(int quadrants) const
+	[[nodiscard]] DVL_ALWAYS_INLINE constexpr DisplacementOf<DeltaT> Rotate(int quadrants) const
 	{
 		static_assert(std::is_signed<DeltaT>::value, "DeltaT must be signed for Rotate");
 		constexpr DeltaT Sines[] = { 0, 1, 0, -1 };
@@ -229,7 +230,7 @@ struct DisplacementOf {
 	}
 
 private:
-	static constexpr DisplacementOf<DeltaT> fromDirection(Direction direction)
+	DVL_ALWAYS_INLINE static constexpr DisplacementOf<DeltaT> fromDirection(Direction direction)
 	{
 		static_assert(std::is_signed<DeltaT>::value, "DeltaT must be signed for conversion from Direction");
 		switch (direction) {
@@ -272,74 +273,74 @@ std::ostream &operator<<(std::ostream &stream, const DisplacementOf<Displacement
 #endif
 
 template <typename DisplacementDeltaT, typename OtherDisplacementDeltaT>
-constexpr DisplacementOf<DisplacementDeltaT> operator+(DisplacementOf<DisplacementDeltaT> a, DisplacementOf<OtherDisplacementDeltaT> b)
+DVL_ALWAYS_INLINE constexpr DisplacementOf<DisplacementDeltaT> operator+(DisplacementOf<DisplacementDeltaT> a, DisplacementOf<OtherDisplacementDeltaT> b)
 {
 	a += b;
 	return a;
 }
 
 template <typename DisplacementDeltaT, typename OtherDisplacementDeltaT>
-constexpr DisplacementOf<DisplacementDeltaT> operator-(DisplacementOf<DisplacementDeltaT> a, DisplacementOf<OtherDisplacementDeltaT> b)
+DVL_ALWAYS_INLINE constexpr DisplacementOf<DisplacementDeltaT> operator-(DisplacementOf<DisplacementDeltaT> a, DisplacementOf<OtherDisplacementDeltaT> b)
 {
 	a -= b;
 	return a;
 }
 
 template <typename DisplacementDeltaT>
-constexpr DisplacementOf<DisplacementDeltaT> operator*(DisplacementOf<DisplacementDeltaT> a, const int factor)
+DVL_ALWAYS_INLINE constexpr DisplacementOf<DisplacementDeltaT> operator*(DisplacementOf<DisplacementDeltaT> a, const int factor)
 {
 	a *= factor;
 	return a;
 }
 
 template <typename DisplacementDeltaT>
-constexpr DisplacementOf<DisplacementDeltaT> operator*(DisplacementOf<DisplacementDeltaT> a, const float factor)
+DVL_ALWAYS_INLINE constexpr DisplacementOf<DisplacementDeltaT> operator*(DisplacementOf<DisplacementDeltaT> a, const float factor)
 {
 	a *= factor;
 	return a;
 }
 
 template <typename DisplacementDeltaT, typename DisplacementDeltaU>
-constexpr DisplacementOf<DisplacementDeltaT> operator*(DisplacementOf<DisplacementDeltaT> a, const DisplacementOf<DisplacementDeltaU> factor)
+DVL_ALWAYS_INLINE constexpr DisplacementOf<DisplacementDeltaT> operator*(DisplacementOf<DisplacementDeltaT> a, const DisplacementOf<DisplacementDeltaU> factor)
 {
 	a *= factor;
 	return a;
 }
 
 template <typename DisplacementDeltaT>
-constexpr DisplacementOf<DisplacementDeltaT> operator/(DisplacementOf<DisplacementDeltaT> a, const int factor)
+DVL_ALWAYS_INLINE constexpr DisplacementOf<DisplacementDeltaT> operator/(DisplacementOf<DisplacementDeltaT> a, const int factor)
 {
 	a /= factor;
 	return a;
 }
 
 template <typename DisplacementDeltaT>
-constexpr DisplacementOf<DisplacementDeltaT> operator/(DisplacementOf<DisplacementDeltaT> a, const float factor)
+DVL_ALWAYS_INLINE constexpr DisplacementOf<DisplacementDeltaT> operator/(DisplacementOf<DisplacementDeltaT> a, const float factor)
 {
 	a /= factor;
 	return a;
 }
 
 template <typename DisplacementDeltaT>
-constexpr DisplacementOf<DisplacementDeltaT> operator-(DisplacementOf<DisplacementDeltaT> a)
+DVL_ALWAYS_INLINE constexpr DisplacementOf<DisplacementDeltaT> operator-(DisplacementOf<DisplacementDeltaT> a)
 {
 	return { -a.deltaX, -a.deltaY };
 }
 
 template <typename DisplacementDeltaT>
-constexpr DisplacementOf<DisplacementDeltaT> operator<<(DisplacementOf<DisplacementDeltaT> a, unsigned factor)
+DVL_ALWAYS_INLINE constexpr DisplacementOf<DisplacementDeltaT> operator<<(DisplacementOf<DisplacementDeltaT> a, unsigned factor)
 {
 	return { a.deltaX << factor, a.deltaY << factor };
 }
 
 template <typename DisplacementDeltaT>
-constexpr DisplacementOf<DisplacementDeltaT> operator>>(DisplacementOf<DisplacementDeltaT> a, unsigned factor)
+DVL_ALWAYS_INLINE constexpr DisplacementOf<DisplacementDeltaT> operator>>(DisplacementOf<DisplacementDeltaT> a, unsigned factor)
 {
 	return { a.deltaX >> factor, a.deltaY >> factor };
 }
 
 template <typename DisplacementDeltaT>
-constexpr DisplacementOf<DisplacementDeltaT> abs(DisplacementOf<DisplacementDeltaT> a)
+DVL_ALWAYS_INLINE constexpr DisplacementOf<DisplacementDeltaT> abs(DisplacementOf<DisplacementDeltaT> a)
 {
 	return DisplacementOf<DisplacementDeltaT>(std::abs(a.deltaX), std::abs(a.deltaY));
 }

--- a/Source/engine/point.hpp
+++ b/Source/engine/point.hpp
@@ -9,6 +9,7 @@
 
 #include "engine/direction.hpp"
 #include "engine/displacement.hpp"
+#include "utils/attributes.h"
 
 namespace devilution {
 
@@ -28,73 +29,73 @@ struct PointOf {
 	PointOf() = default;
 
 	template <typename PointCoordT>
-	constexpr PointOf(PointOf<PointCoordT> other)
+	DVL_ALWAYS_INLINE constexpr PointOf(PointOf<PointCoordT> other)
 	    : x(other.x)
 	    , y(other.y)
 	{
 	}
 
-	constexpr PointOf(CoordT x, CoordT y)
+	DVL_ALWAYS_INLINE constexpr PointOf(CoordT x, CoordT y)
 	    : x(x)
 	    , y(y)
 	{
 	}
 
 	template <typename PointCoordT>
-	constexpr bool operator==(const PointOf<PointCoordT> &other) const
+	DVL_ALWAYS_INLINE constexpr bool operator==(const PointOf<PointCoordT> &other) const
 	{
 		return x == other.x && y == other.y;
 	}
 
 	template <typename PointCoordT>
-	constexpr bool operator!=(const PointOf<PointCoordT> &other) const
+	DVL_ALWAYS_INLINE constexpr bool operator!=(const PointOf<PointCoordT> &other) const
 	{
 		return !(*this == other);
 	}
 
 	template <typename DisplacementDeltaT = int>
-	constexpr PointOf<CoordT> &operator+=(const DisplacementOf<DisplacementDeltaT> &displacement)
+	DVL_ALWAYS_INLINE constexpr PointOf<CoordT> &operator+=(const DisplacementOf<DisplacementDeltaT> &displacement)
 	{
 		x += displacement.deltaX;
 		y += displacement.deltaY;
 		return *this;
 	}
 
-	constexpr PointOf<CoordT> &operator+=(Direction direction)
+	DVL_ALWAYS_INLINE constexpr PointOf<CoordT> &operator+=(Direction direction)
 	{
 		return (*this) += DisplacementOf<typename std::make_signed<CoordT>::type>(direction);
 	}
 
 	template <typename DisplacementDeltaT = int>
-	constexpr PointOf<CoordT> &operator-=(const DisplacementOf<DisplacementDeltaT> &displacement)
+	DVL_ALWAYS_INLINE constexpr PointOf<CoordT> &operator-=(const DisplacementOf<DisplacementDeltaT> &displacement)
 	{
 		x -= displacement.deltaX;
 		y -= displacement.deltaY;
 		return *this;
 	}
 
-	constexpr PointOf<CoordT> &operator*=(const float factor)
+	DVL_ALWAYS_INLINE constexpr PointOf<CoordT> &operator*=(const float factor)
 	{
 		x = static_cast<int>(x * factor);
 		y = static_cast<int>(y * factor);
 		return *this;
 	}
 
-	constexpr PointOf<CoordT> &operator*=(const int factor)
+	DVL_ALWAYS_INLINE constexpr PointOf<CoordT> &operator*=(const int factor)
 	{
 		x *= factor;
 		y *= factor;
 		return *this;
 	}
 
-	constexpr PointOf<CoordT> &operator/=(const int factor)
+	DVL_ALWAYS_INLINE constexpr PointOf<CoordT> &operator/=(const int factor)
 	{
 		x /= factor;
 		y /= factor;
 		return *this;
 	}
 
-	constexpr PointOf<CoordT> operator-() const
+	DVL_ALWAYS_INLINE constexpr PointOf<CoordT> operator-() const
 	{
 		static_assert(std::is_signed<CoordT>::value, "CoordT must be signed");
 		return { -x, -y };
@@ -136,14 +137,14 @@ struct PointOf {
 	}
 
 	template <typename PointCoordT>
-	constexpr int ManhattanDistance(PointOf<PointCoordT> other) const
+	DVL_ALWAYS_INLINE constexpr int ManhattanDistance(PointOf<PointCoordT> other) const
 	{
 		return std::abs(static_cast<int>(x) - static_cast<int>(other.x))
 		    + std::abs(static_cast<int>(y) - static_cast<int>(other.y));
 	}
 
 	template <typename PointCoordT>
-	constexpr int WalkingDistance(PointOf<PointCoordT> other) const
+	DVL_ALWAYS_INLINE constexpr int WalkingDistance(PointOf<PointCoordT> other) const
 	{
 		return std::max<int>(
 		    std::abs(static_cast<int>(x) - static_cast<int>(other.x)),
@@ -153,7 +154,7 @@ struct PointOf {
 	/**
 	 * @brief Converts a coordinate in megatiles to the northmost of the 4 corresponding world tiles
 	 */
-	constexpr PointOf<CoordT> megaToWorld() const
+	DVL_ALWAYS_INLINE constexpr PointOf<CoordT> megaToWorld() const
 	{
 		return { static_cast<CoordT>(16 + 2 * x), static_cast<CoordT>(16 + 2 * y) };
 	}
@@ -161,7 +162,7 @@ struct PointOf {
 	/**
 	 * @brief Converts a coordinate in world tiles back to the corresponding megatile
 	 */
-	constexpr PointOf<CoordT> worldToMega() const
+	DVL_ALWAYS_INLINE constexpr PointOf<CoordT> worldToMega() const
 	{
 		return { static_cast<CoordT>((x - 16) / 2), static_cast<CoordT>((y - 16) / 2) };
 	}
@@ -182,49 +183,49 @@ std::ostream &operator<<(std::ostream &stream, const PointOf<PointCoordT> &point
 #endif
 
 template <typename PointCoordT, typename DisplacementDeltaT>
-constexpr PointOf<PointCoordT> operator+(PointOf<PointCoordT> a, DisplacementOf<DisplacementDeltaT> displacement)
+DVL_ALWAYS_INLINE constexpr PointOf<PointCoordT> operator+(PointOf<PointCoordT> a, DisplacementOf<DisplacementDeltaT> displacement)
 {
 	a += displacement;
 	return a;
 }
 
 template <typename PointCoordT>
-constexpr PointOf<PointCoordT> operator+(PointOf<PointCoordT> a, Direction direction)
+DVL_ALWAYS_INLINE constexpr PointOf<PointCoordT> operator+(PointOf<PointCoordT> a, Direction direction)
 {
 	a += direction;
 	return a;
 }
 
 template <typename PointCoordT, typename OtherPointCoordT>
-constexpr DisplacementOf<PointCoordT> operator-(PointOf<PointCoordT> a, PointOf<OtherPointCoordT> b)
+DVL_ALWAYS_INLINE constexpr DisplacementOf<PointCoordT> operator-(PointOf<PointCoordT> a, PointOf<OtherPointCoordT> b)
 {
 	static_assert(std::is_signed<PointCoordT>::value == std::is_signed<OtherPointCoordT>::value, "points must have the same signedness");
 	return { static_cast<PointCoordT>(a.x - b.x), static_cast<PointCoordT>(a.y - b.y) };
 }
 
 template <typename PointCoordT, typename DisplacementDeltaT>
-constexpr PointOf<PointCoordT> operator-(PointOf<PointCoordT> a, DisplacementOf<DisplacementDeltaT> displacement)
+DVL_ALWAYS_INLINE constexpr PointOf<PointCoordT> operator-(PointOf<PointCoordT> a, DisplacementOf<DisplacementDeltaT> displacement)
 {
 	a -= displacement;
 	return a;
 }
 
 template <typename PointCoordT>
-constexpr PointOf<PointCoordT> operator*(PointOf<PointCoordT> a, const float factor)
+DVL_ALWAYS_INLINE constexpr PointOf<PointCoordT> operator*(PointOf<PointCoordT> a, const float factor)
 {
 	a *= factor;
 	return a;
 }
 
 template <typename PointCoordT>
-constexpr PointOf<PointCoordT> operator*(PointOf<PointCoordT> a, const int factor)
+DVL_ALWAYS_INLINE constexpr PointOf<PointCoordT> operator*(PointOf<PointCoordT> a, const int factor)
 {
 	a *= factor;
 	return a;
 }
 
 template <typename PointCoordT>
-constexpr PointOf<PointCoordT> abs(PointOf<PointCoordT> a)
+DVL_ALWAYS_INLINE constexpr PointOf<PointCoordT> abs(PointOf<PointCoordT> a)
 {
 	return { std::abs(a.x), std::abs(a.y) };
 }

--- a/Source/engine/points_in_rectangle_range.hpp
+++ b/Source/engine/points_in_rectangle_range.hpp
@@ -30,7 +30,7 @@ protected:
 	{
 	}
 
-	void Increment()
+	DVL_ALWAYS_INLINE void Increment()
 	{
 		++minorIndex;
 		if (minorIndex >= majorDimension) {
@@ -82,19 +82,19 @@ public:
 		{
 		}
 
-		value_type operator*() const
+		DVL_ALWAYS_INLINE value_type operator*() const
 		{
 			// Row-major iteration e.g. {0, 0}, {1, 0}, {2, 0}, {0, 1}, {1, 1}, ...
 			return this->origin + Displacement { this->minorIndex, this->majorIndex };
 		}
 
 		// Equality comparable concepts
-		bool operator==(const PointsInRectangleIterator &rhs) const
+		DVL_ALWAYS_INLINE bool operator==(const PointsInRectangleIterator &rhs) const
 		{
 			return this->majorIndex == rhs.majorIndex && this->minorIndex == rhs.minorIndex;
 		}
 
-		bool operator!=(const PointsInRectangleIterator &rhs) const
+		DVL_ALWAYS_INLINE bool operator!=(const PointsInRectangleIterator &rhs) const
 		{
 			return !(*this == rhs);
 		}
@@ -126,7 +126,7 @@ public:
 		}
 
 		// Forward concepts
-		PointsInRectangleIterator &operator++()
+		DVL_ALWAYS_INLINE PointsInRectangleIterator &operator++()
 		{
 			this->Increment();
 			return *this;
@@ -255,19 +255,19 @@ public:
 		{
 		}
 
-		value_type operator*() const
+		DVL_ALWAYS_INLINE value_type operator*() const
 		{
 			// Col-major iteration e.g. {0, 0}, {0, 1}, {0, 2}, {1, 0}, {1, 1}, ...
 			return this->origin + Displacement { this->majorIndex, this->minorIndex };
 		}
 
 		// Equality comparable concepts
-		bool operator==(const PointsInRectangleIteratorColMajor &rhs) const
+		DVL_ALWAYS_INLINE bool operator==(const PointsInRectangleIteratorColMajor &rhs) const
 		{
 			return this->majorIndex == rhs.majorIndex && this->minorIndex == rhs.minorIndex;
 		}
 
-		bool operator!=(const PointsInRectangleIteratorColMajor &rhs) const
+		DVL_ALWAYS_INLINE bool operator!=(const PointsInRectangleIteratorColMajor &rhs) const
 		{
 			return !(*this == rhs);
 		}
@@ -299,7 +299,7 @@ public:
 		}
 
 		// Forward concepts
-		PointsInRectangleIteratorColMajor &operator++()
+		DVL_ALWAYS_INLINE PointsInRectangleIteratorColMajor &operator++()
 		{
 			this->Increment();
 			return *this;

--- a/Source/engine/rectangle.hpp
+++ b/Source/engine/rectangle.hpp
@@ -2,6 +2,7 @@
 
 #include "engine/point.hpp"
 #include "engine/size.hpp"
+#include "utils/attributes.h"
 
 namespace devilution {
 
@@ -12,7 +13,7 @@ struct RectangleOf {
 
 	RectangleOf() = default;
 
-	constexpr RectangleOf(PointOf<CoordT> position, SizeOf<SizeT> size)
+	DVL_ALWAYS_INLINE constexpr RectangleOf(PointOf<CoordT> position, SizeOf<SizeT> size)
 	    : position(position)
 	    , size(size)
 	{
@@ -26,7 +27,7 @@ struct RectangleOf {
 	 * @param center center point of the target rectangle
 	 * @param radius a non-negative value indicating how many tiles to include around the center
 	 */
-	explicit constexpr RectangleOf(PointOf<CoordT> center, SizeT radius)
+	DVL_ALWAYS_INLINE explicit constexpr RectangleOf(PointOf<CoordT> center, SizeT radius)
 	    : position(center - DisplacementOf<SizeT> { radius })
 	    , size(static_cast<SizeT>(2 * radius + 1))
 	{
@@ -37,7 +38,7 @@ struct RectangleOf {
 	 * Works correctly even if the point uses a different underlying numeric type
 	 */
 	template <typename PointCoordT>
-	constexpr bool contains(PointOf<PointCoordT> point) const
+	DVL_ALWAYS_INLINE constexpr bool contains(PointOf<PointCoordT> point) const
 	{
 		return contains(point.x, point.y);
 	}

--- a/Source/engine/size.hpp
+++ b/Source/engine/size.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "utils/attributes.h"
+
 #ifdef BUILD_TESTING
 #include <ostream>
 #endif
@@ -13,80 +15,80 @@ struct SizeOf {
 
 	SizeOf() = default;
 
-	constexpr SizeOf(SizeT width, SizeT height)
+	DVL_ALWAYS_INLINE constexpr SizeOf(SizeT width, SizeT height)
 	    : width(width)
 	    , height(height)
 	{
 	}
 
-	explicit constexpr SizeOf(SizeT size)
+	DVL_ALWAYS_INLINE explicit constexpr SizeOf(SizeT size)
 	    : width(size)
 	    , height(size)
 	{
 	}
 
-	bool operator==(const SizeOf<SizeT> &other) const
+	DVL_ALWAYS_INLINE bool operator==(const SizeOf<SizeT> &other) const
 	{
 		return width == other.width && height == other.height;
 	}
 
-	bool operator!=(const SizeOf<SizeT> &other) const
+	DVL_ALWAYS_INLINE bool operator!=(const SizeOf<SizeT> &other) const
 	{
 		return !(*this == other);
 	}
 
-	constexpr SizeOf<SizeT> &operator+=(SizeT factor)
+	DVL_ALWAYS_INLINE constexpr SizeOf<SizeT> &operator+=(SizeT factor)
 	{
 		width += factor;
 		height += factor;
 		return *this;
 	}
 
-	constexpr SizeOf<SizeT> &operator-=(SizeT factor)
+	DVL_ALWAYS_INLINE constexpr SizeOf<SizeT> &operator-=(SizeT factor)
 	{
 		return *this += -factor;
 	}
 
-	constexpr SizeOf<SizeT> &operator*=(SizeT factor)
+	DVL_ALWAYS_INLINE constexpr SizeOf<SizeT> &operator*=(SizeT factor)
 	{
 		width *= factor;
 		height *= factor;
 		return *this;
 	}
 
-	constexpr SizeOf<SizeT> &operator*=(float factor)
+	DVL_ALWAYS_INLINE constexpr SizeOf<SizeT> &operator*=(float factor)
 	{
 		width = static_cast<SizeT>(width * factor);
 		height = static_cast<SizeT>(height * factor);
 		return *this;
 	}
 
-	constexpr SizeOf<SizeT> &operator/=(SizeT factor)
+	DVL_ALWAYS_INLINE constexpr SizeOf<SizeT> &operator/=(SizeT factor)
 	{
 		width /= factor;
 		height /= factor;
 		return *this;
 	}
 
-	constexpr friend SizeOf<SizeT> operator+(SizeOf<SizeT> a, SizeT factor)
+	DVL_ALWAYS_INLINE constexpr friend SizeOf<SizeT> operator+(SizeOf<SizeT> a, SizeT factor)
 	{
 		a += factor;
 		return a;
 	}
 
-	constexpr friend SizeOf<SizeT> operator-(SizeOf<SizeT> a, SizeT factor)
+	DVL_ALWAYS_INLINE constexpr friend SizeOf<SizeT> operator-(SizeOf<SizeT> a, SizeT factor)
 	{
 		a -= factor;
 		return a;
 	}
 
-	constexpr friend SizeOf<SizeT> operator*(SizeOf<SizeT> a, SizeT factor)
+	DVL_ALWAYS_INLINE constexpr friend SizeOf<SizeT> operator*(SizeOf<SizeT> a, SizeT factor)
 	{
 		a *= factor;
 		return a;
 	}
 
-	constexpr friend SizeOf<SizeT> operator/(SizeOf<SizeT> a, SizeT factor)
+	DVL_ALWAYS_INLINE constexpr friend SizeOf<SizeT> operator/(SizeOf<SizeT> a, SizeT factor)
 	{
 		a /= factor;
 		return a;

--- a/Source/levels/gendung.h
+++ b/Source/levels/gendung.h
@@ -236,7 +236,7 @@ std::optional<WorldTileSize> GetSizeForThemeRoom();
 dungeon_type GetLevelType(int level);
 void CreateDungeon(uint32_t rseed, lvl_entry entry);
 
-constexpr bool InDungeonBounds(Point position)
+DVL_ALWAYS_INLINE constexpr bool InDungeonBounds(Point position)
 {
 	return position.x >= 0 && position.x < MAXDUNX && position.y >= 0 && position.y < MAXDUNY;
 }

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -14,6 +14,7 @@
 #include "engine/load_file.hpp"
 #include "engine/points_in_rectangle_range.hpp"
 #include "player.h"
+#include "utils/attributes.h"
 
 namespace devilution {
 
@@ -94,7 +95,7 @@ void RotateRadius(DisplacementOf<int8_t> &offset, DisplacementOf<int8_t> &dist, 
 	}
 }
 
-void SetLight(Point position, uint8_t v)
+DVL_ALWAYS_INLINE void SetLight(Point position, uint8_t v)
 {
 	if (LoadingMapObjects)
 		dPreLight[position.x][position.y] = v;
@@ -102,7 +103,7 @@ void SetLight(Point position, uint8_t v)
 		dLight[position.x][position.y] = v;
 }
 
-uint8_t GetLight(Point position)
+DVL_ALWAYS_INLINE uint8_t GetLight(Point position)
 {
 	if (LoadingMapObjects)
 		return dPreLight[position.x][position.y];

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -604,7 +604,7 @@ void StartMonsterGotHit(Monster &monster)
 	dMonster[monster.position.tile.x][monster.position.tile.y] = monster.getId() + 1;
 }
 
-bool IsRanged(Monster &monster)
+DVL_ALWAYS_INLINE bool IsRanged(Monster &monster)
 {
 	return IsAnyOf(monster.ai, MonsterAIID::SkeletonRanged, MonsterAIID::GoatRanged, MonsterAIID::Succubus, MonsterAIID::LazarusSuccubus);
 }


### PR DESCRIPTION
This has little or no effect on the optimized build but significantly improves performance of the headless debug build

`timedemo_test` on my machine goes from 3s to 2s.