### PR TITLE
Update Polish translation

### DIFF
--- a/Translations/pl.po
+++ b/Translations/pl.po
@@ -5192,7 +5192,7 @@ msgstr "Niezniszczalność, "
 
 #: Source/stores.cpp:323
 msgid "No required attributes"
-msgstr "Brak wymagów atrybutów"
+msgstr "Brak wymogów atrybutów"
 
 #: Source/stores.cpp:381 Source/stores.cpp:1029 Source/stores.cpp:1248
 msgid "Welcome to the"
@@ -9172,7 +9172,7 @@ msgstr "Kowal Griswold"
 
 #: Source/towners.cpp:104
 msgid "Ogden the Tavern owner"
-msgstr "Właściciel Gospody Ogden"
+msgstr "Gospodarz Ogden"
 
 #: Source/towners.cpp:113
 msgid "Wounded Townsman"

--- a/Translations/pl.po
+++ b/Translations/pl.po
@@ -2660,7 +2660,7 @@ msgstr "Przywraca 20%"
 
 #: Source/items.cpp:1720
 msgid "item's durability"
-msgstr "Wytrzymałości przedmiotu"
+msgstr "wytrzymałości przedmiotu"
 
 #: Source/items.cpp:1723
 msgid "increases an item's"
@@ -3222,11 +3222,11 @@ msgstr "Mała wyt., {:+d}% obrażeń"
 
 #: Source/items.cpp:3865
 msgid "extra AC vs demons"
-msgstr "Ekstra pancerz przeciwko Demonom"
+msgstr "Ekstra pancerz przeciwko demonom"
 
 #: Source/items.cpp:3867
 msgid "extra AC vs undead"
-msgstr "Ekstra pancerz przeciwko Nieumarłym"
+msgstr "Ekstra pancerz przeciwko nieumarłym"
 
 #: Source/items.cpp:3869
 msgid "50% Mana moved to Health"


### PR DESCRIPTION
Unified the wording for certain spots (especially for "defense", "armor", "armor class", "damage", "durability" discrepancies), introduced some clarification to particular monster's messages (resistances and immunities), added missing . and : in some places, leveled and streamlined the confusing strings for certain weapon suffixes, and tackled them oils' descriptions.

The rest is swell, as expected of such a massive project that attracted Diablo lovers from all over the world, including Poland.