### PR TITLE
net: Remove template parameter for cdwrap

### DIFF
--- a/Source/dvlnet/abstract_net.cpp
+++ b/Source/dvlnet/abstract_net.cpp
@@ -13,8 +13,7 @@
 #endif
 #include "dvlnet/loopback.h"
 
-namespace devilution {
-namespace net {
+namespace devilution::net {
 
 std::unique_ptr<abstract_net> abstract_net::MakeNet(provider_t provider)
 {
@@ -24,11 +23,15 @@ std::unique_ptr<abstract_net> abstract_net::MakeNet(provider_t provider)
 	switch (provider) {
 #ifndef DISABLE_TCP
 	case SELCONN_TCP:
-		return std::make_unique<cdwrap<tcp_client>>();
+		return std::make_unique<cdwrap>([]() {
+			return std::make_unique<tcp_client>();
+		});
 #endif
 #ifndef DISABLE_ZERO_TIER
 	case SELCONN_ZT:
-		return std::make_unique<cdwrap<base_protocol<protocol_zt>>>();
+		return std::make_unique<cdwrap>([]() {
+			return std::make_unique<base_protocol<protocol_zt>>();
+		});
 #endif
 	case SELCONN_LOOPBACK:
 		return std::make_unique<loopback>();
@@ -38,5 +41,4 @@ std::unique_ptr<abstract_net> abstract_net::MakeNet(provider_t provider)
 #endif
 }
 
-} // namespace net
-} // namespace devilution
+} // namespace devilution::net

--- a/Source/dvlnet/abstract_net.h
+++ b/Source/dvlnet/abstract_net.h
@@ -9,11 +9,11 @@
 #include "multi.h"
 #include "storm/storm_net.hpp"
 
-namespace devilution {
-namespace net {
+namespace devilution::net {
 
-typedef std::vector<unsigned char> buffer_t;
-typedef unsigned long provider_t;
+using buffer_t = std::vector<unsigned char>;
+using provider_t = unsigned long;
+
 class dvlnet_exception : public std::exception {
 public:
 	const char *what() const throw() override
@@ -67,5 +67,4 @@ public:
 	static std::unique_ptr<abstract_net> MakeNet(provider_t provider);
 };
 
-} // namespace net
-} // namespace devilution
+} // namespace devilution::net

--- a/Source/dvlnet/base.h
+++ b/Source/dvlnet/base.h
@@ -17,21 +17,17 @@ namespace net {
 
 class base : public abstract_net {
 public:
-	virtual int create(std::string addrstr) = 0;
-	virtual int join(std::string addrstr) = 0;
-
-	virtual bool SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size);
-	virtual bool SNetSendMessage(int playerId, void *data, unsigned int size);
-	virtual bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status);
-	virtual bool SNetSendTurn(char *data, unsigned int size);
-	virtual void SNetGetProviderCaps(struct _SNETCAPS *caps);
-	virtual bool SNetRegisterEventHandler(event_type evtype,
-	    SEVTHANDLER func);
-	virtual bool SNetUnregisterEventHandler(event_type evtype);
-	virtual bool SNetLeaveGame(int type);
-	virtual bool SNetDropPlayer(int playerid, uint32_t flags);
-	virtual bool SNetGetOwnerTurnsWaiting(uint32_t *turns);
-	virtual bool SNetGetTurnsInTransit(uint32_t *turns);
+	bool SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size) override;
+	bool SNetSendMessage(int playerId, void *data, unsigned int size) override;
+	bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status) override;
+	bool SNetSendTurn(char *data, unsigned int size) override;
+	void SNetGetProviderCaps(struct _SNETCAPS *caps) override;
+	bool SNetRegisterEventHandler(event_type evtype, SEVTHANDLER func) override;
+	bool SNetUnregisterEventHandler(event_type evtype) override;
+	bool SNetLeaveGame(int type) override;
+	bool SNetDropPlayer(int playerid, uint32_t flags) override;
+	bool SNetGetOwnerTurnsWaiting(uint32_t *turns) override;
+	bool SNetGetTurnsInTransit(uint32_t *turns) override;
 
 	virtual void poll() = 0;
 	virtual void send(packet &pkt) = 0;
@@ -39,10 +35,10 @@ public:
 
 	void setup_gameinfo(buffer_t info);
 
