### PR TITLE
Fix MSVC warnings in controls\*

### DIFF
--- a/Source/controls/controller_motion.cpp
+++ b/Source/controls/controller_motion.cpp
@@ -149,21 +149,22 @@ bool IsControllerMotion(const SDL_Event &event)
 	}
 #endif
 
+#if defined(JOY_AXIS_LEFTX) || defined(JOY_AXIS_LEFTY) || defined(JOY_AXIS_RIGHTX) || defined(JOY_AXIS_RIGHTY)
 	if (event.type == SDL_JOYAXISMOTION) {
 		switch (event.jaxis.axis) {
 #ifdef JOY_AXIS_LEFTX
 		case JOY_AXIS_LEFTX:
 			return true;
 #endif
-#ifdef JOY_AXIS_LEFTX
+#ifdef JOY_AXIS_LEFTY
 		case JOY_AXIS_LEFTY:
 			return true;
 #endif
-#ifdef JOY_AXIS_LEFTX
+#ifdef JOY_AXIS_RIGHTX
 		case JOY_AXIS_RIGHTX:
 			return true;
 #endif
-#ifdef JOY_AXIS_LEFTX
+#ifdef JOY_AXIS_RIGHTY
 		case JOY_AXIS_RIGHTY:
 			return true;
 #endif
@@ -171,6 +172,7 @@ bool IsControllerMotion(const SDL_Event &event)
 			return false;
 		}
 	}
+#endif
 
 	return false;
 }

