### PR TITLE
xbox_nxdk.yml: Remove LTO=y from SDK flags

### DIFF
--- a/.github/workflows/xbox_nxdk.yml
+++ b/.github/workflows/xbox_nxdk.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Build nxdk
       shell: bash
-      run: PATH="${NXDK_DIR}/bin:$PATH" make -j $(nproc) -C "$NXDK_DIR" NXDK_ONLY=1 LTO=y CFLAGS=-O2 CXXFLAGS=-O2 all cxbe
+      run: PATH="${NXDK_DIR}/bin:$PATH" make -j $(nproc) -C "$NXDK_DIR" NXDK_ONLY=1 CFLAGS=-O2 CXXFLAGS=-O2 all cxbe
 
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
Apparently compiling with LTO breaks USB

@StephenCWills 