### PR TITLE
Fix minlvl when generating translated names for staves

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2363,6 +2363,7 @@ std::string GetTranslatedItemNameMagical(const Item &item, bool hellfireItem, bo
 			affixItemType = AffixItemType::Staff;
 		else if (!hellfireItem && FlipCoin(4)) {
 			affixItemType = AffixItemType::Staff;
+			minlvl = maxlvl / 2;
 		} else {
 			DiscardRandomValues(2); // Spell and Charges
 


### PR DESCRIPTION
This particular case where a staff that allows spells rolls with a regular suffix gets its `minlvl` reset to `maxlvl / 2` because `GetStaffSpell()` doesn't receive `minlvl` as a parameter.

https://github.com/diasurgical/devilutionX/blob/c4d25187415c81b12750828e000617867f8a430b/Source/items.cpp#L1264-L1267