### PR TITLE
Fix MSVC warnings in utils\*

### DIFF
--- a/Source/utils/cel_to_clx.cpp
+++ b/Source/utils/cel_to_clx.cpp
@@ -62,7 +62,7 @@ OwnedClxSpriteListOrSheet CelToClx(const uint8_t *data, size_t size, PointerOrVa
 			numFrames = maybeNumFrames;
 		} else {
 			numFrames = LoadLE32(data);
-			WriteLE32(&cl2Data[4 * group], cl2Data.size());
+			WriteLE32(&cl2Data[4 * group], static_cast<uint32_t>(cl2Data.size()));
 		}
 
 		// CL2 header: frame count, frame offset for each frame, file size
@@ -110,7 +110,7 @@ OwnedClxSpriteListOrSheet CelToClx(const uint8_t *data, size_t size, PointerOrVa
 				}
 				++frameHeight;
 			}
-			WriteLE16(&cl2Data[frameHeaderPos + 4], frameHeight);
+			WriteLE16(&cl2Data[frameHeaderPos + 4], static_cast<uint16_t>(frameHeight));
 			memset(&cl2Data[frameHeaderPos + 6], 0, 4);
 			AppendClxTransparentRun(transparentRunWidth, cl2Data);
 		}

--- a/Source/utils/cl2_to_clx.cpp
+++ b/Source/utils/cl2_to_clx.cpp
@@ -55,7 +55,7 @@ uint16_t Cl2ToClx(const uint8_t *data, size_t size,
 		} else {
 			groupBegin = &data[LoadLE32(&data[group * 4])];
 			numFrames = LoadLE32(groupBegin);
-			WriteLE32(&clxData[4 * group], clxData.size());
+			WriteLE32(&clxData[4 * group], static_cast<uint32_t>(clxData.size()));
 		}
 
 		// CLX header: frame count, frame offset for each frame, file size
@@ -126,7 +126,7 @@ uint16_t Cl2ToClx(const uint8_t *data, size_t size,
 			}
 			AppendClxTransparentRun(transparentRunWidth, clxData);
 
-			WriteLE16(&clxData[frameHeaderPos + 4], frameHeight);
+			WriteLE16(&clxData[frameHeaderPos + 4], static_cast<uint16_t>(frameHeight));
 			memset(&clxData[frameHeaderPos + 6], 0, 4);
 		}
 

--- a/Source/utils/clx_encode.hpp
+++ b/Source/utils/clx_encode.hpp
@@ -46,7 +46,7 @@ inline void AppendClxPixelsRun(const uint8_t *src, unsigned width, std::vector<u
 		out.push_back(src[i]);
 }
 
