### PR TITLE
Bugfix: Auto Refill Belt not working properly

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1989,6 +1989,7 @@ bool UseInvItem(int cii)
 			if (player.InvList[i]._iMiscId == item->_iMiscId && player.InvList[i]._iSpell == item->_iSpell) {
 				c = i;
 				item = &player.InvList[c];
+				cii = c + INVITEM_INV_FIRST;
 				speedlist = false;
 				break;
 			}
@@ -2001,6 +2002,7 @@ bool UseInvItem(int cii)
 
 				if (!candidate.isEmpty() && candidate._iMiscId == item->_iMiscId && candidate._iSpell == item->_iSpell) {
 					c = i;
+					cii = c + INVITEM_BELT_FIRST;
 					item = &candidate;
 					break;
 				}


### PR DESCRIPTION
The Auto Refill Belt game option was not correctly setting the `spellFrom` variable or `cii` in the scope usage. The scroll/rune from the inventory or end of the belt was correctly targeted, but the spell itself would cast from the slot that was initially used, causing it to consume whatever item was originally targeted. The logic for Auto Refill Belt already implied that the intended use case was to match items based on spell, so it was already intended that scrolls and runes would refill, therefore I labeled this as a bugfix rather than a feature addition.