### PR TITLE
Introduce xoshiro RNG to generate dungeon seeds

### DIFF
--- a/Source/engine/random.cpp
+++ b/Source/engine/random.cpp
@@ -13,6 +13,19 @@ uint32_t sglGameSeed;
 /** Borland C/C++ psuedo-random number generator needed for vanilla compatibility */
 std::linear_congruential_engine<uint32_t, 0x015A4E35, 1, 0> diabloGenerator;
 
+/** Xoshiro pseudo-random number generator to provide less predictable seeds */
+xoshiro128plusplus seedGenerator;
+
+void ResetSeedGenerator(uint64_t seed)
+{
+	seedGenerator.seed(seed);
+}
+
+uint32_t GenerateSeed()
+{
+	return seedGenerator.next();
+}
+
 void SetRndSeed(uint32_t seed)
 {
 	diabloGenerator.seed(seed);
@@ -27,12 +40,12 @@ uint32_t GetLCGEngineState()
 void DiscardRandomValues(unsigned count)
 {
 	while (count != 0) {
-		GenerateSeed();
+		GenerateRandomNumber();
 		count--;
 	}
 }
 
-uint32_t GenerateSeed()
+uint32_t GenerateRandomNumber()
 {
 	sglGameSeed = diabloGenerator();
 	return sglGameSeed;
@@ -40,7 +53,7 @@ uint32_t GenerateSeed()
 
 int32_t AdvanceRndSeed()
 {
-	const int32_t seed = static_cast<int32_t>(GenerateSeed());
+	const int32_t seed = static_cast<int32_t>(GenerateRandomNumber());
 	// since abs(INT_MIN) is undefined behavior, handle this value specially
 	return seed == std::numeric_limits<int32_t>::min() ? std::numeric_limits<int32_t>::min() : std::abs(seed);
 }

--- a/Source/engine/random.cpp
+++ b/Source/engine/random.cpp
@@ -19,18 +19,29 @@ std::linear_congruential_engine<uint32_t, 0x015A4E35, 1, 0> diabloGenerator;
 /** Xoshiro pseudo-random number generator to provide less predictable seeds */
 xoshiro128plusplus seedGenerator;
 
-uint32_t xoshiro128plusplus::rotl(const uint32_t x, int k)
+uint32_t xoshiro128plusplus::next()
 {
-	return std::rotl(x, k);
+	const uint32_t result = std::rotl(s[0] + s[3], 7) + s[0];
+
+	const uint32_t t = s[1] << 9;
+
+	s[2] ^= s[0];
+	s[3] ^= s[1];
+	s[1] ^= s[2];
+	s[0] ^= s[3];
+
+	s[2] ^= t;
+
+	s[3] = std::rotl(s[3], 11);
+
+	return result;
 }
 
 uint64_t xoshiro128plusplus::timeSeed()
 {
 	auto now = std::chrono::system_clock::now();
 	auto nano = std::chrono::nanoseconds(now.time_since_epoch());
-	long long time = nano.count();
-	SplitMix64 seedSequence { static_cast<uint64_t>(time) };
-	return seedSequence.next();
+	return static_cast<uint64_t>(nano.count());
 }
 
 void xoshiro128plusplus::copy(state &dst, const state &src)

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1821,7 +1821,7 @@ void SaveLevel(SaveWriter &saveWriter, LevelConversionData *levelConversionData)
 	DoUnVision(myPlayer.position.tile, myPlayer._pLightRad); // fix for vision staying on the level
 
 	if (leveltype == DTYPE_TOWN)
-		DungeonSeeds[0] = AdvanceRndSeed();
+		DungeonSeeds[0] = GenerateSeed();
 
 	char szName[MaxMpqPathSize];
 	GetTempLevelNames(szName);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -750,7 +750,7 @@ void DeltaLeaveSync(uint8_t bLevel)
 	if (!gbIsMultiplayer)
 		return;
 	if (leveltype == DTYPE_TOWN) {
-		DungeonSeeds[0] = AdvanceRndSeed();
+		DungeonSeeds[0] = GenerateSeed();
 		return;
 	}
 

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -23,7 +23,7 @@ struct Player;
 struct GameData {
 	int32_t size;
 	/** Used to initialise the seed table for dungeon levels so players in multiplayer games generate the same layout */
-	uint32_t dwSeed;
+	uint64_t gameSeed;
 	uint32_t programid;
 	uint8_t versionMajor;
 	uint8_t versionMinor;

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -22,8 +22,7 @@ struct Player;
 
 struct GameData {
 	int32_t size;
-	/** Used to initialise the seed table for dungeon levels so players in multiplayer games generate the same layout */
-	uint32_t gameSeed[4];
+	uint8_t reserved[4];
 	uint32_t programid;
 	uint8_t versionMajor;
 	uint8_t versionMinor;
@@ -35,6 +34,8 @@ struct GameData {
 	uint8_t bCowQuest;
 	uint8_t bFriendlyFire;
 	uint8_t fullQuests;
+	/** Used to initialise the seed table for dungeon levels so players in multiplayer games generate the same layout */
+	uint32_t gameSeed[4];
 };
 
 /* @brief Contains info of running public game (for game list browsing) */

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -23,7 +23,7 @@ struct Player;
 struct GameData {
 	int32_t size;
 	/** Used to initialise the seed table for dungeon levels so players in multiplayer games generate the same layout */
-	uint64_t gameSeed;
+	uint32_t gameSeed[4];
 	uint32_t programid;
 	uint8_t versionMajor;
 	uint8_t versionMinor;

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2134,8 +2134,6 @@ void SetupTownStores()
 			if (myPlayer._pLvlVisited[i])
 				l = i;
 		}
-	} else {
-		SetRndSeed(DungeonSeeds[currlevel] * SDL_GetTicks());
 	}
 
 	l = std::clamp(l + 2, 6, 16);

--- a/test/random_test.cpp
+++ b/test/random_test.cpp
@@ -17,10 +17,10 @@ TEST(RandomTest, RandomEngineParams)
 	SetRndSeed(0);
 
 	// Starting from a seed of 0 means the multiplicand is dropped and the state advances by increment only
-	ASSERT_EQ(GenerateSeed(), increment) << "Increment factor is incorrect";
+	ASSERT_EQ(GenerateRandomNumber(), increment) << "Increment factor is incorrect";
 
 	// LCGs use a formula of mult * seed + inc. Using a long form in the code to document the expected factors.
-	ASSERT_EQ(GenerateSeed(), (multiplicand * 1) + increment) << "Multiplicand factor is incorrect";
+	ASSERT_EQ(GenerateRandomNumber(), (multiplicand * 1) + increment) << "Multiplicand factor is incorrect";
 
 	// C++11 defines the default seed for a LCG engine as 1. The ten thousandth value is commonly used for sanity checking
 	// a sequence, so as we've had one round since state 1 we need to discard another 9998 values to get to the 10000th state.
@@ -28,9 +28,9 @@ TEST(RandomTest, RandomEngineParams)
 	DiscardRandomValues(9997);
 
 	uint32_t expectedState = 3495122800U;
-	EXPECT_EQ(GenerateSeed(), expectedState) << "Wrong engine state after 9999 invocations";
+	EXPECT_EQ(GenerateRandomNumber(), expectedState) << "Wrong engine state after 9999 invocations";
 	expectedState = 3007658545U;
-	ASSERT_EQ(GenerateSeed(), expectedState) << "Wrong engine state after 10000 invocations";
+	ASSERT_EQ(GenerateRandomNumber(), expectedState) << "Wrong engine state after 10000 invocations";
 }
 
 TEST(RandomTest, AbsDistribution)


### PR DESCRIPTION
Implements the technique for mitigating overlapping random number sequences described in https://github.com/diasurgical/devilutionX/pull/6438#discussion_r1285147193.

Summary of changes:
* Introduce the xoshiro128++ RNG
* Rename `GenerateSeed()` to `GenerateRandomNumber()`
* Use xoshiro128++ to reimplement `GenerateSeed()`
* Rename `GameData::dwSeed` to `GameData::gameSeed`
* Use 64 bits for the game seed and use `std::chrono` to generate it
* Update logic for generating dungeon seeds using xoshiro128++ instead of LCG

The 32-bit overload for `xoshiro128plusplus::seed()` is intended to provide a way to reseed xoshiro128++ using a dungeon seed. This will become necessary to create a deterministic sequence of seeds for monsters, objects, and items during dungeon generation. It feels a bit like falling back on old habits to use this random number generator to seed itself, but the SplitMix32 implementation makes it work.

This replaces #6438
This resolves #6261