### PR TITLE
Add automap type cycling controls

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -32,6 +32,8 @@ namespace devilution {
 namespace {
 Point Automap;
 
+AutomapType CurrentAutomapType;
+
 enum MapColors : uint8_t {
 	/** color used to draw the player's arrow */
 	MapColorsPlayer = (PAL8_ORANGE + 1),
@@ -1550,6 +1552,16 @@ void InitAutomap()
 	for (auto &column : dFlags)
 		for (auto &dFlag : column)
 			dFlag &= ~DungeonFlag::Explored;
+}
+
+void SetAutomapType(AutomapType type)
+{
+	CurrentAutomapType = type;
+}
+
+AutomapType GetAutomapType()
+{
+	return CurrentAutomapType;
 }
 
 void StartAutomap()

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -88,6 +88,20 @@ inline int AmLine(AmLineLength l)
 	return AutoMapScale * static_cast<int>(l) / 100;
 }
 
+enum class AutomapType : uint8_t {
+	Opaque,
+	Transparent,
+	Minimap,
+	LAST = Minimap
+};
+
+/**
+ * @brief Sets the map type. Does not change `AutomapActive`.
+ */
+void SetAutomapType(AutomapType type);
+
+AutomapType GetAutomapType();
+
 /**
  * @brief Initializes the automap.
  */

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1007,6 +1007,20 @@ void DoAutoMap()
 		AutomapActive = false;
 }
 
+void CycleAutomapType()
+{
+	if (!AutomapActive) {
+		StartAutomap();
+		return;
+	}
+	const AutomapType newType { static_cast<std::underlying_type_t<AutomapType>>(
+		(static_cast<unsigned>(GetAutomapType()) + 1) % enum_size<AutomapType>::value) };
+	SetAutomapType(newType);
+	if (newType == AutomapType::Opaque) {
+		AutomapActive = false;
+	}
+}
+
 void CheckPanelInfo()
 {
 	panelflag = false;

--- a/Source/control.h
+++ b/Source/control.h
@@ -153,6 +153,7 @@ void DoPanBtn();
 
 void control_check_btn_press();
 void DoAutoMap();
+void CycleAutomapType();
 
 /**
  * Checks the mouse cursor position within the control panel and sets information

--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -269,7 +269,7 @@ void PressControllerButton(ControllerButton button)
 			gamemenu_on();
 			return;
 		case devilution::ControllerButton_BUTTON_DPAD_DOWN:
-			DoAutoMap();
+			CycleAutomapType();
 			return;
 		case devilution::ControllerButton_BUTTON_DPAD_LEFT:
 			ProcessGameAction(GameAction { GameActionType_TOGGLE_CHARACTER_INFO });

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -554,7 +554,7 @@ void PressKey(SDL_Keycode vkey, uint16_t modState)
 		}
 		return;
 #ifdef _DEBUG
-	case SDLK_m:
+	case SDLK_v:
 		if ((modState & KMOD_SHIFT) != 0)
 			NextDebugMonster();
 		else
@@ -1716,6 +1716,14 @@ void InitKeymapActions()
 	    N_("Toggles if automap is displayed."),
 	    SDLK_TAB,
 	    DoAutoMap,
+	    nullptr,
+	    IsGameRunning);
+	sgOptions.Keymapper.AddAction(
+	    "CycleAutomapType",
+	    N_("Cycle map type"),
+	    N_("Opaque -> Transparent -> Minimap -> None"),
+	    SDLK_m,
+	    CycleAutomapType,
 	    nullptr,
 	    IsGameRunning);
 


### PR DESCRIPTION
Makes cycling the automap type separate from toggling it on/off.

The TAB key can still be used for quick on/off as usual, while the new Cycle key ("m" by default) can be used to switch between available display types.

`Get/NextDebugMonster` debug keybind changed to "v" to avoid a conflict.

The actual implementation for these automap features is in #6607 and #6612