### PR TITLE
Reduce use of exceptions in TCP

### DIFF
--- a/Source/dvlnet/tcp_client.cpp
+++ b/Source/dvlnet/tcp_client.cpp
@@ -61,9 +61,6 @@ int tcp_client::join(std::string addrstr)
 		for (auto i = 0; i < NoSleep; ++i) {
 			try {
 				poll();
-			} catch (const dvlnet_exception &e) {
-				SDL_SetError("Network error: %s", e.what());
-				return -1;
 			} catch (const std::runtime_error &e) {
 				SDL_SetError("%s", e.what());
 				return -1;

--- a/Source/dvlnet/tcp_server.cpp
+++ b/Source/dvlnet/tcp_server.cpp
@@ -208,8 +208,11 @@ void tcp_server::HandleAccept(const scc &con, const asio::error_code &ec)
 	if (NextFree() == PLR_BROADCAST) {
 		DropConnection(con);
 	} else {
+		asio::error_code errorCode;
 		asio::ip::tcp::no_delay option(true);
-		con->socket.set_option(option);
+		con->socket.set_option(option, errorCode);
+		if (errorCode)
+			LogError("Server error setting socket option: {}", errorCode.message());
 		con->timeout = timeout_connect;
 		StartReceive(con);
 		StartTimeout(con);

--- a/Source/dvlnet/tcp_server.h
+++ b/Source/dvlnet/tcp_server.h
@@ -27,9 +27,9 @@
 
 namespace devilution::net {
 
-class server_exception : public dvlnet_exception {
+class ServerError : public PacketError {
 public:
-	const char *what() const throw() override
+	const char *what() const override
 	{
 		return "Invalid player ID";
 	}
@@ -77,8 +77,8 @@ private:
 	void StartReceive(const scc &con);
 	void HandleReceive(const scc &con, const asio::error_code &ec, size_t bytesRead);
 	tl::expected<void, PacketError> HandleReceiveNewPlayer(const scc &con, packet &pkt);
-	void HandleReceivePacket(packet &pkt);
-	void SendPacket(packet &pkt);
+	tl::expected<void, PacketError> HandleReceivePacket(packet &pkt);
+	tl::expected<void, PacketError> SendPacket(packet &pkt);
 	void StartSend(const scc &con, packet &pkt);
 	void HandleSend(const scc &con, const asio::error_code &ec, size_t bytesSent);
 	void StartTimeout(const scc &con);


### PR DESCRIPTION
Just a few simple changes without going so far as fixing the message queue or turning on `ASIO_NO_EXCEPTIONS`. The commits should be pretty self-explanatory. A couple additional notes...

* By eliminating `server_exception`, we no longer use `dvlnet_exception` anywhere on the TCP side so I removed those catch clauses as well.
* Failing to set TCP no-delay shouldn't be a catastrophic error so I just log those and continue.