### PR TITLE
`text_render`: Replace optional args with struct

### DIFF
--- a/Source/DiabloUI/button.cpp
+++ b/Source/DiabloUI/button.cpp
@@ -44,7 +44,8 @@ void RenderButton(const UiButton &button)
 		--textRect.position.y;
 	}
 
-	DrawString(out, button.GetText(), textRect, UiFlags::AlignCenter | UiFlags::FontSizeDialog | UiFlags::ColorDialogWhite);
+	DrawString(out, button.GetText(), textRect,
+	    { .flags = UiFlags::AlignCenter | UiFlags::FontSizeDialog | UiFlags::ColorDialogWhite });
 }
 
 bool HandleMouseEventButton(const SDL_Event &event, UiButton *button)

--- a/Source/DiabloUI/credits.cpp
+++ b/Source/DiabloUI/credits.cpp
@@ -127,7 +127,8 @@ void CreditsRenderer::Render()
 		dstRect.y -= viewport.y;
 
 		const Surface &out = Surface(DiabloUiSurface(), viewport);
-		DrawString(out, lineContent.text, Point { dstRect.x, dstRect.y }, UiFlags::FontSizeDialog | UiFlags::ColorDialogWhite, -1);
+		DrawString(out, lineContent.text, Point { dstRect.x, dstRect.y },
+		    { .flags = UiFlags::FontSizeDialog | UiFlags::ColorDialogWhite, .spacing = -1 });
 	}
 }
 

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -768,13 +768,15 @@ namespace {
 void Render(const UiText &uiText)
 {
 	const Surface &out = Surface(DiabloUiSurface());
-	DrawString(out, uiText.GetText(), MakeRectangle(uiText.m_rect), uiText.GetFlags() | UiFlags::FontSizeDialog);
+	DrawString(out, uiText.GetText(), MakeRectangle(uiText.m_rect),
+	    { .flags = uiText.GetFlags() | UiFlags::FontSizeDialog });
 }
 
 void Render(const UiArtText &uiArtText)
 {
 	const Surface &out = Surface(DiabloUiSurface());
-	DrawString(out, uiArtText.GetText(), MakeRectangle(uiArtText.m_rect), uiArtText.GetFlags(), uiArtText.GetSpacing(), uiArtText.GetLineHeight());
+	DrawString(out, uiArtText.GetText(), MakeRectangle(uiArtText.m_rect),
+	    { .flags = uiArtText.GetFlags(), .spacing = uiArtText.GetSpacing(), .lineHeight = uiArtText.GetLineHeight() });
 }
 
 void Render(const UiImageClx &uiImage)
@@ -800,7 +802,7 @@ void Render(const UiImageAnimatedClx &uiImage)
 void Render(const UiArtTextButton &uiButton)
 {
 	const Surface &out = Surface(DiabloUiSurface());
-	DrawString(out, uiButton.GetText(), MakeRectangle(uiButton.m_rect), uiButton.GetFlags());
+	DrawString(out, uiButton.GetText(), MakeRectangle(uiButton.m_rect), { .flags = uiButton.GetFlags() });
 }
 
 void Render(const UiList &uiList)
@@ -814,10 +816,13 @@ void Render(const UiList &uiList)
 			DrawSelector(rect);
 
 		Rectangle rectangle = MakeRectangle(rect);
-		if (item.args.empty())
-			DrawString(out, item.m_text, rectangle, uiList.GetFlags() | item.uiFlags, uiList.GetSpacing());
-		else
-			DrawStringWithColors(out, item.m_text, item.args, rectangle, uiList.GetFlags() | item.uiFlags, uiList.GetSpacing());
+		if (item.args.empty()) {
+			DrawString(out, item.m_text, rectangle,
+			    { .flags = uiList.GetFlags() | item.uiFlags, .spacing = uiList.GetSpacing() });
+		} else {
+			DrawStringWithColors(out, item.m_text, item.args, rectangle,
+			    { .flags = uiList.GetFlags() | item.uiFlags, .spacing = uiList.GetSpacing() });
+		}
 	}
 }
 
@@ -864,7 +869,8 @@ void Render(const UiEdit &uiEdit)
 	Rectangle rect = MakeRectangle(uiEdit.m_rect).inset({ 43, 1 });
 
 	const Surface &out = Surface(DiabloUiSurface());
-	DrawString(out, uiEdit.m_value, rect, uiEdit.GetFlags(), /*spacing=*/1, /*lineHeight=*/-1, uiEdit.m_cursor);
+	DrawString(out, uiEdit.m_value, rect,
+	    { .flags = uiEdit.GetFlags(), .cursorPosition = static_cast<int>(uiEdit.m_cursor) });
 }
 
 bool HandleMouseEventArtTextButton(const SDL_Event &event, const UiArtTextButton *uiButton)

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1471,32 +1471,33 @@ void DrawAutomapText(const Surface &out)
 	DrawString(out, difficultyString, linePosition);
 
 #ifdef _DEBUG
