### PR TITLE
Introduce Monster::occupyTile

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3730,7 +3730,7 @@ void ProcessRhino(Missile &missile)
 	monster.position.future = newPos;
 	monster.position.old = newPos;
 	monster.position.tile = newPos;
-	dMonster[newPos.x][newPos.y] = -(monst + 1);
+	monster.occupyTile(newPos, true);
 	if (monster.isUnique())
 		ChangeLightXY(missile._mlid, newPos);
 	MoveMissilePos(missile);

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -463,6 +463,13 @@ struct Monster { // note: missing field _mAFNum
 			offset += GetOffsetForWalking(animInfo, direction);
 		return offset;
 	}
+
+	/**
+	 * @brief Sets a tile/dMonster to be occupied by the monster
+	 * @param position tile to update
+	 * @param isMoving specifies whether the monster is moving or not (true/moving results in a negative index in dMonster)
+	 */
+	void occupyTile(Point position, bool isMoving) const;
 };
 
 extern size_t LevelMonsterTypeCount;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2669,7 +2669,7 @@ void DeltaLoadLevel()
 			} else {
 				decode_enemy(monster, deltaLevel.monster[i]._menemy);
 				if (monster.position.tile != Point { 0, 0 } && monster.position.tile != GolemHoldingCell)
-					dMonster[monster.position.tile.x][monster.position.tile.y] = i + 1;
+					monster.occupyTile(monster.position.tile, false);
 				if (monster.type().type == MT_GOLEM) {
 					GolumAi(monster);
 					monster.flags |= (MFLAG_TARGETS_MONSTER | MFLAG_GOLEM);

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -152,8 +152,7 @@ void SyncPlrInv(TSyncHeader *pHdr)
 
 void SyncMonster(bool isOwner, const TSyncMonster &monsterSync)
 {
-	const int monsterId = monsterSync._mndx;
-	Monster &monster = Monsters[monsterId];
+	Monster &monster = Monsters[monsterSync._mndx];
 	if (monster.hitPoints <= 0 || monster.mode == MonsterMode::Death) {
 		return;
 	}
@@ -183,14 +182,14 @@ void SyncMonster(bool isOwner, const TSyncMonster &monsterSync)
 			Direction md = GetDirection(monster.position.tile, position);
 			if (DirOK(monster, md)) {
 				M_ClearSquares(monster);
-				dMonster[monster.position.tile.x][monster.position.tile.y] = monsterId + 1;
+				monster.occupyTile(monster.position.tile, false);
 				Walk(monster, md);
 				monster.activeForTicks = UINT8_MAX;
 			}
 		}
 	} else if (dMonster[position.x][position.y] == 0) {
 		M_ClearSquares(monster);
-		dMonster[position.x][position.y] = monsterId + 1;
+		monster.occupyTile(position, false);
 		monster.position.tile = position;
 		if (monster.lightId != NO_LIGHT)
 			ChangeLightXY(monster.lightId, position);

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -40,7 +40,7 @@ void NewTownerAnim(Towner &towner, ClxSpriteList sprites, uint8_t numFrames, int
 	towner._tAnimDelay = delay;
 }
 
-void InitTownerInfo(int i, const TownerData &townerData)
+void InitTownerInfo(int16_t i, const TownerData &townerData)
 {
 	auto &towner = Towners[i];
 
@@ -218,7 +218,7 @@ void InitCows(Towner &towner, const TownerData &townerData)
 	towner.name = _("Cow");
 
 	const Point position = townerData.position;
-	int cowId = dMonster[position.x][position.y];
+	int16_t cowId = dMonster[position.x][position.y];
 
 	// Cows are large sprites so take up multiple tiles. Vanilla Diablo/Hellfire allowed the player to stand adjacent
 	//  to a cow facing an ordinal direction (the two top-right cows) which leads to visual clipping. It's easier to
@@ -829,7 +829,7 @@ void InitTowners()
 
 	CowSprites.emplace(LoadCelSheet("towners\\animals\\cow", 128));
 
-	int i = 0;
+	int16_t i = 0;
 	for (const auto &townerData : TownersData) {
 		if (!IsTownerPresent(townerData.type))
 			continue;


### PR DESCRIPTION
Monsters are only updated `dMonster` with a non-zero value in `Monster::occupyTile`.

This PR reduces warnings by 23 (from 191 to 168).