### PR TITLE
Migrate some debug.cpp commands to Lua

### DIFF
--- a/Packaging/resources/assets/lua/repl_prelude.lua
+++ b/Packaging/resources/assets/lua/repl_prelude.lua
@@ -2,4 +2,5 @@ log = require('devilutionx.log')
 audio = require('devilutionx.audio')
 render = require('devilutionx.render')
 message = require('devilutionx.message')
+if _DEBUG then dev = require('devilutionx.dev') end
 inspect = require('inspect')

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -136,6 +136,8 @@ set(libdevilutionx_SRCS
   lua/lua.cpp
   lua/repl.cpp
   lua/modules/audio.cpp
+  lua/modules/dev.cpp
+  lua/modules/dev/quests.cpp
   lua/modules/render.cpp
   lua/modules/log.cpp
 

--- a/Source/lua/lua.cpp
+++ b/Source/lua/lua.cpp
@@ -18,6 +18,10 @@
 #include "utils/log.hpp"
 #include "utils/str_cat.hpp"
 
+#ifdef _DEBUG
+#include "lua/modules/dev.hpp"
+#endif
+
 namespace devilution {
 
 namespace {
@@ -172,11 +176,20 @@ void LuaInitialize()
 	// Registering globals
 	lua.set(
 	    "print", LuaPrint,
+	    "_DEBUG",
+#ifdef _DEBUG
+	    true,
+#else
+	    false,
+#endif
 	    "_VERSION", LUA_VERSION);
 
 	// Registering devilutionx object table
 	CheckResult(lua.safe_script(RequireGenSrc), /*optional=*/false);
 	const sol::table loaded = lua.create_table_with(
+#ifdef _DEBUG
+	    "devilutionx.dev", LuaDevModule(lua),
+#endif
 	    "devilutionx.version", PROJECT_VERSION,
 	    "devilutionx.log", LuaLogModule(lua),
 	    "devilutionx.audio", LuaAudioModule(lua),

--- a/Source/lua/metadoc.hpp
+++ b/Source/lua/metadoc.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <sol/sol.hpp>
+
+#include <string_view>
+
+#include "utils/str_cat.hpp"
+
+namespace devilution {
+
+inline std::string LuaSignatureKey(std::string_view key)
+{
+	return StrCat("__sig_", key);
+}
+
+inline std::string LuaDocstringKey(std::string_view key)
+{
+	return StrCat("__doc_", key);
+}
+
+template <typename T>
+void SetWithSignatureAndDoc(sol::table &table, std::string_view key, std::string_view signature, std::string_view doc, T &&value)
+{
+	table[key] = std::forward<T>(value);
+	table[LuaSignatureKey(key)] = signature;
+	table[LuaDocstringKey(key)] = doc;
+}
+
+template <typename T>
+void SetWithSignature(sol::table &table, std::string_view key, std::string_view signature, T &&value)
+{
+	table[key] = std::forward<T>(value);
+	table[LuaSignatureKey(key)] = signature;
+}
+
+inline std::optional<std::string> GetSignature(const sol::table &table, std::string_view key)
+{
+	return table.get<std::optional<std::string>>(LuaSignatureKey(key));
+}
+
+inline std::optional<std::string> GetDocstring(const sol::table &table, std::string_view key)
+{
+	return table.get<std::optional<std::string>>(LuaDocstringKey(key));
+}
+
+} // namespace devilution

--- a/Source/lua/modules/audio.cpp
+++ b/Source/lua/modules/audio.cpp
@@ -3,6 +3,7 @@
 #include <sol/sol.hpp>
 
 #include "effects.h"
+#include "lua/metadoc.hpp"
 
 namespace devilution {
 
@@ -17,9 +18,14 @@ bool IsValidSfx(int16_t psfx)
 
 sol::table LuaAudioModule(sol::state_view &lua)
 {
-	return lua.create_table_with(
-	    "playSfx", [](int psfx) { if (IsValidSfx(psfx)) PlaySFX(static_cast<SfxID>(psfx)); },
-	    "playSfxLoc", [](int psfx, int x, int y) { if (IsValidSfx(psfx)) PlaySfxLoc(static_cast<SfxID>(psfx), { x, y }); });
+	sol::table table = lua.create_table();
+	SetWithSignature(table,
+	    "playSfx", "(id: number)",
+	    [](int16_t psfx) { if (IsValidSfx(psfx)) PlaySFX(static_cast<SfxID>(psfx)); });
+	SetWithSignature(table,
+	    "playSfxLoc", "(id: number, x: number, y: number)",
+	    [](int16_t psfx, int x, int y) { if (IsValidSfx(psfx)) PlaySfxLoc(static_cast<SfxID>(psfx), { x, y }); });
+	return table;
 }
 
 } // namespace devilution

--- a/Source/lua/modules/dev.cpp
+++ b/Source/lua/modules/dev.cpp
@@ -1,0 +1,197 @@
+#ifdef _DEBUG
+#include "lua/modules/dev.hpp"
+
+#include <sol/sol.hpp>
+
+#include "automap.h"
+#include "debug.h"
+#include "items.h"
+#include "lua/metadoc.hpp"
+#include "lua/modules/dev/quests.hpp"
+#include "player.h"
+#include "spells.h"
+#include "utils/str_cat.hpp"
+
+namespace devilution {
+
+namespace {
+
+std::string DebugCmdShowGrid()
+{
+	DebugGrid = !DebugGrid;
+	return StrCat("Tile grid highlighting: ", DebugGrid ? "On" : "Off");
+}
+
+std::string DebugCmdLevelUp(int levels = 1)
+{
+	if (levels <= 0) return "amount must be positive";
+	Player &myPlayer = *MyPlayer;
+	for (int i = 0; i < levels; i++)
+		NetSendCmd(true, CMD_CHEAT_EXPERIENCE);
+	return StrCat("New character level: ", myPlayer.getCharacterLevel() + levels);
+}
+
+std::string DebugCmdMaxStats()
+{
+	Player &myPlayer = *MyPlayer;
+	ModifyPlrStr(myPlayer, myPlayer.GetMaximumAttributeValue(CharacterAttribute::Strength) - myPlayer._pBaseStr);
+	ModifyPlrMag(myPlayer, myPlayer.GetMaximumAttributeValue(CharacterAttribute::Magic) - myPlayer._pBaseMag);
+	ModifyPlrDex(myPlayer, myPlayer.GetMaximumAttributeValue(CharacterAttribute::Dexterity) - myPlayer._pBaseDex);
+	ModifyPlrVit(myPlayer, myPlayer.GetMaximumAttributeValue(CharacterAttribute::Vitality) - myPlayer._pBaseVit);
+	return "Set all character base attributes to maximum.";
+}
+
+std::string DebugCmdMinStats()
+{
+	Player &myPlayer = *MyPlayer;
+	ModifyPlrStr(myPlayer, -myPlayer._pBaseStr);
+	ModifyPlrMag(myPlayer, -myPlayer._pBaseMag);
+	ModifyPlrDex(myPlayer, -myPlayer._pBaseDex);
+	ModifyPlrVit(myPlayer, -myPlayer._pBaseVit);
+	return "Set all character base attributes to minimum.";
+}
+
+std::string DebugCmdGiveGoldCheat(int goldToAdd = GOLD_MAX_LIMIT * InventoryGridCells)
+{
+	if (goldToAdd <= 0) return "amount must be positive";
+	Player &myPlayer = *MyPlayer;
+	const int goldAmountBefore = myPlayer._pGold;
+	for (int8_t &itemIndex : myPlayer.InvGrid) {
+		if (itemIndex < 0)
+			continue;
+
+		Item &item = myPlayer.InvList[itemIndex != 0 ? itemIndex - 1 : myPlayer._pNumInv];
+
+		if (itemIndex != 0) {
+			if ((!item.isGold() && !item.isEmpty()) || (item.isGold() && item._ivalue == GOLD_MAX_LIMIT))
+				continue;
+		} else {
+			if (item.isEmpty()) {
+				MakeGoldStack(item, 0);
+				myPlayer._pNumInv++;
+				itemIndex = myPlayer._pNumInv;
+			}
+		}
+
+		int goldThatCanBeAdded = (GOLD_MAX_LIMIT - item._ivalue);
+		if (goldThatCanBeAdded >= goldToAdd) {
+			item._ivalue += goldToAdd;
+			myPlayer._pGold += goldToAdd;
+			break;
+		}
+
+		item._ivalue += goldThatCanBeAdded;
+		goldToAdd -= goldThatCanBeAdded;
+		myPlayer._pGold += goldThatCanBeAdded;
+	}
+
+	CalcPlrInv(myPlayer, true);
+
+	return StrCat("Set your gold to ", myPlayer._pGold, ", added ", myPlayer._pGold - goldAmountBefore, ".");
+}
+
+std::string DebugCmdTakeGoldCheat(int goldToRemove = GOLD_MAX_LIMIT * InventoryGridCells)
+{
+	Player &myPlayer = *MyPlayer;
+	if (goldToRemove <= 0) return "amount must be positive";
+
+	const int goldAmountBefore = myPlayer._pGold;
+	for (auto itemIndex : myPlayer.InvGrid) {
+		itemIndex -= 1;
+
+		if (itemIndex < 0)
+			continue;
+
+		Item &item = myPlayer.InvList[itemIndex];
+		if (!item.isGold())
+			continue;
+
+		if (item._ivalue >= goldToRemove) {
+			myPlayer._pGold -= goldToRemove;
+			item._ivalue -= goldToRemove;
+			if (item._ivalue == 0)
+				myPlayer.RemoveInvItem(itemIndex);
+			break;
+		}
+
+		myPlayer._pGold -= item._ivalue;
+		goldToRemove -= item._ivalue;
+		myPlayer.RemoveInvItem(itemIndex);
+	}
+
+	return StrCat("Set your gold to ", myPlayer._pGold, ", removed ", goldAmountBefore - myPlayer._pGold, ".");
+}
+
+std::string DebugCmdSetSpellsLevel(uint8_t level)
+{
+	for (uint8_t i = static_cast<uint8_t>(SpellID::Firebolt); i < MAX_SPELLS; i++) {
+		if (GetSpellBookLevel(static_cast<SpellID>(i)) != -1) {
+			NetSendCmdParam2(true, CMD_CHANGE_SPELL_LEVEL, i, level);
+		}
+	}
+	if (level == 0)
+		MyPlayer->_pMemSpells = 0;
+
+	return StrCat("Set all spell levels to ", level);
+}
+
+std::string DebugCmdMapReveal()
+{
+	for (int x = 0; x < DMAXX; x++)
+		for (int y = 0; y < DMAXY; y++)
+			UpdateAutomapExplorer({ x, y }, MAP_EXP_SHRINE);
+	return "Automap fully explored.";
+}
+
+std::string DebugCmdMapHide()
+{
+	for (int x = 0; x < DMAXX; x++)
+		for (int y = 0; y < DMAXY; y++)
+			AutomapView[x][y] = MAP_EXP_NONE;
+	return "Automap exploration removed.";
+}
+
+} // namespace
+
+sol::table LuaDevModule(sol::state_view &lua)
+{
+	sol::table table = lua.create_table();
+	SetWithSignatureAndDoc(table, "grid", "()",
+	    "Toggles showing grid.", &DebugCmdShowGrid);
+	SetWithSignatureAndDoc(table, "giveGold", "(amount: number = MAX)",
+	    "Gives the player gold.",
+	    sol::overload(
+	        []() { return DebugCmdGiveGoldCheat(); },
+	        [](int amount) { return DebugCmdGiveGoldCheat(amount); }));
+	SetWithSignatureAndDoc(table, "giveLvl", "(amount: number = 1)",
+	    "Levels the player up.",
+	    sol::overload(
+	        []() { return DebugCmdLevelUp(); },
+	        [](int amount) { return DebugCmdLevelUp(amount); }));
+	SetWithSignatureAndDoc(table, "giveMap", "()",
+	    "Reveal the map.",
+	    &DebugCmdMapReveal);
+	SetWithSignatureAndDoc(table, "quests", "",
+	    "Quest-related commands.",
+	    LuaDevQuestsModule(lua));
+	SetWithSignatureAndDoc(table, "takeGold", "(amount: number = MAX)",
+	    "Takes the player's gold away.",
+	    sol::overload(
+	        []() { return DebugCmdTakeGoldCheat(); },
+	        [](int amount) { return DebugCmdTakeGoldCheat(amount); }));
+	SetWithSignatureAndDoc(table, "takeMap", "()",
+	    "Hide the map.",
+	    &DebugCmdMapHide);
+	SetWithSignatureAndDoc(table, "maxStats", "()",
+	    "Sets all stat values to maximum.",
+	    &DebugCmdMaxStats);
+	SetWithSignatureAndDoc(table, "minStats", "()",
+	    "Sets all stat values to minimum.",
+	    &DebugCmdMinStats);
+	SetWithSignatureAndDoc(table, "setSpells", "(level: number)",
+	    "Set spell level for all spells.", &DebugCmdSetSpellsLevel);
+	return table;
+}
+
+} // namespace devilution
+#endif // _DEBUG

--- a/Source/lua/modules/dev.hpp
+++ b/Source/lua/modules/dev.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#ifdef _DEBUG
+#include <sol/sol.hpp>
+
+namespace devilution {
+
+sol::table LuaDevModule(sol::state_view &lua);
+
+} // namespace devilution
+#endif // _DEBUG

--- a/Source/lua/modules/dev/quests.cpp
+++ b/Source/lua/modules/dev/quests.cpp
@@ -1,0 +1,78 @@
+#pragma once
+#ifdef _DEBUG
+#include "lua/modules/dev/quests.hpp"
+
+#include <sol/sol.hpp>
+
+#include "lua/metadoc.hpp"
+#include "quests.h"
+#include "utils/str_cat.hpp"
+
+namespace devilution {
+namespace {
+
+std::string DebugCmdEnableQuest(uint8_t questId)
+{
+	if (questId >= MAXQUESTS) return StrCat("Quest ", questId, " does not exist!");
+	Quest &quest = Quests[questId];
+
+	if (IsNoneOf(quest._qactive, QUEST_NOTAVAIL, QUEST_INIT))
+		return StrCat(QuestsData[questId]._qlstr, " is already active!");
+
+	quest._qactive = QUEST_ACTIVE;
+	quest._qlog = true;
+
+	return StrCat(QuestsData[questId]._qlstr, " activated.");
+}
+
+std::string DebugCmdEnableQuests()
+{
+	for (Quest &quest : Quests) {
+		if (IsNoneOf(quest._qactive, QUEST_NOTAVAIL, QUEST_INIT)) continue;
+		quest._qactive = QUEST_ACTIVE;
+		quest._qlog = true;
+	}
+	return StrCat("Activated all quests.");
+}
+
+std::string DebugCmdQuestInfo(const uint8_t questId)
+{
+	if (questId >= MAXQUESTS) return StrCat("Quest ", questId, " does not exist!");
+	const Quest &quest = Quests[questId];
+	return StrCat("Quest id=", quest._qidx, " ", QuestsData[quest._qidx]._qlstr,
+	    " active=", quest._qactive, " var1=", quest._qvar1, " var2=", quest._qvar2);
+}
+
+std::string DebugCmdQuestsInfo()
+{
+	std::string ret;
+	for (const Quest &quest : Quests) {
+		StrAppend(ret, "Quest id=", quest._qidx, " ", QuestsData[quest._qidx]._qlstr,
+		    " active=", quest._qactive, " var1=", quest._qvar1, " var2=", quest._qvar2, "\n");
+	}
+	if (!ret.empty()) ret.pop_back();
+	return ret;
+}
+
+} // namespace
+
+sol::table LuaDevQuestsModule(sol::state_view &lua)
+{
+	sol::table table = lua.create_table();
+	SetWithSignatureAndDoc(table, "activate", "(id: number)",
+	    "Activates the given quest.",
+	    &DebugCmdEnableQuest);
+	SetWithSignatureAndDoc(table, "activateAll", "()",
+	    "Activates all available quests.",
+	    &DebugCmdEnableQuests);
+	SetWithSignatureAndDoc(table, "info", "(id: number)",
+	    "Information on the given quest.",
+	    &DebugCmdQuestInfo);
+	SetWithSignatureAndDoc(table, "all", "()",
+	    "Information on all available quest.",
+	    &DebugCmdQuestsInfo);
+	return table;
+}
+
+} // namespace devilution
+#endif // _DEBUG

--- a/Source/lua/modules/dev/quests.hpp
+++ b/Source/lua/modules/dev/quests.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#ifdef _DEBUG
+#include <sol/sol.hpp>
+
+namespace devilution {
+
+sol::table LuaDevQuestsModule(sol::state_view &lua);
+
+} // namespace devilution
+#endif // _DEBUG


### PR DESCRIPTION
Introduces a new `devilutionx.dev` Lua module, automatically loaded in the console prelude.

Arguments and basic help are shown in autocompletion.

![lua-dev-all](https://github.com/diasurgical/devilutionX/assets/216339/2ee30ae0-693b-4c37-870a-ac25aa1399c6)

We can now also group commands, as seen here with `quests`:

![lua-dev-quests](https://github.com/diasurgical/devilutionX/assets/216339/f4d715e8-da9a-4f8f-89b7-3280a800d638)

Signatures and docstrings are implemented as a bit of a hack:

```lua
> inspect(dev.quests)
{
  __doc_activate = "Activates the given quest.",
  __doc_activateAll = "Activates all available quests.",
  __doc_all = "Information on all available quest.",
  __doc_info = "Information on the given quest.",
  __sig_activate = "(id: number)",
  __sig_activateAll = "()",
  __sig_all = "()",
  __sig_info = "(id: number)",
  activate = <function 1>,
  activateAll = <function 2>,
  all = <function 3>,
  info = <function 4>
}
```

We simply put them on the same table as the functions. Autocomplete doesn't show the keys starting with `__` unless the query starts with `__`.