### PR TITLE
partially revert menu tweaks to restore old look of diablo kill indicators

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -48,7 +48,7 @@
 namespace devilution {
 
 OptionalOwnedClxSpriteList ArtLogo;
-OptionalOwnedClxSpriteList DifficultyIndicator;
+std::array<OptionalOwnedClxSpriteList, 2> DifficultyIndicator;
 
 std::array<OptionalOwnedClxSpriteList, 3> ArtFocus;
 
@@ -595,7 +595,8 @@ void LoadUiGFX()
 	} else {
 		ArtLogo = LoadPcxSpriteList("ui_art\\smlogo", /*numFrames=*/15, /*transparentColor=*/250);
 	}
-	DifficultyIndicator = LoadPcx("ui_art\\r1_gry", /*transparentColor=*/0);
+	DifficultyIndicator[0] = LoadPcx("ui_art\\radio1", /*transparentColor=*/0);
+	DifficultyIndicator[1] = LoadPcx("ui_art\\radio3", /*transparentColor=*/0);
 	ArtFocus[FOCUS_SMALL] = LoadPcxSpriteList("ui_art\\focus16", /*numFrames=*/8, /*transparentColor=*/250);
 	ArtFocus[FOCUS_MED] = LoadPcxSpriteList("ui_art\\focus", /*numFrames=*/8, /*transparentColor=*/250);
 	ArtFocus[FOCUS_BIG] = LoadPcxSpriteList("ui_art\\focus42", /*numFrames=*/8, /*transparentColor=*/250);
@@ -623,7 +624,8 @@ void UnloadUiGFX()
 	for (auto &art : ArtFocus)
 		art = std::nullopt;
 	ArtLogo = std::nullopt;
-	DifficultyIndicator = std::nullopt;
+	for (auto &diffInd : DifficultyIndicator)
+		diffInd = std::nullopt;
 }
 
 void UiInitialize()

--- a/Source/DiabloUI/diabloui.h
+++ b/Source/DiabloUI/diabloui.h
@@ -65,7 +65,7 @@ struct _uiheroinfo {
 };
 
 extern OptionalOwnedClxSpriteList ArtLogo;
-extern OptionalOwnedClxSpriteList DifficultyIndicator;
+extern std::array<OptionalOwnedClxSpriteList, 2> DifficultyIndicator;
 extern std::array<OptionalOwnedClxSpriteList, 3> ArtFocus;
 extern OptionalOwnedClxSpriteList ArtBackgroundWidescreen;
 extern OptionalOwnedClxSpriteList ArtBackground;

--- a/Source/DiabloUI/hero/selhero.cpp
+++ b/Source/DiabloUI/hero/selhero.cpp
@@ -92,17 +92,11 @@ void RenderDifficultyIndicators()
 {
 	if (!selhero_isSavegame)
 		return;
-	const uint16_t width = (*DifficultyIndicator)[0].width();
-	const uint16_t height = (*DifficultyIndicator)[0].height();
-	SDL_Rect rect = MakeSdlRect(
-	    SELHERO_DIALOG_HERO_IMG->m_rect.x + 1,
-	    SELHERO_DIALOG_HERO_IMG->m_rect.y + SELHERO_DIALOG_HERO_IMG->m_rect.h - height - 1,
-	    width,
-	    height);
+	const uint16_t width = (*DifficultyIndicator[0])[0].width();
+	const uint16_t height = (*DifficultyIndicator[0])[0].height();
+	SDL_Rect rect = MakeSdlRect(SELHERO_DIALOG_HERO_IMG->m_rect.x, SELHERO_DIALOG_HERO_IMG->m_rect.y - height - 2, width, height);
 	for (int i = 0; i <= DIFF_LAST; i++) {
-		if (i >= selhero_heroInfo.herorank)
-			break;
-		UiRenderItem(UiImageClx((*DifficultyIndicator)[0], rect, UiFlags::None));
+		UiRenderItem(UiImageClx((*DifficultyIndicator[i < selhero_heroInfo.herorank ? 0 : 1])[0], rect, UiFlags::None));
 		rect.x += width;
 	}
 }

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1,7 +1,7 @@
 /**
  * @file msg.cpp
  *
- * Implementation of function for sending and reciving network messages.
+ * Implementation of function for sending and receiving network messages.
  */
 #include <climits>
 #include <cmath>

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -1,7 +1,7 @@
 /**
  * @file msg.h
  *
- * Interface of function for sending and reciving network messages.
+ * Interface of function for sending and receiving network messages.
  */
 #pragma once
 

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -24,7 +24,7 @@ namespace devilution {
 namespace {
 
 struct PlayerMessage {
-	/** Time message was recived */
+	/** Time message was received */
 	Uint32 time;
 	/** The default text color */
 	UiFlags style;


### PR DESCRIPTION
Restores look from https://github.com/diasurgical/devilutionX/pull/5210
partial revert of https://github.com/diasurgical/devilutionX/commit/9e7d223f1995d651de19da29a8243b9ca7421f44

![image](https://github.com/diasurgical/devilutionX/assets/14297035/27ef9fb5-3ecc-4ef7-8109-10aca43ff938)
current look (getting reverted) as a reference