### PR TITLE
Use uint8_t in msg/multi/sync and fix MSVC warnings

### DIFF
--- a/Source/dvlnet/abstract_net.h
+++ b/Source/dvlnet/abstract_net.h
@@ -19,7 +19,7 @@ public:
 	virtual int create(std::string addrstr) = 0;
 	virtual int join(std::string addrstr) = 0;
 	virtual bool SNetReceiveMessage(uint8_t *sender, void **data, size_t *size) = 0;
-	virtual bool SNetSendMessage(int dest, void *data, size_t size) = 0;
+	virtual bool SNetSendMessage(uint8_t dest, void *data, size_t size) = 0;
 	virtual bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status) = 0;
 	virtual bool SNetSendTurn(char *data, size_t size) = 0;
 	virtual void SNetGetProviderCaps(struct _SNETCAPS *caps) = 0;

--- a/Source/dvlnet/abstract_net.h
+++ b/Source/dvlnet/abstract_net.h
@@ -18,10 +18,10 @@ class abstract_net {
 public:
 	virtual int create(std::string addrstr) = 0;
 	virtual int join(std::string addrstr) = 0;
-	virtual bool SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size) = 0;
-	virtual bool SNetSendMessage(int dest, void *data, unsigned int size) = 0;
+	virtual bool SNetReceiveMessage(uint8_t *sender, void **data, size_t *size) = 0;
+	virtual bool SNetSendMessage(int dest, void *data, size_t size) = 0;
 	virtual bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status) = 0;
-	virtual bool SNetSendTurn(char *data, unsigned int size) = 0;
+	virtual bool SNetSendTurn(char *data, size_t size) = 0;
 	virtual void SNetGetProviderCaps(struct _SNETCAPS *caps) = 0;
 	virtual bool SNetRegisterEventHandler(event_type evtype, SEVTHANDLER func) = 0;
 	virtual bool SNetUnregisterEventHandler(event_type evtype) = 0;

--- a/Source/dvlnet/base.cpp
+++ b/Source/dvlnet/base.cpp
@@ -210,7 +210,7 @@ tl::expected<void, PacketError> base::RecvLocal(packet &pkt)
 	}
 }
 
-bool base::SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size)
+bool base::SNetReceiveMessage(uint8_t *sender, void **data, size_t *size)
 {
 	poll();
 	if (message_queue.empty())
@@ -223,7 +223,7 @@ bool base::SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size)
 	return true;
 }
 
-bool base::SNetSendMessage(int playerId, void *data, unsigned int size)
+bool base::SNetSendMessage(int playerId, void *data, size_t size)
 {
 	if (playerId != SNPLAYER_ALL && playerId != SNPLAYER_OTHERS
 	    && (playerId < 0 || playerId >= MAX_PLRS))
@@ -336,7 +336,7 @@ bool base::SNetReceiveTurns(char **data, size_t *size, uint32_t *status)
 	return false;
 }
 
-bool base::SNetSendTurn(char *data, unsigned int size)
+bool base::SNetSendTurn(char *data, size_t size)
 {
 	if (size != sizeof(int32_t))
 		ABORT();

--- a/Source/dvlnet/base.cpp
+++ b/Source/dvlnet/base.cpp
@@ -223,17 +223,16 @@ bool base::SNetReceiveMessage(uint8_t *sender, void **data, size_t *size)
 	return true;
 }
 
