### PR TITLE
Automap: Minimap

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1527,7 +1527,7 @@ std::unique_ptr<AutomapTile[]> LoadAutomapData(size_t &tileCount)
 } // namespace
 
 bool AutomapActive;
-AutomapType CurrentAutomapType;
+AutomapType CurrentAutomapType = AutomapType::Opaque;
 uint8_t AutomapView[DMAXX][DMAXY];
 int AutoMapScale;
 int MinimapScale;
@@ -1538,7 +1538,6 @@ void InitAutomapOnce()
 {
 	AutomapActive = false;
 	AutoMapScale = 50;
-	SetAutomapType(AutomapType::Opaque);
 
 	// Set the dimensions and screen position of the minimap relative to the screen dimensions
 	int minimapWidth = gnScreenWidth / 4;

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1768,17 +1768,19 @@ void DrawAutomap(const Surface &out)
 		// Background fill
 		DrawHalfTransparentRectTo(out, MinimapRect.position.x, MinimapRect.position.y, MinimapRect.size.width, MinimapRect.size.height);
 
+		uint8_t frameShadowColor = PAL16_YELLOW + 12;
+
 		// Shadow
-		DrawHorizontalLine(out, MinimapRect.position + Displacement { 0, 0 }, MinimapRect.size.width + 2, MapColorsDim);
-		DrawHorizontalLine(out, MinimapRect.position + Displacement { 0, MinimapRect.size.height + 1 }, MinimapRect.size.width + 2, MapColorsDim);
-		DrawVerticalLine(out, MinimapRect.position + Displacement { 0, 1 }, MinimapRect.size.height, MapColorsDim);
-		DrawVerticalLine(out, MinimapRect.position + Displacement { MinimapRect.size.width + 1, 1 }, MinimapRect.size.height, MapColorsDim);
+		DrawHorizontalLine(out, MinimapRect.position + Displacement { -1, -1 }, MinimapRect.size.width + 1, frameShadowColor);
+		DrawHorizontalLine(out, MinimapRect.position + Displacement { -2, MinimapRect.size.height + 1 }, MinimapRect.size.width + 4, frameShadowColor);
+		DrawVerticalLine(out, MinimapRect.position + Displacement { -1, 0 }, MinimapRect.size.height, frameShadowColor);
+		DrawVerticalLine(out, MinimapRect.position + Displacement { MinimapRect.size.width + 1, -2 }, MinimapRect.size.height + 3, frameShadowColor);
 
 		// Frame
-		DrawHorizontalLine(out, MinimapRect.position + Displacement { -1, -1 }, MinimapRect.size.width + 2, MapColorsDim);
-		DrawHorizontalLine(out, MinimapRect.position + Displacement { -1, MinimapRect.size.height }, MinimapRect.size.width + 2, MapColorsDim);
-		DrawVerticalLine(out, MinimapRect.position + Displacement { -1, 0 }, MinimapRect.size.height, MapColorsDim);
-		DrawVerticalLine(out, MinimapRect.position + Displacement { MinimapRect.size.width, 0 }, MinimapRect.size.height, MapColorsDim);
+		DrawHorizontalLine(out, MinimapRect.position + Displacement { -2, -2 }, MinimapRect.size.width + 3, MapColorsDim);
+		DrawHorizontalLine(out, MinimapRect.position + Displacement { -2, MinimapRect.size.height }, MinimapRect.size.width + 3, MapColorsDim);
+		DrawVerticalLine(out, MinimapRect.position + Displacement { -2, -1 }, MinimapRect.size.height + 1, MapColorsDim);
+		DrawVerticalLine(out, MinimapRect.position + Displacement { MinimapRect.size.width, -1 }, MinimapRect.size.height + 1, MapColorsDim);
 	}
 
 	Point screen = {};

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -487,10 +487,10 @@ void DrawLavaRiver(const Surface &out, Point center, uint8_t color, bool hasBrid
 			SetMapPixel(out, center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileUp), color);
 	}
 	if constexpr (IsAnyOf(Direction::NorthWest, TDir1, TDir2) || IsAnyOf(Direction::NorthEast, TDir1, TDir2)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
+		SetMapPixel(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::None), color);
 	}
 	if constexpr (IsAnyOf(Direction::SouthWest, TDir1, TDir2) || IsAnyOf(Direction::NorthWest, TDir1, TDir2)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
+		SetMapPixel(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::QuarterTileDown), color);
 	}
 	if constexpr (IsAnyOf(Direction::SouthWest, TDir1, TDir2)) {
 		SetMapPixel(out, center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::HalfTileDown), color);
