### PR TITLE
Fix MSVC x86 and x64 SDL1 warnings

### DIFF
--- a/Source/engine/assets.hpp
+++ b/Source/engine/assets.hpp
@@ -149,7 +149,7 @@ struct AssetRef {
 			int32_t error;
 			return archive->GetUnpackedFileSize(fileNumber, error);
 		}
-		return SDL_RWsize(directHandle);
+		return static_cast<size_t>(SDL_RWsize(directHandle));
 	}
 };
 

--- a/Source/engine/assets.hpp
+++ b/Source/engine/assets.hpp
@@ -192,7 +192,11 @@ struct AssetHandle {
 
 	bool read(void *buffer, size_t len)
 	{
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 		return handle->read(handle, buffer, len, 1) == 1;
+#else
+		return handle->read(handle, buffer, static_cast<int>(len), 1) == 1;
+#endif
 	}
 
 	bool seek(long pos)

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -46,7 +46,7 @@ const int BarPos[3][2] = { { 53, 37 }, { 53, 421 }, { 53, 37 } };
 
 OptionalOwnedClxSpriteList ArtCutsceneWidescreen;
 
-uint16_t CustomEventsBegin = SDL_USEREVENT;
+SdlEventType CustomEventsBegin = SDL_USEREVENT;
 constexpr uint16_t NumCustomEvents = WM_LAST - WM_FIRST + 1;
 
 Cutscenes GetCutSceneFromLevelType(dungeon_type type)
@@ -234,17 +234,17 @@ void RegisterCustomEvents()
 #endif
 }
 
-bool IsCustomEvent(uint16_t eventType)
+bool IsCustomEvent(SdlEventType eventType)
 {
 	return eventType >= CustomEventsBegin && eventType < CustomEventsBegin + NumCustomEvents;
 }
 
-interface_mode GetCustomEvent(uint16_t eventType)
+interface_mode GetCustomEvent(SdlEventType eventType)
 {
 	return static_cast<interface_mode>(eventType - CustomEventsBegin);
 }
 
-uint16_t CustomEventToSdlEvent(interface_mode eventType)
+SdlEventType CustomEventToSdlEvent(interface_mode eventType)
 {
 	return CustomEventsBegin + eventType;
 }

