### PR TITLE
dun_render: Add `DunTileColorMap` for baked light

### DIFF
--- a/Source/engine/render/dun_render.cpp
+++ b/Source/engine/render/dun_render.cpp
@@ -1207,4 +1207,29 @@ void world_draw_black_tile(const Surface &out, int sx, int sy)
 	}
 }
 
+void DunTileColorMap(std::span<const uint8_t> src, TileType tileType,
+    const uint8_t *tbl, uint8_t *dst)
+{
+	if (tileType == TileType::TransparentSquare) {
+		const uint8_t *srcPtr = src.data();
+		for (auto i = 0; i < Height; ++i) {
+			for (uint_fast8_t drawWidth = Width; drawWidth > 0;) {
+				auto v = static_cast<int8_t>(*srcPtr++);
+				if (v > 0) {
+					drawWidth -= v;
+					while (v-- > 0) {
+						*dst++ = tbl[*srcPtr++];
+					}
+				} else {
+					drawWidth += v;
+				}
+			}
+		}
+	} else {
+		for (const uint8_t pix : src) {
+			*dst++ = tbl[pix];
+		}
+	}
+}
+
 } // namespace devilution

--- a/Source/engine/render/dun_render.hpp
+++ b/Source/engine/render/dun_render.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 
 #include <SDL_endian.h>
 
@@ -274,5 +275,16 @@ void RenderTile(const Surface &out, Point position,
  * @param sy Target buffer coordinate (bottom corner of the tile)
  */
 void world_draw_black_tile(const Surface &out, int sx, int sy);
+
+/**
+ * @brief Applies a color map to a dungeon tile.
+ *
+ * @param src Dungeon CEL data.
+ * @param tileType Dungeon CEL type.
+ * @param tbl Palette mapping.
+ * @param dst Output dungeon CEL data.
+ */
+void DunTileColorMap(std::span<const uint8_t> src, TileType tileType,
+    const uint8_t *tbl, uint8_t *dst);
 
 } // namespace devilution


### PR DESCRIPTION
Adds a function that can be used to implement the baked light cache

Refs #6631