### PR TITLE
[Switch] Ensure romfs directory exists during CMake configure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,6 +421,7 @@ if(NINTENDO_SWITCH)
     VERSION "${PROJECT_VERSION}"
   )
 
+  file(MAKE_DIRECTORY "${DEVILUTIONX_ASSETS_OUTPUT_DIRECTORY}")
   nx_create_nro(${BIN_TARGET}
     NACP  ${BIN_TARGET}.nacp
     ICON  "${PROJECT_SOURCE_DIR}/Packaging/switch/icon.jpg"


### PR DESCRIPTION
It seems that `nx_create_nro()` requires the romfs directory to exist at configure time, and `Assets.cmake` only creates it if `gettext` is installed. The following error occurs when `gettext` is not installed (as reported by WinterMute on the devkitPro forums). This PR resolves the error.

```
-- Could NOT find Gettext (missing: GETTEXT_MSGMERGE_EXECUTABLE GETTEXT_MSGFMT_EXECUTABLE) 
CMake Error at /opt/devkitpro/cmake/Platform/NintendoSwitch.cmake:135 (message):
  nx_create_nro: cannot find romfs dir:
  /projects/switch/devilutionX/_switch/assets
Call Stack (most recent call first):
  CMakeLists.txt:424 (nx_create_nro)


-- Configuring incomplete, errors occurred!
```