-bool base::SNetSendMessage(int playerId, void *data, size_t size)
+bool base::SNetSendMessage(uint8_t playerId, void *data, size_t size)
 {
-	if (playerId != SNPLAYER_ALL && playerId != SNPLAYER_OTHERS
-	    && (playerId < 0 || playerId >= MAX_PLRS))
+	if (playerId != SNPLAYER_OTHERS && playerId >= MAX_PLRS)
 		abort();
 	auto *rawMessage = reinterpret_cast<unsigned char *>(data);
 	buffer_t message(rawMessage, rawMessage + size);
-	if (playerId == plr_self || playerId == SNPLAYER_ALL)
+	if (playerId == plr_self)
 		message_queue.emplace_back(plr_self, message);
 	plr_t dest;
-	if (playerId == SNPLAYER_ALL || playerId == SNPLAYER_OTHERS)
+	if (playerId == SNPLAYER_OTHERS)
 		dest = PLR_BROADCAST;
 	else
 		dest = playerId;
@@ -498,7 +497,7 @@ bool base::SNetDropPlayer(int playerid, uint32_t flags)
 
 plr_t base::GetOwner()
 {
-	for (size_t i = 0; i < Players.size(); ++i) {
+	for (plr_t i = 0; i < Players.size(); ++i) {
 		if (IsConnected(i)) {
 			return i;
 		}

--- a/Source/dvlnet/base.h
+++ b/Source/dvlnet/base.h
@@ -18,7 +18,7 @@ namespace net {
 class base : public abstract_net {
 public:
 	bool SNetReceiveMessage(uint8_t *sender, void **data, size_t *size) override;
-	bool SNetSendMessage(int playerId, void *data, size_t size) override;
+	bool SNetSendMessage(uint8_t playerId, void *data, size_t size) override;
 	bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status) override;
 	bool SNetSendTurn(char *data, size_t size) override;
 	void SNetGetProviderCaps(struct _SNETCAPS *caps) override;

--- a/Source/dvlnet/base.h
+++ b/Source/dvlnet/base.h
@@ -17,10 +17,10 @@ namespace net {
 
 class base : public abstract_net {
 public:
-	bool SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size) override;
-	bool SNetSendMessage(int playerId, void *data, unsigned int size) override;
+	bool SNetReceiveMessage(uint8_t *sender, void **data, size_t *size) override;
+	bool SNetSendMessage(int playerId, void *data, size_t size) override;
 	bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status) override;
-	bool SNetSendTurn(char *data, unsigned int size) override;
+	bool SNetSendTurn(char *data, size_t size) override;
 	void SNetGetProviderCaps(struct _SNETCAPS *caps) override;
 	bool SNetRegisterEventHandler(event_type evtype, SEVTHANDLER func) override;
 	bool SNetUnregisterEventHandler(event_type evtype) override;

--- a/Source/dvlnet/cdwrap.cpp
+++ b/Source/dvlnet/cdwrap.cpp
@@ -37,12 +37,12 @@ void cdwrap::setup_gameinfo(buffer_t info)
 		dvlnet_wrap->setup_gameinfo(game_init_info);
 }
 
-bool cdwrap::SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size)
+bool cdwrap::SNetReceiveMessage(uint8_t *sender, void **data, size_t *size)
 {
 	return dvlnet_wrap->SNetReceiveMessage(sender, data, size);
 }
 
-bool cdwrap::SNetSendMessage(int playerID, void *data, unsigned int size)
+bool cdwrap::SNetSendMessage(int playerID, void *data, size_t size)
 {
 	return dvlnet_wrap->SNetSendMessage(playerID, data, size);
 }
@@ -52,7 +52,7 @@ bool cdwrap::SNetReceiveTurns(char **data, size_t *size, uint32_t *status)
 	return dvlnet_wrap->SNetReceiveTurns(data, size, status);
 }
 
-bool cdwrap::SNetSendTurn(char *data, unsigned int size)
+bool cdwrap::SNetSendTurn(char *data, size_t size)
 {
 	return dvlnet_wrap->SNetSendTurn(data, size);
 }

--- a/Source/dvlnet/cdwrap.cpp
+++ b/Source/dvlnet/cdwrap.cpp
@@ -42,7 +42,7 @@ bool cdwrap::SNetReceiveMessage(uint8_t *sender, void **data, size_t *size)
 	return dvlnet_wrap->SNetReceiveMessage(sender, data, size);
 }
 
-bool cdwrap::SNetSendMessage(int playerID, void *data, size_t size)
+bool cdwrap::SNetSendMessage(uint8_t playerID, void *data, size_t size)
 {
 	return dvlnet_wrap->SNetSendMessage(playerID, data, size);
 }

--- a/Source/dvlnet/cdwrap.h
+++ b/Source/dvlnet/cdwrap.h
@@ -35,7 +35,7 @@ public:
 	int create(std::string addrstr) override;
 	int join(std::string addrstr) override;
 	bool SNetReceiveMessage(uint8_t *sender, void **data, size_t *size) override;
-	bool SNetSendMessage(int dest, void *data, size_t size) override;
+	bool SNetSendMessage(uint8_t dest, void *data, size_t size) override;
 	bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status) override;
 	bool SNetSendTurn(char *data, size_t size) override;
 	void SNetGetProviderCaps(struct _SNETCAPS *caps) override;

--- a/Source/dvlnet/cdwrap.h
+++ b/Source/dvlnet/cdwrap.h
@@ -34,10 +34,10 @@ public:
 
 	int create(std::string addrstr) override;
 	int join(std::string addrstr) override;
-	bool SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size) override;
-	bool SNetSendMessage(int dest, void *data, unsigned int size) override;
+	bool SNetReceiveMessage(uint8_t *sender, void **data, size_t *size) override;
+	bool SNetSendMessage(int dest, void *data, size_t size) override;
 	bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status) override;
-	bool SNetSendTurn(char *data, unsigned int size) override;
+	bool SNetSendTurn(char *data, size_t size) override;
 	void SNetGetProviderCaps(struct _SNETCAPS *caps) override;
 	bool SNetRegisterEventHandler(event_type evtype, SEVTHANDLER func) override;
 	bool SNetUnregisterEventHandler(event_type evtype) override;

--- a/Source/dvlnet/loopback.cpp
+++ b/Source/dvlnet/loopback.cpp
@@ -20,7 +20,7 @@ int loopback::join(std::string /*addrstr*/)
 	ABORT();
 }
 
-bool loopback::SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size)
+bool loopback::SNetReceiveMessage(uint8_t *sender, void **data, size_t *size)
 {
 	if (message_queue.empty())
 		return false;
@@ -32,7 +32,7 @@ bool loopback::SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size)
 	return true;
 }
 
