### PR TITLE
Fix MSVC warnings in stores.cpp

### DIFF
--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -348,7 +348,7 @@ bool StoreAutoPlace(Item &item, bool persistItem)
 	return AutoPlaceItemInInventory(player, item, persistItem, true);
 }
 
-void ScrollVendorStore(Item *itemData, int storeLimit, int idx, int selling = true)
+void ScrollVendorStore(Item *itemData, size_t storeLimit, int idx, int selling = true)
 {
 	ClearSText(5, 21);
 	stextup = 5;
@@ -370,7 +370,7 @@ void ScrollVendorStore(Item *itemData, int storeLimit, int idx, int selling = tr
 		if (stextsel != -1 && !stext[stextsel].isSelectable() && stextsel != BackButtonLine())
 			stextsel = stextdown;
 	} else {
-		stextsmax = std::max(storeLimit - 4, 0);
+		stextsmax = std::max(static_cast<int>(storeLimit) - 4, 0);
 	}
 }
 


### PR DESCRIPTION
This PR reduces warnings by 4 (from 17 to 13).

I thought about doing more refactoring... but stores.cpp needs a more general approach.

Now only `mpq_writer` and `mpq_sdl_rwops` is missing. And there I'm unsure if I should change everything size related to `size_t`, `uint32_t` or `uintmax_t`. 😁 