### PR TITLE
Add ParseFixed6 equivalent of ParseInt

### DIFF
--- a/Source/data/file.cpp
+++ b/Source/data/file.cpp
@@ -47,24 +47,24 @@ void DataFile::reportFatalError(Error code, std::string_view fileName)
 	}
 }
 
-void DataFile::reportFatalFieldError(std::errc code, std::string_view fileName, std::string_view fieldName, const DataFileField &field)
+void DataFile::reportFatalFieldError(DataFileField::Error code, std::string_view fileName, std::string_view fieldName, const DataFileField &field)
 {
 	switch (code) {
-	case std::errc::invalid_argument:
+	case DataFileField::Error::NotANumber:
 		app_fatal(fmt::format(fmt::runtime(_(
 		                          /* TRANSLATORS: Error message when parsing a data file and a text value is encountered when a number is expected. Arguments are {found value}, {column heading}, {file name}, {row/record number}, {column/field number} */
 		                          "Non-numeric value {0} for {1} in {2} at row {3} and column {4}")),
 		    field.currentValue(), fieldName, fileName, field.row(), field.column()));
-	case std::errc::result_out_of_range:
+	case DataFileField::Error::OutOfRange:
 		app_fatal(fmt::format(fmt::runtime(_(
 		                          /* TRANSLATORS: Error message when parsing a data file and we find a number larger than expected. Arguments are {found value}, {column heading}, {file name}, {row/record number}, {column/field number} */
 		                          "Out of range value {0} for {1} in {2} at row {3} and column {4}")),
 		    field.currentValue(), fieldName, fileName, field.row(), field.column()));
-	default:
+	case DataFileField::Error::InvalidValue:
 		app_fatal(fmt::format(fmt::runtime(_(
-		                          /* TRANSLATORS: Fallback error message when an error occurs while parsing a data file and we can't determine the cause. Arguments are {file name}, {row/record number}, {column/field number} */
-		                          "Unexpected error while reading {0} at row {1} and column {2}")),
-		    fileName, field.row(), field.column()));
+		                          /* TRANSLATORS: Error message when we find an unrecognised value in a key column. Arguments are {found value}, {column heading}, {file name}, {row/record number}, {column/field number} */
+		                          "Invalid value {0} for {1} in {2} at row {3} and column {4}")),
+		    field.currentValue(), fieldName, fileName, field.row(), field.column()));
 	}
 }
 

--- a/Source/data/file.hpp
+++ b/Source/data/file.hpp
@@ -75,7 +75,7 @@ public:
 	static tl::expected<DataFile, Error> load(std::string_view path);
 
 	static void reportFatalError(Error code, std::string_view fileName);
