### PR TITLE
Fix MSVC warnings in utils\*

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   add_link_options("$<$<BOOL:${DEVILUTIONX_PROFILE_DIR}>:-fprofile-dir=${DEVILUTIONX_PROFILE_DIR};-fprofile-prefix-path=${CMAKE_CURRENT_BINARY_DIR}>")
 endif()
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  # u8path() function is deprecated but there is no sensible alternative and it might even get un-deprecated.
+  add_definitions(-D_SILENCE_CXX20_U8PATH_DEPRECATION_WARNING)
+endif()
+
 # Not a genexp because CMake doesn't support it
 # https://gitlab.kitware.com/cmake/cmake/-/issues/20546
 if(NOT DISABLE_LTO)

--- a/Source/utils/console.cpp
+++ b/Source/utils/console.cpp
@@ -30,7 +30,7 @@ void WriteToStderr(std::string_view str)
 	HANDLE handle = GetStderrHandle();
 	if (handle == NULL)
 		return;
-	WriteConsole(handle, str.data(), str.size(), NULL, NULL);
+	WriteConsole(handle, str.data(), static_cast<DWORD>(str.size()), NULL, NULL);
 }
 
 } // namespace


### PR DESCRIPTION
Fixes remaining MSVC warnings in utils (see related [discussion](https://github.com/diasurgical/devilutionX/pull/6795#issuecomment-1802720618)).

I added `_SILENCE_CXX20_U8PATH_DEPRECATION_WARNING` to CMake, because adding it before the header include didn't work.
`_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS` is checked in `yvals_core.h` that has a `#pragma once` and is included by some other header before.
So I that's why I thought the least error-prone variant is to set the define in CMake.

This PR reduces warnings by 6 (from 246 to 240).