### PR TITLE
Fix MSVC warnings from headers

### DIFF
--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -401,11 +401,12 @@ void UiSettingsMenu()
 				if (selectedOption == pEntry)
 					itemToSelect = vecDialogItems.size();
 				auto formatArgs = CreateDrawStringFormatArgForEntry(pEntry);
+				int optionId = static_cast<int>(vecOptions.size());
 				if (NeedsTwoLinesToDisplayOption(formatArgs)) {
-					vecDialogItems.push_back(std::make_unique<UiListItem>("{}:", formatArgs, vecOptions.size(), UiFlags::ColorUiGold | UiFlags::NeedsNextElement));
-					vecDialogItems.push_back(std::make_unique<UiListItem>(pEntry->GetValueDescription(), vecOptions.size(), UiFlags::ColorUiSilver | UiFlags::ElementDisabled));
+					vecDialogItems.push_back(std::make_unique<UiListItem>("{}:", formatArgs, optionId, UiFlags::ColorUiGold | UiFlags::NeedsNextElement));
+					vecDialogItems.push_back(std::make_unique<UiListItem>(pEntry->GetValueDescription(), optionId, UiFlags::ColorUiSilver | UiFlags::ElementDisabled));
 				} else {
-					vecDialogItems.push_back(std::make_unique<UiListItem>("{}: {}", formatArgs, vecOptions.size(), UiFlags::ColorUiGold));
+					vecDialogItems.push_back(std::make_unique<UiListItem>("{}: {}", formatArgs, optionId, UiFlags::ColorUiGold));
 				}
 				vecOptions.push_back(pEntry);
 			}