-	UiFlags debugColor = UiFlags::ColorOrange;
-
+	const TextRenderOptions debugTextOptions {
+		.flags = UiFlags::ColorOrange,
+	};
 	linePosition.y += 45;
 	if (DebugGodMode) {
 		linePosition.y += 15;
-		DrawString(out, "God Mode", linePosition, debugColor);
+		DrawString(out, "God Mode", linePosition, debugTextOptions);
 	}
 	if (DisableLighting) {
 		linePosition.y += 15;
-		DrawString(out, "Fullbright", linePosition, debugColor);
+		DrawString(out, "Fullbright", linePosition, debugTextOptions);
 	}
 	if (DebugVision) {
 		linePosition.y += 15;
-		DrawString(out, "Draw Vision", linePosition, debugColor);
+		DrawString(out, "Draw Vision", linePosition, debugTextOptions);
 	}
 	if (DebugPath) {
 		linePosition.y += 15;
-		DrawString(out, "Draw Path", linePosition, debugColor);
+		DrawString(out, "Draw Path", linePosition, debugTextOptions);
 	}
 	if (DebugGrid) {
 		linePosition.y += 15;
-		DrawString(out, "Draw Grid", linePosition, debugColor);
+		DrawString(out, "Draw Grid", linePosition, debugTextOptions);
 	}
 	if (DebugScrollViewEnabled) {
 		linePosition.y += 15;
-		DrawString(out, "Scroll View", linePosition, debugColor);
+		DrawString(out, "Scroll View", linePosition, debugTextOptions);
 	}
 #endif
 }

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -282,7 +282,12 @@ void PrintInfo(const Surface &out)
 
 	SpeakText(InfoString);
 
-	DrawString(out, InfoString, infoArea, InfoColor | UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::KerningFitSpacing, 2, lineHeight);
+	DrawString(out, InfoString, infoArea,
+	    {
+	        .flags = InfoColor | UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::KerningFitSpacing,
+	        .spacing = 2,
+	        .lineHeight = lineHeight,
+	    });
 }
 
 int CapStatPointsToAdd(int remainingStatPoints, const Player &player, CharacterAttribute attribute)
@@ -830,8 +835,10 @@ void DrawFlaskValues(const Surface &out, Point pos, int currValue, int maxValue)
 	UiFlags color = (currValue > 0 ? (currValue == maxValue ? UiFlags::ColorGold : UiFlags::ColorWhite) : UiFlags::ColorRed);
 
 	auto drawStringWithShadow = [out, color](std::string_view text, Point pos) {
-		DrawString(out, text, pos + Displacement { -1, -1 }, UiFlags::ColorBlack | UiFlags::KerningFitSpacing, 0);
-		DrawString(out, text, pos, color | UiFlags::KerningFitSpacing, 0);
+		DrawString(out, text, pos + Displacement { -1, -1 },
+		    { .flags = UiFlags::ColorBlack | UiFlags::KerningFitSpacing, .spacing = 0 });
+		DrawString(out, text, pos,
+		    { .flags = color | UiFlags::KerningFitSpacing, .spacing = 0 });
 	};
 
 	std::string currText = StrCat(currValue);
@@ -1261,7 +1268,8 @@ void DrawLevelUpIcon(const Surface &out)
 {
 	if (IsLevelUpButtonVisible()) {
 		int nCel = lvlbtndown ? 2 : 1;
-		DrawString(out, _("Level Up"), { GetMainPanel().position + Displacement { 0, -62 }, { 120, 0 } }, UiFlags::ColorWhite | UiFlags::AlignCenter | UiFlags::KerningFitSpacing);
+		DrawString(out, _("Level Up"), { GetMainPanel().position + Displacement { 0, -62 }, { 120, 0 } },
+		    { .flags = UiFlags::ColorWhite | UiFlags::AlignCenter | UiFlags::KerningFitSpacing });
 		ClxDraw(out, GetMainPanel().position + Displacement { 40, -17 }, (*pChrButtons)[nCel]);
 	}
 }
@@ -1384,12 +1392,13 @@ void DrawGoldSplit(const Surface &out)
 	// The split gold dialog is roughly 4 lines high, but we need at least one line for the player to input an amount.
 	// Using a clipping region 50 units high (approx 3 lines with a lineheight of 17) to ensure there is enough room left
 	//  for the text entered by the player.
-	DrawString(out, wrapped, { GetPanelPosition(UiPanels::Inventory, { dialogX + 31, 75 }), { 200, 50 } }, UiFlags::ColorWhitegold | UiFlags::AlignCenter, 1, 17);
+	DrawString(out, wrapped, { GetPanelPosition(UiPanels::Inventory, { dialogX + 31, 75 }), { 200, 50 } },
+	    { .flags = UiFlags::ColorWhitegold | UiFlags::AlignCenter, .lineHeight = 17 });
 
 	// Even a ten digit amount of gold only takes up about half a line. There's no need to wrap or clip text here so we
 	// use the Point form of DrawString.
 	DrawString(out, amountText, GetPanelPosition(UiPanels::Inventory, { dialogX + 37, 128 }),
-	    UiFlags::ColorWhite | UiFlags::PentaCursor, /*spacing=*/1, /*lineHeight=*/-1, cursorPosition);
+	    { .flags = UiFlags::ColorWhite | UiFlags::PentaCursor, .cursorPosition = static_cast<int>(cursorPosition) });
 }
 
 void control_drop_gold(SDL_Keycode vkey)
@@ -1439,7 +1448,8 @@ void DrawTalkPan(const Surface &out)
 	int x = mainPanelPosition.x + 200;
 	int y = mainPanelPosition.y + 10;
 
