### PR TITLE
Conditionally prevent damaging and spell auto-targeting Golem

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3546,7 +3546,6 @@ void ProcessChainLightning(Missile &missile)
 				dir = GetDirection(position, target);
 				AddMissile(position, target, dir, MissileID::LightningControl, TARGET_MONSTERS, id, 1, missile._mispllvl);
 			}
-
 		}
 		return false;
 	});

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -206,7 +206,7 @@ bool MonsterMHit(const Player &player, int monsterId, int mindam, int maxdam, in
 {
 	auto &monster = Monsters[monsterId];
 
-	if (!monster.isPossibleToHit() || monster.isImmune(t, damageType) || monster.belongsToPlayer(player) || (!monster.belongsToPlayer(player) && player.friendlyMode))
+	if (!monster.isPossibleToHit() || monster.isImmune(t, damageType) || monster.belongsToPlayer(player) || (sgGameInitInfo.bFriendlyFire == 0 && player.friendlyMode))
 		return false;
 
 	int hit = RandomIntLessThan(100);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -4041,13 +4041,19 @@ void ProcessElemental(Missile &missile)
 		if (missile.var3 == 1) {
 			missile.var3 = 2;
 			missile._mirange = 255;
+
+			auto *player = missile.sourcePlayer();
 			auto *nextMonster = FindClosest(missilePosition, 19);
-			if (nextMonster != nullptr) {
+
+			// Should we also be checking isPossibleToHit() and isImmune()?
+			if (nextMonster != nullptr && !nextMonster->belongsToPlayer(*player) && !(nextMonster->isPlayerMinion() && sgGameInitInfo.bFriendlyFire == 0 && player->friendlyMode)) {
 				Direction sd = GetDirection(missilePosition, nextMonster->position.tile);
+
 				SetMissDir(missile, sd);
 				UpdateMissileVelocity(missile, nextMonster->position.tile, 16);
 			} else {
 				Direction sd = Players[missile._misource]._pdir;
+
 				SetMissDir(missile, sd);
 				UpdateMissileVelocity(missile, missilePosition + sd, 16);
 			}
@@ -4086,8 +4092,10 @@ void ProcessBoneSpirit(Missile &missile)
 		if (missile.var3 == 1) {
 			missile.var3 = 2;
 			missile._mirange = 255;
+			auto *player = missile.sourcePlayer();
 			auto *monster = FindClosest(c, 19);
-			if (monster != nullptr) {
+			// Should we also be checking isPossibleToHit() and isImmune()?
+			if (monster != nullptr && !monster->belongsToPlayer(*player) && !(monster->isPlayerMinion() && sgGameInitInfo.bFriendlyFire == 0 && player->friendlyMode)) {
 				missile._midam = monster->hitPoints >> 7;
 				SetMissDir(missile, GetDirection(c, monster->position.tile));
 				UpdateMissileVelocity(missile, monster->position.tile, 16);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3528,13 +3528,25 @@ void ProcessChainLightning(Missile &missile)
 	Point position = missile.position.tile;
 	Point dst { missile.var1, missile.var2 };
 	Direction dir = GetDirection(position, dst);
+
 	AddMissile(position, dst, dir, MissileID::LightningControl, TARGET_MONSTERS, id, 1, missile._mispllvl);
+
 	int rad = std::min<int>(missile._mispllvl + 3, MaxCrawlRadius);
+
 	Crawl(1, rad, [&](Displacement displacement) {
 		Point target = position + displacement;
-		if (InDungeonBounds(target) && dMonster[target.x][target.y] > 0) {
-			dir = GetDirection(position, target);
-			AddMissile(position, target, dir, MissileID::LightningControl, TARGET_MONSTERS, id, 1, missile._mispllvl);
+		const auto &monsterId = dMonster[target.x][target.y];
+
+		if (InDungeonBounds(target) && monsterId > 0) {
+			const auto &player = Players[id];
+			const auto &monster = Monsters[std::abs(monsterId - 1)];
+
+			// Should we also be checking isPossibleToHit() and isImmune()?
+			if (!monster.belongsToPlayer(player) && !(monster.isPlayerMinion() && sgGameInitInfo.bFriendlyFire == 0 && player.friendlyMode)) {
+				dir = GetDirection(position, target);
+				AddMissile(position, target, dir, MissileID::LightningControl, TARGET_MONSTERS, id, 1, missile._mispllvl);
+			}
+
 		}
 		return false;
 	});

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -206,7 +206,7 @@ bool MonsterMHit(const Player &player, int monsterId, int mindam, int maxdam, in
 {
 	auto &monster = Monsters[monsterId];
 
-	if (!monster.isPossibleToHit() || monster.isImmune(t, damageType) || monster.belongsToPlayer(player) || (monster.isPlayerMinion() && sgGameInitInfo.bFriendlyFire == 0 && player.friendlyMode))
+	if (!monster.isPossibleToHit() || monster.isImmune(t, damageType) || !monster.canPlayerDamage(player))
 		return false;
 
 	int hit = RandomIntLessThan(100);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -206,7 +206,7 @@ bool MonsterMHit(const Player &player, int monsterId, int mindam, int maxdam, in
 {
 	auto &monster = Monsters[monsterId];
 
-	if (!monster.isPossibleToHit() || monster.isImmune(t, damageType) || !monster.canPlayerDamage(player))
+	if (!monster.isPossibleToHit() || monster.isImmune(t, damageType) || !monster.canBeDamagedByPlayer(player))
 		return false;
 
 	int hit = RandomIntLessThan(100);
@@ -3542,7 +3542,7 @@ void ProcessChainLightning(Missile &missile)
 			const auto &monster = Monsters[std::abs(monsterId - 1)];
 
 			// Should we also be checking isPossibleToHit() and isImmune()?
-			if (monster.canPlayerDamage(player)) {
+			if (monster.canBeDamagedByPlayer(player)) {
 				dir = GetDirection(position, target);
 				AddMissile(position, target, dir, MissileID::LightningControl, TARGET_MONSTERS, id, 1, missile._mispllvl);
 			}
@@ -4045,7 +4045,7 @@ void ProcessElemental(Missile &missile)
 			auto *nextMonster = FindClosest(missilePosition, 19);
 
 			// Should we also be checking isPossibleToHit() and isImmune()?
-			if (nextMonster != nullptr && nextMonster->canPlayerDamage(*player)) {
+			if (nextMonster != nullptr && nextMonster->canBeDamagedByPlayer(*player)) {
 				Direction sd = GetDirection(missilePosition, nextMonster->position.tile);
 
 				SetMissDir(missile, sd);
@@ -4095,7 +4095,7 @@ void ProcessBoneSpirit(Missile &missile)
 			auto *monster = FindClosest(c, 19);
 
 			// Should we also be checking isPossibleToHit() and isImmune()?
-			if (monster != nullptr && monster->canPlayerDamage(*player)) {
+			if (monster != nullptr && monster->canBeDamagedByPlayer(*player)) {
 				missile._midam = monster->hitPoints >> 7;
 				SetMissDir(missile, GetDirection(c, monster->position.tile));
 				UpdateMissileVelocity(missile, monster->position.tile, 16);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3542,7 +3542,7 @@ void ProcessChainLightning(Missile &missile)
 			const auto &monster = Monsters[std::abs(monsterId - 1)];
 
 			// Should we also be checking isPossibleToHit() and isImmune()?
-			if (!monster.belongsToPlayer(player) && !(monster.isPlayerMinion() && sgGameInitInfo.bFriendlyFire == 0 && player.friendlyMode)) {
+			if (monster.canPlayerDamage(player)) {
 				dir = GetDirection(position, target);
 				AddMissile(position, target, dir, MissileID::LightningControl, TARGET_MONSTERS, id, 1, missile._mispllvl);
 			}
@@ -4045,7 +4045,7 @@ void ProcessElemental(Missile &missile)
 			auto *nextMonster = FindClosest(missilePosition, 19);
 
 			// Should we also be checking isPossibleToHit() and isImmune()?
-			if (nextMonster != nullptr && !nextMonster->belongsToPlayer(*player) && !(nextMonster->isPlayerMinion() && sgGameInitInfo.bFriendlyFire == 0 && player->friendlyMode)) {
+			if (nextMonster != nullptr && nextMonster->canPlayerDamage(*player)) {
 				Direction sd = GetDirection(missilePosition, nextMonster->position.tile);
 
 				SetMissDir(missile, sd);
@@ -4093,13 +4093,15 @@ void ProcessBoneSpirit(Missile &missile)
 			missile._mirange = 255;
 			auto *player = missile.sourcePlayer();
 			auto *monster = FindClosest(c, 19);
+
 			// Should we also be checking isPossibleToHit() and isImmune()?
-			if (monster != nullptr && !monster->belongsToPlayer(*player) && !(monster->isPlayerMinion() && sgGameInitInfo.bFriendlyFire == 0 && player->friendlyMode)) {
+			if (monster != nullptr && monster->canPlayerDamage(*player)) {
 				missile._midam = monster->hitPoints >> 7;
 				SetMissDir(missile, GetDirection(c, monster->position.tile));
 				UpdateMissileVelocity(missile, monster->position.tile, 16);
 			} else {
 				Direction sd = Players[missile._misource]._pdir;
+
 				SetMissDir(missile, sd);
 				UpdateMissileVelocity(missile, c + sd, 16);
 			}

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3528,19 +3528,14 @@ void ProcessChainLightning(Missile &missile)
 	Point position = missile.position.tile;
 	Point dst { missile.var1, missile.var2 };
 	Direction dir = GetDirection(position, dst);
-
 	AddMissile(position, dst, dir, MissileID::LightningControl, TARGET_MONSTERS, id, 1, missile._mispllvl);
-
 	int rad = std::min<int>(missile._mispllvl + 3, MaxCrawlRadius);
-
 	Crawl(1, rad, [&](Displacement displacement) {
 		Point target = position + displacement;
 		const auto &monsterId = dMonster[target.x][target.y];
-
 		if (InDungeonBounds(target) && monsterId > 0) {
 			const auto &player = Players[id];
 			const auto &monster = Monsters[std::abs(monsterId - 1)];
-
 			// Should we also be checking isPossibleToHit() and isImmune()?
 			if (monster.canBeDamagedByPlayer(player)) {
 				dir = GetDirection(position, target);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -206,7 +206,7 @@ bool MonsterMHit(const Player &player, int monsterId, int mindam, int maxdam, in
 {
 	auto &monster = Monsters[monsterId];
 
-	if (!monster.isPossibleToHit() || monster.isImmune(t, damageType))
+	if (!monster.isPossibleToHit() || monster.isImmune(t, damageType) || monster.belongsToPlayer(player) || (!monster.belongsToPlayer(player) && player.friendlyMode))
 		return false;
 
 	int hit = RandomIntLessThan(100);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -206,7 +206,7 @@ bool MonsterMHit(const Player &player, int monsterId, int mindam, int maxdam, in
 {
 	auto &monster = Monsters[monsterId];
 
-	if (!monster.isPossibleToHit() || monster.isImmune(t, damageType) || monster.belongsToPlayer(player) || (sgGameInitInfo.bFriendlyFire == 0 && player.friendlyMode))
+	if (!monster.isPossibleToHit() || monster.isImmune(t, damageType) || monster.belongsToPlayer(player) || (monster.isPlayerMinion() && sgGameInitInfo.bFriendlyFire == 0 && player.friendlyMode))
 		return false;
 
 	int hit = RandomIntLessThan(100);

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4829,6 +4829,11 @@ bool Monster::isPlayerMinion() const
 	return (flags & MFLAG_GOLEM) != 0 && (flags & MFLAG_BERSERK) == 0;
 }
 
+bool Monster::belongsToPlayer(const Player &player) const
+{
+	return  player.getId() == getId();
+}
+
 bool Monster::isPossibleToHit() const
 {
 	return !(hitPoints >> 6 <= 0

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4829,7 +4829,7 @@ bool Monster::isPlayerMinion() const
 	return (flags & MFLAG_GOLEM) != 0 && (flags & MFLAG_BERSERK) == 0;
 }
 
-bool Monster::canPlayerDamage(const Player &player) const
+bool Monster::canBeDamagedByPlayer(const Player &player) const
 {
 	return !(player.getId() == getId()
 	    || (isPlayerMinion() && sgGameInitInfo.bFriendlyFire == 0 && player.friendlyMode));

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4829,9 +4829,10 @@ bool Monster::isPlayerMinion() const
 	return (flags & MFLAG_GOLEM) != 0 && (flags & MFLAG_BERSERK) == 0;
 }
 
-bool Monster::belongsToPlayer(const Player &player) const
+bool Monster::canPlayerDamage(const Player &player) const
 {
-	return player.getId() == getId();
+	return !(player.getId() == getId()
+	    || (isPlayerMinion() && sgGameInitInfo.bFriendlyFire == 0 && player.friendlyMode));
 }
 
 bool Monster::isPossibleToHit() const

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4831,7 +4831,7 @@ bool Monster::isPlayerMinion() const
 
 bool Monster::belongsToPlayer(const Player &player) const
 {
-	return  player.getId() == getId();
+	return player.getId() == getId();
 }
 
 bool Monster::isPossibleToHit() const

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -437,10 +437,14 @@ struct Monster { // note: missing field _mAFNum
 	 * Is this a player's golem?
 	 */
 	[[nodiscard]] bool isPlayerMinion() const;
+
 	/**
-	 * Can the player damage this monster?
+	 * @brief Can this monster be damaged by the player?
+	 *
+	 * Used for Golems to determine whether or not a player is able to damage it.
+	 * Conditions are set based on Friendly Fire, Player Attack/Friend, and ownership.
 	 */
-	[[nodiscard]] bool canPlayerDamage(const Player &player) const;
+	[[nodiscard]] bool canBeDamagedByPlayer(const Player &player) const;
 
 	bool isPossibleToHit() const;
 	void tag(const Player &tagger);

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -437,7 +437,10 @@ struct Monster { // note: missing field _mAFNum
 	 * Is this a player's golem?
 	 */
 	[[nodiscard]] bool isPlayerMinion() const;
-	[[nodiscard]] bool belongsToPlayer(const Player &player) const;
+	/**
+	 * Can the player damage this monster?
+	*/
+	[[nodiscard]] bool canPlayerDamage(const Player &player) const;
 
 	bool isPossibleToHit() const;
 	void tag(const Player &tagger);

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -437,6 +437,7 @@ struct Monster { // note: missing field _mAFNum
 	 * Is this a player's golem?
 	 */
 	[[nodiscard]] bool isPlayerMinion() const;
+	[[nodiscard]] bool belongsToPlayer(const Player &player) const;
 
 	bool isPossibleToHit() const;
 	void tag(const Player &tagger);

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -439,7 +439,7 @@ struct Monster { // note: missing field _mAFNum
 	[[nodiscard]] bool isPlayerMinion() const;
 	/**
 	 * Can the player damage this monster?
-	*/
+	 */
 	[[nodiscard]] bool canPlayerDamage(const Player &player) const;
 
 	bool isPossibleToHit() const;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -571,7 +571,7 @@ bool PlrHitMonst(Player &player, Monster &monster, bool adjacentDamage = false)
 {
 	int hper = 0;
 
-	if (!monster.isPossibleToHit())
+	if (!monster.isPossibleToHit() || monster.belongsToPlayer(player) || (!monster.belongsToPlayer(player) && player.friendlyMode))
 		return false;
 
 	if (adjacentDamage) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -571,7 +571,7 @@ bool PlrHitMonst(Player &player, Monster &monster, bool adjacentDamage = false)
 {
 	int hper = 0;
 
-	if (!monster.isPossibleToHit() || monster.belongsToPlayer(player) || (!monster.belongsToPlayer(player) && player.friendlyMode))
+	if (!monster.isPossibleToHit() || !monster.canPlayerDamage(player))
 		return false;
 
 	if (adjacentDamage) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2096,6 +2096,11 @@ bool Player::isLevelOwnedByLocalClient() const
 	return false;
 }
 
+Monster *Player::golem() const
+{
+	return &Monsters[getId()];
+}
+
 Player *PlayerAtPosition(Point position, bool ignoreMovingPlayers /*= false*/)
 {
 	if (!InDungeonBounds(position))

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -571,7 +571,7 @@ bool PlrHitMonst(Player &player, Monster &monster, bool adjacentDamage = false)
 {
 	int hper = 0;
 
-	if (!monster.isPossibleToHit() || !monster.canPlayerDamage(player))
+	if (!monster.isPossibleToHit() || !monster.canBeDamagedByPlayer(player))
 		return false;
 
 	if (adjacentDamage) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2096,9 +2096,9 @@ bool Player::isLevelOwnedByLocalClient() const
 	return false;
 }
 
-Monster *Player::golem() const
+Monster &Player::golem() const
 {
-	return &Monsters[getId()];
+	return Monsters[getId()];
 }
 
 Player *PlayerAtPosition(Point position, bool ignoreMovingPlayers /*= false*/)

--- a/Source/player.h
+++ b/Source/player.h
@@ -895,6 +895,7 @@ public:
 	/** @brief Checks if the player level is owned by local client. */
 	bool isLevelOwnedByLocalClient() const;
 
+	/** @brief Returns a reference to the Golem owned by the player. */
 	Monster &golem() const;
 };
 

--- a/Source/player.h
+++ b/Source/player.h
@@ -895,7 +895,7 @@ public:
 	/** @brief Checks if the player level is owned by local client. */
 	bool isLevelOwnedByLocalClient() const;
 
-	Monster *golem() const;
+	Monster &golem() const;
 };
 
 extern DVL_API_FOR_TEST uint8_t MyPlayerId;

--- a/Source/player.h
+++ b/Source/player.h
@@ -894,6 +894,8 @@ public:
 
 	/** @brief Checks if the player level is owned by local client. */
 	bool isLevelOwnedByLocalClient() const;
+
+	Monster *golem() const;
 };
 
 extern DVL_API_FOR_TEST uint8_t MyPlayerId;

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -147,10 +147,12 @@ int GetManaAmount(const Player &player, SpellID sn)
 
 void ConsumeSpell(Player &player, SpellID sn)
 {
-	Monster &golem = Monsters[player.getId()];
+	if (sn == SpellID::Golem && &player == MyPlayer) {
+		Monster *golem = player.golem();
 
-	if (golem.hitPoints <= 0 && &player == MyPlayer)
-		return;
+		if (golem->hitPoints <= 0)
+			return;
+	}
 	switch (player.executedSpell.spellType) {
 	case SpellType::Skill:
 	case SpellType::Invalid:

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -149,7 +149,7 @@ void ConsumeSpell(Player &player, SpellID sn)
 {
 	Monster &golem = Monsters[player.getId()];
 
-	if (golem.position.tile != GolemHoldingCell && &player == MyPlayer)
+	if (golem.hitPoints <= 0 && &player == MyPlayer)
 		return;
 	switch (player.executedSpell.spellType) {
 	case SpellType::Skill:

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -147,6 +147,10 @@ int GetManaAmount(const Player &player, SpellID sn)
 
 void ConsumeSpell(Player &player, SpellID sn)
 {
+	Monster &golem = Monsters[player.getId()];
+
+	if (golem.position.tile != GolemHoldingCell && &player == MyPlayer)
+		return;
 	switch (player.executedSpell.spellType) {
 	case SpellType::Skill:
 	case SpellType::Invalid:

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -148,9 +148,9 @@ int GetManaAmount(const Player &player, SpellID sn)
 void ConsumeSpell(Player &player, SpellID sn)
 {
 	if (sn == SpellID::Golem && &player == MyPlayer) {
-		Monster *golem = player.golem();
+		Monster &golem = player.golem();
 
-		if (golem->hitPoints <= 0)
+		if (golem.hitPoints <= 0)
 			return;
 	}
 	switch (player.executedSpell.spellType) {


### PR DESCRIPTION
Alternative approach to the concept in https://github.com/diasurgical/devilutionX/pull/6881.
Fixes: https://github.com/diasurgical/devilutionX/issues/4352

## When can a Golem be damaged?
![image](https://github.com/diasurgical/devilutionX/assets/68359262/9ac7ba86-38e6-4bb8-9159-837528fd30e8)

By default, you are able to damage any Golem regardless of any settings or damage method.

![image](https://github.com/diasurgical/devilutionX/assets/68359262/3d466b34-2468-480f-a3c3-f5e0551f7277)

In this PR, you are completely unable to damage your own Golem via any method or setting. For damaging Golems belonging to other players, it mirrors the same behavior as damaging other players, regardless of method or setting.

![image](https://github.com/diasurgical/devilutionX/assets/68359262/6dade0ff-8679-49d4-93fd-12409656412d)

In the linked PR, there is no differentiation between owned/unowned Golems. Other than that, damaging Golems is completely consistent with damaging players based on options/settings.


The idea in this PR is to unify behavior between the ability to damage other players and other players' Golems, and to prevent damage to a player's own golem as a QoL improvement.

## Regarding auto-targeting spells

I've revised the behavior of Chain Lightning, Bone Spirit, and Elemental to address the problem originally addressed in the issue before it was renamed. These spells now behave cohesively with the logic for damage in this PR, no longer targeting a Golem if it is unable to damage it. I left some comments for a potential future PR for if we should be preventing auto-targeting spells from targeting monsters they are unable to hit (teleporting monsters, immune monsters).

## Potential problems
Problem: Unable to destroy own Golem with melee/arrows/spells
Solution: Casting Golem will no longer consume scroll/charge/mana if the spell is simply killing your Golem rather than creating a new one.
More solutions:
![image](https://github.com/diasurgical/devilutionX/assets/68359262/1f5ed292-e4ef-4fb6-90fd-fcebc223d46c)
![image](https://github.com/diasurgical/devilutionX/assets/68359262/21d5f3c7-ab18-4a78-8fdb-98b76a53cd7a)
![image](https://github.com/diasurgical/devilutionX/assets/68359262/d1ffe04a-b91e-4cf6-9dd9-e794a61e2669)
![image](https://github.com/diasurgical/devilutionX/assets/68359262/01a067ec-1486-483e-912d-c0206f8b3ad4)
