### PR TITLE
Don't use inheritance with tl::expected

### DIFF
--- a/Source/dvlnet/packet.h
+++ b/Source/dvlnet/packet.h
@@ -61,25 +61,42 @@ static constexpr plr_t PLR_BROADCAST = 0xFF;
 
 class PacketError {
 public:
-	virtual const char *what() const
+	PacketError()
+	    : message_(std::string_view("Incorrect package size"))
 	{
-		return "Incorrect package size";
 	}
-};
 
-class PacketTypeError : public PacketError {
-public:
-	explicit PacketTypeError(std::uint8_t unknownPacketType);
-	PacketTypeError(std::initializer_list<packet_type> expectedTypes, std::uint8_t actual);
-
-	const char *what() const override
+	PacketError(const char message[])
+	    : message_(std::string_view(message))
 	{
-		return message_.c_str();
+	}
+
+	PacketError(std::string &&message)
+	    : message_(std::move(message))
+	{
+	}
+
+	PacketError(const PacketError &error)
+	    : message_(std::string(error.message_))
+	{
+	}
+
+	PacketError(PacketError &&error)
+	    : message_(std::move(error.message_))
+	{
+	}
+
+	std::string_view what() const
+	{
+		return message_;
 	}
 
 private:
-	std::string message_;
+	StringOrView message_;
 };
+
+PacketError PacketTypeError(std::uint8_t unknownPacketType);
+PacketError PacketTypeError(std::initializer_list<packet_type> expectedTypes, std::uint8_t actual);
 
 class packet {
 protected:

--- a/Source/dvlnet/tcp_server.h
+++ b/Source/dvlnet/tcp_server.h
@@ -27,13 +27,10 @@
 
 namespace devilution::net {
 
-class ServerError : public PacketError {
-public:
-	const char *what() const override
-	{
-		return "Invalid player ID";
-	}
-};
+inline PacketError ServerError()
+{
+	return PacketError("Invalid player ID");
+}
 
 class tcp_server {
 public:


### PR DESCRIPTION
I started to have my doubts about using inheritance with `tl::expected` so I ran a little test. The following prints out `DEBUG: Incorrect package size`.

```c++
tl::expected<void, PacketError> test = tl::make_unexpected(PacketTypeError(240));
LogDebug("{}", test.error().what());
```

And this prints out `DEBUG: Unknown packet type 240`.

```c++
tl::expected<void, PacketTypeError> test = tl::make_unexpected(PacketTypeError(240));
LogDebug("{}", test.error().what());
```

This PR fixes it by replacing inheritance with factory functions.