-	const uint32_t len = DrawString(out, TalkMessage, { { x, y }, { 250, 39 } }, UiFlags::ColorWhite | UiFlags::PentaCursor, 1, 13, ChatCursorPosition);
+	const uint32_t len = DrawString(out, TalkMessage, { { x, y }, { 250, 39 } },
+	    { .flags = UiFlags::ColorWhite | UiFlags::PentaCursor, .lineHeight = 13, .cursorPosition = static_cast<int>(ChatCursorPosition) });
 	ChatInputState->truncate(len);
 
 	x += 46;
@@ -1472,7 +1482,7 @@ void DrawTalkPan(const Surface &out)
 			RenderClxSprite(out, (*TalkButton)[TalkButtonsDown[talkBtn] ? 1 : 0], talkPanPosition + Displacement { 4, -15 });
 		}
 		if (player.plractive) {
-			DrawString(out, player._pName, { { x, y + 60 + talkBtn * 18 }, { 204, 0 } }, color);
+			DrawString(out, player._pName, { { x, y + 60 + talkBtn * 18 }, { 204, 0 } }, { .flags = color });
 		}
 
 		talkBtn++;

--- a/Source/diablo_msg.cpp
+++ b/Source/diablo_msg.cpp
@@ -204,7 +204,8 @@ void DrawDiabloMsg(const Surface &out)
 	const int textX = innerXBegin + textPaddingX;
 	int textY = innerYBegin + (innerHeight - LineHeight * static_cast<int>(TextLines.size())) / 2;
 	for (const std::string &line : TextLines) {
-		DrawString(out, line, { { textX, textY }, { lineWidth, LineHeight } }, UiFlags::AlignCenter, 1, LineHeight);
+		DrawString(out, line, { { textX, textY }, { lineWidth, LineHeight } },
+		    { .flags = UiFlags::AlignCenter, .lineHeight = LineHeight });
 		textY += LineHeight;
 	}
 

--- a/Source/engine/render/dun_render.cpp
+++ b/Source/engine/render/dun_render.cpp
@@ -1175,7 +1175,7 @@ void RenderTile(const Surface &out, Point position,
 
 #ifdef DEBUG_STR
 	const auto [debugStr, flags] = GetTileDebugStr(tile);
-	DrawString(out, debugStr, Rectangle { Point { position.x + 2, position.y - 29 }, Size { 28, 28 } }, flags);
+	DrawString(out, debugStr, Rectangle { Point { position.x + 2, position.y - 29 }, Size { 28, 28 } }, { .flags = flags });
 #endif
 }
 

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1066,10 +1066,10 @@ void DrawGame(const Surface &fullOut, Point position, Displacement offset)
 	Point pos { 100, 20 };
 	for (size_t i = 0; i < sortedStats.size(); ++i) {
 		const auto &stat = sortedStats[i];
-		DrawString(out, StrCat(i, "."), Rectangle(pos, Size { 20, 16 }), UiFlags::AlignRight);
+		DrawString(out, StrCat(i, "."), Rectangle(pos, Size { 20, 16 }), { .flags = UiFlags::AlignRight });
 		DrawString(out, MaskTypeToString(stat.first.maskType), { pos.x + 24, pos.y });
 		DrawString(out, TileTypeToString(stat.first.tileType), { pos.x + 184, pos.y });
-		DrawString(out, FormatInteger(stat.second), Rectangle({ pos.x + 354, pos.y }, Size(40, 16)), UiFlags::AlignRight);
+		DrawString(out, FormatInteger(stat.second), Rectangle({ pos.x + 354, pos.y }, Size(40, 16)), { .flags = UiFlags::AlignRight });
 		pos.y += 16;
 	}
 #endif
@@ -1111,7 +1111,8 @@ void DrawView(const Surface &out, Point startPosition)
 				Size tileSize = { TILE_WIDTH, TILE_HEIGHT };
 				if (*sgOptions.Graphics.zoom)
 					tileSize *= 2;
