### PR TITLE
Use memmove when shifting data in high/low priority buffers

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -121,7 +121,7 @@ std::byte *CopyBufferedPackets(std::byte *destination, TBuffer *source, size_t *
 			srcPtr += chunkSize;
 			*size -= chunkSize;
 		}
-		memcpy(source->bData, srcPtr, (source->bData - srcPtr) + source->dwNextWriteOffset + 1);
+		memmove(source->bData, srcPtr, (source->bData - srcPtr) + source->dwNextWriteOffset + 1);
 		source->dwNextWriteOffset += static_cast<uint32_t>(source->bData - srcPtr);
 		return destination;
 	}


### PR DESCRIPTION
I checked into a stack trace AJenbo captured from ASAN when running wkdmod. It seems that any time the `CopyBufferedPackets()` function copies fewer bytes than it has left over after the copy, you'll get an overlap in the call to `memcpy()`.

Here's the stack trace.

```
==835379==ERROR: AddressSanitizer: memcpy-param-overlap: memory ranges [0x55b1e161ede4,0x55b1e161f43f) and [0x55b1e161f00c, 0x55b1e161f667) overlap
    #0 0x7f6bcb470d15 in __interceptor_memcpy ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:899
    #1 0x55b1de334558 in CopyBufferedPackets /home/ajenbo/code/diablo/wkdmod/Source/multi.cpp:124
    #2 0x55b1de33c4c3 in devilution::NetSendHiPri(int, std::byte const*, unsigned long) /home/ajenbo/code/diablo/wkdmod/Source/multi.cpp:519
    #3 0x55b1de33d55f in devilution::multi_handle_delta() /home/ajenbo/code/diablo/wkdmod/Source/multi.cpp:601
    #4 0x55b1ddee9554 in devilution::game_loop(bool) /home/ajenbo/code/diablo/wkdmod/Source/diablo.cpp:2984
    #5 0x55b1ddebc2b5 in RunGameLoop /home/ajenbo/code/diablo/wkdmod/Source/diablo.cpp:869
    #6 0x55b1ddee3bfc in devilution::StartGame(bool, bool) /home/ajenbo/code/diablo/wkdmod/Source/diablo.cpp:2370
    #7 0x55b1de181805 in InitMenu /home/ajenbo/code/diablo/wkdmod/Source/menu.cpp:59
    #8 0x55b1de1818c1 in InitMultiPlayerMenu /home/ajenbo/code/diablo/wkdmod/Source/menu.cpp:75
    #9 0x55b1de18247f in devilution::mainmenu_loop() /home/ajenbo/code/diablo/wkdmod/Source/menu.cpp:166
    #10 0x55b1ddee3e4a in devilution::DiabloMain(int, char**) /home/ajenbo/code/diablo/wkdmod/Source/diablo.cpp:2435
    #11 0x55b1dddcd4ed in main /home/ajenbo/code/diablo/wkdmod/Source/main.cpp:52
    #12 0x7f6bca223a8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #13 0x7f6bca223b48 in __libc_start_main_impl ../csu/libc-start.c:360
    #14 0x55b1dddcd3f4 in _start (/home/ajenbo/code/diablo/wkdmod/build/wkdmod+0x26123f4) (BuildId: 01d46aad733191eea2c77cbc1dc356a816741896)

0x55b1e161ede4 is located 4 bytes inside of global variable 'lowPriorityBuffer' defined in '/home/ajenbo/code/diablo/wkdmod/Source/multi.cpp:50:9' (0x55b1e161ede0) of size 4100
0x55b1e161f00c is located 556 bytes inside of global variable 'lowPriorityBuffer' defined in '/home/ajenbo/code/diablo/wkdmod/Source/multi.cpp:50:9' (0x55b1e161ede0) of size 4100
SUMMARY: AddressSanitizer: memcpy-param-overlap ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:899 in __interceptor_memcpy
```