### PR TITLE
fix gargoyles being always awake in mp

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2645,7 +2645,7 @@ void DeltaLoadLevel()
 					GolumAi(monster);
 					monster.flags |= (MFLAG_TARGETS_MONSTER | MFLAG_GOLEM);
 				} else {
-					if (monster.ai != MonsterAIID::Gargoyle)
+					if (monster.ai != MonsterAIID::Gargoyle || deltaLevel.monster[i]._mactive != 0)
 						M_StartStand(monster, monster.direction);
 				}
 				monster.activeForTicks = deltaLevel.monster[i]._mactive;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2645,7 +2645,8 @@ void DeltaLoadLevel()
 					GolumAi(monster);
 					monster.flags |= (MFLAG_TARGETS_MONSTER | MFLAG_GOLEM);
 				} else {
-					M_StartStand(monster, monster.direction);
+					if (monster.ai != MonsterAIID::Gargoyle)
+						M_StartStand(monster, monster.direction);
 				}
 				monster.activeForTicks = deltaLevel.monster[i]._mactive;
 			}


### PR DESCRIPTION
Partial fix for https://github.com/diasurgical/devilutionX/issues/5600
It's not a perfect fix - basically changes gargoyle's perma awake behavior on subsequent visits to always sit - if player is close, gargoyle will get up anyway - checking for `MFLAG_ALLOW_SPECIAL` is pointless because I think it will be always set from initializing the monster. `activeForTick` wasn't useful either because it can be non-zero and the monster can be sitting anyway - the range at which they wake up is determined by their intelligence. A proper fix would be to rewrite everything to sync actual monster flags in MP - but that's a much bigger and more complex change and imo this fix improves current situation anyway.


After adding a check for nonzero activeForTicks, this PR is a straight improvement for current situation - gargoyles that are close will wake up anyway but this will prevent awakening them on the whole level.