### PR TITLE
Bugfix: DLVL 16 speech after Diablo death

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3465,11 +3465,13 @@ void PlayDungMsgs()
 		myPlayer.pDungMsgs |= DungMsgHell;
 	} else if (!setlevel && currlevel == 16 && !myPlayer._pLvlVisited[16] && (myPlayer.pDungMsgs & DungMsgDiablo) == 0) {
 		for (auto &monster : Monsters) {
-			if (monster.type().type == MT_DIABLO && monster.hitPoints > 0) {
+			if (monster.type().type != MT_DIABLO) continue;
+			if (monster.hitPoints > 0) {
 				sfxdelay = 40;
 				sfxdnum = SfxID::DiabloGreeting;
 				myPlayer.pDungMsgs |= DungMsgDiablo;
 			}
+			break;
 		}
 	} else if (!setlevel && currlevel == 17 && !myPlayer._pLvlVisited[17] && (myPlayer.pDungMsgs2 & 1) == 0) {
 		sfxdelay = 10;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3464,9 +3464,13 @@ void PlayDungMsgs()
 		myPlayer.Say(HeroSpeech::IMustBeGettingClose, 40);
 		myPlayer.pDungMsgs |= DungMsgHell;
 	} else if (!setlevel && currlevel == 16 && !myPlayer._pLvlVisited[16] && (myPlayer.pDungMsgs & DungMsgDiablo) == 0) {
-		sfxdelay = 40;
-		sfxdnum = SfxID::DiabloGreeting;
-		myPlayer.pDungMsgs |= DungMsgDiablo;
+		for (auto &monster : Monsters) {
+			if (monster.type().type == MT_DIABLO && monster.hitPoints > 0) {
+				sfxdelay = 40;
+				sfxdnum = SfxID::DiabloGreeting;
+				myPlayer.pDungMsgs |= DungMsgDiablo;
+			}
+		}
 	} else if (!setlevel && currlevel == 17 && !myPlayer._pLvlVisited[17] && (myPlayer.pDungMsgs2 & 1) == 0) {
 		sfxdelay = 10;
 		sfxdnum = SfxID::Defiler1;


### PR DESCRIPTION
Fixes: https://github.com/diasurgical/devilutionX/issues/6879

Prevents the speech from playing upon entering dungeon level 16 if Diablo is already dead.