### PR TITLE
Go back to using int for missile frame comparison values

### DIFF
--- a/test/missiles_test.cpp
+++ b/test/missiles_test.cpp
@@ -11,7 +11,7 @@ using ::testing::Lt;
 using ::testing::Pair;
 using ::testing::UnorderedElementsAre;
 
-void TestArrowRotatesUniformly(Missile &missile, int startingFrame, unsigned leftFrame, unsigned rightFrame)
+void TestArrowRotatesUniformly(Missile &missile, int startingFrame, int leftFrame, int rightFrame)
 {
 	std::unordered_map<int, unsigned> observed {};
 	for (auto i = 0; i < 100; i++) {


### PR DESCRIPTION
The code that the gmock macros end up generating appears to obscure the type mismatch so there's no warning (in msvc on my system anyway) no matter what types are involved. For clarity the comparison ends up being between `std::pair<int, unsigned int>` and `testing::Pair<int, testing::AllOf<testing::Matchers<unsigned int>...>>`