-	virtual void setup_password(std::string pw);
-	virtual void clear_password();
+	void setup_password(std::string pw) override;
+	void clear_password() override;
 
-	virtual ~base() = default;
+	~base() override = default;
 
 protected:
 	std::map<event_type, SEVTHANDLER> registered_handlers;

--- a/Source/dvlnet/cdwrap.cpp
+++ b/Source/dvlnet/cdwrap.cpp
@@ -1,1 +1,133 @@
 #include "dvlnet/cdwrap.h"
+
+namespace devilution::net {
+
+void cdwrap::reset()
+{
+	dvlnet_wrap = make_net_fn_();
+	dvlnet_wrap->setup_gameinfo(game_init_info);
+
+	if (game_pw != std::nullopt) {
+		dvlnet_wrap->setup_password(*game_pw);
+	} else {
+		dvlnet_wrap->clear_password();
+	}
+
+	for (const auto &[eventType, eventHandler] : registered_handlers)
+		dvlnet_wrap->SNetRegisterEventHandler(eventType, eventHandler);
+}
+
+int cdwrap::create(std::string addrstr)
+{
+	reset();
+	return dvlnet_wrap->create(addrstr);
+}
+
+int cdwrap::join(std::string addrstr)
+{
+	game_init_info = buffer_t();
+	reset();
+	return dvlnet_wrap->join(addrstr);
+}
+
+void cdwrap::setup_gameinfo(buffer_t info)
+{
+	game_init_info = std::move(info);
+	if (dvlnet_wrap)
+		dvlnet_wrap->setup_gameinfo(game_init_info);
+}
+
+bool cdwrap::SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size)
+{
+	return dvlnet_wrap->SNetReceiveMessage(sender, data, size);
+}
+
+bool cdwrap::SNetSendMessage(int playerID, void *data, unsigned int size)
+{
+	return dvlnet_wrap->SNetSendMessage(playerID, data, size);
+}
+
+bool cdwrap::SNetReceiveTurns(char **data, size_t *size, uint32_t *status)
+{
+	return dvlnet_wrap->SNetReceiveTurns(data, size, status);
+}
+
+bool cdwrap::SNetSendTurn(char *data, unsigned int size)
+{
+	return dvlnet_wrap->SNetSendTurn(data, size);
+}
+
+void cdwrap::SNetGetProviderCaps(struct _SNETCAPS *caps)
+{
+	dvlnet_wrap->SNetGetProviderCaps(caps);
+}
+
+bool cdwrap::SNetUnregisterEventHandler(event_type evtype)
+{
+	registered_handlers.erase(evtype);
+	if (dvlnet_wrap)
+		return dvlnet_wrap->SNetUnregisterEventHandler(evtype);
+	return true;
+}
+
+bool cdwrap::SNetRegisterEventHandler(event_type evtype, SEVTHANDLER func)
+{
+	registered_handlers[evtype] = func;
+	if (dvlnet_wrap)
+		return dvlnet_wrap->SNetRegisterEventHandler(evtype, func);
+	return true;
+}
+
+bool cdwrap::SNetLeaveGame(int type)
+{
+	return dvlnet_wrap->SNetLeaveGame(type);
+}
+
+bool cdwrap::SNetDropPlayer(int playerid, uint32_t flags)
+{
+	return dvlnet_wrap->SNetDropPlayer(playerid, flags);
+}
+
+bool cdwrap::SNetGetOwnerTurnsWaiting(uint32_t *turns)
+{
+	return dvlnet_wrap->SNetGetOwnerTurnsWaiting(turns);
+}
+
+bool cdwrap::SNetGetTurnsInTransit(uint32_t *turns)
+{
+	return dvlnet_wrap->SNetGetTurnsInTransit(turns);
+}
+
+std::string cdwrap::make_default_gamename()
+{
+	return dvlnet_wrap->make_default_gamename();
+}
+
+bool cdwrap::send_info_request()
+{
+	return dvlnet_wrap->send_info_request();
+}
+
+void cdwrap::clear_gamelist()
+{
+	dvlnet_wrap->clear_gamelist();
+}
+
+std::vector<GameInfo> cdwrap::get_gamelist()
+{
+	return dvlnet_wrap->get_gamelist();
+}
+
+void cdwrap::setup_password(std::string pw)
+{
+	game_pw = pw;
+	return dvlnet_wrap->setup_password(pw);
+}
+
+void cdwrap::clear_password()
+{
+	game_pw = std::nullopt;
+	return dvlnet_wrap->clear_password();
+}
+
+} // namespace devilution::net