-				DrawString(out, debugGridTextBuffer, { pixelCoords - Displacement { 0, tileSize.height }, tileSize }, UiFlags::ColorRed | UiFlags::AlignCenter | UiFlags::VerticalCenter);
+				DrawString(out, debugGridTextBuffer, { pixelCoords - Displacement { 0, tileSize.height }, tileSize },
+				    { .flags = UiFlags::ColorRed | UiFlags::AlignCenter | UiFlags::VerticalCenter });
 			}
 			if (DebugGrid) {
 				auto DrawDebugSquare = [&out](Point center, Displacement hor, Displacement ver, uint8_t col) {
@@ -1240,7 +1241,7 @@ void DrawFPS(const Surface &out)
 		    : BufCopy(buf, fps / FpsPow10, ".", fps % FpsPow10, " FPS");
 		formatted = { buf, static_cast<std::string_view::size_type>(end - buf) };
 	};
-	DrawString(out, formatted, Point { 8, 68 }, UiFlags::ColorRed);
+	DrawString(out, formatted, Point { 8, 68 }, { .flags = UiFlags::ColorRed });
 }
 
 /**

--- a/Source/engine/render/text_render.hpp
+++ b/Source/engine/render/text_render.hpp
@@ -105,6 +105,25 @@ private:
 	std::string formatted_;
 };
 
+/** @brief Text rendering options. */
+struct TextRenderOptions {
+	/** @brief A combination of UiFlags to describe font size, color, alignment, etc. See ui_items.h for available options */
+	UiFlags flags = UiFlags::None;
+
+	/**
+	 * @brief Additional space to add between characters.
+	 *
+	 * This value may be adjusted if the flag UiFlags::KerningFitSpacing is set.
+	 */
+	int spacing = 1;
+
+	/** @brief Allows overriding the default line height, useful for multi-line strings. */
+	int lineHeight = -1;
+
+	/** @brief If non-negative, draws a blinking cursor after the given byte index.*/
+	int cursorPosition = -1;
+};
+
 /**
  * @brief Small text selection cursor.
  *
@@ -166,14 +185,10 @@ int GetLineHeight(std::string_view text, GameFontTables fontIndex);
  * @param out The screen buffer to draw on.
  * @param text String to be drawn.
  * @param rect Clipping region relative to the output buffer describing where to draw the text and when to wrap long lines.
- * @param flags A combination of UiFlags to describe font size, color, alignment, etc. See ui_items.h for available options
- * @param spacing Additional space to add between characters.
- *                This value may be adjusted if the flag UIS_FIT_SPACING is passed in the flags parameter.
- * @param lineHeight Allows overriding the default line height, useful for multi-line strings.
- * @param cursorPosition If non-negative, draws a blinking cursor after the given byte index.
+ * @param opts Rendering options.
  * @return The number of bytes rendered, including characters "drawn" outside the buffer.
  */
-uint32_t DrawString(const Surface &out, std::string_view text, const Rectangle &rect, UiFlags flags = UiFlags::None, int spacing = 1, int lineHeight = -1, int cursorPosition = -1);
+uint32_t DrawString(const Surface &out, std::string_view text, const Rectangle &rect, TextRenderOptions opts = {});
 
 /**
  * @brief Draws a line of text at the given position relative to the origin of the output buffer.
@@ -185,37 +200,30 @@ uint32_t DrawString(const Surface &out, std::string_view text, const Rectangle &
  * @param out The screen buffer to draw on.
  * @param text String to be drawn.
  * @param position Location of the top left corner of the string relative to the top left corner of the output buffer.
- * @param flags A combination of UiFlags to describe font size, color, alignment, etc. See ui_items.h for available options
- * @param spacing Additional space to add between characters.
- *                This value may be adjusted if the flag UIS_FIT_SPACING is passed in the flags parameter.
- * @param cursorPosition If non-negative, draws a blinking cursor after the given byte index.
- * @param lineHeight Allows overriding the default line height, useful for multi-line strings.
+ * @param opts Rendering options.
  */
-inline void DrawString(const Surface &out, std::string_view text, const Point &position, UiFlags flags = UiFlags::None, int spacing = 1, int lineHeight = -1, int cursorPosition = -1)
+inline void DrawString(const Surface &out, std::string_view text, const Point &position, TextRenderOptions opts = {})
 {
-	DrawString(out, text, { position, { out.w() - position.x, 0 } }, flags, spacing, lineHeight, cursorPosition);
+	DrawString(out, text, { position, { out.w() - position.x, 0 } }, opts);
 }
 
 /**
  * @brief Draws a line of text with different colors for certain parts of the text.
  *
- *     DrawStringWithColors(out, "Press {} to start", {{"Ⓧ", UiFlags::ColorBlue}}, UiFlags::ColorWhite)
+ *     DrawStringWithColors(out, "Press {} to start", {{"Ⓧ", UiFlags::ColorBlue}}, {.flags = UiFlags::ColorWhite})
  *
  * @param out Output buffer to draw the text on.
  * @param fmt An fmt::format string.
  * @param args Format arguments.
  * @param argsLen Number of format arguments.
  * @param rect Clipping region relative to the output buffer describing where to draw the text and when to wrap long lines.
- * @param flags A combination of UiFlags to describe font size, color, alignment, etc. See ui_items.h for available options
- * @param spacing Additional space to add between characters.
- *                This value may be adjusted if the flag UIS_FIT_SPACING is passed in the flags parameter.
- * @param lineHeight Allows overriding the default line height, useful for multi-line strings.
+ * @param opts Rendering options.
  */
-void DrawStringWithColors(const Surface &out, std::string_view fmt, DrawStringFormatArg *args, std::size_t argsLen, const Rectangle &rect, UiFlags flags = UiFlags::None, int spacing = 1, int lineHeight = -1);
+void DrawStringWithColors(const Surface &out, std::string_view fmt, DrawStringFormatArg *args, std::size_t argsLen, const Rectangle &rect, TextRenderOptions opts = {});
 
-inline void DrawStringWithColors(const Surface &out, std::string_view fmt, std::vector<DrawStringFormatArg> args, const Rectangle &rect, UiFlags flags = UiFlags::None, int spacing = 1, int lineHeight = -1)
+inline void DrawStringWithColors(const Surface &out, std::string_view fmt, std::vector<DrawStringFormatArg> args, const Rectangle &rect, TextRenderOptions opts = {})
 {
-	return DrawStringWithColors(out, fmt, args.data(), args.size(), rect, flags, spacing, lineHeight);
+	return DrawStringWithColors(out, fmt, args.data(), args.size(), rect, opts);
 }
 
 uint8_t PentSpn2Spin();

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -129,7 +129,8 @@ void GmenuDrawMenuItem(const Surface &out, TMenuItem *pItem, int y)
 
 	int x = (gnScreenWidth - w) / 2;
 	UiFlags style = pItem->enabled() ? UiFlags::ColorGold : UiFlags::ColorBlack;
