### PR TITLE
Allow Leoric to dynamically spawn skeletons in multiplayer with full quests enabled …

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -2293,7 +2293,7 @@ void LeoricAi(Monster &monster)
 		monster.goal = MonsterGoal::Normal;
 	}
 	if (monster.goal == MonsterGoal::Normal) {
-		if (!gbIsMultiplayer
+		if (!UseMultiplayerQuests()
 		    && ((distanceToEnemy >= 3 && v < 4 * monster.intelligence + 35) || v < 6)
 		    && LineClearMissile(monster.position.tile, monster.enemyPosition)) {
 			Point newPosition = monster.position.tile + md;


### PR DESCRIPTION
In normal multiplayer (full quests off) the normal vanilla behavior is still present.