### PR TITLE
Clean up warnings and debugger errors related to the Lua console

### DIFF
--- a/Source/lua/lua.cpp
+++ b/Source/lua/lua.cpp
@@ -20,6 +20,7 @@
 
 #ifdef _DEBUG
 #include "lua/modules/dev.hpp"
+#include "lua/repl.hpp"
 #endif
 
 namespace devilution {
@@ -252,6 +253,9 @@ void LuaInitialize()
 
 void LuaShutdown()
 {
+#ifdef _DEBUG
+	LuaReplShutdown();
+#endif
 	CurrentLuaState = std::nullopt;
 }
 

--- a/Source/lua/modules/dev/quests.cpp
+++ b/Source/lua/modules/dev/quests.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #ifdef _DEBUG
 #include "lua/modules/dev/quests.hpp"
 

--- a/Source/lua/repl.cpp
+++ b/Source/lua/repl.cpp
@@ -48,7 +48,6 @@ int LuaPrintToConsole(lua_State *state)
 
 void CreateReplEnvironment()
 {
-	sol::state &lua = GetLuaState();
 	sol::environment env = CreateLuaSandbox();
 	env["print"] = LuaPrintToConsole;
 	lua_setwarnf(env.lua_state(), LuaConsoleWarn, /*ud=*/nullptr);
@@ -101,6 +100,11 @@ tl::expected<std::string, std::string> RunLuaReplLine(std::string_view code)
 		return std::string {};
 	}
 	return sol::utility::to_string(sol::stack_object(result));
+}
+
+void LuaReplShutdown()
+{
+	replEnv = std::nullopt;
 }
 
 } // namespace devilution

--- a/Source/lua/repl.hpp
+++ b/Source/lua/repl.hpp
@@ -13,5 +13,7 @@ tl::expected<std::string, std::string> RunLuaReplLine(std::string_view code);
 
 sol::environment &GetLuaReplEnvironment();
 
+void LuaReplShutdown();
+
 } // namespace devilution
 #endif // _DEBUG


### PR DESCRIPTION
MSVC debugger was stopping on an access violation whenever I quit game after opening the Lua console so I decided to track it down. Turns out it was because we were explicitly destroying the Lua state in `LuaShutdown()`, but letting the `replEnv` get reclaimed automatically later. `replEnv` naturally depends on the Lua state, hence the access violation.

I also fixed the following warnings from the Linux build. The second one only happens in debug builds.

```
/home/runner/work/devilutionX/devilutionX/Source/lua/modules/dev/quests.cpp:1:9: warning: #pragma once in main file
    1 | #pragma once
      |         ^~~~
```

```
/home/runner/work/devilutionX/devilutionX/Source/lua/repl.cpp:51:21: warning: unused variable ‘lua’ [-Wunused-variable]
   51 |         sol::state &lua = GetLuaState();
      |                     ^~~
```