### PR TITLE
Fix unused variable warnings for resampler name

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1849,8 +1849,12 @@ bool PadmapperOptions::CanDeferToMovementHandler(const Action &action) const
 }
 
 namespace {
+#ifdef DEVILUTIONX_RESAMPLER_SPEEX
 constexpr char ResamplerSpeex[] = "Speex";
+#endif
+#ifdef DVL_AULIB_SUPPORTS_SDL_RESAMPLER
 constexpr char ResamplerSDL[] = "SDL";
+#endif
 } // namespace
 
 std::string_view ResamplerToString(Resampler resampler)


### PR DESCRIPTION
If a resampler was not enabled, we'd get an unused variable warning:

    warning: unused variable 'ResamplerSpeex' [-Wunused-const-variable]
    constexpr char ResamplerSpeex[] = "Speex";