--- a/Source/dvlnet/cdwrap.h
+++ b/Source/dvlnet/cdwrap.h
@@ -8,204 +8,52 @@
 #include <string>
 #include <vector>
 
+#include <function_ref.hpp>
+
 #include "dvlnet/abstract_net.h"
 #include "storm/storm_net.hpp"
 
-namespace devilution {
-namespace net {
+namespace devilution::net {
 
-template <class T>
 class cdwrap : public abstract_net {
 private:
 	std::unique_ptr<abstract_net> dvlnet_wrap;
 	std::map<event_type, SEVTHANDLER> registered_handlers;
 	buffer_t game_init_info;
 	std::optional<std::string> game_pw;
+	tl::function_ref<std::unique_ptr<abstract_net>()> make_net_fn_;
 
 	void reset();
 
 public:
-	virtual int create(std::string addrstr);
-	virtual int join(std::string addrstr);
-	virtual bool SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size);
-	virtual bool SNetSendMessage(int dest, void *data, unsigned int size);
-	virtual bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status);
-	virtual bool SNetSendTurn(char *data, unsigned int size);
-	virtual void SNetGetProviderCaps(struct _SNETCAPS *caps);
-	virtual bool SNetRegisterEventHandler(event_type evtype,
-	    SEVTHANDLER func);
-	virtual bool SNetUnregisterEventHandler(event_type evtype);
-	virtual bool SNetLeaveGame(int type);
-	virtual bool SNetDropPlayer(int playerid, uint32_t flags);
-	virtual bool SNetGetOwnerTurnsWaiting(uint32_t *turns);
-	virtual bool SNetGetTurnsInTransit(uint32_t *turns);
-	virtual void setup_gameinfo(buffer_t info);
-	virtual std::string make_default_gamename();
-	virtual bool send_info_request();
-	virtual void clear_gamelist();
-	virtual std::vector<GameInfo> get_gamelist();
-	virtual void setup_password(std::string pw);
-	virtual void clear_password();
+	explicit cdwrap(tl::function_ref<std::unique_ptr<abstract_net>()> makeNetFn)
+	    : make_net_fn_(makeNetFn)
+	{
+		reset();
+	}
 
-	cdwrap();
+	int create(std::string addrstr) override;
+	int join(std::string addrstr) override;
+	bool SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size) override;
+	bool SNetSendMessage(int dest, void *data, unsigned int size) override;
+	bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status) override;
+	bool SNetSendTurn(char *data, unsigned int size) override;
+	void SNetGetProviderCaps(struct _SNETCAPS *caps) override;
+	bool SNetRegisterEventHandler(event_type evtype, SEVTHANDLER func) override;
+	bool SNetUnregisterEventHandler(event_type evtype) override;
+	bool SNetLeaveGame(int type) override;
+	bool SNetDropPlayer(int playerid, uint32_t flags) override;
+	bool SNetGetOwnerTurnsWaiting(uint32_t *turns) override;
+	bool SNetGetTurnsInTransit(uint32_t *turns) override;
+	void setup_gameinfo(buffer_t info) override;
+	std::string make_default_gamename() override;
+	bool send_info_request() override;
+	void clear_gamelist() override;
+	std::vector<GameInfo> get_gamelist() override;
+	void setup_password(std::string pw) override;
+	void clear_password() override;
+
 	virtual ~cdwrap() = default;
 };
 
