### PR TITLE
`LoggedFstream`: Fix `OpenFile` error check

### DIFF
--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -156,7 +156,9 @@ std::vector<std::string> GetMPQSearchPaths()
 	}
 #endif
 
-	paths.emplace_back(""); // PWD
+	if (paths.empty() || !paths.back().empty()) {
+		paths.emplace_back(); // PWD
+	}
 
 	if (SDL_LOG_PRIORITY_VERBOSE >= SDL_LogGetPriority(SDL_LOG_CATEGORY_APPLICATION)) {
 		LogVerbose("Paths:\n    base: {}\n    pref: {}\n  config: {}\n  assets: {}",

--- a/Source/utils/file_util.cpp
+++ b/Source/utils/file_util.cpp
@@ -94,9 +94,9 @@ bool FileExists(const char *path)
 			::SetLastError(ERROR_SUCCESS);
 		} else {
 #ifdef DEVILUTIONX_WINDOWS_NO_WCHAR
-			LogError("GetFileAttributesA: error code {}", ::GetLastError());
+			LogError("GetFileAttributesA({}): error code {}", path, ::GetLastError());
 #else
-			LogError("PathFileExistsW: error code {}", ::GetLastError());
+			LogError("PathFileExistsW({}): error code {}", path, ::GetLastError());
 #endif
 		}
 		return false;

--- a/Source/utils/logged_fstream.hpp
+++ b/Source/utils/logged_fstream.hpp
@@ -16,7 +16,7 @@ public:
 	bool Open(const char *path, const char *mode)
 	{
 		s_ = OpenFile(path, mode);
-		return CheckError("fopen(\"{}\", \"{}\")", path, mode);
+		return CheckError(s_ != nullptr, "fopen(\"{}\", \"{}\")", path, mode);
 	}
 
 	void Close()


### PR DESCRIPTION
Fixes #6626

Now shows the error dialog correctly and we get a sensible log as well:

![image](https://github.com/diasurgical/devilutionX/assets/216339/df7b7141-94de-49af-aaf7-144a2c60afa6)
