### PR TITLE
Update on/off for Polish translation.

### DIFF
--- a/Translations/pl.po
+++ b/Translations/pl.po
@@ -3933,11 +3933,11 @@ msgstr "{:s} (wył.)"
 
 #: Source/options.cpp:457 Source/options.cpp:581 Source/options.cpp:587
 msgid "ON"
-msgstr "WŁ."
+msgstr "TAK"
 
 #: Source/options.cpp:457 Source/options.cpp:579 Source/options.cpp:585
 msgid "OFF"
-msgstr "WYŁ."
+msgstr "NIE"
 
 #: Source/options.cpp:569
 msgid "Start Up"


### PR DESCRIPTION
Changing Polish translation:

 * `ON` -> `TAK`, was `WŁ.`
 * `OFF` -> `NIE`, was `WYŁ.`

While "wł." and "wył." are shortened correct translations for "on" and "off" using "tak" and "nie" (literally "yes" and "no") makes the menus slightly prettier.

Before:

![Screenshot from 2023-11-16 22-14-47](https://github.com/diasurgical/devilutionX/assets/896399/9b7bd09d-b5ab-405e-a836-1033d3d78d73)

After:

![Screenshot from 2023-11-16 22-15-27](https://github.com/diasurgical/devilutionX/assets/896399/ae9c3eea-4040-4c46-b26c-6f06103d1b43)

@qndel tagging you as you also speak the language, I would love to hear your opinion on this!