### PR TITLE
rewrite joining/leaving bosspack

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3673,6 +3673,7 @@ void ProcessStoneCurse(Missile &missile)
 			monster.animInfo.isPetrified = false;
 		} else {
 			AddCorpse(monster.position.tile, stonendx, monster.direction);
+			M_UpdateRelations(monster);
 		}
 	}
 	if (missile._miAnimType == MissileGraphicID::StoneCurseShatter)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1602,15 +1602,12 @@ void GroupUnity(Monster &monster)
 
 	auto &leader = *monster.getLeader();
 	if (IsLineNotSolid(monster.position.tile, leader.position.future)) {
-		if (monster.leaderRelation == LeaderRelation::Separated
-		    && monster.position.tile.WalkingDistance(leader.position.future) < 4) {
+		if (monster.position.tile.WalkingDistance(leader.position.future) < 4) {
 			// Reunite the separated monster with the pack
-			leader.packSize++;
-			monster.leaderRelation = LeaderRelation::Leashed;
+			M_JoinLeaderPack(monster);
 		}
-	} else if (monster.leaderRelation == LeaderRelation::Leashed) {
-		leader.packSize--;
-		monster.leaderRelation = LeaderRelation::Separated;
+	} else {
+		M_SeparateFromLeaderPack(monster);
 	}
 
 	if (monster.leaderRelation == LeaderRelation::Leashed) {
@@ -2101,10 +2098,7 @@ void ScavengerAi(Monster &monster)
 	if (monster.mode != MonsterMode::Stand)
 		return;
 	if (monster.hitPoints < (monster.maxHitPoints / 2) && monster.goal != MonsterGoal::Healing) {
-		if (monster.leaderRelation != LeaderRelation::None) {
-			ShrinkLeaderPacksize(monster);
-			monster.leaderRelation = LeaderRelation::None;
-		}
+		M_SeparateFromLeaderPack(monster);
 		monster.goal = MonsterGoal::Healing;
 		monster.goalVar3 = 10;
 	}
@@ -3767,6 +3761,22 @@ void M_UpdateRelations(const Monster &monster)
 	ShrinkLeaderPacksize(monster);
 }
 
+void M_SeparateFromLeaderPack(Monster &monster)
+{
+	if (monster.leaderRelation == LeaderRelation::Leashed) {
+		monster.getLeader()->packSize--;
+		monster.leaderRelation = LeaderRelation::Separated;
+	}
+}
+
+void M_JoinLeaderPack(Monster &monster)
+{
+	if (monster.leaderRelation == LeaderRelation::Separated) {
+		monster.getLeader()->packSize++;
+		monster.leaderRelation = LeaderRelation::Leashed;
+	}
+}
+
 void DoEnding()
 {
 	if (gbIsMultiplayer) {
@@ -4662,6 +4672,7 @@ void Monster::petrify()
 {
 	mode = MonsterMode::Petrified;
 	animInfo.isPetrified = true;
+	M_SeparateFromLeaderPack(*this);
 }
 
 bool Monster::isWalking() const

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -486,6 +486,8 @@ void KillMyGolem();
 void M_StartKill(Monster &monster, const Player &player);
 void M_SyncStartKill(Monster &monster, Point position, const Player &player);
 void M_UpdateRelations(const Monster &monster);
+void M_SeparateFromLeaderPack(Monster &monster);
+void M_JoinLeaderPack(Monster &monster);
 void DoEnding();
 void PrepDoEnding();
 bool Walk(Monster &monster, Direction md);


### PR DESCRIPTION
Fixes https://github.com/diasurgical/devilutionX/issues/6661 and some other cases:
 - scavengers never rejoined the pack after feeding (because their relationship was getting set to LeaderRelation::None while feeding and GroupUnity reconnects only minions with LeaderRelation::Separated)
 - killing any minion while stone cursed basically blocked the whole pack, stone cursing any minion stopped the whole pack - now stone cursed monsters aren't in bosspack, initially I've added rejoining the pack on stone curse expiration but then we were back to the original issue - if a monster "destoned" far away from the pack, both pack and the monster would be stuck so I'm leaving GroupUnity as the only way to rejoin the pack - means monsters have to have line of sight of each other and distance is less than 4