--- a/Source/controls/devices/joystick.cpp
+++ b/Source/controls/devices/joystick.cpp
@@ -16,6 +16,10 @@ StaticVector<ControllerButtonEvent, 4> Joystick::ToControllerButtonEvents(const 
 	case SDL_JOYBUTTONDOWN:
 	case SDL_JOYBUTTONUP: {
 		bool up = (event.jbutton.state == SDL_RELEASED);
+#if defined(JOY_BUTTON_A) || defined(JOY_BUTTON_B) || defined(JOY_BUTTON_X) || defined(JOY_BUTTON_Y)                                            \
+    || defined(JOY_BUTTON_LEFTSTICK) || defined(JOY_BUTTON_RIGHTSTICK) || defined(JOY_BUTTON_LEFTSHOULDER) || defined(JOY_BUTTON_RIGHTSHOULDER) \
+    || defined(JOY_BUTTON_TRIGGERLEFT) || defined(JOY_BUTTON_TRIGGERRIGHT) || defined(JOY_BUTTON_START) || defined(JOY_BUTTON_BACK)             \
+    || defined(JOY_BUTTON_DPAD_LEFT) || defined(JOY_BUTTON_DPAD_UP) || defined(JOY_BUTTON_DPAD_RIGHT) || defined(JOY_BUTTON_DPAD_DOWN)
 		switch (event.jbutton.button) {
 #ifdef JOY_BUTTON_A
 		case JOY_BUTTON_A:
@@ -84,7 +88,9 @@ StaticVector<ControllerButtonEvent, 4> Joystick::ToControllerButtonEvents(const 
 		default:
 			return { ControllerButtonEvent { ControllerButton_IGNORE, up } };
 		}
-		break;
+#else
+		return { ControllerButtonEvent { ControllerButton_IGNORE, up } };
+#endif
 	}
 	case SDL_JOYHATMOTION: {
 		Joystick *joystick = Get(event);
@@ -167,6 +173,10 @@ void Joystick::UnlockHatState()
 
 int Joystick::ToSdlJoyButton(ControllerButton button)
 {
+#if defined(JOY_BUTTON_A) || defined(JOY_BUTTON_B) || defined(JOY_BUTTON_X) || defined(JOY_BUTTON_Y)                                                \
+    || defined(JOY_BUTTON_BACK) || defined(JOY_BUTTON_START) || defined(JOY_BUTTON_LEFTSTICK) || defined(JOY_BUTTON_RIGHTSTICK)                     \
+    || defined(JOY_BUTTON_LEFTSHOULDER) || defined(JOY_BUTTON_RIGHTSHOULDER) || defined(JOY_BUTTON_TRIGGERLEFT) || defined(JOY_BUTTON_TRIGGERRIGHT) \
+    || defined(JOY_BUTTON_DPAD_LEFT) || defined(JOY_BUTTON_DPAD_UP) || defined(JOY_BUTTON_DPAD_RIGHT) || defined(JOY_BUTTON_DPAD_DOWN)
 	switch (button) {
 #ifdef JOY_BUTTON_A
 	case ControllerButton_BUTTON_A:
@@ -235,11 +245,15 @@ int Joystick::ToSdlJoyButton(ControllerButton button)
 	default:
 		return -1;
 	}
+#else
+	return -1;
+#endif
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static): Not static if joystick mappings are defined.
 bool Joystick::IsHatButtonPressed(ControllerButton button) const
 {
+#if (defined(JOY_HAT_DPAD_UP_HAT) && defined(JOY_HAT_DPAD_UP)) || (defined(JOY_HAT_DPAD_DOWN_HAT) && defined(JOY_HAT_DPAD_DOWN)) || (defined(JOY_HAT_DPAD_LEFT_HAT) && defined(JOY_HAT_DPAD_LEFT)) || (defined(JOY_HAT_DPAD_RIGHT_HAT) && defined(JOY_HAT_DPAD_RIGHT))
 	switch (button) {
 #if defined(JOY_HAT_DPAD_UP_HAT) && defined(JOY_HAT_DPAD_UP)
 	case ControllerButton_BUTTON_DPAD_UP:
@@ -260,6 +274,9 @@ bool Joystick::IsHatButtonPressed(ControllerButton button) const
 	default:
 		return false;
 	}
+#else
+	return false;
+#endif
 }
 
 bool Joystick::IsPressed(ControllerButton button) const
@@ -279,6 +296,8 @@ bool Joystick::ProcessAxisMotion(const SDL_Event &event)
 {
 	if (event.type != SDL_JOYAXISMOTION)
 		return false;
+
+#if defined(JOY_AXIS_LEFTX) || defined(JOY_AXIS_LEFTY) || defined(JOY_AXIS_RIGHTX) || defined(JOY_AXIS_RIGHTY)
 	switch (event.jaxis.axis) {
 #ifdef JOY_AXIS_LEFTX
 	case JOY_AXIS_LEFTX:
@@ -307,6 +326,9 @@ bool Joystick::ProcessAxisMotion(const SDL_Event &event)
 	default:
 		return false;
 	}
+#else
+	return false;
+#endif
 }
 
 void Joystick::Add(int deviceIndex)

--- a/Source/controls/touch/gamepad.cpp
+++ b/Source/controls/touch/gamepad.cpp
@@ -14,6 +14,11 @@ namespace {
 
 constexpr double Pi = 3.141592653589793;
 
+int roundToInt(double value)
+{
+	return static_cast<int>(round(value));
+}
+
 constexpr bool PointsUp(double angle)
 {
 	constexpr double UpAngle = Pi / 2;
@@ -52,7 +57,7 @@ void InitializeVirtualGamepad()
 	int inputMargin = screenPixels / 10;
 	int menuButtonWidth = screenPixels / 10;
 	int directionPadSize = screenPixels / 4;
-	int padButtonSize = round(1.1 * screenPixels / 10);
+	int padButtonSize = roundToInt(1.1 * screenPixels / 10);
 	int padButtonSpacing = inputMargin / 3;
 
 	float hdpi;
@@ -70,11 +75,11 @@ void InitializeVirtualGamepad()
 		vdpi *= static_cast<float>(gnScreenHeight) / clientHeight;
 
 		float dpi = std::min(hdpi, vdpi);
-		inputMargin = round(0.25 * dpi);
-		menuButtonWidth = round(0.2 * dpi);
-		directionPadSize = round(dpi);
-		padButtonSize = round(0.3 * dpi);
-		padButtonSpacing = round(0.1 * dpi);
+		inputMargin = roundToInt(0.25 * dpi);
+		menuButtonWidth = roundToInt(0.2 * dpi);
+		directionPadSize = roundToInt(dpi);
+		padButtonSize = roundToInt(0.3 * dpi);
+		padButtonSpacing = roundToInt(0.1 * dpi);
 	}
 
 	int menuPanelTopMargin = 30;
@@ -85,7 +90,7 @@ void InitializeVirtualGamepad()
 	int rightMarginMenuButton2 = rightMarginMenuButton3 + menuPanelButtonSpacing + menuPanelButtonSize.width;
 	int rightMarginMenuButton1 = rightMarginMenuButton2 + menuPanelButtonSpacing + menuPanelButtonSize.width;
 
-	int padButtonAreaWidth = round(std::sqrt(2) * (padButtonSize + padButtonSpacing));
+	int padButtonAreaWidth = roundToInt(std::sqrt(2) * (padButtonSize + padButtonSpacing));
 
 	int padButtonRight = gnScreenWidth - inputMargin - padButtonSize / 2;
 	int padButtonLeft = padButtonRight - padButtonAreaWidth;
@@ -130,7 +135,7 @@ void InitializeVirtualGamepad()
 	directionPad.position = directionPadArea.position;
 
 	int standButtonDiagonalOffset = directionPadArea.radius + padButtonSpacing / 2 + padButtonSize / 2;
-	int standButtonOffset = round(standButtonDiagonalOffset / std::sqrt(2));
+	int standButtonOffset = roundToInt(standButtonDiagonalOffset / std::sqrt(2));
 	Circle &standButtonArea = VirtualGamepadState.standButton.area;
 	standButtonArea.position.x = directionPadArea.position.x - standButtonOffset;
 	standButtonArea.position.y = directionPadArea.position.y + standButtonOffset;
@@ -223,8 +228,8 @@ void VirtualDirectionPad::UpdatePosition(Point touchCoordinates)
 		int x = diff.deltaX;
 		int y = diff.deltaY;
 		double dist = sqrt(x * x + y * y);
-		x = round(x * area.radius / dist);
-		y = round(y * area.radius / dist);
+		x = roundToInt(x * area.radius / dist);
+		y = roundToInt(y * area.radius / dist);
 		position.x = area.position.x + x;
 		position.y = area.position.y + y;
 	}


### PR DESCRIPTION
This PR reduces warnings by 15 (from 32 to 17)

Changes are
- when using `round` cast to int
- avoid switches with only default-case (warning C4065; `switch statement contains 'default' but no 'case' labels`)

The C4065 warning was a bit annoying, as I think the old syntax is fine.
This PR will wrap each switch with another `#ifdef' to see if there is a case present.
An alternative fix would be to ignore the warning. So if we think this is better, we can change the PR.

Note: I haven't been able to test this PR because I don't own a joystick, let alone a device which enables the defines.