### PR TITLE
Fix some compilation warnings

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -178,7 +178,9 @@ set(_optimize_in_debug_srcs
   utils/cel_to_clx.cpp
   utils/cl2_to_clx.cpp
   utils/pcx_to_clx.cpp)
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set_source_files_properties(${_optimize_in_debug_srcs} PROPERTIES COMPILE_OPTIONS "-O2;--param=max-vartrack-size=900000000")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_BUILD_TYPE STREQUAL "Debug")
   set_source_files_properties(${_optimize_in_debug_srcs} PROPERTIES COMPILE_OPTIONS "-O2")
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   set_source_files_properties(${_optimize_in_debug_srcs} PROPERTIES COMPILE_OPTIONS "$<$<CONFIG:Debug>:/O2>")

--- a/test/data_file_test.cpp
+++ b/test/data_file_test.cpp
@@ -34,8 +34,9 @@ void TestFileContents(
 			EXPECT_EQ(result.value, expectedContent[row][col]) << "Unexpected value at record " << row << " and field " << col;
 			col++;
 		} while (!result.endOfRecord());
-		if (!result.endOfFile())
+		if (!result.endOfFile()) {
 			EXPECT_EQ(result.status, expectedEndOfRecordStatus) << "Unexpected status when parsing the end of record " << row;
+		}
 
 		EXPECT_EQ(col, expectedContent[row].size()) << "Parsing returned fewer fields than expected in record " << row;
 		row++;


### PR DESCRIPTION
```
data_file_test.cpp:37:20: warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wdangling-else]
   37 |                 if (!result.endOfFile())
      |                    ^
```

```
Source/engine/render/dun_render.cpp:1126:6: note: variable tracking size limit exceeded with ‘-fvar-tracking-assignments’, retrying without
 1126 | void RenderTile(const Surface &out, Point position,
```