### PR TITLE
Golem friendly fire

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -206,7 +206,8 @@ bool MonsterMHit(const Player &player, int monsterId, int mindam, int maxdam, in
 {
 	auto &monster = Monsters[monsterId];
 
-	if (!monster.isPossibleToHit() || monster.isImmune(t, damageType))
+	if (!monster.isPossibleToHit() || monster.isImmune(t, damageType)
+	    || (monster.type().type == MT_GOLEM && sgGameInitInfo.bFriendlyFire == 0 && player.friendlyMode))
 		return false;
 
 	int hit = RandomIntLessThan(100);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -571,7 +571,7 @@ bool PlrHitMonst(Player &player, Monster &monster, bool adjacentDamage = false)
 {
 	int hper = 0;
 
-	if (!monster.isPossibleToHit() || (monster.type().type == MT_GOLEM && sgGameInitInfo.bFriendlyFire == 0 && player.friendlyMode))
+	if (!monster.isPossibleToHit() || (monster.type().type == MT_GOLEM && player.friendlyMode))
 		return false;
 
 	if (adjacentDamage) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -571,7 +571,7 @@ bool PlrHitMonst(Player &player, Monster &monster, bool adjacentDamage = false)
 {
 	int hper = 0;
 
-	if (!monster.isPossibleToHit())
+	if (!monster.isPossibleToHit() || (monster.type().type == MT_GOLEM && sgGameInitInfo.bFriendlyFire == 0 && player.friendlyMode))
 		return false;
 
 	if (adjacentDamage) {


### PR DESCRIPTION
Makes Golems immune to friendly fire when friendly fire setting is disabled and friendly mode is enabled.  Fixes https://github.com/diasurgical/devilutionX/issues/4352