### PR TITLE
Msg: Change OnXYZ to get a Player reference instead of a player index

### DIFF
--- a/Source/msg.h
+++ b/Source/msg.h
@@ -763,7 +763,7 @@ void NetSendCmdChBeltItem(bool bHiPri, int invGridIndex);
 void NetSendCmdDamage(bool bHiPri, uint8_t bPlr, uint32_t dwDam, DamageType damageType);
 void NetSendCmdMonDmg(bool bHiPri, uint16_t wMon, uint32_t dwDam);
 void NetSendCmdString(uint32_t pmask, const char *pszStr);
-void delta_close_portal(int pnum);
+void delta_close_portal(const Player &player);
 size_t ParseCmd(size_t pnum, const TCmd *pCmd);
 
 } // namespace devilution

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -241,10 +241,8 @@ void ParseTurn(size_t pnum, uint32_t turn)
 	}
 }
 
-void PlayerLeftMsg(int pnum, bool left)
+void PlayerLeftMsg(Player &player, bool left)
 {
-	Player &player = Players[pnum];
-
 	if (&player == InspectPlayer)
 		InspectPlayer = MyPlayer;
 
@@ -254,13 +252,13 @@ void PlayerLeftMsg(int pnum, bool left)
 		return;
 
 	FixPlrWalkTags(player);
-	RemovePortalMissile(pnum);
-	DeactivatePortal(pnum);
-	delta_close_portal(pnum);
+	RemovePortalMissile(player);
+	DeactivatePortal(player);
+	delta_close_portal(player);
 	RemovePlrMissiles(player);
 	if (left) {
 		std::string_view pszFmt = _("Player '{:s}' just left the game");
-		switch (sgdwPlayerLeftReasonTbl[pnum]) {
+		switch (sgdwPlayerLeftReasonTbl[player.getId()]) {
 		case LEAVE_ENDING:
 			pszFmt = _("Player '{:s}' killed Diablo and left the game!");
 			gbSomebodyWonGameKludge = true;
@@ -284,7 +282,7 @@ void ClearPlayerLeftState()
 			if (gbBufferMsgs == 1)
 				msg_send_drop_pkt(i, sgdwPlayerLeftReasonTbl[i]);
 			else
-				PlayerLeftMsg(i, true);
+				PlayerLeftMsg(Players[i], true);
 
 			sgbPlayerLeftGameTbl[i] = false;
 			sgdwPlayerLeftReasonTbl[i] = 0;
@@ -347,7 +345,7 @@ void ProcessTmsgs()
 	}
 }
 
-void SendPlayerInfo(int pnum, _cmd_id cmd)
+void SendPlayerInfo(size_t pnum, _cmd_id cmd)
 {
 	PlayerNetPack packed;
 	Player &myPlayer = *MyPlayer;
@@ -799,15 +797,14 @@ bool NetInit(bool bSinglePlayer)
 	return true;
 }
 
-void recv_plrinfo(int pnum, const TCmdPlrInfoHdr &header, bool recv)
+void recv_plrinfo(Player &player, const TCmdPlrInfoHdr &header, bool recv)
 {
 	static PlayerNetPack PackedPlayerBuffer[MAX_PLRS];
 
-	assert(pnum >= 0 && pnum < MAX_PLRS);
-	Player &player = Players[pnum];
 	if (&player == MyPlayer) {
 		return;
 	}
+	size_t pnum = player.getId();
 	auto &packedPlayer = PackedPlayerBuffer[pnum];
 
 	if (sgwPackPlrOffsetTbl[pnum] != SDL_SwapLE16(header.wOffset)) {
@@ -828,7 +825,7 @@ void recv_plrinfo(int pnum, const TCmdPlrInfoHdr &header, bool recv)
 	}
 	sgwPackPlrOffsetTbl[pnum] = 0;
 
-	PlayerLeftMsg(pnum, false);
+	PlayerLeftMsg(player, false);
 	if (!UnPackNetPlayer(packedPlayer, player)) {
 		player = {};
 		SNetDropPlayer(pnum, LEAVE_DROP);

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -14,6 +14,9 @@
 
 namespace devilution {
 
+// Defined in player.h, forward declared here to allow for functions which operate in the context of a player.
+struct Player;
+
 // must be unsigned to generate unsigned comparisons with pnum
 #define MAX_PLRS 4
 
@@ -71,6 +74,6 @@ void multi_process_network_packets();
 void multi_send_zero_packet(size_t pnum, _cmd_id bCmd, const std::byte *data, size_t size);
 void NetClose();
 bool NetInit(bool bSinglePlayer);
-void recv_plrinfo(int pnum, const TCmdPlrInfoHdr &header, bool recv);
+void recv_plrinfo(Player &player, const TCmdPlrInfoHdr &header, bool recv);
 
 } // namespace devilution

--- a/Source/portal.h
+++ b/Source/portal.h
@@ -10,6 +10,9 @@
 
 namespace devilution {
 
+// Defined in player.h, forward declared here to allow for functions which operate in the context of a player.
+struct Player;
+
 #define MAXPORTAL 4
 
 struct Portal {
@@ -24,13 +27,13 @@ extern Portal Portals[MAXPORTAL];
 
 void InitPortals();
 void SetPortalStats(int i, bool o, Point position, int lvl, dungeon_type lvltype, bool isSetLevel);
-void AddPortalMissile(int i, Point position, bool sync);
+void AddPortalMissile(const Player &player, Point position, bool sync);
 void SyncPortals();
-void AddPortalInTown(int i);
-void ActivatePortal(int i, Point position, int lvl, dungeon_type lvltype, bool sp);
-void DeactivatePortal(int i);
-bool PortalOnLevel(size_t i);
-void RemovePortalMissile(int id);
+void AddPortalInTown(const Player &player);
+void ActivatePortal(const Player &player, Point position, int lvl, dungeon_type lvltype, bool sp);
+void DeactivatePortal(const Player &player);
+bool PortalOnLevel(const Player &player);
+void RemovePortalMissile(const Player &player);
 void SetCurrentPortal(size_t p);
 void GetPortalLevel();
 void GetPortalLvlPos();

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -234,13 +234,9 @@ void CastSpell(int id, SpellID spl, WorldTilePosition src, WorldTilePosition dst
 	}
 }
 
-void DoResurrect(size_t pnum, Player &target)
+void DoResurrect(Player &player, Player &target)
 {
-	if (pnum >= Players.size()) {
-		return;
-	}
-
-	AddMissile(target.position.tile, target.position.tile, Direction::South, MissileID::ResurrectBeam, TARGET_MONSTERS, pnum, 0, 0);
+	AddMissile(target.position.tile, target.position.tile, Direction::South, MissileID::ResurrectBeam, TARGET_MONSTERS, player.getId(), 0, 0);
 
 	if (target._pHitPoints != 0)
 		return;

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -41,7 +41,7 @@ void CastSpell(int id, SpellID spl, WorldTilePosition src, WorldTilePosition dst
  * @param pnum player index
  * @param rid target player index
  */
-void DoResurrect(size_t pnum, Player &target);
+void DoResurrect(Player &player, Player &target);
 void DoHealOther(const Player &caster, Player &target);
 int GetSpellBookLevel(SpellID s);
 int GetSpellStaffLevel(SpellID s);


### PR DESCRIPTION
Contributes to #2435 by removing access to `Players` and uses Player reference instead of player indexes in Msg.cpp and some related functions.

This PR reduces warnings by 48 (from 294 to 246).