-	DrawString(out, _(pItem->pszStr), Point { x, y }, style | UiFlags::FontSize46, 2);
+	DrawString(out, _(pItem->pszStr), Point { x, y },
+	    { .flags = style | UiFlags::FontSize46, .spacing = 2 });
 	if (pItem == sgpCurrItem) {
 		const ClxSprite sprite = (*PentSpin_cel)[PentSpn2Spin()];
 		ClxDraw(out, { x - 54, y + 51 }, sprite);
@@ -174,7 +175,8 @@ void gmenu_draw_pause(const Surface &out)
 		RedBack(out);
 	if (sgpCurrentMenu == nullptr) {
 		LightTableIndex = 0;
-		DrawString(out, _("Pause"), { { 0, 0 }, { gnScreenWidth, GetMainPanel().position.y } }, UiFlags::FontSize46 | UiFlags::ColorGold | UiFlags::AlignCenter | UiFlags::VerticalCenter, 2);
+		DrawString(out, _("Pause"), { { 0, 0 }, { gnScreenWidth, GetMainPanel().position.y } },
+		    { .flags = UiFlags::FontSize46 | UiFlags::ColorGold | UiFlags::AlignCenter | UiFlags::VerticalCenter, .spacing = 2 });
 	}
 }
 

--- a/Source/help.cpp
+++ b/Source/help.cpp
@@ -207,7 +207,7 @@ void DrawHelp(const Surface &out)
 
 	DrawString(out, title,
 	    { { sx, sy + PaddingTop + blankLineHeight }, { ContentTextWidth, lineHeight } },
-	    UiFlags::ColorWhitegold | UiFlags::AlignCenter);
+	    { .flags = UiFlags::ColorWhitegold | UiFlags::AlignCenter });
 
 	const int titleBottom = sy + HeaderHeight();
 	DrawSLine(out, titleBottom);
@@ -227,12 +227,13 @@ void DrawHelp(const Surface &out)
 			style = UiFlags::ColorBlue;
 		}
 
-		DrawString(out, line.substr(offset), { { sx, contentY + i * lineHeight }, { ContentTextWidth, lineHeight } }, style, /*spacing=*/1, lineHeight);
+		DrawString(out, line.substr(offset), { { sx, contentY + i * lineHeight }, { ContentTextWidth, lineHeight } },
+		    { .flags = style, .lineHeight = lineHeight });
 	}
 
 	DrawString(out, _("Press ESC to end or the arrow keys to scroll."),
 	    { { sx, contentY + ContentsTextHeight() + ContentPaddingY() + blankLineHeight }, { ContentTextWidth, lineHeight } },
-	    UiFlags::ColorWhitegold | UiFlags::AlignCenter);
+	    { .flags = UiFlags::ColorWhitegold | UiFlags::AlignCenter });
 
 	DrawHelpSlider(out);
 }

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1179,7 +1179,8 @@ void DrawInvBelt(const Surface &out)
 
 		if (myPlayer.SpdList[i].isUsable()
 		    && myPlayer.SpdList[i]._itype != ItemType::Gold) {
-			DrawString(out, StrCat(i + 1), { position - Displacement { 0, 12 }, InventorySlotSizeInPixels }, UiFlags::ColorWhite | UiFlags::AlignRight);
+			DrawString(out, StrCat(i + 1), { position - Displacement { 0, 12 }, InventorySlotSizeInPixels },
+			    { .flags = UiFlags::ColorWhite | UiFlags::AlignRight });
 		}
 	}
 }

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3885,7 +3885,7 @@ void DrawUniqueInfo(const Surface &out)
 
 	Rectangle rect { position + Displacement { 32, 56 }, { 257, 0 } };
 	const UniqueItem &uitem = UniqueItems[curruitem._iUid];
-	DrawString(out, _(uitem.UIName), rect, UiFlags::AlignCenter);
+	DrawString(out, _(uitem.UIName), rect, { .flags = UiFlags::AlignCenter });
 
 	const Rectangle dividerLineRect { position + Displacement { 26, 25 }, { 267, 3 } };
 	out.BlitFrom(out, MakeSdlRect(dividerLineRect), dividerLineRect.position + Displacement { 0, 5 * 12 + 13 });
@@ -3896,7 +3896,8 @@ void DrawUniqueInfo(const Surface &out)
 		if (power.type == IPL_INVALID)
 			break;
 		rect.position.y += 2 * 12;
-		DrawString(out, PrintItemPower(power.type, curruitem), rect, UiFlags::ColorWhite | UiFlags::AlignCenter);
+		DrawString(out, PrintItemPower(power.type, curruitem), rect,
+		    { .flags = UiFlags::ColorWhite | UiFlags::AlignCenter });
 	}
 }
 

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -116,7 +116,8 @@ void DrawQTextContent(const Surface &out)
 			continue;
 		}
 
