### PR TITLE
Handle PT_DISCONNECT packets more gracefully

### DIFF
--- a/Source/dvlnet/base.cpp
+++ b/Source/dvlnet/base.cpp
@@ -110,9 +110,8 @@ tl::expected<void, PacketError> base::HandleDisconnect(packet &pkt)
 	tl::expected<plr_t, PacketError> newPlayer = pkt.NewPlayer();
 	if (!newPlayer.has_value())
 		return tl::make_unexpected(newPlayer.error());
-	if (*newPlayer == plr_self) {
-		ABORT(); // we were dropped by the owner?!?
-	}
+	if (*newPlayer == plr_self)
+		return tl::make_unexpected("We were dropped by the owner?");
 	if (IsConnected(*newPlayer)) {
 		tl::expected<leaveinfo_t, PacketError> leaveinfo = pkt.LeaveInfo();
 		if (!leaveinfo.has_value())

--- a/Source/dvlnet/tcp_client.cpp
+++ b/Source/dvlnet/tcp_client.cpp
@@ -169,6 +169,12 @@ tl::expected<void, PacketError> tcp_client::send(packet &pkt)
 	return {};
 }
 
+void tcp_client::DisconnectNet(plr_t plr)
+{
+	if (local_server != nullptr)
+		local_server->DisconnectNet(plr);
+}
+
 bool tcp_client::SNetLeaveGame(int type)
 {
 	auto ret = base::SNetLeaveGame(type);

--- a/Source/dvlnet/tcp_client.h
+++ b/Source/dvlnet/tcp_client.h
@@ -32,6 +32,7 @@ public:
 
 	tl::expected<void, PacketError> poll() override;
 	tl::expected<void, PacketError> send(packet &pkt) override;
+	void DisconnectNet(plr_t plr) override;
 
 	bool SNetLeaveGame(int type) override;
 

--- a/Source/dvlnet/tcp_server.h
+++ b/Source/dvlnet/tcp_server.h
@@ -39,6 +39,7 @@ public:
 	    unsigned short port, packet_factory &pktfty);
 	std::string LocalhostSelf();
 	tl::expected<void, PacketError> CheckIoHandlerError();
+	void DisconnectNet(plr_t plr);
 	void Close();
 	virtual ~tcp_server();
 


### PR DESCRIPTION
Since the abort suggests that the owner should not be sending `PT_DISCONNECT` packets to the player being dropped, the first commit avoids that possibility in the TCP server by disconnecting the client socket before sending the packet.

The second commit treats the error as non-fatal to avoid the possibility of a malicious client triggering a crash in remote clients.