### PR TITLE
Statically link BZIP2 and libsodium on AArch64

### DIFF
--- a/.github/workflows/Linux_aarch64.yml
+++ b/.github/workflows/Linux_aarch64.yml
@@ -73,11 +73,13 @@ jobs:
       env:
         CMAKE_BUILD_TYPE: ${{github.event_name == 'release' && 'Release' || 'RelWithDebInfo'}}
       # We set DEVILUTIONX_SYSTEM_LIBFMT=OFF because its soversion changes frequently.
+      # We set DEVILUTIONX_SYSTEM_LIBSODIUM=OFF because its soversion changes frequently.
       # We set DEVILUTIONX_SYSTEM_SIMPLEINI=OFF because we require v4.19+, still missing from many distributions.
+      # We set DEVILUTIONX_SYSTEM_BZIP2=OFF because Fedora and Debian do not agree on how to link it.
       run: |
         cmake -S. -Bbuild -DCMAKE_TOOLCHAIN_FILE=../CMake/platforms/aarch64-linux-gnu-clang-static-libc++.toolchain.cmake \
-          -DCMAKE_BUILD_TYPE=${{env.CMAKE_BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=/usr -DCPACK=ON \
-          -DDEVILUTIONX_SYSTEM_LIBFMT=OFF -DDEVILUTIONX_SYSTEM_SIMPLEINI=OFF && \
+          -DCMAKE_BUILD_TYPE=${{env.CMAKE_BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=/usr -DCPACK=ON -DDEVILUTIONX_SYSTEM_LIBFMT=OFF \
+          -DDEVILUTIONX_SYSTEM_LIBSODIUM=OFF -DDEVILUTIONX_SYSTEM_SIMPLEINI=OFF -DDEVILUTIONX_SYSTEM_BZIP2=OFF && \
         cmake --build build -j $(getconf _NPROCESSORS_ONLN) --target package
 
     - name: Package

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,8 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Amiga: Incorrect rendering of things behind transparent elements
 - Android: Game locking up when switching sound output
-- Fedora: Unable to locate BZIP2 
-- Manjaro: Unable to locate libsodium
+- Linux: Statically link BZIP2 and libsodium on x86_64
 - Stash corrupting when converting a hero between Diablo and Hellfire
 - Xbox: Game crashing unexpectedly
 - Xbox: Improve performance


### PR DESCRIPTION
Fixes #6954