### PR TITLE
Change Automap Scale and Max Zoom Out

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -881,7 +881,7 @@ void AutomapZoomIn()
 
 void AutomapZoomOut()
 {
-	if (AutoMapScale <= 50)
+	if (AutoMapScale <= 25)
 		return;
 
 	AutoMapScale -= 25;

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -876,7 +876,7 @@ void AutomapZoomIn()
 	if (AutoMapScale >= 200)
 		return;
 
-	AutoMapScale += 5;
+	AutoMapScale += 25;
 }
 
 void AutomapZoomOut()
@@ -884,7 +884,7 @@ void AutomapZoomOut()
 	if (AutoMapScale <= 50)
 		return;
 
-	AutoMapScale -= 5;
+	AutoMapScale -= 25;
 }
 
 void DrawAutomap(const Surface &out)

--- a/test/automap_test.cpp
+++ b/test/automap_test.cpp
@@ -64,17 +64,17 @@ TEST(Automap, AutomapZoomIn)
 {
 	AutoMapScale = 50;
 	AutomapZoomIn();
-	EXPECT_EQ(AutoMapScale, 55);
-	EXPECT_EQ(AmLine(64), 35);
-	EXPECT_EQ(AmLine(32), 17);
-	EXPECT_EQ(AmLine(16), 8);
-	EXPECT_EQ(AmLine(8), 4);
-	EXPECT_EQ(AmLine(4), 2);
+	EXPECT_EQ(AutoMapScale, 75);
+	EXPECT_EQ(AmLine(64), 48);
+	EXPECT_EQ(AmLine(32), 24);
+	EXPECT_EQ(AmLine(16), 12);
+	EXPECT_EQ(AmLine(8), 6);
+	EXPECT_EQ(AmLine(4), 3);
 }
 
 TEST(Automap, AutomapZoomIn_Max)
 {
-	AutoMapScale = 195;
+	AutoMapScale = 175;
 	AutomapZoomIn();
 	AutomapZoomIn();
 	EXPECT_EQ(AutoMapScale, 200);
@@ -89,25 +89,25 @@ TEST(Automap, AutomapZoomOut)
 {
 	AutoMapScale = 200;
 	AutomapZoomOut();
-	EXPECT_EQ(AutoMapScale, 195);
-	EXPECT_EQ(AmLine(64), 124);
-	EXPECT_EQ(AmLine(32), 62);
-	EXPECT_EQ(AmLine(16), 31);
-	EXPECT_EQ(AmLine(8), 15);
+	EXPECT_EQ(AutoMapScale, 175);
+	EXPECT_EQ(AmLine(64), 112);
+	EXPECT_EQ(AmLine(32), 56);
+	EXPECT_EQ(AmLine(16), 28);
+	EXPECT_EQ(AmLine(8), 14);
 	EXPECT_EQ(AmLine(4), 7);
 }
 
 TEST(Automap, AutomapZoomOut_Min)
 {
-	AutoMapScale = 55;
+	AutoMapScale = 50;
 	AutomapZoomOut();
 	AutomapZoomOut();
-	EXPECT_EQ(AutoMapScale, 50);
-	EXPECT_EQ(AmLine(64), 32);
-	EXPECT_EQ(AmLine(32), 16);
-	EXPECT_EQ(AmLine(16), 8);
-	EXPECT_EQ(AmLine(8), 4);
-	EXPECT_EQ(AmLine(4), 2);
+	EXPECT_EQ(AutoMapScale, 25);
+	EXPECT_EQ(AmLine(64), 16);
+	EXPECT_EQ(AmLine(32), 8);
+	EXPECT_EQ(AmLine(16), 4);
+	EXPECT_EQ(AmLine(8), 2);
+	EXPECT_EQ(AmLine(4), 1);
 }
 
 TEST(Automap, AutomapZoomReset)


### PR DESCRIPTION
Changes automap scaling to adjust by 25, rather than 5. This corrects strange behavior with lines drawn on the automap when the scale level is not a multiple of 25.

Also changes the max zoom out from 50 to 25. The previous change is necessary for this, as scale levels 30, 35, 40, and 45 are quite ugly. This change helps players to see more of the automap when playing at lower resolutions.