@@ -502,10 +502,10 @@ void DrawLavaRiver(const Surface &out, Point center, uint8_t color, bool hasBrid
 			SetMapPixel(out, center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None), color);
 	}
 	if constexpr (IsAnyOf(Direction::NorthEast, TDir1, TDir2) || IsAnyOf(Direction::SouthEast, TDir1, TDir2)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
+		SetMapPixel(out, center + AmOffset(AmWidthOffset::QuarterTileRight, AmHeightOffset::QuarterTileDown), color);
 	}
 	if constexpr (IsAnyOf(Direction::SouthWest, TDir1, TDir2) || IsAnyOf(Direction::SouthEast, TDir1, TDir2)) {
-		out.SetPixel(center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
+		SetMapPixel(out, center + AmOffset(AmWidthOffset::None, AmHeightOffset::HalfTileDown), color);
 	}
 	if constexpr (IsAnyOf(Direction::SouthWest, TDir1, TDir2)) {
 		SetMapPixel(out, center + AmOffset(AmWidthOffset::QuarterTileLeft, AmHeightOffset::ThreeQuartersTileDown), color);
@@ -1506,6 +1506,7 @@ bool AutomapActive;
 uint8_t AutomapView[DMAXX][DMAXY];
 int AutoMapScale;
 Displacement AutomapOffset;
+bool AutomapTransparent;
 
 void InitAutomapOnce()
 {
@@ -1651,6 +1652,7 @@ void StartAutomap()
 {
 	AutomapOffset = { 0, 0 };
 	AutomapActive = true;
+	AutomapTransparent = false;
 }
 
 void AutomapUp()

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -36,10 +36,6 @@ extern uint8_t AutomapView[DMAXX][DMAXY];
 extern DVL_API_FOR_TEST int AutoMapScale;
 extern DVL_API_FOR_TEST int MinimapScale;
 extern DVL_API_FOR_TEST Displacement AutomapOffset;
-/** Specifies whether the automap is transparent. */
-extern DVL_API_FOR_TEST bool AutomapTransparent;
-/** Specifies whether the automap is in minimap mode. */
-extern DVL_API_FOR_TEST bool Minimap;
 extern Rectangle MinimapRect;
 
 /** Defines the offsets used for Automap lines */
@@ -84,26 +80,44 @@ enum class AmLineLength : uint8_t {
 	OctupleTile = 64,
 };
 
-inline Displacement AmOffset(AmWidthOffset x, AmHeightOffset y)
-{
-	int scale = (Minimap) ? MinimapScale : AutoMapScale;
-
-	return { scale * static_cast<int>(x) / 100, scale * static_cast<int>(y) / 100 };
-}
-
-inline int AmLine(AmLineLength l)
-{
-	int scale = (Minimap) ? MinimapScale : AutoMapScale;
-
-	return scale * static_cast<int>(l) / 100;
-}
-
 enum class AutomapType : uint8_t {
 	Opaque,
 	Transparent,
 	Minimap,
 	LAST = Minimap
 };
+
+extern AutomapType CurrentAutomapType;
+
+/**
+ * @brief Sets the map type. Does not change `AutomapActive`.
+ */
+inline void SetAutomapType(AutomapType type)
+{
+	CurrentAutomapType = type;
+}
+
+/**
+ * @brief Sets the map type. Does not change `AutomapActive`.
+ */
+inline AutomapType GetAutomapType()
+{
+	return CurrentAutomapType;
+}
+
+inline Displacement AmOffset(AmWidthOffset x, AmHeightOffset y)
+{
+	int scale = (GetAutomapType() == AutomapType::Minimap) ? MinimapScale : AutoMapScale;
+
+	return { scale * static_cast<int>(x) / 100, scale * static_cast<int>(y) / 100 };
+}
+
+inline int AmLine(AmLineLength l)
+{
+	int scale = (GetAutomapType() == AutomapType::Minimap) ? MinimapScale : AutoMapScale;
+
+	return scale * static_cast<int>(l) / 100;
+}
 
 /**
  * @brief Sets the map type. Does not change `AutomapActive`.

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -34,9 +34,14 @@ extern DVL_API_FOR_TEST bool AutomapActive;
 extern uint8_t AutomapView[DMAXX][DMAXY];
 /** Specifies the scale of the automap. */
 extern DVL_API_FOR_TEST int AutoMapScale;
+extern DVL_API_FOR_TEST int MinimapScale;
 extern DVL_API_FOR_TEST Displacement AutomapOffset;
 /** Specifies whether the automap is transparent. */
 extern DVL_API_FOR_TEST bool AutomapTransparent;
+/** Specifies whether the automap is in minimap mode. */
+extern DVL_API_FOR_TEST bool Minimap;
+extern Rectangle MinimapRect;
+
 
 /** Defines the offsets used for Automap lines */
 enum class AmWidthOffset : int8_t {
@@ -82,12 +87,16 @@ enum class AmLineLength : uint8_t {
 
 inline Displacement AmOffset(AmWidthOffset x, AmHeightOffset y)
 {
-	return { AutoMapScale * static_cast<int>(x) / 100, AutoMapScale * static_cast<int>(y) / 100 };
+	int scale = (Minimap) ? MinimapScale : AutoMapScale;
+
+	return { scale * static_cast<int>(x) / 100, scale * static_cast<int>(y) / 100 };
 }
 
 inline int AmLine(AmLineLength l)
 {
-	return AutoMapScale * static_cast<int>(l) / 100;
+	int scale = (Minimap) ? MinimapScale : AutoMapScale;
+
+	return scale * static_cast<int>(l) / 100;
 }
 
 enum class AutomapType : uint8_t {
@@ -118,6 +127,11 @@ void InitAutomap();
  * @brief Displays the automap.
  */
 void StartAutomap();
+
+/**
+ * @brief Displays the minimap.
+ */
+void StartMinimap();
 
 /**
  * @brief Scrolls the automap upwards.

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -42,7 +42,6 @@ extern DVL_API_FOR_TEST bool AutomapTransparent;
 extern DVL_API_FOR_TEST bool Minimap;
 extern Rectangle MinimapRect;
 
-
 /** Defines the offsets used for Automap lines */
 enum class AmWidthOffset : int8_t {
 	None,

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -35,6 +35,8 @@ extern uint8_t AutomapView[DMAXX][DMAXY];
 /** Specifies the scale of the automap. */
 extern DVL_API_FOR_TEST int AutoMapScale;
 extern DVL_API_FOR_TEST Displacement AutomapOffset;
+/** Specifies whether the automap is transparent. */
+extern DVL_API_FOR_TEST bool AutomapTransparent;
 
 /** Defines the offsets used for Automap lines */
 enum class AmWidthOffset : int8_t {

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -82,6 +82,7 @@ enum class AmLineLength : uint8_t {
 
 enum class AutomapType : uint8_t {
 	Opaque,
+	FIRST = Opaque,
 	Transparent,
 	Minimap,
 	LAST = Minimap

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -88,7 +88,7 @@ enum class AutomapType : uint8_t {
 	LAST = Minimap
 };
 
-extern AutomapType CurrentAutomapType;
+extern DVL_API_FOR_TEST AutomapType CurrentAutomapType;
 
 /**
  * @brief Sets the map type. Does not change `AutomapActive`.

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1004,11 +1004,10 @@ void control_check_btn_press()
 
 void DoAutoMap()
 {
-	if (!AutomapActive) {
+	if (!AutomapActive)
 		StartAutomap();
-	} else {
+	else
 		AutomapActive = false;
-	}
 }
 
 void CycleAutomapType()
@@ -1016,9 +1015,6 @@ void CycleAutomapType()
 	const AutomapType newType { static_cast<std::underlying_type_t<AutomapType>>(
 		(static_cast<unsigned>(GetAutomapType()) + 1) % enum_size<AutomapType>::value) };
 	SetAutomapType(newType);
-	//if (newType == AutomapType::Minimap) {
-	//	SetAutomapType(AutomapType::Opaque); // temporary hack to skip minimap while minimap hasn't been implemented yet
-	//}
 }
 
 void CheckPanelInfo()

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1006,6 +1006,8 @@ void DoAutoMap()
 {
 	if (!AutomapActive)
 		StartAutomap();
+	else if (!AutomapTransparent)
+		AutomapTransparent = true;
 	else
 		AutomapActive = false;
 }

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1012,9 +1012,16 @@ void DoAutoMap()
 
 void CycleAutomapType()
 {
+	if (!AutomapActive) {
+		StartAutomap();
+		return;
+	}
 	const AutomapType newType { static_cast<std::underlying_type_t<AutomapType>>(
 		(static_cast<unsigned>(GetAutomapType()) + 1) % enum_size<AutomapType>::value) };
 	SetAutomapType(newType);
+	if (newType == AutomapType::FIRST) {
+		AutomapActive = false;
+	}
 }
 
 void CheckPanelInfo()

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1004,12 +1004,14 @@ void control_check_btn_press()
 
 void DoAutoMap()
 {
-	if (!AutomapActive)
+	if (!AutomapActive) {
 		StartAutomap();
-	else if (!AutomapTransparent)
-		AutomapTransparent = true;
-	else
+	} else if (!Minimap) {
+		StartMinimap();
+	} else {
 		AutomapActive = false;
+		Minimap = false;
+	}
 }
 
 void CycleAutomapType()

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1006,11 +1006,8 @@ void DoAutoMap()
 {
 	if (!AutomapActive) {
 		StartAutomap();
-	} else if (!Minimap) {
-		StartMinimap();
 	} else {
 		AutomapActive = false;
-		Minimap = false;
 	}
 }
 
@@ -1019,9 +1016,9 @@ void CycleAutomapType()
 	const AutomapType newType { static_cast<std::underlying_type_t<AutomapType>>(
 		(static_cast<unsigned>(GetAutomapType()) + 1) % enum_size<AutomapType>::value) };
 	SetAutomapType(newType);
-	if (newType == AutomapType::Minimap) {
-		SetAutomapType(AutomapType::Opaque); // temporary hack to skip minimap while minimap hasn't been implemented yet
-	}
+	//if (newType == AutomapType::Minimap) {
+	//	SetAutomapType(AutomapType::Opaque); // temporary hack to skip minimap while minimap hasn't been implemented yet
+	//}
 }
 
 void CheckPanelInfo()

--- a/Source/engine/render/automap_render.cpp
+++ b/Source/engine/render/automap_render.cpp
@@ -163,7 +163,7 @@ void DrawMapFreeLine(const Surface &out, Point from, Point to, uint8_t colorInde
 
 void SetMapPixel(const Surface &out, Point position, uint8_t color)
 {
-	if (Minimap && !MinimapRect.contains(position))
+	if (GetAutomapType() == AutomapType::Minimap && !MinimapRect.contains(position))
 		return;
 
 	if (GetAutomapType() == AutomapType::Transparent) {

--- a/Source/engine/render/automap_render.cpp
+++ b/Source/engine/render/automap_render.cpp
@@ -163,10 +163,14 @@ void DrawMapFreeLine(const Surface &out, Point from, Point to, uint8_t colorInde
 
 void SetMapPixel(const Surface &out, Point position, uint8_t color)
 {
-	if (GetAutomapType() == AutomapType::Transparent)
+	if (Minimap && !MinimapRect.contains(position))
+		return;
+
+	if (GetAutomapType() == AutomapType::Transparent) {
 		SetHalfTransparentPixel(out, position, color);
-	else
+	} else {
 		out.SetPixel(position, color);
+	}
 }
 
 } // namespace devilution


### PR DESCRIPTION
Built on: https://github.com/diasurgical/devilutionX/pull/6607

Adds a minimap to the top right part of the screen. Accessed by toggling automap twice. Minimap scaling is completely separate from automap scaling, so the game will remember which scale you have both at, even when the respective one is disabled. Minimap scale is not saved with the save file.

The size of the minimap is proportional to the display resolution, so it will appear the relative same size regardless of what resolution you're using. The default starting zoom level is also based on your resolution.

https://github.com/diasurgical/devilutionX/assets/68359262/012bfe72-610f-40f4-a46e-93ed59477609

