### PR TITLE
nxdk: Build in optimized mode

### DIFF
--- a/.github/workflows/xbox_nxdk.yml
+++ b/.github/workflows/xbox_nxdk.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Build nxdk
       shell: bash
-      run: PATH="${NXDK_DIR}/bin:$PATH" make -j $(nproc) -C "$NXDK_DIR" NXDK_ONLY=1 all cxbe
+      run: PATH="${NXDK_DIR}/bin:$PATH" make -j $(nproc) -C "$NXDK_DIR" NXDK_ONLY=1 CFLAGS=-O2 CXXFLAGS=-O2 all cxbe
 
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
Back port of the master build flags change to 1.5

We might want to update the xbox release once the SDK is updated with the `hypot`  implementation. Would be nice to have higher FPS then.