### PR TITLE
move definition of non-templated function to cpp file

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -160,6 +160,7 @@ set(libdevilutionx_SRCS
   utils/language.cpp
   utils/logged_fstream.cpp
   utils/paths.cpp
+  utils/parse_int.cpp
   utils/pcx_to_clx.cpp
   utils/sdl_bilinear_scale.cpp
   utils/sdl_thread.cpp

--- a/Source/utils/parse_int.cpp
+++ b/Source/utils/parse_int.cpp
@@ -1,0 +1,34 @@
+#include "parse_int.hpp"
+
+#include <algorithm>
+
+namespace devilution {
+
+uint8_t ParseFixed6Fraction(std::string_view str, const char **endOfParse)
+{
+	unsigned numDigits = 0;
+	uint32_t decimalFraction = 0;
+
+	// Read at most 7 digits, at that threshold we're able to determine an exact rounding for 6 bit fixed point numbers
+	while (!str.empty() && numDigits < 7) {
+		if (str[0] < '0' || str[0] > '9') {
+			break;
+		}
+		decimalFraction = decimalFraction * 10 + str[0] - '0';
+		++numDigits;
+		str.remove_prefix(1);
+	}
+	if (endOfParse != nullptr) {
+		// to mimic the behaviour of std::from_chars consume all remaining digits in case the value was overly precise.
+		*endOfParse = std::find_if_not(str.data(), str.data() + str.size(), [](char character) { return character >= '0' && character <= '9'; });
+	}
+	// to ensure rounding to nearest we normalise all values to 7 decimal places
+	while (numDigits < 7) {
+		decimalFraction *= 10;
+		++numDigits;
+	}
+	// we add half the step between representable values to use integer truncation as a substitute for rounding to nearest.
+	return (decimalFraction + 78125) / 156250;
+}
+
+} // namespace devilution

--- a/Source/utils/parse_int.hpp
+++ b/Source/utils/parse_int.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <algorithm>
 #include <charconv>
+#include <cstdint>
 #include <string_view>
 #include <system_error>
 
@@ -36,32 +36,13 @@ ParseIntResult<IntT> ParseInt(
 	return value;
 }
 
-inline uint8_t ParseFixed6Fraction(std::string_view str, const char **endOfParse = nullptr)
-{
-	unsigned numDigits = 0;
-	uint32_t decimalFraction = 0;
-
-	// Read at most 7 digits, at that threshold we're able to determine an exact rounding for 6 bit fixed point numbers
-	while (!str.empty() && numDigits < 7) {
-		if (str[0] < '0' || str[0] > '9') {
-			break;
-		}
-		decimalFraction = decimalFraction * 10 + str[0] - '0';
-		++numDigits;
-		str.remove_prefix(1);
-	}
-	if (endOfParse != nullptr) {
-		// to mimic the behaviour of std::from_chars consume all remaining digits in case the value was overly precise.
-		*endOfParse = std::find_if_not(str.data(), str.data() + str.size(), [](char character) { return character >= '0' && character <= '9'; });
-	}
-	// to ensure rounding to nearest we normalise all values to 7 decimal places
-	while (numDigits < 7) {
-		decimalFraction *= 10;
-		++numDigits;
-	}
-	// we add half the step between representable values to use integer truncation as a substitute for rounding to nearest.
-	return (decimalFraction + 78125) / 156250;
-}
+/**
+ * @brief Parses a sequence of decimal characters into a 6 bit fixed point number in the range [0, 1.0]
+ * @param str a potentially empty string of base 10 digits, optionally followed by non-digit characters
+ * @param[out] endOfParse equivalent to std::from_chars_result::ptr, used to tell where parsing stopped
+ * @return a value in the range [0, 64], representing a 2.6 fixed value in the range [0, 1.0]
+ */
+uint8_t ParseFixed6Fraction(std::string_view str, const char **endOfParse = nullptr);
 
 template <typename IntT>
 ParseIntResult<IntT> ParseFixed6(std::string_view str, const char **endOfParse = nullptr)

--- a/test/data_file_test.cpp
+++ b/test/data_file_test.cpp
@@ -235,7 +235,7 @@ TEST(DataFileTest, ParseInt)
 
 		int longVal = 1;
 		auto parseFixedResult = field.parseFixed6(longVal);
-		EXPECT_TRUE(parseFixedResult.has_value()) << "Expected " << field << " to be parsed as a fixed point integer wiith only the integer part";
+		EXPECT_TRUE(parseFixedResult.has_value()) << "Expected " << field << " to be parsed as a fixed point integer with only the integer part";
 		EXPECT_EQ(longVal, 145 << 6) << "Parsing should give the expected fixed point base 10 value";
 
 		++fieldIt;
@@ -276,7 +276,7 @@ TEST(DataFileTest, ParseInt)
 		parseFixedResult = field.parseFixed6(shortFixedVal);
 		EXPECT_FALSE(parseFixedResult.has_value()) << "Expected " << field << " to fail to parse into a 2.6 fixed point variable";
 		EXPECT_EQ(parseFixedResult.error(), DataFileField::Error::OutOfRange) << "A value too large to fit into a 2 bit integer part should report an error";
-		EXPECT_EQ(shortFixedVal, 32) << "The variiable should not be modified when parsing fails";
+		EXPECT_EQ(shortFixedVal, 32) << "The variable should not be modified when parsing fails";
 
 		++fieldIt;
 
@@ -286,7 +286,7 @@ TEST(DataFileTest, ParseInt)
 		parseFixedResult = field.parseFixed6(shortFixedVal);
 		EXPECT_FALSE(parseFixedResult.has_value()) << "Expected " << field << " to fail to parse into a 2.6 fixed point variable";
 		EXPECT_EQ(parseFixedResult.error(), DataFileField::Error::OutOfRange) << "A value that after rounding is too large to fit into a 2 bit integer part should report an error";
-		EXPECT_EQ(shortFixedVal, 32) << "The variiable should not be modified when parsing fails";
+		EXPECT_EQ(shortFixedVal, 32) << "The variable should not be modified when parsing fails";
 	}
 }
 


### PR DESCRIPTION
As suggested in https://github.com/diasurgical/devilutionX/pull/6618#discussion_r1328068071

Also fixed a couple of typos.