### PR TITLE
Load objcurs when creating starting items

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3023,11 +3023,13 @@ void CreatePlrItems(Player &player)
 		}
 	}
 
+	InitCursor();
 	for (auto &itemChoice : loadout.items) {
 		_item_indexes itemData = gbIsHellfire && itemChoice.hellfire != _item_indexes::IDI_NONE ? itemChoice.hellfire : itemChoice.diablo;
 		if (itemData != _item_indexes::IDI_NONE)
 			CreateStartingItem(player, itemData);
 	}
+	FreeCursor();
 
 	if (loadout.gold > 0) {
 		Item &goldItem = player.InvList[player._pNumInv];

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -188,8 +188,6 @@ TEST(Player, CreatePlayer)
 	// Please provide them so that the tests can run successfully
 	ASSERT_TRUE(HaveSpawn() || HaveDiabdat());
 
-	InitCursor();
-
 	LoadPlayerDataFiles();
 	LoadItemData();
 	Players.resize(1);

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -384,7 +384,6 @@ TEST(Writehero, pfile_write_hero)
 	MyPlayerId = 0;
 	MyPlayer = &Players[MyPlayerId];
 
-	InitCursor();
 	LoadSpellData();
 	LoadPlayerDataFiles();
 	LoadItemData();


### PR DESCRIPTION
Since the item sizes are no longer hardcoded as of dc59cda, we need to load the cursor graphics when creating starting items or else we can't know if the item fits in a belt slot.

This resolves #6980