### PR TITLE
Remove SNetGet/SetLastError

### DIFF
--- a/Source/menu.cpp
+++ b/Source/menu.cpp
@@ -124,7 +124,6 @@ bool mainmenu_select_hero_dialog(GameData *gameData)
 		    &gSaveNumber);
 	}
 	if (dlgresult == SELHERO_PREVIOUS) {
-		SErrSetLastError(1223);
 		return false;
 	}
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -404,8 +404,7 @@ int WaitForTurns()
 
 	if (sgbDeltaChunks == 0) {
 		nthread_send_and_recv_turn(0, 0);
-		if (!SNetGetOwnerTurnsWaiting(&turns) && SErrGetLastError() == STORM_ERROR_NOT_IN_GAME)
-			return 100;
+		SNetGetOwnerTurnsWaiting(&turns);
 		if (SDL_GetTicks() - sgdwOwnerWait <= 2000 && turns < gdwTurnsInTransit)
 			return 0;
 		sgbDeltaChunks++;

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -533,7 +533,7 @@ void multi_send_msg_packet(uint32_t pmask, const std::byte *data, size_t size)
 	size_t playerID = 0;
 	for (size_t v = 1; playerID < Players.size(); playerID++, v <<= 1) {
 		if ((v & pmask) != 0) {
-			if (!SNetSendMessage(playerID, &pkt.hdr, len) && SErrGetLastError() != STORM_ERROR_INVALID_PLAYER) {
+			if (!SNetSendMessage(playerID, &pkt.hdr, len)) {
 				nthread_terminate_game("SNetSendMessage");
 				return;
 			}
@@ -676,8 +676,6 @@ void multi_process_network_packets()
 		}
 		HandleAllPackets(playerId, (const std::byte *)(pkt + 1), dwMsgSize - sizeof(TPktHdr));
 	}
-	if (SErrGetLastError() != STORM_ERROR_NO_MESSAGES_WAITING)
-		nthread_terminate_game("SNetReceiveMsg");
 	CheckPlayerInfoTimeouts();
 }
 

--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -67,14 +67,7 @@ void NthreadHandler()
 
 void nthread_terminate_game(const char *pszFcn)
 {
-	uint32_t sErr = SErrGetLastError();
-	if (sErr == STORM_ERROR_INVALID_PLAYER) {
-		return;
-	}
-	if (sErr != STORM_ERROR_GAME_TERMINATED && sErr != STORM_ERROR_NOT_IN_GAME) {
-		app_fatal(StrCat(pszFcn, ":\n", pszFcn));
-	}
-
+	app_fatal(pszFcn);
 	gbGameDestroyed = true;
 }
 
@@ -121,8 +114,6 @@ bool nthread_recv_turns(bool *pfSendAsync)
 		return true;
 	}
 	if (!SNetReceiveTurns(MAX_PLRS, (char **)glpMsgTbl, gdwMsgLenTbl, &player_state[0])) {
-		if (SErrGetLastError() != STORM_ERROR_NO_MESSAGES_WAITING)
-			nthread_terminate_game("SNetReceiveTurns");
 		sgbTicsOutOfSync = false;
 		sgbSyncCountdown = 1;
 		sgbPacketCountdown = 1;

--- a/Source/storm/storm_net.cpp
+++ b/Source/storm/storm_net.cpp
@@ -23,33 +23,18 @@ namespace devilution {
 namespace {
 std::unique_ptr<net::abstract_net> dvlnet_inst;
 bool GameIsPublic = {};
-thread_local uint32_t dwLastError = 0;
 
 #ifndef NONET
 SdlMutex storm_net_mutex;
 #endif
 } // namespace
 
-uint32_t SErrGetLastError()
-{
-	return dwLastError;
-}
-
-void SErrSetLastError(uint32_t dwErrCode)
-{
-	dwLastError = dwErrCode;
-}
-
 bool SNetReceiveMessage(uint8_t *senderplayerid, void **data, uint32_t *databytes)
 {
 #ifndef NONET
 	std::lock_guard<SdlMutex> lg(storm_net_mutex);
 #endif
-	if (!dvlnet_inst->SNetReceiveMessage(senderplayerid, data, databytes)) {
-		SErrSetLastError(STORM_ERROR_NO_MESSAGES_WAITING);
-		return false;
-	}
-	return true;
+	return dvlnet_inst->SNetReceiveMessage(senderplayerid, data, databytes);
 }
 
 bool SNetSendMessage(int playerID, void *data, unsigned int databytes)
@@ -67,11 +52,7 @@ bool SNetReceiveTurns(int arraysize, char **arraydata, size_t *arraydatabytes, u
 #endif
 	if (arraysize != MAX_PLRS)
 		UNIMPLEMENTED();
-	if (!dvlnet_inst->SNetReceiveTurns(arraydata, arraydatabytes, arrayplayerstatus)) {
-		SErrSetLastError(STORM_ERROR_NO_MESSAGES_WAITING);
-		return false;
-	}
-	return true;
+	return dvlnet_inst->SNetReceiveTurns(arraydata, arraydatabytes, arrayplayerstatus);
 }
 
 bool SNetSendTurn(char *data, unsigned int databytes)

--- a/Source/storm/storm_net.hpp
+++ b/Source/storm/storm_net.hpp
@@ -126,15 +126,6 @@ bool SNetSendMessage(int playerID, void *data, unsigned int databytes);
  */
 bool SNetSendTurn(char *data, unsigned int databytes);
 
-uint32_t SErrGetLastError();
-void SErrSetLastError(uint32_t dwErrCode);
-
-// Values for dwErrCode
-#define STORM_ERROR_GAME_TERMINATED 0x85100069
-#define STORM_ERROR_INVALID_PLAYER 0x8510006a
-#define STORM_ERROR_NO_MESSAGES_WAITING 0x8510006b
-#define STORM_ERROR_NOT_IN_GAME 0x85100070
-
 bool SNetGetOwnerTurnsWaiting(uint32_t *);
 bool SNetUnregisterEventHandler(event_type);
 bool SNetRegisterEventHandler(event_type, SEVTHANDLER);


### PR DESCRIPTION
The only named code that was ever set is `STORM_ERROR_NO_MESSAGES_WAITING`. There was also a call in `menu.cpp` which as far as I can tell is not needed (if it is, it should be replaced by something else).