### PR TITLE
Lower optimizations for Amiga because of compiler bugs

### DIFF
--- a/.github/workflows/amiga-m68k.yml
+++ b/.github/workflows/amiga-m68k.yml
@@ -41,7 +41,7 @@ jobs:
             -B build \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
-            -DM68K_COMMON="-s -fbbb=- -ffast-math" \
+            -DM68K_COMMON="-s -ffast-math" \
             -DM68K_CPU=68040 \
             -DM68K_FPU=hard
 

--- a/CMake/platforms/amiga.cmake
+++ b/CMake/platforms/amiga.cmake
@@ -8,9 +8,9 @@ set(SDL1_VIDEO_MODE_BPP 8)
 set(DEVILUTIONX_SYSTEM_BZIP2 OFF)
 set(DEVILUTIONX_SYSTEM_ZLIB OFF)
 
-# Lower the optimization level to O2 because there are issues with O3.
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
+# Lower the optimization level to O1 because there are issues with O2 and O3.
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O1")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O1")
 
 # `fseeko` fails to link on Amiga.
 add_definitions(-Dfseeko=fseek)

--- a/Packaging/amiga/Dockerfile
+++ b/Packaging/amiga/Dockerfile
@@ -9,5 +9,5 @@ CMD cmake -S. -Bbuild-amiga -DCPACK=ON \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DM68K_CPU=68040 \
 		-DM68K_FPU=hard \
-		-DM68K_COMMON="-s -fbbb=- -ffast-math" && \
+		-DM68K_COMMON="-s -ffast-math" && \
 	cmake --build build-amiga -j $(nproc)


### PR DESCRIPTION
`-O2` is causing a CPU lockup in `PcxToClx()` with the current version of GCC 13 for Amiga.

This avoid the issue by lowering the optimizations to `-O1` for now. Performance seems largely unaffected compared to builds with GCC 6 at `-O2/3`.