### PR TITLE
Bump libzt

### DIFF
--- a/3rdParty/libzt/CMakeLists.txt
+++ b/3rdParty/libzt/CMakeLists.txt
@@ -5,7 +5,7 @@ set(BUILD_HOST_SELFTEST OFF)
 include(FetchContent)
 FetchContent_Declare(libzt
   GIT_REPOSITORY https://github.com/diasurgical/libzt.git
-  GIT_TAG 8c31715bc48bade2097d66ced54db07598268710)
+  GIT_TAG bd4bd4c13f533ccd4ef8ec86a3bce95342ef163e)
 FetchContent_MakeAvailableExcludeFromAll(libzt)
 
 if(NOT ANDROID)


### PR DESCRIPTION
Fixes MSVC warning LNK4006 see https://github.com/diasurgical/libzt/pull/15.

When compiling devilutionX with MSVC and this PR the warnings gets reduced by 256 (from 691 to 435).