### PR TITLE
Remove frame queue exceptions from the network layer

### DIFF
--- a/3rdParty/libzt/CMakeLists.txt
+++ b/3rdParty/libzt/CMakeLists.txt
@@ -5,7 +5,7 @@ set(BUILD_HOST_SELFTEST OFF)
 include(FetchContent)
 FetchContent_Declare(libzt
   GIT_REPOSITORY https://github.com/diasurgical/libzt.git
-  GIT_TAG def49803307920da0ab5b9e9b70b399fdc2943dc)
+  GIT_TAG 8c31715bc48bade2097d66ced54db07598268710)
 FetchContent_MakeAvailableExcludeFromAll(libzt)
 
 if(NOT ANDROID)

--- a/Source/dvlnet/base.h
+++ b/Source/dvlnet/base.h
@@ -30,7 +30,7 @@ public:
 	bool SNetGetTurnsInTransit(uint32_t *turns) override;
 
 	virtual tl::expected<void, PacketError> poll() = 0;
-	virtual void send(packet &pkt) = 0;
+	virtual tl::expected<void, PacketError> send(packet &pkt) = 0;
 	virtual void DisconnectNet(plr_t plr);
 
 	void setup_gameinfo(buffer_t info);

--- a/Source/dvlnet/frame_queue.cpp
+++ b/Source/dvlnet/frame_queue.cpp
@@ -9,21 +9,24 @@
 namespace devilution {
 namespace net {
 
-#if DVL_EXCEPTIONS
-#define FRAME_QUEUE_ERROR throw frame_queue_exception()
-#else
-#define FRAME_QUEUE_ERROR app_fatal("frame queue error")
-#endif
+namespace {
+
+PacketError FrameQueueError()
+{
+	return PacketError("Incorrect frame size");
+}
+
+} // namespace
 
 framesize_t frame_queue::Size() const
 {
 	return current_size;
 }
 
-buffer_t frame_queue::Read(framesize_t s)
+tl::expected<buffer_t, PacketError> frame_queue::Read(framesize_t s)
 {
 	if (current_size < s)
-		FRAME_QUEUE_ERROR;
+		return tl::make_unexpected(FrameQueueError());
 	buffer_t ret;
 	while (s > 0 && s >= buffer_deque.front().size()) {
 		s -= buffer_deque.front().size();
@@ -50,33 +53,35 @@ void frame_queue::Write(buffer_t buf)
 	buffer_deque.push_back(std::move(buf));
 }
 
-bool frame_queue::PacketReady()
+tl::expected<bool, PacketError> frame_queue::PacketReady()
 {
 	if (nextsize == 0) {
 		if (Size() < sizeof(framesize_t))
 			return false;
-		auto szbuf = Read(sizeof(framesize_t));
-		std::memcpy(&nextsize, &szbuf[0], sizeof(framesize_t));
+		tl::expected<buffer_t, PacketError> szbuf = Read(sizeof(framesize_t));
+		if (!szbuf.has_value())
+			return tl::make_unexpected(szbuf.error());
+		std::memcpy(&nextsize, &(*szbuf)[0], sizeof(framesize_t));
 		if (nextsize == 0)
-			FRAME_QUEUE_ERROR;
+			return tl::make_unexpected(FrameQueueError());
 	}
 	return Size() >= nextsize;
 }
 
-buffer_t frame_queue::ReadPacket()
+tl::expected<buffer_t, PacketError> frame_queue::ReadPacket()
 {
 	if (nextsize == 0 || Size() < nextsize)
-		FRAME_QUEUE_ERROR;
-	auto ret = Read(nextsize);
+		return tl::make_unexpected(FrameQueueError());
+	tl::expected<buffer_t, PacketError> ret = Read(nextsize);
 	nextsize = 0;
 	return ret;
 }
 
-buffer_t frame_queue::MakeFrame(buffer_t packetbuf)
+tl::expected<buffer_t, PacketError> frame_queue::MakeFrame(buffer_t packetbuf)
 {
 	buffer_t ret;
 	if (packetbuf.size() > max_frame_size)
-		ABORT();
+		return tl::make_unexpected("Buffer exceeds maximum frame size");
 	framesize_t size = packetbuf.size();
 	ret.insert(ret.end(), packet_out::begin(size), packet_out::end(size));
 	ret.insert(ret.end(), packetbuf.begin(), packetbuf.end());

--- a/Source/dvlnet/frame_queue.h
+++ b/Source/dvlnet/frame_queue.h
@@ -5,19 +5,14 @@
 #include <exception>
 #include <vector>
 
+#include <expected.hpp>
+
+#include "dvlnet/packet.h"
+
 namespace devilution {
 namespace net {
 
 typedef std::vector<unsigned char> buffer_t;
-
-class frame_queue_exception : public std::exception {
-public:
-	const char *what() const throw() override
-	{
-		return "Incorrect frame size";
-	}
-};
-
 typedef uint32_t framesize_t;
 
 class frame_queue {
@@ -30,14 +25,14 @@ private:
 	framesize_t nextsize = 0;
 
 	framesize_t Size() const;
-	buffer_t Read(framesize_t s);
+	tl::expected<buffer_t, PacketError> Read(framesize_t s);
 
 public:
-	bool PacketReady();
-	buffer_t ReadPacket();
+	tl::expected<bool, PacketError> PacketReady();
+	tl::expected<buffer_t, PacketError> ReadPacket();
 	void Write(buffer_t buf);
 
-	static buffer_t MakeFrame(buffer_t packetbuf);
+	static tl::expected<buffer_t, PacketError> MakeFrame(buffer_t packetbuf);
 };
 
 } // namespace net

--- a/Source/dvlnet/protocol_zt.h
+++ b/Source/dvlnet/protocol_zt.h
@@ -68,7 +68,7 @@ public:
 	protocol_zt();
 	~protocol_zt();
 	void disconnect(const endpoint &peer);
-	bool send(const endpoint &peer, const buffer_t &data);
+	tl::expected<void, PacketError> send(const endpoint &peer, const buffer_t &data);
 	bool send_oob(const endpoint &peer, const buffer_t &data) const;
 	bool send_oob_mc(const buffer_t &data) const;
 	bool recv(endpoint &peer, buffer_t &data);

--- a/Source/dvlnet/tcp_client.h
+++ b/Source/dvlnet/tcp_client.h
@@ -31,7 +31,7 @@ public:
 	int join(std::string addrstr) override;
 
 	tl::expected<void, PacketError> poll() override;
-	void send(packet &pkt) override;
+	tl::expected<void, PacketError> send(packet &pkt) override;
 
 	bool SNetLeaveGame(int type) override;
 

--- a/Source/dvlnet/tcp_server.h
+++ b/Source/dvlnet/tcp_server.h
@@ -80,7 +80,7 @@ private:
 	tl::expected<void, PacketError> HandleReceiveNewPlayer(const scc &con, packet &pkt);
 	tl::expected<void, PacketError> HandleReceivePacket(packet &pkt);
 	tl::expected<void, PacketError> SendPacket(packet &pkt);
-	void StartSend(const scc &con, packet &pkt);
+	tl::expected<void, PacketError> StartSend(const scc &con, packet &pkt);
 	void HandleSend(const scc &con, const asio::error_code &ec, size_t bytesSent);
 	void StartTimeout(const scc &con);
 	void HandleTimeout(const scc &con, const asio::error_code &ec);


### PR DESCRIPTION
Another step on the journey to solving #6602. This eliminates the last of the exceptions used on the TCP side, and eliminates one call to `ABORT()`, albeit one that I don't think we've ever actually encountered. ZT still has `protocol_exception`, but that appears to be all that's left after this.