### PR TITLE
Fix MSVC warning in SDL1

### DIFF
--- a/Source/mpq/mpq_sdl_rwops.cpp
+++ b/Source/mpq/mpq_sdl_rwops.cpp
@@ -59,13 +59,13 @@ static OffsetType MpqFileRwSeek(struct SDL_RWops *context, OffsetType offset, in
 	OffsetType newPosition;
 	switch (whence) {
 	case RW_SEEK_SET:
-		newPosition = static_cast<size_t>(offset);
+		newPosition = offset;
 		break;
 	case RW_SEEK_CUR:
-		newPosition = static_cast<size_t>(data.position + offset);
+		newPosition = static_cast<OffsetType>(data.position + offset);
 		break;
 	case RW_SEEK_END:
-		newPosition = static_cast<size_t>(data.size + offset);
+		newPosition = static_cast<OffsetType>(data.size + offset);
 		break;
 	default:
 		return -1;


### PR DESCRIPTION
Was introduced in #6928 and only happens in MSVC SDL1.

Sorry I wanted to check #6928 before but wasn't fast enough.