### PR TITLE
Debug: Revise Text

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1396,6 +1396,8 @@ void DrawAutomapText(const Surface &out)
 
 #ifdef _DEBUG
 	UiFlags debugColor = UiFlags::ColorOrange;
+
+	linePosition.y += 45;
 	if (DebugGodMode) {
 		linePosition.y += 15;
 		DrawString(out, "God Mode", linePosition, debugColor);

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -25,6 +25,7 @@
 
 #ifdef _DEBUG
 #include "debug.h"
+#include "lighting.h"
 #endif
 
 namespace devilution {
@@ -1392,6 +1393,34 @@ void DrawAutomapText(const Surface &out)
 
 	std::string difficultyString = fmt::format(fmt::runtime(_(/* TRANSLATORS: {:s} means: Game Difficulty. */ "Difficulty: {:s}")), difficulty);
 	DrawString(out, difficultyString, linePosition);
+
+#ifdef _DEBUG
+	UiFlags debugColor = UiFlags::ColorOrange;
+	if (DebugGodMode) {
+		linePosition.y += 15;
+		DrawString(out, "God Mode", linePosition, debugColor);
+	}
+	if (DisableLighting) {
+		linePosition.y += 15;
+		DrawString(out, "Fullbright", linePosition, debugColor);
+	}
+	if (DebugVision) {
+		linePosition.y += 15;
+		DrawString(out, "Draw Vision", linePosition, debugColor);
+	}
+	if (DebugPath) {
+		linePosition.y += 15;
+		DrawString(out, "Draw Path", linePosition, debugColor);
+	}
+	if (DebugGrid) {
+		linePosition.y += 15;
+		DrawString(out, "Draw Grid", linePosition, debugColor);
+	}
+	if (DebugScrollViewEnabled) {
+		linePosition.y += 15;
+		DrawString(out, "Scroll View", linePosition, debugColor);
+	}
+#endif
 }
 
 std::unique_ptr<AutomapTile[]> LoadAutomapData(size_t &tileCount)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4615,8 +4615,10 @@ void PutItemRecord(uint32_t nSeed, uint16_t wCI, int nIndex)
 std::mt19937 BetterRng;
 std::string DebugSpawnItem(std::string itemName)
 {
+	std::string cmdLabel = "[drop] ";
+
 	if (ActiveItemCount >= MAXITEMS)
-		return "No space to generate the item!";
+		return StrCat(cmdLabel, "No space to generate the item!");
 
 	const int max_time = 3000;
 	const int max_iter = 1000000;
@@ -4632,10 +4634,10 @@ std::string DebugSpawnItem(std::string itemName)
 		std::uniform_int_distribution<int32_t> dist(0, INT_MAX);
 		SetRndSeed(dist(BetterRng));
 		if (SDL_GetTicks() - begin > max_time)
-			return StrCat("Item not found in ", max_time / 1000, " seconds!");
+			return StrCat(cmdLabel, "Item not found in ", max_time / 1000, " seconds!");
 
 		if (i > max_iter)
-			return StrCat("Item not found in ", max_iter, " tries!");
+			return StrCat(cmdLabel, "Item not found in ", max_iter, " tries!");
 
 		const int8_t monsterLevel = dist(BetterRng) % CF_LEVEL + 1;
 		_item_indexes idx = RndItemForMonsterLevel(monsterLevel);
@@ -4657,13 +4659,15 @@ std::string DebugSpawnItem(std::string itemName)
 	Point pos = MyPlayer->position.tile;
 	GetSuperItemSpace(pos, ii);
 	NetSendCmdPItem(false, CMD_SPAWNITEM, item.position, item);
-	return StrCat("Item generated successfully - iterations: ", i);
+	return StrCat(cmdLabel, "Item generated successfully - iterations: ", i);
 }
 
 std::string DebugSpawnUniqueItem(std::string itemName)
 {
+	std::string cmdLabel = "[dropu] ";
+
 	if (ActiveItemCount >= MAXITEMS)
-		return "No space to generate the item!";
+		return StrCat(cmdLabel, "No space to generate the item!");
 
 	AsciiStrToLower(itemName);
 	UniqueItem uniqueItem;
@@ -4683,7 +4687,7 @@ std::string DebugSpawnUniqueItem(std::string itemName)
 		}
 	}
 	if (!foundUnique)
-		return "No unique found!";
+		return StrCat(cmdLabel, "No unique item found!");
 
 	_item_indexes uniqueBaseIndex = IDI_GOLD;
 	for (std::underlying_type_t<_item_indexes> j = IDI_GOLD; j <= IDI_LAST; j++) {
@@ -4696,7 +4700,7 @@ std::string DebugSpawnUniqueItem(std::string itemName)
 	}
 
 	if (uniqueBaseIndex == IDI_GOLD)
-		return "Base item not available";
+		return StrCat(cmdLabel, "Base item not available!");
 
 	auto &baseItemData = AllItemsList[static_cast<size_t>(uniqueBaseIndex)];
 
@@ -4706,11 +4710,11 @@ std::string DebugSpawnUniqueItem(std::string itemName)
 	for (uint32_t begin = SDL_GetTicks();; i++) {
 		constexpr int max_time = 3000;
 		if (SDL_GetTicks() - begin > max_time)
-			return StrCat("Item not found in ", max_time / 1000, " seconds!");
+			return StrCat(cmdLabel, "Item not found in ", max_time / 1000, " seconds!");
 
 		constexpr int max_iter = 1000000;
 		if (i > max_iter)
-			return StrCat("Item not found in ", max_iter, " tries!");
+			return StrCat(cmdLabel, "Item not found in ", max_iter, " tries!");
 
 		testItem = {};
 		testItem._iMiscId = baseItemData.iMiscId;
@@ -4729,7 +4733,7 @@ std::string DebugSpawnUniqueItem(std::string itemName)
 		const std::string tmp = AsciiStrToLower(testItem._iIName);
 		if (tmp.find(itemName) != std::string::npos)
 			break;
-		return "Impossible to generate!";
+		return StrCat(cmdLabel, "Impossible to generate!");
 	}
 
 	int ii = AllocateItem();
@@ -4739,7 +4743,8 @@ std::string DebugSpawnUniqueItem(std::string itemName)
 	GetSuperItemSpace(pos, ii);
 	item._iIdentified = true;
 	NetSendCmdPItem(false, CMD_SPAWNITEM, item.position, item);
-	return StrCat("Item generated successfully - iterations: ", i);
+
+	return StrCat(cmdLabel, "Item generated successfully - iterations: ", i);
 }
 #endif
 


### PR DESCRIPTION
This change will make more sense with https://github.com/diasurgical/devilutionX/pull/6624

This adds a label to the output text for debug commands. (Example: `[changemana] Enter a value not equal to 0 to change mana!`)

Also adds text to the automap underneath the rest of the text to show you when any of the following booleans are set to true:
`DebugGodMode`
`DisableLighting`
`DebugVision`
`DebugPath`
`DebugGrid`
`DebugScrollViewEnabled`

![image](https://github.com/diasurgical/devilutionX/assets/68359262/6b098ffd-0d2e-42cd-a581-9d0a65ae0c33)


Revises all the output text for debug commands so they make more sense and are less fun. If you view the following:
![image](https://github.com/diasurgical/devilutionX/assets/68359262/93e332b1-813b-4e38-b87a-b50277936db3)

This doesn't really communicate anything useful to the programmer.