### PR TITLE
Reduce usage of dPlayer

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1274,13 +1274,11 @@ bool IsPathBlocked(Point position, Direction dir)
 	return !PosOkPlayer(myPlayer, leftStep) && !PosOkPlayer(myPlayer, rightStep);
 }
 
-void WalkInDir(size_t playerId, AxisDirection dir)
+void WalkInDir(Player &player, AxisDirection dir)
 {
-	Player &player = Players[playerId];
-
 	if (dir.x == AxisDirectionX_NONE && dir.y == AxisDirectionY_NONE) {
 		if (ControlMode != ControlTypes::KeyboardAndMouse && player.walkpath[0] != WALK_NONE && player.destAction == ACTION_NONE)
-			NetSendCmdLoc(playerId, true, CMD_WALKXY, player.position.future); // Stop walking
+			NetSendCmdLoc(player.getId(), true, CMD_WALKXY, player.position.future); // Stop walking
 		return;
 	}
 
@@ -1302,7 +1300,7 @@ void WalkInDir(size_t playerId, AxisDirection dir)
 		return; // Don't start backtrack around obstacles
 	}
 
-	NetSendCmdLoc(playerId, true, CMD_WALKXY, delta);
+	NetSendCmdLoc(player.getId(), true, CMD_WALKXY, delta);
 }
 
 void QuestLogMove(AxisDirection moveDir)
@@ -1360,13 +1358,13 @@ void ProcessLeftStickOrDPadGameUI()
 		handler(GetLeftStickOrDpadDirection(false));
 }
 
-void Movement(size_t playerId)
+void Movement(Player &player)
 {
 	if (PadMenuNavigatorActive || PadHotspellMenuActive || InGameMenu())
 		return;
 
 	if (GetLeftStickOrDPadGameUIHandler() == nullptr) {
-		WalkInDir(playerId, GetMoveDirection());
+		WalkInDir(player, GetMoveDirection());
 	}
 }
 
@@ -1779,7 +1777,7 @@ void plrctrls_every_frame()
 
 void plrctrls_after_game_logic()
 {
-	Movement(MyPlayerId);
+	Movement(*MyPlayer);
 }
 
 void UseBeltItem(int type)

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -2067,7 +2067,7 @@ bool UseInvItem(int cii)
 	else if (&player == MyPlayer)
 		PlaySFX(ItemInvSnds[idata]);
 
