### PR TITLE
Fix Item Validation

### DIFF
--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -123,13 +123,8 @@ bool IsUniqueMonsterItemValid(uint16_t iCreateInfo, uint32_t dwBuff)
 		const auto &uniqueMonsterData = UniqueMonstersData[i];
 		const auto &uniqueMonsterLevel = static_cast<uint8_t>(MonstersData[uniqueMonsterData.mtype].level);
 
-		if (IsAnyOf(uniqueMonsterData.mtype, MT_DEFILER, MT_NAKRUL)) {
+		if (IsAnyOf(uniqueMonsterData.mtype, MT_DEFILER, MT_NAKRUL, MT_HORKDMN)) {
 			// These monsters don't use their mlvl for item generation
-			continue;
-		}
-
-		if (!isHellfireItem && IsAnyOf(uniqueMonsterData.mtype, MT_HORKDMN)) {
-			// This monster doesn't appear in Diablo
 			continue;
 		}
 


### PR DESCRIPTION
Item validation was missing logic to consider container drops (which is problematic in Hellfire since the Crypt can drop ilvl 32 and 34 items). Also added documentation. Also we have been letting items that have the ilvl that matches the mlvl of Defiler and Na-Krul pass validation; This shouldn't happen because these monsters never drop items equal to their mlvl (Book of Apocalypse doesn't count, because the level of the book is derived from another formula, which coincedentally is 40).