### PR TITLE
Clip parsed level from debug console to 50

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -565,10 +565,10 @@ std::string DebugCmdLevelUp(const std::string_view parameter)
 	Player &myPlayer = *MyPlayer;
 	std::string cmdLabel = "[givelvl] ";
 
-	const int levels = ParseInt<int>(parameter, /*min=*/1).value_or(1);
+	const int levels = std::min<int>(ParseInt<int>(parameter, /*min=*/1).value_or(1), GetMaximumCharacterLevel() - myPlayer.getCharacterLevel());
 	for (int i = 0; i < levels; i++)
 		NetSendCmd(true, CMD_CHEAT_EXPERIENCE);
-	return StrCat(cmdLabel, "New character level: ", myPlayer.getCharacterLevel());
+	return StrCat(cmdLabel, "New character level: ", myPlayer.getCharacterLevel() + levels);
 }
 
 std::string DebugCmdMaxStats(const std::string_view parameter)


### PR DESCRIPTION
Currently, in givelvl command user can type lvl above 50, which is a level cap. This patch clips it to 50, so we can prevent an accidential freeze of the game caused by NetSendCmd loop if user types a really big number.