### PR TITLE
Add a lua debug command

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -35,6 +35,7 @@
 #include "utils/file_util.h"
 #include "utils/language.h"
 #include "utils/log.hpp"
+#include "utils/lua.hpp"
 #include "utils/parse_int.hpp"
 #include "utils/str_case.hpp"
 #include "utils/str_cat.hpp"
@@ -150,6 +151,15 @@ std::string DebugCmdHelp(const std::string_view parameter)
 	if (dbgCmdItem.requiredParameter.empty())
 		return StrCat("Description: ", dbgCmdItem.description, "\nParameters: No additional parameter needed.");
 	return StrCat("Description: ", dbgCmdItem.description, "\nParameters: ", dbgCmdItem.requiredParameter);
+}
+
+std::string DebugCmdLua(std::string_view code)
+{
+	tl::expected<std::string, std::string> result = RunLua(code);
+	if (!result.has_value()) {
+		return StrCat("> ", code, "\n") + std::move(result).error();
+	}
+	return StrCat("> ", code, "\n") + std::move(result).value();
 }
 
 std::string DebugCmdGiveGoldCheat(const std::string_view parameter)
@@ -1231,6 +1241,7 @@ std::vector<DebugCmdItem> DebugCmdList = {
 	{ "searchitem", "Searches the automap for {item}", "{item}", &DebugCmdSearchItem },
 	{ "searchobject", "Searches the automap for {object}", "{object}", &DebugCmdSearchObject },
 	{ "clearsearch", "Search in the auto map is cleared", "", &DebugCmdClearSearch },
+	{ "lua", "Run Lua code", "{code}", &DebugCmdLua },
 };
 
 } // namespace

--- a/Source/utils/lua.cpp
+++ b/Source/utils/lua.cpp
@@ -3,6 +3,8 @@
 #include <optional>
 #include <string_view>
 
+#include <fmt/args.h>
+#include <fmt/format.h>
 #include <sol/sol.hpp>
 #include <sol/utility/to_string.hpp>
 
@@ -67,10 +69,72 @@ void RunScript(std::string_view path)
 	CheckResult(luaState->safe_script(luaScriptStr));
 }
 
-void LuaPanic(sol::optional<std::string> maybe_msg)
+void LuaPanic(sol::optional<std::string> message)
 {
 	LogError("Lua is in a panic state and will now abort() the application:\n",
-	    maybe_msg.value_or("unknown error"));
+	    message.value_or("unknown error"));
+}
+
+void LuaLogMessage(LogPriority priority, std::string_view fmt, sol::variadic_args args)
+{
+	std::string formatted;
+	FMT_TRY
+	{
+		fmt::dynamic_format_arg_store<fmt::format_context> store;
+		for (const sol::stack_proxy arg : args) {
+			switch (arg.get_type()) {
+			case sol::type::boolean:
+				store.push_back(arg.as<bool>());
+				break;
+			case sol::type::number:
+				if (lua_isinteger(arg.lua_state(), arg.stack_index())) {
+					store.push_back(lua_tointeger(arg.lua_state(), arg.stack_index()));
+				} else {
+					store.push_back(lua_tonumber(arg.lua_state(), arg.stack_index()));
+				}
+				break;
+			case sol::type::string:
+				store.push_back(arg.as<std::string>());
+				break;
+			default:
+				store.push_back(sol::utility::to_string(sol::stack_object(arg)));
+				break;
+			}
+		}
+		formatted = fmt::vformat(fmt, store);
+	}
+	FMT_CATCH(const fmt::format_error &e)
+	{
+#if FMT_EXCEPTIONS
+		// e.what() is undefined if exceptions are disabled, so we wrap the whole block
+		// with an `FMT_EXCEPTIONS` check.
+		std::string error = StrCat("Format error, fmt: ", fmt, " error: ", e.what());
+		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "%s", error.c_str());
+		return;
+#endif
+	}
+	SDL_LogMessage(SDL_LOG_CATEGORY_APPLICATION, static_cast<SDL_LogPriority>(priority), "%s", formatted.c_str());
+}
+
+void LuaLog(std::string_view fmt, sol::variadic_args args)
+{
+	LuaLogMessage(LogPriority::Info, fmt, std::move(args));
+}
+void LuaLogVerbose(std::string_view fmt, sol::variadic_args args)
+{
+	LuaLogMessage(LogPriority::Verbose, fmt, std::move(args));
+}
+void LuaLogDebug(std::string_view fmt, sol::variadic_args args)
+{
+	LuaLogMessage(LogPriority::Debug, fmt, std::move(args));
+}
+void LuaLogWarn(std::string_view fmt, sol::variadic_args args)
+{
+	LuaLogMessage(LogPriority::Warn, fmt, std::move(args));
+}
+void LuaLogError(std::string_view fmt, sol::variadic_args args)
+{
+	LuaLogMessage(LogPriority::Error, fmt, std::move(args));
 }
 
 } // namespace
