### PR TITLE
simplify message.from initialization

### DIFF
--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -73,7 +73,7 @@ void EventPlrMsg(std::string_view text, UiFlags style)
 	message.style = style;
 	message.time = SDL_GetTicks();
 	message.text = std::string(text);
-	message.from = std::string_view(message.text.data(), 0);
+	message.from = {};
 	message.lineHeight = GetLineHeight(message.text, GameFont12) + 3;
 	AddMessageToChatLog(text);
 }


### PR DESCRIPTION
I wasn't familiar with string_view but using message.text.data() there was confusing, {} better shows it's actually empty (thx @ephphatha)