### PR TITLE
Update cache version number for MacOS CI builds

### DIFF
--- a/.github/workflows/macOS_x86_64.yml
+++ b/.github/workflows/macOS_x86_64.yml
@@ -38,8 +38,8 @@ jobs:
       uses: actions/cache@v3
       with:
         path: build
-        key: ${{ github.workflow }}-v1-${{ github.sha }}
-        restore-keys: ${{ github.workflow }}-v1-
+        key: ${{ github.workflow }}-v2-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v2-
 
     - name: Build
       working-directory: ${{github.workspace}}


### PR DESCRIPTION
It appears that MacOS CI builds have been failing intermittently due to the following error.

```
CMake Error in Source/CMakeLists.txt:
  Imported target "sodium" includes non-existent path

    "/usr/local/Cellar/libsodium/1.0.18_1/include"
```

I don't know exactly how `brew` works, but I have a feeling this is due to the fact that Homebrew recently updated their libsodium package to version 1.0.19. In case it's relevant, the libsodium package was updated about 3 weeks ago, `brew` was updated about 2 weeks ago to version 4.1.20, and this is the version currently installed on the MacOS 12 GitHub Actions runner we are using via the `macos-latest` label. I'm hopeful that updating the cache version will flush references to libsodium 1.0.18 out of the build folder, forcing it to use the version that we download via `brew bundle install`.