### PR TITLE
 Add "Return to Main Menu" Option in Pause Menu

### DIFF
--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -43,6 +43,7 @@ TMenuItem sgSingleMenu[] = {
 	{ GMENU_ENABLED, N_("Options"),   &GamemenuOptions    },
 	{ GMENU_ENABLED, N_("New Game"),  &GamemenuNewGame    },
 	{ GMENU_ENABLED, N_("Load Game"), &gamemenu_load_game },
+	{ GMENU_ENABLED, N_("Return to Main Menu"), &gamemenu_return_to_main_menu },
 	{ GMENU_ENABLED, N_("Quit Game"), &gamemenu_quit_game },
 	{ GMENU_ENABLED, nullptr,         nullptr             }
 	// clang-format on
@@ -291,6 +292,13 @@ void gamemenu_quit_game(bool bActivate)
 #else
 	ReturnToMainMenu = true;
 #endif
+}
+
+
+void gamemenu_return_to_main_menu(bool bActivate)
+{
+	GamemenuNewGame(bActivate);
+	ReturnToMainMenu = true;
 }
 
 void gamemenu_load_game(bool /*bActivate*/)

--- a/Source/gamemenu.h
+++ b/Source/gamemenu.h
@@ -13,6 +13,7 @@ void gamemenu_handle_previous();
 void gamemenu_quit_game(bool bActivate);
 void gamemenu_load_game(bool bActivate);
 void gamemenu_save_game(bool bActivate);
+void gamemenu_return_to_main_menu(bool bActivate);
 
 extern bool isGameMenuOpen;
 


### PR DESCRIPTION
This pull request introduces a new feature aimed at enhancing the user experience during gameplay. I've observed that the current game flow requires players to completely exit the game to access the main menu. This process can be somewhat cumbersome, especially when needing to modify settings or switch game modes.

Originally, my goal was to implement direct access to the settings menu from the pause menu. This would have allowed players to adjust and immediately observe graphical changes within the game. However, upon further consideration, I realized that such an implementation might require substantial modifications to the existing game structure.

As a more practical and time-efficient solution, I have added an option in the pause menu that allows players to directly return to the main menu. This feature provides a smoother and more convenient way for players to navigate through the game's various options without the need to exit the game completely.