### PR TITLE
Support dynamically spawned monsters in multiplayer

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3080,10 +3080,7 @@ void ProcessHorkSpawn(Missile &missile)
 
 		if (spawnPosition) {
 			auto facing = static_cast<Direction>(missile.var1);
-			Monster *monster = AddMonster(*spawnPosition, facing, 1, true);
-			if (monster != nullptr) {
-				M_StartStand(*monster, facing);
-			}
+			SpawnMonster(*spawnPosition, facing, 1);
 		}
 	} else {
 		missile._midist++;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3135,6 +3135,21 @@ MonsterSpritesData LoadMonsterSpritesData(const MonsterData &monsterData)
 	return result;
 }
 
+void EnsureMonsterIndexIsActive(size_t monsterId)
+{
+	assert(monsterId < MaxMonsters);
+	for (size_t index = 0; index < MaxMonsters; index++) {
+		if (ActiveMonsters[index] != monsterId)
+			continue;
+		if (index < ActiveMonsterCount)
+			return; // monster is already active
+		int oldId = ActiveMonsters[ActiveMonsterCount];
+		ActiveMonsters[ActiveMonsterCount] = static_cast<int>(monsterId);
+		ActiveMonsters[index] = oldId;
+		ActiveMonsterCount += 1;
+	}
+}
+
 } // namespace
 
 size_t AddMonsterType(_monster_id type, placeflag placeflag)
@@ -3645,9 +3660,58 @@ Monster *AddMonster(Point position, Direction dir, size_t typeIndex, bool inMap)
 
 void SpawnMonster(Point position, Direction dir, size_t typeIndex, bool startSpecialStand /*= false*/)
 {
-	Monster *monster = AddMonster(position, dir, typeIndex, true);
-	if (startSpecialStand && monster != nullptr)
-		StartSpecialStand(*monster, dir);
+	if (ActiveMonsterCount >= MaxMonsters)
+		return;
+
+	// The command is only executed for the level owner, to prevent desyncs in multiplayer.
+	if (!MyPlayer->isLevelOwnedByLocalClient())
+		return;
+
+	size_t monsterIndex = ActiveMonsters[ActiveMonsterCount];
+	ActiveMonsterCount += 1;
+	uint32_t seed = GetLCGEngineState();
+	// Update local state immediately to increase ActiveMonsterCount instantly (this allows multiple monsters to be spawned in one game tick)
+	InitializeSpawnedMonster(position, dir, typeIndex, monsterIndex, seed);
+	NetSendCmdSpawnMonster(position, dir, static_cast<uint16_t>(typeIndex), static_cast<uint16_t>(monsterIndex), seed);
+}
+
+void LoadDeltaSpawnedMonster(size_t typeIndex, size_t monsterId, uint32_t seed)
+{
+	SetRndSeed(seed);
+	EnsureMonsterIndexIsActive(monsterId);
+	WorldTilePosition position = GolemHoldingCell;
+	Monster &monster = Monsters[monsterId];
+	M_ClearSquares(monster);
+	InitMonster(monster, Direction::South, typeIndex, position);
+}
+
+void InitializeSpawnedMonster(Point position, Direction dir, size_t typeIndex, size_t monsterId, uint32_t seed)
+{
+	SetRndSeed(seed);
+	EnsureMonsterIndexIsActive(monsterId);
+	Monster &monster = Monsters[monsterId];
+	M_ClearSquares(monster);
+
+	// When we receive a network message, the position we got for the new monster may already be occupied.
+	// That's why we check for the next free tile for the monster.
+	auto freePosition = Crawl(0, MaxCrawlRadius, [&](Displacement displacement) -> std::optional<Point> {
+		Point posToCheck = position + displacement;
+		if (IsTileAvailable(posToCheck))
+			return posToCheck;
+		return {};
+	});
+
+	assert(freePosition);
+	assert(!MyPlayer->isLevelOwnedByLocalClient() || (freePosition && position == *freePosition));
+	position = freePosition.value_or(position);
+
+	monster.occupyTile(position, false);
+	InitMonster(monster, dir, typeIndex, position);
+
+	if (IsSkel(monster.type().type))
+		StartSpecialStand(monster, dir);
+	else
+		M_StartStand(monster, dir);
 }
 
 void AddDoppelganger(Monster &monster)

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -495,6 +495,7 @@ void InitGolems();
 void InitMonsters();
 void SetMapMonsters(const uint16_t *dunData, Point startPosition);
 Monster *AddMonster(Point position, Direction dir, size_t mtype, bool inMap);