-template <class T>
-cdwrap<T>::cdwrap()
-{
-	reset();
-}
-
-template <class T>
-void cdwrap<T>::reset()
-{
-	dvlnet_wrap.reset(new T);
-	dvlnet_wrap->setup_gameinfo(game_init_info);
-
-	if (game_pw != std::nullopt)
-		dvlnet_wrap->setup_password(*game_pw);
-	else
-		dvlnet_wrap->clear_password();
-
-	for (const auto &[eventType, eventHandler] : registered_handlers)
-		dvlnet_wrap->SNetRegisterEventHandler(eventType, eventHandler);
-}
-
-template <class T>
-int cdwrap<T>::create(std::string addrstr)
-{
-	reset();
-	return dvlnet_wrap->create(addrstr);
-}
-
-template <class T>
-int cdwrap<T>::join(std::string addrstr)
-{
-	game_init_info = buffer_t();
-	reset();
-	return dvlnet_wrap->join(addrstr);
-}
-
-template <class T>
-void cdwrap<T>::setup_gameinfo(buffer_t info)
-{
-	game_init_info = std::move(info);
-	if (dvlnet_wrap)
-		dvlnet_wrap->setup_gameinfo(game_init_info);
-}
-
-template <class T>
-bool cdwrap<T>::SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size)
-{
-	return dvlnet_wrap->SNetReceiveMessage(sender, data, size);
-}
-
-template <class T>
-bool cdwrap<T>::SNetSendMessage(int playerID, void *data, unsigned int size)
-{
-	return dvlnet_wrap->SNetSendMessage(playerID, data, size);
-}
-
-template <class T>
-bool cdwrap<T>::SNetReceiveTurns(char **data, size_t *size, uint32_t *status)
-{
-	return dvlnet_wrap->SNetReceiveTurns(data, size, status);
-}
-
-template <class T>
-bool cdwrap<T>::SNetSendTurn(char *data, unsigned int size)
-{
-	return dvlnet_wrap->SNetSendTurn(data, size);
-}
-
-template <class T>
-void cdwrap<T>::SNetGetProviderCaps(struct _SNETCAPS *caps)
-{
-	dvlnet_wrap->SNetGetProviderCaps(caps);
-}
-
-template <class T>
-bool cdwrap<T>::SNetUnregisterEventHandler(event_type evtype)
-{
-	registered_handlers.erase(evtype);
-	if (dvlnet_wrap)
-		return dvlnet_wrap->SNetUnregisterEventHandler(evtype);
-	else
-		return true;
-}
-
-template <class T>
-bool cdwrap<T>::SNetRegisterEventHandler(event_type evtype, SEVTHANDLER func)
-{
-	registered_handlers[evtype] = func;
-	if (dvlnet_wrap)
-		return dvlnet_wrap->SNetRegisterEventHandler(evtype, func);
-	else
-		return true;
-}
-
-template <class T>
-bool cdwrap<T>::SNetLeaveGame(int type)
-{
-	return dvlnet_wrap->SNetLeaveGame(type);
-}
-
-template <class T>
-bool cdwrap<T>::SNetDropPlayer(int playerid, uint32_t flags)
-{
-	return dvlnet_wrap->SNetDropPlayer(playerid, flags);
-}
-
-template <class T>
-bool cdwrap<T>::SNetGetOwnerTurnsWaiting(uint32_t *turns)
-{
-	return dvlnet_wrap->SNetGetOwnerTurnsWaiting(turns);
-}
-
-template <class T>
-bool cdwrap<T>::SNetGetTurnsInTransit(uint32_t *turns)
-{
-	return dvlnet_wrap->SNetGetTurnsInTransit(turns);
-}
-
-template <class T>
-std::string cdwrap<T>::make_default_gamename()
-{
-	return dvlnet_wrap->make_default_gamename();
-}
-
-template <class T>
-bool cdwrap<T>::send_info_request()
-{
-	return dvlnet_wrap->send_info_request();
-}
-
-template <class T>
-void cdwrap<T>::clear_gamelist()
-{
-	dvlnet_wrap->clear_gamelist();
-}
-
-template <class T>
-std::vector<GameInfo> cdwrap<T>::get_gamelist()
-{
-	return dvlnet_wrap->get_gamelist();
-}
-
-template <class T>
-void cdwrap<T>::setup_password(std::string pw)
-{
-	game_pw = pw;
-	return dvlnet_wrap->setup_password(pw);
-}
-
-template <class T>
-void cdwrap<T>::clear_password()
-{
-	game_pw = std::nullopt;
-	return dvlnet_wrap->clear_password();
-}
-
-} // namespace net
-} // namespace devilution
+} // namespace devilution::net

--- a/Source/dvlnet/loopback.cpp
+++ b/Source/dvlnet/loopback.cpp
@@ -7,8 +7,7 @@
 #include "utils/language.h"
 #include "utils/stubs.h"
 
