### PR TITLE
Disable chat in singleplayer also for debug builds

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -710,11 +710,7 @@ void CalculatePanelAreas()
 
 bool IsChatAvailable()
 {
-#ifdef _DEBUG
-	return true;
-#else
 	return gbIsMultiplayer;
-#endif
 }
 
 void FocusOnCharInfo()


### PR DESCRIPTION
Singleplayer chat was been enabled to support debug commands.
We now have a proper console for debugging commands, so this workaround is no longer needed.