+void SpawnMonster(Point position, Direction dir, size_t typeIndex, bool startSpecialStand = false);
 void AddDoppelganger(Monster &monster);
 void ApplyMonsterDamage(DamageType damageType, Monster &monster, int damage);
 bool M_Talker(const Monster &monster);

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -495,7 +495,20 @@ void InitGolems();
 void InitMonsters();
 void SetMapMonsters(const uint16_t *dunData, Point startPosition);
 Monster *AddMonster(Point position, Direction dir, size_t mtype, bool inMap);
+/**
+ * @brief Spawns a new monsters (dynamically/not on level load).
+ * The command is only executed for the level owner, to prevent desyncs in multiplayer.
+ * The level owner sends a CMD_SPAWNMONSTER-message to the other players.
+ */
 void SpawnMonster(Point position, Direction dir, size_t typeIndex, bool startSpecialStand = false);
+/**
+ * @brief Loads data for a dynamically spawned monster when entering a level in multiplayer.
+ */
+void LoadDeltaSpawnedMonster(size_t typeIndex, size_t monsterId, uint32_t seed);
+/**
+ * @brief Initialize a spanwed monster (from a network message or from SpawnMonster-function).
+ */
+void InitializeSpawnedMonster(Point position, Direction dir, size_t typeIndex, size_t monsterId, uint32_t seed);
 void AddDoppelganger(Monster &monster);
 void ApplyMonsterDamage(DamageType damageType, Monster &monster, int damage);
 bool M_Talker(const Monster &monster);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -823,27 +823,6 @@ void DeltaPutItem(const TCmdPItem &message, Point position, const Player &player
 	}
 }
 