-namespace devilution {
-namespace net {
+namespace devilution::net {
 
 int loopback::create(std::string /*addrstr*/)
 {
@@ -118,5 +117,4 @@ std::string loopback::make_default_gamename()
 	return std::string(_("loopback"));
 }
 
-} // namespace net
-} // namespace devilution
+} // namespace devilution::net

--- a/Source/dvlnet/loopback.h
+++ b/Source/dvlnet/loopback.h
@@ -6,37 +6,32 @@
 
 #include "dvlnet/abstract_net.h"
 
-namespace devilution {
-namespace net {
+namespace devilution::net {
 
 class loopback : public abstract_net {
 private:
 	std::queue<buffer_t> message_queue;
 	buffer_t message_last;
-	uint8_t plr_single;
+	uint8_t plr_single = 0;
 
 public:
-	loopback()
-	{
-		plr_single = 0;
-	};
+	loopback() = default;
 
-	virtual int create(std::string addrstr);
-	virtual int join(std::string addrstr);
-	virtual bool SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size);
-	virtual bool SNetSendMessage(int dest, void *data, unsigned int size);
-	virtual bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status);
-	virtual bool SNetSendTurn(char *data, unsigned int size);
-	virtual void SNetGetProviderCaps(struct _SNETCAPS *caps);
-	virtual bool SNetRegisterEventHandler(event_type evtype, SEVTHANDLER func);
-	virtual bool SNetUnregisterEventHandler(event_type evtype);
-	virtual bool SNetLeaveGame(int type);
-	virtual bool SNetDropPlayer(int playerid, uint32_t flags);
-	virtual bool SNetGetOwnerTurnsWaiting(uint32_t *turns);
-	virtual bool SNetGetTurnsInTransit(uint32_t *turns);
-	virtual void setup_gameinfo(buffer_t info);
-	virtual std::string make_default_gamename();
+	int create(std::string addrstr) override;
+	int join(std::string addrstr) override;
+	bool SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size) override;
+	bool SNetSendMessage(int dest, void *data, unsigned int size) override;
+	bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status) override;
+	bool SNetSendTurn(char *data, unsigned int size) override;
+	void SNetGetProviderCaps(struct _SNETCAPS *caps) override;
+	bool SNetRegisterEventHandler(event_type evtype, SEVTHANDLER func) override;
+	bool SNetUnregisterEventHandler(event_type evtype) override;
+	bool SNetLeaveGame(int type) override;
+	bool SNetDropPlayer(int playerid, uint32_t flags) override;
+	bool SNetGetOwnerTurnsWaiting(uint32_t *turns) override;
+	bool SNetGetTurnsInTransit(uint32_t *turns) override;
+	void setup_gameinfo(buffer_t info) override;
+	std::string make_default_gamename() override;
 };
 
-} // namespace net
-} // namespace devilution
+} // namespace devilution::net

--- a/Source/dvlnet/tcp_client.cpp
+++ b/Source/dvlnet/tcp_client.cpp
@@ -11,8 +11,7 @@
 
 #include <asio/connect.hpp>
 
-namespace devilution {
-namespace net {
+namespace devilution::net {
 
 int tcp_client::create(std::string addrstr)
 {
@@ -141,5 +140,4 @@ std::string tcp_client::make_default_gamename()
 tcp_client::~tcp_client()
     = default;
 
-} // namespace net
-} // namespace devilution
+} // namespace devilution::net

--- a/Source/dvlnet/tcp_client.h
+++ b/Source/dvlnet/tcp_client.h
@@ -22,8 +22,7 @@
 #include "dvlnet/packet.h"
 #include "dvlnet/tcp_server.h"
 
-namespace devilution {
-namespace net {
+namespace devilution::net {
 
 class tcp_client : public base {
 public:
@@ -56,5 +55,4 @@ private:
 	void HandleSend(const asio::error_code &error, size_t bytesSent);
 };
 
-} // namespace net
-} // namespace devilution
+} // namespace devilution::net


### PR DESCRIPTION
1. There is no reason for cdwrap to be templated, it can simply store the factory function reference instead.
2. Marks overriden virtual functions as `override` instead of `virtual`.