### PR TITLE
Bugfix: Indestructible Items at Smith Repair

### DIFF
--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -579,14 +579,17 @@ void StartSmithSell()
 bool SmithRepairOk(int i)
 {
 	const Player &myPlayer = *MyPlayer;
+	const Item &item = myPlayer.InvList[i];
 
-	if (myPlayer.InvList[i].isEmpty())
+	if (item.isEmpty())
 		return false;
-	if (myPlayer.InvList[i]._itype == ItemType::Misc)
+	if (item._itype == ItemType::Misc)
 		return false;
-	if (myPlayer.InvList[i]._itype == ItemType::Gold)
+	if (item._itype == ItemType::Gold)
 		return false;
-	if (myPlayer.InvList[i]._iDurability == myPlayer.InvList[i]._iMaxDur)
+	if (item._iDurability == item._iMaxDur)
+		return false;
+	if (item._iMaxDur == DUR_INDESTRUCTIBLE)
 		return false;
 
 	return true;


### PR DESCRIPTION
Indestructible items are eligible for repair if the current durability is less than the max durability, which can occur in cases where the player uses methods to make a non-indestructible item into an indestructible item. This fixes that.