### PR TITLE
HotkeyMessages: Add more quick message slots

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -126,10 +126,16 @@ std::vector<std::string> DebugCmdsFromCommandLine;
 #endif
 GameLogicStep gGameLogicStep = GameLogicStep::None;
 QuickMessage QuickMessages[QUICK_MESSAGE_OPTIONS] = {
-	{ "QuickMessage1", N_("I need help! Come Here!") },
+	{ "QuickMessage1", N_("I need help! Come here!") },
 	{ "QuickMessage2", N_("Follow me.") },
 	{ "QuickMessage3", N_("Here's something for you.") },
-	{ "QuickMessage4", N_("Now you DIE!") }
+	{ "QuickMessage4", N_("Now you DIE!") },
+	{ "QuickMessage5", N_("Heal yourself!") },
+	{ "QuickMessage6", N_("Watch out!") },
+	{ "QuickMessage7", N_("Thanks.") },
+	{ "QuickMessage8", N_("Retreat!") },
+	{ "QuickMessage9", N_("Sorry.") },
+	{ "QuickMessage10", N_("I'm waiting.") },
 };
 
 /** This and the following mouse variables are for handling in-game click-and-hold actions */
@@ -1766,12 +1772,12 @@ void InitKeymapActions()
 	    SpellBookKeyPressed,
 	    nullptr,
 	    CanPlayerTakeAction);
-	for (int i = 0; i < 4; ++i) {
+	for (size_t i = 0; i < QUICK_MESSAGE_OPTIONS; ++i) {
 		sgOptions.Keymapper.AddAction(
 		    "QuickMessage{}",
 		    N_("Quick Message {}"),
 		    N_("Use Quick Message in chat."),
-		    SDLK_F9 + i,
+		    (i < 4) ? SDLK_F9 + i : SDLK_UNKNOWN,
 		    [i]() { DiabloHotkeyMsg(i); },
 		    nullptr,
 		    nullptr,

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -117,7 +117,7 @@ struct QuickMessage {
 	const char *const message;
 };
 
-constexpr size_t QUICK_MESSAGE_OPTIONS = 4;
+constexpr size_t QUICK_MESSAGE_OPTIONS = 10;
 extern QuickMessage QuickMessages[QUICK_MESSAGE_OPTIONS];
 /**
  * @brief Specifices what game logic step is currently executed

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1304,6 +1304,11 @@ KeymapperOptions::KeymapperOptions()
 		keyIDToKeyName.emplace(SDLK_F1 + i, StrCat("F", i + 1));
 	}
 
+	keyIDToKeyName.emplace(SDLK_KP_0, "KEYPADNUM 0");
+	for (int i = 0; i < 9; i++) {
+		keyIDToKeyName.emplace(SDLK_KP_1 + i, StrCat("KEYPADNUM ", i + 1));
+	}
+
 	keyIDToKeyName.emplace(SDLK_LALT, "LALT");
 	keyIDToKeyName.emplace(SDLK_RALT, "RALT");
 	keyIDToKeyName.emplace(SDLK_SPACE, "SPACE");


### PR DESCRIPTION
Resolves: https://github.com/diasurgical/devilutionX/issues/6542

Currently we only have 4 quick message slots - this patch adds more of them, resizing the total amount to 10.

Issue #6542 also mentioned number pad setup, so this PR also adds support to bind hotkeys to numbers on keypad (0-9).