-bool loopback::SNetSendMessage(int dest, void *data, unsigned int size)
+bool loopback::SNetSendMessage(int dest, void *data, size_t size)
 {
 	if (dest == plr_single || dest == SNPLAYER_ALL) {
 		auto *rawMessage = reinterpret_cast<unsigned char *>(data);
@@ -51,7 +51,7 @@ bool loopback::SNetReceiveTurns(char **data, size_t *size, uint32_t * /*status*/
 	return true;
 }
 
-bool loopback::SNetSendTurn(char * /*data*/, unsigned int /*size*/)
+bool loopback::SNetSendTurn(char * /*data*/, size_t /*size*/)
 {
 	return true;
 }

--- a/Source/dvlnet/loopback.cpp
+++ b/Source/dvlnet/loopback.cpp
@@ -32,9 +32,9 @@ bool loopback::SNetReceiveMessage(uint8_t *sender, void **data, size_t *size)
 	return true;
 }
 
-bool loopback::SNetSendMessage(int dest, void *data, size_t size)
+bool loopback::SNetSendMessage(uint8_t dest, void *data, size_t size)
 {
-	if (dest == plr_single || dest == SNPLAYER_ALL) {
+	if (dest == plr_single) {
 		auto *rawMessage = reinterpret_cast<unsigned char *>(data);
 		buffer_t message(rawMessage, rawMessage + size);
 		message_queue.push(message);

--- a/Source/dvlnet/loopback.h
+++ b/Source/dvlnet/loopback.h
@@ -20,7 +20,7 @@ public:
 	int create(std::string addrstr) override;
 	int join(std::string addrstr) override;
 	bool SNetReceiveMessage(uint8_t *sender, void **data, size_t *size) override;
-	bool SNetSendMessage(int dest, void *data, size_t size) override;
+	bool SNetSendMessage(uint8_t dest, void *data, size_t size) override;
 	bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status) override;
 	bool SNetSendTurn(char *data, size_t size) override;
 	void SNetGetProviderCaps(struct _SNETCAPS *caps) override;

--- a/Source/dvlnet/loopback.h
+++ b/Source/dvlnet/loopback.h
@@ -19,10 +19,10 @@ public:
 
 	int create(std::string addrstr) override;
 	int join(std::string addrstr) override;
-	bool SNetReceiveMessage(uint8_t *sender, void **data, uint32_t *size) override;
-	bool SNetSendMessage(int dest, void *data, unsigned int size) override;
+	bool SNetReceiveMessage(uint8_t *sender, void **data, size_t *size) override;
+	bool SNetSendMessage(int dest, void *data, size_t size) override;
 	bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status) override;
-	bool SNetSendTurn(char *data, unsigned int size) override;
+	bool SNetSendTurn(char *data, size_t size) override;
 	void SNetGetProviderCaps(struct _SNETCAPS *caps) override;
 	bool SNetRegisterEventHandler(event_type evtype, SEVTHANDLER func) override;
 	bool SNetUnregisterEventHandler(event_type evtype) override;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -187,7 +187,7 @@ std::string_view CmdIdString(_cmd_id cmd)
 #endif // LOG_RECEIVED_MESSAGES
 
 struct TMegaPkt {
-	uint32_t spaceLeft;
+	size_t spaceLeft;
 	std::byte data[32000];
 
 	TMegaPkt()
@@ -2050,7 +2050,7 @@ size_t OnPlayerJoinLevel(const TCmd *pCmd, Player &player)
 		return sizeof(message);
 	}
 
-	const uint16_t playerLevel = SDL_SwapLE16(message.wParam1);
+	const uint8_t playerLevel = static_cast<uint8_t>(SDL_SwapLE16(message.wParam1));
 	bool isSetLevel = message.wParam2 != 0;
 	if (!IsValidLevel(playerLevel, isSetLevel) || !InDungeonBounds(position)) {
 		return sizeof(message);
@@ -2095,7 +2095,7 @@ size_t OnActivatePortal(const TCmd *pCmd, Player &player)
 {
 	const auto &message = *reinterpret_cast<const TCmdLocParam3 *>(pCmd);
 	const Point position { message.x, message.y };
-	const uint16_t level = SDL_SwapLE16(message.wParam1);
+	const uint8_t level = static_cast<uint8_t>(SDL_SwapLE16(message.wParam1));
 	const uint16_t dungeonTypeIdx = SDL_SwapLE16(message.wParam2);
 	const bool isSetLevel = message.wParam3 != 0;
 
@@ -2222,7 +2222,7 @@ size_t OnString(const TCmd *pCmd, Player &player)
 {
 	auto *p = (TCmdString *)pCmd;
 
-	int len = strlen(p->str);
+	size_t len = strlen(p->str);
 	if (gbBufferMsgs == 0)
 		SendPlrMsg(player, p->str);
 
@@ -2383,8 +2383,8 @@ void RecreateItem(const Player &player, const TItem &messageItem, Item &item)
 	item._iMaxCharges = std::clamp<int>(messageItem.bMCh, 0, item._iMaxCharges);
 	item._iCharges = std::clamp<int>(messageItem.bCh, 0, item._iMaxCharges);
 	if (gbIsHellfire) {
-		item._iPLToHit = ClampToHit(item, SDL_SwapLE16(messageItem.wToHit));
-		item._iMaxDam = ClampMaxDam(item, SDL_SwapLE16(messageItem.wMaxDam));
+		item._iPLToHit = ClampToHit(item, static_cast<uint8_t>(SDL_SwapLE16(messageItem.wToHit)));
+		item._iMaxDam = ClampMaxDam(item, static_cast<uint8_t>(SDL_SwapLE16(messageItem.wMaxDam)));
 	}
 	item.dwBuff = dwBuff;
 }

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -413,7 +413,7 @@ void PrePacket()
 	}
 }
 
-void SendPacket(size_t pnum, const void *packet, size_t dwSize)
+void SendPacket(uint8_t pnum, const void *packet, size_t dwSize)
 {
 	if (pnum != sgnCurrMegaPlayer) {
 		sgnCurrMegaPlayer = pnum;
@@ -644,7 +644,7 @@ void DeltaImportData(_cmd_id cmd, uint32_t recvOffset)
 	sgbDeltaChunks++;
 }
 
-size_t OnLevelData(int pnum, const TCmd *pCmd)
+size_t OnLevelData(uint8_t pnum, const TCmd *pCmd)
 {
 	const auto &message = *reinterpret_cast<const TCmdPlrInfoHdr *>(pCmd);
 	const uint16_t wBytes = SDL_SwapLE16(message.wBytes);
@@ -2394,7 +2394,7 @@ void ClearLastSentPlayerCmd()
 	lastSentPlayerCmd = {};
 }
 
-void msg_send_drop_pkt(int pnum, int reason)
+void msg_send_drop_pkt(uint8_t pnum, int reason)
 {
 	TFakeDropPlr cmd;
 
@@ -2447,7 +2447,7 @@ void run_delta_info()
 	FreePackets();
 }
 
-void DeltaExportData(int pnum)
+void DeltaExportData(uint8_t pnum)
 {
 	for (const auto &[levelNum, deltaLevel] : DeltaLevels) {
 		const size_t bufferSize = 1U                                                      /* marker byte, always 0 */
@@ -2777,7 +2777,7 @@ void NetSendCmdGolem(uint8_t mx, uint8_t my, Direction dir, uint8_t menemy, int 
 	NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
-void NetSendCmdLoc(size_t playerId, bool bHiPri, _cmd_id bCmd, Point position)
+void NetSendCmdLoc(uint8_t playerId, bool bHiPri, _cmd_id bCmd, Point position)
 {
 	if (playerId == MyPlayerId && WasPlayerCmdAlreadyRequested(bCmd, position))
 		return;
@@ -3123,7 +3123,7 @@ void delta_close_portal(const Player &player)
 	memset(&sgJunk.portal[player.getId()], 0xFF, sizeof(sgJunk.portal[player.getId()]));
 }
 
-size_t ParseCmd(size_t pnum, const TCmd *pCmd)
+size_t ParseCmd(uint8_t pnum, const TCmd *pCmd)
 {
 	sbLastCmd = pCmd->bCmd;
 	if (sgwPackPlrOffsetTbl[pnum] != 0 && sbLastCmd != CMD_ACK_PLRINFO && sbLastCmd != CMD_SEND_PLRINFO)
@@ -3137,7 +3137,7 @@ size_t ParseCmd(size_t pnum, const TCmd *pCmd)
 
 	switch (pCmd->bCmd) {
 	case CMD_SYNCDATA:
-		return OnSyncData(pCmd, pnum);
+		return OnSyncData(pCmd, player);
 	case CMD_WALKXY:
 		return OnWalk(pCmd, player);
 	case CMD_ADDSTR:

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -718,10 +718,10 @@ extern int dwRecCount;
 void PrepareItemForNetwork(const Item &item, TItem &messageItem);
 void PrepareEarForNetwork(const Item &item, TEar &ear);
 void RecreateItem(const Player &player, const TItem &messageItem, Item &item);
-void msg_send_drop_pkt(int pnum, int reason);
+void msg_send_drop_pkt(uint8_t pnum, int reason);
 bool msg_wait_resync();
 void run_delta_info();
-void DeltaExportData(int pnum);
+void DeltaExportData(uint8_t pnum);
 void DeltaSyncJunk();
 void delta_init();
 void DeltaClearLevel(uint8_t level);
@@ -738,7 +738,7 @@ void DeltaLoadLevel();
 void ClearLastSentPlayerCmd();
 void NetSendCmd(bool bHiPri, _cmd_id bCmd);
 void NetSendCmdGolem(uint8_t mx, uint8_t my, Direction dir, uint8_t menemy, int hp, uint8_t cl);
-void NetSendCmdLoc(size_t playerId, bool bHiPri, _cmd_id bCmd, Point position);
+void NetSendCmdLoc(uint8_t playerId, bool bHiPri, _cmd_id bCmd, Point position);
 void NetSendCmdLocParam1(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1);
 void NetSendCmdLocParam2(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2);
 void NetSendCmdLocParam3(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3);
@@ -759,6 +759,6 @@ void NetSendCmdDamage(bool bHiPri, const Player &player, uint32_t dwDam, DamageT
 void NetSendCmdMonDmg(bool bHiPri, uint16_t wMon, uint32_t dwDam);
 void NetSendCmdString(uint32_t pmask, const char *pszStr);
 void delta_close_portal(const Player &player);
-size_t ParseCmd(size_t pnum, const TCmd *pCmd);
+size_t ParseCmd(uint8_t pnum, const TCmd *pCmd);
 
 } // namespace devilution

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -712,11 +712,6 @@ struct TPkt {
 };
 #pragma pack(pop)
 
-struct TBuffer {
-	uint32_t dwNextWriteOffset;
-	std::byte bData[4096];
-};
-
 extern uint8_t gbBufferMsgs;
 extern int dwRecCount;
 

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -35,7 +35,6 @@
 namespace devilution {
 
 bool gbSomebodyWonGameKludge;
-TBuffer highPriorityBuffer;
 uint16_t sgwPackPlrOffsetTbl[MAX_PLRS];
 bool sgbPlayerTurnBitTbl[MAX_PLRS];
 bool sgbPlayerLeftGameTbl[MAX_PLRS];
@@ -47,7 +46,6 @@ GameData sgGameInitInfo;
 bool gbSelectProvider;
 int sglTimeoutStart;
 int sgdwPlayerLeftReasonTbl[MAX_PLRS];
-TBuffer lowPriorityBuffer;
 uint32_t sgdwGameLoops;
 /**
  * Specifies the maximum number of players in a game, where 1
@@ -75,6 +73,14 @@ const event_type EventTypes[3] = {
 };
 
 namespace {
+
+struct TBuffer {
+	size_t dwNextWriteOffset;
+	std::byte bData[4096];
+};
+
+TBuffer highPriorityBuffer;
+TBuffer lowPriorityBuffer;
 
 constexpr uint16_t HeaderCheckVal =
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -169,7 +169,7 @@ bool IsNetPlayerValid(const Player &player)
 
 void CheckPlayerInfoTimeouts()
 {
-	for (size_t i = 0; i < Players.size(); i++) {
+	for (uint8_t i = 0; i < Players.size(); i++) {
 		Player &player = Players[i];
 		if (&player == MyPlayer) {
 			continue;
@@ -198,7 +198,7 @@ void CheckPlayerInfoTimeouts()
 	}
 }
 
-void SendPacket(size_t playerId, const std::byte *packet, size_t size)
+void SendPacket(uint8_t playerId, const std::byte *packet, size_t size)
 {
 	TPkt pkt;
 
@@ -206,7 +206,7 @@ void SendPacket(size_t playerId, const std::byte *packet, size_t size)
 	const size_t sizeWithheader = size + sizeof(pkt.hdr);
 	pkt.hdr.wLen = SDL_SwapLE16(static_cast<uint16_t>(sizeWithheader));
 	memcpy(pkt.body, packet, size);
-	if (!SNetSendMessage(static_cast<int>(playerId), &pkt.hdr, sizeWithheader))
+	if (!SNetSendMessage(playerId, &pkt.hdr, sizeWithheader))
 		nthread_terminate_game("SNetSendMessage0");
 }
 
@@ -218,9 +218,9 @@ void MonsterSeeds()
 		Monsters[i].aiSeed = seed + i;
 }
 
-void HandleTurnUpperBit(size_t pnum)
+void HandleTurnUpperBit(uint8_t pnum)
 {
-	size_t i;
+	uint8_t i;
 
 	for (i = 0; i < Players.size(); i++) {
 		if ((player_state[i] & PS_CONNECTED) != 0 && i != pnum)
@@ -234,7 +234,7 @@ void HandleTurnUpperBit(size_t pnum)
 	}
 }
 
-void ParseTurn(size_t pnum, uint32_t turn)
+void ParseTurn(uint8_t pnum, uint32_t turn)
 {
 	if ((turn & 0x80000000) != 0)
 		HandleTurnUpperBit(pnum);
@@ -283,7 +283,7 @@ void PlayerLeftMsg(Player &player, bool left)
 
 void ClearPlayerLeftState()
 {
-	for (size_t i = 0; i < Players.size(); i++) {
+	for (uint8_t i = 0; i < Players.size(); i++) {
 		if (sgbPlayerLeftGameTbl[i]) {
 			if (gbBufferMsgs == 1)
 				msg_send_drop_pkt(i, sgdwPlayerLeftReasonTbl[i]);
@@ -298,7 +298,7 @@ void ClearPlayerLeftState()
 
 void CheckDropPlayer()
 {
-	for (size_t i = 0; i < Players.size(); i++) {
+	for (uint8_t i = 0; i < Players.size(); i++) {
 		if ((player_state[i] & PS_ACTIVE) == 0 && (player_state[i] & PS_CONNECTED) != 0) {
 			SNetDropPlayer(i, LEAVE_DROP);
 		}
@@ -328,7 +328,7 @@ void BeginTimeout()
 	CheckDropPlayer();
 }
 
-void HandleAllPackets(size_t pnum, const std::byte *data, size_t size)
+void HandleAllPackets(uint8_t pnum, const std::byte *data, size_t size)
 {
 	for (size_t offset = 0; offset < size;) {
 		size_t messageSize = ParseCmd(pnum, reinterpret_cast<const TCmd *>(&data[offset]));
@@ -351,7 +351,7 @@ void ProcessTmsgs()
 	}
 }
 
-void SendPlayerInfo(size_t pnum, _cmd_id cmd)
+void SendPlayerInfo(uint8_t pnum, _cmd_id cmd)
 {
 	PlayerNetPack packed;
 	Player &myPlayer = *MyPlayer;
@@ -499,7 +499,7 @@ void InitGameInfo()
 	sgGameInitInfo.fullQuests = (!gbIsMultiplayer || *sgOptions.Gameplay.multiplayerFullQuests) ? 1 : 0;
 }
 
-void NetSendLoPri(size_t playerId, const std::byte *data, size_t size)
+void NetSendLoPri(uint8_t playerId, const std::byte *data, size_t size)
 {
 	if (data != nullptr && size != 0) {
 		CopyPacket(&lowPriorityBuffer, data, size);
@@ -507,7 +507,7 @@ void NetSendLoPri(size_t playerId, const std::byte *data, size_t size)
 	}
 }
 
-void NetSendHiPri(size_t playerId, const std::byte *data, size_t size)
+void NetSendHiPri(uint8_t playerId, const std::byte *data, size_t size)
 {
 	if (data != nullptr && size != 0) {
 		CopyPacket(&highPriorityBuffer, data, size);
@@ -536,8 +536,8 @@ void multi_send_msg_packet(uint32_t pmask, const std::byte *data, size_t size)
 	const size_t len = size + sizeof(pkt.hdr);
 	pkt.hdr.wLen = SDL_SwapLE16(static_cast<uint16_t>(len));
 	memcpy(pkt.body, data, size);
-	size_t playerID = 0;
-	for (size_t v = 1; playerID < Players.size(); playerID++, v <<= 1) {
+	uint8_t playerID = 0;
+	for (uint32_t v = 1; playerID < Players.size(); playerID++, v <<= 1) {
 		if ((v & pmask) != 0) {
 			if (!SNetSendMessage(playerID, &pkt.hdr, len)) {
 				nthread_terminate_game("SNetSendMessage");
@@ -549,7 +549,7 @@ void multi_send_msg_packet(uint32_t pmask, const std::byte *data, size_t size)
 
 void multi_msg_countdown()
 {
-	for (size_t i = 0; i < Players.size(); i++) {
+	for (uint8_t i = 0; i < Players.size(); i++) {
 		if ((player_state[i] & PS_TURN_ARRIVED) != 0) {
 			if (gdwMsgLenTbl[i] == sizeof(int32_t))
 				ParseTurn(i, *(int32_t *)glpMsgTbl[i]);
@@ -557,7 +557,7 @@ void multi_msg_countdown()
 	}
 }
 
-void multi_player_left(int pnum, int reason)
+void multi_player_left(uint8_t pnum, int reason)
 {
 	sgbPlayerLeftGameTbl[pnum] = true;
 	sgdwPlayerLeftReasonTbl[pnum] = reason;
@@ -577,7 +577,7 @@ bool multi_handle_delta()
 		return false;
 	}
 
-	for (size_t i = 0; i < Players.size(); i++) {
+	for (uint8_t i = 0; i < Players.size(); i++) {
 		if (sgbSendDeltaTbl[i]) {
 			sgbSendDeltaTbl[i] = false;
 			DeltaExportData(i);
@@ -685,7 +685,7 @@ void multi_process_network_packets()
 	CheckPlayerInfoTimeouts();
 }
 
-void multi_send_zero_packet(size_t pnum, _cmd_id bCmd, const std::byte *data, size_t size)
+void multi_send_zero_packet(uint8_t pnum, _cmd_id bCmd, const std::byte *data, size_t size)
 {
 	assert(pnum != MyPlayerId);
 	assert(data != nullptr);
@@ -810,7 +810,7 @@ void recv_plrinfo(Player &player, const TCmdPlrInfoHdr &header, bool recv)
 	if (&player == MyPlayer) {
 		return;
 	}
-	size_t pnum = player.getId();
+	uint8_t pnum = player.getId();
 	auto &packedPlayer = PackedPlayerBuffer[pnum];
 
 	if (sgwPackPlrOffsetTbl[pnum] != SDL_SwapLE16(header.wOffset)) {

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -128,7 +128,7 @@ std::byte *CopyBufferedPackets(std::byte *destination, TBuffer *source, size_t *
 			*size -= chunkSize;
 		}
 		memmove(source->bData, srcPtr, (source->bData - srcPtr) + source->dwNextWriteOffset + 1);
-		source->dwNextWriteOffset += static_cast<uint32_t>(source->bData - srcPtr);
+		source->dwNextWriteOffset += source->bData - srcPtr;
 		return destination;
 	}
 	return destination;
@@ -524,7 +524,7 @@ void NetSendHiPri(size_t playerId, const std::byte *data, size_t size)
 		remainingSpace = sync_all_monsters(destination, remainingSpace);
 		const size_t len = gdwNormalMsgSize - remainingSpace;
 		pkt.hdr.wLen = SDL_SwapLE16(static_cast<uint16_t>(len));
-		if (!SNetSendMessage(SNPLAYER_OTHERS, &pkt.hdr, static_cast<unsigned>(len)))
+		if (!SNetSendMessage(SNPLAYER_OTHERS, &pkt.hdr, len))
 			nthread_terminate_game("SNetSendMessage");
 	}
 }
@@ -618,7 +618,7 @@ void multi_process_network_packets()
 
 	uint8_t playerId = std::numeric_limits<uint8_t>::max();
 	TPktHdr *pkt;
-	uint32_t dwMsgSize = 0;
+	size_t dwMsgSize = 0;
 	while (SNetReceiveMessage(&playerId, (void **)&pkt, &dwMsgSize)) {
 		dwRecCount++;
 		ClearPlayerLeftState();

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -59,11 +59,11 @@ extern uint32_t player_state[MAX_PLRS];
 extern bool IsLoopback;
 
 void InitGameInfo();
-void NetSendLoPri(size_t playerId, const std::byte *data, size_t size);
-void NetSendHiPri(size_t playerId, const std::byte *data, size_t size);
+void NetSendLoPri(uint8_t playerId, const std::byte *data, size_t size);
+void NetSendHiPri(uint8_t playerId, const std::byte *data, size_t size);
 void multi_send_msg_packet(uint32_t pmask, const std::byte *data, size_t size);
 void multi_msg_countdown();
-void multi_player_left(int pnum, int reason);
+void multi_player_left(uint8_t pnum, int reason);
 void multi_net_ping();
 
 /**
@@ -71,7 +71,7 @@ void multi_net_ping();
  */
 bool multi_handle_delta();
 void multi_process_network_packets();
-void multi_send_zero_packet(size_t pnum, _cmd_id bCmd, const std::byte *data, size_t size);
+void multi_send_zero_packet(uint8_t pnum, _cmd_id bCmd, const std::byte *data, size_t size);
 void NetClose();
 bool NetInit(bool bSinglePlayer);
 void recv_plrinfo(Player &player, const TCmdPlrInfoHdr &header, bool recv);

--- a/Source/storm/storm_net.cpp
+++ b/Source/storm/storm_net.cpp
@@ -29,7 +29,7 @@ SdlMutex storm_net_mutex;
 #endif
 } // namespace
 
-bool SNetReceiveMessage(uint8_t *senderplayerid, void **data, uint32_t *databytes)
+bool SNetReceiveMessage(uint8_t *senderplayerid, void **data, size_t *databytes)
 {
 #ifndef NONET
 	std::lock_guard<SdlMutex> lg(storm_net_mutex);
@@ -37,7 +37,7 @@ bool SNetReceiveMessage(uint8_t *senderplayerid, void **data, uint32_t *databyte
 	return dvlnet_inst->SNetReceiveMessage(senderplayerid, data, databytes);
 }
 
-bool SNetSendMessage(int playerID, void *data, unsigned int databytes)
+bool SNetSendMessage(int playerID, void *data, size_t databytes)
 {
 #ifndef NONET
 	std::lock_guard<SdlMutex> lg(storm_net_mutex);
@@ -55,7 +55,7 @@ bool SNetReceiveTurns(int arraysize, char **arraydata, size_t *arraydatabytes, u
 	return dvlnet_inst->SNetReceiveTurns(arraydata, arraydatabytes, arrayplayerstatus);
 }
 
-bool SNetSendTurn(char *data, unsigned int databytes)
+bool SNetSendTurn(char *data, size_t databytes)
 {
 #ifndef NONET
 	std::lock_guard<SdlMutex> lg(storm_net_mutex);

--- a/Source/storm/storm_net.cpp
+++ b/Source/storm/storm_net.cpp
@@ -37,7 +37,7 @@ bool SNetReceiveMessage(uint8_t *senderplayerid, void **data, size_t *databytes)
 	return dvlnet_inst->SNetReceiveMessage(senderplayerid, data, databytes);
 }
 
-bool SNetSendMessage(int playerID, void *data, size_t databytes)
+bool SNetSendMessage(uint8_t playerID, void *data, size_t databytes)
 {
 #ifndef NONET
 	std::lock_guard<SdlMutex> lg(storm_net_mutex);
@@ -98,7 +98,7 @@ bool SNetDestroy()
 	return true;
 }
 
-bool SNetDropPlayer(int playerid, uint32_t flags)
+bool SNetDropPlayer(uint8_t playerid, uint32_t flags)
 {
 #ifndef NONET
 	std::lock_guard<SdlMutex> lg(storm_net_mutex);

--- a/Source/storm/storm_net.hpp
+++ b/Source/storm/storm_net.hpp
@@ -61,7 +61,7 @@ bool SNetDestroy();
  *
  *  Returns true if the function was called successfully and false otherwise.
  */
-bool SNetDropPlayer(int playerid, uint32_t flags);
+bool SNetDropPlayer(uint8_t playerid, uint32_t flags);
 
 /*  SNetGetTurnsInTransit @ 115
  *
@@ -107,11 +107,10 @@ typedef void (*SEVTHANDLER)(struct _SNETEVENT *);
  *
  *  Returns true if the function was called successfully and false otherwise.
  */
-bool SNetSendMessage(int playerID, void *data, size_t databytes);
+bool SNetSendMessage(uint8_t playerID, void *data, size_t databytes);
 
 // Macro values to target specific players
-#define SNPLAYER_ALL -1
-#define SNPLAYER_OTHERS -2
+constexpr uint8_t SNPLAYER_OTHERS = 0xFF;
 
 /*  SNetSendTurn @ 128
  *

--- a/Source/storm/storm_net.hpp
+++ b/Source/storm/storm_net.hpp
@@ -87,7 +87,7 @@ bool SNetJoinGame(char *gameName, char *gamePassword, int *playerid);
  */
 bool SNetLeaveGame(int type);
 
-bool SNetReceiveMessage(uint8_t *senderplayerid, void **data, uint32_t *databytes);
+bool SNetReceiveMessage(uint8_t *senderplayerid, void **data, size_t *databytes);
 bool SNetReceiveTurns(int arraysize, char **arraydata, size_t *arraydatabytes, uint32_t *arrayplayerstatus);
 
 typedef void (*SEVTHANDLER)(struct _SNETEVENT *);
@@ -107,7 +107,7 @@ typedef void (*SEVTHANDLER)(struct _SNETEVENT *);
  *
  *  Returns true if the function was called successfully and false otherwise.
  */
-bool SNetSendMessage(int playerID, void *data, unsigned int databytes);
+bool SNetSendMessage(int playerID, void *data, size_t databytes);
 
 // Macro values to target specific players
 #define SNPLAYER_ALL -1
@@ -124,7 +124,7 @@ bool SNetSendMessage(int playerID, void *data, unsigned int databytes);
  *
  *  Returns true if the function was called successfully and false otherwise.
  */
-bool SNetSendTurn(char *data, unsigned int databytes);
+bool SNetSendTurn(char *data, size_t databytes);
 
 bool SNetGetOwnerTurnsWaiting(uint32_t *);
 bool SNetUnregisterEventHandler(event_type);

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -293,7 +293,7 @@ size_t sync_all_monsters(std::byte *pbBuf, size_t dwMaxLen)
 	return dwMaxLen;
 }
 
-uint32_t OnSyncData(const TCmd *pCmd, size_t pnum)
+uint32_t OnSyncData(const TCmd *pCmd, const Player &player)
 {
 	const auto &header = *reinterpret_cast<const TSyncHeader *>(pCmd);
 	const uint16_t wLen = SDL_SwapLE16(header.wLen);
@@ -303,7 +303,7 @@ uint32_t OnSyncData(const TCmd *pCmd, size_t pnum)
 	if (gbBufferMsgs == 1) {
 		return wLen + sizeof(header);
 	}
-	if (pnum == MyPlayerId) {
+	if (&player == MyPlayer) {
 		return wLen + sizeof(header);
 	}
 
@@ -315,13 +315,14 @@ uint32_t OnSyncData(const TCmd *pCmd, size_t pnum)
 
 	if (IsValidLevelForMultiplayer(level)) {
 		const auto *monsterSyncs = reinterpret_cast<const TSyncMonster *>(pCmd + sizeof(header));
+		bool isOwner = player.getId() > MyPlayerId;
 
 		for (int i = 0; i < monsterCount; i++) {
 			if (!IsTSyncMonsterValidate(monsterSyncs[i]))
 				continue;
 
 			if (syncLocalLevel) {
-				SyncMonster(pnum > MyPlayerId, monsterSyncs[i]);
+				SyncMonster(isOwner, monsterSyncs[i]);
 			}
 
 			delta_sync_monster(monsterSyncs[i], level);

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -249,7 +249,7 @@ bool IsTSyncMonsterValidate(const TSyncMonster &monsterSync)
 
 } // namespace
 
-uint32_t sync_all_monsters(std::byte *pbBuf, uint32_t dwMaxLen)
+size_t sync_all_monsters(std::byte *pbBuf, size_t dwMaxLen)
 {
 	if (ActiveMonsterCount < 1) {
 		return dwMaxLen;

--- a/Source/sync.h
+++ b/Source/sync.h
@@ -11,7 +11,7 @@
 namespace devilution {
 
 size_t sync_all_monsters(std::byte *pbBuf, size_t dwMaxLen);
-uint32_t OnSyncData(const TCmd *pCmd, size_t pnum);
+uint32_t OnSyncData(const TCmd *pCmd, const Player &player);
 void sync_init();
 
 } // namespace devilution

--- a/Source/sync.h
+++ b/Source/sync.h
@@ -10,7 +10,7 @@
 
 namespace devilution {
 
-uint32_t sync_all_monsters(std::byte *pbBuf, uint32_t dwMaxLen);
+size_t sync_all_monsters(std::byte *pbBuf, size_t dwMaxLen);
 uint32_t OnSyncData(const TCmd *pCmd, size_t pnum);
 void sync_init();
 


### PR DESCRIPTION
This PR reduces warnings by 33 (from 74 to 41).

One of the big changes is the use of `uint8_t` instead of `size_t` for player id in msg/multi/sync/network code (see also discussion in #6849).
I noticed that `SNPLAYER_ALL` was not being used (now removed).
Another thing is that `size_t` is now mostly used to pass memory sizes around in msg/multi/sync.
The rest are just minor MSVC warning fixes.

Sorry this PR is a bit bigger, but I tried to make different commits to make the review process easier.