### PR TITLE
Lua: `require` supports loads from assets

### DIFF
--- a/Source/engine/assets.hpp
+++ b/Source/engine/assets.hpp
@@ -7,6 +7,7 @@
 #include <string_view>
 
 #include <SDL.h>
+#include <expected.hpp>
 
 #include "appfat.h"
 #include "diablo.h"
@@ -245,5 +246,17 @@ AssetHandle OpenAsset(std::string_view filename, bool threadsafe = false);
 AssetHandle OpenAsset(std::string_view filename, size_t &fileSize, bool threadsafe = false);
 
 SDL_RWops *OpenAssetAsSdlRwOps(std::string_view filename, bool threadsafe = false);
+
+struct AssetData {
+	std::unique_ptr<char[]> data;
+	size_t size;
+
+	explicit operator std::string_view() const
+	{
+		return std::string_view(data.get(), size);
+	}
+};
+
+tl::expected<AssetData, std::string> LoadAsset(std::string_view path);
 
 } // namespace devilution

--- a/Source/lua/lua.hpp
+++ b/Source/lua/lua.hpp
@@ -13,6 +13,6 @@ namespace devilution {
 void LuaInitialize();
 void LuaShutdown();
 void LuaEvent(std::string_view name);
-sol::state &LuaState();
+sol::state &GetLuaState();
 
 } // namespace devilution

--- a/Source/lua/repl.cpp
+++ b/Source/lua/repl.cpp
@@ -38,7 +38,7 @@ int LuaPrintToConsole(lua_State *state)
 
 void CreateReplEnvironment()
 {
-	sol::state &lua = LuaState();
+	sol::state &lua = GetLuaState();
 	replEnv.emplace(lua, sol::create, lua.globals());
 	replEnv->set("print", LuaPrintToConsole);
 }
@@ -53,7 +53,7 @@ sol::environment &ReplEnvironment()
 sol::protected_function_result TryRunLuaAsExpressionThenStatement(std::string_view code)
 {
 	// Try to compile as an expression first. This also how the `lua` repl is implemented.
-	sol::state &lua = LuaState();
+	sol::state &lua = GetLuaState();
 	std::string expression = StrCat("return ", code, ";");
 	sol::detail::typical_chunk_name_t basechunkname = {};
 	sol::load_status status = static_cast<sol::load_status>(


### PR DESCRIPTION
Implements a `require` function that supports built-in modules like so:

```lua
local log = require('devilutionx.log')
```

It falls back to reading from assets, so this loads `lua/user.lua`:

```lua
local user = require('lua.user')
```

The bytecode for the asset scripts is cached, in case we want to later support multiple isolated environments.

There may be a simpler or better way to do this.

It's good enough for now until someone more knowledgeable about Lua comes along.