### PR TITLE
Fix debug spawning monsters

### DIFF
--- a/Source/lua/modules/dev/monsters.cpp
+++ b/Source/lua/modules/dev/monsters.cpp
@@ -30,8 +30,8 @@ std::string DebugCmdSpawnUniqueMonster(std::string name, std::optional<unsigned>
 
 	int mtype = -1;
 	UniqueMonsterType uniqueIndex = UniqueMonsterType::None;
-	for (size_t i = 0; UniqueMonstersData.size(); ++i) {
-		auto mondata = UniqueMonstersData[i];
+	for (size_t i = 0; i < UniqueMonstersData.size(); ++i) {
+		const auto &mondata = UniqueMonstersData[i];
 		const std::string monsterName = AsciiStrToLower(std::string_view(mondata.mName));
 		if (monsterName.find(name) == std::string::npos)
 			continue;
@@ -55,11 +55,11 @@ std::string DebugCmdSpawnUniqueMonster(std::string name, std::optional<unsigned>
 	}
 
 	if (!found) {
+		if (LevelMonsterTypeCount == MaxLvlMTypes)
+			LevelMonsterTypeCount--; // we are running out of monster types, so override last used monster type
+		id = AddMonsterType(uniqueIndex, PLACE_SCATTER);
 		CMonster &monsterType = LevelMonsterTypes[id];
-		monsterType.type = static_cast<_monster_id>(mtype);
 		InitMonsterGFX(monsterType);
-		InitMonsterSND(monsterType);
-		monsterType.placeFlags |= PLACE_SCATTER;
 		monsterType.corpseId = 1;
 	}
 
@@ -104,7 +104,7 @@ std::string DebugCmdSpawnMonster(std::string name, std::optional<unsigned> count
 	int mtype = -1;
 
 	for (int i = 0; i < NUM_MTYPES; i++) {
-		auto mondata = MonstersData[i];
+		const auto &mondata = MonstersData[i];
 		const std::string monsterName = AsciiStrToLower(std::string_view(mondata.name));
 		if (monsterName.find(name) == std::string::npos)
 			continue;
@@ -127,11 +127,11 @@ std::string DebugCmdSpawnMonster(std::string name, std::optional<unsigned> count
 	}
 
 	if (!found) {
+		if (LevelMonsterTypeCount == MaxLvlMTypes)
+			LevelMonsterTypeCount--; // we are running out of monster types, so override last used monster type
+		id = AddMonsterType(static_cast<_monster_id>(mtype), PLACE_SCATTER);
 		CMonster &monsterType = LevelMonsterTypes[id];
-		monsterType.type = static_cast<_monster_id>(mtype);
 		InitMonsterGFX(monsterType);
-		InitMonsterSND(monsterType);
-		monsterType.placeFlags |= PLACE_SCATTER;
 		monsterType.corpseId = 1;
 	}
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -417,39 +417,6 @@ void PlaceUniqueMonst(UniqueMonsterType uniqindex, size_t minionType, int bosspa
 	PrepareUniqueMonst(monster, uniqindex, minionType, bosspacksize, uniqueMonsterData);
 }
 
-size_t AddMonsterType(_monster_id type, placeflag placeflag)
-{
-	const size_t typeIndex = GetMonsterTypeIndex(type);
-	CMonster &monsterType = LevelMonsterTypes[typeIndex];
-
-	if (typeIndex == LevelMonsterTypeCount) {
-		LevelMonsterTypeCount++;
-		monsterType.type = type;
-		const MonsterData &monsterData = MonstersData[type];
-		monstimgtot += monsterData.image;
-
-		const size_t numAnims = GetNumAnims(monsterData);
-		for (size_t i = 0; i < numAnims; ++i) {
-			AnimStruct &anim = monsterType.anims[i];
-			anim.frames = monsterData.frames[i];
-			if (monsterData.hasAnim(i)) {
-				anim.rate = monsterData.rate[i];
-				anim.width = monsterData.width;
-			}
-		}
-
-		InitMonsterSND(monsterType);
-	}
-
-	monsterType.placeFlags |= placeflag;
-	return typeIndex;
-}
-
-inline size_t AddMonsterType(UniqueMonsterType uniqueType, placeflag placeflag)
-{
-	return AddMonsterType(UniqueMonstersData[static_cast<size_t>(uniqueType)].mtype, placeflag);
-}
-
 void ClearMVars(Monster &monster)
 {
 	monster.var1 = 0;
@@ -3164,6 +3131,34 @@ MonsterSpritesData LoadMonsterSpritesData(const MonsterData &monsterData)
 }
 
 } // namespace
+
+size_t AddMonsterType(_monster_id type, placeflag placeflag)
+{
+	const size_t typeIndex = GetMonsterTypeIndex(type);
+	CMonster &monsterType = LevelMonsterTypes[typeIndex];
+
+	if (typeIndex == LevelMonsterTypeCount) {
+		LevelMonsterTypeCount++;
+		monsterType.type = type;
+		const MonsterData &monsterData = MonstersData[type];
+		monstimgtot += monsterData.image;
+
+		const size_t numAnims = GetNumAnims(monsterData);
+		for (size_t i = 0; i < numAnims; ++i) {
+			AnimStruct &anim = monsterType.anims[i];
+			anim.frames = monsterData.frames[i];
+			if (monsterData.hasAnim(i)) {
+				anim.rate = monsterData.rate[i];
+				anim.width = monsterData.width;
+			}
+		}
+
+		InitMonsterSND(monsterType);
+	}
+
+	monsterType.placeFlags |= placeflag;
+	return typeIndex;
+}
 
 void InitTRNForUniqueMonster(Monster &monster)
 {

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -482,6 +482,11 @@ extern bool sgbSaveSoundOn;
 void PrepareUniqueMonst(Monster &monster, UniqueMonsterType monsterType, size_t miniontype, int bosspacksize, const UniqueMonsterData &uniqueMonsterData);
 void InitLevelMonsters();
 void GetLevelMTypes();
+size_t AddMonsterType(_monster_id type, placeflag placeflag);
+inline size_t AddMonsterType(UniqueMonsterType uniqueType, placeflag placeflag)
+{
+	return AddMonsterType(UniqueMonstersData[static_cast<size_t>(uniqueType)].mtype, placeflag);
+}
 void InitMonsterSND(CMonster &monsterType);
 void InitMonsterGFX(CMonster &monsterType, MonsterSpritesData &&spritesData = {});
 void InitAllMonsterGFX();


### PR DESCRIPTION
`dev.monsters.spawn[unique]` didn't work correctly.
Mainly cause this was missing:

```cpp
	const size_t numAnims = GetNumAnims(monsterData);
		for (size_t i = 0; i < numAnims; ++i) {
			AnimStruct &anim = monsterType.anims[i];
			anim.frames = monsterData.frames[i];
			if (monsterData.hasAnim(i)) {
				anim.rate = monsterData.rate[i];
				anim.width = monsterData.width;
			}
		}
```

But instead of cloning this code this PR make `AddMonsterType` public and uses it instead.