### PR TITLE
Compile some files with -O2 even in Debug mode

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -169,6 +169,21 @@ set(libdevilutionx_SRCS
   utils/timer.cpp
   utils/utf8.cpp)
 
+# These files are responsible for most of the runtime in Debug mode.
+# Apply some optimizations to them even in Debug mode to get reasonable performance.
+set(_optimize_in_debug_srcs
+  engine/render/clx_render.cpp
+  engine/render/dun_render.cpp
+  engine/render/text_render.cpp
+  utils/cel_to_clx.cpp
+  utils/cl2_to_clx.cpp
+  utils/pcx_to_clx.cpp)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set_source_files_properties(${_optimize_in_debug_srcs} PROPERTIES COMPILE_OPTIONS "-O2")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  set_source_files_properties(${_optimize_in_debug_srcs} PROPERTIES COMPILE_OPTIONS "$<$<CONFIG:Debug>:/O2>")
+endif()
+
 if(SUPPORTS_MPQ)
   list(APPEND libdevilutionx_DEPS libmpq)
   list(APPEND libdevilutionx_SRCS


### PR DESCRIPTION
These files are responsible for most of the runtime in Debug mode. Apply some optimizations to them even in Debug mode to get reasonable performance.

Timedemo on my machine goes from 40s down to 25s.