### PR TITLE
Limit theme scan to the number of generated rooms

### DIFF
--- a/Source/levels/themes.cpp
+++ b/Source/levels/themes.cpp
@@ -854,7 +854,7 @@ void InitThemes()
 				themes[numthemes].ttype = j;
 				numthemes++;
 			}
-			if (i == std::numeric_limits<int8_t>::max())
+			if (i > TransVal)
 				break;
 		}
 		return;


### PR DESCRIPTION
This greatly speeds up level generation as there is no need to search for the fitness of 127 (or 256 as in the original) rooms if only 23 where created.