### PR TITLE
Fix edge cases for packing empty items

### DIFF
--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -255,6 +255,10 @@ void PackPlayer(PlayerPack &packed, const Player &player)
 
 void PackNetItem(const Item &item, ItemNetPack &packedItem)
 {
+	if (item.isEmpty()) {
+		packedItem.def.wIndx = static_cast<_item_indexes>(0xFFFF);
+		return;
+	}
 	packedItem.def.wIndx = static_cast<_item_indexes>(SDL_SwapLE16(item.IDidx));
 	packedItem.def.wCI = SDL_SwapLE16(item._iCreateInfo);
 	packedItem.def.dwSeed = SDL_SwapLE32(item._iSeed);
@@ -333,6 +337,11 @@ void PackNetPlayer(PlayerNetPack &packed, const Player &player)
 
 void UnPackItem(const ItemPack &packedItem, const Player &player, Item &item, bool isHellfire)
 {
+	if (packedItem.idx == 0xFFFF) {
+		item.clear();
+		return;
+	}
+
 	auto idx = static_cast<_item_indexes>(SDL_SwapLE16(packedItem.idx));
 
 	if (gbIsSpawn) {


### PR DESCRIPTION
This fixes an issue where unequipping items from your character will cause validation to fail when someone joins your game.

I think `UnPackItem()` was working correctly because the underlying type for `_item_indexes` is signed. The -1 would be sign-extended when implicitly cast to an `int`, and `-1` wouldn't be adjusted by `RemapItemIdxFromSpawn()` or `RemapItemIdxFromDiablo()`. Regardless, I don't think we should be attempting to remap sentinel values as though they are valid `_item_indexes` values.