### PR TITLE
Console input: Word-wrap-related cursor fixes

### DIFF
--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -235,11 +235,6 @@ void DrawFont(const Surface &out, Point position, ClxSprite glyph, text_color co
 	}
 }
 
-bool IsWhitespace(char32_t c)
-{
-	return IsAnyOf(c, U' ', U'　', ZWSP);
-}
-
 bool IsFullWidthPunct(char32_t c)
 {
 	return IsAnyOf(c, U'，', U'、', U'。', U'？', U'！');
@@ -641,7 +636,7 @@ std::string WordWrapString(std::string_view text, unsigned width, GameFontTables
 			lineWidth += (*currentFont.sprite)[frame].width() + spacing;
 		}
 
-		if (IsWhitespace(codepoint)) {
+		if (IsBreakableWhitespace(codepoint)) {
 			lastBreakablePos = remaining.data() - begin - codepointLen;
 			lastBreakableLen = codepointLen;
 			continue;
@@ -831,6 +826,11 @@ void DrawStringWithColors(const Surface &out, std::string_view fmt, DrawStringFo
 uint8_t PentSpn2Spin()
 {
 	return (SDL_GetTicks() / 50) % 8;
+}
+
+bool IsBreakableWhitespace(char32_t c)
+{
+	return IsAnyOf(c, U' ', U'　', ZWSP);
 }
 
 } // namespace devilution

--- a/Source/engine/render/text_render.hpp
+++ b/Source/engine/render/text_render.hpp
@@ -262,4 +262,7 @@ inline void DrawStringWithColors(const Surface &out, std::string_view fmt, std::
 uint8_t PentSpn2Spin();
 void UnloadFonts();
 
+/** @brief Whether this character can be substituted by a newline when word-wrapping. */
+bool IsBreakableWhitespace(char32_t c);
+
 } // namespace devilution


### PR DESCRIPTION
1. Handle word breaks in the prompt, e.g. `"> " -> ">\n"`.
2. Handle word breaks in the original newline for all whitespace, not just `"\n"`.