-		DrawString(out, line, { { sx, sy + i * LineHeight }, { 543, LineHeight } }, UiFlags::FontSize30 | UiFlags::ColorGold);
+		DrawString(out, line, { { sx, sy + i * LineHeight }, { 543, LineHeight } },
+		    { .flags = UiFlags::FontSize30 | UiFlags::ColorGold });
 	}
 }
 

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -245,8 +245,10 @@ void DrawShadowString(const Surface &out, const PanelEntry &entry)
 	const int textHeight = (c_count(wrapped, '\n') + 1) * GetLineHeight(wrapped, GameFont12);
 	const int labelHeight = std::max(PanelFieldHeight, textHeight);
 
-	DrawString(out, text, { labelPosition + Displacement { -2, 2 }, { entry.labelLength, labelHeight } }, style | UiFlags::ColorBlack, Spacing);
-	DrawString(out, text, { labelPosition, { entry.labelLength, labelHeight } }, style | UiFlags::ColorWhite, Spacing);
+	DrawString(out, text, { labelPosition + Displacement { -2, 2 }, { entry.labelLength, labelHeight } },
+	    { .flags = style | UiFlags::ColorBlack, .spacing = Spacing });
+	DrawString(out, text, { labelPosition, { entry.labelLength, labelHeight } },
+	    { .flags = style | UiFlags::ColorWhite, .spacing = Spacing });
 }
 
 void DrawStatButtons(const Surface &out)
@@ -311,7 +313,7 @@ void DrawChr(const Surface &out)
 			    out,
 			    tmp.text,
 			    { entry.position + Displacement { pos.x, pos.y + PanelFieldPaddingTop }, { entry.length, PanelFieldInnerHeight } },
-			    UiFlags::AlignCenter | UiFlags::VerticalCenter | tmp.style, tmp.spacing);
+			    { .flags = UiFlags::AlignCenter | UiFlags::VerticalCenter | tmp.style, .spacing = tmp.spacing });
 		}
 	}
 	DrawStatButtons(out);

--- a/Source/panels/mainpanel.cpp
+++ b/Source/panels/mainpanel.cpp
@@ -27,8 +27,10 @@ OptionalOwnedClxSpriteList PanelButtonDownGrime;
 
 void DrawButtonText(const Surface &out, std::string_view text, Rectangle placement, UiFlags style, int spacing = 1)
 {
-	DrawString(out, text, { placement.position + Displacement { 0, 1 }, placement.size }, UiFlags::AlignCenter | UiFlags::KerningFitSpacing | UiFlags::ColorBlack, spacing);
-	DrawString(out, text, placement, UiFlags::AlignCenter | UiFlags::KerningFitSpacing | style, spacing);
+	DrawString(out, text, { placement.position + Displacement { 0, 1 }, placement.size },
+	    { .flags = UiFlags::AlignCenter | UiFlags::KerningFitSpacing | UiFlags::ColorBlack, .spacing = spacing });
+	DrawString(out, text, placement,
+	    { .flags = UiFlags::AlignCenter | UiFlags::KerningFitSpacing | style, .spacing = spacing });
 }
 
 void DrawButtonOnPanel(Point position, std::string_view text, int frame)

--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -80,7 +80,7 @@ void PrintSBookStr(const Surface &out, Point position, std::string_view text, Ui
 	    Rectangle(GetPanelPosition(UiPanels::Spell, position + Displacement { SPLICONLENGTH, 0 }),
 	        SpellBookDescription)
 	        .inset({ SpellBookDescriptionPaddingHorizontal, 0 }),
-	    UiFlags::ColorWhite | flags);
+	    { .flags = UiFlags::ColorWhite | flags });
 }
 
 SpellType GetSBookTrans(SpellID ii, bool townok)

--- a/Source/panels/spell_list.cpp
+++ b/Source/panels/spell_list.cpp
@@ -34,7 +34,7 @@ void PrintSBookSpellType(const Surface &out, Point position, std::string_view te
 	position += Displacement { SPLICONLENGTH / 2 - GetLineWidth(text) / 2, (IsSmallFontTall() ? -19 : -15) };
 
 	// Then draw the text over the top
-	DrawString(out, text, position, UiFlags::ColorWhite | UiFlags::Outlined);
+	DrawString(out, text, position, { .flags = UiFlags::ColorWhite | UiFlags::Outlined });
 }
 
 void PrintSBookHotkey(const Surface &out, Point position, const std::string_view text)
@@ -43,7 +43,7 @@ void PrintSBookHotkey(const Surface &out, Point position, const std::string_view
 	position += Displacement { SPLICONLENGTH - (GetLineWidth(text.data()) + 5), 5 - SPLICONLENGTH };
 
 	// Then draw the text over the top
-	DrawString(out, text, position, UiFlags::ColorWhite | UiFlags::Outlined);
+	DrawString(out, text, position, { .flags = UiFlags::ColorWhite | UiFlags::Outlined });
 }
 
 bool GetSpellListSelection(SpellID &pSpell, SpellType &pSplType)

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -134,7 +134,8 @@ void DrawPlrMsg(const Surface &out)
 			{ std::string_view(text.data(), message.prefixLength), UiFlags::ColorWhitegold },
 			{ std::string_view(text.data() + message.prefixLength, text.size() - message.prefixLength), message.style }
 		};
