### PR TITLE
Upgrade SDL to 2.30.0 and fix Switch build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   switch:
     docker:
-      - image: devkitpro/devkita64:latest
+      - image: devkitpro/devkita64@sha256:ff45e29f2efab7f70651cee39e1d98952d0db970d78c4d71bcd94efcfb0e4e5f
     working_directory: ~/repo
     steps:
       - checkout

--- a/3rdParty/SDL2/CMakeLists.txt
+++ b/3rdParty/SDL2/CMakeLists.txt
@@ -15,7 +15,7 @@ set(SDL_TEST_ENABLED_BY_DEFAULT OFF)
 include(functions/FetchContent_MakeAvailableExcludeFromAll)
 include(FetchContent)
 FetchContent_Declare(SDL2
-    URL https://github.com/libsdl-org/SDL/releases/download/release-2.28.5/SDL2-2.28.5.tar.gz
-    URL_HASH SHA256=332cb37d0be20cb9541739c61f79bae5a477427d79ae85e352089afdaf6666e4
+    URL https://github.com/libsdl-org/SDL/releases/download/release-2.30.0/SDL2-2.30.0.tar.gz
+    URL_HASH SHA256=36e2e41557e0fa4a1519315c0f5958a87ccb27e25c51776beb6f1239526447b0
 )
 FetchContent_MakeAvailableExcludeFromAll(SDL2)

--- a/android-project/app/src/main/java/org/libsdl/app/HIDDeviceManager.java
+++ b/android-project/app/src/main/java/org/libsdl/app/HIDDeviceManager.java
@@ -285,6 +285,7 @@ public class HIDDeviceManager {
             0x24c6, // PowerA
             0x2dc8, // 8BitDo
             0x2e24, // Hyperkin
+            0x3537, // GameSir
         };
 
         if (usbInterface.getId() == 0 &&

--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -60,8 +60,8 @@ import java.util.Locale;
 public class SDLActivity extends Activity implements View.OnSystemUiVisibilityChangeListener {
     private static final String TAG = "SDL";
     private static final int SDL_MAJOR_VERSION = 2;
-    private static final int SDL_MINOR_VERSION = 28;
-    private static final int SDL_MICRO_VERSION = 5;
+    private static final int SDL_MINOR_VERSION = 30;
+    private static final int SDL_MICRO_VERSION = 0;
 /*
     // Display InputType.SOURCE/CLASS of events and devices
     //

--- a/android-project/build.gradle
+++ b/android-project/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 		google()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:8.2.0'
+		classpath 'com.android.tools.build:gradle:8.2.2'
 
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files
@@ -20,6 +20,6 @@ allprojects {
 	}
 }
 
-tasks.register('clean', Delete) {
-	delete rootProject.buildDir
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }


### PR DESCRIPTION
- DevkitPro's latest switch image broke our bulid so I locked it to the previous version.
- Upgrading SDL to 2.30.0 fixes a lockup on Android when the OS switching audio output.