### PR TITLE
Add 1.5.2 release to metainfo

### DIFF
--- a/Packaging/nix/devilutionx.metainfo.xml
+++ b/Packaging/nix/devilutionx.metainfo.xml
@@ -64,13 +64,13 @@
 		</screenshot>
 	</screenshots>
 	<releases>
-		<release version="1.5.2" date="2024-01-01">
+		<release version="1.5.2" date="2023-12-17">
 			<description>
 				<p>This release includes the following updates:</p>
 				<ul>
 					<li>Multiplayer crash fixes</li>
 					<li>Improved packet validation for items</li>
-					<li>Game now builds on Ubuntu 22.04.<br>Warning: This may cause DevilutionX to not launch on systems with older Glibc versions!</li>
+					<li>Release is now built on Ubuntu 22.04.<br>Warning: This may cause DevilutionX to fail launch on systems with older <b>glibc</b> versions!</li>
 				</ul>
 				<p>Please visit the full changelog for more detailed notes</p>
 			</description>

--- a/Packaging/nix/devilutionx.metainfo.xml
+++ b/Packaging/nix/devilutionx.metainfo.xml
@@ -64,7 +64,19 @@
 		</screenshot>
 	</screenshots>
 	<releases>
-		<release version="1.5.1" date="2023-xx-xx">
+		<release version="1.5.2" date="2024-01-01">
+			<description>
+				<p>This release includes the following updates:</p>
+				<ul>
+					<li>Multiplayer crash fixes</li>
+					<li>Improved packet validation for items</li>
+					<li>Game now builds on Ubuntu 22.04.<br>Warning: This may cause DevilutionX to not launch on systems with older Glibc versions!</li>
+				</ul>
+				<p>Please visit the full changelog for more detailed notes</p>
+			</description>
+			<url>https://github.com/diasurgical/devilutionX/releases/tag/1.5.2</url>
+		</release>
+		<release version="1.5.1" date="2023-09-02">
 			<description>
 				<p>This is a primarily bugfix release, which includes the following updates:</p>
 				<ul>


### PR DESCRIPTION
TODO: Release date was put as a stopgap to avoid tripping Flatpak validator, change it before actual release date