### PR TITLE
Fix remaining MSVC x64 SDL2 warnings

### DIFF
--- a/Source/mpq/mpq_reader.cpp
+++ b/Source/mpq/mpq_reader.cpp
@@ -96,7 +96,7 @@ std::unique_ptr<std::byte[]> MpqArchive::ReadFile(std::string_view filename, std
 	return result;
 }
 
-int32_t MpqArchive::ReadBlock(uint32_t fileNumber, uint32_t blockNumber, uint8_t *out, uint32_t outSize)
+int32_t MpqArchive::ReadBlock(uint32_t fileNumber, uint32_t blockNumber, uint8_t *out, size_t outSize)
 {
 	std::vector<std::uint8_t> &tmpBuf = GetTemporaryBuffer(outSize);
 	return libmpq__block_read_with_temporary_buffer(

--- a/Source/mpq/mpq_reader.hpp
+++ b/Source/mpq/mpq_reader.hpp
@@ -44,7 +44,7 @@ public:
 	std::unique_ptr<std::byte[]> ReadFile(std::string_view filename, std::size_t &fileSize, int32_t &error);
 
 	// Returns error code.
-	int32_t ReadBlock(uint32_t fileNumber, uint32_t blockNumber, uint8_t *out, uint32_t outSize);
+	int32_t ReadBlock(uint32_t fileNumber, uint32_t blockNumber, uint8_t *out, size_t outSize);
 
 	std::size_t GetUnpackedFileSize(uint32_t fileNumber, int32_t &error);
 

--- a/Source/mpq/mpq_writer.hpp
+++ b/Source/mpq/mpq_writer.hpp
@@ -38,7 +38,7 @@ private:
 
 	bool ReadMPQHeader(MpqFileHeader *hdr);
 	MpqBlockEntry *AddFile(std::string_view filename, MpqBlockEntry *block, uint32_t blockIndex);
-	bool WriteFileContents(const std::byte *fileData, size_t fileSize, MpqBlockEntry *block);
+	bool WriteFileContents(const std::byte *fileData, uint32_t fileSize, MpqBlockEntry *block);
 
 	// Returns an unused entry in the block entry table.
 	MpqBlockEntry *NewBlock(uint32_t *blockIndex = nullptr);
@@ -57,7 +57,7 @@ private:
 
 	LoggedFStream stream_;
 	std::string name_;
-	std::uintmax_t size_ {};
+	uint32_t size_ {};
 	std::unique_ptr<MpqHashEntry[]> hashTable_;
 	std::unique_ptr<MpqBlockEntry[]> blockTable_;
 


### PR DESCRIPTION
This PR fixes all remaining MSVC warnings for x64 (debug and release) on SDL2.

I tried to stay close to the original/existing code.
For SDL_RWops/Reading `size_t` is used for size.
For MpqWriter `uint32_t` is used for size.

It was a long way from 703 warnings to 0.
I hope that the cleanups will not only help to reduce the warnings, but also make the code more consistent. Especially with the types used.