### PR TITLE
Android build system upgrades

### DIFF
--- a/android-project/app/build.gradle
+++ b/android-project/app/build.gradle
@@ -7,7 +7,7 @@ if (buildAsApplication) {
 }
 
 android {
-	ndkVersion '26.0.10792818'
+	ndkVersion '26.1.10909125'
 	compileSdk 33
 	defaultConfig {
 		if (buildAsApplication) {
@@ -31,6 +31,9 @@ android {
 		}
 	}
 	namespace 'org.diasurgical.devilutionx'
+	buildFeatures {
+		buildConfig true
+	}
 	applicationVariants.all { variant ->
 		tasks["merge${variant.name.capitalize()}Assets"]
 			.dependsOn("externalNativeBuild${variant.name.capitalize()}")

--- a/android-project/build.gradle
+++ b/android-project/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 		google()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:8.1.4'
+		classpath 'com.android.tools.build:gradle:8.2.0'
 
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files

--- a/android-project/gradle.properties
+++ b/android-project/gradle.properties
@@ -1,3 +1,2 @@
-android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
 android.nonTransitiveRClass=false

--- a/android-project/gradle/wrapper/gradle-wrapper.properties
+++ b/android-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Nov 26 11:32:45 EET 2023
+#Wed Dec 13 13:49:58 EET 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
* Upgrade Gradle plugin to 8.2.0
* Upgrade Gradle to 8.5
* Upgrade NDK to 26.1
* Move `buildFeatures` to Gradle build file, since using flag in `gradle.properties` is deprecated

Playtested on my Google Pixel 2, Android 11, but with NDK change, it wouldn't hurt to test CI build on couple more devices before merging