### PR TITLE
Fix windows x86 discord integration

### DIFF
--- a/3rdParty/discord/CMakeLists.txt
+++ b/3rdParty/discord/CMakeLists.txt
@@ -3,11 +3,21 @@ include(FetchContent)
 
 find_package(Patch REQUIRED)
 
-FetchContent_Declare(discordsrc
-  URL https://dl-game-sdk.discordapp.net/3.2.1/discord_game_sdk.zip
-  URL_HASH MD5=73e5e1b3f8413a2c7184ef17476822f2
-  PATCH_COMMAND "${Patch_EXECUTABLE}" -p1 -N < "${CMAKE_CURRENT_LIST_DIR}/fixes.patch" || true
-)
+set(Discord_SDK_URL "https://dl-game-sdk.discordapp.net/3.2.1/discord_game_sdk.zip")
+set(Discord_SDK_HASH "73e5e1b3f8413a2c7184ef17476822f2")
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  FetchContent_Declare(discordsrc
+    URL ${Discord_SDK_URL}
+    URL_HASH MD5=${Discord_SDK_HASH}
+  )
+else()
+  FetchContent_Declare(discordsrc
+    URL ${Discord_SDK_URL}
+    URL_HASH MD5=${Discord_SDK_HASH}
+    PATCH_COMMAND "${Patch_EXECUTABLE}" -p1 -N < "${CMAKE_CURRENT_LIST_DIR}/fixes.patch" || true
+  )
+endif()
 FetchContent_MakeAvailableExcludeFromAll(discordsrc)
 
 file(GLOB discord_SRCS ${discordsrc_SOURCE_DIR}/cpp/*.cpp)


### PR DESCRIPTION
This PR fixes the Discord integration on MSVC on x86.

In devilutionX we are applying some patches to the Discord sdk to fix various issues:

```
1. Replaces `#include <Windows.h>` with `#include <windows.h>`
   for compatibility with case-sensitive file systems (e.g. MinGW
   cross-compilation on a Linux host).
2. Adds missing `#include <cstdint>` to `cpp/types.h`.
3. Fixes calling convention for callback lambdas.
```

The last point (fixing calling convention) breaks MSVC x86 builds.

> error C2760: syntax error: '__stdcall' was unexpected here; expected '{'

The applied fix adds `DISCORD_CALLBACK` to [lambdas](https://github.com/diasurgical/devilutionX/blob/b32cc11ad9b6008d7b31d74e43184829dc39a2cd/3rdParty/discord/fixes.patch#L77-L78).
`DISCORD_CALLBACK` is defined as
```
#ifdef _WIN32
#ifdef _WIN64
#define DISCORD_API
#else
#define DISCORD_API __stdcall
#endif
#else
#define DISCORD_API
#endif

#define DISCORD_CALLBACK DISCORD_API
```

So it's only set on Windows x86 builds. That's why x64 builds work on MSVC.

The devilutionX fixes are not needed on Windows and MSVC. So this PR disables them altogether when using MSVC.

I'm open to better fixes. 😉 