-inline void AppendClxPixelsOrFillRun(const uint8_t *src, unsigned length, std::vector<uint8_t> &out)
+inline void AppendClxPixelsOrFillRun(const uint8_t *src, size_t length, std::vector<uint8_t> &out)
 {
 	const uint8_t *begin = src;
 	const uint8_t *prevColorBegin = src;

--- a/Source/utils/file_util.cpp
+++ b/Source/utils/file_util.cpp
@@ -53,11 +53,11 @@ namespace devilution {
 std::unique_ptr<wchar_t[]> ToWideChar(std::string_view path)
 {
 	constexpr std::uint32_t flags = MB_ERR_INVALID_CHARS;
-	const int utf16Size = ::MultiByteToWideChar(CP_UTF8, flags, path.data(), path.size(), nullptr, 0);
+	const int utf16Size = ::MultiByteToWideChar(CP_UTF8, flags, path.data(), static_cast<int>(path.size()), nullptr, 0);
 	if (utf16Size == 0)
 		return nullptr;
 	std::unique_ptr<wchar_t[]> utf16 { new wchar_t[utf16Size + 1] };
-	if (::MultiByteToWideChar(CP_UTF8, flags, path.data(), path.size(), &utf16[0], utf16Size) != utf16Size)
+	if (::MultiByteToWideChar(CP_UTF8, flags, path.data(), static_cast<int>(path.size()), &utf16[0], utf16Size) != utf16Size)
 		return nullptr;
 	utf16[utf16Size] = L'\0';
 	return utf16;

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -496,7 +496,7 @@ void LanguageInitialize()
 			std::string_view value { valuePtr, dst[i].length + 1 };
 			for (size_t j = 0; j < PluralForms && !value.empty(); j++) {
 				const size_t formValueEnd = value.find('\0');
-				translation[j].emplace(keyPtr, EncodeTranslationRef(value.data() - &translationValues[0], formValueEnd));
+				translation[j].emplace(keyPtr, EncodeTranslationRef(static_cast<uint32_t>(value.data() - &translationValues[0]), static_cast<uint32_t>(formValueEnd)));
 				value.remove_prefix(formValueEnd + 1);
 			}
 

--- a/Source/utils/push_aulib_decoder.cpp
+++ b/Source/utils/push_aulib_decoder.cpp
@@ -18,13 +18,13 @@ namespace {
 
 float SampleToFloat(int16_t sample)
 {
-	constexpr float Factor = 1.0 / (std::numeric_limits<int16_t>::max() + 1);
+	constexpr float Factor = 1.0F / (std::numeric_limits<int16_t>::max() + 1);
 	return sample * Factor;
 }
 
 float SampleToFloat(uint8_t sample)
 {
-	constexpr float Factor = 2.0 / std::numeric_limits<uint8_t>::max();
+	constexpr float Factor = 2.0F / std::numeric_limits<uint8_t>::max();
 	return (sample * Factor) - 1;
 }
 

--- a/Source/utils/soundsample.cpp
+++ b/Source/utils/soundsample.cpp
@@ -140,7 +140,7 @@ int SoundSample::SetChunk(ArraySharedPtr<std::uint8_t> fileData, std::size_t dwB
 	isMp3_ = isMp3;
 	file_data_ = std::move(fileData);
 	file_data_size_ = dwBytes;
-	SDL_RWops *buf = SDL_RWFromConstMem(file_data_.get(), dwBytes);
+	SDL_RWops *buf = SDL_RWFromConstMem(file_data_.get(), static_cast<int>(dwBytes));
 	if (buf == nullptr) {
 		return -1;
 	}
@@ -170,7 +170,7 @@ int SoundSample::GetLength() const
 {
 	if (!stream_)
 		return 0;
-	return std::chrono::duration_cast<std::chrono::milliseconds>(stream_->duration()).count();
+	return static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(stream_->duration()).count());
 }
 
 } // namespace devilution


### PR DESCRIPTION
This reduces warnings by 14 (from 297 to 283)

There are some remaining warnings in utils left.
I'm not sure how to handle them the best way:

```
  [446/650] Building CXX object Source\CMakeFiles\libdevilutionx.dir\utils\console.cpp.obj
devilutionX\Source\utils\console.cpp(33): warning C4267: 'argument': conversion from 'size_t' to 'DWORD', possible loss of data

  [560/650] Building CXX object Source\CMakeFiles\libdevilutionx.dir\utils\file_util.cpp.obj
devilutionX\Source\utils\file_util.cpp(236): warning C4996: 'std::filesystem::u8path': warning STL4021: The std::filesystem::u8path() overloads are deprecated in C++20. The constructors of std::filesystem::path provide equivalent functionality via construction from u8string, u8string_view, or iterators with value_type char8_t. You can define _SILENCE_CXX20_U8PATH_DEPRECATION_WARNING or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to suppress this warning.
devilutionX\Source\utils\file_util.cpp(277): warning C4996: 'std::filesystem::u8path': warning STL4021: The std::filesystem::u8path() overloads are deprecated in C++20. The constructors of std::filesystem::path provide equivalent functionality via construction from u8string, u8string_view, or iterators with value_type char8_t. You can define _SILENCE_CXX20_U8PATH_DEPRECATION_WARNING or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to suppress this warning.
```