### PR TITLE
Automap: Don't close automap when pressing spacebar with other windows open

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1607,6 +1607,18 @@ bool CanPlayerTakeAction()
 {
 	return !IsPlayerDead() && IsGameRunning();
 }
+
+bool CanAutomapBeToggledOff()
+{
+	// check if every window is closed - if yes, automap can be toggled off
+	if (!QuestLogIsOpen && !IsWithdrawGoldOpen && !IsStashOpen && !chrflag
+	    && !sbookflag && !invflag && !isGameMenuOpen && !qtextflag && !spselflag
+	    && !ChatLogFlag && !HelpFlag)
+		return true;
+
+	return false;
+}
+
 } // namespace
 
 void InitKeymapActions()
@@ -1783,6 +1795,9 @@ void InitKeymapActions()
 	    N_("Hide all info screens."),
 	    SDLK_SPACE,
 	    [] {
+		    if (CanAutomapBeToggledOff())
+			    AutomapActive = false;
+
 		    ClosePanels();
 		    HelpFlag = false;
 		    ChatLogFlag = false;
@@ -1791,7 +1806,7 @@ void InitKeymapActions()
 			    qtextflag = false;
 			    stream_stop();
 		    }
-		    AutomapActive = false;
+
 		    CancelCurrentDiabloMsg();
 		    gamemenu_off();
 		    doom_close();
@@ -2251,6 +2266,9 @@ void InitPadmapActions()
 	    N_("Hide all info screens."),
 	    ControllerButton_NONE,
 	    [] {
+		    if (CanAutomapBeToggledOff())
+			    AutomapActive = false;
+
 		    ClosePanels();
 		    HelpFlag = false;
 		    ChatLogFlag = false;
@@ -2259,7 +2277,7 @@ void InitPadmapActions()
 			    qtextflag = false;
 			    stream_stop();
 		    }
-		    AutomapActive = false;
+
 		    CancelCurrentDiabloMsg();
 		    gamemenu_off();
 		    doom_close();

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -20,6 +20,9 @@
 #include "utils/language.h"
 
 namespace devilution {
+
+bool isGameMenuOpen = false;
+
 namespace {
 
 // Forward-declare menu handlers, used by the global menu structs below.
@@ -346,6 +349,7 @@ void gamemenu_save_game(bool /*bActivate*/)
 
 void gamemenu_on()
 {
+	isGameMenuOpen = true;
 	if (!gbIsMultiplayer) {
 		gmenu_set_items(sgSingleMenu, GamemenuUpdateSingle);
 	} else {
@@ -356,6 +360,7 @@ void gamemenu_on()
 
 void gamemenu_off()
 {
+	isGameMenuOpen = false;
 	gmenu_set_items(nullptr, nullptr);
 }
 

--- a/Source/gamemenu.h
+++ b/Source/gamemenu.h
@@ -14,4 +14,6 @@ void gamemenu_quit_game(bool bActivate);
 void gamemenu_load_game(bool bActivate);
 void gamemenu_save_game(bool bActivate);
 
+extern bool isGameMenuOpen;
+
 } // namespace devilution


### PR DESCRIPTION
Resolves: https://github.com/diasurgical/devilutionX/issues/2622

Currently if we open a lot of windows and have automap enabled, and we press space - all of the windows along with automap get closed. This patch removes that, and allows to close automap with spacebar, but only if every window is closed.