### PR TITLE
Slightly improve CJK infobox rendering

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -269,7 +269,7 @@ void PrintInfo(const Surface &out)
 		return;
 
 	const int space[] = { 18, 12, 6, 3, 0 };
-	Rectangle infoArea { GetMainPanel().position + Displacement { 177, 46 }, { 288, 60 } };
+	Rectangle infoArea { GetMainPanel().position + InfoBoxTopLeft, InfoBoxSize };
 
 	const auto newLineCount = static_cast<int>(c_count(InfoString.str(), '\n'));
 	const int spaceIndex = std::min(4, newLineCount);
@@ -1187,7 +1187,7 @@ void FreeControlPan()
 
 void DrawInfoBox(const Surface &out)
 {
-	DrawPanelBox(out, { 177, 62, 288, 63 }, GetMainPanel().position + Displacement { 177, 46 });
+	DrawPanelBox(out, { 177, 62, InfoBoxSize.width, InfoBoxSize.height }, GetMainPanel().position + InfoBoxTopLeft);
 	if (!panelflag && !trigflag && pcursinvitem == -1 && pcursstashitem == StashStruct::EmptyCell && !spselflag) {
 		InfoString = StringOrView {};
 		InfoColor = UiFlags::ColorWhite;

--- a/Source/control.h
+++ b/Source/control.h
@@ -19,9 +19,11 @@
 #include "DiabloUI/text_input.hpp"
 #include "DiabloUI/ui_flags.hpp"
 #include "engine.h"
+#include "engine/displacement.hpp"
 #include "engine/point.hpp"
 #include "engine/rectangle.hpp"
 #include "engine/render/text_render.hpp"
+#include "engine/size.hpp"
 #include "panels/ui_panels.hpp"
 #include "spelldat.h"
 #include "spells.h"
@@ -32,6 +34,10 @@
 namespace devilution {
 
 constexpr Size SidePanelSize { 320, 352 };
+
+// Info box displacement of the top-left corner relative to GetMainPanel().position.
+constexpr Displacement InfoBoxTopLeft { 177, 46 };
+constexpr Size InfoBoxSize { 288, 64 };
 
 extern bool dropGoldFlag;
 extern TextInputCursorState GoldDropCursor;

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1299,7 +1299,8 @@ void DrawMain(const Surface &out, int dwHgt, bool drawDesc, bool drawHp, bool dr
 				// When chat input is displayed, the belt is hidden and the chat moves up.
 				DoBlitScreen(mainPanelPosition.x + 171, mainPanelPosition.y + 6, 298, 116);
 			} else {
-				DoBlitScreen(mainPanelPosition.x + 176, mainPanelPosition.y + 46, 288, 63);
+				DoBlitScreen(mainPanelPosition.x + InfoBoxTopLeft.deltaX, mainPanelPosition.y + InfoBoxTopLeft.deltaY,
+				    InfoBoxSize.width, InfoBoxSize.height);
 			}
 		}
 		if (drawMana) {


### PR DESCRIPTION
It still isn't perfect (there just isn't enough space) but we now cut off fewer pixels at the bottom.

![infobox](https://github.com/diasurgical/devilutionX/assets/216339/d00bbf5a-cfca-4046-b81a-8530ba22008c)

Refs #6889

Let's cherry-pick this for 1.5.2 as well