### PR TITLE
Automap: Remove 25% Zoom

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1232,7 +1232,7 @@ void AutomapZoomIn()
 
 void AutomapZoomOut()
 {
-	if (AutoMapScale <= 25)
+	if (AutoMapScale <= 50)
 		return;
 
 	AutoMapScale -= 25;

--- a/test/automap_test.cpp
+++ b/test/automap_test.cpp
@@ -100,11 +100,11 @@ TEST(Automap, AutomapZoomOut_Min)
 	AutoMapScale = 50;
 	AutomapZoomOut();
 	AutomapZoomOut();
-	EXPECT_EQ(AutoMapScale, 25);
-	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), static_cast<int>(AmLineLength::HalfTile));
-	EXPECT_EQ(AmLine(AmLineLength::FullTile), static_cast<int>(AmLineLength::QuarterTile));
-	EXPECT_EQ(AmLine(AmLineLength::HalfTile), 1);
-	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), 0);
+	EXPECT_EQ(AutoMapScale, 50);
+	EXPECT_EQ(AmLine(AmLineLength::DoubleTile), static_cast<int>(AmLineLength::FullTile));
+	EXPECT_EQ(AmLine(AmLineLength::FullTile), static_cast<int>(AmLineLength::HalfTile));
+	EXPECT_EQ(AmLine(AmLineLength::HalfTile), static_cast<int>(AmLineLength::QuarterTile));
+	EXPECT_EQ(AmLine(AmLineLength::QuarterTile), 1);
 }
 
 TEST(Automap, AutomapZoomReset)


### PR DESCRIPTION
This scale level appears to be too problematic, since it crowds the pixels too much and obscures details. Originally, I thought this zoom level may assist players using low resolutions in order to be able to have a view over the entire level, however keeping it would justify more modifications to the automap and workarounds. I believe this should be revisited at a later time when the automap can be rendered independently of the game surface.