### PR TITLE
`Displacement#distance`: Use a naive hypot impl

### DIFF
--- a/Source/engine/displacement.hpp
+++ b/Source/engine/displacement.hpp
@@ -120,7 +120,8 @@ struct DisplacementOf {
 
 	DVL_ALWAYS_INLINE float magnitude() const
 	{
-		return static_cast<float>(hypot(deltaX, deltaY));
+		// We do not use `std::hypot` here because it is slower and we do not need the extra precision.
+		return sqrtf(deltaX * deltaX + deltaY * deltaY);
 	}
 
 	/**


### PR DESCRIPTION
`std::hypot` is much slower than a naive implementation. It has the advantage of extra precision but we don't need that at all.

Conveniently, this also works around the nxdk issue. We can also cherry-pick this for 1.5.