### PR TITLE
Introduce GetDunSize and remove global SetPiece Handling

### DIFF
--- a/Source/levels/crypt.cpp
+++ b/Source/levels/crypt.cpp
@@ -689,7 +689,7 @@ void SetCryptRoom()
 
 	auto dunData = LoadFileInMem<uint16_t>("nlevels\\l5data\\uberroom.dun");
 
-	SetPiece = { position, WorldTileSize(SDL_SwapLE16(dunData[0]), SDL_SwapLE16(dunData[1])) };
+	SetPiece = { position, GetDunSize(dunData.get()) };
 
 	PlaceDunTiles(dunData.get(), position, 0);
 }
@@ -700,7 +700,7 @@ void SetCornerRoom()
 
 	auto dunData = LoadFileInMem<uint16_t>("nlevels\\l5data\\cornerstone.dun");
 
-	SetPiece = { position, WorldTileSize(SDL_SwapLE16(dunData[0]), SDL_SwapLE16(dunData[1])) };
+	SetPiece = { position, GetDunSize(dunData.get()) };
 
 	PlaceDunTiles(dunData.get(), position, 0);
 }

--- a/Source/levels/drlg_l1.cpp
+++ b/Source/levels/drlg_l1.cpp
@@ -381,15 +381,22 @@ void FillFloor()
 	}
 }
 
-void LoadQuestSetPieces()
+void InitSetPiece()
 {
+	std::unique_ptr<uint16_t[]> setPieceData;
 	if (Quests[Q_BUTCHER].IsAvailable()) {
-		pSetPiece = LoadFileInMem<uint16_t>("levels\\l1data\\rnd6.dun");
+		setPieceData = LoadFileInMem<uint16_t>("levels\\l1data\\rnd6.dun");
 	} else if (Quests[Q_SKELKING].IsAvailable() && !UseMultiplayerQuests()) {
-		pSetPiece = LoadFileInMem<uint16_t>("levels\\l1data\\skngdo.dun");
+		setPieceData = LoadFileInMem<uint16_t>("levels\\l1data\\skngdo.dun");
 	} else if (Quests[Q_LTBANNER].IsAvailable()) {
-		pSetPiece = LoadFileInMem<uint16_t>("levels\\l1data\\banner2.dun");
+		setPieceData = LoadFileInMem<uint16_t>("levels\\l1data\\banner2.dun");
+	} else {
+		return; // no setpiece needed for this level
 	}
+
+	WorldTilePosition setPiecePosition = SelectChamber();
+	PlaceDunTiles(setPieceData.get(), setPiecePosition, Floor);
+	SetPiece = { setPiecePosition, GetDunSize(setPieceData.get()) };
 }
 
 void InitDungeonPieces()
@@ -1015,8 +1022,8 @@ void FillChambers()
 		} else if (CornerStone.isAvailable()) {
 			SetCornerRoom();
 		}
-	} else if (pSetPiece != nullptr) {
-		SetSetPieceRoom(SelectChamber(), Floor);
+	} else {
+		InitSetPiece();
 	}
 }
 
@@ -1170,8 +1177,6 @@ void GenerateLevel(lvl_entry entry)
 		break;
 	}
 
-	LoadQuestSetPieces();
-
 	while (true) {
 		DRLG_InitTrans();
 
@@ -1188,8 +1193,6 @@ void GenerateLevel(lvl_entry entry)
 		if (PlaceStairs(entry))
 			break;
 	}
