### PR TITLE
Lua console: Add a prelude file

### DIFF
--- a/CMake/Assets.cmake
+++ b/CMake/Assets.cmake
@@ -142,6 +142,7 @@ set(devilutionx_assets
   levels/towndata/automap.amp
   lua/init.lua
   lua/inspect.lua
+  lua/repl_prelude.lua
   nlevels/cutl5w.clx
   nlevels/cutl6w.clx
   nlevels/l5data/cornerstone.dun

--- a/Packaging/resources/assets/lua/repl_prelude.lua
+++ b/Packaging/resources/assets/lua/repl_prelude.lua
@@ -1,0 +1,5 @@
+log = require('devilutionx.log')
+audio = require('devilutionx.audio')
+render = require('devilutionx.render')
+message = require('devilutionx.message')
+inspect = require('inspect')


### PR DESCRIPTION
Runs lua/repl_prelude.lua at console initialization.

The default prelude contains global assignments for all devilutionx modules. This should save us on typing.
The console has its own environment so this doesn't affect other Lua scripts.

![console-prelude](https://github.com/diasurgical/devilutionX/assets/216339/adc4cf53-49d6-4c6a-bf65-88674dfd1847)
