### PR TITLE
Don't access sgSFX if sound is not initialized

### DIFF
--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -182,6 +182,8 @@ void PrivSoundInit(uint8_t bLoadMask)
 
 bool effect_is_playing(SfxID nSFX)
 {
+	if (!gbSndInited) return false;
+
 	TSFX *sfx = &sgSFX[static_cast<int16_t>(nSFX)];
 	if (sfx->pSnd != nullptr)
 		return sfx->pSnd->isPlaying();
@@ -203,6 +205,8 @@ void stream_stop()
 void PlaySFX(SfxID psfx)
 {
 	psfx = RndSFX(psfx);
+
+	if (!gbSndInited) return;
 
 	PlaySfxPriv(&sgSFX[static_cast<int16_t>(psfx)], false, { 0, 0 });
 }


### PR DESCRIPTION
Fixes a crash in timedemo when running the test on an MSVC Debug build. Now that the `sgSFX` collection gets populated by a TSV file, it is not guaranteed to be populated and will in fact remain empty when running timedemo headless. I added some guards to prevent OOB access in two of the affected functions, but I find it's unclear what to do about `GetSFXLength()`. It makes me wonder if we should go ahead and load the TSV so we can have the option of testing towner dialogs with timedemo recordings.