-		DrawStringWithColors(out, "{:s}{:s}", args, { { x, y }, { width, 0 } }, UiFlags::None, 1, message.lineHeight);
+		DrawStringWithColors(out, "{:s}{:s}", args, { { x, y }, { width, 0 } },
+		    { .flags = UiFlags::None, .lineHeight = message.lineHeight });
 	}
 }
 

--- a/Source/qol/chatlog.cpp
+++ b/Source/qol/chatlog.cpp
@@ -168,13 +168,14 @@ void DrawChatLog(const Surface &out)
 
 	DrawString(out, fmt::format(fmt::runtime(_("Chat History (Messages: {:d})")), MessageCounter),
 	    { { sx, sy + PaddingTop + blankLineHeight }, { ContentTextWidth, lineHeight } },
-	    (UnreadFlag ? UiFlags::ColorRed : UiFlags::ColorWhitegold) | UiFlags::AlignCenter);
+	    { .flags = (UnreadFlag ? UiFlags::ColorRed : UiFlags::ColorWhitegold) | UiFlags::AlignCenter });
 
 	time_t timeResult = time(nullptr);
 	const std::tm *localtimeResult = localtime(&timeResult);
 	if (localtimeResult != nullptr) {
 		std::string timestamp = fmt::format("{:02}:{:02}:{:02}", localtimeResult->tm_hour, localtimeResult->tm_min, localtimeResult->tm_sec);
-		DrawString(out, timestamp, { { sx, sy + PaddingTop + blankLineHeight }, { ContentTextWidth, lineHeight } }, UiFlags::ColorWhitegold);
+		DrawString(out, timestamp, { { sx, sy + PaddingTop + blankLineHeight }, { ContentTextWidth, lineHeight } },
+		    { .flags = UiFlags::ColorWhitegold });
 	}
 
 	const int titleBottom = sy + HeaderHeight();
@@ -192,12 +193,13 @@ void DrawChatLog(const Surface &out)
 		for (auto &x : text.colors) {
 			args.emplace_back(DrawStringFormatArg { x.text, x.color });
 		}
-		DrawStringWithColors(out, line, args, { { sx, contentY + i * lineHeight }, { ContentTextWidth, lineHeight } }, UiFlags::ColorWhite, /*spacing=*/1, lineHeight);
+		DrawStringWithColors(out, line, args, { { sx, contentY + i * lineHeight }, { ContentTextWidth, lineHeight } },
+		    { .flags = UiFlags::ColorWhite, .lineHeight = lineHeight });
 	}
 
 	DrawString(out, _("Press ESC to end or the arrow keys to scroll."),
 	    { { sx, contentY + ContentsTextHeight() + ContentPaddingY() + blankLineHeight }, { ContentTextWidth, lineHeight } },
-	    UiFlags::ColorWhitegold | UiFlags::AlignCenter);
+	    { .flags = UiFlags::ColorWhitegold | UiFlags::AlignCenter });
 }
 
 void ChatLogScrollUp()

--- a/Source/qol/floatingnumbers.cpp
+++ b/Source/qol/floatingnumbers.cpp
@@ -190,7 +190,8 @@ void DrawFloatingNumbers(const Surface &out, Point viewPosition, Displacement of
 		float mul = 1 - (timeLeft / 2500.0f);
 		screenPosition += floatingNum.endOffset * mul;
 
-		DrawString(out, floatingNum.text, Rectangle { screenPosition, { lineWidth, 0 } }, floatingNum.style);
+		DrawString(out, floatingNum.text, Rectangle { screenPosition, { lineWidth, 0 } },
+		    { .flags = floatingNum.style });
 	}
 
 	ClearExpiredNumbers();

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -204,7 +204,8 @@ void DrawItemNameLabels(const Surface &out)
 			FillRect(clippedOut, label.pos.x, label.pos.y + MarginY, label.width, Height, PAL8_BLUE + 6);
 		else
 			DrawHalfTransparentRectTo(clippedOut, label.pos.x, label.pos.y + MarginY, label.width, Height);
-		DrawString(clippedOut, label.text, { { label.pos.x + MarginX, label.pos.y }, { label.width, Height } }, item.getTextColor());
+		DrawString(clippedOut, label.text, { { label.pos.x + MarginX, label.pos.y }, { label.width, Height } },
+		    { .flags = item.getTextColor() });
 	}
 	labelQueue.clear();
 }

--- a/Source/qol/monhealthbar.cpp
+++ b/Source/qol/monhealthbar.cpp
@@ -130,17 +130,20 @@ void DrawMonsterHealthBar(const Surface &out)
 	}
 
 	UiFlags style = UiFlags::AlignCenter | UiFlags::VerticalCenter;
-	DrawString(out, monster.name(), { position + Displacement { -1, 1 }, { width, height } }, style | UiFlags::ColorBlack);
+	DrawString(out, monster.name(), { position + Displacement { -1, 1 }, { width, height } },
+	    { .flags = style | UiFlags::ColorBlack });
 	if (monster.isUnique())
 		style |= UiFlags::ColorWhitegold;
 	else if (monster.leader != Monster::NoLeader)
 		style |= UiFlags::ColorBlue;
 	else
 		style |= UiFlags::ColorWhite;
-	DrawString(out, monster.name(), { position, { width, height } }, style);
+	DrawString(out, monster.name(), { position, { width, height } },
+	    { .flags = style });
 
 	if (multiplier > 0)
