### PR TITLE
Remove hardcoded SDL controller mapping from UWP build

### DIFF
--- a/uwp-project/src/SDL_winrt_main_NonXAML.cpp
+++ b/uwp-project/src/SDL_winrt_main_NonXAML.cpp
@@ -5,8 +5,6 @@
 #include <SDL.h>
 #include <diablo.h>
 #include <wrl.h>
-#include <iostream>
-#include <string>
 
 /* At least one file in any SDL/WinRT app appears to require compilation
    with C++/CX, otherwise a Windows Metadata file won't get created, and
@@ -60,26 +58,6 @@ void OnBackRequested(Platform::Object^, Windows::UI::Core::BackRequestedEventArg
 void onInitialized()
 {
 	Windows::UI::Core::SystemNavigationManager::GetForCurrentView()->BackRequested += ref new Windows::Foundation::EventHandler<Windows::UI::Core::BackRequestedEventArgs^>(OnBackRequested);
-	
-	// workaround untill new config is released
-	std::string controllerMapping = ",*,a:b1,b:b0,x:b3,y:b2,back:b6,start:b7,leftstick:b8,rightstick:b9,leftshoulder:b4,rightshoulder:b5,dpup:b10,dpdown:b12,dpleft:b13,dpright:b11,leftx:a1,lefty:a0~,rightx:a3,righty:a2~,lefttrigger:a4,righttrigger:a5,platform:WinRT";
-
-	for(int i = 0; i < SDL_NumJoysticks(); ++i)
-	{
-		SDL_JoystickType type = SDL_JoystickGetDeviceType(i);
-
-		if(type == SDL_JOYSTICK_POWER_UNKNOWN)
-			continue;
-
-		SDL_JoystickGUID guid = SDL_JoystickGetDeviceGUID(i);
-
-		if(!guid.data)
-			continue;
-
-		char guidString[33];
-		SDL_JoystickGetGUIDString(guid, guidString, 33);
-		SDL_GameControllerAddMapping((guidString + controllerMapping).c_str());
-	}
 }
 
 int CALLBACK WinMain(HINSTANCE, HINSTANCE, LPSTR, int)


### PR DESCRIPTION
See https://github.com/diasurgical/devilutionX/issues/6930#issuecomment-1926945631

> I remember now that the Xbox One/Xbox Series build had some custom startup code that attempted to swap the A/B and X/Y buttons using SDL controller mappings.
> 
> https://github.com/diasurgical/devilutionX/blob/9a148ab9909e51e4c33468ec232206e327e934d1/uwp-project/src/SDL_winrt_main_NonXAML.cpp#L65-L82
> 
> Now that we are able to detect controller type, this code should be unnecessary. But it's worse than that because I've found that it's subject to a race condition. Sometimes this code runs before the SDL event that adds the game controller. Discord user Tree reported it on Discord back in August 2022, and I think there was another report even before that so I think that confirms it happens on Xbox hardware. I have never run the build on anything but Windows, but I was also able to reproduce the issue there.