-	UseItem(player.getId(), item->_iMiscId, item->_iSpell, cii);
+	UseItem(player, item->_iMiscId, item->_iSpell, cii);
 
 	if (speedlist) {
 		if (player.SpdList[c]._iMiscId == IMISC_NOTE) {

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3981,9 +3981,8 @@ void PrintItemDur(const Item &item)
 	PrintItemInfo(item);
 }
 
-void UseItem(size_t pnum, item_misc_id mid, SpellID spellID, int spellFrom)
+void UseItem(Player &player, item_misc_id mid, SpellID spellID, int spellFrom)
 {
-	Player &player = Players[pnum];
 	std::optional<SpellID> prepareSpellID;
 
 	switch (mid) {

--- a/Source/items.h
+++ b/Source/items.h
@@ -539,7 +539,7 @@ bool DoOil(Player &player, int cii);
 void DrawUniqueInfo(const Surface &out);
 void PrintItemDetails(const Item &item);
 void PrintItemDur(const Item &item);
-void UseItem(size_t pnum, item_misc_id Mid, SpellID spellID, int spellFrom);
+void UseItem(Player &player, item_misc_id Mid, SpellID spellID, int spellFrom);
 bool UseItemOpensHive(const Item &item, Point position);
 bool UseItemOpensGrave(const Item &item, Point position);
 void SpawnSmith(int lvl);

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -205,7 +205,7 @@ DamageRange GetDamageAmt(SpellID spell, int spellLevel);
  */
 Direction16 GetDirection16(Point p1, Point p2);
 bool MonsterTrapHit(int monsterId, int mindam, int maxdam, int dist, MissileID t, DamageType damageType, bool shift);
-bool PlayerMHit(int pnum, Monster *monster, int dist, int mind, int maxd, MissileID mtype, DamageType damageType, bool shift, DeathReason deathReason, bool *blocked);
+bool PlayerMHit(Player &player, Monster *monster, int dist, int mind, int maxd, MissileID mtype, DamageType damageType, bool shift, DeathReason deathReason, bool *blocked);
 
 /**
  * @brief Could the missile collide with solid objects? (like walls or closed doors)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4424,25 +4424,24 @@ void MissToMonst(Missile &missile, Point position)
 		return;
 
 	if ((monster.flags & MFLAG_TARGETS_MONSTER) == 0) {
-		if (dPlayer[oldPosition.x][oldPosition.y] <= 0)
+		Player *player = PlayerAtPosition(oldPosition, true);
+		if (player == nullptr)
 			return;
 
-		int pnum = dPlayer[oldPosition.x][oldPosition.y] - 1;
-		Player &player = Players[pnum];
-		MonsterAttackPlayer(monster, player, 500, monster.minDamageSpecial, monster.maxDamageSpecial);
+		MonsterAttackPlayer(monster, *player, 500, monster.minDamageSpecial, monster.maxDamageSpecial);
 
 		if (IsAnyOf(monster.type().type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE))
 			return;
 
-		if (player._pmode != PM_GOTHIT && player._pmode != PM_DEATH)
-			StartPlrHit(player, 0, true);
+		if (player->_pmode != PM_GOTHIT && player->_pmode != PM_DEATH)
+			StartPlrHit(*player, 0, true);
 		Point newPosition = oldPosition + monster.direction;
-		if (PosOkPlayer(player, newPosition)) {
-			player.position.tile = newPosition;
-			FixPlayerLocation(player, player._pdir);
-			FixPlrWalkTags(player);
-			player.occupyTile(newPosition, false);
-			SetPlayerOld(player);
+		if (PosOkPlayer(*player, newPosition)) {
+			player->position.tile = newPosition;
+			FixPlayerLocation(*player, player->_pdir);
+			FixPlrWalkTags(*player);
+			player->occupyTile(newPosition, false);
+			SetPlayerOld(*player);
 		}
 		return;
 	}

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1613,9 +1613,10 @@ void UpdateFlameTrap(Object &trap)
 		constexpr MissileID TrapMissile = MissileID::FireWallControl;
 		if (dMonster[x][y] > 0)
 			MonsterTrapHit(dMonster[x][y] - 1, mindam / 2, maxdam / 2, 0, TrapMissile, GetMissileData(TrapMissile).damageType(), false);
-		if (dPlayer[x][y] > 0) {
+		Player *player = PlayerAtPosition({ x, y }, true);
+		if (player != nullptr) {
 			bool unused;
-			PlayerMHit(dPlayer[x][y] - 1, nullptr, 0, mindam, maxdam, TrapMissile, GetMissileData(TrapMissile).damageType(), false, DeathReason::MonsterOrTrap, &unused);
+			PlayerMHit(*player, nullptr, 0, mindam, maxdam, TrapMissile, GetMissileData(TrapMissile).damageType(), false, DeathReason::MonsterOrTrap, &unused);
 		}
 
 		if (trap._oAnimFrame == trap._oAnimLen)
@@ -3473,9 +3474,10 @@ void BreakBarrel(const Player &player, Object &barrel, bool forcebreak, bool sen
 				if (dMonster[xp][yp] > 0) {
 					MonsterTrapHit(dMonster[xp][yp] - 1, 1, 4, 0, TrapMissile, GetMissileData(TrapMissile).damageType(), false);
 				}
-				if (dPlayer[xp][yp] > 0) {
+				Player *adjacentPlayer = PlayerAtPosition({ xp, yp }, true);
+				if (adjacentPlayer != nullptr) {
 					bool unused;
-					PlayerMHit(dPlayer[xp][yp] - 1, nullptr, 0, 8, 16, TrapMissile, GetMissileData(TrapMissile).damageType(), false, DeathReason::MonsterOrTrap, &unused);
+					PlayerMHit(*adjacentPlayer, nullptr, 0, 8, 16, TrapMissile, GetMissileData(TrapMissile).damageType(), false, DeathReason::MonsterOrTrap, &unused);
 				}
 				// don't really need to exclude large objects as explosive barrels are single tile objects, but using considerLargeObjects == false as this matches the old logic.
 				Object *adjacentObject = FindObjectAtPosition({ xp, yp }, false);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2075,13 +2075,13 @@ void Player::occupyTile(Point position, bool isMoving) const
 	dPlayer[position.x][position.y] = isMoving ? -id : id;
 }
 
-Player *PlayerAtPosition(Point position)
+Player *PlayerAtPosition(Point position, bool ignoreMovingPlayers /*= false*/)
 {
 	if (!InDungeonBounds(position))
 		return nullptr;
 
 	auto playerIndex = dPlayer[position.x][position.y];
-	if (playerIndex == 0)
+	if (playerIndex == 0 || (ignoreMovingPlayers && playerIndex < 0))
 		return nullptr;
 
 	return &Players[std::abs(playerIndex) - 1];
@@ -3079,12 +3079,9 @@ bool PosOkPlayer(const Player &player, Point position)
 		return false;
 	if (!IsTileWalkable(position))
 		return false;
-	if (dPlayer[position.x][position.y] != 0) {
-		auto &otherPlayer = Players[std::abs(dPlayer[position.x][position.y]) - 1];
-		if (&otherPlayer != &player && otherPlayer._pHitPoints != 0) {
-			return false;
-		}
-	}
+	Player *otherPlayer = PlayerAtPosition(position);
+	if (otherPlayer != nullptr && otherPlayer != &player && otherPlayer->_pHitPoints != 0)
+		return false;
 
 	if (dMonster[position.x][position.y] != 0) {
 		if (leveltype == DTYPE_TOWN) {

--- a/Source/player.h
+++ b/Source/player.h
@@ -905,7 +905,7 @@ inline bool IsInspectingPlayer()
 }
 extern bool MyPlayerIsDead;
 
-Player *PlayerAtPosition(Point position);
+Player *PlayerAtPosition(Point position, bool ignoreMovingPlayers = false);
 
 void LoadPlrGFX(Player &player, player_graphic graphic);
 void InitPlayerGFX(Player &player);

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -501,7 +501,7 @@ bool UseStashItem(uint16_t c)
 	else
 		PlaySFX(ItemInvSnds[ItemCAnimTbl[item->_iCurs]]);
 
-	UseItem(MyPlayerId, item->_iMiscId, item->_iSpell, -1);
+	UseItem(*MyPlayer, item->_iMiscId, item->_iSpell, -1);
 
 	if (Stash.stashList[c]._iMiscId == IMISC_MAPOFDOOM)
 		return true;


### PR DESCRIPTION
Small refactoring.
Done by using more `Player` references and `PlayerAtPosition`.

Btw: it's nice to see that `dPlayer` is relatively rarely used in the current codebase.