-
-	FreeQuestSetPieces();
 
 	for (int j = 0; j < DMAXY; j++) {
 		for (int i = 0; i < DMAXX; i++) {

--- a/Source/levels/drlg_l3.cpp
+++ b/Source/levels/drlg_l3.cpp
@@ -1796,16 +1796,11 @@ void Fence()
 	FenceDoorFix();
 }
 
-void LoadQuestSetPieces()
-{
-	if (Quests[Q_ANVIL].IsAvailable())
-		pSetPiece = LoadFileInMem<uint16_t>("levels\\l3data\\anvil.dun");
-}
-
 bool PlaceAnvil()
 {
+	std::unique_ptr<uint16_t[]> setPieceData = LoadFileInMem<uint16_t>("levels\\l3data\\anvil.dun");
 	// growing the size by 2 to allow a 1 tile border on all sides
-	WorldTileSize areaSize = WorldTileSize(SDL_SwapLE16(pSetPiece[0]), SDL_SwapLE16(pSetPiece[1])) + 2;
+	WorldTileSize areaSize = GetDunSize(setPieceData.get()) + 2;
 	WorldTileCoord sx = GenerateRnd(DMAXX - areaSize.width);
 	WorldTileCoord sy = GenerateRnd(DMAXY - areaSize.height);
 
@@ -1832,7 +1827,7 @@ bool PlaceAnvil()
 			break;
 	}
 
-	PlaceDunTiles(pSetPiece.get(), { sx + 1, sy + 1 }, 7);
+	PlaceDunTiles(setPieceData.get(), { sx + 1, sy + 1 }, 7);
 	SetPiece = { { sx, sy }, areaSize };
 
 	for (WorldTilePosition tile : PointsInRectangle(SetPiece)) {
@@ -1993,8 +1988,6 @@ bool PlaceStairs(lvl_entry entry)
 
 void GenerateLevel(lvl_entry entry)
 {
-	LoadQuestSetPieces();
-
 	while (true) {
 		InitDungeonFlags();
 		int x1 = GenerateRnd(20) + 10;
@@ -2028,8 +2021,6 @@ void GenerateLevel(lvl_entry entry)
 		if (PlacePool())
 			break;
 	}
-
-	FreeQuestSetPieces();
 
 	if (leveltype == DTYPE_NEST) {
 		PlaceMiniSetRandom(L6ISLE1, 70);

--- a/Source/levels/drlg_l4.cpp
+++ b/Source/levels/drlg_l4.cpp
@@ -158,13 +158,21 @@ void ApplyShadowsPatterns()
 	}
 }
 
-void LoadQuestSetPieces()
+void InitSetPiece()
 {
+	std::unique_ptr<uint16_t[]> setPieceData;
+
 	if (Quests[Q_WARLORD].IsAvailable()) {
-		pSetPiece = LoadFileInMem<uint16_t>("levels\\l4data\\warlord.dun");
+		setPieceData = LoadFileInMem<uint16_t>("levels\\l4data\\warlord.dun");
 	} else if (currlevel == 15 && UseMultiplayerQuests()) {
-		pSetPiece = LoadFileInMem<uint16_t>("levels\\l4data\\vile1.dun");
+		setPieceData = LoadFileInMem<uint16_t>("levels\\l4data\\vile1.dun");
+	} else {
+		return; // no setpiece needed for this level
 	}
+
+	WorldTilePosition setPiecePosition = SetPieceRoom.position;
+	PlaceDunTiles(setPieceData.get(), setPiecePosition, 6);
+	SetPiece = { setPiecePosition, GetDunSize(setPieceData.get()) };
 }
 
 void InitDungeonFlags()
@@ -1130,8 +1138,6 @@ bool PlaceStairs(lvl_entry entry)
 
 void GenerateLevel(lvl_entry entry)
 {
-	LoadQuestSetPieces();
-
 	while (true) {
 		DRLG_InitTrans();
 
@@ -1160,15 +1166,13 @@ void GenerateLevel(lvl_entry entry)
 		AddWall();
 		FloodTransparencyValues(6);
 		FixTransparency();
-		SetSetPieceRoom(SetPieceRoom.position, 6);
+		InitSetPiece();
 		if (currlevel == 16) {
 			LoadDiabQuads(true);
 		}
 		if (PlaceStairs(entry))
 			break;
 	}
-
-	FreeQuestSetPieces();
 
 	GeneralFix();
 

--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -23,7 +23,6 @@ uint8_t pdungeon[DMAXX][DMAXY];
 Bitset2d<DMAXX, DMAXY> Protected;
 WorldTileRectangle SetPieceRoom;
 WorldTileRectangle SetPiece;
-std::unique_ptr<uint16_t[]> pSetPiece;
 OptionalOwnedClxSpriteList pSpecialCels;
 std::unique_ptr<MegaTile[]> pMegaTiles;
 std::unique_ptr<std::byte[]> pDungeonCels;
@@ -703,20 +702,6 @@ void DRLG_HoldThemeRooms()
 WorldTileSize GetDunSize(const uint16_t *dunData)
 {
 	return WorldTileSize(static_cast<WorldTileCoord>(SDL_SwapLE16(dunData[0])), static_cast<WorldTileCoord>(SDL_SwapLE16(dunData[1])));
-}
-
-void SetSetPieceRoom(WorldTilePosition position, int floorId)
-{
-	if (pSetPiece == nullptr)
-		return;
-
-	PlaceDunTiles(pSetPiece.get(), position, floorId);
-	SetPiece = { position, GetDunSize(pSetPiece.get()) };
-}
-
-void FreeQuestSetPieces()
-{
-	pSetPiece = nullptr;
 }
 
 void DRLG_LPass3(int lv)

--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -703,13 +703,18 @@ void DRLG_HoldThemeRooms()
 	}
 }
 
+WorldTileSize GetDunSize(const uint16_t *dunData)
+{
+	return WorldTileSize(static_cast<WorldTileCoord>(SDL_SwapLE16(dunData[0])), static_cast<WorldTileCoord>(SDL_SwapLE16(dunData[1])));
+}
+
 void SetSetPieceRoom(WorldTilePosition position, int floorId)
 {
 	if (pSetPiece == nullptr)
 		return;
 
 	PlaceDunTiles(pSetPiece.get(), position, floorId);
-	SetPiece = { position, WorldTileSize(SDL_SwapLE16(pSetPiece[0]), SDL_SwapLE16(pSetPiece[1])) };
+	SetPiece = { position, GetDunSize(pSetPiece.get()) };
 }
 
 void FreeQuestSetPieces()

--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -537,19 +537,17 @@ void DRLG_CopyTrans(int sx, int sy, int dx, int dy)
 
 void LoadTransparency(const uint16_t *dunData)
 {
-	int width = SDL_SwapLE16(dunData[0]);
-	int height = SDL_SwapLE16(dunData[1]);
+	WorldTileSize size = GetDunSize(dunData);
 
-	int layer2Offset = 2 + width * height;
+	int layer2Offset = 2 + size.width * size.height;
 
 	// The rest of the layers are at dPiece scale
-	width *= 2;
-	height *= 2;
+	size *= static_cast<WorldTileCoord>(2);
 
-	const uint16_t *transparentLayer = &dunData[layer2Offset + width * height * 3];
+	const uint16_t *transparentLayer = &dunData[layer2Offset + size.width * size.height * 3];
 
-	for (int j = 0; j < height; j++) {
-		for (int i = 0; i < width; i++) {
+	for (WorldTileCoord j = 0; j < size.height; j++) {
+		for (WorldTileCoord i = 0; i < size.width; i++) {
 			dTransVal[16 + i][16 + j] = SDL_SwapLE16(*transparentLayer);
 			transparentLayer++;
 		}
@@ -631,14 +629,13 @@ std::optional<Point> PlaceMiniSet(const Miniset &miniset, int tries, bool drlg1Q
 
 void PlaceDunTiles(const uint16_t *dunData, Point position, int floorId)
 {
-	int width = SDL_SwapLE16(dunData[0]);
-	int height = SDL_SwapLE16(dunData[1]);
+	WorldTileSize size = GetDunSize(dunData);
 
 	const uint16_t *tileLayer = &dunData[2];
 
-	for (int j = 0; j < height; j++) {
-		for (int i = 0; i < width; i++) {
-			auto tileId = static_cast<uint8_t>(SDL_SwapLE16(tileLayer[j * width + i]));
+	for (WorldTileCoord j = 0; j < size.height; j++) {
+		for (WorldTileCoord i = 0; i < size.width; i++) {
+			auto tileId = static_cast<uint8_t>(SDL_SwapLE16(tileLayer[j * size.width + i]));
 			if (tileId != 0) {
 				dungeon[position.x + i][position.y + j] = tileId;
 				Protected.set(position.x + i, position.y + j);

--- a/Source/levels/gendung.h
+++ b/Source/levels/gendung.h
@@ -358,6 +358,10 @@ std::optional<Point> PlaceMiniSet(const Miniset &miniset, int tries = 199, bool 
 void PlaceDunTiles(const uint16_t *dunData, Point position, int floorId = 0);
 void DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int freq, bool rndSize);
 void DRLG_HoldThemeRooms();
+/**
+ * @brief Returns ths size in tiles of the specified ".dun" Data
+ */
+WorldTileSize GetDunSize(const uint16_t *dunData);
 void SetSetPieceRoom(WorldTilePosition position, int floorId);
 void FreeQuestSetPieces();
 void DRLG_LPass3(int lv);

--- a/Source/levels/gendung.h
+++ b/Source/levels/gendung.h
@@ -158,8 +158,6 @@ extern Bitset2d<DMAXX, DMAXY> Protected;
 extern WorldTileRectangle SetPieceRoom;
 /** Specifies the active set quest piece in coordinate. */
 extern WorldTileRectangle SetPiece;
-/** Contains the contents of the single player quest DUN file. */
-extern std::unique_ptr<uint16_t[]> pSetPiece;
 extern OptionalOwnedClxSpriteList pSpecialCels;
 /** Specifies the tile definitions of the active dungeon type; (e.g. levels/l1data/l1.til). */
 extern DVL_API_FOR_TEST std::unique_ptr<MegaTile[]> pMegaTiles;
@@ -362,8 +360,6 @@ void DRLG_HoldThemeRooms();
  * @brief Returns ths size in tiles of the specified ".dun" Data
  */
 WorldTileSize GetDunSize(const uint16_t *dunData);
-void SetSetPieceRoom(WorldTilePosition position, int floorId);
-void FreeQuestSetPieces();
 void DRLG_LPass3(int lv);
 
 /**

--- a/Source/levels/town.cpp
+++ b/Source/levels/town.cpp
@@ -24,20 +24,18 @@ void FillSector(const char *path, int xi, int yy)
 {
 	auto dunData = LoadFileInMem<uint16_t>(path);
 
-	int width = SDL_SwapLE16(dunData[0]);
-	int height = SDL_SwapLE16(dunData[1]);
-
+	WorldTileSize size = GetDunSize(dunData.get());
 	const uint16_t *tileLayer = &dunData[2];
 
-	for (int j = 0; j < height; j++) {
+	for (WorldTileCoord j = 0; j < size.height; j++) {
 		int xx = xi;
-		for (int i = 0; i < width; i++) {
+		for (WorldTileCoord i = 0; i < size.width; i++) {
 			int v1 = 218;
 			int v2 = 218;
 			int v3 = 218;
 			int v4 = 218;
 
-			int tileId = SDL_SwapLE16(tileLayer[j * width + i]) - 1;
+			int tileId = SDL_SwapLE16(tileLayer[j * size.width + i]) - 1;
 			if (tileId >= 0) {
 				MegaTile mega = pMegaTiles[tileId];
 				v1 = SDL_SwapLE16(mega.micro1);

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3601,20 +3601,18 @@ void SetMapMonsters(const uint16_t *dunData, Point startPosition)
 		PlaceUniqueMonst(UniqueMonsterType::BlackJade, 0, 0);
 	}
 
-	int width = SDL_SwapLE16(dunData[0]);
-	int height = SDL_SwapLE16(dunData[1]);
+	WorldTileSize size = GetDunSize(dunData);
 
-	int layer2Offset = 2 + width * height;
+	int layer2Offset = 2 + size.width * size.height;
 
 	// The rest of the layers are at dPiece scale
-	width *= 2;
-	height *= 2;
+	size *= static_cast<WorldTileCoord>(2);
 
-	const uint16_t *monsterLayer = &dunData[layer2Offset + width * height];
+	const uint16_t *monsterLayer = &dunData[layer2Offset + size.width * size.height];
 
-	for (int j = 0; j < height; j++) {
-		for (int i = 0; i < width; i++) {
-			auto monsterId = static_cast<uint8_t>(SDL_SwapLE16(monsterLayer[j * width + i]));
+	for (WorldTileCoord j = 0; j < size.height; j++) {
+		for (WorldTileCoord i = 0; i < size.width; i++) {
+			auto monsterId = static_cast<uint8_t>(SDL_SwapLE16(monsterLayer[j * size.width + i]));
 			if (monsterId != 0) {
 				const size_t typeIndex = AddMonsterType(MonstConvTbl[monsterId - 1], PLACE_SPECIAL);
 				PlaceMonster(ActiveMonsterCount++, typeIndex, startPosition + Displacement { i, j });

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -559,20 +559,18 @@ void LoadMapObjects(const char *path, Point start, WorldTileRectangle mapRange =
 
 	auto dunData = LoadFileInMem<uint16_t>(path);
 
-	int width = SDL_SwapLE16(dunData[0]);
-	int height = SDL_SwapLE16(dunData[1]);
+	WorldTileSize size = GetDunSize(dunData.get());
 
-	int layer2Offset = 2 + width * height;
+	int layer2Offset = 2 + size.width * size.height;
 
 	// The rest of the layers are at dPiece scale
-	width *= 2;
-	height *= 2;
+	size.width *= static_cast<WorldTileCoord>(2);
 
-	const uint16_t *objectLayer = &dunData[layer2Offset + width * height * 2];
+	const uint16_t *objectLayer = &dunData[layer2Offset + size.width * size.height * 2];
 
-	for (int j = 0; j < height; j++) {
-		for (int i = 0; i < width; i++) {
-			auto objectId = static_cast<uint8_t>(SDL_SwapLE16(objectLayer[j * width + i]));
+	for (WorldTileCoord j = 0; j < size.height; j++) {
+		for (WorldTileCoord i = 0; i < size.width; i++) {
+			auto objectId = static_cast<uint8_t>(SDL_SwapLE16(objectLayer[j * size.width + i]));
 			if (objectId != 0) {
 				Point mapPos = start + Displacement { i, j };
 				Object *mapObject = AddObject(ObjTypeConv[objectId], mapPos);
@@ -3949,20 +3947,18 @@ void SetMapObjects(const uint16_t *dunData, int startx, int starty)
 
 	ClrAllObjects();
 
-	int width = SDL_SwapLE16(dunData[0]);
-	int height = SDL_SwapLE16(dunData[1]);
+	WorldTileSize size = GetDunSize(dunData);
 
-	int layer2Offset = 2 + width * height;
+	int layer2Offset = 2 + size.width * size.height;
 
 	// The rest of the layers are at dPiece scale
-	width *= 2;
-	height *= 2;
+	size.width *= static_cast<WorldTileCoord>(2);
 
-	const uint16_t *objectLayer = &dunData[layer2Offset + width * height * 2];
+	const uint16_t *objectLayer = &dunData[layer2Offset + size.width * size.height * 2];
 
-	for (int j = 0; j < height; j++) {
-		for (int i = 0; i < width; i++) {
-			auto objectId = static_cast<uint8_t>(SDL_SwapLE16(objectLayer[j * width + i]));
+	for (WorldTileCoord j = 0; j < size.height; j++) {
+		for (WorldTileCoord i = 0; i < size.width; i++) {
+			auto objectId = static_cast<uint8_t>(SDL_SwapLE16(objectLayer[j * size.width + i]));
 			if (objectId != 0) {
 				const ObjectData &objectData = AllObjects[ObjTypeConv[objectId]];
 				filesWidths[objectData.ofindex] = objectData.animWidth;
@@ -3972,9 +3968,9 @@ void SetMapObjects(const uint16_t *dunData, int startx, int starty)
 
 	LoadLevelObjects(filesWidths);
 
-	for (int j = 0; j < height; j++) {
-		for (int i = 0; i < width; i++) {
-			auto objectId = static_cast<uint8_t>(SDL_SwapLE16(objectLayer[j * width + i]));
+	for (WorldTileCoord j = 0; j < size.height; j++) {
+		for (WorldTileCoord i = 0; i < size.width; i++) {
+			auto objectId = static_cast<uint8_t>(SDL_SwapLE16(objectLayer[j * size.width + i]));
 			if (objectId != 0) {
 				AddObject(ObjTypeConv[objectId], { startx + 16 + i, starty + 16 + j });
 			}

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -147,7 +147,7 @@ void DrawWarLord(Point position)
 {
 	auto dunData = LoadFileInMem<uint16_t>("levels\\l4data\\warlord2.dun");
 
-	SetPiece = { position, WorldTileSize(SDL_SwapLE16(dunData[0]), SDL_SwapLE16(dunData[1])) };
+	SetPiece = { position, GetDunSize(dunData.get()) };
 
 	PlaceDunTiles(dunData.get(), position, 6);
 }
@@ -156,7 +156,7 @@ void DrawSChamber(quest_id q, Point position)
 {
 	auto dunData = LoadFileInMem<uint16_t>("levels\\l2data\\bonestr1.dun");
 
-	SetPiece = { position, WorldTileSize(SDL_SwapLE16(dunData[0]), SDL_SwapLE16(dunData[1])) };
+	SetPiece = { position, GetDunSize(dunData.get()) };
 
 	PlaceDunTiles(dunData.get(), position, 3);
 
@@ -170,7 +170,7 @@ void DrawLTBanner(Point position)
 	int width = SDL_SwapLE16(dunData[0]);
 	int height = SDL_SwapLE16(dunData[1]);
 
-	SetPiece = { position, WorldTileSize(SDL_SwapLE16(dunData[0]), SDL_SwapLE16(dunData[1])) };
+	SetPiece = { position, GetDunSize(dunData.get()) };
 
 	const uint16_t *tileLayer = &dunData[2];
 
@@ -197,7 +197,7 @@ void DrawBlood(Point position)
 {
 	auto dunData = LoadFileInMem<uint16_t>("levels\\l2data\\blood2.dun");
 
-	SetPiece = { position, WorldTileSize(SDL_SwapLE16(dunData[0]), SDL_SwapLE16(dunData[1])) };
+	SetPiece = { position, GetDunSize(dunData.get()) };
 
 	PlaceDunTiles(dunData.get(), position, 0);
 }

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -167,16 +167,15 @@ void DrawLTBanner(Point position)
 {
 	auto dunData = LoadFileInMem<uint16_t>("levels\\l1data\\banner1.dun");
 
-	int width = SDL_SwapLE16(dunData[0]);
-	int height = SDL_SwapLE16(dunData[1]);
+	WorldTileSize size = GetDunSize(dunData.get());
 
-	SetPiece = { position, GetDunSize(dunData.get()) };
+	SetPiece = { position, size };
 
 	const uint16_t *tileLayer = &dunData[2];
 
-	for (int j = 0; j < height; j++) {
-		for (int i = 0; i < width; i++) {
-			auto tileId = static_cast<uint8_t>(SDL_SwapLE16(tileLayer[j * width + i]));
+	for (WorldTileCoord j = 0; j < size.height; j++) {
+		for (WorldTileCoord i = 0; i < size.width; i++) {
+			auto tileId = static_cast<uint8_t>(SDL_SwapLE16(tileLayer[j * size.width + i]));
 			if (tileId != 0) {
 				pdungeon[position.x + i][position.y + j] = tileId;
 			}

--- a/test/drlg_test.hpp
+++ b/test/drlg_test.hpp
@@ -48,7 +48,7 @@ void LoadExpectedLevelData(const char *fixture)
 	dunPath.append(fixture);
 	DunData = LoadFileInMem<uint16_t>(dunPath.c_str());
 	ASSERT_NE(DunData, nullptr) << "Unable to load test fixture " << dunPath;
-	ASSERT_EQ(Size(DMAXX, DMAXY), Size(SDL_SwapLE16(DunData[0]), SDL_SwapLE16(DunData[1])));
+	ASSERT_EQ(WorldTileSize(DMAXX, DMAXY), GetDunSize(DunData.get()));
 }
 
 void TestInitGame(bool fullQuests = true, bool originalCathedral = true)


### PR DESCRIPTION
This PR includes three refactorings
- Introduce a helper method `GetDunSize` to get the ".dun"-size. Use this in every place a `WorldTileSize` is needed. (first commit)
- Use the new `GetDunSize` also in loops. I'm not 100% of this, that's also why this is a separate commit. (second commit)
- Replace global `pSetPiece` and it's related helper functions (`SetSetPieceRoom` and `FreeQuestSetPieces`) with a anonymous function in each level generator (`InitSetPiece`). Less global variables. 😁 (third commit)

This PR also reduces warnings by 16 (from 153 to 137).