### PR TITLE
fix menu bugs

### DIFF
--- a/Source/DiabloUI/multi/selgame.cpp
+++ b/Source/DiabloUI/multi/selgame.cpp
@@ -122,6 +122,8 @@ void UiInitGameSelectionList(std::string_view search)
 
 	selgame_FreeVectors();
 
+	selgame_Label[0] = '\0';
+
 	UiAddBackground(&vecSelGameDialog);
 	UiAddLogo(&vecSelGameDialog);
 
@@ -422,7 +424,7 @@ bool IsDifficultyAllowed(int value)
 void selgame_Diff_Select(int value)
 {
 	if (selhero_isMultiPlayer && !IsDifficultyAllowed(vecSelGameDlgItems[value]->m_value)) {
-		selgame_GameSelection_Select(0);
+		selgame_GameSelection_Select(selgame_selectedGame);
 		return;
 	}
 
@@ -533,7 +535,7 @@ void selgame_Speed_Focus(int value)
 
 void selgame_Speed_Esc()
 {
-	selgame_GameSelection_Select(0);
+	selgame_GameSelection_Select(selgame_selectedGame);
 }
 
 void selgame_Speed_Select(int value)


### PR DESCRIPTION
Resolves https://github.com/diasurgical/devilutionX/issues/6319
On going back from speed selection and while not meeting difficulty level requirements, selgame_selectedGame was being set to 0 which indicated a private game, that's why it asked for a password

Also added resetting selgame_Label or it'd keep the last value there on IP screen:
![image](https://github.com/diasurgical/devilutionX/assets/14297035/1bf5c019-9839-4e67-aa3d-7ed036447965)
