### PR TITLE
Bump libfmt

### DIFF
--- a/3rdParty/libfmt/CMakeLists.txt
+++ b/3rdParty/libfmt/CMakeLists.txt
@@ -5,6 +5,10 @@ if(NOT WIN32 AND NOT APPLE AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL FreeBSD)
   add_definitions(-D_POSIX_C_SOURCE=200809L)
 endif()
 
+# Disable fmt/os.h functionality.
+# We do not use it and it is not supported on some systems.
+set(FMT_OS OFF)
+
 if(DEVILUTIONX_STATIC_LIBFMT)
   set(BUILD_SHARED_LIBS OFF)
 else()
@@ -19,8 +23,8 @@ if(NXDK)
   )
 else()
   FetchContent_Declare(libfmt
-    URL https://github.com/fmtlib/fmt/archive/refs/tags/10.0.0.tar.gz
-    URL_HASH MD5=fa629bc1178918b7af4b2ea6b6a271dc
+    URL https://github.com/fmtlib/fmt/archive/refs/tags/10.1.1.tar.gz
+    URL_HASH MD5=0d41a16f1b3878d44e6fd7ff1f6cc45a
   )
 endif()
 FetchContent_MakeAvailableExcludeFromAll(libfmt)

--- a/Source/dvlnet/tcp_client.h
+++ b/Source/dvlnet/tcp_client.h
@@ -3,6 +3,15 @@
 #include <memory>
 #include <string>
 
+// This header must be included before any 3DS code
+// because 3DS SDK defines a macro with the same name
+// as an fmt template parameter in some versions of fmt.
+// See https://github.com/fmtlib/fmt/issues/3632
+//
+// 3DS uses some custom ASIO code that transitively includes
+// the 3DS SDK.
+#include <fmt/core.h>
+
 #include <asio/ts/buffer.hpp>
 #include <asio/ts/internet.hpp>
 #include <asio/ts/io_context.hpp>

--- a/Source/dvlnet/tcp_server.h
+++ b/Source/dvlnet/tcp_server.h
@@ -4,6 +4,15 @@
 #include <memory>
 #include <string>
 
+// This header must be included before any 3DS code
+// because 3DS SDK defines a macro with the same name
+// as an fmt template parameter in some versions of fmt.
+// See https://github.com/fmtlib/fmt/issues/3632
+//
+// 3DS uses some custom ASIO code that transitively includes
+// the 3DS SDK.
+#include <fmt/core.h>
+
 #include <asio/ts/buffer.hpp>
 #include <asio/ts/internet.hpp>
 #include <asio/ts/io_context.hpp>

--- a/Source/platform/ctr/sockets.cpp
+++ b/Source/platform/ctr/sockets.cpp
@@ -3,6 +3,12 @@
 #include <cstdint>
 #include <malloc.h>
 
+// This header must be included before any 3DS code
+// because 3DS SDK defines a macro with the same name
+// as an fmt template parameter in some versions of fmt.
+// See https://github.com/fmtlib/fmt/issues/3632
+#include <fmt/core.h>
+
 #include <3ds.h>
 
 #include "utils/log.hpp"


### PR DESCRIPTION
Hopefully we'll be able to get rid of the custom nxdk fork soon.

Disabling `FMT_OS` is the first step towards that. I've also asked the fmt author about handling Windows-like platforms without Unicode support in https://github.com/fmtlib/fmt/issues/3631.

The 3ds build was initially failing due to the 3ds SDK defining a macro (`PACKED`) with the same name as an fmt template argument. Now fixed (worked around). https://github.com/fmtlib/fmt/issues/3632.