-		DrawString(out, StrCat("x", multiplier), { position, { width - 2, height } }, UiFlags::ColorWhite | UiFlags::AlignRight | UiFlags::VerticalCenter);
+		DrawString(out, StrCat("x", multiplier), { position, { width - 2, height } },
+		    { .flags = UiFlags::ColorWhite | UiFlags::AlignRight | UiFlags::VerticalCenter });
 	if (monster.isUnique() || MonsterKillCounts[monster.type().type] >= 15) {
 		monster_resistance immunes[] = { IMMUNE_MAGIC, IMMUNE_FIRE, IMMUNE_LIGHTNING };
 		monster_resistance resists[] = { RESIST_MAGIC, RESIST_FIRE, RESIST_LIGHTNING };

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -398,8 +398,10 @@ void DrawStash(const Surface &out)
 	Point position = GetPanelPosition(UiPanels::Stash);
 	UiFlags style = UiFlags::VerticalCenter | UiFlags::ColorWhite;
 
-	DrawString(out, StrCat(Stash.GetPage() + 1), { position + Displacement { 132, 0 }, { 57, 11 } }, UiFlags::AlignCenter | style);
-	DrawString(out, FormatInteger(Stash.gold), { position + Displacement { 122, 19 }, { 107, 13 } }, UiFlags::AlignRight | style);
+	DrawString(out, StrCat(Stash.GetPage() + 1), { position + Displacement { 132, 0 }, { 57, 11 } },
+	    { .flags = UiFlags::AlignCenter | style });
+	DrawString(out, FormatInteger(Stash.gold), { position + Displacement { 122, 19 }, { 107, 13 } },
+	    { .flags = UiFlags::AlignRight | style });
 }
 
 void CheckStashItem(Point mousePosition, bool isShiftHeld, bool isCtrlHeld)
@@ -650,12 +652,13 @@ void DrawGoldWithdraw(const Surface &out)
 	// The split gold dialog is roughly 4 lines high, but we need at least one line for the player to input an amount.
 	// Using a clipping region 50 units high (approx 3 lines with a lineheight of 17) to ensure there is enough room left
 	//  for the text entered by the player.
-	DrawString(out, wrapped, { GetPanelPosition(UiPanels::Stash, { dialogX + 31, 75 }), { 200, 50 } }, UiFlags::ColorWhitegold | UiFlags::AlignCenter, 1, 17);
+	DrawString(out, wrapped, { GetPanelPosition(UiPanels::Stash, { dialogX + 31, 75 }), { 200, 50 } },
+	    { .flags = UiFlags::ColorWhitegold | UiFlags::AlignCenter, .lineHeight = 17 });
 
 	// Even a ten digit amount of gold only takes up about half a line. There's no need to wrap or clip text here so we
 	// use the Point form of DrawString.
 	DrawString(out, amountText, GetPanelPosition(UiPanels::Stash, { dialogX + 37, 128 }),
-	    UiFlags::ColorWhite | UiFlags::PentaCursor, /*spacing=*/1, /*lineHeight=*/-1, cursorPosition);
+	    { .flags = UiFlags::ColorWhite | UiFlags::PentaCursor, .cursorPosition = static_cast<int>(cursorPosition) });
 }
 
 void CloseGoldWithdraw()

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -225,7 +225,8 @@ void PrintQLString(const Surface &out, int x, int y, std::string_view str, bool 
 	if (marked) {
 		ClxDraw(out, GetPanelPosition(UiPanels::Quest, { x - 20, y + 13 }), (*pSPentSpn2Cels)[PentSpn2Spin()]);
 	}
-	DrawString(out, str, { GetPanelPosition(UiPanels::Quest, { x, y }), { 257, 0 } }, disabled ? UiFlags::ColorWhitegold : UiFlags::ColorWhite);
+	DrawString(out, str, { GetPanelPosition(UiPanels::Quest, { x, y }), { 257, 0 } },
+	    { .flags = disabled ? UiFlags::ColorWhitegold : UiFlags::ColorWhite });
 	if (marked) {
 		ClxDraw(out, GetPanelPosition(UiPanels::Quest, { x + width + 7, y + 13 }), (*pSPentSpn2Cels)[PentSpn2Spin()]);
 	}

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2200,13 +2200,13 @@ void PrintSString(const Surface &out, int margin, int line, std::string_view tex
 
 	if (*sgOptions.Gameplay.showItemGraphicsInStores && cursIndent) {
 		const Rectangle textRect { { rect.position.x + HalfCursWidth + 8, rect.position.y }, { rect.size.width - HalfCursWidth + 8, rect.size.height } };
-		DrawString(out, text, textRect, flags);
+		DrawString(out, text, textRect, { .flags = flags });
 	} else {
-		DrawString(out, text, rect, flags);
+		DrawString(out, text, rect, { .flags = flags });
 	}
 
 	if (price > 0)
-		DrawString(out, FormatInteger(price), rect, flags | UiFlags::AlignRight);
+		DrawString(out, FormatInteger(price), rect, { .flags = flags | UiFlags::AlignRight });
 
 	if (stextsel == line) {
 		DrawSelector(out, rect, text, flags);


### PR DESCRIPTION
4 optional args are a bit unwieldy, especially when you want to pass only the first and the last one.

With a struct, there is no need to specify the default values for the args in between.