@@ -413,7 +414,7 @@ void UiSettingsMenu()
 		case ShownMenuType::ListOption: {
 			auto *pOptionList = static_cast<OptionEntryListBase *>(selectedOption);
 			for (size_t i = 0; i < pOptionList->GetListSize(); i++) {
-				vecDialogItems.push_back(std::make_unique<UiListItem>(pOptionList->GetListDescription(i), i, UiFlags::ColorUiGold));
+				vecDialogItems.push_back(std::make_unique<UiListItem>(pOptionList->GetListDescription(i), static_cast<int>(i), UiFlags::ColorUiGold));
 			}
 			itemToSelect = pOptionList->GetActiveListIndex();
 			UpdateDescription(*pOptionList);

--- a/Source/engine/actor_position.cpp
+++ b/Source/engine/actor_position.cpp
@@ -108,9 +108,7 @@ constexpr std::array<const WalkParameter, 8> WalkParameters { {
 DisplacementOf<int8_t> ActorPosition::CalculateWalkingOffset(Direction dir, const AnimationInfo &animInfo) const
 {
 	DisplacementOf<int16_t> offset = CalculateWalkingOffsetShifted4(dir, animInfo);
-	offset.deltaX >>= 4;
-	offset.deltaY >>= 4;
-	return offset;
+	return { static_cast<int8_t>(offset.deltaX >> 4), static_cast<int8_t>(offset.deltaY >> 4) };
 }
 
 DisplacementOf<int16_t> ActorPosition::CalculateWalkingOffsetShifted4(Direction dir, const AnimationInfo &animInfo) const

--- a/Source/engine/displacement.hpp
+++ b/Source/engine/displacement.hpp
@@ -131,7 +131,7 @@ struct DisplacementOf {
 		assert(deltaX * deltaX + deltaY * deltaY < (1 << 24));
 
 		// We do not use `std::hypot` here because it is slower and we do not need the extra precision.
-		return sqrtf(deltaX * deltaX + deltaY * deltaY);
+		return sqrtf(static_cast<float>(deltaX * deltaX + deltaY * deltaY));
 	}
 
 	/**

--- a/Source/engine/load_file.hpp
+++ b/Source/engine/load_file.hpp
@@ -123,7 +123,7 @@ struct MultiFileLoader {
 			totalSize += size;
 			++j;
 		}
-		outOffsets[files.size()] = totalSize;
+		outOffsets[files.size()] = static_cast<uint32_t>(totalSize);
 		std::unique_ptr<std::byte[]> buf { new std::byte[totalSize] };
 		for (size_t i = 0, j = 0; i < numFiles; ++i) {
 			if (!filterFn(i))

--- a/Source/utils/clx_encode.hpp
+++ b/Source/utils/clx_encode.hpp
@@ -61,7 +61,7 @@ inline void AppendClxPixelsOrFillRun(const uint8_t *src, unsigned length, std::v
 			// 3 appears to be optimal for most of our data (much better than 2, rarely very slightly worse than 4).
 			constexpr unsigned MinFillRunLength = 3;
 			if (prevColorRunLength >= MinFillRunLength) {
-				AppendClxPixelsRun(begin, prevColorBegin - begin, out);
+				AppendClxPixelsRun(begin, static_cast<unsigned>(prevColorBegin - begin), out);
 				AppendClxFillRun(prevColor, prevColorRunLength, out);
 				begin = src;
 			}
@@ -76,10 +76,10 @@ inline void AppendClxPixelsOrFillRun(const uint8_t *src, unsigned length, std::v
 	// is followed by transparent pixels.
 	// Width=2 Fill command takes 2 bytes, while the Pixels command is 3 bytes.
 	if (prevColorRunLength >= 2) {
-		AppendClxPixelsRun(begin, prevColorBegin - begin, out);
+		AppendClxPixelsRun(begin, static_cast<unsigned>(prevColorBegin - begin), out);
 		AppendClxFillRun(prevColor, prevColorRunLength, out);
 	} else {
-		AppendClxPixelsRun(begin, prevColorBegin - begin + prevColorRunLength, out);
+		AppendClxPixelsRun(begin, static_cast<unsigned>(prevColorBegin - begin + prevColorRunLength), out);
 	}
 }
 

--- a/Source/utils/str_cat.cpp
+++ b/Source/utils/str_cat.cpp
@@ -4,14 +4,25 @@
 
 namespace devilution {
 
-char *BufCopy(char *out, int value)
+char *BufCopy(char *out, long long value)
+{
+	const fmt::format_int formatted { value };
+	std::memcpy(out, formatted.data(), formatted.size());
+	return out + formatted.size();
+}
+char *BufCopy(char *out, unsigned long long value)
 {
 	const fmt::format_int formatted { value };
 	std::memcpy(out, formatted.data(), formatted.size());
 	return out + formatted.size();
 }
 
-void StrAppend(std::string &out, int value)
+void StrAppend(std::string &out, long long value)
+{
+	const fmt::format_int formatted { value };
+	out.append(formatted.data(), formatted.size());
+}
+void StrAppend(std::string &out, unsigned long long value)
 {
 	const fmt::format_int formatted { value };
 	out.append(formatted.data(), formatted.size());

--- a/Source/utils/str_cat.hpp
+++ b/Source/utils/str_cat.hpp
@@ -11,12 +11,71 @@ namespace devilution {
  * @brief Writes the integer to the given buffer.
  * @return char* end of the buffer
  */
-char *BufCopy(char *out, int value);
+char *BufCopy(char *out, long long value);
+inline char *BufCopy(char *out, long value)
+{
+	return BufCopy(out, static_cast<long long>(value));
+}
+inline char *BufCopy(char *out, int value)
+{
+	return BufCopy(out, static_cast<long long>(value));
+}
+inline char *BufCopy(char *out, short value)
+{
+	return BufCopy(out, static_cast<long long>(value));
+}
+
+/**
+ * @brief Writes the integer to the given buffer.
+ * @return char* end of the buffer
+ */
+char *BufCopy(char *out, unsigned long long value);
+inline char *BufCopy(char *out, unsigned long value)
+{
+	return BufCopy(out, static_cast<unsigned long long>(value));
+}
+inline char *BufCopy(char *out, unsigned int value)
+{
+	return BufCopy(out, static_cast<unsigned long long>(value));
+}
+inline char *BufCopy(char *out, unsigned short value)
+{
+	return BufCopy(out, static_cast<unsigned long long>(value));
+}
 
 /**
  * @brief Appends the integer to the given string.
  */
-void StrAppend(std::string &out, int value);
+void StrAppend(std::string &out, long long value);
+inline void StrAppend(std::string &out, long value)
+{
+	StrAppend(out, static_cast<long long>(value));
+}
+inline void StrAppend(std::string &out, int value)
+{
+	StrAppend(out, static_cast<long long>(value));
+}
+inline void StrAppend(std::string &out, short value)
+{
+	StrAppend(out, static_cast<long long>(value));
+}
+
+/**
+ * @brief Appends the integer to the given string.
+ */
+void StrAppend(std::string &out, unsigned long long value);
+inline void StrAppend(std::string &out, unsigned long value)
+{
+	StrAppend(out, static_cast<unsigned long long>(value));
+}
+inline void StrAppend(std::string &out, unsigned int value)
+{
+	StrAppend(out, static_cast<unsigned long long>(value));
+}
+inline void StrAppend(std::string &out, unsigned short value)
+{
+	StrAppend(out, static_cast<unsigned long long>(value));
+}
 
 /**
  * @brief Copies the given std::string_view to the given buffer.

--- a/test/player_test.h
+++ b/test/player_test.h
@@ -10,22 +10,22 @@
 
 using namespace devilution;
 
-static int CountItems(Item *items, int n)
+static size_t CountItems(Item *items, int n)
 {
 	return std::count_if(items, items + n, [](Item x) { return !x.isEmpty(); });
 }
 
-static int Count8(int8_t *ints, int n)
+static size_t Count8(int8_t *ints, int n)
 {
 	return std::count_if(ints, ints + n, [](int8_t x) { return x != 0; });
 }
 
-static int CountU8(uint8_t *ints, int n)
+static size_t CountU8(uint8_t *ints, int n)
 {
 	return std::count_if(ints, ints + n, [](uint8_t x) { return x != 0; });
 }
 
-static int CountBool(bool *bools, int n)
+static size_t CountBool(bool *bools, int n)
 {
 	return std::count_if(bools, bools + n, [](bool x) { return x; });
 }


### PR DESCRIPTION
This PR removes all warnings that originate from header files (.h/.hpp) or are related to them.

Reduces warnings by 31 (from 386 to 355).