-bool IOwnLevel(const Player &player)
-{
-	for (const Player &other : Players) {
-		if (!other.plractive)
-			continue;
-		if (other._pLvlChanging)
-			continue;
-		if (other._pmode == PM_NEWLVL)
-			continue;
-		if (other.plrlevel != player.plrlevel)
-			continue;
-		if (other.plrIsOnSetLevel != player.plrIsOnSetLevel)
-			continue;
-		if (&other == MyPlayer && gbBufferMsgs != 0)
-			continue;
-		return &other == MyPlayer;
-	}
-
-	return false;
-}
-
 void DeltaOpenPortal(size_t pnum, Point position, uint8_t bLevel, dungeon_type bLType, bool bSetLvl)
 {
 	sgJunk.portal[pnum].x = position.x;
@@ -1139,7 +1118,7 @@ size_t OnRequestGetItem(const TCmd *pCmd, Player &player)
 {
 	const auto &message = *reinterpret_cast<const TCmdGItem *>(pCmd);
 
-	if (gbBufferMsgs != 1 && IOwnLevel(player) && IsGItemValid(message)) {
+	if (gbBufferMsgs != 1 && player.isLevelOwnedByLocalClient() && IsGItemValid(message)) {
 		const Point position { message.x, message.y };
 		const uint32_t dwSeed = SDL_SwapLE32(message.def.dwSeed);
 		const uint16_t wCI = SDL_SwapLE16(message.def.wCI);
@@ -1231,7 +1210,7 @@ size_t OnRequestAutoGetItem(const TCmd *pCmd, Player &player)
 {
 	const auto &message = *reinterpret_cast<const TCmdGItem *>(pCmd);
 
-	if (gbBufferMsgs != 1 && IOwnLevel(player) && IsGItemValid(message)) {
+	if (gbBufferMsgs != 1 && player.isLevelOwnedByLocalClient() && IsGItemValid(message)) {
 		const Point position { message.x, message.y };
 		const uint32_t dwSeed = SDL_SwapLE32(message.def.dwSeed);
 		const uint16_t wCI = SDL_SwapLE16(message.def.wCI);

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -416,6 +416,10 @@ enum _cmd_id : uint8_t {
 	CMD_NAKRUL,
 	CMD_OPENHIVE,
 	CMD_OPENGRAVE,
+	// Spawn a monster at target location.
+	//
+	// body (TCmdSpawnMonster)
+	CMD_SPAWNMONSTER,
 	// Fake command; set current player for succeeding mega pkt buffer messages.
 	//
 	// body (TFakeCmdPlr)
@@ -512,6 +516,16 @@ struct TCmdGolem {
 	int8_t _menemy;
 	int32_t _mhitpoints;
 	uint8_t _currlevel;
+};
+
+struct TCmdSpawnMonster {
+	_cmd_id bCmd;
+	uint8_t x;
+	uint8_t y;
+	Direction dir;
+	uint16_t typeIndex;
+	uint16_t monsterId;
+	uint32_t seed;
 };
 
 struct TCmdQuest {
@@ -738,6 +752,7 @@ void DeltaLoadLevel();
 void ClearLastSentPlayerCmd();
 void NetSendCmd(bool bHiPri, _cmd_id bCmd);
 void NetSendCmdGolem(uint8_t mx, uint8_t my, Direction dir, uint8_t menemy, int hp, uint8_t cl);
+void NetSendCmdSpawnMonster(Point position, Direction dir, uint16_t typeIndex, uint16_t monsterId, uint32_t seed);
 void NetSendCmdLoc(uint8_t playerId, bool bHiPri, _cmd_id bCmd, Point position);
 void NetSendCmdLocParam1(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1);
 void NetSendCmdLocParam2(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2075,6 +2075,27 @@ void Player::occupyTile(Point position, bool isMoving) const
 	dPlayer[position.x][position.y] = isMoving ? -id : id;
 }
 
+bool Player::isLevelOwnedByLocalClient() const
+{
+	for (const Player &other : Players) {
+		if (!other.plractive)
+			continue;
+		if (other._pLvlChanging)
+			continue;
+		if (other._pmode == PM_NEWLVL)
+			continue;
+		if (other.plrlevel != this->plrlevel)
+			continue;
+		if (other.plrIsOnSetLevel != this->plrIsOnSetLevel)
+			continue;
+		if (&other == MyPlayer && gbBufferMsgs != 0)
+			continue;
+		return &other == MyPlayer;
+	}
+
+	return false;
+}
+
 Player *PlayerAtPosition(Point position, bool ignoreMovingPlayers /*= false*/)
 {
 	if (!InDungeonBounds(position))

--- a/Source/player.h
+++ b/Source/player.h
@@ -891,6 +891,9 @@ public:
 	 * @param isMoving specifies whether the player is moving or not (true/moving results in a negative index in dPlayer)
 	 */
 	void occupyTile(Point position, bool isMoving) const;
+
+	/** @brief Checks if the player level is owned by local client. */
+	bool isLevelOwnedByLocalClient() const;
 };
 
 extern DVL_API_FOR_TEST uint8_t MyPlayerId;


### PR DESCRIPTION
Fixes #1682

This PR synchronises dynamically spawned monsters between clients (monsters not spawned during level loading).
Doppelganger and Hork demon spawns should now synchronise between clients.
This PR would also allow Leoric to dynamically spawn skeletons in multiplayer (not part of this PR).

Logic
- Only one player is the dungeon levelmaster (similar to items).
- This player's game logic decides whether new monsters spawn or not (see the `SpawnMonster` function).
- This ensures that the dynamically spawned monsters have the same monsterId on all clients (necessary for correct synchronisation).
- Other clients are informed about the new monster with the new network command `CMD_SPAWNMONSTER`.
- Information about dynamically spawned monsters is stored in `DLevel`.

This may also be useful for modding purposes.