### PR TITLE
Lua: Show signatures of native (non-C) functions

### DIFF
--- a/CMake/Assets.cmake
+++ b/CMake/Assets.cmake
@@ -140,6 +140,7 @@ set(devilutionx_assets
   levels/l2data/bonechat.dun
   levels/towndata/automap.dun
   levels/towndata/automap.amp
+  lua_internal/get_lua_function_signature.lua
   lua/init.lua
   lua/inspect.lua
   lua/repl_prelude.lua

--- a/Packaging/resources/assets/lua_internal/get_lua_function_signature.lua
+++ b/Packaging/resources/assets/lua_internal/get_lua_function_signature.lua
@@ -1,0 +1,41 @@
+-- Gets the signature of native (non-C) Lua function
+-- Based on https://stackoverflow.com/a/24216007/181228
+
+local function getlocals(l)
+  local i = 0
+  local direction = 1
+  return function()
+    i = i + direction
+    local k, v = debug.getlocal(l, i)
+    if (direction == 1 and (k == nil or k.sub(k, 1, 1) == '(')) then
+      i = -1
+      direction = -1
+      k, v = debug.getlocal(l, i)
+    end
+    return k, v
+  end
+end
+
+local function dumpsig(f)
+  assert(type(f) == 'function', "bad argument #1 to 'dumpsig' (function expected)")
+  local p = {}
+  pcall(function()
+    local oldhook
+    local hook = function(event, line)
+      for k, v in getlocals(3) do
+        if k == "(*vararg)" then
+          table.insert(p, "...")
+          break
+        end
+        table.insert(p, k)
+      end
+      debug.sethook(oldhook)
+      error('aborting the call')
+    end
+    oldhook = debug.sethook(hook, "c")
+    f(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20)
+  end)
+  return "(" .. table.concat(p, ", ") .. ")"
+end
+
+return dumpsig

--- a/Source/lua/lua.hpp
+++ b/Source/lua/lua.hpp
@@ -12,5 +12,6 @@ void LuaShutdown();
 void LuaEvent(std::string_view name);
 sol::state &GetLuaState();
 sol::environment CreateLuaSandbox();
+sol::object SafeCallResult(sol::protected_function_result result, bool optional);
 
 } // namespace devilution


### PR DESCRIPTION
This way we at least get something even if the function is not explicitly documented:

![screenshot](https://github.com/diasurgical/devilutionX/assets/216339/48dd4cb3-eb72-4312-aa8f-a79d9df10fd5)
