### PR TITLE
fix mem leak in pasting name

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -409,11 +409,14 @@ void UiFocusNavigation(SDL_Event *event)
 #ifndef USE_SDL1
 			case SDLK_v:
 				if ((SDL_GetModState() & KMOD_CTRL) != 0) {
-					char *clipboard = SDL_GetClipboardText();
-					if (clipboard == nullptr) {
-						Log("{}", SDL_GetError());
-					} else {
-						SelheroCatToName(clipboard, UiTextInput, UiTextInputLen);
+					if (SDL_HasClipboardText() == SDL_TRUE) {
+						char *clipboard = SDL_GetClipboardText();
+						if (clipboard == nullptr) {
+							Log("{}", SDL_GetError());
+						} else {
+							SelheroCatToName(clipboard, UiTextInput, UiTextInputLen);
+						}
+						SDL_free(clipboard);
 					}
 				}
 				return;


### PR DESCRIPTION
Per https://wiki.libsdl.org/SDL2/SDL_GetClipboardText
Caller must call [SDL_free](https://wiki.libsdl.org/SDL2/SDL_free)() on the returned pointer when done with it (even if there was an error).
Also added checking if clipboard isn't empty