### PR TITLE
Fix MSVC warnings in engine\render\*

### DIFF
--- a/Source/engine/render/clx_render.cpp
+++ b/Source/engine/render/clx_render.cpp
@@ -441,7 +441,7 @@ const uint8_t *RenderClxOutlineRowClipped( // NOLINT(readability-function-cognit
 			return SkipRestOfLineWithOverrun(src, static_cast<int_fast16_t>(srcWidth), skipSize);
 		}
 	}
-	skipSize = GetSkipSize(remainingWidth, srcWidth);
+	skipSize = GetSkipSize(remainingWidth, static_cast<int_fast16_t>(srcWidth));
 
 	return src;
 }

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1123,8 +1123,8 @@ void DrawView(const Surface &out, Point startPosition)
 						int steps = std::abs(dx) > std::abs(dy) ? std::abs(dx) : std::abs(dy);
 						float ix = dx / (float)steps;
 						float iy = dy / (float)steps;
-						float sx = from.x;
-						float sy = from.y;
+						float sx = static_cast<float>(from.x);
+						float sy = static_cast<float>(from.y);
 
 						for (int i = 0; i <= steps; i++, sx += ix, sy += iy)
 							out.SetPixel({ (int)sx, (int)sy }, col);

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -469,7 +469,7 @@ uint32_t DoDrawString(const Surface &out, std::string_view text, Rectangle rect,
 		characterPosition.x += width + opts.spacing;
 	}
 	maybeDrawCursor();
-	return remaining.data() - text.data();
+	return static_cast<uint32_t>(remaining.data() - text.data());
 }
 
 } // namespace
@@ -699,7 +699,7 @@ uint32_t DrawString(const Surface &out, std::string_view text, const Rectangle &
 		opts.lineHeight = GetLineHeight(text, size);
 
 	if (HasAnyOf(opts.flags, UiFlags::VerticalCenter)) {
-		const int textHeight = (c_count(text, '\n') + 1) * opts.lineHeight;
+		const int textHeight = static_cast<int>((c_count(text, '\n') + 1) * opts.lineHeight);
 		characterPosition.y += std::max(0, (rect.size.height - textHeight) / 2);
 	}
 
@@ -750,7 +750,7 @@ void DrawStringWithColors(const Surface &out, std::string_view fmt, DrawStringFo
 		opts.lineHeight = GetLineHeight(fmt, args, argsLen, size);
 
 	if (HasAnyOf(opts.flags, UiFlags::VerticalCenter)) {
-		int textHeight = (CountNewlines(fmt, args, argsLen) + 1) * opts.lineHeight;
+		const int textHeight = static_cast<int>((CountNewlines(fmt, args, argsLen) + 1) * opts.lineHeight);
 		characterPosition.y += std::max(0, (rect.size.height - textHeight) / 2);
 	}
 


### PR DESCRIPTION
Reduces warnings by 7 (from 355 to 348)