### PR TITLE
Remove byte order logic from half-transparency lookups

### DIFF
--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -52,11 +52,7 @@ void DrawHalfTransparentAligned32BlendedRectTo(const Surface &out, unsigned sx, 
 	while (height-- > 0) {
 		for (unsigned i = 0; i < width; ++i, ++pix) {
 			const uint32_t v = *pix;
-#if SDL_BYTEORDER == SDL_LIL_ENDIAN
 			*pix = lookupTable[v & 0xFFFF] | (lookupTable[(v >> 16) & 0xFFFF] << 16);
-#else
-			*pix = lookupTable[(v >> 16) & 0xFFFF] | (lookupTable[v & 0xFFFF] << 16);
-#endif
 		}
 		pix += skipX;
 	}

--- a/Source/engine/palette.cpp
+++ b/Source/engine/palette.cpp
@@ -107,11 +107,7 @@ void GenerateBlendedLookupTable(std::array<SDL_Color, 256> &palette, int skipFro
 #if DEVILUTIONX_PALETTE_TRANSPARENCY_BLACK_16_LUT
 	for (unsigned i = 0; i < 256; ++i) {
 		for (unsigned j = 0; j < 256; ++j) {
-#if SDL_BYTEORDER == SDL_LIL_ENDIAN
 			const std::uint16_t index = i | (j << 8);
-#else
-			const std::uint16_t index = j | (i << 8);
-#endif
 			paletteTransparencyLookupBlack16[index] = paletteTransparencyLookup[0][i] | (paletteTransparencyLookup[0][j] << 8);
 		}
 	}


### PR DESCRIPTION
I think I see two issues. First, here is where we draw the half-transparent rectangle.

https://github.com/diasurgical/devilutionX/blob/6648f080bae31c67bb554372c233d555b42392b7/Source/engine.cpp#L54-L59

When we make use of this lookup table on big-endian systems, we swap the 16-bit values we pass into the lookup, but the 16-bit values themselves are in the system's native endian order. However, since we are interpreting the original pixel as a native-endian 32-bit value and also assigning `*pix` as a native-endian 32-bit value, I think it would be easiest to use native-endian order throughout. The little-endian logic doesn't swap any bytes so we can just remove the special case for big-endian systems.

And that just leaves us with making sure that we build the lookup table using native-endian order...

https://github.com/diasurgical/devilutionX/blob/6648f080bae31c67bb554372c233d555b42392b7/Source/engine/palette.cpp#L110-L115

On big-endian systems, `i` is placed before `j` when computing `index`, but `paletteTransparencyLookup[0][j]` is placed before `paletteTransparencyLookup[0][i]` regardless of the endian order. This swaps the bytes on big-endian systems when you use this lookup table. Since we want to use native-endian order, we don't need to swap any bytes on any systems. Therefore, once again, we should be able to remove the special case for big-endian systems since we currently don't swap the bytes on little-endian systems.

This resolves #6871 (I assume)