--- a/Source/interfac.h
+++ b/Source/interfac.h
@@ -32,11 +32,17 @@ enum interface_mode : uint8_t {
 
 void RegisterCustomEvents();
 
-bool IsCustomEvent(uint16_t eventType);
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+using SdlEventType = uint16_t;
+#else
+using SdlEventType = uint8_t;
+#endif
 
-interface_mode GetCustomEvent(uint16_t eventType);
+bool IsCustomEvent(SdlEventType eventType);
 
-uint16_t CustomEventToSdlEvent(interface_mode eventType);
+interface_mode GetCustomEvent(SdlEventType eventType);
+
+SdlEventType CustomEventToSdlEvent(interface_mode eventType);
 
 enum Cutscenes : uint8_t {
 	CutStart,

--- a/Source/mpq/mpq_reader.cpp
+++ b/Source/mpq/mpq_reader.cpp
@@ -72,7 +72,7 @@ std::unique_ptr<std::byte[]> MpqArchive::ReadFile(std::string_view filename, std
 	if (error != 0)
 		return result;
 
-	result = std::make_unique<std::byte[]>(unpackedSize);
+	result = std::make_unique<std::byte[]>(static_cast<size_t>(unpackedSize));
 
 	const std::size_t blockSize = GetBlockSize(fileNumber, 0, error);
 	if (error != 0)
@@ -92,7 +92,7 @@ std::unique_ptr<std::byte[]> MpqArchive::ReadFile(std::string_view filename, std
 	}
 	CloseBlockOffsetTable(fileNumber);
 
-	fileSize = unpackedSize;
+	fileSize = static_cast<size_t>(unpackedSize);
 	return result;
 }
 
@@ -109,7 +109,7 @@ std::size_t MpqArchive::GetUnpackedFileSize(uint32_t fileNumber, int32_t &error)
 {
 	libmpq__off_t unpackedSize;
 	error = libmpq__file_size_unpacked(archive_, fileNumber, &unpackedSize);
-	return unpackedSize;
+	return static_cast<size_t>(unpackedSize);
 }
 
 uint32_t MpqArchive::GetNumBlocks(uint32_t fileNumber, int32_t &error)
@@ -134,7 +134,7 @@ std::size_t MpqArchive::GetBlockSize(uint32_t fileNumber, uint32_t blockNumber, 
 {
 	libmpq__off_t blockSize;
 	error = libmpq__block_size_unpacked(archive_, fileNumber, blockNumber, &blockSize);
-	return blockSize;
+	return static_cast<size_t>(blockSize);
 }
 
 bool MpqArchive::HasFile(std::string_view filename) const

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -286,7 +286,11 @@ void CreateDetailDiffs(std::string_view prefix, std::string_view memoryMapFile, 
 
 	size_t readBytes = static_cast<size_t>(SDL_RWsize(handle));
 	std::unique_ptr<std::byte[]> memoryMapFileData { new std::byte[readBytes] };
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 	SDL_RWread(handle, memoryMapFileData.get(), readBytes, 1);
+#else
+	SDL_RWread(handle, memoryMapFileData.get(), static_cast<int>(readBytes), 1);
+#endif
 	SDL_RWclose(handle);
 
 	const std::string_view buffer(reinterpret_cast<const char *>(memoryMapFileData.get()), readBytes);

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -284,7 +284,7 @@ void CreateDetailDiffs(std::string_view prefix, std::string_view memoryMapFile, 
 		return;
 	}
 
-	size_t readBytes = SDL_RWsize(handle);
+	size_t readBytes = static_cast<size_t>(SDL_RWsize(handle));
 	std::unique_ptr<std::byte[]> memoryMapFileData { new std::byte[readBytes] };
 	SDL_RWread(handle, memoryMapFileData.get(), readBytes, 1);
 	SDL_RWclose(handle);

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -348,7 +348,7 @@ bool StoreAutoPlace(Item &item, bool persistItem)
 	return AutoPlaceItemInInventory(player, item, persistItem, true);
 }
 
-void ScrollVendorStore(Item *itemData, size_t storeLimit, int idx, int selling = true)
+void ScrollVendorStore(Item *itemData, int storeLimit, int idx, int selling = true)
 {
 	ClearSText(5, 21);
 	stextup = 5;
@@ -393,7 +393,7 @@ void StartSmith()
 
 void ScrollSmithBuy(int idx)
 {
-	ScrollVendorStore(smithitem, std::size(smithitem), idx);
+	ScrollVendorStore(smithitem, static_cast<int>(std::size(smithitem)), idx);
 }
 
 uint32_t TotalPlayerGold()
@@ -439,7 +439,7 @@ void ScrollSmithPremiumBuy(int boughtitems)
 			boughtitems--;
 	}
 
-	ScrollVendorStore(premiumitems, std::size(premiumitems), idx);
+	ScrollVendorStore(premiumitems, static_cast<int>(std::size(premiumitems)), idx);
 }
 
 bool StartSmithPremiumBuy()
@@ -689,7 +689,7 @@ void StartWitch()
 
 void ScrollWitchBuy(int idx)
 {
-	ScrollVendorStore(witchitem, std::size(witchitem), idx);
+	ScrollVendorStore(witchitem, static_cast<int>(std::size(witchitem)), idx);
 }
 
 void WitchBookLevel(Item &bookItem)
@@ -1038,7 +1038,7 @@ void StartHealer()
 
 void ScrollHealerBuy(int idx)
 {
-	ScrollVendorStore(healitem, std::size(healitem), idx);
+	ScrollVendorStore(healitem, static_cast<int>(std::size(healitem)), idx);
 }
 
 void StartHealerBuy()

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -387,8 +387,9 @@ TEST(Writehero, pfile_write_hero)
 	pfile_write_hero();
 
 	const char *path = "multi_0.sv";
-	uintmax_t size;
-	ASSERT_TRUE(GetFileSize(path, &size));
+	uintmax_t fileSize;
+	ASSERT_TRUE(GetFileSize(path, &fileSize));
+	size_t size = static_cast<size_t>(fileSize);
 	FILE *f = std::fopen(path, "rb");
 	ASSERT_TRUE(f != nullptr);
 	std::unique_ptr<char[]> data { new char[size] };


### PR DESCRIPTION
As a bonus this PR fixes the warnings for the remaining MSVC configurations (x86 (debug and release) and x64 SDL1 (debug)).