-	static void reportFatalFieldError(std::errc code, std::string_view fileName, std::string_view fieldName, const DataFileField &field);
+	static void reportFatalFieldError(DataFileField::Error code, std::string_view fileName, std::string_view fieldName, const DataFileField &field);
 
 	void resetHeader()
 	{

--- a/Source/playerdat.cpp
+++ b/Source/playerdat.cpp
@@ -120,11 +120,11 @@ void ReloadExperienceData()
 			case ExperienceColumn::Level: {
 				auto parseIntResult = field.parseInt(level);
 
-				if (parseIntResult != std::errc()) {
+				if (!parseIntResult.has_value()) {
 					if (*field == "MaxLevel") {
 						skipRecord = true;
 					} else {
-						DataFile::reportFatalFieldError(parseIntResult, filename, "Level", field);
+						DataFile::reportFatalFieldError(parseIntResult.error(), filename, "Level", field);
 					}
 				}
 			} break;
@@ -132,8 +132,8 @@ void ReloadExperienceData()
 			case ExperienceColumn::Experience: {
 				auto parseIntResult = field.parseInt(experience);
 
-				if (parseIntResult != std::errc()) {
-					DataFile::reportFatalFieldError(parseIntResult, filename, "Experience", field);
+				if (!parseIntResult.has_value()) {
+					DataFile::reportFatalFieldError(parseIntResult.error(), filename, "Experience", field);
 				}
 			} break;
 

--- a/Source/utils/parse_int.hpp
+++ b/Source/utils/parse_int.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <charconv>
 #include <string_view>
 #include <system_error>
@@ -19,10 +20,13 @@ using ParseIntResult = tl::expected<IntT, ParseIntError>;
 template <typename IntT>
 ParseIntResult<IntT> ParseInt(
     std::string_view str, IntT min = std::numeric_limits<IntT>::min(),
-    IntT max = std::numeric_limits<IntT>::max())
+    IntT max = std::numeric_limits<IntT>::max(), const char **endOfParse = nullptr)
 {
 	IntT value;
 	const std::from_chars_result result = std::from_chars(str.data(), str.data() + str.size(), value);
+	if (endOfParse != nullptr) {
+		*endOfParse = result.ptr;
+	}
 	if (result.ec == std::errc::invalid_argument)
 		return tl::unexpected(ParseIntError::ParseError);
 	if (result.ec == std::errc::result_out_of_range || value < min || value > max)
@@ -30,6 +34,101 @@ ParseIntResult<IntT> ParseInt(
 	if (result.ec != std::errc())
 		return tl::unexpected(ParseIntError::ParseError);
 	return value;
+}
+
+inline uint8_t ParseFixed6Fraction(std::string_view str, const char **endOfParse = nullptr)
+{
+	unsigned numDigits = 0;
+	uint32_t decimalFraction = 0;
+
+	// Read at most 7 digits, at that threshold we're able to determine an exact rounding for 6 bit fixed point numbers
+	while (!str.empty() && numDigits < 7) {
+		if (str[0] < '0' || str[0] > '9') {
+			break;
+		}
+		decimalFraction = decimalFraction * 10 + str[0] - '0';
+		++numDigits;
+		str.remove_prefix(1);
+	}
+	if (endOfParse != nullptr) {
+		// to mimic the behaviour of std::from_chars consume all remaining digits in case the value was overly precise.
+		*endOfParse = std::find_if_not(str.data(), str.data() + str.size(), [](char character) { return character >= '0' && character <= '9'; });
+	}
+	// to ensure rounding to nearest we normalise all values to 7 decimal places
+	while (numDigits < 7) {
+		decimalFraction *= 10;
+		++numDigits;
+	}
+	// we add half the step between representable values to use integer truncation as a substitute for rounding to nearest.
+	return (decimalFraction + 78125) / 156250;
+}
+
+template <typename IntT>
+ParseIntResult<IntT> ParseFixed6(std::string_view str, const char **endOfParse = nullptr)
+{
+	if (endOfParse != nullptr) {
+		// To allow for early returns we set the end pointer to the start of the string, which is the common case for errors.
+		*endOfParse = str.data();
+	}
+
+	if (str.empty()) {
+		return tl::unexpected { ParseIntError::ParseError };
+	}
+
+	constexpr IntT minIntegerValue = std::numeric_limits<IntT>::min() >> 6;
+	constexpr IntT maxIntegerValue = std::numeric_limits<IntT>::max() >> 6;
+
+	const char *currentChar; // will be set by the call to parseInt
+	ParseIntResult<IntT> integerParseResult = ParseInt(str, minIntegerValue, maxIntegerValue, &currentChar);
+
+	bool isNegative = std::is_signed_v<IntT> && str[0] == '-';
+	bool haveDigits = integerParseResult.has_value() || integerParseResult.error() == ParseIntError::OutOfRange;
+	if (haveDigits) {
+		str.remove_prefix(static_cast<size_t>(std::distance(str.data(), currentChar)));
+	} else if (isNegative) {
+		str.remove_prefix(1);
+	}
+
+	// if the string has no leading digits we still need to try parse the fraction part
+	uint8_t fractionPart = 0;
+	if (!str.empty() && str[0] == '.') {
+		// got a fractional part to read too
+		str.remove_prefix(1); // skip past the decimal point
+
+		fractionPart = ParseFixed6Fraction(str, &currentChar);
+		haveDigits = haveDigits || str.data() != currentChar;
+	}
+
+	if (!haveDigits) {
+		// early return in case we got a string like "-.abc", don't want to set the end pointer in this case
+		return tl::unexpected { ParseIntError::ParseError };
+	}
+
+	if (endOfParse != nullptr) {
+		*endOfParse = currentChar;
+	}
+
+	if (!integerParseResult.has_value() && integerParseResult.error() == ParseIntError::OutOfRange) {
+		// if the integer parsing gave us an out of range value then we've done a bit of unnecessary
+		//  work parsing the fraction part, but it saves duplicating code.
+		return integerParseResult;
+	}
+	// integerParseResult could be a ParseError at this point because of a string like ".123" or "-.1"
+	//  so we need to default to 0 (and use the result of the minus sign check when it's relevant)
+	IntT integerPart = integerParseResult.value_or(0);
+
+	// rounding could give us a value of 64 for the fraction part (e.g. 0.993 rounds to 1.0) so we need to ensure this doesn't overflow
+	if (fractionPart >= 64 && (integerPart >= maxIntegerValue || (std::is_signed_v<IntT> && integerPart <= minIntegerValue))) {
+		return tl::unexpected { ParseIntError::OutOfRange };
+	} else {
+		IntT fixedValue = integerPart << 6;
+		if (isNegative) {
+			fixedValue -= fractionPart;
+		} else {
+			fixedValue += fractionPart;
+		}
+		return fixedValue;
+	}
 }
 
 } // namespace devilution

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,7 @@ set(tests
   missiles_test
   pack_test
   path_test
+  parse_int_test
   player_test
   quests_test
   random_test

--- a/test/fixtures/txtdata/sample.tsv
+++ b/test/fixtures/txtdata/sample.tsv
@@ -1,2 +1,2 @@
-String	Byte	Int	Float
-Sample	145	70322	6.34
+String	Byte	Int	Float	FloatOverflow
+Sample	145	70322	6.34	3.999

--- a/test/parse_int_test.cpp
+++ b/test/parse_int_test.cpp
@@ -1,0 +1,151 @@
+#include <gtest/gtest.h>
+
+#include "utils/parse_int.hpp"
+
+namespace devilution {
+TEST(ParseIntTest, ParseInt)
+{
+	ParseIntResult<int> result = ParseInt<int>("");
+	ASSERT_FALSE(result.has_value());
+	EXPECT_EQ(result.error(), ParseIntError::ParseError);
+
+	result = ParseInt<int>("abcd");
+	ASSERT_FALSE(result.has_value());
+	EXPECT_EQ(result.error(), ParseIntError::ParseError);
+
+	result = ParseInt<int>("12");
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result.value(), 12);
+
+	result = ParseInt<int>(("99999999"), -5, 100);
+	ASSERT_FALSE(result.has_value());
+	EXPECT_EQ(result.error(), ParseIntError::OutOfRange);
+
+	ParseIntResult<int8_t> shortResult = ParseInt<int8_t>(("99999999"));
+	ASSERT_FALSE(shortResult.has_value());
+	EXPECT_EQ(shortResult.error(), ParseIntError::OutOfRange);
+}
+
+TEST(ParseIntTest, ParseFixed6Fraction)
+{
+	EXPECT_EQ(ParseFixed6Fraction(""), 0);
+	EXPECT_EQ(ParseFixed6Fraction("0"), 0);
+	EXPECT_EQ(ParseFixed6Fraction("00781249"), 0);
+	EXPECT_EQ(ParseFixed6Fraction("0078125"), 1);
+	EXPECT_EQ(ParseFixed6Fraction("015625"), 1);
+	EXPECT_EQ(ParseFixed6Fraction("03125"), 2);
+	EXPECT_EQ(ParseFixed6Fraction("046875"), 3);
+	EXPECT_EQ(ParseFixed6Fraction("0625"), 4);
+	EXPECT_EQ(ParseFixed6Fraction("078125"), 5);
+	EXPECT_EQ(ParseFixed6Fraction("09375"), 6);
+	EXPECT_EQ(ParseFixed6Fraction("109375"), 7);
+	EXPECT_EQ(ParseFixed6Fraction("125"), 8);
+	EXPECT_EQ(ParseFixed6Fraction("140625"), 9);
+	EXPECT_EQ(ParseFixed6Fraction("15625"), 10);
+	EXPECT_EQ(ParseFixed6Fraction("171875"), 11);
+	EXPECT_EQ(ParseFixed6Fraction("1875"), 12);
+	EXPECT_EQ(ParseFixed6Fraction("203125"), 13);
+	EXPECT_EQ(ParseFixed6Fraction("21875"), 14);
+	EXPECT_EQ(ParseFixed6Fraction("234375"), 15);
+	EXPECT_EQ(ParseFixed6Fraction("25"), 16);
+	EXPECT_EQ(ParseFixed6Fraction("265625"), 17);
+	EXPECT_EQ(ParseFixed6Fraction("28125"), 18);
+	EXPECT_EQ(ParseFixed6Fraction("296875"), 19);
+	EXPECT_EQ(ParseFixed6Fraction("3125"), 20);
+	EXPECT_EQ(ParseFixed6Fraction("328125"), 21);
+	EXPECT_EQ(ParseFixed6Fraction("34375"), 22);
+	EXPECT_EQ(ParseFixed6Fraction("359375"), 23);
+	EXPECT_EQ(ParseFixed6Fraction("375"), 24);
+	EXPECT_EQ(ParseFixed6Fraction("390625"), 25);
+	EXPECT_EQ(ParseFixed6Fraction("40625"), 26);
+	EXPECT_EQ(ParseFixed6Fraction("421875"), 27);
+	EXPECT_EQ(ParseFixed6Fraction("4375"), 28);
+	EXPECT_EQ(ParseFixed6Fraction("453125"), 29);
+	EXPECT_EQ(ParseFixed6Fraction("46875"), 30);
+	EXPECT_EQ(ParseFixed6Fraction("484375"), 31);
+	EXPECT_EQ(ParseFixed6Fraction("5"), 32);
+	EXPECT_EQ(ParseFixed6Fraction("515625"), 33);
+	EXPECT_EQ(ParseFixed6Fraction("53125"), 34);
+	EXPECT_EQ(ParseFixed6Fraction("546875"), 35);
+	EXPECT_EQ(ParseFixed6Fraction("5625"), 36);
+	EXPECT_EQ(ParseFixed6Fraction("578125"), 37);
+	EXPECT_EQ(ParseFixed6Fraction("59375"), 38);
+	EXPECT_EQ(ParseFixed6Fraction("609375"), 39);
+	EXPECT_EQ(ParseFixed6Fraction("625"), 40);
+	EXPECT_EQ(ParseFixed6Fraction("640625"), 41);
+	EXPECT_EQ(ParseFixed6Fraction("65625"), 42);
+	EXPECT_EQ(ParseFixed6Fraction("671875"), 43);
+	EXPECT_EQ(ParseFixed6Fraction("6875"), 44);
+	EXPECT_EQ(ParseFixed6Fraction("703125"), 45);
+	EXPECT_EQ(ParseFixed6Fraction("71875"), 46);
+	EXPECT_EQ(ParseFixed6Fraction("734375"), 47);
+	EXPECT_EQ(ParseFixed6Fraction("75"), 48);
+	EXPECT_EQ(ParseFixed6Fraction("765625"), 49);
+	EXPECT_EQ(ParseFixed6Fraction("78125"), 50);
+	EXPECT_EQ(ParseFixed6Fraction("796875"), 51);
+	EXPECT_EQ(ParseFixed6Fraction("8125"), 52);
+	EXPECT_EQ(ParseFixed6Fraction("828125"), 53);
+	EXPECT_EQ(ParseFixed6Fraction("84375"), 54);
+	EXPECT_EQ(ParseFixed6Fraction("859375"), 55);
+	EXPECT_EQ(ParseFixed6Fraction("875"), 56);
+	EXPECT_EQ(ParseFixed6Fraction("890625"), 57);
+	EXPECT_EQ(ParseFixed6Fraction("90625"), 58);
+	EXPECT_EQ(ParseFixed6Fraction("921875"), 59);
+	EXPECT_EQ(ParseFixed6Fraction("9375"), 60);
+	EXPECT_EQ(ParseFixed6Fraction("953125"), 61);
+	EXPECT_EQ(ParseFixed6Fraction("96875"), 62);
+	EXPECT_EQ(ParseFixed6Fraction("984375"), 63);
+	EXPECT_EQ(ParseFixed6Fraction("99218749"), 63);
+	EXPECT_EQ(ParseFixed6Fraction("9921875"), 64);
+}
+
+TEST(ParseInt, ParseFixed6)
+{
+	ParseIntResult<int> result = ParseFixed6<int>("");
+	ASSERT_FALSE(result.has_value()) << "Empty strings are not valid fixed point values.";
+	EXPECT_EQ(result.error(), ParseIntError::ParseError) << "ParseFixed6 should give a ParseError code when parsing an empty string.";
+
+	result = ParseFixed6<int>("abcd");
+	ASSERT_FALSE(result.has_value()) << "Non-numeric strings should not be parsed as a fixed-point value.";
+	EXPECT_EQ(result.error(), ParseIntError::ParseError) << "ParseFixed6 should give a ParseError code when parsing a non-numeric string.";
+
+	result = ParseFixed6<int>(".");
+	ASSERT_FALSE(result.has_value()) << "To match std::from_chars ParseFixed6 should fail to parse a decimal string with no digits.";
+	EXPECT_EQ(result.error(), ParseIntError::ParseError) << "Decimal strings with no digits are reported as ParseError codes.";
+
+	result = ParseFixed6<int>("1.");
+	ASSERT_TRUE(result.has_value()) << "A trailing decimal point is permitted for fixed point values";
+	EXPECT_EQ(result.value(), 1 << 6);
+
+	result = ParseFixed6<int>(".5");
+	ASSERT_TRUE(result.has_value()) << "A fixed point value with no integer part is accepted";
+	EXPECT_EQ(result.value(), 32);
+
+	std::string_view badString { "-." };
+	const char *endOfParse = nullptr;
+	result = ParseFixed6<int>(badString, &endOfParse);
+	ASSERT_FALSE(result.has_value()) << "To match std::from_chars ParseFixed6 should fail to parse a decimal string with no digits, even if it starts with a minus sign.";
+	EXPECT_EQ(result.error(), ParseIntError::ParseError) << "Decimal strings with no digits are reported as ParseError codes.";
+	EXPECT_EQ(endOfParse, badString.data()) << "Failed fixed point parsing should set the end pointer to match the start of the string even though it read multiple characters";
+
+	result = ParseFixed6<int>("-1.");
+	ASSERT_TRUE(result.has_value()) << "negative fixed point values are handled when reading into signed types";
+	EXPECT_EQ(result.value(), -1 << 6);
+
+	result = ParseFixed6<int>("-1.25");
+	ASSERT_TRUE(result.has_value()) << "negative fixed point values are handled when reading into signed types";
+	EXPECT_EQ(result.value(), -((1 << 6) + 16)) << "and the fraction part is combined with the integer part respecting the sign";
+
+	result = ParseFixed6<int>("-.25");
+	ASSERT_TRUE(result.has_value()) << "negative fixed point values with no integer digits are handled when reading into signed types";
+	EXPECT_EQ(result.value(), -16) << "and the fraction part is used respecting the sign";
+
+	result = ParseFixed6<int>("-0.25");
+	ASSERT_TRUE(result.has_value()) << "negative fixed point values with an explicit -0 integer part are handled when reading into signed types";
+	EXPECT_EQ(result.value(), -16) << "and the fraction part is used respecting the sign";
+
+	ParseIntResult<unsigned> unsignedResult = ParseFixed6<unsigned>("-1.");
+	ASSERT_FALSE(unsignedResult.has_value()) << "negative fixed point values are not permitted when reading into unsigned types";
+	EXPECT_EQ(unsignedResult.error(), ParseIntError::ParseError) << "Attempting to parse a negative value into an unsigned type is a ParseError, not an OutOfRange value";
+}
+} // namespace devilution


### PR DESCRIPTION
Intended for use loading fixed point decimals from strings (e.g. player attributes from text files). Found a few error conditions that I wasn't handling properly so made the code a bit more robust at the expense of added lines :( e: and of course I found another failure case after opening the PR...

Split from #6530