### PR TITLE
Bugfix: Prevent item deletion when dropping items

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1929,42 +1929,6 @@ void UpdateSpellTarget(SpellID spell)
 	cursPosition = myPlayer.position.future + Displacement(myPlayer._pdir) * range;
 }
 
-/**
- * @brief Try dropping item in all 9 possible places
- */
-bool TryDropItem()
-{
-	Player &myPlayer = *MyPlayer;
-
-	if (myPlayer.HoldItem.isEmpty()) {
-		return false;
-	}
-
-	if (leveltype == DTYPE_TOWN) {
-		if (UseItemOpensHive(myPlayer.HoldItem, myPlayer.position.tile)) {
-			OpenHive();
-			NewCursor(CURSOR_HAND);
-			return true;
-		}
-		if (UseItemOpensGrave(myPlayer.HoldItem, myPlayer.position.tile)) {
-			OpenGrave();
-			NewCursor(CURSOR_HAND);
-			return true;
-		}
-	}
-
-	std::optional<Point> itemTile = FindAdjacentPositionForItem(myPlayer.position.future, myPlayer._pdir);
-	if (!itemTile) {
-		myPlayer.Say(HeroSpeech::WhereWouldIPutThis);
-		return false;
-	}
-
-	NetSendCmdPItem(true, CMD_PUTITEM, *itemTile, myPlayer.HoldItem);
-	myPlayer.HoldItem.clear();
-	NewCursor(CURSOR_HAND);
-	return true;
-}
-
 void PerformSpellAction()
 {
 	if (InGameMenu() || QuestLogIsOpen || sbookflag)

--- a/Source/controls/plrctrls.h
+++ b/Source/controls/plrctrls.h
@@ -76,7 +76,6 @@ void PerformPrimaryAction();
 // Open chests, doors, pickup items.
 void PerformSecondaryAction();
 void UpdateSpellTarget(SpellID spell);
-bool TryDropItem();
 void InvalidateInventorySlot();
 void FocusOnInventory();
 void PerformSpellAction();

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -152,30 +152,28 @@ extern void plrctrls_after_game_logic();
 
 bool TryOpenDungeon(bool useCursorPosition)
 {
-    if (leveltype != DTYPE_TOWN)
-        return false;
+	if (leveltype != DTYPE_TOWN)
+		return false;
 
-    Item &holdItem = MyPlayer->HoldItem;
-    WorldTilePosition &position = MyPlayer->position.tile;
+	Item &holdItem = MyPlayer->HoldItem;
+	WorldTilePosition &position = MyPlayer->position.tile;
 
-    // Common function to attempt opening based on input method.
-    auto attemptOpen = [&]() -> bool {
-        if ((useCursorPosition && holdItem.IDidx == IDI_RUNEBOMB && OpensHive(cursPosition)) || 
-            (!useCursorPosition && UseItemOpensHive(holdItem, position))) {
-            OpenHive();
-            NewCursor(CURSOR_HAND);
-            return true;
-        }
-        if ((useCursorPosition && holdItem.IDidx == IDI_MAPOFDOOM && OpensGrave(cursPosition)) || 
-            (!useCursorPosition && UseItemOpensGrave(holdItem, position))) {
-            OpenGrave();
-            NewCursor(CURSOR_HAND);
-            return true;
-        }
-        return false;
-    };
+	// Common function to attempt opening based on input method.
+	auto attemptOpen = [&]() -> bool {
+		if ((useCursorPosition && holdItem.IDidx == IDI_RUNEBOMB && OpensHive(cursPosition)) || (!useCursorPosition && UseItemOpensHive(holdItem, position))) {
+			OpenHive();
+			NewCursor(CURSOR_HAND);
+			return true;
+		}
+		if ((useCursorPosition && holdItem.IDidx == IDI_MAPOFDOOM && OpensGrave(cursPosition)) || (!useCursorPosition && UseItemOpensGrave(holdItem, position))) {
+			OpenGrave();
+			NewCursor(CURSOR_HAND);
+			return true;
+		}
+		return false;
+	};
 
-    return attemptOpen();
+	return attemptOpen();
 }
 
 /**

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -97,6 +97,7 @@ void DisableInputEventHandler(const SDL_Event &event, uint16_t modState);
 void LoadGameLevel(bool firstflag, lvl_entry lvldir);
 bool IsDiabloAlive(bool playSFX);
 void PrintScreen(SDL_Keycode vkey);
+bool TryDropItem(bool useCursorPosition = false);
 
 /**
  * @param bStartup Process additional ticks before returning

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1356,12 +1356,11 @@ size_t OnPutItem(const TCmd *pCmd, Player &player)
 					pfile_update(true);
 			}
 			return sizeof(message);
-		} else {
-			PutItemRecord(dwSeed, wCI, wIndx);
-			DeltaPutItem(message, position, player);
-			if (isSelf)
-				pfile_update(true);
 		}
+		PutItemRecord(dwSeed, wCI, wIndx);
+		DeltaPutItem(message, position, player);
+		if (isSelf)
+			pfile_update(true);
 	}
 
 	return sizeof(message);


### PR DESCRIPTION
Fixes: https://github.com/diasurgical/devilutionX/issues/6937

`TryDropItem()` attempted to use the future position of the player to validate the drop position of an item, which would be invalidated in certain cases in `OnPutItem()` which uses the player's current position. This mismatch would result in the item being removed from the player's hand, but failing to be dropped.

I deduplicated and unified the logic used for handling using the mouse to drop items and other methods (Ctrl + click or non-mouse controls), and set the player's position to current position universally instead of future position. Additionally, I've given the same treatment to the logic for opening dungeons.

For the cherry on top, I removed a redundant `else` in `OnPutItem()`