@@ -110,10 +174,14 @@ void LuaInitialize()
 	// Registering devilutionx object table
 	lua.create_named_table(
 	    "devilutionx",
-	    "message", [](std::string_view text) { EventPlrMsg(text, UiFlags::ColorRed); }
+	    "message", [](std::string_view text) { EventPlrMsg(text, UiFlags::ColorRed); },
 	    // TODO: Re-enable once https://github.com/bebbo/amiga-gcc/issues/363 is fixed.
 	    // "drawString", [](std::string_view text, int x, int y) { DrawString(GlobalBackBuffer(), text, { x, y }); }
-	);
+	    "log", LuaLog,
+	    "logVerbose", LuaLogVerbose,
+	    "logDebug", LuaLogDebug,
+	    "logWarn", LuaLogWarn,
+	    "logError", LuaLogError);
 
 	RunScript("lua/init.lua");
 	RunScript("lua/user.lua");
@@ -150,7 +218,7 @@ tl::expected<std::string, std::string> RunLua(std::string_view code)
 		return tl::make_unexpected("Unknown Lua error");
 	}
 
-	return sol::utility::to_string(sol::object(result));
+	return sol::utility::to_string(sol::stack_object(result));
 }
 
 } // namespace devilution

--- a/Source/utils/lua.cpp
+++ b/Source/utils/lua.cpp
@@ -4,6 +4,7 @@
 #include <string_view>
 
 #include <sol/sol.hpp>
+#include <sol/utility/to_string.hpp>
 
 #include "engine/assets.hpp"
 #include "engine/dx.h"
@@ -135,6 +136,21 @@ void LuaEvent(std::string_view name)
 	}
 	const sol::protected_function fn = trigger->as<sol::protected_function>();
 	CheckResult(fn());
+}
+
+tl::expected<std::string, std::string> RunLua(std::string_view code)
+{
+	sol::state &lua = *luaState;
+	const sol::protected_function_result result = lua.safe_script(code);
+	const bool valid = result.valid();
+	if (!valid) {
+		if (result.get_type() == sol::type::string) {
+			return tl::make_unexpected(result.get<std::string>());
+		}
+		return tl::make_unexpected("Unknown Lua error");
+	}
+
+	return sol::utility::to_string(sol::object(result));
 }
 
 } // namespace devilution

--- a/Source/utils/lua.hpp
+++ b/Source/utils/lua.hpp
@@ -2,10 +2,13 @@
 
 #include <string_view>
 
+#include <expected.hpp>
+
 namespace devilution {
 
 void LuaInitialize();
 void LuaShutdown();
 void LuaEvent(std::string_view name);
+tl::expected<std::string, std::string> RunLua(std::string_view code);
 
 } // namespace devilution

--- a/Source/utils/sdl2_to_1_2_backports.h
+++ b/Source/utils/sdl2_to_1_2_backports.h
@@ -89,6 +89,7 @@ void SDL_LogInfo(int category, const char *fmt, ...) DVL_PRINTF_ATTRIBUTE(2, 3);
 void SDL_LogWarn(int category, const char *fmt, ...) DVL_PRINTF_ATTRIBUTE(2, 3);
 void SDL_LogError(int category, const char *fmt, ...) DVL_PRINTF_ATTRIBUTE(2, 3);
 void SDL_LogCritical(int category, const char *fmt, ...) DVL_PRINTF_ATTRIBUTE(2, 3);
+void SDL_LogMessage(int category, SDL_LogPriority priority, const char *fmt, ...) DVL_PRINTF_ATTRIBUTE(3, 4);
 void SDL_LogMessageV(int category, SDL_LogPriority priority, const char *fmt, va_list ap) DVL_PRINTF_ATTRIBUTE(3, 0);
 
 void SDL_LogSetAllPriority(SDL_LogPriority priority);


### PR DESCRIPTION
1. Adds a `lua` debug command:
    Example:
    ```
    lua return 1 + 2
    ```
    ![image](https://github.com/diasurgical/devilutionX/assets/216339/90b48c10-30f4-407a-a10c-e5177ea79ded)

    Ideally we should have a better UI for this in the future.

2. Adds DevilutionX log functions.